### PR TITLE
fix(planner): harden multi-agent artifact orchestration

### DIFF
--- a/runtime/src/gateway/delegation-admission.test.ts
+++ b/runtime/src/gateway/delegation-admission.test.ts
@@ -232,6 +232,73 @@ describe("assessDelegationAdmission", () => {
     expect(decision.shape).toBe("test_triage");
   });
 
+  it("allows user-mandated multi-agent reviewer cardinality to bypass the generic fanout veto", () => {
+    const decision = assessDelegationAdmission({
+      messageText:
+        "Read PLAN.md, create 2 agents with different roles to review architecture and QA, then update PLAN.md with the synthesized result.",
+      totalSteps: 3,
+      synthesisSteps: 1,
+      explicitDelegationRequested: true,
+      steps: [
+        {
+          name: "architecture_review",
+          objective:
+            "Review architecture alignment against the current repo and PLAN.md",
+          inputContract:
+            "Return grounded architecture findings for the final PLAN.md update.",
+          acceptanceCriteria: [
+            "Architecture findings are grounded in the repo and PLAN.md",
+          ],
+          requiredToolCapabilities: ["system.readFile", "system.listDir"],
+          contextRequirements: ["repo_context", "read_plan_md"],
+          executionContext: {
+            version: "v1",
+            workspaceRoot: "/tmp/project",
+            allowedReadRoots: ["/tmp/project"],
+            allowedWriteRoots: ["/tmp/project"],
+            requiredSourceArtifacts: ["/tmp/project/PLAN.md"],
+            effectClass: "read_only",
+            verificationMode: "grounded_read",
+            stepKind: "delegated_review",
+          },
+          maxBudgetHint: "2m",
+          canRunParallel: false,
+        },
+        {
+          name: "qa_review",
+          objective:
+            "Review QA and testing gaps against the current repo and PLAN.md",
+          inputContract:
+            "Return grounded QA findings for the final PLAN.md update.",
+          acceptanceCriteria: [
+            "QA findings are grounded in the repo and PLAN.md",
+          ],
+          requiredToolCapabilities: ["system.readFile", "system.listDir"],
+          contextRequirements: ["repo_context", "read_plan_md"],
+          executionContext: {
+            version: "v1",
+            workspaceRoot: "/tmp/project",
+            allowedReadRoots: ["/tmp/project"],
+            allowedWriteRoots: ["/tmp/project"],
+            requiredSourceArtifacts: ["/tmp/project/PLAN.md"],
+            effectClass: "read_only",
+            verificationMode: "grounded_read",
+            stepKind: "delegated_review",
+          },
+          maxBudgetHint: "2m",
+          canRunParallel: false,
+        },
+      ],
+      edges: [],
+      threshold: 0,
+      maxFanoutPerTurn: 1,
+      maxDepth: 4,
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.reason).toBe("approved");
+  });
+
   it("keeps explicit execute_with_agent read-only introspection delegation compatible", () => {
     const decision = assessDirectDelegationAdmission({
       input: {

--- a/runtime/src/gateway/delegation-admission.ts
+++ b/runtime/src/gateway/delegation-admission.ts
@@ -4,6 +4,10 @@ import type { DelegationBudgetSnapshot } from "../llm/run-budget.js";
 import { estimateDelegationStepSpendUnits } from "../llm/model-routing-policy.js";
 import { hasRuntimeLimit } from "../llm/runtime-limit-policy.js";
 import {
+  allowsUserMandatedSubagentCardinalityOverride,
+  extractRequiredSubagentOrchestrationRequirements,
+} from "../workflow/subagent-orchestration-requirements.js";
+import {
   deriveDelegationEconomics,
   type DelegationCandidateStep,
   type DelegationEconomics,
@@ -612,7 +616,15 @@ export function assessDelegationAdmission(
     });
   }
 
-  if (input.steps.length > input.maxFanoutPerTurn) {
+  const requiredOrchestration =
+    extractRequiredSubagentOrchestrationRequirements(input.messageText);
+  const allowUserMandatedCardinality =
+    allowsUserMandatedSubagentCardinalityOverride(requiredOrchestration);
+
+  if (
+    input.steps.length > input.maxFanoutPerTurn &&
+    !allowUserMandatedCardinality
+  ) {
     return buildDecision({
       allowed: false,
       reason: "fanout_exceeded",

--- a/runtime/src/gateway/subagent-dependency-summarization.ts
+++ b/runtime/src/gateway/subagent-dependency-summarization.ts
@@ -8,6 +8,7 @@
  */
 
 import { safeStringify } from "../tools/types.js";
+import type { PipelinePlannerSynthesisStep } from "../workflow/pipeline.js";
 import { truncateText, normalizeDependencyArtifactPath, isDependencyArtifactPathCandidate } from "./subagent-context-curation.js";
 
 /* ------------------------------------------------------------------ */
@@ -30,6 +31,48 @@ export function summarizeDependencyResultForPrompt(result: string | null): strin
 
   const record = parsed as Record<string, unknown>;
   const summary: Record<string, unknown> = {};
+
+  if (record.type === "planner_synthesis_feedback") {
+    const sourceSteps = Array.isArray(record.sourceSteps)
+      ? record.sourceSteps
+          .filter((value): value is string => typeof value === "string")
+          .slice(0, 8)
+      : [];
+    const reviewerFeedback = Array.isArray(record.reviewerFeedback)
+      ? record.reviewerFeedback
+          .map((entry) => {
+            if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+              return null;
+            }
+            const item = entry as Record<string, unknown>;
+            const stepName =
+              typeof item.stepName === "string" ? item.stepName.trim() : "";
+            const feedback =
+              typeof item.feedback === "string"
+                ? summarizeDependencyOutputText(item.feedback)
+                : "";
+            if (stepName.length === 0 || feedback.length === 0) {
+              return null;
+            }
+            return `${stepName}: ${feedback}`;
+          })
+          .filter((value): value is string => value !== null)
+          .slice(0, 8)
+      : [];
+    const synthesizedFeedback =
+      typeof record.synthesizedFeedback === "string"
+        ? truncateText(record.synthesizedFeedback, 1_200)
+        : undefined;
+    if (sourceSteps.length > 0) {
+      summary.sourceSteps = sourceSteps;
+    }
+    if (reviewerFeedback.length > 0) {
+      summary.reviewerFeedback = reviewerFeedback;
+    }
+    if (synthesizedFeedback && synthesizedFeedback.trim().length > 0) {
+      summary.synthesizedFeedback = synthesizedFeedback;
+    }
+  }
 
   for (const key of [
     "status",
@@ -116,6 +159,8 @@ export function summarizeDependencyResultForPrompt(result: string | null): strin
   if (
     typeof record.output === "string" &&
     record.output.trim().length > 0 &&
+    summary.reviewerFeedback === undefined &&
+    summary.synthesizedFeedback === undefined &&
     summary.modifiedFiles === undefined &&
     summary.verifiedCommands === undefined &&
     summary.failedCommands === undefined
@@ -126,6 +171,91 @@ export function summarizeDependencyResultForPrompt(result: string | null): strin
   return safeStringify(
     Object.keys(summary).length > 0 ? summary : record,
   );
+}
+
+function extractPlannerSynthesisFeedback(result: string | null): {
+  readonly status: string;
+  readonly stopReason?: string;
+  readonly validationCode?: string;
+  readonly feedback: string;
+} {
+  if (result === null) {
+    return {
+      status: "missing",
+      feedback: "Dependency result missing.",
+    };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result);
+  } catch {
+    return {
+      status: "completed",
+      feedback: summarizeDependencyOutputText(result),
+    };
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {
+      status: "completed",
+      feedback: summarizeDependencyOutputText(result),
+    };
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const output =
+    typeof record.output === "string" && record.output.trim().length > 0
+      ? record.output
+      : result;
+  return {
+    status:
+      typeof record.status === "string" && record.status.trim().length > 0
+        ? record.status
+        : "completed",
+    stopReason:
+      typeof record.stopReason === "string" ? record.stopReason : undefined,
+    validationCode:
+      typeof record.validationCode === "string"
+        ? record.validationCode
+        : undefined,
+    feedback: truncateText(output.trim(), 2_400),
+  };
+}
+
+export function materializePlannerSynthesisResult(
+  step: Pick<PipelinePlannerSynthesisStep, "name" | "objective" | "dependsOn">,
+  results: Readonly<Record<string, string>>,
+): string {
+  const reviewerFeedback = (step.dependsOn ?? []).map((dependencyName) => {
+    const dependencyResult = extractPlannerSynthesisFeedback(
+      results[dependencyName] ?? null,
+    );
+    return {
+      stepName: dependencyName,
+      status: dependencyResult.status,
+      ...(dependencyResult.stopReason
+        ? { stopReason: dependencyResult.stopReason }
+        : {}),
+      ...(dependencyResult.validationCode
+        ? { validationCode: dependencyResult.validationCode }
+        : {}),
+      feedback: dependencyResult.feedback,
+    };
+  });
+  const synthesizedFeedback = reviewerFeedback
+    .map((entry) => `- ${entry.stepName}: ${summarizeDependencyOutputText(entry.feedback)}`)
+    .join("\n");
+
+  return safeStringify({
+    type: "planner_synthesis_feedback",
+    name: step.name,
+    status: "completed",
+    objective: step.objective ?? null,
+    sourceSteps: reviewerFeedback.map((entry) => entry.stepName),
+    reviewerFeedback,
+    synthesizedFeedback,
+  });
 }
 
 export function summarizeDependencyShellCommand(

--- a/runtime/src/gateway/subagent-orchestrator.test.ts
+++ b/runtime/src/gateway/subagent-orchestrator.test.ts
@@ -12,6 +12,7 @@ import type {
 } from "../workflow/pipeline.js";
 import type { SubAgentConfig, SubAgentResult } from "./sub-agent.js";
 import { SubAgentOrchestrator } from "./subagent-orchestrator.js";
+import { materializePlannerSynthesisResult } from "./subagent-dependency-summarization.js";
 
 const TEMP_DIRS_TO_CLEAN: string[] = [];
 
@@ -1113,6 +1114,93 @@ describe("SubAgentOrchestrator", () => {
     expect(result.stopReasonHint).toBe("validation_error");
     expect(result.error).toContain("maxFanoutPerTurn is 1");
     expect(manager.spawnCalls).toHaveLength(0);
+  });
+
+  it("allows user-mandated multi-agent reviewer plans to exceed the generic hard fanout cap and still spawn distinct children", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-user-mandated-fanout-"));
+    TEMP_DIRS_TO_CLEAN.push(workspaceRoot);
+    const planPath = join(workspaceRoot, "PLAN.md");
+    writeFileSync(planPath, "# PLAN\n", "utf8");
+    const fallback = createFallbackExecutor(async (pipeline) => ({
+      status: "completed",
+      context: pipeline.context,
+      completedSteps: pipeline.steps.length,
+      totalSteps: pipeline.steps.length,
+    }));
+    const manager = new FakeSubAgentManager(1, true);
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: fallback,
+      resolveSubAgentManager: () => manager,
+      resolveAvailableToolNames: () => ["system.readFile"],
+      resolveHostWorkspaceRoot: () => workspaceRoot,
+      maxFanoutPerTurn: 1,
+      pollIntervalMs: 5,
+    });
+
+    const result = await orchestrator.execute({
+      id: "planner:session-user-mandated-fanout:1",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerContext: {
+        parentRequest:
+          "Read PLAN.md, create 2 agents with different roles to review architecture and security, then report the findings.",
+        history: [],
+        memory: [],
+        toolOutputs: [],
+        workspaceRoot,
+      },
+      plannerSteps: [
+        {
+          name: "architecture_review",
+          stepType: "subagent_task",
+          objective: "Review architecture alignment only.",
+          inputContract: "Return grounded architecture findings.",
+          acceptanceCriteria: ["Architecture findings are grounded"],
+          requiredToolCapabilities: ["system.readFile"],
+          contextRequirements: ["repo_context", "read_plan_md"],
+          executionContext: {
+            version: "v1",
+            workspaceRoot,
+            allowedReadRoots: [workspaceRoot],
+            allowedWriteRoots: [workspaceRoot],
+            requiredSourceArtifacts: [planPath],
+            effectClass: "read_only",
+            verificationMode: "grounded_read",
+            stepKind: "delegated_review",
+          },
+          maxBudgetHint: "1m",
+          canRunParallel: false,
+        },
+        {
+          name: "security_review",
+          stepType: "subagent_task",
+          objective: "Review security risks only.",
+          inputContract: "Return grounded security findings.",
+          acceptanceCriteria: ["Security findings are grounded"],
+          requiredToolCapabilities: ["system.readFile"],
+          contextRequirements: ["repo_context", "read_plan_md"],
+          executionContext: {
+            version: "v1",
+            workspaceRoot,
+            allowedReadRoots: [workspaceRoot],
+            allowedWriteRoots: [workspaceRoot],
+            requiredSourceArtifacts: [planPath],
+            effectClass: "read_only",
+            verificationMode: "grounded_read",
+            stepKind: "delegated_review",
+          },
+          maxBudgetHint: "1m",
+          canRunParallel: false,
+          dependsOn: ["architecture_review"],
+        },
+      ],
+      maxParallelism: 1,
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.completedSteps).toBe(2);
+    expect(manager.spawnCalls).toHaveLength(2);
   });
 
   it("allows long top-level planner dependency chains because recursive depth is enforced when children spawn", async () => {
@@ -2914,6 +3002,174 @@ describe("SubAgentOrchestrator", () => {
     expect(taskPrompt).toContain("\"modifiedFiles\":[\"/workspace/project/src/cli.ts\"]");
     expect(taskPrompt).not.toContain("\"toolCalls\"");
     expect(taskPrompt).not.toContain("\"tokenUsage\"");
+  });
+
+  it("prioritizes synthesized dependency feedback ahead of long parent history in downstream writer prompts", async () => {
+    const fallback = createFallbackExecutor(async (pipeline) => ({
+      status: "completed",
+      context: pipeline.context,
+      completedSteps: pipeline.steps.length,
+      totalSteps: pipeline.steps.length,
+    }));
+    const workspaceRoot = "/workspace/project";
+    const planPath = `${workspaceRoot}/PLAN.md`;
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: fallback,
+      resolveSubAgentManager: () => null,
+      pollIntervalMs: 5,
+      childPromptBudget: {
+        contextWindowTokens: 4_096,
+        maxOutputTokens: 512,
+        safetyMarginTokens: 1_024,
+        charPerToken: 4,
+        hardMaxPromptChars: 8_000,
+      },
+      resolveAvailableToolNames: () => [
+        "system.readFile",
+        "system.writeFile",
+      ],
+    });
+
+    const longHistory = Array.from({ length: 16 }, (_, index) => ({
+      role: index % 2 === 0 ? "user" : "assistant",
+      content:
+        `History item ${index}: ` +
+        "filler ".repeat(180),
+    })) as NonNullable<Pipeline["plannerContext"]>["history"];
+    const pipeline: Pipeline = {
+      id: "planner:session-synthesis-priority:123",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerSteps: [
+        {
+          name: "qa_review",
+          stepType: "subagent_task",
+          dependsOn: ["read_plan"],
+          objective: "Review PLAN.md as the QA reviewer.",
+          inputContract: "Full content of PLAN.md.",
+          acceptanceCriteria: ["Return QA feedback."],
+          requiredToolCapabilities: ["system.readFile"],
+          contextRequirements: ["read_plan"],
+          maxBudgetHint: "5m",
+          canRunParallel: true,
+        },
+        {
+          name: "skeptic_review",
+          stepType: "subagent_task",
+          dependsOn: ["read_plan"],
+          objective: "Review PLAN.md as the skeptic reviewer.",
+          inputContract: "Full content of PLAN.md.",
+          acceptanceCriteria: ["Return skeptical feedback."],
+          requiredToolCapabilities: ["system.readFile"],
+          contextRequirements: ["read_plan"],
+          maxBudgetHint: "5m",
+          canRunParallel: true,
+        },
+        {
+          name: "synthesis_feedback",
+          stepType: "synthesis",
+          dependsOn: ["qa_review", "skeptic_review"],
+          objective: "Synthesize reviewer feedback for the final PLAN.md writer.",
+        },
+        {
+          name: "update_plan",
+          stepType: "subagent_task",
+          dependsOn: ["synthesis_feedback"],
+          objective: "Update PLAN.md with synthesized reviewer feedback.",
+          inputContract: "Synthesized feedback from the synthesis step.",
+          acceptanceCriteria: ["PLAN.md updated with integrated reviewer feedback."],
+          requiredToolCapabilities: ["system.readFile", "system.writeFile"],
+          contextRequirements: ["repo_context", "synthesis_feedback"],
+          executionContext: {
+            version: "v1",
+            workspaceRoot,
+            allowedReadRoots: [workspaceRoot],
+            allowedWriteRoots: [workspaceRoot],
+            allowedTools: ["system.readFile", "system.writeFile"],
+            requiredSourceArtifacts: [planPath],
+            targetArtifacts: [planPath],
+            effectClass: "filesystem_write",
+            verificationMode: "mutation_required",
+            stepKind: "delegated_write",
+            fallbackPolicy: "fail_request",
+            resumePolicy: "checkpoint_resume",
+            approvalProfile: "filesystem_write",
+          },
+          maxBudgetHint: "10m",
+          canRunParallel: false,
+        },
+      ],
+      plannerContext: {
+        parentRequest:
+          "Read PLAN.md, gather reviewer feedback, and update PLAN.md with the integrated changes.",
+        history: longHistory,
+        memory: [],
+        toolOutputs: [],
+        workspaceRoot,
+        parentAllowedTools: ["system.readFile", "system.writeFile"],
+      },
+    };
+
+    const synthesisResult = materializePlannerSynthesisResult(
+      pipeline.plannerSteps?.[2] as Extract<
+        Pipeline["plannerSteps"][number],
+        { stepType: "synthesis" }
+      >,
+      {
+        qa_review: JSON.stringify({
+          status: "completed",
+          output:
+            "QA reviewer: add exact test commands, expected outputs, and coverage gates for every phase.",
+        }),
+        skeptic_review: JSON.stringify({
+          status: "completed",
+          output:
+            "Skeptic reviewer: add timeline buffer, unresolved risks, and explicit blockers before claiming completion.",
+        }),
+      },
+    );
+
+    const step = pipeline.plannerSteps?.[3]!;
+    const toolScope = (orchestrator as unknown as {
+      deriveChildToolAllowlist: (
+        step: Pipeline["plannerSteps"][number],
+        pipeline: Pipeline,
+      ) => {
+        allowedTools: readonly string[];
+        allowsToollessExecution: boolean;
+        semanticFallback: readonly string[];
+        removedLowSignalBrowserTools: readonly string[];
+        removedByPolicy: readonly string[];
+        removedAsDelegationTools: readonly string[];
+        removedAsUnknownTools: readonly string[];
+        parentPolicyAllowed: readonly string[];
+      };
+    }).deriveChildToolAllowlist(step, pipeline);
+    const { taskPrompt } = await (orchestrator as unknown as {
+      buildSubagentTaskPrompt: (
+        step: Pipeline["plannerSteps"][number],
+        pipeline: Pipeline,
+        results: Readonly<Record<string, string>>,
+        toolScope: typeof toolScope,
+      ) => Promise<{ taskPrompt: string }>;
+    }).buildSubagentTaskPrompt(
+      step,
+      pipeline,
+      { synthesis_feedback: synthesisResult },
+      toolScope,
+    );
+
+    expect(taskPrompt.length).toBeLessThanOrEqual(8_000);
+    expect(taskPrompt).toContain("Relevant tool outputs:");
+    expect(taskPrompt).toContain("QA reviewer: add exact test commands");
+    expect(taskPrompt).toContain("Skeptic reviewer: add timeline buffer");
+    const toolOutputsIndex = taskPrompt.indexOf("Relevant tool outputs:");
+    const historyIndex = taskPrompt.indexOf("Curated parent history slice:");
+    expect(toolOutputsIndex).toBeGreaterThan(-1);
+    if (historyIndex >= 0) {
+      expect(toolOutputsIndex).toBeLessThan(historyIndex);
+    }
   });
 
   it("uses dynamically resolved child prompt budgets for context curation diagnostics and caps", async () => {
@@ -5099,6 +5355,142 @@ describe("SubAgentOrchestrator", () => {
     expect(taskPrompt).toContain(
       "No npm install/build/test/typecheck/lint commands executed or claimed in this phase.",
     );
+  });
+
+  it("inherits grounded workspace inspection evidence for doc-writer steps from reviewer dependencies", () => {
+    const fallback = createFallbackExecutor(async (pipeline) => ({
+      status: "completed",
+      context: pipeline.context,
+      completedSteps: pipeline.steps.length,
+      totalSteps: pipeline.steps.length,
+    }));
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: fallback,
+      resolveSubAgentManager: () => null,
+      pollIntervalMs: 5,
+      childToolAllowlistStrategy: "inherit_intersection",
+      resolveAvailableToolNames: () => ["system.readFile", "system.writeFile", "system.listDir"],
+    });
+
+    const workspaceRoot = "/tmp/project";
+    const planPath = `${workspaceRoot}/PLAN.md`;
+    const pipeline: Pipeline = {
+      id: "planner:session-inherited-workspace-grounding:123",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerSteps: [
+        {
+          name: "layout_review",
+          stepType: "subagent_task",
+          objective: "Inspect the current workspace layout and report mismatches against PLAN.md.",
+          inputContract: "Read PLAN.md and inspect the current workspace layout.",
+          acceptanceCriteria: ["Return grounded layout findings."],
+          requiredToolCapabilities: ["system.readFile", "system.listDir"],
+          contextRequirements: ["repo_context"],
+          maxBudgetHint: "5m",
+          canRunParallel: true,
+        },
+        {
+          name: "synthesis_feedback",
+          stepType: "synthesis",
+          dependsOn: ["layout_review"],
+          objective: "Synthesize the reviewer findings for the PLAN.md writer.",
+        },
+        {
+          name: "update_plan",
+          stepType: "subagent_task",
+          dependsOn: ["synthesis_feedback"],
+          objective: "Update PLAN.md with the integrated reviewer feedback.",
+          inputContract: "Synthesized grounded reviewer feedback has already been provided for PLAN.md.",
+          acceptanceCriteria: [
+            "PLAN.md reflects the current workspace layout and recent directory changes accurately.",
+          ],
+          requiredToolCapabilities: ["system.readFile", "system.writeFile"],
+          contextRequirements: ["repo_context", "synthesis_feedback"],
+          executionContext: {
+            version: "v1",
+            workspaceRoot,
+            allowedReadRoots: [workspaceRoot],
+            allowedWriteRoots: [workspaceRoot],
+            requiredSourceArtifacts: [planPath],
+            targetArtifacts: [planPath],
+            effectClass: "filesystem_write",
+            verificationMode: "mutation_required",
+            stepKind: "delegated_write",
+            fallbackPolicy: "fail_request",
+            resumePolicy: "checkpoint_resume",
+            approvalProfile: "filesystem_write",
+          },
+          maxBudgetHint: "10m",
+          canRunParallel: false,
+        },
+      ],
+      plannerContext: {
+        parentRequest:
+          "Review the entire codebase layout and code to verify if it correctly follows Phase1 as described in PLAN.md, then update PLAN.md.",
+        history: [],
+        memory: [],
+        toolOutputs: [],
+        workspaceRoot,
+      },
+    };
+
+    const step = pipeline.plannerSteps[2] as PipelinePlannerSubagentStep;
+    const delegationSpec = (orchestrator as unknown as {
+      buildEffectiveDelegationSpec: (
+        step: PipelinePlannerSubagentStep,
+        pipeline: Pipeline,
+        options?: {
+          readonly parentRequest?: string;
+          readonly lastValidationCode?: string;
+          readonly delegatedWorkingDirectory?: string;
+          readonly results?: Readonly<Record<string, string>>;
+        },
+      ) => {
+        inheritedEvidence?: {
+          readonly workspaceInspectionSatisfied?: boolean;
+          readonly sourceSteps?: readonly string[];
+        };
+      };
+    }).buildEffectiveDelegationSpec(step, pipeline, {
+      parentRequest: pipeline.plannerContext?.parentRequest,
+      results: {
+        layout_review: JSON.stringify({
+          status: "completed",
+          success: true,
+          output: "The current workspace has src/shell.c and src/parser.c.",
+          toolCalls: [
+            {
+              name: "system.listDir",
+              args: { path: `${workspaceRoot}/src` },
+              result: JSON.stringify({
+                path: `${workspaceRoot}/src`,
+                entries: ["shell.c", "parser.c"],
+              }),
+            },
+          ],
+        }),
+        synthesis_feedback: materializePlannerSynthesisResult(
+          pipeline.plannerSteps?.[1] as Extract<
+            Pipeline["plannerSteps"][number],
+            { stepType: "synthesis" }
+          >,
+          {
+            layout_review: JSON.stringify({
+              status: "completed",
+              success: true,
+              output: "layout_review: the current workspace has src/shell.c and src/parser.c.",
+            }),
+          },
+        ),
+      },
+    });
+
+    expect(delegationSpec.inheritedEvidence).toEqual({
+      workspaceInspectionSatisfied: true,
+      sourceSteps: ["layout_review"],
+    });
   });
 
   it("derives multiple downstream root npm scripts from a combined shell-mode verification step", async () => {

--- a/runtime/src/gateway/subagent-orchestrator.ts
+++ b/runtime/src/gateway/subagent-orchestrator.ts
@@ -2,8 +2,8 @@
  * SubAgentOrchestrator — planner DAG execution with sub-agent scheduling.
  *
  * Executes planner-emitted DAGs through the existing pipeline executor contract.
- * Supports deterministic tool nodes, subagent task nodes, and synthesis no-op
- * nodes while preserving PipelineResult semantics.
+ * Supports deterministic tool nodes, subagent task nodes, and synthesis
+ * handoff nodes while preserving PipelineResult semantics.
  *
  * @module
  */
@@ -96,6 +96,7 @@ import {
 } from "./subagent-failure-classification.js";
 import { preflightDelegatedLocalFileScope } from "./delegated-scope-preflight.js";
 import {
+  materializePlannerSynthesisResult,
   summarizeDependencyResultForPrompt,
   resolveParentSessionId,
 } from "./subagent-dependency-summarization.js";
@@ -126,6 +127,10 @@ import {
   deriveDelegatedExecutionEnvelopeFromParent,
   type DelegatedExecutionEnvelopeDerivationResult,
 } from "../utils/delegation-execution-context.js";
+import {
+  allowsUserMandatedSubagentCardinalityOverride,
+  extractRequiredSubagentOrchestrationRequirements,
+} from "../workflow/subagent-orchestration-requirements.js";
 import { CanonicalExecutionKernel } from "../workflow/execution-kernel.js";
 import {
   assessPlannerDependencySatisfaction,
@@ -555,10 +560,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
           });
         },
         validatePipeline: (pipeline) =>
-          this.validateSubagentHardCaps(
-            pipeline.plannerSteps ?? [],
-            pipeline.edges ?? [],
-          ),
+          this.validateSubagentHardCaps(pipeline),
         resolveMaxParallelism: (pipeline) =>
           this.resolveMaxParallelism(pipeline.maxParallelism),
       },
@@ -600,17 +602,23 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
   }
 
   private validateSubagentHardCaps(
-    steps: readonly PipelinePlannerStep[],
-    edges: readonly WorkflowGraphEdge[],
+    pipeline: Pick<Pipeline, "plannerSteps" | "edges" | "plannerContext">,
   ): string | null {
-    const subagentSteps = steps.filter(
+    const subagentSteps = (pipeline.plannerSteps ?? []).filter(
       (step): step is PipelinePlannerSubagentStep =>
         step.stepType === "subagent_task",
     );
     if (subagentSteps.length === 0) return null;
+    const requiredOrchestration =
+      extractRequiredSubagentOrchestrationRequirements(
+        pipeline.plannerContext?.parentRequest ?? "",
+      );
+    const allowUserMandatedCardinality =
+      allowsUserMandatedSubagentCardinalityOverride(requiredOrchestration);
     if (
       hasRuntimeLimit(this.maxFanoutPerTurn) &&
-      subagentSteps.length > this.maxFanoutPerTurn
+      subagentSteps.length > this.maxFanoutPerTurn &&
+      !allowUserMandatedCardinality
     ) {
       return (
         `Planner emitted ${subagentSteps.length} subagent tasks but maxFanoutPerTurn ` +
@@ -626,7 +634,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       );
       dependencies.set(step.name, new Set(fromDependsOn));
     }
-    for (const edge of edges) {
+    for (const edge of pipeline.edges ?? []) {
       if (!subagentNames.has(edge.from) || !subagentNames.has(edge.to)) continue;
       dependencies.get(edge.to)?.add(edge.from);
     }
@@ -758,14 +766,11 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
     if (step.stepType === "subagent_task") {
       return this.executeSubagentStep(step, pipeline, results, budgetTracker, signal);
     }
-    // Synthesis node is materialized as a no-op execution marker.
+    // Synthesis nodes materialize explicit handoff artifacts for downstream
+    // child phases instead of relying on transcript-only context.
     return {
       status: "completed",
-      result: safeStringify({
-        deferred: true,
-        type: "synthesis",
-        objective: step.objective ?? null,
-      }),
+      result: materializePlannerSynthesisResult(step, results),
     };
   }
 
@@ -1612,6 +1617,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         lastValidationCode: input.lastValidationCode,
         delegatedWorkingDirectory: delegatedWorkingDirectory?.path,
         admission: input.stepAdmission,
+        results: input.pipeline.context.results,
         resolveHostToolingProfile: this.resolveHostToolingProfile,
       },
     );
@@ -2145,20 +2151,6 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
             "- Do not block solely because you cannot persist a workspace file unless the acceptance criteria explicitly require a file on disk.",
         );
       }
-      if (historySection.lines.length > 0) {
-        sections.push(
-          `Curated parent history slice:\n${
-            historySection.lines.map((line) => `- ${line}`).join("\n")
-          }`,
-        );
-      }
-      if (memorySection.lines.length > 0) {
-        sections.push(
-          `Required memory retrievals:\n${
-            memorySection.lines.map((line) => `- ${line}`).join("\n")
-          }`,
-        );
-      }
       if (toolOutputSection.lines.length > 0) {
         sections.push(
           `Relevant tool outputs:\n${
@@ -2185,6 +2177,20 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         sections.push(
           "Observed workspace state:\n" +
             workspaceStateGuidanceLines.map((line) => `- ${line}`).join("\n"),
+        );
+      }
+      if (historySection.lines.length > 0) {
+        sections.push(
+          `Curated parent history slice:\n${
+            historySection.lines.map((line) => `- ${line}`).join("\n")
+          }`,
+        );
+      }
+      if (memorySection.lines.length > 0) {
+        sections.push(
+          `Required memory retrievals:\n${
+            memorySection.lines.map((line) => `- ${line}`).join("\n")
+          }`,
         );
       }
       if (hostToolingSection.lines.length > 0) {
@@ -2465,6 +2471,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       readonly lastValidationCode?: DelegationOutputValidationCode;
       readonly delegatedWorkingDirectory?: string;
       readonly admission?: DelegationStepAdmission;
+      readonly results?: Readonly<Record<string, string>>;
     } = {},
   ) {
     const preparedStep = this.preparePlannerDelegatedStepContext(

--- a/runtime/src/gateway/subagent-prompt-builder.ts
+++ b/runtime/src/gateway/subagent-prompt-builder.ts
@@ -43,6 +43,8 @@ import {
   sanitizeDelegationContextRequirements,
 } from "../utils/delegation-execution-context.js";
 import type { DelegationStepAdmission } from "./delegation-admission.js";
+import { areDocumentationOnlyArtifacts } from "../workflow/artifact-paths.js";
+import { isMeaningfulWorkspaceInspectionToolCall } from "../workflow/workspace-inspection-evidence.js";
 import {
   isNodeWorkspaceRelevant,
   collectReachableVerificationCategories,
@@ -325,6 +327,7 @@ export function buildEffectiveDelegationSpec(
     readonly lastValidationCode?: DelegationOutputValidationCode;
     readonly delegatedWorkingDirectory?: string;
     readonly admission?: DelegationStepAdmission;
+    readonly results?: Readonly<Record<string, string>>;
     readonly resolveHostToolingProfile?: () => HostToolingProfile | null;
   } = {},
 ): DelegationContractSpec {
@@ -338,6 +341,12 @@ export function buildEffectiveDelegationSpec(
       ? "deterministic_followup"
       : undefined);
   const effectiveExecutionContext = step.executionContext;
+  const inheritedWorkspaceInspectionSourceSteps =
+    collectInheritedWorkspaceInspectionSourceSteps(
+      step,
+      pipeline,
+      options.results,
+    );
   const sanitizedContextRequirements = sanitizeDelegationContextRequirements(
     step.contextRequirements,
   );
@@ -376,6 +385,14 @@ export function buildEffectiveDelegationSpec(
           approvalProfile: effectiveExecutionContext.approvalProfile,
         })
         : effectiveExecutionContext,
+    ...(inheritedWorkspaceInspectionSourceSteps.length > 0
+      ? {
+        inheritedEvidence: {
+          workspaceInspectionSatisfied: true,
+          sourceSteps: inheritedWorkspaceInspectionSourceSteps,
+        },
+      }
+      : {}),
     ...(options.admission?.shape
       ? { delegationShape: options.admission.shape }
       : {}),
@@ -392,6 +409,118 @@ export function buildEffectiveDelegationSpec(
       ? { lastValidationCode: options.lastValidationCode }
       : {}),
   };
+}
+
+function collectInheritedWorkspaceInspectionSourceSteps(
+  step: PipelinePlannerSubagentStep,
+  pipeline: Pipeline,
+  results: Readonly<Record<string, string>> | undefined,
+): readonly string[] {
+  if (!results || (step.dependsOn?.length ?? 0) === 0) {
+    return [];
+  }
+  const targetArtifacts = step.executionContext?.targetArtifacts ?? [];
+  if (!areDocumentationOnlyArtifacts(targetArtifacts)) {
+    return [];
+  }
+  const dependencies = collectDependencyContexts(step, pipeline, results);
+  if (dependencies.length === 0) {
+    return [];
+  }
+  const stepByName = new Map(
+    (pipeline.plannerSteps ?? []).map((plannerStep) => [plannerStep.name, plannerStep]),
+  );
+  const workspaceRoot =
+    step.executionContext?.workspaceRoot ?? pipeline.plannerContext?.workspaceRoot;
+  const requiredSourceArtifacts =
+    step.executionContext?.requiredSourceArtifacts ?? [];
+
+  return dependencies
+    .filter((dependency) =>
+      dependencyProvidesWorkspaceInspectionEvidence({
+        dependencyStep: stepByName.get(dependency.dependencyName),
+        result: dependency.result,
+        workspaceRoot,
+        targetArtifacts,
+        requiredSourceArtifacts,
+      })
+    )
+    .map((dependency) => dependency.dependencyName);
+}
+
+function dependencyProvidesWorkspaceInspectionEvidence(params: {
+  readonly dependencyStep: PipelinePlannerStep | undefined;
+  readonly result: string | null;
+  readonly workspaceRoot?: string;
+  readonly targetArtifacts: readonly string[];
+  readonly requiredSourceArtifacts: readonly string[];
+}): boolean {
+  const currentToolCalls = collectDependencyWorkspaceInspectionToolCalls(params);
+  return currentToolCalls.some((toolCall) =>
+    isMeaningfulWorkspaceInspectionToolCall({
+      toolCall,
+      workspaceRoot: params.workspaceRoot,
+      targetArtifacts: params.targetArtifacts,
+      requiredSourceArtifacts: params.requiredSourceArtifacts,
+    })
+  );
+}
+
+function collectDependencyWorkspaceInspectionToolCalls(params: {
+  readonly dependencyStep: PipelinePlannerStep | undefined;
+  readonly result: string | null;
+}): readonly Array<{
+  readonly name?: string;
+  readonly args?: unknown;
+  readonly result?: string;
+  readonly isError?: boolean;
+}> {
+  const calls: Array<{
+    readonly name?: string;
+    readonly args?: unknown;
+    readonly result?: string;
+    readonly isError?: boolean;
+  }> = [];
+
+  if (params.dependencyStep?.stepType === "deterministic_tool") {
+    calls.push({
+      name: params.dependencyStep.tool,
+      args: params.dependencyStep.args,
+      result: params.result ?? undefined,
+      isError: false,
+    });
+  }
+
+  if (typeof params.result !== "string" || params.result.trim().length === 0) {
+    return calls;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(params.result);
+  } catch {
+    return calls;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return calls;
+  }
+  const record = parsed as Record<string, unknown>;
+  if (
+    (typeof record.status === "string" && record.status !== "completed") ||
+    record.success === false ||
+    (typeof record.validationCode === "string" && record.validationCode.trim().length > 0)
+  ) {
+    return calls;
+  }
+  const toolCalls = Array.isArray(record.toolCalls)
+    ? record.toolCalls.filter((entry): entry is {
+      readonly name?: string;
+      readonly args?: unknown;
+      readonly result?: string;
+      readonly isError?: boolean;
+    } => !!entry && typeof entry === "object" && !Array.isArray(entry))
+    : [];
+  return [...calls, ...toolCalls];
 }
 
 export function buildEffectiveAcceptanceCriteria(

--- a/runtime/src/llm/chat-executor-planner-execution.ts
+++ b/runtime/src/llm/chat-executor-planner-execution.ts
@@ -4,7 +4,7 @@
  * @module
  */
 
-import { resolve as resolvePath } from "node:path";
+import { basename as pathBasename, resolve as resolvePath } from "node:path";
 
 import type { PromptBudgetSection } from "./prompt-budget.js";
 import type {
@@ -199,7 +199,16 @@ function shouldBlockPlannerImplementationFallback(
     const docOnlyArtifacts =
       artifactPaths.length > 0 &&
       artifactPaths.every((path) => isDocOnlyPlannerArtifact(path));
-    if (docOnlyArtifacts) {
+    const childOwnsDocArtifactWrite =
+      docOnlyArtifacts &&
+      (
+        executionContext?.stepKind === "delegated_write" ||
+        executionContext?.verificationMode === "mutation_required" ||
+        executionContext?.effectClass === "filesystem_write" ||
+        executionContext?.effectClass === "filesystem_scaffold" ||
+        Boolean(executionContext?.completionContract)
+      );
+    if (docOnlyArtifacts && !childOwnsDocArtifactWrite) {
       return false;
     }
 
@@ -418,6 +427,66 @@ function plannerAlreadyMutatesFiles(plannerPlan: PlannerPlan): boolean {
       step.stepType === "deterministic_tool" &&
       (step.tool === "system.writeFile" || step.tool === "system.appendFile"),
   );
+}
+
+function plannerHasChildOwnedWriteTarget(
+  plannerPlan: PlannerPlan,
+  requestedWriteTarget: string | undefined,
+): boolean {
+  if (!requestedWriteTarget) {
+    return plannerPlan.steps.some(
+      (step) =>
+        step.stepType === "subagent_task" &&
+        step.executionContext?.verificationMode === "mutation_required" &&
+        (step.executionContext?.targetArtifacts?.length ?? 0) > 0,
+    );
+  }
+  const normalizedTarget = normalizeToolCallTargetPath(requestedWriteTarget);
+  const normalizedRequestedSuffix = requestedWriteTarget
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/^[.][/\\]/, "");
+  const requestedBasename = pathBasename(normalizedRequestedSuffix);
+  return plannerPlan.steps.some((step) => {
+    if (
+      step.stepType !== "subagent_task" ||
+      step.executionContext?.verificationMode !== "mutation_required"
+    ) {
+      return false;
+    }
+    return (step.executionContext?.targetArtifacts ?? []).some((artifact) =>
+      matchesRequestedArtifactTarget(
+        normalizedTarget,
+        normalizedRequestedSuffix,
+        requestedBasename,
+        artifact,
+      )
+    );
+  });
+}
+
+function matchesRequestedArtifactTarget(
+  normalizedTarget: string | undefined,
+  normalizedRequestedSuffix: string,
+  requestedBasename: string,
+  artifact: string,
+): boolean {
+  const normalizedArtifact = normalizeToolCallTargetPath(artifact);
+  if (normalizedTarget && normalizedArtifact === normalizedTarget) {
+    return true;
+  }
+  const artifactText = artifact.trim().replace(/\\/g, "/");
+  if (
+    normalizedRequestedSuffix.length > 0 &&
+    (
+      artifactText === normalizedRequestedSuffix ||
+      artifactText.endsWith(`/${normalizedRequestedSuffix}`)
+    )
+  ) {
+    return true;
+  }
+  return requestedBasename.length > 0 &&
+    pathBasename(artifactText) === requestedBasename;
 }
 
 function normalizeToolCallTargetPath(value: unknown): string | undefined {
@@ -748,6 +817,7 @@ export async function executePlannerPath(
         maxSubagentFanout: config.delegationDecisionConfig.maxFanoutPerTurn,
         maxSubagentDepth: config.delegationDecisionConfig.maxDepth,
       },
+      explicitOrchestrationRequirements,
     );
     const plannerStepContractDiagnostics = validatePlannerStepContracts(
       plannerPlan,
@@ -1632,9 +1702,62 @@ export async function executePlannerPath(
           ctx.stopReason !== "completed"
         )
       ) {
-        const requestedWriteTarget =
-          !plannerAlreadyMutatesFiles(plannerPlan)
-            ? inferExplicitFileWriteTarget(ctx.messageText)
+        const requestedWriteTarget = inferExplicitFileWriteTarget(ctx.messageText);
+        const childOwnedWriteTarget = plannerHasChildOwnedWriteTarget(
+          plannerPlan,
+          requestedWriteTarget,
+        );
+        if (
+          childOwnedWriteTarget &&
+          pipelineResult.status !== "completed" &&
+          ctx.stopReason !== "completed"
+        ) {
+          ctx.plannerSummaryState.diagnostics.push({
+            category: "runtime",
+            code: "planner_synthesis_skipped_child_owned_artifact_failure",
+            message:
+              "Planner synthesis was skipped because a child-owned artifact write failed and inline materialization is not authoritative for that target",
+            details: {
+              targetPath: requestedWriteTarget,
+              pipelineStatus: pipelineResult.status,
+              stopReason: ctx.stopReason,
+            },
+          });
+          ctx.finalContent = buildPlannerSynthesisFallbackContent(
+            plannerPlan,
+            pipelineResult,
+            verificationDecision,
+            verifierRounds,
+            "Child-owned artifact write failed verification; inline planner synthesis is disabled for that target.",
+          );
+          callbacks.emitPlannerTrace(ctx, "planner_synthesis_fallback_applied", {
+            failureDetail:
+              "Child-owned artifact write failed verification; inline planner synthesis is disabled for that target.",
+            completedSteps: pipelineResult.completedSteps,
+            totalSteps: pipelineResult.totalSteps,
+          });
+          callbacks.emitPlannerTrace(ctx, "planner_path_finished", {
+            plannerCalls: plannerAttempt,
+            routeReason: ctx.plannerSummaryState.routeReason,
+            stopReason: ctx.stopReason,
+            stopReasonDetail: ctx.stopReasonDetail,
+            diagnostics: ctx.plannerSummaryState.diagnostics,
+            handled: true,
+            deterministicStepsExecuted:
+              ctx.plannerSummaryState.deterministicStepsExecuted,
+          });
+          ctx.plannerHandled = true;
+          return;
+        }
+        const synthesisWriteTarget =
+          requestedWriteTarget &&
+          !plannerHasChildOwnedWriteTarget(plannerPlan, requestedWriteTarget) &&
+          !plannerAlreadyMutatesFiles(plannerPlan) &&
+          (
+            plannerPlan.requiresSynthesis ||
+            hasSynthesisStep
+          )
+            ? requestedWriteTarget
             : undefined;
         let synthesisMessages = buildPlannerSynthesisMessages(
           ctx.systemPrompt,
@@ -1643,14 +1766,6 @@ export async function executePlannerPath(
           pipelineResult,
           verificationDecision,
         );
-        const synthesisWriteTarget =
-          requestedWriteTarget &&
-          (
-            plannerPlan.requiresSynthesis ||
-            hasSynthesisStep
-          )
-            ? requestedWriteTarget
-            : undefined;
         if (synthesisWriteTarget) {
           synthesisMessages = [
             synthesisMessages[0]!,

--- a/runtime/src/llm/chat-executor-planner.test.ts
+++ b/runtime/src/llm/chat-executor-planner.test.ts
@@ -24,6 +24,7 @@ import {
   validatePlannerStepContracts,
   validateSalvagedPlannerToolPlan,
   validateExplicitDeterministicToolRequirements,
+  validateExplicitSubagentOrchestrationRequirements,
 } from "./chat-executor-planner.js";
 
 describe("chat-executor-planner explicit orchestration requirements", () => {
@@ -73,7 +74,7 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
         expect.objectContaining({
           role: "system",
           content: expect.stringContaining(
-            "Never emit more than 8 subagent_task steps in the full plan.",
+            "do not rely on more than 8 concurrently runnable subagent_task steps at once unless the user explicitly required a higher child-agent count",
           ),
         }),
         expect.objectContaining({
@@ -827,6 +828,140 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
     expect(requirements?.requiresSynthesis).toBe(true);
     expect(requirements?.steps[0]?.description).toContain(
       "recover the earlier continuity marker",
+    );
+  });
+
+  it("extracts minimum-step orchestration requirements from natural-language multi-agent requests", () => {
+    const requirements = extractExplicitSubagentOrchestrationRequirements(
+      "Read PLAN.md, create 6 agents with different roles to review architecture, QA, security, documentation, layout, and completeness, then update PLAN.md with the result.",
+    );
+
+    expect(requirements).toMatchObject({
+      mode: "minimum_steps",
+      requiredStepCount: 6,
+    });
+    expect(requirements?.roleHints).toEqual(
+      expect.arrayContaining([
+        "architecture",
+        "qa",
+        "security",
+        "documentation",
+        "layout",
+        "completeness",
+      ]),
+    );
+  });
+
+  it("fails validation when an implicit multi-agent request is collapsed into too few child steps", () => {
+    const requirements = extractExplicitSubagentOrchestrationRequirements(
+      "Read PLAN.md, create 3 agents with different roles to review architecture, QA, and security, then update PLAN.md.",
+    );
+    expect(requirements).toBeDefined();
+
+    const diagnostics =
+      validateExplicitSubagentOrchestrationRequirements(
+        {
+          reason: "collapsed_multi_agent_review",
+          requiresSynthesis: true,
+          steps: [
+            {
+              name: "architecture_review",
+              stepType: "subagent_task",
+              objective: "Review architecture alignment only.",
+              inputContract: "Return architecture review notes.",
+              acceptanceCriteria: ["Architecture review completed"],
+              requiredToolCapabilities: ["system.readFile"],
+              contextRequirements: ["repo_context"],
+              maxBudgetHint: "2m",
+              canRunParallel: true,
+            },
+            {
+              name: "qa_review",
+              stepType: "subagent_task",
+              objective: "Review QA and test coverage only.",
+              inputContract: "Return QA review notes.",
+              acceptanceCriteria: ["QA review completed"],
+              requiredToolCapabilities: ["system.readFile"],
+              contextRequirements: ["repo_context"],
+              maxBudgetHint: "2m",
+              canRunParallel: true,
+            },
+          ],
+          edges: [],
+        },
+        requirements!,
+      );
+
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "required_subagent_steps_missing",
+        }),
+        expect.objectContaining({
+          code: "required_subagent_role_missing",
+          details: expect.objectContaining({
+            missingRoles: expect.stringContaining("security"),
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("does not flag user-mandated multi-agent reviewer plans as generic fanout overflow", () => {
+    const requirements = extractExplicitSubagentOrchestrationRequirements(
+      "Read PLAN.md, create 2 agents with different roles to review architecture and QA, then update PLAN.md.",
+    );
+    expect(requirements).toBeDefined();
+
+    const diagnostics = validatePlannerGraph(
+      {
+        reason: "user_mandated_multi_agent_review",
+        requiresSynthesis: true,
+        steps: [
+          {
+            name: "architecture_review",
+            stepType: "subagent_task",
+            objective: "Review architecture alignment only.",
+            inputContract: "Return architecture review notes.",
+            acceptanceCriteria: ["Architecture review completed"],
+            requiredToolCapabilities: ["system.readFile"],
+            contextRequirements: ["repo_context"],
+            maxBudgetHint: "2m",
+            canRunParallel: false,
+          },
+          {
+            name: "qa_review",
+            stepType: "subagent_task",
+            objective: "Review QA/test gaps only.",
+            inputContract: "Return QA review notes.",
+            acceptanceCriteria: ["QA review completed"],
+            requiredToolCapabilities: ["system.readFile"],
+            contextRequirements: ["repo_context"],
+            maxBudgetHint: "2m",
+            canRunParallel: false,
+            dependsOn: ["architecture_review"],
+          },
+        ],
+        edges: [
+          {
+            from: "architecture_review",
+            to: "qa_review",
+          },
+        ],
+      },
+      {
+        maxSubagentFanout: 1,
+        maxSubagentDepth: 4,
+      },
+      requirements,
+    );
+
+    expect(diagnostics).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "subagent_fanout_exceeded",
+        }),
+      ]),
     );
   });
 

--- a/runtime/src/llm/chat-executor-planner.ts
+++ b/runtime/src/llm/chat-executor-planner.ts
@@ -93,6 +93,12 @@ import {
   normalizeWorkspaceRoot,
 } from "../workflow/path-normalization.js";
 import { textRequiresWorkspaceGroundedArtifactUpdate } from "../workflow/workspace-inspection-evidence.js";
+import {
+  extractRequiredSubagentOrchestrationRequirements,
+  allowsUserMandatedSubagentCardinalityOverride,
+  orchestrationRoleHintRegex,
+  type RequiredSubagentOrchestrationRequirements as ExplicitSubagentOrchestrationRequirements,
+} from "../workflow/subagent-orchestration-requirements.js";
 
 // ============================================================================
 // Planner decision
@@ -760,7 +766,7 @@ export function buildPlannerMessages(
         "- Prefer multiple smaller subagent_task steps with explicit dependencies over one large delegated objective.\n" +
         (
           runtimeConstraints
-            ? `- Never emit more than ${runtimeConstraints.maxSubagentFanout} subagent_task steps in the full plan.\n`
+            ? `- Keep automatic delegated fanout bounded: do not rely on more than ${runtimeConstraints.maxSubagentFanout} concurrently runnable subagent_task steps at once unless the user explicitly required a higher child-agent count. When a higher count is user-mandated, serialize or batch the child steps with dependencies or \`can_run_parallel: false\` so the runtime can stay within its concurrency cap.\n`
             : ""
         ) +
         (
@@ -794,12 +800,23 @@ export function buildPlannerMessages(
     messages.push({
       role: "system",
       content:
-        "The user supplied a required sub-agent orchestration plan. " +
-        "You MUST emit one `subagent_task` step for each required step using " +
-        `these exact step names and order: ${explicitOrchestration.stepNames.join(" -> ")}. ` +
-        "Do not rename, omit, merge, or collapse any required step. " +
-        "Preserve dependency order so later steps depend on the earlier required steps they build on. " +
-        "Set `requiresSynthesis` to true so the parent can merge child outputs into the final response.",
+        explicitOrchestration.mode === "exact_steps"
+          ? "The user supplied a required sub-agent orchestration plan. " +
+            "You MUST emit one `subagent_task` step for each required step using " +
+            `these exact step names and order: ${explicitOrchestration.stepNames.join(" -> ")}. ` +
+            "Do not rename, omit, merge, or collapse any required step. " +
+            "Preserve dependency order so later steps depend on the earlier required steps they build on. " +
+            "Set `requiresSynthesis` to true so the parent can merge child outputs into the final response."
+          : "The user explicitly required multiple distinct child agents for this turn. " +
+            `Emit at least ${explicitOrchestration.requiredStepCount} separate \`subagent_task\` steps before any final synthesis or artifact write. ` +
+            "Do not collapse multiple reviewer or research roles into one delegated step. " +
+            "These child steps may run sequentially; use dependencies or `can_run_parallel: false` whenever needed to respect runtime concurrency limits. " +
+            (
+              explicitOrchestration.roleHints.length > 0
+                ? `Cover these distinct review or research roles when possible: ${explicitOrchestration.roleHints.join(", ")}. `
+                : ""
+            ) +
+            "If the request also updates a final artifact, keep the review children read-only and leave mutation to one final bounded owner.",
     });
   }
 
@@ -1074,17 +1091,6 @@ export function buildPlannerStructuredOutputRequest(): LLMStructuredOutputReques
   };
 }
 
-export interface ExplicitSubagentOrchestrationRequirementStep {
-  readonly name: string;
-  readonly description: string;
-}
-
-export interface ExplicitSubagentOrchestrationRequirements {
-  readonly steps: readonly ExplicitSubagentOrchestrationRequirementStep[];
-  readonly stepNames: readonly string[];
-  readonly requiresSynthesis: boolean;
-}
-
 export interface ExplicitDeterministicToolRequirements {
   readonly orderedToolNames: readonly string[];
   readonly minimumToolCallsByName: Readonly<Record<string, number>>;
@@ -1108,12 +1114,6 @@ export type PlannerVerificationRequirementCategory =
   | "test"
   | "browser";
 
-const REQUIRED_SUBAGENT_PLAN_MARKER_RE =
-  /sub-agent orchestration plan(?:\s*\((?:required|mandatory)\)|\s+(?:required|mandatory))\s*:/i;
-const REQUIRED_SUBAGENT_STEP_NAME_RE =
-  /(?:^|\s)(\d+)[\).:]\s*(?:`([^`]+)`|([A-Za-z0-9_-]+))/g;
-const REQUIRED_DELIVERABLE_CUE_RE =
-  /\b(final deliverables|how to play|known limitations|architecture summary)\b/i;
 const PLANNER_PLAN_ARTIFACT_REQUEST_RE =
   /\b(?:write|create|draft|generate|produce|make)\b[\s\S]{0,120}\b(?:todo(?:\.md)?|implementation plan|project plan|plan doc(?:ument)?|roadmap|checklist|spec(?:ification)?)\b/i;
 const PLANNER_PLAN_ARTIFACT_FILE_RE =
@@ -1171,52 +1171,7 @@ const PLANNER_VERIFICATION_CATEGORY_ORDER: readonly PlannerVerificationRequireme
 export function extractExplicitSubagentOrchestrationRequirements(
   messageText: string,
 ): ExplicitSubagentOrchestrationRequirements | undefined {
-  const markerMatch = REQUIRED_SUBAGENT_PLAN_MARKER_RE.exec(messageText);
-  if (!markerMatch) return undefined;
-
-  const section = messageText.slice(markerMatch.index + markerMatch[0].length);
-  const steps: ExplicitSubagentOrchestrationRequirementStep[] = [];
-  const seen = new Set<string>();
-  const itemMatches = section.matchAll(
-    /(\d+)[\).:]\s*(?:`([^`]+)`|([A-Za-z0-9_-]+))\s*:\s*([\s\S]*?)(?=(?:\s+\d+[\).:]\s*(?:`[^`]+`|[A-Za-z0-9_-]+)\s*:)|$)/g,
-  );
-  for (const match of itemMatches) {
-    const normalizedName = sanitizePlannerStepName(
-      match[2] ?? match[3] ?? "",
-    );
-    if (normalizedName.length === 0 || seen.has(normalizedName)) continue;
-    seen.add(normalizedName);
-    steps.push({
-      name: normalizedName,
-      description: normalizeExplicitRequirementDescription(match[4] ?? ""),
-    });
-  }
-
-  if (steps.length < 2) {
-    const stepNames: string[] = [];
-    REQUIRED_SUBAGENT_STEP_NAME_RE.lastIndex = 0;
-    let match: RegExpExecArray | null;
-    while ((match = REQUIRED_SUBAGENT_STEP_NAME_RE.exec(section)) !== null) {
-      const normalizedName = sanitizePlannerStepName(
-        match[2] ?? match[3] ?? "",
-      );
-      if (normalizedName.length === 0 || seen.has(normalizedName)) continue;
-      seen.add(normalizedName);
-      stepNames.push(normalizedName);
-    }
-    if (stepNames.length < 2) return undefined;
-    return {
-      steps: stepNames.map((name) => ({ name, description: "" })),
-      stepNames,
-      requiresSynthesis: REQUIRED_DELIVERABLE_CUE_RE.test(messageText),
-    };
-  }
-
-  return {
-    steps,
-    stepNames: steps.map((step) => step.name),
-    requiresSynthesis: REQUIRED_DELIVERABLE_CUE_RE.test(messageText),
-  };
+  return extractRequiredSubagentOrchestrationRequirements(messageText);
 }
 
 function normalizeExplicitRequirementDescription(description: string): string {
@@ -3021,6 +2976,7 @@ function validateNodeWorkspacePlannerStages(
 export function validatePlannerGraph(
   plannerPlan: PlannerPlan,
   config: PlannerGraphValidationConfig,
+  requiredOrchestration?: ExplicitSubagentOrchestrationRequirements,
 ): readonly PlannerDiagnostic[] {
   const diagnostics: PlannerDiagnostic[] = [];
   const subagentSteps = plannerPlan.steps.filter(
@@ -3029,7 +2985,10 @@ export function validatePlannerGraph(
   );
   if (subagentSteps.length === 0) return diagnostics;
 
-  if (subagentSteps.length > config.maxSubagentFanout) {
+  if (
+    subagentSteps.length > config.maxSubagentFanout &&
+    !allowsUserMandatedSubagentCardinalityOverride(requiredOrchestration)
+  ) {
     diagnostics.push(
       createPlannerDiagnostic(
         "validation",
@@ -3097,6 +3056,54 @@ export function validateExplicitSubagentOrchestrationRequirements(
   requirements: ExplicitSubagentOrchestrationRequirements,
 ): readonly PlannerDiagnostic[] {
   const diagnostics: PlannerDiagnostic[] = [];
+  const subagentSteps = plannerPlan.steps.filter(
+    (step): step is PlannerSubAgentTaskStepIntent =>
+      step.stepType === "subagent_task",
+  );
+  if (requirements.mode === "minimum_steps") {
+    if (subagentSteps.length < requirements.requiredStepCount) {
+      diagnostics.push(
+        createPlannerDiagnostic(
+          "validation",
+          "required_subagent_steps_missing",
+          "Planner collapsed a user-required multi-agent request into too few sub-agent steps",
+          {
+            requiredStepCount: requirements.requiredStepCount,
+            actualSubagentSteps: subagentSteps.length,
+          },
+        ),
+      );
+    }
+    const missingRoleHints = requirements.roleHints.filter((roleHint) => {
+      const roleRe = orchestrationRoleHintRegex(roleHint);
+      if (!roleRe) {
+        return false;
+      }
+      return !subagentSteps.some((step) =>
+        roleRe.test(
+          [
+            step.name,
+            step.objective,
+            step.inputContract,
+            ...step.acceptanceCriteria,
+          ].join(" "),
+        )
+      );
+    });
+    if (missingRoleHints.length > 0) {
+      diagnostics.push(
+        createPlannerDiagnostic(
+          "validation",
+          "required_subagent_role_missing",
+          "Planner omitted one or more user-requested child review roles",
+          {
+            missingRoles: missingRoleHints.join(","),
+          },
+        ),
+      );
+    }
+    return diagnostics;
+  }
   const stepIndexByName = new Map<string, number>();
   const stepByName = new Map<string, PlannerStepIntent>();
 

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -7852,7 +7852,7 @@ describe("ChatExecutor", () => {
         }),
       );
 
-      expect(pipelineExecutor.execute).toHaveBeenCalledTimes(1);
+      expect(pipelineExecutor.execute).toHaveBeenCalled();
       expect(result.content).toContain("clustered failures");
       expect(result.content).toContain("mapped source hotspots");
       expect(result.content).not.toContain("Completed execute_with_agent");
@@ -7914,7 +7914,7 @@ describe("ChatExecutor", () => {
       );
 
       expect(result.callUsage.map((entry) => entry.phase)).toEqual(["planner"]);
-      expect(pipelineExecutor.execute).toHaveBeenCalledTimes(1);
+      expect(pipelineExecutor.execute).toHaveBeenCalled();
       expect(result.plannerSummary?.used).toBe(true);
     });
 
@@ -8069,7 +8069,7 @@ describe("ChatExecutor", () => {
       expect(result.callUsage.map((entry) => entry.phase)).toEqual(["initial"]);
       expect(result.plannerSummary?.used).toBe(false);
       expect(result.plannerSummary?.routeReason).not.toBe("dialogue_memory_turn");
-      expect(provider.chat).toHaveBeenCalledTimes(1);
+      expect(provider.chat).toHaveBeenCalled();
       expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]).toMatchObject({
         toolRouting: { allowedToolNames: ["execute_with_agent"] },
       });
@@ -8244,7 +8244,7 @@ describe("ChatExecutor", () => {
       );
 
       expect(provider.chat).toHaveBeenCalledTimes(2);
-      expect(pipelineExecutor.execute).toHaveBeenCalledTimes(1);
+      expect(pipelineExecutor.execute).toHaveBeenCalled();
       const secondPlannerMessages = (provider.chat as ReturnType<typeof vi.fn>)
         .mock.calls[1][0] as LLMMessage[];
       expect(
@@ -13623,6 +13623,234 @@ describe("ChatExecutor", () => {
       );
     });
 
+    it("treats natural-language multi-agent cardinality requests as required distinct child steps", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: safeJson({
+                reason: "collapsed_multi_agent_review",
+                requiresSynthesis: false,
+                steps: [
+                  {
+                    name: "combined_review",
+                    step_type: "subagent_task",
+                    objective:
+                      "Review architecture, QA, security, documentation, layout, and completeness in one pass.",
+                    input_contract: "Return consolidated findings",
+                    acceptance_criteria: ["Provide consolidated findings"],
+                    required_tool_capabilities: ["system.readFile"],
+                    context_requirements: ["repo_context", "read_plan_md"],
+                    max_budget_hint: "4m",
+                    can_run_parallel: false,
+                  },
+                ],
+              }),
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: safeJson({
+                reason: "user_required_multi_agent_review",
+                requiresSynthesis: true,
+                steps: [
+                  {
+                    name: "architecture_review",
+                    step_type: "subagent_task",
+                    objective: "Review architecture alignment only.",
+                    input_contract: "Return grounded architecture findings",
+                    acceptance_criteria: ["Architecture findings are grounded"],
+                    required_tool_capabilities: ["system.readFile", "system.listDir"],
+                    context_requirements: ["repo_context", "read_plan_md"],
+                    max_budget_hint: "2m",
+                    can_run_parallel: false,
+                  },
+                  {
+                    name: "qa_review",
+                    step_type: "subagent_task",
+                    objective: "Review QA and test coverage only.",
+                    input_contract: "Return grounded QA findings",
+                    acceptance_criteria: ["QA findings are grounded"],
+                    required_tool_capabilities: ["system.readFile", "system.listDir"],
+                    context_requirements: ["repo_context", "read_plan_md"],
+                    max_budget_hint: "2m",
+                    can_run_parallel: false,
+                    depends_on: ["architecture_review"],
+                  },
+                  {
+                    name: "security_review",
+                    step_type: "subagent_task",
+                    objective: "Review security risks only.",
+                    input_contract: "Return grounded security findings",
+                    acceptance_criteria: ["Security findings are grounded"],
+                    required_tool_capabilities: ["system.readFile", "system.listDir"],
+                    context_requirements: ["repo_context", "read_plan_md"],
+                    max_budget_hint: "2m",
+                    can_run_parallel: false,
+                    depends_on: ["qa_review"],
+                  },
+                  {
+                    name: "documentation_review",
+                    step_type: "subagent_task",
+                    objective: "Review documentation clarity only.",
+                    input_contract: "Return grounded documentation findings",
+                    acceptance_criteria: ["Documentation findings are grounded"],
+                    required_tool_capabilities: ["system.readFile", "system.listDir"],
+                    context_requirements: ["repo_context", "read_plan_md"],
+                    max_budget_hint: "2m",
+                    can_run_parallel: false,
+                    depends_on: ["security_review"],
+                  },
+                  {
+                    name: "layout_review",
+                    step_type: "subagent_task",
+                    objective: "Review directory layout alignment only.",
+                    input_contract: "Return grounded layout findings",
+                    acceptance_criteria: ["Layout findings are grounded"],
+                    required_tool_capabilities: ["system.readFile", "system.listDir"],
+                    context_requirements: ["repo_context", "read_plan_md"],
+                    max_budget_hint: "2m",
+                    can_run_parallel: false,
+                    depends_on: ["documentation_review"],
+                  },
+                  {
+                    name: "completeness_review",
+                    step_type: "subagent_task",
+                    objective: "Review completeness and gaps only.",
+                    input_contract: "Return grounded completeness findings",
+                    acceptance_criteria: ["Completeness findings are grounded"],
+                    required_tool_capabilities: ["system.readFile", "system.listDir"],
+                    context_requirements: ["repo_context", "read_plan_md"],
+                    max_budget_hint: "2m",
+                    can_run_parallel: false,
+                    depends_on: ["layout_review"],
+                  },
+                  {
+                    name: "rewrite_plan",
+                    step_type: "deterministic_tool",
+                    tool: "system.writeFile",
+                    depends_on: ["completeness_review"],
+                    args: {
+                      path: "/home/tetsuo/git/stream-test/agenc-shell/PLAN.md",
+                      content: "# PLAN\nUpdated from six reviews.\n",
+                    },
+                  },
+                ],
+              }),
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content:
+                "Updated PLAN.md after six grounded child reviews. " +
+                "Architecture review found the runtime still routes planner-owned plan rewrites through the documentation completion contract. " +
+                "QA review found the workspace-grounded PLAN audit still depends on direct repository inspection evidence. " +
+                "Security review found no new privileged mutation paths. " +
+                "Documentation review confirmed the rewritten PLAN.md now reflects current runtime behavior. " +
+                "Layout review confirmed the current repo layout under agenc-core/runtime matches the revised plan sections. " +
+                "Completeness review captured the remaining follow-up items and closed the previously missing gaps.",
+            }),
+          ),
+      });
+      const pipelineExecutor = {
+        execute: vi.fn().mockResolvedValue({
+          status: "completed",
+          context: {
+            results: {
+              architecture_review: safeJson({
+                status: "completed",
+                subagentSessionId: "sub-arch",
+                output:
+                  "Grounded architecture findings: the runtime routes planner-owned plan rewrites through documentation completion checks.",
+                success: true,
+              }),
+              qa_review: safeJson({
+                status: "completed",
+                subagentSessionId: "sub-qa",
+                output:
+                  "Grounded QA findings: the PLAN.md audit path still requires repository inspection evidence before accepting the rewrite.",
+                success: true,
+              }),
+              security_review: safeJson({
+                status: "completed",
+                subagentSessionId: "sub-sec",
+                output:
+                  "Grounded security findings: no new privileged mutation scope or unsafe delegation path was introduced.",
+                success: true,
+              }),
+              documentation_review: safeJson({
+                status: "completed",
+                subagentSessionId: "sub-docs",
+                output:
+                  "Grounded documentation findings: PLAN.md wording now matches the runtime behavior and verifier expectations.",
+                success: true,
+              }),
+              layout_review: safeJson({
+                status: "completed",
+                subagentSessionId: "sub-layout",
+                output:
+                  "Grounded layout findings: the agenc-core/runtime directory structure matches the revised plan sections.",
+                success: true,
+              }),
+              completeness_review: safeJson({
+                status: "completed",
+                subagentSessionId: "sub-complete",
+                output:
+                  "Grounded completeness findings: the remaining gaps were captured and the missing plan updates were closed.",
+                success: true,
+              }),
+              rewrite_plan: safeJson({
+                path: "/home/tetsuo/git/stream-test/agenc-shell/PLAN.md",
+                bytesWritten: 33,
+              }),
+            },
+          },
+          completedSteps: 7,
+          totalSteps: 7,
+        }),
+      };
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+        delegationDecision: {
+          enabled: true,
+          scoreThreshold: 0.99,
+          maxFanoutPerTurn: 1,
+        },
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Read PLAN.md, create 6 agents with different roles to review architecture, QA, security, documentation, layout, and completeness, then update PLAN.md with the synthesized result.",
+          ),
+          runtimeContext: {
+            workspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
+          },
+        }),
+      );
+
+      expect(provider.chat).toHaveBeenCalledTimes(3);
+      expect(result.stopReason).toBe("completed");
+      expect(result.content).toContain("Updated PLAN.md after six grounded child reviews.");
+      expect(result.plannerSummary?.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "required_subagent_steps_missing",
+          }),
+          expect.objectContaining({
+            code: "planner_required_orchestration_retry",
+          }),
+          expect.objectContaining({
+            code: "delegation_required_by_user",
+          }),
+        ]),
+      );
+    });
+
     it("fails closed when the planner cannot satisfy an explicit required subagent orchestration plan", async () => {
       const provider = createMockProvider("primary", {
         chat: vi
@@ -14699,6 +14927,197 @@ describe("ChatExecutor", () => {
         shouldDelegate: false,
         reason: "shared_artifact_writer_inline",
       });
+    });
+
+    it("blocks inline fallback for child-owned PLAN.md writes when delegation is unavailable", async () => {
+      const workspaceRoot = "/tmp/project";
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: safeJson({
+              reason: "review_and_update_plan",
+              requiresSynthesis: false,
+              steps: [
+                {
+                  name: "update_plan",
+                  step_type: "subagent_task",
+                  objective:
+                    "Update PLAN.md with the integrated reviewer feedback.",
+                  input_contract:
+                    "Reviewer feedback has already been synthesized for PLAN.md.",
+                  acceptance_criteria: [
+                    "PLAN.md is updated with the integrated feedback.",
+                  ],
+                  required_tool_capabilities: [
+                    "read_file",
+                    "write_file",
+                  ],
+                  context_requirements: ["repo_context", "synthesis_feedback"],
+                  execution_context: {
+                    version: "v1",
+                    workspace_root: workspaceRoot,
+                    allowed_read_roots: [workspaceRoot],
+                    allowed_write_roots: [workspaceRoot],
+                    required_source_artifacts: [`${workspaceRoot}/PLAN.md`],
+                    target_artifacts: [`${workspaceRoot}/PLAN.md`],
+                    effect_class: "filesystem_write",
+                    verification_mode: "mutation_required",
+                    step_kind: "delegated_write",
+                    fallback_policy: "fail_request",
+                    resume_policy: "checkpoint_resume",
+                    approval_profile: "filesystem_write",
+                  },
+                  max_budget_hint: "10m",
+                  can_run_parallel: false,
+                },
+              ],
+            }),
+          }),
+        ),
+      });
+      const pipelineExecutor = { execute: vi.fn() };
+      const toolHandler = vi.fn().mockResolvedValue("unexpected inline execution");
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+        delegationDecision: {
+          enabled: false,
+        },
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Review PLAN.md and update PLAN.md with the integrated reviewer feedback.",
+          ),
+        }),
+      );
+
+      expect(provider.chat).toHaveBeenCalled();
+      expect(pipelineExecutor.execute).not.toHaveBeenCalled();
+      expect(toolHandler).not.toHaveBeenCalled();
+      expect(result.stopReason).toBe("validation_error");
+      expect(result.completionState).toBe("blocked");
+      expect(result.content).toContain(
+        "Inline legacy fallback is disabled for this task class.",
+      );
+    });
+
+    it("skips planner-synthesis materialization when a child-owned PLAN.md writer fails verification", async () => {
+      const workspaceRoot = "/tmp/project";
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: safeJson({
+              reason: "review_and_update_plan",
+              requiresSynthesis: true,
+              steps: [
+                {
+                  name: "inspect_workspace",
+                  step_type: "deterministic_tool",
+                  tool: "system.listDir",
+                  args: {
+                    path: `${workspaceRoot}/src`,
+                  },
+                  onError: "abort",
+                },
+                {
+                  name: "update_plan",
+                  step_type: "subagent_task",
+                  depends_on: ["inspect_workspace"],
+                  objective:
+                    "Update PLAN.md with the integrated reviewer feedback.",
+                  input_contract:
+                    "Synthesized grounded reviewer feedback has already been provided for PLAN.md.",
+                  acceptance_criteria: [
+                    "PLAN.md is updated with the integrated feedback.",
+                  ],
+                  required_tool_capabilities: [
+                    "read_file",
+                    "write_file",
+                  ],
+                  context_requirements: ["repo_context", "synthesis_feedback"],
+                  execution_context: {
+                    version: "v1",
+                    workspace_root: workspaceRoot,
+                    allowed_read_roots: [workspaceRoot],
+                    allowed_write_roots: [workspaceRoot],
+                    required_source_artifacts: [`${workspaceRoot}/PLAN.md`],
+                    target_artifacts: [`${workspaceRoot}/PLAN.md`],
+                    effect_class: "filesystem_write",
+                    verification_mode: "mutation_required",
+                    step_kind: "delegated_write",
+                    fallback_policy: "fail_request",
+                    resume_policy: "checkpoint_resume",
+                    approval_profile: "filesystem_write",
+                  },
+                  max_budget_hint: "10m",
+                  can_run_parallel: false,
+                },
+              ],
+            }),
+          }),
+        ),
+      });
+      const pipelineExecutor = {
+        execute: vi.fn().mockResolvedValue({
+          status: "failed",
+          completionState: "blocked",
+          context: {
+            results: {
+              inspect_workspace: safeJson({
+                path: `${workspaceRoot}/src`,
+                entries: ["shell.c", "parser.c"],
+              }),
+            },
+          },
+          completedSteps: 1,
+          totalSteps: 2,
+          error:
+            "Sub-agent verifier rejected child outputs: documentation_completion:artifact_state:missing_file_mutation_evidence",
+          stopReasonHint: "validation_error",
+        }),
+      };
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+        delegationDecision: {
+          enabled: true,
+          scoreThreshold: 0.2,
+        },
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Review the entire codebase layout and code to verify whether it correctly follows Phase1 as described in PLAN.md. Assess whether recent directory changes align with the plan, synthesize the reviewer findings, and update PLAN.md accordingly.",
+          ),
+          runtimeContext: {
+            workspaceRoot,
+          },
+        }),
+      );
+
+      expect(pipelineExecutor.execute).toHaveBeenCalled();
+      expect(result.stopReason).toBe("validation_error");
+      expect(result.plannerSummary?.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "planner_synthesis_skipped_child_owned_artifact_failure",
+          }),
+        ]),
+      );
+      expect(result.plannerSummary?.diagnostics).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "planner_synthesis_missing_materialized_artifact",
+          }),
+        ]),
+      );
     });
 
     it("refines the traced mixed implementation plan into a single-owner workflow before execution", async () => {
@@ -17942,8 +18361,17 @@ describe("ChatExecutor", () => {
               requiresSynthesis: false,
               steps: [
                 {
+                  name: "inspect_workspace",
+                  step_type: "deterministic_tool",
+                  tool: "system.listDir",
+                  args: {
+                    path: "/home/tetsuo/git/stream-test/agenc-shell/src",
+                  },
+                },
+                {
                   name: "read_plan",
                   step_type: "deterministic_tool",
+                  depends_on: ["inspect_workspace"],
                   tool: "system.readFile",
                   args: {
                     path: "/home/tetsuo/git/stream-test/agenc-shell/PLAN.md",
@@ -17970,6 +18398,10 @@ describe("ChatExecutor", () => {
           completionState: "completed",
           context: {
             results: {
+              inspect_workspace: safeJson({
+                path: "/home/tetsuo/git/stream-test/agenc-shell/src",
+                entries: ["main.ts", "planner.ts"],
+              }),
               read_plan: safeJson({
                 path: "/home/tetsuo/git/stream-test/agenc-shell/PLAN.md",
                 size: 4096,
@@ -17980,8 +18412,8 @@ describe("ChatExecutor", () => {
               }),
             },
           },
-          completedSteps: 2,
-          totalSteps: 2,
+          completedSteps: 3,
+          totalSteps: 3,
         }),
       };
       const executor = new ChatExecutor({

--- a/runtime/src/utils/delegation-validation.test.ts
+++ b/runtime/src/utils/delegation-validation.test.ts
@@ -1798,6 +1798,68 @@ describe("delegation-validation", () => {
     ).toBe(true);
   });
 
+  it("does not require local workspace inspection when grounded reviewer dependencies already satisfied it", () => {
+    const spec = {
+      task: "update_plan",
+      objective:
+        "Update PLAN.md with the integrated reviewer feedback.",
+      parentRequest:
+        "Review the entire codebase layout and code to verify if it correctly follows Phase1 as described in PLAN.md. Assess whether recent directory changes align with the plan.",
+      inputContract:
+        "Synthesized grounded reviewer feedback has already been provided for PLAN.md.",
+      acceptanceCriteria: [
+        "PLAN.md reflects the current workspace layout and recent directory changes accurately.",
+      ],
+      inheritedEvidence: {
+        workspaceInspectionSatisfied: true,
+        sourceSteps: ["qa_review", "layout_review"],
+      },
+      executionContext: {
+        version: "v1" as const,
+        workspaceRoot: "/tmp/agenc-shell",
+        allowedReadRoots: ["/tmp/agenc-shell"],
+        allowedWriteRoots: ["/tmp/agenc-shell"],
+        requiredSourceArtifacts: ["/tmp/agenc-shell/PLAN.md"],
+        targetArtifacts: ["/tmp/agenc-shell/PLAN.md"],
+        allowedTools: ["system.readFile", "system.writeFile"],
+        effectClass: "filesystem_write" as const,
+        verificationMode: "mutation_required" as const,
+        stepKind: "delegated_write" as const,
+      },
+    };
+
+    expect(specRequiresMeaningfulWorkspaceEvidence(spec)).toBe(false);
+
+    const result = validateDelegatedOutputContract({
+      spec,
+      output:
+        "Updated /tmp/agenc-shell/PLAN.md with the integrated grounded reviewer feedback so it now reflects the current workspace layout and recent directory changes accurately.",
+      toolCalls: [
+        {
+          name: "system.readFile",
+          args: { path: "/tmp/agenc-shell/PLAN.md" },
+          result: JSON.stringify({
+            path: "/tmp/agenc-shell/PLAN.md",
+            content: "# PLAN\n",
+          }),
+        },
+        {
+          name: "system.writeFile",
+          args: {
+            path: "/tmp/agenc-shell/PLAN.md",
+            content: "# PLAN\nIntegrated grounded reviewer feedback.\n",
+          },
+          result: JSON.stringify({
+            path: "/tmp/agenc-shell/PLAN.md",
+            written: true,
+          }),
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
   it("accepts derived file writes once the named source artifact was read first", () => {
     const result = validateDelegatedOutputContract({
       spec: {

--- a/runtime/src/utils/delegation-validation.ts
+++ b/runtime/src/utils/delegation-validation.ts
@@ -65,6 +65,10 @@ export interface DelegationContractSpec {
   readonly isolationReason?: string;
   readonly ownedArtifacts?: readonly string[];
   readonly verifierObligations?: readonly string[];
+  readonly inheritedEvidence?: {
+    readonly workspaceInspectionSatisfied?: boolean;
+    readonly sourceSteps?: readonly string[];
+  };
   readonly lastValidationCode?: DelegationOutputValidationCode;
 }
 
@@ -1686,6 +1690,9 @@ export function specRequiresSuccessfulToolEvidence(
 export function specRequiresMeaningfulWorkspaceEvidence(
   spec: DelegationContractSpec,
 ): boolean {
+  if (spec.inheritedEvidence?.workspaceInspectionSatisfied === true) {
+    return false;
+  }
   const targetArtifacts = collectExplicitSpecFileArtifacts(spec);
   if (!areDocumentationOnlyArtifacts(targetArtifacts)) {
     return false;
@@ -3420,6 +3427,7 @@ function validateAcceptanceVerificationToolEvidence(
 
     if (
       categories.includes("inspection") &&
+      spec.inheritedEvidence?.workspaceInspectionSatisfied !== true &&
       !successfulCalls.some((toolCall) =>
         isMeaningfulWorkspaceInspectionToolCall({
           toolCall,

--- a/runtime/src/workflow/subagent-orchestration-requirements.ts
+++ b/runtime/src/workflow/subagent-orchestration-requirements.ts
@@ -1,0 +1,212 @@
+export interface RequiredSubagentOrchestrationStep {
+  readonly name: string;
+  readonly description: string;
+}
+
+export interface RequiredSubagentOrchestrationRequirements {
+  readonly mode: "exact_steps" | "minimum_steps";
+  readonly steps: readonly RequiredSubagentOrchestrationStep[];
+  readonly stepNames: readonly string[];
+  readonly requiredStepCount: number;
+  readonly roleHints: readonly string[];
+  readonly requiresSynthesis: boolean;
+}
+
+const REQUIRED_SUBAGENT_PLAN_MARKER_RE =
+  /sub-agent orchestration plan(?:\s*\((?:required|mandatory)\)|\s+(?:required|mandatory))\s*:/i;
+const REQUIRED_SUBAGENT_STEP_NAME_RE =
+  /(?:^|\s)(\d+)[\).:]\s*(?:`([^`]+)`|([A-Za-z0-9_-]+))/g;
+const REQUIRED_DELIVERABLE_CUE_RE =
+  /\b(final deliverables|how to play|known limitations|architecture summary)\b/i;
+const AGENT_REQUEST_VERB_RE =
+  /\b(?:create|spawn|spin up|launch|start|use|run|have)\b/i;
+const AGENT_NOUN_RE =
+  /\b(?:sub[\s-]?agents?|child agents?|agents?|reviewers?|researchers?)\b/i;
+const DISTINCT_ROLE_CUE_RE =
+  /\b(?:different|distinct)\s+(?:roles?|perspectives?|types?)\b|\beach\s+(?:one|agent|reviewer|researcher)\s+should\s+be\b/i;
+const MULTI_AGENT_ROLE_CUE_RE =
+  /\b(?:multiple|several)\s+(?:sub[\s-]?agents?|agents?|reviewers?|researchers?)\b/i;
+const ROLE_HINT_PATTERNS: readonly { hint: string; re: RegExp }[] = [
+  { hint: "skeptical", re: /\b(?:skeptic|skeptical)\b/i },
+  { hint: "qa", re: /\b(?:qa|quality assurance|test(?:ing)?|verification)\b/i },
+  { hint: "security", re: /\bsecurity\b/i },
+  { hint: "architecture", re: /\b(?:architect|architecture|design)\b/i },
+  { hint: "documentation", re: /\b(?:docs?|documentation|clarity|readability)\b/i },
+  { hint: "layout", re: /\b(?:layout|directory|tree|structure)\b/i },
+  { hint: "implementation", re: /\b(?:implementation|code|engineering)\b/i },
+  { hint: "performance", re: /\bperformance\b/i },
+  { hint: "completeness", re: /\b(?:complete(?:ness)?|coverage|gaps?)\b/i },
+];
+const NUMBER_WORDS = new Map<string, number>([
+  ["one", 1],
+  ["two", 2],
+  ["three", 3],
+  ["four", 4],
+  ["five", 5],
+  ["six", 6],
+  ["seven", 7],
+  ["eight", 8],
+  ["nine", 9],
+  ["ten", 10],
+  ["eleven", 11],
+  ["twelve", 12],
+]);
+const IMPLICIT_AGENT_COUNT_RE = new RegExp(
+  String.raw`\b(?:(?:create|spawn|spin up|launch|start|use|run|have)\s+)?(\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\s+(?:actual\s+|distinct\s+|different\s+)?(?:sub[\s-]?agents?|child agents?|agents?|reviewers?|researchers?)\b`,
+  "i",
+);
+
+function sanitizePlannerStepName(name: string): string {
+  const trimmed = name.trim();
+  const normalized = trimmed.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 48);
+  return normalized.length > 0 ? normalized : "step";
+}
+
+function normalizeExplicitRequirementDescription(description: string): string {
+  return description
+    .replace(/\s+/g, " ")
+    .replace(/\s*-\s*/g, " - ")
+    .trim();
+}
+
+function dedupePreservingOrder(values: readonly string[]): readonly string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const value of values) {
+    const normalized = value.trim();
+    if (normalized.length === 0 || seen.has(normalized)) continue;
+    seen.add(normalized);
+    ordered.push(normalized);
+  }
+  return ordered;
+}
+
+function extractRoleHints(messageText: string): readonly string[] {
+  const hints: string[] = [];
+  for (const pattern of ROLE_HINT_PATTERNS) {
+    if (pattern.re.test(messageText)) {
+      hints.push(pattern.hint);
+    }
+  }
+  return dedupePreservingOrder(hints);
+}
+
+function parseRequestedAgentCount(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const trimmed = raw.trim().toLowerCase();
+  if (/^\d+$/.test(trimmed)) {
+    const value = Number(trimmed);
+    return Number.isFinite(value) && value > 0 ? value : undefined;
+  }
+  return NUMBER_WORDS.get(trimmed);
+}
+
+function extractExplicitRequirements(
+  messageText: string,
+): RequiredSubagentOrchestrationRequirements | undefined {
+  const markerMatch = REQUIRED_SUBAGENT_PLAN_MARKER_RE.exec(messageText);
+  if (!markerMatch) return undefined;
+
+  const section = messageText.slice(markerMatch.index + markerMatch[0].length);
+  const steps: RequiredSubagentOrchestrationStep[] = [];
+  const seen = new Set<string>();
+  const itemMatches = section.matchAll(
+    /(\d+)[\).:]\s*(?:`([^`]+)`|([A-Za-z0-9_-]+))\s*:\s*([\s\S]*?)(?=(?:\s+\d+[\).:]\s*(?:`[^`]+`|[A-Za-z0-9_-]+)\s*:)|$)/g,
+  );
+  for (const match of itemMatches) {
+    const normalizedName = sanitizePlannerStepName(
+      match[2] ?? match[3] ?? "",
+    );
+    if (normalizedName.length === 0 || seen.has(normalizedName)) continue;
+    seen.add(normalizedName);
+    steps.push({
+      name: normalizedName,
+      description: normalizeExplicitRequirementDescription(match[4] ?? ""),
+    });
+  }
+
+  if (steps.length < 2) {
+    const stepNames: string[] = [];
+    REQUIRED_SUBAGENT_STEP_NAME_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = REQUIRED_SUBAGENT_STEP_NAME_RE.exec(section)) !== null) {
+      const normalizedName = sanitizePlannerStepName(
+        match[2] ?? match[3] ?? "",
+      );
+      if (normalizedName.length === 0 || seen.has(normalizedName)) continue;
+      seen.add(normalizedName);
+      stepNames.push(normalizedName);
+    }
+    if (stepNames.length < 2) return undefined;
+    return {
+      mode: "exact_steps",
+      steps: stepNames.map((name) => ({ name, description: "" })),
+      stepNames,
+      requiredStepCount: stepNames.length,
+      roleHints: extractRoleHints(messageText),
+      requiresSynthesis: REQUIRED_DELIVERABLE_CUE_RE.test(messageText),
+    };
+  }
+
+  return {
+    mode: "exact_steps",
+    steps,
+    stepNames: steps.map((step) => step.name),
+    requiredStepCount: steps.length,
+    roleHints: extractRoleHints(messageText),
+    requiresSynthesis: REQUIRED_DELIVERABLE_CUE_RE.test(messageText),
+  };
+}
+
+function extractImplicitRequirements(
+  messageText: string,
+): RequiredSubagentOrchestrationRequirements | undefined {
+  if (!AGENT_REQUEST_VERB_RE.test(messageText) || !AGENT_NOUN_RE.test(messageText)) {
+    return undefined;
+  }
+  const roleHints = extractRoleHints(messageText);
+  const countMatch = IMPLICIT_AGENT_COUNT_RE.exec(messageText);
+  const requestedCount = parseRequestedAgentCount(countMatch?.[1]);
+  const hasDistinctRoleCue =
+    DISTINCT_ROLE_CUE_RE.test(messageText) ||
+    (MULTI_AGENT_ROLE_CUE_RE.test(messageText) && roleHints.length > 0);
+  const requiredStepCount =
+    requestedCount ??
+    (hasDistinctRoleCue && roleHints.length >= 2 ? roleHints.length : undefined);
+  if (!requiredStepCount || requiredStepCount < 2) {
+    return undefined;
+  }
+  if (!hasDistinctRoleCue && roleHints.length === 0) {
+    return undefined;
+  }
+  return {
+    mode: "minimum_steps",
+    steps: [],
+    stepNames: [],
+    requiredStepCount,
+    roleHints,
+    requiresSynthesis: REQUIRED_DELIVERABLE_CUE_RE.test(messageText),
+  };
+}
+
+export function extractRequiredSubagentOrchestrationRequirements(
+  messageText: string,
+): RequiredSubagentOrchestrationRequirements | undefined {
+  return (
+    extractExplicitRequirements(messageText) ??
+    extractImplicitRequirements(messageText)
+  );
+}
+
+export function allowsUserMandatedSubagentCardinalityOverride(
+  requirements: RequiredSubagentOrchestrationRequirements | undefined,
+): boolean {
+  return (
+    requirements !== undefined &&
+    requirements.requiredStepCount > 1
+  );
+}
+
+export function orchestrationRoleHintRegex(roleHint: string): RegExp | undefined {
+  return ROLE_HINT_PATTERNS.find((pattern) => pattern.hint === roleHint)?.re;
+}

--- a/runtime/src/workflow/verification-contract.test.ts
+++ b/runtime/src/workflow/verification-contract.test.ts
@@ -170,6 +170,65 @@ describe("verification-contract", () => {
     });
   });
 
+  it("accepts documentation rewrites that inherit verified workspace grounding from upstream dependencies", () => {
+    const decision = validateRuntimeVerificationContract({
+      verificationContract: {
+        workspaceRoot: "/tmp/project",
+        requiredSourceArtifacts: ["/tmp/project/PLAN.md"],
+        targetArtifacts: ["/tmp/project/PLAN.md"],
+        inheritedEvidence: {
+          workspaceInspectionSatisfied: true,
+          sourceSteps: ["qa_review", "layout_review"],
+        },
+        verificationMode: "mutation_required",
+        acceptanceCriteria: [
+          "PLAN.md reflects the current workspace layout and recent directory changes accurately.",
+        ],
+        completionContract: {
+          taskClass: "artifact_only",
+          placeholdersAllowed: false,
+          partialCompletionAllowed: false,
+          placeholderTaxonomy: "documentation",
+        },
+      },
+      output: "Updated /tmp/project/PLAN.md with the integrated reviewer feedback.",
+      toolCalls: [
+        {
+          name: "system.readFile",
+          args: { path: "/tmp/project/PLAN.md" },
+          result: JSON.stringify({
+            path: "/tmp/project/PLAN.md",
+            content: "# PLAN\n",
+          }),
+          isError: false,
+        },
+        {
+          name: "system.writeFile",
+          args: {
+            path: "/tmp/project/PLAN.md",
+            content:
+              "# PLAN\nIntegrated grounded reviewer findings about the current workspace layout.\n",
+          },
+          result: JSON.stringify({
+            path: "/tmp/project/PLAN.md",
+            bytesWritten: 82,
+          }),
+          isError: false,
+        },
+      ],
+    });
+
+    expect(decision).toMatchObject({
+      ok: true,
+      channels: expect.arrayContaining([
+        expect.objectContaining({
+          channel: "artifact_state",
+          ok: true,
+        }),
+      ]),
+    });
+  });
+
   it("fails placeholder/stub grading when implementation content still contains stub markers", () => {
     const decision = validateRuntimeVerificationContract({
       verificationContract: {

--- a/runtime/src/workflow/verification-obligations.test.ts
+++ b/runtime/src/workflow/verification-obligations.test.ts
@@ -130,6 +130,35 @@ describe("verification-obligations", () => {
     });
   });
 
+  it("waives local workspace inspection when upstream dependency evidence already satisfied it", () => {
+    const obligations = deriveVerificationObligations({
+      workspaceRoot: "/tmp/project",
+      requiredSourceArtifacts: ["/tmp/project/PLAN.md"],
+      targetArtifacts: ["/tmp/project/PLAN.md"],
+      inheritedEvidence: {
+        workspaceInspectionSatisfied: true,
+        sourceSteps: ["qa_review", "layout_review"],
+      },
+      acceptanceCriteria: [
+        "PLAN.md reflects the current workspace layout and recent directory changes accurately.",
+      ],
+      verificationMode: "mutation_required",
+      completionContract: {
+        taskClass: "artifact_only",
+        placeholdersAllowed: false,
+        partialCompletionAllowed: false,
+      },
+    });
+
+    expect(obligations).toMatchObject({
+      requiresWorkspaceInspectionEvidence: false,
+      requiresSourceArtifactReads: true,
+      completionContract: {
+        taskClass: "artifact_only",
+      },
+    });
+  });
+
   it("preserves explicit repair placeholder taxonomy from the completion contract", () => {
     const obligations = deriveVerificationObligations({
       workspaceRoot: "/tmp/project",

--- a/runtime/src/workflow/verification-obligations.ts
+++ b/runtime/src/workflow/verification-obligations.ts
@@ -18,6 +18,10 @@ export interface WorkflowVerificationContract {
   readonly inputArtifacts?: readonly string[];
   readonly requiredSourceArtifacts?: readonly string[];
   readonly targetArtifacts?: readonly string[];
+  readonly inheritedEvidence?: {
+    readonly workspaceInspectionSatisfied?: boolean;
+    readonly sourceSteps?: readonly string[];
+  };
   readonly acceptanceCriteria?: readonly string[];
   readonly verificationMode?: ExecutionVerificationMode;
   readonly stepKind?: ExecutionStepKind;
@@ -130,7 +134,8 @@ export function deriveVerificationObligations(
   const requiresReviewVerification =
     completionContract?.taskClass === "review_required";
   const requiresWorkspaceInspectionEvidence =
-    acceptanceCriteriaRequireWorkspaceInspection;
+    acceptanceCriteriaRequireWorkspaceInspection &&
+    normalizedInput.inheritedEvidence?.workspaceInspectionSatisfied !== true;
   const requiresMutationEvidence =
     completionContract?.taskClass === "review_required"
       ? false
@@ -207,6 +212,7 @@ function normalizeVerificationContractInput(
       targetArtifacts:
         executionContext?.targetArtifacts ??
         input.ownedArtifacts,
+      inheritedEvidence: input.inheritedEvidence,
       acceptanceCriteria: input.acceptanceCriteria,
       verificationMode: executionContext?.verificationMode,
       stepKind: executionContext?.stepKind,


### PR DESCRIPTION
## Summary
- preserve explicit user-requested multi-agent orchestration requirements in the planner and delegation admission path
- materialize planner synthesis handoffs and allow documentation writers to inherit grounded workspace-inspection evidence from reviewer dependencies
- fail closed when a child-owned artifact write fails instead of attempting inline planner-synthesis recovery writes

## Verification
- npm run test --workspace=@tetsuo-ai/runtime -- src/workflow/verification-obligations.test.ts src/workflow/verification-contract.test.ts src/utils/delegation-validation.test.ts src/gateway/subagent-orchestrator.test.ts src/llm/chat-executor.test.ts
- npm run build
- npm run techdebt