### PR TITLE
refactor(runtime): trim chat-executor-planner stubs to live surface (Cut 2.5)

### DIFF
--- a/runtime/src/llm/chat-executor-planner.ts
+++ b/runtime/src/llm/chat-executor-planner.ts
@@ -5,61 +5,17 @@
  * bullet counting, verification cue detection, complexity scoring,
  * planner routing heuristics, imperative tool extraction, artifact
  * target inference). The planner subsystem has been deleted; every
- * planner decision is now a no-op `shouldPlan: false`. The only
- * helper that survives is `safeStepStringArray` — still used by the
- * gateway subagent stack when parsing untrusted LLM output.
+ * planner decision is now a no-op `shouldPlan: false`. Only the four
+ * helpers consumed by chat-executor.ts survive: assessPlannerDecision,
+ * extractExplicitDeterministicToolRequirements,
+ * extractExplicitSubagentOrchestrationRequirements,
+ * requestRequiresToolGroundedExecution.
  *
  * @module
  */
 
 import type { LLMMessage } from "./types.js";
-import type { LLMPipelineStopReason } from "./policy.js";
 import type { PlannerDecision } from "./chat-executor-types.js";
-
-export function safeStepStringArray(
-  value: unknown,
-): readonly string[] {
-  if (Array.isArray(value)) {
-    return value.filter(
-      (entry): entry is string =>
-        typeof entry === "string" && entry.trim().length > 0,
-    );
-  }
-  return [];
-}
-
-interface PlannerRequestSignals {
-  readonly normalized: string;
-  readonly hasMultiStepCue: boolean;
-  readonly hasToolDiversityCue: boolean;
-  readonly hasDelegationCue: boolean;
-  readonly hasImplementationScopeCue: boolean;
-  readonly hasVerificationCue: boolean;
-  readonly hasDocumentationCue: boolean;
-  readonly longTask: boolean;
-  readonly structuredBulletCount: number;
-  readonly priorToolMessages: number;
-  readonly hasPriorNoProgressSignal: boolean;
-}
-
-export function collectPlannerRequestSignals(
-  messageText: string,
-  _history: readonly LLMMessage[],
-): PlannerRequestSignals {
-  return {
-    normalized: messageText.toLowerCase(),
-    hasMultiStepCue: false,
-    hasToolDiversityCue: false,
-    hasDelegationCue: false,
-    hasImplementationScopeCue: false,
-    hasVerificationCue: false,
-    hasDocumentationCue: false,
-    longTask: false,
-    structuredBulletCount: 0,
-    priorToolMessages: 0,
-    hasPriorNoProgressSignal: false,
-  };
-}
 
 export function assessPlannerDecision(
   _plannerEnabled: boolean,
@@ -74,23 +30,11 @@ export function assessPlannerDecision(
   };
 }
 
-export function isDialogueOnlyDirectTurnMessage(_messageText: string): boolean {
-  return false;
-}
-
 export function requestRequiresToolGroundedExecution(
   _messageText: string,
 ): boolean {
   return false;
 }
-
-export function requestExplicitlyRequestsDelegation(
-  _messageText: string,
-): boolean {
-  return false;
-}
-
-export type { PlannerPlanArtifactIntent } from "./chat-executor-types.js";
 
 export function extractExplicitSubagentOrchestrationRequirements(
   _messageText: string,
@@ -109,26 +53,4 @@ export function extractExplicitDeterministicToolRequirements(
   _metadata?: unknown,
 ): ExplicitDeterministicToolRequirements | undefined {
   return undefined;
-}
-
-export function extractPlannerArtifactTargets(
-  _messageText: string,
-): readonly string[] {
-  return [];
-}
-
-export function extractPlannerSourceArtifactTargets(
-  _messageText: string,
-): readonly string[] {
-  return [];
-}
-
-export function sanitizePlannerStepName(name: string): string {
-  return name.trim().toLowerCase().replace(/\s+/g, "_");
-}
-
-export function isPipelineStopReasonHint(
-  _value: unknown,
-): _value is LLMPipelineStopReason {
-  return false;
 }

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -528,44 +528,9 @@ export interface PlannerDecision {
   artifactTargets?: readonly string[];
 }
 
-export type PlannerStepType = "deterministic_tool" | "subagent_task" | "synthesis";
-
-export type PlannerPlanArtifactIntent =
-  | "none"
-  | "grounded_plan_generation"
-  | "edit_artifact"
-  | "implement_from_artifact";
-
-export type SubagentVerifierStepVerdict = "pass" | "retry" | "fail";
-
-export interface SubagentVerifierStepAssessment {
-  readonly name: string;
-  readonly verdict: SubagentVerifierStepVerdict;
-  readonly confidence: number;
-  readonly retryable: boolean;
-  readonly issues: readonly string[];
-  readonly summary: string;
-}
-
-export interface SubagentVerifierDecision {
-  readonly overall: "pass" | "retry" | "fail";
-  readonly confidence: number;
-  readonly unresolvedItems: readonly string[];
-  readonly steps: readonly SubagentVerifierStepAssessment[];
-  readonly source: "deterministic" | "model" | "merged";
-}
-
 export interface MutablePlannerSummaryState {
   deterministicStepsExecuted: number;
   diagnostics: PlannerDiagnostic[];
-  /**
-   * Model-emitted plan-artifact intent classification, propagated from
-   * `PlannerPlan.planIntent`. Replaces the regex-based pre-call classifier
-   * that used to live in `chat-executor-planner.ts`. Downstream contract
-   * flow and turn-execution code reads this instead of re-running a regex
-   * against the user message.
-   */
-  plannerPlanIntent?: PlannerPlanArtifactIntent;
 }
 
 /** Full planner summary state — extends the subset used by executePlannerPipelineWithVerifier. */


### PR DESCRIPTION
## Summary

The \`chat-executor-planner.ts\` module survives Cut 1.2 only because four helpers are still consumed by \`chat-executor.ts\`:
- \`assessPlannerDecision\`
- \`extractExplicitDeterministicToolRequirements\`
- \`extractExplicitSubagentOrchestrationRequirements\`
- \`requestRequiresToolGroundedExecution\`

The other stub functions and types had zero callers anywhere in the runtime, tests, or external packages:
- \`safeStepStringArray\` (the live copy in \`chat-executor-step-utils.ts\` is what gateway/* uses)
- \`collectPlannerRequestSignals\` + \`PlannerRequestSignals\` interface
- \`isDialogueOnlyDirectTurnMessage\`
- \`requestExplicitlyRequestsDelegation\`
- \`extractPlannerArtifactTargets\`
- \`extractPlannerSourceArtifactTargets\`
- \`sanitizePlannerStepName\`
- \`isPipelineStopReasonHint\` (the live copy is in \`gateway/subagent-orchestrator-types.ts\`)
- the \`PlannerPlanArtifactIntent\` re-export

The \`PlannerPlanArtifactIntent\` type itself and the \`MutablePlannerSummaryState.plannerPlanIntent\` field that referenced it were dead end-to-end (declared, never written or read). \`PlannerStepType\`, \`SubagentVerifierStepVerdict\`, \`SubagentVerifierStepAssessment\`, and \`SubagentVerifierDecision\` are also dead types from the deleted planner verifier subsystem.

Rewrites \`chat-executor-planner.ts\` to keep only the four live exports + \`ExplicitDeterministicToolRequirements\` (consumed via the \`extractExplicitDeterministicToolRequirements\` return type) + the necessary imports. Drops the dead types from \`chat-executor-types.ts\`.

2 files changed, 118 deletions.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npx tsc --noEmit --noUnusedLocals --noUnusedParameters\` clean
- [x] focused tests pass: \`chat-executor.test.ts\` (107/107 passing)