### PR TITLE
feat(runtime): wire hook system into tool dispatch boundary (Cut 5.2)

### DIFF
--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -74,6 +74,11 @@ import {
   generateFallbackContent,
   buildPromptToolContent,
 } from "./chat-executor-text.js";
+import {
+  HookRegistry,
+  dispatchHooks,
+  defaultHookExecutor,
+} from "./hooks/index.js";
 
 // ============================================================================
 // Callback interfaces
@@ -134,6 +139,8 @@ export interface ToolLoopConfig {
   readonly retryPolicyMatrix: LLMRetryPolicyMatrix;
   readonly allowedTools: Set<string> | null;
   readonly toolFailureBreaker: ToolFailureCircuitBreaker;
+  /** Cut 5.2: hook registry for PreToolUse / PostToolUse / PostToolUseFailure. */
+  readonly hookRegistry?: HookRegistry;
 }
 
 // ============================================================================
@@ -565,6 +572,50 @@ export async function executeSingleToolCall(
     },
   });
 
+  // Cut 5.2: PreToolUse hook dispatch. With no hooks registered (the
+  // default) the registry returns `noop` immediately and behavior is
+  // unchanged. Hooks may rewrite tool args via `updatedInput` or deny
+  // the call outright.
+  if (config.hookRegistry) {
+    const preDispatch = await dispatchHooks({
+      registry: config.hookRegistry,
+      event: "PreToolUse",
+      matchKey: toolCall.name,
+      executor: defaultHookExecutor,
+      context: {
+        event: "PreToolUse",
+        sessionId: ctx.sessionId,
+        toolCall,
+      },
+    });
+    if (preDispatch.action === "deny") {
+      const denyMessage =
+        preDispatch.message ??
+        `Tool "${toolCall.name}" blocked by PreToolUse hook`;
+      callbacks.pushMessage(
+        ctx,
+        {
+          role: "tool",
+          content: denyMessage,
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+        },
+        "tools",
+      );
+      callbacks.appendToolRecord(ctx, {
+        name: toolCall.name,
+        args,
+        result: denyMessage,
+        isError: true,
+        durationMs: 0,
+      });
+      return "skip";
+    }
+    if (preDispatch.updatedInput) {
+      args = preDispatch.updatedInput as typeof args;
+    }
+  }
+
   // Execute tool with retry.
   const exec = await executeToolWithRetry(
     toolCall,
@@ -626,6 +677,38 @@ export async function executeSingleToolCall(
       result,
     },
   });
+
+  // Cut 5.2: PostToolUse / PostToolUseFailure hook dispatch.
+  if (config.hookRegistry) {
+    if (exec.toolFailed) {
+      await dispatchHooks({
+        registry: config.hookRegistry,
+        event: "PostToolUseFailure",
+        matchKey: toolCall.name,
+        executor: defaultHookExecutor,
+        context: {
+          event: "PostToolUseFailure",
+          sessionId: ctx.sessionId,
+          toolCall,
+          errorMessage: result,
+        },
+      });
+    } else {
+      await dispatchHooks({
+        registry: config.hookRegistry,
+        event: "PostToolUse",
+        matchKey: toolCall.name,
+        executor: defaultHookExecutor,
+        context: {
+          event: "PostToolUse",
+          sessionId: ctx.sessionId,
+          toolCall,
+          result,
+          isError: exec.toolFailed,
+        },
+      });
+    }
+  }
 
   if (isRuntimeLimitExceeded(ctx.failedToolCalls, ctx.effectiveFailureBudget)) {
     callbacks.setStopReason(

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -427,6 +427,13 @@ export interface ChatExecutorConfig {
   readonly memoryRetriever?: MemoryRetriever;
   readonly allowedTools?: readonly string[];
   /**
+   * Cut 5.2: optional hook registry. When provided, the chat-executor
+   * fires PreToolUse / PostToolUse / PostToolUseFailure hooks at the
+   * tool dispatch boundary. With no registry the hook code paths
+   * short-circuit and behavior is unchanged.
+   */
+  readonly hookRegistry?: import("./hooks/index.js").HookRegistry;
+  /**
    * Maximum token budget per session. When cumulative usage meets or exceeds
    * this value, the executor attempts to compact conversation history by
    * summarizing older messages. If compaction fails, falls back to

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -48,6 +48,7 @@ import {
 import type {
   DelegationBanditPolicyTuner,
 } from "./delegation-learning.js";
+import type { HookRegistry } from "./hooks/index.js";
 // ---------------------------------------------------------------------------
 // Imports from extracted sibling modules
 // ---------------------------------------------------------------------------
@@ -352,6 +353,14 @@ export class ChatExecutor {
   private readonly economicsPolicy: RuntimeEconomicsPolicy;
   private readonly modelRoutingPolicy: ModelRoutingPolicy;
   private readonly defaultRunClass?: RuntimeRunClass;
+  /**
+   * Cut 5.2: optional hook registry. When set, the chat-executor fires
+   * PreToolUse/PostToolUse/PostToolUseFailure events at the tool
+   * dispatch boundary inside chat-executor-tool-loop.ts. With no
+   * registry (the default) the hooks code paths short-circuit and the
+   * runtime behaves identically to the pre-hooks shape.
+   */
+  private readonly hookRegistry?: HookRegistry;
 
   private readonly cooldowns = new Map<string, CooldownEntry>();
   private readonly sessionTokens = new Map<string, number>();
@@ -466,6 +475,7 @@ export class ChatExecutor {
       economicsPolicy: this.economicsPolicy,
     });
     this.defaultRunClass = config.defaultRunClass;
+    this.hookRegistry = config.hookRegistry;
   }
 
   private static resolveSubagentVerifierConfig(
@@ -1657,6 +1667,7 @@ export class ChatExecutor {
       retryPolicyMatrix: this.retryPolicyMatrix,
       allowedTools: this.allowedTools,
       toolFailureBreaker: this.toolFailureBreaker,
+      ...(this.hookRegistry ? { hookRegistry: this.hookRegistry } : {}),
     }, this.buildToolLoopCallbacks());
   }
 


### PR DESCRIPTION
Wire the existing `runtime/src/llm/hooks/` registry+dispatcher into the chat-executor tool loop so PreToolUse / PostToolUse / PostToolUseFailure hooks fire at every tool call boundary.

## Context
The hook modules (Cut 5 additive PR) already exist on disk but were never called. This PR connects them.

## Changes
- `chat-executor-types.ts`: add `hookRegistry?: HookRegistry` to `ChatExecutorConfig`
- `chat-executor.ts`: store the registry in a private `hookRegistry` field; thread it into `executeToolCallLoop`
- `chat-executor-tool-loop.ts`: `ToolLoopConfig` accepts the registry and `executeSingleToolCall` calls `dispatchHooks` at three points:
  - **PreToolUse** — just before `executeToolWithRetry`. A `deny` outcome short-circuits with the hook's message; an `updatedInput` rewrites the tool args before dispatch.
  - **PostToolUse** — after a successful tool call.
  - **PostToolUseFailure** — after a failed tool call (`toolFailed=true`).

## Risk model
With no `hookRegistry` configured (the default), `dispatchHooks` is never called and behavior is unchanged. Callers (gateway daemon, eval harnesses, sub-agents) can opt in by constructing a `HookRegistry` and passing it to `ChatExecutorConfig`.

This is the minimum-risk wiring of the Cut 5 hook system: no public SDK changes, no test rewrites, the entire chain is optional.

## Test plan
- [x] tsc --noEmit clean
- [x] runtime test suite: 6,283 passing (matches Cut 4 baseline, sole failed file is the pre-existing marketplace-cli LiteSVM baseline)