### PR TITLE
refactor(runtime): drop dead evaluator + delegationPolicyTuning state (Cut 2.5)

### DIFF
--- a/runtime/src/gateway/chat-executor-factory.ts
+++ b/runtime/src/gateway/chat-executor-factory.ts
@@ -17,10 +17,6 @@ import type {
   SkillInjector,
 } from "../llm/chat-executor-types.js";
 import type { LLMProvider, ToolHandler } from "../llm/types.js";
-import type {
-  DelegationBanditPolicyTuner,
-  DelegationTrajectorySink,
-} from "../llm/delegation-learning.js";
 import type { HostToolingProfile } from "./host-tooling.js";
 import type { ResolvedSubAgentRuntimeConfig } from "./subagent-infrastructure.js";
 import type { GatewayLLMConfig } from "./types.js";
@@ -94,12 +90,6 @@ export interface CreateChatExecutorParams {
   subagentConfig: ResolvedSubAgentRuntimeConfig;
   /** Callback to resolve dynamic delegation score threshold. */
   resolveDelegationScoreThreshold: () => number;
-  /** Delegation learning sinks. */
-  delegationLearning?: {
-    trajectorySink?: DelegationTrajectorySink;
-    banditTuner?: DelegationBanditPolicyTuner;
-    defaultStrategyArmId?: string;
-  };
   /** Callback to resolve host tooling profile. */
   resolveHostToolingProfile: () => HostToolingProfile | null;
   /** Callback to resolve canonical host workspace root. */
@@ -200,12 +190,6 @@ export function createChatExecutor(
     subagentVerifier: {
       enabled: subagentConfig.enabled,
       force: subagentConfig.forceVerifier,
-    },
-    delegationLearning: {
-      trajectorySink: params.delegationLearning?.trajectorySink,
-      banditTuner: params.delegationLearning?.banditTuner,
-      defaultStrategyArmId:
-        params.delegationLearning?.defaultStrategyArmId ?? "balanced",
     },
     toolCallTimeoutMs: llmConfig?.toolCallTimeoutMs,
     requestTimeoutMs: llmConfig?.requestTimeoutMs,

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -1966,11 +1966,6 @@ export class DaemonManager {
       subagentConfig: resolvedSubAgentConfig,
       resolveDelegationScoreThreshold: () =>
         this.resolveDelegationScoreThreshold(),
-      delegationLearning: {
-        trajectorySink: this._delegationTrajectorySink ?? undefined,
-        banditTuner: this._delegationBanditTuner ?? undefined,
-        defaultStrategyArmId: "balanced",
-      },
       resolveHostToolingProfile: () => this._hostToolingProfile,
       resolveHostWorkspaceRoot: () => this._hostWorkspacePath,
       pipelineExecutor: plannerPipelineExecutor,
@@ -3486,11 +3481,6 @@ export class DaemonManager {
         subagentConfig: resolvedSubAgentConfig,
         resolveDelegationScoreThreshold: () =>
           this.resolveDelegationScoreThreshold(),
-        delegationLearning: {
-          trajectorySink: this._delegationTrajectorySink ?? undefined,
-          banditTuner: this._delegationBanditTuner ?? undefined,
-          defaultStrategyArmId: "balanced",
-        },
         resolveHostToolingProfile: () => this._hostToolingProfile,
         resolveHostWorkspaceRoot: () => this._hostWorkspacePath,
         pipelineExecutor: plannerPipelineExecutor,

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -61,10 +61,6 @@ import type {
 import type { HostToolingProfile } from "../gateway/host-tooling.js";
 import type { ArtifactTaskContract } from "./chat-executor-artifact-task.js";
 import type { ActiveTaskContext, TurnExecutionContract } from "./turn-execution-contract-types.js";
-import type {
-  DelegationBanditPolicyTuner,
-  DelegationTrajectorySink,
-} from "./delegation-learning.js";
 import { RuntimeError, RuntimeErrorCodes } from "../types/errors.js";
 
 // ============================================================================
@@ -299,19 +295,6 @@ export interface ChatPlannerSummary {
     readonly confidence: number;
     readonly unresolvedItems: readonly string[];
   };
-  /** Online policy tuning diagnostics for delegation arm selection. */
-  readonly delegationPolicyTuning?: {
-    readonly enabled: boolean;
-    readonly contextClusterId?: string;
-    readonly selectedArmId?: string;
-    readonly selectedArmReason?: string;
-    readonly tunedThreshold?: number;
-    readonly exploration: boolean;
-    readonly finalReward?: number;
-    readonly usefulDelegation?: boolean;
-    readonly usefulDelegationScore?: number;
-    readonly rewardProxyVersion?: string;
-  };
 }
 
 export interface PlannerDiagnostic {
@@ -376,8 +359,6 @@ export interface ChatExecutorResult {
   readonly stopReasonDetail?: string;
   /** Optional delegated-output validation code associated with a validation_error stop. */
   readonly validationCode?: DelegationOutputValidationCode;
-  /** Result of response evaluation, if evaluator is configured. */
-  readonly evaluation?: EvaluationResult;
 }
 
 /** Minimal pipeline executor interface required by ChatExecutor planner path. */
@@ -467,8 +448,6 @@ export interface ChatExecutorConfig {
   readonly sessionCompactionThreshold?: number;
   /** Callback when context compaction occurs (budget recovery). */
   readonly onCompaction?: (sessionId: string, summary: string) => void;
-  /** Optional response evaluator/critic configuration. */
-  readonly evaluator?: EvaluatorConfig;
   /** Optional provider that injects self-learning context per message. */
   readonly learningProvider?: MemoryRetriever;
   /** Optional provider that injects cross-session progress context per message. */
@@ -511,12 +490,6 @@ export interface ChatExecutorConfig {
     /** Max verification rounds (initial verification included). */
     readonly maxRounds?: number;
   };
-  /** Optional delegation learning hooks (trajectory sink + online bandit tuner). */
-  readonly delegationLearning?: {
-    readonly trajectorySink?: DelegationTrajectorySink;
-    readonly banditTuner?: DelegationBanditPolicyTuner;
-    readonly defaultStrategyArmId?: string;
-  };
   /** Maximum tool calls allowed for a single execute() invocation. */
   readonly toolBudgetPerRequest?: number;
   /** Maximum model recalls (calls after the first) for a single execute() invocation. 0 = unlimited. */
@@ -541,27 +514,6 @@ export interface ChatExecutorConfig {
   readonly modelRoutingPolicy?: ModelRoutingPolicy;
   /** Force all calls in this executor instance into one run class (used for child runs). */
   readonly defaultRunClass?: RuntimeRunClass;
-}
-
-// ============================================================================
-// Evaluator types
-// ============================================================================
-
-/** Configuration for optional response evaluation/critic. */
-export interface EvaluatorConfig {
-  readonly rubric?: string;
-  /** Minimum score (0.0–1.0) to accept the response. Default: 0.7. */
-  readonly minScore?: number;
-  /** Maximum retry attempts when score is below threshold. Default: 1. */
-  readonly maxRetries?: number;
-}
-
-/** Result of a response evaluation. */
-export interface EvaluationResult {
-  readonly score: number;
-  readonly feedback: string;
-  readonly passed: boolean;
-  readonly retryCount: number;
 }
 
 // ============================================================================
@@ -673,18 +625,6 @@ export interface FullPlannerSummaryState extends MutablePlannerSummaryState {
   plannedSteps: number;
   estimatedRecallsAvoided: number;
   delegationDecision: DelegationDecision | undefined;
-  delegationPolicyTuning: {
-    enabled: boolean;
-    contextClusterId: string | undefined;
-    selectedArmId: string | undefined;
-    selectedArmReason: string | undefined;
-    tunedThreshold: number | undefined;
-    exploration: boolean;
-    finalReward: number | undefined;
-    usefulDelegation: boolean | undefined;
-    usefulDelegationScore: number | undefined;
-    rewardProxyVersion: string | undefined;
-  };
 }
 
 /** Loop-local mutable state shared across tool calls within a single round. */
@@ -760,7 +700,6 @@ export interface ExecutionContext {
   providerName: string;
   responseModel?: string;
   response?: LLMResponse;
-  evaluation?: EvaluationResult;
   finalContent: string;
   compacted: boolean;
   compactedArtifactContext?: ArtifactCompactionState;
@@ -815,7 +754,6 @@ export interface BuildExecutionContextConfig {
   readonly providerName: string;
   readonly plannerEnabled: boolean;
   readonly subagentVerifierEnabled: boolean;
-  readonly delegationBanditTunerEnabled: boolean;
   readonly delegationScoreThreshold: number;
   readonly defaultRunClass?: RuntimeRunClass;
   readonly economicsPolicy: RuntimeEconomicsPolicy;
@@ -900,7 +838,6 @@ export function buildDefaultExecutionContext(
     providerName: config.providerName,
     responseModel: undefined,
     response: undefined,
-    evaluation: undefined,
     finalContent: "",
     compacted: params.compacted,
     compactedArtifactContext: params.stateful?.artifactContext,
@@ -930,18 +867,6 @@ export function buildDefaultExecutionContext(
         overall: "skipped" as "pass" | "retry" | "fail" | "skipped",
         confidence: 1,
         unresolvedItems: [] as string[],
-      },
-      delegationPolicyTuning: {
-        enabled: config.delegationBanditTunerEnabled,
-        contextClusterId: undefined as string | undefined,
-        selectedArmId: undefined as string | undefined,
-        selectedArmReason: undefined as string | undefined,
-        tunedThreshold: undefined as number | undefined,
-        exploration: false,
-        finalReward: undefined as number | undefined,
-        usefulDelegation: undefined as boolean | undefined,
-        usefulDelegationScore: undefined as number | undefined,
-        rewardProxyVersion: undefined as string | undefined,
       },
     },
     completedRequestMilestoneIds: [],

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -45,9 +45,6 @@ import {
   resolveDelegationDecisionConfig,
   type ResolvedDelegationDecisionConfig,
 } from "./delegation-decision.js";
-import type {
-  DelegationBanditPolicyTuner,
-} from "./delegation-learning.js";
 import type { HookRegistry } from "./hooks/index.js";
 import type { CanUseToolFn } from "./can-use-tool.js";
 import type { IsConcurrencySafeFn } from "./tool-orchestration.js";
@@ -314,8 +311,6 @@ export type {
   LLMRetryPolicyOverrides,
   ToolFailureCircuitBreakerConfig,
   ChatExecutorConfig,
-  EvaluatorConfig,
-  EvaluationResult,
 } from "./chat-executor-types.js";
 
 
@@ -351,7 +346,6 @@ export class ChatExecutor {
   private readonly delegationDecisionConfig: ResolvedDelegationDecisionConfig;
   private readonly resolveDelegationScoreThreshold?: () => number | undefined;
   private readonly subagentVerifierConfig: ResolvedSubagentVerifierConfig;
-  private readonly delegationBanditTuner?: DelegationBanditPolicyTuner;
   private readonly toolBudgetPerRequest: number;
   private readonly maxModelRecallsPerRequest: number;
   private readonly maxFailureBudgetPerRequest: number;
@@ -465,7 +459,6 @@ export class ChatExecutor {
     this.subagentVerifierConfig = ChatExecutor.resolveSubagentVerifierConfig(
       config.subagentVerifier,
     );
-    this.delegationBanditTuner = config.delegationLearning?.banditTuner;
     this.toolBudgetPerRequest = normalizeRuntimeLimit(
       config.toolBudgetPerRequest,
       DEFAULT_TOOL_BUDGET_PER_REQUEST,
@@ -649,7 +642,6 @@ export class ChatExecutor {
       activeTaskContext: deriveActiveTaskContext(ctx.turnExecutionContract),
       stopReasonDetail: ctx.stopReasonDetail,
       validationCode: ctx.validationCode,
-      evaluation: ctx.evaluation,
     };
   }
 
@@ -1325,7 +1317,6 @@ export class ChatExecutor {
         providerName: this.providers[0]?.name ?? "unknown",
         plannerEnabled: this.plannerEnabled,
         subagentVerifierEnabled: this.subagentVerifierConfig.enabled,
-        delegationBanditTunerEnabled: Boolean(this.delegationBanditTuner),
         delegationScoreThreshold: this.delegationDecisionConfig.scoreThreshold,
         defaultRunClass: this.defaultRunClass,
         economicsPolicy: this.economicsPolicy,


### PR DESCRIPTION
## Summary

The chat-executor evaluator/critic seam (`EvaluatorConfig`, `EvaluationResult`, `ChatExecutorConfig.evaluator`, `ExecutionContext.evaluation`, `ChatExecutorResult.evaluation`) has no runtime consumer. \`ctx.evaluation\` is initialized to undefined and forwarded once into the result envelope; nothing ever sets it.

The \`delegationPolicyTuning\` subtree on \`FullPlannerSummaryState\`/\`ChatPlannerSummary\` and its companion \`BuildExecutionContextConfig.delegationBanditTunerEnabled\` flag are written once at init and never read or mutated by any executor or test path.

The entire \`ChatExecutorConfig.delegationLearning\` hook bundle (\`trajectorySink\`, \`banditTuner\`, \`defaultStrategyArmId\`) is plumbed daemon -> factory -> ChatExecutor but the chat-executor never consumes it. The live trajectory sink wiring goes through SubAgentOrchestrator's own \`resolveTrajectorySink\`.

Drops all four pieces of state plus their initializers, type imports, and the daemon/factory pass-through.

- 4 files changed, 110 deletions
- runtime/src/llm/chat-executor-types.ts: -75 LOC
- runtime/src/gateway/chat-executor-factory.ts: -16 LOC
- runtime/src/gateway/daemon.ts: -10 LOC
- runtime/src/llm/chat-executor.ts: -9 LOC

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npx tsc --noEmit --noUnusedLocals --noUnusedParameters\` clean
- [x] \`npx vitest run\` — 6,284 passing / 1 failing (the pre-existing marketplace-cli LiteSVM \`DeclaredProgramIdMismatch\`, unrelated)