### PR TITLE
fix(runtime): harden concordia turn isolation

### DIFF
--- a/runtime/src/gateway/channel-message-memory.ts
+++ b/runtime/src/gateway/channel-message-memory.ts
@@ -1,0 +1,65 @@
+import type { LLMMessage } from "../llm/types.js";
+import type { GatewayMessage } from "./message.js";
+
+export function getMessageMetadataString(
+  msg: GatewayMessage,
+  key: string,
+): string | undefined {
+  const value = msg.metadata?.[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function resolveChannelWorkspaceId(
+  msg: GatewayMessage,
+  fallbackWorkspaceId = "default",
+): string {
+  const workspaceId =
+    getMessageMetadataString(msg, "workspace_id") ?? fallbackWorkspaceId;
+  const worldId = getMessageMetadataString(msg, "world_id");
+
+  if (msg.channel === "concordia" && worldId) {
+    return `${workspaceId}::${worldId}`;
+  }
+
+  return workspaceId;
+}
+
+export function shouldPersistToDaemonMemory(msg: GatewayMessage): boolean {
+  return msg.channel !== "concordia";
+}
+
+export function resolveIngestHistoryRole(
+  msg: GatewayMessage,
+): LLMMessage["role"] {
+  const roleCandidate = msg.metadata?.history_role ?? msg.metadata?.role;
+  if (
+    roleCandidate === "system" ||
+    roleCandidate === "assistant" ||
+    roleCandidate === "user"
+  ) {
+    return roleCandidate;
+  }
+  return "user";
+}
+
+export function buildDaemonMemoryEntryOptions(
+  msg: GatewayMessage,
+  workspaceId: string,
+  channelName: string,
+): {
+  readonly workspaceId: string;
+  readonly agentId?: string;
+  readonly worldId?: string;
+  readonly channel: string;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+} {
+  const agentId = getMessageMetadataString(msg, "agent_id");
+  const worldId = getMessageMetadataString(msg, "world_id");
+  return {
+    workspaceId,
+    ...(agentId ? { agentId } : {}),
+    ...(worldId ? { worldId } : {}),
+    channel: channelName,
+    ...(msg.metadata ? { metadata: msg.metadata } : {}),
+  };
+}

--- a/runtime/src/gateway/channel-wiring.test.ts
+++ b/runtime/src/gateway/channel-wiring.test.ts
@@ -193,4 +193,153 @@ describe("wireExternalChannels", () => {
       { sessionId: "fixture:alice", content: "acknowledged" },
     ]);
   });
+
+  it("isolates Concordia history by world metadata and skips daemon memory persistence", async () => {
+    class FixtureChannel implements ChannelPlugin {
+      readonly name = "concordia";
+      context: ChannelContext | null = null;
+      sent: OutboundMessage[] = [];
+
+      async initialize(context: ChannelContext): Promise<void> {
+        this.context = context;
+      }
+
+      async start(): Promise<void> {
+        return;
+      }
+
+      async stop(): Promise<void> {
+        return;
+      }
+
+      async send(message: OutboundMessage): Promise<void> {
+        this.sent.push(message);
+      }
+
+      isHealthy(): boolean {
+        return this.context !== null;
+      }
+
+      async emit(message: GatewayMessage): Promise<void> {
+        await this.context?.onMessage(message);
+      }
+    }
+
+    const channel = new FixtureChannel();
+    const capturedHistories: Array<Array<{ role: string; content: string }>> = [];
+    const execute = vi.fn().mockImplementation(async (input: {
+      history?: Array<{ role: string; content: string }>;
+    }) => {
+      capturedHistories.push(
+        input.history?.map((entry) => ({ ...entry })) ?? [],
+      );
+      return {
+        content: "ack",
+        provider: "grok",
+        model: "grok-4-1-fast-non-reasoning",
+        usedFallback: false,
+        durationMs: 5,
+        compacted: false,
+        tokenUsage: undefined,
+        callUsage: [],
+        statefulSummary: undefined,
+        plannerSummary: undefined,
+        toolRoutingSummary: undefined,
+        stopReason: "completed",
+        stopReasonDetail: undefined,
+        toolCalls: [],
+      };
+    });
+    const addEntry = vi.fn().mockResolvedValue(undefined);
+
+    await wireExternalChannel(
+      channel,
+      "concordia",
+      makeConfig(),
+      { token: "abc" },
+      {
+        gateway: null,
+        logger: silentLogger,
+        chatExecutor: { execute } as never,
+        memoryBackend: { addEntry } as never,
+        defaultForegroundMaxToolRounds: 1,
+        buildChannelHostServices() {
+          return undefined;
+        },
+        async buildSystemPrompt() {
+          return "system prompt";
+        },
+        async handleTextChannelApprovalCommand() {
+          return false;
+        },
+        registerTextApprovalDispatcher() {
+          return () => {};
+        },
+        createTextChannelSessionToolHandler() {
+          return vi.fn() as never;
+        },
+        buildToolRoutingDecision() {
+          return undefined;
+        },
+        recordToolRoutingOutcome() {
+          return;
+        },
+      },
+    );
+
+    await channel.emit({
+      id: "obs-world-1",
+      channel: "concordia",
+      senderId: "alex",
+      senderName: "Alex",
+      sessionId: "concordia:world-1:alex",
+      content: "[Observation] World 1 only",
+      scope: "dm",
+      metadata: {
+        ingest_only: true,
+        history_role: "system",
+        workspace_id: "concordia-sim",
+        world_id: "world-1",
+        agent_id: "alex",
+      },
+    });
+
+    await channel.emit({
+      id: "act-world-1",
+      channel: "concordia",
+      senderId: "alex",
+      senderName: "Alex",
+      sessionId: "concordia:world-1:alex",
+      content: "Take your next action in world 1.",
+      scope: "dm",
+      metadata: {
+        turn_contract: "concordia_simulation_turn",
+        workspace_id: "concordia-sim",
+        world_id: "world-1",
+        agent_id: "alex",
+      },
+    });
+
+    await channel.emit({
+      id: "act-world-2",
+      channel: "concordia",
+      senderId: "alex",
+      senderName: "Alex",
+      sessionId: "concordia:world-2:alex",
+      content: "Take your next action in world 2.",
+      scope: "dm",
+      metadata: {
+        turn_contract: "concordia_simulation_turn",
+        workspace_id: "concordia-sim",
+        world_id: "world-2",
+        agent_id: "alex",
+      },
+    });
+
+    expect(capturedHistories).toEqual([
+      [{ role: "system", content: "[Observation] World 1 only" }],
+      [],
+    ]);
+    expect(addEntry).not.toHaveBeenCalled();
+  });
 });

--- a/runtime/src/gateway/channel-wiring.ts
+++ b/runtime/src/gateway/channel-wiring.ts
@@ -30,6 +30,12 @@ import {
   SessionManager,
   clearStatefulContinuationMetadata,
 } from "./session.js";
+import {
+  buildDaemonMemoryEntryOptions,
+  resolveChannelWorkspaceId,
+  resolveIngestHistoryRole,
+  shouldPersistToDaemonMemory,
+} from "./channel-message-memory.js";
 import type { ChannelPlugin } from "./channel.js";
 import type { Gateway } from "./gateway.js";
 import { TelegramChannel } from "../channels/telegram/plugin.js";
@@ -131,7 +137,6 @@ function isIngestOnlyChannelMessage(msg: GatewayMessage): boolean {
     msg.metadata?.ingestOnly === true
   );
 }
-
 
 async function stopExternalChannelRegistry(
   channels: ExternalChannelRegistry,
@@ -266,7 +271,7 @@ export async function wireTelegram(
       channel: "telegram",
       senderId: msg.senderId,
       scope: msg.scope,
-      workspaceId: "default",
+      workspaceId: resolveChannelWorkspaceId(msg),
     });
     const unregisterTextApproval = deps.registerTextApprovalDispatcher(
       msg.sessionId,
@@ -298,6 +303,7 @@ export async function wireTelegram(
         memoryBackend: deps.memoryBackend,
         includeTraceArtifacts: true,
         includePlannerSummaryInTrace: true,
+        persistToDaemonMemory: true,
         buildToolRoutingDecision: (sessionId, content, history) =>
           deps.buildToolRoutingDecision(sessionId, content, history),
         recordToolRoutingOutcome: (sessionId, summary) => {
@@ -319,24 +325,6 @@ export async function wireTelegram(
         deps.logger.debug("Telegram reply sent successfully");
       } catch (sendErr) {
         deps.logger.error("Telegram send failed:", sendErr);
-      }
-
-      // Persist to memory
-      if (deps.memoryBackend) {
-        try {
-          await deps.memoryBackend.addEntry({
-            sessionId: msg.sessionId,
-            role: "user",
-            content: msg.content,
-          });
-          await deps.memoryBackend.addEntry({
-            sessionId: msg.sessionId,
-            role: "assistant",
-            content: result.content,
-          });
-        } catch {
-          // non-critical
-        }
       }
     } catch (error) {
       const failure = summarizeLLMFailureForSurface(error);
@@ -446,25 +434,27 @@ export async function wireExternalChannel(
       channel: channelName,
       senderId: msg.senderId,
       scope: msg.scope,
-      workspaceId: "default",
+      workspaceId: resolveChannelWorkspaceId(msg),
     });
 
     if (isIngestOnlyChannelMessage(msg)) {
       clearStatefulContinuationMetadata(session.metadata);
       sessionMgr.appendMessage(session.id, {
-        role: "user",
+        role: resolveIngestHistoryRole(msg),
         content: msg.content,
       });
 
-      if (deps.memoryBackend) {
+      if (deps.memoryBackend && shouldPersistToDaemonMemory(msg)) {
         try {
           await deps.memoryBackend.addEntry({
             sessionId: msg.sessionId,
             role: "user",
             content: msg.content,
-            metadata: msg.metadata,
-            workspaceId: session.workspaceId,
-            channel: channelName,
+            ...buildDaemonMemoryEntryOptions(
+              msg,
+              session.workspaceId,
+              channelName,
+            ),
           });
         } catch {
           /* non-critical */
@@ -501,6 +491,7 @@ export async function wireExternalChannel(
         traceConfig,
         turnTraceId,
         memoryBackend: deps.memoryBackend,
+        persistToDaemonMemory: channelName !== "concordia",
         buildToolRoutingDecision: (sessionId, content, history) =>
           deps.buildToolRoutingDecision(sessionId, content, history),
         recordToolRoutingOutcome: (sessionId, summary) => {
@@ -517,23 +508,6 @@ export async function wireExternalChannel(
         content: formatted,
         metadata: msg.metadata,
       });
-
-      if (deps.memoryBackend) {
-        try {
-          await deps.memoryBackend.addEntry({
-            sessionId: msg.sessionId,
-            role: "user",
-            content: msg.content,
-          });
-          await deps.memoryBackend.addEntry({
-            sessionId: msg.sessionId,
-            role: "assistant",
-            content: result.content,
-          });
-        } catch {
-          /* non-critical */
-        }
-      }
     } catch (error) {
       const failure = summarizeLLMFailureForSurface(error);
       if (traceConfig.enabled) {

--- a/runtime/src/gateway/daemon-text-channel-turn.test.ts
+++ b/runtime/src/gateway/daemon-text-channel-turn.test.ts
@@ -170,16 +170,26 @@ describe("executeTextChannelTurn", () => {
       role: "assistant",
       content: "reply",
     });
-    expect(memoryBackend.addEntry).toHaveBeenNthCalledWith(1, {
-      sessionId: "session:test",
-      role: "user",
-      content: "hello",
-    });
-    expect(memoryBackend.addEntry).toHaveBeenNthCalledWith(2, {
-      sessionId: "session:test",
-      role: "assistant",
-      content: "reply",
-    });
+    expect(memoryBackend.addEntry).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        sessionId: "session:test",
+        role: "user",
+        content: "hello",
+        channel: "telegram",
+        workspaceId: "default",
+      }),
+    );
+    expect(memoryBackend.addEntry).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        sessionId: "session:test",
+        role: "assistant",
+        content: "reply",
+        channel: "telegram",
+        workspaceId: "default",
+      }),
+    );
     expect(
       session.metadata[SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY],
     ).toEqual({

--- a/runtime/src/gateway/daemon-text-channel-turn.ts
+++ b/runtime/src/gateway/daemon-text-channel-turn.ts
@@ -15,6 +15,10 @@ import type { Session, SessionManager } from "./session.js";
 import type { ToolRoutingDecision } from "./tool-routing.js";
 import { resolveTurnMaxToolRounds } from "./tool-round-budget.js";
 import {
+  buildDaemonMemoryEntryOptions,
+  shouldPersistToDaemonMemory,
+} from "./channel-message-memory.js";
+import {
   buildSessionStatefulOptions,
   persistSessionStatefulContinuation,
 } from "./daemon-session-state.js";
@@ -60,6 +64,7 @@ export interface ExecuteTextChannelTurnParams {
     sessionId: string,
     summary: ChatToolRoutingSummary | undefined,
   ) => void;
+  readonly persistToDaemonMemory?: boolean;
 }
 
 export async function executeTextChannelTurn(
@@ -82,6 +87,7 @@ export async function executeTextChannelTurn(
     includePlannerSummaryInTrace = false,
     buildToolRoutingDecision,
     recordToolRoutingOutcome,
+    persistToDaemonMemory = shouldPersistToDaemonMemory(msg),
   } = params;
 
   const toolRoutingDecision = buildToolRoutingDecision(
@@ -321,17 +327,24 @@ export async function executeTextChannelTurn(
     content: result.content,
   });
 
-  if (memoryBackend) {
+  if (memoryBackend && persistToDaemonMemory) {
+    const persistenceOptions = buildDaemonMemoryEntryOptions(
+      msg,
+      session.workspaceId,
+      channelName,
+    );
     try {
       await memoryBackend.addEntry({
         sessionId: msg.sessionId,
         role: "user",
         content: msg.content,
+        ...persistenceOptions,
       });
       await memoryBackend.addEntry({
         sessionId: msg.sessionId,
         role: "assistant",
         content: result.content,
+        ...persistenceOptions,
       });
     } catch {
       // Non-critical memory persistence failures should not fail the chat turn.

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -7938,7 +7938,7 @@ describe("ChatExecutor", () => {
       expect(systemMessages[2].content).toContain("Recent Progress");
     });
 
-    it("does not inject persistent memory providers on a fresh session", async () => {
+    it("still injects cross-session semantic memory but skips session-scoped providers on a fresh session", async () => {
       const memoryRetriever = { retrieve: vi.fn().mockResolvedValue("Memory") };
       const learningProvider = { retrieve: vi.fn().mockResolvedValue("Learning") };
       const progressProvider = { retrieve: vi.fn().mockResolvedValue("Progress") };
@@ -7952,7 +7952,7 @@ describe("ChatExecutor", () => {
 
       await executor.execute(createParams({ history: [] }));
 
-      expect(memoryRetriever.retrieve).not.toHaveBeenCalled();
+      expect(memoryRetriever.retrieve).toHaveBeenCalledWith("hello", "session-1");
       expect(learningProvider.retrieve).not.toHaveBeenCalled();
       expect(progressProvider.retrieve).not.toHaveBeenCalled();
     });

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -2434,8 +2434,12 @@ export class ChatExecutor {
     // Build messages array with explicit section tags for prompt budgeting.
     this.pushMessage(ctx, { role: "system", content: ctx.systemPrompt }, "system_anchor");
 
-    const enableSkillContext = params.contextInjection?.skills !== false;
-    const enableMemoryContext = params.contextInjection?.memory !== false;
+    const isConcordiaTurn = isConcordiaSimulationTurnMessage(ctx.message);
+    const enableSkillContext =
+      params.contextInjection?.skills !== false && !isConcordiaTurn;
+    const enableIdentityContext = !isConcordiaTurn;
+    const enableMemoryContext =
+      params.contextInjection?.memory !== false && !isConcordiaTurn;
 
     // Context injection — skill, identity, memory, and learning (all best-effort)
     if (enableSkillContext) {
@@ -2452,7 +2456,7 @@ export class ChatExecutor {
     // Phase 5.4: inject agent identity (personality, beliefs, traits) after skills
     // but before memory/learning so the agent's persona frames retrieved context.
     // Identity is always injected (not gated on hasHistory) since it defines who the agent is.
-    if (this.identityProvider) {
+    if (enableIdentityContext && this.identityProvider) {
       await this.injectContext(
         ctx,
         this.identityProvider,

--- a/runtime/src/plugins/channel-host-services.test.ts
+++ b/runtime/src/plugins/channel-host-services.test.ts
@@ -87,6 +87,7 @@ describe("createChannelHostServices", () => {
     expect(world?.socialMemory).toBeDefined();
     expect(world?.graph).toBeDefined();
     expect(world?.sharedMemory).toBeDefined();
+    expect(world?.lifecycle).toBeDefined();
   });
 
   it("caches the same world context and isolates different worlds", async () => {

--- a/runtime/src/plugins/channel-host-services.ts
+++ b/runtime/src/plugins/channel-host-services.ts
@@ -16,6 +16,9 @@ import { CuratedMemoryManager, DailyLogManager } from "../memory/structured.js";
 import { SqliteVectorBackend } from "../memory/sqlite/vector-backend.js";
 import { MemoryTraceLogger } from "../memory/trace-logger.js";
 import { resolveWorldVectorDbPath } from "../memory/world-db-resolver.js";
+import { runReflection } from "../memory/reflection.js";
+import { runConsolidation, runRetention } from "../memory/consolidation.js";
+import { createSingleLLMProvider } from "../gateway/llm-provider-manager.js";
 import type { MemoryBackend } from "../memory/types.js";
 import type { Logger } from "../utils/logger.js";
 
@@ -64,6 +67,26 @@ export interface ConcordiaWorldMemoryHostServices {
     ): string;
   };
   readonly graph: {
+    upsertNode(input: {
+      content: string;
+      sessionId?: string;
+      tags?: string[];
+      entityName?: string;
+      entityType?: string;
+      workspaceId?: string;
+      metadata?: Record<string, unknown>;
+      provenance: Array<{
+        type: string;
+        sourceId: string;
+        description?: string;
+        metadata?: Record<string, unknown>;
+      }>;
+    }): Promise<{
+      id: string;
+      content: string;
+      entityName?: string;
+      entityType?: string;
+    }>;
     findByEntity(
       name: string,
       workspaceId?: string,
@@ -130,6 +153,25 @@ export interface ConcordiaWorldMemoryHostServices {
       message: string,
       sessionId: string,
     ): Promise<ConcordiaRetrieverResult>;
+  };
+  readonly lifecycle?: {
+    reflectAgent(input: {
+      agentId: string;
+      sessionId: string;
+      workspaceId?: string;
+    }): Promise<boolean>;
+    consolidate(input?: {
+      workspaceId?: string;
+    }): Promise<{
+      processed: number;
+      consolidated: number;
+      skippedDuplicates: number;
+      durationMs: number;
+    } | null>;
+    retain(): Promise<{
+      expiredDeleted: number;
+      logsDeleted: number;
+    }>;
   };
   readonly vectorDbPath?: string;
 }
@@ -275,6 +317,13 @@ async function createConcordiaWorldContext(params: {
     baseUrl: params.config.memory?.embeddingBaseUrl,
     model: params.config.memory?.embeddingModel,
   });
+  const reflectionProviderPromise = params.config.llm
+    ? createSingleLLMProvider(params.config.llm, [], params.logger)
+    : Promise.resolve(null);
+  const vectorStore = new SqliteVectorBackend({
+    dbPath: vectorDbPath,
+    dimension: embeddingProvider.dimension,
+  });
 
   let ingestionEngine:
     | ConcordiaWorldMemoryHostServices["ingestionEngine"]
@@ -282,10 +331,6 @@ async function createConcordiaWorldContext(params: {
   let retriever: ConcordiaWorldMemoryHostServices["retriever"] | undefined;
 
   if (embeddingProvider.name !== "noop") {
-    const vectorStore = new SqliteVectorBackend({
-      dbPath: vectorDbPath,
-      dimension: embeddingProvider.dimension,
-    });
     const semanticRetriever = new SemanticMemoryRetriever({
       vectorBackend: vectorStore,
       embeddingProvider,
@@ -336,6 +381,47 @@ async function createConcordiaWorldContext(params: {
     };
   }
 
+  const lifecycle: ConcordiaWorldMemoryHostServices["lifecycle"] = {
+    async reflectAgent(input) {
+      const llmProvider = await reflectionProviderPromise;
+      if (!llmProvider) {
+        return false;
+      }
+      const recentHistory = await worldBackend.getThread(input.sessionId, 20);
+      const result = await runReflection({
+        llmProvider,
+        identityManager,
+        agentId: input.agentId,
+        workspaceId: input.workspaceId ?? params.workspaceId,
+        recentHistory: recentHistory.map((entry) => ({
+          role: entry.role,
+          content: entry.content,
+        })),
+        logger: params.logger,
+      });
+      return result !== null;
+    },
+    consolidate(input) {
+      return runConsolidation(
+        {
+          memoryBackend: worldBackend,
+          vectorStore,
+          embeddingProvider,
+          graph,
+          logger: params.logger,
+        },
+        input?.workspaceId ?? params.workspaceId,
+      );
+    },
+    retain() {
+      return runRetention({
+        memoryBackend: worldBackend,
+        logManager: runtimeDailyLogManager,
+        logger: params.logger,
+      });
+    },
+  };
+
   return {
     memoryBackend: worldBackend,
     identityManager,
@@ -372,6 +458,7 @@ async function createConcordiaWorldContext(params: {
     },
     ingestionEngine,
     retriever,
+    lifecycle,
     vectorDbPath,
   };
 }
@@ -430,6 +517,29 @@ function createGraphAdapter(
   graph: MemoryGraph,
 ): ConcordiaWorldMemoryHostServices["graph"] {
   return {
+    async upsertNode(input) {
+      const node = await graph.upsertNode({
+        content: input.content,
+        sessionId: input.sessionId,
+        tags: input.tags,
+        entityName: input.entityName,
+        entityType: input.entityType,
+        workspaceId: input.workspaceId,
+        metadata: input.metadata,
+        provenance: input.provenance.map((source) => ({
+          type: source.type as Parameters<MemoryGraph["upsertNode"]>[0]["provenance"][number]["type"],
+          sourceId: source.sourceId,
+          description: source.description,
+          metadata: source.metadata,
+        })),
+      });
+      return {
+        id: node.id,
+        content: node.content,
+        entityName: node.entityName,
+        entityType: node.entityType,
+      };
+    },
     async findByEntity(name, workspaceId) {
       const result = await graph.findByEntity(name, workspaceId);
       return result.nodes.map((node) => ({


### PR DESCRIPTION
## Summary
- isolate Concordia session/history state by world metadata in the gateway session layer
- keep Concordia observations in system history while skipping daemon-global memory persistence
- expose world-scoped Concordia host services needed by the bridge and align targeted runtime tests

## Validation
- npm run typecheck
- npm test -- --run src/gateway/channel-wiring.test.ts src/gateway/daemon-text-channel-turn.test.ts src/plugins/channel-host-services.test.ts src/llm/chat-executor.test.ts
- npm run build