### PR TITLE
fix(watch): restore matrix theme and local config controls

### DIFF
--- a/runtime/src/watch/agenc-watch-app.mjs
+++ b/runtime/src/watch/agenc-watch-app.mjs
@@ -119,7 +119,10 @@ import {
 } from "./agenc-watch-export-bundle.mjs";
 import { buildWatchInsightsReport } from "./agenc-watch-insights.mjs";
 import { buildWatchAgentsReport } from "./agenc-watch-agents.mjs";
-import { buildWatchUiPreferencesReport } from "./agenc-watch-ui-preferences.mjs";
+import {
+  buildWatchLocalConfigReport,
+  buildWatchUiPreferencesReport,
+} from "./agenc-watch-ui-preferences.mjs";
 import {
   buildWatchSessionQueryCandidates,
   clearWatchSessionLabel,
@@ -479,6 +482,26 @@ function showInputModes() {
   });
   setTransientStatus("input preferences ready");
   pushEvent("operator", "Input Preferences", report, "slate");
+  return report;
+}
+
+function currentStatuslineEnabled() {
+  return watchFeatureFlags.statusline === true;
+}
+
+function setStatuslineEnabled(enabled) {
+  watchFeatureFlags.statusline = enabled === true;
+  scheduleRender();
+  return watchFeatureFlags.statusline;
+}
+
+function showConfig() {
+  const report = buildWatchLocalConfigReport({
+    preferences: watchState.inputPreferences,
+    composerMode: watchState.composerMode,
+    statuslineEnabled: currentStatuslineEnabled(),
+  });
+  pushEvent("operator", "Local Config", report, "slate");
   return report;
 }
 
@@ -1223,6 +1246,7 @@ watchCommandController = createWatchCommandController({
   showAgents,
   showExtensibility,
   showInputModes,
+  showConfig,
   resetLiveRunSurface,
   resetDelegationState,
   persistSessionId,
@@ -1233,6 +1257,8 @@ watchCommandController = createWatchCommandController({
   setInputModeProfile,
   setKeybindingProfile,
   setThemeName,
+  currentStatuslineEnabled,
+  setStatuslineEnabled,
   trustPluginPackage,
   untrustPluginPackage,
   setMcpServerEnabled,
@@ -1809,6 +1835,7 @@ watchFrameController = createWatchFrameController({
   chip,
   row,
   renderPanel,
+  wrapAndLimit,
   joinColumns,
   blankRow,
   paintSurface,

--- a/runtime/src/watch/agenc-watch-commands.mjs
+++ b/runtime/src/watch/agenc-watch-commands.mjs
@@ -742,6 +742,64 @@ function buildInputPreferenceCommand(parsedSlash, {
   };
 }
 
+function isVimPreferenceEnabled(preferences = {}) {
+  return preferences?.inputModeProfile === "vim" || preferences?.keybindingProfile === "vim";
+}
+
+function buildConfigCommand(parsedSlash) {
+  const args = Array.isArray(parsedSlash?.args) ? parsedSlash.args : [];
+  const token = (args[0] ?? "show").trim().toLowerCase();
+  if (!token || ["show", "status", "ui", "local"].includes(token)) {
+    return { mode: "show" };
+  }
+  return {
+    error: "Usage: /config [show]",
+  };
+}
+
+function buildStatuslineCommand(parsedSlash) {
+  const args = Array.isArray(parsedSlash?.args) ? parsedSlash.args : [];
+  const token = (args[0] ?? "show").trim().toLowerCase();
+  if (!token || token === "show" || token === "status") {
+    return { mode: "show" };
+  }
+  if (["on", "enable", "enabled"].includes(token)) {
+    return { mode: "set", enabled: true };
+  }
+  if (["off", "disable", "disabled"].includes(token)) {
+    return { mode: "set", enabled: false };
+  }
+  if (token === "toggle") {
+    return { mode: "toggle" };
+  }
+  return {
+    error: "Usage: /statusline [show|on|off|toggle]",
+  };
+}
+
+function buildVimCommand(parsedSlash, { currentInputPreferences } = {}) {
+  const args = Array.isArray(parsedSlash?.args) ? parsedSlash.args : [];
+  const token = (args[0] ?? "toggle").trim().toLowerCase();
+  if (token === "show" || token === "status") {
+    return { mode: "show" };
+  }
+  if (!token || token === "toggle") {
+    return {
+      mode: "set",
+      enabled: !isVimPreferenceEnabled(currentInputPreferences?.() ?? {}),
+    };
+  }
+  if (["on", "enable", "enabled"].includes(token)) {
+    return { mode: "set", enabled: true };
+  }
+  if (["off", "disable", "disabled"].includes(token)) {
+    return { mode: "set", enabled: false };
+  }
+  return {
+    error: "Usage: /vim [show|on|off|toggle]",
+  };
+}
+
 function buildDiffCommand(
   parsedSlash,
   {
@@ -864,6 +922,7 @@ export function createWatchCommandController(dependencies = {}) {
     showAgents,
     showExtensibility,
     showInputModes,
+    showConfig,
     resetLiveRunSurface,
     resetDelegationState,
     persistSessionId,
@@ -874,6 +933,8 @@ export function createWatchCommandController(dependencies = {}) {
     setInputModeProfile,
     setKeybindingProfile,
     setThemeName,
+    currentStatuslineEnabled,
+    setStatuslineEnabled,
     trustPluginPackage,
     untrustPluginPackage,
     setMcpServerEnabled,
@@ -979,6 +1040,18 @@ export function createWatchCommandController(dependencies = {}) {
     assertFunction("setInputModeProfile", setInputModeProfile);
     assertFunction("setKeybindingProfile", setKeybindingProfile);
     assertFunction("setThemeName", setThemeName);
+  }
+  if (
+    commandNames.has("/config") ||
+    commandNames.has("/statusline") ||
+    commandNames.has("/vim")
+  ) {
+    assertFunction("showConfig", showConfig);
+    assertFunction("currentInputPreferences", currentInputPreferences);
+    assertFunction("setInputModeProfile", setInputModeProfile);
+    assertFunction("setKeybindingProfile", setKeybindingProfile);
+    assertFunction("currentStatuslineEnabled", currentStatuslineEnabled);
+    assertFunction("setStatuslineEnabled", setStatuslineEnabled);
   }
   if (commandNames.has("/plugins")) {
     assertFunction("trustPluginPackage", trustPluginPackage);
@@ -1247,6 +1320,17 @@ export function createWatchCommandController(dependencies = {}) {
         return true;
       }
 
+      if (canonicalName === "/config") {
+        const action = buildConfigCommand(parsedSlash);
+        if (action.error) {
+          pushEvent("error", "Usage Error", action.error, "red");
+          return true;
+        }
+        setTransientStatus("local config ready");
+        showConfig();
+        return true;
+      }
+
       if (
         canonicalName === "/input-mode" ||
         canonicalName === "/keybindings" ||
@@ -1269,9 +1353,9 @@ export function createWatchCommandController(dependencies = {}) {
               })
               : buildInputPreferenceCommand(parsedSlash, {
                 commandName: canonicalName,
-                usage: "/theme [show|default|aurora|ember]",
+                usage: "/theme [show|default|aurora|ember|matrix]",
                 defaultValue: "default",
-                allowedValues: ["default", "aurora", "ember"],
+                allowedValues: ["default", "aurora", "ember", "matrix"],
               });
         if (action.error) {
           pushEvent("error", "Usage Error", action.error, "red");
@@ -1295,6 +1379,46 @@ export function createWatchCommandController(dependencies = {}) {
           setTransientStatus(`theme: ${watchState.inputPreferences.themeName}`);
         }
         showInputModes();
+        return true;
+      }
+
+      if (canonicalName === "/statusline") {
+        const action = buildStatuslineCommand(parsedSlash);
+        if (action.error) {
+          pushEvent("error", "Usage Error", action.error, "red");
+          return true;
+        }
+        if (action.mode === "show") {
+          setTransientStatus("local config ready");
+          showConfig();
+          return true;
+        }
+        const enabled =
+          action.mode === "toggle"
+            ? currentStatuslineEnabled() !== true
+            : action.enabled === true;
+        setStatuslineEnabled(enabled);
+        setTransientStatus(`statusline: ${enabled ? "on" : "off"}`);
+        showConfig();
+        return true;
+      }
+
+      if (canonicalName === "/vim") {
+        const action = buildVimCommand(parsedSlash, { currentInputPreferences });
+        if (action.error) {
+          pushEvent("error", "Usage Error", action.error, "red");
+          return true;
+        }
+        if (action.mode === "show") {
+          setTransientStatus("local config ready");
+          showConfig();
+          return true;
+        }
+        setInputModeProfile(action.enabled === true ? "vim" : "default");
+        setKeybindingProfile(action.enabled === true ? "vim" : "default");
+        watchState.composerMode = "insert";
+        setTransientStatus(`vim mode: ${action.enabled === true ? "on" : "off"}`);
+        showConfig();
         return true;
       }
 

--- a/runtime/src/watch/agenc-watch-frame.mjs
+++ b/runtime/src/watch/agenc-watch-frame.mjs
@@ -71,6 +71,7 @@ export function createWatchFrameController(dependencies = {}) {
     chip,
     row,
     renderPanel,
+    wrapAndLimit,
     joinColumns,
     blankRow,
     paintSurface,
@@ -206,18 +207,37 @@ export function createWatchFrameController(dependencies = {}) {
       lines.push(row(`${color.softInk}Use /help for the full command reference.${color.reset}`, color.panelBg));
     } else {
       for (const command of suggestions) {
-        const aliasSuffix =
-          Array.isArray(command.aliases) && command.aliases.length > 0
-            ? `  ${color.fog}${command.aliases.join(", ")}${color.reset}`
-            : "";
-        const usageLine = fitAnsi(`${color.magenta}${command.usage}${color.reset}${aliasSuffix}`, inner);
-        lines.push(row(usageLine, color.panelBg));
+        const usageText = String(command.usage ?? "");
+        const aliasText = Array.isArray(command.aliases) && command.aliases.length > 0
+          ? command.aliases.join(", ")
+          : "";
+        const usageLines = wrapAndLimit(usageText, inner, 3);
+        const canInlineAlias = usageLines.length === 1 && aliasText.length > 0
+          ? visibleLength(`${usageLines[0]}  ${aliasText}`) <= inner
+          : false;
+
+        for (const usageLine of usageLines) {
+          lines.push(row(fitAnsi(`${color.magenta}${usageLine}${color.reset}`, inner), color.panelBg));
+        }
+        if (aliasText) {
+          if (canInlineAlias) {
+            const aliasLine = `${color.magenta}${usageLines[0]}${color.reset}  ${color.fog}${aliasText}${color.reset}`;
+            lines[lines.length - 1] = row(fitAnsi(aliasLine, inner), color.panelBg);
+          } else {
+            const aliasLines = wrapAndLimit(aliasText, Math.max(8, inner - 2), 2);
+            for (const aliasLine of aliasLines) {
+              lines.push(row(fitAnsi(`  ${color.fog}${aliasLine}${color.reset}`, inner), color.panelBg));
+            }
+          }
+        }
         if (command.description) {
-          const descriptionLine = fitAnsi(
-            `${color.softInk}${command.description}${color.reset}`,
-            inner,
-          );
-          lines.push(row(descriptionLine, color.panelBg));
+          const descriptionLines = wrapAndLimit(String(command.description), inner, 2);
+          for (const descriptionLine of descriptionLines) {
+            lines.push(row(
+              fitAnsi(`${color.softInk}${descriptionLine}${color.reset}`, inner),
+              color.panelBg,
+            ));
+          }
         }
       }
     }

--- a/runtime/src/watch/agenc-watch-helpers.mjs
+++ b/runtime/src/watch/agenc-watch-helpers.mjs
@@ -361,6 +361,12 @@ const EXTENSIBILITY_COMMANDS = Object.freeze([
 
 const INPUT_MODE_COMMANDS = Object.freeze([
   Object.freeze({
+    name: "/config",
+    aliases: ["/settings"],
+    usage: "/config [show]",
+    description: "Show the local watch UI config and quick toggles.",
+  }),
+  Object.freeze({
     name: "/input-mode",
     usage: "/input-mode [show|default|vim]",
     description: "Show or switch the local input profile for the watch composer.",
@@ -372,8 +378,18 @@ const INPUT_MODE_COMMANDS = Object.freeze([
   }),
   Object.freeze({
     name: "/theme",
-    usage: "/theme [show|default|aurora|ember]",
+    usage: "/theme [show|default|aurora|ember|matrix]",
     description: "Show or switch the local watch color theme.",
+  }),
+  Object.freeze({
+    name: "/statusline",
+    usage: "/statusline [show|on|off|toggle]",
+    description: "Show or toggle the structured footer statusline locally.",
+  }),
+  Object.freeze({
+    name: "/vim",
+    usage: "/vim [show|on|off|toggle]",
+    description: "Toggle the local watch composer between default and vim mode.",
   }),
 ]);
 
@@ -473,11 +489,23 @@ export function createOperatorInputBatcher({
     }
   };
 
+  const looksLikeSlashCommand = (value) => String(value ?? "").trim().startsWith("/");
+
   const flush = () => {
     clearPendingTimer();
     if (pendingLines.length === 0) return;
-    const value = pendingLines.join("\n").trim();
+    const batch = pendingLines;
     pendingLines = [];
+    if (batch.length > 1 && batch.some((entry) => looksLikeSlashCommand(entry))) {
+      for (const entry of batch) {
+        const value = String(entry ?? "").trim();
+        if (value) {
+          onDispatch(value);
+        }
+      }
+      return;
+    }
+    const value = batch.join("\n").trim();
     if (value) {
       onDispatch(value);
     }

--- a/runtime/src/watch/agenc-watch-ui-preferences.mjs
+++ b/runtime/src/watch/agenc-watch-ui-preferences.mjs
@@ -20,6 +20,7 @@ export const WATCH_THEME_NAMES = Object.freeze([
   "default",
   "aurora",
   "ember",
+  "matrix",
 ]);
 
 export function normalizeWatchInputModeProfile(value, fallback = "default") {
@@ -45,6 +46,9 @@ export function normalizeWatchThemeName(value, fallback = "default") {
   }
   if (normalized === "cool") {
     return "aurora";
+  }
+  if (normalized === "green" || normalized === "neo") {
+    return "matrix";
   }
   return WATCH_THEME_NAMES.includes(normalized) ? normalized : fallback;
 }
@@ -92,5 +96,32 @@ export function buildWatchUiPreferencesReport({
     `- Input modes: ${WATCH_INPUT_MODE_PROFILES.join(", ")}`,
     `- Keybindings: ${WATCH_KEYBINDING_PROFILES.join(", ")}`,
     `- Themes: ${WATCH_THEME_NAMES.join(", ")}`,
+  ].join("\n");
+}
+
+export function buildWatchLocalConfigReport({
+  preferences = {},
+  composerMode = "insert",
+  statuslineEnabled = false,
+} = {}) {
+  const normalized = createWatchUiPreferences(preferences);
+  const modeLabel =
+    normalized.inputModeProfile === "vim"
+      ? `vim (${String(composerMode ?? "insert").trim() || "insert"})`
+      : normalized.inputModeProfile;
+  return [
+    "Watch Local Config",
+    `Input mode: ${modeLabel}`,
+    `Keybindings: ${normalized.keybindingProfile}`,
+    `Theme: ${normalized.themeName}`,
+    `Statusline: ${statuslineEnabled === true ? "on" : "off"}`,
+    "",
+    "Quick Commands",
+    "- /config",
+    "- /vim [show|on|off|toggle]",
+    "- /input-mode [show|default|vim]",
+    "- /keybindings [show|default|vim]",
+    "- /theme [show|default|aurora|ember|matrix]",
+    "- /statusline [show|on|off|toggle]",
   ].join("\n");
 }

--- a/runtime/tests/watch/agenc-watch-frame.test.mjs
+++ b/runtime/tests/watch/agenc-watch-frame.test.mjs
@@ -150,14 +150,15 @@ test("frame controller scrolls transcript and detail view independently", async 
   });
 });
 
-test("frame controller routes slash palette rows through ansi-aware fitting", () => {
+test("frame controller wraps long slash palette usage lines instead of truncating them", () => {
   const fitCalls = [];
+  const wrapCalls = [];
   const harness = createWatchFrameHarness({
-    inputValue: "/",
+    inputValue: "/pe",
     suggestions: [{
-      usage: "/export",
-      description: "Write the current detail view or transcript to a temp file.",
-      aliases: ["/copy"],
+      usage: "/permissions [status|simulate <toolName> [jsonArgs]|credentials|requests|approve <requestId>|deny <requestId>]",
+      description: "Inspect policy state or simulate approval and policy decisions.",
+      aliases: [],
     }],
     width: 40,
     height: 18,
@@ -184,6 +185,18 @@ test("frame controller routes slash palette rows through ansi-aware fitting", ()
         fitCalls.push({ text: String(text ?? ""), width });
         return String(text ?? "");
       },
+      wrapAndLimit(text, width, maxLines = 2) {
+        const value = String(text ?? "");
+        wrapCalls.push({ text: value, width, maxLines });
+        if (value.startsWith("/permissions")) {
+          return [
+            "/permissions [status|simulate",
+            "<toolName> [jsonArgs]|credentials|",
+            "requests|approve <requestId>|deny <requestId>]",
+          ];
+        }
+        return [value];
+      },
       truncate(value, maxChars = 220) {
         const text = String(value ?? "");
         assert.equal(
@@ -199,12 +212,24 @@ test("frame controller routes slash palette rows through ansi-aware fitting", ()
   harness.controller.buildVisibleFrameSnapshot();
 
   assert.ok(
-    fitCalls.some((call) => call.width === 36 && call.text.includes("/export") && call.text.includes("/copy")),
+    wrapCalls.some((call) => call.width === 36 && call.maxLines === 3 && call.text.startsWith("/permissions")),
   );
   assert.ok(
     fitCalls.some((call) =>
       call.width === 36 &&
-      call.text.includes("Write the current detail view or transcript to a temp file."),
+      call.text.includes("/permissions [status|simulate"),
+    ),
+  );
+  assert.ok(
+    fitCalls.some((call) =>
+      call.width === 36 &&
+      call.text.includes("<toolName> [jsonArgs]|credentials|"),
+    ),
+  );
+  assert.ok(
+    fitCalls.some((call) =>
+      call.width === 36 &&
+      call.text.includes("requests|approve <requestId>|deny <requestId>]"),
     ),
   );
 });

--- a/runtime/tests/watch/agenc-watch-helpers.test.mjs
+++ b/runtime/tests/watch/agenc-watch-helpers.test.mjs
@@ -455,10 +455,10 @@ test("buildWatchCommands adds input-mode commands only when enabled", () => {
   assert.deepEqual(
     inputModeCommands
       .filter((command) =>
-        ["/input-mode", "/keybindings", "/theme"].includes(command.name)
+        ["/config", "/input-mode", "/keybindings", "/theme", "/statusline", "/vim"].includes(command.name)
       )
       .map((command) => command.name),
-    ["/input-mode", "/keybindings", "/theme"],
+    ["/config", "/input-mode", "/keybindings", "/theme", "/statusline", "/vim"],
   );
 });
 

--- a/runtime/tests/watch/agenc-watch-ui-preferences.test.mjs
+++ b/runtime/tests/watch/agenc-watch-ui-preferences.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  buildWatchLocalConfigReport,
   buildWatchUiPreferencesReport,
   createWatchUiPreferences,
 } from "../../src/watch/agenc-watch-ui-preferences.mjs";
@@ -20,6 +21,14 @@ test("createWatchUiPreferences normalizes persisted values", () => {
   });
 });
 
+test("createWatchUiPreferences normalizes matrix aliases", () => {
+  const preferences = createWatchUiPreferences({
+    themeName: "neo",
+  });
+
+  assert.equal(preferences.themeName, "matrix");
+});
+
 test("buildWatchUiPreferencesReport renders the active mode and theme", () => {
   const report = buildWatchUiPreferencesReport({
     preferences: {
@@ -32,4 +41,21 @@ test("buildWatchUiPreferencesReport renders the active mode and theme", () => {
 
   assert.match(report, /Input mode: vim \(normal\)/);
   assert.match(report, /Theme: aurora/);
+});
+
+test("buildWatchLocalConfigReport includes statusline and quick toggles", () => {
+  const report = buildWatchLocalConfigReport({
+    preferences: {
+      inputModeProfile: "vim",
+      keybindingProfile: "vim",
+      themeName: "aurora",
+    },
+    composerMode: "insert",
+    statuslineEnabled: true,
+  });
+
+  assert.match(report, /Statusline: on/);
+  assert.match(report, /- \/vim \[show\|on\|off\|toggle\]/);
+  assert.match(report, /- \/statusline \[show\|on\|off\|toggle\]/);
+  assert.match(report, /- \/theme \[show\|default\|aurora\|ember\|matrix\]/);
 });

--- a/runtime/tests/watch/fixtures/agenc-watch-frame-harness.mjs
+++ b/runtime/tests/watch/fixtures/agenc-watch-frame-harness.mjs
@@ -323,6 +323,24 @@ export function createWatchFrameHarness(overrides = {}) {
     renderPanel({ title, lines = [] }) {
       return [title, ...lines];
     },
+    wrapAndLimit(text, width, maxLines = 2) {
+      const source = String(text ?? "");
+      if (source.length <= width) {
+        return [source];
+      }
+      const lines = [];
+      let remaining = source;
+      while (remaining.length > width) {
+        lines.push(remaining.slice(0, width));
+        remaining = remaining.slice(width);
+      }
+      if (remaining.length > 0) {
+        lines.push(remaining);
+      }
+      return maxLines > 0 && lines.length > maxLines
+        ? [...lines.slice(0, maxLines), `+${lines.length - maxLines} more`]
+        : lines;
+    },
     joinColumns(leftLines = [], rightLines = [], leftWidth = 0, _rightWidth = 0, gap = 2) {
       const rows = Math.max(leftLines.length, rightLines.length);
       return Array.from({ length: rows }, (_, index) =>


### PR DESCRIPTION
## Summary
- restore the `matrix` watch theme plus its `green` and `neo` aliases
- add the missing local watch config commands and reports for `/config`, `/statusline`, and `/vim`
- port the related slash palette wrapping, batching behavior, and watch TUI tests that were left out of the earlier merge

## Testing
- `npm run test:watch-node --workspace=@tetsuo-ai/runtime`
- `npm run build --workspace=@tetsuo-ai/runtime`