### PR TITLE
refactor(mcp): un-export 19 dead externals + delete 3 orphan helpers (-45 LOC)

### DIFF
--- a/docs-mcp/src/loader.ts
+++ b/docs-mcp/src/loader.ts
@@ -173,7 +173,7 @@ function loadNamedFiles(dirPath: string, repoRoot: string, allowedNames: Readonl
   return entries;
 }
 
-export interface LoadedDocs {
+interface LoadedDocs {
   docs: Map<string, DocEntry>;
   repoRoot: string;
 }

--- a/mcp/src/prompts/dispute-drift.ts
+++ b/mcp/src/prompts/dispute-drift.ts
@@ -1,4 +1,4 @@
-export interface DisputeDriftPromptInput {
+interface DisputeDriftPromptInput {
   dispute_pda: string;
   trace_id?: string;
 }

--- a/mcp/src/prompts/payout-mismatch.ts
+++ b/mcp/src/prompts/payout-mismatch.ts
@@ -1,6 +1,6 @@
 import type { DisputeDriftPromptOutput } from "./dispute-drift.js";
 
-export interface PayoutMismatchPromptInput {
+interface PayoutMismatchPromptInput {
   task_pda: string;
   expected_payout_lamports?: string;
   trace_id?: string;

--- a/mcp/src/prompts/replay-anomaly.ts
+++ b/mcp/src/prompts/replay-anomaly.ts
@@ -1,6 +1,6 @@
 import type { DisputeDriftPromptOutput } from "./dispute-drift.js";
 
-export interface ReplayAnomalyPromptInput {
+interface ReplayAnomalyPromptInput {
   anomaly_id: string;
   task_pda?: string;
   dispute_pda?: string;

--- a/mcp/src/tools/errors.ts
+++ b/mcp/src/tools/errors.ts
@@ -644,28 +644,6 @@ function formatError(entry: ErrorEntry): string {
 }
 
 /**
- * Get all error codes as a formatted reference.
- */
-export function getAllErrorCodes(): string {
-  const categories = new Map<string, ErrorEntry[]>();
-  for (const entry of ERROR_TABLE) {
-    const list = categories.get(entry.category) ?? [];
-    list.push(entry);
-    categories.set(entry.category, list);
-  }
-
-  const sections: string[] = [];
-  for (const [category, entries] of categories) {
-    const lines = entries.map(
-      (e) =>
-        `  ${e.code} (0x${e.code.toString(16).padStart(4, "0")}) ${e.name}: ${e.message}`,
-    );
-    sections.push(`## ${category} Errors\n${lines.join("\n")}`);
-  }
-  return sections.join("\n\n");
-}
-
-/**
  * Register error decoder tools on the MCP server.
  */
 export function registerErrorTools(server: McpServer): void {

--- a/mcp/src/tools/replay-audit.ts
+++ b/mcp/src/tools/replay-audit.ts
@@ -1,7 +1,7 @@
 import type { ResolvedActor } from "./replay-actor.js";
 import type { RiskLevel, ToolRiskCaps } from "./replay-risk.js";
 
-export interface ReplayAuditEntry {
+interface ReplayAuditEntry {
   timestamp: string;
   tool: string;
   actor: ResolvedActor;

--- a/mcp/src/tools/replay-changelog.ts
+++ b/mcp/src/tools/replay-changelog.ts
@@ -1,4 +1,4 @@
-export interface SchemaChangeEntry {
+interface SchemaChangeEntry {
   schema: string;
   version: string;
   date: string;

--- a/mcp/src/tools/replay-risk.ts
+++ b/mcp/src/tools/replay-risk.ts
@@ -9,7 +9,7 @@ export interface ToolRiskCaps {
   maxPayloadBytes: number;
 }
 
-export interface ToolRiskProfile {
+interface ToolRiskProfile {
   toolName: string;
   riskLevel: RiskLevel;
   rationale: string;
@@ -25,7 +25,7 @@ const DEFAULT_TOOL_CAPS: ToolRiskCaps = {
   maxPayloadBytes: 120_000,
 };
 
-export const REPLAY_TOOL_RISK_PROFILES: Record<string, ToolRiskProfile> = {
+const REPLAY_TOOL_RISK_PROFILES: Record<string, ToolRiskProfile> = {
   agenc_replay_backfill: {
     toolName: "agenc_replay_backfill",
     riskLevel: "high",
@@ -86,7 +86,7 @@ export function getToolRiskProfile(toolName: string): ToolRiskProfile {
   );
 }
 
-export interface ReplayRiskConfig {
+interface ReplayRiskConfig {
   globalPolicy: ReplayPolicy;
   toolOverrides?: Record<string, Partial<ToolRiskCaps>>;
 }

--- a/mcp/src/tools/replay-test-utils.ts
+++ b/mcp/src/tools/replay-test-utils.ts
@@ -25,7 +25,7 @@ export type FakeBackfillFetcher = {
   }>;
 };
 
-export type TestRuntime = {
+type TestRuntime = {
   store: FakeReplayStore;
   fetcher?: FakeBackfillFetcher;
   trace?: string;

--- a/mcp/src/tools/replay-types.ts
+++ b/mcp/src/tools/replay-types.ts
@@ -69,7 +69,7 @@ export const ReplayStatusInputSchema = baseSchema.extend({
 });
 export type ReplayStatusInput = z.infer<typeof ReplayStatusInputSchema>;
 
-export const ReplayBackfillResultSchema = z.object({
+const ReplayBackfillResultSchema = z.object({
   processed: z.number().nonnegative(),
   duplicates: z.number().nonnegative(),
   cursor: z
@@ -83,7 +83,7 @@ export const ReplayBackfillResultSchema = z.object({
     .nullable(),
 });
 
-export const ReplayCompareAnomalySchema = z.object({
+const ReplayCompareAnomalySchema = z.object({
   anomaly_id: z.string(),
   code: z.string(),
   severity: z.string(),
@@ -93,7 +93,7 @@ export const ReplayCompareAnomalySchema = z.object({
   seq: z.number().int().optional(),
 });
 
-export const ReplayCompareResultSchema = z.object({
+const ReplayCompareResultSchema = z.object({
   status: z.enum(["clean", "mismatched"]),
   strictness: z.enum(["strict", "lenient"]),
   local_event_count: z.number().nonnegative(),

--- a/mcp/src/tools/response.ts
+++ b/mcp/src/tools/response.ts
@@ -1,4 +1,4 @@
-export type ToolTextResponse = { content: [{ type: "text"; text: string }] };
+type ToolTextResponse = { content: [{ type: "text"; text: string }] };
 
 export function toolTextResponse(text: string): ToolTextResponse {
   return {

--- a/mcp/src/tools/status-filter.ts
+++ b/mcp/src/tools/status-filter.ts
@@ -2,7 +2,7 @@
  * Shared helpers for filtering Anchor enum-style account status objects.
  */
 
-export function matchesStatusFilter(
+function matchesStatusFilter(
   status: unknown,
   statusFilter: string,
 ): boolean {

--- a/mcp/src/tools/testing.ts
+++ b/mcp/src/tools/testing.ts
@@ -155,7 +155,7 @@ function asRegressionArray(value: unknown): Array<Record<string, unknown>> {
   ) as Array<Record<string, unknown>>;
 }
 
-export interface BenchmarkMutationSummaryInput {
+interface BenchmarkMutationSummaryInput {
   benchmarkArtifact: unknown;
   mutationArtifact?: unknown;
 }

--- a/mcp/src/utils/connection.ts
+++ b/mcp/src/utils/connection.ts
@@ -20,7 +20,7 @@ import {
 } from "@tetsuo-ai/runtime";
 
 /** Supported network names */
-export type NetworkName = "localnet" | "devnet" | "mainnet";
+type NetworkName = "localnet" | "devnet" | "mainnet";
 
 /** RPC endpoints for each network */
 const NETWORK_URLS: Record<NetworkName, string> = {
@@ -127,15 +127,6 @@ export async function getSigningProgram(): Promise<{
   });
   const program = createProgram(provider, currentProgramId);
   return { program, keypair };
-}
-
-/**
- * Get the wallet public key from the configured keypair.
- */
-export async function getWalletPublicKey(): Promise<PublicKey> {
-  const keypairPath = getKeypairPath();
-  const keypair = await loadKeypairFromFile(keypairPath);
-  return keypair.publicKey;
 }
 
 /**

--- a/mcp/src/utils/formatting.ts
+++ b/mcp/src/utils/formatting.ts
@@ -48,20 +48,6 @@ export function safeBigInt(val: unknown): bigint {
 }
 
 /**
- * Format a public key with optional truncation.
- */
-export function formatPubkey(
-  pubkey: PublicKey | string,
-  truncate = false,
-): string {
-  const s = typeof pubkey === "string" ? pubkey : pubkey.toBase58();
-  if (truncate && s.length > 12) {
-    return `${s.slice(0, 6)}...${s.slice(-6)}`;
-  }
-  return s;
-}
-
-/**
  * Format a byte array as hex string.
  */
 export function formatBytes(

--- a/mcp/src/utils/truncation.ts
+++ b/mcp/src/utils/truncation.ts
@@ -1,11 +1,11 @@
 import { clone, safeStringify } from "./json.js";
 
-export type TruncationReason =
+type TruncationReason =
   | "trimmed_to_minimum"
   | "payload_limit_exceeded"
   | null;
 
-export interface TruncationResult<T> {
+interface TruncationResult<T> {
   payload: T;
   truncated: boolean;
   reason: TruncationReason;


### PR DESCRIPTION
## Summary

Extended the runtime-wide un-export pattern to the \`mcp/\` and \`docs-mcp/\` workspaces. Found 22 symbols with zero external consumers across all workspaces; un-exported all 22 and deleted 3 that were also internally dead.

### Deleted
- \`mcp/src/tools/errors.ts\` — \`getAllErrorCodes\` (22 LOC formatter)
- \`mcp/src/utils/connection.ts\` — \`getWalletPublicKey\` (9 LOC loader)
- \`mcp/src/utils/formatting.ts\` — \`formatPubkey\` (15 LOC truncator)

### Un-exported
Types/interfaces and internal helpers in 13 other mcp/docs-mcp files.

**Net: 16 files changed, +19/-64, -45 LOC**

## Test plan

- [x] \`mcp tsc --noEmit\` clean
- [x] \`mcp\` tests 84/84 passing
- [x] \`docs-mcp tsc --noEmit\` clean
- [x] \`runtime tsc --noEmit\` clean (unaffected)