### PR TITLE
fix(runtime): handle structured Grok planner requests on grok-code-fast-1

### DIFF
--- a/runtime/src/llm/grok/adapter-utils.ts
+++ b/runtime/src/llm/grok/adapter-utils.ts
@@ -106,6 +106,16 @@ export function summarizeTraceToolChoice(value: unknown): string | undefined {
   ) {
     return `function:${record.name.trim()}`;
   }
+  if (
+    record.type === "function" &&
+    record.function &&
+    typeof record.function === "object" &&
+    !Array.isArray(record.function) &&
+    typeof (record.function as Record<string, unknown>).name === "string" &&
+    String((record.function as Record<string, unknown>).name).trim().length > 0
+  ) {
+    return `function:${String((record.function as Record<string, unknown>).name).trim()}`;
+  }
   try {
     return safeStringify(record);
   } catch {

--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -317,7 +317,9 @@ describe("GrokProvider", () => {
     const params = mockCreate.mock.calls[0][0];
     expect(params.tool_choice).toEqual({
       type: "function",
-      name: "system.bash",
+      function: {
+        name: "system.bash",
+      },
     });
   });
 
@@ -439,7 +441,9 @@ describe("GrokProvider", () => {
     const params = mockCreate.mock.calls[0][0];
     expect(params.tool_choice).toEqual({
       type: "function",
-      name: "mcp.browser.browser_navigate",
+      function: {
+        name: "mcp.browser.browser_navigate",
+      },
     });
   });
 
@@ -497,7 +501,9 @@ describe("GrokProvider", () => {
       payload: {
         tool_choice: {
           type: "function",
-          name: "system.bash",
+          function: {
+            name: "system.bash",
+          },
         },
       },
     });
@@ -1280,7 +1286,24 @@ describe("GrokProvider", () => {
     });
   });
 
-  it("fails closed when structured outputs are combined with tools on non-Grok-4 models", async () => {
+  it("suppresses tools when structured outputs are combined with tools on non-Grok-4 models", async () => {
+    mockCreate.mockResolvedValueOnce(
+      makeCompletion({
+        output_text: '{"summary":"repo looks healthy"}',
+        output: [
+          {
+            type: "message",
+            content: [
+              {
+                type: "output_text",
+                text: '{"summary":"repo looks healthy"}',
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
     const provider = new GrokProvider({
       apiKey: "test-key",
       model: "grok-code-fast-1",
@@ -1299,29 +1322,63 @@ describe("GrokProvider", () => {
       ],
     });
 
-    await expect(
-      provider.chat(
-        [{ role: "user", content: "inspect the repo and summarize findings" }],
-        {
-          structuredOutput: {
-            enabled: true,
+    const response = await provider.chat(
+      [{ role: "user", content: "inspect the repo and summarize findings" }],
+      {
+        structuredOutput: {
+          enabled: true,
+          schema: {
+            type: "json_schema",
+            name: "repo_summary",
             schema: {
-              type: "json_schema",
-              name: "repo_summary",
-              schema: {
-                type: "object",
-                properties: {
-                  summary: { type: "string" },
-                },
-                required: ["summary"],
+              type: "object",
+              properties: {
+                summary: { type: "string" },
               },
+              required: ["summary"],
             },
           },
         },
-      ),
-    ).rejects.toThrow(
-      /Structured outputs with tools are only documented for the Grok 4 family/i,
+      },
     );
+
+    const params = mockCreate.mock.calls[0][0];
+    expect(params.tools).toBeUndefined();
+    expect(params.tool_choice).toBeUndefined();
+    expect(params.parallel_tool_calls).toBeUndefined();
+    expect(params.text).toEqual({
+      format: {
+        type: "json_schema",
+        name: "repo_summary",
+        schema: {
+          type: "object",
+          properties: {
+            summary: { type: "string" },
+          },
+          required: ["summary"],
+        },
+        strict: true,
+      },
+    });
+    expect(response.structuredOutput).toEqual({
+      type: "json_schema",
+      name: "repo_summary",
+      rawText: '{"summary":"repo looks healthy"}',
+      parsed: { summary: "repo looks healthy" },
+    });
+    expect(response.requestMetrics).toMatchObject({
+      toolCount: 0,
+      toolNames: ["system.bash"],
+      providerCatalogToolCount: 1,
+      toolsAttached: false,
+      toolSuppressionReason:
+        "structured_output_with_tools_unsupported_model",
+      structuredOutputEnabled: true,
+      structuredOutputName: "repo_summary",
+      structuredOutputStrict: true,
+      store: false,
+    });
+    expect(response.requestMetrics.toolChoice).toBeUndefined();
   });
 
   it("disables parallel tool calls by default when tools are present", async () => {

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -294,7 +294,7 @@ function sanitizeLargeText(value: string): string {
 
 function normalizeResponsesToolChoice(
   toolChoice: LLMToolChoice | undefined,
-): LLMToolChoice | undefined {
+): string | Record<string, unknown> | undefined {
   if (toolChoice === undefined || typeof toolChoice === "string") {
     return toolChoice;
   }
@@ -303,7 +303,7 @@ function normalizeResponsesToolChoice(
     ? toolChoice.name.trim()
     : "";
   if (toolChoice.type === "function" && directName.length > 0) {
-    return { type: "function", name: directName };
+    return { type: "function", function: { name: directName } };
   }
 
   const legacyName = typeof (toolChoice as { function?: { name?: unknown } }).function
@@ -311,7 +311,7 @@ function normalizeResponsesToolChoice(
     ? (toolChoice as { function?: { name?: string } }).function!.name!.trim()
     : "";
   if (toolChoice.type === "function" && legacyName.length > 0) {
-    return { type: "function", name: legacyName };
+    return { type: "function", function: { name: legacyName } };
   }
 
   return toolChoice;
@@ -320,7 +320,7 @@ function normalizeResponsesToolChoice(
 function resolveResponsesToolChoice(
   toolChoice: LLMToolChoice | undefined,
   selection: ToolSelectionDiagnostics,
-): LLMToolChoice | undefined {
+): string | Record<string, unknown> | undefined {
   const normalized = normalizeResponsesToolChoice(toolChoice);
   if (normalized !== "required") {
     return normalized;
@@ -332,7 +332,9 @@ function resolveResponsesToolChoice(
 
   return {
     type: "function",
-    name: selection.resolvedToolNames[0],
+    function: {
+      name: selection.resolvedToolNames[0],
+    },
   };
 }
 
@@ -1876,10 +1878,12 @@ export class GrokProvider implements LLMProvider {
           typeof params.model === "string" ? params.model : this.config.model,
         )
       ) {
-        throw new LLMProviderError(
-          this.name,
-          `Structured outputs with tools are only documented for the Grok 4 family; refusing request for model "${String(params.model ?? this.config.model)}"`,
-        );
+        delete params.tools;
+        delete params.tool_choice;
+        delete params.parallel_tool_calls;
+        selectedTools.toolsAttached = false;
+        selectedTools.toolSuppressionReason =
+          "structured_output_with_tools_unsupported_model";
       }
       params.text = {
         format: {


### PR DESCRIPTION
## Summary
- keep xAI Responses `tool_choice` requests in the nested `function.name` shape expected by current docs
- suppress tools instead of throwing when structured outputs are enabled on non-Grok-4 models such as `grok-code-fast-1`
- extend Grok adapter coverage for forced tool choice tracing and the non-Grok-4 structured-output planner path

## Test plan
- `npm run test --workspace=@tetsuo-ai/runtime -- src/llm/grok/adapter.test.ts`
- `npm run build`