### PR TITLE
fix(runtime): repair concordia host services and typecheck

### DIFF
--- a/runtime/src/cli/skills-cli.ts
+++ b/runtime/src/cli/skills-cli.ts
@@ -21,7 +21,7 @@ import type {
 
 const MAX_INSTALL_SIZE = 1_048_576; // 1 MB
 const BODY_PREVIEW_LENGTH = 500;
-const VALIDATION_DISCOVERY_TIERS: readonly Array<{
+const VALIDATION_DISCOVERY_TIERS: ReadonlyArray<{
   readonly tier: DiscoveryTier;
   readonly key: keyof DiscoveryPaths;
 }> = [

--- a/runtime/src/gateway/background-run-store.ts
+++ b/runtime/src/gateway/background-run-store.ts
@@ -93,7 +93,8 @@ export type BackgroundRunWorkerPool =
   | "code"
   | "research"
   | "approval"
-  | "remote_mcp";
+  | "remote_mcp"
+  | "remote_session";
 
 export interface BackgroundRunManagedProcessLaunchSpec {
   readonly kind?: "process" | "server";
@@ -2977,6 +2978,7 @@ export class BackgroundRunStore {
       research: 0,
       approval: 0,
       remote_mcp: 0,
+      remote_session: 0,
     } satisfies Record<BackgroundRunWorkerPool, number>;
     const claimedByPool = {
       generic: 0,
@@ -2986,6 +2988,7 @@ export class BackgroundRunStore {
       research: 0,
       approval: 0,
       remote_mcp: 0,
+      remote_session: 0,
     } satisfies Record<BackgroundRunWorkerPool, number>;
     let totalClaimed = 0;
     for (const item of queue.items) {

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -3250,6 +3250,7 @@ export class DaemonManager {
           memoryBackend: this._memoryBackend,
           logger: this.logger,
           workspacePath: this._resolveActiveHostWorkspacePath(config),
+          llmConfig: config.llm,
         }),
       buildSystemPrompt: (config, options) =>
         this._buildSystemPrompt(config, options),

--- a/runtime/src/gateway/subagent-orchestrator.ts
+++ b/runtime/src/gateway/subagent-orchestrator.ts
@@ -18,7 +18,6 @@ import type {
   PipelineResult,
   PipelineStep,
 } from "../workflow/pipeline.js";
-import type { WorkflowGraphEdge } from "../workflow/types.js";
 import { canonicalizePipelinePlannerExecutionContexts } from "../workflow/migrations.js";
 import { resolveWorkflowDependencyState } from "../workflow/completion-state.js";
 import type {

--- a/runtime/src/gateway/subagent-prompt-builder.ts
+++ b/runtime/src/gateway/subagent-prompt-builder.ts
@@ -529,7 +529,7 @@ function dependencyProvidesWorkspaceInspectionEvidence(params: {
 function collectDependencyWorkspaceInspectionToolCalls(params: {
   readonly dependencyStep: PipelinePlannerStep | undefined;
   readonly result: string | null;
-}): readonly Array<{
+}): ReadonlyArray<{
   readonly name?: string;
   readonly args?: unknown;
   readonly result?: string;

--- a/runtime/src/gateway/tool-handler-factory.ts
+++ b/runtime/src/gateway/tool-handler-factory.ts
@@ -50,7 +50,10 @@ import {
   normalizeEnvelopePath,
   normalizeEnvelopeRoots,
 } from "../workflow/path-normalization.js";
-import { resolveExecutionEnvelopeArtifactRelations } from "../workflow/execution-envelope.js";
+import {
+  resolveExecutionEnvelopeArtifactRelations,
+  type ExecutionEnvelope,
+} from "../workflow/execution-envelope.js";
 import type { RuntimeIncidentDiagnostics } from "../telemetry/incident-diagnostics.js";
 import {
   FaultInjectionError,
@@ -845,18 +848,7 @@ function getFilesystemToolAccessMode(
 function enforceSubAgentExecutionEnvelope(params: {
   readonly toolName: string;
   readonly args: Record<string, unknown>;
-  readonly executionContext?: {
-    readonly workspaceRoot?: string;
-    readonly allowedReadRoots?: readonly string[];
-    readonly allowedWriteRoots?: readonly string[];
-    readonly inputArtifacts?: readonly string[];
-    readonly requiredSourceArtifacts?: readonly string[];
-    readonly targetArtifacts?: readonly string[];
-    readonly artifactRelations?: readonly {
-      readonly relationType: string;
-      readonly artifactPath: string;
-    }[];
-  };
+  readonly executionContext?: ExecutionEnvelope;
   readonly defaultWorkingDirectory?: string;
 }): string | undefined {
   const { executionContext } = params;

--- a/runtime/src/llm/chat-executor-contract-guidance.ts
+++ b/runtime/src/llm/chat-executor-contract-guidance.ts
@@ -556,7 +556,10 @@ function isPlanBackedImplementationOwnerSpec(
   const ownsWorkspaceRoot = targetArtifacts.some((artifactPath) =>
     artifactPath.trim() === workspaceRoot
   );
-  return ownsWorkspaceRoot || spec.task.trim().toLowerCase() === "implement_owner";
+  return (
+    ownsWorkspaceRoot ||
+    spec.task?.trim().toLowerCase() === "implement_owner"
+  );
 }
 
 function isDelegatedFileAuthoringPhaseWithoutVerification(

--- a/runtime/src/llm/chat-executor-planner-normalization.ts
+++ b/runtime/src/llm/chat-executor-planner-normalization.ts
@@ -15,8 +15,8 @@ import type { PlannerParseResult } from "./chat-executor-types.js";
 import {
   parsePlannerPlan,
   salvagePlannerToolCallsAsPlan,
-  type ExplicitSubagentOrchestrationRequirements,
 } from "./chat-executor-planner.js";
+import type { RequiredSubagentOrchestrationRequirements as ExplicitSubagentOrchestrationRequirements } from "../workflow/subagent-orchestration-requirements.js";
 import { extractStructuredOutputObject } from "./structured-output.js";
 
 export function normalizePlannerResponse(params: {

--- a/runtime/src/llm/chat-executor-planner.ts
+++ b/runtime/src/llm/chat-executor-planner.ts
@@ -544,8 +544,6 @@ const EXPLANATION_ONLY_REQUEST_RE =
   /\b(?:explain|describe|outline|summarize|brainstorm|compare|review|analy(?:s|z)e|what would|how would|plan(?:\s+out)?|walk me through)\b/i;
 const NODE_PACKAGE_TOOLING_RE =
   /\b(?:node(?:\.js)?|npm|npx|package\.json|package-lock\.json|pnpm|pnpm-workspace\.yaml|yarn|bun|typescript|tsconfig(?:\.[a-z]+)?\.json|tsx|vitest|commander|(?:npm|pnpm|yarn|bun)\s+workspaces?)\b/i;
-const NODE_DECLARED_ECOSYSTEM_STRONG_RE =
-  /\b(?:npm|npx|package\.json|package-lock\.json|pnpm|pnpm-workspace\.yaml|yarn|bun|tsconfig(?:\.[a-z]+)?\.json|node_modules|vite\.config(?:\.[a-z]+)?|vitest\.config(?:\.[a-z]+)?|(?:npm|pnpm|yarn|bun)\s+workspaces?)\b/i;
 const NODE_DECLARED_ECOSYSTEM_COMMAND_RE = /\b(?:npm|npx|pnpm|yarn|bun)\b/i;
 const NODE_PACKAGE_MANIFEST_PATH_RE =
   /(?:^|\/)(?:package\.json|package-lock\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|yarn\.lock|bun\.lockb|tsconfig(?:\.[a-z]+)?\.json)$/i;
@@ -2790,6 +2788,21 @@ function collectPlannerSubagentStepText(
     .join(" ");
 }
 
+function extractCommandText(args: Record<string, unknown>): string {
+  const parts: string[] = [];
+  if (typeof args.command === "string") {
+    parts.push(args.command);
+  }
+  if (Array.isArray(args.args)) {
+    for (const value of args.args) {
+      if (typeof value === "string") {
+        parts.push(value);
+      }
+    }
+  }
+  return parts.join(" ");
+}
+
 function collectMalformedPlannerSubagentContractFields(
   step: PlannerSubAgentTaskStepIntent,
 ): readonly string[] {
@@ -3019,7 +3032,8 @@ function collectPlannerStepScopedPaths(
     return [...paths];
   }
 
-  const executionContext = step.executionContext;
+  const executionContext =
+    step.stepType === "subagent_task" ? step.executionContext : undefined;
   const candidatePaths = [
     executionContext?.workspaceRoot,
     ...(executionContext?.allowedReadRoots ?? []),
@@ -3028,7 +3042,7 @@ function collectPlannerStepScopedPaths(
     ...(executionContext?.targetArtifacts ?? []),
     ...(executionContext?.inputArtifacts ?? []),
     ...(executionContext?.artifactRelations ?? []).map(
-      (relation) => relation.artifactPath,
+      (relation: WorkflowArtifactRelation) => relation.artifactPath,
     ),
   ];
   for (const value of candidatePaths) {
@@ -3087,9 +3101,10 @@ function collectPlannerStepDeclaredEcosystems(
   }
 
   const combined = stripNegatedNodeEcosystemLanguage(
-    collectPlannerSubagentStepText(step),
+    step.stepType === "subagent_task"
+      ? collectPlannerSubagentStepText(step)
+      : "",
   );
-  const hasStrongNodeText = NODE_DECLARED_ECOSYSTEM_STRONG_RE.test(combined);
   const hasNodeCommandIntent = NODE_DECLARED_ECOSYSTEM_COMMAND_RE.test(combined);
   const hasNativeText = NATIVE_TOOLING_RE.test(combined);
   if (
@@ -4197,7 +4212,9 @@ function plannerPathTargetsRequestedArtifact(
 
 function isPlannerDeterministicFileWriteStep(
   step: PlannerStepIntent,
-): boolean {
+): step is PlannerDeterministicToolStepIntent & {
+  tool: "system.writeFile" | "system.appendFile";
+} {
   return (
     step.stepType === "deterministic_tool" &&
     (step.tool === "system.writeFile" || step.tool === "system.appendFile")

--- a/runtime/src/llm/chat-executor-recovery.ts
+++ b/runtime/src/llm/chat-executor-recovery.ts
@@ -778,6 +778,9 @@ export function preflightStaleCopiedCmakeHarnessInvocation(
   if (!isStaleCopiedCmakeWorkspace(workspaceRoot)) {
     return { args, repairedFields: [] };
   }
+  if (!workspaceRoot) {
+    return { args, repairedFields: [] };
+  }
   const normalizedWorkspaceRoot = resolvePath(workspaceRoot);
   const freshBuildDir = resolvePreferredFreshBuildDirectory(recentCalls);
   const freshBuildPath = buildFreshBuildDirectoryPath(

--- a/runtime/src/llm/chat-executor-verifier.ts
+++ b/runtime/src/llm/chat-executor-verifier.ts
@@ -51,6 +51,7 @@ import { deriveVerificationObligations } from "../workflow/verification-obligati
 import { validateRuntimeVerificationContract } from "../workflow/verification-contract.js";
 import {
   formatRuntimeVerificationIssueCode,
+  isPlannerVerifierIssueCode,
   mapDelegationValidationCodeToPlannerVerifierIssue,
   type PlannerVerifierIssueCode,
 } from "../workflow/cleanup-mode.js";
@@ -65,6 +66,7 @@ import {
   validateDelegatedOutputContract,
 } from "../utils/delegation-validation.js";
 import { parseJsonObjectFromText } from "../utils/delegated-contract-normalization.js";
+import { buildDelegationExecutionContext } from "../utils/delegation-execution-context.js";
 
 const DIRECT_MUTATION_TOOL_NAMES = new Set([
   "desktop.text_editor",
@@ -355,11 +357,13 @@ export function evaluatePlannerDeterministicChecks(
         providerEvidence,
       });
       if (!contractValidation.ok) {
-        issues.push(
-          mapDelegationValidationCodeToPlannerVerifierIssue(
-            contractValidation.code,
-          ),
-        );
+        if (contractValidation.code) {
+          issues.push(
+            mapDelegationValidationCodeToPlannerVerifierIssue(
+              contractValidation.code,
+            ),
+          );
+        }
         verdict = moreSevereVerifierVerdict(verdict, "retry");
       }
     }
@@ -499,12 +503,15 @@ function enforceRequiredReviewerChildren(params: {
   const issueSuffix = missingExactNames.length > 0
     ? `missing=${missingExactNames.join(",")}`
     : `sessions=${distinctSessionIds.size}/${requiredChildren.cardinality}`;
-  const updatedAssessments = params.stepAssessments.map((assessment) => {
+  const updatedAssessments: SubagentVerifierStepAssessment[] =
+    params.stepAssessments.map((assessment) => {
     if (!namesToFail.has(assessment.name)) {
       return assessment;
     }
-    const issues = assessment.issues.includes("missing_required_reviewer_children")
-      ? assessment.issues
+    const issues: PlannerVerifierIssueCode[] = assessment.issues.includes(
+      "missing_required_reviewer_children",
+    )
+      ? [...assessment.issues]
       : [...assessment.issues, "missing_required_reviewer_children"];
     const unresolvedValue = `${assessment.name}:missing_required_reviewer_children:${issueSuffix}`;
     if (!params.unresolvedItems.includes(unresolvedValue)) {
@@ -512,7 +519,7 @@ function enforceRequiredReviewerChildren(params: {
     }
     return {
       ...assessment,
-      verdict: "fail",
+      verdict: "fail" as const,
       retryable: false,
       issues,
       summary:
@@ -544,7 +551,11 @@ function collectHybridVerifierIssues(
     return [...new Set(issues)];
   }
   if (decision.diagnostic?.code) {
-    return [decision.diagnostic.code];
+    return [
+      mapDelegationValidationCodeToPlannerVerifierIssue(
+        decision.diagnostic.code,
+      ),
+    ];
   }
   return [];
 }
@@ -736,7 +747,7 @@ export function parseSubagentVerifierDecision(
       ? obj.issues
           .filter((issue): issue is string => typeof issue === "string")
           .map((issue) => issue.trim())
-          .filter((issue) => issue.length > 0)
+          .filter(isPlannerVerifierIssueCode)
       : [];
     const summary = parsePlannerOptionalString(obj.summary) ??
       (issues.length > 0 ? issues.join("; ") : "verifier assessment");
@@ -1567,29 +1578,19 @@ function buildDeterministicImplementationVerifierWorkItem(
     contextRequirements: [],
     executionContext:
       verificationContract || completionContract
-        ? {
-          ...(verificationContract?.workspaceRoot
-            ? { workspaceRoot: verificationContract.workspaceRoot }
-            : {}),
-          ...(verificationContract?.inputArtifacts
-            ? { inputArtifacts: verificationContract.inputArtifacts }
-            : {}),
-          ...(verificationContract?.requiredSourceArtifacts
-            ? {
-              requiredSourceArtifacts:
-                verificationContract.requiredSourceArtifacts,
-            }
-            : {}),
-          ...(verificationContract?.targetArtifacts
-            ? { targetArtifacts: verificationContract.targetArtifacts }
-            : {}),
+        ? buildDelegationExecutionContext({
+          workspaceRoot: verificationContract?.workspaceRoot,
+          inputArtifacts: verificationContract?.inputArtifacts,
+          requiredSourceArtifacts:
+            verificationContract?.requiredSourceArtifacts,
+          targetArtifacts: verificationContract?.targetArtifacts,
           verificationMode:
             verificationContract?.verificationMode ??
             "deterministic_followup",
           stepKind:
             verificationContract?.stepKind ??
             "delegated_validation",
-          completionContract,
+          role: "validator",
           artifactRelations: canonicalizeWorkflowArtifactRelations({
             workspaceRoot: verificationContract?.workspaceRoot,
             inputArtifacts: verificationContract?.inputArtifacts,
@@ -1604,8 +1605,8 @@ function buildDeterministicImplementationVerifierWorkItem(
               "deterministic_followup",
             role: "validator",
           }),
-          role: "validator",
-        }
+          completionContract,
+        })
         : undefined,
     artifactRelations: canonicalizeWorkflowArtifactRelations({
       workspaceRoot: verificationContract?.workspaceRoot,

--- a/runtime/src/memory/benchmarks/locomo-bench.ts
+++ b/runtime/src/memory/benchmarks/locomo-bench.ts
@@ -15,9 +15,8 @@
 import { InMemoryBackend } from "../in-memory/backend.js";
 import { InMemoryVectorStore } from "../vector-store.js";
 import { NoopEmbeddingProvider } from "../embeddings.js";
-import { SemanticMemoryRetriever } from "../retriever.js";
 import { MemoryIngestionEngine } from "../ingestion.js";
-import { DailyLogManager, CuratedMemoryManager } from "../structured.js";
+import { DailyLogManager } from "../structured.js";
 
 export interface LocomoBenchResult {
   readonly name: string;
@@ -65,7 +64,7 @@ export async function runLocomoBench(): Promise<LocomoBenchSuite> {
   const backend = new InMemoryBackend();
   const vectorStore = new InMemoryVectorStore();
   const embedding = new NoopEmbeddingProvider();
-  const logManager = new DailyLogManager(backend);
+  const logManager = new DailyLogManager("/tmp/agenc-locomo-bench-logs");
 
   const engine = new MemoryIngestionEngine({
     embeddingProvider: embedding,
@@ -84,16 +83,16 @@ export async function runLocomoBench(): Promise<LocomoBenchSuite> {
   }
 
   // Evaluate QA accuracy
-  results.push(await evaluateQAAccuracy(vectorStore, embedding, qaPairs));
+  results.push(await evaluateQAAccuracy(vectorStore, qaPairs));
 
   // Evaluate multi-session fact linking
-  results.push(await evaluateMultiSessionReasoning(vectorStore, embedding));
+  results.push(await evaluateMultiSessionReasoning(vectorStore));
 
   // Evaluate session boundary handling
   results.push(await evaluateSessionBoundaries(backend, turns));
 
   // Evaluate temporal ordering
-  results.push(await evaluateTemporalOrdering(vectorStore, embedding));
+  results.push(await evaluateTemporalOrdering(vectorStore));
 
   const passCount = results.filter((r) => r.passed).length;
   const passRate = passCount / results.length;
@@ -167,7 +166,6 @@ function generateLocomoData(): {
 
 async function evaluateQAAccuracy(
   vectorStore: InMemoryVectorStore,
-  embedding: NoopEmbeddingProvider,
   qaPairs: QAPair[],
 ): Promise<LocomoBenchResult> {
   const start = Date.now();
@@ -176,10 +174,7 @@ async function evaluateQAAccuracy(
   for (const qa of qaPairs) {
     // Search for the answer
     const keyword = qa.expectedAnswer.split(" ").find((w) => w.length > 4) ?? "";
-    const results = await vectorStore.query({
-      search: keyword,
-      limit: 5,
-    });
+    const results = await queryEntriesByKeyword(vectorStore, keyword, 5);
 
     // Check if any result contains the expected answer
     const found = results.some((r) =>
@@ -202,7 +197,6 @@ async function evaluateQAAccuracy(
 
 async function evaluateMultiSessionReasoning(
   vectorStore: InMemoryVectorStore,
-  embedding: NoopEmbeddingProvider,
 ): Promise<LocomoBenchResult> {
   const start = Date.now();
 
@@ -214,10 +208,7 @@ async function evaluateMultiSessionReasoning(
   const multiSession = sessionIds.size > 1;
 
   // Search for a cross-session concept
-  const results = await vectorStore.query({
-    search: "TypeScript",
-    limit: 10,
-  });
+  const results = await queryEntriesByKeyword(vectorStore, "TypeScript", 10);
 
   const hasResults = results.length > 0;
   const score = (multiSession ? 0.5 : 0) + (hasResults ? 0.5 : 0);
@@ -262,7 +253,6 @@ async function evaluateSessionBoundaries(
 
 async function evaluateTemporalOrdering(
   vectorStore: InMemoryVectorStore,
-  embedding: NoopEmbeddingProvider,
 ): Promise<LocomoBenchResult> {
   const start = Date.now();
 
@@ -289,4 +279,19 @@ async function evaluateTemporalOrdering(
     details: `${ordered}/${Math.max(0, entries.length - 1)} entries in temporal order`,
     durationMs: Date.now() - start,
   };
+}
+
+async function queryEntriesByKeyword(
+  vectorStore: InMemoryVectorStore,
+  keyword: string,
+  limit: number,
+) {
+  const normalizedKeyword = keyword.trim().toLowerCase();
+  const entries = await vectorStore.query({ limit: 200 });
+  return entries
+    .filter((entry) =>
+      normalizedKeyword.length > 0 &&
+      entry.content.toLowerCase().includes(normalizedKeyword)
+    )
+    .slice(0, limit);
 }

--- a/runtime/src/memory/benchmarks/memory-agent-bench.ts
+++ b/runtime/src/memory/benchmarks/memory-agent-bench.ts
@@ -15,10 +15,6 @@
 import { InMemoryBackend } from "../in-memory/backend.js";
 import { InMemoryVectorStore } from "../vector-store.js";
 import { NoopEmbeddingProvider } from "../embeddings.js";
-import { SemanticMemoryRetriever } from "../retriever.js";
-import { MemoryIngestionEngine } from "../ingestion.js";
-import { DailyLogManager, CuratedMemoryManager } from "../structured.js";
-import type { MemoryBackend } from "../types.js";
 
 export interface BenchmarkResult {
   readonly name: string;
@@ -63,7 +59,6 @@ export async function runMemoryAgentBench(): Promise<BenchmarkSuite> {
 
 async function benchAccurateRetrieval(): Promise<BenchmarkResult> {
   const start = Date.now();
-  const backend = new InMemoryBackend();
   const vectorStore = new InMemoryVectorStore();
   const embedding = new NoopEmbeddingProvider();
 
@@ -103,7 +98,7 @@ async function benchAccurateRetrieval(): Promise<BenchmarkResult> {
   for (const fact of facts) {
     // Use a distinctive keyword from each fact
     const keyword = fact.split(" ").find((w) => w.length > 4) ?? fact.slice(0, 10);
-    const results = await vectorStore.query({ search: keyword, limit: 10 });
+    const results = await queryEntriesByKeyword(vectorStore, keyword, 10);
     if (results.some((r) => r.content === fact)) {
       found++;
     }
@@ -174,10 +169,7 @@ async function benchLongRangeUnderstanding(): Promise<BenchmarkResult> {
   }
 
   // Can we find the important fact from turn 0 after 100 turns?
-  const results = await vectorStore.query({
-    search: "secret code",
-    limit: 5,
-  });
+  const results = await queryEntriesByKeyword(vectorStore, "secret code", 5);
 
   const found = results.some((r) => r.content.includes("secret code is 42"));
   const score = found ? 1.0 : 0.0;
@@ -236,7 +228,6 @@ async function benchSelectiveForgetting(): Promise<BenchmarkResult> {
 
 async function benchCrossSessionPersistence(): Promise<BenchmarkResult> {
   const start = Date.now();
-  const backend = new InMemoryBackend();
   const vectorStore = new InMemoryVectorStore();
   const embedding = new NoopEmbeddingProvider();
 
@@ -258,10 +249,7 @@ async function benchCrossSessionPersistence(): Promise<BenchmarkResult> {
   );
 
   // Retrieve from session B (different session, same workspace)
-  const results = await vectorStore.query({
-    search: "favorite color",
-    limit: 5,
-  });
+  const results = await queryEntriesByKeyword(vectorStore, "favorite color", 5);
 
   const found = results.some((r) => r.content.includes("favorite color is blue"));
 
@@ -273,4 +261,19 @@ async function benchCrossSessionPersistence(): Promise<BenchmarkResult> {
     details: `Cross-session retrieval: ${found}`,
     durationMs: Date.now() - start,
   };
+}
+
+async function queryEntriesByKeyword(
+  vectorStore: InMemoryVectorStore,
+  keyword: string,
+  limit: number,
+) {
+  const normalizedKeyword = keyword.trim().toLowerCase();
+  const entries = await vectorStore.query({ limit: 200 });
+  return entries
+    .filter((entry) =>
+      normalizedKeyword.length > 0 &&
+      entry.content.toLowerCase().includes(normalizedKeyword)
+    )
+    .slice(0, limit);
 }

--- a/runtime/src/memory/procedural.ts
+++ b/runtime/src/memory/procedural.ts
@@ -73,24 +73,18 @@ export interface ProceduralMemoryConfig {
 }
 
 const DEFAULT_KEY_PREFIX = "procedure:";
-const DEFAULT_MAX_PROCEDURES = 100;
-
 /**
  * Procedural memory manager — records and retrieves tool sequence patterns.
  */
 export class ProceduralMemory {
   private readonly backend: MemoryBackend;
-  private readonly embedding: EmbeddingProvider | undefined;
   private readonly logger: Logger | undefined;
   private readonly keyPrefix: string;
-  private readonly maxProcedures: number;
 
   constructor(config: ProceduralMemoryConfig) {
     this.backend = config.memoryBackend;
-    this.embedding = config.embeddingProvider;
     this.logger = config.logger;
     this.keyPrefix = config.keyPrefix ?? DEFAULT_KEY_PREFIX;
-    this.maxProcedures = config.maxProcedures ?? DEFAULT_MAX_PROCEDURES;
   }
 
   /**

--- a/runtime/src/memory/reflection.ts
+++ b/runtime/src/memory/reflection.ts
@@ -98,7 +98,7 @@ export async function runReflection(params: {
     }
 
     // Update beliefs (per edge case X5: must have evidence)
-    const beliefs: ReflectionResult["beliefs"] = [];
+    const beliefs: Array<ReflectionResult["beliefs"][number]> = [];
     if (parsed.beliefs && typeof parsed.beliefs === "object") {
       for (const [topic, belief] of Object.entries(parsed.beliefs)) {
         if (

--- a/runtime/src/memory/sqlite/backend.ts
+++ b/runtime/src/memory/sqlite/backend.ts
@@ -34,7 +34,7 @@ function escapeLikePrefix(prefix: string): string {
 }
 
 export class SqliteBackend implements MemoryBackend {
-  readonly name = "sqlite";
+  readonly name: string = "sqlite";
 
   protected db: any = null;
   private readonly config: Required<

--- a/runtime/src/memory/sqlite/vector-backend.ts
+++ b/runtime/src/memory/sqlite/vector-backend.ts
@@ -29,7 +29,6 @@ import type {
 } from "../vector-store.js";
 import type { SqliteBackendConfig } from "./types.js";
 import { SqliteBackend } from "./backend.js";
-import { MemoryBackendError } from "../errors.js";
 
 const BM25_K1 = 1.5;
 const BM25_B = 0.75;
@@ -277,7 +276,12 @@ export class SqliteVectorBackend
   }
 
   override getDurability(): DurabilityInfo {
-    return { level: "sync" };
+    return {
+      level: "sync",
+      supportsFlush: true,
+      description:
+        "SQLite-backed memory persists synchronously on committed writes.",
+    };
   }
 
   override async deleteThread(sessionId: string): Promise<number> {

--- a/runtime/src/memory/trace-logger.ts
+++ b/runtime/src/memory/trace-logger.ts
@@ -7,7 +7,7 @@
  * @module
  */
 
-import type { Logger } from "../utils/logger.js";
+import { silentLogger, type Logger } from "../utils/logger.js";
 
 /** Memory trace event types. */
 export type MemoryTraceEventType =
@@ -212,13 +212,6 @@ export class MemoryTraceLogger {
   ): void {
     if (!this.enabled) return;
     try {
-      const event: MemoryTraceEvent = {
-        type,
-        sessionId,
-        workspaceId,
-        timestamp: Date.now(),
-        payload,
-      };
       this.logger.debug?.(
         `[${type}]${sessionId ? ` session=${sessionId}` : ""}${workspaceId ? ` ws=${workspaceId}` : ""} ${JSON.stringify(payload)}`,
       );
@@ -234,5 +227,5 @@ function round(n: number): number {
 
 /** Create a no-op trace logger for tests. */
 export function createNoopMemoryTraceLogger(): MemoryTraceLogger {
-  return new MemoryTraceLogger({ debug() {}, info() {}, warn() {}, error() {} } as Logger, false);
+  return new MemoryTraceLogger(silentLogger, false);
 }

--- a/runtime/src/plugins/channel-host-services.test.ts
+++ b/runtime/src/plugins/channel-host-services.test.ts
@@ -19,11 +19,23 @@ describe("createChannelHostServices", () => {
         error: vi.fn(),
       },
       workspacePath: "/tmp/agenc-test",
+      llmConfig: {
+        provider: "grok",
+        apiKey: "test-key",
+        model: "grok-4.20-beta-0309-reasoning",
+        baseUrl: "https://api.x.ai/v1",
+      },
     });
 
     expect(services?.concordia_memory).toBeDefined();
     expect(services?.concordia_memory?.memoryBackend).toBe(backend);
     expect(services?.concordia_memory?.dailyLogManager).toBeDefined();
+    expect(services?.concordia_runtime?.llm).toEqual({
+      provider: "grok",
+      apiKey: "test-key",
+      model: "grok-4.20-beta-0309-reasoning",
+      baseUrl: "https://api.x.ai/v1",
+    });
   });
 
   it("returns undefined when memory is unavailable", () => {
@@ -38,5 +50,25 @@ describe("createChannelHostServices", () => {
         },
       }),
     ).toBeUndefined();
+  });
+
+  it("returns runtime LLM services even when memory is unavailable", () => {
+    const services = createChannelHostServices({
+      memoryBackend: null,
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      llmConfig: {
+        provider: "grok",
+        apiKey: "test-key",
+      },
+    });
+
+    expect(services?.concordia_runtime?.llm.provider).toBe("grok");
+    expect(services?.concordia_runtime?.llm.apiKey).toBe("test-key");
+    expect(services?.concordia_memory).toBeUndefined();
   });
 });

--- a/runtime/src/plugins/channel-host-services.ts
+++ b/runtime/src/plugins/channel-host-services.ts
@@ -18,42 +18,73 @@ export interface ConcordiaMemoryHostServices {
   readonly dailyLogManager?: DailyLogManager;
 }
 
+export interface ConcordiaRuntimeHostServices {
+  readonly llm: {
+    readonly provider?: string;
+    readonly apiKey?: string;
+    readonly model?: string;
+    readonly baseUrl?: string;
+  };
+}
+
 export type ChannelHostServices = Readonly<Record<string, unknown>> & {
   readonly concordia_memory?: ConcordiaMemoryHostServices;
+  readonly concordia_runtime?: ConcordiaRuntimeHostServices;
 };
 
 export function createChannelHostServices(params: {
   readonly memoryBackend: MemoryBackend | null;
   readonly logger: Logger;
   readonly workspacePath?: string;
+  readonly llmConfig?: {
+    readonly provider?: string;
+    readonly apiKey?: string;
+    readonly model?: string;
+    readonly baseUrl?: string;
+  };
 }): ChannelHostServices | undefined {
-  if (!params.memoryBackend) {
-    return undefined;
+  const services: Record<string, unknown> = {};
+
+  if (params.llmConfig) {
+    services.concordia_runtime = {
+      llm: {
+        provider: params.llmConfig.provider,
+        apiKey: params.llmConfig.apiKey,
+        model: params.llmConfig.model,
+        baseUrl: params.llmConfig.baseUrl,
+      },
+    } satisfies ConcordiaRuntimeHostServices;
   }
 
-  return {
-    concordia_memory: {
+  if (!params.memoryBackend) {
+    return Object.keys(services).length > 0
+      ? (services as ChannelHostServices)
+      : undefined;
+  }
+
+  services.concordia_memory = {
+    memoryBackend: params.memoryBackend,
+    identityManager: new AgentIdentityManager({
       memoryBackend: params.memoryBackend,
-      identityManager: new AgentIdentityManager({
-        memoryBackend: params.memoryBackend,
-        logger: params.logger,
-      }),
-      socialMemory: new SocialMemoryManager({
-        memoryBackend: params.memoryBackend,
-        logger: params.logger,
-      }),
-      proceduralMemory: new ProceduralMemory({
-        memoryBackend: params.memoryBackend,
-        logger: params.logger,
-      }),
-      sharedMemory: new SharedMemoryBackend({
-        memoryBackend: params.memoryBackend,
-        logger: params.logger,
-      }),
-      traceLogger: new MemoryTraceLogger(params.logger),
-      dailyLogManager: params.workspacePath
-        ? new DailyLogManager(join(params.workspacePath, "logs"))
-        : undefined,
-    },
-  };
+      logger: params.logger,
+    }),
+    socialMemory: new SocialMemoryManager({
+      memoryBackend: params.memoryBackend,
+      logger: params.logger,
+    }),
+    proceduralMemory: new ProceduralMemory({
+      memoryBackend: params.memoryBackend,
+      logger: params.logger,
+    }),
+    sharedMemory: new SharedMemoryBackend({
+      memoryBackend: params.memoryBackend,
+      logger: params.logger,
+    }),
+    traceLogger: new MemoryTraceLogger(params.logger),
+    dailyLogManager: params.workspacePath
+      ? new DailyLogManager(join(params.workspacePath, "logs"))
+      : undefined,
+  } satisfies ConcordiaMemoryHostServices;
+
+  return services as ChannelHostServices;
 }

--- a/runtime/src/workflow/cleanup-mode.ts
+++ b/runtime/src/workflow/cleanup-mode.ts
@@ -19,6 +19,8 @@ export const PLANNER_DELEGATION_VERIFIER_CLEANUP_MODE = {
 } as const;
 
 export const PLANNER_VERIFIER_LITERAL_ISSUE_CODES = [
+  "planner_verifier_unavailable",
+  "planner_verifier_parse_failed",
   "missing_subagent_result",
   "missing_implementation_output_evidence",
   "malformed_subagent_result_payload",
@@ -141,6 +143,35 @@ export function formatRuntimeVerificationIssueCode(params: {
     );
   }
   return `${params.channel}:${params.code}`;
+}
+
+export function isPlannerVerifierIssueCode(
+  value: string,
+): value is PlannerVerifierIssueCode {
+  if (
+    (PLANNER_VERIFIER_LITERAL_ISSUE_CODES as readonly string[]).includes(value)
+  ) {
+    return true;
+  }
+  if (
+    value.startsWith("contract_violation_") &&
+    (
+      PLANNER_VERIFIER_CONTRACT_VIOLATION_CODES as readonly string[]
+    ).includes(value.slice("contract_violation_".length))
+  ) {
+    return true;
+  }
+
+  const separatorIndex = value.indexOf(":");
+  if (separatorIndex <= 0) {
+    return false;
+  }
+  const channel = value.slice(0, separatorIndex);
+  const code = value.slice(separatorIndex + 1);
+  return (
+    (RUNTIME_VERIFICATION_CHANNEL_NAMES as readonly string[]).includes(channel) &&
+    (DELEGATION_OUTPUT_VALIDATION_CODES as readonly string[]).includes(code)
+  );
 }
 
 function assertNever(value: never): never {


### PR DESCRIPTION
## Summary
- pass daemon LLM defaults into channel host services for Concordia plugins
- include the pending runtime type fixes that restore `runtime` typecheck
- add runtime host-service coverage for Concordia launch defaults

## Test plan
- npm run typecheck
- npm run test -- src/plugins/channel-host-services.test.ts