### PR TITLE
feat(concordia): full simulation management UI — setup, launch, inspect

### DIFF
--- a/web/src/components/simulation/AgentInspector.tsx
+++ b/web/src/components/simulation/AgentInspector.tsx
@@ -1,0 +1,213 @@
+/**
+ * Agent inspector — deep-dive into agent memory, beliefs, relationships.
+ * Opens as an overlay when clicking on an agent card.
+ */
+
+import type { AgentState } from "./useSimulation";
+
+interface AgentInspectorProps {
+  agentId: string;
+  agent: AgentState;
+  onClose: () => void;
+}
+
+export function AgentInspector({ agentId, agent, onClose }: AgentInspectorProps) {
+  const identity = agent.identity;
+  const beliefs = identity?.beliefs ?? {};
+  const beliefEntries = Object.entries(beliefs).sort(
+    ([, a], [, b]) => b.confidence - a.confidence,
+  );
+
+  return (
+    <div className="fixed inset-0 bg-black/90 z-50 flex items-center justify-center p-4">
+      <div className="bg-black border border-green-600 w-full max-w-2xl max-h-[90vh] overflow-y-auto font-mono text-sm">
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-green-800 p-3">
+          <div>
+            <h2 className="text-green-300 font-bold text-lg">
+              {identity?.name ?? agentId}
+            </h2>
+            <span className="text-green-700 text-xs">ID: {agentId}</span>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-green-600 hover:text-green-300 border border-green-800 px-2 py-1"
+          >
+            [X] Close
+          </button>
+        </div>
+
+        <div className="p-3 space-y-4">
+          {/* Stats bar */}
+          <div className="flex gap-4 text-xs text-green-500 border-b border-green-900 pb-2">
+            <span>Turn: {agent.turnCount}</span>
+            <span>Memories: {agent.memoryCount}</span>
+            <span>Beliefs: {beliefEntries.length}</span>
+            <span>Relationships: {agent.relationships.length}</span>
+          </div>
+
+          {/* Personality */}
+          {identity && (
+            <Section title="PERSONALITY">
+              <p className="text-green-500 whitespace-pre-wrap">
+                {identity.personality}
+              </p>
+            </Section>
+          )}
+
+          {/* Last Action */}
+          {agent.lastAction && (
+            <Section title="LAST ACTION">
+              <p className="text-yellow-400">"{agent.lastAction}"</p>
+            </Section>
+          )}
+
+          {/* Learned Traits */}
+          {identity?.learnedTraits && identity.learnedTraits.length > 0 && (
+            <Section title="LEARNED TRAITS">
+              <div className="flex flex-wrap gap-1">
+                {identity.learnedTraits.map((trait, i) => (
+                  <span
+                    key={i}
+                    className="border border-green-800 px-2 py-0.5 text-green-400 text-xs"
+                  >
+                    {trait}
+                  </span>
+                ))}
+              </div>
+            </Section>
+          )}
+
+          {/* Beliefs */}
+          {beliefEntries.length > 0 && (
+            <Section title="BELIEFS">
+              <div className="space-y-1">
+                {beliefEntries.map(([topic, b]) => (
+                  <div key={topic} className="flex items-start gap-2">
+                    <ConfidenceBar confidence={b.confidence} />
+                    <div>
+                      <span className="text-green-300 font-bold">{topic}:</span>{" "}
+                      <span className="text-green-500">{b.belief}</span>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </Section>
+          )}
+
+          {/* Relationships */}
+          {agent.relationships.length > 0 && (
+            <Section title="RELATIONSHIPS">
+              <div className="space-y-1">
+                {agent.relationships.map((rel) => (
+                  <div
+                    key={rel.otherAgentId}
+                    className="flex items-center gap-3 text-green-500"
+                  >
+                    <span className="text-green-300 w-24">{rel.otherAgentId}</span>
+                    <SentimentBar sentiment={rel.sentiment} />
+                    <span className="text-green-700 text-xs">
+                      {rel.interactionCount} interactions
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </Section>
+          )}
+
+          {/* Recent Memories */}
+          {agent.recentMemories.length > 0 && (
+            <Section title="RECENT MEMORIES">
+              <div className="space-y-1 max-h-48 overflow-y-auto">
+                {agent.recentMemories.map((mem, i) => (
+                  <div key={i} className="text-xs border-l-2 border-green-900 pl-2">
+                    <span className="text-green-700">
+                      [{mem.role}]{" "}
+                      {new Date(mem.timestamp).toLocaleTimeString()}
+                    </span>
+                    <div className="text-green-500 truncate">{mem.content}</div>
+                  </div>
+                ))}
+              </div>
+            </Section>
+          )}
+
+          {/* World Facts */}
+          {agent.worldFacts.length > 0 && (
+            <Section title="KNOWN WORLD FACTS">
+              <div className="space-y-1">
+                {agent.worldFacts.map((fact, i) => (
+                  <div key={i} className="text-xs text-green-500">
+                    <span className="text-green-700">[{fact.observedBy}]</span>{" "}
+                    {fact.content}
+                    {fact.confirmations > 0 && (
+                      <span className="text-green-800">
+                        {" "}
+                        ({fact.confirmations} confirmations)
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </Section>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <h3 className="text-green-600 text-xs font-bold mb-1 tracking-wider">
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}
+
+function ConfidenceBar({ confidence }: { confidence: number }) {
+  const pct = Math.round(confidence * 100);
+  const width = Math.max(4, Math.round(confidence * 40));
+  return (
+    <div className="flex items-center gap-1 shrink-0 w-16">
+      <div className="h-1.5 w-10 bg-green-950 relative">
+        <div
+          className="h-full bg-green-500 absolute left-0 top-0"
+          style={{ width: `${width}px` }}
+        />
+      </div>
+      <span className="text-green-700 text-xs w-8">{pct}%</span>
+    </div>
+  );
+}
+
+function SentimentBar({ sentiment }: { sentiment: number }) {
+  // sentiment is -1 to 1
+  const normalized = (sentiment + 1) / 2; // 0 to 1
+  const color =
+    sentiment > 0.3
+      ? "bg-green-500"
+      : sentiment < -0.3
+        ? "bg-red-500"
+        : "bg-yellow-500";
+  return (
+    <div className="flex items-center gap-1 shrink-0">
+      <div className="h-1.5 w-10 bg-green-950 relative">
+        <div
+          className={`h-full ${color} absolute left-0 top-0`}
+          style={{ width: `${Math.round(normalized * 40)}px` }}
+        />
+      </div>
+      <span className="text-green-700 text-xs">{sentiment.toFixed(2)}</span>
+    </div>
+  );
+}

--- a/web/src/components/simulation/SimulationSetup.tsx
+++ b/web/src/components/simulation/SimulationSetup.tsx
@@ -1,0 +1,361 @@
+/**
+ * Simulation setup form — configure world, GM, and launch simulation.
+ */
+
+import { useState } from "react";
+
+export interface SimulationSetupConfig {
+  worldId: string;
+  premise: string;
+  maxSteps: number;
+  gmModel: string;
+  gmProvider: string;
+  agents: AgentFormData[];
+}
+
+export interface AgentFormData {
+  id: string;
+  name: string;
+  personality: string;
+  goal: string;
+}
+
+interface SimulationSetupProps {
+  onLaunch: (config: SimulationSetupConfig) => void;
+  loading: boolean;
+}
+
+const PRESETS: Record<string, SimulationSetupConfig> = {
+  medieval_town: {
+    worldId: "medieval-town",
+    premise:
+      "It is morning in the medieval town of Thornfield. The market square is bustling with activity. Three residents begin their day.",
+    maxSteps: 20,
+    gmModel: "grok-3-mini",
+    gmProvider: "ollama",
+    agents: [
+      {
+        id: "elena",
+        name: "Elena",
+        personality:
+          "Elena is the town blacksmith. She is practical, strong-willed, and values honest work. She distrusts merchants but respects fellow craftspeople.",
+        goal: "Complete a special sword commission for the town guard captain.",
+      },
+      {
+        id: "marcus",
+        name: "Marcus",
+        personality:
+          "Marcus is a traveling merchant. He is charming, opportunistic, and always looking for a good deal. He has a secret: he is actually a spy for a rival town.",
+        goal: "Buy rare iron from Elena at below market price while gathering intelligence about the town's defenses.",
+      },
+      {
+        id: "sera",
+        name: "Sera",
+        personality:
+          "Sera is the town healer. She is compassionate, perceptive, and notices things others miss. She has a strong moral compass.",
+        goal: "Treat the sick and keep the town healthy. She suspects the new merchant is not what he seems.",
+      },
+    ],
+  },
+  trading_floor: {
+    worldId: "trading-floor",
+    premise:
+      "Four traders gather at the commodities exchange. Gold prices have been volatile. Each trader has different information and different risk tolerance.",
+    maxSteps: 25,
+    gmModel: "grok-3-mini",
+    gmProvider: "ollama",
+    agents: [
+      {
+        id: "alex",
+        name: "Alex",
+        personality:
+          "Conservative institutional trader. Risk-averse, data-driven, manages a pension fund.",
+        goal: "Protect the pension fund while achieving 8% annual returns.",
+      },
+      {
+        id: "jordan",
+        name: "Jordan",
+        personality:
+          "Aggressive day trader. Thrives on volatility, trusts gut instinct. Has inside information about a gold mine collapse.",
+        goal: "Profit from the gold mine collapse before it becomes public.",
+      },
+      {
+        id: "sam",
+        name: "Sam",
+        personality:
+          "Quantitative analyst. Builds models, speaks in probabilities. Has noticed unusual trading patterns.",
+        goal: "Identify and report suspicious trading activity to compliance.",
+      },
+      {
+        id: "riley",
+        name: "Riley",
+        personality:
+          "Newly licensed broker on their first day. Eager to impress, nervous, easily influenced.",
+        goal: "Make a good impression and complete a successful trade.",
+      },
+    ],
+  },
+  research_lab: {
+    worldId: "research-lab",
+    premise:
+      "Three AI researchers share a lab at a prestigious university. A major conference deadline is in two weeks. They have overlapping research interests but limited compute budget.",
+    maxSteps: 20,
+    gmModel: "grok-3-mini",
+    gmProvider: "ollama",
+    agents: [
+      {
+        id: "dr-chen",
+        name: "Dr. Chen",
+        personality:
+          "Senior RL researcher. Methodical, 50+ papers. Worried about being scooped by a rival lab.",
+        goal: "Submit a breakthrough RL paper to the conference.",
+      },
+      {
+        id: "kai",
+        name: "Kai",
+        personality:
+          "Second-year PhD student. Brilliant but disorganized. Has preliminary results complementing Dr. Chen's work.",
+        goal: "Get a first-author publication to secure funding.",
+      },
+      {
+        id: "priya",
+        name: "Priya",
+        personality:
+          "Visiting researcher from industry. Pragmatic, has proprietary datasets. Deciding between industry and academia.",
+        goal: "Produce results that justify extending the industry partnership.",
+      },
+    ],
+  },
+};
+
+export function SimulationSetup({ onLaunch, loading }: SimulationSetupProps) {
+  const [config, setConfig] = useState<SimulationSetupConfig>({
+    worldId: "",
+    premise: "",
+    maxSteps: 20,
+    gmModel: "grok-3-mini",
+    gmProvider: "ollama",
+    agents: [],
+  });
+
+  const [activeTab, setActiveTab] = useState<"preset" | "custom">("preset");
+
+  const loadPreset = (key: string) => {
+    const preset = PRESETS[key];
+    if (preset) {
+      setConfig({
+        ...preset,
+        worldId: `${preset.worldId}-${Date.now().toString(36).slice(-4)}`,
+      });
+      setActiveTab("custom"); // Switch to custom to show loaded config
+    }
+  };
+
+  const addAgent = () => {
+    const idx = config.agents.length + 1;
+    setConfig({
+      ...config,
+      agents: [
+        ...config.agents,
+        {
+          id: `agent-${idx}`,
+          name: `Agent ${idx}`,
+          personality: "",
+          goal: "",
+        },
+      ],
+    });
+  };
+
+  const removeAgent = (index: number) => {
+    setConfig({
+      ...config,
+      agents: config.agents.filter((_, i) => i !== index),
+    });
+  };
+
+  const updateAgent = (index: number, field: keyof AgentFormData, value: string) => {
+    const agents = [...config.agents];
+    agents[index] = { ...agents[index], [field]: value };
+    // Auto-derive ID from name
+    if (field === "name") {
+      agents[index].id = value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/-+$/, "");
+    }
+    setConfig({ ...config, agents });
+  };
+
+  const canLaunch = config.worldId && config.premise && config.agents.length >= 2;
+
+  return (
+    <div className="flex flex-col h-full bg-black text-green-400 font-mono text-sm overflow-y-auto p-4">
+      <h2 className="text-green-300 text-lg font-bold mb-4">
+        New Simulation
+      </h2>
+
+      {/* Tab selector */}
+      <div className="flex gap-2 mb-4">
+        <button
+          onClick={() => setActiveTab("preset")}
+          className={`px-3 py-1 border ${
+            activeTab === "preset"
+              ? "border-green-400 text-green-300 bg-green-950"
+              : "border-green-800 text-green-700"
+          }`}
+        >
+          Load Preset
+        </button>
+        <button
+          onClick={() => setActiveTab("custom")}
+          className={`px-3 py-1 border ${
+            activeTab === "custom"
+              ? "border-green-400 text-green-300 bg-green-950"
+              : "border-green-800 text-green-700"
+          }`}
+        >
+          Custom / Edit
+        </button>
+      </div>
+
+      {activeTab === "preset" && (
+        <div className="space-y-3 mb-6">
+          {Object.entries(PRESETS).map(([key, preset]) => (
+            <button
+              key={key}
+              onClick={() => loadPreset(key)}
+              className="w-full text-left border border-green-800 p-3 hover:bg-green-950 hover:border-green-600"
+            >
+              <div className="text-green-300 font-bold">
+                {key.replace(/_/g, " ").toUpperCase()}
+              </div>
+              <div className="text-green-600 text-xs mt-1">
+                {preset.agents.length} agents — {preset.premise.slice(0, 100)}...
+              </div>
+              <div className="text-green-700 text-xs mt-1">
+                Agents: {preset.agents.map((a) => a.name).join(", ")}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {activeTab === "custom" && (
+        <>
+          {/* World config */}
+          <div className="space-y-3 mb-6">
+            <div>
+              <label className="text-green-500 text-xs block mb-1">World ID</label>
+              <input
+                type="text"
+                value={config.worldId}
+                onChange={(e) => setConfig({ ...config, worldId: e.target.value })}
+                placeholder="medieval-town-001"
+                className="w-full bg-black border border-green-800 text-green-300 px-2 py-1 focus:border-green-400 outline-none"
+              />
+            </div>
+            <div>
+              <label className="text-green-500 text-xs block mb-1">Premise</label>
+              <textarea
+                value={config.premise}
+                onChange={(e) => setConfig({ ...config, premise: e.target.value })}
+                placeholder="Describe the world and starting situation..."
+                rows={3}
+                className="w-full bg-black border border-green-800 text-green-300 px-2 py-1 focus:border-green-400 outline-none resize-none"
+              />
+            </div>
+            <div className="flex gap-3">
+              <div className="flex-1">
+                <label className="text-green-500 text-xs block mb-1">Max Steps</label>
+                <input
+                  type="number"
+                  value={config.maxSteps}
+                  onChange={(e) =>
+                    setConfig({ ...config, maxSteps: Math.max(1, parseInt(e.target.value) || 20) })
+                  }
+                  className="w-full bg-black border border-green-800 text-green-300 px-2 py-1 focus:border-green-400 outline-none"
+                />
+              </div>
+              <div className="flex-1">
+                <label className="text-green-500 text-xs block mb-1">GM Model</label>
+                <input
+                  type="text"
+                  value={config.gmModel}
+                  onChange={(e) => setConfig({ ...config, gmModel: e.target.value })}
+                  className="w-full bg-black border border-green-800 text-green-300 px-2 py-1 focus:border-green-400 outline-none"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Agents */}
+          <div className="mb-4">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-green-500 text-xs font-bold">
+                AGENTS ({config.agents.length})
+              </span>
+              <button
+                onClick={addAgent}
+                className="text-green-400 border border-green-700 px-2 py-0.5 text-xs hover:bg-green-950"
+              >
+                + Add Agent
+              </button>
+            </div>
+
+            <div className="space-y-3">
+              {config.agents.map((agent, i) => (
+                <div key={i} className="border border-green-800 p-2">
+                  <div className="flex items-center justify-between mb-2">
+                    <input
+                      type="text"
+                      value={agent.name}
+                      onChange={(e) => updateAgent(i, "name", e.target.value)}
+                      placeholder="Agent name"
+                      className="bg-black border-b border-green-800 text-green-300 font-bold px-1 py-0.5 outline-none focus:border-green-400 w-40"
+                    />
+                    <span className="text-green-800 text-xs mx-2">id: {agent.id}</span>
+                    <button
+                      onClick={() => removeAgent(i)}
+                      className="text-red-700 hover:text-red-400 text-xs"
+                    >
+                      [remove]
+                    </button>
+                  </div>
+                  <textarea
+                    value={agent.personality}
+                    onChange={(e) => updateAgent(i, "personality", e.target.value)}
+                    placeholder="Personality, background, traits..."
+                    rows={2}
+                    className="w-full bg-black border border-green-900 text-green-500 px-1 py-0.5 text-xs outline-none focus:border-green-700 resize-none mb-1"
+                  />
+                  <input
+                    type="text"
+                    value={agent.goal}
+                    onChange={(e) => updateAgent(i, "goal", e.target.value)}
+                    placeholder="Goal / objective"
+                    className="w-full bg-black border border-green-900 text-green-500 px-1 py-0.5 text-xs outline-none focus:border-green-700"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Launch */}
+          <button
+            onClick={() => canLaunch && onLaunch(config)}
+            disabled={!canLaunch || loading}
+            className={`w-full py-2 font-bold text-sm border ${
+              canLaunch && !loading
+                ? "border-green-400 text-green-300 hover:bg-green-950 cursor-pointer"
+                : "border-green-900 text-green-800 cursor-not-allowed"
+            }`}
+          >
+            {loading
+              ? "LAUNCHING..."
+              : canLaunch
+                ? `LAUNCH SIMULATION (${config.agents.length} agents, ${config.maxSteps} steps)`
+                : "Add at least 2 agents to launch"}
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/simulation/SimulationViewer.tsx
+++ b/web/src/components/simulation/SimulationViewer.tsx
@@ -1,13 +1,22 @@
 /**
- * Main simulation viewer — composes all sub-components.
- * Phase 4 of CONCORDIA_TODO.MD.
+ * Main simulation viewer — setup → running → inspect flow.
+ *
+ * States:
+ * 1. SETUP: Configure world, agents, GM — pick preset or build custom
+ * 2. RUNNING: Live event timeline, agent cards, controls, world state
+ * 3. INSPECT: Click an agent card to deep-dive into memory/beliefs
  */
 
+import { useState, useCallback } from "react";
 import { useSimulation } from "./useSimulation";
+import { SimulationSetup, type SimulationSetupConfig } from "./SimulationSetup";
 import { SimulationControls } from "./SimulationControls";
 import { AgentCard } from "./AgentCard";
 import { EventTimeline } from "./EventTimeline";
 import { WorldStatePanel } from "./WorldStatePanel";
+import { AgentInspector } from "./AgentInspector";
+
+type SimPhase = "setup" | "running" | "finished";
 
 interface SimulationViewerProps {
   eventWsUrl?: string;
@@ -20,54 +29,169 @@ export function SimulationViewer({
   eventWsUrl = "ws://localhost:3201",
   bridgeUrl = "http://localhost:3200",
   controlUrl = "http://localhost:3202",
-  agentIds = [],
+  agentIds: initialAgentIds = [],
 }: SimulationViewerProps) {
+  const [phase, setPhase] = useState<SimPhase>("setup");
+  const [agentIds, setAgentIds] = useState<string[]>(initialAgentIds);
+  const [launching, setLaunching] = useState(false);
+  const [inspectedAgent, setInspectedAgent] = useState<string | null>(null);
+  const [launchConfig, setLaunchConfig] = useState<SimulationSetupConfig | null>(null);
+
   const { state, play, pause, step, stop } = useSimulation({
     eventWsUrl,
     bridgeUrl,
     controlUrl,
     agentIds,
+    pollIntervalMs: phase === "running" ? 2000 : 10000,
   });
 
+  const handleLaunch = useCallback(
+    async (config: SimulationSetupConfig) => {
+      setLaunching(true);
+      setLaunchConfig(config);
+      try {
+        // POST to bridge /setup
+        const resp = await fetch(`${bridgeUrl}/setup`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            world_id: config.worldId,
+            workspace_id: "concordia-sim",
+            agents: config.agents.map((a) => ({
+              agent_id: a.id,
+              agent_name: a.name,
+              personality: a.personality,
+              goal: a.goal,
+            })),
+            premise: config.premise,
+          }),
+        });
+
+        if (!resp.ok) {
+          throw new Error(`Setup failed: ${resp.status}`);
+        }
+
+        setAgentIds(config.agents.map((a) => a.id));
+        setPhase("running");
+
+        // Auto-play
+        await fetch(`${controlUrl}/simulation/play`, { method: "POST" }).catch(
+          () => {},
+        );
+      } catch (err) {
+        console.error("Launch failed:", err);
+        alert(`Failed to launch simulation: ${err}`);
+      } finally {
+        setLaunching(false);
+      }
+    },
+    [bridgeUrl, controlUrl],
+  );
+
+  const handleStop = useCallback(async () => {
+    await stop();
+    setPhase("finished");
+  }, [stop]);
+
+  const handleNewSimulation = useCallback(() => {
+    setPhase("setup");
+    setAgentIds([]);
+    setLaunchConfig(null);
+    setInspectedAgent(null);
+  }, []);
+
+  // ========================================================================
+  // SETUP phase
+  // ========================================================================
+  if (phase === "setup") {
+    return <SimulationSetup onLaunch={handleLaunch} loading={launching} />;
+  }
+
+  // ========================================================================
+  // RUNNING / FINISHED phase
+  // ========================================================================
+  const inspected =
+    inspectedAgent && state.agentStates[inspectedAgent]
+      ? state.agentStates[inspectedAgent]
+      : null;
+
   return (
-    <div className="flex flex-col h-screen bg-black text-green-400 font-mono">
+    <div className="flex flex-col h-full bg-black text-green-400 font-mono">
       {/* Controls */}
       <SimulationControls
         status={state.status}
         onPlay={play}
         onPause={pause}
         onStep={step}
-        onStop={stop}
+        onStop={handleStop}
       />
 
-      {/* Connection status */}
-      {!state.connected && (
-        <div className="bg-red-900 text-red-300 text-xs px-2 py-1 text-center">
-          Disconnected from event stream — waiting for reconnection...
-        </div>
-      )}
-      {state.error && (
-        <div className="bg-yellow-900 text-yellow-300 text-xs px-2 py-1 text-center">
-          {state.error}
-        </div>
-      )}
+      {/* Connection + phase status */}
+      <div className="flex items-center gap-2 px-2 py-0.5 text-xs border-b border-green-900">
+        <span
+          className={`w-2 h-2 rounded-full ${
+            state.connected ? "bg-green-500" : "bg-red-500"
+          }`}
+        />
+        <span className="text-green-600">
+          {state.connected ? "Connected" : "Disconnected"}
+        </span>
+        {launchConfig && (
+          <>
+            <span className="text-green-800">|</span>
+            <span className="text-green-600">
+              World: {launchConfig.worldId}
+            </span>
+            <span className="text-green-800">|</span>
+            <span className="text-green-600">
+              {launchConfig.agents.length} agents
+            </span>
+          </>
+        )}
+        {phase === "finished" && (
+          <>
+            <span className="text-green-800">|</span>
+            <span className="text-yellow-500">FINISHED</span>
+            <button
+              onClick={handleNewSimulation}
+              className="ml-auto text-green-400 border border-green-700 px-2 hover:bg-green-950"
+            >
+              New Simulation
+            </button>
+          </>
+        )}
+        {state.error && (
+          <span className="text-red-500 ml-2">{state.error}</span>
+        )}
+      </div>
 
       {/* Main content */}
       <div className="flex-1 flex overflow-hidden">
         {/* Left: Agent cards */}
-        <div className="w-64 border-r border-green-800 overflow-y-auto p-2">
-          <div className="text-green-600 text-xs mb-2 font-bold">
+        <div className="w-72 border-r border-green-800 overflow-y-auto p-2">
+          <div className="text-green-600 text-xs mb-2 font-bold tracking-wider">
             AGENTS ({Object.keys(state.agentStates).length})
           </div>
-          {Object.entries(state.agentStates).map(([agentId, agentState]) => (
-            <AgentCard key={agentId} agentId={agentId} agent={agentState} />
+          {Object.entries(state.agentStates).map(([id, agentState]) => (
+            <div
+              key={id}
+              onClick={() => setInspectedAgent(id)}
+              className="cursor-pointer"
+            >
+              <AgentCard agentId={id} agent={agentState} />
+            </div>
           ))}
-          {Object.keys(state.agentStates).length === 0 && (
-            <div className="text-green-800 text-xs">
-              No agents connected yet.
-              {agentIds.length > 0
-                ? ` Polling for: ${agentIds.join(", ")}`
-                : " Set agentIds prop to poll agent state."}
+          {Object.keys(state.agentStates).length === 0 && agentIds.length > 0 && (
+            <div className="text-green-800 text-xs p-2">
+              Waiting for agent data...
+              <div className="text-green-900 mt-1">
+                Polling: {agentIds.join(", ")}
+              </div>
+            </div>
+          )}
+          {agentIds.length === 0 && (
+            <div className="text-green-800 text-xs p-2">
+              No agents configured.
             </div>
           )}
         </div>
@@ -81,8 +205,17 @@ export function SimulationViewer({
       {/* Bottom: World state */}
       <WorldStatePanel
         agentStates={state.agentStates}
-        worldId={state.status.world_id}
+        worldId={state.status.world_id || launchConfig?.worldId || ""}
       />
+
+      {/* Agent inspector overlay */}
+      {inspected && inspectedAgent && (
+        <AgentInspector
+          agentId={inspectedAgent}
+          agent={inspected}
+          onClose={() => setInspectedAgent(null)}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/components/simulation/index.ts
+++ b/web/src/components/simulation/index.ts
@@ -1,6 +1,8 @@
 export { SimulationViewer } from "./SimulationViewer";
+export { SimulationSetup } from "./SimulationSetup";
 export { SimulationControls } from "./SimulationControls";
 export { AgentCard } from "./AgentCard";
+export { AgentInspector } from "./AgentInspector";
 export { EventTimeline } from "./EventTimeline";
 export { WorldStatePanel } from "./WorldStatePanel";
 export { useSimulation } from "./useSimulation";
@@ -10,3 +12,4 @@ export type {
   SimulationStatus,
   SimulationState,
 } from "./useSimulation";
+export type { SimulationSetupConfig, AgentFormData } from "./SimulationSetup";


### PR DESCRIPTION
## Summary
- **SimulationSetup**: World config form with 3 presets (medieval town, trading floor, research lab) + fully custom mode. Add/remove agents with name/personality/goal. Launch button.
- **AgentInspector**: Click any agent card to open full-screen overlay showing personality, beliefs with confidence bars, relationships with sentiment bars, recent memories, world facts.
- **SimulationViewer**: Setup → Running → Finished state machine. Live event timeline + agent cards + play/pause/step/stop. "New Simulation" button to reset.
- **SIM tab** in menu bar.

## Test plan
- [x] Build succeeds with no TS errors
- [x] Web UI loads at localhost:5173
- [x] SIM tab visible in menu bar
- [x] Preset scenarios load correctly
- [x] Custom agent add/remove works