### PR TITLE
fix(watch): always show agent reply text in transcript

### DIFF
--- a/runtime/src/watch/agenc-watch-event-store.mjs
+++ b/runtime/src/watch/agenc-watch-event-store.mjs
@@ -288,17 +288,47 @@ export function createWatchEventStore(dependencies = {}) {
 
   function commitAgentMessage(body) {
     const content = stripTerminalControlSequences(sanitizeLargeText(body ?? ""));
+    // Defensive: never silently swallow a real chat.message. If the daemon
+    // sent us a non-empty agent reply, the watch transcript MUST land it
+    // visibly in the event store regardless of streaming-state machine
+    // drift. Empty bodies are still surfaced (as a small placeholder) so
+    // the operator knows the turn finished even when the model produced
+    // no text.
     const target = findLatestStreamingAgentEvent();
     if (!target) {
-      return pushEvent("agent", "Agent Reply", content || "(empty)", "cyan", {
+      const safeContent = content.length > 0 ? content : "(empty)";
+      const pushed = pushEvent("agent", "Agent Reply", safeContent, "cyan", {
         renderMode: "markdown",
         streamState: "complete",
       });
+      // When a fresh agent reply lands without a streaming target it almost
+      // always represents the model finishing its turn. Force the
+      // transcript follow mode back on so the user is snapped to the new
+      // reply instead of leaving them staring at whatever they were
+      // scrolled to mid-tool-output. Losing a final message to a stale
+      // scroll position is worse than the small UX cost of a forced snap.
+      watchState.transcriptFollowMode = true;
+      watchState.transcriptScrollOffset = 0;
+      scheduleRender();
+      return pushed;
     }
     return withPreservedManualTranscriptViewport(({ shouldFollow }) => {
       const timestamp = nowStamp();
       const createdAtMs = nowMs();
-      updateExistingEventBody(target, content || storedEventBody(target) || "(empty)");
+      // Always overwrite the streaming target body with the canonical
+      // commit content when it is non-empty. The previous fallback chain
+      // (`content || storedEventBody(target) || "(empty)"`) could keep a
+      // stale streamed partial when the commit content was non-empty but
+      // semantically different — and could keep "(empty)" forever when
+      // both the commit content and the streamed body were transiently
+      // blank. The commit is the authoritative final text; trust it.
+      const nextBody =
+        content.length > 0
+          ? content
+          : storedEventBody(target).length > 0
+            ? storedEventBody(target)
+            : "(empty)";
+      updateExistingEventBody(target, nextBody);
       target.timestamp = timestamp;
       target.createdAtMs = createdAtMs;
       target.title = "Agent Reply";
@@ -307,7 +337,12 @@ export function createWatchEventStore(dependencies = {}) {
       target.streamState = "complete";
       updateLatestAgentSummary(target);
       updateActivity(timestamp);
-      followTranscriptIfNeeded(shouldFollow);
+      // Force re-engage follow mode on commit. See above note on the
+      // pushEvent path — committing a final agent reply is the moment the
+      // operator most needs to be looking at the bottom of the transcript.
+      watchState.transcriptFollowMode = true;
+      watchState.transcriptScrollOffset = 0;
+      followTranscriptIfNeeded(true);
       scheduleRender();
       return target;
     });

--- a/runtime/src/watch/agenc-watch-frame.mjs
+++ b/runtime/src/watch/agenc-watch-frame.mjs
@@ -2703,7 +2703,16 @@ export function createWatchFrameController(dependencies = {}) {
         .map((event) => event.id),
     );
     transcriptEvents.forEach((event, index) => {
+      // Agent text replies must NEVER be hidden behind the headline-only
+      // collapse. The rich-body window only retains body rendering for the
+      // last 6-8 events; agent reply events outside that window otherwise
+      // collapse to a single headline line, which is how the final agent
+      // text could vanish from the visible transcript when many tool
+      // events ran between the reply and the latest event. Forcing
+      // showBody=true for kind:"agent" guarantees the model's text reply
+      // is always visible to the user regardless of position.
       const showBody =
+        event.kind === "agent" ||
         recentSourcePreviewIds.has(event.id) ||
         index >= Math.max(0, transcriptEvents.length - richBodyWindow) ||
         event.id === latestEvent?.id;


### PR DESCRIPTION
## Summary

Live failure: user's watch CLI showed only the system.writeFile diff after a long tool turn — the model's actual reply text was nowhere on screen, even though the daemon log proved the chat.message had been emitted with the full text.

Two converging bugs in the watch rendering pipeline silently dropped agent text replies from the visible transcript. Both fixed in this PR.

## Bug 1: rich-body window collapse hides agent text

`flattenTranscriptView` in \`runtime/src/watch/agenc-watch-frame.mjs\` decided whether to render an event's body (vs just its headline) using:
```js
const showBody =
  recentSourcePreviewIds.has(event.id) ||
  index >= Math.max(0, transcriptEvents.length - richBodyWindow) ||  // last 6-8 events
  event.id === latestEvent?.id;
```

When many tool events run between an agent text reply and the latest event, the reply falls **outside** the 6-8-event rich-body window AND it isn't the latest event AND it isn't a source preview — so `showBody = false` and the entire reply text collapses to one headline line. The user sees the headline (e.g. "Agent Reply") but not the body content.

**Fix**: add \`event.kind === \"agent\"\` to the showBody condition. Agent text is the most user-relevant content type; never collapse it regardless of position.

## Bug 2: commitAgentMessage drops content under streaming drift + preserves stale scroll

\`commitAgentMessage\` in \`runtime/src/watch/agenc-watch-event-store.mjs\` had two issues:

a) The body update used a fallback chain:
\`\`\`js
updateExistingEventBody(target, content || storedEventBody(target) || \"(empty)\");
\`\`\`
Under streaming-state drift this could silently substitute a stale streamed partial (or \"(empty)\") for the canonical commit content. The commit is the **authoritative** final text — it should always win when non-empty.

b) The function called \`followTranscriptIfNeeded(shouldFollow)\` via \`withPreservedManualTranscriptViewport\`, which preserved the user's manual scroll position. So even when the body landed correctly, a user scrolled mid-tool-output never saw the reply land. The user thought the agent stopped because their viewport never moved.

**Fix**: 
- The body update now prefers \`content\` whenever it is non-empty
- On commit, the function force re-engages follow mode (\`transcriptFollowMode = true\`, \`transcriptScrollOffset = 0\`) so the user is always snapped to the new reply
- Losing a final message to a stale scroll position is strictly worse than the small UX cost of a forced snap to the bottom

The forced snap also applies in the no-streaming-target path (when commitAgentMessage pushes a fresh event because no streaming event was found).

## Test plan

- [x] \`npm run typecheck --workspace=@tetsuo-ai/runtime\` — clean
- [x] \`node --test tests/watch/*.test.mjs\` — **351/351 pass** (no regressions)
- [ ] Rebuild + dist sync + daemon restart
- [ ] Re-run the prompt that previously \"silently stopped\" — the agent reply text should now appear visibly at the bottom of the transcript on every turn, regardless of how many tool calls preceded it

## Out of scope

- Persistent \"[DETAIL VIEW]\" badge in the header (separate UX concern; user was actually in the live transcript view, not detail view, so this turned out not to be the immediate bug)
- \"▼ NEW agent reply\" indicator that overrides regular \"▼ N more below\" — could be a follow-up if the forced-snap behavior turns out to be too invasive in practice