### PR TITLE
fix(onboarding): remove boxed tui layout

### DIFF
--- a/runtime/src/onboarding/tui.test.ts
+++ b/runtime/src/onboarding/tui.test.ts
@@ -62,7 +62,10 @@ describe("interactive onboarding gating", () => {
 
     expect(visibleLines.length).toBeGreaterThan(4);
     expect(visibleLines.every((line) => line.length <= 60)).toBe(true);
-    expect(visibleLines[0]).toMatch(/^\+-+\+$/u);
-    expect(visibleLines.at(-1)).toMatch(/^\+-+\+$/u);
+    expect(visibleLines.some((line) => line.includes("+---"))).toBe(false);
+    expect(visibleLines.some((line) => line.includes("|"))).toBe(false);
+    expect(visibleLines[0].trim()).toBe("AgenC Onboard");
+    expect(visibleLines[1].trim()).toBe("[#-----------------] 1/17");
+    expect(visibleLines.at(-1)?.trim()).toBe("Enter begin  Ctrl+C cancel");
   });
 });

--- a/runtime/src/onboarding/tui.ts
+++ b/runtime/src/onboarding/tui.ts
@@ -156,46 +156,35 @@ function humanizeBoolean(value: boolean): string {
 
 function resolveFrameInnerWidth(columns?: number): number {
   const safeColumns = columns ?? 100;
-  return Math.min(88, Math.max(10, safeColumns - 2));
+  return Math.min(88, Math.max(24, safeColumns));
 }
 
 export function buildFrameText(params: FrameRenderParams): string {
-  const innerWidth = resolveFrameInnerWidth(params.columns);
-  const bodyWidth = innerWidth - 4;
-  const header = centerText("AgenC Onboard", bodyWidth);
+  const lineWidth = resolveFrameInnerWidth(params.columns);
+  const header = centerText("AgenC Onboard", lineWidth);
   const progress = centerText(
     buildProgressBar(params.step, params.totalSteps),
-    bodyWidth,
+    lineWidth,
   );
   const subtitleLines = params.subtitle
-    ? wrapText(params.subtitle, bodyWidth)
+    ? wrapText(params.subtitle, lineWidth)
     : [];
-  const bodyLines = params.body.flatMap((line) => wrapText(line, bodyWidth));
-  const footerLine = params.footer ? padRight(params.footer, bodyWidth) : "";
+  const bodyLines = params.body.flatMap((line) => wrapText(line, lineWidth));
+  const footerLine = params.footer
+    ? padRight(params.footer, lineWidth)
+    : padRight("Enter continue  Esc back  Ctrl+C cancel", lineWidth);
+  const tone = params.statusTone ? COLOR[params.statusTone] : COLOR.ink;
   const lines = [
-    `${COLOR.border}+${"-".repeat(innerWidth - 2)}+${COLOR.reset}`,
-    `${COLOR.border}|${COLOR.reset}${COLOR.magenta}${COLOR.bold}${header}${COLOR.reset}${COLOR.border}|${COLOR.reset}`,
-    `${COLOR.border}|${COLOR.reset}${COLOR.fog}${progress}${COLOR.reset}${COLOR.border}|${COLOR.reset}`,
-    `${COLOR.border}|${" ".repeat(innerWidth - 2)}|${COLOR.reset}`,
-    ...subtitleLines.map(
-      (line) =>
-        `${COLOR.border}|${COLOR.reset}${COLOR.softInk}${padRight(line, bodyWidth)}${COLOR.reset}${COLOR.border}|${COLOR.reset}`,
-    ),
-    ...(subtitleLines.length > 0
-      ? [`${COLOR.border}|${" ".repeat(innerWidth - 2)}|${COLOR.reset}`]
-      : []),
-    `${COLOR.border}|${COLOR.reset}${COLOR.ink}${COLOR.bold}${padRight(params.title, bodyWidth)}${COLOR.reset}${COLOR.border}|${COLOR.reset}`,
-    `${COLOR.border}|${" ".repeat(innerWidth - 2)}|${COLOR.reset}`,
-    ...bodyLines.map((line) => {
-      const tone = params.statusTone ? COLOR[params.statusTone] : COLOR.ink;
-      return `${COLOR.border}|${COLOR.reset}${tone}${padRight(line, bodyWidth)}${COLOR.reset}${COLOR.border}|${COLOR.reset}`;
-    }),
-    `${COLOR.border}|${" ".repeat(innerWidth - 2)}|${COLOR.reset}`,
-    `${COLOR.border}|${COLOR.reset}${COLOR.fog}${padRight(
-      footerLine || "Enter continue  Esc back  Ctrl+C cancel",
-      bodyWidth,
-    )}${COLOR.reset}${COLOR.border}|${COLOR.reset}`,
-    `${COLOR.border}+${"-".repeat(innerWidth - 2)}+${COLOR.reset}`,
+    `${COLOR.magenta}${COLOR.bold}${header}${COLOR.reset}`,
+    `${COLOR.fog}${progress}${COLOR.reset}`,
+    "",
+    ...subtitleLines.map((line) => `${COLOR.softInk}${padRight(line, lineWidth)}${COLOR.reset}`),
+    ...(subtitleLines.length > 0 ? [""] : []),
+    `${COLOR.ink}${COLOR.bold}${padRight(params.title, lineWidth)}${COLOR.reset}`,
+    "",
+    ...bodyLines.map((line) => `${tone}${padRight(line, lineWidth)}${COLOR.reset}`),
+    "",
+    `${COLOR.fog}${footerLine}${COLOR.reset}`,
   ];
 
   return lines.join("\n");


### PR DESCRIPTION
## Summary
- remove the bordered onboarding frame and switch the TUI to a plain text layout
- keep the onboarding content wrapping within terminal width without drawing jagged frame edges
- update the onboarding TUI regression test to assert the no-box rendering contract

## Why
The first follow-up fix stopped hard overflow, but the framed renderer still looked visually broken because the box treatment was too brittle across terminal sizes. Removing the box entirely produces a cleaner, more stable first-run experience.

## Test plan
- [x] `npx vitest run src/onboarding/tui.test.ts src/cli/index.test.ts src/cli/onboard.test.ts`
- [x] `npm run build`
- [x] manual check: `stty cols 60 rows 24; agenc onboard --force` renders cleanly without any box characters

## Notes
- the local generated tarball `runtime/tetsuo-ai-runtime-0.1.0.tgz` was intentionally excluded from the commit.