### PR TITLE
Handle ambiguous signer agent input

### DIFF
--- a/runtime/src/channels/webchat/handlers.ts
+++ b/runtime/src/channels/webchat/handlers.ts
@@ -176,6 +176,41 @@ function createReadOnlyProgramContext(deps: WebChatDeps): ReturnType<typeof crea
   return createReadOnlyProgram(deps.connection);
 }
 
+interface SignerAgentChoice {
+  registered: true;
+  authority: string;
+  agentPda: string;
+  agentId: string;
+}
+
+class MultipleSignerAgentsError extends Error {
+  readonly authority: string;
+  readonly agents: SignerAgentChoice[];
+
+  constructor(authority: PublicKey, agents: SignerAgentChoice[]) {
+    super(
+      'Multiple agent registrations found for signer wallet. Provide agentPda with one of the listed agentPda values.',
+    );
+    this.name = 'MultipleSignerAgentsError';
+    this.authority = authority.toBase58();
+    this.agents = agents;
+  }
+}
+
+function signerAgentChoicesFromMatches(
+  authority: PublicKey,
+  matches: ReadonlyArray<{ pubkey: PublicKey; account: { data: Uint8Array } }>,
+): SignerAgentChoice[] {
+  return matches
+    .map((match) => ({
+      registered: true as const,
+      authority: authority.toBase58(),
+      agentPda: match.pubkey.toBase58(),
+      agentId: Buffer.from(match.account.data.subarray(AGENT_ID_OFFSET, AGENT_AUTHORITY_OFFSET)).toString('hex'),
+    }))
+    .sort((left, right) => left.agentPda.localeCompare(right.agentPda));
+}
+
 async function resolveSignerAgent(program: ReturnType<typeof createProgram>): Promise<{
   agentPda: PublicKey;
   agentId: Uint8Array;
@@ -190,7 +225,7 @@ async function resolveSignerAgent(program: ReturnType<typeof createProgram>): Pr
   const matches = await program.provider.connection.getProgramAccounts(program.programId, {
     filters: [
       { memcmp: { offset: 0, bytes: bs58.default.encode(AGENT_ACCT_DISCRIMINATOR) } },
-      { memcmp: { offset: 40, bytes: authority.toBase58() } },
+      { memcmp: { offset: AGENT_AUTHORITY_OFFSET, bytes: authority.toBase58() } },
     ],
   });
 
@@ -198,17 +233,17 @@ async function resolveSignerAgent(program: ReturnType<typeof createProgram>): Pr
     throw new Error('No agent registration found for signer wallet');
   }
   if (matches.length > 1) {
-    throw new Error('Multiple agent registrations found for signer wallet');
+    throw new MultipleSignerAgentsError(authority, signerAgentChoicesFromMatches(authority, matches));
   }
 
-  const agentData = matches[0].account.data as Buffer;
+  const agentData = matches[0]!.account.data as Buffer;
   if (agentData.length < 72) {
     throw new Error('Signer agent registration account is truncated');
   }
 
   return {
-    agentPda: matches[0].pubkey,
-    agentId: new Uint8Array(agentData.subarray(8, 40)),
+    agentPda: matches[0]!.pubkey,
+    agentId: new Uint8Array(agentData.subarray(AGENT_ID_OFFSET, AGENT_AUTHORITY_OFFSET)),
     authority,
   };
 }
@@ -941,7 +976,22 @@ async function handleMarketReputationSummary(
     let signerAgent: Awaited<ReturnType<typeof resolveSignerAgent>> | null = null;
     try {
       signerAgent = await resolveSignerAgent(program);
-    } catch {
+    } catch (error) {
+      if (error instanceof MultipleSignerAgentsError) {
+        send({
+          type: 'market.reputation.summary',
+          payload: {
+            status: 'requires_input',
+            registered: false,
+            authority: error.authority,
+            message: error.message,
+            count: error.agents.length,
+            agents: error.agents,
+          },
+          id,
+        });
+        return;
+      }
       send({
         type: 'market.reputation.summary',
         payload: buildMarketplaceUnregisteredSummary({ authority }),
@@ -1675,6 +1725,8 @@ async function handlePolicySimulate(
  * so we parse sequentially rather than using fixed offsets.
  */
 const AGENT_ACCT_DISCRIMINATOR = Buffer.from([130, 53, 100, 103, 121, 77, 148, 19]);
+const AGENT_ID_OFFSET = 8;
+const AGENT_AUTHORITY_OFFSET = 40;
 /** Minimum byte length for an agent account (all variable-length strings empty). */
 const AGENT_ACCT_MIN_LENGTH = 132;
 

--- a/runtime/src/cli/marketplace-cli.ts
+++ b/runtime/src/cli/marketplace-cli.ts
@@ -225,7 +225,45 @@ const SOLANA_RPC_REQUIRED =
 const AGENT_ACCT_DISCRIMINATOR = Buffer.from([
   130, 53, 100, 103, 121, 77, 148, 19,
 ]);
+const AGENT_ID_OFFSET = 8;
+const AGENT_AUTHORITY_OFFSET = 40;
 const ZERO_AGENT_ID = new Uint8Array(32);
+
+interface SignerAgentChoice {
+  registered: true;
+  authority: string;
+  agentPda: string;
+  agentId: string;
+}
+
+class MultipleSignerAgentsError extends Error {
+  readonly code = "MULTIPLE_AGENT_REGISTRATIONS";
+  readonly authority: string;
+  readonly agents: SignerAgentChoice[];
+
+  constructor(authority: PublicKey, agents: SignerAgentChoice[]) {
+    super(
+      "Multiple agent registrations found for signer wallet. Provide agentPda with one of the listed agentPda values.",
+    );
+    this.name = "MultipleSignerAgentsError";
+    this.authority = authority.toBase58();
+    this.agents = agents;
+  }
+}
+
+function signerAgentChoicesFromMatches(
+  authority: PublicKey,
+  matches: ReadonlyArray<{ pubkey: PublicKey; account: { data: Uint8Array } }>,
+): SignerAgentChoice[] {
+  return matches
+    .map((match) => ({
+      registered: true as const,
+      authority: authority.toBase58(),
+      agentPda: match.pubkey.toBase58(),
+      agentId: Buffer.from(match.account.data.subarray(AGENT_ID_OFFSET, AGENT_AUTHORITY_OFFSET)).toString("hex"),
+    }))
+    .sort((left, right) => left.agentPda.localeCompare(right.agentPda));
+}
 
 function parseToolError(result: ToolResult): string {
   if (!result.isError) return "Unknown tool failure";
@@ -357,7 +395,7 @@ async function resolveSignerAgent(
             bytes: bs58.default.encode(AGENT_ACCT_DISCRIMINATOR),
           },
         },
-        { memcmp: { offset: 40, bytes: authority.toBase58() } },
+        { memcmp: { offset: AGENT_AUTHORITY_OFFSET, bytes: authority.toBase58() } },
       ],
     },
   );
@@ -366,15 +404,15 @@ async function resolveSignerAgent(
     throw new Error("No agent registration found for signer wallet");
   }
   if (matches.length > 1) {
-    throw new Error("Multiple agent registrations found for signer wallet");
+    throw new MultipleSignerAgentsError(authority, signerAgentChoicesFromMatches(authority, matches));
   }
 
   const raw = await (program.account as any).agentRegistration.fetch(
-    matches[0].pubkey,
+    matches[0]!.pubkey,
   );
   const agent = parseAgentState(raw as Record<string, unknown>);
   return {
-    agentPda: matches[0].pubkey,
+    agentPda: matches[0]!.pubkey,
     agentId: agent.agentId,
     authority,
   };
@@ -1610,10 +1648,19 @@ export async function runMarketReputationSummaryCommand(
     });
     return 0;
   } catch (error) {
+    const multipleAgentDetails = error instanceof MultipleSignerAgentsError
+      ? {
+          reasonCode: error.code,
+          authority: error.authority,
+          count: error.agents.length,
+          agents: error.agents,
+        }
+      : {};
     context.error({
       status: "error",
       code: "MARKET_REPUTATION_SUMMARY_FAILED",
       message: error instanceof Error ? error.message : String(error),
+      ...multipleAgentDetails,
     });
     return 1;
   }

--- a/runtime/src/gateway/background-run-supervisor-constants.ts
+++ b/runtime/src/gateway/background-run-supervisor-constants.ts
@@ -107,6 +107,7 @@ export const BACKGROUND_ACTOR_SECTION =
   "For long-running shell work, launch it so the tool call returns immediately: background the long-running process, redirect stdout/stderr, and verify in a later cycle instead of waiting inside one command.\n" +
   "Do not spend a whole tool call sleeping or waiting for a delayed effect when the objective is ongoing.\n" +
   "If the objective involves a process that should keep running after setup, do not treat a successful launch as final completion.\n" +
+  "Completion requires verified tool evidence from this cycle or a previous cycle. If no tool evidence is present, run one bounded verification tool call or keep the task working instead of claiming completion.\n" +
   "Do not claim the task is fully complete unless the user objective is actually satisfied.\n" +
   "Return a concise factual update. Avoid sign-off language.\n";
 

--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -267,7 +267,7 @@ describe("DaemonManager host workspace prompt and memory resolution", () => {
       expect(prompt).toContain("Host workspace agent");
       expect(prompt).toContain("For `agenc.inspectMarketplace` reputation requests");
       expect(prompt).toContain("Never invent aliases, labels, or placeholder names for `agentPda`");
-      expect(prompt).toContain("return the `requires_input` placeholder");
+      expect(prompt).toContain("not proof that no agent is registered");
     } finally {
       await rm(hostPath, { recursive: true, force: true });
     }

--- a/runtime/src/gateway/personality.ts
+++ b/runtime/src/gateway/personality.ts
@@ -86,7 +86,7 @@ Professional but approachable. Explain complex protocol concepts clearly without
 - Verify escrow balance before attempting completion
 - Use \`agenc.inspectMarketplace\` first for marketplace overview, tasks, skills, governance, disputes, and reputation surface prompts
 - For \`agenc.inspectMarketplace\` reputation requests, only pass \`subject\` or \`agentPda\` when the user or a prior tool result provides a real base58 agent PDA
-- Never invent aliases, labels, or placeholder names for \`agentPda\`; if no explicit PDA is available, omit the field and let the tool return the \`requires_input\` placeholder
+- Never invent aliases, labels, or placeholder names for \`agentPda\`; if no explicit PDA is available, omit the field and treat a \`requires_input\` reputation result as a request for a listed agent PDA, not proof that no agent is registered
 - Use \`agenc.getProtocolConfig\` only for protocol fees, thresholds, rate limits, and versioning
 - Prefer batch queries over multiple single lookups
 - Choose the output shape deliberately: markdown tables for ordered comparisons, fenced JSON for exact state, and fenced \`diff\` blocks for before/after edits
@@ -287,7 +287,7 @@ Technical but accessible. Use code examples and precise terminology while remain
 - Query task details before claiming to verify technical requirements
 - Use \`agenc.inspectMarketplace\` first for marketplace surface prompts, especially disputes, governance, and reputation inspections
 - For \`agenc.inspectMarketplace\` reputation requests, only pass \`subject\` or \`agentPda\` when the user or a prior tool result provides a real base58 agent PDA
-- Never invent aliases, labels, or placeholder names for \`agentPda\`; if no explicit PDA is available, omit the field and let the tool return the \`requires_input\` placeholder
+- Never invent aliases, labels, or placeholder names for \`agentPda\`; if no explicit PDA is available, omit the field and treat a \`requires_input\` reputation result as a request for a listed agent PDA, not proof that no agent is registered
 - Structure code analysis results as markdown with code blocks, and switch to tables, JSON, or \`diff\` fences when those formats are a better fit than prose
 - Include test commands and expected outputs in task results
 - Verify all on-chain state references with protocol queries

--- a/runtime/src/gateway/system-prompt-builder.ts
+++ b/runtime/src/gateway/system-prompt-builder.ts
@@ -313,7 +313,7 @@ export async function buildSystemPrompt(
     "For marketplace read prompts, use `agenc.inspectMarketplace` first.\n" +
     "For `agenc.inspectMarketplace` reputation requests, only pass `subject` or `agentPda` when the user or a prior tool result provides a real base58 agent PDA.\n" +
     "Never invent aliases, labels, or placeholder names for `agentPda`.\n" +
-    "If no explicit agent PDA is available, omit `subject` and `agentPda` so the tool can return the `requires_input` placeholder.";
+    "If no explicit agent PDA is available, omit `subject` and `agentPda`; treat a `requires_input` reputation result as a request for a listed agent PDA, not proof that no agent is registered.";
 
   const additionalContext =
     desktopContext +

--- a/runtime/src/gateway/workspace-files.ts
+++ b/runtime/src/gateway/workspace-files.ts
@@ -328,7 +328,7 @@ Configure which tools the agent should prefer and how to use them.
 ## Usage Rules
 - Use \`agenc.inspectMarketplace\` first for marketplace overview, tasks, skills, governance, disputes, and reputation read prompts
 - Only pass \`subject\` or \`agentPda\` for marketplace reputation inspection when the user or a prior tool result provides a real base58 agent PDA
-- Never invent aliases, labels, or placeholder names for \`agentPda\`; omit the field when no explicit PDA is available so the tool can return the \`requires_input\` placeholder
+- Never invent aliases, labels, or placeholder names for \`agentPda\`; omit the field when no explicit PDA is available and treat a \`requires_input\` reputation result as a request for a listed agent PDA, not proof that no agent is registered
 `,
   [WORKSPACE_FILES.HEARTBEAT]: `# Heartbeat
 

--- a/runtime/src/llm/chat-executor-model-orchestration.ts
+++ b/runtime/src/llm/chat-executor-model-orchestration.ts
@@ -379,6 +379,16 @@ export async function callModelForPhase(
     },
   });
   let next: FallbackResult;
+  let streamedContent = "";
+  const passThroughStreamChunk = input.onStreamChunk;
+  const onStreamChunk: StreamProgressCallback | undefined = passThroughStreamChunk
+    ? (chunk) => {
+      if (chunk.content.length > 0) {
+        streamedContent += chunk.content;
+      }
+      passThroughStreamChunk(chunk);
+    }
+    : undefined;
   try {
     next = await callWithFallback(
       {
@@ -390,7 +400,7 @@ export async function callModelForPhase(
         maxCooldownMs: deps.maxCooldownMs,
       },
       effectiveCallMessages,
-      input.onStreamChunk,
+      onStreamChunk,
       effectiveCallSections,
       {
         requestDeadlineAt: ctx.requestDeadlineAt,
@@ -437,6 +447,7 @@ export async function callModelForPhase(
     throw annotated.error;
   }
   ctx.modelCalls++;
+  ctx.lastModelStreamedContent = streamedContent;
   ctx.providerName = next.providerName;
   ctx.responseModel = next.response.model;
   ctx.providerEvidence = mergeProviderEvidence(

--- a/runtime/src/llm/chat-executor-recovery.test.ts
+++ b/runtime/src/llm/chat-executor-recovery.test.ts
@@ -51,6 +51,37 @@ describe("chat-executor-recovery", () => {
     expect(hint?.message).toContain("system.sandboxJobStart");
   });
 
+  it("tells the model to ask for required input instead of retrying requires_input tools", () => {
+    const hint = inferRecoveryHint({
+      name: "agenc.registerAgent",
+      args: {
+        capabilities: ["marketplace"],
+      },
+      result: JSON.stringify({
+        status: "requires_input",
+        code: "MULTIPLE_AGENT_REGISTRATIONS",
+        error:
+          "Multiple agent registrations found for signer wallet. Provide creatorAgentPda with one of the listed agentPda values.",
+        agents: [
+          {
+            agentPda: "11111111111111111111111111111111",
+          },
+        ],
+      }),
+      isError: true,
+      durationMs: 5,
+    });
+
+    expect(hint).toBeDefined();
+    expect(hint?.key).toBe(
+      "agenc.registerAgent-requires-input:multiple_agent_registrations",
+    );
+    expect(hint?.message).toContain('status: "requires_input"');
+    expect(hint?.message).toContain("Do not retry the same tool call");
+    expect(hint?.message).toContain("agentPda");
+    expect(hint?.message).toContain("creatorAgentPda");
+  });
+
   it("injects a recovery hint for stale CMake cache path mismatches", () => {
     const hint = inferRecoveryHint({
       name: "system.bash",

--- a/runtime/src/llm/chat-executor-recovery.ts
+++ b/runtime/src/llm/chat-executor-recovery.ts
@@ -31,6 +31,22 @@ const DESKTOP_BIASED_SYSTEM_COMMANDS = new Set([
   "playwright",
   "gdb",
 ]);
+
+function isRequiresInputToolResult(
+  parsedResult: Record<string, unknown> | null,
+): boolean {
+  return parsedResult?.status === "requires_input";
+}
+
+function extractRequiresInputCode(
+  parsedResult: Record<string, unknown> | null,
+): string {
+  const code = parsedResult?.code;
+  return typeof code === "string" && code.trim().length > 0
+    ? code.trim()
+    : "requires_input";
+}
+
 function extractDeniedCommand(failureText: string): string | undefined {
   const quotedDouble = failureText.match(/command\s+"([^"]+)"\s+is denied/i);
   if (quotedDouble && quotedDouble[1]?.trim().length) {
@@ -1325,6 +1341,17 @@ export function inferRecoveryHint(
 
   if (!didToolCallFail(call.isError, call.result)) return undefined;
 
+  if (isRequiresInputToolResult(parsedResult)) {
+    const code = extractRequiresInputCode(parsedResult);
+    return {
+      key: `${call.name}-requires-input:${code.toLowerCase()}`,
+      message:
+        `The tool returned \`status: "requires_input"\` (${code}). ` +
+        "Do not retry the same tool call with the same arguments. Ask the user for the missing input explicitly, using any choices listed in the tool result. " +
+        "For multiple AgenC agent registrations, ask the user to choose one listed `agentPda`/`creatorAgentPda` instead of selecting one automatically.",
+    };
+  }
+
   const failureText = extractToolFailureText(call);
   const failureTextLower = failureText.toLowerCase();
   if (
@@ -1791,4 +1818,3 @@ export function inferRecoveryHint(
 
   return undefined;
 }
-

--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -1690,6 +1690,14 @@ export async function executeToolCallLoop(
   }
 
   ctx.finalContent = ctx.response?.content ?? "";
+  if (
+    !ctx.finalContent &&
+    ctx.lastModelStreamedContent.trim().length > 0 &&
+    ctx.allToolCalls.length > 0 &&
+    ctx.stopReason === "completed"
+  ) {
+    ctx.finalContent = ctx.lastModelStreamedContent;
+  }
   const missingFinalToolFollowupAnswer =
     !ctx.finalContent &&
     ctx.allToolCalls.length > 0 &&

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -611,6 +611,7 @@ export interface ExecutionContext {
   responseModel?: string;
   response?: LLMResponse;
   finalContent: string;
+  lastModelStreamedContent: string;
   compacted: boolean;
   compactedArtifactContext?: ArtifactCompactionState;
   stopReason: LLMPipelineStopReason;
@@ -753,6 +754,7 @@ export function buildDefaultExecutionContext(
     responseModel: undefined,
     response: undefined,
     finalContent: "",
+    lastModelStreamedContent: "",
     compacted: params.compacted,
     compactedArtifactContext: params.stateful?.artifactContext,
     stopReason: "completed",

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -757,6 +757,50 @@ describe("ChatExecutor", () => {
       );
     });
 
+    it("uses streamed post-tool content when the terminal provider payload is empty", async () => {
+      const toolHandler = vi
+        .fn()
+        .mockResolvedValue('{"status":"requires_input"}');
+      const onStreamChunk = vi.fn();
+      const provider = createMockProvider("primary", {
+        chatStream: vi
+          .fn<
+            [LLMMessage[], StreamProgressCallback, LLMChatOptions?],
+            Promise<LLMResponse>
+          >()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                { id: "tc-1", name: "agenc.getReputationSummary", arguments: "{}" },
+              ],
+            }),
+          )
+          .mockImplementationOnce(async (_messages, stream) => {
+            stream({ content: "Yes, but your signer wallet ", done: false });
+            stream({ content: "already has registered agents.", done: true });
+            return mockResponse({ content: "", finishReason: "stop" });
+          }),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        onStreamChunk,
+      });
+      const result = await executor.execute(createParams());
+
+      expect(result.stopReason).toBe("completed");
+      expect(result.content).toBe(
+        "Yes, but your signer wallet already has registered agents.",
+      );
+      expect(onStreamChunk).toHaveBeenCalledWith(
+        expect.objectContaining({ content: "Yes, but your signer wallet " }),
+      );
+      expect(result.content).not.toContain("Model returned empty content");
+    });
+
     it("surfaces timeout detail instead of summarizing tool output when tool follow-up never starts", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-04-08T00:00:00.000Z"));

--- a/runtime/src/tools/agenc/mutation-tools.test.ts
+++ b/runtime/src/tools/agenc/mutation-tools.test.ts
@@ -71,6 +71,12 @@ function makeRawAgent(authority: PublicKey) {
   };
 }
 
+function makeAgentRegistrationData(agentIdSeed: number) {
+  const data = new Uint8Array(72);
+  data.set(new Uint8Array(32).fill(agentIdSeed), 8);
+  return data;
+}
+
 function createRpcChain(signature: string) {
   return {
     accountsPartial: vi.fn().mockReturnThis(),
@@ -154,6 +160,32 @@ describe('agenc mutation tools', () => {
 
     expect(result.isError).toBe(true);
     expect(String(parseJson(result).error)).toContain('agenc-runtime agent register');
+  });
+
+  it('agenc.claimTask lists signer agent choices when auto-discovery finds multiple registrations', async () => {
+    const program = createMockProgram();
+    const firstAgentPda = PublicKey.unique();
+    const secondAgentPda = PublicKey.unique();
+    program.provider.connection.getProgramAccounts.mockResolvedValue([
+      { pubkey: secondAgentPda, account: { data: makeAgentRegistrationData(2) } },
+      { pubkey: firstAgentPda, account: { data: makeAgentRegistrationData(1) } },
+    ]);
+    const tool = createClaimTaskTool(program as never, silentLogger);
+
+    const result = await tool.execute({ taskPda: TASK_PDA.toBase58() });
+    const parsed = parseJson(result) as { agents: Array<Record<string, unknown>> } & Record<string, unknown>;
+    const expectedAgentPdas = [firstAgentPda.toBase58(), secondAgentPda.toBase58()].sort();
+
+    expect(result.isError).toBe(true);
+    expect(parsed).toMatchObject({
+      code: 'MULTIPLE_AGENT_REGISTRATIONS',
+      status: 'requires_input',
+      authority: SIGNER.toBase58(),
+      count: 2,
+    });
+    expect(String(parsed.error)).toContain('workerAgentPda');
+    expect(parsed.agents.map((agent) => agent.agentPda)).toEqual(expectedAgentPdas);
+    expect(parsed.agents.every((agent) => agent.registered === true)).toBe(true);
   });
 
   it('agenc.completeTask validates proofHash length', async () => {

--- a/runtime/src/tools/agenc/mutation-tools.ts
+++ b/runtime/src/tools/agenc/mutation-tools.ts
@@ -39,6 +39,9 @@ const NAME_BYTES = 32;
 const TAG_BYTES = 64;
 const RESULT_BYTES = 64;
 const PROPOSAL_PAYLOAD_BYTES = 64;
+const AGENT_DISCRIMINATOR = Buffer.from([130, 53, 100, 103, 121, 77, 148, 19]);
+const AGENT_ID_OFFSET = 8;
+const AGENT_AUTHORITY_OFFSET = AGENT_ID_OFFSET + 32;
 
 interface ResolvedSignerAgent {
   authority: PublicKey;
@@ -46,8 +49,47 @@ interface ResolvedSignerAgent {
   agentId: Uint8Array;
 }
 
+interface SignerAgentChoice {
+  registered: true;
+  authority: string;
+  agentPda: string;
+  agentId: string;
+}
+
 function errorResult(message: string): ToolResult {
   return { content: safeStringify({ error: message }), isError: true };
+}
+
+function ambiguousSignerAgentsResult(
+  authority: PublicKey,
+  agents: SignerAgentChoice[],
+  field: string,
+): ToolResult {
+  return {
+    content: safeStringify({
+      error: `Multiple agent registrations found for signer wallet. Provide ${field} with one of the listed agentPda values.`,
+      code: 'MULTIPLE_AGENT_REGISTRATIONS',
+      status: 'requires_input',
+      authority: authority.toBase58(),
+      count: agents.length,
+      agents,
+    }),
+    isError: true,
+  };
+}
+
+function signerAgentChoicesFromMatches(
+  authority: PublicKey,
+  matches: ReadonlyArray<{ pubkey: PublicKey; account: { data: Uint8Array } }>,
+): SignerAgentChoice[] {
+  return matches
+    .map((match) => ({
+      registered: true as const,
+      authority: authority.toBase58(),
+      agentPda: match.pubkey.toBase58(),
+      agentId: bytesToHex(match.account.data.subarray(AGENT_ID_OFFSET, AGENT_AUTHORITY_OFFSET)),
+    }))
+    .sort((left, right) => left.agentPda.localeCompare(right.agentPda));
 }
 
 function parseBase58(input: unknown, field: string): [PublicKey | null, ToolResult | null] {
@@ -261,14 +303,13 @@ async function resolveAuthorityAgentPda(
   program: Program<AgencCoordination>,
   authority: PublicKey,
   providedAgentPda?: unknown,
+  field = 'agentPda',
 ): Promise<[PublicKey | null, ToolResult | null]> {
   if (providedAgentPda !== undefined) {
-    return parseBase58(providedAgentPda, 'agentPda');
+    return parseBase58(providedAgentPda, field);
   }
 
   const bs58 = await import('bs58');
-  const AGENT_DISCRIMINATOR = Buffer.from([130, 53, 100, 103, 121, 77, 148, 19]);
-  const AGENT_AUTHORITY_OFFSET = 40;
   const matches = await program.provider.connection.getProgramAccounts(program.programId, {
     filters: [
       { memcmp: { offset: 0, bytes: bs58.default.encode(AGENT_DISCRIMINATOR) } },
@@ -280,22 +321,28 @@ async function resolveAuthorityAgentPda(
     return [null, errorResult('No agent registration found for signer wallet. Run `agenc-runtime agent register --rpc <url>` first, or provide the explicit agent PDA.')];
   }
   if (matches.length > 1) {
-    return [null, errorResult('Multiple agent registrations found for signer wallet. Provide the explicit agent PDA.')];
+    return [null, ambiguousSignerAgentsResult(authority, signerAgentChoicesFromMatches(authority, matches), field)];
   }
 
-  return [matches[0].pubkey, null];
+  return [matches[0]!.pubkey, null];
 }
 
 async function resolveSignerAgentContext(
   program: Program<AgencCoordination>,
   providedAgentPda: unknown,
+  providedAgentPdaField = 'agentPda',
 ): Promise<[ResolvedSignerAgent | null, ToolResult | null]> {
   const authority = program.provider.publicKey;
   if (!authority) {
     return [null, errorResult('This action requires a signer-backed program context')];
   }
 
-  const [agentPda, agentErr] = await resolveAuthorityAgentPda(program, authority, providedAgentPda);
+  const [agentPda, agentErr] = await resolveAuthorityAgentPda(
+    program,
+    authority,
+    providedAgentPda,
+    providedAgentPdaField,
+  );
   if (agentErr || !agentPda) return [null, agentErr ?? errorResult('Unable to resolve signer agent')];
 
   try {
@@ -546,7 +593,11 @@ export function createClaimTaskTool(
       const [taskPda, taskErr] = parseBase58(args.taskPda, 'taskPda');
       if (taskErr || !taskPda) return taskErr ?? errorResult('Invalid taskPda');
 
-      const [signerAgent, signerErr] = await resolveSignerAgentContext(program, args.workerAgentPda);
+      const [signerAgent, signerErr] = await resolveSignerAgentContext(
+        program,
+        args.workerAgentPda,
+        'workerAgentPda',
+      );
       if (signerErr || !signerAgent) return signerErr ?? errorResult('Unable to resolve worker agent');
 
       try {
@@ -614,7 +665,11 @@ export function createCompleteTaskTool(
       const [proofHash, proofErr] = parseFixedHexBytes(args.proofHash, 'proofHash', HASH_BYTES);
       if (proofErr || !proofHash) return proofErr ?? errorResult('Invalid proofHash');
 
-      const [signerAgent, signerErr] = await resolveSignerAgentContext(program, args.workerAgentPda);
+      const [signerAgent, signerErr] = await resolveSignerAgentContext(
+        program,
+        args.workerAgentPda,
+        'workerAgentPda',
+      );
       if (signerErr || !signerAgent) return signerErr ?? errorResult('Unable to resolve worker agent');
 
       let resultData: Uint8Array | null = null;
@@ -712,7 +767,11 @@ export function createRegisterSkillTool(
       required: ['name', 'contentHash', 'price'],
     },
     async execute(args: Record<string, unknown>): Promise<ToolResult> {
-      const [signerAgent, signerErr] = await resolveSignerAgentContext(program, args.authorAgentPda);
+      const [signerAgent, signerErr] = await resolveSignerAgentContext(
+        program,
+        args.authorAgentPda,
+        'authorAgentPda',
+      );
       if (signerErr || !signerAgent) return signerErr ?? errorResult('Unable to resolve author agent');
 
       const [skillId, skillIdErr] = parseFixedHexBytes(args.skillId, 'skillId', HASH_BYTES, true);
@@ -809,7 +868,11 @@ export function createPurchaseSkillTool(
       const [skillPda, skillErr] = parseBase58(args.skillPda, 'skillPda');
       if (skillErr || !skillPda) return skillErr ?? errorResult('Invalid skillPda');
 
-      const [signerAgent, signerErr] = await resolveSignerAgentContext(program, args.buyerAgentPda);
+      const [signerAgent, signerErr] = await resolveSignerAgentContext(
+        program,
+        args.buyerAgentPda,
+        'buyerAgentPda',
+      );
       if (signerErr || !signerAgent) return signerErr ?? errorResult('Unable to resolve buyer agent');
 
       let expectedPrice: bigint | null = null;
@@ -918,7 +981,11 @@ export function createRateSkillTool(
       const [rating, ratingErr] = parseNumberInRange(args.rating, 'rating', 1, 5);
       if (ratingErr || rating === null) return ratingErr ?? errorResult('Invalid rating');
 
-      const [signerAgent, signerErr] = await resolveSignerAgentContext(program, args.raterAgentPda);
+      const [signerAgent, signerErr] = await resolveSignerAgentContext(
+        program,
+        args.raterAgentPda,
+        'raterAgentPda',
+      );
       if (signerErr || !signerAgent) return signerErr ?? errorResult('Unable to resolve rater agent');
 
       const ratingPda = deriveSkillRatingPda(skillPda, signerAgent.agentPda, program.programId);
@@ -1002,7 +1069,11 @@ export function createCreateProposalTool(
       required: ['proposalType', 'title'],
     },
     async execute(args: Record<string, unknown>): Promise<ToolResult> {
-      const [signerAgent, signerErr] = await resolveSignerAgentContext(program, args.proposerAgentPda);
+      const [signerAgent, signerErr] = await resolveSignerAgentContext(
+        program,
+        args.proposerAgentPda,
+        'proposerAgentPda',
+      );
       if (signerErr || !signerAgent) return signerErr ?? errorResult('Unable to resolve proposer agent');
 
       const [proposalType, typeErr] = parseProposalType(args.proposalType);
@@ -1109,7 +1180,11 @@ export function createVoteProposalTool(
       const [approve, approveErr] = parseBooleanInput(args.approve, 'approve');
       if (approveErr || approve === null) return approveErr ?? errorResult('Invalid approve value');
 
-      const [signerAgent, signerErr] = await resolveSignerAgentContext(program, args.voterAgentPda);
+      const [signerAgent, signerErr] = await resolveSignerAgentContext(
+        program,
+        args.voterAgentPda,
+        'voterAgentPda',
+      );
       if (signerErr || !signerAgent) return signerErr ?? errorResult('Unable to resolve voter agent');
 
       try {
@@ -1207,7 +1282,11 @@ export function createInitiateDisputeTool(
       const [disputeId, disputeIdErr] = parseFixedHexBytes(args.disputeId, 'disputeId', HASH_BYTES, true);
       if (disputeIdErr || !disputeId) return disputeIdErr ?? errorResult('Invalid disputeId');
 
-      const [signerAgent, signerErr] = await resolveSignerAgentContext(program, args.initiatorAgentPda);
+      const [signerAgent, signerErr] = await resolveSignerAgentContext(
+        program,
+        args.initiatorAgentPda,
+        'initiatorAgentPda',
+      );
       if (signerErr || !signerAgent) return signerErr ?? errorResult('Unable to resolve initiator agent');
 
       let workerAgentPda: PublicKey | null = null;
@@ -1441,7 +1520,11 @@ export function createStakeReputationTool(
       const amountRangeErr = validateU64(amount, 'amount');
       if (amountRangeErr) return amountRangeErr;
 
-      const [signerAgent, signerErr] = await resolveSignerAgentContext(program, args.stakerAgentPda);
+      const [signerAgent, signerErr] = await resolveSignerAgentContext(
+        program,
+        args.stakerAgentPda,
+        'stakerAgentPda',
+      );
       if (signerErr || !signerAgent) return signerErr ?? errorResult('Unable to resolve staker agent');
 
       try {
@@ -1510,7 +1593,11 @@ export function createDelegateReputationTool(
       );
       if (amountErr || amount === null) return amountErr ?? errorResult('Invalid amount');
 
-      const [signerAgent, signerErr] = await resolveSignerAgentContext(program, args.delegatorAgentPda);
+      const [signerAgent, signerErr] = await resolveSignerAgentContext(
+        program,
+        args.delegatorAgentPda,
+        'delegatorAgentPda',
+      );
       if (signerErr || !signerAgent) return signerErr ?? errorResult('Unable to resolve delegator agent');
 
       let delegateeAgentId: Uint8Array | null = null;

--- a/runtime/src/tools/agenc/tools.test.ts
+++ b/runtime/src/tools/agenc/tools.test.ts
@@ -32,6 +32,12 @@ function fixedBytes(value: string, size = 64) {
   return bytes;
 }
 
+function makeAgentRegistrationData(agentIdSeed: number) {
+  const data = new Uint8Array(72);
+  data.set(new Uint8Array(32).fill(agentIdSeed), 8);
+  return data;
+}
+
 function makeSkillAccount({
   id,
   author,
@@ -383,8 +389,9 @@ describe('agenc query tools', () => {
     });
   });
 
-  it('agenc.inspectMarketplace returns a reputation placeholder when no subject is provided', async () => {
+  it('agenc.inspectMarketplace returns a reputation placeholder when no subject or signer is available', async () => {
     const program = createMockProgram();
+    (program.provider as { publicKey: PublicKey | null }).publicKey = null;
     const summarySpy = vi.spyOn(
       marketplaceSerialization,
       'buildMarketplaceReputationSummaryForAgent',
@@ -406,7 +413,67 @@ describe('agenc query tools', () => {
     expect(summarySpy).not.toHaveBeenCalled();
   });
 
-  it('agenc.inspectMarketplace overview keeps reputation in requires-input state without a subject', async () => {
+  it('agenc.inspectMarketplace returns an unregistered signer summary when no signer registration exists', async () => {
+    const program = createMockProgram();
+    const summarySpy = vi.spyOn(
+      marketplaceSerialization,
+      'buildMarketplaceReputationSummaryForAgent',
+    );
+
+    const tool = createInspectMarketplaceTool(program as never, silentLogger);
+    const result = await tool.execute({ surface: 'reputation' });
+    const parsed = parseJson(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed).toMatchObject({
+      surface: 'reputation',
+      status: 'not_found',
+      count: 0,
+      subject: program.provider.publicKey.toBase58(),
+      items: [
+        {
+          registered: false,
+          authority: program.provider.publicKey.toBase58(),
+        },
+      ],
+    });
+    expect(parsed.message).toContain('No agent registration found');
+    expect(summarySpy).not.toHaveBeenCalled();
+  });
+
+  it('agenc.inspectMarketplace lists signer agent choices when multiple registrations exist', async () => {
+    const program = createMockProgram();
+    const firstAgentPda = PublicKey.unique();
+    const secondAgentPda = PublicKey.unique();
+    const summarySpy = vi.spyOn(
+      marketplaceSerialization,
+      'buildMarketplaceReputationSummaryForAgent',
+    );
+
+    (program.provider.connection.getProgramAccounts as any).mockResolvedValue([
+      { pubkey: secondAgentPda, account: { data: makeAgentRegistrationData(2) } },
+      { pubkey: firstAgentPda, account: { data: makeAgentRegistrationData(1) } },
+    ]);
+
+    const tool = createInspectMarketplaceTool(program as never, silentLogger);
+    const result = await tool.execute({ surface: 'reputation' });
+    const parsed = parseJson(result);
+    const expectedAgentPdas = [firstAgentPda.toBase58(), secondAgentPda.toBase58()].sort();
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed).toMatchObject({
+      surface: 'reputation',
+      status: 'requires_input',
+      count: 2,
+      subject: program.provider.publicKey.toBase58(),
+    });
+    expect(parsed.message).toContain('Multiple agent registrations found');
+    expect(parsed.items.map((item: Record<string, unknown>) => item.agentPda)).toEqual(expectedAgentPdas);
+    expect(parsed.items.every((item: Record<string, unknown>) => item.registered === true)).toBe(true);
+    expect(summarySpy).not.toHaveBeenCalled();
+  });
+
+  it('agenc.inspectMarketplace overview reports signer reputation as not found without a registration', async () => {
     const program = createMockProgram();
     const summarySpy = vi.spyOn(
       marketplaceSerialization,
@@ -423,13 +490,13 @@ describe('agenc query tools', () => {
 
     expect(result.isError).toBeUndefined();
     expect(parsed.surface).toBe('marketplace');
-    expect(parsed.status).toBe('requires_input');
+    expect(parsed.status).toBe('ok');
     expect(parsed.count).toBe(5);
     expect(parsed.overview.reputation).toMatchObject({
-      status: 'requires_input',
+      status: 'not_found',
       count: 0,
     });
-    expect(parsed.overview.reputation.message).toContain('Provide <agentPda>');
+    expect(parsed.overview.reputation.message).toContain('No agent registration found');
     expect(summarySpy).not.toHaveBeenCalled();
   });
 

--- a/runtime/src/tools/agenc/tools.ts
+++ b/runtime/src/tools/agenc/tools.ts
@@ -93,6 +93,9 @@ const DESCRIPTION_BYTES = 64;
 const TASK_ID_BYTES = 32;
 const MAX_U64 = (1n << 64n) - 1n;
 const DUMMY_AGENT_ID = new Uint8Array(32);
+const AGENT_DISCRIMINATOR = Buffer.from([130, 53, 100, 103, 121, 77, 148, 19]);
+const AGENT_ID_OFFSET = 8;
+const AGENT_AUTHORITY_OFFSET = AGENT_ID_OFFSET + TASK_ID_BYTES;
 
 /**
  * Dedup guard for createTask — prevents the LLM from calling createTask
@@ -257,6 +260,66 @@ function parseKnownRewardMint(input: unknown): [PublicKey | null, ToolResult | n
   return [mint, null];
 }
 
+interface SignerAgentChoice {
+  registered: true;
+  authority: string;
+  agentPda: string;
+  agentId: string;
+}
+
+function ambiguousSignerAgentsResult(authority: PublicKey, agents: SignerAgentChoice[]): ToolResult {
+  return {
+    content: safeStringify({
+      error:
+        'Multiple agent registrations found for signer wallet. Provide creatorAgentPda with one of the listed agentPda values.',
+      code: 'MULTIPLE_AGENT_REGISTRATIONS',
+      status: 'requires_input',
+      authority: authority.toBase58(),
+      count: agents.length,
+      agents,
+    }),
+    isError: true,
+  };
+}
+
+async function findSignerAgentChoices(
+  program: Program<AgencCoordination>,
+  authority: PublicKey,
+): Promise<SignerAgentChoice[]> {
+  // Use raw getProgramAccounts to bypass Anchor deserialization bug with enum repr.
+  const bs58 = await import('bs58');
+  const matches = await program.provider.connection.getProgramAccounts(program.programId, {
+    filters: [
+      { memcmp: { offset: 0, bytes: bs58.default.encode(AGENT_DISCRIMINATOR) } },
+      { memcmp: { offset: AGENT_AUTHORITY_OFFSET, bytes: authority.toBase58() } },
+    ],
+  });
+
+  return matches
+    .map((match) => ({
+      registered: true as const,
+      authority: authority.toBase58(),
+      agentPda: match.pubkey.toBase58(),
+      agentId: bytesToHex(match.account.data.subarray(AGENT_ID_OFFSET, AGENT_AUTHORITY_OFFSET)),
+    }))
+    .sort((left, right) => left.agentPda.localeCompare(right.agentPda));
+}
+
+function buildAmbiguousSignerAgentsSurface(
+  authority: PublicKey,
+  agents: SignerAgentChoice[],
+): MarketplaceInspectSurface {
+  return buildMarketplaceInspectSurface({
+    surface: 'reputation',
+    status: 'requires_input',
+    subject: authority.toBase58(),
+    message:
+      'Multiple agent registrations found for signer wallet. Provide one of the listed agentPda values to inspect reputation deterministically.',
+    items: agents,
+    count: agents.length,
+  });
+}
+
 async function resolveCreatorAgentPda(
   program: Program<AgencCoordination>,
   creator: PublicKey,
@@ -267,25 +330,16 @@ async function resolveCreatorAgentPda(
     return [pda, err];
   }
 
-  // Use raw getProgramAccounts to bypass Anchor deserialization bug with enum repr
-  const bs58 = await import('bs58');
-  const AGENT_DISCRIMINATOR = Buffer.from([130, 53, 100, 103, 121, 77, 148, 19]);
-  const AGENT_AUTHORITY_OFFSET = 40; // 8 (disc) + 32 (agent_id)
-  const matches = await program.provider.connection.getProgramAccounts(program.programId, {
-    filters: [
-      { memcmp: { offset: 0, bytes: bs58.default.encode(AGENT_DISCRIMINATOR) } },
-      { memcmp: { offset: AGENT_AUTHORITY_OFFSET, bytes: creator.toBase58() } },
-    ],
-  });
+  const matches = await findSignerAgentChoices(program, creator);
 
   if (matches.length === 0) {
     return [null, errorResult('No agent registration found for signer wallet. Run `agenc-runtime agent register --rpc <url>` first, or provide creatorAgentPda.')];
   }
   if (matches.length > 1) {
-    return [null, errorResult('Multiple agent registrations found for signer wallet. Provide creatorAgentPda.')];
+    return [null, ambiguousSignerAgentsResult(creator, matches)];
   }
 
-  return [matches[0].pubkey, null];
+  return [new PublicKey(matches[0]!.agentPda), null];
 }
 
 function isMissingAccountError(err: unknown): boolean {
@@ -709,7 +763,36 @@ async function buildMarketplaceReputationSurface(
   const requestedSubject =
     typeof requestedAgentPda === 'string' ? requestedAgentPda.trim() : requestedAgentPda;
   if (requestedSubject === undefined || requestedSubject === null || requestedSubject === '') {
-    return buildMarketplaceReputationInspectPlaceholder();
+    const authority = program.provider.publicKey;
+    if (!authority) {
+      return buildMarketplaceReputationInspectPlaceholder();
+    }
+
+    const matches = await findSignerAgentChoices(program, authority);
+    if (matches.length === 0) {
+      return buildMarketplaceInspectSurface({
+        surface: 'reputation',
+        status: 'not_found',
+        subject: authority.toBase58(),
+        message: 'No agent registration found for signer wallet.',
+        items: [buildMarketplaceUnregisteredSummary({ authority: authority.toBase58() })],
+        count: 0,
+      });
+    }
+    if (matches.length > 1) {
+      return buildAmbiguousSignerAgentsSurface(authority, matches);
+    }
+
+    const [summary, summaryErr] = await loadReputationSummary(program, matches[0]!.agentPda);
+    if (summaryErr || !summary) {
+      throw new Error(parseToolErrorMessage(summaryErr) ?? 'Unable to inspect marketplace reputation');
+    }
+    return buildMarketplaceInspectSurface({
+      surface: 'reputation',
+      subject: summary.agentPda ?? summary.authority ?? null,
+      items: [summary],
+      count: 1,
+    });
   }
   const [summary, summaryErr] = await loadReputationSummary(program, requestedSubject);
   if (summaryErr || !summary) {


### PR DESCRIPTION
## Summary

- Return structured `requires_input` results with listed signer agent choices when AgenC tools find multiple registrations for the signer wallet.
- Teach the chat executor to stop retrying `requires_input` tool faults and ask the user for the missing `agentPda`/`creatorAgentPda` instead.
- Preserve streamed post-tool final content when the provider terminal payload is empty, preventing false empty-content recovery.
- Update CLI, webchat, and prompt guidance so ambiguous reputation/agent flows request a concrete PDA instead of treating ambiguity as no registration.

## Root Cause

Signer wallets can have multiple agent registration accounts. The previous auto-discovery path collapsed that case into a generic tool error, which let the model retry the same failing call and eventually hit `no_progress`. Some provider streams also emitted the final useful response as streamed chunks while returning an empty terminal payload, which caused the executor to think the answer was empty.

## Validation

- `git diff --check`
- `npm test -- src/llm/chat-executor-recovery.test.ts src/llm/chat-executor.test.ts src/tools/agenc/tools.test.ts src/tools/agenc/mutation-tools.test.ts src/gateway/daemon.test.ts`
- `npm run typecheck`
- `npm run build`

Note: `npm run build` still emits the existing generated CSS warning for `[all:2]`; the build succeeds.
