### PR TITLE
feat(grok): wire prompt_cache_key for Responses API caching (Cut 5.10)

### DIFF
--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -1474,6 +1474,7 @@ export class GrokProvider implements LLMProvider {
         includeEncryptedReasoning: options?.includeEncryptedReasoning,
         structuredOutput: options?.structuredOutput,
         toolSelection,
+        promptCacheKey: options?.stateful?.sessionId?.trim() || undefined,
       });
       return {
         params: built.params,
@@ -1616,6 +1617,7 @@ export class GrokProvider implements LLMProvider {
       includeEncryptedReasoning: options?.includeEncryptedReasoning,
       structuredOutput: options?.structuredOutput,
       toolSelection,
+      promptCacheKey: sessionId,
     });
 
     return {
@@ -1735,6 +1737,7 @@ export class GrokProvider implements LLMProvider {
       includeEncryptedReasoning?: boolean;
       structuredOutput?: LLMChatOptions["structuredOutput"];
       toolSelection?: ToolSelectionDiagnostics;
+      promptCacheKey?: string;
     },
   ): {
     params: Record<string, unknown>;
@@ -1815,6 +1818,15 @@ export class GrokProvider implements LLMProvider {
     };
     if (options?.previousResponseId) {
       params.previous_response_id = options.previousResponseId;
+    }
+    // Cut 5.10: xAI prompt caching is prefix-based and is maximized by
+    // routing requests with the same conversation ID to the same
+    // server. For the Responses API, that routing hint is the
+    // `prompt_cache_key` request field. Feed it the session ID so
+    // every turn in the same AgenC session lands on the same backend
+    // and reuses the previously-cached system + history prefix.
+    if (options?.promptCacheKey) {
+      params.prompt_cache_key = options.promptCacheKey;
     }
     if (this.config.temperature !== undefined)
       params.temperature = this.config.temperature;


### PR DESCRIPTION
Cut 5.10 from TODO.MD — wire xAI prompt caching into the Grok adapter.

## Context
The original TODO Cut 5.10 was framed around "cache_control breakpoints" but that's Anthropic API semantics. xAI doesn't have explicit breakpoints — the prefix is matched automatically. Verified against the live xAI docs:
- `developers/advanced-api-usage/prompt-caching/how-it-works`
- `developers/advanced-api-usage/prompt-caching/maximizing-cache-hits`

xAI's Responses API supports automatic prefix-based prompt caching when the request includes a `prompt_cache_key` field. The cached prefix is billed at a reduced rate, and requests with the same key are routed to the same backend server (which is where cache entries live).

The right wiring is to set `prompt_cache_key: sessionId` so every turn in the same AgenC session lands on the same backend and reuses the previously-cached system + history prefix.

## Changes
`runtime/src/llm/grok/adapter.ts`:
- Add `promptCacheKey?: string` option to `buildParams()`
- When set, emit `params.prompt_cache_key = options.promptCacheKey`
- Both `buildRequestPlan` call sites wire `sessionId` through:
  - non-stateful path: pass `options.stateful?.sessionId?.trim() || undefined`
  - stateful path: pass the resolved `sessionId`

`prompt_cache_key` was already in the Responses API allow-list (line 82 of grok/adapter.ts), so no other config plumbing is needed.

## Test plan
- [x] tsc --noEmit clean
- [x] runtime test suite: 6,638 passing (matches Cut 5.8 baseline; sole failed file is the pre-existing marketplace-cli.integration.test.ts LiteSVM baseline)