### PR TITLE
fix(runtime): use named BN import to fix ESM/CJS interop in task creation

### DIFF
--- a/runtime/src/tools/agenc/mutation-tools.ts
+++ b/runtime/src/tools/agenc/mutation-tools.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import anchor, { type Program } from '@coral-xyz/anchor';
+import { BN, type Program } from '@coral-xyz/anchor';
 import { PublicKey, SystemProgram } from '@solana/web3.js';
 import {
   getAssociatedTokenAddressSync,
@@ -712,7 +712,7 @@ export function createRegisterSkillTool(
             Array.from(skillId),
             Array.from(name),
             Array.from(contentHash),
-            new anchor.BN(price.toString()),
+            new BN(price.toString()),
             priceMint,
             Array.from(tags),
           )
@@ -812,7 +812,7 @@ export function createPurchaseSkillTool(
         );
 
         const transactionSignature = await (program.methods as any)
-          .purchaseSkill(new anchor.BN(price.toString()))
+          .purchaseSkill(new BN(price.toString()))
           .accountsPartial({
             skill: skillPda,
             purchaseRecord: purchaseRecordPda,

--- a/runtime/src/tools/agenc/tools.ts
+++ b/runtime/src/tools/agenc/tools.ts
@@ -16,7 +16,7 @@
  */
 
 import { PublicKey, SystemProgram } from '@solana/web3.js';
-import anchor, { type Program } from '@coral-xyz/anchor';
+import { BN, type Program } from '@coral-xyz/anchor';
 import { getAssociatedTokenAddressSync } from '@tetsuo-ai/sdk';
 import type { AgencCoordination } from '../../types/agenc_coordination.js';
 import type { Tool, ToolResult } from '../types.js';
@@ -742,10 +742,10 @@ export function createRegisterAgentTool(
         const txSignature = await program.methods
           .registerAgent(
             Array.from(agentId),
-            new anchor.BN(capabilities.toString()),
+            new BN(capabilities.toString()),
             endpoint,
             metadataUri,
-            new anchor.BN(stakeAmount.toString()),
+            new BN(stakeAmount.toString()),
           )
           .accountsPartial({
             agent: agentPda,
@@ -922,11 +922,11 @@ export function createCreateTaskTool(
         const txSignature = await (program.methods as any)
           .createTask(
             toAnchorBytes(taskId),
-            new anchor.BN(requiredCapabilities.toString()),
+            new BN(requiredCapabilities.toString()),
             toAnchorBytes(descBytes),
-            new anchor.BN(reward.toString()),
+            new BN(reward.toString()),
             maxWorkers,
-            new anchor.BN(deadline),
+            new BN(deadline),
             taskType,
             null,
             0,


### PR DESCRIPTION
## Summary

- Replace `anchor.BN` with named `BN` import from `@coral-xyz/anchor` in `tools.ts` and `mutation-tools.ts`
- Drop now-unused `anchor` default import from both files (caught by DTS build)
- Fixes ESM/CJS interop issue where `anchor.BN` is undefined at runtime when the module is loaded as ESM

Closes #141

## Files changed

- `runtime/src/tools/agenc/tools.ts` — 5 call sites (`registerAgent`, `createTask`)
- `runtime/src/tools/agenc/mutation-tools.ts` — 2 call sites (`registerSkill`, `purchaseSkill`)

## Test plan

- [x] `npm run build` passes cleanly (ESM + CJS + DTS)
- [ ] Verify `agenc.createTask` succeeds on devnet without `BN is not a constructor` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)