### PR TITLE
feat(runtime): wire isConcurrencySafe partition trace into tool loop (Cut 5.5)

### DIFF
--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -80,6 +80,10 @@ import {
   defaultHookExecutor,
 } from "./hooks/index.js";
 import type { CanUseToolFn } from "./can-use-tool.js";
+import {
+  partitionToolCalls,
+  type IsConcurrencySafeFn,
+} from "./tool-orchestration.js";
 
 // ============================================================================
 // Callback interfaces
@@ -152,6 +156,15 @@ export interface ToolLoopConfig {
    * before dispatch.
    */
   readonly canUseTool?: CanUseToolFn;
+  /**
+   * Cut 5.5: concurrency-safe tool predicate. When set, the tool loop
+   * partitions each round's tool calls into consecutive-concurrency-safe
+   * batches and emits a telemetry trace describing the partition shape.
+   * The dispatch itself remains serial (stateful mutation through the
+   * loop callbacks is order-sensitive); this wiring lets callers
+   * inventory which rounds would benefit from parallel dispatch.
+   */
+  readonly isConcurrencySafe?: IsConcurrencySafeFn;
 }
 
 // ============================================================================
@@ -880,6 +893,36 @@ export async function executeToolCallLoop(
       },
       "assistant_runtime",
     );
+
+    // Cut 5.5: emit a partitioning trace showing which subset of this
+    // round's tool calls are concurrency-safe. When callers wire a
+    // real `isConcurrencySafe` predicate, the trace records how many
+    // parallel batches the round would have produced. Dispatch remains
+    // serial because the loop callbacks mutate ctx in order-sensitive
+    // ways.
+    if (config.isConcurrencySafe) {
+      const batches = partitionToolCalls(
+        ctx.response.toolCalls,
+        config.isConcurrencySafe,
+      );
+      callbacks.emitExecutionTrace(ctx, {
+        type: "tool_dispatch_started",
+        phase: "tool_followup",
+        callIndex: ctx.callIndex,
+        payload: {
+          tool: "__round_partition__",
+          args: {},
+          argumentDiagnostics: {
+            batchCount: batches.length,
+            parallelBatchCount: batches.filter((batch) => batch.isConcurrencySafe)
+              .length,
+            concurrencySafeToolNames: batches
+              .filter((batch) => batch.isConcurrencySafe)
+              .flatMap((batch) => batch.toolCalls.map((call) => call.name)),
+          },
+        },
+      });
+    }
 
     let abortRound = false;
     for (const toolCall of ctx.response.toolCalls) {

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -442,6 +442,13 @@ export interface ChatExecutorConfig {
    */
   readonly canUseTool?: import("./can-use-tool.js").CanUseToolFn;
   /**
+   * Cut 5.5: optional concurrency-safety predicate. When provided,
+   * the tool loop emits a per-round partition trace identifying which
+   * batches could have been dispatched in parallel. Dispatch itself
+   * remains serial.
+   */
+  readonly isConcurrencySafe?: import("./tool-orchestration.js").IsConcurrencySafeFn;
+  /**
    * Maximum token budget per session. When cumulative usage meets or exceeds
    * this value, the executor attempts to compact conversation history by
    * summarizing older messages. If compaction fails, falls back to

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -50,6 +50,7 @@ import type {
 } from "./delegation-learning.js";
 import type { HookRegistry } from "./hooks/index.js";
 import type { CanUseToolFn } from "./can-use-tool.js";
+import type { IsConcurrencySafeFn } from "./tool-orchestration.js";
 // ---------------------------------------------------------------------------
 // Imports from extracted sibling modules
 // ---------------------------------------------------------------------------
@@ -370,6 +371,14 @@ export class ChatExecutor {
    * unchanged.
    */
   private readonly canUseTool?: CanUseToolFn;
+  /**
+   * Cut 5.5: optional concurrency-safety predicate. When set, the
+   * tool loop emits a per-round partition trace recording which tool
+   * calls could have been dispatched in parallel. Dispatch itself
+   * remains serial; the telemetry lets operators see the parallelism
+   * opportunity before wiring real parallel dispatch.
+   */
+  private readonly isConcurrencySafe?: IsConcurrencySafeFn;
 
   private readonly cooldowns = new Map<string, CooldownEntry>();
   private readonly sessionTokens = new Map<string, number>();
@@ -486,6 +495,7 @@ export class ChatExecutor {
     this.defaultRunClass = config.defaultRunClass;
     this.hookRegistry = config.hookRegistry;
     this.canUseTool = config.canUseTool;
+    this.isConcurrencySafe = config.isConcurrencySafe;
   }
 
   private static resolveSubagentVerifierConfig(
@@ -1679,6 +1689,9 @@ export class ChatExecutor {
       toolFailureBreaker: this.toolFailureBreaker,
       ...(this.hookRegistry ? { hookRegistry: this.hookRegistry } : {}),
       ...(this.canUseTool ? { canUseTool: this.canUseTool } : {}),
+      ...(this.isConcurrencySafe
+        ? { isConcurrencySafe: this.isConcurrencySafe }
+        : {}),
     }, this.buildToolLoopCallbacks());
   }
 


### PR DESCRIPTION
Wire the existing `partitionToolCalls` from `runtime/src/llm/tool-orchestration.ts` into the chat-executor tool loop as a telemetry-only integration.

## Behavior
When a caller supplies `isConcurrencySafe` through `ChatExecutorConfig`, the round dispatch loop calls `partitionToolCalls` at the top of each round and emits a trace event describing the batch shape:
- `batchCount` — total partitions (serial + parallel)
- `parallelBatchCount` — parallel-eligible batches
- `concurrencySafeToolNames` — tool names eligible for parallel dispatch

The dispatch itself remains serial because `executeSingleToolCall` mutates ctx through order-sensitive callbacks (`pushMessage`, `appendToolRecord`, `emitExecutionTrace`, stuck-detection state). The telemetry lets operators inventory how much parallelism the runtime could reclaim before wiring actual parallel dispatch — which requires a more careful refactor of the mutation boundary.

## Changes
- `chat-executor-tool-loop.ts`: import `partitionToolCalls` + `IsConcurrencySafeFn`; add `isConcurrencySafe?: IsConcurrencySafeFn` to `ToolLoopConfig`; emit the partition trace at the start of each round
- `chat-executor.ts`: add `isConcurrencySafe?` private field; store from config; thread into `executeToolCallLoop`
- `chat-executor-types.ts`: expose `isConcurrencySafe` on `ChatExecutorConfig`

## Risk model
With no predicate configured (the default), the partition trace is skipped and behavior is unchanged.

## Test plan
- [x] tsc --noEmit clean
- [x] runtime test suite: 6,283 passing (matches Cut 5.7 baseline)