### PR TITLE
docs(mcp): rotate devnet program id to 6Uc

### DIFF
--- a/docs/DEPLOYMENT_PLAN.md
+++ b/docs/DEPLOYMENT_PLAN.md
@@ -4,7 +4,7 @@
 
 \## Program ID
 
-5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7
+6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab
 
 text## Upgrade Authority Strategy
 
@@ -34,7 +34,7 @@ text## Upgrade Authority Strategy
 
 1\. `anchor build`
 
-2\. `anchor deploy --provider.cluster devnet --program-id 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7`
+2\. `anchor deploy --provider.cluster devnet --program-id 6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab`
 
 3\. Set upgrade authority if needed: `solana program set-upgrade-authority ...`
 
@@ -54,17 +54,17 @@ text## Upgrade Authority Strategy
 
 6\. Set multisig upgrade authority:
 
-solana program set-upgrade-authority 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7 --new-upgrade-authority <multisig-pubkey>
+solana program set-upgrade-authority 6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab --new-upgrade-authority <multisig-pubkey>
 
 text7. (Optional) Revoke authority for immutability:
 
-solana program set-upgrade-authority 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7 --final
+solana program set-upgrade-authority 6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab --final
 
 
 
 \## Verification Steps
 
-1\. `solana program show 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7` → confirm owner and upgrade authority
+1\. `solana program show 6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab` → confirm owner and upgrade authority
 
 2\. Run integration tests on cluster: `anchor test --skip-local-validator`
 

--- a/docs/DEVNET_VALIDATION.md
+++ b/docs/DEVNET_VALIDATION.md
@@ -3,7 +3,7 @@
 ## Deployment Details
 
 - Cluster: Solana Devnet
-- Program ID: `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7`
+- Program ID: `6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab`
 - Anchor Version: `0.32.1`
 - Commit: `c53771ddbb4097f45c08fe339a924bb348c33aab`
 

--- a/docs/MAINNET_DEPLOYMENT.md
+++ b/docs/MAINNET_DEPLOYMENT.md
@@ -3,7 +3,7 @@
 **Protocol:** AgenC Coordination Protocol
 **Anchor Version:** 0.32.1
 **Solana Version:** 3.0.13
-**Current Program ID:** `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7`
+**Current Program ID:** `6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab`
 
 This document provides step-by-step instructions for deploying the AgenC Coordination Protocol to Solana mainnet-beta.
 
@@ -164,7 +164,7 @@ seeds = true
 skip-lint = false
 
 [programs.localnet]
-agenc_coordination = "5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7"
+agenc_coordination = "6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab"
 
 [provider]
 cluster = "localnet"
@@ -174,7 +174,7 @@ wallet = "~/.config/solana/id.json"
 Add mainnet configuration:
 ```toml
 [programs.mainnet]
-agenc_coordination = "5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7"
+agenc_coordination = "6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab"
 
 [provider]
 cluster = "mainnet"
@@ -746,7 +746,7 @@ Before proceeding to mainnet, obtain sign-off from:
 
 | Account | Address |
 |---------|---------|
-| Program ID | `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7` |
+| Program ID | `6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab` |
 | Protocol PDA | |
 | Treasury | |
 | Upgrade Authority (Multisig) | |

--- a/docs/PRIVACY_README.md
+++ b/docs/PRIVACY_README.md
@@ -53,7 +53,7 @@ Replay is blocked with dual spend records:
 
 ## Contracts
 
-- AgenC Program: `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7`
+- AgenC Program: `6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab`
 - Router Program: `E9ZiqfCdr6gGeB2UhBbkWnFP9vGnRYQwqnDsS1LM3NJZ`
 - Verifier Program: `3ZrAHZKjk24AKgXFekpYeG7v3Rz7NucLXTB3zxGGTjsc`
 - Privacy Cash: `9fhQBbumKEFuXtMBDw8AaQyAjCorLGJQiS3skWZdQyQD`

--- a/docs/SECURITY_AUDIT_DEVNET.md
+++ b/docs/SECURITY_AUDIT_DEVNET.md
@@ -21,7 +21,7 @@ declared on-chain scope; informational notes are listed where applicable.
 - Program: `programs/agenc-coordination`
 - Cluster: Solana Devnet
 - Commit: `c53771ddbb4097f45c08fe339a924bb348c33aab`
-- Program ID: `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7`
+- Program ID: `6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab`
 - Anchor Version: `0.32.1`
 
 ### Explicitly Out of Scope

--- a/docs/SECURITY_AUDIT_MAINNET.md
+++ b/docs/SECURITY_AUDIT_MAINNET.md
@@ -2,7 +2,7 @@
 
 **Document Version:** 1.0
 **Protocol:** AgenC Coordination Protocol
-**Program ID:** `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7`
+**Program ID:** `6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab`
 **Framework:** Anchor (Solana)
 
 ## Scope Boundary

--- a/docs/UPGRADE_GUIDE.md
+++ b/docs/UPGRADE_GUIDE.md
@@ -83,7 +83,7 @@ solana config set --url devnet
 
 # Deploy (upgrade existing program)
 anchor upgrade target/deploy/agenc_coordination.so \
-  --program-id 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7 \
+  --program-id 6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab \
   --provider.cluster devnet
 ```
 
@@ -123,11 +123,11 @@ yarn run smoke-test --cluster devnet
 
 ```bash
 # IMPORTANT: Ensure upgrade authority is multisig
-solana program show 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7
+solana program show 6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab
 
 # Deploy with multisig approval
 anchor upgrade target/deploy/agenc_coordination.so \
-  --program-id 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7 \
+  --program-id 6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab \
   --provider.cluster mainnet
 ```
 
@@ -214,12 +214,12 @@ If bugs are discovered after migration:
 ```bash
 # Option A: Deploy hotfix
 anchor upgrade target/deploy/agenc_coordination_hotfix.so \
-  --program-id 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7
+  --program-id 6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab
 
 # Option B: Roll back program binary
 # Deploy the previous version binary
 anchor upgrade target/deploy/agenc_coordination_v1.so \
-  --program-id 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7
+  --program-id 6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab
 ```
 
 **Important**: Rolling back the binary does NOT roll back account state. The old program must handle the new account format.
@@ -267,7 +267,7 @@ The upgrade authority should be a multisig. Example using Squads Protocol:
 
 ```bash
 # Transfer upgrade authority to multisig
-solana program set-upgrade-authority 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7 \
+solana program set-upgrade-authority 6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab \
   --new-upgrade-authority <SQUADS_MULTISIG_ADDRESS>
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,7 +74,7 @@ Required verification accounts:
 
 | Component | Program ID |
 |-----------|------------|
-| AgenC Coordination | `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7` |
+| AgenC Coordination | `6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab` |
 | Router Program | `E9ZiqfCdr6gGeB2UhBbkWnFP9vGnRYQwqnDsS1LM3NJZ` |
 | Verifier Program | `3ZrAHZKjk24AKgXFekpYeG7v3Rz7NucLXTB3zxGGTjsc` |
 | Privacy Cash | `9fhQBbumKEFuXtMBDw8AaQyAjCorLGJQiS3skWZdQyQD` |

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -352,7 +352,7 @@ ALL required capabilities set to claim a task.
 
 const PDA_SEEDS_REFERENCE = `# AgenC PDA Seeds
 
-All PDAs are derived from the program ID: 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7
+All PDAs are derived from the program ID: 6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab
 
 | Account          | Seeds                              | Notes                       |
 |------------------|------------------------------------|-----------------------------|


### PR DESCRIPTION
## Summary
- rotate stale docs and MCP PDA reference text from `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7` to canonical devnet `6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab`
- keep the change limited to documentation and reference text

## Validation
- searched the branch for stale `5j9...` references after the sweep