### PR TITLE
refactor(runtime): remove residual Doom comments + test fixtures (Cut 4.1)

### DIFF
--- a/runtime/src/autonomous/desktop-executor.test.ts
+++ b/runtime/src/autonomous/desktop-executor.test.ts
@@ -486,7 +486,7 @@ describe("DesktopExecutor", () => {
         }),
       );
 
-      const result = await executor.executeGoal("Doomed task", "user");
+      const result = await executor.executeGoal("Stuck task", "user");
 
       expect(result.status).toBe("stuck");
       expect(result.success).toBe(false);

--- a/runtime/src/channels/webchat/plugin.test.ts
+++ b/runtime/src/channels/webchat/plugin.test.ts
@@ -2379,7 +2379,7 @@ describe("WebChatChannel", () => {
           routeMisses: 0,
           completionGateFailures: 0,
         },
-        topTools: [{ name: 'mcp.doom.start_game', count: 1 }],
+        topTools: [{ name: 'mcp.example.start', count: 1 }],
         topStopReasons: [{ name: 'completed', count: 1 }],
       }));
       const listObservabilityTraces = vi.fn(async () => [traceDetail.summary]);

--- a/runtime/src/gateway/background-run-supervisor.test.ts
+++ b/runtime/src/gateway/background-run-supervisor.test.ts
@@ -389,7 +389,7 @@ describe("background-run-supervisor", () => {
   it("detects explicit long-running intent", () => {
     expect(
       inferBackgroundRunIntent(
-        "Start Doom and keep playing until I tell you to stop.",
+        "Start the long-running probe and keep it running until I tell you to stop.",
       ),
     ).toBe(true);
     expect(
@@ -404,7 +404,7 @@ describe("background-run-supervisor", () => {
     ).toBe(true);
     expect(
       inferBackgroundRunIntent(
-        "Play Doom defending the center, keep it smooth and aggressive, and provide periodic status updates.",
+        "Run the soak workload, keep it stable, and provide periodic status updates.",
       ),
     ).toBe(true);
     expect(inferBackgroundRunIntent("What is 2+2?")).toBe(false);
@@ -539,10 +539,10 @@ describe("background-run-supervisor", () => {
     const publishUpdate = vi.fn(async () => undefined);
     const execute = vi.fn(async () =>
       makeResult({
-        content: "Doom launched and verified.",
+        content: "Soak workload launched and verified.",
         toolCalls: [
           {
-            name: "mcp.doom.start_game",
+            name: "mcp.example.start",
             args: { async_player: true },
             result: '{"status":"running"}',
             isError: false,
@@ -555,7 +555,7 @@ describe("background-run-supervisor", () => {
       name: "supervisor",
       chat: vi.fn(async () => ({
         content:
-          '{"state":"working","userUpdate":"Doom is still running in the background.","internalSummary":"verified running","nextCheckMs":4000,"shouldNotifyUser":true}',
+          '{"state":"working","userUpdate":"Soak workload is still running in the background.","internalSummary":"verified running","nextCheckMs":4000,"shouldNotifyUser":true}',
         toolCalls: [],
         usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
         model: "supervisor-model",
@@ -576,7 +576,7 @@ describe("background-run-supervisor", () => {
 
     await supervisor.startRun({
       sessionId: "session-1",
-      objective: "Play Doom until I say stop and keep me updated.",
+      objective: "Run the soak workload until I say stop and keep me updated.",
     });
     await vi.advanceTimersByTimeAsync(0);
     await eventually(() => {
@@ -598,7 +598,7 @@ describe("background-run-supervisor", () => {
     expect(publishUpdate).toHaveBeenNthCalledWith(
       2,
       "session-1",
-      "Doom is still running in the background.",
+      "Soak workload is still running in the background.",
     );
 
     const snapshot = supervisor.getStatusSnapshot("session-1");
@@ -845,12 +845,12 @@ describe("background-run-supervisor", () => {
     const publishUpdate = vi.fn(async () => undefined);
     const execute = vi.fn(async () =>
       makeResult({
-        content: "Game not started yet. Launching Doom now.",
+        content: "Workload not started yet. Launching the soak workload now.",
         toolCalls: [
           {
-            name: "mcp.doom.get_situation_report",
+            name: "mcp.example.status",
             args: {},
-            result: "No game is running. Call start_game first.",
+            result: "No workload is running. Call start first.",
             isError: true,
             durationMs: 15,
           },
@@ -864,7 +864,7 @@ describe("background-run-supervisor", () => {
         name: "supervisor",
         chat: vi.fn(async () => ({
           content:
-            '{"state":"working","userUpdate":"Doom is running in the background.","internalSummary":"verified running","nextCheckMs":4000,"shouldNotifyUser":true}',
+            '{"state":"working","userUpdate":"Soak workload is running in the background.","internalSummary":"verified running","nextCheckMs":4000,"shouldNotifyUser":true}',
           toolCalls: [],
           usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
           model: "supervisor-model",
@@ -881,7 +881,7 @@ describe("background-run-supervisor", () => {
 
     await supervisor.startRun({
       sessionId: "session-grounded",
-      objective: "Play Doom until I say stop and keep me updated.",
+      objective: "Run the soak workload until I say stop and keep me updated.",
     });
     await vi.advanceTimersByTimeAsync(0);
 
@@ -890,8 +890,8 @@ describe("background-run-supervisor", () => {
       "session-grounded",
       expect.stringContaining("Latest cycle hit only tool errors and will retry"),
     );
-    expect(publishUpdate.mock.calls[1]?.[1]).toContain("No game is running");
-    expect(publishUpdate.mock.calls[1]?.[1]).not.toContain("Doom is running in the background.");
+    expect(publishUpdate.mock.calls[1]?.[1]).toContain("No workload is running");
+    expect(publishUpdate.mock.calls[1]?.[1]).not.toContain("Soak workload is running in the background.");
 
     const snapshot = supervisor.getStatusSnapshot("session-grounded");
     expect(snapshot?.state).toBe("working");
@@ -2249,10 +2249,10 @@ describe("background-run-supervisor", () => {
       chatExecutor: {
         execute: vi.fn(async () =>
           makeResult({
-            content: "Doom is launched and verified.",
+            content: "Soak workload is launched and verified.",
             toolCalls: [
               {
-                name: "mcp.doom.start_game",
+                name: "mcp.example.start",
                 args: { async_player: true },
                 result: '{"status":"running"}',
                 isError: false,
@@ -2276,7 +2276,7 @@ describe("background-run-supervisor", () => {
           })
           .mockResolvedValueOnce({
             content:
-              '{"state":"completed","userUpdate":"Doom setup complete.","internalSummary":"done","shouldNotifyUser":true}',
+              '{"state":"completed","userUpdate":"Soak workload setup complete.","internalSummary":"done","shouldNotifyUser":true}',
             toolCalls: [],
             usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
             model: "supervisor-model",
@@ -2293,7 +2293,7 @@ describe("background-run-supervisor", () => {
 
     await supervisor.startRun({
       sessionId: "session-until-stop",
-      objective: "Keep playing Doom until I tell you to stop.",
+      objective: "Keep running the soak workload until I tell you to stop.",
     });
     await vi.runOnlyPendingTimersAsync();
 

--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -1325,7 +1325,7 @@ describe("formatTracePayloadForLog", () => {
       callUsage: [
         {
           providerRequestMetrics: {
-            toolNames: ["mcp.doom.start_game"],
+            toolNames: ["mcp.example.start"],
             toolChoice: "required",
           },
           nested: {

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -292,10 +292,6 @@ import {
   createBackgroundRunToolAfterHook,
   createBackgroundRunWebhookRoute,
 } from "./background-run-wake-adapters.js";
-// Cut 4.1: Doom autoplay subsystem fully excised. The earlier
-// session left no-op shims here so the rest of the runtime would still
-// compile after `chat-executor-doom.ts` was deleted; this commit
-// removes both the shims and the call sites in `executeWebChatTurn`.
 import { parseBackgroundRunQualityArtifact } from "../eval/background-run-quality.js";
 import type { DelegationBenchmarkSummary } from "../eval/delegation-benchmark.js";
 import {
@@ -314,8 +310,6 @@ import {
   wireAutonomousFeatures as wireAutonomousFeaturesStandalone,
   type FeatureWiringContext,
 } from "./daemon-feature-wiring.js";
-// Cut 4.1: doom-stop-guard imports removed alongside the rest of the
-// Doom autoplay subsystem.
 import {
   ObservabilityService,
   setDefaultObservabilityService,
@@ -5449,9 +5443,6 @@ export class DaemonManager {
     }
 
     webChat.broadcastEvent("chat.inbound", { sessionId: msg.sessionId });
-    // Cut 4.1: Doom autoplay subsystem excised. The runtime no longer
-    // special-cases ViZDoom turns; the model treats `mcp.doom.*` like
-    // any other MCP tool.
 
     const activeBackgroundRun =
       this._backgroundRunSupervisor?.getStatusSnapshot(msg.sessionId);
@@ -5624,8 +5615,6 @@ export class DaemonManager {
       traceConfig,
       turnTraceId,
     });
-    // Cut 4.1: post-conversation Doom autoplay → background supervision
-    // hand-off has been removed alongside the rest of the Doom subsystem.
   }
 
   private async executeWebChatConversationTurn(params: {

--- a/runtime/src/gateway/run-domains.ts
+++ b/runtime/src/gateway/run-domains.ts
@@ -725,7 +725,6 @@ export function createGenericRunDomain(): RunDomain {
       run.blocker ? verificationFromBlocker(run.blocker) : undefined,
     detectDeterministicVerification: (run) =>
       run.blocker ? verificationFromBlocker(run.blocker) : undefined,
-    // Cut 4.1: Doom supervision native cycle removed.
   };
 }
 

--- a/runtime/src/gateway/tool-handler-factory.test.ts
+++ b/runtime/src/gateway/tool-handler-factory.test.ts
@@ -96,7 +96,7 @@ describe("createSessionToolHandler", () => {
     expect(lifecyclePayload?.toolCallId).toBeDefined();
   });
 
-  it("does not block duplicate same-turn Doom launches after a successful start", async () => {
+  it("does not block duplicate same-turn tool launches after a successful start", async () => {
     const sentMessages: ControlResponse[] = [];
     const send = vi.fn((msg: ControlResponse): void => {
       sentMessages.push(msg);
@@ -112,10 +112,10 @@ describe("createSessionToolHandler", () => {
       send,
     });
 
-    const firstResult = await handler("mcp.doom.start_game", {
+    const firstResult = await handler("mcp.example.start", {
       scenario: "defend_the_center",
     });
-    const secondResult = await handler("mcp.doom.start_game", {
+    const secondResult = await handler("mcp.example.start", {
       scenario: "defend_the_center",
     });
 
@@ -125,7 +125,7 @@ describe("createSessionToolHandler", () => {
     expect(sentMessages.at(-1)).toMatchObject({
       type: "tools.result",
       payload: {
-        toolName: "mcp.doom.start_game",
+        toolName: "mcp.example.start",
       },
     });
   });

--- a/runtime/src/gateway/tool-handler-factory.ts
+++ b/runtime/src/gateway/tool-handler-factory.ts
@@ -69,7 +69,6 @@ const DESKTOP_FILE_MANAGER_LAUNCH_RE = /\b(?:thunar|nautilus)\b/i;
 const DESKTOP_EDITOR_LAUNCH_RE = /\b(?:mousepad|gedit)\b/i;
 const COLLAPSE_WHITESPACE_RE = /\s+/g;
 const APPROVAL_TASK_PREVIEW_MAX_CHARS = 180;
-// Cut 4.1: DOOM_TOOL_PREFIX removed (Doom autoplay subsystem excised).
 const TOOL_NAME_ALIASES: Readonly<Record<string, string>> = {
   "system.makeDir": "system.mkdir",
   "system.listFiles": "system.listDir",
@@ -1773,11 +1772,6 @@ function allowsMissingRootBootstrapCwd(
   return referencesAbsolutePathWithinRoot(toolName, args, normalizedRoot);
 }
 
-// Cut 4.1: isDoomTool + canonicalizeToolFailureResult removed.
-// Doom-specific failure-result wrapping is gone alongside the rest of
-// the Doom autoplay subsystem; the dispatcher now treats `mcp.doom.*`
-// like any other MCP tool.
-
 function normalizeDesktopBashCommand(
   name: string,
   args: Record<string, unknown>,
@@ -3099,9 +3093,6 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
     }
     const durationMs = Date.now() - start;
     incidentDiagnostics?.clearDomain("tool");
-    // Cut 4.1: canonicalizeToolFailureResult was a Doom-specific
-    // failure-result rewrap; removed alongside the rest of the Doom
-    // autoplay subsystem.
     const isError = didToolCallFail(false, result);
     if (!isError) {
       if (toolName === 'system.readFile') {

--- a/runtime/src/llm/chat-executor-recovery.ts
+++ b/runtime/src/llm/chat-executor-recovery.ts
@@ -1292,7 +1292,6 @@ function inferRoundRecoveryHint(
   });
   if (!failedManagedStop) return undefined;
 
-  // Cut 4: Doom-specific shell-stop fallback hint removed.
   return undefined;
 }
 
@@ -1300,9 +1299,6 @@ export function inferRecoveryHint(
   call: ToolCallRecord,
 ): RecoveryHint | undefined {
   const parsedResult = parseToolResultObject(call.result);
-  // Cut 4: Doom-specific recovery hints removed (resolution normalization,
-  // async-start verification reminder). mcp.doom.* tools are now handled
-  // by the model directly with no runtime-side coaching.
 
   if (
     !didToolCallFail(call.isError, call.result) &&

--- a/runtime/src/llm/chat-executor-routing-state.test.ts
+++ b/runtime/src/llm/chat-executor-routing-state.test.ts
@@ -10,24 +10,24 @@ describe("chat-executor-routing-state", () => {
   it("prefers the active routed subset for evidence checks", () => {
     expect(
       getAllowedToolNamesForEvidence(
-        ["mcp.doom.get_situation_report"],
-        ["desktop.bash", "mcp.doom.start_game"],
+        ["mcp.example.status"],
+        ["desktop.bash", "mcp.example.start"],
       ),
-    ).toEqual(["mcp.doom.get_situation_report"]);
+    ).toEqual(["mcp.example.status"]);
   });
 
   it("keeps the broader turn universe available for contract guidance", () => {
     expect(
       getAllowedToolNamesForContractGuidance({
-        activeRoutedToolNames: ["mcp.doom.set_objective"],
-        initialRoutedToolNames: ["desktop.bash", "mcp.doom.start_game"],
-        expandedRoutedToolNames: ["mcp.doom.set_objective", "mcp.doom.get_state"],
+        activeRoutedToolNames: ["mcp.example.set_objective"],
+        initialRoutedToolNames: ["desktop.bash", "mcp.example.start"],
+        expandedRoutedToolNames: ["mcp.example.set_objective", "mcp.example.get_state"],
       }),
     ).toEqual([
       "desktop.bash",
-      "mcp.doom.start_game",
-      "mcp.doom.set_objective",
-      "mcp.doom.get_state",
+      "mcp.example.start",
+      "mcp.example.set_objective",
+      "mcp.example.get_state",
     ]);
   });
 
@@ -35,10 +35,10 @@ describe("chat-executor-routing-state", () => {
     expect(
       resolveEffectiveRoutedToolNames({
         hasToolRouting: true,
-        activeRoutedToolNames: ["mcp.doom.get_situation_report"],
-        allowedTools: ["desktop.bash", "mcp.doom.start_game"],
+        activeRoutedToolNames: ["mcp.example.status"],
+        allowedTools: ["desktop.bash", "mcp.example.start"],
       }),
-    ).toEqual(["mcp.doom.get_situation_report"]);
+    ).toEqual(["mcp.example.status"]);
   });
 
   it("normalizes and applies the active routed subset in one place", () => {
@@ -48,11 +48,11 @@ describe("chat-executor-routing-state", () => {
 
     expect(
       applyActiveRoutedToolNames(ctx, [
-        " mcp.doom.get_situation_report ",
-        "mcp.doom.get_situation_report",
+        " mcp.example.status ",
+        "mcp.example.status",
         "",
       ]),
-    ).toEqual(["mcp.doom.get_situation_report"]);
-    expect(ctx.activeRoutedToolNames).toEqual(["mcp.doom.get_situation_report"]);
+    ).toEqual(["mcp.example.status"]);
+    expect(ctx.activeRoutedToolNames).toEqual(["mcp.example.status"]);
   });
 });

--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -854,7 +854,6 @@ export async function executeSingleToolCall(
   );
 
   if (abortRound) return "abort_round";
-  // Cut 4: mcp.doom.start_game end-round shortcut removed.
   return "processed";
 }
 

--- a/runtime/src/llm/chat-executor-tool-utils.ts
+++ b/runtime/src/llm/chat-executor-tool-utils.ts
@@ -30,10 +30,8 @@ const NON_JSON_FAILURE_PREFIXES = [
   "error executing tool",
   "tool not found:",
 ];
-// Cut 4: Doom-specific failure regexes and resolution constants removed.
 const SHELL_EXECUTION_ANOMALY_RE =
   /(?:^|\n)(?:[^:\n]+:\s+line\s+\d+:\s+)?(?:(?:ba|z|k)?sh|cd|pushd|popd|source|\.)[^:\n]*:\s+.*(?:no such file or directory|command not found|not found|permission denied|not a directory)/i;
-const NULLISH_STRING_RE = /^(?:null|none|undefined)$/i;
 const COLLABORATION_PAYOUT_MODES = new Set(["fixed", "weighted", "milestone"]);
 
 function truncateText(value: string, maxChars: number): string {
@@ -269,7 +267,6 @@ function isLikelyFailureText(result: string): boolean {
   if (text.length === 0) return false;
   if (text.startsWith("mcp tool \"") && text.includes("\" failed:")) return true;
   if (text.includes("requires desktop session")) return true;
-  // Cut 4: Doom-specific failure regexes removed.
   return NON_JSON_FAILURE_PREFIXES.some((prefix) => text.startsWith(prefix));
 }
 
@@ -349,19 +346,10 @@ export function parseToolCallArguments(
   }
 }
 
-// Cut 4: normalizeDoomScreenResolution removed (Doom autoplay subsystem
-// excised). mcp.doom.start_game now passes through normalizeToolCallArguments
-// without any Doom-specific resolution rewriting.
-
 export function normalizeToolCallArguments(
   toolName: string,
   args: Record<string, unknown>,
 ): Record<string, unknown> {
-  // Cut 4: mcp.doom.start_game arg-rewriting (resolution normalization,
-  // window_visible defaulting, render_hud defaulting, recording_path
-  // null-stripping) removed alongside the rest of the Doom autoplay
-  // subsystem. Filesystem path normalization remains.
-  void NULLISH_STRING_RE; // retained for symmetry; other args paths may use it
   return normalizeFilesystemToolCallArguments(toolName, args);
 }
 

--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -774,7 +774,7 @@ describe("GrokProvider", () => {
     const response = await provider.chat(
       [{ role: "user", content: "inspect the repo" }],
       {
-        toolRouting: { allowedToolNames: ["mcp.doom.start_game"] },
+        toolRouting: { allowedToolNames: ["mcp.example.start"] },
         trace: {
           includeProviderPayloads: true,
           onProviderTraceEvent: (event) => {
@@ -791,17 +791,17 @@ describe("GrokProvider", () => {
     expect(response.requestMetrics).toMatchObject({
       toolCount: 0,
       toolNames: [],
-      requestedToolNames: ["mcp.doom.start_game"],
-      missingRequestedToolNames: ["mcp.doom.start_game"],
+      requestedToolNames: ["mcp.example.start"],
+      missingRequestedToolNames: ["mcp.example.start"],
       toolResolution: "subset_no_resolved_matches",
       providerCatalogToolCount: 1,
     });
     expect(events[0]).toMatchObject({
       kind: "request",
       context: {
-        requestedToolNames: ["mcp.doom.start_game"],
+        requestedToolNames: ["mcp.example.start"],
         resolvedToolNames: [],
-        missingRequestedToolNames: ["mcp.doom.start_game"],
+        missingRequestedToolNames: ["mcp.example.start"],
         toolResolution: "subset_no_resolved_matches",
         providerCatalogToolCount: 1,
       },
@@ -879,8 +879,8 @@ describe("GrokProvider", () => {
         {
           type: "function",
           function: {
-            name: "mcp.doom.start_game",
-            description: "start doom",
+            name: "mcp.example.start",
+            description: "start the example tool",
             parameters: {
               type: "object",
               properties: {
@@ -894,18 +894,18 @@ describe("GrokProvider", () => {
     });
 
     const response = await provider.chat(
-      [{ role: "user", content: "start doom" }],
-      { toolRouting: { allowedToolNames: ["mcp.doom.start_game"] } },
+      [{ role: "user", content: "start the example tool" }],
+      { toolRouting: { allowedToolNames: ["mcp.example.start"] } },
     );
 
     const params = mockCreate.mock.calls[0][0];
     expect(params.tools).toBeDefined();
     expect(params.tools).toHaveLength(1);
-    expect(params.tools[0].name).toBe("mcp.doom.start_game");
+    expect(params.tools[0].name).toBe("mcp.example.start");
     expect(response.requestMetrics).toMatchObject({
       toolCount: 1,
-      toolNames: ["mcp.doom.start_game"],
-      requestedToolNames: ["mcp.doom.start_game"],
+      toolNames: ["mcp.example.start"],
+      requestedToolNames: ["mcp.example.start"],
       missingRequestedToolNames: [],
       toolResolution: "subset_exact",
     });

--- a/runtime/src/llm/ollama/adapter.test.ts
+++ b/runtime/src/llm/ollama/adapter.test.ts
@@ -365,7 +365,7 @@ describe("OllamaProvider", () => {
     const result = await provider.chat(
       [{ role: "user", content: "test" }],
       {
-        toolRouting: { allowedToolNames: ["mcp.doom.start_game"] },
+        toolRouting: { allowedToolNames: ["mcp.example.start"] },
       },
     );
 
@@ -376,8 +376,8 @@ describe("OllamaProvider", () => {
     expect(result.requestMetrics).toMatchObject({
       toolCount: 0,
       toolNames: [],
-      requestedToolNames: ["mcp.doom.start_game"],
-      missingRequestedToolNames: ["mcp.doom.start_game"],
+      requestedToolNames: ["mcp.example.start"],
+      missingRequestedToolNames: ["mcp.example.start"],
       toolResolution: "subset_no_resolved_matches",
       providerCatalogToolCount: 1,
     });

--- a/runtime/src/llm/provider-trace-logger.test.ts
+++ b/runtime/src/llm/provider-trace-logger.test.ts
@@ -81,7 +81,7 @@ describe("createProviderTraceEventLogger", () => {
       setLevel: vi.fn(),
     };
 
-    const shared = ["mcp.doom.start_game"];
+    const shared = ["mcp.example.start"];
     const logEvent = createProviderTraceEventLogger({
       logger,
       traceLabel: "webchat.provider",
@@ -118,10 +118,10 @@ describe("createProviderTraceEventLogger", () => {
       };
     };
     expect(artifact.payload.context?.requestedToolNames).toEqual([
-      "mcp.doom.start_game",
+      "mcp.example.start",
     ]);
     expect(artifact.payload.context?.missingRequestedToolNames).toEqual([
-      "mcp.doom.start_game",
+      "mcp.example.start",
     ]);
     rmSync(artifactPath, { force: true });
   });
@@ -147,7 +147,7 @@ describe("createProviderTraceEventLogger", () => {
       phase: "tool_followup",
       callIndex: 3,
       payload: {
-        tool: "mcp.doom.new_episode",
+        tool: "mcp.example.new_episode",
         routingMiss: true,
       },
     });
@@ -158,7 +158,7 @@ describe("createProviderTraceEventLogger", () => {
     expect(line).toContain('"traceId":"trace-2"');
     expect(line).toContain('"callIndex":3');
     expect(line).toContain('"callPhase":"tool_followup"');
-    expect(line).toContain('"mcp.doom.new_episode"');
+    expect(line).toContain('"mcp.example.new_episode"');
     expect(line).not.toContain("[Object]");
     const payloadArtifactMatch = line.match(
       /"payloadArtifact":\{"path":"([^"]+)"/,

--- a/runtime/src/policy/mcp-governance.test.ts
+++ b/runtime/src/policy/mcp-governance.test.ts
@@ -50,8 +50,8 @@ describe("mcp governance", () => {
     expect(
       validateMCPServerStaticPolicy(
         {
-          name: "doom",
-          command: "doom-mcp-server",
+          name: "example",
+          command: "example-mcp-server",
           args: [],
           container: "desktop",
           supplyChain: {

--- a/runtime/src/utils/trace-payload-serialization.test.ts
+++ b/runtime/src/utils/trace-payload-serialization.test.ts
@@ -8,7 +8,7 @@ import {
 
 describe("trace-payload-serialization", () => {
   it("preserves repeated references in preview mode and only marks true cycles", () => {
-    const shared = ["mcp.doom.start_game"];
+    const shared = ["mcp.example.start"];
     const cyclic: Record<string, unknown> = {};
     cyclic.self = cyclic;
 
@@ -25,9 +25,9 @@ describe("trace-payload-serialization", () => {
       cyclic: { self: string };
     };
 
-    expect(preview.requestedToolNames).toEqual(["mcp.doom.start_game"]);
+    expect(preview.requestedToolNames).toEqual(["mcp.example.start"]);
     expect(preview.missingRequestedToolNames).toEqual([
-      "mcp.doom.start_game",
+      "mcp.example.start",
     ]);
     expect(preview.cyclic.self).toBe("[circular]");
   });

--- a/runtime/src/utils/trace-payload-store.test.ts
+++ b/runtime/src/utils/trace-payload-store.test.ts
@@ -35,7 +35,7 @@ describe("persistTracePayloadArtifact", () => {
   });
 
   it("preserves repeated references and only marks true cycles as circular", () => {
-    const shared = ["mcp.doom.start_game"];
+    const shared = ["mcp.example.start"];
     const cyclic: Record<string, unknown> = {};
     cyclic.self = cyclic;
 
@@ -57,9 +57,9 @@ describe("persistTracePayloadArtifact", () => {
         cyclic: { self: string };
       };
     };
-    expect(artifact.payload.requestedToolNames).toEqual(["mcp.doom.start_game"]);
+    expect(artifact.payload.requestedToolNames).toEqual(["mcp.example.start"]);
     expect(artifact.payload.missingRequestedToolNames).toEqual([
-      "mcp.doom.start_game",
+      "mcp.example.start",
     ]);
     expect(artifact.payload.cyclic.self).toBe("[circular]");
 


### PR DESCRIPTION
## Summary

Cut 4.1 (Doom autoplay subsystem excise) was completed in earlier sessions but left:
1. ~12 stale \"Cut 4.1: ... Doom autoplay subsystem ...\" comments pointing at the deleted code paths
2. ~38 test fixtures using Doom-themed tool names and narrative strings, exercising generic tool dispatch / routing / trace-serialization logic

### Removes
- Stale Cut 4.1 comments in \`daemon.ts\` (3), \`tool-handler-factory.ts\` (3), \`run-domains.ts\` (1), \`chat-executor-recovery.ts\` (2), \`chat-executor-tool-loop.ts\` (1), \`chat-executor-tool-utils.ts\` (4)
- The dead \`NULLISH_STRING_RE\` constant left in chat-executor-tool-utils.ts by the previous Cut 4 cleanup
- The dead \`void NULLISH_STRING_RE\` symmetry placeholder in \`normalizeToolCallArguments\`

### Renames test fixtures (no behavior change)
- \`mcp.doom.start_game\` → \`mcp.example.start\`
- \`mcp.doom.get_situation_report\` → \`mcp.example.status\`
- \`mcp.doom.set_objective\` → \`mcp.example.set_objective\`
- \`mcp.doom.get_state\` → \`mcp.example.get_state\`
- \`mcp.doom.new_episode\` → \`mcp.example.new_episode\`
- \"Doom\" narrative strings in supervisor test fixtures rephrased to \"soak workload\" / \"the example tool\"
- mcp-governance test: \`name: \"doom\"\` → \`name: \"example\"\`
- desktop-executor test \"Doomed task\" → \"Stuck task\"

After this commit \`rg \"doom|Doom\" runtime/src\` returns nothing — satisfying the Cut 4.1 acceptance criterion.

18 files changed, 107 deletions, 69 insertions.

## Test plan
- [x] \`npm run typecheck\` clean
- [x] focused tests pass: 530/530 in the touched test set