### PR TITLE
feat(runtime): wire xai native tool routing

### DIFF
--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -3311,6 +3311,64 @@ describe("DaemonManager", () => {
     expect(genericDecision?.routedToolNames).not.toContain("web_search");
   });
 
+  it("augments tool routing with xAI-native x_search, file_search, code_interpreter, and remote MCP tools", () => {
+    const dm = new DaemonManager({ configPath: "/tmp/config.json" });
+    (dm as any)._toolRouter = new ToolRouter([
+      {
+        type: "function",
+        function: {
+          name: "desktop.bash",
+          description: "run commands",
+          parameters: { type: "object", properties: {} },
+        },
+      },
+    ]);
+
+    (dm as any)._primaryLlmConfig = {
+      provider: "grok",
+      model: "grok-4-1-fast-reasoning",
+      xSearch: true,
+      codeExecution: true,
+      collectionsSearch: {
+        enabled: true,
+        vectorStoreIds: ["collection-123"],
+      },
+      remoteMcp: {
+        enabled: true,
+        servers: [
+          {
+            serverUrl: "https://mcp.deepwiki.com/mcp",
+            serverLabel: "deepwiki",
+            serverDescription: "DeepWiki repository and documentation explorer",
+            allowedTools: ["search_docs"],
+          },
+        ],
+      },
+    };
+
+    const xDecision = (dm as any).buildToolRoutingDecision(
+      "s-x-search",
+      "What are people saying about xAI on X right now?",
+      [],
+    );
+    const fileAndCodeDecision = (dm as any).buildToolRoutingDecision(
+      "s-file-code",
+      "Using the uploaded knowledge base, calculate totals from the internal documents and show your working.",
+      [],
+    );
+    const remoteMcpDecision = (dm as any).buildToolRoutingDecision(
+      "s-remote-mcp",
+      "Use DeepWiki to search docs for the repository adapter behavior.",
+      [],
+    );
+
+    expect(xDecision?.routedToolNames).toContain("x_search");
+    expect(fileAndCodeDecision?.routedToolNames).toEqual(
+      expect.arrayContaining(["file_search", "code_interpreter"]),
+    );
+    expect(remoteMcpDecision?.routedToolNames).toContain("mcp:deepwiki");
+  });
+
   it("registers social tools when enabled", async () => {
     const dm = new DaemonManager({ configPath: "/tmp/config.json" });
     const registry = await (dm as any).createToolRegistry({

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -102,7 +102,7 @@ import {
 import { resolveToolContractExecutionBlock } from "../llm/chat-executor-contract-guidance.js";
 import {
   getProviderNativeAdvertisedToolNames,
-  getProviderNativeWebSearchRoutingDecision,
+  getProviderNativeToolRoutingDecisions,
 } from "../llm/provider-native-search.js";
 import {
   createLLMProviders as createLLMProvidersStandalone,
@@ -4696,7 +4696,7 @@ export class DaemonManager {
         messageText,
         history,
       });
-      return this.maybeAugmentToolRoutingDecisionWithNativeSearch(
+      return this.maybeAugmentToolRoutingDecisionWithNativeTools(
         decision,
         messageText,
         history,
@@ -4749,41 +4749,43 @@ export class DaemonManager {
     );
   }
 
-  private maybeAugmentToolRoutingDecisionWithNativeSearch(
+  private maybeAugmentToolRoutingDecisionWithNativeTools(
     decision: ToolRoutingDecision,
     messageText: string,
     history: readonly LLMMessage[],
   ): ToolRoutingDecision {
-    const nativeSearch = getProviderNativeWebSearchRoutingDecision({
+    const nativeTools = getProviderNativeToolRoutingDecisions({
       llmConfig: this._primaryLlmConfig,
       messageText,
       history,
     });
-    if (!nativeSearch) return decision;
+    if (nativeTools.length === 0) return decision;
 
-    const routedToolNames = Array.from(
-      new Set([...decision.routedToolNames, nativeSearch.toolName]),
-    );
-    const expandedToolNames = Array.from(
-      new Set([...decision.expandedToolNames, nativeSearch.toolName]),
-    );
-    if (
-      routedToolNames.length === decision.routedToolNames.length &&
-      expandedToolNames.length === decision.expandedToolNames.length
-    ) {
+    const addedRoutedTools = nativeTools
+      .map((tool) => tool.toolName)
+      .filter((toolName) => !decision.routedToolNames.includes(toolName));
+    const addedExpandedTools = nativeTools
+      .map((tool) => tool.toolName)
+      .filter((toolName) => !decision.expandedToolNames.includes(toolName));
+    if (addedRoutedTools.length === 0 && addedExpandedTools.length === 0) {
       return decision;
     }
 
-    const routedAdded =
-      routedToolNames.length > decision.routedToolNames.length
-        ? nativeSearch.schemaChars
-        : 0;
-    const expandedAdded =
-      expandedToolNames.length > decision.expandedToolNames.length
-        ? nativeSearch.schemaChars
-        : 0;
+    const routedToolNames = Array.from(
+      new Set([...decision.routedToolNames, ...addedRoutedTools]),
+    );
+    const expandedToolNames = Array.from(
+      new Set([...decision.expandedToolNames, ...addedExpandedTools]),
+    );
+    const routedAdded = nativeTools
+      .filter((tool) => addedRoutedTools.includes(tool.toolName))
+      .reduce((sum, tool) => sum + tool.schemaChars, 0);
+    const expandedAdded = nativeTools
+      .filter((tool) => addedExpandedTools.includes(tool.toolName))
+      .reduce((sum, tool) => sum + tool.schemaChars, 0);
     const schemaCharsFull =
-      decision.diagnostics.schemaCharsFull + nativeSearch.schemaChars;
+      decision.diagnostics.schemaCharsFull +
+      nativeTools.reduce((sum, tool) => sum + tool.schemaChars, 0);
     const schemaCharsRouted =
       decision.diagnostics.schemaCharsRouted + routedAdded;
     const schemaCharsExpanded =
@@ -4794,7 +4796,9 @@ export class DaemonManager {
       expandedToolNames,
       diagnostics: {
         ...decision.diagnostics,
-        totalToolCount: decision.diagnostics.totalToolCount + 1,
+        totalToolCount:
+          decision.diagnostics.totalToolCount +
+          nativeTools.length,
         routedToolCount: routedToolNames.length,
         expandedToolCount: expandedToolNames.length,
         schemaCharsFull,

--- a/runtime/src/llm/chat-executor-contract-flow.ts
+++ b/runtime/src/llm/chat-executor-contract-flow.ts
@@ -40,6 +40,9 @@ import {
   plannerRequestNeedsPlanArtifactExecution,
   requestRequiresToolGroundedExecution,
 } from "./chat-executor-planner.js";
+import {
+  PROVIDER_NATIVE_GROUNDED_INFORMATION_TOOL_NAMES,
+} from "./provider-native-search.js";
 
 type ToolNameCollection = Iterable<string> | readonly string[];
 
@@ -94,7 +97,9 @@ const DIRECT_MUTATION_TOOL_NAMES = new Set([
   "system.writeFile",
 ]);
 const BROWSER_TOOL_PREFIX = "mcp.browser.";
-const RESEARCH_TOOL_NAMES = new Set(["web_search"]);
+const RESEARCH_TOOL_NAMES: ReadonlySet<string> = new Set(
+  PROVIDER_NATIVE_GROUNDED_INFORMATION_TOOL_NAMES,
+);
 const DOC_ONLY_PATH_RE = /\.(?:md|mdx|txt|rst|adoc)$/i;
 const DOC_BASENAME_RE =
   /(?:^|\/)(?:README|CHANGELOG|CONTRIBUTING|LICENSE|COPYING|NOTES|AGENTS|AGENC)(?:\.[^/]+)?$/i;

--- a/runtime/src/llm/provider-native-search.test.ts
+++ b/runtime/src/llm/provider-native-search.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   getProviderNativeAdvertisedToolNames,
+  getProviderNativeToolRoutingDecisions,
   getProviderNativeToolDefinitions,
   getProviderNativeWebSearchRoutingDecision,
   isResearchLikeText,
@@ -117,6 +118,104 @@ describe("provider-native-search", () => {
     });
 
     expect(decision?.toolName).toBe("web_search");
+  });
+
+  it("routes x_search for X-specific prompts", () => {
+    const decisions = getProviderNativeToolRoutingDecisions({
+      llmConfig: {
+        provider: "grok",
+        model: "grok-4-1-fast-reasoning",
+        xSearch: true,
+      },
+      messageText: "What are people saying about xAI on X right now?",
+      history: [],
+    });
+
+    expect(decisions.map((decision) => decision.toolName)).toEqual(["x_search"]);
+  });
+
+  it("routes file_search for uploaded-collection prompts", () => {
+    const decisions = getProviderNativeToolRoutingDecisions({
+      llmConfig: {
+        provider: "grok",
+        model: "grok-4-1-fast-reasoning",
+        collectionsSearch: {
+          enabled: true,
+          vectorStoreIds: ["collection-123"],
+        },
+      },
+      messageText:
+        "Use the uploaded collection and internal documents to answer the policy question.",
+      history: [],
+    });
+
+    expect(decisions.map((decision) => decision.toolName)).toEqual(["file_search"]);
+  });
+
+  it("routes code_interpreter for calculation and data-analysis prompts", () => {
+    const decisions = getProviderNativeToolRoutingDecisions({
+      llmConfig: {
+        provider: "grok",
+        model: "grok-4-1-fast-reasoning",
+        codeExecution: true,
+      },
+      messageText:
+        "Calculate the regression on this dataset [120000, 135000, 98000, 156000] and show your working.",
+      history: [],
+    });
+
+    expect(decisions.map((decision) => decision.toolName)).toEqual([
+      "code_interpreter",
+    ]);
+  });
+
+  it("routes hybrid collection analysis to file_search plus code_interpreter", () => {
+    const decisions = getProviderNativeToolRoutingDecisions({
+      llmConfig: {
+        provider: "grok",
+        model: "grok-4-1-fast-reasoning",
+        collectionsSearch: {
+          enabled: true,
+          vectorStoreIds: ["collection-123"],
+        },
+        codeExecution: true,
+      },
+      messageText:
+        "Using the uploaded knowledge base, calculate the totals from the internal reports and show your working.",
+      history: [],
+    });
+
+    expect(decisions.map((decision) => decision.toolName)).toEqual([
+      "file_search",
+      "code_interpreter",
+    ]);
+  });
+
+  it("routes remote MCP servers when the prompt matches configured metadata", () => {
+    const decisions = getProviderNativeToolRoutingDecisions({
+      llmConfig: {
+        provider: "grok",
+        model: "grok-4-1-fast-reasoning",
+        remoteMcp: {
+          enabled: true,
+          servers: [
+            {
+              serverUrl: "https://mcp.deepwiki.com/mcp",
+              serverLabel: "deepwiki",
+              serverDescription: "DeepWiki repository and documentation explorer",
+              allowedTools: ["search_docs", "read_repo"],
+            },
+          ],
+        },
+      },
+      messageText:
+        "Use DeepWiki to explore the repository documentation and search docs for the adapter behavior.",
+      history: [],
+    });
+
+    expect(decisions.map((decision) => decision.toolName)).toEqual([
+      "mcp:deepwiki",
+    ]);
   });
 
   it("does not treat implementation mechanics language as research", () => {

--- a/runtime/src/llm/provider-native-search.ts
+++ b/runtime/src/llm/provider-native-search.ts
@@ -15,11 +15,29 @@ export const PROVIDER_NATIVE_X_SEARCH_TOOL = "x_search";
 export const PROVIDER_NATIVE_CODE_INTERPRETER_TOOL = "code_interpreter";
 export const PROVIDER_NATIVE_FILE_SEARCH_TOOL = "file_search";
 export const PROVIDER_NATIVE_MCP_TOOL_PREFIX = "mcp:";
+export const PROVIDER_NATIVE_RESEARCH_TOOL_NAMES = [
+  PROVIDER_NATIVE_WEB_SEARCH_TOOL,
+  PROVIDER_NATIVE_X_SEARCH_TOOL,
+  PROVIDER_NATIVE_FILE_SEARCH_TOOL,
+] as const;
+export const PROVIDER_NATIVE_GROUNDED_INFORMATION_TOOL_NAMES = [
+  ...PROVIDER_NATIVE_RESEARCH_TOOL_NAMES,
+  PROVIDER_NATIVE_CODE_INTERPRETER_TOOL,
+] as const;
 
 const RESEARCH_LIKE_RE =
   /\b(?:research|compare|comparison|official docs?|primary sources?|reference|references|citation|citations|look up|latest|up[- ]to[- ]date|news)\b/i;
 const INTERACTIVE_BROWSER_RE =
   /\b(?:localhost|127\.0\.0\.1|about:blank|screenshot|snapshot|console|network|dom|inspect|click|type|hover|scroll|fill|select|tab|tabs|window|windows|playtest|qa|end-to-end|e2e|navigate to|open the page)\b/i;
+const WEB_SEARCH_CUE_RE =
+  /\b(?:official docs?|documentation|docs?|website|web search|search the web|latest|news|current status|current state|up[- ]to[- ]date)\b/i;
+const X_SEARCH_CUE_RE =
+  /(?:\bon x\b|\bfrom x\b|\bx posts?\b|\bx handles?\b|\bx threads?\b|\btwitter\b|\btweets?\b|\bposts?\s+on\s+x\b|\bwhat are people saying\b|\bsentiment\b|\bhandle(?:s)?\b|\bthread(?:s)?\b)/i;
+const FILE_SEARCH_CUE_RE =
+  /\b(?:collection|collections|knowledge base|knowledgebase|uploaded (?:docs?|documents?|files?)|internal (?:docs?|documents?|policies?|knowledge)|my (?:docs?|documents?|files)|our (?:docs?|documents?|files)|from (?:the )?(?:collection|collections|knowledge base|uploaded|internal) (?:docs?|documents?|files))\b/i;
+const CODE_EXECUTION_CUE_RE =
+  /\b(?:calculate|calculation|compute|computation|statistical|statistics|correlation|regression|linear regression|matrix|equation|simulate|simulation|forecast|predict|prediction|t-test|anova|sharpe|dataset|csv|plot|chart|graph|visuali[sz]ation|show your working|show the working)\b/i;
+const SIGNIFICANT_TOKEN_RE = /[a-z0-9][a-z0-9_-]{2,}/gi;
 const GROK_SERVER_SIDE_TOOL_PREFIX = "grok-4";
 
 export type ProviderNativeSearchMode = "auto" | "on" | "off";
@@ -248,20 +266,51 @@ export function isInteractiveBrowserText(value: string): boolean {
   return INTERACTIVE_BROWSER_RE.test(value);
 }
 
-export function getProviderNativeWebSearchRoutingDecision(
-  params: {
-    readonly llmConfig: Pick<
-      GatewayLLMConfig,
-      "provider" | "model" | "webSearch" | "searchMode"
-    > | undefined;
-    readonly messageText: string;
-    readonly history: readonly LLMMessage[];
-  },
-): ProviderNativeSearchRoutingDecision | undefined {
-  const mode = resolveProviderNativeSearchMode(params.llmConfig);
-  if (mode === "off") return undefined;
+export function isXSearchLikeText(value: string): boolean {
+  return X_SEARCH_CUE_RE.test(value);
+}
 
-  const recentHistory = params.history
+export function isCollectionsSearchLikeText(value: string): boolean {
+  return FILE_SEARCH_CUE_RE.test(value);
+}
+
+export function isCodeExecutionLikeText(value: string): boolean {
+  return CODE_EXECUTION_CUE_RE.test(value) ||
+    (/\b(?:data|numbers?)\b/i.test(value) && /\[[^\]]+\]/.test(value));
+}
+
+export function selectPreferredProviderNativeResearchToolName(params: {
+  readonly messageText: string;
+  readonly allowedToolNames: readonly string[];
+}): string | undefined {
+  const normalizedTools = params.allowedToolNames
+    .map((toolName) => toolName.trim())
+    .filter((toolName) => toolName.length > 0);
+  const combined = params.messageText.toLowerCase();
+  if (
+    isXSearchLikeText(combined) &&
+    normalizedTools.includes(PROVIDER_NATIVE_X_SEARCH_TOOL)
+  ) {
+    return PROVIDER_NATIVE_X_SEARCH_TOOL;
+  }
+  if (
+    isCollectionsSearchLikeText(combined) &&
+    normalizedTools.includes(PROVIDER_NATIVE_FILE_SEARCH_TOOL)
+  ) {
+    return PROVIDER_NATIVE_FILE_SEARCH_TOOL;
+  }
+  return normalizedTools.find((toolName) =>
+    PROVIDER_NATIVE_RESEARCH_TOOL_NAMES.includes(
+      toolName as (typeof PROVIDER_NATIVE_RESEARCH_TOOL_NAMES)[number],
+    )
+  );
+}
+
+function collectRoutingText(
+  messageText: string,
+  history: readonly LLMMessage[],
+): string {
+  const recentHistory = history
     .slice(-4)
     .map((entry) =>
       Array.isArray(entry.content)
@@ -277,23 +326,119 @@ export function getProviderNativeWebSearchRoutingDecision(
       (value): value is string => typeof value === "string" && value.length > 0,
     )
     .join(" ");
-  const combined = `${recentHistory}\n${params.messageText}`.trim();
+  return `${recentHistory}\n${messageText}`.trim();
+}
 
-  if (isInteractiveBrowserText(combined)) {
-    return undefined;
+function extractSignificantTokens(value: string): Set<string> {
+  return new Set(
+    (value.toLowerCase().match(SIGNIFICANT_TOKEN_RE) ?? [])
+      .filter((token) => token.length >= 3),
+  );
+}
+
+function matchesRemoteMcpServer(
+  server: LLMRemoteMcpServerConfig,
+  combinedText: string,
+  combinedTokens: Set<string>,
+): boolean {
+  const label = server.serverLabel.trim().toLowerCase();
+  if (label.length > 0 && combinedText.includes(label)) {
+    return true;
   }
-  if (mode === "on" || isResearchLikeText(combined)) {
-    const definition = createDefinition(
-      PROVIDER_NATIVE_WEB_SEARCH_TOOL,
-      "web_search",
-      { type: PROVIDER_NATIVE_WEB_SEARCH_TOOL },
-    );
-    return {
-      toolName: definition.name,
+  const metadataTokens = extractSignificantTokens([
+    server.serverLabel,
+    server.serverDescription,
+    ...(server.allowedTools ?? []),
+  ]
+    .filter((value): value is string => typeof value === "string")
+    .join(" "));
+  const matchingTokens = [...metadataTokens].filter((token) =>
+    combinedTokens.has(token)
+  );
+  return matchingTokens.length >= 2;
+}
+
+export function getProviderNativeToolRoutingDecisions(
+  params: {
+    readonly llmConfig: ProviderNativeToolConfig | undefined;
+    readonly messageText: string;
+    readonly history: readonly LLMMessage[];
+  },
+): readonly ProviderNativeSearchRoutingDecision[] {
+  const llmConfig = params.llmConfig;
+  if (!llmConfig || llmConfig.provider !== "grok") return [];
+  if (!supportsGrokServerSideTools(llmConfig.model)) return [];
+
+  const definitions = getProviderNativeToolDefinitions(llmConfig);
+  if (definitions.length === 0) return [];
+
+  const byName = new Map(
+    definitions.map((definition) => [definition.name, definition] as const),
+  );
+  const combined = collectRoutingText(params.messageText, params.history).toLowerCase();
+  const combinedTokens = extractSignificantTokens(combined);
+  const decisions: ProviderNativeSearchRoutingDecision[] = [];
+  const pushDecision = (toolName: string) => {
+    if (decisions.some((decision) => decision.toolName === toolName)) {
+      return;
+    }
+    const definition = byName.get(toolName);
+    if (!definition) return;
+    decisions.push({
+      toolName,
       schemaChars: definition.schemaChars,
-    };
+    });
+  };
+
+  const wantsXSearch = llmConfig.xSearch === true && X_SEARCH_CUE_RE.test(combined);
+  const wantsFileSearch =
+    llmConfig.collectionsSearch?.enabled === true &&
+    isCollectionsSearchLikeText(combined);
+  const wantsCodeExecution =
+    llmConfig.codeExecution === true &&
+    isCodeExecutionLikeText(combined);
+  const wantsWebSearch =
+    !isInteractiveBrowserText(combined) &&
+    resolveProviderNativeSearchMode(llmConfig) !== "off" &&
+    (
+      resolveProviderNativeSearchMode(llmConfig) === "on" ||
+      WEB_SEARCH_CUE_RE.test(combined) ||
+      (isResearchLikeText(combined) && !wantsXSearch && !wantsFileSearch)
+    );
+
+  if (wantsXSearch) {
+    pushDecision(PROVIDER_NATIVE_X_SEARCH_TOOL);
   }
-  return undefined;
+  if (wantsFileSearch) {
+    pushDecision(PROVIDER_NATIVE_FILE_SEARCH_TOOL);
+  }
+  if (wantsWebSearch) {
+    pushDecision(PROVIDER_NATIVE_WEB_SEARCH_TOOL);
+  }
+  if (wantsCodeExecution) {
+    pushDecision(PROVIDER_NATIVE_CODE_INTERPRETER_TOOL);
+  }
+  if (llmConfig.remoteMcp?.enabled === true) {
+    for (const server of llmConfig.remoteMcp.servers ?? []) {
+      if (matchesRemoteMcpServer(server, combined, combinedTokens)) {
+        pushDecision(`${PROVIDER_NATIVE_MCP_TOOL_PREFIX}${server.serverLabel}`);
+      }
+    }
+  }
+
+  return decisions;
+}
+
+export function getProviderNativeWebSearchRoutingDecision(
+  params: {
+    readonly llmConfig: ProviderNativeToolConfig | undefined;
+    readonly messageText: string;
+    readonly history: readonly LLMMessage[];
+  },
+): ProviderNativeSearchRoutingDecision | undefined {
+  return getProviderNativeToolRoutingDecisions(params).find(
+    (decision) => decision.toolName === PROVIDER_NATIVE_WEB_SEARCH_TOOL,
+  );
 }
 
 export function isProviderNativeToolName(toolName: string): boolean {

--- a/runtime/src/utils/delegation-validation.test.ts
+++ b/runtime/src/utils/delegation-validation.test.ts
@@ -14,7 +14,11 @@ import {
   specRequiresMeaningfulBrowserEvidence,
   validateDelegatedOutputContract,
 } from "./delegation-validation.js";
-import { PROVIDER_NATIVE_WEB_SEARCH_TOOL } from "../llm/provider-native-search.js";
+import {
+  PROVIDER_NATIVE_FILE_SEARCH_TOOL,
+  PROVIDER_NATIVE_WEB_SEARCH_TOOL,
+  PROVIDER_NATIVE_X_SEARCH_TOOL,
+} from "../llm/provider-native-search.js";
 
 describe("delegation-validation", () => {
   it("normalizes prose punctuation off delegation tokens while preserving file-like artifacts", () => {
@@ -3365,6 +3369,38 @@ Project is functional for core/pathfinding; CLI/web assumed usable per authored 
     );
 
     expect(toolChoice).toBe(PROVIDER_NATIVE_WEB_SEARCH_TOOL);
+  });
+
+  it("resolves provider-native x_search as the initial tool choice for X research", () => {
+    const toolChoice = resolveDelegatedInitialToolChoiceToolName(
+      {
+        task: "x_research",
+        objective:
+          "Find what people are saying about xAI on X and cite the key posts",
+      },
+      [
+        PROVIDER_NATIVE_X_SEARCH_TOOL,
+        PROVIDER_NATIVE_WEB_SEARCH_TOOL,
+      ],
+    );
+
+    expect(toolChoice).toBe(PROVIDER_NATIVE_X_SEARCH_TOOL);
+  });
+
+  it("resolves provider-native file_search as the initial tool choice for uploaded collections research", () => {
+    const toolChoice = resolveDelegatedInitialToolChoiceToolName(
+      {
+        task: "knowledge_base_research",
+        objective:
+          "Use the uploaded collection and internal documents to answer the policy question with citations",
+      },
+      [
+        PROVIDER_NATIVE_FILE_SEARCH_TOOL,
+        PROVIDER_NATIVE_WEB_SEARCH_TOOL,
+      ],
+    );
+
+    expect(toolChoice).toBe(PROVIDER_NATIVE_FILE_SEARCH_TOOL);
   });
 
   it("resolves system.browse as the initial tool choice for research when available", () => {

--- a/runtime/src/utils/delegation-validation.ts
+++ b/runtime/src/utils/delegation-validation.ts
@@ -10,9 +10,13 @@
 import type { LLMProviderEvidence } from "../llm/types.js";
 import type { DelegationExecutionContext } from "./delegation-execution-context.js";
 import {
+  PROVIDER_NATIVE_FILE_SEARCH_TOOL,
+  PROVIDER_NATIVE_RESEARCH_TOOL_NAMES,
   PROVIDER_NATIVE_WEB_SEARCH_TOOL,
-  isResearchLikeText,
+  PROVIDER_NATIVE_X_SEARCH_TOOL,
   isProviderNativeToolName,
+  isResearchLikeText,
+  selectPreferredProviderNativeResearchToolName,
 } from "../llm/provider-native-search.js";
 import {
   extractExactOutputExpectation,
@@ -332,8 +336,8 @@ const LOCAL_FILE_INSPECTION_TOOL_NAMES = new Set([
   "mcp.neovim.vim_buffer_save",
   "mcp.neovim.vim_search_replace",
 ]);
-const PREFERRED_PROVIDER_NATIVE_RESEARCH_TOOL_NAMES = new Set([
-  PROVIDER_NATIVE_WEB_SEARCH_TOOL,
+const PREFERRED_PROVIDER_NATIVE_RESEARCH_TOOL_NAMES: ReadonlySet<string> = new Set([
+  ...PROVIDER_NATIVE_RESEARCH_TOOL_NAMES,
 ]);
 const PREFERRED_IMPLEMENTATION_EDITOR_TOOL_NAMES = new Set([
   "desktop.text_editor",
@@ -409,7 +413,7 @@ function isGenericFilesystemCapabilityName(capability: string): boolean {
 function looksLikeExplicitDelegatedToolName(toolName: string): boolean {
   const normalized = toolName.trim().toLowerCase();
   return normalized === "execute_with_agent" ||
-    normalized === PROVIDER_NATIVE_WEB_SEARCH_TOOL ||
+    isProviderNativeToolName(normalized) ||
     normalized.includes(".") ||
     normalized.startsWith("browser") ||
     normalized.startsWith("playwright") ||
@@ -1940,6 +1944,8 @@ export function resolveDelegatedChildToolScope(params: {
     (requireBrowser || (taskIntent === "research" && !localFileInspectionTask))
   ) {
     addSemanticFallback(PROVIDER_NATIVE_WEB_SEARCH_TOOL);
+    addSemanticFallback(PROVIDER_NATIVE_X_SEARCH_TOOL);
+    addSemanticFallback(PROVIDER_NATIVE_FILE_SEARCH_TOOL);
     addSemanticFallback("system.browse");
     addSemanticFallback("system.browserSessionStart");
     addSemanticFallback("system.browserAction");
@@ -2109,9 +2115,14 @@ export function resolveDelegatedInitialToolChoiceToolName(
   }
 
   if (taskIntent === "research" || taskIntent === "validation" || requireBrowser) {
-    const preferredProviderResearchTool = normalizedTools.find((toolName) =>
-      PREFERRED_PROVIDER_NATIVE_RESEARCH_TOOL_NAMES.has(toolName)
-    );
+    const preferredProviderResearchTool = selectPreferredProviderNativeResearchToolName({
+      messageText: [spec.task, spec.objective, ...(spec.acceptanceCriteria ?? [])]
+        .filter((value): value is string => typeof value === "string" && value.length > 0)
+        .join("\n"),
+      allowedToolNames: normalizedTools.filter((toolName) =>
+        PREFERRED_PROVIDER_NATIVE_RESEARCH_TOOL_NAMES.has(toolName)
+      ),
+    });
     if (taskIntent === "research" && preferredProviderResearchTool) {
       return preferredProviderResearchTool;
     }
@@ -2408,8 +2419,21 @@ export function resolveDelegatedCorrectionToolChoiceToolNames(
     };
 
     if (taskIntent === "research") {
+      const preferredProviderResearchTool = selectPreferredProviderNativeResearchToolName({
+        messageText: [spec.task, spec.objective, ...(spec.acceptanceCriteria ?? [])]
+          .filter((value): value is string => typeof value === "string" && value.length > 0)
+          .join("\n"),
+        allowedToolNames: normalizedTools.filter((toolName) =>
+          PREFERRED_PROVIDER_NATIVE_RESEARCH_TOOL_NAMES.has(toolName)
+        ),
+      });
+      if (preferredProviderResearchTool) {
+        pushFirstAvailable([preferredProviderResearchTool]);
+      }
       pushFirstAvailable([
         PROVIDER_NATIVE_WEB_SEARCH_TOOL,
+        PROVIDER_NATIVE_X_SEARCH_TOOL,
+        PROVIDER_NATIVE_FILE_SEARCH_TOOL,
         ...INITIAL_RESEARCH_TOOL_NAMES,
         ...PREFERRED_RESEARCH_BROWSER_TOOL_NAMES,
       ]);


### PR DESCRIPTION
## Summary
- generalize xAI native tool routing beyond `web_search` to cover `x_search`, `file_search`, `code_interpreter`, and remote MCP tools
- align daemon routing and delegated initial/correction tool choice with the documented xAI MCP tool surface
- broaden grounded-information detection so provider-native X, collections, and code-execution evidence count during contract evaluation

## Test plan
- `npx vitest run src/llm/provider-native-search.test.ts src/gateway/daemon.test.ts src/utils/delegation-validation.test.ts src/llm/chat-executor-contract-flow.test.ts src/llm/chat-executor.test.ts`
- `npx vitest run src/gateway/subagent-orchestrator.test.ts src/gateway/tool-handler-factory.test.ts src/llm/grok/adapter.test.ts`
- `npx tsc --noEmit`
- `npm run build`