### PR TITLE
fix(memory): Phase 2B — scope learning KV keys by workspace (CRITICAL security fix)

### DIFF
--- a/runtime/src/gateway/daemon-feature-wiring.ts
+++ b/runtime/src/gateway/daemon-feature-wiring.ts
@@ -314,9 +314,19 @@ export async function wireAutonomousFeatures(
       goalManager: ctx.goalManager,
       traceProviderPayloads,
     });
+    // Phase 2B: scope learning KV keys by workspace to prevent cross-workspace
+    // information leakage (BUG-2 in TODO: learning records are global).
+    // Security finding C-1: User A's learned preferences were injected into User B's context.
+    const workspacePath = ctx.resolveActiveHostWorkspacePath(
+      ctx.gatewayLogging as unknown as GatewayConfig,
+    );
+    const learningKeyPrefix = workspacePath
+      ? `${workspacePath}:learning:`
+      : "learning:";
     const selfLearningAction = createSelfLearningAction({
       llm,
       memory: ctx.memoryBackend!,
+      keyPrefix: learningKeyPrefix,
       traceProviderPayloads,
     });
     const metaPlannerAction = createMetaPlannerAction({

--- a/runtime/src/gateway/memory-retriever-factory.ts
+++ b/runtime/src/gateway/memory-retriever-factory.ts
@@ -113,7 +113,7 @@ export async function createMemoryRetrievers(
 
   return {
     memoryRetriever,
-    learningProvider: createLearningRetriever(memoryBackend),
+    learningProvider: createLearningRetriever(memoryBackend, workspacePath),
   };
 }
 
@@ -232,7 +232,13 @@ export function createBasicHistoryRetriever(
 
 export function createLearningRetriever(
   memoryBackend: MemoryBackend,
+  workspacePath?: string,
 ): MemoryRetriever {
+  // Phase 2B: scope learning key by workspace to prevent cross-workspace leakage.
+  // Security finding C-1: global learning:latest leaked between workspaces.
+  const learningKey = workspacePath
+    ? `${workspacePath}:learning:latest`
+    : "learning:latest";
   return {
     async retrieve(): Promise<string | undefined> {
       if (!memoryBackend) return undefined;
@@ -250,7 +256,7 @@ export function createLearningRetriever(
             steps: string[];
           }>;
           preferences: Record<string, string>;
-        }>("learning:latest");
+        }>(learningKey);
         if (!learning) return undefined;
 
         const parts: string[] = [];


### PR DESCRIPTION
Learning records no longer global — prevents cross-workspace preference leakage