### PR TITLE
refactor(runtime): drop write-only delegationBudgetSnapshot field (Cut 2.5)

### DIFF
--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -45,14 +45,12 @@ import type {
 } from "../workflow/verification-obligations.js";
 import type { DelegationDecision, DelegationDecisionConfig } from "./delegation-decision.js";
 import type {
-  DelegationBudgetSnapshot,
   RuntimeEconomicsPolicy,
   RuntimeEconomicsState,
   RuntimeEconomicsSummary,
   RuntimeRunClass,
 } from "./run-budget.js";
 import {
-  buildDelegationBudgetSnapshot,
   createRuntimeEconomicsState,
 } from "./run-budget.js";
 import type { ModelRoutingPolicy } from "./model-routing-policy.js";
@@ -777,7 +775,6 @@ export interface ExecutionContext {
   plannerSummaryState: FullPlannerSummaryState;
   completedRequestMilestoneIds: readonly string[];
   economicsState: RuntimeEconomicsState;
-  delegationBudgetSnapshot?: DelegationBudgetSnapshot;
 }
 
 // ============================================================================
@@ -949,9 +946,5 @@ export function buildDefaultExecutionContext(
     },
     completedRequestMilestoneIds: [],
     economicsState,
-    delegationBudgetSnapshot: buildDelegationBudgetSnapshot(
-      config.economicsPolicy,
-      economicsState,
-    ),
   };
 }

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -89,7 +89,6 @@ import type {
   ExecutionContext,
 } from "./chat-executor-types.js";
 import {
-  buildDelegationBudgetSnapshot,
   buildRuntimeEconomicsPolicy,
   buildRuntimeEconomicsSummary,
   getRuntimeBudgetPressure,
@@ -1123,10 +1122,6 @@ export class ChatExecutor {
       phase: input.phase,
       reason: routingDecision.route.reason,
     });
-    ctx.delegationBudgetSnapshot = buildDelegationBudgetSnapshot(
-      this.economicsPolicy,
-      ctx.economicsState,
-    );
     ctx.callUsage.push(
       this.createCallUsageRecord({
         callIndex: ++ctx.callIndex,


### PR DESCRIPTION
Small Cut 2.5 follow-up: `ctx.delegationBudgetSnapshot` was assigned in `callModelForPhase` but never read by any caller.

## Changes
- Drop the field from `ExecutionContext`
- Drop the default-value initializer in `buildDefaultExecutionContext`
- Drop the write site in `chat-executor.callModelForPhase`
- Drop the now-unused `buildDelegationBudgetSnapshot` import + `DelegationBudgetSnapshot` type import

## Test plan
- [x] tsc --noEmit clean
- [x] runtime test suite: 6,283 passing