### PR TITLE
feat(runtime): artifact-evidence gate + top-level verifier worker

### DIFF
--- a/.claude/notes/gotchas.md
+++ b/.claude/notes/gotchas.md
@@ -14,3 +14,12 @@
 - `agenc ui` serves the runtime package's installed `dist/dashboard` assets, not the raw `agenc-core/web` source tree.
 - Rebuilding `@tetsuo-ai/runtime` without also rebuilding/syncing the dashboard artifacts leaves the daemon healthy but makes `agenc ui` fail with "dashboard assets are unavailable".
 - Keep dashboard asset generation in the runtime build path so ordinary runtime rebuilds cannot ship an empty dashboard surface.
+
+## Top-level workflow completion depends on contract carryover, not just stop-gate prose checks
+- If `resolveTurnExecutionContract()` collapses an implementation turn back to `dialogue`, top-level execution loses the verification/completion contract and the artifact-evidence gate never sees the target artifacts.
+- Preserve workflow carryover from `activeTaskContext`, and make finalization derive completion/progress from the carried contract rather than passing `undefined` contracts through the request path.
+- Without that plumbing, the model can stop on `finishReason: "stop"` and fabricate completion summaries even when only a subset of target files were actually written.
+
+## Declarative agent definitions are inert until the sub-agent runtime can carry a per-child system prompt
+- Loading `runtime/src/gateway/agent-definitions/*.md` into `Daemon._agentDefinitions` is not enough by itself; the child needs the markdown body wired into its own system prompt, not merely stuffed into the user task text.
+- Without a per-child system prompt override, verifier workers fall back to the generic sub-agent prompt and the `verify.md` contract never actually governs the child turn.

--- a/runtime/src/gateway/agent-definitions/verify.md
+++ b/runtime/src/gateway/agent-definitions/verify.md
@@ -1,0 +1,33 @@
+---
+name: verify
+description: Verification specialist that tries to break completed implementation work
+model: inherit
+tools: [system.readFile, system.listDir, system.stat, system.bash]
+maxTurns: 8
+---
+
+You are a verification agent. Your job is not to explain why the
+implementation looks correct. Your job is to run the checks that can
+prove it is wrong.
+
+Rules:
+- Read-only inside the project workspace. Do not create, edit, move, or
+  delete project files.
+- Run real commands. Reading code is context, not verification.
+- Start with the project's documented build and test commands, then run
+  at least one adversarial probe that matches the change type.
+- If something cannot be verified because the environment is missing a
+  dependency, command, or service, say exactly what blocked it.
+
+Output format:
+- `### Check: ...`
+- `Command run:`
+- `Output observed:`
+- `Result: PASS|FAIL`
+
+End with exactly one line:
+`VERDICT: PASS`
+or
+`VERDICT: FAIL`
+or
+`VERDICT: PARTIAL`

--- a/runtime/src/gateway/channel-wiring.ts
+++ b/runtime/src/gateway/channel-wiring.ts
@@ -48,6 +48,9 @@ import { formatForChannel } from "./format.js";
 import { executeTextChannelTurn } from "./daemon-text-channel-turn.js";
 import type { ToolRoutingDecision } from "./tool-routing.js";
 import { loadConfiguredPluginChannel } from "../plugins/channel-loader.js";
+import type { AgentDefinition } from "./agent-loader.js";
+import type { DelegationVerifierService } from "./delegation-runtime.js";
+import type { SubAgentManager } from "./sub-agent.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -113,6 +116,10 @@ export interface ChannelWiringDeps {
     sessionId: string,
     summary: ChatToolRoutingSummary | undefined,
   ): void;
+
+  readonly subAgentManager?: Pick<SubAgentManager, "spawn" | "waitForResult"> | null;
+  readonly verifierService?: Pick<DelegationVerifierService, "shouldVerifySubAgentResult"> | null;
+  readonly agentDefinitions?: readonly AgentDefinition[];
 }
 
 // ---------------------------------------------------------------------------
@@ -330,6 +337,9 @@ async function wireTelegram(
         recordToolRoutingOutcome: (sessionId, summary) => {
           deps.recordToolRoutingOutcome(sessionId, summary);
         },
+        subAgentManager: deps.subAgentManager ?? null,
+        verifierService: deps.verifierService ?? null,
+        agentDefinitions: deps.agentDefinitions,
       });
 
       deps.logger.debug("Telegram reply ready", {
@@ -521,6 +531,9 @@ export async function wireExternalChannel(
         recordToolRoutingOutcome: (sessionId, summary) => {
           deps.recordToolRoutingOutcome(sessionId, summary);
         },
+        subAgentManager: deps.subAgentManager ?? null,
+        verifierService: deps.verifierService ?? null,
+        agentDefinitions: deps.agentDefinitions,
       });
 
       const formatted = formatForChannel(

--- a/runtime/src/gateway/daemon-text-channel-turn.test.ts
+++ b/runtime/src/gateway/daemon-text-channel-turn.test.ts
@@ -5,6 +5,7 @@ import type { MemoryBackend } from "../memory/types.js";
 import type { Logger } from "../utils/logger.js";
 import { executeTextChannelTurn } from "./daemon-text-channel-turn.js";
 import {
+  SESSION_ACTIVE_TASK_CONTEXT_METADATA_KEY,
   SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY,
   type Session,
 } from "./session.js";
@@ -259,6 +260,82 @@ describe("executeTextChannelTurn", () => {
       previousResponseId: "resp-next",
       reconciliationHash: "hash-next",
     });
+  });
+
+  it("passes persisted active task context into the executor and stores the updated lineage", async () => {
+    const logger = createLoggerStub();
+    const session = createSession();
+    session.metadata[SESSION_ACTIVE_TASK_CONTEXT_METADATA_KEY] = {
+      version: 1,
+      taskLineageId: "task-phase-0",
+      contractFingerprint: "phase-0-contract",
+      turnClass: "workflow_implementation",
+      ownerMode: "workflow_owner",
+      workspaceRoot: "/workspace",
+      sourceArtifacts: ["/workspace/PLAN.md"],
+      targetArtifacts: ["/workspace/src/main.c"],
+    };
+    const sessionMgr = {
+      appendMessage: vi.fn(),
+    } as any;
+    const nextActiveTaskContext = {
+      version: 1 as const,
+      taskLineageId: "task-phase-0",
+      contractFingerprint: "phase-1-contract",
+      turnClass: "workflow_implementation" as const,
+      ownerMode: "workflow_owner" as const,
+      workspaceRoot: "/workspace",
+      sourceArtifacts: ["/workspace/PLAN.md"],
+      targetArtifacts: ["/workspace/src/main.c"],
+    };
+    const execute = vi.fn(async () =>
+      createResult({
+        activeTaskContext: nextActiveTaskContext,
+      }),
+    );
+
+    await executeTextChannelTurn({
+      logger,
+      channelName: "telegram",
+      msg: {
+        sessionId: "session:test",
+        senderId: "user-1",
+        channel: "telegram",
+        content: "implement phase 0",
+      },
+      session,
+      sessionMgr,
+      systemPrompt: "system",
+      chatExecutor: { execute } as any,
+      toolHandler: vi.fn() as any,
+      defaultMaxToolRounds: 3,
+      traceConfig: {
+        enabled: false,
+        includeHistory: true,
+        includeSystemPrompt: true,
+        includeToolArgs: true,
+        includeToolResults: true,
+        includeProviderPayloads: false,
+        maxChars: 20_000,
+      },
+      turnTraceId: "trace-active-task",
+      buildToolRoutingDecision: () => undefined,
+      recordToolRoutingOutcome: vi.fn(),
+    });
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeContext: expect.objectContaining({
+          activeTaskContext: expect.objectContaining({
+            contractFingerprint: "phase-0-contract",
+            taskLineageId: "task-phase-0",
+          }),
+        }),
+      }),
+    );
+    expect(session.metadata[SESSION_ACTIVE_TASK_CONTEXT_METADATA_KEY]).toEqual(
+      nextActiveTaskContext,
+    );
   });
 
   it("passes a strict structured-output contract for Concordia agent generation turns", async () => {

--- a/runtime/src/gateway/daemon-text-channel-turn.ts
+++ b/runtime/src/gateway/daemon-text-channel-turn.ts
@@ -25,9 +25,15 @@ import {
   isConcordiaGenerateAgentsMessage,
 } from "../llm/chat-executor-turn-contracts.js";
 import {
+  buildSessionActiveTaskContext,
   buildSessionStatefulOptions,
+  persistSessionActiveTaskContext,
   persistSessionStatefulContinuation,
 } from "./daemon-session-state.js";
+import { maybeRunTopLevelVerifier } from "./top-level-verifier.js";
+import type { AgentDefinition } from "./agent-loader.js";
+import type { DelegationVerifierService } from "./delegation-runtime.js";
+import type { SubAgentManager } from "./sub-agent.js";
 import { filterSystemPromptForToolRouting } from "./system-prompt-routing.js";
 import {
   logExecutionTraceEvent,
@@ -116,6 +122,9 @@ interface ExecuteTextChannelTurnParams {
     summary: ChatToolRoutingSummary | undefined,
   ) => void;
   readonly persistToDaemonMemory?: boolean;
+  readonly subAgentManager?: Pick<SubAgentManager, "spawn" | "waitForResult"> | null;
+  readonly verifierService?: Pick<DelegationVerifierService, "shouldVerifySubAgentResult"> | null;
+  readonly agentDefinitions?: readonly AgentDefinition[];
 }
 
 export async function executeTextChannelTurn(
@@ -139,6 +148,9 @@ export async function executeTextChannelTurn(
     buildToolRoutingDecision,
     recordToolRoutingOutcome,
     persistToDaemonMemory = shouldPersistToDaemonMemory(msg),
+    subAgentManager = null,
+    verifierService = null,
+    agentDefinitions,
   } = params;
 
   const toolRoutingDecision = buildToolRoutingDecision(
@@ -219,6 +231,7 @@ export async function executeTextChannelTurn(
   }
 
   const sessionStateful = buildSessionStatefulOptions(session);
+  const sessionActiveTaskContext = buildSessionActiveTaskContext(session);
   const isConcordiaGenerateAgentsTurn = isConcordiaGenerateAgentsMessage(msg);
   const structuredOutput =
     buildConcordiaGenerateAgentsStructuredOutput(msg);
@@ -231,11 +244,14 @@ export async function executeTextChannelTurn(
   // direct chatExecutor.execute() call under the adapter shape —
   // Phase F will swap the underlying orchestration without
   // touching this call site.
-  const result = await executeChatToLegacyResult(chatExecutor, {
+  const rawResult = await executeChatToLegacyResult(chatExecutor, {
     message: msg,
     history: session.history,
     systemPrompt: effectiveSystemPrompt,
     sessionId: msg.sessionId,
+    ...(sessionActiveTaskContext
+      ? { runtimeContext: { activeTaskContext: sessionActiveTaskContext } }
+      : {}),
     toolHandler,
     maxToolRounds: effectiveMaxToolRounds,
     ...(sessionStateful ? { stateful: sessionStateful } : {}),
@@ -281,6 +297,15 @@ export async function executeTextChannelTurn(
           },
         }
       : {}),
+  });
+  const result = await maybeRunTopLevelVerifier({
+    sessionId: msg.sessionId,
+    userRequest: msg.content,
+    result: rawResult,
+    subAgentManager,
+    verifierService,
+    agentDefinitions,
+    logger,
   });
   recordToolRoutingOutcome(msg.sessionId, result.toolRoutingSummary);
 
@@ -381,6 +406,7 @@ export async function executeTextChannelTurn(
   }
 
   persistSessionStatefulContinuation(session, result);
+  persistSessionActiveTaskContext(session, result);
   sessionMgr.appendMessage(session.id, {
     role: "user",
     content: msg.content,

--- a/runtime/src/gateway/daemon-webchat-turn.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.ts
@@ -24,6 +24,7 @@ import {
   persistSessionStatefulContinuation,
   persistWebSessionRuntimeState,
 } from "./daemon-session-state.js";
+import { maybeRunTopLevelVerifier } from "./top-level-verifier.js";
 import { filterSystemPromptForToolRouting } from "./system-prompt-routing.js";
 import {
   logExecutionTraceEvent,
@@ -50,6 +51,9 @@ import type { Session, SessionManager } from "./session.js";
 import type { ToolRoutingDecision } from "./tool-routing.js";
 import { resolveTurnMaxToolRounds } from "./tool-round-budget.js";
 import { buildAssistantDelegatedScopeMetadata } from "../utils/delegated-scope-trust.js";
+import type { AgentDefinition } from "./agent-loader.js";
+import type { DelegationVerifierService } from "./delegation-runtime.js";
+import type { SubAgentManager } from "./sub-agent.js";
 
 interface WebChatTurnSignals {
   signalThinking: (sessionId: string) => void;
@@ -85,6 +89,9 @@ interface ExecuteWebChatConversationTurnParams {
   readonly getSessionTokenUsage: (sessionId: string) => number;
   readonly onModelInfo?: (result: ChatExecutorResult) => void;
   readonly onSubagentSynthesis?: (result: ChatExecutorResult) => void;
+  readonly subAgentManager?: Pick<SubAgentManager, "spawn" | "waitForResult"> | null;
+  readonly verifierService?: Pick<DelegationVerifierService, "shouldVerifySubAgentResult"> | null;
+  readonly agentDefinitions?: readonly AgentDefinition[];
 }
 
 async function resolveWebChatTurnWorkspaceRoot(params: {
@@ -136,6 +143,9 @@ export async function executeWebChatConversationTurn(
     getSessionTokenUsage,
     onModelInfo,
     onSubagentSynthesis,
+    subAgentManager = null,
+    verifierService = null,
+    agentDefinitions,
   } = params;
 
   try {
@@ -247,7 +257,7 @@ export async function executeWebChatConversationTurn(
     // stream chunk through the supplied callback before yielding
     // the event, so the caller-visible callback behavior is
     // identical to the direct chatExecutor.execute() call.
-    const result = await executeChatToLegacyResult(chatExecutor, {
+    const rawResult = await executeChatToLegacyResult(chatExecutor, {
       message: effectiveMessage,
       history: session.history,
       systemPrompt: effectiveSystemPrompt,
@@ -304,6 +314,15 @@ export async function executeWebChatConversationTurn(
           }
         },
       },
+    });
+    const result = await maybeRunTopLevelVerifier({
+      sessionId: msg.sessionId,
+      userRequest: msg.content,
+      result: rawResult,
+      subAgentManager,
+      verifierService,
+      agentDefinitions,
+      logger,
     });
     recordToolRoutingOutcome(msg.sessionId, result.toolRoutingSummary);
 

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -3174,6 +3174,9 @@ export class DaemonManager {
       recordToolRoutingOutcome: () => {
         /* no-op: static routing, nothing to record */
       },
+      subAgentManager: this._subAgentManager,
+      verifierService: this._delegationVerifierService,
+      agentDefinitions: this._agentDefinitions,
     };
   }
 
@@ -5715,6 +5718,9 @@ export class DaemonManager {
           this._subagentActivityTraceBySession.delete(msg.sessionId);
           this._latestDelegationSurfaceContextBySession.delete(msg.sessionId);
         },
+        subAgentManager: this._subAgentManager,
+        verifierService: this._delegationVerifierService,
+        agentDefinitions: this._agentDefinitions,
       });
     } finally {
       this._foregroundSessionLocks.delete(msg.sessionId);

--- a/runtime/src/gateway/sub-agent.test.ts
+++ b/runtime/src/gateway/sub-agent.test.ts
@@ -974,6 +974,72 @@ describe("SubAgentManager", () => {
       }
     });
 
+    it("passes system-prompt overrides and explicit required tool evidence into child execution", async () => {
+      const executeSpy = vi.spyOn(ChatExecutor.prototype, "execute")
+        .mockResolvedValueOnce({
+          content: "VERDICT: PASS",
+          provider: "mock",
+          model: "mock",
+          usedFallback: false,
+          toolCalls: [
+            {
+              name: "system.readFile",
+              args: { path: "/workspace/src/main.ts" },
+              result: '{"ok":true}',
+              isError: false,
+              durationMs: 1,
+            },
+          ],
+          tokenUsage: {
+            promptTokens: 10,
+            completionTokens: 5,
+            totalTokens: 15,
+          },
+          callUsage: [],
+          durationMs: 1,
+          compacted: false,
+          stopReason: "completed",
+          completionState: "completed",
+        });
+
+      try {
+        const manager = new SubAgentManager(makeManagerConfig({
+          systemPrompt: "parent sub-agent prompt",
+        }));
+        const sessionId = await manager.spawn({
+          parentSessionId: "p",
+          task: "verify the implementation",
+          prompt: "Run the verifier checks",
+          systemPrompt: "verifier worker prompt",
+          tools: ["system.readFile", "system.bash"],
+          requiredToolEvidence: {
+            maxCorrectionAttempts: 1,
+            executionEnvelope: {
+              workspaceRoot: "/workspace",
+              targetArtifacts: ["/workspace/src/main.ts"],
+              verificationMode: "grounded_read",
+            },
+          },
+        });
+        await settle();
+
+        expect(manager.getResult(sessionId)?.success).toBe(true);
+        expect(executeSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            systemPrompt: "verifier worker prompt",
+            requiredToolEvidence: expect.objectContaining({
+              executionEnvelope: expect.objectContaining({
+                verificationMode: "grounded_read",
+                targetArtifacts: ["/workspace/src/main.ts"],
+              }),
+            }),
+          }),
+        );
+      } finally {
+        executeSpy.mockRestore();
+      }
+    });
+
     it("preserves child completion progress and refuses completion when the workflow state needs verification", async () => {
       const executeSpy = vi.spyOn(ChatExecutor.prototype, "execute")
         .mockResolvedValueOnce({

--- a/runtime/src/gateway/sub-agent.ts
+++ b/runtime/src/gateway/sub-agent.ts
@@ -24,6 +24,7 @@ import {
   type RuntimeBudgetMode,
 } from "../llm/run-budget.js";
 import type {
+  ChatExecuteParams,
   ChatExecutorResult,
   ToolCallRecord,
 } from "../llm/chat-executor-types.js";
@@ -147,6 +148,7 @@ export interface SubAgentConfig {
   readonly parentSessionId: string;
   readonly task: string;
   readonly prompt?: string;
+  readonly systemPrompt?: string;
   readonly continuationSessionId?: string;
   readonly timeoutMs?: number;
   readonly toolBudgetPerRequest?: number;
@@ -157,6 +159,7 @@ export interface SubAgentConfig {
   readonly requiredCapabilities?: readonly string[];
   readonly requireToolCall?: boolean;
   readonly delegationSpec?: DelegationContractSpec;
+  readonly requiredToolEvidence?: ChatExecuteParams["requiredToolEvidence"];
   readonly unsafeBenchmarkMode?: boolean;
   /**
    * Phase 2.8: Memory inheritance policy for sub-agents.
@@ -403,6 +406,14 @@ export class SubAgentManager {
     const handle = this.handles.get(sessionId);
     if (!handle) return null;
     if (handle.status === "running") return null;
+    return handle.result;
+  }
+
+  async waitForResult(sessionId: string): Promise<SubAgentResult | null> {
+    this.pruneTerminalHandles();
+    const handle = this.handles.get(sessionId);
+    if (!handle) return null;
+    await handle.execution;
     return handle.result;
   }
 
@@ -749,7 +760,9 @@ export class SubAgentManager {
       });
 
       const systemPrompt =
-        this.config.systemPrompt ?? DEFAULT_SUB_AGENT_SYSTEM_PROMPT;
+        handle.config.systemPrompt ??
+        this.config.systemPrompt ??
+        DEFAULT_SUB_AGENT_SYSTEM_PROMPT;
       const subAgentTraceId = `subagent:${handle.sessionId}:${Date.now()}`;
       const unsafeBenchmarkMode = handle.config.unsafeBenchmarkMode === true;
       const traceEnabled =
@@ -815,6 +828,26 @@ export class SubAgentManager {
         });
       }
 
+      const inheritedRequiredToolEvidence = handle.config.delegationSpec
+        ? {
+            maxCorrectionAttempts: handle.config.requireToolCall ? 1 : 0,
+            delegationSpec: handle.config.delegationSpec,
+            unsafeBenchmarkMode,
+          }
+        : undefined;
+      const explicitRequiredToolEvidence = handle.config.requiredToolEvidence;
+      const requiredToolEvidence =
+        inheritedRequiredToolEvidence || explicitRequiredToolEvidence
+          ? {
+              ...(inheritedRequiredToolEvidence ?? {}),
+              ...(explicitRequiredToolEvidence ?? {}),
+              maxCorrectionAttempts:
+                explicitRequiredToolEvidence?.maxCorrectionAttempts ??
+                inheritedRequiredToolEvidence?.maxCorrectionAttempts ??
+                0,
+            }
+          : undefined;
+
       // When the spawn comes from the orchestrator pipeline (has an
       // execution context with explicit tool scope), pass the resolved
       // tools as routedToolNames so the sub-agent's ChatExecutor uses
@@ -858,13 +891,9 @@ export class SubAgentManager {
             ...(typeof effectiveToolBudgetPerRequest === "number"
               ? { toolBudgetPerRequest: effectiveToolBudgetPerRequest }
               : {}),
-            requiredToolEvidence: handle.config.delegationSpec
-              ? {
-                maxCorrectionAttempts: handle.config.requireToolCall ? 1 : 0,
-                delegationSpec: handle.config.delegationSpec,
-                unsafeBenchmarkMode,
-              }
-              : undefined,
+            ...(requiredToolEvidence
+              ? { requiredToolEvidence }
+              : {}),
             ...(providerTrace ? { trace: providerTrace } : {}),
           },
         }),

--- a/runtime/src/gateway/top-level-verifier.test.ts
+++ b/runtime/src/gateway/top-level-verifier.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ChatExecutorResult } from "../llm/chat-executor.js";
+import { maybeRunTopLevelVerifier } from "./top-level-verifier.js";
+
+function createResult(
+  overrides: Partial<ChatExecutorResult> = {},
+): ChatExecutorResult {
+  return {
+    content: "Implemented every requested artifact.",
+    provider: "grok",
+    usedFallback: false,
+    toolCalls: [
+      {
+        name: "system.writeFile",
+        args: { path: "/workspace/src/main.c" },
+        result: '{"ok":true}',
+        isError: false,
+        durationMs: 5,
+      },
+    ],
+    tokenUsage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+    callUsage: [],
+    durationMs: 10,
+    compacted: false,
+    stopReason: "completed",
+    completionState: "completed",
+    turnExecutionContract: {
+      version: 1,
+      turnClass: "workflow_implementation",
+      ownerMode: "workflow_owner",
+      workspaceRoot: "/workspace",
+      sourceArtifacts: ["/workspace/PLAN.md"],
+      targetArtifacts: ["/workspace/src/main.c"],
+      delegationPolicy: "direct_owner",
+      contractFingerprint: "contract-1",
+      taskLineageId: "task-1",
+    },
+    activeTaskContext: {
+      version: 1,
+      taskLineageId: "task-1",
+      contractFingerprint: "contract-1",
+      turnClass: "workflow_implementation",
+      ownerMode: "workflow_owner",
+      workspaceRoot: "/workspace",
+      sourceArtifacts: ["/workspace/PLAN.md"],
+      targetArtifacts: ["/workspace/src/main.c"],
+    },
+    ...overrides,
+  };
+}
+
+describe("maybeRunTopLevelVerifier", () => {
+  it("spawns the verifier worker with grounded read evidence", async () => {
+    const spawn = vi.fn(async () => "subagent:verify-1");
+    const waitForResult = vi.fn(async () => ({
+      sessionId: "subagent:verify-1",
+      output: "### Check: build\nResult: FAIL\nVERDICT: FAIL",
+      success: false,
+      durationMs: 42,
+      toolCalls: [
+        {
+          name: "system.readFile",
+          args: { path: "/workspace/src/main.c" },
+          result: '{"ok":true}',
+          isError: false,
+          durationMs: 2,
+        },
+      ],
+      completionState: "completed",
+      stopReason: "completed",
+    }));
+
+    const updated = await maybeRunTopLevelVerifier({
+      sessionId: "session:test",
+      userRequest: "Implement every phase from PLAN.md",
+      result: createResult(),
+      subAgentManager: { spawn, waitForResult },
+      verifierService: {
+        shouldVerifySubAgentResult: vi.fn(() => true),
+      },
+      agentDefinitions: [
+        {
+          name: "verify",
+          description: "Verification worker",
+          model: "inherit",
+          tools: ["system.readFile", "system.bash"],
+          maxTurns: 8,
+          source: "built-in",
+          filePath: "/tmp/verify.md",
+          body: "Verifier system prompt",
+        },
+      ],
+    });
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        systemPrompt: "Verifier system prompt",
+        tools: ["system.readFile", "system.bash"],
+        requiredToolEvidence: expect.objectContaining({
+          executionEnvelope: expect.objectContaining({
+            verificationMode: "grounded_read",
+            targetArtifacts: ["/workspace/src/main.c"],
+          }),
+        }),
+      }),
+    );
+    expect(updated.completionState).toBe("partial");
+    expect(updated.content).toContain("Verification did not pass.");
+    expect(updated.stopReasonDetail).toContain("Top-level verifier fail");
+  });
+
+  it("skips verifier workers for non-workflow turns", async () => {
+    const spawn = vi.fn(async () => "subagent:verify-1");
+
+    const updated = await maybeRunTopLevelVerifier({
+      sessionId: "session:test",
+      userRequest: "hello",
+      result: createResult({
+        turnExecutionContract: {
+          ...createResult().turnExecutionContract,
+          turnClass: "dialogue",
+          ownerMode: "none",
+          targetArtifacts: [],
+        },
+      }),
+      subAgentManager: { spawn, waitForResult: vi.fn(async () => null) },
+      verifierService: {
+        shouldVerifySubAgentResult: vi.fn(() => true),
+      },
+    });
+
+    expect(spawn).not.toHaveBeenCalled();
+    expect(updated.completionState).toBe("completed");
+  });
+});

--- a/runtime/src/gateway/top-level-verifier.ts
+++ b/runtime/src/gateway/top-level-verifier.ts
@@ -1,0 +1,314 @@
+import type { ChatExecutorResult } from "../llm/chat-executor.js";
+import {
+  deriveActiveTaskContext,
+  mergeTurnExecutionRequiredToolEvidence,
+  resolveWorkflowEvidenceFromRequiredToolEvidence,
+} from "../llm/turn-execution-contract.js";
+import {
+  deriveWorkflowProgressSnapshot,
+  mergeWorkflowProgressSnapshots,
+} from "../workflow/completion-progress.js";
+import {
+  resolveWorkflowCompletionState,
+  type PlannerVerificationSnapshot,
+} from "../workflow/completion-state.js";
+import { createExecutionEnvelope } from "../workflow/execution-envelope.js";
+import { normalizeArtifactPaths, normalizeWorkspaceRoot } from "../workflow/path-normalization.js";
+import type { Logger } from "../utils/logger.js";
+import type { AgentDefinition } from "./agent-loader.js";
+import type { DelegationVerifierService } from "./delegation-runtime.js";
+import { isSubAgentSessionId } from "./delegation-runtime.js";
+import type { SubAgentConfig, SubAgentManager, SubAgentResult } from "./sub-agent.js";
+
+const DEFAULT_VERIFY_TOOLS = [
+  "system.readFile",
+  "system.listDir",
+  "system.stat",
+  "system.bash",
+] as const;
+
+const DEFAULT_VERIFY_SYSTEM_PROMPT =
+  "You are a verification agent. Your job is to try to break the claimed implementation with real checks. " +
+  "Stay read-only, inspect the declared artifacts directly, run repo-local verification commands when possible, " +
+  "and finish with exactly one line: VERDICT: PASS, VERDICT: FAIL, or VERDICT: PARTIAL.";
+
+interface MaybeRunTopLevelVerifierParams {
+  readonly sessionId: string;
+  readonly userRequest: string;
+  readonly result: ChatExecutorResult;
+  readonly subAgentManager: Pick<SubAgentManager, "spawn" | "waitForResult"> | null;
+  readonly verifierService: Pick<DelegationVerifierService, "shouldVerifySubAgentResult"> | null;
+  readonly agentDefinitions?: readonly AgentDefinition[];
+  readonly logger?: Logger;
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1).trimEnd()}…`;
+}
+
+function selectVerifyDefinition(
+  definitions: readonly AgentDefinition[] | undefined,
+): {
+  readonly tools: readonly string[];
+  readonly systemPrompt: string;
+} {
+  const match = definitions?.find((definition) => definition.name === "verify");
+  return {
+    tools: match?.tools?.length ? match.tools : DEFAULT_VERIFY_TOOLS,
+    systemPrompt:
+      match?.body.trim().length
+        ? match.body.trim()
+        : DEFAULT_VERIFY_SYSTEM_PROMPT,
+  };
+}
+
+function buildVerifierPrompt(params: {
+  readonly userRequest: string;
+  readonly workspaceRoot?: string;
+  readonly sourceArtifacts: readonly string[];
+  readonly targetArtifacts: readonly string[];
+  readonly assistantContent: string;
+}): string {
+  const lines = [
+    "Verify the implementation result for this parent request.",
+    "",
+    `Parent request: ${params.userRequest.trim() || "(missing request text)"}`,
+  ];
+  if (params.workspaceRoot) {
+    lines.push(`Workspace root: ${params.workspaceRoot}`);
+  }
+  if (params.targetArtifacts.length > 0) {
+    lines.push("");
+    lines.push("Target artifacts:");
+    for (const artifact of params.targetArtifacts) {
+      lines.push(`- ${artifact}`);
+    }
+  }
+  if (params.sourceArtifacts.length > 0) {
+    lines.push("");
+    lines.push("Source artifacts:");
+    for (const artifact of params.sourceArtifacts) {
+      lines.push(`- ${artifact}`);
+    }
+  }
+  if (params.assistantContent.trim().length > 0) {
+    lines.push("");
+    lines.push("Parent completion summary:");
+    lines.push(truncate(params.assistantContent.trim(), 1200));
+  }
+  lines.push("");
+  lines.push(
+    "Run concrete checks, inspect the target artifacts directly, and report whether the implementation actually holds up.",
+  );
+  return lines.join("\n");
+}
+
+function parseVerifierSnapshot(result: SubAgentResult | null): {
+  readonly snapshot: PlannerVerificationSnapshot;
+  readonly summary: string;
+} {
+  if (!result) {
+    return {
+      snapshot: { performed: false, overall: "retry" },
+      summary: "Top-level verifier did not return a result.",
+    };
+  }
+
+  const content = result.output.trim();
+  const verdictMatch = content.match(/^VERDICT:\s*(PASS|FAIL|PARTIAL)\s*$/im);
+  const verdict = verdictMatch?.[1]?.toUpperCase();
+  const snapshot: PlannerVerificationSnapshot =
+    verdict === "PASS"
+      ? { performed: true, overall: "pass" }
+      : verdict === "FAIL"
+        ? { performed: true, overall: "fail" }
+        : verdict === "PARTIAL"
+          ? { performed: true, overall: "retry" }
+          : result.completionState === "completed"
+            ? { performed: true, overall: "retry" }
+            : { performed: false, overall: "retry" };
+
+  const summary =
+    content.length > 0
+      ? truncate(content, 2000)
+      : result.stopReasonDetail?.trim().length
+        ? truncate(result.stopReasonDetail.trim(), 2000)
+        : "Top-level verifier returned no usable output.";
+
+  return { snapshot, summary };
+}
+
+function buildVerifierAdjustedResult(params: {
+  readonly result: ChatExecutorResult;
+  readonly verifier: PlannerVerificationSnapshot;
+  readonly verifierSummary: string;
+}): ChatExecutorResult {
+  const requiredToolEvidence = mergeTurnExecutionRequiredToolEvidence({
+    turnExecutionContract: params.result.turnExecutionContract,
+  });
+  const workflowEvidence = resolveWorkflowEvidenceFromRequiredToolEvidence({
+    requiredToolEvidence,
+    runtimeContext: {
+      workspaceRoot: params.result.turnExecutionContract.workspaceRoot,
+      activeTaskContext: deriveActiveTaskContext(params.result.turnExecutionContract),
+    },
+  });
+  const completionState = resolveWorkflowCompletionState({
+    stopReason: params.result.stopReason,
+    toolCalls: params.result.toolCalls,
+    verificationContract: workflowEvidence.verificationContract,
+    completionContract: workflowEvidence.completionContract,
+    validationCode: params.result.validationCode,
+    verifier: params.verifier,
+  });
+  const nextProgress = deriveWorkflowProgressSnapshot({
+    stopReason: params.result.stopReason,
+    completionState,
+    stopReasonDetail:
+      params.verifier.overall === "pass"
+        ? params.result.stopReasonDetail
+        : `Top-level verifier ${params.verifier.overall}: ${params.verifierSummary}`,
+    validationCode: params.result.validationCode,
+    toolCalls: params.result.toolCalls,
+    verificationContract: workflowEvidence.verificationContract,
+    completionContract: workflowEvidence.completionContract,
+    updatedAt: Date.now(),
+    contractFingerprint: params.result.turnExecutionContract.contractFingerprint,
+    verifier: params.verifier,
+  });
+  const completionProgress = mergeWorkflowProgressSnapshots({
+    previous: params.result.completionProgress,
+    next: nextProgress,
+  });
+
+  if (params.verifier.overall === "pass") {
+    return {
+      ...params.result,
+      completionState,
+      ...(completionProgress ? { completionProgress } : {}),
+    };
+  }
+
+  const content = params.result.content.trim().length > 0
+    ? `${params.result.content.trim()}\n\nVerification did not pass.\n${params.verifierSummary}`
+    : `Verification did not pass.\n${params.verifierSummary}`;
+
+  return {
+    ...params.result,
+    content,
+    completionState,
+    ...(completionProgress ? { completionProgress } : {}),
+    stopReasonDetail: `Top-level verifier ${params.verifier.overall}: ${params.verifierSummary}`,
+  };
+}
+
+function shouldRunTopLevelVerifier(params: MaybeRunTopLevelVerifierParams): boolean {
+  if (!params.subAgentManager || !params.verifierService) return false;
+  if (isSubAgentSessionId(params.sessionId)) return false;
+  if (params.result.stopReason !== "completed") return false;
+  if (params.result.completionState !== "completed") return false;
+  if (params.result.turnExecutionContract.turnClass !== "workflow_implementation") {
+    return false;
+  }
+  const targetArtifacts = params.result.turnExecutionContract.targetArtifacts ?? [];
+  if (targetArtifacts.length === 0) return false;
+  return params.verifierService.shouldVerifySubAgentResult(true);
+}
+
+export async function maybeRunTopLevelVerifier(
+  params: MaybeRunTopLevelVerifierParams,
+): Promise<ChatExecutorResult> {
+  if (!shouldRunTopLevelVerifier(params)) {
+    return params.result;
+  }
+  const subAgentManager = params.subAgentManager;
+  if (!subAgentManager) {
+    return params.result;
+  }
+
+  const workspaceRoot = normalizeWorkspaceRoot(
+    params.result.turnExecutionContract.workspaceRoot,
+  );
+  const sourceArtifacts = normalizeArtifactPaths(
+    params.result.turnExecutionContract.sourceArtifacts ?? [],
+    workspaceRoot,
+  );
+  const targetArtifacts = normalizeArtifactPaths(
+    params.result.turnExecutionContract.targetArtifacts ?? [],
+    workspaceRoot,
+  );
+  const definition = selectVerifyDefinition(params.agentDefinitions);
+  const inspectionArtifacts = [...new Set([...sourceArtifacts, ...targetArtifacts])];
+  const executionEnvelope = createExecutionEnvelope({
+    workspaceRoot,
+    allowedReadRoots: workspaceRoot ? [workspaceRoot] : [],
+    allowedWriteRoots: [],
+    allowedTools: definition.tools,
+    inputArtifacts: inspectionArtifacts,
+    requiredSourceArtifacts: inspectionArtifacts,
+    targetArtifacts,
+    effectClass: "read_only",
+    verificationMode: "grounded_read",
+    stepKind: "delegated_validation",
+    role: "validator",
+    completionContract: {
+      taskClass: "artifact_only",
+      placeholdersAllowed: false,
+      partialCompletionAllowed: false,
+    },
+  });
+
+  const spawnConfig: SubAgentConfig = {
+    parentSessionId: params.sessionId,
+    task: "Verify the completed implementation",
+    prompt: buildVerifierPrompt({
+      userRequest: params.userRequest,
+      workspaceRoot,
+      sourceArtifacts,
+      targetArtifacts,
+      assistantContent: params.result.content,
+    }),
+    systemPrompt: definition.systemPrompt,
+    tools: definition.tools,
+    ...(workspaceRoot ? { workingDirectory: workspaceRoot } : {}),
+    requiredToolEvidence: {
+      maxCorrectionAttempts: 1,
+      executionEnvelope,
+    },
+  };
+
+  let childSessionId: string;
+  try {
+    childSessionId = await subAgentManager.spawn(spawnConfig);
+  } catch (error) {
+    params.logger?.warn(
+      "Failed to spawn top-level verifier worker",
+      { sessionId: params.sessionId, error: error instanceof Error ? error.message : String(error) },
+    );
+    return buildVerifierAdjustedResult({
+      result: params.result,
+      verifier: { performed: false, overall: "retry" },
+      verifierSummary: "Top-level verifier worker could not be started.",
+    });
+  }
+
+  const verifierResult = await subAgentManager.waitForResult(childSessionId);
+  const parsed = parseVerifierSnapshot(verifierResult);
+  if (parsed.snapshot.overall !== "pass") {
+    params.logger?.warn(
+      "Top-level verifier did not pass",
+      {
+        sessionId: params.sessionId,
+        verifierSessionId: childSessionId,
+        verdict: parsed.snapshot.overall,
+      },
+    );
+  }
+
+  return buildVerifierAdjustedResult({
+    result: params.result,
+    verifier: parsed.snapshot,
+    verifierSummary: parsed.summary,
+  });
+}

--- a/runtime/src/llm/chat-executor-artifact-evidence.test.ts
+++ b/runtime/src/llm/chat-executor-artifact-evidence.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ChatExecutor } from "./chat-executor.js";
+import type { ChatExecuteParams } from "./chat-executor.js";
+import { evaluateArtifactEvidenceGate } from "./chat-executor-stop-gate.js";
+import type { ActiveTaskContext } from "./turn-execution-contract-types.js";
+import type {
+  LLMChatOptions,
+  LLMMessage,
+  LLMProvider,
+  LLMResponse,
+} from "./types.js";
+import type { GatewayMessage } from "../gateway/message.js";
+
+const WORKSPACE_ROOT = "/tmp/chat-executor-test-workspace";
+
+function mockResponse(overrides: Partial<LLMResponse> = {}): LLMResponse {
+  return {
+    content: "mock response",
+    toolCalls: [],
+    usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+    model: "mock-model",
+    finishReason: "stop",
+    ...overrides,
+  };
+}
+
+function safeJson(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function createMockProvider(
+  name = "primary",
+  overrides: Partial<LLMProvider> = {},
+): LLMProvider {
+  return {
+    name,
+    chat: vi
+      .fn<[LLMMessage[], LLMChatOptions?], Promise<LLMResponse>>()
+      .mockResolvedValue(mockResponse()),
+    chatStream: vi
+      .fn()
+      .mockResolvedValue(mockResponse()),
+    healthCheck: vi.fn<[], Promise<boolean>>().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+function createMessage(content = "hello"): GatewayMessage {
+  return {
+    id: "msg-1",
+    channel: "test",
+    senderId: "user-1",
+    senderName: "Test User",
+    sessionId: "session-1",
+    content,
+    timestamp: Date.now(),
+    scope: "dm",
+  };
+}
+
+function createParams(
+  overrides: Partial<ChatExecuteParams> = {},
+): ChatExecuteParams {
+  return {
+    message: createMessage("Implement every phase"),
+    history: [],
+    systemPrompt: "You are a helpful assistant.",
+    sessionId: "session-1",
+    runtimeContext: { workspaceRoot: WORKSPACE_ROOT },
+    ...overrides,
+  };
+}
+
+describe("top-level artifact evidence gate", () => {
+  it("forces a recovery tool turn for carried workflow implementation tasks", async () => {
+    const activeTaskContext: ActiveTaskContext = {
+      version: 1,
+      taskLineageId: "task-1",
+      contractFingerprint: "carryover-contract",
+      turnClass: "workflow_implementation",
+      ownerMode: "workflow_owner",
+      workspaceRoot: WORKSPACE_ROOT,
+      sourceArtifacts: [`${WORKSPACE_ROOT}/PLAN.md`],
+      targetArtifacts: [
+        `${WORKSPACE_ROOT}/src/lexer.c`,
+        `${WORKSPACE_ROOT}/src/parser.c`,
+      ],
+    };
+
+    const provider = createMockProvider("primary", {
+      chat: vi
+        .fn<[LLMMessage[], LLMChatOptions?], Promise<LLMResponse>>()
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "",
+            finishReason: "tool_calls",
+            toolCalls: [
+              {
+                id: "tc-1",
+                name: "system.writeFile",
+                arguments: safeJson({
+                  path: "src/lexer.c",
+                  content: "lexer",
+                }),
+              },
+            ],
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "All phases from PLAN.md have been fully implemented and integrated.",
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "",
+            finishReason: "tool_calls",
+            toolCalls: [
+              {
+                id: "tc-2",
+                name: "system.writeFile",
+                arguments: safeJson({
+                  path: "src/parser.c",
+                  content: "parser",
+                }),
+              },
+            ],
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "Implemented lexer and parser with grounded file writes.",
+          }),
+        ),
+    });
+    const toolHandler = vi.fn(async (_name: string, args: Record<string, unknown>) =>
+      safeJson({ ok: true, path: args.path }),
+    );
+    const executor = new ChatExecutor({ providers: [provider], toolHandler });
+
+    const result = await executor.execute(
+      createParams({
+        runtimeContext: {
+          workspaceRoot: WORKSPACE_ROOT,
+          activeTaskContext,
+        },
+      }),
+    );
+
+    expect(result.stopReason).toBe("completed");
+    expect(result.completionState).toBe("completed");
+    expect(result.validationCode).toBeUndefined();
+    expect(result.toolCalls.filter((call) => call.name === "system.writeFile")).toHaveLength(2);
+    expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(4);
+    expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls[2]?.[1]).toMatchObject({
+      toolChoice: "required",
+    });
+    expect(result.turnExecutionContract.turnClass).toBe("workflow_implementation");
+    expect(result.turnExecutionContract.contractFingerprint).toBe("carryover-contract");
+    expect(result.activeTaskContext?.taskLineageId).toBe("task-1");
+  });
+
+  it("fails the turn when target artifacts are still missing after the allowed attempts", async () => {
+    const provider = createMockProvider("primary", {
+      chat: vi
+        .fn<[LLMMessage[], LLMChatOptions?], Promise<LLMResponse>>()
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "",
+            finishReason: "tool_calls",
+            toolCalls: [
+              {
+                id: "tc-1",
+                name: "system.writeFile",
+                arguments: safeJson({
+                  path: "src/lexer.c",
+                  content: "lexer",
+                }),
+              },
+            ],
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "All phases from PLAN.md have been fully implemented and integrated.",
+          }),
+        ),
+    });
+    const toolHandler = vi.fn(async (_name: string, args: Record<string, unknown>) =>
+      safeJson({ ok: true, path: args.path }),
+    );
+    const executor = new ChatExecutor({ providers: [provider], toolHandler });
+
+    const result = await executor.execute(
+      createParams({
+        requiredToolEvidence: {
+          maxCorrectionAttempts: 0,
+          verificationContract: {
+            workspaceRoot: WORKSPACE_ROOT,
+            targetArtifacts: [
+              `${WORKSPACE_ROOT}/src/lexer.c`,
+              `${WORKSPACE_ROOT}/src/parser.c`,
+            ],
+          },
+          completionContract: {
+            taskClass: "artifact_only",
+            placeholdersAllowed: false,
+            partialCompletionAllowed: false,
+          },
+        },
+      }),
+    );
+
+    expect(result.stopReason).toBe("validation_error");
+    expect(result.validationCode).toBe("missing_file_mutation_evidence");
+    expect(result.content).toContain(`${WORKSPACE_ROOT}/src/parser.c`);
+    expect(result.completionState).toBe("partial");
+    expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+  });
+
+  it("allows docs-only no-op completions when the target artifact was inspected", () => {
+    const decision = evaluateArtifactEvidenceGate({
+      runtimeContext: { workspaceRoot: WORKSPACE_ROOT },
+      requiredToolEvidence: {
+        verificationContract: {
+          workspaceRoot: WORKSPACE_ROOT,
+          targetArtifacts: [`${WORKSPACE_ROOT}/README.md`],
+        },
+      },
+      allToolCalls: [
+        {
+          name: "system.readFile",
+          args: { path: "README.md" },
+          result: safeJson({
+            path: `${WORKSPACE_ROOT}/README.md`,
+            content: "# Repo\n",
+          }),
+          isError: false,
+          durationMs: 1,
+        },
+      ],
+    });
+
+    expect(decision.shouldIntervene).toBe(false);
+  });
+
+  it("allows grounded-read verifier turns when the target artifact was inspected", () => {
+    const decision = evaluateArtifactEvidenceGate({
+      runtimeContext: { workspaceRoot: WORKSPACE_ROOT },
+      requiredToolEvidence: {
+        executionEnvelope: {
+          workspaceRoot: WORKSPACE_ROOT,
+          targetArtifacts: [`${WORKSPACE_ROOT}/src/main.c`],
+          verificationMode: "grounded_read",
+        },
+      },
+      allToolCalls: [
+        {
+          name: "system.readFile",
+          args: { path: "src/main.c" },
+          result: safeJson({
+            path: `${WORKSPACE_ROOT}/src/main.c`,
+            content: "int main(void) { return 0; }\n",
+          }),
+          isError: false,
+          durationMs: 1,
+        },
+      ],
+    });
+
+    expect(decision.shouldIntervene).toBe(false);
+  });
+});

--- a/runtime/src/llm/chat-executor-request.ts
+++ b/runtime/src/llm/chat-executor-request.ts
@@ -32,6 +32,7 @@ import { resolveWorkflowCompletionState } from "../workflow/completion-state.js"
 import { deriveWorkflowProgressSnapshot } from "../workflow/completion-progress.js";
 import { buildRuntimeEconomicsSummary } from "./run-budget.js";
 import { deriveActiveTaskContext } from "./turn-execution-contract.js";
+import { resolveWorkflowEvidenceFromRequiredToolEvidence } from "./turn-execution-contract.js";
 import type {
   ChatExecuteParams,
   ChatExecutorResult,
@@ -108,13 +109,18 @@ export async function executeRequest(
   checkRequestTimeout(ctx, "finalization");
 
   // Derive the final completion state from stop reason + tool calls.
-  // The runtime no longer carries verification or completion contracts
-  // through the chat-executor; both are passed as undefined.
+  const workflowEvidence = resolveWorkflowEvidenceFromRequiredToolEvidence({
+    requiredToolEvidence: ctx.requiredToolEvidence,
+    runtimeContext: {
+      workspaceRoot: ctx.runtimeWorkspaceRoot,
+      activeTaskContext: deriveActiveTaskContext(ctx.turnExecutionContract),
+    },
+  });
   ctx.completionState = resolveWorkflowCompletionState({
     stopReason: ctx.stopReason,
     toolCalls: ctx.allToolCalls,
-    verificationContract: undefined,
-    completionContract: undefined,
+    verificationContract: workflowEvidence.verificationContract,
+    completionContract: workflowEvidence.completionContract,
     completedRequestMilestoneIds: ctx.completedRequestMilestoneIds,
     validationCode: ctx.validationCode,
   });
@@ -129,8 +135,8 @@ export async function executeRequest(
     stopReasonDetail: ctx.stopReasonDetail,
     validationCode: ctx.validationCode,
     toolCalls: ctx.allToolCalls,
-    verificationContract: undefined,
-    completionContract: undefined,
+    verificationContract: workflowEvidence.verificationContract,
+    completionContract: workflowEvidence.completionContract,
     completedRequestMilestoneIds: ctx.completedRequestMilestoneIds,
     updatedAt: Date.now(),
     contractFingerprint: ctx.turnExecutionContract.contractFingerprint,
@@ -194,4 +200,3 @@ export async function executeRequest(
     validationCode: ctx.validationCode,
   };
 }
-

--- a/runtime/src/llm/chat-executor-stop-gate.ts
+++ b/runtime/src/llm/chat-executor-stop-gate.ts
@@ -39,9 +39,19 @@
  * @module
  */
 
-import type { ToolCallRecord } from "./chat-executor-types.js";
+import type { ChatExecuteParams, ToolCallRecord } from "./chat-executor-types.js";
 
-import { extractToolFailureText } from "./chat-executor-tool-utils.js";
+import {
+  didToolCallFail,
+  extractToolFailureText,
+} from "./chat-executor-tool-utils.js";
+import type { DelegationOutputValidationCode } from "../utils/delegation-validation.js";
+import { areDocumentationOnlyArtifacts } from "../workflow/artifact-paths.js";
+import {
+  isPathWithinRoot,
+  normalizeArtifactPaths,
+} from "../workflow/path-normalization.js";
+import { resolveWorkflowEvidenceFromRequiredToolEvidence } from "./turn-execution-contract.js";
 
 // ---------------------------------------------------------------------------
 // Detector knobs
@@ -237,10 +247,32 @@ export interface StopGateInterventionDecision {
   readonly evidence: StopGateEvidence;
 }
 
+export interface ArtifactEvidenceGateEvidence {
+  readonly successfulToolCallCount: number;
+  readonly requiredTargetArtifacts: readonly string[];
+  readonly mutatedArtifacts: readonly string[];
+  readonly inspectedArtifacts: readonly string[];
+  readonly missingArtifacts: readonly string[];
+}
+
+export interface ArtifactEvidenceGateDecision {
+  readonly shouldIntervene: boolean;
+  readonly validationCode?: DelegationOutputValidationCode;
+  readonly stopReasonDetail?: string;
+  readonly blockingMessage?: string;
+  readonly evidence: ArtifactEvidenceGateEvidence;
+}
+
 export interface EvaluateTurnEndStopGateParams {
   /** The model's about-to-be-final assistant text. */
   readonly finalContent: string;
   /** The full tool ledger for the turn (`ctx.allToolCalls`, turn-scoped). */
+  readonly allToolCalls: readonly ToolCallRecord[];
+}
+
+export interface EvaluateArtifactEvidenceGateParams {
+  readonly requiredToolEvidence?: ChatExecuteParams["requiredToolEvidence"];
+  readonly runtimeContext?: ChatExecuteParams["runtimeContext"];
   readonly allToolCalls: readonly ToolCallRecord[];
 }
 
@@ -394,6 +426,144 @@ function buildBlockingMessage(params: {
   }
 
   return lines.join("\n");
+}
+
+const MUTATION_PATH_ARG_BY_TOOL: Readonly<Record<string, readonly string[]>> = {
+  "system.writeFile": ["path"],
+  "system.appendFile": ["path"],
+  "system.editFile": ["path"],
+  "system.mkdir": ["path"],
+  "system.move": ["destination"],
+  "desktop.text_editor": ["path"],
+};
+
+const INSPECTION_PATH_ARG_BY_TOOL: Readonly<Record<string, readonly string[]>> = {
+  "system.readFile": ["path"],
+  "system.stat": ["path"],
+  "system.listDir": ["path"],
+  "desktop.text_editor": ["path"],
+};
+
+function normalizeToolPath(
+  rawPath: unknown,
+  workspaceRoot?: string,
+): string | undefined {
+  if (typeof rawPath !== "string" || rawPath.trim().length === 0) {
+    return undefined;
+  }
+  return normalizeArtifactPaths([rawPath], workspaceRoot)[0];
+}
+
+function collectToolPaths(params: {
+  readonly toolCall: ToolCallRecord;
+  readonly workspaceRoot?: string;
+  readonly pathKeys: Readonly<Record<string, readonly string[]>>;
+  readonly includeDesktopEditorViews?: boolean;
+}): readonly string[] {
+  const keys = params.pathKeys[params.toolCall.name] ?? [];
+  if (keys.length === 0) return [];
+
+  if (params.toolCall.name === "desktop.text_editor") {
+    const command =
+      typeof params.toolCall.args.command === "string"
+        ? params.toolCall.args.command.trim().toLowerCase()
+        : "";
+    const isView = command === "view";
+    if (params.includeDesktopEditorViews === true && !isView) {
+      return [];
+    }
+    if (params.includeDesktopEditorViews !== true && isView) {
+      return [];
+    }
+  }
+
+  const paths = new Set<string>();
+  for (const key of keys) {
+    const normalized = normalizeToolPath(
+      params.toolCall.args[key],
+      params.workspaceRoot,
+    );
+    if (normalized) {
+      paths.add(normalized);
+    }
+  }
+  return [...paths];
+}
+
+function artifactHasEvidence(
+  artifactPath: string,
+  evidencePaths: readonly string[],
+): boolean {
+  return evidencePaths.some((evidencePath) =>
+    evidencePath === artifactPath ||
+    isPathWithinRoot(evidencePath, artifactPath)
+  );
+}
+
+function buildMissingArtifactDetail(params: {
+  readonly code: Extract<
+    DelegationOutputValidationCode,
+    | "missing_successful_tool_evidence"
+    | "missing_file_mutation_evidence"
+    | "missing_file_artifact_evidence"
+  >;
+  readonly missingArtifacts: readonly string[];
+}): string {
+  if (params.code === "missing_successful_tool_evidence") {
+    return "Workflow-owned execution requires successful tool-grounded evidence before completion, but this turn recorded no successful tool calls.";
+  }
+  const joined = params.missingArtifacts.join(", ");
+  if (params.code === "missing_file_artifact_evidence") {
+    return `Missing file artifact evidence for ${joined}.`;
+  }
+  return `Missing file mutation evidence for ${joined}.`;
+}
+
+function buildArtifactEvidenceBlockingMessage(params: {
+  readonly validationCode: Extract<
+    DelegationOutputValidationCode,
+    | "missing_successful_tool_evidence"
+    | "missing_file_mutation_evidence"
+    | "missing_file_artifact_evidence"
+  >;
+  readonly missingArtifacts: readonly string[];
+  readonly mutatedArtifacts: readonly string[];
+  readonly inspectedArtifacts: readonly string[];
+}): string {
+  const missingLines = params.missingArtifacts.length > 0
+    ? `Missing artifacts:\n${params.missingArtifacts.map((path) => `- ${path}`).join("\n")}\n\n`
+    : "";
+  const mutatedLines = params.mutatedArtifacts.length > 0
+    ? `Observed file mutations:\n${params.mutatedArtifacts.map((path) => `- ${path}`).join("\n")}\n\n`
+    : "";
+  const inspectedLines = params.inspectedArtifacts.length > 0
+    ? `Observed file inspection evidence:\n${params.inspectedArtifacts.map((path) => `- ${path}`).join("\n")}\n\n`
+    : "";
+
+  if (params.validationCode === "missing_successful_tool_evidence") {
+    return (
+      "Runtime validation blocked completion because this workflow-owned turn has no successful tool-grounded evidence.\n\n" +
+      "Call real tools to continue the work or report the blocker grounded in tool output. Do not claim completion without successful tool results."
+    );
+  }
+
+  if (params.validationCode === "missing_file_artifact_evidence") {
+    return (
+      "Runtime validation blocked completion because the workflow contract only allows a no-op when the target artifacts are proven with tool evidence.\n\n" +
+      missingLines +
+      mutatedLines +
+      inspectedLines +
+      "Call real file-inspection or file-mutation tools on every missing artifact before claiming completion."
+    );
+  }
+
+  return (
+    "Runtime validation blocked completion because the workflow contract requires actual file mutations for every target artifact.\n\n" +
+    missingLines +
+    mutatedLines +
+    inspectedLines +
+    "Call real file-mutation tools (`system.writeFile`, `system.editFile`, `system.appendFile`, `desktop.text_editor`, `system.move`, `system.mkdir`) on every missing artifact before claiming completion."
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -566,6 +736,161 @@ export function evaluateTurnEndStopGate(
     refusedCalls,
     evidence,
   });
+}
+
+export function evaluateArtifactEvidenceGate(
+  params: EvaluateArtifactEvidenceGateParams,
+): ArtifactEvidenceGateDecision {
+  const emptyEvidence: ArtifactEvidenceGateEvidence = {
+    successfulToolCallCount: 0,
+    requiredTargetArtifacts: [],
+    mutatedArtifacts: [],
+    inspectedArtifacts: [],
+    missingArtifacts: [],
+  };
+
+  if (params.requiredToolEvidence?.unsafeBenchmarkMode === true) {
+    return {
+      shouldIntervene: false,
+      evidence: emptyEvidence,
+    };
+  }
+
+  const workflowEvidence = resolveWorkflowEvidenceFromRequiredToolEvidence({
+    requiredToolEvidence: params.requiredToolEvidence,
+    runtimeContext: params.runtimeContext,
+  });
+  const targetArtifacts = workflowEvidence.targetArtifacts;
+  if (targetArtifacts.length === 0) {
+    return {
+      shouldIntervene: false,
+      evidence: emptyEvidence,
+    };
+  }
+
+  const successfulToolCalls = params.allToolCalls.filter((toolCall) =>
+    !didToolCallFail(toolCall.isError, toolCall.result)
+  );
+  if (successfulToolCalls.length === 0) {
+    const validationCode = "missing_successful_tool_evidence" as const;
+    return {
+      shouldIntervene: true,
+      validationCode,
+      stopReasonDetail: buildMissingArtifactDetail({
+        code: validationCode,
+        missingArtifacts: targetArtifacts,
+      }),
+      blockingMessage: buildArtifactEvidenceBlockingMessage({
+        validationCode,
+        missingArtifacts: targetArtifacts,
+        mutatedArtifacts: [],
+        inspectedArtifacts: [],
+      }),
+      evidence: {
+        successfulToolCallCount: 0,
+        requiredTargetArtifacts: targetArtifacts,
+        mutatedArtifacts: [],
+        inspectedArtifacts: [],
+        missingArtifacts: targetArtifacts,
+      },
+    };
+  }
+
+  const workspaceRoot = workflowEvidence.workspaceRoot;
+  const mutatedArtifacts = new Set<string>();
+  const inspectedArtifacts = new Set<string>();
+  for (const toolCall of successfulToolCalls) {
+    for (const path of collectToolPaths({
+      toolCall,
+      workspaceRoot,
+      pathKeys: MUTATION_PATH_ARG_BY_TOOL,
+    })) {
+      mutatedArtifacts.add(path);
+      inspectedArtifacts.add(path);
+    }
+    for (const path of collectToolPaths({
+      toolCall,
+      workspaceRoot,
+      pathKeys: INSPECTION_PATH_ARG_BY_TOOL,
+      includeDesktopEditorViews: true,
+    })) {
+      inspectedArtifacts.add(path);
+    }
+  }
+
+  const mutatedArtifactList = [...mutatedArtifacts];
+  const inspectedArtifactList = [...inspectedArtifacts];
+  const missingMutationArtifacts = targetArtifacts.filter((artifactPath) =>
+    !artifactHasEvidence(artifactPath, mutatedArtifactList)
+  );
+  if (missingMutationArtifacts.length === 0) {
+    return {
+      shouldIntervene: false,
+      evidence: {
+        successfulToolCallCount: successfulToolCalls.length,
+        requiredTargetArtifacts: targetArtifacts,
+        mutatedArtifacts: mutatedArtifactList,
+        inspectedArtifacts: inspectedArtifactList,
+        missingArtifacts: [],
+      },
+    };
+  }
+
+  const verificationMode =
+    workflowEvidence.executionEnvelope?.verificationMode ??
+    workflowEvidence.verificationContract?.verificationMode;
+  const groundedReadAllowed = verificationMode === "grounded_read";
+  const conditionalMutationAllowed =
+    verificationMode === "conditional_mutation" ||
+    areDocumentationOnlyArtifacts(targetArtifacts);
+  const missingArtifactEvidence = targetArtifacts.filter((artifactPath) =>
+    !artifactHasEvidence(artifactPath, inspectedArtifactList)
+  );
+  if (
+    (groundedReadAllowed || conditionalMutationAllowed) &&
+    missingArtifactEvidence.length === 0
+  ) {
+    return {
+      shouldIntervene: false,
+      evidence: {
+        successfulToolCallCount: successfulToolCalls.length,
+        requiredTargetArtifacts: targetArtifacts,
+        mutatedArtifacts: mutatedArtifactList,
+        inspectedArtifacts: inspectedArtifactList,
+        missingArtifacts: [],
+      },
+    };
+  }
+
+  const validationCode = groundedReadAllowed || conditionalMutationAllowed
+    ? "missing_file_artifact_evidence" as const
+    : "missing_file_mutation_evidence" as const;
+  const missingArtifacts =
+    validationCode === "missing_file_artifact_evidence"
+      ? missingArtifactEvidence
+      : missingMutationArtifacts;
+
+  return {
+    shouldIntervene: true,
+    validationCode,
+    stopReasonDetail: buildMissingArtifactDetail({
+      code: validationCode,
+      missingArtifacts,
+    }),
+    blockingMessage: buildArtifactEvidenceBlockingMessage({
+      validationCode,
+      missingArtifacts,
+      mutatedArtifacts: mutatedArtifactList,
+      inspectedArtifacts: inspectedArtifactList,
+    }),
+    evidence: {
+      successfulToolCallCount: successfulToolCalls.length,
+      requiredTargetArtifacts: targetArtifacts,
+      mutatedArtifacts: mutatedArtifactList,
+      inspectedArtifacts: inspectedArtifactList,
+      missingArtifacts,
+    },
+  };
 }
 
 /**

--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -70,7 +70,10 @@ import {
   ANTI_FABRICATION_HARNESS_OVERWRITE_REASON,
   evaluateWriteOverFailedVerification,
 } from "./verification-target-guard.js";
-import { evaluateTurnEndStopGate } from "./chat-executor-stop-gate.js";
+import {
+  evaluateArtifactEvidenceGate,
+  evaluateTurnEndStopGate,
+} from "./chat-executor-stop-gate.js";
 import {
   sanitizeToolCallsForReplay,
   generateFallbackContent,
@@ -1193,6 +1196,7 @@ export async function executeToolCallLoop(
   // calls). After one intervention, `stopGateFired` is true and the gate
   // skips on subsequent passes to prevent infinite loops.
   let stopGateFired = false;
+  let artifactGateCorrectionAttempts = 0;
   let shouldContinueAfterStopGate = false;
   do {
     shouldContinueAfterStopGate = false;
@@ -1458,69 +1462,141 @@ export async function executeToolCallLoop(
   // exited cleanly (model stopped requesting tools, no abort, no
   // budget/timeout failure). Fires at most once per turn.
   if (
-    !stopGateFired &&
     !ctx.signal?.aborted &&
     ctx.response &&
     ctx.response.finishReason !== "tool_calls" &&
     ctx.stopReason === "completed"
   ) {
-    const gateDecision = evaluateTurnEndStopGate({
-      finalContent: ctx.response.content ?? "",
+    const artifactGateDecision = evaluateArtifactEvidenceGate({
+      requiredToolEvidence: ctx.requiredToolEvidence,
+      runtimeContext: {
+        workspaceRoot: ctx.runtimeWorkspaceRoot,
+      },
       allToolCalls: ctx.allToolCalls,
     });
-    if (gateDecision.shouldIntervene && gateDecision.blockingMessage) {
-      stopGateFired = true;
-      callbacks.emitExecutionTrace(ctx, {
-        type: "stop_gate_intervention",
-        phase: "tool_followup",
-        callIndex: ctx.callIndex,
-        payload: {
-          reason: gateDecision.reason,
-          finalContentPreview: (ctx.response.content ?? "").slice(0, 240),
-          evidence: gateDecision.evidence,
-        },
-      });
-      // Inject the synthetic blocking message as a user-role turn so
-      // the model treats it as authoritative runtime feedback (not just
-      // another assistant aside). Phase tagging matches the existing
-      // recovery-hint convention so prompt budget accounting works.
-      callbacks.pushMessage(
-        ctx,
-        {
-          role: "user",
-          content: gateDecision.blockingMessage,
-        },
-        "system_runtime",
-      );
-      // Re-call the model. The recovery response will either be more
-      // tool calls (the inner while loop runs again on the next
-      // do-while iteration) or a text response (the gate skip path
-      // takes over because stopGateFired is now true).
-      await runPerIterationCompactionBeforeModelCall(
-        ctx,
-        config,
-        callbacks,
-        "tool_followup",
-      );
-      const recoveryResponse = await callModelWithReactiveCompact(
-        ctx,
-        callbacks,
-        "tool_followup",
-        () => ({
+    if (artifactGateDecision.shouldIntervene) {
+      const maxCorrectionAttempts = ctx.requiredToolEvidence?.maxCorrectionAttempts ?? 0;
+      if (
+        artifactGateDecision.blockingMessage &&
+        artifactGateCorrectionAttempts < maxCorrectionAttempts
+      ) {
+        artifactGateCorrectionAttempts += 1;
+        callbacks.emitExecutionTrace(ctx, {
+          type: "stop_gate_intervention",
           phase: "tool_followup",
-          callMessages: ctx.messages,
-          callSections: ctx.messageSections,
-          onStreamChunk: ctx.activeStreamCallback,
-          statefulSessionId: ctx.sessionId,
-          statefulResumeAnchor: ctx.stateful?.resumeAnchor,
-          statefulHistoryCompacted: ctx.stateful?.historyCompacted,
-          budgetReason:
-            "Max model recalls exceeded during stop-gate recovery turn",
-        }),
-      );
-      if (recoveryResponse) {
-        ctx.response = recoveryResponse;
-        shouldContinueAfterStopGate = true;
+          callIndex: ctx.callIndex,
+          payload: {
+            reason: artifactGateDecision.validationCode,
+            finalContentPreview: (ctx.response.content ?? "").slice(0, 240),
+            evidence: artifactGateDecision.evidence,
+          },
+        });
+        callbacks.pushMessage(
+          ctx,
+          {
+            role: "user",
+            content: artifactGateDecision.blockingMessage,
+          },
+          "system_runtime",
+        );
+        await runPerIterationCompactionBeforeModelCall(
+          ctx,
+          config,
+          callbacks,
+          "tool_followup",
+        );
+        const recoveryResponse = await callModelWithReactiveCompact(
+          ctx,
+          callbacks,
+          "tool_followup",
+          () => ({
+            phase: "tool_followup",
+            callMessages: ctx.messages,
+            callSections: ctx.messageSections,
+            onStreamChunk: ctx.activeStreamCallback,
+            statefulSessionId: ctx.sessionId,
+            statefulResumeAnchor: ctx.stateful?.resumeAnchor,
+            statefulHistoryCompacted: ctx.stateful?.historyCompacted,
+            toolChoice: "required",
+            budgetReason:
+              "Max model recalls exceeded during artifact-evidence recovery turn",
+          }),
+        );
+        if (recoveryResponse) {
+          ctx.response = recoveryResponse;
+          shouldContinueAfterStopGate = true;
+        }
+      } else {
+        callbacks.setStopReason(
+          ctx,
+          "validation_error",
+          artifactGateDecision.stopReasonDetail,
+        );
+        ctx.validationCode = artifactGateDecision.validationCode;
+        ctx.response = {
+          ...ctx.response,
+          content: "",
+        };
+      }
+    } else if (!stopGateFired) {
+      const gateDecision = evaluateTurnEndStopGate({
+        finalContent: ctx.response.content ?? "",
+        allToolCalls: ctx.allToolCalls,
+      });
+      if (gateDecision.shouldIntervene && gateDecision.blockingMessage) {
+        stopGateFired = true;
+        callbacks.emitExecutionTrace(ctx, {
+          type: "stop_gate_intervention",
+          phase: "tool_followup",
+          callIndex: ctx.callIndex,
+          payload: {
+            reason: gateDecision.reason,
+            finalContentPreview: (ctx.response.content ?? "").slice(0, 240),
+            evidence: gateDecision.evidence,
+          },
+        });
+        // Inject the synthetic blocking message as a user-role turn so
+        // the model treats it as authoritative runtime feedback (not just
+        // another assistant aside). Phase tagging matches the existing
+        // recovery-hint convention so prompt budget accounting works.
+        callbacks.pushMessage(
+          ctx,
+          {
+            role: "user",
+            content: gateDecision.blockingMessage,
+          },
+          "system_runtime",
+        );
+        // Re-call the model. The recovery response will either be more
+        // tool calls (the inner while loop runs again on the next
+        // do-while iteration) or a text response (the gate skip path
+        // takes over because stopGateFired is now true).
+        await runPerIterationCompactionBeforeModelCall(
+          ctx,
+          config,
+          callbacks,
+          "tool_followup",
+        );
+        const recoveryResponse = await callModelWithReactiveCompact(
+          ctx,
+          callbacks,
+          "tool_followup",
+          () => ({
+            phase: "tool_followup",
+            callMessages: ctx.messages,
+            callSections: ctx.messageSections,
+            onStreamChunk: ctx.activeStreamCallback,
+            statefulSessionId: ctx.sessionId,
+            statefulResumeAnchor: ctx.stateful?.resumeAnchor,
+            statefulHistoryCompacted: ctx.stateful?.historyCompacted,
+            budgetReason:
+              "Max model recalls exceeded during stop-gate recovery turn",
+          }),
+        );
+        if (recoveryResponse) {
+          ctx.response = recoveryResponse;
+          shouldContinueAfterStopGate = true;
+        }
       }
     }
   }

--- a/runtime/src/llm/turn-execution-contract.ts
+++ b/runtime/src/llm/turn-execution-contract.ts
@@ -1,12 +1,9 @@
 /**
- * Turn execution contract — collapsed stub (Cut 1.2).
+ * Turn execution contract helpers.
  *
- * Replaces the previous 801-LOC turn-classification + delegation
- * inference + workflow contract synthesis machinery. The planner
- * subsystem that consumed this output has been deleted, so the runtime
- * now produces a default `dialogue` contract for every turn. The
- * exported function shapes are preserved so chat-executor and the
- * gateway initialization paths still link.
+ * Restores the minimum workflow-owned contract plumbing needed for
+ * top-level execution to preserve active-task lineage and reuse the same
+ * artifact-evidence validation path delegated children already obey.
  *
  * @module
  */
@@ -18,6 +15,17 @@ import type {
   ActiveTaskContext,
   TurnExecutionContract,
 } from "./turn-execution-contract-types.js";
+import type { ImplementationCompletionContract } from "../workflow/completion-contract.js";
+import {
+  createExecutionEnvelope,
+  type ExecutionEnvelope,
+} from "../workflow/execution-envelope.js";
+import {
+  normalizeArtifactPaths,
+  normalizeWorkspaceRoot,
+} from "../workflow/path-normalization.js";
+import type { WorkflowVerificationContract } from "../workflow/verification-obligations.js";
+import { areDocumentationOnlyArtifacts } from "../workflow/artifact-paths.js";
 
 function stableHash(payload: unknown): string {
   return createHash("sha256").update(JSON.stringify(payload)).digest("hex").slice(0, 24);
@@ -37,19 +45,310 @@ function buildDefaultContract(): TurnExecutionContract {
   };
 }
 
-export function resolveTurnExecutionContract(_params: {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asExecutionEnvelope(value: unknown): ExecutionEnvelope | undefined {
+  return isRecord(value) ? value as ExecutionEnvelope : undefined;
+}
+
+function asWorkflowVerificationContract(
+  value: unknown,
+): WorkflowVerificationContract | undefined {
+  return isRecord(value) ? value as WorkflowVerificationContract : undefined;
+}
+
+function asCompletionContract(
+  value: unknown,
+): ImplementationCompletionContract | undefined {
+  return isRecord(value)
+    ? value as unknown as ImplementationCompletionContract
+    : undefined;
+}
+
+function buildCarryoverExecutionEnvelope(
+  activeTaskContext: ActiveTaskContext | undefined,
+): ExecutionEnvelope | undefined {
+  if (!activeTaskContext) return undefined;
+  if (activeTaskContext.turnClass !== "workflow_implementation") return undefined;
+  if (activeTaskContext.ownerMode !== "workflow_owner") return undefined;
+  if ((activeTaskContext.targetArtifacts?.length ?? 0) === 0) return undefined;
+
+  const workspaceRoot = normalizeWorkspaceRoot(activeTaskContext.workspaceRoot);
+  const sourceArtifacts = normalizeArtifactPaths(
+    activeTaskContext.sourceArtifacts ?? [],
+    workspaceRoot,
+  );
+  const targetArtifacts = normalizeArtifactPaths(
+    activeTaskContext.targetArtifacts ?? [],
+    workspaceRoot,
+  );
+  if (targetArtifacts.length === 0) return undefined;
+
+  const docsOnlyTargets = areDocumentationOnlyArtifacts(targetArtifacts);
+
+  return createExecutionEnvelope({
+    workspaceRoot,
+    allowedReadRoots: workspaceRoot ? [workspaceRoot] : [],
+    allowedWriteRoots: workspaceRoot ? [workspaceRoot] : [],
+    inputArtifacts: sourceArtifacts,
+    requiredSourceArtifacts: sourceArtifacts,
+    targetArtifacts,
+    effectClass: "filesystem_write",
+    verificationMode: docsOnlyTargets
+      ? "conditional_mutation"
+      : "mutation_required",
+    stepKind: "delegated_write",
+    role: "writer",
+    completionContract: {
+      taskClass: "artifact_only",
+      placeholdersAllowed: false,
+      partialCompletionAllowed: docsOnlyTargets,
+    },
+  });
+}
+
+function buildVerificationContractFromEnvelope(
+  envelope: ExecutionEnvelope | undefined,
+): WorkflowVerificationContract | undefined {
+  if (!envelope) return undefined;
+  if (
+    !envelope.workspaceRoot &&
+    (envelope.inputArtifacts?.length ?? 0) === 0 &&
+    (envelope.requiredSourceArtifacts?.length ?? 0) === 0 &&
+    (envelope.targetArtifacts?.length ?? 0) === 0 &&
+    !envelope.completionContract &&
+    !envelope.verificationMode &&
+    !envelope.stepKind &&
+    !envelope.role
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...(envelope.workspaceRoot ? { workspaceRoot: envelope.workspaceRoot } : {}),
+    ...(envelope.inputArtifacts ? { inputArtifacts: envelope.inputArtifacts } : {}),
+    ...(envelope.requiredSourceArtifacts
+      ? { requiredSourceArtifacts: envelope.requiredSourceArtifacts }
+      : {}),
+    ...(envelope.targetArtifacts ? { targetArtifacts: envelope.targetArtifacts } : {}),
+    ...(envelope.verificationMode
+      ? { verificationMode: envelope.verificationMode }
+      : {}),
+    ...(envelope.stepKind ? { stepKind: envelope.stepKind } : {}),
+    ...(envelope.completionContract
+      ? { completionContract: envelope.completionContract }
+      : {}),
+    ...(envelope.role ? { role: envelope.role } : {}),
+  };
+}
+
+interface ResolvedWorkflowEvidence {
+  readonly workspaceRoot?: string;
+  readonly sourceArtifacts: readonly string[];
+  readonly targetArtifacts: readonly string[];
+  readonly verificationContract?: WorkflowVerificationContract;
+  readonly completionContract?: ImplementationCompletionContract;
+  readonly executionEnvelope?: ExecutionEnvelope;
+}
+
+export function resolveWorkflowEvidenceFromRequiredToolEvidence(params: {
+  readonly requiredToolEvidence?: ChatExecuteParams["requiredToolEvidence"];
+  readonly runtimeContext?: ChatExecuteParams["runtimeContext"];
+}): ResolvedWorkflowEvidence {
+  const activeTaskContext = params.runtimeContext?.activeTaskContext;
+  const explicitVerification = params.requiredToolEvidence?.verificationContract;
+  const explicitEnvelope = params.requiredToolEvidence?.executionEnvelope;
+  const synthesizedCarryoverEnvelope =
+    explicitVerification || explicitEnvelope
+      ? undefined
+      : buildCarryoverExecutionEnvelope(activeTaskContext);
+  const executionEnvelope = explicitEnvelope ?? synthesizedCarryoverEnvelope;
+  const verificationContract =
+    explicitVerification ?? buildVerificationContractFromEnvelope(executionEnvelope);
+  const workspaceRoot = normalizeWorkspaceRoot(
+    verificationContract?.workspaceRoot ??
+      executionEnvelope?.workspaceRoot ??
+      params.runtimeContext?.workspaceRoot ??
+      activeTaskContext?.workspaceRoot,
+  );
+  const sourceArtifacts = normalizeArtifactPaths(
+    [
+      ...(verificationContract?.requiredSourceArtifacts ??
+        verificationContract?.inputArtifacts ??
+        []),
+      ...(executionEnvelope?.requiredSourceArtifacts ??
+        executionEnvelope?.inputArtifacts ??
+        []),
+    ],
+    workspaceRoot,
+  );
+  const targetArtifacts = normalizeArtifactPaths(
+    [
+      ...(verificationContract?.targetArtifacts ?? []),
+      ...(executionEnvelope?.targetArtifacts ?? []),
+    ],
+    workspaceRoot,
+  );
+  const completionContract =
+    params.requiredToolEvidence?.completionContract ??
+    verificationContract?.completionContract ??
+    executionEnvelope?.completionContract;
+
+  return {
+    workspaceRoot,
+    sourceArtifacts,
+    targetArtifacts,
+    verificationContract,
+    completionContract,
+    executionEnvelope,
+  };
+}
+
+export function resolveTurnExecutionContract(params: {
   readonly message: ChatExecuteParams["message"];
   readonly runtimeContext?: ChatExecuteParams["runtimeContext"];
   readonly requiredToolEvidence?: ChatExecuteParams["requiredToolEvidence"];
 }): TurnExecutionContract {
-  return buildDefaultContract();
+  void params.message;
+  const fallback = buildDefaultContract();
+  const activeTaskContext = params.runtimeContext?.activeTaskContext;
+  const workflowEvidence = resolveWorkflowEvidenceFromRequiredToolEvidence({
+    requiredToolEvidence: params.requiredToolEvidence,
+    runtimeContext: params.runtimeContext,
+  });
+
+  const workspaceRoot =
+    workflowEvidence.workspaceRoot ??
+    normalizeWorkspaceRoot(activeTaskContext?.workspaceRoot);
+  const sourceArtifacts = normalizeArtifactPaths(
+    [
+      ...(activeTaskContext?.sourceArtifacts ?? []),
+      ...workflowEvidence.sourceArtifacts,
+    ],
+    workspaceRoot,
+  );
+  const targetArtifacts = normalizeArtifactPaths(
+    [
+      ...(activeTaskContext?.targetArtifacts ?? []),
+      ...workflowEvidence.targetArtifacts,
+    ],
+    workspaceRoot,
+  );
+
+  const hasWorkflowOwnership =
+    (
+      workflowEvidence.verificationContract !== undefined ||
+      workflowEvidence.completionContract !== undefined ||
+      workflowEvidence.executionEnvelope !== undefined
+    ) &&
+    targetArtifacts.length > 0;
+
+  if (!activeTaskContext && !hasWorkflowOwnership) {
+    return fallback;
+  }
+
+  const turnClass = hasWorkflowOwnership
+    ? "workflow_implementation"
+    : activeTaskContext?.turnClass ?? fallback.turnClass;
+  const ownerMode = hasWorkflowOwnership
+    ? "workflow_owner"
+    : activeTaskContext?.ownerMode ?? fallback.ownerMode;
+  const delegationPolicy =
+    ownerMode === "workflow_owner" || ownerMode === "artifact_owner"
+      ? "direct_owner"
+      : fallback.delegationPolicy;
+  const contractPayload = {
+    turnClass,
+    ownerMode,
+    workspaceRoot,
+    sourceArtifacts,
+    targetArtifacts,
+    verificationContract: workflowEvidence.verificationContract,
+    completionContract: workflowEvidence.completionContract,
+    executionEnvelope: workflowEvidence.executionEnvelope,
+  };
+  const contractFingerprint =
+    activeTaskContext?.contractFingerprint ?? stableHash(contractPayload);
+  const taskLineageId =
+    activeTaskContext?.taskLineageId ?? contractFingerprint;
+
+  return {
+    version: 1,
+    turnClass,
+    ownerMode,
+    ...(workspaceRoot ? { workspaceRoot } : {}),
+    sourceArtifacts,
+    targetArtifacts,
+    delegationPolicy,
+    ...(workflowEvidence.verificationContract
+      ? { verificationContract: workflowEvidence.verificationContract }
+      : {}),
+    ...(workflowEvidence.completionContract
+      ? { completionContract: workflowEvidence.completionContract }
+      : {}),
+    ...(workflowEvidence.executionEnvelope
+      ? { executionEnvelope: workflowEvidence.executionEnvelope }
+      : {}),
+    contractFingerprint,
+    taskLineageId,
+  };
 }
 
 export function mergeTurnExecutionRequiredToolEvidence(params: {
   readonly base?: ChatExecuteParams["requiredToolEvidence"];
   readonly turnExecutionContract: TurnExecutionContract;
 }): ChatExecuteParams["requiredToolEvidence"] {
-  return params.base;
+  const verificationContract = asWorkflowVerificationContract(
+    params.turnExecutionContract.verificationContract,
+  );
+  const completionContract = asCompletionContract(
+    params.turnExecutionContract.completionContract,
+  );
+  const executionEnvelope = asExecutionEnvelope(
+    params.turnExecutionContract.executionEnvelope,
+  );
+
+  if (
+    !params.base &&
+    !verificationContract &&
+    !completionContract &&
+    !executionEnvelope
+  ) {
+    return undefined;
+  }
+
+  return {
+    maxCorrectionAttempts: Math.max(
+      0,
+      Math.floor(params.base?.maxCorrectionAttempts ?? 1),
+    ),
+    ...(params.base?.delegationSpec
+      ? { delegationSpec: params.base.delegationSpec }
+      : {}),
+    ...(params.base?.unsafeBenchmarkMode === true
+      ? { unsafeBenchmarkMode: true }
+      : {}),
+    ...((params.base?.verificationContract ?? verificationContract)
+      ? {
+        verificationContract:
+          params.base?.verificationContract ?? verificationContract,
+      }
+      : {}),
+    ...((params.base?.completionContract ?? completionContract)
+      ? {
+        completionContract:
+          params.base?.completionContract ?? completionContract,
+      }
+      : {}),
+    ...((params.base?.executionEnvelope ?? executionEnvelope)
+      ? {
+        executionEnvelope:
+          params.base?.executionEnvelope ?? executionEnvelope,
+      }
+      : {}),
+  };
 }
 
 export function deriveActiveTaskContext(


### PR DESCRIPTION
## Summary

Structural anti-fabrication defense. Two mechanisms:

1. **Artifact-evidence gate** — stop gate extension that enforces structural artifact evidence against declared targetArtifacts before accepting a model stop. If required artifacts are missing/empty, forces another \`toolChoice: "required"\` turn. If retries exhausted, returns \`validation_error\`.

2. **Top-level verifier worker** — spawns a read-only verifier child with \`verificationMode: "grounded_read"\` against target artifacts. Can downgrade completed → partial on FAIL/PARTIAL.

## The problem this solves

The model claimed "All phases from PLAN.md have been fully implemented" with a 2500-char detailed summary. Reality: 12 of 14 source files were 0 bytes. No binary. 438 total lines of C. Every claim was fabricated.

## Test plan

- [x] typecheck clean
- [x] 176/176 tests pass across 6 test files
- [x] techdebt report: no critical issues