### PR TITLE
refactor(runtime): drop dead DelegationDecision verdict stub (Cut 2.5)

### DIFF
--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -43,7 +43,7 @@ import type { WorkflowProgressSnapshot } from "../workflow/completion-progress.j
 import type {
   WorkflowVerificationContract,
 } from "../workflow/verification-obligations.js";
-import type { DelegationDecision, DelegationDecisionConfig } from "./delegation-decision.js";
+import type { DelegationDecisionConfig } from "./delegation-decision.js";
 import type {
   RuntimeEconomicsPolicy,
   RuntimeEconomicsState,
@@ -284,8 +284,6 @@ export interface ChatPlannerSummary {
   readonly estimatedRecallsAvoided: number;
   /** Structured planner parse/validation/policy diagnostics for this turn. */
   readonly diagnostics?: readonly PlannerDiagnostic[];
-  /** Sub-agent delegation utility decision for planner-emitted subagent tasks. */
-  readonly delegationDecision?: DelegationDecision;
   /** Sub-agent verification/critic pass summary. */
   readonly subagentVerification?: {
     readonly enabled: boolean;
@@ -624,7 +622,6 @@ export interface FullPlannerSummaryState extends MutablePlannerSummaryState {
   plannerCalls: number;
   plannedSteps: number;
   estimatedRecallsAvoided: number;
-  delegationDecision: DelegationDecision | undefined;
 }
 
 /** Loop-local mutable state shared across tool calls within a single round. */
@@ -859,7 +856,6 @@ export function buildDefaultExecutionContext(
       deterministicStepsExecuted: 0,
       estimatedRecallsAvoided: 0,
       diagnostics: [] as PlannerDiagnostic[],
-      delegationDecision: undefined as DelegationDecision | undefined,
       subagentVerification: {
         enabled: config.subagentVerifierEnabled,
         performed: false,

--- a/runtime/src/llm/delegation-decision.ts
+++ b/runtime/src/llm/delegation-decision.ts
@@ -1,5 +1,5 @@
 /**
- * Delegation decision — collapsed stub (Cut 1.2).
+ * Delegation decision config — collapsed stub (Cut 1.2).
  *
  * Replaces the previous 619-LOC `assessDelegationDecision()` machinery
  * (utility scoring, decomposition benefit, coordination overhead,
@@ -7,15 +7,11 @@
  * fanout/depth caps). The planner subsystem that consumed this output
  * has been deleted; live delegation now flows through
  * `gateway/delegation-admission.ts::assessDelegationAdmission` which
- * applies hard-rejection-only gates. The exported types are kept as
- * tiny shapes so chat-executor configuration call sites still parse.
+ * applies hard-rejection-only gates. Only the config shape survives so
+ * the chat-executor constructor can still parse it.
  *
  * @module
  */
-
-export type DelegationDecisionReason =
-  | "delegation_disabled"
-  | "approved";
 
 export type DelegationHardBlockedTaskClass =
   | "wallet_signing"
@@ -23,22 +19,6 @@ export type DelegationHardBlockedTaskClass =
   | "stake_or_rewards"
   | "destructive_host_mutation"
   | "credential_exfiltration";
-
-export type DelegationHardBlockedMatchSource = "capability" | "text";
-
-/**
- * Minimal delegation verdict shape kept for ExecutionContext plumbing.
- * The rich scoring output (utilityScore, decompositionBenefit,
- * coordinationOverhead, latencyCostRisk, safetyRisk, ...) was produced
- * by the deleted assessDelegationDecision pipeline. The runtime now
- * only distinguishes approved vs delegation_disabled outcomes.
- */
-export interface DelegationDecision {
-  readonly shouldDelegate: boolean;
-  readonly reason: DelegationDecisionReason;
-  readonly hardBlockedTaskClass: DelegationHardBlockedTaskClass | null;
-  readonly hardBlockedTaskClassSource: DelegationHardBlockedMatchSource | null;
-}
 
 export interface DelegationDecisionConfig {
   readonly enabled?: boolean;

--- a/runtime/src/llm/index.ts
+++ b/runtime/src/llm/index.ts
@@ -131,8 +131,6 @@ export {
 } from "./delegation-decision.js";
 export type {
   DelegationDecisionConfig,
-  DelegationDecisionReason,
-  DelegationDecision,
   ResolvedDelegationDecisionConfig,
 } from "./delegation-decision.js";
 


### PR DESCRIPTION
## Summary

The \`DelegationDecision\` interface in \`delegation-decision.ts\` was kept as a stub when \`assessDelegationDecision()\` was deleted in Cut 1.2, so that the chat-executor's planner-summary state plumbing still parsed. Every consumer was removed in the same cut:

- \`ChatPlannerSummary.delegationDecision\` — unread by any consumer
- \`FullPlannerSummaryState.delegationDecision\` — unread, never written after init
- \`buildDefaultExecutionContext\` writes \`undefined\` and nothing reads it

Drop the public field, the internal mutable field, the init slot, the \`DelegationDecision\` interface itself, and the now-unused \`DelegationDecisionReason\` and \`DelegationHardBlockedMatchSource\` helper types it referenced. Drop their re-exports from \`llm/index.ts\`. The \`DelegationDecisionConfig\` + \`ResolvedDelegationDecisionConfig\` types stay because the chat-executor constructor still consumes them.

3 files changed, 26 deletions.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] focused tests pass: \`delegation-decision.test.ts\`, \`delegation-learning.test.ts\`, \`background-run-supervisor.test.ts\` (182/183 passing, 1 pre-existing skip)