### PR TITLE
fix(memory): persistent memory not loading on first turn of new sessions

### DIFF
--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -2450,9 +2450,11 @@ export class ChatExecutor {
         "system_runtime",
       );
     }
-    // Session-scoped persistence should not bleed into truly fresh chats.
-    // For the first turn, only inject static skill context.
-    if (enableMemoryContext && ctx.hasHistory) {
+    // Persistent semantic memory (workspace-scoped, cross-session) is always
+    // injected — it provides facts learned in prior sessions (e.g. user's name).
+    // The retriever handles its own scoping: working memory is session-scoped,
+    // semantic/episodic memory is workspace-scoped with maxAge filtering.
+    if (enableMemoryContext) {
       await this.injectContext(
         ctx,
         this.memoryRetriever,
@@ -2462,6 +2464,11 @@ export class ChatExecutor {
         ctx.messageSections,
         "memory_semantic",
       );
+    }
+    // Session-scoped providers (learning patterns, progress tracker) are gated
+    // on hasHistory since they rely on current-session context and should not
+    // inject stale session state into a truly fresh first turn.
+    if (enableMemoryContext && ctx.hasHistory) {
       await this.injectContext(
         ctx,
         this.learningProvider,


### PR DESCRIPTION
## Summary

- **Root cause**: `memoryRetriever` injection was gated on `ctx.hasHistory` (line 2455 of chat-executor.ts), which is `false` for the first turn of every new session since `session.history` starts as `[]`
- **Impact**: When a user tells the agent their name in session A, then starts session B, the agent has no knowledge of it on the first turn — persistent workspace-scoped memories were never loaded
- **Fix**: Split the gate — `memoryRetriever` (workspace-scoped, cross-session) always runs when `enableMemoryContext` is true, while `learningProvider` and `progressProvider` (session-contextual) remain gated on `hasHistory`
- The retriever already handles scoping correctly internally: working memory is session-scoped, semantic/episodic memory is workspace-scoped with maxAge filtering

## Test plan

- [ ] Start session A, tell agent "my name is Alice"
- [ ] Start session B, ask "do you remember my name?" — agent should recall "Alice"
- [ ] Verify first turn of new session includes semantic memory context in prompt
- [ ] Verify learning/progress providers still skip on first turn (session-scoped)