### PR TITLE
docs(architecture): define public framework product contract

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -4,7 +4,9 @@ Architecture reference for AgenC protocol and runtime surfaces. These docs are i
 
 ## How to Use
 
-- **Planning whole-repository refactor work?** Start with [REFACTOR.MD](../../REFACTOR.MD) and [REFACTOR-MASTER-PROGRAM.md](../../REFACTOR-MASTER-PROGRAM.md)
+- **Understanding the current product contract?** Start with [product-contract.md](product-contract.md) and [adr/adr-003-public-framework-product.md](adr/adr-003-public-framework-product.md)
+- **Understanding the tracked rollout for that contract?** See [product-contract.md](product-contract.md) plus GitHub issues `#4` through `#9` in `tetsuo-ai/agenc-core`
+- **Planning whole-repository refactor work?** Use the historical records only as background: [REFACTOR.MD](../../REFACTOR.MD) and [REFACTOR-MASTER-PROGRAM.md](../../REFACTOR-MASTER-PROGRAM.md)
 - **Reading legacy runtime roadmap material?** Use the relevant phase guide in `phases/` as historical runtime-scoped reference only
 - **Understanding the system?** Read `overview.md` then `runtime-layers.md`
 - **Writing new code?** Check `guides/` for conventions and templates
@@ -17,6 +19,7 @@ Architecture reference for AgenC protocol and runtime surfaces. These docs are i
 | Document | Description |
 |----------|-------------|
 | [overview.md](overview.md) | System component diagram — 5 packages and their relationships |
+| [product-contract.md](product-contract.md) | Public product contract: one daemon, shared TUI/web surfaces, and public install path |
 | [runtime-layers.md](runtime-layers.md) | 7-layer module dependency diagram for the runtime |
 | [interfaces.md](interfaces.md) | Class diagrams for 10 key interfaces |
 
@@ -25,7 +28,8 @@ Architecture reference for AgenC protocol and runtime surfaces. These docs are i
 | Document | Description |
 |----------|-------------|
 | [adr/adr-001-durable-task-runtime.md](adr/adr-001-durable-task-runtime.md) | Canonical durable task runtime contract, lifecycle semantics, and invariants |
-| [adr/adr-002-public-contract-private-kernel-boundary.md](adr/adr-002-public-contract-private-kernel-boundary.md) | Gate 11 boundary decision: public contracts and plugin ABI, private kernel and proving/control plane |
+| [adr/adr-002-public-contract-private-kernel-boundary.md](adr/adr-002-public-contract-private-kernel-boundary.md) | Historical private-kernel boundary decision, now superseded by ADR-003 |
+| [adr/adr-003-public-framework-product.md](adr/adr-003-public-framework-product.md) | Current direction: public framework product, shared daemon, and staged declassification |
 
 ### Flow Diagrams
 
@@ -45,6 +49,7 @@ Architecture reference for AgenC protocol and runtime surfaces. These docs are i
 
 | Document | Description |
 |----------|-------------|
+| [guides/cli-runtime-migration-map.md](guides/cli-runtime-migration-map.md) | Current `agenc` / `agenc-runtime` surface mapping into the public product contract |
 | [guides/new-module-template.md](guides/new-module-template.md) | Standard module structure, error codes, barrel exports |
 | [guides/type-conventions.md](guides/type-conventions.md) | bigint vs BN, Uint8Array vs Buffer, etc. |
 | [guides/testing-patterns.md](guides/testing-patterns.md) | Mock patterns, vitest setup, LiteSVM |

--- a/docs/architecture/adr/adr-002-public-contract-private-kernel-boundary.md
+++ b/docs/architecture/adr/adr-002-public-contract-private-kernel-boundary.md
@@ -1,12 +1,19 @@
 # ADR-002: Public Contract And Private Kernel Boundary
 
-- **Status:** Accepted
+- **Status:** Superseded by [ADR-003](adr-003-public-framework-product.md)
 - **Date:** 2026-03-16
 - **Owners:** Repository / Platform Architecture
 - **Related roadmap:** [REFACTOR.MD](../../../REFACTOR.MD), [REFACTOR-MASTER-PROGRAM.md](../../../REFACTOR-MASTER-PROGRAM.md)
 - **Supersedes:** none
 
 ## Context
+
+This ADR was accepted during the private-kernel split program and remains
+important historical context for why the private-kernel boundary existed.
+
+It is no longer the current architectural direction. The active direction is
+now [ADR-003](adr-003-public-framework-product.md), which changes the end-state
+product model to a public framework with a staged declassification path.
 
 AgenC completed Gate 10 split-readiness proof, but Gate 11 exposed a harder problem than simple repo extraction:
 

--- a/docs/architecture/adr/adr-003-public-framework-product.md
+++ b/docs/architecture/adr/adr-003-public-framework-product.md
@@ -1,0 +1,180 @@
+# ADR-003: Public Framework Product And Shared-Daemon Surfaces
+
+- **Status:** Accepted
+- **Date:** 2026-03-18
+- **Owners:** Product / Runtime Architecture
+- **Supersedes:** [ADR-002](adr-002-public-contract-private-kernel-boundary.md)
+
+## Context
+
+ADR-002 solved a real problem: the repo had public-contract surfaces and a
+still-public runtime posture at the same time, which made the intended
+public/private split incoherent.
+
+That decision produced a clean boundary:
+
+- SDK, protocol, and plugin-kit were the public surfaces
+- the kernel/runtime stayed private
+- private-kernel CI/docs/package policy enforced that boundary
+
+That boundary was internally coherent, but it conflicts with what AgenC is
+supposed to be as a product.
+
+The current codebase already behaves much more like an installable agent
+framework:
+
+- a local daemon/gateway is the runtime authority
+- `agenc` already defaults to the operator console and forwards other commands
+  to the runtime CLI
+- the TUI/watch surface is the more mature operator client
+- the web app already speaks the same runtime websocket/browser protocol rather
+  than a separate backend model
+- task, bid, marketplace, plugin, and connector behaviors belong to the product
+  itself
+
+The product requirement is therefore:
+
+- users should be able to install AgenC
+- run a local daemon/runtime
+- use the TUI and a web dashboard against that same daemon
+- connect channels/connectors
+- participate in task and bid flows
+
+Trying to preserve a permanently private local framework fights that product
+reality. Source privacy is not the right primary moat for a local-first agent
+framework. Product quality, ecosystem, marketplace participation, operational
+advantage, and premium network services are.
+
+## Decision
+
+### Product direction
+
+AgenC is a public framework product.
+
+The end state is:
+
+- installable public `agenc` CLI/package
+- one local daemon/gateway as runtime authority
+- TUI/operator console and web UI as sibling clients of the same daemon
+- public plugin/add-on model around the same daemon/runtime
+- public marketplace participation flows in the product surface
+
+### Shared-daemon rule
+
+There is exactly one local runtime authority: the daemon/gateway.
+
+It owns:
+
+- sessions
+- health/status
+- logs
+- approvals
+- plugins
+- connectors
+- jobs/tasks
+- bids/marketplace state
+- UI-facing observability state
+
+TUI, CLI lifecycle commands, and the web dashboard all operate that same daemon.
+
+### Web UI rule
+
+The web UI is a dashboard/control center over the daemon.
+
+It is **not** a second runtime, **not** a second state authority, and **not** a
+forked product brain.
+
+For the public product path:
+
+- `web/` is the dashboard surface
+- `demo-app/` is not a peer dashboard candidate
+
+### Package/install rule
+
+The public install identity is `agenc`.
+
+`agenc` is a public wrapper/launcher package around the runtime surface. It is
+not a hand-waved public rename of the current private/transitional runtime
+package.
+
+`@tetsuo-ai/runtime` may remain transitional/internal while the installable
+public product surface is stabilized.
+
+### Connector/plugin rule
+
+There must not be two connector models.
+
+The versioned public host ABI must be frozen before connector shipping:
+
+- `plugin_api_version`
+- `host_api_version`
+
+First-party connectors may ship built-in first, but they still align to the
+same public plugin/connector host model rather than inventing a second
+incompatible lifecycle.
+
+### Private boundary after this ADR
+
+Private code is limited to genuine service-side or operational advantage:
+
+- proving backends
+- premium ranking/indexing/search/co-ordination services
+- anti-abuse/reputation services
+- admin/ops tooling
+- internal service credentials and deployments
+
+### Transition rule
+
+This ADR supersedes ADR-002 as the architectural direction, but the repo is not
+considered declassified just because this ADR exists.
+
+Implementation must proceed in two stages:
+
+1. make the public product install path, shared-daemon model, and package
+   contract real
+2. perform a declassification/public-scrub program before flipping
+   `agenc-core` visibility or removing private-boundary CI/policy
+
+Until that scrub is complete, old private-boundary checks remain transitional
+enforcement, not proof that ADR-003 is invalid.
+
+## Consequences
+
+### Positive
+
+- product direction now matches what AgenC actually is
+- OpenClaw-style shared-daemon operation becomes the explicit target
+- TUI and web can evolve as coherent clients instead of separate products
+- the framework becomes easier to install and adopt
+- marketplace participation is treated as first-class product behavior
+
+### Tradeoffs
+
+- the old private-kernel posture must be unwound carefully rather than ignored
+- package/install strategy must be explicit because public `agenc` cannot simply
+  depend on a private runtime package
+- declassification is now a real tracked implementation phase, not a future
+  hand-wave
+- source visibility is no longer the primary moat assumption
+
+## Implementation status
+
+Accepted direction. Not yet fully implemented.
+
+Required implementation gates:
+
+1. Phase 0: product contract + command/config/package strategy lock
+2. Phase 1: command/config convergence and compatibility handling
+3. Phase 2: public `agenc` install path
+4. Phase 3: daemon-backed web dashboard via `agenc ui`
+5. Later: task/bid contract, marketplace UX, connector expansion
+6. Final: public-scrub/declassification program for `agenc-core`
+
+Tracked implementation issues in `tetsuo-ai/agenc-core`:
+
+- `#4` CLI/config convergence
+- `#5` public `agenc` wrapper and runtime install path
+- `#6` daemon-backed web dashboard and `demo-app` retirement from product path
+- `#7` connector/plugin ABI freeze plus Telegram lifecycle
+- `#8` task/bid daemon contract before marketplace UX
+- `#9` declassification disposition table and scrub plan

--- a/docs/architecture/guides/cli-runtime-migration-map.md
+++ b/docs/architecture/guides/cli-runtime-migration-map.md
@@ -1,0 +1,76 @@
+# CLI And Runtime Migration Map
+
+This map records how the current `agenc` and `agenc-runtime` surfaces migrate
+into the public product contract defined by
+[ADR-003](../adr/adr-003-public-framework-product.md) and
+[product-contract.md](../product-contract.md).
+
+## Canonical state decision
+
+Target canonical paths:
+
+- config: `~/.agenc/config.json`
+- PID: `~/.agenc/daemon.pid`
+- logs/state/plugin/connector data: `~/.agenc/`
+
+Compatibility rule:
+
+- `.agenc-runtime.json` is importable legacy state
+- it is not a long-term competing default
+- both `agenc` and direct `agenc-runtime` execution must resolve the canonical
+  config path by default after convergence
+
+## Command migration table
+
+| Current surface | Current behavior | Public product disposition | Notes |
+| --- | --- | --- | --- |
+| `agenc` | opens operator console by default | `KEEP` | remains the default interactive operator/TUI surface |
+| `agenc console` | explicit operator console | `KEEP` | keep as explicit alias for default interactive mode |
+| `agenc <runtime-command>` | pass-through to runtime CLI | `KEEP` in transition | wrapper continues forwarding while public contract is stabilized |
+| `agenc-runtime onboard` | write local runtime config | `WRAP` | public surface becomes `agenc onboard`; runtime alias remains for compatibility |
+| `agenc-runtime health` | health checks | `WRAP` | public surface becomes `agenc health` |
+| `agenc-runtime doctor` | diagnostics/remediation | `WRAP` | public surface becomes `agenc doctor` |
+| `agenc-runtime init` | contributor-guide scaffolding | `DEFER/ADVANCED` | not required for end-user v1 |
+| `agenc-runtime config init|validate|show` | config commands | `KEEP/WRAP` | keep available; public wording should align to canonical config path |
+| `agenc-runtime start` | start daemon | `WRAP` | public surface becomes `agenc start` |
+| `agenc-runtime stop` | stop daemon | `WRAP` | public surface becomes `agenc stop` |
+| `agenc-runtime restart` | restart daemon | `WRAP` | public surface becomes `agenc restart` |
+| `agenc-runtime status` | daemon status | `WRAP` | public surface becomes `agenc status` |
+| `agenc-runtime logs` | daemon log access/help | `WRAP` | public surface becomes `agenc logs` |
+| `agenc-runtime service install` | service template generation | `KEEP/ADVANCED` | available for power users; not required to explain first-run product usage |
+| `agenc-runtime sessions list|kill` | control-plane sessions | `KEEP/ADVANCED` | important operator tooling; not day-one onboarding copy |
+| `agenc-runtime plugin ...` | plugin lifecycle | `WRAP` | plugin lifecycle becomes part of the public product surface |
+| `agenc-runtime jobs ...` | scheduled job controls | `KEEP INTERNAL TERM` | do not confuse with future public marketplace `tasks`/`bids` contract |
+| `agenc-runtime skill ...` | skill registry/management | `KEEP/ADVANCED` | retain as advanced surface; not first-run product copy |
+| `agenc-runtime replay ...` | replay/incident tooling | `KEEP INTERNAL/ADVANCED` | operator/debug tooling, not first-run public onboarding |
+
+## Config migration map
+
+| Current source | Target state | Disposition |
+| --- | --- | --- |
+| `.agenc-runtime.json` in cwd | import into `~/.agenc/config.json` | preserve as migration source only |
+| `~/.agenc/config.json` | canonical product config | preserve |
+| `~/.agenc/daemon.pid` | canonical PID file | preserve |
+
+Migration expectations:
+
+- first run detects legacy `.agenc-runtime.json` and offers import/migration
+- imported files are backed up before mutation
+- direct `agenc-runtime` uses the canonical config by default after migration
+
+## UI migration map
+
+| Surface | Disposition |
+| --- | --- |
+| operator console / TUI | primary mature operator surface |
+| `web/` | chosen daemon-backed dashboard surface |
+| `demo-app/` | move out of product path into demo/example track |
+
+## Marketplace language rule
+
+Current `jobs` commands are scheduled runtime job controls.
+
+They are **not** automatically the public marketplace UX.
+
+Public marketplace terms such as `tasks` and `bids` need their own explicit
+daemon/API contract before they are exposed as first-class public commands.

--- a/docs/architecture/product-contract.md
+++ b/docs/architecture/product-contract.md
@@ -1,0 +1,156 @@
+# AgenC Product Contract
+
+This document defines the public product contract for AgenC after
+[ADR-003](adr/adr-003-public-framework-product.md).
+
+## Core statement
+
+AgenC is an installable agent framework product with:
+
+- a public CLI
+- one local daemon/gateway as runtime authority
+- a TUI/operator console
+- a web dashboard using that same daemon
+- plugin/connector/task/marketplace behavior through the same runtime
+
+## Runtime authority
+
+The daemon/gateway is the single local source of truth for:
+
+- agent lifecycle
+- session state
+- health/status
+- approvals
+- logs and observability
+- plugins and connectors
+- jobs/tasks/bids
+
+No client surface is allowed to create a second runtime authority.
+
+## Client surfaces
+
+### CLI
+
+Primary responsibilities:
+
+- onboarding
+- lifecycle control: start/stop/restart/status/logs
+- connector and plugin management
+- eventual task/bid interaction
+
+### TUI / operator console
+
+Primary responsibilities:
+
+- mature operator workflow
+- advanced session/workspace/log/approval visibility
+- deep local control
+
+### Web dashboard
+
+Primary responsibilities:
+
+- health/status dashboard
+- runs and observability
+- approvals and configuration
+- agent summary/control
+- task and marketplace dashboards
+
+The web dashboard is a daemon client, not a separate runtime.
+
+## Public install surface
+
+The public user-facing install identity is `agenc`.
+
+V1 install flow:
+
+```bash
+npm install -g agenc
+agenc onboard
+agenc start
+agenc
+agenc ui
+```
+
+## Public package composition
+
+The public `agenc` package is a wrapper/launcher package.
+
+It does not depend on a private runtime package as a normal npm dependency.
+
+V1 public package composition:
+
+- `agenc-core` CI builds monolithic public runtime distributions from the
+  existing runtime bins
+- signed public runtime artifacts are published on the public release channel
+- the public `agenc` wrapper installs/updates/launches those runtime artifacts
+- no end-user install path requires private-registry credentials
+
+## Canonical local state
+
+Canonical operator layout:
+
+- config: `~/.agenc/config.json`
+- PID: `~/.agenc/daemon.pid`
+- logs/cache/plugin/connector state: `~/.agenc/`
+
+Legacy `.agenc-runtime.json` is compatibility input only. It must not remain a
+competing default.
+
+## Dashboard choice
+
+`web/` is the dashboard product surface.
+
+`demo-app/` is not a peer dashboard. It is a separate demo-only surface that
+must be moved out of the product path.
+
+## Connector and plugin contract
+
+Connectors and plugins must share one public host contract:
+
+- `plugin_api_version`
+- `host_api_version`
+
+First-party connectors may ship built-in first, but they cannot create a second
+incompatible lifecycle model.
+
+## V1 scope
+
+V1 means:
+
+- install `agenc`
+- onboard
+- start/stop/status/logs
+- TUI attach
+- one daemon-backed web dashboard via `agenc ui`
+- one first-party connector: Telegram
+
+V1 does **not** require:
+
+- voice/phone connector
+- desktop packaging
+- full marketplace UX polish
+- fully public source visibility on day one
+
+## Tracked implementation
+
+This contract is being implemented in `tetsuo-ai/agenc-core` through:
+
+- `#4` `feat(cli): converge agenc and agenc-runtime config/state defaults`
+- `#5` `feat(distribution): ship public agenc wrapper package and runtime install path`
+- `#6` `feat(web): lock agenc ui to the daemon-backed dashboard and retire demo-app from product surface`
+- `#7` `feat(connectors): freeze plugin/connector host ABI and ship Telegram lifecycle`
+- `#8` `feat(marketplace): define task/bid daemon contract before public marketplace UX`
+- `#9` `chore(repo): build agenc-core declassification disposition table and scrub plan`
+
+## Private service boundary
+
+These may remain private:
+
+- proving backends
+- premium ranking/indexing/search/co-ordination
+- anti-abuse/reputation
+- admin/ops systems
+- internal credentials and deployments
+
+The local framework/runtime product itself is the public-facing product.


### PR DESCRIPTION
## Summary
- add ADR-003 to supersede the old private-framework direction with the public framework product model
- add a product contract and CLI/runtime migration map for the shared-daemon AgenC install surface
- link the architecture docs to the tracked Phase 0-3 implementation issues

## Testing
- git diff --check

## Related
- #4
- #5
- #6
- #7
- #8
- #9
