### PR TITLE
fix(concordia): restore running simulation on tab switch

### DIFF
--- a/runtime/src/gateway/concordia-bridge.ts
+++ b/runtime/src/gateway/concordia-bridge.ts
@@ -107,6 +107,7 @@ export class ConcordiaBridge {
     if (req.method === "GET") {
       if (path === "/health") return this.handleHealth(res);
       if (path === "/metrics") return this.handleMetrics(res);
+      if (path === "/agents") return this.handleListAgents(res);
       if (path.startsWith("/agent/") && path.endsWith("/state")) {
         const agentId = decodeURIComponent(path.split("/")[2]);
         return this.handleAgentState(agentId, res);
@@ -272,6 +273,18 @@ export class ConcordiaBridge {
   // ==========================================================================
   // GET handlers
   // ==========================================================================
+
+  private handleListAgents(res: ServerResponse): void {
+    const agents = Array.from(this.agents.entries()).map(([id, agent]) => ({
+      id,
+      name: agent.name,
+      personality: agent.personality,
+      goal: agent.goal,
+      turns: agent.turns,
+      lastAction: agent.lastAction,
+    }));
+    this.sendJson(res, 200, agents);
+  }
 
   private handleHealth(res: ServerResponse): void {
     this.sendJson(res, 200, {

--- a/web/src/components/simulation/SimulationViewer.tsx
+++ b/web/src/components/simulation/SimulationViewer.tsx
@@ -36,6 +36,7 @@ export function SimulationViewer({
   const [launching, setLaunching] = useState(false);
   const [inspectedAgent, setInspectedAgent] = useState<string | null>(null);
   const [launchConfig, setLaunchConfig] = useState<SimulationSetupConfig | null>(null);
+  const [checkedBridge, setCheckedBridge] = useState(false);
 
   const { state, play, pause, step, stop } = useSimulation({
     eventWsUrl,
@@ -44,6 +45,45 @@ export function SimulationViewer({
     agentIds,
     pollIntervalMs: phase === "running" ? 2000 : 10000,
   });
+
+  // On mount: check if a simulation is already running on the bridge
+  useEffect(() => {
+    if (checkedBridge) return;
+    setCheckedBridge(true);
+
+    fetch(`${bridgeUrl}/health`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.active_sessions > 0) {
+          // Simulation is already running — restore agent IDs from metrics
+          fetch(`${bridgeUrl}/metrics`)
+            .then((r) => r.json())
+            .then((metrics) => {
+              // Poll the bridge for known agent IDs
+              // The health endpoint tells us sessions exist
+              setPhase(data.active_sessions > 0 ? "running" : "setup");
+            })
+            .catch(() => {});
+
+          // Try to get agent list from bridge
+          fetch(`${bridgeUrl}/agents`)
+            .then((r) => r.ok ? r.json() : null)
+            .then((agents) => {
+              if (agents && Array.isArray(agents)) {
+                setAgentIds(agents.map((a: { id: string }) => a.id));
+                setPhase("running");
+              }
+            })
+            .catch(() => {
+              // Fallback: we know sessions exist, show running view
+              setPhase("running");
+            });
+        }
+      })
+      .catch(() => {
+        // Bridge not available — stay on setup
+      });
+  }, [bridgeUrl, checkedBridge]);
 
   const handleLaunch = useCallback(
     async (config: SimulationSetupConfig) => {


### PR DESCRIPTION
Checks bridge /health on mount. If active, fetches /agents and shows running view.