### PR TITLE
fix(grok): auto-trim tool catalog to documented xAI 128-tool maximum

### DIFF
--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -1518,6 +1518,100 @@ describe("GrokProvider", () => {
     expect((params.tools as unknown[]).length).toBe(120);
   });
 
+  it("auto-trims tool catalog to documented xAI 128-tool maximum", async () => {
+    // AgenC's live tool registry has 129 tools (77 system + 20 doom MCP
+    // + 18 agenc protocol + 6 social + 4 task + execute_with_agent +
+    // coordinator_mode + 2 solana-fender). xAI docs cap tools at 128.
+    // The adapter must auto-trim to stay functional; the strict filter's
+    // 128-tool rejection is a defense-in-depth catch below this layer.
+    mockCreate.mockResolvedValueOnce(makeCompletion());
+
+    const overLimitTools: LLMTool[] = Array.from(
+      { length: 129 },
+      (_, i) => ({
+        type: "function",
+        function: {
+          name: `tool_${String(i).padStart(3, "0")}`,
+          description: `Tool ${i}`,
+          parameters: {
+            type: "object",
+            properties: { a: { type: "string" } },
+            required: ["a"],
+          },
+        },
+      }),
+    );
+
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      tools: overLimitTools,
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let capturedWarnCalls: unknown[][] = [];
+    try {
+      await provider.chat([{ role: "user", content: "hello" }]);
+      // Capture before mockRestore() below clears mock.calls.
+      capturedWarnCalls = warnSpy.mock.calls.map((call) => [...call]);
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    const params = mockCreate.mock.calls[0][0];
+    expect(Array.isArray(params.tools)).toBe(true);
+    // Trimmed to exactly 128; the last tool (tool_128) is dropped.
+    expect((params.tools as unknown[]).length).toBe(128);
+    const sentNames = (params.tools as Array<{ name?: unknown }>).map((t) =>
+      String(t.name),
+    );
+    expect(sentNames[0]).toBe("tool_000");
+    expect(sentNames[127]).toBe("tool_127");
+    expect(sentNames).not.toContain("tool_128");
+
+    // Operator-visible warning naming the dropped tool.
+    const warnCall = capturedWarnCalls.find((call) =>
+      String(call[0] ?? "").includes("Tool catalog has 129 tools"),
+    );
+    expect(warnCall).toBeDefined();
+    expect(String(warnCall?.[0] ?? "")).toContain("tool_128");
+  });
+
+  it("does NOT trim when tool catalog is exactly at the 128 limit", async () => {
+    mockCreate.mockResolvedValueOnce(makeCompletion());
+
+    const atLimitTools: LLMTool[] = Array.from({ length: 128 }, (_, i) => ({
+      type: "function",
+      function: {
+        name: `tool_${i}`,
+        description: `Tool ${i}`,
+        parameters: {
+          type: "object",
+          properties: { a: { type: "string" } },
+          required: ["a"],
+        },
+      },
+    }));
+
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      tools: atLimitTools,
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let capturedWarnCalls: unknown[][] = [];
+    try {
+      await provider.chat([{ role: "user", content: "hello" }]);
+      capturedWarnCalls = warnSpy.mock.calls.map((call) => [...call]);
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    const params = mockCreate.mock.calls[0][0];
+    expect((params.tools as unknown[]).length).toBe(128);
+    const trimWarns = capturedWarnCalls.filter((call) =>
+      String(call[0] ?? "").includes("Tool catalog has"),
+    );
+    expect(trimWarns).toHaveLength(0);
+  });
+
   it("passes usage information", async () => {
     mockCreate.mockResolvedValueOnce(makeCompletion());
 

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -37,6 +37,7 @@ import {
   validateXaiRequestPreFlight,
   validateXaiResponsePostFlight,
   XaiSilentToolDropError,
+  XAI_RESPONSES_MAX_TOOL_COUNT,
 } from "./xai-strict-filter.js";
 import { ensureLazyImport } from "../lazy-import.js";
 import {
@@ -1965,6 +1966,37 @@ export class GrokProvider implements LLMProvider {
     // silently broke multi-step tool sequences end-to-end.
     if (selectedTools.tools.length > 0) {
       if (!hasImages || VISION_MODELS_WITH_TOOLS.has(visionModel)) {
+        // Enforce the documented xAI Responses API maximum of 128
+        // tools (developers/rest-api-reference/inference/chat). The
+        // strict pre-flight validator throws on any request with more
+        // than XAI_RESPONSES_MAX_TOOL_COUNT tools; trim here so a
+        // local catalog that legitimately exceeds the limit (e.g.
+        // many MCP servers enabled) stays functional instead of
+        // failing closed at every request. The trim is deterministic
+        // (tail of the registry order) and the dropped tool names
+        // are logged so operators can reorder their tool registry
+        // or drop unused MCP servers to reclaim the dropped slots.
+        if (selectedTools.tools.length > XAI_RESPONSES_MAX_TOOL_COUNT) {
+          const dropped = selectedTools.tools.slice(
+            XAI_RESPONSES_MAX_TOOL_COUNT,
+          );
+          const droppedNames = dropped
+            .map((t) => String((t as { name?: unknown }).name ?? "<unnamed>"))
+            .join(", ");
+          console.warn(
+            `[GrokProvider] Tool catalog has ${selectedTools.tools.length} ` +
+              `tools but xAI Responses API documents a maximum of ` +
+              `${XAI_RESPONSES_MAX_TOOL_COUNT}. Trimming the tail of the ` +
+              `registry to stay within the contract. Dropped tools (last ` +
+              `in registry order): ${droppedNames}. Reorder your tool ` +
+              `registry or disable unused MCP servers if these should be ` +
+              `retained.`,
+          );
+          selectedTools.tools = selectedTools.tools.slice(
+            0,
+            XAI_RESPONSES_MAX_TOOL_COUNT,
+          ) as typeof selectedTools.tools;
+        }
         params.tools = selectedTools.tools;
         selectedTools.toolsAttached = true;
         params.parallel_tool_calls = this.config.parallelToolCalls;

--- a/runtime/src/llm/grok/xai-strict-filter.ts
+++ b/runtime/src/llm/grok/xai-strict-filter.ts
@@ -72,6 +72,21 @@ import type { LLMFailureClass, LLMPipelineStopReason } from "../policy.js";
  * top-level key not in this set instead of silently stripping it the way
  * `sanitizeToDocumentedXaiResponsesParams()` does.
  */
+/**
+ * Documented maximum `tools` array length for xAI /v1/responses. Source:
+ * developers/rest-api-reference/inference/chat Responses API section:
+ * "A max of 128 tools are supported."
+ *
+ * The runtime enforces this in two places: the Grok adapter's
+ * `buildParams()` auto-trims the tool array to this cap BEFORE the
+ * strict filter runs (so agents with large tool catalogs stay
+ * functional), and `validateXaiRequestPreFlight()` throws on any
+ * request whose tools array still exceeds this after the auto-trim
+ * (defense in depth against a regression that bypasses the adapter
+ * trim).
+ */
+export const XAI_RESPONSES_MAX_TOOL_COUNT = 128;
+
 export const DOCUMENTED_XAI_RESPONSES_REQUEST_FIELDS: ReadonlySet<string> = new Set([
   "include",
   "input",
@@ -496,15 +511,19 @@ export function validateXaiRequestPreFlight(
   // of 128 tools are supported." AgenC was previously sending 129 which
   // silently passed through xAI's 200-level validation but potentially
   // contributed to undefined downstream decoder behavior. Fail closed
-  // at the boundary so the runtime cannot exceed the contract.
-  if (tools.length > 128) {
+  // at the boundary so the runtime cannot exceed the contract. The
+  // Grok adapter also auto-trims to this cap in buildParams() before
+  // this validator runs, so in normal operation this throw is a
+  // defense-in-depth against a regression that bypasses the adapter
+  // trim.
+  if (tools.length > XAI_RESPONSES_MAX_TOOL_COUNT) {
     throw new XaiUndocumentedFieldError(
       "tools",
       `has ${tools.length} entries but the xAI Responses API documents a ` +
-        `maximum of 128 tools per request ` +
+        `maximum of ${XAI_RESPONSES_MAX_TOOL_COUNT} tools per request ` +
         `(developers/rest-api-reference/inference/chat). Sending more than ` +
-        `128 violates the documented contract even if the request returns ` +
-        `HTTP 200.`,
+        `${XAI_RESPONSES_MAX_TOOL_COUNT} violates the documented contract ` +
+        `even if the request returns HTTP 200.`,
     );
   }
   for (let i = 0; i < tools.length; i++) {


### PR DESCRIPTION
## Summary

- Follow-up to #306: the strict 128-tool pre-flight rejection was breaking every live request because the runtime's tool catalog legitimately has **129** tools (77 system + 20 mcp.doom + 18 agenc protocol + 6 social + 4 task + execute_with_agent + coordinator_mode + 2 mcp.solana-fender)
- Add auto-trim in `buildParams()` that runs before the strict filter and deterministically trims the tool array tail to exactly 128 when it exceeds the limit
- Emit an operator-visible \`console.warn\` naming the dropped tools so operators can reorder their registry or disable unused MCP servers
- Keep the strict filter's 128-tool throw as defense-in-depth against any regression that bypasses the adapter trim

## The problem this fixes

After #306 landed, every chat turn failed with:
\`\`\`
Error: xAI Responses API request rejected by strict filter: field \"tools\"
has 129 entries but the xAI Responses API documents a maximum of 128 tools
per request. Sending more than 128 violates the documented contract even
if the request returns HTTP 200.
\`\`\`

The strict filter was doing the right thing per the docs, but the runtime's default tool catalog was 1 over the documented cap. We'd caught a real contract violation and then immediately gotten blocked on it.

## Fix

### `runtime/src/llm/grok/xai-strict-filter.ts`
- Export new constant \`XAI_RESPONSES_MAX_TOOL_COUNT = 128\` as the single source of truth for the documented limit
- Pre-flight check now uses the constant instead of a magic number

### \`runtime/src/llm/grok/adapter.ts\`
- Import \`XAI_RESPONSES_MAX_TOOL_COUNT\`
- In \`buildParams()\` right before \`params.tools = selectedTools.tools\`, check if \`selectedTools.tools.length > XAI_RESPONSES_MAX_TOOL_COUNT\`
- If yes: slice the tail (deterministic, registry-order), emit \`console.warn\` listing the dropped tool names so the operator can see exactly what got cut
- The strict filter's 128-tool throw still runs after the trim — it becomes a regression guard rather than a user-facing rejection

## Tests

Two new tests in \`adapter.test.ts\`:

- **\`auto-trims tool catalog to documented xAI 128-tool maximum\`**: constructs a provider with 129 tools, verifies the outgoing \`params.tools\` has exactly 128 entries with \`tool_128\` dropped and \`tool_000\`..\`tool_127\` preserved. Verifies the operator warning fires and names the dropped tool.
- **\`does NOT trim when tool catalog is exactly at the 128 limit\`**: verifies the no-op path — exactly 128 tools flow through untouched with zero warnings.

Both tests use \`vi.spyOn(console, \"warn\")\` with the calls captured before \`mockRestore()\` (subtle vitest gotcha: \`mockRestore()\` clears \`mock.calls\`).

## Test plan

- [x] \`npm run typecheck --workspace=@tetsuo-ai/runtime\` — clean
- [x] adapter.test.ts: **85/85 pass** (was 83, +2 new auto-trim tests)
- [x] xai-strict-filter.test.ts: **91/91 pass**
- [x] All \`src/llm\` tests: **638/638 pass** (was 636)
- [ ] Rebuild + dist sync + daemon restart
- [ ] Re-run the failing \"implement @PLAN.md\" prompt that originally hit the 129-tool rejection; verify the request now proceeds and the operator warning appears in \`~/.agenc/daemon.log\` naming the dropped tool

## Note on tool drop order

The drop is deterministic (registry tail) but the \"correct\" tool to drop is an operator decision. The registry order in the current catalog results in \`agenc.getProtocolConfig\` being dropped (position 129, last in registry order). If an operator wants to retain \`agenc.getProtocolConfig\` and drop something else, they can reorder the registry or disable a less-critical tool. A future follow-up could introduce a priority annotation on tool registrations, but that's out of scope for unblocking the runtime.