### PR TITLE
fix(runtime): add marketplace smoke coverage

### DIFF
--- a/runtime/src/cli/wizard.test.ts
+++ b/runtime/src/cli/wizard.test.ts
@@ -22,6 +22,7 @@ import {
 } from "./wizard.js";
 import type { GatewayConfig } from "../gateway/types.js";
 import { createContextCapture } from "./test-utils.js";
+import { validateGatewayConfig } from "../gateway/config-watcher.js";
 
 function baseOptions(): Omit<WizardOptions, "configPath" | "force"> {
   return {
@@ -63,6 +64,35 @@ describe("wizard: generateDefaultConfig", () => {
     });
     expect(config.llm?.provider).toBe("grok");
     expect(config.llm?.apiKey).toBe("test-key");
+  });
+
+  it("preserves marketplace and optional runtime overrides in generated config", () => {
+    const config = generateDefaultConfig({
+      marketplace: {
+        enabled: true,
+        defaultMatchingPolicy: "weighted_score",
+        authorizedSelectorIds: ["selector-1"],
+      },
+      voice: {
+        enabled: true,
+      },
+      telemetry: {
+        enabled: true,
+      },
+      mcp: {
+        servers: [],
+      },
+    });
+
+    expect(config.marketplace).toEqual({
+      enabled: true,
+      defaultMatchingPolicy: "weighted_score",
+      authorizedSelectorIds: ["selector-1"],
+    });
+    expect(config.voice).toEqual({ enabled: true });
+    expect(config.telemetry).toEqual({ enabled: true });
+    expect(config.mcp).toEqual({ servers: [] });
+    expect(validateGatewayConfig(config).valid).toBe(true);
   });
 });
 

--- a/runtime/src/cli/wizard.ts
+++ b/runtime/src/cli/wizard.ts
@@ -128,8 +128,11 @@ export function generateDefaultConfig(
   if (overrides.plugins) result.plugins = overrides.plugins;
   if (overrides.policy) result.policy = overrides.policy;
   if (overrides.auth) result.auth = overrides.auth;
+  if (overrides.voice) result.voice = overrides.voice;
+  if (overrides.telemetry) result.telemetry = overrides.telemetry;
   if (overrides.workspace) result.workspace = overrides.workspace;
   if (overrides.desktop) result.desktop = overrides.desktop;
+  if (overrides.mcp) result.mcp = overrides.mcp;
   if (overrides.approvals) result.approvals = overrides.approvals;
   if (overrides.marketplace) result.marketplace = overrides.marketplace;
   if (overrides.social) result.social = overrides.social;

--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -69,6 +69,10 @@ vi.mock("./config-watcher.js", () => ({
   getDefaultConfigPath: vi.fn(() => "/tmp/config.json"),
 }));
 
+vi.mock("./wallet-loader.js", () => ({
+  loadWallet: vi.fn(async () => null),
+}));
+
 vi.mock("../desktop/manager.js", () => ({
   DesktopSandboxManager: vi.fn(class DesktopSandboxManager {
     start = mockDesktopManagerStart;
@@ -123,12 +127,16 @@ import type { PidFileInfo } from "./daemon.js";
 import { buildDesktopContext, buildSystemPrompt } from "./system-prompt-builder.js";
 import { LLMTimeoutError, LLMAuthenticationError } from "../llm/errors.js";
 import { loadGatewayConfig } from "./config-watcher.js";
+import { loadWallet } from "./wallet-loader.js";
 import { WorkspaceValidationError } from "./workspace.js";
 import { ToolRouter } from "./tool-routing.js";
+import { createSessionToolHandler } from "./tool-handler-factory.js";
 import type { ToolCallRecord } from "../llm/chat-executor.js";
 import type { ChatExecutorResult } from "../llm/chat-executor.js";
 import { didToolCallFail } from "../llm/chat-executor-tool-utils.js";
 import { resolveToolContractExecutionBlock } from "../llm/chat-executor-contract-guidance.js";
+import { PolicyEngine } from "../policy/engine.js";
+import { createPolicyGateHook } from "../policy/policy-gate.js";
 import { SESSION_ALLOWED_ROOTS_ARG } from "../tools/system/filesystem.js";
 import {
   SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY,
@@ -3076,6 +3084,219 @@ describe("DaemonManager", () => {
 
     expect(marketplaceResult).toContain("Marketplace not enabled");
     expect(socialResult).toContain("Social module not enabled");
+  });
+
+  it("uses live marketplace tools after the marketplace subsystem is wired", async () => {
+    const dm = new DaemonManager({ configPath: "/tmp/config.json" });
+    await (dm as any).wireMarketplace({ marketplace: { enabled: true } });
+
+    const registry = await (dm as any).createToolRegistry({
+      desktop: { enabled: false },
+      marketplace: { enabled: true },
+    });
+
+    const toolHandler = registry.createToolHandler();
+    const createResult = await toolHandler("marketplace.createService", {
+      serviceId: "svc-live-1",
+      title: "Monitor DeFi positions",
+      description: "Watch positions and send a daily report.",
+      budget: "1000",
+      requiredCapabilities: "1",
+      deliverables: ["daily report"],
+    });
+    const created = JSON.parse(createResult) as {
+      serviceId: string;
+      status: string;
+      requesterId: string;
+    };
+
+    expect(created.serviceId).toBe("svc-live-1");
+    expect(created.status).toBe("open");
+    expect(created.requesterId).toEqual(expect.any(String));
+    expect(created.requesterId.length).toBeGreaterThan(0);
+
+    const listResult = await toolHandler("marketplace.listServices", {});
+    const listed = JSON.parse(listResult) as {
+      count: number;
+      services: Array<{ serviceId: string; status: string }>;
+    };
+
+    expect(listed.count).toBe(1);
+    expect(listed.services).toEqual([
+      expect.objectContaining({
+        serviceId: "svc-live-1",
+        status: "open",
+      }),
+    ]);
+  });
+
+  it("starts with marketplace enabled config and allows separate agents to participate through tool registries", async () => {
+    vi.mocked(loadGatewayConfig).mockResolvedValueOnce({
+      gateway: { port: 9000 },
+      agent: { name: "marketplace-smoke" },
+      connection: { rpcUrl: "http://localhost:8899" },
+      marketplace: {
+        enabled: true,
+        defaultMatchingPolicy: "weighted_score",
+      },
+    } as any);
+
+    const pidPath = join(tempDir, "marketplace-smoke.pid");
+    const dm = new DaemonManager({ configPath: "/tmp/config.json", pidPath });
+    vi.spyOn(dm, "setupSignalHandlers").mockImplementation(() => {});
+
+    await dm.start();
+
+    expect(dm.marketplace).not.toBeNull();
+
+    vi.mocked(loadWallet).mockResolvedValueOnce(null);
+    const requesterRegistry = await (dm as any).createToolRegistry({
+      desktop: { enabled: false },
+      marketplace: { enabled: true },
+    });
+
+    vi.mocked(loadWallet).mockResolvedValueOnce({
+      agentId: Uint8Array.from([1, 2, 3, 4]),
+    });
+    const bidderRegistry = await (dm as any).createToolRegistry({
+      desktop: { enabled: false },
+      marketplace: { enabled: true },
+    });
+
+    const requesterTools = requesterRegistry.createToolHandler();
+    const bidderTools = bidderRegistry.createToolHandler();
+
+    const createResult = await requesterTools("marketplace.createService", {
+      serviceId: "svc-smoke-1",
+      title: "Smoke test service",
+      description: "Validate daemon startup marketplace participation.",
+      budget: "1000",
+      requiredCapabilities: "1",
+      deliverables: ["smoke-test report"],
+    });
+    const created = JSON.parse(createResult) as {
+      serviceId: string;
+      requesterId: string;
+      status: string;
+    };
+
+    expect(created.serviceId).toBe("svc-smoke-1");
+    expect(created.requesterId).toBe("gateway-agent");
+    expect(created.status).toBe("open");
+
+    const bidResult = await bidderTools("marketplace.bidOnService", {
+      serviceId: "svc-smoke-1",
+      price: "900",
+      deliveryTime: 1800,
+      proposal: "I can deliver this smoke validation quickly.",
+    });
+    const bid = JSON.parse(bidResult) as {
+      bidId: string;
+      bidderId: string;
+      taskId: string;
+      rewardLamports: string;
+      etaSeconds: number;
+      status: string;
+    };
+
+    expect(bid.taskId).toBe("svc-smoke-1");
+    expect(bid.bidderId).toBe("01020304");
+    expect(bid.rewardLamports).toBe("900");
+    expect(bid.etaSeconds).toBe(1800);
+    expect(bid.status).toBe("active");
+
+    const bidsResult = await bidderTools("marketplace.listBids", {
+      serviceId: "svc-smoke-1",
+    });
+    const bids = JSON.parse(bidsResult) as {
+      serviceId: string;
+      count: number;
+      bids: Array<{ bidId: string; bidderId: string; status: string }>;
+    };
+
+    expect(bids.serviceId).toBe("svc-smoke-1");
+    expect(bids.count).toBe(1);
+    expect(bids.bids).toEqual([
+      expect.objectContaining({
+        bidId: bid.bidId,
+        bidderId: "01020304",
+        status: "active",
+      }),
+    ]);
+
+    await dm.stop();
+  });
+
+  it("keeps marketplace read-only when safe mode is active", async () => {
+    const dm = new DaemonManager({ configPath: "/tmp/config.json" });
+    await (dm as any).wireMarketplace({ marketplace: { enabled: true } });
+
+    const registry = await (dm as any).createToolRegistry({
+      desktop: { enabled: false },
+      marketplace: { enabled: true },
+    });
+
+    const hooks = new HookDispatcher();
+    const policyEngine = new PolicyEngine({
+      policy: { enabled: true },
+    });
+    hooks.on(
+      createPolicyGateHook({
+        engine: policyEngine,
+        logger: (dm as any).logger,
+      }),
+    );
+
+    const send = vi.fn();
+    const toolHandler = createSessionToolHandler({
+      sessionId: "session-marketplace",
+      baseHandler: registry.createToolHandler(),
+      routerId: "router-marketplace",
+      send,
+      hooks,
+    });
+
+    const seedResult = await toolHandler("marketplace.createService", {
+      serviceId: "svc-safe-1",
+      title: "Seed service",
+      description: "Create a service before safe mode is enabled.",
+      budget: "1000",
+      requiredCapabilities: "1",
+      deliverables: ["daily report"],
+    });
+    expect(JSON.parse(seedResult)).toEqual(
+      expect.objectContaining({
+        serviceId: "svc-safe-1",
+        status: "open",
+      }),
+    );
+
+    policyEngine.setMode("safe_mode", "manual-test");
+
+    const blockedWrite = await toolHandler("marketplace.createService", {
+      serviceId: "svc-safe-2",
+      title: "Blocked service",
+      description: "This write should be blocked by safe mode.",
+      budget: "1000",
+      requiredCapabilities: "1",
+      deliverables: ["daily report"],
+    });
+    expect(JSON.parse(blockedWrite)).toEqual({
+      error:
+        'Policy blocked tool "marketplace.createService": Safe mode blocks write actions',
+    });
+
+    const allowedRead = await toolHandler("marketplace.listServices", {});
+    const listed = JSON.parse(allowedRead) as {
+      count: number;
+      services: Array<{ serviceId: string }>;
+    };
+
+    expect(listed.count).toBe(1);
+    expect(listed.services).toEqual([
+      expect.objectContaining({ serviceId: "svc-safe-1" }),
+    ]);
+    expect(send).toHaveBeenCalled();
   });
 
   it("auto-creates missing default workspace for sub-agent isolation", async () => {


### PR DESCRIPTION
## Summary
- preserve optional gateway overrides that should survive wizard config generation, including voice, telemetry, and mcp alongside marketplace coverage
- add runtime marketplace smoke coverage for live create service, bid, and list flows across separate tool registries
- verify marketplace stays read-only when safe mode is active

## Validation
- npm --prefix /Users/pchmirenko/agenc-core-marketplace-smoke/runtime run test -- src/cli/wizard.test.ts
- npm --prefix /Users/pchmirenko/agenc-core-marketplace-smoke/runtime run test -- src/gateway/daemon.test.ts -t marketplace

## Context
- follow-up for the remaining marketplace runtime validation gap tracked in agenc-core#8