### PR TITLE
fix(memory): resolve TS build errors in encryption + /memory command

### DIFF
--- a/runtime/src/gateway/daemon-command-registry.ts
+++ b/runtime/src/gateway/daemon-command-registry.ts
@@ -2199,15 +2199,25 @@ export function createDaemonCommandRegistry(
       // /memory search <query>
       if (subcommand === "search" && rest) {
         try {
-          const results = await memoryBackend.query({
-            search: rest,
-            limit: 10,
-          });
-          if (results.length === 0) {
+          const needle = rest.toLowerCase();
+          const sessions = await memoryBackend.listSessions();
+          const matches: Array<{ content: string; role: string; timestamp: number; metadata?: Record<string, unknown> }> = [];
+          // Sample recent sessions for search (cap at 20 to avoid scanning everything)
+          for (const sid of sessions.slice(-20)) {
+            const thread = await memoryBackend.getThread(sid, 50);
+            for (const entry of thread) {
+              if (entry.content.toLowerCase().includes(needle)) {
+                matches.push(entry);
+                if (matches.length >= 10) break;
+              }
+            }
+            if (matches.length >= 10) break;
+          }
+          if (matches.length === 0) {
             await cmdCtx.reply(`No memory entries matching "${rest}".`);
             return;
           }
-          const lines = results.map((e, i) => {
+          const lines = matches.map((e, i) => {
             const age = Math.round((Date.now() - e.timestamp) / 3_600_000);
             const preview = e.content.slice(0, 80).replace(/\n/g, " ");
             const meta = e.metadata as Record<string, unknown> | undefined;
@@ -2295,7 +2305,7 @@ export function createDaemonCommandRegistry(
       if (subcommand === "export") {
         try {
           const { exportMemory } = await import("../memory/export-import.js");
-          const data = await exportMemory(memoryBackend);
+          const data = await exportMemory({ memoryBackend });
           const json = JSON.stringify(data, null, 2);
           await cmdCtx.reply(`Memory export (${data.entries?.length ?? 0} entries):\n\`\`\`json\n${json.slice(0, 4000)}\n\`\`\``);
         } catch (err) {

--- a/runtime/src/memory/encryption.ts
+++ b/runtime/src/memory/encryption.ts
@@ -152,12 +152,13 @@ export function createVersionedAES256GCMProvider(
   }
 
   const currentVersion = config.currentVersion;
-  const currentKey = keyMap.get(currentVersion);
-  if (!currentKey) {
+  const currentKeyLookup = keyMap.get(currentVersion);
+  if (!currentKeyLookup) {
     throw new Error(
       `Current key version ${currentVersion} not found in key map`,
     );
   }
+  const currentKey: Buffer = currentKeyLookup;
 
   function encryptWithVersion(plaintext: string, version: number, key: Buffer): string {
     const iv = randomBytes(IV_BYTES);
@@ -207,7 +208,7 @@ export function createVersionedAES256GCMProvider(
     }
 
     // Non-versioned ciphertext — try version 0 key, then current key
-    const legacyKey = keyMap.get(0) ?? currentKey;
+    const legacyKey: Buffer = keyMap.get(0) ?? currentKey;
     if (combined.length < IV_BYTES + TAG_BYTES) {
       throw new Error("Ciphertext too short");
     }


### PR DESCRIPTION
## Summary
- Fix versioned encryption provider TS type narrowing (`currentKey` after `Map.get()` + throw guard)
- Replace invalid `MemoryQuery.search` field with client-side content substring filter in `/memory search`
- Fix `exportMemory` and `collectMemoryHealthReport` call signatures (both take object params, not bare backend)

## Test plan
- [x] `npm run build` succeeds
- [x] daemon-command-registry tests pass (9/9)
- [x] encryption tests pass (16/16)