### PR TITLE
fix(agenc): harden public install release gates

### DIFF
--- a/.github/workflows/package-pack-smoke.yml
+++ b/.github/workflows/package-pack-smoke.yml
@@ -81,3 +81,25 @@ jobs:
 
       - name: Run public agenc install smoke test
         run: npm run smoke:public-agenc-install -- --skip-build
+
+  public-install-min-node:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install workspace dependencies
+        run: npm install --no-fund
+
+      - name: Build private-kernel packages
+        run: npm run build:private-kernel
+
+      - name: Run minimum-supported Node public agenc install smoke test
+        run: npm run smoke:public-agenc-install -- --skip-build

--- a/docs/architecture/guides/public-runtime-release-channel.md
+++ b/docs/architecture/guides/public-runtime-release-channel.md
@@ -49,6 +49,11 @@ Current public wrapper support is intentionally narrow:
 - arch: `x64`
 - Node: `>=18.0.0`
 
+The current release gate validates that tuple on:
+
+- Node `18` minimum-floor CI
+- Node `20` mainline CI
+
 Anything else must fail clearly as unsupported. Broader platform support should
 only be added once release CI and smoke coverage exist for those tuples.
 
@@ -66,6 +71,12 @@ It also maintains:
 The wrapper always launches the runtime through the stable `current` pointer so
 service templates, TUI handoff, and compatibility bins do not bind to a stale
 versioned path.
+
+Release-gate requirement:
+
+- fresh install must create `~/.agenc/runtime/current`
+- wrapper-managed update must advance `current` to the newer release
+- `install-state.json` must converge to the upgraded runtime version
 
 ## Trust model
 

--- a/docs/architecture/guides/runtime-install-matrix.md
+++ b/docs/architecture/guides/runtime-install-matrix.md
@@ -30,11 +30,9 @@ Current package engine floor from
 Current support statement:
 
 - Node `18+` is the minimum supported runtime floor for local CLI/daemon use
-- the package contract does not currently publish a narrower supported-LTS
-  matrix than that engine floor
-- when release CI pins exact Node versions for the public `agenc` install
-  surface, this document should be updated to list those exact validated
-  versions
+- the public `agenc` install path is currently validated in CI on:
+  - Node `18` as the supported minimum floor
+  - Node `20` as the current mainline release gate
 
 ## Public wrapper install support
 
@@ -45,8 +43,14 @@ tuple:
 - Node `>=18.0.0`
 
 That support is enforced both in the wrapper and in the runtime-artifact build
-pipeline. Other tuples must fail clearly as unsupported until explicit release
-coverage is added.
+pipeline, and the release gate now proves:
+
+- fresh install
+- wrapper-managed upgrade to a newer embedded runtime manifest
+- `~/.agenc/runtime/current` convergence to the upgraded release
+
+Other tuples must fail clearly as unsupported until explicit release coverage is
+added.
 
 ## Operating system support
 

--- a/docs/architecture/product-contract.md
+++ b/docs/architecture/product-contract.md
@@ -79,7 +79,8 @@ Phase 2 public wrapper support is intentionally narrow:
 - Node: `>=18.0.0`
 
 That tuple is the only one the public release/install contract should claim
-until release CI validates more.
+until release CI validates more. Current CI validates it on Node `18` as the
+minimum floor and Node `20` as the mainline lane.
 
 ## Public package composition
 
@@ -98,6 +99,12 @@ V1 public package composition:
 
 See [guides/public-runtime-release-channel.md](guides/public-runtime-release-channel.md)
 for the explicit release-channel and trust model.
+
+Release hardening requires proof of:
+
+- fresh install
+- wrapper-package upgrade to a newer embedded runtime manifest
+- stable `~/.agenc/runtime/current` handoff after upgrade
 
 ## Canonical local state
 

--- a/packages/agenc/README.md
+++ b/packages/agenc/README.md
@@ -20,6 +20,11 @@ Current public support is intentionally narrow:
 - Linux `x64`
 - Node `>=18.0.0`
 
+Current validated release-gate lanes:
+
+- Node `18` minimum floor
+- Node `20` mainline lane
+
 Production release channel:
 
 - npm package: `agenc`

--- a/packages/agenc/tests/runtime-manager.test.mjs
+++ b/packages/agenc/tests/runtime-manager.test.mjs
@@ -25,18 +25,8 @@ async function createFixtureContext(t) {
   const packageRoot = path.join(root, "package");
   const generatedDir = path.join(packageRoot, "generated");
   const homeDir = path.join(root, "home");
-  const artifactStageDir = path.join(root, "artifact-stage");
-  const runtimeBinDir = path.join(
-    artifactStageDir,
-    "node_modules",
-    "@tetsuo-ai",
-    "runtime",
-    "dist",
-    "bin",
-  );
   await mkdir(generatedDir, { recursive: true });
   await mkdir(homeDir, { recursive: true });
-  await mkdir(runtimeBinDir, { recursive: true });
 
   await writeFile(
     path.join(packageRoot, "package.json"),
@@ -44,90 +34,109 @@ async function createFixtureContext(t) {
     "utf8",
   );
 
-  const fakeBins = {
-    agenc: `#!/usr/bin/env node\nconsole.log("agenc-bin");\n`,
-    "agenc-runtime": `#!/usr/bin/env node\nconsole.log("agenc-runtime-bin");\n`,
-    daemon: `#!/usr/bin/env node\nconsole.log("daemon-bin");\n`,
-    "agenc-watch": `#!/usr/bin/env node\nconsole.log("agenc-watch-bin");\n`,
-  };
-
-  for (const [name, contents] of Object.entries(fakeBins)) {
-    await writeFile(path.join(runtimeBinDir, `${name}.js`), contents, {
-      encoding: "utf8",
-      mode: 0o755,
-    });
-  }
-
-  const artifactPath = path.join(root, "agenc-runtime-0.1.0-linux-x64.tar.gz");
-  execFileSync("tar", ["-czf", artifactPath, "-C", artifactStageDir, "."], {
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  const artifactSha = sha256(await readFile(artifactPath));
-
-  const manifest = {
-    manifestVersion: 1,
-    wrapperVersion: "0.1.0",
-    keyId: "local-dev",
-    artifacts: [
-      {
-        platform: "linux",
-        arch: "x64",
-        nodeRange: ">=18.0.0",
-        runtimeVersion: "0.1.0",
-        url: pathToFileURL(artifactPath).href,
-        sha256: artifactSha,
-        bins: {
-          agenc: "node_modules/@tetsuo-ai/runtime/dist/bin/agenc.js",
-          "agenc-runtime":
-            "node_modules/@tetsuo-ai/runtime/dist/bin/agenc-runtime.js",
-          daemon: "node_modules/@tetsuo-ai/runtime/dist/bin/daemon.js",
-          "agenc-watch":
-            "node_modules/@tetsuo-ai/runtime/dist/bin/agenc-watch.js",
-        },
-      },
-    ],
-  };
-  const manifestBytes = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
   const { privateKey, publicKey } = generateKeyPairSync("ed25519");
-  const signature = sign(null, manifestBytes, privateKey).toString("base64");
-
-  await writeFile(
-    path.join(generatedDir, "agenc-runtime-manifest.json"),
-    manifestBytes,
-  );
-  await writeFile(
-    path.join(generatedDir, "agenc-runtime-manifest.json.sig"),
-    `${signature}\n`,
-    "utf8",
-  );
   await writeFile(
     path.join(generatedDir, "agenc-runtime-public-key.pem"),
     publicKey.export({ type: "spki", format: "pem" }),
-    "utf8",
-  );
-  await writeFile(
-    path.join(generatedDir, "agenc-runtime-trust-policy.json"),
-    `${JSON.stringify(
-      {
-        wrapperVersion: "0.1.0",
-        keyId: "local-dev",
-        revokedManifestDigests: [],
-        revokedRuntimeVersions: [],
-      },
-      null,
-      2,
-    )}\n`,
     "utf8",
   );
 
   return {
     packageRoot,
     homeDir,
+    async stageEmbeddedRelease(runtimeVersion) {
+      const artifactStageDir = path.join(root, `artifact-stage-${runtimeVersion}`);
+      const runtimeBinDir = path.join(
+        artifactStageDir,
+        "node_modules",
+        "@tetsuo-ai",
+        "runtime",
+        "dist",
+        "bin",
+      );
+      await mkdir(runtimeBinDir, { recursive: true });
+
+      const fakeBins = {
+        agenc: `#!/usr/bin/env node\nconsole.log("agenc-bin:${runtimeVersion}");\n`,
+        "agenc-runtime": `#!/usr/bin/env node\nconsole.log("agenc-runtime-bin:${runtimeVersion}");\n`,
+        daemon: `#!/usr/bin/env node\nconsole.log("daemon-bin:${runtimeVersion}");\n`,
+        "agenc-watch": `#!/usr/bin/env node\nconsole.log("agenc-watch-bin:${runtimeVersion}");\n`,
+      };
+
+      for (const [name, contents] of Object.entries(fakeBins)) {
+        await writeFile(path.join(runtimeBinDir, `${name}.js`), contents, {
+          encoding: "utf8",
+          mode: 0o755,
+        });
+      }
+
+      const artifactPath = path.join(
+        root,
+        `agenc-runtime-${runtimeVersion}-linux-x64.tar.gz`,
+      );
+      execFileSync("tar", ["-czf", artifactPath, "-C", artifactStageDir, "."], {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const artifactSha = sha256(await readFile(artifactPath));
+
+      const manifest = {
+        manifestVersion: 1,
+        wrapperVersion: "0.1.0",
+        keyId: "local-dev",
+        artifacts: [
+          {
+            platform: "linux",
+            arch: "x64",
+            nodeRange: ">=18.0.0",
+            runtimeVersion,
+            url: pathToFileURL(artifactPath).href,
+            sha256: artifactSha,
+            bins: {
+              agenc: "node_modules/@tetsuo-ai/runtime/dist/bin/agenc.js",
+              "agenc-runtime":
+                "node_modules/@tetsuo-ai/runtime/dist/bin/agenc-runtime.js",
+              daemon: "node_modules/@tetsuo-ai/runtime/dist/bin/daemon.js",
+              "agenc-watch":
+                "node_modules/@tetsuo-ai/runtime/dist/bin/agenc-watch.js",
+            },
+          },
+        ],
+      };
+      const manifestBytes = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
+      const signature = sign(null, manifestBytes, privateKey).toString("base64");
+
+      await writeFile(
+        path.join(generatedDir, "agenc-runtime-manifest.json"),
+        manifestBytes,
+      );
+      await writeFile(
+        path.join(generatedDir, "agenc-runtime-manifest.json.sig"),
+        `${signature}\n`,
+        "utf8",
+      );
+      await writeFile(
+        path.join(generatedDir, "agenc-runtime-trust-policy.json"),
+        `${JSON.stringify(
+          {
+            wrapperVersion: "0.1.0",
+            keyId: "local-dev",
+            revokedManifestDigests: [],
+            revokedRuntimeVersions: [],
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+
+      return { artifactPath, runtimeVersion };
+    },
   };
 }
 
 test("loadVerifiedManifest accepts embedded signed manifests", async (t) => {
   const fixture = await createFixtureContext(t);
+  await fixture.stageEmbeddedRelease("0.1.0");
 
   const loaded = await loadVerifiedManifest({
     packageRoot: fixture.packageRoot,
@@ -141,6 +150,7 @@ test("loadVerifiedManifest accepts embedded signed manifests", async (t) => {
 
 test("ensureRuntimeInstalled installs the runtime artifact under ~/.agenc/runtime", async (t) => {
   const fixture = await createFixtureContext(t);
+  await fixture.stageEmbeddedRelease("0.1.0");
 
   const installed = await ensureRuntimeInstalled({
     packageRoot: fixture.packageRoot,
@@ -158,10 +168,56 @@ test("ensureRuntimeInstalled installs the runtime artifact under ~/.agenc/runtim
     await readlink(installed.currentDir),
     installed.releaseDir,
   );
+  assert.ok(installed.bins.agenc.startsWith(installed.currentDir));
+});
+
+test("ensureRuntimeInstalled force=true advances the stable current pointer on upgrade", async (t) => {
+  const fixture = await createFixtureContext(t);
+  await fixture.stageEmbeddedRelease("0.1.0");
+
+  const installedV1 = await ensureRuntimeInstalled({
+    packageRoot: fixture.packageRoot,
+    homeDir: fixture.homeDir,
+    platform: "linux",
+    arch: "x64",
+    nodeVersion: "20.0.0",
+  });
+  const currentTargetV1 = await readlink(installedV1.currentDir);
+  const installStatePath = path.join(
+    fixture.homeDir,
+    ".agenc",
+    "runtime",
+    "install-state.json",
+  );
+  const installStateV1 = JSON.parse(await readFile(installStatePath, "utf8"));
+
+  await fixture.stageEmbeddedRelease("0.1.1");
+
+  const installedV2 = await ensureRuntimeInstalled({
+    packageRoot: fixture.packageRoot,
+    homeDir: fixture.homeDir,
+    platform: "linux",
+    arch: "x64",
+    nodeVersion: "20.0.0",
+    force: true,
+  });
+  const currentTargetV2 = await readlink(installedV2.currentDir);
+  const installStateV2 = JSON.parse(await readFile(installStatePath, "utf8"));
+
+  assert.equal(installStateV1.runtimeVersion, "0.1.0");
+  assert.equal(installStateV2.runtimeVersion, "0.1.1");
+  assert.notEqual(currentTargetV1, currentTargetV2);
+  assert.equal(currentTargetV2, installedV2.releaseDir);
+  assert.match(installedV2.releaseDir, /releases\/0\.1\.1\/linux-x64$/u);
+  await stat(installedV1.releaseDir);
+  await stat(installedV2.releaseDir);
+  await stat(installedV2.bins.agenc);
+  assert.ok(installedV2.bins.agenc.startsWith(installedV2.currentDir));
 });
 
 test("uninstallRuntime refuses to remove a live runtime without --force", async (t) => {
   const fixture = await createFixtureContext(t);
+  await fixture.stageEmbeddedRelease("0.1.0");
   const operatorHome = path.join(fixture.homeDir, ".agenc");
   await mkdir(operatorHome, { recursive: true });
   await writeFile(
@@ -188,6 +244,7 @@ test("uninstallRuntime refuses to remove a live runtime without --force", async 
 
 test("uninstallRuntime removes the installed runtime but preserves operator state", async (t) => {
   const fixture = await createFixtureContext(t);
+  await fixture.stageEmbeddedRelease("0.1.0");
 
   const installed = await ensureRuntimeInstalled({
     packageRoot: fixture.packageRoot,
@@ -215,6 +272,7 @@ test("uninstallRuntime removes the installed runtime but preserves operator stat
 
 test("loadVerifiedManifest rejects revoked runtime versions", async (t) => {
   const fixture = await createFixtureContext(t);
+  await fixture.stageEmbeddedRelease("0.1.0");
   const trustPolicyPath = path.join(
     fixture.packageRoot,
     "generated",

--- a/runtime/src/bin/agenc-runtime.ts
+++ b/runtime/src/bin/agenc-runtime.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import "./node-compat.js";
 import { runCli } from '../cli/index.js';
 
 void (async () => {

--- a/runtime/src/bin/agenc-watch.ts
+++ b/runtime/src/bin/agenc-watch.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import "./node-compat.js";
 import { runAgencWatchCli } from "../watch/entry.mjs";
 
 void (async () => {

--- a/runtime/src/bin/agenc.ts
+++ b/runtime/src/bin/agenc.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import "./node-compat.js";
 import { runAgencCli } from "../cli/agenc.js";
 
 void (async () => {

--- a/runtime/src/bin/daemon.ts
+++ b/runtime/src/bin/daemon.ts
@@ -3,6 +3,7 @@
  * Daemon entry point. Forked by `agenc start` or run directly with `--foreground`.
  */
 
+import "./node-compat.js";
 import { DaemonManager } from '../gateway/daemon.js';
 import { createLogger } from '../utils/logger.js';
 import { toErrorMessage } from '../utils/async.js';

--- a/runtime/src/bin/node-compat.test.ts
+++ b/runtime/src/bin/node-compat.test.ts
@@ -1,0 +1,41 @@
+import { File as NodeFile } from "node:buffer";
+import { afterEach, describe, expect, it } from "vitest";
+import { installNodeRuntimeCompat } from "./node-compat.js";
+
+const originalFileDescriptor = Object.getOwnPropertyDescriptor(globalThis, "File");
+
+function restoreGlobalFile(): void {
+  if (originalFileDescriptor) {
+    Object.defineProperty(globalThis, "File", originalFileDescriptor);
+    return;
+  }
+  Reflect.deleteProperty(globalThis, "File");
+}
+
+describe("node runtime compatibility", () => {
+  afterEach(() => {
+    restoreGlobalFile();
+  });
+
+  it("installs node:buffer File when the Node global is missing", () => {
+    Reflect.deleteProperty(globalThis, "File");
+    expect(typeof globalThis.File).toBe("undefined");
+
+    installNodeRuntimeCompat();
+
+    expect(globalThis.File).toBe(NodeFile);
+  });
+
+  it("preserves an existing File global", () => {
+    const sentinel = class SentinelFile {} as unknown as typeof globalThis.File;
+    Object.defineProperty(globalThis, "File", {
+      value: sentinel,
+      configurable: true,
+      writable: true,
+    });
+
+    installNodeRuntimeCompat();
+
+    expect(globalThis.File).toBe(sentinel);
+  });
+});

--- a/runtime/src/bin/node-compat.ts
+++ b/runtime/src/bin/node-compat.ts
@@ -1,0 +1,9 @@
+import { File as NodeFile } from "node:buffer";
+
+export function installNodeRuntimeCompat(): void {
+  if (typeof globalThis.File === "undefined") {
+    globalThis.File = NodeFile as typeof globalThis.File;
+  }
+}
+
+installNodeRuntimeCompat();

--- a/scripts/build-public-runtime-artifacts.mjs
+++ b/scripts/build-public-runtime-artifacts.mjs
@@ -21,6 +21,7 @@ function parseArgs(argv) {
     keyId: null,
     releaseRepository: "tetsuo-ai/agenc-core",
     releaseTag: null,
+    runtimeVersionOverride: null,
     skipBuild: false,
   };
 
@@ -44,6 +45,9 @@ function parseArgs(argv) {
         break;
       case "--release-tag":
         options.releaseTag = argv[++index];
+        break;
+      case "--runtime-version-override":
+        options.runtimeVersionOverride = argv[++index];
         break;
       case "--skip-build":
         options.skipBuild = true;
@@ -131,6 +135,8 @@ async function main() {
   const options = parseArgs(process.argv.slice(2));
   const runtimePackage = await readJson(path.join(runtimeDir, "package.json"));
   const wrapperPackage = await readJson(path.join(wrapperDir, "package.json"));
+  const runtimeVersion =
+    options.runtimeVersionOverride ?? runtimePackage.version;
   const platform = process.platform;
   const arch = process.arch;
   const platformArch = `${platform}-${arch}`;
@@ -191,7 +197,7 @@ async function main() {
 
     const metadata = {
       builtAt: new Date().toISOString(),
-      runtimeVersion: runtimePackage.version,
+      runtimeVersion,
       wrapperVersion: wrapperPackage.version,
       platform,
       arch,
@@ -209,7 +215,7 @@ async function main() {
       "utf8",
     );
 
-    const artifactFilename = `agenc-runtime-${runtimePackage.version}-${platform}-${arch}.tar.gz`;
+    const artifactFilename = `agenc-runtime-${runtimeVersion}-${platform}-${arch}.tar.gz`;
     const artifactPath = path.join(options.outDir, artifactFilename);
     run("tar", ["-czf", artifactPath, "-C", installRoot, "."], repoRoot);
     const artifactSha = sha256(await readFile(artifactPath));
@@ -231,7 +237,7 @@ async function main() {
           platform,
           arch,
           nodeRange: runtimePackage.engines?.node ?? ">=18.0.0",
-          runtimeVersion: runtimePackage.version,
+          runtimeVersion,
           url: artifactUrl,
           sha256: artifactSha,
           bins: metadata.bins,
@@ -290,7 +296,7 @@ async function main() {
           releaseTag: manifest.releaseTag,
           platform,
           arch,
-          runtimeVersion: runtimePackage.version,
+          runtimeVersion,
           wrapperVersion: wrapperPackage.version,
           artifactSha256: artifactSha,
           artifactUrl,

--- a/scripts/public-agenc-install-smoke.mjs
+++ b/scripts/public-agenc-install-smoke.mjs
@@ -2,7 +2,17 @@
 
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { lstat, mkdtemp, readFile, rm, unlink } from "node:fs/promises";
+import { generateKeyPairSync } from "node:crypto";
+import {
+  copyFile,
+  lstat,
+  mkdtemp,
+  readFile,
+  readlink,
+  rm,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
@@ -32,13 +42,93 @@ function runJson(command, args, cwd, env = process.env) {
   return JSON.parse(run(command, args, cwd, env));
 }
 
+function bumpPatchVersion(version) {
+  const match = /^v?(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$/u.exec(version);
+  if (!match?.groups) {
+    throw new Error(`cannot derive next runtime version from ${version}`);
+  }
+  return `${match.groups.major}.${match.groups.minor}.${Number.parseInt(match.groups.patch, 10) + 1}`;
+}
+
+async function createSigningKeyFile(tempRoot) {
+  const { privateKey } = generateKeyPairSync("ed25519");
+  const privateKeyPath = path.join(tempRoot, "release-signing-key.pem");
+  await writeFile(
+    privateKeyPath,
+    privateKey.export({ type: "pkcs8", format: "pem" }),
+    { encoding: "utf8", mode: 0o600 },
+  );
+  return privateKeyPath;
+}
+
+function buildRuntimeArtifacts(repoRootPath, artifactDir, runtimeVersion, privateKeyPath) {
+  run(
+    "node",
+    [
+      "scripts/build-public-runtime-artifacts.mjs",
+      "--out-dir",
+      artifactDir,
+      "--runtime-version-override",
+      runtimeVersion,
+      "--private-key-file",
+      privateKeyPath,
+      "--key-id",
+      "local-dev",
+      "--skip-build",
+    ],
+    repoRootPath,
+  );
+}
+
+async function packPreparedWrapper(repoRootPath, artifactDir, tempRoot, label) {
+  run(
+    "node",
+    ["scripts/prepare-public-agenc-package.mjs", "--artifact-dir", artifactDir],
+    repoRootPath,
+  );
+  const packed = JSON.parse(run("npm", ["pack", "--json"], wrapperDir))[0];
+  if (!packed?.filename) {
+    throw new Error("npm pack did not return a tarball filename for agenc");
+  }
+  const originalTarballPath = path.join(wrapperDir, packed.filename);
+  const tarballPath = path.join(tempRoot, `${label}-${packed.filename}`);
+  await copyFile(originalTarballPath, tarballPath);
+  await unlink(originalTarballPath);
+  return tarballPath;
+}
+
+function installWrapperTarball(repoRootPath, prefixDir, homeDir, tarballPath, force = false) {
+  const installArgs = [
+    "install",
+    "--global",
+    "--no-fund",
+    "--no-audit",
+    "--prefix",
+    prefixDir,
+  ];
+  if (force) {
+    installArgs.push("--force");
+  }
+  installArgs.push(tarballPath);
+  run("npm", installArgs, repoRootPath, {
+    ...process.env,
+    HOME: homeDir,
+  });
+}
+
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), "agenc-public-install."));
-  const artifactDir = path.join(tempRoot, "artifacts");
+  const artifactDirV1 = path.join(tempRoot, "artifacts-v1");
+  const artifactDirV2 = path.join(tempRoot, "artifacts-v2");
   const prefixDir = path.join(tempRoot, "prefix");
   const homeDir = path.join(tempRoot, "home");
-  let wrapperTarballPath = null;
+  const wrapperTarballPaths = [];
+  const runtimePackage = JSON.parse(
+    await readFile(path.join(repoRoot, "runtime", "package.json"), "utf8"),
+  );
+  const initialRuntimeVersion = runtimePackage.version;
+  const upgradedRuntimeVersion = bumpPatchVersion(initialRuntimeVersion);
 
   try {
     if (!options.skipBuild) {
@@ -46,36 +136,27 @@ async function main() {
       run("npm", ["run", "build", "--workspace=@tetsuo-ai/runtime"], repoRoot);
     }
 
-    process.stdout.write("[public-install-smoke] building runtime artifacts\n");
-    run(
-      "node",
-      ["scripts/build-public-runtime-artifacts.mjs", "--out-dir", artifactDir, "--skip-build"],
+    const privateKeyPath = await createSigningKeyFile(tempRoot);
+
+    process.stdout.write("[public-install-smoke] building initial runtime artifacts\n");
+    buildRuntimeArtifacts(
       repoRoot,
+      artifactDirV1,
+      initialRuntimeVersion,
+      privateKeyPath,
     );
 
-    process.stdout.write("[public-install-smoke] embedding manifest into wrapper package\n");
-    run(
-      "node",
-      ["scripts/prepare-public-agenc-package.mjs", "--artifact-dir", artifactDir],
+    process.stdout.write("[public-install-smoke] embedding initial manifest into wrapper package\n");
+    const wrapperTarballV1 = await packPreparedWrapper(
       repoRoot,
+      artifactDirV1,
+      tempRoot,
+      "wrapper-v1",
     );
-
-    const packed = JSON.parse(run("npm", ["pack", "--json"], wrapperDir))[0];
-    if (!packed?.filename) {
-      throw new Error("npm pack did not return a tarball filename for agenc");
-    }
-    wrapperTarballPath = path.join(wrapperDir, packed.filename);
+    wrapperTarballPaths.push(wrapperTarballV1);
 
     process.stdout.write("[public-install-smoke] installing wrapper globally into temp prefix\n");
-    run(
-      "npm",
-      ["install", "--global", "--no-fund", "--no-audit", "--prefix", prefixDir, wrapperTarballPath],
-      repoRoot,
-      {
-        ...process.env,
-        HOME: homeDir,
-      },
-    );
+    installWrapperTarball(repoRoot, prefixDir, homeDir, wrapperTarballV1);
 
     const binDir = path.join(prefixDir, "bin");
     const agencBin = path.join(binDir, "agenc");
@@ -99,15 +180,74 @@ async function main() {
     assert.equal(typeof wherePayload.currentDir, "string");
     assert.equal(wherePayload.selectedArtifact?.platform, "linux");
     assert.equal(wherePayload.selectedArtifact?.arch, "x64");
+    assert.equal(wherePayload.selectedArtifact?.runtimeVersion, initialRuntimeVersion);
     assert.equal(wherePayload.trustPolicy?.releaseChannel, "local-dev");
 
     const currentDirStat = await lstat(wherePayload.currentDir);
     assert.equal(currentDirStat.isSymbolicLink(), true);
+    assert.equal(await readlink(wherePayload.currentDir), wherePayload.releaseDir);
 
     const statusPayload = runJson(agencBin, ["status"], repoRoot, execEnv);
     assert.equal(statusPayload.status, "ok");
     assert.equal(statusPayload.command, "status");
     assert.equal(statusPayload.running, false);
+
+    const installStatePath = path.join(homeDir, ".agenc", "runtime", "install-state.json");
+    const installStateV1 = JSON.parse(await readFile(installStatePath, "utf8"));
+    assert.equal(installStateV1.runtimeVersion, initialRuntimeVersion);
+    const currentSymlinkTargetV1 = wherePayload.releaseDir;
+
+    process.stdout.write("[public-install-smoke] building upgraded runtime artifacts\n");
+    buildRuntimeArtifacts(
+      repoRoot,
+      artifactDirV2,
+      upgradedRuntimeVersion,
+      privateKeyPath,
+    );
+
+    process.stdout.write("[public-install-smoke] embedding upgraded manifest into wrapper package\n");
+    const wrapperTarballV2 = await packPreparedWrapper(
+      repoRoot,
+      artifactDirV2,
+      tempRoot,
+      "wrapper-v2",
+    );
+    wrapperTarballPaths.push(wrapperTarballV2);
+
+    process.stdout.write("[public-install-smoke] reinstalling wrapper with upgraded manifest\n");
+    installWrapperTarball(repoRoot, prefixDir, homeDir, wrapperTarballV2, true);
+
+    run(agencBin, ["runtime", "update"], repoRoot, execEnv);
+    const upgradedWherePayload = runJson(
+      agencBin,
+      ["runtime", "where"],
+      repoRoot,
+      execEnv,
+    );
+    assert.equal(
+      upgradedWherePayload.selectedArtifact?.runtimeVersion,
+      upgradedRuntimeVersion,
+    );
+    assert.notEqual(upgradedWherePayload.releaseDir, currentSymlinkTargetV1);
+    assert.match(
+      upgradedWherePayload.releaseDir,
+      new RegExp(`releases/${upgradedRuntimeVersion.replace(/\./gu, "\\.")}/linux-x64$`, "u"),
+    );
+    const upgradedCurrentDirStat = await lstat(upgradedWherePayload.currentDir);
+    assert.equal(upgradedCurrentDirStat.isSymbolicLink(), true);
+    assert.equal(
+      await readlink(upgradedWherePayload.currentDir),
+      upgradedWherePayload.releaseDir,
+    );
+    const installStateV2 = JSON.parse(await readFile(installStatePath, "utf8"));
+    assert.equal(installStateV2.runtimeVersion, upgradedRuntimeVersion);
+    assert.equal(installStateV2.releaseDir, upgradedWherePayload.releaseDir);
+    assert.equal(installStateV2.currentDir, upgradedWherePayload.currentDir);
+
+    const upgradedStatusPayload = runJson(agencBin, ["status"], repoRoot, execEnv);
+    assert.equal(upgradedStatusPayload.status, "ok");
+    assert.equal(upgradedStatusPayload.command, "status");
+    assert.equal(upgradedStatusPayload.running, false);
 
     run(agencBin, ["runtime", "uninstall", "--force"], repoRoot, execEnv);
     const lazyReinstallStatus = runJson(agencBin, ["status"], repoRoot, execEnv);
@@ -125,14 +265,14 @@ async function main() {
     assert.equal(runtimeAliasStatus.command, "status");
     assert.equal(runtimeAliasStatus.running, false);
 
-    const statePath = path.join(homeDir, ".agenc", "runtime", "install-state.json");
-    const state = JSON.parse(await readFile(statePath, "utf8"));
+    const state = JSON.parse(await readFile(installStatePath, "utf8"));
     if (typeof state.releaseDir !== "string" || state.releaseDir.length === 0) {
-      throw new Error(`unexpected install state payload at ${statePath}`);
+      throw new Error(`unexpected install state payload at ${installStatePath}`);
     }
     if (typeof state.currentDir !== "string" || state.currentDir.length === 0) {
-      throw new Error(`unexpected currentDir in install state at ${statePath}`);
+      throw new Error(`unexpected currentDir in install state at ${installStatePath}`);
     }
+    assert.equal(state.runtimeVersion, upgradedRuntimeVersion);
 
     process.stdout.write("[public-install-smoke] smoke-ok\n");
   } finally {
@@ -140,7 +280,7 @@ async function main() {
     await unlink(path.join(generatedDir, "agenc-runtime-manifest.json.sig")).catch(() => {});
     await unlink(path.join(generatedDir, "agenc-runtime-public-key.pem")).catch(() => {});
     await unlink(path.join(generatedDir, "agenc-runtime-trust-policy.json")).catch(() => {});
-    if (wrapperTarballPath) {
+    for (const wrapperTarballPath of wrapperTarballPaths) {
       await unlink(wrapperTarballPath).catch(() => {});
     }
     if (options.keepTemp) {


### PR DESCRIPTION
## Summary
- harden the public install smoke to cover wrapper-managed upgrades and stable current-pointer handoff
- validate the public install contract on Node 20 and the minimum supported Node 18 lane
- patch runtime bin startup so Node 18 provides a File global before undici-backed code loads

## Testing
- npm run test --workspace=agenc
- npm run test --workspace=@tetsuo-ai/runtime -- src/bin/node-compat.test.ts src/cli/daemon.test.ts src/cli/operator-console.test.ts
- npm run build --workspace=@tetsuo-ai/runtime
- source ~/.nvm/nvm.sh && nvm use 20.19.6 >/dev/null && npm run smoke:public-agenc-install -- --skip-build
- source ~/.nvm/nvm.sh && nvm use 18.20.8 >/dev/null && npm run build:private-kernel && npm run smoke:public-agenc-install -- --skip-build
- git diff --check