### PR TITLE
Ground planner repair retries in workspace build failures

### DIFF
--- a/runtime/src/llm/chat-executor-planner-execution.ts
+++ b/runtime/src/llm/chat-executor-planner-execution.ts
@@ -53,6 +53,7 @@ import {
   extractRecoverablePlannerParseDiagnostics,
   isHighRiskSubagentPlan,
   plannerRequestImplementsFromArtifact,
+  pipelineResultToToolCalls,
 } from "./chat-executor-planner.js";
 import { normalizePlannerResponse } from "./chat-executor-planner-normalization.js";
 import {
@@ -1471,9 +1472,14 @@ export async function executePlannerPath(
         if (runtimeRepairFailureSignature) {
           seenRuntimeRepairFailureSignatures.add(runtimeRepairFailureSignature);
         }
+        const plannerToolCalls = pipelineResultToToolCalls(
+          plannerPlan.steps,
+          pipelineResult,
+        );
         refinementHint = buildPipelineFailureRepairRefinementHint({
           pipelineResult,
           plannerPlan,
+          plannerToolCalls,
         });
         ctx.plannerSummaryState.diagnostics.push({
           category: "policy",

--- a/runtime/src/llm/chat-executor-planner.test.ts
+++ b/runtime/src/llm/chat-executor-planner.test.ts
@@ -462,6 +462,133 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
     expect(hint).toContain("CI=1 npm test");
   });
 
+  it("grounds missing npm script repair hints with the failing command and cwd", () => {
+    const hint = buildPipelineFailureRepairRefinementHint({
+      pipelineResult: {
+        status: "failed",
+        completedSteps: 2,
+        totalSteps: 4,
+        error:
+          'npm ERR! Missing script: "build"\nnpm ERR! To see a list of scripts, run:\nnpm ERR!   npm run',
+        stopReasonHint: "tool_error",
+      },
+      plannerPlan: {
+        reason: "repair",
+        requiresSynthesis: true,
+        steps: [
+          {
+            name: "scaffold_workspace",
+            stepType: "subagent_task",
+            objective: "Scaffold the nested workspace app.",
+            inputContract: "Repo root exists.",
+            acceptanceCriteria: ["Workspace package.json exists"],
+            requiredToolCapabilities: ["system.writeFile"],
+            contextRequirements: ["repo root"],
+            maxBudgetHint: "2m",
+            canRunParallel: false,
+          },
+          {
+            name: "build_workspace_app",
+            stepType: "deterministic_tool",
+            tool: "system.bash",
+            args: {
+              command: "npm",
+              args: ["run", "build"],
+              cwd: "/tmp/agenc-umbrella",
+            },
+          },
+        ],
+      },
+      plannerToolCalls: [
+        {
+          name: "execute_with_agent",
+          args: { objective: "Scaffold the nested workspace app." },
+          result: '{"status":"completed","success":true}',
+          isError: false,
+          durationMs: 0,
+        },
+        {
+          name: "system.bash",
+          args: {
+            command: "npm",
+            args: ["run", "build"],
+            cwd: "/tmp/agenc-umbrella",
+          },
+          result:
+            '{"exitCode":1,"stdout":"","stderr":"npm ERR! Missing script: \\"build\\""}',
+          isError: true,
+          durationMs: 0,
+        },
+      ],
+    });
+
+    expect(hint).toContain("The failed deterministic shell command was `npm run build`");
+    expect(hint).toContain("cwd `/tmp/agenc-umbrella`");
+    expect(hint).toContain("matching workspace/package-specific command");
+    expect(hint).toContain("generic `npm run build`");
+  });
+
+  it("adds exact workspace selector repair guidance for planner retry hints", () => {
+    const hint = buildPipelineFailureRepairRefinementHint({
+      pipelineResult: {
+        status: "failed",
+        completedSteps: 3,
+        totalSteps: 5,
+        error:
+          "npm error No workspaces found:\nnpm error   --workspace=core --workspace=cli --workspace=web",
+        stopReasonHint: "tool_error",
+      },
+      plannerPlan: {
+        reason: "repair",
+        requiresSynthesis: true,
+        steps: [
+          {
+            name: "build_workspace_packages",
+            stepType: "deterministic_tool",
+            tool: "system.bash",
+            args: {
+              command: "npm",
+              args: [
+                "run",
+                "build",
+                "--workspace=core",
+                "--workspace=cli",
+                "--workspace=web",
+              ],
+              cwd: "/tmp/transit-weave",
+            },
+          },
+        ],
+      },
+      plannerToolCalls: [
+        {
+          name: "system.bash",
+          args: {
+            command: "npm",
+            args: [
+              "run",
+              "build",
+              "--workspace=core",
+              "--workspace=cli",
+              "--workspace=web",
+            ],
+            cwd: "/tmp/transit-weave",
+          },
+          result:
+            '{"exitCode":1,"stdout":"","stderr":"npm error No workspaces found:\\nnpm error   --workspace=core --workspace=cli --workspace=web"}',
+          isError: true,
+          durationMs: 0,
+        },
+      ],
+    });
+
+    expect(hint).toContain("npm could not match one or more `--workspace` selectors");
+    expect(hint).toContain("`core`");
+    expect(hint).toContain("`cli`");
+    expect(hint).toContain("`web`");
+    expect(hint).toContain("matching workspace cwd");
+  });
+
   it("adds host tooling planner guidance when npm workspace protocol is unsupported", () => {
     const messages = buildPlannerMessages(
       "Create a TypeScript npm workspace project with package.json files for core and cli.",

--- a/runtime/src/llm/chat-executor-planner.ts
+++ b/runtime/src/llm/chat-executor-planner.ts
@@ -4329,9 +4329,17 @@ export function buildPipelineDecompositionRefinementHint(
 export function buildPipelineFailureRepairRefinementHint(params: {
   readonly pipelineResult: PipelineResult;
   readonly plannerPlan: PlannerPlan;
+  readonly plannerToolCalls?: readonly ToolCallRecord[];
 }): string {
+  const failedPlannerCall = findRelevantFailedPlannerToolCall(
+    params.plannerToolCalls,
+  );
+  const failedPlannerCallHint = buildFailedPlannerCallHint(
+    failedPlannerCall,
+  );
   const failureSpecificRepairHint = buildFailureSpecificRepairHint(
     params.pipelineResult.error,
+    failedPlannerCall,
   );
   const unresolvedSteps = params.plannerPlan.steps
     .slice(Math.max(0, params.pipelineResult.completedSteps))
@@ -4347,6 +4355,7 @@ export function buildPipelineFailureRepairRefinementHint(params: {
       params.pipelineResult.error.trim().length > 0
       ? `failure details: ${truncateText(params.pipelineResult.error.trim(), 800)}`
       : "",
+    failedPlannerCallHint ?? "",
     failureSpecificRepairHint ?? "",
   ].filter((fragment) => fragment.length > 0);
   return (
@@ -4357,13 +4366,129 @@ export function buildPipelineFailureRepairRefinementHint(params: {
   );
 }
 
+function findRelevantFailedPlannerToolCall(
+  plannerToolCalls: readonly ToolCallRecord[] | undefined,
+): ToolCallRecord | undefined {
+  if (!plannerToolCalls || plannerToolCalls.length === 0) {
+    return undefined;
+  }
+  for (let index = plannerToolCalls.length - 1; index >= 0; index--) {
+    const candidate = plannerToolCalls[index];
+    if (candidate?.isError) {
+      return candidate;
+    }
+  }
+  return plannerToolCalls[plannerToolCalls.length - 1];
+}
+
+function buildFailedPlannerCallHint(
+  call: ToolCallRecord | undefined,
+): string | undefined {
+  if (!call) {
+    return undefined;
+  }
+  if (call.name === "system.bash" || call.name === "desktop.bash") {
+    const commandText = extractPlannerToolCommandText(call.args).trim();
+    const cwd = extractPlannerToolCwd(call.args);
+    if (commandText.length === 0 && !cwd) {
+      return undefined;
+    }
+    return (
+      `The failed deterministic shell command was \`${truncateText(commandText, 240)}\`` +
+      `${cwd ? ` with cwd \`${cwd}\`` : ""}.`
+    );
+  }
+  return `The failed deterministic tool was \`${call.name}\`.`;
+}
+
+function extractPlannerToolCommandText(args: Record<string, unknown>): string {
+  const parts: string[] = [];
+  if (typeof args.command === "string") {
+    parts.push(args.command);
+  }
+  if (Array.isArray(args.args)) {
+    for (const entry of args.args) {
+      if (typeof entry === "string") {
+        parts.push(entry);
+      }
+    }
+  }
+  return parts.join(" ");
+}
+
+function extractPlannerToolCwd(
+  args: Record<string, unknown>,
+): string | undefined {
+  return typeof args.cwd === "string" && args.cwd.trim().length > 0
+    ? args.cwd.trim()
+    : undefined;
+}
+
+function extractMissingNpmScriptNameFromError(
+  error: string,
+): string | undefined {
+  const match = error.match(/missing script:\s*["'`]?([^"'`\n]+)["'`]?/i);
+  const scriptName = match?.[1]?.trim();
+  return scriptName && scriptName.length > 0 ? scriptName : undefined;
+}
+
+function extractRequestedWorkspaceSelectorsFromToolCall(
+  call: ToolCallRecord | undefined,
+): string[] {
+  const rawArgs = Array.isArray(call?.args.args) ? call?.args.args : [];
+  const selectors: string[] = [];
+  for (let index = 0; index < rawArgs.length; index++) {
+    const value = rawArgs[index];
+    if (typeof value !== "string") {
+      continue;
+    }
+    if (value.startsWith("--workspace=")) {
+      const selector = value.slice("--workspace=".length).trim();
+      if (selector.length > 0) {
+        selectors.push(selector);
+      }
+      continue;
+    }
+    if (value === "--workspace") {
+      const next = rawArgs[index + 1];
+      if (typeof next === "string" && next.trim().length > 0) {
+        selectors.push(next.trim());
+      }
+    }
+  }
+  return [...new Set(selectors)];
+}
+
 function buildFailureSpecificRepairHint(
   error: string | undefined,
+  failedPlannerCall?: ToolCallRecord,
 ): string | undefined {
   if (typeof error !== "string" || error.trim().length === 0) {
     return undefined;
   }
   const normalized = error.toLowerCase();
+  const failingCwd = extractPlannerToolCwd(failedPlannerCall?.args ?? {});
+  const missingScriptName = extractMissingNpmScriptNameFromError(error);
+  if (missingScriptName) {
+    return (
+      `The current package.json${failingCwd ? ` at \`${failingCwd}\`` : ""} does not define the npm script \`${missingScriptName}\`. ` +
+      `Inspect that manifest${failingCwd ? " and any nested workspace package manifests created earlier" : ""}, then rerun the matching workspace/package-specific command or execute from the matching workspace cwd instead of retrying the same generic \`npm run ${missingScriptName}\`.`
+    );
+  }
+  if (normalized.includes("no workspaces found:")) {
+    const selectors = extractRequestedWorkspaceSelectorsFromToolCall(
+      failedPlannerCall,
+    );
+    const selectorSuffix =
+      selectors.length > 0
+        ? ` The rejected selectors were: ${selectors.map((value) => `\`${value}\``).join(", ")}.`
+        : "";
+    return (
+      "npm could not match one or more `--workspace` selectors in this repo." +
+      selectorSuffix +
+      " Inspect the root `package.json` workspaces and each package `name`, then rerun with the exact workspace package names or execute from the matching workspace cwd instead of collapsing back to a generic repo-root npm command."
+    );
+  }
   if (
     normalized.includes('unsupported url type "workspace:"') ||
     normalized.includes("eunsupportedprotocol")

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -10130,6 +10130,241 @@ describe("ChatExecutor", () => {
       );
     });
 
+    it("grounds planner repair retries with nested workspace npm build context", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi.fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: safeJson({
+                reason: "initial_workspace_build_plan",
+                requiresSynthesis: false,
+                steps: [
+                  {
+                    name: "scaffold_black_hole_app",
+                    step_type: "subagent_task",
+                    objective: "Scaffold the black-hole simulation workspace package.",
+                    input_contract: "Umbrella workspace root exists.",
+                    acceptance_criteria: [
+                      "Workspace package manifest and source files exist",
+                    ],
+                    required_tool_capabilities: ["system.writeFile"],
+                    context_requirements: ["umbrella workspace root"],
+                    execution_context: plannerWriteExecutionContext(
+                      "/tmp/agenc-umbrella",
+                      {
+                        stepKind: "delegated_scaffold",
+                        effectClass: "filesystem_scaffold",
+                        targetArtifacts: ["examples/black-hole-simulation"],
+                      },
+                    ),
+                    max_budget_hint: "3m",
+                    can_run_parallel: false,
+                  },
+                  {
+                    name: "build_black_hole_app",
+                    step_type: "deterministic_tool",
+                    tool: "system.bash",
+                    args: {
+                      command: "npm",
+                      args: ["run", "build"],
+                      cwd: "/tmp/agenc-umbrella",
+                    },
+                    onError: "abort",
+                    depends_on: ["scaffold_black_hole_app"],
+                  },
+                ],
+              }),
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: safeJson({
+                reason: "repair_workspace_build_command",
+                requiresSynthesis: false,
+                steps: [
+                  {
+                    name: "diagnose_workspace_build_command",
+                    step_type: "subagent_task",
+                    objective:
+                      "Inspect the umbrella and nested workspace manifests to identify the correct build entrypoint.",
+                    input_contract:
+                      "The nested workspace package already exists from the prior scaffold step.",
+                    acceptance_criteria: [
+                      "Correct workspace build command is identified without rewriting the existing scaffold",
+                    ],
+                    required_tool_capabilities: ["system.readFile"],
+                    context_requirements: ["existing umbrella workspace"],
+                    execution_context: plannerReadOnlyExecutionContext(
+                      "/tmp/agenc-umbrella",
+                      {
+                        stepKind: "delegated_research",
+                        sourceArtifacts: [
+                          "package.json",
+                          "examples/black-hole-simulation/package.json",
+                        ],
+                      },
+                    ),
+                    max_budget_hint: "2m",
+                    can_run_parallel: false,
+                  },
+                  {
+                    name: "build_black_hole_app",
+                    step_type: "deterministic_tool",
+                    tool: "system.bash",
+                    args: {
+                      command: "npm",
+                      args: ["run", "build", "--workspace", "black-hole-simulation"],
+                      cwd: "/tmp/agenc-umbrella",
+                    },
+                    onError: "abort",
+                    depends_on: ["diagnose_workspace_build_command"],
+                  },
+                ],
+              }),
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: safeJson({
+                overall: "pass",
+                confidence: 0.95,
+                unresolved: [],
+                steps: [
+                  {
+                    name: "implementation_completion",
+                    verdict: "pass",
+                    confidence: 0.95,
+                    retryable: true,
+                    issues: [],
+                    summary:
+                      "The repaired workspace build command matches the scaffolded package and deterministic verification passed.",
+                  },
+                ],
+              }),
+            }),
+          ),
+      });
+      const pipelineExecutor = {
+        execute: vi
+          .fn()
+          .mockResolvedValueOnce({
+            status: "failed",
+            context: {
+              results: {
+                scaffold_black_hole_app:
+                  completedDelegatedPlannerResult("Workspace package scaffolded", [
+                    {
+                      name: "system.writeFile",
+                      args: {
+                        path: "examples/black-hole-simulation/package.json",
+                        content:
+                          '{"name":"black-hole-simulation","scripts":{"build":"vite build"}}',
+                      },
+                    },
+                  ]),
+                build_black_hole_app: safeJson({
+                  exitCode: 1,
+                  stdout: "",
+                  stderr:
+                    'npm ERR! Missing script: "build"\nnpm ERR! To see a list of scripts, run:\nnpm ERR!   npm run',
+                }),
+              },
+            },
+            completedSteps: 1,
+            totalSteps: 2,
+            stopReasonHint: "tool_error",
+            error:
+              'npm ERR! Missing script: "build"\nnpm ERR! To see a list of scripts, run:\nnpm ERR!   npm run',
+          })
+          .mockResolvedValueOnce({
+            status: "completed",
+            context: {
+              results: {
+                diagnose_workspace_build_command:
+                  completedDelegatedPlannerResult(
+                    "Workspace build entrypoint identified",
+                    [
+                      {
+                        name: "system.readFile",
+                        args: {
+                          path: "package.json",
+                        },
+                        result: safeJson({
+                          path: "package.json",
+                          content:
+                            '{"workspaces":["examples/black-hole-simulation"],"scripts":{"example:black-hole:build":"npm run build --workspace black-hole-simulation"}}',
+                        }),
+                      },
+                      {
+                        name: "system.readFile",
+                        args: {
+                          path: "examples/black-hole-simulation/package.json",
+                        },
+                        result: safeJson({
+                          path: "examples/black-hole-simulation/package.json",
+                          content:
+                            '{"name":"black-hole-simulation","scripts":{"build":"vite build"}}',
+                        }),
+                      },
+                    ],
+                  ),
+                build_black_hole_app: '{"exitCode":0,"stdout":"vite build completed"}',
+              },
+            },
+            completedSteps: 2,
+            totalSteps: 2,
+          }),
+      };
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+        delegationDecision: {
+          enabled: true,
+          scoreThreshold: 0.2,
+          maxFanoutPerTurn: 8,
+          maxDepth: 4,
+        },
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Build the black-hole simulation app in this umbrella workspace and repair deterministic verification failures before finishing.",
+          ),
+          runtimeContext: {
+            workspaceRoot: "/tmp/agenc-umbrella",
+          },
+        }),
+      );
+
+      expect(provider.chat).toHaveBeenCalledTimes(2);
+      expect(pipelineExecutor.execute).toHaveBeenCalledTimes(1);
+      const secondPlannerMessages = (provider.chat as ReturnType<typeof vi.fn>)
+        .mock.calls[1][0] as LLMMessage[];
+      const repairHintMessage = secondPlannerMessages.find(
+        (msg) =>
+          msg.role === "system" &&
+          typeof msg.content === "string" &&
+          msg.content.includes("The failed deterministic shell command was `npm run build`"),
+      );
+      expect(repairHintMessage).toBeDefined();
+      expect(String(repairHintMessage?.content)).toContain("cwd `/tmp/agenc-umbrella`");
+      expect(String(repairHintMessage?.content)).toContain(
+        "matching workspace/package-specific command",
+      );
+      expect(String(repairHintMessage?.content)).toContain("generic `npm run build`");
+      expect(result.plannerSummary?.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "planner_runtime_repair_retry",
+          }),
+        ]),
+      );
+    });
+
     it("does not treat a planner repair retry as completed without verifier-backed evidence", async () => {
       const provider = createMockProvider("primary", {
         chat: vi.fn()


### PR DESCRIPTION
 ## Summary

  This PR fixes planner repair retries for nested npm workspace failures.

  Previously, when deterministic verification failed during planner execution, the repair path could lose
  the original workspace context and fall back to a generic repo-root `npm run build`. That caused bad
  retries in umbrella/workspace repos where the real build script lives in a nested workspace package.

  This change makes the planner repair path carry forward the failed deterministic command context,
  including the command shape and `cwd`, and adds explicit repair guidance for common npm workspace failures
  such as:

  - `npm ERR! Missing script`
  - `npm error No workspaces found`

  As a result, repair replans stay grounded in the actual workspace contract and are more likely to recover
  with the correct workspace-aware command instead of repeating a generic root-level npm command.
