### PR TITLE
fix(runtime): remove server-handle gate + raise sub-agent timeout floor

### DIFF
--- a/runtime/src/gateway/delegation-timeout.ts
+++ b/runtime/src/gateway/delegation-timeout.ts
@@ -7,8 +7,13 @@
  * @module
  */
 
-export const MIN_DELEGATION_TIMEOUT_MS = 0;
-export const MAX_DELEGATION_TIMEOUT_MS = 3_600_000;
+// Floor: sub-agents always get at least 2 minutes.  The planner's LLM
+// sometimes emits aggressive budgets (e.g. "30s") that starve coding tasks
+// before the first tool call even completes.  0 = unlimited (no timer).
+export const MIN_DELEGATION_TIMEOUT_MS = 120_000;
+// Ceiling removed — the runtime should support indefinite sub-agent work.
+// Individual callers can still pass explicit timeouts when needed.
+export const MAX_DELEGATION_TIMEOUT_MS = 0;
 
 const EXPLICIT_BUDGET_HINT_RE =
   /^(\d+(?:\.\d+)?)\s*(ms|s|sec|m|min|h|hr)$/i;
@@ -101,10 +106,16 @@ export function normalizeDelegationTimeoutMs(
     return undefined;
   }
   const normalized = Math.floor(timeoutMs);
-  if (normalized <= MIN_DELEGATION_TIMEOUT_MS) {
+  if (normalized <= 0) {
+    return 0; // unlimited
+  }
+  if (MIN_DELEGATION_TIMEOUT_MS > 0 && normalized < MIN_DELEGATION_TIMEOUT_MS) {
     return MIN_DELEGATION_TIMEOUT_MS;
   }
-  return Math.min(MAX_DELEGATION_TIMEOUT_MS, normalized);
+  if (MAX_DELEGATION_TIMEOUT_MS > 0) {
+    return Math.min(MAX_DELEGATION_TIMEOUT_MS, normalized);
+  }
+  return normalized;
 }
 
 export function resolveDelegationBudgetHintMs(

--- a/runtime/src/llm/chat-executor-contract-guidance.ts
+++ b/runtime/src/llm/chat-executor-contract-guidance.ts
@@ -218,6 +218,10 @@ function inferServerHandleTurn(messageText: string): boolean {
     lower.includes("server handle");
   if (!mentionsServer) return false;
 
+  // Only trigger when the user explicitly asks for long-running / durable
+  // server semantics.  A bare "port NNNN" mention in a create-project or
+  // coding task should NOT gate file writes behind system.serverStart —
+  // file scaffolding is a prerequisite for starting the server.
   return (
     lower.includes("durable") ||
     lower.includes("typed server handle") ||
@@ -226,8 +230,7 @@ function inferServerHandleTurn(messageText: string): boolean {
     lower.includes("until i say stop") ||
     lower.includes("verify it is ready") ||
     lower.includes("verify readiness") ||
-    lower.includes("readiness") ||
-    /\bport\s+\d+\b/.test(lower)
+    lower.includes("readiness")
   );
 }
 


### PR DESCRIPTION
## Summary
- Remove bare port-number regex from server lifecycle gate — was blocking normal file writes in coding tasks that mention ports
- Raise MIN_DELEGATION_TIMEOUT_MS to 120s — LLM planner sometimes picks 30s budgets that starve sub-agents
- Remove MAX_DELEGATION_TIMEOUT_MS ceiling — support indefinite sub-agent work

## Test plan
- [x] 40/40 contract guidance tests pass
- [x] 80/80 sub-agent tests pass
- [x] Verified in live TUI: coding tasks with port mentions now scaffold files correctly