### PR TITLE
refactor(runtime): consolidate 2 duplicate helpers (-25 net LOC)

### DIFF
--- a/runtime/src/eval/background-run-quality-runner.ts
+++ b/runtime/src/eval/background-run-quality-runner.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ChatExecutorResult } from "../llm/chat-executor.js";
+import { createSyntheticDialogueTurnExecutionContract } from "../llm/turn-execution-contract.js";
 import type { LLMProvider, ToolHandler } from "../llm/types.js";
 import { InMemoryBackend } from "../memory/in-memory/backend.js";
 import { SqliteBackend } from "../memory/sqlite/backend.js";
@@ -49,19 +50,6 @@ function makeActorResult(
     stopReason: "completed",
     completionState: "completed",
     turnExecutionContract: createSyntheticDialogueTurnExecutionContract(),
-  };
-}
-
-function createSyntheticDialogueTurnExecutionContract() {
-  return {
-    version: 1 as const,
-    turnClass: "dialogue" as const,
-    ownerMode: "none" as const,
-    sourceArtifacts: [],
-    targetArtifacts: [],
-    delegationPolicy: "forbid" as const,
-    contractFingerprint: "synthetic-dialogue-contract",
-    taskLineageId: "synthetic-dialogue-task",
   };
 }
 

--- a/runtime/src/eval/chaos-suite.ts
+++ b/runtime/src/eval/chaos-suite.ts
@@ -10,6 +10,7 @@ import { join } from "node:path";
 import type { ChatExecutorResult } from "../llm/chat-executor.js";
 import { callWithFallback } from "../llm/chat-executor-fallback.js";
 import { DEFAULT_LLM_RETRY_POLICY_MATRIX } from "../llm/policy.js";
+import { createSyntheticDialogueTurnExecutionContract } from "../llm/turn-execution-contract.js";
 import type {
   LLMChatOptions,
   LLMMessage,
@@ -94,19 +95,6 @@ function makeProvider(
       return response;
     },
     healthCheck: async () => true,
-  };
-}
-
-function createSyntheticDialogueTurnExecutionContract() {
-  return {
-    version: 1 as const,
-    turnClass: "dialogue" as const,
-    ownerMode: "none" as const,
-    sourceArtifacts: [],
-    targetArtifacts: [],
-    delegationPolicy: "forbid" as const,
-    contractFingerprint: "synthetic-dialogue-contract",
-    taskLineageId: "synthetic-dialogue-task",
   };
 }
 

--- a/runtime/src/gateway/run-domain-native-tools.ts
+++ b/runtime/src/gateway/run-domain-native-tools.ts
@@ -1,5 +1,6 @@
 import { didToolCallFail } from "../llm/chat-executor-tool-utils.js";
 import type { ChatExecutorResult } from "../llm/chat-executor.js";
+import { createSyntheticDialogueTurnExecutionContract } from "../llm/turn-execution-contract.js";
 import type { ToolHandler } from "../llm/types.js";
 import { toErrorMessage } from "../utils/async.js";
 
@@ -28,19 +29,6 @@ export async function executeNativeToolCall(
       durationMs: Math.max(0, Date.now() - startedAt),
     };
   }
-}
-
-function createSyntheticDialogueTurnExecutionContract() {
-  return {
-    version: 1 as const,
-    turnClass: "dialogue" as const,
-    ownerMode: "none" as const,
-    sourceArtifacts: [],
-    targetArtifacts: [],
-    delegationPolicy: "forbid" as const,
-    contractFingerprint: "synthetic-dialogue-contract",
-    taskLineageId: "synthetic-dialogue-task",
-  };
 }
 
 export function buildNativeActorResult(

--- a/runtime/src/llm/prompt-budget.ts
+++ b/runtime/src/llm/prompt-budget.ts
@@ -1,3 +1,4 @@
+import { estimateContentChars } from "./chat-executor-text.js";
 import type { LLMContentPart, LLMMessage } from "./types.js";
 
 export type PromptBudgetMemoryRole = "working" | "episodic" | "semantic";
@@ -232,14 +233,6 @@ function truncateContent(
   }
 
   return out.length > 0 ? out : [{ type: "text", text: "" }];
-}
-
-function estimateContentChars(content: string | LLMContentPart[]): number {
-  if (typeof content === "string") return content.length;
-  return content.reduce((sum, part) => {
-    if (part.type === "text") return sum + part.text.length;
-    return sum + part.image_url.url.length;
-  }, 0);
 }
 
 function estimateMessageChars(message: LLMMessage): number {

--- a/runtime/src/llm/turn-execution-contract.ts
+++ b/runtime/src/llm/turn-execution-contract.ts
@@ -66,3 +66,21 @@ export function deriveActiveTaskContext(
     targetArtifacts: contract.targetArtifacts,
   };
 }
+
+/**
+ * Synthetic "dialogue" contract for runtime-native tool invocations and
+ * benchmark harnesses that do not go through the LLM adapter. Uses
+ * `delegationPolicy: "forbid"` to short-circuit delegation heuristics.
+ */
+export function createSyntheticDialogueTurnExecutionContract(): TurnExecutionContract {
+  return {
+    version: 1 as const,
+    turnClass: "dialogue" as const,
+    ownerMode: "none" as const,
+    sourceArtifacts: [],
+    targetArtifacts: [],
+    delegationPolicy: "forbid" as const,
+    contractFingerprint: "synthetic-dialogue-contract",
+    taskLineageId: "synthetic-dialogue-task",
+  };
+}


### PR DESCRIPTION
Two copy-paste helpers consolidated:

1. createSyntheticDialogueTurnExecutionContract() - duplicated 3x, moved to llm/turn-execution-contract.ts
2. estimateContentChars() - duplicated 2x, moved to llm/chat-executor-text.ts

Net -25 LOC. tsc clean, baseline holds.