### PR TITLE
fix(stop-gate): add narrated_future_tool_work detector

### DIFF
--- a/runtime/src/llm/chat-executor-stop-gate.test.ts
+++ b/runtime/src/llm/chat-executor-stop-gate.test.ts
@@ -160,6 +160,161 @@ describe("evaluateTurnEndStopGate (pass cases)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// detector 0: narrated_future_tool_work — model checkpointed in text
+// instead of calling the next tool
+// ---------------------------------------------------------------------------
+
+describe("evaluateTurnEndStopGate — narrated_future_tool_work", () => {
+  // Live trigger from session at 2026-04-09 19:33 (chat.message at
+  // 01:33:34.469Z): the model emitted "Next tool calls will implement
+  // lexer.c from PLAN.md specs." as a final reply. The user had said
+  // "do not stop until every single phase has been implemented" so the
+  // model checkpointed instead of asking permission. The chat-executor
+  // saw text-only -> turn ended.
+  it("fires on the exact 'Next tool calls will...' pattern from the live trace", () => {
+    const decision = evaluateTurnEndStopGate({
+      finalContent:
+        "**Project structure created per @PLAN.md Phase 1: directories, " +
+        "CMakeLists.txt, headers, utils.c stub, shell.c stub. Build " +
+        "blocked by missing lexer/parser/executor implementations and " +
+        "some utils compilation issues (fixed in latest write). Ready " +
+        "for Phase 2 lexer implementation.**\n\nNext tool calls will " +
+        "implement lexer.c from PLAN.md specs.",
+      allToolCalls: [
+        bashSuccess("mkdir src"),
+        bashSuccess("touch src/lexer.c"),
+        bashSuccess("cmake .."),
+      ],
+    });
+    expect(decision.shouldIntervene).toBe(true);
+    expect(decision.reason).toBe("narrated_future_tool_work");
+    expect(decision.blockingMessage).toContain("NARRATED");
+    expect(decision.blockingMessage).toContain("ONE recovery turn");
+    expect(decision.blockingMessage).toContain("Next tool calls will");
+  });
+
+  it("fires on 'Now I will write the parser'", () => {
+    // No success-claim prefix and length > TRUNCATED_SUCCESS_MAX_CHARS
+    // so truncated_success_claim does not pre-empt narrated.
+    const decision = evaluateTurnEndStopGate({
+      finalContent:
+        "Lexer scaffolding is in place across src/lexer.c and tests/lexer_test.c. " +
+        "Now I will write the parser to handle pipelines.",
+      allToolCalls: [bashSuccess("ls")],
+    });
+    expect(decision.shouldIntervene).toBe(true);
+    expect(decision.reason).toBe("narrated_future_tool_work");
+  });
+
+  it("fires on \"Next, I'll create the executor\"", () => {
+    const decision = evaluateTurnEndStopGate({
+      finalContent:
+        "Lexer scaffolding written. Next, I'll create the executor module.",
+      allToolCalls: [bashSuccess("ls")],
+    });
+    expect(decision.shouldIntervene).toBe(true);
+    expect(decision.reason).toBe("narrated_future_tool_work");
+  });
+
+  it("fires on 'Going to implement Phase 2 now'", () => {
+    const decision = evaluateTurnEndStopGate({
+      finalContent: "Phase 1 stubs in place. Going to implement Phase 2 now.",
+      allToolCalls: [bashSuccess("ls")],
+    });
+    expect(decision.shouldIntervene).toBe(true);
+    expect(decision.reason).toBe("narrated_future_tool_work");
+  });
+
+  it("fires on \"I'll continue with the build fix\"", () => {
+    const decision = evaluateTurnEndStopGate({
+      finalContent:
+        "First pass scaffolding complete. I'll continue with the build fix in the next round.",
+      allToolCalls: [bashSuccess("ls")],
+    });
+    expect(decision.shouldIntervene).toBe(true);
+    expect(decision.reason).toBe("narrated_future_tool_work");
+  });
+
+  it("fires on 'Next step is to run cmake'", () => {
+    const decision = evaluateTurnEndStopGate({
+      finalContent:
+        "Source files are written. Next step is to run cmake and verify the build.",
+      allToolCalls: [bashSuccess("ls")],
+    });
+    expect(decision.shouldIntervene).toBe(true);
+    expect(decision.reason).toBe("narrated_future_tool_work");
+  });
+
+  it("fires on 'Continuing with Phase 3'", () => {
+    const decision = evaluateTurnEndStopGate({
+      finalContent:
+        "Wrote parser tests in tests/parser_test.c and verified the " +
+        "AST matches expected shape. Continuing with Phase 3 now.",
+      allToolCalls: [bashSuccess("ls")],
+    });
+    expect(decision.shouldIntervene).toBe(true);
+    expect(decision.reason).toBe("narrated_future_tool_work");
+  });
+
+  it("fires on 'Moving on to lexer implementation'", () => {
+    const decision = evaluateTurnEndStopGate({
+      finalContent:
+        "Stubs in place. Moving on to lexer implementation in the next turn.",
+      allToolCalls: [bashSuccess("ls")],
+    });
+    expect(decision.shouldIntervene).toBe(true);
+    expect(decision.reason).toBe("narrated_future_tool_work");
+  });
+
+  it("does NOT fire when the model says 'task complete'", () => {
+    // Test message must be > TRUNCATED_SUCCESS_MAX_CHARS (100) so the
+    // truncated_success_claim detector does not also fire on the
+    // success-claim phrasing.
+    const decision = evaluateTurnEndStopGate({
+      finalContent:
+        "All phases implemented. Task complete. I'll continue with " +
+        "maintenance items if you need them later, but the primary " +
+        "task you asked for is fully done and the binary is built " +
+        "and tests are passing across the entire suite.",
+      allToolCalls: [bashSuccess("ls"), bashSuccess("make")],
+    });
+    expect(decision.shouldIntervene).toBe(false);
+  });
+
+  it("does NOT fire when the model says 'all phases implemented'", () => {
+    const decision = evaluateTurnEndStopGate({
+      finalContent:
+        "All phases implemented successfully. Ready for the next user " +
+        "request whenever you have one. The codebase compiles cleanly " +
+        "and all tests pass with no warnings, and the implementation " +
+        "follows every spec in PLAN.md exactly.",
+      allToolCalls: [bashSuccess("ls")],
+    });
+    expect(decision.shouldIntervene).toBe(false);
+  });
+
+  it("does NOT fire on a fresh greeting turn with no tool calls", () => {
+    // Empty allToolCalls means this is the first model call. The model
+    // is not checkpointing mid-task; it's starting a conversation.
+    const decision = evaluateTurnEndStopGate({
+      finalContent:
+        "I'll run the tests for you. Let me call system.bash now.",
+      allToolCalls: [],
+    });
+    expect(decision.shouldIntervene).toBe(false);
+  });
+
+  it("does NOT fire on a normal text response without future-work narration", () => {
+    const decision = evaluateTurnEndStopGate({
+      finalContent:
+        "I checked the file and it looks correct. The output matches what you expected.",
+      allToolCalls: [readFile("src/main.c")],
+    });
+    expect(decision.shouldIntervene).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // detector 1: anti-fab refusal + success claim
 // ---------------------------------------------------------------------------
 

--- a/runtime/src/llm/chat-executor-stop-gate.ts
+++ b/runtime/src/llm/chat-executor-stop-gate.ts
@@ -98,6 +98,59 @@ const ANTI_FAB_REFUSAL_REASON_KEYWORDS: readonly string[] = [
 const TRUNCATED_SUCCESS_MAX_CHARS = 100;
 
 /**
+ * Phrases the model emits when it has decided to checkpoint with a
+ * narration of future tool work INSTEAD of actually calling those tools.
+ *
+ * Sourced from real failure traces 2026-04-09 19:33 (session
+ * `3e887760...` call_2 final reply at 01:33:34.469Z): the model said
+ * "Next tool calls will implement lexer.c from PLAN.md specs." and then
+ * stopped, even though the user had explicitly said "do not stop until
+ * every single phase has been implemented." The chat-executor's tool
+ * loop sees `finishReason !== "tool_calls"` and exits, so the
+ * narration becomes a hard turn boundary.
+ *
+ * This pattern is structurally identical to "Continue to Phase N?" from
+ * pre-PR-#309: the model is checkpointing with text instead of doing the
+ * work. PR #309 forbade question-form permission asks but did not cover
+ * statement-form intent narration. The verbs are intentionally broad —
+ * the goal is to catch every flavor of "I'm pausing to talk about the
+ * next tool call instead of just calling it" while not interfering with
+ * legitimate completion summaries.
+ *
+ * Examples that should match:
+ *   - "Next tool calls will implement lexer.c"
+ *   - "Now I will write the parser"
+ *   - "Next, I'll create the executor"
+ *   - "Going to implement Phase 2 now"
+ *   - "I'll continue with the build fix"
+ *   - "Next step is to run cmake"
+ *   - "Let me run the test now"
+ *   - "Continuing with Phase 3"
+ *   - "Moving on to lexer implementation"
+ *   - "Proceeding to write builtins.c"
+ *   - "About to implement parser"
+ *
+ * Examples that should NOT match (legitimate completion summaries):
+ *   - "Phase 0 complete. Tests passed."
+ *   - "All phases implemented successfully."
+ *   - "Task done. Binary built and tests passing."
+ */
+const NARRATED_FUTURE_TOOL_WORK_RE =
+  /\b(?:next\s+tool\s+calls?\s+(?:will|should|must)|now\s+I\s+(?:will|need\s+to|am\s+going\s+to|am\s+about\s+to)|now\s+I[''']?ll|next,?\s+I\s+(?:will|need\s+to|am\s+going\s+to|am\s+about\s+to)|next,?\s+I[''']?ll|going\s+to\s+(?:call|invoke|run|execute|implement|write|create|continue|start|finish|build|compile|test|fix|add|edit|update|generate|produce|stub|complete)|I[''']?ll\s+(?:call|invoke|run|execute|implement|write|create|continue|start|finish|build|compile|test|fix|add|edit|update|generate|produce|stub|complete)|next\s+step\s+(?:is|will\s+be)\s+to|let\s+me\s+(?:call|invoke|run|execute|implement|write|create|continue|start|finish|build|compile|test|fix|add|edit|update|generate|produce|stub|complete)|I\s+will\s+now\s+(?:call|invoke|run|execute|implement|write|create|continue|start|finish|build|compile|test|fix|add|edit|update|generate|produce|stub|complete)|continuing\s+(?:with|to)\s+\w+|moving\s+on\s+to\s+\w+|proceeding\s+(?:to|with)\s+\w+|about\s+to\s+(?:call|invoke|run|execute|implement|write|create|continue|start|finish|build|compile|test|fix|add|edit|update|generate|produce|stub|complete)|will\s+now\s+(?:implement|write|create|build|compile|test|fix|continue))/i;
+
+/**
+ * Phrases that explicitly mark the turn as terminally complete. When the
+ * final assistant text contains one of these AND the
+ * `NARRATED_FUTURE_TOOL_WORK_RE` would otherwise match, treat the
+ * narration as a legitimate "here is what would come next if the user
+ * asked for more" closing rather than a checkpoint. The narration
+ * detector skips the turn in that case so genuine session-end summaries
+ * are not forced into a recovery loop.
+ */
+const TERMINAL_COMPLETION_RE =
+  /\b(?:task\s+(?:complete|completed|done|finished)|all\s+phases?\s+(?:complete|completed|done|finished|implemented)|implementation\s+(?:complete|completed|done|finished)|nothing\s+(?:more|else)\s+to\s+(?:do|implement)|session\s+(?:complete|done|finished)|finished\s+the\s+(?:task|work|implementation|plan)|project\s+(?:complete|completed|done|finished))/i;
+
+/**
  * Tool names whose failures count as "this turn had a failed shell
  * command", which is the strongest signal that a success claim is fake.
  * Reading file errors and lookup failures are excluded to avoid
@@ -122,7 +175,8 @@ const SHELL_LIKE_TOOL_NAMES: ReadonlySet<string> = new Set([
 export type StopGateInterventionReason =
   | "false_success_after_failed_bash"
   | "false_success_after_anti_fab_refusal"
-  | "truncated_success_claim";
+  | "truncated_success_claim"
+  | "narrated_future_tool_work";
 
 export interface StopGateEvidence {
   /** Number of `system.bash` / `desktop.bash` calls in the turn that returned `isError: true`. */
@@ -236,6 +290,21 @@ function buildBlockingMessage(params: {
           `an incomplete summary. Either way, the user cannot act on this.`,
       );
       break;
+    case "narrated_future_tool_work":
+      lines.push(
+        `Your previous reply NARRATED future tool work in plain text ` +
+          `instead of actually calling the tools. The runtime's tool ` +
+          `loop sees a text-only response as the end of the turn, so ` +
+          `your "next, I'll implement X" / "going to call Y" / "next ` +
+          `tool calls will Z" sentence is interpreted as "I am stopping ` +
+          `here." The user explicitly told you to keep going until the ` +
+          `work is done — they have NOT asked for a status update or a ` +
+          `preview of upcoming steps.`,
+      );
+      lines.push("");
+      lines.push(`The exact narration that triggered this stop:`);
+      lines.push(`  > ${truncate(params.finalContent.trim(), 400)}`);
+      break;
   }
 
   if (params.failedShellCalls.length > 0) {
@@ -254,23 +323,44 @@ function buildBlockingMessage(params: {
   }
 
   lines.push("");
-  lines.push(
-    `You have ONE recovery turn. Either:`,
-  );
-  lines.push(
-    `  (a) Make tool calls to actually fix the underlying causes, or`,
-  );
-  lines.push(
-    `  (b) Retract the success claim in plain English, list which steps ` +
-      `actually failed, and explain the blockers (e.g. missing system ` +
-      `package, configuration error, file permissions). Be specific.`,
-  );
-  lines.push("");
-  lines.push(
-    `Do NOT repeat the success claim. Do NOT narrate that "everything ` +
-      `worked despite minor issues" — the runtime tool ledger is the ` +
-      `source of truth, and it shows failures.`,
-  );
+  if (params.reason === "narrated_future_tool_work") {
+    lines.push(
+      `You have ONE recovery turn. In this turn you MUST:`,
+    );
+    lines.push(
+      `  • Call the tools you said you were going to call. ` +
+        `Do NOT preview them, do NOT explain what you are about to do, ` +
+        `do NOT ask permission, do NOT checkpoint. Just CALL the tools.`,
+    );
+    lines.push("");
+    lines.push(
+      `Do NOT emit another text-only message that talks about future ` +
+        `tool calls. The runtime treats text-only as turn-end. If you ` +
+        `genuinely cannot proceed (waiting on credentials, blocked by an ` +
+        `external decision, hit a hard error you have already fixed and ` +
+        `are confident requires human input), say so explicitly with ` +
+        `the exact blocker — but only after you have actually attempted ` +
+        `the next tool call.`,
+    );
+  } else {
+    lines.push(
+      `You have ONE recovery turn. Either:`,
+    );
+    lines.push(
+      `  (a) Make tool calls to actually fix the underlying causes, or`,
+    );
+    lines.push(
+      `  (b) Retract the success claim in plain English, list which steps ` +
+        `actually failed, and explain the blockers (e.g. missing system ` +
+        `package, configuration error, file permissions). Be specific.`,
+    );
+    lines.push("");
+    lines.push(
+      `Do NOT repeat the success claim. Do NOT narrate that "everything ` +
+        `worked despite minor issues" — the runtime tool ledger is the ` +
+        `source of truth, and it shows failures.`,
+    );
+  }
 
   return lines.join("\n");
 }
@@ -365,7 +455,18 @@ export function evaluateTurnEndStopGate(
 
   const claimsSuccess = FALSE_SUCCESS_RE.test(finalContent);
   if (!claimsSuccess) {
-    return { shouldIntervene: false, evidence };
+    // Skip the success-claim detectors but still check the
+    // narrated-future-tool-work detector below — narration without a
+    // false success claim is the post-PR-#309 checkpointing failure
+    // mode and is the only thing the gate should fire on for an
+    // honest-but-stalling reply.
+    return maybeFireNarratedFutureToolWork({
+      finalContent,
+      allToolCalls,
+      failedShellCalls,
+      refusedCalls,
+      evidence,
+    });
   }
 
   const acknowledgesFailure = FAILURE_ACKNOWLEDGMENT_RE.test(finalContent);
@@ -421,7 +522,57 @@ export function evaluateTurnEndStopGate(
     };
   }
 
-  return { shouldIntervene: false, evidence };
+  // Detector 4 (lowest priority): the model claimed success but ALSO
+  // narrated future tool work. This catches the post-PR-#309 stall
+  // pattern even when the model wraps it in success language ("Phase 0
+  // complete. Now I will write the lexer.") — the success claim alone
+  // might be honest but stopping after it when the user said "do not
+  // stop" is the actual failure mode.
+  return maybeFireNarratedFutureToolWork({
+    finalContent,
+    allToolCalls,
+    failedShellCalls,
+    refusedCalls,
+    evidence,
+  });
+}
+
+/**
+ * Helper for the narrated-future-tool-work detector. Called from two
+ * branches of `evaluateTurnEndStopGate`: once when there is no false
+ * success claim at all (the honest-but-stalling case) and once at the
+ * very bottom of the function as the lowest-priority detector after
+ * the false-success branches fail to match.
+ *
+ * The check skips when the text contains a TERMINAL_COMPLETION_RE
+ * marker (legitimate end-of-task) or when the turn made zero tool
+ * calls (fresh greeting/question, not mid-task checkpointing).
+ */
+function maybeFireNarratedFutureToolWork(params: {
+  readonly finalContent: string;
+  readonly allToolCalls: readonly ToolCallRecord[];
+  readonly failedShellCalls: readonly ToolCallRecord[];
+  readonly refusedCalls: readonly ToolCallRecord[];
+  readonly evidence: StopGateEvidence;
+}): StopGateInterventionDecision {
+  if (
+    params.allToolCalls.length > 0 &&
+    NARRATED_FUTURE_TOOL_WORK_RE.test(params.finalContent) &&
+    !TERMINAL_COMPLETION_RE.test(params.finalContent)
+  ) {
+    return {
+      shouldIntervene: true,
+      reason: "narrated_future_tool_work",
+      blockingMessage: buildBlockingMessage({
+        reason: "narrated_future_tool_work",
+        finalContent: params.finalContent,
+        failedShellCalls: params.failedShellCalls,
+        refusedCalls: params.refusedCalls,
+      }),
+      evidence: params.evidence,
+    };
+  }
+  return { shouldIntervene: false, evidence: params.evidence };
 }
 
 // ---------------------------------------------------------------------------
@@ -432,6 +583,8 @@ export function evaluateTurnEndStopGate(
 export const __TESTING__ = {
   FALSE_SUCCESS_RE,
   FAILURE_ACKNOWLEDGMENT_RE,
+  NARRATED_FUTURE_TOOL_WORK_RE,
+  TERMINAL_COMPLETION_RE,
   TRUNCATED_SUCCESS_MAX_CHARS,
   ANTI_FAB_REFUSAL_REASON_KEYWORDS,
 };


### PR DESCRIPTION
## Summary

Adds a fourth detector to the chat-executor turn-end stop gate: \`narrated_future_tool_work\`. Catches the post-PR-#309 \"checkpoint with statement-form intent narration\" stall mode that PR #309 (forbidding question-form permission asks) didn't cover.

## The bug

PR #309 made the model stop using \`\"Continue to Phase N?\"\` style permission asks. The model adapted: it now ends turns with statement-form narration like \`\"Next tool calls will implement lexer.c from PLAN.md specs.\"\` and stops. The chat-executor tool loop still sees \`finishReason !== \"tool_calls\"\` and exits, exactly the same hard turn boundary.

Live trigger captured 2026-04-09 19:33:34 in session \`3e887760...\` chat.message at \`01:33:34.469Z\`:

\`\`\`
**Project structure created per @PLAN.md Phase 1: directories, CMakeLists.txt,
headers, utils.c stub, shell.c stub. Build blocked by missing lexer/parser/executor
implementations and some utils compilation issues (fixed in latest write).
Ready for Phase 2 lexer implementation.**

Next tool calls will implement lexer.c from PLAN.md specs.
\`\`\`

The agent had produced 37 successful tool calls in the turn, ran into compile errors, made an honest partial-progress report, then narrated future work and stopped. The user had explicitly said *\"do not stop until every single phase has been implemented.\"*

None of the existing detectors caught this:
- \`false_success_after_failed_bash\`: text honestly acknowledges failure (\"build blocked\"), so \`FAILURE_ACKNOWLEDGMENT_RE\` matches and the detector skips
- \`false_success_after_anti_fab_refusal\`: no anti-fab refusals in the ledger
- \`truncated_success_claim\`: text is too long (302 chars)
- Strict-filter post-flight \`silent_tool_drop_promised_in_text\`: \`PROMISE_LANGUAGE_RE\` only matches verbs \`call|invoke|run|execute\`. The agent said \"will implement\" which doesn't match.

## Fix

New detector \`narrated_future_tool_work\` in \`runtime/src/llm/chat-executor-stop-gate.ts\` with:

**\`NARRATED_FUTURE_TOOL_WORK_RE\`** — broad regex for checkpointing patterns:
- \`Next tool calls will|should|must\`
- \`Now I (will|need to|am going to|am about to)\` / \`Now I'll\`
- \`Next, I (will|need to|...)\` / \`Next, I'll\`
- \`Going to (call|invoke|run|execute|implement|write|create|continue|start|finish|build|compile|test|fix|add|edit|update|generate|produce|stub|complete)\`
- \`I'll (call|...|complete)\`
- \`Next step (is|will be) to\`
- \`Let me (call|...|complete)\`
- \`I will now (call|...|complete)\`
- \`Continuing with X\` / \`Moving on to X\` / \`Proceeding to X\` (any noun)
- \`About to (call|...|complete)\`
- \`Will now (implement|write|create|build|compile|test|fix|continue)\`

**\`TERMINAL_COMPLETION_RE\`** — escape hatch for genuine end-of-task messages:
- \`task (complete|completed|done|finished)\`
- \`all phases (complete|completed|done|finished|implemented)\`
- \`implementation (complete|...|finished)\`
- \`nothing (more|else) to (do|implement)\`
- \`session (complete|done|finished)\`
- \`finished the (task|work|implementation|plan)\`
- \`project (complete|...|finished)\`

When the message contains a TERMINAL_COMPLETION marker the narrated detector skips, so legitimate \"task complete. I'll continue with maintenance items if you ask\" closings don't get force-recovered.

**Detector priority**: narrated is placed at LOWEST priority so the existing false-success detectors (which catch the model lying about work — a more serious failure) win when both apply. The narrated detector only fires when the message has no false success claim, OR when the message has a success claim but none of the failure-evidence detectors found anything to fire on.

**Blocking message**: tells the model to actually CALL the tools it narrated. Explicitly forbids previewing/explaining/checkpointing/asking-permission in the recovery turn. Genuine blockers (credentials, external decisions) are still legitimate escalation reasons.

## Test plan

- [x] \`npm run typecheck --workspace=@tetsuo-ai/runtime\` — clean
- [x] 12 new tests in \`chat-executor-stop-gate.test.ts\`:
  - Exact \`Next tool calls will implement lexer.c\` live trigger
  - \`Now I will write the parser\`
  - \`Next, I'll create the executor\`
  - \`Going to implement Phase 2 now\`
  - \`I'll continue with the build fix\`
  - \`Next step is to run cmake\`
  - \`Continuing with Phase 3\`
  - \`Moving on to lexer implementation\`
  - Negative: \`task complete\` (TERMINAL escape)
  - Negative: \`all phases implemented\` (TERMINAL escape)
  - Negative: fresh greeting with no tool calls
  - Negative: normal text reply with no future-work narration
- [x] **66/66 stop gate tests pass** (was 54)
- [x] **650/650 src/llm tests pass** (was 638)
- [ ] Rebuild + dist sync + daemon restart
- [ ] Re-run the prompt that previously stopped at \"Next tool calls will implement lexer.c\". Expected: stop gate fires, recovery message tells the model to CALL the tools, model implements lexer.c, parser, executor, builtins, etc. without emitting more checkpointing narration.

## Out of scope

- A persistent runtime metric counting how often the gate fires per session (would be useful for measuring the rate of post-fix regressions)
- Auto-tuning the regex from production traces (would be useful but requires a feedback loop we don't have)