### PR TITLE
expand marketplace watch and daemon flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "pack:smoke": "npm run build && node scripts/pack-smoke.mjs",
     "pack:smoke:skip-build": "node scripts/pack-smoke.mjs",
     "smoke:marketplace:devnet": "tsx scripts/marketplace-devnet-smoke.ts",
+    "smoke:marketplace:tui:devnet": "tsx scripts/marketplace-tui-devnet-smoke.ts",
     "build:public-runtime-artifacts": "node scripts/build-public-runtime-artifacts.mjs",
     "sync:dashboard-assets": "node scripts/sync-dashboard-assets.mjs",
     "prepare:public-agenc-package": "node scripts/prepare-public-agenc-package.mjs",

--- a/runtime/src/agent/index.ts
+++ b/runtime/src/agent/index.ts
@@ -57,8 +57,10 @@ export {
 export {
   deriveAgentPda,
   deriveProtocolPda,
+  deriveAuthorityRateLimitPda,
   findAgentPda,
   findProtocolPda,
+  findAuthorityRateLimitPda,
   deriveAuthorityVotePda,
   findAuthorityVotePda,
   type PdaWithBump,

--- a/runtime/src/agent/manager.ts
+++ b/runtime/src/agent/manager.ts
@@ -8,7 +8,7 @@
  */
 
 import { Connection, PublicKey, TransactionSignature } from "@solana/web3.js";
-import anchor, { Program, AnchorProvider } from "@coral-xyz/anchor";
+import { BN, Program, AnchorProvider } from "@coral-xyz/anchor";
 import { PROGRAM_ID } from "@tetsuo-ai/sdk";
 import type { AgencCoordination } from "../types/agenc_coordination.js";
 import {
@@ -297,10 +297,10 @@ export class AgentManager {
     await this.program.methods
       .registerAgent(
         Array.from(params.agentId),
-        new anchor.BN(params.capabilities.toString()),
+        new BN(params.capabilities.toString()),
         params.endpoint,
         params.metadataUri ?? null,
-        new anchor.BN(params.stakeAmount.toString()),
+        new BN(params.stakeAmount.toString()),
       )
       .accountsPartial({
         agent: agentPda,
@@ -463,7 +463,7 @@ export class AgentManager {
     // Prepare update values (null means "keep current value" in the instruction)
     const capabilities =
       params.capabilities !== undefined
-        ? new anchor.BN(params.capabilities.toString())
+        ? new BN(params.capabilities.toString())
         : null;
     const endpoint = params.endpoint ?? null;
     const metadataUri = params.metadataUri ?? null;

--- a/runtime/src/agent/pda.test.ts
+++ b/runtime/src/agent/pda.test.ts
@@ -4,8 +4,10 @@ import { PROGRAM_ID, SEEDS } from "@tetsuo-ai/sdk";
 import {
   deriveAgentPda,
   deriveProtocolPda,
+  deriveAuthorityRateLimitPda,
   findAgentPda,
   findProtocolPda,
+  findAuthorityRateLimitPda,
   type PdaWithBump,
 } from "./pda";
 import { AGENT_ID_LENGTH } from "./types";
@@ -196,6 +198,40 @@ describe("PDA derivation helpers", () => {
       const shortId = new Uint8Array(10);
 
       expect(() => findAgentPda(shortId)).toThrow("Invalid agentId length");
+    });
+  });
+
+  describe("deriveAuthorityRateLimitPda", () => {
+    it("returns address and bump for an authority wallet", () => {
+      const authority = PublicKey.unique();
+      const result = deriveAuthorityRateLimitPda(authority);
+
+      expect(result.address).toBeInstanceOf(PublicKey);
+      expect(typeof result.bump).toBe("number");
+      expect(result.bump).toBeGreaterThanOrEqual(0);
+      expect(result.bump).toBeLessThanOrEqual(255);
+    });
+
+    it("uses the authority_rate_limit seed bytes even before the SDK exports it", () => {
+      const authority = PublicKey.unique();
+      const result = deriveAuthorityRateLimitPda(authority);
+      const [expected, expectedBump] = PublicKey.findProgramAddressSync(
+        [Buffer.from("authority_rate_limit"), authority.toBuffer()],
+        PROGRAM_ID,
+      );
+
+      expect(result.address.equals(expected)).toBe(true);
+      expect(result.bump).toBe(expectedBump);
+    });
+  });
+
+  describe("findAuthorityRateLimitPda", () => {
+    it("matches deriveAuthorityRateLimitPda address", () => {
+      const authority = PublicKey.unique();
+      const address = findAuthorityRateLimitPda(authority);
+      const { address: derivedAddress } = deriveAuthorityRateLimitPda(authority);
+
+      expect(address.equals(derivedAddress)).toBe(true);
     });
   });
 

--- a/runtime/src/agent/pda.ts
+++ b/runtime/src/agent/pda.ts
@@ -5,6 +5,14 @@
 
 import { PublicKey } from "@solana/web3.js";
 import { PROGRAM_ID, SEEDS } from "@tetsuo-ai/sdk";
+
+type OptionalSeedRecord = Partial<Record<string, Buffer>>;
+
+// The runtime can move ahead of the published SDK package. Fall back to raw
+// seed bytes locally until the matching SDK release is available.
+const optionalSeeds = SEEDS as OptionalSeedRecord;
+const AUTHORITY_RATE_LIMIT_SEED =
+  optionalSeeds.AUTHORITY_RATE_LIMIT ?? Buffer.from("authority_rate_limit");
 import { AGENT_ID_LENGTH } from "./types.js";
 import { derivePda, validateIdLength } from "../utils/pda.js";
 
@@ -91,6 +99,38 @@ export function findAgentPda(
  */
 export function findProtocolPda(programId: PublicKey = PROGRAM_ID): PublicKey {
   return deriveProtocolPda(programId).address;
+}
+
+/**
+ * Derives the authority rate-limit PDA and bump seed.
+ * Used by task creation and dispute initiation cooldown logic.
+ * Seeds: ["authority_rate_limit", authority]
+ *
+ * @param authority - Authority (wallet) public key
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address and bump seed
+ */
+export function deriveAuthorityRateLimitPda(
+  authority: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): PdaWithBump {
+  return derivePda([AUTHORITY_RATE_LIMIT_SEED, authority.toBuffer()], programId);
+}
+
+/**
+ * Finds the authority rate-limit PDA address (without bump).
+ * Convenience wrapper around deriveAuthorityRateLimitPda for when only the
+ * address is needed.
+ *
+ * @param authority - Authority (wallet) public key
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address
+ */
+export function findAuthorityRateLimitPda(
+  authority: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): PublicKey {
+  return deriveAuthorityRateLimitPda(authority, programId).address;
 }
 
 /**

--- a/runtime/src/channels/webchat/handlers.test.ts
+++ b/runtime/src/channels/webchat/handlers.test.ts
@@ -9,6 +9,8 @@ const mocks = vi.hoisted(() => ({
   getDefaultKeypairPath: vi.fn(() => '/tmp/test-id.json'),
   fetchAllTasks: vi.fn(),
   fetchActiveClaims: vi.fn(),
+  serializeMarketplaceDisputeDetail: vi.fn(),
+  serializeMarketplaceTask: vi.fn(),
   serializeMarketplaceTaskEntry: vi.fn(),
 }));
 
@@ -37,6 +39,8 @@ vi.mock('../../marketplace/serialization.js', () => ({
   serializeMarketplaceProposalDetail: vi.fn(),
   serializeMarketplaceProposalSummary: vi.fn(),
   serializeMarketplaceSkill: vi.fn(),
+  serializeMarketplaceDisputeDetail: mocks.serializeMarketplaceDisputeDetail,
+  serializeMarketplaceTask: mocks.serializeMarketplaceTask,
   serializeMarketplaceTaskEntry: mocks.serializeMarketplaceTaskEntry,
 }));
 

--- a/runtime/src/channels/webchat/handlers.ts
+++ b/runtime/src/channels/webchat/handlers.ts
@@ -28,10 +28,12 @@ import { createProgram, createReadOnlyProgram } from '../../idl.js';
 import {
   buildMarketplaceReputationSummaryForAgent,
   buildMarketplaceUnregisteredSummary,
+  serializeMarketplaceDisputeDetail,
   serializeMarketplaceDisputeSummary,
   serializeMarketplaceProposalDetail,
   serializeMarketplaceProposalSummary,
   serializeMarketplaceSkill,
+  serializeMarketplaceTask,
   serializeMarketplaceTaskEntry,
 } from '../../marketplace/serialization.js';
 import { TaskOperations } from '../../task/operations.js';
@@ -56,6 +58,7 @@ import {
   createDelegateReputationTool,
   createInitiateDisputeTool,
   createRateSkillTool,
+  createResolveDisputeTool,
   createStakeReputationTool,
   createVoteProposalTool,
 } from '../../tools/agenc/mutation-tools.js';
@@ -64,6 +67,7 @@ import { PublicKey, SystemProgram } from '@solana/web3.js';
 import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { parseAgentState } from '../../agent/types.js';
 
 export type SendFn = (response: ControlResponse) => void;
 export interface HandlerRequestContext {
@@ -270,6 +274,36 @@ function parseToolError(result: { content: string; isError?: boolean }): string 
   } catch {
     return result.content;
   }
+}
+
+function parseToolPayload(result: { content: string }): unknown {
+  try {
+    return JSON.parse(result.content);
+  } catch {
+    return { raw: result.content };
+  }
+}
+
+function readTaskIdentifier(payload: Record<string, unknown> | undefined): string {
+  const taskId = typeof payload?.taskId === 'string' ? payload.taskId.trim() : '';
+  if (taskId) return taskId;
+  const taskPda = typeof payload?.taskPda === 'string' ? payload.taskPda.trim() : '';
+  return taskPda;
+}
+
+function readStatusFilters(payload: Record<string, unknown> | undefined): string[] {
+  if (Array.isArray(payload?.statuses)) {
+    return payload.statuses
+      .map((entry) => String(entry ?? '').trim().toLowerCase())
+      .filter(Boolean);
+  }
+  if (typeof payload?.status === 'string') {
+    return payload.status
+      .split(',')
+      .map((entry) => entry.trim().toLowerCase())
+      .filter(Boolean);
+  }
+  return [];
 }
 
 // ============================================================================
@@ -541,13 +575,8 @@ async function handleMarketSkillsPurchase(
   send: SendFn,
 ): Promise<void> {
   const skillPda = payload?.skillPda;
-  const skillId = payload?.skillId;
   if (!skillPda || typeof skillPda !== 'string') {
     send({ type: 'error', error: 'Missing skillPda in payload', id });
-    return;
-  }
-  if (!skillId || typeof skillId !== 'string') {
-    send({ type: 'error', error: 'Missing skillId in payload', id });
     return;
   }
   if (!deps.connection) {
@@ -558,6 +587,19 @@ async function handleMarketSkillsPurchase(
   try {
     const connection = deps.connection!;
     const { program } = await createProgramContext(deps);
+    const skillPublicKey = new PublicKey(skillPda);
+    let skillId = typeof payload?.skillId === 'string' ? payload.skillId.trim() : '';
+    if (!skillId) {
+      const account = await (program.account as any).skillRegistration.fetchNullable(skillPublicKey);
+      if (!account) {
+        send({ type: 'error', error: `Skill not found: ${skillPda}`, id });
+        return;
+      }
+      skillId = serializeMarketplaceSkill({
+        publicKey: skillPublicKey,
+        account: account as Record<string, unknown>,
+      }).skillId;
+    }
     const signerAgent = await resolveSignerAgent(program);
     const registryClient = new OnChainSkillRegistryClient({
       connection,
@@ -570,7 +612,7 @@ async function handleMarketSkillsPurchase(
       logger: silentLogger,
     });
     const result = await purchaseManager.purchase(
-      new PublicKey(skillPda),
+      skillPublicKey,
       skillId,
       join(homedir(), '.agenc', 'skills', `${skillId}.md`),
     );
@@ -759,11 +801,10 @@ async function handleMarketDisputesList(
       agentId: new Uint8Array(32),
       logger: silentLogger,
     });
-    const statusFilter =
-      typeof payload?.status === 'string' ? payload.status.trim().toLowerCase() : '';
+    const statusFilters = readStatusFilters(payload);
     const disputes = (await ops.fetchAllDisputes())
       .map(mapDisputeSummary)
-      .filter((entry) => !statusFilter || entry.status === statusFilter)
+      .filter((entry) => statusFilters.length === 0 || statusFilters.includes(entry.status))
       .sort((left, right) => right.createdAt - left.createdAt);
 
     send({ type: 'market.disputes.list', payload: disputes, id });
@@ -800,18 +841,62 @@ async function handleMarketDisputesDetail(
     }
     send({
       type: 'market.disputes.detail',
-      payload: serializeMarketplaceDisputeSummary({
-        dispute,
-        disputePda: new PublicKey(disputePda),
-      }),
+      payload: serializeMarketplaceDisputeDetail(new PublicKey(disputePda), dispute),
       id,
     });
   });
 }
 
+async function handleMarketDisputesResolve(
+  deps: WebChatDeps,
+  payload: Record<string, unknown> | undefined,
+  id: string | undefined,
+  send: SendFn,
+): Promise<void> {
+  const disputePda = typeof payload?.disputePda === 'string' ? payload.disputePda.trim() : '';
+  if (!disputePda) {
+    send({ type: 'error', error: 'Missing disputePda in payload', id });
+    return;
+  }
+  if (!Array.isArray(payload?.arbiterVotes) || payload.arbiterVotes.length === 0) {
+    send({ type: 'error', error: 'Missing arbiterVotes in payload', id });
+    return;
+  }
+  if (!deps.connection) {
+    send({ type: 'error', error: SOLANA_NOT_CONFIGURED, id });
+    return;
+  }
+
+  try {
+    const { program } = await createProgramContext(deps);
+    const tool = createResolveDisputeTool(program, silentLogger);
+    const result = await tool.execute({
+      disputePda,
+      arbiterVotes: payload.arbiterVotes,
+      ...(Array.isArray(payload?.extraWorkers) ? { extraWorkers: payload.extraWorkers } : {}),
+    });
+    if (result.isError) {
+      send({ type: 'error', error: `Failed to resolve dispute: ${parseToolError(result)}`, id });
+      return;
+    }
+    const resolvedPayload = {
+      disputePda,
+      result: parseToolPayload(result),
+    };
+    send({
+      type: 'market.disputes.resolved',
+      payload: resolvedPayload,
+      id,
+    });
+    deps.broadcastEvent?.('market.dispute.resolved', resolvedPayload);
+  } catch (err) {
+    send({ type: 'error', error: `Failed to resolve dispute: ${(err as Error).message}`, id });
+  }
+}
+
 async function handleMarketReputationSummary(
   deps: WebChatDeps,
-  _payload: Record<string, unknown> | undefined,
+  payload: Record<string, unknown> | undefined,
   id: string | undefined,
   send: SendFn,
 ): Promise<void> {
@@ -821,6 +906,35 @@ async function handleMarketReputationSummary(
   }
 
   await safeAsync(send, id, 'error', 'Failed to load reputation summary', async () => {
+    const requestedAgentPda =
+      typeof payload?.agentPda === 'string' ? payload.agentPda.trim() : '';
+    if (requestedAgentPda) {
+      const program = createReadOnlyProgramContext(deps);
+      const agentPda = new PublicKey(requestedAgentPda);
+      const rawAgent = await (program.account as any).agentRegistration.fetchNullable(agentPda);
+      if (!rawAgent) {
+        send({ type: 'error', error: `Agent not found: ${requestedAgentPda}`, id });
+        return;
+      }
+      const agent = parseAgentState(rawAgent as Record<string, unknown>);
+      const summary = await buildMarketplaceReputationSummaryForAgent(
+        program,
+        agentPda,
+        agent.agentId,
+      );
+      if (!summary) {
+        send({ type: 'error', error: `Reputation summary unavailable: ${requestedAgentPda}`, id });
+        return;
+      }
+      const { agentId: _agentId, ...summaryPayload } = summary;
+      send({
+        type: 'market.reputation.summary',
+        payload: summaryPayload,
+        id,
+      });
+      return;
+    }
+
     const { program } = await createProgramContext(deps);
     const authority = program.provider.publicKey?.toBase58() ?? '';
 
@@ -944,7 +1058,12 @@ async function handleMarketReputationDelegate(
  *       + 1 (max_workers) + 1 (current_workers) + 1 (status)
  */
 /** Helper: send a refreshed task list to the client using typed task operations. */
-async function sendTaskList(deps: WebChatDeps, id: string | undefined, send: SendFn): Promise<void> {
+async function sendTaskList(
+  deps: WebChatDeps,
+  id: string | undefined,
+  send: SendFn,
+  { statuses = [] }: { statuses?: string[] } = {},
+): Promise<void> {
   const program = createReadOnlyProgramContext(deps);
   const ops = new TaskOperations({
     program,
@@ -973,13 +1092,14 @@ async function sendTaskList(deps: WebChatDeps, id: string | undefined, send: Sen
 
   const payload = allTasks
     .sort((left, right) => right.task.createdAt - left.task.createdAt)
-    .map((entry) => mapTaskSummary(entry, viewerContext));
+    .map((entry) => mapTaskSummary(entry, viewerContext))
+    .filter((entry) => statuses.length === 0 || statuses.includes(entry.status));
   send({ type: 'tasks.list', payload, id });
 }
 
 export async function handleTasksList(
   deps: WebChatDeps,
-  _payload: Record<string, unknown> | undefined,
+  payload: Record<string, unknown> | undefined,
   id: string | undefined,
   send: SendFn,
 ): Promise<void> {
@@ -987,7 +1107,44 @@ export async function handleTasksList(
     send({ type: 'error', error: SOLANA_NOT_CONFIGURED, id });
     return;
   }
-  await safeAsync(send, id, 'error', 'Failed to list tasks', () => sendTaskList(deps, id, send));
+  const statuses = readStatusFilters(payload);
+  await safeAsync(send, id, 'error', 'Failed to list tasks', () => sendTaskList(deps, id, send, { statuses }));
+}
+
+async function handleTasksDetail(
+  deps: WebChatDeps,
+  payload: Record<string, unknown> | undefined,
+  id: string | undefined,
+  send: SendFn,
+): Promise<void> {
+  const taskPda = readTaskIdentifier(payload);
+  if (!taskPda) {
+    send({ type: 'error', error: 'Missing taskPda in payload', id });
+    return;
+  }
+  if (!deps.connection) {
+    send({ type: 'error', error: SOLANA_NOT_CONFIGURED, id });
+    return;
+  }
+  await safeAsync(send, id, 'error', 'Failed to inspect task', async () => {
+    const program = createReadOnlyProgramContext(deps);
+    const taskOps = new TaskOperations({
+      program,
+      agentId: new Uint8Array(32),
+      logger: silentLogger,
+    });
+    const publicKey = new PublicKey(taskPda);
+    const task = await taskOps.fetchTask(publicKey);
+    if (!task) {
+      send({ type: 'error', error: `Task not found: ${taskPda}`, id });
+      return;
+    }
+    send({
+      type: 'tasks.detail',
+      payload: serializeMarketplaceTask(publicKey, task),
+      id,
+    });
+  });
 }
 
 async function handleTasksCreate(
@@ -1010,10 +1167,15 @@ async function handleTasksCreate(
     const descStr = typeof (params as Record<string, unknown>).description === 'string'
       ? (params as Record<string, unknown>).description as string
       : 'Task from WebUI';
+    const explicitRewardLamports = typeof (params as Record<string, unknown>).rewardLamports === 'string'
+      ? (params as Record<string, unknown>).rewardLamports as string
+      : '';
     const rewardInput = typeof (params as Record<string, unknown>).reward === 'number'
       ? (params as Record<string, unknown>).reward as number
       : 0;
-    const rewardLamports = BigInt(Math.max(Math.round(rewardInput * 1_000_000_000), 10_000_000));
+    const rewardLamports = explicitRewardLamports
+      ? BigInt(explicitRewardLamports)
+      : BigInt(Math.max(Math.round(rewardInput * 1_000_000_000), 10_000_000));
     const { program } = await createProgramContext(deps);
     const tool = createCreateTaskTool(program, silentLogger);
     const result = await tool.execute({
@@ -1046,8 +1208,8 @@ async function handleTasksCancel(
   id: string | undefined,
   send: SendFn,
 ): Promise<void> {
-  const taskId = payload?.taskId;
-  if (!taskId || typeof taskId !== 'string') {
+  const taskId = readTaskIdentifier(payload);
+  if (!taskId) {
     send({ type: 'error', error: 'Missing taskId in payload', id });
     return;
   }
@@ -1086,8 +1248,8 @@ async function handleTasksClaim(
   id: string | undefined,
   send: SendFn,
 ): Promise<void> {
-  const taskId = payload?.taskId;
-  if (!taskId || typeof taskId !== 'string') {
+  const taskId = readTaskIdentifier(payload);
+  if (!taskId) {
     send({ type: 'error', error: 'Missing taskId in payload', id });
     return;
   }
@@ -1118,8 +1280,8 @@ async function handleTasksComplete(
   id: string | undefined,
   send: SendFn,
 ): Promise<void> {
-  const taskId = payload?.taskId;
-  if (!taskId || typeof taskId !== 'string') {
+  const taskId = readTaskIdentifier(payload);
+  if (!taskId) {
     send({ type: 'error', error: 'Missing taskId in payload', id });
     return;
   }
@@ -1158,8 +1320,8 @@ async function handleTasksDispute(
   id: string | undefined,
   send: SendFn,
 ): Promise<void> {
-  const taskId = payload?.taskId;
-  if (!taskId || typeof taskId !== 'string') {
+  const taskId = readTaskIdentifier(payload);
+  if (!taskId) {
     send({ type: 'error', error: 'Missing taskId in payload', id });
     return;
   }
@@ -2229,10 +2391,12 @@ export const HANDLER_MAP: Readonly<Record<string, HandlerFn>> = {
   'market.governance.vote': handleMarketGovernanceVote,
   'market.disputes.list': handleMarketDisputesList,
   'market.disputes.detail': handleMarketDisputesDetail,
+  'market.disputes.resolve': handleMarketDisputesResolve,
   'market.reputation.summary': handleMarketReputationSummary,
   'market.reputation.stake': handleMarketReputationStake,
   'market.reputation.delegate': handleMarketReputationDelegate,
   'tasks.list': handleTasksList,
+  'tasks.detail': handleTasksDetail,
   'tasks.create': handleTasksCreate,
   'tasks.claim': handleTasksClaim,
   'tasks.complete': handleTasksComplete,

--- a/runtime/src/channels/webchat/handlers.ts
+++ b/runtime/src/channels/webchat/handlers.ts
@@ -963,11 +963,11 @@ async function handleMarketReputationSummary(
       });
       return;
     }
-    const { agentId: _agentId, ...payload } = summary;
+    const { agentId: _agentId, ...summaryPayload } = summary;
 
     send({
       type: 'market.reputation.summary',
-      payload,
+      payload: summaryPayload,
       id,
     });
   });

--- a/runtime/src/channels/webchat/operator-events.test.ts
+++ b/runtime/src/channels/webchat/operator-events.test.ts
@@ -262,6 +262,31 @@ describe("operator event normalization", () => {
     });
   });
 
+  it("classifies marketplace and task events into the market family", () => {
+    const normalized = normalizeOperatorMessage({
+      type: "tasks.detail",
+      payload: {
+        taskPda: "task-1",
+        status: "open",
+      },
+    });
+    const surface = projectOperatorSurfaceEvent(normalized);
+
+    expect(normalized).toMatchObject({
+      kind: "market",
+      type: "tasks.detail",
+    });
+    expect(surface).toMatchObject({
+      family: "market",
+      type: "tasks.detail",
+      payloadRecord: {
+        taskPda: "task-1",
+        status: "open",
+      },
+      isSessionScoped: false,
+    });
+  });
+
   it("preserves top-level error strings on normalized messages and surface events", () => {
     const normalized = normalizeOperatorMessage({
       type: "error",

--- a/runtime/src/channels/webchat/operator-events.ts
+++ b/runtime/src/channels/webchat/operator-events.ts
@@ -3,6 +3,7 @@ export type NormalizedOperatorMessageKind =
   | "approval"
   | "chat"
   | "error"
+  | "market"
   | "observability"
   | "planner"
   | "run"
@@ -42,6 +43,7 @@ export type OperatorSurfaceEventFamily =
   | "approval"
   | "chat"
   | "error"
+  | "market"
   | "observability"
   | "planner"
   | "run"
@@ -131,6 +133,7 @@ function classifyOperatorMessageKind(type: string): NormalizedOperatorMessageKin
   if (type.startsWith("subagents.")) return "subagent";
   if (type === "tools.executing" || type === "tools.result") return "tool";
   if (type.startsWith("chat.")) return "chat";
+  if (type.startsWith("market.") || type.startsWith("tasks.") || type.startsWith("task.")) return "market";
   if (type === "runs.list" || type.startsWith("run.")) return "run";
   if (type.startsWith("approval.")) return "approval";
   if (type.startsWith("observability.")) return "observability";
@@ -165,6 +168,9 @@ function classifyOperatorSurfaceEventFamily(type: string): OperatorSurfaceEventF
     type === "chat.usage"
   ) {
     return "chat";
+  }
+  if (type.startsWith("market.") || type.startsWith("tasks.") || type.startsWith("task.")) {
+    return "market";
   }
   if (type === "runs.list" || type.startsWith("run.")) return "run";
   if (type.startsWith("observability.")) return "observability";

--- a/runtime/src/channels/webchat/plugin.test.ts
+++ b/runtime/src/channels/webchat/plugin.test.ts
@@ -1620,6 +1620,25 @@ describe("WebChatChannel", () => {
       );
     });
 
+    it("should handle tasks.detail with informative error (no Solana connection)", () => {
+      const send = vi.fn<(response: ControlResponse) => void>();
+
+      channel.handleMessage(
+        "client_1",
+        "tasks.detail",
+        msg("tasks.detail", { taskPda: "task-1" }, "req-task-detail"),
+        send,
+      );
+
+      expect(send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "error",
+          error: expect.stringContaining("Solana connection"),
+          id: "req-task-detail",
+        }),
+      );
+    });
+
     it("should handle task mutations with informative errors when no Solana connection", () => {
       const send = vi.fn<(response: ControlResponse) => void>();
 
@@ -2231,6 +2250,32 @@ describe("WebChatChannel", () => {
           type: "error",
           error: expect.stringContaining("Solana connection"),
           id: "req-market-reputation",
+        }),
+      );
+    });
+
+    it("should handle dispute resolution with informative error when no Solana connection", () => {
+      const send = vi.fn<(response: ControlResponse) => void>();
+
+      channel.handleMessage(
+        "client_1",
+        "market.disputes.resolve",
+        msg(
+          "market.disputes.resolve",
+          {
+            disputePda: "dispute-1",
+            arbiterVotes: [{ votePda: "vote-1", arbiterAgentPda: "agent-1" }],
+          },
+          "req-market-resolve",
+        ),
+        send,
+      );
+
+      expect(send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "error",
+          error: expect.stringContaining("Solana connection"),
+          id: "req-market-resolve",
         }),
       );
     });

--- a/runtime/src/cli/config-contract.test.ts
+++ b/runtime/src/cli/config-contract.test.ts
@@ -72,6 +72,7 @@ describe("cli config contract", () => {
       connection: {
         rpcUrl: "https://rpc.example",
         programId: "AGENT1111111111111111111111111111111111111",
+        keypairPath: "/tmp/agenc/configured-id.json",
       },
       logging: { level: "info" },
       replay: {
@@ -97,6 +98,7 @@ describe("cli config contract", () => {
     expect(contract.fileConfig.programId).toBe(
       "AGENT1111111111111111111111111111111111111",
     );
+    expect(contract.fileConfig.keypairPath).toBe("/tmp/agenc/configured-id.json");
     expect(contract.fileConfig.storeType).toBe("sqlite");
     expect(contract.fileConfig.sqlitePath).toBe("/tmp/replay.sqlite");
     expect(contract.fileConfig.traceId).toBe("trace-123");

--- a/runtime/src/cli/config-contract.ts
+++ b/runtime/src/cli/config-contract.ts
@@ -159,6 +159,7 @@ function parseCanonicalCliConfig(value: GatewayConfig): CliFileConfig {
   return {
     rpcUrl: parseOptionalString(value.connection.rpcUrl),
     programId: parseOptionalString(value.connection.programId),
+    keypairPath: parseOptionalString(value.connection.keypairPath),
     storeType:
       normalizeStoreType(value.replay?.store?.type) ?? DEFAULT_CLI_STORE_TYPE,
     sqlitePath: parseOptionalString(value.replay?.store?.sqlitePath),

--- a/runtime/src/cli/index.test.ts
+++ b/runtime/src/cli/index.test.ts
@@ -42,11 +42,13 @@ const {
   runMarketTaskCreateCommand,
   runMarketTaskClaimCommand,
   runMarketGovernanceVoteCommand,
+  runMarketReputationSummaryCommand,
 } = vi.hoisted(() => ({
   runMarketTasksListCommand: vi.fn(async () => 0),
   runMarketTaskCreateCommand: vi.fn(async () => 0),
   runMarketTaskClaimCommand: vi.fn(async () => 0),
   runMarketGovernanceVoteCommand: vi.fn(async () => 0),
+  runMarketReputationSummaryCommand: vi.fn(async () => 0),
 }));
 const { runMarketTuiCommand } = vi.hoisted(() => ({
   runMarketTuiCommand: vi.fn(async () => 0),
@@ -85,6 +87,7 @@ vi.mock("./marketplace-cli.js", async () => {
     runMarketTaskCreateCommand,
     runMarketTaskClaimCommand,
     runMarketGovernanceVoteCommand,
+    runMarketReputationSummaryCommand,
   };
 });
 
@@ -402,6 +405,41 @@ describe("runtime root CLI", () => {
         description: "Public task from CLI test",
         reward: "50000000",
         requiredCapabilities: "1",
+      }),
+    );
+  });
+
+  it("routes market reputation summaries through the root CLI command surface with configured keypair paths", async () => {
+    const stdout = captureStream();
+    const stderr = captureStream();
+    const configuredKeypairPath = join(workspace, "configured-id.json");
+    writeFileSync(
+      process.env.AGENC_CONFIG!,
+      JSON.stringify({
+        gateway: { port: 3100 },
+        agent: { name: "cli-root-test-agent" },
+        connection: {
+          rpcUrl: "https://api.devnet.solana.com",
+          keypairPath: configuredKeypairPath,
+        },
+        replay: { store: { type: "memory" } },
+      }),
+      "utf8",
+    );
+
+    const code = await runCli({
+      argv: ["market", "reputation", "summary"],
+      stdout: stdout.stream,
+      stderr: stderr.stream,
+    });
+
+    expect(code).toBe(0);
+    expect(stderr.data()).toBe("");
+    expect(runMarketReputationSummaryCommand).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        rpcUrl: "https://api.devnet.solana.com",
+        keypairPath: configuredKeypairPath,
       }),
     );
   });

--- a/runtime/src/cli/index.ts
+++ b/runtime/src/cli/index.ts
@@ -1473,6 +1473,7 @@ function normalizeGlobalFlags(
   role?: OperatorRole;
   rpcUrl?: string;
   programId?: string;
+  keypairPath?: string;
   storeType: "memory" | "sqlite";
   sqlitePath?: string;
   traceId?: string;
@@ -1499,6 +1500,7 @@ function normalizeGlobalFlags(
     programId: parseOptionalString(
       flags["program-id"] ?? envConfig.programId ?? fileConfig.programId,
     ),
+    keypairPath: parseOptionalString(fileConfig.keypairPath),
     storeType: normalizeStoreType(
       flags["store-type"] ?? envConfig.storeType ?? fileConfig.storeType,
     ),
@@ -1616,6 +1618,7 @@ function makePluginOptionsBase(global: PluginGlobalContext): BaseCliOptions {
     role: global.role,
     rpcUrl: global.rpcUrl,
     programId: global.programId,
+    keypairPath: global.keypairPath,
     storeType: global.storeType,
     sqlitePath: global.sqlitePath,
     traceId: global.traceId,
@@ -2083,6 +2086,7 @@ function normalizeAndValidate(parsed: ParsedArgv): CliParseReport {
     role: global.role,
     rpcUrl: global.rpcUrl,
     programId: global.programId,
+    keypairPath: global.keypairPath,
     storeType: global.storeType,
     sqlitePath: global.sqlitePath,
     traceId: global.traceId,
@@ -2193,6 +2197,7 @@ function normalizeAndValidatePluginCommand(
     role: global.role,
     rpcUrl: global.rpcUrl,
     programId: global.programId,
+    keypairPath: global.keypairPath,
     storeType: global.storeType,
     sqlitePath: global.sqlitePath,
     traceId: global.traceId,
@@ -2315,6 +2320,7 @@ function normalizeAndValidateSkillCommand(
     role: global.role,
     rpcUrl: global.rpcUrl,
     programId: global.programId,
+    keypairPath: global.keypairPath,
     storeType: global.storeType,
     sqlitePath: global.sqlitePath,
     traceId: global.traceId,
@@ -2560,6 +2566,7 @@ function normalizeAndValidateMarketCommand(
     role: global.role,
     rpcUrl: global.rpcUrl,
     programId: global.programId,
+    keypairPath: global.keypairPath,
     storeType: global.storeType,
     sqlitePath: global.sqlitePath,
     traceId: global.traceId,

--- a/runtime/src/cli/marketplace-cli.ts
+++ b/runtime/src/cli/marketplace-cli.ts
@@ -290,7 +290,9 @@ async function createSignerProgramContext(options: BaseCliOptions): Promise<{
   const connection = new Connection(rpcUrl);
   const programId = parseProgramId(options.programId);
   const keypairPath =
-    process.env.SOLANA_KEYPAIR_PATH ?? getDefaultKeypairPath();
+    options.keypairPath ??
+    process.env.SOLANA_KEYPAIR_PATH ??
+    getDefaultKeypairPath();
   const keypair = await loadKeypairFromFile(keypairPath);
   const provider = createWalletProvider(connection, keypair);
   return {

--- a/runtime/src/cli/operator-console.test.ts
+++ b/runtime/src/cli/operator-console.test.ts
@@ -95,6 +95,7 @@ describe("operator console launcher", () => {
         stdio: "inherit",
         cwd: "/repo",
         env: expect.objectContaining({
+          AGENC_WATCH_ENABLE_REMOTE_TOOLS: "true",
           AGENC_WATCH_WS_URL: "ws://127.0.0.1:3100",
           AGENC_WATCH_PROJECT_ROOT: "/repo",
           AGENC_WATCH_CLIENT_KEY: expect.stringMatching(
@@ -133,6 +134,7 @@ describe("operator console launcher", () => {
       ["/repo/runtime/dist/bin/agenc-watch.js"],
       expect.objectContaining({
         env: expect.objectContaining({
+          AGENC_WATCH_ENABLE_REMOTE_TOOLS: "true",
           AGENC_WATCH_WS_URL: "ws://127.0.0.1:4100",
           AGENC_WATCH_PROJECT_ROOT: "/repo",
           AGENC_WATCH_CLIENT_KEY: expect.stringMatching(
@@ -171,7 +173,43 @@ describe("operator console launcher", () => {
       ["/repo/runtime/dist/bin/agenc-watch.js"],
       expect.objectContaining({
         env: expect.objectContaining({
+          AGENC_WATCH_ENABLE_REMOTE_TOOLS: "true",
           AGENC_WATCH_CLIENT_KEY: "manual-watch-key",
+          AGENC_WATCH_PROJECT_ROOT: "/repo",
+        }),
+      }),
+    );
+  });
+
+  it("preserves an explicit remote tools override", async () => {
+    const child = new FakeChildProcess();
+    const spawnProcess = vi.fn().mockImplementation(() => {
+      queueMicrotask(() => child.exit(0));
+      return child;
+    });
+    const deps = createDeps({
+      readPidFile: vi.fn().mockResolvedValue({
+        pid: 7654,
+        port: 4100,
+        configPath: "/tmp/agenc.json",
+      }),
+      isProcessAlive: vi.fn().mockReturnValue(true),
+      spawnProcess,
+      env: {
+        PATH: process.env.PATH ?? "",
+        AGENC_WATCH_ENABLE_REMOTE_TOOLS: "false",
+      },
+    });
+
+    const code = await runOperatorConsole({}, deps);
+
+    expect(code).toBe(0);
+    expect(spawnProcess).toHaveBeenCalledWith(
+      process.execPath,
+      ["/repo/runtime/dist/bin/agenc-watch.js"],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          AGENC_WATCH_ENABLE_REMOTE_TOOLS: "false",
           AGENC_WATCH_PROJECT_ROOT: "/repo",
         }),
       }),

--- a/runtime/src/cli/operator-console.ts
+++ b/runtime/src/cli/operator-console.ts
@@ -258,6 +258,9 @@ async function launchConsoleProcess(
     AGENC_WATCH_WS_URL: `ws://127.0.0.1:${port}`,
     AGENC_WATCH_PROJECT_ROOT: launchCwd,
   };
+  if (mergedEnv.AGENC_WATCH_ENABLE_REMOTE_TOOLS == null) {
+    mergedEnv.AGENC_WATCH_ENABLE_REMOTE_TOOLS = "true";
+  }
   const explicitClientKey = mergedEnv.AGENC_WATCH_CLIENT_KEY?.trim();
   if (!explicitClientKey) {
     mergedEnv.AGENC_WATCH_CLIENT_KEY = deriveProjectWatchClientKey(launchCwd);

--- a/runtime/src/cli/types.ts
+++ b/runtime/src/cli/types.ts
@@ -27,6 +27,7 @@ export interface BaseCliOptions {
   role?: OperatorRole;
   rpcUrl?: string;
   programId?: string;
+  keypairPath?: string;
   storeType: "memory" | "sqlite";
   sqlitePath?: string;
   traceId?: string;
@@ -184,6 +185,7 @@ export interface CliFileConfig {
   configVersion?: string;
   rpcUrl?: string;
   programId?: string;
+  keypairPath?: string;
   storeType?: "memory" | "sqlite";
   sqlitePath?: string;
   traceId?: string;

--- a/runtime/src/dispute/operations.test.ts
+++ b/runtime/src/dispute/operations.test.ts
@@ -31,6 +31,8 @@ import {
 import { PROGRAM_ID, SEEDS } from "@tetsuo-ai/sdk";
 import { silentLogger } from "../utils/logger.js";
 import { generateAgentId } from "../utils/encoding.js";
+import { findAuthorityRateLimitPda } from "../agent/pda.js";
+import { deriveTaskSubmissionPda } from "../task/pda.js";
 
 // ============================================================================
 // Test Helpers
@@ -126,6 +128,9 @@ function createMockProgram(overrides: Record<string, any> = {}) {
       },
       task: {
         fetch: vi.fn().mockResolvedValue({ rewardMint: null }),
+      },
+      taskSubmission: {
+        fetchNullable: vi.fn().mockResolvedValue(null),
       },
     },
     methods: {
@@ -565,7 +570,65 @@ describe("DisputeOperations", () => {
       expect(result.transactionSignature).toBe("mock-signature");
       expect(result.disputePda).toBeDefined();
       expect(program.methods.initiateDispute).toHaveBeenCalled();
-      expect(program._methodBuilder.accountsPartial).toHaveBeenCalled();
+      expect(program._methodBuilder.accountsPartial).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authorityRateLimit: findAuthorityRateLimitPda(
+            program.provider.publicKey,
+            program.programId,
+          ),
+        }),
+      );
+    });
+
+    it("omits taskSubmission when the derived submission account does not exist", async () => {
+      const workerClaimPda = randomPubkey();
+
+      await ops.initiateDispute({
+        disputeId: randomBytes(32),
+        taskPda: randomPubkey(),
+        taskId: randomBytes(32),
+        evidenceHash: randomBytes(32),
+        resolutionType: 1,
+        evidence: "Creator dispute tied to an existing worker claim.",
+        workerAgentPda: randomPubkey(),
+        workerClaimPda,
+      });
+
+      expect(program.account.taskSubmission.fetchNullable).toHaveBeenCalledWith(
+        deriveTaskSubmissionPda(workerClaimPda, program.programId).address,
+      );
+      expect(program._methodBuilder.accountsPartial).toHaveBeenCalledWith(
+        expect.objectContaining({
+          taskSubmission: null,
+        }),
+      );
+    });
+
+    it("passes taskSubmission when the derived submission account exists", async () => {
+      const workerClaimPda = randomPubkey();
+      program.account.taskSubmission.fetchNullable.mockResolvedValue({
+        worker: randomPubkey(),
+      });
+
+      await ops.initiateDispute({
+        disputeId: randomBytes(32),
+        taskPda: randomPubkey(),
+        taskId: randomBytes(32),
+        evidenceHash: randomBytes(32),
+        resolutionType: 1,
+        evidence: "Creator dispute tied to an existing worker submission.",
+        workerAgentPda: randomPubkey(),
+        workerClaimPda,
+      });
+
+      expect(program._methodBuilder.accountsPartial).toHaveBeenCalledWith(
+        expect.objectContaining({
+          taskSubmission: deriveTaskSubmissionPda(
+            workerClaimPda,
+            program.programId,
+          ).address,
+        }),
+      );
     });
 
     it("initiates dispute as creator with defendant workers", async () => {

--- a/runtime/src/dispute/operations.ts
+++ b/runtime/src/dispute/operations.ts
@@ -366,7 +366,10 @@ export class DisputeOperations {
         params.defendantWorkers,
       );
 
-      const builder = this.program.methods
+      // The runtime patches local IDL account layouts ahead of the published
+      // protocol typings, so this builder needs a narrow escape hatch until the
+      // package catches up.
+      const builder = (this.program.methods as any)
         .initiateDispute(
           toAnchorBytes(params.disputeId),
           toAnchorBytes(params.taskId),

--- a/runtime/src/dispute/operations.ts
+++ b/runtime/src/dispute/operations.ts
@@ -35,11 +35,12 @@ import {
 import { deriveDisputePda, deriveVotePda } from "./pda.js";
 import {
   findAgentPda,
+  findAuthorityRateLimitPda,
   findProtocolPda,
   deriveAuthorityVotePda,
 } from "../agent/pda.js";
 import { fetchTreasury } from "../utils/treasury.js";
-import { deriveClaimPda, deriveEscrowPda } from "../task/pda.js";
+import { deriveClaimPda, deriveEscrowPda, deriveTaskSubmissionPda } from "../task/pda.js";
 import {
   buildResolveDisputeTokenAccounts,
   buildExpireDisputeTokenAccounts,
@@ -113,6 +114,7 @@ export class DisputeOperations {
   // Cached derived values
   private readonly agentPda: PublicKey;
   private readonly protocolPda: PublicKey;
+  private readonly authorityRateLimitPda: PublicKey;
   private cachedTreasury: PublicKey | null = null;
 
   constructor(config: DisputeOpsConfig) {
@@ -123,6 +125,30 @@ export class DisputeOperations {
 
     this.agentPda = findAgentPda(this.agentId, this.program.programId);
     this.protocolPda = findProtocolPda(this.program.programId);
+    this.authorityRateLimitPda = findAuthorityRateLimitPda(
+      this.program.provider.publicKey!,
+      this.program.programId,
+    );
+  }
+
+  private async resolveExistingTaskSubmissionPda(
+    claimPda: PublicKey | null,
+  ): Promise<PublicKey | null> {
+    if (!claimPda) return null;
+
+    const taskSubmissionPda = deriveTaskSubmissionPda(
+      claimPda,
+      this.program.programId,
+    ).address;
+    const taskSubmissionAccount = await (
+      this.program.account as unknown as {
+        taskSubmission?: {
+          fetchNullable?: (pda: PublicKey) => Promise<unknown>;
+        };
+      }
+    ).taskSubmission?.fetchNullable?.(taskSubmissionPda);
+
+    return taskSubmissionAccount ? taskSubmissionPda : null;
   }
 
   // ==========================================================================
@@ -324,6 +350,11 @@ export class DisputeOperations {
       params.initiatorClaimPda === undefined
         ? derivedClaimPda
         : params.initiatorClaimPda;
+    const taskSubmissionClaimPda =
+      params.workerClaimPda ?? initiatorClaimPda ?? null;
+    const taskSubmissionPda = await this.resolveExistingTaskSubmissionPda(
+      taskSubmissionClaimPda,
+    );
 
     this.logger.info(
       `Initiating dispute for task ${params.taskPda.toBase58()}`,
@@ -347,10 +378,12 @@ export class DisputeOperations {
           dispute: disputePda,
           task: params.taskPda,
           agent: this.agentPda,
+          authorityRateLimit: this.authorityRateLimitPda,
           protocolConfig: this.protocolPda,
           initiatorClaim: initiatorClaimPda ?? null,
           workerAgent: params.workerAgentPda ?? null,
           workerClaim: params.workerClaimPda ?? null,
+          taskSubmission: taskSubmissionPda,
           authority: this.program.provider.publicKey,
           systemProgram: SystemProgram.programId,
         });

--- a/runtime/src/gateway/daemon-tool-registry.ts
+++ b/runtime/src/gateway/daemon-tool-registry.ts
@@ -36,7 +36,10 @@ import { createSandboxTools } from "../tools/system/sandbox-handle.js";
 import { createServerTools } from "../tools/system/server.js";
 import { createSqliteTools } from "../tools/system/sqlite.js";
 import { createSpreadsheetTools } from "../tools/system/spreadsheet.js";
-import { createTaskTrackerTools } from "../tools/system/task-tracker.js";
+import {
+  createTaskTrackerTools,
+  TaskStore,
+} from "../tools/system/task-tracker.js";
 import { resolveBrowserToolMode } from "./browser-tool-mode.js";
 import { createExecuteWithAgentTool } from "./delegation-tool.js";
 import { createCoordinatorModeTool } from "./coordinator-tool.js";
@@ -51,6 +54,7 @@ import {
 } from "../policy/index.js";
 import { ConnectionManager } from "../connection/manager.js";
 import type { UnifiedTelemetryCollector } from "../telemetry/collector.js";
+import { PublicKey } from "@solana/web3.js";
 import {
   resolveBashToolEnv,
   resolveBashDenyExclusions,
@@ -88,6 +92,7 @@ interface ToolRegistrySideEffects {
   containerMCPConfigs: GatewayMCPServerConfig[];
   mcpManager: import("../mcp-client/manager.js").MCPManager | null;
   connectionManager: ConnectionManager | null;
+  taskTrackerStore: TaskStore;
 }
 
 // ============================================================================
@@ -308,7 +313,8 @@ export async function createDaemonToolRegistry(
       logger,
     ),
   );
-  registry.registerAll(createTaskTrackerTools());
+  const taskTrackerStore = new TaskStore();
+  registry.registerAll(createTaskTrackerTools(taskTrackerStore));
   registry.register(createExecuteWithAgentTool());
   registry.register(createCoordinatorModeTool());
   const walletResult = await loadWallet(config);
@@ -571,12 +577,16 @@ export async function createDaemonToolRegistry(
         metrics,
       });
       connectionManager = connMgr;
+      const configuredProgramId = config.connection.programId?.trim()
+        ? new PublicKey(config.connection.programId.trim())
+        : undefined;
 
       const { createAgencTools } = await import("../tools/agenc/index.js");
       registry.registerAll(
         createAgencTools({
           connection: connMgr.getConnection(),
           wallet: walletResult?.wallet,
+          ...(configuredProgramId ? { programId: configuredProgramId } : {}),
           logger,
         }),
       );
@@ -626,5 +636,6 @@ export async function createDaemonToolRegistry(
     containerMCPConfigs,
     mcpManager,
     connectionManager,
+    taskTrackerStore,
   };
 }

--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { PublicKey } from "@solana/web3.js";
 import { mkdtemp, rm, readFile, writeFile, stat, mkdir, chmod } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -7,6 +8,9 @@ const mockDesktopManagerStart = vi.fn(async () => {});
 const mockDesktopManagerStop = vi.fn(async () => {});
 const mockWatchdogStart = vi.fn();
 const mockWatchdogStop = vi.fn();
+const { mockCreateAgencTools } = vi.hoisted(() => ({
+  mockCreateAgencTools: vi.fn(() => []),
+}));
 
 // Provide real async utils (no dependency chain)
 vi.mock("../utils/async.js", () => ({
@@ -71,6 +75,10 @@ vi.mock("./config-watcher.js", () => ({
 
 vi.mock("./wallet-loader.js", () => ({
   loadWallet: vi.fn(async () => null),
+}));
+
+vi.mock("../tools/agenc/index.js", () => ({
+  createAgencTools: mockCreateAgencTools,
 }));
 
 vi.mock("../desktop/manager.js", () => {
@@ -138,6 +146,7 @@ import { didToolCallFail } from "../llm/chat-executor-tool-utils.js";
 import { PolicyEngine } from "../policy/engine.js";
 import { createPolicyGateHook } from "../policy/policy-gate.js";
 import { SESSION_ALLOWED_ROOTS_ARG } from "../tools/system/filesystem.js";
+import { TaskStore } from "../tools/system/task-tracker.js";
 import {
   SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY,
   SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY,
@@ -2169,6 +2178,134 @@ describe("DaemonManager", () => {
       { task: "test" },
     );
     expect(directResult).toContain("session-scoped tool handler");
+  });
+
+  it("forwards the configured programId when registering agenc tools", async () => {
+    const programId = "11111111111111111111111111111111";
+    const dm = new DaemonManager({ configPath: "/tmp/config.json" });
+
+    await (dm as any).createToolRegistry({
+      desktop: { enabled: false },
+      connection: {
+        rpcUrl: "http://localhost:8899",
+        programId,
+      },
+    });
+
+    expect(mockCreateAgencTools).toHaveBeenCalledTimes(1);
+    expect(mockCreateAgencTools).toHaveBeenCalledWith(
+      expect.objectContaining({
+        programId: expect.any(PublicKey),
+      }),
+    );
+    const registrationArgs = mockCreateAgencTools.mock.calls[0]?.[0] as {
+      programId?: PublicKey;
+    };
+    expect(registrationArgs.programId?.toBase58()).toBe(programId);
+  });
+
+  it("drops web-session task tracker state during session reset", async () => {
+    const dm = new DaemonManager({ configPath: "/tmp/config.json" });
+    const taskStore = new TaskStore();
+    taskStore.create("web-session-1", {
+      subject: "Existing task",
+      description: "Should be dropped on reset",
+    });
+    (dm as any)._taskTrackerStore = taskStore;
+
+    const sessionMgr = {
+      reset: vi.fn(),
+    };
+    const memoryBackend = {
+      deleteThread: vi.fn(async () => undefined),
+      get: vi.fn(async () => undefined),
+      delete: vi.fn(async () => undefined),
+    };
+    const progressTracker = {
+      clear: vi.fn(async () => undefined),
+    };
+
+    await (dm as any).resetWebSessionContext({
+      webSessionId: "web-session-1",
+      sessionMgr,
+      resolveSessionId: (sessionKey: string) => `history:${sessionKey}`,
+      memoryBackend,
+      progressTracker,
+    });
+
+    expect(sessionMgr.reset).toHaveBeenCalledWith("history:web-session-1");
+    expect(taskStore.create("web-session-1", {
+      subject: "Replacement task",
+      description: "Fresh list after reset",
+    }).id).toBe("1");
+  });
+
+  it("drops subagent task tracker state when subagent contexts are destroyed", async () => {
+    const dm = new DaemonManager({ configPath: "/tmp/config.json" });
+    const taskStore = new TaskStore();
+    taskStore.create("subagent:child-1", {
+      subject: "Subagent task",
+      description: "Should be dropped during teardown",
+    });
+    (dm as any)._taskTrackerStore = taskStore;
+    (dm as any)._llmProviders = [{}];
+    vi.spyOn(dm as any, "ensureSubAgentDefaultWorkspace").mockResolvedValue(undefined);
+    vi.spyOn(dm as any, "resolveLlmContextWindowTokens").mockResolvedValue(128_000);
+
+    await (dm as any).configureSubAgentInfrastructure({
+      llm: {
+        provider: "grok",
+        subagents: {
+          enabled: true,
+        },
+      },
+    });
+
+    const destroyContext = vi.fn(async () => undefined);
+    (dm as any)._sessionIsolationManager = {
+      destroyContext,
+      listActiveContexts: () => [],
+    };
+
+    const destroySubagentContext = ((dm as any)._subAgentManager as any).config
+      .destroyContext as (sessionIdentity: {
+        parentSessionId: string;
+        subagentSessionId: string;
+      }) => Promise<void>;
+
+    await destroySubagentContext({
+      parentSessionId: "parent-session-1",
+      subagentSessionId: "subagent:child-1",
+    });
+
+    expect(destroyContext).toHaveBeenCalledWith({
+      parentSessionId: "parent-session-1",
+      subagentSessionId: "subagent:child-1",
+    });
+    expect(taskStore.create("subagent:child-1", {
+      subject: "Replacement subagent task",
+      description: "Fresh list after teardown",
+    }).id).toBe("1");
+
+    await (dm as any).destroySubAgentInfrastructure();
+  });
+
+  it("clears the shared task tracker store when the daemon stops", async () => {
+    const dm = new DaemonManager({ configPath: "/tmp/config.json" });
+    const taskStore = new TaskStore();
+    taskStore.create("session-stop-1", {
+      subject: "Stop cleanup",
+      description: "Should be cleared during daemon shutdown",
+    });
+    (dm as any)._taskTrackerStore = taskStore;
+
+    await dm.stop();
+
+    expect((dm as any)._taskTrackerStore).toBeNull();
+    expect(taskStore.create("session-stop-1", {
+      subject: "Replacement stop cleanup",
+      description: "Fresh list after stop",
+    }).id).toBe("1");
   });
 
   it("disables host execution deny lists when yolo mode is enabled", async () => {

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -129,6 +129,7 @@ import {
 import { ToolRegistry } from "../tools/registry.js";
 import { SystemRemoteJobManager } from "../tools/system/remote-job.js";
 import { SystemRemoteSessionManager } from "../tools/system/remote-session.js";
+import { TaskStore } from "../tools/system/task-tracker.js";
 import { DEFAULT_TIMEOUT_MS as DEFAULT_BASH_TOOL_TIMEOUT_MS } from "../tools/system/types.js";
 import {
   SkillDiscovery,
@@ -1026,6 +1027,7 @@ export class DaemonManager {
   private _durableSubrunOrchestrator: DurableSubrunOrchestrator | null = null;
   private _remoteJobManager: SystemRemoteJobManager | null = null;
   private _remoteSessionManager: SystemRemoteSessionManager | null = null;
+  private _taskTrackerStore: TaskStore | null = null;
   private _sessionModelInfo = new Map<
     string,
     {
@@ -1347,6 +1349,10 @@ export class DaemonManager {
         if (manager) {
           await manager.destroyContext(sessionIdentity);
         }
+        this.dropTaskTrackerSession(
+          sessionIdentity.subagentSessionId,
+          "subagent_teardown",
+        );
         await cleanupDesktopSession(
           sessionIdentity.subagentSessionId,
           {
@@ -3583,6 +3589,7 @@ export class DaemonManager {
     }, metrics);
     this._remoteJobManager = result.remoteJobManager;
     this._remoteSessionManager = result.remoteSessionManager;
+    this._taskTrackerStore = result.taskTrackerStore;
     this._containerMCPConfigs = result.containerMCPConfigs;
     this._mcpManager = result.mcpManager;
     this._connectionManager = result.connectionManager;
@@ -3596,6 +3603,20 @@ export class DaemonManager {
       },
       logger: this.logger,
     });
+  }
+
+  private dropTaskTrackerSession(sessionId: string, reason: string): void {
+    const normalizedSessionId = sessionId.trim();
+    if (!normalizedSessionId || !this._taskTrackerStore) {
+      return;
+    }
+    const dropped = this._taskTrackerStore.dropList(normalizedSessionId);
+    if (dropped) {
+      this.logger.debug("Dropped task tracker state for session", {
+        sessionId: normalizedSessionId,
+        reason,
+      });
+    }
   }
 
   private handleIncomingSocialMessage(
@@ -3696,6 +3717,7 @@ export class DaemonManager {
 
     const historySessionId = resolveSessionId(webSessionId);
     sessionMgr.reset(historySessionId);
+    this.dropTaskTrackerSession(webSessionId, "session_reset");
     this._chatExecutor?.resetSessionTokens(webSessionId);
     this._sessionModelInfo.delete(webSessionId);
     await progressTracker?.clear(webSessionId);
@@ -5890,6 +5912,10 @@ export class DaemonManager {
       if (this._connectionManager !== null) {
         this._connectionManager.destroy();
         this._connectionManager = null;
+      }
+      if (this._taskTrackerStore !== null) {
+        this._taskTrackerStore.reset();
+        this._taskTrackerStore = null;
       }
       if (this._memoryBackend !== null) {
         await this._memoryBackend.close();

--- a/runtime/src/gateway/tool-handler-factory.test.ts
+++ b/runtime/src/gateway/tool-handler-factory.test.ts
@@ -14,6 +14,11 @@ import type { SubAgentResult } from "./sub-agent.js";
 import { createSessionToolHandler } from "./tool-handler-factory.js";
 import { SessionCredentialBroker } from "../policy/session-credentials.js";
 import { SESSION_ALLOWED_ROOTS_ARG } from "../tools/system/filesystem.js";
+import {
+  createTaskTrackerTools,
+  TASK_LIST_ARG,
+  TaskStore,
+} from "../tools/system/task-tracker.js";
 import { createMockMemoryBackend } from "../memory/test-utils.js";
 import { EffectLedger } from "../workflow/effect-ledger.js";
 
@@ -354,6 +359,132 @@ describe("createSessionToolHandler", () => {
       path: `${workspaceRoot}/src/index.ts`,
       content: "export const safe = true;\n",
       [SESSION_ALLOWED_ROOTS_ARG]: [workspaceRoot],
+    });
+  });
+
+  it("injects session task-list ids on the gateway path and strips spoofed internal args", async () => {
+    const taskStore = new TaskStore();
+    const taskTools = new Map(
+      createTaskTrackerTools(taskStore).map((tool) => [tool.name, tool]),
+    );
+    const sentMessages: ControlResponse[] = [];
+    const send = vi.fn((msg: ControlResponse): void => {
+      sentMessages.push(msg);
+    });
+    const baseHandler = vi.fn(
+      async (toolName: string, args: Record<string, unknown>) => {
+        const tool = taskTools.get(toolName);
+        if (!tool) {
+          throw new Error(`Unexpected tool: ${toolName}`);
+        }
+        const result = await tool.execute(args);
+        return result.content;
+      },
+    );
+
+    const sessionAHandler = createSessionToolHandler({
+      sessionId: "session-a",
+      baseHandler,
+      routerId: "router-a",
+      send,
+    });
+    const sessionBHandler = createSessionToolHandler({
+      sessionId: "session-b",
+      baseHandler,
+      routerId: "router-a",
+      send,
+    });
+
+    await sessionAHandler("task.create", {
+      subject: "Session A task",
+      description: "Created through the gateway handler",
+      [TASK_LIST_ARG]: "spoofed-a",
+    });
+    await sessionBHandler("task.create", {
+      subject: "Session B task",
+      description: "Created through the gateway handler",
+      [TASK_LIST_ARG]: "spoofed-b",
+    });
+    const sessionATasks = JSON.parse(await sessionAHandler("task.list", {})) as {
+      count: number;
+      tasks: Array<{ subject: string }>;
+    };
+    const sessionBTasks = JSON.parse(await sessionBHandler("task.list", {})) as {
+      count: number;
+      tasks: Array<{ subject: string }>;
+    };
+
+    expect(baseHandler).toHaveBeenNthCalledWith(1, "task.create", {
+      subject: "Session A task",
+      description: "Created through the gateway handler",
+      [TASK_LIST_ARG]: "session-a",
+    });
+    expect(baseHandler).toHaveBeenNthCalledWith(2, "task.create", {
+      subject: "Session B task",
+      description: "Created through the gateway handler",
+      [TASK_LIST_ARG]: "session-b",
+    });
+    expect(baseHandler).toHaveBeenNthCalledWith(3, "task.list", {
+      [TASK_LIST_ARG]: "session-a",
+    });
+    expect(baseHandler).toHaveBeenNthCalledWith(4, "task.list", {
+      [TASK_LIST_ARG]: "session-b",
+    });
+
+    const executingMessages = sentMessages.filter(
+      (msg) => msg.type === "tools.executing",
+    );
+    expect(executingMessages).toHaveLength(4);
+    expect(executingMessages[0]).toMatchObject({
+      payload: {
+        toolName: "task.create",
+        args: {
+          subject: "Session A task",
+          description: "Created through the gateway handler",
+        },
+      },
+    });
+    expect((executingMessages[0]?.payload as { args?: Record<string, unknown> }).args).not.toHaveProperty(
+      TASK_LIST_ARG,
+    );
+    expect(executingMessages[1]).toMatchObject({
+      payload: {
+        toolName: "task.create",
+        args: {
+          subject: "Session B task",
+          description: "Created through the gateway handler",
+        },
+      },
+    });
+    expect((executingMessages[1]?.payload as { args?: Record<string, unknown> }).args).not.toHaveProperty(
+      TASK_LIST_ARG,
+    );
+    expect(executingMessages[2]).toMatchObject({
+      payload: {
+        toolName: "task.list",
+        args: {},
+      },
+    });
+    expect((executingMessages[2]?.payload as { args?: Record<string, unknown> }).args).not.toHaveProperty(
+      TASK_LIST_ARG,
+    );
+    expect(executingMessages[3]).toMatchObject({
+      payload: {
+        toolName: "task.list",
+        args: {},
+      },
+    });
+    expect((executingMessages[3]?.payload as { args?: Record<string, unknown> }).args).not.toHaveProperty(
+      TASK_LIST_ARG,
+    );
+
+    expect(sessionATasks).toMatchObject({
+      count: 1,
+      tasks: [{ subject: "Session A task" }],
+    });
+    expect(sessionBTasks).toMatchObject({
+      count: 1,
+      tasks: [{ subject: "Session B task" }],
     });
   });
 

--- a/runtime/src/governance/operations.ts
+++ b/runtime/src/governance/operations.ts
@@ -8,7 +8,7 @@
  */
 
 import { PublicKey, SystemProgram } from "@solana/web3.js";
-import anchor, { type Program } from "@coral-xyz/anchor";
+import { BN, type Program } from "@coral-xyz/anchor";
 import type { AgencCoordination } from "../types/agenc_coordination.js";
 import type { Logger } from "../utils/logger.js";
 import { silentLogger } from "../utils/logger.js";
@@ -201,11 +201,11 @@ export class GovernanceOperations {
 
     const signature = await (this.program.methods as any)
       .initializeGovernance(
-        new anchor.BN(params.votingPeriod),
-        new anchor.BN(params.executionDelay),
+        new BN(params.votingPeriod),
+        new BN(params.executionDelay),
         params.quorumBps,
         params.approvalThresholdBps,
-        new anchor.BN(params.minProposalStake),
+        new BN(params.minProposalStake),
       )
       .accountsPartial({
         governanceConfig: this.governanceConfigPda,
@@ -236,12 +236,12 @@ export class GovernanceOperations {
 
     const signature = await (this.program.methods as any)
       .createProposal(
-        new anchor.BN(params.nonce.toString()),
+        new BN(params.nonce.toString()),
         params.proposalType,
         Array.from(params.titleHash),
         Array.from(params.descriptionHash),
         Array.from(payload),
-        new anchor.BN(params.votingPeriod),
+        new BN(params.votingPeriod),
       )
       .accountsPartial({
         proposal: proposalPda,

--- a/runtime/src/idl.test.ts
+++ b/runtime/src/idl.test.ts
@@ -41,6 +41,29 @@ describe('IDL exports', () => {
     expect(IDL.instructions.length).toBeGreaterThan(0);
   });
 
+  it('overrides devnet marketplace account layouts for task/dispute instructions', () => {
+    const createTask = IDL.instructions.find((ix) => ix.name === 'create_task');
+    const createDependentTask = IDL.instructions.find(
+      (ix) => ix.name === 'create_dependent_task',
+    );
+    const initiateDispute = IDL.instructions.find(
+      (ix) => ix.name === 'initiate_dispute',
+    );
+
+    expect(createTask?.accounts.map((account) => account.name)).toContain(
+      'authority_rate_limit',
+    );
+    expect(
+      createDependentTask?.accounts.map((account) => account.name),
+    ).toContain('authority_rate_limit');
+    expect(
+      initiateDispute?.accounts.map((account) => account.name),
+    ).toContain('authority_rate_limit');
+    expect(
+      initiateDispute?.accounts.map((account) => account.name),
+    ).toContain('task_submission');
+  });
+
   it('has expected instruction names', () => {
     const instructionNames = IDL.instructions.map((ix) => ix.name);
     // Verify some key instructions exist

--- a/runtime/src/idl.ts
+++ b/runtime/src/idl.ts
@@ -22,6 +22,345 @@ import { PROGRAM_ID } from "@tetsuo-ai/sdk";
 export type { AgencCoordination };
 
 type NamedIdlEntry = { name: string };
+type NamedIdlInstruction = NamedIdlEntry & { accounts?: unknown[] };
+
+// The published protocol package currently lags behind the deployed
+// marketplace/task-dispute account layouts on devnet. Override the stale
+// account metadata here so Anchor derives and validates the correct accounts
+// without requiring a package release first.
+const MARKETPLACE_ACCOUNT_LAYOUT_OVERRIDES = {
+  create_task: [
+    {
+      name: "task",
+      writable: true,
+      pda: {
+        seeds: [
+          { kind: "const", value: [116, 97, 115, 107] },
+          { kind: "account", path: "creator" },
+          { kind: "arg", path: "task_id" },
+        ],
+      },
+    },
+    {
+      name: "escrow",
+      writable: true,
+      pda: {
+        seeds: [
+          { kind: "const", value: [101, 115, 99, 114, 111, 119] },
+          { kind: "account", path: "task" },
+        ],
+      },
+    },
+    {
+      name: "protocol_config",
+      writable: true,
+      pda: {
+        seeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108] }],
+      },
+    },
+    {
+      name: "creator_agent",
+      docs: ["Creator's agent registration for identity/authorization checks"],
+      pda: {
+        seeds: [
+          { kind: "const", value: [97, 103, 101, 110, 116] },
+          {
+            kind: "account",
+            path: "creator_agent.agent_id",
+            account: "AgentRegistration",
+          },
+        ],
+      },
+    },
+    {
+      name: "authority_rate_limit",
+      docs: ["Wallet-scoped task/dispute rate limit state shared across all agents"],
+      writable: true,
+      pda: {
+        seeds: [
+          {
+            kind: "const",
+            value: [
+              97, 117, 116, 104, 111, 114, 105, 116, 121, 95, 114, 97, 116, 101, 95, 108, 105,
+              109, 105, 116,
+            ],
+          },
+          { kind: "account", path: "authority" },
+        ],
+      },
+    },
+    {
+      name: "authority",
+      docs: ["The authority that owns the creator_agent"],
+      signer: true,
+      relations: ["creator_agent"],
+    },
+    {
+      name: "creator",
+      docs: [
+        "The creator who pays for and owns the task",
+        "Must match authority to prevent social engineering attacks (#375)",
+      ],
+      writable: true,
+      signer: true,
+    },
+    {
+      name: "system_program",
+      address: "11111111111111111111111111111111",
+    },
+    {
+      name: "reward_mint",
+      docs: ["SPL token mint for reward denomination (optional)"],
+      optional: true,
+    },
+    {
+      name: "creator_token_account",
+      docs: ["Creator's token account holding reward tokens (optional)"],
+      writable: true,
+      optional: true,
+    },
+    {
+      name: "token_escrow_ata",
+      docs: [
+        "Escrow's associated token account for holding reward tokens (optional).",
+        "Created via ATA CPI during handler if token task.",
+      ],
+      writable: true,
+      optional: true,
+    },
+    {
+      name: "token_program",
+      docs: ["SPL Token program (optional, required for token tasks)"],
+      optional: true,
+      address: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    },
+    {
+      name: "associated_token_program",
+      docs: [
+        "Associated Token Account program (optional, required for token tasks)",
+      ],
+      optional: true,
+      address: "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+    },
+  ],
+  create_dependent_task: [
+    {
+      name: "task",
+      writable: true,
+      pda: {
+        seeds: [
+          { kind: "const", value: [116, 97, 115, 107] },
+          { kind: "account", path: "creator" },
+          { kind: "arg", path: "task_id" },
+        ],
+      },
+    },
+    {
+      name: "escrow",
+      writable: true,
+      pda: {
+        seeds: [
+          { kind: "const", value: [101, 115, 99, 114, 111, 119] },
+          { kind: "account", path: "task" },
+        ],
+      },
+    },
+    {
+      name: "parent_task",
+      docs: [
+        "The parent task this new task depends on",
+        "Note: Uses Box to reduce stack usage for this large account",
+      ],
+    },
+    {
+      name: "protocol_config",
+      docs: ["Note: Uses Box to reduce stack usage for this large account"],
+      writable: true,
+      pda: {
+        seeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108] }],
+      },
+    },
+    {
+      name: "creator_agent",
+      docs: ["Creator's agent registration for identity/authorization checks"],
+      pda: {
+        seeds: [
+          { kind: "const", value: [97, 103, 101, 110, 116] },
+          {
+            kind: "account",
+            path: "creator_agent.agent_id",
+            account: "AgentRegistration",
+          },
+        ],
+      },
+    },
+    {
+      name: "authority_rate_limit",
+      docs: ["Wallet-scoped task/dispute rate limit state shared across all agents"],
+      writable: true,
+      pda: {
+        seeds: [
+          {
+            kind: "const",
+            value: [
+              97, 117, 116, 104, 111, 114, 105, 116, 121, 95, 114, 97, 116, 101, 95, 108, 105,
+              109, 105, 116,
+            ],
+          },
+          { kind: "account", path: "authority" },
+        ],
+      },
+    },
+    {
+      name: "authority",
+      docs: ["The authority that owns the creator_agent"],
+      signer: true,
+      relations: ["creator_agent"],
+    },
+    {
+      name: "creator",
+      docs: [
+        "The creator who pays for and owns the task",
+        "Must match authority to prevent social engineering attacks (#375)",
+      ],
+      writable: true,
+      signer: true,
+    },
+    {
+      name: "system_program",
+      address: "11111111111111111111111111111111",
+    },
+    {
+      name: "reward_mint",
+      docs: ["SPL token mint for reward denomination (optional)"],
+      optional: true,
+    },
+    {
+      name: "creator_token_account",
+      docs: ["Creator's token account holding reward tokens (optional)"],
+      writable: true,
+      optional: true,
+    },
+    {
+      name: "token_escrow_ata",
+      docs: ["Escrow's associated token account for holding reward tokens (optional)."],
+      writable: true,
+      optional: true,
+    },
+    {
+      name: "token_program",
+      docs: ["SPL Token program (optional, required for token tasks)"],
+      optional: true,
+      address: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    },
+    {
+      name: "associated_token_program",
+      docs: [
+        "Associated Token Account program (optional, required for token tasks)",
+      ],
+      optional: true,
+      address: "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+    },
+  ],
+  initiate_dispute: [
+    {
+      name: "dispute",
+      writable: true,
+      pda: {
+        seeds: [
+          { kind: "const", value: [100, 105, 115, 112, 117, 116, 101] },
+          { kind: "arg", path: "dispute_id" },
+        ],
+      },
+    },
+    {
+      name: "task",
+      writable: true,
+      pda: {
+        seeds: [
+          { kind: "const", value: [116, 97, 115, 107] },
+          { kind: "account", path: "task.creator", account: "Task" },
+          { kind: "account", path: "task.task_id", account: "Task" },
+        ],
+      },
+    },
+    {
+      name: "agent",
+      writable: true,
+      pda: {
+        seeds: [
+          { kind: "const", value: [97, 103, 101, 110, 116] },
+          { kind: "account", path: "agent.agent_id", account: "AgentRegistration" },
+        ],
+      },
+    },
+    {
+      name: "authority_rate_limit",
+      docs: ["Wallet-scoped task/dispute rate limit state shared across all agents"],
+      writable: true,
+      pda: {
+        seeds: [
+          {
+            kind: "const",
+            value: [
+              97, 117, 116, 104, 111, 114, 105, 116, 121, 95, 114, 97, 116, 101, 95, 108, 105,
+              109, 105, 116,
+            ],
+          },
+          { kind: "account", path: "authority" },
+        ],
+      },
+    },
+    {
+      name: "protocol_config",
+      pda: {
+        seeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108] }],
+      },
+    },
+    {
+      name: "initiator_claim",
+      docs: ["Optional: Initiator's claim if they are a worker (not the creator)"],
+      optional: true,
+      pda: {
+        seeds: [
+          { kind: "const", value: [99, 108, 97, 105, 109] },
+          { kind: "account", path: "task" },
+          { kind: "account", path: "agent" },
+        ],
+      },
+    },
+    {
+      name: "worker_agent",
+      docs: [
+        "Optional: Worker agent to be disputed (required when initiator is task creator)",
+      ],
+      writable: true,
+      optional: true,
+    },
+    {
+      name: "worker_claim",
+      docs: ["Optional: Worker's claim (required when worker_agent is provided)"],
+      optional: true,
+    },
+    {
+      name: "task_submission",
+      docs: [
+        "Optional durable submission record used once the claim slot has been released.",
+      ],
+      optional: true,
+    },
+    {
+      name: "authority",
+      writable: true,
+      signer: true,
+      relations: ["agent"],
+    },
+    {
+      name: "system_program",
+      address: "11111111111111111111111111111111",
+    },
+  ],
+} as const;
 
 // The published protocol package can lag behind the runtime's supported V2 flow.
 // Merge these entries in locally so Program.methods exposes the task validation
@@ -862,11 +1201,31 @@ function mergeIdlEntries<T extends NamedIdlEntry>(
   return Array.from(merged.values());
 }
 
+function overrideInstructionAccounts(
+  existing: readonly NamedIdlInstruction[] | undefined,
+): NamedIdlInstruction[] {
+  return (existing ?? []).map((instruction) => {
+    const override =
+      MARKETPLACE_ACCOUNT_LAYOUT_OVERRIDES[
+        instruction.name as keyof typeof MARKETPLACE_ACCOUNT_LAYOUT_OVERRIDES
+      ];
+    if (!override) {
+      return instruction;
+    }
+    return {
+      ...instruction,
+      accounts: override as unknown as NamedIdlInstruction["accounts"],
+    };
+  });
+}
+
 function augmentIdl(baseIdl: Idl): Idl {
   return {
     ...baseIdl,
     instructions: mergeIdlEntries(
-      baseIdl.instructions as NamedIdlEntry[] | undefined,
+      overrideInstructionAccounts(
+        baseIdl.instructions as NamedIdlInstruction[] | undefined,
+      ) as unknown as NamedIdlEntry[],
       TASK_VALIDATION_V2_INSTRUCTIONS as unknown as NamedIdlEntry[],
     ) as Idl["instructions"],
     accounts: mergeIdlEntries(

--- a/runtime/src/reputation/economy.test.ts
+++ b/runtime/src/reputation/economy.test.ts
@@ -335,6 +335,30 @@ describe("ReputationEconomyOperations - delegation", () => {
     expect(result.transactionSignature).toBe("mock-tx-signature");
   });
 
+  it("delegateReputation rejects when the delegation already exists", async () => {
+    const program = createMockProgram({
+      reputationDelegation: {
+        delegator: Keypair.generate().publicKey,
+        delegatee: Keypair.generate().publicKey,
+        amount: 1000,
+        expiresAt: new BN(0),
+        createdAt: new BN(1700000000),
+        bump: 253,
+      },
+    });
+    const ops = new ReputationEconomyOperations({
+      program,
+      agentId: createAgentId(),
+    });
+
+    await expect(
+      ops.delegateReputation({
+        delegateeId: new Uint8Array(32).fill(4),
+        amount: 1000,
+      }),
+    ).rejects.toThrow(/Delegation already exists for this delegator\/delegatee pair\./);
+  });
+
   it("getDelegation returns null when not found", async () => {
     const program = createMockProgram();
     const ops = new ReputationEconomyOperations({

--- a/runtime/src/reputation/economy.ts
+++ b/runtime/src/reputation/economy.ts
@@ -6,7 +6,7 @@
 import { PublicKey, SystemProgram, type Keypair } from "@solana/web3.js";
 import { sign, createPrivateKey } from "node:crypto";
 import { randomBytes } from "node:crypto";
-import anchor, { type Program } from "@coral-xyz/anchor";
+import { BN, type Program } from "@coral-xyz/anchor";
 import type { AgencCoordination } from "../types/agenc_coordination.js";
 import type { Logger } from "../utils/logger.js";
 import { silentLogger } from "../utils/logger.js";
@@ -99,7 +99,7 @@ export class ReputationEconomyOperations {
 
     try {
       const signature = await (this.program.methods as any)
-        .stakeReputation(new anchor.BN(params.amount.toString()))
+        .stakeReputation(new BN(params.amount.toString()))
         .accountsPartial({
           authority: this.program.provider.publicKey,
           agent: this.agentPda,
@@ -132,7 +132,7 @@ export class ReputationEconomyOperations {
 
     try {
       const signature = await (this.program.methods as any)
-        .withdrawReputationStake(new anchor.BN(params.amount.toString()))
+        .withdrawReputationStake(new BN(params.amount.toString()))
         .accountsPartial({
           authority: this.program.provider.publicKey,
           agent: this.agentPda,
@@ -191,12 +191,26 @@ export class ReputationEconomyOperations {
       this.program.programId,
     );
 
+    const expiresAt = params.expiresAt ?? 0;
+    const existingDelegation = await this.getDelegation(
+      this.agentPda,
+      delegateePda,
+    );
+    if (existingDelegation) {
+      const sameTerms =
+        existingDelegation.amount === params.amount &&
+        existingDelegation.expiresAt === expiresAt;
+      const message = sameTerms
+        ? "Delegation already exists for this delegator/delegatee pair."
+        : "Delegation already exists for this delegator/delegatee pair. Revoke it after the cooldown before changing amount or expiry.";
+      throw new ReputationDelegationError(message);
+    }
+
     this.logger.info(`Delegating ${params.amount} reputation points`);
 
     try {
-      const expiresAt = params.expiresAt ?? 0;
       const signature = await (this.program.methods as any)
-        .delegateReputation(params.amount, new anchor.BN(expiresAt))
+        .delegateReputation(params.amount, new BN(expiresAt))
         .accountsPartial({
           authority: this.program.provider.publicKey,
           delegatorAgent: this.agentPda,

--- a/runtime/src/task/operations.test.ts
+++ b/runtime/src/task/operations.test.ts
@@ -122,7 +122,77 @@ function createParsedTask(overrides: Partial<OnChainTask> = {}): OnChainTask {
     requiredCompletions: 1,
     bump: 255,
     rewardMint: null,
+    protocolFeeBps: 101,
+    minReputation: 0,
+    dependsOn: null,
+    dependencyType: null,
     ...overrides,
+  };
+}
+
+function createSerializedTaskAccountData(
+  overrides: Partial<OnChainTask> = {},
+): Buffer {
+  const task = createParsedTask(overrides);
+  const buffer = Buffer.alloc(382);
+  let offset = 8;
+
+  const writeFixedBytes = (value: Uint8Array, length: number) => {
+    const bytes = Buffer.from(value);
+    bytes.copy(buffer, offset, 0, Math.min(bytes.length, length));
+    offset += length;
+  };
+
+  writeFixedBytes(task.taskId, 32);
+  task.creator.toBuffer().copy(buffer, offset);
+  offset += 32;
+  buffer.writeBigUInt64LE(task.requiredCapabilities, offset);
+  offset += 8;
+  writeFixedBytes(task.description, 64);
+  writeFixedBytes(task.constraintHash, 32);
+  buffer.writeBigUInt64LE(task.rewardAmount, offset);
+  offset += 8;
+  buffer[offset++] = task.maxWorkers;
+  buffer[offset++] = task.currentWorkers;
+  buffer[offset++] = task.status;
+  buffer[offset++] = task.taskType;
+  buffer.writeBigInt64LE(BigInt(task.createdAt), offset);
+  offset += 8;
+  buffer.writeBigInt64LE(BigInt(task.deadline), offset);
+  offset += 8;
+  buffer.writeBigInt64LE(BigInt(task.completedAt), offset);
+  offset += 8;
+  task.escrow.toBuffer().copy(buffer, offset);
+  offset += 32;
+  writeFixedBytes(task.result, 64);
+  buffer[offset++] = task.completions;
+  buffer[offset++] = task.requiredCompletions;
+  buffer[offset++] = task.bump;
+  buffer.writeUInt16LE(task.protocolFeeBps ?? 101, offset);
+  offset += 2;
+  if (task.dependsOn) {
+    task.dependsOn.toBuffer().copy(buffer, offset);
+  }
+  offset += 32;
+  buffer[offset++] = task.dependencyType ?? 0;
+  buffer.writeUInt16LE(task.minReputation ?? 0, offset);
+  offset += 2;
+  if (task.rewardMint) {
+    buffer[offset++] = 1;
+    task.rewardMint.toBuffer().copy(buffer, offset);
+  } else {
+    buffer[offset++] = 0;
+  }
+
+  return buffer;
+}
+
+function createProgramTaskAccount(overrides: Partial<OnChainTask> = {}) {
+  return {
+    pubkey: Keypair.generate().publicKey,
+    account: {
+      data: createSerializedTaskAccountData(overrides),
+    },
   };
 }
 
@@ -150,8 +220,19 @@ function createMockRawAgentRegistration(authority: PublicKey) {
  */
 function createMockProgram() {
   const providerPublicKey = Keypair.generate().publicKey;
+  const getProgramAccounts = vi.fn().mockResolvedValue([]);
+  const getAccountInfo = vi.fn().mockResolvedValue(null);
+  const getTokenAccountBalance = vi.fn();
+  const coderAccountsMemcmp = vi
+    .fn()
+    .mockReturnValue({ offset: 0, bytes: "task-discriminator" });
   const mockProvider = {
     publicKey: providerPublicKey,
+    connection: {
+      getProgramAccounts,
+      getAccountInfo,
+      getTokenAccountBalance,
+    },
   };
 
   const taskFetch = vi.fn();
@@ -243,6 +324,11 @@ function createMockProgram() {
   const program = {
     programId: PROGRAM_ID,
     provider: mockProvider,
+    coder: {
+      accounts: {
+        memcmp: coderAccountsMemcmp,
+      },
+    },
     account: {
       task: { fetch: taskFetch, all: taskAll },
       taskClaim: { fetch: taskClaimFetch, all: taskClaimAll },
@@ -271,6 +357,10 @@ function createMockProgram() {
       taskClaimAll,
       protocolConfigFetch,
       agentRegistrationFetch,
+      getProgramAccounts,
+      getAccountInfo,
+      getTokenAccountBalance,
+      coderAccountsMemcmp,
       claimTaskRpc,
       completeTaskRpc,
       completeTaskPrivateRpc,
@@ -374,16 +464,9 @@ describe("TaskOperations", () => {
 
   describe("fetchAllTasks", () => {
     it("returns all tasks from chain", async () => {
-      const rawTask1 = createMockRawTask({
-        rewardAmount: { toString: () => "1000" },
-      });
-      const rawTask2 = createMockRawTask({
-        rewardAmount: { toString: () => "2000" },
-      });
-
-      mocks.taskAll.mockResolvedValue([
-        { publicKey: Keypair.generate().publicKey, account: rawTask1 },
-        { publicKey: Keypair.generate().publicKey, account: rawTask2 },
+      mocks.getProgramAccounts.mockResolvedValue([
+        createProgramTaskAccount({ rewardAmount: 1_000n }),
+        createProgramTaskAccount({ rewardAmount: 2_000n }),
       ]);
 
       const results = await ops.fetchAllTasks();
@@ -392,10 +475,11 @@ describe("TaskOperations", () => {
       expect(results[0].task.rewardAmount).toBe(1_000n);
       expect(results[1].task.rewardAmount).toBe(2_000n);
       expect(results[0].taskPda).toBeInstanceOf(PublicKey);
+      expect(mocks.coderAccountsMemcmp).toHaveBeenCalledWith("task");
     });
 
     it("returns empty array when no tasks", async () => {
-      mocks.taskAll.mockResolvedValue([]);
+      mocks.getProgramAccounts.mockResolvedValue([]);
 
       const results = await ops.fetchAllTasks();
 
@@ -405,78 +489,81 @@ describe("TaskOperations", () => {
 
   describe("fetchClaimableTasks", () => {
     it("issues two memcmp-filtered queries for Open and InProgress", async () => {
-      const openTask = createMockRawTask({ status: { open: {} } });
-      const inProgressTask = createMockRawTask({ status: { inProgress: {} } });
-
-      const openPda = Keypair.generate().publicKey;
-      const inProgressPda = Keypair.generate().publicKey;
-
-      // Return different results depending on the filter argument
-      mocks.taskAll.mockImplementation((filters?: unknown[]) => {
-        if (!filters || !Array.isArray(filters) || filters.length === 0) {
-          return Promise.resolve([]);
-        }
-        const filter = filters[0] as {
-          memcmp: { offset: number; bytes: string };
-        };
-        if (
-          filter.memcmp.bytes ===
-          utils.bytes.bs58.encode(Buffer.from([OnChainTaskStatus.Open]))
-        ) {
-          return Promise.resolve([{ publicKey: openPda, account: openTask }]);
-        }
-        if (
-          filter.memcmp.bytes ===
-          utils.bytes.bs58.encode(Buffer.from([OnChainTaskStatus.InProgress]))
-        ) {
-          return Promise.resolve([
-            { publicKey: inProgressPda, account: inProgressTask },
-          ]);
-        }
-        return Promise.resolve([]);
+      const openAccount = createProgramTaskAccount({
+        status: OnChainTaskStatus.Open,
       });
+      const inProgressAccount = createProgramTaskAccount({
+        status: OnChainTaskStatus.InProgress,
+      });
+
+      mocks.getProgramAccounts.mockImplementation(
+        (_programId: PublicKey, config?: { filters?: unknown[] }) => {
+          const filters = config?.filters;
+          if (!Array.isArray(filters) || filters.length < 2) {
+            return Promise.resolve([]);
+          }
+          const filter = filters[1] as {
+            memcmp: { offset: number; bytes: string };
+          };
+          if (
+            filter.memcmp.bytes ===
+            utils.bytes.bs58.encode(Buffer.from([OnChainTaskStatus.Open]))
+          ) {
+            return Promise.resolve([openAccount]);
+          }
+          if (
+            filter.memcmp.bytes ===
+            utils.bytes.bs58.encode(Buffer.from([OnChainTaskStatus.InProgress]))
+          ) {
+            return Promise.resolve([inProgressAccount]);
+          }
+          return Promise.resolve([]);
+        },
+      );
 
       const results = await ops.fetchClaimableTasks();
 
       expect(results.length).toBe(2);
       expect(results[0].task.status).toBe(OnChainTaskStatus.Open);
-      expect(results[0].taskPda.equals(openPda)).toBe(true);
+      expect(results[0].taskPda.equals(openAccount.pubkey)).toBe(true);
       expect(results[1].task.status).toBe(OnChainTaskStatus.InProgress);
-      expect(results[1].taskPda.equals(inProgressPda)).toBe(true);
+      expect(results[1].taskPda.equals(inProgressAccount.pubkey)).toBe(true);
 
-      // Verify two calls with correct memcmp filters
-      expect(mocks.taskAll).toHaveBeenCalledTimes(2);
-      expect(mocks.taskAll).toHaveBeenCalledWith([
-        {
-          memcmp: {
-            offset: TASK_STATUS_OFFSET,
-            bytes: utils.bytes.bs58.encode(
-              Buffer.from([OnChainTaskStatus.Open]),
-            ),
-          },
+      expect(mocks.getProgramAccounts).toHaveBeenCalledTimes(2);
+      const firstCall = mocks.getProgramAccounts.mock.calls[0];
+      const secondCall = mocks.getProgramAccounts.mock.calls[1];
+      expect(firstCall[0]).toEqual(PROGRAM_ID);
+      expect(secondCall[0]).toEqual(PROGRAM_ID);
+      expect(firstCall[1].filters[0]).toEqual({
+        memcmp: { offset: 0, bytes: "task-discriminator" },
+      });
+      expect(firstCall[1].filters[1]).toEqual({
+        memcmp: {
+          offset: TASK_STATUS_OFFSET,
+          bytes: utils.bytes.bs58.encode(
+            Buffer.from([OnChainTaskStatus.Open]),
+          ),
         },
-      ]);
-      expect(mocks.taskAll).toHaveBeenCalledWith([
-        {
-          memcmp: {
-            offset: TASK_STATUS_OFFSET,
-            bytes: utils.bytes.bs58.encode(
-              Buffer.from([OnChainTaskStatus.InProgress]),
-            ),
-          },
+      });
+      expect(secondCall[1].filters[0]).toEqual({
+        memcmp: { offset: 0, bytes: "task-discriminator" },
+      });
+      expect(secondCall[1].filters[1]).toEqual({
+        memcmp: {
+          offset: TASK_STATUS_OFFSET,
+          bytes: utils.bytes.bs58.encode(
+            Buffer.from([OnChainTaskStatus.InProgress]),
+          ),
         },
-      ]);
+      });
     });
 
     it("uses correct offset 186 for status field", () => {
-      // 8 (discriminator) + 32 (task_id) + 32 (creator) + 8 (required_capabilities)
-      // + 64 (description) + 32 (constraint_hash) + 8 (reward_amount)
-      // + 1 (max_workers) + 1 (current_workers) = 186
       expect(TASK_STATUS_OFFSET).toBe(186);
     });
 
     it("returns empty array when no claimable tasks exist", async () => {
-      mocks.taskAll.mockResolvedValue([]);
+      mocks.getProgramAccounts.mockResolvedValue([]);
 
       const results = await ops.fetchClaimableTasks();
 
@@ -484,78 +571,64 @@ describe("TaskOperations", () => {
     });
 
     it("falls back to fetchAllTasks on memcmp filter failure", async () => {
-      const openTask = createMockRawTask({ status: { open: {} } });
-      const completedTask = createMockRawTask({ status: { completed: {} } });
-      const openPda = Keypair.generate().publicKey;
-      const completedPda = Keypair.generate().publicKey;
-
-      let callCount = 0;
-      mocks.taskAll.mockImplementation((filters?: unknown[]) => {
-        callCount++;
-        // First two calls (memcmp) fail
-        if (
-          callCount <= 2 &&
-          filters &&
-          Array.isArray(filters) &&
-          filters.length > 0
-        ) {
-          return Promise.reject(
-            new Error("RPC does not support memcmp filters"),
-          );
-        }
-        // Third call (fallback, no filters) returns all tasks
-        return Promise.resolve([
-          { publicKey: openPda, account: openTask },
-          { publicKey: completedPda, account: completedTask },
-        ]);
+      const openAccount = createProgramTaskAccount({
+        status: OnChainTaskStatus.Open,
       });
+      const completedAccount = createProgramTaskAccount({
+        status: OnChainTaskStatus.Completed,
+      });
+
+      mocks.getProgramAccounts.mockImplementation(
+        (_programId: PublicKey, config?: { filters?: unknown[] }) => {
+          const filters = config?.filters;
+          if (Array.isArray(filters) && filters.length > 1) {
+            return Promise.reject(
+              new Error("RPC does not support memcmp filters"),
+            );
+          }
+          return Promise.resolve([openAccount, completedAccount]);
+        },
+      );
 
       const results = await ops.fetchClaimableTasks();
 
-      // Should only return the Open task (fallback filters client-side)
       expect(results.length).toBe(1);
       expect(results[0].task.status).toBe(OnChainTaskStatus.Open);
+      expect(mocks.getProgramAccounts).toHaveBeenCalledTimes(3);
     });
 
     it("combines results from both filtered queries", async () => {
-      const openTasks = Array.from({ length: 3 }, () =>
-        createMockRawTask({ status: { open: {} } }),
+      const openAccounts = Array.from({ length: 3 }, () =>
+        createProgramTaskAccount({ status: OnChainTaskStatus.Open }),
       );
-      const inProgressTasks = Array.from({ length: 2 }, () =>
-        createMockRawTask({ status: { inProgress: {} } }),
+      const inProgressAccounts = Array.from({ length: 2 }, () =>
+        createProgramTaskAccount({ status: OnChainTaskStatus.InProgress }),
       );
 
-      mocks.taskAll.mockImplementation((filters?: unknown[]) => {
-        if (!filters || !Array.isArray(filters) || filters.length === 0) {
+      mocks.getProgramAccounts.mockImplementation(
+        (_programId: PublicKey, config?: { filters?: unknown[] }) => {
+          const filters = config?.filters;
+          if (!Array.isArray(filters) || filters.length < 2) {
+            return Promise.resolve([]);
+          }
+          const filter = filters[1] as {
+            memcmp: { offset: number; bytes: string };
+          };
+          if (
+            filter.memcmp.bytes ===
+            utils.bytes.bs58.encode(Buffer.from([OnChainTaskStatus.Open]))
+          ) {
+            return Promise.resolve(openAccounts);
+          }
+          if (
+            filter.memcmp.bytes ===
+            utils.bytes.bs58.encode(Buffer.from([OnChainTaskStatus.InProgress]))
+          ) {
+            return Promise.resolve(inProgressAccounts);
+          }
           return Promise.resolve([]);
-        }
-        const filter = filters[0] as {
-          memcmp: { offset: number; bytes: string };
-        };
-        if (
-          filter.memcmp.bytes ===
-          utils.bytes.bs58.encode(Buffer.from([OnChainTaskStatus.Open]))
-        ) {
-          return Promise.resolve(
-            openTasks.map((t) => ({
-              publicKey: Keypair.generate().publicKey,
-              account: t,
-            })),
-          );
-        }
-        if (
-          filter.memcmp.bytes ===
-          utils.bytes.bs58.encode(Buffer.from([OnChainTaskStatus.InProgress]))
-        ) {
-          return Promise.resolve(
-            inProgressTasks.map((t) => ({
-              publicKey: Keypair.generate().publicKey,
-              account: t,
-            })),
-          );
-        }
-        return Promise.resolve([]);
-      });
+        },
+      );
 
       const results = await ops.fetchClaimableTasks();
 

--- a/runtime/src/task/operations.ts
+++ b/runtime/src/task/operations.ts
@@ -37,6 +37,7 @@ import type {
 import {
   isManualValidationTask,
   parseOnChainTask,
+  parseOnChainTaskAccountData,
   parseOnChainTaskClaim,
   OnChainTaskStatus,
 } from "./types.js";
@@ -191,6 +192,34 @@ export class TaskOperations {
     return { task, taskPda };
   }
 
+  private async fetchTaskAccounts(
+    filters: Array<{ memcmp: { offset: number; bytes: string } }> = [],
+  ): Promise<Array<{ task: OnChainTask; taskPda: PublicKey }>> {
+    const discriminator = this.program.coder.accounts.memcmp("task");
+    const accounts = await this.program.provider.connection.getProgramAccounts(
+      this.program.programId,
+      {
+        filters: [{ memcmp: discriminator }, ...filters],
+      },
+    );
+
+    const results: Array<{ task: OnChainTask; taskPda: PublicKey }> = [];
+    for (const account of accounts) {
+      try {
+        results.push({
+          task: parseOnChainTaskAccountData(account.account.data),
+          taskPda: account.pubkey,
+        });
+      } catch (err) {
+        this.logger.warn(
+          `Skipping undecodable task account ${account.pubkey.toBase58()}: ${String(err)}`,
+        );
+      }
+    }
+
+    return results;
+  }
+
   /**
    * Fetch all tasks from the chain.
    *
@@ -199,11 +228,7 @@ export class TaskOperations {
   async fetchAllTasks(): Promise<
     Array<{ task: OnChainTask; taskPda: PublicKey }>
   > {
-    const accounts = await this.program.account.task.all();
-    return accounts.map((acc) => ({
-      task: parseOnChainTask(acc.account),
-      taskPda: acc.publicKey,
-    }));
+    return this.fetchTaskAccounts();
   }
 
   /**
@@ -222,7 +247,7 @@ export class TaskOperations {
     return queryWithFallback(
       async () => {
         const [openAccounts, inProgressAccounts] = await Promise.all([
-          this.program.account.task.all([
+          this.fetchTaskAccounts([
             {
               memcmp: {
                 offset: TASK_STATUS_OFFSET,
@@ -230,7 +255,7 @@ export class TaskOperations {
               },
             },
           ]),
-          this.program.account.task.all([
+          this.fetchTaskAccounts([
             {
               memcmp: {
                 offset: TASK_STATUS_OFFSET,
@@ -240,20 +265,7 @@ export class TaskOperations {
           ]),
         ]);
 
-        const results: Array<{ task: OnChainTask; taskPda: PublicKey }> = [];
-        for (const acc of openAccounts) {
-          results.push({
-            task: parseOnChainTask(acc.account),
-            taskPda: acc.publicKey,
-          });
-        }
-        for (const acc of inProgressAccounts) {
-          results.push({
-            task: parseOnChainTask(acc.account),
-            taskPda: acc.publicKey,
-          });
-        }
-        return results;
+        return [...openAccounts, ...inProgressAccounts];
       },
       async () => {
         const all = await this.fetchAllTasks();

--- a/runtime/src/task/types.ts
+++ b/runtime/src/task/types.ts
@@ -5,7 +5,7 @@
  * @module
  */
 
-import type { PublicKey, TransactionSignature } from "@solana/web3.js";
+import { PublicKey, type TransactionSignature } from "@solana/web3.js";
 import { TaskType } from "../events/types.js";
 import type { Logger } from "../utils/logger.js";
 import { toUint8Array } from "../utils/encoding.js";
@@ -126,6 +126,14 @@ export interface OnChainTask {
   bump: number;
   /** SPL token mint for reward denomination (null = SOL) */
   rewardMint: PublicKey | null;
+  /** Locked protocol fee basis points at creation time. */
+  protocolFeeBps?: number;
+  /** Minimum reputation score required to claim the task. */
+  minReputation?: number;
+  /** Optional parent task PDA for dependency-aware workflows. */
+  dependsOn?: PublicKey | null;
+  /** Optional on-chain dependency type ordinal. */
+  dependencyType?: number | null;
 }
 
 /**
@@ -202,6 +210,10 @@ export interface RawOnChainTask {
   requiredCompletions: number;
   bump: number;
   rewardMint: PublicKey | null;
+  protocolFeeBps?: number;
+  dependsOn?: PublicKey | null;
+  dependencyType?: number | null;
+  minReputation?: number;
 }
 
 /**
@@ -477,6 +489,13 @@ export function parseOnChainTask(data: unknown): OnChainTask {
     throw new Error("Invalid task data: missing required fields");
   }
 
+  const dependencyType =
+    typeof data.dependencyType === "number"
+      ? data.dependencyType === 0
+        ? null
+        : data.dependencyType
+      : null;
+
   return {
     taskId: toUint8Array(data.taskId),
     creator: data.creator,
@@ -497,6 +516,108 @@ export function parseOnChainTask(data: unknown): OnChainTask {
     requiredCompletions: data.requiredCompletions,
     bump: data.bump,
     rewardMint: data.rewardMint ?? null,
+    protocolFeeBps:
+      typeof data.protocolFeeBps === "number" ? data.protocolFeeBps : undefined,
+    minReputation:
+      typeof data.minReputation === "number" ? data.minReputation : undefined,
+    dependsOn: data.dependsOn ?? null,
+    dependencyType,
+  };
+}
+
+const TASK_ACCOUNT_DISCRIMINATOR_LEN = 8;
+const TASK_ACCOUNT_MIN_DATA_LEN = 372;
+
+/**
+ * Parses raw task account bytes directly.
+ *
+ * This bypasses Anchor's account enum decoding, which can fail when the
+ * deployed program has newer enum variants than the local IDL. The parser
+ * reads the stable binary layout for task listings and ignores trailing
+ * reserved bytes.
+ *
+ * @param data - Raw account data including the 8-byte discriminator
+ * @returns Parsed OnChainTask
+ */
+export function parseOnChainTaskAccountData(
+  data: Buffer | Uint8Array,
+): OnChainTask {
+  const buffer = Buffer.from(data);
+  if (buffer.length < TASK_ACCOUNT_MIN_DATA_LEN) {
+    throw new Error(
+      `Invalid task account data length: expected at least ${TASK_ACCOUNT_MIN_DATA_LEN} bytes, received ${buffer.length}`,
+    );
+  }
+
+  let offset = TASK_ACCOUNT_DISCRIMINATOR_LEN;
+
+  const readBytes = (length: number): Uint8Array => {
+    const value = Uint8Array.from(buffer.subarray(offset, offset + length));
+    offset += length;
+    return value;
+  };
+
+  const taskId = readBytes(32);
+  const creator = new PublicKey(buffer.subarray(offset, offset + 32));
+  offset += 32;
+  const requiredCapabilities = buffer.readBigUInt64LE(offset);
+  offset += 8;
+  const description = readBytes(64);
+  const constraintHash = readBytes(32);
+  const rewardAmount = buffer.readBigUInt64LE(offset);
+  offset += 8;
+  const maxWorkers = buffer[offset++] ?? 0;
+  const currentWorkers = buffer[offset++] ?? 0;
+  const status = parseTaskStatus(buffer[offset++] ?? 0);
+  const taskType = parseTaskType(buffer[offset++] ?? 0);
+  const createdAt = Number(buffer.readBigInt64LE(offset));
+  offset += 8;
+  const deadline = Number(buffer.readBigInt64LE(offset));
+  offset += 8;
+  const completedAt = Number(buffer.readBigInt64LE(offset));
+  offset += 8;
+  const escrow = new PublicKey(buffer.subarray(offset, offset + 32));
+  offset += 32;
+  const result = readBytes(64);
+  const completions = buffer[offset++] ?? 0;
+  const requiredCompletions = buffer[offset++] ?? 0;
+  const bump = buffer[offset++] ?? 0;
+  const protocolFeeBps = buffer.readUInt16LE(offset);
+  offset += 2;
+  const dependsOnBytes = buffer.subarray(offset, offset + 32);
+  offset += 32;
+  const dependencyTypeValue = buffer[offset++] ?? 0;
+  const minReputation = buffer.readUInt16LE(offset);
+  offset += 2;
+  const rewardMintTag = buffer[offset++] ?? 0;
+  const rewardMintBytes = buffer.subarray(offset, offset + 32);
+
+  return {
+    taskId,
+    creator,
+    requiredCapabilities,
+    description,
+    constraintHash,
+    rewardAmount,
+    maxWorkers,
+    currentWorkers,
+    status,
+    taskType,
+    createdAt,
+    deadline,
+    completedAt,
+    escrow,
+    result,
+    completions,
+    requiredCompletions,
+    bump,
+    rewardMint: rewardMintTag === 0 ? null : new PublicKey(rewardMintBytes),
+    protocolFeeBps,
+    minReputation,
+    dependsOn: dependsOnBytes.every((byte) => byte === 0)
+      ? null
+      : new PublicKey(dependsOnBytes),
+    dependencyType: dependencyTypeValue === 0 ? null : dependencyTypeValue,
   };
 }
 

--- a/runtime/src/tools/agenc/mutation-tools.test.ts
+++ b/runtime/src/tools/agenc/mutation-tools.test.ts
@@ -16,6 +16,7 @@ import {
 import {
   createClaimTaskTool,
   createCompleteTaskTool,
+  createInitiateDisputeTool,
   createRegisterSkillTool,
   createPurchaseSkillTool,
   createCreateProposalTool,
@@ -27,6 +28,7 @@ import {
 const SIGNER = PublicKey.unique();
 const AGENT_PDA = PublicKey.unique();
 const TASK_PDA = PublicKey.unique();
+const CLAIM_PDA = PublicKey.unique();
 const DISPUTE_PDA = PublicKey.unique();
 const SKILL_PDA = PublicKey.unique();
 const DEFENDANT_AGENT_PDA = PublicKey.unique();
@@ -111,6 +113,9 @@ function createMockProgram(options: { signer?: PublicKey | null } = {}) {
           }
           throw new Error(`Unknown skill: ${pda.toBase58()}`);
         }),
+      },
+      taskClaim: {
+        all: vi.fn(async () => []),
       },
     },
     methods: {
@@ -285,6 +290,60 @@ describe('agenc mutation tools', () => {
     expect(purchaseArg?.constructor?.name).toBe('BN');
     expect(purchaseArg?.toString()).toBe('42');
     expect(program._purchaseSkillChain.accountsPartial).toHaveBeenCalledTimes(1);
+  });
+
+
+  it('agenc.initiateDispute auto-discovers the sole worker claim for creator-initiated disputes', async () => {
+    const program = createMockProgram();
+    vi.spyOn(TaskOperations.prototype, 'fetchTask').mockResolvedValue({
+      creator: SIGNER,
+      taskId: new Uint8Array(32).fill(9),
+    } as never);
+    program.account.taskClaim.all.mockResolvedValue([
+      {
+        publicKey: CLAIM_PDA,
+        account: {
+          task: TASK_PDA,
+          worker: DEFENDANT_AGENT_PDA,
+          claimedAt: { toNumber: () => 1700000000 },
+          expiresAt: { toNumber: () => 1700003600 },
+          completedAt: { toNumber: () => 0 },
+          proofHash: new Uint8Array(32),
+          resultData: new Uint8Array(64),
+          isCompleted: false,
+          isValidated: false,
+          rewardPaid: { toString: () => '0' },
+          bump: 1,
+        },
+      },
+    ]);
+    const initiateSpy = vi
+      .spyOn(DisputeOperations.prototype, 'initiateDispute')
+      .mockResolvedValue({
+        disputePda: DISPUTE_PDA,
+        transactionSignature: 'dispute-sig',
+      });
+
+    const tool = createInitiateDisputeTool(program as never, silentLogger);
+    const result = await tool.execute({
+      taskPda: TASK_PDA.toBase58(),
+      evidence: 'creator dispute evidence',
+      resolutionType: 'refund',
+      initiatorAgentPda: AGENT_PDA.toBase58(),
+    });
+
+    const parsed = parseJson(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed.disputePda).toBe(DISPUTE_PDA.toBase58());
+    expect(parsed.transactionSignature).toBe('dispute-sig');
+    expect(initiateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initiatorClaimPda: null,
+        workerAgentPda: DEFENDANT_AGENT_PDA,
+        workerClaimPda: CLAIM_PDA,
+      }),
+    );
   });
 
   it('agenc.resolveDispute returns transaction details when the dispute resolves', async () => {

--- a/runtime/src/tools/agenc/mutation-tools.ts
+++ b/runtime/src/tools/agenc/mutation-tools.ts
@@ -26,6 +26,7 @@ import {
   findBidderMarketStatePda,
   findClaimPda,
 } from '../../task/pda.js';
+import { parseOnChainTaskClaim } from '../../task/types.js';
 import type { Logger } from '../../utils/logger.js';
 import { bytesToHex, generateAgentId, hexToBytes } from '../../utils/encoding.js';
 import type { Tool, ToolResult } from '../types.js';
@@ -483,6 +484,41 @@ function parseWorkerPairs(
     pairs.push({ claimPda, workerPda });
   }
   return [pairs, null];
+}
+
+async function resolveUniqueWorkerClaimForTask(
+  program: Program<AgencCoordination>,
+  taskPda: PublicKey,
+): Promise<
+  | { workerAgentPda: PublicKey; workerClaimPda: PublicKey }
+  | { error: string }
+> {
+  const taskClaims = await program.account.taskClaim.all();
+  const matchingClaims = taskClaims
+    .map((account) => ({
+      claimPda: account.publicKey,
+      claim: parseOnChainTaskClaim(account.account),
+    }))
+    .filter(({ claim }) => claim.task.equals(taskPda));
+
+  if (matchingClaims.length === 0) {
+    return {
+      error:
+        'workerAgentPda is required when creator initiates dispute and no worker claim exists for the task.',
+    };
+  }
+
+  if (matchingClaims.length > 1) {
+    return {
+      error:
+        'workerAgentPda is required when creator initiates dispute for a task with multiple worker claims.',
+    };
+  }
+
+  return {
+    workerAgentPda: matchingClaims[0].claim.worker,
+    workerClaimPda: matchingClaims[0].claimPda,
+  };
 }
 
 export function createClaimTaskTool(
@@ -1208,6 +1244,18 @@ export function createInitiateDisputeTool(
         const initiatorClaimPda = initiatedByCreator
           ? null
           : findClaimPda(taskPda, signerAgent.agentPda, program.programId);
+
+        if (initiatedByCreator && workerAgentPda === null) {
+          const resolvedWorker = await resolveUniqueWorkerClaimForTask(
+            program,
+            taskPda,
+          );
+          if ('error' in resolvedWorker) {
+            return errorResult(resolvedWorker.error);
+          }
+          workerAgentPda = resolvedWorker.workerAgentPda;
+          workerClaimPda = workerClaimPda ?? resolvedWorker.workerClaimPda;
+        }
 
         const derivedWorkerClaimPda =
           workerClaimPda ?? (workerAgentPda ? findClaimPda(taskPda, workerAgentPda, program.programId) : undefined);

--- a/runtime/src/tools/agenc/tools.ts
+++ b/runtime/src/tools/agenc/tools.ts
@@ -16,7 +16,7 @@
  */
 
 import { PublicKey, SystemProgram } from '@solana/web3.js';
-import anchor, { BN, type Program } from '@coral-xyz/anchor';
+import { BN, type Program } from '@coral-xyz/anchor';
 import { getAssociatedTokenAddressSync } from '@tetsuo-ai/sdk';
 import type { AgencCoordination } from '../../types/agenc_coordination.js';
 import type { Tool, ToolResult } from '../types.js';

--- a/runtime/src/tools/agenc/tools.ts
+++ b/runtime/src/tools/agenc/tools.ts
@@ -22,7 +22,7 @@ import type { AgencCoordination } from '../../types/agenc_coordination.js';
 import type { Tool, ToolResult } from '../types.js';
 import { safeStringify } from '../types.js';
 import { TaskOperations } from '../../task/operations.js';
-import { findAgentPda, findProtocolPda } from '../../agent/pda.js';
+import { findAgentPda, findAuthorityRateLimitPda, findProtocolPda } from '../../agent/pda.js';
 import { findTaskPda, findEscrowPda } from '../../task/pda.js';
 import {
   taskStatusToString,
@@ -738,10 +738,10 @@ export function createRegisterAgentTool(
         const txSignature = await program.methods
           .registerAgent(
             Array.from(agentId),
-            new anchor.BN(capabilities.toString()),
+            new BN(capabilities.toString()),
             endpoint,
             metadataUri,
-            new anchor.BN(stakeAmount.toString()),
+            new BN(stakeAmount.toString()),
           )
           .accountsPartial({
             agent: agentPda,
@@ -909,6 +909,7 @@ export function createCreateTaskTool(
         const taskPda = findTaskPda(creator, taskId, program.programId);
         const escrowPda = findEscrowPda(taskPda, program.programId);
         const protocolPda = findProtocolPda(program.programId);
+        const authorityRateLimitPda = findAuthorityRateLimitPda(creator, program.programId);
         const tokenAccounts = buildCreateTaskTokenAccounts(
           rewardMint,
           escrowPda,
@@ -933,6 +934,7 @@ export function createCreateTaskTool(
             escrow: escrowPda,
             protocolConfig: protocolPda,
             creatorAgent: creatorAgentPda,
+            authorityRateLimit: authorityRateLimitPda,
             authority: creator,
             creator,
             systemProgram: SystemProgram.programId,

--- a/runtime/src/watch/agenc-watch-app.mjs
+++ b/runtime/src/watch/agenc-watch-app.mjs
@@ -1695,6 +1695,8 @@ watchCommandController = createWatchCommandController({
   clearPendingAttachments,
   prepareChatMessagePayload,
   applyOptimisticModelSelection,
+  openMarketTaskBrowser,
+  dismissMarketTaskBrowser,
   openLatestDiffDetail,
   currentDiffNavigationState: () =>
     watchFrameController?.currentDiffNavigationState() ?? {
@@ -1753,7 +1755,533 @@ function currentExpandedEvent() {
       : null);
 }
 
+function marketBrowserKind(value) {
+  const kind = String(value?.kind ?? value ?? "").trim().toLowerCase();
+  switch (kind) {
+    case "skills":
+    case "governance":
+    case "disputes":
+    case "reputation":
+      return kind;
+    default:
+      return "tasks";
+  }
+}
+
+function marketTaskBrowserDefaultTitle(kind = "tasks") {
+  switch (marketBrowserKind(kind)) {
+    case "skills":
+      return "Marketplace Skills";
+    case "governance":
+      return "Governance Proposals";
+    case "disputes":
+      return "Marketplace Disputes";
+    case "reputation":
+      return "Reputation Summary";
+    default:
+      return "Marketplace Tasks";
+  }
+}
+
+function marketTaskBrowserNoun(kind = "tasks") {
+  switch (marketBrowserKind(kind)) {
+    case "skills":
+      return "skill";
+    case "governance":
+      return "proposal";
+    case "disputes":
+      return "dispute";
+    case "reputation":
+      return "reputation summary";
+    default:
+      return "task";
+  }
+}
+
+function marketTaskBrowserItemLabel(item, kind = "tasks") {
+  switch (marketBrowserKind(kind)) {
+    case "skills":
+      return item?.name ?? item?.skillId ?? item?.key ?? "selected skill";
+    case "governance":
+      return item?.payloadPreview ?? item?.proposalType ?? item?.proposalPda ?? item?.key ?? "selected proposal";
+    case "disputes":
+      return item?.disputePda ?? item?.resolutionType ?? item?.taskPda ?? item?.key ?? "selected dispute";
+    case "reputation":
+      return item?.authority ?? item?.agentPda ?? item?.agentId ?? item?.key ?? "selected reputation summary";
+    default:
+      return item?.description ?? item?.taskId ?? item?.key ?? "selected task";
+  }
+}
+
+function marketTaskBrowserUsesStatuses(kind = "tasks") {
+  const browserKind = marketBrowserKind(kind);
+  return browserKind === "tasks" || browserKind === "governance" || browserKind === "disputes";
+}
+
+function marketTaskBrowserItemKey(item, fallbackIndex = 0, kind = "tasks") {
+  switch (marketBrowserKind(kind)) {
+    case "skills": {
+      const skillPda = String(item?.skillPda ?? "").trim();
+      if (skillPda) {
+        return skillPda;
+      }
+      const skillId = String(item?.skillId ?? "").trim();
+      if (skillId) {
+        return skillId;
+      }
+      return `skill-${fallbackIndex + 1}`;
+    }
+    case "governance": {
+      const proposalPda = String(item?.proposalPda ?? "").trim();
+      if (proposalPda) {
+        return proposalPda;
+      }
+      return `proposal-${fallbackIndex + 1}`;
+    }
+    case "disputes": {
+      const disputePda = String(item?.disputePda ?? "").trim();
+      if (disputePda) {
+        return disputePda;
+      }
+      const disputeId = String(item?.disputeId ?? "").trim();
+      if (disputeId) {
+        return disputeId;
+      }
+      return `dispute-${fallbackIndex + 1}`;
+    }
+    case "reputation": {
+      const agentPda = String(item?.agentPda ?? "").trim();
+      if (agentPda) {
+        return agentPda;
+      }
+      const authority = String(item?.authority ?? "").trim();
+      if (authority) {
+        return authority;
+      }
+      const agentId = String(item?.agentId ?? "").trim();
+      if (agentId) {
+        return agentId;
+      }
+      return `reputation-${fallbackIndex + 1}`;
+    }
+    default: {
+      const taskPda = String(item?.taskPda ?? "").trim();
+      if (taskPda) {
+        return taskPda;
+      }
+      const taskId = String(item?.taskId ?? "").trim();
+      if (taskId) {
+        return taskId;
+      }
+      return `task-${fallbackIndex + 1}`;
+    }
+  }
+}
+
+function formatMarketTaskBrowserTimestamp(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return null;
+  }
+  const millis = numeric >= 1e12
+    ? numeric
+    : numeric >= 1e9
+      ? numeric * 1000
+      : null;
+  if (!millis) {
+    return String(value);
+  }
+  const date = new Date(millis);
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+  return date.toISOString().replace("T", " ").replace(".000Z", "Z");
+}
+
+function normalizeMarketSkillBrowserItems(items = []) {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return items
+    .map((item, index) => {
+      const priceSol = String(item?.priceSol ?? item?.price ?? "").trim();
+      const priceLamports = String(item?.priceLamports ?? "").trim();
+      return {
+        key: marketTaskBrowserItemKey(item, index, "skills"),
+        skillPda: String(item?.skillPda ?? "").trim(),
+        skillId: String(item?.skillId ?? "").trim(),
+        name: String(item?.name ?? "").trim() || "unknown skill",
+        author: String(item?.author ?? item?.seller ?? "").trim(),
+        tags: Array.isArray(item?.tags)
+          ? item.tags.map((tag) => String(tag ?? "").trim()).filter(Boolean)
+          : [],
+        priceSol,
+        priceLamports,
+        priceMint: item?.priceMint ?? null,
+        priceDisplay: priceSol
+          ? `${priceSol} SOL`
+          : priceLamports
+            ? `${priceLamports} lamports`
+            : "n/a",
+        rating: Number.isFinite(Number(item?.rating ?? item?.averageRating))
+          ? Number(item?.rating ?? item?.averageRating)
+          : null,
+        ratingCount: Number.isFinite(Number(item?.ratingCount))
+          ? Number(item.ratingCount)
+          : null,
+        downloads: Number.isFinite(Number(item?.downloads))
+          ? Number(item.downloads)
+          : null,
+        version: Number.isFinite(Number(item?.version))
+          ? Number(item.version)
+          : null,
+        isActive: item?.isActive !== false,
+        createdAt: item?.createdAt ?? null,
+        createdAtLabel: formatMarketTaskBrowserTimestamp(item?.createdAt),
+        updatedAt: item?.updatedAt ?? null,
+        updatedAtLabel: formatMarketTaskBrowserTimestamp(item?.updatedAt),
+        contentHash: String(item?.contentHash ?? "").trim(),
+      };
+    })
+    .filter((item) => item.skillPda || item.skillId || item.name);
+}
+
+function normalizeMarketGovernanceBrowserItems(items = []) {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return items
+    .map((item, index) => ({
+      key: marketTaskBrowserItemKey(item, index, "governance"),
+      proposalPda: String(item?.proposalPda ?? "").trim(),
+      proposer: String(item?.proposer ?? "").trim(),
+      proposalType: String(item?.proposalType ?? "").trim(),
+      status: String(item?.status ?? "unknown").trim() || "unknown",
+      titleHash: String(item?.titleHash ?? "").trim(),
+      descriptionHash: String(item?.descriptionHash ?? "").trim(),
+      payloadPreview: String(item?.payloadPreview ?? "").trim(),
+      votesFor: String(item?.votesFor ?? "").trim(),
+      votesAgainst: String(item?.votesAgainst ?? "").trim(),
+      totalVoters: Number.isFinite(Number(item?.totalVoters))
+        ? Number(item.totalVoters)
+        : null,
+      quorum: String(item?.quorum ?? "").trim(),
+      createdAt: item?.createdAt ?? null,
+      createdAtLabel: formatMarketTaskBrowserTimestamp(item?.createdAt),
+      votingDeadline: item?.votingDeadline ?? null,
+      votingDeadlineLabel: formatMarketTaskBrowserTimestamp(item?.votingDeadline),
+      executionAfter: item?.executionAfter ?? null,
+      executionAfterLabel: formatMarketTaskBrowserTimestamp(item?.executionAfter),
+    }))
+    .filter((item) => item.proposalPda || item.payloadPreview || item.proposalType);
+}
+
+function normalizeMarketDisputeBrowserItems(items = []) {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return items
+    .map((item, index) => ({
+      key: marketTaskBrowserItemKey(item, index, "disputes"),
+      disputePda: String(item?.disputePda ?? "").trim(),
+      disputeId: String(item?.disputeId ?? "").trim(),
+      taskPda: String(item?.taskPda ?? "").trim(),
+      initiator: String(item?.initiator ?? "").trim(),
+      defendant: String(item?.defendant ?? "").trim(),
+      status: String(item?.status ?? "unknown").trim() || "unknown",
+      resolutionType: String(item?.resolutionType ?? "").trim(),
+      evidenceHash: String(item?.evidenceHash ?? "").trim(),
+      votesFor: String(item?.votesFor ?? "").trim(),
+      votesAgainst: String(item?.votesAgainst ?? "").trim(),
+      totalVoters: Number.isFinite(Number(item?.totalVoters))
+        ? Number(item.totalVoters)
+        : null,
+      createdAt: item?.createdAt ?? null,
+      createdAtLabel: formatMarketTaskBrowserTimestamp(item?.createdAt),
+      votingDeadline: item?.votingDeadline ?? null,
+      votingDeadlineLabel: formatMarketTaskBrowserTimestamp(item?.votingDeadline),
+      expiresAt: item?.expiresAt ?? null,
+      expiresAtLabel: formatMarketTaskBrowserTimestamp(item?.expiresAt),
+      resolvedAt: item?.resolvedAt ?? null,
+      resolvedAtLabel: formatMarketTaskBrowserTimestamp(item?.resolvedAt),
+      slashApplied: item?.slashApplied === true,
+      initiatorSlashApplied: item?.initiatorSlashApplied === true,
+      workerStakeAtDispute: String(item?.workerStakeAtDispute ?? "").trim(),
+      initiatedByCreator: item?.initiatedByCreator === true,
+      rewardMint: item?.rewardMint ?? null,
+    }))
+    .filter((item) => item.disputePda || item.disputeId || item.taskPda);
+}
+
+function normalizeMarketReputationBrowserItems(items = []) {
+  const list = Array.isArray(items)
+    ? items
+    : items && typeof items === "object"
+      ? [items]
+      : [];
+  return list
+    .filter((item) => item && typeof item === "object")
+    .map((item, index) => ({
+      key: marketTaskBrowserItemKey(item, index, "reputation"),
+      registered: item?.registered !== false,
+      authority: String(item?.authority ?? "").trim(),
+      agentPda: String(item?.agentPda ?? "").trim(),
+      agentId: String(item?.agentId ?? "").trim(),
+      baseReputation: Number.isFinite(Number(item?.baseReputation))
+        ? Number(item.baseReputation)
+        : null,
+      effectiveReputation: Number.isFinite(Number(item?.effectiveReputation))
+        ? Number(item.effectiveReputation)
+        : null,
+      tasksCompleted: String(item?.tasksCompleted ?? "").trim(),
+      totalEarned: String(item?.totalEarned ?? "").trim(),
+      totalEarnedSol: String(item?.totalEarnedSol ?? "").trim(),
+      stakedAmount: String(item?.stakedAmount ?? "").trim(),
+      stakedAmountSol: String(item?.stakedAmountSol ?? "").trim(),
+      lockedUntil: item?.lockedUntil ?? null,
+      lockedUntilLabel: formatMarketTaskBrowserTimestamp(item?.lockedUntil),
+      inboundDelegations: Array.isArray(item?.inboundDelegations)
+        ? item.inboundDelegations
+        : [],
+      outboundDelegations: Array.isArray(item?.outboundDelegations)
+        ? item.outboundDelegations
+        : [],
+    }))
+    .filter(
+      (item) =>
+        item.agentPda ||
+        item.authority ||
+        item.agentId ||
+        item.baseReputation !== null ||
+        item.effectiveReputation !== null ||
+        item.tasksCompleted ||
+        item.totalEarned ||
+        item.stakedAmount ||
+        item.registered === false,
+    );
+}
+
+function normalizeMarketTaskBrowserItems(items = [], kind = "tasks") {
+  switch (marketBrowserKind(kind)) {
+    case "skills":
+      return normalizeMarketSkillBrowserItems(items);
+    case "governance":
+      return normalizeMarketGovernanceBrowserItems(items);
+    case "disputes":
+      return normalizeMarketDisputeBrowserItems(items);
+    case "reputation":
+      return normalizeMarketReputationBrowserItems(items);
+    default:
+      if (!Array.isArray(items)) {
+        return [];
+      }
+      return items
+        .map((item, index) => {
+          const rewardSol = String(item?.rewardSol ?? item?.reward ?? "").trim();
+          const rewardLamports = String(item?.rewardLamports ?? "").trim();
+          return {
+            key: marketTaskBrowserItemKey(item, index, "tasks"),
+            taskPda: String(item?.taskPda ?? "").trim(),
+            taskId: String(item?.taskId ?? "").trim(),
+            status: String(item?.status ?? "unknown").trim() || "unknown",
+            description: String(item?.description ?? "").trim() || "untitled task",
+            creator: String(item?.creator ?? "").trim(),
+            rewardSol,
+            rewardLamports,
+            rewardMint: item?.rewardMint ?? null,
+            rewardDisplay: rewardSol
+              ? `${rewardSol} SOL`
+              : rewardLamports
+                ? `${rewardLamports} lamports`
+                : "n/a",
+            currentWorkers: Number.isFinite(Number(item?.currentWorkers))
+              ? Number(item.currentWorkers)
+              : null,
+            maxWorkers: Number.isFinite(Number(item?.maxWorkers))
+              ? Number(item.maxWorkers)
+              : null,
+            deadline: item?.deadline ?? null,
+            deadlineLabel: formatMarketTaskBrowserTimestamp(item?.deadline),
+            createdAt: item?.createdAt ?? null,
+            createdAtLabel: formatMarketTaskBrowserTimestamp(item?.createdAt),
+          };
+        })
+        .filter((item) => item.taskPda || item.taskId || item.description);
+  }
+}
+
+function currentMarketTaskBrowser() {
+
+  const browser = watchState.marketTaskBrowser;
+  return browser && typeof browser === "object" && browser.open === true
+    ? browser
+    : null;
+}
+
+function hasActiveMarketTaskBrowser({ requireBlankComposer = false } = {}) {
+  const browser = currentMarketTaskBrowser();
+  if (!browser) {
+    return false;
+  }
+  if (!requireBlankComposer) {
+    return true;
+  }
+  return String(watchState.composerInput ?? "").trim().length === 0;
+}
+
+function openMarketTaskBrowser({
+  title = "Marketplace Tasks",
+  statuses = [],
+  kind = "tasks",
+  query = "",
+  activeOnly = true,
+} = {}) {
+  const browserKind = marketBrowserKind(kind);
+  const current = currentMarketTaskBrowser();
+  const currentKind = marketBrowserKind(current);
+  const normalizedStatuses = marketTaskBrowserUsesStatuses(browserKind) && Array.isArray(statuses)
+    ? statuses.map((value) => String(value ?? "").trim()).filter(Boolean)
+    : [];
+  const normalizedQuery = browserKind === "skills"
+    ? String(query ?? "").trim()
+    : "";
+  const defaultTitle = marketTaskBrowserDefaultTitle(browserKind);
+  watchState.expandedEventId = null;
+  watchState.detailScrollOffset = 0;
+  watchState.marketTaskBrowser = {
+    open: true,
+    kind: browserKind,
+    title: String(title ?? defaultTitle).trim() || defaultTitle,
+    statuses: marketTaskBrowserUsesStatuses(browserKind)
+      ? normalizedStatuses
+      : [],
+    query: browserKind === "skills" ? normalizedQuery : "",
+    activeOnly: browserKind === "skills" ? activeOnly !== false : true,
+    loading: true,
+    items:
+      browserKind === currentKind && Array.isArray(current?.items)
+        ? current.items
+        : [],
+    selectedIndex:
+      browserKind === currentKind && Number.isFinite(Number(current?.selectedIndex))
+        ? Number(current.selectedIndex)
+        : 0,
+    expandedTaskKey:
+      browserKind === currentKind ? current?.expandedTaskKey ?? null : null,
+    updatedAtMs: nowMs(),
+  };
+  return watchState.marketTaskBrowser;
+}
+
+function hydrateMarketTaskBrowser({ title = "Marketplace Tasks", items = [], kind = "tasks" } = {}) {
+  const browserKind = marketBrowserKind(kind);
+  const normalizedItems = normalizeMarketTaskBrowserItems(items, browserKind);
+  const current = currentMarketTaskBrowser();
+  const currentKind = marketBrowserKind(current);
+  const currentSelectedKey =
+    current && browserKind === currentKind && Array.isArray(current.items) && current.items.length > 0
+      ? current.items[Math.max(0, Math.min(current.items.length - 1, Number(current.selectedIndex) || 0))]?.key ?? null
+      : null;
+  let selectedIndex = normalizedItems.findIndex((item) => item.key === currentSelectedKey);
+  if (selectedIndex < 0) {
+    selectedIndex = Math.max(
+      0,
+      Math.min(
+        normalizedItems.length - 1,
+        browserKind === currentKind ? Number(current?.selectedIndex) || 0 : 0,
+      ),
+    );
+  }
+  const expandedTaskKey =
+    current?.expandedTaskKey && browserKind === currentKind && normalizedItems.some((item) => item.key === current.expandedTaskKey)
+      ? current.expandedTaskKey
+      : null;
+  const defaultTitle = marketTaskBrowserDefaultTitle(browserKind);
+  watchState.expandedEventId = null;
+  watchState.detailScrollOffset = 0;
+  watchState.marketTaskBrowser = {
+    open: true,
+    kind: browserKind,
+    title: String(title ?? current?.title ?? defaultTitle).trim() || defaultTitle,
+    statuses: marketTaskBrowserUsesStatuses(browserKind) && browserKind === currentKind && Array.isArray(current?.statuses)
+      ? current.statuses
+      : [],
+    query: browserKind === "skills" && browserKind === currentKind
+      ? String(current?.query ?? "").trim()
+      : "",
+    activeOnly: browserKind === "skills" && browserKind === currentKind
+      ? current?.activeOnly !== false
+      : true,
+    loading: false,
+    items: normalizedItems,
+    selectedIndex: normalizedItems.length > 0 ? selectedIndex : 0,
+    expandedTaskKey,
+    updatedAtMs: nowMs(),
+  };
+  return watchState.marketTaskBrowser;
+}
+
+function navigateMarketTaskBrowser(direction) {
+
+  const browser = currentMarketTaskBrowser();
+  if (!browser || !Array.isArray(browser.items) || browser.items.length === 0) {
+    return false;
+  }
+  const delta = direction < 0 ? -1 : 1;
+  const nextIndex = Math.max(0, Math.min(browser.items.length - 1, browser.selectedIndex + delta));
+  if (nextIndex === browser.selectedIndex) {
+    return false;
+  }
+  browser.selectedIndex = nextIndex;
+  if (browser.expandedTaskKey) {
+    browser.expandedTaskKey = browser.items[nextIndex]?.key ?? null;
+  }
+  return true;
+}
+
+function toggleMarketTaskBrowserExpansion() {
+  const browser = currentMarketTaskBrowser();
+  const browserKind = marketBrowserKind(browser);
+  const noun = marketTaskBrowserNoun(browserKind);
+  if (!browser || !Array.isArray(browser.items) || browser.items.length === 0) {
+    setTransientStatus(`no marketplace ${noun} selected`);
+    return false;
+  }
+  const item = browser.items[Math.max(0, Math.min(browser.items.length - 1, browser.selectedIndex))];
+  if (!item) {
+    setTransientStatus(`no marketplace ${noun} selected`);
+    return false;
+  }
+  const label = String(marketTaskBrowserItemLabel(item, browserKind) ?? "").trim() || `selected ${noun}`;
+  if (browser.expandedTaskKey === item.key) {
+    browser.expandedTaskKey = null;
+    setTransientStatus(`${noun} details collapsed`);
+    return true;
+  }
+  browser.expandedTaskKey = item.key;
+  setTransientStatus(`${noun} details open: ${label}`);
+  return true;
+}
+
+function dismissMarketTaskBrowser() {
+  const browser = currentMarketTaskBrowser();
+  if (!browser) {
+    return false;
+  }
+  const browserKind = marketBrowserKind(browser);
+  const noun = marketTaskBrowserNoun(browserKind);
+  if (browser.expandedTaskKey) {
+    browser.expandedTaskKey = null;
+    setTransientStatus(`${noun} details collapsed`);
+    return true;
+  }
+  watchState.marketTaskBrowser = null;
+  setTransientStatus(`market ${noun} browser closed`);
+  return true;
+}
+
 function openLatestDiffDetail() {
+
   for (let index = events.length - 1; index >= 0; index -= 1) {
     const event = events[index];
     if (!isDiffRenderableEvent(event)) {
@@ -2283,6 +2811,7 @@ watchTransportController = createWatchTransportController({
     handlePlannerTraceEvent,
     handleSubagentLifecycleMessage,
     hydratePlannerDagFromTraceArtifacts,
+    hydrateMarketTaskBrowser,
     isExpectedMissingRunInspect,
     isUnavailableBackgroundRunInspect,
     isRetryableBootstrapError,
@@ -2429,6 +2958,10 @@ watchInputController = createWatchInputController({
   autocompleteComposerInput,
   acceptComposerPaletteSelection,
   navigateComposer,
+  hasActiveMarketTaskBrowser: () => hasActiveMarketTaskBrowser({ requireBlankComposer: true }),
+  navigateMarketTaskBrowser,
+  toggleMarketTaskBrowserExpansion,
+  dismissMarketTaskBrowser,
   hasActiveComposerPalette,
   navigateComposerPalette,
   moveComposerCursorByCharacter: moveComposerCursorHorizontally,

--- a/runtime/src/watch/agenc-watch-commands.mjs
+++ b/runtime/src/watch/agenc-watch-commands.mjs
@@ -604,6 +604,537 @@ function buildDesktopCommand(parsedSlash) {
   };
 }
 
+function parseSlashFlagTokens(tokens = []) {
+  const positional = [];
+  const flags = {};
+  for (let index = 0; index < tokens.length;) {
+    const token = String(tokens[index] ?? "").trim();
+    if (token.startsWith("--")) {
+      const values = [];
+      index += 1;
+      while (index < tokens.length) {
+        const nextToken = String(tokens[index] ?? "").trim();
+        if (nextToken.startsWith("--")) {
+          break;
+        }
+        values.push(nextToken);
+        index += 1;
+      }
+      flags[token.toLowerCase()] = values.join(" ").trim();
+      continue;
+    }
+    positional.push(token);
+    index += 1;
+  }
+  return { positional, flags };
+}
+
+function hasSlashFlag(flags, flagName) {
+  return Object.prototype.hasOwnProperty.call(
+    flags ?? {},
+    `--${String(flagName ?? "").trim().toLowerCase()}`,
+  );
+}
+
+function readSlashFlag(flags, flagName) {
+  const key = `--${String(flagName ?? "").trim().toLowerCase()}`;
+  const value = flags?.[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function parseDelimitedStrings(value) {
+  return String(value ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function parsePairListValue(value, leftKey, rightKey) {
+  const entries = parseDelimitedStrings(value);
+  if (entries.length === 0) {
+    return {
+      error: `Expected ${leftKey}:${rightKey}[,${leftKey}:${rightKey}...]`,
+    };
+  }
+  const pairs = [];
+  for (const entry of entries) {
+    const parts = entry.split(":").map((part) => part.trim());
+    if (parts.length !== 2 || !parts[0] || !parts[1]) {
+      return {
+        error: `Invalid pair "${entry}". Expected ${leftKey}:${rightKey}.`,
+      };
+    }
+    pairs.push({
+      [leftKey]: parts[0],
+      [rightKey]: parts[1],
+    });
+  }
+  return { value: pairs };
+}
+
+function parseFiniteNumber(value, label) {
+  const parsed = Number.parseFloat(String(value ?? "").trim());
+  if (!Number.isFinite(parsed)) {
+    return {
+      error: `${label} must be a finite number.`,
+    };
+  }
+  return { value: parsed };
+}
+
+function parseSafeInteger(value, label) {
+  const parsed = Number.parseInt(String(value ?? "").trim(), 10);
+  if (!Number.isSafeInteger(parsed)) {
+    return {
+      error: `${label} must be a safe integer.`,
+    };
+  }
+  return { value: parsed };
+}
+
+function buildMarketCommand(parsedSlash) {
+  const usage =
+    "Usage: /market <tasks|skills|governance|disputes|reputation> ...";
+  const args = Array.isArray(parsedSlash?.args) ? parsedSlash.args : [];
+  const area = String(args[0] ?? "").trim().toLowerCase();
+  const action = String(args[1] ?? "").trim().toLowerCase();
+  const { positional, flags } = parseSlashFlagTokens(args.slice(2));
+
+  if (!area || !["tasks", "skills", "governance", "disputes", "reputation"].includes(area)) {
+    return { error: usage };
+  }
+
+  if (area === "tasks") {
+    const taskAction = action || "list";
+    if (taskAction === "list") {
+      const statuses = parseDelimitedStrings(readSlashFlag(flags, "status"));
+      return {
+        messageType: "tasks.list",
+        payload: statuses.length > 0 ? { statuses } : {},
+        title: "Marketplace Tasks",
+        body:
+          statuses.length > 0
+            ? `Requested marketplace tasks with status filter: ${statuses.join(", ")}.`
+            : "Requested marketplace tasks.",
+        status: "requesting marketplace tasks",
+        openBrowser: {
+          kind: "tasks",
+          statuses,
+        },
+      };
+    }
+    if (taskAction === "create") {
+      const description = readSlashFlag(flags, "description") || readSlashFlag(flags, "desc");
+      if (!description) {
+        return {
+          error:
+            "Usage: /market tasks create --description <text> (--reward <sol> | --reward-lamports <lamports>)",
+        };
+      }
+      const rewardLamports = readSlashFlag(flags, "reward-lamports");
+      const reward = readSlashFlag(flags, "reward");
+      if (!rewardLamports && !reward) {
+        return {
+          error:
+            "Usage: /market tasks create --description <text> (--reward <sol> | --reward-lamports <lamports>)",
+        };
+      }
+      if (rewardLamports) {
+        const parsedLamports = parseSafeInteger(rewardLamports, "reward-lamports");
+        if (parsedLamports.error || parsedLamports.value <= 0) {
+          return {
+            error: parsedLamports.error ?? "reward-lamports must be greater than 0.",
+          };
+        }
+        return {
+          messageType: "tasks.create",
+          payload: {
+            params: {
+              description,
+              rewardLamports: String(parsedLamports.value),
+            },
+          },
+          title: "Create Task",
+          body: `Creating marketplace task.\n\ndescription: ${description}\nreward: ${parsedLamports.value} lamports`,
+          status: "creating marketplace task",
+        };
+      }
+      const parsedReward = parseFiniteNumber(reward, "reward");
+      if (parsedReward.error || parsedReward.value <= 0) {
+        return {
+          error: parsedReward.error ?? "reward must be greater than 0.",
+        };
+      }
+      return {
+        messageType: "tasks.create",
+        payload: {
+          params: {
+            description,
+            reward: parsedReward.value,
+          },
+        },
+        title: "Create Task",
+        body: `Creating marketplace task.\n\ndescription: ${description}\nreward: ${parsedReward.value} SOL`,
+        status: "creating marketplace task",
+      };
+    }
+    if (taskAction === "detail") {
+      const taskPda = String(positional[0] ?? "").trim();
+      if (!taskPda) {
+        return {
+          error: "Usage: /market tasks detail <taskPda>",
+        };
+      }
+      return {
+        messageType: "tasks.detail",
+        payload: { taskPda },
+        title: "Task Detail",
+        body: `Requested marketplace task ${taskPda}.`,
+        status: "loading task detail",
+      };
+    }
+    if (["cancel", "claim"].includes(taskAction)) {
+      const taskId = String(positional[0] ?? "").trim();
+      if (!taskId) {
+        return {
+          error: `Usage: /market tasks ${taskAction} <taskPda>`,
+        };
+      }
+      return {
+        messageType: `tasks.${taskAction}`,
+        payload: { taskId },
+        title: taskAction === "cancel" ? "Cancel Task" : "Claim Task",
+        body:
+          taskAction === "cancel"
+            ? `Cancelling marketplace task ${taskId}.`
+            : `Claiming marketplace task ${taskId}.`,
+        status:
+          taskAction === "cancel"
+            ? "cancelling marketplace task"
+            : "claiming marketplace task",
+      };
+    }
+    if (taskAction === "complete") {
+      const taskId = String(positional[0] ?? "").trim();
+      if (!taskId) {
+        return {
+          error: "Usage: /market tasks complete <taskPda> [--result-data <text>]",
+        };
+      }
+      const resultData = readSlashFlag(flags, "result-data");
+      return {
+        messageType: "tasks.complete",
+        payload: {
+          taskId,
+          ...(resultData ? { resultData } : {}),
+        },
+        title: "Complete Task",
+        body: resultData
+          ? `Completing marketplace task ${taskId}.\n\nresult: ${resultData}`
+          : `Completing marketplace task ${taskId}.`,
+        status: "completing marketplace task",
+      };
+    }
+    if (taskAction === "dispute") {
+      const taskId = String(positional[0] ?? "").trim();
+      const evidence = readSlashFlag(flags, "evidence");
+      const resolutionType = readSlashFlag(flags, "resolution-type") || "refund";
+      if (!taskId || !evidence) {
+        return {
+          error:
+            "Usage: /market tasks dispute <taskPda> --evidence <text> [--resolution-type refund|complete|split]",
+        };
+      }
+      if (!["refund", "complete", "split"].includes(resolutionType)) {
+        return {
+          error: "resolution-type must be one of refund, complete, or split.",
+        };
+      }
+      return {
+        messageType: "tasks.dispute",
+        payload: { taskId, evidence, resolutionType },
+        title: "Open Dispute",
+        body: `Opening dispute for task ${taskId}.\n\nresolution: ${resolutionType}\nevidence: ${evidence}`,
+        status: "opening marketplace dispute",
+      };
+    }
+    return { error: `${usage}\n\nTasks: list, create, detail, cancel, claim, complete, dispute` };
+  }
+
+  if (area === "skills") {
+    const skillAction = action || "list";
+    if (skillAction === "list") {
+      const query = readSlashFlag(flags, "query") || String(positional[0] ?? "").trim();
+      const activeOnly = !hasSlashFlag(flags, "all");
+      return {
+        messageType: "market.skills.list",
+        payload: {
+          ...(query ? { query } : {}),
+          activeOnly,
+        },
+        title: "Marketplace Skills",
+        body: query
+          ? `Searching marketplace skills for "${query}".`
+          : activeOnly
+            ? "Requested active marketplace skills."
+            : "Requested all marketplace skills.",
+        status: "requesting marketplace skills",
+        openBrowser: {
+          kind: "skills",
+          query,
+          activeOnly,
+        },
+      };
+    }
+    if (skillAction === "detail") {
+      const skillPda = String(positional[0] ?? "").trim();
+      if (!skillPda) {
+        return { error: "Usage: /market skills detail <skillPda>" };
+      }
+      return {
+        messageType: "market.skills.detail",
+        payload: { skillPda },
+        title: "Skill Detail",
+        body: `Requested marketplace skill ${skillPda}.`,
+        status: "loading skill detail",
+      };
+    }
+    if (skillAction === "purchase") {
+      const skillPda = String(positional[0] ?? "").trim();
+      const skillId = String(positional[1] ?? "").trim();
+      if (!skillPda) {
+        return { error: "Usage: /market skills purchase <skillPda> [skillId]" };
+      }
+      return {
+        messageType: "market.skills.purchase",
+        payload: {
+          skillPda,
+          ...(skillId ? { skillId } : {}),
+        },
+        title: "Purchase Skill",
+        body: skillId
+          ? `Purchasing marketplace skill ${skillPda} (${skillId}).`
+          : `Purchasing marketplace skill ${skillPda}.`,
+        status: "purchasing marketplace skill",
+      };
+    }
+    if (skillAction === "rate") {
+      const skillPda = String(positional[0] ?? "").trim();
+      const ratingToken = String(positional[1] ?? "").trim();
+      const parsedRating = parseSafeInteger(ratingToken, "rating");
+      if (!skillPda || parsedRating.error || parsedRating.value < 1 || parsedRating.value > 5) {
+        return {
+          error: "Usage: /market skills rate <skillPda> <1-5> [--review <text>]",
+        };
+      }
+      const review = readSlashFlag(flags, "review");
+      return {
+        messageType: "market.skills.rate",
+        payload: {
+          skillPda,
+          rating: parsedRating.value,
+          ...(review ? { review } : {}),
+        },
+        title: "Rate Skill",
+        body: review
+          ? `Rating marketplace skill ${skillPda} with ${parsedRating.value}/5.\n\nreview: ${review}`
+          : `Rating marketplace skill ${skillPda} with ${parsedRating.value}/5.`,
+        status: "rating marketplace skill",
+      };
+    }
+    return { error: `${usage}\n\nSkills: list, detail, purchase, rate` };
+  }
+
+  if (area === "governance") {
+    const governanceAction = action || "list";
+    if (governanceAction === "list") {
+      const status = readSlashFlag(flags, "status");
+      return {
+        messageType: "market.governance.list",
+        payload: status ? { status } : {},
+        title: "Governance Proposals",
+        body: status
+          ? `Requested governance proposals with status ${status}.`
+          : "Requested governance proposals.",
+        status: "requesting governance proposals",
+        openBrowser: {
+          kind: "governance",
+          statuses: status ? [status] : [],
+        },
+      };
+    }
+    if (governanceAction === "detail") {
+      const proposalPda = String(positional[0] ?? "").trim();
+      if (!proposalPda) {
+        return { error: "Usage: /market governance detail <proposalPda>" };
+      }
+      return {
+        messageType: "market.governance.detail",
+        payload: { proposalPda },
+        title: "Governance Detail",
+        body: `Requested governance proposal ${proposalPda}.`,
+        status: "loading governance detail",
+      };
+    }
+    if (governanceAction === "vote") {
+      const proposalPda = String(positional[0] ?? "").trim();
+      const voteToken = String(positional[1] ?? "").trim().toLowerCase();
+      if (!proposalPda || !["yes", "no"].includes(voteToken)) {
+        return { error: "Usage: /market governance vote <proposalPda> <yes|no>" };
+      }
+      return {
+        messageType: "market.governance.vote",
+        payload: {
+          proposalPda,
+          approve: voteToken === "yes",
+        },
+        title: "Governance Vote",
+        body: `Casting ${voteToken} vote for proposal ${proposalPda}.`,
+        status: "submitting governance vote",
+      };
+    }
+    return { error: `${usage}\n\nGovernance: list, detail, vote` };
+  }
+
+  if (area === "disputes") {
+    const disputeAction = action || "list";
+    if (disputeAction === "list") {
+      const statuses = parseDelimitedStrings(readSlashFlag(flags, "status"));
+      return {
+        messageType: "market.disputes.list",
+        payload: statuses.length > 0 ? { statuses } : {},
+        title: "Marketplace Disputes",
+        body:
+          statuses.length > 0
+            ? `Requested disputes with status filter: ${statuses.join(", ")}.`
+            : "Requested marketplace disputes.",
+        status: "requesting marketplace disputes",
+        openBrowser: {
+          kind: "disputes",
+          statuses,
+        },
+      };
+    }
+    if (disputeAction === "detail") {
+      const disputePda = String(positional[0] ?? "").trim();
+      if (!disputePda) {
+        return { error: "Usage: /market disputes detail <disputePda>" };
+      }
+      return {
+        messageType: "market.disputes.detail",
+        payload: { disputePda },
+        title: "Dispute Detail",
+        body: `Requested dispute ${disputePda}.`,
+        status: "loading dispute detail",
+      };
+    }
+    if (disputeAction === "resolve") {
+      const disputePda = String(positional[0] ?? "").trim();
+      const arbiterVotesText = readSlashFlag(flags, "arbiter-votes");
+      const extraWorkersText = readSlashFlag(flags, "extra-workers");
+      if (!disputePda || !arbiterVotesText) {
+        return {
+          error:
+            "Usage: /market disputes resolve <disputePda> --arbiter-votes <votePda:arbiterPda[,..]> [--extra-workers <claimPda:workerPda[,..]>]",
+        };
+      }
+      const arbiterVotes = parsePairListValue(
+        arbiterVotesText,
+        "votePda",
+        "arbiterAgentPda",
+      );
+      if (arbiterVotes.error) {
+        return { error: arbiterVotes.error };
+      }
+      const extraWorkers = extraWorkersText
+        ? parsePairListValue(extraWorkersText, "claimPda", "workerPda")
+        : { value: [] };
+      if (extraWorkers.error) {
+        return { error: extraWorkers.error };
+      }
+      return {
+        messageType: "market.disputes.resolve",
+        payload: {
+          disputePda,
+          arbiterVotes: arbiterVotes.value,
+          ...(extraWorkers.value.length > 0 ? { extraWorkers: extraWorkers.value } : {}),
+        },
+        title: "Resolve Dispute",
+        body: `Resolving dispute ${disputePda} with ${arbiterVotes.value.length} arbiter vote(s).`,
+        status: "resolving marketplace dispute",
+      };
+    }
+    return { error: `${usage}\n\nDisputes: list, detail, resolve` };
+  }
+
+  const reputationAction = action || "summary";
+  if (reputationAction === "summary") {
+    const agentPda = readSlashFlag(flags, "agent-pda") || String(positional[0] ?? "").trim();
+    return {
+      messageType: "market.reputation.summary",
+      payload: agentPda ? { agentPda } : {},
+      title: "Reputation Summary",
+      body: agentPda
+        ? `Requested reputation summary for ${agentPda}.`
+        : "Requested signer reputation summary.",
+      status: "loading reputation summary",
+      openBrowser: {
+        kind: "reputation",
+      },
+    };
+  }
+  if (reputationAction === "stake") {
+    const amount = String(positional[0] ?? "").trim() || readSlashFlag(flags, "amount");
+    if (!amount) {
+      return { error: "Usage: /market reputation stake <lamports>" };
+    }
+    return {
+      messageType: "market.reputation.stake",
+      payload: { amount },
+      title: "Stake Reputation",
+      body: `Staking ${amount} lamports into reputation.`,
+      status: "staking reputation",
+    };
+  }
+  if (reputationAction === "delegate") {
+    const amount = String(positional[0] ?? "").trim() || readSlashFlag(flags, "amount");
+    const parsedAmount = parseFiniteNumber(amount, "amount");
+    const delegateeAgentPda = readSlashFlag(flags, "delegatee-agent-pda");
+    const delegateeAgentId = readSlashFlag(flags, "delegatee-agent-id");
+    const expiresAtText = readSlashFlag(flags, "expires-at");
+    if (!amount || parsedAmount.error || (!delegateeAgentPda && !delegateeAgentId)) {
+      return {
+        error:
+          "Usage: /market reputation delegate <amount> (--delegatee-agent-pda <pda> | --delegatee-agent-id <id>) [--expires-at <unix>]",
+      };
+    }
+    let expiresAt;
+    if (expiresAtText) {
+      const parsedExpiresAt = parseSafeInteger(expiresAtText, "expires-at");
+      if (parsedExpiresAt.error) {
+        return { error: parsedExpiresAt.error };
+      }
+      expiresAt = parsedExpiresAt.value;
+    }
+    return {
+      messageType: "market.reputation.delegate",
+      payload: {
+        amount: parsedAmount.value,
+        ...(delegateeAgentPda ? { delegateeAgentPda } : {}),
+        ...(delegateeAgentId ? { delegateeAgentId } : {}),
+        ...(typeof expiresAt === "number" ? { expiresAt } : {}),
+      },
+      title: "Delegate Reputation",
+      body: delegateeAgentPda
+        ? `Delegating ${parsedAmount.value} reputation to ${delegateeAgentPda}.`
+        : `Delegating ${parsedAmount.value} reputation to agent ${delegateeAgentId}.`,
+      status: "delegating reputation",
+    };
+  }
+
+  return { error: `${usage}\n\nReputation: summary, stake, delegate` };
+}
+
 function buildSkillTogglePayload(parsedSlash) {
   const args = Array.isArray(parsedSlash?.args) ? parsedSlash.args : [];
   const subcommand = (args[0] ?? "list").trim().toLowerCase();
@@ -911,6 +1442,8 @@ export function createWatchCommandController(dependencies = {}) {
     clearPendingAttachments,
     prepareChatMessagePayload,
     applyOptimisticModelSelection,
+    openMarketTaskBrowser,
+    dismissMarketTaskBrowser,
     openLatestDiffDetail,
     currentDiffNavigationState,
     jumpCurrentDiffHunk,
@@ -967,6 +1500,10 @@ export function createWatchCommandController(dependencies = {}) {
     assertFunction("captureCheckpoint", captureCheckpoint);
     assertFunction("listCheckpoints", listCheckpoints);
     assertFunction("rewindToCheckpoint", rewindToCheckpoint);
+  }
+  if (commandNames.has("/market")) {
+    assertFunction("openMarketTaskBrowser", openMarketTaskBrowser);
+    assertFunction("dismissMarketTaskBrowser", dismissMarketTaskBrowser);
   }
   if (commandNames.has("/diff")) {
     assertFunction("openLatestDiffDetail", openLatestDiffDetail);
@@ -1610,6 +2147,31 @@ export function createWatchCommandController(dependencies = {}) {
         }
         pushEvent("operator", action.title, action.body, "teal");
         send("chat.message", authPayload({ content: action.content }));
+        return true;
+      }
+
+      if (canonicalName === "/market") {
+        const action = buildMarketCommand(parsedSlash);
+        if (action.error) {
+          pushEvent("error", "Usage Error", action.error, "red");
+          return true;
+        }
+        pushEvent("operator", action.title, action.body, "teal");
+        if (action.openBrowser) {
+          openMarketTaskBrowser({
+            title: action.title,
+            kind: action.openBrowser.kind,
+            statuses: action.openBrowser.statuses,
+            query: action.openBrowser.query,
+            activeOnly: action.openBrowser.activeOnly,
+          });
+        } else {
+          dismissMarketTaskBrowser();
+        }
+        if (action.status) {
+          setTransientStatus(action.status);
+        }
+        send(action.messageType, action.payload);
         return true;
       }
 

--- a/runtime/src/watch/agenc-watch-frame.mjs
+++ b/runtime/src/watch/agenc-watch-frame.mjs
@@ -1167,18 +1167,515 @@ export function createWatchFrameController(dependencies = {}) {
     return lines;
   }
 
-  function currentBottomPopupLayout(width = termWidth(), height = termHeight()) {
-    const paletteState = currentComposerPaletteState(64);
+  function marketTaskBrowserStatusTone(status) {
+    switch (String(status ?? "").trim().toLowerCase()) {
+      case "open":
+      case "active":
+      case "approved":
+      case "passed":
+      case "registered":
+        return color.green;
+      case "claimed":
+      case "pending":
+      case "appealed":
+      case "review":
+        return color.yellow;
+      case "completed":
+      case "closed":
+      case "resolved":
+      case "executed":
+        return color.teal;
+      case "failed":
+      case "cancelled":
+      case "rejected":
+      case "expired":
+      case "slashed":
+        return color.red;
+      default:
+        return color.fog;
+    }
+  }
+
+  function normalizeMarketTaskBrowserSelectionIndex(itemCount, browserState) {
+    if (!Number.isInteger(itemCount) || itemCount <= 0) {
+      return -1;
+    }
+    const nextIndex = Number.isInteger(browserState?.selectedIndex)
+      ? browserState.selectedIndex
+      : 0;
+    return Math.max(0, Math.min(itemCount - 1, nextIndex));
+  }
+
+  function marketTaskBrowserVisibleEntryLimit(height) {
+    const safeHeight = Math.max(0, Number(height) || 0);
+    if (safeHeight >= 30) return 4;
+    if (safeHeight >= 24) return 3;
+    if (safeHeight >= 20) return 2;
+    return 1;
+  }
+
+  function currentMarketTaskBrowserState() {
+    const browser = watchState.marketTaskBrowser;
+    if (!browser || typeof browser !== "object" || browser.open !== true) {
+      return {
+        mode: "none",
+        browser: null,
+        items: [],
+        activeIndex: -1,
+      };
+    }
+    if (watchState.expandedEventId) {
+      return {
+        mode: "none",
+        browser: null,
+        items: [],
+        activeIndex: -1,
+      };
+    }
+    if (String(currentInputValue() ?? "").trim().length > 0) {
+      return {
+        mode: "none",
+        browser: null,
+        items: [],
+        activeIndex: -1,
+      };
+    }
+    const items = Array.isArray(browser.items) ? browser.items : [];
     return {
-      paletteState,
-      popup: composerPaletteLines(width, paletteState, height),
+      mode: "browser",
+      browser,
+      items,
+      activeIndex: normalizeMarketTaskBrowserSelectionIndex(items.length, browser),
+    };
+  }
+
+  function marketTaskBrowserKind(browserState) {
+    const kind = String(browserState?.browser?.kind ?? "tasks").trim().toLowerCase();
+    switch (kind) {
+      case "skills":
+      case "governance":
+      case "disputes":
+      case "reputation":
+        return kind;
+      default:
+        return "tasks";
+    }
+  }
+
+  function marketTaskBrowserCountLabel(kind, count) {
+    switch (kind) {
+      case "skills":
+        return `${count} skill${count === 1 ? "" : "s"}`;
+      case "governance":
+        return `${count} proposal${count === 1 ? "" : "s"}`;
+      case "disputes":
+        return `${count} dispute${count === 1 ? "" : "s"}`;
+      case "reputation":
+        return `${count} record${count === 1 ? "" : "s"}`;
+      default:
+        return `${count} task${count === 1 ? "" : "s"}`;
+    }
+  }
+
+  function marketTaskBrowserLoadingLabel(kind) {
+    switch (kind) {
+      case "skills":
+        return "Loading marketplace skills…";
+      case "governance":
+        return "Loading governance proposals…";
+      case "disputes":
+        return "Loading marketplace disputes…";
+      case "reputation":
+        return "Loading reputation summary…";
+      default:
+        return "Loading marketplace tasks…";
+    }
+  }
+
+  function marketTaskBrowserEmptyLabel(kind) {
+    switch (kind) {
+      case "skills":
+        return "No marketplace skills found.";
+      case "governance":
+        return "No governance proposals found.";
+      case "disputes":
+        return "No marketplace disputes found.";
+      case "reputation":
+        return "No reputation summary available.";
+      default:
+        return "No marketplace tasks found.";
+    }
+  }
+
+  function marketTaskBrowserSummaryLine(width, browserState) {
+    const browser = browserState.browser;
+    const kind = marketTaskBrowserKind(browserState);
+    const count = browserState.items.length;
+    const summaryLabel = browser.loading
+      ? "loading…"
+      : marketTaskBrowserCountLabel(kind, count);
+    return fitAnsi(
+      flexBetween(
+        `${color.magenta}${browser.title}${color.reset}${color.fog} · ${summaryLabel}${color.reset}`,
+        `${color.fog}↑↓ navigate · Enter details · Esc close${color.reset}`,
+        width,
+      ),
+      width,
+    );
+  }
+
+  function marketTaskBrowserFilterLine(width, browserState) {
+    const kind = marketTaskBrowserKind(browserState);
+    if (kind === "skills") {
+      const query = String(browserState.browser?.query ?? "").trim();
+      const filters = [];
+      if (query) {
+        filters.push(`query "${sanitizeInlineText(query) || query}"`);
+      }
+      filters.push(browserState.browser?.activeOnly === false ? "all skills" : "active only");
+      return fitAnsi(
+        `${color.fog}filters:${color.reset} ${color.softInk}${filters.join(" · ")}${color.reset}`,
+        width,
+      );
+    }
+    if (kind === "tasks" || kind === "governance" || kind === "disputes") {
+      const statuses = Array.isArray(browserState.browser?.statuses)
+        ? browserState.browser.statuses.filter(Boolean)
+        : [];
+      if (statuses.length === 0) {
+        return null;
+      }
+      return fitAnsi(
+        `${color.fog}filters:${color.reset} ${color.softInk}${statuses.join(", ")}${color.reset}`,
+        width,
+      );
+    }
+    return null;
+  }
+
+  function marketTaskBrowserEntryLine(item, width, browserState, { selected = false } = {}) {
+    const kind = marketTaskBrowserKind(browserState);
+    const marker = selected
+      ? `${color.magenta}${color.bold}›${color.reset}`
+      : `${color.fog}·${color.reset}`;
+    if (kind === "skills") {
+      const stateLabel = item?.isActive === false ? "inactive" : "active";
+      const stateTone = item?.isActive === false ? color.fog : color.green;
+      const name = sanitizeInlineText(item?.name ?? "") || "unknown skill";
+      const priceLabel = String(item?.priceDisplay ?? "").trim() || "n/a";
+      const ratingLabel = Number.isFinite(Number(item?.rating))
+        ? `rating ${Number(item.rating).toFixed(1)}`
+        : null;
+      const downloads = Number(item?.downloads);
+      const downloadsLabel = Number.isFinite(downloads)
+        ? `${downloads} download${downloads === 1 ? "" : "s"}`
+        : null;
+      return fitAnsi(
+        flexBetween(
+          `${marker} ${stateTone}[${stateLabel}]${color.reset} ${(selected ? color.magenta : color.softInk)}${name}${color.reset}`,
+          `${color.fog}${[priceLabel, ratingLabel, downloadsLabel].filter(Boolean).join(" · ")}${color.reset}`,
+          width,
+        ),
+        width,
+      );
+    }
+    if (kind === "governance") {
+      const status = String(item?.status ?? "unknown").trim() || "unknown";
+      const proposalType = sanitizeInlineText(item?.proposalType ?? "");
+      const preview = sanitizeInlineText(item?.payloadPreview ?? "");
+      const title = proposalType && preview
+        ? `${proposalType}: ${preview}`
+        : preview || proposalType || sanitizeInlineText(item?.proposalPda ?? "") || "proposal";
+      const votesForLabel = item?.votesFor ? `for ${item.votesFor}` : null;
+      const votesAgainstLabel = item?.votesAgainst ? `against ${item.votesAgainst}` : null;
+      const votersLabel = Number.isFinite(Number(item?.totalVoters))
+        ? `${item.totalVoters} voter${Number(item.totalVoters) === 1 ? "" : "s"}`
+        : null;
+      return fitAnsi(
+        flexBetween(
+          `${marker} ${marketTaskBrowserStatusTone(status)}[${status}]${color.reset} ${(selected ? color.magenta : color.softInk)}${title}${color.reset}`,
+          `${color.fog}${[votesForLabel, votesAgainstLabel, votersLabel].filter(Boolean).join(" · ")}${color.reset}`,
+          width,
+        ),
+        width,
+      );
+    }
+    if (kind === "disputes") {
+      const status = String(item?.status ?? "unknown").trim() || "unknown";
+      const resolution = sanitizeInlineText(item?.resolutionType ?? "") || "dispute";
+      const disputeLabel = sanitizeInlineText(item?.disputePda ?? "") || sanitizeInlineText(item?.taskPda ?? "") || "record";
+      const title = `${resolution} · ${disputeLabel}`;
+      const votesForLabel = item?.votesFor ? `for ${item.votesFor}` : null;
+      const votesAgainstLabel = item?.votesAgainst ? `against ${item.votesAgainst}` : null;
+      const votersLabel = Number.isFinite(Number(item?.totalVoters))
+        ? `${item.totalVoters} voter${Number(item.totalVoters) === 1 ? "" : "s"}`
+        : null;
+      return fitAnsi(
+        flexBetween(
+          `${marker} ${marketTaskBrowserStatusTone(status)}[${status}]${color.reset} ${(selected ? color.magenta : color.softInk)}${title}${color.reset}`,
+          `${color.fog}${[votesForLabel, votesAgainstLabel, votersLabel].filter(Boolean).join(" · ")}${color.reset}`,
+          width,
+        ),
+        width,
+      );
+    }
+    if (kind === "reputation") {
+      const registered = item?.registered !== false;
+      const stateLabel = registered ? "registered" : "unregistered";
+      const stateTone = registered ? color.green : color.fog;
+      const subject = sanitizeInlineText(item?.authority ?? item?.agentPda ?? item?.agentId ?? "") || "reputation summary";
+      const effectiveLabel = Number.isFinite(Number(item?.effectiveReputation))
+        ? `effective ${Number(item.effectiveReputation)}`
+        : null;
+      const tasksCompleted = String(item?.tasksCompleted ?? "").trim();
+      const tasksLabel = tasksCompleted
+        ? `${tasksCompleted} task${tasksCompleted === "1" ? "" : "s"}`
+        : null;
+      return fitAnsi(
+        flexBetween(
+          `${marker} ${stateTone}[${stateLabel}]${color.reset} ${(selected ? color.magenta : color.softInk)}${subject}${color.reset}`,
+          `${color.fog}${[effectiveLabel, tasksLabel].filter(Boolean).join(" · ")}${color.reset}`,
+          width,
+        ),
+        width,
+      );
+    }
+    const status = String(item?.status ?? "unknown").trim() || "unknown";
+    const description = sanitizeInlineText(item?.description ?? "") || "untitled task";
+    const workersLabel = Number.isFinite(Number(item?.currentWorkers))
+      ? Number.isFinite(Number(item?.maxWorkers))
+        ? `${item.currentWorkers}/${item.maxWorkers} workers`
+        : `${item.currentWorkers} workers`
+      : null;
+    const rewardLabel = String(item?.rewardDisplay ?? "").trim() || "n/a";
+    return fitAnsi(
+      flexBetween(
+        `${marker} ${marketTaskBrowserStatusTone(status)}[${status}]${color.reset} ${(selected ? color.magenta : color.softInk)}${description}${color.reset}`,
+        `${color.fog}${[rewardLabel, workersLabel].filter(Boolean).join(" · ")}${color.reset}`,
+        width,
+      ),
+      width,
+    );
+  }
+
+  function marketTaskBrowserDetailLines(item, width, height, browserState) {
+    const prefix = "   ";
+    const detailWidth = Math.max(12, width - visibleLength(prefix));
+    const lines = [];
+    const maxRows = Math.max(2, Math.min(6, Math.floor(Math.max(0, Number(height) || 0) / 3)));
+    const kind = marketTaskBrowserKind(browserState);
+    const pushField = (label, value) => {
+      if (value === null || value === undefined || value === "") {
+        return;
+      }
+      const wrapped = wrapBlock(`${label}: ${String(value)}`, detailWidth);
+      wrapped.forEach((line) => {
+        lines.push(fitAnsi(`${prefix}${color.fog}${line}${color.reset}`, width));
+      });
+    };
+
+    if (kind === "skills") {
+      pushField("skill id", item?.skillId ?? item?.key ?? null);
+      pushField("skill pda", item?.skillPda ?? null);
+      pushField("author", item?.author ?? null);
+      if (item?.priceDisplay && item.priceDisplay !== "n/a") {
+        pushField(
+          "price",
+          item?.priceLamports
+            ? `${item.priceDisplay} (${item.priceLamports} lamports)`
+            : item.priceDisplay,
+        );
+      }
+      if (Number.isFinite(Number(item?.rating))) {
+        const rating = Number(item.rating).toFixed(1);
+        const ratingCount = Number(item?.ratingCount);
+        pushField(
+          "rating",
+          Number.isFinite(ratingCount) && ratingCount > 0
+            ? `${rating} (${ratingCount} rating${ratingCount === 1 ? "" : "s"})`
+            : rating,
+        );
+      }
+      if (Number.isFinite(Number(item?.downloads))) {
+        pushField("downloads", String(Number(item.downloads)));
+      }
+      if (Number.isFinite(Number(item?.version))) {
+        pushField("version", String(Number(item.version)));
+      }
+      if (Array.isArray(item?.tags) && item.tags.length > 0) {
+        pushField("tags", item.tags.join(", "));
+      }
+      pushField("created", item?.createdAtLabel ?? item?.createdAt ?? null);
+      pushField("updated", item?.updatedAtLabel ?? item?.updatedAt ?? null);
+      pushField("content hash", item?.contentHash ?? null);
+    } else if (kind === "governance") {
+      pushField("proposal pda", item?.proposalPda ?? item?.key ?? null);
+      pushField("proposer", item?.proposer ?? null);
+      pushField("type", item?.proposalType ?? null);
+      pushField("status", item?.status ?? null);
+      const voteParts = [];
+      if (item?.votesFor) voteParts.push(`for ${item.votesFor}`);
+      if (item?.votesAgainst) voteParts.push(`against ${item.votesAgainst}`);
+      if (Number.isFinite(Number(item?.totalVoters))) voteParts.push(`${item.totalVoters} voters`);
+      pushField("votes", voteParts.join(" · ") || null);
+      pushField("quorum", item?.quorum ?? null);
+      pushField("created", item?.createdAtLabel ?? item?.createdAt ?? null);
+      pushField("voting deadline", item?.votingDeadlineLabel ?? item?.votingDeadline ?? null);
+      pushField("execution after", item?.executionAfterLabel ?? item?.executionAfter ?? null);
+      pushField("payload", item?.payloadPreview ?? null);
+      pushField("title hash", item?.titleHash ?? null);
+      pushField("description hash", item?.descriptionHash ?? null);
+    } else if (kind === "disputes") {
+      pushField("dispute pda", item?.disputePda ?? item?.key ?? null);
+      pushField("task pda", item?.taskPda ?? null);
+      pushField("initiator", item?.initiator ?? null);
+      pushField("defendant", item?.defendant ?? null);
+      pushField("status", item?.status ?? null);
+      pushField("resolution", item?.resolutionType ?? null);
+      const voteParts = [];
+      if (item?.votesFor) voteParts.push(`for ${item.votesFor}`);
+      if (item?.votesAgainst) voteParts.push(`against ${item.votesAgainst}`);
+      if (Number.isFinite(Number(item?.totalVoters))) voteParts.push(`${item.totalVoters} voters`);
+      pushField("votes", voteParts.join(" · ") || null);
+      pushField("created", item?.createdAtLabel ?? item?.createdAt ?? null);
+      pushField("voting deadline", item?.votingDeadlineLabel ?? item?.votingDeadline ?? null);
+      pushField("expires", item?.expiresAtLabel ?? item?.expiresAt ?? null);
+      pushField("resolved", item?.resolvedAtLabel ?? item?.resolvedAt ?? null);
+      pushField("slash applied", item?.slashApplied);
+      pushField("initiator slash", item?.initiatorSlashApplied);
+      pushField("worker stake", item?.workerStakeAtDispute ?? null);
+      pushField("initiated by creator", item?.initiatedByCreator);
+      pushField("reward mint", item?.rewardMint ?? null);
+      pushField("evidence hash", item?.evidenceHash ?? null);
+    } else if (kind === "reputation") {
+      pushField("registered", item?.registered !== false ? "true" : "false");
+      pushField("authority", item?.authority ?? null);
+      pushField("agent pda", item?.agentPda ?? null);
+      pushField("agent id", item?.agentId ?? null);
+      pushField("base reputation", item?.baseReputation ?? null);
+      pushField("effective reputation", item?.effectiveReputation ?? null);
+      pushField("tasks completed", item?.tasksCompleted ?? null);
+      if (item?.totalEarnedSol || item?.totalEarned) {
+        pushField(
+          "total earned",
+          item?.totalEarnedSol
+            ? `${item.totalEarnedSol} SOL${item?.totalEarned ? ` (${item.totalEarned} lamports)` : ""}`
+            : item.totalEarned,
+        );
+      }
+      if (item?.stakedAmountSol || item?.stakedAmount) {
+        pushField(
+          "staked",
+          item?.stakedAmountSol
+            ? `${item.stakedAmountSol} SOL${item?.stakedAmount ? ` (${item.stakedAmount} lamports)` : ""}`
+            : item.stakedAmount,
+        );
+      }
+      pushField("locked until", item?.lockedUntilLabel ?? item?.lockedUntil ?? null);
+      if (Array.isArray(item?.inboundDelegations)) {
+        pushField("inbound delegations", String(item.inboundDelegations.length));
+      }
+      if (Array.isArray(item?.outboundDelegations)) {
+        pushField("outbound delegations", String(item.outboundDelegations.length));
+      }
+    } else {
+      pushField("task id", item?.taskId ?? item?.key ?? null);
+      pushField("task pda", item?.taskPda ?? null);
+      pushField("creator", item?.creator ?? null);
+      if (item?.rewardDisplay && item.rewardDisplay !== "n/a") {
+        pushField(
+          "reward",
+          item?.rewardLamports
+            ? `${item.rewardDisplay} (${item.rewardLamports} lamports)`
+            : item.rewardDisplay,
+        );
+      }
+      if (Number.isFinite(Number(item?.currentWorkers)) || Number.isFinite(Number(item?.maxWorkers))) {
+        pushField(
+          "workers",
+          Number.isFinite(Number(item?.maxWorkers))
+            ? `${item?.currentWorkers ?? 0}/${item.maxWorkers}`
+            : String(item?.currentWorkers ?? 0),
+        );
+      }
+      pushField("deadline", item?.deadlineLabel ?? item?.deadline ?? null);
+      pushField("created", item?.createdAtLabel ?? item?.createdAt ?? null);
+    }
+
+    if (lines.length <= maxRows) {
+      return lines;
+    }
+    return [
+      ...lines.slice(0, maxRows - 1),
+      fitAnsi(`${prefix}${color.fog}…${color.reset}`, width),
+    ];
+  }
+
+  function marketTaskBrowserLines(width, browserState, height = termHeight()) {
+    if (browserState.mode === "none") {
+      return [];
+    }
+    const lines = [marketTaskBrowserSummaryLine(width, browserState)];
+    const filterLine = marketTaskBrowserFilterLine(width, browserState);
+    if (filterLine) {
+      lines.push(filterLine);
+    }
+    const kind = marketTaskBrowserKind(browserState);
+    if (browserState.browser?.loading) {
+      lines.push(
+        fitAnsi(
+          `${color.fog}${marketTaskBrowserLoadingLabel(kind)}${color.reset}`,
+          width,
+        ),
+      );
+      return lines;
+    }
+    if (browserState.items.length === 0) {
+      lines.push(
+        fitAnsi(
+          `${color.fog}${marketTaskBrowserEmptyLabel(kind)}${color.reset}`,
+          width,
+        ),
+      );
+      return lines;
+    }
+
+    const visibleEntries = composerPaletteWindow(
+      browserState.items,
+      browserState.activeIndex,
+      marketTaskBrowserVisibleEntryLimit(height),
+    );
+    visibleEntries.entries.forEach((item, index) => {
+      const absoluteIndex = visibleEntries.start + index;
+      const selected = absoluteIndex === browserState.activeIndex;
+      lines.push(marketTaskBrowserEntryLine(item, width, browserState, { selected }));
+      if (selected && browserState.browser?.expandedTaskKey === item?.key) {
+        lines.push(...marketTaskBrowserDetailLines(item, width, height, browserState));
+      }
+    });
+    return lines;
+  }
+
+  function currentBottomPopupLayout(width = termWidth(), height = termHeight()) {
+
+    const paletteState = currentComposerPaletteState(64);
+    if (paletteState.mode !== "none") {
+      return {
+        popupState: paletteState,
+        popup: composerPaletteLines(width, paletteState, height),
+      };
+    }
+    const marketTaskBrowserState = currentMarketTaskBrowserState();
+    return {
+      popupState: marketTaskBrowserState,
+      popup: marketTaskBrowserLines(width, marketTaskBrowserState, height),
     };
   }
 
   function currentTranscriptLayout() {
     const width = termWidth();
     const height = termHeight();
-    const { paletteState, popup } = currentBottomPopupLayout(width, height);
+    const { popupState, popup } = currentBottomPopupLayout(width, height);
     const popupRows = popup.length;
     const headerRows = headerLines(width).length;
     return buildWatchLayout({
@@ -1186,7 +1683,7 @@ export function createWatchFrameController(dependencies = {}) {
       height,
       headerRows,
       popupRows,
-      slashMode: paletteState.mode !== "none",
+      slashMode: popupState.mode !== "none",
       detailOpen: Boolean(watchState.expandedEventId),
     });
   }
@@ -2008,7 +2505,27 @@ export function createWatchFrameController(dependencies = {}) {
     return preview;
   }
 
+  function eventDetailVariant(event) {
+    if (
+      !event ||
+      typeof event !== "object" ||
+      typeof event.detailBody !== "string" ||
+      event.detailBody.trim().length === 0 ||
+      event.detailBody === event.body
+    ) {
+      return event;
+    }
+    return {
+      ...event,
+      body: event.detailBody,
+      bodyTruncated: false,
+    };
+  }
+
   function eventHasHiddenPreview(event, width) {
+    if (eventDetailVariant(event) !== event) {
+      return true;
+    }
     const sourcePreview = isSourcePreviewEvent(event);
     const markdownPreview = isMarkdownRenderableEvent(event);
     const displayLinePreview =
@@ -2258,7 +2775,7 @@ export function createWatchFrameController(dependencies = {}) {
   }
 
   function detailViewportState(event, width, targetHeight) {
-    const body = wrapEventDisplayLines(event, width);
+    const body = wrapEventDisplayLines(eventDetailVariant(event), width);
     const metaRows = event?.title && buildTranscriptEventSummary(event).meta !== sanitizeDisplayText(event.title)
       ? 1
       : 0;

--- a/runtime/src/watch/agenc-watch-helpers.mjs
+++ b/runtime/src/watch/agenc-watch-helpers.mjs
@@ -335,6 +335,11 @@ const REMOTE_TOOL_COMMANDS = Object.freeze([
     usage: "/desktop <start|stop|status|vnc|list|attach>",
     description: "Manage remote desktop/browser sandboxes from the watch TUI.",
   }),
+  Object.freeze({
+    name: "/market",
+    usage: "/market <tasks|skills|governance|disputes|reputation> ...",
+    description: "Inspect and mutate marketplace tasks, skills, governance, disputes, and reputation from the main watch TUI.",
+  }),
 ]);
 
 const EXTENSIBILITY_COMMANDS = Object.freeze([

--- a/runtime/src/watch/agenc-watch-input.mjs
+++ b/runtime/src/watch/agenc-watch-input.mjs
@@ -31,6 +31,10 @@ export function createWatchInputController(dependencies = {}) {
     autocompleteComposerInput,
     acceptComposerPaletteSelection = () => false,
     navigateComposer,
+    hasActiveMarketTaskBrowser = () => false,
+    navigateMarketTaskBrowser = () => false,
+    toggleMarketTaskBrowserExpansion = () => false,
+    dismissMarketTaskBrowser = () => false,
     hasActiveComposerPalette = () => false,
     navigateComposerPalette = () => false,
     moveComposerCursorByCharacter,
@@ -64,6 +68,10 @@ export function createWatchInputController(dependencies = {}) {
   assertFunction("autocompleteComposerInput", autocompleteComposerInput);
   assertFunction("acceptComposerPaletteSelection", acceptComposerPaletteSelection);
   assertFunction("navigateComposer", navigateComposer);
+  assertFunction("hasActiveMarketTaskBrowser", hasActiveMarketTaskBrowser);
+  assertFunction("navigateMarketTaskBrowser", navigateMarketTaskBrowser);
+  assertFunction("toggleMarketTaskBrowserExpansion", toggleMarketTaskBrowserExpansion);
+  assertFunction("dismissMarketTaskBrowser", dismissMarketTaskBrowser);
   assertFunction("hasActiveComposerPalette", hasActiveComposerPalette);
   assertFunction("navigateComposerPalette", navigateComposerPalette);
   assertFunction("moveComposerCursorByCharacter", moveComposerCursorByCharacter);
@@ -246,6 +254,11 @@ export function createWatchInputController(dependencies = {}) {
   }
 
   function submitComposerInput() {
+    if (hasActiveMarketTaskBrowser()) {
+      toggleMarketTaskBrowserExpansion();
+      scheduleRender();
+      return;
+    }
     if (hasActiveComposerPalette()) {
       acceptComposerPaletteSelection();
     }
@@ -307,6 +320,10 @@ export function createWatchInputController(dependencies = {}) {
         deleteComposerForward();
       } },
       { seq: "\x1b[A", run: () => {
+        if (hasActiveMarketTaskBrowser()) {
+          navigateMarketTaskBrowser(-1);
+          return;
+        }
         if (hasActiveComposerPalette()) {
           navigateComposerPalette(-1);
           return;
@@ -314,6 +331,10 @@ export function createWatchInputController(dependencies = {}) {
         navigateComposer(-1);
       } },
       { seq: "\x1b[B", run: () => {
+        if (hasActiveMarketTaskBrowser()) {
+          navigateMarketTaskBrowser(1);
+          return;
+        }
         if (hasActiveComposerPalette()) {
           navigateComposerPalette(1);
           return;
@@ -344,7 +365,9 @@ export function createWatchInputController(dependencies = {}) {
     }
 
     if (rest === "\x1b") {
-      if (watchState.expandedEventId) {
+      if (hasActiveMarketTaskBrowser()) {
+        dismissMarketTaskBrowser();
+      } else if (watchState.expandedEventId) {
         watchState.expandedEventId = null;
         watchState.detailScrollOffset = 0;
         setTransientStatus("detail closed");

--- a/runtime/src/watch/agenc-watch-state.mjs
+++ b/runtime/src/watch/agenc-watch-state.mjs
@@ -558,6 +558,7 @@ export function createWatchState({
       persistedWatchState.activeCheckpointId,
       null,
     ),
+    marketTaskBrowser: null,
     expandedEventId: null,
     secretPrompt: null,
     composerInput: "",

--- a/runtime/src/watch/agenc-watch-surface-dispatch.mjs
+++ b/runtime/src/watch/agenc-watch-surface-dispatch.mjs
@@ -15,6 +15,8 @@ export function dispatchOperatorSurfaceEvent(surfaceEvent, rawMessage, api) {
       return handleToolSurfaceEvent(surfaceEvent, state, api);
     case "social":
       return handleSocialSurfaceEvent(surfaceEvent, api);
+    case "market":
+      return handleMarketSurfaceEvent(surfaceEvent, api);
     case "run":
       return handleRunSurfaceEvent(surfaceEvent, state, api);
     case "observability":
@@ -339,6 +341,365 @@ function handleSocialSurfaceEvent(surfaceEvent, api) {
       payload.content ?? "",
     ].join("\n"),
     "blue",
+  );
+  return true;
+}
+
+function coerceMarketText(value, fallback = "unknown") {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+  const text = String(value).trim();
+  return text.length > 0 ? text : fallback;
+}
+
+function joinMarketLines(lines) {
+  return lines.filter(Boolean).join("\n");
+}
+
+function renderMarketList(items, buildLine, { limit = Infinity } = {}) {
+  if (!Array.isArray(items) || items.length === 0) {
+    return "No records returned.";
+  }
+  const safeLimit =
+    Number.isFinite(Number(limit)) && Number(limit) > 0
+      ? Math.max(1, Math.floor(Number(limit)))
+      : Infinity;
+  const visible =
+    safeLimit === Infinity ? items : items.slice(0, safeLimit);
+  const lines = visible
+    .map((item, index) => buildLine(item ?? {}, index))
+    .filter(Boolean);
+  if (items.length > visible.length) {
+    lines.push(`... ${items.length - visible.length} more`);
+  }
+  return lines.join("\n");
+}
+
+function summarizeMarketList(items, buildLine) {
+  return renderMarketList(items, buildLine, { limit: 5 });
+}
+
+function marketEventTitle(type) {
+  switch (type) {
+    case "tasks.list":
+      return "Marketplace Tasks";
+    case "tasks.detail":
+      return "Task Detail";
+    case "task.created":
+      return "Task Created";
+    case "task.claimed":
+      return "Task Claimed";
+    case "task.completed":
+      return "Task Completed";
+    case "task.cancelled":
+      return "Task Cancelled";
+    case "task.disputed":
+      return "Task Disputed";
+    case "market.skills.list":
+      return "Marketplace Skills";
+    case "market.skills.detail":
+      return "Skill Detail";
+    case "market.skills.purchased":
+      return "Skill Purchased";
+    case "market.skills.rated":
+      return "Skill Rated";
+    case "market.governance.list":
+      return "Governance Proposals";
+    case "market.governance.detail":
+      return "Governance Proposal";
+    case "market.governance.voted":
+      return "Governance Vote";
+    case "market.disputes.list":
+      return "Marketplace Disputes";
+    case "market.disputes.detail":
+      return "Dispute Detail";
+    case "market.disputes.resolved":
+      return "Dispute Resolved";
+    case "market.reputation.summary":
+      return "Reputation Summary";
+    case "market.reputation.staked":
+      return "Reputation Staked";
+    case "market.reputation.delegated":
+      return "Reputation Delegated";
+    default:
+      return "Marketplace Event";
+  }
+}
+
+function marketEventTone(type) {
+  if (type.startsWith("market.disputes") || type === "task.disputed") {
+    return "amber";
+  }
+  if (type === "task.completed" || type === "market.disputes.resolved") {
+    return "green";
+  }
+  return "teal";
+}
+
+function formatMarketplaceSkillListLine(item, index) {
+  const name = coerceMarketText(item?.name ?? item?.skillId ?? item?.skillPda, "unknown skill");
+  const ratingValue = Number(item?.rating ?? item?.averageRating);
+  const downloadsValue = Number(item?.downloads);
+  const details = [];
+  if (Number.isFinite(ratingValue)) {
+    details.push(`rating ${ratingValue.toFixed(1)}`);
+  }
+  if (Number.isFinite(downloadsValue)) {
+    details.push(`downloads ${downloadsValue}`);
+  }
+  return `${index + 1}. ${name}${details.length > 0 ? ` · ${details.join(" · ")}` : ""}`;
+}
+
+function formatMarketplaceGovernanceListLine(item, index) {
+  const subject = coerceMarketText(
+    item?.payloadPreview ?? item?.proposalType ?? item?.proposalPda,
+    "proposal",
+  );
+  const details = [];
+  const votesFor = String(item?.votesFor ?? "").trim();
+  const votesAgainst = String(item?.votesAgainst ?? "").trim();
+  if (votesFor) {
+    details.push(`for ${votesFor}`);
+  }
+  if (votesAgainst) {
+    details.push(`against ${votesAgainst}`);
+  }
+  return `${index + 1}. [${coerceMarketText(item?.status)}] ${subject}${details.length > 0 ? ` · ${details.join(" · ")}` : ""}`;
+}
+
+function formatMarketplaceDisputeListLine(item, index) {
+  const subject = coerceMarketText(
+    item?.resolutionType ?? item?.disputePda ?? item?.taskPda,
+    "dispute",
+  );
+  const details = [];
+  const votesFor = String(item?.votesFor ?? "").trim();
+  const votesAgainst = String(item?.votesAgainst ?? "").trim();
+  if (votesFor) {
+    details.push(`for ${votesFor}`);
+  }
+  if (votesAgainst) {
+    details.push(`against ${votesAgainst}`);
+  }
+  return `${index + 1}. [${coerceMarketText(item?.status)}] ${subject}${details.length > 0 ? ` · ${details.join(" · ")}` : ""}`;
+}
+
+function formatMarketplaceReputationListLine(item, index) {
+  const label = coerceMarketText(
+    item?.authority ?? item?.agentPda ?? item?.agentId,
+    "reputation summary",
+  );
+  const details = [];
+  if (item?.effectiveReputation !== undefined) {
+    details.push(`effective ${coerceMarketText(item.effectiveReputation)}`);
+  }
+  if (item?.tasksCompleted !== undefined) {
+    details.push(`tasks ${coerceMarketText(item.tasksCompleted)}`);
+  }
+  return `${index + 1}. [${item?.registered === false ? "unregistered" : "registered"}] ${label}${details.length > 0 ? ` · ${details.join(" · ")}` : ""}`;
+}
+
+function marketEventStatus(type) {
+  switch (type) {
+    case "tasks.list":
+      return "market tasks loaded";
+    case "tasks.detail":
+      return "task detail loaded";
+    case "market.skills.list":
+      return "market skills loaded";
+    case "market.governance.list":
+      return "governance proposals loaded";
+    case "market.disputes.list":
+      return "market disputes loaded";
+    case "market.reputation.summary":
+      return "reputation summary loaded";
+    default:
+      return `${marketEventTitle(type).toLowerCase()} received`;
+  }
+}
+
+function summarizeMarketSurfaceEvent(surfaceEvent, api) {
+  const payload = surfaceEvent.payloadRecord;
+  const list = surfaceEvent.payloadList;
+  switch (surfaceEvent.type) {
+    case "tasks.list":
+      return summarizeMarketList(list ?? [], (item, index) =>
+        `${index + 1}. [${coerceMarketText(item.status)}] ${coerceMarketText(item.description, "untitled task")} (${coerceMarketText(item.reward, "n/a")} SOL)`,
+      );
+    case "tasks.detail":
+      return joinMarketLines([
+        `task: ${coerceMarketText(payload.taskPda ?? payload.id)}`,
+        `status: ${coerceMarketText(payload.status)}`,
+        payload.reward !== undefined ? `reward: ${coerceMarketText(payload.reward)} SOL` : null,
+        payload.rewardLamports !== undefined ? `reward lamports: ${coerceMarketText(payload.rewardLamports)}` : null,
+        payload.creator ? `creator: ${coerceMarketText(payload.creator)}` : null,
+        payload.currentWorkers !== undefined ? `workers: ${coerceMarketText(payload.currentWorkers)}` : null,
+        payload.description ? "" : null,
+        payload.description ? coerceMarketText(payload.description, "") : null,
+      ]);
+    case "task.created":
+      return joinMarketLines([
+        `task: ${coerceMarketText(payload.taskPda)}`,
+        payload.description ? "" : null,
+        payload.description ? coerceMarketText(payload.description, "") : null,
+      ]);
+    case "task.claimed":
+      return joinMarketLines([
+        `task: ${coerceMarketText(payload.taskPda)}`,
+        payload.worker ? `worker: ${coerceMarketText(payload.worker)}` : null,
+      ]);
+    case "task.completed":
+      return joinMarketLines([
+        `task: ${coerceMarketText(payload.taskPda)}`,
+        payload.resultData ? `result: ${coerceMarketText(payload.resultData)}` : null,
+      ]);
+    case "task.cancelled":
+      return `task: ${coerceMarketText(payload.taskPda)}`;
+    case "task.disputed":
+      return joinMarketLines([
+        `task: ${coerceMarketText(payload.taskPda)}`,
+        payload.evidence ? `evidence: ${coerceMarketText(payload.evidence)}` : null,
+        payload.resolutionType ? `requested resolution: ${coerceMarketText(payload.resolutionType)}` : null,
+      ]);
+    case "market.skills.list":
+      return summarizeMarketList(list ?? [], (item, index) =>
+        formatMarketplaceSkillListLine(item, index),
+      );
+    case "market.skills.detail":
+      return joinMarketLines([
+        `skill: ${coerceMarketText(payload.skillId ?? payload.skillPda)}`,
+        payload.seller ? `seller: ${coerceMarketText(payload.seller)}` : null,
+        payload.price !== undefined ? `price: ${coerceMarketText(payload.price)}` : null,
+        payload.averageRating !== undefined ? `rating: ${coerceMarketText(payload.averageRating)}` : null,
+        payload.description ? "" : null,
+        payload.description ? coerceMarketText(payload.description, "") : null,
+      ]);
+    case "market.skills.purchased":
+      return joinMarketLines([
+        `skill: ${coerceMarketText(payload.skillId ?? payload.skillPda)}`,
+        payload.receiptPda ? `receipt: ${coerceMarketText(payload.receiptPda)}` : null,
+      ]);
+    case "market.skills.rated":
+      return joinMarketLines([
+        `skill: ${coerceMarketText(payload.skillPda)}`,
+        `rating: ${coerceMarketText(payload.rating)}`,
+      ]);
+    case "market.governance.list":
+      return summarizeMarketList(list ?? [], (item, index) =>
+        formatMarketplaceGovernanceListLine(item, index),
+      );
+    case "market.governance.detail":
+      return joinMarketLines([
+        `proposal: ${coerceMarketText(payload.proposalPda)}`,
+        payload.title ? `title: ${coerceMarketText(payload.title)}` : null,
+        payload.status ? `status: ${coerceMarketText(payload.status)}` : null,
+        payload.description ? "" : null,
+        payload.description ? coerceMarketText(payload.description, "") : null,
+      ]);
+    case "market.governance.voted":
+      return joinMarketLines([
+        `proposal: ${coerceMarketText(payload.proposalPda)}`,
+        `vote: ${payload.approve === true ? "yes" : "no"}`,
+      ]);
+    case "market.disputes.list":
+      return summarizeMarketList(list ?? [], (item, index) =>
+        formatMarketplaceDisputeListLine(item, index),
+      );
+    case "market.disputes.detail":
+      return joinMarketLines([
+        `dispute: ${coerceMarketText(payload.disputePda)}`,
+        payload.status ? `status: ${coerceMarketText(payload.status)}` : null,
+        payload.taskPda ? `task: ${coerceMarketText(payload.taskPda)}` : null,
+        payload.reason ? `reason: ${coerceMarketText(payload.reason)}` : null,
+      ]);
+    case "market.disputes.resolved":
+      return joinMarketLines([
+        `dispute: ${coerceMarketText(payload.disputePda)}`,
+        payload.result ? api.tryPrettyJson(payload.result) : null,
+      ]);
+    case "market.reputation.summary":
+      return formatMarketplaceReputationListLine(payload ?? {}, 0);
+    case "market.reputation.staked":
+      return `amount: ${coerceMarketText(payload.amount)}`;
+    case "market.reputation.delegated":
+      return joinMarketLines([
+        `amount: ${coerceMarketText(payload.amount)}`,
+        payload.delegateeAgentPda ? `delegatee: ${coerceMarketText(payload.delegateeAgentPda)}` : null,
+        payload.expiresAt ? `expires at: ${coerceMarketText(payload.expiresAt)}` : null,
+      ]);
+    default:
+      return api.tryPrettyJson(surfaceEvent.payload ?? payload);
+  }
+}
+
+function buildMarketDetailSurfaceEvent(surfaceEvent, api) {
+  const payload = surfaceEvent.payloadRecord;
+  const list = surfaceEvent.payloadList;
+  switch (surfaceEvent.type) {
+    case "tasks.list":
+      return renderMarketList(list ?? [], (item, index) =>
+        `${index + 1}. [${coerceMarketText(item.status)}] ${coerceMarketText(item.description, "untitled task")} (${coerceMarketText(item.reward, "n/a")} SOL)`,
+      );
+    case "market.skills.list":
+      return renderMarketList(list ?? [], (item, index) =>
+        formatMarketplaceSkillListLine(item, index),
+      );
+    case "market.governance.list":
+      return renderMarketList(list ?? [], (item, index) =>
+        formatMarketplaceGovernanceListLine(item, index),
+      );
+    case "market.disputes.list":
+      return renderMarketList(list ?? [], (item, index) =>
+        formatMarketplaceDisputeListLine(item, index),
+      );
+    case "market.reputation.summary":
+      return joinMarketLines([
+        payload.authority ? `authority: ${coerceMarketText(payload.authority)}` : null,
+        payload.agentPda ? `agent: ${coerceMarketText(payload.agentPda)}` : null,
+        payload.agentId ? `agent id: ${coerceMarketText(payload.agentId)}` : null,
+        payload.baseReputation !== undefined ? `base reputation: ${coerceMarketText(payload.baseReputation)}` : null,
+        payload.effectiveReputation !== undefined ? `effective reputation: ${coerceMarketText(payload.effectiveReputation)}` : null,
+        payload.tasksCompleted !== undefined ? `completed tasks: ${coerceMarketText(payload.tasksCompleted)}` : null,
+        payload.totalEarnedSol !== undefined ? `total earned: ${coerceMarketText(payload.totalEarnedSol)} SOL` : null,
+        payload.stakedAmountSol !== undefined ? `staked: ${coerceMarketText(payload.stakedAmountSol)} SOL` : null,
+      ]);
+    default:
+      return summarizeMarketSurfaceEvent(surfaceEvent, api);
+  }
+}
+
+function handleMarketSurfaceEvent(surfaceEvent, api) {
+  const title = marketEventTitle(surfaceEvent.type);
+  const summaryBody = summarizeMarketSurfaceEvent(surfaceEvent, api);
+  const detailBody = buildMarketDetailSurfaceEvent(surfaceEvent, api);
+  const browserKinds = {
+    "tasks.list": "tasks",
+    "market.skills.list": "skills",
+    "market.governance.list": "governance",
+    "market.disputes.list": "disputes",
+    "market.reputation.summary": "reputation",
+  };
+  const browserKind = browserKinds[surfaceEvent.type];
+  if (browserKind && typeof api.hydrateMarketTaskBrowser === "function") {
+    api.hydrateMarketTaskBrowser({
+      title,
+      items:
+        surfaceEvent.type === "market.reputation.summary"
+          ? (surfaceEvent.payloadRecord && Object.keys(surfaceEvent.payloadRecord).length > 0
+            ? [surfaceEvent.payloadRecord]
+            : [])
+          : surfaceEvent.payloadList ?? [],
+      kind: browserKind,
+    });
+  }
+  api.setTransientStatus(marketEventStatus(surfaceEvent.type));
+  api.eventStore.pushEvent(
+    "market",
+    title,
+    summaryBody,
+    marketEventTone(surfaceEvent.type),
+    detailBody && detailBody !== summaryBody ? { detailBody } : {},
   );
   return true;
 }

--- a/runtime/src/watch/agenc-watch-transcript-cards.mjs
+++ b/runtime/src/watch/agenc-watch-transcript-cards.mjs
@@ -65,6 +65,9 @@ export function computeTranscriptPreviewMaxLines({
       Math.floor(viewport * (latestIsCurrent ? 0.42 : 0.24)),
     );
   }
+  if (eventKind === "market") {
+    return latestIsCurrent ? 8 : 6;
+  }
   if (eventKind === "subagent") {
     return 2;
   }

--- a/runtime/src/watch/entry.mjs
+++ b/runtime/src/watch/entry.mjs
@@ -7,6 +7,9 @@ function applyDefaultWatchCliEnvironment(env) {
   if (env.AGENC_WATCH_ENABLE_ATTACHMENTS == null) {
     env.AGENC_WATCH_ENABLE_ATTACHMENTS = "true";
   }
+  if (env.AGENC_WATCH_ENABLE_REMOTE_TOOLS == null) {
+    env.AGENC_WATCH_ENABLE_REMOTE_TOOLS = "true";
+  }
 }
 
 export async function runAgencWatchCli({ runWatchApp = defaultRunWatchApp, processLike = process } = {}) {

--- a/runtime/src/workflow/orchestrator.test.ts
+++ b/runtime/src/workflow/orchestrator.test.ts
@@ -33,6 +33,7 @@ import type {
   WorkflowState,
 } from "./types.js";
 import { RuntimeErrorCodes } from "../types/errors.js";
+import { findAuthorityRateLimitPda } from "../agent/pda.js";
 
 // ============================================================================
 // Test Helpers
@@ -472,6 +473,10 @@ describe("DAGSubmitter", () => {
 
     expect(methodChain.accountsPartial).toHaveBeenCalledWith(
       expect.objectContaining({
+        authorityRateLimit: findAuthorityRateLimitPda(
+          program.provider.publicKey,
+          program.programId,
+        ),
         authority: program.provider.publicKey,
         creator: program.provider.publicKey,
       }),

--- a/runtime/src/workflow/submitter.ts
+++ b/runtime/src/workflow/submitter.ts
@@ -10,13 +10,13 @@
 
 import { SystemProgram } from "@solana/web3.js";
 import type { PublicKey } from "@solana/web3.js";
-import anchor, { type Program } from "@coral-xyz/anchor";
+import { BN, type Program } from "@coral-xyz/anchor";
 import type { AgencCoordination } from "../types/agenc_coordination.js";
 import type { Logger } from "../utils/logger.js";
 import { silentLogger } from "../utils/logger.js";
 import { sleep } from "../utils/async.js";
 import { generateAgentId, toAnchorBytes } from "../utils/encoding.js";
-import { findAgentPda, findProtocolPda } from "../agent/pda.js";
+import { findAgentPda, findAuthorityRateLimitPda, findProtocolPda } from "../agent/pda.js";
 import { findTaskPda, findEscrowPda } from "../task/pda.js";
 import { isAnchorError, AnchorErrorCodes } from "../types/errors.js";
 import { buildCreateTaskTokenAccounts } from "../utils/token.js";
@@ -54,6 +54,7 @@ export class DAGSubmitter {
   private readonly retryDelayMs: number;
   private readonly agentPda;
   private readonly protocolPda;
+  private readonly authorityRateLimitPda;
 
   constructor(config: DAGSubmitterConfig) {
     this.program = config.program;
@@ -61,8 +62,16 @@ export class DAGSubmitter {
     this.logger = config.logger ?? silentLogger;
     this.maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
     this.retryDelayMs = config.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+    const authority = this.program.provider.publicKey;
+    if (!authority) {
+      throw new Error("Signer-backed program required for workflow submission");
+    }
     this.agentPda = findAgentPda(this.agentId, this.program.programId);
     this.protocolPda = findProtocolPda(this.program.programId);
+    this.authorityRateLimitPda = findAuthorityRateLimitPda(
+      authority,
+      this.program.programId,
+    );
   }
 
   /**
@@ -231,11 +240,11 @@ export class DAGSubmitter {
     return this.program.methods
       .createTask(
         toAnchorBytes(taskId),
-        new anchor.BN(template.requiredCapabilities.toString()),
+        new BN(template.requiredCapabilities.toString()),
         toAnchorBytes(template.description),
-        new anchor.BN(template.rewardAmount.toString()),
+        new BN(template.rewardAmount.toString()),
         template.maxWorkers,
-        new anchor.BN(template.deadline),
+        new BN(template.deadline),
         template.taskType,
         constraintHash,
         template.minReputation ?? 0,
@@ -246,6 +255,7 @@ export class DAGSubmitter {
         escrow: escrowPda,
         protocolConfig: this.protocolPda,
         creatorAgent: this.agentPda,
+        authorityRateLimit: this.authorityRateLimitPda,
         authority: creator,
         creator,
         systemProgram: SystemProgram.programId,
@@ -280,11 +290,11 @@ export class DAGSubmitter {
     return this.program.methods
       .createDependentTask(
         toAnchorBytes(taskId),
-        new anchor.BN(template.requiredCapabilities.toString()),
+        new BN(template.requiredCapabilities.toString()),
         toAnchorBytes(template.description),
-        new anchor.BN(template.rewardAmount.toString()),
+        new BN(template.rewardAmount.toString()),
         template.maxWorkers,
-        new anchor.BN(template.deadline),
+        new BN(template.deadline),
         template.taskType,
         constraintHash,
         dependencyType,
@@ -297,6 +307,7 @@ export class DAGSubmitter {
         parentTask: parentTaskPda,
         protocolConfig: this.protocolPda,
         creatorAgent: this.agentPda,
+        authorityRateLimit: this.authorityRateLimitPda,
         authority: creator,
         creator,
         systemProgram: SystemProgram.programId,

--- a/runtime/src/workflow/submitter.ts
+++ b/runtime/src/workflow/submitter.ts
@@ -237,7 +237,10 @@ export class DAGSubmitter {
       creator,
     );
 
-    return this.program.methods
+    // The runtime patches local IDL account layouts ahead of the published
+    // protocol typings, so these builders need a narrow escape hatch until the
+    // package catches up.
+    return (this.program.methods as any)
       .createTask(
         toAnchorBytes(taskId),
         new BN(template.requiredCapabilities.toString()),
@@ -287,7 +290,10 @@ export class DAGSubmitter {
       creator,
     );
 
-    return this.program.methods
+    // The runtime patches local IDL account layouts ahead of the published
+    // protocol typings, so these builders need a narrow escape hatch until the
+    // package catches up.
+    return (this.program.methods as any)
       .createDependentTask(
         toAnchorBytes(taskId),
         new BN(template.requiredCapabilities.toString()),

--- a/runtime/tests/marketplace-cli.integration.test.ts
+++ b/runtime/tests/marketplace-cli.integration.test.ts
@@ -438,7 +438,6 @@ describeIfProtocolWorkspace("marketplace CLI integration", () => {
         evidence: VALID_EVIDENCE,
         resolutionType: "refund",
         initiatorAgentPda: creator.agentPda.toBase58(),
-        workerAgentPda: worker.agentPda.toBase58(),
       },
       creator.agentPda.toBase58(),
     );

--- a/runtime/tests/watch/agenc-watch-commands.test.mjs
+++ b/runtime/tests/watch/agenc-watch-commands.test.mjs
@@ -337,6 +337,14 @@ function createCommandHarness(overrides = {}) {
         attachmentSummaries,
       };
     },
+    openMarketTaskBrowser({ title, kind, statuses, query, activeOnly }) {
+      calls.push({ type: "openMarketTaskBrowser", title, kind, statuses, query, activeOnly });
+      return { title, kind, statuses, query, activeOnly };
+    },
+    dismissMarketTaskBrowser() {
+      calls.push({ type: "dismissMarketTaskBrowser" });
+      return true;
+    },
     openLatestDiffDetail() {
       calls.push({ type: "openLatestDiffDetail" });
       return {
@@ -1330,6 +1338,176 @@ test("command controller forwards desktop tooling commands onto chat.message", (
         entry.kind === "error" &&
         entry.title === "Usage Error" &&
         /Usage: \/desktop/.test(entry.body),
+    ),
+  );
+});
+
+test("command controller opens the market task browser before requesting marketplace tasks", () => {
+  const { controller, calls } = createCommandHarness({
+    WATCH_COMMANDS: [
+      { name: "/market", usage: "/market", description: "market", aliases: [] },
+    ],
+  });
+
+  assert.equal(controller.dispatchOperatorInput("/market tasks list --status open,claimed"), true);
+
+  const marketRequest = calls.find(
+    (entry) => entry.type === "send" && entry.frameType === "tasks.list",
+  );
+  assert.deepEqual(marketRequest?.payload, { statuses: ["open", "claimed"] });
+  assert.deepEqual(
+    calls.filter((entry) => entry.type === "openMarketTaskBrowser"),
+    [
+      {
+        type: "openMarketTaskBrowser",
+        title: "Marketplace Tasks",
+        kind: "tasks",
+        statuses: ["open", "claimed"],
+        query: undefined,
+        activeOnly: undefined,
+      },
+    ],
+  );
+  assert.ok(
+    calls.some(
+      (entry) => entry.type === "status" && entry.status === "requesting marketplace tasks",
+    ),
+  );
+});
+
+test("command controller opens the market skill browser before requesting marketplace skills", () => {
+  const { controller, calls } = createCommandHarness({
+    WATCH_COMMANDS: [
+      { name: "/market", usage: "/market", description: "market", aliases: [] },
+    ],
+  });
+
+  assert.equal(controller.dispatchOperatorInput("/market skills list --query browser"), true);
+
+  const marketRequest = calls.find(
+    (entry) => entry.type === "send" && entry.frameType === "market.skills.list",
+  );
+  assert.deepEqual(marketRequest?.payload, { query: "browser", activeOnly: true });
+  assert.deepEqual(
+    calls.filter((entry) => entry.type === "dismissMarketTaskBrowser"),
+    [],
+  );
+  assert.deepEqual(
+    calls.filter((entry) => entry.type === "openMarketTaskBrowser"),
+    [
+      {
+        type: "openMarketTaskBrowser",
+        title: "Marketplace Skills",
+        kind: "skills",
+        statuses: undefined,
+        query: "browser",
+        activeOnly: true,
+      },
+    ],
+  );
+  assert.ok(
+    calls.some(
+      (entry) => entry.type === "status" && entry.status === "requesting marketplace skills",
+    ),
+  );
+});
+
+
+test("command controller opens the governance browser before requesting governance proposals", () => {
+  const { controller, calls } = createCommandHarness({
+    WATCH_COMMANDS: [
+      { name: "/market", usage: "/market", description: "market", aliases: [] },
+    ],
+  });
+
+  assert.equal(controller.dispatchOperatorInput("/market governance list --status active"), true);
+
+  const marketRequest = calls.find(
+    (entry) => entry.type === "send" && entry.frameType === "market.governance.list",
+  );
+  assert.deepEqual(marketRequest?.payload, { status: "active" });
+  assert.deepEqual(
+    calls.filter((entry) => entry.type === "openMarketTaskBrowser"),
+    [
+      {
+        type: "openMarketTaskBrowser",
+        title: "Governance Proposals",
+        kind: "governance",
+        statuses: ["active"],
+        query: undefined,
+        activeOnly: undefined,
+      },
+    ],
+  );
+  assert.ok(
+    calls.some(
+      (entry) => entry.type === "status" && entry.status === "requesting governance proposals",
+    ),
+  );
+});
+
+test("command controller opens the disputes browser before requesting marketplace disputes", () => {
+  const { controller, calls } = createCommandHarness({
+    WATCH_COMMANDS: [
+      { name: "/market", usage: "/market", description: "market", aliases: [] },
+    ],
+  });
+
+  assert.equal(controller.dispatchOperatorInput("/market disputes list --status open,resolved"), true);
+
+  const marketRequest = calls.find(
+    (entry) => entry.type === "send" && entry.frameType === "market.disputes.list",
+  );
+  assert.deepEqual(marketRequest?.payload, { statuses: ["open", "resolved"] });
+  assert.deepEqual(
+    calls.filter((entry) => entry.type === "openMarketTaskBrowser"),
+    [
+      {
+        type: "openMarketTaskBrowser",
+        title: "Marketplace Disputes",
+        kind: "disputes",
+        statuses: ["open", "resolved"],
+        query: undefined,
+        activeOnly: undefined,
+      },
+    ],
+  );
+  assert.ok(
+    calls.some(
+      (entry) => entry.type === "status" && entry.status === "requesting marketplace disputes",
+    ),
+  );
+});
+
+test("command controller opens the reputation browser before requesting a reputation summary", () => {
+  const { controller, calls } = createCommandHarness({
+    WATCH_COMMANDS: [
+      { name: "/market", usage: "/market", description: "market", aliases: [] },
+    ],
+  });
+
+  assert.equal(controller.dispatchOperatorInput("/market reputation summary --agent-pda agent-pda-1"), true);
+
+  const marketRequest = calls.find(
+    (entry) => entry.type === "send" && entry.frameType === "market.reputation.summary",
+  );
+  assert.deepEqual(marketRequest?.payload, { agentPda: "agent-pda-1" });
+  assert.deepEqual(
+    calls.filter((entry) => entry.type === "openMarketTaskBrowser"),
+    [
+      {
+        type: "openMarketTaskBrowser",
+        title: "Reputation Summary",
+        kind: "reputation",
+        statuses: undefined,
+        query: undefined,
+        activeOnly: undefined,
+      },
+    ],
+  );
+  assert.ok(
+    calls.some(
+      (entry) => entry.type === "status" && entry.status === "loading reputation summary",
     ),
   );
 });

--- a/runtime/tests/watch/agenc-watch-entry.test.mjs
+++ b/runtime/tests/watch/agenc-watch-entry.test.mjs
@@ -36,6 +36,7 @@ test("runAgencWatchCli exits with the app exit code on success", async () => {
   assert.deepEqual(harness.exits, [7]);
   assert.deepEqual(harness.writes, []);
   assert.equal(harness.env.AGENC_WATCH_ENABLE_ATTACHMENTS, "true");
+  assert.equal(harness.env.AGENC_WATCH_ENABLE_REMOTE_TOOLS, "true");
 });
 
 test("runAgencWatchCli writes errors and exits non-zero on failure", async () => {
@@ -52,11 +53,13 @@ test("runAgencWatchCli writes errors and exits non-zero on failure", async () =>
   assert.equal(harness.writes.length, 1);
   assert.match(harness.writes[0], /boom/);
   assert.equal(harness.env.AGENC_WATCH_ENABLE_ATTACHMENTS, "true");
+  assert.equal(harness.env.AGENC_WATCH_ENABLE_REMOTE_TOOLS, "true");
 });
 
-test("runAgencWatchCli preserves an explicit attachment override", async () => {
+test("runAgencWatchCli preserves explicit attachment and remote-tool overrides", async () => {
   const harness = createProcessHarness();
   harness.env.AGENC_WATCH_ENABLE_ATTACHMENTS = "false";
+  harness.env.AGENC_WATCH_ENABLE_REMOTE_TOOLS = "false";
 
   await runAgencWatchCli({
     runWatchApp: async () => 0,
@@ -65,4 +68,5 @@ test("runAgencWatchCli preserves an explicit attachment override", async () => {
 
   assert.deepEqual(harness.exits, [0]);
   assert.equal(harness.env.AGENC_WATCH_ENABLE_ATTACHMENTS, "false");
+  assert.equal(harness.env.AGENC_WATCH_ENABLE_REMOTE_TOOLS, "false");
 });

--- a/runtime/tests/watch/agenc-watch-frame.test.mjs
+++ b/runtime/tests/watch/agenc-watch-frame.test.mjs
@@ -110,6 +110,310 @@ test("frame controller prefers the newest truncated event when opening detail mo
   assert.ok(harness.statusCalls.includes("detail open: Prompt"));
 });
 
+test("frame controller treats market events with detailBody as expandable", () => {
+  const harness = createWatchFrameHarness({
+    events: [
+      {
+        id: "evt-1",
+        kind: "market",
+        title: "Marketplace Tasks",
+        body: "1. Task 1",
+        detailBody: "1. Task 1\n2. Task 2\n3. Task 3",
+        timestamp: "12:00:00",
+      },
+    ],
+  });
+
+  harness.controller.toggleExpandedEvent();
+
+  assert.equal(harness.watchState.expandedEventId, "evt-1");
+  assert.ok(harness.statusCalls.includes("detail open: Marketplace Tasks"));
+});
+
+test("frame controller renders the marketplace task browser inline below the composer", () => {
+  const harness = createWatchFrameHarness({
+    watchState: {
+      marketTaskBrowser: {
+        open: true,
+        title: "Marketplace Tasks",
+        statuses: ["open", "claimed"],
+        loading: false,
+        selectedIndex: 1,
+        expandedTaskKey: "task-2",
+        items: [
+          {
+            key: "task-1",
+            taskId: "task-1",
+            taskPda: "task-pda-1",
+            status: "open",
+            description: "Task 1",
+            rewardDisplay: "1 SOL",
+            currentWorkers: 1,
+            maxWorkers: 2,
+          },
+          {
+            key: "task-2",
+            taskId: "task-2",
+            taskPda: "task-pda-2",
+            status: "claimed",
+            description: "Task 2",
+            rewardDisplay: "2 SOL",
+            rewardLamports: "2000000000",
+            creator: "creator-2",
+            currentWorkers: 2,
+            maxWorkers: 4,
+            deadlineLabel: "2026-04-10 12:00:00Z",
+            createdAtLabel: "2026-04-09 12:00:00Z",
+          },
+        ],
+      },
+    },
+    inputValue: "",
+    width: 120,
+    height: 38,
+  });
+
+  const snapshot = harness.controller.buildVisibleFrameSnapshot();
+  const titleRow = snapshot.lines.findIndex((line) => String(line).includes("Marketplace Tasks"));
+  const taskRow = snapshot.lines.findIndex((line) => String(line).includes("Task 2") && String(line).includes("2 SOL"));
+  const detailRow = snapshot.lines.findIndex((line) => String(line).includes("task id: task-2"));
+
+  assert.notEqual(titleRow, -1);
+  assert.notEqual(taskRow, -1);
+  assert.notEqual(detailRow, -1);
+  assert.ok(titleRow + 1 > snapshot.composer.absoluteRow);
+  assert.ok(taskRow + 1 > snapshot.composer.absoluteRow);
+  assert.ok(detailRow + 1 > snapshot.composer.absoluteRow);
+  assert.equal(harness.layoutCalls.at(-1)?.slashMode, true);
+});
+
+test("frame controller renders the marketplace skill browser inline below the composer", () => {
+  const harness = createWatchFrameHarness({
+    watchState: {
+      marketTaskBrowser: {
+        open: true,
+        kind: "skills",
+        title: "Marketplace Skills",
+        query: "browser",
+        activeOnly: true,
+        loading: false,
+        selectedIndex: 1,
+        expandedTaskKey: "skill-2",
+        items: [
+          {
+            key: "skill-1",
+            skillId: "skill-1",
+            skillPda: "skill-pda-1",
+            name: "Skill 1",
+            isActive: true,
+            priceDisplay: "1 SOL",
+            rating: 4.1,
+            downloads: 11,
+          },
+          {
+            key: "skill-2",
+            skillId: "skill-2",
+            skillPda: "skill-pda-2",
+            name: "Browser Skill",
+            author: "author-2",
+            tags: ["browser", "automation"],
+            isActive: true,
+            priceDisplay: "2 SOL",
+            priceLamports: "2000000000",
+            rating: 4.8,
+            ratingCount: 12,
+            downloads: 42,
+            version: 3,
+            createdAtLabel: "2026-04-09 12:00:00Z",
+            updatedAtLabel: "2026-04-10 08:00:00Z",
+          },
+        ],
+      },
+    },
+    inputValue: "",
+    width: 120,
+    height: 38,
+  });
+
+  const snapshot = harness.controller.buildVisibleFrameSnapshot();
+  const titleRow = snapshot.lines.findIndex((line) => String(line).includes("Marketplace Skills"));
+  const skillRow = snapshot.lines.findIndex((line) => String(line).includes("Browser Skill") && String(line).includes("2 SOL"));
+  const detailRow = snapshot.lines.findIndex((line) => String(line).includes("skill id: skill-2"));
+
+  assert.notEqual(titleRow, -1);
+  assert.notEqual(skillRow, -1);
+  assert.notEqual(detailRow, -1);
+  assert.ok(titleRow + 1 > snapshot.composer.absoluteRow);
+  assert.ok(skillRow + 1 > snapshot.composer.absoluteRow);
+  assert.ok(detailRow + 1 > snapshot.composer.absoluteRow);
+  assert.equal(harness.layoutCalls.at(-1)?.slashMode, true);
+});
+
+
+test("frame controller renders the governance browser inline below the composer", () => {
+  const harness = createWatchFrameHarness({
+    watchState: {
+      marketTaskBrowser: {
+        open: true,
+        kind: "governance",
+        title: "Governance Proposals",
+        statuses: ["active"],
+        loading: false,
+        selectedIndex: 1,
+        expandedTaskKey: "proposal-2",
+        items: [
+          {
+            key: "proposal-1",
+            proposalPda: "proposal-pda-1",
+            status: "open",
+            proposalType: "budget",
+            payloadPreview: "Treasury top-up",
+          },
+          {
+            key: "proposal-2",
+            proposalPda: "proposal-pda-2",
+            proposer: "agent-2",
+            status: "active",
+            proposalType: "upgrade",
+            payloadPreview: "Upgrade validator set",
+            votesFor: "12",
+            votesAgainst: "3",
+            totalVoters: 15,
+            createdAtLabel: "2026-04-09 12:00:00Z",
+            votingDeadlineLabel: "2026-04-10 12:00:00Z",
+          },
+        ],
+      },
+    },
+    inputValue: "",
+    width: 120,
+    height: 38,
+  });
+
+  const snapshot = harness.controller.buildVisibleFrameSnapshot();
+  const titleRow = snapshot.lines.findIndex((line) => String(line).includes("Governance Proposals"));
+  const proposalRow = snapshot.lines.findIndex(
+    (line) =>
+      String(line).includes("Upgrade validator set") &&
+      String(line).includes("for 12") &&
+      String(line).includes("against 3"),
+  );
+  const detailRow = snapshot.lines.findIndex((line) =>
+    String(line).includes("proposal pda: proposal-pda-2"),
+  );
+
+  assert.notEqual(titleRow, -1);
+  assert.notEqual(proposalRow, -1);
+  assert.notEqual(detailRow, -1);
+  assert.ok(titleRow + 1 > snapshot.composer.absoluteRow);
+  assert.ok(proposalRow + 1 > snapshot.composer.absoluteRow);
+  assert.ok(detailRow + 1 > snapshot.composer.absoluteRow);
+  assert.equal(harness.layoutCalls.at(-1)?.slashMode, true);
+});
+
+test("frame controller renders the disputes browser inline below the composer", () => {
+  const harness = createWatchFrameHarness({
+    watchState: {
+      marketTaskBrowser: {
+        open: true,
+        kind: "disputes",
+        title: "Marketplace Disputes",
+        statuses: ["pending"],
+        loading: false,
+        selectedIndex: 0,
+        expandedTaskKey: "dispute-1",
+        items: [
+          {
+            key: "dispute-1",
+            disputePda: "dispute-pda-1",
+            taskPda: "task-pda-9",
+            initiator: "creator-1",
+            defendant: "worker-1",
+            status: "pending",
+            resolutionType: "refund",
+            votesFor: "2",
+            votesAgainst: "1",
+            totalVoters: 3,
+            createdAtLabel: "2026-04-09 12:00:00Z",
+          },
+        ],
+      },
+    },
+    inputValue: "",
+    width: 120,
+    height: 38,
+  });
+
+  const snapshot = harness.controller.buildVisibleFrameSnapshot();
+  const titleRow = snapshot.lines.findIndex((line) => String(line).includes("Marketplace Disputes"));
+  const disputeRow = snapshot.lines.findIndex(
+    (line) =>
+      String(line).includes("refund") &&
+      String(line).includes("dispute-pda-1") &&
+      String(line).includes("for 2"),
+  );
+  const detailRow = snapshot.lines.findIndex((line) =>
+    String(line).includes("dispute pda: dispute-pda-1"),
+  );
+
+  assert.notEqual(titleRow, -1);
+  assert.notEqual(disputeRow, -1);
+  assert.notEqual(detailRow, -1);
+  assert.ok(titleRow + 1 > snapshot.composer.absoluteRow);
+  assert.ok(disputeRow + 1 > snapshot.composer.absoluteRow);
+  assert.ok(detailRow + 1 > snapshot.composer.absoluteRow);
+  assert.equal(harness.layoutCalls.at(-1)?.slashMode, true);
+});
+
+test("frame controller renders the reputation browser inline below the composer", () => {
+  const harness = createWatchFrameHarness({
+    watchState: {
+      marketTaskBrowser: {
+        open: true,
+        kind: "reputation",
+        title: "Reputation Summary",
+        loading: false,
+        selectedIndex: 0,
+        expandedTaskKey: "rep-1",
+        items: [
+          {
+            key: "rep-1",
+            authority: "agent-authority-1",
+            agentPda: "agent-pda-1",
+            registered: true,
+            effectiveReputation: 98,
+            tasksCompleted: "14",
+            totalEarnedSol: "4.2",
+          },
+        ],
+      },
+    },
+    inputValue: "",
+    width: 120,
+    height: 38,
+  });
+
+  const snapshot = harness.controller.buildVisibleFrameSnapshot();
+  const titleRow = snapshot.lines.findIndex((line) => String(line).includes("Reputation Summary"));
+  const reputationRow = snapshot.lines.findIndex(
+    (line) =>
+      String(line).includes("agent-authority-1") &&
+      String(line).includes("effective 98") &&
+      String(line).includes("14 tasks"),
+  );
+  const detailRow = snapshot.lines.findIndex((line) =>
+    String(line).includes("agent pda: agent-pda-1"),
+  );
+
+  assert.notEqual(titleRow, -1);
+  assert.notEqual(reputationRow, -1);
+  assert.notEqual(detailRow, -1);
+  assert.ok(titleRow + 1 > snapshot.composer.absoluteRow);
+  assert.ok(reputationRow + 1 > snapshot.composer.absoluteRow);
+  assert.ok(detailRow + 1 > snapshot.composer.absoluteRow);
+  assert.equal(harness.layoutCalls.at(-1)?.slashMode, true);
+});
+
 test("frame controller exports transcript view through the extracted seam", () => {
   const harness = createWatchFrameHarness({
     events: [
@@ -167,6 +471,31 @@ test("frame controller exports the rendered detail view instead of raw event bod
   assert.equal(
     harness.fileWrites[0].text,
     "[12:00:00] Patch Preview\n\ndiff --git a/file.ts b/file.ts\n+const value = 1;\n",
+  );
+});
+
+test("frame controller exports detailBody when an expanded event provides richer detail text", () => {
+  const harness = createWatchFrameHarness({
+    events: [
+      {
+        id: "evt-1",
+        kind: "market",
+        title: "Marketplace Tasks",
+        body: "1. Task 1",
+        detailBody: "1. Task 1\n2. Task 2\n3. Task 3",
+        timestamp: "12:00:00",
+      },
+    ],
+  });
+  harness.watchState.expandedEventId = "evt-1";
+
+  const exportPath = harness.controller.exportCurrentView({ announce: true });
+
+  assert.ok(exportPath);
+  assert.equal(harness.fileWrites.length, 1);
+  assert.equal(
+    harness.fileWrites[0].text,
+    "[12:00:00] Marketplace Tasks\n\n1. Task 1\n2. Task 2\n3. Task 3\n",
   );
 });
 
@@ -449,7 +778,7 @@ test("frame controller keeps footer minimal while surfacing run context in the f
   assert.match(frameText, /LATEST:system\.bash/);
   assert.match(frameText, /PLAN:2/);
   assert.match(frameText, /session 12345678/);
-  assert.match(frameText, /~\/(?:agenc-core(?:\/runtime)?)?\n>/);
+  assert.match(frameText, /(?:~\/[^\n]*|\/[^\n]+)\n>/);
   assert.equal(/\nlive\s+idle\n>/.test(frameText), false);
 });
 

--- a/runtime/tests/watch/agenc-watch-input.test.mjs
+++ b/runtime/tests/watch/agenc-watch-input.test.mjs
@@ -79,6 +79,19 @@ function createInputHarness(overrides = {}) {
     navigateComposer(direction) {
       calls.push({ type: "navigate", direction });
     },
+    hasActiveMarketTaskBrowser: overrides.hasActiveMarketTaskBrowser ?? (() => false),
+    navigateMarketTaskBrowser(direction) {
+      calls.push({ type: "navigateMarketTaskBrowser", direction });
+      return true;
+    },
+    toggleMarketTaskBrowserExpansion() {
+      calls.push({ type: "toggleMarketTaskBrowserExpansion" });
+      return true;
+    },
+    dismissMarketTaskBrowser() {
+      calls.push({ type: "dismissMarketTaskBrowser" });
+      return true;
+    },
     hasActiveComposerPalette: overrides.hasActiveComposerPalette ?? (() => false),
     navigateComposerPalette(direction) {
       calls.push({ type: "navigatePalette", direction });
@@ -254,6 +267,52 @@ test("input controller routes arrow keys to palette navigation while the compose
     ],
   );
   assert.equal(calls.some((entry) => entry.type === "navigate"), false);
+});
+
+test("input controller routes arrow keys to the market browser before palette navigation", () => {
+  const { controller, calls } = createInputHarness({
+    hasActiveMarketTaskBrowser: () => true,
+    hasActiveComposerPalette: () => true,
+  });
+
+  controller.handleTerminalInput("\x1b[A\x1b[B");
+
+  assert.deepEqual(
+    calls.filter((entry) => entry.type === "navigateMarketTaskBrowser"),
+    [
+      { type: "navigateMarketTaskBrowser", direction: -1 },
+      { type: "navigateMarketTaskBrowser", direction: 1 },
+    ],
+  );
+  assert.equal(calls.some((entry) => entry.type === "navigatePalette"), false);
+  assert.equal(calls.some((entry) => entry.type === "navigate"), false);
+});
+
+test("input controller toggles market task details instead of submitting when the browser is active", () => {
+  const { controller, watchState, calls } = createInputHarness({
+    hasActiveMarketTaskBrowser: () => true,
+  });
+  watchState.composerInput = "leave me alone";
+  watchState.composerCursor = watchState.composerInput.length;
+
+  controller.handleTerminalInput("\r");
+
+  assert.equal(watchState.composerInput, "leave me alone");
+  assert.ok(calls.some((entry) => entry.type === "toggleMarketTaskBrowserExpansion"));
+  assert.equal(calls.some((entry) => entry.type === "submit"), false);
+});
+
+test("input controller dismisses the market task browser before closing detail or cancelling chat", () => {
+  const { controller, watchState, calls } = createInputHarness({
+    hasActiveMarketTaskBrowser: () => true,
+  });
+  watchState.expandedEventId = "evt-1";
+
+  controller.handleTerminalEscapeSequence("\x1b", 0);
+
+  assert.ok(calls.some((entry) => entry.type === "dismissMarketTaskBrowser"));
+  assert.equal(watchState.expandedEventId, "evt-1");
+  assert.equal(calls.some((entry) => entry.type === "cancelActiveChat"), false);
 });
 
 test("input controller routes ctrl+p and ctrl+n to diff hunk navigation only in diff detail mode", () => {

--- a/runtime/tests/watch/agenc-watch-surface-dispatch.test.mjs
+++ b/runtime/tests/watch/agenc-watch-surface-dispatch.test.mjs
@@ -84,6 +84,7 @@ function createHarness(overrides = {}) {
       calls.push(["handlePlannerTraceEvent", ...args]);
       return true;
     },
+    hydrateMarketTaskBrowser: (value) => calls.push(["hydrateMarketTaskBrowser", value]),
     handleSubagentLifecycleMessage: (...args) => {
       calls.push(["handleSubagentLifecycleMessage", ...args]);
       return true;
@@ -254,6 +255,298 @@ test("dispatchOperatorSurfaceEvent filters manual session lists with the active 
       "teal",
     ],
     ["status", "session filter loaded: 1 match(es)"],
+  ]);
+});
+
+test("dispatchOperatorSurfaceEvent preserves full marketplace task lists in detail metadata", () => {
+  const { api, calls } = createHarness();
+  const tasks = Array.from({ length: 7 }, (_, index) => ({
+    status: index % 2 === 0 ? "open" : "claimed",
+    description: `Task ${index + 1}`,
+    reward: `${index + 1}`,
+  }));
+
+  dispatchOperatorSurfaceEvent(
+    {
+      family: "market",
+      type: "tasks.list",
+      payload: tasks,
+      payloadRecord: {},
+      payloadList: tasks,
+      isSessionScoped: true,
+      message: {},
+    },
+    null,
+    api,
+  );
+
+  assert.deepEqual(calls, [
+    [
+      "hydrateMarketTaskBrowser",
+      {
+        title: "Marketplace Tasks",
+        items: tasks,
+        kind: "tasks",
+      },
+    ],
+    ["status", "market tasks loaded"],
+    [
+      "pushEvent",
+      "market",
+      "Marketplace Tasks",
+      [
+        "1. [open] Task 1 (1 SOL)",
+        "2. [claimed] Task 2 (2 SOL)",
+        "3. [open] Task 3 (3 SOL)",
+        "4. [claimed] Task 4 (4 SOL)",
+        "5. [open] Task 5 (5 SOL)",
+        "... 2 more",
+      ].join("\n"),
+      "teal",
+      {
+        detailBody: [
+          "1. [open] Task 1 (1 SOL)",
+          "2. [claimed] Task 2 (2 SOL)",
+          "3. [open] Task 3 (3 SOL)",
+          "4. [claimed] Task 4 (4 SOL)",
+          "5. [open] Task 5 (5 SOL)",
+          "6. [claimed] Task 6 (6 SOL)",
+          "7. [open] Task 7 (7 SOL)",
+        ].join("\n"),
+      },
+    ],
+  ]);
+});
+
+test("dispatchOperatorSurfaceEvent preserves full marketplace skill lists in detail metadata", () => {
+  const { api, calls } = createHarness();
+  const skills = Array.from({ length: 6 }, (_, index) => ({
+    skillId: `skill-${index + 1}`,
+    skillPda: `skill-pda-${index + 1}`,
+    name: `Skill ${index + 1}`,
+    priceSol: `${index + 1}`,
+    rating: 4.5,
+    downloads: index + 10,
+  }));
+
+  dispatchOperatorSurfaceEvent(
+    {
+      family: "market",
+      type: "market.skills.list",
+      payload: skills,
+      payloadRecord: {},
+      payloadList: skills,
+      isSessionScoped: true,
+      message: {},
+    },
+    null,
+    api,
+  );
+
+  assert.deepEqual(calls, [
+    [
+      "hydrateMarketTaskBrowser",
+      {
+        title: "Marketplace Skills",
+        items: skills,
+        kind: "skills",
+      },
+    ],
+    ["status", "market skills loaded"],
+    [
+      "pushEvent",
+      "market",
+      "Marketplace Skills",
+      [
+        "1. Skill 1 · rating 4.5 · downloads 10",
+        "2. Skill 2 · rating 4.5 · downloads 11",
+        "3. Skill 3 · rating 4.5 · downloads 12",
+        "4. Skill 4 · rating 4.5 · downloads 13",
+        "5. Skill 5 · rating 4.5 · downloads 14",
+        "... 1 more",
+      ].join("\n"),
+      "teal",
+      {
+        detailBody: [
+          "1. Skill 1 · rating 4.5 · downloads 10",
+          "2. Skill 2 · rating 4.5 · downloads 11",
+          "3. Skill 3 · rating 4.5 · downloads 12",
+          "4. Skill 4 · rating 4.5 · downloads 13",
+          "5. Skill 5 · rating 4.5 · downloads 14",
+          "6. Skill 6 · rating 4.5 · downloads 15",
+        ].join("\n"),
+      },
+    ],
+  ]);
+});
+
+test("dispatchOperatorSurfaceEvent preserves governance lists in browser hydration and detail metadata", () => {
+  const { api, calls } = createHarness();
+  const proposals = [
+    {
+      proposalPda: "proposal-pda-1",
+      status: "active",
+      payloadPreview: "Upgrade validator set",
+      votesFor: "12",
+      votesAgainst: "3",
+    },
+    {
+      proposalPda: "proposal-pda-2",
+      status: "approved",
+      proposalType: "budget",
+      votesFor: "20",
+      votesAgainst: "1",
+    },
+  ];
+
+  dispatchOperatorSurfaceEvent(
+    {
+      family: "market",
+      type: "market.governance.list",
+      payload: proposals,
+      payloadRecord: {},
+      payloadList: proposals,
+      isSessionScoped: true,
+      message: {},
+    },
+    null,
+    api,
+  );
+
+  assert.deepEqual(calls, [
+    [
+      "hydrateMarketTaskBrowser",
+      {
+        title: "Governance Proposals",
+        items: proposals,
+        kind: "governance",
+      },
+    ],
+    ["status", "governance proposals loaded"],
+    [
+      "pushEvent",
+      "market",
+      "Governance Proposals",
+      [
+        "1. [active] Upgrade validator set · for 12 · against 3",
+        "2. [approved] budget · for 20 · against 1",
+      ].join("\n"),
+      "teal",
+      {},
+    ],
+  ]);
+});
+
+test("dispatchOperatorSurfaceEvent preserves dispute lists in browser hydration and detail metadata", () => {
+  const { api, calls } = createHarness();
+  const disputes = [
+    {
+      disputePda: "dispute-pda-1",
+      status: "pending",
+      resolutionType: "refund",
+      votesFor: "2",
+      votesAgainst: "1",
+    },
+    {
+      disputePda: "dispute-pda-2",
+      status: "resolved",
+      resolutionType: "slash",
+      votesFor: "5",
+      votesAgainst: "0",
+    },
+  ];
+
+  dispatchOperatorSurfaceEvent(
+    {
+      family: "market",
+      type: "market.disputes.list",
+      payload: disputes,
+      payloadRecord: {},
+      payloadList: disputes,
+      isSessionScoped: true,
+      message: {},
+    },
+    null,
+    api,
+  );
+
+  assert.deepEqual(calls, [
+    [
+      "hydrateMarketTaskBrowser",
+      {
+        title: "Marketplace Disputes",
+        items: disputes,
+        kind: "disputes",
+      },
+    ],
+    ["status", "market disputes loaded"],
+    [
+      "pushEvent",
+      "market",
+      "Marketplace Disputes",
+      [
+        "1. [pending] refund · for 2 · against 1",
+        "2. [resolved] slash · for 5 · against 0",
+      ].join("\n"),
+      "amber",
+      {},
+    ],
+  ]);
+});
+
+test("dispatchOperatorSurfaceEvent hydrates reputation summaries into the inline browser", () => {
+  const { api, calls } = createHarness();
+  const summary = {
+    authority: "agent-authority-1",
+    agentPda: "agent-pda-1",
+    registered: true,
+    effectiveReputation: 98,
+    tasksCompleted: 14,
+    totalEarnedSol: "4.2",
+    stakedAmountSol: "1.5",
+  };
+
+  dispatchOperatorSurfaceEvent(
+    {
+      family: "market",
+      type: "market.reputation.summary",
+      payload: summary,
+      payloadRecord: summary,
+      payloadList: [],
+      isSessionScoped: true,
+      message: {},
+    },
+    null,
+    api,
+  );
+
+  assert.deepEqual(calls, [
+    [
+      "hydrateMarketTaskBrowser",
+      {
+        title: "Reputation Summary",
+        items: [summary],
+        kind: "reputation",
+      },
+    ],
+    ["status", "reputation summary loaded"],
+    [
+      "pushEvent",
+      "market",
+      "Reputation Summary",
+      "1. [registered] agent-authority-1 · effective 98 · tasks 14",
+      "teal",
+      {
+        detailBody: [
+          "authority: agent-authority-1",
+          "agent: agent-pda-1",
+          "effective reputation: 98",
+          "completed tasks: 14",
+          "total earned: 4.2 SOL",
+          "staked: 1.5 SOL",
+        ].join("\n"),
+      },
+    ],
   ]);
 });
 

--- a/runtime/tests/watch/agenc-watch-transcript-cards.test.mjs
+++ b/runtime/tests/watch/agenc-watch-transcript-cards.test.mjs
@@ -43,3 +43,24 @@ test("computeTranscriptPreviewMaxLines gives the latest followed agent more room
   assert.equal(followedLatest, Infinity);
   assert.ok(followedLatest > olderAgent);
 });
+
+test("computeTranscriptPreviewMaxLines gives marketplace events enough room for multi-row previews", () => {
+  const generic = computeTranscriptPreviewMaxLines({
+    eventKind: "history",
+    latestIsCurrent: false,
+    following: true,
+    viewportLines: 28,
+    maxPreviewSourceLines: 160,
+  });
+  const market = computeTranscriptPreviewMaxLines({
+    eventKind: "market",
+    latestIsCurrent: false,
+    following: true,
+    viewportLines: 28,
+    maxPreviewSourceLines: 160,
+  });
+
+  assert.equal(generic, 2);
+  assert.equal(market, 6);
+  assert.ok(market > generic);
+});

--- a/runtime/tests/watch/fixtures/agenc-watch-frame-harness.mjs
+++ b/runtime/tests/watch/fixtures/agenc-watch-frame-harness.mjs
@@ -39,6 +39,7 @@ export function createWatchFrameHarness(overrides = {}) {
     lastUsageSummary: null,
     activeRunStartedAtMs: null,
     bootstrapAttempts: 0,
+    marketTaskBrowser: null,
     ...overrides.watchState,
   };
   const transportState = {

--- a/scripts/marketplace-tui-devnet-smoke.ts
+++ b/scripts/marketplace-tui-devnet-smoke.ts
@@ -1,0 +1,1833 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { PassThrough } from "node:stream";
+import { AnchorProvider } from "@coral-xyz/anchor";
+import bs58 from "bs58";
+import { Connection, PublicKey, type Keypair } from "@solana/web3.js";
+import {
+  AgentCapabilities,
+  createProgram,
+  createReadOnlyProgram,
+  findProtocolPda,
+  hasCapability,
+  keypairToWallet,
+  ReputationEconomyOperations,
+  AGENT_REGISTRATION_SIZE,
+  loadKeypairFromFileSync,
+  parseAgentState,
+  parseProtocolConfig,
+  silentLogger,
+  type AgencCoordination,
+  type ProtocolConfig,
+} from "../runtime/src/index.js";
+import {
+  resetMarketplaceCliProgramContextOverrides,
+  runMarketDisputeDetailCommand,
+  runMarketGovernanceDetailCommand,
+  runMarketReputationSummaryCommand,
+  runMarketSkillDetailCommand,
+  runMarketTaskDetailCommand,
+  setMarketplaceCliProgramContextOverrides,
+} from "../runtime/src/cli/marketplace-cli.js";
+import { runMarketTuiCommand } from "../runtime/src/cli/marketplace-tui.js";
+import type { BaseCliOptions, CliRuntimeContext } from "../runtime/src/cli/types.js";
+import { DisputeOperations } from "../runtime/src/dispute/operations.js";
+import { MIN_DELEGATION_AMOUNT } from "../runtime/src/reputation/types.js";
+import { createAgencTools } from "../runtime/src/tools/agenc/index.js";
+
+const DEFAULT_RPC_URL =
+  process.env.AGENC_RPC_URL ?? "https://api.devnet.solana.com";
+const DEFAULT_TASK_REWARD_LAMPORTS = 1_000_000n;
+const DEFAULT_SKILL_PRICE_LAMPORTS = 500_000n;
+const DEFAULT_REPUTATION_STAKE_LAMPORTS = 1_000_000n;
+const DEFAULT_DELEGATION_AMOUNT = 137;
+const DEFAULT_PROPOSAL_VOTING_PERIOD = 600;
+const DEFAULT_MAX_WAIT_SECONDS = 300;
+const DEFAULT_STATE_WAIT_SECONDS = 45;
+const DEFAULT_RPC_COOLDOWN_MS = 1_000;
+const DEFAULT_RPC_RETRY_ATTEMPTS = 5;
+const DEFAULT_RPC_RETRY_DELAY_MS = 1_500;
+const DEFAULT_ENDPOINT_BASE = "https://agenc.local";
+const DEFAULT_FEE_BUFFER_LAMPORTS = 10_000_000n;
+const DEFAULT_AUTHORITY_FEE_BUFFER_LAMPORTS = 1_000_000n;
+const ARTIFACT_DIR = path.join(os.tmpdir(), "agenc-marketplace-tui-smoke");
+const AGENT_DISCRIMINATOR = Buffer.from([130, 53, 100, 103, 121, 77, 148, 19]);
+const AGENT_AUTHORITY_OFFSET = 40;
+
+type MarketRunner = (
+  context: CliRuntimeContext,
+  options: Record<string, unknown>,
+) => Promise<0 | 1 | 2>;
+
+interface SignerContext {
+  label: string;
+  walletPath: string;
+  keypair: Keypair;
+  program: ReturnType<typeof createProgram>;
+}
+
+interface AgentActor extends SignerContext {
+  agentPda: PublicKey;
+  agentId: Uint8Array;
+}
+
+interface SmokeRuntime {
+  connection: Connection;
+  readOnlyProgram: ReturnType<typeof createReadOnlyProgram>;
+  signersByKey: Map<string, SignerContext>;
+}
+
+interface TuiSmokeArtifact {
+  version: 1;
+  kind: "marketplace-tui-devnet-smoke";
+  createdAt: string;
+  rpcUrl: string;
+  programId: string;
+  runId: string;
+  authorityPubkey: string;
+  taskPda: string;
+  disputePda: string;
+  workerClaimPda: string;
+  votingDeadline: number;
+  arbiterVotes: Array<{ votePda: string; arbiterAgentPda: string }>;
+}
+
+let activeSignerKey: string | null = null;
+
+function usage(): void {
+  process.stdout.write(`Usage:
+  CREATOR_WALLET=/path/to/creator.json \\
+  WORKER_WALLET=/path/to/worker.json \\
+  ARBITER_A_WALLET=/path/to/arbiter-a.json \\
+  ARBITER_B_WALLET=/path/to/arbiter-b.json \\
+  ARBITER_C_WALLET=/path/to/arbiter-c.json \\
+  PROTOCOL_AUTHORITY_WALLET=/path/to/authority.json \\
+  npm run smoke:marketplace:tui:devnet
+
+  PROTOCOL_AUTHORITY_WALLET=/path/to/authority.json \\
+  npm run smoke:marketplace:tui:devnet -- --resume /tmp/agenc-marketplace-tui-smoke/marketplace-tui-devnet-smoke-....json
+
+Environment:
+  CREATOR_WALLET                Required for the initial run.
+  WORKER_WALLET                 Required for the initial run.
+  ARBITER_A_WALLET              Required for the initial run.
+  ARBITER_B_WALLET              Required for the initial run.
+  ARBITER_C_WALLET              Required for the initial run.
+  PROTOCOL_AUTHORITY_WALLET     Required in both modes.
+  AGENC_RPC_URL                 Optional. Defaults to ${DEFAULT_RPC_URL}
+  AGENC_PROGRAM_ID              Optional. Defaults to the runtime program ID.
+  AGENC_TASK_REWARD_LAMPORTS    Optional. Defaults to ${DEFAULT_TASK_REWARD_LAMPORTS.toString()}
+  AGENC_SKILL_PRICE_LAMPORTS    Optional. Defaults to ${DEFAULT_SKILL_PRICE_LAMPORTS.toString()}
+  AGENC_REPUTATION_STAKE_LAMPORTS Optional. Defaults to ${DEFAULT_REPUTATION_STAKE_LAMPORTS.toString()}
+  AGENC_DELEGATION_AMOUNT       Optional. Defaults to ${DEFAULT_DELEGATION_AMOUNT}
+  AGENC_PROPOSAL_VOTING_PERIOD  Optional. Defaults to ${DEFAULT_PROPOSAL_VOTING_PERIOD}
+  AGENC_MAX_WAIT_SECONDS        Optional. Defaults to ${DEFAULT_MAX_WAIT_SECONDS}
+
+Flags:
+  --resume <path>               Resume a saved dispute-resolution artifact.
+  --artifact <path>             Custom output path for the resume artifact.
+  --help                        Show this message.
+`);
+}
+
+function env(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required env var: ${name}`);
+  }
+  return value;
+}
+
+function hasFlag(flag: string): boolean {
+  return process.argv.includes(flag);
+}
+
+function getFlagValue(flag: string): string | null {
+  const index = process.argv.indexOf(flag);
+  if (index === -1) {
+    return null;
+  }
+
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+
+  return value;
+}
+
+function parseOptionalProgramId(): PublicKey | undefined {
+  const value = process.env.AGENC_PROGRAM_ID;
+  if (!value) {
+    return undefined;
+  }
+  return new PublicKey(value);
+}
+
+function readBigIntEnv(name: string, fallback: bigint): bigint {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  return BigInt(raw);
+}
+
+function readNumberEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative number`);
+  }
+  return Math.trunc(parsed);
+}
+
+function formatUnix(unixSeconds: number): string {
+  return new Date(unixSeconds * 1000).toISOString();
+}
+
+function lamportsToSol(value: bigint): string {
+  return (Number(value) / 1_000_000_000).toFixed(4);
+}
+
+function maxBigInt(...values: bigint[]): bigint {
+  return values.reduce((current, value) => (value > current ? value : current));
+}
+
+function stringifyUnknown(value: unknown): string {
+  if (value instanceof Error) {
+    return value.message;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function isRpcRateLimitError(error: unknown): boolean {
+  const message = stringifyUnknown(error);
+  return (
+    message.includes("429 Too Many Requests") ||
+    message.includes('"code":429') ||
+    message.includes('"code": 429') ||
+    message.includes("Too many requests for a specific RPC call")
+  );
+}
+
+async function withRpcRateLimitRetry<T>(
+  label: string,
+  action: () => Promise<T>,
+): Promise<T> {
+  let delayMs = DEFAULT_RPC_RETRY_DELAY_MS;
+
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await action();
+    } catch (error) {
+      if (!isRpcRateLimitError(error) || attempt >= DEFAULT_RPC_RETRY_ATTEMPTS) {
+        throw error;
+      }
+      console.log(
+        `[retry] ${label} hit RPC 429, sleeping ${delayMs}ms before retry ${attempt + 1}/${DEFAULT_RPC_RETRY_ATTEMPTS}`,
+      );
+      await sleep(delayMs);
+      delayMs *= 2;
+    }
+  }
+}
+
+function asRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} is not an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function getStringField(
+  record: Record<string, unknown>,
+  field: string,
+  label: string,
+): string {
+  const value = record[field];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label}.${field} is missing or invalid`);
+  }
+  return value;
+}
+
+function getNumberField(
+  record: Record<string, unknown>,
+  field: string,
+  label: string,
+): number {
+  const value = record[field];
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${label}.${field} is missing or invalid`);
+  }
+  return value;
+}
+
+function getBooleanField(
+  record: Record<string, unknown>,
+  field: string,
+  label: string,
+): boolean {
+  const value = record[field];
+  if (typeof value !== "boolean") {
+    throw new Error(`${label}.${field} is missing or invalid`);
+  }
+  return value;
+}
+
+function getArrayField(
+  record: Record<string, unknown>,
+  field: string,
+  label: string,
+): unknown[] {
+  const value = record[field];
+  if (!Array.isArray(value)) {
+    throw new Error(`${label}.${field} is missing or invalid`);
+  }
+  return value;
+}
+
+function buildBaseOptions(rpcUrl: string, programId?: string): BaseCliOptions {
+  return {
+    help: false,
+    outputFormat: "json",
+    strictMode: true,
+    rpcUrl,
+    programId,
+    storeType: "memory",
+    idempotencyWindow: 900,
+  };
+}
+
+function createSignerContext(
+  label: string,
+  walletPath: string,
+  connection: Connection,
+  programId?: PublicKey,
+): SignerContext {
+  const keypair = loadKeypairFromFileSync(walletPath);
+  const provider = new AnchorProvider(connection, keypairToWallet(keypair), {
+    commitment: "confirmed",
+  });
+
+  return {
+    label,
+    walletPath,
+    keypair,
+    program: programId ? createProgram(provider, programId) : createProgram(provider),
+  };
+}
+
+function ensureDistinctWallets(signers: SignerContext[]): void {
+  const seen = new Map<string, string>();
+
+  for (const signer of signers) {
+    const pubkey = signer.keypair.publicKey.toBase58();
+    const existing = seen.get(pubkey);
+    if (existing) {
+      throw new Error(
+        `${signer.label} and ${existing} must use different wallets (${pubkey})`,
+      );
+    }
+    seen.set(pubkey, signer.label);
+  }
+}
+
+async function getRentExemptLamports(
+  connection: Connection,
+  size: number,
+): Promise<bigint> {
+  return BigInt(await connection.getMinimumBalanceForRentExemption(size));
+}
+
+async function ensureBalance(
+  connection: Connection,
+  label: string,
+  pubkey: PublicKey,
+  minimumLamports: bigint,
+): Promise<void> {
+  const balance = BigInt(await connection.getBalance(pubkey, "confirmed"));
+  if (balance < minimumLamports) {
+    throw new Error(
+      `${label} ${pubkey.toBase58()} has ${balance.toString()} lamports (${lamportsToSol(balance)} SOL), needs at least ${minimumLamports.toString()} lamports (${lamportsToSol(minimumLamports)} SOL)`,
+    );
+  }
+}
+
+async function countAgentRegistrations(
+  connection: Connection,
+  programId: PublicKey,
+  authority: PublicKey,
+): Promise<number> {
+  const matches = await connection.getProgramAccounts(programId, {
+    filters: [
+      { memcmp: { offset: 0, bytes: bs58.encode(AGENT_DISCRIMINATOR) } },
+      { memcmp: { offset: AGENT_AUTHORITY_OFFSET, bytes: authority.toBase58() } },
+    ],
+  });
+  return matches.length;
+}
+
+async function loadProtocolConfig(
+  program: ReturnType<typeof createReadOnlyProgram> | ReturnType<typeof createProgram>,
+): Promise<ProtocolConfig> {
+  const raw = await (program.account as any).protocolConfig.fetch(
+    findProtocolPda(program.programId),
+  );
+  return parseProtocolConfig(raw);
+}
+
+async function registerOrLoadAgent(
+  signer: SignerContext,
+  connection: Connection,
+  programId: PublicKey | undefined,
+  requiredCapabilities: bigint,
+  stakeAmount: bigint,
+  minimumExpectedStake: bigint,
+): Promise<AgentActor> {
+  const registerTool = createAgencTools({
+    connection,
+    wallet: keypairToWallet(signer.keypair),
+    programId,
+    logger: silentLogger,
+  }).find((tool) => tool.name === "agenc.registerAgent");
+
+  if (!registerTool) {
+    throw new Error("agenc.registerAgent tool is not available");
+  }
+
+  const endpoint = `${DEFAULT_ENDPOINT_BASE}/${signer.label}`;
+  const result = await registerTool.execute({
+    capabilities: requiredCapabilities.toString(),
+    endpoint,
+    stakeAmount: stakeAmount.toString(),
+  });
+
+  if (result.isError) {
+    throw new Error(
+      `${signer.label} registration failed: ${stringifyUnknown(result.content)}`,
+    );
+  }
+
+  const payload = asRecord(
+    JSON.parse(result.content) as unknown,
+    `${signer.label}.registerAgent`,
+  );
+  const agentPda = new PublicKey(
+    getStringField(payload, "agentPda", `${signer.label}.registerAgent`),
+  );
+  const rawAgent = await (signer.program.account as any).agentRegistration.fetch(
+    agentPda,
+  );
+  const agent = parseAgentState(rawAgent);
+
+  if (!agent.authority.equals(signer.keypair.publicKey)) {
+    throw new Error(
+      `${signer.label} agent authority mismatch for ${agentPda.toBase58()}`,
+    );
+  }
+  if (!hasCapability(agent.capabilities, requiredCapabilities)) {
+    throw new Error(
+      `${signer.label} agent ${agentPda.toBase58()} does not have required capabilities ${requiredCapabilities.toString()}`,
+    );
+  }
+  if (agent.stake < minimumExpectedStake) {
+    throw new Error(
+      `${signer.label} agent ${agentPda.toBase58()} has insufficient stake ${agent.stake.toString()} < ${minimumExpectedStake.toString()}`,
+    );
+  }
+
+  return {
+    ...signer,
+    agentPda,
+    agentId: agent.agentId,
+  };
+}
+
+function installMarketplaceCliOverrides(runtime: SmokeRuntime): void {
+  setMarketplaceCliProgramContextOverrides({
+    async createReadOnlyProgramContext() {
+      return {
+        connection: runtime.connection,
+        program: runtime.readOnlyProgram,
+      };
+    },
+    async createSignerProgramContext() {
+      if (!activeSignerKey) {
+        throw new Error("Missing active signer key for marketplace command");
+      }
+
+      const signer = runtime.signersByKey.get(activeSignerKey);
+      if (!signer) {
+        throw new Error(`Unknown signer context: ${activeSignerKey}`);
+      }
+
+      return {
+        connection: runtime.connection,
+        program: signer.program,
+      };
+    },
+  });
+}
+
+async function runMarketCommand(
+  baseOptions: BaseCliOptions,
+  runner: MarketRunner,
+  options: Record<string, unknown>,
+  signerKey?: string,
+): Promise<Record<string, unknown>> {
+  return withRpcRateLimitRetry("marketplace command", async () => {
+    let output: unknown;
+    let errorOutput: unknown;
+
+    activeSignerKey = signerKey ?? null;
+    try {
+      const code = await runner(
+        {
+          logger: silentLogger,
+          outputFormat: "json",
+          output(value) {
+            output = value;
+          },
+          error(value) {
+            errorOutput = value;
+          },
+        },
+        {
+          ...baseOptions,
+          ...options,
+        },
+      );
+
+      if (code !== 0) {
+        throw new Error(
+          errorOutput
+            ? stringifyUnknown(errorOutput)
+            : `Marketplace command failed with exit code ${code}`,
+        );
+      }
+      if (errorOutput) {
+        throw new Error(stringifyUnknown(errorOutput));
+      }
+      if (output === undefined) {
+        throw new Error("Marketplace command produced no output");
+      }
+
+      return asRecord(output, "marketplaceCommand");
+    } finally {
+      activeSignerKey = null;
+    }
+  });
+}
+
+async function executeToolJson(
+  signer: SignerContext,
+  connection: Connection,
+  programId: PublicKey | undefined,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  return withRpcRateLimitRetry(toolName, async () => {
+    const tool = createAgencTools({
+      connection,
+      wallet: keypairToWallet(signer.keypair),
+      programId,
+      logger: silentLogger,
+    }).find((entry) => entry.name === toolName);
+
+    if (!tool) {
+      throw new Error(`${toolName} is not available`);
+    }
+
+    const result = await tool.execute(args);
+    if (result.isError) {
+      throw new Error(`${toolName} failed: ${stringifyUnknown(result.content)}`);
+    }
+
+    return asRecord(JSON.parse(result.content) as unknown, `${toolName}.result`);
+  });
+}
+
+async function castVotes(
+  disputePda: string,
+  taskPda: string,
+  workerClaimPda: string,
+  arbiters: AgentActor[],
+): Promise<Array<{ votePda: string; arbiterAgentPda: string }>> {
+  const disputeKey = new PublicKey(disputePda);
+  const taskKey = new PublicKey(taskPda);
+  const claimKey = new PublicKey(workerClaimPda);
+  const votes: Array<{ votePda: string; arbiterAgentPda: string }> = [];
+
+  for (const arbiter of arbiters) {
+    const ops = new DisputeOperations({
+      program: arbiter.program,
+      agentId: arbiter.agentId,
+      logger: silentLogger,
+    });
+    const vote = await ops.voteOnDispute({
+      disputePda: disputeKey,
+      taskPda: taskKey,
+      approve: true,
+      workerClaimPda: claimKey,
+    });
+
+    votes.push({
+      votePda: vote.votePda.toBase58(),
+      arbiterAgentPda: arbiter.agentPda.toBase58(),
+    });
+    console.log(
+      `[vote] ${arbiter.label} approved dispute ${disputePda} -> ${vote.votePda.toBase58()}`,
+    );
+  }
+
+  return votes;
+}
+
+async function waitForDeadline(
+  votingDeadline: number,
+  maxWaitSeconds: number,
+): Promise<boolean> {
+  const now = Math.floor(Date.now() / 1000);
+  const waitSeconds = Math.max(0, votingDeadline - now + 1);
+
+  if (waitSeconds > maxWaitSeconds) {
+    return false;
+  }
+
+  if (waitSeconds > 0) {
+    console.log(`[wait] sleeping ${waitSeconds}s until ${formatUnix(votingDeadline)}`);
+    await new Promise((resolve) => {
+      setTimeout(resolve, waitSeconds * 1000);
+    });
+  }
+
+  return true;
+}
+
+async function writeArtifact(
+  artifact: TuiSmokeArtifact,
+  explicitPath?: string | null,
+): Promise<string> {
+  const filePath =
+    explicitPath ??
+    path.join(
+      ARTIFACT_DIR,
+      `marketplace-tui-devnet-smoke-${Date.now()}.json`,
+    );
+
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
+  return filePath;
+}
+
+async function readArtifact(filePath: string): Promise<TuiSmokeArtifact> {
+  const parsed = JSON.parse(await readFile(filePath, "utf8")) as unknown;
+  const artifact = asRecord(parsed, "artifact");
+
+  if (artifact.kind !== "marketplace-tui-devnet-smoke") {
+    throw new Error(`Unsupported artifact kind: ${String(artifact.kind)}`);
+  }
+  if (artifact.version !== 1) {
+    throw new Error(`Unsupported artifact version: ${String(artifact.version)}`);
+  }
+  if (!Array.isArray(artifact.arbiterVotes) || artifact.arbiterVotes.length === 0) {
+    throw new Error("Artifact is missing arbiterVotes");
+  }
+
+  return artifact as unknown as TuiSmokeArtifact;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function waitFor<T>(
+  label: string,
+  timeoutSeconds: number,
+  loader: () => Promise<T>,
+): Promise<T> {
+  const deadline = Date.now() + timeoutSeconds * 1000;
+  let lastError: unknown = null;
+
+  while (Date.now() <= deadline) {
+    try {
+      return await loader();
+    } catch (error) {
+      lastError = error;
+      await sleep(1500);
+    }
+  }
+
+  throw new Error(
+    `${label} timed out: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+  );
+}
+
+function createTtyInput(): PassThrough & { isTTY: boolean } {
+  const stream = new PassThrough() as PassThrough & { isTTY: boolean };
+  stream.isTTY = true;
+  return stream;
+}
+
+function createTtyOutput(): {
+  stream: PassThrough & { isTTY: boolean; columns: number };
+  getText: () => string;
+} {
+  const chunks: string[] = [];
+  const stream = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    columns: number;
+  };
+  stream.isTTY = true;
+  stream.columns = 100;
+  stream.on("data", (chunk) => {
+    chunks.push(String(chunk));
+  });
+  return {
+    stream,
+    getText: () => chunks.join(""),
+  };
+}
+
+async function runTuiSession(
+  baseOptions: BaseCliOptions,
+  signerKey: string,
+  lines: string[],
+): Promise<string> {
+  await sleep(DEFAULT_RPC_COOLDOWN_MS);
+
+  const input = createTtyInput();
+  const stdout = createTtyOutput();
+  let errorOutput: unknown;
+  let lineIndex = 0;
+  let feedScheduled = false;
+  const maybeFeedNextLine = () => {
+    if (feedScheduled || lineIndex >= lines.length) {
+      return;
+    }
+
+    const text = stdout.getText();
+    const tail = text.slice(-256);
+    const promptMatch = tail.match(/(?:^|\n)([^\n]*(?:> |: ))$/);
+    const prompt = promptMatch?.[1] ?? "";
+    if (!prompt) {
+      return;
+    }
+
+    feedScheduled = true;
+    setTimeout(() => {
+      feedScheduled = false;
+      input.write(`${lines[lineIndex++] ?? ""}\n`);
+    }, 10);
+  };
+
+  stdout.stream.on("data", () => {
+    maybeFeedNextLine();
+  });
+
+  activeSignerKey = signerKey;
+  try {
+    const code = await runMarketTuiCommand(
+      {
+        logger: silentLogger,
+        outputFormat: "table",
+        output() {
+          // TUI writes directly to stdout.
+        },
+        error(value) {
+          errorOutput = value;
+        },
+      },
+      {
+        ...baseOptions,
+        outputFormat: "table",
+      },
+      {
+        stdin: input,
+        stdout: stdout.stream,
+      },
+    );
+
+    const text = stdout.getText();
+    if (code !== 0) {
+      throw new Error(
+        errorOutput
+          ? stringifyUnknown(errorOutput)
+          : `TUI exited with code ${code}`,
+      );
+    }
+    if (errorOutput) {
+      throw new Error(stringifyUnknown(errorOutput));
+    }
+    return text;
+  } catch (error) {
+    const partialOutput = stdout.getText();
+    throw new Error(
+      `${error instanceof Error ? error.message : String(error)}
+[partial tui output]
+${partialOutput}`,
+    );
+  } finally {
+    activeSignerKey = null;
+    input.destroy();
+    stdout.stream.destroy();
+  }
+}
+
+function assertTuiSuccess(text: string, title: string): void {
+  if (text.includes(`${title} failed`)) {
+    throw new Error(`TUI ${title} failed:\n${text}`);
+  }
+  if (!text.includes(title)) {
+    throw new Error(`TUI output did not include ${title}:\n${text}`);
+  }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function extractJsonString(text: string, key: string): string {
+  const pattern = new RegExp(`"${escapeRegExp(key)}"\\s*:\\s*"([^"]+)"`, "g");
+  const matches = [...text.matchAll(pattern)];
+  const match = matches[matches.length - 1];
+  if (!match) {
+    throw new Error(`Could not find ${key} in TUI output:\n${text}`);
+  }
+  return match[1];
+}
+
+function formatVotePairs(
+  votes: Array<{ votePda: string; arbiterAgentPda: string }>,
+): string {
+  return votes
+    .map((entry) => `${entry.votePda}:${entry.arbiterAgentPda}`)
+    .join(",");
+}
+
+async function fetchTaskDetail(
+  baseOptions: BaseCliOptions,
+  taskPda: string,
+): Promise<Record<string, unknown>> {
+  const output = await runMarketCommand(
+    baseOptions,
+    runMarketTaskDetailCommand as MarketRunner,
+    { taskPda },
+  );
+  return asRecord(output.task, "taskDetail.task");
+}
+
+async function fetchSkillDetail(
+  baseOptions: BaseCliOptions,
+  skillPda: string,
+  signerKey?: string,
+): Promise<Record<string, unknown>> {
+  const output = await runMarketCommand(
+    baseOptions,
+    runMarketSkillDetailCommand as MarketRunner,
+    { skillPda },
+    signerKey,
+  );
+  return asRecord(output.skill, "skillDetail.skill");
+}
+
+async function fetchProposalDetail(
+  baseOptions: BaseCliOptions,
+  proposalPda: string,
+): Promise<Record<string, unknown>> {
+  const output = await runMarketCommand(
+    baseOptions,
+    runMarketGovernanceDetailCommand as MarketRunner,
+    { proposalPda },
+  );
+  return asRecord(output.proposal, "proposalDetail.proposal");
+}
+
+async function fetchDisputeDetail(
+  baseOptions: BaseCliOptions,
+  disputePda: string,
+): Promise<Record<string, unknown>> {
+  const output = await runMarketCommand(
+    baseOptions,
+    runMarketDisputeDetailCommand as MarketRunner,
+    { disputePda },
+  );
+  return asRecord(output.dispute, "disputeDetail.dispute");
+}
+
+async function fetchReputationSummary(
+  baseOptions: BaseCliOptions,
+  signerKey: string,
+  agentPda?: string,
+): Promise<Record<string, unknown>> {
+  const output = await runMarketCommand(
+    baseOptions,
+    runMarketReputationSummaryCommand as MarketRunner,
+    { agentPda },
+    signerKey,
+  );
+  return asRecord(output.summary, "reputationSummary.summary");
+}
+
+function isDelegationActive(expiresAt: number, nowUnixSeconds: number): boolean {
+  return expiresAt === 0 || expiresAt > nowUnixSeconds;
+}
+
+function formatDelegationOccupancy(
+  candidate: AgentActor,
+  amount: number,
+  expiresAt: number,
+  nowUnixSeconds: number,
+): string {
+  const expiry =
+    expiresAt === 0
+      ? "no-expiry"
+      : isDelegationActive(expiresAt, nowUnixSeconds)
+        ? `expires:${formatUnix(expiresAt)}`
+        : `expired:${formatUnix(expiresAt)}`;
+  return `${candidate.label}:${candidate.agentPda.toBase58()}=amount:${amount},${expiry}`;
+}
+
+async function selectDelegationTarget(
+  reputationOps: ReputationEconomyOperations,
+  delegator: AgentActor,
+  candidates: AgentActor[],
+  amount: number,
+): Promise<{ target: AgentActor; reusedExisting: boolean }> {
+  const occupied: string[] = [];
+  let reusable: AgentActor | null = null;
+  const nowUnixSeconds = Math.floor(Date.now() / 1000);
+
+  for (const candidate of candidates) {
+    const existing = await reputationOps.getDelegation(
+      delegator.agentPda,
+      candidate.agentPda,
+    );
+    if (!existing) {
+      return { target: candidate, reusedExisting: false };
+    }
+
+    occupied.push(
+      formatDelegationOccupancy(
+        candidate,
+        existing.amount,
+        existing.expiresAt,
+        nowUnixSeconds,
+      ),
+    );
+    if (
+      reusable === null &&
+      existing.amount === amount &&
+      isDelegationActive(existing.expiresAt, nowUnixSeconds)
+    ) {
+      reusable = candidate;
+    }
+  }
+
+  if (reusable) {
+    return { target: reusable, reusedExisting: true };
+  }
+
+  throw new Error(
+    `No delegation target available for amount ${amount}. Existing delegation accounts: ${occupied.join(", ")}`,
+  );
+}
+
+async function resolveDisputeViaTui(
+  baseOptions: BaseCliOptions,
+  disputePda: string,
+  votes: Array<{ votePda: string; arbiterAgentPda: string }>,
+): Promise<void> {
+  const text = await runTuiSession(baseOptions, "authority", [
+    "4",
+    `resolve ${disputePda}`,
+    formatVotePairs(votes),
+    "",
+    "",
+    "back",
+    "q",
+  ]);
+  assertTuiSuccess(text, "dispute resolve");
+}
+
+const taskCreationMsBySigner = new Map<string, number>();
+
+async function waitForTaskCreationCooldown(
+  signerKey: string,
+  cooldownSeconds: number,
+): Promise<void> {
+  if (cooldownSeconds <= 0) {
+    return;
+  }
+
+  const lastCreatedAt = taskCreationMsBySigner.get(signerKey);
+  if (lastCreatedAt === undefined) {
+    return;
+  }
+
+  const remainingMs = lastCreatedAt + cooldownSeconds * 1000 - Date.now();
+  if (remainingMs <= 0) {
+    return;
+  }
+
+  const waitSeconds = Math.ceil(remainingMs / 1000);
+  console.log(
+    `[wait] sleeping ${waitSeconds}s for task creation cooldown on ${signerKey}`,
+  );
+  await sleep(remainingMs + 1000);
+}
+
+async function createTaskViaTui(
+  baseOptions: BaseCliOptions,
+  signerKey: string,
+  description: string,
+  rewardLamports: bigint,
+  requiredCapabilities: number,
+  taskCreationCooldownSeconds: number,
+): Promise<{ text: string; taskPda: string }> {
+  await waitForTaskCreationCooldown(signerKey, taskCreationCooldownSeconds);
+
+  const text = await runTuiSession(baseOptions, signerKey, [
+    "1",
+    "create",
+    description,
+    rewardLamports.toString(),
+    requiredCapabilities.toString(),
+    "",
+    "",
+    "",
+    "",
+    "back",
+    "q",
+  ]);
+  assertTuiSuccess(text, "task creation");
+  const taskPda = extractJsonString(text, "taskPda");
+  taskCreationMsBySigner.set(signerKey, Date.now());
+  return { text, taskPda };
+}
+
+async function runInitial(): Promise<void> {
+  const rpcUrl = process.env.AGENC_RPC_URL ?? DEFAULT_RPC_URL;
+  const programId = parseOptionalProgramId();
+  const taskRewardLamports = readBigIntEnv(
+    "AGENC_TASK_REWARD_LAMPORTS",
+    DEFAULT_TASK_REWARD_LAMPORTS,
+  );
+  const skillPriceLamports = readBigIntEnv(
+    "AGENC_SKILL_PRICE_LAMPORTS",
+    DEFAULT_SKILL_PRICE_LAMPORTS,
+  );
+  const reputationStakeLamports = readBigIntEnv(
+    "AGENC_REPUTATION_STAKE_LAMPORTS",
+    DEFAULT_REPUTATION_STAKE_LAMPORTS,
+  );
+  const delegationAmount = readNumberEnv(
+    "AGENC_DELEGATION_AMOUNT",
+    DEFAULT_DELEGATION_AMOUNT,
+  );
+  const proposalVotingPeriod = readNumberEnv(
+    "AGENC_PROPOSAL_VOTING_PERIOD",
+    DEFAULT_PROPOSAL_VOTING_PERIOD,
+  );
+  const maxWaitSeconds = readNumberEnv(
+    "AGENC_MAX_WAIT_SECONDS",
+    DEFAULT_MAX_WAIT_SECONDS,
+  );
+  const artifactPath = getFlagValue("--artifact");
+
+  if (delegationAmount < MIN_DELEGATION_AMOUNT) {
+    throw new Error(
+      `AGENC_DELEGATION_AMOUNT must be at least ${MIN_DELEGATION_AMOUNT}`,
+    );
+  }
+
+  const connection = new Connection(rpcUrl, "confirmed");
+  const creatorSigner = createSignerContext(
+    "creator",
+    env("CREATOR_WALLET"),
+    connection,
+    programId,
+  );
+  const workerSigner = createSignerContext(
+    "worker",
+    env("WORKER_WALLET"),
+    connection,
+    programId,
+  );
+  const arbiterASigner = createSignerContext(
+    "arbiter-a",
+    env("ARBITER_A_WALLET"),
+    connection,
+    programId,
+  );
+  const arbiterBSigner = createSignerContext(
+    "arbiter-b",
+    env("ARBITER_B_WALLET"),
+    connection,
+    programId,
+  );
+  const arbiterCSigner = createSignerContext(
+    "arbiter-c",
+    env("ARBITER_C_WALLET"),
+    connection,
+    programId,
+  );
+  const authoritySigner = createSignerContext(
+    "authority",
+    env("PROTOCOL_AUTHORITY_WALLET"),
+    connection,
+    programId,
+  );
+  const readOnlyProgram = programId
+    ? createReadOnlyProgram(connection, programId)
+    : createReadOnlyProgram(connection);
+
+  ensureDistinctWallets([
+    creatorSigner,
+    workerSigner,
+    arbiterASigner,
+    arbiterBSigner,
+    arbiterCSigner,
+    authoritySigner,
+  ]);
+
+  const protocolConfig = await loadProtocolConfig(readOnlyProgram);
+  if (!authoritySigner.keypair.publicKey.equals(protocolConfig.authority)) {
+    throw new Error(
+      `PROTOCOL_AUTHORITY_WALLET ${authoritySigner.keypair.publicKey.toBase58()} does not match protocol authority ${protocolConfig.authority.toBase58()}`,
+    );
+  }
+
+  const creatorStake = maxBigInt(
+    protocolConfig.minAgentStake,
+    protocolConfig.minStakeForDispute * 2n,
+  );
+  const workerStake = protocolConfig.minAgentStake;
+  const arbiterStake = maxBigInt(
+    protocolConfig.minAgentStake,
+    protocolConfig.minArbiterStake,
+  );
+  const agentRegistrationRentLamports = await getRentExemptLamports(
+    connection,
+    AGENT_REGISTRATION_SIZE,
+  );
+
+  const [
+    creatorAgentCount,
+    workerAgentCount,
+    arbiterAgentCountA,
+    arbiterAgentCountB,
+    arbiterAgentCountC,
+  ] = await Promise.all([
+    countAgentRegistrations(
+      connection,
+      readOnlyProgram.programId,
+      creatorSigner.keypair.publicKey,
+    ),
+    countAgentRegistrations(
+      connection,
+      readOnlyProgram.programId,
+      workerSigner.keypair.publicKey,
+    ),
+    countAgentRegistrations(
+      connection,
+      readOnlyProgram.programId,
+      arbiterASigner.keypair.publicKey,
+    ),
+    countAgentRegistrations(
+      connection,
+      readOnlyProgram.programId,
+      arbiterBSigner.keypair.publicKey,
+    ),
+    countAgentRegistrations(
+      connection,
+      readOnlyProgram.programId,
+      arbiterCSigner.keypair.publicKey,
+    ),
+  ]);
+
+  await Promise.all([
+    ensureBalance(
+      connection,
+      "creator",
+      creatorSigner.keypair.publicKey,
+      (creatorAgentCount > 0
+        ? 0n
+        : creatorStake + agentRegistrationRentLamports) +
+        reputationStakeLamports +
+        taskRewardLamports * 3n +
+        DEFAULT_FEE_BUFFER_LAMPORTS,
+    ),
+    ensureBalance(
+      connection,
+      "worker",
+      workerSigner.keypair.publicKey,
+      (workerAgentCount > 0
+        ? 0n
+        : workerStake + agentRegistrationRentLamports) +
+        skillPriceLamports +
+        DEFAULT_FEE_BUFFER_LAMPORTS,
+    ),
+    ensureBalance(
+      connection,
+      "arbiter-a",
+      arbiterASigner.keypair.publicKey,
+      (arbiterAgentCountA > 0
+        ? 0n
+        : arbiterStake + agentRegistrationRentLamports) +
+        DEFAULT_FEE_BUFFER_LAMPORTS,
+    ),
+    ensureBalance(
+      connection,
+      "arbiter-b",
+      arbiterBSigner.keypair.publicKey,
+      (arbiterAgentCountB > 0
+        ? 0n
+        : arbiterStake + agentRegistrationRentLamports) +
+        DEFAULT_FEE_BUFFER_LAMPORTS,
+    ),
+    ensureBalance(
+      connection,
+      "arbiter-c",
+      arbiterCSigner.keypair.publicKey,
+      (arbiterAgentCountC > 0
+        ? 0n
+        : arbiterStake + agentRegistrationRentLamports) +
+        DEFAULT_FEE_BUFFER_LAMPORTS,
+    ),
+    ensureBalance(
+      connection,
+      "authority",
+      authoritySigner.keypair.publicKey,
+      DEFAULT_AUTHORITY_FEE_BUFFER_LAMPORTS,
+    ),
+  ]);
+
+  console.log(`[config] rpc: ${rpcUrl}`);
+  console.log(`[config] program: ${readOnlyProgram.programId.toBase58()}`);
+  console.log(`[config] task reward lamports: ${taskRewardLamports.toString()}`);
+  console.log(`[config] skill price lamports: ${skillPriceLamports.toString()}`);
+  console.log(`[config] reputation stake lamports: ${reputationStakeLamports.toString()}`);
+  console.log(`[config] delegation amount: ${delegationAmount}`);
+  console.log(`[config] proposal voting period: ${proposalVotingPeriod}`);
+  console.log(`[config] max wait seconds: ${maxWaitSeconds}`);
+  console.log(`[config] agent registration rent lamports: ${agentRegistrationRentLamports.toString()}`);
+  console.log(`[config] creator wallet: ${creatorSigner.keypair.publicKey.toBase58()}`);
+  console.log(`[config] worker wallet: ${workerSigner.keypair.publicKey.toBase58()}`);
+  console.log(`[config] authority wallet: ${authoritySigner.keypair.publicKey.toBase58()}`);
+
+  const creator = await registerOrLoadAgent(
+    creatorSigner,
+    connection,
+    programId,
+    AgentCapabilities.COMPUTE,
+    creatorStake,
+    maxBigInt(protocolConfig.minAgentStake, protocolConfig.minStakeForDispute),
+  );
+  const worker = await registerOrLoadAgent(
+    workerSigner,
+    connection,
+    programId,
+    AgentCapabilities.COMPUTE,
+    workerStake,
+    workerStake,
+  );
+  const arbiterA = await registerOrLoadAgent(
+    arbiterASigner,
+    connection,
+    programId,
+    AgentCapabilities.ARBITER,
+    arbiterStake,
+    arbiterStake,
+  );
+  const arbiterB = await registerOrLoadAgent(
+    arbiterBSigner,
+    connection,
+    programId,
+    AgentCapabilities.ARBITER,
+    arbiterStake,
+    arbiterStake,
+  );
+  const arbiterC = await registerOrLoadAgent(
+    arbiterCSigner,
+    connection,
+    programId,
+    AgentCapabilities.ARBITER,
+    arbiterStake,
+    arbiterStake,
+  );
+
+  console.log(`[agent] creator: ${creator.agentPda.toBase58()}`);
+  console.log(`[agent] worker: ${worker.agentPda.toBase58()}`);
+  console.log(`[agent] arbiter-a: ${arbiterA.agentPda.toBase58()}`);
+  console.log(`[agent] arbiter-b: ${arbiterB.agentPda.toBase58()}`);
+  console.log(`[agent] arbiter-c: ${arbiterC.agentPda.toBase58()}`);
+
+  const runtime: SmokeRuntime = {
+    connection,
+    readOnlyProgram,
+    signersByKey: new Map<string, SignerContext>([
+      [creator.agentPda.toBase58(), creator],
+      [worker.agentPda.toBase58(), worker],
+      [arbiterA.agentPda.toBase58(), arbiterA],
+      [arbiterB.agentPda.toBase58(), arbiterB],
+      [arbiterC.agentPda.toBase58(), arbiterC],
+      ["authority", authoritySigner],
+    ]),
+  };
+  installMarketplaceCliOverrides(runtime);
+
+  const baseOptions = buildBaseOptions(
+    rpcUrl,
+    readOnlyProgram.programId.toBase58(),
+  );
+  const runId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  const creatorKey = creator.agentPda.toBase58();
+  const workerKey = worker.agentPda.toBase58();
+  const creatorReputationOps = new ReputationEconomyOperations({
+    program: readOnlyProgram,
+    agentId: creator.agentId,
+    logger: silentLogger,
+  });
+
+  try {
+    console.log("[phase] reputation");
+    const beforeStakeSummary = await fetchReputationSummary(baseOptions, creatorKey);
+    const beforeStakedAmount = BigInt(
+      getStringField(beforeStakeSummary, "stakedAmount", "beforeStakeSummary"),
+    );
+
+    console.log("[tui] reputation summary start");
+    const summaryText = await runTuiSession(baseOptions, creatorKey, [
+      "5",
+      "summary",
+      "",
+      "back",
+      "q",
+    ]);
+    assertTuiSuccess(summaryText, "reputation summary");
+    console.log("[tui] reputation summary done");
+
+    console.log("[tui] reputation stake start");
+    const stakeText = await runTuiSession(baseOptions, creatorKey, [
+      "5",
+      "stake",
+      reputationStakeLamports.toString(),
+      "",
+      "back",
+      "q",
+    ]);
+    assertTuiSuccess(stakeText, "reputation stake");
+    console.log("[tui] reputation stake done");
+
+    await waitFor(
+      "reputation stake to settle",
+      DEFAULT_STATE_WAIT_SECONDS,
+      async () => {
+        const summary = await fetchReputationSummary(baseOptions, creatorKey);
+        const stakedAmount = BigInt(
+          getStringField(summary, "stakedAmount", "afterStakeSummary"),
+        );
+        if (stakedAmount < beforeStakedAmount + reputationStakeLamports) {
+          throw new Error(
+            `stakedAmount ${stakedAmount.toString()} is below expected minimum ${(beforeStakedAmount + reputationStakeLamports).toString()}`,
+          );
+        }
+        return summary;
+      },
+    );
+
+    const delegationSelection = await selectDelegationTarget(
+      creatorReputationOps,
+      creator,
+      [worker, arbiterA, arbiterB, arbiterC],
+      delegationAmount,
+    );
+    const delegationTarget = delegationSelection.target;
+    console.log(
+      `[delegation] target: ${delegationTarget.label} ${delegationTarget.agentPda.toBase58()}${
+        delegationSelection.reusedExisting ? " (reusing existing delegation)" : ""
+      }`,
+    );
+    if (!delegationSelection.reusedExisting) {
+      console.log("[tui] reputation delegate start");
+      const delegateText = await runTuiSession(baseOptions, creatorKey, [
+        "5",
+        "delegate",
+        String(delegationAmount),
+        delegationTarget.agentPda.toBase58(),
+        "",
+        "",
+        "back",
+        "q",
+      ]);
+      assertTuiSuccess(delegateText, "reputation delegate");
+      console.log("[tui] reputation delegate done");
+    } else {
+      console.log("[tui] reputation delegate skipped; matching delegation already exists");
+    }
+
+    await waitFor(
+      "reputation delegation to settle",
+      DEFAULT_STATE_WAIT_SECONDS,
+      async () => {
+        const delegation = await creatorReputationOps.getDelegation(
+          creator.agentPda,
+          delegationTarget.agentPda,
+        );
+        if (!delegation) {
+          throw new Error(
+            `delegation account missing for ${delegationTarget.agentPda.toBase58()}`,
+          );
+        }
+        if (delegation.amount !== delegationAmount) {
+          throw new Error(
+            `delegation amount ${delegation.amount} does not match ${delegationAmount}`,
+          );
+        }
+        if (delegation.expiresAt !== 0) {
+          throw new Error(
+            `delegation expiresAt ${delegation.expiresAt} does not match the expected no-expiry delegation`,
+          );
+        }
+        return delegation;
+      },
+    );
+
+    console.log("[phase] task cancel flow");
+    const { taskPda: cancelTaskPda } = await createTaskViaTui(
+      baseOptions,
+      creatorKey,
+      `tui-cancel-${runId}`,
+      taskRewardLamports,
+      AgentCapabilities.COMPUTE,
+      protocolConfig.taskCreationCooldown,
+    );
+
+    const cancelText = await runTuiSession(baseOptions, creatorKey, [
+      "1",
+      `cancel ${cancelTaskPda}`,
+      "",
+      "back",
+      "q",
+    ]);
+    assertTuiSuccess(cancelText, "task cancel");
+
+    await waitFor("cancelled task status", DEFAULT_STATE_WAIT_SECONDS, async () => {
+      const task = await fetchTaskDetail(baseOptions, cancelTaskPda);
+      const status = getStringField(task, "status", "cancelTaskDetail");
+      if (status !== "cancelled") {
+        throw new Error(`task status is ${status}`);
+      }
+      return task;
+    });
+
+    console.log("[phase] task completion flow");
+    const { taskPda: completeTaskPda } = await createTaskViaTui(
+      baseOptions,
+      creatorKey,
+      `tui-complete-${runId}`,
+      taskRewardLamports,
+      AgentCapabilities.COMPUTE,
+      protocolConfig.taskCreationCooldown,
+    );
+
+    const claimText = await runTuiSession(baseOptions, workerKey, [
+      "1",
+      `claim ${completeTaskPda}`,
+      "",
+      "back",
+      "q",
+    ]);
+    assertTuiSuccess(claimText, "task claim");
+    const completeClaimPda = extractJsonString(claimText, "claimPda");
+
+    await waitFor("claimed task worker count", DEFAULT_STATE_WAIT_SECONDS, async () => {
+      const task = await fetchTaskDetail(baseOptions, completeTaskPda);
+      const workers = getNumberField(task, "currentWorkers", "claimedTaskDetail");
+      if (workers < 1) {
+        throw new Error(`currentWorkers is ${workers}`);
+      }
+      return task;
+    });
+
+    const completionText = await runTuiSession(baseOptions, workerKey, [
+      "1",
+      `complete ${completeTaskPda}`,
+      `tui complete ${runId}`,
+      "",
+      "back",
+      "q",
+    ]);
+    assertTuiSuccess(completionText, "task completion");
+
+    await waitFor("completed task status", DEFAULT_STATE_WAIT_SECONDS, async () => {
+      const task = await fetchTaskDetail(baseOptions, completeTaskPda);
+      const status = getStringField(task, "status", "completedTaskDetail");
+      if (status !== "completed") {
+        throw new Error(`task status is ${status}`);
+      }
+      return task;
+    });
+
+    console.log("[phase] skills");
+    const skillRegistration = await executeToolJson(
+      creator,
+      connection,
+      programId,
+      "agenc.registerSkill",
+      {
+        name: `tui-skill-${runId}`.slice(0, 32),
+        contentHash: createHash("sha256")
+          .update(`skill-content-${runId}`)
+          .digest("hex"),
+        price: skillPriceLamports.toString(),
+        tags: ["tui", "devnet", runId.slice(0, 8)],
+      },
+    );
+    const skillPda = getStringField(skillRegistration, "skillPda", "registerSkill");
+    console.log(`[skill] registered ${skillPda}`);
+
+    const skillDetailText = await runTuiSession(baseOptions, workerKey, [
+      "2",
+      `detail ${skillPda}`,
+      "",
+      "back",
+      "q",
+    ]);
+    assertTuiSuccess(skillDetailText, "skill detail");
+
+    const skillPurchaseText = await runTuiSession(baseOptions, workerKey, [
+      "2",
+      `purchase ${skillPda}`,
+      "",
+      "back",
+      "q",
+    ]);
+    assertTuiSuccess(skillPurchaseText, "skill purchase");
+
+    await waitFor("skill purchase visibility", DEFAULT_STATE_WAIT_SECONDS, async () => {
+      const skill = await fetchSkillDetail(baseOptions, skillPda, workerKey);
+      if (!getBooleanField(skill, "purchased", "purchasedSkillDetail")) {
+        throw new Error("skill detail does not show purchased=true");
+      }
+      return skill;
+    });
+
+    const skillRateText = await runTuiSession(baseOptions, workerKey, [
+      "2",
+      `rate ${skillPda}`,
+      "5",
+      `solid skill ${runId}`,
+      "",
+      "back",
+      "q",
+    ]);
+    assertTuiSuccess(skillRateText, "skill rating");
+
+    await waitFor("skill rating visibility", DEFAULT_STATE_WAIT_SECONDS, async () => {
+      const skill = await fetchSkillDetail(baseOptions, skillPda, workerKey);
+      const ratingCount = getNumberField(skill, "ratingCount", "ratedSkillDetail");
+      const rating = getNumberField(skill, "rating", "ratedSkillDetail");
+      if (ratingCount < 1) {
+        throw new Error(`ratingCount is ${ratingCount}`);
+      }
+      if (rating < 5) {
+        throw new Error(`rating is ${rating}`);
+      }
+      return skill;
+    });
+
+    console.log("[phase] governance");
+    const proposalRegistration = await executeToolJson(
+      creator,
+      connection,
+      programId,
+      "agenc.createProposal",
+      {
+        proposalType: "protocol_upgrade",
+        title: `TUI governance ${runId}`,
+        description: `TUI governance proposal ${runId}`,
+        votingPeriod: proposalVotingPeriod,
+      },
+    );
+    const proposalPda = getStringField(
+      proposalRegistration,
+      "proposalPda",
+      "createProposal",
+    );
+    console.log(`[proposal] created ${proposalPda}`);
+
+    const governanceDetailText = await runTuiSession(baseOptions, creatorKey, [
+      "3",
+      `detail ${proposalPda}`,
+      "",
+      "back",
+      "q",
+    ]);
+    assertTuiSuccess(governanceDetailText, "governance proposal detail");
+
+    const governanceVoteText = await runTuiSession(baseOptions, creatorKey, [
+      "3",
+      `vote ${proposalPda}`,
+      "yes",
+      "",
+      "back",
+      "q",
+    ]);
+    assertTuiSuccess(governanceVoteText, "governance vote");
+
+    await waitFor("governance vote visibility", DEFAULT_STATE_WAIT_SECONDS, async () => {
+      const proposal = await fetchProposalDetail(baseOptions, proposalPda);
+      const votesFor = BigInt(
+        getStringField(proposal, "votesFor", "proposalAfterVote"),
+      );
+      if (votesFor < 1n) {
+        throw new Error(`votesFor is ${votesFor.toString()}`);
+      }
+      return proposal;
+    });
+
+    console.log("[phase] dispute flow");
+    const { taskPda: disputeTaskPda } = await createTaskViaTui(
+      baseOptions,
+      creatorKey,
+      `tui-dispute-${runId}`,
+      taskRewardLamports,
+      AgentCapabilities.COMPUTE,
+      protocolConfig.taskCreationCooldown,
+    );
+
+    const disputeClaimText = await runTuiSession(baseOptions, workerKey, [
+      "1",
+      `claim ${disputeTaskPda}`,
+      "",
+      "back",
+      "q",
+    ]);
+    assertTuiSuccess(disputeClaimText, "task claim");
+    const disputeClaimPda = extractJsonString(disputeClaimText, "claimPda");
+
+    const taskDisputeText = await runTuiSession(baseOptions, creatorKey, [
+      "1",
+      `dispute ${disputeTaskPda}`,
+      `creator dispute ${runId}`,
+      "refund",
+      "",
+      "back",
+      "q",
+    ]);
+    assertTuiSuccess(taskDisputeText, "task dispute");
+    const disputePda = extractJsonString(taskDisputeText, "disputePda");
+
+    const disputeDetailText = await runTuiSession(baseOptions, creatorKey, [
+      "4",
+      `detail ${disputePda}`,
+      "",
+      "back",
+      "q",
+    ]);
+    assertTuiSuccess(disputeDetailText, "dispute detail");
+
+    const arbiterVotes = await castVotes(disputePda, disputeTaskPda, disputeClaimPda, [
+      arbiterA,
+      arbiterB,
+      arbiterC,
+    ]);
+
+    const disputeBeforeResolve = await fetchDisputeDetail(baseOptions, disputePda);
+    const votingDeadline = getNumberField(
+      disputeBeforeResolve,
+      "votingDeadline",
+      "disputeBeforeResolve",
+    );
+    console.log(`[dispute] voting deadline: ${formatUnix(votingDeadline)}`);
+
+    const waited = await waitForDeadline(votingDeadline, maxWaitSeconds);
+    if (!waited) {
+      const artifact: TuiSmokeArtifact = {
+        version: 1,
+        kind: "marketplace-tui-devnet-smoke",
+        createdAt: new Date().toISOString(),
+        rpcUrl,
+        programId: readOnlyProgram.programId.toBase58(),
+        runId,
+        authorityPubkey: authoritySigner.keypair.publicKey.toBase58(),
+        taskPda: disputeTaskPda,
+        disputePda,
+        workerClaimPda: disputeClaimPda,
+        votingDeadline,
+        arbiterVotes,
+      };
+      const savedPath = await writeArtifact(artifact, artifactPath);
+      console.log(
+        `[pending] dispute deadline ${formatUnix(votingDeadline)} exceeds max wait of ${maxWaitSeconds}s`,
+      );
+      console.log(`[artifact] ${savedPath}`);
+      console.log(
+        `[resume] PROTOCOL_AUTHORITY_WALLET=${authoritySigner.walletPath} npm run smoke:marketplace:tui:devnet -- --resume ${savedPath}`,
+      );
+      return;
+    }
+
+    await resolveDisputeViaTui(baseOptions, disputePda, arbiterVotes);
+
+    const disputeAfterResolve = await waitFor(
+      "resolved dispute status",
+      DEFAULT_STATE_WAIT_SECONDS,
+      async () => {
+        const dispute = await fetchDisputeDetail(baseOptions, disputePda);
+        const status = getStringField(dispute, "status", "disputeAfterResolve");
+        if (status === "active") {
+          throw new Error("dispute is still active");
+        }
+        return dispute;
+      },
+    );
+    const taskAfterResolve = await fetchTaskDetail(baseOptions, disputeTaskPda);
+
+    console.log(
+      `[ok] marketplace TUI devnet smoke complete: dispute status=${getStringField(disputeAfterResolve, "status", "disputeAfterResolve")}, task status=${getStringField(taskAfterResolve, "status", "taskAfterResolve")}, task claim=${completeClaimPda}`,
+    );
+  } finally {
+    resetMarketplaceCliProgramContextOverrides();
+  }
+}
+
+async function runResume(): Promise<void> {
+  const resumePath = getFlagValue("--resume");
+  if (!resumePath) {
+    throw new Error("Missing artifact path. Use --resume /path/to/file.json");
+  }
+
+  const artifact = await readArtifact(resumePath);
+  const rpcUrl = process.env.AGENC_RPC_URL ?? artifact.rpcUrl ?? DEFAULT_RPC_URL;
+  const programId = new PublicKey(
+    process.env.AGENC_PROGRAM_ID ?? artifact.programId,
+  );
+  const connection = new Connection(rpcUrl, "confirmed");
+  const authoritySigner = createSignerContext(
+    "authority",
+    env("PROTOCOL_AUTHORITY_WALLET"),
+    connection,
+    programId,
+  );
+  const readOnlyProgram = createReadOnlyProgram(connection, programId);
+
+  const protocolConfig = await loadProtocolConfig(readOnlyProgram);
+  if (!authoritySigner.keypair.publicKey.equals(protocolConfig.authority)) {
+    throw new Error(
+      `PROTOCOL_AUTHORITY_WALLET ${authoritySigner.keypair.publicKey.toBase58()} does not match protocol authority ${protocolConfig.authority.toBase58()}`,
+    );
+  }
+
+  await ensureBalance(
+    connection,
+    "authority",
+    authoritySigner.keypair.publicKey,
+    DEFAULT_AUTHORITY_FEE_BUFFER_LAMPORTS,
+  );
+
+  console.log(`[resume] artifact: ${resumePath}`);
+  console.log(`[resume] rpc: ${rpcUrl}`);
+  console.log(`[resume] program: ${programId.toBase58()}`);
+  console.log(
+    `[resume] authority wallet: ${authoritySigner.keypair.publicKey.toBase58()}`,
+  );
+
+  const runtime: SmokeRuntime = {
+    connection,
+    readOnlyProgram,
+    signersByKey: new Map<string, SignerContext>([["authority", authoritySigner]]),
+  };
+  installMarketplaceCliOverrides(runtime);
+
+  const baseOptions = buildBaseOptions(rpcUrl, programId.toBase58());
+
+  try {
+    const disputeBeforeResolve = await fetchDisputeDetail(baseOptions, artifact.disputePda);
+    const disputeStatus = getStringField(
+      disputeBeforeResolve,
+      "status",
+      "resume.disputeBefore",
+    );
+    const votingDeadline = getNumberField(
+      disputeBeforeResolve,
+      "votingDeadline",
+      "resume.disputeBefore",
+    );
+
+    if (disputeStatus !== "active") {
+      console.log(
+        `[resume] dispute ${artifact.disputePda} already moved to status=${disputeStatus}`,
+      );
+      return;
+    }
+
+    const now = Math.floor(Date.now() / 1000);
+    if (votingDeadline > now) {
+      console.log(
+        `[resume] dispute ${artifact.disputePda} is still locked until ${formatUnix(votingDeadline)}`,
+      );
+      return;
+    }
+
+    await resolveDisputeViaTui(baseOptions, artifact.disputePda, artifact.arbiterVotes);
+
+    const disputeAfterResolve = await waitFor(
+      "resumed dispute resolution",
+      DEFAULT_STATE_WAIT_SECONDS,
+      async () => {
+        const dispute = await fetchDisputeDetail(baseOptions, artifact.disputePda);
+        const status = getStringField(dispute, "status", "resume.disputeAfter");
+        if (status === "active") {
+          throw new Error("dispute is still active");
+        }
+        return dispute;
+      },
+    );
+    const taskAfterResolve = await fetchTaskDetail(baseOptions, artifact.taskPda);
+
+    console.log(
+      `[ok] resumed marketplace TUI dispute resolution complete: dispute status=${getStringField(disputeAfterResolve, "status", "resume.disputeAfter")}, task status=${getStringField(taskAfterResolve, "status", "resume.taskAfter")}`,
+    );
+  } finally {
+    resetMarketplaceCliProgramContextOverrides();
+  }
+}
+
+async function main(): Promise<void> {
+  if (hasFlag("--help")) {
+    usage();
+    return;
+  }
+
+  if (hasFlag("--resume")) {
+    await runResume();
+    return;
+  }
+
+  await runInitial();
+}
+
+main().catch((error) => {
+  console.error(
+    `[error] ${error instanceof Error ? error.message : String(error)}`,
+  );
+  process.exitCode = 1;
+});

--- a/web/src/components/simulation/SimulationWorkspace.test.tsx
+++ b/web/src/components/simulation/SimulationWorkspace.test.tsx
@@ -84,7 +84,7 @@ function makeRecord(overrides: Partial<Record<string, unknown>> = {}) {
 }
 
 describe('SimulationWorkspace', () => {
-  const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>();
+  const fetchMock = vi.fn();
 
   beforeEach(() => {
     viewerSimulationId = null;
@@ -151,7 +151,7 @@ describe('SimulationWorkspace', () => {
   });
 
   it('hydrates detail mode from the selected simulation record and lists active/recent cards', async () => {
-    fetchMock.mockImplementation(async (input) => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.endsWith('/simulations')) {
         return new Response(JSON.stringify({
@@ -196,7 +196,7 @@ describe('SimulationWorkspace', () => {
   });
 
   it('shows sim-not-found state when the selected simulation disappears', async () => {
-    fetchMock.mockImplementation(async (input) => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.endsWith('/simulations')) {
         return new Response(JSON.stringify({ simulations: [] }), {

--- a/web/src/components/simulation/SimulationWorkspace.test.tsx
+++ b/web/src/components/simulation/SimulationWorkspace.test.tsx
@@ -84,7 +84,7 @@ function makeRecord(overrides: Partial<Record<string, unknown>> = {}) {
 }
 
 describe('SimulationWorkspace', () => {
-  const fetchMock = vi.fn<typeof fetch>();
+  const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>();
 
   beforeEach(() => {
     viewerSimulationId = null;

--- a/web/src/components/simulation/useSimulation.test.tsx
+++ b/web/src/components/simulation/useSimulation.test.tsx
@@ -115,7 +115,7 @@ class MockEventSource {
 }
 
 describe('useSimulation', () => {
-  const fetchMock = vi.fn<typeof fetch>();
+  const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>();
 
   beforeEach(() => {
     fetchMock.mockReset();

--- a/web/src/components/simulation/useSimulation.test.tsx
+++ b/web/src/components/simulation/useSimulation.test.tsx
@@ -115,7 +115,7 @@ class MockEventSource {
 }
 
 describe('useSimulation', () => {
-  const fetchMock = vi.fn<Parameters<typeof fetch>, ReturnType<typeof fetch>>();
+  const fetchMock = vi.fn();
 
   beforeEach(() => {
     fetchMock.mockReset();
@@ -133,7 +133,7 @@ describe('useSimulation', () => {
   it('ignores late responses from a previously selected simulation', async () => {
     const staleStatus = deferred<Response>();
 
-    fetchMock.mockImplementation(async (input) => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes('/simulations/sim-1/events') && !url.includes('/stream')) {
         return jsonResponse({
@@ -229,7 +229,7 @@ describe('useSimulation', () => {
   it('swallows aborted replay hydration during selection changes', async () => {
     const aborted = deferred<Response>();
 
-    fetchMock.mockImplementation(async (input) => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes('/simulations/sim-1/events') && !url.includes('/stream')) {
         return aborted.promise;
@@ -313,7 +313,7 @@ describe('useSimulation', () => {
 
   it('hydrates replay, catches up after reconnect, and deduplicates repeated live events', async () => {
 
-    fetchMock.mockImplementation(async (input) => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes('/simulations/sim-live/events') && !url.includes('/stream') && url.includes('cursor=evt-3')) {
         return jsonResponse({
@@ -390,7 +390,7 @@ describe('useSimulation', () => {
   it('keeps paused sims on heartbeat status polling while disabling repeated agent polling', async () => {
     vi.useFakeTimers();
 
-    fetchMock.mockImplementation(async (input) => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes('/simulations/sim-paused/events') && !url.includes('/stream')) {
         return jsonResponse({ simulation_id: 'sim-paused', events: [], next_cursor: null });
@@ -457,7 +457,7 @@ describe('useSimulation', () => {
 
   it('keeps archived sims disconnected after initial hydration', async () => {
 
-    fetchMock.mockImplementation(async (input) => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url.includes('/simulations/sim-archived/events') && !url.includes('/stream')) {
         return jsonResponse({

--- a/web/src/hooks/useWebSocket.test.ts
+++ b/web/src/hooks/useWebSocket.test.ts
@@ -5,21 +5,7 @@ import { useWebSocket } from './useWebSocket';
 const CONNECTING = 0;
 const OPEN = 1;
 
-interface WsMockInstance {
-  url: string;
-  readyState: number;
-  sent: string[];
-  onopen: ((ev?: Event) => void) | null;
-  onmessage: ((ev: MessageEvent) => void) | null;
-  onclose: (() => void) | null;
-  onerror: (() => void) | null;
-  triggerOpen: () => void;
-  triggerMessage: (data: unknown) => void;
-  triggerClose: () => void;
-  close: ReturnType<typeof vi.fn>;
-}
-
-const instances: WsMockInstance[] = [];
+const instances: WsMock[] = [];
 
 class WsMock {
   static CONNECTING = CONNECTING;


### PR DESCRIPTION
## What changed
- add the marketplace TUI devnet smoke path and unblock the existing smoke coverage
- expand marketplace protocol/runtime wiring for governance, disputes, reputation, PDA/IDL updates, and marketplace mutation tooling
- extend the watch/operator console flow so marketplace resources open inline with consistent browser hydration and detail handling
- add follow-up coverage across daemon/operator-console, protocol tooling, and watch UI behavior

## Why
- marketplace follow-up flows were inconsistent across tasks, skills, governance, disputes, and reputation
- the devnet TUI smoke path was blocked and the related protocol/tool plumbing needed broader follow-through

## Impact
- operator console and watch now expose a more consistent marketplace browsing experience
- daemon/runtime protocol tooling has stronger marketplace coverage and follow-up behavior
- the repo now includes a dedicated marketplace TUI devnet smoke script

## Validation
- `node --test runtime/tests/watch/agenc-watch-commands.test.mjs runtime/tests/watch/agenc-watch-entry.test.mjs runtime/tests/watch/agenc-watch-frame.test.mjs runtime/tests/watch/agenc-watch-input.test.mjs runtime/tests/watch/agenc-watch-surface-dispatch.test.mjs runtime/tests/watch/agenc-watch-transcript-cards.test.mjs`
- `npm run test --workspace=@tetsuo-ai/runtime`
