### PR TITLE
fix(runtime): harden live replay orchestration and verification

### DIFF
--- a/runtime/src/gateway/chat-executor-factory.test.ts
+++ b/runtime/src/gateway/chat-executor-factory.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createChatExecutor } from "./chat-executor-factory.js";
+import type { ResolvedSubAgentRuntimeConfig } from "./subagent-infrastructure.js";
+import type { GatewayLLMConfig } from "./types.js";
+import type { LLMProvider } from "../llm/types.js";
+
+function createProvider(): LLMProvider {
+  return {
+    name: "primary",
+    chat: vi.fn(),
+    chatStream: vi.fn(),
+    healthCheck: vi.fn().mockResolvedValue(true),
+  } as unknown as LLMProvider;
+}
+
+function createSubagentConfig(
+  overrides: Partial<ResolvedSubAgentRuntimeConfig> = {},
+): ResolvedSubAgentRuntimeConfig {
+  return {
+    enabled: true,
+    unsafeBenchmarkMode: true,
+    mode: "manager_tools",
+    delegationAggressiveness: "aggressive",
+    maxConcurrent: 0,
+    maxDepth: 0,
+    maxFanoutPerTurn: 0,
+    maxTotalSubagentsPerRequest: 0,
+    maxCumulativeToolCallsPerRequestTree: 0,
+    maxCumulativeTokensPerRequestTree: 0,
+    maxCumulativeTokensPerRequestTreeExplicitlyConfigured: false,
+    defaultTimeoutMs: 0,
+    baseSpawnDecisionThreshold: 0,
+    spawnDecisionThreshold: 0,
+    handoffMinPlannerConfidence: 0.82,
+    forceVerifier: false,
+    allowParallelSubtasks: true,
+    hardBlockedTaskClasses: [],
+    childToolAllowlistStrategy: "inherit_intersection",
+    childProviderStrategy: "same_as_parent",
+    fallbackBehavior: "continue_without_delegation",
+    policyLearningEnabled: false,
+    policyLearningEpsilon: 0.1,
+    policyLearningExplorationBudget: 0,
+    policyLearningMinSamplesPerArm: 0,
+    policyLearningUcbExplorationScale: 1,
+    policyLearningArms: [],
+    ...overrides,
+  };
+}
+
+describe("createChatExecutor", () => {
+  it("keeps planner verifier enabled in unsafe benchmark mode when subagents are enabled", () => {
+    const executor = createChatExecutor({
+      providers: [createProvider()],
+      toolHandler: vi.fn(),
+      allowedTools: ["system.readFile"],
+      maxToolRounds: 0,
+      llmConfig: {
+        provider: "grok",
+        model: "grok-code-fast-1",
+        plannerEnabled: true,
+      } as GatewayLLMConfig,
+      subagentConfig: createSubagentConfig(),
+      resolveDelegationScoreThreshold: () => 0,
+      resolveHostToolingProfile: () => null,
+      resolveHostWorkspaceRoot: () => null,
+    });
+
+    expect(executor).not.toBeNull();
+    expect((executor as any).subagentVerifierConfig).toMatchObject({
+      enabled: true,
+      force: false,
+    });
+  });
+});

--- a/runtime/src/gateway/chat-executor-factory.ts
+++ b/runtime/src/gateway/chat-executor-factory.ts
@@ -56,6 +56,8 @@ export interface CreateChatExecutorParams {
   onCompaction?: ChatExecutorConfig["onCompaction"];
   /** Gateway LLM config (for planner, timeout, retry, circuit breaker settings). */
   llmConfig?: GatewayLLMConfig;
+  /** Provider configs aligned 1:1 with the provider chain, including auto-added fallbacks. */
+  providerConfigs?: readonly GatewayLLMConfig[];
   /** Resolved subagent runtime config. */
   subagentConfig: ResolvedSubAgentRuntimeConfig;
   /** Callback to resolve dynamic delegation score threshold. */
@@ -104,6 +106,7 @@ export function createChatExecutor(
     providers: params.providers,
     economicsPolicy,
     llmConfig,
+    providerConfigs: params.providerConfigs,
   });
 
   return new ChatExecutor({
@@ -134,9 +137,7 @@ export function createChatExecutor(
     },
     resolveDelegationScoreThreshold: params.resolveDelegationScoreThreshold,
     subagentVerifier: {
-      enabled:
-        subagentConfig.enabled &&
-        !subagentConfig.unsafeBenchmarkMode,
+      enabled: subagentConfig.enabled,
       force: subagentConfig.forceVerifier,
     },
     delegationLearning: {

--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -278,7 +278,7 @@ describe("resolveBashToolTimeoutConfig", () => {
         llm: {},
       } as any),
     ).toEqual({
-      timeoutMs: 300_000,
+      timeoutMs: 60_000,
       maxTimeoutMs: 600_000,
     });
   });
@@ -314,7 +314,7 @@ describe("resolveBashToolTimeoutConfig", () => {
         llm: { toolCallTimeoutMs: 480_000 },
       } as any),
     ).toEqual({
-      timeoutMs: 300_000,
+      timeoutMs: 60_000,
       maxTimeoutMs: 480_000,
     });
   });

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -633,7 +633,7 @@ export function resolveBashToolTimeoutConfig(
     DEFAULT_TOOL_CALL_TIMEOUT_MS,
   );
   const baseTimeoutMs = config.desktop?.enabled
-    ? 300_000
+    ? 60_000
     : DEFAULT_BASH_TOOL_TIMEOUT_MS;
   const baseMaxTimeoutMs = config.desktop?.enabled
     ? 600_000
@@ -1276,6 +1276,7 @@ export class DaemonManager {
       providers: this._llmProviders,
       economicsPolicy,
       llmConfig: this._primaryLlmConfig,
+      providerConfigs: this._llmProviderConfigCatalog.map((entry) => entry.config),
     });
     const routingDecision = resolveModelRoute({
       policy: routingPolicy,
@@ -2040,6 +2041,7 @@ export class DaemonManager {
       sessionCompactionThreshold,
       onCompaction: this.handleCompaction,
       llmConfig: config.llm,
+      providerConfigs: this._llmProviderConfigCatalog.map((entry) => entry.config),
       subagentConfig: resolvedSubAgentConfig,
       resolveDelegationScoreThreshold: () =>
         this.resolveDelegationScoreThreshold(),
@@ -3507,6 +3509,7 @@ export class DaemonManager {
         sessionCompactionThreshold,
         onCompaction: this.handleCompaction,
         llmConfig: newConfig.llm,
+        providerConfigs: this._llmProviderConfigCatalog.map((entry) => entry.config),
         subagentConfig: resolvedSubAgentConfig,
         resolveDelegationScoreThreshold: () =>
           this.resolveDelegationScoreThreshold(),

--- a/runtime/src/gateway/delegation-admission.test.ts
+++ b/runtime/src/gateway/delegation-admission.test.ts
@@ -399,6 +399,214 @@ describe("assessDelegationAdmission", () => {
     expect(decision.shape).toBe("test_triage");
   });
 
+  it("allows a single typed writer handoff for implement-from-plan work even when retry cost is high", () => {
+    const workspaceRoot = "/tmp/agenc-shell";
+    const decision = assessDelegationAdmission({
+      messageText:
+        "Can you go through @PLAN.md and implement every phase sequentially in full and make sure they are fully tested.",
+      totalSteps: 2,
+      synthesisSteps: 0,
+      steps: [
+        {
+          name: "implement_phase_1",
+          objective:
+            "Implement Phase 1 from PLAN.md in the workspace and verify the result.",
+          inputContract: "PLAN.md plus the existing source tree.",
+          acceptanceCriteria: [
+            "Phase 1 implementation is present in workspace files.",
+            "Verification passes for the updated phase.",
+          ],
+          requiredToolCapabilities: [
+            "system.readFile",
+            "system.writeFile",
+            "system.bash",
+          ],
+          contextRequirements: ["read_plan"],
+          executionContext: {
+            version: "v1",
+            workspaceRoot,
+            allowedReadRoots: [workspaceRoot],
+            allowedWriteRoots: [workspaceRoot],
+            requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+            targetArtifacts: [
+              `${workspaceRoot}/src/lexer.c`,
+              `${workspaceRoot}/include/shell.h`,
+            ],
+            effectClass: "filesystem_write",
+            verificationMode: "mutation_required",
+            stepKind: "delegated_write",
+            artifactRelations: [
+              {
+                relationType: "read_dependency",
+                artifactPath: `${workspaceRoot}/PLAN.md`,
+              },
+              {
+                relationType: "write_owner",
+                artifactPath: `${workspaceRoot}/src/lexer.c`,
+              },
+              {
+                relationType: "write_owner",
+                artifactPath: `${workspaceRoot}/include/shell.h`,
+              },
+            ],
+          },
+          maxBudgetHint: "20m",
+          canRunParallel: false,
+        },
+      ],
+      edges: [],
+      threshold: 0.2,
+      maxFanoutPerTurn: 0,
+      maxDepth: 4,
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.reason).toBe("approved");
+    expect(decision.shape).toBe("bounded_sequential_handoff");
+    expect(decision.stepAdmissions).toEqual([
+      expect.objectContaining({
+        stepName: "implement_phase_1",
+        ownedArtifacts: [
+          `${workspaceRoot}/src/lexer.c`,
+          `${workspaceRoot}/include/shell.h`,
+        ],
+      }),
+    ]);
+  });
+
+  it("allows a writer plus validator handoff for sequential implementation from PLAN.md", () => {
+    const workspaceRoot = "/home/tetsuo/git/stream-test/agenc-shell";
+    const sourceDir = `${workspaceRoot}/src`;
+    const decision = assessDelegationAdmission({
+      messageText:
+        "Can you go through @PLAN.md and implement every phase sequentially in full and make sure they are fully tested. Do not move on to the next phase until the current one passes.",
+      totalSteps: 4,
+      synthesisSteps: 1,
+      steps: [
+        {
+          name: "implement_phase_1",
+          objective:
+            "Fully implement Phase 1 as specified in PLAN.md. Create all required files and code. Do not proceed to later phases.",
+          inputContract:
+            "PLAN.md content with Phase 1 details extracted and summarized.",
+          acceptanceCriteria: [
+            "All Phase 1 deliverables created in targetArtifacts.",
+            "Phase 1 code implements exact spec from PLAN.md.",
+            "All Phase 1 tests pass successfully.",
+            "No work done on later phases.",
+          ],
+          requiredToolCapabilities: [
+            "system.readFile",
+            "system.writeFile",
+            "system.bash",
+          ],
+          contextRequirements: ["repo_context", "parse_phases"],
+          executionContext: {
+            version: "v1",
+            workspaceRoot,
+            allowedReadRoots: [workspaceRoot],
+            allowedWriteRoots: [workspaceRoot],
+            allowedTools: [
+              "system.readFile",
+              "system.writeFile",
+              "system.bash",
+              "system.listDir",
+            ],
+            requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+            targetArtifacts: [sourceDir],
+            effectClass: "filesystem_write",
+            verificationMode: "mutation_required",
+            stepKind: "delegated_write",
+            role: "writer",
+            artifactRelations: [
+              {
+                relationType: "read_dependency",
+                artifactPath: `${workspaceRoot}/PLAN.md`,
+              },
+              {
+                relationType: "write_owner",
+                artifactPath: sourceDir,
+              },
+            ],
+            fallbackPolicy: "fail_request",
+            resumePolicy: "stateless_retry",
+            approvalProfile: "filesystem_write",
+          },
+          maxBudgetHint: "30m",
+          canRunParallel: false,
+        },
+        {
+          name: "test_phase_1",
+          objective:
+            "Run all Phase 1 tests from PLAN.md and report any failures blocking progression.",
+          inputContract:
+            "Phase 1 implementation artifacts and test specifications from PLAN.md.",
+          acceptanceCriteria: [
+            "All Phase 1 tests execute successfully with 100% pass rate.",
+            "No test failures or errors reported.",
+          ],
+          requiredToolCapabilities: ["system.bash", "system.readFile"],
+          contextRequirements: ["repo_context", "implement_phase_1"],
+          executionContext: {
+            version: "v1",
+            workspaceRoot,
+            allowedReadRoots: [workspaceRoot],
+            allowedWriteRoots: [workspaceRoot],
+            allowedTools: ["system.bash", "system.readFile", "system.listDir"],
+            requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+            targetArtifacts: [workspaceRoot],
+            effectClass: "shell",
+            verificationMode: "deterministic_followup",
+            stepKind: "delegated_validation",
+            role: "validator",
+            artifactRelations: [
+              {
+                relationType: "read_dependency",
+                artifactPath: `${workspaceRoot}/PLAN.md`,
+              },
+              {
+                relationType: "verification_subject",
+                artifactPath: sourceDir,
+              },
+            ],
+            fallbackPolicy: "fail_request",
+            resumePolicy: "stateless_retry",
+            approvalProfile: "shell",
+          },
+          maxBudgetHint: "15m",
+          canRunParallel: false,
+        },
+      ],
+      edges: [{ from: "implement_phase_1", to: "test_phase_1" }],
+      threshold: 0,
+      maxFanoutPerTurn: 0,
+      maxDepth: 1,
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.reason).toBe("approved");
+    expect(decision.shape).toBe("bounded_sequential_handoff");
+    expect(decision.diagnostics).toMatchObject({
+      shape: "bounded_sequential_handoff",
+      retryCost: expect.any(Number),
+    });
+    expect(
+      decision.stepAdmissions.map((entry) => ({
+        stepName: entry.stepName,
+        ownedArtifacts: entry.ownedArtifacts,
+      })),
+    ).toEqual([
+      {
+        stepName: "implement_phase_1",
+        ownedArtifacts: [sourceDir],
+      },
+      {
+        stepName: "test_phase_1",
+        ownedArtifacts: [],
+      },
+    ]);
+  });
+
   it("allows user-mandated multi-agent reviewer cardinality to bypass the generic fanout veto", () => {
     const decision = assessDelegationAdmission({
       messageText:
@@ -459,6 +667,114 @@ describe("assessDelegationAdmission", () => {
       edges: [],
       threshold: 0,
       maxFanoutPerTurn: 1,
+      maxDepth: 4,
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.reason).toBe("approved");
+  });
+
+  it("treats zero fanout as unlimited during delegation admission", () => {
+    const decision = assessDelegationAdmission({
+      messageText:
+        "Delegate architecture review, security review, and the final writer update.",
+      totalSteps: 3,
+      synthesisSteps: 1,
+      explicitDelegationRequested: true,
+      steps: [
+        {
+          name: "architecture_review",
+          objective: "Review the architecture",
+          inputContract: "Return grounded architecture findings.",
+          acceptanceCriteria: ["Architecture findings are grounded."],
+          requiredToolCapabilities: ["system.readFile"],
+          contextRequirements: [],
+          executionContext: {
+            version: "v1",
+            workspaceRoot: "/tmp/project",
+            allowedReadRoots: ["/tmp/project"],
+            allowedWriteRoots: ["/tmp/project"],
+            requiredSourceArtifacts: ["/tmp/project/PLAN.md"],
+            effectClass: "read_only",
+            verificationMode: "grounded_read",
+            stepKind: "delegated_review",
+            role: "reviewer",
+            artifactRelations: [
+              {
+                relationType: "read_dependency",
+                artifactPath: "/tmp/project/PLAN.md",
+              },
+            ],
+          },
+          maxBudgetHint: "2m",
+          canRunParallel: true,
+        },
+        {
+          name: "security_review",
+          objective: "Review the security plan",
+          inputContract: "Return grounded security findings.",
+          acceptanceCriteria: ["Security findings are grounded."],
+          requiredToolCapabilities: ["system.readFile"],
+          contextRequirements: [],
+          executionContext: {
+            version: "v1",
+            workspaceRoot: "/tmp/project",
+            allowedReadRoots: ["/tmp/project"],
+            allowedWriteRoots: ["/tmp/project"],
+            requiredSourceArtifacts: ["/tmp/project/PLAN.md"],
+            effectClass: "read_only",
+            verificationMode: "grounded_read",
+            stepKind: "delegated_review",
+            role: "reviewer",
+            artifactRelations: [
+              {
+                relationType: "read_dependency",
+                artifactPath: "/tmp/project/PLAN.md",
+              },
+            ],
+          },
+          maxBudgetHint: "2m",
+          canRunParallel: true,
+        },
+        {
+          name: "writer",
+          objective: "Update PLAN.md with the review findings",
+          inputContract: "Apply grounded findings to PLAN.md only.",
+          acceptanceCriteria: ["PLAN.md is updated."],
+          requiredToolCapabilities: ["system.readFile", "system.writeFile"],
+          contextRequirements: [],
+          executionContext: {
+            version: "v1",
+            workspaceRoot: "/tmp/project",
+            allowedReadRoots: ["/tmp/project"],
+            allowedWriteRoots: ["/tmp/project"],
+            requiredSourceArtifacts: ["/tmp/project/PLAN.md"],
+            targetArtifacts: ["/tmp/project/PLAN.md"],
+            effectClass: "filesystem_write",
+            verificationMode: "mutation_required",
+            stepKind: "delegated_write",
+            role: "writer",
+            artifactRelations: [
+              {
+                relationType: "read_dependency",
+                artifactPath: "/tmp/project/PLAN.md",
+              },
+              {
+                relationType: "write_owner",
+                artifactPath: "/tmp/project/PLAN.md",
+              },
+            ],
+          },
+          maxBudgetHint: "3m",
+          canRunParallel: false,
+        },
+      ],
+      edges: [
+        { from: "architecture_review", to: "writer" },
+        { from: "security_review", to: "writer" },
+      ],
+      threshold: 0,
+      maxFanoutPerTurn: 0,
       maxDepth: 4,
     });
 

--- a/runtime/src/gateway/delegation-admission.ts
+++ b/runtime/src/gateway/delegation-admission.ts
@@ -13,6 +13,10 @@ import {
   type DelegationEconomics,
   type DelegationStepAnalysis,
 } from "./delegation-economics.js";
+import {
+  resolveExecutionEnvelopeArtifactRelations,
+  resolveExecutionEnvelopeRole,
+} from "../workflow/execution-envelope.js";
 
 const REVIEW_TEXT_RE =
   /\b(?:review|critique|audit|inspect|assess|evaluate|docs?|documentation|security|architecture)\b/i;
@@ -160,6 +164,34 @@ function hasSingleWriterReadOnlyReviewerHandoff(
   }
   return readOnlyReviewerCount > 0;
 }
+
+function hasSingleMutableOwnerHandoff(
+  analyses: readonly DelegationStepAnalysis[],
+): boolean {
+  if (analyses.length === 0) {
+    return false;
+  }
+  const mutable = analyses.filter((analysis) => analysis.mutable);
+  if (mutable.length !== 1) {
+    return false;
+  }
+  const [analysis] = mutable;
+  if (!analysis || analysis.readOnly || analysis.shellObservationOnly) {
+    return false;
+  }
+  const hasOwnedScope =
+    analysis.ownedArtifacts.length > 0 ||
+    Boolean(analysis.step.executionContext?.workspaceRoot);
+  if (!hasOwnedScope) {
+    return false;
+  }
+  return analyses.every((candidate) =>
+    candidate.step.name === analysis.step.name ||
+    candidate.readOnly ||
+    candidate.shellObservationOnly
+  );
+}
+
 function collectSharedReviewArtifacts(
   analysis: DelegationStepAnalysis,
 ): readonly string[] {
@@ -442,10 +474,49 @@ function buildIsolationReason(
     case "independent_parallel_branches":
       return `This child owns a disjoint branch of work scoped to ${ownedArtifacts}, separate from sibling artifact sets.`;
     case "bounded_sequential_handoff":
+      if (ownsRemainingRequestEndToEnd(analysis)) {
+        return `This child owns the remaining request end to end inside ${ownedArtifacts} after its declared dependencies complete.`;
+      }
       return `This child owns a bounded handoff phase scoped to ${ownedArtifacts} after its declared dependencies complete.`;
     default:
       return `This child owns work scoped to ${ownedArtifacts}.`;
   }
+}
+
+function ownsRemainingRequestEndToEnd(
+  analysis: DelegationStepAnalysis,
+): boolean {
+  const executionContext = analysis.step.executionContext;
+  const workspaceRoot = executionContext?.workspaceRoot?.trim();
+  const role = resolveExecutionEnvelopeRole(executionContext);
+  if (!workspaceRoot || role !== "writer") {
+    return false;
+  }
+  const artifactRelations = resolveExecutionEnvelopeArtifactRelations(
+    executionContext,
+  );
+  const ownsWorkspaceRoot = artifactRelations.some((relation) =>
+    relation.relationType === "write_owner" &&
+      relation.artifactPath.trim() === workspaceRoot
+  ) || (executionContext?.targetArtifacts ?? []).some((artifactPath) =>
+    artifactPath.trim() === workspaceRoot
+  );
+  if (!ownsWorkspaceRoot) {
+    return false;
+  }
+  const combinedText = [
+    analysis.step.name,
+    analysis.step.objective,
+    analysis.step.inputContract,
+    ...(analysis.step.acceptanceCriteria ?? []),
+  ]
+    .join(" ")
+    .toLowerCase();
+  return (
+    analysis.step.name.trim().toLowerCase() === "implement_owner" ||
+    /\b(?:end to end|every phase|all phases|sequentially in full|requested implementation phases|full request)\b/i
+      .test(combinedText)
+  );
 }
 
 export function buildDelegationStepAdmission(params: {
@@ -678,6 +749,7 @@ export function assessDelegationAdmission(
     allowsUserMandatedSubagentCardinalityOverride(requiredOrchestration);
 
   if (
+    hasRuntimeLimit(input.maxFanoutPerTurn) &&
     input.steps.length > input.maxFanoutPerTurn &&
     !allowUserMandatedCardinality
   ) {
@@ -898,7 +970,11 @@ export function assessDelegationAdmission(
     });
   }
 
-  if (economics.retryCost > 0.9 && shape === "bounded_sequential_handoff") {
+  if (
+    economics.retryCost > 0.9 &&
+    shape === "bounded_sequential_handoff" &&
+    !hasSingleMutableOwnerHandoff(economics.stepAnalyses)
+  ) {
     return buildDecision({
       allowed: false,
       reason: "retry_cost_high",

--- a/runtime/src/gateway/delegation-economics.test.ts
+++ b/runtime/src/gateway/delegation-economics.test.ts
@@ -81,4 +81,101 @@ describe("deriveDelegationEconomics", () => {
     ).toEqual([[planPath], [planPath]]);
     expect(economics.explicitOwnershipCoverage).toBe(0.5);
   });
+
+  it("treats validator follow-up shell steps with verification_subject relations as non-writer work", () => {
+    const workspaceRoot = "/tmp/agenc-shell";
+    const sourceDir = `${workspaceRoot}/src`;
+    const economics = deriveDelegationEconomics({
+      messageText:
+        "Implement Phase 1 from PLAN.md, then run the Phase 1 tests before moving on.",
+      steps: [
+        {
+          name: "implement_phase_1",
+          objective: "Implement Phase 1 exactly as specified in PLAN.md.",
+          inputContract: "PLAN.md plus the existing source tree.",
+          acceptanceCriteria: ["Phase 1 source artifacts are implemented."],
+          requiredToolCapabilities: [
+            "system.readFile",
+            "system.writeFile",
+            "system.bash",
+          ],
+          contextRequirements: [],
+          executionContext: {
+            version: "v1",
+            workspaceRoot,
+            allowedReadRoots: [workspaceRoot],
+            allowedWriteRoots: [workspaceRoot],
+            requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+            targetArtifacts: [sourceDir],
+            effectClass: "filesystem_write",
+            verificationMode: "mutation_required",
+            stepKind: "delegated_write",
+            role: "writer",
+            artifactRelations: [
+              {
+                relationType: "read_dependency",
+                artifactPath: `${workspaceRoot}/PLAN.md`,
+              },
+              {
+                relationType: "write_owner",
+                artifactPath: sourceDir,
+              },
+            ],
+          },
+          maxBudgetHint: "30m",
+          canRunParallel: false,
+        },
+        {
+          name: "test_phase_1",
+          objective: "Run the Phase 1 tests and report grounded failures only.",
+          inputContract: "Implemented Phase 1 artifacts plus PLAN.md test requirements.",
+          acceptanceCriteria: ["All Phase 1 tests pass."],
+          requiredToolCapabilities: ["system.bash", "system.readFile"],
+          contextRequirements: ["implement_phase_1"],
+          executionContext: {
+            version: "v1",
+            workspaceRoot,
+            allowedReadRoots: [workspaceRoot],
+            allowedWriteRoots: [workspaceRoot],
+            requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+            targetArtifacts: [workspaceRoot],
+            effectClass: "shell",
+            verificationMode: "deterministic_followup",
+            stepKind: "delegated_validation",
+            role: "validator",
+            artifactRelations: [
+              {
+                relationType: "read_dependency",
+                artifactPath: `${workspaceRoot}/PLAN.md`,
+              },
+              {
+                relationType: "verification_subject",
+                artifactPath: sourceDir,
+              },
+            ],
+          },
+          maxBudgetHint: "15m",
+          canRunParallel: false,
+        },
+      ],
+      edges: [{ from: "implement_phase_1", to: "test_phase_1" }],
+    });
+
+    expect(economics.stepAnalyses.map((analysis) => analysis.mutable)).toEqual([
+      true,
+      false,
+    ]);
+    expect(
+      economics.stepAnalyses.map((analysis) => analysis.shellObservationOnly),
+    ).toEqual([false, true]);
+    expect(
+      economics.stepAnalyses.map((analysis) => analysis.ownedArtifacts),
+    ).toEqual([[sourceDir], []]);
+    expect(
+      economics.stepAnalyses.map((analysis) => analysis.referencedArtifacts),
+    ).toEqual([
+      [`${workspaceRoot}/PLAN.md`, sourceDir],
+      [`${workspaceRoot}/PLAN.md`, sourceDir],
+    ]);
+  });
 });

--- a/runtime/src/gateway/delegation-economics.ts
+++ b/runtime/src/gateway/delegation-economics.ts
@@ -105,6 +105,39 @@ function isReadOnlyEnvelope(effectClass?: DelegationExecutionContext["effectClas
   return effectClass === "read_only";
 }
 
+function hasArtifactRelationType(
+  artifactRelations: readonly WorkflowArtifactRelation[],
+  relationType: WorkflowArtifactRelation["relationType"],
+): boolean {
+  return artifactRelations.some((relation) => relation.relationType === relationType);
+}
+
+function isTypedVerificationOnlyStep(params: {
+  readonly step: DelegationCandidateStep;
+  readonly artifactRelations: readonly WorkflowArtifactRelation[];
+  readonly shellCapabilityCount: number;
+  readonly writeCapabilityCount: number;
+}): boolean {
+  const { step, artifactRelations, shellCapabilityCount, writeCapabilityCount } =
+    params;
+  const executionContext = step.executionContext;
+  if (!executionContext) return false;
+  if (hasArtifactRelationType(artifactRelations, "write_owner")) {
+    return false;
+  }
+  if (writeCapabilityCount > 0) {
+    return false;
+  }
+  if (executionContext.role !== "validator") {
+    return false;
+  }
+  return (
+    executionContext.verificationMode === "deterministic_followup" ||
+    hasArtifactRelationType(artifactRelations, "verification_subject") ||
+    shellCapabilityCount > 0
+  );
+}
+
 function extractExplicitFileArtifacts(
   segments: readonly string[],
   workspaceRoot?: string,
@@ -167,6 +200,12 @@ function analyzeStep(step: DelegationCandidateStep): DelegationStepAnalysis {
   const artifactRelations = collectArtifactRelations(step);
   const ownedArtifacts = collectOwnedArtifacts(artifactRelations);
   const referencedArtifacts = collectReferencedArtifacts(step, artifactRelations);
+  const typedVerificationOnly = isTypedVerificationOnlyStep({
+    step,
+    artifactRelations,
+    shellCapabilityCount,
+    writeCapabilityCount,
+  });
   const readOnly = isReadOnlyEnvelope(envelope?.effectClass) ||
     (
       writeCapabilityCount === 0 &&
@@ -174,17 +213,19 @@ function analyzeStep(step: DelegationCandidateStep): DelegationStepAnalysis {
       capabilities.length > 0 &&
       readCapabilityCount === capabilities.length
     );
-  const shellObservationOnly =
+  const shellObservationOnly = typedVerificationOnly || (
     writeCapabilityCount === 0 &&
     shellCapabilityCount > 0 &&
     (envelope?.targetArtifacts?.length ?? 0) === 0 &&
-    (envelope?.effectClass === "read_only" || readOnly);
-  const mutable =
+    (envelope?.effectClass === "read_only" || readOnly)
+  );
+  const mutable = !typedVerificationOnly && (
     envelope?.effectClass === "filesystem_write" ||
     envelope?.effectClass === "filesystem_scaffold" ||
     envelope?.effectClass === "mixed" ||
     writeCapabilityCount > 0 ||
-    (!readOnly && shellCapabilityCount > 0);
+    (!readOnly && shellCapabilityCount > 0)
+  );
 
   return {
     step,

--- a/runtime/src/gateway/sub-agent.test.ts
+++ b/runtime/src/gateway/sub-agent.test.ts
@@ -441,6 +441,84 @@ describe("SubAgentManager", () => {
       }
     });
 
+    it("preserves the resolved grok model contract for child route preflight", async () => {
+      const grokProvider: LLMProvider = {
+        name: "grok",
+        chat: vi.fn(async (): Promise<LLMResponse> => ({
+          content: "sub-agent output",
+          toolCalls: [],
+          usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+          model: "grok-code-fast-1",
+          finishReason: "stop",
+        })),
+        chatStream: vi.fn(
+          async (
+            _messages: LLMMessage[],
+            _cb: StreamProgressCallback,
+          ): Promise<LLMResponse> => ({
+            content: "sub-agent output",
+            toolCalls: [],
+            usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+            model: "grok-code-fast-1",
+            finishReason: "stop",
+          }),
+        ),
+        healthCheck: vi.fn(async () => true),
+        getCapabilities: () => ({
+          provider: "grok",
+          stateful: {
+            assistantPhase: false,
+            previousResponseId: true,
+            encryptedReasoning: true,
+            storedResponseRetrieval: true,
+            storedResponseDeletion: true,
+            opaqueCompaction: false,
+            deterministicFallback: true,
+          },
+        }),
+      };
+      const toolRegistry = new ToolRegistry({});
+      toolRegistry.register(makeMockTool("system.readFile"));
+      toolRegistry.register(makeMockTool("system.writeFile"));
+      toolRegistry.register(makeMockTool("system.bash"));
+      const createContext = vi.fn(async () => ({
+        ...makeMockContext(),
+        llmProvider: grokProvider,
+        toolRegistry,
+      }));
+      const manager = new SubAgentManager(
+        makeManagerConfig({
+          createContext,
+          resolveExecutionBudget: () => ({
+            providerProfile: {
+              provider: "grok",
+              model: "grok-code-fast-1",
+              contextWindowTokens: 256_000,
+              contextWindowSource: "grok_model_catalog",
+              maxOutputTokens: 4_096,
+            },
+          }),
+        }),
+      );
+
+      const sessionId = await manager.spawn({
+        parentSessionId: "p",
+        task: "Inspect the workspace and report which files need attention.",
+        tools: ["system.readFile", "system.writeFile", "system.bash"],
+      });
+
+      let result = manager.getResult(sessionId);
+      for (let i = 0; i < 20 && result === null; i += 1) {
+        await settle();
+        result = manager.getResult(sessionId);
+      }
+
+      expect(result).not.toBeNull();
+      expect(result?.success).toBe(true);
+      expect(result?.stopReason).toBe("completed");
+      expect(grokProvider.chat).toHaveBeenCalledTimes(1);
+    });
+
     it("allows iterative coding child phases to exceed the base text-only tool-round cap", async () => {
       let rounds = 0;
       const llmProvider: LLMProvider = {
@@ -1334,6 +1412,57 @@ describe("SubAgentManager", () => {
               maxCorrectionAttempts: 0,
               delegationSpec,
             }),
+          }),
+        );
+      } finally {
+        executeSpy.mockRestore();
+      }
+    });
+
+    it("passes delegated workspace roots into child execution runtime context", async () => {
+      const executeSpy = vi.spyOn(ChatExecutor.prototype, "execute")
+        .mockResolvedValueOnce({
+          content: "ok",
+          provider: "mock",
+          model: "mock",
+          usedFallback: false,
+          toolCalls: [],
+          tokenUsage: {
+            promptTokens: 10,
+            completionTokens: 5,
+            totalTokens: 15,
+          },
+          callUsage: [],
+          durationMs: 1,
+          compacted: false,
+          stopReason: "completed",
+          completionState: "completed",
+          completionProgress: {
+            completionState: "completed",
+            stopReason: "completed",
+            requiredRequirements: [],
+            satisfiedRequirements: [],
+            remainingRequirements: [],
+            reusableEvidence: [],
+            updatedAt: 1_700_000_000_000,
+          },
+        });
+
+      try {
+        const manager = new SubAgentManager(makeManagerConfig());
+        const sessionId = await manager.spawn({
+          parentSessionId: "p",
+          task: "Run repo-local verification",
+          workingDirectory: "/tmp/project",
+        });
+        await settle();
+
+        expect(manager.getResult(sessionId)?.success).toBe(true);
+        expect(executeSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            runtimeContext: {
+              workspaceRoot: "/tmp/project",
+            },
           }),
         );
       } finally {

--- a/runtime/src/gateway/sub-agent.ts
+++ b/runtime/src/gateway/sub-agent.ts
@@ -16,6 +16,7 @@ import type {
 import { createGatewayMessage } from "./message.js";
 import { ChatExecutor } from "../llm/chat-executor.js";
 import { buildModelRoutingPolicy } from "../llm/model-routing-policy.js";
+import type { GatewayLLMConfig } from "./types.js";
 import type { PromptBudgetConfig } from "../llm/prompt-budget.js";
 import {
   buildRuntimeEconomicsPolicy,
@@ -67,11 +68,10 @@ export const DEFAULT_TERMINAL_SUB_AGENT_RETENTION_MS = 6 * 60 * 60 * 1000; // 6h
 export const SUB_AGENT_SESSION_PREFIX = "subagent:";
 
 const DEFAULT_SUB_AGENT_SYSTEM_PROMPT =
-  "You are a sub-agent. Execute only the assigned phase, stay within the provided scope, " +
-  "and report the result concisely. Do not reinterpret the broader parent request into a " +
-  "new multi-step plan, do not attempt sibling phases, and do not delegate unless the " +
-  "task explicitly grants that authority. Honor the declared isolation reason, " +
-  "owned artifacts, and verifier obligations for the delegated phase.";
+  "You are a sub-agent. Execute only the assigned delegated contract, stay within the provided scope, " +
+  "and report the result concisely. Do not widen a bounded phase into a new broader parent plan, and do not delegate unless the " +
+  "task explicitly grants that authority. If the delegated contract owns the remaining request end to end, keep working until it is complete or concretely blocked. " +
+  "Honor the declared isolation reason, owned artifacts, and verifier obligations for the delegated contract.";
 
 const ABORT_SENTINEL = Symbol("abort");
 const TIMEOUT_SENTINEL = Symbol("timeout");
@@ -695,6 +695,15 @@ export class SubAgentManager {
         maxFanoutPerTurn: 1,
         mode: this.config.economicsMode ?? "enforce",
       });
+      const selectedProviderRoutingConfig: GatewayLLMConfig | undefined =
+        selectedProvider.name === "grok" || selectedProvider.name === "ollama"
+          ? {
+            provider: selectedProvider.name,
+            ...(resolvedProviderProfile?.model
+              ? { model: resolvedProviderProfile.model }
+              : {}),
+          }
+          : undefined;
       const executor = new ChatExecutor({
         providers: [selectedProvider],
         toolHandler,
@@ -711,6 +720,9 @@ export class SubAgentManager {
         modelRoutingPolicy: buildModelRoutingPolicy({
           providers: [selectedProvider],
           economicsPolicy,
+          ...(selectedProviderRoutingConfig
+            ? { providerConfigs: [selectedProviderRoutingConfig] }
+            : {}),
         }),
         resolveHostWorkspaceRoot: () =>
           handle.config.workingDirectory ?? null,
@@ -801,6 +813,13 @@ export class SubAgentManager {
           history: handle.history,
           systemPrompt,
           sessionId: handle.sessionId,
+          ...(handle.config.workingDirectory
+            ? {
+              runtimeContext: {
+                workspaceRoot: handle.config.workingDirectory,
+              },
+            }
+            : {}),
           ...(typeof effectiveToolBudgetPerRequest === "number"
             ? { toolBudgetPerRequest: effectiveToolBudgetPerRequest }
             : {}),

--- a/runtime/src/gateway/subagent-orchestrator.test.ts
+++ b/runtime/src/gateway/subagent-orchestrator.test.ts
@@ -2890,6 +2890,117 @@ describe("SubAgentOrchestrator", () => {
     expect(taskPrompt).toContain("Assigned phase only: recover_marker");
   });
 
+  it("treats single-owner implement_owner handoffs as end-to-end request ownership", async () => {
+    const fallback = createFallbackExecutor(async (pipeline) => ({
+      status: "completed",
+      context: pipeline.context,
+      completedSteps: pipeline.steps.length,
+      totalSteps: pipeline.steps.length,
+    }));
+    const manager = new FakeSubAgentManager(5, true);
+    const workspaceRoot = "/home/tetsuo/git/stream-test/agenc-shell";
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: fallback,
+      resolveSubAgentManager: () => manager,
+      pollIntervalMs: 5,
+      resolveAvailableToolNames: () => [
+        "system.readFile",
+        "system.writeFile",
+        "system.bash",
+      ],
+    });
+
+    const pipeline: Pipeline = {
+      id: "planner:session-parent-implement-owner:123",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerSteps: [
+        {
+          name: "implement_owner",
+          stepType: "subagent_task",
+          objective:
+            "Execute this implementation request inside the workspace: Can you go through @PLAN.md and implement every phase sequentially in full and make sure they are fully tested.",
+          inputContract:
+            "Use the planning artifact plus the current workspace to perform the requested implementation end to end. Do not stop at analysis only.",
+          acceptanceCriteria: [
+            "Workspace files are updated to satisfy the requested implementation phases.",
+            "Grounded verification runs before completion, and passing or failing commands are reported concretely.",
+          ],
+          requiredToolCapabilities: [
+            "system.readFile",
+            "system.writeFile",
+            "system.bash",
+          ],
+          contextRequirements: ["read_plan"],
+          executionContext: {
+            workspaceRoot,
+            allowedReadRoots: [workspaceRoot],
+            allowedWriteRoots: [workspaceRoot],
+            targetArtifacts: [workspaceRoot],
+            requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+            effectClass: "filesystem_write",
+            verificationMode: "mutation_required",
+            stepKind: "delegated_write",
+            role: "writer",
+            artifactRelations: [
+              {
+                relationType: "read_dependency",
+                artifactPath: `${workspaceRoot}/PLAN.md`,
+              },
+              {
+                relationType: "write_owner",
+                artifactPath: workspaceRoot,
+              },
+            ],
+          },
+          maxBudgetHint: "30m",
+          canRunParallel: false,
+        },
+      ],
+      plannerContext: {
+        parentRequest:
+          "Can you go through @PLAN.md and implement every phase sequentially in full and make sure they are fully tested. do not move on to the next phase until you finish the current one and it is passing all tests.",
+        history: [],
+        memory: [],
+        toolOutputs: [],
+        workspaceRoot,
+      },
+    };
+
+    const result = await orchestrator.execute(pipeline);
+
+    expect(result.status).toBe("completed");
+    const taskPrompt = manager.spawnCalls[0]?.task ?? "";
+    expect(taskPrompt).toContain(
+      "You own the assigned implementation contract end to end inside the approved workspace.",
+    );
+    expect(taskPrompt).toContain(
+      "Complete the remaining requested phases sequentially; do not stop after a single named phase from the planning artifact.",
+    );
+    expect(taskPrompt).toContain(
+      "When the planning artifact is the source specification, inspect the current workspace before assuming plan-listed files already exist.",
+    );
+    expect(taskPrompt).toContain(
+      "Confirm relevant directories or files under the owned workspace before reading them or presenting them as present.",
+    );
+    expect(taskPrompt).toContain(
+      "Treat generated artifacts such as copied build/output directories as provisional state, not trusted source inputs.",
+    );
+    expect(taskPrompt).toContain(
+      "create a fresh generated directory/path for the current workspace and verify against that instead.",
+    );
+    expect(taskPrompt).not.toContain("Execute only the assigned phase `implement_owner`.");
+    expect(taskPrompt).not.toContain("Assigned phase only: implement_owner");
+    expect(taskPrompt).not.toContain(
+      "Ignore broader orchestration instructions and other phases.",
+    );
+    expect(taskPrompt).toContain(
+      `This child owns the remaining request end to end inside ${workspaceRoot} after its declared dependencies complete.`,
+    );
+    expect(taskPrompt).not.toContain("bounded handoff phase");
+  });
+
   it("adds structured shell usage guidance to child prompts when shell tools are allowed", async () => {
     const fallback = createFallbackExecutor(async (pipeline) => ({
       status: "completed",
@@ -2966,6 +3077,21 @@ describe("SubAgentOrchestrator", () => {
     );
     expect(taskPrompt).toContain(
       "Verification commands must be non-interactive and exit on their own.",
+    );
+    expect(taskPrompt).toContain(
+      "invoke them from the workspace root (for example `bash tests/run_tests.sh`)",
+    );
+    expect(taskPrompt).toContain(
+      "Treat existing repo-local verification scripts and harnesses as read-only grader infrastructure unless the contract explicitly names them as writable targets.",
+    );
+    expect(taskPrompt).toContain(
+      "Do not create alternate copies or wrapper variants of repo-local verification harnesses",
+    );
+    expect(taskPrompt).toContain(
+      "If a repo-local verification script contains a command that can block indefinitely without its own one-shot flag or timeout, do not invoke the script raw.",
+    );
+    expect(taskPrompt).toContain(
+      "Do not delete binaries or build artifacts with commands like `rm` just to prove a rebuild",
     );
   });
 
@@ -6807,6 +6933,306 @@ describe("SubAgentOrchestrator", () => {
     expect(manager.spawnCalls).toHaveLength(1);
   });
 
+  it("retries blocked_phase_output once for full-request owner implementation handoffs", async () => {
+    const fallback = createFallbackExecutor(async (pipeline) => ({
+      status: "completed",
+      context: pipeline.context,
+      completedSteps: pipeline.steps.length,
+      totalSteps: pipeline.steps.length,
+    }));
+    const workspaceRoot = "/home/tetsuo/git/stream-test/agenc-shell";
+    const manager = new SequencedSubAgentManager([
+      {
+        delayMs: 5,
+        result: {
+          output:
+            "Phase 0 complete. Phase 1 complete. Phase 2 implemented. Phase 3/4 implemented. " +
+            "Phase 2 is blocked by failing parser tests, so I cannot finish the full request yet.",
+          success: false,
+          completionState: "blocked",
+          durationMs: 14,
+          toolCalls: [
+            {
+              name: "system.writeFile",
+              args: {
+                path: `${workspaceRoot}/src/parser.c`,
+                content: "/* parser repair */\n",
+              },
+              result: `{"path":"${workspaceRoot}/src/parser.c","bytesWritten":19}`,
+              durationMs: 3,
+            },
+            {
+              name: "system.bash",
+              args: {
+                command: "./tests/run_tests.sh",
+                cwd: workspaceRoot,
+              },
+              result:
+                '{"stdout":"","stderr":"parser test segfault","exitCode":139}',
+              isError: false,
+              durationMs: 6,
+            },
+          ],
+          stopReason: "validation_error",
+          stopReasonDetail:
+            "Delegated task output reported the phase as blocked or incomplete instead of completing it: Phase 2 is blocked by failing parser tests, so I cannot finish the full request yet.",
+          validationCode: "blocked_phase_output",
+        },
+      },
+      {
+        delayMs: 5,
+        result: {
+          output:
+            "Implemented the remaining phases end to end, fixed the parser failure, and verified the full request with the workspace test harness.",
+          success: true,
+          completionState: "completed",
+          durationMs: 18,
+          toolCalls: [
+            {
+              name: "system.writeFile",
+              args: {
+                path: `${workspaceRoot}/src/parser.c`,
+                content: "/* parser repair final */\n",
+              },
+              result: `{"path":"${workspaceRoot}/src/parser.c","bytesWritten":25}`,
+              durationMs: 3,
+            },
+            {
+              name: "system.bash",
+              args: {
+                command: "./tests/run_tests.sh",
+                cwd: workspaceRoot,
+              },
+              result:
+                '{"stdout":"all tests passed","stderr":"","exitCode":0}',
+              isError: false,
+              durationMs: 7,
+            },
+          ],
+          stopReason: "completed",
+        },
+      },
+    ]);
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: fallback,
+      resolveSubAgentManager: () => manager,
+      pollIntervalMs: 5,
+    });
+
+    const pipeline: Pipeline = {
+      id: "planner:session-owner-blocked-retry:1",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerSteps: [
+        {
+          name: "implement_owner",
+          stepType: "subagent_task",
+          objective:
+            "Execute this implementation request inside the workspace: Can you go through @PLAN.md and implement every phase sequentially in full and make sure they are fully tested.",
+          inputContract:
+            "Use the planning artifact plus the current workspace to perform the requested implementation end to end. Do not stop at analysis only.",
+          acceptanceCriteria: [
+            "Workspace files are updated to satisfy the requested implementation phases.",
+            "Grounded verification runs before completion, and passing or failing commands are reported concretely.",
+          ],
+          requiredToolCapabilities: [
+            "system.readFile",
+            "system.writeFile",
+            "system.bash",
+          ],
+          contextRequirements: ["read_plan"],
+          executionContext: {
+            workspaceRoot,
+            allowedReadRoots: [workspaceRoot],
+            allowedWriteRoots: [workspaceRoot],
+            targetArtifacts: [workspaceRoot],
+            requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+            effectClass: "filesystem_write",
+            verificationMode: "mutation_required",
+            stepKind: "delegated_write",
+            role: "writer",
+            artifactRelations: [
+              {
+                relationType: "read_dependency",
+                artifactPath: `${workspaceRoot}/PLAN.md`,
+              },
+              {
+                relationType: "write_owner",
+                artifactPath: workspaceRoot,
+              },
+            ],
+          },
+          maxBudgetHint: "30m",
+          canRunParallel: false,
+        },
+      ],
+      plannerContext: {
+        parentRequest:
+          "Can you go through @PLAN.md and implement every phase sequentially in full and make sure they are fully tested. do not move on to the next phase until you finish the current one and it is passing all tests.",
+        history: [],
+        memory: [],
+        toolOutputs: [],
+        workspaceRoot,
+      },
+    };
+
+    const result = await orchestrator.execute(pipeline);
+
+    expect(result.status).toBe("completed");
+    expect(manager.spawnCalls).toHaveLength(2);
+    const retryPrompt = manager.spawnCalls[1]?.task ?? "";
+    expect(retryPrompt).toContain(
+      "This delegated contract owns the remaining request end to end. Do not stop at a phase-progress summary because one later phase is failing.",
+    );
+    expect(retryPrompt).toContain(
+      "Continue repairing the current blocker with the allowed tools until the full request is complete",
+    );
+  });
+
+  it("retries contradictory_completion_claim once for full-request owner implementation handoffs", async () => {
+    const fallback = createFallbackExecutor(async (pipeline) => ({
+      status: "completed",
+      context: pipeline.context,
+      completedSteps: pipeline.steps.length,
+      totalSteps: pipeline.steps.length,
+    }));
+    const workspaceRoot = "/home/tetsuo/git/stream-test/agenc-shell";
+    const manager = new SequencedSubAgentManager([
+      {
+        delayMs: 5,
+        result: {
+          output:
+            "The assigned phase `implement_owner` completed Phase 1 and Phase 2 successfully. " +
+            "Phase 3 is out of scope for this phase, so the remaining work belongs to the next phase.",
+          success: false,
+          completionState: "blocked",
+          durationMs: 14,
+          toolCalls: [
+            {
+              name: "system.writeFile",
+              args: {
+                path: `${workspaceRoot}/src/parser.c`,
+                content: "/* parser repair */\n",
+              },
+              result: `{\"path\":\"${workspaceRoot}/src/parser.c\",\"bytesWritten\":19}`,
+              durationMs: 3,
+            },
+          ],
+          stopReason: "validation_error",
+          stopReasonDetail:
+            "Delegated task output claimed completion while still reporting unresolved work: Phase 3 is out of scope for this phase.",
+          validationCode: "contradictory_completion_claim",
+        },
+      },
+      {
+        delayMs: 5,
+        result: {
+          output:
+            "Implemented the remaining phases end to end, completed the shell plan, and verified the full request with the workspace test harness.",
+          success: true,
+          completionState: "completed",
+          durationMs: 18,
+          toolCalls: [
+            {
+              name: "system.writeFile",
+              args: {
+                path: `${workspaceRoot}/src/executor.c`,
+                content: "/* executor repair final */\n",
+              },
+              result: `{\"path\":\"${workspaceRoot}/src/executor.c\",\"bytesWritten\":27}`,
+              durationMs: 3,
+            },
+            {
+              name: "system.bash",
+              args: {
+                command: "./tests/run_tests.sh",
+                cwd: workspaceRoot,
+              },
+              result:
+                '{"stdout":"all tests passed","stderr":"","exitCode":0}',
+              isError: false,
+              durationMs: 7,
+            },
+          ],
+          stopReason: "completed",
+        },
+      },
+    ]);
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: fallback,
+      resolveSubAgentManager: () => manager,
+      pollIntervalMs: 5,
+    });
+
+    const pipeline: Pipeline = {
+      id: "planner:session-owner-contradictory-retry:1",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerSteps: [
+        {
+          name: "implement_owner",
+          stepType: "subagent_task",
+          objective:
+            "Execute this implementation request inside the workspace: Can you go through @PLAN.md and implement every phase sequentially in full and make sure they are fully tested.",
+          inputContract:
+            "Use the planning artifact plus the current workspace to perform the requested implementation end to end. Do not stop at analysis only.",
+          acceptanceCriteria: [
+            "Workspace files are updated to satisfy the requested implementation phases.",
+            "Grounded verification runs before completion, and passing or failing commands are reported concretely.",
+          ],
+          requiredToolCapabilities: [
+            "system.readFile",
+            "system.writeFile",
+            "system.bash",
+          ],
+          contextRequirements: ["read_plan"],
+          executionContext: {
+            workspaceRoot,
+            allowedReadRoots: [workspaceRoot],
+            allowedWriteRoots: [workspaceRoot],
+            targetArtifacts: [workspaceRoot],
+            requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+            effectClass: "filesystem_write",
+            verificationMode: "mutation_required",
+            stepKind: "delegated_write",
+            role: "writer",
+            artifactRelations: [
+              {
+                relationType: "read_dependency",
+                artifactPath: `${workspaceRoot}/PLAN.md`,
+              },
+              {
+                relationType: "write_owner",
+                artifactPath: workspaceRoot,
+              },
+            ],
+          },
+          maxBudgetHint: "30m",
+          canRunParallel: false,
+        },
+      ],
+      plannerContext: {
+        parentRequest:
+          "Can you go through @PLAN.md and implement every phase sequentially in full and make sure they are fully tested. do not move on to the next phase until you finish the current one and it is passing all tests.",
+        history: [],
+        memory: [],
+        toolOutputs: [],
+        workspaceRoot,
+      },
+    };
+
+    const result = await orchestrator.execute(pipeline);
+
+    expect(result.status).toBe("completed");
+    expect(manager.spawnCalls).toHaveLength(2);
+    const retryPrompt = manager.spawnCalls[1]?.task ?? "";
+    expect(retryPrompt).toContain(
+      "For an end-to-end owner contract, do not return a mixed phase-progress/completion summary.",
+    );
+  });
+
   it("fails successful child outputs that hide omitted implementation behind code comments", async () => {
     const fallback = createFallbackExecutor(async (pipeline) => ({
       status: "completed",
@@ -7477,6 +7903,64 @@ describe("SubAgentOrchestrator", () => {
     expect(corePayload.stopReasonHint).toBe("budget_exceeded");
     expect((corePayload as { attempts?: number }).attempts).toBe(2);
     expect(result.context.results.implement_cli).toContain("dependency_blocked");
+  });
+
+  it("honors per-step fail_request fallback policy even when orchestrator fallback is continue_without_delegation", async () => {
+    const fallback = createFallbackExecutor(async (pipeline) => ({
+      status: "completed",
+      context: pipeline.context,
+      completedSteps: pipeline.steps.length,
+      totalSteps: pipeline.steps.length,
+    }));
+    const manager = new SequencedSubAgentManager([
+      {
+        delayMs: 5,
+        result: {
+          output: "All tool calls failed for 3 consecutive rounds",
+          success: false,
+          durationMs: 20,
+          toolCalls: [],
+          stopReason: "no_progress",
+        },
+      },
+    ]);
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: fallback,
+      resolveSubAgentManager: () => manager,
+      pollIntervalMs: 5,
+      fallbackBehavior: "continue_without_delegation",
+    });
+
+    const { executionContext } = createTestExecutionContext({
+      prefix: "subagent-fail-request-precedence-",
+    });
+    const result = await orchestrator.execute({
+      id: "planner:session-step-fallback-precedence:1",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerSteps: [
+        {
+          name: "implement_owner",
+          stepType: "subagent_task",
+          objective: "Implement the owned request end to end",
+          inputContract: "Workspace exists",
+          acceptanceCriteria: ["Implementation is complete"],
+          requiredToolCapabilities: ["system.bash", "system.writeFile"],
+          contextRequirements: [],
+          executionContext: {
+            ...executionContext,
+            fallbackPolicy: "fail_request",
+          },
+          maxBudgetHint: "3m",
+          canRunParallel: false,
+        },
+      ],
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toContain("All tool calls failed for 3 consecutive rounds");
+    expect(result.context.results.implement_owner).toBeUndefined();
   });
 
   it("retries delegated budget exhaustion once with an expanded child tool budget", async () => {

--- a/runtime/src/gateway/subagent-orchestrator.ts
+++ b/runtime/src/gateway/subagent-orchestrator.ts
@@ -109,6 +109,7 @@ import {
 } from "./subagent-workspace-probes.js";
 import {
   summarizeParentRequestForSubagent,
+  isFullRequestOwnerStep,
   collectDependencyContexts,
   buildArtifactRelevanceTerms,
   buildDownstreamRequirementLines,
@@ -140,6 +141,7 @@ import {
   mapDeterministicPipelineResultToNodeOutcome,
 } from "../workflow/execution-kernel-policy.js";
 import type { ExecutionKernelNodeOutcome } from "../workflow/execution-kernel-types.js";
+import { areDocumentationOnlyArtifacts } from "../workflow/artifact-paths.js";
 
 interface ExecuteSubagentAttemptParams {
   readonly subAgentManager: SubAgentExecutionManager;
@@ -276,6 +278,20 @@ interface SubAgentExecutionManager {
 interface ResolvedChildPromptBudget {
   readonly promptBudget?: PromptBudgetConfig;
   readonly providerProfile?: LLMProviderExecutionProfile;
+}
+
+function resolveStepFallbackBehavior(
+  step: PipelinePlannerSubagentStep,
+  orchestratorFallbackBehavior: "continue_without_delegation" | "fail_request",
+): "continue_without_delegation" | "fail_request" {
+  const stepPolicy = step.executionContext?.fallbackPolicy;
+  if (
+    stepPolicy === "continue_without_delegation" ||
+    stepPolicy === "fail_request"
+  ) {
+    return stepPolicy;
+  }
+  return orchestratorFallbackBehavior;
 }
 
 export interface SubAgentOrchestratorConfig {
@@ -1370,8 +1386,37 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       }
       const retryRule = SUBAGENT_RETRY_POLICY[lastFailure.failureClass];
       const retriesUsed = retryAttempts[lastFailure.failureClass];
+      const stepLooksLikeLocalWriter =
+        preparedStep.executionContext?.verificationMode ===
+          "mutation_required" ||
+        (preparedStep.executionContext?.allowedWriteRoots?.length ?? 0) > 0 ||
+        preparedStep.requiredToolCapabilities.some((capability) =>
+          capability === "system.writeFile" ||
+          capability === "system.appendFile" ||
+          capability === "desktop.text_editor" ||
+          capability === "mcp.neovim.vim_edit" ||
+          capability === "mcp.neovim.vim_buffer_save" ||
+          capability === "mcp.neovim.vim_search_replace"
+        );
+      const allowResultContractRepairRetry =
+        lastFailure.failureClass === "malformed_result_contract" &&
+        (
+          (
+            lastFailure.validationCode === "blocked_phase_output" &&
+            isFullRequestOwnerStep(preparedStep)
+          ) ||
+          (
+            lastFailure.validationCode === "contradictory_completion_claim" &&
+            (
+              isFullRequestOwnerStep(preparedStep) ||
+              stepLooksLikeLocalWriter
+            )
+          )
+        );
       const shouldRetry =
-        lastFailure.validationCode !== "blocked_phase_output" &&
+        ((lastFailure.validationCode !== "blocked_phase_output" &&
+          lastFailure.validationCode !== "contradictory_completion_claim") ||
+          allowResultContractRepairRetry) &&
         retriesUsed < retryRule.maxRetries;
       const retryAttempt = retriesUsed + 1;
       const retryDelayMs = shouldRetry
@@ -1510,7 +1555,10 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         };
       }
 
-      if (this.fallbackBehavior === "continue_without_delegation") {
+      if (
+        resolveStepFallbackBehavior(preparedStep, this.fallbackBehavior) ===
+          "continue_without_delegation"
+      ) {
         return {
           status: "completed",
           result: safeStringify({
@@ -2169,8 +2217,29 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         toolName === "system.appendFile" ||
         toolName === "desktop.text_editor"
       );
+      const fullRequestOwner = isFullRequestOwnerStep(effectiveStep);
+      const planBackedFullRequestOwner =
+        fullRequestOwner &&
+        areDocumentationOnlyArtifacts(
+          effectiveStep.executionContext?.requiredSourceArtifacts ?? [],
+        );
       sections.push(
-        `Execution rules:
+        fullRequestOwner
+          ? `Execution rules:
+- You own the assigned implementation contract end to end inside the approved workspace.
+- Complete the remaining requested phases sequentially; do not stop after a single named phase from the planning artifact.
+- You may organize the work phase by phase internally, but do not hand back an intermediate phase completion as the final result.
+- Do not delegate unless the task explicitly grants that authority.
+- If the task requires tool-grounded evidence, you must use one or more allowed tools before answering.
+- If the input contract or context requirements name source files or current workspace artifacts, inspect those sources before writing derived files.
+- If a source artifact describes intended or planned structure, label it as intended/planned unless you directly confirmed the files currently exist.
+- When the planning artifact is the source specification, inspect the current workspace before assuming plan-listed files already exist.${planBackedFullRequestOwner ? " Confirm relevant directories or files under the owned workspace before reading them or presenting them as present." : ""}
+-${planBackedFullRequestOwner
+            ? " Treat generated artifacts such as copied build/output directories as provisional state, not trusted source inputs. If verification shows a generated directory is stale or unconfigured, do not delete it with `rm`; create a fresh generated directory/path for the current workspace and verify against that instead."
+            : " Treat generated artifacts and build outputs as provisional state. If verification shows they are stale or unconfigured, regenerate them in a fresh location for the current workspace instead of assuming they are reusable."}
+- The per-call tool JSON is authoritative for the current recall. The phase allowlist below is broader policy scope, and the runtime may attach only a routed subset on a given turn.
+- If you cannot complete the remaining request with the currently attached tools, state the concrete blocker and the unfinished phase instead of claiming success.`
+          : `Execution rules:
 - Execute only the assigned phase \`${effectiveStep.name}\`.
 - Do not create a new multi-step plan for the broader parent request.
 - Do not attempt sibling phases or synthesize the final deliverable.
@@ -2245,6 +2314,21 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
           );
           toolUsageRules.push(
             "- Verification commands must be non-interactive and exit on their own. Do not use watch/dev mode for tests or validation. Prefer runner-native single-run invocations. For Vitest use `vitest run`/`vitest --run`. For Jest use `CI=1 npm test` or `jest --runInBand`. Only pass extra npm `--` flags when the underlying runner supports them.",
+          );
+          toolUsageRules.push(
+            "- When running repository scripts that rely on relative paths, invoke them from the workspace root (for example `bash tests/run_tests.sh`) unless the script explicitly documents a different required cwd.",
+          );
+          toolUsageRules.push(
+            "- Treat existing repo-local verification scripts and harnesses as read-only grader infrastructure unless the contract explicitly names them as writable targets. Do not rewrite them just to make verification pass.",
+          );
+          toolUsageRules.push(
+            "- Do not create alternate copies or wrapper variants of repo-local verification harnesses (for example `run_tests_fresh.sh`) to work around that read-only restriction. Use equivalent bounded verification commands directly from the workspace root instead.",
+          );
+          toolUsageRules.push(
+            "- If a repo-local verification script contains a command that can block indefinitely without its own one-shot flag or timeout, do not invoke the script raw. Wrap the script in an outer timeout or run the equivalent bounded verification commands directly and report that grounded result.",
+          );
+          toolUsageRules.push(
+            "- Prefer non-destructive rebuild or verification commands. Do not delete binaries or build artifacts with commands like `rm` just to prove a rebuild; use build-system-native clean rebuild commands instead.",
           );
         }
         if (allowsDirectFileWrite) {

--- a/runtime/src/gateway/subagent-prompt-builder.ts
+++ b/runtime/src/gateway/subagent-prompt-builder.ts
@@ -73,9 +73,51 @@ export function summarizeParentRequestForSubagent(
       : stripped.length > 0
         ? stripped
       : `Complete only the assigned ${step.name} phase of the parent request.`;
+  if (isFullRequestOwnerStep(step)) {
+    return truncateText(
+      `${base} This child owns the remaining implementation request end to end inside the approved workspace. Do not stop after a single named phase from the planning artifact.`,
+      600,
+    );
+  }
   return truncateText(
     `${base} Assigned phase only: ${step.name}. Ignore broader orchestration instructions and other phases.`,
     600,
+  );
+}
+
+export function isFullRequestOwnerStep(
+  step: PipelinePlannerSubagentStep,
+): boolean {
+  const executionContext = step.executionContext;
+  const workspaceRoot = executionContext?.workspaceRoot?.trim();
+  const role = resolveExecutionEnvelopeRole(executionContext);
+  if (role !== "writer" || !workspaceRoot) {
+    return false;
+  }
+  const artifactRelations = resolveExecutionEnvelopeArtifactRelations(
+    executionContext,
+  );
+  const ownsWorkspaceRoot = artifactRelations.some((relation) =>
+    relation.relationType === "write_owner" &&
+    relation.artifactPath.trim() === workspaceRoot
+  ) || (executionContext?.targetArtifacts ?? []).some((artifactPath) =>
+    artifactPath.trim() === workspaceRoot
+  );
+  if (!ownsWorkspaceRoot) {
+    return false;
+  }
+  const combinedText = [
+    step.name,
+    step.objective,
+    step.inputContract,
+    ...step.acceptanceCriteria,
+  ]
+    .join(" ")
+    .toLowerCase();
+  return (
+    step.name.trim().toLowerCase() === "implement_owner" ||
+    /\b(?:end to end|every phase|all phases|sequentially in full|requested implementation phases|full request)\b/i
+      .test(combinedText)
   );
 }
 
@@ -929,6 +971,7 @@ export function buildRetryTaskPrompt(
       return currentTaskPrompt;
     }
 
+    const fullRequestOwner = isFullRequestOwnerStep(step);
     const corrections: string[] = [];
     if (failure.validationCode === "expected_json_object") {
       corrections.push(
@@ -1034,6 +1077,14 @@ export function buildRetryTaskPrompt(
       corrections.push(
         "Only return a completed phase after fixing and verifying the blocking issue with the allowed tools.",
       );
+      if (fullRequestOwner) {
+        corrections.push(
+          "This delegated contract owns the remaining request end to end. Do not stop at a phase-progress summary because one later phase is failing.",
+        );
+        corrections.push(
+          "Continue repairing the current blocker with the allowed tools until the full request is complete, or emit a strictly blocked result only when you can name the final unresolved blocker and why no further allowed action in this attempt can clear it.",
+        );
+      }
     }
     if (failure.validationCode === "contradictory_completion_claim") {
       corrections.push(
@@ -1042,6 +1093,11 @@ export function buildRetryTaskPrompt(
       corrections.push(
         "Fix and verify the issue with the allowed tools first. If the issue remains unresolved, report the phase as blocked instead of successful.",
       );
+      if (fullRequestOwner) {
+        corrections.push(
+          "For an end-to-end owner contract, do not return a mixed phase-progress/completion summary. Either keep working until the remaining phases are complete and verified, or emit a strictly blocked result with the concrete unresolved failure.",
+        );
+      }
       if (
         /documentation completion|shorthand placeholders|todo markers/i.test(
           failure.message,

--- a/runtime/src/gateway/subagent-workspace-probes.test.ts
+++ b/runtime/src/gateway/subagent-workspace-probes.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 import type { Pipeline, PipelinePlannerSubagentStep } from "../workflow/pipeline.js";
 import { buildWorkspaceStateGuidanceLines } from "./subagent-workspace-probes.js";
@@ -48,5 +51,64 @@ describe("subagent-workspace-probes", () => {
         "/tmp/fabricated-root",
       ),
     ).toEqual([]);
+  });
+
+  it("warns when a delegated CMake workspace contains a stale copied build cache", () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-probes-"));
+    try {
+      mkdirSync(join(workspaceRoot, "build"), { recursive: true });
+      writeFileSync(join(workspaceRoot, "CMakeLists.txt"), "cmake_minimum_required(VERSION 3.10)\nproject(test C)\n");
+      writeFileSync(
+        join(workspaceRoot, "build", "CMakeCache.txt"),
+        "CMAKE_HOME_DIRECTORY:INTERNAL=/home/tetsuo/git/stream-test/agenc-shell\n",
+      );
+      const step: PipelinePlannerSubagentStep = {
+        name: "implement_owner",
+        stepType: "subagent_task",
+        objective: "Implement the shell phases and keep tests passing",
+        inputContract: "Own the implementation request end to end",
+        acceptanceCriteria: ["Build and test the shell"],
+        requiredToolCapabilities: ["system.readFile", "system.bash"],
+        contextRequirements: [],
+        executionContext: {
+          version: "v1",
+          workspaceRoot,
+          allowedReadRoots: [workspaceRoot],
+          allowedWriteRoots: [workspaceRoot],
+          allowedTools: ["system.readFile", "system.bash"],
+          effectClass: "workspace_write",
+          verificationMode: "grounded_verification",
+          stepKind: "delegated_execution",
+        },
+        maxBudgetHint: "10m",
+        canRunParallel: false,
+      };
+      const pipeline: Pipeline = {
+        id: "planner:test:stale-cmake-cache",
+        createdAt: Date.now(),
+        context: { results: {} },
+        steps: [],
+        plannerSteps: [step],
+        plannerContext: {
+          parentRequest: "Implement the shell and keep the build green.",
+          history: [],
+          memory: [],
+          toolOutputs: [],
+        },
+      };
+
+      const lines = buildWorkspaceStateGuidanceLines(
+        step,
+        pipeline,
+        [],
+        workspaceRoot,
+      );
+
+      expect(lines.some((line) => line.includes("build/CMakeCache.txt"))).toBe(true);
+      expect(lines.some((line) => line.includes("build-agenc-fresh"))).toBe(true);
+      expect(lines.some((line) => line.includes("first build or verification attempt"))).toBe(true);
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/runtime/src/gateway/subagent-workspace-probes.ts
+++ b/runtime/src/gateway/subagent-workspace-probes.ts
@@ -737,11 +737,12 @@ export function buildWorkspaceStateGuidanceLines(
       "The delegated workspace root does not exist yet. Create it before listing directories or writing phase files.",
     ];
   }
+  const staleCmakeCacheGuidance = readStaleCmakeCacheGuidance(workspaceRoot);
   const packageDirectories = collectPromptArtifactPackageDirectories(
     promptArtifactCandidates,
     workspaceRoot,
   );
-  if (packageDirectories.length === 0) {
+  if (packageDirectories.length === 0 && !staleCmakeCacheGuidance) {
     return [];
   }
 
@@ -757,6 +758,9 @@ export function buildWorkspaceStateGuidanceLines(
     /\b(?:test|tests|vitest|jest|coverage|spec)\b/i.test(stepText);
 
   const lines: string[] = [];
+  if (staleCmakeCacheGuidance) {
+    lines.push(staleCmakeCacheGuidance);
+  }
   let missingSourceFiles = false;
   let missingTests = false;
   for (const packageDirectory of packageDirectories.slice(0, 3)) {
@@ -796,4 +800,33 @@ export function buildWorkspaceStateGuidanceLines(
   return lines.filter((line, index, entries) =>
     line.length > 0 && entries.indexOf(line) === index
   );
+}
+
+function readStaleCmakeCacheGuidance(workspaceRoot: string): string | undefined {
+  const cmakeListsPath = resolvePath(workspaceRoot, "CMakeLists.txt");
+  const cmakeCachePath = resolvePath(workspaceRoot, "build", "CMakeCache.txt");
+  if (!existsSync(cmakeListsPath) || !existsSync(cmakeCachePath)) {
+    return undefined;
+  }
+  try {
+    const cache = readFileSync(cmakeCachePath, "utf8");
+    const homeDirectoryMatch = cache.match(
+      /^CMAKE_HOME_DIRECTORY(?::[A-Z]+)?=(.+)$/m,
+    );
+    const cacheHomeDirectory = homeDirectoryMatch?.[1]?.trim();
+    if (!cacheHomeDirectory) {
+      return undefined;
+    }
+    const normalizedWorkspaceRoot = resolvePath(workspaceRoot);
+    const normalizedCacheHomeDirectory = resolvePath(cacheHomeDirectory);
+    if (normalizedCacheHomeDirectory === normalizedWorkspaceRoot) {
+      return undefined;
+    }
+    return (
+      `\`build/CMakeCache.txt\` points at \`${sanitizeExecutionPromptText(normalizedCacheHomeDirectory)}\`, not this delegated workspace.` +
+      " Treat `build/` as stale copied output, do not use it for the first build or verification attempt, and configure a fresh build directory from the current workspace root instead (for example `cmake -S . -B build-agenc-fresh && cmake --build build-agenc-fresh`)."
+    );
+  } catch {
+    return undefined;
+  }
 }

--- a/runtime/src/gateway/tool-handler-factory.test.ts
+++ b/runtime/src/gateway/tool-handler-factory.test.ts
@@ -2537,6 +2537,112 @@ describe("createSessionToolHandler", () => {
     });
   });
 
+  it("blocks delegated child rewrites of repo-local verification harnesses unless explicitly writable", async () => {
+    const baseHandler = vi.fn(async () => JSON.stringify({ ok: true }));
+    const subAgentManager = {
+      getInfo: vi.fn(() => ({
+        sessionId: "subagent:child-harness-block",
+        parentSessionId: "session-parent",
+        depth: 1,
+        status: "running",
+        startedAt: Date.now() - 100,
+        task: "Implement the shell",
+      })),
+      getExecutionContext: vi.fn(() => ({
+        version: "v1",
+        workspaceRoot: "/tmp/workspace",
+        allowedReadRoots: ["/tmp/workspace"],
+        allowedWriteRoots: ["/tmp/workspace"],
+        targetArtifacts: ["/tmp/workspace"],
+        artifactRelations: [
+          {
+            relationType: "write_owner",
+            artifactPath: "/tmp/workspace",
+          },
+        ],
+      })),
+    };
+
+    const handler = createSessionToolHandler({
+      sessionId: "subagent:child-harness-block",
+      baseHandler,
+      availableToolNames: ["system.writeFile"],
+      routerId: "router-a",
+      send: vi.fn(),
+      defaultWorkingDirectory: "/tmp/workspace",
+      delegation: () => ({
+        subAgentManager: subAgentManager as any,
+        policyEngine: null,
+        verifier: null,
+        lifecycleEmitter: null,
+      }),
+    });
+
+    const result = await handler("system.writeFile", {
+      path: "tests/run_tests.sh",
+      content: "#!/bin/bash\nrm -rf build\n",
+    });
+
+    expect(baseHandler).not.toHaveBeenCalled();
+    expect(JSON.parse(result)).toEqual({
+      error:
+        'Delegated write path "/tmp/workspace/tests/run_tests.sh" rewrites a repo-local verification harness without explicitly owning it as a writable target',
+    });
+  });
+
+  it("allows delegated verification harness rewrites when the harness is explicitly writable", async () => {
+    const baseHandler = vi.fn(async () => JSON.stringify({ ok: true }));
+    const subAgentManager = {
+      getInfo: vi.fn(() => ({
+        sessionId: "subagent:child-harness-allow",
+        parentSessionId: "session-parent",
+        depth: 1,
+        status: "running",
+        startedAt: Date.now() - 100,
+        task: "Update the test harness",
+      })),
+      getExecutionContext: vi.fn(() => ({
+        version: "v1",
+        workspaceRoot: "/tmp/workspace",
+        allowedReadRoots: ["/tmp/workspace"],
+        allowedWriteRoots: ["/tmp/workspace"],
+        targetArtifacts: ["/tmp/workspace"],
+        artifactRelations: [
+          {
+            relationType: "write_owner",
+            artifactPath: "/tmp/workspace/tests/run_tests.sh",
+          },
+        ],
+      })),
+    };
+
+    const handler = createSessionToolHandler({
+      sessionId: "subagent:child-harness-allow",
+      baseHandler,
+      availableToolNames: ["system.writeFile"],
+      routerId: "router-a",
+      send: vi.fn(),
+      defaultWorkingDirectory: "/tmp/workspace",
+      delegation: () => ({
+        subAgentManager: subAgentManager as any,
+        policyEngine: null,
+        verifier: null,
+        lifecycleEmitter: null,
+      }),
+    });
+
+    await handler("system.writeFile", {
+      path: "tests/run_tests.sh",
+      content: "#!/bin/bash\nbash tests/run_tests.sh\n",
+    });
+
+    expect(baseHandler).toHaveBeenCalledWith("system.writeFile", {
+      path: "/tmp/workspace/tests/run_tests.sh",
+      content: "#!/bin/bash\nbash tests/run_tests.sh\n",
+      [SESSION_ALLOWED_ROOTS_ARG]: ["/tmp/workspace"],
+    });
+  });
+
   it("allows scaffold flows within the execution envelope for mkdir plus relative file writes", async () => {
     const baseHandler = vi.fn(async () => JSON.stringify({ ok: true }));
     const subAgentManager = {

--- a/runtime/src/gateway/tool-handler-factory.ts
+++ b/runtime/src/gateway/tool-handler-factory.ts
@@ -42,7 +42,13 @@ import {
   type EffectTarget,
 } from "../workflow/effects.js";
 import { deriveEffectIdempotencyKey, getCurrentEffectExecutionContext } from "../workflow/idempotency.js";
-import { isPathWithinAnyRoot, normalizeEnvelopePath, normalizeEnvelopeRoots } from "../workflow/path-normalization.js";
+import {
+  isPathWithinAnyRoot,
+  isPathWithinRoot,
+  normalizeEnvelopePath,
+  normalizeEnvelopeRoots,
+} from "../workflow/path-normalization.js";
+import { resolveExecutionEnvelopeArtifactRelations } from "../workflow/execution-envelope.js";
 import type { RuntimeIncidentDiagnostics } from "../telemetry/incident-diagnostics.js";
 import {
   FaultInjectionError,
@@ -844,6 +850,10 @@ function enforceSubAgentExecutionEnvelope(params: {
     readonly inputArtifacts?: readonly string[];
     readonly requiredSourceArtifacts?: readonly string[];
     readonly targetArtifacts?: readonly string[];
+    readonly artifactRelations?: readonly {
+      readonly relationType: string;
+      readonly artifactPath: string;
+    }[];
   };
   readonly defaultWorkingDirectory?: string;
 }): string | undefined {
@@ -871,6 +881,10 @@ function enforceSubAgentExecutionEnvelope(params: {
       executionContext.inputArtifacts,
     targetArtifacts: executionContext.targetArtifacts,
   });
+  const explicitlyWritableArtifacts = collectExplicitWritableExecutionArtifacts(
+    executionContext,
+    workspaceRoot,
+  );
 
   for (const key of pathKeys) {
     const rawValue = params.args[key];
@@ -897,9 +911,73 @@ function enforceSubAgentExecutionEnvelope(params: {
     ) {
       return `Delegated ${mode} path "${resolvedPath}" is not permitted by the execution envelope target artifacts`;
     }
+    if (
+      mode !== "read" &&
+      isRepoLocalVerificationHarnessPath(resolvedPath, workspaceRoot) &&
+      !explicitlyWritableArtifacts.some((artifactPath) =>
+        artifactPath === resolvedPath || isPathWithinRoot(resolvedPath, artifactPath)
+      )
+    ) {
+      return `Delegated ${mode} path "${resolvedPath}" rewrites a repo-local verification harness without explicitly owning it as a writable target`;
+    }
   }
 
   return undefined;
+}
+
+function collectExplicitWritableExecutionArtifacts(
+  executionContext: NonNullable<
+    Parameters<typeof enforceSubAgentExecutionEnvelope>[0]["executionContext"]
+  >,
+  workspaceRoot?: string,
+): readonly string[] {
+  const normalizedWorkspaceRoot =
+    typeof workspaceRoot === "string" ? normalizeEnvelopePath(workspaceRoot) : "";
+  const explicitArtifacts = new Set<string>();
+  const addArtifact = (value: string | undefined): void => {
+    if (typeof value !== "string" || value.trim().length === 0) {
+      return;
+    }
+    const normalized = normalizeEnvelopePath(value, workspaceRoot);
+    if (!normalized || normalized === normalizedWorkspaceRoot) {
+      return;
+    }
+    explicitArtifacts.add(normalized);
+  };
+
+  for (const artifact of executionContext.targetArtifacts ?? []) {
+    addArtifact(artifact);
+  }
+  for (const relation of resolveExecutionEnvelopeArtifactRelations(
+    executionContext,
+  )) {
+    if (relation.relationType !== "write_owner") {
+      continue;
+    }
+    addArtifact(relation.artifactPath);
+  }
+
+  return [...explicitArtifacts];
+}
+
+function isRepoLocalVerificationHarnessPath(
+  path: string,
+  workspaceRoot?: string,
+): boolean {
+  if (!workspaceRoot || !isPathWithinRoot(path, workspaceRoot)) {
+    return false;
+  }
+  const relativePath = relative(workspaceRoot, path).replace(/\\/gu, "/");
+  if (relativePath.startsWith("../")) {
+    return false;
+  }
+  return (
+    /(?:^|\/)(?:test|tests|spec|specs|__tests__)\/.+\.(?:sh|bash|zsh)$/iu.test(
+      relativePath,
+    ) ||
+    /(?:^|\/)(?:run|verify|smoke|integration|e2e)[-_]?tests?\.(?:sh|bash|zsh)$/iu
+      .test(relativePath)
+  );
 }
 
 function collectMeaningfulLines(value: string): string[] {

--- a/runtime/src/llm/chat-executor-contract-flow.test.ts
+++ b/runtime/src/llm/chat-executor-contract-flow.test.ts
@@ -217,6 +217,73 @@ describe("chat-executor-contract-flow", () => {
     ).toBe(true);
   });
 
+  it("keeps implement-from-plan reconnaissance turns inside workflow-owned completion", () => {
+    expect(
+      requiresWorkflowOwnedImplementationCompletion({
+        ctx: {
+          messageText:
+            "Read all of @PLAN.md and complete every single phase in full.",
+          allToolCalls: [
+            {
+              name: "system.readFile",
+              args: {
+                path: "/tmp/project/PLAN.md",
+              },
+              result: JSON.stringify({
+                path: "/tmp/project/PLAN.md",
+                size: 4096,
+              }),
+              isError: false,
+              durationMs: 2,
+            },
+          ],
+          activeRoutedToolNames: ["system.readFile"],
+          initialRoutedToolNames: ["system.readFile"],
+          expandedRoutedToolNames: [],
+          requiredToolEvidence: undefined,
+          providerEvidence: undefined,
+          response: undefined,
+          plannerSummaryState: {
+            routeReason: "plan_artifact_execution_request",
+          },
+        } as any,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not classify documentation reconnaissance turns as implementation-class work", () => {
+    expect(
+      requiresWorkflowOwnedImplementationCompletion({
+        ctx: {
+          messageText: "Update README.md with usage notes for the workspace.",
+          allToolCalls: [
+            {
+              name: "system.readFile",
+              args: {
+                path: "/tmp/project/README.md",
+              },
+              result: JSON.stringify({
+                path: "/tmp/project/README.md",
+                size: 1024,
+              }),
+              isError: false,
+              durationMs: 2,
+            },
+          ],
+          activeRoutedToolNames: ["system.readFile"],
+          initialRoutedToolNames: ["system.readFile"],
+          expandedRoutedToolNames: [],
+          requiredToolEvidence: undefined,
+          providerEvidence: undefined,
+          response: undefined,
+          plannerSummaryState: {
+            routeReason: "tool_loop",
+          },
+        } as any,
+      }),
+    ).toBe(false);
+  });
+
   it("limits legacy completion compatibility to docs, research, and plan-only turns", () => {
     const docsDecision = resolveLegacyCompletionCompatibility({
       ctx: {
@@ -541,7 +608,7 @@ describe("chat-executor-contract-flow", () => {
     expect(result.missingEvidenceMessage).toContain("Behavior verification was required");
   });
 
-  it("treats unsafe benchmark mode as evidence-only for delegated validation", () => {
+  it("still enforces delegated validation truth in unsafe benchmark mode", () => {
     const result = validateRequiredToolEvidence({
       ctx: {
         messageText: "Scaffold manifests only for the workspace",
@@ -578,7 +645,10 @@ describe("chat-executor-contract-flow", () => {
       } as any,
     });
 
-    expect(result.contractValidation).toMatchObject({ ok: true });
-    expect(result.missingEvidenceMessage).toBeUndefined();
+    expect(result.contractValidation).toMatchObject({
+      ok: false,
+      code: "forbidden_phase_action",
+    });
+    expect(result.missingEvidenceMessage).toContain("dependency-install commands");
   });
 });

--- a/runtime/src/llm/chat-executor-contract-flow.ts
+++ b/runtime/src/llm/chat-executor-contract-flow.ts
@@ -38,6 +38,7 @@ import {
 } from "./chat-executor-routing-state.js";
 import { didToolCallFail } from "./chat-executor-tool-utils.js";
 import {
+  plannerRequestImplementsFromArtifact,
   plannerRequestNeedsGroundedPlanArtifact,
   plannerRequestNeedsPlanArtifactExecution,
   requestRequiresToolGroundedExecution,
@@ -623,9 +624,26 @@ function analyzeLegacyCompletionTurn(
   const mutatesSourceLikeArtifacts = mutatedArtifacts.some((artifact) =>
     SOURCE_LIKE_PATH_RE.test(artifact),
   );
+  const implementsFromArtifact = plannerRequestImplementsFromArtifact(
+    ctx.messageText,
+  );
   const likelyImplementationRequest =
-    LIKELY_IMPLEMENTATION_REQUEST_RE.test(ctx.messageText) &&
-    requestRequiresToolGroundedExecution(ctx.messageText);
+    (
+      LIKELY_IMPLEMENTATION_REQUEST_RE.test(ctx.messageText) ||
+      implementsFromArtifact
+    ) &&
+    (
+      requestRequiresToolGroundedExecution(ctx.messageText) ||
+      implementsFromArtifact
+    );
+  const hasExecutionScopedArtifactCue =
+    implementsFromArtifact ||
+    SOURCE_LIKE_PATH_RE.test(ctx.messageText) ||
+    BUILD_REQUIREMENT_RE.test(ctx.messageText) ||
+    BEHAVIOR_REQUIREMENT_RE.test(ctx.messageText);
+  const hasOnlyNonTerminalExecutionEvidence =
+    !hasMutationProgress &&
+    !hasBuildOrBehaviorEvidence;
   return {
     successfulToolCalls,
     mutatedArtifacts,
@@ -635,7 +653,16 @@ function analyzeLegacyCompletionTurn(
     implementationLikeTurn:
       mutatesSourceLikeArtifacts ||
       hasBuildOrBehaviorEvidence ||
-      (successfulToolCalls.length === 0 && likelyImplementationRequest),
+      (
+        likelyImplementationRequest &&
+        (
+          successfulToolCalls.length === 0 ||
+          (
+            hasExecutionScopedArtifactCue &&
+            hasOnlyNonTerminalExecutionEvidence
+          )
+        )
+      ),
   };
 }
 

--- a/runtime/src/llm/chat-executor-contract-guidance.test.ts
+++ b/runtime/src/llm/chat-executor-contract-guidance.test.ts
@@ -511,7 +511,7 @@ describe("chat-executor-contract-guidance", () => {
     expect(guidance).toEqual({
       source: "delegation-initial",
       routedToolNames: ["desktop.text_editor"],
-      persistRoutedToolNames: false,
+      persistRoutedToolNames: true,
       toolChoice: "required",
     });
   });
@@ -543,7 +543,7 @@ describe("chat-executor-contract-guidance", () => {
         "Inspect the existing workspace state before mutating files when that will prevent avoidable rework, " +
         "then create or update the required files directly. Do not spend shell rounds on speculative build/test/runtime verification unless acceptance explicitly requires that evidence.",
       routedToolNames: ["system.readFile", "system.writeFile"],
-      persistRoutedToolNames: false,
+      persistRoutedToolNames: true,
       toolChoice: "required",
     });
   });
@@ -592,7 +592,7 @@ describe("chat-executor-contract-guidance", () => {
         "system.writeFile",
         "system.bash",
       ],
-      persistRoutedToolNames: false,
+      persistRoutedToolNames: true,
       toolChoice: "required",
     });
   });
@@ -627,7 +627,7 @@ describe("chat-executor-contract-guidance", () => {
         "Inspect the existing workspace state before mutating files when that will prevent avoidable rework, " +
         "and use shell verification when build/test/install evidence is part of acceptance.",
       routedToolNames: ["system.readFile", "system.listDir"],
-      persistRoutedToolNames: false,
+      persistRoutedToolNames: true,
       toolChoice: "required",
     });
   });
@@ -663,7 +663,73 @@ describe("chat-executor-contract-guidance", () => {
         "Inspect the existing workspace state before mutating files when that will prevent avoidable rework, " +
         "then create or update the required files directly. Do not spend shell rounds on speculative build/test/runtime verification unless acceptance explicitly requires that evidence.",
       routedToolNames: ["system.readFile", "system.writeFile"],
-      persistRoutedToolNames: false,
+      persistRoutedToolNames: true,
+      toolChoice: "required",
+    });
+  });
+
+  it("keeps bash routed for end-to-end owner contracts when acceptance requires grounded verification commands", () => {
+    const guidance = resolveToolContractGuidance({
+      phase: "initial",
+      messageText:
+        "Execute this implementation request inside the workspace: okay what i did was delete absolutely everything except for the @PLAN.md because i want to start this fresh can you go through the plan.md file and anything that says it has been completed already fix since it's a fresh folder",
+      toolCalls: [],
+      allowedToolNames: [
+        "system.readFile",
+        "system.writeFile",
+        "system.bash",
+      ],
+      requiredToolEvidence: {
+        delegationSpec: {
+          task: "implement_owner",
+          objective:
+            "Execute this implementation request inside the workspace: okay what i did was delete absolutely everything except for the @PLAN.md because i want to start this fresh can you go through the plan.md file and anything that says it has been completed already fix since it's a fresh folder",
+          inputContract:
+            "Use the planning artifact plus the current workspace to perform the requested implementation end to end. Do not stop at analysis only.",
+          acceptanceCriteria: [
+            "Workspace files are updated to satisfy the requested implementation phases.",
+            "Grounded verification runs before completion, and passing or failing commands are reported concretely.",
+            "If a blocker prevents completion, report the concrete blocker with evidence instead of returning an analysis-only summary.",
+          ],
+          executionContext: {
+            workspaceRoot: "/tmp/agenc-shell-fresh",
+            allowedReadRoots: ["/tmp/agenc-shell-fresh"],
+            allowedWriteRoots: ["/tmp/agenc-shell-fresh"],
+            allowedTools: ["system.readFile", "system.writeFile", "system.bash"],
+            requiredSourceArtifacts: ["/tmp/agenc-shell-fresh/PLAN.md"],
+            targetArtifacts: ["/tmp/agenc-shell-fresh"],
+            effectClass: "filesystem_write",
+            verificationMode: "mutation_required",
+            stepKind: "delegated_write",
+            role: "writer",
+            artifactRelations: [
+              {
+                relationType: "read_dependency",
+                artifactPath: "/tmp/agenc-shell-fresh/PLAN.md",
+              },
+              {
+                relationType: "write_owner",
+                artifactPath: "/tmp/agenc-shell-fresh",
+              },
+            ],
+            fallbackPolicy: "fail_request",
+            resumePolicy: "stateless_retry",
+            approvalProfile: "filesystem_write",
+          },
+        },
+      },
+    });
+
+    expect(guidance).toEqual({
+      source: "delegation-initial",
+      runtimeInstruction:
+        "Start with the smallest grounded step that reduces uncertainty in the delegated contract. " +
+        "Inspect the existing workspace state before mutating files when that will prevent avoidable rework, " +
+        "When the planning artifact is the source specification, survey the current workspace before assuming plan-listed files already exist. " +
+        "Confirm directories or files under the owned workspace before reading them or presenting them as present. " +
+        "and use shell verification when build/test/install evidence is part of acceptance.",
+      routedToolNames: ["system.readFile", "system.writeFile", "system.bash"],
+      persistRoutedToolNames: true,
       toolChoice: "required",
     });
   });
@@ -697,7 +763,7 @@ describe("chat-executor-contract-guidance", () => {
         "Begin by creating or updating files under the delegated workspace root. " +
         "If the delegated cwd does not exist yet, target that workspace via absolute paths instead of starting with shell inspection.",
       routedToolNames: ["system.writeFile"],
-      persistRoutedToolNames: false,
+      persistRoutedToolNames: true,
       toolChoice: "required",
     });
   });
@@ -733,7 +799,7 @@ describe("chat-executor-contract-guidance", () => {
         "Begin by creating or updating files under the delegated workspace root. " +
         "If the delegated cwd does not exist yet, target that workspace via absolute paths instead of starting with shell inspection.",
       routedToolNames: ["system.writeFile"],
-      persistRoutedToolNames: false,
+      persistRoutedToolNames: true,
       toolChoice: "required",
     });
   });
@@ -770,7 +836,7 @@ describe("chat-executor-contract-guidance", () => {
         "Inspect the existing workspace state before mutating files when that will prevent avoidable rework, " +
         "and use shell verification when build/test/install evidence is part of acceptance.",
       routedToolNames: ["system.readFile", "system.writeFile", "system.bash"],
-      persistRoutedToolNames: false,
+      persistRoutedToolNames: true,
       toolChoice: "required",
     });
   });
@@ -806,7 +872,7 @@ describe("chat-executor-contract-guidance", () => {
     expect(guidance).toEqual({
       source: "delegation-initial",
       routedToolNames: ["desktop.text_editor"],
-      persistRoutedToolNames: false,
+      persistRoutedToolNames: true,
       toolChoice: "required",
     });
   });
@@ -1078,7 +1144,7 @@ describe("chat-executor-contract-guidance", () => {
         "Inspect the existing workspace state before mutating files when that will prevent avoidable rework, " +
         "and use shell verification when build/test/install evidence is part of acceptance.",
       routedToolNames: ["system.bash", "system.writeFile"],
-      persistRoutedToolNames: false,
+      persistRoutedToolNames: true,
       toolChoice: "required",
     });
   });

--- a/runtime/src/llm/chat-executor-contract-guidance.ts
+++ b/runtime/src/llm/chat-executor-contract-guidance.ts
@@ -42,6 +42,7 @@ import {
 } from "../utils/parent-safe-introspection.js";
 import { extractExplicitImperativeToolNames } from "./chat-executor-explicit-tools.js";
 import { getAcceptanceVerificationCategories } from "../utils/delegation-validation.js";
+import { areDocumentationOnlyArtifacts } from "../workflow/artifact-paths.js";
 
 export type ToolContractGuidancePhase =
   | "initial"
@@ -482,6 +483,11 @@ function resolveDelegationInitialContractGuidance(
   const usesFlexibleInitialSubset = effectiveRoutedToolNames.length > 1;
   const sourceGroundingRetry =
     (spec.lastValidationCode ?? "") === "missing_required_source_evidence";
+  const planBackedImplementationOwner =
+    isPlanBackedImplementationOwnerSpec(spec);
+  const planBackedWorkspaceInspectionInstruction =
+    "When the planning artifact is the source specification, survey the current workspace before assuming plan-listed files already exist. " +
+    "Confirm directories or files under the owned workspace before reading them or presenting them as present.";
   const runtimeInstruction = usesFlexibleInitialSubset
     ? workspaceBootstrap
       ? "Bootstrap the delegated workspace before inspecting it. " +
@@ -493,9 +499,16 @@ function resolveDelegationInitialContractGuidance(
       : fileAuthoringOnlyPhase
         ? "Start with the smallest grounded step that reduces uncertainty in the delegated contract. " +
           "Inspect the existing workspace state before mutating files when that will prevent avoidable rework, " +
-          "then create or update the required files directly. Do not spend shell rounds on speculative build/test/runtime verification unless acceptance explicitly requires that evidence."
+          "then create or update the required files directly. " +
+          (planBackedImplementationOwner
+            ? `${planBackedWorkspaceInspectionInstruction} `
+            : "") +
+          "Do not spend shell rounds on speculative build/test/runtime verification unless acceptance explicitly requires that evidence."
       : "Start with the smallest grounded step that reduces uncertainty in the delegated contract. " +
         "Inspect the existing workspace state before mutating files when that will prevent avoidable rework, " +
+        (planBackedImplementationOwner
+          ? `${planBackedWorkspaceInspectionInstruction} `
+          : "") +
         "and use shell verification when build/test/install evidence is part of acceptance."
     : preferredToolName === "system.writeFile" ||
         preferredToolName === "system.appendFile"
@@ -510,9 +523,28 @@ function resolveDelegationInitialContractGuidance(
     source: "delegation-initial",
     runtimeInstruction,
     routedToolNames: effectiveRoutedToolNames,
-    persistRoutedToolNames: false,
+    persistRoutedToolNames: true,
     toolChoice: "required",
   };
+}
+
+function isPlanBackedImplementationOwnerSpec(
+  spec: DelegationContractSpec,
+): boolean {
+  const executionContext = spec.executionContext;
+  const workspaceRoot = executionContext?.workspaceRoot?.trim();
+  const requiredSourceArtifacts = executionContext?.requiredSourceArtifacts ?? [];
+  const targetArtifacts = executionContext?.targetArtifacts ?? [];
+  if (!workspaceRoot || requiredSourceArtifacts.length === 0) {
+    return false;
+  }
+  if (!areDocumentationOnlyArtifacts(requiredSourceArtifacts)) {
+    return false;
+  }
+  const ownsWorkspaceRoot = targetArtifacts.some((artifactPath) =>
+    artifactPath.trim() === workspaceRoot
+  );
+  return ownsWorkspaceRoot || spec.task.trim().toLowerCase() === "implement_owner";
 }
 
 function isDelegatedFileAuthoringPhaseWithoutVerification(

--- a/runtime/src/llm/chat-executor-fallback.test.ts
+++ b/runtime/src/llm/chat-executor-fallback.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { callWithFallback } from "./chat-executor-fallback.js";
 import { DEFAULT_LLM_RETRY_POLICY_MATRIX } from "./policy.js";
+import { LLMServerError } from "./errors.js";
 import type {
   LLMChatOptions,
   LLMMessage,
@@ -48,6 +49,44 @@ function createDeps(provider: LLMProvider) {
 }
 
 describe("callWithFallback", () => {
+  it("falls through to a second same-family model after a transient server error", async () => {
+    const failingProvider = {
+      ...createMockProvider({
+        name: "grok",
+        chat: vi.fn().mockRejectedValue(
+          new LLMServerError("grok", 503, "temporary outage"),
+        ),
+      }),
+      config: { model: "grok-4-1-fast-non-reasoning" },
+    } as LLMProvider & { config: { model: string } };
+    const succeedingProvider = {
+      ...createMockProvider({
+        name: "grok",
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({ model: "grok-code-fast-1" }),
+        ),
+      }),
+      config: { model: "grok-code-fast-1" },
+    } as LLMProvider & { config: { model: string } };
+
+    const result = await callWithFallback(
+      {
+        providers: [failingProvider, succeedingProvider],
+        cooldowns: new Map(),
+        promptBudget: {},
+        retryPolicyMatrix: DEFAULT_LLM_RETRY_POLICY_MATRIX,
+        cooldownMs: 1_000,
+        maxCooldownMs: 60_000,
+      },
+      [{ role: "user", content: "continue" }],
+    );
+
+    expect(failingProvider.chat.mock.calls.length).toBeGreaterThan(0);
+    expect(succeedingProvider.chat).toHaveBeenCalledOnce();
+    expect(result.response.model).toBe("grok-code-fast-1");
+    expect(result.providerName).toBe("grok");
+  });
+
   it("uses non-stream chat for tool follow-up turns that still require tools", async () => {
     const provider = createMockProvider({
       chat: vi.fn().mockResolvedValue(

--- a/runtime/src/llm/chat-executor-fallback.ts
+++ b/runtime/src/llm/chat-executor-fallback.ts
@@ -40,6 +40,7 @@ import {
 import {
   estimatePromptShape,
 } from "./chat-executor-text.js";
+import { getProviderRouteKey } from "./model-routing-policy.js";
 import type { RuntimeFaultInjector } from "../eval/fault-injection.js";
 
 // ============================================================================
@@ -196,8 +197,9 @@ export async function callWithFallback(
 
   for (let i = 0; i < deps.providers.length; i++) {
     const provider = deps.providers[i];
+    const providerRouteKey = getProviderRouteKey(provider);
     const now = Date.now();
-    const cooldown = deps.cooldowns.get(provider.name);
+    const cooldown = deps.cooldowns.get(providerRouteKey);
 
     if (cooldown && cooldown.availableAt > now) {
       emitProviderTraceEvent(options, {
@@ -257,8 +259,8 @@ export async function callWithFallback(
         }
 
         // Success — clear cooldown
-        const priorCooldown = deps.cooldowns.get(provider.name);
-        deps.cooldowns.delete(provider.name);
+        const priorCooldown = deps.cooldowns.get(providerRouteKey);
+        deps.cooldowns.delete(providerRouteKey);
         if (priorCooldown) {
           emitProviderTraceEvent(options, {
             kind: "response",
@@ -308,7 +310,7 @@ export async function callWithFallback(
 
         // Apply cooldown for this provider before trying fallbacks.
         const failures =
-          (deps.cooldowns.get(provider.name)?.failures ?? 0) + 1;
+          (deps.cooldowns.get(providerRouteKey)?.failures ?? 0) + 1;
         const cooldownDuration = computeProviderCooldownMs(
           failures,
           retryRule,
@@ -317,7 +319,7 @@ export async function callWithFallback(
           deps.maxCooldownMs,
         );
         const availableAt = Date.now() + cooldownDuration;
-        deps.cooldowns.set(provider.name, {
+        deps.cooldowns.set(providerRouteKey, {
           availableAt,
           failures,
         });

--- a/runtime/src/llm/chat-executor-planner-execution.ts
+++ b/runtime/src/llm/chat-executor-planner-execution.ts
@@ -52,8 +52,11 @@ import {
   buildExplicitSubagentOrchestrationFailureMessage,
   extractRecoverablePlannerParseDiagnostics,
   isHighRiskSubagentPlan,
+  extractPlannerArtifactTargets,
   plannerRequestImplementsFromArtifact,
   pipelineResultToToolCalls,
+  buildPlannerWorkflowContract,
+  buildPlannerWorkflowStepContract,
 } from "./chat-executor-planner.js";
 import { normalizePlannerResponse } from "./chat-executor-planner-normalization.js";
 import {
@@ -88,16 +91,19 @@ import {
 } from "./runtime-limit-policy.js";
 import type { LLMPipelineStopReason } from "./policy.js";
 import type { LLMResponse } from "./types.js";
+import { createExecutionEnvelope } from "../workflow/execution-envelope.js";
 import { resolveRequiredSubagentVerificationStepNames } from "../workflow/subagent-orchestration-requirements.js";
 import {
   summarizeToolCalls,
   generateFallbackContent,
   truncateText,
 } from "./chat-executor-text.js";
+import { classifyLLMFailure } from "./errors.js";
 
 const DOC_ONLY_ARTIFACT_RE = /\.(?:md|mdx|txt|rst|adoc)$/i;
 const DOC_ONLY_BASENAME_RE =
   /(?:^|\/)(?:README|CHANGELOG|CONTRIBUTING|LICENSE|COPYING|NOTES|AGENTS|AGENC|PLAN|TASK_BREAKDOWN)(?:\.[^/]+)?$/i;
+const PLANNER_SYNTHESIS_TOOL_BLOCK_RE = /```tool:\s*([^\s`]+)[\s\S]*?```/gi;
 
 // ============================================================================
 // Dependencies interface
@@ -167,6 +173,34 @@ export interface PlannerExecutionCallbacks {
 
 function isDocOnlyPlannerArtifact(path: string): boolean {
   return DOC_ONLY_ARTIFACT_RE.test(path) || DOC_ONLY_BASENAME_RE.test(path);
+}
+
+function extractClaimedToolBlockNames(content: string): readonly string[] {
+  const claimedNames = new Set<string>();
+  for (const match of content.matchAll(PLANNER_SYNTHESIS_TOOL_BLOCK_RE)) {
+    const toolName = match[1]?.trim();
+    if (toolName) {
+      claimedNames.add(toolName);
+    }
+  }
+  return [...claimedNames];
+}
+
+function resolvePlannerSynthesisToolMarkupMismatch(input: {
+  readonly content: string;
+  readonly toolCalls: readonly ToolCallRecord[];
+}): readonly string[] {
+  const claimedToolNames = extractClaimedToolBlockNames(input.content);
+  if (claimedToolNames.length === 0) {
+    return [];
+  }
+  const executedToolNames = new Set(
+    input.toolCalls
+      .filter((toolCall) => !toolCall.isError)
+      .map((toolCall) => toolCall.name.trim())
+      .filter((toolName) => toolName.length > 0),
+  );
+  return claimedToolNames.filter((toolName) => !executedToolNames.has(toolName));
 }
 
 function resolvePlannerWorkspaceRoot(
@@ -425,6 +459,237 @@ function plannerAlreadyMutatesFiles(plannerPlan: PlannerPlan): boolean {
   );
 }
 
+function extractPlannerReadDependencyArtifacts(
+  plannerPlan: PlannerPlan,
+): readonly string[] {
+  const artifacts = new Set<string>();
+  for (const step of plannerPlan.steps) {
+    if (
+      step.stepType === "deterministic_tool" &&
+      step.tool === "system.readFile" &&
+      typeof step.args.path === "string" &&
+      step.args.path.trim().length > 0
+    ) {
+      artifacts.add(step.args.path.trim());
+    }
+  }
+  return [...artifacts];
+}
+
+function canRuntimeRepairImplementFromArtifactPlan(params: {
+  readonly plannerPlan: PlannerPlan;
+  readonly diagnostics: readonly PlannerDiagnostic[];
+  readonly messageText: string;
+  readonly workspaceRoot: string | undefined;
+}): boolean {
+  if (!plannerRequestImplementsFromArtifact(params.messageText)) {
+    return false;
+  }
+  if (!params.workspaceRoot) {
+    return false;
+  }
+  if (params.diagnostics.length === 0) {
+    return false;
+  }
+  if (
+    !params.diagnostics.every((diagnostic) =>
+      diagnostic.code === "planner_implementation_missing_mutation_path"
+    )
+  ) {
+    return false;
+  }
+  if (params.plannerPlan.steps.some((step) => step.stepType === "subagent_task")) {
+    return false;
+  }
+  if (plannerAlreadyMutatesFiles(params.plannerPlan)) {
+    return false;
+  }
+  return params.plannerPlan.steps.every((step) => {
+    if (step.stepType !== "deterministic_tool") {
+      return false;
+    }
+    return (
+      step.tool === "system.readFile" ||
+      step.tool === "system.listDir" ||
+      step.tool === "system.stat"
+    );
+  });
+}
+
+function buildSingleOwnerImplementFromArtifactPlan(params: {
+  readonly messageText: string;
+  readonly workspaceRoot: string;
+  readonly reason: string;
+  readonly requiredSourceArtifacts: readonly string[];
+  readonly readStepNames?: readonly string[];
+  readonly confidence?: number;
+}): PlannerPlan | undefined {
+  const requiredSourceArtifacts =
+    params.requiredSourceArtifacts.length > 0
+      ? [...new Set(params.requiredSourceArtifacts)]
+      : ["PLAN.md"];
+  const executionContext = createExecutionEnvelope({
+    workspaceRoot: params.workspaceRoot,
+    allowedReadRoots: [params.workspaceRoot],
+    allowedWriteRoots: [params.workspaceRoot],
+    allowedTools: [
+      "system.readFile",
+      "system.writeFile",
+      "system.bash",
+    ],
+    requiredSourceArtifacts,
+    targetArtifacts: [params.workspaceRoot],
+    effectClass: "filesystem_write",
+    verificationMode: "mutation_required",
+    stepKind: "delegated_write",
+    role: "writer",
+    artifactRelations: [
+      ...requiredSourceArtifacts.map((artifactPath) => ({
+        relationType: "read_dependency" as const,
+        artifactPath,
+      })),
+      {
+        relationType: "write_owner" as const,
+        artifactPath: params.workspaceRoot,
+      },
+    ],
+    fallbackPolicy: "fail_request",
+    resumePolicy: "stateless_retry",
+    approvalProfile: "filesystem_write",
+  });
+  if (!executionContext) {
+    return undefined;
+  }
+  const objectiveSource = truncateText(params.messageText.trim(), 240);
+  const writerBaseStep: PlannerSubAgentTaskStepIntent = {
+    name: "implement_owner",
+    stepType: "subagent_task",
+    objective:
+      objectiveSource.length > 0
+        ? `Execute this implementation request inside the workspace: ${objectiveSource}`
+        : "Implement the requested planning-artifact phases inside the workspace and verify the result before finishing.",
+    inputContract:
+      "Use the planning artifact plus the current workspace to perform the requested implementation end to end. Do not stop at analysis only.",
+    acceptanceCriteria: [
+      "Workspace files are updated to satisfy the requested implementation phases.",
+      "Grounded verification runs before completion, and passing or failing commands are reported concretely.",
+      "If a blocker prevents completion, report the concrete blocker with evidence instead of returning an analysis-only summary.",
+    ],
+    requiredToolCapabilities: [
+      "system.readFile",
+      "system.writeFile",
+      "system.bash",
+    ],
+    contextRequirements:
+      (params.readStepNames?.length ?? 0) > 0
+        ? params.readStepNames!
+        : requiredSourceArtifacts.length > 0
+          ? ["planning_artifact_context"]
+          : ["workspace_context"],
+    executionContext,
+    maxBudgetHint: "30m",
+    canRunParallel: false,
+    ...((params.readStepNames?.length ?? 0) > 0
+      ? { dependsOn: params.readStepNames }
+      : {}),
+  };
+  const writerStep: PlannerSubAgentTaskStepIntent = {
+    ...writerBaseStep,
+    workflowStep: buildPlannerWorkflowStepContract(writerBaseStep),
+  };
+  return {
+    reason: params.reason,
+    requiresSynthesis: false,
+    confidence: params.confidence,
+    steps: [writerStep],
+    edges: [],
+    workflowContract: buildPlannerWorkflowContract({
+      steps: [writerStep],
+    }),
+  };
+}
+
+function buildRuntimeRepairedImplementFromArtifactPlan(params: {
+  readonly plannerPlan: PlannerPlan;
+  readonly messageText: string;
+  readonly workspaceRoot: string;
+}): PlannerPlan | undefined {
+  const requestedArtifacts = extractPlannerArtifactTargets(params.messageText);
+  const readDependencyArtifacts = extractPlannerReadDependencyArtifacts(
+    params.plannerPlan,
+  );
+  const requiredSourceArtifacts = [
+    ...new Set([...requestedArtifacts, ...readDependencyArtifacts]),
+  ];
+  const readStepNames = params.plannerPlan.steps
+    .filter(
+      (step): step is PlannerDeterministicToolStepIntent =>
+        step.stepType === "deterministic_tool" && step.tool === "system.readFile",
+    )
+    .map((step) => step.name);
+  const repairedPlan = buildSingleOwnerImplementFromArtifactPlan({
+    messageText: params.messageText,
+    workspaceRoot: params.workspaceRoot,
+    reason: "runtime_repaired_single_owner_plan_artifact_execution",
+    requiredSourceArtifacts,
+    readStepNames,
+    confidence: params.plannerPlan.confidence,
+  });
+  if (!repairedPlan) {
+    return undefined;
+  }
+  return {
+    ...repairedPlan,
+    steps: [
+      ...params.plannerPlan.steps.filter((step) => step.stepType !== "synthesis"),
+      ...repairedPlan.steps,
+    ],
+    edges: [
+      ...params.plannerPlan.edges,
+      ...readStepNames.map((stepName) => ({
+        from: stepName,
+        to: repairedPlan.steps[0]!.name,
+      })),
+    ].filter(
+      (edge, index, edges) =>
+        edges.findIndex((candidate) =>
+          candidate.from === edge.from && candidate.to === edge.to
+        ) === index,
+    ),
+  };
+}
+
+function canRuntimeRepairPlannerProviderFailure(params: {
+  readonly messageText: string;
+  readonly workspaceRoot: string | undefined;
+  readonly failureClass: ReturnType<typeof classifyLLMFailure>;
+}): boolean {
+  if (!params.workspaceRoot) {
+    return false;
+  }
+  if (!plannerRequestImplementsFromArtifact(params.messageText)) {
+    return false;
+  }
+  return (
+    params.failureClass === "provider_error" ||
+    params.failureClass === "timeout" ||
+    params.failureClass === "rate_limited"
+  );
+}
+
+function buildRuntimeRepairedPlannerProviderFailurePlan(params: {
+  readonly messageText: string;
+  readonly workspaceRoot: string;
+}): PlannerPlan | undefined {
+  return buildSingleOwnerImplementFromArtifactPlan({
+    messageText: params.messageText,
+    workspaceRoot: params.workspaceRoot,
+    reason: "runtime_repaired_single_owner_planner_unavailable_execution",
+    requiredSourceArtifacts: extractPlannerArtifactTargets(params.messageText),
+    confidence: 0.25,
+  });
+}
+
 function stepWriteOwnerTargets(
   step: PlannerSubAgentTaskStepIntent,
 ): readonly string[] {
@@ -557,6 +822,117 @@ function resolveTypedRequiredSubagentOutputStepNames(params: {
   });
 }
 
+function evaluatePlannerValidationState(params: {
+  readonly plannerPlan: PlannerPlan;
+  readonly messageText: string;
+  readonly workspaceRoot?: string;
+  readonly delegationConfig: PlannerExecutionConfig["delegationDecisionConfig"];
+  readonly explicitOrchestrationRequirements: ReturnType<
+    typeof extractExplicitSubagentOrchestrationRequirements
+  >;
+  readonly explicitDeterministicToolRequirements:
+    | ReturnType<typeof extractExplicitDeterministicToolRequirements>
+    | undefined;
+  readonly explicitVerificationRequirements: ReturnType<
+    typeof extractPlannerVerificationRequirements
+  >;
+  readonly explicitVerificationCommandRequirements: ReturnType<
+    typeof extractPlannerVerificationCommandRequirements
+  >;
+}): {
+  readonly graphDiagnostics: readonly PlannerDiagnostic[];
+  readonly plannerStepContractDiagnostics: readonly PlannerDiagnostic[];
+  readonly verificationRequirementDiagnostics: readonly PlannerDiagnostic[];
+  readonly structuralGraphDiagnostics: readonly PlannerDiagnostic[];
+  readonly decompositionGraphDiagnostics: readonly PlannerDiagnostic[];
+  readonly requiredOrchestrationDiagnostics: readonly PlannerDiagnostic[];
+  readonly explicitToolDiagnostics: readonly PlannerDiagnostic[];
+  readonly hasStructuralDiagnostics: boolean;
+  readonly currentValidationDiagnostics: readonly PlannerDiagnostic[];
+  readonly hasOnlyStepContractDiagnostics: boolean;
+  readonly structuralDiagnosticSignature: string;
+} {
+  const graphDiagnostics = validatePlannerGraph(
+    params.plannerPlan,
+    {
+      maxSubagentFanout: params.delegationConfig.maxFanoutPerTurn,
+      maxSubagentDepth: params.delegationConfig.maxDepth,
+      workspaceRoot: params.workspaceRoot,
+    },
+    params.explicitOrchestrationRequirements,
+  );
+  const plannerStepContractDiagnostics = validatePlannerStepContracts(
+    params.plannerPlan,
+    params.messageText,
+  );
+  const verificationRequirementDiagnostics =
+    params.explicitVerificationRequirements.length > 0 ||
+    params.explicitVerificationCommandRequirements.length > 0
+      ? validatePlannerVerificationRequirements(
+          params.plannerPlan,
+          params.explicitVerificationRequirements,
+          params.explicitVerificationCommandRequirements,
+        )
+      : [];
+  const structuralGraphDiagnostics = extractPlannerStructuralDiagnostics(
+    [
+      ...graphDiagnostics,
+      ...verificationRequirementDiagnostics,
+    ],
+  );
+  const decompositionGraphDiagnostics =
+    extractPlannerDecompositionDiagnostics(structuralGraphDiagnostics);
+  const requiredOrchestrationDiagnostics =
+    params.explicitOrchestrationRequirements
+      ? validateExplicitSubagentOrchestrationRequirements(
+          params.plannerPlan,
+          params.explicitOrchestrationRequirements,
+        )
+      : [];
+  const explicitToolDiagnostics =
+    params.explicitDeterministicToolRequirements
+      ? validateExplicitDeterministicToolRequirements(
+          params.plannerPlan,
+          params.explicitDeterministicToolRequirements,
+        )
+      : [];
+  const hasStructuralDiagnostics =
+    structuralGraphDiagnostics.length > 0 ||
+    requiredOrchestrationDiagnostics.length > 0 ||
+    explicitToolDiagnostics.length > 0;
+  const currentValidationDiagnostics = [
+    ...graphDiagnostics,
+    ...plannerStepContractDiagnostics,
+    ...verificationRequirementDiagnostics,
+    ...requiredOrchestrationDiagnostics,
+    ...explicitToolDiagnostics,
+  ];
+  const hasOnlyStepContractDiagnostics =
+    !hasStructuralDiagnostics &&
+    plannerStepContractDiagnostics.length > 0;
+  const structuralDiagnosticSignature =
+    hasStructuralDiagnostics
+      ? buildPlannerDiagnosticSignature([
+          ...structuralGraphDiagnostics,
+          ...requiredOrchestrationDiagnostics,
+          ...explicitToolDiagnostics,
+        ])
+      : "";
+  return {
+    graphDiagnostics,
+    plannerStepContractDiagnostics,
+    verificationRequirementDiagnostics,
+    structuralGraphDiagnostics,
+    decompositionGraphDiagnostics,
+    requiredOrchestrationDiagnostics,
+    explicitToolDiagnostics,
+    hasStructuralDiagnostics,
+    currentValidationDiagnostics,
+    hasOnlyStepContractDiagnostics,
+    structuralDiagnosticSignature,
+  };
+}
+
 // ============================================================================
 // executePlannerPath (standalone)
 // ============================================================================
@@ -640,18 +1016,72 @@ export async function executePlannerPath(
       },
       plannerWorkspaceRoot,
     );
-    const plannerResponse = await callbacks.callModelForPhase(ctx, {
-      phase: "planner",
-      callMessages: plannerMessages,
-      callSections: plannerSections,
-      ...(explicitPlannerToolNames
-        ? { routedToolNames: explicitPlannerToolNames }
-        : {}),
-      structuredOutput: buildPlannerStructuredOutputRequest(),
-      budgetReason:
-        "Planner pass blocked by max model recalls per request budget",
-    });
-    if (!plannerResponse) return;
+    let plannerResponse: LLMResponse | undefined;
+    let plannerParseDiagnostics: readonly PlannerDiagnostic[] = [];
+    let plannerPlan: PlannerPlan | undefined;
+    try {
+      plannerResponse = await callbacks.callModelForPhase(ctx, {
+        phase: "planner",
+        callMessages: plannerMessages,
+        callSections: plannerSections,
+        ...(explicitPlannerToolNames
+          ? { routedToolNames: explicitPlannerToolNames }
+          : {}),
+        structuredOutput: buildPlannerStructuredOutputRequest(),
+        budgetReason:
+          "Planner pass blocked by max model recalls per request budget",
+      });
+      if (!plannerResponse) return;
+
+      const plannerParse = normalizePlannerResponse({
+        content: plannerResponse.content,
+        toolCalls: plannerResponse.toolCalls,
+        structuredOutput: plannerResponse.structuredOutput,
+        repairRequirements: explicitOrchestrationRequirements,
+        plannerWorkspaceRoot,
+      });
+      plannerParseDiagnostics = plannerParse.diagnostics;
+      plannerPlan = plannerParse.plan;
+    } catch (error) {
+      const failureClass = classifyLLMFailure(error);
+      if (
+        canRuntimeRepairPlannerProviderFailure({
+          messageText: ctx.messageText,
+          workspaceRoot: plannerWorkspaceRoot,
+          failureClass,
+        })
+      ) {
+        plannerPlan = buildRuntimeRepairedPlannerProviderFailurePlan({
+          messageText: ctx.messageText,
+          workspaceRoot: plannerWorkspaceRoot!,
+        });
+        if (!plannerPlan) {
+          throw error;
+        }
+        ctx.stopReason = "completed";
+        ctx.completionState = "completed";
+        ctx.stopReasonDetail = undefined;
+        ctx.validationCode = undefined;
+        plannerParseDiagnostics = [
+          {
+            category: "policy",
+            code: "planner_runtime_repair_provider_unavailable",
+            message:
+              "Planner model was transiently unavailable; runtime promoted the request to a canonical single-owner implementation contract",
+            details: {
+              attempt: plannerAttempt,
+              failureClass,
+              providerError:
+                error instanceof Error
+                  ? truncateText(error.message, 240)
+                  : String(error),
+            },
+          },
+        ];
+      } else {
+        throw error;
+      }
+    }
 
     ctx.plannerSummaryState.plannerCalls = plannerAttempt;
     ctx.plannerSummaryState.delegationDecision = undefined;
@@ -660,16 +1090,7 @@ export async function executePlannerPath(
     ctx.plannedSynthesisSteps = 0;
     ctx.plannedFanout = 0;
     ctx.plannedDependencyDepth = 0;
-
-    const plannerParse = normalizePlannerResponse({
-      content: plannerResponse.content,
-      toolCalls: plannerResponse.toolCalls,
-      structuredOutput: plannerResponse.structuredOutput,
-      repairRequirements: explicitOrchestrationRequirements,
-      plannerWorkspaceRoot,
-    });
-    ctx.plannerSummaryState.diagnostics.push(...plannerParse.diagnostics);
-    const plannerPlan = plannerParse.plan;
+    ctx.plannerSummaryState.diagnostics.push(...plannerParseDiagnostics);
     if (!plannerPlan) {
       if (explicitOrchestrationRequirements) {
         if (
@@ -679,7 +1100,7 @@ export async function executePlannerPath(
           structuralPlannerRetriesUsed++;
           refinementHint = buildExplicitSubagentOrchestrationRefinementHint(
             explicitOrchestrationRequirements,
-            plannerParse.diagnostics,
+            plannerParseDiagnostics,
           );
           ctx.plannerSummaryState.diagnostics.push({
             category: "policy",
@@ -697,7 +1118,7 @@ export async function executePlannerPath(
             nextAttempt: plannerAttempt + 1,
             reason: "planner_required_orchestration_retry",
             routeReason: "planner_required_orchestration_unmet",
-            diagnostics: plannerParse.diagnostics,
+            diagnostics: plannerParseDiagnostics,
           });
           continue;
         }
@@ -710,7 +1131,7 @@ export async function executePlannerPath(
         );
         ctx.finalContent = buildExplicitSubagentOrchestrationFailureMessage(
           explicitOrchestrationRequirements,
-          plannerParse.diagnostics,
+          plannerParseDiagnostics,
         );
         callbacks.emitPlannerTrace(ctx, "planner_path_finished", {
           plannerCalls: plannerAttempt,
@@ -731,7 +1152,7 @@ export async function executePlannerPath(
           structuralPlannerRetriesUsed++;
           refinementHint = buildExplicitDeterministicToolRefinementHint(
             explicitDeterministicToolRequirements,
-            plannerParse.diagnostics,
+            plannerParseDiagnostics,
           );
           ctx.plannerSummaryState.diagnostics.push({
             category: "policy",
@@ -749,7 +1170,7 @@ export async function executePlannerPath(
             nextAttempt: plannerAttempt + 1,
             reason: "planner_explicit_tool_parse_retry",
             routeReason: "planner_explicit_tool_requirements_unmet",
-            diagnostics: plannerParse.diagnostics,
+            diagnostics: plannerParseDiagnostics,
           });
           continue;
         }
@@ -762,7 +1183,7 @@ export async function executePlannerPath(
         );
         ctx.finalContent = buildExplicitDeterministicToolFailureMessage(
           explicitDeterministicToolRequirements,
-          plannerParse.diagnostics,
+          plannerParseDiagnostics,
         );
         callbacks.emitPlannerTrace(ctx, "planner_path_finished", {
           plannerCalls: plannerAttempt,
@@ -777,12 +1198,12 @@ export async function executePlannerPath(
       }
       const recoverablePlannerParseDiagnostics =
         extractRecoverablePlannerParseDiagnostics(
-          plannerParse.diagnostics,
+          plannerParseDiagnostics,
         );
       if (
         recoverablePlannerParseDiagnostics.length > 0 &&
         recoverablePlannerParseDiagnostics.length ===
-          plannerParse.diagnostics.length &&
+          plannerParseDiagnostics.length &&
         plannerAttempt < maxPlannerAttempts &&
         plannerStepContractRetriesUsed < maxPlannerStepContractRetries
       ) {
@@ -870,102 +1291,50 @@ export async function executePlannerPath(
       return;
     }
 
-    const graphDiagnostics = validatePlannerGraph(
+    let validationState = evaluatePlannerValidationState({
       plannerPlan,
-      {
-        maxSubagentFanout: config.delegationDecisionConfig.maxFanoutPerTurn,
-        maxSubagentDepth: config.delegationDecisionConfig.maxDepth,
-      },
+      messageText: ctx.messageText,
+      workspaceRoot: plannerWorkspaceRoot,
+      delegationConfig: config.delegationDecisionConfig,
       explicitOrchestrationRequirements,
-    );
-    const plannerStepContractDiagnostics = validatePlannerStepContracts(
-      plannerPlan,
-      ctx.messageText,
-    );
-    const verificationRequirementDiagnostics =
-      explicitVerificationRequirements.length > 0 ||
-      explicitVerificationCommandRequirements.length > 0
-        ? validatePlannerVerificationRequirements(
-            plannerPlan,
-            explicitVerificationRequirements,
-            explicitVerificationCommandRequirements,
-          )
-        : [];
-    const structuralGraphDiagnostics = extractPlannerStructuralDiagnostics(
-      [
-        ...graphDiagnostics,
-        ...verificationRequirementDiagnostics,
-      ],
-    );
-    const decompositionGraphDiagnostics =
-      extractPlannerDecompositionDiagnostics(structuralGraphDiagnostics);
-    const requiredOrchestrationDiagnostics =
-      explicitOrchestrationRequirements
-        ? validateExplicitSubagentOrchestrationRequirements(
-            plannerPlan,
-            explicitOrchestrationRequirements,
-          )
-        : [];
-    const explicitToolDiagnostics =
-      explicitDeterministicToolRequirements
-        ? validateExplicitDeterministicToolRequirements(
-            plannerPlan,
-            explicitDeterministicToolRequirements,
-          )
-        : [];
-    const hasStructuralDiagnostics =
-      structuralGraphDiagnostics.length > 0 ||
-      requiredOrchestrationDiagnostics.length > 0 ||
-      explicitToolDiagnostics.length > 0;
-    const currentValidationDiagnostics = [
-      ...graphDiagnostics,
-      ...plannerStepContractDiagnostics,
-      ...verificationRequirementDiagnostics,
-      ...requiredOrchestrationDiagnostics,
-      ...explicitToolDiagnostics,
-    ];
-    latestPlannerValidationDiagnostics = currentValidationDiagnostics;
-    const hasOnlyStepContractDiagnostics =
-      !hasStructuralDiagnostics &&
-      plannerStepContractDiagnostics.length > 0;
-    const structuralDiagnosticSignature =
-      hasStructuralDiagnostics
-        ? buildPlannerDiagnosticSignature([
-            ...structuralGraphDiagnostics,
-            ...requiredOrchestrationDiagnostics,
-            ...explicitToolDiagnostics,
-          ])
-        : "";
+      explicitDeterministicToolRequirements,
+      explicitVerificationRequirements,
+      explicitVerificationCommandRequirements,
+    });
+    latestPlannerValidationDiagnostics =
+      validationState.currentValidationDiagnostics;
     const canUseProgressStructuralRetry =
-      hasStructuralDiagnostics &&
+      validationState.hasStructuralDiagnostics &&
       structuralPlannerRetriesUsed >= maxStructuralPlannerRetries &&
       plannerAttempt < maxPlannerAttempts &&
-      structuralDiagnosticSignature.length > 0 &&
-      !seenStructuralDiagnosticSignatures.has(structuralDiagnosticSignature);
+      validationState.structuralDiagnosticSignature.length > 0 &&
+      !seenStructuralDiagnosticSignatures.has(
+        validationState.structuralDiagnosticSignature,
+      );
     const hasOnlyDecompositionStructuralDiagnostics =
-      decompositionGraphDiagnostics.length > 0 &&
-      decompositionGraphDiagnostics.length ===
-        structuralGraphDiagnostics.length &&
-      plannerStepContractDiagnostics.length === 0 &&
-      verificationRequirementDiagnostics.length === 0 &&
-      requiredOrchestrationDiagnostics.length === 0 &&
-      explicitToolDiagnostics.length === 0;
+      validationState.decompositionGraphDiagnostics.length > 0 &&
+      validationState.decompositionGraphDiagnostics.length ===
+        validationState.structuralGraphDiagnostics.length &&
+      validationState.plannerStepContractDiagnostics.length === 0 &&
+      validationState.verificationRequirementDiagnostics.length === 0 &&
+      validationState.requiredOrchestrationDiagnostics.length === 0 &&
+      validationState.explicitToolDiagnostics.length === 0;
     const canUseDecompositionRetry =
       hasOnlyDecompositionStructuralDiagnostics &&
       decompositionPlannerRetriesUsed < maxPlannerDecompositionRetries &&
       plannerAttempt < maxPlannerAttempts;
     const shouldRefinePlan =
       (
-        structuralGraphDiagnostics.length > 0 ||
-        plannerStepContractDiagnostics.length > 0 ||
-        verificationRequirementDiagnostics.length > 0 ||
-        requiredOrchestrationDiagnostics.length > 0 ||
-        explicitToolDiagnostics.length > 0
+        validationState.structuralGraphDiagnostics.length > 0 ||
+        validationState.plannerStepContractDiagnostics.length > 0 ||
+        validationState.verificationRequirementDiagnostics.length > 0 ||
+        validationState.requiredOrchestrationDiagnostics.length > 0 ||
+        validationState.explicitToolDiagnostics.length > 0
       ) &&
       plannerAttempt < maxPlannerAttempts &&
       (
         (
-          hasOnlyStepContractDiagnostics &&
+          validationState.hasOnlyStepContractDiagnostics &&
           plannerStepContractRetriesUsed < maxPlannerStepContractRetries
         ) ||
         structuralPlannerRetriesUsed < maxStructuralPlannerRetries ||
@@ -973,26 +1342,28 @@ export async function executePlannerPath(
         canUseDecompositionRetry
       );
     if (
-      graphDiagnostics.length > 0 ||
-      plannerStepContractDiagnostics.length > 0 ||
-      verificationRequirementDiagnostics.length > 0 ||
-      requiredOrchestrationDiagnostics.length > 0 ||
-      explicitToolDiagnostics.length > 0
+      validationState.graphDiagnostics.length > 0 ||
+      validationState.plannerStepContractDiagnostics.length > 0 ||
+      validationState.verificationRequirementDiagnostics.length > 0 ||
+      validationState.requiredOrchestrationDiagnostics.length > 0 ||
+      validationState.explicitToolDiagnostics.length > 0
     ) {
-      ctx.plannerSummaryState.diagnostics.push(...graphDiagnostics);
+      ctx.plannerSummaryState.diagnostics.push(...validationState.graphDiagnostics);
       ctx.plannerSummaryState.diagnostics.push(
-        ...plannerStepContractDiagnostics,
+        ...validationState.plannerStepContractDiagnostics,
       );
       ctx.plannerSummaryState.diagnostics.push(
-        ...verificationRequirementDiagnostics,
+        ...validationState.verificationRequirementDiagnostics,
       );
       ctx.plannerSummaryState.diagnostics.push(
-        ...requiredOrchestrationDiagnostics,
+        ...validationState.requiredOrchestrationDiagnostics,
       );
-      ctx.plannerSummaryState.diagnostics.push(...explicitToolDiagnostics);
+      ctx.plannerSummaryState.diagnostics.push(
+        ...validationState.explicitToolDiagnostics,
+      );
       if (shouldRefinePlan) {
         if (
-          hasOnlyStepContractDiagnostics &&
+          validationState.hasOnlyStepContractDiagnostics &&
           plannerStepContractRetriesUsed < maxPlannerStepContractRetries
         ) {
           plannerStepContractRetriesUsed++;
@@ -1001,69 +1372,69 @@ export async function executePlannerPath(
         } else if (canUseDecompositionRetry) {
           decompositionPlannerRetriesUsed++;
         }
-        if (structuralDiagnosticSignature.length > 0) {
+        if (validationState.structuralDiagnosticSignature.length > 0) {
           seenStructuralDiagnosticSignatures.add(
-            structuralDiagnosticSignature,
+            validationState.structuralDiagnosticSignature,
           );
         }
         const refinementHints: string[] = [];
-        if (structuralGraphDiagnostics.length > 0) {
+        if (validationState.structuralGraphDiagnostics.length > 0) {
           refinementHints.push(
             buildPlannerStructuralRefinementHint(
-              structuralGraphDiagnostics,
+              validationState.structuralGraphDiagnostics,
             ),
           );
         }
-        if (plannerStepContractDiagnostics.length > 0) {
+        if (validationState.plannerStepContractDiagnostics.length > 0) {
           refinementHints.push(
             buildPlannerStepContractRefinementHint(
-              plannerStepContractDiagnostics,
+              validationState.plannerStepContractDiagnostics,
             ),
           );
         }
-        if (verificationRequirementDiagnostics.length > 0) {
+        if (validationState.verificationRequirementDiagnostics.length > 0) {
           refinementHints.push(
             buildPlannerVerificationRequirementsRefinementHint(
               explicitVerificationRequirements,
-              verificationRequirementDiagnostics,
+              validationState.verificationRequirementDiagnostics,
             ),
           );
         }
-        if (requiredOrchestrationDiagnostics.length > 0) {
+        if (validationState.requiredOrchestrationDiagnostics.length > 0) {
           refinementHints.push(
             buildExplicitSubagentOrchestrationRefinementHint(
               explicitOrchestrationRequirements!,
-              requiredOrchestrationDiagnostics,
+              validationState.requiredOrchestrationDiagnostics,
             ),
           );
         }
-        if (explicitToolDiagnostics.length > 0) {
+        if (validationState.explicitToolDiagnostics.length > 0) {
           refinementHints.push(
             buildExplicitDeterministicToolRefinementHint(
               explicitDeterministicToolRequirements!,
-              explicitToolDiagnostics,
+              validationState.explicitToolDiagnostics,
             ),
           );
         }
         refinementHint = refinementHints.join(" ");
         const plannerRetryCode =
-          requiredOrchestrationDiagnostics.length > 0
+          validationState.requiredOrchestrationDiagnostics.length > 0
             ? "planner_required_orchestration_retry"
-            : explicitToolDiagnostics.length > 0
+            : validationState.explicitToolDiagnostics.length > 0
               ? "planner_explicit_tool_retry"
-              : verificationRequirementDiagnostics.length > 0
+              : validationState.verificationRequirementDiagnostics.length > 0
                 ? "planner_verification_requirements_retry"
-              : plannerStepContractDiagnostics.length > 0
+              : validationState.plannerStepContractDiagnostics.length > 0
                 ? "planner_step_contract_retry"
               : "planner_refinement_retry";
         const plannerRetryMessage =
-          requiredOrchestrationDiagnostics.length > 0
+          validationState.requiredOrchestrationDiagnostics.length > 0
             ? "Planner did not satisfy the user-required sub-agent orchestration plan; requesting a refined plan"
-            : explicitToolDiagnostics.length > 0
+            : validationState.explicitToolDiagnostics.length > 0
               ? "Planner drifted outside the explicitly requested deterministic tool contract; requesting a refined plan"
-              : verificationRequirementDiagnostics.length > 0
+              : validationState.verificationRequirementDiagnostics.length > 0
                 ? "Planner dropped one or more user-requested verification modes; requesting a refined plan"
-              : plannerStepContractDiagnostics.length > 0
+              : validationState.plannerStepContractDiagnostics.length > 0
                 ? "Planner emitted steps that violate runtime tool contracts; requesting a refined plan"
               : "Planner emitted structural delegation violations; requesting a refined plan";
         ctx.plannerSummaryState.diagnostics.push({
@@ -1082,19 +1453,73 @@ export async function executePlannerPath(
           attempt: plannerAttempt,
           nextAttempt: plannerAttempt + 1,
           reason: plannerRetryCode,
-          graphDiagnostics,
-          decompositionGraphDiagnostics,
-          plannerStepContractDiagnostics,
-          verificationRequirementDiagnostics,
+          graphDiagnostics: validationState.graphDiagnostics,
+          decompositionGraphDiagnostics:
+            validationState.decompositionGraphDiagnostics,
+          plannerStepContractDiagnostics:
+            validationState.plannerStepContractDiagnostics,
+          verificationRequirementDiagnostics:
+            validationState.verificationRequirementDiagnostics,
           requestedVerificationCategories: explicitVerificationRequirements,
           requestedVerificationCommands: explicitVerificationCommandRequirements,
-          requiredOrchestrationDiagnostics,
-          explicitToolDiagnostics,
+          requiredOrchestrationDiagnostics:
+            validationState.requiredOrchestrationDiagnostics,
+          explicitToolDiagnostics: validationState.explicitToolDiagnostics,
           decompositionRetry: canUseDecompositionRetry,
         });
         continue;
       }
-      if (requiredOrchestrationDiagnostics.length > 0) {
+      const repairedPlannerPlan = canRuntimeRepairImplementFromArtifactPlan({
+        plannerPlan,
+        diagnostics: validationState.currentValidationDiagnostics,
+        messageText: ctx.messageText,
+        workspaceRoot: plannerWorkspaceRoot,
+      })
+        ? buildRuntimeRepairedImplementFromArtifactPlan({
+            plannerPlan,
+            messageText: ctx.messageText,
+            workspaceRoot: plannerWorkspaceRoot!,
+          })
+        : undefined;
+      if (repairedPlannerPlan) {
+        const repairedFromStepCount = plannerPlan.steps.length;
+        plannerPlan = repairedPlannerPlan;
+        ctx.plannerSummaryState.diagnostics.push({
+          category: "policy",
+          code: "planner_runtime_repair_single_owner_contract",
+          message:
+            "Planner collapsed an implement-from-artifact request into read-only inspection; runtime promoted it to a canonical single-owner implementation contract",
+          details: {
+            attempt: plannerAttempt,
+            repairedFromStepCount,
+            repairedToStepCount: repairedPlannerPlan.steps.length,
+            ...(plannerWorkspaceRoot
+              ? { workspaceRoot: plannerWorkspaceRoot }
+              : {}),
+          },
+        });
+        validationState = evaluatePlannerValidationState({
+          plannerPlan,
+          messageText: ctx.messageText,
+          workspaceRoot: plannerWorkspaceRoot,
+          delegationConfig: config.delegationDecisionConfig,
+          explicitOrchestrationRequirements,
+          explicitDeterministicToolRequirements,
+          explicitVerificationRequirements,
+          explicitVerificationCommandRequirements,
+        });
+        latestPlannerValidationDiagnostics =
+          validationState.currentValidationDiagnostics;
+        if (
+          validationState.currentValidationDiagnostics.length === 0 &&
+          plannerPlan.reason
+        ) {
+          ctx.plannerSummaryState.routeReason = plannerPlan.reason;
+        }
+      }
+      if (validationState.currentValidationDiagnostics.length === 0) {
+        latestPlannerValidationDiagnostics = [];
+      } else if (validationState.requiredOrchestrationDiagnostics.length > 0) {
         ctx.plannerSummaryState.routeReason =
           "planner_required_orchestration_unmet";
         callbacks.setStopReason(
@@ -1104,7 +1529,7 @@ export async function executePlannerPath(
         );
         ctx.finalContent = buildExplicitSubagentOrchestrationFailureMessage(
           explicitOrchestrationRequirements!,
-          requiredOrchestrationDiagnostics,
+          validationState.requiredOrchestrationDiagnostics,
         );
         callbacks.emitPlannerTrace(ctx, "planner_path_finished", {
           plannerCalls: plannerAttempt,
@@ -1116,8 +1541,7 @@ export async function executePlannerPath(
         });
         ctx.plannerHandled = true;
         return;
-      }
-      if (verificationRequirementDiagnostics.length > 0) {
+      } else if (validationState.verificationRequirementDiagnostics.length > 0) {
         ctx.plannerSummaryState.routeReason =
           "planner_verification_requirements_unmet";
         callbacks.setStopReason(
@@ -1128,7 +1552,7 @@ export async function executePlannerPath(
         ctx.finalContent =
           buildPlannerVerificationRequirementsFailureMessage(
             explicitVerificationRequirements,
-            verificationRequirementDiagnostics,
+            validationState.verificationRequirementDiagnostics,
           );
         callbacks.emitPlannerTrace(ctx, "planner_path_finished", {
           plannerCalls: plannerAttempt,
@@ -1140,8 +1564,7 @@ export async function executePlannerPath(
         });
         ctx.plannerHandled = true;
         return;
-      }
-      if (explicitToolDiagnostics.length > 0) {
+      } else if (validationState.explicitToolDiagnostics.length > 0) {
         ctx.plannerSummaryState.routeReason =
           "planner_explicit_tool_requirements_unmet";
         callbacks.setStopReason(
@@ -1151,7 +1574,7 @@ export async function executePlannerPath(
         );
         ctx.finalContent = buildExplicitDeterministicToolFailureMessage(
           explicitDeterministicToolRequirements!,
-          explicitToolDiagnostics,
+          validationState.explicitToolDiagnostics,
         );
         callbacks.emitPlannerTrace(ctx, "planner_path_finished", {
           plannerCalls: plannerAttempt,
@@ -1163,11 +1586,12 @@ export async function executePlannerPath(
         });
         ctx.plannerHandled = true;
         return;
+      } else {
+        ctx.plannerSummaryState.routeReason =
+          validationState.explicitToolDiagnostics.length > 0
+            ? "planner_explicit_tool_requirements_unmet"
+            : "planner_validation_failed";
       }
-      ctx.plannerSummaryState.routeReason =
-        explicitToolDiagnostics.length > 0
-          ? "planner_explicit_tool_requirements_unmet"
-          : "planner_validation_failed";
     } else if (plannerPlan.reason) {
       ctx.plannerSummaryState.routeReason = plannerPlan.reason;
     }
@@ -1186,12 +1610,15 @@ export async function executePlannerPath(
       synthesisSteps: plannerPlan.steps.filter((step) =>
         step.stepType === "synthesis"
       ).length,
-      graphDiagnostics,
-      plannerStepContractDiagnostics,
-      verificationRequirementDiagnostics,
+      graphDiagnostics: validationState.graphDiagnostics,
+      plannerStepContractDiagnostics:
+        validationState.plannerStepContractDiagnostics,
+      verificationRequirementDiagnostics:
+        validationState.verificationRequirementDiagnostics,
       requestedVerificationCategories: explicitVerificationRequirements,
-      requiredOrchestrationDiagnostics,
-      explicitToolDiagnostics,
+      requiredOrchestrationDiagnostics:
+        validationState.requiredOrchestrationDiagnostics,
+      explicitToolDiagnostics: validationState.explicitToolDiagnostics,
       steps: plannerPlan.steps.map((step) => ({ ...step })),
       edges: plannerPlan.edges.map((edge) => ({ ...edge })),
     });
@@ -1421,7 +1848,7 @@ export async function executePlannerPath(
         subagentSteps,
         deterministicSteps,
         workflowContract: plannerPlan.workflowContract,
-        workspaceRoot: plannerExecutionContext.workspaceRoot,
+        workspaceRoot: plannerExecutionContext?.workspaceRoot,
         verificationContract: ctx.requiredToolEvidence?.verificationContract,
         completionContract: ctx.requiredToolEvidence?.completionContract,
         includeSubagentOutputVerification:
@@ -1461,7 +1888,7 @@ export async function executePlannerPath(
         subagentSteps,
         deterministicSteps,
         workflowContract: plannerPlan.workflowContract,
-        workspaceRoot: plannerExecutionContext.workspaceRoot,
+        workspaceRoot: plannerExecutionContext?.workspaceRoot,
         verificationContract: plannerWorkflowAdmission.verificationContract,
         completionContract: plannerWorkflowAdmission.completionContract,
         includeSubagentOutputVerification:
@@ -1791,7 +2218,9 @@ export async function executePlannerPath(
             message:
               "Planner synthesis was skipped because a child-owned artifact write failed and inline materialization is not authoritative for that target",
             details: {
-              targetPath: requestedWriteTarget,
+              ...(requestedWriteTarget
+                ? { targetPath: requestedWriteTarget }
+                : {}),
               pipelineStatus: pipelineResult.status,
               stopReason: ctx.stopReason,
             },
@@ -1908,10 +2337,62 @@ export async function executePlannerPath(
                   targetPath: synthesisWriteTarget,
                 },
               });
+              callbacks.emitPlannerTrace(ctx, "planner_path_finished", {
+                plannerCalls: plannerAttempt,
+                routeReason: ctx.plannerSummaryState.routeReason,
+                stopReason: ctx.stopReason,
+                stopReasonDetail: ctx.stopReasonDetail,
+                diagnostics: ctx.plannerSummaryState.diagnostics,
+                handled: true,
+                deterministicStepsExecuted:
+                  ctx.plannerSummaryState.deterministicStepsExecuted,
+              });
+              ctx.plannerHandled = true;
               return;
             }
           }
           if (synthesisResponse) {
+            const postSynthesisToolCalls = ctx.allToolCalls.slice(
+              toolCallCountBeforeSynthesis,
+            );
+            const claimedButUnexecutedToolNames =
+              resolvePlannerSynthesisToolMarkupMismatch({
+                content: synthesisResponse.content,
+                toolCalls: postSynthesisToolCalls,
+              });
+            if (claimedButUnexecutedToolNames.length > 0) {
+              callbacks.setStopReason(
+                ctx,
+                "validation_error",
+                "Planner synthesis emitted tool-call markup that was not executed. " +
+                  "Synthesis must summarize the authoritative execution ledger instead of inventing tool invocations.",
+              );
+              ctx.finalContent =
+                "Planner synthesis emitted tool-call markup that was not executed. " +
+                `Missing executed tool calls: ${claimedButUnexecutedToolNames.join(", ")}.`;
+              ctx.plannerSummaryState.diagnostics.push({
+                category: "runtime",
+                code: "planner_synthesis_unexecuted_tool_markup",
+                message:
+                  "Planner synthesis emitted fenced tool-call markup for tool invocations that do not exist in the authoritative execution ledger",
+                details: {
+                  claimedToolNames:
+                    claimedButUnexecutedToolNames.join(", "),
+                },
+              });
+              callbacks.emitPlannerTrace(ctx, "planner_path_finished", {
+                plannerCalls: plannerAttempt,
+                routeReason: ctx.plannerSummaryState.routeReason,
+                stopReason: ctx.stopReason,
+                stopReasonDetail: ctx.stopReasonDetail,
+                diagnostics: ctx.plannerSummaryState.diagnostics,
+                handled: true,
+                deterministicStepsExecuted:
+                  ctx.plannerSummaryState.deterministicStepsExecuted,
+              });
+              ctx.plannerHandled = true;
+              return;
+            }
             ctx.response = synthesisResponse;
             ctx.finalContent = ensureSubagentProvenanceCitations(
               synthesisResponse.content,

--- a/runtime/src/llm/chat-executor-planner.test.ts
+++ b/runtime/src/llm/chat-executor-planner.test.ts
@@ -1,3 +1,7 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -84,6 +88,25 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
           ),
         }),
       ]),
+    );
+  });
+
+  it("omits numeric fanout guidance when runtime fanout is unlimited", () => {
+    const messages = buildPlannerMessages(
+      "Create a TypeScript monorepo from scratch with multiple packages, tests, and docs.",
+      [],
+      512,
+      undefined,
+      undefined,
+      undefined,
+      { maxSubagentFanout: 0 },
+    );
+
+    expect(messages[0]).toMatchObject({
+      role: "system",
+    });
+    expect(messages[0]?.content).not.toContain(
+      "do not rely on more than 0 concurrently runnable subagent_task steps at once",
     );
   });
 
@@ -187,6 +210,42 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
 
     const finalUserMessage = messages[messages.length - 1];
     expect(finalUserMessage?.content).toContain("perfect ROADMAP.md");
+  });
+
+  it("filters same-target failed implement-from-artifact history when retrying implementation", () => {
+    const messages = buildPlannerMessages(
+      "Read all of @PLAN.md and implement every phase in full.",
+      [
+        {
+          role: "user",
+          content:
+            "Can you go through @PLAN.md and implement every phase sequentially in full and make sure they are fully tested.",
+        },
+        {
+          role: "assistant",
+          content:
+            "Execution stopped before completion (validation_error). Planner emitted a structured plan that failed local validation.",
+        },
+        {
+          role: "user",
+          content:
+            "Keep the workspace root at /tmp/agenc-shell and do not move to the next phase until tests pass.",
+        },
+      ],
+      512,
+    );
+
+    const finalUserMessage = messages[messages.length - 1];
+    expect(finalUserMessage?.role).toBe("user");
+    expect(finalUserMessage?.content).not.toContain(
+      "implement every phase sequentially in full",
+    );
+    expect(finalUserMessage?.content).not.toContain(
+      "Planner emitted a structured plan that failed local validation",
+    );
+    expect(finalUserMessage?.content).toContain(
+      "Keep the workspace root at /tmp/agenc-shell",
+    );
   });
 
   it("treats plain-language delegation research requests as explicit delegation", () => {
@@ -1020,6 +1079,51 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
         ],
       }),
     ]);
+  });
+
+  it("treats zero fanout as unlimited during planner graph validation", () => {
+    const diagnostics = validatePlannerGraph(
+      {
+        requiresSynthesis: true,
+        steps: [
+          {
+            name: "review_architecture",
+            stepType: "subagent_task",
+            objective: "Review the architecture grounding.",
+            inputContract: "Read the workspace and return grounded findings.",
+            acceptanceCriteria: ["Findings are grounded in the workspace."],
+            requiredToolCapabilities: ["system.readFile"],
+            contextRequirements: ["repo_context"],
+            maxBudgetHint: "2m",
+            canRunParallel: true,
+          },
+          {
+            name: "review_quality",
+            stepType: "subagent_task",
+            objective: "Review the quality risks.",
+            inputContract: "Read the workspace and return grounded findings.",
+            acceptanceCriteria: ["Findings are grounded in the workspace."],
+            requiredToolCapabilities: ["system.readFile"],
+            contextRequirements: ["repo_context"],
+            maxBudgetHint: "2m",
+            canRunParallel: true,
+          },
+        ],
+        edges: [],
+      },
+      {
+        maxSubagentFanout: 0,
+        maxSubagentDepth: 4,
+      },
+    );
+
+    expect(diagnostics).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "subagent_fanout_exceeded",
+        }),
+      ]),
+    );
   });
 
   it("preserves semantic planner capabilities instead of falling back to heuristic repair defaults", () => {
@@ -2382,6 +2486,60 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
     );
   });
 
+  it("rejects implement-from-plan plans that only contain read-only analysis", () => {
+    const workspaceRoot = "/tmp/agenc-shell";
+    const diagnostics = validatePlannerStepContracts(
+      {
+        reason: "implement_from_plan",
+        requiresSynthesis: false,
+        confidence: 0.82,
+        steps: [
+          {
+            name: "read_plan",
+            stepType: "deterministic_tool",
+            dependsOn: [],
+            tool: "system.readFile",
+            args: {
+              path: `${workspaceRoot}/PLAN.md`,
+            },
+          },
+          {
+            name: "phase1_analysis",
+            stepType: "subagent_task",
+            dependsOn: ["read_plan"],
+            objective:
+              "Analyze PLAN.md to identify Phase 1 work. Do not implement code yet.",
+            inputContract: "PLAN.md plus the existing source tree.",
+            acceptanceCriteria: ["No code changes; output is analysis only."],
+            requiredToolCapabilities: ["system.readFile", "system.listDir"],
+            contextRequirements: ["read_plan"],
+            maxBudgetHint: "2m",
+            canRunParallel: false,
+            executionContext: {
+              version: "v1",
+              workspaceRoot,
+              allowedReadRoots: [workspaceRoot],
+              requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+              effectClass: "read_only",
+              verificationMode: "grounded_read",
+              stepKind: "delegated_research",
+            },
+          },
+        ],
+        edges: [{ from: "read_plan", to: "phase1_analysis" }],
+      },
+      "Can you go through @PLAN.md and implement every phase sequentially in full and make sure they are fully tested.",
+    );
+
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "planner_implementation_missing_mutation_path",
+        }),
+      ]),
+    );
+  });
+
   it("classifies the full existing artifact alias family consistently", () => {
     expect(
       classifyPlannerPlanArtifactIntent(
@@ -2436,6 +2594,30 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
           role: "system",
           content: expect.stringContaining(
             "This is a workspace-grounded artifact update request.",
+          ),
+        }),
+      ]),
+    );
+  });
+
+  it("warns implement-from-artifact planner prompts that read-only plan inspection is invalid", () => {
+    const messages = buildPlannerMessages(
+      "Can you go through @PLAN.md and implement every phase sequentially in full and make sure they are fully tested.",
+      [],
+      4000,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "/tmp/agenc-shell",
+    );
+
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "system",
+          content: expect.stringContaining(
+            "A plan that only reads the plan artifact, lists files, or produces read-only analysis is invalid for this request class.",
           ),
         }),
       ]),
@@ -2745,6 +2927,419 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
         diagnostic.code === "node_workspace_install_phase_mismatch"
       ),
     ).toBe(false);
+  });
+
+  it("rejects node workspace scaffolding plans for a CMake workspace", () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "planner-cmake-"));
+    try {
+      writeFileSync(join(workspaceRoot, "CMakeLists.txt"), "cmake_minimum_required(VERSION 3.20)\nproject(agenc_shell C)\n");
+      const diagnostics = validatePlannerGraph(
+        {
+          reason: "workspace_project",
+          requiresSynthesis: true,
+          confidence: 0.77,
+          steps: [
+            {
+              name: "phase1_setup",
+              stepType: "subagent_task",
+              dependsOn: [],
+              objective:
+                "Create initial project structure, package.json, and scaffold files as specified.",
+              inputContract:
+                "Phase 1 details including file structure, initial package.json, and scaffold instructions.",
+              acceptanceCriteria: [
+                "package.json exists with exact dependencies/devDependencies from phase 1.",
+                "Buildable TypeScript workspace packages use package-local tsconfig/project references.",
+              ],
+              requiredToolCapabilities: ["system.writeFile", "system.listDir"],
+              contextRequirements: ["repo_context", "parse_phases"],
+              maxBudgetHint: "2m",
+              canRunParallel: false,
+            },
+          ],
+          edges: [],
+        },
+        {
+          maxSubagentFanout: 8,
+          maxSubagentDepth: 4,
+          workspaceRoot,
+        },
+      );
+
+      expect(diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            category: "validation",
+            code: "planner_workspace_ecosystem_mismatch",
+            details: expect.objectContaining({
+              actualEcosystem: "cmake",
+              mismatchedSteps:
+                "phase1_setup:subagent_task:declared=node:scoped=cmake",
+            }),
+          }),
+        ]),
+      );
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("allows generic runtime-repaired writer steps for a CMake workspace", () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "planner-cmake-"));
+    try {
+      writeFileSync(
+        join(workspaceRoot, "CMakeLists.txt"),
+        "cmake_minimum_required(VERSION 3.20)\nproject(agenc_shell C)\n",
+      );
+      const diagnostics = validatePlannerGraph(
+        {
+          reason: "implement_from_artifact_repair",
+          requiresSynthesis: false,
+          confidence: 0.81,
+          steps: [
+            {
+              name: "read_plan",
+              stepType: "deterministic_tool",
+              dependsOn: [],
+              tool: "system.readFile",
+              args: {
+                path: `${workspaceRoot}/PLAN.md`,
+              },
+            },
+            {
+              name: "implement_owner",
+              stepType: "subagent_task",
+              dependsOn: ["read_plan"],
+              objective:
+                "Execute this implementation request inside the workspace: Can you go through @PLAN.md and implement every phase sequentially in full and make sure they are fully passing.",
+              inputContract:
+                "Use the planning artifact plus the current workspace to perform the requested implementation end to end. Do not stop at analysis only.",
+              acceptanceCriteria: [
+                "Workspace files are updated to satisfy the requested implementation phases.",
+                "Grounded verification runs before completion, and passing or failing commands are reported concretely.",
+              ],
+              requiredToolCapabilities: [
+                "system.readFile",
+                "system.writeFile",
+                "system.bash",
+              ],
+              contextRequirements: ["read_plan"],
+              maxBudgetHint: "30m",
+              canRunParallel: false,
+              executionContext: {
+                version: "v1",
+                workspaceRoot,
+                allowedReadRoots: [workspaceRoot],
+                allowedWriteRoots: [workspaceRoot],
+                allowedTools: ["system.readFile", "system.writeFile", "system.bash"],
+                requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+                targetArtifacts: [workspaceRoot],
+                effectClass: "filesystem_write",
+                verificationMode: "mutation_required",
+                stepKind: "delegated_write",
+                role: "writer",
+                artifactRelations: [
+                  {
+                    relationType: "read_dependency",
+                    artifactPath: `${workspaceRoot}/PLAN.md`,
+                  },
+                  {
+                    relationType: "write_owner",
+                    artifactPath: workspaceRoot,
+                  },
+                ],
+              },
+            },
+          ],
+          edges: [{ from: "read_plan", to: "implement_owner" }],
+        },
+        {
+          maxSubagentFanout: 8,
+          maxSubagentDepth: 4,
+          workspaceRoot,
+        },
+      );
+
+      expect(
+        diagnostics.some(
+          (diagnostic) =>
+            diagnostic.code === "planner_workspace_ecosystem_mismatch",
+        ),
+      ).toBe(false);
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("does not treat generic node runner examples as node ownership inside a CMake-scoped step", () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "planner-cmake-"));
+    try {
+      writeFileSync(
+        join(workspaceRoot, "CMakeLists.txt"),
+        "cmake_minimum_required(VERSION 3.20)\nproject(agenc_shell C)\n",
+      );
+      const diagnostics = validatePlannerGraph(
+        {
+          reason: "implementation_with_verification",
+          requiresSynthesis: false,
+          confidence: 0.81,
+          steps: [
+            {
+              name: "implement_phase_1",
+              stepType: "subagent_task",
+              dependsOn: [],
+              objective:
+                "Implement Phase 1 from PLAN.md using only filesystem write tools. Create all specified files and directories exactly as described. Do not install, build, or test yet - only scaffold files.",
+              inputContract: "PLAN.md content with Phase 1 details",
+              acceptanceCriteria: [
+                "All Phase 1 files created in targetArtifacts with correct structure",
+                "No package.json changes or installs performed",
+                "Files match Phase 1 spec from PLAN.md",
+              ],
+              requiredToolCapabilities: [
+                "system.writeFile",
+                "system.readFile",
+                "system.listDir",
+              ],
+              contextRequirements: ["repo_context"],
+              maxBudgetHint: "5m",
+              canRunParallel: false,
+              executionContext: {
+                version: "v1",
+                workspaceRoot,
+                allowedReadRoots: [workspaceRoot],
+                allowedWriteRoots: [workspaceRoot],
+                requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+                targetArtifacts: [join(workspaceRoot, "src")],
+                effectClass: "filesystem_scaffold",
+                verificationMode: "mutation_required",
+                stepKind: "delegated_scaffold",
+                role: "writer",
+                artifactRelations: [
+                  {
+                    relationType: "read_dependency",
+                    artifactPath: `${workspaceRoot}/PLAN.md`,
+                  },
+                  {
+                    relationType: "write_owner",
+                    artifactPath: join(workspaceRoot, "src"),
+                  },
+                ],
+              },
+            },
+            {
+              name: "test_phase_1",
+              stepType: "subagent_task",
+              dependsOn: ["implement_phase_1"],
+              objective:
+                "Run all Phase 1 tests and verify 100% pass before completing.",
+              inputContract: "Phase 1 scaffolded files + PLAN.md test specs",
+              acceptanceCriteria: [
+                "All Phase 1 tests pass (vitest run, jest --runInBand, etc.)",
+                "No test failures or errors reported",
+                "Build succeeds if Phase 1 includes build step",
+              ],
+              requiredToolCapabilities: [
+                "system.bash",
+                "system.readFile",
+                "system.listDir",
+              ],
+              contextRequirements: ["repo_context", "implement_phase_1"],
+              maxBudgetHint: "10m",
+              canRunParallel: false,
+              executionContext: {
+                version: "v1",
+                workspaceRoot,
+                allowedReadRoots: [workspaceRoot],
+                allowedWriteRoots: [workspaceRoot],
+                requiredSourceArtifacts: [
+                  `${workspaceRoot}/PLAN.md`,
+                  join(workspaceRoot, "src"),
+                ],
+                targetArtifacts: [workspaceRoot],
+                effectClass: "shell",
+                verificationMode: "deterministic_followup",
+                stepKind: "delegated_validation",
+                role: "validator",
+                artifactRelations: [
+                  {
+                    relationType: "verification_subject",
+                    artifactPath: join(workspaceRoot, "src"),
+                  },
+                  {
+                    relationType: "read_dependency",
+                    artifactPath: `${workspaceRoot}/PLAN.md`,
+                  },
+                ],
+              },
+            },
+          ],
+          edges: [{ from: "implement_phase_1", to: "test_phase_1" }],
+        },
+        {
+          maxSubagentFanout: 8,
+          maxSubagentDepth: 4,
+          workspaceRoot,
+        },
+      );
+
+      expect(
+        diagnostics.some(
+          (diagnostic) =>
+            diagnostic.code === "planner_workspace_ecosystem_mismatch",
+        ),
+      ).toBe(false);
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed on malformed subagent acceptance criteria instead of throwing", () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "planner-cmake-"));
+    try {
+      writeFileSync(
+        join(workspaceRoot, "CMakeLists.txt"),
+        "cmake_minimum_required(VERSION 3.20)\nproject(agenc_shell C)\n",
+      );
+      const diagnostics = validatePlannerGraph(
+        {
+          reason: "malformed_contract",
+          requiresSynthesis: false,
+          confidence: 0.7,
+          steps: [
+            {
+              name: "implement_owner",
+              stepType: "subagent_task",
+              dependsOn: [],
+              objective: "Implement the requested shell features in the workspace.",
+              inputContract: "Use PLAN.md and the workspace as the source of truth.",
+              acceptanceCriteria:
+                "Workspace files are updated and verified." as unknown as readonly string[],
+              requiredToolCapabilities: [
+                "system.readFile",
+                "system.writeFile",
+                "system.bash",
+              ],
+              contextRequirements: ["read_plan"],
+              maxBudgetHint: "30m",
+              canRunParallel: false,
+              executionContext: {
+                version: "v1",
+                workspaceRoot,
+                allowedReadRoots: [workspaceRoot],
+                allowedWriteRoots: [workspaceRoot],
+                targetArtifacts: [workspaceRoot],
+                effectClass: "filesystem_write",
+                verificationMode: "mutation_required",
+                stepKind: "delegated_write",
+                role: "writer",
+                artifactRelations: [
+                  {
+                    relationType: "write_owner",
+                    artifactPath: workspaceRoot,
+                  },
+                ],
+              },
+            } as never,
+          ],
+          edges: [],
+        },
+        {
+          maxSubagentFanout: 8,
+          maxSubagentDepth: 4,
+          workspaceRoot,
+        },
+      );
+
+      expect(diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "planner_subagent_step_malformed_contract",
+            details: expect.objectContaining({
+              stepName: "implement_owner",
+              malformedFields: expect.stringContaining("acceptanceCriteria"),
+            }),
+          }),
+        ]),
+      );
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("allows node-scoped steps inside a mixed CMake and Node workspace", () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "planner-polyglot-"));
+    try {
+      writeFileSync(
+        join(workspaceRoot, "CMakeLists.txt"),
+        "cmake_minimum_required(VERSION 3.20)\nproject(polyglot C)\n",
+      );
+      mkdirSync(join(workspaceRoot, "frontend"), { recursive: true });
+      writeFileSync(
+        join(workspaceRoot, "frontend", "package.json"),
+        '{"name":"frontend","private":true}\n',
+      );
+      const frontendRoot = join(workspaceRoot, "frontend");
+      const diagnostics = validatePlannerGraph(
+        {
+          reason: "polyglot_workspace",
+          requiresSynthesis: false,
+          confidence: 0.83,
+          steps: [
+            {
+              name: "scaffold_frontend",
+              stepType: "subagent_task",
+              dependsOn: [],
+              objective:
+                "Create package.json scripts and TypeScript frontend scaffolding under frontend/.",
+              inputContract:
+                "Implement the frontend package using package.json, tsconfig.json, and npm scripts.",
+              acceptanceCriteria: [
+                "frontend/package.json defines scripts and dependencies.",
+                "frontend/tsconfig.json is present and references the package-local source tree.",
+              ],
+              requiredToolCapabilities: ["system.writeFile", "system.bash"],
+              contextRequirements: ["repo_context"],
+              maxBudgetHint: "10m",
+              canRunParallel: false,
+              executionContext: {
+                version: "v1",
+                workspaceRoot: frontendRoot,
+                allowedReadRoots: [frontendRoot],
+                allowedWriteRoots: [frontendRoot],
+                allowedTools: ["system.readFile", "system.writeFile", "system.bash"],
+                targetArtifacts: [frontendRoot],
+                effectClass: "filesystem_scaffold",
+                verificationMode: "mutation_required",
+                stepKind: "delegated_scaffold",
+                role: "writer",
+                artifactRelations: [
+                  {
+                    relationType: "write_owner",
+                    artifactPath: frontendRoot,
+                  },
+                ],
+              },
+            },
+          ],
+          edges: [],
+        },
+        {
+          maxSubagentFanout: 8,
+          maxSubagentDepth: 4,
+          workspaceRoot,
+        },
+      );
+
+      expect(
+        diagnostics.some(
+          (diagnostic) =>
+            diagnostic.code === "planner_workspace_ecosystem_mismatch",
+        ),
+      ).toBe(false);
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
   });
 
   it("allows scaffold_environment plans that inventory package metadata and build/test scripts before install", () => {

--- a/runtime/src/llm/chat-executor-planner.ts
+++ b/runtime/src/llm/chat-executor-planner.ts
@@ -4,6 +4,14 @@
  * @module
  */
 
+import { existsSync } from "node:fs";
+import {
+  basename as pathBasename,
+  dirname as pathDirname,
+  join as joinPath,
+  resolve as resolvePath,
+} from "node:path";
+
 import type {
   LLMMessage,
   LLMStructuredOutputRequest,
@@ -495,13 +503,21 @@ const EXECUTION_SCOPE_BOUNDARY_CUE_RE =
 const EXPLANATION_ONLY_REQUEST_RE =
   /\b(?:explain|describe|outline|summarize|brainstorm|compare|review|analy(?:s|z)e|what would|how would|plan(?:\s+out)?|walk me through)\b/i;
 const NODE_PACKAGE_TOOLING_RE =
-  /\b(?:node(?:\.js)?|npm|npx|package\.json|package-lock\.json|pnpm|pnpm-workspace\.yaml|yarn|bun|workspaces?|typescript|tsconfig(?:\.[a-z]+)?\.json|tsx|vitest|commander)\b/i;
+  /\b(?:node(?:\.js)?|npm|npx|package\.json|package-lock\.json|pnpm|pnpm-workspace\.yaml|yarn|bun|typescript|tsconfig(?:\.[a-z]+)?\.json|tsx|vitest|commander|(?:npm|pnpm|yarn|bun)\s+workspaces?)\b/i;
+const NODE_DECLARED_ECOSYSTEM_STRONG_RE =
+  /\b(?:npm|npx|package\.json|package-lock\.json|pnpm|pnpm-workspace\.yaml|yarn|bun|tsconfig(?:\.[a-z]+)?\.json|node_modules|vite\.config(?:\.[a-z]+)?|vitest\.config(?:\.[a-z]+)?|(?:npm|pnpm|yarn|bun)\s+workspaces?)\b/i;
+const NODE_DECLARED_ECOSYSTEM_COMMAND_RE = /\b(?:npm|npx|pnpm|yarn|bun)\b/i;
 const NODE_PACKAGE_MANIFEST_PATH_RE =
   /(?:^|\/)(?:package\.json|package-lock\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|yarn\.lock|bun\.lockb|tsconfig(?:\.[a-z]+)?\.json)$/i;
 const NODE_LOCAL_DEPENDENCY_SPEC_RE =
   /\b(?:file:\.\.\/|workspace:\*|local deps?|local dependency references?)\b/i;
 const NODE_MANIFEST_OR_CONFIG_RE =
-  /\b(?:package\.json|package-lock\.json|pnpm-workspace\.yaml|pnpm-lock\.yaml|yarn\.lock|bun\.lockb|tsconfig(?:\.[a-z]+)?\.json|vite\.config(?:\.[a-z]+)?|vitest\.config(?:\.[a-z]+)?|workspaces?|dependencies|devdependencies|scripts?|bin)\b/i;
+  /\b(?:package\.json|package-lock\.json|pnpm-workspace\.yaml|pnpm-lock\.yaml|yarn\.lock|bun\.lockb|tsconfig(?:\.[a-z]+)?\.json|vite\.config(?:\.[a-z]+)?|vitest\.config(?:\.[a-z]+)?|(?:npm|pnpm|yarn|bun)\s+workspaces?|package\s+scripts?|dependencies|devdependencies|bin)\b/i;
+const NATIVE_TOOLING_RE =
+  /\b(?:cmake|ctest|ninja|gcc|g\+\+|clang|clang\+\+|make|valgrind|gprof|perf|meson)\b/i;
+const NATIVE_MANIFEST_PATH_RE =
+  /(?:^|\/)(?:CMakeLists\.txt|Makefile|meson\.build|build\.ninja|compile_commands\.json)$/i;
+const NATIVE_SOURCE_PATH_RE = /(?:^|\/)[^/]+\.(?:c|cc|cpp|cxx|h|hpp)$/i;
 const NODE_INSTALL_SENSITIVE_VERIFICATION_ACTION_RE =
   /\b(?:verify|verified|validat(?:e|ed|ion)|confirm|confirmed|ensure|ensures|ensured|check|checks|checked|run|runs|running|execute|executes|executed|prove|proves|proven)\b/i;
 const NODE_INSTALL_SENSITIVE_VERIFICATION_TARGET_RE =
@@ -510,11 +526,20 @@ const NODE_INSTALL_SENSITIVE_VERIFICATION_PHRASE_RE =
   /\b(?:tests?\s+(?:pass|passing|passed|run|runs|running|succeed|succeeds|succeeded)|coverage(?:\s+(?:reported|generated|collected|runs?|ran))?|builds?\s+(?:cleanly|correctly|successfully|without errors?|ok)|compiles?\s+(?:cleanly|correctly|successfully|without errors?)|typechecks?\s+(?:cleanly|correctly|successfully|without errors?)|lints?\s+(?:cleanly|correctly|successfully|without errors?)|installs?\s+(?:cleanly|correctly|successfully|without errors?)|npm\s+(?:test|run\s+build|run\s+typecheck|run\s+lint)\s+(?:passes?|succeeds?|runs?)|pnpm\s+(?:test|build|typecheck|lint)\s+(?:passes?|succeeds?|runs?)|yarn\s+(?:test|build|typecheck|lint)\s+(?:passes?|succeeds?|runs?)|bun\s+(?:test|run(?:\s+(?:build|typecheck|lint))?)\s+(?:passes?|succeeds?|runs?)|vite\s+build\s+(?:passes?|succeeds?|runs?)|tsc\s+(?:passes?|succeeds?|runs?))\b/i;
 const NEGATED_NODE_VERIFICATION_RE =
   /\b(?:no|without|avoid(?:ing)?|skip|exclude(?:d|ing)?|do\s+not|don't)\s+(?:any\s+)?(?:install(?:ation|ing)?|run(?:ning)?|runtime\s+testing|tests?|testing|build(?:s|ing)?|compile(?:s|d|ing)?|typecheck(?:s|ed|ing)?|lint(?:s|ed|ing)?)(?:\s*(?:\/|or|and)\s*(?:install(?:ation|ing)?|run(?:ning)?|tests?|testing|build(?:s|ing)?|compile(?:s|d|ing)?|typecheck(?:s|ed|ing)?|lint(?:s|ed|ing)?))*\b/gi;
+const NEGATED_NODE_ARTIFACT_RE =
+  /\b(?:no|without|avoid(?:ing)?|skip|exclude(?:d|ing)?|do\s+not|don't)\s+(?:any\s+)?(?:package\.json|package-lock\.json|pnpm-workspace\.yaml|pnpm-lock\.yaml|yarn\.lock|bun\.lockb|tsconfig(?:\.[a-z]+)?\.json|vite\.config(?:\.[a-z]+)?|vitest\.config(?:\.[a-z]+)?|npm|npx|pnpm|yarn|bun)(?:\s+changes?)?\b/gi;
 const NODE_PACKAGE_MANAGER_COMMANDS = new Set(["npm", "pnpm", "yarn", "bun"]);
 const NODE_INSTALL_ACTIONS = new Set(["install", "ci", "add"]);
 
 function stripNegatedNodeVerificationLanguage(value: string): string {
   return value.replace(NEGATED_NODE_VERIFICATION_RE, " ");
+}
+
+function stripNegatedNodeEcosystemLanguage(value: string): string {
+  return stripNegatedNodeVerificationLanguage(value).replace(
+    NEGATED_NODE_ARTIFACT_RE,
+    " ",
+  );
 }
 
 function isDialogueOnlyExactResponseTurn(messageText: string): boolean {
@@ -642,6 +667,8 @@ export function buildPlannerMessages(
     artifactIntent === "grounded_plan_generation";
   const workspaceGroundedArtifactUpdate =
     plannerRequestNeedsWorkspaceGroundedArtifactUpdate(messageText);
+  const sameTargetImplementFromArtifactHistoryBlockedRe =
+    /\b(?:validation_error|workflow state:\s*(?:blocked|partial)|inline legacy fallback is disabled|planner emitted a structured plan that failed local validation|implementation-class completion requires workflow-owned verification closure|do not present the work as complete)\b/i;
   const currentArtifactTargets = extractPlannerArtifactTargets(messageText);
   const hostToolingHint = buildPlannerHostToolingHint(
     messageText,
@@ -680,6 +707,20 @@ export function buildPlannerMessages(
         )
       ) {
         suppressImmediateAssistantReply = entry.role === "user";
+        return false;
+      }
+      if (
+        sameArtifactTarget &&
+        entryIntent === "implement_from_artifact"
+      ) {
+        suppressImmediateAssistantReply = entry.role === "user";
+        return false;
+      }
+      if (
+        sameArtifactTarget &&
+        entry.role === "assistant" &&
+        sameTargetImplementFromArtifactHistoryBlockedRe.test(raw)
+      ) {
         return false;
       }
       suppressImmediateAssistantReply = false;
@@ -778,7 +819,8 @@ export function buildPlannerMessages(
         "- Each subagent_task must stay narrowly scoped to one phase of work. Do not combine research, setup, implementation, and validation into one delegated step.\n" +
         "- Prefer multiple smaller subagent_task steps with explicit dependencies over one large delegated objective.\n" +
         (
-          runtimeConstraints
+          runtimeConstraints &&
+          hasRuntimeLimit(runtimeConstraints.maxSubagentFanout)
             ? `- Keep automatic delegated fanout bounded: do not rely on more than ${runtimeConstraints.maxSubagentFanout} concurrently runnable subagent_task steps at once unless the user explicitly required a higher child-agent count. When a higher count is user-mandated, serialize or batch the child steps with dependencies or \`can_run_parallel: false\` so the runtime can stay within its concurrency cap.\n`
             : ""
         ) +
@@ -911,7 +953,9 @@ export function buildPlannerMessages(
       content:
         "The named planning artifact is the source specification for implementation work, not the primary artifact to rewrite. " +
         "Plan code changes, build/test verification, and bounded delegated implementation around the source spec. " +
-        "Do not collapse the task into editing the planning artifact unless the user explicitly asks to update that artifact.",
+        "Do not collapse the task into editing the planning artifact unless the user explicitly asks to update that artifact. " +
+        "A plan that only reads the plan artifact, lists files, or produces read-only analysis is invalid for this request class. " +
+        "Emit at least one concrete mutable implementation step, or a deterministic build/test-backed mutation path that changes owned source artifacts.",
     });
   }
 
@@ -2680,19 +2724,61 @@ export function validateSalvagedPlannerToolPlan(input: {
 function collectPlannerSubagentStepText(
   step: PlannerSubAgentTaskStepIntent,
 ): string {
+  const acceptanceCriteria = Array.isArray(step.acceptanceCriteria)
+    ? step.acceptanceCriteria.filter(
+      (value): value is string =>
+        typeof value === "string" && value.trim().length > 0,
+    )
+    : [];
   return [
     step.objective,
     step.inputContract,
-    ...step.acceptanceCriteria,
+    ...acceptanceCriteria,
   ]
-    .filter((value) => value.trim().length > 0)
+    .filter((value): value is string =>
+      typeof value === "string" && value.trim().length > 0
+    )
     .join(" ");
+}
+
+function collectMalformedPlannerSubagentContractFields(
+  step: PlannerSubAgentTaskStepIntent,
+): readonly string[] {
+  const malformedFields: string[] = [];
+  const hasValidStringArray = (value: unknown): boolean =>
+    Array.isArray(value) &&
+    value.every((entry) =>
+      typeof entry === "string" && entry.trim().length > 0
+    );
+
+  if (typeof step.objective !== "string" || step.objective.trim().length === 0) {
+    malformedFields.push("objective");
+  }
+  if (
+    typeof step.inputContract !== "string" ||
+    step.inputContract.trim().length === 0
+  ) {
+    malformedFields.push("inputContract");
+  }
+  if (!hasValidStringArray(step.acceptanceCriteria)) {
+    malformedFields.push("acceptanceCriteria");
+  }
+  if (!hasValidStringArray(step.requiredToolCapabilities)) {
+    malformedFields.push("requiredToolCapabilities");
+  }
+  if (!hasValidStringArray(step.contextRequirements)) {
+    malformedFields.push("contextRequirements");
+  }
+
+  return malformedFields;
 }
 
 function isNodeWorkspaceSubagentStep(
   step: PlannerSubAgentTaskStepIntent,
 ): boolean {
-  const combined = collectPlannerSubagentStepText(step);
+  const combined = stripNegatedNodeEcosystemLanguage(
+    collectPlannerSubagentStepText(step),
+  );
   return NODE_PACKAGE_TOOLING_RE.test(combined) ||
     NODE_PACKAGE_MANIFEST_PATH_RE.test(combined) ||
     NODE_LOCAL_DEPENDENCY_SPEC_RE.test(combined);
@@ -2702,7 +2788,7 @@ function stepAuthorsNodeManifestOrConfig(
   step: PlannerSubAgentTaskStepIntent,
 ): boolean {
   return NODE_MANIFEST_OR_CONFIG_RE.test(
-    [step.objective, step.inputContract, ...step.acceptanceCriteria].join(" "),
+    collectPlannerSubagentStepText(step),
   );
 }
 
@@ -2731,7 +2817,7 @@ function stepRequiresInstallSensitiveNodeVerification(
 } {
   const categories = [
     ...new Set(
-      step.acceptanceCriteria.flatMap((criterion) =>
+      (Array.isArray(step.acceptanceCriteria) ? step.acceptanceCriteria : []).flatMap((criterion) =>
         getAcceptanceVerificationCategories(criterion)
       ).filter((category) => category === "build" || category === "test"),
     ),
@@ -2767,6 +2853,217 @@ function isNodeInstallPlannerStep(
   return parsedArgs.some((entry, index) =>
     index === 0 && NODE_INSTALL_ACTIONS.has(entry.trim().toLowerCase())
   );
+}
+
+type WorkspacePlanEcosystem = "node" | "cmake" | "mixed" | "unknown";
+
+function mergeWorkspacePlanEcosystems(
+  current: WorkspacePlanEcosystem,
+  next: WorkspacePlanEcosystem,
+): WorkspacePlanEcosystem {
+  if (next === "unknown") return current;
+  if (current === "unknown") return next;
+  if (current === next) return current;
+  return "mixed";
+}
+
+function detectDeclaredArtifactEcosystem(path: string): WorkspacePlanEcosystem {
+  const trimmedPath = path.trim();
+  if (trimmedPath.length === 0) return "unknown";
+  const basename = pathBasename(trimmedPath);
+  if (
+    NODE_PACKAGE_MANIFEST_PATH_RE.test(basename) ||
+    NODE_MANIFEST_OR_CONFIG_RE.test(basename)
+  ) {
+    return "node";
+  }
+  if (
+    NATIVE_MANIFEST_PATH_RE.test(basename) ||
+    NATIVE_SOURCE_PATH_RE.test(basename)
+  ) {
+    return "cmake";
+  }
+  return "unknown";
+}
+
+function isSamePathOrDescendant(path: string, root: string): boolean {
+  return path === root || path.startsWith(`${root}/`);
+}
+
+function detectWorkspacePlanEcosystem(
+  workspaceRoot?: string,
+  boundaryRoot?: string,
+): WorkspacePlanEcosystem {
+  if (typeof workspaceRoot !== "string" || workspaceRoot.trim().length === 0) {
+    return "unknown";
+  }
+  try {
+    const declaredEcosystem = detectDeclaredArtifactEcosystem(workspaceRoot);
+    if (declaredEcosystem !== "unknown") {
+      return declaredEcosystem;
+    }
+    const resolvedBoundary =
+      typeof boundaryRoot === "string" && boundaryRoot.trim().length > 0
+        ? resolvePath(boundaryRoot)
+        : undefined;
+    let current =
+      /\.[^/]+$/.test(pathBasename(workspaceRoot))
+        ? pathDirname(resolvePath(workspaceRoot))
+        : resolvePath(workspaceRoot);
+    let detected: WorkspacePlanEcosystem = "unknown";
+    while (true) {
+      const hasNodeManifest =
+        existsSync(joinPath(current, "package.json")) ||
+        existsSync(joinPath(current, "pnpm-workspace.yaml")) ||
+        existsSync(joinPath(current, "package-lock.json")) ||
+        existsSync(joinPath(current, "yarn.lock")) ||
+        existsSync(joinPath(current, "bun.lockb"));
+      const hasCmakeManifest =
+        existsSync(joinPath(current, "CMakeLists.txt")) ||
+        existsSync(joinPath(current, "Makefile")) ||
+        existsSync(joinPath(current, "meson.build")) ||
+        existsSync(joinPath(current, "build.ninja"));
+      detected = mergeWorkspacePlanEcosystems(
+        detected,
+        hasNodeManifest && hasCmakeManifest
+          ? "mixed"
+          : hasNodeManifest
+            ? "node"
+            : hasCmakeManifest
+              ? "cmake"
+              : "unknown",
+      );
+      if (detected === "mixed") return detected;
+      const parent = pathDirname(current);
+      if (parent === current) break;
+      if (!resolvedBoundary) break;
+      if (current === resolvedBoundary) break;
+      if (!isSamePathOrDescendant(parent, resolvedBoundary)) break;
+      current = parent;
+    }
+    return detected;
+  } catch {
+    return "unknown";
+  }
+}
+
+function collectPlannerStepScopedPaths(
+  step: PlannerStepIntent,
+  workspaceRoot?: string,
+): readonly string[] {
+  const paths = new Set<string>();
+  if (typeof workspaceRoot === "string" && workspaceRoot.trim().length > 0) {
+    paths.add(resolvePath(workspaceRoot));
+  }
+
+  if (step.stepType === "deterministic_tool") {
+    const candidateValues = [
+      step.args.path,
+      step.args.sourcePath,
+      step.args.destinationPath,
+      step.args.cwd,
+    ];
+    for (const value of candidateValues) {
+      if (typeof value !== "string" || value.trim().length === 0) continue;
+      paths.add(resolvePath(value.trim()));
+    }
+    return [...paths];
+  }
+
+  const executionContext = step.executionContext;
+  const candidatePaths = [
+    executionContext?.workspaceRoot,
+    ...(executionContext?.allowedReadRoots ?? []),
+    ...(executionContext?.allowedWriteRoots ?? []),
+    ...(executionContext?.requiredSourceArtifacts ?? []),
+    ...(executionContext?.targetArtifacts ?? []),
+    ...(executionContext?.inputArtifacts ?? []),
+    ...(executionContext?.artifactRelations ?? []).map(
+      (relation) => relation.artifactPath,
+    ),
+  ];
+  for (const value of candidatePaths) {
+    if (typeof value !== "string" || value.trim().length === 0) continue;
+    paths.add(resolvePath(value.trim()));
+  }
+  return [...paths];
+}
+
+function collectPlannerStepDeclaredEcosystems(
+  step: PlannerStepIntent,
+): ReadonlySet<WorkspacePlanEcosystem> {
+  const declared = new Set<WorkspacePlanEcosystem>();
+  const pushIfKnown = (ecosystem: WorkspacePlanEcosystem): void => {
+    if (ecosystem !== "unknown") {
+      declared.add(ecosystem);
+    }
+  };
+
+  if (step.stepType === "deterministic_tool") {
+    const pathValues = [
+      step.args.path,
+      step.args.sourcePath,
+      step.args.destinationPath,
+      step.args.cwd,
+    ];
+    for (const value of pathValues) {
+      if (typeof value !== "string") continue;
+      pushIfKnown(detectDeclaredArtifactEcosystem(value));
+    }
+    if (isNodeInstallPlannerStep(step)) {
+      declared.add("node");
+    }
+    if (PLANNER_BASH_TOOL_NAMES.has(step.tool)) {
+      const command =
+        typeof step.args.command === "string" ? step.args.command : "";
+      const parsedArgs = parsePlannerStringArgs(step.args.args) ?? [];
+      const combined = [command, ...parsedArgs].join(" ").trim();
+      if (NODE_PACKAGE_TOOLING_RE.test(combined)) {
+        declared.add("node");
+      }
+      if (NATIVE_TOOLING_RE.test(combined)) {
+        declared.add("cmake");
+      }
+    }
+    return declared;
+  }
+
+  const scopedPathEcosystems = new Set<WorkspacePlanEcosystem>();
+  for (const path of collectPlannerStepScopedPaths(step)) {
+    pushIfKnown(detectDeclaredArtifactEcosystem(path));
+    const detected = detectWorkspacePlanEcosystem(path);
+    if (detected !== "unknown") {
+      scopedPathEcosystems.add(detected);
+    }
+  }
+
+  const combined = stripNegatedNodeEcosystemLanguage(
+    collectPlannerSubagentStepText(step),
+  );
+  const hasStrongNodeText = NODE_DECLARED_ECOSYSTEM_STRONG_RE.test(combined);
+  const hasNodeCommandIntent = NODE_DECLARED_ECOSYSTEM_COMMAND_RE.test(combined);
+  const hasNativeText = NATIVE_TOOLING_RE.test(combined);
+  if (
+    !(
+      scopedPathEcosystems.size === 1 &&
+      scopedPathEcosystems.has("cmake") &&
+      !hasNodeCommandIntent
+    ) &&
+    NODE_PACKAGE_TOOLING_RE.test(combined)
+  ) {
+    declared.add("node");
+  }
+  if (
+    !(
+      scopedPathEcosystems.size === 1 &&
+      scopedPathEcosystems.has("node") &&
+      !hasNativeText
+    ) &&
+    hasNativeText
+  ) {
+    declared.add("cmake");
+  }
+  return declared;
 }
 
 function collectPlannerStepVerificationCategories(
@@ -2811,7 +3108,7 @@ function collectPlannerStepVerificationCategories(
   }
 
   const combined = stripNegatedNodeVerificationLanguage(
-    [step.objective, step.inputContract, ...step.acceptanceCriteria].join(" "),
+    collectPlannerSubagentStepText(step),
   );
   if (REQUEST_INSTALL_VERIFICATION_RE.test(combined)) {
     categories.add("install");
@@ -3035,6 +3332,55 @@ function validateNodeWorkspacePlannerStages(
   return diagnostics;
 }
 
+function validateWorkspaceEcosystemConsistency(
+  plannerPlan: PlannerPlan,
+  workspaceRoot?: string,
+): readonly PlannerDiagnostic[] {
+  const workspaceEcosystem = detectWorkspacePlanEcosystem(workspaceRoot);
+  const mismatchedSteps = plannerPlan.steps.flatMap((step) => {
+    const declaredEcosystems = collectPlannerStepDeclaredEcosystems(step);
+    if (declaredEcosystems.size === 0) {
+      return [];
+    }
+    const scopedPaths = collectPlannerStepScopedPaths(step, workspaceRoot);
+    const scopedEcosystem = scopedPaths.reduce<WorkspacePlanEcosystem>(
+      (current, path) =>
+        mergeWorkspacePlanEcosystems(
+          current,
+          detectWorkspacePlanEcosystem(path, workspaceRoot),
+        ),
+      workspaceEcosystem,
+    );
+    const mismatchedNode =
+      declaredEcosystems.has("node") && scopedEcosystem === "cmake";
+    const mismatchedNative =
+      declaredEcosystems.has("cmake") && scopedEcosystem === "node";
+    if (!mismatchedNode && !mismatchedNative) {
+      return [];
+    }
+    return [
+      `${step.name}:${step.stepType}:declared=${[...declaredEcosystems].join("+")}:scoped=${scopedEcosystem}`,
+    ];
+  });
+
+  if (mismatchedSteps.length === 0) {
+    return [];
+  }
+
+  return [
+    createPlannerDiagnostic(
+      "validation",
+      "planner_workspace_ecosystem_mismatch",
+      "Planner emitted step contracts whose declared toolchain does not match the scoped workspace slice they own",
+      {
+        workspaceRoot: workspaceRoot ?? "",
+        actualEcosystem: workspaceEcosystem,
+        mismatchedSteps: mismatchedSteps.join(","),
+      },
+    ),
+  ];
+}
+
 export function validatePlannerGraph(
   plannerPlan: PlannerPlan,
   config: PlannerGraphValidationConfig,
@@ -3048,6 +3394,7 @@ export function validatePlannerGraph(
   if (subagentSteps.length === 0) return diagnostics;
 
   if (
+    hasRuntimeLimit(config.maxSubagentFanout) &&
     subagentSteps.length > config.maxSubagentFanout &&
     !allowsUserMandatedSubagentCardinalityOverride(requiredOrchestration)
   ) {
@@ -3084,6 +3431,21 @@ export function validatePlannerGraph(
   }
 
   for (const step of subagentSteps) {
+    const malformedFields = collectMalformedPlannerSubagentContractFields(step);
+    if (malformedFields.length > 0) {
+      diagnostics.push(
+        createPlannerDiagnostic(
+          "validation",
+          "planner_subagent_step_malformed_contract",
+          `Planner subagent step "${step.name}" has malformed contract fields and cannot be admitted`,
+          {
+            stepName: step.name,
+            malformedFields: malformedFields.join(","),
+          },
+        ),
+      );
+      continue;
+    }
     const scopeAssessment = assessDelegationScope({
       objective: step.objective,
       inputContract: step.inputContract,
@@ -3109,6 +3471,12 @@ export function validatePlannerGraph(
   }
 
   diagnostics.push(...validateNodeWorkspacePlannerStages(plannerPlan));
+  diagnostics.push(
+    ...validateWorkspaceEcosystemConsistency(
+      plannerPlan,
+      config.workspaceRoot,
+    ),
+  );
 
   return diagnostics;
 }
@@ -3460,6 +3828,15 @@ export function validatePlannerStepContracts(
     }
     if (artifactIntent === "implement_from_artifact") {
       diagnostics.push(...validatePlannerPlanArtifactExecutionOwnership(plannerPlan));
+      if (!plannerPlanHasMutableImplementationPath(plannerPlan)) {
+        diagnostics.push(
+          createPlannerDiagnostic(
+            "validation",
+            "planner_implementation_missing_mutation_path",
+            "Planner emitted an implementation-scoped plan without any mutable implementation step or verification-backed mutation path",
+          ),
+        );
+      }
     }
   }
 
@@ -3538,6 +3915,21 @@ export function validatePlannerStepContracts(
     }
 
     if (step.stepType !== "subagent_task") continue;
+    const malformedFields = collectMalformedPlannerSubagentContractFields(step);
+    if (malformedFields.length > 0) {
+      diagnostics.push(
+        createPlannerDiagnostic(
+          "validation",
+          "planner_subagent_step_malformed_contract",
+          `Planner subagent step "${step.name}" has malformed contract fields and cannot be admitted`,
+          {
+            stepName: step.name,
+            malformedFields: malformedFields.join(","),
+          },
+        ),
+      );
+      continue;
+    }
     const budgetHint = inspectDelegationBudgetHint(step.maxBudgetHint);
     if (budgetHint.kind === "ambiguous_numeric") {
       diagnostics.push(
@@ -3575,7 +3967,9 @@ export function validatePlannerStepContracts(
   return diagnostics;
 }
 
-function extractPlannerArtifactTargets(messageText: string): readonly string[] {
+export function extractPlannerArtifactTargets(
+  messageText: string,
+): readonly string[] {
   const sourceText = messageText.trim();
   if (sourceText.length === 0) {
     return [];
@@ -3830,6 +4224,29 @@ function plannerStepHasMutableImplementationAuthority(
   );
 }
 
+function plannerPlanHasMutableImplementationPath(
+  plannerPlan: PlannerPlan,
+): boolean {
+  return plannerPlan.steps.some((step) => {
+    if (isPlannerDeterministicFileWriteStep(step)) {
+      return true;
+    }
+    if (step.stepType === "subagent_task") {
+      return plannerStepHasMutableImplementationAuthority(step);
+    }
+    if (
+      step.stepType === "deterministic_tool" &&
+      PLANNER_BASH_TOOL_NAMES.has(step.tool)
+    ) {
+      const commandText = extractCommandText(step.args).trim();
+      return /\b(?:build|compile|typecheck|lint|test|install|implement|scaffold|write|edit|create|fix|refactor|migrate)\b/i.test(
+        commandText,
+      );
+    }
+    return false;
+  });
+}
+
 function isPlannerArtifactMaterializationStep(
   step: PlannerStepIntent,
   requestedArtifactTargets: readonly string[],
@@ -4082,6 +4499,15 @@ export function buildPlannerStepContractRefinementHint(
         diagnostic.code === "planner_subagent_budget_hint_too_small"
       ) {
         return `give subagent steps at least ${readDiagnosticDetail(diagnostic, "minimumSeconds") ?? "60"}s with an explicit unit`;
+      }
+      if (
+        diagnostic.code === "planner_implementation_missing_mutation_path"
+      ) {
+        return (
+          "for implement-from-plan requests, the executable plan must include at least one mutable implementation step or deterministic build/test-backed mutation path. " +
+          "Do not emit an analysis-only delegated research/review step, do not say \"do not implement code yet\" when the user asked for implementation, " +
+          "and do not return a plan whose only action is reading PLAN.md or listing the workspace"
+        );
       }
       if (
         diagnostic.code === "planner_plan_artifact_single_write_collapse" ||

--- a/runtime/src/llm/chat-executor-recovery.test.ts
+++ b/runtime/src/llm/chat-executor-recovery.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   buildWorkflowRecoveryStateLines,
   buildRecoveryHints,
   computeQualityProxy,
   inferRecoveryHint,
+  preflightStaleCopiedCmakeHarnessInvocation,
 } from "./chat-executor-recovery.js";
 
 describe("chat-executor-recovery", () => {
@@ -117,6 +121,526 @@ describe("chat-executor-recovery", () => {
     expect(hint?.key).toBe("system-bash-sandbox-handle");
     expect(hint?.message).toContain("system.sandboxStart");
     expect(hint?.message).toContain("system.sandboxJobStart");
+  });
+
+  it("injects a recovery hint for stale CMake cache path mismatches", () => {
+    const hint = inferRecoveryHint({
+      name: "system.bash",
+      args: {
+        command: "cd /tmp/agenc-shell/build && cmake .. && make",
+      },
+      result: JSON.stringify({
+        exitCode: 1,
+        stderr:
+          "CMake Error: The current CMakeCache.txt directory /tmp/agenc-shell/build/CMakeCache.txt is different than the directory /home/tetsuo/git/stream-test/agenc-shell/build where CMakeCache.txt was created.\n" +
+          'CMake Error: The source "/tmp/agenc-shell/CMakeLists.txt" does not match the source "/home/tetsuo/git/stream-test/agenc-shell/CMakeLists.txt" used to generate cache.\n' +
+          "Re-run cmake with a different source directory.\n",
+      }),
+      isError: true,
+      durationMs: 61,
+    });
+
+    expect(hint).toBeDefined();
+    expect(hint?.key).toBe("system-bash-cmake-cache-source-mismatch");
+    expect(hint?.message).toContain("stale CMake cache");
+    expect(hint?.message).toContain("Do not keep retrying");
+    expect(hint?.message).toContain("build-agenc-fresh");
+  });
+
+  it("rewrites a simple stale copied build harness to direct fresh-build commands before execution", () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-stale-cmake-"));
+    mkdirSync(join(workspaceRoot, "build"), { recursive: true });
+    mkdirSync(join(workspaceRoot, "tests"), { recursive: true });
+    writeFileSync(join(workspaceRoot, "CMakeLists.txt"), "cmake_minimum_required(VERSION 3.20)\nproject(test)\n");
+    writeFileSync(
+      join(workspaceRoot, "build", "CMakeCache.txt"),
+      "CMAKE_HOME_DIRECTORY:INTERNAL=/home/tetsuo/git/stream-test/agenc-shell\n",
+    );
+    writeFileSync(
+      join(workspaceRoot, "tests", "run_tests.sh"),
+      "#!/bin/bash\nset -e\ncd build\ncmake .. && make\n",
+    );
+
+    const result = preflightStaleCopiedCmakeHarnessInvocation(
+      "system.bash",
+      {
+        command: "bash",
+        args: ["tests/run_tests.sh"],
+        cwd: workspaceRoot,
+      },
+      workspaceRoot,
+      [],
+    );
+
+    expect(result.rejectionError).toBeUndefined();
+    expect(result.reasonKey).toBe("system-bash-cmake-stale-harness-rewritten");
+    expect(result.args).toEqual({
+      command:
+        "cmake -S . -B build-agenc-fresh && cmake --build build-agenc-fresh",
+      cwd: workspaceRoot,
+    });
+    expect(result.repairedFields).toEqual(["command", "args", "cwd"]);
+  });
+
+  it("rewrites direct configure commands that target the stale copied build directory", () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-stale-cmake-"));
+    mkdirSync(join(workspaceRoot, "build"), { recursive: true });
+    writeFileSync(join(workspaceRoot, "CMakeLists.txt"), "cmake_minimum_required(VERSION 3.20)\nproject(test)\n");
+    writeFileSync(
+      join(workspaceRoot, "build", "CMakeCache.txt"),
+      "CMAKE_HOME_DIRECTORY:INTERNAL=/home/tetsuo/git/stream-test/agenc-shell\n",
+    );
+
+    const result = preflightStaleCopiedCmakeHarnessInvocation(
+      "system.bash",
+      {
+        command: "cd",
+        args: [join(workspaceRoot, "build"), "&&", "cmake", ".."],
+        cwd: workspaceRoot,
+      },
+      workspaceRoot,
+      [],
+    );
+
+    expect(result.rejectionError).toBeUndefined();
+    expect(result.reasonKey).toBe("system-bash-cmake-stale-default-build-rewritten");
+    expect(result.args).toEqual({
+      command: "cmake",
+      args: ["-S", workspaceRoot, "-B", join(workspaceRoot, "build-agenc-fresh")],
+      cwd: workspaceRoot,
+    });
+    expect(result.repairedFields).toEqual(["command", "args", "cwd"]);
+  });
+
+  it("rewrites direct make calls from the stale copied build directory to the fresh build root", () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-stale-cmake-"));
+    mkdirSync(join(workspaceRoot, "build"), { recursive: true });
+    writeFileSync(join(workspaceRoot, "CMakeLists.txt"), "cmake_minimum_required(VERSION 3.20)\nproject(test)\n");
+    writeFileSync(
+      join(workspaceRoot, "build", "CMakeCache.txt"),
+      "CMAKE_HOME_DIRECTORY:INTERNAL=/home/tetsuo/git/stream-test/agenc-shell\n",
+    );
+
+    const result = preflightStaleCopiedCmakeHarnessInvocation(
+      "system.bash",
+      {
+        command: "make",
+        cwd: join(workspaceRoot, "build"),
+      },
+      workspaceRoot,
+      [],
+    );
+
+    expect(result.rejectionError).toBeUndefined();
+    expect(result.reasonKey).toBe("system-bash-cmake-stale-default-build-rewritten");
+    expect(result.args).toEqual({
+      command: "cmake",
+      args: ["--build", join(workspaceRoot, "build-agenc-fresh")],
+      cwd: workspaceRoot,
+    });
+    expect(result.repairedFields).toEqual(["command", "args", "cwd"]);
+  });
+
+  it("fails closed when a stale copied build harness hardcodes build/ but cannot be safely rewritten", () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-stale-cmake-"));
+    mkdirSync(join(workspaceRoot, "build"), { recursive: true });
+    mkdirSync(join(workspaceRoot, "tests"), { recursive: true });
+    writeFileSync(join(workspaceRoot, "CMakeLists.txt"), "cmake_minimum_required(VERSION 3.20)\nproject(test)\n");
+    writeFileSync(
+      join(workspaceRoot, "build", "CMakeCache.txt"),
+      "CMAKE_HOME_DIRECTORY:INTERNAL=/home/tetsuo/git/stream-test/agenc-shell\n",
+    );
+    writeFileSync(
+      join(workspaceRoot, "tests", "run_tests.sh"),
+      "#!/bin/bash\nset -e\ncd build\ncmake .. && make\n./integration_suite.sh\n",
+    );
+
+    const result = preflightStaleCopiedCmakeHarnessInvocation(
+      "system.bash",
+      {
+        command: "bash",
+        args: ["tests/run_tests.sh"],
+        cwd: workspaceRoot,
+      },
+      workspaceRoot,
+      [],
+    );
+
+    expect(result.repairedFields).toEqual([]);
+    expect(result.reasonKey).toBe("system-bash-cmake-stale-harness-rejected");
+    expect(result.rejectionError).toContain("Refusing to invoke");
+    expect(result.rejectionError).toContain("build-agenc-fresh");
+  });
+
+  it("injects a round-level recovery hint when stale CMake cleanup falls into denied rm", () => {
+    const hints = buildRecoveryHints(
+      [
+        {
+          name: "system.bash",
+          args: {
+            command: "bash tests/run_tests.sh",
+          },
+          result: JSON.stringify({
+            exitCode: 1,
+            stderr:
+              "CMake Error: The current CMakeCache.txt directory /tmp/agenc-shell/build/CMakeCache.txt is different than the directory /home/tetsuo/git/stream-test/agenc-shell/build where CMakeCache.txt was created.\n" +
+              'CMake Error: The source "/tmp/agenc-shell/CMakeLists.txt" does not match the source "/home/tetsuo/git/stream-test/agenc-shell/CMakeLists.txt" used to generate cache.\n' +
+              "Re-run cmake with a different source directory.\n",
+          }),
+          isError: true,
+          durationMs: 11,
+        },
+        {
+          name: "system.bash",
+          args: {
+            command: "rm /tmp/agenc-shell/build/CMakeCache.txt",
+          },
+          result: JSON.stringify({
+            error: 'Command "rm" is denied',
+          }),
+          isError: true,
+          durationMs: 1,
+        },
+      ],
+      new Set(),
+    );
+
+    const hint = hints.find(
+      (entry) => entry.key === "system-bash-cmake-cache-rebuild-in-fresh-dir",
+    );
+    expect(hint).toBeDefined();
+    expect(hint?.message).toContain("destructive cleanup is blocked");
+    expect(hint?.message).toContain("build-agenc-fresh");
+    expect(hint?.message).toContain("run the equivalent compile/test verification command directly");
+  });
+
+  it("injects a round-level recovery hint when a stale repo harness is retried after a successful fresh build", () => {
+    const hints = buildRecoveryHints(
+      [
+        {
+          name: "system.bash",
+          args: {
+            command: "bash tests/run_tests.sh",
+          },
+          result: JSON.stringify({
+            exitCode: 1,
+            stderr:
+              "CMake Error: The current CMakeCache.txt directory /tmp/agenc-shell/build/CMakeCache.txt is different than the directory /home/tetsuo/git/stream-test/agenc-shell/build where CMakeCache.txt was created.\n" +
+              'CMake Error: The source "/tmp/agenc-shell/CMakeLists.txt" does not match the source "/home/tetsuo/git/stream-test/agenc-shell/CMakeLists.txt" used to generate cache.\n',
+          }),
+          isError: true,
+          durationMs: 38,
+        },
+        {
+          name: "system.bash",
+          args: {
+            command: "cd build-fresh && cmake .. && make",
+          },
+          result: JSON.stringify({
+            exitCode: 0,
+            stdout:
+              "-- Build files have been written to: /tmp/agenc-shell/build-fresh\n[100%] Built target agenc-shell\n",
+            stderr: "",
+          }),
+          isError: false,
+          durationMs: 119,
+        },
+      ],
+      new Set(),
+    );
+
+    const hint = hints.find(
+      (entry) => entry.key === "system-bash-cmake-stale-harness-after-fresh-build",
+    );
+    expect(hint).toBeDefined();
+    expect(hint?.message).toContain("bash tests/run_tests.sh");
+    expect(hint?.message).toContain("build-fresh");
+    expect(hint?.message).toContain("explicit writable target");
+  });
+
+  it("injects the stale harness hint regardless of whether the fresh build succeeded earlier in the round", () => {
+    const hints = buildRecoveryHints(
+      [
+        {
+          name: "system.bash",
+          args: {
+            command: "cmake -S . -B build-agenc-fresh && cmake --build build-agenc-fresh",
+          },
+          result: JSON.stringify({
+            exitCode: 0,
+            stdout:
+              "-- Build files have been written to: /tmp/agenc-shell/build-agenc-fresh\n[100%] Built target agenc-shell\n",
+            stderr: "",
+          }),
+          isError: false,
+          durationMs: 151,
+        },
+        {
+          name: "system.bash",
+          args: {
+            command: "bash tests/run_tests.sh",
+          },
+          result: JSON.stringify({
+            exitCode: 1,
+            stderr:
+              "Running tests...\n" +
+              "CMake Error: The current CMakeCache.txt directory /tmp/agenc-shell/build/CMakeCache.txt is different than the directory /home/tetsuo/git/stream-test/agenc-shell/build where CMakeCache.txt was created.\n" +
+              'CMake Error: The source "/tmp/agenc-shell/CMakeLists.txt" does not match the source "/home/tetsuo/git/stream-test/agenc-shell/CMakeLists.txt" used to generate cache.\n',
+          }),
+          isError: true,
+          durationMs: 63,
+        },
+      ],
+      new Set(),
+    );
+
+    const hint = hints.find(
+      (entry) => entry.key === "system-bash-cmake-stale-harness-after-fresh-build",
+    );
+    expect(hint).toBeDefined();
+    expect(hint?.message).toContain("build-agenc-fresh");
+    expect(hint?.message).toContain("Continue verification directly");
+  });
+
+  it("carries the stale harness hint across rounds when a later split-shell retry falls back into run_tests.sh", () => {
+    const history = [
+      {
+        name: "system.bash",
+        args: {
+          command: "cmake",
+          args: ["-S", ".", "-B", "build-new", "&&", "cmake", "--build", "build-new"],
+        },
+        result: JSON.stringify({
+          exitCode: 0,
+          stdout:
+            "-- Build files have been written to: /tmp/agenc-shell/build-new\n[100%] Built target agenc-shell\n",
+          stderr: "",
+        }),
+        isError: false,
+        durationMs: 144,
+      },
+      {
+        name: "system.bash",
+        args: {
+          command: "cd",
+          args: [
+            "/tmp/agenc-shell",
+            "&&",
+            "chmod",
+            "+x",
+            "tests/run_tests.sh",
+            "&&",
+            "./tests/run_tests.sh",
+          ],
+        },
+        result: JSON.stringify({
+          exitCode: 1,
+          stderr:
+            "CMake Error: The current CMakeCache.txt directory /tmp/agenc-shell/build/CMakeCache.txt is different than the directory /home/tetsuo/git/stream-test/agenc-shell/build where CMakeCache.txt was created.\n" +
+            'CMake Error: The source "/tmp/agenc-shell/CMakeLists.txt" does not match the source "/home/tetsuo/git/stream-test/agenc-shell/CMakeLists.txt" used to generate cache.\n',
+        }),
+        isError: true,
+        durationMs: 72,
+      },
+    ] as const;
+
+    const hints = buildRecoveryHints(
+      history.slice(-1),
+      new Set(),
+      history,
+    );
+
+    const hint = hints.find(
+      (entry) => entry.key === "system-bash-cmake-stale-harness-after-fresh-build",
+    );
+    expect(hint).toBeDefined();
+    expect(hint?.message).toContain("build-new");
+    expect(hint?.message).toContain("bash tests/run_tests.sh");
+  });
+
+  it("pins subsequent rebuilds to the established fresh build dir after a stale CMake cache is repaired", () => {
+    const history = [
+      {
+        name: "system.bash",
+        args: {
+          command: "cd /tmp/agenc-shell/build && cmake .. && make",
+        },
+        result: JSON.stringify({
+          exitCode: 1,
+          stderr:
+            "CMake Error: The current CMakeCache.txt directory /tmp/agenc-shell/build/CMakeCache.txt is different than the directory /home/tetsuo/git/stream-test/agenc-shell/build where CMakeCache.txt was created.\n" +
+            'CMake Error: The source "/tmp/agenc-shell/CMakeLists.txt" does not match the source "/home/tetsuo/git/stream-test/agenc-shell/CMakeLists.txt" used to generate cache.\n',
+        }),
+        isError: true,
+        durationMs: 41,
+      },
+      {
+        name: "system.bash",
+        args: {
+          command: "cd /tmp/agenc-shell && cmake -S . -B build-fresh && make -C build-fresh",
+        },
+        result: JSON.stringify({
+          exitCode: 0,
+          stdout:
+            "-- Build files have been written to: /tmp/agenc-shell/build-fresh\n[100%] Built target agenc-shell\n",
+          stderr: "",
+        }),
+        isError: false,
+        durationMs: 188,
+      },
+    ] as const;
+
+    const hints = buildRecoveryHints(
+      history.slice(-1),
+      new Set(),
+      history,
+    );
+
+    const hint = hints.find(
+      (entry) => entry.key === "system-bash-cmake-use-established-fresh-build-dir",
+    );
+    expect(hint).toBeDefined();
+    expect(hint?.message).toContain("build-fresh");
+    expect(hint?.message).toContain("do not switch back to `build/`");
+    expect(hint?.message).toContain("delete build directories with `rm`");
+  });
+
+  it("suggests a fresh build directory when rm is denied for stale build artifacts", () => {
+    const hint = inferRecoveryHint({
+      name: "system.bash",
+      args: {
+        command: "rm /tmp/agenc-shell/build/CMakeCache.txt",
+      },
+      result: JSON.stringify({
+        error: 'Command "rm" is denied',
+      }),
+      isError: true,
+      durationMs: 1,
+    });
+
+    expect(hint).toBeDefined();
+    expect(hint?.key).toBe("system-bash-command-denied-rm-build-artifacts");
+    expect(hint?.message).toContain("build-agenc-fresh");
+  });
+
+  it("suggests configuring a fresh build directory when make runs in an unconfigured stale build dir", () => {
+    const hint = inferRecoveryHint({
+      name: "system.bash",
+      args: {
+        command: "make",
+        cwd: "/tmp/agenc-shell/build",
+      },
+      result: JSON.stringify({
+        exitCode: 2,
+        stderr: "make: *** No targets specified and no makefile found.  Stop.\n",
+      }),
+      isError: true,
+      durationMs: 5,
+    });
+
+    expect(hint).toBeDefined();
+    expect(hint?.key).toBe("system-bash-build-directory-not-configured");
+    expect(hint?.message).toContain("build-agenc-fresh");
+    expect(hint?.message).toContain("Do not keep retrying `make`");
+  });
+
+  it("injects a recovery hint for compiler diagnostics so the model repairs source instead of rerunning build", () => {
+    const hint = inferRecoveryHint({
+      name: "system.bash",
+      args: {
+        command: "cd /tmp/agenc-shell && cmake -S . -B build && cmake --build build",
+      },
+      result: JSON.stringify({
+        exitCode: 2,
+        stderr:
+          "/tmp/agenc-shell/src/lexer.c:54:44: error: macro \"ALLOC\" passed 2 arguments, but takes just 1\n" +
+          "/tmp/agenc-shell/src/lexer.c:54:25: error: ‘ALLOC’ undeclared (first use in this function)\n",
+      }),
+      isError: true,
+      durationMs: 184,
+    });
+
+    expect(hint).toBeDefined();
+    expect(hint?.key).toBe(
+      "system-bash-compiler-diagnostic:/tmp/agenc-shell/src/lexer.c:54:44",
+    );
+    expect(hint?.message).toContain("/tmp/agenc-shell/src/lexer.c:54:44");
+    expect(hint?.message).toContain("Stop rerunning the same build command");
+    expect(hint?.message).toContain("Read and edit the cited file");
+  });
+
+  it("injects a stronger recovery hint for header type-order compiler failures", () => {
+    const hint = inferRecoveryHint({
+      name: "system.bash",
+      args: {
+        command: "bash tests/run_tests.sh",
+      },
+      result: JSON.stringify({
+        exitCode: 2,
+        stderr:
+          "/tmp/agenc-shell/include/shell.h:27:5: error: unknown type name 'AstNode'\n" +
+          "/tmp/agenc-shell/include/shell.h:28:5: error: unknown type name 'AstNode'\n",
+      }),
+      isError: true,
+      durationMs: 211,
+    });
+
+    expect(hint).toBeDefined();
+    expect(hint?.key).toBe(
+      "system-bash-compiler-header-ordering:/tmp/agenc-shell/include/shell.h:27:5",
+    );
+    expect(hint?.message).toContain("header/type-ordering error");
+    expect(hint?.message).toContain("AstNode");
+    expect(hint?.message).toContain("forward declaration");
+  });
+
+  it("injects a stronger recovery hint for cross-file compiler interface drift", () => {
+    const hint = inferRecoveryHint({
+      name: "system.bash",
+      args: {
+        command: "bash tests/run_tests.sh",
+      },
+      result: JSON.stringify({
+        exitCode: 2,
+        stderr:
+          "/tmp/agenc-shell/src/parser.c:87:23: error: 'ASTNode' has no member named 'next'\n" +
+          "/tmp/agenc-shell/src/parser.c:102:17: error: unknown type name 'Redirect'; did you mean 'Redir'?\n" +
+          "/tmp/agenc-shell/src/parser.c:133:21: error: 'TOK_REDIRECT_IN' undeclared (first use in this function); did you mean 'TOK_REDIR_IN'?\n",
+      }),
+      isError: true,
+      durationMs: 233,
+    });
+
+    expect(hint).toBeDefined();
+    expect(hint?.key).toBe(
+      "system-bash-compiler-interface-drift:/tmp/agenc-shell/src/parser.c:87:23",
+    );
+    expect(hint?.message).toContain("cross-file interface drift");
+    expect(hint?.message).toContain("Redir");
+    expect(hint?.message).toContain("shared type surface");
+    expect(hint?.message).toContain("one coherent repair pass");
+  });
+
+  it("injects a recovery hint when a repo script is run from the wrong cwd and shell stderr reports a path failure", () => {
+    const hint = inferRecoveryHint({
+      name: "system.bash",
+      args: {
+        command: "cd /tmp/agenc-shell/tests && bash run_tests.sh",
+      },
+      result: JSON.stringify({
+        exitCode: 0,
+        stdout: "Running tests...\nCompilation test passed\n",
+        stderr:
+          "run_tests.sh: line 6: cd: build: No such file or directory\n",
+      }),
+      isError: false,
+      durationMs: 263,
+    });
+
+    expect(hint).toBeDefined();
+    expect(hint?.key).toBe("system-bash-shell-execution-anomaly");
+    expect(hint?.message).toContain("stderr even though the outer process returned success");
+    expect(hint?.message).toContain("bash tests/run_tests.sh");
   });
 
   it("flags heredoc commands that put a conjunction on a fresh line", () => {
@@ -283,6 +807,49 @@ describe("chat-executor-recovery", () => {
     expect(hint?.key).toBe("system-bash-workspace-protocol-unsupported");
     expect(hint?.message).toContain("workspace:*");
     expect(hint?.message).toContain("rerun `npm install`");
+  });
+
+  it("flags destructive writeFile overwrites with whole-file rewrite guidance", () => {
+    const hint = inferRecoveryHint({
+      name: "system.writeFile",
+      args: {
+        path: "/tmp/workspace/src/lexer.c",
+        content: "advance(lexer); // skip backslash",
+      },
+      result: JSON.stringify({
+        error:
+          'Refusing destructive overwrite of previously-read file "/tmp/workspace/src/lexer.c". Preserve the existing content when revising the file, or use system.appendFile for an additive update.',
+      }),
+      isError: true,
+      durationMs: 2,
+    });
+
+    expect(hint).toBeDefined();
+    expect(hint?.key).toBe("system-writefile-destructive-overwrite");
+    expect(hint?.message).toContain("rewrite the COMPLETE file body");
+    expect(hint?.message).toContain("system.appendFile");
+  });
+
+  it("flags repo-local verification harness shadow copies and redirects to direct bounded verification", () => {
+    const hint = inferRecoveryHint({
+      name: "system.writeFile",
+      args: {
+        path: "/tmp/agenc-shell/tests/run_tests_fresh.sh",
+        content: "#!/bin/bash\ncmake -S . -B build-agenc-fresh && cmake --build build-agenc-fresh\n",
+      },
+      result: JSON.stringify({
+        error:
+          'Delegated write path "/tmp/agenc-shell/tests/run_tests_fresh.sh" rewrites a repo-local verification harness without explicitly owning it as a writable target',
+      }),
+      isError: true,
+      durationMs: 2,
+    });
+
+    expect(hint).toBeDefined();
+    expect(hint?.key).toBe("system.writeFile-repo-local-verification-harness");
+    expect(hint?.message).toContain("run_tests_fresh.sh");
+    expect(hint?.message).toContain("Do not edit `tests/run_tests.sh`");
+    expect(hint?.message).toContain("equivalent bounded verification commands directly");
   });
 
   it("flags recursive npm install lifecycle scripts before they burn the turn budget", () => {

--- a/runtime/src/llm/chat-executor-recovery.ts
+++ b/runtime/src/llm/chat-executor-recovery.ts
@@ -4,6 +4,8 @@
  * @module
  */
 
+import { existsSync, readFileSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
 import type {
   ToolCallRecord,
   RecoveryHint,
@@ -73,6 +75,10 @@ function isPythonInterpreterCommand(command: string): boolean {
   return base === "python" || /^python\d+(?:\.\d+)?$/.test(base);
 }
 
+function isDestructiveRemovalCommand(command: string): boolean {
+  return commandBasename(command) === "rm";
+}
+
 function isAgencRuntimeNodeInvocation(args: Record<string, unknown>): boolean {
   const raw = args.args;
   if (!Array.isArray(raw)) return false;
@@ -104,6 +110,12 @@ function isDesktopBiasedSystemCommandFailure(
     failureTextLower.includes("command not found") ||
     failureTextLower.includes("is denied") ||
     failureTextLower.includes("not found")
+  );
+}
+
+function isShellExecutionAnomalyFailure(failureText: string): boolean {
+  return /(?:^|\n)(?:[^:\n]+:\s+line\s+\d+:\s+)?(?:(?:ba|z|k)?sh|cd|pushd|popd|source|\.)[^:\n]*:\s+.*(?:no such file or directory|command not found|not found|permission denied|not a directory)/i.test(
+    failureText,
   );
 }
 
@@ -380,6 +392,499 @@ function isJsonEscapedSourceLiteralFailure(failureText: string): boolean {
   return hasCompilerStylePath && hasEscapeTokenSignal && hasEscapedLiteralSignal;
 }
 
+function isCmakeCacheSourceMismatchFailure(failureText: string): boolean {
+  return (
+    /cmakecache\.txt directory .* is different than the directory .* was created/i
+      .test(failureText) ||
+    /does not match the source .* used to generate cache/i.test(failureText) ||
+    /re-run cmake with a different source directory/i.test(failureText)
+  );
+}
+
+function extractShellCommand(call: ToolCallRecord): string {
+  const command =
+    typeof call.args?.command === "string" ? call.args.command.trim() : "";
+  const rawArgs = Array.isArray(call.args?.args)
+    ? call.args.args.filter((value): value is string => typeof value === "string")
+    : [];
+  if (rawArgs.length === 0) {
+    return command;
+  }
+  return [command, ...rawArgs].filter((value) => value.length > 0).join(" ").trim();
+}
+
+function normalizeShellPathToken(raw: string): string {
+  return raw.replace(/^['"`]+|['"`]+$/g, "").trim();
+}
+
+function extractNonDefaultBuildDirectory(command: string): string | undefined {
+  const candidates: string[] = [];
+  for (const pattern of [
+    /\bcmake\b[\s\S]*?\s-B\s+([^\s;&|]+)/gi,
+    /\bcmake\b[\s\S]*?\s--build\s+([^\s;&|]+)/gi,
+    /\bcd\s+([^\s;&|]+)\s*&&\s*(?:cmake|make|ninja|ctest)\b/gi,
+  ]) {
+    for (const match of command.matchAll(pattern)) {
+      const candidate = normalizeShellPathToken(match[1] ?? "");
+      if (candidate.length > 0) {
+        candidates.push(candidate);
+      }
+    }
+  }
+  for (const candidate of candidates) {
+    const normalized = candidate.replace(/\\/g, "/");
+    const basename = normalized.split("/").pop()?.toLowerCase() ?? normalized.toLowerCase();
+    if (basename.startsWith("build") && basename !== "build") {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function isSuccessfulFreshBuildCall(call: ToolCallRecord): boolean {
+  if (call.name !== "system.bash" && call.name !== "desktop.bash") {
+    return false;
+  }
+  if (didToolCallFail(call.isError, call.result)) {
+    return false;
+  }
+  const command = extractShellCommand(call);
+  if (command.length === 0) {
+    return false;
+  }
+  if (extractNonDefaultBuildDirectory(command) === undefined) {
+    return false;
+  }
+  return /\b(?:cmake|make|ninja|ctest)\b/i.test(command);
+}
+
+function isRepositoryBuildHarnessCommand(call: ToolCallRecord): boolean {
+  if (call.name !== "system.bash" && call.name !== "desktop.bash") {
+    return false;
+  }
+  const command = extractShellCommand(call).toLowerCase();
+  return (
+    /(?:^|\s)(?:ba|z|k)?sh\s+(?:\.\/)?(?:[^\s]+\/)?tests\/run_tests\.sh(?:\s|$)/.test(
+      command,
+    ) ||
+    /(?:^|\s)(?:ba|z|k)?sh\s+(?:\.\/)?run_tests\.sh(?:\s|$)/.test(command) ||
+    /(?:^|[\s;&|])(?:\.\/)?(?:[^\s]+\/)?tests\/run_tests\.sh(?:\s|$)/.test(
+      command,
+    ) ||
+    /(?:^|[\s;&|])(?:\.\/)?run_tests\.sh(?:\s|$)/.test(command)
+  );
+}
+
+interface RepositoryBuildHarnessInvocation {
+  readonly cwd: string;
+  readonly scriptPath: string;
+}
+
+interface StaleCopiedCmakeHarnessPreflightResult {
+  readonly args: Record<string, unknown>;
+  readonly repairedFields: readonly string[];
+  readonly reasonKey?: string;
+  readonly rejectionError?: string;
+}
+
+function isStaleCopiedCmakeWorkspace(workspaceRoot: string | undefined): boolean {
+  if (!workspaceRoot) return false;
+  const cmakeListsPath = resolvePath(workspaceRoot, "CMakeLists.txt");
+  const cmakeCachePath = resolvePath(workspaceRoot, "build", "CMakeCache.txt");
+  if (!existsSync(cmakeListsPath) || !existsSync(cmakeCachePath)) {
+    return false;
+  }
+  try {
+    const cache = readFileSync(cmakeCachePath, "utf8");
+    const homeDirectoryMatch = cache.match(
+      /^CMAKE_HOME_DIRECTORY(?::[A-Z]+)?=(.+)$/m,
+    );
+    const cacheHomeDirectory = homeDirectoryMatch?.[1]?.trim();
+    if (!cacheHomeDirectory) return false;
+    return resolvePath(cacheHomeDirectory) !== resolvePath(workspaceRoot);
+  } catch {
+    return false;
+  }
+}
+
+function resolveRepositoryBuildHarnessInvocation(
+  args: Record<string, unknown>,
+  workspaceRoot?: string,
+): RepositoryBuildHarnessInvocation | undefined {
+  const cwdCandidate =
+    typeof args.cwd === "string" && args.cwd.trim().length > 0
+      ? resolvePath(args.cwd)
+      : workspaceRoot
+        ? resolvePath(workspaceRoot)
+        : undefined;
+  if (!cwdCandidate) return undefined;
+
+  const command =
+    typeof args.command === "string" ? args.command.trim() : "";
+  const rawArgs = Array.isArray(args.args)
+    ? args.args.filter((value): value is string => typeof value === "string")
+    : [];
+
+  const shellBase = commandBasename(command);
+  if (rawArgs.length > 0 && /^(?:ba|z|k)?sh$/.test(shellBase)) {
+    const scriptArg = rawArgs.find((value) => !value.startsWith("-"));
+    if (!scriptArg) return undefined;
+    return {
+      cwd: cwdCandidate,
+      scriptPath: resolvePath(cwdCandidate, scriptArg),
+    };
+  }
+
+  const inlineShellMatch = command.match(
+    /(?:^|\s)(?:ba|z|k)?sh\s+((?:\.\/)?[^\s]+\.(?:sh|bash|zsh))(?:\s|$)/i,
+  );
+  if (inlineShellMatch?.[1]) {
+    return {
+      cwd: cwdCandidate,
+      scriptPath: resolvePath(cwdCandidate, inlineShellMatch[1]),
+    };
+  }
+
+  if (/\.(?:sh|bash|zsh)$/i.test(command)) {
+    return {
+      cwd: cwdCandidate,
+      scriptPath: resolvePath(cwdCandidate, command),
+    };
+  }
+  return undefined;
+}
+
+function parseSimpleRepositoryBuildHarness(
+  scriptContent: string,
+): { readonly equivalentCommand: string } | undefined {
+  const segments = scriptContent
+    .split(/\r?\n/)
+    .flatMap((line) => line.split("&&"))
+    .map((line) => line.trim())
+    .filter((line) =>
+      line.length > 0 &&
+      !line.startsWith("#") &&
+      !/^set(?:\s+-[A-Za-z]+|\s+-o\s+\w+)/.test(line)
+    );
+  if (segments.length === 0) return undefined;
+
+  const normalized = segments.map((segment) =>
+    segment.replace(/\s+/g, " ").trim().toLowerCase()
+  );
+  const supported = new Set([
+    "mkdir build",
+    "mkdir -p build",
+    "cd build",
+    "cmake ..",
+    "cmake --build .",
+    "make",
+    "ctest",
+    "ctest --output-on-failure",
+  ]);
+  if (normalized.some((segment) => !supported.has(segment))) {
+    return undefined;
+  }
+  if (!normalized.includes("cd build") || !normalized.includes("cmake ..")) {
+    return undefined;
+  }
+  const needsBuild = normalized.includes("make") || normalized.includes("cmake --build .");
+  if (!needsBuild) return undefined;
+
+  const commands = [
+    "cmake -S . -B __AGENC_FRESH_BUILD_DIR__",
+    "cmake --build __AGENC_FRESH_BUILD_DIR__",
+  ];
+  if (normalized.includes("ctest") || normalized.includes("ctest --output-on-failure")) {
+    commands.push("ctest --test-dir __AGENC_FRESH_BUILD_DIR__ --output-on-failure");
+  }
+  return {
+    equivalentCommand: commands.join(" && "),
+  };
+}
+
+function resolvePreferredFreshBuildDirectory(
+  recentCalls: readonly ToolCallRecord[],
+): string {
+  const latestFreshBuild = [...recentCalls]
+    .reverse()
+    .find((call) => isSuccessfulFreshBuildCall(call));
+  return (
+    (latestFreshBuild
+      ? extractNonDefaultBuildDirectory(extractShellCommand(latestFreshBuild))
+      : undefined) ?? "build-agenc-fresh"
+  );
+}
+
+function buildFreshBuildDirectoryPath(
+  workspaceRoot: string,
+  freshBuildDir: string,
+): string {
+  if (freshBuildDir.startsWith("/")) {
+    return freshBuildDir;
+  }
+  return resolvePath(workspaceRoot, freshBuildDir);
+}
+
+function isWorkspaceBuildDirectoryPath(
+  candidate: string,
+  workspaceRoot: string,
+): boolean {
+  return resolvePath(candidate) === resolvePath(workspaceRoot, "build");
+}
+
+function isDirectConfigureIntoStaleDefaultBuild(
+  args: Record<string, unknown>,
+  workspaceRoot: string,
+): boolean {
+  const command =
+    typeof args.command === "string" ? args.command.trim().toLowerCase() : "";
+  const commandBase = commandBasename(command);
+  const rawArgs = Array.isArray(args.args)
+    ? args.args.filter((value): value is string => typeof value === "string")
+    : [];
+  const cwd =
+    typeof args.cwd === "string" && args.cwd.trim().length > 0
+      ? resolvePath(args.cwd)
+      : resolvePath(workspaceRoot);
+  if (
+    commandBase === "cd" &&
+    rawArgs.length >= 4 &&
+    isWorkspaceBuildDirectoryPath(rawArgs[0], workspaceRoot) &&
+    rawArgs[1] === "&&" &&
+    rawArgs[2]?.toLowerCase() === "cmake" &&
+    rawArgs[3] === ".."
+  ) {
+    return true;
+  }
+  if (commandBase !== "cmake") return false;
+  if (cwd === resolvePath(workspaceRoot, "build") && rawArgs.length === 1 && rawArgs[0] === "..") {
+    return true;
+  }
+  const buildIndex = rawArgs.findIndex((value) => value === "-B");
+  if (buildIndex >= 0) {
+    const buildTarget = rawArgs[buildIndex + 1];
+    if (
+      typeof buildTarget === "string" &&
+      (buildTarget === "build" || isWorkspaceBuildDirectoryPath(buildTarget, workspaceRoot))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isDirectBuildAgainstStaleDefaultBuild(
+  args: Record<string, unknown>,
+  workspaceRoot: string,
+): boolean {
+  const command =
+    typeof args.command === "string" ? args.command.trim().toLowerCase() : "";
+  const commandBase = commandBasename(command);
+  const cwd =
+    typeof args.cwd === "string" && args.cwd.trim().length > 0
+      ? resolvePath(args.cwd)
+      : resolvePath(workspaceRoot);
+  return (
+    ["make", "ninja", "ctest"].includes(commandBase) &&
+    cwd === resolvePath(workspaceRoot, "build")
+  );
+}
+
+export function preflightStaleCopiedCmakeHarnessInvocation(
+  toolName: string,
+  args: Record<string, unknown>,
+  workspaceRoot: string | undefined,
+  recentCalls: readonly ToolCallRecord[],
+): StaleCopiedCmakeHarnessPreflightResult {
+  if (toolName !== "system.bash" && toolName !== "desktop.bash") {
+    return { args, repairedFields: [] };
+  }
+  if (!isStaleCopiedCmakeWorkspace(workspaceRoot)) {
+    return { args, repairedFields: [] };
+  }
+  const normalizedWorkspaceRoot = resolvePath(workspaceRoot);
+  const freshBuildDir = resolvePreferredFreshBuildDirectory(recentCalls);
+  const freshBuildPath = buildFreshBuildDirectoryPath(
+    normalizedWorkspaceRoot,
+    freshBuildDir,
+  );
+
+  if (isDirectConfigureIntoStaleDefaultBuild(args, normalizedWorkspaceRoot)) {
+    return {
+      args: {
+        command: "cmake",
+        args: ["-S", normalizedWorkspaceRoot, "-B", freshBuildPath],
+        cwd: normalizedWorkspaceRoot,
+      },
+      repairedFields: ["command", "args", "cwd"],
+      reasonKey: "system-bash-cmake-stale-default-build-rewritten",
+    };
+  }
+  if (isDirectBuildAgainstStaleDefaultBuild(args, normalizedWorkspaceRoot)) {
+    return {
+      args: {
+        command: "cmake",
+        args: ["--build", freshBuildPath],
+        cwd: normalizedWorkspaceRoot,
+      },
+      repairedFields: ["command", "args", "cwd"],
+      reasonKey: "system-bash-cmake-stale-default-build-rewritten",
+    };
+  }
+
+  const invocation = resolveRepositoryBuildHarnessInvocation(args, normalizedWorkspaceRoot);
+  if (!invocation || !existsSync(invocation.scriptPath)) {
+    return { args, repairedFields: [] };
+  }
+
+  try {
+    const scriptContent = readFileSync(invocation.scriptPath, "utf8");
+    const normalizedScript = scriptContent.toLowerCase();
+    if (
+      !/\bcd\s+build\b/.test(normalizedScript) ||
+      !/\bcmake\s+\.\./.test(normalizedScript)
+    ) {
+      return { args, repairedFields: [] };
+    }
+
+    const parsedHarness = parseSimpleRepositoryBuildHarness(scriptContent);
+    if (!parsedHarness) {
+      return {
+        args,
+        repairedFields: [],
+        reasonKey: "system-bash-cmake-stale-harness-rejected",
+        rejectionError:
+          `Refusing to invoke \`${invocation.scriptPath}\` in this delegated workspace because the script hardcodes the stale copied \`build/\` directory and cannot be safely rewritten automatically. ` +
+          `Run the equivalent verification directly from \`${resolvePath(normalizedWorkspaceRoot ?? invocation.cwd)}\` against a fresh build directory such as \`${freshBuildDir}\` instead.`,
+      };
+    }
+
+    return {
+      args: {
+        command: parsedHarness.equivalentCommand.replaceAll(
+          "__AGENC_FRESH_BUILD_DIR__",
+          freshBuildDir,
+        ),
+        cwd: resolvePath(normalizedWorkspaceRoot ?? invocation.cwd),
+      },
+      repairedFields: ["command", "args", "cwd"],
+      reasonKey: "system-bash-cmake-stale-harness-rewritten",
+    };
+  } catch {
+    return { args, repairedFields: [] };
+  }
+}
+
+function isUnconfiguredBuildDirectoryFailure(
+  call: ToolCallRecord,
+  failureText: string,
+): boolean {
+  if (call.name !== "system.bash" && call.name !== "desktop.bash") {
+    return false;
+  }
+  const command = String(call.args?.command ?? "").trim().toLowerCase();
+  const args = Array.isArray(call.args?.args)
+    ? call.args.args
+        .filter((value): value is string => typeof value === "string")
+        .map((value) => value.toLowerCase())
+    : [];
+  const joined = [command, ...args].join(" ");
+  const buildCommand =
+    /\b(?:make|cmake|ninja)\b/.test(joined);
+  if (!buildCommand) {
+    return false;
+  }
+  return (
+    /no targets specified and no makefile found/i.test(failureText) ||
+    /ninja:\s+error:\s+loading ['"`]?build\.ninja['"`]?: no such file or directory/i.test(
+      failureText,
+    ) ||
+    /could not load cache/i.test(failureText)
+  );
+}
+
+function extractCompilerDiagnosticLocation(
+  failureText: string,
+): string | undefined {
+  const match = failureText.match(
+    /(^|\n)([^:\n]+\.(?:c|cc|cpp|cxx|h|hpp|hh|m|mm|rs|go|ts|tsx|js|jsx|py)):(\d+)(?::(\d+))?:\s*(?:fatal\s+)?error:/i,
+  );
+  const file = match?.[2]?.trim();
+  const line = match?.[3]?.trim();
+  const column = match?.[4]?.trim();
+  if (!file || !line) {
+    return undefined;
+  }
+  return `${file}:${line}${column ? `:${column}` : ""}`;
+}
+
+function extractUnknownTypeNameFromCompilerFailure(
+  failureText: string,
+): string | undefined {
+  const match = failureText.match(
+    /\bunknown type name ['"`]?([A-Za-z_][A-Za-z0-9_]*)['"`]?/i,
+  );
+  return match?.[1]?.trim();
+}
+
+function extractCompilerSuggestedName(
+  failureText: string,
+): string | undefined {
+  const match = failureText.match(/\bdid you mean ['"`]?([A-Za-z_][A-Za-z0-9_]*)['"`]?/i);
+  return match?.[1]?.trim();
+}
+
+function isHeaderTypeOrderingCompilerFailure(
+  failureText: string,
+): boolean {
+  return (
+    /\bunknown type name ['"`]?[A-Za-z_][A-Za-z0-9_]*['"`]?/i.test(
+      failureText,
+    ) ||
+    /\bfield has incomplete type\b/i.test(failureText) ||
+    /\bunknown type\b/i.test(failureText) &&
+      /\b(?:struct|typedef|enum|union|header)\b/i.test(failureText)
+  );
+}
+
+function isCompilerInterfaceDriftFailure(
+  failureText: string,
+): boolean {
+  return (
+    /\bhas no member named ['"`]?[A-Za-z_][A-Za-z0-9_]*['"`]?/i.test(
+      failureText,
+    ) ||
+    /\bdid you mean ['"`]?[A-Za-z_][A-Za-z0-9_]*['"`]?/i.test(failureText) ||
+    /\bincompatible types when assigning to type\b/i.test(failureText) ||
+    /\bundeclared\b.*\bdid you mean\b/i.test(failureText)
+  );
+}
+
+function isCompilerDiagnosticFailure(
+  call: ToolCallRecord,
+  failureText: string,
+): boolean {
+  if (call.name !== "system.bash" && call.name !== "desktop.bash") return false;
+  const command = String(call.args?.command ?? "").toLowerCase();
+  const args = Array.isArray(call.args?.args)
+    ? call.args.args
+        .filter((value): value is string => typeof value === "string")
+        .map((value) => value.toLowerCase())
+    : [];
+  const joined = [command, ...args].join(" ");
+  const looksLikeBuildCommand =
+    /\b(?:cmake|ctest|make|ninja|meson|gcc|g\+\+|clang|clang\+\+|cc|c\+\+)\b/
+      .test(joined);
+  const looksLikeRepoScriptBuildWrapper =
+    (
+      /^(?:ba|z|k)?sh$/.test(command.split(/[\\/]/).pop() ?? "") &&
+      args.some((value) => /(?:^|\/)[^/\s]+\.(?:sh|bash|zsh)$/i.test(value))
+    ) ||
+    /\b(?:ba|z|k)?sh\s+[^\s]+\.(?:sh|bash|zsh)\b/i.test(joined);
+  return (looksLikeBuildCommand || looksLikeRepoScriptBuildWrapper) &&
+    extractCompilerDiagnosticLocation(failureText) !== undefined;
+}
+
 function isPackagePathNotExportedFailure(failureTextLower: string): boolean {
   return (
     failureTextLower.includes("err_package_path_not_exported") ||
@@ -571,9 +1076,10 @@ export function summarizeStateful(
 export function buildRecoveryHints(
   roundCalls: readonly ToolCallRecord[],
   emittedHints: Set<string>,
+  recentCalls: readonly ToolCallRecord[] = roundCalls,
 ): RecoveryHint[] {
   const hints: RecoveryHint[] = [];
-  const roundHint = inferRoundRecoveryHint(roundCalls);
+  const roundHint = inferRoundRecoveryHint(roundCalls, recentCalls);
   if (roundHint && !emittedHints.has(roundHint.key)) {
     emittedHints.add(roundHint.key);
     hints.push(roundHint);
@@ -590,7 +1096,110 @@ export function buildRecoveryHints(
 
 function inferRoundRecoveryHint(
   roundCalls: readonly ToolCallRecord[],
+  recentCalls: readonly ToolCallRecord[] = roundCalls,
 ): RecoveryHint | undefined {
+  const latestStaleCmakeMismatch = [...recentCalls]
+    .reverse()
+    .find((call) => {
+      if (!didToolCallFail(call.isError, call.result)) return false;
+      return isCmakeCacheSourceMismatchFailure(extractToolFailureText(call));
+    });
+  const latestFreshBuild = [...recentCalls]
+    .reverse()
+    .find((call) => isSuccessfulFreshBuildCall(call));
+  const latestStaleHarnessMismatch = [...recentCalls]
+    .reverse()
+    .find((call) => {
+      if (!didToolCallFail(call.isError, call.result)) return false;
+      if (!isRepositoryBuildHarnessCommand(call)) return false;
+      return isCmakeCacheSourceMismatchFailure(extractToolFailureText(call));
+    });
+  const roundHasStaleHarnessMismatch = roundCalls.some((call) => {
+    if (!didToolCallFail(call.isError, call.result)) return false;
+    if (!isRepositoryBuildHarnessCommand(call)) return false;
+    return isCmakeCacheSourceMismatchFailure(extractToolFailureText(call));
+  });
+  const recentHarnessRetryAfterFreshBuild = (() => {
+    if (!latestFreshBuild) return false;
+    const freshBuildIndex = recentCalls.lastIndexOf(latestFreshBuild);
+    return recentCalls.some(
+      (call, index) =>
+        index > freshBuildIndex && isRepositoryBuildHarnessCommand(call),
+    );
+  })();
+  if (
+    latestFreshBuild &&
+    latestStaleHarnessMismatch &&
+    (roundHasStaleHarnessMismatch || recentHarnessRetryAfterFreshBuild)
+  ) {
+    const freshBuildDir =
+      extractNonDefaultBuildDirectory(extractShellCommand(latestFreshBuild)) ??
+      "build-agenc-fresh";
+    return {
+      key: "system-bash-cmake-stale-harness-after-fresh-build",
+      message:
+        "The repository verification script is still bound to the stale copied `build/` directory, but a regenerated build directory already succeeded. " +
+        "Do not bounce back into `bash tests/run_tests.sh` or edit that script unless it is an explicit writable target. " +
+        `Continue verification directly against \`${freshBuildDir}\` with equivalent build/test commands from the workspace root.`,
+    };
+  }
+  if (latestFreshBuild && latestStaleCmakeMismatch) {
+    const freshBuildDir =
+      extractNonDefaultBuildDirectory(extractShellCommand(latestFreshBuild)) ??
+      "build-agenc-fresh";
+    return {
+      key: "system-bash-cmake-use-established-fresh-build-dir",
+      message:
+        `A regenerated build directory (\`${freshBuildDir}\`) already succeeded after the stale copied CMake cache failure. ` +
+        `Treat \`${freshBuildDir}\` as the trusted build root for the rest of this workspace run. ` +
+        "Keep rebuilds and verification in that directory after source edits, and do not switch back to `build/`, recreate `build/`, or delete build directories with `rm` unless the contract explicitly requires that cleanup.",
+    };
+  }
+
+  const staleCmakeMismatchCall = roundCalls.find((call) => {
+    if (!didToolCallFail(call.isError, call.result)) return false;
+    return isCmakeCacheSourceMismatchFailure(extractToolFailureText(call));
+  });
+  if (staleCmakeMismatchCall) {
+    const successfulFreshBuildCall = roundCalls.find((call) =>
+      isSuccessfulFreshBuildCall(call)
+    );
+    if (
+      successfulFreshBuildCall &&
+      isRepositoryBuildHarnessCommand(staleCmakeMismatchCall)
+    ) {
+      const freshBuildDir = extractNonDefaultBuildDirectory(
+        extractShellCommand(successfulFreshBuildCall),
+      ) ?? "build-agenc-fresh";
+      return {
+        key: "system-bash-cmake-stale-harness-after-fresh-build",
+        message:
+          "The repository verification script is still bound to the stale copied `build/` directory, but a regenerated build directory already succeeded. " +
+          `Do not bounce back into \`bash tests/run_tests.sh\` or edit that script unless it is an explicit writable target. ` +
+          `Continue verification directly against \`${freshBuildDir}\` with equivalent build/test commands from the workspace root.`,
+      };
+    }
+    const deniedRemovalCall = roundCalls.find((call) => {
+      if (!didToolCallFail(call.isError, call.result)) return false;
+      const failureText = extractToolFailureText(call);
+      const deniedCommand = extractDeniedCommand(failureText);
+      if (!deniedCommand || !isDestructiveRemovalCommand(deniedCommand)) {
+        return false;
+      }
+      const rawCommand =
+        typeof call.args?.command === "string" ? call.args.command : "";
+      return /(?:^|\/)build(?:[\/\s]|$)|cmakecache\.txt/i.test(rawCommand);
+    });
+    if (deniedRemovalCall) {
+      return {
+        key: "system-bash-cmake-cache-rebuild-in-fresh-dir",
+        message:
+          "The current workspace contains a stale copied CMake cache, and destructive cleanup is blocked. " +
+          "Do not retry `rm`. Configure a fresh build directory instead (for example `cmake -S . -B build-agenc-fresh`), " +
+          "build from that directory, and if the repository test script hardcodes the stale `build/` path, run the equivalent compile/test verification command directly against the fresh build directory.",
+      };
+    }
+  }
   const failedManagedStop = roundCalls.some((call) => {
     if (call.name !== "desktop.process_stop") return false;
     if (!didToolCallFail(call.isError, call.result)) return false;
@@ -662,6 +1271,18 @@ export function inferRecoveryHint(
 
   const failureText = extractToolFailureText(call);
   const failureTextLower = failureText.toLowerCase();
+  if (
+    failureTextLower.includes("repo-local verification harness") &&
+    failureTextLower.includes("writable target")
+  ) {
+    return {
+      key: `${call.name}-repo-local-verification-harness`,
+      message:
+        "This attempt tried to bypass the repo-local verification harness contract by rewriting or shadowing a grader script. " +
+        "Do not edit `tests/run_tests.sh`, do not create alternate wrappers like `run_tests_fresh.sh`, and do not clone the harness under a new filename unless the contract explicitly names that file as writable. " +
+        "Keep the repo harness read-only and run the equivalent bounded verification commands directly from the workspace root instead.",
+    };
+  }
   if (isWatchModeTestRunnerFailure(call, parsedResult, failureTextLower)) {
     return {
       key: `${call.name}-test-runner-watch-mode`,
@@ -960,6 +1581,73 @@ export function inferRecoveryHint(
           "Only rerun the compile/test command after the source file itself is fixed.",
       };
     }
+    if (isCmakeCacheSourceMismatchFailure(failureText)) {
+      return {
+        key: "system-bash-cmake-cache-source-mismatch",
+        message:
+          "This build directory contains a stale CMake cache from a different workspace or source root. " +
+          "Do not keep retrying the same build command or delete files with `rm`. Reconfigure the project into a fresh build directory " +
+          "(for example `cmake -S . -B build-agenc-fresh`) and continue from that regenerated cache before rerunning follow-up builds.",
+      };
+    }
+    if (isUnconfiguredBuildDirectoryFailure(call, failureText)) {
+      return {
+        key: "system-bash-build-directory-not-configured",
+        message:
+          "This build directory is present on disk but is not configured for the current workspace. " +
+          "Do not keep retrying `make`/`ninja` inside that stale directory. Configure a fresh build directory first " +
+          "(for example `cmake -S . -B build-agenc-fresh`), then build and test from that new directory instead of assuming `build/` is reusable.",
+      };
+    }
+    if (isCompilerDiagnosticFailure(call, failureText)) {
+      const location = extractCompilerDiagnosticLocation(failureText);
+      const unknownTypeName = extractUnknownTypeNameFromCompilerFailure(
+        failureText,
+      );
+      const suggestedName = extractCompilerSuggestedName(failureText);
+      if (isCompilerInterfaceDriftFailure(failureText)) {
+        return {
+          key: location
+            ? `system-bash-compiler-interface-drift:${location.toLowerCase()}`
+            : "system-bash-compiler-interface-drift",
+          message:
+            "The compiler is reporting cross-file interface drift" +
+            (location ? ` at \`${location}\`` : "") +
+            (suggestedName ? ` and is already suggesting \`${suggestedName}\`` : "") +
+            ". Treat the cited header or shared type surface as authoritative. Read the cited header plus every touched source file that consumes it, align the type/member/enum names in one coherent repair pass, and only rerun the minimal build/test command after the full interface is consistent again.",
+        };
+      }
+      if (isHeaderTypeOrderingCompilerFailure(failureText)) {
+        return {
+          key: location
+            ? `system-bash-compiler-header-ordering:${location.toLowerCase()}`
+            : "system-bash-compiler-header-ordering",
+          message:
+            "The compiler is reporting a header/type-ordering error" +
+            (location ? ` at \`${location}\`` : "") +
+            (unknownTypeName ? ` involving \`${unknownTypeName}\`` : "") +
+            ". Read the cited header and the first source file that includes it, move the type definition or forward declaration before the first use, and only rerun the minimal build/test command after the header itself is fixed.",
+        };
+      }
+      return {
+        key: location
+          ? `system-bash-compiler-diagnostic:${location.toLowerCase()}`
+          : "system-bash-compiler-diagnostic",
+        message:
+          "The compiler already identified a concrete source or header location" +
+          (location ? ` (\`${location}\`)` : "") +
+          ". Stop rerunning the same build command. Read and edit the cited file or header, fix the reported code error, and only rerun the minimal build command after the source change is in place.",
+      };
+    }
+    if (isShellExecutionAnomalyFailure(failureText)) {
+      return {
+        key: "system-bash-shell-execution-anomaly",
+        message:
+          "This shell command printed a real shell/runtime error on stderr even though the outer process returned success. " +
+          "Treat that verification step as failed. Fix the cwd/path/script invocation before rerunning it. " +
+          "For repository scripts that use relative paths, invoke them from the workspace root (for example `bash tests/run_tests.sh`) instead of `cd`-ing into the script directory unless the script explicitly requires that cwd.",
+      };
+    }
     if (isPackagePathNotExportedFailure(failureTextLower)) {
       return {
         key: usesCommonJsRequireSnippet(call)
@@ -1047,6 +1735,25 @@ export function inferRecoveryHint(
     }
     const deniedCommand = extractDeniedCommand(failureText);
     if (deniedCommand) {
+      if (isDestructiveRemovalCommand(deniedCommand)) {
+        const rawCommand =
+          typeof call.args?.command === "string" ? call.args.command : "";
+        if (/(?:^|\/)build(?:[\/\s]|$)|cmakecache\.txt/i.test(rawCommand)) {
+          return {
+            key: "system-bash-command-denied-rm-build-artifacts",
+            message:
+              "Destructive deletion is blocked here. For stale generated build artifacts such as `build/` or `CMakeCache.txt`, " +
+              "do not retry with `rm`. Reconfigure into a fresh build directory instead (for example `cmake -S . -B build-agenc-fresh`) " +
+              "and run build/test verification from that new directory.",
+          };
+        }
+        return {
+          key: "system-bash-command-denied-rm",
+          message:
+            "Destructive file-deletion commands are blocked on system.bash unless the user explicitly asked for deletion. " +
+            "Do not retry with `rm`. For rebuild verification, prefer non-destructive commands such as `make clean && make`, `cmake --build . --clean-first`, or another build-system-native clean rebuild path.",
+        };
+      }
       if (isNodeInterpreterCommand(deniedCommand)) {
         if (isAgencRuntimeNodeInvocation(call.args)) {
           return {
@@ -1103,6 +1810,19 @@ export function inferRecoveryHint(
         "This child task is scoped to a delegated workspace root. " +
         "Keep file paths under the assigned root, prefer relative paths from that cwd, " +
         "and do not create fallback workspaces elsewhere (for example under `/tmp`).",
+      };
+  }
+
+  if (
+    call.name === "system.writeFile" &&
+    failureTextLower.includes("refusing destructive overwrite of previously-read file")
+  ) {
+    return {
+      key: "system-writefile-destructive-overwrite",
+      message:
+        "This `system.writeFile` call tried to replace a previously-read file with partial or destructive content. " +
+        "Re-read the current file contents, preserve the unchanged sections, and rewrite the COMPLETE file body in one `system.writeFile` call. " +
+        "Do not send only the changed snippet unless you are using an additive tool like `system.appendFile`.",
     };
   }
 

--- a/runtime/src/llm/chat-executor-text.test.ts
+++ b/runtime/src/llm/chat-executor-text.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildToolExecutionGroundingMessage,
   generateFallbackContent,
+  isExecutionDeferralResponse,
   normalizeHistory,
   prepareToolResultForPrompt,
   reconcileDirectShellObservationContent,
@@ -721,5 +722,15 @@ describe("chat-executor-text", () => {
     expect(content).toContain("execute_with_agent");
     expect(content).not.toContain("Partial response before failure:");
     expect(content).not.toContain("Completed execute_with_agent");
+  });
+
+  it("does not treat grounded completion summaries as execution deferrals just because they mention future readiness", () => {
+    const content =
+      "Phase 0 (Bootstrap) has been re-implemented from scratch and verified.\n\n" +
+      "Build successful. `./agenc-shell <<< 'exit'` exits cleanly.\n\n" +
+      'No further phases were addressed as only Phase 0 was marked "Fully implemented" in PLAN.md.\n' +
+      "The workspace is ready for incremental development of subsequent phases.";
+
+    expect(isExecutionDeferralResponse(content)).toBe(false);
   });
 });

--- a/runtime/src/llm/chat-executor-text.ts
+++ b/runtime/src/llm/chat-executor-text.ts
@@ -634,7 +634,7 @@ const PLAN_HEADING_RE = /^(?:\*\*)?plan(?:\*\*)?:?/im;
 const FUTURE_EXECUTION_SIGNAL_RE =
   /\b(?:starting execution|begin(?:ning)? execution|i(?:'ll| will)|going to|next(?: up)?|after that|then)\b/i;
 const EXECUTION_DEFERRAL_SIGNAL_RE =
-  /\b(?:let me know|ready for|next (?:feature|module|step)|deepen next|specific feature|specific module|continue next|follow up next)\b/i;
+  /\b(?:let me know|ready for (?:the )?(?:next|follow[- ]?up|another|you to)|next (?:feature|module|step)|deepen next|specific feature|specific module|continue next|follow up next)\b/i;
 const EXECUTION_PROGRESS_SUMMARY_SIGNAL_RE =
   /\b(?:summary of process|current status|compiled|build succeeded|updated\s+`|updated\s+src\/|wrote\s+|fixed\s+|implemented\s+|ready)\b/i;
 const EXECUTION_BLOCKER_SIGNAL_RE =

--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -61,6 +61,7 @@ import {
 import {
   buildSemanticToolCallKey,
   buildRecoveryHints,
+  preflightStaleCopiedCmakeHarnessInvocation,
 } from "./chat-executor-recovery.js";
 import {
   sanitizeToolCallsForReplay,
@@ -261,6 +262,13 @@ export async function executeSingleToolCall(
     ctx.messageText,
   );
   args = repaired.args;
+  const staleHarnessPreflight = preflightStaleCopiedCmakeHarnessInvocation(
+    toolCall.name,
+    args,
+    ctx.runtimeWorkspaceRoot,
+    ctx.allToolCalls,
+  );
+  args = staleHarnessPreflight.args;
   const contractAdjustedFields: string[] = [];
   if (toolCall.name === "mcp.doom.start_game") {
     const doomTurnContract = inferDoomTurnContract(ctx.messageText);
@@ -280,11 +288,48 @@ export async function executeSingleToolCall(
     argumentDiagnostics.repairSource = "message_text";
     argumentDiagnostics.repairedFields = repaired.repairedFields;
   }
+  if (staleHarnessPreflight.repairedFields.length > 0) {
+    argumentDiagnostics.workspacePreflightReason = staleHarnessPreflight.reasonKey;
+    argumentDiagnostics.workspaceAdjustedFields =
+      staleHarnessPreflight.repairedFields;
+  }
   if (contractAdjustedFields.length > 0) {
     argumentDiagnostics.contractAdjustedFields = contractAdjustedFields;
   }
   if (Object.keys(argumentDiagnostics).length > 0) {
     argumentDiagnostics.rawArgs = rawArgs;
+  }
+  if (staleHarnessPreflight.rejectionError) {
+    callbacks.emitExecutionTrace(ctx, {
+      type: "tool_rejected",
+      phase: "tool_followup",
+      callIndex: ctx.callIndex,
+      payload: {
+        tool: toolCall.name,
+        args,
+        originalArgs: rawArgs,
+        reason: staleHarnessPreflight.reasonKey,
+        error: staleHarnessPreflight.rejectionError,
+      },
+    });
+    callbacks.pushMessage(
+      ctx,
+      {
+        role: "tool",
+        content: staleHarnessPreflight.rejectionError,
+        toolCallId: toolCall.id,
+        toolName: toolCall.name,
+      },
+      "tools",
+    );
+    callbacks.appendToolRecord(ctx, {
+      name: toolCall.name,
+      args,
+      result: staleHarnessPreflight.rejectionError,
+      isError: true,
+      durationMs: 0,
+    });
+    return "skip";
   }
   callbacks.emitExecutionTrace(ctx, {
     type: "tool_dispatch_started",
@@ -622,7 +667,14 @@ export async function executeToolCallLoop(
     }
 
     // Recovery hints.
-    const recoveryHints = buildRecoveryHints(roundCalls, new Set<string>());
+    const recoveryHistoryWindow = ctx.allToolCalls.slice(
+      Math.max(0, ctx.allToolCalls.length - 48),
+    );
+    const recoveryHints = buildRecoveryHints(
+      roundCalls,
+      new Set<string>(),
+      recoveryHistoryWindow,
+    );
     callbacks.replaceRuntimeRecoveryHintMessages(ctx, recoveryHints);
     if (recoveryHints.length > 0) {
       callbacks.emitExecutionTrace(ctx, {

--- a/runtime/src/llm/chat-executor-tool-utils.test.ts
+++ b/runtime/src/llm/chat-executor-tool-utils.test.ts
@@ -42,6 +42,20 @@ describe("chat-executor-tool-utils", () => {
       expect(didToolCallFail(false, '{"timedOut":true,"exitCode":null}')).toBe(true);
     });
 
+    it("returns true when shell stderr reports a path/cwd failure despite exitCode 0", () => {
+      expect(
+        didToolCallFail(
+          false,
+          JSON.stringify({
+            stdout: "Running tests...\nCompilation test passed\n",
+            stderr:
+              "run_tests.sh: line 6: cd: build: No such file or directory\n",
+            exitCode: 0,
+          }),
+        ),
+      ).toBe(true);
+    });
+
     it("returns true for MCP plain-text failure signatures", () => {
       expect(
         didToolCallFail(

--- a/runtime/src/llm/chat-executor-tool-utils.ts
+++ b/runtime/src/llm/chat-executor-tool-utils.ts
@@ -34,6 +34,8 @@ const DOOM_VALIDATION_FAILURE_RE =
   /^unknown\s+(?:resolution|screen resolution|scenario|map|skill(?:\s+level)?|wad)\b.*\bvalid:/i;
 const DOOM_RUNTIME_FAILURE_RE =
   /^(?:executor not running\b|no game is running\b|game is not running\b)/i;
+const SHELL_EXECUTION_ANOMALY_RE =
+  /(?:^|\n)(?:[^:\n]+:\s+line\s+\d+:\s+)?(?:(?:ba|z|k)?sh|cd|pushd|popd|source|\.)[^:\n]*:\s+.*(?:no such file or directory|command not found|not found|permission denied|not a directory)/i;
 const DOOM_SCREEN_RESOLUTION_RE = /^(?:RES_)?(\d{2,4})[xX](\d{2,4})$/i;
 const NULLISH_STRING_RE = /^(?:null|none|undefined)$/i;
 const DEFAULT_VISIBLE_DOOM_SCREEN_RESOLUTION = "RES_1280X720";
@@ -80,6 +82,12 @@ export function didToolCallFail(isError: boolean, result: string): boolean {
     }
     if (obj.timedOut === true) return true;
     if (typeof obj.exitCode === "number" && obj.exitCode !== 0) return true;
+    if (
+      typeof obj.stderr === "string" &&
+      SHELL_EXECUTION_ANOMALY_RE.test(obj.stderr)
+    ) {
+      return true;
+    }
   } catch {
     // Non-JSON tool output — detect known tool-wrapper failure signatures.
     return isLikelyFailureText(result);

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -669,6 +669,7 @@ export interface PlannerParseResult {
 export interface PlannerGraphValidationConfig {
   readonly maxSubagentFanout: number;
   readonly maxSubagentDepth: number;
+  readonly workspaceRoot?: string;
 }
 
 export type SubagentVerifierStepVerdict = "pass" | "retry" | "fail";
@@ -863,6 +864,7 @@ export interface ExecutionContext {
   evaluation?: EvaluationResult;
   finalContent: string;
   compacted: boolean;
+  compactedArtifactContext?: ArtifactCompactionState;
   stopReason: LLMPipelineStopReason;
   completionState: WorkflowCompletionState;
   stopReasonDetail?: string;
@@ -1014,6 +1016,7 @@ export function buildDefaultExecutionContext(
     evaluation: undefined,
     finalContent: "",
     compacted: params.compacted,
+    compactedArtifactContext: params.stateful?.artifactContext,
     stopReason: "completed",
     completionState: "completed",
     stopReasonDetail: undefined,

--- a/runtime/src/llm/chat-executor-verifier.test.ts
+++ b/runtime/src/llm/chat-executor-verifier.test.ts
@@ -295,6 +295,26 @@ describe("buildPlannerWorkflowAdmission", () => {
     expect(admission.completionContract?.taskClass).toBe("review_required");
   });
 
+  it("does not treat read-only deterministic implement-from-plan reconnaissance as workflow-owned completion", () => {
+    const admission = buildPlannerWorkflowAdmission({
+      workspaceRoot: "/tmp/project",
+      subagentSteps: [],
+      deterministicSteps: [
+        {
+          name: "read_plan",
+          stepType: "deterministic_tool",
+          tool: "system.readFile",
+          args: { path: "/tmp/project/PLAN.md" },
+        },
+      ],
+    });
+
+    expect(admission.taskClassification).toBe("docs_research_plan_only");
+    expect(admission.completionContract).toBeUndefined();
+    expect(admission.verificationContract).toBeUndefined();
+    expect(admission.requiresMandatoryImplementationVerification).toBe(false);
+  });
+
   it("uses documentation completion verification for delegated plan rewrites", () => {
     const admission = buildPlannerWorkflowAdmission({
       workspaceRoot: "/tmp/project",

--- a/runtime/src/llm/chat-executor-verifier.ts
+++ b/runtime/src/llm/chat-executor-verifier.ts
@@ -1283,16 +1283,17 @@ function buildPlannerWorkflowVerificationContract(params: {
       })
       : undefined
     );
+  const hasWorkflowVerificationSemantics =
+    acceptanceCriteria.length > 0 ||
+    inputArtifacts.length > 0 ||
+    requiredSourceArtifacts.length > 0 ||
+    targetArtifacts.length > 0 ||
+    Boolean(verificationMode) ||
+    Boolean(stepKind) ||
+    Boolean(params.completionContract) ||
+    Boolean(requestCompletion);
   if (
-    !workspaceRoot &&
-    acceptanceCriteria.length === 0 &&
-    inputArtifacts.length === 0 &&
-    requiredSourceArtifacts.length === 0 &&
-    targetArtifacts.length === 0 &&
-    !verificationMode &&
-    !stepKind &&
-    !params.completionContract &&
-    !requestCompletion
+    !hasWorkflowVerificationSemantics
   ) {
     return undefined;
   }

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -17,6 +17,7 @@ import {
   LLMMessageValidationError,
   LLMProviderError,
 } from "./errors.js";
+import { findToolTurnValidationIssue } from "./tool-turn-validator.js";
 import { inferExplicitFileWriteTarget } from "./chat-executor-planner-execution.js";
 import type { ArtifactCompactionState } from "../memory/artifact-store.js";
 import type { Pipeline } from "../workflow/pipeline.js";
@@ -1082,7 +1083,7 @@ describe("ChatExecutor", () => {
 
       expect(result.content).toBe("done");
       expect(result.toolCalls).toHaveLength(2);
-      expect(provider.chat).toHaveBeenCalledTimes(3);
+      expect(provider.chat).toHaveBeenCalledTimes(4);
     });
 
     it("retries once with a correction hint when delegated tool evidence is required", async () => {
@@ -1132,7 +1133,7 @@ describe("ChatExecutor", () => {
       expect(toolHandler).toHaveBeenCalledWith("search", {
         query: "official docs",
       });
-      expect(provider.chat).toHaveBeenCalledTimes(3);
+      expect(provider.chat).toHaveBeenCalledTimes(4);
       expect(
         (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]?.toolChoice,
       ).toBe("required");
@@ -1259,7 +1260,7 @@ describe("ChatExecutor", () => {
         path: "/tmp/tui-smoke/main.c",
         content: "int main(void) { return 0; }\n",
       });
-      expect(provider.chat).toHaveBeenCalledTimes(3);
+      expect(provider.chat).toHaveBeenCalledTimes(4);
       expect(
         (provider.chat as ReturnType<typeof vi.fn>).mock.calls[1]?.[1]?.toolChoice,
       ).toBe("required");
@@ -1411,6 +1412,91 @@ describe("ChatExecutor", () => {
       );
     });
 
+    it("accepts grounded implementation summaries that mention future readiness without reopening the tool loop", async () => {
+      const events: Record<string, unknown>[] = [];
+      const toolHandler = vi.fn().mockResolvedValue("bootstrap complete");
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-bootstrap",
+                  name: "system.writeFile",
+                  arguments: safeJson({
+                    path: "/tmp/agenc-shell-fresh/src/main.c",
+                    content: "int main(void) { return 0; }\n",
+                  }),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content:
+                "Phase 0 (Bootstrap) has been re-implemented from scratch and verified.\n\n" +
+                "Build successful. `./agenc-shell <<< 'exit'` exits cleanly.\n\n" +
+                'No further phases were addressed as only Phase 0 was marked "Fully implemented" in PLAN.md.\n' +
+                "The workspace is ready for incremental development of subsequent phases.",
+            }),
+          ),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        allowedTools: ["system.writeFile", "system.bash"],
+      });
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "In /tmp/agenc-shell-fresh only, complete the bootstrap implementation and stop once that phase is verified.",
+          ),
+          runtimeContext: {
+            workspaceRoot: "/tmp/agenc-shell-fresh",
+          },
+          trace: {
+            onExecutionTraceEvent: (event) => {
+              events.push(event as unknown as Record<string, unknown>);
+            },
+          },
+        }),
+      );
+
+      expect(result.stopReason).toBe("completed");
+      expect(result.content).toContain("Phase 0 (Bootstrap)");
+      expect(provider.chat).toHaveBeenCalledTimes(2);
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "completion_gate_checked",
+            phase: "tool_followup",
+            payload: expect.objectContaining({
+              gate: "plan_only_execution",
+              decision: "accept",
+              executionDeferred: false,
+            }),
+          }),
+        ]),
+      );
+      expect(events).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "completion_gate_checked",
+            phase: "tool_followup",
+            payload: expect.objectContaining({
+              gate: "plan_only_execution",
+              decision: "retry",
+              executionDeferred: true,
+            }),
+          }),
+        ]),
+      );
+    });
+
     it("materializes a runtime-owned workflow contract for direct implementation instead of falling back to legacy compatibility", async () => {
       const events: Record<string, unknown>[] = [];
       const toolHandler = vi.fn().mockResolvedValue("wrote source");
@@ -1461,8 +1547,8 @@ describe("ChatExecutor", () => {
         }),
       );
 
-      expect(result.stopReason).toBe("completed");
-      expect(result.completionState).toBe("completed");
+      expect(result.stopReason).toBe("validation_error");
+      expect(result.completionState).toBe("partial");
       expect(result.completionProgress?.verificationContract).toMatchObject({
         workspaceRoot: "/tmp/phase9-direct",
         targetArtifacts: ["/tmp/phase9-direct/src/main.c"],
@@ -1923,7 +2009,7 @@ describe("ChatExecutor", () => {
 
       expect(result.stopReason).toBe("completed");
       expect(toolHandler).toHaveBeenCalledTimes(1);
-      expect(provider.chat).toHaveBeenCalledTimes(3);
+      expect(provider.chat).toHaveBeenCalledTimes(4);
       const correctionOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
         .calls[2]?.[1] as LLMChatOptions | undefined;
       expect(correctionOptions?.tools).toBeUndefined();
@@ -4743,6 +4829,82 @@ describe("ChatExecutor", () => {
       ]);
     });
 
+    it("preserves delegated initial contract tools across follow-up recalls", async () => {
+      const toolHandler = vi.fn().mockResolvedValue(
+        safeJson({
+          path: "/workspace/agenc-shell/include/shell.h",
+          content: "#ifndef SHELL_H\n#endif\n",
+        }),
+      );
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-1",
+                  name: "system.readFile",
+                  arguments: safeJson({
+                    path: "/workspace/agenc-shell/include/shell.h",
+                  }),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "Summarized the current workspace structure.",
+              finishReason: "stop",
+            }),
+          )
+          .mockResolvedValue(
+            mockResponse({
+              content: "Summarized the current workspace structure.",
+              finishReason: "stop",
+            }),
+          ),
+      });
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        allowedTools: ["system.readFile", "system.listDir"],
+      });
+
+      await executor.execute(
+        createParams({
+          requiredToolEvidence: {
+            maxCorrectionAttempts: 1,
+            delegationSpec: {
+              task: "explore_repository",
+              objective:
+                "List all files in /workspace/agenc-shell and read key files to summarize project structure and guidance",
+              inputContract: "No input - initial exploration",
+              acceptanceCriteria: [
+                "Full directory listing obtained",
+                "Key file contents read and reported",
+              ],
+            },
+          },
+        }),
+      );
+
+      const firstOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[0][1] as LLMChatOptions | undefined;
+      const secondOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[1][1] as LLMChatOptions | undefined;
+      expect(firstOptions?.toolRouting?.allowedToolNames).toEqual([
+        "system.readFile",
+        "system.listDir",
+      ]);
+      expect(secondOptions?.toolRouting?.allowedToolNames).toEqual([
+        "system.readFile",
+        "system.listDir",
+      ]);
+    });
+
     it("passes provider trace callbacks through with logical call metadata", async () => {
       const providerTraceEvents: unknown[] = [];
       const provider = createMockProvider("primary", {
@@ -6102,6 +6264,49 @@ describe("ChatExecutor", () => {
       expect(String(injectedHint?.content)).toContain("desktop.bash");
     });
 
+    it("injects a recovery hint when rm is denied on system.bash", async () => {
+      const toolHandler = vi
+        .fn()
+        .mockResolvedValue('{"error":"Command \\"rm\\" is denied"}');
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "call-1",
+                  name: "system.bash",
+                  arguments: '{"command":"rm","args":["build/agenc-shell"]}',
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(mockResponse({ content: "recovered" })),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        maxToolRounds: 4,
+      });
+      await executor.execute(createParams());
+
+      const secondCallMessages = (provider.chat as ReturnType<typeof vi.fn>)
+        .mock.calls[1][0] as LLMMessage[];
+      const injectedHint = secondCallMessages.find(
+        (msg) =>
+          msg.role === "system" &&
+          typeof msg.content === "string" &&
+          msg.content.includes("Destructive file-deletion commands are blocked"),
+      );
+      expect(injectedHint).toBeDefined();
+      expect(String(injectedHint?.content)).toContain("make clean && make");
+      expect(String(injectedHint?.content)).toContain("clean-first");
+    });
+
     it("injects a recovery hint when filesystem path is outside allowlist", async () => {
       const toolHandler = vi
         .fn()
@@ -6871,6 +7076,43 @@ describe("ChatExecutor", () => {
       expect(result.content).toBe("response after compaction");
     });
 
+    it("uses an explicit no-tool contract for compaction summary calls", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              usage: { promptTokens: 500, completionTokens: 500, totalTokens: 1000 },
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              usage: { promptTokens: 500, completionTokens: 500, totalTokens: 1000 },
+            }),
+          )
+          .mockResolvedValueOnce(mockResponse({ content: "Summary of conversation" }))
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "response after compaction",
+              usage: { promptTokens: 20, completionTokens: 10, totalTokens: 30 },
+            }),
+          ),
+      });
+      const executor = new ChatExecutor({
+        providers: [provider],
+        sessionTokenBudget: 1500,
+      });
+
+      await executor.execute(createParams({ history: buildLongHistory(10) }));
+      await executor.execute(createParams({ history: buildLongHistory(10) }));
+      await executor.execute(createParams({ history: buildLongHistory(10) }));
+
+      const compactionCallOptions = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[2]?.[1];
+      expect(compactionCallOptions?.toolChoice).toBe("none");
+      expect(compactionCallOptions?.toolRouting?.allowedToolNames).toEqual([]);
+      expect(compactionCallOptions?.parallelToolCalls).toBe(false);
+    });
+
     it("preserves exact parent recall output after compaction", async () => {
       const provider = createMockProvider("primary", {
         chat: vi
@@ -7184,6 +7426,120 @@ describe("ChatExecutor", () => {
 
       expect(result.compacted).toBe(true);
       expect(result.content).toBe("response after soft-threshold compaction");
+    });
+
+    it("triggers soft-threshold compaction during a single long tool loop", async () => {
+      const toolHandler = vi
+        .fn()
+        .mockResolvedValueOnce("tool result 1")
+        .mockResolvedValueOnce("tool result 2");
+      const onCompaction = vi.fn();
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [{ id: "tc-1", name: "tool-a", arguments: "{}" }],
+              usage: { promptTokens: 500, completionTokens: 500, totalTokens: 1000 },
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [{ id: "tc-2", name: "tool-b", arguments: "{}" }],
+              usage: { promptTokens: 500, completionTokens: 500, totalTokens: 1000 },
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "Compacted long-running tool state",
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "final after in-flight compaction",
+              usage: { promptTokens: 20, completionTokens: 10, totalTokens: 30 },
+            }),
+          ),
+      });
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        sessionTokenBudget: 0,
+        sessionCompactionThreshold: 1500,
+        onCompaction,
+      });
+
+      const result = await executor.execute(createParams());
+
+      expect(result.compacted).toBe(true);
+      expect(result.content).toBe("final after in-flight compaction");
+      expect(result.toolCalls).toHaveLength(2);
+      expect(toolHandler).toHaveBeenCalledTimes(2);
+      expect(onCompaction).toHaveBeenCalledOnce();
+      expect(onCompaction).toHaveBeenCalledWith(
+        "session-1",
+        "Compacted long-running tool state",
+      );
+      expect(provider.chat).toHaveBeenCalledTimes(4);
+      expect(executor.getSessionTokenUsage("session-1")).toBe(30);
+    });
+
+    it("preserves valid tool-turn replay boundaries during in-flight compaction", async () => {
+      const toolHandler = vi
+        .fn()
+        .mockResolvedValueOnce("tool result 1")
+        .mockResolvedValueOnce("tool result 2");
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [{ id: "tc-1", name: "tool-a", arguments: "{}" }],
+              usage: { promptTokens: 500, completionTokens: 500, totalTokens: 1000 },
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [{ id: "tc-2", name: "tool-b", arguments: "{}" }],
+              usage: { promptTokens: 500, completionTokens: 500, totalTokens: 1000 },
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "Compacted long-running tool state",
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "final after safe in-flight compaction",
+              usage: { promptTokens: 20, completionTokens: 10, totalTokens: 30 },
+            }),
+          ),
+      });
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        sessionTokenBudget: 0,
+        sessionCompactionThreshold: 1500,
+      });
+
+      const result = await executor.execute(createParams());
+
+      expect(result.compacted).toBe(true);
+      expect(result.content).toBe("final after safe in-flight compaction");
+      expect(provider.chat).toHaveBeenCalledTimes(4);
+
+      const compactedFollowUpMessages = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[3]?.[0] as LLMMessage[];
+      expect(findToolTurnValidationIssue(compactedFollowUpMessages)).toBeNull();
     });
 
     it("treats soft-threshold compaction failures as best-effort when the hard budget is unlimited", async () => {
@@ -7998,7 +8354,7 @@ describe("ChatExecutor", () => {
       expect(result.callUsage.map((entry) => entry.phase)).toEqual(["initial"]);
       expect(result.plannerSummary?.used).toBe(false);
       expect(result.plannerSummary?.routeReason).toBe("exact_response_turn");
-      expect(provider.chat).toHaveBeenCalledTimes(1);
+      expect(provider.chat).toHaveBeenCalledTimes(3);
       expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]).toMatchObject({
         toolChoice: "none",
         toolRouting: { allowedToolNames: [] },
@@ -8036,7 +8392,7 @@ describe("ChatExecutor", () => {
       expect(result.callUsage.map((entry) => entry.phase)).toEqual(["initial"]);
       expect(result.plannerSummary?.used).toBe(false);
       expect(result.plannerSummary?.routeReason).toBe("exact_response_turn");
-      expect(provider.chat).toHaveBeenCalledTimes(1);
+      expect(provider.chat).toHaveBeenCalledTimes(3);
       expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]).toMatchObject({
         toolChoice: "none",
         toolRouting: { allowedToolNames: [] },
@@ -8160,6 +8516,11 @@ describe("ChatExecutor", () => {
       const provider = createMockProvider("primary", {
         chat: vi
           .fn()
+          .mockResolvedValue(
+            mockResponse({
+              content: "unexpected fallback",
+            }),
+          )
           .mockResolvedValueOnce(
             mockResponse({
               content: safeJson({
@@ -8411,7 +8772,7 @@ describe("ChatExecutor", () => {
         }),
       );
 
-      expect(provider.chat).toHaveBeenCalledTimes(1);
+      expect(provider.chat).toHaveBeenCalledTimes(3);
       expect(pipelineExecutor.execute).toHaveBeenCalledTimes(1);
       expect(result.callUsage.map((entry) => entry.phase)).toEqual(["planner"]);
       expect(result.content).toBe("A1_R1_DONE");
@@ -8512,7 +8873,7 @@ describe("ChatExecutor", () => {
         }),
       );
 
-      expect(provider.chat).toHaveBeenCalledTimes(1);
+      expect(provider.chat).toHaveBeenCalledTimes(3);
       expect(pipelineExecutor.execute).toHaveBeenCalledTimes(1);
       expect(result.callUsage.map((entry) => entry.phase)).toEqual(["planner"]);
       expect(result.stopReason).toBe("completed");
@@ -9256,6 +9617,10 @@ describe("ChatExecutor", () => {
         toolHandler: vi.fn().mockResolvedValue("unused"),
         plannerEnabled: true,
         pipelineExecutor: pipelineExecutor as any,
+        delegationDecision: {
+          enabled: true,
+          scoreThreshold: 0.2,
+        },
         subagentVerifier: {
           enabled: false,
           force: false,
@@ -10559,7 +10924,7 @@ describe("ChatExecutor", () => {
       // it can consume an extra direct-execution model turn.
       expect(provider.chat).toHaveBeenCalledTimes(1);
       expect(result.stopReason).toBe("validation_error");
-      expect(result.completionState).toBe("blocked");
+      expect(result.completionState).toBe("partial");
     });
 
     it("continues repair-focused replans across distinct deterministic failure signatures", async () => {
@@ -11756,6 +12121,439 @@ describe("ChatExecutor", () => {
         toolChoice: "none",
         toolRouting: { allowedToolNames: [] },
       });
+    });
+
+    it("fails planner synthesis when it invents fenced tool-call markup that never executed", async () => {
+      const workspaceRoot = "/home/tetsuo/git/stream-test/agenc-shell";
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: safeJson({
+                reason: "plan_artifact_execution_request",
+                requiresSynthesis: true,
+                steps: [
+                  {
+                    name: "read_plan",
+                    step_type: "deterministic_tool",
+                    tool: "system.readFile",
+                    args: {
+                      path: `${workspaceRoot}/PLAN.md`,
+                    },
+                  },
+                ],
+              }),
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content:
+                "First, let's verify the current state and read key files.\n" +
+                "```tool: system.readFile\n" +
+                '{ "path": "include/shell.h" }\n' +
+                "```",
+            }),
+          ),
+      });
+      const pipelineExecutor = {
+        execute: vi.fn().mockResolvedValue({
+          status: "completed",
+          completionState: "completed",
+          context: {
+            results: {
+              read_plan: safeJson({
+                path: `${workspaceRoot}/PLAN.md`,
+                size: 4096,
+              }),
+            },
+          },
+          completedSteps: 1,
+          totalSteps: 1,
+        }),
+      };
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+        delegationDecision: {
+          enabled: true,
+          scoreThreshold: 0.2,
+        },
+        subagentVerifier: {
+          enabled: false,
+          force: false,
+        },
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Read @PLAN.md and summarize the current implementation status before choosing next steps.",
+          ),
+          runtimeContext: {
+            workspaceRoot,
+          },
+        }),
+      );
+
+      expect(provider.chat).toHaveBeenCalledTimes(2);
+      expect(result.callUsage.map((entry) => entry.phase)).toEqual([
+        "planner",
+        "planner_synthesis",
+      ]);
+      expect(result.stopReason).toBe("validation_error");
+      expect(result.completionState).not.toBe("completed");
+      expect(result.stopReasonDetail).toContain(
+        "Planner synthesis emitted tool-call markup that was not executed",
+      );
+      expect(result.content).toContain("Missing executed tool calls: system.readFile");
+      expect(result.plannerSummary?.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "planner_synthesis_unexecuted_tool_markup",
+          }),
+        ]),
+      );
+    });
+
+    it("runtime-repairs a read-only implement-from-plan planner collapse into a canonical writer workflow", async () => {
+      const workspaceRoot = "/home/tetsuo/git/stream-test/agenc-shell";
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: safeJson({
+              reason: "plan_artifact_execution_request",
+              requiresSynthesis: false,
+              steps: [
+                {
+                  name: "read_plan",
+                  step_type: "deterministic_tool",
+                  tool: "system.readFile",
+                  args: {
+                    path: `${workspaceRoot}/PLAN.md`,
+                  },
+                },
+              ],
+            }),
+          }),
+        ),
+      });
+      const pipelineExecutor = {
+        execute: vi.fn().mockResolvedValue({
+          status: "completed",
+          completionState: "completed",
+          context: {
+            results: {
+              read_plan: safeJson({
+                path: `${workspaceRoot}/PLAN.md`,
+                size: 4096,
+              }),
+              implement_owner: completedDelegatedPlannerResult(
+                "Implemented the requested phase work and verified the workspace.",
+                [
+                  {
+                    name: "system.readFile",
+                    args: {
+                      path: `${workspaceRoot}/PLAN.md`,
+                    },
+                  },
+                  {
+                    name: "system.writeFile",
+                    args: {
+                      path: `${workspaceRoot}/src/lexer.c`,
+                      content: "lexer changes\n",
+                    },
+                  },
+                  {
+                    name: "system.bash",
+                    args: {
+                      command: "make",
+                      args: ["test"],
+                      cwd: workspaceRoot,
+                    },
+                    result: safeJson({
+                      exitCode: 0,
+                      stdout: "tests passed",
+                    }),
+                  },
+                ],
+              ),
+            },
+          },
+          completedSteps: 2,
+          totalSteps: 2,
+        }),
+      };
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+        delegationDecision: {
+          enabled: true,
+          scoreThreshold: 0.2,
+        },
+        subagentVerifier: {
+          enabled: false,
+          force: false,
+        },
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Can you go through @PLAN.md and implement it in full. Make sure each phase is fully tested and working before moving on.",
+          ),
+          runtimeContext: {
+            workspaceRoot,
+          },
+        }),
+      );
+
+      expect(provider.chat).toHaveBeenCalledTimes(4);
+      expect(pipelineExecutor.execute).toHaveBeenCalledTimes(1);
+      const pipelineArg = pipelineExecutor.execute.mock.calls[0]?.[0];
+      expect(pipelineArg?.plannerSteps).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: "implement_owner",
+            stepType: "subagent_task",
+            requiredToolCapabilities: [
+              "system.readFile",
+              "system.writeFile",
+              "system.bash",
+            ],
+            executionContext: expect.objectContaining({
+              workspaceRoot,
+              verificationMode: "mutation_required",
+              stepKind: "delegated_write",
+              targetArtifacts: [workspaceRoot],
+            }),
+          }),
+        ]),
+      );
+      expect(result.stopReason).toBe("validation_error");
+      expect(result.completionState).toBe("partial");
+      expect(result.plannerSummary?.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "planner_implementation_missing_mutation_path",
+          }),
+          expect.objectContaining({
+            code: "planner_step_contract_retry",
+          }),
+          expect.objectContaining({
+            code: "planner_runtime_repair_single_owner_contract",
+          }),
+        ]),
+      );
+    });
+
+    it("does not crash planner validation when only the resolved host workspace root is available", async () => {
+      const workspaceRoot = "/home/tetsuo/git/stream-test/agenc-shell";
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: safeJson({
+              reason: "plan_artifact_execution_request",
+              requiresSynthesis: false,
+              steps: [
+                {
+                  name: "read_plan",
+                  step_type: "deterministic_tool",
+                  tool: "system.readFile",
+                  args: {
+                    path: `${workspaceRoot}/PLAN.md`,
+                  },
+                },
+              ],
+            }),
+          }),
+        ),
+      });
+      const pipelineExecutor = {
+        execute: vi.fn().mockResolvedValue({
+          status: "completed",
+          completionState: "completed",
+          context: {
+            results: {
+              read_plan: safeJson({
+                path: `${workspaceRoot}/PLAN.md`,
+                size: 4096,
+              }),
+              implement_owner: completedDelegatedPlannerResult(
+                "Implemented the requested phase work and verified the workspace.",
+                [
+                  {
+                    name: "system.readFile",
+                    args: {
+                      path: `${workspaceRoot}/PLAN.md`,
+                    },
+                  },
+                  {
+                    name: "system.writeFile",
+                    args: {
+                      path: `${workspaceRoot}/src/lexer.c`,
+                      content: "lexer changes\n",
+                    },
+                  },
+                ],
+              ),
+            },
+          },
+          completedSteps: 2,
+          totalSteps: 2,
+        }),
+      };
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+        resolveHostWorkspaceRoot: () => workspaceRoot,
+        delegationDecision: {
+          enabled: true,
+          scoreThreshold: 0.2,
+        },
+        subagentVerifier: {
+          enabled: false,
+          force: false,
+        },
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Can you go through @PLAN.md and implement it in full. Make sure each phase is fully tested and working before moving on.",
+          ),
+        }),
+      );
+
+      expect(result.stopReason).not.toBe("provider_error");
+      expect(result.stopReasonDetail).not.toContain("workspaceRoot");
+      expect(result.stopReason).toBe("validation_error");
+      expect(result.completionState).toBe("partial");
+      expect(pipelineExecutor.execute).toHaveBeenCalledTimes(1);
+      expect(result.plannerSummary?.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "planner_implementation_missing_mutation_path",
+          }),
+        ]),
+      );
+    });
+
+    it("runtime-repairs a transient planner provider outage into a canonical writer workflow", async () => {
+      const workspaceRoot = "/home/tetsuo/git/stream-test/agenc-shell";
+      const provider = createMockProvider("primary");
+      provider.chat = vi
+        .fn()
+        .mockRejectedValue(
+          new LLMServerError(
+            "grok",
+            503,
+            "upstream connect error: delayed connect error: Connection refused",
+          ),
+        );
+      const pipelineExecutor = {
+        execute: vi.fn().mockResolvedValue({
+          status: "completed",
+          completionState: "completed",
+          context: {
+            results: {
+              implement_owner: completedDelegatedPlannerResult(
+                "Implemented the requested phase work and verified the workspace.",
+                [
+                  {
+                    name: "system.readFile",
+                    args: {
+                      path: `${workspaceRoot}/PLAN.md`,
+                    },
+                  },
+                  {
+                    name: "system.writeFile",
+                    args: {
+                      path: `${workspaceRoot}/src/lexer.c`,
+                      content: "lexer changes\n",
+                    },
+                  },
+                  {
+                    name: "system.bash",
+                    args: {
+                      command: "make",
+                      args: ["test"],
+                      cwd: workspaceRoot,
+                    },
+                    result: safeJson({
+                      exitCode: 0,
+                      stdout: "tests passed",
+                    }),
+                  },
+                ],
+              ),
+            },
+          },
+          completedSteps: 1,
+          totalSteps: 1,
+        }),
+      };
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+        delegationDecision: {
+          enabled: true,
+          scoreThreshold: 0.2,
+        },
+        subagentVerifier: {
+          enabled: false,
+          force: false,
+        },
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Can you go through @PLAN.md and implement it in full. Make sure each phase is fully tested and working before moving on.",
+          ),
+          runtimeContext: {
+            workspaceRoot,
+          },
+        }),
+      );
+
+      expect(pipelineExecutor.execute).toHaveBeenCalledTimes(1);
+      expect(provider.chat).toHaveBeenCalledTimes(3);
+      const pipelineArg = pipelineExecutor.execute.mock.calls[0]?.[0];
+      expect(pipelineArg?.plannerSteps).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: "implement_owner",
+            stepType: "subagent_task",
+            executionContext: expect.objectContaining({
+              workspaceRoot,
+              verificationMode: "mutation_required",
+              stepKind: "delegated_write",
+              targetArtifacts: [workspaceRoot],
+            }),
+          }),
+        ]),
+      );
+      expect(result.stopReason).toBe("validation_error");
+      expect(result.completionState).toBe("partial");
+      expect(result.plannerSummary?.routeReason).toBe(
+        "runtime_repaired_single_owner_planner_unavailable_execution",
+      );
+      expect(result.plannerSummary?.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "planner_runtime_repair_provider_unavailable",
+          }),
+        ]),
+      );
     });
 
     it("maps failed subagent pipeline stopReasonHint into parent stopReason semantics", async () => {
@@ -16125,6 +16923,203 @@ describe("ChatExecutor", () => {
       );
     });
 
+    it("refines analysis-only implement-from-plan plans before any freeform tool loop fallback", async () => {
+      const events: Record<string, unknown>[] = [];
+      const workspaceRoot = "/tmp/agenc-shell";
+      const invalidAnalysisOnlyPlan = mockResponse({
+        content: safeJson({
+          reason: "implement_from_plan",
+          requiresSynthesis: false,
+          steps: [
+            {
+              name: "read_plan",
+              step_type: "deterministic_tool",
+              tool: "system.readFile",
+              args: {
+                path: `${workspaceRoot}/PLAN.md`,
+              },
+            },
+            {
+              name: "phase1_analysis",
+              step_type: "subagent_task",
+              depends_on: ["read_plan"],
+              objective:
+                "Analyze PLAN.md to identify Phase 1 work. Do not implement code yet.",
+              input_contract: "PLAN.md plus the existing source tree.",
+              acceptance_criteria: [
+                "No code changes; output is analysis only.",
+              ],
+              required_tool_capabilities: [
+                "system.readFile",
+                "system.listDir",
+              ],
+              context_requirements: ["read_plan"],
+              execution_context: plannerReadOnlyExecutionContext(
+                workspaceRoot,
+                {
+                  sourceArtifacts: ["PLAN.md"],
+                  stepKind: "delegated_research",
+                },
+              ),
+              max_budget_hint: "2m",
+              can_run_parallel: false,
+            },
+          ],
+        }),
+      });
+      const refinedMutablePlan = mockResponse({
+        content: safeJson({
+          reason: "implement_from_plan",
+          requiresSynthesis: false,
+          steps: [
+            {
+              name: "read_plan",
+              step_type: "deterministic_tool",
+              tool: "system.readFile",
+              args: {
+                path: `${workspaceRoot}/PLAN.md`,
+              },
+            },
+            {
+              name: "implement_phase_1",
+              step_type: "subagent_task",
+              depends_on: ["read_plan"],
+              objective:
+                "Implement Phase 1 from PLAN.md in the workspace and verify the result.",
+              input_contract: "PLAN.md plus the existing source tree.",
+              acceptance_criteria: [
+                "Phase 1 implementation is present in workspace files.",
+                "Verification passes for the updated phase.",
+              ],
+              required_tool_capabilities: [
+                "system.readFile",
+                "system.writeFile",
+                "system.bash",
+              ],
+              context_requirements: ["read_plan"],
+              execution_context: plannerWriteExecutionContext(
+                workspaceRoot,
+                {
+                  sourceArtifacts: ["PLAN.md"],
+                  targetArtifacts: ["src/lexer.c", "include/shell.h"],
+                  effectClass: "filesystem_write",
+                  verificationMode: "mutation_required",
+                  stepKind: "delegated_write",
+                },
+              ),
+              max_budget_hint: "20m",
+              can_run_parallel: false,
+            },
+          ],
+        }),
+      });
+      let plannerCallCount = 0;
+      const provider = createMockProvider("primary", {
+        chat: vi.fn(async () => {
+          plannerCallCount += 1;
+          return plannerCallCount === 1
+            ? invalidAnalysisOnlyPlan
+            : refinedMutablePlan;
+        }),
+      });
+      const pipelineExecutor = {
+        execute: vi.fn().mockResolvedValue({
+          status: "completed",
+          context: {
+            results: {
+              read_plan: safeJson({
+                path: `${workspaceRoot}/PLAN.md`,
+                content: "# Plan",
+              }),
+              implement_phase_1: completedDelegatedPlannerResult(
+                "Phase 1 implemented and verified.",
+                [
+                  {
+                    name: "system.writeFile",
+                    args: {
+                      path: `${workspaceRoot}/src/lexer.c`,
+                    },
+                  },
+                  {
+                    name: "system.bash",
+                    args: {
+                      command: "make",
+                      args: ["test"],
+                      cwd: workspaceRoot,
+                    },
+                    result: safeJson({ exitCode: 0, stdout: "tests passed" }),
+                  },
+                ],
+              ),
+            },
+          },
+          completedSteps: 2,
+          totalSteps: 2,
+        }),
+      };
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+        delegationDecision: {
+          enabled: true,
+          scoreThreshold: 0.2,
+        },
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: {
+            ...createMessage(
+              "Can you go through @PLAN.md and implement every phase sequentially in full and make sure they are fully tested.",
+            ),
+            metadata: undefined,
+          } as GatewayMessage,
+          runtimeContext: {
+            workspaceRoot,
+          },
+          trace: {
+            onExecutionTraceEvent: (event) => {
+              events.push(event as unknown as Record<string, unknown>);
+            },
+          },
+        }),
+      );
+
+      expect(plannerCallCount).toBeGreaterThanOrEqual(2);
+      expect(pipelineExecutor.execute).toHaveBeenCalledTimes(1);
+      expect(result.content).not.toContain(
+        "Inline legacy fallback is disabled",
+      );
+      expect(result.plannerSummary?.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            category: "validation",
+            code: "planner_implementation_missing_mutation_path",
+          }),
+          expect.objectContaining({
+            category: "policy",
+            code: "planner_step_contract_retry",
+          }),
+        ]),
+      );
+      expect(
+        events.some((event) => event.type === "planner_pipeline_started"),
+      ).toBe(true);
+      expect(
+        events.some((event) =>
+          event.type === "planner_path_finished" &&
+          event.phase === "planner" &&
+          typeof (event.payload as { routeReason?: unknown })?.routeReason === "string" &&
+          /^delegation_veto_/.test(
+            String((event.payload as { routeReason?: unknown }).routeReason),
+          ) &&
+          (event.payload as { handled?: unknown })?.handled === false
+        ),
+      ).toBe(false);
+    });
+
     it("does not mark planner-owned multi-phase work completed when request milestones remain", async () => {
       const provider = createMockProvider("primary");
       const executor = new ChatExecutor({
@@ -19874,7 +20869,7 @@ describe("ChatExecutor", () => {
       );
     });
 
-    it("fails closed before execution when preserved state cannot be honored by the route", async () => {
+    it("fails closed before execution when explicit preserved state cannot be honored by the route", async () => {
       const provider = createMockProvider("ollama", {
         getCapabilities: () => ({
           provider: "ollama",
@@ -19899,10 +20894,51 @@ describe("ChatExecutor", () => {
               ...createMessage("continue"),
               sessionId: "stateful-unavailable",
             },
+            stateful: {
+              resumeAnchor: {
+                previousResponseId: "resp_prev_123",
+              },
+            },
           }),
         ),
       ).rejects.toThrow(/stateful continuation/i);
       expect(provider.chat).not.toHaveBeenCalled();
+    });
+
+    it("does not require preserved-state routing on a fresh custom-tool initial turn", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: "fresh child request accepted",
+          }),
+        ),
+      });
+      const executor = new ChatExecutor({
+        providers: [provider],
+        allowedTools: ["system.readFile", "system.writeFile", "system.bash"],
+      });
+
+      const result = await executor.execute(
+        createParams({
+          sessionId: "fresh-custom-tools",
+          message: {
+            ...createMessage(
+              "Inspect the workspace and summarize what is present before choosing next steps.",
+            ),
+            sessionId: "fresh-custom-tools",
+          },
+          toolRouting: {
+            routedToolNames: [
+              "system.readFile",
+              "system.writeFile",
+              "system.bash",
+            ],
+          },
+        }),
+      );
+
+      expect(provider.chat).toHaveBeenCalledTimes(1);
+      expect(result.content).toContain("fresh child request accepted");
     });
 
     it("passes the full normalized history into reconciliationMessages", async () => {

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -45,6 +45,7 @@ import { deriveWorkflowProgressSnapshot } from "../workflow/completion-progress.
 import { isDocumentationArtifactPath } from "../workflow/artifact-paths.js";
 import {
   buildModelRoutingPolicy,
+  getProviderRouteKey,
   resolveParallelToolCallPolicy,
   resolveModelRoute,
   type ModelRoutingPolicy,
@@ -684,7 +685,6 @@ export class ChatExecutor {
     this.enforceLegacyCompletionCompatibilityBeforeFinalization(ctx);
 
     this.checkRequestTimeout(ctx, "finalization");
-    this.trackTokenUsage(ctx.sessionId, ctx.cumulativeUsage.totalTokens);
     this.synchronizeCompletionState(ctx);
 
     // Optional response evaluation (critic)
@@ -1941,6 +1941,12 @@ export class ChatExecutor {
     } else {
       ctx.transientRoutedToolNames = effectiveRoutedToolNames;
     }
+    const compactedCallInput = await this.maybeCompactInFlightCallInput(ctx, {
+      callMessages: input.callMessages,
+      callReconciliationMessages: input.callReconciliationMessages,
+      callSections: input.callSections,
+      statefulHistoryCompacted: input.statefulHistoryCompacted,
+    });
     const groundingMessage =
       input.phase === "tool_followup" || input.phase === "planner_synthesis"
         ? buildToolExecutionGroundingMessage({
@@ -1949,21 +1955,30 @@ export class ChatExecutor {
         })
         : undefined;
     const effectiveCallMessages = groundingMessage
-      ? [...input.callMessages, groundingMessage]
-      : [...input.callMessages];
-    const effectiveCallSections = groundingMessage && input.callSections
-      ? [...input.callSections, "system_runtime" as const]
-      : input.callSections;
+      ? [...compactedCallInput.callMessages, groundingMessage]
+      : [...compactedCallInput.callMessages];
+    const effectiveCallSections =
+      groundingMessage && compactedCallInput.callSections
+        ? [...compactedCallInput.callSections, "system_runtime" as const]
+        : compactedCallInput.callSections;
     const requestedStructuredOutput =
       input.structuredOutput?.enabled === false ||
         input.structuredOutput?.schema === undefined
         ? undefined
         : input.structuredOutput;
+    const statefulContinuationRequired =
+      allowStatefulContinuation &&
+      Boolean(input.statefulSessionId) &&
+      (
+        input.phase === "tool_followup" ||
+        Boolean(input.statefulResumeAnchor) ||
+        compactedCallInput.statefulHistoryCompacted === true ||
+        ctx.history.length > 0
+      );
     let routingDecision: ReturnType<ChatExecutor["resolveRoutingDecision"]>;
     try {
       routingDecision = this.resolveRoutingDecision(ctx, input.phase, {
-        statefulContinuationRequired:
-          allowStatefulContinuation && Boolean(input.statefulSessionId),
+        statefulContinuationRequired,
         structuredOutputRequired: requestedStructuredOutput !== undefined,
         routedToolNames: effectiveRoutedToolNames,
       });
@@ -1978,6 +1993,7 @@ export class ChatExecutor {
     const parallelToolCalls = resolveParallelToolCallPolicy({
       policy: this.modelRoutingPolicy,
       selectedProviderName: routingDecision.route.selectedProviderName,
+      selectedProviderRouteKey: routingDecision.route.selectedProviderRouteKey,
       phase: input.phase,
     });
     const structuredOutput =
@@ -2026,7 +2042,9 @@ export class ChatExecutor {
         activeRouteMisses: ctx.routedToolMisses,
         routedToolsExpanded: ctx.routedToolsExpanded,
         economicsRunClass: routingDecision.runClass,
-        providerRoute: routingDecision.route.providers.map((provider) => provider.name),
+        providerRoute: routingDecision.route.providers.map((provider) =>
+          getProviderRouteKey(provider)
+        ),
         providerRouteReason: routingDecision.route.reason,
         budgetPressure: {
           tokenRatio: Number(routingDecision.pressure.tokenRatio.toFixed(4)),
@@ -2050,8 +2068,9 @@ export class ChatExecutor {
             ? {
               statefulSessionId: input.statefulSessionId,
               reconciliationMessages:
-                input.callReconciliationMessages ?? ctx.reconciliationMessages,
-              ...(input.statefulHistoryCompacted
+                compactedCallInput.callReconciliationMessages ??
+                ctx.reconciliationMessages,
+              ...(compactedCallInput.statefulHistoryCompacted
                 ? { statefulHistoryCompacted: true }
                 : {}),
               ...(input.statefulResumeAnchor
@@ -2096,6 +2115,7 @@ export class ChatExecutor {
     );
     if (next.usedFallback) ctx.usedFallback = true;
     this.accumulateUsage(ctx.cumulativeUsage, next.response.usage);
+    this.trackTokenUsage(ctx.sessionId, next.response.usage.totalTokens);
     recordRuntimeModelCall({
       policy: this.economicsPolicy,
       state: ctx.economicsState,
@@ -2443,6 +2463,186 @@ export class ChatExecutor {
     );
 
     return ctx;
+  }
+
+  private async maybeCompactInFlightCallInput(
+    ctx: ExecutionContext,
+    input: {
+      readonly callMessages: readonly LLMMessage[];
+      readonly callReconciliationMessages?: readonly LLMMessage[];
+      readonly callSections?: readonly PromptBudgetSection[];
+      readonly statefulHistoryCompacted?: boolean;
+    },
+  ): Promise<{
+    readonly callMessages: readonly LLMMessage[];
+    readonly callReconciliationMessages?: readonly LLMMessage[];
+    readonly callSections?: readonly PromptBudgetSection[];
+    readonly statefulHistoryCompacted: boolean;
+  }> {
+    const compactionState = this.getSessionCompactionState(ctx.sessionId);
+    const statefulHistoryCompacted =
+      input.statefulHistoryCompacted === true || ctx.compacted;
+    if (
+      !compactionState.hardBudgetReached &&
+      !compactionState.softThresholdReached
+    ) {
+      return {
+        callMessages: input.callMessages,
+        callReconciliationMessages: input.callReconciliationMessages,
+        callSections: input.callSections,
+        statefulHistoryCompacted,
+      };
+    }
+
+    const usesLiveExecutionMessages =
+      input.callMessages === ctx.messages &&
+      (
+        input.callSections === undefined ||
+        input.callSections === ctx.messageSections
+      ) &&
+      (
+        input.callReconciliationMessages === undefined ||
+        input.callReconciliationMessages === ctx.reconciliationMessages
+      );
+    if (!usesLiveExecutionMessages) {
+      if (compactionState.hardBudgetReached) {
+        throw new ChatBudgetExceededError(
+          ctx.sessionId,
+          compactionState.used,
+          this.sessionTokenBudget!,
+        );
+      }
+      return {
+        callMessages: input.callMessages,
+        callReconciliationMessages: input.callReconciliationMessages,
+        callSections: input.callSections,
+        statefulHistoryCompacted,
+      };
+    }
+
+    const replayTailStartIndex = this.findInFlightCompactionTailStartIndex(
+      input.callMessages,
+      input.callSections,
+    );
+    const replayTail = input.callMessages.slice(replayTailStartIndex);
+    const inFlightKeepTailCount = 3;
+    if (replayTail.length <= inFlightKeepTailCount) {
+      if (compactionState.hardBudgetReached) {
+        throw new ChatBudgetExceededError(
+          ctx.sessionId,
+          compactionState.used,
+          this.sessionTokenBudget!,
+        );
+      }
+      return {
+        callMessages: input.callMessages,
+        callReconciliationMessages: input.callReconciliationMessages,
+        callSections: input.callSections,
+        statefulHistoryCompacted,
+      };
+    }
+
+    const cooldownSnapshot = compactionState.hardBudgetReached
+      ? undefined
+      : new Map(this.cooldowns);
+    try {
+      const compacted = await this.compactHistory(
+        replayTail,
+        ctx.sessionId,
+        ctx.trace,
+        ctx.compactedArtifactContext,
+        inFlightKeepTailCount,
+      );
+      const retainedTailCount = Math.max(0, compacted.history.length - 1);
+      const replayTailReconciliationMessages = (
+        input.callReconciliationMessages ?? ctx.reconciliationMessages
+      ).slice(replayTailStartIndex);
+      const replayTailSections = (
+        input.callSections ?? ctx.messageSections
+      ).slice(replayTailStartIndex);
+      const compactedReconciliationMessages: readonly LLMMessage[] = [
+        {
+          role: "system",
+          content:
+            typeof compacted.history[0]?.content === "string"
+              ? compacted.history[0].content
+              : "",
+        },
+        ...replayTailReconciliationMessages.slice(-retainedTailCount),
+      ];
+      const compactedSections: readonly PromptBudgetSection[] = [
+        "memory_working",
+        ...replayTailSections.slice(-retainedTailCount),
+      ];
+      const nextMessages = [
+        ...input.callMessages.slice(0, replayTailStartIndex),
+        ...compacted.history,
+      ];
+      const nextReconciliationMessages = [
+        ...(input.callReconciliationMessages ?? ctx.reconciliationMessages).slice(
+          0,
+          replayTailStartIndex,
+        ),
+        ...compactedReconciliationMessages,
+      ];
+      const nextSections = [
+        ...(input.callSections ?? ctx.messageSections).slice(
+          0,
+          replayTailStartIndex,
+        ),
+        ...compactedSections,
+      ];
+      ctx.messages = [...nextMessages];
+      ctx.reconciliationMessages = [...nextReconciliationMessages];
+      ctx.messageSections = [...nextSections];
+      ctx.compacted = true;
+      ctx.compactedArtifactContext = compacted.artifactContext;
+      this.resetSessionTokens(ctx.sessionId);
+      return {
+        callMessages: ctx.messages,
+        callReconciliationMessages: ctx.reconciliationMessages,
+        callSections: ctx.messageSections,
+        statefulHistoryCompacted: true,
+      };
+    } catch (error) {
+      if (compactionState.hardBudgetReached) {
+        if (error instanceof ChatBudgetExceededError) {
+          throw error;
+        }
+        throw new ChatBudgetExceededError(
+          ctx.sessionId,
+          compactionState.used,
+          this.sessionTokenBudget!,
+        );
+      }
+      if (cooldownSnapshot) {
+        this.cooldowns.clear();
+        for (const [providerName, cooldown] of cooldownSnapshot.entries()) {
+          this.cooldowns.set(providerName, cooldown);
+        }
+      }
+      return {
+        callMessages: input.callMessages,
+        callReconciliationMessages: input.callReconciliationMessages,
+        callSections: input.callSections,
+        statefulHistoryCompacted,
+      };
+    }
+  }
+
+  private findInFlightCompactionTailStartIndex(
+    messages: readonly LLMMessage[],
+    sections?: readonly PromptBudgetSection[],
+  ): number {
+    for (let index = messages.length - 1; index >= 0; index--) {
+      if (
+        sections?.[index] === "user" ||
+        messages[index]?.role === "user"
+      ) {
+        return index + 1;
+      }
+    }
+    return messages.length;
   }
 
   private recordOutcomeAndFinalize(ctx: ExecutionContext): {
@@ -3138,8 +3338,10 @@ export class ChatExecutor {
     sessionId: string,
     trace?: ChatExecuteParams["trace"],
     existingArtifactContext?: ArtifactCompactionState,
+    keepTailCount?: number,
   ): Promise<{ history: readonly LLMMessage[]; artifactContext?: ArtifactCompactionState }> {
-    if (history.length <= 5) {
+    const effectiveKeepTailCount = Math.max(1, keepTailCount ?? 5);
+    if (history.length <= effectiveKeepTailCount) {
       return {
         history: [...history],
         artifactContext: existingArtifactContext,
@@ -3147,7 +3349,7 @@ export class ChatExecutor {
     }
 
     let narrativeSummary: string | undefined;
-    const toSummarize = history.slice(0, history.length - 5);
+    const toSummarize = history.slice(0, history.length - effectiveKeepTailCount);
     let historyText = toSummarize
       .map((message) => {
         const content =
@@ -3169,7 +3371,9 @@ export class ChatExecutor {
           {
             role: "system",
             content:
-              "Summarize only the durable task state from this history. Preserve key decisions, important tool outcomes, current artifacts, and unresolved work. Omit pleasantries.",
+              "Summarize only the durable task state from this history. Preserve key decisions, important tool outcomes, current artifacts, explicit blockers, and unfinished implementation or verification work. " +
+              "If the history contains stubs, placeholders, partial work, denied commands, or anything still needing verification, list that as unresolved work. " +
+              "Never say there is no unresolved work unless the history explicitly shows final completion and verification closure. Omit pleasantries.",
           },
           { role: "user", content: historyText },
         ],
@@ -3183,6 +3387,9 @@ export class ChatExecutor {
                 callPhase: "compaction" as const,
               }
             : {}),
+          routedToolNames: [],
+          toolChoice: "none",
+          parallelToolCalls: false,
         },
       );
       narrativeSummary = compactResponse.response.content.trim() || undefined;
@@ -3193,7 +3400,7 @@ export class ChatExecutor {
     const compacted = compactHistoryIntoArtifactContext({
       sessionId,
       history,
-      keepTailCount: 5,
+      keepTailCount: effectiveKeepTailCount,
       source: "executor_compaction",
       existingState: existingArtifactContext,
       ...(narrativeSummary ? { narrativeSummary } : {}),

--- a/runtime/src/llm/context-compaction.test.ts
+++ b/runtime/src/llm/context-compaction.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import { compactHistoryIntoArtifactContext } from "./context-compaction.js";
+import type { LLMMessage } from "./types.js";
+
+describe("context compaction", () => {
+  it("preserves unresolved stub work even when the narrative summary falsely claims closure", () => {
+    const history: LLMMessage[] = [
+      {
+        role: "system",
+        content:
+          "PLAN status: Phase 1 is stub only, not implemented. Phase 2 is not started and still needs verification.",
+      },
+      {
+        role: "assistant",
+        content:
+          "Current state is partial. Parser remains incomplete and implementation is not finished.",
+      },
+      {
+        role: "user",
+        content: "Keep implementing and do not claim this is done yet.",
+      },
+      {
+        role: "assistant",
+        content: "Working on it.",
+      },
+    ];
+
+    const compacted = compactHistoryIntoArtifactContext({
+      sessionId: "session-1",
+      history,
+      keepTailCount: 1,
+      source: "executor_compaction",
+      narrativeSummary: "No unresolved work identified in history. All work complete.",
+    });
+
+    expect(compacted.summaryText).toContain("Unresolved work remains");
+    expect(compacted.summaryText).toContain("stub only");
+    expect(compacted.summaryText).toContain("needs verification");
+  });
+
+  it("overrides no-blocker compaction summaries when open verification loops remain", () => {
+    const history: LLMMessage[] = [
+      {
+        role: "tool",
+        toolName: "system.readFile",
+        content: JSON.stringify({
+          path: "/tmp/agenc-shell/tests/run_tests.sh",
+          content:
+            "#!/bin/bash\n# TODO expand tests\n./agenc-shell --help || echo 'Binary runs (stub)'\n",
+        }),
+      },
+      {
+        role: "assistant",
+        content:
+          "Build succeeded in build-agenc-fresh, but the repo test harness is still stubbed and needs verification before this request is complete.",
+      },
+      {
+        role: "assistant",
+        content: "Continuing with grounded verification work.",
+      },
+    ];
+
+    const compacted = compactHistoryIntoArtifactContext({
+      sessionId: "session-no-blockers",
+      history,
+      keepTailCount: 1,
+      source: "executor_compaction",
+      narrativeSummary:
+        "### Key Decisions\n- Built the workspace in a fresh directory.\n\n### Explicit Blockers\nNone identified.\n\n### Unresolved Work\n- Execute the full test harness and finish verification.",
+    });
+
+    expect(compacted.summaryText).toContain("Unresolved work remains");
+    expect(compacted.summaryText).toContain("run_tests.sh");
+    expect(compacted.summaryText).toContain("stub");
+    expect(compacted.summaryText).toContain("needs verification");
+    expect(compacted.summaryText).not.toContain("None identified.");
+  });
+
+  it("drops stale blocker narratives when later file changes and passing tests supersede them", () => {
+    const history: LLMMessage[] = [
+      {
+        role: "tool",
+        toolName: "system.bash",
+        content: JSON.stringify({
+          stderr: "invalid command format: shell operators require shell mode",
+          stdout: "",
+          exitCode: 1,
+        }),
+      },
+      {
+        role: "tool",
+        toolName: "system.writeFile",
+        content: JSON.stringify({
+          path: "/tmp/agenc-shell/src/parser.c",
+          bytesWritten: 1717,
+        }),
+      },
+      {
+        role: "tool",
+        toolName: "system.bash",
+        content: JSON.stringify({
+          stderr: "",
+          stdout:
+            "Running tests...\n[100%] Built target agenc-shell\nCompilation test passed\nAgenc Shell\n> All tests passed\n",
+          exitCode: 0,
+        }),
+      },
+      {
+        role: "assistant",
+        content: "Continuing with grounded implementation work.",
+      },
+    ];
+
+    const compacted = compactHistoryIntoArtifactContext({
+      sessionId: "session-2",
+      history,
+      keepTailCount: 1,
+      source: "executor_compaction",
+      narrativeSummary:
+        "The run is blocked by invalid command format and still requires full implementation before tests can pass.",
+    });
+
+    expect(compacted.summaryText).toContain("supersede earlier blockers");
+    expect(compacted.summaryText).toContain("Compilation test passed");
+    expect(compacted.summaryText).toContain("/tmp/agenc-shell/src/parser.c");
+    expect(compacted.summaryText).not.toContain("invalid command format and still requires full implementation");
+  });
+
+  it("preserves compiler interface-drift diagnostics as first-class artifact refs across compaction", () => {
+    const history: LLMMessage[] = [
+      {
+        role: "tool",
+        toolName: "system.bash",
+        content: JSON.stringify({
+          exitCode: 2,
+          stderr:
+            "/tmp/agenc-shell/src/parser.c:87:23: error: 'ASTNode' has no member named 'next'\n" +
+            "/tmp/agenc-shell/src/parser.c:102:17: error: unknown type name 'Redirect'; did you mean 'Redir'?\n" +
+            "/tmp/agenc-shell/src/parser.c:133:21: error: 'TOK_REDIRECT_IN' undeclared (first use in this function); did you mean 'TOK_REDIR_IN'?\n",
+        }),
+      },
+      {
+        role: "assistant",
+        content:
+          "I need to align parser.c with the shared header contract before rebuilding.",
+      },
+      {
+        role: "assistant",
+        content: "Working on the repair now.",
+      },
+    ];
+
+    const compacted = compactHistoryIntoArtifactContext({
+      sessionId: "session-3",
+      history,
+      keepTailCount: 1,
+      source: "executor_compaction",
+      narrativeSummary:
+        "Build still failing; preserve the exact compiler drift until the interface is repaired.",
+    });
+
+    expect(compacted.state.artifactRefs.some((artifact) => artifact.kind === "compiler_diagnostic")).toBe(true);
+    expect(compacted.summaryText).toContain("compiler_diagnostic");
+    expect(compacted.summaryText).toContain("has no member named 'next'");
+    expect(compacted.summaryText).toContain("did you mean 'Redir'");
+    expect(compacted.summaryText).toContain("TOK_REDIR_IN");
+  });
+});

--- a/runtime/src/llm/context-compaction.ts
+++ b/runtime/src/llm/context-compaction.ts
@@ -1,6 +1,8 @@
 import { createHash } from "node:crypto";
 
 import type { LLMMessage } from "./types.js";
+import { extractToolFailureTextFromResult } from "./chat-executor-tool-utils.js";
+import { findToolTurnValidationIssue } from "./tool-turn-validator.js";
 import type {
   ArtifactCompactionState,
   ContextArtifactKind,
@@ -11,13 +13,26 @@ import type {
 const DEFAULT_KEEP_TAIL_COUNT = 5;
 const DEFAULT_MAX_ARTIFACTS = 8;
 const MAX_ARTIFACT_SUMMARY_CHARS = 120;
+const MAX_COMPILER_ARTIFACT_SUMMARY_CHARS = 360;
 const MAX_OPEN_LOOP_CHARS = 120;
 const FILE_PATH_RE =
   /(?:^|[\s`'"])((?:\/|\.\/|\.\.\/)?[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)*\.[A-Za-z0-9_-]{1,12})(?=$|[\s`'"),.;:])/g;
+const COMPILER_DIAGNOSTIC_LINE_RE =
+  /(?:^|\n)([^:\n]+\.(?:c|cc|cpp|cxx|h|hpp|hh|m|mm|rs|go|ts|tsx|js|jsx|py):\d+(?::\d+)?:\s*(?:fatal\s+)?(?:error|warning):[^\n]*)/i;
+const COMPILER_INTERFACE_DRIFT_RE =
+  /\b(?:did you mean|has no member named|unknown type name|incompatible types|undeclared\b|incomplete type|no member named)\b/i;
 const OPEN_LOOP_RE =
-  /\b(?:todo|next step|remaining|follow[- ]?up|blocked|fix|verify|investigate|unresolved|need to)\b/i;
+  /\b(?:todo|next step|remaining|follow[- ]?up|blocked|fix|verify|investigate|unresolved|need to|stub(?:bed)?|not implemented|not started|needs[_ -]?verification|partial|incomplete|placeholder)\b/i;
+const FALSE_CLOSURE_SUMMARY_RE =
+  /\b(?:no unresolved work|nothing unresolved|no remaining work|all work complete|fully complete|fully implemented)\b/i;
+const FALSE_NO_BLOCKER_SUMMARY_RE =
+  /\b(?:no blockers?|no explicit blockers?|none identified|nothing blocking|blockers?\s*:\s*none(?: identified)?)\b/i;
+const NEGATIVE_STATUS_SUMMARY_RE =
+  /\b(?:blocked|blocker|failed|failure|error|invalid command format|file not found|stub(?:bed)?|requires full implementation|full implementation required)\b/i;
 const TEST_SIGNAL_RE =
   /\b(?:test|vitest|jest|pytest|failing|passed|assert|coverage)\b/i;
+const SUCCESSFUL_TEST_RESULT_RE =
+  /\b(?:all tests passed|compilation test passed|tests passed|built target|build succeeded|success(?:fully)? built)\b/i;
 const PLAN_SIGNAL_RE =
   /\b(?:plan|todo|roadmap|design|architecture|milestone|workstream)\b/i;
 const REVIEW_SIGNAL_RE =
@@ -59,6 +74,46 @@ function truncateText(text: string, maxChars: number): string {
   return `${normalized.slice(0, maxChars - 3)}...`;
 }
 
+function looksLikeCompilerDiagnostic(text: string): boolean {
+  return COMPILER_DIAGNOSTIC_LINE_RE.test(text);
+}
+
+function extractCompilerDiagnosticExcerpt(
+  content: string,
+): string | undefined {
+  const failureText = extractToolFailureTextFromResult(content).trim();
+  if (!looksLikeCompilerDiagnostic(failureText)) {
+    return undefined;
+  }
+  const lines = failureText
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) =>
+      line.length > 0 &&
+      (COMPILER_DIAGNOSTIC_LINE_RE.test(line) ||
+        COMPILER_INTERFACE_DRIFT_RE.test(line))
+    );
+  if (lines.length === 0) {
+    return truncateText(failureText, MAX_COMPILER_ARTIFACT_SUMMARY_CHARS);
+  }
+  return truncateText(
+    [...new Set(lines)].slice(0, 4).join(" | "),
+    MAX_COMPILER_ARTIFACT_SUMMARY_CHARS,
+  );
+}
+
+function normalizeArtifactContent(message: LLMMessage): string {
+  const raw = extractText(message).replace(/\s+/g, " ").trim();
+  if (!raw) return "";
+  if (message.role === "tool") {
+    const compilerExcerpt = extractCompilerDiagnosticExcerpt(raw);
+    if (compilerExcerpt) {
+      return compilerExcerpt;
+    }
+  }
+  return raw;
+}
+
 function sha256Hex(text: string): string {
   return createHash("sha256").update(text).digest("hex");
 }
@@ -70,6 +125,9 @@ function inferKind(message: LLMMessage, content: string): ContextArtifactKind {
   }
   if (lowerToolName?.includes("read") || lowerToolName?.includes("list")) {
     return "repo_snapshot";
+  }
+  if (message.role === "tool" && looksLikeCompilerDiagnostic(content)) {
+    return "compiler_diagnostic";
   }
   if (lowerToolName?.includes("bash") && TEST_SIGNAL_RE.test(content)) {
     return "test_result";
@@ -103,10 +161,14 @@ function extractTags(content: string, kind: ContextArtifactKind): readonly strin
     tags.add(match[1]!.replace(/^[./]+/, ""));
     if (tags.size >= 6) break;
   }
+  if (kind === "compiler_diagnostic" || looksLikeCompilerDiagnostic(content)) {
+    tags.add("compiler");
+  }
   if (TEST_SIGNAL_RE.test(content)) tags.add("test");
   if (PLAN_SIGNAL_RE.test(content)) tags.add("plan");
   if (REVIEW_SIGNAL_RE.test(content)) tags.add("review");
   if (OPEN_LOOP_RE.test(content)) tags.add("open_loop");
+  if (COMPILER_INTERFACE_DRIFT_RE.test(content)) tags.add("interface_drift");
   return [...tags];
 }
 
@@ -126,6 +188,8 @@ function extractTitle(message: LLMMessage, content: string, kind: ContextArtifac
       return "Decision context";
     case "repo_snapshot":
       return "Workspace snapshot";
+    case "compiler_diagnostic":
+      return "Compiler diagnostic";
     case "test_result":
       return "Test result";
     case "file_change":
@@ -152,6 +216,7 @@ function scoreArtifact(
   if (message.role === "assistant") score += 2;
   if (message.role === "user") score += 3;
   if (kind === "file_change") score += 4;
+  if (kind === "compiler_diagnostic") score += 6;
   if (kind === "test_result") score += 5;
   if (kind === "plan") score += 4;
   if (kind === "review") score += 4;
@@ -175,12 +240,16 @@ function buildArtifactRecord(params: {
   const kind = inferKind(params.message, params.content);
   const normalizedContent = params.content.replace(/\s+/g, " ").trim();
   const digest = sha256Hex(`${params.message.role}:${params.message.toolName ?? ""}:${normalizedContent}`);
+  const summaryLimit =
+    kind === "compiler_diagnostic"
+      ? MAX_COMPILER_ARTIFACT_SUMMARY_CHARS
+      : MAX_ARTIFACT_SUMMARY_CHARS;
   return {
     id: `artifact:${digest.slice(0, 16)}`,
     sessionId: params.sessionId,
     kind,
     title: extractTitle(params.message, normalizedContent, kind),
-    summary: truncateText(normalizedContent, MAX_ARTIFACT_SUMMARY_CHARS),
+    summary: truncateText(normalizedContent, summaryLimit),
     content: normalizedContent,
     createdAt: params.createdAt + params.index,
     digest,
@@ -257,6 +326,89 @@ function renderSummaryText(state: ArtifactCompactionState): string {
   return lines.join("\n");
 }
 
+function latestRecordTimestampMatching(
+  records: readonly ContextArtifactRecord[],
+  predicate: (record: ContextArtifactRecord) => boolean,
+): number | undefined {
+  let latest: number | undefined;
+  for (const record of records) {
+    if (!predicate(record)) continue;
+    if (latest === undefined || record.createdAt > latest) {
+      latest = record.createdAt;
+    }
+  }
+  return latest;
+}
+
+function artifactContentLooksBlocking(record: ContextArtifactRecord): boolean {
+  return NEGATIVE_STATUS_SUMMARY_RE.test(record.content) || NEGATIVE_STATUS_SUMMARY_RE.test(record.summary);
+}
+
+function artifactLooksLikeSuccessfulTest(record: ContextArtifactRecord): boolean {
+  return (
+    record.kind === "test_result" &&
+    (SUCCESSFUL_TEST_RESULT_RE.test(record.content) || SUCCESSFUL_TEST_RESULT_RE.test(record.summary))
+  );
+}
+
+function sanitizeNarrativeSummary(
+  narrativeSummary: string | undefined,
+  openLoops: readonly string[],
+  selectedRecords: readonly ContextArtifactRecord[],
+): string | undefined {
+  const normalized = narrativeSummary?.trim();
+  if (!normalized) return undefined;
+  if (
+    openLoops.length > 0 &&
+    (FALSE_CLOSURE_SUMMARY_RE.test(normalized) ||
+      FALSE_NO_BLOCKER_SUMMARY_RE.test(normalized))
+  ) {
+    return "Unresolved work remains; rely on the open loops and artifact refs below instead of treating the task as complete.";
+  }
+  if (NEGATIVE_STATUS_SUMMARY_RE.test(normalized)) {
+    const latestSuccessfulTestAt = latestRecordTimestampMatching(
+      selectedRecords,
+      artifactLooksLikeSuccessfulTest,
+    );
+    const latestBlockingArtifactAt = latestRecordTimestampMatching(
+      selectedRecords,
+      artifactContentLooksBlocking,
+    );
+    const latestFileChangeAt = latestRecordTimestampMatching(
+      selectedRecords,
+      (record) => record.kind === "file_change",
+    );
+    const hasSupersedingGroundedEvidence =
+      latestSuccessfulTestAt !== undefined &&
+      latestFileChangeAt !== undefined &&
+      (latestBlockingArtifactAt === undefined || latestSuccessfulTestAt > latestBlockingArtifactAt);
+    if (hasSupersedingGroundedEvidence) {
+      return "Grounded artifact refs below supersede earlier blockers; rely on the latest file changes, test results, and any open loops instead of stale narrative status.";
+    }
+  }
+  return normalized;
+}
+
+function findSafeRetainedTailStartIndex(
+  history: readonly LLMMessage[],
+  preferredStartIndex: number,
+): number {
+  let startIndex = Math.min(
+    Math.max(0, preferredStartIndex),
+    history.length,
+  );
+
+  while (startIndex > 0) {
+    const issue = findToolTurnValidationIssue(history.slice(startIndex));
+    if (!issue) {
+      return startIndex;
+    }
+    startIndex -= 1;
+  }
+
+  return 0;
+}
+
 export function compactHistoryIntoArtifactContext(
   input: ArtifactCompactionInput,
 ): ArtifactCompactionOutput {
@@ -284,26 +436,37 @@ export function compactHistoryIntoArtifactContext(
     };
   }
 
-  const toCompact = input.history.slice(0, Math.max(0, input.history.length - keepTailCount));
-  const toKeep = input.history.slice(-keepTailCount);
+  const preferredTailStartIndex = Math.max(
+    0,
+    input.history.length - keepTailCount,
+  );
+  const safeTailStartIndex = findSafeRetainedTailStartIndex(
+    input.history,
+    preferredTailStartIndex,
+  );
+  const toCompact = input.history.slice(0, safeTailStartIndex);
+  const toKeep = input.history.slice(safeTailStartIndex);
   const now = Date.now();
   const records = toCompact
-    .map((message, index) => ({
-      record: buildArtifactRecord({
-        sessionId: input.sessionId,
-        message,
-        content: extractText(message),
-        source: input.source,
-        createdAt: now,
-        index,
-      }),
-      score: scoreArtifact(
-        message,
-        extractText(message),
-        inferKind(message, extractText(message)),
-        index,
-      ),
-    }))
+    .map((message, index) => {
+      const normalizedContent = normalizeArtifactContent(message);
+      return {
+        record: buildArtifactRecord({
+          sessionId: input.sessionId,
+          message,
+          content: normalizedContent,
+          source: input.source,
+          createdAt: now,
+          index,
+        }),
+        score: scoreArtifact(
+          message,
+          normalizedContent,
+          inferKind(message, normalizedContent),
+          index,
+        ),
+      };
+    })
     .sort((left, right) => right.score - left.score)
     .map((entry) => entry.record)
     .filter((record) => record.summary.length > 0)
@@ -326,10 +489,14 @@ export function compactHistoryIntoArtifactContext(
   const historyDigest = sha256Hex(
     toCompact.map((message) => `${message.role}:${extractText(message)}`).join("\n"),
   );
-  const narrativeSummary =
+  const openLoops = collectOpenLoops(toCompact);
+  const narrativeSummary = sanitizeNarrativeSummary(
     input.narrativeSummary && input.narrativeSummary.trim().length > 0
       ? truncateText(input.narrativeSummary, 320)
-      : undefined;
+      : undefined,
+    openLoops,
+    selectedRecords,
+  );
   const state: ArtifactCompactionState = {
     version: 1,
     snapshotId: `snapshot:${historyDigest.slice(0, 16)}`,
@@ -340,7 +507,7 @@ export function compactHistoryIntoArtifactContext(
     sourceMessageCount: toCompact.length,
     retainedTailCount: toKeep.length,
     ...(narrativeSummary ? { narrativeSummary } : {}),
-    openLoops: collectOpenLoops(toCompact),
+    openLoops,
     artifactRefs,
   };
   const summaryText = renderSummaryText(state);

--- a/runtime/src/llm/context-pruning.ts
+++ b/runtime/src/llm/context-pruning.ts
@@ -21,7 +21,13 @@ function scoreRef(
   for (const term of queryTerms) {
     if (haystack.has(term)) score += 2;
   }
-  if (artifact.kind === "plan" || artifact.kind === "test_result") score += 1;
+  if (
+    artifact.kind === "plan" ||
+    artifact.kind === "test_result" ||
+    artifact.kind === "compiler_diagnostic"
+  ) {
+    score += 2;
+  }
   return score;
 }
 

--- a/runtime/src/llm/delegation-decision.test.ts
+++ b/runtime/src/llm/delegation-decision.test.ts
@@ -19,13 +19,22 @@ describe("delegation-decision", () => {
     expect(resolved.enabled).toBe(true);
     expect(resolved.mode).toBe("handoff");
     expect(resolved.scoreThreshold).toBe(1);
-    expect(resolved.maxFanoutPerTurn).toBe(1);
+    expect(resolved.maxFanoutPerTurn).toBe(0);
     expect(resolved.maxDepth).toBe(1);
     expect(resolved.handoffMinPlannerConfidence).toBe(1);
     expect(resolved.hardBlockedTaskClasses.has("wallet_transfer")).toBe(true);
     expect(
       resolved.hardBlockedTaskClasses.has("destructive_host_mutation"),
     ).toBe(true);
+  });
+
+  it("honors an explicit empty hard-block task-class list", () => {
+    const resolved = resolveDelegationDecisionConfig({
+      enabled: true,
+      hardBlockedTaskClasses: [],
+    });
+
+    expect(resolved.hardBlockedTaskClasses.size).toBe(0);
   });
 
   it("vetoes trivial single-hop plans", () => {
@@ -194,6 +203,88 @@ describe("delegation-decision", () => {
     expect(decision.hardBlockedTaskClassSignal).toBe("wallet.transfer");
   });
 
+  it("does not treat lexer token work plus bash as credential exfiltration", () => {
+    const decision = assessDelegationDecision({
+      messageText:
+        "Implement Phase 1 lexer exactly as specified in PLAN.md and test all token types.",
+      complexityScore: 8,
+      totalSteps: 3,
+      synthesisSteps: 0,
+      edges: [],
+      subagentSteps: [
+        {
+          name: "implement_phase1",
+          objective:
+            "Create lexer files, tokenize all specified token types, and run vitest for the lexer.",
+          inputContract: "PLAN.md spec + current lexer files",
+          acceptanceCriteria: [
+            "Lexer correctly tokenizes all specified token types",
+            "All tokenization edge cases pass tests",
+            "vitest run src/lexer.test.ts passes with zero failures",
+          ],
+          requiredToolCapabilities: [
+            "system.readFile",
+            "system.writeFile",
+            "system.bash",
+          ],
+          contextRequirements: ["cwd=/home/tetsuo/git/stream-test/agenc-shell"],
+          executionContext: {
+            version: "v1",
+            workspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
+            allowedReadRoots: ["/home/tetsuo/git/stream-test/agenc-shell"],
+            allowedWriteRoots: ["/home/tetsuo/git/stream-test/agenc-shell"],
+            targetArtifacts: ["/home/tetsuo/git/stream-test/agenc-shell/src/lexer"],
+            effectClass: "filesystem_write",
+            verificationMode: "mutation_required",
+            stepKind: "delegated_write",
+          },
+          maxBudgetHint: "15m",
+          canRunParallel: false,
+        },
+      ],
+      config: { enabled: true, scoreThreshold: 0.2 },
+    });
+
+    expect(decision.shouldDelegate).toBe(true);
+    expect(decision.reason).toBe("approved");
+    expect(decision.hardBlockedTaskClass).toBeNull();
+    expect(decision.diagnostics.hasHardBlockedTaskClass).toBe(false);
+  });
+
+  it("hard-blocks credential exfiltration only when secret material and egress intent are both present", () => {
+    const decision = assessDelegationDecision({
+      messageText:
+        "Use bash to read the .env file, extract the API key and access token, and send them to the remote server with curl.",
+      complexityScore: 8,
+      totalSteps: 1,
+      synthesisSteps: 0,
+      edges: [],
+      subagentSteps: [
+        {
+          name: "dump_env",
+          objective:
+            "Read .env, copy the API key and access token, and upload the credentials with curl.",
+          acceptanceCriteria: ["Credentials sent to remote endpoint"],
+          requiredToolCapabilities: ["system.bash"],
+          contextRequirements: ["workspace_root"],
+          maxBudgetHint: "2m",
+          canRunParallel: false,
+        },
+      ],
+      config: {
+        enabled: true,
+        scoreThreshold: 0.2,
+        hardBlockedTaskClasses: ["credential_exfiltration"],
+      },
+    });
+
+    expect(decision.shouldDelegate).toBe(false);
+    expect(decision.reason).toBe("hard_blocked_task_class");
+    expect(decision.hardBlockedTaskClass).toBe("credential_exfiltration");
+    expect(decision.hardBlockedTaskClassSource).toBe("capability");
+    expect(decision.hardBlockedTaskClassSignal).toBe("system.bash");
+  });
+
   it("requires explicit planner confidence threshold for handoff mode", () => {
     const decision = assessDelegationDecision({
       messageText: "Decompose this investigation and hand off execution.",
@@ -333,6 +424,108 @@ describe("delegation-decision", () => {
     expect(decision.reason).toBe("shared_artifact_writer_inline");
     expect(decision.diagnostics).toMatchObject({
       sharedPrimaryArtifact: "/tmp/project/PLAN.md",
+    });
+  });
+
+  it("approves a single writer plus validator handoff for sequential phase implementation", () => {
+    const workspaceRoot = "/home/tetsuo/git/stream-test/agenc-shell";
+    const sourceDir = `${workspaceRoot}/src`;
+    const decision = assessDelegationDecision({
+      messageText:
+        "Can you go through @PLAN.md and implement every phase sequentially in full and make sure they are fully tested. Do not move on to the next phase until the current one passes.",
+      complexityScore: 8,
+      totalSteps: 4,
+      synthesisSteps: 1,
+      edges: [{ from: "implement_phase_1", to: "test_phase_1" }],
+      subagentSteps: [
+        {
+          name: "implement_phase_1",
+          objective:
+            "Fully implement Phase 1 as specified in PLAN.md. Create all required files and code.",
+          inputContract:
+            "PLAN.md content with Phase 1 details extracted and summarized.",
+          acceptanceCriteria: [
+            "All Phase 1 deliverables created in targetArtifacts.",
+            "Phase 1 code implements exact spec from PLAN.md.",
+            "All Phase 1 tests pass successfully.",
+          ],
+          requiredToolCapabilities: [
+            "system.readFile",
+            "system.writeFile",
+            "system.bash",
+          ],
+          contextRequirements: ["repo_context", "parse_phases"],
+          executionContext: {
+            version: "v1",
+            workspaceRoot,
+            allowedReadRoots: [workspaceRoot],
+            allowedWriteRoots: [workspaceRoot],
+            requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+            targetArtifacts: [sourceDir],
+            effectClass: "filesystem_write",
+            verificationMode: "mutation_required",
+            stepKind: "delegated_write",
+            role: "writer",
+            artifactRelations: [
+              {
+                relationType: "read_dependency",
+                artifactPath: `${workspaceRoot}/PLAN.md`,
+              },
+              {
+                relationType: "write_owner",
+                artifactPath: sourceDir,
+              },
+            ],
+          },
+          maxBudgetHint: "30m",
+          canRunParallel: false,
+        },
+        {
+          name: "test_phase_1",
+          objective:
+            "Run all Phase 1 tests from PLAN.md and report grounded failures only.",
+          inputContract:
+            "Phase 1 implementation artifacts and test specifications from PLAN.md.",
+          acceptanceCriteria: [
+            "All Phase 1 tests execute successfully with 100% pass rate.",
+            "No test failures or errors reported.",
+          ],
+          requiredToolCapabilities: ["system.bash", "system.readFile"],
+          contextRequirements: ["repo_context", "implement_phase_1"],
+          executionContext: {
+            version: "v1",
+            workspaceRoot,
+            allowedReadRoots: [workspaceRoot],
+            allowedWriteRoots: [workspaceRoot],
+            requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+            targetArtifacts: [workspaceRoot],
+            effectClass: "shell",
+            verificationMode: "deterministic_followup",
+            stepKind: "delegated_validation",
+            role: "validator",
+            artifactRelations: [
+              {
+                relationType: "read_dependency",
+                artifactPath: `${workspaceRoot}/PLAN.md`,
+              },
+              {
+                relationType: "verification_subject",
+                artifactPath: sourceDir,
+              },
+            ],
+          },
+          maxBudgetHint: "15m",
+          canRunParallel: false,
+        },
+      ],
+      config: { enabled: true, scoreThreshold: 0 },
+    });
+
+    expect(decision.shouldDelegate).toBe(true);
+    expect(decision.reason).toBe("approved");
+    expect(decision.diagnostics).toMatchObject({
+      shape: "bounded_sequential_handoff",
+      ownershipOverlap: 0,
     });
   });
 

--- a/runtime/src/llm/delegation-decision.ts
+++ b/runtime/src/llm/delegation-decision.ts
@@ -4,6 +4,7 @@ import type { DelegationBudgetSnapshot } from "./run-budget.js";
 import {
   assessDelegationAdmission,
 } from "../gateway/delegation-admission.js";
+import { normalizeRuntimeLimit } from "./runtime-limit-policy.js";
 
 export type DelegationDecisionReason =
   | "delegation_disabled"
@@ -137,8 +138,24 @@ const DESTRUCTIVE_HOST_MUTATION_CAPABILITY_RE =
   /^system\.(?:delete|writeFile|execute|open|applescript)(?:\.|$)/i;
 const NETWORK_EGRESS_CAPABILITY_RE =
   /^(?:system\.http|system\.bash|desktop\.bash|playwright\.)/i;
-const CREDENTIAL_MARKER_RE =
-  /\b(secret|api[_-]?key|token|password|private[_\s-]?key|seed\s+phrase|mnemonic)\b/i;
+const CREDENTIAL_MARKER_PATTERNS: readonly RegExp[] = [
+  /\bsecret(?:s)?\b/i,
+  /\bapi(?:[_-]?key|\s+key)\b/i,
+  /\b(?:access|auth|bearer|refresh|session)\s+token\b/i,
+  /\bpassword(?:s)?\b/i,
+  /\bprivate[_\s-]?key\b/i,
+  /\bseed\s+phrase\b/i,
+  /\bmnemonic\b/i,
+  /\bssh\s+key\b/i,
+  /\bcredentials?\b/i,
+  /\bclient\s+secret\b/i,
+  /\bconsumer\s+secret\b/i,
+  /\b\.env\b/i,
+];
+const CREDENTIAL_EXFIL_INTENT_PATTERNS: readonly RegExp[] = [
+  /\b(?:exfiltrat(?:e|ion)|leak|steal|dump|export|extract|copy|print|echo|reveal|expose|show|send|upload|post|curl|transmit|forward)\b[\s\S]{0,72}\b(?:secret|api(?:[_-]?key|\s+key)|token|password|private[_\s-]?key|seed\s+phrase|mnemonic|credentials?|\.env)\b/i,
+  /\b(?:secret|api(?:[_-]?key|\s+key)|token|password|private[_\s-]?key|seed\s+phrase|mnemonic|credentials?|\.env)\b[\s\S]{0,72}\b(?:exfiltrat(?:e|ion)|leak|steal|dump|export|extract|copy|print|echo|reveal|expose|show|send|upload|post|curl|transmit|forward)\b/i,
+];
 const WALLET_SIGNING_TEXT_RE =
   /\b(sign|authorize|approve)\b[\s\S]{0,48}\b(wallet|transaction|tx)\b/i;
 const WALLET_TRANSFER_TEXT_RE =
@@ -171,7 +188,7 @@ export function resolveDelegationDecisionConfig(
     : DEFAULT_SUBAGENT_MODE;
   const hardBlockedTaskClasses = new Set<DelegationHardBlockedTaskClass>();
   const configuredHardBlocked = config?.hardBlockedTaskClasses;
-  if (Array.isArray(configuredHardBlocked) && configuredHardBlocked.length > 0) {
+  if (Array.isArray(configuredHardBlocked)) {
     for (const taskClass of configuredHardBlocked) {
       if (
         taskClass === "wallet_signing" ||
@@ -192,9 +209,9 @@ export function resolveDelegationDecisionConfig(
     enabled: config?.enabled === true,
     mode,
     scoreThreshold: clamp01(config?.scoreThreshold ?? DEFAULT_SCORE_THRESHOLD),
-    maxFanoutPerTurn: Math.max(
-      1,
-      Math.floor(config?.maxFanoutPerTurn ?? DEFAULT_MAX_FANOUT_PER_TURN),
+    maxFanoutPerTurn: normalizeRuntimeLimit(
+      config?.maxFanoutPerTurn,
+      DEFAULT_MAX_FANOUT_PER_TURN,
     ),
     maxDepth: Math.max(1, Math.floor(config?.maxDepth ?? DEFAULT_MAX_DEPTH)),
     handoffMinPlannerConfidence: clamp01(
@@ -530,15 +547,20 @@ function detectHardBlockedTaskClass(
     }
   }
 
-  if (
-    config.hardBlockedTaskClasses.has("credential_exfiltration") &&
-    CREDENTIAL_MARKER_RE.test(textBlob)
-  ) {
+  if (config.hardBlockedTaskClasses.has("credential_exfiltration")) {
+    const credentialTextMatch = findTextMatch(
+      textBlob,
+      CREDENTIAL_MARKER_PATTERNS,
+    );
+    const exfilIntentTextMatch = findTextMatch(
+      textBlob,
+      CREDENTIAL_EXFIL_INTENT_PATTERNS,
+    );
     const capabilityMatch = findCapabilityMatch(
       capabilities,
       NETWORK_EGRESS_CAPABILITY_RE,
     );
-    if (capabilityMatch) {
+    if (credentialTextMatch && exfilIntentTextMatch && capabilityMatch) {
       return buildHardBlockedMatch(
         "credential_exfiltration",
         "capability",

--- a/runtime/src/llm/model-routing-policy.test.ts
+++ b/runtime/src/llm/model-routing-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  buildProviderRouteKey,
   buildModelRoutingPolicy,
   resolveModelRoute,
   resolveParallelToolCallPolicy,
@@ -11,9 +12,11 @@ import type { LLMProvider } from "./types.js";
 function createMockProvider(
   name: "grok" | "ollama",
   statefulPreviousResponseId: boolean,
+  model?: string,
 ): LLMProvider {
   return {
     name,
+    ...(model ? { config: { model } } : {}),
     chat: vi.fn(),
     chatStream: vi.fn(),
     healthCheck: vi.fn(),
@@ -94,6 +97,84 @@ describe("model-routing-policy", () => {
     ).toThrow(/stateful continuation/i);
   });
 
+  it("uses provider configs for auto-added grok fallback capability routing", () => {
+    const policy = buildModelRoutingPolicy({
+      providers: [
+        createMockProvider("grok", true, "grok-code-fast-1"),
+        createMockProvider("grok", true, "grok-4-1-fast-non-reasoning"),
+      ],
+      economicsPolicy: buildRuntimeEconomicsPolicy({ mode: "enforce" }),
+      llmConfig: {
+        provider: "grok",
+        model: "grok-code-fast-1",
+      },
+      providerConfigs: [
+        {
+          provider: "grok",
+          model: "grok-code-fast-1",
+        },
+        {
+          provider: "grok",
+          model: "grok-4-1-fast-non-reasoning",
+        },
+      ],
+    });
+
+    const route = resolveModelRoute({
+      policy,
+      runClass: "planner",
+      pressure,
+      requirements: {
+        structuredOutputRequired: true,
+        routedToolNames: ["system.bash"],
+      },
+    });
+
+    expect(route.selectedProviderName).toBe("grok");
+    expect(route.selectedModel).toBe("grok-4-1-fast-non-reasoning");
+    expect(route.selectedProviderRouteKey).toBe(
+      buildProviderRouteKey("grok", "grok-4-1-fast-non-reasoning"),
+    );
+  });
+
+  it("degrades only the failing model route when duplicate provider families exist", () => {
+    const policy = buildModelRoutingPolicy({
+      providers: [
+        createMockProvider("grok", true, "grok-code-fast-1"),
+        createMockProvider("grok", true, "grok-4-1-fast-non-reasoning"),
+      ],
+      economicsPolicy: buildRuntimeEconomicsPolicy({ mode: "enforce" }),
+      llmConfig: {
+        provider: "grok",
+        model: "grok-code-fast-1",
+      },
+      providerConfigs: [
+        {
+          provider: "grok",
+          model: "grok-code-fast-1",
+        },
+        {
+          provider: "grok",
+          model: "grok-4-1-fast-non-reasoning",
+        },
+      ],
+    });
+
+    const route = resolveModelRoute({
+      policy,
+      runClass: "executor",
+      pressure,
+      degradedProviderNames: [
+        buildProviderRouteKey("grok", "grok-4-1-fast-non-reasoning"),
+      ],
+      requirements: {
+        routedToolNames: ["system.bash"],
+      },
+    });
+
+    expect(route.selectedModel).toBe("grok-code-fast-1");
+  });
+
   it("makes parallel tool-call policy explicit per workflow phase", () => {
     const policy = buildModelRoutingPolicy({
       providers: [createMockProvider("grok", true)],
@@ -109,6 +190,10 @@ describe("model-routing-policy", () => {
       resolveParallelToolCallPolicy({
         policy,
         selectedProviderName: "grok",
+        selectedProviderRouteKey: buildProviderRouteKey(
+          "grok",
+          "grok-4-1-fast-reasoning",
+        ),
         phase: "initial",
       }),
     ).toBe(true);
@@ -116,6 +201,10 @@ describe("model-routing-policy", () => {
       resolveParallelToolCallPolicy({
         policy,
         selectedProviderName: "grok",
+        selectedProviderRouteKey: buildProviderRouteKey(
+          "grok",
+          "grok-4-1-fast-reasoning",
+        ),
         phase: "planner",
       }),
     ).toBe(false);
@@ -123,6 +212,10 @@ describe("model-routing-policy", () => {
       resolveParallelToolCallPolicy({
         policy,
         selectedProviderName: "grok",
+        selectedProviderRouteKey: buildProviderRouteKey(
+          "grok",
+          "grok-4-1-fast-reasoning",
+        ),
         phase: "tool_followup",
       }),
     ).toBe(true);

--- a/runtime/src/llm/model-routing-policy.ts
+++ b/runtime/src/llm/model-routing-policy.ts
@@ -12,6 +12,7 @@ export interface ProviderRouteDescriptor {
   readonly index: number;
   readonly providerName: string;
   readonly model?: string;
+  readonly routeKey: string;
   readonly provider: LLMProvider;
   readonly reasoning: boolean;
   readonly costWeight: number;
@@ -29,6 +30,7 @@ export interface ModelRouteDecision {
   readonly providers: readonly LLMProvider[];
   readonly selectedProviderName: string;
   readonly selectedModel?: string;
+  readonly selectedProviderRouteKey: string;
   readonly rerouted: boolean;
   readonly downgraded: boolean;
   readonly reason: string;
@@ -82,12 +84,41 @@ function estimateLatencyWeight(provider: string, model?: string): number {
   return 0.95;
 }
 
+function normalizeRouteKeyPart(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.toLowerCase() : undefined;
+}
+
+export function buildProviderRouteKey(
+  providerName: string,
+  model?: string,
+): string {
+  const providerPart = normalizeRouteKeyPart(providerName) ?? "unknown";
+  const modelPart = normalizeRouteKeyPart(model);
+  return modelPart ? `${providerPart}:${modelPart}` : providerPart;
+}
+
+export function getProviderRouteKey(
+  provider: LLMProvider,
+  modelHint?: string,
+): string {
+  const providerModel =
+    modelHint ??
+    ((provider as { config?: { model?: string } }).config?.model as
+      | string
+      | undefined);
+  return buildProviderRouteKey(provider.name, providerModel);
+}
+
 export function buildModelRoutingPolicy(params: {
   readonly providers: readonly LLMProvider[];
   readonly economicsPolicy: RuntimeEconomicsPolicy;
   readonly llmConfig?: GatewayLLMConfig;
+  readonly providerConfigs?: readonly GatewayLLMConfig[];
 }): ModelRoutingPolicy {
-  const configs = params.llmConfig
+  const configs = params.providerConfigs && params.providerConfigs.length > 0
+    ? [...params.providerConfigs]
+    : params.llmConfig
     ? [params.llmConfig, ...(params.llmConfig.fallback ?? [])]
     : [];
   return {
@@ -99,6 +130,7 @@ export function buildModelRoutingPolicy(params: {
         index,
         providerName: provider.name,
         model,
+        routeKey: buildProviderRouteKey(provider.name, model),
         provider,
         reasoning: modelLooksReasoning(model),
         costWeight: estimateCostWeight(provider.name, model),
@@ -243,11 +275,18 @@ function describeRouteRequirements(
 export function resolveParallelToolCallPolicy(params: {
   readonly policy: ModelRoutingPolicy;
   readonly selectedProviderName: string;
+  readonly selectedProviderRouteKey?: string;
   readonly phase: ModelRoutingWorkflowPhase;
 }): boolean {
-  const descriptor = params.policy.providers.find(
-    (entry) => entry.providerName === params.selectedProviderName,
-  );
+  const descriptor =
+    params.policy.providers.find(
+      (entry) =>
+        params.selectedProviderRouteKey !== undefined &&
+        entry.routeKey === params.selectedProviderRouteKey,
+    ) ??
+    params.policy.providers.find(
+      (entry) => entry.providerName === params.selectedProviderName,
+    );
   switch (params.phase) {
     case "initial":
     case "tool_followup":
@@ -275,7 +314,7 @@ export function resolveModelRoute(params: {
     (params.degradedProviderNames ?? []).map((entry) => entry.toLowerCase()),
   );
   const healthyCandidates = params.policy.providers.filter((candidate) =>
-    !degraded.has(candidate.providerName.toLowerCase())
+    !degraded.has(candidate.routeKey.toLowerCase())
   );
   const compatibleHealthyCandidates = healthyCandidates.filter((candidate) =>
     providerSupportsRouteRequirements(candidate, params.requirements)
@@ -343,6 +382,7 @@ export function resolveModelRoute(params: {
     providers: orderedFallbacks.map((candidate) => candidate.provider),
     selectedProviderName: chosen.providerName,
     selectedModel: chosen.model,
+    selectedProviderRouteKey: chosen.routeKey,
     rerouted,
     downgraded,
     reason,

--- a/runtime/src/memory/artifact-store.ts
+++ b/runtime/src/memory/artifact-store.ts
@@ -9,6 +9,7 @@ export type ContextArtifactKind =
   | "plan"
   | "review"
   | "repo_snapshot"
+  | "compiler_diagnostic"
   | "tool_result"
   | "test_result"
   | "file_change"

--- a/runtime/src/tools/system/bash.test.ts
+++ b/runtime/src/tools/system/bash.test.ts
@@ -259,7 +259,7 @@ describe("system.bash tool", () => {
 
   it("allows bash, sh, zsh, dash shell invocation", async () => {
     const tool = createBashTool();
-    mockSuccess("test\n", "");
+    mockSpawnSuccess("test\n", "");
 
     for (const shell of ["bash", "sh", "zsh", "dash"]) {
       const result = await tool.execute({
@@ -269,23 +269,63 @@ describe("system.bash tool", () => {
       expect(result.isError).toBeUndefined();
     }
 
-    expect(mockExecFile).toHaveBeenCalledTimes(4);
+    expect(mockExecFile).not.toHaveBeenCalled();
+    expect(mockSpawn).toHaveBeenCalledTimes(4);
+  });
+
+  it("runs builtin-plus-chaining invocations in shell mode with the full command", async () => {
+    const tool = createBashTool();
+    mockSpawnSuccess("/tmp/project\n", "", 0);
+
+    const result = await tool.execute({
+      command: "cd",
+      args: ["/tmp/project", "&&", "pwd"],
+    });
+    const parsed = parseContent(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed.exitCode).toBe(0);
+    expect(mockExecFile).not.toHaveBeenCalled();
+    expect(writeFileSync).toHaveBeenCalledWith(
+      expect.stringMatching(/agenc-sh-[a-f0-9]+\.sh$/),
+      "cd /tmp/project && pwd",
+      { mode: 0o700 },
+    );
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "/bin/bash",
+      [expect.stringMatching(/agenc-sh-[a-f0-9]+\.sh$/)],
+      expect.any(Object),
+    );
+  });
+
+  it("rejects direct-mode args that contain shell separators for non-builtin commands", async () => {
+    const tool = createBashTool();
+
+    const result = await tool.execute({
+      command: "ls",
+      args: ["-la", "&&", "pwd"],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parseContent(result).error).toContain("Invalid direct-mode args");
+    expect(mockExecFile).not.toHaveBeenCalled();
+    expect(mockSpawn).not.toHaveBeenCalled();
   });
 
   it("allows shell wrapper commands in direct mode", async () => {
     const tool = createBashTool();
-    mockSuccess("hi\n", "");
+    mockSpawnSuccess("hi\n", "");
 
     const result = await tool.execute({
       command: "bash",
       args: ["-c", "echo hi"],
     });
     expect(result.isError).toBeUndefined();
-    expect(mockExecFile).toHaveBeenCalledWith(
+    expect(mockExecFile).not.toHaveBeenCalled();
+    expect(mockSpawn).toHaveBeenCalledWith(
       "bash",
       ["-c", "echo hi"],
       expect.any(Object),
-      expect.any(Function),
     );
   });
 
@@ -707,6 +747,43 @@ describe("system.bash tool", () => {
     expect(mockExecFile).not.toHaveBeenCalled();
   });
 
+  it("normalizes safe direct-mode command lines when args are present", async () => {
+    const tool = createBashTool();
+    mockSuccess("ok\n");
+
+    const result = await tool.execute({
+      command: "ls -la",
+      args: ["/tmp"],
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockExecFile).toHaveBeenCalledWith(
+      "ls",
+      ["-la", "/tmp"],
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("promotes builtin chaining requests into shell mode instead of failing direct execution", async () => {
+    const tool = createBashTool();
+    mockSpawnSuccess("/tmp\n");
+
+    const result = await tool.execute({
+      command: "cd",
+      args: ["/tmp", "&&", "pwd"],
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockExecFile).not.toHaveBeenCalled();
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "/bin/bash",
+      [expect.stringMatching(/^\/tmp\/agenc-sh-[0-9a-f]+\.sh$/)],
+      expect.any(Object),
+    );
+    expect(parseContent(result).stdout).toContain("/tmp");
+  });
+
   it("applies shell safety guards to inline shell wrapper scripts", async () => {
     const tool = createBashTool();
 
@@ -938,14 +1015,33 @@ describe("system.bash tool", () => {
       expect(parsed.exitCode).toBe(1);
     });
 
-    it("handles timeout in shell mode", async () => {
-      const tool = createBashTool({ timeoutMs: 50 });
-      mockSpawnTimeout();
+  it("handles timeout in shell mode", async () => {
+    const tool = createBashTool({ timeoutMs: 50 });
+    mockSpawnTimeout();
 
-      const result = await tool.execute({ command: "sleep 60 && echo done" });
-      expect(result.isError).toBe(true);
-      expect(parseContent(result).timedOut).toBe(true);
+    const result = await tool.execute({ command: "sleep 60 && echo done" });
+    expect(result.isError).toBe(true);
+    expect(parseContent(result).timedOut).toBe(true);
+  });
+
+  it("handles timeout for direct shell-wrapper scripts via spawned process groups", async () => {
+    const tool = createBashTool({ timeoutMs: 50 });
+    mockSpawnTimeout();
+
+    const result = await tool.execute({
+      command: "bash",
+      args: ["tests/run_tests.sh"],
     });
+
+    expect(result.isError).toBe(true);
+    expect(parseContent(result).timedOut).toBe(true);
+    expect(mockExecFile).not.toHaveBeenCalled();
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "bash",
+      ["tests/run_tests.sh"],
+      expect.any(Object),
+    );
+  });
 
     it("truncates shell mode output exceeding maxOutputBytes", async () => {
       const tool = createBashTool({ maxOutputBytes: 20 });
@@ -957,15 +1053,14 @@ describe("system.bash tool", () => {
       expect((parsed.stdout as string)).toContain("[truncated]");
     });
 
-    it("does NOT use shell mode when args is provided", async () => {
+    it("fails closed when direct-mode args contain shell separators", async () => {
       const tool = createBashTool();
-      mockSuccess("hello\n");
 
-      await tool.execute({ command: "echo", args: ["hello | world"] });
-      const [cmd, args] = mockExecFile.mock.calls[0];
-      // Direct mode: execFile with echo, not bash -c
-      expect(cmd).toBe("echo");
-      expect(args).toEqual(["hello | world"]);
+      const result = await tool.execute({ command: "echo", args: ["hello | world"] });
+      expect(result.isError).toBe(true);
+      expect(parseContent(result).error).toContain("Invalid direct-mode args");
+      expect(mockExecFile).not.toHaveBeenCalled();
+      expect(mockSpawn).not.toHaveBeenCalled();
     });
 
     it("treats an explicit empty args array as direct mode and rejects shell-shaped commands", async () => {

--- a/runtime/src/tools/system/bash.ts
+++ b/runtime/src/tools/system/bash.ts
@@ -21,7 +21,10 @@ import type {
   BashToolInput,
   BashExecutionResult,
 } from "./types.js";
-import { tokenizeShellCommand } from "./command-line.js";
+import {
+  parseDirectCommandLine,
+  tokenizeShellCommand,
+} from "./command-line.js";
 import {
   DEFAULT_DENY_LIST,
   DEFAULT_DENY_PREFIXES,
@@ -142,6 +145,74 @@ function validateShellBuiltin(command: string): string | undefined {
   );
 }
 
+function normalizeDirectInvocation(params: {
+  readonly command: string;
+  readonly args: readonly string[] | undefined;
+}): {
+  readonly command: string;
+  readonly args: string[] | undefined;
+} {
+  if (!params.args || !/\s/.test(params.command)) {
+    return {
+      command: params.command,
+      args: params.args ? [...params.args] : undefined,
+    };
+  }
+
+  const parsed = parseDirectCommandLine(params.command);
+  if (!parsed) {
+    return {
+      command: params.command,
+      args: [...params.args],
+    };
+  }
+
+  return {
+    command: parsed.command,
+    args: [...parsed.args, ...params.args],
+  };
+}
+
+function argsRequireShellSemantics(args: readonly string[]): boolean {
+  return args.some((arg) =>
+    SHELL_COMMAND_SEPARATORS.has(arg) ||
+    SHELL_REDIRECT_OPERATORS.has(arg) ||
+    SHELL_OPERATOR_RE.test(arg)
+  );
+}
+
+function validateDirectArgs(args: readonly string[]): string | undefined {
+  if (!argsRequireShellSemantics(args)) {
+    return undefined;
+  }
+  return (
+    "Invalid direct-mode args. Shell separators, redirects, or chaining tokens " +
+    "were passed in `args`. Put flags and operands in `args`, or omit `args` and " +
+    "use shell mode with the full shell command in `command`."
+  );
+}
+
+function normalizeBuiltinShellFallback(params: {
+  readonly command: string;
+  readonly args: readonly string[] | undefined;
+  readonly shellModeEnabled: boolean;
+}): string | undefined {
+  if (!params.shellModeEnabled || !params.args || params.args.length === 0) {
+    return undefined;
+  }
+
+  const base = basename(params.command).toLowerCase();
+  if (!SHELL_BUILTIN_COMMANDS.has(base)) {
+    return undefined;
+  }
+
+  if (!argsRequireShellSemantics(params.args)) {
+    return undefined;
+  }
+
+  return [params.command, ...params.args].join(" ");
+}
+
 function truncate(
   text: string,
   maxBytes: number,
@@ -151,6 +222,175 @@ function truncate(
   const buf = Buffer.from(text, "utf-8");
   const truncatedText = buf.subarray(0, maxBytes).toString("utf-8");
   return { text: truncatedText + "\n[truncated]", truncated: true };
+}
+
+function runSpawnedCommand(params: {
+  readonly execCommand: string;
+  readonly execArgs: readonly string[];
+  readonly cwd: string;
+  readonly env: Record<string, string>;
+  readonly timeout: number;
+  readonly maxOutputBytes: number;
+  readonly logCmd: string;
+  readonly logger: Logger;
+  readonly startTime: number;
+  readonly metadataCommand: string;
+  readonly metadataArgs: readonly string[];
+  readonly shellMode: boolean;
+  readonly cleanupPath?: string;
+}): Promise<ToolResult> {
+  return new Promise<ToolResult>((resolve) => {
+    let resolved = false;
+    let stdoutBuf = "";
+    let stderrBuf = "";
+    let timedOut = false;
+    let forceKillTimer: NodeJS.Timeout | null = null;
+
+    const cleanup = (reason: "timeout" | "resolve" | "error") => {
+      if (!params.cleanupPath) return;
+      try {
+        unlinkSync(params.cleanupPath);
+      } catch (error) {
+        params.logger.debug("Bash tool cleanup failed", {
+          reason,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    };
+
+    const child = spawn(params.execCommand, [...params.execArgs], {
+      cwd: params.cwd,
+      env: params.env,
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: true,
+    });
+
+    child.unref();
+
+    child.stdout!.on("data", (chunk: Buffer) => {
+      stdoutBuf += chunk.toString();
+    });
+    child.stderr!.on("data", (chunk: Buffer) => {
+      stderrBuf += chunk.toString();
+    });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        process.kill(-child.pid!, "SIGTERM");
+      } catch (error) {
+        params.logger.debug(
+          "Bash tool process-group SIGTERM failed; falling back to child.kill",
+          {
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+        child.kill("SIGTERM");
+      }
+      forceKillTimer = setTimeout(() => {
+        try {
+          process.kill(-child.pid!, "SIGKILL");
+        } catch {
+          child.kill("SIGKILL");
+        }
+      }, 500);
+      cleanup("timeout");
+    }, params.timeout);
+
+    const doResolve = (code: number | null) => {
+      if (resolved) return;
+      resolved = true;
+      clearTimeout(timer);
+      if (forceKillTimer) {
+        clearTimeout(forceKillTimer);
+      }
+      cleanup("resolve");
+
+      const durationMs = Date.now() - params.startTime;
+      const exitCode = timedOut ? null : (code ?? 1);
+      const isError = timedOut || (exitCode !== null && exitCode !== 0);
+
+      const stdoutResult = truncate(stdoutBuf, params.maxOutputBytes);
+      const stderrResult = truncate(
+        stderrBuf.trim().length > 0
+          ? stderrBuf
+          : isError
+            ? `Command "${params.metadataCommand}" failed`
+            : "",
+        params.maxOutputBytes,
+      );
+
+      if (timedOut) {
+        params.logger.warn(
+          `Bash tool timed out after ${durationMs}ms: ${params.logCmd}`,
+        );
+      } else if (isError) {
+        params.logger.debug(
+          `Bash tool error (exit ${exitCode}): ${params.logCmd}`,
+        );
+      } else {
+        params.logger.debug(
+          `Bash tool success (${durationMs}ms): ${params.logCmd}`,
+        );
+      }
+
+      const result: BashExecutionResult = {
+        exitCode,
+        stdout: stdoutResult.text,
+        stderr: stderrResult.text,
+        timedOut,
+        durationMs,
+        truncated: stdoutResult.truncated || stderrResult.truncated,
+      };
+
+      resolve({
+        content: safeStringify(result),
+        isError: isError || undefined,
+        metadata: {
+          command: params.metadataCommand,
+          args: params.metadataArgs,
+          cwd: params.cwd,
+          shellMode: params.shellMode,
+          timedOut,
+          durationMs,
+        },
+      });
+    };
+
+    child.on("exit", (code) => {
+      setTimeout(() => doResolve(code), 50);
+    });
+
+    child.on("error", (err) => {
+      if (resolved) return;
+      resolved = true;
+      clearTimeout(timer);
+      if (forceKillTimer) {
+        clearTimeout(forceKillTimer);
+      }
+      cleanup("error");
+      const durationMs = Date.now() - params.startTime;
+      resolve({
+        content: safeStringify({
+          error: err.message,
+          exitCode: null,
+          stdout: "",
+          stderr: err.message,
+          timedOut: false,
+          durationMs,
+          truncated: false,
+        }),
+        isError: true,
+        metadata: {
+          command: params.metadataCommand,
+          args: params.metadataArgs,
+          cwd: params.cwd,
+          shellMode: params.shellMode,
+          durationMs,
+        },
+      });
+    });
+  });
 }
 
 function buildDenySet(
@@ -488,22 +728,38 @@ export function createBashTool(config?: BashToolConfig): Tool {
       ) {
         return errorResult("command must be a non-empty string");
       }
+      if (input.args !== undefined && !Array.isArray(input.args)) {
+        return errorResult("args must be an array of strings");
+      }
 
-      const command = input.command.trim();
-      const normalizedArgs = Array.isArray(input.args)
+      const directArgs = Array.isArray(input.args)
         ? input.args
         : undefined;
+      const normalizedDirectInvocation = normalizeDirectInvocation({
+        command: input.command.trim(),
+        args: directArgs,
+      });
+      const command = normalizedDirectInvocation.command;
+      const normalizedArgs = normalizedDirectInvocation.args;
+      const builtinShellFallback = normalizeBuiltinShellFallback({
+        command,
+        args: normalizedArgs,
+        shellModeEnabled,
+      });
+      const shellCommand = builtinShellFallback ?? command;
 
       // Determine execution mode: shell vs direct
       const useShellMode =
-        shellModeEnabled && isShellModeCommand(command, normalizedArgs);
+        shellModeEnabled &&
+        (builtinShellFallback !== undefined ||
+          isShellModeCommand(command, normalizedArgs));
 
       let execCommand: string;
       let execArgs: string[];
 
       if (useShellMode) {
         // Shell mode: validate against dangerous patterns, then run via bash -c
-        const shellCheck = validateShellCommand(command);
+        const shellCheck = validateShellCommand(shellCommand);
         if (!shellCheck.allowed) {
           logger.warn(`Bash tool shell-mode denied: ${shellCheck.reason}`);
           return errorResult(shellCheck.reason);
@@ -514,7 +770,7 @@ export function createBashTool(config?: BashToolConfig): Tool {
           const {
             executables: shellExecutables,
             dynamicExecutableReason,
-          } = extractShellExecutables(command);
+          } = extractShellExecutables(shellCommand);
           if (dynamicExecutableReason) {
             logger.warn(`Bash tool shell-mode denied: ${dynamicExecutableReason}`);
             return errorResult(dynamicExecutableReason);
@@ -534,7 +790,7 @@ export function createBashTool(config?: BashToolConfig): Tool {
         }
 
         execCommand = "/bin/bash";
-        execArgs = ["-c", command];
+        execArgs = ["-c", shellCommand];
       } else {
         // Direct mode: validate command shape, builtins, and deny/allow lists
         if (
@@ -575,15 +831,19 @@ export function createBashTool(config?: BashToolConfig): Tool {
 
         // Validate args
         const args: string[] = [];
-        if (input.args !== undefined) {
-          if (!Array.isArray(input.args)) {
+        if (normalizedArgs !== undefined) {
+          if (!Array.isArray(normalizedArgs)) {
             return errorResult("args must be an array of strings");
           }
-          for (const arg of input.args) {
+          for (const arg of normalizedArgs) {
             if (typeof arg !== "string") {
               return errorResult("Each argument must be a string");
             }
             args.push(arg);
+          }
+          const directArgsError = validateDirectArgs(args);
+          if (directArgsError) {
+            return errorResult(directArgsError);
           }
         }
 
@@ -638,10 +898,12 @@ export function createBashTool(config?: BashToolConfig): Tool {
       const timeout = Math.min(input.timeoutMs ?? defaultTimeout, maxTimeoutMs);
 
       const logCmd = useShellMode
-        ? `[shell] ${command}`
+        ? `[shell] ${shellCommand}`
         : `${command} ${execArgs.join(" ")}`;
       logger.debug(`Bash tool executing: ${logCmd}`);
       const startTime = Date.now();
+      const useSpawnedWrapperMode =
+        !useShellMode && SHELL_WRAPPER_COMMANDS.has(basename(command).toLowerCase());
 
       // Shell mode uses spawn + exit event to avoid hanging when backgrounded
       // children (e.g. `python3 ... &`) inherit stdout/stderr pipes.
@@ -657,156 +919,43 @@ export function createBashTool(config?: BashToolConfig): Tool {
         const scriptId = randomBytes(4).toString("hex");
         const scriptPath = join(tmpdir(), `agenc-sh-${scriptId}.sh`);
         try {
-          writeFileSync(scriptPath, command, { mode: 0o700 });
+          writeFileSync(scriptPath, shellCommand, { mode: 0o700 });
         } catch (writeErr) {
           return errorResult(
             `Failed to create temp script: ${writeErr instanceof Error ? writeErr.message : String(writeErr)}`,
           );
         }
+        return runSpawnedCommand({
+          execCommand: "/bin/bash",
+          execArgs: [scriptPath],
+          cwd,
+          env,
+          timeout,
+          maxOutputBytes,
+          logCmd,
+          logger,
+          startTime,
+          metadataCommand: command,
+          metadataArgs: execArgs,
+          shellMode: true,
+          cleanupPath: scriptPath,
+        });
+      }
 
-        return new Promise<ToolResult>((resolve) => {
-          let resolved = false;
-          let stdoutBuf = "";
-          let stderrBuf = "";
-          let timedOut = false;
-
-          const child = spawn("/bin/bash", [scriptPath], {
-            cwd,
-            env,
-            stdio: ["ignore", "pipe", "pipe"],
-            detached: true, // Own process group for clean timeout kill
-          });
-
-          // Unref so backgrounded grandchildren don't keep Node alive
-          child.unref();
-
-          child.stdout!.on("data", (chunk: Buffer) => {
-            stdoutBuf += chunk.toString();
-          });
-          child.stderr!.on("data", (chunk: Buffer) => {
-            stderrBuf += chunk.toString();
-          });
-
-	          const timer = setTimeout(() => {
-	            timedOut = true;
-	            // Kill entire process group (bash + any backgrounded children)
-	            try {
-	              process.kill(-child.pid!, "SIGTERM");
-	            } catch (error) {
-	              logger.debug("Bash tool process-group SIGTERM failed; falling back to child.kill", {
-	                error: error instanceof Error ? error.message : String(error),
-	              });
-	              child.kill("SIGTERM");
-	            }
-	            try {
-	              unlinkSync(scriptPath);
-	            } catch (error) {
-	              logger.debug("Bash tool script cleanup failed after timeout", {
-	                error: error instanceof Error ? error.message : String(error),
-	              });
-	            }
-	          }, timeout);
-
-	          const doResolve = (code: number | null) => {
-	            if (resolved) return;
-	            resolved = true;
-	            clearTimeout(timer);
-	            try {
-	              unlinkSync(scriptPath);
-	            } catch (error) {
-	              logger.debug("Bash tool script cleanup failed on resolve", {
-	                error: error instanceof Error ? error.message : String(error),
-	              });
-	            }
-
-            const durationMs = Date.now() - startTime;
-            const exitCode = timedOut ? null : (code ?? 1);
-            const isError = timedOut || (exitCode !== null && exitCode !== 0);
-
-            const stdoutResult = truncate(stdoutBuf, maxOutputBytes);
-            const stderrResult = truncate(
-              stderrBuf.trim().length > 0
-                ? stderrBuf
-                : isError
-                  ? `Command "${command}" failed`
-                  : "",
-              maxOutputBytes,
-            );
-
-            if (timedOut) {
-              logger.warn(
-                `Bash tool timed out after ${durationMs}ms: ${logCmd}`,
-              );
-            } else if (isError) {
-              logger.debug(
-                `Bash tool error (exit ${exitCode}): ${logCmd}`,
-              );
-            } else {
-              logger.debug(`Bash tool success (${durationMs}ms): ${logCmd}`);
-            }
-
-            const result: BashExecutionResult = {
-              exitCode,
-              stdout: stdoutResult.text,
-              stderr: stderrResult.text,
-              timedOut,
-              durationMs,
-              truncated: stdoutResult.truncated || stderrResult.truncated,
-            };
-
-            resolve({
-              content: safeStringify(result),
-              isError: isError || undefined,
-              metadata: {
-                command,
-                args: execArgs,
-                cwd,
-                shellMode: true,
-                timedOut,
-                durationMs,
-              },
-            });
-          };
-
-          // Resolve on exit (NOT close) — close waits for pipes,
-          // exit fires when bash process terminates.
-          child.on("exit", (code) => {
-            // Brief delay to flush any remaining pipe data from bash itself
-            setTimeout(() => doResolve(code), 50);
-          });
-
-	          child.on("error", (err) => {
-	            if (resolved) return;
-	            resolved = true;
-	            clearTimeout(timer);
-	            try {
-	              unlinkSync(scriptPath);
-	            } catch (error) {
-	              logger.debug("Bash tool script cleanup failed on child error", {
-	                error: error instanceof Error ? error.message : String(error),
-	              });
-	            }
-	            const durationMs = Date.now() - startTime;
-            resolve({
-              content: safeStringify({
-                error: err.message,
-                exitCode: null,
-                stdout: "",
-                stderr: err.message,
-                timedOut: false,
-                durationMs,
-                truncated: false,
-              }),
-              isError: true,
-              metadata: {
-                command,
-                args: execArgs,
-                cwd,
-                shellMode: true,
-                durationMs,
-              },
-            });
-          });
+      if (useSpawnedWrapperMode) {
+        return runSpawnedCommand({
+          execCommand,
+          execArgs,
+          cwd,
+          env,
+          timeout,
+          maxOutputBytes,
+          logCmd,
+          logger,
+          startTime,
+          metadataCommand: command,
+          metadataArgs: execArgs,
+          shellMode: false,
         });
       }
 

--- a/runtime/src/utils/delegation-validation.test.ts
+++ b/runtime/src/utils/delegation-validation.test.ts
@@ -79,6 +79,14 @@ describe("delegation-validation", () => {
     ).toEqual(["inspection"]);
   });
 
+  it("treats grounded verification command-reporting criteria as command verification", () => {
+    expect(
+      getAcceptanceVerificationCategories(
+        "Grounded verification runs before completion, and passing or failing commands are reported concretely.",
+      ),
+    ).toEqual(["command"]);
+  });
+
   it("does not treat current-guide review criteria as workspace inspection verification", () => {
     expect(
       getAcceptanceVerificationCategories(
@@ -593,7 +601,72 @@ describe("delegation-validation", () => {
     expect(result.error).toContain("npm install");
   });
 
-  it("bypasses delegated contract enforcement in unsafe benchmark mode", () => {
+  it("rejects rewriting a repo-local verification harness unless the contract names it as writable", () => {
+    const workspaceRoot = "/workspace/agenc-shell";
+    const result = validateDelegatedOutputContract({
+      spec: {
+        task: "implement_owner",
+        objective:
+          "Implement the requested shell features in the workspace and verify them with the existing repo-local harness.",
+        inputContract:
+          "Use PLAN.md plus the current workspace sources to complete the implementation.",
+        acceptanceCriteria: [
+          "Workspace files are updated to satisfy the requested implementation phases.",
+          "Verify with bash tests/run_tests.sh before completion.",
+        ],
+        executionContext: {
+          workspaceRoot,
+          allowedReadRoots: [workspaceRoot],
+          allowedWriteRoots: [workspaceRoot],
+          targetArtifacts: [workspaceRoot],
+          requiredSourceArtifacts: [`${workspaceRoot}/PLAN.md`],
+          effectClass: "filesystem_write",
+          verificationMode: "mutation_required",
+          stepKind: "delegated_write",
+          role: "writer",
+          artifactRelations: [
+            {
+              relationType: "read_dependency",
+              artifactPath: `${workspaceRoot}/PLAN.md`,
+            },
+            {
+              relationType: "write_owner",
+              artifactPath: workspaceRoot,
+            },
+          ],
+        },
+      },
+      output:
+        "Implemented the remaining phases and verified the full request with the workspace test harness.",
+      toolCalls: [
+        {
+          name: "system.writeFile",
+          args: {
+            path: `${workspaceRoot}/tests/run_tests.sh`,
+            content: "#!/usr/bin/env bash\nrm -rf build\nmkdir build\n",
+          },
+          result:
+            `{"path":"${workspaceRoot}/tests/run_tests.sh","bytesWritten":47}`,
+        },
+        {
+          name: "system.bash",
+          args: {
+            command: "bash",
+            args: ["tests/run_tests.sh"],
+            cwd: workspaceRoot,
+          },
+          result: '{"stdout":"all tests passed","stderr":"","exitCode":0}',
+        },
+      ],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("forbidden_phase_action");
+    expect(result.error).toContain("repo-local verification harness");
+    expect(result.error).toContain("run_tests.sh");
+  });
+
+  it("still enforces delegated contract truth in unsafe benchmark mode", () => {
     const result = validateDelegatedOutputContract({
       spec: {
         task: "scaffold_manifests",
@@ -620,7 +693,117 @@ describe("delegation-validation", () => {
       unsafeBenchmarkMode: true,
     });
 
-    expect(result.ok).toBe(true);
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("forbidden_phase_action");
+    expect(result.error).toContain("dependency-install commands");
+  });
+
+  it("still rejects repo-local verification harness rewrites in unsafe benchmark mode", () => {
+    const result = validateDelegatedOutputContract({
+      spec: {
+        task: "implement_owner",
+        objective: "Implement the shell and verify it with the existing repo-local test harness.",
+        inputContract: "Use the workspace test script as read-only grader infrastructure.",
+        acceptanceCriteria: [
+          "Run the existing tests/run_tests.sh harness and report grounded results.",
+        ],
+      },
+      output:
+        "**implement_owner complete** Updated the shell and expanded tests/run_tests.sh to validate builtins before running it.",
+      toolCalls: [
+        {
+          name: "system.writeFile",
+          args: {
+            path: "/workspace/agenc-shell/tests/run_tests.sh",
+            content: "#!/bin/bash\necho hacked\n",
+          },
+          result:
+            "{\"path\":\"/workspace/agenc-shell/tests/run_tests.sh\",\"bytesWritten\":24,\"__agencVerification\":{\"category\":\"behavior\",\"generatedHarness\":true,\"path\":\"/workspace/agenc-shell/tests/run_tests.sh\",\"repoLocal\":true}}",
+        },
+        {
+          name: "system.bash",
+          args: {
+            command: "bash",
+            args: ["/workspace/agenc-shell/tests/run_tests.sh"],
+            cwd: "/workspace/agenc-shell",
+          },
+          result: "{\"stdout\":\"ok\",\"stderr\":\"\",\"exitCode\":0}",
+        },
+      ],
+      unsafeBenchmarkMode: true,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("forbidden_phase_action");
+    expect(result.error).toContain("repo-local verification harness");
+    expect(result.error).toContain("run_tests.sh");
+  });
+
+  it("rejects failed deterministic verification summaries in unsafe benchmark mode", () => {
+    const workspaceRoot = "/workspace/agenc-shell";
+    const result = validateDelegatedOutputContract({
+      spec: {
+        task: "test_phase_1",
+        objective:
+          "Run all tests for Phase 1 implementation. Verify 100% passing test suite specific to this phase. Fix any failures before completion.",
+        inputContract: "Run the repo-local harness and report grounded verification results.",
+        acceptanceCriteria: [
+          "All Phase 1 tests pass with 100% success rate",
+          "No test failures or errors remain",
+          "Test command exits with code 0",
+        ],
+        executionContext: {
+          workspaceRoot,
+          allowedReadRoots: [workspaceRoot],
+          allowedWriteRoots: [workspaceRoot],
+          targetArtifacts: [workspaceRoot],
+          requiredSourceArtifacts: [`${workspaceRoot}/tests/run_tests.sh`],
+          verificationMode: "deterministic_followup",
+          stepKind: "delegated_validation",
+          role: "validator",
+          artifactRelations: [
+            {
+              relationType: "read_dependency",
+              artifactPath: `${workspaceRoot}/tests/run_tests.sh`,
+            },
+            {
+              relationType: "verification_subject",
+              artifactPath: workspaceRoot,
+            },
+          ],
+        },
+        requiredToolCapabilities: ["shell", "system.readFile"],
+      },
+      output:
+        "Inspected tests/run_tests.sh. Blocked: The test suite in tests/run_tests.sh includes tests for later phases, so Phase 1 is complete but full verification is out of scope for this delegated contract.",
+      toolCalls: [
+        {
+          name: "system.readFile",
+          args: { path: `${workspaceRoot}/tests/run_tests.sh` },
+          result:
+            `{"path":"${workspaceRoot}/tests/run_tests.sh","content":"#!/bin/bash\\n./agenc-shell --help\\n"}`,
+        },
+        {
+          name: "system.bash",
+          args: {
+            command: "bash",
+            args: ["tests/run_tests.sh"],
+            cwd: workspaceRoot,
+          },
+          result:
+            "{\"exitCode\":1,\"stdout\":\"Running tests...\\npwd test failed: got 'Agenc Shell', expected '/workspace/agenc-shell/build'\\n\",\"stderr\":\"Command \\\"bash\\\" failed\",\"timedOut\":false}",
+          isError: true,
+        },
+      ],
+      unsafeBenchmarkMode: true,
+    });
+
+    expect(result.ok).toBe(false);
+    expect([
+      "missing_required_source_evidence",
+      "blocked_phase_output",
+      "acceptance_evidence_missing",
+    ]).toContain(result.code);
   });
 
   it("does not treat authored root config summaries as forbidden test execution claims", () => {
@@ -913,6 +1096,49 @@ describe("delegation-validation", () => {
     });
 
     expect(result.ok).toBe(true);
+  });
+
+  it("rejects full-request owner completions that defer later phases as out of scope", () => {
+    const workspaceRoot = "/workspace/agenc-shell";
+    const result = validateDelegatedOutputContract({
+      spec: {
+        task: "implement_owner",
+        objective:
+          "Execute this implementation request end to end and complete every phase sequentially in full.",
+        parentRequest:
+          "Can you go through @PLAN.md and implement every phase sequentially in full and make sure they are fully tested.",
+        inputContract:
+          "Use the planning artifact plus the current workspace to perform the requested implementation end to end.",
+        acceptanceCriteria: [
+          "Update the owned workspace files to implement the remaining plan phases.",
+        ],
+        executionContext: {
+          workspaceRoot,
+          targetArtifacts: [workspaceRoot],
+          role: "writer",
+          artifactRelations: [
+            {
+              relationType: "write_owner",
+              artifactPath: workspaceRoot,
+            },
+          ],
+        },
+      },
+      output:
+        "Implemented Phase 1 and Phase 2 successfully. Phase 3 is out of scope for this phase, so the remaining work belongs to the next phase.",
+      toolCalls: [{
+        name: "system.writeFile",
+        args: {
+          path: `${workspaceRoot}/src/parser.c`,
+          content: "/* parser */\n",
+        },
+        result: `{\"path\":\"${workspaceRoot}/src/parser.c\",\"bytesWritten\":13}`,
+      }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("blocked_phase_output");
+    expect(result.error).toContain("out of scope");
   });
 
   it("rejects completion claims that describe an implementation as stubbed", () => {
@@ -2031,6 +2257,40 @@ describe("delegation-validation", () => {
         name: "mcp.browser.browser_snapshot",
         isError: true,
         result: '{"error":"navigation failed"}',
+      }],
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("missing_successful_tool_evidence");
+  });
+
+  it("rejects shell verification output when stderr shows a shell path failure despite exitCode 0", () => {
+    const result = validateDelegatedOutputContract({
+      spec: {
+        objective: "Run the project test script and report whether verification passed",
+        acceptanceCriteria: [
+          "Tests pass with grounded shell evidence and commands are reported concretely.",
+        ],
+        tools: ["system.bash"],
+        executionContext: {
+          version: "v1",
+          workspaceRoot: "/tmp/project",
+          effectClass: "shell",
+          verificationMode: "deterministic_followup",
+          stepKind: "delegated_validation",
+          role: "validator",
+        },
+      },
+      output: "Tests passed.",
+      toolCalls: [{
+        name: "system.bash",
+        args: { command: "cd /tmp/project/tests && bash run_tests.sh" },
+        result: JSON.stringify({
+          stdout: "Running tests...\nCompilation test passed\n",
+          stderr:
+            "run_tests.sh: line 6: cd: build: No such file or directory\n",
+          exitCode: 0,
+        }),
       }],
     });
 
@@ -3886,6 +4146,55 @@ Project is functional for core/pathfinding; CLI/web assumed usable per authored 
       "system.bash",
       "system.listDir",
       "system.writeFile",
+    ]);
+  });
+
+  it("keeps shell available for live implement-from-plan owner contracts that require grounded verification", () => {
+    const toolNames = resolveDelegatedInitialToolChoiceToolNames(
+      {
+        task: "implement_owner",
+        objective:
+          "Execute this implementation request inside the workspace: okay what i did was delete absolutely everything except for the @PLAN.md because i want to start this fresh can you go through the plan.md file and anything that says it has been completed already fix since it's a fresh folder",
+        inputContract:
+          "Use the planning artifact plus the current workspace to perform the requested implementation end to end. Do not stop at analysis only.",
+        acceptanceCriteria: [
+          "Workspace files are updated to satisfy the requested implementation phases.",
+          "Grounded verification runs before completion, and passing or failing commands are reported concretely.",
+          "If a blocker prevents completion, report the concrete blocker with evidence instead of returning an analysis-only summary.",
+        ],
+        executionContext: {
+          workspaceRoot: "/tmp/agenc-shell-fresh",
+          allowedReadRoots: ["/tmp/agenc-shell-fresh"],
+          allowedWriteRoots: ["/tmp/agenc-shell-fresh"],
+          allowedTools: ["system.readFile", "system.writeFile", "system.bash"],
+          requiredSourceArtifacts: ["/tmp/agenc-shell-fresh/PLAN.md"],
+          targetArtifacts: ["/tmp/agenc-shell-fresh"],
+          effectClass: "filesystem_write",
+          verificationMode: "mutation_required",
+          stepKind: "delegated_write",
+          role: "writer",
+          artifactRelations: [
+            {
+              relationType: "read_dependency",
+              artifactPath: "/tmp/agenc-shell-fresh/PLAN.md",
+            },
+            {
+              relationType: "write_owner",
+              artifactPath: "/tmp/agenc-shell-fresh",
+            },
+          ],
+          fallbackPolicy: "fail_request",
+          resumePolicy: "stateless_retry",
+          approvalProfile: "filesystem_write",
+        },
+      },
+      ["system.readFile", "system.writeFile", "system.bash"],
+    );
+
+    expect(toolNames).toEqual([
+      "system.readFile",
+      "system.writeFile",
+      "system.bash",
     ]);
   });
 

--- a/runtime/src/utils/delegation-validation.ts
+++ b/runtime/src/utils/delegation-validation.ts
@@ -11,6 +11,10 @@ import type { LLMProviderEvidence } from "../llm/types.js";
 import type { DelegationExecutionContext } from "./delegation-execution-context.js";
 import type { WorkflowStepRole } from "../workflow/execution-envelope.js";
 import {
+  resolveExecutionEnvelopeArtifactRelations,
+  resolveExecutionEnvelopeRole,
+} from "../workflow/execution-envelope.js";
+import {
   PROVIDER_NATIVE_FILE_SEARCH_TOOL,
   PROVIDER_NATIVE_RESEARCH_TOOL_NAMES,
   PROVIDER_NATIVE_WEB_SEARCH_TOOL,
@@ -83,6 +87,9 @@ export interface DelegationValidationToolCall {
 
 export interface DelegationValidationProviderEvidence
   extends LLMProviderEvidence {}
+
+const SHELL_EXECUTION_ANOMALY_RE =
+  /(?:^|\n)(?:[^:\n]+:\s+line\s+\d+:\s+)?(?:(?:ba|z|k)?sh|cd|pushd|popd|source|\.)[^:\n]*:\s+.*(?:no such file or directory|command not found|not found|permission denied|not a directory)/i;
 
 export const DELEGATION_OUTPUT_VALIDATION_CODES = [
   "empty_output",
@@ -199,7 +206,7 @@ const VALIDATION_STRONG_TASK_RE =
   /\b(?:validate|validation|verify|verified|playtest|qa|end-to-end|e2e|test|tests|smoke test|acceptance test|build checks?)\b/i;
 const VALIDATION_WEAK_TASK_RE = /\b(?:browser|chromium|localhost)\b/i;
 const ACCEPTANCE_VERIFICATION_CUE_RE =
-  /\b(?:compile|compiles|compiled|compiling|build(?:able|\s+checks?)?|test(?:able|s)?|verify|validated?|confirm|install(?:able|s|ed|ing)?|stdout|stderr|exit(?:\s+code|s)?)\b/i;
+  /\b(?:compile|compiles|compiled|compiling|build(?:able|\s+checks?)?|test(?:able|s)?|verify|verification|validated?|confirm|install(?:able|s|ed|ing)?|stdout|stderr|exit(?:\s+code|s)?|passing\s+or\s+failing\s+commands?|commands?\s+are\s+reported)\b/i;
 const ACCEPTANCE_BUILD_VERIFICATION_RE =
   /\b(?:compiles?|compiled|compiling|builds?|built|typechecks?|lints?|installs?)\b(?:\s+(?:cleanly|correctly|successfully|without errors?))?|\b(?:compile|build|typecheck|lint|install)\s+(?:cleanly|correctly|successfully|without errors?|passes?|succeeds?)\b/i;
 const ACCEPTANCE_TEST_VERIFICATION_RE =
@@ -221,7 +228,9 @@ const ACCEPTANCE_DOCUMENTATION_DEFINITION_RE =
 const ACCEPTANCE_DOCUMENTATION_DEFINITION_VERB_RE =
   /\b(?:present|exists?|author(?:ed)?|wrote|created?|added?|included?|outlined?|section(?:s)?|placeholder(?:s)?|skeleton|template)\b/i;
 const ACCEPTANCE_STRONG_VERIFICATION_CUE_RE =
-  /\b(?:pass(?:es|ed|ing)?|succeed(?:s|ed|ing)?|run(?:s|ning)?|ran|verify|verified|validated?|confirm(?:ed|s)?|coverage|stdout|stderr|exit(?:\s+code|s)?|cleanly|correctly|successfully|without errors?)\b/i;
+  /\b(?:pass(?:es|ed|ing)?|succeed(?:s|ed|ing)?|run(?:s|ning)?|ran|verify|verification|verified|validated?|confirm(?:ed|s)?|coverage|stdout|stderr|exit(?:\s+code|s)?|cleanly|correctly|successfully|without errors?|passing\s+or\s+failing\s+commands?|commands?\s+are\s+reported)\b/i;
+const ACCEPTANCE_COMMAND_VERIFICATION_RE =
+  /\b(?:verification\s+runs?\b|passing\s+or\s+failing\s+commands?\b|commands?\s+are\s+reported\b|report(?:ed|ing)?\s+(?:passing|failing|command)\b)\b/i;
 const ACCEPTANCE_BUILD_TEST_OUTCOME_RE =
   /\b(?:compiles?|compiled|compiling|builds|built|building|typechecks?|typechecked|lints?|linted|installs?|installed|installing)\b/i;
 const ACCEPTANCE_EXPLICIT_EXECUTION_RE =
@@ -1328,6 +1337,43 @@ function collectExplicitSourceSpecFileArtifacts(
   ]);
 }
 
+function collectExplicitWritableSpecFileArtifacts(
+  spec: DelegationContractSpec,
+): readonly string[] {
+  const workspaceRoot = normalizeExplicitArtifactPath(
+    spec.executionContext?.workspaceRoot ?? "",
+  );
+  const explicitArtifacts = new Set<string>();
+  const addArtifact = (value: string | undefined): void => {
+    if (typeof value !== "string" || value.trim().length === 0) return;
+    const normalized = normalizeExplicitArtifactPath(value);
+    if (normalized.length === 0 || normalized === workspaceRoot) return;
+    explicitArtifacts.add(normalized);
+  };
+
+  for (const artifact of spec.executionContext?.targetArtifacts ?? []) {
+    addArtifact(artifact);
+  }
+  for (const artifact of spec.ownedArtifacts ?? []) {
+    addArtifact(artifact);
+  }
+  for (const relation of resolveExecutionEnvelopeArtifactRelations(
+    spec.executionContext,
+  )) {
+    if (relation.relationType !== "write_owner") continue;
+    addArtifact(relation.artifactPath);
+  }
+  for (const artifact of collectExplicitFileArtifactsFromSegments([
+    spec.task,
+    spec.objective,
+    spec.parentRequest,
+  ])) {
+    addArtifact(artifact);
+  }
+
+  return [...explicitArtifacts];
+}
+
 function outputClaimsAlreadySatisfiedWithoutMutation(output: string): boolean {
   return FILE_ALREADY_SATISFIED_NOOP_RE.test(output) &&
     !FILE_MUTATION_CLAIM_RE.test(output);
@@ -1387,6 +1433,150 @@ function pathsMatchByTarget(candidatePath: string, targetPath: string): boolean 
   return normalizedCandidate === normalizedTarget ||
     normalizedCandidate.endsWith(`/${normalizedTarget}`) ||
     normalizedTarget.endsWith(`/${normalizedCandidate}`);
+}
+
+function collectMutatedFilePaths(
+  toolCalls: readonly DelegationValidationToolCall[],
+): readonly string[] {
+  const paths = new Set<string>();
+  for (const toolCall of toolCalls) {
+    if (!hasToolCallFileMutationEvidence(toolCall)) continue;
+    const observedPaths = extractToolCallObservedFileStateEvidence(toolCall)
+      .map((entry) => entry.path)
+      .filter((value): value is string =>
+        typeof value === "string" && value.trim().length > 0
+      );
+    for (const value of observedPaths) {
+      paths.add(normalizeExplicitArtifactPath(value));
+    }
+    const resultPath = getToolCallResultPath(toolCall);
+    if (typeof resultPath === "string" && resultPath.trim().length > 0) {
+      paths.add(normalizeExplicitArtifactPath(resultPath));
+    }
+    if (
+      typeof toolCall.args === "object" &&
+      toolCall.args !== null &&
+      !Array.isArray(toolCall.args)
+    ) {
+      const argPath = (toolCall.args as { path?: unknown }).path;
+      if (typeof argPath === "string" && argPath.trim().length > 0) {
+        paths.add(normalizeExplicitArtifactPath(argPath));
+      }
+    }
+  }
+  return [...paths].filter((value) => value.length > 0);
+}
+
+function looksLikeLocalScriptPath(value: string): boolean {
+  const normalized = normalizeExplicitArtifactPath(value)
+    .replace(/^\.\/+/, "")
+    .replace(/^["'`]+|["'`]+$/g, "");
+  if (normalized.length === 0) return false;
+  if (/^(?:https?:|node:)/i.test(normalized)) return false;
+  return /(?:^|\/)[^/\s]+\.(?:sh|bash|zsh|ps1|py|js|ts)$/i.test(normalized);
+}
+
+function collectVerificationHarnessInvocationPaths(
+  toolCall: DelegationValidationToolCall,
+): readonly string[] {
+  if (!getToolCallVerificationCategories(toolCall).includes("command")) {
+    return [];
+  }
+  if (
+    typeof toolCall.args !== "object" ||
+    toolCall.args === null ||
+    Array.isArray(toolCall.args)
+  ) {
+    return [];
+  }
+
+  const payload = toolCall.args as { command?: unknown; args?: unknown };
+  const command =
+    typeof payload.command === "string" ? payload.command.trim() : "";
+  const args = Array.isArray(payload.args)
+    ? payload.args.filter((value): value is string => typeof value === "string")
+    : [];
+  const paths = new Set<string>();
+  const addIfScriptPath = (value: string): void => {
+    if (!looksLikeLocalScriptPath(value)) return;
+    paths.add(normalizeExplicitArtifactPath(value));
+  };
+
+  const commandBasename = command.split(/[\\/]/).pop()?.toLowerCase() ?? "";
+  if (
+    /^(?:ba|z|k)?sh$/.test(commandBasename) &&
+    typeof args[0] === "string"
+  ) {
+    addIfScriptPath(args[0]);
+  }
+  addIfScriptPath(command);
+
+  if (args.length === 0 && command.length > 0) {
+    const shellInvocationPatterns = [
+      /\b(?:ba|z|k)?sh\s+((?:\.{1,2}\/|\/)?[^\s;&|`'"]+\.(?:sh|bash|zsh))\b/gi,
+      /(?:^|[;&|]\s*)((?:\.{1,2}\/|\/)[^\s;&|`'"]+\.(?:sh|bash|zsh))\b/gi,
+    ];
+    for (const pattern of shellInvocationPatterns) {
+      let match: RegExpExecArray | null;
+      while ((match = pattern.exec(command)) !== null) {
+        addIfScriptPath(match[1] ?? "");
+      }
+    }
+  }
+
+  return [...paths];
+}
+
+function validateRepoLocalVerificationHarnessMutation(
+  spec: DelegationContractSpec,
+  parsedOutput: Record<string, unknown> | undefined,
+  toolCalls: readonly DelegationValidationToolCall[] | undefined,
+): DelegationOutputValidationResult | undefined {
+  if (!Array.isArray(toolCalls) || toolCalls.length === 0) {
+    return undefined;
+  }
+
+  const mutatedPaths = collectMutatedFilePaths(toolCalls);
+  if (mutatedPaths.length === 0) {
+    return undefined;
+  }
+
+  const executedHarnessPaths = [
+    ...new Set(
+      toolCalls.flatMap((toolCall) =>
+        collectVerificationHarnessInvocationPaths(toolCall)
+      ),
+    ),
+  ];
+  if (executedHarnessPaths.length === 0) {
+    return undefined;
+  }
+
+  const explicitlyWritableArtifacts = collectExplicitWritableSpecFileArtifacts(
+    spec,
+  );
+  const offendingHarnessPath = mutatedPaths.find((mutatedPath) =>
+    executedHarnessPaths.some((harnessPath) =>
+      pathsMatchByTarget(mutatedPath, harnessPath) ||
+      getNormalizedPathBasename(mutatedPath) ===
+        getNormalizedPathBasename(harnessPath)
+    ) &&
+    !explicitlyWritableArtifacts.some((artifactPath) =>
+      pathsMatchByTarget(mutatedPath, artifactPath) ||
+      getNormalizedPathBasename(mutatedPath) ===
+        getNormalizedPathBasename(artifactPath)
+    )
+  );
+  if (!offendingHarnessPath) {
+    return undefined;
+  }
+
+  return validationFailure(
+    "forbidden_phase_action",
+    "Delegated task rewrote a repo-local verification harness without explicitly owning it as a writable target: " +
+      offendingHarnessPath,
+    parsedOutput,
+  );
 }
 
 function collectLatestReadFileStateEvidence(
@@ -2851,10 +3041,20 @@ function isToolCallFailure(toolCall: DelegationValidationToolCall): boolean {
   ) {
     return true;
   }
+  if (
+    typeof parsed.stderr === "string" &&
+    SHELL_EXECUTION_ANOMALY_RE.test(parsed.stderr)
+  ) {
+    return true;
+  }
   return false;
 }
 
-export type AcceptanceVerificationCategory = "build" | "test" | "inspection";
+export type AcceptanceVerificationCategory =
+  | "build"
+  | "test"
+  | "inspection"
+  | "command";
 type ForbiddenPhaseActionCategory =
   | "install"
   | "build"
@@ -3028,6 +3228,9 @@ export function getAcceptanceVerificationCategories(
   if (ACCEPTANCE_TEST_VERIFICATION_RE.test(criterion)) {
     categories.add("test");
   }
+  if (ACCEPTANCE_COMMAND_VERIFICATION_RE.test(criterion)) {
+    categories.add("command");
+  }
   if (criterionRequiresWorkspaceInspectionVerification(criterion)) {
     categories.add("inspection");
   }
@@ -3052,6 +3255,9 @@ function getToolCallVerificationCategories(
   }
 
   const categories = new Set<AcceptanceVerificationCategory>();
+  if (combined.trim().length > 0) {
+    categories.add("command");
+  }
   if (TOOLCALL_BUILD_EVIDENCE_RE.test(combined)) {
     categories.add("build");
   }
@@ -3981,7 +4187,18 @@ function validateBlockedPhaseOutput(
         allowsExpectedPlaceholders ? DELEGATED_ALLOWABLE_PLACEHOLDER_RE : /$^/,
         " ",
       );
-      if (reportsCompletion && DELEGATED_SCOPED_EXCLUSION_RE.test(normalized)) {
+      if (
+        reportsCompletion &&
+        DELEGATED_SCOPED_EXCLUSION_RE.test(normalized) &&
+        specOwnsRemainingRequestEndToEnd(spec)
+      ) {
+        return true;
+      }
+      if (
+        reportsCompletion &&
+        DELEGATED_SCOPED_EXCLUSION_RE.test(normalized) &&
+        !specOwnsRemainingRequestEndToEnd(spec)
+      ) {
         return false;
       }
       return normalized.length > 0 && DELEGATED_BLOCKED_PHASE_RE.test(normalized);
@@ -3996,6 +4213,46 @@ function validateBlockedPhaseOutput(
     "Delegated task output reported the phase as blocked or incomplete instead of completing it: " +
       truncateValidationExcerpt(blockedSnippet),
     parsedOutput,
+  );
+}
+
+function specOwnsRemainingRequestEndToEnd(
+  spec: DelegationContractSpec,
+): boolean {
+  const executionContext = spec.executionContext;
+  const workspaceRoot = executionContext?.workspaceRoot?.trim();
+  const role = resolveExecutionEnvelopeRole(executionContext);
+  if (!workspaceRoot || role !== "writer") {
+    return false;
+  }
+  const artifactRelations = resolveExecutionEnvelopeArtifactRelations(
+    executionContext,
+  );
+  const ownsWorkspaceRoot = artifactRelations.some((relation) =>
+    relation.relationType === "write_owner" &&
+      relation.artifactPath.trim() === workspaceRoot
+  ) || (executionContext?.targetArtifacts ?? []).some((artifactPath) =>
+    artifactPath.trim() === workspaceRoot
+  );
+  if (!ownsWorkspaceRoot) {
+    return false;
+  }
+  const combinedText = [
+    spec.task,
+    spec.objective,
+    spec.parentRequest,
+    spec.inputContract,
+    ...(spec.acceptanceCriteria ?? []),
+  ]
+    .filter((value): value is string =>
+      typeof value === "string" && value.trim().length > 0
+    )
+    .join(" ")
+    .toLowerCase();
+  return (
+    (spec.task?.trim().toLowerCase() ?? "") === "implement_owner" ||
+    /\b(?:end to end|every phase|all phases|sequentially in full|requested implementation phases|full request)\b/i
+      .test(combinedText)
   );
 }
 
@@ -4093,16 +4350,21 @@ export function validateDelegatedOutputContract(params: {
     providerEvidence,
     enforceAcceptanceEvidence = true,
     deferExecutableOutcomeValidation = false,
-    unsafeBenchmarkMode = false,
   } = params;
   const baseValidation = validateBasicOutputContract({
     inputContract: spec.inputContract,
     output,
   });
   if (!baseValidation.ok) return baseValidation;
-  if (unsafeBenchmarkMode) return baseValidation;
 
   const parsedOutput = baseValidation.parsedOutput;
+  const harnessMutationFailure = validateRepoLocalVerificationHarnessMutation(
+    spec,
+    parsedOutput,
+    toolCalls,
+  );
+  if (harnessMutationFailure) return harnessMutationFailure;
+
   const toolEvidenceFailure = validateSuccessfulToolEvidence(
     spec,
     parsedOutput,

--- a/runtime/src/workflow/delegated-filesystem-scope.test.ts
+++ b/runtime/src/workflow/delegated-filesystem-scope.test.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { buildCanonicalDelegatedFilesystemScope } from "./delegated-filesystem-scope.js";
+
+const TEMP_DIRS: string[] = [];
+
+afterEach(() => {
+  for (const path of TEMP_DIRS.splice(0, TEMP_DIRS.length)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+});
 
 describe("buildCanonicalDelegatedFilesystemScope", () => {
   it("canonicalizes alias placeholders only when a trusted host root is supplied", () => {
@@ -49,5 +60,23 @@ describe("buildCanonicalDelegatedFilesystemScope", () => {
       requiredSourceArtifacts: [],
       targetArtifacts: [],
     });
+  });
+
+  it("resolves required source artifacts to existing workspace casing", () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-scope-case-"));
+    TEMP_DIRS.push(workspaceRoot);
+    writeFileSync(join(workspaceRoot, "PLAN.md"), "# plan\n", "utf8");
+
+    const scope = buildCanonicalDelegatedFilesystemScope({
+      workspaceRoot,
+      allowedReadRoots: [workspaceRoot],
+      allowedWriteRoots: [workspaceRoot],
+      requiredSourceArtifacts: [`${workspaceRoot}/plan.md`],
+      targetArtifacts: [`${workspaceRoot}/src`],
+    });
+
+    expect(scope.requiredSourceArtifacts).toEqual([
+      join(workspaceRoot, "PLAN.md"),
+    ]);
   });
 });

--- a/runtime/src/workflow/path-normalization.ts
+++ b/runtime/src/workflow/path-normalization.ts
@@ -1,3 +1,4 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
 import { dirname, isAbsolute, relative, resolve as resolvePath } from "node:path";
 
 const WORKSPACE_ALIAS_ROOT = "/workspace";
@@ -156,12 +157,77 @@ export function normalizeArtifactPaths(
   for (const path of paths) {
     const trimmed = trimPath(path);
     if (!trimmed) continue;
-    const resolved = normalizeEnvelopePath(trimmed, workspaceRoot);
+    const resolved = resolveWorkspaceArtifactPathCase(
+      normalizeEnvelopePath(trimmed, workspaceRoot),
+      workspaceRoot,
+    );
     if (!resolved || seen.has(resolved)) continue;
     seen.add(resolved);
     normalized.push(resolved);
   }
   return normalized;
+}
+
+function resolveWorkspaceArtifactPathCase(
+  artifactPath: string,
+  workspaceRoot?: string,
+): string {
+  if (!workspaceRoot || artifactPath.length === 0 || existsSync(artifactPath)) {
+    return artifactPath;
+  }
+
+  const normalizedWorkspaceRoot = resolvePath(workspaceRoot);
+  const normalizedArtifactPath = resolvePath(artifactPath);
+  if (
+    normalizedArtifactPath !== normalizedWorkspaceRoot &&
+    !isPathWithinRoot(normalizedArtifactPath, normalizedWorkspaceRoot)
+  ) {
+    return normalizedArtifactPath;
+  }
+
+  const relativeArtifactPath = relative(
+    normalizedWorkspaceRoot,
+    normalizedArtifactPath,
+  );
+  if (
+    relativeArtifactPath.length === 0 ||
+    relativeArtifactPath.startsWith("..") ||
+    isAbsolute(relativeArtifactPath)
+  ) {
+    return normalizedArtifactPath;
+  }
+
+  const segments = relativeArtifactPath.split(/[\\/]+/u).filter(Boolean);
+  let currentPath = normalizedWorkspaceRoot;
+  for (const segment of segments) {
+    if (!existsSync(currentPath)) {
+      return normalizedArtifactPath;
+    }
+    let directoryEntries: readonly string[];
+    try {
+      if (!statSync(currentPath).isDirectory()) {
+        return normalizedArtifactPath;
+      }
+      directoryEntries = readdirSync(currentPath);
+    } catch {
+      return normalizedArtifactPath;
+    }
+    const exactMatch = directoryEntries.find((entry) => entry === segment);
+    const matchedSegment =
+      exactMatch ??
+      (() => {
+        const foldedMatches = directoryEntries.filter(
+          (entry) => entry.toLowerCase() === segment.toLowerCase(),
+        );
+        return foldedMatches.length === 1 ? foldedMatches[0] : undefined;
+      })();
+    if (!matchedSegment) {
+      return normalizedArtifactPath;
+    }
+    currentPath = resolvePath(currentPath, matchedSegment);
+  }
+
+  return currentPath;
 }
 
 export function inferDirectoryTargetsForArtifacts(


### PR DESCRIPTION
## Summary
- harden delegated runtime context, planner recovery, compaction, and verification handling for live shell replay workflows
- tighten repo-local verification harness protections and direct children toward bounded root-level verification instead of shadow harnesses
- add regression coverage for workspace-root propagation, compaction false-closure, recovery hints, planner/runtime contract preservation, and routed provider/tool edge cases

## Validation
- `npx vitest run src/gateway/sub-agent.test.ts -t "passes delegated workspace roots into child execution runtime context|still passes the delegated contract into child execution when tool calls are optional"`
- `npx vitest run src/llm/context-compaction.test.ts`
- `npx vitest run src/llm/context-compaction.test.ts src/llm/chat-executor-recovery.test.ts src/gateway/subagent-orchestrator.test.ts -t "repo-local verification harness|single-owner implement_owner handoffs as end-to-end request ownership|adds structured shell usage guidance to child prompts|overrides no-blocker compaction summaries"`
- `npm run build`
- `npm run techdebt`