### PR TITLE
refactor(runtime): drop dead baseDelegationThreshold plumbing (Cut 2.5)

### DIFF
--- a/runtime/src/gateway/chat-executor-factory.test.ts
+++ b/runtime/src/gateway/chat-executor-factory.test.ts
@@ -62,7 +62,6 @@ describe("createChatExecutor", () => {
         plannerEnabled: true,
       } as GatewayLLMConfig,
       subagentConfig: createSubagentConfig(),
-      resolveDelegationScoreThreshold: () => 0,
       resolveHostToolingProfile: () => null,
       resolveHostWorkspaceRoot: () => null,
     });

--- a/runtime/src/gateway/chat-executor-factory.ts
+++ b/runtime/src/gateway/chat-executor-factory.ts
@@ -88,8 +88,6 @@ export interface CreateChatExecutorParams {
   providerConfigs?: readonly GatewayLLMConfig[];
   /** Resolved subagent runtime config. */
   subagentConfig: ResolvedSubAgentRuntimeConfig;
-  /** Callback to resolve dynamic delegation score threshold. */
-  resolveDelegationScoreThreshold: () => number;
   /** Callback to resolve host tooling profile. */
   resolveHostToolingProfile: () => HostToolingProfile | null;
   /** Callback to resolve canonical host workspace root. */
@@ -186,7 +184,6 @@ export function createChatExecutor(
         subagentConfig.handoffMinPlannerConfidence,
       hardBlockedTaskClasses: subagentConfig.hardBlockedTaskClasses,
     },
-    resolveDelegationScoreThreshold: params.resolveDelegationScoreThreshold,
     subagentVerifier: {
       enabled: subagentConfig.enabled,
       force: subagentConfig.forceVerifier,

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -1964,8 +1964,6 @@ export class DaemonManager {
       llmConfig: config.llm,
       providerConfigs: this._llmProviderConfigCatalog.map((entry) => entry.config),
       subagentConfig: resolvedSubAgentConfig,
-      resolveDelegationScoreThreshold: () =>
-        this.resolveDelegationScoreThreshold(),
       resolveHostToolingProfile: () => this._hostToolingProfile,
       resolveHostWorkspaceRoot: () => this._hostWorkspacePath,
       pipelineExecutor: plannerPipelineExecutor,
@@ -3479,8 +3477,6 @@ export class DaemonManager {
         llmConfig: newConfig.llm,
         providerConfigs: this._llmProviderConfigCatalog.map((entry) => entry.config),
         subagentConfig: resolvedSubAgentConfig,
-        resolveDelegationScoreThreshold: () =>
-          this.resolveDelegationScoreThreshold(),
         resolveHostToolingProfile: () => this._hostToolingProfile,
         resolveHostWorkspaceRoot: () => this._hostWorkspacePath,
         pipelineExecutor: plannerPipelineExecutor,

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -475,8 +475,6 @@ export interface ChatExecutorConfig {
   readonly pipelineExecutor?: DeterministicPipelineExecutor;
   /** Delegation utility scoring controls for planner-emitted subagent tasks. */
   readonly delegationDecision?: DelegationDecisionConfig;
-  /** Optional live resolver for delegation threshold overrides. */
-  readonly resolveDelegationScoreThreshold?: () => number | undefined;
   /** Optional verifier/critic loop for planner-emitted subagent outputs. */
   readonly subagentVerifier?: {
     /** Enable verifier flow for planner-emitted subagent steps. */
@@ -665,7 +663,6 @@ export interface ExecutionContext {
   readonly canExpandOnRoutingMiss: boolean;
   readonly hasHistory: boolean;
   readonly plannerDecision: PlannerDecision;
-  readonly baseDelegationThreshold: number;
   readonly toolRouting?: ChatExecuteParams["toolRouting"];
   readonly stateful?: ChatExecuteParams["stateful"];
   readonly requiredToolEvidence?: {
@@ -737,7 +734,6 @@ export interface BuildExecutionContextParams {
   readonly trace?: ChatExecuteParams["trace"];
   readonly initialRoutedToolNames: readonly string[];
   readonly expandedRoutedToolNames: readonly string[];
-  readonly baseDelegationThreshold: number;
 }
 
 /** Configuration values from ChatExecutor instance needed for context building. */
@@ -794,7 +790,6 @@ export function buildDefaultExecutionContext(
     ),
     hasHistory,
     plannerDecision: params.plannerDecision,
-    baseDelegationThreshold: params.baseDelegationThreshold,
     toolRouting: params.toolRouting,
     stateful: params.stateful,
     trace: params.trace,

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -344,7 +344,6 @@ export class ChatExecutor {
   private readonly plannerEnabled: boolean;
   private readonly plannerMaxTokens: number;
   private readonly delegationDecisionConfig: ResolvedDelegationDecisionConfig;
-  private readonly resolveDelegationScoreThreshold?: () => number | undefined;
   private readonly subagentVerifierConfig: ResolvedSubagentVerifierConfig;
   private readonly toolBudgetPerRequest: number;
   private readonly maxModelRecallsPerRequest: number;
@@ -454,7 +453,6 @@ export class ChatExecutor {
     this.delegationDecisionConfig = resolveDelegationDecisionConfig(
       config.delegationDecision,
     );
-    this.resolveDelegationScoreThreshold = config.resolveDelegationScoreThreshold;
     this.resolveHostWorkspaceRoot = config.resolveHostWorkspaceRoot;
     this.subagentVerifierConfig = ChatExecutor.resolveSubagentVerifierConfig(
       config.subagentVerifier,
@@ -1225,12 +1223,6 @@ export class ChatExecutor {
         reason: "grounded_execution_request",
       };
     }
-    const resolvedThresholdOverride = this.resolveDelegationScoreThreshold?.();
-    const baseDelegationThreshold =
-      typeof resolvedThresholdOverride === "number" &&
-        Number.isFinite(resolvedThresholdOverride)
-        ? Math.max(0, Math.min(1, resolvedThresholdOverride))
-        : this.delegationDecisionConfig.scoreThreshold;
 
     // Pre-check token budget — attempt compaction instead of hard fail
     let compacted = false;
@@ -1304,7 +1296,6 @@ export class ChatExecutor {
         requiredToolEvidence: resolvedRequiredToolEvidence,
         initialRoutedToolNames,
         expandedRoutedToolNames,
-        baseDelegationThreshold,
       },
       {
         maxToolRounds: effectiveMaxToolRounds,


### PR DESCRIPTION
## Summary

The chat-executor's \`baseDelegationThreshold\` field on \`ExecutionContext\` is computed from \`resolveDelegationScoreThreshold\` and stashed on the context, but no executor or sibling file ever reads it. The \`resolveDelegationScoreThreshold\` callback was forwarded daemon -> factory -> ChatExecutor -> \`ctx.baseDelegationThreshold\` and stopped there.

The daemon's own private \`resolveDelegationScoreThreshold\` method survives because \`daemon-command-registry\` uses it through the unrelated \`CommandContext\` interface to display delegation status.

Drops:
- \`ctx.baseDelegationThreshold\` (ExecutionContext + builder param + builder writer)
- The \`baseDelegationThreshold\` calculation in \`chat-executor.ts\` (\`resolvedThresholdOverride\` + clamp), now ~7 LOC of dead math
- \`ChatExecutorConfig.resolveDelegationScoreThreshold\` + \`ChatExecutor.resolveDelegationScoreThreshold\` private field + constructor assignment
- \`CreateChatExecutorParams.resolveDelegationScoreThreshold\` + the factory pass-through
- Both daemon \`createChatExecutor\` callsites + the test fixture entry on \`chat-executor-factory.test.ts\`

5 files changed, 22 deletions.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] focused tests pass: \`chat-executor-factory.test.ts\`, \`daemon-command-registry.test.ts\`, \`background-run-supervisor.test.ts\` (77/78 passing, 1 pre-existing skip)