### PR TITLE
fix(channels): remove duplicate registerGatewayChannel in wireExterna…

### DIFF
--- a/runtime/src/gateway/channel-wiring.ts
+++ b/runtime/src/gateway/channel-wiring.ts
@@ -120,22 +120,6 @@ function isPluginChannelConfig(config: unknown): config is {
   return isRecord(config) && config.type === "plugin";
 }
 
-async function registerGatewayChannel(
-  gateway: Gateway | null,
-  channel: ChannelPlugin,
-): Promise<void> {
-  if (!gateway) return;
-  try {
-    gateway.registerChannel(channel);
-  } catch (error) {
-    try {
-      await channel.stop();
-    } catch {
-      // Best-effort cleanup after failed registration.
-    }
-    throw error;
-  }
-}
 
 async function stopExternalChannelRegistry(
   channels: ExternalChannelRegistry,
@@ -386,7 +370,6 @@ export async function wireTelegram(
     config: telegramConfig as unknown as Record<string, unknown>,
   });
   await telegram.start();
-  await registerGatewayChannel(deps.gateway, telegram);
   deps.logger.info("Telegram channel wired");
   return telegram;
 }
@@ -548,7 +531,6 @@ export async function wireExternalChannel(
     config: channelConfig,
   });
   await channel.start();
-  await registerGatewayChannel(deps.gateway, channel);
   deps.logger.info(`${channelName} channel wired`);
 }
 


### PR DESCRIPTION
Closes #73

## Problem
All external channel connectors (Telegram, Discord, Slack, etc.) 
double-registered with the gateway on daemon startup.

`wireTelegram` and `wireExternalChannel` in `channel-wiring.ts` each called 
`registerGatewayChannel` internally, while `daemon.ts` also calls 
`registerGatewayChannel` in its own startup registration loop — causing every 
external channel to register twice and crash the daemon.

## Fix
Removed the two redundant `registerGatewayChannel` calls from 
`channel-wiring.ts` (lines 389 and 551). Deleted the now-unused internal 
helper. `daemon.ts` remains the single owner of the registration loop.

## Testing
- Telegram connector tested on both agenc-creator and agenc-worker containers
- Confirmed single registration in logs: `Channel 'telegram' registered` (once)
- Both bots responding healthy in polling mode
- `npm run typecheck` passes