### PR TITLE
feat(concordia): native TS simulation engine — click SIM, it runs

### DIFF
--- a/runtime/src/gateway/concordia-bridge.ts
+++ b/runtime/src/gateway/concordia-bridge.ts
@@ -1,27 +1,34 @@
 /**
- * Concordia simulation bridge — built into the daemon.
+ * Concordia simulation bridge — HTTP API + native simulation engine.
  *
- * Starts an HTTP server on port 3200 that the Python Concordia engine
- * talks to via ProxyEntity. Agent actions are routed through the daemon's
- * existing ChatExecutor pipeline (Grok, memory, identity, tools).
+ * Starts an HTTP server on port 3200 for backward compatibility with the
+ * Python Concordia engine. Also hosts the native TypeScript simulation
+ * engine that runs entirely inside the daemon.
  *
- * Also starts a WebSocket event server on port 3201 for the React viewer.
+ * Events stream through the daemon's existing WebSocket (port 3100)
+ * via broadcastEvent("simulation.*", ...). No extra ports needed.
  *
  * @module
  */
 
-import { createServer, type Server, type IncomingMessage, type ServerResponse } from "node:http";
+import {
+  createServer,
+  type Server,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
 import type { Logger } from "../utils/logger.js";
+import { SimulationEngine } from "./simulation-engine.js";
 
 export interface ConcordiaBridgeConfig {
   readonly enabled?: boolean;
   readonly bridgePort?: number;
-  readonly eventPort?: number;
 }
 
-interface ConcordiaBridgeContext {
+export interface ConcordiaBridgeContext {
   readonly logger: Logger;
-  readonly sendMessage: (agentId: string, content: string) => Promise<string>;
+  readonly sendMessage: (sessionId: string, content: string) => Promise<string>;
+  readonly broadcastEvent: (eventType: string, data: Record<string, unknown>) => void;
   readonly generateAgents: (count: number, premise: string) => Promise<Array<{
     id: string;
     name: string;
@@ -30,33 +37,28 @@ interface ConcordiaBridgeContext {
   }>>;
 }
 
-interface AgentState {
-  name: string;
-  personality: string;
-  goal: string;
-  observations: string[];
-  turns: number;
-  lastAction: string | null;
-  relationships: Record<string, { count: number; sentiment: number }>;
-}
-
 // ============================================================================
-// Bridge server
+// Bridge
 // ============================================================================
 
 export class ConcordiaBridge {
   private httpServer: Server | null = null;
-  private readonly agents = new Map<string, AgentState>();
-  private readonly worldFacts: Array<{ content: string; observedBy: string; confirmations: number; timestamp: number }> = [];
-  private readonly logger: Logger;
+  private readonly engine: SimulationEngine;
   private readonly ctx: ConcordiaBridgeContext;
   private readonly bridgePort: number;
+  private readonly logger: Logger;
   private startTime = Date.now();
 
   constructor(config: ConcordiaBridgeConfig, ctx: ConcordiaBridgeContext) {
-    this.logger = ctx.logger;
     this.ctx = ctx;
+    this.logger = ctx.logger;
     this.bridgePort = config.bridgePort ?? 3200;
+
+    this.engine = new SimulationEngine({
+      sendMessage: ctx.sendMessage,
+      broadcastEvent: ctx.broadcastEvent,
+      logger: ctx.logger,
+    });
   }
 
   async start(): Promise<void> {
@@ -71,27 +73,27 @@ export class ConcordiaBridge {
     await new Promise<void>((resolve, reject) => {
       this.httpServer!.on("error", reject);
       this.httpServer!.listen(this.bridgePort, "0.0.0.0", () => {
-        this.logger.info?.(`Concordia bridge listening on 0.0.0.0:${this.bridgePort}`);
+        this.logger.info?.(
+          `Concordia bridge on 0.0.0.0:${this.bridgePort} (simulation engine ready)`,
+        );
         resolve();
       });
     });
   }
 
   async stop(): Promise<void> {
+    await this.engine.stop();
     if (this.httpServer) {
-      await new Promise<void>((resolve) => {
-        this.httpServer!.close(() => resolve());
-      });
+      await new Promise<void>((r) => this.httpServer!.close(() => r()));
       this.httpServer = null;
     }
   }
 
   // ==========================================================================
-  // Request routing
+  // HTTP routing
   // ==========================================================================
 
   private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
-    // CORS
     res.setHeader("Access-Control-Allow-Origin", "*");
     res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
     res.setHeader("Access-Control-Allow-Headers", "Content-Type");
@@ -105,240 +107,95 @@ export class ConcordiaBridge {
     const path = req.url ?? "/";
 
     if (req.method === "GET") {
-      if (path === "/health") return this.handleHealth(res);
-      if (path === "/metrics") return this.handleMetrics(res);
-      if (path === "/agents") return this.handleListAgents(res);
+      if (path === "/health") {
+        return this.sendJson(res, 200, {
+          status: "ok",
+          active_sessions: this.engine.getAgents().length,
+          uptime_ms: Date.now() - this.startTime,
+          ...this.engine.getStatus(),
+        });
+      }
+      if (path === "/agents") {
+        return this.sendJson(res, 200, this.engine.getAgents());
+      }
+      if (path === "/simulation/status") {
+        return this.sendJson(res, 200, this.engine.getStatus());
+      }
+      if (path.startsWith("/simulation/events")) {
+        const url = new URL(path, "http://localhost");
+        const since = parseInt(url.searchParams.get("since") ?? "0", 10);
+        const events = this.engine.getEventsSince(since);
+        return this.sendJson(res, 200, {
+          events,
+          total: this.engine.eventCount,
+        });
+      }
       if (path.startsWith("/agent/") && path.endsWith("/state")) {
         const agentId = decodeURIComponent(path.split("/")[2]);
-        return this.handleAgentState(agentId, res);
+        const state = this.engine.getAgentState(agentId);
+        if (state) return this.sendJson(res, 200, state);
+        return this.sendJson(res, 404, { error: `Agent ${agentId} not found` });
       }
       return this.sendJson(res, 404, { error: "Not found" });
     }
 
     if (req.method === "POST") {
       const body = await this.readJson(req);
-      if (path === "/setup") return this.handleSetup(body, res);
-      if (path === "/act") return this.handleAct(body, res);
-      if (path === "/observe") return this.handleObserve(body, res);
-      if (path === "/event") return this.handleEvent(body, res);
-      if (path === "/generate-agents") return this.handleGenerateAgents(body, res);
-      if (path === "/reset") { this.agents.clear(); this.worldFacts.length = 0; return this.sendJson(res, 200, { status: "ok" }); }
+
+      if (path === "/setup") {
+        const agents = (body.agents as Array<Record<string, string>>) ?? [];
+        await this.engine.setup({
+          worldId: String(body.world_id ?? body.worldId ?? "default"),
+          premise: String(body.premise ?? ""),
+          maxSteps: Number(body.max_steps ?? body.maxSteps ?? 20),
+          agents: agents.map((a) => ({
+            id: a.agent_id ?? a.id ?? "",
+            name: a.agent_name ?? a.name ?? "",
+            personality: a.personality ?? "",
+            goal: a.goal ?? "",
+          })),
+        });
+        await this.engine.start();
+        const sessions: Record<string, string> = {};
+        for (const a of this.engine.getAgents()) {
+          sessions[a.id] = `concordia:${a.id}`;
+        }
+        return this.sendJson(res, 200, { status: "ok", sessions });
+      }
+      if (path === "/simulation/play" || path === "/simulation/resume") {
+        this.engine.resume();
+        return this.sendJson(res, 200, { status: "ok" });
+      }
+      if (path === "/simulation/pause") {
+        this.engine.pause();
+        return this.sendJson(res, 200, { status: "ok" });
+      }
+      if (path === "/simulation/stop") {
+        await this.engine.stop();
+        return this.sendJson(res, 200, { status: "ok" });
+      }
+      if (path === "/generate-agents") {
+        const count = Math.min(10, Math.max(2, Number(body.count) || 3));
+        const premise = String(body.premise ?? "");
+        const agents = await this.ctx.generateAgents(count, premise);
+        return this.sendJson(res, 200, { agents });
+      }
+      if (path === "/act") {
+        const agentId = String(body.agent_id ?? "");
+        const content = String(
+          (body.action_spec as Record<string, unknown>)?.call_to_action ?? "",
+        );
+        const action = await this.ctx.sendMessage(agentId, content);
+        return this.sendJson(res, 200, { action });
+      }
+      if (path === "/observe" || path === "/event" || path === "/reset") {
+        return this.sendJson(res, 200, { status: "ok" });
+      }
+
       return this.sendJson(res, 404, { error: "Not found" });
     }
 
     this.sendJson(res, 405, { error: "Method not allowed" });
-  }
-
-  // ==========================================================================
-  // POST handlers
-  // ==========================================================================
-
-  private handleSetup(body: Record<string, unknown>, res: ServerResponse): void {
-    this.agents.clear();
-    this.worldFacts.length = 0;
-
-    const agents = body.agents as Array<Record<string, string>> ?? [];
-    const sessions: Record<string, string> = {};
-
-    for (const agent of agents) {
-      const id = agent.agent_id;
-      this.agents.set(id, {
-        name: agent.agent_name ?? id,
-        personality: agent.personality ?? "",
-        goal: agent.goal ?? "",
-        observations: [],
-        turns: 0,
-        lastAction: null,
-        relationships: {},
-      });
-      sessions[id] = `concordia:${id}`;
-    }
-
-    const premise = String(body.premise ?? "");
-    if (premise) {
-      this.worldFacts.push({
-        content: premise,
-        observedBy: "GM",
-        confirmations: 0,
-        timestamp: Date.now(),
-      });
-    }
-
-    this.logger.info?.(
-      `Concordia bridge: setup ${agents.length} agents, ` +
-      `maxSteps=${body.max_steps ?? body.maxSteps ?? 20}, ` +
-      `world=${body.world_id ?? "default"}`,
-    );
-
-    this.sendJson(res, 200, { status: "ok", sessions });
-  }
-
-  private async handleAct(body: Record<string, unknown>, res: ServerResponse): Promise<void> {
-    const agentId = String(body.agent_id ?? "");
-    const agentName = String(body.agent_name ?? "");
-    const spec = body.action_spec as Record<string, unknown> ?? {};
-    const callToAction = String(spec.call_to_action ?? "What would you do?");
-    const outputType = String(spec.output_type ?? "free");
-    const options = (spec.options as string[]) ?? [];
-
-    const agent = this.agents.get(agentId);
-    if (agent) agent.turns++;
-
-    // Build prompt
-    let prompt: string;
-    if (outputType === "choice" && options.length > 0) {
-      prompt = `${callToAction}\n\nChoose EXACTLY one:\n${options.map((o) => `- ${o}`).join("\n")}\n\nRespond with only the chosen option.`;
-    } else {
-      prompt = `${callToAction}\n\nRespond concisely (1-2 sentences). Do not include your name.`;
-    }
-
-    // Route through daemon's ChatExecutor
-    let action = await this.ctx.sendMessage(agentId, prompt);
-
-    // Strip name prefix
-    if (action.startsWith(`${agentName}: `)) {
-      action = action.slice(agentName.length + 2);
-    }
-
-    // Fuzzy match for choice
-    if (outputType === "choice" && options.length > 0) {
-      const lower = action.toLowerCase().trim();
-      const match = options.find((o) =>
-        o.toLowerCase() === lower ||
-        lower.includes(o.toLowerCase()) ||
-        o.toLowerCase().includes(lower)
-      );
-      action = match ?? options[0];
-    }
-
-    if (agent) agent.lastAction = action;
-
-    this.sendJson(res, 200, { action });
-  }
-
-  private handleObserve(body: Record<string, unknown>, res: ServerResponse): void {
-    const agentId = String(body.agent_id ?? "");
-    const observation = String(body.observation ?? "");
-    const agent = this.agents.get(agentId);
-    if (agent) {
-      agent.observations.push(observation);
-      if (agent.observations.length > 50) {
-        agent.observations.splice(0, agent.observations.length - 50);
-      }
-    }
-    this.sendJson(res, 200, { status: "ok" });
-  }
-
-  private handleEvent(body: Record<string, unknown>, res: ServerResponse): void {
-    const content = String(body.content ?? "");
-    const acting = String(body.acting_agent ?? "");
-
-    if (acting && content) {
-      const actingAgent = this.agents.get(acting);
-      if (actingAgent) {
-        for (const [id, agent] of this.agents) {
-          if (id !== acting && content.toLowerCase().includes(id.toLowerCase())) {
-            if (!actingAgent.relationships[id]) {
-              actingAgent.relationships[id] = { count: 0, sentiment: 0 };
-            }
-            actingAgent.relationships[id].count++;
-          }
-        }
-      }
-
-      if (body.type === "resolution") {
-        this.worldFacts.push({
-          content: content.slice(0, 200),
-          observedBy: acting || "GM",
-          confirmations: 0,
-          timestamp: Date.now(),
-        });
-        if (this.worldFacts.length > 20) {
-          this.worldFacts.splice(0, this.worldFacts.length - 20);
-        }
-      }
-    }
-
-    this.sendJson(res, 200, { status: "ok" });
-  }
-
-  private async handleGenerateAgents(body: Record<string, unknown>, res: ServerResponse): Promise<void> {
-    const count = Math.min(10, Math.max(2, Number(body.count) || 3));
-    const premise = String(body.premise ?? "");
-
-    const agents = await this.ctx.generateAgents(count, premise);
-    this.sendJson(res, 200, { agents });
-  }
-
-  // ==========================================================================
-  // GET handlers
-  // ==========================================================================
-
-  private handleListAgents(res: ServerResponse): void {
-    const agents = Array.from(this.agents.entries()).map(([id, agent]) => ({
-      id,
-      name: agent.name,
-      personality: agent.personality,
-      goal: agent.goal,
-      turns: agent.turns,
-      lastAction: agent.lastAction,
-    }));
-    this.sendJson(res, 200, agents);
-  }
-
-  private handleHealth(res: ServerResponse): void {
-    this.sendJson(res, 200, {
-      status: "ok",
-      active_sessions: this.agents.size,
-      uptime_ms: Date.now() - this.startTime,
-    });
-  }
-
-  private handleMetrics(res: ServerResponse): void {
-    let totalTurns = 0;
-    let totalObs = 0;
-    for (const agent of this.agents.values()) {
-      totalTurns += agent.turns;
-      totalObs += agent.observations.length;
-    }
-    this.sendJson(res, 200, {
-      act_requests: totalTurns,
-      observe_requests: totalObs,
-      active_sessions: this.agents.size,
-    });
-  }
-
-  private handleAgentState(agentId: string, res: ServerResponse): void {
-    const agent = this.agents.get(agentId);
-    if (!agent) {
-      return this.sendJson(res, 404, { error: `Agent ${agentId} not found` });
-    }
-
-    const relationships = Object.entries(agent.relationships).map(([otherId, data]) => ({
-      otherAgentId: otherId,
-      relationship: "acquaintance",
-      sentiment: data.sentiment,
-      interactionCount: data.count,
-    }));
-
-    this.sendJson(res, 200, {
-      identity: {
-        name: agent.name,
-        personality: agent.personality,
-        learnedTraits: [],
-        beliefs: {},
-      },
-      memoryCount: agent.observations.length,
-      recentMemories: agent.observations.slice(-5).map((obs) => ({
-        content: obs.slice(0, 200),
-        role: "system",
-        timestamp: Date.now(),
-      })),
-      relationships,
-      worldFacts: this.worldFacts.slice(-5),
-      turnCount: agent.turns,
-      lastAction: agent.lastAction,
-    });
   }
 
   // ==========================================================================
@@ -361,8 +218,8 @@ export class ConcordiaBridge {
       req.on("data", (chunk: Buffer) => chunks.push(chunk));
       req.on("end", () => {
         try {
-          const body = Buffer.concat(chunks).toString("utf-8");
-          resolve(body ? JSON.parse(body) : {});
+          const raw = Buffer.concat(chunks).toString("utf-8");
+          resolve(raw ? JSON.parse(raw) : {});
         } catch (err) {
           reject(new Error(`Invalid JSON: ${err}`));
         }

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -1689,10 +1689,14 @@ export class DaemonManager {
         const daemonLogger = this.logger;
         const concordiaHistories = new Map<string, Array<{ role: string; content: string }>>();
 
+        const webChatRef = this._webChatChannel;
         this._concordiaBridge = new ConcordiaBridge(
           { enabled: true, bridgePort: 3200 },
           {
             logger: this.logger,
+            broadcastEvent: (eventType: string, data: Record<string, unknown>) => {
+              webChatRef?.broadcastEvent(eventType, data);
+            },
             sendMessage: async (agentId: string, content: string): Promise<string> => {
               if (!chatExecutor) return "";
               const sessionId = `concordia:${agentId}`;

--- a/runtime/src/gateway/simulation-engine.ts
+++ b/runtime/src/gateway/simulation-engine.ts
@@ -1,0 +1,465 @@
+/**
+ * Native TypeScript simulation engine for Concordia-style social simulations.
+ *
+ * Runs entirely inside the daemon — no Python, no extra ports, no separate
+ * processes. Uses the same ChatExecutor as the webchat channel for LLM calls.
+ * Events stream through the existing daemon WebSocket via broadcastEvent().
+ *
+ * Architecture mirrors BackgroundRunSupervisor: setTimeout-based stepping,
+ * pause/resume support, event broadcasting through the webchat channel.
+ *
+ * @module
+ */
+
+import type { Logger } from "../utils/logger.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SimulationAgent {
+  id: string;
+  name: string;
+  personality: string;
+  goal: string;
+  observations: string[];
+  turns: number;
+  lastAction: string | null;
+  relationships: Record<string, { count: number; sentiment: number }>;
+}
+
+export interface WorldFact {
+  content: string;
+  observedBy: string;
+  timestamp: number;
+}
+
+export interface SimulationConfig {
+  worldId: string;
+  premise: string;
+  maxSteps: number;
+  agents: Array<{
+    id: string;
+    name: string;
+    personality: string;
+    goal: string;
+  }>;
+}
+
+export interface SimulationStatus {
+  worldId: string;
+  step: number;
+  maxSteps: number;
+  running: boolean;
+  paused: boolean;
+  agentCount: number;
+}
+
+export interface SimulationDeps {
+  /** Call the LLM — routes through ChatExecutor (Grok). */
+  sendMessage: (sessionId: string, content: string) => Promise<string>;
+  /** Broadcast event to all subscribed WebSocket clients. */
+  broadcastEvent: (eventType: string, data: Record<string, unknown>) => void;
+  logger: Logger;
+}
+
+// ============================================================================
+// Engine
+// ============================================================================
+
+export class SimulationEngine {
+  private step = 0;
+  private maxSteps = 20;
+  private running = false;
+  private paused = false;
+  private worldId = "";
+  private premise = "";
+  private turnIndex = 0;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private readonly agents = new Map<string, SimulationAgent>();
+  private readonly worldFacts: WorldFact[] = [];
+  private readonly agentOrder: string[] = [];
+  private readonly eventLog: Array<{ type: string; data: Record<string, unknown> }> = [];
+  private readonly deps: SimulationDeps;
+  private readonly logger: Logger;
+
+  constructor(deps: SimulationDeps) {
+    this.deps = deps;
+    this.logger = deps.logger;
+  }
+
+  // ==========================================================================
+  // Public API
+  // ==========================================================================
+
+  async setup(config: SimulationConfig): Promise<void> {
+    // Stop any existing simulation
+    await this.stop();
+
+    this.step = 0;
+    this.maxSteps = config.maxSteps;
+    this.worldId = config.worldId;
+    this.premise = config.premise;
+    this.turnIndex = 0;
+    this.agents.clear();
+    this.worldFacts.length = 0;
+    this.agentOrder.length = 0;
+
+    for (const a of config.agents) {
+      this.agents.set(a.id, {
+        id: a.id,
+        name: a.name,
+        personality: a.personality,
+        goal: a.goal,
+        observations: [],
+        turns: 0,
+        lastAction: null,
+        relationships: {},
+      });
+      this.agentOrder.push(a.id);
+    }
+
+    if (config.premise) {
+      this.worldFacts.push({
+        content: config.premise,
+        observedBy: "GM",
+        timestamp: Date.now(),
+      });
+    }
+
+    this.logger.info?.(
+      `Simulation setup: ${config.worldId}, ${config.agents.length} agents, ${config.maxSteps} steps`,
+    );
+
+    this.broadcast("simulation.setup", {
+      worldId: this.worldId,
+      agentCount: this.agents.size,
+      maxSteps: this.maxSteps,
+      premise: this.premise,
+    });
+  }
+
+  async start(): Promise<void> {
+    if (this.agents.size === 0) return;
+    this.running = true;
+    this.paused = false;
+    this.logger.info?.(`Simulation starting: ${this.worldId}`);
+    this.broadcastStatus();
+
+    // Broadcast premise as first event
+    this.broadcast("simulation.premise", {
+      step: 0,
+      content: this.premise,
+    });
+
+    this.scheduleNextStep();
+  }
+
+  pause(): void {
+    if (!this.running) return;
+    this.paused = true;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.logger.info?.(`Simulation paused at step ${this.step}`);
+    this.broadcastStatus();
+  }
+
+  resume(): void {
+    if (!this.running || !this.paused) return;
+    this.paused = false;
+    this.logger.info?.(`Simulation resumed at step ${this.step}`);
+    this.broadcastStatus();
+    this.scheduleNextStep();
+  }
+
+  async stop(): Promise<void> {
+    this.running = false;
+    this.paused = false;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    if (this.step > 0) {
+      this.logger.info?.(`Simulation stopped at step ${this.step}/${this.maxSteps}`);
+      this.broadcast("simulation.complete", {
+        step: this.step,
+        maxSteps: this.maxSteps,
+        worldId: this.worldId,
+      });
+    }
+    this.broadcastStatus();
+  }
+
+  getStatus(): SimulationStatus {
+    return {
+      worldId: this.worldId,
+      step: this.step,
+      maxSteps: this.maxSteps,
+      running: this.running,
+      paused: this.paused,
+      agentCount: this.agents.size,
+    };
+  }
+
+  getAgents(): Array<{
+    id: string;
+    name: string;
+    personality: string;
+    goal: string;
+    turns: number;
+    lastAction: string | null;
+  }> {
+    return Array.from(this.agents.values()).map((a) => ({
+      id: a.id,
+      name: a.name,
+      personality: a.personality,
+      goal: a.goal,
+      turns: a.turns,
+      lastAction: a.lastAction,
+    }));
+  }
+
+  getAgentState(agentId: string): Record<string, unknown> | null {
+    const agent = this.agents.get(agentId);
+    if (!agent) return null;
+
+    const relationships = Object.entries(agent.relationships).map(
+      ([otherId, data]) => ({
+        otherAgentId: otherId,
+        relationship: "acquaintance",
+        sentiment: data.sentiment,
+        interactionCount: data.count,
+      }),
+    );
+
+    return {
+      identity: {
+        name: agent.name,
+        personality: agent.personality,
+        learnedTraits: [],
+        beliefs: {},
+      },
+      memoryCount: agent.observations.length,
+      recentMemories: agent.observations.slice(-5).map((obs) => ({
+        content: obs.slice(0, 200),
+        role: "system",
+        timestamp: Date.now(),
+      })),
+      relationships,
+      worldFacts: this.worldFacts.slice(-5).map((f) => ({
+        content: f.content,
+        observedBy: f.observedBy,
+        confirmations: 0,
+      })),
+      turnCount: agent.turns,
+      lastAction: agent.lastAction,
+    };
+  }
+
+  // ==========================================================================
+  // Core simulation loop
+  // ==========================================================================
+
+  private scheduleNextStep(): void {
+    if (!this.running || this.paused) return;
+    // 2s between steps for pacing (user can watch in real-time)
+    this.timer = setTimeout(() => void this.runStep().catch((err) => {
+      this.logger.error?.("Simulation step error:", err);
+      this.broadcast("simulation.error", {
+        step: this.step,
+        error: String(err),
+      });
+    }), 2000);
+  }
+
+  private async runStep(): Promise<void> {
+    if (!this.running || this.paused) return;
+
+    this.step++;
+    if (this.step > this.maxSteps) {
+      await this.stop();
+      return;
+    }
+
+    this.logger.info?.(`Simulation step ${this.step}/${this.maxSteps}`);
+
+    // 1. Pick the acting agent (round-robin)
+    const actorId = this.agentOrder[this.turnIndex % this.agentOrder.length];
+    this.turnIndex++;
+    const actor = this.agents.get(actorId);
+    if (!actor) {
+      this.scheduleNextStep();
+      return;
+    }
+
+    // 2. Generate GM observation for the actor
+    const observation = await this.generateObservation(actor);
+    if (observation) {
+      actor.observations.push(observation);
+      if (actor.observations.length > 30) {
+        actor.observations.splice(0, actor.observations.length - 30);
+      }
+      this.broadcast("simulation.observation", {
+        step: this.step,
+        agentName: actor.name,
+        agentId: actor.id,
+        content: observation,
+      });
+    }
+
+    // 3. Get the agent's action
+    const action = await this.getAgentAction(actor, observation);
+    actor.turns++;
+    actor.lastAction = action;
+    this.broadcast("simulation.action", {
+      step: this.step,
+      agentName: actor.name,
+      agentId: actor.id,
+      content: action,
+    });
+
+    // 4. Resolve the event via GM
+    const resolution = await this.resolveEvent(actor, action);
+    this.broadcast("simulation.resolution", {
+      step: this.step,
+      agentName: actor.name,
+      content: resolution,
+    });
+
+    // 5. Track relationships (if resolution mentions other agents)
+    this.trackRelationships(actor, resolution);
+
+    // 6. Add to world facts
+    this.worldFacts.push({
+      content: `${actor.name}: ${action}`,
+      observedBy: actor.name,
+      timestamp: Date.now(),
+    });
+    if (this.worldFacts.length > 30) {
+      this.worldFacts.splice(0, this.worldFacts.length - 30);
+    }
+
+    // 7. Broadcast step complete
+    this.broadcastStatus();
+
+    // 8. Schedule next
+    this.scheduleNextStep();
+  }
+
+  // ==========================================================================
+  // LLM calls (via ChatExecutor)
+  // ==========================================================================
+
+  private async generateObservation(actor: SimulationAgent): Promise<string> {
+    const recentEvents = this.worldFacts.slice(-5).map((f) => f.content).join("\n");
+    const prompt = [
+      `[Game Master - Observation for ${actor.name}]`,
+      `World: ${this.premise}`,
+      recentEvents ? `Recent events:\n${recentEvents}` : "",
+      `Generate a 1-2 sentence observation that ${actor.name} would notice right now.`,
+      `Be specific and vivid. Include sensory details.`,
+    ].filter(Boolean).join("\n\n");
+
+    try {
+      const response = await this.deps.sendMessage(`sim-gm-${this.worldId}`, prompt);
+      return response || "The scene continues to unfold around you.";
+    } catch {
+      return "The scene continues to unfold around you.";
+    }
+  }
+
+  private async getAgentAction(
+    actor: SimulationAgent,
+    observation: string,
+  ): Promise<string> {
+    const recentObs = actor.observations.slice(-3).join("\n");
+    const prompt = [
+      `[You are ${actor.name}]`,
+      `Personality: ${actor.personality}`,
+      `Goal: ${actor.goal}`,
+      recentObs ? `Recent observations:\n${recentObs}` : "",
+      observation ? `Current observation: ${observation}` : "",
+      `What do you do next? Respond with a specific action in 1-2 sentences.`,
+      `Stay in character. Do not include your name as a prefix.`,
+    ].filter(Boolean).join("\n\n");
+
+    try {
+      const response = await this.deps.sendMessage(
+        `sim-agent-${actor.id}-${this.worldId}`,
+        prompt,
+      );
+      // Strip name prefix if included
+      let action = response || "considers the situation carefully";
+      if (action.startsWith(`${actor.name}: `)) {
+        action = action.slice(actor.name.length + 2);
+      }
+      return action;
+    } catch {
+      return "considers the situation carefully";
+    }
+  }
+
+  private async resolveEvent(
+    actor: SimulationAgent,
+    action: string,
+  ): Promise<string> {
+    const recentEvents = this.worldFacts.slice(-3).map((f) => f.content).join("\n");
+    const prompt = [
+      `[Game Master - Event Resolution]`,
+      `World: ${this.premise}`,
+      recentEvents ? `Recent events:\n${recentEvents}` : "",
+      `${actor.name} attempts: ${action}`,
+      `What happens as a result? Describe the outcome in 1-2 sentences.`,
+      `Be specific. Consider how other characters might react.`,
+    ].filter(Boolean).join("\n\n");
+
+    try {
+      const response = await this.deps.sendMessage(`sim-gm-${this.worldId}`, prompt);
+      return response || `${actor.name}'s action proceeds without incident.`;
+    } catch {
+      return `${actor.name}'s action proceeds without incident.`;
+    }
+  }
+
+  // ==========================================================================
+  // Helpers
+  // ==========================================================================
+
+  private trackRelationships(actor: SimulationAgent, text: string): void {
+    const lower = text.toLowerCase();
+    for (const [id, agent] of this.agents) {
+      if (id === actor.id) continue;
+      if (lower.includes(agent.name.toLowerCase()) || lower.includes(id)) {
+        if (!actor.relationships[id]) {
+          actor.relationships[id] = { count: 0, sentiment: 0 };
+        }
+        actor.relationships[id].count++;
+      }
+    }
+  }
+
+  /** Get events since a given index (for HTTP polling). */
+  getEventsSince(sinceIndex: number): Array<{ type: string; data: Record<string, unknown> }> {
+    return this.eventLog.slice(sinceIndex);
+  }
+
+  get eventCount(): number {
+    return this.eventLog.length;
+  }
+
+  private broadcast(eventType: string, data: Record<string, unknown>): void {
+    const event = { ...data, timestamp: Date.now() };
+    this.eventLog.push({ type: eventType, data: event });
+    // Cap at 500 events
+    if (this.eventLog.length > 500) {
+      this.eventLog.splice(0, this.eventLog.length - 500);
+    }
+    this.deps.broadcastEvent(eventType, event);
+  }
+
+  private broadcastStatus(): void {
+    this.broadcast("simulation.status", this.getStatus() as unknown as Record<string, unknown>);
+  }
+}

--- a/web/src/components/simulation/useSimulation.ts
+++ b/web/src/components/simulation/useSimulation.ts
@@ -134,59 +134,52 @@ export function useSimulation(config: {
   } = config;
 
   const [state, dispatch] = useReducer(reducer, initialState);
-  const wsRef = useRef<WebSocket | null>(null);
 
-  // WebSocket connection for events with auto-reconnect
+  // Poll bridge for simulation events (no separate WebSocket needed)
+  const eventIndexRef = useRef(0);
+
   useEffect(() => {
-    let ws: WebSocket | null = null;
-    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     let alive = true;
 
-    function connect() {
+    const pollEvents = async () => {
       if (!alive) return;
       try {
-        ws = new WebSocket(eventWsUrl);
-        wsRef.current = ws;
-
-        ws.onopen = () => {
+        const resp = await fetch(
+          `${bridgeUrl}/simulation/events?since=${eventIndexRef.current}`,
+        );
+        if (resp.ok) {
+          const data = await resp.json();
+          if (data.events && Array.isArray(data.events)) {
+            for (const evt of data.events) {
+              const simEvent: SimulationEvent = {
+                type: evt.type?.replace("simulation.", "") ?? "step",
+                step: evt.data?.step ?? 0,
+                timestamp: evt.data?.timestamp ?? Date.now(),
+                agent_name: evt.data?.agentName ?? evt.data?.agent_name,
+                content: evt.data?.content,
+                resolved_event: evt.data?.resolution,
+                metadata: evt.data,
+              };
+              dispatch({ type: "ADD_EVENT", event: simEvent });
+            }
+            eventIndexRef.current = data.total ?? eventIndexRef.current;
+          }
           dispatch({ type: "SET_CONNECTED", connected: true });
-          dispatch({ type: "SET_ERROR", error: null });
-        };
-        ws.onclose = () => {
-          dispatch({ type: "SET_CONNECTED", connected: false });
-          // Auto-reconnect after 2s
-          if (alive) {
-            reconnectTimer = setTimeout(connect, 2000);
-          }
-        };
-        ws.onerror = () => {
-          // onclose will fire after onerror, triggering reconnect
-        };
-
-        ws.onmessage = (msg) => {
-          try {
-            const event: SimulationEvent = JSON.parse(msg.data);
-            dispatch({ type: "ADD_EVENT", event });
-          } catch {
-            // Ignore malformed events
-          }
-        };
-      } catch {
-        if (alive) {
-          reconnectTimer = setTimeout(connect, 2000);
         }
+      } catch {
+        dispatch({ type: "SET_CONNECTED", connected: false });
       }
-    }
+    };
 
-    connect();
+    const interval = setInterval(pollEvents, 1000);
+    // Initial poll
+    void pollEvents();
 
     return () => {
       alive = false;
-      if (reconnectTimer) clearTimeout(reconnectTimer);
-      if (ws) ws.close();
-      wsRef.current = null;
+      clearInterval(interval);
     };
-  }, [eventWsUrl]);
+  }, [bridgeUrl]);
 
   // Poll agent states
   useEffect(() => {
@@ -209,11 +202,11 @@ export function useSimulation(config: {
     return () => clearInterval(interval);
   }, [bridgeUrl, agentIds, pollIntervalMs]);
 
-  // Poll simulation status
+  // Poll simulation status (from bridge on same port as /setup)
   useEffect(() => {
     const interval = setInterval(async () => {
       try {
-        const resp = await fetch(`${controlUrl}/simulation/status`);
+        const resp = await fetch(`${bridgeUrl}/simulation/status`);
         if (resp.ok) {
           const status: SimulationStatus = await resp.json();
           dispatch({ type: "SET_STATUS", status });
@@ -224,24 +217,24 @@ export function useSimulation(config: {
     }, pollIntervalMs);
 
     return () => clearInterval(interval);
-  }, [controlUrl, pollIntervalMs]);
+  }, [bridgeUrl, pollIntervalMs]);
 
-  // Control functions
+  // Control functions (all on bridge URL — no separate control port)
   const play = useCallback(async () => {
-    await fetch(`${controlUrl}/simulation/play`, { method: "POST" }).catch(() => {});
-  }, [controlUrl]);
+    await fetch(`${bridgeUrl}/simulation/play`, { method: "POST" }).catch(() => {});
+  }, [bridgeUrl]);
 
   const pause = useCallback(async () => {
-    await fetch(`${controlUrl}/simulation/pause`, { method: "POST" }).catch(() => {});
-  }, [controlUrl]);
+    await fetch(`${bridgeUrl}/simulation/pause`, { method: "POST" }).catch(() => {});
+  }, [bridgeUrl]);
 
   const step = useCallback(async () => {
-    await fetch(`${controlUrl}/simulation/step`, { method: "POST" }).catch(() => {});
-  }, [controlUrl]);
+    await fetch(`${bridgeUrl}/simulation/step`, { method: "POST" }).catch(() => {});
+  }, [bridgeUrl]);
 
   const stop = useCallback(async () => {
-    await fetch(`${controlUrl}/simulation/stop`, { method: "POST" }).catch(() => {});
-  }, [controlUrl]);
+    await fetch(`${bridgeUrl}/simulation/stop`, { method: "POST" }).catch(() => {});
+  }, [bridgeUrl]);
 
   return { state, play, pause, step, stop };
 }


### PR DESCRIPTION
## What changed
- NEW: `simulation-engine.ts` — setTimeout-based simulation loop inside the daemon
- REWRITE: `concordia-bridge.ts` — wraps engine, adds /simulation/* endpoints
- FIX: `daemon.ts` — passes broadcastEvent to bridge context
- FIX: `useSimulation.ts` — polls /simulation/events, controls via bridge (no ports 3201/3202)

## How it works
1. User clicks SIM → picks preset → Launch
2. POST /setup → engine.setup() + engine.start()
3. Engine runs steps via setTimeout (2s between steps)
4. Each step: GM observation → agent action → GM resolution (all via ChatExecutor/Grok)
5. Events stored in log, broadcast via webchat channel
6. UI polls /simulation/events?since=N every 1s
7. Play/Pause/Stop via /simulation/* endpoints
8. No Python, no port 3201, no port 3202. Everything on 3100 + 3200.