### PR TITLE
fix(runtime): suppress meta planner tools and relax readonly completion gate

### DIFF
--- a/runtime/src/autonomous/meta-planner.test.ts
+++ b/runtime/src/autonomous/meta-planner.test.ts
@@ -129,4 +129,33 @@ describe("meta-planner", () => {
     expect(store.has("goal:active")).toBe(true);
     expect(store.has("goals:active")).toBe(true);
   });
+
+  it("suppresses client tools on the planning LLM call", async () => {
+    const { backend } = makeMockMemory();
+    const chat = vi.fn().mockResolvedValue({
+      content: "[]",
+    });
+    const llm = {
+      name: "test-llm",
+      chat,
+    } as any;
+
+    const action = createMetaPlannerAction({
+      llm,
+      memory: backend as any,
+      traceProviderPayloads: false,
+    });
+
+    await action.execute({
+      logger: silentLogger,
+      sendToChannels: async () => {},
+    });
+
+    expect(chat).toHaveBeenCalledTimes(1);
+    expect(chat.mock.calls[0]?.[1]).toMatchObject({
+      toolChoice: "none",
+      toolRouting: { allowedToolNames: [] },
+      parallelToolCalls: false,
+    });
+  });
 });

--- a/runtime/src/autonomous/meta-planner.ts
+++ b/runtime/src/autonomous/meta-planner.ts
@@ -104,23 +104,28 @@ export function createMetaPlannerAction(
                 `Generate up to ${maxGoals} new strategic goals.`,
             },
           ],
-          config.traceProviderPayloads === true
-            ? {
-                trace: {
-                  includeProviderPayloads: true,
-                  onProviderTraceEvent: createProviderTraceEventLogger({
-                    logger: context.logger,
-                    traceLabel: "meta_planner.provider",
-                    traceId: `meta-planner:${Date.now()}`,
-                    staticFields: {
-                      phase: "planning",
-                      activeGoalCount: planningSnapshot.activeGoals.length,
-                      recentOutcomeCount: planningSnapshot.recentOutcomes.length,
-                    },
-                  }),
-                },
-              }
-            : undefined,
+          {
+            toolChoice: "none",
+            toolRouting: { allowedToolNames: [] },
+            parallelToolCalls: false,
+            ...(config.traceProviderPayloads === true
+              ? {
+                  trace: {
+                    includeProviderPayloads: true,
+                    onProviderTraceEvent: createProviderTraceEventLogger({
+                      logger: context.logger,
+                      traceLabel: "meta_planner.provider",
+                      traceId: `meta-planner:${Date.now()}`,
+                      staticFields: {
+                        phase: "planning",
+                        activeGoalCount: planningSnapshot.activeGoals.length,
+                        recentOutcomeCount: planningSnapshot.recentOutcomes.length,
+                      },
+                    }),
+                  },
+                }
+              : {}),
+          },
         );
 
         if (!response.content) {

--- a/runtime/src/llm/chat-executor-contract-flow.ts
+++ b/runtime/src/llm/chat-executor-contract-flow.ts
@@ -23,6 +23,7 @@ import {
   normalizeEnvelopePath,
   normalizeWorkspaceRoot,
 } from "../workflow/path-normalization.js";
+import { textRequiresWorkspaceGroundedArtifactUpdate } from "../workflow/workspace-inspection-evidence.js";
 import type { WorkflowVerificationContract } from "../workflow/verification-obligations.js";
 import { buildBrowserEvidenceRetryGuidance } from "../utils/browser-tool-taxonomy.js";
 import type { ExecutionContext, ToolCallRecord } from "./chat-executor-types.js";
@@ -644,6 +645,10 @@ function analyzeLegacyCompletionTurn(
   const hasOnlyNonTerminalExecutionEvidence =
     !hasMutationProgress &&
     !hasBuildOrBehaviorEvidence;
+  const isReadOnlyWorkspaceInspectionTurn =
+    hasOnlyNonTerminalExecutionEvidence &&
+    successfulToolCalls.length > 0 &&
+    textRequiresWorkspaceGroundedArtifactUpdate(ctx.messageText);
   return {
     successfulToolCalls,
     mutatedArtifacts,
@@ -651,15 +656,18 @@ function analyzeLegacyCompletionTurn(
     hasResearchEvidence,
     hasBuildOrBehaviorEvidence,
     implementationLikeTurn:
-      mutatesSourceLikeArtifacts ||
-      hasBuildOrBehaviorEvidence ||
+      !isReadOnlyWorkspaceInspectionTurn &&
       (
-        likelyImplementationRequest &&
+        mutatesSourceLikeArtifacts ||
+        hasBuildOrBehaviorEvidence ||
         (
-          successfulToolCalls.length === 0 ||
+          likelyImplementationRequest &&
           (
-            hasExecutionScopedArtifactCue &&
-            hasOnlyNonTerminalExecutionEvidence
+            successfulToolCalls.length === 0 ||
+            (
+              hasExecutionScopedArtifactCue &&
+              hasOnlyNonTerminalExecutionEvidence
+            )
           )
         )
       ),

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -1656,6 +1656,95 @@ describe("ChatExecutor", () => {
       );
     });
 
+    it("does not classify read-only implementation inspection turns as implementation-class completion", async () => {
+      const events: Record<string, unknown>[] = [];
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-readonly-coordinator",
+                  name: "coordinator_mode",
+                  arguments: safeJson({
+                    action: "list",
+                  }),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content:
+                "Latest successful worker session: subagent:9427d092-42ae-4e53-9909-6357dd03a084.",
+            }),
+          ),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue(
+          safeJson({
+            workerSessionIds: [
+              "subagent:9427d092-42ae-4e53-9909-6357dd03a084",
+              "subagent:16336e03-3196-4006-9b29-a43fb812901f",
+            ],
+            latestSuccessfulWorkerSessionId:
+              "subagent:9427d092-42ae-4e53-9909-6357dd03a084",
+          }),
+        ),
+        allowedTools: ["coordinator_mode"],
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Use coordinator_mode to inspect the current implementation under /tmp/project/runtime/src/llm/chat-executor.ts and /tmp/project/runtime/src/llm/chat-executor-contract-flow.ts, then summarize the latest worker session and failure logs.",
+          ),
+          trace: {
+            onExecutionTraceEvent: (event) => {
+              events.push(event as unknown as Record<string, unknown>);
+            },
+          },
+        }),
+      );
+
+      expect(result.stopReason).toBe("completed");
+      expect(result.completionState).toBe("completed");
+      expect(result.content).toContain(
+        "Latest successful worker session",
+      );
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "completion_gate_checked",
+            phase: "tool_followup",
+            payload: expect.objectContaining({
+              gate: "legacy_completion_compatibility",
+              decision: "accept",
+              compatibilityClass: "plan_only",
+            }),
+          }),
+        ]),
+      );
+      expect(events).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "completion_gate_checked",
+            phase: "tool_followup",
+            payload: expect.objectContaining({
+              gate: "workflow_completion_truth",
+              decision: "fail",
+              ownerClass: "implementation",
+            }),
+          }),
+        ]),
+      );
+    });
+
     it("reports equivalent completion semantics for direct and planner deterministic implementation", async () => {
       const directProvider = createMockProvider("primary", {
         chat: vi


### PR DESCRIPTION
## Summary
- suppress tool usage in the heartbeat MetaPlanner LLM call so Grok-backed planning cannot inherit unsupported client/custom tools
- avoid treating read-only `coordinator_mode` implementation-inspection turns as implementation-class completion work that requires workflow-owned verification closure
- add regression tests covering both code paths

## Testing
- `npm test -- src/autonomous/meta-planner.test.ts src/llm/chat-executor.test.ts`
- `npm run typecheck` *(currently fails due to pre-existing unrelated errors in `cli`, `gateway`, `memory`, planner, and verifier modules)*