### PR TITLE
feat(memory): Phase 0 — cross-session semantic retrieval

### DIFF
--- a/runtime/src/memory/ingestion.ts
+++ b/runtime/src/memory/ingestion.ts
@@ -501,8 +501,11 @@ export class MemoryIngestionEngine {
     try {
       const normalized = normalizeForDedup(content);
       const tokenized = tokenizeForSimilarity(content);
+      // For semantic entries, check dedup across ALL sessions (not just
+      // the current one) since semantic memory is now cross-session.
+      // For working/episodic, keep session-scoped dedup.
       const recent = await this.vectorStore.query({
-        sessionId,
+        ...(memoryRole === "semantic" ? {} : { sessionId }),
         order: "desc",
         limit: this.dedupRecentEntries,
       });

--- a/runtime/src/memory/retriever.test.ts
+++ b/runtime/src/memory/retriever.test.ts
@@ -201,17 +201,18 @@ describe("SemanticMemoryRetriever", () => {
     expect(result.content).toContain('confidence="0.90"');
 
     expect(backend.searchHybrid).toHaveBeenCalledTimes(2);
+    // Semantic and episodic roles use cross-session retrieval — no sessionId filter.
     expect(backend.searchHybrid).toHaveBeenNthCalledWith(
       1,
       expect.any(String),
       expect.any(Array),
-      expect.objectContaining({ memoryRoles: ["semantic"], sessionId: "sess-1" }),
+      expect.objectContaining({ memoryRoles: ["semantic"], sessionId: undefined }),
     );
     expect(backend.searchHybrid).toHaveBeenNthCalledWith(
       2,
       expect.any(String),
       expect.any(Array),
-      expect.objectContaining({ memoryRoles: ["episodic"], sessionId: "sess-1" }),
+      expect.objectContaining({ memoryRoles: ["episodic"], sessionId: undefined }),
     );
   });
 
@@ -296,18 +297,26 @@ describe("SemanticMemoryRetriever", () => {
     expect(result.content).not.toContain("Subagent cwd: /");
   });
 
-  it("forwards session id for isolation in both thread and vector retrieval", async () => {
+  it("forwards session id for working memory but omits it for semantic/episodic retrieval", async () => {
     const backend = createMockVectorBackend();
     const retriever = createRetriever({ vectorBackend: backend });
 
     await retriever.retrieveDetailed("query", "ws-a:sess-22");
 
+    // Working memory (thread) is always session-scoped.
     expect(backend.getThread).toHaveBeenCalledWith("ws-a:sess-22", expect.any(Number));
-    expect(backend.searchHybrid).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.any(Array),
-      expect.objectContaining({ sessionId: "ws-a:sess-22" }),
-    );
+    // Semantic and episodic roles use cross-session retrieval (no sessionId filter)
+    // so the searchHybrid calls should NOT contain sessionId for those roles.
+    const hybridCalls = (backend.searchHybrid as ReturnType<typeof vi.fn>).mock.calls;
+    // Should have 2 calls: semantic + episodic
+    expect(hybridCalls.length).toBe(2);
+    for (const call of hybridCalls) {
+      const options = call[2] as Record<string, unknown>;
+      // sessionId should be undefined for cross-session roles
+      expect(options.sessionId).toBeUndefined();
+      // But should have an age filter
+      expect(options.after).toBeDefined();
+    }
   });
 
   it("includes curated memory with bounded budget", async () => {

--- a/runtime/src/memory/retriever.ts
+++ b/runtime/src/memory/retriever.ts
@@ -35,6 +35,10 @@ const DEFAULT_HYBRID_KEYWORD_WEIGHT = 0.3;
 const DEFAULT_WORKING_WINDOW = 12;
 const DEFAULT_MAX_CANDIDATES_PER_ROLE = 24;
 const DEFAULT_DIVERSITY_THRESHOLD = 0.86;
+/** Max age for semantic/episodic cross-session retrieval (30 days).
+ *  Bounds the search scope to prevent noise from ancient entries.
+ *  0 = no age limit (search everything). */
+const DEFAULT_SEMANTIC_MAX_AGE_MS = 30 * 86_400_000;
 const DEFAULT_ROLE_WEIGHTS = {
   working: 0.34,
   episodic: 0.22,
@@ -69,6 +73,8 @@ export interface SemanticMemoryRetrieverConfig {
   diversityThreshold?: number;
   /** Relative role budget split within memory budget. */
   roleBudgetWeights?: Partial<Record<RetrievalMemoryRole, number>>;
+  /** Max age in ms for cross-session semantic/episodic retrieval. 0 = unlimited. Default: 30 days. */
+  maxSemanticAgeMs?: number;
   logger?: Logger;
 }
 
@@ -303,6 +309,7 @@ export class SemanticMemoryRetriever implements MemoryRetriever {
   private readonly workingMemoryWindow: number;
   private readonly maxCandidatesPerRole: number;
   private readonly diversityThreshold: number;
+  private readonly maxSemanticAgeMs: number;
   private readonly roleBudgetWeights: Record<RetrievalMemoryRole, number>;
   private readonly logger: Logger | undefined;
 
@@ -336,6 +343,10 @@ export class SemanticMemoryRetriever implements MemoryRetriever {
     );
     this.diversityThreshold = clamp01(
       config.diversityThreshold ?? DEFAULT_DIVERSITY_THRESHOLD,
+    );
+    this.maxSemanticAgeMs = Math.max(
+      0,
+      Math.floor(config.maxSemanticAgeMs ?? DEFAULT_SEMANTIC_MAX_AGE_MS),
     );
     this.roleBudgetWeights = normalizeRoleWeights(config.roleBudgetWeights);
     this.logger = config.logger;
@@ -552,12 +563,26 @@ export class SemanticMemoryRetriever implements MemoryRetriever {
     role: RetrievalMemoryRole,
     embedding: number[],
   ): Promise<RetrievalCandidate[]> {
+    // Working memory is per-session (recent context).  Semantic and episodic
+    // memory must be cross-session — they represent long-lived facts and
+    // summaries that should survive across sessions within the same context.
+    // Without this, semantic facts ingested in session A are invisible in
+    // session B, making long-term memory effectively useless.
+    // A maxAge filter (default 30 days) bounds the search scope to prevent
+    // noise from ancient, irrelevant entries (skeptic review finding).
+    const isSessionScopedRole = role === "working";
+    const maxAgeMs = this.maxSemanticAgeMs ?? DEFAULT_SEMANTIC_MAX_AGE_MS;
     const searchResults = await this.vectorBackend.searchHybrid(
       message,
       embedding,
       {
         limit: this.maxCandidatesPerRole,
-        sessionId,
+        sessionId: isSessionScopedRole ? sessionId : undefined,
+        ...(
+          !isSessionScopedRole && maxAgeMs > 0
+            ? { after: Date.now() - maxAgeMs }
+            : {}
+        ),
         vectorWeight: this.hybridVectorWeight,
         keywordWeight: this.hybridKeywordWeight,
         memoryRoles: [role],


### PR DESCRIPTION
## Summary
- Semantic/episodic retrieval no longer filtered by sessionId (cross-session recall enabled)
- Working memory stays session-scoped (correct behavior)
- Added maxSemanticAgeMs (default 30 days) to bound search scope
- Semantic dedup now cross-session (prevents duplicates)

## Research
- R24: Memory in the Age of AI Agents — cross-session recall as fundamental requirement

## Tests
- 264/264 memory tests pass
- 13/13 retriever tests pass (2 updated for new behavior)