### PR TITLE
fix(runtime): route plan/doc generation through direct tool loop

### DIFF
--- a/runtime/src/llm/chat-executor-planner.test.ts
+++ b/runtime/src/llm/chat-executor-planner.test.ts
@@ -834,15 +834,17 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
     expect(decision.reason).toContain("delegation_cue");
   });
 
-  it("forces planner routing for grounded plan-artifact expansion requests", () => {
+  it("routes plan-artifact generation through the direct tool loop", () => {
     const decision = assessPlannerDecision(
       true,
       "i want you to read @TODO.md and turn it into a complete plan for making a shell in the c-programming language.",
       [],
     );
 
-    expect(decision.shouldPlan).toBe(true);
-    expect(decision.reason).toContain("plan_artifact_request");
+    // Plan/document generation goes through the direct tool loop where
+    // the LLM can reason and write the file directly.
+    expect(decision.shouldPlan).toBe(false);
+    expect(decision.reason).toBe("plan_generation_direct_path");
   });
 
   it("routes plan-artifact edit requests through the direct tool loop", () => {

--- a/runtime/src/llm/chat-executor-planner.ts
+++ b/runtime/src/llm/chat-executor-planner.ts
@@ -396,13 +396,15 @@ export function assessPlannerDecision(
   const artifactIntent = classifyPlannerPlanArtifactIntent(messageText);
 
   if (artifactIntent === "grounded_plan_generation") {
+    // Plan/document creation is best handled by the direct tool loop.
+    // The LLM can reason about the plan structure and write the file
+    // directly.  The planner's validator rejects single-write plans
+    // and demands "grounding research" that isn't needed for document
+    // generation from the LLM's existing knowledge.
     return {
-      score: Math.max(score, 3),
-      shouldPlan: true,
-      reason:
-        reasons.length > 0
-          ? `${reasons.join("+")}+plan_artifact_request`
-          : "plan_artifact_request",
+      score,
+      shouldPlan: false,
+      reason: "plan_generation_direct_path",
     };
   }
 


### PR DESCRIPTION
## Summary
- Plan/document generation bypasses planner, uses direct tool loop
- Before: 5+ min, 6 sub-agents, validation failures
- After: 15 seconds, 0 spawns, clean TODO.MD

## Verified
- "Create TODO.MD for flappy birds" → 15s, detailed 8-phase plan
- "Read PLAN.md and update it" → 15s, file correctly edited  
- 90/90 planner tests pass