### PR TITLE
refactor(runtime): inline dead workflow verification stubs (-145 LOC, Cut 1.1 partial)

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -819,7 +819,6 @@ export {
   computeAnomalySetHashFromContexts,
   REPLAY_OPERATIONAL_LIMITS,
   normalizePdaValue,
-  normalizePdaString,
   extractDisputePdaFromPayload,
 } from "./replay/index.js";
 

--- a/runtime/src/replay/index.ts
+++ b/runtime/src/replay/index.ts
@@ -77,6 +77,5 @@ export {
 
 export {
   normalizePdaValue,
-  normalizePdaString,
   extractDisputePdaFromPayload,
 } from "./pda-utils.js";

--- a/runtime/src/replay/pda-utils.ts
+++ b/runtime/src/replay/pda-utils.ts
@@ -71,11 +71,6 @@ export function normalizePdaValue(value: unknown): string | undefined {
 }
 
 /**
- * @deprecated Use {@link normalizePdaValue} which also handles byte arrays.
- */
-export const normalizePdaString = normalizePdaValue;
-
-/**
  * Extract a dispute PDA from an event payload.
  *
  * Checks `payload.disputeId` first, then falls back to

--- a/runtime/src/workflow/completion-progress.ts
+++ b/runtime/src/workflow/completion-progress.ts
@@ -9,10 +9,7 @@ import type {
   PlannerVerificationSnapshot,
   WorkflowCompletionState,
 } from "./completion-state.js";
-import {
-  deriveVerificationObligations,
-  type WorkflowVerificationContract,
-} from "./verification-obligations.js";
+import type { WorkflowVerificationContract } from "./verification-obligations.js";
 
 export type WorkflowProgressRequirement =
   | "workflow_verifier_pass"
@@ -81,19 +78,7 @@ export function deriveWorkflowProgressSnapshot(params: {
     verificationContract: params.verificationContract,
     completionContract: params.completionContract,
   });
-  const obligations = mergedContract
-    ? deriveVerificationObligations(mergedContract)
-    : undefined;
   const requiredRequirements = new Set<WorkflowProgressRequirement>();
-  if (obligations?.requiresBuildVerification) {
-    requiredRequirements.add("build_verification");
-  }
-  if (obligations?.requiresBehaviorVerification) {
-    requiredRequirements.add("behavior_verification");
-  }
-  if (obligations?.requiresReviewVerification) {
-    requiredRequirements.add("review_verification");
-  }
   if (params.completionState === "needs_verification") {
     requiredRequirements.add("workflow_verifier_pass");
   }

--- a/runtime/src/workflow/completion-state.ts
+++ b/runtime/src/workflow/completion-state.ts
@@ -2,7 +2,7 @@ import { didToolCallFail } from "../llm/chat-executor-tool-utils.js";
 import type { DelegationOutputValidationCode } from "../utils/delegation-validation.js";
 import type { ImplementationCompletionContract } from "./completion-contract.js";
 import { resolveWorkflowRequestCompletionStatus } from "./request-completion.js";
-import { deriveVerificationObligations, type WorkflowVerificationContract } from "./verification-obligations.js";
+import type { WorkflowVerificationContract } from "./verification-obligations.js";
 
 export type WorkflowCompletionState =
   | "completed"
@@ -44,44 +44,22 @@ export function resolveWorkflowCompletionState(input: {
   readonly validationCode?: DelegationOutputValidationCode;
   readonly verifier?: PlannerVerificationSnapshot;
 }): WorkflowCompletionState {
-  const verificationContract = mergeVerificationContract(input);
-  const obligations = verificationContract
-    ? deriveVerificationObligations(verificationContract)
-    : undefined;
   const verifier = input.verifier;
   const successfulToolCalls = input.toolCalls.filter(
     (toolCall) => !didToolCallFail(toolCall.isError, toolCall.result),
   );
   const hasProgress = successfulToolCalls.length > 0;
   const requestCompletion = resolveWorkflowRequestCompletionStatus({
-    contract: verificationContract?.requestCompletion,
+    contract: input.verificationContract?.requestCompletion,
     completedMilestoneIds: input.completedRequestMilestoneIds,
   });
-  const requiresExplicitVerification = Boolean(
-    obligations &&
-      (
-        obligations.requiresBuildVerification ||
-        obligations.requiresBehaviorVerification ||
-        obligations.requiresReviewVerification
-      ),
-  );
-  const requiresVerificationBeforeCompletion =
-    requiresExplicitVerification;
 
   if (input.stopReason === "completed") {
     if ((requestCompletion?.remainingMilestones.length ?? 0) > 0) {
       return hasProgress ? "partial" : "blocked";
     }
-    if (
-      requiresVerificationBeforeCompletion &&
-      (!verifier || verifier.performed !== true || verifier.overall === "skipped")
-    ) {
-      return "needs_verification";
-    }
     if (verifier?.overall === "retry" || verifier?.overall === "fail") {
-      return hasProgress || obligations?.partialCompletionAllowed === true
-        ? "partial"
-        : "blocked";
+      return hasProgress ? "partial" : "blocked";
     }
     return "completed";
   }
@@ -90,30 +68,9 @@ export function resolveWorkflowCompletionState(input: {
     return "blocked";
   }
 
-  if (
-    input.validationCode === "missing_behavior_harness" &&
-    (hasProgress || obligations?.requiresBehaviorVerification)
-  ) {
+  if (input.validationCode === "missing_behavior_harness" && hasProgress) {
     return "needs_verification";
   }
 
-  if (hasProgress || obligations?.partialCompletionAllowed === true) {
-    return "partial";
-  }
-  return "blocked";
-}
-
-function mergeVerificationContract(input: {
-  readonly verificationContract?: WorkflowVerificationContract;
-  readonly completionContract?: ImplementationCompletionContract;
-}): WorkflowVerificationContract | undefined {
-  if (!input.verificationContract && !input.completionContract) {
-    return undefined;
-  }
-  return {
-    ...(input.verificationContract ?? {}),
-    ...(input.completionContract
-      ? { completionContract: input.completionContract }
-      : {}),
-  };
+  return hasProgress ? "partial" : "blocked";
 }

--- a/runtime/src/workflow/index.ts
+++ b/runtime/src/workflow/index.ts
@@ -182,22 +182,10 @@ export type {
 } from "./completion-contract.js";
 export type { ArtifactContract, ArtifactAccessMode } from "./artifact-contract.js";
 export { buildArtifactContract, isArtifactAccessAllowed } from "./artifact-contract.js";
-export type {
-  WorkflowVerificationContract,
-  VerificationObligations,
-} from "./verification-obligations.js";
-export {
-  deriveVerificationObligations,
-  hasDelegationRuntimeVerificationContext,
-} from "./verification-obligations.js";
+export type { WorkflowVerificationContract } from "./verification-obligations.js";
 export type {
   RuntimeVerificationDiagnostic,
   RuntimeVerificationDecision,
-} from "./verification-results.js";
-export {
-  verificationFail,
-  verificationPass,
-  toDelegationOutputValidationResult,
 } from "./verification-results.js";
 export { validateRuntimeVerificationContract } from "./verification-contract.js";
 export type {

--- a/runtime/src/workflow/verification-obligations.ts
+++ b/runtime/src/workflow/verification-obligations.ts
@@ -1,16 +1,14 @@
 /**
- * Workflow verification obligations — collapsed type stub (Cut 1.1).
+ * Workflow verification contract shape — opaque type stub (Cut 1.1).
  *
- * Replaces the previous 296-LOC verification-obligation derivation
- * pipeline. The planner subsystem that produced workflow contracts
- * has been deleted; the runtime no longer derives obligations from
- * acceptance criteria. The exported types are kept as opaque shapes
- * so consumer call sites still link.
+ * The verification-obligation derivation pipeline and all its reachability
+ * helpers have been deleted. This module now exports only the contract
+ * shape, which is still carried through progress snapshots and fingerprints
+ * for consumer telemetry.
  *
  * @module
  */
 
-import type { DelegationContractSpec } from "../utils/delegation-validation.js";
 import type { ImplementationCompletionContract } from "./completion-contract.js";
 import type { WorkflowRequestCompletionContract } from "./request-completion.js";
 
@@ -29,35 +27,4 @@ export interface WorkflowVerificationContract {
   readonly completionContract?: ImplementationCompletionContract;
   readonly requestCompletion?: WorkflowRequestCompletionContract;
   readonly role?: "reviewer" | "writer" | "validator" | "researcher" | "synthesizer";
-}
-
-export interface VerificationObligations {
-  readonly workspaceRoot?: string;
-  readonly artifactContract: unknown;
-  readonly acceptanceCriteria: readonly string[];
-  readonly verificationMode: unknown;
-  readonly stepKind?: unknown;
-  readonly completionContract?: unknown;
-  readonly placeholderTaxonomy: string;
-  readonly requiresBuildVerification: boolean;
-  readonly requiresBehaviorVerification: boolean;
-  readonly requiresReviewVerification: boolean;
-  readonly requiresWorkspaceInspectionEvidence: boolean;
-  readonly requiresMutationEvidence: boolean;
-  readonly requiresSourceArtifactReads: boolean;
-  readonly allowsGroundedNoop: boolean;
-  readonly placeholdersAllowed: boolean;
-  readonly partialCompletionAllowed: boolean;
-}
-
-export function hasDelegationRuntimeVerificationContext(
-  _spec: DelegationContractSpec | undefined,
-): boolean {
-  return false;
-}
-
-export function deriveVerificationObligations(
-  _input: DelegationContractSpec | WorkflowVerificationContract,
-): VerificationObligations | undefined {
-  return undefined;
 }

--- a/runtime/src/workflow/verification-results.ts
+++ b/runtime/src/workflow/verification-results.ts
@@ -1,27 +1,15 @@
 /**
- * Workflow verification results — collapsed type stub (Cut 1.1).
+ * Workflow verification results — opaque type stub (Cut 1.1).
  *
- * Replaces the previous 127-LOC channel-decision builder API used by
- * the deleted planner verifier. Kept as opaque types so workflow/index
- * still re-exports cleanly.
+ * The planner-era channel-decision builder API has been deleted. Only the
+ * opaque decision type remains so that the verification-contract stub can
+ * still advertise a no-op return shape to its sole consumer
+ * (eval/implementation-gate-suite.ts).
  *
  * @module
  */
 
-import type {
-  DelegationOutputValidationCode,
-  DelegationOutputValidationResult,
-} from "../utils/delegation-validation.js";
-
-const RUNTIME_VERIFICATION_CHANNEL_NAMES = [
-  "artifact_state",
-  "placeholder_stub",
-  "executable_outcome",
-  "rubric",
-] as const;
-
-type RuntimeVerificationChannelName =
-  typeof RUNTIME_VERIFICATION_CHANNEL_NAMES[number];
+import type { DelegationOutputValidationCode } from "../utils/delegation-validation.js";
 
 export interface RuntimeVerificationDiagnostic {
   readonly code: DelegationOutputValidationCode;
@@ -29,7 +17,7 @@ export interface RuntimeVerificationDiagnostic {
 }
 
 interface RuntimeVerificationChannelDecision {
-  readonly channel: RuntimeVerificationChannelName;
+  readonly channel: "artifact_state" | "placeholder_stub" | "executable_outcome" | "rubric";
   readonly ok: boolean;
   readonly message: string;
   readonly evidence?: readonly string[];
@@ -41,27 +29,4 @@ export interface RuntimeVerificationDecision {
   readonly compatibilityFallbackSuggested?: boolean;
   readonly diagnostic?: RuntimeVerificationDiagnostic;
   readonly channels: readonly RuntimeVerificationChannelDecision[];
-}
-
-export function verificationPass(
-  channels: readonly RuntimeVerificationChannelDecision[] = [],
-): RuntimeVerificationDecision {
-  return { ok: true, channels };
-}
-
-export function verificationFail(
-  code: DelegationOutputValidationCode,
-  message: string,
-): RuntimeVerificationDecision {
-  return {
-    ok: false,
-    diagnostic: { code, message },
-    channels: [],
-  };
-}
-
-export function toDelegationOutputValidationResult(
-  _params: Record<string, unknown>,
-): DelegationOutputValidationResult | undefined {
-  return undefined;
 }


### PR DESCRIPTION
## Summary

The workflow verification subsystem (\`deriveVerificationObligations\`, \`validateRuntimeVerificationContract\`) was collapsed into always-return-empty stubs when the planner subsystem was deleted. Their results propagate through \`completion-state.ts\` and \`completion-progress.ts\` into conditional branches that are dead in production.

This PR inlines the dead branches and deletes the unused stub helpers, partially addressing Cut 1.1 from TODO.MD.

### Files modified

| File | Change |
|---|---|
| \`workflow/completion-state.ts\` | Dropped \`deriveVerificationObligations\` call + obligations-dependent branches + \`mergeVerificationContract\` helper |
| \`workflow/completion-progress.ts\` | Dropped \`deriveVerificationObligations\` call + dead \`requiredRequirements\` additions |
| \`workflow/verification-obligations.ts\` | Deleted dead helpers + \`VerificationObligations\` interface; kept \`WorkflowVerificationContract\` as opaque telemetry |
| \`workflow/verification-results.ts\` | Deleted \`verificationPass\`, \`verificationFail\`, \`toDelegationOutputValidationResult\`, channel name tuple |
| \`workflow/index.ts\` | Dropped dead re-exports |
| \`replay/pda-utils.ts\` (+index re-exports) | Dropped \`@deprecated normalizePdaString\` alias |

**Net: 8 files changed, +19/-164, -145 LOC**

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] 357/358 test files passing, 6,073 tests (same baseline)
- [x] \`completion-state.test.ts\` (6 tests) still passing
- [x] \`completion-progress.test.ts\` (8 tests) still passing
- [x] Only pre-existing failure: marketplace-cli LiteSVM DeclaredProgramIdMismatch