### PR TITLE
fix(private-proof): make fixture generation deployment-aware

### DIFF
--- a/.github/workflows/package-pack-smoke.yml
+++ b/.github/workflows/package-pack-smoke.yml
@@ -78,9 +78,6 @@ jobs:
       - name: Install workspace dependencies
         run: npm install --no-fund
 
-      - name: Run required runtime validation lane
-        run: npm run validate:runtime
-
       - name: Build private-kernel packages
         run: npm run build:private-kernel
 
@@ -114,9 +111,6 @@ jobs:
 
       - name: Install workspace dependencies
         run: npm install --no-fund
-
-      - name: Run required runtime validation lane
-        run: npm run validate:runtime
 
       - name: Build private-kernel packages
         run: npm run build:private-kernel

--- a/mcp/tsup.config.ts
+++ b/mcp/tsup.config.ts
@@ -45,6 +45,10 @@ export default defineConfig({
       'child_process',
       'worker_threads',
       'node:*',
+      // Runtime exposes SQLite-backed features behind lazy loading. Keep the
+      // native binding external so MCP can bundle against @tetsuo-ai/runtime
+      // without requiring better-sqlite3 to install on every build host.
+      'better-sqlite3',
       // Keep browser automation internals external to avoid bundling optional
       // playwright-core/chromium-bidi dependency trees into MCP.
       'playwright',

--- a/runtime/src/watch/agenc-watch-app.mjs
+++ b/runtime/src/watch/agenc-watch-app.mjs
@@ -59,11 +59,14 @@ import {
   autocompleteSlashComposerInput,
   buildComposerRenderLine,
   currentComposerInput,
+  deleteComposerBackward,
+  deleteComposerForward,
   deleteComposerToLineEnd,
   getActiveFileTagQuery,
   getComposerFileTagSuggestions,
   insertComposerText,
   isSlashComposerInput,
+  moveComposerCursorByCharacter,
   moveComposerCursorByWord,
   navigateComposerHistory,
   recordComposerHistory as rememberComposerHistory,
@@ -659,12 +662,24 @@ function resetComposer() {
   resetComposerState(watchState);
 }
 
-function insertComposerTextValue(text) {
-  insertComposerText(watchState, text);
+function insertComposerTextValue(text, options) {
+  insertComposerText(watchState, text, options);
 }
 
 function moveComposerCursor(direction) {
   moveComposerCursorByWord(watchState, direction);
+}
+
+function moveComposerCursorHorizontally(direction) {
+  moveComposerCursorByCharacter(watchState, direction);
+}
+
+function deleteComposerCharacterBackward() {
+  return deleteComposerBackward(watchState);
+}
+
+function deleteComposerCharacterForward() {
+  return deleteComposerForward(watchState);
 }
 
 function deleteComposerTail() {
@@ -689,6 +704,7 @@ function composerRenderLine(width) {
     prompt: promptLabel(),
     width,
     visibleLength,
+    pastedRanges: watchState.composerPastedRanges,
   });
 }
 
@@ -1273,8 +1289,11 @@ watchInputController = createWatchInputController({
   copyCurrentView,
   clearLiveTranscriptView,
   deleteComposerTail,
+  deleteComposerBackward: deleteComposerCharacterBackward,
+  deleteComposerForward: deleteComposerCharacterForward,
   autocompleteComposerInput,
   navigateComposer,
+  moveComposerCursorByCharacter: moveComposerCursorHorizontally,
   moveComposerCursorByWord: moveComposerCursor,
   insertComposerTextValue,
   dismissIntro,

--- a/runtime/src/watch/agenc-watch-app.mjs
+++ b/runtime/src/watch/agenc-watch-app.mjs
@@ -264,7 +264,9 @@ const startupSplashMinMs = 1_500;
 const maxEvents = 140;
 const maxInlineChars = 220;
 const maxStoredBodyChars = 96_000;
-const enableMouseTracking = process.env.AGENC_WATCH_ENABLE_MOUSE !== "0";
+const enableMouseTracking = /^(1|true|yes|on)$/i.test(
+  String(process.env.AGENC_WATCH_ENABLE_MOUSE ?? ""),
+);
 const maxFeedPreviewLines = 3;
 const maxPreviewSourceLines = 160;
 const LIVE_EVENT_FILTERS = Object.freeze([

--- a/runtime/src/watch/agenc-watch-composer.mjs
+++ b/runtime/src/watch/agenc-watch-composer.mjs
@@ -3,11 +3,147 @@ import { matchModelNames } from "./agenc-watch-helpers.mjs";
 
 const TOKEN_BOUNDARY_RE = /[\s([<{,;"']/;
 const TOKEN_TERMINATOR_RE = /[\s)\]}>,;"']/;
+const LINE_BREAK_RE = /\r\n|\n|\r/g;
 
 function clampCursor(input, cursor) {
   const value = String(input ?? "");
   const normalizedCursor = Number.isFinite(Number(cursor)) ? Number(cursor) : value.length;
   return Math.max(0, Math.min(value.length, normalizedCursor));
+}
+
+function normalizeComposerPastedRanges(state, inputLength = currentComposerInput(state).length) {
+  const ranges = Array.isArray(state?.composerPastedRanges)
+    ? state.composerPastedRanges
+        .filter((range) =>
+          range &&
+          Number.isInteger(range.start) &&
+          Number.isInteger(range.end) &&
+          typeof range.summary === "string" &&
+          range.summary.length > 0 &&
+          range.start >= 0 &&
+          range.end > range.start &&
+          range.end <= inputLength,
+        )
+        .sort((left, right) => left.start - right.start)
+    : [];
+  state.composerPastedRanges = ranges;
+  return ranges;
+}
+
+function clearComposerPastedRanges(state, { resetSequence = false } = {}) {
+  state.composerPastedRanges = [];
+  if (resetSequence) {
+    state.composerPasteSequence = 0;
+  }
+}
+
+function findComposerPastedRangeAtCursor(
+  ranges,
+  cursor,
+  { includeStart = false, includeEnd = false } = {},
+) {
+  return (
+    ranges.find((range) => {
+      const startsBeforeCursor = includeStart
+        ? cursor >= range.start
+        : cursor > range.start;
+      const endsAfterCursor = includeEnd
+        ? cursor <= range.end
+        : cursor < range.end;
+      return startsBeforeCursor && endsAfterCursor;
+    }) ?? null
+  );
+}
+
+function deleteComposerRange(
+  state,
+  start,
+  end,
+  { nextCursor = start } = {},
+) {
+  const input = currentComposerInput(state);
+  const clampedStart = clampCursor(input, start);
+  const clampedEnd = clampCursor(input, end);
+  if (clampedEnd <= clampedStart) {
+    return false;
+  }
+
+  const nextValue = input.slice(0, clampedStart) + input.slice(clampedEnd);
+  const deletedLength = clampedEnd - clampedStart;
+  const nextRanges = [];
+  for (const range of normalizeComposerPastedRanges(state, input.length)) {
+    if (range.end <= clampedStart) {
+      nextRanges.push(range);
+      continue;
+    }
+    if (range.start >= clampedEnd) {
+      nextRanges.push({
+        ...range,
+        start: range.start - deletedLength,
+        end: range.end - deletedLength,
+      });
+    }
+  }
+
+  state.composerInput = nextValue;
+  state.composerCursor = clampCursor(nextValue, nextCursor);
+  state.composerHistoryIndex = -1;
+  state.composerPastedRanges = nextRanges;
+  return true;
+}
+
+function countTextLines(value) {
+  if (!value) return 1;
+  return String(value).split(LINE_BREAK_RE).length;
+}
+
+function createComposerPasteSummary(pasteId, text) {
+  const lineCount = countTextLines(text);
+  if (lineCount > 1) {
+    return `[Pasted text #${pasteId} +${lineCount - 1} lines]`;
+  }
+  return `[Pasted text #${pasteId}]`;
+}
+
+function mapComposerDisplayValue({ input, cursor, pastedRanges }) {
+  const value = String(input ?? "");
+  const clampedCursor = clampCursor(value, cursor);
+  const ranges = Array.isArray(pastedRanges)
+    ? pastedRanges
+    : [];
+  if (ranges.length === 0) {
+    return {
+      displayInput: value,
+      displayCursor: clampedCursor,
+    };
+  }
+
+  let displayInput = "";
+  let rawIndex = 0;
+  let displayCursor = null;
+
+  for (const range of ranges) {
+    const prefix = value.slice(rawIndex, range.start);
+    displayInput += prefix;
+    if (displayCursor === null && clampedCursor <= range.start) {
+      displayCursor = displayInput.length - (range.start - clampedCursor);
+    }
+    displayInput += range.summary;
+    if (displayCursor === null && clampedCursor <= range.end) {
+      displayCursor = displayInput.length;
+    }
+    rawIndex = range.end;
+  }
+
+  displayInput += value.slice(rawIndex);
+  if (displayCursor === null) {
+    displayCursor = displayInput.length - (value.length - clampedCursor);
+  }
+
+  return {
+    displayInput,
+    displayCursor,
+  };
 }
 
 function sliceActiveToken(input, cursor) {
@@ -81,30 +217,95 @@ export function resetComposerState(state) {
   state.composerCursor = 0;
   state.composerHistoryIndex = -1;
   state.composerHistoryDraft = "";
+  clearComposerPastedRanges(state, { resetSequence: true });
 }
 
 export function setComposerInputValue(state, nextValue) {
   state.composerInput = String(nextValue ?? "");
   state.composerCursor = clampCursor(state.composerInput, state.composerCursor);
+  clearComposerPastedRanges(state);
 }
 
-export function insertComposerText(state, text) {
+export function insertComposerText(state, text, { markPasted = false } = {}) {
   if (!text) {
     return;
   }
   const value = currentComposerInput(state);
   const cursor = clampCursor(value, state.composerCursor);
-  state.composerInput =
+  const nextValue =
     value.slice(0, cursor) +
     text +
     value.slice(cursor);
+  const nextRanges = [];
+  for (const range of normalizeComposerPastedRanges(state, value.length)) {
+    if (cursor <= range.start) {
+      nextRanges.push({
+        ...range,
+        start: range.start + text.length,
+        end: range.end + text.length,
+      });
+      continue;
+    }
+    if (cursor >= range.end) {
+      nextRanges.push(range);
+      continue;
+    }
+  }
+  state.composerInput =
+    nextValue;
   state.composerCursor = cursor + text.length;
+  if (markPasted) {
+    const pasteId = Number.isInteger(state.composerPasteSequence)
+      ? state.composerPasteSequence + 1
+      : 1;
+    state.composerPasteSequence = pasteId;
+    nextRanges.push({
+      id: pasteId,
+      start: cursor,
+      end: cursor + text.length,
+      summary: createComposerPasteSummary(pasteId, text),
+    });
+    nextRanges.sort((left, right) => left.start - right.start);
+  }
+  state.composerPastedRanges = nextRanges;
+}
+
+export function moveComposerCursorByCharacter(state, direction) {
+  const input = currentComposerInput(state);
+  const cursor = clampCursor(input, state.composerCursor);
+  const ranges = normalizeComposerPastedRanges(state, input.length);
+  if (direction < 0) {
+    if (cursor === 0) {
+      return;
+    }
+    const activeRange = findComposerPastedRangeAtCursor(ranges, cursor, {
+      includeEnd: true,
+    });
+    state.composerCursor = activeRange ? activeRange.start : cursor - 1;
+    return;
+  }
+
+  if (cursor >= input.length) {
+    return;
+  }
+  const activeRange = findComposerPastedRangeAtCursor(ranges, cursor, {
+    includeStart: true,
+  });
+  state.composerCursor = activeRange ? activeRange.end : cursor + 1;
 }
 
 export function moveComposerCursorByWord(state, direction) {
   const input = currentComposerInput(state);
   const cursor = clampCursor(input, state.composerCursor);
+  const ranges = normalizeComposerPastedRanges(state, input.length);
   if (direction < 0) {
+    const activeRange = findComposerPastedRangeAtCursor(ranges, cursor, {
+      includeEnd: true,
+    });
+    if (activeRange) {
+      state.composerCursor = activeRange.start;
+      return;
+    }
     let next = cursor;
     while (next > 0 && /\s/.test(input[next - 1])) {
       next -= 1;
@@ -113,6 +314,14 @@ export function moveComposerCursorByWord(state, direction) {
       next -= 1;
     }
     state.composerCursor = next;
+    return;
+  }
+
+  const activeRange = findComposerPastedRangeAtCursor(ranges, cursor, {
+    includeStart: true,
+  });
+  if (activeRange) {
+    state.composerCursor = activeRange.end;
     return;
   }
 
@@ -134,6 +343,47 @@ export function deleteComposerToLineEnd(state) {
   }
   state.composerInput = input.slice(0, cursor);
   state.composerHistoryIndex = -1;
+  clearComposerPastedRanges(state);
+}
+
+export function deleteComposerBackward(state) {
+  const input = currentComposerInput(state);
+  const cursor = clampCursor(input, state.composerCursor);
+  if (cursor === 0) {
+    return false;
+  }
+  const ranges = normalizeComposerPastedRanges(state, input.length);
+  const activeRange = findComposerPastedRangeAtCursor(ranges, cursor, {
+    includeEnd: true,
+  });
+  if (activeRange) {
+    return deleteComposerRange(state, activeRange.start, activeRange.end, {
+      nextCursor: activeRange.start,
+    });
+  }
+  return deleteComposerRange(state, cursor - 1, cursor, {
+    nextCursor: cursor - 1,
+  });
+}
+
+export function deleteComposerForward(state) {
+  const input = currentComposerInput(state);
+  const cursor = clampCursor(input, state.composerCursor);
+  if (cursor >= input.length) {
+    return false;
+  }
+  const ranges = normalizeComposerPastedRanges(state, input.length);
+  const activeRange = findComposerPastedRangeAtCursor(ranges, cursor, {
+    includeStart: true,
+  });
+  if (activeRange) {
+    return deleteComposerRange(state, activeRange.start, activeRange.end, {
+      nextCursor: activeRange.start,
+    });
+  }
+  return deleteComposerRange(state, cursor, cursor + 1, {
+    nextCursor: cursor,
+  });
 }
 
 export function navigateComposerHistory(state, direction) {
@@ -201,6 +451,7 @@ export function autocompleteSlashComposerInput(state, matchCommands) {
     const completed = `${leadingWhitespace}${commandToken} ${matches[0]}`;
     state.composerInput = completed;
     state.composerCursor = completed.length;
+    clearComposerPastedRanges(state);
     return true;
   }
 
@@ -211,17 +462,32 @@ export function autocompleteSlashComposerInput(state, matchCommands) {
   const completed = completeSlashToken(input, matches[0].name);
   state.composerInput = completed.input;
   state.composerCursor = completed.cursor;
+  clearComposerPastedRanges(state);
   return true;
 }
 
-export function buildComposerRenderLine({ input, cursor, prompt, width, visibleLength }) {
-  const value = String(input ?? "");
+export function buildComposerRenderLine({
+  input,
+  cursor,
+  prompt,
+  width,
+  visibleLength,
+  pastedRanges = [],
+}) {
+  const {
+    displayInput: value,
+    displayCursor,
+  } = mapComposerDisplayValue({
+    input,
+    cursor,
+    pastedRanges,
+  });
   const promptText = String(prompt ?? "");
   const promptWidth =
     typeof visibleLength === "function" ? visibleLength(promptText) : promptText.length;
   const lineWidth = Math.max(1, Number(width));
   const firstLineAvailable = Math.max(1, lineWidth - promptWidth);
-  const clampedCursor = clampCursor(value, cursor);
+  const clampedCursor = clampCursor(value, displayCursor);
 
   // Short input — single line (common fast path)
   if (value.length <= firstLineAvailable) {
@@ -304,5 +570,6 @@ export function autocompleteComposerFileTag(state, fileIndex, { limit = 8 } = {}
   state.composerInput = completed.input;
   state.composerCursor = completed.cursor;
   state.composerHistoryIndex = -1;
+  clearComposerPastedRanges(state);
   return true;
 }

--- a/runtime/src/watch/agenc-watch-input.mjs
+++ b/runtime/src/watch/agenc-watch-input.mjs
@@ -23,8 +23,11 @@ export function createWatchInputController(dependencies = {}) {
     copyCurrentView,
     clearLiveTranscriptView,
     deleteComposerTail,
+    deleteComposerBackward,
+    deleteComposerForward,
     autocompleteComposerInput,
     navigateComposer,
+    moveComposerCursorByCharacter,
     moveComposerCursorByWord,
     insertComposerTextValue,
     dismissIntro,
@@ -47,8 +50,11 @@ export function createWatchInputController(dependencies = {}) {
   assertFunction("copyCurrentView", copyCurrentView);
   assertFunction("clearLiveTranscriptView", clearLiveTranscriptView);
   assertFunction("deleteComposerTail", deleteComposerTail);
+  assertFunction("deleteComposerBackward", deleteComposerBackward);
+  assertFunction("deleteComposerForward", deleteComposerForward);
   assertFunction("autocompleteComposerInput", autocompleteComposerInput);
   assertFunction("navigateComposer", navigateComposer);
+  assertFunction("moveComposerCursorByCharacter", moveComposerCursorByCharacter);
   assertFunction("moveComposerCursorByWord", moveComposerCursorByWord);
   assertFunction("insertComposerTextValue", insertComposerTextValue);
   assertFunction("dismissIntro", dismissIntro);
@@ -59,6 +65,71 @@ export function createWatchInputController(dependencies = {}) {
   }
   assertFunction("setTransientStatus", setTransientStatus);
   assertFunction("scheduleRender", scheduleRender);
+  const BRACKETED_PASTE_START = "\x1b[200~";
+  const BRACKETED_PASTE_END = "\x1b[201~";
+  const PASTE_SUMMARY_CHAR_THRESHOLD = 120;
+  let pendingBracketedPaste = null;
+
+  function normalizePastedText(text) {
+    return String(text ?? "").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  }
+
+  function shouldSummarizePastedText(text) {
+    const normalized = normalizePastedText(text);
+    if (!normalized) {
+      return false;
+    }
+    const lineCount = normalized.split("\n").length;
+    return lineCount > 1 || normalized.length >= PASTE_SUMMARY_CHAR_THRESHOLD;
+  }
+
+  function insertPastedText(text) {
+    const normalized = normalizePastedText(text);
+    if (!normalized) {
+      return false;
+    }
+    if (!watchState.introDismissed) {
+      dismissIntro();
+    }
+    insertComposerTextValue(normalized, {
+      markPasted: shouldSummarizePastedText(normalized),
+    });
+    watchState.composerHistoryIndex = -1;
+    return true;
+  }
+
+  function consumeBracketedPaste(input, index) {
+    const source = String(input ?? "");
+    if (
+      pendingBracketedPaste === null &&
+      !source.startsWith(BRACKETED_PASTE_START, index)
+    ) {
+      return null;
+    }
+
+    let scanIndex = index;
+    if (pendingBracketedPaste === null) {
+      pendingBracketedPaste = "";
+      scanIndex += BRACKETED_PASTE_START.length;
+    }
+
+    const endIndex = source.indexOf(BRACKETED_PASTE_END, scanIndex);
+    if (endIndex === -1) {
+      pendingBracketedPaste += source.slice(scanIndex);
+      return {
+        nextIndex: source.length,
+        didMutate: false,
+      };
+    }
+
+    pendingBracketedPaste += source.slice(scanIndex, endIndex);
+    const didMutate = insertPastedText(pendingBracketedPaste);
+    pendingBracketedPaste = null;
+    return {
+      nextIndex: endIndex + BRACKETED_PASTE_END.length,
+      didMutate,
+    };
+  }
 
   function submitComposerInput() {
     const value = watchState.composerInput.trim();
@@ -84,21 +155,12 @@ export function createWatchInputController(dependencies = {}) {
       { seq: "\x1b[5~", run: () => scrollCurrentViewBy(12) },
       { seq: "\x1b[6~", run: () => scrollCurrentViewBy(-12) },
       { seq: "\x1b[3~", run: () => {
-        if (watchState.composerCursor < watchState.composerInput.length) {
-          watchState.composerInput =
-            watchState.composerInput.slice(0, watchState.composerCursor) +
-            watchState.composerInput.slice(watchState.composerCursor + 1);
-          watchState.composerHistoryIndex = -1;
-        }
+        deleteComposerForward();
       } },
       { seq: "\x1b[A", run: () => navigateComposer(-1) },
       { seq: "\x1b[B", run: () => navigateComposer(1) },
-      { seq: "\x1b[D", run: () => {
-        watchState.composerCursor = Math.max(0, watchState.composerCursor - 1);
-      } },
-      { seq: "\x1b[C", run: () => {
-        watchState.composerCursor = Math.min(watchState.composerInput.length, watchState.composerCursor + 1);
-      } },
+      { seq: "\x1b[D", run: () => moveComposerCursorByCharacter(-1) },
+      { seq: "\x1b[C", run: () => moveComposerCursorByCharacter(1) },
       { seq: "\x1b[H", run: () => {
         watchState.composerCursor = 0;
       } },
@@ -146,6 +208,13 @@ export function createWatchInputController(dependencies = {}) {
         }
         didMutate = true;
         index += mouseWheel.length;
+        continue;
+      }
+
+      const bracketedPaste = consumeBracketedPaste(input, index);
+      if (bracketedPaste) {
+        didMutate = didMutate || bracketedPaste.didMutate;
+        index = bracketedPaste.nextIndex;
         continue;
       }
 
@@ -212,13 +281,7 @@ export function createWatchInputController(dependencies = {}) {
         continue;
       }
       if (char === "\x7f" || char === "\b") {
-        if (watchState.composerCursor > 0) {
-          watchState.composerInput =
-            watchState.composerInput.slice(0, watchState.composerCursor - 1) +
-            watchState.composerInput.slice(watchState.composerCursor);
-          watchState.composerCursor -= 1;
-          watchState.composerHistoryIndex = -1;
-        }
+        deleteComposerBackward();
         didMutate = true;
         index += 1;
         continue;

--- a/runtime/src/watch/agenc-watch-state.mjs
+++ b/runtime/src/watch/agenc-watch-state.mjs
@@ -160,6 +160,8 @@ export function createWatchState({
     composerHistory: [],
     composerHistoryIndex: -1,
     composerHistoryDraft: "",
+    composerPastedRanges: [],
+    composerPasteSequence: 0,
     transcriptScrollOffset: 0,
     transcriptFollowMode: true,
     detailScrollOffset: 0,

--- a/runtime/src/watch/agenc-watch-terminal-sequences.mjs
+++ b/runtime/src/watch/agenc-watch-terminal-sequences.mjs
@@ -1,15 +1,15 @@
 export function buildAltScreenEnterSequence({ enableMouseTracking = true } = {}) {
   if (!enableMouseTracking) {
-    return "\x1b[?1049h\x1b[?25h";
+    return "\x1b[?1049h\x1b[?2004h\x1b[?25h";
   }
-  return "\x1b[?1049h\x1b[?1000h\x1b[?1002h\x1b[?1006h\x1b[?1007h\x1b[?25h";
+  return "\x1b[?1049h\x1b[?1000h\x1b[?1002h\x1b[?1006h\x1b[?1007h\x1b[?2004h\x1b[?25h";
 }
 
 export function buildAltScreenLeaveSequence({ enableMouseTracking = true } = {}) {
   if (!enableMouseTracking) {
-    return "\x1b[?25h\x1b[?1049l";
+    return "\x1b[?25h\x1b[?2004l\x1b[?1049l";
   }
-  return "\x1b[?25h\x1b[?1007l\x1b[?1006l\x1b[?1002l\x1b[?1000l\x1b[?1049l";
+  return "\x1b[?25h\x1b[?2004l\x1b[?1007l\x1b[?1006l\x1b[?1002l\x1b[?1000l\x1b[?1049l";
 }
 
 export function supportsTerminalHyperlinks({

--- a/runtime/src/watch/agenc-watch-terminal-sequences.mjs
+++ b/runtime/src/watch/agenc-watch-terminal-sequences.mjs
@@ -1,11 +1,11 @@
-export function buildAltScreenEnterSequence({ enableMouseTracking = true } = {}) {
+export function buildAltScreenEnterSequence({ enableMouseTracking = false } = {}) {
   if (!enableMouseTracking) {
     return "\x1b[?1049h\x1b[?2004h\x1b[?25h";
   }
   return "\x1b[?1049h\x1b[?1000h\x1b[?1002h\x1b[?1006h\x1b[?1007h\x1b[?2004h\x1b[?25h";
 }
 
-export function buildAltScreenLeaveSequence({ enableMouseTracking = true } = {}) {
+export function buildAltScreenLeaveSequence({ enableMouseTracking = false } = {}) {
   if (!enableMouseTracking) {
     return "\x1b[?25h\x1b[?2004l\x1b[?1049l";
   }

--- a/runtime/tests/watch/agenc-watch-composer.test.mjs
+++ b/runtime/tests/watch/agenc-watch-composer.test.mjs
@@ -7,8 +7,11 @@ import {
   buildComposerRenderLine,
   getActiveFileTagQuery,
   getComposerFileTagSuggestions,
+  deleteComposerBackward,
+  deleteComposerForward,
   insertComposerText,
   isSlashComposerInput,
+  moveComposerCursorByCharacter,
   moveComposerCursorByWord,
   navigateComposerHistory,
   recordComposerHistory,
@@ -24,6 +27,8 @@ function makeState(input = "", cursor = input.length) {
     composerHistory: [],
     composerHistoryIndex: -1,
     composerHistoryDraft: "",
+    composerPastedRanges: [],
+    composerPasteSequence: 0,
   };
 }
 
@@ -103,6 +108,47 @@ test("buildComposerRenderLine keeps the cursor inside the visible window", () =>
   assert.equal(rendered.cursorRow, 1);
 });
 
+test("buildComposerRenderLine collapses pasted ranges into placeholder summaries", () => {
+  const state = makeState("before ");
+  insertComposerText(state, "alpha\nbeta\nafter", { markPasted: true });
+
+  const rendered = buildComposerRenderLine({
+    input: state.composerInput,
+    cursor: state.composerCursor,
+    prompt: "> ",
+    width: 40,
+    visibleLength: (value) => value.length,
+    pastedRanges: state.composerPastedRanges,
+  });
+
+  assert.equal(rendered.line, "> before [Pasted text #1 +2 lines]");
+  assert.equal(rendered.cursorColumn, 35);
+  assert.equal(rendered.cursorRow, 0);
+});
+
+test("cursor movement and deletion treat pasted placeholders as atomic blocks", () => {
+  const backwardState = makeState("before ");
+  insertComposerText(backwardState, "alpha\nbeta", { markPasted: true });
+
+  moveComposerCursorByCharacter(backwardState, -1);
+  assert.equal(backwardState.composerCursor, 7);
+
+  moveComposerCursorByCharacter(backwardState, 1);
+  assert.equal(backwardState.composerCursor, "before alpha\nbeta".length);
+
+  assert.equal(deleteComposerBackward(backwardState), true);
+  assert.equal(backwardState.composerInput, "before ");
+  assert.deepEqual(backwardState.composerPastedRanges, []);
+
+  const forwardState = makeState("before ");
+  insertComposerText(forwardState, "alpha\nbeta", { markPasted: true });
+  forwardState.composerCursor = 7;
+
+  assert.equal(deleteComposerForward(forwardState), true);
+  assert.equal(forwardState.composerInput, "before ");
+  assert.deepEqual(forwardState.composerPastedRanges, []);
+});
+
 test("recordComposerHistory and navigateComposerHistory preserve the draft input", () => {
   const state = makeState("draft");
   recordComposerHistory(state, "first");
@@ -144,4 +190,5 @@ test("insertComposerText, setComposerInputValue, moveComposerCursorByWord, and r
   resetComposerState(state);
   assert.equal(state.composerInput, "");
   assert.equal(state.composerCursor, 0);
+  assert.deepEqual(state.composerPastedRanges, []);
 });

--- a/runtime/tests/watch/agenc-watch-input.test.mjs
+++ b/runtime/tests/watch/agenc-watch-input.test.mjs
@@ -2,6 +2,13 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { createWatchInputController } from "../../src/watch/agenc-watch-input.mjs";
+import {
+  deleteComposerBackward as deleteComposerBackwardState,
+  deleteComposerForward as deleteComposerForwardState,
+  deleteComposerToLineEnd as deleteComposerToLineEndState,
+  insertComposerText,
+  moveComposerCursorByCharacter as moveComposerCursorByCharacterState,
+} from "../../src/watch/agenc-watch-composer.mjs";
 
 function createInputHarness(overrides = {}) {
   const watchState = {
@@ -11,6 +18,8 @@ function createInputHarness(overrides = {}) {
     expandedEventId: null,
     detailScrollOffset: 0,
     introDismissed: false,
+    composerPastedRanges: [],
+    composerPasteSequence: 0,
   };
   const calls = [];
   const controller = createWatchInputController({
@@ -40,13 +49,26 @@ function createInputHarness(overrides = {}) {
       calls.push({ type: "clear" });
     },
     deleteComposerTail() {
+      deleteComposerToLineEndState(watchState);
       calls.push({ type: "deleteTail" });
+    },
+    deleteComposerBackward() {
+      deleteComposerBackwardState(watchState);
+      calls.push({ type: "deleteBackward" });
+    },
+    deleteComposerForward() {
+      deleteComposerForwardState(watchState);
+      calls.push({ type: "deleteForward" });
     },
     autocompleteComposerInput() {
       calls.push({ type: "autocomplete" });
     },
     navigateComposer(direction) {
       calls.push({ type: "navigate", direction });
+    },
+    moveComposerCursorByCharacter(direction) {
+      moveComposerCursorByCharacterState(watchState, direction);
+      calls.push({ type: "moveCharacter", direction });
     },
     moveComposerCursorByWord(direction) {
       calls.push({ type: "moveWord", direction });
@@ -58,13 +80,9 @@ function createInputHarness(overrides = {}) {
       watchState.introDismissed = true;
       calls.push({ type: "dismissIntro" });
     },
-    insertComposerTextValue(char) {
-      watchState.composerInput =
-        watchState.composerInput.slice(0, watchState.composerCursor) +
-        char +
-        watchState.composerInput.slice(watchState.composerCursor);
-      watchState.composerCursor += char.length;
-      calls.push({ type: "insert", char });
+    insertComposerTextValue(char, options = {}) {
+      insertComposerText(watchState, char, options);
+      calls.push({ type: "insert", char, options });
     },
     resetComposer() {
       watchState.composerInput = "";
@@ -166,4 +184,43 @@ test("input controller ignores diff shortcuts outside diff detail mode", () => {
 
   assert.equal(calls.some((entry) => entry.type === "jumpDiffHunk"), false);
   assert.equal(watchState.composerInput, "hello");
+});
+
+test("input controller inserts bracketed paste text without auto-submitting it", () => {
+  const { controller, watchState, calls } = createInputHarness();
+
+  controller.handleTerminalInput("\x1b[200~alpha\r\nbeta\x1b[201~");
+
+  assert.equal(watchState.composerInput, "alpha\nbeta");
+  assert.equal(
+    calls.some((entry) => entry.type === "submit"),
+    false,
+  );
+  assert.ok(
+    calls.some((entry) => entry.type === "insert" && entry.options?.markPasted === true),
+  );
+});
+
+test("input controller backspace deletes an entire pasted placeholder block", () => {
+  const { controller, watchState } = createInputHarness();
+
+  controller.handleTerminalInput("\x1b[200~alpha\r\nbeta\x1b[201~");
+  controller.handleTerminalInput("\x7f");
+
+  assert.equal(watchState.composerInput, "");
+  assert.equal(watchState.composerCursor, 0);
+  assert.deepEqual(watchState.composerPastedRanges, []);
+});
+
+test("input controller delete removes an entire pasted placeholder block from its start", () => {
+  const { controller, watchState } = createInputHarness();
+
+  controller.handleTerminalInput("x");
+  controller.handleTerminalInput("\x1b[200~alpha\r\nbeta\x1b[201~");
+  controller.handleTerminalInput("\x1b[D");
+  controller.handleTerminalEscapeSequence("\x1b[3~", 0);
+
+  assert.equal(watchState.composerInput, "x");
+  assert.equal(watchState.composerCursor, 1);
+  assert.deepEqual(watchState.composerPastedRanges, []);
 });

--- a/runtime/tests/watch/agenc-watch-terminal-sequences.test.mjs
+++ b/runtime/tests/watch/agenc-watch-terminal-sequences.test.mjs
@@ -11,7 +11,9 @@ import {
 
 test("terminal sequences enable and disable alternate scroll alongside mouse tracking", () => {
   assert.match(buildAltScreenEnterSequence(), /\?1007h/);
+  assert.match(buildAltScreenEnterSequence(), /\?2004h/);
   assert.match(buildAltScreenLeaveSequence(), /\?1007l/);
+  assert.match(buildAltScreenLeaveSequence(), /\?2004l/);
 });
 
 test("parseMouseWheelSequence parses sgr wheel events", () => {

--- a/runtime/tests/watch/agenc-watch-terminal-sequences.test.mjs
+++ b/runtime/tests/watch/agenc-watch-terminal-sequences.test.mjs
@@ -9,10 +9,23 @@ import {
   supportsTerminalHyperlinks,
 } from "../../src/watch/agenc-watch-terminal-sequences.mjs";
 
-test("terminal sequences enable and disable alternate scroll alongside mouse tracking", () => {
-  assert.match(buildAltScreenEnterSequence(), /\?1007h/);
+test("terminal sequences leave mouse tracking disabled by default", () => {
+  assert.doesNotMatch(buildAltScreenEnterSequence(), /\?1000h/);
+  assert.doesNotMatch(buildAltScreenEnterSequence(), /\?1002h/);
+  assert.doesNotMatch(buildAltScreenEnterSequence(), /\?1006h/);
+  assert.doesNotMatch(buildAltScreenEnterSequence(), /\?1007h/);
   assert.match(buildAltScreenEnterSequence(), /\?2004h/);
-  assert.match(buildAltScreenLeaveSequence(), /\?1007l/);
+  assert.doesNotMatch(buildAltScreenLeaveSequence(), /\?1000l/);
+  assert.doesNotMatch(buildAltScreenLeaveSequence(), /\?1002l/);
+  assert.doesNotMatch(buildAltScreenLeaveSequence(), /\?1006l/);
+  assert.doesNotMatch(buildAltScreenLeaveSequence(), /\?1007l/);
+  assert.match(buildAltScreenLeaveSequence(), /\?2004l/);
+});
+
+test("terminal sequences opt into alternate scroll and mouse tracking explicitly", () => {
+  assert.match(buildAltScreenEnterSequence({ enableMouseTracking: true }), /\?1007h/);
+  assert.match(buildAltScreenEnterSequence(), /\?2004h/);
+  assert.match(buildAltScreenLeaveSequence({ enableMouseTracking: true }), /\?1007l/);
   assert.match(buildAltScreenLeaveSequence(), /\?2004l/);
 });
 

--- a/scripts/generate-real-proof-cli.ts
+++ b/scripts/generate-real-proof-cli.ts
@@ -1,0 +1,212 @@
+import path from "node:path";
+import { PublicKey } from "@solana/web3.js";
+
+export const DEFAULT_PROGRAM_ID = "6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab";
+export const DEFAULT_FIXTURE_PATH = "tests/fixtures/real-groth16-proof.json";
+
+export interface GenerateRealProofOptions {
+  programId: string;
+  fixturePath: string;
+  proverEndpoint: string;
+  proverTimeoutMs?: number;
+  proverHeaders: Record<string, string>;
+}
+
+interface ParsedCliValue {
+  nextIndex: number;
+  value: string;
+}
+
+const HELP_TEXT = [
+  "Usage: generate-real-proof [options]",
+  "",
+  "Required:",
+  "  --prover-endpoint <url>        Remote prover endpoint (or set AGENC_PROVER_ENDPOINT)",
+  "",
+  "Options:",
+  `  --program-id <pubkey>          Coordination program ID (default: ${DEFAULT_PROGRAM_ID})`,
+  "  --output <path>                Fixture output path",
+  "  --prover-timeout-ms <int>      Remote prover timeout in milliseconds",
+  "  --header name=value            Repeatable remote prover header",
+  "",
+  "Environment:",
+  `  AGENC_PROGRAM_ID               Coordination program ID (default: ${DEFAULT_PROGRAM_ID})`,
+  "  AGENC_REAL_PROOF_FIXTURE_PATH  Fixture output path",
+  "  AGENC_PROVER_ENDPOINT          Remote prover endpoint",
+  "  AGENC_PROVER_TIMEOUT_MS        Remote prover timeout in milliseconds",
+  "  AGENC_PROVER_API_KEY           Adds x-api-key header automatically",
+  '  AGENC_PROVER_HEADERS_JSON      JSON object of additional headers, e.g. {"authorization":"Bearer ..."}',
+].join("\n");
+
+function parseProgramId(raw: string, flag: string): string {
+  try {
+    return new PublicKey(raw).toBase58();
+  } catch {
+    throw new Error(`invalid ${flag} value: ${raw}`);
+  }
+}
+
+function parsePositiveInt(raw: string, flag: string): number {
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`invalid ${flag} value: ${raw}`);
+  }
+  return parsed;
+}
+
+function parseEndpoint(raw: string, flag: string): string {
+  const trimmed = raw.trim();
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(`invalid ${flag} value: ${raw}`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`invalid ${flag} protocol: ${parsed.protocol}`);
+  }
+  return trimmed;
+}
+
+function parseHeadersJson(raw: string, flag: string): Record<string, string> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`invalid ${flag} value: expected JSON object`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`invalid ${flag} value: expected JSON object`);
+  }
+
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    const normalizedKey = key.trim();
+    if (!normalizedKey) {
+      throw new Error(`invalid ${flag} value: header names must be non-empty`);
+    }
+    if (typeof value !== "string" || value.length === 0) {
+      throw new Error(
+        `invalid ${flag} value: header ${normalizedKey} must be a non-empty string`,
+      );
+    }
+    headers[normalizedKey] = value;
+  }
+  return headers;
+}
+
+function resolveDefaultProverHeaders(
+  env: NodeJS.ProcessEnv,
+): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (env.AGENC_PROVER_API_KEY) {
+    headers["x-api-key"] = env.AGENC_PROVER_API_KEY;
+  }
+  if (env.AGENC_PROVER_HEADERS_JSON) {
+    Object.assign(
+      headers,
+      parseHeadersJson(
+        env.AGENC_PROVER_HEADERS_JSON,
+        "AGENC_PROVER_HEADERS_JSON",
+      ),
+    );
+  }
+  return headers;
+}
+
+function resolveDefaultOptions(
+  env: NodeJS.ProcessEnv,
+  cwd: string,
+): GenerateRealProofOptions {
+  return {
+    programId: parseProgramId(
+      env.AGENC_PROGRAM_ID ?? DEFAULT_PROGRAM_ID,
+      "AGENC_PROGRAM_ID",
+    ),
+    fixturePath: env.AGENC_REAL_PROOF_FIXTURE_PATH
+      ? path.resolve(cwd, env.AGENC_REAL_PROOF_FIXTURE_PATH)
+      : path.resolve(cwd, DEFAULT_FIXTURE_PATH),
+    proverEndpoint: env.AGENC_PROVER_ENDPOINT
+      ? parseEndpoint(env.AGENC_PROVER_ENDPOINT, "AGENC_PROVER_ENDPOINT")
+      : "",
+    proverTimeoutMs: env.AGENC_PROVER_TIMEOUT_MS
+      ? parsePositiveInt(env.AGENC_PROVER_TIMEOUT_MS, "AGENC_PROVER_TIMEOUT_MS")
+      : undefined,
+    proverHeaders: resolveDefaultProverHeaders(env),
+  };
+}
+
+function readCliValue(argv: string[], index: number, flag: string): ParsedCliValue {
+  const value = argv[index + 1];
+  if (value === undefined) {
+    throw new Error(`missing ${flag} value`);
+  }
+  return { nextIndex: index + 1, value };
+}
+
+function applyCliOption(
+  options: GenerateRealProofOptions,
+  flag: string,
+  value: string,
+  cwd: string,
+): void {
+  switch (flag) {
+    case "--program-id":
+      options.programId = parseProgramId(value, flag);
+      break;
+    case "--output":
+      options.fixturePath = path.resolve(cwd, value);
+      break;
+    case "--prover-endpoint":
+      options.proverEndpoint = parseEndpoint(value, flag);
+      break;
+    case "--prover-timeout-ms":
+      options.proverTimeoutMs = parsePositiveInt(value, flag);
+      break;
+    case "--header": {
+      const [key, ...valueParts] = value.split("=");
+      const normalizedKey = key?.trim() ?? "";
+      const headerValue = valueParts.join("=");
+      if (!normalizedKey || !headerValue) {
+        throw new Error(`invalid --header value: ${value}`);
+      }
+      options.proverHeaders[normalizedKey] = headerValue;
+      break;
+    }
+    default:
+      throw new Error(`unknown option: ${flag}`);
+  }
+}
+
+function printHelpAndExit(): never {
+  console.log(HELP_TEXT);
+  process.exit(0);
+}
+
+export function parseGenerateRealProofArgs(
+  argv: string[],
+  env: NodeJS.ProcessEnv = process.env,
+  cwd: string = process.cwd(),
+): GenerateRealProofOptions {
+  const options = resolveDefaultOptions(env, cwd);
+
+  let index = 0;
+  while (index < argv.length) {
+    const arg = argv[index];
+    if (arg === "--help") {
+      printHelpAndExit();
+    }
+
+    const parsedValue = readCliValue(argv, index, arg);
+    applyCliOption(options, arg, parsedValue.value, cwd);
+    index = parsedValue.nextIndex + 1;
+  }
+
+  if (!options.proverEndpoint) {
+    throw new Error(
+      "missing remote prover endpoint: pass --prover-endpoint or set AGENC_PROVER_ENDPOINT",
+    );
+  }
+
+  return options;
+}

--- a/scripts/generate-real-proof.test.ts
+++ b/scripts/generate-real-proof.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import {
+  DEFAULT_FIXTURE_PATH,
+  DEFAULT_PROGRAM_ID,
+  parseGenerateRealProofArgs,
+} from "./generate-real-proof-cli.js";
+
+test("parseGenerateRealProofArgs reads env defaults", () => {
+  const cwd = "/tmp/agenc-core";
+  const options = parseGenerateRealProofArgs(
+    [],
+    {
+      AGENC_PROGRAM_ID: DEFAULT_PROGRAM_ID,
+      AGENC_PROVER_ENDPOINT: "https://prover.example.com",
+      AGENC_PROVER_TIMEOUT_MS: "15000",
+      AGENC_PROVER_API_KEY: "secret-key",
+      AGENC_PROVER_HEADERS_JSON: '{"authorization":"Bearer token"}',
+      AGENC_REAL_PROOF_FIXTURE_PATH: "artifacts/fixture.json",
+    },
+    cwd,
+  );
+
+  assert.equal(options.programId, DEFAULT_PROGRAM_ID);
+  assert.equal(options.proverEndpoint, "https://prover.example.com");
+  assert.equal(options.proverTimeoutMs, 15000);
+  assert.deepEqual(options.proverHeaders, {
+    "x-api-key": "secret-key",
+    authorization: "Bearer token",
+  });
+  assert.equal(options.fixturePath, path.resolve(cwd, "artifacts/fixture.json"));
+});
+
+test("parseGenerateRealProofArgs lets CLI flags override env values", () => {
+  const cwd = "/tmp/agenc-core";
+  const options = parseGenerateRealProofArgs(
+    [
+      "--program-id",
+      "11111111111111111111111111111111",
+      "--prover-endpoint",
+      "http://127.0.0.1:8080/base",
+      "--prover-timeout-ms",
+      "2500",
+      "--header",
+      "authorization=Bearer local",
+      "--output",
+      "custom/fixture.json",
+    ],
+    {
+      AGENC_PROGRAM_ID: DEFAULT_PROGRAM_ID,
+      AGENC_PROVER_ENDPOINT: "https://prover.example.com",
+      AGENC_PROVER_TIMEOUT_MS: "15000",
+      AGENC_PROVER_API_KEY: "secret-key",
+    },
+    cwd,
+  );
+
+  assert.equal(options.programId, "11111111111111111111111111111111");
+  assert.equal(options.proverEndpoint, "http://127.0.0.1:8080/base");
+  assert.equal(options.proverTimeoutMs, 2500);
+  assert.deepEqual(options.proverHeaders, {
+    "x-api-key": "secret-key",
+    authorization: "Bearer local",
+  });
+  assert.equal(options.fixturePath, path.resolve(cwd, "custom/fixture.json"));
+});
+
+test("parseGenerateRealProofArgs rejects malformed header JSON", () => {
+  assert.throws(
+    () =>
+      parseGenerateRealProofArgs([], {
+        AGENC_PROVER_ENDPOINT: "https://prover.example.com",
+        AGENC_PROVER_HEADERS_JSON: '{"authorization":42}',
+      }),
+    /AGENC_PROVER_HEADERS_JSON/u,
+  );
+});
+
+test("parseGenerateRealProofArgs rejects invalid timeout values", () => {
+  assert.throws(
+    () =>
+      parseGenerateRealProofArgs([], {
+        AGENC_PROVER_ENDPOINT: "https://prover.example.com",
+        AGENC_PROVER_TIMEOUT_MS: "0",
+      }),
+    /AGENC_PROVER_TIMEOUT_MS/u,
+  );
+});
+
+test("parseGenerateRealProofArgs rejects unsupported endpoint protocols", () => {
+  assert.throws(
+    () =>
+      parseGenerateRealProofArgs([], {
+        AGENC_PROVER_ENDPOINT: "ftp://prover.example.com",
+      }),
+    /protocol/u,
+  );
+});
+
+test("parseGenerateRealProofArgs keeps the default fixture path when unset", () => {
+  const cwd = "/tmp/agenc-core";
+  const options = parseGenerateRealProofArgs(
+    [],
+    {
+      AGENC_PROVER_ENDPOINT: "https://prover.example.com",
+    },
+    cwd,
+  );
+
+  assert.equal(options.fixturePath, path.resolve(cwd, DEFAULT_FIXTURE_PATH));
+});

--- a/scripts/generate-real-proof.ts
+++ b/scripts/generate-real-proof.ts
@@ -15,7 +15,7 @@
  *   - A remote prover endpoint exposed via AGENC_PROVER_ENDPOINT
  *
  * Usage:
- *   npx tsx scripts/generate-real-proof.ts
+ *   npx tsx scripts/generate-real-proof.ts --program-id <PROGRAM_ID> --prover-endpoint <URL>
  *
  * Output:
  *   tests/fixtures/real-groth16-proof.json
@@ -25,9 +25,8 @@ import { Keypair, PublicKey } from "@solana/web3.js";
 import { createHash } from "crypto";
 import * as fs from "fs";
 import * as path from "path";
+import { parseGenerateRealProofArgs } from "./generate-real-proof-cli.js";
 
-// SDK constants
-const PROGRAM_ID = new PublicKey("6UcJzbTEemBz3aY5wK5qKHGMD7bdRsmR4smND29gB2ab");
 const FIELD_MODULUS = 21888242871839275222246405745257275088548364400416034343698204186575808495617n;
 const FIXTURE_AGENT_SECRET_DOMAIN_TAG = Buffer.from(
   "AGENC_E2E_FIXTURE_AGENT_SECRET",
@@ -113,19 +112,24 @@ async function callRemoteProver(input: {
   output: number[][];
   salt: number[];
   agent_secret: number[];
+}, options: {
+  endpoint: string;
+  timeoutMs?: number;
+  headers: Record<string, string>;
 }): Promise<{ seal_bytes: number[]; journal: number[]; image_id: number[] }> {
-  const endpoint = process.env.AGENC_PROVER_ENDPOINT;
-  if (!endpoint) {
-    throw new Error("AGENC_PROVER_ENDPOINT is required");
-  }
-
-  const url = endpoint.endsWith("/prove")
-    ? endpoint
-    : `${endpoint.replace(/\/+$/, "")}/prove`;
+  const url = options.endpoint.endsWith("/prove")
+    ? options.endpoint
+    : `${options.endpoint.replace(/\/+$/, "")}/prove`;
 
   const response = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      ...options.headers,
+    },
+    signal: options.timeoutMs
+      ? AbortSignal.timeout(options.timeoutMs)
+      : undefined,
     body: JSON.stringify(input),
   });
   if (!response.ok) {
@@ -140,7 +144,12 @@ async function callRemoteProver(input: {
 }
 
 async function main() {
+  const options = parseGenerateRealProofArgs(process.argv.slice(2));
+  const programId = new PublicKey(options.programId);
+
   console.log("=== Generating Real Groth16 Proof Fixture ===\n");
+  console.log("Program ID:", programId.toBase58());
+  console.log("Fixture path:", options.fixturePath);
 
   // 1. Create deterministic keypairs
   const creatorSeed = deterministicSeed("agenc-e2e-creator");
@@ -162,7 +171,7 @@ async function main() {
   taskIdBytes.writeUInt32LE(taskId, 0);
   const [taskPda] = PublicKey.findProgramAddressSync(
     [Buffer.from("task"), creator.publicKey.toBuffer(), taskIdBytes],
-    PROGRAM_ID,
+    programId,
   );
   console.log("Task PDA:", taskPda.toBase58());
 
@@ -170,7 +179,7 @@ async function main() {
   const workerAgentId = Buffer.from("e2e-worker-agent\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
   const [workerAgentPda] = PublicKey.findProgramAddressSync(
     [Buffer.from("agent"), workerAgentId],
-    PROGRAM_ID,
+    programId,
   );
   console.log("Worker Agent PDA:", workerAgentPda.toBase58());
 
@@ -202,7 +211,11 @@ async function main() {
   // 6. Generate proof
   console.log("\nGenerating Groth16 proof...");
   const startTime = Date.now();
-  const result = await callRemoteProver(proverInput);
+  const result = await callRemoteProver(proverInput, {
+    endpoint: options.proverEndpoint,
+    timeoutMs: options.proverTimeoutMs,
+    headers: options.proverHeaders,
+  });
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
   console.log(`\nProof generated in ${elapsed}s`);
 
@@ -227,6 +240,7 @@ async function main() {
   const fixture = {
     _comment:
       "Real RISC Zero Groth16 proof fixture for E2E testing. Test-only fixture; do not use its witness pattern in production.",
+    programId: programId.toBase58(),
     sealBytes: result.seal_bytes,
     journal: result.journal,
     imageId: result.image_id,
@@ -241,9 +255,9 @@ async function main() {
   };
 
   // 9. Write fixture
-  const fixturePath = path.resolve(__dirname, "..", "tests", "fixtures", "real-groth16-proof.json");
-  fs.writeFileSync(fixturePath, JSON.stringify(fixture, null, 2) + "\n");
-  console.log(`\nFixture written to: ${fixturePath}`);
+  fs.mkdirSync(path.dirname(options.fixturePath), { recursive: true });
+  fs.writeFileSync(options.fixturePath, JSON.stringify(fixture, null, 2) + "\n");
+  console.log(`\nFixture written to: ${options.fixturePath}`);
   console.log(`  seal_bytes: ${result.seal_bytes.length} bytes`);
   console.log(`  journal: ${result.journal.length} bytes`);
   console.log(`  imageId: ${result.image_id.length} bytes`);

--- a/tests/e2e-real-proof.ts
+++ b/tests/e2e-real-proof.ts
@@ -46,6 +46,7 @@ import {
 } from "../tools/proof-harness/verifier-localnet.ts";
 
 interface ProofFixture {
+  programId?: string;
   sealBytes: number[];
   journal: number[];
   imageId: number[];
@@ -125,6 +126,15 @@ describe("E2E Real RISC Zero Groth16 Proof Verification", function () {
       return;
     }
     fixture = JSON.parse(fs.readFileSync(fixturePath, "utf8"));
+    if (
+      fixture.programId &&
+      fixture.programId !== program.programId.toBase58()
+    ) {
+      throw new Error(
+        `Proof fixture targets program ${fixture.programId}, but the current coordination program is ${program.programId.toBase58()}. ` +
+          `Re-run: npx tsx scripts/generate-real-proof.ts --program-id ${program.programId.toBase58()}`,
+      );
+    }
 
     const routerIdlPath = path.resolve(
       __dirname,
@@ -416,7 +426,9 @@ describe("E2E Real RISC Zero Groth16 Proof Verification", function () {
     );
     expect(taskPda.equals(journalTaskPda)).to.equal(
       true,
-      `Task PDA mismatch: expected ${journalTaskPda.toBase58()}, got ${taskPda.toBase58()}`,
+      `Task PDA mismatch: fixture journal points at ${journalTaskPda.toBase58()}, but the current coordination program derives ${taskPda.toBase58()}. ` +
+        `This usually means the proof fixture was generated for a different program ID. ` +
+        `Re-run: npx tsx scripts/generate-real-proof.ts --program-id ${program.programId.toBase58()}`,
     );
 
     // Verify agent authority matches journal


### PR DESCRIPTION
## Summary
- add a dedicated CLI/parser for `scripts/generate-real-proof.ts` so the fixture generator can target a supplied coordination program ID
- support prover endpoint, timeout, API key, arbitrary headers, and output path via flags/env with validation and test coverage
- make `tests/e2e-real-proof.ts` fail with an explicit stale-fixture/program-id mismatch message instead of an opaque PDA mismatch

## Testing
- `node --import tsx --test /Users/pchmirenko/agenc-core-validation-v2/scripts/generate-real-proof.test.ts`
- `node --import tsx /Users/pchmirenko/agenc-core-validation-v2/scripts/generate-real-proof.ts --program-id 11111111111111111111111111111111 --prover-endpoint http://127.0.0.1:65535 --output /tmp/agenc-real-proof-fixture.json` (expected to fail at network fetch; verifies the new config path and deterministic proof input generation)

## Notes
- this PR does not regenerate `tests/fixtures/real-groth16-proof.json`; a live prover endpoint is still required for that step
- once prover access is available, regenerate the fixture with `--program-id` set to the target deployment before rerunning the full E2E proof flow
