### PR TITLE
fix(marketplace): restore bid settlement tooling

### DIFF
--- a/runtime/src/task/pda.test.ts
+++ b/runtime/src/task/pda.test.ts
@@ -8,6 +8,12 @@ import {
   findClaimPda,
   deriveEscrowPda,
   findEscrowPda,
+  deriveBidBookPda,
+  findBidBookPda,
+  deriveBidPda,
+  findBidPda,
+  deriveBidderMarketStatePda,
+  findBidderMarketStatePda,
   TASK_ID_LENGTH,
   type PdaWithBump,
 } from "./pda.js";
@@ -229,6 +235,83 @@ describe("Task PDA derivation helpers", () => {
     });
   });
 
+  describe("deriveBidBookPda", () => {
+    it("derives deterministic PDA from taskPda", () => {
+      const taskPda = Keypair.generate().publicKey;
+
+      const result1 = deriveBidBookPda(taskPda);
+      const result2 = deriveBidBookPda(taskPda);
+
+      expect(result1.address.equals(result2.address)).toBe(true);
+      expect(result1.bump).toBe(result2.bump);
+    });
+
+    it("uses correct seeds", () => {
+      const taskPda = Keypair.generate().publicKey;
+
+      const result = deriveBidBookPda(taskPda);
+      const [expected, expectedBump] = PublicKey.findProgramAddressSync(
+        [Buffer.from("bid_book"), taskPda.toBuffer()],
+        PROGRAM_ID,
+      );
+
+      expect(result.address.equals(expected)).toBe(true);
+      expect(result.bump).toBe(expectedBump);
+    });
+  });
+
+  describe("deriveBidPda", () => {
+    it("derives deterministic PDA from taskPda + bidderAgentPda", () => {
+      const taskPda = Keypair.generate().publicKey;
+      const bidderAgentPda = Keypair.generate().publicKey;
+
+      const result1 = deriveBidPda(taskPda, bidderAgentPda);
+      const result2 = deriveBidPda(taskPda, bidderAgentPda);
+
+      expect(result1.address.equals(result2.address)).toBe(true);
+      expect(result1.bump).toBe(result2.bump);
+    });
+
+    it("uses correct seeds", () => {
+      const taskPda = Keypair.generate().publicKey;
+      const bidderAgentPda = Keypair.generate().publicKey;
+
+      const result = deriveBidPda(taskPda, bidderAgentPda);
+      const [expected, expectedBump] = PublicKey.findProgramAddressSync(
+        [Buffer.from("bid"), taskPda.toBuffer(), bidderAgentPda.toBuffer()],
+        PROGRAM_ID,
+      );
+
+      expect(result.address.equals(expected)).toBe(true);
+      expect(result.bump).toBe(expectedBump);
+    });
+  });
+
+  describe("deriveBidderMarketStatePda", () => {
+    it("derives deterministic PDA from bidderAgentPda", () => {
+      const bidderAgentPda = Keypair.generate().publicKey;
+
+      const result1 = deriveBidderMarketStatePda(bidderAgentPda);
+      const result2 = deriveBidderMarketStatePda(bidderAgentPda);
+
+      expect(result1.address.equals(result2.address)).toBe(true);
+      expect(result1.bump).toBe(result2.bump);
+    });
+
+    it("uses correct seeds", () => {
+      const bidderAgentPda = Keypair.generate().publicKey;
+
+      const result = deriveBidderMarketStatePda(bidderAgentPda);
+      const [expected, expectedBump] = PublicKey.findProgramAddressSync(
+        [Buffer.from("bidder_market"), bidderAgentPda.toBuffer()],
+        PROGRAM_ID,
+      );
+
+      expect(result.address.equals(expected)).toBe(true);
+      expect(result.bump).toBe(expectedBump);
+    });
+  });
+
   describe("findTaskPda", () => {
     it("returns address only (no bump)", () => {
       const creator = Keypair.generate().publicKey;
@@ -309,6 +392,40 @@ describe("Task PDA derivation helpers", () => {
 
       const address = findEscrowPda(taskPda);
       const { address: derivedAddress } = deriveEscrowPda(taskPda);
+
+      expect(address.equals(derivedAddress)).toBe(true);
+    });
+  });
+
+  describe("findBidBookPda", () => {
+    it("matches deriveBidBookPda().address", () => {
+      const taskPda = Keypair.generate().publicKey;
+
+      const address = findBidBookPda(taskPda);
+      const { address: derivedAddress } = deriveBidBookPda(taskPda);
+
+      expect(address.equals(derivedAddress)).toBe(true);
+    });
+  });
+
+  describe("findBidPda", () => {
+    it("matches deriveBidPda().address", () => {
+      const taskPda = Keypair.generate().publicKey;
+      const bidderAgentPda = Keypair.generate().publicKey;
+
+      const address = findBidPda(taskPda, bidderAgentPda);
+      const { address: derivedAddress } = deriveBidPda(taskPda, bidderAgentPda);
+
+      expect(address.equals(derivedAddress)).toBe(true);
+    });
+  });
+
+  describe("findBidderMarketStatePda", () => {
+    it("matches deriveBidderMarketStatePda().address", () => {
+      const bidderAgentPda = Keypair.generate().publicKey;
+
+      const address = findBidderMarketStatePda(bidderAgentPda);
+      const { address: derivedAddress } = deriveBidderMarketStatePda(bidderAgentPda);
 
       expect(address.equals(derivedAddress)).toBe(true);
     });

--- a/runtime/src/task/pda.ts
+++ b/runtime/src/task/pda.ts
@@ -156,3 +156,100 @@ export function findEscrowPda(
 ): PublicKey {
   return deriveEscrowPda(taskPda, programId).address;
 }
+
+/**
+ * Derives the bid book PDA and bump seed.
+ * Seeds: ["bid_book", task_pda]
+ *
+ * @param taskPda - Task account PDA
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address and bump seed
+ */
+export function deriveBidBookPda(
+  taskPda: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): PdaWithBump {
+  return derivePda([Buffer.from("bid_book"), taskPda.toBuffer()], programId);
+}
+
+/**
+ * Finds the bid book PDA address (without bump).
+ *
+ * @param taskPda - Task account PDA
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address
+ */
+export function findBidBookPda(
+  taskPda: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): PublicKey {
+  return deriveBidBookPda(taskPda, programId).address;
+}
+
+/**
+ * Derives the bid PDA and bump seed.
+ * Seeds: ["bid", task_pda, bidder_agent_pda]
+ *
+ * @param taskPda - Task account PDA
+ * @param bidderAgentPda - Bidder agent PDA
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address and bump seed
+ */
+export function deriveBidPda(
+  taskPda: PublicKey,
+  bidderAgentPda: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): PdaWithBump {
+  return derivePda(
+    [Buffer.from("bid"), taskPda.toBuffer(), bidderAgentPda.toBuffer()],
+    programId,
+  );
+}
+
+/**
+ * Finds the bid PDA address (without bump).
+ *
+ * @param taskPda - Task account PDA
+ * @param bidderAgentPda - Bidder agent PDA
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address
+ */
+export function findBidPda(
+  taskPda: PublicKey,
+  bidderAgentPda: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): PublicKey {
+  return deriveBidPda(taskPda, bidderAgentPda, programId).address;
+}
+
+/**
+ * Derives the bidder marketplace state PDA and bump seed.
+ * Seeds: ["bidder_market", bidder_agent_pda]
+ *
+ * @param bidderAgentPda - Bidder agent PDA
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address and bump seed
+ */
+export function deriveBidderMarketStatePda(
+  bidderAgentPda: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): PdaWithBump {
+  return derivePda(
+    [Buffer.from("bidder_market"), bidderAgentPda.toBuffer()],
+    programId,
+  );
+}
+
+/**
+ * Finds the bidder marketplace state PDA address (without bump).
+ *
+ * @param bidderAgentPda - Bidder agent PDA
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address
+ */
+export function findBidderMarketStatePda(
+  bidderAgentPda: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): PublicKey {
+  return deriveBidderMarketStatePda(bidderAgentPda, programId).address;
+}

--- a/runtime/src/tools/agenc/agenc-tools.test.ts
+++ b/runtime/src/tools/agenc/agenc-tools.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { PublicKey } from '@solana/web3.js';
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  getAssociatedTokenAddressSync,
+  TOKEN_PROGRAM_ID,
+} from '@tetsuo-ai/sdk';
 import { createAgencTools } from './index.js';
 import {
   createListTasksTool,
@@ -530,6 +535,34 @@ describe('agenc.createTask', () => {
 
     expect(result.isError).toBe(true);
     expect(JSON.parse(result.content).error).toContain('Unsupported rewardMint');
+  });
+
+  it('wires SPL reward accounts for known reward mints', async () => {
+    const mockProgram = createMockProgram();
+    const tool = createCreateTaskTool(mockProgram as never, silentLogger);
+
+    const result = await tool.execute({
+      description: 'usdc task',
+      reward: '1000000',
+      requiredCapabilities: '1',
+      rewardMint: USDC_MINT.toBase58(),
+    });
+    const parsed = JSON.parse(result.content);
+    const accounts = mockProgram._createTaskMethodChain.accountsPartial.mock.calls[0][0];
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed.rewardMint).toBe(USDC_MINT.toBase58());
+    expect(accounts.rewardMint.equals(USDC_MINT)).toBe(true);
+    expect(accounts.creatorTokenAccount.equals(getAssociatedTokenAddressSync(USDC_MINT, SIGNER))).toBe(
+      true,
+    );
+    expect(
+      accounts.tokenEscrowAta.equals(
+        getAssociatedTokenAddressSync(USDC_MINT, accounts.escrow, true),
+      ),
+    ).toBe(true);
+    expect(accounts.tokenProgram.equals(TOKEN_PROGRAM_ID)).toBe(true);
+    expect(accounts.associatedTokenProgram.equals(ASSOCIATED_TOKEN_PROGRAM_ID)).toBe(true);
   });
 
   it('proceeds to RPC without pre-checking protocol config (on-chain validation)', async () => {

--- a/runtime/src/tools/agenc/mutation-tools.test.ts
+++ b/runtime/src/tools/agenc/mutation-tools.test.ts
@@ -2,11 +2,17 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { PublicKey } from '@solana/web3.js';
 import type { ToolResult } from '../types.js';
 import { silentLogger } from '../../utils/logger.js';
+import { TaskType } from '../../events/types.js';
 import { ProposalType } from '../../governance/types.js';
 import { GovernanceOperations } from '../../governance/operations.js';
 import { DisputeOperations } from '../../dispute/operations.js';
 import { ReputationEconomyOperations } from '../../reputation/economy.js';
 import { TaskOperations } from '../../task/operations.js';
+import {
+  findBidBookPda,
+  findBidPda,
+  findBidderMarketStatePda,
+} from '../../task/pda.js';
 import {
   createClaimTaskTool,
   createCompleteTaskTool,
@@ -148,6 +154,47 @@ describe('agenc mutation tools', () => {
     expect(String(parseJson(result).error)).toContain('proofHash');
   });
 
+  it('agenc.completeTask derives accepted-bid settlement accounts for bid-exclusive tasks', async () => {
+    const program = createMockProgram();
+    vi.spyOn(TaskOperations.prototype, 'fetchTask').mockResolvedValue({
+      creator: CREATOR_WALLET,
+      taskType: TaskType.BidExclusive,
+    } as never);
+    const completeSpy = vi
+      .spyOn(TaskOperations.prototype, 'completeTask')
+      .mockResolvedValue({
+        success: true,
+        taskId: new Uint8Array(32).fill(3),
+        isPrivate: false,
+        transactionSignature: 'complete-sig',
+      });
+
+    const tool = createCompleteTaskTool(program as never, silentLogger);
+    const result = await tool.execute({
+      taskPda: TASK_PDA.toBase58(),
+      proofHash: 'ab'.repeat(32),
+      workerAgentPda: AGENT_PDA.toBase58(),
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(completeSpy).toHaveBeenCalledWith(
+      TASK_PDA,
+      expect.objectContaining({
+        taskType: TaskType.BidExclusive,
+      }),
+      expect.any(Uint8Array),
+      null,
+      {
+        acceptedBidSettlement: {
+          bidBook: findBidBookPda(TASK_PDA, program.programId),
+          acceptedBid: findBidPda(TASK_PDA, AGENT_PDA, program.programId),
+          bidderMarketState: findBidderMarketStatePda(AGENT_PDA, program.programId),
+        },
+        bidderAuthority: SIGNER,
+      },
+    );
+  });
+
   it('agenc.registerSkill returns the derived skill payload on success', async () => {
     const program = createMockProgram();
     const tool = createRegisterSkillTool(program as never, silentLogger);
@@ -273,6 +320,53 @@ describe('agenc mutation tools', () => {
             arbiterAgentPda,
           },
         ],
+      }),
+    );
+  });
+
+  it('agenc.resolveDispute derives accepted-bid settlement accounts for bid-exclusive disputes', async () => {
+    const program = createMockProgram();
+    vi.spyOn(DisputeOperations.prototype, 'fetchDispute').mockResolvedValue({
+      task: TASK_PDA,
+      defendant: DEFENDANT_AGENT_PDA,
+    } as never);
+    vi.spyOn(TaskOperations.prototype, 'fetchTask').mockResolvedValue({
+      creator: CREATOR_WALLET,
+      taskType: TaskType.BidExclusive,
+    } as never);
+    const resolveSpy = vi
+      .spyOn(DisputeOperations.prototype, 'resolveDispute')
+      .mockResolvedValue({
+        disputePda: DISPUTE_PDA,
+        transactionSignature: 'resolve-bid-sig',
+      });
+
+    const tool = createResolveDisputeTool(program as never, silentLogger);
+    const votePda = PublicKey.unique();
+    const arbiterAgentPda = PublicKey.unique();
+    const result = await tool.execute({
+      disputePda: DISPUTE_PDA.toBase58(),
+      arbiterVotes: [
+        {
+          votePda: votePda.toBase58(),
+          arbiterAgentPda: arbiterAgentPda.toBase58(),
+        },
+      ],
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(resolveSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskPda: TASK_PDA,
+        workerAgentPda: DEFENDANT_AGENT_PDA,
+        acceptedBidSettlement: {
+          bidBook: findBidBookPda(TASK_PDA, program.programId),
+          acceptedBid: findBidPda(TASK_PDA, DEFENDANT_AGENT_PDA, program.programId),
+          bidderMarketState: findBidderMarketStatePda(
+            DEFENDANT_AGENT_PDA,
+            program.programId,
+          ),
+        },
       }),
     );
   });

--- a/runtime/src/tools/agenc/mutation-tools.ts
+++ b/runtime/src/tools/agenc/mutation-tools.ts
@@ -19,7 +19,13 @@ import {
   REPUTATION_MAX,
 } from '../../reputation/types.js';
 import { TaskOperations } from '../../task/operations.js';
-import { findClaimPda } from '../../task/pda.js';
+import { TaskType } from '../../events/types.js';
+import {
+  findBidBookPda,
+  findBidPda,
+  findBidderMarketStatePda,
+  findClaimPda,
+} from '../../task/pda.js';
 import type { Logger } from '../../utils/logger.js';
 import { bytesToHex, generateAgentId, hexToBytes } from '../../utils/encoding.js';
 import type { Tool, ToolResult } from '../types.js';
@@ -361,6 +367,18 @@ async function fetchProtocolTreasury(
   }
 }
 
+function deriveAcceptedBidSettlementAccounts(
+  taskPda: PublicKey,
+  bidderAgentPda: PublicKey,
+  programId: PublicKey,
+) {
+  return {
+    bidBook: findBidBookPda(taskPda, programId),
+    acceptedBid: findBidPda(taskPda, bidderAgentPda, programId),
+    bidderMarketState: findBidderMarketStatePda(bidderAgentPda, programId),
+  };
+}
+
 function deriveSkillPda(
   authorAgentPda: PublicKey,
   skillId: Uint8Array,
@@ -579,7 +597,25 @@ export function createCompleteTaskTool(
         const task = await ops.fetchTask(taskPda);
         if (!task) return errorResult(`Task not found: ${taskPda.toBase58()}`);
 
-        const result = await ops.completeTask(taskPda, task, proofHash, resultData);
+        const completionOptions =
+          task.taskType === TaskType.BidExclusive
+            ? {
+                acceptedBidSettlement: deriveAcceptedBidSettlementAccounts(
+                  taskPda,
+                  signerAgent.agentPda,
+                  program.programId,
+                ),
+                bidderAuthority: signerAgent.authority,
+              }
+            : undefined;
+
+        const result = await ops.completeTask(
+          taskPda,
+          task,
+          proofHash,
+          resultData,
+          completionOptions,
+        );
         return {
           content: safeStringify({
             success: result.success,
@@ -1291,6 +1327,15 @@ export function createResolveDisputeTool(
           return workerAuthorityErr ?? errorResult('Unable to resolve defendant worker authority');
         }
 
+        const acceptedBidSettlement =
+          task.taskType === TaskType.BidExclusive
+            ? deriveAcceptedBidSettlementAccounts(
+                dispute.task,
+                dispute.defendant,
+                program.programId,
+              )
+            : undefined;
+
         const result = await ops.resolveDispute({
           disputePda,
           taskPda: dispute.task,
@@ -1300,6 +1345,7 @@ export function createResolveDisputeTool(
           workerAuthority,
           arbiterVotes,
           extraWorkers,
+          acceptedBidSettlement,
         });
 
         return {

--- a/runtime/src/tools/agenc/tools.ts
+++ b/runtime/src/tools/agenc/tools.ts
@@ -33,7 +33,7 @@ import {
 import { parseAgentState, agentStatusToString } from '../../agent/types.js';
 import { getCapabilityNames } from '../../agent/capabilities.js';
 import { parseProtocolConfig } from '../../types/protocol.js';
-// buildCreateTaskTokenAccounts omitted — devnet only supports SOL escrow
+import { buildCreateTaskTokenAccounts } from '../../utils/token.js';
 import {
   lamportsToSol,
   bytesToHex,
@@ -913,6 +913,11 @@ export function createCreateTaskTool(
         const taskPda = findTaskPda(creator, taskId, program.programId);
         const escrowPda = findEscrowPda(taskPda, program.programId);
         const protocolPda = findProtocolPda(program.programId);
+        const tokenAccounts = buildCreateTaskTokenAccounts(
+          rewardMint,
+          escrowPda,
+          creator,
+        );
 
         const txSignature = await (program.methods as any)
           .createTask(
@@ -935,11 +940,7 @@ export function createCreateTaskTool(
             authority: creator,
             creator,
             systemProgram: SystemProgram.programId,
-            rewardMint,
-            creatorTokenAccount: null,
-            tokenEscrowAta: null,
-            tokenProgram: null,
-            associatedTokenProgram: null,
+            ...tokenAccounts,
           })
           .rpc();
 


### PR DESCRIPTION
## Summary
- derive Marketplace V2 bid settlement PDAs in the public `agenc.completeTask` and `agenc.resolveDispute` tool surfaces
- add shared task PDA helpers and regression coverage for the bid-exclusive settlement path
- wire `agenc.createTask` through the shared SPL token-account helper so supported reward mints use the correct token accounts

## Test plan
- `npm test -- --run src/task/pda.test.ts src/tools/agenc/mutation-tools.test.ts src/tools/agenc/agenc-tools.test.ts src/task/operations.test.ts src/dispute/operations.test.ts src/tools/marketplace/tools.test.ts src/marketplace/service-marketplace.test.ts`