### PR TITLE
refactor(runtime): drop dead helpers from runtime-limit + model-routing stubs (Cut 2.5)

### DIFF
--- a/runtime/src/llm/model-routing-policy.ts
+++ b/runtime/src/llm/model-routing-policy.ts
@@ -47,16 +47,6 @@ export interface ModelRouteDecision {
   readonly reason: string;
 }
 
-export type ModelRoutingWorkflowPhase =
-  | "compaction"
-  | "initial"
-  | "planner"
-  | "planner_verifier"
-  | "planner_synthesis"
-  | "tool_followup"
-  | "evaluator"
-  | "evaluator_retry";
-
 export interface ModelRouteRequirements {
   readonly statefulContinuationRequired?: boolean;
   readonly structuredOutputRequired?: boolean;

--- a/runtime/src/llm/runtime-limit-policy.ts
+++ b/runtime/src/llm/runtime-limit-policy.ts
@@ -1,5 +1,4 @@
-export const UNLIMITED_RUNTIME_LIMIT = 0;
-export const UNLIMITED_RUNTIME_REMAINING = Number.MAX_SAFE_INTEGER;
+const UNLIMITED_RUNTIME_LIMIT = 0;
 
 interface NormalizeRuntimeLimitOptions {
   readonly min?: number;
@@ -20,16 +19,6 @@ function clampLimitedRuntimeValue(
     normalized = Math.min(normalized, Math.floor(options.max));
   }
   return normalized;
-}
-
-export function isUnlimitedRuntimeLimit(
-  value: number | undefined | null,
-): boolean {
-  return (
-    typeof value === "number" &&
-    Number.isFinite(value) &&
-    Math.floor(value) <= UNLIMITED_RUNTIME_LIMIT
-  );
 }
 
 export function hasRuntimeLimit(value: number | undefined | null): boolean {
@@ -81,16 +70,6 @@ export function isRuntimeLimitExceeded(
   limit: number | undefined | null,
 ): boolean {
   return hasRuntimeLimit(limit) && used > Number(limit);
-}
-
-export function remainingRuntimeLimit(
-  used: number,
-  limit: number | undefined | null,
-): number {
-  if (!hasRuntimeLimit(limit)) {
-    return UNLIMITED_RUNTIME_REMAINING;
-  }
-  return Math.max(0, Number(limit) - used);
 }
 
 export function resolveRuntimeTimeoutMs(params: {


### PR DESCRIPTION
## Summary

Two small dead-helper sweeps in collapsed Cut 1.2 stubs:

### runtime-limit-policy.ts
- \`isUnlimitedRuntimeLimit\` (zero callers)
- \`remainingRuntimeLimit\` (zero callers)
- \`UNLIMITED_RUNTIME_REMAINING\` constant (only used by remainingRuntimeLimit)
- \`UNLIMITED_RUNTIME_LIMIT\` constant un-exported (still used internally by hasRuntimeLimit + normalizeRuntimeLimit + normalizeOptionalRuntimeLimit)

### model-routing-policy.ts
- \`ModelRoutingWorkflowPhase\` type (zero callers, parallel duplicate of \`ChatCallUsageRecord[\"phase\"]\` from chat-executor-types.ts)

2 files changed, 32 deletions.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npx tsc --noEmit --noUnusedLocals --noUnusedParameters\` clean