### PR TITLE
feat(runtime): add task validation v2 runtime support

### DIFF
--- a/runtime/src/idl.test.ts
+++ b/runtime/src/idl.test.ts
@@ -47,6 +47,10 @@ describe('IDL exports', () => {
     expect(instructionNames).toContain('create_task');
     expect(instructionNames).toContain('claim_task');
     expect(instructionNames).toContain('complete_task');
+    expect(instructionNames).toContain('configure_task_validation');
+    expect(instructionNames).toContain('submit_task_result');
+    expect(instructionNames).toContain('accept_task_result');
+    expect(instructionNames).toContain('reject_task_result');
     expect(instructionNames).toContain('register_agent');
   });
 
@@ -60,11 +64,21 @@ describe('IDL exports', () => {
     expect(accountNames).toContain('AgentRegistration');
     expect(accountNames).toContain('Task');
     expect(accountNames).toContain('ProtocolConfig');
+    expect(accountNames).toContain('TaskValidationConfig');
+    expect(accountNames).toContain('TaskSubmission');
   });
 
   it('has types array', () => {
     expect(Array.isArray(IDL.types)).toBe(true);
     expect(IDL.types.length).toBeGreaterThan(0);
+  });
+
+  it('has task validation V2 type definitions', () => {
+    const typeNames = IDL.types.map((typeDef) => typeDef.name);
+    expect(typeNames).toContain('ValidationMode');
+    expect(typeNames).toContain('SubmissionStatus');
+    expect(typeNames).toContain('TaskValidationConfig');
+    expect(typeNames).toContain('TaskSubmission');
   });
 
   it('has events array', () => {
@@ -131,6 +145,15 @@ describe('createProgram', () => {
     const program = createProgram(provider);
     // Verify methods namespace is accessible
     expect(program.methods).toBeDefined();
+  });
+
+  it('exposes task validation V2 methods through Program.methods', () => {
+    const program = createProgram(provider);
+    const methods = program.methods as Record<string, unknown>;
+    expect(typeof methods.configureTaskValidation).toBe('function');
+    expect(typeof methods.submitTaskResult).toBe('function');
+    expect(typeof methods.acceptTaskResult).toBe('function');
+    expect(typeof methods.rejectTaskResult).toBe('function');
   });
 });
 

--- a/runtime/src/idl.ts
+++ b/runtime/src/idl.ts
@@ -21,6 +21,491 @@ import { PROGRAM_ID } from "@tetsuo-ai/sdk";
 /** Re-export the IDL type for Program<T> generics */
 export type { AgencCoordination };
 
+type NamedIdlEntry = { name: string };
+
+// The published protocol package can lag behind the runtime's supported V2 flow.
+// Merge these entries in locally so Program.methods exposes the creator-review
+// instructions without requiring a package release first.
+const TASK_VALIDATION_V2_INSTRUCTIONS = [
+  {
+    name: "configure_task_validation",
+    docs: ["Enable Task Validation V2 creator review for an open task."],
+    discriminator: [11, 79, 19, 188, 13, 32, 244, 90],
+    accounts: [
+      {
+        name: "task",
+        writable: true,
+        pda: {
+          seeds: [
+            { kind: "const", value: [116, 97, 115, 107] },
+            { kind: "account", path: "task.creator", account: "Task" },
+            { kind: "account", path: "task.task_id", account: "Task" },
+          ],
+        },
+      },
+      {
+        name: "task_validation_config",
+        writable: true,
+        pda: {
+          seeds: [
+            {
+              kind: "const",
+              value: [116, 97, 115, 107, 95, 118, 97, 108, 105, 100, 97, 116, 105, 111, 110],
+            },
+            { kind: "account", path: "task" },
+          ],
+        },
+      },
+      {
+        name: "protocol_config",
+        pda: {
+          seeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108] }],
+        },
+      },
+      { name: "creator", writable: true, signer: true },
+      {
+        name: "system_program",
+        address: "11111111111111111111111111111111",
+      },
+    ],
+    args: [
+      { name: "mode", type: "u8" },
+      { name: "review_window_secs", type: "i64" },
+    ],
+  },
+  {
+    name: "submit_task_result",
+    docs: ["Submit a result for creator review before final settlement."],
+    discriminator: [39, 108, 74, 4, 66, 125, 157, 7],
+    accounts: [
+      {
+        name: "task",
+        writable: true,
+        pda: {
+          seeds: [
+            { kind: "const", value: [116, 97, 115, 107] },
+            { kind: "account", path: "task.creator", account: "Task" },
+            { kind: "account", path: "task.task_id", account: "Task" },
+          ],
+        },
+      },
+      {
+        name: "claim",
+        writable: true,
+        pda: {
+          seeds: [
+            { kind: "const", value: [99, 108, 97, 105, 109] },
+            { kind: "account", path: "task" },
+            { kind: "account", path: "worker" },
+          ],
+        },
+      },
+      {
+        name: "task_validation_config",
+        pda: {
+          seeds: [
+            {
+              kind: "const",
+              value: [116, 97, 115, 107, 95, 118, 97, 108, 105, 100, 97, 116, 105, 111, 110],
+            },
+            { kind: "account", path: "task" },
+          ],
+        },
+      },
+      {
+        name: "task_submission",
+        writable: true,
+        pda: {
+          seeds: [
+            {
+              kind: "const",
+              value: [116, 97, 115, 107, 95, 115, 117, 98, 109, 105, 115, 115, 105, 111, 110],
+            },
+            { kind: "account", path: "claim" },
+          ],
+        },
+      },
+      {
+        name: "protocol_config",
+        pda: {
+          seeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108] }],
+        },
+      },
+      {
+        name: "worker",
+        pda: {
+          seeds: [
+            { kind: "const", value: [97, 103, 101, 110, 116] },
+            {
+              kind: "account",
+              path: "worker.agent_id",
+              account: "AgentRegistration",
+            },
+          ],
+        },
+      },
+      {
+        name: "authority",
+        writable: true,
+        signer: true,
+        relations: ["worker"],
+      },
+      {
+        name: "system_program",
+        address: "11111111111111111111111111111111",
+      },
+    ],
+    args: [
+      { name: "proof_hash", type: { array: ["u8", 32] } },
+      { name: "result_data", type: { option: { array: ["u8", 64] } } },
+    ],
+  },
+  {
+    name: "accept_task_result",
+    docs: ["Accept a creator-reviewed submission and settle rewards."],
+    discriminator: [89, 230, 51, 25, 0, 219, 5, 137],
+    accounts: [
+      {
+        name: "task",
+        writable: true,
+        pda: {
+          seeds: [
+            { kind: "const", value: [116, 97, 115, 107] },
+            { kind: "account", path: "task.creator", account: "Task" },
+            { kind: "account", path: "task.task_id", account: "Task" },
+          ],
+        },
+      },
+      {
+        name: "claim",
+        writable: true,
+        pda: {
+          seeds: [
+            { kind: "const", value: [99, 108, 97, 105, 109] },
+            { kind: "account", path: "task" },
+            { kind: "account", path: "worker" },
+          ],
+        },
+      },
+      {
+        name: "escrow",
+        writable: true,
+        pda: {
+          seeds: [
+            { kind: "const", value: [101, 115, 99, 114, 111, 119] },
+            { kind: "account", path: "task" },
+          ],
+        },
+      },
+      {
+        name: "task_validation_config",
+        pda: {
+          seeds: [
+            {
+              kind: "const",
+              value: [116, 97, 115, 107, 95, 118, 97, 108, 105, 100, 97, 116, 105, 111, 110],
+            },
+            { kind: "account", path: "task" },
+          ],
+        },
+      },
+      {
+        name: "task_submission",
+        writable: true,
+        pda: {
+          seeds: [
+            {
+              kind: "const",
+              value: [116, 97, 115, 107, 95, 115, 117, 98, 109, 105, 115, 115, 105, 111, 110],
+            },
+            { kind: "account", path: "claim" },
+          ],
+        },
+      },
+      {
+        name: "worker",
+        writable: true,
+        pda: {
+          seeds: [
+            { kind: "const", value: [97, 103, 101, 110, 116] },
+            {
+              kind: "account",
+              path: "worker.agent_id",
+              account: "AgentRegistration",
+            },
+          ],
+        },
+      },
+      {
+        name: "protocol_config",
+        writable: true,
+        pda: {
+          seeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108] }],
+        },
+      },
+      { name: "treasury", writable: true },
+      { name: "creator", writable: true },
+      { name: "worker_authority", writable: true },
+      { name: "reviewer", writable: true, signer: true },
+      {
+        name: "system_program",
+        address: "11111111111111111111111111111111",
+      },
+      { name: "token_escrow_ata", writable: true, optional: true },
+      { name: "worker_token_account", writable: true, optional: true },
+      { name: "treasury_token_account", writable: true, optional: true },
+      { name: "reward_mint", optional: true },
+      {
+        name: "token_program",
+        optional: true,
+        address: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+      },
+    ],
+    args: [],
+  },
+  {
+    name: "reject_task_result",
+    docs: [
+      "Reject a creator-reviewed submission and return the task to active work.",
+    ],
+    discriminator: [144, 7, 58, 232, 157, 167, 85, 214],
+    accounts: [
+      {
+        name: "task",
+        writable: true,
+        pda: {
+          seeds: [
+            { kind: "const", value: [116, 97, 115, 107] },
+            { kind: "account", path: "task.creator", account: "Task" },
+            { kind: "account", path: "task.task_id", account: "Task" },
+          ],
+        },
+      },
+      {
+        name: "claim",
+        writable: true,
+        pda: {
+          seeds: [
+            { kind: "const", value: [99, 108, 97, 105, 109] },
+            { kind: "account", path: "task" },
+            { kind: "account", path: "claim.worker", account: "TaskClaim" },
+          ],
+        },
+      },
+      {
+        name: "task_validation_config",
+        pda: {
+          seeds: [
+            {
+              kind: "const",
+              value: [116, 97, 115, 107, 95, 118, 97, 108, 105, 100, 97, 116, 105, 111, 110],
+            },
+            { kind: "account", path: "task" },
+          ],
+        },
+      },
+      {
+        name: "task_submission",
+        writable: true,
+        pda: {
+          seeds: [
+            {
+              kind: "const",
+              value: [116, 97, 115, 107, 95, 115, 117, 98, 109, 105, 115, 115, 105, 111, 110],
+            },
+            { kind: "account", path: "claim" },
+          ],
+        },
+      },
+      {
+        name: "protocol_config",
+        pda: {
+          seeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108] }],
+        },
+      },
+      { name: "creator", writable: true, signer: true },
+    ],
+    args: [{ name: "rejection_hash", type: { array: ["u8", 32] } }],
+  },
+] as const;
+
+const TASK_VALIDATION_V2_ACCOUNTS = [
+  {
+    name: "TaskValidationConfig",
+    discriminator: [101, 204, 19, 0, 210, 2, 191, 0],
+  },
+  {
+    name: "TaskSubmission",
+    discriminator: [111, 64, 190, 132, 148, 33, 215, 63],
+  },
+] as const;
+
+const TASK_VALIDATION_V2_TYPES = [
+  {
+    name: "TaskValidationConfig",
+    docs: [
+      "Task-level validation configuration.",
+      'PDA seeds: ["task_validation", task]',
+    ],
+    type: {
+      kind: "struct",
+      fields: [
+        { name: "task", docs: ["Task this config belongs to."], type: "pubkey" },
+        {
+          name: "creator",
+          docs: ["Task creator / reviewer authority."],
+          type: "pubkey",
+        },
+        {
+          name: "mode",
+          docs: ["Active validation mode."],
+          type: { defined: { name: "ValidationMode" } },
+        },
+        {
+          name: "review_window_secs",
+          docs: [
+            "Review window in seconds before the submission may be escalated off-path.",
+          ],
+          type: "i64",
+        },
+        { name: "created_at", docs: ["Creation timestamp."], type: "i64" },
+        { name: "updated_at", docs: ["Last update timestamp."], type: "i64" },
+        { name: "bump", docs: ["PDA bump."], type: "u8" },
+        {
+          name: "_reserved",
+          docs: ["Reserved for future validation variants."],
+          type: { array: ["u8", 7] },
+        },
+      ],
+    },
+  },
+  {
+    name: "TaskSubmission",
+    docs: [
+      "Claim-level submission state for creator-review validation.",
+      'PDA seeds: ["task_submission", claim]',
+    ],
+    type: {
+      kind: "struct",
+      fields: [
+        { name: "task", docs: ["Task being submitted."], type: "pubkey" },
+        { name: "claim", docs: ["Claim tied to this submission."], type: "pubkey" },
+        { name: "worker", docs: ["Worker that submitted the result."], type: "pubkey" },
+        {
+          name: "status",
+          docs: ["Current submission status."],
+          type: { defined: { name: "SubmissionStatus" } },
+        },
+        {
+          name: "proof_hash",
+          docs: ["Latest proof hash supplied by the worker."],
+          type: { array: ["u8", 32] },
+        },
+        {
+          name: "result_data",
+          docs: ["Latest result payload supplied by the worker."],
+          type: { array: ["u8", 64] },
+        },
+        {
+          name: "submission_count",
+          docs: ["Number of times this claim has been submitted for review."],
+          type: "u16",
+        },
+        {
+          name: "submitted_at",
+          docs: ["Timestamp of latest submission."],
+          type: "i64",
+        },
+        {
+          name: "review_deadline_at",
+          docs: ["Timestamp after which the review window has elapsed."],
+          type: "i64",
+        },
+        {
+          name: "accepted_at",
+          docs: ["Acceptance timestamp (0 when unresolved)."],
+          type: "i64",
+        },
+        {
+          name: "rejected_at",
+          docs: ["Rejection timestamp (0 when unresolved)."],
+          type: "i64",
+        },
+        {
+          name: "rejection_hash",
+          docs: ["Optional rejection reason hash."],
+          type: { array: ["u8", 32] },
+        },
+        { name: "bump", docs: ["PDA bump."], type: "u8" },
+        {
+          name: "_reserved",
+          docs: ["Reserved for future attestation metadata."],
+          type: { array: ["u8", 5] },
+        },
+      ],
+    },
+  },
+  {
+    name: "ValidationMode",
+    docs: ["Validation mode configured for a task."],
+    repr: { kind: "rust" },
+    type: {
+      kind: "enum",
+      variants: [{ name: "Auto" }, { name: "CreatorReview" }],
+    },
+  },
+  {
+    name: "SubmissionStatus",
+    docs: ["Task submission lifecycle for creator-review validation."],
+    repr: { kind: "rust" },
+    type: {
+      kind: "enum",
+      variants: [
+        { name: "Idle" },
+        { name: "Submitted" },
+        { name: "Accepted" },
+        { name: "Rejected" },
+      ],
+    },
+  },
+] as const;
+
+function mergeIdlEntries<T extends NamedIdlEntry>(
+  existing: readonly T[] | undefined,
+  extras: readonly T[],
+): T[] {
+  const merged = new Map<string, T>();
+
+  for (const entry of existing ?? []) {
+    merged.set(entry.name, entry);
+  }
+  for (const entry of extras) {
+    if (!merged.has(entry.name)) {
+      merged.set(entry.name, entry);
+    }
+  }
+
+  return Array.from(merged.values());
+}
+
+function augmentIdl(baseIdl: Idl): Idl {
+  return {
+    ...baseIdl,
+    instructions: mergeIdlEntries(
+      baseIdl.instructions as NamedIdlEntry[] | undefined,
+      TASK_VALIDATION_V2_INSTRUCTIONS as unknown as NamedIdlEntry[],
+    ) as Idl["instructions"],
+    accounts: mergeIdlEntries(
+      baseIdl.accounts as NamedIdlEntry[] | undefined,
+      TASK_VALIDATION_V2_ACCOUNTS as unknown as NamedIdlEntry[],
+    ) as Idl["accounts"],
+    types: mergeIdlEntries(
+      baseIdl.types as NamedIdlEntry[] | undefined,
+      TASK_VALIDATION_V2_TYPES as unknown as NamedIdlEntry[],
+    ) as Idl["types"],
+  };
+}
+
 /**
  * The AgenC Coordination program IDL.
  *
@@ -28,7 +513,7 @@ export type { AgencCoordination };
  * JSON structure. Use `Program<AgencCoordination>` for type-safe method access.
  */
 export const IDL: Idl = {
-  ...(AGENC_COORDINATION_IDL as Idl),
+  ...augmentIdl(AGENC_COORDINATION_IDL as Idl),
   address: PROGRAM_ID.toBase58(),
 };
 

--- a/runtime/src/task/operations.test.ts
+++ b/runtime/src/task/operations.test.ts
@@ -6,7 +6,12 @@ import {
   TASK_STATUS_OFFSET,
   type TaskOpsConfig,
 } from "./operations.js";
-import { OnChainTaskStatus, type OnChainTask } from "./types.js";
+import {
+  MANUAL_VALIDATION_SENTINEL,
+  OnChainTaskStatus,
+  TaskValidationMode,
+  type OnChainTask,
+} from "./types.js";
 import { TaskType } from "../events/types.js";
 import {
   TaskNotClaimableError,
@@ -121,12 +126,32 @@ function createParsedTask(overrides: Partial<OnChainTask> = {}): OnChainTask {
   };
 }
 
+function createMockRawAgentRegistration(authority: PublicKey) {
+  return {
+    agentId: Array.from(createAgentId(77)),
+    authority,
+    capabilities: { toString: () => "3" },
+    status: { active: {} },
+    endpoint: "http://localhost:3000",
+    metadataUri: "https://example.com/agent.json",
+    registeredAt: { toNumber: () => 1700000000 },
+    lastActive: { toNumber: () => 1700000100 },
+    tasksCompleted: { toString: () => "10" },
+    totalEarned: { toString: () => "5000000" },
+    reputation: 9000,
+    activeTasks: 1,
+    stake: { toString: () => "1000000" },
+    bump: 200,
+  };
+}
+
 /**
  * Creates a mock Anchor program for testing.
  */
 function createMockProgram() {
+  const providerPublicKey = Keypair.generate().publicKey;
   const mockProvider = {
-    publicKey: Keypair.generate().publicKey,
+    publicKey: providerPublicKey,
   };
 
   const taskFetch = vi.fn();
@@ -136,10 +161,17 @@ function createMockProgram() {
   const protocolConfigFetch = vi.fn().mockResolvedValue({
     treasury: Keypair.generate().publicKey,
   });
+  const agentRegistrationFetch = vi
+    .fn()
+    .mockResolvedValue(createMockRawAgentRegistration(providerPublicKey));
 
   const claimTaskRpc = vi.fn().mockResolvedValue("claim-sig");
   const completeTaskRpc = vi.fn().mockResolvedValue("complete-sig");
   const completeTaskPrivateRpc = vi.fn().mockResolvedValue("private-sig");
+  const configureTaskValidationRpc = vi.fn().mockResolvedValue("configure-sig");
+  const submitTaskResultRpc = vi.fn().mockResolvedValue("submit-sig");
+  const acceptTaskResultRpc = vi.fn().mockResolvedValue("accept-sig");
+  const rejectTaskResultRpc = vi.fn().mockResolvedValue("reject-sig");
 
   const claimTaskBuilder = {
     accountsPartial: vi.fn().mockReturnThis(),
@@ -157,9 +189,38 @@ function createMockProgram() {
     remainingAccounts: vi.fn().mockReturnThis(),
     rpc: completeTaskPrivateRpc,
   };
+  const configureTaskValidationBuilder = {
+    accountsPartial: vi.fn().mockReturnThis(),
+    rpc: configureTaskValidationRpc,
+  };
+  const submitTaskResultBuilder = {
+    accountsPartial: vi.fn().mockReturnThis(),
+    rpc: submitTaskResultRpc,
+  };
+  const acceptTaskResultBuilder = {
+    accountsPartial: vi.fn().mockReturnThis(),
+    remainingAccounts: vi.fn().mockReturnThis(),
+    rpc: acceptTaskResultRpc,
+  };
+  const rejectTaskResultBuilder = {
+    accountsPartial: vi.fn().mockReturnThis(),
+    rpc: rejectTaskResultRpc,
+  };
   const completeTaskPrivateMethod = vi
     .fn()
     .mockReturnValue(completeTaskPrivateBuilder);
+  const configureTaskValidationMethod = vi
+    .fn()
+    .mockReturnValue(configureTaskValidationBuilder);
+  const submitTaskResultMethod = vi
+    .fn()
+    .mockReturnValue(submitTaskResultBuilder);
+  const acceptTaskResultMethod = vi
+    .fn()
+    .mockReturnValue(acceptTaskResultBuilder);
+  const rejectTaskResultMethod = vi
+    .fn()
+    .mockReturnValue(rejectTaskResultBuilder);
 
   const program = {
     programId: PROGRAM_ID,
@@ -168,11 +229,16 @@ function createMockProgram() {
       task: { fetch: taskFetch, all: taskAll },
       taskClaim: { fetch: taskClaimFetch, all: taskClaimAll },
       protocolConfig: { fetch: protocolConfigFetch },
+      agentRegistration: { fetch: agentRegistrationFetch },
     },
     methods: {
       claimTask: vi.fn().mockReturnValue(claimTaskBuilder),
       completeTask: vi.fn().mockReturnValue(completeTaskBuilder),
       completeTaskPrivate: completeTaskPrivateMethod,
+      configureTaskValidation: configureTaskValidationMethod,
+      submitTaskResult: submitTaskResultMethod,
+      acceptTaskResult: acceptTaskResultMethod,
+      rejectTaskResult: rejectTaskResultMethod,
     },
   };
 
@@ -184,13 +250,26 @@ function createMockProgram() {
       taskClaimFetch,
       taskClaimAll,
       protocolConfigFetch,
+      agentRegistrationFetch,
       claimTaskRpc,
       completeTaskRpc,
       completeTaskPrivateRpc,
+      configureTaskValidationRpc,
+      submitTaskResultRpc,
+      acceptTaskResultRpc,
+      rejectTaskResultRpc,
       completeTaskPrivateMethod,
+      configureTaskValidationMethod,
+      submitTaskResultMethod,
+      acceptTaskResultMethod,
+      rejectTaskResultMethod,
       claimTaskBuilder,
       completeTaskBuilder,
       completeTaskPrivateBuilder,
+      configureTaskValidationBuilder,
+      submitTaskResultBuilder,
+      acceptTaskResultBuilder,
+      rejectTaskResultBuilder,
     },
   };
 }
@@ -668,6 +747,21 @@ describe("TaskOperations", () => {
       expect(result.success).toBe(true);
     });
 
+    it("routes manual validation tasks to submitTaskResult", async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createParsedTask({
+        constraintHash: new Uint8Array(MANUAL_VALIDATION_SENTINEL),
+      });
+      const proofHash = new Uint8Array(32).fill(0xab);
+
+      const result = await ops.completeTask(taskPda, task, proofHash, null);
+
+      expect(result.success).toBe(true);
+      expect(result.transactionSignature).toBe("submit-sig");
+      expect(mocks.submitTaskResultMethod).toHaveBeenCalledTimes(1);
+      expect(mocks.completeTaskBuilder.accountsPartial).not.toHaveBeenCalled();
+    });
+
     it("appends parent and accepted-bid settlement accounts when provided", async () => {
       const taskPda = Keypair.generate().publicKey;
       const task = createParsedTask();
@@ -833,6 +927,133 @@ describe("TaskOperations", () => {
           new Uint8Array(HASH_SIZE).fill(0x05),
         ),
       ).rejects.toThrow(TaskSubmissionError);
+    });
+  });
+
+  describe("Task Validation V2", () => {
+    it("configures task validation with creator review mode", async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createParsedTask();
+
+      const result = await ops.configureTaskValidation(
+        taskPda,
+        task,
+        TaskValidationMode.CreatorReview,
+        900,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.transactionSignature).toBe("configure-sig");
+      expect(mocks.configureTaskValidationMethod).toHaveBeenCalledTimes(1);
+      expect(mocks.configureTaskValidationMethod.mock.calls[0][0]).toBe(
+        TaskValidationMode.CreatorReview,
+      );
+      expect(
+        mocks.configureTaskValidationMethod.mock.calls[0][1].toString(),
+      ).toBe("900");
+      expect(
+        mocks.configureTaskValidationBuilder.accountsPartial,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          task: taskPda,
+          creator: mockProgram.provider.publicKey,
+          systemProgram: SystemProgram.programId,
+        }),
+      );
+    });
+
+    it("submits a task result for creator review", async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createParsedTask();
+      const proofHash = new Uint8Array(32).fill(0xab);
+      const resultData = new Uint8Array(64).fill(0xcd);
+
+      const result = await ops.submitTaskResult(
+        taskPda,
+        task,
+        proofHash,
+        resultData,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.transactionSignature).toBe("submit-sig");
+      expect(mocks.submitTaskResultMethod).toHaveBeenCalledTimes(1);
+      expect(
+        mocks.submitTaskResultBuilder.accountsPartial,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          task: taskPda,
+          authority: mockProgram.provider.publicKey,
+          systemProgram: SystemProgram.programId,
+        }),
+      );
+    });
+
+    it("accepts a reviewed task result using the worker authority wallet", async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createParsedTask();
+      const workerPda = Keypair.generate().publicKey;
+      const workerAuthority = Keypair.generate().publicKey;
+      const bidBook = Keypair.generate().publicKey;
+      const acceptedBid = Keypair.generate().publicKey;
+      const bidderMarketState = Keypair.generate().publicKey;
+
+      mocks.agentRegistrationFetch.mockResolvedValue(
+        createMockRawAgentRegistration(workerAuthority),
+      );
+
+      const result = await ops.acceptTaskResult(taskPda, task, workerPda, {
+        acceptedBidSettlement: {
+          bidBook,
+          acceptedBid,
+          bidderMarketState,
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.transactionSignature).toBe("accept-sig");
+      expect(mocks.agentRegistrationFetch).toHaveBeenCalledWith(workerPda);
+      expect(mocks.acceptTaskResultMethod).toHaveBeenCalledTimes(1);
+      expect(mocks.acceptTaskResultBuilder.accountsPartial).toHaveBeenCalledWith(
+        expect.objectContaining({
+          task: taskPda,
+          worker: workerPda,
+          workerAuthority,
+          reviewer: mockProgram.provider.publicKey,
+        }),
+      );
+      expect(
+        mocks.acceptTaskResultBuilder.remainingAccounts,
+      ).toHaveBeenCalledWith([
+        { pubkey: bidBook, isSigner: false, isWritable: true },
+        { pubkey: acceptedBid, isSigner: false, isWritable: true },
+        { pubkey: bidderMarketState, isSigner: false, isWritable: true },
+        { pubkey: workerAuthority, isSigner: false, isWritable: true },
+      ]);
+    });
+
+    it("rejects a reviewed task result", async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createParsedTask();
+      const workerPda = Keypair.generate().publicKey;
+      const rejectionHash = new Uint8Array(32).fill(0xee);
+
+      const result = await ops.rejectTaskResult(
+        taskPda,
+        task,
+        workerPda,
+        rejectionHash,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.transactionSignature).toBe("reject-sig");
+      expect(mocks.rejectTaskResultMethod).toHaveBeenCalledTimes(1);
+      expect(mocks.rejectTaskResultBuilder.accountsPartial).toHaveBeenCalledWith(
+        expect.objectContaining({
+          task: taskPda,
+          creator: mockProgram.provider.publicKey,
+        }),
+      );
     });
   });
 

--- a/runtime/src/task/operations.ts
+++ b/runtime/src/task/operations.ts
@@ -29,15 +29,20 @@ import type {
   OnChainTaskClaim,
   ClaimResult,
   CompleteResult,
+  TaskSubmissionResult,
   TaskCompletionOptions,
+  TaskValidationConfigResult,
+  TaskValidationMode,
 } from "./types.js";
 import {
+  isManualValidationTask,
   parseOnChainTask,
   parseOnChainTaskClaim,
   OnChainTaskStatus,
 } from "./types.js";
 import { deriveTaskPda, deriveClaimPda, deriveEscrowPda } from "./pda.js";
 import { deriveAgentPda, findProtocolPda } from "../agent/pda.js";
+import { parseAgentState } from "../agent/types.js";
 import { fetchTreasury } from "../utils/treasury.js";
 import { buildCompleteTaskTokenAccounts } from "../utils/token.js";
 import {
@@ -69,12 +74,34 @@ const BINDING_SPEND_SEED = Buffer.from("binding_spend");
 const NULLIFIER_SPEND_SEED = Buffer.from("nullifier_spend");
 const ROUTER_SEED = Buffer.from("router");
 const VERIFIER_SEED = Buffer.from("verifier");
+const TASK_VALIDATION_SEED = Buffer.from("task_validation");
+const TASK_SUBMISSION_SEED = Buffer.from("task_submission");
 const TRUSTED_RISC0_ROUTER_PROGRAM_ID = new PublicKey(
   "E9ZiqfCdr6gGeB2UhBbkWnFP9vGnRYQwqnDsS1LM3NJZ",
 );
 const TRUSTED_RISC0_VERIFIER_PROGRAM_ID = new PublicKey(
   "3ZrAHZKjk24AKgXFekpYeG7v3Rz7NucLXTB3zxGGTjsc",
 );
+
+function deriveTaskValidationConfigPda(
+  taskPda: PublicKey,
+  programId: PublicKey,
+): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [TASK_VALIDATION_SEED, taskPda.toBuffer()],
+    programId,
+  )[0];
+}
+
+function deriveTaskSubmissionPda(
+  claimPda: PublicKey,
+  programId: PublicKey,
+): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [TASK_SUBMISSION_SEED, claimPda.toBuffer()],
+    programId,
+  )[0];
+}
 
 // ============================================================================
 // Configuration
@@ -450,6 +477,351 @@ export class TaskOperations {
   }
 
   /**
+   * Configure Task Validation V2 for an existing task.
+   *
+   * @param taskPda - Task account PDA
+   * @param task - The on-chain task data
+   * @param mode - Validation mode matching the on-chain enum
+   * @param reviewWindowSecs - Review window in seconds
+   * @returns Configuration result with signature and validation config PDA
+   */
+  async configureTaskValidation(
+    taskPda: PublicKey,
+    task: OnChainTask,
+    mode: TaskValidationMode | number,
+    reviewWindowSecs: number | bigint,
+  ): Promise<TaskValidationConfigResult> {
+    const creator = this.program.provider.publicKey;
+    if (!creator) {
+      throw new ValidationError(
+        "Program provider does not have a public key for task validation",
+      );
+    }
+
+    const taskValidationConfigPda = deriveTaskValidationConfigPda(
+      taskPda,
+      this.program.programId,
+    );
+    const protocolPda = findProtocolPda(this.program.programId);
+
+    const methods = this.program.methods as unknown as {
+      configureTaskValidation: (
+        validationMode: number,
+        reviewWindow: BN,
+      ) => {
+        accountsPartial: (accounts: Record<string, unknown>) => {
+          rpc: () => Promise<string>;
+        };
+      };
+    };
+
+    this.logger.info(`Configuring validation for task ${taskPda.toBase58()}`);
+
+    try {
+      const signature = await methods
+        .configureTaskValidation(Number(mode), new BN(reviewWindowSecs.toString()))
+        .accountsPartial({
+          task: taskPda,
+          taskValidationConfig: taskValidationConfigPda,
+          protocolConfig: protocolPda,
+          creator,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc();
+
+      return {
+        success: true,
+        taskId: task.taskId,
+        taskValidationConfigPda,
+        transactionSignature: signature,
+      };
+    } catch (err) {
+      this.logger.error(
+        `Failed to configure validation for ${taskPda.toBase58()}: ${err}`,
+      );
+      throw new TaskSubmissionError(
+        taskPda,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  /**
+   * Submit a result for Task Validation V2 creator review.
+   *
+   * @param taskPda - Task account PDA
+   * @param task - The on-chain task data
+   * @param proofHash - Worker-submitted proof hash
+   * @param resultData - Optional worker-submitted result payload
+   * @returns Submission result with signature and submission PDA
+   */
+  async submitTaskResult(
+    taskPda: PublicKey,
+    task: OnChainTask,
+    proofHash: Uint8Array,
+    resultData: Uint8Array | null,
+  ): Promise<TaskSubmissionResult> {
+    validateByteLength(proofHash, 32, "proofHash");
+    validateNonZeroBytes(proofHash, "proofHash");
+    if (resultData !== null) {
+      validateByteLength(resultData, 64, "resultData");
+    }
+
+    const authority = this.program.provider.publicKey;
+    if (!authority) {
+      throw new ValidationError(
+        "Program provider does not have a public key for task submission",
+      );
+    }
+
+    const workerPda = this.getAgentPda();
+    const { address: claimPda } = deriveClaimPda(
+      taskPda,
+      workerPda,
+      this.program.programId,
+    );
+    const taskValidationConfigPda = deriveTaskValidationConfigPda(
+      taskPda,
+      this.program.programId,
+    );
+    const taskSubmissionPda = deriveTaskSubmissionPda(
+      claimPda,
+      this.program.programId,
+    );
+    const protocolPda = findProtocolPda(this.program.programId);
+
+    const methods = this.program.methods as unknown as {
+      submitTaskResult: (
+        proofHashBytes: number[],
+        resultBytes: number[] | null,
+      ) => {
+        accountsPartial: (accounts: Record<string, unknown>) => {
+          rpc: () => Promise<string>;
+        };
+      };
+    };
+
+    this.logger.info(`Submitting task result ${taskPda.toBase58()} for review`);
+
+    try {
+      const signature = await methods
+        .submitTaskResult(
+          toAnchorBytes(proofHash),
+          resultData ? toAnchorBytes(resultData) : null,
+        )
+        .accountsPartial({
+          task: taskPda,
+          claim: claimPda,
+          taskValidationConfig: taskValidationConfigPda,
+          taskSubmission: taskSubmissionPda,
+          protocolConfig: protocolPda,
+          worker: workerPda,
+          authority,
+          systemProgram: SystemProgram.programId,
+        })
+        .rpc();
+
+      return {
+        success: true,
+        taskId: task.taskId,
+        taskSubmissionPda,
+        transactionSignature: signature,
+      };
+    } catch (err) {
+      this.logger.error(
+        `Failed to submit task result ${taskPda.toBase58()}: ${err}`,
+      );
+      throw new TaskSubmissionError(
+        taskPda,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  /**
+   * Accept a pending Task Validation V2 submission and settle the reward.
+   *
+   * @param taskPda - Task account PDA
+   * @param task - The on-chain task data
+   * @param workerPda - Worker agent PDA that owns the submission
+   * @param options - Optional dependent-task and marketplace settlement accounts
+   * @returns Completion result with signature
+   */
+  async acceptTaskResult(
+    taskPda: PublicKey,
+    task: OnChainTask,
+    workerPda: PublicKey,
+    options?: TaskCompletionOptions,
+  ): Promise<CompleteResult> {
+    const reviewer = this.program.provider.publicKey;
+    if (!reviewer) {
+      throw new ValidationError(
+        "Program provider does not have a public key for task review",
+      );
+    }
+
+    const { address: claimPda } = deriveClaimPda(
+      taskPda,
+      workerPda,
+      this.program.programId,
+    );
+    const { address: escrowPda } = deriveEscrowPda(
+      taskPda,
+      this.program.programId,
+    );
+    const taskValidationConfigPda = deriveTaskValidationConfigPda(
+      taskPda,
+      this.program.programId,
+    );
+    const taskSubmissionPda = deriveTaskSubmissionPda(
+      claimPda,
+      this.program.programId,
+    );
+    const protocolPda = findProtocolPda(this.program.programId);
+    const treasury = await this.getProtocolTreasury();
+    const workerAuthority = await this.getWorkerAuthority(workerPda);
+    const tokenAccounts = buildCompleteTaskTokenAccounts(
+      task.rewardMint,
+      escrowPda,
+      workerAuthority,
+      treasury,
+    );
+    const remainingAccounts = this.buildTaskCompletionRemainingAccounts(
+      options,
+      workerAuthority,
+    );
+
+    const methods = this.program.methods as unknown as {
+      acceptTaskResult: () => {
+        accountsPartial: (accounts: Record<string, unknown>) => {
+          remainingAccounts: (accounts: AccountMeta[]) => { rpc: () => Promise<string> };
+          rpc: () => Promise<string>;
+        };
+      };
+    };
+
+    this.logger.info(`Accepting task result ${taskPda.toBase58()}`);
+
+    try {
+      const builder = methods.acceptTaskResult().accountsPartial({
+        task: taskPda,
+        claim: claimPda,
+        escrow: escrowPda,
+        taskValidationConfig: taskValidationConfigPda,
+        taskSubmission: taskSubmissionPda,
+        worker: workerPda,
+        protocolConfig: protocolPda,
+        treasury,
+        creator: task.creator,
+        workerAuthority,
+        reviewer,
+        systemProgram: SystemProgram.programId,
+        ...tokenAccounts,
+      });
+
+      if (remainingAccounts.length > 0) {
+        builder.remainingAccounts(remainingAccounts);
+      }
+
+      const signature = await builder.rpc();
+
+      return {
+        success: true,
+        taskId: task.taskId,
+        isPrivate: false,
+        transactionSignature: signature,
+      };
+    } catch (err) {
+      this.logger.error(
+        `Failed to accept task result ${taskPda.toBase58()}: ${err}`,
+      );
+      throw new TaskSubmissionError(
+        taskPda,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  /**
+   * Reject a pending Task Validation V2 submission.
+   *
+   * @param taskPda - Task account PDA
+   * @param task - The on-chain task data
+   * @param workerPda - Worker agent PDA that owns the submission
+   * @param rejectionHash - Evidence or rejection reason hash
+   * @returns Submission result with signature and submission PDA
+   */
+  async rejectTaskResult(
+    taskPda: PublicKey,
+    task: OnChainTask,
+    workerPda: PublicKey,
+    rejectionHash: Uint8Array,
+  ): Promise<TaskSubmissionResult> {
+    validateByteLength(rejectionHash, 32, "rejectionHash");
+
+    const creator = this.program.provider.publicKey;
+    if (!creator) {
+      throw new ValidationError(
+        "Program provider does not have a public key for task rejection",
+      );
+    }
+
+    const { address: claimPda } = deriveClaimPda(
+      taskPda,
+      workerPda,
+      this.program.programId,
+    );
+    const taskValidationConfigPda = deriveTaskValidationConfigPda(
+      taskPda,
+      this.program.programId,
+    );
+    const taskSubmissionPda = deriveTaskSubmissionPda(
+      claimPda,
+      this.program.programId,
+    );
+    const protocolPda = findProtocolPda(this.program.programId);
+
+    const methods = this.program.methods as unknown as {
+      rejectTaskResult: (rejectionHashBytes: number[]) => {
+        accountsPartial: (accounts: Record<string, unknown>) => {
+          rpc: () => Promise<string>;
+        };
+      };
+    };
+
+    this.logger.info(`Rejecting task result ${taskPda.toBase58()}`);
+
+    try {
+      const signature = await methods
+        .rejectTaskResult(toAnchorBytes(rejectionHash))
+        .accountsPartial({
+          task: taskPda,
+          claim: claimPda,
+          taskValidationConfig: taskValidationConfigPda,
+          taskSubmission: taskSubmissionPda,
+          protocolConfig: protocolPda,
+          creator,
+        })
+        .rpc();
+
+      return {
+        success: true,
+        taskId: task.taskId,
+        taskSubmissionPda,
+        transactionSignature: signature,
+      };
+    } catch (err) {
+      this.logger.error(
+        `Failed to reject task result ${taskPda.toBase58()}: ${err}`,
+      );
+      throw new TaskSubmissionError(
+        taskPda,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  /**
    * Complete a task with a public proof.
    *
    * @param taskPda - Task account PDA
@@ -471,6 +843,24 @@ export class TaskOperations {
       validateByteLength(resultData, 64, "resultData");
     }
 
+    if (isManualValidationTask(task)) {
+      this.logger.info(
+        `Task ${taskPda.toBase58()} requires creator review; routing to submitTaskResult`,
+      );
+      const submission = await this.submitTaskResult(
+        taskPda,
+        task,
+        proofHash,
+        resultData,
+      );
+      return {
+        success: submission.success,
+        taskId: submission.taskId,
+        isPrivate: false,
+        transactionSignature: submission.transactionSignature,
+      };
+    }
+
     const workerPda = this.getAgentPda();
     const { address: claimPda } = deriveClaimPda(
       taskPda,
@@ -489,7 +879,10 @@ export class TaskOperations {
       this.program.provider.publicKey!,
       treasury,
     );
-    const remainingAccounts = this.buildTaskCompletionRemainingAccounts(options);
+    const remainingAccounts = this.buildTaskCompletionRemainingAccounts(
+      options,
+      this.program.provider.publicKey ?? undefined,
+    );
 
     this.logger.info(`Completing task ${taskPda.toBase58()}`);
 
@@ -612,7 +1005,10 @@ export class TaskOperations {
       this.program.provider.publicKey!,
       treasury,
     );
-    const remainingAccounts = this.buildTaskCompletionRemainingAccounts(options);
+    const remainingAccounts = this.buildTaskCompletionRemainingAccounts(
+      options,
+      this.program.provider.publicKey ?? undefined,
+    );
 
     this.logger.info(`Completing task privately ${taskPda.toBase58()}`);
 
@@ -722,10 +1118,31 @@ export class TaskOperations {
   }
 
   /**
+   * Resolve the worker authority wallet from an agent registration PDA.
+   */
+  private async getWorkerAuthority(workerPda: PublicKey): Promise<PublicKey> {
+    const agentAccount = this.program.account as unknown as {
+      agentRegistration?: {
+        fetch?: (address: PublicKey) => Promise<unknown>;
+      };
+    };
+
+    if (!agentAccount.agentRegistration?.fetch) {
+      throw new ValidationError(
+        "Program account namespace is missing agentRegistration.fetch",
+      );
+    }
+
+    const rawAgent = await agentAccount.agentRegistration.fetch(workerPda);
+    return parseAgentState(rawAgent).authority;
+  }
+
+  /**
    * Build remaining accounts for dependent-task and Marketplace V2 settlement.
    */
   private buildTaskCompletionRemainingAccounts(
     options?: TaskCompletionOptions,
+    defaultBidderAuthority?: PublicKey,
   ): AccountMeta[] {
     const accounts: AccountMeta[] = [];
     if (!options) return accounts;
@@ -740,7 +1157,9 @@ export class TaskOperations {
 
     if (options.acceptedBidSettlement) {
       const bidderAuthority =
-        options.bidderAuthority ?? this.program.provider.publicKey;
+        options.bidderAuthority ??
+        defaultBidderAuthority ??
+        this.program.provider.publicKey;
       if (!bidderAuthority) {
         throw new ValidationError(
           "bidderAuthority is required when acceptedBidSettlement is provided",

--- a/runtime/src/task/types.test.ts
+++ b/runtime/src/task/types.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from "vitest";
 import { Keypair } from "@solana/web3.js";
 import { TaskType } from "../events/types.js";
 import {
+  MANUAL_VALIDATION_SENTINEL,
   OnChainTaskStatus,
+  isManualValidationTask,
   parseTaskStatus,
   parseTaskType,
   parseOnChainTask,
@@ -369,6 +371,32 @@ describe("isPrivateTask", () => {
     const task = createParsedTask({ constraintHash: new Uint8Array(32) });
 
     expect(isPrivateTask(task)).toBe(false);
+  });
+
+  it("returns false for manual validation sentinel tasks", () => {
+    const task = createParsedTask({
+      constraintHash: new Uint8Array(MANUAL_VALIDATION_SENTINEL),
+    });
+
+    expect(isPrivateTask(task)).toBe(false);
+  });
+});
+
+describe("isManualValidationTask", () => {
+  it("returns true for the manual validation sentinel", () => {
+    const task = createParsedTask({
+      constraintHash: new Uint8Array(MANUAL_VALIDATION_SENTINEL),
+    });
+
+    expect(isManualValidationTask(task)).toBe(true);
+  });
+
+  it("returns false for other non-zero constraint hashes", () => {
+    const constraintHash = new Uint8Array(32);
+    constraintHash[0] = 9;
+    const task = createParsedTask({ constraintHash });
+
+    expect(isManualValidationTask(task)).toBe(false);
   });
 });
 

--- a/runtime/src/task/types.ts
+++ b/runtime/src/task/types.ts
@@ -41,6 +41,36 @@ export enum OnChainTaskStatus {
   Disputed = 5,
 }
 
+/**
+ * Validation mode configured for a task.
+ * Matches the on-chain ValidationMode enum.
+ */
+export enum TaskValidationMode {
+  /** Complete the task immediately on submission */
+  Auto = 0,
+  /** Submit work for creator review before settlement */
+  CreatorReview = 1,
+}
+
+/**
+ * Submission status for Task Validation V2.
+ * Matches the on-chain SubmissionStatus enum.
+ */
+export enum TaskSubmissionStatus {
+  Idle = 0,
+  Submitted = 1,
+  Accepted = 2,
+  Rejected = 3,
+}
+
+/**
+ * Sentinel value stored in `constraintHash` for public tasks that require
+ * creator review instead of immediate settlement.
+ */
+export const MANUAL_VALIDATION_SENTINEL = new Uint8Array(
+  Buffer.from("agenc-manual-validation-v2-seed!"),
+);
+
 // ============================================================================
 // On-Chain Interfaces (parsed, developer-friendly types)
 // ============================================================================
@@ -59,7 +89,10 @@ export interface OnChainTask {
   requiredCapabilities: bigint;
   /** Task description or instruction hash (64 bytes) */
   description: Uint8Array;
-  /** Constraint hash for private task verification (32 bytes, all zeros = public) */
+  /**
+   * Constraint hash for private task verification.
+   * All zeros = public task, manual-validation sentinel = public creator-review task.
+   */
   constraintHash: Uint8Array;
   /** Reward amount in lamports (u64 as bigint) */
   rewardAmount: bigint;
@@ -516,6 +549,26 @@ export function parseOnChainTaskClaim(data: unknown): OnChainTaskClaim {
  * ```
  */
 export function isPrivateTask(task: OnChainTask): boolean {
+  return hasConstraintHash(task) && !isManualValidationTask(task);
+}
+
+/**
+ * Checks if a task is configured for Task Validation V2 creator review.
+ *
+ * @param task - Parsed on-chain task
+ * @returns True if the task uses the manual validation sentinel
+ */
+export function isManualValidationTask(task: OnChainTask): boolean {
+  if (task.constraintHash.length !== MANUAL_VALIDATION_SENTINEL.length) {
+    return false;
+  }
+
+  return task.constraintHash.every(
+    (byte, index) => byte === MANUAL_VALIDATION_SENTINEL[index],
+  );
+}
+
+function hasConstraintHash(task: OnChainTask): boolean {
   return task.constraintHash.some((byte) => byte !== 0);
 }
 
@@ -824,6 +877,38 @@ export interface CompleteResult {
   /** Transaction signature if submitted */
   transactionSignature?: TransactionSignature;
   /** Error message if completion failed */
+  error?: string;
+}
+
+/**
+ * Result of configuring Task Validation V2 for a task.
+ */
+export interface TaskValidationConfigResult {
+  /** Whether the configuration succeeded */
+  success: boolean;
+  /** Task identifier (32 bytes) */
+  taskId: Uint8Array;
+  /** Validation config PDA address */
+  taskValidationConfigPda: PublicKey;
+  /** Transaction signature if submitted */
+  transactionSignature?: TransactionSignature;
+  /** Error message if configuration failed */
+  error?: string;
+}
+
+/**
+ * Result of submitting or reviewing a Task Validation V2 submission.
+ */
+export interface TaskSubmissionResult {
+  /** Whether the submission action succeeded */
+  success: boolean;
+  /** Task identifier (32 bytes) */
+  taskId: Uint8Array;
+  /** Submission PDA address */
+  taskSubmissionPda: PublicKey;
+  /** Transaction signature if submitted */
+  transactionSignature?: TransactionSignature;
+  /** Error message if the action failed */
   error?: string;
 }
 


### PR DESCRIPTION
## Summary
Add runtime support for the Task Validation V2 creator-review flow while the published protocol package catches up.

## What changed
- patch the runtime IDL surface with the creator-review instructions, accounts, and type definitions
- add `TaskValidationMode` and `TaskSubmissionStatus` runtime types
- add runtime task operations for configure/submit/accept/reject result flows
- add targeted tests covering the new IDL and task operation surface

## Companion PRs
- tetsuo-ai/agenc-protocol#15
- tetsuo-ai/agenc-sdk#25

## Validation
- `npm run build` (in `runtime/`)
- `npx vitest run src/idl.test.ts src/task/operations.test.ts src/task/types.test.ts` (in `runtime/`)

## Notes
The workspace-wide runtime test command still has unrelated pre-existing failures outside this surface, so validation here stays scoped to the touched runtime modules.

## Scope
Partial for tetsuo-ai/AgenC#1518.
This PR covers the creator-review runtime surface only.
