### PR TITLE
fix(runtime): route edit_artifact through direct tool loop — 15s vs 5min

### DIFF
--- a/runtime/src/llm/chat-executor-planner.test.ts
+++ b/runtime/src/llm/chat-executor-planner.test.ts
@@ -845,15 +845,18 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
     expect(decision.reason).toContain("plan_artifact_request");
   });
 
-  it("forces planner routing for plan-artifact execution requests", () => {
+  it("routes plan-artifact edit requests through the direct tool loop", () => {
     const decision = assessPlannerDecision(
       true,
       "Update PLAN.md so it reflects the corrected architecture and missing validation steps.",
       [],
     );
 
-    expect(decision.shouldPlan).toBe(true);
-    expect(decision.reason).toContain("plan_artifact_execution_request");
+    // Edit-artifact requests go through the direct tool loop where the
+    // LLM can read → reason → write, not the planner which can't express
+    // LLM-driven edits as deterministic steps.
+    expect(decision.shouldPlan).toBe(false);
+    expect(decision.reason).toBe("edit_artifact_direct_path");
   });
 
   it("routes implement-from-plan requests through the planner without classifying them as artifact edits", () => {

--- a/runtime/src/llm/chat-executor-planner.ts
+++ b/runtime/src/llm/chat-executor-planner.ts
@@ -407,13 +407,17 @@ export function assessPlannerDecision(
   }
 
   if (artifactIntent === "edit_artifact") {
+    // Edit-artifact requests (read file → analyze → rewrite) are best
+    // handled by the direct tool loop where the LLM can read the file,
+    // reason about edits, and write the updated version.  The planner
+    // can't express this as deterministic steps because the edit content
+    // requires LLM reasoning.  Sending through the planner causes either:
+    // (a) read-only plans that fail validation, or
+    // (b) implementation sub-agents that build code instead of editing.
     return {
-      score: Math.max(score, 4),
-      shouldPlan: true,
-      reason:
-        reasons.length > 0
-          ? `${reasons.join("+")}+plan_artifact_execution_request`
-          : "plan_artifact_execution_request",
+      score,
+      shouldPlan: false,
+      reason: "edit_artifact_direct_path",
     };
   }
 


### PR DESCRIPTION
## Summary
- edit_artifact requests bypass planner, use direct tool loop (readFile → LLM → writeFile)
- Before: 5+ min, 6 sub-agent spawns, code implementation instead of file edit
- After: 15 seconds, 0 spawns, file correctly edited

## Verified
- [x] Tested "read PLAN.md identify gaps and update it" — file updated in 15s
- [x] 90/90 planner tests pass