### PR TITLE
feat(runtime): add xai response replay surfaces

### DIFF
--- a/runtime/src/gateway/daemon-command-registry.test.ts
+++ b/runtime/src/gateway/daemon-command-registry.test.ts
@@ -2,103 +2,258 @@ import { describe, expect, it, vi } from "vitest";
 
 import { silentLogger } from "../utils/logger.js";
 import { createDaemonCommandRegistry } from "./daemon-command-registry.js";
+import {
+  SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY,
+  SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY,
+} from "./session.js";
+
+function makeCommandRegistry(params?: {
+  providerOverrides?: Array<Record<string, unknown>>;
+  sessionOverrides?: Record<string, unknown>;
+  memoryBackendOverrides?: Record<string, unknown>;
+  gatewayLlmOverrides?: Record<string, unknown>;
+}) {
+  const session = {
+    history: new Array(6).fill({}),
+    metadata: {
+      [SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY]: {
+        previousResponseId: "resp-anchor-1",
+      },
+      [SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY]: true,
+      ...(params?.sessionOverrides ?? {}),
+    },
+  } as any;
+
+  const providers = (
+    params?.providerOverrides ?? [
+      {
+        name: "grok",
+        getCapabilities: () => ({
+          provider: "grok",
+          stateful: {
+            assistantPhase: false,
+            previousResponseId: true,
+            encryptedReasoning: true,
+            storedResponseRetrieval: true,
+            storedResponseDeletion: true,
+            opaqueCompaction: false,
+            deterministicFallback: true,
+          },
+        }),
+        retrieveStoredResponse: vi.fn(async () => ({
+          id: "resp-anchor-1",
+          provider: "grok",
+          model: "grok-4.20-reasoning",
+          status: "completed",
+          content: "stored response content",
+          toolCalls: [],
+          encryptedReasoning: { requested: true, available: true },
+          providerEvidence: {
+            citations: ["https://x.ai"],
+            serverSideToolUsage: [
+              {
+                category: "SERVER_SIDE_TOOL_WEB_SEARCH",
+                toolType: "web_search",
+                count: 1,
+              },
+            ],
+          },
+          raw: { id: "resp-anchor-1", output_text: "stored response content" },
+        })),
+        deleteStoredResponse: vi.fn(async () => ({
+          id: "resp-anchor-1",
+          provider: "grok",
+          deleted: true,
+          raw: { id: "resp-anchor-1", deleted: true },
+        })),
+      },
+    ]
+  ) as any[];
+
+  const memoryBackend = {
+    name: "sqlite",
+    delete: vi.fn(async () => {}),
+    get: vi.fn(async () => undefined),
+    set: vi.fn(async () => {}),
+    ...(params?.memoryBackendOverrides ?? {}),
+  } as any;
+
+  const registry = createDaemonCommandRegistry(
+    {
+      logger: silentLogger,
+      configPath: "/tmp/config.json",
+      gateway: {
+        config: {
+          llm: {
+            provider: "grok",
+            model: "grok-4.20-beta-0309-reasoning",
+            sessionTokenBudget: 0,
+            statefulResponses: {
+              enabled: true,
+              store: true,
+            },
+            includeEncryptedReasoning: true,
+            ...(params?.gatewayLlmOverrides ?? {}),
+          },
+        },
+      },
+      yolo: false,
+      resetWebSessionContext: vi.fn(async () => {}),
+      getWebChatChannel: () => null,
+      getHostWorkspacePath: () => "/tmp/project",
+      getChatExecutor: () =>
+        ({
+          getSessionTokenUsage: () => 25_136,
+        }) as any,
+      getResolvedContextWindowTokens: () => 2_000_000,
+      getSystemPrompt: () => "# Agent\n# Repository Guidelines\n# Tool\n# Memory\n",
+      getMemoryBackendName: () => "sqlite",
+      getPolicyEngineState: () => undefined,
+      isPolicyEngineEnabled: () => false,
+      isGovernanceAuditLogEnabled: () => false,
+      listSessionCredentialLeases: () => [],
+      revokeSessionCredentials: vi.fn(async () => 0),
+      resolvePolicyScopeForSession: ({ sessionId, runId, channel }) => ({
+        sessionId,
+        runId,
+        channel: channel ?? "webchat",
+      }),
+      buildPolicySimulationPreview: vi.fn(async () => ({
+        toolName: "system.readFile",
+        sessionId: "session-1",
+        policy: { allowed: true, mode: "normal", violations: [] },
+        approval: { required: false, elevated: false, denied: false },
+      })),
+      getSubAgentRuntimeConfig: () => null,
+      getActiveDelegationAggressiveness: () => "balanced",
+      resolveDelegationScoreThreshold: () => 0,
+      getDelegationAggressivenessOverride: () => null,
+      setDelegationAggressivenessOverride: () => {},
+      configureDelegationRuntimeServices: () => {},
+      getWebChatInboundHandler: () => null,
+      getDesktopHandleBySession: () => undefined,
+      getSessionModelInfo: () => ({
+        provider: "grok",
+        model: "grok-4.20-reasoning",
+        usedFallback: false,
+      }),
+      handleConfigReload: vi.fn(async () => {}),
+      getVoiceBridge: () => null,
+      getDesktopManager: () => null,
+      getDesktopBridges: () => new Map(),
+      getPlaywrightBridges: () => new Map(),
+      getContainerMCPBridges: () => new Map(),
+      getGoalManager: () => null,
+      startSlashInit: vi.fn(async () => ({
+        filePath: "/tmp/project/AGENC.md",
+        started: true,
+      })),
+    },
+    {
+      get: () => session,
+    } as any,
+    (value) => value,
+    providers as any,
+    memoryBackend,
+    { size: 181 } as any,
+    [],
+    [],
+    {} as any,
+    {} as any,
+    null,
+    undefined,
+    undefined,
+  );
+
+  return {
+    registry,
+    session,
+    memoryBackend,
+    providers,
+  };
+}
+
+async function dispatchAndCollect(
+  registry: ReturnType<typeof createDaemonCommandRegistry>,
+  command: string,
+): Promise<string[]> {
+  const replies: string[] = [];
+  const handled = await registry.dispatch(
+    command,
+    "session-1",
+    "user-1",
+    "webchat",
+    async (content) => {
+      replies.push(content);
+    },
+  );
+  expect(handled).toBe(true);
+  return replies;
+}
 
 describe("createDaemonCommandRegistry /context", () => {
   it("reports a finite local compaction window even when the hard session budget is unlimited", async () => {
-    const replies: string[] = [];
-    const registry = createDaemonCommandRegistry(
-      {
-        logger: silentLogger,
-        configPath: "/tmp/config.json",
-        gateway: {
-          config: {
-            llm: {
-              provider: "grok",
-              model: "grok-4.20-beta-0309-reasoning",
-              sessionTokenBudget: 0,
-            },
-          },
-        },
-        yolo: false,
-        resetWebSessionContext: vi.fn(async () => {}),
-        getWebChatChannel: () => null,
-        getHostWorkspacePath: () => "/tmp/project",
-        getChatExecutor: () =>
-          ({
-            getSessionTokenUsage: () => 25_136,
-          }) as any,
-        getResolvedContextWindowTokens: () => 2_000_000,
-        getSystemPrompt: () => "# Agent\n# Repository Guidelines\n# Tool\n# Memory\n",
-        getMemoryBackendName: () => "sqlite",
-        getPolicyEngineState: () => undefined,
-        isPolicyEngineEnabled: () => false,
-        isGovernanceAuditLogEnabled: () => false,
-        listSessionCredentialLeases: () => [],
-        revokeSessionCredentials: vi.fn(async () => 0),
-        resolvePolicyScopeForSession: ({ sessionId, runId, channel }) => ({
-          sessionId,
-          runId,
-          channel: channel ?? "webchat",
-        }),
-        buildPolicySimulationPreview: vi.fn(async () => ({
-          toolName: "system.readFile",
-          sessionId: "session-1",
-          policy: { allowed: true, mode: "normal", violations: [] },
-          approval: { required: false, elevated: false, denied: false },
-        })),
-        getSubAgentRuntimeConfig: () => null,
-        getActiveDelegationAggressiveness: () => "balanced",
-        resolveDelegationScoreThreshold: () => 0,
-        getDelegationAggressivenessOverride: () => null,
-        setDelegationAggressivenessOverride: () => {},
-        configureDelegationRuntimeServices: () => {},
-        getWebChatInboundHandler: () => null,
-        getDesktopHandleBySession: () => undefined,
-        getSessionModelInfo: () => undefined,
-        handleConfigReload: vi.fn(async () => {}),
-        getVoiceBridge: () => null,
-        getDesktopManager: () => null,
-        getDesktopBridges: () => new Map(),
-        getPlaywrightBridges: () => new Map(),
-        getContainerMCPBridges: () => new Map(),
-        getGoalManager: () => null,
-        startSlashInit: vi.fn(async () => ({
-          filePath: "/tmp/project/AGENC.md",
-          started: true,
-        })),
-      },
-      {
-        get: () => ({ history: new Array(6).fill({}) }),
-      } as any,
-      (value) => value,
-      [],
-      { name: "sqlite" } as any,
-      { size: 181 } as any,
-      [],
-      [],
-      {} as any,
-      {} as any,
-      null,
-      undefined,
-      undefined,
-    );
+    const { registry } = makeCommandRegistry();
+    const replies = await dispatchAndCollect(registry, "/context");
 
-    const handled = await registry.dispatch(
-      "/context",
-      "session-1",
-      "user-1",
-      "webchat",
-      async (content) => {
-        replies.push(content);
-      },
-    );
-
-    expect(handled).toBe(true);
     expect(replies).toHaveLength(1);
     expect(replies[0]).toContain("Session Budget: unlimited");
     expect(replies[0]).toContain("Free: 0 tokens");
     expect(replies[0]).toContain(
       "Compaction: local enabled @ 16,000 tokens; provider disabled",
     );
+  });
+});
+
+describe("createDaemonCommandRegistry /response", () => {
+  it("shows the active stored-response status and encrypted reasoning setting", async () => {
+    const { registry } = makeCommandRegistry();
+    const replies = await dispatchAndCollect(registry, "/response status");
+
+    expect(replies).toHaveLength(1);
+    expect(replies[0]).toContain("Retrieval supported: yes");
+    expect(replies[0]).toContain("Deletion supported: yes");
+    expect(replies[0]).toContain("Encrypted reasoning support: yes");
+    expect(replies[0]).toContain("Current response anchor: resp-anchor-1");
+  });
+
+  it("retrieves the latest stored response via the active anchor", async () => {
+    const { registry, providers } = makeCommandRegistry();
+    const replies = await dispatchAndCollect(registry, "/response get latest");
+
+    expect(replies).toHaveLength(1);
+    expect(replies[0]).toContain("Stored response: resp-anchor-1");
+    expect(replies[0]).toContain("stored response content");
+    expect(providers[0].retrieveStoredResponse).toHaveBeenCalledWith(
+      "resp-anchor-1",
+    );
+  });
+
+  it("deletes the active stored response and clears the live continuation anchor", async () => {
+    const { registry, session, memoryBackend, providers } = makeCommandRegistry();
+    const replies = await dispatchAndCollect(registry, "/response delete latest");
+
+    expect(replies).toHaveLength(1);
+    expect(replies[0]).toContain("Stored response delete: confirmed");
+    expect(replies[0]).toContain("Cleared active anchor: yes");
+    expect(
+      session.metadata[SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY],
+    ).toBeUndefined();
+    expect(
+      session.metadata[SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY],
+    ).toBeUndefined();
+    expect(memoryBackend.delete).toHaveBeenCalled();
+    expect(providers[0].deleteStoredResponse).toHaveBeenCalledWith(
+      "resp-anchor-1",
+    );
+  });
+
+  it("returns raw JSON for stored-response inspection when requested", async () => {
+    const { registry } = makeCommandRegistry();
+    const replies = await dispatchAndCollect(registry, "/response get latest --json");
+
+    expect(replies).toHaveLength(1);
+    expect(replies[0]).toContain("\"id\": \"resp-anchor-1\"");
+    expect(replies[0]).toContain("\"output_text\": \"stored response content\"");
   });
 });

--- a/runtime/src/gateway/daemon-command-registry.ts
+++ b/runtime/src/gateway/daemon-command-registry.ts
@@ -13,10 +13,21 @@ import { resolve as resolvePath } from "node:path";
 import type { Logger } from "../utils/logger.js";
 import { toErrorMessage } from "../utils/async.js";
 import type { GatewayConfig } from "./types.js";
-import type { LLMProvider, LLMProviderTraceEvent, ToolHandler } from "../llm/types.js";
+import type {
+  LLMProvider,
+  LLMProviderTraceEvent,
+  LLMStoredResponse,
+  ToolHandler,
+} from "../llm/types.js";
 import type { MemoryBackend } from "../memory/types.js";
 import { SlashCommandRegistry, createDefaultCommands } from "./commands.js";
-import { SessionManager } from "./session.js";
+import {
+  clearStatefulContinuationMetadata,
+  SessionManager,
+  SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY,
+  SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY,
+  type Session,
+} from "./session.js";
 import type { DiscoveredSkill } from "../skills/markdown/discovery.js";
 import { ToolRegistry } from "../tools/registry.js";
 import { HookDispatcher } from "./hooks.js";
@@ -42,6 +53,7 @@ import {
   resolveLocalCompactionThreshold,
   DEFAULT_GROK_MODEL,
 } from "./llm-provider-manager.js";
+import { clearWebSessionRuntimeState } from "./daemon-session-state.js";
 import { hasRuntimeLimit } from "../llm/runtime-limit-policy.js";
 import {
   listKnownGrokModels,
@@ -295,6 +307,136 @@ export interface WebChatSkillSummary {
   name: string;
   description: string;
   enabled: boolean;
+}
+
+function getSessionResumeAnchorResponseId(session: Session | undefined): string | undefined {
+  const candidate = session?.metadata[SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY];
+  if (!candidate || typeof candidate !== "object") return undefined;
+  const responseId = (candidate as { previousResponseId?: unknown }).previousResponseId;
+  return typeof responseId === "string" && responseId.trim().length > 0
+    ? responseId.trim()
+    : undefined;
+}
+
+function getSessionHistoryCompacted(session: Session | undefined): boolean {
+  return session?.metadata[SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY] === true;
+}
+
+function summarizeStoredResponse(response: LLMStoredResponse): string {
+  const usage = response.usage
+    ? `prompt=${response.usage.promptTokens}, completion=${response.usage.completionTokens}, total=${response.usage.totalTokens}`
+    : "unavailable";
+  const citations = response.providerEvidence?.citations ?? [];
+  const serverSideToolCalls = response.providerEvidence?.serverSideToolCalls ?? [];
+  const serverSideToolUsage = response.providerEvidence?.serverSideToolUsage ?? [];
+  const content = response.content.trim();
+  const contentPreview =
+    content.length > 0
+      ? truncateToolLogText(content, 1_000)
+      : "(no assistant text content)";
+  const lines = [
+    `Stored response: ${response.id}`,
+    `Provider: ${response.provider}`,
+    `Model: ${response.model ?? "unknown"}`,
+    `Status: ${response.status ?? "unknown"}`,
+    `Usage: ${usage}`,
+    `Client-side tool calls: ${response.toolCalls.length}`,
+    `Server-side tool calls: ${serverSideToolCalls.length}`,
+    `Server-side tool usage entries: ${serverSideToolUsage.length}`,
+    `Citations: ${citations.length}`,
+    `Encrypted reasoning: ${
+      response.encryptedReasoning
+        ? `${response.encryptedReasoning.available ? "available" : "not returned"}`
+        : "not requested/not available"
+    }`,
+    "Content:",
+    contentPreview,
+  ];
+  if (serverSideToolUsage.length > 0) {
+    lines.push(
+      "Server-side usage:",
+      ...serverSideToolUsage.map((entry) =>
+        `  ${entry.category}: ${entry.count}${entry.toolType ? ` (${entry.toolType})` : ""}`
+      ),
+    );
+  }
+  return lines.join("\n");
+}
+
+function orderProvidersForStoredResponses(
+  providers: readonly LLMProvider[],
+  preferredProviderName: string | undefined,
+  operation: "retrieve" | "delete",
+): LLMProvider[] {
+  const supported = providers.filter((provider) =>
+    operation === "retrieve"
+      ? typeof provider.retrieveStoredResponse === "function"
+      : typeof provider.deleteStoredResponse === "function"
+  );
+  if (!preferredProviderName) {
+    return supported;
+  }
+  return [
+    ...supported.filter((provider) => provider.name === preferredProviderName),
+    ...supported.filter((provider) => provider.name !== preferredProviderName),
+  ];
+}
+
+async function retrieveStoredResponseWithFallback(
+  providers: readonly LLMProvider[],
+  responseId: string,
+  preferredProviderName?: string,
+): Promise<LLMStoredResponse> {
+  const candidates = orderProvidersForStoredResponses(
+    providers,
+    preferredProviderName,
+    "retrieve",
+  );
+  if (candidates.length === 0) {
+    throw new Error("No configured provider supports stored response retrieval.");
+  }
+  let lastError: unknown;
+  for (const provider of candidates) {
+    try {
+      return await provider.retrieveStoredResponse!(responseId);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Stored response retrieval failed.");
+}
+
+async function deleteStoredResponseWithFallback(
+  providers: readonly LLMProvider[],
+  responseId: string,
+  preferredProviderName?: string,
+): Promise<{ readonly providerName: string; readonly deleted: boolean; readonly id: string }> {
+  const candidates = orderProvidersForStoredResponses(
+    providers,
+    preferredProviderName,
+    "delete",
+  );
+  if (candidates.length === 0) {
+    throw new Error("No configured provider supports stored response deletion.");
+  }
+  let lastError: unknown;
+  for (const provider of candidates) {
+    try {
+      const result = await provider.deleteStoredResponse!(responseId);
+      return {
+        providerName: provider.name,
+        deleted: result.deleted,
+        id: result.id,
+      };
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Stored response deletion failed.");
 }
 
 // ============================================================================
@@ -695,15 +837,137 @@ export function createDaemonCommandRegistry(
       const historyLen = session?.history.length ?? 0;
       const providerNames =
         providers.map((provider) => provider.name).join(" → ") || "none";
+      const statefulConfig = ctx.gateway?.config.llm?.statefulResponses;
+      const encryptedReasoningEnabled =
+        ctx.gateway?.config.llm?.includeEncryptedReasoning === true;
+      const responseAnchor = getSessionResumeAnchorResponseId(session);
       await cmdCtx.reply(
         `Agent is running.\n` +
           `Session: ${cmdCtx.sessionId}\n` +
           `History: ${historyLen} messages\n` +
           `LLM: ${providerNames}\n` +
+          `Stateful: ${
+            statefulConfig?.enabled === true
+              ? `enabled (store=${statefulConfig.store === true ? "yes" : "no"}, encrypted_reasoning=${encryptedReasoningEnabled ? "yes" : "no"}, anchor=${responseAnchor ?? "none"})`
+              : "disabled"
+          }\n` +
           `Memory: ${memoryBackend.name}\n` +
           `Tools: ${registry.size}\n` +
           `Skills: ${availableSkills.length}`,
       );
+    },
+  });
+  commandRegistry.register({
+    name: "response",
+    description: "Inspect or delete stored xAI Responses API objects",
+    args: "[status|get [response-id|latest] [--json]|delete [response-id|latest]]",
+    global: true,
+    handler: async (cmdCtx) => {
+      const subcommand = cmdCtx.argv[0]?.toLowerCase() ?? "status";
+      const sessionId = resolveSessionId(cmdCtx.sessionId);
+      const session = sessionMgr.get(sessionId);
+      const responseAnchor = getSessionResumeAnchorResponseId(session);
+      const preferredProviderName =
+        ctx.getSessionModelInfo(cmdCtx.sessionId)?.provider ??
+        ctx.gateway?.config.llm?.provider;
+      const providersWithReplay = orderProvidersForStoredResponses(
+        providers,
+        preferredProviderName,
+        "retrieve",
+      );
+      const capabilityProvider = providersWithReplay[0];
+      const capabilityStateful = capabilityProvider?.getCapabilities?.().stateful;
+      const encryptedReasoningEnabled =
+        ctx.gateway?.config.llm?.includeEncryptedReasoning === true;
+      const statefulConfig = ctx.gateway?.config.llm?.statefulResponses;
+
+      if (subcommand === "status") {
+        await cmdCtx.reply(
+          [
+            "Stored response state:",
+            `  Replay provider available: ${capabilityProvider ? "yes" : "no"}`,
+            `  Retrieval supported: ${capabilityStateful?.storedResponseRetrieval === true ? "yes" : "no"}`,
+            `  Deletion supported: ${capabilityStateful?.storedResponseDeletion === true ? "yes" : "no"}`,
+            `  Encrypted reasoning support: ${capabilityStateful?.encryptedReasoning === true ? "yes" : "no"}`,
+            `  Stateful responses: ${statefulConfig?.enabled === true ? "enabled" : "disabled"}`,
+            `  Provider storage: ${statefulConfig?.store === true ? "enabled" : "disabled"}`,
+            `  Runtime includeEncryptedReasoning: ${encryptedReasoningEnabled ? "enabled" : "disabled"}`,
+            `  Current response anchor: ${responseAnchor ?? "none"}`,
+            `  History compacted: ${getSessionHistoryCompacted(session) ? "yes" : "no"}`,
+          ].join("\n"),
+        );
+        return;
+      }
+
+      if (subcommand !== "get" && subcommand !== "delete") {
+        await cmdCtx.reply(
+          "Usage: /response [status|get [response-id|latest] [--json]|delete [response-id|latest]]",
+        );
+        return;
+      }
+
+      const wantsJson = cmdCtx.argv.some((arg) => arg === "--json");
+      const requestedId = cmdCtx.argv
+        .slice(1)
+        .find((arg) => arg !== "--json");
+      const responseId =
+        !requestedId || requestedId.toLowerCase() === "latest"
+          ? responseAnchor
+          : requestedId.trim();
+      if (!responseId) {
+        await cmdCtx.reply(
+          subcommand === "get"
+            ? "No stored response anchor is available for this session. Pass an explicit response id or run another stateful turn first."
+            : "No stored response anchor is available for this session to delete. Pass an explicit response id or run another stateful turn first.",
+        );
+        return;
+      }
+
+      if (subcommand === "get") {
+        try {
+          const stored = await retrieveStoredResponseWithFallback(
+            providers,
+            responseId,
+            preferredProviderName,
+          );
+          if (wantsJson) {
+            await cmdCtx.reply(JSON.stringify(stored.raw ?? stored, null, 2));
+            return;
+          }
+          await cmdCtx.reply(summarizeStoredResponse(stored));
+        } catch (error) {
+          await cmdCtx.reply(
+            `Stored response retrieval failed: ${toErrorMessage(error)}`,
+          );
+        }
+        return;
+      }
+
+      try {
+        const deleted = await deleteStoredResponseWithFallback(
+          providers,
+          responseId,
+          preferredProviderName,
+        );
+        let clearedAnchor = false;
+        if (responseAnchor && responseAnchor === responseId && session) {
+          clearStatefulContinuationMetadata(session.metadata);
+          await clearWebSessionRuntimeState(memoryBackend, cmdCtx.sessionId);
+          clearedAnchor = true;
+        }
+        await cmdCtx.reply(
+          [
+            `Stored response delete: ${deleted.deleted ? "confirmed" : "not confirmed"}`,
+            `  Provider: ${deleted.providerName}`,
+            `  Response: ${deleted.id}`,
+            `  Cleared active anchor: ${clearedAnchor ? "yes" : "no"}`,
+          ].join("\n"),
+        );
+      } catch (error) {
+        await cmdCtx.reply(
+          `Stored response deletion failed: ${toErrorMessage(error)}`,
+        );
+      }
     },
   });
   commandRegistry.register({

--- a/runtime/src/gateway/subagent-infrastructure.ts
+++ b/runtime/src/gateway/subagent-infrastructure.ts
@@ -360,6 +360,9 @@ export function createDelegatingSubAgentLLMProvider(
         stateful: {
           assistantPhase: false,
           previousResponseId: false,
+          encryptedReasoning: false,
+          storedResponseRetrieval: false,
+          storedResponseDeletion: false,
           opaqueCompaction: false,
           deterministicFallback: true,
         },
@@ -375,6 +378,20 @@ export function createDelegatingSubAgentLLMProvider(
     },
     clearSessionState() {
       resolve().clearSessionState?.();
+    },
+    retrieveStoredResponse(responseId) {
+      const provider = resolve();
+      if (!provider.retrieveStoredResponse) {
+        throw new Error("Active provider does not support stored response retrieval");
+      }
+      return provider.retrieveStoredResponse(responseId);
+    },
+    deleteStoredResponse(responseId) {
+      const provider = resolve();
+      if (!provider.deleteStoredResponse) {
+        throw new Error("Active provider does not support stored response deletion");
+      }
+      return provider.deleteStoredResponse(responseId);
     },
   };
 }

--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -12,13 +12,19 @@ import { sanitizeToolCallArgumentsForReplay } from "../chat-executor-tool-utils.
 
 // Mock the openai module
 const mockCreate = vi.fn();
+const mockRetrieve = vi.fn();
+const mockDelete = vi.fn();
 const mockModelsListFn = vi.fn();
 const mockOpenAIConstructor = vi.fn();
 
 vi.mock("openai", () => {
   return {
     default: class MockOpenAI {
-      responses = { create: mockCreate };
+      responses = {
+        create: mockCreate,
+        retrieve: mockRetrieve,
+        delete: mockDelete,
+      };
       models = { list: mockModelsListFn };
       constructor(opts: any) {
         mockOpenAIConstructor(opts);
@@ -107,7 +113,73 @@ describe("GrokProvider", () => {
       stateful: {
         assistantPhase: false,
         previousResponseId: true,
+        encryptedReasoning: true,
+        storedResponseRetrieval: true,
+        storedResponseDeletion: true,
         opaqueCompaction: false,
+      },
+    });
+  });
+
+  it("retrieves a stored xAI response using the documented Responses API method", async () => {
+    mockRetrieve.mockResolvedValueOnce({
+      id: "resp_saved_1",
+      model: "grok-4.20-reasoning",
+      status: "completed",
+      output_text: "Saved answer",
+      output: [
+        {
+          type: "reasoning",
+          encrypted_content: "ciphertext",
+        },
+        {
+          type: "message",
+          content: [{ type: "output_text", text: "Saved answer" }],
+        },
+      ],
+      usage: { input_tokens: 12, output_tokens: 4, total_tokens: 16 },
+      server_side_tool_usage: {
+        SERVER_SIDE_TOOL_WEB_SEARCH: 1,
+      },
+    });
+
+    const provider = new GrokProvider({ apiKey: "test-key" });
+    const response = await provider.retrieveStoredResponse?.("resp_saved_1");
+
+    expect(mockRetrieve).toHaveBeenCalledWith("resp_saved_1");
+    expect(response).toMatchObject({
+      id: "resp_saved_1",
+      provider: "grok",
+      model: "grok-4.20-reasoning",
+      status: "completed",
+      content: "Saved answer",
+      encryptedReasoning: {
+        requested: true,
+        available: true,
+      },
+    });
+    expect(
+      response?.providerEvidence?.serverSideToolUsage?.[0]?.category,
+    ).toBe("SERVER_SIDE_TOOL_WEB_SEARCH");
+  });
+
+  it("deletes a stored xAI response using the documented Responses API method", async () => {
+    mockDelete.mockResolvedValueOnce({
+      id: "resp_saved_1",
+      deleted: true,
+    });
+
+    const provider = new GrokProvider({ apiKey: "test-key" });
+    const result = await provider.deleteStoredResponse?.("resp_saved_1");
+
+    expect(mockDelete).toHaveBeenCalledWith("resp_saved_1");
+    expect(result).toEqual({
+      id: "resp_saved_1",
+      provider: "grok",
+      deleted: true,
+      raw: {
+        id: "resp_saved_1",
+        deleted: true,
       },
     });
   });

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -24,6 +24,8 @@ import type {
   LLMProviderNativeServerToolCall,
   LLMProviderServerSideToolUsageEntry,
   LLMTool,
+  LLMStoredResponse,
+  LLMStoredResponseDeleteResult,
   StreamProgressCallback,
   ToolCallValidationFailure,
 } from "../types.js";
@@ -1342,12 +1344,64 @@ export class GrokProvider implements LLMProvider {
     }
   }
 
+  async retrieveStoredResponse(responseId: string): Promise<LLMStoredResponse> {
+    const trimmedResponseId = responseId.trim();
+    if (trimmedResponseId.length === 0) {
+      throw new LLMProviderError(
+        this.name,
+        "Stored response retrieval requires a non-empty response ID.",
+        400,
+      );
+    }
+    try {
+      const client = await this.ensureClient();
+      const response = await (client as any).responses.retrieve(trimmedResponseId);
+      return this.toStoredResponse(response);
+    } catch (error) {
+      throw mapLLMError(this.name, error, this.config.timeoutMs ?? 0);
+    }
+  }
+
+  async deleteStoredResponse(
+    responseId: string,
+  ): Promise<LLMStoredResponseDeleteResult> {
+    const trimmedResponseId = responseId.trim();
+    if (trimmedResponseId.length === 0) {
+      throw new LLMProviderError(
+        this.name,
+        "Stored response deletion requires a non-empty response ID.",
+        400,
+      );
+    }
+    try {
+      const client = await this.ensureClient();
+      const response = await (client as any).responses.delete(trimmedResponseId);
+      return {
+        id:
+          typeof response?.id === "string" && response.id.trim().length > 0
+            ? response.id.trim()
+            : trimmedResponseId,
+        provider: this.name,
+        deleted: response?.deleted === true,
+        raw:
+          response && typeof response === "object" && !Array.isArray(response)
+            ? cloneProviderTracePayload(response as Record<string, unknown>)
+            : undefined,
+      };
+    } catch (error) {
+      throw mapLLMError(this.name, error, this.config.timeoutMs ?? 0);
+    }
+  }
+
   getCapabilities() {
     return {
       provider: this.name,
       stateful: {
         assistantPhase: false,
         previousResponseId: true,
+        encryptedReasoning: true,
+        storedResponseRetrieval: true,
+        storedResponseDeletion: true,
         opaqueCompaction: false,
         deterministicFallback: true,
       },
@@ -2148,10 +2202,60 @@ export class GrokProvider implements LLMProvider {
         response,
         structuredOutputRequest,
       ),
-      encryptedReasoning: this.extractEncryptedReasoningDiagnostics(response),
+      encryptedReasoning: this.extractEncryptedReasoningDiagnostics(response, {
+        requested: this.config.includeEncryptedReasoning,
+      }),
       finishReason,
       ...(normalizationIssues.length > 0 ? { normalizationIssues } : {}),
       ...(parsedError ? { error: parsedError } : {}),
+    };
+  }
+
+  private toStoredResponse(response: Record<string, unknown>): LLMStoredResponse {
+    const parsed = this.parseResponse(response);
+    const encryptedReasoning = this.extractEncryptedReasoningDiagnostics(response, {
+      requested: undefined,
+    });
+    const responseId =
+      typeof response.id === "string" && response.id.trim().length > 0
+        ? response.id.trim()
+        : undefined;
+    if (!responseId) {
+      throw new LLMProviderError(
+        this.name,
+        "Stored response payload did not include an id.",
+        502,
+      );
+    }
+    const rawOutput = Array.isArray(response.output)
+      ? response.output
+          .filter((item): item is Record<string, unknown> =>
+            Boolean(item) && typeof item === "object" && !Array.isArray(item)
+          )
+          .map((item) => cloneProviderTracePayload(item))
+          .filter((item): item is Record<string, unknown> => item !== undefined)
+      : undefined;
+    return {
+      id: responseId,
+      provider: this.name,
+      ...(typeof response.model === "string" && response.model.trim().length > 0
+        ? { model: response.model.trim() }
+        : {}),
+      ...(typeof response.status === "string" && response.status.trim().length > 0
+        ? { status: response.status.trim() }
+        : {}),
+      content: parsed.content,
+      toolCalls: parsed.toolCalls,
+      ...(parsed.usage.totalTokens > 0 ||
+        parsed.usage.promptTokens > 0 ||
+        parsed.usage.completionTokens > 0
+        ? { usage: parsed.usage }
+        : {}),
+      ...(parsed.providerEvidence ? { providerEvidence: parsed.providerEvidence } : {}),
+      ...(parsed.structuredOutput ? { structuredOutput: parsed.structuredOutput } : {}),
+      ...(encryptedReasoning ? { encryptedReasoning } : {}),
+      ...(rawOutput ? { output: rawOutput } : {}),
+      raw: cloneProviderTracePayload(response),
     };
   }
 
@@ -2223,6 +2327,9 @@ export class GrokProvider implements LLMProvider {
 
   private extractEncryptedReasoningDiagnostics(
     response: Record<string, unknown>,
+    options?: {
+      requested?: boolean;
+    },
   ): LLMResponse["encryptedReasoning"] {
     const output = Array.isArray(response.output)
       ? (response.output as Array<Record<string, unknown>>)
@@ -2233,7 +2340,9 @@ export class GrokProvider implements LLMProvider {
         typeof item.encrypted_content === "string" &&
         item.encrypted_content.length > 0,
     );
-    const requested = this.config.includeEncryptedReasoning === true;
+    const requested =
+      options?.requested ??
+      (available ? true : this.config.includeEncryptedReasoning === true);
     if (!requested && !available) {
       return undefined;
     }

--- a/runtime/src/llm/index.ts
+++ b/runtime/src/llm/index.ts
@@ -24,6 +24,8 @@ export type {
   LLMStatefulEventType,
   LLMStatefulFallbackReason,
   LLMStatefulResponsesConfig,
+  LLMStoredResponse,
+  LLMStoredResponseDeleteResult,
   LLMResponse,
   LLMStreamChunk,
   LLMTool,

--- a/runtime/src/llm/ollama/adapter.test.ts
+++ b/runtime/src/llm/ollama/adapter.test.ts
@@ -128,6 +128,9 @@ describe("OllamaProvider", () => {
       stateful: {
         assistantPhase: false,
         previousResponseId: false,
+        encryptedReasoning: false,
+        storedResponseRetrieval: false,
+        storedResponseDeletion: false,
         opaqueCompaction: false,
         deterministicFallback: true,
       },

--- a/runtime/src/llm/ollama/adapter.ts
+++ b/runtime/src/llm/ollama/adapter.ts
@@ -460,6 +460,9 @@ export class OllamaProvider implements LLMProvider {
       stateful: {
         assistantPhase: false,
         previousResponseId: false,
+        encryptedReasoning: false,
+        storedResponseRetrieval: false,
+        storedResponseDeletion: false,
         opaqueCompaction: false,
         deterministicFallback: true,
       },

--- a/runtime/src/llm/provider-capabilities.ts
+++ b/runtime/src/llm/provider-capabilities.ts
@@ -26,6 +26,9 @@ export interface ResolvedLLMStatefulResponsesConfig {
 export const UNSUPPORTED_STATEFUL_CAPABILITIES: LLMProviderCapabilities["stateful"] = {
   assistantPhase: false,
   previousResponseId: false,
+  encryptedReasoning: false,
+  storedResponseRetrieval: false,
+  storedResponseDeletion: false,
   opaqueCompaction: false,
   deterministicFallback: true,
 };

--- a/runtime/src/llm/types.ts
+++ b/runtime/src/llm/types.ts
@@ -290,6 +290,12 @@ export interface LLMProviderStatefulCapabilities {
   readonly assistantPhase: boolean;
   /** Provider supports `previous_response_id` / equivalent continuation. */
   readonly previousResponseId: boolean;
+  /** Provider supports requesting encrypted reasoning content via include. */
+  readonly encryptedReasoning: boolean;
+  /** Provider supports fetching stored responses by ID. */
+  readonly storedResponseRetrieval: boolean;
+  /** Provider supports deleting stored responses by ID. */
+  readonly storedResponseDeletion: boolean;
   /** Provider supports opaque provider-managed compaction state. */
   readonly opaqueCompaction: boolean;
   /** Runtime can safely fall back to stateless replay for unsupported features. */
@@ -610,6 +616,44 @@ export interface LLMProviderEvidence {
   readonly serverSideToolUsage?: readonly LLMProviderServerSideToolUsageEntry[];
 }
 
+export interface LLMStoredResponse {
+  /** Provider-emitted response identifier. */
+  readonly id: string;
+  /** Provider name backing the stored response. */
+  readonly provider: string;
+  /** Provider-emitted model identifier when available. */
+  readonly model?: string;
+  /** Provider-emitted lifecycle status when available. */
+  readonly status?: string;
+  /** Parsed assistant text content derived from the stored response output. */
+  readonly content: string;
+  /** Parsed client-side function calls preserved in the stored response. */
+  readonly toolCalls: readonly LLMToolCall[];
+  /** Provider usage block when available. */
+  readonly usage?: LLMUsage;
+  /** Provider-side tool/citation evidence derived from stored output. */
+  readonly providerEvidence?: LLMProviderEvidence;
+  /** Structured output parsing result when present in the stored response. */
+  readonly structuredOutput?: LLMStructuredOutputResult;
+  /** Encrypted reasoning request/availability diagnostics for the stored response. */
+  readonly encryptedReasoning?: LLMEncryptedReasoningDiagnostics;
+  /** Raw provider output array, cloned for debugging/replay inspection. */
+  readonly output?: readonly Record<string, unknown>[];
+  /** Sanitized raw provider response object for debugging/replay inspection. */
+  readonly raw?: Record<string, unknown>;
+}
+
+export interface LLMStoredResponseDeleteResult {
+  /** Deleted response identifier. */
+  readonly id: string;
+  /** Provider name backing the deletion request. */
+  readonly provider: string;
+  /** Whether the provider confirmed the response was deleted. */
+  readonly deleted: boolean;
+  /** Sanitized raw provider delete response for debugging/auditing. */
+  readonly raw?: Record<string, unknown>;
+}
+
 /**
  * Response from an LLM provider
  */
@@ -679,6 +723,12 @@ export interface LLMProvider {
   resetSessionState?(sessionId: string): void;
   /** Optional lifecycle hook to clear all provider-managed session state. */
   clearSessionState?(): void;
+  /** Optional debug/replay hook for fetching a stored provider response by ID. */
+  retrieveStoredResponse?(responseId: string): Promise<LLMStoredResponse>;
+  /** Optional debug/replay hook for deleting a stored provider response by ID. */
+  deleteStoredResponse?(
+    responseId: string,
+  ): Promise<LLMStoredResponseDeleteResult>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add xAI response retrieve/delete support to the shared runtime provider surface
- expose daemon `/response` debug commands for status, fetch, and delete operations
- report replay/encrypted reasoning capabilities explicitly across provider capability plumbing

## Testing
- npx vitest run runtime/src/llm/grok/adapter.test.ts runtime/src/gateway/daemon-command-registry.test.ts runtime/src/llm/ollama/adapter.test.ts
- npx tsc --noEmit
- npm run build
- npm run techdebt