### PR TITLE
fix(tui): don't resume sessions from different workspaces + timeout/spawn fixes

### DIFF
--- a/runtime/src/watch/agenc-watch-session-utils.mjs
+++ b/runtime/src/watch/agenc-watch-session-utils.mjs
@@ -198,6 +198,16 @@ export function latestSessionSummary(
       return preferred;
     }
   }
+  // When a workspace root is specified, only resume sessions from that
+  // workspace.  Falling back to sessions from other workspaces causes
+  // old session context to bleed into new workspace tasks.
+  if (
+    typeof preferredWorkspaceRoot === "string" &&
+    preferredWorkspaceRoot &&
+    sameWorkspaceSessions.length === 0
+  ) {
+    return null;
+  }
   const candidateSessions =
     sameWorkspaceSessions.length > 0 ? sameWorkspaceSessions : payload;
   return [...candidateSessions].sort((left, right) => {


### PR DESCRIPTION
## Summary
- **Session bleeding fix**: TUI no longer resumes sessions from other workspaces when starting in a new directory
- **Timeout floor**: MIN_DELEGATION_TIMEOUT_MS raised to 300s (5 minutes)
- **Spawn cap**: Cumulative sub-agent spawns capped at 6 per planner turn to prevent 30+ minute runaway retry loops

## Test plan
- [x] 185/185 planner + orchestrator tests pass
- [x] Session utils change is a simple null-return guard