### PR TITLE
feat(packaging): scope the agenc wrapper package

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ This repository currently owns the implementation for:
 Under [ADR-003](docs/architecture/adr/adr-003-public-framework-product.md), the
 product contract is public-framework-first:
 
-- the install surface is `agenc`
+- the npm install surface is `@tetsuo-ai/agenc`
+- the CLI command remains `agenc`
 - one daemon/gateway is the runtime authority
 - TUI and web are sibling clients of that daemon
 
@@ -40,7 +41,8 @@ Implementation packages in this repo remain non-builder surfaces:
 
 ### Public Product Install Surface
 
-The public operator install identity is `agenc`.
+The public operator install identity is the scoped package `@tetsuo-ai/agenc`,
+which installs the `agenc` CLI.
 
 Phase 2 public wrapper support is currently:
 

--- a/docs/architecture/adr/adr-003-public-framework-product.md
+++ b/docs/architecture/adr/adr-003-public-framework-product.md
@@ -53,7 +53,7 @@ AgenC is a public framework product.
 
 The end state is:
 
-- installable public `agenc` CLI/package
+- installable public `@tetsuo-ai/agenc` package with the `agenc` CLI
 - one local daemon/gateway as runtime authority
 - TUI/operator console and web UI as sibling clients of the same daemon
 - public plugin/add-on model around the same daemon/runtime
@@ -91,11 +91,12 @@ For the public product path:
 
 ### Package/install rule
 
-The public install identity is `agenc`.
+The public install identity is the scoped npm package `@tetsuo-ai/agenc`,
+which installs the `agenc` CLI.
 
-`agenc` is a public wrapper/launcher package around the runtime surface. It is
-not a hand-waved public rename of the current private/transitional runtime
-package.
+`@tetsuo-ai/agenc` is a public wrapper/launcher package around the runtime
+surface. It is not a hand-waved public rename of the current
+private/transitional runtime package.
 
 `@tetsuo-ai/runtime` may remain transitional/internal while the installable
 public product surface is stabilized.
@@ -151,8 +152,8 @@ enforcement, not proof that ADR-003 is invalid.
 ### Tradeoffs
 
 - the old private-kernel posture must be unwound carefully rather than ignored
-- package/install strategy must be explicit because public `agenc` cannot simply
-  depend on a private runtime package
+- package/install strategy must be explicit because public `@tetsuo-ai/agenc`
+  cannot simply depend on a private runtime package
 - declassification is now a real tracked implementation phase, not a future
   hand-wave
 - source visibility is no longer the primary moat assumption
@@ -165,7 +166,7 @@ Required implementation gates:
 
 1. Phase 0: product contract + command/config/package strategy lock
 2. Phase 1: command/config convergence and compatibility handling
-3. Phase 2: public `agenc` install path
+3. Phase 2: public `@tetsuo-ai/agenc` install path
 4. Phase 3: daemon-backed web dashboard via `agenc ui`
 5. Later: task/bid contract, marketplace UX, connector expansion
 6. Final: public-scrub/declassification program for `agenc-core`
@@ -173,7 +174,7 @@ Required implementation gates:
 Tracked implementation issues in `tetsuo-ai/agenc-core`:
 
 - `#4` CLI/config convergence
-- `#5` public `agenc` wrapper and runtime install path
+- `#5` public `@tetsuo-ai/agenc` wrapper and runtime install path
 - `#6` daemon-backed web dashboard and `demo-app` retirement from product path
 - `#7` connector/plugin ABI freeze plus Telegram lifecycle
 - `#8` task/bid daemon contract before marketplace UX

--- a/docs/architecture/guides/public-runtime-release-channel.md
+++ b/docs/architecture/guides/public-runtime-release-channel.md
@@ -4,10 +4,13 @@ This guide defines the public release channel for the `agenc` install path.
 
 ## Core contract
 
-The public install surface is the `agenc` npm package.
+The public install surface is the `@tetsuo-ai/agenc` npm package, which exposes
+the `agenc` CLI binary.
+
+The unscoped `agenc` package name is not part of this public release channel.
 
 ```bash
-npm install -g agenc
+npm install -g @tetsuo-ai/agenc
 ```
 
 That package does **not** publish the raw runtime workspace as a normal npm
@@ -27,7 +30,7 @@ bins from there.
 
 The public runtime artifact channel is:
 
-- npm package: `agenc`
+- npm package: `@tetsuo-ai/agenc`
 - runtime artifact host: GitHub Releases on `tetsuo-ai/agenc-core`
 
 Release flow:
@@ -38,7 +41,7 @@ Release flow:
 3. CI signs the manifest for that artifact.
 4. CI attaches the artifact to the corresponding GitHub Release.
 5. CI embeds the signed manifest, signature, public key, and trust policy into
-   the published `agenc` wrapper package.
+   the published `@tetsuo-ai/agenc` wrapper package.
 
 Phase 2 keeps local smoke/rehearsal on `file://` manifests, but the production
 release contract is GitHub Releases.
@@ -82,7 +85,7 @@ Runtime packaging requirement:
   checkout or build step on the user machine
 - the base runtime artifact must include the first-party Telegram connector
   lifecycle surface so `agenc connector add telegram` does not require a second
-  package install after `npm install -g agenc`
+  package install after `npm install -g @tetsuo-ai/agenc`
 
 Release-gate requirement:
 
@@ -103,7 +106,7 @@ The trust model is:
 
 Key rotation model:
 
-- production key rotation is delivered by publishing a new `agenc` wrapper
+- production key rotation is delivered by publishing a new `@tetsuo-ai/agenc` wrapper
   version with a new embedded public key and trust policy
 - local development can override trust assets explicitly through development
   environment variables
@@ -135,4 +138,4 @@ with:
 - `AGENC_RUNTIME_TRUST_POLICY_FILE`
 
 These are development-only escape hatches. Production installs should rely on
-the embedded release assets shipped in the `agenc` package.
+the embedded release assets shipped in the `@tetsuo-ai/agenc` package.

--- a/docs/architecture/guides/runtime-install-matrix.md
+++ b/docs/architecture/guides/runtime-install-matrix.md
@@ -30,14 +30,14 @@ Current package engine floor from
 Current support statement:
 
 - Node `18+` is the minimum supported runtime floor for local CLI/daemon use
-- the public `agenc` install path is currently validated in CI on:
+- the public `@tetsuo-ai/agenc` install path is currently validated in CI on:
   - Node `18` as the supported minimum floor
   - Node `20` as the current mainline release gate
 
 ## Public wrapper install support
 
-The public `agenc` wrapper install path currently supports exactly one validated
-tuple:
+The public `@tetsuo-ai/agenc` wrapper install path currently supports exactly
+one validated tuple:
 
 - Linux `x64`
 - Node `>=18.0.0`
@@ -56,8 +56,8 @@ added.
 
 ### Linux
 
-Status: supported for local CLI/daemon operation and for the public `agenc`
-wrapper install path on `x64`.
+Status: supported for local CLI/daemon operation and for the public
+`@tetsuo-ai/agenc` wrapper install path on `x64`.
 
 Evidence in the current repo:
 
@@ -67,8 +67,8 @@ Evidence in the current repo:
 
 ### macOS
 
-Status: source/runtime development is plausible, but the public `agenc` wrapper
-install path is **not yet** claimed as supported.
+Status: source/runtime development is plausible, but the public
+`@tetsuo-ai/agenc` wrapper install path is **not yet** claimed as supported.
 
 Evidence in the current repo:
 
@@ -148,7 +148,8 @@ Current behavior:
 
 ## Product-install implication
 
-This matrix is the baseline for the public `agenc` install path:
+This matrix is the baseline for the public `@tetsuo-ai/agenc` install path and
+the `agenc` CLI it installs:
 
 - one daemon/gateway authority
 - CLI + TUI + dashboard all attach to that same daemon
@@ -166,7 +167,7 @@ This matrix is the baseline for the public `agenc` install path:
 
 The production public wrapper contract is:
 
-- npm package: `agenc`
+- npm package: `@tetsuo-ai/agenc`
 - runtime artifact host: GitHub Releases on `tetsuo-ai/agenc-core`
 - trust: embedded signed manifest + embedded public key + embedded trust policy
 

--- a/docs/architecture/product-contract.md
+++ b/docs/architecture/product-contract.md
@@ -68,12 +68,16 @@ The web dashboard is a daemon client, not a separate runtime.
 
 ## Public install surface
 
-The public user-facing install identity is `agenc`.
+The public user-facing install identity is the scoped npm package
+`@tetsuo-ai/agenc`, which installs the `agenc` CLI command.
+
+The unscoped `agenc` package name is not part of the supported public install
+contract.
 
 V1 install flow:
 
 ```bash
-npm install -g agenc
+npm install -g @tetsuo-ai/agenc
 agenc onboard
 agenc
 agenc ui
@@ -95,7 +99,7 @@ minimum floor and Node `20` as the mainline lane.
 
 ## Public package composition
 
-The public `agenc` package is a wrapper/launcher package.
+The public `@tetsuo-ai/agenc` package is a wrapper/launcher package.
 
 It does not depend on a private runtime package as a normal npm dependency.
 
@@ -105,7 +109,7 @@ V1 public package composition:
   existing runtime bins
 - signed public runtime artifacts are published on GitHub Releases for
   `tetsuo-ai/agenc-core`
-- the public `agenc` wrapper installs/updates/launches those runtime artifacts
+- the public `@tetsuo-ai/agenc` wrapper installs/updates/launches those runtime artifacts
 - no end-user install path requires private-registry credentials
 
 See [guides/public-runtime-release-channel.md](guides/public-runtime-release-channel.md)
@@ -151,7 +155,7 @@ incompatible lifecycle model.
 
 V1 means:
 
-- install `agenc`
+- install `@tetsuo-ai/agenc`
 - onboard
 - start/stop/status/logs
 - TUI attach

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "prepare:public-agenc-package": "node scripts/prepare-public-agenc-package.mjs",
     "smoke:public-agenc-install": "node scripts/public-agenc-install-smoke.mjs",
     "test:private-registry-scripts": "node --test scripts/private-registry-service.test.mjs scripts/bootstrap-private-registry-user.test.mjs scripts/private-kernel-distribution.test.mjs scripts/private-registry-rehearsal.test.mjs",
-    "test": "npm run test --workspace=agenc && npm run test --workspace=@tetsuo-ai/runtime && npm run test --workspace=@tetsuo-ai/mcp && npm run test --workspace=@tetsuo-ai/proof-harness-tools && npm run test --workspace=@tetsuo-ai/desktop-server",
+    "test": "npm run test --workspace=packages/agenc && npm run test --workspace=@tetsuo-ai/runtime && npm run test --workspace=@tetsuo-ai/mcp && npm run test --workspace=@tetsuo-ai/proof-harness-tools && npm run test --workspace=@tetsuo-ai/desktop-server",
     "test:cross-repo-integration": "npm run test:cross-repo-integration --workspace=@tetsuo-ai/runtime",
     "typecheck": "npm run typecheck --workspace=@tetsuo-ai/runtime && npm run typecheck --workspace=@tetsuo-ai/mcp && npm run typecheck --workspace=@tetsuo-ai/docs-mcp && npm run typecheck --workspace=@tetsuo-ai/proof-harness-tools",
     "build:product-surfaces": "npm run build --workspace=@tetsuo-ai/web && npm run build --workspace=agenc-demo",

--- a/packages/agenc/README.md
+++ b/packages/agenc/README.md
@@ -5,7 +5,7 @@ Public CLI and launcher for the AgenC framework.
 This package owns the user-facing global install surface:
 
 ```bash
-npm install -g agenc
+npm install -g @tetsuo-ai/agenc
 agenc onboard
 agenc start
 agenc
@@ -15,6 +15,9 @@ agenc ui
 It does not expose the runtime source tree directly. Instead, it installs and
 launches the matching AgenC runtime artifact for the current supported
 platform.
+
+The supported npm install identity is `@tetsuo-ai/agenc`. The unscoped
+`agenc` package name is not part of the supported public release contract.
 
 Current public support is intentionally narrow:
 
@@ -28,12 +31,13 @@ Current validated release-gate lanes:
 
 Production release channel:
 
-- npm package: `agenc`
+- npm package: `@tetsuo-ai/agenc`
 - runtime artifact host: GitHub Releases on `tetsuo-ai/agenc-core`
 - trust: embedded signed manifest + embedded public key + embedded trust policy
 
 After the matching runtime artifact is installed, `agenc` can continue to run
-offline against the local install.
+offline against the local install. The npm package name is scoped, but the CLI
+binary remains `agenc`.
 
 `agenc` exposes two primary local operator surfaces against the same daemon:
 

--- a/packages/agenc/package.json
+++ b/packages/agenc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agenc",
+  "name": "@tetsuo-ai/agenc",
   "version": "0.1.0",
   "description": "Public CLI and launcher for the AgenC framework",
   "type": "module",

--- a/packages/agenc/tests/runtime-manager.test.mjs
+++ b/packages/agenc/tests/runtime-manager.test.mjs
@@ -30,7 +30,7 @@ async function createFixtureContext(t) {
 
   await writeFile(
     path.join(packageRoot, "package.json"),
-    JSON.stringify({ name: "agenc", version: "0.1.0" }, null, 2),
+    JSON.stringify({ name: "@tetsuo-ai/agenc", version: "0.1.0" }, null, 2),
     "utf8",
   );
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -3,13 +3,14 @@
 Implementation runtime package for AgenC.
 
 `@tetsuo-ai/runtime` is the current operator/runtime implementation baseline in
-`agenc-core`. It powers the public `agenc` install surface, but it is not
+`agenc-core`. It powers the public `@tetsuo-ai/agenc` install surface and the
+`agenc` CLI, but it is not
 itself the supported end-user install identity and it is not a supported public
 builder target.
 
 The public operator install contract is:
 
-- npm package: `agenc`
+- npm package: `@tetsuo-ai/agenc`
 - runtime artifact channel: GitHub Releases on `tetsuo-ai/agenc-core`
 - canonical local state: `~/.agenc/`
 

--- a/scripts/public-agenc-install-smoke.mjs
+++ b/scripts/public-agenc-install-smoke.mjs
@@ -43,6 +43,12 @@ function runJson(command, args, cwd, env = process.env) {
   return JSON.parse(run(command, args, cwd, env));
 }
 
+function readPackedWrapperPackageJson(tarballPath, cwd) {
+  return JSON.parse(
+    run("tar", ["-xOf", tarballPath, "package/package.json"], cwd),
+  );
+}
+
 function bumpPatchVersion(version) {
   const match = /^v?(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$/u.exec(version);
   if (!match?.groups) {
@@ -119,6 +125,15 @@ async function packPreparedWrapper(repoRootPath, artifactDir, tempRoot, label) {
     throw new Error("npm pack did not return a tarball filename for agenc");
   }
   const originalTarballPath = path.join(wrapperDir, packed.filename);
+  const packedPackageJson = readPackedWrapperPackageJson(
+    originalTarballPath,
+    repoRootPath,
+  );
+  assert.equal(
+    packedPackageJson.name,
+    "@tetsuo-ai/agenc",
+    "packed wrapper package.json must publish the scoped npm identity",
+  );
   const tarballPath = path.join(tempRoot, `${label}-${packed.filename}`);
   await copyFile(originalTarballPath, tarballPath);
   await unlink(originalTarballPath);


### PR DESCRIPTION
## Summary
- rename the public wrapper package to  while keeping the  CLI binary
- reconcile install/release docs around the scoped package identity
- harden the public install smoke to verify the packed tarball metadata

## Testing
- npm run test --workspace=packages/agenc
- npm run smoke:public-agenc-install -- --skip-build
- git diff --check