### PR TITLE
fix(runtime): harden delegated scope trust and completion flow

### DIFF
--- a/docs/architecture/guides/delegated-workspace-semantics.md
+++ b/docs/architecture/guides/delegated-workspace-semantics.md
@@ -6,13 +6,18 @@ This guide defines the final delegated local-file execution rules for AgenC runt
 
 Delegated local-file execution has one executable filesystem contract:
 
-- `executionContext.workspaceRoot`
-- `executionContext.allowedReadRoots`
-- `executionContext.allowedWriteRoots`
-- `executionContext.requiredSourceArtifacts`
-- `executionContext.targetArtifacts`
+- runtime-owned `executionContext.workspaceRoot`
+- runtime-owned `executionContext.allowedReadRoots`
+- runtime-owned `executionContext.allowedWriteRoots`
+- validated `executionContext.requiredSourceArtifacts`
+- validated `executionContext.targetArtifacts`
 
 Those values are canonical concrete host paths by the time a child session is spawned.
+
+On the live public `execute_with_agent` path, the model must not supply the
+first trusted root. The public contract may carry bounded artifact and
+verification hints, but the runtime derives the child workspace root and
+allowed roots from trusted parent session state.
 
 ## Why `/workspace` is presentation-only
 
@@ -65,9 +70,9 @@ Why:
 When delegated local-file spawn fails before child execution, check these in order:
 
 1. Does the step carry a canonical `executionContext`?
-2. Does `executionContext.workspaceRoot` match the child `workingDirectory`?
-3. Are all required source artifacts inside `allowedReadRoots` and present on disk?
-4. Are all target artifacts inside `allowedWriteRoots`?
+2. Does the runtime-owned `executionContext.workspaceRoot` match the child `workingDirectory`?
+3. Are all required source artifacts inside the runtime-owned `allowedReadRoots` and present on disk?
+4. Are all target artifacts inside the runtime-owned `allowedWriteRoots`?
 5. Are any paths still using `/workspace/...` instead of concrete host paths?
 
 Common failure modes:

--- a/runtime/src/eval/delegated-workspace-gate-suite.ts
+++ b/runtime/src/eval/delegated-workspace-gate-suite.ts
@@ -394,8 +394,6 @@ async function runDegradedProviderRetryBrokenScopeScenario(): Promise<PipelineDe
   const completionState = resolveWorkflowCompletionState({
     stopReason: "completed",
     toolCalls: [],
-    plannerUsed: true,
-    deterministicStepsExecuted: 1,
     verificationContract,
     verifier: {
       performed: false,

--- a/runtime/src/eval/implementation-gate-suite.ts
+++ b/runtime/src/eval/implementation-gate-suite.ts
@@ -170,8 +170,6 @@ function resolveVerifiedCompletionState(params: {
       result: typeof toolCall.result === "string" ? toolCall.result : "",
       isError: toolCall.isError === true,
     })),
-    plannerUsed: true,
-    deterministicStepsExecuted: 1,
     verificationContract: params.verificationContract,
     verifier: {
       performed: params.verifierPerformed,

--- a/runtime/src/gateway/config-watcher.ts
+++ b/runtime/src/gateway/config-watcher.ts
@@ -2411,7 +2411,7 @@ function validateLlmSection(llm: unknown, errors: string[]): void {
     requireIntRange(llm.maxRuntimeHints, "llm.maxRuntimeHints", 0, 32, errors);
   }
   if (llm.maxToolRounds !== undefined) {
-    requireIntRange(llm.maxToolRounds, "llm.maxToolRounds", 1, 64, errors);
+    requireIntRange(llm.maxToolRounds, "llm.maxToolRounds", 1, 2_048, errors);
   }
   if (llm.plannerEnabled !== undefined && typeof llm.plannerEnabled !== "boolean") {
     errors.push("llm.plannerEnabled must be a boolean");
@@ -2421,7 +2421,7 @@ function validateLlmSection(llm: unknown, errors: string[]): void {
       llm.plannerMaxTokens,
       "llm.plannerMaxTokens",
       16,
-      8_192,
+      65_536,
       errors,
     );
   }
@@ -2430,7 +2430,7 @@ function validateLlmSection(llm: unknown, errors: string[]): void {
       llm.toolBudgetPerRequest,
       "llm.toolBudgetPerRequest",
       1,
-      256,
+      8_192,
       errors,
     );
   }

--- a/runtime/src/gateway/daemon-trace.ts
+++ b/runtime/src/gateway/daemon-trace.ts
@@ -747,6 +747,15 @@ export function summarizeToolResultForTrace(
         record.stopReasonDetail.trim().length > 0
           ? truncateToolLogText(record.stopReasonDetail, maxChars)
           : undefined;
+      const delegatedScopeTrust =
+        typeof record.delegatedScopeTrust === "string"
+          ? record.delegatedScopeTrust
+          : undefined;
+      const delegatedScopeTrustReason =
+        typeof record.delegatedScopeTrustReason === "string" &&
+        record.delegatedScopeTrustReason.trim().length > 0
+          ? truncateToolLogText(record.delegatedScopeTrustReason, maxChars)
+          : undefined;
       const failedToolCalls =
         typeof record.failedToolCalls === "number" &&
         Number.isFinite(record.failedToolCalls)
@@ -766,6 +775,8 @@ export function summarizeToolResultForTrace(
         validationCode !== undefined ||
         stopReason !== undefined ||
         stopReasonDetail !== undefined ||
+        delegatedScopeTrust !== undefined ||
+        delegatedScopeTrustReason !== undefined ||
         failedToolCalls !== undefined ||
         toolCalls !== undefined
       ) {
@@ -778,6 +789,10 @@ export function summarizeToolResultForTrace(
           ...(validationCode !== undefined ? { validationCode } : {}),
           ...(stopReason !== undefined ? { stopReason } : {}),
           ...(stopReasonDetail !== undefined ? { stopReasonDetail } : {}),
+          ...(delegatedScopeTrust !== undefined ? { delegatedScopeTrust } : {}),
+          ...(delegatedScopeTrustReason !== undefined
+            ? { delegatedScopeTrustReason }
+            : {}),
           ...(failedToolCalls !== undefined ? { failedToolCalls } : {}),
           ...(decomposition !== undefined ? { decomposition } : {}),
           ...(error !== undefined ? { error } : {}),

--- a/runtime/src/gateway/daemon-webchat-turn.test.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.test.ts
@@ -376,6 +376,107 @@ You have broad access to this machine via the system.bash tool.`,
     });
   });
 
+  it("persists delegated scope trust metadata for poisoned child cwd summaries", async () => {
+    const logger = createLoggerStub();
+    const memoryBackend = createMemoryBackendStub();
+    const session = createSession();
+    const sessionMgr = {
+      getOrCreate: vi.fn(() => session),
+      appendMessage: vi.fn(),
+      compact: vi.fn(async () => undefined),
+    } as any;
+    const webChat = {
+      createAbortController: vi.fn(() => new AbortController()),
+      clearAbortController: vi.fn(),
+      send: vi.fn(async () => undefined),
+      pushToSession: vi.fn(),
+      broadcastEvent: vi.fn(),
+    } as any;
+    const hooks = {
+      dispatch: vi.fn(async () => ({ completed: true, payload: {} })),
+    } as any;
+    const signals = {
+      signalThinking: vi.fn(),
+      signalIdle: vi.fn(),
+    };
+    const result = createResult({
+      content: "Subagent cwd: /",
+      toolCalls: [
+        {
+          name: "execute_with_agent",
+          args: { task: "Run pwd in the child and report it." },
+          result: JSON.stringify({
+            success: true,
+            output: "Subagent cwd: /",
+          }),
+          isError: false,
+          durationMs: 11,
+        },
+      ],
+    });
+    const execute = vi.fn(async () => result);
+
+    await executeWebChatConversationTurn({
+      logger,
+      msg: {
+        sessionId: "session:test",
+        senderId: "operator-1",
+        channel: "webchat",
+        content: "what did the child cwd say?",
+      },
+      webChat,
+      chatExecutor: { execute } as any,
+      sessionMgr,
+      getSystemPrompt: () => "sys",
+      sessionToolHandler: vi.fn() as any,
+      sessionStreamCallback: vi.fn(),
+      signals,
+      hooks,
+      memoryBackend,
+      sessionTokenBudget: 16_000,
+      defaultMaxToolRounds: 3,
+      contextWindowTokens: 64_000,
+      traceConfig: {
+        enabled: false,
+        includeHistory: true,
+        includeSystemPrompt: true,
+        includeToolArgs: true,
+        includeToolResults: true,
+        includeProviderPayloads: false,
+        maxChars: 20_000,
+      },
+      turnTraceId: "trace-2",
+      buildToolRoutingDecision: () => undefined,
+      recordToolRoutingOutcome: vi.fn(),
+      getSessionTokenUsage: () => 42,
+    });
+
+    expect(hooks.dispatch).toHaveBeenCalledWith("message:outbound", {
+      sessionId: "session:test",
+      content: "Subagent cwd: /",
+      provider: "grok",
+      userMessage: "what did the child cwd say?",
+      agentResponse: "Subagent cwd: /",
+      agentResponseMetadata: {
+        delegatedScopeTrust: "informational_untrusted",
+        delegatedScopeTrustReason: "assistant_delegated_environment_summary",
+        delegatedScopeContainsEnvironmentFact: true,
+        memoryRole: "working",
+      },
+    });
+    expect(memoryBackend.addEntry).toHaveBeenNthCalledWith(2, {
+      sessionId: "session:test",
+      role: "assistant",
+      content: "Subagent cwd: /",
+      metadata: {
+        delegatedScopeTrust: "informational_untrusted",
+        delegatedScopeTrustReason: "assistant_delegated_environment_summary",
+        delegatedScopeContainsEnvironmentFact: true,
+        memoryRole: "working",
+      },
+    });
+  });
+
   it("broadcasts planner trace events to webchat even when trace logging is disabled", async () => {
     const logger = createLoggerStub();
     const memoryBackend = createMemoryBackendStub();
@@ -597,5 +698,85 @@ You have broad access to this machine via the system.bash tool.`,
     expect(sessionMgr.appendMessage).not.toHaveBeenCalled();
     expect(hooks.dispatch).not.toHaveBeenCalled();
     expect(memoryBackend.addEntry).not.toHaveBeenCalled();
+  });
+
+  it("passes the session workspace root into planner/runtime execution instead of a conflicting message root", async () => {
+    const logger = createLoggerStub();
+    const memoryBackend = createMemoryBackendStub();
+    const session = createSession();
+    const sessionMgr = {
+      getOrCreate: vi.fn(() => session),
+      appendMessage: vi.fn(),
+      compact: vi.fn(async () => undefined),
+    } as any;
+    const webChat = {
+      createAbortController: vi.fn(() => new AbortController()),
+      clearAbortController: vi.fn(),
+      send: vi.fn(async () => undefined),
+      pushToSession: vi.fn(),
+      broadcastEvent: vi.fn(),
+      loadSessionWorkspaceRoot: vi
+        .fn(async () => "/home/tetsuo/git/stream-test/agenc-shell"),
+    } as any;
+    const hooks = {
+      dispatch: vi.fn(async () => ({ completed: true, payload: {} })),
+    } as any;
+    const signals = {
+      signalThinking: vi.fn(),
+      signalIdle: vi.fn(),
+    };
+    const execute = vi.fn(async () => createResult());
+
+    await executeWebChatConversationTurn({
+      logger,
+      msg: {
+        sessionId: "session:test",
+        senderId: "operator-1",
+        channel: "webchat",
+        content: "Read PLAN.md and execute the implementation plan.",
+        metadata: { workspaceRoot: "/home/tetsuo/git/AgenC" },
+      },
+      webChat,
+      chatExecutor: {
+        execute,
+      } as any,
+      sessionMgr,
+      getSystemPrompt: () => "system",
+      sessionToolHandler: vi.fn() as any,
+      sessionStreamCallback: vi.fn(),
+      signals,
+      hooks,
+      memoryBackend,
+      sessionTokenBudget: 16_000,
+      defaultMaxToolRounds: 3,
+      contextWindowTokens: 64_000,
+      traceConfig: {
+        enabled: false,
+        includeHistory: true,
+        includeSystemPrompt: true,
+        includeToolArgs: true,
+        includeToolResults: true,
+        includeProviderPayloads: false,
+        maxChars: 20_000,
+      },
+      turnTraceId: "trace-2",
+      buildToolRoutingDecision: () => undefined,
+      recordToolRoutingOutcome: vi.fn(),
+      getSessionTokenUsage: () => 0,
+    });
+
+    expect(webChat.loadSessionWorkspaceRoot).toHaveBeenCalledWith("session:test");
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeContext: {
+          workspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
+        },
+        message: expect.objectContaining({
+          metadata: expect.objectContaining({
+            workspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
+          }),
+        }),
+      }),
+    );
   });
 });

--- a/runtime/src/gateway/daemon-webchat-turn.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.ts
@@ -45,6 +45,7 @@ import type { GatewayMessage } from "./message.js";
 import type { Session, SessionManager } from "./session.js";
 import type { ToolRoutingDecision } from "./tool-routing.js";
 import { resolveTurnMaxToolRounds } from "./tool-round-budget.js";
+import { buildAssistantDelegatedScopeMetadata } from "../utils/delegated-scope-trust.js";
 
 export interface WebChatTurnSignals {
   signalThinking: (sessionId: string) => void;
@@ -132,6 +133,30 @@ function maybeBroadcastExecutionTraceEventToWebChat(params: {
     default:
       return;
   }
+}
+
+async function resolveWebChatTurnWorkspaceRoot(params: {
+  readonly webChat: WebChatChannel;
+  readonly sessionId: string;
+  readonly messageWorkspaceRoot: unknown;
+}): Promise<string | undefined> {
+  const sessionWorkspaceRoot =
+    typeof params.webChat.loadSessionWorkspaceRoot === "function"
+      ? await params.webChat.loadSessionWorkspaceRoot(params.sessionId)
+      : undefined;
+  if (
+    typeof sessionWorkspaceRoot === "string" &&
+    sessionWorkspaceRoot.trim().length > 0
+  ) {
+    return sessionWorkspaceRoot.trim();
+  }
+  if (
+    typeof params.messageWorkspaceRoot === "string" &&
+    params.messageWorkspaceRoot.trim().length > 0
+  ) {
+    return params.messageWorkspaceRoot.trim();
+  }
+  return undefined;
 }
 
 export async function executeWebChatConversationTurn(
@@ -247,12 +272,31 @@ export async function executeWebChatConversationTurn(
       defaultMaxToolRounds,
       toolRoutingDecision,
     );
+    const runtimeWorkspaceRoot = await resolveWebChatTurnWorkspaceRoot({
+      webChat,
+      sessionId: msg.sessionId,
+      messageWorkspaceRoot: msg.metadata?.workspaceRoot,
+    });
+    const effectiveMessage =
+      typeof runtimeWorkspaceRoot === "string"
+        ? {
+            ...msg,
+            metadata: {
+              ...(msg.metadata ?? {}),
+              workspaceRoot: runtimeWorkspaceRoot,
+            },
+          }
+        : msg;
 
     const result = await chatExecutor.execute({
-      message: msg,
+      message: effectiveMessage,
       history: session.history,
       systemPrompt: effectiveSystemPrompt,
       sessionId: msg.sessionId,
+      runtimeContext:
+        typeof runtimeWorkspaceRoot === "string"
+          ? { workspaceRoot: runtimeWorkspaceRoot }
+          : undefined,
       toolHandler: sessionToolHandler,
       onStreamChunk: sessionStreamCallback,
       signal: abortController.signal,
@@ -443,12 +487,20 @@ export async function executeWebChatConversationTurn(
       stopReasonDetail: result.stopReasonDetail,
     });
 
+    const assistantMemoryMetadata = buildAssistantDelegatedScopeMetadata({
+      content: result.content,
+      toolCalls: result.toolCalls,
+    });
+
     await hooks.dispatch("message:outbound", {
       sessionId: msg.sessionId,
       content: result.content,
       provider: result.provider,
       userMessage: msg.content,
       agentResponse: result.content,
+      ...(assistantMemoryMetadata
+        ? { agentResponseMetadata: assistantMemoryMetadata }
+        : {}),
     });
 
     try {
@@ -461,6 +513,9 @@ export async function executeWebChatConversationTurn(
         sessionId: msg.sessionId,
         role: "assistant",
         content: result.content,
+        ...(assistantMemoryMetadata
+          ? { metadata: assistantMemoryMetadata }
+          : {}),
       });
     } catch (error) {
       logger.warn?.("Failed to persist messages to memory:", error);

--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -1102,6 +1102,8 @@ describe("summarizeToolResultForTrace", () => {
         status: "failed",
         objective: "Build core implementation",
         validationCode: "missing_file_mutation_evidence",
+        delegatedScopeTrust: "rejected_invalid_scope",
+        delegatedScopeTrustReason: "workspace_root_outside_parent_workspace",
         error:
           "Delegated task required file creation/edit evidence but child used no file mutation tools",
         failedToolCalls: 1,
@@ -1124,6 +1126,8 @@ describe("summarizeToolResultForTrace", () => {
       status: "failed",
       objective: "Build core implementation",
       validationCode: "missing_file_mutation_evidence",
+      delegatedScopeTrust: "rejected_invalid_scope",
+      delegatedScopeTrustReason: "workspace_root_outside_parent_workspace",
       failedToolCalls: 1,
       error: expect.stringContaining("file creation/edit evidence"),
       output: "Completed execute_with_agent",
@@ -3058,6 +3062,115 @@ describe("DaemonManager", () => {
       content: "export const ok = true;\n",
       [SESSION_ALLOWED_ROOTS_ARG]: [sessionWorkspaceRoot],
     });
+  });
+
+  it("uses the session workspace root for direct delegated child shell calls in webchat when workspace.hostPath is not pinned", async () => {
+    const dm = new DaemonManager({ configPath: "/tmp/config.json" });
+    const sessionWorkspaceRoot = await mkdtemp(
+      join(tmpdir(), "agenc-daemon-child-root-"),
+    );
+    (dm as any)._hostWorkspacePath = "/tmp/daemon-root";
+    (dm as any)._hostWorkspacePathPinned = false;
+    (dm as any)._llmTools = [
+      {
+        type: "function",
+        function: {
+          name: "system.bash",
+          description: "run commands",
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    ];
+    (dm as any)._subAgentManager = {
+      spawn: vi.fn(async () => "subagent:child-webchat"),
+      getResult: vi.fn(() => ({
+        sessionId: "subagent:child-webchat",
+        output: JSON.stringify({
+          stdout: `${sessionWorkspaceRoot}\n`,
+          stderr: "",
+          exitCode: 0,
+        }),
+        success: true,
+        completionState: "completed",
+        stopReason: "completed",
+        durationMs: 42,
+        toolCalls: [
+          {
+            name: "system.bash",
+            args: { command: "pwd" },
+            result: JSON.stringify({
+              stdout: `${sessionWorkspaceRoot}\n`,
+              stderr: "",
+              exitCode: 0,
+            }),
+            isError: false,
+            durationMs: 5,
+          },
+        ],
+      })),
+      getInfo: vi.fn(() => ({
+        sessionId: "subagent:child-webchat",
+        parentSessionId: "session-project-root",
+        depth: 1,
+        status: "completed",
+        startedAt: Date.now() - 100,
+        task: "Print the delegated cwd",
+      })),
+    };
+    const baseToolHandler = vi.fn(async () => JSON.stringify({ ok: true }));
+    const hooks = {
+      dispatch: vi.fn(async () => ({ completed: true, payload: {} })),
+    } as any;
+    const webChat = {
+      pushToSession: vi.fn(),
+      broadcastEvent: vi.fn(),
+      loadSessionWorkspaceRoot: vi.fn(async () => sessionWorkspaceRoot),
+    } as any;
+
+    try {
+      const handler = (dm as any).createWebChatSessionToolHandler({
+        sessionId: "session-project-root",
+        webChat,
+        hooks,
+        baseToolHandler,
+        traceLabel: "webchat",
+        traceConfig: { enabled: false },
+        traceId: "trace-delegated-project-root",
+      });
+
+      const result = await handler("execute_with_agent", {
+        task: "Print the delegated cwd",
+        objective: "Run pwd in the child shell and report it.",
+        tools: ["system.bash"],
+      });
+
+      expect(JSON.parse(result)).toMatchObject({
+        success: true,
+        status: "completed",
+      });
+    } finally {
+      await rm(sessionWorkspaceRoot, { recursive: true, force: true });
+    }
+
+    expect(webChat.loadSessionWorkspaceRoot).toHaveBeenCalledWith(
+      "session-project-root",
+    );
+    expect((dm as any)._subAgentManager.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentSessionId: "session-project-root",
+        workingDirectory: sessionWorkspaceRoot,
+        workingDirectorySource: "execution_envelope",
+        tools: ["system.bash"],
+        delegationSpec: expect.objectContaining({
+          executionContext: expect.objectContaining({
+            workspaceRoot: sessionWorkspaceRoot,
+            allowedReadRoots: [sessionWorkspaceRoot],
+            allowedWriteRoots: [sessionWorkspaceRoot],
+          }),
+        }),
+      }),
+    );
+    expect(baseToolHandler).not.toHaveBeenCalled();
   });
 
   it("keeps the configured host workspace root authoritative when workspace.hostPath is pinned", async () => {

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -860,16 +860,16 @@ export type { EvalScriptResult };
 /**
  * Default max tool rounds for ChatExecutor based on config.
  *
- * Desktop-enabled sessions get 50 rounds because multi-step desktop automation
- * (open app → type → screenshot → verify → retry) legitimately chains many calls.
- * Text-only chat gets 3 rounds to keep simple responses snappy. Foreground
- * coding and durable-execution turns can raise their per-turn cap above this
- * default via resolveTurnMaxToolRounds().
+ * Foreground chat is allowed to run for very long coding turns by default.
+ * Runtime-owned repair gates, request budgets, and failure breakers still bound
+ * bad loops, so the round ceiling should not be the reason a healthy coding
+ * turn stops mid-execution.
  * Voice delegation uses a separate cap (MAX_DELEGATION_TOOL_ROUNDS = 15) set
  * per-call in voice-bridge.ts.
  */
 function getDefaultMaxToolRounds(config: GatewayConfig): number {
-  return config.desktop?.enabled ? 50 : 3;
+  void config;
+  return 2_048;
 }
 
 /** Result of loadWallet() — either a keypair + wallet adapter or null. */

--- a/runtime/src/gateway/delegated-scope-preflight.ts
+++ b/runtime/src/gateway/delegated-scope-preflight.ts
@@ -86,7 +86,7 @@ const LOCAL_FILESYSTEM_CAPABLE_TOOL_NAMES = new Set([
   "system.writeFile",
 ]);
 
-function toolScopeRequiresStructuredExecutionContext(
+export function toolScopeRequiresStructuredExecutionContext(
   allowedTools?: readonly string[],
 ): boolean {
   return (allowedTools ?? []).some((toolName) =>

--- a/runtime/src/gateway/delegation-tool.test.ts
+++ b/runtime/src/gateway/delegation-tool.test.ts
@@ -107,7 +107,7 @@ describe("delegation-tool", () => {
     expect(parsed.value.spawnDecisionScore).toBe(0.42);
   });
 
-  it("parses structured execution envelopes from planner-shaped payloads", () => {
+  it("rejects planner-shaped execution_context payloads on the public path", () => {
     const parsed = parseExecuteWithAgentInput({
       task: "write_agenc_md",
       execution_context: {
@@ -123,13 +123,28 @@ describe("delegation-tool", () => {
       },
     });
 
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) return;
+    expect(parsed.error).toContain('"execution_context"');
+  });
+
+  it("preserves only bounded artifact and verification hints on the public path", () => {
+    const parsed = parseExecuteWithAgentInput({
+      task: "write_agenc_md",
+      executionContext: {
+        requiredSourceArtifacts: ["/tmp/agenc-shell/PLAN.md"],
+        targetArtifacts: ["/tmp/agenc-shell/AGENC.md"],
+        allowedTools: ["system.readFile", "system.writeFile"],
+        effectClass: "filesystem_write",
+        verificationMode: "mutation_required",
+        stepKind: "delegated_write",
+      },
+    });
+
     expect(parsed.ok).toBe(true);
     if (!parsed.ok) return;
     expect(parsed.value.executionContext).toEqual(
       expect.objectContaining({
-        workspaceRoot: "/tmp/agenc-shell",
-        allowedReadRoots: ["/tmp/agenc-shell"],
-        allowedWriteRoots: ["/tmp/agenc-shell"],
         requiredSourceArtifacts: ["/tmp/agenc-shell/PLAN.md"],
         targetArtifacts: ["/tmp/agenc-shell/AGENC.md"],
         allowedTools: ["system.readFile", "system.writeFile"],
@@ -138,6 +153,22 @@ describe("delegation-tool", () => {
         stepKind: "delegated_write",
       }),
     );
+  });
+
+  it("rejects model-authored delegated root authority on the public path", () => {
+    const parsed = parseExecuteWithAgentInput({
+      task: "inspect doc",
+      executionContext: {
+        workspaceRoot: "/tmp/canonical-root",
+        allowedReadRoots: ["/tmp/canonical-root"],
+        allowedWriteRoots: ["/tmp/canonical-root"],
+      },
+    });
+
+    expect(parsed.ok).toBe(false);
+    if (parsed.ok) return;
+    expect(parsed.error).toContain("executionContext.workspaceRoot");
+    expect(parsed.error).toContain("first trusted child root");
   });
 
   it("does not infer a delegated working directory from objective text", () => {
@@ -175,13 +206,10 @@ describe("delegation-tool", () => {
     });
   });
 
-  it("uses only executionContext as runtime working-directory truth", () => {
+  it("uses only runtime-owned executionContext as delegated working-directory truth", () => {
     const parsed = parseExecuteWithAgentInput({
       task: "inspect doc",
       contextRequirements: ["cwd=/tmp/legacy-only"],
-      executionContext: {
-        workspaceRoot: "/tmp/canonical-root",
-      },
     });
 
     expect(parsed.ok).toBe(true);
@@ -189,7 +217,9 @@ describe("delegation-tool", () => {
     expect(
       resolveDelegatedWorkingDirectory({
         task: parsed.value.task,
-        executionContext: parsed.value.executionContext,
+        executionContext: {
+          workspaceRoot: "/tmp/canonical-root",
+        },
       }),
     ).toEqual({
       path: "/tmp/canonical-root",
@@ -213,6 +243,12 @@ describe("delegation-tool", () => {
     expect(tool.inputSchema.properties).not.toHaveProperty(
       "contextRequirements",
     );
+    const executionContext = tool.inputSchema.properties.executionContext as {
+      properties?: Record<string, unknown>;
+    };
+    expect(executionContext.properties).not.toHaveProperty("workspaceRoot");
+    expect(executionContext.properties).not.toHaveProperty("allowedReadRoots");
+    expect(executionContext.properties).not.toHaveProperty("allowedWriteRoots");
     const direct = await tool.execute({ task: "do work" });
     expect(direct.isError).toBe(true);
     expect(direct.content).toContain("session-scoped tool handler");

--- a/runtime/src/gateway/delegation-tool.ts
+++ b/runtime/src/gateway/delegation-tool.ts
@@ -71,55 +71,68 @@ function toOptionalTimeout(value: unknown): number | undefined {
   return rounded;
 }
 
-function toExecutionContext(value: unknown): DelegationExecutionContext | undefined {
+function hasOwnNonEmptyString(record: Record<string, unknown>, key: string): boolean {
+  const value = record[key];
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function hasOwnNonEmptyStringArray(record: Record<string, unknown>, key: string): boolean {
+  const value = record[key];
+  return Array.isArray(value) && value.some((entry) =>
+    typeof entry === "string" && entry.trim().length > 0
+  );
+}
+
+function findPublicExecutionContextAuthorityFields(
+  value: unknown,
+): readonly string[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return [];
+  }
+  const record = value as Record<string, unknown>;
+  const fields: string[] = [];
+  if (
+    hasOwnNonEmptyString(record, "workspaceRoot") ||
+    hasOwnNonEmptyString(record, "workspace_root")
+  ) {
+    fields.push("executionContext.workspaceRoot");
+  }
+  if (
+    hasOwnNonEmptyStringArray(record, "allowedReadRoots") ||
+    hasOwnNonEmptyStringArray(record, "allowed_read_roots")
+  ) {
+    fields.push("executionContext.allowedReadRoots");
+  }
+  if (
+    hasOwnNonEmptyStringArray(record, "allowedWriteRoots") ||
+    hasOwnNonEmptyStringArray(record, "allowed_write_roots")
+  ) {
+    fields.push("executionContext.allowedWriteRoots");
+  }
+  return fields;
+}
+
+function toPublicExecutionContext(
+  value: unknown,
+): DelegationExecutionContext | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return undefined;
   }
   const record = value as Record<string, unknown>;
-  const workspaceRoot =
-    toNonEmptyString(record.workspaceRoot) ??
-    toNonEmptyString(record.workspace_root);
-  const allowedReadRoots =
-    toTrimmedStringArray(record.allowedReadRoots) ??
-    toTrimmedStringArray(record.allowed_read_roots);
-  const allowedWriteRoots =
-    toTrimmedStringArray(record.allowedWriteRoots) ??
-    toTrimmedStringArray(record.allowed_write_roots);
-  const allowedTools =
-    toTrimmedStringArray(record.allowedTools) ??
-    toTrimmedStringArray(record.allowed_tools);
-  const inputArtifacts =
-    toTrimmedStringArray(record.inputArtifacts) ??
-    toTrimmedStringArray(record.input_artifacts);
-  const requiredSourceArtifacts =
-    toTrimmedStringArray(record.requiredSourceArtifacts) ??
-    toTrimmedStringArray(record.required_source_artifacts);
-  const targetArtifacts =
-    toTrimmedStringArray(record.targetArtifacts) ??
-    toTrimmedStringArray(record.target_artifacts);
-  const effectClass =
-    toNonEmptyString(record.effectClass) ??
-    toNonEmptyString(record.effect_class);
-  const verificationMode =
-    toNonEmptyString(record.verificationMode) ??
-    toNonEmptyString(record.verification_mode);
-  const stepKind =
-    toNonEmptyString(record.stepKind) ??
-    toNonEmptyString(record.step_kind);
-  const fallbackPolicy =
-    toNonEmptyString(record.fallbackPolicy) ??
-    toNonEmptyString(record.fallback_policy);
-  const resumePolicy =
-    toNonEmptyString(record.resumePolicy) ??
-    toNonEmptyString(record.resume_policy);
-  const approvalProfile =
-    toNonEmptyString(record.approvalProfile) ??
-    toNonEmptyString(record.approval_profile);
+  const allowedTools = toTrimmedStringArray(record.allowedTools);
+  const inputArtifacts = toTrimmedStringArray(record.inputArtifacts);
+  const requiredSourceArtifacts = toTrimmedStringArray(
+    record.requiredSourceArtifacts,
+  );
+  const targetArtifacts = toTrimmedStringArray(record.targetArtifacts);
+  const effectClass = toNonEmptyString(record.effectClass);
+  const verificationMode = toNonEmptyString(record.verificationMode);
+  const stepKind = toNonEmptyString(record.stepKind);
+  const fallbackPolicy = toNonEmptyString(record.fallbackPolicy);
+  const resumePolicy = toNonEmptyString(record.resumePolicy);
+  const approvalProfile = toNonEmptyString(record.approvalProfile);
 
   if (
-    !workspaceRoot &&
-    !allowedReadRoots &&
-    !allowedWriteRoots &&
     !allowedTools &&
     !inputArtifacts &&
     !requiredSourceArtifacts &&
@@ -135,9 +148,6 @@ function toExecutionContext(value: unknown): DelegationExecutionContext | undefi
   }
 
   return {
-    ...(workspaceRoot ? { workspaceRoot } : {}),
-    ...(allowedReadRoots ? { allowedReadRoots } : {}),
-    ...(allowedWriteRoots ? { allowedWriteRoots } : {}),
     ...(allowedTools ? { allowedTools } : {}),
     ...(inputArtifacts ? { inputArtifacts } : {}),
     ...(requiredSourceArtifacts ? { requiredSourceArtifacts } : {}),
@@ -248,9 +258,24 @@ export function parseExecuteWithAgentInput(
   const acceptanceCriteria =
     toTrimmedStringArray(args.acceptanceCriteria) ??
     toTrimmedStringArray(args.acceptance_criteria);
-  const explicitExecutionContext =
-    toExecutionContext(args.executionContext) ??
-    toExecutionContext(args.execution_context);
+  if (Object.hasOwn(args, "execution_context")) {
+    return {
+      ok: false,
+      error:
+        'execute_with_agent does not accept "execution_context" on the public path; runtime owns child scope authority.',
+    };
+  }
+  const blockedAuthorityFields = findPublicExecutionContextAuthorityFields(
+    args.executionContext,
+  );
+  if (blockedAuthorityFields.length > 0) {
+    return {
+      ok: false,
+      error:
+        `execute_with_agent does not accept ${blockedAuthorityFields.join(", ")} on the public path; runtime owns the first trusted child root.`,
+    };
+  }
+  const explicitExecutionContext = toPublicExecutionContext(args.executionContext);
 
   return {
     ok: true,
@@ -329,20 +354,8 @@ export function createExecuteWithAgentTool(): Tool {
         executionContext: {
           type: "object",
           description:
-            "Optional structured execution envelope for the child task",
+            "Optional bounded artifact and verification hints for the child task. The runtime derives child workspace scope from trusted parent state.",
           properties: {
-            workspaceRoot: {
-              type: "string",
-              description: "Canonical workspace root for the delegated phase",
-            },
-            allowedReadRoots: {
-              type: "array",
-              items: { type: "string" },
-            },
-        allowedWriteRoots: {
-          type: "array",
-          items: { type: "string" },
-        },
             allowedTools: {
               type: "array",
               items: { type: "string" },

--- a/runtime/src/gateway/gateway.test.ts
+++ b/runtime/src/gateway/gateway.test.ts
@@ -1496,9 +1496,10 @@ describe("config loading", () => {
         llm: {
           provider: "grok",
           apiKey: "test",
+          maxToolRounds: 2_048,
           plannerEnabled: true,
-          plannerMaxTokens: 512,
-          toolBudgetPerRequest: 32,
+          plannerMaxTokens: 4_096,
+          toolBudgetPerRequest: 2_048,
           maxModelRecallsPerRequest: 12,
           maxFailureBudgetPerRequest: 6,
           toolCallTimeoutMs: 120_000,
@@ -1532,6 +1533,7 @@ describe("config loading", () => {
         llm: {
           provider: "grok",
           apiKey: "test",
+          maxToolRounds: 2_049,
           plannerEnabled: "yes" as unknown as boolean,
           plannerMaxTokens: 8,
           toolBudgetPerRequest: 0,
@@ -1560,12 +1562,15 @@ describe("config loading", () => {
     );
 
     expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "llm.maxToolRounds must be an integer between 1 and 2048",
+    );
     expect(result.errors).toContain("llm.plannerEnabled must be a boolean");
     expect(result.errors).toContain(
-      "llm.plannerMaxTokens must be an integer between 16 and 8192",
+      "llm.plannerMaxTokens must be an integer between 16 and 65536",
     );
     expect(result.errors).toContain(
-      "llm.toolBudgetPerRequest must be an integer between 1 and 256",
+      "llm.toolBudgetPerRequest must be an integer between 1 and 8192",
     );
     expect(result.errors).toContain(
       "llm.maxModelRecallsPerRequest must be an integer between 0 and 128",

--- a/runtime/src/gateway/memory-retriever-factory.ts
+++ b/runtime/src/gateway/memory-retriever-factory.ts
@@ -22,6 +22,7 @@ import {
   createIngestionHooks,
 } from "../memory/ingestion.js";
 import { CuratedMemoryManager, DailyLogManager } from "../memory/structured.js";
+import { sanitizeDelegatedAssistantEnvironmentSummary } from "../utils/delegated-scope-trust.js";
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -168,7 +169,15 @@ export function createBasicHistoryRetriever(
         const lines: string[] = [];
         let used = 0;
         for (const entry of entries) {
-          const normalized = entry.content.trim();
+          const shouldSuppressDelegatedEnvironmentFact =
+            entry.metadata?.delegatedScopeContainsEnvironmentFact === true &&
+            entry.metadata?.delegatedScopeTrust !== "trusted_authoritative";
+          if (shouldSuppressDelegatedEnvironmentFact) {
+            continue;
+          }
+          const normalized = sanitizeDelegatedAssistantEnvironmentSummary(
+            entry.content.trim(),
+          );
           const clipped =
             normalized.length > BASIC_MAX_ENTRY_CHARS
               ? normalized.slice(0, BASIC_MAX_ENTRY_CHARS - 3) + "..."

--- a/runtime/src/gateway/progress.test.ts
+++ b/runtime/src/gateway/progress.test.ts
@@ -246,4 +246,38 @@ describe("summarizeToolResult()", () => {
     const result = summarizeToolResult("tool", longArgs, longResult, 10);
     expect(result.length).toBeLessThan(400);
   });
+
+  it("redacts rejected delegated scope failures from recent progress", () => {
+    const result = summarizeToolResult(
+      "execute_with_agent",
+      { task: "run pwd in child" },
+      JSON.stringify({
+        success: false,
+        error:
+          'Requested delegated workspace root "/" is outside the trusted parent workspace root "/tmp/project".',
+        issues: [{ code: "workspace_root_outside_parent_workspace" }],
+      }),
+      14,
+    );
+
+    expect(result).toContain("[delegated scope rejected by runtime]");
+    expect(result).not.toContain('workspace root "/"');
+  });
+
+  it("redacts untrusted delegated cwd echoes from recent progress", () => {
+    const result = summarizeToolResult(
+      "execute_with_agent",
+      { task: "run pwd in the child and report it" },
+      JSON.stringify({
+        success: true,
+        output: "Subagent cwd: /tmp/project",
+      }),
+      14,
+    );
+
+    expect(result).toContain(
+      "[delegated cwd/workspace fact treated as informational only]",
+    );
+    expect(result).not.toContain("Subagent cwd: /tmp/project");
+  });
 });

--- a/runtime/src/gateway/progress.ts
+++ b/runtime/src/gateway/progress.ts
@@ -12,6 +12,7 @@ import type { MemoryBackend } from "../memory/types.js";
 import type { MemoryRetriever } from "../llm/chat-executor.js";
 import type { Logger } from "../utils/logger.js";
 import { safeStringify } from "../tools/types.js";
+import { assessExecuteWithAgentResult } from "../utils/delegated-scope-trust.js";
 import { SEVEN_DAYS_MS } from "../utils/async.js";
 
 // ============================================================================
@@ -86,7 +87,19 @@ export function summarizeToolResult(
   durationMs: number,
 ): string {
   const argStr = truncate(safeStringify(args), MAX_ARGS_PREVIEW_CHARS);
-  const resultStr = truncate(result, MAX_RESULT_PREVIEW_CHARS);
+  const delegatedScopeAssessment =
+    toolName === "execute_with_agent"
+      ? assessExecuteWithAgentResult({ args, result })
+      : undefined;
+  const resultStr = truncate(
+    delegatedScopeAssessment?.delegatedScopeTrust === "rejected_invalid_scope"
+      ? "[delegated scope rejected by runtime]"
+      : delegatedScopeAssessment?.delegatedScopeTrust ===
+          "informational_untrusted"
+        ? "[delegated cwd/workspace fact treated as informational only]"
+        : result,
+    MAX_RESULT_PREVIEW_CHARS,
+  );
   return `${toolName}(${argStr}) -> ${resultStr} [${durationMs}ms]`;
 }
 

--- a/runtime/src/gateway/subagent-context-curation.test.ts
+++ b/runtime/src/gateway/subagent-context-curation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  collectWorkspaceArtifactCandidates,
+  normalizeDependencyArtifactPath,
+  redactSensitiveData,
+  sanitizeExecutionPromptText,
+} from "./subagent-context-curation.js";
+
+describe("subagent-context-curation", () => {
+  it("does not relativize dependency artifacts against placeholder workspace aliases", () => {
+    expect(
+      normalizeDependencyArtifactPath("/workspace/src/index.ts", "/workspace"),
+    ).toBe("/workspace/src/index.ts");
+  });
+
+  it("requires a trusted concrete workspace root before scanning workspace artifacts", () => {
+    expect(
+      collectWorkspaceArtifactCandidates("/workspace", new Set(["index"]), 512),
+    ).toEqual([]);
+  });
+
+  it("keeps display redaction and execution sanitization separate", () => {
+    expect(
+      redactSensitiveData("Inspect /home/tetsuo/private/key.pem"),
+    ).toContain("[REDACTED_ABSOLUTE_PATH]");
+    expect(
+      sanitizeExecutionPromptText("Inspect /home/tetsuo/private/key.pem"),
+    ).toContain("an absolute path omitted by runtime redaction");
+  });
+
+  it("preserves only runtime-approved absolute paths in execution-facing text", () => {
+    const trustedRoot = "/home/tetsuo/git/stream-test/agenc-shell";
+    const sanitized = sanitizeExecutionPromptText(
+      "Use /home/tetsuo/git/stream-test/agenc-shell/PLAN.md but ignore /home/tetsuo/.ssh/id_rsa",
+      { preserveAbsolutePathsWithin: [trustedRoot] },
+    );
+
+    expect(sanitized).toContain(
+      "/home/tetsuo/git/stream-test/agenc-shell/PLAN.md",
+    );
+    expect(sanitized).toContain("an absolute path omitted by runtime redaction");
+    expect(sanitized).not.toContain("/home/tetsuo/.ssh/id_rsa");
+  });
+});

--- a/runtime/src/gateway/subagent-context-curation.ts
+++ b/runtime/src/gateway/subagent-context-curation.ts
@@ -23,6 +23,10 @@ import { derivePromptBudgetPlan } from "../llm/prompt-budget.js";
 import { selectRelevantArtifactRefs } from "../llm/context-pruning.js";
 import { sanitizeDelegationContextRequirements } from "../utils/delegation-execution-context.js";
 import {
+  isConcreteExecutableEnvelopeRoot,
+  normalizeWorkspaceRoot,
+} from "../workflow/path-normalization.js";
+import {
   type CuratedSection,
   type DependencyArtifactCandidate,
   type DependencyContextEntry,
@@ -40,6 +44,7 @@ import {
   REDACTED_BEARER_TOKEN,
   REDACTED_API_KEY,
   REDACTED_ABSOLUTE_PATH,
+  OMITTED_EXECUTION_ABSOLUTE_PATH,
   PRIVATE_KEY_BLOCK_RE,
   IMAGE_DATA_URL_RE,
   BEARER_TOKEN_RE,
@@ -64,7 +69,39 @@ import {
 /*  Sensitive-data redaction                                            */
 /* ------------------------------------------------------------------ */
 
-export function redactSensitiveData(value: string): string {
+export interface SensitiveTextSanitizationOptions {
+  readonly preserveAbsolutePathsWithin?: readonly string[];
+  readonly absolutePathReplacement?: string;
+}
+
+function normalizeTrustedExecutionRoot(root: string): string | undefined {
+  if (!isConcreteExecutableEnvelopeRoot(root)) {
+    return undefined;
+  }
+  const normalizedRoot = normalizeWorkspaceRoot(root);
+  return normalizedRoot ? normalizedRoot.replace(/\/+$/g, "") : undefined;
+}
+
+function shouldPreserveExecutionAbsolutePath(
+  candidatePath: string,
+  preserveAbsolutePathsWithin: readonly string[] | undefined,
+): boolean {
+  if (!preserveAbsolutePathsWithin || preserveAbsolutePathsWithin.length === 0) {
+    return false;
+  }
+  const normalizedCandidate = resolvePath(candidatePath);
+  return preserveAbsolutePathsWithin.some((root) => {
+    const normalizedRoot = normalizeTrustedExecutionRoot(root);
+    if (!normalizedRoot) return false;
+    return normalizedCandidate === normalizedRoot ||
+      normalizedCandidate.startsWith(`${normalizedRoot}/`);
+  });
+}
+
+export function sanitizeSensitiveText(
+  value: string,
+  options: SensitiveTextSanitizationOptions = {},
+): string {
   if (value.length === 0) return value;
   let redacted = value;
   redacted = redacted.replace(PRIVATE_KEY_BLOCK_RE, REDACTED_PRIVATE_KEY_BLOCK);
@@ -79,9 +116,29 @@ export function redactSensitiveData(value: string): string {
   redacted = redacted.replace(FILE_URL_RE, REDACTED_FILE_URL);
   redacted = redacted.replace(
     ABSOLUTE_PATH_RE,
-    (_match, prefix: string) => `${prefix}${REDACTED_ABSOLUTE_PATH}`,
+    (_match, prefix: string, candidatePath: string) =>
+      shouldPreserveExecutionAbsolutePath(
+        candidatePath,
+        options.preserveAbsolutePathsWithin,
+      )
+        ? `${prefix}${candidatePath}`
+        : `${prefix}${options.absolutePathReplacement ?? REDACTED_ABSOLUTE_PATH}`,
   );
   return redacted;
+}
+
+export function redactSensitiveData(value: string): string {
+  return sanitizeSensitiveText(value);
+}
+
+export function sanitizeExecutionPromptText(
+  value: string,
+  options: Pick<SensitiveTextSanitizationOptions, "preserveAbsolutePathsWithin"> = {},
+): string {
+  return sanitizeSensitiveText(value, {
+    preserveAbsolutePathsWithin: options.preserveAbsolutePathsWithin,
+    absolutePathReplacement: OMITTED_EXECUTION_ABSOLUTE_PATH,
+  });
 }
 
 /* ------------------------------------------------------------------ */
@@ -231,9 +288,10 @@ export function truncateText(value: string, maxChars: number): string {
 export function applySectionCaps(
   lines: readonly string[],
   maxChars: number,
+  sanitizeLine: (value: string) => string = redactSensitiveData,
 ): CuratedSection {
   const cleaned = lines
-    .map((line) => redactSensitiveData(line.trim()))
+    .map((line) => sanitizeLine(line.trim()))
     .filter((line) => line.length > 0);
   if (cleaned.length === 0) {
     return {
@@ -332,6 +390,7 @@ export function curateHistorySection(
   history: readonly PipelinePlannerContextHistoryEntry[],
   relevanceTerms: ReadonlySet<string>,
   maxChars: number,
+  trustedWorkspaceRoots: readonly string[] = [],
 ): CuratedSection {
   if (history.length === 0) {
     return {
@@ -382,9 +441,20 @@ export function curateHistorySection(
       const prefix = entry.toolName
         ? `[${entry.role}:${entry.toolName}]`
         : `[${entry.role}]`;
-      return `${prefix} ${redactSensitiveData(entry.content)}`;
+      return `${prefix} ${
+        sanitizeExecutionPromptText(entry.content, {
+          preserveAbsolutePathsWithin: trustedWorkspaceRoots,
+        })
+      }`;
     });
-  const section = applySectionCaps(orderedLines, maxChars);
+  const section = applySectionCaps(
+    orderedLines,
+    maxChars,
+    (value) =>
+      sanitizeExecutionPromptText(value, {
+        preserveAbsolutePathsWithin: trustedWorkspaceRoots,
+      }),
+  );
   return {
     ...section,
     available: history.length,
@@ -397,6 +467,7 @@ export function curateMemorySection(
   contextRequirements: readonly string[],
   relevanceTerms: ReadonlySet<string>,
   maxChars: number,
+  trustedWorkspaceRoots: readonly string[] = [],
 ): CuratedSection {
   if (memory.length === 0) {
     return {
@@ -463,9 +534,20 @@ export function curateMemorySection(
   }
   const lines = candidates.map(
     ({ entry }) =>
-      `[${entry.source}] ${redactSensitiveData(entry.content)}`,
+      `[${entry.source}] ${
+        sanitizeExecutionPromptText(entry.content, {
+          preserveAbsolutePathsWithin: trustedWorkspaceRoots,
+        })
+      }`,
   );
-  const section = applySectionCaps(lines, maxChars);
+  const section = applySectionCaps(
+    lines,
+    maxChars,
+    (value) =>
+      sanitizeExecutionPromptText(value, {
+        preserveAbsolutePathsWithin: trustedWorkspaceRoots,
+      }),
+  );
   return {
     ...section,
     available: memory.length,
@@ -481,6 +563,7 @@ export function curateToolOutputSection(
   requirementTerms: readonly string[],
   maxChars: number,
   summarizeDependencyResult: (result: string | null) => string,
+  trustedWorkspaceRoots: readonly string[] = [],
 ): CuratedSection {
   const requiredCapabilities = new Set(
     step.requiredToolCapabilities.map((tool) => tool.toLowerCase()),
@@ -490,9 +573,11 @@ export function curateToolOutputSection(
   );
   const dependencyLines = dependencies.map(
     ({ dependencyName, result }) =>
-      `[dependency:${dependencyName}] ${redactSensitiveData(
-        summarizeDependencyResult(result),
-      )}`,
+      `[dependency:${dependencyName}] ${
+        sanitizeExecutionPromptText(summarizeDependencyResult(result), {
+          preserveAbsolutePathsWithin: trustedWorkspaceRoots,
+        })
+      }`,
   );
   const historicalLines = toolOutputs
     .map((entry) => {
@@ -510,12 +595,23 @@ export function curateToolOutputSection(
       const prefix = entry.toolName
         ? `[tool:${entry.toolName}]`
         : "[tool]";
-      return `${prefix} ${redactSensitiveData(entry.content)}`;
+      return `${prefix} ${
+        sanitizeExecutionPromptText(entry.content, {
+          preserveAbsolutePathsWithin: trustedWorkspaceRoots,
+        })
+      }`;
     })
     .filter((line): line is string => line !== null);
 
   const combined = [...dependencyLines, ...historicalLines];
-  const section = applySectionCaps(combined, maxChars);
+  const section = applySectionCaps(
+    combined,
+    maxChars,
+    (value) =>
+      sanitizeExecutionPromptText(value, {
+        preserveAbsolutePathsWithin: trustedWorkspaceRoots,
+      }),
+  );
   return {
     ...section,
     available: dependencies.length + toolOutputs.length,
@@ -529,6 +625,7 @@ export function curateToolOutputSection(
 export function curateDependencyArtifactSection(
   artifacts: readonly DependencyArtifactCandidate[],
   maxChars: number,
+  trustedWorkspaceRoots: readonly string[] = [],
 ): CuratedSection {
   if (artifacts.length === 0 || maxChars <= 0) {
     return {
@@ -577,7 +674,14 @@ export function curateDependencyArtifactSection(
       truncateText(normalizedContent, previewChars)
     }`;
   });
-  const section = applySectionCaps(lines, maxChars);
+  const section = applySectionCaps(
+    lines,
+    maxChars,
+    (value) =>
+      sanitizeExecutionPromptText(value, {
+        preserveAbsolutePathsWithin: trustedWorkspaceRoots,
+      }),
+  );
   return {
     ...section,
     available: artifacts.length,
@@ -589,6 +693,7 @@ export function curateArtifactReferenceSection(
   artifacts: readonly ContextArtifactRef[],
   query: string,
   maxChars: number,
+  trustedWorkspaceRoots: readonly string[] = [],
 ): CuratedSection {
   if (artifacts.length === 0 || maxChars <= 0) {
     return {
@@ -603,7 +708,11 @@ export function curateArtifactReferenceSection(
     artifacts,
     query,
     maxChars,
-  });
+  }).map((line) =>
+    sanitizeExecutionPromptText(line, {
+      preserveAbsolutePathsWithin: trustedWorkspaceRoots,
+    })
+  );
   const truncated = lines.length < artifacts.length;
   return {
     lines,
@@ -635,10 +744,14 @@ export function normalizeDependencyArtifactPath(
     return normalizedPath;
   }
 
-  const normalizedWorkspaceRoot =
-    typeof workspaceRoot === "string" && workspaceRoot.trim().length > 0
-      ? normalize(workspaceRoot)
-      : "";
+  const trustedWorkspaceRoot =
+    typeof workspaceRoot === "string" &&
+      isConcreteExecutableEnvelopeRoot(workspaceRoot)
+      ? normalizeWorkspaceRoot(workspaceRoot)
+      : undefined;
+  const normalizedWorkspaceRoot = trustedWorkspaceRoot
+    ? normalize(trustedWorkspaceRoot)
+    : "";
   if (
     normalizedWorkspaceRoot.length > 0 &&
     (
@@ -911,6 +1024,9 @@ export function collectWorkspaceArtifactCandidates(
   queryTerms: ReadonlySet<string>,
   maxChars: number,
 ): readonly DependencyArtifactCandidate[] {
+  if (!isConcreteExecutableEnvelopeRoot(workspaceRoot)) {
+    return [];
+  }
   const normalizedWorkspaceRoot = resolvePath(workspaceRoot);
   if (
     maxChars <= 0 ||

--- a/runtime/src/gateway/subagent-failure-classification.test.ts
+++ b/runtime/src/gateway/subagent-failure-classification.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildEffectiveContextRequirements,
+  classifyDelegatedScopeTrustSignal,
   resolvePlannerStepWorkingDirectory,
   stepRequiresStructuredDelegatedFilesystemScope,
 } from "./subagent-failure-classification.js";
@@ -117,5 +118,27 @@ describe("subagent-failure-classification", () => {
         canRunParallel: true,
       }),
     ).toEqual(["repo_context"]);
+  });
+
+  it("distinguishes trusted runtime envelope mismatches from invalid root attempts and informational cwd mentions", () => {
+    expect(
+      classifyDelegatedScopeTrustSignal({
+        message:
+          'Delegated workspace root "/repo" does not match the child working directory "/tmp".',
+      }),
+    ).toBe("trusted_runtime_envelope_mismatch");
+
+    expect(
+      classifyDelegatedScopeTrustSignal({
+        message:
+          'Requested delegated workspace root "/" is outside the trusted parent workspace root "/home/tetsuo/git/AgenC".',
+      }),
+    ).toBe("model_authored_invalid_root_attempt");
+
+    expect(
+      classifyDelegatedScopeTrustSignal({
+        contextRequirements: ["cwd=/workspace/demo", "repo_context"],
+      }),
+    ).toBe("informational_untrusted_cwd_mention");
   });
 });

--- a/runtime/src/gateway/subagent-failure-classification.ts
+++ b/runtime/src/gateway/subagent-failure-classification.ts
@@ -16,7 +16,10 @@ import {
   type DelegatedWorkingDirectoryResolution,
   resolveDelegatedWorkingDirectory,
 } from "./delegation-tool.js";
-import { sanitizeDelegationContextRequirements } from "../utils/delegation-execution-context.js";
+import {
+  isLegacyDelegatedScopeRequirement,
+  sanitizeDelegationContextRequirements,
+} from "../utils/delegation-execution-context.js";
 import {
   resolveDelegationBudgetHintMs,
 } from "./delegation-timeout.js";
@@ -24,14 +27,28 @@ import type { SubagentFailureClass, SubagentRetryRule } from "./subagent-orchest
 import {
   DEFAULT_TOOL_BUDGET_PER_REQUEST,
 } from "../llm/chat-executor-constants.js";
-import { buildCanonicalDelegatedFilesystemScope } from "../workflow/delegated-filesystem-scope.js";
+import {
+  isConcreteExecutableEnvelopeRoot,
+  normalizeWorkspaceRoot,
+} from "../workflow/path-normalization.js";
+
+export type DelegatedScopeTrustSignal =
+  | "trusted_runtime_envelope_mismatch"
+  | "model_authored_invalid_root_attempt"
+  | "informational_untrusted_cwd_mention"
+  | "none";
+
+const TRUSTED_RUNTIME_ENVELOPE_MISMATCH_RE =
+  /\bdelegated workspace root\b.*\bdoes not match the child working directory\b|\bdelegated (?:read|write) root\b.*\boutside the canonical workspace root\b|\b(?:required source|target) artifact\b.*\boutside the canonical workspace root\b|\bdelegated workspace root\b.*\bdoes not exist\b/i;
+const MODEL_AUTHORED_INVALID_ROOT_ATTEMPT_RE =
+  /\brequested delegated (?:workspace root|read root|write root|required source artifact|input artifact|target artifact)\b.*\boutside the trusted parent workspace (?:root|authority)\b/i;
 
 /* ------------------------------------------------------------------ */
 /*  Budget & tool budget constants                                     */
 /* ------------------------------------------------------------------ */
 
 const DEFAULT_PLANNED_SUBAGENT_TOOL_BUDGET = DEFAULT_TOOL_BUDGET_PER_REQUEST;
-const MAX_PLANNED_SUBAGENT_TOOL_BUDGET = 96;
+const MAX_PLANNED_SUBAGENT_TOOL_BUDGET = DEFAULT_TOOL_BUDGET_PER_REQUEST;
 const PLANNED_SUBAGENT_TOOL_BUDGET_MS_PER_CALL = 7_500;
 const BUDGET_EXCEEDED_RETRY_TOOL_BUDGET_MULTIPLIER = 1.5;
 
@@ -234,19 +251,16 @@ export function resolvePlannerStepWorkingDirectory(
 } | undefined {
   void pipeline;
   void hostWorkspaceRoot;
-  const canonicalScope = buildCanonicalDelegatedFilesystemScope({
-    workspaceRoot: step.executionContext?.workspaceRoot,
-    allowedReadRoots: step.executionContext?.allowedReadRoots,
-    allowedWriteRoots: step.executionContext?.allowedWriteRoots,
-    inputArtifacts: step.executionContext?.inputArtifacts,
-    requiredSourceArtifacts: step.executionContext?.requiredSourceArtifacts,
-    targetArtifacts: step.executionContext?.targetArtifacts,
-  });
-  if (canonicalScope.workspaceRoot) {
+  const rawWorkspaceRoot = step.executionContext?.workspaceRoot;
+  if (isConcreteExecutableEnvelopeRoot(rawWorkspaceRoot)) {
+    const workspaceRoot = normalizeWorkspaceRoot(rawWorkspaceRoot);
+    if (!workspaceRoot) {
+      return undefined;
+    }
     return {
-      path: canonicalScope.workspaceRoot,
+      path: workspaceRoot,
       anchored: isAnchoredDelegatedWorkingDirectory(
-        canonicalScope.workspaceRoot,
+        workspaceRoot,
       ),
       source: "execution_envelope",
     };
@@ -259,6 +273,31 @@ export function buildEffectiveContextRequirements(
   step: PipelinePlannerSubagentStep,
 ): readonly string[] {
   return sanitizeDelegationContextRequirements(step.contextRequirements);
+}
+
+export function classifyDelegatedScopeTrustSignal(input: {
+  readonly message?: string | null;
+  readonly contextRequirements?: readonly (string | undefined | null)[];
+}): DelegatedScopeTrustSignal {
+  const message = typeof input.message === "string" ? input.message.trim() : "";
+  if (message.length > 0) {
+    if (MODEL_AUTHORED_INVALID_ROOT_ATTEMPT_RE.test(message)) {
+      return "model_authored_invalid_root_attempt";
+    }
+    if (TRUSTED_RUNTIME_ENVELOPE_MISMATCH_RE.test(message)) {
+      return "trusted_runtime_envelope_mismatch";
+    }
+  }
+
+  if (
+    (input.contextRequirements ?? []).some((value) =>
+      isLegacyDelegatedScopeRequirement(value)
+    )
+  ) {
+    return "informational_untrusted_cwd_mention";
+  }
+
+  return "none";
 }
 
 /* ------------------------------------------------------------------ */

--- a/runtime/src/gateway/subagent-orchestrator-types.ts
+++ b/runtime/src/gateway/subagent-orchestrator-types.ts
@@ -38,6 +38,8 @@ export const REDACTED_FILE_URL = "[REDACTED_FILE_URL]";
 export const REDACTED_BEARER_TOKEN = "Bearer [REDACTED_TOKEN]";
 export const REDACTED_API_KEY = "[REDACTED_API_KEY]";
 export const REDACTED_ABSOLUTE_PATH = "[REDACTED_ABSOLUTE_PATH]";
+export const OMITTED_EXECUTION_ABSOLUTE_PATH =
+  "an absolute path omitted by runtime redaction";
 
 export const PRIVATE_KEY_BLOCK_RE =
   /-----BEGIN [A-Z ]+ PRIVATE KEY-----[\s\S]*?-----END [A-Z ]+ PRIVATE KEY-----/g;

--- a/runtime/src/gateway/subagent-orchestrator.test.ts
+++ b/runtime/src/gateway/subagent-orchestrator.test.ts
@@ -876,7 +876,7 @@ describe("SubAgentOrchestrator", () => {
 
     expect(result.status).toBe("completed");
     expect(manager.spawnCalls).toHaveLength(1);
-    expect(manager.spawnCalls[0]?.toolBudgetPerRequest).toBe(64);
+    expect(manager.spawnCalls[0]?.toolBudgetPerRequest).toBe(2048);
   });
 
   it("emits normalized child trajectory records when trajectory sink is configured", async () => {
@@ -2123,7 +2123,7 @@ describe("SubAgentOrchestrator", () => {
       resolveSubAgentManager: () => manager,
       pollIntervalMs: 10,
     });
-    const { executionContext } = createTestExecutionContext({
+    const { workspaceRoot, executionContext } = createTestExecutionContext({
       prefix: "subagent-redaction-",
     });
 
@@ -2189,13 +2189,15 @@ describe("SubAgentOrchestrator", () => {
     expect(prompt).toContain("[REDACTED_API_KEY]");
     expect(prompt).toContain("[REDACTED_INTERNAL_URL]");
     expect(prompt).toContain("[REDACTED_FILE_URL]");
-    expect(prompt).toContain("[REDACTED_ABSOLUTE_PATH]");
     expect(prompt).toContain("[REDACTED_IMAGE_DATA_URL]");
+    expect(prompt).toContain(workspaceRoot);
+    expect(prompt).toContain("an absolute path omitted by runtime redaction");
     expect(prompt).not.toContain("supersecrettoken");
     expect(prompt).not.toContain("sk-abcdefghijklmnopqrstuvwxyz");
     expect(prompt).not.toContain("127.0.0.1:8080");
     expect(prompt).not.toContain("192.168.1.20:8080");
     expect(prompt).not.toContain("/home/tetsuo/.ssh/id_rsa");
+    expect(prompt).not.toContain("[REDACTED_ABSOLUTE_PATH]");
     expect(prompt).not.toContain("episodic memory should not leak");
   });
 
@@ -6104,6 +6106,65 @@ describe("SubAgentOrchestrator", () => {
     expect(prompt).toContain("host-side browser verification command");
   });
 
+  it("adds trust-aware retry guidance for invalid delegated workspace-root attempts", () => {
+    const fallback = createFallbackExecutor(async (pipeline) => ({
+      status: "completed",
+      context: pipeline.context,
+      completedSteps: pipeline.steps.length,
+      totalSteps: pipeline.steps.length,
+    }));
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: fallback,
+      resolveSubAgentManager: () => null,
+      pollIntervalMs: 5,
+      fallbackBehavior: "fail_request",
+    });
+
+    const step: PipelinePlannerSubagentStep = {
+      name: "author_core",
+      stepType: "subagent_task",
+      objective:
+        "Author the delegated package files only inside the approved workspace.",
+      inputContract: "Stay inside the runtime-approved workspace root.",
+      acceptanceCriteria: ["Files authored inside the approved workspace"],
+      requiredToolCapabilities: ["system.writeFile"],
+      contextRequirements: ["cwd=/workspace/legacy-hint"],
+      canRunParallel: false,
+    };
+
+    const prompt = (orchestrator as unknown as {
+      buildRetryTaskPrompt: (
+        currentTaskPrompt: string,
+        step: PipelinePlannerSubagentStep,
+        allowedTools: readonly string[],
+        failure: {
+          failureClass: "malformed_result_contract";
+          message: string;
+          stopReasonHint: "validation_error";
+        },
+        retryAttempt: number,
+      ) => string;
+    }).buildRetryTaskPrompt(
+      "Base prompt",
+      step,
+      ["system.writeFile"],
+      {
+        failureClass: "malformed_result_contract",
+        message:
+          'Requested delegated workspace root "/" is outside the trusted parent workspace root "/home/tetsuo/git/AgenC".',
+        stopReasonHint: "validation_error",
+      },
+      1,
+    );
+
+    expect(prompt).toContain(
+      "The runtime-owned execution envelope already defines the child filesystem boundary.",
+    );
+    expect(prompt).toContain(
+      "keep all work inside the approved workspace scope",
+    );
+  });
+
   it("fails blocked successful child outputs without retrying them as completed phases", async () => {
     const fallback = createFallbackExecutor(async (pipeline) => ({
       status: "completed",
@@ -6862,8 +6923,8 @@ describe("SubAgentOrchestrator", () => {
 
     expect(result.status).toBe("completed");
     expect(manager.spawnCalls).toHaveLength(2);
-    expect(manager.spawnCalls[0]?.toolBudgetPerRequest).toBe(64);
-    expect(manager.spawnCalls[1]?.toolBudgetPerRequest).toBe(96);
+    expect(manager.spawnCalls[0]?.toolBudgetPerRequest).toBe(2048);
+    expect(manager.spawnCalls[1]?.toolBudgetPerRequest).toBe(2048);
   });
 
   it("retries child validation failures that return non-completed stop reasons without tool evidence", async () => {

--- a/runtime/src/gateway/subagent-orchestrator.ts
+++ b/runtime/src/gateway/subagent-orchestrator.ts
@@ -63,7 +63,7 @@ import {
   SUBAGENT_FAILURE_STOP_REASON,
 } from "./subagent-orchestrator-types.js";
 import {
-  redactSensitiveData,
+  sanitizeExecutionPromptText,
   truncateText,
   buildRelevanceTerms,
   extractTerms,
@@ -84,6 +84,7 @@ import {
   computeRetryDelayMs,
   classifySpawnFailure,
   classifySubagentFailureResult,
+  isAnchoredDelegatedWorkingDirectory,
   resolvePlannerStepWorkingDirectory,
   buildEffectiveContextRequirements,
   hasHighRiskCapabilities,
@@ -118,7 +119,8 @@ import {
   type DelegationStepAdmission,
 } from "./delegation-admission.js";
 import {
-  canonicalizeDelegationExecutionContext,
+  deriveDelegatedExecutionEnvelopeFromParent,
+  type DelegatedExecutionEnvelopeDerivationResult,
 } from "../utils/delegation-execution-context.js";
 import { CanonicalExecutionKernel } from "../workflow/execution-kernel.js";
 import {
@@ -139,8 +141,22 @@ interface ExecuteSubagentAttemptParams {
   readonly taskPrompt: string;
   readonly diagnostics: SubagentContextDiagnostics;
   readonly tools: readonly string[];
+  readonly stepAdmission?: DelegationStepAdmission;
+  readonly delegatedWorkingDirectory?: PreparedPlannerDelegatedWorkingDirectory;
   readonly lifecycleEmitter: SubAgentLifecycleEmitter | null;
   readonly signal?: AbortSignal;
+}
+
+interface PreparedPlannerDelegatedWorkingDirectory {
+  readonly path: string;
+  readonly anchored: boolean;
+  readonly source: "execution_envelope";
+}
+
+interface PreparedPlannerDelegatedStepContext {
+  readonly step: PipelinePlannerSubagentStep;
+  readonly derivation: DelegatedExecutionEnvelopeDerivationResult;
+  readonly delegatedWorkingDirectory?: PreparedPlannerDelegatedWorkingDirectory;
 }
 
 type ExecuteSubagentAttemptOutcome =
@@ -675,6 +691,41 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
     };
   }
 
+  private preparePlannerDelegatedStepContext(
+    step: PipelinePlannerSubagentStep,
+    pipeline: Pipeline,
+  ): PreparedPlannerDelegatedStepContext {
+    const parentWorkspaceRoot =
+      pipeline.plannerContext?.workspaceRoot ?? this.resolveHostWorkspaceRoot();
+    const derivation = deriveDelegatedExecutionEnvelopeFromParent({
+      parentWorkspaceRoot,
+      requestedExecutionContext: step.executionContext,
+      requiresStructuredExecutionContext:
+        stepRequiresStructuredDelegatedFilesystemScope(step),
+      source: "internal_planner_path",
+    });
+    const effectiveStep = {
+      ...step,
+      contextRequirements: buildEffectiveContextRequirements(step),
+      executionContext: derivation.ok ? derivation.executionContext : undefined,
+    } satisfies PipelinePlannerSubagentStep;
+    const delegatedWorkingDirectory =
+      derivation.ok && derivation.workingDirectory
+        ? {
+            path: derivation.workingDirectory,
+            anchored: isAnchoredDelegatedWorkingDirectory(
+              derivation.workingDirectory,
+            ),
+            source: "execution_envelope" as const,
+          }
+        : undefined;
+    return {
+      step: effectiveStep,
+      derivation,
+      delegatedWorkingDirectory,
+    };
+  }
+
   private async executeNode(
     step: PipelinePlannerStep,
     pipeline: Pipeline,
@@ -773,6 +824,13 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       (plannerStep): plannerStep is PipelinePlannerSubagentStep =>
         plannerStep.stepType === "subagent_task",
     );
+    const preparedSubagentSteps = subagentSteps.map((plannerStep) =>
+      this.preparePlannerDelegatedStepContext(plannerStep, pipeline)
+    );
+    const preparedStepContext =
+      preparedSubagentSteps.find((entry) => entry.step.name === step.name) ??
+      this.preparePlannerDelegatedStepContext(step, pipeline);
+    const preparedStep = preparedStepContext.step;
     const synthesisStepCount = plannerSteps.filter(
       (plannerStep) => plannerStep.stepType === "synthesis",
     ).length;
@@ -780,10 +838,10 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       messageText:
         pipeline.plannerContext?.parentRequest?.trim().length
           ? pipeline.plannerContext.parentRequest
-          : step.objective,
+          : preparedStep.objective,
       totalSteps: plannerSteps.length,
       synthesisSteps: synthesisStepCount,
-      steps: subagentSteps,
+      steps: preparedSubagentSteps.map((entry) => entry.step),
       edges: pipeline.edges ?? [],
       threshold: 0,
       maxFanoutPerTurn: this.maxFanoutPerTurn,
@@ -791,16 +849,56 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       explicitDelegationRequested: true,
     });
     const stepAdmission =
-      delegationAdmission.stepAdmissions.find((entry) => entry.stepName === step.name) ??
+      delegationAdmission.stepAdmissions.find((entry) => entry.stepName === preparedStep.name) ??
       buildDelegationStepAdmission({
         analysis: delegationAdmission.economics.stepAnalyses.find((analysis) =>
-          analysis.step.name === step.name
+          analysis.step.name === preparedStep.name
         )!,
         shape: delegationAdmission.shape,
       });
 
-    const timeoutMs = parseBudgetHintMsFn(step.maxBudgetHint, this.defaultSubagentTimeoutMs);
-    const toolScope = this.deriveChildToolAllowlist(step, pipeline);
+    if (
+      !preparedStepContext.derivation.ok &&
+      stepRequiresStructuredDelegatedFilesystemScope(step)
+    ) {
+      return {
+        status: "failed",
+        error:
+          `Refusing delegated step "${preparedStep.name}" before child execution: ${preparedStepContext.derivation.error}`,
+        stopReasonHint: "validation_error",
+      };
+    }
+    if (
+      !this.unsafeBenchmarkMode &&
+      !delegationAdmission.allowed &&
+      shouldRejectPlannedDelegationAtExecutionTime(delegationAdmission.reason)
+    ) {
+      lifecycleEmitter?.emit({
+        type: "subagents.failed",
+        timestamp: Date.now(),
+        sessionId: parentSessionId,
+        parentSessionId,
+        toolName: "execute_with_agent",
+        payload: {
+          stepName: preparedStep.name,
+          stage: "admission",
+          reason: delegationAdmission.reason,
+          diagnostics: delegationAdmission.diagnostics,
+        },
+      });
+      return {
+        status: "failed",
+        error:
+          `Refusing delegated step "${preparedStep.name}" because delegation admission rejected the plan: ${delegationAdmission.reason}`,
+        stopReasonHint: "validation_error",
+      };
+    }
+
+    const timeoutMs = parseBudgetHintMsFn(
+      preparedStep.maxBudgetHint,
+      this.defaultSubagentTimeoutMs,
+    );
+    const toolScope = this.deriveChildToolAllowlist(preparedStep, pipeline);
     if (toolScope.blockedReason) {
       lifecycleEmitter?.emit({
         type: "subagents.failed",
@@ -809,7 +907,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         parentSessionId,
         toolName: "execute_with_agent",
         payload: {
-          stepName: step.name,
+          stepName: preparedStep.name,
           stage: "validation",
           reason: toolScope.blockedReason,
           removedLowSignalBrowserTools: toolScope.removedLowSignalBrowserTools,
@@ -827,7 +925,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
     }
     if (toolScope.allowedTools.length === 0 && !toolScope.allowsToollessExecution) {
       const error =
-        `No permitted child tools remain for step "${step.name}" after policy scoping`;
+        `No permitted child tools remain for step "${preparedStep.name}" after policy scoping`;
       lifecycleEmitter?.emit({
         type: "subagents.failed",
         timestamp: Date.now(),
@@ -835,7 +933,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         parentSessionId,
         toolName: "execute_with_agent",
         payload: {
-          stepName: step.name,
+          stepName: preparedStep.name,
           stage: "validation",
           reason: error,
           removedLowSignalBrowserTools: toolScope.removedLowSignalBrowserTools,
@@ -852,7 +950,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       };
     }
     const subagentTask = await this.buildSubagentTaskPrompt(
-      step,
+      preparedStep,
       pipeline,
       results,
       toolScope,
@@ -869,11 +967,11 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       Math.max(
         1,
         1 +
-          step.acceptanceCriteria.length +
-          step.requiredToolCapabilities.length +
+          preparedStep.acceptanceCriteria.length +
+          preparedStep.requiredToolCapabilities.length +
           Math.min(
             3,
-            buildEffectiveContextRequirements(step).length,
+            preparedStep.contextRequirements.length,
           ),
       ),
     );
@@ -881,7 +979,9 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       complexityScore: stepComplexityScore,
       subagentStepCount: Math.max(1, subagentStepCount),
       hasHistory: (pipeline.plannerContext?.history.length ?? 0) > 0,
-      highRiskPlan: hasHighRiskCapabilities(step.requiredToolCapabilities),
+      highRiskPlan: hasHighRiskCapabilities(
+        preparedStep.requiredToolCapabilities,
+      ),
     });
     const parentTurnId = `parent:${parentSessionId}:${pipeline.createdAt}`;
     const trajectoryTraceId = `trace:${parentSessionId}:${pipeline.createdAt}`;
@@ -907,7 +1007,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
           parentSessionId,
           toolName: "execute_with_agent",
           payload: this.buildRequestTreeBudgetBreachPayload({
-            stepName: step.name,
+            stepName: preparedStep.name,
             attempt,
             breach: reservationBreach,
           }),
@@ -915,14 +1015,14 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         return {
           status: "failed",
           error:
-            `Sub-agent circuit breaker opened for step "${step.name}": ${breakerMessage}`,
+            `Sub-agent circuit breaker opened for step "${preparedStep.name}": ${breakerMessage}`,
           stopReasonHint: "budget_exceeded",
         };
       }
       let attemptOutcome: ExecuteSubagentAttemptOutcome =
         await this.executeSubagentAttempt({
         subAgentManager,
-        step,
+        step: preparedStep,
         pipeline,
         parentSessionId,
         parentRequest: pipeline.plannerContext?.parentRequest,
@@ -935,13 +1035,15 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         taskPrompt,
         diagnostics: subagentTask.diagnostics,
         tools: toolScope.allowedTools,
+        stepAdmission,
+        delegatedWorkingDirectory: preparedStepContext.delegatedWorkingDirectory,
         lifecycleEmitter,
         signal,
       });
       if (attemptOutcome.status === "completed") {
         const acceptanceProbeFailure =
           await this.runCompletedSubagentAcceptanceProbes({
-            step,
+            step: preparedStep,
             pipeline,
             results,
             parentSessionId,
@@ -967,18 +1069,21 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         this.recordSubagentTrajectory({
           traceId: trajectoryTraceId,
           turnId:
-            `child:${step.name}:${attempt}:${attemptOutcome.subagentSessionId}`,
+            `child:${preparedStep.name}:${attempt}:${attemptOutcome.subagentSessionId}`,
           parentTurnId,
           parentSessionId,
           subagentSessionId: attemptOutcome.subagentSessionId,
-          step,
+          step: preparedStep,
           stepComplexityScore,
           contextClusterId: childContextClusterId,
           plannerStepCount: plannerSteps.length,
           subagentStepCount,
           deterministicStepCount,
           synthesisStepCount,
-          dependencyDepth: Math.max(1, (step.dependsOn?.length ?? 0) + 1),
+          dependencyDepth: Math.max(
+            1,
+            (preparedStep.dependsOn?.length ?? 0) + 1,
+          ),
           fanout: Math.max(1, subagentStepCount),
           tools: toolScope.allowedTools,
           timeoutMs,
@@ -993,7 +1098,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
             attempt,
             pipelineId: pipeline.id,
             toolCalls: attemptOutcome.toolCalls.length,
-            stepName: step.name,
+            stepName: preparedStep.name,
             providerName: attemptOutcome.providerName ?? "unknown",
           },
         });
@@ -1006,18 +1111,21 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
           this.recordSubagentTrajectory({
             traceId: trajectoryTraceId,
             turnId:
-              `child:${step.name}:${attempt}:${attemptOutcome.subagentSessionId}:budget`,
+              `child:${preparedStep.name}:${attempt}:${attemptOutcome.subagentSessionId}:budget`,
             parentTurnId,
             parentSessionId,
             subagentSessionId: attemptOutcome.subagentSessionId,
-            step,
+            step: preparedStep,
             stepComplexityScore,
             contextClusterId: childContextClusterId,
             plannerStepCount: plannerSteps.length,
             subagentStepCount,
             deterministicStepCount,
             synthesisStepCount,
-            dependencyDepth: Math.max(1, (step.dependsOn?.length ?? 0) + 1),
+            dependencyDepth: Math.max(
+              1,
+              (preparedStep.dependsOn?.length ?? 0) + 1,
+            ),
             fanout: Math.max(1, subagentStepCount),
             tools: toolScope.allowedTools,
             timeoutMs,
@@ -1032,7 +1140,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
               success: false,
               attempt,
               pipelineId: pipeline.id,
-              stepName: step.name,
+              stepName: preparedStep.name,
               stage: "circuit_breaker",
             },
           });
@@ -1044,7 +1152,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
             subagentSessionId: attemptOutcome.subagentSessionId,
             toolName: "execute_with_agent",
             payload: this.buildRequestTreeBudgetBreachPayload({
-              stepName: step.name,
+              stepName: preparedStep.name,
               attempt,
               breach: usageBreach,
             }),
@@ -1052,7 +1160,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
           return {
             status: "failed",
             error:
-              `Sub-agent circuit breaker opened for step "${step.name}": ${breakerMessage}`,
+              `Sub-agent circuit breaker opened for step "${preparedStep.name}": ${breakerMessage}`,
             stopReasonHint: "budget_exceeded",
           };
         }
@@ -1064,7 +1172,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
           subagentSessionId: attemptOutcome.subagentSessionId,
           toolName: "execute_with_agent",
           payload: {
-            stepName: step.name,
+            stepName: preparedStep.name,
             durationMs: attemptOutcome.durationMs,
             toolCalls: attemptOutcome.toolCalls.length,
             providerName: attemptOutcome.providerName,
@@ -1104,18 +1212,21 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
           this.recordSubagentTrajectory({
             traceId: trajectoryTraceId,
             turnId:
-              `child:${step.name}:${attempt}:${lastFailure.childSessionId ?? "unknown"}:budget`,
+              `child:${preparedStep.name}:${attempt}:${lastFailure.childSessionId ?? "unknown"}:budget`,
             parentTurnId,
             parentSessionId,
             subagentSessionId: lastFailure.childSessionId,
-            step,
+            step: preparedStep,
             stepComplexityScore,
             contextClusterId: childContextClusterId,
             plannerStepCount: plannerSteps.length,
             subagentStepCount,
             deterministicStepCount,
             synthesisStepCount,
-            dependencyDepth: Math.max(1, (step.dependsOn?.length ?? 0) + 1),
+            dependencyDepth: Math.max(
+              1,
+              (preparedStep.dependsOn?.length ?? 0) + 1,
+            ),
             fanout: Math.max(1, subagentStepCount),
             tools: toolScope.allowedTools,
             timeoutMs,
@@ -1130,7 +1241,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
               success: false,
               attempt,
               pipelineId: pipeline.id,
-              stepName: step.name,
+              stepName: preparedStep.name,
               stage: "circuit_breaker",
             },
           });
@@ -1142,7 +1253,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
             subagentSessionId: lastFailure.childSessionId,
             toolName: "execute_with_agent",
             payload: this.buildRequestTreeBudgetBreachPayload({
-              stepName: step.name,
+              stepName: preparedStep.name,
               attempt,
               breach: usageBreach,
             }),
@@ -1150,7 +1261,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
           return {
             status: "failed",
             error:
-              `Sub-agent circuit breaker opened for step "${step.name}": ${breakerMessage}`,
+              `Sub-agent circuit breaker opened for step "${preparedStep.name}": ${breakerMessage}`,
             stopReasonHint: "budget_exceeded",
           };
         }
@@ -1167,18 +1278,22 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
 
       this.recordSubagentTrajectory({
         traceId: trajectoryTraceId,
-        turnId: `child:${step.name}:${attempt}:${lastFailure.childSessionId ?? "unknown"}`,
+        turnId:
+          `child:${preparedStep.name}:${attempt}:${lastFailure.childSessionId ?? "unknown"}`,
         parentTurnId,
         parentSessionId,
         subagentSessionId: lastFailure.childSessionId,
-        step,
+        step: preparedStep,
         stepComplexityScore,
         contextClusterId: childContextClusterId,
         plannerStepCount: plannerSteps.length,
         subagentStepCount,
         deterministicStepCount,
         synthesisStepCount,
-        dependencyDepth: Math.max(1, (step.dependsOn?.length ?? 0) + 1),
+        dependencyDepth: Math.max(
+          1,
+          (preparedStep.dependsOn?.length ?? 0) + 1,
+        ),
         fanout: Math.max(1, subagentStepCount),
         tools: toolScope.allowedTools,
         timeoutMs,
@@ -1194,7 +1309,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
           attempt,
           retrying: shouldRetry,
           pipelineId: pipeline.id,
-          stepName: step.name,
+          stepName: preparedStep.name,
         },
       });
 
@@ -1202,7 +1317,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         retryAttempts[lastFailure.failureClass] = retryAttempt;
         taskPrompt = buildRetryTaskPromptFn(
           taskPrompt,
-          step,
+          preparedStep,
           toolScope.allowedTools,
           lastFailure,
           retryAttempt,
@@ -1215,7 +1330,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
           subagentSessionId: lastFailure.childSessionId,
           toolName: "execute_with_agent",
           payload: {
-            stepName: step.name,
+            stepName: preparedStep.name,
             phase: "retry_backoff",
             output: lastFailure.message,
             durationMs: lastFailure.durationMs,
@@ -1247,7 +1362,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         subagentSessionId: lastFailure.childSessionId,
         toolName: "execute_with_agent",
         payload: {
-          stepName: step.name,
+          stepName: preparedStep.name,
           output: lastFailure.message,
           durationMs: lastFailure.durationMs,
           failureClass: lastFailure.failureClass,
@@ -1268,7 +1383,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         return {
           status: "failed",
           error:
-            `Sub-agent step "${step.name}" requires decomposition: ${lastFailure.message}`,
+            `Sub-agent step "${preparedStep.name}" requires decomposition: ${lastFailure.message}`,
           stopReasonHint: lastFailure.stopReasonHint,
           decomposition: lastFailure.decomposition,
           result: safeStringify({
@@ -1325,7 +1440,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
 
       return {
         status: "failed",
-        error: summarizeSubagentFailureHistory(step.name, failureHistory),
+        error: summarizeSubagentFailureHistory(preparedStep.name, failureHistory),
         stopReasonHint: lastFailure.stopReasonHint,
       };
     }
@@ -1434,17 +1549,12 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       };
     }
 
-    const hostWorkspaceRoot = this.resolveHostWorkspaceRoot();
-    const canonicalExecutionContext = canonicalizeDelegationExecutionContext(
-      input.step.executionContext,
-      {
-        inheritedWorkspaceRoot: input.pipeline.plannerContext?.workspaceRoot,
-        hostWorkspaceRoot,
-      },
-    );
+    const delegatedWorkingDirectory =
+      input.delegatedWorkingDirectory ??
+      resolvePlannerStepWorkingDirectory(input.step, input.pipeline);
     if (
       stepRequiresStructuredDelegatedFilesystemScope(input.step) &&
-      !canonicalExecutionContext
+      !input.step.executionContext
     ) {
       return {
         status: "failed",
@@ -1456,20 +1566,8 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         },
       };
     }
-    const effectiveStep = {
-      ...input.step,
-      contextRequirements: buildEffectiveContextRequirements(
-        input.step,
-      ),
-      executionContext: canonicalExecutionContext,
-    } satisfies PipelinePlannerSubagentStep;
-    const delegatedWorkingDirectory = resolvePlannerStepWorkingDirectory(
-      effectiveStep,
-      input.pipeline,
-      hostWorkspaceRoot,
-    );
     const delegatedScopePreflight = preflightDelegatedLocalFileScope({
-      executionContext: effectiveStep.executionContext,
+      executionContext: input.step.executionContext,
       workingDirectory: delegatedWorkingDirectory?.path,
       allowedTools: input.tools,
     });
@@ -1497,84 +1595,14 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         },
       };
     }
-    const admissionPlannerSteps = (input.pipeline.plannerSteps ?? [])
-      .filter(
-        (plannerStep): plannerStep is PipelinePlannerSubagentStep =>
-          plannerStep.stepType === "subagent_task",
-      )
-      .map((plannerStep) => {
-        const canonicalPlannerExecutionContext =
-          canonicalizeDelegationExecutionContext(
-            plannerStep.executionContext,
-            {
-              inheritedWorkspaceRoot:
-                input.pipeline.plannerContext?.workspaceRoot,
-              hostWorkspaceRoot,
-            },
-          );
-        return {
-          ...plannerStep,
-          contextRequirements: buildEffectiveContextRequirements(
-            plannerStep,
-          ),
-          executionContext: canonicalPlannerExecutionContext,
-        } satisfies PipelinePlannerSubagentStep;
-      });
-    const admissionDecision = assessDelegationAdmission({
-      messageText:
-        input.pipeline.plannerContext?.parentRequest?.trim().length
-          ? input.pipeline.plannerContext.parentRequest
-          : input.step.objective,
-      totalSteps: admissionPlannerSteps.length,
-      synthesisSteps: (input.pipeline.plannerSteps ?? []).filter(
-        (plannerStep) => plannerStep.stepType === "synthesis",
-      ).length,
-      steps: admissionPlannerSteps,
-      edges: input.pipeline.edges ?? [],
-      threshold: 0,
-      maxFanoutPerTurn: this.maxFanoutPerTurn,
-      maxDepth: this.maxDepth,
-      explicitDelegationRequested: true,
-    });
-    if (
-      !this.unsafeBenchmarkMode &&
-      !admissionDecision.allowed &&
-      shouldRejectPlannedDelegationAtExecutionTime(admissionDecision.reason)
-    ) {
-      input.lifecycleEmitter?.emit({
-        type: "subagents.failed",
-        timestamp: Date.now(),
-        sessionId: input.parentSessionId,
-        parentSessionId: input.parentSessionId,
-        toolName: "execute_with_agent",
-        payload: {
-          stepName: input.step.name,
-          stage: "admission",
-          reason: admissionDecision.reason,
-          diagnostics: admissionDecision.diagnostics,
-        },
-      });
-      return {
-        status: "failed",
-        failure: {
-          failureClass: "needs_decomposition",
-          message:
-            `Refusing delegated step "${input.step.name}" because delegation admission rejected the plan: ${admissionDecision.reason}`,
-          stopReasonHint: "validation_error",
-        },
-      };
-    }
-    const stepAdmission = admissionDecision.stepAdmissions.find(
-      (entry) => entry.stepName === input.step.name,
-    );
     const effectiveDelegationSpec = buildEffectiveDelegationSpec(
-      effectiveStep,
+      input.step,
       input.pipeline,
       {
         parentRequest: input.parentRequest,
         lastValidationCode: input.lastValidationCode,
         delegatedWorkingDirectory: delegatedWorkingDirectory?.path,
-        admission: stepAdmission,
+        admission: input.stepAdmission,
         resolveHostToolingProfile: this.resolveHostToolingProfile,
       },
     );
@@ -1591,13 +1619,13 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
           ? { workingDirectorySource: delegatedWorkingDirectory.source }
           : {}),
         tools: input.tools,
-        requiredCapabilities: effectiveStep.requiredToolCapabilities,
+        requiredCapabilities: input.step.requiredToolCapabilities,
         requireToolCall: specRequiresSuccessfulToolEvidence({
-            objective: effectiveStep.objective,
-            inputContract: effectiveStep.inputContract,
+            objective: input.step.objective,
+            inputContract: input.step.inputContract,
             acceptanceCriteria:
               effectiveDelegationSpec.acceptanceCriteria,
-            requiredToolCapabilities: effectiveStep.requiredToolCapabilities,
+            requiredToolCapabilities: input.step.requiredToolCapabilities,
             tools: input.tools,
           }),
         delegationSpec: effectiveDelegationSpec,
@@ -1802,7 +1830,9 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       const commandSummary = renderDeterministicCommandSummary(probe.step);
       const cwdSummary =
         typeof probeArgs.cwd === "string" && probeArgs.cwd.trim().length > 0
-          ? ` in \`${redactSensitiveData(probeArgs.cwd)}\``
+          ? ` in \`${sanitizeExecutionPromptText(probeArgs.cwd, {
+            preserveAbsolutePathsWithin: [probeArgs.cwd],
+          })}\``
           : "";
       const failureMessage =
         `Parent-side deterministic acceptance probe failed for step "${params.step.name}" ` +
@@ -1861,14 +1891,18 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
     taskPrompt: string;
     diagnostics: SubagentContextDiagnostics;
   }> {
+    const preparedStep = this.preparePlannerDelegatedStepContext(
+      step,
+      pipeline,
+    ).step;
     const plannerContext = pipeline.plannerContext;
     let resolvedChildPromptBudget: ResolvedChildPromptBudget | undefined;
     try {
       resolvedChildPromptBudget =
         await this.resolveChildPromptBudget?.({
-          task: step.objective,
+          task: preparedStep.objective,
           tools: toolScope.allowedTools,
-          requiredCapabilities: step.requiredToolCapabilities,
+          requiredCapabilities: preparedStep.requiredToolCapabilities,
         });
     } catch {
       resolvedChildPromptBudget = undefined;
@@ -1880,28 +1914,18 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
     );
     const parentRequest = plannerContext?.parentRequest?.trim();
     const summarizedParentRequest = parentRequest
-      ? summarizeParentRequestForSubagent(parentRequest, step)
+      ? summarizeParentRequestForSubagent(parentRequest, preparedStep)
       : undefined;
-    const effectiveContextRequirements = buildEffectiveContextRequirements(
-      step,
-    );
-    const hostWorkspaceRoot = this.resolveHostWorkspaceRoot();
-    const canonicalExecutionContext =
-      canonicalizeDelegationExecutionContext(step.executionContext);
-    const effectiveStep = {
-      ...step,
-      contextRequirements: effectiveContextRequirements,
-      executionContext: canonicalExecutionContext,
-    } satisfies PipelinePlannerSubagentStep;
+    const effectiveStep = preparedStep;
+    const effectiveContextRequirements = effectiveStep.contextRequirements;
     const relevanceTerms = buildRelevanceTerms(effectiveStep);
     const artifactRelevanceTerms = buildArtifactRelevanceTerms(effectiveStep);
     const delegatedWorkingDirectory = resolvePlannerStepWorkingDirectory(
       effectiveStep,
       pipeline,
-      hostWorkspaceRoot,
     );
     const requirementTerms = extractTerms(
-      effectiveContextRequirements.join(" "),
+      effectiveStep.contextRequirements.join(" "),
     );
     const dependencies = collectDependencyContexts(
       effectiveStep,
@@ -1940,17 +1964,25 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         { key: "artifactContext", active: plannerArtifactContext.length > 0 },
       ],
     );
+    const trustedExecutionRoots = [
+      delegatedWorkingDirectory?.path,
+      effectiveStep.executionContext?.workspaceRoot,
+    ].filter((value): value is string =>
+      typeof value === "string" && value.trim().length > 0
+    );
 
     const historySection = curateHistorySection(
       plannerContext?.history ?? [],
       relevanceTerms,
       promptBudgetCaps.historyChars,
+      trustedExecutionRoots,
     );
     const memorySection = curateMemorySection(
       plannerContext?.memory ?? [],
       effectiveContextRequirements,
       relevanceTerms,
       promptBudgetCaps.memoryChars,
+      trustedExecutionRoots,
     );
     const toolOutputSection = curateToolOutputSection(
       effectiveStep,
@@ -1960,15 +1992,18 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       requirementTerms,
       toolContextBudgets.toolOutputs ?? 0,
       summarizeDependencyResultForPrompt,
+      trustedExecutionRoots,
     );
     const dependencyArtifactSection = curateDependencyArtifactSection(
       promptArtifactCandidates,
       toolContextBudgets.dependencyArtifacts ?? 0,
+      trustedExecutionRoots,
     );
     const artifactContextSection = curateArtifactReferenceSection(
       plannerArtifactContext,
       `${effectiveStep.objective} ${effectiveStep.inputContract} ${effectiveContextRequirements.join(" ")}`,
       toolContextBudgets.artifactContext ?? 0,
+      trustedExecutionRoots,
     );
     const workspaceStateGuidanceLines = buildWorkspaceStateGuidanceLines(
       effectiveStep,
@@ -1997,6 +2032,10 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
 
     const buildPrompt = (diagnostics: SubagentContextDiagnostics): string => {
       const sections: string[] = [];
+      const sanitizePromptField = (value: string): string =>
+        sanitizeExecutionPromptText(value, {
+          preserveAbsolutePathsWithin: trustedExecutionRoots,
+        });
       const allowsStructuredShell = toolScope.allowedTools.some((toolName) =>
         toolName === "system.bash" || toolName === "desktop.bash"
       );
@@ -2017,46 +2056,46 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
 - The per-call tool JSON is authoritative for the current recall. The phase allowlist below is broader policy scope, and the runtime may attach only a routed subset on a given turn.
 - If you cannot complete the phase with the currently attached tools, state that you are blocked and explain exactly why.`,
       );
-      sections.push(`Objective: ${redactSensitiveData(effectiveStep.objective)}`);
+      sections.push(`Objective: ${sanitizePromptField(effectiveStep.objective)}`);
       sections.push(
-        `Input contract: ${redactSensitiveData(effectiveStep.inputContract)}`,
+        `Input contract: ${sanitizePromptField(effectiveStep.inputContract)}`,
       );
       if (summarizedParentRequest && summarizedParentRequest.length > 0) {
         sections.push(
-          `Parent request summary: ${redactSensitiveData(summarizedParentRequest)}`,
+          `Parent request summary: ${sanitizePromptField(summarizedParentRequest)}`,
         );
       }
       if (effectiveAcceptanceCriteria.length > 0) {
         sections.push(
-          `Acceptance criteria:\n${effectiveAcceptanceCriteria.map((item) => `- ${redactSensitiveData(item)}`).join("\n")}`,
+          `Acceptance criteria:\n${effectiveAcceptanceCriteria.map((item) => `- ${sanitizePromptField(item)}`).join("\n")}`,
         );
       }
       if (stepAdmission?.isolationReason) {
         sections.push(
-          `Delegation isolation:\n- ${redactSensitiveData(stepAdmission.isolationReason)}`,
+          `Delegation isolation:\n- ${sanitizePromptField(stepAdmission.isolationReason)}`,
         );
       }
       if (stepAdmission && stepAdmission.ownedArtifacts.length > 0) {
         sections.push(
-          `Owned artifacts:\n${stepAdmission.ownedArtifacts.map((item) => `- ${redactSensitiveData(item)}`).join("\n")}`,
+          `Owned artifacts:\n${stepAdmission.ownedArtifacts.map((item) => `- ${sanitizePromptField(item)}`).join("\n")}`,
         );
       }
       if (stepAdmission && stepAdmission.verifierObligations.length > 0) {
         sections.push(
-          `Verifier obligations:\n${stepAdmission.verifierObligations.map((item) => `- ${redactSensitiveData(item)}`).join("\n")}`,
+          `Verifier obligations:\n${stepAdmission.verifierObligations.map((item) => `- ${sanitizePromptField(item)}`).join("\n")}`,
         );
       }
       if (effectiveContextRequirements.length > 0) {
         sections.push(
-          `Context requirements:\n${effectiveContextRequirements.map((item) => `- ${redactSensitiveData(item)}`).join("\n")}`,
+          `Context requirements:\n${effectiveContextRequirements.map((item) => `- ${sanitizePromptField(item)}`).join("\n")}`,
         );
       }
       if (delegatedWorkingDirectory) {
         sections.push(
-          "Working directory:\n" +
-            `- Use \`${redactSensitiveData(delegatedWorkingDirectory.path)}\` as the workspace root for this phase.\n` +
-            "- Keep filesystem reads and writes under that root.\n" +
-            "- Prefer relative paths rooted there; do not create alternate workspaces elsewhere.",
+          "Runtime-approved workspace scope:\n" +
+            `- The runtime has already pinned this phase to \`${sanitizePromptField(delegatedWorkingDirectory.path)}\`.\n` +
+            "- Filesystem tools are validated against that approved scope at execution time.\n" +
+            "- Treat any free-form cwd or workspace-root text elsewhere as informational only; do not invent alternate roots.",
         );
       }
       if (toolScope.allowedTools.length > 0) {
@@ -2158,9 +2197,9 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       }
       sections.push(`Budget hint: ${step.maxBudgetHint}`);
       sections.push(
-        `Context curation diagnostics:\n${safeStringify(diagnostics)}`,
+        `Context curation diagnostics:\n${sanitizePromptField(safeStringify(diagnostics))}`,
       );
-      return redactSensitiveData(sections.join("\n\n"));
+      return sections.join("\n\n");
     };
 
     let diagnostics: SubagentContextDiagnostics = {
@@ -2396,7 +2435,11 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       readonly admission?: DelegationStepAdmission;
     } = {},
   ) {
-    return buildEffectiveDelegationSpec(step, pipeline, {
+    const preparedStep = this.preparePlannerDelegatedStepContext(
+      step,
+      pipeline,
+    ).step;
+    return buildEffectiveDelegationSpec(preparedStep, pipeline, {
       ...options,
       resolveHostToolingProfile: this.resolveHostToolingProfile,
     });

--- a/runtime/src/gateway/subagent-prompt-builder.ts
+++ b/runtime/src/gateway/subagent-prompt-builder.ts
@@ -34,13 +34,12 @@ import {
   SUBAGENT_ORCHESTRATION_SECTION_RE,
 } from "./subagent-orchestrator-types.js";
 import {
-  redactSensitiveData,
+  sanitizeExecutionPromptText,
   truncateText,
   extractTerms,
 } from "./subagent-context-curation.js";
 import {
   buildDelegationExecutionContext,
-  canonicalizeDelegationExecutionContext,
   sanitizeDelegationContextRequirements,
 } from "../utils/delegation-execution-context.js";
 import type { DelegationStepAdmission } from "./delegation-admission.js";
@@ -48,6 +47,7 @@ import {
   isNodeWorkspaceRelevant,
   collectReachableVerificationCategories,
 } from "./subagent-workspace-probes.js";
+import { classifyDelegatedScopeTrustSignal } from "./subagent-failure-classification.js";
 
 /* ------------------------------------------------------------------ */
 /*  Parent request summarization                                       */
@@ -170,7 +170,7 @@ export function summarizeDownstreamRequirementStep(
       return [];
     }
     return [
-      `\`${step.name}\` expects: ${redactSensitiveData(inputContract)}`,
+      `\`${step.name}\` expects: ${sanitizeExecutionPromptText(inputContract)}`,
     ];
   }
 
@@ -214,7 +214,7 @@ export function summarizeDeterministicVerificationStep(
     return "Later deterministic verification reruns the workspace test command in non-interactive single-run mode.";
   }
 
-  return `Later deterministic verification runs \`${redactSensitiveData(rendered)}\`.`;
+  return `Later deterministic verification runs \`${sanitizeExecutionPromptText(rendered)}\`.`;
 }
 
 export function buildDownstreamRequirementLines(
@@ -337,8 +337,7 @@ export function buildEffectiveDelegationSpec(
     (reachableVerificationCategories.size > 0
       ? "deterministic_followup"
       : undefined);
-  const effectiveExecutionContext =
-    canonicalizeDelegationExecutionContext(step.executionContext);
+  const effectiveExecutionContext = step.executionContext;
   const sanitizedContextRequirements = sanitizeDelegationContextRequirements(
     step.contextRequirements,
   );
@@ -861,7 +860,7 @@ export function buildRetryTaskPrompt(
         "Do not guess or restate success. Ground the retry in the concrete probe failure details.",
       );
       corrections.push(
-        `Probe failure details: ${redactSensitiveData(failure.message)}`,
+        `Probe failure details: ${sanitizeExecutionPromptText(failure.message)}`,
       );
       if (
         step.acceptanceCriteria.some((criterion) =>
@@ -888,6 +887,30 @@ export function buildRetryTaskPrompt(
       );
       corrections.push(
         "Fix and verify the issue with the allowed tools first. If the issue remains unresolved, report the phase as blocked instead of successful.",
+      );
+    }
+    const delegatedScopeTrustSignal = classifyDelegatedScopeTrustSignal({
+      message: failure.message,
+      contextRequirements: step.contextRequirements,
+    });
+    if (delegatedScopeTrustSignal === "model_authored_invalid_root_attempt") {
+      corrections.push(
+        "Do not invent, widen, or restate workspace-root / cwd authority in free-form text. The runtime-owned execution envelope already defines the child filesystem boundary.",
+      );
+      corrections.push(
+        "If the runtime rejects a requested root or artifact path, keep all work inside the approved workspace scope instead of proposing another root.",
+      );
+    } else if (
+      delegatedScopeTrustSignal === "trusted_runtime_envelope_mismatch"
+    ) {
+      corrections.push(
+        "Treat the runtime-approved execution envelope as authoritative. Keep shell cwd, reads, writes, and artifact references aligned to that exact approved scope.",
+      );
+    } else if (
+      delegatedScopeTrustSignal === "informational_untrusted_cwd_mention"
+    ) {
+      corrections.push(
+        "Treat free-form cwd or working-directory mentions as informational only. Do not convert them into execution authority or alternative workspace roots.",
       );
     }
     if (
@@ -992,7 +1015,7 @@ export function buildHostToolingPromptSection(
   );
   if (profile.npm?.workspaceProtocolSupport === "unsupported") {
     const evidence = profile.npm.workspaceProtocolEvidence
-      ? ` (${redactSensitiveData(profile.npm.workspaceProtocolEvidence)})`
+      ? ` (${sanitizeExecutionPromptText(profile.npm.workspaceProtocolEvidence)})`
       : "";
     lines.push(
       "Empirical npm probe: local `workspace:*` dependency specifiers are unsupported on this host" +
@@ -1003,7 +1026,7 @@ export function buildHostToolingPromptSection(
     );
   } else if (profile.npm?.workspaceProtocolSupport === "unknown") {
     const evidence = profile.npm.workspaceProtocolEvidence
-      ? ` (${redactSensitiveData(profile.npm.workspaceProtocolEvidence)})`
+      ? ` (${sanitizeExecutionPromptText(profile.npm.workspaceProtocolEvidence)})`
       : "";
     lines.push(
       "Empirical npm probe could not confirm whether local `workspace:*` dependency specifiers work on this host" +

--- a/runtime/src/gateway/subagent-workspace-probes.test.ts
+++ b/runtime/src/gateway/subagent-workspace-probes.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import type { Pipeline, PipelinePlannerSubagentStep } from "../workflow/pipeline.js";
+import { buildWorkspaceStateGuidanceLines } from "./subagent-workspace-probes.js";
+
+describe("subagent-workspace-probes", () => {
+  it("uses only the trusted execution-envelope workspace root for prompt guidance", () => {
+    const step: PipelinePlannerSubagentStep = {
+      name: "inspect_workspace",
+      stepType: "subagent_task",
+      objective: "Inspect authored package state",
+      inputContract: "Use the approved workspace only",
+      acceptanceCriteria: ["Summarize package state"],
+      requiredToolCapabilities: ["system.readFile"],
+      contextRequirements: ["cwd=/workspace/legacy-hint"],
+      executionContext: {
+        version: "v1",
+        workspaceRoot: "/home/tetsuo/git/AgenC/agenc-core",
+        allowedReadRoots: ["/home/tetsuo/git/AgenC/agenc-core"],
+        allowedWriteRoots: ["/home/tetsuo/git/AgenC/agenc-core"],
+        allowedTools: ["system.readFile"],
+        effectClass: "read_only",
+        verificationMode: "grounded_read",
+        stepKind: "delegated_review",
+      },
+      maxBudgetHint: "2m",
+      canRunParallel: true,
+    };
+    const pipeline: Pipeline = {
+      id: "planner:test:trusted-guidance",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerSteps: [step],
+      plannerContext: {
+        parentRequest: "Inspect the approved workspace only.",
+        history: [],
+        memory: [],
+        toolOutputs: [],
+      },
+    };
+
+    expect(
+      buildWorkspaceStateGuidanceLines(
+        step,
+        pipeline,
+        [{ path: "/home/tetsuo/git/AgenC/agenc-core/package.json" }],
+        "/tmp/fabricated-root",
+      ),
+    ).toEqual([]);
+  });
+});

--- a/runtime/src/gateway/subagent-workspace-probes.ts
+++ b/runtime/src/gateway/subagent-workspace-probes.ts
@@ -20,7 +20,7 @@ import type {
 import type { SubAgentResult } from "./sub-agent.js";
 import { tokenizeShellCommand } from "../tools/system/command-line.js";
 import { sanitizeDelegationContextRequirements } from "../utils/delegation-execution-context.js";
-import { redactSensitiveData, normalizeDependencyArtifactPath } from "./subagent-context-curation.js";
+import { normalizeDependencyArtifactPath, sanitizeExecutionPromptText } from "./subagent-context-curation.js";
 import type {
   PipelinePlannerDeterministicStep as DeterministicStep,
 } from "../workflow/pipeline.js";
@@ -429,7 +429,7 @@ export function renderDeterministicCommandSummary(
   const rendered = [command, ...commandArgs].filter((value) => value.length > 0)
     .join(" ");
   return rendered.length > 0
-    ? `\`${redactSensitiveData(rendered)}\``
+    ? `\`${sanitizeExecutionPromptText(rendered)}\``
     : `deterministic probe "${step.name}"`;
 }
 
@@ -695,20 +695,43 @@ export function collectPromptArtifactPackageDirectories(
   return directories;
 }
 
+function resolveTrustedWorkspaceRootForGuidance(
+  step: PipelinePlannerSubagentStep,
+  pipeline: Pipeline,
+  delegatedWorkingDirectory?: string,
+): string | undefined {
+  const trustedResolution = resolvePlannerStepWorkingDirectory(step, pipeline);
+  if (!trustedResolution?.path) {
+    return undefined;
+  }
+
+  const trustedWorkspaceRoot = resolvePath(trustedResolution.path);
+  if (
+    typeof delegatedWorkingDirectory === "string" &&
+    delegatedWorkingDirectory.trim().length > 0 &&
+    resolvePath(delegatedWorkingDirectory) !== trustedWorkspaceRoot
+  ) {
+    return undefined;
+  }
+
+  return trustedWorkspaceRoot;
+}
+
 export function buildWorkspaceStateGuidanceLines(
   step: PipelinePlannerSubagentStep,
   pipeline: Pipeline,
   promptArtifactCandidates: readonly { path: string }[],
   delegatedWorkingDirectory?: string,
 ): readonly string[] {
-  if (
-    typeof delegatedWorkingDirectory !== "string" ||
-    delegatedWorkingDirectory.trim().length === 0
-  ) {
+  const workspaceRoot = resolveTrustedWorkspaceRootForGuidance(
+    step,
+    pipeline,
+    delegatedWorkingDirectory,
+  );
+  if (!workspaceRoot) {
     return [];
   }
 
-  const workspaceRoot = resolvePath(delegatedWorkingDirectory);
   if (!existsSync(workspaceRoot)) {
     return [
       "The delegated workspace root does not exist yet. Create it before listing directories or writing phase files.",

--- a/runtime/src/gateway/tool-handler-factory-delegation.ts
+++ b/runtime/src/gateway/tool-handler-factory-delegation.ts
@@ -25,10 +25,14 @@ import {
   parseJsonObjectFromText,
   sanitizeDelegatedRecallInput,
 } from "../utils/delegated-contract-normalization.js";
+import { annotateExecuteWithAgentResult } from "../utils/delegated-scope-trust.js";
 import {
-  canonicalizeDelegationExecutionContext,
+  deriveDelegatedExecutionEnvelopeFromParent,
 } from "../utils/delegation-execution-context.js";
-import { preflightDelegatedLocalFileScope } from "./delegated-scope-preflight.js";
+import {
+  preflightDelegatedLocalFileScope,
+  toolScopeRequiresStructuredExecutionContext,
+} from "./delegated-scope-preflight.js";
 
 const DELEGATION_POLL_INTERVAL_MS = 75;
 const DELEGATION_PROGRESS_INTERVAL_MS = 1000;
@@ -60,6 +64,8 @@ export interface ExecuteDelegationToolParams {
   readonly verifier: DelegationVerifier;
   readonly availableToolNames?: readonly string[];
   readonly defaultWorkingDirectory?: string;
+  readonly parentAllowedReadRoots?: readonly string[];
+  readonly parentAllowedWriteRoots?: readonly string[];
   readonly delegationThreshold?: number;
   readonly unsafeBenchmarkMode?: boolean;
 }
@@ -209,11 +215,10 @@ function buildDelegatedChildPrompt(
 
   if (options.workingDirectory) {
     guidance.push(
-      "Workspace root:\n" +
-        `- Use \`${options.workingDirectory}\` as the working directory for this phase.\n` +
-        "- Keep filesystem reads and writes under that root.\n" +
-        "- Prefer relative paths rooted there for filesystem tools.\n" +
-        "- Do not create fallback copies or alternate workspaces elsewhere.",
+      "Runtime-approved workspace scope:\n" +
+        `- The runtime has already pinned this child phase to \`${options.workingDirectory}\`.\n` +
+        "- Filesystem tools are validated against that approved scope at execution time.\n" +
+        "- Treat any free-form cwd or workspace-root text elsewhere as informational only; do not invent alternate roots.",
     );
   }
 
@@ -395,8 +400,13 @@ export async function executeDelegationTool(
     availableToolNames,
     unsafeBenchmarkMode = false,
   } = params;
+  const finalizeDelegationResult = (payload: Record<string, unknown>): string =>
+    annotateExecuteWithAgentResult({
+      args: toolArgs,
+      payload,
+    });
   if (!subAgentManager) {
-    return JSON.stringify({
+    return finalizeDelegationResult({
       error:
         "Delegation runtime unavailable: sub-agent manager is not initialized",
     });
@@ -416,7 +426,7 @@ export async function executeDelegationTool(
         toolCallId,
       },
     });
-    return JSON.stringify({ error: parsedInput.error });
+    return finalizeDelegationResult({ error: parsedInput.error });
   }
 
   const input = normalizeDelegatedLiteralOutputContract(
@@ -441,7 +451,7 @@ export async function executeDelegationTool(
         toolCallId,
       },
     });
-    return JSON.stringify({
+    return finalizeDelegationResult({
       success: false,
       status: "needs_decomposition",
       objective: input.objective ?? input.task,
@@ -451,19 +461,8 @@ export async function executeDelegationTool(
   }
   const objective = input.objective ?? input.task;
   const effectiveTimeoutMs = normalizeDelegationTimeoutMs(input.timeoutMs);
-  const effectiveExecutionContext = input.executionContext
-    ? canonicalizeDelegationExecutionContext(input.executionContext, {
-      inheritedWorkspaceRoot: params.defaultWorkingDirectory,
-      hostWorkspaceRoot: params.defaultWorkingDirectory,
-    })
-    : undefined;
-  const workingDirectory = effectiveExecutionContext?.workspaceRoot?.trim()
-    || undefined;
-  const effectiveInput: ExecuteWithAgentInput = effectiveExecutionContext
-    ? { ...input, executionContext: effectiveExecutionContext }
-    : input;
   const resolvedChildScope = resolveDelegatedChildToolScope({
-    spec: effectiveInput,
+    spec: input,
     requestedTools: input.tools,
     parentAllowedTools: availableToolNames,
     availableTools: availableToolNames,
@@ -471,6 +470,49 @@ export async function executeDelegationTool(
     strictExplicitToolAllowlist: Array.isArray(input.tools) && input.tools.length > 0,
     unsafeBenchmarkMode,
   });
+  const derivedExecutionEnvelope = deriveDelegatedExecutionEnvelopeFromParent({
+    parentWorkspaceRoot: params.defaultWorkingDirectory,
+    parentAllowedReadRoots: params.parentAllowedReadRoots,
+    parentAllowedWriteRoots: params.parentAllowedWriteRoots,
+    requestedExecutionContext: input.executionContext,
+    requiresStructuredExecutionContext: toolScopeRequiresStructuredExecutionContext(
+      resolvedChildScope.allowedTools,
+    ),
+    source: "direct_live_path",
+  });
+  if (!derivedExecutionEnvelope.ok) {
+    lifecycleEmitter?.emit({
+      type: "subagents.failed",
+      timestamp: Date.now(),
+      sessionId,
+      parentSessionId: sessionId,
+      toolName: name,
+      payload: {
+        stage: "validation",
+        objective,
+        reason: derivedExecutionEnvelope.error,
+        issues: derivedExecutionEnvelope.issues,
+        toolCallId,
+      },
+    });
+    return finalizeDelegationResult({
+      success: false,
+      status: "failed",
+      objective,
+      error: derivedExecutionEnvelope.error,
+      issues: derivedExecutionEnvelope.issues,
+    });
+  }
+  const effectiveExecutionContext = derivedExecutionEnvelope.executionContext;
+  const workingDirectory = derivedExecutionEnvelope.workingDirectory;
+  const { executionContext: _requestedExecutionContext, ...inputWithoutExecutionContext } =
+    input;
+  const effectiveInput: ExecuteWithAgentInput = effectiveExecutionContext
+    ? {
+        ...inputWithoutExecutionContext,
+        executionContext: effectiveExecutionContext,
+      }
+    : inputWithoutExecutionContext;
   const delegatedScopePreflight = preflightDelegatedLocalFileScope({
     executionContext: effectiveExecutionContext,
     workingDirectory,
@@ -491,7 +533,7 @@ export async function executeDelegationTool(
         toolCallId,
       },
     });
-    return JSON.stringify({
+    return finalizeDelegationResult({
       success: false,
       status: "failed",
       objective,
@@ -519,7 +561,7 @@ export async function executeDelegationTool(
         toolCallId,
       },
     });
-    return JSON.stringify({
+    return finalizeDelegationResult({
       success: false,
       status: "failed",
       objective,
@@ -565,7 +607,7 @@ export async function executeDelegationTool(
         toolCallId,
       },
     });
-    return JSON.stringify({
+    return finalizeDelegationResult({
       success: false,
       status: "failed",
       objective,
@@ -622,7 +664,7 @@ export async function executeDelegationTool(
         toolCallId,
       },
     });
-    return JSON.stringify({
+    return finalizeDelegationResult({
       error: `Failed to spawn sub-agent: ${message}`,
     });
   }
@@ -750,7 +792,7 @@ export async function executeDelegationTool(
           verifyRequested: verifier?.shouldVerifySubAgentResult() ?? false,
         },
       });
-      return JSON.stringify({
+      return finalizeDelegationResult({
         success: true,
         status: finalStatus,
         subagentSessionId: childSessionId,
@@ -793,7 +835,7 @@ export async function executeDelegationTool(
         toolCallId,
       },
     });
-    return JSON.stringify({
+      return finalizeDelegationResult({
       success: false,
       status: finalStatus,
       subagentSessionId: childSessionId,

--- a/runtime/src/gateway/tool-handler-factory.test.ts
+++ b/runtime/src/gateway/tool-handler-factory.test.ts
@@ -1802,6 +1802,7 @@ describe("createSessionToolHandler", () => {
       availableToolNames: ["system.readFile"],
       routerId: "router-a",
       send,
+      defaultWorkingDirectory: "/tmp/project-root",
       delegation: () => ({
         subAgentManager: subAgentManager as any,
         policyEngine: null,
@@ -1814,10 +1815,6 @@ describe("createSessionToolHandler", () => {
       task: "Inspect file",
       tools: ["system.readFile"],
       timeoutMs: 120_000,
-      executionContext: {
-        workspaceRoot: "/tmp/project-root",
-        allowedReadRoots: ["/tmp/project-root"],
-      },
     });
     const parsed = JSON.parse(result) as {
       success?: boolean;
@@ -1866,6 +1863,7 @@ describe("createSessionToolHandler", () => {
       availableToolNames: ["system.writeFile", "system.bash"],
       routerId: "router-a",
       send: vi.fn(),
+      defaultWorkingDirectory: "/tmp/project",
       delegation: () => ({
         subAgentManager: {
           spawn: vi.fn(async () => "subagent:child-verify"),
@@ -1913,11 +1911,6 @@ describe("createSessionToolHandler", () => {
     const result = await handler("execute_with_agent", {
       task: "Implement the CLI",
       tools: ["system.writeFile", "system.bash"],
-      executionContext: {
-        workspaceRoot: "/tmp/project",
-        allowedReadRoots: ["/tmp/project"],
-        allowedWriteRoots: ["/tmp/project"],
-      },
     });
     const parsed = JSON.parse(result) as {
       success?: boolean;
@@ -2004,24 +1997,25 @@ describe("createSessionToolHandler", () => {
     );
   });
 
-  it("rejects contextRequirements-only local-file execute_with_agent calls before spawn", async () => {
+  it("rejects direct local-file execute_with_agent calls when trusted parent workspace authority is absent", async () => {
     const subAgentManager = {
       spawn: vi.fn(async () => "subagent:child-1"),
-      getResult: vi.fn(() => ({
-        sessionId: "subagent:child-1",
-        output: '{"summary":"child completed"}',
-        success: true,
-        durationMs: 42,
-        toolCalls: [
-          {
-            name: "system.writeFile",
-            args: { path: "/tmp/project-root/src/grid.ts" },
-            result: '{"ok":true}',
-            isError: false,
-            durationMs: 5,
-          },
-        ],
-      })),
+      getResult: vi.fn(() =>
+        makeCompletedChildResult({
+          sessionId: "subagent:child-1",
+          output: '{"summary":"child completed"}',
+          success: true,
+          durationMs: 42,
+          toolCalls: [
+            {
+              name: "system.writeFile",
+              args: { path: "/tmp/project-root/src/grid.ts" },
+              result: '{"ok":true}',
+              isError: false,
+              durationMs: 5,
+            },
+          ],
+        })),
       getInfo: vi.fn(() => ({
         sessionId: "subagent:child-1",
         parentSessionId: "session-parent",
@@ -2059,45 +2053,49 @@ describe("createSessionToolHandler", () => {
       status?: string;
       error?: string;
       issues?: Array<{ code?: string }>;
+      delegatedScopeTrust?: string;
     };
 
     expect(subAgentManager.spawn).not.toHaveBeenCalled();
     expect(parsed.success).toBe(false);
     expect(parsed.status).toBe("failed");
-    expect(parsed.error).toContain("structured executionContext");
+    expect(parsed.error).toContain("trusted parent workspace root");
     expect(parsed.issues?.map((issue) => issue.code)).toContain(
-      "missing_execution_context",
+      "missing_parent_workspace_authority",
     );
   });
 
-  it("rejects local-file execute_with_agent calls that rely on /workspace cwd hints without a structured envelope", async () => {
+  it("derives direct child pwd shell scope from the trusted parent workspace root", async () => {
     const hostWorkspaceRoot = "/home/tetsuo/agent-test";
     const subAgentManager = {
       spawn: vi.fn(async () => "subagent:child-1"),
-      getResult: vi.fn(() => ({
-        sessionId: "subagent:child-1",
-        output: '{"summary":"child completed"}',
-        success: true,
-        durationMs: 42,
-        toolCalls: [
-          {
-            name: "system.writeFile",
-            args: {
-              path: `${hostWorkspaceRoot}/signal-cartography-ts-57/package.json`,
+      getResult: vi.fn(() =>
+        makeCompletedChildResult({
+          sessionId: "subagent:child-1",
+          output: JSON.stringify({ stdout: hostWorkspaceRoot, stderr: "", exitCode: 0 }),
+          success: true,
+          durationMs: 42,
+          toolCalls: [
+            {
+              name: "system.bash",
+              args: { command: "pwd" },
+              result: JSON.stringify({
+                stdout: `${hostWorkspaceRoot}\n`,
+                stderr: "",
+                exitCode: 0,
+              }),
+              isError: false,
+              durationMs: 5,
             },
-            result: '{"ok":true}',
-            isError: false,
-            durationMs: 5,
-          },
-        ],
-      })),
+          ],
+        })),
       getInfo: vi.fn(() => ({
         sessionId: "subagent:child-1",
         parentSessionId: "session-parent",
         depth: 1,
         status: "completed",
         startedAt: Date.now() - 100,
-        task: "Scaffold the signal cartography workspace",
+        task: "Print the delegated cwd",
       })),
     };
 
@@ -2117,23 +2115,110 @@ describe("createSessionToolHandler", () => {
     });
 
     const result = await handler("execute_with_agent", {
-      task: "Scaffold the signal cartography workspace",
-      tools: ["system.writeFile", "system.bash"],
-      contextRequirements: ["cwd=/workspace/signal-cartography-ts-57"],
+      task: "Print the delegated cwd",
+      objective: "Run pwd in the delegated child shell and report it.",
+      tools: ["system.bash"],
     });
     const parsed = JSON.parse(result) as {
       success?: boolean;
       status?: string;
-      error?: string;
-      issues?: Array<{ code?: string }>;
     };
 
-    expect(subAgentManager.spawn).not.toHaveBeenCalled();
-    expect(parsed.success).toBe(false);
-    expect(parsed.status).toBe("failed");
-    expect(parsed.error).toContain("structured executionContext");
-    expect(parsed.issues?.map((issue) => issue.code)).toContain(
-      "missing_execution_context",
+    expect(parsed.success).toBe(true);
+    expect(parsed.status).toBe("completed");
+    expect(subAgentManager.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentSessionId: "session-parent",
+        workingDirectory: hostWorkspaceRoot,
+        workingDirectorySource: "execution_envelope",
+        tools: ["system.bash"],
+        delegationSpec: expect.objectContaining({
+          executionContext: expect.objectContaining({
+            workspaceRoot: hostWorkspaceRoot,
+            allowedReadRoots: [hostWorkspaceRoot],
+            allowedWriteRoots: [hostWorkspaceRoot],
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("derives direct child ls shell scope from the trusted parent workspace root even when legacy cwd hints are present", async () => {
+    const hostWorkspaceRoot = "/home/tetsuo/agent-test";
+    const subAgentManager = {
+      spawn: vi.fn(async () => "subagent:child-1"),
+      getResult: vi.fn(() =>
+        makeCompletedChildResult({
+          sessionId: "subagent:child-1",
+          output: JSON.stringify({ stdout: "PLAN.md\nsrc\n", stderr: "", exitCode: 0 }),
+          success: true,
+          durationMs: 42,
+          toolCalls: [
+            {
+              name: "system.bash",
+              args: { command: "ls" },
+              result: JSON.stringify({
+                stdout: "PLAN.md\nsrc\n",
+                stderr: "",
+                exitCode: 0,
+              }),
+              isError: false,
+              durationMs: 5,
+            },
+          ],
+        })),
+      getInfo: vi.fn(() => ({
+        sessionId: "subagent:child-1",
+        parentSessionId: "session-parent",
+        depth: 1,
+        status: "completed",
+        startedAt: Date.now() - 100,
+        task: "List the delegated cwd",
+      })),
+    };
+
+    const handler = createSessionToolHandler({
+      sessionId: "session-parent",
+      baseHandler: vi.fn(async () => "should-not-run"),
+      availableToolNames: ["system.bash"],
+      routerId: "router-a",
+      send: vi.fn(),
+      defaultWorkingDirectory: hostWorkspaceRoot,
+      delegation: () => ({
+        subAgentManager: subAgentManager as any,
+        policyEngine: null,
+        verifier: null,
+        lifecycleEmitter: null,
+      }),
+    });
+
+    const result = await handler("execute_with_agent", {
+      task: "List the delegated cwd",
+      objective: "Run ls in the delegated child shell and report it.",
+      tools: ["system.bash"],
+      contextRequirements: ["cwd=/workspace/ignored-child-root"],
+    });
+    const parsed = JSON.parse(result) as {
+      success?: boolean;
+      status?: string;
+    };
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.status).toBe("completed");
+    expect(subAgentManager.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentSessionId: "session-parent",
+        workingDirectory: hostWorkspaceRoot,
+        workingDirectorySource: "execution_envelope",
+        tools: ["system.bash"],
+        delegationSpec: expect.objectContaining({
+          executionContext: expect.objectContaining({
+            workspaceRoot: hostWorkspaceRoot,
+            allowedReadRoots: [hostWorkspaceRoot],
+            allowedWriteRoots: [hostWorkspaceRoot],
+          }),
+        }),
+      }),
     );
   });
 
@@ -2164,8 +2249,6 @@ describe("createSessionToolHandler", () => {
       task: "Inspect PLAN.md",
       tools: ["system.readFile"],
       executionContext: {
-        workspaceRoot: "/workspace",
-        allowedReadRoots: ["/workspace"],
         requiredSourceArtifacts: ["/home/tetsuo/git/AgenC/AGENTS.md"],
       },
     });
@@ -2179,32 +2262,35 @@ describe("createSessionToolHandler", () => {
     expect(subAgentManager.spawn).not.toHaveBeenCalled();
     expect(parsed.success).toBe(false);
     expect(parsed.status).toBe("failed");
-    expect(parsed.error).toContain("outside the delegated read roots");
+    expect(parsed.error).toContain("outside the trusted parent workspace authority");
     expect(parsed.issues?.map((issue) => issue.code)).toContain(
-      "required_source_outside_read_roots",
+      "required_source_outside_parent_workspace",
     );
   });
 
-  it("requires a structured execution envelope instead of inferring delegated cwd from objective text", async () => {
+  it("preserves validated descendant target-artifact scope under the trusted parent workspace root", async () => {
+    const parentWorkspaceRoot = "/home/tetsuo/agent-test";
+    const childWorkspaceRoot = "/home/tetsuo/agent-test/terrain-router-ts-2";
     const subAgentManager = {
       spawn: vi.fn(async () => "subagent:child-1"),
-      getResult: vi.fn(() => ({
-        sessionId: "subagent:child-1",
-        output: '{"summary":"child completed"}',
-        success: true,
-        durationMs: 42,
-        toolCalls: [
-          {
-            name: "system.writeFile",
-            args: {
-              path: "/home/tetsuo/agent-test/terrain-router-ts-2/packages/core/src/index.ts",
+      getResult: vi.fn(() =>
+        makeCompletedChildResult({
+          sessionId: "subagent:child-1",
+          output: '{"summary":"child completed"}',
+          success: true,
+          durationMs: 42,
+          toolCalls: [
+            {
+              name: "system.writeFile",
+              args: {
+                path: `${childWorkspaceRoot}/packages/core/src/index.ts`,
+              },
+              result: '{"ok":true}',
+              isError: false,
+              durationMs: 5,
             },
-            result: '{"ok":true}',
-            isError: false,
-            durationMs: 5,
-          },
-        ],
-      })),
+          ],
+        })),
       getInfo: vi.fn(() => ({
         sessionId: "subagent:child-1",
         parentSessionId: "session-parent",
@@ -2221,6 +2307,7 @@ describe("createSessionToolHandler", () => {
       availableToolNames: ["system.writeFile", "system.bash"],
       routerId: "router-a",
       send: vi.fn(),
+      defaultWorkingDirectory: parentWorkspaceRoot,
       delegation: () => ({
         subAgentManager: subAgentManager as any,
         policyEngine: null,
@@ -2232,14 +2319,11 @@ describe("createSessionToolHandler", () => {
     await handler("execute_with_agent", {
       task: "Implement the terrain router core",
       objective:
-        "Write the core terrain router files under /home/tetsuo/agent-test/terrain-router-ts-2 and keep all code changes there.",
+        `Write the core terrain router files under ${childWorkspaceRoot} and keep all code changes there.`,
       tools: ["system.writeFile", "system.bash"],
       executionContext: {
-        workspaceRoot: "/home/tetsuo/agent-test/terrain-router-ts-2",
-        allowedReadRoots: ["/home/tetsuo/agent-test/terrain-router-ts-2"],
-        allowedWriteRoots: ["/home/tetsuo/agent-test/terrain-router-ts-2"],
         targetArtifacts: [
-          "/home/tetsuo/agent-test/terrain-router-ts-2/packages/core/src/index.ts",
+          `${childWorkspaceRoot}/packages/core/src/index.ts`,
         ],
       },
     });
@@ -2247,20 +2331,105 @@ describe("createSessionToolHandler", () => {
     expect(subAgentManager.spawn).toHaveBeenCalledWith(
       expect.objectContaining({
         parentSessionId: "session-parent",
-        workingDirectory: "/home/tetsuo/agent-test/terrain-router-ts-2",
+        workingDirectory: parentWorkspaceRoot,
         prompt: expect.stringContaining(
-          "Use `/home/tetsuo/agent-test/terrain-router-ts-2` as the working directory for this phase.",
+          `The runtime has already pinned this child phase to \`${parentWorkspaceRoot}\`.`,
         ),
         delegationSpec: expect.objectContaining({
           executionContext: expect.objectContaining({
-            workspaceRoot: "/home/tetsuo/agent-test/terrain-router-ts-2",
+            workspaceRoot: parentWorkspaceRoot,
             targetArtifacts: [
-              "/home/tetsuo/agent-test/terrain-router-ts-2/packages/core/src/index.ts",
+              `${childWorkspaceRoot}/packages/core/src/index.ts`,
             ],
           }),
         }),
       }),
     );
+  });
+
+  it("rejects public model-authored delegated workspace roots on the direct child path", async () => {
+    const hostWorkspaceRoot = "/home/tetsuo/agent-test";
+    const subAgentManager = {
+      spawn: vi.fn(async () => "subagent:child-1"),
+      getResult: vi.fn(),
+      getInfo: vi.fn(),
+    };
+
+    const handler = createSessionToolHandler({
+      sessionId: "session-parent",
+      baseHandler: vi.fn(async () => "should-not-run"),
+      availableToolNames: ["system.bash"],
+      routerId: "router-a",
+      send: vi.fn(),
+      defaultWorkingDirectory: hostWorkspaceRoot,
+      delegation: () => ({
+        subAgentManager: subAgentManager as any,
+        policyEngine: null,
+        verifier: null,
+        lifecycleEmitter: null,
+      }),
+    });
+
+    const result = await handler("execute_with_agent", {
+      task: "Print the delegated cwd",
+      tools: ["system.bash"],
+      executionContext: {
+        workspaceRoot: "/",
+        allowedReadRoots: ["/"],
+        allowedWriteRoots: ["/"],
+      },
+    });
+    const parsed = JSON.parse(result) as {
+      error?: string;
+      delegatedScopeTrust?: string;
+    };
+
+    expect(subAgentManager.spawn).not.toHaveBeenCalled();
+    expect(parsed.error).toContain("executionContext.workspaceRoot");
+    expect(parsed.delegatedScopeTrust).toBe("rejected_invalid_scope");
+  });
+
+  it("rejects public model-authored sibling-repo roots on the direct child path", async () => {
+    const hostWorkspaceRoot = "/home/tetsuo/git/AgenC";
+    const siblingWorkspaceRoot = "/home/tetsuo/git/agenc-shell";
+    const subAgentManager = {
+      spawn: vi.fn(async () => "subagent:child-1"),
+      getResult: vi.fn(),
+      getInfo: vi.fn(),
+    };
+
+    const handler = createSessionToolHandler({
+      sessionId: "session-parent",
+      baseHandler: vi.fn(async () => "should-not-run"),
+      availableToolNames: ["system.bash"],
+      routerId: "router-a",
+      send: vi.fn(),
+      defaultWorkingDirectory: hostWorkspaceRoot,
+      delegation: () => ({
+        subAgentManager: subAgentManager as any,
+        policyEngine: null,
+        verifier: null,
+        lifecycleEmitter: null,
+      }),
+    });
+
+    const result = await handler("execute_with_agent", {
+      task: "Run pwd in the child shell and report it.",
+      tools: ["system.bash"],
+      executionContext: {
+        workspaceRoot: siblingWorkspaceRoot,
+        allowedReadRoots: [siblingWorkspaceRoot],
+        allowedWriteRoots: [siblingWorkspaceRoot],
+      },
+    });
+    const parsed = JSON.parse(result) as {
+      error?: string;
+      delegatedScopeTrust?: string;
+    };
+
+    expect(subAgentManager.spawn).not.toHaveBeenCalled();
+    expect(parsed.error).toContain("executionContext.workspaceRoot");
+    expect(parsed.delegatedScopeTrust).toBe("rejected_invalid_scope");
   });
 
   it("blocks delegated child writes outside the execution envelope target artifacts", async () => {
@@ -2419,21 +2588,22 @@ describe("createSessionToolHandler", () => {
 
     const subAgentManager = {
       spawn: vi.fn(async () => "subagent:child-1"),
-      getResult: vi.fn(() => ({
-        sessionId: "subagent:child-1",
-        output: '{"summary":"child completed"}',
-        success: true,
-        durationMs: 42,
-        toolCalls: [
-          {
-            name: "system.readFile",
-            args: { path: planPath },
-            result: JSON.stringify({ path: planPath, content: originalPlan }),
-            isError: false,
-            durationMs: 5,
-          },
-        ],
-      })),
+      getResult: vi.fn(() =>
+        makeCompletedChildResult({
+          sessionId: "subagent:child-1",
+          output: '{"summary":"child completed"}',
+          success: true,
+          durationMs: 42,
+          toolCalls: [
+            {
+              name: "system.readFile",
+              args: { path: planPath },
+              result: JSON.stringify({ path: planPath, content: originalPlan }),
+              isError: false,
+              durationMs: 5,
+            },
+          ],
+        })),
       getInfo: vi.fn(() => ({
         sessionId: "subagent:child-1",
         parentSessionId: "session-parent",
@@ -2448,7 +2618,7 @@ describe("createSessionToolHandler", () => {
       if (toolName === "system.readFile") {
         expect(args).toEqual({
           path: planPath,
-          [SESSION_ALLOWED_ROOTS_ARG]: ["/tmp/fallback-root"],
+          [SESSION_ALLOWED_ROOTS_ARG]: [workspaceRoot],
         });
         return JSON.stringify({ path: planPath, content: originalPlan });
       }
@@ -2461,7 +2631,7 @@ describe("createSessionToolHandler", () => {
       availableToolNames: ["system.readFile"],
       routerId: "router-a",
       send: vi.fn(),
-      defaultWorkingDirectory: "/tmp/fallback-root",
+      defaultWorkingDirectory: workspaceRoot,
       delegation: () => ({
         subAgentManager: subAgentManager as any,
         policyEngine: null,
@@ -2479,11 +2649,22 @@ describe("createSessionToolHandler", () => {
     });
 
     expect(JSON.parse(result)).toMatchObject({
-      success: false,
-      error:
-        "Direct execute_with_agent local-file work must provide a structured executionContext before child execution.",
+      success: true,
+      status: "completed",
     });
-    expect(subAgentManager.spawn).not.toHaveBeenCalled();
+    expect(subAgentManager.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workingDirectory: workspaceRoot,
+        workingDirectorySource: "execution_envelope",
+        delegationSpec: expect.objectContaining({
+          executionContext: expect.objectContaining({
+            workspaceRoot,
+            allowedReadRoots: [workspaceRoot],
+            allowedWriteRoots: [workspaceRoot],
+          }),
+        }),
+      }),
+    );
 
     rmSync(workspaceRoot, { recursive: true, force: true });
   });
@@ -2944,6 +3125,7 @@ describe("createSessionToolHandler", () => {
       availableToolNames: ["system.bash"],
       routerId: "router-a",
       send: vi.fn(),
+      defaultWorkingDirectory: "/tmp/delegated-shell-contract",
       delegation: () => ({
         subAgentManager: subAgentManager as any,
         policyEngine: null,
@@ -2954,11 +3136,6 @@ describe("createSessionToolHandler", () => {
 
     const result = await handler("execute_with_agent", {
       task: "collect node version",
-      executionContext: {
-        workspaceRoot: "/tmp/delegated-shell-contract",
-        allowedReadRoots: ["/tmp/delegated-shell-contract"],
-        allowedWriteRoots: ["/tmp/delegated-shell-contract"],
-      },
     });
     const parsed = JSON.parse(result) as {
       success?: boolean;
@@ -3021,6 +3198,7 @@ describe("createSessionToolHandler", () => {
       availableToolNames: ["desktop.bash"],
       routerId: "router-a",
       send: vi.fn(),
+      defaultWorkingDirectory: "/tmp/child-json-contract",
       delegation: () => ({
         subAgentManager: subAgentManager as any,
         policyEngine: null,
@@ -3032,11 +3210,6 @@ describe("createSessionToolHandler", () => {
     const result = await handler("execute_with_agent", {
       task: "Build core game",
       inputContract: "JSON output with files and verification",
-      executionContext: {
-        workspaceRoot: "/tmp/child-json-contract",
-        allowedReadRoots: ["/tmp/child-json-contract"],
-        allowedWriteRoots: ["/tmp/child-json-contract"],
-      },
     });
     const parsed = JSON.parse(result) as {
       success?: boolean;
@@ -3158,6 +3331,7 @@ describe("createSessionToolHandler", () => {
       availableToolNames: ["desktop.bash"],
       routerId: "router-a",
       send: vi.fn(),
+      defaultWorkingDirectory: "/home/agenc/neon-heist",
       delegation: () => ({
         subAgentManager: subAgentManager as any,
         policyEngine: null,
@@ -3171,9 +3345,6 @@ describe("createSessionToolHandler", () => {
       inputContract: "JSON output with files and verification",
       acceptanceCriteria: ["Create all files"],
       executionContext: {
-        workspaceRoot: "/home/agenc/neon-heist",
-        allowedReadRoots: ["/home/agenc/neon-heist"],
-        allowedWriteRoots: ["/home/agenc/neon-heist"],
         targetArtifacts: [
           "/home/agenc/neon-heist/index.html",
           "/home/agenc/neon-heist/src/game.js",
@@ -3232,6 +3403,7 @@ describe("createSessionToolHandler", () => {
       availableToolNames: ["system.readFile", "system.writeFile"],
       routerId: "router-a",
       send: vi.fn(),
+      defaultWorkingDirectory: "/home/tetsuo/git/stream-test/agenc-shell",
       delegation: () => ({
         subAgentManager: subAgentManager as any,
         policyEngine: null,
@@ -3247,9 +3419,6 @@ describe("createSessionToolHandler", () => {
       acceptanceCriteria: ["AGENC.md written with all required sections"],
       requiredToolCapabilities: ["read_file", "write_file"],
       executionContext: {
-        workspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
-        allowedReadRoots: ["/home/tetsuo/git/stream-test/agenc-shell"],
-        allowedWriteRoots: ["/home/tetsuo/git/stream-test/agenc-shell"],
         targetArtifacts: ["/home/tetsuo/git/stream-test/agenc-shell/AGENC.md"],
       },
     });
@@ -3390,7 +3559,7 @@ describe("createSessionToolHandler", () => {
   it("clamps execute_with_agent timeoutMs to a safe minimum", async () => {
     const subAgentManager = {
       spawn: vi.fn(async () => "subagent:child-min-timeout"),
-      getResult: vi.fn(() => ({
+      getResult: vi.fn(() => makeCompletedChildResult({
         sessionId: "subagent:child-min-timeout",
         output: "ok",
         success: true,
@@ -3413,6 +3582,7 @@ describe("createSessionToolHandler", () => {
       availableToolNames: ["desktop.bash"],
       routerId: "router-a",
       send: vi.fn(),
+      defaultWorkingDirectory: "/tmp/runtime-timeout-scope",
       delegation: () => ({
         subAgentManager: subAgentManager as any,
         policyEngine: null,
@@ -3424,9 +3594,6 @@ describe("createSessionToolHandler", () => {
     await handler("execute_with_agent", {
       task: "Inspect file quickly",
       timeoutMs: 10_000,
-      executionContext: {
-        workspaceRoot: "/tmp/runtime-timeout-scope",
-      },
     });
 
     expect(subAgentManager.spawn).toHaveBeenCalledWith(
@@ -3475,11 +3642,6 @@ describe("createSessionToolHandler", () => {
         "Create src/Game.ts",
         "Validate localhost runs cleanly",
       ],
-      executionContext: {
-        workspaceRoot: "/tmp/unsafe-benchmark-scope",
-        allowedReadRoots: ["/tmp/unsafe-benchmark-scope"],
-        allowedWriteRoots: ["/tmp/unsafe-benchmark-scope"],
-      },
     });
     const parsed = JSON.parse(result) as {
       success?: boolean;
@@ -3553,6 +3715,7 @@ describe("createSessionToolHandler", () => {
       ],
       routerId: "router-a",
       send: vi.fn(),
+      defaultWorkingDirectory: "/tmp/unsafe-benchmark-scope",
       delegation: () => ({
         subAgentManager: subAgentManager as any,
         policyEngine: null,
@@ -3575,9 +3738,6 @@ describe("createSessionToolHandler", () => {
         "Validate localhost runs cleanly",
       ],
       executionContext: {
-        workspaceRoot: "/tmp/unsafe-benchmark-scope",
-        allowedReadRoots: ["/tmp/unsafe-benchmark-scope"],
-        allowedWriteRoots: ["/tmp/unsafe-benchmark-scope"],
         targetArtifacts: ["/tmp/unsafe-benchmark-scope/src/main.ts"],
       },
     });
@@ -3643,6 +3803,7 @@ describe("createSessionToolHandler", () => {
       ],
       routerId: "router-a",
       send: vi.fn(),
+      defaultWorkingDirectory: "/tmp/unsafe-benchmark-policy-bypass",
       delegation: () => ({
         subAgentManager: subAgentManager as any,
         policyEngine,
@@ -3657,9 +3818,6 @@ describe("createSessionToolHandler", () => {
       inputContract: "Return JSON summary",
       acceptanceCriteria: ["Create files", "Run npm install"],
       executionContext: {
-        workspaceRoot: "/tmp/unsafe-benchmark-policy-bypass",
-        allowedReadRoots: ["/tmp/unsafe-benchmark-policy-bypass"],
-        allowedWriteRoots: ["/tmp/unsafe-benchmark-policy-bypass"],
         targetArtifacts: ["/tmp/unsafe-benchmark-policy-bypass/src/main.ts"],
       },
     });
@@ -3857,6 +4015,7 @@ describe("createSessionToolHandler", () => {
       availableToolNames: ["desktop.text_editor", "web_search"],
       routerId: "router-a",
       send: vi.fn(),
+      defaultWorkingDirectory: "/tmp/runtime-docs-scope",
       delegation: () => ({
         subAgentManager: subAgentManager as any,
         policyEngine: null,
@@ -3870,10 +4029,6 @@ describe("createSessionToolHandler", () => {
       objective:
         'Read docs/RUNTIME_API.md (full path /workspace/docs/RUNTIME_API.md). Focus ONLY on "Delegation Runtime Surface" and "Stateful Response Compaction" sections. Identify exactly one autonomy-validation risk/mismatch with a direct reference.',
       acceptanceCriteria: ["one specific risk or mismatch identified"],
-      executionContext: {
-        workspaceRoot: "/tmp/runtime-docs-scope",
-        allowedReadRoots: ["/tmp/runtime-docs-scope"],
-      },
     });
     expect(typeof result).toBe("string");
     expect(subAgentManager.spawn).toHaveBeenCalledWith(
@@ -4044,6 +4199,7 @@ describe("createSessionToolHandler", () => {
       availableToolNames: ["execute_with_agent", "system.readFile"],
       routerId: "router-a",
       send: vi.fn(),
+      defaultWorkingDirectory: "/tmp/unsafe-benchmark-nested",
       delegation: () => ({
         subAgentManager: subAgentManager as any,
         policyEngine,
@@ -4056,10 +4212,6 @@ describe("createSessionToolHandler", () => {
     const result = await handler("execute_with_agent", {
       task: "expand scope",
       tools: ["system.readFile"],
-      executionContext: {
-        workspaceRoot: "/tmp/unsafe-benchmark-nested",
-        allowedReadRoots: ["/tmp/unsafe-benchmark-nested"],
-      },
     });
     const parsed = JSON.parse(result) as { success?: boolean };
 

--- a/runtime/src/gateway/tool-handler-factory.ts
+++ b/runtime/src/gateway/tool-handler-factory.ts
@@ -2719,16 +2719,19 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
       }
       executionArgs = injectionResult.args;
     }
-    executionArgs = applySessionAllowedRoots(toolName, executionArgs,
-      deriveSessionAllowedPaths({
-        explicitAdditionalAllowedPaths: [
-          ...(workspaceContext.additionalAllowedPaths ?? []),
-          ...(subAgentExecutionContext?.allowedReadRoots ?? []),
-          ...(subAgentExecutionContext?.allowedWriteRoots ?? []),
-        ],
-        scopedFilesystemRoot: effectiveScopedFilesystemRoot,
-        defaultWorkingDirectory: effectiveDefaultWorkingDirectory,
-      }),
+    const delegatedParentAllowedRoots = deriveSessionAllowedPaths({
+      explicitAdditionalAllowedPaths: [
+        ...(workspaceContext.additionalAllowedPaths ?? []),
+        ...(subAgentExecutionContext?.allowedReadRoots ?? []),
+        ...(subAgentExecutionContext?.allowedWriteRoots ?? []),
+      ],
+      scopedFilesystemRoot: effectiveScopedFilesystemRoot,
+      defaultWorkingDirectory: effectiveDefaultWorkingDirectory,
+    });
+    executionArgs = applySessionAllowedRoots(
+      toolName,
+      executionArgs,
+      delegatedParentAllowedRoots,
     );
 
     const subAgentEnvelopeError = isSubAgentSession
@@ -2762,6 +2765,8 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
           verifier,
           availableToolNames,
           defaultWorkingDirectory: effectiveDefaultWorkingDirectory,
+          parentAllowedReadRoots: delegatedParentAllowedRoots,
+          parentAllowedWriteRoots: delegatedParentAllowedRoots,
           delegationThreshold: policyEngine?.snapshot().spawnDecisionThreshold,
           unsafeBenchmarkMode,
         })

--- a/runtime/src/gateway/tool-round-budget.test.ts
+++ b/runtime/src/gateway/tool-round-budget.test.ts
@@ -55,7 +55,7 @@ describe("resolveTurnMaxToolRounds", () => {
 
   it("never lowers an explicit higher default cap", () => {
     expect(
-      resolveTurnMaxToolRounds(50, {
+      resolveTurnMaxToolRounds(COMPLEX_TURN_MAX_TOOL_ROUNDS + 10, {
         routedToolNames: ["system.writeFile"],
         expandedToolNames: [],
         diagnostics: {
@@ -71,7 +71,7 @@ describe("resolveTurnMaxToolRounds", () => {
           schemaCharsSaved: 0,
         },
       }),
-    ).toBe(50);
+    ).toBe(COMPLEX_TURN_MAX_TOOL_ROUNDS + 10);
   });
 });
 

--- a/runtime/src/gateway/tool-round-budget.ts
+++ b/runtime/src/gateway/tool-round-budget.ts
@@ -1,6 +1,6 @@
 import type { ToolRoutingDecision } from "./tool-routing.js";
 
-export const COMPLEX_TURN_MAX_TOOL_ROUNDS = 20;
+export const COMPLEX_TURN_MAX_TOOL_ROUNDS = 2_048;
 
 const HIGH_ITERATION_TOOL_NAMES = new Set<string>([
   "desktop.text_editor",

--- a/runtime/src/gateway/tool-routing.test.ts
+++ b/runtime/src/gateway/tool-routing.test.ts
@@ -721,6 +721,72 @@ describe("ToolRouter", () => {
     expect(decision.routedToolNames).not.toContain("agenc.getProtocolConfig");
   });
 
+  it("keeps trivial cwd introspection on the parent shell path even after coding history", () => {
+    const router = new ToolRouter(TOOLS, {
+      maxToolsPerTurn: 18,
+      minToolsPerTurn: 6,
+      maxExpandedToolsPerTurn: 24,
+    });
+
+    const decision = router.route({
+      sessionId: "s-parent-safe-pwd-after-codegen",
+      messageText: "what is the current working directory?",
+      history: [
+        {
+          role: "user",
+          content:
+            "Build a complete self-contained TypeScript codebase in /tmp/codegen-bench-parent-safe-pwd with tests and benchmarks.",
+        } as any,
+      ],
+    });
+
+    expect(decision.routedToolNames).toContain("system.bash");
+    expect(decision.routedToolNames).not.toContain("execute_with_agent");
+    expect(decision.routedToolNames).not.toContain("system.writeFile");
+    expect(decision.expandedToolNames).not.toContain("execute_with_agent");
+  });
+
+  it("keeps trivial ls introspection on the parent tool path even after coding history", () => {
+    const router = new ToolRouter(TOOLS, {
+      maxToolsPerTurn: 18,
+      minToolsPerTurn: 6,
+      maxExpandedToolsPerTurn: 24,
+    });
+
+    const decision = router.route({
+      sessionId: "s-parent-safe-ls-after-codegen",
+      messageText: "ls",
+      history: [
+        {
+          role: "user",
+          content:
+            "Create a complete self-contained Node.js project in /tmp/codegen-bench-parent-safe-ls and keep iterating until it builds cleanly.",
+        } as any,
+      ],
+    });
+
+    expect(decision.routedToolNames).toContain("system.bash");
+    expect(decision.routedToolNames).not.toContain("execute_with_agent");
+    expect(decision.expandedToolNames).not.toContain("execute_with_agent");
+  });
+
+  it("preserves execute_with_agent for explicit child ls delegation requests", () => {
+    const router = new ToolRouter(TOOLS, {
+      maxToolsPerTurn: 18,
+      minToolsPerTurn: 6,
+      maxExpandedToolsPerTurn: 24,
+    });
+
+    const decision = router.route({
+      sessionId: "s-explicit-child-ls",
+      messageText:
+        "Use execute_with_agent to run ls in a child agent and tell me what it prints.",
+      history: [],
+    });
+
+    expect(decision.routedToolNames).toContain("execute_with_agent");
+  });
+
   it("routes protocol and Solana audit tools only for explicit protocol prompts", () => {
     const router = new ToolRouter(TOOLS, {
       maxToolsPerTurn: 18,

--- a/runtime/src/gateway/tool-routing.ts
+++ b/runtime/src/gateway/tool-routing.ts
@@ -3,6 +3,10 @@ import type { ChatToolRoutingSummary } from "../llm/chat-executor.js";
 import type { Logger } from "../utils/logger.js";
 import { silentLogger } from "../utils/logger.js";
 import {
+  inferParentSafeReadOnlyIntrospection,
+  resolveParentSafeReadOnlyIntrospectionToolNames,
+} from "../utils/parent-safe-introspection.js";
+import {
   HIGH_SIGNAL_BROWSER_TOOL_NAMES,
   LOW_SIGNAL_BROWSER_TOOL_NAMES,
   PRIMARY_BROWSER_READ_TOOL_NAMES,
@@ -940,19 +944,37 @@ export class ToolRouter {
       };
     }
 
-    const currentIntentTerms = toTerms(params.messageText);
-    const intentTerms = this.extractIntentTerms(currentIntentTerms, params.history);
     const explicitToolMentions = this.extractExplicitToolMentions(params.messageText);
+    const parentSafeIntrospection = inferParentSafeReadOnlyIntrospection(
+      params.messageText,
+    );
+    const currentIntentTerms = toTerms(params.messageText);
+    const intentTerms = parentSafeIntrospection
+      ? [...currentIntentTerms]
+      : this.extractIntentTerms(currentIntentTerms, params.history);
     const blockedToolNames = inferBlockedToolNamesForMessage(
       params.messageText,
       this.allToolNames,
     );
-    const constrainedAllowedToolNames = inferConstrainedAllowedToolNamesForMessage(
-      params.messageText,
-      explicitToolMentions,
-      this.allToolNames,
-    );
-    const clusterKey = intentTerms.slice(0, 6).join("|") || "general";
+    const parentSafeAllowedToolNames = parentSafeIntrospection
+      ? new Set(
+          resolveParentSafeReadOnlyIntrospectionToolNames(
+            parentSafeIntrospection,
+            this.allToolNames,
+          ),
+        )
+      : null;
+    const constrainedAllowedToolNames =
+      parentSafeAllowedToolNames && parentSafeAllowedToolNames.size > 0
+        ? parentSafeAllowedToolNames
+        : inferConstrainedAllowedToolNamesForMessage(
+            params.messageText,
+            explicitToolMentions,
+            this.allToolNames,
+          );
+    const clusterKey = parentSafeIntrospection
+      ? `parent_safe_introspection:${parentSafeIntrospection.command}`
+      : intentTerms.slice(0, 6).join("|") || "general";
     const now = Date.now();
     const cached = this.cache.get(params.sessionId);
     const requiredFamilies = requiredFamiliesForTerms(currentIntentTerms);
@@ -960,7 +982,7 @@ export class ToolRouter {
     const terminalIntent = resolveTerminalIntent(currentIntentTerms);
 
     let invalidatedReason: string | undefined;
-    if (cached) {
+    if (cached && !parentSafeIntrospection) {
       const cachedTerminalIntent = resolveTerminalIntent(cached.terms);
       if (cached.missCount >= this.config.pivotMissThreshold) {
         invalidatedReason = "tool_miss_threshold";
@@ -1021,6 +1043,9 @@ export class ToolRouter {
           },
         );
       }
+    }
+    if (cached && parentSafeIntrospection) {
+      invalidatedReason = "parent_safe_introspection";
     }
 
     const hasHostCodegenIntent = inferHostCodegenIntent(params.messageText);

--- a/runtime/src/llm/chat-executor-constants.ts
+++ b/runtime/src/llm/chat-executor-constants.ts
@@ -96,7 +96,7 @@ export const REPETITIVE_LINE_MAX_UNIQUE_RATIO = 0.35;
 /** Upper bound on additive runtime hint system messages per execution. */
 export const DEFAULT_MAX_RUNTIME_SYSTEM_HINTS = 4;
 /** Default max planner output budget in tokens (soft, prompt-enforced). */
-export const DEFAULT_PLANNER_MAX_TOKENS = 256;
+export const DEFAULT_PLANNER_MAX_TOKENS = 8_192;
 /** Bounded planner retries when a delegated step is rejected for decomposition. */
 export const DEFAULT_PLANNER_MAX_REFINEMENT_ATTEMPTS = 2;
 /** Default retries reserved for planner step-contract cleanup before structural replans. */
@@ -117,7 +117,7 @@ export const MAX_PLANNER_CONTEXT_MEMORY_CHARS = 1_200;
 /** Max chars retained for one planner tool-output candidate entry. */
 export const MAX_PLANNER_CONTEXT_TOOL_OUTPUT_CHARS = 1_200;
 /** Default per-request tool-call budget. */
-export const DEFAULT_TOOL_BUDGET_PER_REQUEST = 24;
+export const DEFAULT_TOOL_BUDGET_PER_REQUEST = 2_048;
 /** Default per-request model recall budget (calls after first). 0 = unlimited. */
 export const DEFAULT_MODEL_RECALLS_PER_REQUEST = 0;
 /** Default per-request failed-tool-call budget. */
@@ -130,7 +130,7 @@ export const DEFAULT_REQUEST_TIMEOUT_MS = 0;
  * Absolute adaptive ceiling for tool rounds.
  * Keep aligned with gateway config validation for `llm.maxToolRounds`.
  */
-export const MAX_ADAPTIVE_TOOL_ROUNDS = 64;
+export const MAX_ADAPTIVE_TOOL_ROUNDS = 2_048;
 /** Default minimum verifier confidence for accepting subagent outputs. */
 export const DEFAULT_SUBAGENT_VERIFIER_MIN_CONFIDENCE = 0.65;
 /** Default max rounds for verifier/critique loops (initial round included). */

--- a/runtime/src/llm/chat-executor-contract-flow.test.ts
+++ b/runtime/src/llm/chat-executor-contract-flow.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   buildRequiredToolEvidenceRetryInstruction,
   canRetryDelegatedOutputWithoutAdditionalToolCalls,
+  requiresWorkflowOwnedImplementationCompletion,
   resolveCorrectionAllowedToolNames,
   resolveExecutionToolContractGuidance,
+  resolveLegacyCompletionCompatibility,
+  resolveRuntimeWorkflowContext,
   validateRequiredToolEvidence,
 } from "./chat-executor-contract-flow.js";
 
@@ -44,6 +47,186 @@ describe("chat-executor-contract-flow", () => {
       "mcp.doom.start_game",
       "mcp.doom.set_objective",
     ]);
+  });
+
+  it("synthesizes a runtime-owned workflow contract for direct deterministic implementation", () => {
+    const workflowContext = resolveRuntimeWorkflowContext({
+      ctx: {
+        messageText:
+          "Implement src/main.c in the current workspace and finish only when the implementation is complete.",
+        allToolCalls: [
+          {
+            name: "system.writeFile",
+            args: {
+              path: "/tmp/project/src/main.c",
+              content: "int main(void) { return 0; }\n",
+            },
+            result: JSON.stringify({
+              path: "/tmp/project/src/main.c",
+              bytesWritten: 30,
+            }),
+            isError: false,
+            durationMs: 2,
+          },
+        ],
+        activeRoutedToolNames: ["system.writeFile"],
+        initialRoutedToolNames: ["system.writeFile"],
+        expandedRoutedToolNames: [],
+        requiredToolEvidence: undefined,
+        providerEvidence: undefined,
+        response: undefined,
+        plannerSummaryState: {
+          routeReason: "tool_loop",
+        },
+        runtimeWorkspaceRoot: "/tmp/project",
+        plannerVerificationContract: undefined,
+        plannerCompletionContract: undefined,
+      } as any,
+    });
+
+    expect(workflowContext).toMatchObject({
+      ownershipSource: "direct_deterministic_implementation",
+      verificationContract: {
+        workspaceRoot: "/tmp/project",
+        targetArtifacts: ["/tmp/project/src/main.c"],
+        verificationMode: "mutation_required",
+      },
+      completionContract: {
+        taskClass: "artifact_only",
+      },
+    });
+  });
+
+  it("does not synthesize implementation ownership for documentation-only direct writes", () => {
+    const workflowContext = resolveRuntimeWorkflowContext({
+      ctx: {
+        messageText: "Update README.md with usage notes for the workspace.",
+        allToolCalls: [
+          {
+            name: "system.writeFile",
+            args: {
+              path: "/tmp/project/README.md",
+              content: "# Usage\n",
+            },
+            result: JSON.stringify({
+              path: "/tmp/project/README.md",
+              bytesWritten: 8,
+            }),
+            isError: false,
+            durationMs: 2,
+          },
+        ],
+        activeRoutedToolNames: ["system.writeFile"],
+        initialRoutedToolNames: ["system.writeFile"],
+        expandedRoutedToolNames: [],
+        requiredToolEvidence: undefined,
+        providerEvidence: undefined,
+        response: undefined,
+        plannerSummaryState: {
+          routeReason: "tool_loop",
+        },
+        runtimeWorkspaceRoot: "/tmp/project",
+        plannerVerificationContract: undefined,
+        plannerCompletionContract: undefined,
+      } as any,
+    });
+
+    expect(workflowContext).toEqual({});
+  });
+
+  it("requires workflow-owned completion for implementation-class turns outside legacy compatibility", () => {
+    expect(
+      requiresWorkflowOwnedImplementationCompletion({
+        ctx: {
+          messageText:
+            "Implement src/main.c in the current workspace and finish only when the implementation is complete.",
+          allToolCalls: [
+            {
+              name: "system.writeFile",
+              args: {
+                path: "/tmp/project/src/main.c",
+                content: "int main(void) { return 0; }\n",
+              },
+              result: JSON.stringify({
+                path: "/tmp/project/src/main.c",
+                bytesWritten: 30,
+              }),
+              isError: false,
+              durationMs: 2,
+            },
+          ],
+          activeRoutedToolNames: ["system.writeFile"],
+          initialRoutedToolNames: ["system.writeFile"],
+          expandedRoutedToolNames: [],
+          requiredToolEvidence: undefined,
+          providerEvidence: undefined,
+          response: undefined,
+          plannerSummaryState: {
+            routeReason: "tool_loop",
+          },
+        } as any,
+      }),
+    ).toBe(true);
+  });
+
+  it("limits legacy completion compatibility to docs, research, and plan-only turns", () => {
+    const docsDecision = resolveLegacyCompletionCompatibility({
+      ctx: {
+        messageText: "Update README.md with usage notes for the workspace.",
+        allToolCalls: [
+          {
+            name: "system.writeFile",
+            args: {
+              path: "/tmp/project/README.md",
+              content: "# Usage\n",
+            },
+            result: JSON.stringify({
+              path: "/tmp/project/README.md",
+              bytesWritten: 8,
+            }),
+            isError: false,
+            durationMs: 2,
+          },
+        ],
+        activeRoutedToolNames: ["system.writeFile"],
+        initialRoutedToolNames: ["system.writeFile"],
+        expandedRoutedToolNames: [],
+        requiredToolEvidence: undefined,
+        providerEvidence: undefined,
+        response: undefined,
+        plannerSummaryState: {
+          routeReason: "tool_loop",
+        },
+      } as any,
+    });
+
+    expect(docsDecision).toMatchObject({
+      allowed: true,
+      compatibilityClass: "docs",
+    });
+
+    const researchDecision = resolveLegacyCompletionCompatibility({
+      ctx: {
+        messageText: "Compare PixiJS and Phaser from official docs and cite sources.",
+        allToolCalls: [],
+        activeRoutedToolNames: ["web_search"],
+        initialRoutedToolNames: ["web_search"],
+        expandedRoutedToolNames: [],
+        requiredToolEvidence: undefined,
+        providerEvidence: {
+          citations: ["https://pixijs.com", "https://docs.phaser.io"],
+        },
+        response: undefined,
+        plannerSummaryState: {
+          routeReason: "tool_loop",
+        },
+      } as any,
+    });
+
+    expect(researchDecision).toMatchObject({
+      allowed: true,
+      compatibilityClass: "research",
+    });
   });
 
   it("adds validation-specific retry guidance", () => {

--- a/runtime/src/llm/chat-executor-contract-flow.ts
+++ b/runtime/src/llm/chat-executor-contract-flow.ts
@@ -16,6 +16,13 @@ import {
   validateDelegatedOutputContract,
 } from "../utils/delegation-validation.js";
 import { validateRuntimeVerificationContract } from "../workflow/index.js";
+import type { ImplementationCompletionContract } from "../workflow/completion-contract.js";
+import {
+  isPathWithinRoot,
+  normalizeEnvelopePath,
+  normalizeWorkspaceRoot,
+} from "../workflow/path-normalization.js";
+import type { WorkflowVerificationContract } from "../workflow/verification-obligations.js";
 import { buildBrowserEvidenceRetryGuidance } from "../utils/browser-tool-taxonomy.js";
 import type { ExecutionContext, ToolCallRecord } from "./chat-executor-types.js";
 import type { LLMProviderEvidence } from "./types.js";
@@ -33,29 +40,46 @@ import { requestRequiresToolGroundedExecution } from "./chat-executor-planner.js
 
 type ToolNameCollection = Iterable<string> | readonly string[];
 
-type ContractFlowContext = Pick<
-  ExecutionContext,
-  | "messageText"
-  | "allToolCalls"
-  | "activeRoutedToolNames"
-  | "initialRoutedToolNames"
-  | "expandedRoutedToolNames"
-  | "requiredToolEvidence"
-  | "providerEvidence"
-  | "response"
-  | "plannerSummaryState"
->;
+type ContractFlowContext =
+  Pick<
+    ExecutionContext,
+    | "messageText"
+    | "allToolCalls"
+    | "activeRoutedToolNames"
+    | "initialRoutedToolNames"
+    | "expandedRoutedToolNames"
+    | "requiredToolEvidence"
+    | "providerEvidence"
+    | "response"
+    | "plannerSummaryState"
+  > &
+  Partial<
+    Pick<
+      ExecutionContext,
+      | "runtimeWorkspaceRoot"
+      | "plannerVerificationContract"
+      | "plannerCompletionContract"
+    >
+  >;
 
 export type LegacyCompletionCompatibilityClass =
   | "docs"
   | "research"
-  | "plan_only"
-  | "implementation";
+  | "plan_only";
 
 export interface LegacyCompletionCompatibilityDecision {
   readonly allowed: boolean;
   readonly compatibilityClass: LegacyCompletionCompatibilityClass;
   readonly reason: string;
+}
+
+export interface RuntimeWorkflowContextResolution {
+  readonly verificationContract?: WorkflowVerificationContract;
+  readonly completionContract?: ImplementationCompletionContract;
+  readonly ownershipSource?:
+    | "planner_owned"
+    | "required_tool_evidence"
+    | "direct_deterministic_implementation";
 }
 
 const DIRECT_MUTATION_TOOL_NAMES = new Set([
@@ -77,6 +101,10 @@ const BUILD_OR_BEHAVIOR_COMMAND_RE =
   /\b(?:build|compile|typecheck|lint|test|tests|testing|vitest|jest|pytest|playwright|ctest|cargo test|go test|smoke|scenario|e2e|end-to-end)\b/i;
 const LIKELY_IMPLEMENTATION_REQUEST_RE =
   /\b(?:implement|implementation|fix|repair|refactor|build|compile|typecheck|lint|test|write|edit|update|create)\b/i;
+const BEHAVIOR_REQUIREMENT_RE =
+  /\b(?:behavior|behaviour|scenario|smoke|integration|e2e|end-to-end|playtest|job control)\b/i;
+const BUILD_REQUIREMENT_RE =
+  /\b(?:build|compile|typecheck|lint|test|tests|testing|vitest|jest|pytest|playwright|ctest|cargo test|go test)\b/i;
 
 interface EncodedEffectTarget {
   readonly path?: string;
@@ -114,12 +142,47 @@ export function resolveExecutionToolContractGuidance(input: {
   });
 }
 
+export function resolveRuntimeWorkflowContext(input: {
+  readonly ctx: ContractFlowContext;
+}): RuntimeWorkflowContextResolution {
+  const plannerContext = mergeWorkflowVerificationContext({
+    verificationContract: input.ctx.plannerVerificationContract,
+    completionContract: input.ctx.plannerCompletionContract,
+  });
+  if (plannerContext.verificationContract || plannerContext.completionContract) {
+    return {
+      ...plannerContext,
+      ownershipSource: "planner_owned",
+    };
+  }
+
+  const explicitContext = mergeWorkflowVerificationContext({
+    verificationContract: input.ctx.requiredToolEvidence?.verificationContract,
+    completionContract: input.ctx.requiredToolEvidence?.completionContract,
+  });
+  if (explicitContext.verificationContract || explicitContext.completionContract) {
+    return {
+      ...explicitContext,
+      ownershipSource: "required_tool_evidence",
+    };
+  }
+
+  const directImplementationContext =
+    synthesizeDirectImplementationWorkflowContext(input.ctx);
+  if (directImplementationContext) {
+    return {
+      ...directImplementationContext,
+      ownershipSource: "direct_deterministic_implementation",
+    };
+  }
+
+  return {};
+}
+
 export function resolveLegacyCompletionCompatibility(input: {
   readonly ctx: ContractFlowContext;
 }): LegacyCompletionCompatibilityDecision {
-  const successfulToolCalls = input.ctx.allToolCalls.filter(
-    (toolCall) => !didToolCallFail(toolCall.isError, toolCall.result),
-  );
+  const analysis = analyzeLegacyCompletionTurn(input.ctx);
   const plannerRouteReason = input.ctx.plannerSummaryState.routeReason;
   if (
     plannerRouteReason === "exact_response_turn" ||
@@ -133,41 +196,9 @@ export function resolveLegacyCompletionCompatibility(input: {
     };
   }
 
-  const mutatedArtifacts = collectLegacyMutatedArtifacts(successfulToolCalls);
-  const hasMutationProgress = mutatedArtifacts.length > 0;
-  const hasResearchEvidence =
-    (input.ctx.providerEvidence?.citations?.length ?? 0) > 0 ||
-    successfulToolCalls.some((toolCall) =>
-      toolCall.name.startsWith(BROWSER_TOOL_PREFIX) ||
-      RESEARCH_TOOL_NAMES.has(toolCall.name),
-    );
-  const hasBuildOrBehaviorEvidence = successfulToolCalls.some((toolCall) => {
-    const verification = parseEncodedVerificationMetadata(toolCall.result);
-    if (
-      verification?.category === "build" ||
-      verification?.category === "behavior"
-    ) {
-      return true;
-    }
-    const command =
-      verification?.command ??
-      resolveCommandText(toolCall);
-    return BUILD_OR_BEHAVIOR_COMMAND_RE.test(command);
-  });
-  const mutatesSourceLikeArtifacts = mutatedArtifacts.some((artifact) =>
-    SOURCE_LIKE_PATH_RE.test(artifact),
-  );
-  const likelyImplementationRequest =
-    LIKELY_IMPLEMENTATION_REQUEST_RE.test(input.ctx.messageText) &&
-    requestRequiresToolGroundedExecution(input.ctx.messageText);
-  const implementationLikeTurn =
-    mutatesSourceLikeArtifacts ||
-    hasBuildOrBehaviorEvidence ||
-    (successfulToolCalls.length === 0 && likelyImplementationRequest);
-
   if (
-    hasMutationProgress &&
-    mutatedArtifacts.every((artifact) => isDocOnlyArtifactPath(artifact))
+    analysis.hasMutationProgress &&
+    analysis.mutatedArtifacts.every((artifact) => isDocOnlyArtifactPath(artifact))
   ) {
     return {
       allowed: true,
@@ -177,7 +208,11 @@ export function resolveLegacyCompletionCompatibility(input: {
     };
   }
 
-  if (!hasMutationProgress && hasResearchEvidence && !hasBuildOrBehaviorEvidence) {
+  if (
+    !analysis.hasMutationProgress &&
+    analysis.hasResearchEvidence &&
+    !analysis.hasBuildOrBehaviorEvidence
+  ) {
     return {
       allowed: true,
       compatibilityClass: "research",
@@ -187,7 +222,7 @@ export function resolveLegacyCompletionCompatibility(input: {
   }
 
   if (
-    !hasMutationProgress &&
+    !analysis.hasMutationProgress &&
     !requestRequiresToolGroundedExecution(input.ctx.messageText)
   ) {
     return {
@@ -198,7 +233,7 @@ export function resolveLegacyCompletionCompatibility(input: {
     };
   }
 
-  if (!implementationLikeTurn) {
+  if (!analysis.implementationLikeTurn) {
     return {
       allowed: true,
       compatibilityClass: "plan_only",
@@ -206,14 +241,16 @@ export function resolveLegacyCompletionCompatibility(input: {
         "Legacy completion remains allowed for non-implementation turns outside the implementation verifier scope.",
     };
   }
+  throw new Error(
+    "resolveLegacyCompletionCompatibility received implementation-class work. " +
+      "Implementation completion must be handled by workflow-owned truth before compatibility.",
+  );
+}
 
-  return {
-    allowed: false,
-    compatibilityClass: "implementation",
-    reason:
-      "Implementation-class completion now requires the workflow verification contract. " +
-      "Only docs, research, and plan-only turns may use the legacy completion path.",
-  };
+export function requiresWorkflowOwnedImplementationCompletion(input: {
+  readonly ctx: ContractFlowContext;
+}): boolean {
+  return analyzeLegacyCompletionTurn(input.ctx).implementationLikeTurn;
 }
 
 export function validateRequiredToolEvidence(input: {
@@ -409,6 +446,170 @@ export function buildRequiredToolEvidenceRetryInstruction(input: {
     correctionLines.join(" ") +
     allowedToolSummary
   );
+}
+
+function mergeWorkflowVerificationContext(input: {
+  readonly verificationContract?: WorkflowVerificationContract;
+  readonly completionContract?: ImplementationCompletionContract;
+}): RuntimeWorkflowContextResolution {
+  if (!input.verificationContract && !input.completionContract) {
+    return {};
+  }
+  return {
+    verificationContract: {
+      ...(input.verificationContract ?? {}),
+      ...(input.completionContract
+        ? { completionContract: input.completionContract }
+        : {}),
+    },
+    completionContract:
+      input.completionContract ?? input.verificationContract?.completionContract,
+  };
+}
+
+function synthesizeDirectImplementationWorkflowContext(
+  ctx: ContractFlowContext,
+): RuntimeWorkflowContextResolution | undefined {
+  const workspaceRoot = normalizeWorkspaceRoot(ctx.runtimeWorkspaceRoot);
+  if (!workspaceRoot) {
+    return undefined;
+  }
+
+  const successfulToolCalls = ctx.allToolCalls.filter(
+    (toolCall) => !didToolCallFail(toolCall.isError, toolCall.result),
+  );
+  if (successfulToolCalls.length === 0) {
+    return undefined;
+  }
+
+  const mutatedArtifacts = collectLegacyMutatedArtifacts(successfulToolCalls)
+    .map((artifact) => normalizeEnvelopePath(artifact, workspaceRoot))
+    .filter((artifact) => isPathWithinRoot(artifact, workspaceRoot));
+  const uniqueMutatedArtifacts = [...new Set(mutatedArtifacts)];
+  const docOnlyMutations =
+    uniqueMutatedArtifacts.length > 0 &&
+    uniqueMutatedArtifacts.every((artifact) => isDocOnlyArtifactPath(artifact));
+  if (docOnlyMutations) {
+    return undefined;
+  }
+
+  const hasMutationProgress = uniqueMutatedArtifacts.length > 0;
+  const mutatesSourceLikeArtifacts = uniqueMutatedArtifacts.some((artifact) =>
+    SOURCE_LIKE_PATH_RE.test(artifact),
+  );
+  const buildOrBehaviorSignals = successfulToolCalls.map((toolCall) => {
+    const verification = parseEncodedVerificationMetadata(toolCall.result);
+    return {
+      verificationCategory: verification?.category,
+      command: verification?.command ?? resolveCommandText(toolCall),
+    };
+  });
+  const hasBehaviorRequirement =
+    BEHAVIOR_REQUIREMENT_RE.test(ctx.messageText) ||
+    buildOrBehaviorSignals.some(({ verificationCategory, command }) =>
+      verificationCategory === "behavior" || BEHAVIOR_REQUIREMENT_RE.test(command)
+    );
+  const hasBuildRequirement =
+    hasBehaviorRequirement ||
+    BUILD_REQUIREMENT_RE.test(ctx.messageText) ||
+    buildOrBehaviorSignals.some(({ verificationCategory, command }) =>
+      verificationCategory === "build" || BUILD_REQUIREMENT_RE.test(command)
+    );
+  const likelyImplementationRequest =
+    LIKELY_IMPLEMENTATION_REQUEST_RE.test(ctx.messageText) &&
+    requestRequiresToolGroundedExecution(ctx.messageText);
+  const implementationLikeTurn =
+    hasMutationProgress &&
+    (mutatesSourceLikeArtifacts || likelyImplementationRequest || hasBuildRequirement);
+  if (!implementationLikeTurn) {
+    return undefined;
+  }
+
+  const completionContract: ImplementationCompletionContract = hasBehaviorRequirement
+    ? {
+      taskClass: "behavior_required",
+      placeholdersAllowed: false,
+      partialCompletionAllowed: false,
+      placeholderTaxonomy: "implementation",
+    }
+    : hasBuildRequirement
+      ? {
+        taskClass: "build_required",
+        placeholdersAllowed: false,
+        partialCompletionAllowed: false,
+        placeholderTaxonomy: "implementation",
+      }
+      : {
+        taskClass: "artifact_only",
+        placeholdersAllowed: false,
+        partialCompletionAllowed: false,
+        placeholderTaxonomy: "implementation",
+      };
+
+  return {
+    verificationContract: {
+      workspaceRoot,
+      targetArtifacts: uniqueMutatedArtifacts,
+      verificationMode: "mutation_required",
+      completionContract,
+    },
+    completionContract,
+  };
+}
+
+interface LegacyCompletionTurnAnalysis {
+  readonly successfulToolCalls: readonly ToolCallRecord[];
+  readonly mutatedArtifacts: readonly string[];
+  readonly hasMutationProgress: boolean;
+  readonly hasResearchEvidence: boolean;
+  readonly hasBuildOrBehaviorEvidence: boolean;
+  readonly implementationLikeTurn: boolean;
+}
+
+function analyzeLegacyCompletionTurn(
+  ctx: ContractFlowContext,
+): LegacyCompletionTurnAnalysis {
+  const successfulToolCalls = ctx.allToolCalls.filter(
+    (toolCall) => !didToolCallFail(toolCall.isError, toolCall.result),
+  );
+  const mutatedArtifacts = collectLegacyMutatedArtifacts(successfulToolCalls);
+  const hasMutationProgress = mutatedArtifacts.length > 0;
+  const hasResearchEvidence =
+    (ctx.providerEvidence?.citations?.length ?? 0) > 0 ||
+    successfulToolCalls.some((toolCall) =>
+      toolCall.name.startsWith(BROWSER_TOOL_PREFIX) ||
+      RESEARCH_TOOL_NAMES.has(toolCall.name),
+    );
+  const hasBuildOrBehaviorEvidence = successfulToolCalls.some((toolCall) => {
+    const verification = parseEncodedVerificationMetadata(toolCall.result);
+    if (
+      verification?.category === "build" ||
+      verification?.category === "behavior"
+    ) {
+      return true;
+    }
+    const command =
+      verification?.command ??
+      resolveCommandText(toolCall);
+    return BUILD_OR_BEHAVIOR_COMMAND_RE.test(command);
+  });
+  const mutatesSourceLikeArtifacts = mutatedArtifacts.some((artifact) =>
+    SOURCE_LIKE_PATH_RE.test(artifact),
+  );
+  const likelyImplementationRequest =
+    LIKELY_IMPLEMENTATION_REQUEST_RE.test(ctx.messageText) &&
+    requestRequiresToolGroundedExecution(ctx.messageText);
+  return {
+    successfulToolCalls,
+    mutatedArtifacts,
+    hasMutationProgress,
+    hasResearchEvidence,
+    hasBuildOrBehaviorEvidence,
+    implementationLikeTurn:
+      mutatesSourceLikeArtifacts ||
+      hasBuildOrBehaviorEvidence ||
+      (successfulToolCalls.length === 0 && likelyImplementationRequest),
+  };
 }
 
 function collectLegacyMutatedArtifacts(

--- a/runtime/src/llm/chat-executor-contract-guidance.test.ts
+++ b/runtime/src/llm/chat-executor-contract-guidance.test.ts
@@ -209,6 +209,67 @@ describe("chat-executor-contract-guidance", () => {
     });
   });
 
+  it("keeps trivial cwd introspection on the parent shell path", () => {
+    const guidance = resolveToolContractGuidance({
+      phase: "initial",
+      messageText: "what is the current working directory?",
+      toolCalls: [],
+      allowedToolNames: ["system.bash", "execute_with_agent"],
+    });
+
+    expect(guidance).toEqual({
+      source: "parent-safe-introspection",
+      runtimeInstruction:
+        "This is a trivial read-only workspace introspection turn. " +
+        "Run `pwd` directly on the parent session with `system.bash` and answer from that output. " +
+        "Do not delegate a child agent unless the user explicitly asked for child isolation.",
+      routedToolNames: ["system.bash"],
+      toolChoice: "required",
+      enforcement: {
+        mode: "block_other_tools",
+        message:
+          "This trivial read-only workspace introspection request should stay on the parent session tool path. " +
+          "Run `pwd` directly instead of using child delegation or unrelated tools.",
+      },
+    });
+  });
+
+  it("blocks execute_with_agent for trivial parent-safe introspection turns", () => {
+    const block = resolveToolContractExecutionBlock({
+      phase: "initial",
+      messageText: "ls",
+      toolCalls: [],
+      allowedToolNames: ["system.bash", "execute_with_agent"],
+      candidateToolName: "execute_with_agent",
+    });
+
+    expect(block).toBe(
+      "This trivial read-only workspace introspection request should stay on the parent session tool path. " +
+      "Run `ls` directly instead of using child delegation or unrelated tools. " +
+      "Allowed now: `system.bash`. " +
+      "Do not use `execute_with_agent` yet.",
+    );
+  });
+
+  it("does not override explicit child delegation requests for trivial shell commands", () => {
+    const guidance = resolveToolContractGuidance({
+      phase: "initial",
+      messageText:
+        "Use execute_with_agent to run ls in a child agent and tell me what it prints.",
+      toolCalls: [],
+      allowedToolNames: ["system.bash", "execute_with_agent"],
+    });
+
+    expect(guidance).toEqual({
+      source: "explicit-tool-invocation",
+      runtimeInstruction:
+        "The user explicitly instructed this turn to call `execute_with_agent`. " +
+        "Execute that tool before answering.",
+      routedToolNames: ["execute_with_agent"],
+      toolChoice: "required",
+    });
+  });
+
   it("blocks desktop/bash detours before the Doom launch contract is satisfied", () => {
     const block = resolveToolContractExecutionBlock({
       phase: "initial",

--- a/runtime/src/llm/chat-executor-contract-guidance.ts
+++ b/runtime/src/llm/chat-executor-contract-guidance.ts
@@ -35,6 +35,10 @@ import {
   inferTypedArtifactInspectionIntent,
   type TypedArtifactDomain,
 } from "../tools/system/typed-artifact-domains.js";
+import {
+  inferParentSafeReadOnlyIntrospection,
+  resolveParentSafeReadOnlyIntrospectionToolNames,
+} from "../utils/parent-safe-introspection.js";
 import { extractExplicitImperativeToolNames } from "./chat-executor-explicit-tools.js";
 import { getAcceptanceVerificationCategories } from "../utils/delegation-validation.js";
 
@@ -80,6 +84,11 @@ const TOOL_CONTRACT_GUIDANCE_RESOLVERS: readonly ToolContractGuidanceResolver[] 
     name: "explicit-tool-invocation",
     priority: 260,
     resolve: resolveExplicitToolInvocationContractGuidance,
+  },
+  {
+    name: "parent-safe-introspection",
+    priority: 255,
+    resolve: resolveParentSafeReadOnlyIntrospectionContractGuidance,
   },
   {
     name: "server-handle",
@@ -285,6 +294,44 @@ function resolveExplicitToolInvocationContractGuidance(
       `Execute ${noun} before answering.`,
     routedToolNames,
     toolChoice: "required",
+  };
+}
+
+function resolveParentSafeReadOnlyIntrospectionContractGuidance(
+  input: ToolContractGuidanceContext,
+): ToolContractGuidance | undefined {
+  if (input.phase !== "initial") return undefined;
+  if (input.toolCalls.length > 0) return undefined;
+
+  const intent = inferParentSafeReadOnlyIntrospection(input.messageText);
+  if (!intent) return undefined;
+
+  const routedToolNames = resolveParentSafeReadOnlyIntrospectionToolNames(
+    intent,
+    input.allowedToolNames,
+  );
+  if (routedToolNames.length === 0) return undefined;
+
+  const commandSummary = intent.command === "pwd" ? "`pwd`" : "`ls`";
+  const preferredToolName = routedToolNames[0]!;
+  const toolAction =
+    preferredToolName === "system.listDir"
+      ? "a direct parent-session directory listing"
+      : `${commandSummary} directly on the parent session`;
+  return {
+    source: "parent-safe-introspection",
+    runtimeInstruction:
+      "This is a trivial read-only workspace introspection turn. " +
+      `Run ${toolAction} with \`${preferredToolName}\` and answer from that output. ` +
+      "Do not delegate a child agent unless the user explicitly asked for child isolation.",
+    routedToolNames: [preferredToolName],
+    toolChoice: "required",
+    enforcement: {
+      mode: "block_other_tools",
+      message:
+        "This trivial read-only workspace introspection request should stay on the parent session tool path. " +
+        `Run ${commandSummary} directly instead of using child delegation or unrelated tools.`,
+    },
   };
 }
 

--- a/runtime/src/llm/chat-executor-planner-execution.ts
+++ b/runtime/src/llm/chat-executor-planner-execution.ts
@@ -51,13 +51,17 @@ import {
   buildExplicitSubagentOrchestrationFailureMessage,
   extractRecoverablePlannerParseDiagnostics,
   isHighRiskSubagentPlan,
+  plannerRequestNeedsPlanArtifactExecution,
 } from "./chat-executor-planner.js";
 import { normalizePlannerResponse } from "./chat-executor-planner-normalization.js";
 import {
   executePlannerPipelineWithVerifierLoop,
   runSubagentVerifierRound,
 } from "./chat-executor-planner-verifier-loop.js";
-import { buildPlannerVerifierAdmission } from "./chat-executor-verifier.js";
+import {
+  buildPlannerVerifierAdmission,
+  buildPlannerWorkflowAdmission,
+} from "./chat-executor-verifier.js";
 import {
   deriveDelegationContextClusterId,
   type DelegationBanditPolicyTuner,
@@ -162,8 +166,11 @@ function resolvePlannerWorkspaceRoot(
   ctx: ExecutionContext,
   config: PlannerExecutionConfig,
 ): string | undefined {
-  if (typeof ctx.message.metadata?.workspaceRoot === "string") {
-    return ctx.message.metadata.workspaceRoot;
+  if (
+    typeof ctx.runtimeWorkspaceRoot === "string" &&
+    ctx.runtimeWorkspaceRoot.trim().length > 0
+  ) {
+    return ctx.runtimeWorkspaceRoot.trim();
   }
   const hostWorkspaceRoot = config.resolveHostWorkspaceRoot?.();
   return typeof hostWorkspaceRoot === "string" &&
@@ -174,8 +181,9 @@ function resolvePlannerWorkspaceRoot(
 
 function shouldBlockPlannerImplementationFallback(
   subagentSteps: readonly PlannerSubAgentTaskStepIntent[],
+  deterministicSteps: readonly PlannerDeterministicToolStepIntent[],
 ): boolean {
-  return subagentSteps.some((step) => {
+  const subagentImplementationStepDetected = subagentSteps.some((step) => {
     const executionContext = step.executionContext;
     const artifactPaths = [
       ...(executionContext?.targetArtifacts ?? []),
@@ -231,6 +239,74 @@ function shouldBlockPlannerImplementationFallback(
       Boolean(executionContext?.completionContract)
     );
   });
+  if (subagentImplementationStepDetected) {
+    return true;
+  }
+
+  return deterministicSteps.some((step) => {
+    if (step.tool !== "system.bash" && step.tool !== "desktop.bash") {
+      return false;
+    }
+    const command =
+      typeof step.args.command === "string"
+        ? step.args.command
+        : "";
+    const argv = Array.isArray(step.args.args)
+      ? step.args.args.filter((value): value is string => typeof value === "string")
+      : [];
+    const joined = [command, ...argv].join(" ").trim();
+    return /\b(?:build|compile|typecheck|lint|test|install|implement|scaffold|write|edit|create|fix|refactor|migrate)\b/i.test(
+      joined,
+    );
+  });
+}
+
+function buildPlannerImplementationFallbackBlockedDetail(
+  reason: string,
+): string {
+  return (
+    "Planner produced an implementation-scoped delegated plan, " +
+    `but runtime delegation admission rejected it (${reason}). ` +
+    "Inline legacy fallback is disabled for this task class; re-plan the work with a single-owner execution contract or provide an explicit workflow verification contract."
+  );
+}
+
+function canRefinePlannerDelegationVeto(reason: string): boolean {
+  switch (reason) {
+    case "shared_artifact_writer_inline":
+    case "fanout_exceeded":
+    case "depth_exceeded":
+    case "missing_execution_envelope":
+    case "parallel_gain_insufficient":
+    case "dependency_coupling_high":
+    case "tool_overlap_high":
+    case "retry_cost_high":
+    case "negative_economics":
+    case "no_safe_delegation_shape":
+    case "score_below_threshold":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function buildPlannerDelegationVetoRefinementHint(reason: string): string {
+  if (reason === "shared_artifact_writer_inline") {
+    return (
+      "The previous plan gave multiple delegated steps mutable or verification authority over the same workspace root. " +
+      "Re-emit a single-owner execution contract: one mutable implementation owner for the repo root, optional bounded read-only grounding before it, and deterministic verification/build/test steps after it unless a later delegated step owns disjoint artifacts."
+    );
+  }
+  if (reason === "score_below_threshold") {
+    return (
+      "The previous delegated plan was not strong enough to justify multiple child owners. " +
+      "Re-emit a smaller plan with one implementation owner and deterministic verification around it."
+    );
+  }
+  return (
+    `Runtime delegation admission rejected the previous implementation plan (${reason}). ` +
+    "Re-emit a valid single-owner execution contract with explicit artifact ownership and deterministic verification around the implementation owner."
+  );
 }
 
 // ============================================================================
@@ -1075,15 +1151,57 @@ export async function executePlannerPath(
       ctx.messages,
       ctx.messageSections,
       ctx.stateful?.artifactContext?.artifactRefs,
-      typeof ctx.message.metadata?.workspaceRoot === "string"
-        ? ctx.message.metadata.workspaceRoot
-        : undefined,
+      plannerWorkspaceRoot,
       ctx.expandedRoutedToolNames.length > 0
         ? ctx.expandedRoutedToolNames
         : ctx.activeRoutedToolNames.length > 0
         ? ctx.activeRoutedToolNames
         : (config.allowedTools ? [...config.allowedTools] : undefined),
     );
+    const plannerImplementationFallbackBlocked =
+      subagentSteps.length > 0 &&
+      shouldBlockPlannerImplementationFallback(
+        subagentSteps,
+        deterministicSteps,
+      );
+    ctx.plannerImplementationFallbackBlocked =
+      plannerImplementationFallbackBlocked;
+    const planArtifactExecutionRequest = plannerRequestNeedsPlanArtifactExecution(
+      ctx.messageText,
+    );
+    const delegationVetoReason = delegationDecision?.reason;
+    const shouldRefineDelegationVeto =
+      planArtifactExecutionRequest &&
+      subagentSteps.length > 0 &&
+      plannerImplementationFallbackBlocked &&
+      delegationDecision?.shouldDelegate === false &&
+      plannerAttempt < maxPlannerAttempts &&
+      typeof delegationVetoReason === "string" &&
+      canRefinePlannerDelegationVeto(delegationVetoReason);
+    if (shouldRefineDelegationVeto && delegationVetoReason) {
+      refinementHint = buildPlannerDelegationVetoRefinementHint(
+        delegationVetoReason,
+      );
+      ctx.plannerSummaryState.diagnostics.push({
+        category: "policy",
+        code: "planner_delegation_veto_retry",
+        message:
+          "Runtime delegation admission rejected the previous implementation plan; requesting a refined single-owner plan",
+        details: {
+          attempt: plannerAttempt,
+          nextAttempt: plannerAttempt + 1,
+          reason: delegationVetoReason,
+        },
+      });
+      callbacks.emitPlannerTrace(ctx, "planner_refinement_requested", {
+        attempt: plannerAttempt,
+        nextAttempt: plannerAttempt + 1,
+        reason: "planner_delegation_veto_retry",
+        delegationDecision,
+        plannerImplementationFallbackBlocked: true,
+      });
+      continue;
+    }
     const hasExecutablePlannerSteps =
       (
         deterministicSteps.length > 0 &&
@@ -1154,11 +1272,50 @@ export async function executePlannerPath(
         delegatedSteps: subagentSteps.map((step) => step.name),
       });
 
+      const plannerWorkflowAdmission = buildPlannerWorkflowAdmission({
+        subagentSteps,
+        deterministicSteps,
+        workspaceRoot: plannerExecutionContext.workspaceRoot,
+        verificationContract: ctx.requiredToolEvidence?.verificationContract,
+        completionContract: ctx.requiredToolEvidence?.completionContract,
+        includeSubagentOutputVerification:
+          config.subagentVerifierConfig.enabled ||
+          config.subagentVerifierConfig.force,
+      });
+      ctx.plannerWorkflowTaskClassification =
+        plannerWorkflowAdmission.taskClassification;
+      ctx.plannerVerificationContract =
+        plannerWorkflowAdmission.verificationContract;
+      ctx.plannerCompletionContract =
+        plannerWorkflowAdmission.completionContract;
+      if (plannerWorkflowAdmission.taskClassification === "invalid") {
+        callbacks.setStopReason(
+          ctx,
+          "validation_error",
+          plannerWorkflowAdmission.invalidReason ??
+            "Planner could not materialize a runtime-owned workflow contract for implementation-class work.",
+        );
+        ctx.finalContent =
+          plannerWorkflowAdmission.invalidReason ??
+          "Planner could not materialize a runtime-owned workflow contract for implementation-class work.";
+        callbacks.emitPlannerTrace(ctx, "planner_path_finished", {
+          plannerCalls: plannerAttempt,
+          routeReason: ctx.plannerSummaryState.routeReason,
+          stopReason: ctx.stopReason,
+          stopReasonDetail: ctx.stopReasonDetail,
+          diagnostics: ctx.plannerSummaryState.diagnostics,
+          handled: true,
+          taskClassification: plannerWorkflowAdmission.taskClassification,
+        });
+        ctx.plannerHandled = true;
+        return;
+      }
       const plannerVerifierAdmission = buildPlannerVerifierAdmission({
         subagentSteps,
         deterministicSteps,
-        verificationContract: ctx.requiredToolEvidence?.verificationContract,
-        completionContract: ctx.requiredToolEvidence?.completionContract,
+        workspaceRoot: plannerExecutionContext.workspaceRoot,
+        verificationContract: plannerWorkflowAdmission.verificationContract,
+        completionContract: plannerWorkflowAdmission.completionContract,
         includeSubagentOutputVerification:
           config.subagentVerifierConfig.enabled ||
           config.subagentVerifierConfig.force,
@@ -1664,17 +1821,16 @@ export async function executePlannerPath(
     if (
       subagentSteps.length > 0 &&
       delegationDecision?.shouldDelegate === false &&
-      shouldBlockPlannerImplementationFallback(subagentSteps)
+      plannerImplementationFallbackBlocked
     ) {
       callbacks.setStopReason(
         ctx,
         "validation_error",
         "Planner produced an implementation-scoped delegated plan, but runtime delegation admission rejected it. Inline legacy fallback is disabled for this task class.",
       );
-      ctx.finalContent =
-        `Planner produced an implementation-scoped delegated plan, ` +
-        `but runtime delegation admission rejected it (${delegationDecision.reason}). ` +
-        `Inline legacy fallback is disabled for this task class; re-plan the work with a single-owner execution contract or provide an explicit workflow verification contract.`;
+      ctx.finalContent = buildPlannerImplementationFallbackBlockedDetail(
+        delegationDecision.reason,
+      );
       callbacks.emitPlannerTrace(ctx, "planner_path_finished", {
         plannerCalls: plannerAttempt,
         routeReason: ctx.plannerSummaryState.routeReason,
@@ -1686,13 +1842,24 @@ export async function executePlannerPath(
       ctx.plannerHandled = true;
       return;
     }
+    if (plannerImplementationFallbackBlocked) {
+      callbacks.setStopReason(
+        ctx,
+        "validation_error",
+        "Planner produced an implementation-scoped delegated plan, but runtime delegation admission rejected it. Inline legacy fallback is disabled for this task class.",
+      );
+      ctx.finalContent = buildPlannerImplementationFallbackBlockedDetail(
+        delegationDecision?.reason ?? "delegation_veto",
+      );
+      ctx.plannerHandled = true;
+    }
     callbacks.emitPlannerTrace(ctx, "planner_path_finished", {
       plannerCalls: plannerAttempt,
       routeReason: ctx.plannerSummaryState.routeReason,
       stopReason: ctx.stopReason,
       stopReasonDetail: ctx.stopReasonDetail,
       diagnostics: ctx.plannerSummaryState.diagnostics,
-      handled: false,
+      handled: plannerImplementationFallbackBlocked ? true : false,
     });
     return;
   }

--- a/runtime/src/llm/chat-executor-planner.test.ts
+++ b/runtime/src/llm/chat-executor-planner.test.ts
@@ -558,6 +558,17 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
     expect(decision.reason).toContain("plan_artifact_request");
   });
 
+  it("forces planner routing for plan-artifact execution requests", () => {
+    const decision = assessPlannerDecision(
+      true,
+      "You are to read all of @PLAN.md and complete every single phase in full.",
+      [],
+    );
+
+    expect(decision.shouldPlan).toBe(true);
+    expect(decision.reason).toContain("plan_artifact_execution_request");
+  });
+
   it("extracts required subagent steps from the compact 'plan required' prompt shape", () => {
     const requirements = extractExplicitSubagentOrchestrationRequirements(
       "Subagent context audit SG3. Sub-agent orchestration plan required: " +
@@ -1418,12 +1429,14 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
       "Write a TODO.md with a complete plan for building a C shell with jobs, fork(), argv parsing, and pipes.",
     );
 
-    expect(diagnostics).toEqual([
-      expect.objectContaining({
-        category: "validation",
-        code: "planner_plan_artifact_single_write_collapse",
-      }),
-    ]);
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          category: "validation",
+          code: "planner_plan_artifact_single_write_collapse",
+        }),
+      ]),
+    );
   });
 
   it("allows substantial software plan-doc requests when the plan grounds before the final artifact write", () => {
@@ -1459,6 +1472,88 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
     );
 
     expect(diagnostics).toEqual([]);
+  });
+
+  it("rejects plan-artifact execution requests that emit multiple mutable delegated owners for one workspace root", () => {
+    const workspaceRoot = "/tmp/agenc-shell";
+    const diagnostics = validatePlannerStepContracts(
+      {
+        reason: "complete_plan_artifact_execution",
+        requiresSynthesis: false,
+        confidence: 0.82,
+        steps: [
+          {
+            name: "read_plan",
+            stepType: "deterministic_tool",
+            dependsOn: [],
+            tool: "system.readFile",
+            args: {
+              path: `${workspaceRoot}/PLAN.md`,
+            },
+          },
+          {
+            name: "implement_changes",
+            stepType: "subagent_task",
+            dependsOn: ["read_plan"],
+            objective: "Implement the requested code changes from PLAN.md.",
+            inputContract: "PLAN.md plus existing source tree.",
+            acceptanceCriteria: ["Required source files updated."],
+            requiredToolCapabilities: ["read", "write", "bash"],
+            contextRequirements: ["read_plan"],
+            maxBudgetHint: "20m",
+            canRunParallel: false,
+            executionContext: {
+              version: "v1",
+              workspaceRoot,
+              allowedReadRoots: [workspaceRoot],
+              allowedWriteRoots: [workspaceRoot],
+              requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+              targetArtifacts: [`${workspaceRoot}/src`],
+              effectClass: "filesystem_write",
+              verificationMode: "mutation_required",
+              stepKind: "delegated_write",
+            },
+          },
+          {
+            name: "qa_doublecheck",
+            stepType: "subagent_task",
+            dependsOn: ["implement_changes"],
+            objective: "Retest, polish, and keep fixing until PLAN.md is complete.",
+            inputContract: "Updated repo and PLAN.md.",
+            acceptanceCriteria: ["All tests pass after any fixes."],
+            requiredToolCapabilities: ["read", "write", "bash"],
+            contextRequirements: ["implement_changes"],
+            maxBudgetHint: "15m",
+            canRunParallel: false,
+            executionContext: {
+              version: "v1",
+              workspaceRoot,
+              allowedReadRoots: [workspaceRoot],
+              allowedWriteRoots: [workspaceRoot],
+              requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+              targetArtifacts: [workspaceRoot],
+              effectClass: "mixed",
+              verificationMode: "mutation_required",
+              stepKind: "delegated_review",
+            },
+          },
+        ],
+        edges: [
+          { from: "read_plan", to: "implement_changes" },
+          { from: "implement_changes", to: "qa_doublecheck" },
+        ],
+      },
+      "Read all of @PLAN.md and complete every single phase in full.",
+    );
+
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          category: "validation",
+          code: "planner_plan_artifact_single_owner_required",
+        }),
+      ]),
+    );
   });
 
   it("rejects deterministic bash steps that embed shell separators in direct args", () => {

--- a/runtime/src/llm/chat-executor-planner.ts
+++ b/runtime/src/llm/chat-executor-planner.ts
@@ -341,6 +341,17 @@ export function assessPlannerDecision(
     };
   }
 
+  if (plannerRequestNeedsPlanArtifactExecution(messageText)) {
+    return {
+      score: Math.max(score, 4),
+      shouldPlan: true,
+      reason:
+        reasons.length > 0
+          ? `${reasons.join("+")}+plan_artifact_execution_request`
+          : "plan_artifact_execution_request",
+    };
+  }
+
   const directFastPath =
     score < 3 ||
     signals.normalized.trim().length < 20 ||
@@ -589,6 +600,8 @@ export function buildPlannerMessages(
     extractPlannerVerificationRequirements(messageText);
   const verificationCommandRequirements =
     extractPlannerVerificationCommandRequirements(messageText);
+  const planArtifactExecutionRequest =
+    plannerRequestNeedsPlanArtifactExecution(messageText);
   const hostToolingHint = buildPlannerHostToolingHint(
     messageText,
     history,
@@ -757,6 +770,18 @@ export function buildPlannerMessages(
     });
   }
 
+  if (planArtifactExecutionRequest) {
+    messages.push({
+      role: "system",
+      content:
+        "This is a plan-artifact execution request over a real workspace. " +
+        "Use exactly one mutable implementation owner for the repo root. " +
+        "If you need prior grounding, keep it read-only and bounded to explicit source or analysis artifacts. " +
+        "Do not emit multiple mutable, validation, or QA subagent_task steps that all re-own the same workspace root. " +
+        "Build, test, and verification around the implementation owner should be deterministic_tool steps unless a later delegated step owns disjoint artifacts.",
+    });
+  }
+
   if (typeof hostToolingHint === "string" && hostToolingHint.length > 0) {
     messages.push({
       role: "system",
@@ -830,6 +855,12 @@ const PLANNER_PLAN_ARTIFACT_REQUEST_RE =
   /\b(?:write|create|draft|generate|produce|make)\b[\s\S]{0,120}\b(?:todo(?:\.md)?|implementation plan|project plan|plan doc(?:ument)?|roadmap|checklist|spec(?:ification)?)\b/i;
 const PLANNER_PLAN_ARTIFACT_FILE_RE =
   /\b(?:todo(?:\.md)?|plan\.(?:md|txt|rst)|implementation[-_ ]plan(?:\.md)?|project[-_ ]plan(?:\.md)?|roadmap(?:\.md)?|checklist(?:\.md)?|spec(?:ification)?(?:\.md)?)\b/i;
+const PLANNER_PLAN_ARTIFACT_SOURCE_CUE_RE =
+  /\b(?:read|review|inspect|use|follow|based on|source of truth|go through)\b/i;
+const PLANNER_PLAN_ARTIFACT_EXECUTION_CUE_RE =
+  /\b(?:implement|execute|complete|finish|carry\s+out|apply|fix|repair|refactor|ship)\b/i;
+const PLANNER_PLAN_ARTIFACT_PHASE_CUE_RE =
+  /\b(?:phase|step|task|item)s?\b/i;
 const REQUEST_VERIFICATION_DIRECTIVE_RE =
   /\b(?:verify|verification|validated?|before\s+finish(?:ing)?|before\s+returning|before\s+completion|browser-grounded checks?)\b/i;
 const REQUEST_INSTALL_VERIFICATION_RE =
@@ -3085,6 +3116,9 @@ export function validatePlannerStepContracts(
   if (typeof messageText === "string" && plannerRequestNeedsGroundedPlanArtifact(messageText)) {
     diagnostics.push(...validatePlannerPlanArtifactSteps(plannerPlan));
   }
+  if (typeof messageText === "string" && plannerRequestNeedsPlanArtifactExecution(messageText)) {
+    diagnostics.push(...validatePlannerPlanArtifactExecutionOwnership(plannerPlan));
+  }
 
   for (const step of plannerPlan.steps) {
     if (step.stepType === "deterministic_tool") {
@@ -3251,6 +3285,27 @@ function plannerRequestNeedsGroundedPlanArtifact(messageText: string): boolean {
   );
 }
 
+export function plannerRequestNeedsPlanArtifactExecution(messageText: string): boolean {
+  const normalized = messageText.trim();
+  if (normalized.length === 0) {
+    return false;
+  }
+  if (!PLANNER_PLAN_ARTIFACT_FILE_RE.test(normalized)) {
+    return false;
+  }
+  if (!PLANNER_PLAN_ARTIFACT_EXECUTION_CUE_RE.test(normalized)) {
+    return false;
+  }
+  const signals = collectPlannerRequestSignals(normalized, []);
+  return (
+    PLANNER_PLAN_ARTIFACT_SOURCE_CUE_RE.test(normalized) ||
+    PLANNER_PLAN_ARTIFACT_PHASE_CUE_RE.test(normalized) ||
+    signals.hasImplementationScopeCue ||
+    signals.hasMultiStepCue ||
+    signals.longTask
+  );
+}
+
 function isPlannerFileWriteStep(step: PlannerStepIntent): boolean {
   return (
     step.stepType === "deterministic_tool" &&
@@ -3258,22 +3313,125 @@ function isPlannerFileWriteStep(step: PlannerStepIntent): boolean {
   );
 }
 
+function plannerStepHasMutableImplementationAuthority(
+  step: PlannerSubAgentTaskStepIntent,
+): boolean {
+  const executionContext = step.executionContext;
+  const isBoundedGroundingStep =
+    executionContext?.effectClass === "read_only" &&
+    executionContext?.verificationMode === "grounded_read" &&
+    (
+      executionContext?.stepKind === "delegated_research" ||
+      executionContext?.stepKind === "delegated_review"
+    );
+  if (isBoundedGroundingStep) {
+    return false;
+  }
+  const requiredCapabilities = step.requiredToolCapabilities.map((capability) =>
+    capability.trim().toLowerCase(),
+  );
+  if (
+    requiredCapabilities.some((capability) =>
+      capability.includes("write") ||
+      capability.includes("append") ||
+      capability.includes("delete") ||
+      capability.includes("move") ||
+      capability.includes("mkdir") ||
+      capability.includes("text_editor")
+    )
+  ) {
+    return true;
+  }
+  if (
+    requiredCapabilities.some((capability) => capability.includes("bash")) &&
+    /\b(?:build|compile|typecheck|lint|test|install|implement|scaffold|write|edit|create|fix|refactor|migrate)\b/i.test(
+      [
+        step.objective,
+        step.inputContract,
+        ...step.acceptanceCriteria,
+      ].join(" "),
+    )
+  ) {
+    return true;
+  }
+  return (
+    executionContext?.verificationMode === "mutation_required" ||
+    executionContext?.verificationMode === "deterministic_followup" ||
+    executionContext?.stepKind === "delegated_write" ||
+    executionContext?.stepKind === "delegated_scaffold" ||
+    executionContext?.stepKind === "delegated_validation" ||
+    executionContext?.stepKind === "delegated_review" ||
+    executionContext?.effectClass === "filesystem_write" ||
+    executionContext?.effectClass === "filesystem_scaffold" ||
+    executionContext?.effectClass === "shell" ||
+    executionContext?.effectClass === "mixed" ||
+    Boolean(executionContext?.completionContract)
+  );
+}
+
+function validatePlannerPlanArtifactExecutionOwnership(
+  plannerPlan: PlannerPlan,
+): readonly PlannerDiagnostic[] {
+  const diagnostics: PlannerDiagnostic[] = [];
+  const subagentSteps = plannerPlan.steps.filter(
+    (step): step is PlannerSubAgentTaskStepIntent =>
+      step.stepType === "subagent_task",
+  );
+  if (subagentSteps.length === 0) {
+    return diagnostics;
+  }
+
+  const mutableWorkspaceOwners = new Map<string, string[]>();
+  for (const step of subagentSteps) {
+    if (!plannerStepHasMutableImplementationAuthority(step)) {
+      continue;
+    }
+    const workspaceRoot = normalizeWorkspaceRoot(step.executionContext?.workspaceRoot);
+    if (!workspaceRoot) {
+      continue;
+    }
+    const owners = mutableWorkspaceOwners.get(workspaceRoot) ?? [];
+    owners.push(step.name);
+    mutableWorkspaceOwners.set(workspaceRoot, owners);
+  }
+
+  for (const [workspaceRoot, stepNames] of mutableWorkspaceOwners.entries()) {
+    if (stepNames.length <= 1) {
+      continue;
+    }
+    diagnostics.push(
+      createPlannerDiagnostic(
+        "validation",
+        "planner_plan_artifact_single_owner_required",
+        `Planner emitted multiple mutable delegated owners for plan-artifact execution workspace "${workspaceRoot}"`,
+        {
+          workspaceRoot,
+          stepNames: stepNames.join(","),
+        },
+      ),
+    );
+  }
+
+  return diagnostics;
+}
+
 function validatePlannerPlanArtifactSteps(
   plannerPlan: PlannerPlan,
 ): readonly PlannerDiagnostic[] {
+  const diagnostics: PlannerDiagnostic[] = [];
   const writeSteps = plannerPlan.steps.filter(isPlannerFileWriteStep);
   if (writeSteps.length === 0) {
-    return [
+    diagnostics.push(
       createPlannerDiagnostic(
         "validation",
         "planner_plan_artifact_missing_write_step",
         "Planner did not include a final file-write step for the requested planning artifact",
       ),
-    ];
+    );
   }
 
   if (plannerPlan.steps.length === 1 && isPlannerFileWriteStep(plannerPlan.steps[0]!)) {
-    return [
+    diagnostics.push(
       createPlannerDiagnostic(
         "validation",
         "planner_plan_artifact_single_write_collapse",
@@ -3283,7 +3441,7 @@ function validatePlannerPlanArtifactSteps(
           tool: (plannerPlan.steps[0] as PlannerDeterministicToolStepIntent).tool,
         },
       ),
-    ];
+    );
   }
 
   const lastWriteIndex = plannerPlan.steps.reduce((index, step, currentIndex) =>
@@ -3292,7 +3450,7 @@ function validatePlannerPlanArtifactSteps(
     (step, index) => index < lastWriteIndex && !isPlannerFileWriteStep(step),
   );
   if (lastWriteIndex >= 0 && !hasGroundingBeforeWrite) {
-    return [
+    diagnostics.push(
       createPlannerDiagnostic(
         "validation",
         "planner_plan_artifact_needs_grounding_step",
@@ -3301,10 +3459,9 @@ function validatePlannerPlanArtifactSteps(
           finalWriteStep: plannerPlan.steps[lastWriteIndex]!.name,
         },
       ),
-    ];
+    );
   }
-
-  return [];
+  return diagnostics;
 }
 
 export function buildPlannerStepContractRefinementHint(
@@ -3340,6 +3497,18 @@ export function buildPlannerStepContractRefinementHint(
         diagnostic.code === "planner_plan_artifact_needs_grounding_step"
       ) {
         return "for substantial software plan/TODO requests, do not jump straight to writeFile; add at least one grounding or decomposition step before the final artifact write";
+      }
+      if (diagnostic.code === "planner_plan_artifact_single_owner_required") {
+        const workspaceRoot =
+          readDiagnosticDetail(diagnostic, "workspaceRoot") ??
+          "the workspace root";
+        const stepNames =
+          readDiagnosticDetail(diagnostic, "stepNames") ??
+          "the delegated implementation steps";
+        return (
+          `for PLAN.md/TODO execution over ${workspaceRoot}, use exactly one mutable implementation owner; ` +
+          `do not let ${stepNames} all re-own the same workspace. Keep plan analysis bounded, and move build/test/QA into deterministic verification steps unless a later step owns disjoint artifacts`
+        );
       }
       if (diagnostic.code === "planner_plan_artifact_missing_write_step") {
         return "include a final file-write step for the requested planning artifact";

--- a/runtime/src/llm/chat-executor-recovery.test.ts
+++ b/runtime/src/llm/chat-executor-recovery.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildWorkflowRecoveryStateLines,
   buildRecoveryHints,
   computeQualityProxy,
   inferRecoveryHint,
@@ -371,6 +372,33 @@ describe("chat-executor-recovery", () => {
         verifierOverall: "skipped",
         failedToolCalls: 0,
       }),
+    );
+  });
+
+  it("preserves workflow-owned remaining requirements in recovery state lines", () => {
+    const lines = buildWorkflowRecoveryStateLines({
+      completionState: "needs_verification",
+      stopReason: "completed",
+      requiredRequirements: ["build_verification", "workflow_verifier_pass"],
+      satisfiedRequirements: ["build_verification"],
+      remainingRequirements: ["workflow_verifier_pass"],
+      reusableEvidence: [
+        {
+          requirement: "build_verification",
+          summary: "make test",
+          observedAt: 10,
+        },
+      ],
+      updatedAt: 10,
+    });
+
+    expect(lines).toEqual(
+      expect.arrayContaining([
+        "Workflow state: needs_verification",
+        "Still required before completion: workflow_verifier_pass",
+        "Reusable grounded evidence: make test",
+        "Do not mark this implementation complete until the remaining verifier requirements pass.",
+      ]),
     );
   });
 });

--- a/runtime/src/llm/chat-executor-recovery.ts
+++ b/runtime/src/llm/chat-executor-recovery.ts
@@ -20,6 +20,7 @@ import type {
   DelegationTrajectoryRecord,
 } from "./delegation-learning.js";
 import type { WorkflowCompletionState } from "../workflow/completion-state.js";
+import type { WorkflowProgressSnapshot } from "../workflow/completion-progress.js";
 import { createLLMStatefulFallbackReasonCounts } from "./types.js";
 import { SHELL_BUILTIN_COMMANDS } from "./chat-executor-constants.js";
 import {
@@ -28,6 +29,7 @@ import {
   normalizeDoomScreenResolution,
   parseToolResultObject,
 } from "./chat-executor-tool-utils.js";
+import { assessExecuteWithAgentResult } from "../utils/delegated-scope-trust.js";
 
 const DESKTOP_BIASED_SYSTEM_COMMANDS = new Set([
   "chromium",
@@ -700,6 +702,22 @@ export function inferRecoveryHint(
     };
   }
   if (call.name === "execute_with_agent" && parsedResult) {
+    const delegatedScopeAssessment = assessExecuteWithAgentResult({
+      args:
+        call.args && typeof call.args === "object" && !Array.isArray(call.args)
+          ? call.args
+          : undefined,
+      result: call.result,
+    });
+    if (delegatedScopeAssessment?.delegatedScopeTrust === "rejected_invalid_scope") {
+      return {
+        key: "execute-with-agent-invalid-scope",
+        message:
+          "The previous `execute_with_agent` attempt was rejected because delegated scope/root authority was invalid. " +
+          "Do not invent or widen child cwd/workspace roots in the next attempt. " +
+          "Use the parent tool path for trivial cwd/ls introspection, or rely only on runtime-provided delegated scope.",
+      };
+    }
     const status =
       typeof parsedResult.status === "string"
         ? parsedResult.status.trim().toLowerCase()
@@ -1162,6 +1180,43 @@ export interface QualityProxyInput {
   readonly verifierOverall: "pass" | "retry" | "fail" | "skipped";
   readonly evaluation?: EvaluationResult;
   readonly failedToolCalls: number;
+}
+
+export function buildWorkflowRecoveryStateLines(
+  progress?: WorkflowProgressSnapshot,
+): readonly string[] {
+  if (!progress || progress.completionState === "completed") {
+    return [];
+  }
+
+  const lines = [`Workflow state: ${progress.completionState}`];
+  if (progress.remainingRequirements.length > 0) {
+    lines.push(
+      `Still required before completion: ${progress.remainingRequirements.join(", ")}`,
+    );
+  }
+  if (progress.reusableEvidence.length > 0) {
+    lines.push(
+      `Reusable grounded evidence: ${progress.reusableEvidence
+        .slice(-3)
+        .map((entry) => entry.summary)
+        .join(" | ")}`,
+    );
+  }
+  if (progress.completionState === "needs_verification") {
+    lines.push(
+      "Do not mark this implementation complete until the remaining verifier requirements pass.",
+    );
+  } else if (progress.completionState === "partial") {
+    lines.push(
+      "Do not present the work as finished; continue from the grounded evidence and close the remaining requirements.",
+    );
+  } else if (progress.completionState === "blocked") {
+    lines.push(
+      "Do not present the work as complete; address the blocking condition or report it explicitly.",
+    );
+  }
+  return lines;
 }
 
 /** Compute a 0–1 quality proxy score from execution outcome signals. */

--- a/runtime/src/llm/chat-executor-text.test.ts
+++ b/runtime/src/llm/chat-executor-text.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
   buildToolExecutionGroundingMessage,
   generateFallbackContent,
+  normalizeHistory,
+  prepareToolResultForPrompt,
   reconcileDirectShellObservationContent,
   reconcileExactResponseContract,
   reconcileTerminalCompletionStateContent,
@@ -125,6 +127,21 @@ describe("chat-executor-text", () => {
         "Implemented. The shell is fully functional and matches the spec.",
       completionState: "needs_verification",
       stopReason: "completed",
+      completionProgress: {
+        completionState: "needs_verification",
+        stopReason: "completed",
+        requiredRequirements: ["workflow_verifier_pass"],
+        satisfiedRequirements: [],
+        remainingRequirements: ["workflow_verifier_pass"],
+        reusableEvidence: [
+          {
+            requirement: "build_verification",
+            summary: "make test",
+            observedAt: 7,
+          },
+        ],
+        updatedAt: 7,
+      },
       toolCalls: [
         {
           name: "system.writeFile",
@@ -137,6 +154,8 @@ describe("chat-executor-text", () => {
     });
 
     expect(content).toContain("needs verification");
+    expect(content).toContain("Still required before completion: workflow_verifier_pass");
+    expect(content).toContain("Reusable grounded evidence: make test");
     expect(content).not.toContain("fully functional");
   });
 
@@ -147,6 +166,16 @@ describe("chat-executor-text", () => {
       completionState: "partial",
       stopReason: "validation_error",
       stopReasonDetail: "Behavior checks still missing",
+      completionProgress: {
+        completionState: "partial",
+        stopReason: "validation_error",
+        stopReasonDetail: "Behavior checks still missing",
+        requiredRequirements: ["behavior_verification"],
+        satisfiedRequirements: [],
+        remainingRequirements: ["behavior_verification"],
+        reusableEvidence: [],
+        updatedAt: 9,
+      },
       toolCalls: [
         {
           name: "system.writeFile",
@@ -160,6 +189,50 @@ describe("chat-executor-text", () => {
 
     expect(content).toContain("Partial implementation");
     expect(content).toContain("Behavior checks still missing");
+    expect(content).toContain(
+      "Do not present the work as finished; continue from the grounded evidence and close the remaining requirements.",
+    );
+  });
+
+  it("does not render blocked implementation work as effectively complete", () => {
+    const content = reconcileTerminalCompletionStateContent({
+      content: "Implemented the core changes and everything should be done now.",
+      completionState: "blocked",
+      stopReason: "validation_error",
+      stopReasonDetail: "Verification artifacts are still missing",
+      completionProgress: {
+        completionState: "blocked",
+        stopReason: "validation_error",
+        stopReasonDetail: "Verification artifacts are still missing",
+        requiredRequirements: ["workflow_verifier_pass"],
+        satisfiedRequirements: [],
+        remainingRequirements: ["workflow_verifier_pass"],
+        reusableEvidence: [
+          {
+            requirement: "build_verification",
+            summary: "npm test",
+            observedAt: 12,
+          },
+        ],
+        updatedAt: 12,
+      },
+      toolCalls: [
+        {
+          name: "system.writeFile",
+          args: { path: "/workspace/src/main.c" },
+          result: JSON.stringify({ ok: true }),
+          isError: false,
+          durationMs: 7,
+        },
+      ],
+    });
+
+    expect(content).toContain("Verification artifacts are still missing");
+    expect(content).toContain("Workflow state: blocked");
+    expect(content).toContain("Still required before completion: workflow_verifier_pass");
+    expect(content).toContain(
+      "Do not present the work as complete; address the blocking condition or report it explicitly.",
+    );
   });
 
   it("reconciles verified file workflow output when final synthesis mangles the absolute path", () => {
@@ -495,6 +568,28 @@ describe("chat-executor-text", () => {
     expect(content).toBe("TOKEN=IVORY-CIRCUIT-92");
   });
 
+  it("does not replay delegated cwd claims as authoritative fallback summaries", () => {
+    const content = summarizeToolCalls([
+      {
+        name: "execute_with_agent",
+        args: {
+          task: "What is the current working directory in the child agent?",
+        },
+        result: JSON.stringify({
+          status: "completed",
+          success: true,
+          output: "Subagent cwd: /",
+          subagentSessionId: "subagent:cwd",
+          toolCalls: [],
+        }),
+        isError: false,
+        durationMs: 12,
+      },
+    ]);
+
+    expect(content).toBe("Completed execute_with_agent");
+  });
+
   it("propagates delegated child output from generateFallbackContent", () => {
     const content = generateFallbackContent([
       {
@@ -515,6 +610,63 @@ describe("chat-executor-text", () => {
     ]);
 
     expect(content).toBe("TOKEN=IVORY-CIRCUIT-92");
+  });
+
+  it("suppresses delegated cwd echoes from the authoritative runtime tool ledger preview", () => {
+    const message = buildToolExecutionGroundingMessage({
+      toolCalls: [
+        {
+          name: "execute_with_agent",
+          args: {
+            task: "Run pwd in the child agent and report it.",
+          },
+          result: JSON.stringify({
+            status: "completed",
+            success: true,
+            output: "Subagent cwd: /",
+            subagentSessionId: "subagent:cwd",
+            toolCalls: [],
+          }),
+          isError: false,
+          durationMs: 17,
+        },
+      ],
+    });
+
+    expect(String(message?.content)).toContain(
+      "[delegated output suppressed: untrusted cwd/workspace-root claim]",
+    );
+    expect(String(message?.content)).not.toContain("Subagent cwd: /");
+  });
+
+  it("rewrites rejected delegated scope failures before replaying them to the model", () => {
+    const prepared = prepareToolResultForPrompt(
+      JSON.stringify({
+        success: false,
+        error:
+          'Requested delegated workspace root "/" is outside the trusted parent workspace root "/tmp/project".',
+        issues: [{ code: "workspace_root_outside_parent_workspace" }],
+        delegatedScopeTrust: "rejected_invalid_scope",
+      }),
+    );
+
+    expect(prepared.text).toContain("Delegated scope was rejected by the runtime");
+    expect(prepared.text).not.toContain('workspace root "/"');
+    expect(prepared.text).not.toContain('"issues"');
+  });
+
+  it("omits assistant delegated cwd summaries from replay history", () => {
+    const normalized = normalizeHistory([
+      {
+        role: "assistant",
+        content: "Subagent cwd: /",
+      },
+    ]);
+
+    expect(String(normalized[0]?.content)).toContain(
+      "[assistant summary omitted: delegated cwd/workspace-root claim not replayed]",
+    );
+    expect(String(normalized[0]?.content)).not.toContain("Subagent cwd: /");
   });
 
   it("replaces low-information partial timeout completions with a failure fallback", () => {

--- a/runtime/src/llm/chat-executor-text.ts
+++ b/runtime/src/llm/chat-executor-text.ts
@@ -16,6 +16,7 @@ import type {
 } from "./prompt-budget.js";
 import type { ToolCallRecord, ChatPromptShape } from "./chat-executor-types.js";
 import type { WorkflowCompletionState } from "../workflow/completion-state.js";
+import type { WorkflowProgressSnapshot } from "../workflow/completion-progress.js";
 import {
   MAX_FINAL_RESPONSE_CHARS,
   REPETITIVE_LINE_MIN_COUNT,
@@ -47,6 +48,11 @@ import {
   parseJsonObjectFromText,
   tryParseJsonObject as tryParseObject,
 } from "../utils/delegated-contract-normalization.js";
+import {
+  assessExecuteWithAgentResult,
+  sanitizeDelegatedAssistantEnvironmentSummary,
+} from "../utils/delegated-scope-trust.js";
+import { buildWorkflowRecoveryStateLines } from "./chat-executor-recovery.js";
 
 // ============================================================================
 // JSON parsing helpers (used by planner + verifier)
@@ -110,7 +116,6 @@ const SIMPLE_READ_ONLY_SHELL_COMMANDS = new Set([
 ]);
 const SHELL_ADVICE_RE =
   /\b(?:spawns fresh shells|non-persistent|future commands there start|to work in\s+[`~]|prefix like|demo:)\b/i;
-
 function normalizeInlineText(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
@@ -174,7 +179,46 @@ function extractDelegatedToolOutput(
   if (!output || isLowInformationCompletion(output)) {
     return undefined;
   }
+  const assessment = assessExecuteWithAgentResult({
+    args:
+      toolCall.args &&
+        typeof toolCall.args === "object" &&
+        !Array.isArray(toolCall.args)
+        ? toolCall.args as Record<string, unknown>
+        : undefined,
+    result: toolCall.result,
+  });
+  if (
+    assessment &&
+    assessment.delegatedScopeTrust !== "trusted_authoritative"
+  ) {
+    return undefined;
+  }
   return output;
+}
+
+function delegatedResultPreview(
+  toolCall: ToolCallRecord,
+  preparedText: string,
+): string {
+  if (toolCall.name !== "execute_with_agent") {
+    return preparedText;
+  }
+  const assessment = assessExecuteWithAgentResult({
+    args:
+      toolCall.args &&
+        typeof toolCall.args === "object" &&
+        !Array.isArray(toolCall.args)
+        ? toolCall.args as Record<string, unknown>
+        : undefined,
+    result: toolCall.result,
+  });
+  if (!assessment || assessment.delegatedScopeTrust === "trusted_authoritative") {
+    return preparedText;
+  }
+  return assessment.delegatedScopeTrust === "rejected_invalid_scope"
+    ? "[delegated scope rejected by runtime: invalid child root/workspace authority]"
+    : "[delegated output suppressed: untrusted cwd/workspace-root claim]";
 }
 
 export function reconcileDirectShellObservationContent(
@@ -589,6 +633,12 @@ const EXECUTION_PLAN_LINE_RE =
 const PLAN_HEADING_RE = /^(?:\*\*)?plan(?:\*\*)?:?/im;
 const FUTURE_EXECUTION_SIGNAL_RE =
   /\b(?:starting execution|begin(?:ning)? execution|i(?:'ll| will)|going to|next(?: up)?|after that|then)\b/i;
+const EXECUTION_DEFERRAL_SIGNAL_RE =
+  /\b(?:let me know|ready for|next (?:feature|module|step)|deepen next|specific feature|specific module|continue next|follow up next)\b/i;
+const EXECUTION_PROGRESS_SUMMARY_SIGNAL_RE =
+  /\b(?:summary of process|current status|compiled|build succeeded|updated\s+`|updated\s+src\/|wrote\s+|fixed\s+|implemented\s+|ready)\b/i;
+const EXECUTION_BLOCKER_SIGNAL_RE =
+  /\b(?:blocked|blocker|cannot continue|can't continue|unable to continue|needs verification|requires verification|verification pending|waiting on)\b/i;
 
 export function reconcileTerminalFailureContent(params: {
   content: string;
@@ -630,6 +680,7 @@ export function reconcileTerminalCompletionStateContent(params: {
   stopReason: string;
   stopReasonDetail?: string;
   toolCalls: readonly ToolCallRecord[];
+  completionProgress?: WorkflowProgressSnapshot;
 }): string {
   const {
     content,
@@ -637,17 +688,22 @@ export function reconcileTerminalCompletionStateContent(params: {
     stopReason,
     stopReasonDetail,
     toolCalls,
+    completionProgress,
   } = params;
   if (completionState === "completed") {
     return content;
   }
+  const workflowStateSection = buildWorkflowStateSection(completionProgress);
   if (completionState === "blocked") {
-    return reconcileTerminalFailureContent({
+    const blockedContent = reconcileTerminalFailureContent({
       content,
       stopReason,
       stopReasonDetail,
       toolCalls,
     });
+    return workflowStateSection
+      ? `${blockedContent}\n\n${workflowStateSection}`
+      : blockedContent;
   }
 
   const fallback = buildTerminalCompletionStateFallback({
@@ -655,6 +711,7 @@ export function reconcileTerminalCompletionStateContent(params: {
     stopReason,
     stopReasonDetail,
     toolCalls,
+    completionProgress,
   });
   const trimmed = content.trim();
   if (trimmed.length === 0) {
@@ -675,6 +732,7 @@ function buildTerminalCompletionStateFallback(params: {
   stopReason: string;
   stopReasonDetail?: string;
   toolCalls: readonly ToolCallRecord[];
+  completionProgress?: WorkflowProgressSnapshot;
 }): string {
   const lines: string[] = [];
   if (params.completionState === "partial") {
@@ -687,15 +745,30 @@ function buildTerminalCompletionStateFallback(params: {
   } else if (params.stopReason !== "completed") {
     lines.push(`Stop reason: ${params.stopReason.replace(/_/g, " ")}.`);
   }
-  const successfulCalls = params.toolCalls.filter((toolCall) =>
-    !didToolCallFail(toolCall.isError, toolCall.result),
-  );
-  if (successfulCalls.length > 0) {
-    lines.push(
-      `Grounded work recorded: ${summarizeToolCalls(successfulCalls).trim()}`,
+  const workflowStateSection = buildWorkflowStateSection(params.completionProgress);
+  if (workflowStateSection) {
+    lines.push(workflowStateSection);
+  } else {
+    const successfulCalls = params.toolCalls.filter((toolCall) =>
+      !didToolCallFail(toolCall.isError, toolCall.result),
     );
+    if (successfulCalls.length > 0) {
+      lines.push(
+        `Grounded progress so far: ${summarizeToolCalls(successfulCalls).trim()}`,
+      );
+    }
   }
   return lines.join("\n\n");
+}
+
+function buildWorkflowStateSection(
+  progress?: WorkflowProgressSnapshot,
+): string | undefined {
+  const lines = buildWorkflowRecoveryStateLines(progress);
+  if (lines.length === 0) {
+    return undefined;
+  }
+  return lines.join("\n");
 }
 
 function isContradictoryCompletionStateCopy(
@@ -797,6 +870,16 @@ export function isPlanOnlyExecutionResponse(content: string): boolean {
   const trimmed = content.trim();
   if (!looksLikeExecutionPlan(trimmed)) return false;
   return PLAN_HEADING_RE.test(trimmed) || FUTURE_EXECUTION_SIGNAL_RE.test(trimmed);
+}
+
+export function isExecutionDeferralResponse(content: string): boolean {
+  const trimmed = content.trim();
+  if (trimmed.length === 0) return false;
+  if (EXECUTION_BLOCKER_SIGNAL_RE.test(trimmed)) return false;
+  return (
+    EXECUTION_DEFERRAL_SIGNAL_RE.test(trimmed) &&
+    EXECUTION_PROGRESS_SUMMARY_SIGNAL_RE.test(trimmed)
+  );
 }
 
 function normalizeFailurePreview(value: string): string {
@@ -1035,7 +1118,7 @@ export function normalizeHistory(history: readonly LLMMessage[]): LLMMessage[] {
       return {
         ...baseMessage,
         content: truncateText(
-          entry.content,
+          sanitizeDelegatedAssistantEnvironmentSummary(entry.content),
           MAX_HISTORY_MESSAGE_CHARS,
         ),
       };
@@ -1046,7 +1129,7 @@ export function normalizeHistory(history: readonly LLMMessage[]): LLMMessage[] {
         return {
           type: "text" as const,
           text: truncateText(
-            part.text,
+            sanitizeDelegatedAssistantEnvironmentSummary(part.text),
             MAX_HISTORY_MESSAGE_CHARS,
           ),
         };
@@ -1092,7 +1175,9 @@ export function toStatefulReconciliationMessage(
 
   return {
     ...baseMessage,
-    content: extractStatefulReconciliationText(message.content),
+    content: sanitizeDelegatedAssistantEnvironmentSummary(
+      extractStatefulReconciliationText(message.content),
+    ),
   };
 }
 
@@ -1214,7 +1299,31 @@ export function prepareToolResultForPrompt(result: string): {
 
   try {
     const parsed = JSON.parse(result) as unknown;
-    const sanitized = sanitizeJsonForPrompt(parsed, setDataUrl);
+    const parsedObject =
+      typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+        ? parsed as Record<string, unknown>
+        : undefined;
+    const delegatedScopeTrust =
+      typeof parsedObject?.delegatedScopeTrust === "string"
+        ? parsedObject.delegatedScopeTrust
+        : undefined;
+    const replaySafeParsed =
+      delegatedScopeTrust === "rejected_invalid_scope"
+        ? {
+          ...parsedObject,
+          error:
+            "Delegated scope was rejected by the runtime. Do not infer or invent child cwd/workspace roots from this failure.",
+          output: undefined,
+          issues: undefined,
+        }
+        : delegatedScopeTrust === "informational_untrusted"
+          ? {
+            ...parsedObject,
+            output:
+              "[delegated cwd/workspace-root claim treated as informational only]",
+          }
+          : parsed;
+    const sanitized = sanitizeJsonForPrompt(replaySafeParsed, setDataUrl);
     return {
       text: truncateText(
         safeStringify(sanitized),
@@ -1327,7 +1436,7 @@ function buildToolExecutionLedgerEntries(
         MAX_TOOL_LEDGER_ENTRY_ARGUMENT_CHARS,
       ),
       resultPreview: truncateText(
-        preparedResult.text,
+        delegatedResultPreview(toolCall, preparedResult.text),
         MAX_TOOL_LEDGER_ENTRY_RESULT_CHARS,
       ),
     };

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -161,6 +161,11 @@ export interface ChatExecuteParams {
   readonly history: readonly LLMMessage[];
   readonly systemPrompt: string;
   readonly sessionId: string;
+  /** Runtime-owned execution context resolved before model/planner execution. */
+  readonly runtimeContext?: {
+    /** Authoritative workspace root for planning/execution when known. */
+    readonly workspaceRoot?: string;
+  };
   /** Per-call tool handler — overrides the constructor handler for this call. */
   readonly toolHandler?: ToolHandler;
   /** Per-call stream callback — overrides the constructor callback for this call. */
@@ -578,6 +583,20 @@ export interface PlannerVerifierWorkItem {
   readonly verificationContract?: WorkflowVerificationContract;
 }
 
+export type PlannerWorkflowTaskClassification =
+  | "implementation_class"
+  | "docs_research_plan_only"
+  | "invalid";
+
+export interface PlannerWorkflowAdmission {
+  readonly taskClassification: PlannerWorkflowTaskClassification;
+  readonly verificationContract?: WorkflowVerificationContract;
+  readonly completionContract?: ImplementationCompletionContract;
+  readonly verifierWorkItems: readonly PlannerVerifierWorkItem[];
+  readonly requiresMandatoryImplementationVerification: boolean;
+  readonly invalidReason?: string;
+}
+
 export interface PlannerSynthesisStepIntent extends PlannerStepBaseIntent {
   stepType: "synthesis";
   objective?: string;
@@ -746,6 +765,7 @@ export interface ExecutionContext {
   readonly messageText: string;
   readonly systemPrompt: string;
   readonly sessionId: string;
+  readonly runtimeWorkspaceRoot?: string;
   readonly signal?: AbortSignal;
   readonly activeToolHandler?: ToolHandler;
   readonly activeStreamCallback?: StreamProgressCallback;
@@ -805,6 +825,10 @@ export interface ExecutionContext {
   routedToolsExpanded: boolean;
   routedToolMisses: number;
   plannerHandled: boolean;
+  plannerImplementationFallbackBlocked: boolean;
+  plannerWorkflowTaskClassification?: PlannerWorkflowTaskClassification;
+  plannerVerificationContract?: WorkflowVerificationContract;
+  plannerCompletionContract?: ImplementationCompletionContract;
   plannerSummaryState: FullPlannerSummaryState;
   trajectoryContextClusterId: string;
   selectedBanditArm?: DelegationBanditSelection;
@@ -829,6 +853,7 @@ export interface BuildExecutionContextParams {
   readonly messageText: string;
   readonly systemPrompt: string;
   readonly sessionId: string;
+  readonly runtimeContext?: ChatExecuteParams["runtimeContext"];
   readonly signal?: AbortSignal;
   readonly history: readonly LLMMessage[];
   readonly plannerDecision: PlannerDecision;
@@ -875,6 +900,7 @@ export function buildDefaultExecutionContext(
     messageText: params.messageText,
     systemPrompt: params.systemPrompt,
     sessionId: params.sessionId,
+    runtimeWorkspaceRoot: params.runtimeContext?.workspaceRoot,
     signal: params.signal,
     activeToolHandler: params.toolHandler,
     activeStreamCallback: params.streamCallback,
@@ -949,6 +975,10 @@ export function buildDefaultExecutionContext(
     routedToolsExpanded: false,
     routedToolMisses: 0,
     plannerHandled: false,
+    plannerImplementationFallbackBlocked: false,
+    plannerWorkflowTaskClassification: undefined,
+    plannerVerificationContract: undefined,
+    plannerCompletionContract: undefined,
     plannerSummaryState: {
       enabled: config.plannerEnabled,
       used: false,

--- a/runtime/src/llm/chat-executor-verifier.test.ts
+++ b/runtime/src/llm/chat-executor-verifier.test.ts
@@ -5,6 +5,7 @@ import type {
 } from "../workflow/pipeline.js";
 import type { PlannerSubAgentTaskStepIntent } from "./chat-executor-types.js";
 import {
+  buildPlannerWorkflowAdmission,
   buildPlannerVerifierAdmission,
   evaluatePlannerDeterministicChecks,
 } from "./chat-executor-verifier.js";
@@ -203,5 +204,61 @@ describe("evaluateSubagentDeterministicChecks", () => {
     expect(decision.steps[0]?.issues).not.toContain(
       "missing_successful_tool_evidence",
     );
+  });
+});
+
+describe("buildPlannerWorkflowAdmission", () => {
+  it("synthesizes a runtime-owned workflow contract for implementation-class planner work", () => {
+    const admission = buildPlannerWorkflowAdmission({
+      workspaceRoot: "/tmp/project",
+      subagentSteps: [],
+      deterministicSteps: [
+        {
+          name: "implement_core",
+          stepType: "deterministic_tool",
+          tool: "system.writeFile",
+          args: { path: "/tmp/project/src/main.ts", content: "export {};\n" },
+        },
+      ],
+    });
+
+    expect(admission.taskClassification).toBe("implementation_class");
+    expect(admission.requiresMandatoryImplementationVerification).toBe(true);
+    expect(admission.completionContract).toMatchObject({
+      taskClass: "artifact_only",
+    });
+    expect(admission.verificationContract).toMatchObject({
+      workspaceRoot: "/tmp/project",
+      verificationMode: "mutation_required",
+      completionContract: expect.objectContaining({
+        taskClass: "artifact_only",
+      }),
+    });
+  });
+
+  it("keeps docs and research planner work lightweight", () => {
+    const admission = buildPlannerWorkflowAdmission({
+      workspaceRoot: "/tmp/project",
+      subagentSteps: [
+        createStep({
+          objective: "Review PLAN.md",
+          acceptanceCriteria: ["Summarize findings"],
+          executionContext: {
+            version: "v1",
+            workspaceRoot: "/tmp/project",
+            allowedReadRoots: ["/tmp/project"],
+            requiredSourceArtifacts: ["/tmp/project/PLAN.md"],
+            verificationMode: "grounded_read",
+            stepKind: "delegated_review",
+            effectClass: "read_only",
+          },
+        }),
+      ],
+      deterministicSteps: [],
+    });
+
+    expect(admission.taskClassification).toBe("docs_research_plan_only");
+    expect(admission.requiresMandatoryImplementationVerification).toBe(false);
+    expect(admission.completionContract?.taskClass).toBe("review_required");
   });
 });

--- a/runtime/src/llm/chat-executor-verifier.ts
+++ b/runtime/src/llm/chat-executor-verifier.ts
@@ -11,6 +11,7 @@ import type {
 import type {
   PlannerDeterministicToolStepIntent,
   PlannerSubAgentTaskStepIntent,
+  PlannerWorkflowAdmission,
   PlannerVerifierWorkItem,
   PlannerPlan,
   SubagentVerifierStepVerdict,
@@ -50,20 +51,43 @@ const DIRECT_MUTATION_TOOL_NAMES = new Set([
 
 const SHELL_MUTATION_RE =
   /(?:^|[;&|]\s*|\n)\s*(?:cp|mv|rm|mkdir|touch|tee|sed|perl|python|node|ruby|go|cargo|npm|pnpm|yarn|make|cmake)\b|>>?|(?:^|[;&|]\s*|\n)\s*cat\s+.+>>?/i;
+const DETERMINISTIC_IMPLEMENTATION_COMMAND_RE =
+  /\b(?:implement|implementation|fix|repair|refactor|migrate|write|edit|update|create|build|compile|typecheck|lint|test|install|scaffold)\b/i;
 const SOURCE_LIKE_PATH_RE =
   /(?:^|\/)(?:src|lib|app|server|client|cmd|pkg|include|internal|tests?|spec)(?:\/|$)|\.(?:c|cc|cpp|cxx|h|hpp|m|mm|rs|go|py|rb|php|java|kt|swift|cs|js|jsx|ts|tsx|json|toml|yaml|yml|xml|sh|zsh|bash)$/i;
 const DOC_ONLY_PATH_RE = /\.(?:md|mdx|txt|rst|adoc)$/i;
 
-export function buildPlannerVerifierAdmission(params: {
+export function buildPlannerWorkflowAdmission(params: {
   readonly subagentSteps: readonly PlannerSubAgentTaskStepIntent[];
   readonly deterministicSteps: readonly PlannerDeterministicToolStepIntent[];
+  readonly workspaceRoot?: string;
   readonly verificationContract?: WorkflowVerificationContract;
   readonly completionContract?: ImplementationCompletionContract;
   readonly includeSubagentOutputVerification?: boolean;
-}): {
-  readonly verifierWorkItems: readonly PlannerVerifierWorkItem[];
-  readonly requiresMandatoryImplementationVerification: boolean;
-} {
+}): PlannerWorkflowAdmission {
+  const completionContract = resolvePlannerCompletionContract(params);
+  const verificationContract = buildPlannerWorkflowVerificationContract({
+    workspaceRoot: params.workspaceRoot,
+    subagentSteps: params.subagentSteps,
+    deterministicSteps: params.deterministicSteps,
+    verificationContract: params.verificationContract,
+    completionContract,
+  });
+  const taskClassification = classifyPlannerWorkflowAdmission({
+    workspaceRoot: params.workspaceRoot,
+    completionContract,
+  });
+  if (taskClassification === "invalid") {
+    return {
+      taskClassification,
+      verificationContract,
+      completionContract,
+      verifierWorkItems: [],
+      requiresMandatoryImplementationVerification: false,
+      invalidReason:
+        "Implementation-class planner work requires a runtime-owned workspace root and workflow contract before execution can begin.",
+    };
+  }
   const verifierWorkItems: PlannerVerifierWorkItem[] =
     params.includeSubagentOutputVerification === false
       ? []
@@ -76,25 +100,45 @@ export function buildPlannerVerifierAdmission(params: {
         requiredToolCapabilities: step.requiredToolCapabilities,
         resultStepNames: [step.name],
       }));
-  const completionContract = resolvePlannerCompletionContract(params);
   const requiresMandatoryImplementationVerification =
-    completionContract !== undefined &&
-    completionContract.taskClass !== "scaffold_allowed" &&
-    completionContract.taskClass !== "review_required";
+    taskClassification === "implementation_class";
 
   if (requiresMandatoryImplementationVerification) {
     verifierWorkItems.push(
       buildDeterministicImplementationVerifierWorkItem(
-        completionContract,
+        completionContract!,
+        params.subagentSteps,
         params.deterministicSteps,
-        params.verificationContract,
+        verificationContract,
       ),
     );
   }
 
   return {
+    taskClassification,
+    verificationContract,
+    completionContract,
     verifierWorkItems,
     requiresMandatoryImplementationVerification,
+  };
+}
+
+export function buildPlannerVerifierAdmission(params: {
+  readonly subagentSteps: readonly PlannerSubAgentTaskStepIntent[];
+  readonly deterministicSteps: readonly PlannerDeterministicToolStepIntent[];
+  readonly workspaceRoot?: string;
+  readonly verificationContract?: WorkflowVerificationContract;
+  readonly completionContract?: ImplementationCompletionContract;
+  readonly includeSubagentOutputVerification?: boolean;
+}): {
+  readonly verifierWorkItems: readonly PlannerVerifierWorkItem[];
+  readonly requiresMandatoryImplementationVerification: boolean;
+} {
+  const admission = buildPlannerWorkflowAdmission(params);
+  return {
+    verifierWorkItems: admission.verifierWorkItems,
+    requiresMandatoryImplementationVerification:
+      admission.requiresMandatoryImplementationVerification,
   };
 }
 
@@ -139,9 +183,23 @@ export function evaluatePlannerDeterministicChecks(
       issues.push("missing_subagent_result");
       verdict = "retry";
     } else if (step.verificationKind === "deterministic_implementation") {
+      const implementationToolCalls =
+        collectDeterministicImplementationToolCalls({
+          pipelineResult,
+          plannerToolCalls,
+          resultStepNames: step.resultStepNames,
+        });
+      const implementationProviderEvidence =
+        collectDeterministicImplementationProviderEvidence({
+          pipelineResult,
+          resultStepNames: step.resultStepNames,
+        });
       output = raw;
       status = "completed";
-      toolCallsCount = plannerToolCalls.length;
+      toolCallsCount = implementationToolCalls.length;
+      failedToolCallsCount = implementationToolCalls.filter(
+        (toolCall) => toolCall.isError === true,
+      ).length;
       if (output.trim().length === 0) {
         issues.push("missing_implementation_output_evidence");
         verdict = "retry";
@@ -149,7 +207,8 @@ export function evaluatePlannerDeterministicChecks(
         const hybridDecision = validateRuntimeVerificationContract({
           verificationContract: step.verificationContract,
           output: trimmedOrRawOutput(raw),
-          toolCalls: plannerToolCalls,
+          toolCalls: implementationToolCalls,
+          providerEvidence: implementationProviderEvidence,
         });
         if (hybridDecision && !hybridDecision.ok) {
           const hybridIssues = collectHybridVerifierIssues(hybridDecision);
@@ -647,6 +706,118 @@ function resolveVerifierWorkItemOutput(
     .join("\n");
 }
 
+function collectDeterministicImplementationToolCalls(params: {
+  readonly pipelineResult: PipelineResult;
+  readonly plannerToolCalls: readonly import("./chat-executor-types.js").ToolCallRecord[];
+  readonly resultStepNames?: readonly string[];
+}): readonly {
+  readonly name?: string;
+  readonly args?: unknown;
+  readonly result?: string;
+  readonly isError?: boolean;
+}[] {
+  const calls: {
+    readonly name?: string;
+    readonly args?: unknown;
+    readonly result?: string;
+    readonly isError?: boolean;
+  }[] = [...params.plannerToolCalls];
+  const seenSignatures = new Set(
+    calls.map((toolCall) => stableVerifierToolCallSignature(toolCall)),
+  );
+  const resultStepNames =
+    params.resultStepNames && params.resultStepNames.length > 0
+      ? params.resultStepNames
+      : Object.keys(params.pipelineResult.context.results);
+
+  for (const stepName of resultStepNames) {
+    const raw = params.pipelineResult.context.results[stepName];
+    if (typeof raw !== "string") {
+      continue;
+    }
+    const parsed = parseJsonObjectFromText(raw);
+    const nestedToolCalls = Array.isArray(parsed?.toolCalls)
+      ? parsed.toolCalls
+      : [];
+    for (const entry of nestedToolCalls) {
+      if (
+        typeof entry !== "object" ||
+        entry === null ||
+        Array.isArray(entry)
+      ) {
+        continue;
+      }
+      const toolCall = entry as {
+        readonly name?: string;
+        readonly args?: unknown;
+        readonly result?: string;
+        readonly isError?: boolean;
+      };
+      const signature = stableVerifierToolCallSignature(toolCall);
+      if (seenSignatures.has(signature)) {
+        continue;
+      }
+      seenSignatures.add(signature);
+      calls.push(toolCall);
+    }
+  }
+
+  return calls;
+}
+
+function collectDeterministicImplementationProviderEvidence(params: {
+  readonly pipelineResult: PipelineResult;
+  readonly resultStepNames?: readonly string[];
+}): { readonly citations?: readonly string[] } | undefined {
+  const citations = new Set<string>();
+  const resultStepNames =
+    params.resultStepNames && params.resultStepNames.length > 0
+      ? params.resultStepNames
+      : Object.keys(params.pipelineResult.context.results);
+
+  for (const stepName of resultStepNames) {
+    const raw = params.pipelineResult.context.results[stepName];
+    if (typeof raw !== "string") {
+      continue;
+    }
+    const parsed = parseJsonObjectFromText(raw);
+    const providerEvidence = parsed?.providerEvidence;
+    if (
+      !providerEvidence ||
+      typeof providerEvidence !== "object" ||
+      Array.isArray(providerEvidence)
+    ) {
+      continue;
+    }
+    const stepCitations = Array.isArray(
+      (providerEvidence as { citations?: unknown }).citations,
+    )
+      ? (providerEvidence as { citations: unknown[] }).citations
+      : [];
+    for (const citation of stepCitations) {
+      if (typeof citation === "string" && citation.trim().length > 0) {
+        citations.add(citation.trim());
+      }
+    }
+  }
+
+  return citations.size > 0 ? { citations: [...citations] } : undefined;
+}
+
+function stableVerifierToolCallSignature(toolCall: {
+  readonly name?: string;
+  readonly args?: unknown;
+  readonly result?: string;
+  readonly isError?: boolean;
+}): string {
+  return safeStringify({
+    name: toolCall.name,
+    args: toolCall.args,
+    result: toolCall.result,
+    isError: toolCall.isError === true,
+  });
+}
+
 function resolvePlannerCompletionContract(params: {
   readonly subagentSteps: readonly PlannerSubAgentTaskStepIntent[];
   readonly deterministicSteps: readonly PlannerDeterministicToolStepIntent[];
@@ -668,15 +839,14 @@ function resolvePlannerCompletionContract(params: {
   if (subagentCompletionContract) {
     return subagentCompletionContract;
   }
-  if (!hasDeterministicImplementationMutation(params.deterministicSteps)) {
+  const deterministicCompletionContract =
+    resolveDeterministicImplementationCompletionContract(
+      params.deterministicSteps,
+    );
+  if (!deterministicCompletionContract) {
     return undefined;
   }
-  return {
-    taskClass: "artifact_only",
-    placeholdersAllowed: false,
-    partialCompletionAllowed: false,
-    placeholderTaxonomy: "implementation",
-  };
+  return deterministicCompletionContract;
 }
 
 function resolvePlannerSubagentCompletionContract(
@@ -712,8 +882,183 @@ function resolvePlannerSubagentCompletionContract(
   return fallbackContract;
 }
 
+function buildPlannerWorkflowVerificationContract(params: {
+  readonly workspaceRoot?: string;
+  readonly subagentSteps: readonly PlannerSubAgentTaskStepIntent[];
+  readonly deterministicSteps: readonly PlannerDeterministicToolStepIntent[];
+  readonly verificationContract?: WorkflowVerificationContract;
+  readonly completionContract?: ImplementationCompletionContract;
+}): WorkflowVerificationContract | undefined {
+  const workspaceRoot =
+    typeof params.workspaceRoot === "string" &&
+      params.workspaceRoot.trim().length > 0
+      ? params.workspaceRoot.trim()
+      : typeof params.verificationContract?.workspaceRoot === "string" &&
+          params.verificationContract.workspaceRoot.trim().length > 0
+        ? params.verificationContract.workspaceRoot.trim()
+        : undefined;
+  const acceptanceCriteria = [
+    ...(params.verificationContract?.acceptanceCriteria ?? []),
+    ...params.subagentSteps.flatMap((step) => step.acceptanceCriteria),
+  ].filter((criterion) => criterion.trim().length > 0);
+  const inputArtifacts = Array.from(
+    new Set(
+      params.subagentSteps.flatMap(
+        (step) => step.executionContext?.inputArtifacts ?? [],
+      ),
+    ),
+  );
+  const requiredSourceArtifacts = Array.from(
+    new Set(
+      params.subagentSteps.flatMap(
+        (step) => step.executionContext?.requiredSourceArtifacts ??
+          step.executionContext?.inputArtifacts ??
+          [],
+      ),
+    ),
+  );
+  const targetArtifacts = Array.from(
+    new Set(
+      params.subagentSteps.flatMap(
+        (step) => step.executionContext?.targetArtifacts ?? [],
+      ),
+    ),
+  );
+  const verificationMode = selectPlannerVerificationMode({
+    explicit: params.verificationContract?.verificationMode,
+    subagentSteps: params.subagentSteps,
+    deterministicSteps: params.deterministicSteps,
+    completionContract: params.completionContract,
+  });
+  const stepKind = selectPlannerStepKind({
+    explicit: params.verificationContract?.stepKind,
+    subagentSteps: params.subagentSteps,
+    completionContract: params.completionContract,
+  });
+  if (
+    !workspaceRoot &&
+    acceptanceCriteria.length === 0 &&
+    inputArtifacts.length === 0 &&
+    requiredSourceArtifacts.length === 0 &&
+    targetArtifacts.length === 0 &&
+    !verificationMode &&
+    !stepKind &&
+    !params.completionContract
+  ) {
+    return undefined;
+  }
+  return {
+    ...(workspaceRoot ? { workspaceRoot } : {}),
+    ...(inputArtifacts.length > 0 ? { inputArtifacts } : {}),
+    ...(requiredSourceArtifacts.length > 0 ? { requiredSourceArtifacts } : {}),
+    ...(targetArtifacts.length > 0 ? { targetArtifacts } : {}),
+    ...(acceptanceCriteria.length > 0
+      ? { acceptanceCriteria: Array.from(new Set(acceptanceCriteria)) }
+      : {}),
+    ...(verificationMode ? { verificationMode } : {}),
+    ...(stepKind ? { stepKind } : {}),
+    ...(params.completionContract
+      ? { completionContract: params.completionContract }
+      : {}),
+  };
+}
+
+function classifyPlannerWorkflowAdmission(params: {
+  readonly workspaceRoot?: string;
+  readonly completionContract?: ImplementationCompletionContract;
+}): PlannerWorkflowAdmission["taskClassification"] {
+  const completionContract = params.completionContract;
+  if (
+    !completionContract ||
+    completionContract.taskClass === "scaffold_allowed" ||
+    completionContract.taskClass === "review_required"
+  ) {
+    return "docs_research_plan_only";
+  }
+  if (
+    typeof params.workspaceRoot !== "string" ||
+    params.workspaceRoot.trim().length === 0
+  ) {
+    return "invalid";
+  }
+  return "implementation_class";
+}
+
+function selectPlannerVerificationMode(params: {
+  readonly explicit?: WorkflowVerificationContract["verificationMode"];
+  readonly subagentSteps: readonly PlannerSubAgentTaskStepIntent[];
+  readonly deterministicSteps: readonly PlannerDeterministicToolStepIntent[];
+  readonly completionContract?: ImplementationCompletionContract;
+}): WorkflowVerificationContract["verificationMode"] | undefined {
+  if (params.explicit) {
+    return params.explicit;
+  }
+  for (const step of params.subagentSteps) {
+    if (step.executionContext?.verificationMode === "mutation_required") {
+      return "mutation_required";
+    }
+  }
+  if (
+    hasDeterministicImplementationMutation(params.deterministicSteps) ||
+    params.completionContract?.taskClass === "artifact_only" ||
+    params.completionContract?.taskClass === "build_required" ||
+    params.completionContract?.taskClass === "behavior_required"
+  ) {
+    return "mutation_required";
+  }
+  for (const step of params.subagentSteps) {
+    if (step.executionContext?.verificationMode === "deterministic_followup") {
+      return "deterministic_followup";
+    }
+  }
+  for (const step of params.subagentSteps) {
+    if (step.executionContext?.verificationMode === "grounded_read") {
+      return "grounded_read";
+    }
+  }
+  return undefined;
+}
+
+function selectPlannerStepKind(params: {
+  readonly explicit?: WorkflowVerificationContract["stepKind"];
+  readonly subagentSteps: readonly PlannerSubAgentTaskStepIntent[];
+  readonly completionContract?: ImplementationCompletionContract;
+}): WorkflowVerificationContract["stepKind"] | undefined {
+  if (params.explicit) {
+    return params.explicit;
+  }
+  for (const step of params.subagentSteps) {
+    if (step.executionContext?.stepKind === "delegated_write") {
+      return "delegated_write";
+    }
+  }
+  for (const step of params.subagentSteps) {
+    if (step.executionContext?.stepKind === "delegated_validation") {
+      return "delegated_validation";
+    }
+  }
+  for (const step of params.subagentSteps) {
+    if (step.executionContext?.stepKind === "delegated_review") {
+      return "delegated_review";
+    }
+  }
+  for (const step of params.subagentSteps) {
+    if (step.executionContext?.stepKind === "delegated_scaffold") {
+      return "delegated_scaffold";
+    }
+  }
+  if (params.completionContract?.taskClass === "review_required") {
+    return "delegated_review";
+  }
+  if (params.completionContract?.taskClass === "scaffold_allowed") {
+    return "delegated_scaffold";
+  }
+  return undefined;
+}
+
 function buildDeterministicImplementationVerifierWorkItem(
   completionContract: ImplementationCompletionContract,
+  subagentSteps: readonly PlannerSubAgentTaskStepIntent[],
   deterministicSteps: readonly PlannerDeterministicToolStepIntent[],
   verificationContract?: WorkflowVerificationContract,
 ): PlannerVerifierWorkItem {
@@ -729,8 +1074,18 @@ function buildDeterministicImplementationVerifierWorkItem(
     inputContract:
       "Assess the deterministic tool outputs and resulting artifacts against the implementation completion contract.",
     acceptanceCriteria,
-    requiredToolCapabilities: [...new Set(deterministicSteps.map((step) => step.tool))],
-    resultStepNames: deterministicSteps.map((step) => step.name),
+    requiredToolCapabilities: [
+      ...new Set([
+        ...subagentSteps.flatMap((step) => step.requiredToolCapabilities),
+        ...deterministicSteps.map((step) => step.tool),
+      ]),
+    ],
+    resultStepNames: [
+      ...new Set([
+        ...subagentSteps.map((step) => step.name),
+        ...deterministicSteps.map((step) => step.name),
+      ]),
+    ],
     verificationContract:
       verificationContract || acceptanceCriteria.length > 0
         ? {
@@ -761,6 +1116,62 @@ function hasDeterministicImplementationMutation(
   return deterministicSteps.some((step) => isImplementationMutationStep(step));
 }
 
+function resolveDeterministicImplementationCompletionContract(
+  deterministicSteps: readonly PlannerDeterministicToolStepIntent[],
+): ImplementationCompletionContract | undefined {
+  if (hasDeterministicBehaviorVerification(deterministicSteps)) {
+    return {
+      taskClass: "behavior_required",
+      placeholdersAllowed: false,
+      partialCompletionAllowed: false,
+      placeholderTaxonomy: "implementation",
+    };
+  }
+  if (hasDeterministicBuildVerification(deterministicSteps)) {
+    return {
+      taskClass: "build_required",
+      placeholdersAllowed: false,
+      partialCompletionAllowed: false,
+      placeholderTaxonomy: "implementation",
+    };
+  }
+  if (hasDeterministicImplementationMutation(deterministicSteps)) {
+    return {
+      taskClass: "artifact_only",
+      placeholdersAllowed: false,
+      partialCompletionAllowed: false,
+      placeholderTaxonomy: "implementation",
+    };
+  }
+  return undefined;
+}
+
+function hasDeterministicBuildVerification(
+  deterministicSteps: readonly PlannerDeterministicToolStepIntent[],
+): boolean {
+  return deterministicSteps.some((step) => {
+    if (step.tool !== "system.bash" && step.tool !== "desktop.bash") {
+      return false;
+    }
+    const commandText = extractCommandText(step.args);
+    return /\b(?:build|compile|typecheck|lint|install)\b/i.test(commandText);
+  });
+}
+
+function hasDeterministicBehaviorVerification(
+  deterministicSteps: readonly PlannerDeterministicToolStepIntent[],
+): boolean {
+  return deterministicSteps.some((step) => {
+    if (step.tool !== "system.bash" && step.tool !== "desktop.bash") {
+      return false;
+    }
+    const commandText = extractCommandText(step.args);
+    return /\b(?:test|tests|testing|vitest|jest|pytest|playwright|ctest|cargo test|go test|smoke|scenario|e2e|end-to-end)\b/i.test(
+      commandText,
+    );
+  });
+}
+
 function isImplementationMutationStep(
   step: PlannerDeterministicToolStepIntent,
 ): boolean {
@@ -775,6 +1186,9 @@ function isImplementationMutationStep(
     return false;
   }
   const commandText = extractCommandText(step.args);
+  if (DETERMINISTIC_IMPLEMENTATION_COMMAND_RE.test(commandText)) {
+    return true;
+  }
   if (!SHELL_MUTATION_RE.test(commandText)) {
     return false;
   }

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -175,7 +175,14 @@ function plannerWriteExecutionContext(
 
 function completedDelegatedPlannerResult(
   output: string,
-  toolNames: readonly string[] = ["system.writeFile"],
+  toolCalls:
+    | readonly string[]
+    | readonly {
+      readonly name?: string;
+      readonly args?: unknown;
+      readonly result?: string;
+      readonly isError?: boolean;
+    }[] = ["system.writeFile"],
 ): string {
   return safeJson({
     status: "completed",
@@ -183,10 +190,17 @@ function completedDelegatedPlannerResult(
     success: true,
     durationMs: 12,
     failedToolCalls: 0,
-    toolCalls: toolNames.map((name) => ({
-      name,
-      isError: false,
-    })),
+    toolCalls: toolCalls.map((entry) =>
+      typeof entry === "string"
+        ? {
+          name: entry,
+          isError: false,
+        }
+        : {
+          ...entry,
+          isError: entry.isError === true,
+        }
+    ),
   });
 }
 
@@ -1270,15 +1284,133 @@ describe("ChatExecutor", () => {
             type: "completion_gate_checked",
             phase: "tool_followup",
             payload: expect.objectContaining({
-              gate: "legacy_completion_compatibility",
-              decision: "not_required",
+              gate: "workflow_completion_truth",
+              decision: "accept",
+              ownerClass: "implementation",
+              ownershipSource: "required_tool_evidence",
+              completionState: "completed",
             }),
           }),
         ]),
       );
     });
 
-    it("rejects legacy direct implementation completion without a workflow verification contract", async () => {
+    it("retries deferred execution summaries instead of stopping mid-implementation", async () => {
+      const events: Record<string, unknown>[] = [];
+      const toolHandler = vi.fn()
+        .mockResolvedValueOnce("wrote main")
+        .mockResolvedValueOnce("wrote readme");
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-main",
+                  name: "system.writeFile",
+                  arguments: safeJson({
+                    path: "/tmp/tui-smoke/main.c",
+                    content: "int main(void) { return 0; }\n",
+                  }),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content:
+                "**Implementation complete where implemented.**\n\n" +
+                "**Summary of process:**\n" +
+                "- Updated `main.c`\n" +
+                "- Current status: compilable and aligned\n\n" +
+                "Ready for targeted module completion. Let me know specific feature to deepen next.",
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-readme",
+                  name: "system.writeFile",
+                  arguments: safeJson({
+                    path: "/tmp/tui-smoke/README.md",
+                    content: "done\n",
+                  }),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content:
+                "Created `main.c` and `README.md` with grounded tool execution.",
+            }),
+          ),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        allowedTools: ["system.writeFile", "system.bash"],
+      });
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "In /tmp/tui-smoke only, create main.c and README.md.",
+          ),
+          runtimeContext: {
+            workspaceRoot: "/tmp/tui-smoke",
+          },
+          trace: {
+            onExecutionTraceEvent: (event) => {
+              events.push(event as unknown as Record<string, unknown>);
+            },
+          },
+        }),
+      );
+
+      expect(result.stopReason).toBe("completed");
+      expect(result.content).toContain("main.c");
+      expect(result.content).toContain("README.md");
+      expect(toolHandler).toHaveBeenNthCalledWith(1, "system.writeFile", {
+        path: "/tmp/tui-smoke/main.c",
+        content: "int main(void) { return 0; }\n",
+      });
+      expect(toolHandler).toHaveBeenNthCalledWith(2, "system.writeFile", {
+        path: "/tmp/tui-smoke/README.md",
+        content: "done\n",
+      });
+      expect(provider.chat).toHaveBeenCalledTimes(4);
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "completion_gate_checked",
+            phase: "tool_followup",
+            payload: expect.objectContaining({
+              gate: "plan_only_execution",
+              decision: "retry",
+              executionDeferred: true,
+            }),
+          }),
+          expect.objectContaining({
+            type: "completion_gate_checked",
+            phase: "tool_followup",
+            payload: expect.objectContaining({
+              gate: "plan_only_execution",
+              decision: "accept",
+              executionDeferred: false,
+            }),
+          }),
+        ]),
+      );
+    });
+
+    it("materializes a runtime-owned workflow contract for direct implementation instead of falling back to legacy compatibility", async () => {
       const events: Record<string, unknown>[] = [];
       const toolHandler = vi.fn().mockResolvedValue("wrote source");
       const provider = createMockProvider("primary", {
@@ -1317,6 +1449,83 @@ describe("ChatExecutor", () => {
           message: createMessage(
             "In /tmp/phase9-direct only, implement src/main.c and finish when the implementation is done.",
           ),
+          runtimeContext: {
+            workspaceRoot: "/tmp/phase9-direct",
+          },
+          trace: {
+            onExecutionTraceEvent: (event) => {
+              events.push(event as unknown as Record<string, unknown>);
+            },
+          },
+        }),
+      );
+
+      expect(result.stopReason).toBe("completed");
+      expect(result.completionState).toBe("completed");
+      expect(result.completionProgress?.verificationContract).toMatchObject({
+        workspaceRoot: "/tmp/phase9-direct",
+        targetArtifacts: ["/tmp/phase9-direct/src/main.c"],
+        verificationMode: "mutation_required",
+        completionContract: expect.objectContaining({
+          taskClass: "artifact_only",
+        }),
+      });
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "completion_gate_checked",
+            phase: "tool_followup",
+            payload: expect.objectContaining({
+              gate: "workflow_completion_truth",
+              decision: "accept",
+              ownerClass: "implementation",
+              ownershipSource: "direct_deterministic_implementation",
+              reason: "workflow_verification_contract_present",
+            }),
+          }),
+        ]),
+      );
+    });
+
+    it("fails implementation-class completion through the workflow gate when no runtime-owned contract exists", async () => {
+      const events: Record<string, unknown>[] = [];
+      const toolHandler = vi.fn().mockResolvedValue("wrote source");
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-missing-contract",
+                  name: "system.writeFile",
+                  arguments: safeJson({
+                    path: "/tmp/phase9-missing-contract/src/main.c",
+                    content: "int main(void) { return 0; }\n",
+                  }),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "Implemented src/main.c successfully.",
+            }),
+          ),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        allowedTools: ["system.writeFile"],
+      });
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Implement src/main.c and finish when the implementation is done.",
+          ),
           trace: {
             onExecutionTraceEvent: (event) => {
               events.push(event as unknown as Record<string, unknown>);
@@ -1327,23 +1536,142 @@ describe("ChatExecutor", () => {
 
       expect(result.stopReason).toBe("validation_error");
       expect(result.stopReasonDetail).toContain(
-        "workflow verification contract",
+        "workflow-owned verification closure",
       );
-      expect(result.completionState).toBe("partial");
-      expect(result.content).toContain("Only docs, research, and plan-only turns");
+      expect(result.content).toContain(
+        "workflow-owned verification closure",
+      );
       expect(events).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
             type: "completion_gate_checked",
             phase: "tool_followup",
             payload: expect.objectContaining({
-              gate: "legacy_completion_compatibility",
+              gate: "workflow_completion_truth",
               decision: "fail",
-              compatibilityClass: "implementation",
+              ownerClass: "implementation",
             }),
           }),
         ]),
       );
+      expect(events).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "completion_gate_checked",
+            phase: "tool_followup",
+            payload: expect.objectContaining({
+              gate: "legacy_completion_compatibility",
+            }),
+          }),
+        ]),
+      );
+    });
+
+    it("reports equivalent completion semantics for direct and planner deterministic implementation", async () => {
+      const directProvider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-direct",
+                  name: "system.writeFile",
+                  arguments: safeJson({
+                    path: "/tmp/phase9-parity/src/main.c",
+                    content: "int main(void) { return 0; }\n",
+                  }),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "Implemented src/main.c successfully.",
+            }),
+          ),
+      });
+      const directExecutor = new ChatExecutor({
+        providers: [directProvider],
+        toolHandler: vi.fn().mockResolvedValue("wrote source"),
+        allowedTools: ["system.writeFile"],
+      });
+      const directResult = await directExecutor.execute(
+        createParams({
+          message: createMessage(
+            "In /tmp/phase9-parity only, implement src/main.c and finish only when the implementation is complete.",
+          ),
+          runtimeContext: {
+            workspaceRoot: "/tmp/phase9-parity",
+          },
+        }),
+      );
+
+      const plannerProvider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: safeJson({
+              reason: "planner_parity_contract",
+              requiresSynthesis: false,
+              steps: [
+                {
+                  name: "write_source",
+                  step_type: "deterministic_tool",
+                  tool: "system.writeFile",
+                  args: {
+                    path: "/tmp/phase9-parity/src/main.c",
+                    content: "int main(void) { return 0; }\n",
+                  },
+                },
+              ],
+            }),
+          }),
+        ),
+      });
+      const plannerExecutor = new ChatExecutor({
+        providers: [plannerProvider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        pipelineExecutor: {
+          execute: vi.fn().mockResolvedValue({
+            status: "completed",
+            completionState: "needs_verification",
+            context: {
+              results: {
+                write_source: safeJson({
+                  path: "/tmp/phase9-parity/src/main.c",
+                  bytesWritten: 30,
+                }),
+              },
+            },
+            completedSteps: 1,
+            totalSteps: 1,
+          }),
+        } as any,
+      });
+      const plannerResult = await plannerExecutor.execute(
+        createParams({
+          message: createMessage(
+            "In /tmp/phase9-parity only, implement src/main.c and finish only when the implementation is complete.",
+          ),
+          runtimeContext: {
+            workspaceRoot: "/tmp/phase9-parity",
+          },
+        }),
+      );
+
+      expect(directResult.completionState).toBe("completed");
+      expect(plannerResult.completionState).toBe("completed");
+      expect(directResult.completionProgress).toMatchObject({
+        requiredRequirements: [],
+        remainingRequirements: [],
+      });
+      expect(plannerResult.completionProgress).toMatchObject({
+        requiredRequirements: [],
+        remainingRequirements: [],
+      });
     });
 
     it("preserves legacy completion compatibility for documentation-only direct writes", async () => {
@@ -8782,6 +9110,9 @@ describe("ChatExecutor", () => {
           message: createMessage(
             "Implement a minimal C entrypoint under src/main.c and finish only when the implementation is actually complete.",
           ),
+          runtimeContext: {
+            workspaceRoot: "/tmp/phase3-shell",
+          },
         }),
       );
 
@@ -8864,6 +9195,9 @@ describe("ChatExecutor", () => {
           message: createMessage(
             "Implement the job table in src/jobs.c and only report success if the implementation has actually been verified.",
           ),
+          runtimeContext: {
+            workspaceRoot: "/tmp/phase3-shell",
+          },
         }),
       );
 
@@ -8963,6 +9297,9 @@ describe("ChatExecutor", () => {
           message: createMessage(
             "Implement src/jobs.c for the shell and only finish when the implementation is actually complete.",
           ),
+          runtimeContext: {
+            workspaceRoot: "/tmp/phase4-shell",
+          },
         }),
       );
 
@@ -9514,6 +9851,26 @@ describe("ChatExecutor", () => {
                 ],
               }),
             }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: safeJson({
+                overall: "pass",
+                confidence: 0.92,
+                unresolved: [],
+                steps: [
+                  {
+                    name: "implementation_completion",
+                    verdict: "pass",
+                    confidence: 0.92,
+                    retryable: true,
+                    issues: [],
+                    summary:
+                      "deterministic implementation outputs and test evidence satisfy the implementation contract",
+                  },
+                ],
+              }),
+            }),
           ),
       });
       const pipelineExecutor = {
@@ -9524,9 +9881,35 @@ describe("ChatExecutor", () => {
             context: {
               results: {
                 setup_workspace:
-                  '{"status":"completed","success":true,"output":"Workspace prepared"}',
+                  completedDelegatedPlannerResult("Workspace prepared", [
+                    {
+                      name: "system.writeFile",
+                      args: {
+                        path: "package.json",
+                        content: "{\"name\":\"gameplay-app\"}",
+                      },
+                    },
+                  ]),
                 implement_core:
-                  '{"status":"completed","success":true,"output":"Core implemented"}',
+                  completedDelegatedPlannerResult("Core implemented", [
+                    {
+                      name: "system.readFile",
+                      args: {
+                        path: "packages/core/test/index.test.ts",
+                      },
+                      result: safeJson({
+                        path: "packages/core/test/index.test.ts",
+                        content: "expect(findPath()).toBe(Infinity)",
+                      }),
+                    },
+                    {
+                      name: "system.writeFile",
+                      args: {
+                        path: "packages/core/src/index.ts",
+                        content: "export function findPath() { return Infinity; }",
+                      },
+                    },
+                  ]),
               },
             },
             completedSteps: 2,
@@ -9540,9 +9923,41 @@ describe("ChatExecutor", () => {
             context: {
               results: {
                 diagnose_test_failure:
-                  '{"status":"completed","success":true,"output":"Root cause identified"}',
+                  completedDelegatedPlannerResult("Root cause identified", [
+                    {
+                      name: "system.readFile",
+                      args: {
+                        path: "packages/core/test/index.test.ts",
+                      },
+                      result: safeJson({
+                        path: "packages/core/test/index.test.ts",
+                        content: "expect(findPath()).toBe(Infinity)",
+                      }),
+                    },
+                  ]),
                 repair_unreachable_behavior:
-                  '{"status":"completed","success":true,"output":"Unreachable-path behavior repaired"}',
+                  completedDelegatedPlannerResult(
+                    "Unreachable-path behavior repaired",
+                    [
+                      {
+                        name: "system.readFile",
+                        args: {
+                          path: "packages/core/test/index.test.ts",
+                        },
+                        result: safeJson({
+                          path: "packages/core/test/index.test.ts",
+                          content: "expect(findPath()).toBe(Infinity)",
+                        }),
+                      },
+                      {
+                        name: "system.writeFile",
+                        args: {
+                          path: "packages/core/src/index.ts",
+                          content: "export function findPath() { return Infinity; }",
+                        },
+                      },
+                    ],
+                  ),
                 run_tests: '{"exitCode":0,"stdout":"2 passed"}',
               },
             },
@@ -9569,6 +9984,9 @@ describe("ChatExecutor", () => {
           message: createMessage(
             "Implement the gameplay flow, verify it with tests, and repair any failing behavior before finishing.",
           ),
+          runtimeContext: {
+            workspaceRoot: "/tmp/gameplay-app",
+          },
         }),
       );
 
@@ -9931,6 +10349,27 @@ describe("ChatExecutor", () => {
                 ],
               }),
             }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content:
+                safeJson({
+                  overall: "pass",
+                  confidence: 0.94,
+                  unresolved: [],
+                  steps: [
+                    {
+                      name: "implementation_completion",
+                      verdict: "pass",
+                      confidence: 0.94,
+                      retryable: true,
+                      issues: [],
+                      summary:
+                        "deterministic implementation outputs and repeated test evidence satisfy the implementation contract",
+                    },
+                  ],
+                }),
+            }),
           ),
       });
       const pipelineExecutor = {
@@ -9940,9 +10379,35 @@ describe("ChatExecutor", () => {
             context: {
               results: {
                 setup_workspace:
-                  '{"status":"completed","success":true,"output":"Workspace prepared"}',
+                  completedDelegatedPlannerResult("Workspace prepared", [
+                    {
+                      name: "system.writeFile",
+                      args: {
+                        path: "package.json",
+                        content: "{\"name\":\"gameplay-app\"}",
+                      },
+                    },
+                  ]),
                 implement_core:
-                  '{"status":"completed","success":true,"output":"Core implemented"}',
+                  completedDelegatedPlannerResult("Core implemented", [
+                    {
+                      name: "system.readFile",
+                      args: {
+                        path: "artifacts/type-error.log",
+                      },
+                      result: safeJson({
+                        path: "artifacts/type-error.log",
+                        content: "TS2365 operator '+' cannot be applied",
+                      }),
+                    },
+                    {
+                      name: "system.writeFile",
+                      args: {
+                        path: "packages/core/src/index.ts",
+                        content: "export const total = Number(a) + Number(b);",
+                      },
+                    },
+                  ]),
               },
             },
             completedSteps: 2,
@@ -9956,9 +10421,43 @@ describe("ChatExecutor", () => {
             context: {
               results: {
                 diagnose_type_failure:
-                  '{"status":"completed","success":true,"output":"Type root cause identified"}',
+                  completedDelegatedPlannerResult(
+                    "Type root cause identified",
+                    [
+                      {
+                        name: "system.readFile",
+                        args: {
+                          path: "artifacts/type-error.log",
+                        },
+                        result: safeJson({
+                          path: "artifacts/type-error.log",
+                          content:
+                            "TS2365 operator '+' cannot be applied to number and string | number",
+                        }),
+                      },
+                    ],
+                  ),
                 repair_type_failure:
-                  '{"status":"completed","success":true,"output":"Type failure resolved"}',
+                  completedDelegatedPlannerResult("Type failure resolved", [
+                    {
+                      name: "system.readFile",
+                      args: {
+                        path: "artifacts/type-error.log",
+                      },
+                      result: safeJson({
+                        path: "artifacts/type-error.log",
+                        content:
+                          "TS2365 operator '+' cannot be applied to number and string | number",
+                      }),
+                    },
+                    {
+                      name: "system.writeFile",
+                      args: {
+                        path: "packages/core/src/index.ts",
+                        content: "export const total = Number(a) + Number(b);",
+                      },
+                    },
+                  ]),
               },
             },
             completedSteps: 2,
@@ -9972,9 +10471,43 @@ describe("ChatExecutor", () => {
             context: {
               results: {
                 diagnose_import_failure:
-                  '{"status":"completed","success":true,"output":"Import root cause identified"}',
+                  completedDelegatedPlannerResult(
+                    "Import root cause identified",
+                    [
+                      {
+                        name: "system.readFile",
+                        args: {
+                          path: "artifacts/import-error.log",
+                        },
+                        result: safeJson({
+                          path: "artifacts/import-error.log",
+                          content:
+                            "TS5097 import path can only end with .ts when allowImportingTsExtensions is enabled",
+                        }),
+                      },
+                    ],
+                  ),
                 repair_import_failure:
-                  '{"status":"completed","success":true,"output":"Import failure resolved"}',
+                  completedDelegatedPlannerResult("Import failure resolved", [
+                    {
+                      name: "system.readFile",
+                      args: {
+                        path: "artifacts/import-error.log",
+                      },
+                      result: safeJson({
+                        path: "artifacts/import-error.log",
+                        content:
+                          "TS5097 import path can only end with .ts when allowImportingTsExtensions is enabled",
+                      }),
+                    },
+                    {
+                      name: "system.writeFile",
+                      args: {
+                        path: "packages/core/tests/index.test.ts",
+                        content: "import { total } from '../src/index.js';",
+                      },
+                    },
+                  ]),
                 run_tests: '{"exitCode":0,"stdout":"2 passed"}',
               },
             },
@@ -10001,6 +10534,9 @@ describe("ChatExecutor", () => {
           message: createMessage(
             "Implement the gameplay flow, verify it with tests, and keep repairing deterministic failures until the tests are green.",
           ),
+          runtimeContext: {
+            workspaceRoot: "/tmp/gameplay-app",
+          },
         }),
       );
 
@@ -12285,6 +12821,9 @@ describe("ChatExecutor", () => {
               "- add Vitest coverage\n" +
               "- write a README and report exact passing commands",
           ),
+          runtimeContext: {
+            workspaceRoot: "/tmp",
+          },
         }),
       );
 
@@ -12415,6 +12954,84 @@ describe("ChatExecutor", () => {
       expect(result.plannerSummary).toMatchObject({
         used: true,
         routeReason: "expand_plan_artifact",
+        plannerCalls: 1,
+        plannedSteps: 2,
+        deterministicStepsExecuted: 2,
+      });
+      expect(result.callUsage.map((entry) => entry.phase)).toEqual(["planner"]);
+    });
+
+    it("routes plan-artifact execution requests through the planner instead of the direct tool loop", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValueOnce(
+          mockResponse({
+            content: safeJson({
+              reason: "complete_plan_artifact_execution",
+              requiresSynthesis: false,
+              steps: [
+                {
+                  name: "read_plan",
+                  step_type: "deterministic_tool",
+                  tool: "system.readFile",
+                  args: {
+                    path: "/home/tetsuo/git/stream-test/agenc-shell/PLAN.md",
+                  },
+                },
+                {
+                  name: "write_phase_summary",
+                  step_type: "deterministic_tool",
+                  depends_on: ["read_plan"],
+                  tool: "system.writeFile",
+                  args: {
+                    path: "/home/tetsuo/git/stream-test/agenc-shell/PHASE_SUMMARY.md",
+                    content: "# Phase summary\n",
+                  },
+                },
+              ],
+            }),
+          }),
+        ),
+      });
+      const pipelineExecutor = {
+        execute: vi.fn().mockResolvedValue({
+          status: "completed",
+          context: {
+            results: {
+              read_plan: safeJson({
+                path: "/home/tetsuo/git/stream-test/agenc-shell/PLAN.md",
+                size: 4096,
+              }),
+              write_phase_summary: safeJson({
+                path: "/home/tetsuo/git/stream-test/agenc-shell/PHASE_SUMMARY.md",
+                bytesWritten: 16,
+              }),
+            },
+          },
+          completedSteps: 2,
+          totalSteps: 2,
+        }),
+      };
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "You are to read all of @PLAN.md and complete every single phase in full.",
+          ),
+        }),
+      );
+
+      expect(provider.chat).toHaveBeenCalledTimes(1);
+      expect(pipelineExecutor.execute).toHaveBeenCalledTimes(1);
+      expect(result.stopReason).toBe("completed");
+      expect(result.plannerSummary).toMatchObject({
+        used: true,
+        routeReason: "complete_plan_artifact_execution",
         plannerCalls: 1,
         plannedSteps: 2,
         deterministicStepsExecuted: 2,
@@ -13691,6 +14308,492 @@ describe("ChatExecutor", () => {
       });
     });
 
+    it("refines the traced mixed implementation plan into a single-owner workflow before execution", async () => {
+      const events: Record<string, unknown>[] = [];
+      const workspaceRoot = "/home/tetsuo/git/AgenC";
+      const toolHandler = vi.fn().mockResolvedValue("unexpected inline execution");
+      const refinedSingleOwnerPlan = mockResponse({
+        content: safeJson({
+          reason: "single_owner_plan_artifact_execution",
+          requiresSynthesis: false,
+          steps: [
+            {
+              name: "read_plan",
+              step_type: "deterministic_tool",
+              tool: "system.readFile",
+              args: {
+                path: `${workspaceRoot}/PLAN.md`,
+              },
+              onError: "abort",
+            },
+            {
+              name: "analyze_plan",
+              step_type: "subagent_task",
+              objective:
+                "Read PLAN.md completely and write a bounded implementation analysis artifact.",
+              input_contract: "PLAN.md text only.",
+              acceptance_criteria: [
+                "ANALYSIS.md cites the full PLAN.md requirements.",
+              ],
+              required_tool_capabilities: ["read_file", "write_file"],
+              context_requirements: ["read_plan"],
+              execution_context: {
+                version: "v1",
+                workspace_root: workspaceRoot,
+                allowed_read_roots: [workspaceRoot],
+                allowed_write_roots: [workspaceRoot],
+                required_source_artifacts: [`${workspaceRoot}/PLAN.md`],
+                target_artifacts: [`${workspaceRoot}/ANALYSIS.md`],
+                effect_class: "read_only",
+                verification_mode: "grounded_read",
+                step_kind: "delegated_research",
+                fallback_policy: "continue_without_delegation",
+                resume_policy: "stateless_retry",
+                approval_profile: "read_only",
+              },
+              max_budget_hint: "10m",
+              can_run_parallel: false,
+              depends_on: ["read_plan"],
+            },
+            {
+              name: "implement_owner",
+              step_type: "subagent_task",
+              objective:
+                "Own the code changes required by PLAN.md inside the repo workspace.",
+              input_contract: "PLAN.md plus the bounded analysis artifact.",
+              acceptance_criteria: [
+                "src/main.ts contains the required implementation changes.",
+              ],
+              required_tool_capabilities: [
+                "read_file",
+                "write_file",
+                "execute_command",
+              ],
+              context_requirements: ["analyze_plan"],
+              execution_context: {
+                version: "v1",
+                workspace_root: workspaceRoot,
+                allowed_read_roots: [workspaceRoot],
+                allowed_write_roots: [workspaceRoot],
+                required_source_artifacts: [
+                  `${workspaceRoot}/PLAN.md`,
+                  `${workspaceRoot}/ANALYSIS.md`,
+                ],
+                target_artifacts: [`${workspaceRoot}/src`],
+                effect_class: "filesystem_write",
+                verification_mode: "mutation_required",
+                step_kind: "delegated_write",
+                fallback_policy: "continue_without_delegation",
+                resume_policy: "stateless_retry",
+                approval_profile: "filesystem_write",
+              },
+              max_budget_hint: "30m",
+              can_run_parallel: false,
+              depends_on: ["analyze_plan"],
+            },
+            {
+              name: "verify_build",
+              step_type: "deterministic_tool",
+              tool: "system.bash",
+              args: {
+                command: "npm",
+                args: ["test"],
+                cwd: workspaceRoot,
+              },
+              onError: "abort",
+              depends_on: ["implement_owner"],
+            },
+          ],
+        }),
+      });
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: safeJson({
+                reason:
+                  "Phased implementation of PLAN.md with sequential setup/impl/test and verification",
+                requiresSynthesis: true,
+                steps: [
+                  {
+                    name: "read_plan",
+                    step_type: "deterministic_tool",
+                    tool: "system.readFile",
+                    args: {
+                      path: `${workspaceRoot}/PLAN.md`,
+                    },
+                    onError: "abort",
+                  },
+                  {
+                    name: "setup_phase",
+                    step_type: "subagent_task",
+                    objective:
+                      "Author initial setup files and scaffolding per first phase of PLAN.md",
+                    input_contract: "PLAN.md content plus current workspace files",
+                    acceptance_criteria: [
+                      "Required config and source files created/updated",
+                      "Directory structure matches plan",
+                    ],
+                    required_tool_capabilities: [
+                      "read_file",
+                      "write_file",
+                      "list_dir",
+                    ],
+                    context_requirements: ["repo_context", "read_plan"],
+                    execution_context: {
+                      version: "v1",
+                      workspace_root: workspaceRoot,
+                      allowed_read_roots: [workspaceRoot],
+                      allowed_write_roots: [workspaceRoot],
+                      allowed_tools: [
+                        "system.readFile",
+                        "system.writeFile",
+                        "system.listDir",
+                      ],
+                      required_source_artifacts: [`${workspaceRoot}/PLAN.md`],
+                      target_artifacts: [workspaceRoot],
+                      effect_class: "filesystem_scaffold",
+                      verification_mode: "grounded_read",
+                      step_kind: "delegated_scaffold",
+                      fallback_policy: "continue_without_delegation",
+                      resume_policy: "stateless_retry",
+                      approval_profile: "filesystem_write",
+                    },
+                    max_budget_hint: "20m",
+                    can_run_parallel: false,
+                    depends_on: ["read_plan"],
+                  },
+                  {
+                    name: "install_deps",
+                    step_type: "deterministic_tool",
+                    tool: "system.bash",
+                    args: {
+                      command: "npm",
+                      args: ["install"],
+                      cwd: workspaceRoot,
+                    },
+                    onError: "abort",
+                    depends_on: ["setup_phase"],
+                  },
+                  {
+                    name: "core_implementation",
+                    step_type: "subagent_task",
+                    objective: "Implement core functionality phase from PLAN.md",
+                    input_contract:
+                      "Setup complete, PLAN.md phase details, current code",
+                    acceptance_criteria: [
+                      "Core features coded per plan",
+                      "Changes limited to target artifacts",
+                    ],
+                    required_tool_capabilities: [
+                      "read_file",
+                      "write_file",
+                      "execute_command",
+                    ],
+                    context_requirements: ["repo_context", "setup_phase"],
+                    execution_context: {
+                      version: "v1",
+                      workspace_root: workspaceRoot,
+                      allowed_read_roots: [workspaceRoot],
+                      allowed_write_roots: [workspaceRoot],
+                      required_source_artifacts: [
+                        `${workspaceRoot}/src`,
+                        `${workspaceRoot}/PLAN.md`,
+                      ],
+                      target_artifacts: [`${workspaceRoot}/src`],
+                      effect_class: "filesystem_write",
+                      verification_mode: "mutation_required",
+                      step_kind: "delegated_write",
+                      fallback_policy: "continue_without_delegation",
+                      resume_policy: "stateless_retry",
+                      approval_profile: "filesystem_write",
+                    },
+                    max_budget_hint: "30m",
+                    can_run_parallel: false,
+                    depends_on: ["install_deps"],
+                  },
+                  {
+                    name: "testing_phase",
+                    step_type: "subagent_task",
+                    objective:
+                      "Run test and verification phase from PLAN.md and report failing or passing commands",
+                    input_contract: "Implementation complete, return grounded test results",
+                    acceptance_criteria: [
+                      "Relevant tests or validation commands executed",
+                      "Failures and passes reported concretely",
+                    ],
+                    required_tool_capabilities: [
+                      "read_file",
+                      "execute_command",
+                    ],
+                    context_requirements: ["repo_context", "core_implementation"],
+                    execution_context: {
+                      version: "v1",
+                      workspace_root: workspaceRoot,
+                      allowed_read_roots: [workspaceRoot],
+                      allowed_write_roots: [workspaceRoot],
+                      required_source_artifacts: [`${workspaceRoot}/src`],
+                      effect_class: "shell",
+                      verification_mode: "deterministic_followup",
+                      step_kind: "delegated_validation",
+                      fallback_policy: "continue_without_delegation",
+                      resume_policy: "stateless_retry",
+                      approval_profile: "filesystem_write",
+                    },
+                    max_budget_hint: "20m",
+                    can_run_parallel: false,
+                    depends_on: ["core_implementation"],
+                  },
+                  {
+                    name: "final_synthesis",
+                    step_type: "synthesis",
+                    depends_on: ["testing_phase"],
+                  },
+                ],
+              }),
+            }),
+          )
+          .mockResolvedValueOnce(refinedSingleOwnerPlan)
+          .mockResolvedValueOnce(
+            mockResponse({
+              content:
+                "Implementation completed successfully. PLAN.md was analyzed, the owned source artifacts were updated, and npm test passed in the workspace.",
+            }),
+          ),
+      });
+      const pipelineExecutor = {
+        execute: vi.fn().mockResolvedValue({
+          status: "completed",
+          context: {
+            results: {
+              read_plan: safeJson({
+                path: `${workspaceRoot}/PLAN.md`,
+                size: 4096,
+              }),
+              analyze_plan: completedDelegatedPlannerResult(
+                "ANALYSIS.md captures the full PLAN.md requirements and implementation order.",
+                [
+                  {
+                    name: "system.readFile",
+                    args: {
+                      path: `${workspaceRoot}/PLAN.md`,
+                    },
+                  },
+                  {
+                    name: "system.writeFile",
+                    args: {
+                      path: `${workspaceRoot}/ANALYSIS.md`,
+                      content: "analysis artifact",
+                    },
+                  },
+                ],
+              ),
+              implement_owner: completedDelegatedPlannerResult(
+                "Updated src/main.ts with the required implementation changes and verified tests passed.",
+                [
+                  {
+                    name: "system.readFile",
+                    args: {
+                      path: `${workspaceRoot}/ANALYSIS.md`,
+                    },
+                  },
+                  {
+                    name: "system.writeFile",
+                    args: {
+                      path: `${workspaceRoot}/src/main.ts`,
+                      content: "export const ready = true;\n",
+                    },
+                  },
+                  {
+                    name: "system.bash",
+                    args: {
+                      command: "npm",
+                      args: ["test"],
+                      cwd: workspaceRoot,
+                    },
+                    result: safeJson({
+                      exitCode: 0,
+                      stdout: "tests passed",
+                    }),
+                  },
+                ],
+              ),
+              verify_build: safeJson({
+                exitCode: 0,
+                stdout: "tests passed",
+              }),
+            },
+          },
+          completedSteps: 4,
+          totalSteps: 4,
+        }),
+      };
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+        delegationDecision: {
+          enabled: true,
+          scoreThreshold: 0.2,
+        },
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: {
+            ...createMessage(
+              "Can you go through @PLAN.md and implement it in full. Make sure each phase is fully tested and working before moving on.",
+            ),
+            metadata: undefined,
+          } as GatewayMessage,
+          runtimeContext: {
+            workspaceRoot,
+          },
+          trace: {
+            onExecutionTraceEvent: (event) => {
+              events.push(event as unknown as Record<string, unknown>);
+            },
+          },
+        }),
+      );
+
+      expect(provider.chat).toHaveBeenCalledTimes(2);
+      expect(toolHandler).not.toHaveBeenCalled();
+      expect(pipelineExecutor.execute).toHaveBeenCalledTimes(1);
+      expect(result.stopReason).toBe("completed");
+      expect(result.completionState).toBe("completed");
+      expect(result.completionProgress).toMatchObject({
+        completionState: "completed",
+        remainingRequirements: [],
+      });
+      expect(result.plannerSummary?.routeReason).toBe(
+        "single_owner_plan_artifact_execution",
+      );
+      expect(result.plannerSummary?.delegationDecision).toMatchObject({
+        shouldDelegate: true,
+      });
+      expect(result.plannerSummary?.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            category: "validation",
+            code: "planner_plan_artifact_single_owner_required",
+          }),
+          expect.objectContaining({
+            category: "policy",
+            code: "planner_step_contract_retry",
+          }),
+        ]),
+      );
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "planner_refinement_requested",
+            phase: "planner",
+            payload: expect.objectContaining({
+              reason: "planner_step_contract_retry",
+            }),
+          }),
+        ]),
+      );
+      expect(
+        events.some((event) =>
+          event.type === "planner_path_finished" &&
+          event.phase === "planner" &&
+          typeof (event.payload as { routeReason?: unknown })?.routeReason === "string" &&
+          /^delegation_veto_/.test(
+            String((event.payload as { routeReason?: unknown }).routeReason),
+          ) &&
+          (event.payload as { handled?: unknown })?.handled === false
+        ),
+      ).toBe(false);
+      expect(result.callUsage.map((entry) => entry.phase)).toEqual([
+        "planner",
+        "planner",
+      ]);
+    });
+
+    it("keeps an executor-level barrier if planner veto handling ever regresses to unhandled", async () => {
+      const events: Record<string, unknown>[] = [];
+      const toolHandler = vi.fn().mockResolvedValue("unexpected inline execution");
+      const provider = createMockProvider("primary");
+      const pipelineExecutor = { execute: vi.fn() };
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+      });
+
+      vi.spyOn(executor as any, "executePlannerPath").mockImplementation(
+        async (ctx: any) => {
+          ctx.plannerHandled = false;
+          ctx.plannerImplementationFallbackBlocked = true;
+          ctx.plannedSubagentSteps = 2;
+          ctx.plannerSummaryState.routeReason =
+            "delegation_veto_shared_artifact_writer_inline";
+          ctx.plannerSummaryState.delegationDecision = {
+            shouldDelegate: false,
+            reason: "shared_artifact_writer_inline",
+            threshold: 0.2,
+            utilityScore: 0.37,
+            decompositionBenefit: 0.4,
+            coordinationOverhead: 0.5,
+            latencyCostRisk: 0.1,
+            safetyRisk: 0.05,
+            confidence: 0.9,
+            hardBlockedTaskClass: null,
+            hardBlockedTaskClassSource: null,
+            hardBlockedTaskClassSignal: null,
+            diagnostics: {},
+          };
+          ctx.plannerSummaryState.diagnostics.push({
+            category: "policy",
+            code: "delegation_veto",
+            message:
+              "Delegation vetoed by runtime admission policy: shared_artifact_writer_inline",
+            details: {
+              reason: "shared_artifact_writer_inline",
+            },
+          });
+        },
+      );
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Read PLAN.md, implement the project in phases, test each phase, and only finish when verification is complete.",
+          ),
+          trace: {
+            onExecutionTraceEvent: (event) => {
+              events.push(event as unknown as Record<string, unknown>);
+            },
+          },
+        }),
+      );
+
+      expect(toolHandler).not.toHaveBeenCalled();
+      expect(result.stopReason).toBe("validation_error");
+      expect(result.completionState).toBe("blocked");
+      expect(result.content).toContain(
+        "Inline legacy fallback is disabled for this task class.",
+      );
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "planner_path_finished",
+            phase: "planner",
+            payload: expect.objectContaining({
+              routeReason: "delegation_veto_shared_artifact_writer_inline",
+              handled: true,
+              enforcement: "executor_level_planner_veto_barrier",
+            }),
+          }),
+        ]),
+      );
+    });
+
     it("applies live delegation threshold resolver for aggressiveness overrides", async () => {
       const provider = createMockProvider("primary", {
         chat: vi
@@ -14668,6 +15771,39 @@ describe("ChatExecutor", () => {
             results: {
               create_root_directory:
                 "mkdir -p /tmp/transit-weave/packages/core/src /tmp/transit-weave/packages/cli/src /tmp/transit-weave/packages/web/src /tmp/transit-weave/fixtures",
+              scaffold_monorepo_configs: completedDelegatedPlannerResult(
+                "Root workspace and per-package manifests/configs were scaffolded without implementation source files.",
+                [
+                  {
+                    name: "system.writeFile",
+                    args: {
+                      path: "package.json",
+                      content: "{\"private\":true,\"workspaces\":[\"packages/*\"]}",
+                    },
+                  },
+                  {
+                    name: "system.writeFile",
+                    args: {
+                      path: "packages/core/package.json",
+                      content: "{\"name\":\"@transit-weave/core\"}",
+                    },
+                  },
+                  {
+                    name: "system.writeFile",
+                    args: {
+                      path: "packages/cli/package.json",
+                      content: "{\"name\":\"@transit-weave/cli\"}",
+                    },
+                  },
+                  {
+                    name: "system.writeFile",
+                    args: {
+                      path: "packages/web/package.json",
+                      content: "{\"name\":\"@transit-weave/web\"}",
+                    },
+                  },
+                ],
+              ),
               install_dependencies:
                 "npm install completed in /tmp/transit-weave with workspace dependencies resolved.",
               run_build:
@@ -14676,19 +15812,178 @@ describe("ChatExecutor", () => {
                 "npm test completed successfully; stdout line 41 confirms the Vitest workspace suite passed with the fixture-backed route scenarios.",
               implement_core: completedDelegatedPlannerResult(
                 "packages/core/src/index.ts file exports parseNetwork and findRoutes with types; build log line 14 shows the core route search compiles cleanly and returns the best itinerary plus two alternatives.",
-                ["system.writeFile", "system.readFile", "system.bash"],
+                [
+                  {
+                    name: "system.readFile",
+                    args: {
+                      path: "packages/core/package.json",
+                    },
+                    result: safeJson({
+                      path: "packages/core/package.json",
+                      content: "{\"name\":\"@transit-weave/core\"}",
+                    }),
+                  },
+                  {
+                    name: "system.writeFile",
+                    args: {
+                      path: "packages/core/src/index.ts",
+                      content:
+                        "export function parseNetwork(){} export function findRoutes(){}",
+                    },
+                  },
+                  {
+                    name: "system.bash",
+                    args: {
+                      command: "npm",
+                      args: ["run", "build"],
+                      cwd: "/tmp/transit-weave",
+                    },
+                    result: safeJson({
+                      exitCode: 0,
+                      stdout:
+                        "build completed successfully for @transit-weave/core",
+                    }),
+                  },
+                ],
               ),
               implement_cli: completedDelegatedPlannerResult(
                 "packages/cli/src/index.ts file wires validate and route commander commands; stdout line 22 shows the CLI prints cost, transfer count, and ordered steps using the core package.",
-                ["system.writeFile", "system.readFile", "system.bash"],
+                [
+                  {
+                    name: "system.readFile",
+                    args: {
+                      path: "packages/cli/package.json",
+                    },
+                    result: safeJson({
+                      path: "packages/cli/package.json",
+                      content: "{\"name\":\"@transit-weave/cli\"}",
+                    }),
+                  },
+                  {
+                    name: "system.writeFile",
+                    args: {
+                      path: "packages/cli/src/index.ts",
+                      content: "console.log('route');",
+                    },
+                  },
+                  {
+                    name: "system.bash",
+                    args: {
+                      command: "npm",
+                      args: ["run", "build"],
+                      cwd: "/tmp/transit-weave",
+                    },
+                    result: safeJson({
+                      exitCode: 0,
+                      stdout:
+                        "build completed successfully for @transit-weave/cli",
+                    }),
+                  },
+                ],
               ),
               implement_web: completedDelegatedPlannerResult(
                 "packages/web/src/App.tsx file renders the editable sample network UI with origin and destination selectors; build log line 31 confirms the Vite React app compiles successfully.",
-                ["system.writeFile", "system.readFile", "system.bash"],
+                [
+                  {
+                    name: "system.readFile",
+                    args: {
+                      path: "packages/web/package.json",
+                    },
+                    result: safeJson({
+                      path: "packages/web/package.json",
+                      content: "{\"name\":\"@transit-weave/web\"}",
+                    }),
+                  },
+                  {
+                    name: "system.writeFile",
+                    args: {
+                      path: "packages/web/src/App.tsx",
+                      content: "export default function App(){ return null; }",
+                    },
+                  },
+                  {
+                    name: "system.bash",
+                    args: {
+                      command: "npm",
+                      args: ["run", "build"],
+                      cwd: "/tmp/transit-weave",
+                    },
+                    result: safeJson({
+                      exitCode: 0,
+                      stdout:
+                        "build completed successfully for @transit-weave/web",
+                    }),
+                  },
+                ],
               ),
               add_fixtures_tests_readme: completedDelegatedPlannerResult(
                 "fixtures/sample-network.txt, README.md, and packages/core/test/index.test.ts were authored; test log line 44 shows the fixture-backed tests and coverage passed.",
-                ["system.writeFile", "system.readFile", "system.bash"],
+                [
+                  {
+                    name: "system.readFile",
+                    args: {
+                      path: "packages/core/src/index.ts",
+                    },
+                    result: safeJson({
+                      path: "packages/core/src/index.ts",
+                      content:
+                        "export function parseNetwork(){} export function findRoutes(){}",
+                    }),
+                  },
+                  {
+                    name: "system.readFile",
+                    args: {
+                      path: "packages/cli/src/index.ts",
+                    },
+                    result: safeJson({
+                      path: "packages/cli/src/index.ts",
+                      content: "console.log('route');",
+                    }),
+                  },
+                  {
+                    name: "system.readFile",
+                    args: {
+                      path: "packages/web/src/App.tsx",
+                    },
+                    result: safeJson({
+                      path: "packages/web/src/App.tsx",
+                      content: "export default function App(){ return null; }",
+                    }),
+                  },
+                  {
+                    name: "system.writeFile",
+                    args: {
+                      path: "fixtures/sample-network.txt",
+                      content: "A B 5",
+                    },
+                  },
+                  {
+                    name: "system.writeFile",
+                    args: {
+                      path: "README.md",
+                      content: "# Transit weave",
+                    },
+                  },
+                  {
+                    name: "system.writeFile",
+                    args: {
+                      path: "packages/core/test/index.test.ts",
+                      content: "it('routes', () => expect(true).toBe(true));",
+                    },
+                  },
+                  {
+                    name: "system.bash",
+                    args: {
+                      command: "npm",
+                      args: ["test"],
+                      cwd: "/tmp/transit-weave",
+                    },
+                    result: safeJson({
+                      exitCode: 0,
+                      stdout: "tests passed with coverage",
+                    }),
+                  },
+                ],
               ),
               final_synthesis: "Transit weave monorepo completed successfully.",
             },
@@ -14713,6 +16008,9 @@ describe("ChatExecutor", () => {
           message: createMessage(
             "Create a TypeScript npm-workspaces monorepo with core, cli, and web, then install, build, and test it.",
           ),
+          runtimeContext: {
+            workspaceRoot: "/tmp/transit-weave",
+          },
         }),
       );
 
@@ -15784,6 +17082,171 @@ describe("ChatExecutor", () => {
         "system.readFile",
         "system.searchFiles",
       ]);
+    });
+
+    it("uses the runtime-owned workspace root for planner context instead of conflicting message metadata or host fallback", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: safeJson({
+              reason: "single_root",
+              requiresSynthesis: false,
+              steps: [
+                {
+                  name: "inspect_workspace",
+                  step_type: "deterministic_tool",
+                  tool: "system.bash",
+                  args: { command: "pwd" },
+                },
+              ],
+            }),
+          }),
+        ),
+      });
+      const pipelineExecutor = {
+        execute: vi.fn().mockResolvedValue({
+          status: "completed",
+          completionState: "completed",
+          context: {
+            results: {
+              inspect_workspace: "/home/tetsuo/git/stream-test/agenc-shell",
+            },
+          },
+          completedSteps: 1,
+          totalSteps: 1,
+        }),
+      };
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+        resolveHostWorkspaceRoot: () => "/home/tetsuo/git/AgenC",
+      });
+
+      await executor.execute(
+        createParams({
+          message: {
+            ...createMessage(
+              "Inspect the current workspace, then report the deterministic execution root.",
+            ),
+            metadata: { workspaceRoot: "/wrong/message/root" },
+          },
+          runtimeContext: {
+            workspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
+          },
+        }),
+      );
+
+      const pipelineArg = (pipelineExecutor.execute as ReturnType<typeof vi.fn>).mock
+        .calls[0][0] as {
+          plannerContext?: {
+            workspaceRoot?: string;
+          };
+        };
+      expect(pipelineArg.plannerContext?.workspaceRoot).toBe(
+        "/home/tetsuo/git/stream-test/agenc-shell",
+      );
+    });
+
+    it("materializes a planner-owned workflow contract before implementation execution begins", async () => {
+      const events: Record<string, unknown>[] = [];
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: safeJson({
+              reason: "planner_implementation_contract",
+              requiresSynthesis: false,
+              steps: [
+                {
+                  name: "implement_core",
+                  step_type: "deterministic_tool",
+                  tool: "system.writeFile",
+                  args: {
+                    path: "/home/tetsuo/git/stream-test/agenc-shell/src/main.ts",
+                    content: "export {};\n",
+                  },
+                },
+              ],
+            }),
+          }),
+        ),
+      });
+      const pipelineExecutor = {
+        execute: vi.fn().mockResolvedValue({
+          status: "completed",
+          completionState: "completed",
+          context: {
+            results: {
+              implement_core: "built successfully",
+            },
+          },
+          completedSteps: 1,
+          totalSteps: 1,
+        }),
+      };
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Implement the requested change in the current workspace and finish only when the implementation is complete.",
+          ),
+          runtimeContext: {
+            workspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
+          },
+          trace: {
+            onExecutionTraceEvent: (event) => {
+              events.push(event as unknown as Record<string, unknown>);
+            },
+          },
+        }),
+      );
+
+      expect(result.completionProgress?.verificationContract).toMatchObject({
+        workspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
+        verificationMode: "mutation_required",
+        completionContract: expect.objectContaining({
+          taskClass: "artifact_only",
+        }),
+      });
+      expect(result.stopReason).toBe("completed");
+      expect(result.completionState).toBe("completed");
+      expect(result.completionProgress).toMatchObject({
+        completionState: "completed",
+        requiredRequirements: [],
+        remainingRequirements: [],
+      });
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "completion_gate_checked",
+            phase: "tool_followup",
+            payload: expect.objectContaining({
+              gate: "workflow_completion_truth",
+              decision: expect.stringMatching(/^accept/),
+              ownerClass: "implementation",
+              reason: "workflow_verification_contract_present",
+            }),
+          }),
+        ]),
+      );
+      expect(events).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "completion_gate_checked",
+            phase: "tool_followup",
+            payload: expect.objectContaining({
+              gate: "legacy_completion_compatibility",
+            }),
+          }),
+        ]),
+      );
     });
 
     it("forwards expanded routed tools into planner context for child scoping when available", async () => {

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -36,6 +36,8 @@ import type {
   PipelineExecutionEvent,
   PipelineResult,
 } from "../workflow/pipeline.js";
+import type { ImplementationCompletionContract } from "../workflow/completion-contract.js";
+import type { WorkflowVerificationContract } from "../workflow/verification-obligations.js";
 import type { HostToolingProfile } from "../gateway/host-tooling.js";
 import { resolveWorkflowCompletionState } from "../workflow/completion-state.js";
 import { deriveWorkflowProgressSnapshot } from "../workflow/completion-progress.js";
@@ -106,6 +108,7 @@ import {
   DEFAULT_FAILURE_BUDGET_PER_REQUEST,
   DEFAULT_TOOL_CALL_TIMEOUT_MS,
   DEFAULT_REQUEST_TIMEOUT_MS,
+  MAX_ADAPTIVE_TOOL_ROUNDS,
   DEFAULT_SUBAGENT_VERIFIER_MIN_CONFIDENCE,
   DEFAULT_SUBAGENT_VERIFIER_MAX_ROUNDS,
   DEFAULT_TOOL_FAILURE_BREAKER_THRESHOLD,
@@ -118,9 +121,11 @@ import {
 import {
   buildRequiredToolEvidenceRetryInstruction,
   canRetryDelegatedOutputWithoutAdditionalToolCalls,
+  requiresWorkflowOwnedImplementationCompletion,
   resolveCorrectionAllowedToolNames,
   resolveExecutionToolContractGuidance,
   resolveLegacyCompletionCompatibility,
+  resolveRuntimeWorkflowContext,
   validateRequiredToolEvidence,
 } from "./chat-executor-contract-flow.js";
 import type { ToolContractGuidance } from "./chat-executor-contract-guidance.js";
@@ -268,6 +273,7 @@ import {
   appendUserMessage,
   buildToolExecutionGroundingMessage,
   isPlanOnlyExecutionResponse,
+  isExecutionDeferralResponse,
 } from "./chat-executor-text.js";
 import {
   summarizeStateful,
@@ -390,7 +396,7 @@ export class ChatExecutor {
     }
     this.providers = config.providers;
     this.toolHandler = config.toolHandler;
-    this.maxToolRounds = config.maxToolRounds ?? 10;
+    this.maxToolRounds = config.maxToolRounds ?? MAX_ADAPTIVE_TOOL_ROUNDS;
     this.onStreamChunk = config.onStreamChunk;
     this.allowedTools = config.allowedTools
       ? new Set(config.allowedTools)
@@ -543,7 +549,34 @@ export class ChatExecutor {
 
     // Direct path: initial LLM call + tool loop
     if (!ctx.plannerHandled) {
-      await this.executeToolCallLoop(ctx);
+      if (this.shouldBlockToolLoopAfterPlannerVeto(ctx)) {
+        this.emitExecutionTrace(ctx, {
+          type: "planner_path_finished",
+          phase: "planner",
+          callIndex: ctx.callIndex,
+          payload: {
+            routeReason: ctx.plannerSummaryState.routeReason,
+            stopReason: "validation_error",
+            stopReasonDetail:
+              "Planner produced an implementation-scoped delegated plan, but runtime delegation admission rejected it. Inline legacy fallback is disabled for this task class.",
+            diagnostics: ctx.plannerSummaryState.diagnostics,
+            handled: true,
+            enforcement: "executor_level_planner_veto_barrier",
+          },
+        });
+        this.setStopReason(
+          ctx,
+          "validation_error",
+          "Planner produced an implementation-scoped delegated plan, but runtime delegation admission rejected it. Inline legacy fallback is disabled for this task class.",
+        );
+        ctx.finalContent =
+          "Planner produced an implementation-scoped delegated plan, " +
+          `but runtime delegation admission rejected it (${ctx.plannerSummaryState.delegationDecision?.reason ?? "delegation_veto"}). ` +
+          "Inline legacy fallback is disabled for this task class; re-plan the work with a single-owner execution contract or provide an explicit workflow verification contract.";
+        ctx.plannerHandled = true;
+      } else {
+        await this.executeToolCallLoop(ctx);
+      }
     }
 
     this.enforceLegacyCompletionCompatibilityBeforeFinalization(ctx);
@@ -587,6 +620,18 @@ export class ChatExecutor {
       ctx.allToolCalls,
       ctx.messageText,
     );
+    const workflowContext = this.resolveWorkflowVerificationContext(ctx);
+    const completionProgress = deriveWorkflowProgressSnapshot({
+      stopReason: ctx.stopReason,
+      completionState: ctx.completionState,
+      stopReasonDetail: ctx.stopReasonDetail,
+      validationCode: ctx.validationCode,
+      toolCalls: ctx.allToolCalls,
+      verificationContract: workflowContext.verificationContract,
+      completionContract: workflowContext.completionContract,
+      updatedAt: Date.now(),
+    });
+
     ctx.finalContent = reconcileTerminalFailureContent({
       content: ctx.finalContent,
       stopReason: ctx.stopReason,
@@ -599,6 +644,7 @@ export class ChatExecutor {
       stopReason: ctx.stopReason,
       stopReasonDetail: ctx.stopReasonDetail,
       toolCalls: ctx.allToolCalls,
+      completionProgress,
     });
     ctx.finalContent = sanitizeFinalContent(ctx.finalContent);
 
@@ -630,19 +676,7 @@ export class ChatExecutor {
       ),
       stopReason: ctx.stopReason,
       completionState: ctx.completionState,
-      completionProgress: deriveWorkflowProgressSnapshot({
-        stopReason: ctx.stopReason,
-        completionState: ctx.completionState,
-        stopReasonDetail: ctx.stopReasonDetail,
-        validationCode: ctx.validationCode,
-        toolCalls: ctx.allToolCalls,
-        plannerUsed: ctx.plannerSummaryState.used,
-        deterministicStepsExecuted:
-          ctx.plannerSummaryState.deterministicStepsExecuted,
-        verificationContract: ctx.requiredToolEvidence?.verificationContract,
-        completionContract: ctx.requiredToolEvidence?.completionContract,
-        updatedAt: Date.now(),
-      }),
+      completionProgress,
       stopReasonDetail: ctx.stopReasonDetail,
       validationCode: ctx.validationCode,
       evaluation: ctx.evaluation,
@@ -677,21 +711,46 @@ export class ChatExecutor {
     }
   }
 
+  private resolveWorkflowVerificationContext(ctx: ExecutionContext): {
+    verificationContract?: WorkflowVerificationContract;
+    completionContract?: ImplementationCompletionContract;
+  } {
+    const workflowContext = resolveRuntimeWorkflowContext({ ctx });
+    return {
+      verificationContract: workflowContext.verificationContract,
+      completionContract: workflowContext.completionContract,
+    };
+  }
+
   private synchronizeCompletionState(ctx: ExecutionContext): void {
+    const workflowContext = this.resolveWorkflowVerificationContext(ctx);
     ctx.completionState = resolveWorkflowCompletionState({
       stopReason: ctx.stopReason,
       toolCalls: ctx.allToolCalls,
-      plannerUsed: ctx.plannerSummaryState.used,
-      deterministicStepsExecuted:
-        ctx.plannerSummaryState.deterministicStepsExecuted,
-      verificationContract: ctx.requiredToolEvidence?.verificationContract,
-      completionContract: ctx.requiredToolEvidence?.completionContract,
+      verificationContract: workflowContext.verificationContract,
+      completionContract: workflowContext.completionContract,
       validationCode: ctx.validationCode,
       verifier: {
         performed: ctx.plannerSummaryState.subagentVerification.performed,
         overall: ctx.plannerSummaryState.subagentVerification.overall,
       },
     });
+  }
+
+  private shouldBlockToolLoopAfterPlannerVeto(
+    ctx: ExecutionContext,
+  ): boolean {
+    if (!ctx.plannerImplementationFallbackBlocked) {
+      return false;
+    }
+    if (ctx.plannerHandled) {
+      return false;
+    }
+    const delegationDecision = ctx.plannerSummaryState.delegationDecision;
+    if (!delegationDecision || delegationDecision.shouldDelegate !== false) {
+      return false;
+    }
+    return ctx.plannedSubagentSteps > 0;
   }
 
   private timeoutDetail(
@@ -1176,7 +1235,11 @@ export class ChatExecutor {
       const planOnly =
         responseContent.length > 0 &&
         isPlanOnlyExecutionResponse(responseContent);
-      if (!planOnly) {
+      const executionDeferred =
+        phase === "tool_followup" &&
+        responseContent.length > 0 &&
+        isExecutionDeferralResponse(responseContent);
+      if (!planOnly && !executionDeferred) {
         this.emitExecutionTrace(ctx, {
           type: "completion_gate_checked",
           phase,
@@ -1186,6 +1249,7 @@ export class ChatExecutor {
             decision: retried ? "accept_after_retry" : "accept",
             finishReason: ctx.response?.finishReason,
             correctionAttempts,
+            executionDeferred: false,
           },
         });
         return retried ? "continue" : "not_required";
@@ -1196,7 +1260,9 @@ export class ChatExecutor {
         this.allowedTools ?? undefined,
       );
       const failureMessage =
-        "Execution task returned only a plan without grounded tool work. Start executing with tools or report a concrete blocker instead of another plan.";
+        executionDeferred
+          ? "Execution task stopped with a progress summary that deferred remaining work. Continue executing with tools or report a concrete blocker instead of asking what to do next."
+          : "Execution task returned only a plan without grounded tool work. Start executing with tools or report a concrete blocker instead of another plan.";
       if (correctionAttempts >= MAX_PLAN_ONLY_EXECUTION_CORRECTIONS) {
         this.emitExecutionTrace(ctx, {
           type: "completion_gate_checked",
@@ -1207,6 +1273,7 @@ export class ChatExecutor {
             decision: "fail",
             finishReason: ctx.response?.finishReason,
             correctionAttempts,
+            executionDeferred,
             responsePreview: truncateText(responseContent, 180),
           },
         });
@@ -1241,6 +1308,7 @@ export class ChatExecutor {
           decision: "retry",
           finishReason: ctx.response?.finishReason,
           correctionAttempts,
+          executionDeferred,
           allowedToolNames,
           responsePreview: truncateText(responseContent, 180),
         },
@@ -1414,17 +1482,22 @@ export class ChatExecutor {
     if (ctx.stopReason !== "completed") {
       return;
     }
+    const workflowContext = resolveRuntimeWorkflowContext({ ctx });
     if (
-      ctx.requiredToolEvidence?.verificationContract ||
-      ctx.requiredToolEvidence?.completionContract
+      workflowContext.verificationContract ||
+      workflowContext.completionContract
     ) {
       this.emitExecutionTrace(ctx, {
         type: "completion_gate_checked",
         phase: "tool_followup",
         callIndex: ctx.callIndex,
         payload: {
-          gate: "legacy_completion_compatibility",
-          decision: "not_required",
+          gate: "workflow_completion_truth",
+          decision:
+            ctx.completionState === "completed" ? "accept" : "accept_nonterminal",
+          ownerClass: "implementation",
+          completionState: ctx.completionState,
+          ownershipSource: workflowContext.ownershipSource,
           reason: "workflow_verification_contract_present",
         },
       });
@@ -1452,11 +1525,35 @@ export class ChatExecutor {
         phase: "tool_followup",
         callIndex: ctx.callIndex,
         payload: {
-          gate: "legacy_completion_compatibility",
-          decision: "not_required",
+          gate: "workflow_completion_truth",
+          decision:
+            ctx.completionState === "completed" ? "accept" : "accept_nonterminal",
+          ownerClass: "implementation",
+          completionState: ctx.completionState,
+          ownershipSource: "planner_owned",
           reason: "planner_verifier_passed",
         },
       });
+      return;
+    }
+
+    if (requiresWorkflowOwnedImplementationCompletion({ ctx })) {
+      const reason =
+        "Implementation-class completion requires workflow-owned verification closure before finalization.";
+      this.emitExecutionTrace(ctx, {
+        type: "completion_gate_checked",
+        phase: "tool_followup",
+        callIndex: ctx.callIndex,
+        payload: {
+          gate: "workflow_completion_truth",
+          decision: "fail",
+          ownerClass: "implementation",
+          completionState: ctx.completionState,
+          reason,
+        },
+      });
+      this.setStopReason(ctx, "validation_error", reason);
+      ctx.finalContent = reason;
       return;
     }
 
@@ -1829,6 +1926,7 @@ export class ChatExecutor {
         messageText,
         systemPrompt,
         sessionId,
+        runtimeContext: params.runtimeContext,
         signal,
         history,
         plannerDecision,

--- a/runtime/src/memory/ingestion.test.ts
+++ b/runtime/src/memory/ingestion.test.ts
@@ -223,6 +223,45 @@ describe("MemoryIngestionEngine", () => {
       expect(logManager.append).toHaveBeenCalledTimes(2);
     });
 
+    it("preserves delegated scope trust metadata on indexed turn entries", async () => {
+      const engine = createEngine();
+      await engine.ingestTurn(
+        "sess-1",
+        "what is the child cwd?",
+        "Subagent cwd: /",
+        {
+          agentResponseMetadata: {
+            delegatedScopeTrust: "informational_untrusted",
+            delegatedScopeTrustReason: "assistant_delegated_environment_summary",
+            delegatedScopeContainsEnvironmentFact: true,
+          },
+        },
+      );
+
+      expect(vectorStore.storeWithEmbedding).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            delegatedScopeTrust: "informational_untrusted",
+            delegatedScopeTrustReason:
+              "assistant_delegated_environment_summary",
+            delegatedScopeContainsEnvironmentFact: true,
+          }),
+        }),
+        new Array(128).fill(0.1),
+      );
+      expect(vectorStore.storeWithEmbedding).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            delegatedScopeTrust: "informational_untrusted",
+            delegatedScopeContainsEnvironmentFact: true,
+          }),
+        }),
+        new Array(128).fill(0.1),
+      );
+    });
+
     it("deduplicates near-identical turns per role", async () => {
       (vectorStore.query as ReturnType<typeof vi.fn>).mockResolvedValue([
         {
@@ -418,7 +457,34 @@ describe("MemoryIngestionEngine", () => {
       expect(result.continue).toBe(true);
 
       await new Promise((resolve) => setTimeout(resolve, 5));
-      expect(ingestSpy).toHaveBeenCalledWith("sess-1", "hello", "hi");
+      expect(ingestSpy).toHaveBeenCalledWith("sess-1", "hello", "hi", {
+        agentResponseMetadata: undefined,
+      });
+    });
+
+    it("passes outbound assistant delegated scope metadata into ingestion", async () => {
+      const engine = createEngine();
+      const ingestSpy = vi.spyOn(engine, "ingestTurn").mockResolvedValue(undefined);
+      const hooks = createIngestionHooks(engine, logger);
+
+      const ctx = createHookContext("message:outbound", {
+        sessionId: "sess-1",
+        userMessage: "hello",
+        agentResponse: "Subagent cwd: /",
+        agentResponseMetadata: {
+          delegatedScopeTrust: "informational_untrusted",
+          delegatedScopeContainsEnvironmentFact: true,
+        },
+      });
+
+      await hooks[0].handler(ctx);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      expect(ingestSpy).toHaveBeenCalledWith("sess-1", "hello", "Subagent cwd: /", {
+        agentResponseMetadata: {
+          delegatedScopeTrust: "informational_untrusted",
+          delegatedScopeContainsEnvironmentFact: true,
+        },
+      });
     });
 
     it("session end hook attaches ingestion result", async () => {

--- a/runtime/src/memory/ingestion.ts
+++ b/runtime/src/memory/ingestion.ts
@@ -63,6 +63,10 @@ export interface SessionEndResult {
   readonly proposedFacts: readonly string[];
 }
 
+export interface TurnIngestionMetadata {
+  readonly agentResponseMetadata?: Record<string, unknown>;
+}
+
 // ============================================================================
 // Constants
 // ============================================================================
@@ -211,6 +215,7 @@ export class MemoryIngestionEngine {
     sessionId: string,
     userMessage: string,
     agentResponse: string,
+    metadata?: TurnIngestionMetadata,
   ): Promise<void> {
     const safeUserMessage = truncateForIngestion(userMessage);
     const safeAgentResponse = truncateForIngestion(agentResponse);
@@ -259,6 +264,7 @@ export class MemoryIngestionEngine {
                 confidence,
                 salienceScore: roundToTwoDecimals(salience),
                 contentHash,
+                ...(metadata?.agentResponseMetadata ?? {}),
               },
             },
             embedding,
@@ -284,6 +290,7 @@ export class MemoryIngestionEngine {
                 confidence,
                 salienceScore: roundToTwoDecimals(salience),
                 contentHash,
+                ...(metadata?.agentResponseMetadata ?? {}),
               },
             },
             embedding,
@@ -550,7 +557,12 @@ export function createIngestionHooks(
     priority: 200,
     handler: async (ctx: HookContext): Promise<HookResult> => {
       try {
-        const { sessionId, userMessage, agentResponse } = ctx.payload;
+        const {
+          sessionId,
+          userMessage,
+          agentResponse,
+          agentResponseMetadata,
+        } = ctx.payload;
         if (
           typeof sessionId !== "string" ||
           typeof userMessage !== "string" ||
@@ -564,7 +576,14 @@ export function createIngestionHooks(
 
         // Fire-and-forget — do not block the response pipeline
         void engine
-          .ingestTurn(sessionId, userMessage, agentResponse)
+          .ingestTurn(sessionId, userMessage, agentResponse, {
+            agentResponseMetadata:
+              typeof agentResponseMetadata === "object" &&
+                agentResponseMetadata !== null &&
+                !Array.isArray(agentResponseMetadata)
+                ? agentResponseMetadata as Record<string, unknown>
+                : undefined,
+          })
           .catch((err) => {
             log.error("memory-ingestion-turn: ingestTurn failed", err);
           });

--- a/runtime/src/memory/retriever.test.ts
+++ b/runtime/src/memory/retriever.test.ts
@@ -251,6 +251,51 @@ describe("SemanticMemoryRetriever", () => {
     expect(result.content).toContain("retry budget");
   });
 
+  it("filters untrusted delegated environment facts from working and semantic retrieval", async () => {
+    const backend = createMockVectorBackend();
+    (backend.getThread as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makeEntry("Subagent cwd: /", Date.now(), "sess-1", {
+        memoryRole: "working",
+        delegatedScopeTrust: "informational_untrusted",
+        delegatedScopeContainsEnvironmentFact: true,
+      }),
+      makeEntry("Verified build command succeeded", Date.now(), "sess-1", {
+        memoryRole: "working",
+      }),
+    ]);
+    (backend.searchHybrid as ReturnType<typeof vi.fn>).mockImplementation(
+      async (
+        _query: string,
+        _embedding: number[],
+        options?: { memoryRoles?: readonly ("working" | "episodic" | "semantic")[] },
+      ) => {
+        if (!options?.memoryRoles?.includes("semantic")) return [];
+        return [
+          makeScoredEntry("Subagent cwd: /", 0.99, {
+            metadata: {
+              memoryRole: "semantic",
+              delegatedScopeTrust: "rejected_invalid_scope",
+              delegatedScopeContainsEnvironmentFact: true,
+            },
+          }),
+          makeScoredEntry("Repository uses pnpm workspaces", 0.91, {
+            metadata: {
+              memoryRole: "semantic",
+              confidence: 0.88,
+            },
+          }),
+        ];
+      },
+    );
+
+    const retriever = createRetriever({ vectorBackend: backend, maxTokenBudget: 4000 });
+    const result = await retriever.retrieveDetailed("cwd workspace", "sess-1");
+
+    expect(result.content).toContain("Verified build command succeeded");
+    expect(result.content).toContain("Repository uses pnpm workspaces");
+    expect(result.content).not.toContain("Subagent cwd: /");
+  });
+
   it("forwards session id for isolation in both thread and vector retrieval", async () => {
     const backend = createMockVectorBackend();
     const retriever = createRetriever({ vectorBackend: backend });

--- a/runtime/src/memory/retriever.ts
+++ b/runtime/src/memory/retriever.ts
@@ -267,6 +267,15 @@ function inferProvenance(entry: MemoryEntry): string {
   return "unknown";
 }
 
+function shouldSuppressOperationalEntry(entry: MemoryEntry): boolean {
+  const metadata = entry.metadata;
+  if (!metadata) return false;
+  if (metadata.delegatedScopeContainsEnvironmentFact !== true) {
+    return false;
+  }
+  return metadata.delegatedScopeTrust !== "trusted_authoritative";
+}
+
 function truncateByTokens(text: string, maxTokens: number): string {
   if (maxTokens <= 0) return "";
   const maxChars = maxTokens * CHARS_PER_TOKEN;
@@ -497,6 +506,7 @@ export class SemanticMemoryRetriever implements MemoryRetriever {
 
     const scored: RetrievalCandidate[] = [];
     for (const entry of [...thread].reverse()) {
+      if (shouldSuppressOperationalEntry(entry)) continue;
       const role = inferRole(entry, "working");
       if (role !== "working") continue;
 
@@ -556,6 +566,7 @@ export class SemanticMemoryRetriever implements MemoryRetriever {
 
     const scored: RetrievalCandidate[] = [];
     for (const result of searchResults) {
+      if (shouldSuppressOperationalEntry(result.entry)) continue;
       const entryRole = inferRole(result.entry, role);
       if (entryRole !== role) continue;
 

--- a/runtime/src/utils/delegated-scope-trust.ts
+++ b/runtime/src/utils/delegated-scope-trust.ts
@@ -1,0 +1,263 @@
+import { safeStringify } from "../tools/types.js";
+
+export type DelegatedScopeTrustClass =
+  | "trusted_authoritative"
+  | "informational_untrusted"
+  | "rejected_invalid_scope";
+
+export interface DelegatedScopeTrustAssessment {
+  readonly delegatedScopeTrust: DelegatedScopeTrustClass;
+  readonly delegatedScopeTrustReason: string;
+  readonly delegatedScopeContainsEnvironmentFact: boolean;
+}
+
+const TRUST_CLASSES = new Set<DelegatedScopeTrustClass>([
+  "trusted_authoritative",
+  "informational_untrusted",
+  "rejected_invalid_scope",
+]);
+
+const INVALID_SCOPE_ISSUE_CODES = new Set([
+  "missing_execution_context",
+  "missing_workspace_root",
+  "workspace_root_mismatch",
+  "read_root_outside_workspace_root",
+  "write_root_outside_workspace_root",
+  "required_source_outside_workspace_root",
+  "target_outside_workspace_root",
+  "workspace_root_missing_for_required_sources",
+  "missing_parent_workspace_authority",
+  "workspace_root_outside_parent_workspace",
+  "read_root_outside_parent_workspace",
+  "write_root_outside_parent_workspace",
+  "input_artifact_outside_parent_workspace",
+  "required_source_outside_parent_workspace",
+  "target_outside_parent_workspace",
+]);
+
+const INVALID_SCOPE_VALIDATION_CODES = new Set([
+  "missing_execution_context",
+]);
+
+const INVALID_SCOPE_MESSAGE_RE =
+  /\b(?:missing_execution_context|trusted parent workspace root|canonical workspace root|child working directory|outside the trusted parent workspace|outside the canonical workspace root|delegated local-file work must have a canonical workspace root|requires a trusted parent workspace root|first trusted child root|does not accept executionContext\.workspaceRoot)\b/i;
+const DELEGATED_SCOPE_OUTPUT_RE =
+  /\b(?:subagent|child|delegated)\b[\s\S]{0,32}\b(?:cwd|current working directory|working directory|workspace root)\b/i;
+const DELEGATED_SCOPE_TASK_RE =
+  /\b(?:pwd|cwd|current working directory|working directory|workspace root|what(?:'s| is)? the current working directory|what(?:'s| is)? the workspace root)\b/i;
+const ASSISTANT_DELEGATED_SCOPE_SUMMARY_RE =
+  /\b(?:subagent|child|delegated)\b[\s\S]{0,24}\b(?:cwd|current working directory|working directory|workspace root)\b/i;
+const ABSOLUTE_PATH_OUTPUT_RE = /^(?:\/|~|[A-Za-z]:[\\/])[^\n\r]*$/;
+
+function parseObject(value: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function extractDelegatedTaskText(
+  args: Record<string, unknown> | undefined,
+): string {
+  if (!args) return "";
+  const task = args.task;
+  if (typeof task === "string" && task.trim().length > 0) {
+    return task.trim();
+  }
+  const objective = args.objective;
+  return typeof objective === "string" ? objective.trim() : "";
+}
+
+function extractIssueCodes(parsed: Record<string, unknown>): readonly string[] {
+  const issues = parsed.issues;
+  if (!Array.isArray(issues)) return [];
+  return issues.flatMap((issue) => {
+    if (typeof issue !== "object" || issue === null || Array.isArray(issue)) {
+      return [];
+    }
+    const code = (issue as { code?: unknown }).code;
+    return typeof code === "string" && code.trim().length > 0
+      ? [code.trim()]
+      : [];
+  });
+}
+
+function isInvalidScopeFailure(parsed: Record<string, unknown>): boolean {
+  const validationCode =
+    typeof parsed.validationCode === "string"
+      ? parsed.validationCode.trim().toLowerCase()
+      : "";
+  if (INVALID_SCOPE_VALIDATION_CODES.has(validationCode)) {
+    return true;
+  }
+
+  const issueCodes = extractIssueCodes(parsed);
+  if (issueCodes.some((code) => INVALID_SCOPE_ISSUE_CODES.has(code))) {
+    return true;
+  }
+
+  const pieces = [
+    typeof parsed.error === "string" ? parsed.error : "",
+    typeof parsed.output === "string" ? parsed.output : "",
+  ]
+    .filter((value) => value.length > 0)
+    .join("\n");
+  return INVALID_SCOPE_MESSAGE_RE.test(pieces);
+}
+
+export function isDelegatedEnvironmentClaimOutput(params: {
+  readonly args?: Record<string, unknown>;
+  readonly output: string;
+}): boolean {
+  const trimmed = params.output.trim();
+  if (trimmed.length === 0) return false;
+  if (DELEGATED_SCOPE_OUTPUT_RE.test(trimmed)) return true;
+  const delegatedTask = extractDelegatedTaskText(params.args);
+  return (
+    delegatedTask.length > 0 &&
+    DELEGATED_SCOPE_TASK_RE.test(delegatedTask) &&
+    ABSOLUTE_PATH_OUTPUT_RE.test(trimmed)
+  );
+}
+
+export function isDelegatedAssistantEnvironmentSummary(
+  content: string,
+): boolean {
+  return ASSISTANT_DELEGATED_SCOPE_SUMMARY_RE.test(content);
+}
+
+export function sanitizeDelegatedAssistantEnvironmentSummary(
+  content: string,
+): string {
+  if (!isDelegatedAssistantEnvironmentSummary(content)) {
+    return content;
+  }
+  return "[assistant summary omitted: delegated cwd/workspace-root claim not replayed]";
+}
+
+export function assessExecuteWithAgentResult(params: {
+  readonly args?: Record<string, unknown>;
+  readonly result: string;
+}): DelegatedScopeTrustAssessment | undefined {
+  const parsed = parseObject(params.result);
+  if (!parsed) return undefined;
+
+  const existingTrust = parsed.delegatedScopeTrust;
+  const existingReason = parsed.delegatedScopeTrustReason;
+  const existingContainsEnvironmentFact =
+    parsed.delegatedScopeContainsEnvironmentFact;
+  if (
+    typeof existingTrust === "string" &&
+    TRUST_CLASSES.has(existingTrust as DelegatedScopeTrustClass)
+  ) {
+    return {
+      delegatedScopeTrust: existingTrust as DelegatedScopeTrustClass,
+      delegatedScopeTrustReason:
+        typeof existingReason === "string" && existingReason.trim().length > 0
+          ? existingReason.trim()
+          : "annotated_execute_with_agent_result",
+      delegatedScopeContainsEnvironmentFact:
+        existingContainsEnvironmentFact === true,
+    };
+  }
+
+  if (isInvalidScopeFailure(parsed)) {
+    return {
+      delegatedScopeTrust: "rejected_invalid_scope",
+      delegatedScopeTrustReason: "runtime_scope_rejection",
+      delegatedScopeContainsEnvironmentFact: false,
+    };
+  }
+
+  const output = typeof parsed.output === "string" ? parsed.output.trim() : "";
+  if (
+    output.length > 0 &&
+    isDelegatedEnvironmentClaimOutput({ args: params.args, output })
+  ) {
+    return {
+      delegatedScopeTrust: "informational_untrusted",
+      delegatedScopeTrustReason: "delegated_environment_claim",
+      delegatedScopeContainsEnvironmentFact: true,
+    };
+  }
+
+  return {
+    delegatedScopeTrust: "trusted_authoritative",
+    delegatedScopeTrustReason: "runtime_approved_result",
+    delegatedScopeContainsEnvironmentFact: false,
+  };
+}
+
+export function annotateExecuteWithAgentResult(params: {
+  readonly args?: Record<string, unknown>;
+  readonly payload: Record<string, unknown>;
+}): string {
+  const assessment = assessExecuteWithAgentResult({
+    args: params.args,
+    result: safeStringify(params.payload),
+  }) ?? {
+    delegatedScopeTrust: "trusted_authoritative" as const,
+    delegatedScopeTrustReason: "runtime_approved_result",
+    delegatedScopeContainsEnvironmentFact: false,
+  };
+
+  return safeStringify({
+    ...params.payload,
+    delegatedScopeTrust: assessment.delegatedScopeTrust,
+    delegatedScopeTrustReason: assessment.delegatedScopeTrustReason,
+    delegatedScopeContainsEnvironmentFact:
+      assessment.delegatedScopeContainsEnvironmentFact,
+  });
+}
+
+export function buildAssistantDelegatedScopeMetadata(params: {
+  readonly content: string;
+  readonly toolCalls: readonly {
+    readonly name: string;
+    readonly args?: Record<string, unknown>;
+    readonly result: string;
+  }[];
+}): Record<string, unknown> | undefined {
+  if (!isDelegatedAssistantEnvironmentSummary(params.content)) {
+    return undefined;
+  }
+
+  const assessments = params.toolCalls
+    .filter((toolCall) => toolCall.name === "execute_with_agent")
+    .map((toolCall) =>
+      assessExecuteWithAgentResult({
+        args: toolCall.args,
+        result: toolCall.result,
+      })
+    )
+    .filter(
+      (assessment): assessment is DelegatedScopeTrustAssessment =>
+        assessment !== undefined,
+    );
+
+  const delegatedScopeTrust = assessments.some(
+    (assessment) => assessment.delegatedScopeTrust === "rejected_invalid_scope",
+  )
+    ? "rejected_invalid_scope"
+    : assessments.some(
+        (assessment) =>
+          assessment.delegatedScopeTrust === "informational_untrusted",
+      )
+      ? "informational_untrusted"
+      : "trusted_authoritative";
+
+  return {
+    delegatedScopeTrust,
+    delegatedScopeTrustReason:
+      delegatedScopeTrust === "rejected_invalid_scope"
+        ? "assistant_summary_after_scope_rejection"
+        : "assistant_delegated_environment_summary",
+    delegatedScopeContainsEnvironmentFact: true,
+    memoryRole: "working",
+  };
+}

--- a/runtime/src/utils/delegation-execution-context.ts
+++ b/runtime/src/utils/delegation-execution-context.ts
@@ -12,6 +12,14 @@ import {
 import type { ImplementationCompletionContract } from "../workflow/completion-contract.js";
 import { migrateExecutionEnvelope } from "../workflow/migrations.js";
 import { buildCanonicalDelegatedFilesystemScope } from "../workflow/delegated-filesystem-scope.js";
+import {
+  isConcreteExecutableEnvelopeRoot,
+  isPathWithinAnyRoot,
+  isPathWithinRoot,
+  normalizeArtifactPaths,
+  normalizeEnvelopeRoots,
+  normalizeWorkspaceRoot,
+} from "../workflow/path-normalization.js";
 
 export type DelegationExecutionContext = ExecutionEnvelope;
 
@@ -143,10 +151,12 @@ export function buildDelegationExecutionContext(params: {
 }
 
 /**
- * Temporary ingestion-only compatibility adapter for legacy planner/tool
- * payloads that still express the workspace root through `context_requirements`.
- * Once converted, downstream runtime code must consume only the structured
- * execution envelope.
+ * Reader-only compatibility adapter for historical planner/eval payloads that
+ * still express the workspace root through `context_requirements`.
+ *
+ * This helper is intentionally off the live direct adapter path. It exists only
+ * for bounded migration/eval readers and must be removed once those readers no
+ * longer need legacy fixture coverage.
  */
 export function buildLegacyDelegationExecutionContext(params: {
   readonly contextRequirements?: readonly (string | undefined | null)[];
@@ -236,4 +246,314 @@ export function canonicalizeDelegationExecutionContext(
     resumePolicy: context.resumePolicy,
     approvalProfile: context.approvalProfile,
   });
+}
+
+export type DelegatedExecutionEnvelopeDerivationSource =
+  | "direct_live_path"
+  | "internal_planner_path";
+
+export type DelegatedExecutionEnvelopeDerivationIssueCode =
+  | "missing_parent_workspace_authority"
+  | "workspace_root_outside_parent_workspace"
+  | "read_root_outside_parent_workspace"
+  | "write_root_outside_parent_workspace"
+  | "input_artifact_outside_parent_workspace"
+  | "required_source_outside_parent_workspace"
+  | "target_outside_parent_workspace";
+
+export interface DelegatedExecutionEnvelopeDerivationIssue {
+  readonly code: DelegatedExecutionEnvelopeDerivationIssueCode;
+  readonly message: string;
+  readonly path?: string;
+}
+
+export type DelegatedExecutionEnvelopeDerivationResult =
+  | {
+      readonly ok: true;
+      readonly executionContext?: DelegationExecutionContext;
+      readonly workingDirectory?: string;
+    }
+  | {
+      readonly ok: false;
+      readonly error: string;
+      readonly issues: readonly DelegatedExecutionEnvelopeDerivationIssue[];
+    };
+
+function buildDerivationFailure(
+  issue: DelegatedExecutionEnvelopeDerivationIssue,
+): DelegatedExecutionEnvelopeDerivationResult {
+  return {
+    ok: false,
+    error: issue.message,
+    issues: [issue],
+  };
+}
+
+function buildMissingParentWorkspaceAuthorityFailure(
+  source: DelegatedExecutionEnvelopeDerivationSource,
+): DelegatedExecutionEnvelopeDerivationResult {
+  return buildDerivationFailure({
+    code: "missing_parent_workspace_authority",
+    message:
+      source === "internal_planner_path"
+        ? "Delegated local-file work must have a canonical workspace root before child execution."
+        : "Direct execute_with_agent local-file work requires a trusted parent workspace root before child execution.",
+  });
+}
+
+function normalizeParentRoots(
+  roots: readonly (string | undefined | null)[] | undefined,
+  parentWorkspaceRoot: string,
+): readonly string[] {
+  const normalized = normalizeEnvelopeRoots(roots ?? [], parentWorkspaceRoot);
+  const filtered = normalized.filter((path) =>
+    isPathWithinRoot(path, parentWorkspaceRoot)
+  );
+  return filtered.length > 0 ? filtered : [parentWorkspaceRoot];
+}
+
+function normalizeRequestedReadRoots(
+  roots: readonly string[] | undefined,
+  childWorkspaceRoot: string,
+): readonly string[] | undefined {
+  if (!roots || roots.length === 0) return undefined;
+  return normalizeEnvelopeRoots(roots, childWorkspaceRoot);
+}
+
+function normalizeRequestedArtifacts(
+  paths: readonly string[] | undefined,
+  childWorkspaceRoot: string,
+): readonly string[] | undefined {
+  if (!paths || paths.length === 0) return undefined;
+  return normalizeArtifactPaths(paths, childWorkspaceRoot);
+}
+
+export function deriveDelegatedExecutionEnvelopeFromParent(params: {
+  readonly parentWorkspaceRoot?: string | null;
+  readonly parentAllowedReadRoots?: readonly (string | undefined | null)[];
+  readonly parentAllowedWriteRoots?: readonly (string | undefined | null)[];
+  readonly requestedExecutionContext?: DelegationExecutionContext;
+  readonly requiresStructuredExecutionContext: boolean;
+  readonly source: DelegatedExecutionEnvelopeDerivationSource;
+}): DelegatedExecutionEnvelopeDerivationResult {
+  if (!params.requiresStructuredExecutionContext) {
+    return { ok: true };
+  }
+
+  const rawRequestedWorkspaceRoot =
+    params.requestedExecutionContext?.workspaceRoot;
+  if (
+    typeof rawRequestedWorkspaceRoot === "string" &&
+    rawRequestedWorkspaceRoot.trim().length > 0 &&
+    !isConcreteExecutableEnvelopeRoot(rawRequestedWorkspaceRoot)
+  ) {
+    return buildMissingParentWorkspaceAuthorityFailure(params.source);
+  }
+
+  const runtimeOwnedPlannerWorkspaceRoot =
+    params.source === "internal_planner_path" &&
+      params.requestedExecutionContext
+      ? normalizeWorkspaceRoot(rawRequestedWorkspaceRoot)
+      : undefined;
+  const parentWorkspaceRoot = normalizeWorkspaceRoot(
+    params.parentWorkspaceRoot ??
+      (runtimeOwnedPlannerWorkspaceRoot &&
+          isConcreteExecutableEnvelopeRoot(runtimeOwnedPlannerWorkspaceRoot)
+        ? runtimeOwnedPlannerWorkspaceRoot
+        : undefined),
+  );
+  if (!parentWorkspaceRoot) {
+    return buildMissingParentWorkspaceAuthorityFailure(params.source);
+  }
+
+  const parentAllowedReadRoots = normalizeParentRoots(
+    params.parentAllowedReadRoots,
+    parentWorkspaceRoot,
+  );
+  const parentAllowedWriteRoots = normalizeParentRoots(
+    params.parentAllowedWriteRoots,
+    parentWorkspaceRoot,
+  );
+
+  const requestedContext = params.requestedExecutionContext
+    ? canonicalizeDelegationExecutionContext(params.requestedExecutionContext, {
+        inheritedWorkspaceRoot: parentWorkspaceRoot,
+        hostWorkspaceRoot: parentWorkspaceRoot,
+      })
+    : undefined;
+
+  const requestedWorkspaceRoot = normalizeWorkspaceRoot(
+    requestedContext?.workspaceRoot,
+  );
+  if (
+    requestedWorkspaceRoot &&
+    !isPathWithinRoot(requestedWorkspaceRoot, parentWorkspaceRoot)
+  ) {
+    return buildDerivationFailure({
+      code: "workspace_root_outside_parent_workspace",
+      message:
+        `Requested delegated workspace root "${requestedWorkspaceRoot}" is outside the trusted parent workspace root "${parentWorkspaceRoot}".`,
+      path: requestedWorkspaceRoot,
+    });
+  }
+
+  const childWorkspaceRoot = requestedWorkspaceRoot ?? parentWorkspaceRoot;
+
+  const requestedReadRoots = normalizeRequestedReadRoots(
+    requestedContext?.allowedReadRoots,
+    childWorkspaceRoot,
+  );
+  if (
+    requestedReadRoots?.some(
+      (path) =>
+        !isPathWithinRoot(path, childWorkspaceRoot) ||
+        !isPathWithinAnyRoot(path, parentAllowedReadRoots),
+    )
+  ) {
+    const offendingPath = requestedReadRoots.find(
+      (path) =>
+        !isPathWithinRoot(path, childWorkspaceRoot) ||
+        !isPathWithinAnyRoot(path, parentAllowedReadRoots),
+    );
+    return buildDerivationFailure({
+      code: "read_root_outside_parent_workspace",
+      message:
+        `Requested delegated read root "${offendingPath}" is outside the trusted parent workspace authority.`,
+      path: offendingPath,
+    });
+  }
+
+  const requestedWriteRoots = normalizeRequestedReadRoots(
+    requestedContext?.allowedWriteRoots,
+    childWorkspaceRoot,
+  );
+  if (
+    requestedWriteRoots?.some(
+      (path) =>
+        !isPathWithinRoot(path, childWorkspaceRoot) ||
+        !isPathWithinAnyRoot(path, parentAllowedWriteRoots),
+    )
+  ) {
+    const offendingPath = requestedWriteRoots.find(
+      (path) =>
+        !isPathWithinRoot(path, childWorkspaceRoot) ||
+        !isPathWithinAnyRoot(path, parentAllowedWriteRoots),
+    );
+    return buildDerivationFailure({
+      code: "write_root_outside_parent_workspace",
+      message:
+        `Requested delegated write root "${offendingPath}" is outside the trusted parent workspace authority.`,
+      path: offendingPath,
+    });
+  }
+
+  const inputArtifacts = normalizeRequestedArtifacts(
+    requestedContext?.inputArtifacts,
+    childWorkspaceRoot,
+  );
+  if (
+    inputArtifacts?.some(
+      (path) =>
+        !isPathWithinRoot(path, childWorkspaceRoot) ||
+        !isPathWithinAnyRoot(path, parentAllowedReadRoots),
+    )
+  ) {
+    const offendingPath = inputArtifacts.find(
+      (path) =>
+        !isPathWithinRoot(path, childWorkspaceRoot) ||
+        !isPathWithinAnyRoot(path, parentAllowedReadRoots),
+    );
+    return buildDerivationFailure({
+      code: "input_artifact_outside_parent_workspace",
+      message:
+        `Requested delegated input artifact "${offendingPath}" is outside the trusted parent workspace authority.`,
+      path: offendingPath,
+    });
+  }
+
+  const requiredSourceArtifacts = normalizeRequestedArtifacts(
+    requestedContext?.requiredSourceArtifacts ?? requestedContext?.inputArtifacts,
+    childWorkspaceRoot,
+  );
+  if (
+    requiredSourceArtifacts?.some(
+      (path) =>
+        !isPathWithinRoot(path, childWorkspaceRoot) ||
+        !isPathWithinAnyRoot(path, parentAllowedReadRoots),
+    )
+  ) {
+    const offendingPath = requiredSourceArtifacts.find(
+      (path) =>
+        !isPathWithinRoot(path, childWorkspaceRoot) ||
+        !isPathWithinAnyRoot(path, parentAllowedReadRoots),
+    );
+    return buildDerivationFailure({
+      code: "required_source_outside_parent_workspace",
+      message:
+        `Requested delegated required source artifact "${offendingPath}" is outside the trusted parent workspace authority.`,
+      path: offendingPath,
+    });
+  }
+
+  const targetArtifacts = normalizeRequestedArtifacts(
+    requestedContext?.targetArtifacts,
+    childWorkspaceRoot,
+  );
+  if (
+    targetArtifacts?.some(
+      (path) =>
+        !isPathWithinRoot(path, childWorkspaceRoot) ||
+        !isPathWithinAnyRoot(path, parentAllowedWriteRoots),
+    )
+  ) {
+    const offendingPath = targetArtifacts.find(
+      (path) =>
+        !isPathWithinRoot(path, childWorkspaceRoot) ||
+        !isPathWithinAnyRoot(path, parentAllowedWriteRoots),
+    );
+    return buildDerivationFailure({
+      code: "target_outside_parent_workspace",
+      message:
+        `Requested delegated target artifact "${offendingPath}" is outside the trusted parent workspace authority.`,
+      path: offendingPath,
+    });
+  }
+
+  const defaultAllowedReadRoots = parentAllowedReadRoots.filter((path) =>
+    isPathWithinRoot(path, childWorkspaceRoot)
+  );
+  const defaultAllowedWriteRoots = parentAllowedWriteRoots.filter((path) =>
+    isPathWithinRoot(path, childWorkspaceRoot)
+  );
+
+  const executionContext = buildDelegationExecutionContext({
+    workspaceRoot: childWorkspaceRoot,
+    allowedReadRoots:
+      requestedReadRoots ??
+      (defaultAllowedReadRoots.length > 0
+        ? defaultAllowedReadRoots
+        : [childWorkspaceRoot]),
+    allowedWriteRoots:
+      requestedWriteRoots ??
+      (defaultAllowedWriteRoots.length > 0
+        ? defaultAllowedWriteRoots
+        : [childWorkspaceRoot]),
+    allowedTools: requestedContext?.allowedTools,
+    inputArtifacts,
+    requiredSourceArtifacts,
+    targetArtifacts,
+    effectClass: requestedContext?.effectClass,
+    verificationMode: requestedContext?.verificationMode,
+    stepKind: requestedContext?.stepKind,
+    completionContract: requestedContext?.completionContract,
+    fallbackPolicy: requestedContext?.fallbackPolicy,
+    resumePolicy: requestedContext?.resumePolicy,
+    approvalProfile: requestedContext?.approvalProfile,
+  });
+
+  return {
+    ok: true,
+    executionContext,
+    workingDirectory: executionContext?.workspaceRoot?.trim() || undefined,
+  };
 }

--- a/runtime/src/utils/parent-safe-introspection.ts
+++ b/runtime/src/utils/parent-safe-introspection.ts
@@ -1,0 +1,45 @@
+export interface ParentSafeReadOnlyIntrospectionIntent {
+  readonly command: "pwd" | "ls";
+}
+
+const EXPLICIT_CHILD_ISOLATION_RE =
+  /\b(?:execute_with_agent|sub[\s-]?agent|child\s+agent|delegate|delegation|spawn|parallel(?:ize|ism)?|handoff|isolation)\b/i;
+const COMPLEX_INTROSPECTION_RE =
+  /\b(?:grep|find|search|rg|ripgrep|tree|recursive|glob|write|edit|modify|create|delete|remove|move|rename|build|test|install|deploy|serve|status|diff)\b/i;
+const TRIVIAL_PWD_RE =
+  /^\s*(?:pwd|run\s+pwd|what(?:'s| is)\s+(?:the\s+)?(?:current\s+)?(?:working\s+directory|cwd)|show\s+(?:me\s+)?(?:the\s+)?(?:current\s+)?(?:working\s+directory|cwd)|tell\s+me\s+(?:the\s+)?(?:current\s+)?(?:working\s+directory|cwd))\s*[?.!]*\s*$/i;
+const TRIVIAL_LS_RE =
+  /^\s*(?:ls(?:\s+-[A-Za-z]+)?|run\s+ls(?:\s+-[A-Za-z]+)?|list\s+(?:the\s+)?files(?:\s+(?:here|in\s+(?:the\s+)?(?:current\s+)?(?:directory|workspace)))?|show\s+(?:me\s+)?(?:the\s+)?files(?:\s+(?:here|in\s+(?:the\s+)?(?:current\s+)?(?:directory|workspace)))?|what(?:'s| is)\s+in\s+(?:the\s+)?(?:current\s+)?(?:directory|workspace)|show\s+(?:me\s+)?what(?:'s| is)\s+in\s+(?:the\s+)?(?:current\s+)?(?:directory|workspace)|what\s+files\s+are\s+here)\s*[?.!]*\s*$/i;
+
+export function inferParentSafeReadOnlyIntrospection(
+  messageText: string,
+): ParentSafeReadOnlyIntrospectionIntent | undefined {
+  const trimmed = messageText.trim();
+  if (trimmed.length === 0) return undefined;
+  if (EXPLICIT_CHILD_ISOLATION_RE.test(trimmed)) return undefined;
+  if (COMPLEX_INTROSPECTION_RE.test(trimmed)) return undefined;
+
+  if (TRIVIAL_PWD_RE.test(trimmed)) {
+    return { command: "pwd" };
+  }
+  if (TRIVIAL_LS_RE.test(trimmed)) {
+    return { command: "ls" };
+  }
+  return undefined;
+}
+
+export function resolveParentSafeReadOnlyIntrospectionToolNames(
+  intent: ParentSafeReadOnlyIntrospectionIntent,
+  allowedToolNames: readonly string[],
+): readonly string[] {
+  const preferredToolNames =
+    intent.command === "ls"
+      ? ["system.bash", "desktop.bash", "system.listDir"]
+      : ["system.bash", "desktop.bash"];
+  if (allowedToolNames.length === 0) {
+    return preferredToolNames;
+  }
+  return preferredToolNames.filter((toolName) =>
+    allowedToolNames.includes(toolName),
+  );
+}

--- a/runtime/src/workflow/completion-progress.test.ts
+++ b/runtime/src/workflow/completion-progress.test.ts
@@ -26,8 +26,17 @@ describe("completion-progress", () => {
           isError: false,
         },
       ],
-      plannerUsed: true,
-      deterministicStepsExecuted: 2,
+      verificationContract: {
+        workspaceRoot: "/workspace",
+        targetArtifacts: ["/workspace/src/main.c"],
+        verificationMode: "mutation_required",
+        completionContract: {
+          taskClass: "build_required",
+          placeholdersAllowed: false,
+          partialCompletionAllowed: false,
+          placeholderTaxonomy: "implementation",
+        },
+      },
       updatedAt: 10,
     });
 
@@ -65,8 +74,17 @@ describe("completion-progress", () => {
           isError: false,
         },
       ],
-      plannerUsed: true,
-      deterministicStepsExecuted: 1,
+      verificationContract: {
+        workspaceRoot: "/workspace",
+        targetArtifacts: ["/workspace/src/main.c"],
+        verificationMode: "mutation_required",
+        completionContract: {
+          taskClass: "build_required",
+          placeholdersAllowed: false,
+          partialCompletionAllowed: false,
+          placeholderTaxonomy: "implementation",
+        },
+      },
       updatedAt: 5,
     });
     const next = {
@@ -97,6 +115,133 @@ describe("completion-progress", () => {
         expect.objectContaining({
           requirement: "build_verification",
           summary: "ctest",
+        }),
+      ]),
+    );
+  });
+
+  it("produces the same progress requirements for equivalent direct and planner implementation contracts", () => {
+    const direct = deriveWorkflowProgressSnapshot({
+      stopReason: "completed",
+      completionState: "needs_verification",
+      toolCalls: [
+        {
+          name: "system.writeFile",
+          args: { path: "/workspace/src/main.c" },
+          result: JSON.stringify({ ok: true }),
+          isError: false,
+        },
+      ],
+      verificationContract: {
+        workspaceRoot: "/workspace",
+        targetArtifacts: ["/workspace/src/main.c"],
+        verificationMode: "mutation_required",
+        completionContract: {
+          taskClass: "artifact_only",
+          placeholdersAllowed: false,
+          partialCompletionAllowed: false,
+          placeholderTaxonomy: "implementation",
+        },
+      },
+      updatedAt: 20,
+    });
+    const planner = deriveWorkflowProgressSnapshot({
+      stopReason: "completed",
+      completionState: "needs_verification",
+      toolCalls: [
+        {
+          name: "system.writeFile",
+          args: { path: "/workspace/src/main.c" },
+          result: JSON.stringify({ ok: true }),
+          isError: false,
+        },
+      ],
+      verificationContract: {
+        workspaceRoot: "/workspace",
+        targetArtifacts: ["/workspace/src/main.c"],
+        verificationMode: "mutation_required",
+        stepKind: "delegated_write",
+        completionContract: {
+          taskClass: "artifact_only",
+          placeholdersAllowed: false,
+          partialCompletionAllowed: false,
+          placeholderTaxonomy: "implementation",
+        },
+      },
+      updatedAt: 20,
+    });
+
+    expect(direct).toMatchObject({
+      requiredRequirements: ["workflow_verifier_pass"],
+      remainingRequirements: ["workflow_verifier_pass"],
+    });
+    expect(planner).toMatchObject({
+      requiredRequirements: ["workflow_verifier_pass"],
+      remainingRequirements: ["workflow_verifier_pass"],
+    });
+  });
+
+  it("preserves needs-verification carryover when a later snapshot blocks before verifier closure", () => {
+    const previous = deriveWorkflowProgressSnapshot({
+      stopReason: "completed",
+      completionState: "needs_verification",
+      toolCalls: [
+        {
+          name: "system.bash",
+          args: { command: "npm test" },
+          result: JSON.stringify({
+            stdout: "ok",
+            stderr: "",
+            exitCode: 0,
+            __agencVerification: {
+              category: "build",
+              repoLocal: true,
+              command: "npm test",
+            },
+          }),
+          isError: false,
+        },
+      ],
+      verificationContract: {
+        workspaceRoot: "/workspace",
+        targetArtifacts: ["/workspace/src/main.c"],
+        verificationMode: "mutation_required",
+        completionContract: {
+          taskClass: "build_required",
+          placeholdersAllowed: false,
+          partialCompletionAllowed: false,
+          placeholderTaxonomy: "implementation",
+        },
+      },
+      updatedAt: 5,
+    });
+    const next = {
+      completionState: "blocked" as const,
+      stopReason: "validation_error" as const,
+      stopReasonDetail: "Verification artifacts are still missing",
+      requiredRequirements: [] as const,
+      satisfiedRequirements: [] as const,
+      remainingRequirements: [] as const,
+      reusableEvidence: [] as const,
+      updatedAt: 15,
+    };
+
+    const merged = mergeWorkflowProgressSnapshots({
+      previous,
+      next,
+    });
+
+    expect(merged).toMatchObject({
+      completionState: "needs_verification",
+      remainingRequirements: ["workflow_verifier_pass"],
+      stopReason: "validation_error",
+      stopReasonDetail: "Verification artifacts are still missing",
+    });
+    expect(merged?.reusableEvidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          requirement: "build_verification",
+          summary: "npm test",
         }),
       ]),
     );

--- a/runtime/src/workflow/completion-progress.ts
+++ b/runtime/src/workflow/completion-progress.ts
@@ -52,39 +52,19 @@ interface EncodedVerificationMetadata {
   readonly path?: string;
 }
 
-const DIRECT_MUTATION_TOOL_NAMES = new Set([
-  "desktop.text_editor",
-  "system.appendFile",
-  "system.delete",
-  "system.mkdir",
-  "system.move",
-  "system.writeFile",
-]);
-
-const SHELL_MUTATION_RE =
-  /(?:^|[;&|]\s*|\n)\s*(?:cp|mv|rm|mkdir|touch|tee|sed|perl|python|node|ruby|go|cargo|npm|pnpm|yarn|make|cmake)\b|>>?|(?:^|[;&|]\s*|\n)\s*cat\s+.+>>?/i;
-
 export function deriveWorkflowProgressSnapshot(params: {
   readonly stopReason: LLMPipelineStopReason;
   readonly completionState: WorkflowCompletionState;
   readonly stopReasonDetail?: string;
   readonly validationCode?: DelegationOutputValidationCode;
   readonly toolCalls: readonly CompletionProgressToolCall[];
-  readonly plannerUsed?: boolean;
-  readonly deterministicStepsExecuted?: number;
   readonly verificationContract?: WorkflowVerificationContract;
   readonly completionContract?: ImplementationCompletionContract;
   readonly updatedAt: number;
 }): WorkflowProgressSnapshot | undefined {
   const mergedContract = mergeVerificationContract({
     verificationContract: params.verificationContract,
-    completionContract:
-      params.completionContract ??
-      inferDeterministicCompletionContract({
-        plannerUsed: params.plannerUsed,
-        deterministicStepsExecuted: params.deterministicStepsExecuted,
-        toolCalls: params.toolCalls,
-      }),
+    completionContract: params.completionContract,
   });
   const obligations = mergedContract
     ? deriveVerificationObligations(mergedContract)
@@ -223,51 +203,6 @@ function mergeVerificationContract(params: {
       ? { completionContract: params.completionContract }
       : {}),
   };
-}
-
-function inferDeterministicCompletionContract(params: {
-  readonly plannerUsed?: boolean;
-  readonly deterministicStepsExecuted?: number;
-  readonly toolCalls: readonly CompletionProgressToolCall[];
-}): ImplementationCompletionContract | undefined {
-  if (params.plannerUsed !== true) {
-    return undefined;
-  }
-  if (Number(params.deterministicStepsExecuted ?? 0) <= 0) {
-    return undefined;
-  }
-  const hasMutationProgress = params.toolCalls.some((toolCall) =>
-    isMutationToolCall(toolCall),
-  );
-  if (!hasMutationProgress) {
-    return undefined;
-  }
-  return {
-    taskClass: "artifact_only",
-    placeholdersAllowed: false,
-    partialCompletionAllowed: false,
-    placeholderTaxonomy: "implementation",
-  };
-}
-
-function isMutationToolCall(toolCall: CompletionProgressToolCall): boolean {
-  if (toolCall.isError) {
-    return false;
-  }
-  if (DIRECT_MUTATION_TOOL_NAMES.has(toolCall.name.trim())) {
-    return true;
-  }
-  if (toolCall.name !== "system.bash" && toolCall.name !== "desktop.bash") {
-    return false;
-  }
-  const command =
-    toolCall.args &&
-    typeof toolCall.args === "object" &&
-    !Array.isArray(toolCall.args) &&
-    typeof (toolCall.args as { command?: unknown }).command === "string"
-      ? String((toolCall.args as { command: string }).command)
-      : "";
-  return SHELL_MUTATION_RE.test(command);
 }
 
 function decodeVerificationMetadata(

--- a/runtime/src/workflow/completion-state.test.ts
+++ b/runtime/src/workflow/completion-state.test.ts
@@ -53,12 +53,10 @@ describe("completion-state", () => {
     ).toBe("needs_verification");
   });
 
-  it("marks the shell-stub incident shape as needs_verification before verifier rollout", () => {
+  it("marks deterministic implementation as needs_verification when the runtime-owned contract lacks verifier closure", () => {
     expect(
       resolveWorkflowCompletionState({
         stopReason: "completed",
-        plannerUsed: true,
-        deterministicStepsExecuted: 4,
         toolCalls: [
           {
             name: "system.bash",
@@ -76,6 +74,17 @@ describe("completion-state", () => {
             isError: false,
           },
         ],
+        verificationContract: {
+          workspaceRoot: "/workspace",
+          targetArtifacts: ["/workspace/src/jobs.c"],
+          verificationMode: "mutation_required",
+          completionContract: {
+            taskClass: "build_required",
+            placeholdersAllowed: false,
+            partialCompletionAllowed: false,
+            placeholderTaxonomy: "implementation",
+          },
+        },
         verifier: {
           performed: false,
           overall: "skipped",
@@ -132,5 +141,45 @@ describe("completion-state", () => {
         },
       }),
     ).toBe("needs_verification");
+  });
+
+  it("uses the same completion semantics for planner and direct implementation when the workflow contract matches", () => {
+    const sharedInput = {
+      stopReason: "completed",
+      toolCalls: [
+        {
+          name: "system.writeFile",
+          args: { path: "/workspace/src/main.c" },
+          result: JSON.stringify({ ok: true }),
+          isError: false,
+        },
+      ],
+      verificationContract: {
+        workspaceRoot: "/workspace",
+        targetArtifacts: ["/workspace/src/main.c"],
+        verificationMode: "mutation_required" as const,
+        completionContract: {
+          taskClass: "artifact_only" as const,
+          placeholdersAllowed: false,
+          partialCompletionAllowed: false,
+          placeholderTaxonomy: "implementation" as const,
+        },
+      },
+      verifier: {
+        performed: false,
+        overall: "skipped" as const,
+      },
+    };
+
+    expect(resolveWorkflowCompletionState(sharedInput)).toBe("completed");
+    expect(
+      resolveWorkflowCompletionState({
+        ...sharedInput,
+        verificationContract: {
+          ...sharedInput.verificationContract,
+          stepKind: "delegated_write",
+        },
+      }),
+    ).toBe("completed");
   });
 });

--- a/runtime/src/workflow/completion-state.ts
+++ b/runtime/src/workflow/completion-state.ts
@@ -21,17 +21,6 @@ export interface CompletionStateToolCall {
   readonly isError: boolean;
 }
 
-const DIRECT_MUTATION_TOOL_NAMES = new Set([
-  "desktop.text_editor",
-  "system.appendFile",
-  "system.delete",
-  "system.mkdir",
-  "system.move",
-  "system.writeFile",
-]);
-
-const SHELL_MUTATION_RE = /(?:^|[;&|]\s*|\n)\s*(?:cp|mv|rm|mkdir|touch|tee|sed|perl|python|node|ruby|go|cargo|npm|pnpm|yarn|make|cmake)\b|>>?|(?:^|[;&|]\s*|\n)\s*cat\s+.+>>?/i;
-
 export function resolvePipelineCompletionState(input: {
   readonly status: "running" | "completed" | "failed" | "halted";
   readonly completedSteps: number;
@@ -48,8 +37,6 @@ export function resolvePipelineCompletionState(input: {
 export function resolveWorkflowCompletionState(input: {
   readonly stopReason: string;
   readonly toolCalls: readonly CompletionStateToolCall[];
-  readonly plannerUsed?: boolean;
-  readonly deterministicStepsExecuted?: number;
   readonly verificationContract?: WorkflowVerificationContract;
   readonly completionContract?: ImplementationCompletionContract;
   readonly validationCode?: DelegationOutputValidationCode;
@@ -64,9 +51,6 @@ export function resolveWorkflowCompletionState(input: {
     (toolCall) => !didToolCallFail(toolCall.isError, toolCall.result),
   );
   const hasProgress = successfulToolCalls.length > 0;
-  const hasMutationProgress = successfulToolCalls.some((toolCall) =>
-    isMutationToolCall(toolCall),
-  );
   const requiresExplicitVerification = Boolean(
     obligations &&
       (
@@ -75,13 +59,8 @@ export function resolveWorkflowCompletionState(input: {
         obligations.requiresReviewVerification
       ),
   );
-  const requiresDeterministicImplementationVerification =
-    !obligations?.completionContract &&
-    input.plannerUsed === true &&
-    Number(input.deterministicStepsExecuted ?? 0) > 0 &&
-    hasMutationProgress;
   const requiresVerificationBeforeCompletion =
-    requiresExplicitVerification || requiresDeterministicImplementationVerification;
+    requiresExplicitVerification;
 
   if (input.stopReason === "completed") {
     if (
@@ -128,21 +107,4 @@ function mergeVerificationContract(input: {
       ? { completionContract: input.completionContract }
       : {}),
   };
-}
-
-function isMutationToolCall(toolCall: CompletionStateToolCall): boolean {
-  if (DIRECT_MUTATION_TOOL_NAMES.has(toolCall.name.trim())) {
-    return true;
-  }
-  if (toolCall.name !== "system.bash" && toolCall.name !== "desktop.bash") {
-    return false;
-  }
-  const command =
-    toolCall.args &&
-    typeof toolCall.args === "object" &&
-    !Array.isArray(toolCall.args) &&
-    typeof (toolCall.args as { command?: unknown }).command === "string"
-      ? String((toolCall.args as { command: string }).command)
-      : "";
-  return SHELL_MUTATION_RE.test(command);
 }

--- a/runtime/tests/regression/orchestration/execution-envelope.integration.test.ts
+++ b/runtime/tests/regression/orchestration/execution-envelope.integration.test.ts
@@ -7,6 +7,7 @@ import { createMockMemoryBackend } from "../../../src/memory/test-utils.js";
 import { PipelineExecutor } from "../../../src/workflow/pipeline.js";
 import type { SubAgentConfig, SubAgentResult } from "../../../src/gateway/sub-agent.js";
 import { SubAgentOrchestrator } from "../../../src/gateway/subagent-orchestrator.js";
+import { deriveDelegatedExecutionEnvelopeFromParent } from "../../../src/utils/delegation-execution-context.js";
 
 class RecordingManager {
   private readonly entries = new Map<string, SubAgentResult>();
@@ -120,25 +121,44 @@ describe("execution envelope integration", () => {
       ],
     });
 
+    const directDerivation = deriveDelegatedExecutionEnvelopeFromParent({
+      parentWorkspaceRoot: workspaceRoot,
+      parentAllowedReadRoots: [workspaceRoot],
+      parentAllowedWriteRoots: [workspaceRoot],
+      requestedExecutionContext: {
+        version: "v1",
+        workspaceRoot,
+        allowedReadRoots: [workspaceRoot],
+        allowedWriteRoots: [workspaceRoot],
+        requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+        targetArtifacts: [`${workspaceRoot}/AGENC.md`],
+        allowedTools: ["system.readFile", "system.writeFile"],
+        effectClass: "filesystem_write",
+        verificationMode: "mutation_required",
+        stepKind: "delegated_write",
+      },
+      requiresStructuredExecutionContext: true,
+      source: "direct_live_path",
+    });
+
     expect(result.status).toMatch(/^(?:completed|failed)$/);
+    expect(directDerivation.ok).toBe(true);
     expect(manager.spawnCalls).toHaveLength(1);
     expect(manager.spawnCalls[0]).toMatchObject({
-      workingDirectory: workspaceRoot,
+      workingDirectory: directDerivation.ok
+        ? directDerivation.workingDirectory
+        : workspaceRoot,
       workingDirectorySource: "execution_envelope",
     });
     expect(manager.spawnCalls[0]?.tools).toEqual(
       expect.arrayContaining(["system.readFile", "system.writeFile"]),
     );
     expect(manager.spawnCalls[0]?.delegationSpec?.executionContext).toEqual(
-      expect.objectContaining({
-        workspaceRoot,
-        requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
-        targetArtifacts: [`${workspaceRoot}/AGENC.md`],
-      }),
+      directDerivation.ok ? directDerivation.executionContext : undefined,
     );
   });
 
-  it("rejects delegated workspace aliases instead of canonicalizing them into live execution scope", async () => {
+  it("derives planner child scope from trusted parent authority instead of treating workspace aliases as live root truth", async () => {
     const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-envelope-"));
     TEMP_DIRS.push(workspaceRoot);
     writeFileSync(join(workspaceRoot, "PLAN.md"), "# plan\n", "utf8");
@@ -150,6 +170,7 @@ describe("execution envelope integration", () => {
       output: '{"status":"completed","summary":"updated PLAN.md"}',
       success: true,
       durationMs: 12,
+      completionState: "completed",
       toolCalls: [
         {
           name: "system.readFile",
@@ -209,11 +230,36 @@ describe("execution envelope integration", () => {
       ],
     });
 
-    expect(result.status).toBe("failed");
-    expect(result.error).toContain(
-      "Delegated local-file work must have a canonical workspace root before child execution.",
+    const directDerivation = deriveDelegatedExecutionEnvelopeFromParent({
+      parentWorkspaceRoot: workspaceRoot,
+      parentAllowedReadRoots: [workspaceRoot],
+      parentAllowedWriteRoots: [workspaceRoot],
+      requestedExecutionContext: {
+        version: "v1",
+        allowedReadRoots: [workspaceRoot],
+        allowedWriteRoots: [],
+        requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+        allowedTools: ["system.readFile"],
+        effectClass: "read_only",
+        verificationMode: "grounded_read",
+        stepKind: "delegated_review",
+      },
+      requiresStructuredExecutionContext: true,
+      source: "direct_live_path",
+    });
+
+    expect(result.status).toBe("completed");
+    expect(directDerivation.ok).toBe(true);
+    expect(manager.spawnCalls).toHaveLength(1);
+    expect(manager.spawnCalls[0]).toMatchObject({
+      workingDirectory: directDerivation.ok
+        ? directDerivation.workingDirectory
+        : workspaceRoot,
+      workingDirectorySource: "execution_envelope",
+    });
+    expect(manager.spawnCalls[0]?.delegationSpec?.executionContext).toEqual(
+      directDerivation.ok ? directDerivation.executionContext : undefined,
     );
-    expect(manager.spawnCalls).toHaveLength(0);
   });
 
   it("rejects broken delegated contracts before any child execution begins", async () => {
@@ -281,7 +327,170 @@ describe("execution envelope integration", () => {
     expect(result.status).toBe("failed");
     expect(manager.spawnCalls).toHaveLength(0);
     expect(result.error).toContain(
-      "Delegated local-file work must have a canonical workspace root before child execution.",
+      "outside the trusted parent workspace authority",
     );
+  });
+
+  it("derives the same narrowed child envelope for planner and direct descendant-scoped work", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-envelope-"));
+    const packageRoot = join(workspaceRoot, "packages", "shell");
+    TEMP_DIRS.push(workspaceRoot);
+    mkdirSync(packageRoot, { recursive: true });
+    writeFileSync(join(packageRoot, "PLAN.md"), "# plan\n", "utf8");
+    const baseExecutor = new PipelineExecutor({
+      toolHandler: async () => '{"stdout":"ok","exitCode":0}',
+      memoryBackend: createMockMemoryBackend(),
+    });
+    const manager = new RecordingManager({
+      output: '{"status":"completed","summary":"inspected package plan"}',
+      success: true,
+      durationMs: 12,
+      completionState: "completed",
+      toolCalls: [
+        {
+          name: "system.readFile",
+          args: { path: `${packageRoot}/PLAN.md` },
+          result: `{"path":"${packageRoot}/PLAN.md","content":"# plan"}`,
+          isError: false,
+          durationMs: 2,
+        },
+      ],
+      stopReason: "completed",
+    });
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: baseExecutor,
+      resolveSubAgentManager: () => manager,
+      pollIntervalMs: 5,
+      unsafeBenchmarkMode: true,
+    });
+
+    const requestedExecutionContext = {
+      version: "v1" as const,
+      workspaceRoot: packageRoot,
+      allowedReadRoots: [packageRoot],
+      allowedWriteRoots: [],
+      requiredSourceArtifacts: [`${packageRoot}/PLAN.md`],
+      allowedTools: ["system.readFile"],
+      effectClass: "read_only" as const,
+      verificationMode: "grounded_read" as const,
+      stepKind: "delegated_review" as const,
+    };
+
+    const result = await orchestrator.execute({
+      id: "planner:envelope:descendant-parity",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerContext: {
+        parentRequest: "Inspect the shell package plan",
+        history: [],
+        memory: [],
+        toolOutputs: [],
+        workspaceRoot,
+      },
+      plannerSteps: [
+        {
+          name: "review_shell_plan",
+          stepType: "subagent_task",
+          objective: "Review the shell package plan",
+          inputContract: "Inspect the delegated PLAN.md under packages/shell.",
+          acceptanceCriteria: ["packages/shell/PLAN.md inspected"],
+          requiredToolCapabilities: ["system.readFile"],
+          contextRequirements: ["cwd=/workspace/packages/shell"],
+          executionContext: requestedExecutionContext,
+          maxBudgetHint: "2m",
+          canRunParallel: false,
+        },
+      ],
+    });
+
+    const directDerivation = deriveDelegatedExecutionEnvelopeFromParent({
+      parentWorkspaceRoot: workspaceRoot,
+      parentAllowedReadRoots: [workspaceRoot],
+      parentAllowedWriteRoots: [workspaceRoot],
+      requestedExecutionContext,
+      requiresStructuredExecutionContext: true,
+      source: "direct_live_path",
+    });
+
+    expect(result.status).toBe("completed");
+    expect(directDerivation.ok).toBe(true);
+    expect(manager.spawnCalls).toHaveLength(1);
+    expect(manager.spawnCalls[0]).toMatchObject({
+      workingDirectory: directDerivation.ok
+        ? directDerivation.workingDirectory
+        : packageRoot,
+      workingDirectorySource: "execution_envelope",
+    });
+    expect(manager.spawnCalls[0]?.delegationSpec?.executionContext).toEqual(
+      directDerivation.ok ? directDerivation.executionContext : undefined,
+    );
+  });
+
+  it("rejects planner child workspace roots that widen outside the trusted parent authority", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-envelope-"));
+    const outsideRoot = mkdtempSync(join(tmpdir(), "agenc-envelope-outside-"));
+    TEMP_DIRS.push(workspaceRoot);
+    TEMP_DIRS.push(outsideRoot);
+    const baseExecutor = new PipelineExecutor({
+      toolHandler: async () => '{"stdout":"ok","exitCode":0}',
+      memoryBackend: createMockMemoryBackend(),
+    });
+    const manager = new RecordingManager({
+      output: '{"status":"completed","summary":"should not run"}',
+      success: true,
+      durationMs: 12,
+      toolCalls: [],
+      stopReason: "completed",
+    });
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: baseExecutor,
+      resolveSubAgentManager: () => manager,
+      pollIntervalMs: 5,
+    });
+
+    const result = await orchestrator.execute({
+      id: "planner:envelope:4",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerContext: {
+        parentRequest: "Inspect PLAN.md",
+        history: [],
+        memory: [],
+        toolOutputs: [],
+        workspaceRoot,
+      },
+      plannerSteps: [
+        {
+          name: "review_plan",
+          stepType: "subagent_task",
+          objective: "Review the implementation plan",
+          inputContract: "Inspect PLAN.md in the delegated workspace.",
+          acceptanceCriteria: ["PLAN.md inspected"],
+          requiredToolCapabilities: ["system.readFile"],
+          contextRequirements: [],
+          executionContext: {
+            version: "v1",
+            workspaceRoot: outsideRoot,
+            allowedReadRoots: [outsideRoot],
+            allowedWriteRoots: [],
+            requiredSourceArtifacts: [join(outsideRoot, "PLAN.md")],
+            allowedTools: ["system.readFile"],
+            effectClass: "filesystem_read",
+            verificationMode: "evidence_only",
+            stepKind: "delegated_analysis",
+          },
+          maxBudgetHint: "2m",
+          canRunParallel: false,
+        },
+      ],
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toContain(
+      "outside the trusted parent workspace root",
+    );
+    expect(manager.spawnCalls).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
- harden delegated workspace trust classification and parent-safe introspection across delegated execution paths
- tighten workflow-owned completion, verification, and planner contract handling in the runtime executor
- expand runtime regression coverage for subagent context curation, workspace probes, routing, recovery, and execution-envelope flows

## Test Plan
- npm run validate:runtime