### PR TITLE
fix(concordia): pass host services through runtime host

### DIFF
--- a/runtime/src/gateway/channel-wiring.ts
+++ b/runtime/src/gateway/channel-wiring.ts
@@ -65,6 +65,9 @@ export interface ChannelWiringDeps {
   readonly chatExecutor: ChatExecutor | null;
   readonly memoryBackend: MemoryBackend | null;
   readonly defaultForegroundMaxToolRounds: number;
+  buildChannelHostServices(
+    config: GatewayConfig,
+  ): Readonly<Record<string, unknown>> | undefined;
 
   buildSystemPrompt(
     config: GatewayConfig,
@@ -528,6 +531,7 @@ export async function wireExternalChannel(
     onMessage,
     logger: deps.logger,
     config: channelConfig,
+    hostServices: deps.buildChannelHostServices(config),
   });
   await channel.start();
   deps.logger.info(`${channelName} channel wired`);

--- a/runtime/src/gateway/channel.ts
+++ b/runtime/src/gateway/channel.ts
@@ -63,6 +63,8 @@ export interface ChannelContext {
   readonly logger: Logger;
   /** Channel-specific config from gateway config. */
   readonly config: Readonly<Record<string, unknown>>;
+  /** Optional host-provided services for hosted channel adapters. */
+  readonly hostServices?: Readonly<Record<string, unknown>>;
   /**
    * Hook dispatcher for lifecycle events.
    * Optional because activate() does not wire hooks yet — will become

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -221,6 +221,7 @@ import {
   type ChannelWiringDeps,
   type ExternalChannelRegistry,
 } from "./channel-wiring.js";
+import { createChannelHostServices } from "../plugins/channel-host-services.js";
 import type { ProactiveCommunicator } from "./proactive.js";
 import { ToolRouter, type ToolRoutingDecision } from "./tool-routing.js";
 import {
@@ -3244,6 +3245,12 @@ export class DaemonManager {
       chatExecutor: this._chatExecutor,
       memoryBackend: this._memoryBackend,
       defaultForegroundMaxToolRounds: this._defaultForegroundMaxToolRounds,
+      buildChannelHostServices: (config) =>
+        createChannelHostServices({
+          memoryBackend: this._memoryBackend,
+          logger: this.logger,
+          workspacePath: this._resolveActiveHostWorkspacePath(config),
+        }),
       buildSystemPrompt: (config, options) =>
         this._buildSystemPrompt(config, options),
       handleTextChannelApprovalCommand: (params) =>

--- a/runtime/src/plugins/channel-host-services.test.ts
+++ b/runtime/src/plugins/channel-host-services.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { createChannelHostServices } from "./channel-host-services.js";
+
+describe("createChannelHostServices", () => {
+  it("returns concordia memory services when a backend is available", () => {
+    const backend = {
+      addEntry: vi.fn(),
+      getThread: vi.fn(),
+      set: vi.fn(),
+      get: vi.fn(),
+    };
+
+    const services = createChannelHostServices({
+      memoryBackend: backend as never,
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      workspacePath: "/tmp/agenc-test",
+    });
+
+    expect(services?.concordia_memory).toBeDefined();
+    expect(services?.concordia_memory?.memoryBackend).toBe(backend);
+    expect(services?.concordia_memory?.dailyLogManager).toBeDefined();
+  });
+
+  it("returns undefined when memory is unavailable", () => {
+    expect(
+      createChannelHostServices({
+        memoryBackend: null,
+        logger: {
+          debug: vi.fn(),
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/runtime/src/plugins/channel-host-services.ts
+++ b/runtime/src/plugins/channel-host-services.ts
@@ -1,0 +1,59 @@
+import { join } from "node:path";
+import type { MemoryBackend } from "../memory/types.js";
+import { AgentIdentityManager } from "../memory/agent-identity.js";
+import { SocialMemoryManager } from "../memory/social-memory.js";
+import { ProceduralMemory } from "../memory/procedural.js";
+import { SharedMemoryBackend } from "../memory/shared-memory.js";
+import { DailyLogManager } from "../memory/structured.js";
+import { MemoryTraceLogger } from "../memory/trace-logger.js";
+import type { Logger } from "../utils/logger.js";
+
+export interface ConcordiaMemoryHostServices {
+  readonly memoryBackend: MemoryBackend;
+  readonly identityManager: AgentIdentityManager;
+  readonly socialMemory: SocialMemoryManager;
+  readonly proceduralMemory: ProceduralMemory;
+  readonly sharedMemory: SharedMemoryBackend;
+  readonly traceLogger: MemoryTraceLogger;
+  readonly dailyLogManager?: DailyLogManager;
+}
+
+export type ChannelHostServices = Readonly<Record<string, unknown>> & {
+  readonly concordia_memory?: ConcordiaMemoryHostServices;
+};
+
+export function createChannelHostServices(params: {
+  readonly memoryBackend: MemoryBackend | null;
+  readonly logger: Logger;
+  readonly workspacePath?: string;
+}): ChannelHostServices | undefined {
+  if (!params.memoryBackend) {
+    return undefined;
+  }
+
+  return {
+    concordia_memory: {
+      memoryBackend: params.memoryBackend,
+      identityManager: new AgentIdentityManager({
+        memoryBackend: params.memoryBackend,
+        logger: params.logger,
+      }),
+      socialMemory: new SocialMemoryManager({
+        memoryBackend: params.memoryBackend,
+        logger: params.logger,
+      }),
+      proceduralMemory: new ProceduralMemory({
+        memoryBackend: params.memoryBackend,
+        logger: params.logger,
+      }),
+      sharedMemory: new SharedMemoryBackend({
+        memoryBackend: params.memoryBackend,
+        logger: params.logger,
+      }),
+      traceLogger: new MemoryTraceLogger(params.logger),
+      dailyLogManager: params.workspacePath
+        ? new DailyLogManager(join(params.workspacePath, "logs"))
+        : undefined,
+    },
+  };
+}

--- a/runtime/src/plugins/channel-host.test.ts
+++ b/runtime/src/plugins/channel-host.test.ts
@@ -62,6 +62,9 @@ describe("HostedChannelPlugin", () => {
       logger: silentLogger,
       config: {},
       onMessage,
+      hostServices: {
+        concordia_memory: { enabled: true },
+      },
     });
 
     await adapter.context!.on_message({
@@ -136,6 +139,9 @@ describe("HostedChannelPlugin", () => {
         ],
       },
     ]);
+    expect(adapter.context?.host_services).toEqual({
+      concordia_memory: { enabled: true },
+    });
   });
 
   it("rejects invalid inbound payloads from adapters", async () => {

--- a/runtime/src/plugins/channel-host.ts
+++ b/runtime/src/plugins/channel-host.ts
@@ -181,12 +181,15 @@ export class HostedChannelPlugin<
   }
 
   async initialize(context: ChannelContext): Promise<void> {
-    const adapterContext: ChannelAdapterContext<TConfig> = {
+    const adapterContext = {
       logger: createAdapterLogger(context.logger, this.manifest),
       config: this.config,
       on_message: async (message) => {
         await context.onMessage(normalizeInboundMessage(this.name, message));
       },
+      host_services: context.hostServices,
+    } as ChannelAdapterContext<TConfig> & {
+      readonly host_services?: Readonly<Record<string, unknown>>;
     };
     await this.adapter.initialize(adapterContext);
   }

--- a/web/src/components/simulation/SimulationViewer.tsx
+++ b/web/src/components/simulation/SimulationViewer.tsx
@@ -50,8 +50,9 @@ export function SimulationViewer({
       setLaunching(true);
       setLaunchConfig(config);
       try {
-        // POST to bridge /setup
-        const resp = await fetch(`${bridgeUrl}/setup`, {
+        // POST to bridge /launch. The plugin bridge will spawn the Python
+        // runner, and the runner will call back into bridge /setup.
+        const resp = await fetch(`${bridgeUrl}/launch`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({


### PR DESCRIPTION
## Summary
- pass host-provided services through the runtime channel host initialization path
- build and attach a Concordia memory-services bundle for hosted channel adapters
- repoint the simulation viewer launch flow to the plugin `/launch` endpoint

## Companion PRs
- `agenc-plugin-kit` #5
- `AgenC` #1537

## Test plan
- `npx vitest run src/plugins/channel-host.test.ts src/plugins/channel-host-services.test.ts`
- `npm run typecheck` is currently red in this repo on unrelated pre-existing errors; this PR removes the new host-service-specific errors and relies on targeted validation for the touched surface
