### PR TITLE
feat(runtime): wire tool result budget + disk persistence (Cut 5.3)

### DIFF
--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -84,6 +84,11 @@ import {
   partitionToolCalls,
   type IsConcurrencySafeFn,
 } from "./tool-orchestration.js";
+import {
+  applyToolResultBudget,
+  type ContentReplacementState,
+  type ToolBudgetConfig,
+} from "./tool-result-budget.js";
 
 // ============================================================================
 // Callback interfaces
@@ -165,6 +170,16 @@ export interface ToolLoopConfig {
    * inventory which rounds would benefit from parallel dispatch.
    */
   readonly isConcurrencySafe?: IsConcurrencySafeFn;
+  /**
+   * Cut 5.3: tool result budget config. When set, oversized tool
+   * results are persisted to disk and replaced in the message
+   * history with a `<persisted-output>` placeholder that includes
+   * the file path + a 2 KB preview. The state is stored on the
+   * caller-supplied Map<sessionId, ContentReplacementState> so it
+   * persists across rounds in the same session.
+   */
+  readonly toolResultBudget?: ToolBudgetConfig;
+  readonly toolResultBudgetState?: Map<string, ContentReplacementState>;
 }
 
 // ============================================================================
@@ -714,6 +729,49 @@ export async function executeSingleToolCall(
       result = enrichToolResultMetadata(result, {
         circuitBreaker: "open",
         circuitBreakerReason: circuitReason,
+      });
+    }
+  }
+
+  // Cut 5.3: apply per-tool result budget. When the budget config is
+  // wired, oversized successful results are persisted to disk and
+  // replaced with a placeholder pointing at the file path. Failed
+  // results are skipped — error messages are typically small and
+  // their text is needed for the model to recover.
+  if (
+    config.toolResultBudget &&
+    config.toolResultBudgetState &&
+    !exec.toolFailed
+  ) {
+    const currentState =
+      config.toolResultBudgetState.get(ctx.sessionId) ?? {
+        seenIds: new Set<string>(),
+        replacements: new Map(),
+      };
+    const budgetResult = applyToolResultBudget({
+      sessionId: ctx.sessionId,
+      toolUseId: toolCall.id,
+      toolName: toolCall.name,
+      content: result,
+      state: currentState,
+      config: config.toolResultBudget,
+    });
+    if (budgetResult.persisted) {
+      result = budgetResult.content;
+      config.toolResultBudgetState.set(ctx.sessionId, budgetResult.state);
+      callbacks.emitExecutionTrace(ctx, {
+        type: "tool_dispatch_started",
+        phase: "tool_followup",
+        callIndex: ctx.callIndex,
+        payload: {
+          tool: "__tool_result_persisted__",
+          args: {},
+          argumentDiagnostics: {
+            toolCallId: toolCall.id,
+            toolName: toolCall.name,
+            diskPath: budgetResult.diskPath,
+          },
+        },
       });
     }
   }

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -457,6 +457,14 @@ export interface ChatExecutorConfig {
    */
   readonly queryTracking?: import("./query-tracking.js").QueryTracking;
   /**
+   * Cut 5.3: tool result budget config. When set, oversized tool
+   * results are persisted to disk and replaced in the message history
+   * with a `<persisted-output>` placeholder pointing at the file
+   * path. Per-session ContentReplacementState is owned by the
+   * executor; callers only need to supply the budget config.
+   */
+  readonly toolResultBudget?: import("./tool-result-budget.js").ToolBudgetConfig;
+  /**
    * Maximum token budget per session. When cumulative usage meets or exceeds
    * this value, the executor attempts to compact conversation history by
    * summarizing older messages. If compaction fails, falls back to

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -56,6 +56,10 @@ import {
   isQueryDepthExceeded,
   type QueryTracking,
 } from "./query-tracking.js";
+import type {
+  ContentReplacementState,
+  ToolBudgetConfig,
+} from "./tool-result-budget.js";
 // ---------------------------------------------------------------------------
 // Imports from extracted sibling modules
 // ---------------------------------------------------------------------------
@@ -392,6 +396,19 @@ export class ChatExecutor {
    * executor defaults to a fresh chainId with depth 0.
    */
   private readonly queryTracking: QueryTracking;
+  /**
+   * Cut 5.3: tool result budget config + per-session content
+   * replacement state. When the budget config is provided, oversized
+   * tool results are persisted to disk and the in-memory message
+   * history sees a small placeholder that includes the file path.
+   * The state Map is owned by the executor and survives across the
+   * tool loop rounds inside a single session.
+   */
+  private readonly toolResultBudget?: ToolBudgetConfig;
+  private readonly toolResultBudgetState = new Map<
+    string,
+    ContentReplacementState
+  >();
 
   private readonly cooldowns = new Map<string, CooldownEntry>();
   private readonly sessionTokens = new Map<string, number>();
@@ -509,6 +526,7 @@ export class ChatExecutor {
     this.hookRegistry = config.hookRegistry;
     this.canUseTool = config.canUseTool;
     this.isConcurrencySafe = config.isConcurrencySafe;
+    this.toolResultBudget = config.toolResultBudget;
     this.queryTracking = config.queryTracking ?? rootQueryTracking();
     if (isQueryDepthExceeded(this.queryTracking)) {
       throw new Error(
@@ -1715,6 +1733,12 @@ export class ChatExecutor {
       ...(this.canUseTool ? { canUseTool: this.canUseTool } : {}),
       ...(this.isConcurrencySafe
         ? { isConcurrencySafe: this.isConcurrencySafe }
+        : {}),
+      ...(this.toolResultBudget
+        ? {
+            toolResultBudget: this.toolResultBudget,
+            toolResultBudgetState: this.toolResultBudgetState,
+          }
         : {}),
     }, this.buildToolLoopCallbacks());
   }


### PR DESCRIPTION
Wire the existing `runtime/src/llm/tool-result-budget.ts` into the chat-executor tool dispatch boundary.

## Behavior
When a caller provides a `toolResultBudget` config through `ChatExecutorConfig`, oversized successful tool results are persisted to disk under `~/.agenc/workspace/tool-results/<sessionId>/` and replaced in the in-memory message history with a `<persisted-output>` placeholder that includes the file path + a 2 KB preview.

## Changes
- `chat-executor-tool-loop.ts`: import `applyToolResultBudget` + `ContentReplacementState` + `ToolBudgetConfig`; add `toolResultBudget` + `toolResultBudgetState` to `ToolLoopConfig`; in `executeSingleToolCall` after the result comes back and before `appendToolRecord`, apply the budget when configured (skipping failed results so error messages stay inline). Emits a `__tool_result_persisted__` telemetry trace with the disk path when persistence fires.
- `chat-executor.ts`: add `toolResultBudget?: ToolBudgetConfig` field + a per-session `toolResultBudgetState: Map<sessionId, ContentReplacementState>` owned by the executor; thread both into `executeToolCallLoop` when the budget is configured.
- `chat-executor-types.ts`: expose `toolResultBudget` on `ChatExecutorConfig`.

## State model
The state Map survives across rounds in the same session, so the same `tool_use_id` receiving identical content twice in a row reuses the existing disk file. Failed tool results bypass persistence because the error text is small and is needed inline for the model to recover.

## Risk model
With no `toolResultBudget` configured (the default), the budget code paths short-circuit and behavior is unchanged.

## Test plan
- [x] tsc --noEmit clean
- [x] runtime test suite: 6,283 passing (matches Cut 5.6 baseline)