### PR TITLE
fix(memory): use global vector DB for cross-workspace memory persistence

### DIFF
--- a/runtime/src/gateway/memory-retriever-factory.ts
+++ b/runtime/src/gateway/memory-retriever-factory.ts
@@ -68,11 +68,15 @@ export interface MemoryRetrieversResult {
 // Vector DB path resolution
 // ---------------------------------------------------------------------------
 
-function resolveVectorDbPath(workspacePath: string): string | undefined {
-  if (!workspacePath) return undefined;
+function resolveVectorDbPath(_workspacePath: string): string | undefined {
+  // Use a single global vector DB at ~/.agenc/vectors.db so memories
+  // are accessible across all workspaces.  The daemon serves sessions
+  // from many workspaces but only opens one vector backend, so a
+  // per-workspace DB makes memories invisible to other workspaces.
   try {
     const { existsSync, mkdirSync } = require("node:fs");
-    const vectorDir = join(workspacePath, ".agenc");
+    const home = process.env.HOME ?? process.env.USERPROFILE ?? "/tmp";
+    const vectorDir = join(home, ".agenc");
     if (!existsSync(vectorDir)) {
       mkdirSync(vectorDir, { recursive: true });
     }


### PR DESCRIPTION
## Summary

- The daemon serves sessions from many workspaces but only opens one vector backend at startup
- Per-workspace vector DBs (`{workspace}/.agenc/vectors.db`) meant memories stored from one workspace were invisible to sessions from another
- This was the root cause of persistent memory not working — the user chatted from `stream-test/agenc-shell` but the vector DB was opened from `agenc-core`
- Fix: use a single global DB at `~/.agenc/vectors.db`

## Test plan

- [ ] Tell agent your name, new session, ask if it remembers
- [ ] Verify entries from different workspaces are all visible