### PR TITLE
fix(runtime): propagate xai server-side tool evidence

### DIFF
--- a/runtime/src/gateway/tool-handler-factory.test.ts
+++ b/runtime/src/gateway/tool-handler-factory.test.ts
@@ -3556,6 +3556,86 @@ describe("createSessionToolHandler", () => {
     ]);
   });
 
+  it("preserves provider-native server-side tool telemetry in delegated child results", async () => {
+    const subAgentManager = {
+      spawn: vi.fn(async () => "subagent:child-native-tools"),
+      getResult: vi.fn(() => makeCompletedChildResult({
+        sessionId: "subagent:child-native-tools",
+        output: '{"selected":"pixi"}',
+        success: true,
+        durationMs: 18,
+        toolCalls: [],
+        providerEvidence: {
+          serverSideToolCalls: [
+            {
+              type: "web_search_call",
+              toolType: "web_search",
+              id: "ws_123",
+              status: "completed",
+            },
+          ],
+          serverSideToolUsage: [
+            {
+              category: "SERVER_SIDE_TOOL_WEB_SEARCH",
+              toolType: "web_search",
+              count: 1,
+            },
+          ],
+        },
+      })),
+      getInfo: vi.fn(() => ({
+        sessionId: "subagent:child-native-tools",
+        parentSessionId: "session-parent",
+        depth: 1,
+        status: "completed",
+        startedAt: Date.now() - 25,
+        task: "Compare official framework docs",
+      })),
+    };
+
+    const handler = createSessionToolHandler({
+      sessionId: "session-parent",
+      baseHandler: vi.fn(async () => "should-not-run"),
+      availableToolNames: ["web_search"],
+      routerId: "router-a",
+      send: vi.fn(),
+      delegation: () => ({
+        subAgentManager: subAgentManager as any,
+        policyEngine: null,
+        verifier: null,
+        lifecycleEmitter: null,
+      }),
+    });
+
+    const result = await handler("execute_with_agent", {
+      task: "Compare Canvas API, Phaser, and PixiJS from official docs",
+      inputContract:
+        "Return JSON with selected framework and supporting evidence",
+      tools: ["web_search"],
+    });
+    const parsed = JSON.parse(result) as {
+      success?: boolean;
+      providerEvidence?: {
+        serverSideToolCalls?: Array<{ type?: string; toolType?: string }>;
+        serverSideToolUsage?: Array<{ category?: string; count?: number }>;
+      };
+    };
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.providerEvidence?.serverSideToolCalls).toEqual([
+      expect.objectContaining({
+        type: "web_search_call",
+        toolType: "web_search",
+      }),
+    ]);
+    expect(parsed.providerEvidence?.serverSideToolUsage).toEqual([
+      expect.objectContaining({
+        category: "SERVER_SIDE_TOOL_WEB_SEARCH",
+        count: 1,
+      }),
+    ]);
+  });
+
   it("clamps execute_with_agent timeoutMs to a safe minimum", async () => {
     const subAgentManager = {
       spawn: vi.fn(async () => "subagent:child-min-timeout"),

--- a/runtime/src/llm/chat-executor-contract-flow.ts
+++ b/runtime/src/llm/chat-executor-contract-flow.ts
@@ -582,6 +582,8 @@ function analyzeLegacyCompletionTurn(
   const hasMutationProgress = mutatedArtifacts.length > 0;
   const hasResearchEvidence =
     (ctx.providerEvidence?.citations?.length ?? 0) > 0 ||
+    (ctx.providerEvidence?.serverSideToolCalls?.length ?? 0) > 0 ||
+    (ctx.providerEvidence?.serverSideToolUsage?.length ?? 0) > 0 ||
     successfulToolCalls.some((toolCall) =>
       toolCall.name.startsWith(BROWSER_TOOL_PREFIX) ||
       RESEARCH_TOOL_NAMES.has(toolCall.name),

--- a/runtime/src/llm/chat-executor-text.test.ts
+++ b/runtime/src/llm/chat-executor-text.test.ts
@@ -56,6 +56,34 @@ describe("chat-executor-text", () => {
     );
   });
 
+  it("surfaces provider-native server-side tool telemetry even without citations", () => {
+    const message = buildToolExecutionGroundingMessage({
+      toolCalls: [],
+      providerEvidence: {
+        serverSideToolCalls: [
+          {
+            type: "web_search_call",
+            toolType: "web_search",
+            id: "ws_123",
+            status: "completed",
+          },
+        ],
+        serverSideToolUsage: [
+          {
+            category: "SERVER_SIDE_TOOL_WEB_SEARCH",
+            toolType: "web_search",
+            count: 1,
+          },
+        ],
+      },
+    });
+
+    expect(message).toBeDefined();
+    expect(String(message?.content)).toContain('"providerServerSideToolCallCount":1');
+    expect(String(message?.content)).toContain('"type":"web_search_call"');
+    expect(String(message?.content)).toContain('"category":"SERVER_SIDE_TOOL_WEB_SEARCH"');
+  });
+
   it("keeps oversized runtime tool ledgers bounded and marks them truncated", () => {
     const message = buildToolExecutionGroundingMessage({
       toolCalls: Array.from({ length: 30 }, (_, index) => ({

--- a/runtime/src/llm/chat-executor-text.ts
+++ b/runtime/src/llm/chat-executor-text.ts
@@ -1453,6 +1453,23 @@ function buildToolExecutionLedgerPayload(params: {
   );
   const citations = (providerEvidence?.citations ?? [])
     .map((citation) => truncateText(citation, MAX_TOOL_LEDGER_CITATION_CHARS));
+  const providerServerSideToolCalls = (providerEvidence?.serverSideToolCalls ?? [])
+    .map((toolCall, index) => ({
+      index: index + 1,
+      type: toolCall.type,
+      toolType: toolCall.toolType,
+      ...(typeof toolCall.status === "string" ? { status: toolCall.status } : {}),
+      ...(typeof toolCall.functionName === "string"
+        ? { functionName: toolCall.functionName }
+        : {}),
+      ...(typeof toolCall.id === "string" ? { id: toolCall.id } : {}),
+    }));
+  const providerServerSideToolUsage = (providerEvidence?.serverSideToolUsage ?? [])
+    .map((entry) => ({
+      category: entry.category,
+      ...(typeof entry.toolType === "string" ? { toolType: entry.toolType } : {}),
+      count: entry.count,
+    }));
 
   return {
     authoritative: true,
@@ -1468,6 +1485,15 @@ function buildToolExecutionLedgerPayload(params: {
       }
       : {}),
     ...(citations.length > 0 ? { providerCitations: citations } : {}),
+    ...(providerServerSideToolCalls.length > 0
+      ? {
+        providerServerSideToolCallCount: providerServerSideToolCalls.length,
+        providerServerSideToolCalls,
+      }
+      : {}),
+    ...(providerServerSideToolUsage.length > 0
+      ? { providerServerSideToolUsage }
+      : {}),
   };
 }
 
@@ -1507,7 +1533,11 @@ export function buildToolExecutionGroundingMessage(params: {
   providerEvidence?: LLMProviderEvidence;
 }): LLMMessage | undefined {
   const { toolCalls, providerEvidence } = params;
-  if (toolCalls.length === 0 && (providerEvidence?.citations?.length ?? 0) === 0) {
+  const hasProviderEvidence =
+    (providerEvidence?.citations?.length ?? 0) > 0 ||
+    (providerEvidence?.serverSideToolCalls?.length ?? 0) > 0 ||
+    (providerEvidence?.serverSideToolUsage?.length ?? 0) > 0;
+  if (toolCalls.length === 0 && !hasProviderEvidence) {
     return undefined;
   }
 

--- a/runtime/src/llm/chat-executor-verifier.test.ts
+++ b/runtime/src/llm/chat-executor-verifier.test.ts
@@ -205,6 +205,37 @@ describe("evaluateSubagentDeterministicChecks", () => {
       "missing_successful_tool_evidence",
     );
   });
+
+  it("accepts provider-native server-side tool telemetry as research evidence", () => {
+    const decision = evaluateSubagentDeterministicChecks(
+      [createStep({
+        name: "tech_research",
+        objective:
+          "Compare Canvas API, Phaser, and PixiJS from official docs",
+        inputContract:
+          "Return JSON with selected framework and supporting evidence",
+        acceptanceCriteria: ["Ground the choice in official sources"],
+        requiredToolCapabilities: ["web_search"],
+      })],
+      {
+        status: "completed",
+        context: {
+          results: {
+            tech_research:
+              '{"success":true,"status":"completed","output":"{\\"selected\\":\\"pixi\\",\\"why\\":[\\"small\\",\\"fast\\"],\\"evidence\\":[\\"official docs reviewed via provider-native web search\\"]}","toolCalls":0,"providerEvidence":{"serverSideToolCalls":[{"type":"web_search_call","toolType":"web_search","status":"completed","id":"ws_123"}],"serverSideToolUsage":[{"category":"SERVER_SIDE_TOOL_WEB_SEARCH","toolType":"web_search","count":1}]}}',
+          },
+        },
+        completedSteps: 1,
+        totalSteps: 1,
+      },
+      createPlannerContext(),
+    );
+
+    expect(decision.overall).toBe("pass");
+    expect(decision.steps[0]?.issues).not.toContain(
+      "missing_successful_tool_evidence",
+    );
+  });
 });
 
 describe("buildPlannerWorkflowAdmission", () => {

--- a/runtime/src/llm/chat-executor-verifier.ts
+++ b/runtime/src/llm/chat-executor-verifier.ts
@@ -18,7 +18,12 @@ import type {
   SubagentVerifierStepAssessment,
   SubagentVerifierDecision,
 } from "./chat-executor-types.js";
-import type { LLMMessage } from "./types.js";
+import type {
+  LLMMessage,
+  LLMProviderEvidence,
+  LLMProviderNativeServerToolCall,
+  LLMProviderServerSideToolUsageEntry,
+} from "./types.js";
 import type { ImplementationCompletionContract } from "../workflow/completion-contract.js";
 import type {
   WorkflowRequestCompletionContract,
@@ -177,11 +182,7 @@ export function evaluatePlannerDeterministicChecks(
         readonly isError?: boolean;
       }[]
       | undefined;
-    let providerEvidence:
-      | {
-        readonly citations?: readonly string[];
-      }
-      | undefined;
+    let providerEvidence: LLMProviderEvidence | undefined;
 
     if (typeof raw !== "string") {
       issues.push("missing_subagent_result");
@@ -259,19 +260,7 @@ export function evaluatePlannerDeterministicChecks(
           ? parsed.failedToolCalls
           : 0;
         const parsedProviderEvidence = parsed.providerEvidence;
-        if (
-          parsedProviderEvidence &&
-          typeof parsedProviderEvidence === "object" &&
-          !Array.isArray(parsedProviderEvidence)
-        ) {
-          const citations = Array.isArray(
-            (parsedProviderEvidence as { citations?: unknown }).citations,
-          )
-            ? (parsedProviderEvidence as { citations: unknown[] }).citations
-              .filter((entry): entry is string => typeof entry === "string")
-            : [];
-          providerEvidence = citations.length > 0 ? { citations } : undefined;
-        }
+        providerEvidence = parseStructuredProviderEvidence(parsedProviderEvidence);
         if (parsed.success === false || status === "failed") {
           issues.push("child_reported_failure");
           verdict = "retry";
@@ -772,8 +761,10 @@ function collectDeterministicImplementationToolCalls(params: {
 function collectDeterministicImplementationProviderEvidence(params: {
   readonly pipelineResult: PipelineResult;
   readonly resultStepNames?: readonly string[];
-}): { readonly citations?: readonly string[] } | undefined {
+}): LLMProviderEvidence | undefined {
   const citations = new Set<string>();
+  const serverSideToolCalls = new Map<string, LLMProviderNativeServerToolCall>();
+  const serverSideToolUsage = new Map<string, LLMProviderServerSideToolUsageEntry>();
   const resultStepNames =
     params.resultStepNames && params.resultStepNames.length > 0
       ? params.resultStepNames
@@ -785,27 +776,161 @@ function collectDeterministicImplementationProviderEvidence(params: {
       continue;
     }
     const parsed = parseJsonObjectFromText(raw);
-    const providerEvidence = parsed?.providerEvidence;
-    if (
-      !providerEvidence ||
-      typeof providerEvidence !== "object" ||
-      Array.isArray(providerEvidence)
-    ) {
+    const providerEvidence = parseStructuredProviderEvidence(parsed?.providerEvidence);
+    if (!providerEvidence) {
       continue;
     }
-    const stepCitations = Array.isArray(
-      (providerEvidence as { citations?: unknown }).citations,
-    )
-      ? (providerEvidence as { citations: unknown[] }).citations
-      : [];
-    for (const citation of stepCitations) {
+    for (const citation of providerEvidence.citations ?? []) {
       if (typeof citation === "string" && citation.trim().length > 0) {
         citations.add(citation.trim());
       }
     }
+    for (const toolCall of providerEvidence.serverSideToolCalls ?? []) {
+      serverSideToolCalls.set(
+        stableVerifierServerSideToolCallSignature(toolCall),
+        toolCall,
+      );
+    }
+    for (const entry of providerEvidence.serverSideToolUsage ?? []) {
+      const key = `${entry.category}::${entry.toolType ?? ""}`;
+      const current = serverSideToolUsage.get(key);
+      serverSideToolUsage.set(key, {
+        category: entry.category,
+        ...(entry.toolType ? { toolType: entry.toolType } : {}),
+        count: (current?.count ?? 0) + entry.count,
+      });
+    }
   }
 
-  return citations.size > 0 ? { citations: [...citations] } : undefined;
+  if (
+    citations.size === 0 &&
+    serverSideToolCalls.size === 0 &&
+    serverSideToolUsage.size === 0
+  ) {
+    return undefined;
+  }
+  return {
+    ...(citations.size > 0 ? { citations: [...citations] } : {}),
+    ...(serverSideToolCalls.size > 0
+      ? { serverSideToolCalls: [...serverSideToolCalls.values()] }
+      : {}),
+    ...(serverSideToolUsage.size > 0
+      ? { serverSideToolUsage: [...serverSideToolUsage.values()] }
+      : {}),
+  };
+}
+
+function parseStructuredProviderEvidence(
+  value: unknown,
+): LLMProviderEvidence | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const record = value as Record<string, unknown>;
+  const citations = Array.isArray(record.citations)
+    ? record.citations
+      .filter((entry): entry is string => typeof entry === "string")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0)
+    : [];
+  const serverSideToolCalls = Array.isArray(record.serverSideToolCalls)
+    ? record.serverSideToolCalls
+      .map((entry) => parseStructuredServerSideToolCall(entry))
+      .filter(
+        (entry): entry is LLMProviderNativeServerToolCall => entry !== undefined,
+      )
+    : [];
+  const serverSideToolUsage = Array.isArray(record.serverSideToolUsage)
+    ? record.serverSideToolUsage
+      .map((entry) => parseStructuredServerSideToolUsageEntry(entry))
+      .filter(
+        (entry): entry is LLMProviderServerSideToolUsageEntry =>
+          entry !== undefined,
+      )
+    : [];
+
+  if (
+    citations.length === 0 &&
+    serverSideToolCalls.length === 0 &&
+    serverSideToolUsage.length === 0
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...(citations.length > 0 ? { citations } : {}),
+    ...(serverSideToolCalls.length > 0 ? { serverSideToolCalls } : {}),
+    ...(serverSideToolUsage.length > 0 ? { serverSideToolUsage } : {}),
+  };
+}
+
+function parseStructuredServerSideToolCall(
+  value: unknown,
+): LLMProviderNativeServerToolCall | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.type !== "string" ||
+    typeof record.toolType !== "string"
+  ) {
+    return undefined;
+  }
+  const normalized: LLMProviderNativeServerToolCall = {
+    type: record.type as LLMProviderNativeServerToolCall["type"],
+    toolType: record.toolType as LLMProviderNativeServerToolCall["toolType"],
+    ...(typeof record.id === "string" ? { id: record.id } : {}),
+    ...(typeof record.functionName === "string"
+      ? { functionName: record.functionName }
+      : {}),
+    ...(typeof record.arguments === "string"
+      ? { arguments: record.arguments }
+      : {}),
+    ...(typeof record.status === "string" ? { status: record.status } : {}),
+    ...(record.raw && typeof record.raw === "object" && !Array.isArray(record.raw)
+      ? { raw: record.raw as Record<string, unknown> }
+      : {}),
+  };
+  return normalized;
+}
+
+function parseStructuredServerSideToolUsageEntry(
+  value: unknown,
+): LLMProviderServerSideToolUsageEntry | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.category !== "string" ||
+    typeof record.count !== "number" ||
+    !Number.isFinite(record.count) ||
+    record.count <= 0
+  ) {
+    return undefined;
+  }
+  return {
+    category: record.category,
+    ...(typeof record.toolType === "string"
+      ? { toolType: record.toolType as LLMProviderServerSideToolUsageEntry["toolType"] }
+      : {}),
+    count: record.count,
+  };
+}
+
+function stableVerifierServerSideToolCallSignature(
+  toolCall: LLMProviderNativeServerToolCall,
+): string {
+  return safeStringify({
+    type: toolCall.type,
+    toolType: toolCall.toolType,
+    id: toolCall.id,
+    functionName: toolCall.functionName,
+    arguments: toolCall.arguments,
+    status: toolCall.status,
+  });
 }
 
 function stableVerifierToolCallSignature(toolCall: {

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -2278,6 +2278,66 @@ describe("ChatExecutor", () => {
       expect(firstOptions?.toolRouting?.allowedToolNames).toEqual(["web_search"]);
     });
 
+    it("preserves provider-native server-side tool telemetry for delegated research", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: '{"selected":"pixi","why":["small","fast"]}',
+            providerEvidence: {
+              serverSideToolCalls: [
+                {
+                  type: "web_search_call",
+                  toolType: "web_search",
+                  id: "ws_123",
+                  status: "completed",
+                },
+              ],
+              serverSideToolUsage: [
+                {
+                  category: "SERVER_SIDE_TOOL_WEB_SEARCH",
+                  toolType: "web_search",
+                  count: 1,
+                },
+              ],
+            },
+          }),
+        ),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        allowedTools: ["web_search"],
+      });
+      const result = await executor.execute(
+        createParams({
+          requiredToolEvidence: {
+            maxCorrectionAttempts: 1,
+            delegationSpec: {
+              task: "tech_research",
+              objective:
+                "Compare Canvas API, Phaser, and PixiJS from official docs",
+              inputContract:
+                "Return JSON with selected framework and supporting evidence",
+            },
+          },
+        }),
+      );
+
+      expect(result.stopReason).toBe("completed");
+      expect(result.providerEvidence?.serverSideToolCalls).toEqual([
+        expect.objectContaining({
+          type: "web_search_call",
+          toolType: "web_search",
+        }),
+      ]);
+      expect(result.providerEvidence?.serverSideToolUsage).toEqual([
+        expect.objectContaining({
+          category: "SERVER_SIDE_TOOL_WEB_SEARCH",
+          count: 1,
+        }),
+      ]);
+    });
+
     it("forces an editor-first tool choice for implementation delegation", async () => {
       const provider = createMockProvider("primary", {
         chat: vi

--- a/runtime/src/utils/delegation-validation.test.ts
+++ b/runtime/src/utils/delegation-validation.test.ts
@@ -1944,6 +1944,40 @@ describe("delegation-validation", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("accepts research output backed by provider-native server-side tool telemetry", () => {
+    const result = validateDelegatedOutputContract({
+      spec: {
+        task: "tech_research",
+        objective:
+          "Compare Canvas API, Phaser, and PixiJS from official docs and cite sources",
+        inputContract:
+          "Return JSON with selected framework and supporting evidence",
+        requiredToolCapabilities: [PROVIDER_NATIVE_WEB_SEARCH_TOOL],
+      },
+      output: '{"selected":"pixi","why":["small","fast"]}',
+      toolCalls: [],
+      providerEvidence: {
+        serverSideToolCalls: [
+          {
+            type: "web_search_call",
+            toolType: "web_search",
+            id: "ws_123",
+            status: "completed",
+          },
+        ],
+        serverSideToolUsage: [
+          {
+            category: "SERVER_SIDE_TOOL_WEB_SEARCH",
+            toolType: "web_search",
+            count: 1,
+          },
+        ],
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
   it("treats the parent request as browser-grounded evidence context for research steps", () => {
     expect(specRequiresMeaningfulBrowserEvidence({
       task: "design_research",

--- a/runtime/src/utils/delegation-validation.ts
+++ b/runtime/src/utils/delegation-validation.ts
@@ -3436,7 +3436,7 @@ function getMeaningfulBrowserEvidenceFailureMessage(
 ): string | undefined {
   if (!specRequiresMeaningfulBrowserEvidence(spec)) return undefined;
   const taskIntent = classifyDelegatedTaskIntent(spec);
-  if (taskIntent === "research" && hasProviderCitationEvidence(providerEvidence)) {
+  if (taskIntent === "research" && hasProviderResearchEvidence(providerEvidence)) {
     return undefined;
   }
   if (
@@ -3462,6 +3462,22 @@ function hasProviderCitationEvidence(
   );
 }
 
+function hasProviderServerSideToolEvidence(
+  providerEvidence: DelegationValidationProviderEvidence | undefined,
+): boolean {
+  return (providerEvidence?.serverSideToolCalls?.length ?? 0) > 0 ||
+    (providerEvidence?.serverSideToolUsage ?? []).some((entry) =>
+      typeof entry.count === "number" && Number.isFinite(entry.count) && entry.count > 0
+    );
+}
+
+function hasProviderResearchEvidence(
+  providerEvidence: DelegationValidationProviderEvidence | undefined,
+): boolean {
+  return hasProviderCitationEvidence(providerEvidence) ||
+    hasProviderServerSideToolEvidence(providerEvidence);
+}
+
 function getSuccessfulToolEvidenceFailure(
   toolCalls: readonly DelegationValidationToolCall[] | undefined,
   spec?: DelegationContractSpec,
@@ -3473,7 +3489,7 @@ function getSuccessfulToolEvidenceFailure(
   if (
     spec &&
     classifyDelegatedTaskIntent(spec) === "research" &&
-    hasProviderCitationEvidence(providerEvidence)
+    hasProviderResearchEvidence(providerEvidence)
   ) {
     return undefined;
   }
@@ -3518,7 +3534,7 @@ function validateSuccessfulToolEvidence(
     if (
       specRequiresSuccessfulToolEvidence(spec) &&
       classifyDelegatedTaskIntent(spec) === "research" &&
-      hasProviderCitationEvidence(providerEvidence)
+      hasProviderResearchEvidence(providerEvidence)
     ) {
       return undefined;
     }


### PR DESCRIPTION
## Summary
- propagate xAI MCP-documented server-side tool evidence through verifier, delegation validation, and runtime grounding
- treat provider-native server-side tool telemetry as research evidence in completion and delegation paths
- add targeted tests for grounding, verifier parsing, delegated child payloads, and research validation

## Test plan
- npx vitest run src/llm/chat-executor-text.test.ts src/llm/chat-executor-verifier.test.ts src/utils/delegation-validation.test.ts src/gateway/tool-handler-factory.test.ts src/llm/chat-executor.test.ts
- npx vitest run src/llm/chat-executor-contract-flow.test.ts src/gateway/subagent-orchestrator.test.ts -t "provider-native|research"
- npx tsc --noEmit