### PR TITLE
refactor(runtime): drop 3 dead helpers from run-budget stub (Cut 1.2)

### DIFF
--- a/runtime/src/llm/run-budget.ts
+++ b/runtime/src/llm/run-budget.ts
@@ -196,14 +196,6 @@ export function createRuntimeEconomicsState(): RuntimeEconomicsState {
   };
 }
 
-export function estimateSpendUnitsForUsage(_params: {
-  readonly usage: LLMUsage;
-  readonly provider?: string;
-  readonly model?: string;
-}): number {
-  return 0;
-}
-
 export function getRuntimeBudgetPressure(
   _policy: RuntimeEconomicsPolicy,
   _state: RuntimeEconomicsState,
@@ -232,32 +224,6 @@ export function recordRuntimeModelCall(_params: {
   readonly reason?: string;
 }): void {
   // no-op
-}
-
-export function recordRuntimeDenial(
-  _state: RuntimeEconomicsState,
-  _runClass: RuntimeRunClass,
-): void {
-  // no-op
-}
-
-export function buildDelegationBudgetSnapshot(
-  policy: RuntimeEconomicsPolicy,
-  _state: RuntimeEconomicsState,
-): DelegationBudgetSnapshot {
-  return {
-    mode: policy.mode,
-    childBudget: policy.budgets.child,
-    remainingTokens: Number.POSITIVE_INFINITY,
-    remainingLatencyMs: Number.POSITIVE_INFINITY,
-    remainingSpendUnits: Number.POSITIVE_INFINITY,
-    parentTokenRatio: 0,
-    parentLatencyRatio: 0,
-    parentSpendRatio: 0,
-    childFanoutSoftCap: policy.childFanoutSoftCap,
-    negativeDelegationMarginUnits: policy.negativeDelegationMarginUnits,
-    negativeDelegationMarginTokens: policy.negativeDelegationMarginTokens,
-  };
 }
 
 export function buildRuntimeEconomicsSummary(


### PR DESCRIPTION
## Summary

\`run-budget.ts\` (Cut 1.2 stub) had 3 exported helpers with zero callers anywhere in the runtime, tests, or external packages:
- \`estimateSpendUnitsForUsage\` — always returned 0
- \`recordRuntimeDenial\` — no-op
- \`buildDelegationBudgetSnapshot\` — built a snapshot from policy defaults; never invoked

The \`DelegationBudgetSnapshot\` type itself stays because \`gateway/delegation-admission.ts\` references it as the type of an optional input field.

1 file changed, 34 deletions.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npx tsc --noEmit --noUnusedLocals --noUnusedParameters\` clean