### PR TITLE
feat(runtime): enforce xai structured outputs in planner flows

### DIFF
--- a/runtime/src/llm/chat-executor-fallback.ts
+++ b/runtime/src/llm/chat-executor-fallback.ts
@@ -87,6 +87,7 @@ export interface CallWithFallbackOptions {
   reconciliationMessages?: readonly LLMMessage[];
   routedToolNames?: readonly string[];
   toolChoice?: LLMToolChoice;
+  structuredOutput?: LLMChatOptions["structuredOutput"];
   requestDeadlineAt?: number;
   signal?: AbortSignal;
   trace?: ChatExecuteParams["trace"];
@@ -128,6 +129,7 @@ export async function callWithFallback(
     hasStatefulSessionId && options?.statefulHistoryCompacted === true;
   const hasRoutedToolNames = options?.routedToolNames !== undefined;
   const hasToolChoice = options?.toolChoice !== undefined;
+  const hasStructuredOutput = options?.structuredOutput !== undefined;
   const hasAbortSignal = options?.signal !== undefined;
   const hasProviderTrace =
     options?.trace?.includeProviderPayloads === true ||
@@ -136,6 +138,7 @@ export async function callWithFallback(
     hasStatefulSessionId ||
       hasRoutedToolNames ||
       hasToolChoice ||
+      hasStructuredOutput ||
       hasAbortSignal ||
       hasProviderTrace
       ? {
@@ -158,6 +161,9 @@ export async function callWithFallback(
           ? { toolRouting: { allowedToolNames: options?.routedToolNames } }
           : {}),
         ...(hasToolChoice ? { toolChoice: options?.toolChoice } : {}),
+        ...(hasStructuredOutput
+          ? { structuredOutput: options?.structuredOutput }
+          : {}),
         ...(hasAbortSignal ? { signal: options?.signal } : {}),
         ...(hasProviderTrace
           ? {

--- a/runtime/src/llm/chat-executor-planner-execution.ts
+++ b/runtime/src/llm/chat-executor-planner-execution.ts
@@ -24,6 +24,7 @@ import {
   mapPlannerStepsToPipelineSteps,
   validateSalvagedPlannerToolPlan,
   buildPlannerMessages,
+  buildPlannerStructuredOutputRequest,
   buildPlannerExecutionContext,
   buildPlannerVerificationRequirementsFailureMessage,
   buildPlannerVerificationRequirementsRefinementHint,
@@ -145,6 +146,7 @@ export interface PlannerExecutionCallbacks {
       routedToolNames?: readonly string[];
       persistRoutedToolNames?: boolean;
       toolChoice?: import("./types.js").LLMToolChoice;
+      structuredOutput?: import("./types.js").LLMStructuredOutputRequest;
       preparationDiagnostics?: Record<string, unknown>;
       allowRecallBudgetBypass?: boolean;
       budgetReason: string;
@@ -516,6 +518,7 @@ export async function executePlannerPath(
       ...(explicitPlannerToolNames
         ? { routedToolNames: explicitPlannerToolNames }
         : {}),
+      structuredOutput: buildPlannerStructuredOutputRequest(),
       budgetReason:
         "Planner pass blocked by max model recalls per request budget",
     });
@@ -532,6 +535,7 @@ export async function executePlannerPath(
     const plannerParse = normalizePlannerResponse({
       content: plannerResponse.content,
       toolCalls: plannerResponse.toolCalls,
+      structuredOutput: plannerResponse.structuredOutput,
       repairRequirements: explicitOrchestrationRequirements,
       plannerWorkspaceRoot,
     });

--- a/runtime/src/llm/chat-executor-planner-normalization.test.ts
+++ b/runtime/src/llm/chat-executor-planner-normalization.test.ts
@@ -68,6 +68,38 @@ describe("chat-executor-planner-normalization", () => {
     ]);
   });
 
+  it("prefers provider structured output payloads over raw text parsing", () => {
+    const result = normalizePlannerResponse({
+      content: "",
+      structuredOutput: {
+        type: "json_schema",
+        name: "agenc_planner_plan",
+        rawText: "",
+        parsed: {
+          reason: "structured_json",
+          steps: [
+            {
+              name: "delegate",
+              step_type: "subagent_task",
+              objective: "Investigate issue",
+              input_contract: "Return findings",
+              acceptance_criteria: ["Return one finding"],
+              required_tool_capabilities: ["desktop.bash"],
+              context_requirements: ["repo_context"],
+              max_budget_hint: "2m",
+              can_run_parallel: false,
+            },
+          ],
+        },
+      },
+      toolCalls: [],
+    });
+
+    expect(result.plan?.reason).toBe("structured_json");
+    expect(result.plan?.steps).toHaveLength(1);
+    expect(result.diagnostics).toEqual([]);
+  });
+
   it("surfaces salvage failures instead of inventing planner steps", () => {
     const result = normalizePlannerResponse({
       content: "",

--- a/runtime/src/llm/chat-executor-planner-normalization.ts
+++ b/runtime/src/llm/chat-executor-planner-normalization.ts
@@ -7,22 +7,33 @@
  * @module
  */
 
-import type { LLMToolCall } from "./types.js";
+import type {
+  LLMStructuredOutputResult,
+  LLMToolCall,
+} from "./types.js";
 import type { PlannerParseResult } from "./chat-executor-types.js";
 import {
   parsePlannerPlan,
   salvagePlannerToolCallsAsPlan,
   type ExplicitSubagentOrchestrationRequirements,
 } from "./chat-executor-planner.js";
+import { extractStructuredOutputObject } from "./structured-output.js";
 
 export function normalizePlannerResponse(params: {
   readonly content: string;
   readonly toolCalls: readonly LLMToolCall[];
+  readonly structuredOutput?: LLMStructuredOutputResult;
   readonly repairRequirements?: ExplicitSubagentOrchestrationRequirements;
   readonly plannerWorkspaceRoot?: string;
 }): PlannerParseResult {
+  const structuredPayload = params.structuredOutput
+    ? extractStructuredOutputObject({
+      content: params.content,
+      structuredOutput: params.structuredOutput,
+    })
+    : undefined;
   const parsed = parsePlannerPlan(
-    params.content,
+    structuredPayload ?? params.content,
     params.repairRequirements,
     { plannerWorkspaceRoot: params.plannerWorkspaceRoot },
   );

--- a/runtime/src/llm/chat-executor-planner-verifier-loop.ts
+++ b/runtime/src/llm/chat-executor-planner-verifier-loop.ts
@@ -25,15 +25,17 @@ import type {
 import { pipelineResultToToolCalls } from "./chat-executor-planner.js";
 import {
   buildSubagentVerifierMessages,
+  buildSubagentVerifierStructuredOutputRequest,
   buildMandatoryPlannerVerificationFailureDecision,
   evaluatePlannerDeterministicChecks,
   mergeSubagentVerifierDecisions,
   parseSubagentVerifierDecision,
 } from "./chat-executor-verifier.js";
 import { hasRuntimeLimit } from "./runtime-limit-policy.js";
+import { extractStructuredOutputObject } from "./structured-output.js";
 
 interface CallModelForPhaseResult
-  extends Pick<LLMResponse, "content" | "finishReason" | "toolCalls"> {}
+  extends Pick<LLMResponse, "content" | "finishReason" | "toolCalls" | "structuredOutput"> {}
 
 export async function runSubagentVerifierRound(params: {
   readonly systemPrompt: string;
@@ -60,6 +62,7 @@ export async function runSubagentVerifierRound(params: {
     statefulResumeAnchor?: LLMStatefulResumeAnchor;
     statefulHistoryCompacted?: boolean;
     toolChoice?: "none";
+    structuredOutput?: import("./types.js").LLMStructuredOutputRequest;
     budgetReason: string;
   }) => Promise<CallModelForPhaseResult | undefined>;
 }): Promise<SubagentVerifierDecision> {
@@ -92,6 +95,7 @@ export async function runSubagentVerifierRound(params: {
     statefulResumeAnchor: params.stateful?.resumeAnchor,
     statefulHistoryCompacted: params.stateful?.historyCompacted,
     toolChoice: "none",
+    structuredOutput: buildSubagentVerifierStructuredOutputRequest(),
     budgetReason:
       "Planner verifier blocked by max model recalls per request budget",
   });
@@ -105,7 +109,10 @@ export async function runSubagentVerifierRound(params: {
     return deterministic;
   }
   const modelDecision = parseSubagentVerifierDecision(
-    verifierResponse.content,
+    extractStructuredOutputObject({
+      content: verifierResponse.content,
+      structuredOutput: verifierResponse.structuredOutput,
+    }) ?? verifierResponse.content,
     params.verifierWorkItems,
   );
   if (!modelDecision) {

--- a/runtime/src/llm/chat-executor-planner.test.ts
+++ b/runtime/src/llm/chat-executor-planner.test.ts
@@ -4,6 +4,7 @@ import {
   assessPlannerDecision,
   buildPipelineFailureRepairRefinementHint,
   buildPlannerMessages,
+  buildPlannerStructuredOutputRequest,
   buildPlannerSynthesisFallbackContent,
   buildPlannerVerificationRequirementsFailureMessage,
   buildPlannerVerificationRequirementsRefinementHint,
@@ -23,6 +24,17 @@ import {
 } from "./chat-executor-planner.js";
 
 describe("chat-executor-planner explicit orchestration requirements", () => {
+  it("builds a strict documented planner json_schema request", () => {
+    expect(buildPlannerStructuredOutputRequest()).toEqual({
+      enabled: true,
+      schema: expect.objectContaining({
+        type: "json_schema",
+        name: "agenc_planner_plan",
+        strict: true,
+      }),
+    });
+  });
+
   it("includes non-interactive validation guidance in planner messages", () => {
     const messages = buildPlannerMessages(
       "Create a TypeScript package and run tests before finishing.",

--- a/runtime/src/llm/chat-executor-planner.ts
+++ b/runtime/src/llm/chat-executor-planner.ts
@@ -4,7 +4,11 @@
  * @module
  */
 
-import type { LLMMessage, LLMToolCall } from "./types.js";
+import type {
+  LLMMessage,
+  LLMStructuredOutputRequest,
+  LLMToolCall,
+} from "./types.js";
 import type {
   PromptBudgetSection,
 } from "./prompt-budget.js";
@@ -814,6 +818,166 @@ export function buildPlannerMessages(
   });
 
   return messages;
+}
+
+export function buildPlannerStructuredOutputRequest(): LLMStructuredOutputRequest {
+  return {
+    enabled: true,
+    schema: {
+      type: "json_schema",
+      name: "agenc_planner_plan",
+      strict: true,
+      schema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          reason: { type: "string" },
+          confidence: { type: "number" },
+          requiresSynthesis: { type: "boolean" },
+          steps: {
+            type: "array",
+            items: {
+              anyOf: [
+                {
+                  type: "object",
+                  additionalProperties: false,
+                  properties: {
+                    name: { type: "string" },
+                    step_type: { enum: ["deterministic_tool"] },
+                    depends_on: { type: "array", items: { type: "string" } },
+                    tool: { type: "string" },
+                    args: { type: "object", additionalProperties: true },
+                    onError: { enum: ["abort", "retry", "skip"] },
+                    maxRetries: { type: "integer" },
+                  },
+                  required: ["name", "step_type", "tool", "args"],
+                },
+                {
+                  type: "object",
+                  additionalProperties: false,
+                  properties: {
+                    name: { type: "string" },
+                    step_type: { enum: ["subagent_task"] },
+                    depends_on: { type: "array", items: { type: "string" } },
+                    objective: { type: "string" },
+                    input_contract: { type: "string" },
+                    acceptance_criteria: {
+                      type: "array",
+                      items: { type: "string" },
+                    },
+                    required_tool_capabilities: {
+                      type: "array",
+                      items: { type: "string" },
+                    },
+                    context_requirements: {
+                      type: "array",
+                      items: { type: "string" },
+                    },
+                    execution_context: {
+                      type: "object",
+                      additionalProperties: false,
+                      properties: {
+                        workspaceRoot: { type: "string" },
+                        allowedReadRoots: {
+                          type: "array",
+                          items: { type: "string" },
+                        },
+                        allowedWriteRoots: {
+                          type: "array",
+                          items: { type: "string" },
+                        },
+                        allowedTools: {
+                          type: "array",
+                          items: { type: "string" },
+                        },
+                        requiredSourceArtifacts: {
+                          type: "array",
+                          items: { type: "string" },
+                        },
+                        inputArtifacts: {
+                          type: "array",
+                          items: { type: "string" },
+                        },
+                        targetArtifacts: {
+                          type: "array",
+                          items: { type: "string" },
+                        },
+                        effectClass: {
+                          enum: [
+                            "read_only",
+                            "filesystem_write",
+                            "filesystem_scaffold",
+                            "shell",
+                            "mixed",
+                          ],
+                        },
+                        verificationMode: {
+                          enum: [
+                            "none",
+                            "grounded_read",
+                            "mutation_required",
+                            "deterministic_followup",
+                          ],
+                        },
+                        stepKind: {
+                          enum: [
+                            "delegated_research",
+                            "delegated_review",
+                            "delegated_write",
+                            "delegated_scaffold",
+                            "delegated_validation",
+                          ],
+                        },
+                        fallbackPolicy: {
+                          enum: [
+                            "continue_without_delegation",
+                            "fail_request",
+                          ],
+                        },
+                        resumePolicy: {
+                          enum: ["stateless_retry", "checkpoint_resume"],
+                        },
+                        approvalProfile: {
+                          enum: ["inherit", "read_only", "filesystem_write", "shell"],
+                        },
+                      },
+                    },
+                    max_budget_hint: { type: "string" },
+                    can_run_parallel: { type: "boolean" },
+                  },
+                  required: [
+                    "name",
+                    "step_type",
+                    "objective",
+                    "input_contract",
+                    "acceptance_criteria",
+                    "required_tool_capabilities",
+                    "max_budget_hint",
+                  ],
+                  anyOf: [
+                    { required: ["execution_context"] },
+                    { required: ["context_requirements"] },
+                  ],
+                },
+                {
+                  type: "object",
+                  additionalProperties: false,
+                  properties: {
+                    name: { type: "string" },
+                    step_type: { enum: ["synthesis"] },
+                    depends_on: { type: "array", items: { type: "string" } },
+                    objective: { type: "string" },
+                  },
+                  required: ["name", "step_type"],
+                },
+              ],
+            },
+          },
+        },
+        required: ["steps"],
+      },
+    },
+  };
 }
 
 export interface ExplicitSubagentOrchestrationRequirementStep {
@@ -1781,7 +1945,7 @@ function normalizePlannerShellModeToken(token: string): string {
 }
 
 export function parsePlannerPlan(
-  content: string,
+  content: string | Record<string, unknown>,
   repairRequirements?: ExplicitSubagentOrchestrationRequirements,
   options: {
     readonly plannerWorkspaceRoot?: string;
@@ -1789,7 +1953,8 @@ export function parsePlannerPlan(
 ): PlannerParseResult {
   void options;
   const diagnostics: PlannerDiagnostic[] = [];
-  const parsed = parseJsonObjectFromText(content);
+  const parsed =
+    typeof content === "string" ? parseJsonObjectFromText(content) : content;
   if (!parsed) {
     diagnostics.push(
       createPlannerDiagnostic(

--- a/runtime/src/llm/chat-executor-verifier.test.ts
+++ b/runtime/src/llm/chat-executor-verifier.test.ts
@@ -7,7 +7,9 @@ import type { PlannerSubAgentTaskStepIntent } from "./chat-executor-types.js";
 import {
   buildPlannerWorkflowAdmission,
   buildPlannerVerifierAdmission,
+  buildSubagentVerifierStructuredOutputRequest,
   evaluatePlannerDeterministicChecks,
+  parseSubagentVerifierDecision,
 } from "./chat-executor-verifier.js";
 
 function createStep(
@@ -291,5 +293,58 @@ describe("buildPlannerWorkflowAdmission", () => {
     expect(admission.taskClassification).toBe("docs_research_plan_only");
     expect(admission.requiresMandatoryImplementationVerification).toBe(false);
     expect(admission.completionContract?.taskClass).toBe("review_required");
+  });
+});
+
+describe("structured verifier outputs", () => {
+  it("builds a strict documented json_schema request", () => {
+    expect(buildSubagentVerifierStructuredOutputRequest()).toEqual({
+      enabled: true,
+      schema: expect.objectContaining({
+        type: "json_schema",
+        name: "agenc_subagent_verifier_decision",
+        strict: true,
+      }),
+    });
+  });
+
+  it("parses structured verifier payload objects directly", () => {
+    const step = createStep();
+    const { verifierWorkItems } = buildPlannerVerifierAdmission({
+      subagentSteps: [step],
+      deterministicSteps: [],
+    });
+
+    const decision = parseSubagentVerifierDecision(
+      {
+        overall: "pass",
+        confidence: 0.91,
+        unresolved: [],
+        steps: [
+          {
+            name: step.name,
+            verdict: "pass",
+            confidence: 0.91,
+            retryable: false,
+            issues: [],
+            summary: "grounded and complete",
+          },
+        ],
+      },
+      verifierWorkItems,
+    );
+
+    expect(decision).toMatchObject({
+      overall: "pass",
+      confidence: 0.91,
+      unresolvedItems: [],
+      steps: [
+        expect.objectContaining({
+          name: step.name,
+          verdict: "pass",
+          retryable: false,
+        }),
+      ],
+    });
   });
 });

--- a/runtime/src/llm/chat-executor-verifier.ts
+++ b/runtime/src/llm/chat-executor-verifier.ts
@@ -23,6 +23,7 @@ import type {
   LLMProviderEvidence,
   LLMProviderNativeServerToolCall,
   LLMProviderServerSideToolUsageEntry,
+  LLMStructuredOutputRequest,
 } from "./types.js";
 import type { ImplementationCompletionContract } from "../workflow/completion-contract.js";
 import type {
@@ -471,11 +472,64 @@ export function buildSubagentVerifierMessages(
   ];
 }
 
+export function buildSubagentVerifierStructuredOutputRequest(): LLMStructuredOutputRequest {
+  return {
+    enabled: true,
+    schema: {
+      type: "json_schema",
+      name: "agenc_subagent_verifier_decision",
+      strict: true,
+      schema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          overall: {
+            enum: ["pass", "retry", "fail"],
+          },
+          confidence: { type: "number" },
+          unresolved: {
+            type: "array",
+            items: { type: "string" },
+          },
+          steps: {
+            type: "array",
+            items: {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                name: { type: "string" },
+                verdict: { enum: ["pass", "retry", "fail"] },
+                confidence: { type: "number" },
+                retryable: { type: "boolean" },
+                issues: {
+                  type: "array",
+                  items: { type: "string" },
+                },
+                summary: { type: "string" },
+              },
+              required: [
+                "name",
+                "verdict",
+                "confidence",
+                "retryable",
+                "issues",
+                "summary",
+              ],
+            },
+          },
+        },
+        required: ["overall", "confidence", "unresolved", "steps"],
+      },
+    },
+  };
+}
+
 export function parseSubagentVerifierDecision(
-  content: string,
+  content: string | Record<string, unknown>,
   verifierWorkItems: readonly PlannerVerifierWorkItem[],
 ): SubagentVerifierDecision | undefined {
-  const parsed = parseJsonObjectFromText(content);
+  const parsed =
+    typeof content === "string" ? parseJsonObjectFromText(content) : content;
   if (!parsed) return undefined;
   const overallRaw = parsed.overall;
   if (

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -11643,7 +11643,7 @@ describe("ChatExecutor", () => {
 
     it("runs bounded verifier rounds for child outputs and retries low-confidence delegation once", async () => {
       const events: Array<Record<string, unknown>> = [];
-      const provider = createMockProvider("primary", {
+      const provider = createMockProvider("grok", {
         chat: vi
           .fn()
           .mockResolvedValueOnce(
@@ -11855,14 +11855,26 @@ describe("ChatExecutor", () => {
       });
       expect(result.content).toContain("[source:delegate_a]");
       expect(result.stopReason).toBe("completed");
+      const plannerOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[0]?.[1] as LLMChatOptions | undefined;
       const verifierOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
         .calls[1]?.[1] as LLMChatOptions | undefined;
       const retryVerifierOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
         .calls[2]?.[1] as LLMChatOptions | undefined;
       const synthesisOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
         .calls[3]?.[1] as LLMChatOptions | undefined;
+      expect(plannerOptions?.structuredOutput?.schema?.name).toBe(
+        "agenc_planner_plan",
+      );
       expect(verifierOptions?.toolChoice).toBe("none");
       expect(retryVerifierOptions?.toolChoice).toBe("none");
+      expect(verifierOptions?.structuredOutput?.schema?.name).toBe(
+        "agenc_subagent_verifier_decision",
+      );
+      expect(retryVerifierOptions?.structuredOutput?.schema?.name).toBe(
+        "agenc_subagent_verifier_decision",
+      );
+      expect(synthesisOptions?.structuredOutput).toBeUndefined();
       expect(verifierOptions?.stateful).toBeUndefined();
       expect(retryVerifierOptions?.stateful).toBeUndefined();
       expect(synthesisOptions?.stateful).toBeUndefined();

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -14,6 +14,7 @@ import type {
   LLMProviderEvidence,
   LLMMessage,
   LLMStatefulResumeAnchor,
+  LLMStructuredOutputRequest,
   LLMToolChoice,
   LLMResponse,
   LLMUsage,
@@ -1627,6 +1628,7 @@ export class ChatExecutor {
       routedToolNames?: readonly string[];
       persistRoutedToolNames?: boolean;
       toolChoice?: LLMToolChoice;
+      structuredOutput?: LLMStructuredOutputRequest;
       preparationDiagnostics?: Record<string, unknown>;
       allowRecallBudgetBypass?: boolean;
       budgetReason: string;
@@ -1667,6 +1669,11 @@ export class ChatExecutor {
       ? [...input.callSections, "system_runtime" as const]
       : input.callSections;
     const routingDecision = this.resolveRoutingDecision(ctx, input.phase);
+    const structuredOutput =
+      input.structuredOutput &&
+      this.supportsStructuredOutputsForProviders(routingDecision.route.providers)
+        ? input.structuredOutput
+        : undefined;
     if (
       this.economicsPolicy.mode === "enforce" &&
       routingDecision.pressure.hardExceeded
@@ -1701,6 +1708,7 @@ export class ChatExecutor {
             : typeof input.toolChoice === "string"
             ? input.toolChoice
             : input.toolChoice.name,
+        structuredOutputSchemaName: structuredOutput?.schema?.name,
         messageCount: effectiveCallMessages.length,
         groundingMessageAdded: Boolean(groundingMessage),
         activeRouteMisses: ctx.routedToolMisses,
@@ -1744,6 +1752,9 @@ export class ChatExecutor {
             : {}),
           ...(input.toolChoice !== undefined
             ? { toolChoice: input.toolChoice }
+            : {}),
+          ...(structuredOutput !== undefined
+            ? { structuredOutput }
             : {}),
           ...(ctx.trace
             ? {
@@ -1802,6 +1813,13 @@ export class ChatExecutor {
       }),
     );
     return next.response;
+  }
+
+  private supportsStructuredOutputsForProviders(
+    providers: readonly LLMProvider[],
+  ): boolean {
+    return providers.length > 0 &&
+      providers.every((provider) => provider.name === "grok");
   }
 
   private async runPipelineWithTimeout(

--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -33,7 +33,6 @@ import { GrokProvider } from "./adapter.js";
 const DOCUMENTED_XAI_RESPONSES_FIELDS = new Set([
   "include",
   "input",
-  "instructions",
   "logprobs",
   "max_output_tokens",
   "max_turns",
@@ -1123,6 +1122,134 @@ describe("GrokProvider", () => {
     expect(params.max_turns).toBe(4);
     expect(params.reasoning).toEqual({ effort: "high" });
     expect(params.include).toEqual(["reasoning.encrypted_content"]);
+  });
+
+  it("sends documented xAI text.format requests and parses structured output payloads", async () => {
+    mockCreate.mockResolvedValueOnce(
+      makeCompletion({
+        output_text:
+          '{"overall":"pass","confidence":0.93,"unresolved":[],"steps":[{"name":"delegate_logs","verdict":"pass","confidence":0.93,"retryable":false,"issues":[],"summary":"grounded"}]}',
+        output: [
+          {
+            type: "message",
+            content: [
+              {
+                type: "output_text",
+                text:
+                  '{"overall":"pass","confidence":0.93,"unresolved":[],"steps":[{"name":"delegate_logs","verdict":"pass","confidence":0.93,"retryable":false,"issues":[],"summary":"grounded"}]}',
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    const provider = new GrokProvider({ apiKey: "test-key" });
+    const response = await provider.chat(
+      [{ role: "user", content: "verify the delegated output" }],
+      {
+        structuredOutput: {
+          enabled: true,
+          schema: {
+            type: "json_schema",
+            name: "agenc_subagent_verifier_decision",
+            schema: {
+              type: "object",
+              properties: {
+                overall: { type: "string" },
+              },
+              required: ["overall"],
+            },
+          },
+        },
+      },
+    );
+
+    const params = mockCreate.mock.calls[0][0];
+    expect(params.text).toEqual({
+      format: {
+        type: "json_schema",
+        name: "agenc_subagent_verifier_decision",
+        schema: {
+          type: "object",
+          properties: {
+            overall: { type: "string" },
+          },
+          required: ["overall"],
+        },
+        strict: true,
+      },
+    });
+    expect(response.structuredOutput).toEqual({
+      type: "json_schema",
+      name: "agenc_subagent_verifier_decision",
+      rawText:
+        '{"overall":"pass","confidence":0.93,"unresolved":[],"steps":[{"name":"delegate_logs","verdict":"pass","confidence":0.93,"retryable":false,"issues":[],"summary":"grounded"}]}',
+      parsed: {
+        overall: "pass",
+        confidence: 0.93,
+        unresolved: [],
+        steps: [
+          {
+            name: "delegate_logs",
+            verdict: "pass",
+            confidence: 0.93,
+            retryable: false,
+            issues: [],
+            summary: "grounded",
+          },
+        ],
+      },
+    });
+    expect(response.requestMetrics).toMatchObject({
+      structuredOutputEnabled: true,
+      structuredOutputName: "agenc_subagent_verifier_decision",
+      structuredOutputStrict: true,
+    });
+  });
+
+  it("fails closed when structured outputs are combined with tools on non-Grok-4 models", async () => {
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      model: "grok-code-fast-1",
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "system.bash",
+            description: "run command",
+            parameters: {
+              type: "object",
+              properties: { command: { type: "string" } },
+            },
+          },
+        },
+      ],
+    });
+
+    await expect(
+      provider.chat(
+        [{ role: "user", content: "inspect the repo and summarize findings" }],
+        {
+          structuredOutput: {
+            enabled: true,
+            schema: {
+              type: "json_schema",
+              name: "repo_summary",
+              schema: {
+                type: "object",
+                properties: {
+                  summary: { type: "string" },
+                },
+                required: ["summary"],
+              },
+            },
+          },
+        },
+      ),
+    ).rejects.toThrow(
+      /Structured outputs with tools are only documented for the Grok 4 family/i,
+    );
   });
 
   it("disables parallel tool calls by default when tools are present", async () => {

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -38,6 +38,10 @@ import {
   getProviderNativeToolDefinitions,
   type ProviderNativeToolDefinition,
 } from "../provider-native-search.js";
+import {
+  parseStructuredOutputText,
+  supportsXaiStructuredOutputsWithTools,
+} from "../structured-output.js";
 import { withTimeout } from "../timeout.js";
 import { validateToolTurnSequence } from "../tool-turn-validator.js";
 import type { GrokProviderConfig } from "./types.js";
@@ -69,7 +73,6 @@ const MAX_TOOL_SCHEMA_CHARS_FOLLOWUP = 20_000;
 const DOCUMENTED_XAI_RESPONSES_FIELDS = new Set([
   "include",
   "input",
-  "instructions",
   "logprobs",
   "max_output_tokens",
   "max_turns",
@@ -428,6 +431,15 @@ function collectParamDiagnostics(
   } catch {
     toolSchemaChars = -1;
   }
+  const structuredFormat =
+    params.text &&
+    typeof params.text === "object" &&
+    !Array.isArray(params.text) &&
+    (params.text as Record<string, unknown>).format &&
+    typeof (params.text as Record<string, unknown>).format === "object" &&
+    !Array.isArray((params.text as Record<string, unknown>).format)
+      ? ((params.text as Record<string, unknown>).format as Record<string, unknown>)
+      : undefined;
 
   return {
     messageCount: effectiveMessages.length,
@@ -449,6 +461,15 @@ function collectParamDiagnostics(
     toolSuppressionReason: selection?.toolSuppressionReason,
     toolChoice: summarizeTraceToolChoice(params.tool_choice),
     toolSchemaChars,
+    structuredOutputEnabled: structuredFormat !== undefined,
+    structuredOutputName:
+      typeof structuredFormat?.name === "string"
+        ? structuredFormat.name
+        : undefined,
+    structuredOutputStrict:
+      typeof structuredFormat?.strict === "boolean"
+        ? structuredFormat.strict
+        : undefined,
     serializedChars,
     previousResponseId:
       typeof params.previous_response_id === "string"
@@ -907,6 +928,7 @@ export class GrokProvider implements LLMProvider {
           activePlan.requestMetrics,
           activePlan.statefulDiagnostics,
           activePlan.compactionDiagnostics,
+          options?.structuredOutput,
         );
         this.emitToolCallNormalizationIssues(
           parsed.normalizationIssues,
@@ -1241,6 +1263,14 @@ export class GrokProvider implements LLMProvider {
         stateful: statefulDiagnostics,
         compaction: compactionDiagnostics,
         providerEvidence,
+        structuredOutput:
+          options?.structuredOutput?.enabled === false ||
+            !options?.structuredOutput?.schema
+            ? undefined
+            : parseStructuredOutputText(
+              content,
+              options.structuredOutput.schema.name,
+            ),
         encryptedReasoning,
         finishReason,
         ...(responseError ? { error: responseError } : {}),
@@ -1283,6 +1313,14 @@ export class GrokProvider implements LLMProvider {
           stateful: statefulDiagnostics,
           compaction: compactionDiagnostics,
           providerEvidence,
+          structuredOutput:
+            options?.structuredOutput?.enabled === false ||
+              !options?.structuredOutput?.schema
+              ? undefined
+              : parseStructuredOutputText(
+                content,
+                options.structuredOutput.schema.name,
+              ),
           finishReason: "error",
           error: mappedError,
           partial: true,
@@ -1746,27 +1784,14 @@ export class GrokProvider implements LLMProvider {
     if (includeEncryptedReasoning) {
       params.include = ["reasoning.encrypted_content"];
     }
-    const structuredOutputSchema = options?.structuredOutput?.schema;
-    if (
-      options?.structuredOutput?.enabled !== false &&
-      structuredOutputSchema
-    ) {
-      params.text = {
-        format: {
-          type: structuredOutputSchema.type,
-          name: structuredOutputSchema.name,
-          schema: structuredOutputSchema.schema,
-          strict:
-            structuredOutputSchema.strict ??
-            this.config.structuredOutputs?.strict ??
-            true,
-        },
-      };
-    }
     const selectedTools = {
       ...(options?.toolSelection ??
         this.resolveResponseTools(options?.allowedToolNames)),
     };
+    const structuredOutputSchema = options?.structuredOutput?.schema;
+    const structuredOutputEnabled =
+      options?.structuredOutput?.enabled !== false &&
+      structuredOutputSchema !== undefined;
     // Enable tools unless the vision model is known to not support them.
     if (selectedTools.tools.length > 0) {
       const hasToolResults = messages.some((m) => m.role === "tool");
@@ -1789,6 +1814,30 @@ export class GrokProvider implements LLMProvider {
       } else if (hasToolResults) {
         selectedTools.toolSuppressionReason = "followup_tool_schema_limit";
       }
+    }
+    if (structuredOutputEnabled && structuredOutputSchema) {
+      if (
+        selectedTools.toolsAttached &&
+        !supportsXaiStructuredOutputsWithTools(
+          typeof params.model === "string" ? params.model : this.config.model,
+        )
+      ) {
+        throw new LLMProviderError(
+          this.name,
+          `Structured outputs with tools are only documented for the Grok 4 family; refusing request for model "${String(params.model ?? this.config.model)}"`,
+        );
+      }
+      params.text = {
+        format: {
+          type: structuredOutputSchema.type,
+          name: structuredOutputSchema.name,
+          schema: structuredOutputSchema.schema,
+          strict:
+            structuredOutputSchema.strict ??
+            this.config.structuredOutputs?.strict ??
+            true,
+        },
+      };
     }
     return {
       params: sanitizeToDocumentedXaiResponsesParams(params),
@@ -2067,6 +2116,7 @@ export class GrokProvider implements LLMProvider {
     requestMetrics?: LLMRequestMetrics,
     statefulDiagnostics?: LLMStatefulDiagnostics,
     compactionDiagnostics?: LLMCompactionDiagnostics,
+    structuredOutputRequest?: LLMChatOptions["structuredOutput"],
   ): LLMResponse & {
     normalizationIssues?: readonly ToolCallNormalizationIssue[];
   } {
@@ -2094,6 +2144,10 @@ export class GrokProvider implements LLMProvider {
       stateful,
       compaction,
       providerEvidence: this.extractProviderEvidence(response),
+      structuredOutput: this.extractStructuredOutputResult(
+        response,
+        structuredOutputRequest,
+      ),
       encryptedReasoning: this.extractEncryptedReasoningDiagnostics(response),
       finishReason,
       ...(normalizationIssues.length > 0 ? { normalizationIssues } : {}),
@@ -2124,6 +2178,18 @@ export class GrokProvider implements LLMProvider {
       }
     }
     return chunks.join("");
+  }
+
+  private extractStructuredOutputResult(
+    response: Record<string, unknown>,
+    structuredOutputRequest?: LLMChatOptions["structuredOutput"],
+  ): LLMResponse["structuredOutput"] {
+    const schema = structuredOutputRequest?.schema;
+    if (structuredOutputRequest?.enabled === false || !schema) {
+      return undefined;
+    }
+    const rawText = this.extractOutputText(response);
+    return parseStructuredOutputText(rawText, schema.name);
   }
 
   private parseUsage(response: Record<string, unknown>): LLMUsage {

--- a/runtime/src/llm/structured-output.ts
+++ b/runtime/src/llm/structured-output.ts
@@ -1,0 +1,57 @@
+/**
+ * Structured-output helpers shared by provider adapters and planner/verifier flows.
+ *
+ * xAI MCP source of truth:
+ * - Structured outputs are supported by all language models.
+ * - Structured outputs with tools are only supported by the Grok 4 family.
+ *
+ * @module
+ */
+
+import type {
+  LLMResponse,
+  LLMStructuredOutputResult,
+} from "./types.js";
+import { parseJsonObjectFromText } from "./chat-executor-text.js";
+
+export function supportsXaiStructuredOutputsWithTools(
+  model: string | undefined,
+): boolean {
+  if (typeof model !== "string") return false;
+  return /^grok-4(?:[.-]|$)/i.test(model.trim());
+}
+
+export function parseStructuredOutputText(
+  rawText: string,
+  schemaName?: string,
+): LLMStructuredOutputResult {
+  const trimmed = rawText.trim();
+  let parsed: unknown;
+  if (trimmed.length > 0) {
+    try {
+      parsed = JSON.parse(trimmed) as unknown;
+    } catch {
+      parsed = undefined;
+    }
+  }
+  return {
+    type: "json_schema",
+    ...(schemaName ? { name: schemaName } : {}),
+    rawText,
+    ...(parsed !== undefined ? { parsed } : {}),
+  };
+}
+
+export function extractStructuredOutputObject(
+  result: Pick<LLMResponse, "content" | "structuredOutput">,
+): Record<string, unknown> | undefined {
+  const parsed = result.structuredOutput?.parsed;
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    return parsed as Record<string, unknown>;
+  }
+  const rawText = result.structuredOutput?.rawText;
+  if (typeof rawText === "string" && rawText.trim().length > 0) {
+    return parseJsonObjectFromText(rawText);
+  }
+  return parseJsonObjectFromText(result.content);
+}

--- a/runtime/src/llm/types.ts
+++ b/runtime/src/llm/types.ts
@@ -118,6 +118,9 @@ export interface LLMRequestMetrics {
   toolSuppressionReason?: string;
   toolChoice?: string;
   toolSchemaChars: number;
+  structuredOutputEnabled?: boolean;
+  structuredOutputName?: string;
+  structuredOutputStrict?: boolean;
   serializedChars: number;
   previousResponseId?: string;
   statefulInputMode?: "full_replay" | "incremental_delta";


### PR DESCRIPTION
## Summary
- wire documented xAI structured outputs through the Grok adapter and runtime request metrics
- move planner and subagent verifier flows onto json-schema structured outputs with parser fallback
- fail closed for unsupported structured-output-plus-tools combinations and remove the stale unsupported `instructions` field from the xAI responses allowlist

## Verification
- npx vitest run src/llm/grok/adapter.test.ts src/llm/chat-executor-planner-normalization.test.ts src/llm/chat-executor-planner.test.ts src/llm/chat-executor-verifier.test.ts src/llm/chat-executor.test.ts
- npx tsc --noEmit
- npm run build
- npm run techdebt