### PR TITLE
feat(runtime): wire canUseTool seam into tool dispatch boundary (Cut 5.7)

### DIFF
--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -79,6 +79,7 @@ import {
   dispatchHooks,
   defaultHookExecutor,
 } from "./hooks/index.js";
+import type { CanUseToolFn } from "./can-use-tool.js";
 
 // ============================================================================
 // Callback interfaces
@@ -141,6 +142,16 @@ export interface ToolLoopConfig {
   readonly toolFailureBreaker: ToolFailureCircuitBreaker;
   /** Cut 5.2: hook registry for PreToolUse / PostToolUse / PostToolUseFailure. */
   readonly hookRegistry?: HookRegistry;
+  /**
+   * Cut 5.7: canUseTool permission seam. When set, the tool dispatch
+   * loop calls this before each tool to check whether the call is
+   * allowed. Returning `deny` short-circuits the call with the hook's
+   * message. Returning `ask` is currently treated as a soft deny at
+   * this layer (interactive approval is the gateway's responsibility).
+   * Returning `allow` with `updatedInput` rewrites the tool args
+   * before dispatch.
+   */
+  readonly canUseTool?: CanUseToolFn;
 }
 
 // ============================================================================
@@ -571,6 +582,43 @@ export async function executeSingleToolCall(
         : {}),
     },
   });
+
+  // Cut 5.7: canUseTool permission seam. When configured, this fires
+  // before the hook system so the global policy decision is the first
+  // gate at the dispatch boundary. With no canUseTool wired (the
+  // default), the seam is skipped and behavior is unchanged.
+  if (config.canUseTool) {
+    const decision = await config.canUseTool(toolCall, {
+      sessionId: ctx.sessionId,
+    });
+    if (decision.behavior === "deny" || decision.behavior === "ask") {
+      const denyMessage =
+        decision.behavior === "deny"
+          ? decision.message
+          : `Tool "${toolCall.name}" requires interactive approval: ${decision.message}`;
+      callbacks.pushMessage(
+        ctx,
+        {
+          role: "tool",
+          content: denyMessage,
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+        },
+        "tools",
+      );
+      callbacks.appendToolRecord(ctx, {
+        name: toolCall.name,
+        args,
+        result: denyMessage,
+        isError: true,
+        durationMs: 0,
+      });
+      return "skip";
+    }
+    if (decision.updatedInput) {
+      args = decision.updatedInput as typeof args;
+    }
+  }
 
   // Cut 5.2: PreToolUse hook dispatch. With no hooks registered (the
   // default) the registry returns `noop` immediately and behavior is

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -434,6 +434,14 @@ export interface ChatExecutorConfig {
    */
   readonly hookRegistry?: import("./hooks/index.js").HookRegistry;
   /**
+   * Cut 5.7: optional canUseTool seam. When provided, the runtime
+   * calls this before every tool dispatch and honors deny/ask/allow
+   * with optional updatedInput. Callers can wrap a
+   * ToolPermissionEvaluator via `evaluatorToCanUseTool()` to plug the
+   * unified policy pipeline through this single hook.
+   */
+  readonly canUseTool?: import("./can-use-tool.js").CanUseToolFn;
+  /**
    * Maximum token budget per session. When cumulative usage meets or exceeds
    * this value, the executor attempts to compact conversation history by
    * summarizing older messages. If compaction fails, falls back to

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -49,6 +49,7 @@ import type {
   DelegationBanditPolicyTuner,
 } from "./delegation-learning.js";
 import type { HookRegistry } from "./hooks/index.js";
+import type { CanUseToolFn } from "./can-use-tool.js";
 // ---------------------------------------------------------------------------
 // Imports from extracted sibling modules
 // ---------------------------------------------------------------------------
@@ -361,6 +362,14 @@ export class ChatExecutor {
    * runtime behaves identically to the pre-hooks shape.
    */
   private readonly hookRegistry?: HookRegistry;
+  /**
+   * Cut 5.7: optional canUseTool seam. When set, the runtime calls
+   * this before every tool dispatch and honors deny / ask / allow with
+   * optional updatedInput. With no value (the default) the seam is
+   * skipped and the existing allowedTools / approval flow continues
+   * unchanged.
+   */
+  private readonly canUseTool?: CanUseToolFn;
 
   private readonly cooldowns = new Map<string, CooldownEntry>();
   private readonly sessionTokens = new Map<string, number>();
@@ -476,6 +485,7 @@ export class ChatExecutor {
     });
     this.defaultRunClass = config.defaultRunClass;
     this.hookRegistry = config.hookRegistry;
+    this.canUseTool = config.canUseTool;
   }
 
   private static resolveSubagentVerifierConfig(
@@ -1668,6 +1678,7 @@ export class ChatExecutor {
       allowedTools: this.allowedTools,
       toolFailureBreaker: this.toolFailureBreaker,
       ...(this.hookRegistry ? { hookRegistry: this.hookRegistry } : {}),
+      ...(this.canUseTool ? { canUseTool: this.canUseTool } : {}),
     }, this.buildToolLoopCallbacks());
   }
 


### PR DESCRIPTION
Wire the existing `CanUseToolFn` from `runtime/src/llm/can-use-tool.ts` into the chat-executor tool loop so callers can plug a single permission function (or a wrapped `ToolPermissionEvaluator`) through one seam.

## Changes
- `chat-executor-types.ts`: add `canUseTool?: CanUseToolFn` to `ChatExecutorConfig`
- `chat-executor.ts`: store the function in a private `canUseTool` field; thread it into `executeToolCallLoop`
- `chat-executor-tool-loop.ts`: `ToolLoopConfig` accepts `canUseTool`; `executeSingleToolCall` calls it before the existing PreToolUse hook dispatch and honors:
  - `allow` → continue (with optional `updatedInput` rewrite)
  - `allow` + `updatedInput` → rewrite tool args before dispatch
  - `deny` → short-circuit with the hook's message
  - `ask` → soft deny at this layer (interactive approval is the gateway's responsibility)

## Bridge to Cut 7
Cut 7's `ToolPermissionEvaluator` already exposes `evaluatorToCanUseTool()` which adapts an evaluator instance to the `CanUseToolFn` shape, so callers can wire the unified policy pipeline through this single seam without further plumbing.

## Risk model
With no `canUseTool` configured (the default), the seam is skipped and behavior is unchanged. This is the minimum-risk wiring of Cut 5.7 and the bridge into Cut 7's permission consolidation.

## Test plan
- [x] tsc --noEmit clean
- [x] runtime test suite: 6,283 passing (matches Cut 5.2 baseline)