### PR TITLE
fix(runtime): pass spawn-resolved tools to sub-agent executor

### DIFF
--- a/runtime/src/gateway/sub-agent.ts
+++ b/runtime/src/gateway/sub-agent.ts
@@ -807,12 +807,26 @@ export class SubAgentManager {
         });
       }
 
+      // When the spawn comes from the orchestrator pipeline (has an
+      // execution context with explicit tool scope), pass the resolved
+      // tools as routedToolNames so the sub-agent's ChatExecutor uses
+      // the full scope instead of re-deriving a narrower set from
+      // message content heuristics.  Direct spawns (no delegation spec)
+      // continue to use the ChatExecutor's default routing.
+      const spawnRoutedTools =
+        handle.config.delegationSpec &&
+        handle.config.tools &&
+        handle.config.tools.length > 0
+          ? [...handle.config.tools]
+          : undefined;
+
       const resultOrAbort = await raceAbort(
         executor.execute({
           message,
           history: handle.history,
           systemPrompt,
           sessionId: handle.sessionId,
+          ...(spawnRoutedTools ? { routedToolNames: spawnRoutedTools } : {}),
           ...(handle.config.workingDirectory
             ? {
               runtimeContext: {


### PR DESCRIPTION
## Summary
- Sub-agents from orchestrator pipeline now use spawn-resolved tools as routedToolNames
- Prevents content-based tool routing from stripping verification tools
- Fixes sub-agents getting only writeFile when they need readFile+bash for verification

## Test plan
- [x] 79/80 sub-agent tests pass (1 pre-existing failure)
- [x] 95/95 orchestrator tests pass