### PR TITLE
feat(runtime): align task validation helpers with merged contract

### DIFF
--- a/runtime/src/idl.test.ts
+++ b/runtime/src/idl.test.ts
@@ -51,6 +51,8 @@ describe('IDL exports', () => {
     expect(instructionNames).toContain('submit_task_result');
     expect(instructionNames).toContain('accept_task_result');
     expect(instructionNames).toContain('reject_task_result');
+    expect(instructionNames).toContain('auto_accept_task_result');
+    expect(instructionNames).toContain('validate_task_result');
     expect(instructionNames).toContain('register_agent');
   });
 
@@ -66,6 +68,8 @@ describe('IDL exports', () => {
     expect(accountNames).toContain('ProtocolConfig');
     expect(accountNames).toContain('TaskValidationConfig');
     expect(accountNames).toContain('TaskSubmission');
+    expect(accountNames).toContain('TaskAttestorConfig');
+    expect(accountNames).toContain('TaskValidationVote');
   });
 
   it('has types array', () => {
@@ -79,6 +83,8 @@ describe('IDL exports', () => {
     expect(typeNames).toContain('SubmissionStatus');
     expect(typeNames).toContain('TaskValidationConfig');
     expect(typeNames).toContain('TaskSubmission');
+    expect(typeNames).toContain('TaskAttestorConfig');
+    expect(typeNames).toContain('TaskValidationVote');
   });
 
   it('has events array', () => {
@@ -154,6 +160,8 @@ describe('createProgram', () => {
     expect(typeof methods.submitTaskResult).toBe('function');
     expect(typeof methods.acceptTaskResult).toBe('function');
     expect(typeof methods.rejectTaskResult).toBe('function');
+    expect(typeof methods.autoAcceptTaskResult).toBe('function');
+    expect(typeof methods.validateTaskResult).toBe('function');
   });
 });
 

--- a/runtime/src/idl.ts
+++ b/runtime/src/idl.ts
@@ -24,8 +24,8 @@ export type { AgencCoordination };
 type NamedIdlEntry = { name: string };
 
 // The published protocol package can lag behind the runtime's supported V2 flow.
-// Merge these entries in locally so Program.methods exposes the creator-review
-// instructions without requiring a package release first.
+// Merge these entries in locally so Program.methods exposes the task validation
+// instructions and accounts without requiring a package release first.
 const TASK_VALIDATION_V2_INSTRUCTIONS = [
   {
     name: "configure_task_validation",
@@ -57,6 +57,19 @@ const TASK_VALIDATION_V2_INSTRUCTIONS = [
         },
       },
       {
+        name: "task_attestor_config",
+        writable: true,
+        pda: {
+          seeds: [
+            {
+              kind: "const",
+              value: [116, 97, 115, 107, 95, 97, 116, 116, 101, 115, 116, 111, 114],
+            },
+            { kind: "account", path: "task" },
+          ],
+        },
+      },
+      {
         name: "protocol_config",
         pda: {
           seeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108] }],
@@ -71,11 +84,13 @@ const TASK_VALIDATION_V2_INSTRUCTIONS = [
     args: [
       { name: "mode", type: "u8" },
       { name: "review_window_secs", type: "i64" },
+      { name: "validator_quorum", type: "u8" },
+      { name: "attestor", type: { option: "pubkey" } },
     ],
   },
   {
     name: "submit_task_result",
-    docs: ["Submit a result for creator review before final settlement."],
+    docs: ["Submit a result for manual validation before final settlement."],
     discriminator: [39, 108, 74, 4, 66, 125, 157, 7],
     accounts: [
       {
@@ -199,6 +214,192 @@ const TASK_VALIDATION_V2_INSTRUCTIONS = [
       },
       {
         name: "task_validation_config",
+        writable: true,
+        pda: {
+          seeds: [
+            {
+              kind: "const",
+              value: [116, 97, 115, 107, 95, 118, 97, 108, 105, 100, 97, 116, 105, 111, 110],
+            },
+            { kind: "account", path: "task" },
+          ],
+        },
+      },
+      {
+        name: "task_submission",
+        writable: true,
+        pda: {
+          seeds: [
+            {
+              kind: "const",
+              value: [116, 97, 115, 107, 95, 115, 117, 98, 109, 105, 115, 115, 105, 111, 110],
+            },
+            { kind: "account", path: "claim" },
+          ],
+        },
+      },
+      {
+        name: "worker",
+        writable: true,
+        pda: {
+          seeds: [
+            { kind: "const", value: [97, 103, 101, 110, 116] },
+            {
+              kind: "account",
+              path: "worker.agent_id",
+              account: "AgentRegistration",
+            },
+          ],
+        },
+      },
+      {
+        name: "protocol_config",
+        writable: true,
+        pda: {
+          seeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108] }],
+        },
+      },
+      { name: "treasury", writable: true },
+      { name: "creator", writable: true, signer: true },
+      { name: "worker_authority", writable: true },
+      { name: "token_escrow_ata", writable: true, optional: true },
+      { name: "worker_token_account", writable: true, optional: true },
+      { name: "treasury_token_account", writable: true, optional: true },
+      { name: "reward_mint", optional: true },
+      {
+        name: "token_program",
+        optional: true,
+        address: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+      },
+      {
+        name: "system_program",
+        address: "11111111111111111111111111111111",
+      },
+    ],
+    args: [],
+  },
+  {
+    name: "reject_task_result",
+    docs: [
+      "Reject a creator-reviewed submission and return the task to active work.",
+    ],
+    discriminator: [144, 7, 58, 232, 157, 167, 85, 214],
+    accounts: [
+      {
+        name: "task",
+        writable: true,
+        pda: {
+          seeds: [
+            { kind: "const", value: [116, 97, 115, 107] },
+            { kind: "account", path: "task.creator", account: "Task" },
+            { kind: "account", path: "task.task_id", account: "Task" },
+          ],
+        },
+      },
+      {
+        name: "claim",
+        writable: true,
+        pda: {
+          seeds: [
+            { kind: "const", value: [99, 108, 97, 105, 109] },
+            { kind: "account", path: "task" },
+            { kind: "account", path: "claim.worker", account: "TaskClaim" },
+          ],
+        },
+      },
+      {
+        name: "task_validation_config",
+        writable: true,
+        pda: {
+          seeds: [
+            {
+              kind: "const",
+              value: [116, 97, 115, 107, 95, 118, 97, 108, 105, 100, 97, 116, 105, 111, 110],
+            },
+            { kind: "account", path: "task" },
+          ],
+        },
+      },
+      {
+        name: "task_submission",
+        writable: true,
+        pda: {
+          seeds: [
+            {
+              kind: "const",
+              value: [116, 97, 115, 107, 95, 115, 117, 98, 109, 105, 115, 115, 105, 111, 110],
+            },
+            { kind: "account", path: "claim" },
+          ],
+        },
+      },
+      {
+        name: "worker",
+        writable: true,
+        pda: {
+          seeds: [
+            { kind: "const", value: [97, 103, 101, 110, 116] },
+            {
+              kind: "account",
+              path: "worker.agent_id",
+              account: "AgentRegistration",
+            },
+          ],
+        },
+      },
+      {
+        name: "protocol_config",
+        pda: {
+          seeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108] }],
+        },
+      },
+      { name: "creator", writable: true, signer: true },
+      { name: "worker_authority", writable: true },
+    ],
+    args: [{ name: "rejection_hash", type: { array: ["u8", 32] } }],
+  },
+  {
+    name: "auto_accept_task_result",
+    docs: [
+      "Permissionlessly auto-accept a creator-reviewed submission after timeout.",
+    ],
+    discriminator: [217, 200, 76, 0, 144, 80, 23, 241],
+    accounts: [
+      {
+        name: "task",
+        writable: true,
+        pda: {
+          seeds: [
+            { kind: "const", value: [116, 97, 115, 107] },
+            { kind: "account", path: "task.creator", account: "Task" },
+            { kind: "account", path: "task.task_id", account: "Task" },
+          ],
+        },
+      },
+      {
+        name: "claim",
+        writable: true,
+        pda: {
+          seeds: [
+            { kind: "const", value: [99, 108, 97, 105, 109] },
+            { kind: "account", path: "task" },
+            { kind: "account", path: "worker" },
+          ],
+        },
+      },
+      {
+        name: "escrow",
+        writable: true,
+        pda: {
+          seeds: [
+            { kind: "const", value: [101, 115, 99, 114, 111, 119] },
+            { kind: "account", path: "task" },
+          ],
+        },
+      },
+      {
+        name: "task_validation_config",
+        writable: true,
         pda: {
           seeds: [
             {
@@ -246,11 +447,7 @@ const TASK_VALIDATION_V2_INSTRUCTIONS = [
       { name: "treasury", writable: true },
       { name: "creator", writable: true },
       { name: "worker_authority", writable: true },
-      { name: "reviewer", writable: true, signer: true },
-      {
-        name: "system_program",
-        address: "11111111111111111111111111111111",
-      },
+      { name: "authority", writable: true, signer: true },
       { name: "token_escrow_ata", writable: true, optional: true },
       { name: "worker_token_account", writable: true, optional: true },
       { name: "treasury_token_account", writable: true, optional: true },
@@ -260,15 +457,19 @@ const TASK_VALIDATION_V2_INSTRUCTIONS = [
         optional: true,
         address: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
       },
+      {
+        name: "system_program",
+        address: "11111111111111111111111111111111",
+      },
     ],
     args: [],
   },
   {
-    name: "reject_task_result",
+    name: "validate_task_result",
     docs: [
-      "Reject a creator-reviewed submission and return the task to active work.",
+      "Record a validator quorum vote or external attestation for a submission.",
     ],
-    discriminator: [144, 7, 58, 232, 157, 167, 85, 214],
+    discriminator: [141, 192, 86, 228, 233, 168, 41, 224],
     accounts: [
       {
         name: "task",
@@ -288,17 +489,41 @@ const TASK_VALIDATION_V2_INSTRUCTIONS = [
           seeds: [
             { kind: "const", value: [99, 108, 97, 105, 109] },
             { kind: "account", path: "task" },
-            { kind: "account", path: "claim.worker", account: "TaskClaim" },
+            { kind: "account", path: "worker" },
+          ],
+        },
+      },
+      {
+        name: "escrow",
+        writable: true,
+        pda: {
+          seeds: [
+            { kind: "const", value: [101, 115, 99, 114, 111, 119] },
+            { kind: "account", path: "task" },
           ],
         },
       },
       {
         name: "task_validation_config",
+        writable: true,
         pda: {
           seeds: [
             {
               kind: "const",
               value: [116, 97, 115, 107, 95, 118, 97, 108, 105, 100, 97, 116, 105, 111, 110],
+            },
+            { kind: "account", path: "task" },
+          ],
+        },
+      },
+      {
+        name: "task_attestor_config",
+        optional: true,
+        pda: {
+          seeds: [
+            {
+              kind: "const",
+              value: [116, 97, 115, 107, 95, 97, 116, 116, 101, 115, 116, 111, 114],
             },
             { kind: "account", path: "task" },
           ],
@@ -318,14 +543,69 @@ const TASK_VALIDATION_V2_INSTRUCTIONS = [
         },
       },
       {
+        name: "task_validation_vote",
+        writable: true,
+        pda: {
+          seeds: [
+            {
+              kind: "const",
+              value: [
+                116, 97, 115, 107, 95, 118, 97, 108, 105, 100, 97, 116, 105, 111, 110, 95, 118,
+                111, 116, 101,
+              ],
+            },
+            { kind: "account", path: "task_submission" },
+            { kind: "account", path: "reviewer" },
+          ],
+        },
+      },
+      {
+        name: "worker",
+        writable: true,
+        pda: {
+          seeds: [
+            { kind: "const", value: [97, 103, 101, 110, 116] },
+            {
+              kind: "account",
+              path: "worker.agent_id",
+              account: "AgentRegistration",
+            },
+          ],
+        },
+      },
+      {
         name: "protocol_config",
+        writable: true,
         pda: {
           seeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108] }],
         },
       },
-      { name: "creator", writable: true, signer: true },
+      {
+        name: "validator_agent",
+        docs: [
+          "Optional validator agent for validator-quorum mode, validated in handler.",
+        ],
+        optional: true,
+      },
+      { name: "treasury", writable: true },
+      { name: "creator", writable: true },
+      { name: "worker_authority", writable: true },
+      { name: "reviewer", writable: true, signer: true },
+      { name: "token_escrow_ata", writable: true, optional: true },
+      { name: "worker_token_account", writable: true, optional: true },
+      { name: "treasury_token_account", writable: true, optional: true },
+      { name: "reward_mint", optional: true },
+      {
+        name: "token_program",
+        optional: true,
+        address: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+      },
+      {
+        name: "system_program",
+        address: "11111111111111111111111111111111",
+      },
     ],
-    args: [{ name: "rejection_hash", type: { array: ["u8", 32] } }],
+    args: [{ name: "approved", type: "bool" }],
   },
 ] as const;
 
@@ -337,6 +617,14 @@ const TASK_VALIDATION_V2_ACCOUNTS = [
   {
     name: "TaskSubmission",
     discriminator: [111, 64, 190, 132, 148, 33, 215, 63],
+  },
+  {
+    name: "TaskAttestorConfig",
+    discriminator: [103, 130, 20, 87, 207, 120, 111, 34],
+  },
+  {
+    name: "TaskValidationVote",
+    discriminator: [48, 129, 51, 174, 154, 5, 68, 65],
   },
 ] as const;
 
@@ -382,7 +670,7 @@ const TASK_VALIDATION_V2_TYPES = [
   {
     name: "TaskSubmission",
     docs: [
-      "Claim-level submission state for creator-review validation.",
+      "Claim-level submission state for manual validation.",
       'PDA seeds: ["task_submission", claim]',
     ],
     type: {
@@ -446,17 +734,103 @@ const TASK_VALIDATION_V2_TYPES = [
     },
   },
   {
+    name: "TaskAttestorConfig",
+    docs: [
+      "Task-level external attestor configuration.",
+      'PDA seeds: ["task_attestor", task]',
+    ],
+    type: {
+      kind: "struct",
+      fields: [
+        { name: "task", docs: ["Task this config belongs to."], type: "pubkey" },
+        {
+          name: "creator",
+          docs: ["Task creator / reviewer authority."],
+          type: "pubkey",
+        },
+        {
+          name: "attestor",
+          docs: ["Wallet allowed to attest the outcome."],
+          type: "pubkey",
+        },
+        { name: "created_at", docs: ["Creation timestamp."], type: "i64" },
+        { name: "updated_at", docs: ["Last update timestamp."], type: "i64" },
+        { name: "bump", docs: ["PDA bump."], type: "u8" },
+        {
+          name: "_reserved",
+          docs: ["Reserved for future attestor metadata."],
+          type: { array: ["u8", 7] },
+        },
+      ],
+    },
+  },
+  {
+    name: "TaskValidationVote",
+    docs: [
+      "Reviewer vote or attestation recorded for a task submission round.",
+      'PDA seeds: ["task_validation_vote", task_submission, reviewer]',
+    ],
+    type: {
+      kind: "struct",
+      fields: [
+        {
+          name: "submission",
+          docs: ["Submission being validated."],
+          type: "pubkey",
+        },
+        {
+          name: "reviewer",
+          docs: ["Reviewer wallet that cast the vote / attestation."],
+          type: "pubkey",
+        },
+        {
+          name: "reviewer_agent",
+          docs: [
+            "Reviewer agent used for validator-quorum mode (default pubkey for attestors).",
+          ],
+          type: "pubkey",
+        },
+        {
+          name: "submission_round",
+          docs: ["Submission round the vote applies to."],
+          type: "u16",
+        },
+        {
+          name: "approved",
+          docs: ["Whether the reviewer approved the result."],
+          type: "bool",
+        },
+        {
+          name: "voted_at",
+          docs: ["Timestamp of the vote / attestation."],
+          type: "i64",
+        },
+        { name: "bump", docs: ["PDA bump."], type: "u8" },
+        {
+          name: "_reserved",
+          docs: ["Reserved for future metadata."],
+          type: { array: ["u8", 5] },
+        },
+      ],
+    },
+  },
+  {
     name: "ValidationMode",
     docs: ["Validation mode configured for a task."],
     repr: { kind: "rust" },
     type: {
       kind: "enum",
-      variants: [{ name: "Auto" }, { name: "CreatorReview" }],
+      variants: [
+        { name: "Auto" },
+        { name: "CreatorReview" },
+        { name: "ValidatorQuorum" },
+        { name: "ExternalAttestation" },
+      ],
     },
   },
   {
     name: "SubmissionStatus",
-    docs: ["Task submission lifecycle for creator-review validation."],
+    docs: ["Task submission lifecycle for manual validation."],
     repr: { kind: "rust" },
     type: {
       kind: "enum",

--- a/runtime/src/task/operations.test.ts
+++ b/runtime/src/task/operations.test.ts
@@ -172,6 +172,8 @@ function createMockProgram() {
   const submitTaskResultRpc = vi.fn().mockResolvedValue("submit-sig");
   const acceptTaskResultRpc = vi.fn().mockResolvedValue("accept-sig");
   const rejectTaskResultRpc = vi.fn().mockResolvedValue("reject-sig");
+  const autoAcceptTaskResultRpc = vi.fn().mockResolvedValue("auto-accept-sig");
+  const validateTaskResultRpc = vi.fn().mockResolvedValue("validate-sig");
 
   const claimTaskBuilder = {
     accountsPartial: vi.fn().mockReturnThis(),
@@ -206,6 +208,16 @@ function createMockProgram() {
     accountsPartial: vi.fn().mockReturnThis(),
     rpc: rejectTaskResultRpc,
   };
+  const autoAcceptTaskResultBuilder = {
+    accountsPartial: vi.fn().mockReturnThis(),
+    remainingAccounts: vi.fn().mockReturnThis(),
+    rpc: autoAcceptTaskResultRpc,
+  };
+  const validateTaskResultBuilder = {
+    accountsPartial: vi.fn().mockReturnThis(),
+    remainingAccounts: vi.fn().mockReturnThis(),
+    rpc: validateTaskResultRpc,
+  };
   const completeTaskPrivateMethod = vi
     .fn()
     .mockReturnValue(completeTaskPrivateBuilder);
@@ -221,6 +233,12 @@ function createMockProgram() {
   const rejectTaskResultMethod = vi
     .fn()
     .mockReturnValue(rejectTaskResultBuilder);
+  const autoAcceptTaskResultMethod = vi
+    .fn()
+    .mockReturnValue(autoAcceptTaskResultBuilder);
+  const validateTaskResultMethod = vi
+    .fn()
+    .mockReturnValue(validateTaskResultBuilder);
 
   const program = {
     programId: PROGRAM_ID,
@@ -239,6 +257,8 @@ function createMockProgram() {
       submitTaskResult: submitTaskResultMethod,
       acceptTaskResult: acceptTaskResultMethod,
       rejectTaskResult: rejectTaskResultMethod,
+      autoAcceptTaskResult: autoAcceptTaskResultMethod,
+      validateTaskResult: validateTaskResultMethod,
     },
   };
 
@@ -258,11 +278,15 @@ function createMockProgram() {
       submitTaskResultRpc,
       acceptTaskResultRpc,
       rejectTaskResultRpc,
+      autoAcceptTaskResultRpc,
+      validateTaskResultRpc,
       completeTaskPrivateMethod,
       configureTaskValidationMethod,
       submitTaskResultMethod,
       acceptTaskResultMethod,
       rejectTaskResultMethod,
+      autoAcceptTaskResultMethod,
+      validateTaskResultMethod,
       claimTaskBuilder,
       completeTaskBuilder,
       completeTaskPrivateBuilder,
@@ -270,6 +294,8 @@ function createMockProgram() {
       submitTaskResultBuilder,
       acceptTaskResultBuilder,
       rejectTaskResultBuilder,
+      autoAcceptTaskResultBuilder,
+      validateTaskResultBuilder,
     },
   };
 }
@@ -934,12 +960,15 @@ describe("TaskOperations", () => {
     it("configures task validation with creator review mode", async () => {
       const taskPda = Keypair.generate().publicKey;
       const task = createParsedTask();
+      const attestor = Keypair.generate().publicKey;
 
       const result = await ops.configureTaskValidation(
         taskPda,
         task,
         TaskValidationMode.CreatorReview,
         900,
+        2,
+        attestor,
       );
 
       expect(result.success).toBe(true);
@@ -951,15 +980,21 @@ describe("TaskOperations", () => {
       expect(
         mocks.configureTaskValidationMethod.mock.calls[0][1].toString(),
       ).toBe("900");
+      expect(mocks.configureTaskValidationMethod.mock.calls[0][2]).toBe(2);
+      expect(mocks.configureTaskValidationMethod.mock.calls[0][3]).toBe(
+        attestor,
+      );
       expect(
         mocks.configureTaskValidationBuilder.accountsPartial,
       ).toHaveBeenCalledWith(
         expect.objectContaining({
           task: taskPda,
+          taskAttestorConfig: expect.any(PublicKey),
           creator: mockProgram.provider.publicKey,
           systemProgram: SystemProgram.programId,
         }),
       );
+      expect(result.taskAttestorConfigPda).toBeInstanceOf(PublicKey);
     });
 
     it("submits a task result for creator review", async () => {
@@ -1018,8 +1053,8 @@ describe("TaskOperations", () => {
         expect.objectContaining({
           task: taskPda,
           worker: workerPda,
+          creator: mockProgram.provider.publicKey,
           workerAuthority,
-          reviewer: mockProgram.provider.publicKey,
         }),
       );
       expect(
@@ -1036,7 +1071,12 @@ describe("TaskOperations", () => {
       const taskPda = Keypair.generate().publicKey;
       const task = createParsedTask();
       const workerPda = Keypair.generate().publicKey;
+      const workerAuthority = Keypair.generate().publicKey;
       const rejectionHash = new Uint8Array(32).fill(0xee);
+
+      mocks.agentRegistrationFetch.mockResolvedValue(
+        createMockRawAgentRegistration(workerAuthority),
+      );
 
       const result = await ops.rejectTaskResult(
         taskPda,
@@ -1047,11 +1087,97 @@ describe("TaskOperations", () => {
 
       expect(result.success).toBe(true);
       expect(result.transactionSignature).toBe("reject-sig");
+      expect(mocks.agentRegistrationFetch).toHaveBeenCalledWith(workerPda);
       expect(mocks.rejectTaskResultMethod).toHaveBeenCalledTimes(1);
       expect(mocks.rejectTaskResultBuilder.accountsPartial).toHaveBeenCalledWith(
         expect.objectContaining({
           task: taskPda,
           creator: mockProgram.provider.publicKey,
+          worker: workerPda,
+          workerAuthority,
+        }),
+      );
+    });
+
+    it("auto-accepts a timed-out reviewed task result", async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createParsedTask();
+      const workerPda = Keypair.generate().publicKey;
+      const workerAuthority = Keypair.generate().publicKey;
+      const bidBook = Keypair.generate().publicKey;
+      const acceptedBid = Keypair.generate().publicKey;
+      const bidderMarketState = Keypair.generate().publicKey;
+
+      mocks.agentRegistrationFetch.mockResolvedValue(
+        createMockRawAgentRegistration(workerAuthority),
+      );
+
+      const result = await ops.autoAcceptTaskResult(taskPda, task, workerPda, {
+        acceptedBidSettlement: {
+          bidBook,
+          acceptedBid,
+          bidderMarketState,
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.transactionSignature).toBe("auto-accept-sig");
+      expect(mocks.autoAcceptTaskResultMethod).toHaveBeenCalledTimes(1);
+      expect(
+        mocks.autoAcceptTaskResultBuilder.accountsPartial,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          task: taskPda,
+          worker: workerPda,
+          creator: task.creator,
+          authority: mockProgram.provider.publicKey,
+          workerAuthority,
+        }),
+      );
+      expect(
+        mocks.autoAcceptTaskResultBuilder.remainingAccounts,
+      ).toHaveBeenCalledWith([
+        { pubkey: bidBook, isSigner: false, isWritable: true },
+        { pubkey: acceptedBid, isSigner: false, isWritable: true },
+        { pubkey: bidderMarketState, isSigner: false, isWritable: true },
+        { pubkey: workerAuthority, isSigner: false, isWritable: true },
+      ]);
+    });
+
+    it("records a validator vote for a reviewed task result", async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createParsedTask();
+      const workerPda = Keypair.generate().publicKey;
+      const workerAuthority = Keypair.generate().publicKey;
+      const validatorAgentPda = Keypair.generate().publicKey;
+
+      mocks.agentRegistrationFetch.mockResolvedValue(
+        createMockRawAgentRegistration(workerAuthority),
+      );
+
+      const result = await ops.validateTaskResult(
+        taskPda,
+        task,
+        workerPda,
+        true,
+        validatorAgentPda,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.transactionSignature).toBe("validate-sig");
+      expect(result.taskValidationVotePda).toBeInstanceOf(PublicKey);
+      expect(mocks.validateTaskResultMethod).toHaveBeenCalledTimes(1);
+      expect(mocks.validateTaskResultMethod).toHaveBeenCalledWith(true);
+      expect(mocks.validateTaskResultBuilder.accountsPartial).toHaveBeenCalledWith(
+        expect.objectContaining({
+          task: taskPda,
+          worker: workerPda,
+          creator: task.creator,
+          reviewer: mockProgram.provider.publicKey,
+          validatorAgent: validatorAgentPda,
+          taskAttestorConfig: null,
+          taskValidationVote: expect.any(PublicKey),
+          workerAuthority,
         }),
       );
     });

--- a/runtime/src/task/operations.ts
+++ b/runtime/src/task/operations.ts
@@ -40,7 +40,15 @@ import {
   parseOnChainTaskClaim,
   OnChainTaskStatus,
 } from "./types.js";
-import { deriveTaskPda, deriveClaimPda, deriveEscrowPda } from "./pda.js";
+import {
+  deriveTaskPda,
+  deriveClaimPda,
+  deriveEscrowPda,
+  deriveTaskValidationConfigPda,
+  deriveTaskAttestorConfigPda,
+  deriveTaskSubmissionPda,
+  deriveTaskValidationVotePda,
+} from "./pda.js";
 import { deriveAgentPda, findProtocolPda } from "../agent/pda.js";
 import { parseAgentState } from "../agent/types.js";
 import { fetchTreasury } from "../utils/treasury.js";
@@ -74,34 +82,12 @@ const BINDING_SPEND_SEED = Buffer.from("binding_spend");
 const NULLIFIER_SPEND_SEED = Buffer.from("nullifier_spend");
 const ROUTER_SEED = Buffer.from("router");
 const VERIFIER_SEED = Buffer.from("verifier");
-const TASK_VALIDATION_SEED = Buffer.from("task_validation");
-const TASK_SUBMISSION_SEED = Buffer.from("task_submission");
 const TRUSTED_RISC0_ROUTER_PROGRAM_ID = new PublicKey(
   "E9ZiqfCdr6gGeB2UhBbkWnFP9vGnRYQwqnDsS1LM3NJZ",
 );
 const TRUSTED_RISC0_VERIFIER_PROGRAM_ID = new PublicKey(
   "3ZrAHZKjk24AKgXFekpYeG7v3Rz7NucLXTB3zxGGTjsc",
 );
-
-function deriveTaskValidationConfigPda(
-  taskPda: PublicKey,
-  programId: PublicKey,
-): PublicKey {
-  return PublicKey.findProgramAddressSync(
-    [TASK_VALIDATION_SEED, taskPda.toBuffer()],
-    programId,
-  )[0];
-}
-
-function deriveTaskSubmissionPda(
-  claimPda: PublicKey,
-  programId: PublicKey,
-): PublicKey {
-  return PublicKey.findProgramAddressSync(
-    [TASK_SUBMISSION_SEED, claimPda.toBuffer()],
-    programId,
-  )[0];
-}
 
 // ============================================================================
 // Configuration
@@ -490,6 +476,8 @@ export class TaskOperations {
     task: OnChainTask,
     mode: TaskValidationMode | number,
     reviewWindowSecs: number | bigint,
+    validatorQuorum = 0,
+    attestor?: PublicKey | null,
   ): Promise<TaskValidationConfigResult> {
     const creator = this.program.provider.publicKey;
     if (!creator) {
@@ -501,13 +489,19 @@ export class TaskOperations {
     const taskValidationConfigPda = deriveTaskValidationConfigPda(
       taskPda,
       this.program.programId,
-    );
+    ).address;
+    const taskAttestorConfigPda = deriveTaskAttestorConfigPda(
+      taskPda,
+      this.program.programId,
+    ).address;
     const protocolPda = findProtocolPda(this.program.programId);
 
     const methods = this.program.methods as unknown as {
       configureTaskValidation: (
         validationMode: number,
         reviewWindow: BN,
+        validatorQuorum: number,
+        attestor: PublicKey | null,
       ) => {
         accountsPartial: (accounts: Record<string, unknown>) => {
           rpc: () => Promise<string>;
@@ -519,10 +513,16 @@ export class TaskOperations {
 
     try {
       const signature = await methods
-        .configureTaskValidation(Number(mode), new BN(reviewWindowSecs.toString()))
+        .configureTaskValidation(
+          Number(mode),
+          new BN(reviewWindowSecs.toString()),
+          validatorQuorum,
+          attestor ?? null,
+        )
         .accountsPartial({
           task: taskPda,
           taskValidationConfig: taskValidationConfigPda,
+          taskAttestorConfig: taskAttestorConfigPda,
           protocolConfig: protocolPda,
           creator,
           systemProgram: SystemProgram.programId,
@@ -533,6 +533,7 @@ export class TaskOperations {
         success: true,
         taskId: task.taskId,
         taskValidationConfigPda,
+        taskAttestorConfigPda,
         transactionSignature: signature,
       };
     } catch (err) {
@@ -583,11 +584,11 @@ export class TaskOperations {
     const taskValidationConfigPda = deriveTaskValidationConfigPda(
       taskPda,
       this.program.programId,
-    );
+    ).address;
     const taskSubmissionPda = deriveTaskSubmissionPda(
       claimPda,
       this.program.programId,
-    );
+    ).address;
     const protocolPda = findProtocolPda(this.program.programId);
 
     const methods = this.program.methods as unknown as {
@@ -653,10 +654,10 @@ export class TaskOperations {
     workerPda: PublicKey,
     options?: TaskCompletionOptions,
   ): Promise<CompleteResult> {
-    const reviewer = this.program.provider.publicKey;
-    if (!reviewer) {
+    const creator = this.program.provider.publicKey;
+    if (!creator) {
       throw new ValidationError(
-        "Program provider does not have a public key for task review",
+        "Program provider does not have a public key for task acceptance",
       );
     }
 
@@ -672,11 +673,11 @@ export class TaskOperations {
     const taskValidationConfigPda = deriveTaskValidationConfigPda(
       taskPda,
       this.program.programId,
-    );
+    ).address;
     const taskSubmissionPda = deriveTaskSubmissionPda(
       claimPda,
       this.program.programId,
-    );
+    ).address;
     const protocolPda = findProtocolPda(this.program.programId);
     const treasury = await this.getProtocolTreasury();
     const workerAuthority = await this.getWorkerAuthority(workerPda);
@@ -712,9 +713,8 @@ export class TaskOperations {
         worker: workerPda,
         protocolConfig: protocolPda,
         treasury,
-        creator: task.creator,
+        creator,
         workerAuthority,
-        reviewer,
         systemProgram: SystemProgram.programId,
         ...tokenAccounts,
       });
@@ -774,11 +774,11 @@ export class TaskOperations {
     const taskValidationConfigPda = deriveTaskValidationConfigPda(
       taskPda,
       this.program.programId,
-    );
+    ).address;
     const taskSubmissionPda = deriveTaskSubmissionPda(
       claimPda,
       this.program.programId,
-    );
+    ).address;
     const protocolPda = findProtocolPda(this.program.programId);
 
     const methods = this.program.methods as unknown as {
@@ -792,6 +792,7 @@ export class TaskOperations {
     this.logger.info(`Rejecting task result ${taskPda.toBase58()}`);
 
     try {
+      const workerAuthority = await this.getWorkerAuthority(workerPda);
       const signature = await methods
         .rejectTaskResult(toAnchorBytes(rejectionHash))
         .accountsPartial({
@@ -799,8 +800,10 @@ export class TaskOperations {
           claim: claimPda,
           taskValidationConfig: taskValidationConfigPda,
           taskSubmission: taskSubmissionPda,
+          worker: workerPda,
           protocolConfig: protocolPda,
           creator,
+          workerAuthority,
         })
         .rpc();
 
@@ -813,6 +816,231 @@ export class TaskOperations {
     } catch (err) {
       this.logger.error(
         `Failed to reject task result ${taskPda.toBase58()}: ${err}`,
+      );
+      throw new TaskSubmissionError(
+        taskPda,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  /**
+   * Permissionlessly auto-accept a timed-out creator-review submission.
+   *
+   * @param taskPda - Task account PDA
+   * @param task - The on-chain task data
+   * @param workerPda - Worker agent PDA that owns the submission
+   * @param options - Optional dependent-task and marketplace settlement accounts
+   * @returns Completion result with signature
+   */
+  async autoAcceptTaskResult(
+    taskPda: PublicKey,
+    task: OnChainTask,
+    workerPda: PublicKey,
+    options?: TaskCompletionOptions,
+  ): Promise<CompleteResult> {
+    const authority = this.program.provider.publicKey;
+    if (!authority) {
+      throw new ValidationError(
+        "Program provider does not have a public key for auto-acceptance",
+      );
+    }
+
+    const { address: claimPda } = deriveClaimPda(
+      taskPda,
+      workerPda,
+      this.program.programId,
+    );
+    const { address: escrowPda } = deriveEscrowPda(
+      taskPda,
+      this.program.programId,
+    );
+    const taskValidationConfigPda = deriveTaskValidationConfigPda(
+      taskPda,
+      this.program.programId,
+    ).address;
+    const taskSubmissionPda = deriveTaskSubmissionPda(
+      claimPda,
+      this.program.programId,
+    ).address;
+    const protocolPda = findProtocolPda(this.program.programId);
+    const treasury = await this.getProtocolTreasury();
+    const workerAuthority = await this.getWorkerAuthority(workerPda);
+    const tokenAccounts = buildCompleteTaskTokenAccounts(
+      task.rewardMint,
+      escrowPda,
+      workerAuthority,
+      treasury,
+    );
+    const remainingAccounts = this.buildTaskCompletionRemainingAccounts(
+      options,
+      workerAuthority,
+    );
+
+    const methods = this.program.methods as unknown as {
+      autoAcceptTaskResult: () => {
+        accountsPartial: (accounts: Record<string, unknown>) => {
+          remainingAccounts: (accounts: AccountMeta[]) => { rpc: () => Promise<string> };
+          rpc: () => Promise<string>;
+        };
+      };
+    };
+
+    this.logger.info(`Auto-accepting task result ${taskPda.toBase58()}`);
+
+    try {
+      const builder = methods.autoAcceptTaskResult().accountsPartial({
+        task: taskPda,
+        claim: claimPda,
+        escrow: escrowPda,
+        taskValidationConfig: taskValidationConfigPda,
+        taskSubmission: taskSubmissionPda,
+        worker: workerPda,
+        protocolConfig: protocolPda,
+        treasury,
+        creator: task.creator,
+        workerAuthority,
+        authority,
+        systemProgram: SystemProgram.programId,
+        ...tokenAccounts,
+      });
+
+      if (remainingAccounts.length > 0) {
+        builder.remainingAccounts(remainingAccounts);
+      }
+
+      const signature = await builder.rpc();
+
+      return {
+        success: true,
+        taskId: task.taskId,
+        isPrivate: false,
+        transactionSignature: signature,
+      };
+    } catch (err) {
+      this.logger.error(
+        `Failed to auto-accept task result ${taskPda.toBase58()}: ${err}`,
+      );
+      throw new TaskSubmissionError(
+        taskPda,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  /**
+   * Record a validator quorum vote or external attestation for a submission.
+   *
+   * @param taskPda - Task account PDA
+   * @param task - The on-chain task data
+   * @param workerPda - Worker agent PDA that owns the submission
+   * @param approved - Whether the reviewer approves the submission
+   * @param validatorAgentPda - Optional validator agent PDA for quorum mode
+   * @param options - Optional dependent-task and marketplace settlement accounts
+   * @returns Submission result with signature, submission PDA, and vote PDA
+   */
+  async validateTaskResult(
+    taskPda: PublicKey,
+    task: OnChainTask,
+    workerPda: PublicKey,
+    approved: boolean,
+    validatorAgentPda?: PublicKey | null,
+    options?: TaskCompletionOptions,
+  ): Promise<TaskSubmissionResult> {
+    const reviewer = this.program.provider.publicKey;
+    if (!reviewer) {
+      throw new ValidationError(
+        "Program provider does not have a public key for task validation voting",
+      );
+    }
+
+    const { address: claimPda } = deriveClaimPda(
+      taskPda,
+      workerPda,
+      this.program.programId,
+    );
+    const { address: escrowPda } = deriveEscrowPda(
+      taskPda,
+      this.program.programId,
+    );
+    const taskValidationConfigPda = deriveTaskValidationConfigPda(
+      taskPda,
+      this.program.programId,
+    ).address;
+    const taskAttestorConfigPda = deriveTaskAttestorConfigPda(
+      taskPda,
+      this.program.programId,
+    ).address;
+    const taskSubmissionPda = deriveTaskSubmissionPda(
+      claimPda,
+      this.program.programId,
+    ).address;
+    const taskValidationVotePda = deriveTaskValidationVotePda(
+      taskSubmissionPda,
+      reviewer,
+      this.program.programId,
+    ).address;
+    const protocolPda = findProtocolPda(this.program.programId);
+    const treasury = await this.getProtocolTreasury();
+    const workerAuthority = await this.getWorkerAuthority(workerPda);
+    const tokenAccounts = buildCompleteTaskTokenAccounts(
+      task.rewardMint,
+      escrowPda,
+      workerAuthority,
+      treasury,
+    );
+    const remainingAccounts = this.buildTaskCompletionRemainingAccounts(
+      options,
+      workerAuthority,
+    );
+
+    const methods = this.program.methods as unknown as {
+      validateTaskResult: (approved: boolean) => {
+        accountsPartial: (accounts: Record<string, unknown>) => {
+          remainingAccounts: (accounts: AccountMeta[]) => { rpc: () => Promise<string> };
+          rpc: () => Promise<string>;
+        };
+      };
+    };
+
+    this.logger.info(`Recording task validation vote ${taskPda.toBase58()}`);
+
+    try {
+      const builder = methods.validateTaskResult(approved).accountsPartial({
+        task: taskPda,
+        claim: claimPda,
+        escrow: escrowPda,
+        taskValidationConfig: taskValidationConfigPda,
+        taskAttestorConfig: validatorAgentPda ? null : taskAttestorConfigPda,
+        taskSubmission: taskSubmissionPda,
+        taskValidationVote: taskValidationVotePda,
+        worker: workerPda,
+        protocolConfig: protocolPda,
+        validatorAgent: validatorAgentPda ?? null,
+        treasury,
+        creator: task.creator,
+        workerAuthority,
+        reviewer,
+        systemProgram: SystemProgram.programId,
+        ...tokenAccounts,
+      });
+
+      if (remainingAccounts.length > 0) {
+        builder.remainingAccounts(remainingAccounts);
+      }
+
+      const signature = await builder.rpc();
+
+      return {
+        success: true,
+        taskId: task.taskId,
+        taskSubmissionPda,
+        taskValidationVotePda,
+        transactionSignature: signature,
+      };
+    } catch (err) {
+      this.logger.error(
+        `Failed to validate task result ${taskPda.toBase58()}: ${err}`,
       );
       throw new TaskSubmissionError(
         taskPda,

--- a/runtime/src/task/pda.ts
+++ b/runtime/src/task/pda.ts
@@ -14,6 +14,20 @@ import type { PdaWithBump } from "../utils/pda.js";
 /** Length of task_id field (bytes) */
 export const TASK_ID_LENGTH = 32;
 
+type OptionalSeedRecord = Partial<Record<string, Buffer>>;
+
+// The runtime can be upgraded ahead of the published SDK package. Fall back to
+// the raw seed bytes locally until the matching SDK release is available.
+const optionalSeeds = SEEDS as OptionalSeedRecord;
+const TASK_VALIDATION_SEED =
+  optionalSeeds.TASK_VALIDATION ?? Buffer.from("task_validation");
+const TASK_ATTESTOR_SEED =
+  optionalSeeds.TASK_ATTESTOR ?? Buffer.from("task_attestor");
+const TASK_SUBMISSION_SEED =
+  optionalSeeds.TASK_SUBMISSION ?? Buffer.from("task_submission");
+const TASK_VALIDATION_VOTE_SEED =
+  optionalSeeds.TASK_VALIDATION_VOTE ?? Buffer.from("task_validation_vote");
+
 /**
  * Derives the task PDA and bump seed.
  * Seeds: ["task", creator, task_id]
@@ -155,6 +169,137 @@ export function findEscrowPda(
   programId: PublicKey = PROGRAM_ID,
 ): PublicKey {
   return deriveEscrowPda(taskPda, programId).address;
+}
+
+/**
+ * Derives the task validation config PDA and bump seed.
+ * Seeds: ["task_validation", task_pda]
+ *
+ * @param taskPda - Task account PDA
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address and bump seed
+ */
+export function deriveTaskValidationConfigPda(
+  taskPda: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): PdaWithBump {
+  return derivePda([TASK_VALIDATION_SEED, taskPda.toBuffer()], programId);
+}
+
+/**
+ * Finds the task validation config PDA address (without bump).
+ *
+ * @param taskPda - Task account PDA
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address
+ */
+export function findTaskValidationConfigPda(
+  taskPda: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): PublicKey {
+  return deriveTaskValidationConfigPda(taskPda, programId).address;
+}
+
+/**
+ * Derives the task attestor config PDA and bump seed.
+ * Seeds: ["task_attestor", task_pda]
+ *
+ * @param taskPda - Task account PDA
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address and bump seed
+ */
+export function deriveTaskAttestorConfigPda(
+  taskPda: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): PdaWithBump {
+  return derivePda([TASK_ATTESTOR_SEED, taskPda.toBuffer()], programId);
+}
+
+/**
+ * Finds the task attestor config PDA address (without bump).
+ *
+ * @param taskPda - Task account PDA
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address
+ */
+export function findTaskAttestorConfigPda(
+  taskPda: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): PublicKey {
+  return deriveTaskAttestorConfigPda(taskPda, programId).address;
+}
+
+/**
+ * Derives the task submission PDA and bump seed.
+ * Seeds: ["task_submission", claim_pda]
+ *
+ * @param claimPda - Task claim PDA
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address and bump seed
+ */
+export function deriveTaskSubmissionPda(
+  claimPda: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): PdaWithBump {
+  return derivePda([TASK_SUBMISSION_SEED, claimPda.toBuffer()], programId);
+}
+
+/**
+ * Finds the task submission PDA address (without bump).
+ *
+ * @param claimPda - Task claim PDA
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address
+ */
+export function findTaskSubmissionPda(
+  claimPda: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): PublicKey {
+  return deriveTaskSubmissionPda(claimPda, programId).address;
+}
+
+/**
+ * Derives the task validation vote PDA and bump seed.
+ * Seeds: ["task_validation_vote", task_submission_pda, reviewer]
+ *
+ * @param taskSubmissionPda - Task submission PDA
+ * @param reviewer - Reviewer wallet public key
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address and bump seed
+ */
+export function deriveTaskValidationVotePda(
+  taskSubmissionPda: PublicKey,
+  reviewer: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): PdaWithBump {
+  return derivePda(
+    [
+      TASK_VALIDATION_VOTE_SEED,
+      taskSubmissionPda.toBuffer(),
+      reviewer.toBuffer(),
+    ],
+    programId,
+  );
+}
+
+/**
+ * Finds the task validation vote PDA address (without bump).
+ *
+ * @param taskSubmissionPda - Task submission PDA
+ * @param reviewer - Reviewer wallet public key
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address
+ */
+export function findTaskValidationVotePda(
+  taskSubmissionPda: PublicKey,
+  reviewer: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): PublicKey {
+  return deriveTaskValidationVotePda(
+    taskSubmissionPda,
+    reviewer,
+    programId,
+  ).address;
 }
 
 /**

--- a/runtime/src/task/types.ts
+++ b/runtime/src/task/types.ts
@@ -50,6 +50,10 @@ export enum TaskValidationMode {
   Auto = 0,
   /** Submit work for creator review before settlement */
   CreatorReview = 1,
+  /** Require multiple validator approvals before settlement */
+  ValidatorQuorum = 2,
+  /** Require an external attestor wallet to approve settlement */
+  ExternalAttestation = 3,
 }
 
 /**
@@ -890,6 +894,8 @@ export interface TaskValidationConfigResult {
   taskId: Uint8Array;
   /** Validation config PDA address */
   taskValidationConfigPda: PublicKey;
+  /** Task attestor config PDA address */
+  taskAttestorConfigPda?: PublicKey;
   /** Transaction signature if submitted */
   transactionSignature?: TransactionSignature;
   /** Error message if configuration failed */
@@ -906,6 +912,8 @@ export interface TaskSubmissionResult {
   taskId: Uint8Array;
   /** Submission PDA address */
   taskSubmissionPda: PublicKey;
+  /** Validation vote PDA address for validator/attestor review flows */
+  taskValidationVotePda?: PublicKey;
   /** Transaction signature if submitted */
   transactionSignature?: TransactionSignature;
   /** Error message if the action failed */


### PR DESCRIPTION
## Summary
- extend the local IDL merge with validator quorum, external attestor, and vote/attestor accounts
- add runtime PDA helpers plus task operations for auto-accept and validator review flows
- keep local seed fallbacks so runtime support does not depend on SDK release timing

## Testing
- `npm run typecheck`
- `npx vitest run runtime/src/idl.test.ts runtime/src/task/operations.test.ts`
