### PR TITLE
fix(runtime): harden planner artifact grounding

### DIFF
--- a/runtime/src/gateway/subagent-orchestrator.test.ts
+++ b/runtime/src/gateway/subagent-orchestrator.test.ts
@@ -6559,6 +6559,134 @@ describe("SubAgentOrchestrator", () => {
     });
   });
 
+  it("uses execution-context file tools for planner-owned documentation writes and strips recursive delegation tools", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-plan-doc-write-"));
+    TEMP_DIRS_TO_CLEAN.push(workspaceRoot);
+    const planPath = join(workspaceRoot, "PLAN.md");
+    writeFileSync(planPath, "# PLAN\n", "utf8");
+    const fallback = createFallbackExecutor(async () => ({
+      status: "completed",
+      context: { results: {} },
+      completedSteps: 0,
+      totalSteps: 0,
+    }));
+    const manager = new SequencedSubAgentManager([
+      {
+        delayMs: 1,
+        result: {
+          output: "PLAN.md updated from grounded repo inspection.",
+          success: true,
+          durationMs: 1,
+          toolCalls: [
+            {
+              name: "system.readFile",
+              args: { path: planPath },
+              result: JSON.stringify({ path: planPath, content: "# PLAN\n" }),
+              isError: false,
+              durationMs: 1,
+            },
+            {
+              name: "system.writeFile",
+              args: { path: planPath, content: "# PLAN\nUpdated\n" },
+              result: JSON.stringify({ path: planPath, bytesWritten: 15 }),
+              isError: false,
+              durationMs: 1,
+            },
+          ],
+        },
+      },
+    ]);
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: fallback,
+      resolveSubAgentManager: () => manager,
+      resolveHostWorkspaceRoot: () => workspaceRoot,
+      resolveAvailableToolNames: () => [
+        "system.readFile",
+        "system.listDir",
+        "system.writeFile",
+        "system.appendFile",
+        "execute_with_agent",
+      ],
+      pollIntervalMs: 1,
+      unsafeBenchmarkMode: true,
+    });
+
+    const result = await orchestrator.execute({
+      id: "planner:plan-doc-write-scope:1",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerContext: {
+        parentRequest:
+          "Review the repo against PLAN.md and update PLAN.md if the structure changed. Please use subagents where they make sense.",
+        history: [],
+        memory: [],
+        toolOutputs: [],
+        workspaceRoot,
+        parentAllowedTools: [
+          "system.readFile",
+          "system.listDir",
+          "system.writeFile",
+          "system.appendFile",
+          "execute_with_agent",
+        ],
+      },
+      plannerSteps: [
+        {
+          name: "analyze_and_update_plan",
+          stepType: "subagent_task",
+          objective:
+            "Review the codebase layout against PLAN.md and update PLAN.md so it matches the current workspace state.",
+          inputContract: "Current PLAN.md and full workspace layout are available.",
+          acceptanceCriteria: [
+            "Update PLAN.md with corrected structure and any gaps.",
+          ],
+          requiredToolCapabilities: [
+            "Filesystem read access to all source files and directories in the workspace.",
+          ],
+          contextRequirements: ["repo_context", "read_plan_md"],
+          executionContext: {
+            version: "v1",
+            workspaceRoot,
+            allowedReadRoots: [workspaceRoot],
+            allowedWriteRoots: [workspaceRoot],
+            allowedTools: [
+              "system.readFile",
+              "system.listDir",
+              "system.writeFile",
+              "system.appendFile",
+            ],
+            requiredSourceArtifacts: [planPath],
+            targetArtifacts: [planPath],
+            effectClass: "filesystem_write",
+            verificationMode: "mutation_required",
+            stepKind: "delegated_write",
+            fallbackPolicy: "fail_request",
+            resumePolicy: "stateless_retry",
+            approvalProfile: "filesystem_write",
+          },
+          maxBudgetHint: "2m",
+          canRunParallel: false,
+        },
+      ],
+    });
+
+    expect(result.status).toBe("completed");
+    expect(manager.spawnCalls).toHaveLength(1);
+    expect(manager.spawnCalls[0]?.tools).toEqual([
+      "system.readFile",
+      "system.listDir",
+      "system.writeFile",
+      "system.appendFile",
+    ]);
+    expect(manager.spawnCalls[0]?.task).toContain(
+      "Allowed tools (policy-scoped):\n- system.readFile\n- system.listDir\n- system.writeFile\n- system.appendFile",
+    );
+    expect(manager.spawnCalls[0]?.task).toContain(
+      '"removedAsDelegationTools":["execute_with_agent"]',
+    );
+  });
+
   it("rejects local-file delegated steps that still rely on raw cwd hints instead of a canonical execution envelope", async () => {
     const hostWorkspaceRoot = "/home/tetsuo/agent-test";
     const fallback = createFallbackExecutor(async () => ({

--- a/runtime/src/gateway/subagent-orchestrator.ts
+++ b/runtime/src/gateway/subagent-orchestrator.ts
@@ -206,6 +206,13 @@ const HARD_PLANNER_ADMISSION_REASONS = new Set<DelegationAdmissionReason>([
   "depth_exceeded",
 ]);
 
+function isPlannerChildDelegationToolName(toolName: string): boolean {
+  const normalized = toolName.trim().toLowerCase();
+  return normalized === "execute_with_agent" ||
+    normalized.startsWith("subagent.") ||
+    normalized.startsWith("agenc.subagent.");
+}
+
 function shouldRejectPlannedDelegationAtExecutionTime(
   reason: DelegationAdmissionReason,
 ): boolean {
@@ -2308,6 +2315,11 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
   } {
     const parentPolicyAllowed = resolveParentPolicyAllowlistFn(pipeline, this.allowedParentTools);
     const availableTools = this.resolveAvailableToolNames();
+    const requestedTools =
+      step.executionContext?.allowedTools &&
+        step.executionContext.allowedTools.length > 0
+        ? step.executionContext.allowedTools
+        : step.requiredToolCapabilities;
     const resolvedScope = resolveDelegatedChildToolScope({
       spec: {
         task: step.name,
@@ -2317,7 +2329,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         acceptanceCriteria: step.acceptanceCriteria,
         requiredToolCapabilities: step.requiredToolCapabilities,
       },
-      requestedTools: step.requiredToolCapabilities,
+      requestedTools,
       parentAllowedTools: parentPolicyAllowed,
       availableTools: availableTools ?? undefined,
       forbiddenTools: [...this.forbiddenParentTools],
@@ -2325,15 +2337,33 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         this.childToolAllowlistStrategy === "inherit_intersection",
       unsafeBenchmarkMode: this.unsafeBenchmarkMode,
     });
+    const strippedDelegationTools = resolvedScope.allowedTools.filter(
+      isPlannerChildDelegationToolName,
+    );
+    const allowedTools = strippedDelegationTools.length > 0
+      ? resolvedScope.allowedTools.filter(
+        (toolName) => !isPlannerChildDelegationToolName(toolName),
+      )
+      : resolvedScope.allowedTools;
+    const removedAsDelegationTools = [
+      ...resolvedScope.removedAsDelegationTools,
+      ...strippedDelegationTools.filter((toolName) =>
+        !resolvedScope.removedAsDelegationTools.includes(toolName)
+      ),
+    ];
 
     return {
-      allowedTools: resolvedScope.allowedTools,
+      allowedTools,
       allowsToollessExecution: resolvedScope.allowsToollessExecution,
       semanticFallback: resolvedScope.semanticFallback,
       removedLowSignalBrowserTools: resolvedScope.removedLowSignalBrowserTools,
-      blockedReason: resolvedScope.blockedReason,
+      blockedReason:
+        resolvedScope.blockedReason ??
+        (!resolvedScope.allowsToollessExecution && allowedTools.length === 0
+          ? "No permitted child tools remain after policy scoping"
+          : undefined),
       removedByPolicy: resolvedScope.removedByPolicy,
-      removedAsDelegationTools: resolvedScope.removedAsDelegationTools,
+      removedAsDelegationTools,
       removedAsUnknownTools: resolvedScope.removedAsUnknownTools,
       parentPolicyAllowed,
     };

--- a/runtime/src/gateway/subagent-prompt-builder.ts
+++ b/runtime/src/gateway/subagent-prompt-builder.ts
@@ -852,6 +852,14 @@ export function buildRetryTaskPrompt(
         "If those sources describe intended or planned structure, say that explicitly instead of presenting those files as already present.",
       );
     }
+    if (failure.validationCode === "missing_workspace_inspection_evidence") {
+      corrections.push(
+        "Inspect the current workspace state beyond the target documentation artifact before writing again.",
+      );
+      corrections.push(
+        "Use directory listing, file inspection, or bounded shell inspection to ground claims about repo layout, current implementation state, or recent directory changes.",
+      );
+    }
     if (failure.validationCode === "acceptance_probe_failed") {
       corrections.push(
         "A parent-side deterministic acceptance probe failed after your edits. Fix the cited package/workspace compatibility issue in the authored files before answering again.",
@@ -888,6 +896,15 @@ export function buildRetryTaskPrompt(
       corrections.push(
         "Fix and verify the issue with the allowed tools first. If the issue remains unresolved, report the phase as blocked instead of successful.",
       );
+      if (
+        /documentation completion|shorthand placeholders|todo markers/i.test(
+          failure.message,
+        )
+      ) {
+        corrections.push(
+          "For documentation rewrites, replace shorthand elisions such as [Same as original], [etc.], TODO, FIXME, or TBD with the full concrete text before returning completed.",
+        );
+      }
     }
     const delegatedScopeTrustSignal = classifyDelegatedScopeTrustSignal({
       message: failure.message,

--- a/runtime/src/llm/chat-executor-contract-flow.ts
+++ b/runtime/src/llm/chat-executor-contract-flow.ts
@@ -16,6 +16,7 @@ import {
   validateDelegatedOutputContract,
 } from "../utils/delegation-validation.js";
 import { validateRuntimeVerificationContract } from "../workflow/index.js";
+import { isDocumentationArtifactPath } from "../workflow/artifact-paths.js";
 import type { ImplementationCompletionContract } from "../workflow/completion-contract.js";
 import {
   isPathWithinRoot,
@@ -101,9 +102,6 @@ const BROWSER_TOOL_PREFIX = "mcp.browser.";
 const RESEARCH_TOOL_NAMES: ReadonlySet<string> = new Set(
   PROVIDER_NATIVE_GROUNDED_INFORMATION_TOOL_NAMES,
 );
-const DOC_ONLY_PATH_RE = /\.(?:md|mdx|txt|rst|adoc)$/i;
-const DOC_BASENAME_RE =
-  /(?:^|\/)(?:README|CHANGELOG|CONTRIBUTING|LICENSE|COPYING|NOTES|AGENTS|AGENC)(?:\.[^/]+)?$/i;
 const SOURCE_LIKE_PATH_RE =
   /(?:^|\/)(?:src|lib|app|server|client|cmd|pkg|include|internal|tests?|spec)(?:\/|$)|\.(?:c|cc|cpp|cxx|h|hpp|m|mm|rs|go|py|rb|php|java|kt|swift|cs|js|jsx|ts|tsx|json|toml|yaml|yml|xml|sh|zsh|bash)$/i;
 const BUILD_OR_BEHAVIOR_COMMAND_RE =
@@ -422,6 +420,14 @@ export function buildRequiredToolEvidenceRetryInstruction(input: {
       "If those sources describe intended or planned structure, keep that distinction explicit instead of presenting planned files as already present.",
     );
   }
+  if (input.validationCode === "missing_workspace_inspection_evidence") {
+    correctionLines.push(
+      "Inspect the current workspace state beyond the target documentation artifact before writing again.",
+    );
+    correctionLines.push(
+      "Use directory listing, file inspection, or bounded shell inspection to ground claims about repo layout, current implementation state, or recent directory changes.",
+    );
+  }
   if (input.validationCode === "forbidden_phase_action") {
     correctionLines.push(
       "This phase explicitly forbids one or more actions such as install/build/test/typecheck/lint execution or banned dependency specifiers. Do not repeat them.",
@@ -690,7 +696,7 @@ function normalizeStringPaths(value: unknown): readonly string[] {
 }
 
 function isDocOnlyArtifactPath(value: string): boolean {
-  return DOC_ONLY_PATH_RE.test(value) || DOC_BASENAME_RE.test(value);
+  return isDocumentationArtifactPath(value);
 }
 
 function parseEncodedEffectMetadata(

--- a/runtime/src/llm/chat-executor-contract-guidance.test.ts
+++ b/runtime/src/llm/chat-executor-contract-guidance.test.ts
@@ -548,6 +548,55 @@ describe("chat-executor-contract-guidance", () => {
     });
   });
 
+  it("prioritizes workspace inspection ahead of mutation for workspace-grounded doc rewrites", () => {
+    const guidance = resolveToolContractGuidance({
+      phase: "initial",
+      messageText:
+        "Review the codebase layout against phase1, identify plan gaps, and update PLAN.md so it reflects the current state.",
+      toolCalls: [],
+      allowedToolNames: [
+        "system.bash",
+        "system.writeFile",
+        "system.readFile",
+        "system.listDir",
+      ],
+      requiredToolEvidence: {
+        delegationSpec: {
+          task: "review_and_update_plan",
+          objective:
+            "Review the codebase layout against phase1, identify plan gaps, and update PLAN.md.",
+          parentRequest:
+            "Assess whether recent directory changes align with the plan and update PLAN.md accordingly.",
+          inputContract: "Use PLAN.md and the current workspace state as sources of truth.",
+          acceptanceCriteria: [
+            "PLAN.md reflects the current workspace layout and recent directory changes accurately.",
+          ],
+          executionContext: {
+            workspaceRoot: "/tmp/agenc-shell",
+            targetArtifacts: ["/tmp/agenc-shell/PLAN.md"],
+            requiredSourceArtifacts: ["/tmp/agenc-shell/PLAN.md"],
+          },
+        },
+      },
+    });
+
+    expect(guidance).toEqual({
+      source: "delegation-initial",
+      runtimeInstruction:
+        "Start with the smallest grounded step that reduces uncertainty in the delegated contract. " +
+        "Inspect the existing workspace state before mutating files when that will prevent avoidable rework, " +
+        "and use shell verification when build/test/install evidence is part of acceptance.",
+      routedToolNames: [
+        "system.listDir",
+        "system.readFile",
+        "system.writeFile",
+        "system.bash",
+      ],
+      persistRoutedToolNames: false,
+      toolChoice: "required",
+    });
+  });
+
   it("keeps listDir and readFile together for delegated local exploration phases", () => {
     const guidance = resolveToolContractGuidance({
       phase: "initial",
@@ -865,6 +914,42 @@ describe("chat-executor-contract-guidance", () => {
     expect(guidance).toEqual({
       source: "delegation-correction",
       routedToolNames: ["system.listDir", "system.readFile"],
+      persistRoutedToolNames: false,
+      toolChoice: "required",
+    });
+  });
+
+  it("routes delegated correction turns to workspace inspection after missing workspace-grounding evidence", () => {
+    const guidance = resolveToolContractGuidance({
+      phase: "correction",
+      messageText:
+        "Inspect the current workspace state before updating PLAN.md again.",
+      toolCalls: [],
+      allowedToolNames: ["system.listDir", "system.readFile", "system.writeFile"],
+      requiredToolEvidence: {
+        delegationSpec: {
+          task: "review_and_update_plan",
+          objective:
+            "Review the codebase layout against phase1, identify plan gaps, and update PLAN.md.",
+          parentRequest:
+            "Assess whether recent directory changes align with the plan and update PLAN.md accordingly.",
+          inputContract: "Use PLAN.md and the current workspace state as sources of truth.",
+          acceptanceCriteria: [
+            "PLAN.md reflects the current workspace layout and recent directory changes accurately.",
+          ],
+          executionContext: {
+            workspaceRoot: "/tmp/agenc-shell",
+            targetArtifacts: ["/tmp/agenc-shell/PLAN.md"],
+            requiredSourceArtifacts: ["/tmp/agenc-shell/PLAN.md"],
+          },
+        },
+      },
+      validationCode: "missing_workspace_inspection_evidence",
+    });
+
+    expect(guidance).toEqual({
+      source: "delegation-correction",
+      routedToolNames: ["system.listDir", "system.readFile", "system.writeFile"],
       persistRoutedToolNames: false,
       toolChoice: "required",
     });

--- a/runtime/src/llm/chat-executor-contract-guidance.ts
+++ b/runtime/src/llm/chat-executor-contract-guidance.ts
@@ -27,6 +27,7 @@ import {
   resolveDelegatedCorrectionToolChoiceToolNames,
   resolveDelegatedInitialToolChoiceToolNames,
   resolveDelegatedInitialToolChoiceToolName,
+  specRequiresMeaningfulWorkspaceEvidence,
   specRequiresFileMutationEvidence,
 } from "../utils/delegation-validation.js";
 import { sanitizeDelegationContextRequirements } from "../utils/delegation-execution-context.js";
@@ -518,6 +519,9 @@ function isDelegatedFileAuthoringPhaseWithoutVerification(
   spec: DelegationContractSpec,
 ): boolean {
   if ((spec.lastValidationCode ?? "") === "acceptance_evidence_missing") {
+    return false;
+  }
+  if (specRequiresMeaningfulWorkspaceEvidence(spec)) {
     return false;
   }
   if (!specRequiresFileMutationEvidence(spec)) {

--- a/runtime/src/llm/chat-executor-planner.test.ts
+++ b/runtime/src/llm/chat-executor-planner.test.ts
@@ -16,6 +16,7 @@ import {
   extractExplicitSubagentOrchestrationRequirements,
   parsePlannerPlan,
   plannerRequestImplementsFromArtifact,
+  plannerRequestNeedsWorkspaceGroundedArtifactUpdate,
   requestExplicitlyRequestsDelegation,
   salvagePlannerToolCallsAsPlan,
   validatePlannerVerificationRequirements,
@@ -108,6 +109,37 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
     );
     expect(messages[0]?.content).not.toContain(
       '"requiredSourceArtifacts": ["/abs/path/PLAN.md"]',
+    );
+  });
+
+  it("grounds plan-artifact edit schema examples to the requested artifact instead of AGENC.md", () => {
+    const messages = buildPlannerMessages(
+      "Update PLAN.md so it reflects the corrected architecture and missing validation steps.",
+      [],
+      512,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "/home/tetsuo/git/AgenC",
+    );
+
+    expect(messages[0]?.content).toContain(
+      '"requiredSourceArtifacts": ["/home/tetsuo/git/AgenC/PLAN.md"]',
+    );
+    expect(messages[0]?.content).toContain(
+      '"targetArtifacts": ["/home/tetsuo/git/AgenC/PLAN.md"]',
+    );
+    expect(messages[0]?.content).not.toContain("AGENC.md");
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "system",
+          content: expect.stringContaining(
+            "This request must materialize the named planning artifact itself.",
+          ),
+        }),
+      ]),
     );
   });
 
@@ -1177,6 +1209,53 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
     ]);
   });
 
+  it("canonicalizes contradictory review-tagged plan rewrites into delegated writes", () => {
+    const result = parsePlannerPlan(
+      JSON.stringify({
+        reason: "delegate_plan_rewrite",
+        requiresSynthesis: true,
+        steps: [
+          {
+            name: "analyze_and_update_plan",
+            step_type: "subagent_task",
+            objective:
+              "Review the repo against PLAN.md, then update PLAN.md so it reflects the current state.",
+            input_contract: "Use PLAN.md and the workspace tree as the source of truth.",
+            acceptance_criteria: [
+              "PLAN.md reflects the current repo layout accurately.",
+            ],
+            required_tool_capabilities: ["system.readFile", "system.writeFile"],
+            execution_context: {
+              workspaceRoot: "/tmp/agenc-shell",
+              allowedReadRoots: ["/tmp/agenc-shell"],
+              allowedWriteRoots: ["/tmp/agenc-shell"],
+              requiredSourceArtifacts: ["/tmp/agenc-shell/PLAN.md"],
+              targetArtifacts: ["/tmp/agenc-shell/PLAN.md"],
+              allowedTools: ["system.readFile", "system.writeFile"],
+              effectClass: "filesystem_write",
+              verificationMode: "mutation_required",
+              stepKind: "delegated_review",
+            },
+            max_budget_hint: "8m",
+          },
+        ],
+      }),
+    );
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.plan?.steps).toEqual([
+      expect.objectContaining({
+        name: "analyze_and_update_plan",
+        stepType: "subagent_task",
+        executionContext: expect.objectContaining({
+          targetArtifacts: ["/tmp/agenc-shell/PLAN.md"],
+          verificationMode: "mutation_required",
+          stepKind: "delegated_write",
+        }),
+      }),
+    ]);
+  });
+
   it("rejects subagent execution envelopes that still use /workspace placeholder roots", () => {
     const result = parsePlannerPlan(
       JSON.stringify({
@@ -1679,6 +1758,118 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
     expect(diagnostics).toEqual([]);
   });
 
+  it("allows grounded plan-artifact update requests that end in a bounded delegated write to the requested artifact", () => {
+    const workspaceRoot = "/tmp/agenc-shell";
+    const diagnostics = validatePlannerStepContracts(
+      {
+        reason: "update_plan_artifact",
+        requiresSynthesis: false,
+        confidence: 0.79,
+        steps: [
+          {
+            name: "read_plan",
+            stepType: "deterministic_tool",
+            dependsOn: [],
+            tool: "system.readFile",
+            args: {
+              path: `${workspaceRoot}/PLAN.md`,
+            },
+          },
+          {
+            name: "analyze_and_update_plan",
+            stepType: "subagent_task",
+            dependsOn: ["read_plan"],
+            objective:
+              "Review the codebase layout against phase1, identify plan gaps, and update PLAN.md.",
+            inputContract: "PLAN.md plus the current source tree.",
+            acceptanceCriteria: ["PLAN.md reflects the current workspace layout."],
+            requiredToolCapabilities: ["read", "write"],
+            contextRequirements: ["read_plan"],
+            maxBudgetHint: "10m",
+            canRunParallel: false,
+            executionContext: {
+              version: "v1",
+              workspaceRoot,
+              allowedReadRoots: [workspaceRoot],
+              allowedWriteRoots: [workspaceRoot],
+              requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+              targetArtifacts: [`${workspaceRoot}/PLAN.md`],
+              effectClass: "filesystem_write",
+              verificationMode: "mutation_required",
+              stepKind: "delegated_write",
+            },
+          },
+        ],
+        edges: [{ from: "read_plan", to: "analyze_and_update_plan" }],
+      },
+      "Update PLAN.md so it reflects the corrected architecture and missing validation steps.",
+    );
+
+    expect(diagnostics).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "planner_plan_artifact_missing_write_step",
+        }),
+      ]),
+    );
+  });
+
+  it("rejects workspace-grounded artifact rewrites that only read the target doc before a generic rewrite", () => {
+    const workspaceRoot = "/tmp/agenc-shell";
+    const diagnostics = validatePlannerStepContracts(
+      {
+        reason: "review_and_update_plan",
+        requiresSynthesis: false,
+        confidence: 0.81,
+        steps: [
+          {
+            name: "read_plan",
+            stepType: "deterministic_tool",
+            dependsOn: [],
+            tool: "system.readFile",
+            args: {
+              path: `${workspaceRoot}/PLAN.md`,
+            },
+          },
+          {
+            name: "review_and_update_plan",
+            stepType: "subagent_task",
+            dependsOn: ["read_plan"],
+            objective:
+              "Review PLAN.md from multiple perspectives and update it accordingly.",
+            inputContract: "Provide the PLAN.md contents.",
+            acceptanceCriteria: [
+              "PLAN.md is updated cleanly and remains coherent.",
+            ],
+            requiredToolCapabilities: ["system.readFile", "system.writeFile"],
+            maxBudgetHint: "8m",
+            executionContext: {
+              version: "v1",
+              workspaceRoot,
+              allowedReadRoots: [workspaceRoot],
+              allowedWriteRoots: [workspaceRoot],
+              requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+              targetArtifacts: [`${workspaceRoot}/PLAN.md`],
+              allowedTools: ["system.readFile", "system.writeFile"],
+              effectClass: "filesystem_write",
+              verificationMode: "mutation_required",
+              stepKind: "delegated_write",
+            },
+          },
+        ],
+      },
+      "Review the codebase layout and code against Phase1 in PLAN.md, assess whether recent directory changes align with the plan, then update PLAN.md accordingly.",
+    );
+
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "planner_plan_artifact_missing_workspace_grounding",
+        }),
+      ]),
+    );
+  });
+
   it("rejects plan-artifact execution requests that emit multiple mutable delegated owners for one workspace root", () => {
     const workspaceRoot = "/tmp/agenc-shell";
     const diagnostics = validatePlannerStepContracts(
@@ -1837,6 +2028,43 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
         "Use spec.md as the source of truth and implement the project in full.",
       ),
     ).toBe("implement_from_artifact");
+  });
+
+  it("detects workspace-grounded artifact update requests separately from plain artifact edits", () => {
+    expect(
+      plannerRequestNeedsWorkspaceGroundedArtifactUpdate(
+        "Review the codebase layout against Phase1 in PLAN.md and update PLAN.md so it reflects the current workspace state.",
+      ),
+    ).toBe(true);
+    expect(
+      plannerRequestNeedsWorkspaceGroundedArtifactUpdate(
+        "Update roadmap.md so it reflects the latest sequencing and owners.",
+      ),
+    ).toBe(false);
+  });
+
+  it("adds explicit workspace-grounding guidance to planner prompts for grounded artifact rewrites", () => {
+    const messages = buildPlannerMessages(
+      "Review the codebase layout against Phase1 in PLAN.md and update PLAN.md so it reflects the current workspace state.",
+      [],
+      4000,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "/tmp/agenc-shell",
+    );
+
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "system",
+          content: expect.stringContaining(
+            "This is a workspace-grounded artifact update request.",
+          ),
+        }),
+      ]),
+    );
   });
 
   it("rejects deterministic bash steps that embed shell separators in direct args", () => {

--- a/runtime/src/llm/chat-executor-planner.ts
+++ b/runtime/src/llm/chat-executor-planner.ts
@@ -92,6 +92,7 @@ import {
   isNonExecutableEnvelopePath,
   normalizeWorkspaceRoot,
 } from "../workflow/path-normalization.js";
+import { textRequiresWorkspaceGroundedArtifactUpdate } from "../workflow/workspace-inspection-evidence.js";
 
 // ============================================================================
 // Planner decision
@@ -622,6 +623,10 @@ export function buildPlannerMessages(
   const planArtifactExecutionRequest = artifactIntent === "edit_artifact";
   const implementFromArtifactRequest =
     artifactIntent === "implement_from_artifact";
+  const groundedPlanArtifactRequest =
+    artifactIntent === "grounded_plan_generation";
+  const workspaceGroundedArtifactUpdate =
+    plannerRequestNeedsWorkspaceGroundedArtifactUpdate(messageText);
   const currentArtifactTargets = extractPlannerArtifactTargets(messageText);
   const hostToolingHint = buildPlannerHostToolingHint(
     messageText,
@@ -681,14 +686,23 @@ export function buildPlannerMessages(
     normalizeWorkspaceRoot(plannerWorkspaceRoot);
   const schemaWorkspaceRoot =
     canonicalPlannerWorkspaceRoot ?? "<actual-workspace-root>";
+  const schemaPrimaryArtifact =
+    currentArtifactTargets[0] ??
+    (groundedPlanArtifactRequest || planArtifactExecutionRequest || implementFromArtifactRequest
+      ? "PLAN.md"
+      : "output.md");
   const schemaPlanArtifact =
     canonicalPlannerWorkspaceRoot
-      ? `${canonicalPlannerWorkspaceRoot}/PLAN.md`
-      : "<actual-workspace-root>/PLAN.md";
+      ? `${canonicalPlannerWorkspaceRoot}/${schemaPrimaryArtifact}`
+      : `<actual-workspace-root>/${schemaPrimaryArtifact}`;
   const schemaTargetArtifact =
-    canonicalPlannerWorkspaceRoot
-      ? `${canonicalPlannerWorkspaceRoot}/AGENC.md`
-      : "<actual-workspace-root>/AGENC.md";
+    groundedPlanArtifactRequest || planArtifactExecutionRequest
+      ? schemaPlanArtifact
+      : (
+          canonicalPlannerWorkspaceRoot
+            ? `${canonicalPlannerWorkspaceRoot}/src`
+            : "<actual-workspace-root>/src"
+        );
 
   const messages: LLMMessage[] = [
     {
@@ -820,6 +834,17 @@ export function buildPlannerMessages(
     });
   }
 
+  if (workspaceGroundedArtifactUpdate) {
+    messages.push({
+      role: "system",
+      content:
+        "This is a workspace-grounded artifact update request. " +
+        "Do not satisfy it by reading and rewriting the planning document alone. " +
+        "The plan must preserve meaningful inspection of the current workspace state or codebase layout before final artifact mutation, " +
+        "and the delegated write step's objective or acceptance criteria must explicitly require the updated artifact to reflect current workspace state, repo layout, or recent directory changes.",
+    });
+  }
+
   if (verificationCommandRequirements.length > 0) {
     messages.push({
       role: "system",
@@ -839,6 +864,15 @@ export function buildPlannerMessages(
         "If you need prior grounding, keep it read-only and bounded to explicit source or analysis artifacts. " +
         "Do not emit multiple mutable, validation, or QA subagent_task steps that all re-own the same workspace root. " +
         "Build, test, and verification around the implementation owner should be deterministic_tool steps unless a later delegated step owns disjoint artifacts.",
+    });
+  }
+  if (groundedPlanArtifactRequest || planArtifactExecutionRequest) {
+    messages.push({
+      role: "system",
+      content:
+        "This request must materialize the named planning artifact itself. " +
+        `The step that mutates ${schemaTargetArtifact} may be either a final deterministic \`system.writeFile\`/\`system.appendFile\` step or a single bounded \`subagent_task\` whose \`execution_context.targetArtifacts\` explicitly include ${schemaTargetArtifact}. ` +
+        "Do not target a different file for the final artifact update.",
     });
   }
   if (implementFromArtifactRequest) {
@@ -2682,7 +2716,7 @@ function stepRequiresInstallSensitiveNodeVerification(
     ...new Set(
       step.acceptanceCriteria.flatMap((criterion) =>
         getAcceptanceVerificationCategories(criterion)
-      ),
+      ).filter((category) => category === "build" || category === "test"),
     ),
   ];
   if (categories.length > 0) {
@@ -3351,7 +3385,9 @@ export function validatePlannerStepContracts(
       artifactIntent === "grounded_plan_generation" ||
       artifactIntent === "edit_artifact"
     ) {
-      diagnostics.push(...validatePlannerPlanArtifactSteps(plannerPlan));
+      diagnostics.push(
+        ...validatePlannerPlanArtifactSteps(plannerPlan, messageText),
+      );
     }
     if (artifactIntent === "implement_from_artifact") {
       diagnostics.push(...validatePlannerPlanArtifactExecutionOwnership(plannerPlan));
@@ -3471,15 +3507,15 @@ export function validatePlannerStepContracts(
 }
 
 function extractPlannerArtifactTargets(messageText: string): readonly string[] {
-  const normalized = messageText.trim();
-  if (normalized.length === 0) {
+  const sourceText = messageText.trim();
+  if (sourceText.length === 0) {
     return [];
   }
   PLANNER_PLAN_ARTIFACT_FILE_CAPTURE_RE.lastIndex = 0;
   const targets = new Set<string>();
   let match: RegExpExecArray | null;
-  while ((match = PLANNER_PLAN_ARTIFACT_FILE_CAPTURE_RE.exec(normalized)) !== null) {
-    const value = (match[0] ?? "").trim().toLowerCase();
+  while ((match = PLANNER_PLAN_ARTIFACT_FILE_CAPTURE_RE.exec(sourceText)) !== null) {
+    const value = (match[0] ?? "").trim();
     if (value.length > 0) {
       targets.add(value);
     }
@@ -3581,6 +3617,15 @@ export function plannerRequestNeedsPlanArtifactExecution(messageText: string): b
   return classifyPlannerPlanArtifactIntent(messageText) === "edit_artifact";
 }
 
+export function plannerRequestNeedsWorkspaceGroundedArtifactUpdate(
+  messageText: string,
+): boolean {
+  return (
+    classifyPlannerPlanArtifactIntent(messageText) === "edit_artifact" &&
+    textRequiresWorkspaceGroundedArtifactUpdate(messageText)
+  );
+}
+
 export function plannerRequestImplementsFromArtifact(
   messageText: string,
 ): boolean {
@@ -3590,6 +3635,14 @@ export function plannerRequestImplementsFromArtifact(
   );
 }
 
+function normalizePlannerArtifactTarget(target: string): string {
+  return target.trim().toLowerCase();
+}
+
+function plannerStepTextRequiresWorkspaceGrounding(value: string): boolean {
+  return textRequiresWorkspaceGroundedArtifactUpdate(value);
+}
+
 function plannerArtifactTargetsOverlap(
   left: readonly string[],
   right: readonly string[],
@@ -3597,11 +3650,35 @@ function plannerArtifactTargetsOverlap(
   if (left.length === 0 || right.length === 0) {
     return false;
   }
-  const rightSet = new Set(right);
-  return left.some((target) => rightSet.has(target));
+  const rightSet = new Set(right.map(normalizePlannerArtifactTarget));
+  return left
+    .map(normalizePlannerArtifactTarget)
+    .some((target) => rightSet.has(target));
 }
 
-function isPlannerFileWriteStep(step: PlannerStepIntent): boolean {
+function plannerPathTargetsRequestedArtifact(
+  rawPath: string | undefined,
+  requestedArtifactTargets: readonly string[],
+): boolean {
+  if (typeof rawPath !== "string" || requestedArtifactTargets.length === 0) {
+    return false;
+  }
+  const normalizedPath = rawPath.trim().toLowerCase();
+  if (normalizedPath.length === 0) {
+    return false;
+  }
+  return requestedArtifactTargets.some((target) => {
+    const normalizedTarget = normalizePlannerArtifactTarget(target);
+    return (
+      normalizedPath === normalizedTarget ||
+      normalizedPath.endsWith(`/${normalizedTarget}`)
+    );
+  });
+}
+
+function isPlannerDeterministicFileWriteStep(
+  step: PlannerStepIntent,
+): boolean {
   return (
     step.stepType === "deterministic_tool" &&
     (step.tool === "system.writeFile" || step.tool === "system.appendFile")
@@ -3664,6 +3741,86 @@ function plannerStepHasMutableImplementationAuthority(
   );
 }
 
+function isPlannerArtifactMaterializationStep(
+  step: PlannerStepIntent,
+  requestedArtifactTargets: readonly string[],
+): boolean {
+  if (isPlannerDeterministicFileWriteStep(step)) {
+    if (requestedArtifactTargets.length === 0) {
+      return true;
+    }
+    return plannerPathTargetsRequestedArtifact(
+      typeof step.args.path === "string" ? step.args.path : undefined,
+      requestedArtifactTargets,
+    );
+  }
+  if (step.stepType !== "subagent_task") {
+    return false;
+  }
+  if (!plannerStepHasMutableImplementationAuthority(step)) {
+    return false;
+  }
+  return (step.executionContext?.targetArtifacts ?? []).some((targetArtifact) =>
+    plannerPathTargetsRequestedArtifact(targetArtifact, requestedArtifactTargets)
+  );
+}
+
+function plannerSubagentHasWorkspaceGrounding(
+  step: PlannerSubAgentTaskStepIntent,
+): boolean {
+  const executionContext = step.executionContext;
+  const stepText = [
+    step.objective,
+    step.inputContract,
+    ...step.acceptanceCriteria,
+    ...(step.contextRequirements ?? []),
+  ]
+    .filter((value) => value.trim().length > 0)
+    .join(" ");
+  if (!plannerStepTextRequiresWorkspaceGrounding(stepText)) {
+    return false;
+  }
+  const scopedTools = [
+    ...(executionContext?.allowedTools ?? []),
+    ...step.requiredToolCapabilities,
+  ].map((value) => value.trim().toLowerCase());
+  return scopedTools.some((toolName) =>
+    toolName.includes("read") ||
+    toolName.includes("listdir") ||
+    toolName.includes("stat") ||
+    toolName.includes("bash") ||
+    toolName.includes("text_editor")
+  );
+}
+
+function isPlannerWorkspaceGroundingStep(
+  step: PlannerStepIntent,
+  requestedArtifactTargets: readonly string[],
+): boolean {
+  if (step.stepType === "subagent_task") {
+    return plannerSubagentHasWorkspaceGrounding(step);
+  }
+  if (step.stepType !== "deterministic_tool") {
+    return false;
+  }
+  if (step.tool === "system.listDir" || step.tool === "system.stat") {
+    return true;
+  }
+  if (step.tool === "system.readFile") {
+    return !plannerPathTargetsRequestedArtifact(
+      typeof step.args.path === "string" ? step.args.path : undefined,
+      requestedArtifactTargets,
+    );
+  }
+  if (!PLANNER_BASH_TOOL_NAMES.has(step.tool)) {
+    return false;
+  }
+  const commandText = extractCommandText(step.args).trim();
+  return /\b(?:ls|find|tree|rg|ripgrep|git\s+(?:status|diff|ls-files)|stat)\b/i.test(
+    commandText,
+  );
+}
+
 function validatePlannerPlanArtifactExecutionOwnership(
   plannerPlan: PlannerPlan,
 ): readonly PlannerDiagnostic[] {
@@ -3712,10 +3869,20 @@ function validatePlannerPlanArtifactExecutionOwnership(
 
 function validatePlannerPlanArtifactSteps(
   plannerPlan: PlannerPlan,
+  messageText?: string,
 ): readonly PlannerDiagnostic[] {
   const diagnostics: PlannerDiagnostic[] = [];
-  const writeSteps = plannerPlan.steps.filter(isPlannerFileWriteStep);
-  if (writeSteps.length === 0) {
+  const workspaceGroundedArtifactUpdate =
+    typeof messageText === "string" &&
+    plannerRequestNeedsWorkspaceGroundedArtifactUpdate(messageText);
+  const requestedArtifactTargets =
+    typeof messageText === "string"
+      ? extractPlannerArtifactTargets(messageText)
+      : [];
+  const materializationSteps = plannerPlan.steps.filter((step) =>
+    isPlannerArtifactMaterializationStep(step, requestedArtifactTargets)
+  );
+  if (materializationSteps.length === 0) {
     diagnostics.push(
       createPlannerDiagnostic(
         "validation",
@@ -3725,24 +3892,40 @@ function validatePlannerPlanArtifactSteps(
     );
   }
 
-  if (plannerPlan.steps.length === 1 && isPlannerFileWriteStep(plannerPlan.steps[0]!)) {
+  if (
+    plannerPlan.steps.length === 1 &&
+    isPlannerArtifactMaterializationStep(
+      plannerPlan.steps[0]!,
+      requestedArtifactTargets,
+    )
+  ) {
     diagnostics.push(
       createPlannerDiagnostic(
         "validation",
         "planner_plan_artifact_single_write_collapse",
-        "Planner collapsed a substantial software planning-document request into a single writeFile step without prior grounding or decomposition",
+        "Planner collapsed a substantial software planning-document request into a single artifact-write step without prior grounding or decomposition",
         {
           stepName: plannerPlan.steps[0]!.name,
-          tool: (plannerPlan.steps[0] as PlannerDeterministicToolStepIntent).tool,
+          tool:
+            plannerPlan.steps[0]!.stepType === "deterministic_tool"
+              ? (plannerPlan.steps[0] as PlannerDeterministicToolStepIntent).tool
+              : "subagent_task",
         },
       ),
     );
   }
 
-  const lastWriteIndex = plannerPlan.steps.reduce((index, step, currentIndex) =>
-    isPlannerFileWriteStep(step) ? currentIndex : index, -1);
+  const lastWriteIndex = plannerPlan.steps.reduce(
+    (index, step, currentIndex) =>
+      isPlannerArtifactMaterializationStep(step, requestedArtifactTargets)
+        ? currentIndex
+        : index,
+    -1,
+  );
   const hasGroundingBeforeWrite = plannerPlan.steps.some(
-    (step, index) => index < lastWriteIndex && !isPlannerFileWriteStep(step),
+    (step, index) =>
+      index < lastWriteIndex &&
+      !isPlannerArtifactMaterializationStep(step, requestedArtifactTargets),
   );
   if (lastWriteIndex >= 0 && !hasGroundingBeforeWrite) {
     diagnostics.push(
@@ -3755,6 +3938,33 @@ function validatePlannerPlanArtifactSteps(
         },
       ),
     );
+  }
+
+  if (workspaceGroundedArtifactUpdate && lastWriteIndex >= 0) {
+    const finalWriteStep = plannerPlan.steps[lastWriteIndex]!;
+    const hasWorkspaceGroundingBeforeWrite = plannerPlan.steps.some(
+      (step, index) =>
+        index < lastWriteIndex &&
+        isPlannerWorkspaceGroundingStep(step, requestedArtifactTargets),
+    );
+    const finalWriteCarriesWorkspaceGrounding =
+      finalWriteStep.stepType === "subagent_task" &&
+      plannerSubagentHasWorkspaceGrounding(finalWriteStep);
+    if (
+      !hasWorkspaceGroundingBeforeWrite &&
+      !finalWriteCarriesWorkspaceGrounding
+    ) {
+      diagnostics.push(
+        createPlannerDiagnostic(
+          "validation",
+          "planner_plan_artifact_missing_workspace_grounding",
+          "Planner must preserve explicit current-workspace inspection before completing a workspace-grounded planning artifact update",
+          {
+            finalWriteStep: finalWriteStep.name,
+          },
+        ),
+      );
+    }
   }
   return diagnostics;
 }
@@ -3788,7 +3998,13 @@ export function buildPlannerStepContractRefinementHint(
         diagnostic.code === "planner_plan_artifact_single_write_collapse" ||
         diagnostic.code === "planner_plan_artifact_needs_grounding_step"
       ) {
-        return "for substantial software plan/TODO requests, do not jump straight to writeFile; add at least one grounding or decomposition step before the final artifact write";
+        return "for substantial software plan/TODO requests, do not jump straight to the final artifact materialization step; add at least one grounding or decomposition step before the final artifact write";
+      }
+      if (diagnostic.code === "planner_plan_artifact_missing_workspace_grounding") {
+        return (
+          "for workspace-grounded PLAN.md/TODO rewrites, preserve explicit current-workspace inspection. " +
+          "Either add a prior repo/layout inspection step, or make the bounded delegated write step itself explicitly inspect current workspace state and require the artifact to reflect that evidence"
+        );
       }
       if (diagnostic.code === "planner_plan_artifact_single_owner_required") {
         const workspaceRoot =
@@ -3803,7 +4019,11 @@ export function buildPlannerStepContractRefinementHint(
         );
       }
       if (diagnostic.code === "planner_plan_artifact_missing_write_step") {
-        return "include a final file-write step for the requested planning artifact";
+        return (
+          "include a final artifact materialization step for the requested planning artifact; " +
+          "either use deterministic `system.writeFile`/`system.appendFile`, or a single bounded " +
+          "`subagent_task` whose `execution_context.targetArtifacts` explicitly include that artifact"
+        );
       }
       return diagnostic.message;
     })

--- a/runtime/src/llm/chat-executor-recovery.ts
+++ b/runtime/src/llm/chat-executor-recovery.ts
@@ -785,6 +785,14 @@ export function inferRecoveryHint(
           "Retry only after reading those source files and preserving the distinction between planned structure and files that actually exist.",
       };
     }
+    if (validationCode === "missing_workspace_inspection_evidence") {
+      return {
+        key: "execute-with-agent-missing-workspace-inspection-evidence",
+        message:
+          "The previous `execute_with_agent` attempt updated a derived documentation artifact without first inspecting the current workspace state beyond the target artifact itself. " +
+          "Retry only after collecting concrete repo/layout inspection evidence and grounding the rewrite in that evidence.",
+      };
+    }
     if (validationCode === "forbidden_phase_action") {
       return {
         key: "execute-with-agent-forbidden-phase-action",

--- a/runtime/src/llm/chat-executor-verifier.test.ts
+++ b/runtime/src/llm/chat-executor-verifier.test.ts
@@ -294,6 +294,133 @@ describe("buildPlannerWorkflowAdmission", () => {
     expect(admission.requiresMandatoryImplementationVerification).toBe(false);
     expect(admission.completionContract?.taskClass).toBe("review_required");
   });
+
+  it("uses documentation completion verification for delegated plan rewrites", () => {
+    const admission = buildPlannerWorkflowAdmission({
+      workspaceRoot: "/tmp/project",
+      subagentSteps: [
+        createStep({
+          name: "rewrite_plan",
+          objective: "Rewrite PLAN.md to reflect the latest implementation state",
+          acceptanceCriteria: ["PLAN.md is fully updated with no shorthand placeholders"],
+          executionContext: {
+            version: "v1",
+            workspaceRoot: "/tmp/project",
+            allowedReadRoots: ["/tmp/project"],
+            allowedWriteRoots: ["/tmp/project"],
+            requiredSourceArtifacts: ["/tmp/project/PLAN.md"],
+            targetArtifacts: ["/tmp/project/PLAN.md"],
+            verificationMode: "mutation_required",
+            stepKind: "delegated_write",
+            effectClass: "filesystem_write",
+          },
+        }),
+      ],
+      deterministicSteps: [],
+    });
+
+    expect(admission.taskClassification).toBe("implementation_class");
+    expect(admission.requiresMandatoryImplementationVerification).toBe(true);
+    expect(admission.completionContract).toMatchObject({
+      taskClass: "artifact_only",
+      placeholderTaxonomy: "documentation",
+    });
+    expect(admission.verifierWorkItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "documentation_completion",
+          verificationKind: "deterministic_implementation",
+          objective: expect.stringContaining("documentation or planning artifact"),
+          verificationContract: expect.objectContaining({
+            completionContract: expect.objectContaining({
+              placeholderTaxonomy: "documentation",
+            }),
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("uses documentation completion verification for deterministic plan rewrites", () => {
+    const admission = buildPlannerWorkflowAdmission({
+      workspaceRoot: "/tmp/project",
+      subagentSteps: [],
+      deterministicSteps: [
+        {
+          name: "read_plan",
+          stepType: "deterministic_tool",
+          tool: "system.readFile",
+          args: { path: "/tmp/project/PLAN.md" },
+        },
+        {
+          name: "rewrite_plan",
+          stepType: "deterministic_tool",
+          tool: "system.writeFile",
+          args: { path: "/tmp/project/PLAN.md", content: "# PLAN\n" },
+        },
+      ],
+    });
+
+    expect(admission.taskClassification).toBe("implementation_class");
+    expect(admission.completionContract).toMatchObject({
+      taskClass: "artifact_only",
+      placeholderTaxonomy: "documentation",
+    });
+    expect(admission.verifierWorkItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "documentation_completion",
+        }),
+      ]),
+    );
+  });
+
+  it("normalizes contradictory review-tagged plan rewrites into documentation write admission", () => {
+    const admission = buildPlannerWorkflowAdmission({
+      workspaceRoot: "/tmp/project",
+      subagentSteps: [
+        createStep({
+          name: "analyze_and_update_plan",
+          objective:
+            "Assess the repo against PLAN.md and update PLAN.md to match the current state.",
+          acceptanceCriteria: ["PLAN.md is updated accurately."],
+          executionContext: {
+            version: "v1",
+            workspaceRoot: "/tmp/project",
+            allowedReadRoots: ["/tmp/project"],
+            allowedWriteRoots: ["/tmp/project"],
+            requiredSourceArtifacts: ["/tmp/project/PLAN.md"],
+            targetArtifacts: ["/tmp/project/PLAN.md"],
+            verificationMode: "mutation_required",
+            stepKind: "delegated_review",
+            effectClass: "filesystem_write",
+          },
+        }),
+      ],
+      deterministicSteps: [],
+    });
+
+    expect(admission.taskClassification).toBe("implementation_class");
+    expect(admission.completionContract).toMatchObject({
+      taskClass: "artifact_only",
+      placeholderTaxonomy: "documentation",
+    });
+    expect(admission.verificationContract).toMatchObject({
+      verificationMode: "mutation_required",
+      stepKind: "delegated_write",
+      completionContract: expect.objectContaining({
+        taskClass: "artifact_only",
+        placeholderTaxonomy: "documentation",
+      }),
+    });
+    expect(admission.verifierWorkItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "documentation_completion",
+        }),
+      ]),
+    );
+  });
 });
 
 describe("structured verifier outputs", () => {

--- a/runtime/src/llm/chat-executor-verifier.ts
+++ b/runtime/src/llm/chat-executor-verifier.ts
@@ -31,6 +31,7 @@ import type {
   WorkflowRequestMilestone,
 } from "../workflow/request-completion.js";
 import type { WorkflowVerificationContract } from "../workflow/verification-obligations.js";
+import { isDocumentationArtifactPath } from "../workflow/artifact-paths.js";
 import {
   DEFAULT_SUBAGENT_VERIFIER_MIN_CONFIDENCE,
   MAX_SUBAGENT_VERIFIER_OUTPUT_CHARS,
@@ -44,6 +45,7 @@ import {
 import { safeStringify } from "../tools/types.js";
 import { deriveVerificationObligations } from "../workflow/verification-obligations.js";
 import { validateRuntimeVerificationContract } from "../workflow/verification-contract.js";
+import { canonicalizeExecutionStepKind } from "../workflow/execution-intent.js";
 import {
   extractDelegationTokens,
   validateDelegatedOutputContract,
@@ -65,7 +67,6 @@ const DETERMINISTIC_IMPLEMENTATION_COMMAND_RE =
   /\b(?:implement|implementation|fix|repair|refactor|migrate|write|edit|update|create|build|compile|typecheck|lint|test|install|scaffold)\b/i;
 const SOURCE_LIKE_PATH_RE =
   /(?:^|\/)(?:src|lib|app|server|client|cmd|pkg|include|internal|tests?|spec)(?:\/|$)|\.(?:c|cc|cpp|cxx|h|hpp|m|mm|rs|go|py|rb|php|java|kt|swift|cs|js|jsx|ts|tsx|json|toml|yaml|yml|xml|sh|zsh|bash)$/i;
-const DOC_ONLY_PATH_RE = /\.(?:md|mdx|txt|rst|adoc)$/i;
 
 export function buildPlannerWorkflowAdmission(params: {
   readonly subagentSteps: readonly PlannerSubAgentTaskStepIntent[];
@@ -316,6 +317,10 @@ export function evaluatePlannerDeterministicChecks(
           contractValidation.code === "missing_required_source_evidence"
         ) {
           issues.push("missing_required_source_evidence");
+        } else if (
+          contractValidation.code === "missing_workspace_inspection_evidence"
+        ) {
+          issues.push("missing_workspace_inspection_evidence");
         } else if (
           contractValidation.code === "missing_file_artifact_evidence"
         ) {
@@ -1256,25 +1261,55 @@ function selectPlannerStepKind(params: {
   readonly completionContract?: ImplementationCompletionContract;
 }): WorkflowVerificationContract["stepKind"] | undefined {
   if (params.explicit) {
-    return params.explicit;
+    return canonicalizeExecutionStepKind({
+      stepKind: params.explicit,
+      verificationMode:
+        params.completionContract?.taskClass === "review_required"
+          ? "grounded_read"
+          : undefined,
+    });
   }
   for (const step of params.subagentSteps) {
-    if (step.executionContext?.stepKind === "delegated_write") {
+    const stepKind = canonicalizeExecutionStepKind({
+      stepKind: step.executionContext?.stepKind,
+      effectClass: step.executionContext?.effectClass,
+      verificationMode: step.executionContext?.verificationMode,
+      targetArtifacts: step.executionContext?.targetArtifacts,
+    });
+    if (stepKind === "delegated_write") {
       return "delegated_write";
     }
   }
   for (const step of params.subagentSteps) {
-    if (step.executionContext?.stepKind === "delegated_validation") {
+    const stepKind = canonicalizeExecutionStepKind({
+      stepKind: step.executionContext?.stepKind,
+      effectClass: step.executionContext?.effectClass,
+      verificationMode: step.executionContext?.verificationMode,
+      targetArtifacts: step.executionContext?.targetArtifacts,
+    });
+    if (stepKind === "delegated_validation") {
       return "delegated_validation";
     }
   }
   for (const step of params.subagentSteps) {
-    if (step.executionContext?.stepKind === "delegated_review") {
+    const stepKind = canonicalizeExecutionStepKind({
+      stepKind: step.executionContext?.stepKind,
+      effectClass: step.executionContext?.effectClass,
+      verificationMode: step.executionContext?.verificationMode,
+      targetArtifacts: step.executionContext?.targetArtifacts,
+    });
+    if (stepKind === "delegated_review") {
       return "delegated_review";
     }
   }
   for (const step of params.subagentSteps) {
-    if (step.executionContext?.stepKind === "delegated_scaffold") {
+    const stepKind = canonicalizeExecutionStepKind({
+      stepKind: step.executionContext?.stepKind,
+      effectClass: step.executionContext?.effectClass,
+      verificationMode: step.executionContext?.verificationMode,
+      targetArtifacts: step.executionContext?.targetArtifacts,
+    });
+    if (stepKind === "delegated_scaffold") {
       return "delegated_scaffold";
     }
   }
@@ -1297,13 +1332,21 @@ function buildDeterministicImplementationVerifierWorkItem(
     completionContract,
     verificationContract?.acceptanceCriteria,
   );
+  const documentationOnly =
+    completionContract.placeholderTaxonomy === "documentation";
   return {
-    name: "implementation_completion",
+    name: documentationOnly
+      ? "documentation_completion"
+      : "implementation_completion",
     verificationKind: "deterministic_implementation",
     objective:
-      "Verify that the deterministic implementation/fix/refactor work is complete enough to count as implemented.",
+      documentationOnly
+        ? "Verify that the deterministic documentation or planning artifact rewrite is complete enough to count as finished."
+        : "Verify that the deterministic implementation/fix/refactor work is complete enough to count as implemented.",
     inputContract:
-      "Assess the deterministic tool outputs and resulting artifacts against the implementation completion contract.",
+      documentationOnly
+        ? "Assess the deterministic tool outputs and resulting artifacts against the documentation completion contract."
+        : "Assess the deterministic tool outputs and resulting artifacts against the implementation completion contract.",
     acceptanceCriteria,
     requiredToolCapabilities: [
       ...new Set([
@@ -1347,6 +1390,12 @@ function hasDeterministicImplementationMutation(
   return deterministicSteps.some((step) => isImplementationMutationStep(step));
 }
 
+function hasDeterministicDocumentationMutation(
+  deterministicSteps: readonly PlannerDeterministicToolStepIntent[],
+): boolean {
+  return deterministicSteps.some((step) => isDocumentationMutationStep(step));
+}
+
 function resolveDeterministicImplementationCompletionContract(
   deterministicSteps: readonly PlannerDeterministicToolStepIntent[],
 ): ImplementationCompletionContract | undefined {
@@ -1372,6 +1421,14 @@ function resolveDeterministicImplementationCompletionContract(
       placeholdersAllowed: false,
       partialCompletionAllowed: false,
       placeholderTaxonomy: "implementation",
+    };
+  }
+  if (hasDeterministicDocumentationMutation(deterministicSteps)) {
+    return {
+      taskClass: "artifact_only",
+      placeholdersAllowed: false,
+      partialCompletionAllowed: false,
+      placeholderTaxonomy: "documentation",
     };
   }
   return undefined;
@@ -1411,7 +1468,7 @@ function isImplementationMutationStep(
     if (candidatePaths.length === 0) {
       return true;
     }
-    return candidatePaths.some((path) => !DOC_ONLY_PATH_RE.test(path));
+    return candidatePaths.some((path) => !isDocumentationArtifactPath(path));
   }
   if (step.tool !== "system.bash" && step.tool !== "desktop.bash") {
     return false;
@@ -1430,6 +1487,30 @@ function isImplementationMutationStep(
     );
   }
   return pathHints.some((path) => SOURCE_LIKE_PATH_RE.test(path));
+}
+
+function isDocumentationMutationStep(
+  step: PlannerDeterministicToolStepIntent,
+): boolean {
+  if (DIRECT_MUTATION_TOOL_NAMES.has(step.tool.trim())) {
+    const candidatePaths = extractDeterministicTargetPaths(step);
+    return (
+      candidatePaths.length > 0 &&
+      candidatePaths.every((path) => isDocumentationArtifactPath(path))
+    );
+  }
+  if (step.tool !== "system.bash" && step.tool !== "desktop.bash") {
+    return false;
+  }
+  const commandText = extractCommandText(step.args);
+  if (!SHELL_MUTATION_RE.test(commandText)) {
+    return false;
+  }
+  const pathHints = extractDeterministicTargetPaths(step);
+  return (
+    pathHints.length > 0 &&
+    pathHints.every((path) => isDocumentationArtifactPath(path))
+  );
 }
 
 function extractDeterministicTargetPaths(

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -13318,8 +13318,11 @@ describe("ChatExecutor", () => {
       const result = await executor.execute(
         createParams({
           message: createMessage(
-            "i want you to read @TODO.md and turn it into a complete plan for making a shell in the c-programming language.",
+            "i want you to read @TODO.md and turn it into a complete plan in @PLAN.md for making a shell in the c-programming language.",
           ),
+          runtimeContext: {
+            workspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
+          },
         }),
       );
 
@@ -13353,13 +13356,13 @@ describe("ChatExecutor", () => {
                   },
                 },
                 {
-                  name: "write_phase_summary",
+                  name: "write_plan_summary",
                   step_type: "deterministic_tool",
                   depends_on: ["read_plan"],
                   tool: "system.writeFile",
                   args: {
-                    path: "/home/tetsuo/git/stream-test/agenc-shell/PHASE_SUMMARY.md",
-                    content: "# Phase summary\n",
+                    path: "/home/tetsuo/git/stream-test/agenc-shell/PLAN.md",
+                    content: "# Plan\n\n## Final Phase Summary\n",
                   },
                 },
               ],
@@ -13376,9 +13379,9 @@ describe("ChatExecutor", () => {
                 path: "/home/tetsuo/git/stream-test/agenc-shell/PLAN.md",
                 size: 4096,
               }),
-              write_phase_summary: safeJson({
-                path: "/home/tetsuo/git/stream-test/agenc-shell/PHASE_SUMMARY.md",
-                bytesWritten: 16,
+              write_plan_summary: safeJson({
+                path: "/home/tetsuo/git/stream-test/agenc-shell/PLAN.md",
+                bytesWritten: 31,
               }),
             },
           },
@@ -13398,6 +13401,9 @@ describe("ChatExecutor", () => {
           message: createMessage(
             "Read PLAN.md and update it with a final phase summary for the completed work.",
           ),
+          runtimeContext: {
+            workspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
+          },
         }),
       );
 
@@ -17920,6 +17926,99 @@ describe("ChatExecutor", () => {
             phase: "tool_followup",
             payload: expect.objectContaining({
               gate: "legacy_completion_compatibility",
+            }),
+          }),
+        ]),
+      );
+    });
+
+    it("labels planner-owned documentation rewrites as documentation in completion-gate traces", async () => {
+      const events: Record<string, unknown>[] = [];
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: safeJson({
+              reason: "planner_doc_contract",
+              requiresSynthesis: false,
+              steps: [
+                {
+                  name: "read_plan",
+                  step_type: "deterministic_tool",
+                  tool: "system.readFile",
+                  args: {
+                    path: "/home/tetsuo/git/stream-test/agenc-shell/PLAN.md",
+                  },
+                },
+                {
+                  name: "rewrite_plan",
+                  step_type: "deterministic_tool",
+                  depends_on: ["read_plan"],
+                  tool: "system.writeFile",
+                  args: {
+                    path: "/home/tetsuo/git/stream-test/agenc-shell/PLAN.md",
+                    content: "# PLAN\n",
+                  },
+                },
+              ],
+            }),
+          }),
+        ),
+      });
+      const pipelineExecutor = {
+        execute: vi.fn().mockResolvedValue({
+          status: "completed",
+          completionState: "completed",
+          context: {
+            results: {
+              read_plan: safeJson({
+                path: "/home/tetsuo/git/stream-test/agenc-shell/PLAN.md",
+                size: 4096,
+              }),
+              rewrite_plan: safeJson({
+                path: "/home/tetsuo/git/stream-test/agenc-shell/PLAN.md",
+                bytesWritten: 7,
+              }),
+            },
+          },
+          completedSteps: 2,
+          totalSteps: 2,
+        }),
+      };
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Update PLAN.md so it matches the current implementation.",
+          ),
+          runtimeContext: {
+            workspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
+          },
+          trace: {
+            onExecutionTraceEvent: (event) => {
+              events.push(event as unknown as Record<string, unknown>);
+            },
+          },
+        }),
+      );
+
+      expect(result.stopReason).toBe("completed");
+      expect(result.completionState).toBe("completed");
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "completion_gate_checked",
+            phase: "tool_followup",
+            payload: expect.objectContaining({
+              gate: "workflow_completion_truth",
+              decision: expect.stringMatching(/^accept/),
+              ownerClass: "documentation",
+              reason: "workflow_verification_contract_present",
             }),
           }),
         ]),

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -42,6 +42,7 @@ import type { WorkflowVerificationContract } from "../workflow/verification-obli
 import type { HostToolingProfile } from "../gateway/host-tooling.js";
 import { resolveWorkflowCompletionState } from "../workflow/completion-state.js";
 import { deriveWorkflowProgressSnapshot } from "../workflow/completion-progress.js";
+import { isDocumentationArtifactPath } from "../workflow/artifact-paths.js";
 import {
   buildModelRoutingPolicy,
   resolveModelRoute,
@@ -132,6 +133,7 @@ import {
   resolveExecutionToolContractGuidance,
   resolveLegacyCompletionCompatibility,
   resolveRuntimeWorkflowContext,
+  type RuntimeWorkflowContextResolution,
   validateRequiredToolEvidence,
 } from "./chat-executor-contract-flow.js";
 import type { ToolContractGuidance } from "./chat-executor-contract-guidance.js";
@@ -247,6 +249,34 @@ function mergeExplicitRequirementToolNames(
     return merged;
   }
   return Array.from(new Set(fallbackToolNames));
+}
+
+function resolveWorkflowOwnerClass(params: {
+  readonly workflowContext?: RuntimeWorkflowContextResolution;
+  readonly plannerCompletionContract?: ImplementationCompletionContract;
+  readonly plannerVerificationContract?: WorkflowVerificationContract;
+}): "documentation" | "implementation" {
+  const completionContract =
+    params.workflowContext?.completionContract ??
+    params.workflowContext?.verificationContract?.completionContract ??
+    params.plannerCompletionContract ??
+    params.plannerVerificationContract?.completionContract;
+  if (completionContract?.placeholderTaxonomy === "documentation") {
+    return "documentation";
+  }
+  const targetArtifacts =
+    params.workflowContext?.verificationContract?.targetArtifacts ??
+    params.plannerVerificationContract?.targetArtifacts ??
+    [];
+  if (
+    targetArtifacts.length > 0 &&
+    targetArtifacts.every((artifact) => isDocumentationArtifactPath(artifact)) &&
+    completionContract?.taskClass !== "build_required" &&
+    completionContract?.taskClass !== "behavior_required"
+  ) {
+    return "documentation";
+  }
+  return "implementation";
 }
 
 function buildDelegatedBudgetFinalizationInstruction(params: {
@@ -1765,6 +1795,11 @@ export class ChatExecutor {
       workflowContext.verificationContract ||
       workflowContext.completionContract
     ) {
+      const ownerClass = resolveWorkflowOwnerClass({
+        workflowContext,
+        plannerCompletionContract: ctx.plannerCompletionContract,
+        plannerVerificationContract: ctx.plannerVerificationContract,
+      });
       this.emitExecutionTrace(ctx, {
         type: "completion_gate_checked",
         phase: "tool_followup",
@@ -1773,7 +1808,7 @@ export class ChatExecutor {
           gate: "workflow_completion_truth",
           decision:
             ctx.completionState === "completed" ? "accept" : "accept_nonterminal",
-          ownerClass: "implementation",
+          ownerClass,
           completionState: ctx.completionState,
           ownershipSource: workflowContext.ownershipSource,
           reason: "workflow_verification_contract_present",
@@ -1798,6 +1833,10 @@ export class ChatExecutor {
       ctx.plannerSummaryState.subagentVerification.performed === true &&
       ctx.plannerSummaryState.subagentVerification.overall === "pass"
     ) {
+      const ownerClass = resolveWorkflowOwnerClass({
+        plannerCompletionContract: ctx.plannerCompletionContract,
+        plannerVerificationContract: ctx.plannerVerificationContract,
+      });
       this.emitExecutionTrace(ctx, {
         type: "completion_gate_checked",
         phase: "tool_followup",
@@ -1806,7 +1845,7 @@ export class ChatExecutor {
           gate: "workflow_completion_truth",
           decision:
             ctx.completionState === "completed" ? "accept" : "accept_nonterminal",
-          ownerClass: "implementation",
+          ownerClass,
           completionState: ctx.completionState,
           ownershipSource: "planner_owned",
           reason: "planner_verifier_passed",

--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -289,7 +289,7 @@ describe("GrokProvider", () => {
     expect(params.tools[0].name).toBe("system.bash");
   });
 
-  it("normalizes required single-tool choice to a named function for the Responses API", async () => {
+  it("preserves documented required single-tool choice for the Responses API", async () => {
     mockCreate.mockResolvedValueOnce(makeCompletion());
 
     const provider = new GrokProvider({
@@ -315,12 +315,7 @@ describe("GrokProvider", () => {
     );
 
     const params = mockCreate.mock.calls[0][0];
-    expect(params.tool_choice).toEqual({
-      type: "function",
-      function: {
-        name: "system.bash",
-      },
-    });
+    expect(params.tool_choice).toBe("required");
   });
 
   it("captures selected tools and tool_choice in request metrics", async () => {
@@ -368,7 +363,7 @@ describe("GrokProvider", () => {
       requestedToolNames: ["system.bash"],
       missingRequestedToolNames: [],
       toolResolution: "subset_exact",
-      toolChoice: "function:system.bash",
+      toolChoice: "required",
       store: false,
     });
   });
@@ -499,12 +494,7 @@ describe("GrokProvider", () => {
         toolMessages: 0,
       },
       payload: {
-        tool_choice: {
-          type: "function",
-          function: {
-            name: "system.bash",
-          },
-        },
+        tool_choice: "required",
       },
     });
     expect((events[0].payload as { tools?: Array<{ name?: string }> }).tools?.[0]?.name).toBe(

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -319,23 +319,10 @@ function normalizeResponsesToolChoice(
 
 function resolveResponsesToolChoice(
   toolChoice: LLMToolChoice | undefined,
-  selection: ToolSelectionDiagnostics,
 ): string | Record<string, unknown> | undefined {
-  const normalized = normalizeResponsesToolChoice(toolChoice);
-  if (normalized !== "required") {
-    return normalized;
-  }
-
-  if (!selection.toolsAttached || selection.resolvedToolNames.length !== 1) {
-    return normalized;
-  }
-
-  return {
-    type: "function",
-    function: {
-      name: selection.resolvedToolNames[0],
-    },
-  };
+  // xAI documents `required` as a first-class tool_choice mode. Preserve it
+  // instead of tightening it into a named-function selection.
+  return normalizeResponsesToolChoice(toolChoice);
 }
 
 function estimateOpenAIContentChars(content: unknown): number {
@@ -1858,10 +1845,7 @@ export class GrokProvider implements LLMProvider {
         params.tools = selectedTools.tools;
         selectedTools.toolsAttached = true;
         params.parallel_tool_calls = this.config.parallelToolCalls;
-        const toolChoice = resolveResponsesToolChoice(
-          options?.toolChoice,
-          selectedTools,
-        );
+        const toolChoice = resolveResponsesToolChoice(options?.toolChoice);
         if (toolChoice !== undefined) {
           params.tool_choice = toolChoice;
         }

--- a/runtime/src/utils/delegation-validation.test.ts
+++ b/runtime/src/utils/delegation-validation.test.ts
@@ -12,6 +12,7 @@ import {
   resolveDelegatedInitialToolChoiceToolName,
   specRequiresFileMutationEvidence,
   specRequiresMeaningfulBrowserEvidence,
+  specRequiresMeaningfulWorkspaceEvidence,
   validateDelegatedOutputContract,
 } from "./delegation-validation.js";
 import {
@@ -67,6 +68,22 @@ describe("delegation-validation", () => {
   it("does not treat negative pre-install guardrails as build verification", () => {
     expect(
       getAcceptanceVerificationCategories("No logic code or install commands in objective"),
+    ).toEqual([]);
+  });
+
+  it("treats current-workspace alignment criteria as inspection verification", () => {
+    expect(
+      getAcceptanceVerificationCategories(
+        "PLAN.md reflects the current workspace layout and recent directory changes accurately.",
+      ),
+    ).toEqual(["inspection"]);
+  });
+
+  it("does not treat current-guide review criteria as workspace inspection verification", () => {
+    expect(
+      getAcceptanceVerificationCategories(
+        "Ground the review on the current guide before claiming no changes are needed.",
+      ),
     ).toEqual([]);
   });
 
@@ -1711,6 +1728,76 @@ describe("delegation-validation", () => {
     expect(result.code).toBe("missing_required_source_evidence");
   });
 
+  it("requires meaningful workspace inspection before workspace-grounded documentation rewrites", () => {
+    const result = validateDelegatedOutputContract({
+      spec: {
+        task: "review_and_update_plan",
+        objective:
+          "Review the codebase layout against phase1, identify plan gaps, and update PLAN.md.",
+        parentRequest:
+          "Review the entire codebase layout and code to verify if it correctly follows Phase1 as described in PLAN.md. Assess whether recent directory changes align with the plan.",
+        inputContract: "Use PLAN.md and the current workspace state as sources of truth.",
+        acceptanceCriteria: [
+          "PLAN.md reflects the current workspace layout and recent directory changes accurately.",
+        ],
+        executionContext: {
+          workspaceRoot: "/tmp/agenc-shell",
+          allowedReadRoots: ["/tmp/agenc-shell"],
+          allowedWriteRoots: ["/tmp/agenc-shell"],
+          requiredSourceArtifacts: ["/tmp/agenc-shell/PLAN.md"],
+          targetArtifacts: ["/tmp/agenc-shell/PLAN.md"],
+          allowedTools: ["system.readFile", "system.writeFile"],
+          effectClass: "filesystem_write",
+          verificationMode: "mutation_required",
+          stepKind: "delegated_write",
+        },
+      },
+      output: "Updated /tmp/agenc-shell/PLAN.md to reflect the current workspace layout.",
+      toolCalls: [
+        {
+          name: "system.readFile",
+          args: { path: "/tmp/agenc-shell/PLAN.md" },
+          result: JSON.stringify({
+            path: "/tmp/agenc-shell/PLAN.md",
+            content: "# PLAN\n",
+          }),
+        },
+        {
+          name: "system.writeFile",
+          args: {
+            path: "/tmp/agenc-shell/PLAN.md",
+            content: "# PLAN\nUpdated\n",
+          },
+          result: JSON.stringify({
+            path: "/tmp/agenc-shell/PLAN.md",
+            written: true,
+          }),
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("missing_workspace_inspection_evidence");
+  });
+
+  it("detects workspace-grounded documentation rewrites from the delegated contract", () => {
+    expect(
+      specRequiresMeaningfulWorkspaceEvidence({
+        task: "review_and_update_plan",
+        objective:
+          "Review the codebase layout against phase1, identify plan gaps, and update PLAN.md.",
+        parentRequest:
+          "Assess whether recent directory changes align with the plan and update PLAN.md accordingly.",
+        inputContract: "Use PLAN.md and the current workspace state as sources of truth.",
+        executionContext: {
+          workspaceRoot: "/tmp/agenc-shell",
+          targetArtifacts: ["/tmp/agenc-shell/PLAN.md"],
+          requiredSourceArtifacts: ["/tmp/agenc-shell/PLAN.md"],
+        },
+      }),
+    ).toBe(true);
+  });
+
   it("accepts derived file writes once the named source artifact was read first", () => {
     const result = validateDelegatedOutputContract({
       spec: {
@@ -1729,6 +1816,16 @@ describe("delegation-validation", () => {
       output:
         "Wrote /home/tetsuo/git/stream-test/agenc-shell/AGENC.md with repository guidelines derived from PLAN.md.",
       toolCalls: [
+        {
+          name: "system.listDir",
+          args: {
+            path: "/home/tetsuo/git/stream-test/agenc-shell/src",
+          },
+          result: JSON.stringify({
+            path: "/home/tetsuo/git/stream-test/agenc-shell/src",
+            entries: ["shell.c", "parser.c"],
+          }),
+        },
         {
           name: "system.readFile",
           args: {
@@ -1757,23 +1854,27 @@ describe("delegation-validation", () => {
   });
 
   it("accepts grounded no-op success from typed required source artifacts without relying on prompt file extraction", () => {
-    const result = validateDelegatedOutputContract({
-      spec: {
-        task: "review_agenc_md",
-        objective: "Verify that AGENC.md already satisfies the requested sections.",
-        inputContract: "Review the existing guide and report whether it already satisfies the request.",
-        acceptanceCriteria: ["Ground the review on the current guide before claiming no changes are needed."],
-        executionContext: {
-          version: "v1",
-          workspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
-          requiredSourceArtifacts: [
-            "/home/tetsuo/git/stream-test/agenc-shell/AGENC.md",
-          ],
-          targetArtifacts: [
-            "/home/tetsuo/git/stream-test/agenc-shell/AGENC.md",
-          ],
-        },
+    const spec = {
+      task: "review_agenc_md",
+      objective: "Verify that AGENC.md already satisfies the requested sections.",
+      inputContract: "Review the existing guide and report whether it already satisfies the request.",
+      acceptanceCriteria: ["Ground the review on the current guide before claiming no changes are needed."],
+      executionContext: {
+        version: "v1" as const,
+        workspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
+        requiredSourceArtifacts: [
+          "/home/tetsuo/git/stream-test/agenc-shell/AGENC.md",
+        ],
+        targetArtifacts: [
+          "/home/tetsuo/git/stream-test/agenc-shell/AGENC.md",
+        ],
       },
+    };
+
+    expect(specRequiresMeaningfulWorkspaceEvidence(spec)).toBe(false);
+
+    const result = validateDelegatedOutputContract({
+      spec,
       output:
         "AGENC.md already satisfies the requested guide sections. No mutation needed.",
       toolCalls: [{
@@ -2112,6 +2213,59 @@ describe("delegation-validation", () => {
     ]);
     expect(resolved.blockedReason).toBeUndefined();
     expect(resolved.removedByPolicy).toEqual([]);
+  });
+
+  it("treats capability prose with sentence punctuation as semantic input instead of an explicit tool name", () => {
+    const resolved = resolveDelegatedChildToolScope({
+      spec: {
+        task: "analyze_and_update_plan",
+        objective:
+          "Review the codebase and update PLAN.md to reflect the current Phase 1 workspace state.",
+        inputContract: "Current PLAN.md and workspace layout are available.",
+        acceptanceCriteria: [
+          "Update PLAN.md with corrected structure and gaps.",
+        ],
+        executionContext: {
+          workspaceRoot: "/workspace",
+          allowedReadRoots: ["/workspace"],
+          allowedWriteRoots: ["/workspace"],
+          targetArtifacts: ["/workspace/PLAN.md"],
+          requiredSourceArtifacts: ["/workspace/PLAN.md"],
+        },
+        requiredToolCapabilities: [
+          "Filesystem read access to all source files and directories in the workspace.",
+        ],
+      },
+      requestedTools: [
+        "Filesystem read access to all source files and directories in the workspace.",
+      ],
+      parentAllowedTools: [
+        "system.bash",
+        "system.mkdir",
+        "system.writeFile",
+        "system.appendFile",
+        "execute_with_agent",
+      ],
+      availableTools: [
+        "system.bash",
+        "system.mkdir",
+        "system.writeFile",
+        "system.appendFile",
+        "execute_with_agent",
+      ],
+      enforceParentIntersection: true,
+      unsafeBenchmarkMode: true,
+    });
+
+    expect(resolved.allowedTools).toEqual([
+      "system.bash",
+      "system.writeFile",
+      "system.appendFile",
+    ]);
+    expect(resolved.removedAsUnknownTools).not.toContain(
+      "Filesystem read access to all source files and directories in the workspace.",
+    );
+    expect(resolved.blockedReason).toBeUndefined();
   });
 
   it("maps generic filesystem capability names onto read/write directory tools", () => {
@@ -3622,6 +3776,73 @@ Project is functional for core/pathfinding; CLI/web assumed usable per authored 
     expect(toolNames).toEqual([
       "system.listDir",
       "system.readFile",
+    ]);
+  });
+
+  it("prioritizes workspace inspection before mutation for workspace-grounded doc rewrites", () => {
+    const toolNames = resolveDelegatedInitialToolChoiceToolNames(
+      {
+        task: "review_and_update_plan",
+        objective:
+          "Review the codebase layout against phase1, identify plan gaps, and update PLAN.md.",
+        parentRequest:
+          "Assess whether recent directory changes align with the plan and update PLAN.md accordingly.",
+        inputContract: "Use PLAN.md and the current workspace state as sources of truth.",
+        acceptanceCriteria: [
+          "PLAN.md reflects the current workspace layout and recent directory changes accurately.",
+        ],
+        executionContext: {
+          workspaceRoot: "/tmp/agenc-shell",
+          targetArtifacts: ["/tmp/agenc-shell/PLAN.md"],
+          requiredSourceArtifacts: ["/tmp/agenc-shell/PLAN.md"],
+        },
+      },
+      [
+        "system.readFile",
+        "system.listDir",
+        "system.writeFile",
+        "system.bash",
+      ],
+    );
+
+    expect(toolNames).toEqual([
+      "system.listDir",
+      "system.readFile",
+      "system.writeFile",
+      "system.bash",
+    ]);
+  });
+
+  it("routes workspace-inspection correction retries to inspection before mutation", () => {
+    const toolNames = resolveDelegatedCorrectionToolChoiceToolNames(
+      {
+        task: "review_and_update_plan",
+        objective:
+          "Review the codebase layout against phase1, identify plan gaps, and update PLAN.md.",
+        parentRequest:
+          "Assess whether recent directory changes align with the plan and update PLAN.md accordingly.",
+        inputContract: "Use PLAN.md and the current workspace state as sources of truth.",
+        acceptanceCriteria: [
+          "PLAN.md reflects the current workspace layout and recent directory changes accurately.",
+        ],
+        executionContext: {
+          workspaceRoot: "/tmp/agenc-shell",
+          targetArtifacts: ["/tmp/agenc-shell/PLAN.md"],
+          requiredSourceArtifacts: ["/tmp/agenc-shell/PLAN.md"],
+        },
+      },
+      [
+        "system.listDir",
+        "system.readFile",
+        "system.writeFile",
+      ],
+      "missing_workspace_inspection_evidence",
+    );
+
+    expect(toolNames).toEqual([
+      "system.listDir",
+      "system.readFile",
+      "system.writeFile",
     ]);
   });
 

--- a/runtime/src/utils/delegation-validation.ts
+++ b/runtime/src/utils/delegation-validation.ts
@@ -37,6 +37,12 @@ import {
   toDelegationOutputValidationResult,
   validateRuntimeVerificationContract,
 } from "../workflow/index.js";
+import { areDocumentationOnlyArtifacts } from "../workflow/artifact-paths.js";
+import {
+  criterionRequiresWorkspaceInspectionVerification,
+  isMeaningfulWorkspaceInspectionToolCall,
+  textRequiresWorkspaceGroundedArtifactUpdate,
+} from "../workflow/workspace-inspection-evidence.js";
 
 export interface DelegationContractSpec {
   readonly task?: string;
@@ -85,6 +91,7 @@ export type DelegationOutputValidationCode =
   | "contradictory_completion_claim"
   | "missing_successful_tool_evidence"
   | "low_signal_browser_evidence"
+  | "missing_workspace_inspection_evidence"
   | "missing_file_mutation_evidence"
   | "missing_required_source_evidence"
   | "missing_file_artifact_evidence";
@@ -412,6 +419,8 @@ function isGenericFilesystemCapabilityName(capability: string): boolean {
 
 function looksLikeExplicitDelegatedToolName(toolName: string): boolean {
   const normalized = toolName.trim().toLowerCase();
+  if (normalized.length === 0) return false;
+  if (/\s/.test(normalized)) return false;
   return normalized === "execute_with_agent" ||
     isProviderNativeToolName(normalized) ||
     normalized.includes(".") ||
@@ -1664,6 +1673,7 @@ export function specRequiresSuccessfulToolEvidence(
   spec: DelegationContractSpec,
 ): boolean {
   if (hasExplicitToolRequirement(spec)) return true;
+  if (specRequiresMeaningfulWorkspaceEvidence(spec)) return true;
   const stepText = collectDelegationStepText(spec);
   if (TOOL_GROUNDED_TASK_RE.test(stepText)) return true;
   const taskIntent = classifyDelegatedTaskIntent(spec);
@@ -1671,6 +1681,24 @@ export function specRequiresSuccessfulToolEvidence(
     (taskIntent === "research" || taskIntent === "validation") &&
     TOOL_GROUNDED_TASK_RE.test(collectDelegationContextText(spec))
   );
+}
+
+export function specRequiresMeaningfulWorkspaceEvidence(
+  spec: DelegationContractSpec,
+): boolean {
+  const targetArtifacts = collectExplicitSpecFileArtifacts(spec);
+  if (!areDocumentationOnlyArtifacts(targetArtifacts)) {
+    return false;
+  }
+  if (!specTargetsLocalFiles(spec)) {
+    return false;
+  }
+  const text = collectDelegationStepText(spec, { includeParentRequest: true });
+  if (!textRequiresWorkspaceGroundedArtifactUpdate(text)) {
+    return false;
+  }
+  const capabilityProfile = getDelegatedCapabilityProfile(spec);
+  return capabilityProfile.hasFileWrite || targetArtifacts.length > 0;
 }
 
 export function specRequiresMeaningfulBrowserEvidence(
@@ -2055,11 +2083,16 @@ export function resolveDelegatedInitialToolChoiceToolName(
   const normalizedTools = normalizeToolNames(tools);
   const taskIntent = classifyDelegatedTaskIntent(spec);
   const requireBrowser = specRequiresMeaningfulBrowserEvidence(spec);
+  const requireWorkspaceInspection = specRequiresMeaningfulWorkspaceEvidence(spec);
   const requireFileMutation = specRequiresFileMutationEvidence(spec);
   const setupHeavy = isSetupHeavyDelegatedTask(spec);
   const localFileInspectionTask = specTargetsLocalFiles(spec);
   const shouldPrioritizeSourceGroundingRetry =
     spec.lastValidationCode === "missing_required_source_evidence" &&
+    localFileInspectionTask &&
+    !requireBrowser;
+  const shouldPrioritizeWorkspaceGroundingRetry =
+    spec.lastValidationCode === "missing_workspace_inspection_evidence" &&
     localFileInspectionTask &&
     !requireBrowser;
   const shouldPrioritizeVerificationRetry =
@@ -2076,6 +2109,16 @@ export function resolveDelegatedInitialToolChoiceToolName(
     return INITIAL_FILE_INSPECTION_TOOL_NAMES.find((toolName) =>
       normalizedTools.includes(toolName)
     );
+  }
+
+  if (shouldPrioritizeWorkspaceGroundingRetry || requireWorkspaceInspection) {
+    const preferredInspectionTool = [
+      "system.listDir",
+      ...INITIAL_FILE_INSPECTION_TOOL_NAMES,
+    ].find((toolName) => normalizedTools.includes(toolName));
+    if (preferredInspectionTool) {
+      return preferredInspectionTool;
+    }
   }
 
   if (shouldPrioritizeVerificationRetry) {
@@ -2157,6 +2200,7 @@ export function resolveDelegatedInitialToolChoiceToolNames(
 
   const taskIntent = classifyDelegatedTaskIntent(spec);
   const requireBrowser = specRequiresMeaningfulBrowserEvidence(spec);
+  const requireWorkspaceInspection = specRequiresMeaningfulWorkspaceEvidence(spec);
   const requireFileMutation = specRequiresFileMutationEvidence(spec);
   const setupHeavy = isSetupHeavyDelegatedTask(spec);
   const localFileInspectionTask = specTargetsLocalFiles(spec);
@@ -2166,6 +2210,10 @@ export function resolveDelegatedInitialToolChoiceToolNames(
   );
   const shouldPrioritizeSourceGroundingRetry =
     spec.lastValidationCode === "missing_required_source_evidence" &&
+    localFileInspectionTask &&
+    !requireBrowser;
+  const shouldPrioritizeWorkspaceGroundingRetry =
+    spec.lastValidationCode === "missing_workspace_inspection_evidence" &&
     localFileInspectionTask &&
     !requireBrowser;
   const shouldPrioritizeVerificationRetry =
@@ -2206,12 +2254,31 @@ export function resolveDelegatedInitialToolChoiceToolNames(
     return correctionTools.length > 0 ? correctionTools : [preferredToolName];
   }
 
+  if (shouldPrioritizeWorkspaceGroundingRetry) {
+    const correctionTools: string[] = [];
+    const pushFirstAvailable = (candidates: readonly string[]) => {
+      const toolName = candidates.find((candidate) =>
+        normalizedTools.includes(candidate)
+      );
+      if (toolName && !correctionTools.includes(toolName)) {
+        correctionTools.push(toolName);
+      }
+    };
+    pushFirstAvailable(["system.listDir"]);
+    pushFirstAvailable(INITIAL_FILE_INSPECTION_TOOL_NAMES);
+    if (requireFileMutation || taskIntent === "implementation") {
+      pushFirstAvailable(INITIAL_FILE_MUTATION_TOOL_NAMES);
+    }
+    return correctionTools.length > 0 ? correctionTools : [preferredToolName];
+  }
+
   const shouldUseFlexibleInitialSubset =
     hasSystemTooling &&
     (
       setupHeavy ||
       researchLikeButLocalInspectionOnly ||
       shouldUseFullInspectionCoverage ||
+      requireWorkspaceInspection ||
       verificationCue ||
       taskIntent === "validation" ||
       taskIntent === "implementation"
@@ -2241,10 +2308,9 @@ export function resolveDelegatedInitialToolChoiceToolNames(
   const inspectionCandidates = setupHeavy
     ? (["system.listDir", ...INITIAL_FILE_INSPECTION_TOOL_NAMES] as const)
     : INITIAL_FILE_INSPECTION_TOOL_NAMES;
-  const fullInspectionCandidates = [
-    "system.readFile",
-    "system.listDir",
-  ] as const;
+  const fullInspectionCandidates = requireWorkspaceInspection
+    ? (["system.listDir", "system.readFile"] as const)
+    : (["system.readFile", "system.listDir"] as const);
 
   if (shouldPrioritizeVerificationRetry) {
     pushFirstAvailable(INITIAL_SETUP_TOOL_NAMES);
@@ -2258,10 +2324,11 @@ export function resolveDelegatedInitialToolChoiceToolNames(
     if (
       taskIntent === "implementation" ||
       taskIntent === "validation" ||
+      requireWorkspaceInspection ||
       localFileInspectionTask ||
       setupHeavy
     ) {
-      if (shouldUseFullInspectionCoverage) {
+      if (shouldUseFullInspectionCoverage || requireWorkspaceInspection) {
         pushAllAvailable(fullInspectionCandidates);
       } else {
         pushFirstAvailable(inspectionCandidates);
@@ -2400,6 +2467,24 @@ export function resolveDelegatedCorrectionToolChoiceToolNames(
     };
     pushFirstAvailable(["system.listDir"]);
     pushFirstAvailable(INITIAL_FILE_INSPECTION_TOOL_NAMES);
+    if (correctionTools.length > 0) {
+      return correctionTools;
+    }
+  }
+
+  if (validationCode === "missing_workspace_inspection_evidence") {
+    const correctionTools: string[] = [];
+    const pushFirstAvailable = (candidates: readonly string[]) => {
+      const toolName = candidates.find((candidate) =>
+        normalizedTools.includes(candidate)
+      );
+      if (toolName && !correctionTools.includes(toolName)) {
+        correctionTools.push(toolName);
+      }
+    };
+    pushFirstAvailable(["system.listDir"]);
+    pushFirstAvailable(INITIAL_FILE_INSPECTION_TOOL_NAMES);
+    pushFirstAvailable(INITIAL_FILE_MUTATION_TOOL_NAMES);
     if (correctionTools.length > 0) {
       return correctionTools;
     }
@@ -2655,7 +2740,7 @@ function isToolCallFailure(toolCall: DelegationValidationToolCall): boolean {
   return false;
 }
 
-export type AcceptanceVerificationCategory = "build" | "test";
+export type AcceptanceVerificationCategory = "build" | "test" | "inspection";
 type ForbiddenPhaseActionCategory =
   | "install"
   | "build"
@@ -2828,6 +2913,9 @@ export function getAcceptanceVerificationCategories(
   }
   if (ACCEPTANCE_TEST_VERIFICATION_RE.test(criterion)) {
     categories.add("test");
+  }
+  if (criterionRequiresWorkspaceInspectionVerification(criterion)) {
+    categories.add("inspection");
   }
   return [...categories];
 }
@@ -3330,9 +3418,37 @@ function validateAcceptanceVerificationToolEvidence(
       continue;
     }
 
+    if (
+      categories.includes("inspection") &&
+      !successfulCalls.some((toolCall) =>
+        isMeaningfulWorkspaceInspectionToolCall({
+          toolCall,
+          workspaceRoot: spec.executionContext?.workspaceRoot,
+          targetArtifacts: collectExplicitSpecFileArtifacts(spec),
+          requiredSourceArtifacts: collectExplicitSourceSpecFileArtifacts(spec),
+        })
+      )
+    ) {
+      return validationFailure(
+        "missing_workspace_inspection_evidence",
+        "Acceptance criterion required grounded workspace inspection evidence but the child did not inspect non-target workspace state: " +
+          truncateValidationExcerpt(criterion),
+        parsedOutput,
+      );
+    }
+
+    const remainingCategories = categories.filter((category) =>
+      category !== "inspection"
+    );
+    if (remainingCategories.length === 0) {
+      continue;
+    }
+
     const hasMatchingSuccess = successfulCalls.some((toolCall) => {
       const toolCategories = getToolCallVerificationCategories(toolCall);
-      return categories.some((category) => toolCategories.includes(category));
+      return remainingCategories.some((category) =>
+        toolCategories.includes(category)
+      );
     });
     if (hasMatchingSuccess) {
       continue;
@@ -3453,6 +3569,58 @@ function isMeaningfulHostBrowserValidationToolCall(
   return hasBrowserCue && (hasTargetCue || specHasBrowserCue);
 }
 
+function getMeaningfulWorkspaceEvidenceFailureMessage(
+  spec: DelegationContractSpec,
+  successfulCalls: readonly DelegationValidationToolCall[],
+): string | undefined {
+  if (!specRequiresMeaningfulWorkspaceEvidence(spec)) {
+    return undefined;
+  }
+  const explicitSourceArtifacts = collectExplicitSourceSpecFileArtifacts(spec);
+  if (explicitSourceArtifacts.length > 0) {
+    const observedReadEvidence = collectLatestReadFileStateEvidence(successfulCalls);
+    const hasAllNamedSourceReads = explicitSourceArtifacts.every((target) => {
+      const normalizedTarget = normalizeExplicitArtifactPath(target);
+      const targetBasename = getNormalizedPathBasename(normalizedTarget);
+      return observedReadEvidence.some((entry) => {
+        const normalizedPath = normalizeExplicitArtifactPath(entry.path ?? "");
+        if (normalizedPath.length === 0) {
+          return false;
+        }
+        return pathsMatchByTarget(normalizedPath, normalizedTarget) ||
+          getNormalizedPathBasename(normalizedPath) === targetBasename;
+      });
+    });
+    if (!hasAllNamedSourceReads) {
+      return undefined;
+    }
+  }
+  if (
+    successfulCalls.some((toolCall) =>
+      isMeaningfulWorkspaceInspectionToolCall({
+        toolCall,
+        workspaceRoot: spec.executionContext?.workspaceRoot,
+        targetArtifacts: collectExplicitSpecFileArtifacts(spec),
+        requiredSourceArtifacts: collectExplicitSourceSpecFileArtifacts(spec),
+      })
+    )
+  ) {
+    return undefined;
+  }
+  const hadInspectionAttempt = successfulCalls.some((toolCall) => {
+    const toolName = toolCall.name?.trim() ?? "";
+    return toolName === "system.readFile" ||
+      toolName === "system.listDir" ||
+      toolName === "system.stat" ||
+      toolName === "desktop.text_editor" ||
+      toolName === "system.bash" ||
+      toolName === "desktop.bash";
+  });
+  return hadInspectionAttempt
+    ? "Delegated task required workspace-grounded evidence but the child only inspected the target documentation artifact instead of the current workspace state"
+    : "Delegated task required workspace-grounded evidence but the child recorded no meaningful non-target workspace inspection before completion";
+}
+
 function getMeaningfulBrowserEvidenceFailureMessage(
   spec: DelegationContractSpec,
   successfulCalls: readonly DelegationValidationToolCall[],
@@ -3507,7 +3675,10 @@ function getSuccessfulToolEvidenceFailure(
   spec?: DelegationContractSpec,
   providerEvidence?: DelegationValidationProviderEvidence,
 ): {
-  code: "missing_successful_tool_evidence" | "low_signal_browser_evidence";
+  code:
+    | "missing_successful_tool_evidence"
+    | "low_signal_browser_evidence"
+    | "missing_workspace_inspection_evidence";
   message: string;
 } | undefined {
   if (
@@ -3542,6 +3713,16 @@ function getSuccessfulToolEvidenceFailure(
       return {
         code: "low_signal_browser_evidence",
         message: browserEvidenceFailure,
+      };
+    }
+    const workspaceEvidenceFailure = getMeaningfulWorkspaceEvidenceFailureMessage(
+      spec,
+      successfulCalls,
+    );
+    if (workspaceEvidenceFailure) {
+      return {
+        code: "missing_workspace_inspection_evidence",
+        message: workspaceEvidenceFailure,
       };
     }
   }

--- a/runtime/src/workflow/artifact-paths.ts
+++ b/runtime/src/workflow/artifact-paths.ts
@@ -1,0 +1,22 @@
+const DOC_ONLY_PATH_RE = /\.(?:md|mdx|txt|rst|adoc)$/i;
+const DOC_BASENAME_RE =
+  /(?:^|\/)(?:README|CHANGELOG|CONTRIBUTING|LICENSE|COPYING|NOTES|AGENTS|AGENC|PLAN)(?:\.[^/]+)?$/i;
+
+export function isDocumentationArtifactPath(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return false;
+  }
+  return DOC_ONLY_PATH_RE.test(trimmed) || DOC_BASENAME_RE.test(trimmed);
+}
+
+export function areDocumentationOnlyArtifacts(
+  values: readonly string[],
+): boolean {
+  const normalized = values
+    .filter((value): value is string => typeof value === "string")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+  return normalized.length > 0 &&
+    normalized.every((value) => isDocumentationArtifactPath(value));
+}

--- a/runtime/src/workflow/completion-contract.ts
+++ b/runtime/src/workflow/completion-contract.ts
@@ -8,6 +8,7 @@ export type ImplementationCompletionTaskClass =
 export type PlaceholderTaxonomy =
   | "scaffold"
   | "implementation"
+  | "documentation"
   | "repair";
 
 export interface ImplementationCompletionContract {

--- a/runtime/src/workflow/execution-envelope.ts
+++ b/runtime/src/workflow/execution-envelope.ts
@@ -4,6 +4,10 @@ import {
   normalizeWorkspaceRoot,
 } from "./path-normalization.js";
 import type { ImplementationCompletionContract } from "./completion-contract.js";
+import {
+  canonicalizeExecutionCompletionContract,
+  canonicalizeExecutionStepKind,
+} from "./execution-intent.js";
 
 export type ExecutionEnvelopeVersion = "v1";
 export type ExecutionEffectClass =
@@ -109,6 +113,19 @@ export function createExecutionEnvelope(params: {
     params.targetArtifacts ?? [],
     workspaceRoot,
   );
+  const stepKind = canonicalizeExecutionStepKind({
+    stepKind: params.stepKind,
+    effectClass: params.effectClass,
+    verificationMode: params.verificationMode,
+    targetArtifacts,
+  });
+  const completionContract = canonicalizeExecutionCompletionContract({
+    completionContract: params.completionContract,
+    stepKind,
+    effectClass: params.effectClass,
+    verificationMode: params.verificationMode,
+    targetArtifacts,
+  });
 
   if (
     !workspaceRoot &&
@@ -120,8 +137,8 @@ export function createExecutionEnvelope(params: {
     targetArtifacts.length === 0 &&
     !params.effectClass &&
     !params.verificationMode &&
-    !params.stepKind &&
-    !params.completionContract &&
+    !stepKind &&
+    !completionContract &&
     !params.fallbackPolicy &&
     !params.resumePolicy &&
     !params.approvalProfile
@@ -140,18 +157,18 @@ export function createExecutionEnvelope(params: {
     ...(targetArtifacts.length > 0 ? { targetArtifacts } : {}),
     ...(params.effectClass ? { effectClass: params.effectClass } : {}),
     ...(params.verificationMode ? { verificationMode: params.verificationMode } : {}),
-    ...(params.stepKind ? { stepKind: params.stepKind } : {}),
-    ...(params.completionContract
+    ...(stepKind ? { stepKind } : {}),
+    ...(completionContract
       ? {
         completionContract: {
-          taskClass: params.completionContract.taskClass,
-          placeholdersAllowed: params.completionContract.placeholdersAllowed,
+          taskClass: completionContract.taskClass,
+          placeholdersAllowed: completionContract.placeholdersAllowed,
           partialCompletionAllowed:
-            params.completionContract.partialCompletionAllowed,
-          ...(params.completionContract.placeholderTaxonomy
+            completionContract.partialCompletionAllowed,
+          ...(completionContract.placeholderTaxonomy
             ? {
               placeholderTaxonomy:
-                params.completionContract.placeholderTaxonomy,
+                completionContract.placeholderTaxonomy,
             }
             : {}),
         },

--- a/runtime/src/workflow/execution-intent.ts
+++ b/runtime/src/workflow/execution-intent.ts
@@ -1,0 +1,123 @@
+import { areDocumentationOnlyArtifacts } from "./artifact-paths.js";
+import type { ImplementationCompletionContract } from "./completion-contract.js";
+import type {
+  ExecutionEffectClass,
+  ExecutionStepKind,
+  ExecutionVerificationMode,
+} from "./execution-envelope.js";
+
+export function canonicalizeExecutionStepKind(params: {
+  readonly stepKind?: ExecutionStepKind;
+  readonly effectClass?: ExecutionEffectClass;
+  readonly verificationMode?: ExecutionVerificationMode;
+  readonly targetArtifacts?: readonly string[];
+}): ExecutionStepKind | undefined {
+  const stepKind = params.stepKind;
+  if (!stepKind) {
+    return undefined;
+  }
+  const ownsTargetArtifacts = (params.targetArtifacts?.length ?? 0) > 0;
+  if (!ownsTargetArtifacts) {
+    return stepKind;
+  }
+  const mutationLikeVerification = params.verificationMode === "mutation_required";
+  const writeLikeEffect =
+    params.effectClass === "filesystem_write" ||
+    params.effectClass === "mixed" ||
+    params.effectClass === "shell";
+  const scaffoldLikeEffect = params.effectClass === "filesystem_scaffold";
+  if (
+    stepKind === "delegated_review" &&
+    (mutationLikeVerification || writeLikeEffect || scaffoldLikeEffect)
+  ) {
+    return scaffoldLikeEffect ? "delegated_scaffold" : "delegated_write";
+  }
+  return stepKind;
+}
+
+export function inferCompatibilityCompletionContract(params: {
+  readonly stepKind?: ExecutionStepKind;
+  readonly effectClass?: ExecutionEffectClass;
+  readonly verificationMode: ExecutionVerificationMode;
+  readonly targetArtifacts: readonly string[];
+}): ImplementationCompletionContract | undefined {
+  const stepKind = canonicalizeExecutionStepKind(params);
+  if (stepKind === "delegated_scaffold") {
+    return {
+      taskClass: "scaffold_allowed",
+      placeholdersAllowed: true,
+      partialCompletionAllowed: true,
+      placeholderTaxonomy: "scaffold",
+    };
+  }
+  if (
+    stepKind === "delegated_review" ||
+    stepKind === "delegated_validation"
+  ) {
+    return {
+      taskClass: "review_required",
+      placeholdersAllowed: false,
+      partialCompletionAllowed: false,
+      placeholderTaxonomy: "implementation",
+    };
+  }
+  if (
+    stepKind === "delegated_write" ||
+    (params.verificationMode === "mutation_required" &&
+      params.targetArtifacts.length > 0)
+  ) {
+    const placeholderTaxonomy = areDocumentationOnlyArtifacts(
+      params.targetArtifacts,
+    )
+      ? "documentation"
+      : "implementation";
+    return {
+      taskClass: "artifact_only",
+      placeholdersAllowed: false,
+      partialCompletionAllowed: false,
+      placeholderTaxonomy,
+    };
+  }
+  return undefined;
+}
+
+export function canonicalizeExecutionCompletionContract(params: {
+  readonly completionContract?: ImplementationCompletionContract;
+  readonly stepKind?: ExecutionStepKind;
+  readonly effectClass?: ExecutionEffectClass;
+  readonly verificationMode?: ExecutionVerificationMode;
+  readonly targetArtifacts?: readonly string[];
+}): ImplementationCompletionContract | undefined {
+  const completionContract = params.completionContract;
+  if (!completionContract) {
+    return undefined;
+  }
+  const targetArtifacts = params.targetArtifacts ?? [];
+  const stepKind = canonicalizeExecutionStepKind(params);
+  if (
+    completionContract.taskClass === "review_required" &&
+    stepKind &&
+    stepKind !== "delegated_review" &&
+    stepKind !== "delegated_validation"
+  ) {
+    return inferCompatibilityCompletionContract({
+      stepKind,
+      effectClass: params.effectClass,
+      verificationMode:
+        params.verificationMode ??
+        (targetArtifacts.length > 0 ? "mutation_required" : "none"),
+      targetArtifacts,
+    });
+  }
+  if (
+    completionContract.taskClass === "artifact_only" &&
+    !completionContract.placeholderTaxonomy &&
+    areDocumentationOnlyArtifacts(targetArtifacts)
+  ) {
+    return {
+      ...completionContract,
+      placeholderTaxonomy: "documentation",
+    };
+  }
+  return completionContract;
+}

--- a/runtime/src/workflow/verification-contract.test.ts
+++ b/runtime/src/workflow/verification-contract.test.ts
@@ -49,6 +49,127 @@ describe("verification-contract", () => {
     });
   });
 
+  it("fails workspace-grounded documentation rewrites that never inspect non-target workspace state", () => {
+    const decision = validateRuntimeVerificationContract({
+      verificationContract: {
+        workspaceRoot: "/tmp/project",
+        requiredSourceArtifacts: ["/tmp/project/PLAN.md"],
+        targetArtifacts: ["/tmp/project/PLAN.md"],
+        verificationMode: "mutation_required",
+        acceptanceCriteria: [
+          "PLAN.md reflects the current workspace layout and recent directory changes accurately.",
+        ],
+        completionContract: {
+          taskClass: "artifact_only",
+          placeholdersAllowed: false,
+          partialCompletionAllowed: false,
+          placeholderTaxonomy: "documentation",
+        },
+      },
+      output: "Updated /tmp/project/PLAN.md to reflect the current workspace layout.",
+      toolCalls: [
+        {
+          name: "system.readFile",
+          args: { path: "/tmp/project/PLAN.md" },
+          result: JSON.stringify({
+            path: "/tmp/project/PLAN.md",
+            content: "# PLAN\n",
+          }),
+          isError: false,
+        },
+        {
+          name: "system.writeFile",
+          args: {
+            path: "/tmp/project/PLAN.md",
+            content: "# PLAN\nUpdated\n",
+          },
+          result: JSON.stringify({
+            path: "/tmp/project/PLAN.md",
+            bytesWritten: 16,
+          }),
+          isError: false,
+        },
+      ],
+    });
+
+    expect(decision).toMatchObject({
+      ok: false,
+      diagnostic: {
+        code: "missing_workspace_inspection_evidence",
+      },
+      channels: expect.arrayContaining([
+        expect.objectContaining({
+          channel: "artifact_state",
+          ok: false,
+        }),
+      ]),
+    });
+  });
+
+  it("accepts workspace-grounded documentation rewrites when non-target workspace inspection is recorded", () => {
+    const decision = validateRuntimeVerificationContract({
+      verificationContract: {
+        workspaceRoot: "/tmp/project",
+        requiredSourceArtifacts: ["/tmp/project/PLAN.md"],
+        targetArtifacts: ["/tmp/project/PLAN.md"],
+        verificationMode: "mutation_required",
+        acceptanceCriteria: [
+          "PLAN.md reflects the current workspace layout and recent directory changes accurately.",
+        ],
+        completionContract: {
+          taskClass: "artifact_only",
+          placeholdersAllowed: false,
+          partialCompletionAllowed: false,
+          placeholderTaxonomy: "documentation",
+        },
+      },
+      output: "Updated /tmp/project/PLAN.md to reflect the current workspace layout.",
+      toolCalls: [
+        {
+          name: "system.listDir",
+          args: { path: "/tmp/project/src" },
+          result: JSON.stringify({
+            path: "/tmp/project/src",
+            entries: ["shell.c", "parser.c"],
+          }),
+          isError: false,
+        },
+        {
+          name: "system.readFile",
+          args: { path: "/tmp/project/PLAN.md" },
+          result: JSON.stringify({
+            path: "/tmp/project/PLAN.md",
+            content: "# PLAN\n",
+          }),
+          isError: false,
+        },
+        {
+          name: "system.writeFile",
+          args: {
+            path: "/tmp/project/PLAN.md",
+            content:
+              "# PLAN\nCurrent workspace layout includes src/shell.c and src/parser.c.\n",
+          },
+          result: JSON.stringify({
+            path: "/tmp/project/PLAN.md",
+            bytesWritten: 70,
+          }),
+          isError: false,
+        },
+      ],
+    });
+
+    expect(decision).toMatchObject({
+      ok: true,
+      channels: expect.arrayContaining([
+        expect.objectContaining({
+          channel: "artifact_state",
+          ok: true,
+        }),
+      ]),
+    });
+  });
+
   it("fails placeholder/stub grading when implementation content still contains stub markers", () => {
     const decision = validateRuntimeVerificationContract({
       verificationContract: {
@@ -484,6 +605,147 @@ describe("verification-contract", () => {
         expect.objectContaining({
           channel: "rubric",
           ok: false,
+        }),
+      ]),
+    });
+  });
+
+  it("allows documentation rewrites that accurately describe stubbed or pending code", () => {
+    const decision = validateRuntimeVerificationContract({
+      verificationContract: {
+        workspaceRoot: "/tmp/project",
+        targetArtifacts: ["/tmp/project/PLAN.md"],
+        verificationMode: "mutation_required",
+        completionContract: {
+          taskClass: "artifact_only",
+          placeholdersAllowed: false,
+          partialCompletionAllowed: false,
+          placeholderTaxonomy: "documentation",
+        },
+      },
+      output: "Updated PLAN.md to reflect the current stubbed modules and pending parser work.",
+      toolCalls: [
+        {
+          name: "system.writeFile",
+          args: {
+            path: "/tmp/project/PLAN.md",
+            content:
+              "# Plan\n\nCurrent state: parser and dispatcher are still stub implementations. Remaining work is pending behind the next milestone.\n",
+          },
+          result: JSON.stringify({
+            path: "/tmp/project/PLAN.md",
+            bytesWritten: 124,
+          }),
+          isError: false,
+        },
+      ],
+    });
+
+    expect(decision).toMatchObject({
+      ok: true,
+      channels: expect.arrayContaining([
+        expect.objectContaining({
+          channel: "placeholder_stub",
+          ok: true,
+        }),
+      ]),
+    });
+  });
+
+  it("fails documentation rewrites that keep shorthand placeholder elisions", () => {
+    const decision = validateRuntimeVerificationContract({
+      verificationContract: {
+        workspaceRoot: "/tmp/project",
+        targetArtifacts: ["/tmp/project/PLAN.md"],
+        verificationMode: "mutation_required",
+        completionContract: {
+          taskClass: "artifact_only",
+          placeholdersAllowed: false,
+          partialCompletionAllowed: false,
+          placeholderTaxonomy: "documentation",
+        },
+      },
+      output: "Updated PLAN.md completely.",
+      toolCalls: [
+        {
+          name: "system.writeFile",
+          args: {
+            path: "/tmp/project/PLAN.md",
+            content:
+              "# Plan\n\n[Same as original, copied here]\n\n[etc., full content from original plan]\n",
+          },
+          result: JSON.stringify({
+            path: "/tmp/project/PLAN.md",
+            bytesWritten: 80,
+          }),
+          isError: false,
+        },
+      ],
+    });
+
+    expect(decision).toMatchObject({
+      ok: false,
+      diagnostic: {
+        code: "contradictory_completion_claim",
+      },
+      channels: expect.arrayContaining([
+        expect.objectContaining({
+          channel: "placeholder_stub",
+          ok: false,
+          message: expect.stringContaining("Documentation completion"),
+        }),
+      ]),
+    });
+  });
+
+  it("does not treat TODO.md source artifact paths as unresolved documentation placeholders", () => {
+    const decision = validateRuntimeVerificationContract({
+      verificationContract: {
+        workspaceRoot: "/tmp/project",
+        targetArtifacts: ["/tmp/project/PLAN.md"],
+        verificationMode: "mutation_required",
+        completionContract: {
+          taskClass: "artifact_only",
+          placeholdersAllowed: false,
+          partialCompletionAllowed: false,
+          placeholderTaxonomy: "documentation",
+        },
+      },
+      output:
+        'result_1: {"path":"/tmp/project/TODO.md","size":849}\n' +
+        'result_2: {"path":"/tmp/project/PLAN.md","bytesWritten":16}',
+      toolCalls: [
+        {
+          name: "system.readFile",
+          args: { path: "/tmp/project/TODO.md" },
+          result: JSON.stringify({
+            path: "/tmp/project/TODO.md",
+            content: "- shell parser\n- job control\n",
+          }),
+          isError: false,
+        },
+        {
+          name: "system.writeFile",
+          args: {
+            path: "/tmp/project/PLAN.md",
+            content:
+              "# Plan\n\nImplement the shell parser and job control in the next two phases.\n",
+          },
+          result: JSON.stringify({
+            path: "/tmp/project/PLAN.md",
+            bytesWritten: 76,
+          }),
+          isError: false,
+        },
+      ],
+    });
+
+    expect(decision).toMatchObject({
+      ok: true,
+      channels: expect.arrayContaining([
+        expect.objectContaining({
+          channel: "placeholder_stub",
+          ok: true,
         }),
       ]),
     });

--- a/runtime/src/workflow/verification-contract.ts
+++ b/runtime/src/workflow/verification-contract.ts
@@ -8,7 +8,9 @@ import {
   getAcceptanceVerificationCategories,
 } from "../utils/delegation-validation.js";
 import { isArtifactAccessAllowed } from "./artifact-contract.js";
+import type { PlaceholderTaxonomy } from "./completion-contract.js";
 import { isPathWithinRoot, normalizeEnvelopePath } from "./path-normalization.js";
+import { isMeaningfulWorkspaceInspectionToolCall } from "./workspace-inspection-evidence.js";
 import {
   deriveVerificationObligations,
   hasDelegationRuntimeVerificationContext,
@@ -67,6 +69,7 @@ interface EncodedVerificationMetadata {
 interface RuntimeArtifactEvidence {
   readonly readArtifacts: ReadonlySet<string>;
   readonly readArtifactContents: ReadonlyMap<string, readonly string[]>;
+  readonly inspectedWorkspaceArtifacts: ReadonlySet<string>;
   readonly mutatedArtifacts: ReadonlySet<string>;
   readonly unauthorizedMutations: readonly string[];
   readonly successfulToolCalls: number;
@@ -87,6 +90,15 @@ interface RuntimeArtifactEvidence {
 }
 
 const READ_FILE_TOOL_NAMES = new Set(["system.readFile"]);
+const WORKSPACE_INSPECTION_TOOL_NAMES = new Set([
+  "system.readFile",
+  "system.listDir",
+  "system.stat",
+  "desktop.text_editor",
+  "mcp.neovim.vim_edit",
+  "mcp.neovim.vim_buffer_save",
+  "mcp.neovim.vim_search_replace",
+]);
 const DIRECT_MUTATION_TOOL_NAMES = new Set([
   "desktop.text_editor",
   "system.appendFile",
@@ -98,10 +110,14 @@ const DIRECT_MUTATION_TOOL_NAMES = new Set([
 const SHELL_TOOL_NAMES = new Set(["system.bash", "desktop.bash"]);
 const NOOP_COMPLETION_RE =
   /\b(?:already (?:satisf(?:ies|y)|exists?|present|up to date)|no (?:changes?|mutation|update)s? (?:needed|required)|nothing to change|no edits? needed)\b/i;
-const PLACEHOLDER_MARKER_RE =
+const IMPLEMENTATION_PLACEHOLDER_MARKER_RE =
   /\b(?:stub(?:bed)?|placeholder|todo|not implemented|unimplemented|pending implementation|coming soon|fixme)\b/i;
-const RESOLVED_PLACEHOLDER_CUE_RE =
+const DOCUMENTATION_PLACEHOLDER_MARKER_RE =
+  /\b(?:placeholder|todo|fixme|tbd|coming soon)\b|\[(?:same\b|etc\.?\b|omitted\b|truncated\b|cop(?:y|ied)\b|unchanged\b|full content\b)[^\]]*\]/i;
+const IMPLEMENTATION_RESOLVED_PLACEHOLDER_CUE_RE =
   /\b(?:resolve(?:d|s|ing)?|replace(?:d|s|ing)?|remove(?:d|s|ing)?|clear(?:ed|s|ing)?|fix(?:ed|es|ing)?|complete(?:d|s|ing)?)\b[^.\n]{0,64}\b(?:placeholder(?:s)?|stub(?:s|bed)?|todo|fixme|unimplemented)\b|\b(?:placeholder(?:s)?|stub(?:s|bed)?|todo|fixme|unimplemented)\b[^.\n]{0,64}\b(?:resolve(?:d|s|ing)?|replace(?:d|s|ing)?|remove(?:d|s|ing)?|clear(?:ed|s|ing)?|fix(?:ed|es|ing)?|complete(?:d|s|ing)?)\b/i;
+const DOCUMENTATION_RESOLVED_PLACEHOLDER_CUE_RE =
+  /\b(?:resolve(?:d|s|ing)?|replace(?:d|s|ing)?|remove(?:d|s|ing)?|clear(?:ed|s|ing)?|fix(?:ed|es|ing)?|complete(?:d|s|ing)?)\b[^.\n]{0,64}\b(?:placeholder(?:s)?|todo|fixme|tbd)\b|\b(?:placeholder(?:s)?|todo|fixme|tbd)\b[^.\n]{0,64}\b(?:resolve(?:d|s|ing)?|replace(?:d|s|ing)?|remove(?:d|s|ing)?|clear(?:ed|s|ing)?|fix(?:ed|es|ing)?|complete(?:d|s|ing)?)\b/i;
 const BUILD_SIGNAL_RE =
   /\b(?:build|compile|compiled|compiles|compiling|typecheck|typechecked|lint|linted|install|installed|tsc)\b/i;
 const TEST_SIGNAL_RE =
@@ -263,6 +279,18 @@ function evaluateArtifactStateChannel(params: {
     }
   }
 
+  if (
+    params.obligations.requiresWorkspaceInspectionEvidence &&
+    params.evidence.inspectedWorkspaceArtifacts.size === 0
+  ) {
+    return verificationChannelFail({
+      channel: "artifact_state",
+      code: "missing_workspace_inspection_evidence",
+      message:
+        "Execution required grounded inspection of current workspace state before deriving the updated artifact, but no non-target workspace inspection evidence was observed.",
+    });
+  }
+
   if (!params.obligations.requiresMutationEvidence) {
     if (params.hasGroundedNoop && !params.targetReadSatisfied) {
       const unreadTargets = params.obligations.artifactContract.targetArtifacts
@@ -331,11 +359,14 @@ function evaluatePlaceholderStubChannel(params: {
   }
 
   if (placeholderHits.length > 0) {
+    const placeholderConfig = getPlaceholderTaxonomyConfig(
+      params.obligations.placeholderTaxonomy,
+    );
     return verificationChannelFail({
       channel: "placeholder_stub",
       code: "contradictory_completion_claim",
       message:
-        "Implementation completion was claimed while placeholder or stub markers remained in authored evidence: " +
+        `${placeholderConfig.completionLabel} completion was claimed while ${placeholderConfig.unresolvedLabel} remained in authored evidence: ` +
         placeholderHits.slice(0, 3).join("; "),
       evidence: placeholderHits.slice(0, 3),
     });
@@ -343,7 +374,8 @@ function evaluatePlaceholderStubChannel(params: {
 
   return verificationChannelPass({
     channel: "placeholder_stub",
-    message: "No unresolved placeholder or stub markers were found in authored evidence.",
+    message: getPlaceholderTaxonomyConfig(params.obligations.placeholderTaxonomy)
+      .passMessage,
   });
 }
 
@@ -352,12 +384,15 @@ function evaluateRepairPlaceholderChannel(params: {
   readonly evidence: RuntimeArtifactEvidence;
   readonly placeholderHits: readonly string[];
 }): RuntimeVerificationChannelDecision | undefined {
+  const placeholderConfig = getPlaceholderTaxonomyConfig(
+    params.obligations.placeholderTaxonomy,
+  );
   const targetArtifacts = params.obligations.artifactContract.targetArtifacts;
   const baselineTargetReads = targetArtifacts.flatMap((artifact) =>
     params.evidence.readArtifactContents.get(artifact) ?? []
   );
   const baselineContainsPlaceholders =
-    baselineTargetReads.some((value) => PLACEHOLDER_MARKER_RE.test(value));
+    baselineTargetReads.some((value) => placeholderConfig.markerRe.test(value));
 
   if (!baselineContainsPlaceholders) {
     if (params.placeholderHits.length > 0) {
@@ -365,7 +400,7 @@ function evaluateRepairPlaceholderChannel(params: {
         channel: "placeholder_stub",
         code: "contradictory_completion_claim",
         message:
-          "Repair work introduced new placeholder or stub markers into artifacts that were previously concrete: " +
+          `Repair work introduced new ${placeholderConfig.unresolvedLabel} into artifacts that were previously concrete: ` +
           params.placeholderHits.slice(0, 3).join("; "),
         evidence: params.placeholderHits.slice(0, 3),
       });
@@ -382,7 +417,7 @@ function evaluateRepairPlaceholderChannel(params: {
       channel: "placeholder_stub",
       code: "contradictory_completion_claim",
       message:
-        "Repair work preserved unresolved placeholder or stub markers from the baseline artifacts: " +
+        `Repair work preserved unresolved ${placeholderConfig.unresolvedLabel} from the baseline artifacts: ` +
         params.placeholderHits.slice(0, 3).join("; "),
       evidence: params.placeholderHits.slice(0, 3),
     });
@@ -549,6 +584,7 @@ function collectRuntimeArtifactEvidence(params: {
 }): RuntimeArtifactEvidence {
   const readArtifacts = new Set<string>();
   const readArtifactContents = new Map<string, string[]>();
+  const inspectedWorkspaceArtifacts = new Set<string>();
   const mutatedArtifacts = new Set<string>();
   const unauthorizedMutations = new Set<string>();
   const authoredContent: string[] = [];
@@ -582,6 +618,22 @@ function collectRuntimeArtifactEvidence(params: {
     successfulToolCalls += 1;
     evidenceCorpus.push(...collectToolCallEvidenceStrings(toolCall));
     const directPaths = collectDirectArtifactPaths(toolCall, params.obligations.workspaceRoot);
+    if (
+      isMeaningfulWorkspaceInspectionToolCall({
+        toolCall,
+        workspaceRoot: params.obligations.workspaceRoot,
+        targetArtifacts: params.obligations.artifactContract.targetArtifacts,
+        requiredSourceArtifacts:
+          params.obligations.artifactContract.requiredSourceArtifacts,
+      })
+    ) {
+      for (const path of collectInspectionArtifactPaths(
+        toolCall,
+        params.obligations.workspaceRoot,
+      )) {
+        inspectedWorkspaceArtifacts.add(path);
+      }
+    }
     if (READ_FILE_TOOL_NAMES.has(toolCall.name?.trim() ?? "")) {
       for (const path of directPaths) {
         readArtifacts.add(path);
@@ -645,6 +697,7 @@ function collectRuntimeArtifactEvidence(params: {
   return {
     readArtifacts,
     readArtifactContents,
+    inspectedWorkspaceArtifacts,
     mutatedArtifacts,
     unauthorizedMutations: [...unauthorizedMutations],
     successfulToolCalls,
@@ -697,6 +750,31 @@ function collectDirectArtifactPaths(
     pushPathCandidate(candidates, parsedResult?.path, workspaceRoot);
   }
 
+  return [...new Set(candidates)];
+}
+
+function collectInspectionArtifactPaths(
+  toolCall: DelegationValidationToolCall,
+  workspaceRoot?: string,
+): readonly string[] {
+  const toolName = typeof toolCall.name === "string" ? toolCall.name.trim() : "";
+  if (
+    !WORKSPACE_INSPECTION_TOOL_NAMES.has(toolName) &&
+    !SHELL_TOOL_NAMES.has(toolName)
+  ) {
+    return [];
+  }
+  const args =
+    toolCall.args && typeof toolCall.args === "object" && !Array.isArray(toolCall.args)
+      ? (toolCall.args as Record<string, unknown>)
+      : {};
+  const parsedResult = parseResultObject(toolCall.result);
+  const candidates: string[] = [];
+  pushPathCandidate(candidates, args.path, workspaceRoot);
+  pushPathCandidate(candidates, args.source, workspaceRoot);
+  pushPathCandidate(candidates, args.destination, workspaceRoot);
+  pushPathCandidate(candidates, args.cwd, workspaceRoot);
+  pushPathCandidate(candidates, parsedResult?.path, workspaceRoot);
   return [...new Set(candidates)];
 }
 
@@ -805,15 +883,25 @@ function collectPlaceholderEvidence(params: {
   readonly output: string;
   readonly parsedOutput?: Record<string, unknown>;
 }): readonly string[] {
+  const placeholderConfig = getPlaceholderTaxonomyConfig(
+    params.obligations.placeholderTaxonomy,
+  );
   const rawValues = [
-    params.output,
-    ...collectStringValues(params.parsedOutput),
+    ...(params.obligations.placeholderTaxonomy === "documentation"
+      ? []
+      : [params.output]),
+    ...collectStringValues(params.parsedOutput).filter((value) =>
+      !(
+        params.obligations.placeholderTaxonomy === "documentation" &&
+        isLikelyFilesystemPathValue(value)
+      )
+    ),
     ...params.evidence.authoredContent,
   ];
   const matches: string[] = [];
   for (const value of rawValues) {
     const trimmed = value.trim();
-    if (!trimmed || !PLACEHOLDER_MARKER_RE.test(trimmed)) {
+    if (!trimmed || !placeholderConfig.markerRe.test(trimmed)) {
       continue;
     }
     if (
@@ -822,12 +910,56 @@ function collectPlaceholderEvidence(params: {
     ) {
       continue;
     }
-    if (RESOLVED_PLACEHOLDER_CUE_RE.test(trimmed)) {
+    if (placeholderConfig.resolvedCueRe.test(trimmed)) {
       continue;
     }
     matches.push(trimmed.slice(0, 160));
   }
   return [...new Set(matches)];
+}
+
+function isLikelyFilesystemPathValue(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || /\s/.test(trimmed)) {
+    return false;
+  }
+  return (
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("./") ||
+    trimmed.startsWith("../") ||
+    /^[a-zA-Z]:[\\/]/.test(trimmed) ||
+    /^(?:[^\\/]+[\\/])+[^\\/]+$/.test(trimmed) ||
+    /^[^\\/]+\.[a-z0-9]+$/i.test(trimmed)
+  );
+}
+
+function getPlaceholderTaxonomyConfig(
+  taxonomy: PlaceholderTaxonomy,
+): {
+  readonly markerRe: RegExp;
+  readonly resolvedCueRe: RegExp;
+  readonly completionLabel: string;
+  readonly unresolvedLabel: string;
+  readonly passMessage: string;
+} {
+  if (taxonomy === "documentation") {
+    return {
+      markerRe: DOCUMENTATION_PLACEHOLDER_MARKER_RE,
+      resolvedCueRe: DOCUMENTATION_RESOLVED_PLACEHOLDER_CUE_RE,
+      completionLabel: "Documentation",
+      unresolvedLabel: "shorthand placeholders or TODO markers",
+      passMessage:
+        "No unresolved shorthand placeholders or TODO markers were found in authored documentation evidence.",
+    };
+  }
+  return {
+    markerRe: IMPLEMENTATION_PLACEHOLDER_MARKER_RE,
+    resolvedCueRe: IMPLEMENTATION_RESOLVED_PLACEHOLDER_CUE_RE,
+    completionLabel: "Implementation",
+    unresolvedLabel: "placeholder or stub markers",
+    passMessage:
+      "No unresolved placeholder or stub markers were found in authored evidence.",
+  };
 }
 
 function rubricCriterionSatisfied(
@@ -863,6 +995,7 @@ function summarizeArtifactEvidence(
 ): readonly string[] {
   return [
     ...[...evidence.readArtifacts].slice(0, 2),
+    ...[...evidence.inspectedWorkspaceArtifacts].slice(0, 2),
     ...[...evidence.mutatedArtifacts].slice(0, 2),
   ];
 }

--- a/runtime/src/workflow/verification-obligations.test.ts
+++ b/runtime/src/workflow/verification-obligations.test.ts
@@ -105,6 +105,31 @@ describe("verification-obligations", () => {
     });
   });
 
+  it("treats current-workspace alignment criteria as workspace inspection requirements", () => {
+    const obligations = deriveVerificationObligations({
+      workspaceRoot: "/tmp/project",
+      requiredSourceArtifacts: ["/tmp/project/PLAN.md"],
+      targetArtifacts: ["/tmp/project/PLAN.md"],
+      acceptanceCriteria: [
+        "PLAN.md reflects the current workspace layout and recent directory changes accurately.",
+      ],
+      verificationMode: "mutation_required",
+      completionContract: {
+        taskClass: "artifact_only",
+        placeholdersAllowed: false,
+        partialCompletionAllowed: false,
+      },
+    });
+
+    expect(obligations).toMatchObject({
+      requiresWorkspaceInspectionEvidence: true,
+      requiresSourceArtifactReads: true,
+      completionContract: {
+        taskClass: "artifact_only",
+      },
+    });
+  });
+
   it("preserves explicit repair placeholder taxonomy from the completion contract", () => {
     const obligations = deriveVerificationObligations({
       workspaceRoot: "/tmp/project",
@@ -122,6 +147,46 @@ describe("verification-obligations", () => {
       placeholderTaxonomy: "repair",
       completionContract: {
         placeholderTaxonomy: "repair",
+      },
+    });
+  });
+
+  it("uses documentation placeholder defaults for delegated documentation writes", () => {
+    const obligations = deriveVerificationObligations({
+      workspaceRoot: "/tmp/project",
+      targetArtifacts: ["/tmp/project/PLAN.md"],
+      stepKind: "delegated_write",
+      verificationMode: "mutation_required",
+    });
+
+    expect(obligations).toMatchObject({
+      requiresMutationEvidence: true,
+      placeholderTaxonomy: "documentation",
+      placeholdersAllowed: false,
+      partialCompletionAllowed: false,
+      completionContract: {
+        taskClass: "artifact_only",
+        placeholderTaxonomy: "documentation",
+      },
+    });
+  });
+
+  it("infers documentation taxonomy for explicit artifact-only contracts on doc targets", () => {
+    const obligations = deriveVerificationObligations({
+      workspaceRoot: "/tmp/project",
+      targetArtifacts: ["/tmp/project/PLAN.md"],
+      verificationMode: "mutation_required",
+      completionContract: {
+        taskClass: "artifact_only",
+        placeholdersAllowed: false,
+        partialCompletionAllowed: false,
+      },
+    });
+
+    expect(obligations).toMatchObject({
+      placeholderTaxonomy: "documentation",
+      completionContract: {
+        taskClass: "artifact_only",
       },
     });
   });

--- a/runtime/src/workflow/verification-obligations.ts
+++ b/runtime/src/workflow/verification-obligations.ts
@@ -4,11 +4,14 @@ import type {
   ImplementationCompletionContract,
   PlaceholderTaxonomy,
 } from "./completion-contract.js";
+import { areDocumentationOnlyArtifacts } from "./artifact-paths.js";
 import type { WorkflowRequestCompletionContract } from "./request-completion.js";
 import type {
   ExecutionStepKind,
   ExecutionVerificationMode,
 } from "./execution-envelope.js";
+import { inferCompatibilityCompletionContract } from "./execution-intent.js";
+import { criterionRequiresWorkspaceInspectionVerification } from "./workspace-inspection-evidence.js";
 
 export interface WorkflowVerificationContract {
   readonly workspaceRoot?: string;
@@ -33,6 +36,7 @@ export interface VerificationObligations {
   readonly requiresBuildVerification: boolean;
   readonly requiresBehaviorVerification: boolean;
   readonly requiresReviewVerification: boolean;
+  readonly requiresWorkspaceInspectionEvidence: boolean;
   readonly requiresMutationEvidence: boolean;
   readonly requiresSourceArtifactReads: boolean;
   readonly requiresTargetAuthorization: boolean;
@@ -111,6 +115,10 @@ export function deriveVerificationObligations(
     acceptanceCriteria.some((criterion) => criterionRequiresBehaviorVerification(criterion));
   const acceptanceCriteriaRequireBuild =
     acceptanceCriteria.some((criterion) => criterionRequiresBuildVerification(criterion));
+  const acceptanceCriteriaRequireWorkspaceInspection =
+    acceptanceCriteria.some((criterion) =>
+      criterionRequiresWorkspaceInspectionVerification(criterion)
+    );
   const requiresBuildVerification =
     completionContract?.taskClass === "build_required" ||
     completionContract?.taskClass === "behavior_required" ||
@@ -121,6 +129,8 @@ export function deriveVerificationObligations(
     acceptanceCriteriaRequireBehavior;
   const requiresReviewVerification =
     completionContract?.taskClass === "review_required";
+  const requiresWorkspaceInspectionEvidence =
+    acceptanceCriteriaRequireWorkspaceInspection;
   const requiresMutationEvidence =
     completionContract?.taskClass === "review_required"
       ? false
@@ -140,6 +150,7 @@ export function deriveVerificationObligations(
     inferPlaceholderTaxonomy({
       completionContract,
       stepKind,
+      targetArtifacts,
     });
 
   return {
@@ -156,10 +167,12 @@ export function deriveVerificationObligations(
     requiresBuildVerification,
     requiresBehaviorVerification,
     requiresReviewVerification,
+    requiresWorkspaceInspectionEvidence,
     requiresMutationEvidence,
     requiresSourceArtifactReads:
       verificationMode === "grounded_read" ||
       requiresReviewVerification ||
+      requiresWorkspaceInspectionEvidence ||
       requiresMutationEvidence ||
       requiredSourceArtifacts.length > 0,
     requiresTargetAuthorization: targetArtifacts.length > 0,
@@ -229,48 +242,10 @@ function inferVerificationMode(
   return "none";
 }
 
-function inferCompatibilityCompletionContract(params: {
-  readonly stepKind?: ExecutionStepKind;
-  readonly verificationMode: ExecutionVerificationMode;
-  readonly targetArtifacts: readonly string[];
-}): ImplementationCompletionContract | undefined {
-  if (params.stepKind === "delegated_scaffold") {
-    return {
-      taskClass: "scaffold_allowed",
-      placeholdersAllowed: true,
-      partialCompletionAllowed: true,
-      placeholderTaxonomy: "scaffold",
-    };
-  }
-  if (
-    params.stepKind === "delegated_review" ||
-    params.stepKind === "delegated_validation"
-  ) {
-    return {
-      taskClass: "review_required",
-      placeholdersAllowed: false,
-      partialCompletionAllowed: false,
-      placeholderTaxonomy: "implementation",
-    };
-  }
-  if (
-    params.stepKind === "delegated_write" ||
-    (params.verificationMode === "mutation_required" &&
-      params.targetArtifacts.length > 0)
-  ) {
-    return {
-      taskClass: "artifact_only",
-      placeholdersAllowed: false,
-      partialCompletionAllowed: false,
-      placeholderTaxonomy: "implementation",
-    };
-  }
-  return undefined;
-}
-
 function inferPlaceholderTaxonomy(params: {
   readonly completionContract?: ImplementationCompletionContract;
   readonly stepKind?: ExecutionStepKind;
+  readonly targetArtifacts?: readonly string[];
 }): PlaceholderTaxonomy {
   if (params.completionContract?.placeholderTaxonomy) {
     return params.completionContract.placeholderTaxonomy;
@@ -280,6 +255,12 @@ function inferPlaceholderTaxonomy(params: {
     params.stepKind === "delegated_scaffold"
   ) {
     return "scaffold";
+  }
+  if (
+    params.completionContract?.taskClass === "artifact_only" &&
+    areDocumentationOnlyArtifacts(params.targetArtifacts ?? [])
+  ) {
+    return "documentation";
   }
   return "implementation";
 }

--- a/runtime/src/workflow/workspace-inspection-evidence.ts
+++ b/runtime/src/workflow/workspace-inspection-evidence.ts
@@ -1,0 +1,237 @@
+import { areDocumentationOnlyArtifacts } from "./artifact-paths.js";
+import {
+  isPathWithinRoot,
+  normalizeEnvelopePath,
+  normalizeWorkspaceRoot,
+} from "./path-normalization.js";
+
+interface ToolCallLike {
+  readonly name?: string;
+  readonly args?: unknown;
+  readonly result?: string;
+  readonly isError?: boolean;
+}
+
+const WORKSPACE_AUDIT_VERB_RE =
+  /\b(?:review|audit|inspect|assess|evaluate|verify|compare|check|analy[sz]e|map|survey|inventory|trace)\b/i;
+const WORKSPACE_TARGET_NOUN_RE =
+  /\b(?:repo(?:sitory)?|codebase|workspace|source tree|directory|directories|layout|structure|implementation|files?|folders?)\b/i;
+const WORKSPACE_CHANGE_PHRASE_RE =
+  /\b(?:repo(?:sitory)?|codebase|workspace|directory|directories|layout|structure|implementation|code|files?|folders?)\s+changes?\b/i;
+const WORKSPACE_STATE_PHRASE_RE =
+  /\b(?:state\s+of\s+(?:the\s+)?(?:repo(?:sitory)?|codebase|workspace|implementation)|(?:repo(?:sitory)?|codebase|workspace|implementation)\s+state)\b/i;
+const WORKSPACE_AUDIT_TARGET_RE = new RegExp(
+  `${WORKSPACE_TARGET_NOUN_RE.source}|${WORKSPACE_CHANGE_PHRASE_RE.source}|${WORKSPACE_STATE_PHRASE_RE.source}`,
+  "i",
+);
+const CURRENT_WORKSPACE_STATE_RE = new RegExp(
+  String.raw`\b(?:current|existing|actual|live|recent)\s+(?:${WORKSPACE_TARGET_NOUN_RE.source}|${WORKSPACE_CHANGE_PHRASE_RE.source}|${WORKSPACE_STATE_PHRASE_RE.source})`,
+  "i",
+);
+const WORKSPACE_ALIGNMENT_RE = new RegExp(
+  String.raw`\b(?:reflect(?:s)?|align(?:s)?|match(?:es)?|correspond(?:s)?)\b[\s\S]{0,96}(?:\b(?:current|existing|actual|live|recent)\b[\s\S]{0,48})?(?:${WORKSPACE_TARGET_NOUN_RE.source}|${WORKSPACE_CHANGE_PHRASE_RE.source}|${WORKSPACE_STATE_PHRASE_RE.source})`,
+  "i",
+);
+const SHELL_WORKSPACE_INSPECTION_COMMAND_RE =
+  /\b(?:ls|find|tree|rg|ripgrep|git\s+(?:status|diff|ls-files)|stat)\b/i;
+const DIRECT_WORKSPACE_INSPECTION_TOOL_NAMES = new Set([
+  "system.readFile",
+  "system.listDir",
+  "system.stat",
+  "desktop.text_editor",
+  "mcp.neovim.vim_edit",
+  "mcp.neovim.vim_buffer_save",
+  "mcp.neovim.vim_search_replace",
+]);
+const SHELL_WORKSPACE_INSPECTION_TOOL_NAMES = new Set([
+  "system.bash",
+  "desktop.bash",
+]);
+
+export function textRequiresWorkspaceGroundedArtifactUpdate(
+  value: string,
+): boolean {
+  const normalized = value.trim().replace(/[_-]+/g, " ");
+  if (normalized.length === 0) {
+    return false;
+  }
+  return (
+    (WORKSPACE_AUDIT_VERB_RE.test(normalized) &&
+      WORKSPACE_AUDIT_TARGET_RE.test(normalized)) ||
+    CURRENT_WORKSPACE_STATE_RE.test(normalized) ||
+    WORKSPACE_ALIGNMENT_RE.test(normalized)
+  );
+}
+
+export function criterionRequiresWorkspaceInspectionVerification(
+  criterion: string,
+): boolean {
+  const normalized = criterion.trim();
+  if (normalized.length === 0) {
+    return false;
+  }
+  return textRequiresWorkspaceGroundedArtifactUpdate(normalized);
+}
+
+function parseToolCallArgs(toolCall: ToolCallLike): Record<string, unknown> {
+  return toolCall.args &&
+      typeof toolCall.args === "object" &&
+      !Array.isArray(toolCall.args)
+    ? (toolCall.args as Record<string, unknown>)
+    : {};
+}
+
+function parseToolCallResult(toolCall: ToolCallLike): Record<string, unknown> | undefined {
+  if (typeof toolCall.result !== "string" || toolCall.result.trim().length === 0) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(toolCall.result) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function pushPathCandidate(
+  results: Set<string>,
+  rawValue: unknown,
+  workspaceRoot?: string,
+): void {
+  if (typeof rawValue !== "string") {
+    return;
+  }
+  const trimmed = rawValue.trim();
+  if (trimmed.length === 0) {
+    return;
+  }
+  const normalized = normalizeEnvelopePath(trimmed, workspaceRoot);
+  if (normalized.length > 0) {
+    results.add(normalized);
+  }
+}
+
+function pathMatchesArtifact(
+  path: string,
+  artifact: string,
+  workspaceRoot?: string,
+): boolean {
+  const normalizedPath = normalizeEnvelopePath(path, workspaceRoot);
+  const normalizedArtifact = normalizeEnvelopePath(artifact, workspaceRoot);
+  return normalizedPath === normalizedArtifact ||
+    normalizedPath.endsWith(`/${normalizedArtifact}`) ||
+    normalizedArtifact.endsWith(`/${normalizedPath}`);
+}
+
+function pathExcludedFromWorkspaceInspection(params: {
+  readonly path: string;
+  readonly workspaceRoot?: string;
+  readonly targetArtifacts: readonly string[];
+  readonly requiredSourceArtifacts: readonly string[];
+}): boolean {
+  if (
+    params.targetArtifacts.some((artifact) =>
+      pathMatchesArtifact(params.path, artifact, params.workspaceRoot)
+    )
+  ) {
+    return true;
+  }
+  return params.requiredSourceArtifacts
+    .filter((artifact) => areDocumentationOnlyArtifacts([artifact]))
+    .some((artifact) =>
+      pathMatchesArtifact(params.path, artifact, params.workspaceRoot)
+    );
+}
+
+function collectWorkspaceInspectionPathCandidates(params: {
+  readonly toolCall: ToolCallLike;
+  readonly workspaceRoot?: string;
+}): readonly string[] {
+  const args = parseToolCallArgs(params.toolCall);
+  const parsedResult = parseToolCallResult(params.toolCall);
+  const candidates = new Set<string>();
+  pushPathCandidate(candidates, args.path, params.workspaceRoot);
+  pushPathCandidate(candidates, args.source, params.workspaceRoot);
+  pushPathCandidate(candidates, args.destination, params.workspaceRoot);
+  pushPathCandidate(candidates, args.cwd, params.workspaceRoot);
+  pushPathCandidate(candidates, parsedResult?.path, params.workspaceRoot);
+  return [...candidates];
+}
+
+function isMeaningfulInspectionPath(params: {
+  readonly path: string;
+  readonly workspaceRoot?: string;
+  readonly targetArtifacts: readonly string[];
+  readonly requiredSourceArtifacts: readonly string[];
+}): boolean {
+  const normalizedPath = normalizeEnvelopePath(params.path, params.workspaceRoot);
+  if (normalizedPath.length === 0) {
+    return false;
+  }
+  if (
+    params.workspaceRoot &&
+    !isPathWithinRoot(normalizedPath, params.workspaceRoot) &&
+    normalizedPath !== normalizeWorkspaceRoot(params.workspaceRoot)
+  ) {
+    return false;
+  }
+  return !pathExcludedFromWorkspaceInspection({
+    path: normalizedPath,
+    workspaceRoot: params.workspaceRoot,
+    targetArtifacts: params.targetArtifacts,
+    requiredSourceArtifacts: params.requiredSourceArtifacts,
+  });
+}
+
+export function isMeaningfulWorkspaceInspectionToolCall(params: {
+  readonly toolCall: ToolCallLike;
+  readonly workspaceRoot?: string;
+  readonly targetArtifacts?: readonly string[];
+  readonly requiredSourceArtifacts?: readonly string[];
+}): boolean {
+  if (params.toolCall.isError === true) {
+    return false;
+  }
+  const toolName = params.toolCall.name?.trim() ?? "";
+  if (toolName.length === 0) {
+    return false;
+  }
+  const targetArtifacts = params.targetArtifacts ?? [];
+  const requiredSourceArtifacts = params.requiredSourceArtifacts ?? [];
+  const pathCandidates = collectWorkspaceInspectionPathCandidates({
+    toolCall: params.toolCall,
+    workspaceRoot: params.workspaceRoot,
+  });
+  const hasMeaningfulPath = pathCandidates.some((path) =>
+    isMeaningfulInspectionPath({
+      path,
+      workspaceRoot: params.workspaceRoot,
+      targetArtifacts,
+      requiredSourceArtifacts,
+    })
+  );
+
+  if (DIRECT_WORKSPACE_INSPECTION_TOOL_NAMES.has(toolName)) {
+    return hasMeaningfulPath;
+  }
+
+  if (!SHELL_WORKSPACE_INSPECTION_TOOL_NAMES.has(toolName)) {
+    return false;
+  }
+
+  const args = parseToolCallArgs(params.toolCall);
+  const commandText = [
+    typeof args.command === "string" ? args.command : "",
+    ...(Array.isArray(args.args)
+      ? args.args.filter((entry): entry is string => typeof entry === "string")
+      : []),
+  ]
+    .join(" ")
+    .trim();
+  if (!SHELL_WORKSPACE_INSPECTION_COMMAND_RE.test(commandText)) {
+    return false;
+  }
+  return hasMeaningfulPath;
+}


### PR DESCRIPTION
## Summary
- harden Grok planner and tool-choice handling for delegated planner/doc workflows
- add first-class documentation/workspace-grounded verification for plan artifact updates
- tighten child tool scoping and verifier gating so grounded doc rewrites complete correctly

## Test plan
- npm run test --workspace=@tetsuo-ai/runtime -- src/utils/delegation-validation.test.ts src/llm/chat-executor-contract-guidance.test.ts src/llm/chat-executor-planner.test.ts src/workflow/verification-obligations.test.ts src/workflow/verification-contract.test.ts
- npm run build
- npm run techdebt