### PR TITLE
fix(memory): legacy unscoped entries invisible to workspace-scoped retrieval

### DIFF
--- a/runtime/src/memory/sqlite/vector-backend.ts
+++ b/runtime/src/memory/sqlite/vector-backend.ts
@@ -353,7 +353,15 @@ export class SqliteVectorBackend
         if (!options.memoryRoles.some((r) => combined.includes(r))) continue;
       }
       // Workspace/agent scoping (Phase 2)
-      if (options?.workspaceId && entry.workspaceId !== options.workspaceId) continue;
+      // Allow entries with "default" or undefined workspaceId to match any workspace
+      // (legacy unscoped entries from before workspace-aware ingestion).
+      if (
+        options?.workspaceId &&
+        entry.workspaceId !== options.workspaceId &&
+        entry.workspaceId !== "default" &&
+        entry.workspaceId !== undefined &&
+        entry.workspaceId !== ""
+      ) continue;
       if (options?.agentId && entry.agentId !== options.agentId) continue;
       result.set(id, entry);
     }


### PR DESCRIPTION
## Summary

- Entries stored before the workspace-aware ingestion fix have `workspaceId="default"` or undefined
- The vector backend filter rejected these when the retriever queried with the actual workspace path (e.g. `/home/tetsuo/git/stream-test/agenc-shell`)
- This made ALL pre-fix memories invisible — the user could tell the agent their name and it would be stored, but never retrieved in new sessions
- Fix: treat entries with workspaceId `"default"`, `undefined`, or `""` as global — visible to any workspace query
- New entries stored with correct workspace paths remain properly scoped

## Test plan

- [ ] Tell agent your name in session A, start session B, ask if it remembers
- [ ] Verify legacy `ws=default` entries are now returned by retriever
- [ ] Verify new entries still get correct workspace path stored