### PR TITLE
feat: Add per-call LLM usage logging (issue #48)

### DIFF
--- a/runtime/src/gateway/background-run-supervisor.test.ts
+++ b/runtime/src/gateway/background-run-supervisor.test.ts
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { ChatExecutor } from "../llm/chat-executor.js";
 import type { ChatExecutorResult } from "../llm/chat-executor.js";
 import type { LLMProvider, ToolHandler } from "../llm/types.js";
+import { resolveLlmUsageLoggingConfig } from "../llm/usage-logging.js";
 import { InMemoryBackend } from "../memory/in-memory/backend.js";
 import { SqliteBackend } from "../memory/sqlite/backend.js";
 import { PolicyEngine } from "../policy/engine.js";
@@ -68,6 +70,30 @@ function makeCallUsageRecord(overrides: Record<string, unknown> = {}) {
       estimatedChars: 20,
       systemPromptChars: 10,
     },
+    ...overrides,
+  };
+}
+
+function makeActorProvider(
+  overrides: Partial<LLMProvider> = {},
+): LLMProvider {
+  return {
+    name: "grok",
+    chat: vi.fn(async () => ({
+      content: "background reply",
+      toolCalls: [],
+      usage: { promptTokens: 7, completionTokens: 3, totalTokens: 10 },
+      model: "grok-test",
+      finishReason: "stop",
+    })),
+    chatStream: vi.fn(async () => ({
+      content: "background reply",
+      toolCalls: [],
+      usage: { promptTokens: 7, completionTokens: 3, totalTokens: 10 },
+      model: "grok-test",
+      finishReason: "stop",
+    })),
+    healthCheck: vi.fn(async () => true),
     ...overrides,
   };
 }
@@ -533,6 +559,73 @@ describe("background-run-supervisor", () => {
       "session-natural-language-server",
       "HTTP server is running in the background.",
     );
+  });
+
+  it("emits llm.call_usage logs for background actor cycles when enabled", async () => {
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      setLevel: vi.fn(),
+    } as any;
+    const publishUpdate = vi.fn(async () => undefined);
+    const chatExecutor = new ChatExecutor({
+      providers: [makeActorProvider()],
+      logger,
+      llmUsageLogging: resolveLlmUsageLoggingConfig({
+        enabled: true,
+      }),
+    });
+    const supervisor = new BackgroundRunSupervisor({
+      logger,
+      chatExecutor,
+      supervisorLlm: {
+        name: "supervisor",
+        chat: vi.fn(async () => ({
+          content:
+            '{"state":"working","userUpdate":"Background run is progressing.","internalSummary":"verified running","nextCheckMs":4000,"shouldNotifyUser":true}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })),
+        chatStream: vi.fn(),
+        healthCheck: vi.fn(async () => true),
+      },
+      getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
+      createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
+      publishUpdate,
+    });
+
+    await supervisor.startRun({
+      sessionId: "session-background-usage",
+      objective: "Keep checking this workspace until I stop you.",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    await eventually(() => {
+      expect(logger.info).toHaveBeenCalledWith(
+        "llm.call_usage",
+        expect.objectContaining({
+          event: "llm.call_usage",
+          sessionId: "session-background-usage",
+          runId: expect.stringMatching(/^bg-/),
+          traceId: expect.stringMatching(
+            /^background:session-background-usage:bg-.*:1:actor$/,
+          ),
+          provider: "grok",
+          phase: "initial",
+        }),
+      );
+    });
+
+    const payload = (logger.info as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([message]) => message === "llm.call_usage",
+    )?.[1];
+    expect(JSON.stringify(payload)).not.toContain("base system prompt");
+    expect(JSON.stringify(payload)).not.toContain("background reply");
   });
 
   it("starts a run, executes a cycle, and keeps it working", async () => {

--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -3223,6 +3223,7 @@ export class BackgroundRunSupervisor {
     heartbeatMs?: number;
   }> {
     const { run, sessionId, cycleToolHandler, actorPrompt, actorSystemPrompt } = params;
+    const actorTraceId = `background:${sessionId}:${run.id}:${run.cycleCount}:actor`;
     let actorResult: ChatExecutorResult | undefined;
     let decision: BackgroundRunDecision;
     let heartbeatMs: number | undefined;
@@ -3233,7 +3234,7 @@ export class BackgroundRunSupervisor {
           onProviderTraceEvent: createProviderTraceEventLogger({
             logger: this.logger,
             traceLabel: "background_run.provider",
-            traceId: `background:${sessionId}:${run.id}:${run.cycleCount}:actor`,
+            traceId: actorTraceId,
             sessionId,
             staticFields: {
               runId: run.id,
@@ -3244,7 +3245,7 @@ export class BackgroundRunSupervisor {
           onExecutionTraceEvent: createExecutionTraceEventLogger({
             logger: this.logger,
             traceLabel: "background_run.executor",
-            traceId: `background:${sessionId}:${run.id}:${run.cycleCount}:actor`,
+            traceId: actorTraceId,
             sessionId,
             staticFields: {
               runId: run.id,
@@ -3283,6 +3284,12 @@ export class BackgroundRunSupervisor {
           history: run.internalHistory,
           systemPrompt: actorSystemPrompt,
           sessionId,
+          runtimeContext: {
+            identifiers: {
+              traceId: actorTraceId,
+              runId: run.id,
+            },
+          },
           requestTimeoutMs: BACKGROUND_RUN_ACTOR_REQUEST_TIMEOUT_MS,
           stateful: run.carryForward?.providerContinuation
             ? {

--- a/runtime/src/gateway/chat-executor-factory.ts
+++ b/runtime/src/gateway/chat-executor-factory.ts
@@ -21,9 +21,11 @@ import type {
   DelegationBanditPolicyTuner,
   DelegationTrajectorySink,
 } from "../llm/delegation-learning.js";
+import type { ResolvedLlmUsageLoggingConfig } from "../llm/usage-logging.js";
 import type { HostToolingProfile } from "./host-tooling.js";
 import type { ResolvedSubAgentRuntimeConfig } from "./subagent-infrastructure.js";
 import type { GatewayLLMConfig } from "./types.js";
+import type { Logger } from "../utils/logger.js";
 
 // ---------------------------------------------------------------------------
 // Factory input
@@ -32,6 +34,10 @@ import type { GatewayLLMConfig } from "./types.js";
 export interface CreateChatExecutorParams {
   /** LLM providers (if empty, returns null). */
   providers: LLMProvider[];
+  /** Runtime logger for executor-owned operational events. */
+  logger?: Logger;
+  /** Resolved lightweight per-call LLM usage logging policy. */
+  llmUsageLogging?: ResolvedLlmUsageLoggingConfig;
   /** Base tool handler from ToolRegistry. */
   toolHandler: ToolHandler;
   /** Tool names advertised to the model. */
@@ -106,6 +112,8 @@ export function createChatExecutor(
 
   return new ChatExecutor({
     providers: params.providers,
+    logger: params.logger,
+    llmUsageLogging: params.llmUsageLogging,
     toolHandler: params.toolHandler,
     allowedTools: params.allowedTools,
     skillInjector: params.skillInjector,

--- a/runtime/src/gateway/config-watcher.ts
+++ b/runtime/src/gateway/config-watcher.ts
@@ -71,6 +71,10 @@ const VALID_LOG_LEVELS: ReadonlySet<string> = new Set([
   "warn",
   "error",
 ]);
+const VALID_LLM_USAGE_LOG_LEVELS: ReadonlySet<string> = new Set([
+  "debug",
+  "info",
+]);
 const VALID_CLI_OUTPUT_FORMATS: ReadonlySet<string> = new Set([
   "json",
   "jsonl",
@@ -2555,7 +2559,7 @@ export function validateGatewayConfig(obj: unknown): ValidationResult {
             requireOneOf(
               obj.logging.llmUsage.level,
               "logging.llmUsage.level",
-              ["debug", "info"] as const,
+              VALID_LLM_USAGE_LOG_LEVELS,
               errors,
             );
           }

--- a/runtime/src/gateway/config-watcher.ts
+++ b/runtime/src/gateway/config-watcher.ts
@@ -2532,6 +2532,45 @@ export function validateGatewayConfig(obj: unknown): ValidationResult {
           errors,
         );
       }
+      if (obj.logging.llmUsage !== undefined) {
+        if (!isRecord(obj.logging.llmUsage)) {
+          errors.push("logging.llmUsage must be an object");
+        } else {
+          const boolFields = [
+            "enabled",
+            "includeIdentifiers",
+            "includeCallContext",
+            "includePromptShape",
+            "includeBudgetDiagnostics",
+          ];
+          for (const field of boolFields) {
+            if (
+              obj.logging.llmUsage[field] !== undefined &&
+              typeof obj.logging.llmUsage[field] !== "boolean"
+            ) {
+              errors.push(`logging.llmUsage.${field} must be a boolean`);
+            }
+          }
+          if (obj.logging.llmUsage.level !== undefined) {
+            requireOneOf(
+              obj.logging.llmUsage.level,
+              "logging.llmUsage.level",
+              ["debug", "info"] as const,
+              errors,
+            );
+          }
+          if (obj.logging.llmUsage.sampleRate !== undefined &&
+            (typeof obj.logging.llmUsage.sampleRate !== "number" ||
+              !Number.isFinite(obj.logging.llmUsage.sampleRate) ||
+              obj.logging.llmUsage.sampleRate < 0 ||
+              obj.logging.llmUsage.sampleRate > 1)
+          ) {
+            errors.push(
+              "logging.llmUsage.sampleRate must be a number between 0 and 1",
+            );
+          }
+        }
+      }
       if (obj.logging.trace !== undefined) {
         if (!isRecord(obj.logging.trace)) {
           errors.push("logging.trace must be an object");

--- a/runtime/src/gateway/daemon-text-channel-turn.test.ts
+++ b/runtime/src/gateway/daemon-text-channel-turn.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { ChatExecutor } from "../llm/chat-executor.js";
 import type { ChatExecutorResult } from "../llm/chat-executor.js";
+import type { LLMProvider } from "../llm/types.js";
 import type { MemoryBackend } from "../memory/types.js";
 import type { Logger } from "../utils/logger.js";
+import { resolveLlmUsageLoggingConfig } from "../llm/usage-logging.js";
 import { executeTextChannelTurn } from "./daemon-text-channel-turn.js";
 import {
   SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY,
@@ -69,6 +72,27 @@ function createResult(
     compacted: false,
     stopReason: "completed",
     ...overrides,
+  };
+}
+
+function createProvider(): LLMProvider {
+  return {
+    name: "grok",
+    chat: vi.fn(async () => ({
+      content: "reply",
+      toolCalls: [],
+      usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      model: "grok-test",
+      finishReason: "stop",
+    })),
+    chatStream: vi.fn(async () => ({
+      content: "reply",
+      toolCalls: [],
+      usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      model: "grok-test",
+      finishReason: "stop",
+    })),
+    healthCheck: vi.fn(async () => true),
   };
 }
 
@@ -233,5 +257,67 @@ describe("executeTextChannelTurn", () => {
 
     expect(sessionMgr.appendMessage).not.toHaveBeenCalled();
     expect(memoryBackend.addEntry).not.toHaveBeenCalled();
+  });
+
+  it("emits llm.call_usage logs for text turns when lightweight usage logging is enabled", async () => {
+    const logger = createLoggerStub();
+    const memoryBackend = createMemoryBackendStub();
+    const session = createSession();
+    const sessionMgr = {
+      appendMessage: vi.fn(),
+    } as any;
+    const chatExecutor = new ChatExecutor({
+      providers: [createProvider()],
+      logger,
+      llmUsageLogging: resolveLlmUsageLoggingConfig({
+        enabled: true,
+      }),
+    });
+
+    await executeTextChannelTurn({
+      logger,
+      channelName: "telegram",
+      msg: {
+        sessionId: "session:test",
+        senderId: "user-1",
+        channel: "telegram",
+        content: "hello",
+      },
+      session,
+      sessionMgr,
+      systemPrompt: "system prompt",
+      chatExecutor,
+      toolHandler: vi.fn() as any,
+      defaultMaxToolRounds: 3,
+      traceConfig: {
+        enabled: false,
+        includeHistory: true,
+        includeSystemPrompt: true,
+        includeToolArgs: true,
+        includeToolResults: true,
+        includeProviderPayloads: false,
+        maxChars: 20_000,
+      },
+      turnTraceId: "trace-usage-text",
+      memoryBackend,
+      buildToolRoutingDecision: () => undefined,
+      recordToolRoutingOutcome: vi.fn(),
+    });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "llm.call_usage",
+      expect.objectContaining({
+        event: "llm.call_usage",
+        sessionId: "session:test",
+        traceId: "trace-usage-text",
+        provider: "grok",
+        phase: "initial",
+      }),
+    );
+    const payload = (logger.info as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([message]) => message === "llm.call_usage",
+    )?.[1];
+    expect(JSON.stringify(payload)).not.toContain("system prompt");
+    expect(JSON.stringify(payload)).not.toContain("reply");
   });
 });

--- a/runtime/src/gateway/daemon-text-channel-turn.ts
+++ b/runtime/src/gateway/daemon-text-channel-turn.ts
@@ -171,6 +171,11 @@ export async function executeTextChannelTurn(
     history: session.history,
     systemPrompt: effectiveSystemPrompt,
     sessionId: msg.sessionId,
+    runtimeContext: {
+      identifiers: {
+        traceId: turnTraceId,
+      },
+    },
     toolHandler,
     maxToolRounds: effectiveMaxToolRounds,
     ...(sessionStateful ? { stateful: sessionStateful } : {}),

--- a/runtime/src/gateway/daemon-webchat-turn.test.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { ChatExecutor } from "../llm/chat-executor.js";
 import type { ChatExecutorResult } from "../llm/chat-executor.js";
+import type { LLMProvider } from "../llm/types.js";
 import type { MemoryBackend } from "../memory/types.js";
 import type { Logger } from "../utils/logger.js";
+import { resolveLlmUsageLoggingConfig } from "../llm/usage-logging.js";
 import { hydrateWebSessionRuntimeState } from "./daemon-session-state.js";
 import { executeWebChatConversationTurn } from "./daemon-webchat-turn.js";
 import {
@@ -84,6 +87,27 @@ function createResult(
     stopReason: "completed",
     completionState: "completed",
     ...overrides,
+  };
+}
+
+function createProvider(): LLMProvider {
+  return {
+    name: "grok",
+    chat: vi.fn(async () => ({
+      content: "reply",
+      toolCalls: [],
+      usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      model: "grok-test",
+      finishReason: "stop",
+    })),
+    chatStream: vi.fn(async () => ({
+      content: "reply",
+      toolCalls: [],
+      usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      model: "grok-test",
+      finishReason: "stop",
+    })),
+    healthCheck: vi.fn(async () => true),
   };
 }
 
@@ -770,6 +794,9 @@ You have broad access to this machine via the system.bash tool.`,
       expect.objectContaining({
         runtimeContext: {
           workspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
+          identifiers: {
+            traceId: "trace-2",
+          },
         },
         message: expect.objectContaining({
           metadata: expect.objectContaining({
@@ -778,5 +805,88 @@ You have broad access to this machine via the system.bash tool.`,
         }),
       }),
     );
+  });
+
+  it("emits llm.call_usage logs for webchat turns when lightweight usage logging is enabled", async () => {
+    const logger = createLoggerStub();
+    const memoryBackend = createMemoryBackendStub();
+    const session = createSession();
+    const sessionMgr = {
+      getOrCreate: vi.fn(() => session),
+      appendMessage: vi.fn(),
+      compact: vi.fn(async () => undefined),
+    } as any;
+    const webChat = {
+      createAbortController: vi.fn(() => new AbortController()),
+      clearAbortController: vi.fn(),
+      send: vi.fn(async () => undefined),
+      pushToSession: vi.fn(),
+      broadcastEvent: vi.fn(),
+    } as any;
+    const hooks = {
+      dispatch: vi.fn(async () => ({ completed: true, payload: {} })),
+    } as any;
+    const signals = {
+      signalThinking: vi.fn(),
+      signalIdle: vi.fn(),
+    };
+    const chatExecutor = new ChatExecutor({
+      providers: [createProvider()],
+      logger,
+      llmUsageLogging: resolveLlmUsageLoggingConfig({
+        enabled: true,
+      }),
+    });
+
+    await executeWebChatConversationTurn({
+      logger,
+      msg: {
+        sessionId: "session:test",
+        senderId: "operator-1",
+        channel: "webchat",
+        content: "hello",
+      },
+      webChat,
+      chatExecutor,
+      sessionMgr,
+      getSystemPrompt: () => "system prompt",
+      sessionToolHandler: vi.fn() as any,
+      sessionStreamCallback: vi.fn(),
+      signals,
+      hooks,
+      memoryBackend,
+      sessionTokenBudget: 16_000,
+      defaultMaxToolRounds: 3,
+      contextWindowTokens: 64_000,
+      traceConfig: {
+        enabled: false,
+        includeHistory: true,
+        includeSystemPrompt: true,
+        includeToolArgs: true,
+        includeToolResults: true,
+        includeProviderPayloads: false,
+        maxChars: 20_000,
+      },
+      turnTraceId: "trace-usage-webchat",
+      buildToolRoutingDecision: () => undefined,
+      recordToolRoutingOutcome: vi.fn(),
+      getSessionTokenUsage: () => 0,
+    });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "llm.call_usage",
+      expect.objectContaining({
+        event: "llm.call_usage",
+        sessionId: "session:test",
+        traceId: "trace-usage-webchat",
+        provider: "grok",
+        phase: "initial",
+      }),
+    );
+    const payload = (logger.info as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([message]) => message === "llm.call_usage",
+    )?.[1];
+    expect(JSON.stringify(payload)).not.toContain("system prompt");
+    expect(JSON.stringify(payload)).not.toContain("reply");
   });
 });

--- a/runtime/src/gateway/daemon-webchat-turn.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.ts
@@ -294,9 +294,14 @@ export async function executeWebChatConversationTurn(
       systemPrompt: effectiveSystemPrompt,
       sessionId: msg.sessionId,
       runtimeContext:
-        typeof runtimeWorkspaceRoot === "string"
-          ? { workspaceRoot: runtimeWorkspaceRoot }
-          : undefined,
+        {
+          ...(typeof runtimeWorkspaceRoot === "string"
+            ? { workspaceRoot: runtimeWorkspaceRoot }
+            : {}),
+          identifiers: {
+            traceId: turnTraceId,
+          },
+        },
       toolHandler: sessionToolHandler,
       onStreamChunk: sessionStreamCallback,
       signal: abortController.signal,

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -56,6 +56,7 @@ import {
   createTurnTraceId,
 } from "./daemon-trace.js";
 import type { ResolvedTraceLoggingConfig } from "./daemon-trace.js";
+import { resolveLlmUsageLoggingConfig } from "../llm/usage-logging.js";
 import { WebChatChannel } from "../channels/webchat/plugin.js";
 import { WorkspaceManager } from "./workspace.js";
 import {
@@ -1483,6 +1484,7 @@ export class DaemonManager {
           requiredCapabilities,
           contextProvider,
         ),
+      llmUsageLogging: resolveLlmUsageLoggingConfig(config.logging?.llmUsage),
       traceExecution: traceConfig.enabled,
       traceProviderPayloads:
         traceConfig.enabled && traceConfig.includeProviderPayloads,
@@ -2018,6 +2020,8 @@ export class DaemonManager {
 
     this._chatExecutor = createChatExecutor({
       providers,
+      logger: this.logger,
+      llmUsageLogging: resolveLlmUsageLoggingConfig(config.logging?.llmUsage),
       toolHandler: baseToolHandler,
       allowedTools: this.getAdvertisedToolNames(),
       skillInjector,
@@ -3480,6 +3484,10 @@ export class DaemonManager {
       this._llmProviders = providers;
       this._chatExecutor = createChatExecutor({
         providers,
+        logger: this.logger,
+        llmUsageLogging: resolveLlmUsageLoggingConfig(
+          newConfig.logging?.llmUsage,
+        ),
         toolHandler: this._baseToolHandler!,
         allowedTools: this.getAdvertisedToolNames(),
         skillInjector,

--- a/runtime/src/gateway/gateway.test.ts
+++ b/runtime/src/gateway/gateway.test.ts
@@ -1101,6 +1101,28 @@ describe("config loading", () => {
     expect(result.errors).toEqual([]);
   });
 
+  it("validateGatewayConfig accepts logging.llmUsage settings", () => {
+    const result = validateGatewayConfig(
+      makeConfig({
+        logging: {
+          level: "debug",
+          llmUsage: {
+            enabled: true,
+            level: "info",
+            includeIdentifiers: true,
+            includeCallContext: true,
+            includePromptShape: false,
+            includeBudgetDiagnostics: false,
+            sampleRate: 0.5,
+          },
+        },
+      }),
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
   it("validateGatewayConfig rejects invalid logging.trace fields", () => {
     const result = validateGatewayConfig(
       makeConfig({
@@ -1128,6 +1150,34 @@ describe("config loading", () => {
     );
     expect(result.errors).toContain(
       "logging.trace.fanout.enabled must be a boolean",
+    );
+  });
+
+  it("validateGatewayConfig rejects invalid logging.llmUsage fields", () => {
+    const result = validateGatewayConfig(
+      makeConfig({
+        logging: {
+          level: "debug",
+          llmUsage: {
+            enabled: "yes" as unknown as boolean,
+            level: "warn" as unknown as "info",
+            includePromptShape: "yes" as unknown as boolean,
+            sampleRate: 2,
+          },
+        },
+      }),
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("logging.llmUsage.enabled must be a boolean");
+    expect(result.errors).toContain(
+      "logging.llmUsage.level must be one of: debug, info",
+    );
+    expect(result.errors).toContain(
+      "logging.llmUsage.includePromptShape must be a boolean",
+    );
+    expect(result.errors).toContain(
+      "logging.llmUsage.sampleRate must be a number between 0 and 1",
     );
   });
 
@@ -1628,6 +1678,22 @@ describe("config loading", () => {
     expect(diff.safe).toContain("logging.level");
     expect(diff.safe).toContain("logging.trace.enabled");
     expect(diff.unsafe).toContain("gateway.port");
+  });
+
+  it("diffGatewayConfig treats logging.llmUsage fields as safe", () => {
+    const oldConfig = makeConfig();
+    const newConfig = makeConfig({
+      logging: {
+        llmUsage: {
+          enabled: true,
+        },
+      },
+    });
+
+    const diff = diffGatewayConfig(oldConfig, newConfig);
+
+    expect(diff.safe).toContain("logging.llmUsage.enabled");
+    expect(diff.unsafe).toEqual(expect.not.arrayContaining(["logging.llmUsage.enabled"]));
   });
 
   it("diffGatewayConfig treats channels and plugin trust policy as restart-only", () => {

--- a/runtime/src/gateway/sub-agent.test.ts
+++ b/runtime/src/gateway/sub-agent.test.ts
@@ -21,6 +21,7 @@ import type {
 import type { Tool, ToolResult } from "../tools/types.js";
 import { ToolRegistry } from "../tools/registry.js";
 import { RuntimeErrorCodes } from "../types/errors.js";
+import { resolveLlmUsageLoggingConfig } from "../llm/usage-logging.js";
 
 // ============================================================================
 // Helpers
@@ -309,6 +310,38 @@ describe("SubAgentManager", () => {
       } finally {
         executeSpy.mockRestore();
       }
+    });
+
+    it("emits llm.call_usage logs for sub-agent executions when enabled", async () => {
+      const logger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        setLevel: vi.fn(),
+      } as any;
+      const manager = new SubAgentManager(
+        makeManagerConfig({
+          logger,
+          llmUsageLogging: resolveLlmUsageLoggingConfig({
+            enabled: true,
+          }),
+        }),
+      );
+
+      await manager.spawn({ parentSessionId: "parent-1", task: "log usage" });
+      await settle();
+
+      expect(logger.info).toHaveBeenCalledWith(
+        "llm.call_usage",
+        expect.objectContaining({
+          event: "llm.call_usage",
+          sessionId: expect.stringContaining("subagent:"),
+          parentSessionId: "parent-1",
+          provider: "mock-llm",
+          phase: "initial",
+        }),
+      );
     });
 
     it("forwards prompt budgeting and compaction controls to child executors", async () => {

--- a/runtime/src/gateway/sub-agent.ts
+++ b/runtime/src/gateway/sub-agent.ts
@@ -40,6 +40,7 @@ import {
   createProviderTraceEventLogger,
   logStructuredTraceEvent,
 } from "../llm/provider-trace-logger.js";
+import type { ResolvedLlmUsageLoggingConfig } from "../llm/usage-logging.js";
 import { resolveMaxToolRoundsForToolNames } from "./tool-round-budget.js";
 import {
   isRuntimeLimitExceeded,
@@ -213,6 +214,7 @@ export interface SubAgentManagerConfig {
     | undefined;
   readonly resolveDefaultMaxToolRounds?: () => number | undefined;
   readonly logger?: Logger;
+  readonly llmUsageLogging?: ResolvedLlmUsageLoggingConfig;
   readonly traceExecution?: boolean;
   readonly traceProviderPayloads?: boolean;
   readonly promptBudget?: PromptBudgetConfig;
@@ -678,6 +680,8 @@ export class SubAgentManager {
       });
       const executor = new ChatExecutor({
         providers: [selectedProvider],
+        logger: this.logger,
+        llmUsageLogging: this.config.llmUsageLogging,
         toolHandler,
         allowedTools: handle.config.tools
           ? [...handle.config.tools]
@@ -781,6 +785,12 @@ export class SubAgentManager {
           history: handle.history,
           systemPrompt,
           sessionId: handle.sessionId,
+          runtimeContext: {
+            identifiers: {
+              traceId: subAgentTraceId,
+              parentSessionId: handle.parentSessionId,
+            },
+          },
           ...(typeof effectiveToolBudgetPerRequest === "number"
             ? { toolBudgetPerRequest: effectiveToolBudgetPerRequest }
             : {}),

--- a/runtime/src/gateway/types.ts
+++ b/runtime/src/gateway/types.ts
@@ -10,6 +10,7 @@
 import type { GatewayAuthConfig } from "./remote-types.js";
 import type { BackgroundRunOperatorAvailabilityCode } from "./background-run-operator.js";
 import type { DesktopSandboxConfig } from "../desktop/types.js";
+import type { LlmUsageLoggingConfig } from "../llm/usage-logging.js";
 import type { SocialPeerDirectoryEntry } from "../social/types.js";
 
 // ============================================================================
@@ -314,6 +315,7 @@ export interface GatewayReplayConfig {
 
 export interface GatewayLoggingConfig {
   level?: "debug" | "info" | "warn" | "error";
+  llmUsage?: LlmUsageLoggingConfig;
   trace?: {
     /** Enable verbose per-turn chat/tool tracing in daemon logs. */
     enabled?: boolean;

--- a/runtime/src/gateway/voice-bridge.test.ts
+++ b/runtime/src/gateway/voice-bridge.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { ChatExecutor } from "../llm/chat-executor.js";
+import { resolveLlmUsageLoggingConfig } from "../llm/usage-logging.js";
 import {
   VoiceBridge,
   createVoiceDelegationTool,
@@ -140,6 +142,11 @@ describe("VoiceBridge delegation", () => {
       expect.objectContaining({
         sessionId: "session-1",
         systemPrompt: "You are a helpful assistant.",
+        runtimeContext: {
+          identifiers: {
+            traceId: expect.stringMatching(/^session-1:voice:/),
+          },
+        },
       }),
     );
     expect(send).toHaveBeenCalledWith(
@@ -240,6 +247,85 @@ describe("VoiceBridge delegation", () => {
         }),
       }),
     );
+  });
+
+  it("emits llm.call_usage logs for delegated voice turns when lightweight usage logging is enabled", async () => {
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      setLevel: vi.fn(),
+    };
+    const send = vi.fn();
+    const chatExecutor = new ChatExecutor({
+      providers: [
+        {
+          name: "grok",
+          chat: vi.fn(async () => ({
+            content: "voice delegation reply",
+            toolCalls: [],
+            usage: { promptTokens: 9, completionTokens: 4, totalTokens: 13 },
+            model: "grok-voice-test",
+            finishReason: "stop",
+          })),
+          chatStream: vi.fn(async () => ({
+            content: "voice delegation reply",
+            toolCalls: [],
+            usage: { promptTokens: 9, completionTokens: 4, totalTokens: 13 },
+            model: "grok-voice-test",
+            finishReason: "stop",
+          })),
+          healthCheck: vi.fn(async () => true),
+        },
+      ],
+      logger: logger as any,
+      llmUsageLogging: resolveLlmUsageLoggingConfig({
+        enabled: true,
+      }),
+    });
+    const bridge = new VoiceBridge({
+      apiKey: "voice-key",
+      toolHandler: vi.fn(async () => ""),
+      systemPrompt: "You are a helpful assistant.",
+      getChatExecutor: () => chatExecutor,
+      logger: logger as any,
+    });
+
+    (bridge as any).sessions.set("client-1", {
+      client: { cancelResponse: vi.fn(), clearAudio: vi.fn() } as any,
+      send,
+      toolHandler: vi.fn(async () => ""),
+      sessionId: "session-1",
+      managedSessionId: "session-1",
+      delegationAbort: null,
+      currentTraceId: null,
+      currentTurnDelegated: false,
+    });
+
+    await (bridge as any).handleDelegation(
+      "client-1",
+      "session-1",
+      JSON.stringify({ task: "Inspect the workspace" }),
+      send,
+    );
+
+    expect(logger.info).toHaveBeenCalledWith(
+      "llm.call_usage",
+      expect.objectContaining({
+        event: "llm.call_usage",
+        sessionId: "session-1",
+        traceId: expect.stringMatching(/^session-1:voice:/),
+        provider: "grok",
+        phase: "initial",
+      }),
+    );
+    const payload = (logger.info as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([message]) => message === "llm.call_usage",
+    )?.[1];
+    expect(JSON.stringify(payload)).not.toContain("You are a helpful assistant.");
+    expect(JSON.stringify(payload)).not.toContain("Inspect the workspace");
+    expect(JSON.stringify(payload)).not.toContain("voice delegation reply");
   });
 
   it("uses one trace for voice inbound, delegated tool calls, and the final response", async () => {

--- a/runtime/src/gateway/voice-bridge.ts
+++ b/runtime/src/gateway/voice-bridge.ts
@@ -731,6 +731,11 @@ export class VoiceBridge {
         history,
         systemPrompt: this.config.systemPrompt,
         sessionId,
+        runtimeContext: {
+          identifiers: {
+            traceId,
+          },
+        },
         toolHandler: delegationToolHandler,
         // No onStreamChunk — streaming LLM text to the voice overlay floods
         // it with hundreds of words the user can't read. Tool cards in the

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -69,6 +69,11 @@ import type {
   DelegationBanditSelection,
   DelegationTrajectorySink,
 } from "./delegation-learning.js";
+import type { Logger } from "../utils/logger.js";
+import type {
+  ChatRuntimeIdentifiers,
+  ResolvedLlmUsageLoggingConfig,
+} from "./usage-logging.js";
 import { deriveDelegationContextClusterId } from "./delegation-learning.js";
 import { RuntimeError, RuntimeErrorCodes } from "../types/errors.js";
 
@@ -165,6 +170,8 @@ export interface ChatExecuteParams {
   readonly runtimeContext?: {
     /** Authoritative workspace root for planning/execution when known. */
     readonly workspaceRoot?: string;
+    /** Stable runtime identifiers safe for lightweight observability. */
+    readonly identifiers?: ChatRuntimeIdentifiers;
   };
   /** Per-call tool handler — overrides the constructor handler for this call. */
   readonly toolHandler?: ToolHandler;
@@ -393,6 +400,10 @@ export interface ToolFailureCircuitBreakerConfig {
 export interface ChatExecutorConfig {
   /** Ordered providers — first is primary, rest are fallbacks. */
   readonly providers: readonly LLMProvider[];
+  /** Optional runtime logger for operational events. */
+  readonly logger?: Logger;
+  /** Optional per-call LLM usage logging policy. */
+  readonly llmUsageLogging?: ResolvedLlmUsageLoggingConfig;
   readonly toolHandler?: ToolHandler;
   readonly maxToolRounds?: number;
   readonly onStreamChunk?: StreamProgressCallback;
@@ -766,6 +777,7 @@ export interface ExecutionContext {
   readonly systemPrompt: string;
   readonly sessionId: string;
   readonly runtimeWorkspaceRoot?: string;
+  readonly runtimeIdentifiers?: ChatRuntimeIdentifiers;
   readonly signal?: AbortSignal;
   readonly activeToolHandler?: ToolHandler;
   readonly activeStreamCallback?: StreamProgressCallback;
@@ -902,6 +914,7 @@ export function buildDefaultExecutionContext(
     systemPrompt: params.systemPrompt,
     sessionId: params.sessionId,
     runtimeWorkspaceRoot: params.runtimeContext?.workspaceRoot,
+    runtimeIdentifiers: params.runtimeContext?.identifiers,
     signal: params.signal,
     activeToolHandler: params.toolHandler,
     activeStreamCallback: params.streamCallback,

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -19,6 +19,8 @@ import {
 } from "./errors.js";
 import { inferExplicitFileWriteTarget } from "./chat-executor-planner-execution.js";
 import type { ArtifactCompactionState } from "../memory/artifact-store.js";
+import type { Logger } from "../utils/logger.js";
+import { resolveLlmUsageLoggingConfig } from "./usage-logging.js";
 
 // ============================================================================
 // Test helpers
@@ -78,6 +80,16 @@ function createParams(
     systemPrompt: "You are a helpful assistant.",
     sessionId: "session-1",
     ...overrides,
+  };
+}
+
+function createLoggerStub(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    setLevel: vi.fn(),
   };
 }
 
@@ -18597,6 +18609,241 @@ describe("ChatExecutor", () => {
       expect(result.statefulSummary).toBeDefined();
       expect(result.statefulSummary?.fallbackReasons.store_disabled).toBe(1);
       expect(result.statefulSummary?.attemptedCalls).toBe(0);
+    });
+  });
+
+  describe("llm usage logging", () => {
+    it("emits one structured usage log for an initial call with bounded metadata", async () => {
+      const logger = createLoggerStub();
+      const provider = createMockProvider();
+      const executor = new ChatExecutor({
+        providers: [provider],
+        logger,
+        llmUsageLogging: resolveLlmUsageLoggingConfig({
+          enabled: true,
+          includePromptShape: true,
+          includeBudgetDiagnostics: true,
+        }),
+      });
+
+      await executor.execute(
+        createParams({
+          runtimeContext: {
+            identifiers: {
+              traceId: "trace-1",
+              runId: "run-1",
+              taskId: "task-1",
+              parentSessionId: "parent-1",
+            },
+          },
+        }),
+      );
+
+      expect(logger.info).toHaveBeenCalledTimes(1);
+      expect(logger.info).toHaveBeenCalledWith(
+        "llm.call_usage",
+        expect.objectContaining({
+          event: "llm.call_usage",
+          sessionId: "session-1",
+          traceId: "trace-1",
+          runId: "run-1",
+          taskId: "task-1",
+          parentSessionId: "parent-1",
+          callIndex: 1,
+          phase: "initial",
+          provider: "primary",
+          model: "mock-model",
+          usageAvailable: true,
+          promptTokens: 10,
+          completionTokens: 5,
+          totalTokens: 15,
+          durationMs: expect.any(Number),
+          finishReason: "stop",
+          usedFallback: false,
+          rerouted: false,
+          downgraded: false,
+          promptShape: expect.any(Object),
+          budgetDiagnostics: expect.any(Object),
+        }),
+      );
+
+      const payload = (logger.info as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      const serialized = JSON.stringify(payload);
+      expect(payload).not.toHaveProperty("prompt");
+      expect(payload).not.toHaveProperty("response");
+      expect(payload).not.toHaveProperty("messages");
+      expect(payload).not.toHaveProperty("toolArgs");
+      expect(payload).not.toHaveProperty("toolResults");
+      expect(payload).not.toHaveProperty("providerPayload");
+      expect(serialized).not.toContain("You are a helpful assistant.");
+      expect(serialized).not.toContain("hello");
+      expect(serialized).not.toContain("mock response");
+      expect(serialized).not.toContain("toolCalls");
+    });
+
+    it("does not emit when disabled or sampled out", async () => {
+      const logger = createLoggerStub();
+      const disabledExecutor = new ChatExecutor({
+        providers: [createMockProvider()],
+        logger,
+      });
+
+      await disabledExecutor.execute(createParams());
+
+      expect(logger.info).not.toHaveBeenCalled();
+      expect(logger.debug).not.toHaveBeenCalled();
+
+      const sampledExecutor = new ChatExecutor({
+        providers: [createMockProvider()],
+        logger,
+        llmUsageLogging: resolveLlmUsageLoggingConfig({
+          enabled: true,
+          sampleRate: 0,
+        }),
+      });
+
+      await sampledExecutor.execute(createParams());
+
+      expect(logger.info).not.toHaveBeenCalled();
+      expect(logger.debug).not.toHaveBeenCalled();
+    });
+
+    it("respects debug level and optional field gates", async () => {
+      const logger = createLoggerStub();
+      const executor = new ChatExecutor({
+        providers: [createMockProvider()],
+        logger,
+        llmUsageLogging: resolveLlmUsageLoggingConfig({
+          enabled: true,
+          level: "debug",
+          includeIdentifiers: false,
+          includeCallContext: false,
+          includePromptShape: false,
+          includeBudgetDiagnostics: false,
+        }),
+      });
+
+      await executor.execute(
+        createParams({
+          runtimeContext: {
+            identifiers: {
+              traceId: "trace-2",
+            },
+          },
+        }),
+      );
+
+      expect(logger.debug).toHaveBeenCalledTimes(1);
+      const payload = (logger.debug as ReturnType<typeof vi.fn>).mock.calls[0][1];
+      expect(payload).toMatchObject({
+        event: "llm.call_usage",
+        provider: "primary",
+        usageAvailable: true,
+      });
+      expect(payload).not.toHaveProperty("sessionId");
+      expect(payload).not.toHaveProperty("traceId");
+      expect(payload).not.toHaveProperty("callIndex");
+      expect(payload).not.toHaveProperty("phase");
+      expect(payload).not.toHaveProperty("usedFallback");
+      expect(payload).not.toHaveProperty("promptShape");
+      expect(payload).not.toHaveProperty("budgetDiagnostics");
+    });
+
+    it("marks fallback and missing usage consistently", async () => {
+      const logger = createLoggerStub();
+      const primary = createMockProvider("primary", {
+        chat: vi.fn(async () => {
+          throw new LLMServerError("primary", 500, "primary failed");
+        }),
+      });
+      const secondary = createMockProvider("secondary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            usage: {
+              promptTokens: 0,
+              completionTokens: 0,
+              totalTokens: 0,
+            },
+          }),
+        ),
+      });
+      const executor = new ChatExecutor({
+        providers: [primary, secondary],
+        logger,
+        llmUsageLogging: resolveLlmUsageLoggingConfig({
+          enabled: true,
+        }),
+      });
+
+      await executor.execute(createParams());
+
+      expect(logger.info).toHaveBeenCalledTimes(1);
+      expect(logger.info).toHaveBeenCalledWith(
+        "llm.call_usage",
+        expect.objectContaining({
+          provider: "secondary",
+          usageAvailable: false,
+          promptTokens: 0,
+          completionTokens: 0,
+          totalTokens: 0,
+          usedFallback: true,
+          rerouted: true,
+          downgraded: false,
+        }),
+      );
+    });
+
+    it("emits evaluator and evaluator_retry phases in call order", async () => {
+      const logger = createLoggerStub();
+      const provider = createMockProvider("primary", {
+        chat: vi.fn()
+          .mockResolvedValueOnce(
+            mockResponse({ content: "initial draft" }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: JSON.stringify({
+                score: 0.2,
+                feedback: "Needs more detail",
+              }),
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({ content: "revised draft" }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: JSON.stringify({
+                score: 1,
+                feedback: "Looks good",
+              }),
+            }),
+          ),
+      });
+      const executor = new ChatExecutor({
+        providers: [provider],
+        logger,
+        llmUsageLogging: resolveLlmUsageLoggingConfig({
+          enabled: true,
+        }),
+        evaluator: {
+          minScore: 0.7,
+          maxRetries: 1,
+        },
+      });
+
+      await executor.execute(createParams());
+
+      const payloads = (logger.info as ReturnType<typeof vi.fn>).mock.calls.map(
+        ([, payload]) => payload as { phase?: string; callIndex?: number },
+      );
+      expect(payloads.map((payload) => payload.phase)).toEqual([
+        "initial",
+        "evaluator",
+        "evaluator_retry",
+        "evaluator",
+      ]);
+      expect(payloads.map((payload) => payload.callIndex)).toEqual([1, 2, 3, 4]);
     });
   });
 });

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -145,6 +145,14 @@ import {
 import { ToolFailureCircuitBreaker } from "./tool-failure-circuit-breaker.js";
 import { compactHistoryIntoArtifactContext } from "./context-compaction.js";
 import { selectRelevantArtifactRefs } from "./context-pruning.js";
+import {
+  buildLlmCallUsageLogPayload,
+  emitLlmCallUsageLog,
+  resolveLlmUsageLoggingConfig,
+  shouldEmitLlmUsageLog,
+  type ResolvedLlmUsageLoggingConfig,
+} from "./usage-logging.js";
+import type { Logger } from "../utils/logger.js";
 
 function shouldUseSessionStatefulContinuationForPhase(
   phase: ChatCallUsageRecord["phase"],
@@ -342,6 +350,8 @@ export type {
  */
 export class ChatExecutor {
   private readonly providers: readonly LLMProvider[];
+  private readonly logger?: Logger;
+  private readonly llmUsageLogging: ResolvedLlmUsageLoggingConfig;
   private readonly toolHandler?: ToolHandler;
   private readonly maxToolRounds: number;
   private readonly onStreamChunk?: StreamProgressCallback;
@@ -393,6 +403,9 @@ export class ChatExecutor {
       throw new Error("ChatExecutor requires at least one provider");
     }
     this.providers = config.providers;
+    this.logger = config.logger;
+    this.llmUsageLogging = config.llmUsageLogging ??
+      resolveLlmUsageLoggingConfig();
     this.toolHandler = config.toolHandler;
     this.maxToolRounds = normalizeRuntimeLimit(
       config.maxToolRounds,
@@ -1754,18 +1767,19 @@ export class ChatExecutor {
       this.economicsPolicy,
       ctx.economicsState,
     );
-    ctx.callUsage.push(
-      this.createCallUsageRecord({
-        callIndex: ++ctx.callIndex,
-        phase: input.phase,
-        providerName: next.providerName,
-        response: next.response,
-        durationMs: next.durationMs,
-        beforeBudget: next.beforeBudget,
-        afterBudget: next.afterBudget,
-        budgetDiagnostics: next.budgetDiagnostics,
-      }),
-    );
+    this.appendCallUsageRecord(ctx, {
+      callIndex: ++ctx.callIndex,
+      phase: input.phase,
+      providerName: next.providerName,
+      response: next.response,
+      durationMs: next.durationMs,
+      beforeBudget: next.beforeBudget,
+      afterBudget: next.afterBudget,
+      budgetDiagnostics: next.budgetDiagnostics,
+      usedFallback: next.usedFallback,
+      rerouted: routingDecision.route.rerouted || next.usedFallback,
+      downgraded: routingDecision.route.downgraded,
+    });
     return next.response;
   }
 
@@ -2220,18 +2234,19 @@ export class ChatExecutor {
         this.economicsPolicy,
         ctx.economicsState,
       );
-      ctx.callUsage.push(
-        this.createCallUsageRecord({
-          callIndex: ++ctx.callIndex,
-          phase: "evaluator",
-          providerName: evalResult.providerName,
-          response: evalResult.response,
-          durationMs: evalResult.durationMs,
-          beforeBudget: evalResult.beforeBudget,
-          afterBudget: evalResult.afterBudget,
-          budgetDiagnostics: evalResult.budgetDiagnostics,
-        }),
-      );
+      this.appendCallUsageRecord(ctx, {
+        callIndex: ++ctx.callIndex,
+        phase: "evaluator",
+        providerName: evalResult.providerName,
+        response: evalResult.response,
+        durationMs: evalResult.durationMs,
+        beforeBudget: evalResult.beforeBudget,
+        afterBudget: evalResult.afterBudget,
+        budgetDiagnostics: evalResult.budgetDiagnostics,
+        usedFallback: evalResult.usedFallback,
+        rerouted: evalResult.rerouted,
+        downgraded: evalResult.downgraded,
+      });
 
       if (evalResult.score >= minScore || retryCount === maxRetries) {
         ctx.evaluation = {
@@ -2326,18 +2341,19 @@ export class ChatExecutor {
         this.economicsPolicy,
         ctx.economicsState,
       );
-      ctx.callUsage.push(
-        this.createCallUsageRecord({
-          callIndex: ++ctx.callIndex,
-          phase: "evaluator_retry",
-          providerName: retry.providerName,
-          response: retry.response,
-          durationMs: retry.durationMs,
-          beforeBudget: retry.beforeBudget,
-          afterBudget: retry.afterBudget,
-          budgetDiagnostics: retry.budgetDiagnostics,
-        }),
-      );
+      this.appendCallUsageRecord(ctx, {
+        callIndex: ++ctx.callIndex,
+        phase: "evaluator_retry",
+        providerName: retry.providerName,
+        response: retry.response,
+        durationMs: retry.durationMs,
+        beforeBudget: retry.beforeBudget,
+        afterBudget: retry.afterBudget,
+        budgetDiagnostics: retry.budgetDiagnostics,
+        usedFallback: retry.usedFallback,
+        rerouted: retryRoutingDecision.route.rerouted || retry.usedFallback,
+        downgraded: retryRoutingDecision.route.downgraded,
+      });
       ctx.providerName = retry.providerName;
       ctx.responseModel = retry.response.model;
       if (retry.usedFallback) ctx.usedFallback = true;
@@ -2640,6 +2656,73 @@ export class ChatExecutor {
       statefulDiagnostics: input.response.stateful,
       compactionDiagnostics: input.response.compaction,
     };
+  }
+
+  private appendCallUsageRecord(
+    ctx: ExecutionContext,
+    input: {
+      callIndex: number;
+      phase: ChatCallUsageRecord["phase"];
+      providerName: string;
+      response: LLMResponse;
+      beforeBudget: ChatPromptShape;
+      afterBudget: ChatPromptShape;
+      budgetDiagnostics?: PromptBudgetDiagnostics;
+      durationMs: number;
+      usedFallback: boolean;
+      rerouted: boolean;
+      downgraded: boolean;
+    },
+  ): void {
+    const record = this.createCallUsageRecord({
+      callIndex: input.callIndex,
+      phase: input.phase,
+      providerName: input.providerName,
+      response: input.response,
+      beforeBudget: input.beforeBudget,
+      afterBudget: input.afterBudget,
+      budgetDiagnostics: input.budgetDiagnostics,
+      durationMs: input.durationMs,
+    });
+    ctx.callUsage.push(record);
+    this.maybeLogCallUsageRecord(ctx, record, {
+      usedFallback: input.usedFallback,
+      rerouted: input.rerouted,
+      downgraded: input.downgraded,
+    });
+  }
+
+  private maybeLogCallUsageRecord(
+    ctx: ExecutionContext,
+    record: ChatCallUsageRecord,
+    input: {
+      usedFallback: boolean;
+      rerouted: boolean;
+      downgraded: boolean;
+    },
+  ): void {
+    if (!this.logger || !this.llmUsageLogging.enabled) {
+      return;
+    }
+    const sampleKey =
+      ctx.runtimeIdentifiers?.traceId ??
+      `${ctx.trajectoryTraceId}:${record.callIndex}`;
+    if (!shouldEmitLlmUsageLog(this.llmUsageLogging, sampleKey)) {
+      return;
+    }
+    emitLlmCallUsageLog({
+      logger: this.logger,
+      config: this.llmUsageLogging,
+      payload: buildLlmCallUsageLogPayload({
+        sessionId: ctx.sessionId,
+        identifiers: ctx.runtimeIdentifiers,
+        record,
+        usedFallback: input.usedFallback,
+        rerouted: input.rerouted,
+        downgraded: input.downgraded,
+        config: this.llmUsageLogging,
+      }),
+    });
   }
 
   // --------------------------------------------------------------------------

--- a/runtime/src/llm/usage-logging.test.ts
+++ b/runtime/src/llm/usage-logging.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLlmCallUsageLogPayload,
+  resolveLlmUsageLoggingConfig,
+  shouldEmitLlmUsageLog,
+} from "./usage-logging.js";
+
+const baseRecord = {
+  callIndex: 2,
+  phase: "tool_followup",
+  provider: "grok",
+  model: "grok-4-fast",
+  finishReason: "stop",
+  usage: {
+    promptTokens: 2410,
+    completionTokens: 311,
+    totalTokens: 2721,
+  },
+  durationMs: 1842,
+  beforeBudget: {
+    messageCount: 8,
+    systemMessages: 2,
+    userMessages: 2,
+    assistantMessages: 2,
+    toolMessages: 2,
+    estimatedChars: 9_500,
+    systemPromptChars: 2_000,
+  },
+  afterBudget: {
+    messageCount: 8,
+    systemMessages: 2,
+    userMessages: 2,
+    assistantMessages: 2,
+    toolMessages: 2,
+    estimatedChars: 8_900,
+    systemPromptChars: 2_000,
+  },
+  budgetDiagnostics: {
+    constrained: true,
+    totalBeforeChars: 10_000,
+    totalAfterChars: 9_000,
+    droppedSections: ["history"],
+    sections: {
+      history: {
+        droppedMessages: 3,
+        truncatedMessages: 1,
+      },
+      tools: {
+        droppedMessages: 0,
+        truncatedMessages: 0,
+      },
+    },
+  },
+};
+
+describe("resolveLlmUsageLoggingConfig", () => {
+  it("returns disabled defaults when config is missing", () => {
+    expect(resolveLlmUsageLoggingConfig()).toEqual({
+      enabled: false,
+      level: "info",
+      includeIdentifiers: true,
+      includeCallContext: true,
+      includePromptShape: false,
+      includeBudgetDiagnostics: false,
+      sampleRate: 1,
+    });
+  });
+
+  it("applies configured values and clamps sampleRate", () => {
+    expect(
+      resolveLlmUsageLoggingConfig({
+        enabled: true,
+        level: "debug",
+        includeIdentifiers: false,
+        includeCallContext: false,
+        includePromptShape: true,
+        includeBudgetDiagnostics: true,
+        sampleRate: 9,
+      }),
+    ).toEqual({
+      enabled: true,
+      level: "debug",
+      includeIdentifiers: false,
+      includeCallContext: false,
+      includePromptShape: true,
+      includeBudgetDiagnostics: true,
+      sampleRate: 1,
+    });
+  });
+});
+
+describe("shouldEmitLlmUsageLog", () => {
+  it("uses deterministic sampling for the same key", () => {
+    const config = resolveLlmUsageLoggingConfig({
+      enabled: true,
+      sampleRate: 0.5,
+    });
+
+    expect(shouldEmitLlmUsageLog(config, "trace-1")).toBe(
+      shouldEmitLlmUsageLog(config, "trace-1"),
+    );
+  });
+
+  it("short-circuits for disabled and zero-sample configs", () => {
+    expect(
+      shouldEmitLlmUsageLog(resolveLlmUsageLoggingConfig(), "trace-1"),
+    ).toBe(false);
+    expect(
+      shouldEmitLlmUsageLog(
+        resolveLlmUsageLoggingConfig({ enabled: true, sampleRate: 0 }),
+        "trace-1",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("buildLlmCallUsageLogPayload", () => {
+  it("includes only bounded metadata selected by config", () => {
+    const payload = buildLlmCallUsageLogPayload({
+      sessionId: "session-1",
+      identifiers: {
+        traceId: "trace-1",
+        runId: "run-1",
+        taskId: "task-1",
+        parentSessionId: "parent-1",
+      },
+      record: baseRecord,
+      usedFallback: false,
+      rerouted: true,
+      downgraded: false,
+      config: resolveLlmUsageLoggingConfig({
+        enabled: true,
+        includeIdentifiers: true,
+        includeCallContext: true,
+        includePromptShape: true,
+        includeBudgetDiagnostics: true,
+      }),
+    });
+
+    expect(payload).toMatchObject({
+      event: "llm.call_usage",
+      sessionId: "session-1",
+      traceId: "trace-1",
+      runId: "run-1",
+      taskId: "task-1",
+      parentSessionId: "parent-1",
+      callIndex: 2,
+      phase: "tool_followup",
+      provider: "grok",
+      model: "grok-4-fast",
+      promptTokens: 2410,
+      completionTokens: 311,
+      totalTokens: 2721,
+      durationMs: 1842,
+      finishReason: "stop",
+      usedFallback: false,
+      rerouted: true,
+      downgraded: false,
+    });
+    expect(payload).toHaveProperty("promptShape");
+    expect(payload).toHaveProperty("budgetDiagnostics");
+  });
+
+  it("suppresses optional fields when disabled and reports missing usage", () => {
+    const payload = buildLlmCallUsageLogPayload({
+      sessionId: "session-2",
+      identifiers: {
+        traceId: "trace-2",
+      },
+      record: {
+        ...baseRecord,
+        usage: {
+          promptTokens: 0,
+          completionTokens: 0,
+          totalTokens: 0,
+        },
+      },
+      usedFallback: true,
+      rerouted: true,
+      downgraded: true,
+      config: resolveLlmUsageLoggingConfig({
+        enabled: true,
+        includeIdentifiers: false,
+        includeCallContext: false,
+        includePromptShape: false,
+        includeBudgetDiagnostics: false,
+      }),
+    });
+
+    expect(payload).toMatchObject({
+      event: "llm.call_usage",
+      provider: "grok",
+      usageAvailable: false,
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+    });
+    expect(payload).not.toHaveProperty("sessionId");
+    expect(payload).not.toHaveProperty("traceId");
+    expect(payload).not.toHaveProperty("callIndex");
+    expect(payload).not.toHaveProperty("promptShape");
+    expect(payload).not.toHaveProperty("budgetDiagnostics");
+  });
+});

--- a/runtime/src/llm/usage-logging.ts
+++ b/runtime/src/llm/usage-logging.ts
@@ -1,0 +1,260 @@
+import { createHash } from "node:crypto";
+import type { Logger } from "../utils/logger.js";
+
+export interface LlmUsageLoggingConfig {
+  readonly enabled?: boolean;
+  readonly level?: "debug" | "info";
+  readonly includeIdentifiers?: boolean;
+  readonly includeCallContext?: boolean;
+  readonly includePromptShape?: boolean;
+  readonly includeBudgetDiagnostics?: boolean;
+  readonly sampleRate?: number;
+}
+
+export interface ResolvedLlmUsageLoggingConfig {
+  readonly enabled: boolean;
+  readonly level: "debug" | "info";
+  readonly includeIdentifiers: boolean;
+  readonly includeCallContext: boolean;
+  readonly includePromptShape: boolean;
+  readonly includeBudgetDiagnostics: boolean;
+  readonly sampleRate: number;
+}
+
+export interface ChatRuntimeIdentifiers {
+  readonly traceId?: string;
+  readonly runId?: string;
+  readonly taskId?: string;
+  readonly parentSessionId?: string;
+}
+
+interface UsageLike {
+  readonly promptTokens: number;
+  readonly completionTokens: number;
+  readonly totalTokens: number;
+}
+
+interface PromptShapeLike {
+  readonly messageCount: number;
+  readonly systemMessages: number;
+  readonly userMessages: number;
+  readonly assistantMessages: number;
+  readonly toolMessages: number;
+  readonly estimatedChars: number;
+  readonly systemPromptChars: number;
+}
+
+interface PromptBudgetSectionStatsLike {
+  readonly droppedMessages: number;
+  readonly truncatedMessages: number;
+}
+
+interface PromptBudgetDiagnosticsLike {
+  readonly constrained: boolean;
+  readonly totalBeforeChars: number;
+  readonly totalAfterChars: number;
+  readonly droppedSections: readonly string[];
+  readonly sections: Record<string, PromptBudgetSectionStatsLike>;
+}
+
+export interface LlmCallUsageRecordLike {
+  readonly callIndex: number;
+  readonly phase: string;
+  readonly provider: string;
+  readonly model?: string;
+  readonly finishReason: string;
+  readonly usage: UsageLike;
+  readonly durationMs: number;
+  readonly beforeBudget: PromptShapeLike;
+  readonly afterBudget: PromptShapeLike;
+  readonly budgetDiagnostics?: PromptBudgetDiagnosticsLike;
+}
+
+export const DEFAULT_LLM_USAGE_LOGGING_CONFIG: ResolvedLlmUsageLoggingConfig = {
+  enabled: false,
+  level: "info",
+  includeIdentifiers: true,
+  includeCallContext: true,
+  includePromptShape: false,
+  includeBudgetDiagnostics: false,
+  sampleRate: 1,
+};
+
+function normalizeSampleRate(sampleRate: number | undefined): number {
+  if (sampleRate === undefined || Number.isNaN(sampleRate)) {
+    return DEFAULT_LLM_USAGE_LOGGING_CONFIG.sampleRate;
+  }
+  if (sampleRate <= 0) return 0;
+  if (sampleRate >= 1) return 1;
+  return sampleRate;
+}
+
+function hashHex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function deterministicSample(key: string, sampleRate: number): boolean {
+  if (sampleRate >= 1) return true;
+  if (sampleRate <= 0) return false;
+  const value = Number.parseInt(hashHex(key).slice(0, 8), 16);
+  return value / 0xffff_ffff < sampleRate;
+}
+
+function normalizeUsageCount(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.floor(value));
+}
+
+function trimOptionalString(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function summarizePromptShape(shape: PromptShapeLike): Record<string, number> {
+  return {
+    messageCount: shape.messageCount,
+    systemMessages: shape.systemMessages,
+    userMessages: shape.userMessages,
+    assistantMessages: shape.assistantMessages,
+    toolMessages: shape.toolMessages,
+    estimatedChars: shape.estimatedChars,
+    systemPromptChars: shape.systemPromptChars,
+  };
+}
+
+function summarizeBudgetDiagnostics(
+  diagnostics: PromptBudgetDiagnosticsLike,
+): Record<string, unknown> {
+  let droppedMessages = 0;
+  let truncatedMessages = 0;
+  for (const stats of Object.values(diagnostics.sections)) {
+    droppedMessages += stats.droppedMessages;
+    truncatedMessages += stats.truncatedMessages;
+  }
+  return {
+    constrained: diagnostics.constrained,
+    totalBeforeChars: diagnostics.totalBeforeChars,
+    totalAfterChars: diagnostics.totalAfterChars,
+    droppedSections: [...diagnostics.droppedSections],
+    droppedMessages,
+    truncatedMessages,
+  };
+}
+
+export function resolveLlmUsageLoggingConfig(
+  config?: LlmUsageLoggingConfig,
+): ResolvedLlmUsageLoggingConfig {
+  if (!config?.enabled) {
+    return DEFAULT_LLM_USAGE_LOGGING_CONFIG;
+  }
+  return {
+    enabled: true,
+    level: config.level ?? DEFAULT_LLM_USAGE_LOGGING_CONFIG.level,
+    includeIdentifiers:
+      config.includeIdentifiers ??
+      DEFAULT_LLM_USAGE_LOGGING_CONFIG.includeIdentifiers,
+    includeCallContext:
+      config.includeCallContext ??
+      DEFAULT_LLM_USAGE_LOGGING_CONFIG.includeCallContext,
+    includePromptShape:
+      config.includePromptShape ??
+      DEFAULT_LLM_USAGE_LOGGING_CONFIG.includePromptShape,
+    includeBudgetDiagnostics:
+      config.includeBudgetDiagnostics ??
+      DEFAULT_LLM_USAGE_LOGGING_CONFIG.includeBudgetDiagnostics,
+    sampleRate: normalizeSampleRate(config.sampleRate),
+  };
+}
+
+export function usageMetadataAvailable(usage: UsageLike): boolean {
+  return (
+    normalizeUsageCount(usage.promptTokens) > 0 ||
+    normalizeUsageCount(usage.completionTokens) > 0 ||
+    normalizeUsageCount(usage.totalTokens) > 0
+  );
+}
+
+export function shouldEmitLlmUsageLog(
+  config: ResolvedLlmUsageLoggingConfig,
+  sampleKey: string,
+): boolean {
+  if (!config.enabled) return false;
+  return deterministicSample(sampleKey, config.sampleRate);
+}
+
+export function buildLlmCallUsageLogPayload(params: {
+  readonly sessionId: string;
+  readonly identifiers?: ChatRuntimeIdentifiers;
+  readonly record: LlmCallUsageRecordLike;
+  readonly usedFallback: boolean;
+  readonly rerouted: boolean;
+  readonly downgraded: boolean;
+  readonly config: ResolvedLlmUsageLoggingConfig;
+}): Record<string, unknown> {
+  const { sessionId, identifiers, record, usedFallback, rerouted, downgraded, config } = params;
+  const usage = {
+    promptTokens: normalizeUsageCount(record.usage.promptTokens),
+    completionTokens: normalizeUsageCount(record.usage.completionTokens),
+    totalTokens: normalizeUsageCount(record.usage.totalTokens),
+  };
+  const payload: Record<string, unknown> = {
+    event: "llm.call_usage",
+    provider: record.provider,
+    model: trimOptionalString(record.model) ?? null,
+    usageAvailable: usageMetadataAvailable(record.usage),
+    promptTokens: usage.promptTokens,
+    completionTokens: usage.completionTokens,
+    totalTokens: usage.totalTokens,
+    durationMs: record.durationMs,
+    finishReason: record.finishReason,
+  };
+
+  if (config.includeIdentifiers) {
+    payload.sessionId = sessionId;
+    const traceId = trimOptionalString(identifiers?.traceId);
+    const runId = trimOptionalString(identifiers?.runId);
+    const taskId = trimOptionalString(identifiers?.taskId);
+    const parentSessionId = trimOptionalString(identifiers?.parentSessionId);
+    if (traceId) payload.traceId = traceId;
+    if (runId) payload.runId = runId;
+    if (taskId) payload.taskId = taskId;
+    if (parentSessionId) payload.parentSessionId = parentSessionId;
+  }
+
+  if (config.includeCallContext) {
+    payload.callIndex = record.callIndex;
+    payload.phase = record.phase;
+    payload.usedFallback = usedFallback;
+    payload.rerouted = rerouted;
+    payload.downgraded = downgraded;
+  }
+
+  if (config.includePromptShape) {
+    payload.promptShape = {
+      before: summarizePromptShape(record.beforeBudget),
+      after: summarizePromptShape(record.afterBudget),
+    };
+  }
+
+  if (config.includeBudgetDiagnostics && record.budgetDiagnostics) {
+    payload.budgetDiagnostics = summarizeBudgetDiagnostics(
+      record.budgetDiagnostics,
+    );
+  }
+
+  return payload;
+}
+
+export function emitLlmCallUsageLog(params: {
+  readonly logger: Logger;
+  readonly config: ResolvedLlmUsageLoggingConfig;
+  readonly payload: Record<string, unknown>;
+}): void {
+  const { logger, config, payload } = params;
+  if (config.level === "debug") {
+    logger.debug("llm.call_usage", payload);
+    return;
+  }
+  logger.info("llm.call_usage", payload);
+}


### PR DESCRIPTION
## Summary

Adds lightweight per-call LLM usage logging so the runtime can emit structured `llm.call_usage` events across the main chat execution paths. Covers text-channel turns, webchat turns, and background actor cycles, and threads trace-related identifiers through runtime context so usage events can be correlated cleanly.

Closes #48

## What Changed

- Added `llmUsageLogging` and runtime `logger` support to chat executor construction, including the factory path and daemon-managed executor initialization and reload flows.
- Added validation for `logging.llmUsage` config fields: `enabled`, `includeIdentifiers`, `includeCallContext`, `includePromptShape`, `includeBudgetDiagnostics`, `level`, and `sampleRate`.
- Updated text and webchat turn execution to pass `traceId` through `runtimeContext.identifiers` so emitted usage logs can be tied back to the active turn.
- Updated background run supervision to reuse a stable actor trace ID and include `traceId` plus `runId` in runtime context for actor-cycle logging.
- Added tests covering text turns, webchat turns, and background actor cycles to verify that `llm.call_usage` is emitted when enabled.
- Added assertions that logged payloads do not include the system prompt or model response content, preserving the lightweight, non-content nature of the logging.

## Why

This makes it easier to observe LLM usage at the call level without depending on full trace logging or exposing prompt/response bodies in operational logs. Provides a configurable path for low-overhead usage telemetry that can be sampled and tuned via gateway config.

## Testing

Tests were added or updated for the relevant gateway execution paths:
- `background-run-supervisor`
- `daemon-text-channel-turn`
- `daemon-webchat-turn`

Tests specifically verify emitted `llm.call_usage` events and content redaction behavior (system prompt and model response bodies are not included in logged payloads).