### PR TITLE
refactor(runtime): drop stale Cut-N tombstone comments

### DIFF
--- a/runtime/src/eval/pipeline-quality-runner.ts
+++ b/runtime/src/eval/pipeline-quality-runner.ts
@@ -52,10 +52,6 @@ import {
   type EconomicsScenarioRecord,
 } from "./economics-scorecard.js";
 import { buildRuntimeEconomicsPolicy } from "../llm/run-budget.js";
-// Cut 1.2: assessDelegationDecision deleted; this eval scenario was
-// exercising the deleted utility-scoring path. The negative-economics
-// branch is now handled by gateway/delegation-admission.ts at the
-// admission layer rather than a utility-score post-check.
 
 const DEFAULT_CONTEXT_BENCHMARK_TURNS = 24;
 const DEFAULT_DESKTOP_RUNS = 1;
@@ -302,11 +298,6 @@ async function runEconomicsBenchmark(): Promise<ReturnType<typeof computeEconomi
       latencyMs: 1,
     });
   }
-
-  // Cut 1.2: negative_economics_delegation_denial scenario deleted
-  // along with assessDelegationDecision. The same hard-rejection path
-  // is now exercised by the delegation-admission integration test
-  // (gateway/delegation-admission.test.ts).
 
   {
     const primary = createEconomicsProvider({

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -4737,7 +4737,7 @@ export class DaemonManager {
     _sessionId: string,
     _summary: ChatToolRoutingSummary | undefined,
   ): void {
-    // Cut 4.2: routing cache deleted; nothing to record.
+    // Tool routing decisions are static now; nothing to record per-turn.
   }
 
   private resolveLifecycleParentSessionId(

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -241,8 +241,6 @@ import {
   extractMessageText,
   truncateText,
   sanitizeFinalContent,
-  // Cut 2: reconcile* helpers no longer imported — finalContent
-  // post-processing chain removed.
   normalizeHistory,
   normalizeHistoryForStatefulReconciliation,
   toStatefulReconciliationMessage,
@@ -498,9 +496,9 @@ export class ChatExecutor {
 
     this.checkRequestTimeout(ctx, "finalization");
 
-    // Cut 2: derive the final completion state from stop reason + tool
-    // calls. The planner verifier/contract path is gone; the resolver
-    // collapses to defaults when given undefined contracts.
+    // Derive the final completion state from stop reason + tool calls.
+    // The runtime no longer carries verification or completion contracts
+    // through the chat-executor; both are passed as undefined.
     ctx.completionState = resolveWorkflowCompletionState({
       stopReason: ctx.stopReason,
       toolCalls: ctx.allToolCalls,
@@ -514,9 +512,6 @@ export class ChatExecutor {
     const plannerSummary: ChatPlannerSummary = ctx.plannerSummaryState;
 
     ctx.finalContent = sanitizeFinalContent(ctx.finalContent);
-    // Cut 4: resolveWorkflowVerificationContext always returned `{}`
-    // after the planner subsystem was deleted; the workflow contract
-    // fields here are now plumbed as undefined.
     const completionProgress = deriveWorkflowProgressSnapshot({
       stopReason: ctx.stopReason,
       completionState: ctx.completionState,
@@ -611,9 +606,6 @@ export class ChatExecutor {
       ctx.stopReasonDetail = detail;
     }
   }
-
-  // Cut 4: resolveWorkflowVerificationContext deleted (returned `{}`
-  // unconditionally after the planner-era contract flow was removed).
 
   private timeoutDetail(
     stage: string,


### PR DESCRIPTION
## Summary

After ~20 PRs of dead-code removal, several \"Cut N: X deleted because Y\" comments are pointing at code paths that no longer exist as distinct concepts. The comments add no signal — readers don't need the historical reason for why something is undefined or empty.

### Drops
- \`chat-executor.ts\`: \"Cut 2: reconcile* helpers no longer imported\" inside the import block, \"Cut 2: derive the final completion state\" (rephrased to a normal comment), \"Cut 4: resolveWorkflowVerificationContext always returned \`{}\`\"
- \`daemon.ts\`: \"Cut 4.2: routing cache deleted; nothing to record\" (rephrased to describe current behavior)
- \`pipeline-quality-runner.ts\`: 9 LOC across two \"Cut 1.2: assessDelegationDecision deleted\" comment blocks

3 files changed, 21 deletions.

## Test plan
- [x] \`npm run typecheck\` clean