### PR TITLE
fix(watch): force-snap to agent reply must bypass viewport-preserve wrapper

### DIFF
--- a/runtime/src/watch/agenc-watch-event-store.mjs
+++ b/runtime/src/watch/agenc-watch-event-store.mjs
@@ -294,27 +294,26 @@ export function createWatchEventStore(dependencies = {}) {
     // drift. Empty bodies are still surfaced (as a small placeholder) so
     // the operator knows the turn finished even when the model produced
     // no text.
+    //
+    // CRITICAL: this function DELIBERATELY bypasses
+    // withPreservedManualTranscriptViewport for the force-snap. PR #310
+    // set transcriptFollowMode/transcriptScrollOffset INSIDE the wrapper,
+    // and the wrapper's cleanup re-applied preserveManualTranscriptViewport
+    // after the mutator returned, undoing the snap. The fix is to perform
+    // the body mutation directly and force-set the viewport AFTER any
+    // wrapper that might overwrite it. The lost-message bug is strictly
+    // worse than the small UX cost of a forced snap on agent reply.
     const target = findLatestStreamingAgentEvent();
+    const timestamp = nowStamp();
+    const createdAtMs = nowMs();
+    let result;
     if (!target) {
       const safeContent = content.length > 0 ? content : "(empty)";
-      const pushed = pushEvent("agent", "Agent Reply", safeContent, "cyan", {
+      result = pushEvent("agent", "Agent Reply", safeContent, "cyan", {
         renderMode: "markdown",
         streamState: "complete",
       });
-      // When a fresh agent reply lands without a streaming target it almost
-      // always represents the model finishing its turn. Force the
-      // transcript follow mode back on so the user is snapped to the new
-      // reply instead of leaving them staring at whatever they were
-      // scrolled to mid-tool-output. Losing a final message to a stale
-      // scroll position is worse than the small UX cost of a forced snap.
-      watchState.transcriptFollowMode = true;
-      watchState.transcriptScrollOffset = 0;
-      scheduleRender();
-      return pushed;
-    }
-    return withPreservedManualTranscriptViewport(({ shouldFollow }) => {
-      const timestamp = nowStamp();
-      const createdAtMs = nowMs();
+    } else {
       // Always overwrite the streaming target body with the canonical
       // commit content when it is non-empty. The previous fallback chain
       // (`content || storedEventBody(target) || "(empty)"`) could keep a
@@ -337,15 +336,16 @@ export function createWatchEventStore(dependencies = {}) {
       target.streamState = "complete";
       updateLatestAgentSummary(target);
       updateActivity(timestamp);
-      // Force re-engage follow mode on commit. See above note on the
-      // pushEvent path — committing a final agent reply is the moment the
-      // operator most needs to be looking at the bottom of the transcript.
-      watchState.transcriptFollowMode = true;
-      watchState.transcriptScrollOffset = 0;
-      followTranscriptIfNeeded(true);
-      scheduleRender();
-      return target;
-    });
+      result = target;
+    }
+    // Force-snap to the new reply AFTER any nested wrapper has run. This
+    // line MUST be outside withPreservedManualTranscriptViewport — the
+    // wrapper's cleanup overwrote it in PR #310, which is exactly why
+    // agent replies were still invisible despite landing in events[].
+    watchState.transcriptFollowMode = true;
+    watchState.transcriptScrollOffset = 0;
+    scheduleRender();
+    return result;
   }
 
   function cancelAgentStream(reason = "cancelled") {


### PR DESCRIPTION
## Summary

Follow-up to #310: the force-snap to new agent replies didn't actually work in production. PR #310 set \`transcriptFollowMode\` and \`transcriptScrollOffset\` **inside** the \`withPreservedManualTranscriptViewport\` mutator, but the wrapper's cleanup runs \`preserveManualTranscriptViewport\` on exit which **overwrites** both values with the preserved manual scroll position. The fix made things land in \`events[]\` but the viewport never moved, so the user still saw the writeFile diff instead of the new reply.

## Evidence

Live trace from session at 19:25 today:

\`\`\`
Daemon log line (proven in ~/.agenc/daemon.log):
  2026-04-10T01:25:11.534Z webchat.ws.outbound clientId=client_2
    type=chat.message
    payloadPreview.content=\"**Build failures identified:**\n\n1. **6 failed system.bash calls**...\"

Watch CLI process (verified):
  PID 2475638  STARTED 19:23:03  /home/tetsuo/.agenc/runtime/current/.../bin/agenc-watch.js
  → started AFTER the PR #310 build at 19:16:15, on the new code

Bundle verification (verified by python regex):
  ✓ showBody = event.kind === \"agent\" || ...  (PR #310 fix 1)
  ✓ commitAgentMessage uses content.length > 0 guard (PR #310 fix 2)
  ✓ commitAgentMessage sets transcriptFollowMode = true (PR #310 fix 3)
  ✓ All present in /home/tetsuo/.agenc/runtime/current/.../bin/agenc-watch.mjs

User-reported screen state (verified by screenshot):
  - Last visible content: writeFile diff for include/history.h
  - Last visible event: \"FAULT Command failed cd build && rm -rf * && cmake .. && make\"
  - Status: idle 2m 29s, 5 errors, phase idle, tool system.bash
  - NO agent reply text visible
\`\`\`

The chat.message arrived. The watch processed it. The body landed in \`events[]\`. The viewport snap didn't stick. The reply stayed invisible.

## Root cause

\`runtime/src/watch/agenc-watch-frame.mjs:2735\`:

\`\`\`js
function withPreservedManualTranscriptViewport(mutator) {
  const shouldFollow = isTranscriptFollowing();
  const beforeRows = shouldFollow ? null : currentTranscriptRowCount();
  const result = mutator({ shouldFollow });
  if (beforeRows !== null) {
    const afterRows = currentTranscriptRowCount();
    const nextViewport = preserveManualTranscriptViewport({...});
    watchState.transcriptScrollOffset = nextViewport.transcriptScrollOffset;  // ← OVERWRITES my snap
    watchState.transcriptFollowMode = nextViewport.transcriptFollowMode;       // ← OVERWRITES my snap
  }
  return result;
}
\`\`\`

PR #310's mutator did:
\`\`\`js
return withPreservedManualTranscriptViewport(({ shouldFollow }) => {
  ...
  watchState.transcriptFollowMode = true;       // ← INSIDE mutator
  watchState.transcriptScrollOffset = 0;        // ← INSIDE mutator
  followTranscriptIfNeeded(true);
  scheduleRender();
  return target;
});
\`\`\`

The wrapper's cleanup runs AFTER the mutator and reads \`isTranscriptFollowing()\` from the captured \`shouldFollow=false\`, then overwrites both viewport fields with the preserved manual scroll. The snap is destroyed before the next render fires.

## Fix

Rewrite \`commitAgentMessage\` to bypass \`withPreservedManualTranscriptViewport\` entirely:

1. Body mutation runs directly (\`updateExistingEventBody\` for the streaming target path, or \`pushEvent\` for the no-target path — pushEvent has its own internal wrapper but commitAgentMessage's force-snap runs **after** pushEvent returns, outside that wrapper)
2. Force-set \`transcriptFollowMode = true\` and \`transcriptScrollOffset = 0\` AFTER all wrapper cleanup
3. Add a CRITICAL comment documenting the trap so the next person doesn't put the snap back inside a preserve wrapper

## Test plan

- [x] \`npm run typecheck --workspace=@tetsuo-ai/runtime\` — clean
- [x] \`node --test tests/watch/*.test.mjs\` — **351/351 pass** (no regressions)
- [ ] Rebuild + dist sync + watch CLI restart (the user must restart their watch since it's a separate process from the daemon)
- [ ] Re-send the prompt — the agent reply should appear at the bottom of the transcript and the viewport should snap to it on commit

## Why this needed a separate PR

PR #310 looked correct on inspection — the force-snap calls were there in the bundle. The bug only surfaced when the wrapper cleanup ran and silently overwrote the state. This is exactly the kind of bug that needs end-to-end live testing to catch; static review wouldn't have shown it. The lesson: any \"force this state\" code must run OUTSIDE any wrapper that touches the same state on cleanup.