### PR TITLE
refactor(runtime): delete simpleAgentLoop transition flag (Cut 1.3)

### DIFF
--- a/runtime/src/gateway/chat-executor-factory.ts
+++ b/runtime/src/gateway/chat-executor-factory.ts
@@ -124,7 +124,6 @@ export function createChatExecutor(
     maxToolRounds: params.maxToolRounds,
     plannerEnabled:
       llmConfig?.plannerEnabled ?? subagentConfig.enabled,
-    simpleAgentLoop: llmConfig?.simpleAgentLoop ?? true,
     plannerMaxTokens: llmConfig?.plannerMaxTokens,
     toolBudgetPerRequest: llmConfig?.toolBudgetPerRequest,
     maxModelRecallsPerRequest: llmConfig?.maxModelRecallsPerRequest,

--- a/runtime/src/gateway/config-watcher.ts
+++ b/runtime/src/gateway/config-watcher.ts
@@ -2770,9 +2770,6 @@ function validateLlmSection(llm: unknown, errors: string[]): void {
   if (llm.plannerEnabled !== undefined && typeof llm.plannerEnabled !== "boolean") {
     errors.push("llm.plannerEnabled must be a boolean");
   }
-  if (llm.simpleAgentLoop !== undefined && typeof llm.simpleAgentLoop !== "boolean") {
-    errors.push("llm.simpleAgentLoop must be a boolean");
-  }
   if (llm.plannerMaxTokens !== undefined) {
     requireUnlimitedOrIntRange(
       llm.plannerMaxTokens,

--- a/runtime/src/gateway/types.ts
+++ b/runtime/src/gateway/types.ts
@@ -74,12 +74,6 @@ export interface GatewayLLMConfig extends LLMXaiCapabilitySurface {
   maxToolRounds?: number;
   /** Enable planner/executor split for high-complexity turns. */
   plannerEnabled?: boolean;
-  /**
-   * Bypass the planner subsystem entirely and run a Claude Code-style
-   * tool loop directly. Defaults to true. Set false to fall back to the
-   * legacy planner-driven flow during the transition window.
-   */
-  simpleAgentLoop?: boolean;
   /** Maximum output tokens for the planner pass. 0 or undefined = unlimited. */
   plannerMaxTokens?: number;
   /** Maximum tool calls allowed in one request execution. 0 or undefined = unlimited. */

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -459,20 +459,6 @@ export interface ChatExecutorConfig {
   readonly maxTrackedSessions?: number;
   /** Enable planner/executor split for high-complexity turns. */
   readonly plannerEnabled?: boolean;
-  /**
-   * When true, bypass the planner subsystem AND the contract-inference
-   * machinery entirely, running a Claude Code-style tool loop directly:
-   * the model is given the system prompt + tools + history, called once,
-   * and the loop continues as long as it returns tool_use blocks. No
-   * structured plan, no completion contract synthesis, no placeholder
-   * detector, no salvage paths, no refinement retries. Defaults to true.
-   * Set false to fall back to the legacy planner-driven flow.
-   *
-   * The legacy planner subsystem is being removed; this flag exists for
-   * the transition window so the old path can still be exercised by
-   * eval/regression jobs while the new path is rolled out.
-   */
-  readonly simpleAgentLoop?: boolean;
   /** Max output tokens for the planner pass (bounded planning call). */
   readonly plannerMaxTokens?: number;
   /**

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -516,8 +516,7 @@ export class ChatExecutor {
     const ctx = await this.initializeExecutionContext(params);
 
     // Planner path removed in Phase 2 of the refactor — every request
-    // now flows through `executeToolCallLoop` directly. See PR #188 for
-    // the simpleAgentLoop flag that gated this for Phase 1.
+    // now flows through `executeToolCallLoop` directly.
 
     // Direct path: initial LLM call + tool loop. The planner subsystem
     // was deleted in Phase 2; `plannerHandled` is always false here and


### PR DESCRIPTION
Cut 1.3 from TODO.MD — drop the simpleAgentLoop transition flag.

The flag was a Phase 1 switch that allowed exercising the legacy planner-driven flow during the planner rip-out. Every request now unconditionally flows through executeToolCallLoop and the legacy path was deleted in earlier cuts. The flag has zero live call sites that exercise the old branch.

## Changes
- gateway/types.ts — drop simpleAgentLoop from LLMRuntimeConfig
- gateway/config-watcher.ts — drop validation
- gateway/chat-executor-factory.ts — drop factory wiring
- llm/chat-executor-types.ts — drop ChatExecutorConfig field
- llm/chat-executor.ts — drop stale comment reference

## Test plan
- [x] tsc --noEmit clean
- [x] runtime test suite: 6,769 passing (sole baseline failure: marketplace-cli.integration.test.ts LiteSVM DeclaredProgramIdMismatch — pre-existing, unrelated)