### PR TITLE
fix(grok): normalize 4.20 model IDs to canonical 0309 names

### DIFF
--- a/runtime/src/gateway/context-window.test.ts
+++ b/runtime/src/gateway/context-window.test.ts
@@ -20,24 +20,24 @@ describe("normalizeGrokModel", () => {
     expect(normalizeGrokModel("grok-4-fast-non-reasoning")).toBe("grok-4-1-fast-non-reasoning");
   });
 
-  it("maps superseded 0304 experimental models to 0309 beta successors", () => {
-    expect(normalizeGrokModel("grok-4.20-experimental-beta-0304-reasoning")).toBe("grok-4.20-beta-0309-reasoning");
-    expect(normalizeGrokModel("grok-4.20-experimental-beta-0304-non-reasoning")).toBe("grok-4.20-beta-0309-non-reasoning");
-    expect(normalizeGrokModel("grok-4.20-multi-agent-experimental-beta-0304")).toBe("grok-4.20-multi-agent-beta-0309");
+  it("maps superseded 0304 experimental models to 0309 canonical models", () => {
+    expect(normalizeGrokModel("grok-4.20-experimental-beta-0304-reasoning")).toBe("grok-4.20-0309-reasoning");
+    expect(normalizeGrokModel("grok-4.20-experimental-beta-0304-non-reasoning")).toBe("grok-4.20-0309-non-reasoning");
+    expect(normalizeGrokModel("grok-4.20-multi-agent-experimental-beta-0304")).toBe("grok-4.20-multi-agent-0309");
   });
 });
 
 describe("inferGrokContextWindowTokens", () => {
-  it("resolves 2M windows for grok-4 fast and 0309 beta models", () => {
+  it("resolves 2M windows for grok-4 fast and 0309 models", () => {
     expect(inferGrokContextWindowTokens("grok-4-1-fast")).toBe(2_000_000);
     expect(inferGrokContextWindowTokens("grok-4-1-fast-reasoning")).toBe(2_000_000);
     expect(inferGrokContextWindowTokens("grok-4-1-fast-non-reasoning")).toBe(2_000_000);
     expect(inferGrokContextWindowTokens("grok-4-fast")).toBe(2_000_000);
     expect(inferGrokContextWindowTokens("grok-4-fast-reasoning")).toBe(2_000_000);
     expect(inferGrokContextWindowTokens("grok-4-fast-non-reasoning")).toBe(2_000_000);
-    expect(inferGrokContextWindowTokens("grok-4.20-beta-0309-reasoning")).toBe(2_000_000);
-    expect(inferGrokContextWindowTokens("grok-4.20-beta-0309-non-reasoning")).toBe(2_000_000);
-    expect(inferGrokContextWindowTokens("grok-4.20-multi-agent-beta-0309")).toBe(2_000_000);
+    expect(inferGrokContextWindowTokens("grok-4.20-0309-reasoning")).toBe(2_000_000);
+    expect(inferGrokContextWindowTokens("grok-4.20-0309-non-reasoning")).toBe(2_000_000);
+    expect(inferGrokContextWindowTokens("grok-4.20-multi-agent-0309")).toBe(2_000_000);
   });
 
   it("resolves model-specific windows for non-fast variants", () => {
@@ -61,11 +61,12 @@ describe("listKnownGrokModels", () => {
     });
   });
 
-  it("includes 0309 beta models with aliases from superseded 0304 variants", () => {
+  it("includes 0309 models with aliases from superseded variants", () => {
     const models = listKnownGrokModels();
-    const reasoning = models.find((e) => e.id === "grok-4.20-beta-0309-reasoning");
+    const reasoning = models.find((e) => e.id === "grok-4.20-0309-reasoning");
     expect(reasoning).toBeDefined();
     expect(reasoning!.contextWindowTokens).toBe(2_000_000);
+    expect(reasoning!.aliases).toContain("grok-4.20-beta-0309-reasoning");
     expect(reasoning!.aliases).toContain("grok-4.20-experimental-beta-0304-reasoning");
   });
 

--- a/runtime/src/gateway/context-window.ts
+++ b/runtime/src/gateway/context-window.ts
@@ -21,22 +21,29 @@ const LEGACY_GROK_MODEL_ALIASES: Record<string, string> = {
   "grok-4": "grok-4-1-fast-reasoning",
   "grok-4-fast-reasoning": "grok-4-1-fast-reasoning",
   "grok-4-fast-non-reasoning": "grok-4-1-fast-non-reasoning",
-  // Superseded 0304 experimental models → 0309 beta successors
+  // Superseded Grok 4.20 aliases -> 0309 canonical models
   "grok-4.20-experimental-beta-0304-reasoning":
-    "grok-4.20-beta-0309-reasoning",
+    "grok-4.20-0309-reasoning",
   "grok-4.20-experimental-beta-0304-non-reasoning":
-    "grok-4.20-beta-0309-non-reasoning",
+    "grok-4.20-0309-non-reasoning",
   "grok-4.20-multi-agent-experimental-beta-0304":
-    "grok-4.20-multi-agent-beta-0309",
+    "grok-4.20-multi-agent-0309",
+  "grok-4.20-beta-0309-reasoning": "grok-4.20-0309-reasoning",
+  "grok-4.20-beta-0309-non-reasoning": "grok-4.20-0309-non-reasoning",
+  "grok-4.20-multi-agent-beta-0309": "grok-4.20-multi-agent-0309",
+  "grok-4.20-beta-latest-reasoning": "grok-4.20-0309-reasoning",
+  "grok-4.20-beta-latest-non-reasoning": "grok-4.20-0309-non-reasoning",
 };
 
 const KNOWN_GROK_MODEL_IDS = [
   // Chat / language models (source: xAI docs, March 14 2026)
-  "grok-4.20-multi-agent-beta-0309",
-  "grok-4.20-beta-0309-reasoning",
-  "grok-4.20-beta-0309-non-reasoning",
+  "grok-4.20-0309-reasoning",
+  "grok-4.20-0309-non-reasoning",
+  "grok-4.20-multi-agent-0309",
   "grok-4-1-fast-reasoning",
   "grok-4-1-fast-non-reasoning",
+  "grok-4-fast-reasoning",
+  "grok-4-fast-non-reasoning",
   "grok-code-fast-1",
   "grok-4-0709",
   "grok-3",
@@ -56,10 +63,10 @@ const GROK_CONTEXT_WINDOW_BY_PREFIX: ReadonlyArray<{
   readonly contextWindowTokens: number;
 }> = [
   // Source: xAI Docs MCP page developers/models (retrieved March 14, 2026)
-  { prefix: "grok-4.20-multi-agent-beta-0309", contextWindowTokens: 2_000_000 },
-  { prefix: "grok-4.20-beta-0309-reasoning", contextWindowTokens: 2_000_000 },
+  { prefix: "grok-4.20-multi-agent-0309", contextWindowTokens: 2_000_000 },
+  { prefix: "grok-4.20-0309-reasoning", contextWindowTokens: 2_000_000 },
   {
-    prefix: "grok-4.20-beta-0309-non-reasoning",
+    prefix: "grok-4.20-0309-non-reasoning",
     contextWindowTokens: 2_000_000,
   },
   { prefix: "grok-4-1-fast", contextWindowTokens: 2_000_000 },

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -97,9 +97,9 @@ const VISION_MODELS_WITH_TOOLS = new Set([
   "grok-4-0709",
   "grok-4-1-fast-reasoning",
   "grok-4-1-fast-non-reasoning",
-  "grok-4.20-beta-0309-reasoning",
-  "grok-4.20-beta-0309-non-reasoning",
-  "grok-4.20-multi-agent-beta-0309",
+  "grok-4.20-0309-reasoning",
+  "grok-4.20-0309-non-reasoning",
+  "grok-4.20-multi-agent-0309",
 ]);
 
 interface StatefulSessionAnchor {

--- a/runtime/src/onboarding/xai-validation.js
+++ b/runtime/src/onboarding/xai-validation.js
@@ -7,19 +7,26 @@ const LEGACY_GROK_MODEL_ALIASES = Object.freeze({
   "grok-4-fast-reasoning": "grok-4-1-fast-reasoning",
   "grok-4-fast-non-reasoning": "grok-4-1-fast-non-reasoning",
   "grok-4.20-experimental-beta-0304-reasoning":
-    "grok-4.20-beta-0309-reasoning",
+    "grok-4.20-0309-reasoning",
   "grok-4.20-experimental-beta-0304-non-reasoning":
-    "grok-4.20-beta-0309-non-reasoning",
+    "grok-4.20-0309-non-reasoning",
   "grok-4.20-multi-agent-experimental-beta-0304":
-    "grok-4.20-multi-agent-beta-0309",
+    "grok-4.20-multi-agent-0309",
+  "grok-4.20-beta-0309-reasoning": "grok-4.20-0309-reasoning",
+  "grok-4.20-beta-0309-non-reasoning": "grok-4.20-0309-non-reasoning",
+  "grok-4.20-multi-agent-beta-0309": "grok-4.20-multi-agent-0309",
+  "grok-4.20-beta-latest-reasoning": "grok-4.20-0309-reasoning",
+  "grok-4.20-beta-latest-non-reasoning": "grok-4.20-0309-non-reasoning",
 });
 
 const KNOWN_GROK_CHAT_MODELS = new Set([
-  "grok-4.20-multi-agent-beta-0309",
-  "grok-4.20-beta-0309-reasoning",
-  "grok-4.20-beta-0309-non-reasoning",
+  "grok-4.20-multi-agent-0309",
+  "grok-4.20-0309-reasoning",
+  "grok-4.20-0309-non-reasoning",
   "grok-4-1-fast-reasoning",
   "grok-4-1-fast-non-reasoning",
+  "grok-4-fast-reasoning",
+  "grok-4-fast-non-reasoning",
   "grok-code-fast-1",
   "grok-4-0709",
   "grok-3",

--- a/runtime/src/watch/agenc-watch-helpers.mjs
+++ b/runtime/src/watch/agenc-watch-helpers.mjs
@@ -5,11 +5,13 @@ export const DEFAULT_INPUT_BATCH_DELAY_MS = 45;
  * Kept in sync with runtime/src/gateway/context-window.ts KNOWN_GROK_MODEL_IDS.
  */
 export const KNOWN_CHAT_MODELS = Object.freeze([
-  "grok-4.20-multi-agent-beta-0309",
-  "grok-4.20-beta-0309-reasoning",
-  "grok-4.20-beta-0309-non-reasoning",
+  "grok-4.20-multi-agent-0309",
+  "grok-4.20-0309-reasoning",
+  "grok-4.20-0309-non-reasoning",
   "grok-4-1-fast-reasoning",
   "grok-4-1-fast-non-reasoning",
+  "grok-4-fast-reasoning",
+  "grok-4-fast-non-reasoning",
   "grok-code-fast-1",
   "grok-4-0709",
   "grok-3",

--- a/web/src/components/simulation/SimulationSetup.tsx
+++ b/web/src/components/simulation/SimulationSetup.tsx
@@ -498,10 +498,12 @@ const PRESETS: Record<string, SimulationSetupConfig> = {
 // Chat-capable Grok models (source: xAI docs, March 2026)
 const GROK_MODELS = [
   { id: "grok-4-1-fast-non-reasoning", label: "Grok 4.1 Fast Non-Reasoning (2M ctx)", default: true },
-  { id: "grok-4.20-beta-0309-reasoning", label: "Grok 4.20 Reasoning (2M ctx)" },
-  { id: "grok-4.20-beta-0309-non-reasoning", label: "Grok 4.20 Non-Reasoning (2M ctx)" },
-  { id: "grok-4.20-multi-agent-beta-0309", label: "Grok 4.20 Multi-Agent (2M ctx)" },
+  { id: "grok-4.20-0309-reasoning", label: "Grok 4.20 Reasoning (2M ctx)" },
+  { id: "grok-4.20-0309-non-reasoning", label: "Grok 4.20 Non-Reasoning (2M ctx)" },
+  { id: "grok-4.20-multi-agent-0309", label: "Grok 4.20 Multi-Agent (2M ctx)" },
   { id: "grok-4-1-fast-reasoning", label: "Grok 4.1 Fast Reasoning (2M ctx)" },
+  { id: "grok-4-fast-reasoning", label: "Grok 4 Fast Reasoning (2M ctx)" },
+  { id: "grok-4-fast-non-reasoning", label: "Grok 4 Fast Non-Reasoning (2M ctx)" },
   { id: "grok-code-fast-1", label: "Grok Code Fast (256K ctx)" },
   { id: "grok-3", label: "Grok 3 (131K ctx)" },
   { id: "grok-3-mini", label: "Grok 3 Mini (131K ctx)" },

--- a/web/src/constants/llm.ts
+++ b/web/src/constants/llm.ts
@@ -9,9 +9,11 @@ export interface LLMProviderDef {
 export const GROK_MODEL_OPTIONS = [
   'grok-4-1-fast-reasoning',
   'grok-4-1-fast-non-reasoning',
-  'grok-4.20-experimental-beta-0304-reasoning',
-  'grok-4.20-experimental-beta-0304-non-reasoning',
-  'grok-4.20-multi-agent-experimental-beta-0304',
+  'grok-4-fast-reasoning',
+  'grok-4-fast-non-reasoning',
+  'grok-4.20-0309-reasoning',
+  'grok-4.20-0309-non-reasoning',
+  'grok-4.20-multi-agent-0309',
   'grok-code-fast-1',
 ] as const;
 


### PR DESCRIPTION
## Summary
- migrate Grok 4.20 references from deprecated beta/experimental IDs to canonical 0309 IDs
- preserve backward compatibility through alias normalization in runtime + onboarding validation
- update runtime/web known model lists and UI options, including fast aliases

## Validation
- npx vitest run src/gateway/context-window.test.ts src/onboarding/xai-validation.test.ts tests/watch/agenc-watch-helpers.test.mjs
- node --test tests/watch/agenc-watch-helpers.test.mjs