### PR TITLE
fix(runtime): correct sub-agent tool routing param

### DIFF
--- a/runtime/src/gateway/sub-agent.ts
+++ b/runtime/src/gateway/sub-agent.ts
@@ -826,7 +826,9 @@ export class SubAgentManager {
           history: handle.history,
           systemPrompt,
           sessionId: handle.sessionId,
-          ...(spawnRoutedTools ? { routedToolNames: spawnRoutedTools } : {}),
+          ...(spawnRoutedTools
+            ? { toolRouting: { routedToolNames: spawnRoutedTools } }
+            : {}),
           ...(handle.config.workingDirectory
             ? {
               runtimeContext: {


### PR DESCRIPTION
## Summary
- Use `toolRouting.routedToolNames` (correct ChatExecuteParams field) for sub-agent spawn tool scope
- Previously used non-existent `routedToolNames` param which was silently ignored
- Sub-agents from orchestrator pipeline now get the full resolved tool set

## Test plan
- [x] 79/80 sub-agent tests pass (1 pre-existing failure)