### PR TITLE
refactor(runtime): wire normalizeMessagesForAPI + unify glob matching (Cut 5.8 + 7.1)

### DIFF
--- a/runtime/src/gateway/approvals.ts
+++ b/runtime/src/gateway/approvals.ts
@@ -212,35 +212,16 @@ export interface ApprovalEngineConfig {
 // Utilities
 // ============================================================================
 
+// Cut 7.1: glob matching is unified through policy/glob.ts.
+import { matchGlob } from "../policy/glob.js";
+
 /**
- * Simple glob matcher — supports `*` as a wildcard for any sequence of chars.
+ * Simple glob matcher — delegates to the unified policy/glob matcher.
+ * Re-exported for backwards compatibility with consumers that still
+ * import this name from approvals.ts.
  */
 export function globMatch(pattern: string, value: string): boolean {
-  if (pattern === "*") return true;
-  if (!pattern.includes("*")) return value === pattern;
-
-  const parts = pattern.split("*");
-  let cursor = 0;
-  const [first, ...rest] = parts;
-
-  if (!value.startsWith(first ?? "")) return false;
-  cursor = (first ?? "").length;
-
-  for (let i = 0; i < rest.length; i += 1) {
-    const part = rest[i] ?? "";
-    if (part.length === 0) continue;
-
-    // Last segment must match the end.
-    if (i === rest.length - 1) {
-      return value.slice(cursor).endsWith(part);
-    }
-
-    const next = value.indexOf(part, cursor);
-    if (next === -1) return false;
-    cursor = next + part.length;
-  }
-
-  return true;
+  return matchGlob(pattern, value);
 }
 
 /**

--- a/runtime/src/llm/chat-executor-fallback.ts
+++ b/runtime/src/llm/chat-executor-fallback.ts
@@ -41,6 +41,7 @@ import {
 import {
   estimatePromptShape,
 } from "./chat-executor-text.js";
+import { normalizeMessagesForAPI } from "./messages.js";
 import { getProviderRouteKey } from "./model-routing-policy.js";
 import type { RuntimeFaultInjector } from "../eval/fault-injection.js";
 
@@ -126,7 +127,15 @@ export async function callWithFallback(
     })),
     deps.promptBudget,
   );
-  const boundedMessages = budgeted.messages;
+  // Cut 5.8: pass the budgeted history through normalizeMessagesForAPI
+  // before handing it to the provider. This drops boundary/snip system
+  // messages, merges consecutive user messages, drops empty assistant
+  // content (except the last message), and prunes orphan tool results
+  // whose tool_call_id no longer matches a preceding assistant
+  // tool_calls entry.
+  const boundedMessages: LLMMessage[] = [
+    ...normalizeMessagesForAPI(budgeted.messages),
+  ];
   const afterBudget = estimatePromptShape(boundedMessages);
   const budgetDiagnostics = budgeted.diagnostics;
   const hasStatefulSessionId = Boolean(options?.statefulSessionId);

--- a/runtime/src/policy/engine.ts
+++ b/runtime/src/policy/engine.ts
@@ -31,17 +31,11 @@ const DEFAULT_POLICY: RuntimePolicyConfig = {
   enabled: false,
 };
 
+// Cut 7.1: glob matching is unified through policy/glob.ts.
+import { matchGlob } from "./glob.js";
+
 function globMatch(pattern: string, value: string): boolean {
-  if (pattern === "*") return true;
-  const normalizedPattern = pattern.trim().toLowerCase();
-  const normalizedValue = value.trim().toLowerCase();
-  if (!normalizedPattern.includes("*")) {
-    return normalizedPattern === normalizedValue;
-  }
-  const escaped = normalizedPattern
-    .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
-    .replace(/\*/g, ".*");
-  return new RegExp(`^${escaped}$`, "i").test(normalizedValue);
+  return matchGlob(pattern.trim().toLowerCase(), value.trim().toLowerCase());
 }
 
 function pathMatchesRoot(candidate: string, root: string): boolean {

--- a/runtime/src/policy/glob.ts
+++ b/runtime/src/policy/glob.ts
@@ -85,3 +85,45 @@ function matchPlain(pattern: string, candidate: string): boolean {
   }
   return candidate === pattern;
 }
+
+/**
+ * Generic glob match for a single value. Supports the same syntax as
+ * `matchToolPattern` but extends `*` to be a free wildcard that can
+ * appear anywhere in the pattern, for callers that need to match
+ * hosts, channel names, identity IDs, and tool prefixes uniformly.
+ * Empty pattern only matches an empty value.
+ */
+export function matchGlob(pattern: string, value: string): boolean {
+  if (pattern === "" && value === "") return true;
+  if (!pattern) return false;
+  if (pattern === "*") return true;
+  if (pattern.length > 2 && pattern.startsWith("/") && pattern.endsWith("/")) {
+    try {
+      return new RegExp(pattern.slice(1, -1)).test(value);
+    } catch {
+      return false;
+    }
+  }
+  if (pattern.includes("|")) {
+    return pattern
+      .split("|")
+      .map((entry) => entry.trim())
+      .some((entry) => matchGlob(entry, value));
+  }
+  if (!pattern.includes("*")) return value === pattern;
+  // Multi-segment glob: split on `*` and walk segments left-to-right.
+  const parts = pattern.split("*");
+  const first = parts[0] ?? "";
+  const last = parts[parts.length - 1] ?? "";
+  if (!value.startsWith(first)) return false;
+  if (!value.endsWith(last)) return false;
+  let cursor = first.length;
+  for (let i = 1; i < parts.length - 1; i += 1) {
+    const part = parts[i] ?? "";
+    if (part.length === 0) continue;
+    const next = value.indexOf(part, cursor);
+    if (next === -1) return false;
+    cursor = next + part.length;
+  }
+  return cursor <= value.length - last.length || parts.length === 1;
+}

--- a/runtime/src/policy/mcp-governance.ts
+++ b/runtime/src/policy/mcp-governance.ts
@@ -40,28 +40,8 @@ export interface ValidateMCPServerPolicyOptions {
   readonly desktopImage?: string;
 }
 
-function globMatch(pattern: string, value: string): boolean {
-  if (pattern === "*") return true;
-  if (!pattern.includes("*")) return value === pattern;
-  const parts = pattern.split("*");
-  let cursor = 0;
-  const [first, ...rest] = parts;
-  if (!value.startsWith(first ?? "")) {
-    return false;
-  }
-  cursor = (first ?? "").length;
-  for (let i = 0; i < rest.length; i += 1) {
-    const part = rest[i] ?? "";
-    if (part.length === 0) continue;
-    if (i === rest.length - 1) {
-      return value.slice(cursor).endsWith(part);
-    }
-    const next = value.indexOf(part, cursor);
-    if (next === -1) return false;
-    cursor = next + part.length;
-  }
-  return true;
-}
+// Cut 7.1: glob matching is unified through policy/glob.ts.
+import { matchGlob as globMatch } from "./glob.js";
 
 async function resolveExecutablePath(
   command: string,


### PR DESCRIPTION
Two surgical wirings of existing claude_code-shaped capability modules into the live execution path.

## Cut 5.8 — normalizeMessagesForAPI in provider call boundary

`runtime/src/llm/messages.ts::normalizeMessagesForAPI` already existed on disk (Cut 5 additive PR) but was not called anywhere. Wire it into the provider call boundary in `chat-executor-fallback.ts` immediately after the prompt budgeter so every outbound provider request goes through the same 4-step normalization:
1. Drop boundary system messages (`[snip]`, `[microcompact]`, `[autocompact]`, `[reactive-compact]`, `[boundary]`)
2. Drop empty assistant content (except the last message in the array)
3. Merge consecutive user messages
4. Drop orphan tool results whose `tool_call_id` no longer matches a preceding assistant `tool_calls` entry

## Cut 7.1 — unify glob matching

`policy/glob.ts` already exposed `matchToolPattern` + `matchArgPattern` (Cut 7 prep). Three duplicate glob impls remained:
- `policy/engine.ts::globMatch` (regex with case-insensitive lowercase, ~12 LOC)
- `gateway/approvals.ts::globMatch` (substring split, ~30 LOC)
- `policy/mcp-governance.ts::globMatch` (substring split, ~22 LOC)

Replace all three with a unified `policy/glob.ts::matchGlob` helper that handles:
- empty pattern <-> empty value
- exact match
- alternation (`a|b|c`)
- regex (`/.../`)
- multi-segment globs with `*` anywhere in the pattern

The legacy substring-split semantics are preserved (start/middle/end wildcards all work) so existing `approvals.test.ts` coverage stays green.

## Test plan
- [x] tsc --noEmit clean
- [x] runtime test suite: 6,638 passing (matches Cut 1.1+1.2 baseline; sole failed file is the pre-existing marketplace-cli.integration.test.ts LiteSVM baseline)