### PR TITLE
refactor(runtime): drop dead empty imports + stale planner doc

### DIFF
--- a/runtime/src/llm/chat-executor-recovery.ts
+++ b/runtime/src/llm/chat-executor-recovery.ts
@@ -20,7 +20,6 @@ import {
   extractToolFailureText,
   parseToolResultObject,
 } from "./chat-executor-tool-utils.js";
-import {} from "../utils/delegated-scope-trust.js";
 
 const NON_ACTIONABLE_STATEFUL_FALLBACK_REASONS = new Set<LLMStatefulFallbackReason>(["store_disabled"]);
 

--- a/runtime/src/llm/chat-executor-text.ts
+++ b/runtime/src/llm/chat-executor-text.ts
@@ -15,8 +15,6 @@ import type {
   PromptBudgetSection,
 } from "./prompt-budget.js";
 import type { ToolCallRecord, ChatPromptShape } from "./chat-executor-types.js";
-import type {} from "../workflow/completion-state.js";
-import type {} from "../workflow/completion-progress.js";
 import {
   MAX_FINAL_RESPONSE_CHARS,
   REPETITIVE_LINE_MIN_COUNT,
@@ -52,10 +50,9 @@ import {
   assessExecuteWithAgentResult,
   sanitizeDelegatedAssistantEnvironmentSummary,
 } from "../utils/delegated-scope-trust.js";
-import {} from "./chat-executor-recovery.js";
 
 // ============================================================================
-// JSON parsing helpers (used by planner + verifier)
+// JSON parsing helpers
 // ============================================================================
 
 export { parseJsonObjectFromText, tryParseObject };


### PR DESCRIPTION
## Summary

Three dead empty import statements left over from earlier cuts:
- \`chat-executor-text.ts:18\` — \`import type {} from \"../workflow/completion-state.js\"\`
- \`chat-executor-text.ts:19\` — \`import type {} from \"../workflow/completion-progress.js\"\`
- \`chat-executor-text.ts:55\` — \`import {} from \"./chat-executor-recovery.js\"\`
- \`chat-executor-recovery.ts:23\` — \`import {} from \"../utils/delegated-scope-trust.js\"\`

Also drop the misleading \"(used by planner + verifier)\" comment on the JSON parsing helpers re-export — the planner and verifier paths were deleted in Cut 1.2 / PR #225.

2 files changed, 4 deletions.

## Test plan

- [x] \`npm run typecheck\` clean