### PR TITLE
fix: surface tool follow-up failures instead of fallback summaries

### DIFF
--- a/runtime/src/gateway/daemon-webchat-turn.test.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.test.ts
@@ -654,6 +654,86 @@ You have broad access to this machine via the system.bash tool.`,
     expect(memoryBackend.addEntry).not.toHaveBeenCalled();
   });
 
+  it("surfaces returned non-success results to webchat and skips outbound persistence side effects", async () => {
+    const logger = createLoggerStub();
+    const memoryBackend = createMemoryBackendStub();
+    const sessionMgr = {
+      getOrCreate: vi.fn(() => createSession()),
+      appendMessage: vi.fn(),
+      compact: vi.fn(async () => undefined),
+    } as any;
+    const webChat = {
+      createAbortController: vi.fn(() => new AbortController()),
+      clearAbortController: vi.fn(),
+      send: vi.fn(async () => undefined),
+      pushToSession: vi.fn(),
+      broadcastEvent: vi.fn(),
+    } as any;
+    const hooks = {
+      dispatch: vi.fn(async () => ({ completed: true, payload: {} })),
+    } as any;
+    const signals = {
+      signalThinking: vi.fn(),
+      signalIdle: vi.fn(),
+    };
+
+    await executeWebChatConversationTurn({
+      logger,
+      msg: {
+        sessionId: "session:test",
+        senderId: "operator-1",
+        channel: "webchat",
+        content: "hello",
+      },
+      webChat,
+      chatExecutor: {
+        execute: vi.fn(async () =>
+          createResult({
+            content: "Operation completed. Result:\n```json\n{\"entries\":[\"src\"]}\n```",
+            stopReason: "timeout",
+            stopReasonDetail: "tool follow-up timed out",
+            completionState: "blocked",
+          })
+        ),
+      } as any,
+      sessionMgr,
+      getSystemPrompt: () => "system",
+      sessionToolHandler: vi.fn() as any,
+      sessionStreamCallback: vi.fn(),
+      signals,
+      hooks,
+      memoryBackend,
+      sessionTokenBudget: 16_000,
+      defaultMaxToolRounds: 3,
+      contextWindowTokens: 64_000,
+      traceConfig: {
+        enabled: false,
+        includeHistory: true,
+        includeSystemPrompt: true,
+        includeToolArgs: true,
+        includeToolResults: true,
+        includeProviderPayloads: false,
+        maxChars: 20_000,
+      },
+      turnTraceId: "trace-1",
+      buildToolRoutingDecision: () => undefined,
+      recordToolRoutingOutcome: vi.fn(),
+      getSessionTokenUsage: () => 0,
+      onModelInfo: vi.fn(),
+      onSubagentSynthesis: vi.fn(),
+    });
+
+    expect(webChat.clearAbortController).toHaveBeenCalledWith("session:test");
+    expect(signals.signalIdle).toHaveBeenCalledWith("session:test");
+    expect(webChat.send).toHaveBeenCalledWith({
+      sessionId: "session:test",
+      content: "Error (timeout): tool follow-up timed out",
+    });
+    expect(sessionMgr.appendMessage).not.toHaveBeenCalled();
+    expect(hooks.dispatch).not.toHaveBeenCalled();
+    expect(memoryBackend.addEntry).not.toHaveBeenCalled();
+  });
+
   it("passes the session workspace root into planner/runtime execution instead of a conflicting message root", async () => {
     const logger = createLoggerStub();
     const memoryBackend = createMemoryBackendStub();

--- a/runtime/src/gateway/daemon-webchat-turn.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.ts
@@ -394,6 +394,14 @@ export async function executeWebChatConversationTurn(
         },
       );
     }
+    if (result.stopReason !== "completed" && result.stopReason !== "tool_calls") {
+      const stopReasonDetail =
+        result.stopReasonDetail ?? result.content ?? "LLM execution did not complete";
+      throw Object.assign(new Error(stopReasonDetail), {
+        stopReason: result.stopReason,
+        stopReasonDetail,
+      });
+    }
     if (hasActionableStatefulFallback(result.statefulSummary)) {
       logger.warn("[stateful] webchat fallback_to_stateless", {
         traceId: turnTraceId,

--- a/runtime/src/llm/chat-executor-fallback.test.ts
+++ b/runtime/src/llm/chat-executor-fallback.test.ts
@@ -131,6 +131,60 @@ describe("callWithFallback", () => {
     expect(provider.chat).not.toHaveBeenCalled();
   });
 
+  it("stops fallback once the end-to-end deadline has expired instead of starting a 1ms retry", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-08T00:00:00.000Z"));
+    try {
+      const primary = {
+        ...createMockProvider({
+          name: "primary",
+          chat: vi.fn().mockImplementation(async () => {
+            vi.setSystemTime(new Date(Date.now() + 250));
+            throw new LLMServerError("primary", 503, "temporary outage");
+          }),
+        }),
+        config: { model: "primary-model" },
+      } as LLMProvider & { config: { model: string } };
+      const secondary = {
+        ...createMockProvider({
+          name: "secondary",
+          chat: vi.fn().mockResolvedValue(mockResponse({ model: "secondary-model" })),
+        }),
+        config: { model: "secondary-model" },
+      } as LLMProvider & { config: { model: string } };
+
+      await expect(
+        callWithFallback(
+          {
+            providers: [primary, secondary],
+            cooldowns: new Map(),
+            promptBudget: {},
+            retryPolicyMatrix: DEFAULT_LLM_RETRY_POLICY_MATRIX,
+            cooldownMs: 1_000,
+            maxCooldownMs: 60_000,
+          },
+          [{ role: "user", content: "continue" }],
+          undefined,
+          undefined,
+          {
+            callPhase: "tool_followup",
+            toolChoice: "required",
+            requestDeadlineAt: Date.now() + 200,
+            requestTimeoutMs: 200,
+          },
+        ),
+      ).rejects.toMatchObject({
+        message:
+          "Request exceeded end-to-end timeout (200ms) during tool_followup model call",
+      });
+
+      expect(primary.chat).toHaveBeenCalledOnce();
+      expect(secondary.chat).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("uses non-stream chat when streaming is explicitly disabled", async () => {
     const provider = createMockProvider();
     const onStreamChunk = vi.fn();

--- a/runtime/src/llm/chat-executor-fallback.ts
+++ b/runtime/src/llm/chat-executor-fallback.ts
@@ -17,6 +17,7 @@ import {
   LLMRateLimitError,
   classifyLLMFailure,
 } from "./errors.js";
+import { RuntimeError, RuntimeErrorCodes } from "../types/errors.js";
 import { assertValidLLMResponse } from "./response-validation.js";
 import {
   applyPromptBudget,
@@ -74,6 +75,25 @@ function shouldBypassStreamingForModelCall(
   return isExplicitToolTurn;
 }
 
+function createRequestDeadlineExceededError(
+  callPhase: ChatCallUsageRecord["phase"] | undefined,
+  requestTimeoutMs: number | undefined,
+): RuntimeError {
+  const stage = callPhase ? `${callPhase} model call` : "model call";
+  const normalizedTimeoutMs =
+    typeof requestTimeoutMs === "number" &&
+    Number.isFinite(requestTimeoutMs) &&
+    requestTimeoutMs > 0
+      ? Math.floor(requestTimeoutMs)
+      : undefined;
+  return new RuntimeError(
+    normalizedTimeoutMs === undefined
+      ? `Request exceeded end-to-end timeout during ${stage}`
+      : `Request exceeded end-to-end timeout (${normalizedTimeoutMs}ms) during ${stage}`,
+    RuntimeErrorCodes.LLM_TIMEOUT,
+  );
+}
+
 // ============================================================================
 // Configuration interface for callWithFallback
 // ============================================================================
@@ -104,6 +124,7 @@ interface CallWithFallbackOptions {
   parallelToolCalls?: boolean;
   structuredOutput?: LLMChatOptions["structuredOutput"];
   requestDeadlineAt?: number;
+  requestTimeoutMs?: number;
   signal?: AbortSignal;
   trace?: ChatExecuteParams["trace"];
   callIndex?: number;
@@ -253,14 +274,20 @@ export async function callWithFallback(
         const remainingProviderMs =
           options?.requestDeadlineAt !== undefined &&
             Number.isFinite(options.requestDeadlineAt)
-            ? Math.max(1, options.requestDeadlineAt - Date.now())
+            ? options.requestDeadlineAt - Date.now()
             : undefined;
+        if (remainingProviderMs !== undefined && remainingProviderMs <= 0) {
+          throw createRequestDeadlineExceededError(
+            options?.callPhase,
+            options?.requestTimeoutMs,
+          );
+        }
         const providerChatOptions: LLMChatOptions | undefined =
           baseChatOptions || remainingProviderMs !== undefined
             ? {
               ...(baseChatOptions ?? {}),
               ...(remainingProviderMs !== undefined
-                ? { timeoutMs: remainingProviderMs }
+                ? { timeoutMs: Math.max(1, Math.floor(remainingProviderMs)) }
                 : {}),
             }
             : undefined;

--- a/runtime/src/llm/chat-executor-model-orchestration.ts
+++ b/runtime/src/llm/chat-executor-model-orchestration.ts
@@ -394,6 +394,7 @@ export async function callModelForPhase(
       effectiveCallSections,
       {
         requestDeadlineAt: ctx.requestDeadlineAt,
+        requestTimeoutMs: ctx.effectiveRequestTimeoutMs,
         signal: ctx.signal,
         ...(allowStatefulContinuation && input.statefulSessionId
           ? {

--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -1410,7 +1410,23 @@ export async function executeToolCallLoop(
   }
 
   ctx.finalContent = ctx.response?.content ?? "";
-  if (!ctx.finalContent && ctx.allToolCalls.length > 0) {
+  const missingFinalToolFollowupAnswer =
+    !ctx.finalContent &&
+    ctx.allToolCalls.length > 0 &&
+    ctx.stopReason === "completed";
+  if (missingFinalToolFollowupAnswer) {
+    callbacks.setStopReason(
+      ctx,
+      "no_progress",
+      "Model returned empty content after tool follow-up; refusing to surface raw tool output as the final answer.",
+    );
+  }
+  const shouldSummarizeToolFallback =
+    !missingFinalToolFollowupAnswer &&
+    !ctx.finalContent &&
+    ctx.allToolCalls.length > 0 &&
+    ctx.stopReason === "tool_calls";
+  if (shouldSummarizeToolFallback) {
     ctx.finalContent =
       generateFallbackContent(ctx.allToolCalls) ?? ctx.finalContent;
   }

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -716,6 +716,133 @@ describe("ChatExecutor", () => {
       ]);
     });
 
+
+    it("does not turn an empty post-tool follow-up into a fake tool-result success", async () => {
+      const toolHandler = vi
+        .fn()
+        .mockResolvedValue('{"entries":["src","package.json"]}');
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                { id: "tc-1", name: "system.listDir", arguments: '{"path":"."}' },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({ content: "", finishReason: "stop" }),
+          ),
+      });
+
+      const executor = new ChatExecutor({ providers: [provider], toolHandler });
+      const result = await executor.execute(createParams());
+
+      expect(result.stopReason).toBe("no_progress");
+      expect(result.content).toContain(
+        "Model returned empty content after tool follow-up",
+      );
+      expect(result.content).not.toContain("Operation completed. Result");
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0]).toEqual(
+        expect.objectContaining({
+          name: "system.listDir",
+          args: { path: "." },
+          result: '{"entries":["src","package.json"]}',
+          isError: false,
+        }),
+      );
+    });
+
+    it("surfaces timeout detail instead of summarizing tool output when tool follow-up never starts", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-04-08T00:00:00.000Z"));
+      try {
+        const toolHandler = vi.fn().mockImplementation(async () => {
+          vi.setSystemTime(new Date(Date.now() + 250));
+          return '{"entries":["src","package.json"]}';
+        });
+        const provider = createMockProvider("primary", {
+          chat: vi
+            .fn()
+            .mockResolvedValueOnce(
+              mockResponse({
+                content: "",
+                finishReason: "tool_calls",
+                toolCalls: [
+                  { id: "tc-1", name: "system.listDir", arguments: '{"path":"."}' },
+                ],
+              }),
+            ),
+        });
+
+        const executor = new ChatExecutor({ providers: [provider], toolHandler });
+        const result = await executor.execute(
+          createParams({ requestTimeoutMs: 200 }),
+        );
+
+        expect(result.stopReason).toBe("timeout");
+        expect(result.content).toContain(
+          "Request exceeded end-to-end timeout (200ms) during tool follow-up",
+        );
+        expect(result.content).not.toContain("Completed system.listDir");
+        expect(result.content).not.toContain("Operation completed. Result");
+        expect(provider.chat).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("summarizes structured tool payloads when max tool rounds end before a final answer", async () => {
+      const toolHandler = vi.fn().mockResolvedValue(
+        JSON.stringify({
+          path: "/tmp/project",
+          entries: [
+            { name: "runtime", type: "dir", size: 0 },
+            { name: "package.json", type: "file", size: 128 },
+          ],
+        }),
+      );
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                { id: "tc-1", name: "system.listDir", arguments: '{"path":"."}' },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                { id: "tc-2", name: "system.listDir", arguments: '{"path":"."}' },
+              ],
+            }),
+          ),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        maxToolRounds: 1,
+      });
+      const result = await executor.execute(createParams());
+
+      expect(result.stopReason).toBe("tool_calls");
+      expect(result.content).toContain("Operation completed. Result");
+      expect(result.content).toContain("package.json");
+      expect(result.content).toContain('"entries"');
+      expect(provider.chat).toHaveBeenCalledTimes(2);
+    });
+
     it("sanitizes screenshot tool payloads and keeps image artifacts out-of-band", async () => {
       const hugeBase64 = "A".repeat(90_000);
       const toolHandler = vi.fn().mockResolvedValue(

--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -1637,12 +1637,14 @@ describe("GrokProvider", () => {
     );
 
     const provider = new GrokProvider({ apiKey: "test-key", timeoutMs: 60_000 });
-    await expect(
-      provider.chat(
-        [{ role: "user", content: "test" }],
-        { timeoutMs: 5 },
-      ),
-    ).rejects.toThrow(LLMTimeoutError);
+    const timeoutError = await provider.chat(
+      [{ role: "user", content: "test" }],
+      { timeoutMs: 5 },
+    ).catch((error: unknown) => error);
+
+    expect(timeoutError).toBeInstanceOf(LLMTimeoutError);
+    expect((timeoutError as LLMTimeoutError).timeoutMs).toBe(5);
+    expect((timeoutError as LLMTimeoutError).message).toContain("5ms");
 
     expect(mockCreate).toHaveBeenCalledOnce();
     expect(mockCreate.mock.calls[0]?.[1]?.signal).toBeInstanceOf(AbortSignal);

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -860,6 +860,7 @@ export class GrokProvider implements LLMProvider {
   ): Promise<LLMResponse> {
     const client = await this.ensureClient();
     let plan = this.buildRequestPlan(messages, options);
+    let lastAttemptTimeoutMs: number | undefined;
     const requestTimeout = resolveRequestTimeoutMs(
       this.configuredTimeoutMs,
       options?.timeoutMs,
@@ -877,6 +878,7 @@ export class GrokProvider implements LLMProvider {
             timeoutMs: Math.max(1, requestDeadlineAt - Date.now()),
           }
           : requestTimeout;
+      lastAttemptTimeoutMs = activeRequestTimeout.timeoutMs;
       emitProviderTraceEvent(options, {
         kind: "request",
         transport: "chat",
@@ -965,7 +967,10 @@ export class GrokProvider implements LLMProvider {
           });
           continue;
         }
-        const mapped = this.mapError(err, Math.max(1, requestDeadlineAt - Date.now()));
+        const mapped = this.mapError(
+          err,
+          lastAttemptTimeoutMs ?? requestTimeout.timeoutMs,
+        );
         this.logPromptOverflowDiagnostics(mapped, plan.params);
         throw mapped;
       }

--- a/runtime/src/memory/encryption.test.ts
+++ b/runtime/src/memory/encryption.test.ts
@@ -3,7 +3,7 @@ import {
   createAES256GCMProvider,
   createVersionedAES256GCMProvider,
 } from "./encryption.js";
-import { randomBytes } from "node:crypto";
+import { createCipheriv, randomBytes } from "node:crypto";
 
 describe("AES-256-GCM encryption", () => {
   const key = randomBytes(32);
@@ -173,6 +173,29 @@ describe("Versioned AES-256-GCM key rotation", () => {
     });
 
     expect(versionedProvider.decrypt(legacyCiphertext)).toBe("legacy data");
+  });
+
+  it("decrypts legacy ciphertexts whose IV collides with the version marker", () => {
+    const legacyKey = randomBytes(32);
+    const iv = Buffer.concat([Buffer.from([0x56, 0xee]), randomBytes(10)]);
+    const cipher = createCipheriv("aes-256-gcm", legacyKey, iv);
+    const encrypted = Buffer.concat([
+      cipher.update("legacy marker collision", "utf8"),
+      cipher.final(),
+    ]);
+    const authTag = cipher.getAuthTag();
+    const legacyCiphertext = Buffer.concat([iv, authTag, encrypted]).toString(
+      "base64",
+    );
+
+    const versionedProvider = createVersionedAES256GCMProvider({
+      keys: { 0: legacyKey, 1: keyV1 },
+      currentVersion: 1,
+    });
+
+    expect(versionedProvider.decrypt(legacyCiphertext)).toBe(
+      "legacy marker collision",
+    );
   });
 
   it("different versions produce different ciphertexts", () => {

--- a/runtime/src/memory/encryption.ts
+++ b/runtime/src/memory/encryption.ts
@@ -179,44 +179,20 @@ export function createVersionedAES256GCMProvider(
     return combined.toString("base64");
   }
 
-  function detectVersionAndDecrypt(ciphertext: string): string {
-    const combined = Buffer.from(ciphertext, "base64");
-
-    // Check for version marker
-    if (combined.length >= 2 && combined[0] === VERSION_MARKER) {
-      const version = combined[1];
-      const key = keyMap.get(version);
-      if (!key) {
-        throw new Error(`No key available for version ${version}`);
-      }
-      const payload = combined.subarray(2);
-      if (payload.length < IV_BYTES + TAG_BYTES) {
-        throw new Error("Versioned ciphertext too short");
-      }
-      const iv = payload.subarray(0, IV_BYTES);
-      const authTag = payload.subarray(IV_BYTES, IV_BYTES + TAG_BYTES);
-      const encrypted = payload.subarray(IV_BYTES + TAG_BYTES);
-
-      const decipher = createDecipheriv(ALGORITHM, key, iv, {
-        authTagLength: TAG_BYTES,
-      });
-      decipher.setAuthTag(authTag);
-      return Buffer.concat([
-        decipher.update(encrypted),
-        decipher.final(),
-      ]).toString("utf8");
+  function decryptPayload(
+    payload: Buffer,
+    key: Buffer,
+    shortCiphertextError: string,
+  ): string {
+    if (payload.length < IV_BYTES + TAG_BYTES) {
+      throw new Error(shortCiphertextError);
     }
 
-    // Non-versioned ciphertext — try version 0 key, then current key
-    const legacyKey: Buffer = keyMap.get(0) ?? currentKey;
-    if (combined.length < IV_BYTES + TAG_BYTES) {
-      throw new Error("Ciphertext too short");
-    }
-    const iv = combined.subarray(0, IV_BYTES);
-    const authTag = combined.subarray(IV_BYTES, IV_BYTES + TAG_BYTES);
-    const encrypted = combined.subarray(IV_BYTES + TAG_BYTES);
+    const iv = payload.subarray(0, IV_BYTES);
+    const authTag = payload.subarray(IV_BYTES, IV_BYTES + TAG_BYTES);
+    const encrypted = payload.subarray(IV_BYTES + TAG_BYTES);
 
-    const decipher = createDecipheriv(ALGORITHM, legacyKey, iv, {
+    const decipher = createDecipheriv(ALGORITHM, key, iv, {
       authTagLength: TAG_BYTES,
     });
     decipher.setAuthTag(authTag);
@@ -224,6 +200,36 @@ export function createVersionedAES256GCMProvider(
       decipher.update(encrypted),
       decipher.final(),
     ]).toString("utf8");
+  }
+
+  function decryptLegacyPayload(combined: Buffer): string {
+    const legacyKey: Buffer = keyMap.get(0) ?? currentKey;
+    return decryptPayload(combined, legacyKey, "Ciphertext too short");
+  }
+
+  function detectVersionAndDecrypt(ciphertext: string): string {
+    const combined = Buffer.from(ciphertext, "base64");
+
+    // Check for version marker
+    if (combined.length >= 2 && combined[0] === VERSION_MARKER) {
+      const version = combined[1];
+      const key = keyMap.get(version);
+      const payload = combined.subarray(2);
+
+      if (key) {
+        return decryptPayload(payload, key, "Versioned ciphertext too short");
+      }
+
+      // Legacy ciphertexts can start with the version marker because their IV is random.
+      // Only preserve the unknown-version error when the legacy decode also fails.
+      try {
+        return decryptLegacyPayload(combined);
+      } catch {
+        throw new Error(`No key available for version ${version}`);
+      }
+    }
+
+    return decryptLegacyPayload(combined);
   }
 
   return {


### PR DESCRIPTION
## Summary
- stop the executor from converting failed or empty post-tool follow-ups into synthetic tool-result success messages
- route returned non-success webchat results through the existing error surface path so users see `Error (<stopReason>): <detail>`
- add regression coverage for empty follow-ups, timed-out follow-ups, preserved tool-call fallback behavior, and webchat non-success handling

## Testing
- `./node_modules/.bin/vitest run runtime/src/llm/chat-executor.test.ts runtime/src/gateway/daemon-webchat-turn.test.ts`
