### PR TITLE
feat(gateway): wire ToolPermissionEvaluator through canUseTool seam (Cut 7)

### DIFF
--- a/runtime/src/gateway/chat-executor-factory.ts
+++ b/runtime/src/gateway/chat-executor-factory.ts
@@ -24,6 +24,36 @@ import type {
 import type { HostToolingProfile } from "./host-tooling.js";
 import type { ResolvedSubAgentRuntimeConfig } from "./subagent-infrastructure.js";
 import type { GatewayLLMConfig } from "./types.js";
+import {
+  ToolPermissionEvaluator,
+  evaluatorToCanUseTool,
+  type ToolRule,
+} from "../policy/tool-permission-evaluator.js";
+import { BudgetStateService } from "../policy/budget-state.js";
+
+/**
+ * Cut 7: convert a gateway config tool allow/deny list into the
+ * ToolRule[] shape the ToolPermissionEvaluator consumes. Deny rules
+ * always win over allow rules; the evaluator preserves that ordering
+ * when it walks the rule list.
+ */
+export function buildPermissionRulesFromAllowDeny(input: {
+  readonly toolAllowList?: readonly string[];
+  readonly toolDenyList?: readonly string[];
+}): readonly ToolRule[] {
+  const rules: ToolRule[] = [];
+  for (const pattern of input.toolDenyList ?? []) {
+    rules.push({
+      pattern,
+      effect: "deny",
+      message: `Tool denied by gateway policy.toolDenyList rule: ${pattern}`,
+    });
+  }
+  for (const pattern of input.toolAllowList ?? []) {
+    rules.push({ pattern, effect: "allow" });
+  }
+  return rules;
+}
 
 // ---------------------------------------------------------------------------
 // Factory input
@@ -76,6 +106,17 @@ export interface CreateChatExecutorParams {
   resolveHostWorkspaceRoot: () => string | null;
   /** Optional deterministic pipeline executor. */
   pipelineExecutor?: DeterministicPipelineExecutor;
+  /**
+   * Cut 7: optional permission rules. When provided, the factory
+   * builds a ToolPermissionEvaluator from the rules + a fresh
+   * BudgetStateService and wraps it as the chat-executor's
+   * canUseTool seam (Cut 5.7). Empty rules array opts out of the
+   * evaluator entirely; the existing approval flow continues to
+   * gate tool calls through tool-handler-factory.
+   */
+  permissionRules?: readonly ToolRule[];
+  /** Optional cap on tool call rate per minute (used by the budget service). */
+  maxToolCallRatePerMinute?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -110,6 +151,23 @@ export function createChatExecutor(
     llmConfig,
     providerConfigs: params.providerConfigs,
   });
+
+  // Cut 7: build a ToolPermissionEvaluator + BudgetStateService when
+  // the caller supplies permission rules, and adapt it to the
+  // chat-executor's canUseTool seam (Cut 5.7). With no rules
+  // configured the seam is not wired and the existing approval flow
+  // remains the only gate.
+  const canUseTool = (() => {
+    if (!params.permissionRules || params.permissionRules.length === 0) {
+      return undefined;
+    }
+    const evaluator = new ToolPermissionEvaluator({
+      rules: params.permissionRules,
+      budgetState: new BudgetStateService(),
+      maxToolCallRatePerMinute: params.maxToolCallRatePerMinute,
+    });
+    return evaluatorToCanUseTool(evaluator);
+  })();
 
   return new ChatExecutor({
     providers: params.providers,
@@ -161,5 +219,6 @@ export function createChatExecutor(
     onCompaction: params.onCompaction,
     economicsPolicy,
     modelRoutingPolicy,
+    ...(canUseTool ? { canUseTool } : {}),
   });
 }

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -93,7 +93,10 @@ import { type Tool } from "../tools/types.js";
 import type { GatewayMessage } from "./message.js";
 import { createGatewayMessage } from "./message.js";
 import { ChatExecutor } from "../llm/chat-executor.js";
-import { createChatExecutor } from "./chat-executor-factory.js";
+import {
+  createChatExecutor,
+  buildPermissionRulesFromAllowDeny,
+} from "./chat-executor-factory.js";
 import {
   normalizeToolCallArguments,
 } from "../llm/chat-executor-tool-utils.js";
@@ -1971,6 +1974,15 @@ export class DaemonManager {
       resolveHostToolingProfile: () => this._hostToolingProfile,
       resolveHostWorkspaceRoot: () => this._hostWorkspacePath,
       pipelineExecutor: plannerPipelineExecutor,
+      // Cut 7: wire ToolPermissionEvaluator through the canUseTool
+      // seam. The evaluator runs every tool call through the gateway
+      // policy.toolAllowList / policy.toolDenyList rules before the
+      // existing approval flow. With no policy configured the rules
+      // array is empty and the seam is skipped.
+      permissionRules: buildPermissionRulesFromAllowDeny({
+        toolAllowList: config.policy?.toolAllowList,
+        toolDenyList: config.policy?.toolDenyList,
+      }),
     });
 
     const sessionMgr = this.createSessionManager(hooks);
@@ -3482,6 +3494,10 @@ export class DaemonManager {
         resolveHostToolingProfile: () => this._hostToolingProfile,
         resolveHostWorkspaceRoot: () => this._hostWorkspacePath,
         pipelineExecutor: plannerPipelineExecutor,
+        permissionRules: buildPermissionRulesFromAllowDeny({
+          toolAllowList: newConfig.policy?.toolAllowList,
+          toolDenyList: newConfig.policy?.toolDenyList,
+        }),
       });
 
       const providerNames = providers.map((p) => p.name).join(" → ") || "none";


### PR DESCRIPTION
The `ToolPermissionEvaluator` + `BudgetStateService` modules from the Cut 7 additive PR were on disk but never exercised. The Cut 5.7 `canUseTool` seam was wired in chat-executor but no caller built an evaluator. **This PR closes the loop**: the daemon now constructs a `ToolPermissionEvaluator` from the gateway `policy.toolAllowList` / `policy.toolDenyList` and passes it through the `canUseTool` seam.

## Changes
- `chat-executor-factory.ts`: add `permissionRules?: readonly ToolRule[]` + `maxToolCallRatePerMinute?: number` to `CreateChatExecutorParams`. When `permissionRules` are provided, the factory builds a `ToolPermissionEvaluator` + `BudgetStateService` and adapts it to a `CanUseToolFn` via `evaluatorToCanUseTool()`, then passes it through to the `ChatExecutor` as `canUseTool`. With no rules the seam is not wired and the existing approval flow remains the only gate.
- `chat-executor-factory.ts`: export `buildPermissionRulesFromAllowDeny` helper that converts gateway config tool allow/deny lists into the `ToolRule[]` shape. Deny rules come first so they preempt allow matches.
- `daemon.ts`: thread the `policy.toolAllowList` / `policy.toolDenyList` through `createChatExecutor` at both construction sites (initial `configureChannelHosts` + `hotSwapLLMProvider`).

## Effect
The runtime now has a unified permission seam that runs every tool call through the `policy/glob.ts` `matchToolPattern` matcher (Cut 7.1) before the existing `tool-handler-factory` approval flow. Future work can migrate `policy/engine.ts:evaluate()` callers to construct evaluators of their own.

## Risk model
With no policy configured (the default), the rules array is empty and the seam is skipped — behavior unchanged.

## Test plan
- [x] tsc --noEmit clean
- [x] runtime test suite: 6,283 passing (matches Cut 5.3 baseline)