### PR TITLE
ground runtime todo recreation in workspace evidence

### DIFF
--- a/runtime/src/llm/chat-executor-planner.test.ts
+++ b/runtime/src/llm/chat-executor-planner.test.ts
@@ -720,6 +720,47 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
     expect(hint).toContain("rerun `npm install`");
   });
 
+  it("adds grounded runtime todo repair guidance when the todo artifact is missing", () => {
+    const hint = buildPipelineFailureRepairRefinementHint({
+      pipelineResult: {
+        status: "failed",
+        completedSteps: 1,
+        totalSteps: 3,
+        error: "File not found: /tmp/project/todo",
+        stopReasonHint: "tool_error",
+      },
+      plannerPlan: {
+        reason: "repair",
+        requiresSynthesis: true,
+        steps: [
+          {
+            name: "read_runtime_todo",
+            stepType: "deterministic_tool",
+            tool: "system.readFile",
+            args: {
+              path: "/tmp/project/todo",
+            },
+          },
+        ],
+      },
+      plannerToolCalls: [
+        {
+          name: "system.readFile",
+          args: {
+            path: "/tmp/project/todo",
+          },
+          result: '{"error":"File not found: /tmp/project/todo"}',
+          isError: true,
+          durationMs: 0,
+        },
+      ],
+    });
+
+    expect(hint).toContain("runtime-owned `/todo` artifact is missing");
+    expect(hint).toContain("directory listing alone");
+    expect(hint).toContain("non-target implementation, project, or config file");
+  });
+
   it("adds explicit browser split guidance for implementation-browser decomposition", () => {
     const hint = buildPlannerStructuralRefinementHint([
       {
@@ -2169,6 +2210,132 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
         }),
       ]),
     );
+  });
+
+  it("rejects workspace-grounded artifact rewrites when the planner only lists directories before rewriting the target doc", () => {
+    const workspaceRoot = "/tmp/agenc-shell";
+    const diagnostics = validatePlannerStepContracts(
+      {
+        reason: "review_and_update_plan",
+        requiresSynthesis: false,
+        confidence: 0.8,
+        steps: [
+          {
+            name: "list_src",
+            stepType: "deterministic_tool",
+            dependsOn: [],
+            tool: "system.listDir",
+            args: {
+              path: `${workspaceRoot}/src`,
+            },
+          },
+          {
+            name: "read_plan",
+            stepType: "deterministic_tool",
+            dependsOn: ["list_src"],
+            tool: "system.readFile",
+            args: {
+              path: `${workspaceRoot}/PLAN.md`,
+            },
+          },
+          {
+            name: "rewrite_plan",
+            stepType: "deterministic_tool",
+            dependsOn: ["read_plan"],
+            tool: "system.writeFile",
+            args: {
+              path: `${workspaceRoot}/PLAN.md`,
+              content: "updated plan",
+            },
+          },
+        ],
+      },
+      "Review the codebase layout against Phase1 in PLAN.md and update PLAN.md so it reflects the current workspace state.",
+    );
+
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "planner_plan_artifact_missing_workspace_grounding",
+        }),
+      ]),
+    );
+  });
+
+  it("rejects runtime-owned todo repairs that only list directories before recreating the artifact", () => {
+    const workspaceRoot = "/tmp/agenc-shell";
+    const diagnostics = validatePlannerStepContracts(
+      {
+        reason: "repair_missing_runtime_todo",
+        requiresSynthesis: false,
+        confidence: 0.74,
+        steps: [
+          {
+            name: "inspect_workspace",
+            stepType: "deterministic_tool",
+            dependsOn: [],
+            tool: "system.listDir",
+            args: {
+              path: workspaceRoot,
+            },
+          },
+          {
+            name: "rewrite_runtime_todo",
+            stepType: "deterministic_tool",
+            dependsOn: ["inspect_workspace"],
+            tool: "system.writeFile",
+            args: {
+              path: `${workspaceRoot}/todo`,
+              content: "continue work",
+            },
+          },
+        ],
+      },
+      "Inspect the current workspace state, compare it to the implementation, and continue the remaining app work.",
+    );
+
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "planner_plan_artifact_missing_workspace_grounding",
+        }),
+      ]),
+    );
+  });
+
+  it("allows runtime-owned todo repairs when the planner reads a non-target workspace file before recreating the artifact", () => {
+    const workspaceRoot = "/tmp/agenc-shell";
+    const diagnostics = validatePlannerStepContracts(
+      {
+        reason: "repair_missing_runtime_todo",
+        requiresSynthesis: false,
+        confidence: 0.78,
+        steps: [
+          {
+            name: "inspect_source_file",
+            stepType: "deterministic_tool",
+            dependsOn: [],
+            tool: "system.readFile",
+            args: {
+              path: `${workspaceRoot}/src/ContentView.swift`,
+            },
+          },
+          {
+            name: "rewrite_runtime_todo",
+            stepType: "deterministic_tool",
+            dependsOn: ["inspect_source_file"],
+            tool: "system.writeFile",
+            args: {
+              path: `${workspaceRoot}/todo`,
+              content: "continue work",
+            },
+          },
+        ],
+      },
+      "Inspect the current workspace state, compare it to the implementation, and continue the remaining app work.",
+    );
+
+    expect(diagnostics).toEqual([]);
   });
 
   it("rejects plan-artifact execution requests that emit multiple mutable delegated owners for one workspace root", () => {

--- a/runtime/src/llm/chat-executor-planner.test.ts
+++ b/runtime/src/llm/chat-executor-planner.test.ts
@@ -2212,7 +2212,7 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
     );
   });
 
-  it("rejects workspace-grounded artifact rewrites when the planner only lists directories before rewriting the target doc", () => {
+  it("allows generic workspace-grounded artifact rewrites when the planner lists directories before rewriting the target doc", () => {
     const workspaceRoot = "/tmp/agenc-shell";
     const diagnostics = validatePlannerStepContracts(
       {
@@ -2253,13 +2253,7 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
       "Review the codebase layout against Phase1 in PLAN.md and update PLAN.md so it reflects the current workspace state.",
     );
 
-    expect(diagnostics).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          code: "planner_plan_artifact_missing_workspace_grounding",
-        }),
-      ]),
-    );
+    expect(diagnostics).toEqual([]);
   });
 
   it("rejects runtime-owned todo repairs that only list directories before recreating the artifact", () => {

--- a/runtime/src/llm/chat-executor-planner.ts
+++ b/runtime/src/llm/chat-executor-planner.ts
@@ -4103,12 +4103,23 @@ export function validatePlannerStepContracts(
   if (typeof messageText === "string") {
     diagnostics.push(...validatePlannerArtifactAuthority(plannerPlan, messageText));
     const artifactIntent = classifyPlannerPlanArtifactIntent(messageText);
+    const runtimeTodoArtifactRepairValidation =
+      artifactIntent === "none" &&
+      plannerPlanNeedsRuntimeTodoArtifactRepairValidation(
+        plannerPlan,
+        messageText,
+      );
     if (
       artifactIntent === "grounded_plan_generation" ||
-      artifactIntent === "edit_artifact"
+      artifactIntent === "edit_artifact" ||
+      runtimeTodoArtifactRepairValidation
     ) {
       diagnostics.push(
-        ...validatePlannerPlanArtifactSteps(plannerPlan, messageText),
+        ...validatePlannerPlanArtifactSteps(plannerPlan, messageText, {
+          requestedArtifactTargetsOverride: runtimeTodoArtifactRepairValidation
+            ? collectPlannerRuntimeTodoArtifactTargets(plannerPlan)
+            : undefined,
+        }),
       );
     }
     if (artifactIntent === "implement_from_artifact") {
@@ -4495,6 +4506,14 @@ function normalizePlannerArtifactIdentity(target: string): string {
   return pathBasename(normalized);
 }
 
+function isPlannerRuntimeTodoArtifactPath(value: string): boolean {
+  const normalized = normalizePlannerArtifactTarget(value);
+  if (normalized.length === 0) {
+    return false;
+  }
+  return /^todo(?:\.[a-z0-9._-]+)?$/i.test(pathBasename(normalized));
+}
+
 function plannerStepTextRequiresWorkspaceGrounding(value: string): boolean {
   return textRequiresWorkspaceGroundedArtifactUpdate(value);
 }
@@ -4677,6 +4696,10 @@ function isPlannerArtifactMaterializationStep(
 
 function plannerSubagentHasWorkspaceGrounding(
   step: PlannerSubAgentTaskStepIntent,
+  requestedArtifactTargets: readonly string[],
+  options?: {
+    readonly allowBoundedWriteStep?: boolean;
+  },
 ): boolean {
   const executionContext = step.executionContext;
   const stepText = [
@@ -4694,13 +4717,61 @@ function plannerSubagentHasWorkspaceGrounding(
     ...(executionContext?.allowedTools ?? []),
     ...safeStepStringArray(step.requiredToolCapabilities),
   ].map((value) => value.trim().toLowerCase());
-  return scopedTools.some((toolName) =>
-    toolName.includes("read") ||
-    toolName.includes("listdir") ||
-    toolName.includes("stat") ||
-    toolName.includes("bash") ||
-    toolName.includes("text_editor")
+  const hasReadCapability = scopedTools.some((toolName) =>
+    toolName.includes("read") || toolName.includes("text_editor")
   );
+  if (!hasReadCapability) {
+    return false;
+  }
+
+  const artifactRelations = canonicalizeWorkflowArtifactRelations({
+    workspaceRoot: executionContext?.workspaceRoot,
+    artifactRelations: executionContext?.artifactRelations,
+    inputArtifacts: executionContext?.inputArtifacts,
+    requiredSourceArtifacts: executionContext?.requiredSourceArtifacts,
+    targetArtifacts: executionContext?.targetArtifacts,
+    stepKind: executionContext?.stepKind,
+    verificationMode: executionContext?.verificationMode,
+    role: canonicalizeWorkflowStepRole({
+      role: executionContext?.role,
+      stepKind: executionContext?.stepKind,
+      effectClass: executionContext?.effectClass,
+      verificationMode: executionContext?.verificationMode,
+    }),
+  });
+  const nonTargetSourceArtifacts = [
+    ...safeStepStringArray(executionContext?.requiredSourceArtifacts),
+    ...safeStepStringArray(executionContext?.inputArtifacts),
+    ...artifactRelations
+      .filter((relation) =>
+        relation.relationType === "read_dependency" ||
+        relation.relationType === "context_input"
+      )
+      .map((relation) => relation.artifactPath),
+  ].filter((artifactPath) =>
+    !plannerPathTargetsRequestedArtifact(artifactPath, requestedArtifactTargets)
+  );
+  const hasExplicitNonTargetSourceArtifacts =
+    nonTargetSourceArtifacts.length > 0;
+  const workspaceRoot = normalizeWorkspaceRoot(executionContext?.workspaceRoot);
+  const hasWorkspaceRoot =
+    typeof workspaceRoot === "string" && workspaceRoot.length > 0;
+  const isGroundedReadReviewStep =
+    hasWorkspaceRoot &&
+    executionContext?.effectClass === "read_only" &&
+    executionContext?.verificationMode === "grounded_read" &&
+    (executionContext?.stepKind === "delegated_review" ||
+      executionContext?.stepKind === "delegated_research");
+  if (isGroundedReadReviewStep) {
+    return true;
+  }
+  if (!hasExplicitNonTargetSourceArtifacts) {
+    return false;
+  }
+  if (!plannerStepHasMutableImplementationAuthority(step)) {
+    return true;
+  }
+  return options?.allowBoundedWriteStep === true;
 }
 
 function isPlannerWorkspaceGroundingStep(
@@ -4708,13 +4779,10 @@ function isPlannerWorkspaceGroundingStep(
   requestedArtifactTargets: readonly string[],
 ): boolean {
   if (step.stepType === "subagent_task") {
-    return plannerSubagentHasWorkspaceGrounding(step);
+    return plannerSubagentHasWorkspaceGrounding(step, requestedArtifactTargets);
   }
   if (step.stepType !== "deterministic_tool") {
     return false;
-  }
-  if (step.tool === "system.listDir" || step.tool === "system.stat") {
-    return true;
   }
   if (step.tool === "system.readFile") {
     return !plannerPathTargetsRequestedArtifact(
@@ -4726,7 +4794,7 @@ function isPlannerWorkspaceGroundingStep(
     return false;
   }
   const commandText = extractCommandText(step.args).trim();
-  return /\b(?:ls|find|tree|rg|ripgrep|git\s+(?:status|diff|ls-files)|stat)\b/i.test(
+  return /\b(?:cat|sed|head|tail|grep|rg|ripgrep)\b/i.test(
     commandText,
   );
 }
@@ -4966,16 +5034,48 @@ function collectPlannerWritableArtifactTargets(
   return [...targets];
 }
 
+function collectPlannerRuntimeTodoArtifactTargets(
+  plannerPlan: PlannerPlan,
+): readonly string[] {
+  return collectPlannerWritableArtifactTargets(plannerPlan).filter(
+    isPlannerRuntimeTodoArtifactPath,
+  );
+}
+
+function plannerPlanNeedsRuntimeTodoArtifactRepairValidation(
+  plannerPlan: PlannerPlan,
+  messageText: string,
+): boolean {
+  if (!textRequiresWorkspaceGroundedArtifactUpdate(messageText)) {
+    return false;
+  }
+  const writableTargets = collectPlannerWritableArtifactTargets(plannerPlan);
+  if (writableTargets.length === 0) {
+    return false;
+  }
+  return writableTargets.every(isPlannerRuntimeTodoArtifactPath);
+}
 function validatePlannerPlanArtifactSteps(
   plannerPlan: PlannerPlan,
   messageText?: string,
+  options?: {
+    readonly requestedArtifactTargetsOverride?: readonly string[];
+  },
 ): readonly PlannerDiagnostic[] {
   const diagnostics: PlannerDiagnostic[] = [];
+  const usesRequestedArtifactTargetsOverride =
+    (options?.requestedArtifactTargetsOverride?.length ?? 0) > 0;
   const workspaceGroundedArtifactUpdate =
     typeof messageText === "string" &&
-    plannerRequestNeedsWorkspaceGroundedArtifactUpdate(messageText);
+    (
+      plannerRequestNeedsWorkspaceGroundedArtifactUpdate(messageText) ||
+      (usesRequestedArtifactTargetsOverride &&
+        textRequiresWorkspaceGroundedArtifactUpdate(messageText))
+    );
   const requestedArtifactTargets =
-    typeof messageText === "string"
+    usesRequestedArtifactTargetsOverride
+      ? (options?.requestedArtifactTargetsOverride ?? [])
+      : typeof messageText === "string"
       ? extractPlannerArtifactTargets(messageText)
       : [];
   const materializationSteps = plannerPlan.steps.filter((step) =>
@@ -5048,7 +5148,11 @@ function validatePlannerPlanArtifactSteps(
     );
     const finalWriteCarriesWorkspaceGrounding =
       finalWriteStep.stepType === "subagent_task" &&
-      plannerSubagentHasWorkspaceGrounding(finalWriteStep);
+      plannerSubagentHasWorkspaceGrounding(
+        finalWriteStep,
+        requestedArtifactTargets,
+        { allowBoundedWriteStep: true },
+      );
     if (
       !hasWorkspaceGroundingBeforeWrite &&
       !finalWriteCarriesWorkspaceGrounding
@@ -5873,6 +5977,23 @@ function buildFailureSpecificRepairHint(
   const normalized = error.toLowerCase();
   const failingCwd = extractPlannerToolCwd(failedPlannerCall?.args ?? {});
   const missingScriptName = extractMissingNpmScriptNameFromError(error);
+  const failedPath =
+    typeof failedPlannerCall?.args.path === "string"
+      ? failedPlannerCall.args.path.trim()
+      : undefined;
+  if (
+    failedPlannerCall?.name === "system.readFile" &&
+    failedPath &&
+    isPlannerRuntimeTodoArtifactPath(failedPath) &&
+    (normalized.includes("file not found") ||
+      normalized.includes("no such file") ||
+      normalized.includes("enoent"))
+  ) {
+    return (
+      "If the runtime-owned `/todo` artifact is missing, do not recreate it from directory listing alone. " +
+      "First inspect at least one non-target implementation, project, or config file with `system.readFile` or a content-reading shell command, then regenerate `/todo` from that concrete workspace evidence."
+    );
+  }
   if (missingScriptName) {
     return (
       `The current package.json${failingCwd ? ` at \`${failingCwd}\`` : ""} does not define the npm script \`${missingScriptName}\`. ` +

--- a/runtime/src/llm/chat-executor-planner.ts
+++ b/runtime/src/llm/chat-executor-planner.ts
@@ -4699,6 +4699,7 @@ function plannerSubagentHasWorkspaceGrounding(
   requestedArtifactTargets: readonly string[],
   options?: {
     readonly allowBoundedWriteStep?: boolean;
+    readonly enforceNonTargetWorkspaceEvidence?: boolean;
   },
 ): boolean {
   const executionContext = step.executionContext;
@@ -4717,6 +4718,15 @@ function plannerSubagentHasWorkspaceGrounding(
     ...(executionContext?.allowedTools ?? []),
     ...safeStepStringArray(step.requiredToolCapabilities),
   ].map((value) => value.trim().toLowerCase());
+  if (options?.enforceNonTargetWorkspaceEvidence !== true) {
+    return scopedTools.some((toolName) =>
+      toolName.includes("read") ||
+      toolName.includes("listdir") ||
+      toolName.includes("stat") ||
+      toolName.includes("bash") ||
+      toolName.includes("text_editor")
+    );
+  }
   const hasReadCapability = scopedTools.some((toolName) =>
     toolName.includes("read") || toolName.includes("text_editor")
   );
@@ -4777,12 +4787,37 @@ function plannerSubagentHasWorkspaceGrounding(
 function isPlannerWorkspaceGroundingStep(
   step: PlannerStepIntent,
   requestedArtifactTargets: readonly string[],
+  options?: {
+    readonly enforceNonTargetWorkspaceEvidence?: boolean;
+  },
 ): boolean {
   if (step.stepType === "subagent_task") {
-    return plannerSubagentHasWorkspaceGrounding(step, requestedArtifactTargets);
+    return plannerSubagentHasWorkspaceGrounding(
+      step,
+      requestedArtifactTargets,
+      options,
+    );
   }
   if (step.stepType !== "deterministic_tool") {
     return false;
+  }
+  if (options?.enforceNonTargetWorkspaceEvidence !== true) {
+    if (step.tool === "system.listDir" || step.tool === "system.stat") {
+      return true;
+    }
+    if (step.tool === "system.readFile") {
+      return !plannerPathTargetsRequestedArtifact(
+        typeof step.args.path === "string" ? step.args.path : undefined,
+        requestedArtifactTargets,
+      );
+    }
+    if (!PLANNER_BASH_TOOL_NAMES.has(step.tool)) {
+      return false;
+    }
+    const commandText = extractCommandText(step.args).trim();
+    return /\b(?:ls|find|tree|rg|ripgrep|git\s+(?:status|diff|ls-files)|stat)\b/i.test(
+      commandText,
+    );
   }
   if (step.tool === "system.readFile") {
     return !plannerPathTargetsRequestedArtifact(
@@ -5065,6 +5100,7 @@ function validatePlannerPlanArtifactSteps(
   const diagnostics: PlannerDiagnostic[] = [];
   const usesRequestedArtifactTargetsOverride =
     (options?.requestedArtifactTargetsOverride?.length ?? 0) > 0;
+  const strictWorkspaceGrounding = usesRequestedArtifactTargetsOverride;
   const workspaceGroundedArtifactUpdate =
     typeof messageText === "string" &&
     (
@@ -5144,7 +5180,9 @@ function validatePlannerPlanArtifactSteps(
     const hasWorkspaceGroundingBeforeWrite = plannerPlan.steps.some(
       (step, index) =>
         index < lastWriteIndex &&
-        isPlannerWorkspaceGroundingStep(step, requestedArtifactTargets),
+        isPlannerWorkspaceGroundingStep(step, requestedArtifactTargets, {
+          enforceNonTargetWorkspaceEvidence: strictWorkspaceGrounding,
+        }),
     );
     const finalWriteCarriesWorkspaceGrounding =
       finalWriteStep.stepType === "subagent_task" &&
@@ -5153,9 +5191,23 @@ function validatePlannerPlanArtifactSteps(
         requestedArtifactTargets,
         { allowBoundedWriteStep: true },
       );
+    const finalWriteCarriesStrictWorkspaceGrounding =
+      finalWriteStep.stepType === "subagent_task" &&
+      plannerSubagentHasWorkspaceGrounding(
+        finalWriteStep,
+        requestedArtifactTargets,
+        {
+          allowBoundedWriteStep: true,
+          enforceNonTargetWorkspaceEvidence: strictWorkspaceGrounding,
+        },
+      );
     if (
       !hasWorkspaceGroundingBeforeWrite &&
-      !finalWriteCarriesWorkspaceGrounding
+      !(
+        strictWorkspaceGrounding
+          ? finalWriteCarriesStrictWorkspaceGrounding
+          : finalWriteCarriesWorkspaceGrounding
+      )
     ) {
       diagnostics.push(
         createPlannerDiagnostic(

--- a/runtime/src/workflow/execution-kernel-policy.ts
+++ b/runtime/src/workflow/execution-kernel-policy.ts
@@ -72,19 +72,7 @@ function subagentStepAllowsDelegationFallback(
   ) {
     return false;
   }
-  return !step.requiredToolCapabilities.some((capability) => {
-    const normalized = capability.trim().toLowerCase();
-    return (
-      normalized.includes("write") ||
-      normalized.includes("append") ||
-      normalized.includes("delete") ||
-      normalized.includes("move") ||
-      normalized.includes("mkdir") ||
-      normalized.includes("rename") ||
-      normalized.includes("bash") ||
-      normalized.includes("shell")
-    );
-  });
+  return true;
 }
 
 function assessSubagentDependencySatisfaction(

--- a/runtime/src/workflow/execution-kernel.test.ts
+++ b/runtime/src/workflow/execution-kernel.test.ts
@@ -73,6 +73,15 @@ describe("CanonicalExecutionKernel", () => {
             acceptanceCriteria: ["core builds"],
             requiredToolCapabilities: ["system.writeFile"],
             contextRequirements: ["cwd=/workspace"],
+            executionContext: {
+              version: "v1",
+              workspaceRoot: "/workspace",
+              targetArtifacts: ["/workspace/src/core.ts"],
+              effectClass: "filesystem_write",
+              verificationMode: "mutation_required",
+              stepKind: "delegated_write",
+              fallbackPolicy: "continue_without_delegation",
+            },
             maxBudgetHint: "2m",
             canRunParallel: true,
           },
@@ -99,8 +108,12 @@ describe("CanonicalExecutionKernel", () => {
     );
 
     expect(result.status).toBe("failed");
-    expect(result.context.results.implement_core).toContain("delegation_fallback");
-    expect(result.context.results.implement_cli).toContain("dependency_blocked");
+    expect(result.context.results.implement_core).toContain(
+      "delegation_fallback",
+    );
+    expect(result.context.results.implement_cli).toContain(
+      "dependency_blocked",
+    );
     expect(events).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -118,28 +131,30 @@ describe("CanonicalExecutionKernel", () => {
     const kernel = new CanonicalExecutionKernel({
       deterministicExecutor,
       plannerDelegate: {
-        executeNode: vi.fn(async (step): Promise<ExecutionKernelNodeOutcome> => {
-          if (step.name === "review_plan") {
-            return {
-              status: "failed",
-              error: "provider timeout",
-              stopReasonHint: "timeout",
-              fallback: {
-                satisfied: true,
-                reason: "Recovered via parent fallback",
+        executeNode: vi.fn(
+          async (step): Promise<ExecutionKernelNodeOutcome> => {
+            if (step.name === "review_plan") {
+              return {
+                status: "failed",
+                error: "provider timeout",
                 stopReasonHint: "timeout",
-                result: JSON.stringify({
-                  status: "delegation_fallback",
-                  recoveredViaParentFallback: true,
-                }),
-              },
+                fallback: {
+                  satisfied: true,
+                  reason: "Recovered via parent fallback",
+                  stopReasonHint: "timeout",
+                  result: JSON.stringify({
+                    status: "delegation_fallback",
+                    recoveredViaParentFallback: true,
+                  }),
+                },
+              };
+            }
+            return {
+              status: "completed",
+              result: JSON.stringify({ status: "completed", step: step.name }),
             };
-          }
-          return {
-            status: "completed",
-            result: JSON.stringify({ status: "completed", step: step.name }),
-          };
-        }),
+          },
+        ),
         assessDependencySatisfaction: assessPlannerDependencySatisfaction,
         isExclusiveNode: () => false,
         resolveMaxParallelism: () => 4,
@@ -189,7 +204,9 @@ describe("CanonicalExecutionKernel", () => {
 
     expect(result.status).toBe("completed");
     expect(result.context.results.review_plan).toContain("delegation_fallback");
-    expect(result.context.results.summarize_review).toContain("summarize_review");
+    expect(result.context.results.summarize_review).toContain(
+      "summarize_review",
+    );
   });
 
   it("blocks dependents when an upstream step finishes without satisfying its contract", async () => {
@@ -197,20 +214,24 @@ describe("CanonicalExecutionKernel", () => {
     const kernel = new CanonicalExecutionKernel({
       deterministicExecutor,
       plannerDelegate: {
-        executeNode: vi.fn(async (step): Promise<ExecutionKernelNodeOutcome> => ({
-          status: "completed",
-          result: JSON.stringify({ status: "completed", step: step.name }),
-        })),
-        assessDependencySatisfaction: vi.fn((step): ExecutionKernelDependencyState => {
-          if (step.name === "implement_core") {
-            return {
-              satisfied: false,
-              reason: "Core contract missing build proof",
-              stopReasonHint: "validation_error",
-            };
-          }
-          return { satisfied: true };
-        }),
+        executeNode: vi.fn(
+          async (step): Promise<ExecutionKernelNodeOutcome> => ({
+            status: "completed",
+            result: JSON.stringify({ status: "completed", step: step.name }),
+          }),
+        ),
+        assessDependencySatisfaction: vi.fn(
+          (step): ExecutionKernelDependencyState => {
+            if (step.name === "implement_core") {
+              return {
+                satisfied: false,
+                reason: "Core contract missing build proof",
+                stopReasonHint: "validation_error",
+              };
+            }
+            return { satisfied: true };
+          },
+        ),
         isExclusiveNode: () => false,
         resolveMaxParallelism: () => 4,
       },
@@ -250,6 +271,8 @@ describe("CanonicalExecutionKernel", () => {
 
     expect(result.status).toBe("failed");
     expect(result.error).toContain("Core contract missing build proof");
-    expect(result.context.results.implement_cli).toContain("dependency_blocked");
+    expect(result.context.results.implement_cli).toContain(
+      "dependency_blocked",
+    );
   });
 });

--- a/runtime/src/workflow/verification-obligations.test.ts
+++ b/runtime/src/workflow/verification-obligations.test.ts
@@ -159,6 +159,30 @@ describe("verification-obligations", () => {
     });
   });
 
+  it("allows grounded no-ops when every required source artifact is also a tracked target", () => {
+    const obligations = deriveVerificationObligations({
+      workspaceRoot: "/tmp/project",
+      requiredSourceArtifacts: ["/tmp/project/AGENC.md"],
+      targetArtifacts: ["/tmp/project/AGENC.md"],
+      completionContract: {
+        taskClass: "artifact_only",
+        placeholdersAllowed: false,
+        partialCompletionAllowed: false,
+        placeholderTaxonomy: "documentation",
+      },
+    });
+
+    expect(obligations).toMatchObject({
+      verificationMode: "mutation_required",
+      requiresMutationEvidence: true,
+      requiresSourceArtifactReads: true,
+      allowsGroundedNoop: true,
+      completionContract: {
+        taskClass: "artifact_only",
+      },
+    });
+  });
+
   it("preserves explicit repair placeholder taxonomy from the completion contract", () => {
     const obligations = deriveVerificationObligations({
       workspaceRoot: "/tmp/project",

--- a/runtime/src/workflow/verification-obligations.ts
+++ b/runtime/src/workflow/verification-obligations.ts
@@ -158,6 +158,12 @@ export function deriveVerificationObligations(
       stepKind,
       targetArtifacts,
     });
+  const allowsGroundedNoop =
+    verificationMode === "conditional_mutation" ||
+    requiredSourceArtifactsCoveredByTargetReads(
+      requiredSourceArtifacts,
+      targetArtifacts,
+    );
 
   return {
     workspaceRoot,
@@ -182,7 +188,7 @@ export function deriveVerificationObligations(
       requiresMutationEvidence ||
       requiredSourceArtifacts.length > 0,
     requiresTargetAuthorization: targetArtifacts.length > 0,
-    allowsGroundedNoop: verificationMode === "conditional_mutation",
+    allowsGroundedNoop,
     placeholdersAllowed,
     partialCompletionAllowed,
   };
@@ -247,6 +253,17 @@ function inferVerificationMode(
     return "grounded_read";
   }
   return "none";
+}
+
+function requiredSourceArtifactsCoveredByTargetReads(
+  requiredSourceArtifacts: readonly string[],
+  targetArtifacts: readonly string[],
+): boolean {
+  if (requiredSourceArtifacts.length === 0 || targetArtifacts.length === 0) {
+    return false;
+  }
+  const targetArtifactSet = new Set(targetArtifacts);
+  return requiredSourceArtifacts.every((artifact) => targetArtifactSet.has(artifact));
 }
 
 function inferPlaceholderTaxonomy(params: {


### PR DESCRIPTION
## What changed
- tighten planner validation so runtime-owned `/todo` artifacts cannot be recreated from directory listings alone when the request still requires current workspace grounding
- require real non-target workspace evidence before bounded `/todo` regeneration is accepted
- add a repair hint for missing runtime `/todo` reads that directs the planner to inspect concrete implementation or config files first
- add planner tests covering the rejected and accepted `/todo` repair paths

## Why
The planner could regenerate the runtime-owned `/todo` file from weak grounding such as `system.listDir`, which let it synthesize state without actually reading implementation evidence from the workspace.

## Impact
This prevents stale or invented runtime `/todo` regeneration and forces grounded repair behavior when the planner needs to continue work based on the actual repository state.

## Validation
- `npm exec vitest -- run runtime/src/llm/chat-executor-planner.test.ts`
- result on the clean PR branch: `92 passed`

## Notes
- `npm --prefix runtime run build` was not used as the PR gate because the repository currently has unrelated `web` workspace TypeScript test failures outside this change set.
