### PR TITLE
[codex] Enable watch input modes by default

### DIFF
--- a/runtime/src/watch/agenc-watch-feature-flags.mjs
+++ b/runtime/src/watch/agenc-watch-feature-flags.mjs
@@ -252,9 +252,13 @@ export function resolveWatchFeatureFlags({ env = process.env } = {}) {
     extensibilityHub = explicitExtensibilityHub;
   }
 
-  let inputModes =
+  let inputModes = true;
+  if (
     featureEnabled(enabled, "input_modes") ||
-    featureEnabled(enabled, "inputmodes");
+    featureEnabled(enabled, "inputmodes")
+  ) {
+    inputModes = true;
+  }
   if (
     featureEnabled(disabled, "input_modes") ||
     featureEnabled(disabled, "inputmodes")

--- a/runtime/src/watch/agenc-watch-helpers.mjs
+++ b/runtime/src/watch/agenc-watch-helpers.mjs
@@ -399,47 +399,51 @@ const INPUT_MODE_COMMANDS = Object.freeze([
 ]);
 
 export function buildWatchCommands({ featureFlags = {} } = {}) {
+  const resolvedFeatureFlags = {
+    inputModes: true,
+    ...(featureFlags ?? {}),
+  };
   const commands = [...CORE_WATCH_COMMANDS];
-  if (featureFlags?.reviewModes === true) {
+  if (resolvedFeatureFlags?.reviewModes === true) {
     commands.push(...REVIEW_MODE_COMMANDS);
   }
-  if (featureFlags?.checkpoints === true) {
+  if (resolvedFeatureFlags?.checkpoints === true) {
     commands.push(...CHECKPOINT_COMMANDS);
   }
-  if (featureFlags?.diffReview === true) {
+  if (resolvedFeatureFlags?.diffReview === true) {
     commands.push(...DIFF_REVIEW_COMMANDS);
   }
-  if (featureFlags?.compactionControls === true) {
+  if (resolvedFeatureFlags?.compactionControls === true) {
     commands.push(...COMPACTION_COMMANDS);
   }
-  if (featureFlags?.permissionsControls === true) {
+  if (resolvedFeatureFlags?.permissionsControls === true) {
     commands.push(...PERMISSIONS_COMMANDS);
   }
-  if (featureFlags?.attachments === true) {
+  if (resolvedFeatureFlags?.attachments === true) {
     commands.push(...ATTACHMENT_COMMANDS);
   }
-  if (featureFlags?.exportBundles === true) {
+  if (resolvedFeatureFlags?.exportBundles === true) {
     commands.push(...EXPORT_BUNDLE_COMMANDS);
   }
-  if (featureFlags?.insights === true) {
+  if (resolvedFeatureFlags?.insights === true) {
     commands.push(...INSIGHTS_COMMANDS);
   }
-  if (featureFlags?.threadSwitcher === true) {
+  if (resolvedFeatureFlags?.threadSwitcher === true) {
     commands.push(...THREAD_SWITCHER_COMMANDS);
   }
-  if (featureFlags?.sessionIndexing === true) {
+  if (resolvedFeatureFlags?.sessionIndexing === true) {
     commands.push(...SESSION_INDEXING_COMMANDS);
   }
-  if (featureFlags?.rerunFromTrace === true) {
+  if (resolvedFeatureFlags?.rerunFromTrace === true) {
     commands.push(...RUN_CONTROL_COMMANDS);
   }
-  if (featureFlags?.remoteTools === true) {
+  if (resolvedFeatureFlags?.remoteTools === true) {
     commands.push(...REMOTE_TOOL_COMMANDS);
   }
-  if (featureFlags?.extensibilityHub === true) {
+  if (resolvedFeatureFlags?.extensibilityHub === true) {
     commands.push(...EXTENSIBILITY_COMMANDS);
   }
-  if (featureFlags?.inputModes === true) {
+  if (resolvedFeatureFlags?.inputModes === true) {
     commands.push(...INPUT_MODE_COMMANDS);
   }
   return Object.freeze(commands.map((command) => Object.freeze({

--- a/runtime/tests/watch/agenc-watch-feature-flags.test.mjs
+++ b/runtime/tests/watch/agenc-watch-feature-flags.test.mjs
@@ -244,20 +244,27 @@ test("resolveWatchFeatureFlags honors the explicit extensibility hub override", 
   assert.equal(flags.extensibilityHub, false);
 });
 
-test("resolveWatchFeatureFlags enables input modes from feature lists", () => {
+test("resolveWatchFeatureFlags enables input modes by default", () => {
   const flags = resolveWatchFeatureFlags({
-    env: {
-      AGENC_WATCH_FEATURES: "watch.input_modes",
-    },
+    env: {},
   });
 
   assert.equal(flags.inputModes, true);
 });
 
+test("resolveWatchFeatureFlags honors disabled input modes feature tokens", () => {
+  const flags = resolveWatchFeatureFlags({
+    env: {
+      AGENC_WATCH_DISABLE_FEATURES: "watch.input_modes",
+    },
+  });
+
+  assert.equal(flags.inputModes, false);
+});
+
 test("resolveWatchFeatureFlags honors the explicit input modes override", () => {
   const flags = resolveWatchFeatureFlags({
     env: {
-      AGENC_WATCH_FEATURES: "input-modes",
       AGENC_WATCH_ENABLE_INPUT_MODES: "off",
     },
   });

--- a/runtime/tests/watch/agenc-watch-helpers.test.mjs
+++ b/runtime/tests/watch/agenc-watch-helpers.test.mjs
@@ -83,7 +83,7 @@ test("matchWatchCommands returns the full command palette for slash-only input",
 test("matchWatchCommands filters by prefix and aliases", () => {
   assert.deepEqual(
     matchWatchCommands("/se").map((command) => command.name),
-    ["/session", "/sessions"],
+    ["/config", "/session", "/sessions"],
   );
   assert.equal(findWatchCommandDefinition("/init")?.name, "/init");
   assert.equal(findWatchCommandDefinition("/commands")?.name, "/help");
@@ -440,25 +440,29 @@ test("buildWatchCommands adds extensibility commands only when enabled", () => {
   );
 });
 
-test("buildWatchCommands adds input-mode commands only when enabled", () => {
+test("buildWatchCommands enables input-mode commands by default and allows opt-out", () => {
   const defaultCommands = buildWatchCommands();
   const inputModeCommands = buildWatchCommands({
     featureFlags: {
-      inputModes: true,
+      inputModes: false,
     },
   });
 
   assert.equal(
     defaultCommands.some((command) => command.name === "/input-mode"),
-    false,
+    true,
   );
   assert.deepEqual(
-    inputModeCommands
+    defaultCommands
       .filter((command) =>
         ["/config", "/input-mode", "/keybindings", "/theme", "/statusline", "/vim"].includes(command.name)
       )
       .map((command) => command.name),
     ["/config", "/input-mode", "/keybindings", "/theme", "/statusline", "/vim"],
+  );
+  assert.equal(
+    inputModeCommands.some((command) => command.name === "/input-mode"),
+    false,
   );
 });
 


### PR DESCRIPTION
## Summary
- enable watch input-mode commands by default
- keep explicit opt-out behavior via feature disable lists and env overrides
- update watch feature-flag and command helper tests for the new default

## Why
`/theme` and the other input-mode commands were registered only when the watch `inputModes` flag was explicitly enabled. That made the commands disappear in normal TUI sessions even though the functionality was otherwise ready to use.

## Impact
Users now get the input-mode command set by default in watch mode, while retaining a supported way to disable it when needed.

## Validation
- `node --test runtime/tests/watch/agenc-watch-feature-flags.test.mjs runtime/tests/watch/agenc-watch-helpers.test.mjs runtime/tests/watch/agenc-watch-commands.test.mjs runtime/tests/watch/agenc-watch-ui-preferences.test.mjs`
- `npm run build --workspace=@tetsuo-ai/runtime`
