### PR TITLE
fix(runtime): route concordia turns through fast direct path

### DIFF
--- a/runtime/src/llm/chat-executor-contract-flow.ts
+++ b/runtime/src/llm/chat-executor-contract-flow.ts
@@ -198,6 +198,7 @@ export function resolveLegacyCompletionCompatibility(input: {
   const analysis = analyzeLegacyCompletionTurn(input.ctx);
   const plannerRouteReason = input.ctx.plannerSummaryState.routeReason;
   if (
+    plannerRouteReason === "concordia_simulation_turn" ||
     plannerRouteReason === "exact_response_turn" ||
     plannerRouteReason === "dialogue_memory_turn"
   ) {
@@ -205,7 +206,7 @@ export function resolveLegacyCompletionCompatibility(input: {
       allowed: true,
       compatibilityClass: "plan_only",
       reason:
-        "Legacy completion remains allowed for exact-response and dialogue-memory turns.",
+        "Legacy completion remains allowed for direct Concordia/exact-response/dialogue-memory turns.",
     };
   }
 

--- a/runtime/src/llm/chat-executor-fallback.test.ts
+++ b/runtime/src/llm/chat-executor-fallback.test.ts
@@ -130,4 +130,24 @@ describe("callWithFallback", () => {
     expect(provider.chatStream).toHaveBeenCalledOnce();
     expect(provider.chat).not.toHaveBeenCalled();
   });
+
+  it("uses non-stream chat when streaming is explicitly disabled", async () => {
+    const provider = createMockProvider();
+    const onStreamChunk = vi.fn();
+
+    await callWithFallback(
+      createDeps(provider),
+      [{ role: "user", content: "reply with exactly ACK" }],
+      onStreamChunk,
+      undefined,
+      {
+        callPhase: "initial",
+        toolChoice: "none",
+        disableStreaming: true,
+      },
+    );
+
+    expect(provider.chat).toHaveBeenCalledOnce();
+    expect(provider.chatStream).not.toHaveBeenCalled();
+  });
 });

--- a/runtime/src/llm/chat-executor-fallback.ts
+++ b/runtime/src/llm/chat-executor-fallback.ts
@@ -50,7 +50,11 @@ import type { RuntimeFaultInjector } from "../eval/fault-injection.js";
 function shouldBypassStreamingForModelCall(
   options: LLMChatOptions | undefined,
   callPhase: ChatCallUsageRecord["phase"] | undefined,
+  disableStreaming: boolean | undefined,
 ): boolean {
+  if (disableStreaming === true) {
+    return true;
+  }
   const isExplicitToolTurn =
     options?.toolChoice === "required" ||
     (typeof options?.toolChoice === "object" &&
@@ -96,6 +100,7 @@ export interface CallWithFallbackOptions {
   callIndex?: number;
   callPhase?: ChatCallUsageRecord["phase"];
   faultInjector?: RuntimeFaultInjector;
+  disableStreaming?: boolean;
 }
 
 // ============================================================================
@@ -191,7 +196,11 @@ export async function callWithFallback(
   let lastError: Error | undefined;
   const transport =
     onStreamChunk !== undefined &&
-    !shouldBypassStreamingForModelCall(baseChatOptions, options?.callPhase)
+    !shouldBypassStreamingForModelCall(
+      baseChatOptions,
+      options?.callPhase,
+      options?.disableStreaming,
+    )
       ? "chat_stream"
       : "chat";
 

--- a/runtime/src/llm/chat-executor-planner.test.ts
+++ b/runtime/src/llm/chat-executor-planner.test.ts
@@ -876,6 +876,26 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
     expect(decision.reason).toContain("artifact_spec_execution_request");
   });
 
+  it("routes concordia simulation turns through the direct non-planner path using metadata, not prompt regex", () => {
+    const decision = assessPlannerDecision(
+      true,
+      [
+        "[Concordia Action Request]",
+        "Agent: Alex",
+        "Reply with one short plain-text description of your immediate next action.",
+        "",
+        "What would Alex do next?",
+      ].join("\n"),
+      [],
+      {
+        turn_contract: "concordia_simulation_turn",
+      },
+    );
+
+    expect(decision.shouldPlan).toBe(false);
+    expect(decision.reason).toBe("concordia_simulation_turn");
+  });
+
   it("extracts required subagent steps from the compact 'plan required' prompt shape", () => {
     const requirements = extractExplicitSubagentOrchestrationRequirements(
       "Subagent context audit SG3. Sub-agent orchestration plan required: " +

--- a/runtime/src/llm/chat-executor-planner.ts
+++ b/runtime/src/llm/chat-executor-planner.ts
@@ -94,6 +94,7 @@ import {
   MIN_DELEGATION_TIMEOUT_MS,
 } from "../gateway/delegation-timeout.js";
 import type { HostToolingProfile } from "../gateway/host-tooling.js";
+import { hasConcordiaSimulationTurnContract } from "./chat-executor-turn-contracts.js";
 import { collectDirectModeShellControlTokens } from "../tools/system/command-line.js";
 import {
   buildDelegationExecutionContext,
@@ -304,6 +305,7 @@ export function assessPlannerDecision(
   plannerEnabled: boolean,
   messageText: string,
   history: readonly LLMMessage[],
+  metadata?: Readonly<Record<string, unknown>>,
 ): PlannerDecision {
   if (!plannerEnabled) {
     return {
@@ -316,6 +318,14 @@ export function assessPlannerDecision(
   const signals = collectPlannerRequestSignals(messageText, history);
   let score = 0;
   const reasons: string[] = [];
+
+  if (hasConcordiaSimulationTurnContract(metadata)) {
+    return {
+      score,
+      shouldPlan: false,
+      reason: "concordia_simulation_turn",
+    };
+  }
 
   if (signals.hasMultiStepCue) {
     score += 3;

--- a/runtime/src/llm/chat-executor-text.ts
+++ b/runtime/src/llm/chat-executor-text.ts
@@ -53,6 +53,7 @@ import {
   sanitizeDelegatedAssistantEnvironmentSummary,
 } from "../utils/delegated-scope-trust.js";
 import { buildWorkflowRecoveryStateLines } from "./chat-executor-recovery.js";
+import { hasConcordiaSimulationTurnContract } from "./chat-executor-turn-contracts.js";
 
 // ============================================================================
 // JSON parsing helpers (used by planner + verifier)
@@ -349,7 +350,17 @@ export function reconcileVerifiedFileWorkflowContent(
   return content;
 }
 
-function extractExactResponseLiteral(messageText: string): string | undefined {
+function extractExactResponseLiteral(
+  messageText: string,
+  metadata?: Readonly<Record<string, unknown>>,
+): string | undefined {
+  if (
+    hasConcordiaSimulationTurnContract(metadata) ||
+    /^\[Concordia (?:Action|Speech|Choice|Numeric) Request\]/.test(messageText)
+  ) {
+    return undefined;
+  }
+
   const directiveMatch =
     /\b(?:return|reply|respond|output|answer)(?:\s+with)?\s+exactly(?:\s+as)?\s+/i.exec(
       messageText,
@@ -434,11 +445,12 @@ export function reconcileExactResponseContract(
   toolCalls: readonly ToolCallRecord[],
   messageText: string,
   options?: {
+    readonly metadata?: Readonly<Record<string, unknown>>;
     readonly forceLiteralWhenNoToolEvidence?: boolean;
   },
 ): string {
   if (!content) return content;
-  const literal = extractExactResponseLiteral(messageText);
+  const literal = extractExactResponseLiteral(messageText, options?.metadata);
   if (!literal) return content;
 
   const trimmed = content.trim();

--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -457,7 +457,8 @@ export async function executeToolCallLoop(
 ): Promise<void> {
   const suppressToolsForDialogueTurn =
     !ctx.plannerDecision.shouldPlan &&
-    (ctx.plannerDecision.reason === "exact_response_turn" ||
+    (ctx.plannerDecision.reason === "concordia_simulation_turn" ||
+      ctx.plannerDecision.reason === "exact_response_turn" ||
       ctx.plannerDecision.reason === "dialogue_memory_turn" ||
       ctx.plannerDecision.reason === "dialogue_recall_turn");
   const initialContractGuidance = callbacks.resolveActiveToolContractGuidance(ctx, {

--- a/runtime/src/llm/chat-executor-turn-contracts.ts
+++ b/runtime/src/llm/chat-executor-turn-contracts.ts
@@ -1,0 +1,24 @@
+import type { GatewayMessage } from "../gateway/message.js";
+
+export const CONCORDIA_SIMULATION_TURN_CONTRACT =
+  "concordia_simulation_turn";
+
+export function hasConcordiaSimulationTurnContract(
+  metadata?: Readonly<Record<string, unknown>>,
+): boolean {
+  if (!metadata) return false;
+  return (
+    metadata.turn_contract === CONCORDIA_SIMULATION_TURN_CONTRACT ||
+    metadata.turnContract === CONCORDIA_SIMULATION_TURN_CONTRACT ||
+    metadata.concordia_turn_contract === CONCORDIA_SIMULATION_TURN_CONTRACT
+  );
+}
+
+export function isConcordiaSimulationTurnMessage(
+  message: Pick<GatewayMessage, "channel" | "metadata">,
+): boolean {
+  return (
+    message.channel === "concordia" &&
+    hasConcordiaSimulationTurnContract(message.metadata)
+  );
+}

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -8569,6 +8569,87 @@ describe("ChatExecutor", () => {
       });
     });
 
+    it("disables streaming for exact-response turns even when a default stream callback exists", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: "ACK-STREAMLESS",
+          }),
+        ),
+      });
+      const constructorStreamCallback = vi.fn();
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        onStreamChunk: constructorStreamCallback,
+        allowedTools: ["desktop.text_editor", "execute_with_agent"],
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Concordia exact turn check. Reply with exactly ACK-STREAMLESS and nothing else.",
+          ),
+        }),
+      );
+
+      expect(result.content).toBe("ACK-STREAMLESS");
+      expect(result.plannerSummary?.routeReason).toBe("exact_response_turn");
+      expect(provider.chat).toHaveBeenCalledTimes(1);
+      expect(provider.chatStream).not.toHaveBeenCalled();
+      expect(constructorStreamCallback).not.toHaveBeenCalled();
+    });
+
+    it("treats concordia action turns as direct simulation turns instead of exact-response turns", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: "checks the live gold quote and places a bid for 2 contracts at 2453.",
+          }),
+        ),
+      });
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        allowedTools: ["desktop.text_editor", "execute_with_agent"],
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: {
+            ...createMessage(
+              [
+                "[Concordia Action Request]",
+                "Agent: Alex",
+                "Reply with one short plain-text description of your immediate next action.",
+                "Be specific and concrete.",
+                "Do not include your name, quotation marks, or any explanation.",
+                "",
+                "What would Alex do next? Give one specific, concrete action that Alex personally takes right now.",
+              ].join("\n"),
+            ),
+            channel: "concordia",
+            metadata: {
+              turn_contract: "concordia_simulation_turn",
+              type: "concordia_agent_turn",
+            },
+          },
+        }),
+      );
+
+      expect(result.content).toBe(
+        "checks the live gold quote and places a bid for 2 contracts at 2453.",
+      );
+      expect(result.plannerSummary?.routeReason).toBe("concordia_simulation_turn");
+      expect(provider.chat).toHaveBeenCalledTimes(1);
+      expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]).toMatchObject({
+        toolChoice: "none",
+        toolRouting: { allowedToolNames: [] },
+      });
+    });
+
     it("does not suppress tools for delegated child-memory turns that explicitly require execute_with_agent", async () => {
       const provider = createMockProvider("primary", {
         chat: vi.fn().mockResolvedValue(

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -50,6 +50,7 @@ import {
   resolveModelRoute,
   type ModelRoutingPolicy,
 } from "./model-routing-policy.js";
+import { isConcordiaSimulationTurnMessage } from "./chat-executor-turn-contracts.js";
 import {
   resolveDelegationDecisionConfig,
   type ResolvedDelegationDecisionConfig,
@@ -733,6 +734,7 @@ export class ChatExecutor {
       ctx.allToolCalls,
       ctx.messageText,
       {
+        metadata: ctx.message.metadata,
         forceLiteralWhenNoToolEvidence:
           plannerSummary?.routeReason === "exact_response_turn" ||
           plannerSummary?.routeReason === "dialogue_memory_turn",
@@ -944,6 +946,12 @@ export class ChatExecutor {
     ctx: ExecutionContext,
     phase: ChatCallUsageRecord["phase"],
   ): RuntimeRunClass {
+    if (
+      isConcordiaSimulationTurnMessage(ctx.message) &&
+      (phase === "initial" || phase === "tool_followup")
+    ) {
+      return "child";
+    }
     return ctx.defaultRunClass ?? this.defaultRunClass ?? mapPhaseToRunClass(phase);
   }
 
@@ -2017,6 +2025,9 @@ export class ChatExecutor {
       selectedProviderRouteKey: routingDecision.route.selectedProviderRouteKey,
       phase: input.phase,
     });
+    const disableStreaming =
+      ctx.plannerDecision.reason === "exact_response_turn" ||
+      ctx.plannerDecision.reason === "dialogue_memory_turn";
     const structuredOutput =
       requestedStructuredOutput &&
       routingDecision.route.selectedProviderName === "grok"
@@ -2116,6 +2127,7 @@ export class ChatExecutor {
               callPhase: input.phase,
             }
             : {}),
+          ...(disableStreaming ? { disableStreaming: true } : {}),
           providersOverride: routingDecision.route.providers,
         },
       );
@@ -2287,6 +2299,7 @@ export class ChatExecutor {
       this.plannerEnabled,
       messageText,
       history,
+      params.message.metadata,
     );
     const plannerArtifactDirectPath =
       plannerDecision.reason === "plan_generation_direct_path" ||

--- a/runtime/src/plugins/channel-host-services.test.ts
+++ b/runtime/src/plugins/channel-host-services.test.ts
@@ -36,6 +36,12 @@ describe("createChannelHostServices", () => {
       model: "grok-4.20-beta-0309-reasoning",
       baseUrl: "https://api.x.ai/v1",
     });
+    expect(services?.concordia_runtime?.defaults).toEqual({
+      provider: "grok",
+      apiKey: "test-key",
+      model: "grok-4-1-fast-non-reasoning",
+      baseUrl: "https://api.x.ai/v1",
+    });
   });
 
   it("returns undefined when memory is unavailable", () => {
@@ -69,6 +75,9 @@ describe("createChannelHostServices", () => {
 
     expect(services?.concordia_runtime?.llm.provider).toBe("grok");
     expect(services?.concordia_runtime?.llm.apiKey).toBe("test-key");
+    expect(services?.concordia_runtime?.defaults?.model).toBe(
+      "grok-4-1-fast-non-reasoning",
+    );
     expect(services?.concordia_memory).toBeUndefined();
   });
 });

--- a/runtime/src/plugins/channel-host-services.ts
+++ b/runtime/src/plugins/channel-host-services.ts
@@ -8,6 +8,8 @@ import { DailyLogManager } from "../memory/structured.js";
 import { MemoryTraceLogger } from "../memory/trace-logger.js";
 import type { Logger } from "../utils/logger.js";
 
+const DEFAULT_CONCORDIA_GM_MODEL = "grok-4-1-fast-non-reasoning";
+
 export interface ConcordiaMemoryHostServices {
   readonly memoryBackend: MemoryBackend;
   readonly identityManager: AgentIdentityManager;
@@ -20,6 +22,12 @@ export interface ConcordiaMemoryHostServices {
 
 export interface ConcordiaRuntimeHostServices {
   readonly llm: {
+    readonly provider?: string;
+    readonly apiKey?: string;
+    readonly model?: string;
+    readonly baseUrl?: string;
+  };
+  readonly defaults?: {
     readonly provider?: string;
     readonly apiKey?: string;
     readonly model?: string;
@@ -51,6 +59,14 @@ export function createChannelHostServices(params: {
         provider: params.llmConfig.provider,
         apiKey: params.llmConfig.apiKey,
         model: params.llmConfig.model,
+        baseUrl: params.llmConfig.baseUrl,
+      },
+      defaults: {
+        provider: params.llmConfig.provider,
+        apiKey: params.llmConfig.apiKey,
+        model: params.llmConfig.provider === "grok"
+          ? DEFAULT_CONCORDIA_GM_MODEL
+          : params.llmConfig.model,
         baseUrl: params.llmConfig.baseUrl,
       },
     } satisfies ConcordiaRuntimeHostServices;

--- a/web/src/components/simulation/AgentInspector.tsx
+++ b/web/src/components/simulation/AgentInspector.tsx
@@ -125,7 +125,9 @@ export function AgentInspector({ agentId, agent, onClose }: AgentInspectorProps)
                       [{mem.role}]{" "}
                       {new Date(mem.timestamp).toLocaleTimeString()}
                     </span>
-                    <div className="text-green-500 truncate">{mem.content}</div>
+                    <div className="text-green-500 whitespace-pre-wrap break-words">
+                      {mem.content}
+                    </div>
                   </div>
                 ))}
               </div>
@@ -137,7 +139,7 @@ export function AgentInspector({ agentId, agent, onClose }: AgentInspectorProps)
             <Section title="KNOWN WORLD FACTS">
               <div className="space-y-1">
                 {agent.worldFacts.map((fact, i) => (
-                  <div key={i} className="text-xs text-green-500">
+                  <div key={i} className="text-xs whitespace-pre-wrap break-words text-green-500">
                     <span className="text-green-700">[{fact.observedBy}]</span>{" "}
                     {fact.content}
                     {fact.confirmations > 0 && (

--- a/web/src/components/simulation/EventTimeline.tsx
+++ b/web/src/components/simulation/EventTimeline.tsx
@@ -91,7 +91,7 @@ export function EventTimeline({ events }: EventTimelineProps) {
       {/* Event list */}
       <div
         ref={containerRef}
-        className="flex-1 overflow-y-auto p-1 space-y-0.5"
+        className="flex-1 overflow-x-hidden overflow-y-auto p-1 space-y-0.5"
       >
         {filtered.map((event, i) => (
           <EventCard key={i} event={event} />
@@ -109,30 +109,32 @@ function EventCard({ event }: { event: SimulationEvent }) {
   const color = EVENT_COLORS[event.type] ?? "text-green-600";
   const label = EVENT_LABELS[event.type] ?? event.type.slice(0, 3).toUpperCase();
   const time = new Date(event.timestamp * 1000).toLocaleTimeString();
+  const content = event.content ?? event.resolved_event ?? "";
 
   return (
     <div
-      className="hover:bg-green-950 cursor-pointer px-1"
+      className="min-w-0 w-full hover:bg-green-950 cursor-pointer px-1"
       onClick={() => setExpanded(!expanded)}
     >
-      <div className="flex gap-2">
+      <div className="grid w-full grid-cols-[4.5rem_2.5rem_2.75rem_auto_minmax(0,1fr)] items-start gap-x-2 gap-y-0.5">
         <span className="text-green-800 w-16 shrink-0">{time}</span>
         <span className={`${color} w-6 shrink-0 font-bold`}>{label}</span>
         <span className="text-green-500 w-4 shrink-0">#{event.step}</span>
         {event.agent_name && (
           <span className="text-green-300 shrink-0">{event.agent_name}:</span>
         )}
-        <span className="text-green-500 truncate">
-          {event.content ?? event.resolved_event ?? ""}
+        {!event.agent_name && <span className="shrink-0" />}
+        <span className="min-w-0 whitespace-pre-wrap break-words text-green-500">
+          {content}
         </span>
       </div>
       {expanded && event.resolved_event && event.content !== event.resolved_event && (
-        <div className="ml-24 text-green-600 mt-0.5">
+        <div className="ml-24 mt-0.5 whitespace-pre-wrap break-words text-green-600">
           Resolved: {event.resolved_event}
         </div>
       )}
       {expanded && event.metadata && (
-        <div className="ml-24 text-green-800 mt-0.5">
+        <div className="ml-24 mt-0.5 whitespace-pre-wrap break-words text-green-800">
           {JSON.stringify(event.metadata, null, 0).slice(0, 200)}
         </div>
       )}

--- a/web/src/components/simulation/SimulationSetup.tsx
+++ b/web/src/components/simulation/SimulationSetup.tsx
@@ -10,6 +10,7 @@ export interface SimulationSetupConfig {
   maxSteps: number;
   gmModel: string;
   gmProvider: string;
+  engineType: "sequential" | "simultaneous";
   agents: AgentFormData[];
 }
 
@@ -32,8 +33,9 @@ const PRESETS: Record<string, SimulationSetupConfig> = {
     premise:
       "It is morning in the medieval town of Thornfield. The market square is bustling with activity. Three residents begin their day.",
     maxSteps: 20,
-    gmModel: "grok-4.20-beta-0309-reasoning",
+    gmModel: "grok-4-1-fast-non-reasoning",
     gmProvider: "grok",
+    engineType: "simultaneous",
     agents: [
       {
         id: "elena",
@@ -63,8 +65,9 @@ const PRESETS: Record<string, SimulationSetupConfig> = {
     premise:
       "Four traders gather at the commodities exchange. Gold prices have been volatile. Each trader has different information and different risk tolerance.",
     maxSteps: 25,
-    gmModel: "grok-4.20-beta-0309-reasoning",
+    gmModel: "grok-4-1-fast-non-reasoning",
     gmProvider: "grok",
+    engineType: "simultaneous",
     agents: [
       {
         id: "alex",
@@ -101,8 +104,9 @@ const PRESETS: Record<string, SimulationSetupConfig> = {
     premise:
       "Three AI researchers share a lab at a prestigious university. A major conference deadline is in two weeks. They have overlapping research interests but limited compute budget.",
     maxSteps: 20,
-    gmModel: "grok-4.20-beta-0309-reasoning",
+    gmModel: "grok-4-1-fast-non-reasoning",
     gmProvider: "grok",
+    engineType: "simultaneous",
     agents: [
       {
         id: "dr-chen",
@@ -131,11 +135,11 @@ const PRESETS: Record<string, SimulationSetupConfig> = {
 
 // Chat-capable Grok models (source: xAI docs, March 2026)
 const GROK_MODELS = [
-  { id: "grok-4.20-beta-0309-reasoning", label: "Grok 4.20 Reasoning (2M ctx)", default: true },
+  { id: "grok-4-1-fast-non-reasoning", label: "Grok 4.1 Fast Non-Reasoning (2M ctx)", default: true },
+  { id: "grok-4.20-beta-0309-reasoning", label: "Grok 4.20 Reasoning (2M ctx)" },
   { id: "grok-4.20-beta-0309-non-reasoning", label: "Grok 4.20 Non-Reasoning (2M ctx)" },
   { id: "grok-4.20-multi-agent-beta-0309", label: "Grok 4.20 Multi-Agent (2M ctx)" },
   { id: "grok-4-1-fast-reasoning", label: "Grok 4.1 Fast Reasoning (2M ctx)" },
-  { id: "grok-4-1-fast-non-reasoning", label: "Grok 4.1 Fast Non-Reasoning (2M ctx)" },
   { id: "grok-code-fast-1", label: "Grok Code Fast (256K ctx)" },
   { id: "grok-3", label: "Grok 3 (131K ctx)" },
   { id: "grok-3-mini", label: "Grok 3 Mini (131K ctx)" },
@@ -148,8 +152,9 @@ export function SimulationSetup({ onLaunch, loading, bridgeUrl = "http://localho
     worldId: "",
     premise: "",
     maxSteps: 20,
-    gmModel: "grok-4.20-beta-0309-reasoning",
+    gmModel: "grok-4-1-fast-non-reasoning",
     gmProvider: "grok",
+    engineType: "simultaneous",
     agents: [],
   });
   const [agentCount, setAgentCount] = useState(3);
@@ -305,6 +310,10 @@ export function SimulationSetup({ onLaunch, loading, bridgeUrl = "http://localho
                     </option>
                   ))}
                 </select>
+                <div className="mt-1 text-[11px] text-green-700">
+                  Default uses a faster 2M-context model for better turn cadence. Switch to a
+                  reasoning model only if you want slower but more deliberate GM behavior.
+                </div>
               </div>
             </div>
           </div>

--- a/web/src/components/simulation/SimulationViewer.tsx
+++ b/web/src/components/simulation/SimulationViewer.tsx
@@ -42,7 +42,7 @@ export function SimulationViewer({
     bridgeUrl,
     controlUrl,
     agentIds,
-    pollIntervalMs: phase === "running" ? 2000 : 10000,
+    pollIntervalMs: phase === "running" ? 750 : 3000,
   });
 
   const handleLaunch = useCallback(
@@ -68,6 +68,7 @@ export function SimulationViewer({
             max_steps: config.maxSteps,
             gm_model: config.gmModel,
             gm_provider: config.gmProvider,
+            engine_type: config.engineType,
           }),
         });
 
@@ -157,6 +158,10 @@ export function SimulationViewer({
             <span className="text-green-600">
               {launchConfig.agents.length} agents
             </span>
+            <span className="text-green-800">|</span>
+            <span className="text-green-600">
+              Engine: {launchConfig.engineType}
+            </span>
           </>
         )}
         {phase === "finished" && (
@@ -179,7 +184,7 @@ export function SimulationViewer({
       {/* Main content */}
       <div className="flex-1 flex overflow-hidden">
         {/* Left: Agent cards */}
-        <div className="w-72 shrink-0 border-r border-green-800 overflow-y-auto p-2">
+        <div className="w-64 xl:w-72 shrink-0 border-r border-green-800 overflow-y-auto p-2">
           <div className="text-green-600 text-xs mb-2 font-bold tracking-wider">
             AGENTS ({Object.keys(state.agentStates).length})
           </div>

--- a/web/src/components/simulation/WorldStatePanel.tsx
+++ b/web/src/components/simulation/WorldStatePanel.tsx
@@ -61,7 +61,7 @@ export function WorldStatePanel({ agentStates, worldId }: WorldStatePanelProps) 
       {worldFacts.length > 0 && (
         <div className="mt-1">
           {worldFacts.slice(0, 5).map((f, i) => (
-            <div key={i} className="text-green-600 truncate">
+            <div key={i} className="text-green-600 whitespace-pre-wrap break-words">
               [{f.observedBy}] {f.content}
               {f.confirmations > 0 && (
                 <span className="text-green-800">


### PR DESCRIPTION
## Summary
- add an explicit Concordia turn contract in the runtime instead of inferring exact-response behavior from prompt text
- suppress tools for Concordia simulation turns without literalizing the prompt
- route Concordia turns through the fast non-reasoning path
- tighten simulation UI wrapping and expose simultaneous-engine defaults

## Validation
- rebuilt runtime and synced dashboard assets into the live install
- live daemon restart succeeded
- live Concordia `/act` smoke routed on `grok-4-1-fast-non-reasoning` and returned an in-world action