### PR TITLE
fix(runtime): disambiguate plan artifact intent routing

### DIFF
--- a/runtime/src/llm/chat-executor-contract-flow.test.ts
+++ b/runtime/src/llm/chat-executor-contract-flow.test.ts
@@ -134,7 +134,7 @@ describe("chat-executor-contract-flow", () => {
     expect(workflowContext).toEqual({});
   });
 
-  it("does not synthesize direct implementation ownership for explicit PLAN.md phase-execution requests", () => {
+  it("synthesizes direct implementation ownership for implement-from-plan requests", () => {
     const workflowContext = resolveRuntimeWorkflowContext({
       ctx: {
         messageText:
@@ -169,7 +169,17 @@ describe("chat-executor-contract-flow", () => {
       } as any,
     });
 
-    expect(workflowContext).toEqual({});
+    expect(workflowContext).toMatchObject({
+      ownershipSource: "direct_deterministic_implementation",
+      verificationContract: {
+        workspaceRoot: "/tmp/project",
+        verificationMode: "mutation_required",
+        targetArtifacts: ["/tmp/project/src/main.c"],
+      },
+      completionContract: {
+        taskClass: "artifact_only",
+      },
+    });
   });
 
   it("requires workflow-owned completion for implementation-class turns outside legacy compatibility", () => {

--- a/runtime/src/llm/chat-executor-contract-flow.ts
+++ b/runtime/src/llm/chat-executor-contract-flow.ts
@@ -37,6 +37,7 @@ import {
 } from "./chat-executor-routing-state.js";
 import { didToolCallFail } from "./chat-executor-tool-utils.js";
 import {
+  plannerRequestNeedsGroundedPlanArtifact,
   plannerRequestNeedsPlanArtifactExecution,
   requestRequiresToolGroundedExecution,
 } from "./chat-executor-planner.js";
@@ -478,7 +479,10 @@ function mergeWorkflowVerificationContext(input: {
 function synthesizeDirectImplementationWorkflowContext(
   ctx: ContractFlowContext,
 ): RuntimeWorkflowContextResolution | undefined {
-  if (plannerRequestNeedsPlanArtifactExecution(ctx.messageText)) {
+  if (
+    plannerRequestNeedsGroundedPlanArtifact(ctx.messageText) ||
+    plannerRequestNeedsPlanArtifactExecution(ctx.messageText)
+  ) {
     return undefined;
   }
   const workspaceRoot = normalizeWorkspaceRoot(ctx.runtimeWorkspaceRoot);

--- a/runtime/src/llm/chat-executor-planner-execution.ts
+++ b/runtime/src/llm/chat-executor-planner-execution.ts
@@ -52,7 +52,7 @@ import {
   buildExplicitSubagentOrchestrationFailureMessage,
   extractRecoverablePlannerParseDiagnostics,
   isHighRiskSubagentPlan,
-  plannerRequestNeedsPlanArtifactExecution,
+  plannerRequestImplementsFromArtifact,
 } from "./chat-executor-planner.js";
 import { normalizePlannerResponse } from "./chat-executor-planner-normalization.js";
 import {
@@ -1173,7 +1173,7 @@ export async function executePlannerPath(
       );
     ctx.plannerImplementationFallbackBlocked =
       plannerImplementationFallbackBlocked;
-    const planArtifactExecutionRequest = plannerRequestNeedsPlanArtifactExecution(
+    const planArtifactExecutionRequest = plannerRequestImplementsFromArtifact(
       ctx.messageText,
     );
     const delegationVetoReason = delegationDecision?.reason;

--- a/runtime/src/llm/chat-executor-planner.test.ts
+++ b/runtime/src/llm/chat-executor-planner.test.ts
@@ -11,9 +11,11 @@ import {
   extractPlannerVerificationCommandRequirements,
   extractPlannerVerificationRequirements,
   buildPlannerStructuralRefinementHint,
+  classifyPlannerPlanArtifactIntent,
   extractExplicitDeterministicToolRequirements,
   extractExplicitSubagentOrchestrationRequirements,
   parsePlannerPlan,
+  plannerRequestImplementsFromArtifact,
   requestExplicitlyRequestsDelegation,
   salvagePlannerToolCallsAsPlan,
   validatePlannerVerificationRequirements,
@@ -107,6 +109,51 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
     expect(messages[0]?.content).not.toContain(
       '"requiredSourceArtifacts": ["/abs/path/PLAN.md"]',
     );
+  });
+
+  it("filters same-target artifact-edit history when the current turn is implementing from the artifact", () => {
+    const messages = buildPlannerMessages(
+      "Read all of @PLAN.md and implement every phase in full.",
+      [
+        {
+          role: "user",
+          content: "Go through @PLAN.md and make sure it is perfect before we implement anything.",
+        },
+        {
+          role: "assistant",
+          content: "I found several gaps in PLAN.md and can fix them next.",
+        },
+        {
+          role: "user",
+          content: "Keep the workspace root at /tmp/agenc-shell and use gcc with non-interactive tests.",
+        },
+      ],
+      512,
+    );
+
+    const finalUserMessage = messages[messages.length - 1];
+    expect(finalUserMessage?.role).toBe("user");
+    expect(finalUserMessage?.content).not.toContain("make sure it is perfect");
+    expect(finalUserMessage?.content).not.toContain("I found several gaps in PLAN.md");
+    expect(finalUserMessage?.content).toContain(
+      "Keep the workspace root at /tmp/agenc-shell",
+    );
+  });
+
+  it("keeps different-target artifact history when implementing from a plan artifact", () => {
+    const messages = buildPlannerMessages(
+      "Read all of @PLAN.md and implement every phase in full.",
+      [
+        {
+          role: "user",
+          content: "Please perfect ROADMAP.md before the release.",
+        },
+      ],
+      512,
+    );
+
+    const finalUserMessage = messages[messages.length - 1];
+    expect(finalUserMessage?.content).toContain("perfect ROADMAP.md");
   });
 
   it("treats plain-language delegation research requests as explicit delegation", () => {
@@ -582,12 +629,27 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
   it("forces planner routing for plan-artifact execution requests", () => {
     const decision = assessPlannerDecision(
       true,
-      "You are to read all of @PLAN.md and complete every single phase in full.",
+      "Update PLAN.md so it reflects the corrected architecture and missing validation steps.",
       [],
     );
 
     expect(decision.shouldPlan).toBe(true);
     expect(decision.reason).toContain("plan_artifact_execution_request");
+  });
+
+  it("routes implement-from-plan requests through the planner without classifying them as artifact edits", () => {
+    const messageText =
+      "You are to read all of @PLAN.md and complete every single phase in full.";
+
+    expect(classifyPlannerPlanArtifactIntent(messageText)).toBe(
+      "implement_from_artifact",
+    );
+    expect(plannerRequestImplementsFromArtifact(messageText)).toBe(true);
+
+    const decision = assessPlannerDecision(true, messageText, []);
+
+    expect(decision.shouldPlan).toBe(true);
+    expect(decision.reason).toContain("artifact_spec_execution_request");
   });
 
   it("extracts required subagent steps from the compact 'plan required' prompt shape", () => {
@@ -1570,6 +1632,84 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
         }),
       ]),
     );
+  });
+
+  it("does not require a final artifact write step for implement-from-plan requests", () => {
+    const workspaceRoot = "/tmp/agenc-shell";
+    const diagnostics = validatePlannerStepContracts(
+      {
+        reason: "implement_from_plan",
+        requiresSynthesis: false,
+        confidence: 0.82,
+        steps: [
+          {
+            name: "read_plan",
+            stepType: "deterministic_tool",
+            dependsOn: [],
+            tool: "system.readFile",
+            args: {
+              path: `${workspaceRoot}/PLAN.md`,
+            },
+          },
+          {
+            name: "implement_phase_work",
+            stepType: "subagent_task",
+            dependsOn: ["read_plan"],
+            objective: "Implement the requested shell phases from PLAN.md.",
+            inputContract: "PLAN.md plus existing source tree.",
+            acceptanceCriteria: ["Requested shell phases are implemented and tested."],
+            requiredToolCapabilities: ["read", "write", "bash"],
+            contextRequirements: ["read_plan"],
+            maxBudgetHint: "20m",
+            canRunParallel: false,
+            executionContext: {
+              version: "v1",
+              workspaceRoot,
+              allowedReadRoots: [workspaceRoot],
+              allowedWriteRoots: [workspaceRoot],
+              requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+              targetArtifacts: [`${workspaceRoot}/src`],
+              effectClass: "filesystem_write",
+              verificationMode: "mutation_required",
+              stepKind: "delegated_write",
+            },
+          },
+        ],
+        edges: [{ from: "read_plan", to: "implement_phase_work" }],
+      },
+      "Read all of @PLAN.md and complete every single phase in full.",
+    );
+
+    expect(diagnostics).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "planner_plan_artifact_missing_write_step",
+        }),
+      ]),
+    );
+  });
+
+  it("classifies the full existing artifact alias family consistently", () => {
+    expect(
+      classifyPlannerPlanArtifactIntent(
+        "Read TODO.md and turn it into a complete implementation plan.",
+      ),
+    ).toBe("grounded_plan_generation");
+    expect(
+      classifyPlannerPlanArtifactIntent(
+        "Update roadmap.md so it reflects the latest sequencing and owners.",
+      ),
+    ).toBe("edit_artifact");
+    expect(
+      classifyPlannerPlanArtifactIntent(
+        "Implement everything in implementation-plan.md and verify each phase before moving on.",
+      ),
+    ).toBe("implement_from_artifact");
+    expect(
+      classifyPlannerPlanArtifactIntent(
+        "Use spec.md as the source of truth and implement the project in full.",
+      ),
+    ).toBe("implement_from_artifact");
   });
 
   it("rejects deterministic bash steps that embed shell separators in direct args", () => {

--- a/runtime/src/llm/chat-executor-planner.ts
+++ b/runtime/src/llm/chat-executor-planner.ts
@@ -335,7 +335,9 @@ export function assessPlannerDecision(
     };
   }
 
-  if (plannerRequestNeedsGroundedPlanArtifact(messageText)) {
+  const artifactIntent = classifyPlannerPlanArtifactIntent(messageText);
+
+  if (artifactIntent === "grounded_plan_generation") {
     return {
       score: Math.max(score, 3),
       shouldPlan: true,
@@ -346,7 +348,7 @@ export function assessPlannerDecision(
     };
   }
 
-  if (plannerRequestNeedsPlanArtifactExecution(messageText)) {
+  if (artifactIntent === "edit_artifact") {
     return {
       score: Math.max(score, 4),
       shouldPlan: true,
@@ -354,6 +356,17 @@ export function assessPlannerDecision(
         reasons.length > 0
           ? `${reasons.join("+")}+plan_artifact_execution_request`
           : "plan_artifact_execution_request",
+    };
+  }
+
+  if (artifactIntent === "implement_from_artifact") {
+    return {
+      score: Math.max(score, 4),
+      shouldPlan: true,
+      reason:
+        reasons.length > 0
+          ? `${reasons.join("+")}+artifact_spec_execution_request`
+          : "artifact_spec_execution_request",
     };
   }
 
@@ -605,15 +618,53 @@ export function buildPlannerMessages(
     extractPlannerVerificationRequirements(messageText);
   const verificationCommandRequirements =
     extractPlannerVerificationCommandRequirements(messageText);
-  const planArtifactExecutionRequest =
-    plannerRequestNeedsPlanArtifactExecution(messageText);
+  const artifactIntent = classifyPlannerPlanArtifactIntent(messageText);
+  const planArtifactExecutionRequest = artifactIntent === "edit_artifact";
+  const implementFromArtifactRequest =
+    artifactIntent === "implement_from_artifact";
+  const currentArtifactTargets = extractPlannerArtifactTargets(messageText);
   const hostToolingHint = buildPlannerHostToolingHint(
     messageText,
     history,
     hostToolingProfile,
   );
+  let suppressImmediateAssistantReply = false;
   const historyPreview = history
     .slice(-6)
+    .filter((entry) => {
+      const raw =
+        typeof entry.content === "string"
+          ? entry.content
+          : entry.content
+              .filter((part) => part.type === "text")
+              .map((part) => part.text)
+              .join(" ");
+      if (!implementFromArtifactRequest) {
+        suppressImmediateAssistantReply = false;
+        return true;
+      }
+      if (entry.role === "assistant" && suppressImmediateAssistantReply) {
+        suppressImmediateAssistantReply = false;
+        return false;
+      }
+      const entryIntent = classifyPlannerPlanArtifactIntent(raw);
+      const sameArtifactTarget = plannerArtifactTargetsOverlap(
+        currentArtifactTargets,
+        extractPlannerArtifactTargets(raw),
+      );
+      if (
+        sameArtifactTarget &&
+        (
+          entryIntent === "grounded_plan_generation" ||
+          entryIntent === "edit_artifact"
+        )
+      ) {
+        suppressImmediateAssistantReply = entry.role === "user";
+        return false;
+      }
+      suppressImmediateAssistantReply = false;
+      return true;
+    })
     .map((entry) => {
       const raw =
         typeof entry.content === "string"
@@ -788,6 +839,15 @@ export function buildPlannerMessages(
         "If you need prior grounding, keep it read-only and bounded to explicit source or analysis artifacts. " +
         "Do not emit multiple mutable, validation, or QA subagent_task steps that all re-own the same workspace root. " +
         "Build, test, and verification around the implementation owner should be deterministic_tool steps unless a later delegated step owns disjoint artifacts.",
+    });
+  }
+  if (implementFromArtifactRequest) {
+    messages.push({
+      role: "system",
+      content:
+        "The named planning artifact is the source specification for implementation work, not the primary artifact to rewrite. " +
+        "Plan code changes, build/test verification, and bounded delegated implementation around the source spec. " +
+        "Do not collapse the task into editing the planning artifact unless the user explicitly asks to update that artifact.",
     });
   }
 
@@ -1024,18 +1084,30 @@ const PLANNER_PLAN_ARTIFACT_REQUEST_RE =
   /\b(?:write|create|draft|generate|produce|make)\b[\s\S]{0,120}\b(?:todo(?:\.md)?|implementation plan|project plan|plan doc(?:ument)?|roadmap|checklist|spec(?:ification)?)\b/i;
 const PLANNER_PLAN_ARTIFACT_FILE_RE =
   /\b(?:todo(?:\.md)?|plan\.(?:md|txt|rst)|implementation[-_ ]plan(?:\.md)?|project[-_ ]plan(?:\.md)?|roadmap(?:\.md)?|checklist(?:\.md)?|spec(?:ification)?(?:\.md)?)\b/i;
+const PLANNER_PLAN_ARTIFACT_FILE_CAPTURE_RE =
+  /\b(?:todo(?:\.md)?|plan\.(?:md|txt|rst)|implementation[-_ ]plan(?:\.md)?|project[-_ ]plan(?:\.md)?|roadmap(?:\.md)?|checklist(?:\.md)?|spec(?:ification)?(?:\.md)?)\b/gi;
 const PLANNER_PLAN_ARTIFACT_SOURCE_CUE_RE =
   /\b(?:read|review|inspect|use|follow|based on|source of truth|go through)\b/i;
 const PLANNER_PLAN_ARTIFACT_EXECUTION_CUE_RE =
   /\b(?:implement|execute|complete|finish|carry\s+out|apply|fix|repair|refactor|ship)\b/i;
 const PLANNER_PLAN_ARTIFACT_PHASE_CUE_RE =
   /\b(?:phase|step|task|item)s?\b/i;
+const PLANNER_PLAN_ARTIFACT_EDIT_CUE_RE =
+  /\b(?:update|rewrite|improve|perfect|polish|edit|revise|expand|flesh\s+out|address\s+gaps?|fix\s+gaps?|tighten|correct)\b/i;
+const PLANNER_PLAN_ARTIFACT_IMPLEMENTATION_CUE_RE =
+  /\b(?:all|each|every|entire|full|fully|phase\s+by\s+phase|one\s+phase\s+at\s+a\s+time|before\s+moving\s+on|move\s+on\s+to\s+the\s+next\s+phase)\b/i;
 const REQUEST_VERIFICATION_DIRECTIVE_RE =
   /\b(?:verify|verification|validated?|before\s+finish(?:ing)?|before\s+returning|before\s+completion|browser-grounded checks?)\b/i;
 const REQUEST_INSTALL_VERIFICATION_RE =
   /\b(?:npm|pnpm|yarn|bun)\s+(?:install|ci)\b|\binstall(?:ation|able|ed|ing|s)?\b/i;
 const REQUEST_BUILD_VERIFICATION_RE =
   /\b(?:npm|pnpm|yarn|bun)\s+(?:run\s+)?(?:build|typecheck|lint)\b|\b(?:vite\s+build|tsc\b|build(?:s|ing)?|compile(?:s|d|ing)?|typecheck(?:s|ed|ing)?|lint(?:s|ed|ing)?)\b/i;
+
+export type PlannerPlanArtifactIntent =
+  | "none"
+  | "grounded_plan_generation"
+  | "edit_artifact"
+  | "implement_from_artifact";
 const REQUEST_TEST_VERIFICATION_RE =
   /\b(?:npm|pnpm|yarn|bun)\s+(?:run\s+)?(?:test|coverage|vitest|jest)\b|\b(?:tests?|testing|smoke tests?|unit tests?|vitest|jest|pytest|mocha|ava|coverage)\b/i;
 const REQUEST_BROWSER_VERIFICATION_RE =
@@ -3273,11 +3345,17 @@ export function validatePlannerStepContracts(
 ): readonly PlannerDiagnostic[] {
   const diagnostics: PlannerDiagnostic[] = [];
 
-  if (typeof messageText === "string" && plannerRequestNeedsGroundedPlanArtifact(messageText)) {
-    diagnostics.push(...validatePlannerPlanArtifactSteps(plannerPlan));
-  }
-  if (typeof messageText === "string" && plannerRequestNeedsPlanArtifactExecution(messageText)) {
-    diagnostics.push(...validatePlannerPlanArtifactExecutionOwnership(plannerPlan));
+  if (typeof messageText === "string") {
+    const artifactIntent = classifyPlannerPlanArtifactIntent(messageText);
+    if (
+      artifactIntent === "grounded_plan_generation" ||
+      artifactIntent === "edit_artifact"
+    ) {
+      diagnostics.push(...validatePlannerPlanArtifactSteps(plannerPlan));
+    }
+    if (artifactIntent === "implement_from_artifact") {
+      diagnostics.push(...validatePlannerPlanArtifactExecutionOwnership(plannerPlan));
+    }
   }
 
   for (const step of plannerPlan.steps) {
@@ -3392,15 +3470,26 @@ export function validatePlannerStepContracts(
   return diagnostics;
 }
 
-function plannerRequestNeedsGroundedPlanArtifact(messageText: string): boolean {
+function extractPlannerArtifactTargets(messageText: string): readonly string[] {
   const normalized = messageText.trim();
   if (normalized.length === 0) {
-    return false;
+    return [];
   }
-  if (
-    !PLANNER_PLAN_ARTIFACT_REQUEST_RE.test(normalized) &&
-    !PLANNER_PLAN_ARTIFACT_FILE_RE.test(normalized)
-  ) {
+  PLANNER_PLAN_ARTIFACT_FILE_CAPTURE_RE.lastIndex = 0;
+  const targets = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = PLANNER_PLAN_ARTIFACT_FILE_CAPTURE_RE.exec(normalized)) !== null) {
+    const value = (match[0] ?? "").trim().toLowerCase();
+    if (value.length > 0) {
+      targets.add(value);
+    }
+  }
+  return [...targets];
+}
+
+function plannerRequestGroundedPlanArtifactIntent(messageText: string): boolean {
+  const normalized = messageText.trim();
+  if (normalized.length === 0) {
     return false;
   }
   const signals = collectPlannerRequestSignals(normalized, []);
@@ -3408,9 +3497,16 @@ function plannerRequestNeedsGroundedPlanArtifact(messageText: string): boolean {
     /\b(?:read|expand|turn|convert|rewrite|flesh\s+out|promote)\b[\s\S]{0,80}\b(?:into|to)\b[\s\S]{0,80}\b(?:complete|full|detailed)?\s*(?:implementation\s+)?plan\b/i.test(
       normalized,
     );
+  const hasGenerationCue =
+    PLANNER_PLAN_ARTIFACT_REQUEST_RE.test(normalized) ||
+    explicitPlanExpansionCue;
+  if (!hasGenerationCue) {
+    return false;
+  }
   return (
     (signals.hasImplementationScopeCue || explicitPlanExpansionCue) &&
     (
+      PLANNER_PLAN_ARTIFACT_FILE_RE.test(normalized) ||
       signals.hasDocumentationCue ||
       signals.hasMultiStepCue ||
       signals.longTask ||
@@ -3421,25 +3517,88 @@ function plannerRequestNeedsGroundedPlanArtifact(messageText: string): boolean {
   );
 }
 
-export function plannerRequestNeedsPlanArtifactExecution(messageText: string): boolean {
+export function classifyPlannerPlanArtifactIntent(
+  messageText: string,
+): PlannerPlanArtifactIntent {
   const normalized = messageText.trim();
   if (normalized.length === 0) {
-    return false;
+    return "none";
   }
+
+  if (plannerRequestGroundedPlanArtifactIntent(normalized)) {
+    return "grounded_plan_generation";
+  }
+
   if (!PLANNER_PLAN_ARTIFACT_FILE_RE.test(normalized)) {
-    return false;
-  }
-  if (!PLANNER_PLAN_ARTIFACT_EXECUTION_CUE_RE.test(normalized)) {
-    return false;
+    return "none";
   }
   const signals = collectPlannerRequestSignals(normalized, []);
+  const hasDirectArtifactEditCue =
+    /\b(?:todo(?:\.md)?|plan\.(?:md|txt|rst)|implementation[-_ ]plan(?:\.md)?|project[-_ ]plan(?:\.md)?|roadmap(?:\.md)?|checklist(?:\.md)?|spec(?:ification)?(?:\.md)?)\b[\s\S]{0,80}\b(?:update|rewrite|improve|perfect|polish|edit|revise|expand|flesh\s+out|address\s+gaps?|fix\s+gaps?|tighten|correct)\b/i.test(
+      normalized,
+    ) ||
+    /\b(?:update|rewrite|improve|perfect|polish|edit|revise|expand|flesh\s+out|address\s+gaps?|fix\s+gaps?|tighten|correct)\b[\s\S]{0,80}\b(?:todo(?:\.md)?|plan\.(?:md|txt|rst)|implementation[-_ ]plan(?:\.md)?|project[-_ ]plan(?:\.md)?|roadmap(?:\.md)?|checklist(?:\.md)?|spec(?:ification)?(?:\.md)?)\b/i.test(
+      normalized,
+    );
+  const hasImplementationFromArtifactCue =
+    PLANNER_PLAN_ARTIFACT_EXECUTION_CUE_RE.test(normalized) &&
+    (
+      PLANNER_PLAN_ARTIFACT_SOURCE_CUE_RE.test(normalized) ||
+      PLANNER_PLAN_ARTIFACT_PHASE_CUE_RE.test(normalized) ||
+      PLANNER_PLAN_ARTIFACT_IMPLEMENTATION_CUE_RE.test(normalized) ||
+      signals.hasImplementationScopeCue ||
+      signals.hasVerificationCue ||
+      signals.hasMultiStepCue ||
+      signals.longTask
+    );
+  const hasArtifactEditCue =
+    hasDirectArtifactEditCue ||
+    PLANNER_PLAN_ARTIFACT_EDIT_CUE_RE.test(normalized) ||
+    /\b(?:fill|add)\b[\s\S]{0,80}\b(?:gaps?|missing sections?|missing items?)\b/i.test(
+      normalized,
+    ) ||
+    /\b(?:make|keep)\b[\s\S]{0,80}\b(?:perfect|complete|consistent|correct)\b/i.test(
+      normalized,
+    );
+  if (hasArtifactEditCue) {
+    return "edit_artifact";
+  }
+  if (hasImplementationFromArtifactCue) {
+    return "implement_from_artifact";
+  }
+
+  return "none";
+}
+
+export function plannerRequestNeedsGroundedPlanArtifact(messageText: string): boolean {
   return (
-    PLANNER_PLAN_ARTIFACT_SOURCE_CUE_RE.test(normalized) ||
-    PLANNER_PLAN_ARTIFACT_PHASE_CUE_RE.test(normalized) ||
-    signals.hasImplementationScopeCue ||
-    signals.hasMultiStepCue ||
-    signals.longTask
+    classifyPlannerPlanArtifactIntent(messageText) ===
+    "grounded_plan_generation"
   );
+}
+
+export function plannerRequestNeedsPlanArtifactExecution(messageText: string): boolean {
+  return classifyPlannerPlanArtifactIntent(messageText) === "edit_artifact";
+}
+
+export function plannerRequestImplementsFromArtifact(
+  messageText: string,
+): boolean {
+  return (
+    classifyPlannerPlanArtifactIntent(messageText) ===
+    "implement_from_artifact"
+  );
+}
+
+function plannerArtifactTargetsOverlap(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  if (left.length === 0 || right.length === 0) {
+    return false;
+  }
+  const rightSet = new Set(right);
+  return left.some((target) => rightSet.has(target));
 }
 
 function isPlannerFileWriteStep(step: PlannerStepIntent): boolean {

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -13073,7 +13073,7 @@ describe("ChatExecutor", () => {
       expect(result.callUsage.map((entry) => entry.phase)).toEqual(["planner"]);
     });
 
-    it("routes plan-artifact execution requests through the planner instead of the direct tool loop", async () => {
+    it("routes plan-artifact edit requests through the planner instead of the direct tool loop", async () => {
       const provider = createMockProvider("primary", {
         chat: vi.fn().mockResolvedValueOnce(
           mockResponse({
@@ -13133,7 +13133,7 @@ describe("ChatExecutor", () => {
       const result = await executor.execute(
         createParams({
           message: createMessage(
-            "You are to read all of @PLAN.md and complete every single phase in full.",
+            "Read PLAN.md and update it with a final phase summary for the completed work.",
           ),
         }),
       );
@@ -14795,6 +14795,13 @@ describe("ChatExecutor", () => {
           expect.objectContaining({
             category: "policy",
             code: "planner_step_contract_retry",
+          }),
+        ]),
+      );
+      expect(result.plannerSummary?.diagnostics).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "planner_plan_artifact_missing_write_step",
           }),
         ]),
       );


### PR DESCRIPTION
## Summary
- distinguish plan generation/editing from implement-from-plan requests
- stop requiring a plan-file write step for implement-from-plan execution
- filter same-target artifact-edit history so stale plan-fix context does not poison implementation turns

## Test plan
- [x] `npx vitest run src/llm/chat-executor-planner.test.ts`
- [x] `npx vitest run src/llm/chat-executor-contract-flow.test.ts src/llm/chat-executor-planner.test.ts src/llm/chat-executor.test.ts`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
