### PR TITLE
feat(onboarding): add interactive first-run wizard

### DIFF
--- a/docs/architecture/product-contract.md
+++ b/docs/architecture/product-contract.md
@@ -87,6 +87,11 @@ agenc ui
 second runtime; it is a loopback dashboard surface mounted at `/ui/` on the
 daemon HTTP port.
 
+`agenc onboard` is the canonical first-run experience. In V1 it is an
+interactive terminal onboarding flow that validates xAI access, collects the
+core agent identity/soul posture, writes `~/.agenc/config.json`, and generates
+the curated workspace markdown profile under `~/.agenc/workspace/`.
+
 Phase 2 public wrapper support is intentionally narrow:
 
 - platform: `linux`

--- a/packages/agenc/README.md
+++ b/packages/agenc/README.md
@@ -12,6 +12,14 @@ agenc
 agenc ui
 ```
 
+`agenc onboard` is the canonical first-run path. It opens an interactive
+terminal onboarding flow that:
+
+- validates an xAI API key
+- lets the operator shape the agent name, mission, role, soul, and tool posture
+- writes the canonical config at `~/.agenc/config.json`
+- generates the curated workspace markdown profile under `~/.agenc/workspace/`
+
 It does not expose the runtime source tree directly. Instead, it installs and
 launches the matching AgenC runtime artifact for the current supported
 platform.

--- a/runtime/src/cli/health.test.ts
+++ b/runtime/src/cli/health.test.ts
@@ -164,6 +164,54 @@ describe("health cli commands", () => {
     expect(ids.has("store.integrity")).toBe(true);
   });
 
+  it("health prefers the configured keypair path over a missing environment override", async () => {
+    vi.spyOn(Connection.prototype, "getSlot").mockResolvedValue(123);
+    const configuredKeypairPath = join(workspace, "configured-id.json");
+    writeFileSync(configuredKeypairPath, "[]", "utf8");
+    writeConfig(configPath, {
+      gateway: { port: 3100 },
+      agent: { name: "health-agent" },
+      connection: {
+        rpcUrl: "http://rpc.example",
+        keypairPath: configuredKeypairPath,
+      },
+      replay: { store: { type: "memory" } },
+      cli: {
+        outputFormat: "json",
+        strictMode: false,
+        idempotencyWindow: 900,
+      },
+    });
+    process.env.SOLANA_KEYPAIR_PATH = join(workspace, "missing-id.json");
+
+    const { context, outputs } = createContextCapture();
+    const options: HealthOptions = {
+      help: false,
+      outputFormat: "json",
+      strictMode: false,
+      rpcUrl: "http://rpc.example",
+      programId: undefined,
+      storeType: "memory",
+      sqlitePath: undefined,
+      traceId: undefined,
+      idempotencyWindow: 900,
+      configPath,
+      configPathSource: "explicit",
+      nonInteractive: true,
+      deep: false,
+    };
+
+    const code = await runHealthCommand(context, options);
+    expect(code).toBe(0);
+
+    const payload = outputs[0] as any;
+    const wallet = payload.report.checks.find(
+      (c: any) => c.id === "wallet.exists",
+    );
+    expect(wallet.status).toBe("pass");
+    expect(wallet.message).toContain(configuredKeypairPath);
+  });
+
   it("doctor: warnings only returns exit code 1", async () => {
     vi.spyOn(Connection.prototype, "getSlot").mockResolvedValue(123);
     process.env.SOLANA_KEYPAIR_PATH = join(workspace, "missing-id.json");

--- a/runtime/src/cli/health.ts
+++ b/runtime/src/cli/health.ts
@@ -237,6 +237,7 @@ async function checkStoreIntegrity(
 
 export async function checkWalletAvailability(
   checks: HealthCheckResult[],
+  configuredKeyPath?: string,
 ): Promise<boolean> {
   const defaultKeyPath = path.join(
     os.homedir(),
@@ -246,7 +247,9 @@ export async function checkWalletAvailability(
   );
   const envKeyPath = process.env.SOLANA_KEYPAIR_PATH;
   const keyPath =
-    typeof envKeyPath === "string" && envKeyPath.length > 0
+    typeof configuredKeyPath === "string" && configuredKeyPath.trim().length > 0
+      ? configuredKeyPath.trim()
+      : typeof envKeyPath === "string" && envKeyPath.length > 0
       ? envKeyPath
       : defaultKeyPath;
 
@@ -361,6 +364,26 @@ export function checkConfigValidity(
   }
 }
 
+function resolveConfiguredWalletPath(options: {
+  configPath?: string;
+  configPathSource?: HealthOptions["configPathSource"];
+}): string | undefined {
+  const resolvedPath = path.resolve(
+    options.configPath ?? getCanonicalDefaultConfigPath(),
+  );
+  if (!existsSync(resolvedPath)) {
+    return undefined;
+  }
+
+  try {
+    return loadCliConfigContract(resolvedPath, {
+      configPathSource: options.configPathSource ?? "canonical",
+    }).gatewayConfig?.connection?.keypairPath;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function runAllHealthChecks(
   options: Pick<
     HealthOptions,
@@ -379,7 +402,10 @@ export async function runAllHealthChecks(
     { storeType: options.storeType, sqlitePath: options.sqlitePath },
     checks,
   );
-  await checkWalletAvailability(checks);
+  await checkWalletAvailability(
+    checks,
+    resolveConfiguredWalletPath(options),
+  );
   checkProgramAvailability(options.programId, checks);
   checkConfigValidity(options.configPath, checks, options.configPathSource);
 

--- a/runtime/src/cli/index.test.ts
+++ b/runtime/src/cli/index.test.ts
@@ -1,9 +1,28 @@
 import { Writable } from "node:stream";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { runInitCommand } = vi.hoisted(() => ({
   runInitCommand: vi.fn(async () => 0),
 }));
+const { runOnboardCommand } = vi.hoisted(() => ({
+  runOnboardCommand: vi.fn(async () => 0),
+}));
+const { runInteractiveOnboarding, shouldUseInteractiveOnboarding } =
+  vi.hoisted(() => ({
+    runInteractiveOnboarding: vi.fn(async () => 0),
+    shouldUseInteractiveOnboarding: vi.fn(
+      (
+        flags: Record<string, string | number | boolean>,
+        deps: { stdin?: { isTTY?: boolean }; stdout?: { isTTY?: boolean } },
+      ) =>
+        deps.stdin?.isTTY === true &&
+        deps.stdout?.isTTY === true &&
+        flags["non-interactive"] !== true &&
+        flags.output !== "json" &&
+        flags["output-format"] !== "json" &&
+        flags["output-format"] !== "jsonl",
+    ),
+  }));
 const {
   runConnectorListCommand,
   runConnectorStatusCommand,
@@ -20,6 +39,15 @@ vi.mock("./init.js", () => ({
   runInitCommand,
 }));
 
+vi.mock("./onboard.js", () => ({
+  runOnboardCommand,
+}));
+
+vi.mock("../onboarding/tui.js", () => ({
+  runInteractiveOnboarding,
+  shouldUseInteractiveOnboarding,
+}));
+
 vi.mock("./connectors.js", () => ({
   runConnectorListCommand,
   runConnectorStatusCommand,
@@ -28,6 +56,8 @@ vi.mock("./connectors.js", () => ({
 }));
 
 import { runCli } from "./index.js";
+
+const stdinTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
 
 function captureStream(): { stream: Writable; data: () => string } {
   let data = "";
@@ -43,7 +73,23 @@ function captureStream(): { stream: Writable; data: () => string } {
   };
 }
 
+function setStdinTTY(value: boolean): void {
+  Object.defineProperty(process.stdin, "isTTY", {
+    configurable: true,
+    value,
+  });
+}
+
 describe("runtime root CLI", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    if (stdinTtyDescriptor) {
+      Object.defineProperty(process.stdin, "isTTY", stdinTtyDescriptor);
+      return;
+    }
+    delete (process.stdin as { isTTY?: boolean }).isTTY;
+  });
+
   it("includes init in root help output", async () => {
     const stdout = captureStream();
     const stderr = captureStream();
@@ -136,5 +182,58 @@ describe("runtime root CLI", () => {
         allowedUsers: [123, 456],
       }),
     );
+  });
+
+  it("routes onboard through the interactive TUI for tty sessions", async () => {
+    setStdinTTY(true);
+    const stdout = captureStream();
+    const stderr = captureStream();
+    (stdout.stream as Writable & { isTTY?: boolean }).isTTY = true;
+
+    const code = await runCli({
+      argv: ["onboard", "--config", "/tmp/agenc-config.json"],
+      stdout: stdout.stream,
+      stderr: stderr.stream,
+    });
+
+    expect(code).toBe(0);
+    expect(runInteractiveOnboarding).toHaveBeenCalledWith(
+      expect.objectContaining({
+        configPath: "/tmp/agenc-config.json",
+      }),
+      expect.objectContaining({
+        stdin: process.stdin,
+        stdout: stdout.stream,
+      }),
+    );
+    expect(runOnboardCommand).not.toHaveBeenCalled();
+  });
+
+  it("keeps onboard on the structured path for json output", async () => {
+    setStdinTTY(true);
+    const stdout = captureStream();
+    const stderr = captureStream();
+    (stdout.stream as Writable & { isTTY?: boolean }).isTTY = true;
+
+    const code = await runCli({
+      argv: [
+        "onboard",
+        "--config",
+        "/tmp/agenc-config.json",
+        "--output",
+        "json",
+      ],
+      stdout: stdout.stream,
+      stderr: stderr.stream,
+    });
+
+    expect(code).toBe(0);
+    expect(runOnboardCommand).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        configPath: "/tmp/agenc-config.json",
+      }),
+    );
+    expect(runInteractiveOnboarding).not.toHaveBeenCalled();
   });
 });

--- a/runtime/src/cli/index.ts
+++ b/runtime/src/cli/index.ts
@@ -61,6 +61,10 @@ import {
   runImportOpenclawCommand,
 } from "./registry-cli.js";
 import { runOnboardCommand } from "./onboard.js";
+import {
+  runInteractiveOnboarding,
+  shouldUseInteractiveOnboarding,
+} from "../onboarding/tui.js";
 import { runDoctorCommand, runHealthCommand } from "./health.js";
 import {
   runStartCommand,
@@ -2113,6 +2117,7 @@ function resolveLenientGlobalFlags(parsed: ParsedArgv): {
 async function dispatchBootstrapCommands(
   parsed: ParsedArgv,
   context: CliRuntimeContext,
+  stdout: NodeJS.WritableStream = process.stdout,
 ): Promise<RoutedStatus> {
   if (parsed.positional[0] === "onboard") {
     try {
@@ -2143,6 +2148,18 @@ async function dispatchBootstrapCommands(
         nonInteractive: normalizeBool(parsed.flags["non-interactive"], false),
         force: normalizeBool(parsed.flags.force, false),
       };
+
+      if (
+        shouldUseInteractiveOnboarding(parsed.flags, {
+          stdin: process.stdin,
+          stdout,
+        })
+      ) {
+        return await runInteractiveOnboarding(onboardOpts, {
+          stdin: process.stdin,
+          stdout,
+        });
+      }
 
       return await runOnboardCommand(context, onboardOpts);
     } catch (error) {
@@ -2890,7 +2907,7 @@ export async function runCli(
   }
 
   const routed =
-    (await dispatchBootstrapCommands(parsed, context)) ??
+    (await dispatchBootstrapCommands(parsed, context, stdout)) ??
     (await dispatchDaemonCommands(parsed, context)) ??
     (await dispatchConfigCommands(parsed, context)) ??
     (await dispatchConnectorCommands(parsed, context)) ??

--- a/runtime/src/cli/onboard.test.ts
+++ b/runtime/src/cli/onboard.test.ts
@@ -9,9 +9,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Connection } from "@solana/web3.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildOnboardingProfile } from "../onboarding/profile.js";
 import * as gatewayDaemon from "../gateway/daemon.js";
 import type { OnboardOptions } from "./types.js";
-import { runOnboardCommand } from "./onboard.js";
+import { executeOnboardCommand, runOnboardCommand } from "./onboard.js";
 import { createContextCapture } from "./test-utils.js";
 
 describe("onboard cli command", () => {
@@ -273,5 +274,77 @@ describe("onboard cli command", () => {
 
     const written = JSON.parse(readFileSync(configPath, "utf8")) as any;
     expect(written.connection.rpcUrl).toBe("http://old.example");
+  });
+
+  it("writes curated workspace files and uses the configured wallet path for health", async () => {
+    vi.spyOn(Connection.prototype, "getSlot").mockResolvedValue(123);
+    const workspacePath = join(workspace, "agent-workspace");
+    const configuredWalletPath = join(workspace, "configured-id.json");
+    writeFileSync(configuredWalletPath, "[]", "utf8");
+    process.env.SOLANA_KEYPAIR_PATH = join(workspace, "missing-wallet.json");
+
+    const profile = buildOnboardingProfile({
+      apiKey: "xai-test-key",
+      model: "grok-4-1-fast-reasoning",
+      agentName: "Operator",
+      mission: "Run a clean first-run profile.",
+      role: "Operator",
+      alwaysDoRules: ["Keep outputs factual."],
+      soulTraits: ["direct", "disciplined"],
+      tone: "Direct and calm",
+      verbosity: "balanced",
+      autonomy: "balanced",
+      toolPosture: "balanced",
+      memorySeeds: ["This is a local operator workspace."],
+      desktopAutomationEnabled: false,
+      walletPath: configuredWalletPath,
+      rpcUrl: "http://rpc.example",
+      marketplaceEnabled: true,
+      socialEnabled: false,
+    });
+    const finalConfig = structuredClone(profile.config);
+    finalConfig.workspace = {
+      ...(finalConfig.workspace ?? {}),
+      hostPath: workspacePath,
+    };
+
+    const options: OnboardOptions = {
+      help: false,
+      outputFormat: "json",
+      strictMode: false,
+      rpcUrl: "http://rpc.example",
+      programId: undefined,
+      storeType: "sqlite",
+      sqlitePath: undefined,
+      traceId: undefined,
+      idempotencyWindow: 900,
+      configPath,
+      configPathSource: "explicit",
+      nonInteractive: true,
+      force: false,
+    };
+
+    const result = await executeOnboardCommand(options, {
+      finalConfig,
+      workspace: {
+        workspacePath,
+        files: profile.workspaceFiles,
+      },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.walletDetected).toBe(true);
+    expect(result.workspacePath).toBe(workspacePath);
+    expect(result.workspaceFilesCreated).toContain("AGENT.md");
+    expect(readFileSync(join(workspacePath, "SOUL.md"), "utf8")).toContain(
+      "# Soul",
+    );
+    expect(
+      JSON.parse(readFileSync(configPath, "utf8")) as {
+        workspace?: { hostPath?: string };
+      },
+    ).toMatchObject({
+      workspace: { hostPath: workspacePath },
+    });
   });
 });

--- a/runtime/src/cli/onboard.ts
+++ b/runtime/src/cli/onboard.ts
@@ -18,12 +18,15 @@ import {
   type LoadedCliConfigContract,
 } from "./config-contract.js";
 import { findDaemonProcessesByIdentity } from "./daemon.js";
+import { getDefaultWorkspacePath } from "../gateway/workspace-files.js";
 import type {
   CliFileConfig,
   CliRuntimeContext,
   OnboardOptions,
 } from "./types.js";
 import { validateGatewayConfig } from "../gateway/config-watcher.js";
+import type { GatewayConfig } from "../gateway/types.js";
+import { writeOnboardingWorkspaceFiles } from "../onboarding/workspace.js";
 import {
   type HealthCheckResult,
   checkConfigValidity,
@@ -38,10 +41,28 @@ export interface OnboardResult {
   configGenerated: boolean;
   backupPath?: string;
   importedLegacyConfigPath?: string | null;
+  workspacePath?: string;
+  workspaceFilesCreated?: string[];
+  workspaceFilesOverwritten?: string[];
+  workspaceFilesPreserved?: string[];
+  workspaceBackupPaths?: string[];
   walletDetected: boolean;
   rpcReachable: boolean;
   checks: HealthCheckResult[];
   exitCode: 0 | 1 | 2;
+}
+
+export interface PreparedOnboardWorkspace {
+  readonly workspacePath?: string;
+  readonly files: Record<string, string>;
+  readonly overwrite?: boolean;
+  readonly backupExisting?: boolean;
+}
+
+export interface PreparedOnboardRun {
+  readonly finalConfig: GatewayConfig;
+  readonly importedLegacyConfigPath?: string | null;
+  readonly workspace?: PreparedOnboardWorkspace;
 }
 
 function computeExitCode(checks: HealthCheckResult[]): 0 | 1 | 2 {
@@ -163,6 +184,19 @@ export async function runOnboardCommand(
   context: CliRuntimeContext,
   options: OnboardOptions,
 ): Promise<0 | 1 | 2> {
+  const result = await executeOnboardCommand(options);
+  context.output({
+    status: "ok",
+    command: "onboard",
+    result,
+  });
+  return result.exitCode;
+}
+
+export async function executeOnboardCommand(
+  options: OnboardOptions,
+  prepared?: PreparedOnboardRun,
+): Promise<OnboardResult> {
   const checks: HealthCheckResult[] = [];
 
   const configPath = path.resolve(
@@ -191,9 +225,11 @@ export async function runOnboardCommand(
   }
 
   const managedConfig = buildOnboardManagedConfig(options);
-  let importedLegacyConfigPath: string | null = null;
+  let importedLegacyConfigPath: string | null =
+    prepared?.importedLegacyConfigPath ?? null;
   let importedFileConfig: CliFileConfig = {};
   if (
+    !prepared &&
     options.legacyImportConfigPath &&
     path.resolve(options.legacyImportConfigPath) !== configPath
   ) {
@@ -225,10 +261,12 @@ export async function runOnboardCommand(
     baseConfig,
     buildManagedGatewayPatch(importedFileConfig),
   );
-  const finalConfig = applyManagedGatewayPatch(
-    importedConfig,
-    buildManagedGatewayPatch(managedConfig),
-  );
+  const finalConfig = prepared?.finalConfig
+    ? structuredClone(prepared.finalConfig)
+    : applyManagedGatewayPatch(
+        importedConfig,
+        buildManagedGatewayPatch(managedConfig),
+      );
   const validation = validateGatewayConfig(finalConfig);
   if (!validation.valid) {
     checks.push({
@@ -287,6 +325,11 @@ export async function runOnboardCommand(
     }
   }
 
+  let workspacePath: string | undefined;
+  let workspaceFilesCreated: string[] | undefined;
+  let workspaceFilesOverwritten: string[] | undefined;
+  let workspaceFilesPreserved: string[] | undefined;
+  let workspaceBackupPaths: string[] | undefined;
   const effectiveFileConfig = configGenerated
     ? loadCliConfigContract(configPath, {
         configPathSource: options.configPathSource ?? "canonical",
@@ -295,7 +338,64 @@ export async function runOnboardCommand(
       ? mergeCliFileConfig(importedFileConfig, managedConfig)
       : existingContract.fileConfig;
 
-  const walletDetected = await checkWalletAvailability(checks);
+  if (configGenerated && prepared?.workspace) {
+    workspacePath = path.resolve(
+      prepared.workspace.workspacePath ?? getDefaultWorkspacePath(),
+    );
+    try {
+      const writeResult = await writeOnboardingWorkspaceFiles(
+        workspacePath,
+        prepared.workspace.files,
+        {
+          overwrite: prepared.workspace.overwrite ?? false,
+          backupExisting: prepared.workspace.backupExisting ?? false,
+        },
+      );
+      workspaceFilesCreated = [...writeResult.created];
+      workspaceFilesOverwritten = [...writeResult.overwritten];
+      workspaceFilesPreserved = [...writeResult.preserved];
+      workspaceBackupPaths = [...writeResult.backupPaths];
+
+      checks.push({
+        id: "workspace.generated",
+        category: "config",
+        status: "pass",
+        message:
+          `Workspace updated at ${workspacePath}` +
+          ` (created ${writeResult.created.length}, overwritten ${writeResult.overwritten.length}, preserved ${writeResult.preserved.length})`,
+      });
+
+      if (writeResult.backupPaths.length > 0) {
+        checks.push({
+          id: "workspace.backup",
+          category: "config",
+          status: "pass",
+          message: `Backed up ${writeResult.backupPaths.length} workspace file(s) before overwrite`,
+        });
+      }
+    } catch (error) {
+      checks.push({
+        id: "workspace.generated",
+        category: "config",
+        status: "fail",
+        message: `Failed to write workspace files to ${workspacePath}: ${error instanceof Error ? error.message : String(error)}`,
+        remediation: "Check filesystem permissions or rerun onboarding with a writable workspace path",
+      });
+    }
+  }
+
+  const effectiveGatewayConfig = configGenerated
+    ? (loadCliConfigContract(configPath, {
+        configPathSource: options.configPathSource ?? "canonical",
+      }).gatewayConfig ?? finalConfig)
+    : existingContract.shape === "canonical-gateway" && existingContract.gatewayConfig
+      ? existingContract.gatewayConfig
+      : finalConfig;
+
+  const walletDetected = await checkWalletAvailability(
+    checks,
+    effectiveGatewayConfig.connection.keypairPath,
+  );
   const rpcUrl = effectiveFileConfig.rpcUrl;
   const rpcReachable = await checkRpcReachability(rpcUrl, checks);
 
@@ -312,17 +412,16 @@ export async function runOnboardCommand(
     configGenerated,
     ...(backupPath ? { backupPath } : {}),
     importedLegacyConfigPath,
+    ...(workspacePath ? { workspacePath } : {}),
+    ...(workspaceFilesCreated ? { workspaceFilesCreated } : {}),
+    ...(workspaceFilesOverwritten ? { workspaceFilesOverwritten } : {}),
+    ...(workspaceFilesPreserved ? { workspaceFilesPreserved } : {}),
+    ...(workspaceBackupPaths ? { workspaceBackupPaths } : {}),
     walletDetected,
     rpcReachable,
     checks,
     exitCode,
   };
 
-  context.output({
-    status: "ok",
-    command: "onboard",
-    result,
-  });
-
-  return exitCode;
+  return result;
 }

--- a/runtime/src/onboarding/profile.test.ts
+++ b/runtime/src/onboarding/profile.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { getDefaultWorkspacePath, WORKSPACE_FILES } from "../gateway/workspace-files.js";
+import type { GatewayConfig } from "../gateway/types.js";
+import { buildOnboardingProfile, createDefaultOnboardingAnswers } from "./profile.js";
+import type { OnboardingAnswers } from "./types.js";
+
+function makeAnswers(
+  overrides: Partial<OnboardingAnswers> = {},
+): OnboardingAnswers {
+  return {
+    apiKey: "xai-test-key",
+    model: "grok-4-1-fast-reasoning",
+    agentName: "AgenC",
+    mission: "Help me execute real work.",
+    role: "General-purpose operator",
+    alwaysDoRules: ["Prefer action over narration."],
+    soulTraits: ["direct", "strategic"],
+    tone: "Direct and calm",
+    verbosity: "balanced",
+    autonomy: "balanced",
+    toolPosture: "balanced",
+    memorySeeds: ["The workspace is operator-owned."],
+    desktopAutomationEnabled: true,
+    walletPath: "/tmp/id.json",
+    rpcUrl: "http://rpc.example",
+    marketplaceEnabled: true,
+    socialEnabled: false,
+    ...overrides,
+  };
+}
+
+describe("onboarding profile", () => {
+  it("hydrates onboarding defaults from an existing gateway config", () => {
+    const existingConfig: GatewayConfig = {
+      gateway: { port: 3100 },
+      agent: { name: "Scout" },
+      connection: {
+        rpcUrl: "http://rpc.example",
+        keypairPath: "/tmp/custom-id.json",
+      },
+      llm: {
+        provider: "grok",
+        apiKey: "xai-existing",
+        model: "grok-3-mini",
+      },
+      desktop: { enabled: true },
+      marketplace: { enabled: false },
+      social: { enabled: true },
+    };
+
+    const defaults = createDefaultOnboardingAnswers(existingConfig);
+
+    expect(defaults.agentName).toBe("Scout");
+    expect(defaults.apiKey).toBe("xai-existing");
+    expect(defaults.model).toBe("grok-3-mini");
+    expect(defaults.walletPath).toBe("/tmp/custom-id.json");
+    expect(defaults.rpcUrl).toBe("http://rpc.example");
+    expect(defaults.desktopAutomationEnabled).toBe(true);
+    expect(defaults.marketplaceEnabled).toBe(false);
+    expect(defaults.socialEnabled).toBe(true);
+  });
+
+  it("builds a canonical config plus curated workspace files", () => {
+    const profile = buildOnboardingProfile(makeAnswers());
+
+    expect(profile.config.llm?.provider).toBe("grok");
+    expect(profile.config.llm?.apiKey).toBe("xai-test-key");
+    expect(profile.config.workspace?.hostPath).toBe(getDefaultWorkspacePath());
+    expect(profile.config.marketplace?.enabled).toBe(true);
+    expect(profile.config.social?.enabled).toBe(false);
+    expect(profile.workspaceFiles[WORKSPACE_FILES.AGENT]).toContain(
+      "## Mission",
+    );
+    expect(profile.workspaceFiles[WORKSPACE_FILES.SOUL]).toContain("# Soul");
+    expect(profile.workspaceFiles[WORKSPACE_FILES.MEMORY]).toContain(
+      "The workspace is operator-owned.",
+    );
+  });
+
+  it("removes blank wallet paths from the generated config", () => {
+    const profile = buildOnboardingProfile(
+      makeAnswers({
+        walletPath: null,
+      }),
+    );
+
+    expect(profile.config.connection.keypairPath).toBeUndefined();
+  });
+});

--- a/runtime/src/onboarding/profile.ts
+++ b/runtime/src/onboarding/profile.ts
@@ -1,0 +1,418 @@
+import { detectSolanaKeypair, generateDefaultConfig } from "../cli/wizard.js";
+import { defaultDesktopSandboxConfig } from "../desktop/types.js";
+import {
+  WORKSPACE_FILES,
+  getDefaultWorkspacePath,
+  type WorkspaceFileName,
+} from "../gateway/workspace-files.js";
+import type { GatewayConfig } from "../gateway/types.js";
+import { DEFAULT_GROK_MODEL } from "../gateway/llm-provider-manager.js";
+import type {
+  GeneratedOnboardingProfile,
+  OnboardingAnswers,
+} from "./types.js";
+
+const DEFAULT_MISSION =
+  "Operate as a capable local agent that can reason clearly, use tools, and help me execute real work without drama.";
+const DEFAULT_ROLE = "General-purpose operator";
+const DEFAULT_TRAITS = ["direct", "disciplined", "strategic"];
+const DEFAULT_RULES = [
+  "Prefer action over narration.",
+  "State uncertainty plainly when facts are unclear.",
+  "Protect user data and ask before destructive changes.",
+];
+const DEFAULT_MEMORY = [
+  "This agent runs inside AgenC and should treat the local workspace as operator-owned.",
+];
+
+function cleanText(value: string | undefined, fallback = ""): string {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
+function cleanList(
+  values: readonly string[] | undefined,
+  fallback: readonly string[],
+): string[] {
+  const normalized = (values ?? [])
+    .map((value) => value.trim())
+    .filter((value, index, array) => value.length > 0 && array.indexOf(value) === index);
+  return normalized.length > 0 ? normalized : [...fallback];
+}
+
+function describeToolPosture(posture: OnboardingAnswers["toolPosture"]): string {
+  switch (posture) {
+    case "guarded":
+      return "Use tools narrowly. Prefer asking before tool-heavy or system-changing actions.";
+    case "broad":
+      return "Use tools aggressively when they materially speed up execution, while still respecting policy.";
+    case "balanced":
+    default:
+      return "Use tools when they unlock execution, but narrate intent clearly before risky moves.";
+  }
+}
+
+function describeAutonomy(posture: OnboardingAnswers["autonomy"]): string {
+  switch (posture) {
+    case "conservative":
+      return "Default to confirmation before risky, expensive, or irreversible actions.";
+    case "aggressive":
+      return "Bias toward self-starting execution and only pause for real risk boundaries.";
+    case "balanced":
+    default:
+      return "Act decisively on low-risk work and escalate when the blast radius is meaningful.";
+  }
+}
+
+function describeVerbosity(verbosity: OnboardingAnswers["verbosity"]): string {
+  switch (verbosity) {
+    case "tight":
+      return "Keep responses compact and high-signal by default.";
+    case "detailed":
+      return "Give fuller reasoning and context when it helps the operator move faster.";
+    case "balanced":
+    default:
+      return "Prefer concise answers, but expand when the task actually needs it.";
+  }
+}
+
+function withBulletList(
+  title: string,
+  values: readonly string[],
+  emptyFallback: string,
+): string {
+  const lines = values.length > 0 ? values.map((value) => `- ${value}`) : [`- ${emptyFallback}`];
+  return [`## ${title}`, ...lines].join("\n");
+}
+
+function buildAgentFile(answers: OnboardingAnswers): string {
+  return [
+    "# Agent Configuration",
+    "",
+    "This file defines the operating identity of the local AgenC agent.",
+    "",
+    "## Name",
+    answers.agentName,
+    "",
+    "## Role",
+    answers.role,
+    "",
+    "## Mission",
+    answers.mission,
+    "",
+    withBulletList("Always-Do Rules", answers.alwaysDoRules, "Move the task forward without unnecessary ceremony."),
+    "",
+  ].join("\n");
+}
+
+function buildAgencFile(answers: OnboardingAnswers): string {
+  return [
+    "# AgenC Workspace Contract",
+    "",
+    "This workspace is the operator-controlled local contract for this agent.",
+    "",
+    "## Operating Assumptions",
+    `- Primary role: ${answers.role}`,
+    `- Marketplace features: ${answers.marketplaceEnabled ? "enabled" : "disabled"}`,
+    `- Social features: ${answers.socialEnabled ? "enabled" : "disabled"}`,
+    `- Desktop automation: ${answers.desktopAutomationEnabled ? "enabled" : "disabled"}`,
+    "",
+    "## General Rules",
+    "- Treat workspace markdown files as durable operator instructions.",
+    "- Keep outputs grounded in actual tool evidence.",
+    "- Do not invent completion, progress, or marketplace outcomes.",
+    "",
+  ].join("\n");
+}
+
+function buildSoulFile(answers: OnboardingAnswers): string {
+  return [
+    "# Soul",
+    "",
+    "This file captures the voice and temperament of the agent.",
+    "",
+    withBulletList("Core Traits", answers.soulTraits, "direct"),
+    "",
+    "## Tone",
+    answers.tone,
+    "",
+    "## Verbosity",
+    describeVerbosity(answers.verbosity),
+    "",
+    "## Autonomy",
+    describeAutonomy(answers.autonomy),
+    "",
+  ].join("\n");
+}
+
+function buildUserFile(answers: OnboardingAnswers): string {
+  return [
+    "# User Preferences",
+    "",
+    "These are the default interaction preferences for this local operator.",
+    "",
+    "## Response Style",
+    `- Tone alignment: ${answers.tone}`,
+    `- Verbosity: ${answers.verbosity}`,
+    "- Prioritize clarity, directness, and execution-ready output.",
+    "",
+  ].join("\n");
+}
+
+function buildToolsFile(answers: OnboardingAnswers): string {
+  return [
+    "# Tool Guidelines",
+    "",
+    "Tool use should be deliberate and operator-aligned.",
+    "",
+    "## Tool Posture",
+    describeToolPosture(answers.toolPosture),
+    "",
+    "## Desktop Automation",
+    answers.desktopAutomationEnabled
+      ? "- Desktop/browser automation is available when it materially helps execution."
+      : "- Do not rely on desktop/browser automation by default.",
+    "",
+    "## Execution Rules",
+    "- Use tools to verify claims instead of guessing.",
+    "- Prefer the smallest useful action before escalating to heavier automation.",
+    "- Summarize the result of tool work in plain language.",
+    "",
+  ].join("\n");
+}
+
+function buildHeartbeatFile(answers: OnboardingAnswers): string {
+  const checks = answers.marketplaceEnabled
+    ? ["- Refresh marketplace/task visibility when the daemon is healthy."]
+    : ["- No autonomous marketplace polling is required by default."];
+  return [
+    "# Heartbeat",
+    "",
+    "Periodic posture for the local agent runtime.",
+    "",
+    ...checks,
+    "- Confirm wallet and RPC health before high-value actions.",
+    "- Keep local state tidy and avoid noisy loops.",
+    "",
+  ].join("\n");
+}
+
+function buildBootFile(answers: OnboardingAnswers): string {
+  return [
+    "# Boot",
+    "",
+    "Startup checklist executed when the agent comes online.",
+    "",
+    "- Load the canonical AgenC config and workspace files.",
+    "- Verify xAI access, wallet path, and RPC connectivity.",
+    `- Assume the agent is operating as: ${answers.role}.`,
+    answers.marketplaceEnabled
+      ? "- Enable marketplace-aware posture after core health checks pass."
+      : "- Keep marketplace-specific behavior disabled unless explicitly enabled later.",
+    "",
+  ].join("\n");
+}
+
+function buildIdentityFile(answers: OnboardingAnswers): string {
+  return [
+    "# Identity",
+    "",
+    "Durable identity hints for the local agent.",
+    "",
+    "## Primary",
+    `- Agent name: ${answers.agentName}`,
+    `- Role: ${answers.role}`,
+    `- Wallet path: ${answers.walletPath ?? "not configured yet"}`,
+    "",
+  ].join("\n");
+}
+
+function buildMemoryFile(answers: OnboardingAnswers): string {
+  return [
+    "# Memory",
+    "",
+    "Stable facts the agent should keep in mind across sessions.",
+    "",
+    ...cleanList(answers.memorySeeds, DEFAULT_MEMORY).map((value) => `- ${value}`),
+    "",
+  ].join("\n");
+}
+
+function buildCapabilitiesFile(answers: OnboardingAnswers): string {
+  return [
+    "# Capabilities",
+    "",
+    "High-level behavioral capability map for this local agent.",
+    "",
+    `- Core operating mode: ${answers.role}`,
+    "- Tool execution and verification",
+    answers.marketplaceEnabled
+      ? "- Marketplace discovery and task participation"
+      : "- Marketplace flows disabled until explicitly enabled",
+    answers.desktopAutomationEnabled
+      ? "- Local desktop/browser automation"
+      : "- No desktop/browser automation by default",
+    "",
+  ].join("\n");
+}
+
+function buildPolicyFile(answers: OnboardingAnswers): string {
+  return [
+    "# Policy",
+    "",
+    "Operator-facing safety and execution boundaries.",
+    "",
+    "## Autonomy",
+    describeAutonomy(answers.autonomy),
+    "",
+    "## Non-Negotiables",
+    "- Never claim a result that was not actually observed.",
+    "- Ask before destructive filesystem, wallet, or irreversible marketplace actions.",
+    "- Keep secrets out of markdown and normal user-facing output.",
+    "",
+  ].join("\n");
+}
+
+function buildReputationFile(answers: OnboardingAnswers): string {
+  return [
+    "# Reputation",
+    "",
+    "Reputation posture for marketplace-facing behavior.",
+    "",
+    answers.marketplaceEnabled
+      ? "- Favor reliable execution, honest status reporting, and conservative claims."
+      : "- Marketplace reputation is inactive until marketplace mode is enabled.",
+    "- Do not chase reputation with spammy or low-signal behavior.",
+    "",
+  ].join("\n");
+}
+
+function buildXFile(answers: OnboardingAnswers): string {
+  return [
+    "# X",
+    "",
+    "Public posting posture for this agent.",
+    "",
+    answers.socialEnabled
+      ? "- If posting publicly, stay useful, restrained, and evidence-backed."
+      : "- Public posting is disabled by default.",
+    "- No manufactured hype or false certainty.",
+    "",
+  ].join("\n");
+}
+
+export function createDefaultOnboardingAnswers(
+  existingConfig?: GatewayConfig,
+): OnboardingAnswers {
+  const walletPath =
+    cleanText(existingConfig?.connection?.keypairPath) || detectSolanaKeypair();
+  return {
+    apiKey: cleanText(existingConfig?.llm?.apiKey),
+    model: cleanText(existingConfig?.llm?.model, DEFAULT_GROK_MODEL),
+    agentName: cleanText(existingConfig?.agent?.name, "AgenC"),
+    mission: DEFAULT_MISSION,
+    role: DEFAULT_ROLE,
+    alwaysDoRules: [...DEFAULT_RULES],
+    soulTraits: [...DEFAULT_TRAITS],
+    tone: "Direct and calm",
+    verbosity: "balanced",
+    autonomy: "balanced",
+    toolPosture: "balanced",
+    memorySeeds: [...DEFAULT_MEMORY],
+    desktopAutomationEnabled: existingConfig?.desktop?.enabled ?? false,
+    walletPath: walletPath ? walletPath : null,
+    rpcUrl: cleanText(
+      existingConfig?.connection?.rpcUrl,
+      "https://api.devnet.solana.com",
+    ),
+    marketplaceEnabled: existingConfig?.marketplace?.enabled ?? true,
+    socialEnabled: existingConfig?.social?.enabled ?? false,
+  };
+}
+
+export function buildOnboardingProfile(
+  answers: OnboardingAnswers,
+  baseConfig?: GatewayConfig,
+): GeneratedOnboardingProfile {
+  const normalizedAnswers: OnboardingAnswers = {
+    ...answers,
+    apiKey: cleanText(answers.apiKey),
+    model: cleanText(answers.model, DEFAULT_GROK_MODEL),
+    agentName: cleanText(answers.agentName, "AgenC"),
+    mission: cleanText(answers.mission, DEFAULT_MISSION),
+    role: cleanText(answers.role, DEFAULT_ROLE),
+    alwaysDoRules: cleanList(answers.alwaysDoRules, DEFAULT_RULES),
+    soulTraits: cleanList(answers.soulTraits, DEFAULT_TRAITS),
+    tone: cleanText(answers.tone, "Direct and calm"),
+    memorySeeds: cleanList(answers.memorySeeds, DEFAULT_MEMORY),
+    rpcUrl: cleanText(answers.rpcUrl, "https://api.devnet.solana.com"),
+    walletPath: cleanText(answers.walletPath ?? undefined) || null,
+  };
+
+  const base = baseConfig ? structuredClone(baseConfig) : generateDefaultConfig();
+  const connection = {
+    ...base.connection,
+    rpcUrl: normalizedAnswers.rpcUrl,
+  };
+  if (normalizedAnswers.walletPath) {
+    connection.keypairPath = normalizedAnswers.walletPath;
+  } else {
+    delete connection.keypairPath;
+  }
+
+  const config: GatewayConfig = {
+    ...base,
+    agent: {
+      ...base.agent,
+      name: normalizedAnswers.agentName,
+    },
+    connection,
+    llm: {
+      ...(base.llm ?? {}),
+      provider: "grok",
+      apiKey: normalizedAnswers.apiKey,
+      model: normalizedAnswers.model,
+    },
+    logging: {
+      ...(base.logging ?? {}),
+      level: base.logging?.level ?? "info",
+    },
+    desktop: {
+      ...(base.desktop ?? defaultDesktopSandboxConfig()),
+      enabled: normalizedAnswers.desktopAutomationEnabled,
+    },
+    marketplace: {
+      ...(base.marketplace ?? {}),
+      enabled: normalizedAnswers.marketplaceEnabled,
+    },
+    social: {
+      ...(base.social ?? {}),
+      enabled: normalizedAnswers.socialEnabled,
+    },
+    workspace: {
+      ...(base.workspace ?? {}),
+      hostPath: getDefaultWorkspacePath(),
+    },
+  };
+
+  const workspaceFiles: Record<WorkspaceFileName, string> = {
+    [WORKSPACE_FILES.AGENC]: buildAgencFile(normalizedAnswers),
+    [WORKSPACE_FILES.AGENT]: buildAgentFile(normalizedAnswers),
+    [WORKSPACE_FILES.SOUL]: buildSoulFile(normalizedAnswers),
+    [WORKSPACE_FILES.USER]: buildUserFile(normalizedAnswers),
+    [WORKSPACE_FILES.TOOLS]: buildToolsFile(normalizedAnswers),
+    [WORKSPACE_FILES.HEARTBEAT]: buildHeartbeatFile(normalizedAnswers),
+    [WORKSPACE_FILES.BOOT]: buildBootFile(normalizedAnswers),
+    [WORKSPACE_FILES.IDENTITY]: buildIdentityFile(normalizedAnswers),
+    [WORKSPACE_FILES.MEMORY]: buildMemoryFile(normalizedAnswers),
+    [WORKSPACE_FILES.CAPABILITIES]: buildCapabilitiesFile(normalizedAnswers),
+    [WORKSPACE_FILES.POLICY]: buildPolicyFile(normalizedAnswers),
+    [WORKSPACE_FILES.REPUTATION]: buildReputationFile(normalizedAnswers),
+    [WORKSPACE_FILES.X]: buildXFile(normalizedAnswers),
+  };
+
+  return {
+    config,
+    workspaceFiles,
+  };
+}

--- a/runtime/src/onboarding/tui.test.ts
+++ b/runtime/src/onboarding/tui.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFrameText,
+  maskSecret,
+  shouldUseInteractiveOnboarding,
+} from "./tui.js";
+
+const ANSI_PATTERN = /\x1b\[[0-9;?]*[A-Za-z]/gu;
+
+function stripAnsi(value: string): string {
+  return value.replace(ANSI_PATTERN, "");
+}
+
+describe("interactive onboarding gating", () => {
+  const ttyDeps = {
+    stdin: { isTTY: true } as any,
+    stdout: { isTTY: true } as any,
+  };
+
+  it("only enables the TUI for real human terminal sessions", () => {
+    expect(shouldUseInteractiveOnboarding({}, ttyDeps)).toBe(true);
+    expect(
+      shouldUseInteractiveOnboarding({ "non-interactive": true }, ttyDeps),
+    ).toBe(false);
+    expect(shouldUseInteractiveOnboarding({ output: "json" }, ttyDeps)).toBe(
+      false,
+    );
+    expect(
+      shouldUseInteractiveOnboarding({ "output-format": "jsonl" }, ttyDeps),
+    ).toBe(false);
+    expect(
+      shouldUseInteractiveOnboarding(
+        {},
+        {
+          stdin: { isTTY: false } as any,
+          stdout: { isTTY: true } as any,
+        },
+      ),
+    ).toBe(false);
+  });
+
+  it("masks secrets without dropping the tail", () => {
+    expect(maskSecret("xai-super-secret")).toMatch(/\*+cret$/);
+    expect(maskSecret("123")).toBe("****");
+  });
+
+  it("fits the onboarding frame inside narrow terminals", () => {
+    const rendered = buildFrameText({
+      columns: 60,
+      step: 1,
+      totalSteps: 17,
+      title: "Welcome",
+      subtitle:
+        "This wizard sets up your local xAI-powered AgenC agent, generates the core workspace files, and gives you a clean first-run starting point.",
+      body: [
+        "You will add an xAI API key, tune the agent identity and soul, confirm wallet/RPC basics, and review everything before it is written.",
+        "Get your xAI API key from: https://console.x.ai/",
+      ],
+      footer: "Enter begin  Ctrl+C cancel",
+    });
+    const visibleLines = rendered.split("\n").map(stripAnsi);
+
+    expect(visibleLines.length).toBeGreaterThan(4);
+    expect(visibleLines.every((line) => line.length <= 60)).toBe(true);
+    expect(visibleLines[0]).toMatch(/^\+-+\+$/u);
+    expect(visibleLines.at(-1)).toMatch(/^\+-+\+$/u);
+  });
+});

--- a/runtime/src/onboarding/tui.ts
+++ b/runtime/src/onboarding/tui.ts
@@ -1,0 +1,1122 @@
+import { existsSync } from "node:fs";
+import { emitKeypressEvents } from "node:readline";
+import { resolve as resolvePath } from "node:path";
+import {
+  applyManagedGatewayPatch,
+  buildManagedGatewayPatch,
+  getCanonicalDefaultConfigPath,
+  loadCliConfigContract,
+} from "../cli/config-contract.js";
+import { executeOnboardCommand, type PreparedOnboardRun } from "../cli/onboard.js";
+import { generateDefaultConfig } from "../cli/wizard.js";
+import type { OnboardOptions } from "../cli/types.js";
+import type { GatewayConfig } from "../gateway/types.js";
+import { createDefaultOnboardingAnswers, buildOnboardingProfile } from "./profile.js";
+import type { OnboardingAnswers } from "./types.js";
+import { validateXaiApiKey } from "./xai-validation.js";
+
+const GO_BACK = Symbol("onboarding.go-back");
+const CANCEL = Symbol("onboarding.cancel");
+
+const COLOR = Object.freeze({
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  ink: "\x1b[38;5;225m",
+  softInk: "\x1b[38;5;189m",
+  fog: "\x1b[38;5;97m",
+  teal: "\x1b[38;5;111m",
+  green: "\x1b[38;5;50m",
+  yellow: "\x1b[38;5;221m",
+  magenta: "\x1b[38;5;177m",
+  red: "\x1b[38;5;203m",
+  border: "\x1b[38;5;99m",
+});
+
+type PromptResult<T> = T | typeof GO_BACK | typeof CANCEL;
+
+interface KeypressKey {
+  readonly name?: string;
+  readonly ctrl?: boolean;
+  readonly meta?: boolean;
+  readonly shift?: boolean;
+}
+
+interface TerminalInput {
+  readonly isTTY?: boolean;
+  readonly on: (event: string, listener: (...args: any[]) => void) => any;
+  readonly off: (event: string, listener: (...args: any[]) => void) => any;
+  readonly resume: () => void;
+  readonly setRawMode?: (enabled: boolean) => void;
+}
+
+interface TerminalOutput {
+  readonly isTTY?: boolean;
+  readonly columns?: number;
+  readonly rows?: number;
+  readonly write: (chunk: string) => any;
+  readonly on: (event: string, listener: (...args: any[]) => void) => any;
+  readonly off: (event: string, listener: (...args: any[]) => void) => any;
+}
+
+interface OnboardingTuiDeps {
+  readonly stdin: TerminalInput;
+  readonly stdout: TerminalOutput;
+  readonly validateXaiApiKey: typeof validateXaiApiKey;
+}
+
+type FrameTone = "teal" | "green" | "yellow" | "red";
+
+interface FrameRenderParams {
+  readonly columns?: number;
+  readonly step: number;
+  readonly totalSteps: number;
+  readonly title: string;
+  readonly subtitle?: string;
+  readonly body: readonly string[];
+  readonly footer?: string;
+  readonly statusTone?: FrameTone;
+}
+
+const DEFAULT_TUI_DEPS: OnboardingTuiDeps = {
+  stdin: process.stdin,
+  stdout: process.stdout,
+  validateXaiApiKey,
+};
+
+function canUseInteractiveOnboarding(
+  flags: Record<string, string | number | boolean>,
+  deps: Pick<OnboardingTuiDeps, "stdin" | "stdout">,
+): boolean {
+  if (flags["non-interactive"] === true) return false;
+  if (flags.output === "json" || flags.output === "jsonl") return false;
+  if (flags["output-format"] === "json" || flags["output-format"] === "jsonl") {
+    return false;
+  }
+  return deps.stdin.isTTY === true && deps.stdout.isTTY === true;
+}
+
+function wrapText(text: string, width: number): string[] {
+  const normalized = text.trim();
+  if (normalized.length === 0) return [""];
+  const words = normalized.split(/\s+/);
+  const lines: string[] = [];
+  let current = "";
+  for (const word of words) {
+    const next = current.length === 0 ? word : `${current} ${word}`;
+    if (next.length <= width) {
+      current = next;
+      continue;
+    }
+    if (current.length > 0) {
+      lines.push(current);
+    }
+    current = word;
+  }
+  if (current.length > 0) {
+    lines.push(current);
+  }
+  return lines.length > 0 ? lines : [""];
+}
+
+function padRight(value: string, width: number): string {
+  return value.length >= width ? value.slice(0, width) : value + " ".repeat(width - value.length);
+}
+
+function centerText(value: string, width: number): string {
+  if (value.length >= width) return value.slice(0, width);
+  const left = Math.floor((width - value.length) / 2);
+  return " ".repeat(left) + value + " ".repeat(width - value.length - left);
+}
+
+function buildProgressBar(current: number, total: number, width = 18): string {
+  const safeTotal = Math.max(total, 1);
+  const filled = Math.max(0, Math.min(width, Math.round((current / safeTotal) * width)));
+  return `[${"#".repeat(filled)}${"-".repeat(width - filled)}] ${current}/${total}`;
+}
+
+function maskSecret(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= 4) {
+    return "*".repeat(Math.max(trimmed.length, 4));
+  }
+  return `${"*".repeat(Math.max(4, trimmed.length - 4))}${trimmed.slice(-4)}`;
+}
+
+function parseCsvList(value: string): string[] {
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry, index, array) => entry.length > 0 && array.indexOf(entry) === index);
+}
+
+function humanizeBoolean(value: boolean): string {
+  return value ? "Enabled" : "Disabled";
+}
+
+function resolveFrameInnerWidth(columns?: number): number {
+  const safeColumns = columns ?? 100;
+  return Math.min(88, Math.max(10, safeColumns - 2));
+}
+
+export function buildFrameText(params: FrameRenderParams): string {
+  const innerWidth = resolveFrameInnerWidth(params.columns);
+  const bodyWidth = innerWidth - 4;
+  const header = centerText("AgenC Onboard", bodyWidth);
+  const progress = centerText(
+    buildProgressBar(params.step, params.totalSteps),
+    bodyWidth,
+  );
+  const subtitleLines = params.subtitle
+    ? wrapText(params.subtitle, bodyWidth)
+    : [];
+  const bodyLines = params.body.flatMap((line) => wrapText(line, bodyWidth));
+  const footerLine = params.footer ? padRight(params.footer, bodyWidth) : "";
+  const lines = [
+    `${COLOR.border}+${"-".repeat(innerWidth - 2)}+${COLOR.reset}`,
+    `${COLOR.border}|${COLOR.reset}${COLOR.magenta}${COLOR.bold}${header}${COLOR.reset}${COLOR.border}|${COLOR.reset}`,
+    `${COLOR.border}|${COLOR.reset}${COLOR.fog}${progress}${COLOR.reset}${COLOR.border}|${COLOR.reset}`,
+    `${COLOR.border}|${" ".repeat(innerWidth - 2)}|${COLOR.reset}`,
+    ...subtitleLines.map(
+      (line) =>
+        `${COLOR.border}|${COLOR.reset}${COLOR.softInk}${padRight(line, bodyWidth)}${COLOR.reset}${COLOR.border}|${COLOR.reset}`,
+    ),
+    ...(subtitleLines.length > 0
+      ? [`${COLOR.border}|${" ".repeat(innerWidth - 2)}|${COLOR.reset}`]
+      : []),
+    `${COLOR.border}|${COLOR.reset}${COLOR.ink}${COLOR.bold}${padRight(params.title, bodyWidth)}${COLOR.reset}${COLOR.border}|${COLOR.reset}`,
+    `${COLOR.border}|${" ".repeat(innerWidth - 2)}|${COLOR.reset}`,
+    ...bodyLines.map((line) => {
+      const tone = params.statusTone ? COLOR[params.statusTone] : COLOR.ink;
+      return `${COLOR.border}|${COLOR.reset}${tone}${padRight(line, bodyWidth)}${COLOR.reset}${COLOR.border}|${COLOR.reset}`;
+    }),
+    `${COLOR.border}|${" ".repeat(innerWidth - 2)}|${COLOR.reset}`,
+    `${COLOR.border}|${COLOR.reset}${COLOR.fog}${padRight(
+      footerLine || "Enter continue  Esc back  Ctrl+C cancel",
+      bodyWidth,
+    )}${COLOR.reset}${COLOR.border}|${COLOR.reset}`,
+    `${COLOR.border}+${"-".repeat(innerWidth - 2)}+${COLOR.reset}`,
+  ];
+
+  return lines.join("\n");
+}
+
+function renderFrame(params: FrameRenderParams & { stdout: TerminalOutput }): void {
+  params.stdout.write("\x1b[2J\x1b[H");
+  params.stdout.write(
+    buildFrameText({
+      columns: params.stdout.columns,
+      step: params.step,
+      totalSteps: params.totalSteps,
+      title: params.title,
+      subtitle: params.subtitle,
+      body: params.body,
+      footer: params.footer,
+      statusTone: params.statusTone,
+    }),
+  );
+}
+
+class OnboardingTerminalSession {
+  private readonly stdin: TerminalInput;
+  private readonly stdout: TerminalOutput;
+  private keypressHandler: ((input: string, key: KeypressKey) => void) | null = null;
+  private resizeHandler: (() => void) | null = null;
+  private renderCurrent: (() => void) | null = null;
+  private entered = false;
+
+  constructor(stdin: TerminalInput, stdout: TerminalOutput) {
+    this.stdin = stdin;
+    this.stdout = stdout;
+  }
+
+  enter(): void {
+    if (this.entered) return;
+    emitKeypressEvents(this.stdin as any);
+    this.stdin.resume();
+    this.stdin.setRawMode?.(true);
+    this.stdout.write("\x1b[?1049h\x1b[?25l\x1b[2J\x1b[H");
+    this.resizeHandler = () => {
+      this.renderCurrent?.();
+    };
+    this.stdout.on("resize", this.resizeHandler);
+    this.entered = true;
+  }
+
+  dispose(): void {
+    if (!this.entered) return;
+    if (this.keypressHandler) {
+      this.stdin.off("keypress", this.keypressHandler);
+      this.keypressHandler = null;
+    }
+    if (this.resizeHandler) {
+      this.stdout.off("resize", this.resizeHandler);
+      this.resizeHandler = null;
+    }
+    this.stdin.setRawMode?.(false);
+    this.stdout.write("\x1b[?25h\x1b[?1049l");
+    this.entered = false;
+    this.renderCurrent = null;
+  }
+
+  private bind(
+    render: () => void,
+    handler: (input: string, key: KeypressKey) => void,
+  ): void {
+    if (this.keypressHandler) {
+      this.stdin.off("keypress", this.keypressHandler);
+    }
+    this.renderCurrent = render;
+    this.keypressHandler = handler;
+    this.stdin.on("keypress", this.keypressHandler);
+    render();
+  }
+
+  renderStatic(params: {
+    step: number;
+    totalSteps: number;
+    title: string;
+    subtitle?: string;
+    body: readonly string[];
+    footer?: string;
+    statusTone?: FrameTone;
+  }): void {
+    if (this.keypressHandler) {
+      this.stdin.off("keypress", this.keypressHandler);
+      this.keypressHandler = null;
+    }
+    this.renderCurrent = () =>
+      renderFrame({
+        stdout: this.stdout,
+        step: params.step,
+        totalSteps: params.totalSteps,
+        title: params.title,
+        subtitle: params.subtitle,
+        body: params.body,
+        footer: params.footer,
+        statusTone: params.statusTone,
+      });
+    this.renderCurrent();
+  }
+
+  async showIntro(totalSteps: number): Promise<PromptResult<void>> {
+    return new Promise((resolve) => {
+      const render = () =>
+        renderFrame({
+          stdout: this.stdout,
+          step: 1,
+          totalSteps,
+          title: "Welcome",
+          subtitle:
+            "This wizard sets up your local xAI-powered AgenC agent, generates the core workspace files, and gives you a clean first-run starting point.",
+          body: [
+            "You will add an xAI API key, tune the agent identity and soul, confirm wallet/RPC basics, and review everything before it is written.",
+            "Get your xAI API key from: https://console.x.ai/",
+          ],
+          footer: "Enter begin  Ctrl+C cancel",
+        });
+
+      this.bind(render, (_input, key) => {
+        if (key.ctrl && key.name === "c") {
+          resolve(CANCEL);
+          return;
+        }
+        if (key.name === "return" || key.name === "enter") {
+          resolve(undefined);
+        }
+      });
+    });
+  }
+
+  async promptText(params: {
+    step: number;
+    totalSteps: number;
+    title: string;
+    subtitle?: string;
+    hint?: string;
+    value?: string;
+    placeholder?: string;
+    masked?: boolean;
+    allowEmpty?: boolean;
+    allowBack?: boolean;
+    error?: string;
+  }): Promise<PromptResult<string>> {
+    return new Promise((resolve) => {
+      let value = params.value ?? "";
+
+      const render = () => {
+        const shownValue =
+          value.length > 0
+            ? params.masked
+              ? maskSecret(value)
+              : value
+            : params.placeholder ?? "";
+        renderFrame({
+          stdout: this.stdout,
+          step: params.step,
+          totalSteps: params.totalSteps,
+          title: params.title,
+          subtitle: params.subtitle,
+          body: [
+            ...(params.hint ? [params.hint] : []),
+            "",
+            `> ${shownValue}`,
+            ...(params.error ? ["", `Warning: ${params.error}`] : []),
+          ],
+          footer: params.allowBack
+            ? "Type and press Enter  Esc back  Ctrl+C cancel"
+            : "Type and press Enter  Ctrl+C cancel",
+          statusTone: params.error ? "yellow" : "teal",
+        });
+      };
+
+      this.bind(render, (input, key) => {
+        if (key.ctrl && key.name === "c") {
+          resolve(CANCEL);
+          return;
+        }
+        if (params.allowBack && key.name === "escape") {
+          resolve(GO_BACK);
+          return;
+        }
+        if (key.name === "backspace") {
+          value = value.slice(0, -1);
+          render();
+          return;
+        }
+        if (key.name === "return" || key.name === "enter") {
+          if (!params.allowEmpty && value.trim().length === 0) {
+            renderFrame({
+              stdout: this.stdout,
+              step: params.step,
+              totalSteps: params.totalSteps,
+              title: params.title,
+              subtitle: params.subtitle,
+              body: [
+                ...(params.hint ? [params.hint] : []),
+                "",
+                `> ${params.masked ? maskSecret(value) : value}`,
+                "",
+                "This field cannot be empty.",
+              ],
+              footer: params.allowBack
+                ? "Type and press Enter  Esc back  Ctrl+C cancel"
+                : "Type and press Enter  Ctrl+C cancel",
+              statusTone: "red",
+            });
+            return;
+          }
+          resolve(value.trim());
+          return;
+        }
+        if (typeof input === "string" && input >= " " && input !== "\u007f") {
+          value += input;
+          render();
+        }
+      });
+    });
+  }
+
+  async promptSelect<T extends string>(params: {
+    step: number;
+    totalSteps: number;
+    title: string;
+    subtitle?: string;
+    options: readonly { value: T; label: string; detail?: string }[];
+    initialValue?: T;
+    allowBack?: boolean;
+  }): Promise<PromptResult<T>> {
+    return new Promise((resolve) => {
+      let index = Math.max(
+        0,
+        params.options.findIndex((option) => option.value === params.initialValue),
+      );
+
+      const render = () => {
+        const body = params.options.flatMap((option, optionIndex) => {
+          const selected = optionIndex === index;
+          const prefix = selected ? ">" : " ";
+          return [
+            `${prefix} ${option.label}`,
+            ...(option.detail ? [`  ${option.detail}`] : []),
+            "",
+          ];
+        });
+        renderFrame({
+          stdout: this.stdout,
+          step: params.step,
+          totalSteps: params.totalSteps,
+          title: params.title,
+          subtitle: params.subtitle,
+          body,
+          footer: params.allowBack
+            ? "Arrow keys move  Enter select  Esc back  Ctrl+C cancel"
+            : "Arrow keys move  Enter select  Ctrl+C cancel",
+        });
+      };
+
+      this.bind(render, (_input, key) => {
+        if (key.ctrl && key.name === "c") {
+          resolve(CANCEL);
+          return;
+        }
+        if (params.allowBack && key.name === "escape") {
+          resolve(GO_BACK);
+          return;
+        }
+        if (key.name === "up" || key.name === "k") {
+          index = (index - 1 + params.options.length) % params.options.length;
+          render();
+          return;
+        }
+        if (key.name === "down" || key.name === "j") {
+          index = (index + 1) % params.options.length;
+          render();
+          return;
+        }
+        if (key.name === "return" || key.name === "enter") {
+          resolve(params.options[index]!.value);
+        }
+      });
+    });
+  }
+
+  async promptReview(
+    step: number,
+    totalSteps: number,
+    lines: readonly string[],
+  ): Promise<PromptResult<"confirm">> {
+    return new Promise((resolve) => {
+      const render = () =>
+        renderFrame({
+          stdout: this.stdout,
+          step,
+          totalSteps,
+          title: "Review",
+          subtitle: "Check the first-run profile before it is written to disk.",
+          body: lines,
+          footer: "Enter write setup  Esc back  Ctrl+C cancel",
+        });
+
+      this.bind(render, (_input, key) => {
+        if (key.ctrl && key.name === "c") {
+          resolve(CANCEL);
+          return;
+        }
+        if (key.name === "escape") {
+          resolve(GO_BACK);
+          return;
+        }
+        if (key.name === "return" || key.name === "enter") {
+          resolve("confirm");
+        }
+      });
+    });
+  }
+
+  async showMessage(params: {
+    step: number;
+    totalSteps: number;
+    title: string;
+    subtitle?: string;
+    body: readonly string[];
+    footer?: string;
+    statusTone?: FrameTone;
+  }): Promise<PromptResult<void>> {
+    return new Promise((resolve) => {
+      const render = () =>
+        renderFrame({
+          stdout: this.stdout,
+          step: params.step,
+          totalSteps: params.totalSteps,
+          title: params.title,
+          subtitle: params.subtitle,
+          body: params.body,
+          footer: params.footer ?? "Enter continue  Ctrl+C cancel",
+          statusTone: params.statusTone,
+        });
+      this.bind(render, (_input, key) => {
+        if (key.ctrl && key.name === "c") {
+          resolve(CANCEL);
+          return;
+        }
+        if (key.name === "return" || key.name === "enter") {
+          resolve(undefined);
+        }
+      });
+    });
+  }
+}
+
+function loadInteractiveBaseConfig(options: OnboardOptions): {
+  baseConfig: GatewayConfig;
+  importedLegacyConfigPath: string | null;
+} {
+  const configPath = resolvePath(
+    options.configPath ?? getCanonicalDefaultConfigPath(),
+  );
+  if (existsSync(configPath)) {
+    const contract = loadCliConfigContract(configPath, {
+      configPathSource: options.configPathSource,
+    });
+    if (contract.shape === "canonical-gateway" && contract.gatewayConfig) {
+      return {
+        baseConfig: contract.gatewayConfig,
+        importedLegacyConfigPath: null,
+      };
+    }
+  }
+
+  if (options.legacyImportConfigPath) {
+    const imported = loadCliConfigContract(options.legacyImportConfigPath, {
+      configPathSource: "env:AGENC_RUNTIME_CONFIG",
+    });
+    return {
+      baseConfig: applyManagedGatewayPatch(
+        generateDefaultConfig(),
+        buildManagedGatewayPatch(imported.fileConfig),
+      ),
+      importedLegacyConfigPath: options.legacyImportConfigPath,
+    };
+  }
+
+  return {
+    baseConfig: generateDefaultConfig(),
+    importedLegacyConfigPath: null,
+  };
+}
+
+function buildReviewLines(answers: OnboardingAnswers): string[] {
+  return [
+    `xAI key: ${maskSecret(answers.apiKey)}`,
+    `Model: ${answers.model}`,
+    `Agent name: ${answers.agentName}`,
+    `Mission: ${answers.mission}`,
+    `Role: ${answers.role}`,
+    `Soul traits: ${answers.soulTraits.join(", ")}`,
+    `Tone: ${answers.tone}`,
+    `Verbosity: ${answers.verbosity}`,
+    `Autonomy: ${answers.autonomy}`,
+    `Tool posture: ${answers.toolPosture}`,
+    `Wallet path: ${answers.walletPath ?? "not configured"}`,
+    `RPC URL: ${answers.rpcUrl}`,
+    `Marketplace mode: ${humanizeBoolean(answers.marketplaceEnabled)}`,
+  ];
+}
+
+function buildFinalSummaryLines(result: Awaited<ReturnType<typeof executeOnboardCommand>>): string[] {
+  const checkLines = result.checks.map((check) => {
+    const marker =
+      check.status === "pass" ? "[ok]" : check.status === "warn" ? "[!]" : "[x]";
+    return `${marker} ${check.message}`;
+  });
+  return [
+    `Config: ${result.configPath}`,
+    ...(result.workspacePath ? [`Workspace: ${result.workspacePath}`] : []),
+    ...(result.backupPath ? [`Config backup: ${result.backupPath}`] : []),
+    ...checkLines,
+  ];
+}
+
+export async function runInteractiveOnboarding(
+  options: OnboardOptions,
+  deps: Partial<OnboardingTuiDeps> = {},
+): Promise<0 | 1 | 2> {
+  const resolvedDeps: OnboardingTuiDeps = {
+    ...DEFAULT_TUI_DEPS,
+    ...deps,
+  };
+  const session = new OnboardingTerminalSession(
+    resolvedDeps.stdin,
+    resolvedDeps.stdout,
+  );
+
+  const resolvedConfigPath = resolvePath(
+    options.configPath ?? getCanonicalDefaultConfigPath(),
+  );
+  if (existsSync(resolvedConfigPath) && !options.force) {
+    session.enter();
+    try {
+      const outcome = await session.showMessage({
+        step: 1,
+        totalSteps: 1,
+        title: "Existing setup detected",
+        subtitle:
+          "AgenC already has a config at this path. The v1 onboarding flow is first-run plus explicit overwrite only.",
+        body: [
+          `Config path: ${resolvedConfigPath}`,
+          "",
+          "Rerun with --force if you want the onboarding wizard to rewrite the profile and curated workspace files.",
+        ],
+        statusTone: "yellow",
+      });
+      return outcome === CANCEL ? 1 : 1;
+    } finally {
+      session.dispose();
+    }
+  }
+
+  const { baseConfig, importedLegacyConfigPath } = loadInteractiveBaseConfig(options);
+  let answers = createDefaultOnboardingAnswers(baseConfig);
+  let availableModels = [answers.model];
+  const totalSteps = 17;
+  let finalSummaryText: string | null = null;
+
+  session.enter();
+
+  try {
+    let stepIndex = 0;
+    while (stepIndex < totalSteps) {
+      if (stepIndex === 0) {
+        const result = await session.showIntro(totalSteps);
+        if (result === CANCEL) return 1;
+        stepIndex += 1;
+        continue;
+      }
+
+      if (stepIndex === 1) {
+        const value = await session.promptText({
+          step: 2,
+          totalSteps,
+          title: "xAI API Key",
+          subtitle:
+            "AgenC uses xAI as the default first-run provider. Paste the API key you generated from console.x.ai.",
+          hint: "The key is stored in the AgenC config for v1 so the local runtime can use it immediately.",
+          value: answers.apiKey,
+          placeholder: "xai-...",
+          masked: true,
+          allowBack: true,
+        });
+        if (value === CANCEL) return 1;
+        if (value === GO_BACK) {
+          stepIndex -= 1;
+          continue;
+        }
+
+        session.renderStatic({
+          step: 2,
+          totalSteps,
+          title: "Validating xAI",
+          subtitle: "Checking the API key and fetching available chat models from xAI.",
+          body: ["This should only take a moment."],
+          footer: "Please wait...",
+          statusTone: "teal",
+        });
+
+        const validation = await resolvedDeps.validateXaiApiKey({
+          apiKey: value,
+        });
+        if (!validation.ok) {
+          const retry = await session.promptText({
+            step: 2,
+            totalSteps,
+            title: "xAI API Key",
+            subtitle:
+              "AgenC uses xAI as the default first-run provider. Paste the API key you generated from console.x.ai.",
+            hint: "The last validation attempt failed. Fix the key and try again.",
+            value,
+            placeholder: "xai-...",
+            masked: true,
+            allowBack: true,
+            error: validation.message,
+          });
+          if (retry === CANCEL) return 1;
+          if (retry === GO_BACK) {
+            stepIndex -= 1;
+            continue;
+          }
+          answers = { ...answers, apiKey: retry };
+          continue;
+        }
+
+        answers = {
+          ...answers,
+          apiKey: value,
+          model: validation.availableModels[0] ?? answers.model,
+        };
+        availableModels = [...validation.availableModels];
+        stepIndex += 1;
+        continue;
+      }
+
+      if (stepIndex === 2) {
+        const selection = await session.promptSelect({
+          step: 3,
+          totalSteps,
+          title: "Default Model",
+          subtitle: "Pick the default xAI model for your local agent.",
+          allowBack: true,
+          initialValue: answers.model,
+          options: availableModels.map((model) => ({
+            value: model,
+            label: model,
+          })),
+        });
+        if (selection === CANCEL) return 1;
+        if (selection === GO_BACK) {
+          stepIndex -= 1;
+          continue;
+        }
+        answers = { ...answers, model: selection };
+        stepIndex += 1;
+        continue;
+      }
+
+      if (stepIndex === 3) {
+        const value = await session.promptText({
+          step: 4,
+          totalSteps,
+          title: "Agent Name",
+          subtitle: "This becomes the runtime-facing agent identity and shows up in the generated workspace files.",
+          value: answers.agentName,
+          allowBack: true,
+        });
+        if (value === CANCEL) return 1;
+        if (value === GO_BACK) {
+          stepIndex -= 1;
+          continue;
+        }
+        answers = { ...answers, agentName: value };
+        stepIndex += 1;
+        continue;
+      }
+
+      if (stepIndex === 4) {
+        const value = await session.promptText({
+          step: 5,
+          totalSteps,
+          title: "Mission",
+          subtitle: "Describe what this agent is fundamentally supposed to do.",
+          value: answers.mission,
+          allowBack: true,
+        });
+        if (value === CANCEL) return 1;
+        if (value === GO_BACK) {
+          stepIndex -= 1;
+          continue;
+        }
+        answers = { ...answers, mission: value };
+        stepIndex += 1;
+        continue;
+      }
+
+      if (stepIndex === 5) {
+        const value = await session.promptText({
+          step: 6,
+          totalSteps,
+          title: "Role",
+          subtitle: "Give the agent a short operating role. Examples: General-purpose operator, Research scout, Marketplace builder.",
+          value: answers.role,
+          allowBack: true,
+        });
+        if (value === CANCEL) return 1;
+        if (value === GO_BACK) {
+          stepIndex -= 1;
+          continue;
+        }
+        answers = { ...answers, role: value };
+        stepIndex += 1;
+        continue;
+      }
+
+      if (stepIndex === 6) {
+        const value = await session.promptText({
+          step: 7,
+          totalSteps,
+          title: "Always-Do Rules",
+          subtitle: "Enter 2-4 non-negotiable rules as a comma-separated list.",
+          value: answers.alwaysDoRules.join(", "),
+          allowBack: true,
+        });
+        if (value === CANCEL) return 1;
+        if (value === GO_BACK) {
+          stepIndex -= 1;
+          continue;
+        }
+        answers = { ...answers, alwaysDoRules: parseCsvList(value) };
+        stepIndex += 1;
+        continue;
+      }
+
+      if (stepIndex === 7) {
+        const value = await session.promptText({
+          step: 8,
+          totalSteps,
+          title: "Soul Traits",
+          subtitle: "Enter personality traits as a comma-separated list. Keep it sharp and stable.",
+          value: answers.soulTraits.join(", "),
+          allowBack: true,
+        });
+        if (value === CANCEL) return 1;
+        if (value === GO_BACK) {
+          stepIndex -= 1;
+          continue;
+        }
+        answers = { ...answers, soulTraits: parseCsvList(value) };
+        stepIndex += 1;
+        continue;
+      }
+
+      if (stepIndex === 8) {
+        const selection = await session.promptSelect({
+          step: 9,
+          totalSteps,
+          title: "Tone",
+          subtitle: "Choose the communication tone for the generated SOUL and USER docs.",
+          allowBack: true,
+          initialValue: answers.tone,
+          options: [
+            { value: "Direct and calm", label: "Direct and calm" },
+            { value: "Strategic and composed", label: "Strategic and composed" },
+            { value: "Warm and clear", label: "Warm and clear" },
+            { value: "High-agency operator", label: "High-agency operator" },
+          ],
+        });
+        if (selection === CANCEL) return 1;
+        if (selection === GO_BACK) {
+          stepIndex -= 1;
+          continue;
+        }
+        answers = { ...answers, tone: selection };
+        stepIndex += 1;
+        continue;
+      }
+
+      if (stepIndex === 9) {
+        const selection = await session.promptSelect({
+          step: 10,
+          totalSteps,
+          title: "Verbosity",
+          subtitle: "Set the default response density for this agent.",
+          allowBack: true,
+          initialValue: answers.verbosity,
+          options: [
+            { value: "tight", label: "Tight", detail: "Compact, high-signal responses." },
+            { value: "balanced", label: "Balanced", detail: "Concise first, fuller when needed." },
+            { value: "detailed", label: "Detailed", detail: "More context and reasoning by default." },
+          ],
+        });
+        if (selection === CANCEL) return 1;
+        if (selection === GO_BACK) {
+          stepIndex -= 1;
+          continue;
+        }
+        answers = { ...answers, verbosity: selection };
+        stepIndex += 1;
+        continue;
+      }
+
+      if (stepIndex === 10) {
+        const selection = await session.promptSelect({
+          step: 11,
+          totalSteps,
+          title: "Autonomy",
+          subtitle: "Choose how self-starting the agent should be before escalating for confirmation.",
+          allowBack: true,
+          initialValue: answers.autonomy,
+          options: [
+            { value: "conservative", label: "Conservative", detail: "Ask before risky or ambiguous actions." },
+            { value: "balanced", label: "Balanced", detail: "Move on low-risk work, escalate when it matters." },
+            { value: "aggressive", label: "Aggressive", detail: "Bias toward execution and only stop at hard boundaries." },
+          ],
+        });
+        if (selection === CANCEL) return 1;
+        if (selection === GO_BACK) {
+          stepIndex -= 1;
+          continue;
+        }
+        answers = { ...answers, autonomy: selection };
+        stepIndex += 1;
+        continue;
+      }
+
+      if (stepIndex === 11) {
+        const selection = await session.promptSelect({
+          step: 12,
+          totalSteps,
+          title: "Tool Posture",
+          subtitle: "Set the default appetite for tool use.",
+          allowBack: true,
+          initialValue: answers.toolPosture,
+          options: [
+            { value: "guarded", label: "Guarded", detail: "Use tools narrowly and explain intent first." },
+            { value: "balanced", label: "Balanced", detail: "Use tools when they materially unlock progress." },
+            { value: "broad", label: "Broad", detail: "Lean into tool execution when it speeds things up." },
+          ],
+        });
+        if (selection === CANCEL) return 1;
+        if (selection === GO_BACK) {
+          stepIndex -= 1;
+          continue;
+        }
+        answers = { ...answers, toolPosture: selection };
+        stepIndex += 1;
+        continue;
+      }
+
+      if (stepIndex === 12) {
+        const value = await session.promptText({
+          step: 13,
+          totalSteps,
+          title: "Memory Seeds",
+          subtitle: "Optional durable facts as a comma-separated list. Leave blank to keep the default operator memory note.",
+          value: answers.memorySeeds.join(", "),
+          allowBack: true,
+          allowEmpty: true,
+        });
+        if (value === CANCEL) return 1;
+        if (value === GO_BACK) {
+          stepIndex -= 1;
+          continue;
+        }
+        answers = {
+          ...answers,
+          memorySeeds: value.length > 0 ? parseCsvList(value) : [],
+        };
+        stepIndex += 1;
+        continue;
+      }
+
+      if (stepIndex === 13) {
+        const value = await session.promptText({
+          step: 14,
+          totalSteps,
+          title: "Wallet Path",
+          subtitle: "Confirm the Solana keypair path AgenC should use. Leave blank to skip local wallet setup for now.",
+          value: answers.walletPath ?? "",
+          allowBack: true,
+          allowEmpty: true,
+          placeholder: "~/.config/solana/id.json",
+        });
+        if (value === CANCEL) return 1;
+        if (value === GO_BACK) {
+          stepIndex -= 1;
+          continue;
+        }
+        answers = { ...answers, walletPath: value.length > 0 ? value : null };
+        stepIndex += 1;
+        continue;
+      }
+
+      if (stepIndex === 14) {
+        const value = await session.promptText({
+          step: 15,
+          totalSteps,
+          title: "RPC URL",
+          subtitle: "Choose the Solana RPC endpoint for the generated config.",
+          value: answers.rpcUrl,
+          allowBack: true,
+        });
+        if (value === CANCEL) return 1;
+        if (value === GO_BACK) {
+          stepIndex -= 1;
+          continue;
+        }
+        answers = { ...answers, rpcUrl: value };
+        stepIndex += 1;
+        continue;
+      }
+
+      if (stepIndex === 15) {
+        const marketplaceMode = await session.promptSelect({
+          step: 16,
+          totalSteps,
+          title: "Marketplace Mode",
+          subtitle: "Enable the marketplace/task posture in the generated config and workspace files.",
+          allowBack: true,
+          initialValue: answers.marketplaceEnabled ? "enabled" : "disabled",
+          options: [
+            { value: "enabled", label: "Enabled", detail: "Agent can adopt marketplace-aware defaults." },
+            { value: "disabled", label: "Disabled", detail: "Keep marketplace behavior quiet until you enable it later." },
+          ],
+        });
+        if (marketplaceMode === CANCEL) return 1;
+        if (marketplaceMode === GO_BACK) {
+          stepIndex -= 1;
+          continue;
+        }
+        answers = {
+          ...answers,
+          marketplaceEnabled: marketplaceMode === "enabled",
+        };
+        stepIndex += 1;
+        continue;
+      }
+
+      if (stepIndex === 16) {
+        const review = await session.promptReview(
+          17,
+          totalSteps,
+          buildReviewLines(answers),
+        );
+        if (review === CANCEL) return 1;
+        if (review === GO_BACK) {
+          stepIndex -= 1;
+          continue;
+        }
+
+        const profile = buildOnboardingProfile(answers, baseConfig);
+        const prepared: PreparedOnboardRun = {
+          finalConfig: profile.config,
+          importedLegacyConfigPath,
+          workspace: {
+            workspacePath: profile.config.workspace?.hostPath,
+            files: profile.workspaceFiles,
+            overwrite: options.force ?? false,
+            backupExisting: options.force ?? false,
+          },
+        };
+
+        session.renderStatic({
+          step: 17,
+          totalSteps,
+          title: "Writing setup",
+          subtitle: "Saving the canonical config and curated workspace files, then running health checks.",
+          body: ["Please wait..."],
+          footer: "Working...",
+          statusTone: "teal",
+        });
+
+        const result = await executeOnboardCommand(options, prepared);
+
+        const finished = await session.showMessage({
+          step: 17,
+          totalSteps,
+          title: result.exitCode === 0 ? "Onboarding complete" : "Onboarding finished with warnings",
+          subtitle:
+            result.exitCode === 0
+              ? "AgenC has a working first-run profile. Review the summary, then continue into the normal command flow."
+              : "Setup wrote what it could, but one or more checks need attention before you rely on the runtime.",
+          body: buildFinalSummaryLines(result),
+          footer: "Enter continue",
+          statusTone: result.exitCode === 0 ? "green" : "yellow",
+        });
+        finalSummaryText =
+          `${COLOR.bold}AgenC onboard${COLOR.reset}\n` +
+          `Config: ${result.configPath}\n` +
+          `${result.workspacePath ? `Workspace: ${result.workspacePath}\n` : ""}` +
+          "Next steps:\n" +
+          "  agenc start\n" +
+          "  agenc\n" +
+          "  agenc ui\n";
+        if (finished === CANCEL) return result.exitCode;
+        return result.exitCode;
+      }
+    }
+    return 1;
+  } finally {
+    session.dispose();
+    if (finalSummaryText) {
+      resolvedDeps.stdout.write(finalSummaryText);
+    }
+  }
+}
+
+export function shouldUseInteractiveOnboarding(
+  parsedFlags: Record<string, string | number | boolean>,
+  deps: Pick<OnboardingTuiDeps, "stdin" | "stdout"> = DEFAULT_TUI_DEPS,
+): boolean {
+  return canUseInteractiveOnboarding(parsedFlags, deps);
+}
+
+export { maskSecret };

--- a/runtime/src/onboarding/types.ts
+++ b/runtime/src/onboarding/types.ts
@@ -1,0 +1,38 @@
+import type { GatewayConfig } from "../gateway/types.js";
+import type { WorkspaceFileName } from "../gateway/workspace-files.js";
+
+export type OnboardingVerbosity = "tight" | "balanced" | "detailed";
+export type OnboardingAutonomy = "conservative" | "balanced" | "aggressive";
+export type OnboardingToolPosture = "guarded" | "balanced" | "broad";
+
+export interface OnboardingAnswers {
+  readonly apiKey: string;
+  readonly model: string;
+  readonly agentName: string;
+  readonly mission: string;
+  readonly role: string;
+  readonly alwaysDoRules: readonly string[];
+  readonly soulTraits: readonly string[];
+  readonly tone: string;
+  readonly verbosity: OnboardingVerbosity;
+  readonly autonomy: OnboardingAutonomy;
+  readonly toolPosture: OnboardingToolPosture;
+  readonly memorySeeds: readonly string[];
+  readonly desktopAutomationEnabled: boolean;
+  readonly walletPath: string | null;
+  readonly rpcUrl: string;
+  readonly marketplaceEnabled: boolean;
+  readonly socialEnabled: boolean;
+}
+
+export interface GeneratedOnboardingProfile {
+  readonly config: GatewayConfig;
+  readonly workspaceFiles: Record<WorkspaceFileName, string>;
+}
+
+export interface XaiValidationResult {
+  readonly ok: boolean;
+  readonly message: string;
+  readonly availableModels: readonly string[];
+}
+

--- a/runtime/src/onboarding/workspace.ts
+++ b/runtime/src/onboarding/workspace.ts
@@ -1,0 +1,79 @@
+import { access, copyFile, mkdir, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+import { join } from "node:path";
+import {
+  WORKSPACE_FILES,
+  generateTemplate,
+  type WorkspaceFileName,
+} from "../gateway/workspace-files.js";
+
+export interface OnboardingWorkspaceWriteResult {
+  readonly created: string[];
+  readonly overwritten: string[];
+  readonly preserved: string[];
+  readonly backupPaths: readonly string[];
+}
+
+function buildWorkspaceBackupPath(filePath: string): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  return `${filePath}.bak.${timestamp}`;
+}
+
+export async function writeOnboardingWorkspaceFiles(
+  workspacePath: string,
+  files: Partial<Record<WorkspaceFileName, string>>,
+  options: {
+    overwrite?: boolean;
+    backupExisting?: boolean;
+  } = {},
+): Promise<OnboardingWorkspaceWriteResult> {
+  await mkdir(workspacePath, { recursive: true });
+
+  const created: string[] = [];
+  const overwritten: string[] = [];
+  const preserved: string[] = [];
+  const backupPaths: string[] = [];
+
+  for (const fileName of Object.values(WORKSPACE_FILES)) {
+    const filePath = join(workspacePath, fileName);
+    const content = files[fileName] ?? generateTemplate(fileName);
+    let exists = true;
+    try {
+      await access(filePath, constants.F_OK);
+    } catch {
+      exists = false;
+    }
+
+    if (!exists) {
+      await writeFile(filePath, content, {
+        encoding: "utf-8",
+        flag: "wx",
+      });
+      created.push(fileName);
+      continue;
+    }
+
+    if (!options.overwrite) {
+      preserved.push(fileName);
+      continue;
+    }
+
+    if (options.backupExisting) {
+      const backupPath = buildWorkspaceBackupPath(filePath);
+      await copyFile(filePath, backupPath);
+      backupPaths.push(backupPath);
+    }
+
+    await writeFile(filePath, content, {
+      encoding: "utf-8",
+    });
+    overwritten.push(fileName);
+  }
+
+  return {
+    created,
+    overwritten,
+    preserved,
+    backupPaths,
+  };
+}

--- a/runtime/src/onboarding/xai-validation.test.ts
+++ b/runtime/src/onboarding/xai-validation.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_GROK_MODEL } from "../gateway/llm-provider-manager.js";
+import { validateXaiApiKey } from "./xai-validation.js";
+
+describe("xAI onboarding validation", () => {
+  it("normalizes known Grok models from the xAI models response", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "grok-4-fast-reasoning" }, { id: "unknown-model" }],
+      }),
+    })) as unknown as typeof fetch;
+
+    const result = await validateXaiApiKey({
+      apiKey: "xai-test-key",
+      fetchImpl,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.availableModels).toContain("grok-4-1-fast-reasoning");
+    expect(result.availableModels).not.toContain("unknown-model");
+  });
+
+  it("falls back to the default model when no known chat models are returned", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "unknown-model" }],
+      }),
+    })) as unknown as typeof fetch;
+
+    const result = await validateXaiApiKey({
+      apiKey: "xai-test-key",
+      fetchImpl,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.availableModels).toEqual([DEFAULT_GROK_MODEL]);
+  });
+
+  it("returns a clear auth error when xAI rejects the API key", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 401,
+    })) as unknown as typeof fetch;
+
+    const result = await validateXaiApiKey({
+      apiKey: "bad-key",
+      fetchImpl,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("rejected");
+  });
+});

--- a/runtime/src/onboarding/xai-validation.ts
+++ b/runtime/src/onboarding/xai-validation.ts
@@ -1,0 +1,118 @@
+import { listKnownGrokModels, normalizeGrokModel } from "../gateway/context-window.js";
+import { DEFAULT_GROK_MODEL } from "../gateway/llm-provider-manager.js";
+import type { XaiValidationResult } from "./types.js";
+
+const DEFAULT_XAI_BASE_URL = "https://api.x.ai/v1";
+const VALIDATION_TIMEOUT_MS = 8_000;
+
+function normalizeBaseUrl(baseUrl: string | undefined): string {
+  const raw = baseUrl?.trim() || DEFAULT_XAI_BASE_URL;
+  return raw.replace(/\/+$/, "");
+}
+
+function extractModelIds(payload: unknown): string[] {
+  if (typeof payload !== "object" || payload === null) {
+    return [];
+  }
+  const record = payload as Record<string, unknown>;
+  const candidates = [record.data, record.models, record.items, record.results];
+  const collected = new Set<string>();
+
+  for (const candidate of candidates) {
+    if (!Array.isArray(candidate)) continue;
+    for (const entry of candidate) {
+      if (typeof entry === "string" && entry.trim().length > 0) {
+        collected.add(entry.trim());
+        continue;
+      }
+      if (typeof entry !== "object" || entry === null) continue;
+      const value = entry as Record<string, unknown>;
+      const id =
+        typeof value.id === "string"
+          ? value.id
+          : typeof value.name === "string"
+            ? value.name
+            : typeof value.model === "string"
+              ? value.model
+              : undefined;
+      if (id && id.trim().length > 0) {
+        collected.add(id.trim());
+      }
+    }
+  }
+
+  return [...collected];
+}
+
+export async function validateXaiApiKey(options: {
+  apiKey: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<XaiValidationResult> {
+  const apiKey = options.apiKey.trim();
+  if (apiKey.length === 0) {
+    return {
+      ok: false,
+      message: "xAI API key cannot be empty.",
+      availableModels: [],
+    };
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), VALIDATION_TIMEOUT_MS);
+
+  try {
+    const response = await fetchImpl(`${normalizeBaseUrl(options.baseUrl)}/models`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json",
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const message =
+        response.status === 401 || response.status === 403
+          ? "xAI rejected the API key. Double-check it and try again."
+          : `xAI returned HTTP ${response.status} during validation.`;
+      return {
+        ok: false,
+        message,
+        availableModels: [],
+      };
+    }
+
+    const payload = (await response.json()) as unknown;
+    const knownChatModels = new Set(
+      listKnownGrokModels()
+        .filter((entry) => entry.contextWindowTokens > 0)
+        .map((entry) => entry.id),
+    );
+    const availableModels = extractModelIds(payload)
+      .map((value) => normalizeGrokModel(value) ?? value)
+      .filter((value, index, array) => array.indexOf(value) === index)
+      .filter((value) => knownChatModels.has(value));
+
+    return {
+      ok: true,
+      message: "xAI credentials validated.",
+      availableModels:
+        availableModels.length > 0
+          ? availableModels
+          : [DEFAULT_GROK_MODEL],
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      message:
+        error instanceof Error && error.name === "AbortError"
+          ? "xAI validation timed out. Check your network and try again."
+          : `Unable to reach xAI: ${error instanceof Error ? error.message : String(error)}`,
+      availableModels: [],
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}


### PR DESCRIPTION
## Summary
- route `agenc onboard` through an interactive terminal wizard for real TTY sessions
- generate curated workspace markdown files during onboarding and wire onboard output through reusable execution paths
- respect the configured wallet path during health/onboard checks and fix narrow-terminal onboarding frame rendering

## Why
`agenc onboard` is supposed to be the canonical first-run path, but the shipped runtime still behaved like a structured JSON command unless users knew the internals. This PR makes onboarding feel like a real first-run product surface and fixes the terminal rendering issue that caused the onboarding frame to wrap and misalign in narrower panes.

## Test plan
- [x] `npx vitest run src/onboarding/profile.test.ts src/onboarding/tui.test.ts src/onboarding/xai-validation.test.ts src/cli/index.test.ts src/cli/onboard.test.ts src/cli/health.test.ts`
- [x] `npm run build`
- [x] manual check: `agenc onboard --force` renders the TUI instead of JSON in a real TTY
- [x] manual check: `agenc onboard --force` in a 60-column PTY keeps the frame inside the terminal width

## Notes
- the local generated tarball `runtime/tetsuo-ai-runtime-0.1.0.tgz` was intentionally left out of the commit.
- `packages/agenc/README.md` and `docs/architecture/product-contract.md` were updated to describe the onboarding contract users now get.