### PR TITLE
feat(runtime): add marketplace job spec support

### DIFF
--- a/runtime/src/agent/pda.test.ts
+++ b/runtime/src/agent/pda.test.ts
@@ -3,9 +3,11 @@ import { PublicKey } from "@solana/web3.js";
 import { PROGRAM_ID, SEEDS } from "@tetsuo-ai/sdk";
 import {
   deriveAgentPda,
+  deriveAuthorityRateLimitPda,
   deriveProtocolPda,
   deriveAuthorityRateLimitPda,
   findAgentPda,
+  findAuthorityRateLimitPda,
   findProtocolPda,
   findAuthorityRateLimitPda,
   type PdaWithBump,
@@ -254,6 +256,29 @@ describe("PDA derivation helpers", () => {
 
       const address = findProtocolPda(customProgramId);
       const { address: derivedAddress } = deriveProtocolPda(customProgramId);
+
+      expect(address.equals(derivedAddress)).toBe(true);
+    });
+  });
+
+  describe("deriveAuthorityRateLimitPda", () => {
+    it("uses authority_rate_limit and authority seeds", () => {
+      const authority = PublicKey.unique();
+      const result = deriveAuthorityRateLimitPda(authority);
+
+      const [expected, expectedBump] = PublicKey.findProgramAddressSync(
+        [Buffer.from("authority_rate_limit"), authority.toBuffer()],
+        PROGRAM_ID,
+      );
+
+      expect(result.address.equals(expected)).toBe(true);
+      expect(result.bump).toBe(expectedBump);
+    });
+
+    it("findAuthorityRateLimitPda returns the derived address", () => {
+      const authority = PublicKey.unique();
+      const address = findAuthorityRateLimitPda(authority);
+      const { address: derivedAddress } = deriveAuthorityRateLimitPda(authority);
 
       expect(address.equals(derivedAddress)).toBe(true);
     });

--- a/runtime/src/agent/pda.ts
+++ b/runtime/src/agent/pda.ts
@@ -5,20 +5,20 @@
 
 import { PublicKey } from "@solana/web3.js";
 import { PROGRAM_ID, SEEDS } from "@tetsuo-ai/sdk";
-
-type OptionalSeedRecord = Partial<Record<string, Buffer>>;
-
-// The runtime can move ahead of the published SDK package. Fall back to raw
-// seed bytes locally until the matching SDK release is available.
-const optionalSeeds = SEEDS as OptionalSeedRecord;
-const AUTHORITY_RATE_LIMIT_SEED =
-  optionalSeeds.AUTHORITY_RATE_LIMIT ?? Buffer.from("authority_rate_limit");
 import { AGENT_ID_LENGTH } from "./types.js";
 import { derivePda, validateIdLength } from "../utils/pda.js";
 
 // Re-export PdaWithBump from utils — existing consumers import from here
 export type { PdaWithBump } from "../utils/pda.js";
 import type { PdaWithBump } from "../utils/pda.js";
+
+type OptionalSeedRecord = Partial<Record<string, Buffer>>;
+
+// The runtime can be upgraded ahead of the published SDK package. Fall back to
+// the raw seed bytes locally until the matching SDK release is available.
+const optionalSeeds = SEEDS as OptionalSeedRecord;
+const AUTHORITY_RATE_LIMIT_SEED =
+  optionalSeeds.AUTHORITY_RATE_LIMIT ?? Buffer.from("authority_rate_limit");
 
 /**
  * Derives the agent PDA and bump seed from an agent ID.

--- a/runtime/src/channels/webchat/handlers.ts
+++ b/runtime/src/channels/webchat/handlers.ts
@@ -1226,27 +1226,57 @@ async function handleTasksCreate(
     const rewardLamports = explicitRewardLamports
       ? BigInt(explicitRewardLamports)
       : BigInt(Math.max(Math.round(rewardInput * 1_000_000_000), 10_000_000));
-    const { program } = await createProgramContext(deps);
-    const tool = createCreateTaskTool(program, silentLogger);
-    const result = await tool.execute({
+    const taskParams = params as Record<string, unknown>;
+    const createArgs: Record<string, unknown> = {
       description: descStr,
       reward: rewardLamports.toString(),
       requiredCapabilities: '1',
-    });
+    };
+    for (const field of [
+      'jobSpec',
+      'fullDescription',
+      'acceptanceCriteria',
+      'deliverables',
+      'constraints',
+      'attachments',
+    ]) {
+      if (taskParams[field] !== undefined) {
+        createArgs[field] = taskParams[field];
+      }
+    }
+    const { program } = await createProgramContext(deps);
+    const tool = createCreateTaskTool(program, silentLogger);
+    const result = await tool.execute(createArgs);
     if (result.isError) {
       send({ type: 'error', error: `Failed to create task: ${parseToolError(result)}`, id });
       return;
     }
     let createdTaskPda: string | undefined;
+    let createdJobSpecHash: string | undefined;
+    let createdJobSpecUri: string | undefined;
     try {
-      createdTaskPda = (JSON.parse(result.content) as { taskPda?: string }).taskPda;
+      const createdPayload = JSON.parse(result.content) as {
+        taskPda?: string;
+        jobSpecHash?: string | null;
+        jobSpecUri?: string | null;
+      };
+      createdTaskPda = createdPayload.taskPda;
+      createdJobSpecHash = createdPayload.jobSpecHash ?? undefined;
+      createdJobSpecUri = createdPayload.jobSpecUri ?? undefined;
     } catch {
       createdTaskPda = undefined;
+      createdJobSpecHash = undefined;
+      createdJobSpecUri = undefined;
     }
 
     // Auto-refresh task list after creation
     await sendTaskList(deps, id, send);
-    deps.broadcastEvent?.('task.created', { taskPda: createdTaskPda, description: descStr });
+    deps.broadcastEvent?.('task.created', {
+      taskPda: createdTaskPda,
+      description: descStr,
+      jobSpecHash: createdJobSpecHash,
+      jobSpecUri: createdJobSpecUri,
+    });
   } catch (err) {
     send({ type: 'error', error: `Failed to create task: ${(err as Error).message}`, id });
   }

--- a/runtime/src/cli/index.test.ts
+++ b/runtime/src/cli/index.test.ts
@@ -399,6 +399,10 @@ describe("runtime root CLI", () => {
         "50000000",
         "--required-capabilities",
         "1",
+        "--validation-mode",
+        "creator-review",
+        "--review-window-secs",
+        "120",
       ],
       stdout: stdout.stream,
       stderr: stderr.stream,
@@ -412,6 +416,8 @@ describe("runtime root CLI", () => {
         description: "Public task from CLI test",
         reward: "50000000",
         requiredCapabilities: "1",
+        validationMode: "creator-review",
+        reviewWindowSecs: 120,
       }),
     );
   });

--- a/runtime/src/cli/index.ts
+++ b/runtime/src/cli/index.ts
@@ -598,17 +598,30 @@ type MarketCommand =
   | "tui";
 
 const MARKET_COMMAND_OPTIONS: Record<MarketCommand, Set<string>> = {
-  "tasks.list": new Set(["status"]),
+  "tasks.list": new Set(["status", "task-type", "job-spec-store-dir"]),
   "tasks.create": new Set([
     "description",
     "reward",
+    "reward-mint",
     "required-capabilities",
     "max-workers",
     "deadline",
     "task-type",
+    "min-reputation",
+    "constraint-hash",
+    "validation-mode",
+    "review-window-secs",
     "creator-agent-pda",
+    "job-spec",
+    "full-description",
+    "acceptance-criteria",
+    "deliverables",
+    "constraints",
+    "attachment",
+    "attachments",
+    "job-spec-store-dir",
   ]),
-  "tasks.detail": new Set(),
+  "tasks.detail": new Set(["job-spec-store-dir"]),
   "tasks.cancel": new Set(),
   "tasks.claim": new Set(["worker-agent-pda"]),
   "tasks.complete": new Set(["proof-hash", "result-data", "worker-agent-pda"]),
@@ -1074,11 +1087,23 @@ function buildHelp(): string {
     "      --status <s1,s2>                      Status filter for tasks/disputes list",
     "      --description <text>                  Task description for market tasks create",
     "      --reward <lamports>                   Task reward for market tasks create",
+    "      --reward-mint <mint>                  Optional SPL reward mint for task creation",
     "      --required-capabilities <u64>         Required capability bitmask for task creation (default: 1)",
     "      --max-workers <n>                     Max workers for task creation",
     "      --deadline <unix>                     Task deadline for task creation",
-    "      --task-type <0|1|2>                   Task type for task creation",
+    "      --task-type <type>                    Task type for task list/create: 0/exclusive, 1/collaborative, 2/competitive, 3/bid-exclusive",
+    "      --min-reputation <n>                  Minimum worker reputation for task creation",
+    "      --constraint-hash <hex>               Optional 32-byte private-task constraint hash",
+    "      --validation-mode auto|creator-review Hold payout until creator approval when creator-review",
+    "      --review-window-secs <n>              Review window for creator-review task creation",
     "      --creator-agent-pda <pda>             Explicit creator agent PDA for task creation",
+    "      --job-spec <text>                    Full off-chain job spec text for task creation",
+    "      --full-description <text>            Detailed off-chain task description",
+    "      --acceptance-criteria <items>        Comma/newline-separated acceptance criteria",
+    "      --deliverables <items>               Comma/newline-separated deliverables",
+    "      --constraints <json>                 JSON constraints stored in the off-chain job spec",
+    "      --attachment <url>                   Off-chain job spec attachment URL (repeatable)",
+    "      --job-spec-store-dir <path>          Local content-addressed job spec store override",
     "      --query <text>                        Text filter for skills list",
     "      --tags <t1,t2>                        Tag filter for skills list",
     "      --limit <n>                           Limit skills list results",
@@ -1136,6 +1161,7 @@ function buildHelp(): string {
     "  agenc-runtime plugin list",
     "  agenc-runtime market tasks list --status open,in_progress",
     "  agenc-runtime market tasks create --description 'public task' --reward 50000000",
+    "  agenc-runtime market tasks create --description 'reviewed task' --reward 50000000 --validation-mode creator-review --review-window-secs 3600 --creator-agent-pda <agentPda>",
     "  agenc-runtime market tasks claim <taskPda>",
     "  agenc-runtime market tasks cancel <taskPda>",
     "  agenc-runtime market tasks complete <taskPda> --result-data 'completed via cli'",
@@ -2697,6 +2723,10 @@ function normalizeAndValidateMarketCommand(
       options = {
         ...base,
         statuses: parseStringListFlag(parsed.flags.status),
+        taskType: parseOptionalScalarFlag(parsed.flags["task-type"]),
+        jobSpecStoreDir: parseOptionalStringFlag(
+          parsed.flags["job-spec-store-dir"],
+        ),
       } as MarketTasksListOptions;
       break;
     case "tasks.create": {
@@ -2718,12 +2748,28 @@ function normalizeAndValidateMarketCommand(
         ...base,
         description,
         reward,
+        rewardMint: parseOptionalStringFlag(parsed.flags["reward-mint"]),
         requiredCapabilities:
           parseOptionalScalarFlag(parsed.flags["required-capabilities"]) ?? "1",
         maxWorkers: parseOptionalNumberFlag(parsed.flags["max-workers"]),
         deadline: parseOptionalNumberFlag(parsed.flags.deadline),
-        taskType: parseOptionalNumberFlag(parsed.flags["task-type"]),
+        taskType: parseOptionalScalarFlag(parsed.flags["task-type"]),
+        minReputation: parseOptionalNumberFlag(parsed.flags["min-reputation"]),
+        constraintHash: parseOptionalStringFlag(parsed.flags["constraint-hash"]),
+        validationMode: parseOptionalStringFlag(parsed.flags["validation-mode"]),
+        reviewWindowSecs: parseOptionalNumberFlag(parsed.flags["review-window-secs"]),
         creatorAgentPda: parseOptionalStringFlag(parsed.flags["creator-agent-pda"]),
+        jobSpec: parseOptionalStringFlag(parsed.flags["job-spec"]),
+        fullDescription: parseOptionalStringFlag(parsed.flags["full-description"]),
+        acceptanceCriteria: parseStringListFlag(parsed.flags["acceptance-criteria"]),
+        deliverables: parseStringListFlag(parsed.flags.deliverables),
+        constraints: parseOptionalStringFlag(parsed.flags.constraints),
+        attachments:
+          parseStringListFlag(parsed.flags.attachment) ??
+          parseStringListFlag(parsed.flags.attachments),
+        jobSpecStoreDir: parseOptionalStringFlag(
+          parsed.flags["job-spec-store-dir"],
+        ),
       } as MarketTaskCreateOptions;
       break;
     }
@@ -2735,7 +2781,13 @@ function normalizeAndValidateMarketCommand(
           ERROR_CODES.MISSING_TARGET,
         );
       }
-      options = { ...base, taskPda } as MarketTaskDetailOptions;
+      options = {
+        ...base,
+        taskPda,
+        jobSpecStoreDir: parseOptionalStringFlag(
+          parsed.flags["job-spec-store-dir"],
+        ),
+      } as MarketTaskDetailOptions;
       break;
     }
     case "tasks.cancel": {

--- a/runtime/src/cli/marketplace-cli.ts
+++ b/runtime/src/cli/marketplace-cli.ts
@@ -24,6 +24,18 @@ import {
   serializeMarketplaceTaskEntry,
 } from "../marketplace/serialization.js";
 import {
+  isMarketplaceJobSpecTaskLinkNotFoundError,
+  readMarketplaceJobSpecPointerForTask,
+  resolveMarketplaceJobSpecForTask,
+  type MarketplaceJobSpecStoreOptions,
+  type MarketplaceJobSpecTaskPointer,
+  type ResolvedMarketplaceJobSpec,
+} from "../marketplace/job-spec-store.js";
+import {
+  resolveOnChainTaskJobSpecForTask,
+  type ResolvedOnChainTaskJobSpec,
+} from "../marketplace/task-job-spec.js";
+import {
   buildMarketplaceInspectOverview,
   buildMarketplaceInspectSurface,
   buildMarketplaceReputationInspectPlaceholder,
@@ -33,6 +45,7 @@ import { OnChainSkillRegistryClient } from "../skills/registry/client.js";
 import { SkillPurchaseManager } from "../skills/registry/payment.js";
 import { TaskOperations } from "../task/operations.js";
 import { findEscrowPda } from "../task/pda.js";
+import { parseTaskTypeAlias } from "../task/types.js";
 import {
   loadKeypairFromFile,
   keypairToWallet,
@@ -55,20 +68,35 @@ import type { BaseCliOptions, CliRuntimeContext, CliStatusCode } from "./types.j
 
 export interface MarketTasksListOptions extends BaseCliOptions {
   statuses?: string[];
+  taskType?: string;
+  jobSpecStoreDir?: string;
 }
 
 export interface MarketTaskCreateOptions extends BaseCliOptions {
   description: string;
   reward: string;
   requiredCapabilities: string;
+  rewardMint?: string;
   maxWorkers?: number;
   deadline?: number;
-  taskType?: number;
+  taskType?: string;
+  minReputation?: number;
+  constraintHash?: string;
+  validationMode?: string;
+  reviewWindowSecs?: number;
   creatorAgentPda?: string;
+  jobSpec?: unknown;
+  fullDescription?: string;
+  acceptanceCriteria?: string[];
+  deliverables?: string[];
+  constraints?: unknown;
+  attachments?: unknown;
+  jobSpecStoreDir?: string;
 }
 
 export interface MarketTaskDetailOptions extends BaseCliOptions {
   taskPda: string;
+  jobSpecStoreDir?: string;
 }
 
 export interface MarketTaskCancelOptions extends MarketTaskDetailOptions {}
@@ -431,6 +459,10 @@ function mapTaskSummary(
     rewardLamports: task.rewardLamports,
     rewardSol: task.rewardSol,
     rewardMint: task.rewardMint,
+    taskType: task.taskType,
+    taskTypeId: task.taskTypeId,
+    taskTypeName: task.taskTypeName,
+    taskTypeKey: task.taskTypeKey,
     currentWorkers: task.currentWorkers,
     maxWorkers: task.maxWorkers,
     deadline: task.deadline,
@@ -441,6 +473,144 @@ function mapTaskSummary(
 function mapTaskDetail(taskPda: PublicKey, task: Awaited<ReturnType<TaskOperations["fetchTask"]>>) {
   if (!task) return null;
   return serializeMarketplaceTask(taskPda, task);
+}
+
+type SerializedJobSpecPointer =
+  | {
+      available: true;
+      jobSpecHash: string;
+      jobSpecUri: string;
+      jobSpecTaskLinkPath: string;
+      transactionSignature: string;
+    }
+  | { available: false; error?: string };
+
+type SerializedResolvedJobSpec = {
+  available: true;
+  jobSpecHash: string;
+  jobSpecUri: string;
+  jobSpecPath: string;
+  jobSpecTaskLinkPath: string | null;
+  transactionSignature: string | null;
+  integrity: ResolvedMarketplaceJobSpec["integrity"];
+  payload: ResolvedMarketplaceJobSpec["payload"];
+};
+
+function getJobSpecStoreOptions(
+  rootDir?: string,
+): MarketplaceJobSpecStoreOptions {
+  return rootDir ? { rootDir } : {};
+}
+
+function serializeJobSpecPointer(
+  pointer: MarketplaceJobSpecTaskPointer,
+): SerializedJobSpecPointer {
+  return {
+    available: true,
+    jobSpecHash: pointer.jobSpecHash,
+    jobSpecUri: pointer.jobSpecUri,
+    jobSpecTaskLinkPath: pointer.jobSpecTaskLinkPath,
+    transactionSignature: pointer.transactionSignature,
+  };
+}
+
+function serializeResolvedJobSpec(
+  spec: ResolvedMarketplaceJobSpec,
+): SerializedResolvedJobSpec {
+  return {
+    available: true,
+    jobSpecHash: spec.jobSpecHash,
+    jobSpecUri: spec.jobSpecUri,
+    jobSpecPath: spec.jobSpecPath,
+    jobSpecTaskLinkPath: spec.jobSpecTaskLinkPath,
+    transactionSignature: spec.transactionSignature,
+    integrity: spec.integrity,
+    payload: spec.payload,
+  };
+}
+
+function serializeResolvedOnChainJobSpec(
+  spec: ResolvedOnChainTaskJobSpec,
+  localPointer?: MarketplaceJobSpecTaskPointer | null,
+): SerializedResolvedJobSpec {
+  return {
+    available: true,
+    jobSpecHash: spec.jobSpecHash,
+    jobSpecUri: spec.jobSpecUri,
+    jobSpecPath: spec.jobSpecPath,
+    jobSpecTaskLinkPath: localPointer?.jobSpecTaskLinkPath ?? null,
+    transactionSignature: localPointer?.transactionSignature ?? null,
+    integrity: spec.integrity,
+    payload: spec.payload,
+  };
+}
+
+async function enrichTaskSummaryWithJobSpec<T extends { taskPda: string }>(
+  task: T,
+  rootDir?: string,
+): Promise<T & { jobSpec: SerializedJobSpecPointer }> {
+  try {
+    const pointer = await readMarketplaceJobSpecPointerForTask(
+      task.taskPda,
+      getJobSpecStoreOptions(rootDir),
+    );
+    return {
+      ...task,
+      jobSpec: pointer ? serializeJobSpecPointer(pointer) : { available: false },
+    };
+  } catch (error) {
+    return {
+      ...task,
+      jobSpec: {
+        available: false,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
+}
+
+async function enrichTaskDetailWithJobSpec<T extends { taskPda: string }>(
+  task: T,
+  rootDir?: string,
+  program?: MarketProgram,
+): Promise<T & { jobSpec: SerializedResolvedJobSpec | null }> {
+  const storeOptions = getJobSpecStoreOptions(rootDir);
+  if (program) {
+    const taskPda = new PublicKey(task.taskPda);
+    const onChainSpec = await resolveOnChainTaskJobSpecForTask(
+      program,
+      taskPda,
+      storeOptions,
+    );
+    if (onChainSpec) {
+      let localPointer: MarketplaceJobSpecTaskPointer | null = null;
+      try {
+        localPointer = await readMarketplaceJobSpecPointerForTask(
+          task.taskPda,
+          storeOptions,
+        );
+      } catch (error) {
+        if (!isMarketplaceJobSpecTaskLinkNotFoundError(error)) throw error;
+      }
+      return {
+        ...task,
+        jobSpec: serializeResolvedOnChainJobSpec(onChainSpec, localPointer),
+      };
+    }
+  }
+
+  try {
+    const spec = await resolveMarketplaceJobSpecForTask(
+      task.taskPda,
+      storeOptions,
+    );
+    return { ...task, jobSpec: serializeResolvedJobSpec(spec) };
+  } catch (error) {
+    if (isMarketplaceJobSpecTaskLinkNotFoundError(error)) {
+      return { ...task, jobSpec: null };
+    }
+    throw error;
+  }
 }
 
 function mapSkillSummary(entry: {
@@ -474,6 +644,17 @@ function filterByStatus<T extends { status: string }>(
   const filter = normalizeStatusFilter(statuses);
   if (!filter) return items;
   return items.filter((item) => filter.has(item.status));
+}
+
+function parseTaskTypeFilter(input?: string): number | undefined {
+  if (!input) return undefined;
+  const parsed = parseTaskTypeAlias(input);
+  if (parsed === null) {
+    throw new Error(
+      'taskType must be one of 0/exclusive, 1/collaborative, 2/competitive, or 3/bid-exclusive',
+    );
+  }
+  return parsed;
 }
 
 function filterInspectItemsByStatus(
@@ -852,16 +1033,26 @@ export async function runMarketTasksListCommand(
       agentId: ZERO_AGENT_ID,
       logger: silentLogger,
     });
+    const taskTypeFilter = parseTaskTypeFilter(options.taskType);
+    const entries = await ops.fetchAllTasks();
+    const filteredEntries = taskTypeFilter === undefined
+      ? entries
+      : entries.filter(({ task }) => task.taskType === taskTypeFilter);
     const items = filterByStatus(
-      (await ops.fetchAllTasks()).map(mapTaskSummary),
+      filteredEntries.map(mapTaskSummary),
       options.statuses,
+    );
+    const tasks = await Promise.all(
+      items.map((task) =>
+        enrichTaskSummaryWithJobSpec(task, options.jobSpecStoreDir),
+      ),
     );
     context.output({
       status: "ok",
       command: "market.tasks.list",
       schema: "market.tasks.list.output.v1",
-      count: items.length,
-      tasks: items,
+      count: tasks.length,
+      tasks,
     });
     return 0;
   } catch (error) {
@@ -882,15 +1073,29 @@ export async function runMarketTaskCreateCommand(
 
   try {
     const { program } = await createSignerProgramContext(options);
-    const tool = createCreateTaskTool(program, silentLogger);
+    const createTaskOptions = options.jobSpecStoreDir
+      ? { jobSpecStoreDir: options.jobSpecStoreDir }
+      : undefined;
+    const tool = createCreateTaskTool(program, silentLogger, createTaskOptions);
     const result = await tool.execute({
       description: options.description,
       reward: options.reward,
       requiredCapabilities: options.requiredCapabilities,
+      rewardMint: options.rewardMint,
       maxWorkers: options.maxWorkers,
       deadline: options.deadline,
       taskType: options.taskType,
+      minReputation: options.minReputation,
+      constraintHash: options.constraintHash,
+      validationMode: options.validationMode,
+      reviewWindowSecs: options.reviewWindowSecs,
       creatorAgentPda: options.creatorAgentPda,
+      jobSpec: options.jobSpec,
+      fullDescription: options.fullDescription,
+      acceptanceCriteria: options.acceptanceCriteria,
+      deliverables: options.deliverables,
+      constraints: options.constraints,
+      attachments: options.attachments,
     });
     if (result.isError) {
       context.error({
@@ -940,11 +1145,24 @@ export async function runMarketTaskDetailCommand(
       });
       return 1;
     }
+    const taskDetail = mapTaskDetail(taskPda, task);
+    if (!taskDetail) {
+      context.error({
+        status: "error",
+        code: "MARKET_TASK_NOT_FOUND",
+        message: `Task not found: ${options.taskPda}`,
+      });
+      return 1;
+    }
     context.output({
       status: "ok",
       command: "market.tasks.detail",
       schema: "market.tasks.detail.output.v1",
-      task: mapTaskDetail(taskPda, task),
+      task: await enrichTaskDetailWithJobSpec(
+        taskDetail,
+        options.jobSpecStoreDir,
+        program,
+      ),
     });
     return 0;
   } catch (error) {

--- a/runtime/src/cli/marketplace-tui.ts
+++ b/runtime/src/cli/marketplace-tui.ts
@@ -158,6 +158,15 @@ async function promptOptional(
   return value.length > 0 ? value : undefined;
 }
 
+function parseCommaSeparatedOptional(value: string | undefined): string[] | undefined {
+  if (!value) return undefined;
+  const items = value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return items.length > 0 ? items : undefined;
+}
+
 async function promptRequired(
   rl: ReturnType<typeof createInterface>,
   label: string,
@@ -360,7 +369,12 @@ async function runTasksLoop(
     if (action === "back") return "back";
     if (action === "quit" || action === "exit") return "quit";
     if (action === "create") {
-      const description = await promptRequired(rl, "description");
+      const description = await promptRequired(rl, "short on-chain description");
+      const fullDescription = await promptOptional(rl, "full job description");
+      const acceptanceCriteriaRaw = await promptOptional(rl, "acceptance criteria (comma-separated)");
+      const deliverablesRaw = await promptOptional(rl, "deliverables (comma-separated)");
+      const attachmentsRaw = await promptOptional(rl, "attachment URLs (comma-separated)");
+      const constraints = await promptOptional(rl, "constraints / safety notes");
       const reward = await promptRequired(rl, "reward lamports");
       const requiredCapabilities = await promptRequired(
         rl,
@@ -370,6 +384,16 @@ async function runTasksLoop(
       const maxWorkersRaw = await promptOptional(rl, "max workers");
       const deadlineRaw = await promptOptional(rl, "deadline (unix seconds)");
       const taskTypeRaw = await promptOptional(rl, "task type (0 exclusive, 1 collaborative, 2 competitive)");
+      const validationModeRaw = await promptRequired(
+        rl,
+        "validation mode (auto, creator-review)",
+        "auto",
+      );
+      const reviewWindowRaw =
+        validationModeRaw.trim().toLowerCase().replace(/_/g, "-") ===
+        "creator-review"
+          ? await promptRequired(rl, "review window seconds", "3600")
+          : "";
       await showRunnerResult(
         rl,
         stdout,
@@ -384,6 +408,13 @@ async function runTasksLoop(
           maxWorkers: maxWorkersRaw ? Number.parseInt(maxWorkersRaw, 10) : undefined,
           deadline: deadlineRaw ? Number.parseInt(deadlineRaw, 10) : undefined,
           taskType: taskTypeRaw ? Number.parseInt(taskTypeRaw, 10) : undefined,
+          validationMode: validationModeRaw,
+          reviewWindowSecs: reviewWindowRaw ? Number.parseInt(reviewWindowRaw, 10) : undefined,
+          fullDescription,
+          acceptanceCriteria: parseCommaSeparatedOptional(acceptanceCriteriaRaw),
+          deliverables: parseCommaSeparatedOptional(deliverablesRaw),
+          constraints,
+          attachments: parseCommaSeparatedOptional(attachmentsRaw),
         } as MarketTaskCreateOptions,
       );
       continue;

--- a/runtime/src/idl.test.ts
+++ b/runtime/src/idl.test.ts
@@ -15,6 +15,11 @@ import {
 } from './idl';
 
 describe('IDL exports', () => {
+  type InstructionWithAccounts = {
+    name: string;
+    accounts?: Array<{ name: string }>;
+  };
+
   it('exports a valid IDL object', () => {
     expect(IDL).toBeDefined();
     expect(typeof IDL).toBe('object');
@@ -77,6 +82,23 @@ describe('IDL exports', () => {
     expect(instructionNames).toContain('auto_accept_task_result');
     expect(instructionNames).toContain('validate_task_result');
     expect(instructionNames).toContain('register_agent');
+  });
+
+  it('adds authority rate limit accounts to task creation instructions', () => {
+    const instructions = IDL.instructions as InstructionWithAccounts[];
+
+    for (const instructionName of ['create_task', 'create_dependent_task']) {
+      const instruction = instructions.find((ix) => ix.name === instructionName);
+      expect(instruction).toBeDefined();
+
+      const accountNames = instruction?.accounts?.map((account) => account.name) ?? [];
+      const authorityRateLimitIndex = accountNames.indexOf('authority_rate_limit');
+      const authorityIndex = accountNames.indexOf('authority');
+
+      expect(authorityRateLimitIndex).toBeGreaterThanOrEqual(0);
+      expect(authorityIndex).toBeGreaterThanOrEqual(0);
+      expect(authorityRateLimitIndex).toBeLessThan(authorityIndex);
+    }
   });
 
   it('has accounts array with entries', () => {

--- a/runtime/src/idl.ts
+++ b/runtime/src/idl.ts
@@ -948,6 +948,51 @@ const TASK_VALIDATION_V2_INSTRUCTIONS = [
   },
 ] as const;
 
+const TASK_JOB_SPEC_INSTRUCTIONS = [
+  {
+    name: "set_task_job_spec",
+    docs: ["Attach or update verified marketplace job spec metadata for a task."],
+    discriminator: [134, 102, 102, 86, 31, 164, 202, 193],
+    accounts: [
+      {
+        name: "task",
+        writable: true,
+        pda: {
+          seeds: [
+            { kind: "const", value: [116, 97, 115, 107] },
+            { kind: "account", path: "task.creator", account: "Task" },
+            { kind: "account", path: "task.task_id", account: "Task" },
+          ],
+        },
+      },
+      {
+        name: "task_job_spec",
+        writable: true,
+        pda: {
+          seeds: [
+            {
+              kind: "const",
+              value: [
+                116, 97, 115, 107, 95, 106, 111, 98, 95, 115, 112, 101, 99,
+              ],
+            },
+            { kind: "account", path: "task" },
+          ],
+        },
+      },
+      { name: "creator", writable: true, signer: true },
+      {
+        name: "system_program",
+        address: "11111111111111111111111111111111",
+      },
+    ],
+    args: [
+      { name: "job_spec_hash", type: { array: ["u8", 32] } },
+      { name: "job_spec_uri", type: "string" },
+    ],
+  },
+] as const;
+
 const TASK_VALIDATION_V2_ACCOUNTS = [
   {
     name: "TaskValidationConfig",
@@ -964,6 +1009,36 @@ const TASK_VALIDATION_V2_ACCOUNTS = [
   {
     name: "TaskValidationVote",
     discriminator: [48, 129, 51, 174, 154, 5, 68, 65],
+  },
+] as const;
+
+const TASK_JOB_SPEC_ACCOUNTS = [
+  {
+    name: "TaskJobSpec",
+    discriminator: [249, 63, 211, 94, 228, 165, 3, 196],
+  },
+] as const;
+
+const TASK_JOB_SPEC_TYPES = [
+  {
+    name: "TaskJobSpec",
+    docs: [
+      "Verified marketplace job spec metadata for a task.",
+      '["task_job_spec", task]',
+    ],
+    type: {
+      kind: "struct",
+      fields: [
+        { name: "task", docs: ["Task this metadata belongs to."], type: "pubkey" },
+        { name: "creator", docs: ["Task creator that published the metadata."], type: "pubkey" },
+        { name: "job_spec_hash", docs: ["Canonical sha256 hash for the off-chain job spec envelope payload."], type: { array: ["u8", 32] } },
+        { name: "job_spec_uri", docs: ["Canonical job spec URI."], type: "string" },
+        { name: "created_at", docs: ["Creation timestamp."], type: "i64" },
+        { name: "updated_at", docs: ["Last update timestamp."], type: "i64" },
+        { name: "bump", docs: ["PDA bump."], type: "u8" },
+        { name: "_reserved", docs: ["Reserved for future metadata extensions."], type: { array: ["u8", 7] } },
+      ],
+    },
   },
 ] as const;
 
@@ -1223,18 +1298,27 @@ function augmentIdl(baseIdl: Idl): Idl {
   return {
     ...baseIdl,
     instructions: mergeIdlEntries(
-      overrideInstructionAccounts(
-        baseIdl.instructions as NamedIdlInstruction[] | undefined,
-      ) as unknown as NamedIdlEntry[],
-      TASK_VALIDATION_V2_INSTRUCTIONS as unknown as NamedIdlEntry[],
+      mergeIdlEntries(
+        overrideInstructionAccounts(
+          baseIdl.instructions as NamedIdlInstruction[] | undefined,
+        ) as unknown as NamedIdlEntry[],
+        TASK_VALIDATION_V2_INSTRUCTIONS as unknown as NamedIdlEntry[],
+      ),
+      TASK_JOB_SPEC_INSTRUCTIONS as unknown as NamedIdlEntry[],
     ) as Idl["instructions"],
     accounts: mergeIdlEntries(
-      baseIdl.accounts as NamedIdlEntry[] | undefined,
-      TASK_VALIDATION_V2_ACCOUNTS as unknown as NamedIdlEntry[],
+      mergeIdlEntries(
+        baseIdl.accounts as NamedIdlEntry[] | undefined,
+        TASK_VALIDATION_V2_ACCOUNTS as unknown as NamedIdlEntry[],
+      ),
+      TASK_JOB_SPEC_ACCOUNTS as unknown as NamedIdlEntry[],
     ) as Idl["accounts"],
     types: mergeIdlEntries(
-      baseIdl.types as NamedIdlEntry[] | undefined,
-      TASK_VALIDATION_V2_TYPES as unknown as NamedIdlEntry[],
+      mergeIdlEntries(
+        baseIdl.types as NamedIdlEntry[] | undefined,
+        TASK_VALIDATION_V2_TYPES as unknown as NamedIdlEntry[],
+      ),
+      TASK_JOB_SPEC_TYPES as unknown as NamedIdlEntry[],
     ) as Idl["types"],
   };
 }

--- a/runtime/src/llm/chat-executor-tool-utils.test.ts
+++ b/runtime/src/llm/chat-executor-tool-utils.test.ts
@@ -179,6 +179,30 @@ describe("chat-executor-tool-utils", () => {
       expect(repaired.args.description).toBe("Existing description");
       expect(repaired.repairedFields).toEqual([]);
     });
+
+    it("removes model-invented agenc.createTask taskId when the prompt forbids it", () => {
+      const repaired = repairToolCallArgumentsFromMessageText(
+        "agenc.createTask",
+        {
+          description: "self test parser omitted task id after restart",
+          reward: "10000000",
+          requiredCapabilities: "1",
+          taskId: '{"description":"self',
+          constraintHash: '{"description":"self',
+          validationMode: "auto",
+        },
+        "Call agenc.createTask with exactly this JSON. Do not add taskId or constraintHash:\n" +
+          '{"description":"self test parser omitted task id after restart","reward":"10000000","requiredCapabilities":"1","validationMode":"auto"}',
+      );
+
+      expect(repaired.args).toEqual({
+        description: "self test parser omitted task id after restart",
+        reward: "10000000",
+        requiredCapabilities: "1",
+        validationMode: "auto",
+      });
+      expect(repaired.repairedFields).toEqual(["constraintHash", "taskId"]);
+    });
   });
 
   describe("summarizeToolArgumentChanges", () => {

--- a/runtime/src/llm/chat-executor-tool-utils.ts
+++ b/runtime/src/llm/chat-executor-tool-utils.ts
@@ -546,10 +546,64 @@ export function repairToolCallArgumentsFromMessageText(
   args: Record<string, unknown>,
   messageText: string,
 ): ToolArgumentRepairResult {
+  if (toolName === "agenc.createTask") {
+    return repairAgencCreateTaskArgumentsFromMessageText(args, messageText);
+  }
   if (toolName !== "social.requestCollaboration") {
     return { args, repairedFields: [] };
   }
   return repairCollaborationArgumentsFromMessageText(args, messageText);
+}
+
+const AGENC_CREATE_TASK_OMITTABLE_REPAIR_FIELD_ALIASES: Record<
+  string,
+  readonly string[]
+> = {
+  constraintHash: ["constraintHash", "constraint_hash"],
+  rewardMint: ["rewardMint", "reward_mint"],
+  taskId: ["taskId", "task_id"],
+};
+
+function escapeToolArgumentRegexLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function messageForbidsAgencCreateTaskArgument(
+  messageText: string,
+  aliases: readonly string[],
+): boolean {
+  const fieldPattern = aliases.map(escapeToolArgumentRegexLiteral).join("|");
+  const directiveRe =
+    /\b(?:do\s+not|don't|dont|never)\s+(?:add|include|set|provide)\s+([^:.;\n]+)/gi;
+  const fieldRe = new RegExp(`\\b(?:${fieldPattern})\\b`, "i");
+  for (const match of messageText.matchAll(directiveRe)) {
+    if (match[1] && fieldRe.test(match[1])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function repairAgencCreateTaskArgumentsFromMessageText(
+  args: Record<string, unknown>,
+  messageText: string,
+): ToolArgumentRepairResult {
+  let nextArgs = args;
+  const repairedFields: string[] = [];
+  for (const [field, aliases] of Object.entries(
+    AGENC_CREATE_TASK_OMITTABLE_REPAIR_FIELD_ALIASES,
+  )) {
+    if (
+      field in args &&
+      messageForbidsAgencCreateTaskArgument(messageText, aliases)
+    ) {
+      if (nextArgs === args) nextArgs = { ...args };
+      delete nextArgs[field];
+      repairedFields.push(field);
+    }
+  }
+
+  return { args: nextArgs, repairedFields };
 }
 
 export function summarizeToolArgumentChanges(

--- a/runtime/src/marketplace/job-spec-store.ts
+++ b/runtime/src/marketplace/job-spec-store.ts
@@ -1,0 +1,885 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type MarketplaceJobSpecJsonPrimitive = string | number | boolean | null;
+export type MarketplaceJobSpecJsonObject = {
+  readonly [key: string]: MarketplaceJobSpecJsonValue;
+};
+export type MarketplaceJobSpecJsonArray = readonly MarketplaceJobSpecJsonValue[];
+export type MarketplaceJobSpecJsonValue =
+  | MarketplaceJobSpecJsonPrimitive
+  | MarketplaceJobSpecJsonObject
+  | MarketplaceJobSpecJsonArray;
+
+const JOB_SPEC_SCHEMA_VERSION = 1;
+const MAX_SPEC_BYTES = 64 * 1024;
+const MAX_REMOTE_SPEC_BYTES = MAX_SPEC_BYTES * 2;
+const MAX_JOB_SPEC_URI_BYTES = 256;
+const MAX_STRING_BYTES = 16 * 1024;
+const MAX_KEY_BYTES = 128;
+const MAX_ARRAY_ITEMS = 64;
+const MAX_OBJECT_KEYS = 128;
+const MAX_DEPTH = 8;
+const CONTROL_CHARS_RE = /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/;
+const FORBIDDEN_OBJECT_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+const HASH_RE = /^[a-f0-9]{64}$/;
+const TASK_PDA_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+const TASK_ID_RE = /^[a-fA-F0-9]{64}$/;
+const ALLOWED_ATTACHMENT_PROTOCOLS = new Set([
+  "https:",
+  "ipfs:",
+  "ar:",
+  "arweave:",
+]);
+const ALLOWED_REMOTE_JOB_SPEC_PROTOCOLS = new Set(["https:"]);
+
+export interface MarketplaceJobAttachment {
+  readonly uri: string;
+  readonly label?: string;
+  readonly sha256?: string;
+}
+
+export interface MarketplaceJobSpecPayload {
+  readonly schemaVersion: typeof JOB_SPEC_SCHEMA_VERSION;
+  readonly kind: "agenc.marketplace.jobSpec";
+  readonly title: string;
+  readonly shortDescription: string;
+  readonly fullDescription: string | null;
+  readonly acceptanceCriteria: readonly string[];
+  readonly deliverables: readonly string[];
+  readonly constraints: MarketplaceJobSpecJsonValue | null;
+  readonly attachments: readonly MarketplaceJobAttachment[];
+  readonly custom: MarketplaceJobSpecJsonObject | null;
+  readonly context: MarketplaceJobSpecJsonObject;
+}
+
+export interface MarketplaceJobSpecEnvelope {
+  readonly schemaVersion: typeof JOB_SPEC_SCHEMA_VERSION;
+  readonly kind: "agenc.marketplace.jobSpecEnvelope";
+  readonly integrity: {
+    readonly algorithm: "sha256";
+    readonly canonicalization: "json-stable-v1";
+    readonly payloadHash: string;
+    readonly uri: string;
+  };
+  readonly payload: MarketplaceJobSpecPayload;
+}
+
+export interface MarketplaceJobSpecInput {
+  readonly description: string;
+  readonly jobSpec?: unknown;
+  readonly fullDescription?: unknown;
+  readonly acceptanceCriteria?: unknown;
+  readonly deliverables?: unknown;
+  readonly constraints?: unknown;
+  readonly attachments?: unknown;
+  readonly context?: Record<string, unknown>;
+}
+
+export interface MarketplaceJobSpecStoreOptions {
+  readonly rootDir?: string;
+}
+
+export class MarketplaceJobSpecNotFoundError extends Error {
+  readonly label: string;
+  readonly path: string;
+
+  constructor(label: string, path: string) {
+    super(`No ${label} found: ${path}`);
+    this.name = "MarketplaceJobSpecNotFoundError";
+    this.label = label;
+    this.path = path;
+  }
+}
+
+export function isMarketplaceJobSpecNotFoundError(
+  error: unknown,
+): error is MarketplaceJobSpecNotFoundError {
+  return error instanceof MarketplaceJobSpecNotFoundError;
+}
+
+export function isMarketplaceJobSpecTaskLinkNotFoundError(
+  error: unknown,
+): error is MarketplaceJobSpecNotFoundError {
+  return (
+    isMarketplaceJobSpecNotFoundError(error) &&
+    error.label.startsWith("marketplace jobSpec task link")
+  );
+}
+
+export interface StoredMarketplaceJobSpec {
+  readonly hash: string;
+  readonly uri: string;
+  readonly path: string;
+  readonly payload: MarketplaceJobSpecPayload;
+}
+
+export interface MarketplaceJobSpecTaskLinkInput {
+  readonly hash: string;
+  readonly uri: string;
+  readonly taskPda: string;
+  readonly taskId: string;
+  readonly transactionSignature: string;
+}
+
+export interface MarketplaceJobSpecTaskLink {
+  readonly schemaVersion: typeof JOB_SPEC_SCHEMA_VERSION;
+  readonly kind: "agenc.marketplace.jobSpecTaskLink";
+  readonly taskPda: string;
+  readonly taskId: string;
+  readonly jobSpecHash: string;
+  readonly jobSpecUri: string;
+  readonly transactionSignature: string;
+}
+
+export interface MarketplaceJobSpecReference {
+  readonly jobSpecHash: string;
+  readonly jobSpecUri: string;
+}
+
+export interface ResolvedMarketplaceJobSpecReference {
+  readonly jobSpecHash: string;
+  readonly jobSpecUri: string;
+  readonly jobSpecPath: string;
+  readonly integrity: MarketplaceJobSpecEnvelope["integrity"];
+  readonly envelope: MarketplaceJobSpecEnvelope;
+  readonly payload: MarketplaceJobSpecPayload;
+}
+
+export interface ResolvedMarketplaceJobSpec {
+  readonly taskPda: string;
+  readonly taskId: string;
+  readonly jobSpecHash: string;
+  readonly jobSpecUri: string;
+  readonly jobSpecPath: string;
+  readonly jobSpecTaskLinkPath: string;
+  readonly transactionSignature: string;
+  readonly integrity: MarketplaceJobSpecEnvelope["integrity"];
+  readonly envelope: MarketplaceJobSpecEnvelope;
+  readonly payload: MarketplaceJobSpecPayload;
+  readonly link: MarketplaceJobSpecTaskLink;
+}
+
+export interface MarketplaceJobSpecTaskPointer {
+  readonly taskPda: string;
+  readonly taskId: string;
+  readonly jobSpecHash: string;
+  readonly jobSpecUri: string;
+  readonly jobSpecTaskLinkPath: string;
+  readonly transactionSignature: string;
+  readonly link: MarketplaceJobSpecTaskLink;
+}
+
+export function getDefaultMarketplaceJobSpecStoreDir(): string {
+  return join(homedir(), ".agenc", "marketplace", "job-specs");
+}
+
+export function hasMarketplaceJobSpecInput(args: Record<string, unknown>): boolean {
+  return [
+    "jobSpec",
+    "fullDescription",
+    "acceptanceCriteria",
+    "deliverables",
+    "constraints",
+    "attachments",
+  ].some((field) => args[field] !== undefined && args[field] !== null);
+}
+
+export async function persistMarketplaceJobSpec(
+  input: MarketplaceJobSpecInput,
+  options: MarketplaceJobSpecStoreOptions = {},
+): Promise<StoredMarketplaceJobSpec> {
+  const payload = buildMarketplaceJobSpecPayload(input);
+  const canonicalPayload = canonicalJson(payload);
+  if (Buffer.byteLength(canonicalPayload, "utf8") > MAX_SPEC_BYTES) {
+    throw new Error(`jobSpec exceeds ${MAX_SPEC_BYTES} bytes after canonicalization`);
+  }
+
+  const hash = sha256Hex(canonicalPayload);
+  const uri = `agenc://job-spec/sha256/${hash}`;
+  const envelope: MarketplaceJobSpecEnvelope = {
+    schemaVersion: JOB_SPEC_SCHEMA_VERSION,
+    kind: "agenc.marketplace.jobSpecEnvelope",
+    integrity: {
+      algorithm: "sha256",
+      canonicalization: "json-stable-v1",
+      payloadHash: hash,
+      uri,
+    },
+    payload,
+  };
+  const serializedEnvelope = `${canonicalJson(envelope)}\n`;
+  const rootDir = options.rootDir ?? getDefaultMarketplaceJobSpecStoreDir();
+  const objectsDir = join(rootDir, "objects");
+  const objectPath = join(objectsDir, `${hash}.json`);
+
+  await mkdir(objectsDir, { recursive: true, mode: 0o700 });
+  await writeContentAddressedFile(objectPath, serializedEnvelope, hash);
+
+  return { hash, uri, path: objectPath, payload };
+}
+
+export async function linkMarketplaceJobSpecToTask(
+  input: MarketplaceJobSpecTaskLinkInput,
+  options: MarketplaceJobSpecStoreOptions = {},
+): Promise<string> {
+  if (!HASH_RE.test(input.hash)) {
+    throw new Error("jobSpec hash must be a 64-character lowercase sha256 hex string");
+  }
+  const jobSpecUri = normalizeJobSpecReferenceUri(
+    input.uri,
+    input.hash,
+    "jobSpec uri",
+  );
+  if (!TASK_PDA_RE.test(input.taskPda)) {
+    throw new Error("taskPda is not a valid base58 task address");
+  }
+  if (!TASK_ID_RE.test(input.taskId)) {
+    throw new Error("taskId must be a 32-byte hex string");
+  }
+
+  const link: MarketplaceJobSpecTaskLink = {
+    schemaVersion: JOB_SPEC_SCHEMA_VERSION,
+    kind: "agenc.marketplace.jobSpecTaskLink",
+    taskPda: input.taskPda,
+    taskId: input.taskId.toLowerCase(),
+    jobSpecHash: input.hash,
+    jobSpecUri,
+    transactionSignature: normalizeBoundedString(
+      input.transactionSignature,
+      "transactionSignature",
+      256,
+    ),
+  };
+  const rootDir = options.rootDir ?? getDefaultMarketplaceJobSpecStoreDir();
+  const linksDir = join(rootDir, "task-links");
+  const linkPath = join(linksDir, `${input.taskPda}.json`);
+  const serializedLink = `${canonicalJson(link)}\n`;
+
+  await mkdir(linksDir, { recursive: true, mode: 0o700 });
+  await writeStableLinkFile(linkPath, serializedLink, input.hash);
+  return linkPath;
+}
+
+export async function readMarketplaceJobSpecPointerForTask(
+  taskPda: string,
+  options: MarketplaceJobSpecStoreOptions = {},
+): Promise<MarketplaceJobSpecTaskPointer | null> {
+  const normalizedTaskPda = normalizeTaskPda(taskPda);
+  const rootDir = options.rootDir ?? getDefaultMarketplaceJobSpecStoreDir();
+  const jobSpecTaskLinkPath = join(
+    rootDir,
+    "task-links",
+    `${normalizedTaskPda}.json`,
+  );
+
+  let link: MarketplaceJobSpecTaskLink;
+  try {
+    link = await readMarketplaceJobSpecTaskLink(
+      jobSpecTaskLinkPath,
+      normalizedTaskPda,
+    );
+  } catch (error) {
+    if (isMarketplaceJobSpecNotFoundError(error)) return null;
+    throw error;
+  }
+
+  return {
+    taskPda: link.taskPda,
+    taskId: link.taskId,
+    jobSpecHash: link.jobSpecHash,
+    jobSpecUri: link.jobSpecUri,
+    jobSpecTaskLinkPath,
+    transactionSignature: link.transactionSignature,
+    link,
+  };
+}
+
+export async function resolveMarketplaceJobSpecReference(
+  reference: MarketplaceJobSpecReference,
+  options: MarketplaceJobSpecStoreOptions = {},
+): Promise<ResolvedMarketplaceJobSpecReference> {
+  if (!HASH_RE.test(reference.jobSpecHash)) {
+    throw new Error(
+      "jobSpec hash must be a 64-character lowercase sha256 hex string",
+    );
+  }
+  const jobSpecUri = normalizeJobSpecReferenceUri(
+    reference.jobSpecUri,
+    reference.jobSpecHash,
+    "jobSpec uri",
+  );
+  const expectedUri = canonicalJobSpecUri(reference.jobSpecHash);
+  const isRemote = isRemoteJobSpecUri(jobSpecUri);
+
+  const rootDir = options.rootDir ?? getDefaultMarketplaceJobSpecStoreDir();
+  const jobSpecPath = isRemote
+    ? jobSpecUri
+    : join(rootDir, "objects", `${reference.jobSpecHash}.json`);
+  const envelope = isRemote
+    ? await fetchRemoteMarketplaceJobSpecEnvelope(jobSpecUri, reference.jobSpecHash)
+    : await readMarketplaceJobSpecEnvelope(
+        jobSpecPath,
+        reference.jobSpecHash,
+      );
+
+  if (envelope.integrity.payloadHash !== reference.jobSpecHash) {
+    throw new Error(
+      `jobSpec object hash ${envelope.integrity.payloadHash} does not match requested hash ${reference.jobSpecHash}`,
+    );
+  }
+  if (envelope.integrity.uri !== expectedUri) {
+    throw new Error(
+      `jobSpec object uri ${envelope.integrity.uri} does not match canonical uri ${expectedUri}`,
+    );
+  }
+
+  return {
+    jobSpecHash: reference.jobSpecHash,
+    jobSpecUri,
+    jobSpecPath,
+    integrity: envelope.integrity,
+    envelope,
+    payload: envelope.payload,
+  };
+}
+
+export async function resolveMarketplaceJobSpecForTask(
+  taskPda: string,
+  options: MarketplaceJobSpecStoreOptions = {},
+): Promise<ResolvedMarketplaceJobSpec> {
+  const normalizedTaskPda = normalizeTaskPda(taskPda);
+  const rootDir = options.rootDir ?? getDefaultMarketplaceJobSpecStoreDir();
+  const jobSpecTaskLinkPath = join(
+    rootDir,
+    "task-links",
+    `${normalizedTaskPda}.json`,
+  );
+  const link = await readMarketplaceJobSpecTaskLink(
+    jobSpecTaskLinkPath,
+    normalizedTaskPda,
+  );
+  const resolved = await resolveMarketplaceJobSpecReference(link, options);
+
+  return {
+    taskPda: link.taskPda,
+    taskId: link.taskId,
+    jobSpecHash: link.jobSpecHash,
+    jobSpecUri: link.jobSpecUri,
+    jobSpecPath: resolved.jobSpecPath,
+    jobSpecTaskLinkPath,
+    transactionSignature: link.transactionSignature,
+    integrity: resolved.integrity,
+    envelope: resolved.envelope,
+    payload: resolved.payload,
+    link,
+  };
+}
+
+export function verifyMarketplaceJobSpecEnvelope(
+  envelope: unknown,
+): envelope is MarketplaceJobSpecEnvelope {
+  if (!envelope || typeof envelope !== "object" || Array.isArray(envelope)) {
+    return false;
+  }
+  const candidate = envelope as Partial<MarketplaceJobSpecEnvelope>;
+  if (candidate.schemaVersion !== JOB_SPEC_SCHEMA_VERSION) return false;
+  if (candidate.kind !== "agenc.marketplace.jobSpecEnvelope") return false;
+  if (!candidate.integrity || !candidate.payload) return false;
+  const payloadHash = candidate.integrity.payloadHash;
+  if (typeof payloadHash !== "string" || !HASH_RE.test(payloadHash)) return false;
+  const expectedUri = `agenc://job-spec/sha256/${payloadHash}`;
+  if (candidate.integrity.uri !== expectedUri) return false;
+  return sha256Hex(canonicalJson(candidate.payload)) === payloadHash;
+}
+
+function buildMarketplaceJobSpecPayload(
+  input: MarketplaceJobSpecInput,
+): MarketplaceJobSpecPayload {
+  const title = normalizeBoundedString(input.description, "description", 512);
+  const rawObjectSpec = normalizeRawObjectSpec(input.jobSpec);
+  const explicitFullDescription = normalizeOptionalString(
+    input.fullDescription,
+    "fullDescription",
+  );
+  const fullDescription =
+    explicitFullDescription ??
+    normalizeOptionalString(input.jobSpec, "jobSpec") ??
+    pickOptionalString(rawObjectSpec, ["fullDescription", "description", "body"]);
+
+  const acceptanceCriteria = normalizeStringList(
+    input.acceptanceCriteria ?? rawObjectSpec?.acceptanceCriteria,
+    "acceptanceCriteria",
+  );
+  const deliverables = normalizeStringList(
+    input.deliverables ?? rawObjectSpec?.deliverables,
+    "deliverables",
+  );
+  const constraintsInput = input.constraints ?? rawObjectSpec?.constraints;
+  const attachmentsInput = input.attachments ?? rawObjectSpec?.attachments;
+  const custom = rawObjectSpec
+    ? sanitizeMarketplaceJobSpecJsonValue(rawObjectSpec, "jobSpec") as MarketplaceJobSpecJsonObject
+    : null;
+  const context = input.context
+    ? sanitizeMarketplaceJobSpecJsonValue(input.context, "context") as MarketplaceJobSpecJsonObject
+    : {};
+
+  return {
+    schemaVersion: JOB_SPEC_SCHEMA_VERSION,
+    kind: "agenc.marketplace.jobSpec",
+    title,
+    shortDescription: title,
+    fullDescription,
+    acceptanceCriteria,
+    deliverables,
+    constraints:
+      constraintsInput === undefined || constraintsInput === null
+        ? null
+        : sanitizeMarketplaceJobSpecJsonValue(constraintsInput, "constraints"),
+    attachments: normalizeAttachments(attachmentsInput),
+    custom,
+    context,
+  };
+}
+
+function normalizeRawObjectSpec(input: unknown): Record<string, unknown> | null {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return null;
+  assertPlainObject(input, "jobSpec");
+  return input as Record<string, unknown>;
+}
+
+function pickOptionalString(
+  source: Record<string, unknown> | null,
+  keys: readonly string[],
+): string | null {
+  if (!source) return null;
+  for (const key of keys) {
+    const value = normalizeOptionalString(source[key], `jobSpec.${key}`);
+    if (value) return value;
+  }
+  return null;
+}
+
+function normalizeOptionalString(input: unknown, field: string): string | null {
+  if (input === undefined || input === null) return null;
+  if (typeof input !== "string") return null;
+  const normalized = normalizeBoundedString(input, field, MAX_STRING_BYTES);
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeStringList(input: unknown, field: string): readonly string[] {
+  if (input === undefined || input === null) return [];
+  const values = Array.isArray(input)
+    ? input
+    : typeof input === "string"
+      ? input.split(/\r?\n/).filter((line) => line.trim().length > 0)
+      : [input];
+
+  if (values.length > MAX_ARRAY_ITEMS) {
+    throw new Error(`${field} cannot contain more than ${MAX_ARRAY_ITEMS} items`);
+  }
+
+  return values.map((value, index) => {
+    if (typeof value !== "string" && typeof value !== "number" && typeof value !== "boolean") {
+      throw new Error(`${field}[${index}] must be a string, number, or boolean`);
+    }
+    return normalizeBoundedString(String(value), `${field}[${index}]`, MAX_STRING_BYTES);
+  });
+}
+
+function normalizeAttachments(input: unknown): readonly MarketplaceJobAttachment[] {
+  if (input === undefined || input === null) return [];
+  const values = Array.isArray(input) ? input : [input];
+  if (values.length > MAX_ARRAY_ITEMS) {
+    throw new Error(`attachments cannot contain more than ${MAX_ARRAY_ITEMS} items`);
+  }
+  return values.map((value, index) => normalizeAttachment(value, index));
+}
+
+function normalizeAttachment(input: unknown, index: number): MarketplaceJobAttachment {
+  if (typeof input === "string") {
+    return { uri: normalizeAttachmentUri(input, `attachments[${index}]`) };
+  }
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error(`attachments[${index}] must be a URL string or object`);
+  }
+  assertPlainObject(input, `attachments[${index}]`);
+  const record = input as Record<string, unknown>;
+  const uriInput = record.uri ?? record.url;
+  if (typeof uriInput !== "string") {
+    throw new Error(`attachments[${index}].uri must be a URL string`);
+  }
+  const label = normalizeOptionalString(record.label, `attachments[${index}].label`);
+  const sha256 = normalizeOptionalString(record.sha256, `attachments[${index}].sha256`);
+  const attachment: { uri: string; label?: string; sha256?: string } = {
+    uri: normalizeAttachmentUri(uriInput, `attachments[${index}].uri`),
+  };
+  if (label) attachment.label = label;
+  if (sha256) {
+    if (!HASH_RE.test(sha256.toLowerCase())) {
+      throw new Error(`attachments[${index}].sha256 must be a 64-character hex string`);
+    }
+    attachment.sha256 = sha256.toLowerCase();
+  }
+  return attachment;
+}
+
+function normalizeAttachmentUri(input: string, field: string): string {
+  const uri = normalizeBoundedString(input, field, 2048);
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    throw new Error(`${field} must be an absolute URL`);
+  }
+  if (!ALLOWED_ATTACHMENT_PROTOCOLS.has(parsed.protocol)) {
+    throw new Error(`${field} must use https, ipfs, ar, or arweave protocol`);
+  }
+  return uri;
+}
+
+function sanitizeMarketplaceJobSpecJsonValue(input: unknown, field: string, depth = 0): MarketplaceJobSpecJsonValue {
+  if (depth > MAX_DEPTH) {
+    throw new Error(`${field} exceeds max object depth ${MAX_DEPTH}`);
+  }
+  if (input === null) return null;
+  if (typeof input === "string") {
+    return normalizeBoundedString(input, field, MAX_STRING_BYTES);
+  }
+  if (typeof input === "number") {
+    if (!Number.isFinite(input)) {
+      throw new Error(`${field} must be a finite number`);
+    }
+    return input;
+  }
+  if (typeof input === "boolean") return input;
+  if (Array.isArray(input)) {
+    if (input.length > MAX_ARRAY_ITEMS) {
+      throw new Error(`${field} cannot contain more than ${MAX_ARRAY_ITEMS} items`);
+    }
+    return input.map((value, index) =>
+      sanitizeMarketplaceJobSpecJsonValue(value, `${field}[${index}]`, depth + 1),
+    );
+  }
+  if (typeof input === "object") {
+    assertPlainObject(input, field);
+    const entries = Object.entries(input as Record<string, unknown>);
+    if (entries.length > MAX_OBJECT_KEYS) {
+      throw new Error(`${field} cannot contain more than ${MAX_OBJECT_KEYS} keys`);
+    }
+    const output: Record<string, MarketplaceJobSpecJsonValue> = {};
+    for (const [key, value] of entries) {
+      const normalizedKey = normalizeObjectKey(key, `${field}.${key}`);
+      output[normalizedKey] = sanitizeMarketplaceJobSpecJsonValue(
+        value,
+        `${field}.${normalizedKey}`,
+        depth + 1,
+      );
+    }
+    return output;
+  }
+  throw new Error(`${field} contains unsupported JSON value`);
+}
+
+function assertPlainObject(input: object, field: string): void {
+  const prototype = Object.getPrototypeOf(input);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error(`${field} must be a plain JSON object`);
+  }
+}
+
+function normalizeObjectKey(key: string, field: string): string {
+  const normalized = normalizeBoundedString(key, field, MAX_KEY_BYTES);
+  if (FORBIDDEN_OBJECT_KEYS.has(normalized)) {
+    throw new Error(`${field} is not allowed`);
+  }
+  return normalized;
+}
+
+function normalizeBoundedString(input: string, field: string, maxBytes: number): string {
+  const normalized = input.trim();
+  if (CONTROL_CHARS_RE.test(normalized)) {
+    throw new Error(`${field} contains control characters`);
+  }
+  if (Buffer.byteLength(normalized, "utf8") > maxBytes) {
+    throw new Error(`${field} exceeds ${maxBytes} bytes`);
+  }
+  return normalized;
+}
+
+function normalizeTaskPda(input: string): string {
+  const normalized = normalizeBoundedString(input, "taskPda", 64);
+  if (!TASK_PDA_RE.test(normalized)) {
+    throw new Error("taskPda is not a valid base58 task address");
+  }
+  return normalized;
+}
+
+function canonicalJobSpecUri(hash: string): string {
+  return `agenc://job-spec/sha256/${hash}`;
+}
+
+function normalizeJobSpecReferenceUri(input: string, hash: string, field: string): string {
+  const uri = normalizeBoundedString(input, field, MAX_JOB_SPEC_URI_BYTES);
+  const canonicalUri = canonicalJobSpecUri(hash);
+  if (uri === canonicalUri) return uri;
+  if (uri.startsWith("agenc://job-spec/sha256/")) {
+    throw new Error(`${field} does not match hash`);
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    throw new Error(`${field} must be a canonical agenc URI or absolute https URL`);
+  }
+  if (!ALLOWED_REMOTE_JOB_SPEC_PROTOCOLS.has(parsed.protocol)) {
+    throw new Error(`${field} must use canonical agenc URI or https protocol`);
+  }
+  if (!parsed.hostname) {
+    throw new Error(`${field} must include a hostname`);
+  }
+  return uri;
+}
+
+function isRemoteJobSpecUri(uri: string): boolean {
+  try {
+    return ALLOWED_REMOTE_JOB_SPEC_PROTOCOLS.has(new URL(uri).protocol);
+  } catch {
+    return false;
+  }
+}
+
+async function readMarketplaceJobSpecTaskLink(
+  path: string,
+  expectedTaskPda: string,
+): Promise<MarketplaceJobSpecTaskLink> {
+  const parsed = await readJsonFile(
+    path,
+    `marketplace jobSpec task link for task ${expectedTaskPda}`,
+  );
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`marketplace jobSpec task link is not a JSON object: ${path}`);
+  }
+  const candidate = parsed as Partial<MarketplaceJobSpecTaskLink>;
+  if (candidate.schemaVersion !== JOB_SPEC_SCHEMA_VERSION) {
+    throw new Error(`marketplace jobSpec task link has unsupported schemaVersion: ${path}`);
+  }
+  if (candidate.kind !== "agenc.marketplace.jobSpecTaskLink") {
+    throw new Error(`marketplace jobSpec task link has invalid kind: ${path}`);
+  }
+  if (typeof candidate.taskPda !== "string" || !TASK_PDA_RE.test(candidate.taskPda)) {
+    throw new Error(`marketplace jobSpec task link has invalid taskPda: ${path}`);
+  }
+  if (candidate.taskPda !== expectedTaskPda) {
+    throw new Error(
+      `marketplace jobSpec task link taskPda ${candidate.taskPda} does not match requested task ${expectedTaskPda}`,
+    );
+  }
+  if (typeof candidate.taskId !== "string" || !TASK_ID_RE.test(candidate.taskId)) {
+    throw new Error(`marketplace jobSpec task link has invalid taskId: ${path}`);
+  }
+  const taskId = candidate.taskId.toLowerCase();
+  if (typeof candidate.jobSpecHash !== "string" || !HASH_RE.test(candidate.jobSpecHash)) {
+    throw new Error(`marketplace jobSpec task link has invalid jobSpecHash: ${path}`);
+  }
+  if (typeof candidate.jobSpecUri !== "string") {
+    throw new Error(`marketplace jobSpec task link has invalid jobSpecUri: ${path}`);
+  }
+  let jobSpecUri: string;
+  try {
+    jobSpecUri = normalizeJobSpecReferenceUri(
+      candidate.jobSpecUri,
+      candidate.jobSpecHash,
+      "marketplace jobSpec task link uri",
+    );
+  } catch (error) {
+    throw new Error(`${error instanceof Error ? error.message : String(error)}: ${path}`);
+  }
+  if (typeof candidate.transactionSignature !== "string") {
+    throw new Error(`marketplace jobSpec task link has invalid transactionSignature: ${path}`);
+  }
+
+  return {
+    schemaVersion: JOB_SPEC_SCHEMA_VERSION,
+    kind: "agenc.marketplace.jobSpecTaskLink",
+    taskPda: candidate.taskPda,
+    taskId,
+    jobSpecHash: candidate.jobSpecHash,
+    jobSpecUri,
+    transactionSignature: normalizeBoundedString(
+      candidate.transactionSignature,
+      "transactionSignature",
+      256,
+    ),
+  };
+}
+
+async function readMarketplaceJobSpecEnvelope(
+  path: string,
+  expectedHash: string,
+): Promise<MarketplaceJobSpecEnvelope> {
+  const parsed = await readJsonFile(
+    path,
+    `marketplace jobSpec object for hash ${expectedHash}`,
+  );
+  if (!verifyMarketplaceJobSpecEnvelope(parsed)) {
+    throw new Error(`marketplace jobSpec object failed integrity verification: ${path}`);
+  }
+  return parsed;
+}
+
+async function fetchRemoteMarketplaceJobSpecEnvelope(
+  uri: string,
+  expectedHash: string,
+): Promise<MarketplaceJobSpecEnvelope> {
+  if (typeof fetch !== "function") {
+    throw new Error("global fetch is not available to resolve remote jobSpec URI");
+  }
+
+  let response: Awaited<ReturnType<typeof fetch>>;
+  try {
+    response = await fetch(uri, { headers: { accept: "application/json" } });
+  } catch (error) {
+    throw new Error(
+      `failed to fetch remote marketplace jobSpec object ${uri}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `remote marketplace jobSpec object fetch failed with HTTP ${response.status} ${response.statusText}: ${uri}`,
+    );
+  }
+
+  const contentLength = response.headers.get("content-length");
+  if (contentLength) {
+    const contentLengthBytes = Number(contentLength);
+    if (Number.isFinite(contentLengthBytes) && contentLengthBytes > MAX_REMOTE_SPEC_BYTES) {
+      throw new Error(
+        `remote marketplace jobSpec object exceeds ${MAX_REMOTE_SPEC_BYTES} bytes: ${uri}`,
+      );
+    }
+  }
+
+  const content = await response.text();
+  if (Buffer.byteLength(content, "utf8") > MAX_REMOTE_SPEC_BYTES) {
+    throw new Error(
+      `remote marketplace jobSpec object exceeds ${MAX_REMOTE_SPEC_BYTES} bytes: ${uri}`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content) as unknown;
+  } catch {
+    throw new Error(`remote marketplace jobSpec object is not valid JSON: ${uri}`);
+  }
+  if (!verifyMarketplaceJobSpecEnvelope(parsed)) {
+    throw new Error(`remote marketplace jobSpec object failed integrity verification: ${uri}`);
+  }
+  if (parsed.integrity.payloadHash !== expectedHash) {
+    throw new Error(
+      `remote marketplace jobSpec object hash ${parsed.integrity.payloadHash} does not match requested hash ${expectedHash}`,
+    );
+  }
+  return parsed;
+}
+
+async function readJsonFile(path: string, label: string): Promise<unknown> {
+  let content: string;
+  try {
+    content = await readFile(path, "utf8");
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      throw new MarketplaceJobSpecNotFoundError(label, path);
+    }
+    throw error;
+  }
+
+  try {
+    return JSON.parse(content) as unknown;
+  } catch {
+    throw new Error(`${label} is not valid JSON: ${path}`);
+  }
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortMarketplaceJobSpecJsonValue(value));
+}
+
+function sortMarketplaceJobSpecJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortMarketplaceJobSpecJsonValue);
+  if (!value || typeof value !== "object") return value;
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort()) {
+    sorted[key] = sortMarketplaceJobSpecJsonValue((value as Record<string, unknown>)[key]);
+  }
+  return sorted;
+}
+
+function sha256Hex(input: string): string {
+  return createHash("sha256").update(input, "utf8").digest("hex");
+}
+
+async function writeContentAddressedFile(
+  path: string,
+  content: string,
+  expectedHash: string,
+): Promise<void> {
+  try {
+    await writeFile(path, content, { encoding: "utf8", flag: "wx", mode: 0o600 });
+  } catch (error) {
+    if (!isAlreadyExistsError(error)) throw error;
+    const existing = await readFile(path, "utf8");
+    const parsed = JSON.parse(existing) as unknown;
+    if (!verifyMarketplaceJobSpecEnvelope(parsed)) {
+      throw new Error(`existing jobSpec object is invalid or tampered: ${path}`);
+    }
+    if ((parsed as MarketplaceJobSpecEnvelope).integrity.payloadHash !== expectedHash) {
+      throw new Error(`existing jobSpec object hash mismatch: ${path}`);
+    }
+  }
+}
+
+async function writeStableLinkFile(
+  path: string,
+  content: string,
+  expectedHash: string,
+): Promise<void> {
+  try {
+    await writeFile(path, content, { encoding: "utf8", flag: "wx", mode: 0o600 });
+  } catch (error) {
+    if (!isAlreadyExistsError(error)) throw error;
+    const existing = JSON.parse(await readFile(path, "utf8")) as Partial<MarketplaceJobSpecTaskLink>;
+    const next = JSON.parse(content) as Partial<MarketplaceJobSpecTaskLink>;
+    if (existing.jobSpecHash !== expectedHash) {
+      throw new Error(`existing task link points to a different jobSpec hash: ${path}`);
+    }
+    if (existing.taskPda !== next.taskPda || existing.taskId !== next.taskId) {
+      throw new Error(`existing task link points to a different task: ${path}`);
+    }
+    if (canonicalJson(existing) === canonicalJson(next)) return;
+    await writeFile(path, content, { encoding: "utf8", mode: 0o600 });
+  }
+}
+
+function isAlreadyExistsError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === "EEXIST"
+  );
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}

--- a/runtime/src/marketplace/serialization.ts
+++ b/runtime/src/marketplace/serialization.ts
@@ -13,7 +13,11 @@ import {
 import { createProgram, createReadOnlyProgram } from "../idl.js";
 import { ReputationEconomyOperations } from "../reputation/economy.js";
 import { TaskOperations } from "../task/operations.js";
-import { taskStatusToString } from "../task/types.js";
+import {
+  taskStatusToString,
+  taskTypeToKey,
+  taskTypeToString,
+} from "../task/types.js";
 import { lamportsToSol } from "../utils/encoding.js";
 import { silentLogger } from "../utils/logger.js";
 
@@ -42,6 +46,9 @@ interface SerializedMarketplaceTask {
   rewardSol: string | undefined;
   rewardMint: string | null;
   taskType: string;
+  taskTypeId: number;
+  taskTypeName: string;
+  taskTypeKey: string;
   currentWorkers: number;
   maxWorkers: number;
   requiredCompletions: number;
@@ -280,6 +287,9 @@ export function serializeMarketplaceTask(
     rewardSol: task.rewardMint ? undefined : lamportsToSol(task.rewardAmount),
     rewardMint: task.rewardMint?.toBase58() ?? null,
     taskType: String(task.taskType),
+    taskTypeId: task.taskType,
+    taskTypeName: taskTypeToString(task.taskType),
+    taskTypeKey: taskTypeToKey(task.taskType),
     currentWorkers: task.currentWorkers,
     maxWorkers: task.maxWorkers,
     requiredCompletions: task.requiredCompletions,

--- a/runtime/src/marketplace/task-job-spec.ts
+++ b/runtime/src/marketplace/task-job-spec.ts
@@ -1,0 +1,166 @@
+import { SystemProgram, PublicKey } from "@solana/web3.js";
+import type { Program } from "@coral-xyz/anchor";
+import type { AgencCoordination } from "../types/agenc_coordination.js";
+import { bytesToHex, hexToBytes } from "../utils/encoding.js";
+import {
+  resolveMarketplaceJobSpecReference,
+  type MarketplaceJobSpecStoreOptions,
+  type ResolvedMarketplaceJobSpecReference,
+} from "./job-spec-store.js";
+
+const TASK_JOB_SPEC_SEED = Buffer.from("task_job_spec");
+const TASK_JOB_SPEC_HASH_BYTES = 32;
+
+export interface OnChainTaskJobSpecPointer {
+  readonly taskPda: string;
+  readonly taskJobSpecPda: string;
+  readonly creator: string;
+  readonly jobSpecHash: string;
+  readonly jobSpecUri: string;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly bump: number;
+}
+
+export interface ResolvedOnChainTaskJobSpec
+  extends OnChainTaskJobSpecPointer,
+    ResolvedMarketplaceJobSpecReference {}
+
+interface TaskJobSpecAccountData {
+  readonly task: PublicKey;
+  readonly creator: PublicKey;
+  readonly jobSpecHash: Uint8Array | number[];
+  readonly jobSpecUri: string;
+  readonly createdAt: unknown;
+  readonly updatedAt: unknown;
+  readonly bump: number;
+}
+
+export function findTaskJobSpecPda(
+  taskPda: PublicKey,
+  programId: PublicKey,
+): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [TASK_JOB_SPEC_SEED, taskPda.toBuffer()],
+    programId,
+  )[0];
+}
+
+export async function fetchTaskJobSpecPointer(
+  program: Program<AgencCoordination>,
+  taskPda: PublicKey,
+): Promise<OnChainTaskJobSpecPointer | null> {
+  const taskJobSpecPda = findTaskJobSpecPda(taskPda, program.programId);
+  try {
+    const raw = (await (program.account as any).taskJobSpec.fetch(
+      taskJobSpecPda,
+    )) as TaskJobSpecAccountData;
+    return parseTaskJobSpecAccountData(taskPda, taskJobSpecPda, raw);
+  } catch (error) {
+    if (isMissingAccountError(error)) return null;
+    throw error;
+  }
+}
+
+export async function resolveOnChainTaskJobSpecForTask(
+  program: Program<AgencCoordination>,
+  taskPda: PublicKey,
+  options: MarketplaceJobSpecStoreOptions = {},
+): Promise<ResolvedOnChainTaskJobSpec | null> {
+  const pointer = await fetchTaskJobSpecPointer(program, taskPda);
+  if (!pointer) return null;
+
+  const resolved = await resolveMarketplaceJobSpecReference(pointer, options);
+  return {
+    ...pointer,
+    ...resolved,
+  };
+}
+
+export async function setTaskJobSpecPointer(
+  program: Program<AgencCoordination>,
+  creator: PublicKey,
+  taskPda: PublicKey,
+  jobSpecHash: string | Uint8Array | number[],
+  jobSpecUri: string,
+): Promise<{ taskJobSpecPda: PublicKey; transactionSignature: string }> {
+  const taskJobSpecPda = findTaskJobSpecPda(taskPda, program.programId);
+  const jobSpecHashBytes = normalizeJobSpecHash(jobSpecHash);
+  const transactionSignature = await (program.methods as any)
+    .setTaskJobSpec(Array.from(jobSpecHashBytes), jobSpecUri)
+    .accountsPartial({
+      task: taskPda,
+      taskJobSpec: taskJobSpecPda,
+      creator,
+      systemProgram: SystemProgram.programId,
+    })
+    .rpc();
+
+  return { taskJobSpecPda, transactionSignature };
+}
+
+function parseTaskJobSpecAccountData(
+  taskPda: PublicKey,
+  taskJobSpecPda: PublicKey,
+  raw: TaskJobSpecAccountData,
+): OnChainTaskJobSpecPointer {
+  const hashBytes = normalizeJobSpecHash(raw.jobSpecHash);
+  return {
+    taskPda: taskPda.toBase58(),
+    taskJobSpecPda: taskJobSpecPda.toBase58(),
+    creator: raw.creator.toBase58(),
+    jobSpecHash: bytesToHex(hashBytes),
+    jobSpecUri: raw.jobSpecUri,
+    createdAt: numberFromAnchorValue(raw.createdAt),
+    updatedAt: numberFromAnchorValue(raw.updatedAt),
+    bump: raw.bump,
+  };
+}
+
+function normalizeJobSpecHash(
+  jobSpecHash: string | Uint8Array | number[],
+): Uint8Array {
+  const bytes =
+    typeof jobSpecHash === "string"
+      ? hexToBytes(jobSpecHash)
+      : Uint8Array.from(jobSpecHash);
+  if (bytes.length !== TASK_JOB_SPEC_HASH_BYTES) {
+    throw new Error(
+      `jobSpecHash must be ${TASK_JOB_SPEC_HASH_BYTES} bytes`,
+    );
+  }
+  return bytes;
+}
+
+function numberFromAnchorValue(value: unknown): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "bigint") return Number(value);
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "toNumber" in value &&
+    typeof (value as { toNumber?: unknown }).toNumber === "function"
+  ) {
+    return (value as { toNumber: () => number }).toNumber();
+  }
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "toString" in value &&
+    typeof (value as { toString?: unknown }).toString === "function"
+  ) {
+    return Number((value as { toString: () => string }).toString());
+  }
+  throw new Error(`Unsupported anchor numeric value: ${String(value)}`);
+}
+
+function isMissingAccountError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const lower = message.toLowerCase();
+  return (
+    lower.includes("account does not exist") ||
+    lower.includes("could not find account") ||
+    lower.includes("invalid param") ||
+    lower.includes("not found")
+  );
+}

--- a/runtime/src/task/types.ts
+++ b/runtime/src/task/types.ts
@@ -470,6 +470,54 @@ export function parseTaskType(
   throw new Error("Invalid task type format");
 }
 
+function normalizeTaskTypeAlias(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[_\s]+/g, "-")
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Parses user-facing task type aliases used by CLIs and agent tools.
+ */
+export function parseTaskTypeAlias(input: string | number): TaskType | null {
+  if (typeof input === "number") {
+    if (!Number.isFinite(input)) return null;
+    const value = Math.trunc(input);
+    return value >= TaskType.Exclusive && value <= TaskType.BidExclusive
+      ? value
+      : null;
+  }
+
+  const normalized = normalizeTaskTypeAlias(input);
+  switch (normalized) {
+    case "0":
+    case "exclusive":
+    case "exclusive-task":
+      return TaskType.Exclusive;
+    case "1":
+    case "collaborative":
+    case "collab":
+    case "collaborative-task":
+      return TaskType.Collaborative;
+    case "2":
+    case "competitive":
+    case "competition":
+    case "competitive-task":
+      return TaskType.Competitive;
+    case "3":
+    case "bid-exclusive":
+    case "bidexclusive":
+    case "bid":
+    case "auction":
+      return TaskType.BidExclusive;
+    default:
+      return null;
+  }
+}
+
 /**
  * Parses raw Anchor task account data into a typed OnChainTask.
  *
@@ -813,6 +861,21 @@ export function taskTypeToString(type: TaskType): string {
       return "BidExclusive";
     default:
       return `Unknown (${type})`;
+  }
+}
+
+export function taskTypeToKey(type: TaskType): string {
+  switch (type) {
+    case TaskType.Exclusive:
+      return "exclusive";
+    case TaskType.Collaborative:
+      return "collaborative";
+    case TaskType.Competitive:
+      return "competitive";
+    case TaskType.BidExclusive:
+      return "bid-exclusive";
+    default:
+      return `unknown-${type}`;
   }
 }
 

--- a/runtime/src/tools/agenc/index.ts
+++ b/runtime/src/tools/agenc/index.ts
@@ -20,6 +20,7 @@ import {
   createGetDisputeTool,
   createGetReputationSummaryTool,
   createGetTokenBalanceTool,
+  createGetJobSpecTool,
   createRegisterAgentTool,
   createCreateTaskTool,
   createGetAgentTool,
@@ -65,6 +66,7 @@ export {
   createGetDisputeTool,
   createGetReputationSummaryTool,
   createGetTokenBalanceTool,
+  createGetJobSpecTool,
   createRegisterAgentTool,
   createCreateTaskTool,
   createGetAgentTool,
@@ -130,8 +132,9 @@ export function createAgencTools(context: ToolContext): Tool[] {
 
   return [
     createInspectMarketplaceTool(program, context.logger),
-    createListTasksTool(ops, context.logger),
-    createGetTaskTool(ops, context.logger),
+    createListTasksTool(ops, context.logger, { program }),
+    createGetTaskTool(ops, context.logger, { program }),
+    createGetJobSpecTool(context.logger, { program }),
     createListSkillsTool(program, context.logger),
     createGetSkillTool(program, context.logger),
     createListGovernanceProposalsTool(program, context.logger),

--- a/runtime/src/tools/agenc/tools.ts
+++ b/runtime/src/tools/agenc/tools.ts
@@ -4,6 +4,7 @@
  * Query tools:
  * - agenc.listTasks — list tasks with optional status filter
  * - agenc.getTask — fetch a single task by PDA
+ * - agenc.getJobSpec — resolve a task PDA to its verified off-chain marketplace job spec
  * - agenc.listSkills — list marketplace skills with optional filtering
  * - agenc.getSkill — fetch a single marketplace skill by PDA
  * - agenc.listGovernanceProposals — list governance proposals with optional status filter
@@ -37,8 +38,12 @@ import { findTaskPda, findEscrowPda } from '../../task/pda.js';
 import {
   taskStatusToString,
   taskTypeToString,
+  taskTypeToKey,
   isPrivateTask,
   OnChainTaskStatus,
+  TaskType,
+  TaskValidationMode,
+  parseTaskTypeAlias,
 } from '../../task/types.js';
 import { parseAgentState, agentStatusToString } from '../../agent/types.js';
 import { getCapabilityNames } from '../../agent/capabilities.js';
@@ -65,6 +70,18 @@ import type {
 import { parseProtocolConfig } from '../../types/protocol.js';
 import { buildCreateTaskTokenAccounts } from '../../utils/token.js';
 import {
+  hasMarketplaceJobSpecInput,
+  linkMarketplaceJobSpecToTask,
+  persistMarketplaceJobSpec,
+  readMarketplaceJobSpecPointerForTask,
+  resolveMarketplaceJobSpecReference,
+} from '../../marketplace/job-spec-store.js';
+import {
+  fetchTaskJobSpecPointer,
+  resolveOnChainTaskJobSpecForTask,
+  setTaskJobSpecPointer,
+} from '../../marketplace/task-job-spec.js';
+import {
   lamportsToSol,
   bytesToHex,
   generateAgentId,
@@ -85,13 +102,18 @@ import type {
   SerializedReputationSummary,
   SerializedSkill,
   SerializedTask,
+  SerializedTaskJobSpec,
 } from './types.js';
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
 const DESCRIPTION_BYTES = 64;
 const TASK_ID_BYTES = 32;
+const DEFAULT_CREATOR_REVIEW_WINDOW_SECS = 3600;
 const MAX_U64 = (1n << 64n) - 1n;
+const MAX_REPUTATION = 10_000;
+const TASK_TYPE_INPUT_ERROR =
+  'taskType must be one of 0/exclusive, 1/collaborative, 2/competitive, or 3/bid-exclusive';
 const DUMMY_AGENT_ID = new Uint8Array(32);
 const AGENT_DISCRIMINATOR = Buffer.from([130, 53, 100, 103, 121, 77, 148, 19]);
 const AGENT_ID_OFFSET = 8;
@@ -105,7 +127,18 @@ const AGENT_AUTHORITY_OFFSET = AGENT_ID_OFFSET + TASK_ID_BYTES;
 const recentCreateTaskCalls = new Map<string, number>();
 const CREATE_TASK_DEDUP_TTL_MS = 30_000;
 
-/** @internal Exposed for testing only. */
+export interface CreateTaskToolOptions {
+  readonly jobSpecStoreDir?: string;
+}
+
+export interface GetJobSpecToolOptions {
+  readonly jobSpecStoreDir?: string;
+}
+export interface TaskJobSpecQueryToolOptions {
+  readonly program?: Program<AgencCoordination>;
+  readonly jobSpecStoreDir?: string;
+}
+
 const KNOWN_MINTS: Record<string, { symbol: string; decimals: number }> = {
   EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: { symbol: 'USDC', decimals: 6 },
   Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB: { symbol: 'USDT', decimals: 6 },
@@ -148,6 +181,29 @@ function parseRewardMintFilter(input: unknown): [PublicKey | null | undefined, T
   return [mint, null];
 }
 
+function parseTaskTypeInput(
+  input: unknown,
+  defaultValue: TaskType,
+): [TaskType, ToolResult | null] {
+  if (isOptionalPlaceholder(input)) return [defaultValue, null];
+  if (typeof input !== 'string' && typeof input !== 'number') {
+    return [defaultValue, errorResult(TASK_TYPE_INPUT_ERROR)];
+  }
+  const parsed = parseTaskTypeAlias(input);
+  if (parsed === null) return [defaultValue, errorResult(TASK_TYPE_INPUT_ERROR)];
+  return [parsed, null];
+}
+
+function parseOptionalTaskTypeFilter(input: unknown): [TaskType | undefined, ToolResult | null] {
+  if (isOptionalPlaceholder(input)) return [undefined, null];
+  if (typeof input !== 'string' && typeof input !== 'number') {
+    return [undefined, errorResult(TASK_TYPE_INPUT_ERROR)];
+  }
+  const parsed = parseTaskTypeAlias(input);
+  if (parsed === null) return [undefined, errorResult(TASK_TYPE_INPUT_ERROR)];
+  return [parsed, null];
+}
+
 function parseBigIntInput(value: unknown, field: string): [bigint | null, ToolResult | null] {
   if (typeof value === 'number') {
     if (!Number.isFinite(value) || value < 0) {
@@ -172,7 +228,7 @@ function parseBoundedNumber(
   max: number,
   defaultValue: number,
 ): [number, ToolResult | null] {
-  if (value === undefined) return [defaultValue, null];
+  if (isOptionalPlaceholder(value)) return [defaultValue, null];
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     return [defaultValue, errorResult(`${field} must be a number`)];
   }
@@ -205,6 +261,87 @@ function validateU64(value: bigint, field: string): ToolResult | null {
   return null;
 }
 
+function isOptionalPlaceholder(input: unknown): boolean {
+  if (input === undefined || input === null) return true;
+  if (typeof input !== 'string') return false;
+  const normalized = input.trim().toLowerCase();
+  return (
+    normalized === '' ||
+    normalized === 'none' ||
+    normalized === 'null' ||
+    normalized === 'undefined' ||
+    normalized === 'n/a' ||
+    normalized === 'na' ||
+    normalized === 'omit' ||
+    normalized === 'omitted'
+  );
+}
+
+function parseOptionalHexBytes(
+  input: unknown,
+  field: string,
+  expectedBytes: number,
+): [Uint8Array | null, ToolResult | null] {
+  if (isOptionalPlaceholder(input)) return [null, null];
+  if (typeof input !== 'string' || input.trim().length === 0) {
+    return [null, errorResult(`${field} must be a ${expectedBytes}-byte hex string if provided`)];
+  }
+  try {
+    const bytes = hexToBytes(input.trim());
+    if (bytes.length !== expectedBytes) {
+      return [null, errorResult(`${field} must be ${expectedBytes} bytes (${expectedBytes * 2} hex chars)`)];
+    }
+    return [bytes, null];
+  } catch {
+    return [null, errorResult(`${field} must be a valid hex string`)];
+  }
+}
+
+function parseTaskValidationMode(input: unknown): [TaskValidationMode, ToolResult | null] {
+  if (isOptionalPlaceholder(input)) return [TaskValidationMode.Auto, null];
+  if (typeof input === 'number') {
+    if (input === TaskValidationMode.Auto || input === TaskValidationMode.CreatorReview) {
+      return [input, null];
+    }
+    return [
+      TaskValidationMode.Auto,
+      errorResult('validationMode must be "auto" or "creator-review"'),
+    ];
+  }
+  if (typeof input !== 'string') {
+    return [
+      TaskValidationMode.Auto,
+      errorResult('validationMode must be "auto" or "creator-review"'),
+    ];
+  }
+
+  const normalized = input
+    .trim()
+    .toLowerCase()
+    .replace(/_/g, '-')
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  if (normalized === '' || normalized === 'auto' || normalized === '0' || normalized.startsWith('auto-')) {
+    return [TaskValidationMode.Auto, null];
+  }
+  if (
+    normalized === 'creator-review' ||
+    normalized === 'creatorreview' ||
+    normalized.startsWith('creator-review-') ||
+    normalized === 'manual' ||
+    normalized === 'manual-validation' ||
+    normalized.startsWith('manual-validation-') ||
+    normalized === '1'
+  ) {
+    return [TaskValidationMode.CreatorReview, null];
+  }
+
+  return [
+    TaskValidationMode.Auto,
+    errorResult('validationMode must be "auto" or "creator-review"'),
+  ];
+}
+
 function parseTaskDescription(input: unknown): [Uint8Array | null, ToolResult | null] {
   if (typeof input !== 'string' || input.trim().length === 0) {
     return [null, errorResult('description must be a non-empty string')];
@@ -219,7 +356,7 @@ function parseTaskDescription(input: unknown): [Uint8Array | null, ToolResult | 
 }
 
 function parseTaskId(input: unknown): [Uint8Array | null, ToolResult | null] {
-  if (input === undefined) return [generateAgentId(), null];
+  if (isOptionalPlaceholder(input)) return [generateAgentId(), null];
   if (typeof input !== 'string' || input.trim().length === 0) {
     return [null, errorResult('taskId must be a 64-char hex string if provided')];
   }
@@ -235,7 +372,7 @@ function parseTaskId(input: unknown): [Uint8Array | null, ToolResult | null] {
 }
 
 function parseAgentId(input: unknown): [Uint8Array | null, ToolResult | null] {
-  if (input === undefined) return [generateAgentId(), null];
+  if (isOptionalPlaceholder(input)) return [generateAgentId(), null];
   if (typeof input !== 'string' || input.trim().length === 0) {
     return [null, errorResult('agentId must be a 64-char hex string if provided')];
   }
@@ -251,7 +388,7 @@ function parseAgentId(input: unknown): [Uint8Array | null, ToolResult | null] {
 }
 
 function parseKnownRewardMint(input: unknown): [PublicKey | null, ToolResult | null] {
-  if (input === undefined || input === null) return [null, null];
+  if (isOptionalPlaceholder(input)) return [null, null];
   const [mint, err] = parseBase58(input);
   if (err || !mint) return [null, errorResult('Invalid rewardMint address')];
   if (!KNOWN_MINTS[mint.toBase58()]) {
@@ -325,7 +462,7 @@ async function resolveCreatorAgentPda(
   creator: PublicKey,
   providedCreatorAgentPda?: unknown,
 ): Promise<[PublicKey | null, ToolResult | null]> {
-  if (providedCreatorAgentPda !== undefined) {
+  if (!isOptionalPlaceholder(providedCreatorAgentPda)) {
     const [pda, err] = parseBase58(providedCreatorAgentPda);
     return [pda, err];
   }
@@ -351,6 +488,185 @@ function isMissingAccountError(err: unknown): boolean {
     lower.includes('invalid param') ||
     lower.includes('not found')
   );
+}
+
+
+function getJobSpecStoreOptions(rootDir?: string): { rootDir: string } | undefined {
+  return rootDir ? { rootDir } : undefined;
+}
+
+function formatUnknownError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function buildVerifiedTaskJobSpec(
+  source: SerializedTaskJobSpec['source'],
+  base: Omit<SerializedTaskJobSpec, 'source' | 'verified' | 'jobSpecPath' | 'integrity' | 'payload' | 'error'>,
+  resolved: {
+    jobSpecPath: string;
+    integrity: {
+      algorithm: string;
+      canonicalization: string;
+      payloadHash: string;
+      uri: string;
+    };
+    payload: unknown;
+  },
+): SerializedTaskJobSpec {
+  return {
+    source,
+    ...base,
+    verified: true,
+    jobSpecPath: resolved.jobSpecPath,
+    integrity: resolved.integrity,
+    payload: resolved.payload,
+  };
+}
+
+async function buildTaskJobSpecView(
+  taskPda: PublicKey,
+  options: TaskJobSpecQueryToolOptions,
+  includePayload: boolean,
+): Promise<SerializedTaskJobSpec | null> {
+  const storeOptions = getJobSpecStoreOptions(options.jobSpecStoreDir);
+
+  if (options.program) {
+    const onChainPointer = await fetchTaskJobSpecPointer(options.program, taskPda);
+    if (onChainPointer) {
+      const base: Omit<SerializedTaskJobSpec, 'source' | 'verified' | 'jobSpecPath' | 'integrity' | 'payload' | 'error'> = {
+        taskJobSpecPda: onChainPointer.taskJobSpecPda,
+        creator: onChainPointer.creator,
+        jobSpecHash: onChainPointer.jobSpecHash,
+        jobSpecUri: onChainPointer.jobSpecUri,
+        createdAt: onChainPointer.createdAt,
+        updatedAt: onChainPointer.updatedAt,
+      };
+
+      if (!includePayload) {
+        return { source: 'on-chain', ...base, verified: false };
+      }
+
+      try {
+        const resolved = await resolveOnChainTaskJobSpecForTask(
+          options.program,
+          taskPda,
+          storeOptions ?? {},
+        );
+        if (!resolved) {
+          return { source: 'on-chain', ...base, verified: false };
+        }
+        return buildVerifiedTaskJobSpec('on-chain', base, resolved);
+      } catch (error) {
+        return {
+          source: 'on-chain',
+          ...base,
+          verified: false,
+          error: formatUnknownError(error),
+        };
+      }
+    }
+  }
+
+  const localPointer = await readMarketplaceJobSpecPointerForTask(
+    taskPda.toBase58(),
+    storeOptions,
+  );
+  if (!localPointer) return null;
+
+  const base: Omit<SerializedTaskJobSpec, 'source' | 'verified' | 'jobSpecPath' | 'integrity' | 'payload' | 'error'> = {
+    taskJobSpecPda: null,
+    creator: null,
+    jobSpecHash: localPointer.jobSpecHash,
+    jobSpecUri: localPointer.jobSpecUri,
+    jobSpecTaskLinkPath: localPointer.jobSpecTaskLinkPath,
+    transactionSignature: localPointer.transactionSignature,
+  };
+
+  if (!includePayload) {
+    return { source: 'local-task-link', ...base, verified: false };
+  }
+
+  try {
+    const resolved = await resolveMarketplaceJobSpecReference(
+      localPointer,
+      storeOptions,
+    );
+    return buildVerifiedTaskJobSpec('local-task-link', base, resolved);
+  } catch (error) {
+    return {
+      source: 'local-task-link',
+      ...base,
+      verified: false,
+      error: formatUnknownError(error),
+    };
+  }
+}
+
+async function resolveTaskJobSpecPayloadOrThrow(
+  taskPda: PublicKey,
+  options: TaskJobSpecQueryToolOptions,
+): Promise<Record<string, unknown>> {
+  const storeOptions = getJobSpecStoreOptions(options.jobSpecStoreDir);
+  const taskAddress = taskPda.toBase58();
+  const localPointer = await readMarketplaceJobSpecPointerForTask(
+    taskAddress,
+    storeOptions,
+  );
+
+  if (options.program) {
+    const onChainPointer = await fetchTaskJobSpecPointer(options.program, taskPda);
+    if (onChainPointer) {
+      const resolved = await resolveOnChainTaskJobSpecForTask(
+        options.program,
+        taskPda,
+        storeOptions ?? {},
+      );
+      if (!resolved) {
+        throw new Error(`No verified task job spec metadata found for task ${taskAddress}`);
+      }
+      return {
+        taskPda: taskAddress,
+        taskId: localPointer?.taskId ?? null,
+        source: 'on-chain',
+        taskJobSpecPda: resolved.taskJobSpecPda,
+        creator: resolved.creator,
+        jobSpecHash: resolved.jobSpecHash,
+        jobSpecUri: resolved.jobSpecUri,
+        createdAt: resolved.createdAt,
+        updatedAt: resolved.updatedAt,
+        verified: true,
+        jobSpecPath: resolved.jobSpecPath,
+        jobSpecTaskLinkPath: localPointer?.jobSpecTaskLinkPath ?? null,
+        transactionSignature: localPointer?.transactionSignature ?? null,
+        integrity: resolved.integrity,
+        payload: resolved.payload,
+      };
+    }
+  }
+
+  if (localPointer) {
+    const resolved = await resolveMarketplaceJobSpecReference(
+      localPointer,
+      storeOptions,
+    );
+    return {
+      taskPda: taskAddress,
+      taskId: localPointer.taskId,
+      source: 'local-task-link',
+      taskJobSpecPda: null,
+      creator: null,
+      jobSpecHash: resolved.jobSpecHash,
+      jobSpecUri: resolved.jobSpecUri,
+      verified: true,
+      jobSpecPath: resolved.jobSpecPath,
+      jobSpecTaskLinkPath: localPointer.jobSpecTaskLinkPath,
+      transactionSignature: localPointer.transactionSignature,
+      integrity: resolved.integrity,
+      payload: resolved.payload,
+    };
+  }
+
+  throw new Error(`No task job spec metadata found for task ${taskAddress}`);
 }
 
 async function fetchProtocolConfigForAction(
@@ -418,17 +734,28 @@ function getRewardSymbol(rewardMint: PublicKey | null): string | undefined {
   return KNOWN_MINTS[rewardMint.toBase58()]?.symbol;
 }
 
+function decodeFixedBytes(bytes: Uint8Array): string {
+  const nullIndex = bytes.indexOf(0);
+  const slice = nullIndex === -1 ? bytes : bytes.subarray(0, nullIndex);
+  return new TextDecoder().decode(slice).trim();
+}
+
 function serializeTask(
   task: OnChainTask,
   taskPda: PublicKey,
-  extras?: Partial<Pick<SerializedTask, 'escrowTokenAccount' | 'escrowTokenBalance'>>,
+  extras?: Partial<Pick<SerializedTask, 'escrowTokenAccount' | 'escrowTokenBalance' | 'jobSpec'>>,
 ): SerializedTask {
+  const descriptionText = decodeFixedBytes(task.description);
+  const resultText = decodeFixedBytes(task.result);
+
   return {
     taskPda: taskPda.toBase58(),
     taskId: bytesToHex(task.taskId),
     creator: task.creator.toBase58(),
     status: taskStatusToString(task.status),
     taskType: taskTypeToString(task.taskType),
+    taskTypeId: task.taskType,
+    taskTypeKey: taskTypeToKey(task.taskType),
     rewardAmount: task.rewardAmount.toString(),
     rewardSol: lamportsToSol(task.rewardAmount),
     requiredCapabilities: getCapabilityNames(task.requiredCapabilities),
@@ -437,9 +764,14 @@ function serializeTask(
     deadline: task.deadline,
     isPrivate: isPrivateTask(task),
     createdAt: task.createdAt,
+    completedAt: task.completedAt,
     completions: task.completions,
     requiredCompletions: task.requiredCompletions,
-    description: bytesToHex(task.description),
+    description: descriptionText || 'untitled task',
+    descriptionHex: bytesToHex(task.description),
+    constraintHash: bytesToHex(task.constraintHash),
+    result: bytesToHex(task.result),
+    resultText: resultText || null,
     rewardMint: task.rewardMint?.toBase58() ?? null,
     rewardSymbol: getRewardSymbol(task.rewardMint),
     ...extras,
@@ -816,11 +1148,12 @@ async function buildMarketplaceReputationSurface(
 export function createListTasksTool(
   ops: TaskOperations,
   logger: Logger,
+  options: TaskJobSpecQueryToolOptions = {},
 ): Tool {
   return {
     name: 'agenc.listTasks',
     description:
-      'List tasks on the AgenC protocol. Filter by status (open, in_progress, all). Returns task details including reward, capabilities, and deadline.',
+      'List tasks on the AgenC protocol. Filter by status (open, in_progress, all). Returns task details including reward, capabilities, deadline, and any published marketplace job spec metadata.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -837,6 +1170,19 @@ export function createListTasksTool(
           type: 'string',
           description: 'Optional reward mint filter (base58), or "SOL" for native SOL rewards',
         },
+        taskType: {
+          anyOf: [
+            { type: 'number', enum: [0, 1, 2, 3] },
+            { type: 'string' },
+          ],
+          description:
+            'Optional task type filter: 0/exclusive, 1/collaborative, 2/competitive, or 3/bid-exclusive',
+        },
+        includeJobSpecPayload: {
+          type: 'boolean',
+          description:
+            'When true, verify and include the full off-chain marketplace job spec payload for each listed task.',
+        },
       },
     },
     async execute(args: Record<string, unknown>): Promise<ToolResult> {
@@ -846,18 +1192,19 @@ export function createListTasksTool(
         const limit = Math.min(Math.max(1, rawLimit), MAX_LIMIT);
         const [rewardMintFilter, rewardMintErr] = parseRewardMintFilter(args.rewardMint);
         if (rewardMintErr) return rewardMintErr;
+        const [taskTypeFilter, taskTypeFilterErr] = parseOptionalTaskTypeFilter(args.taskType);
+        if (taskTypeFilterErr) return taskTypeFilterErr;
+        const includeJobSpecPayload = args.includeJobSpecPayload === true;
 
         let tasks: Array<{ task: OnChainTask; taskPda: PublicKey }>;
 
         if (status === 'all') {
           tasks = await ops.fetchAllTasks();
         } else {
-          // fetchClaimableTasks uses memcmp filters (scalable)
           const claimable = await ops.fetchClaimableTasks();
           if (status === 'open') {
             tasks = claimable.filter((t) => t.task.status === OnChainTaskStatus.Open);
           } else {
-            // in_progress
             tasks = claimable.filter((t) => t.task.status === OnChainTaskStatus.InProgress);
           }
         }
@@ -869,8 +1216,21 @@ export function createListTasksTool(
           });
         }
 
+        if (taskTypeFilter !== undefined) {
+          tasks = tasks.filter(({ task }) => task.taskType === taskTypeFilter);
+        }
+
         const limited = tasks.slice(0, limit);
-        const serialized = limited.map((t) => serializeTask(t.task, t.taskPda));
+        const serialized = await Promise.all(
+          limited.map(async ({ task, taskPda }) => {
+            const jobSpec = await buildTaskJobSpecView(
+              taskPda,
+              options,
+              includeJobSpecPayload,
+            );
+            return serializeTask(task, taskPda, jobSpec ? { jobSpec } : undefined);
+          }),
+        );
 
         return {
           content: safeStringify({
@@ -894,11 +1254,12 @@ export function createListTasksTool(
 export function createGetTaskTool(
   ops: TaskOperations,
   logger: Logger,
+  options: TaskJobSpecQueryToolOptions = {},
 ): Tool {
   return {
     name: 'agenc.getTask',
     description:
-      'Get details for a specific AgenC task by its PDA address (base58).',
+      'Get details for a specific AgenC task by its PDA address (base58), including verified marketplace job spec metadata when available.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -918,6 +1279,8 @@ export function createGetTaskTool(
         if (!task) {
           return errorResult(`Task not found: ${pda!.toBase58()}`);
         }
+
+        const jobSpec = await buildTaskJobSpecView(pda!, options, true);
         if (task.rewardMint) {
           const escrowTokenAccount = getAssociatedTokenAddressSync(task.rewardMint, task.escrow, true);
           const escrowTokenBalance = await ops.fetchEscrowTokenBalance(pda!, task.rewardMint);
@@ -926,6 +1289,7 @@ export function createGetTaskTool(
               serializeTask(task, pda!, {
                 escrowTokenAccount: escrowTokenAccount.toBase58(),
                 escrowTokenBalance: escrowTokenBalance.toString(),
+                jobSpec,
               }),
             ),
           };
@@ -935,12 +1299,52 @@ export function createGetTaskTool(
             serializeTask(task, pda!, {
               escrowTokenAccount: null,
               escrowTokenBalance: null,
+              jobSpec,
             }),
           ),
         };
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         logger.error(`agenc.getTask failed: ${msg}`);
+        return errorResult(msg);
+      }
+    },
+  };
+}
+
+/**
+ * Create the agenc.getJobSpec tool.
+ */
+export function createGetJobSpecTool(
+  logger: Logger,
+  options: TaskJobSpecQueryToolOptions = {},
+): Tool {
+  return {
+    name: 'agenc.getJobSpec',
+    description:
+      'Resolve and verify the off-chain marketplace job spec for a task PDA. Prefers the on-chain task_job_spec pointer and falls back to the local task-link cache when needed.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        taskPda: {
+          type: 'string',
+          description: 'Task account PDA address (base58)',
+        },
+      },
+      required: ['taskPda'],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const [pda, err] = parseBase58(args.taskPda);
+      if (err) return err;
+
+      try {
+        const resolved = await resolveTaskJobSpecPayloadOrThrow(pda!, options);
+        return {
+          content: safeStringify(resolved),
+        };
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        logger.error(`agenc.getJobSpec failed: ${msg}`);
         return errorResult(msg);
       }
     },
@@ -1760,6 +2164,7 @@ export function createRegisterAgentTool(
 export function createCreateTaskTool(
   program: Program<AgencCoordination>,
   logger: Logger,
+  options: CreateTaskToolOptions = {},
 ): Tool {
   return {
     name: 'agenc.createTask',
@@ -1770,7 +2175,35 @@ export function createCreateTaskTool(
       properties: {
         description: {
           type: 'string',
-          description: `Task description (max ${DESCRIPTION_BYTES} UTF-8 bytes)`,
+          description: `Short on-chain task title/summary (max ${DESCRIPTION_BYTES} UTF-8 bytes). Put the long marketplace job details in jobSpec/fullDescription.`,
+        },
+        jobSpec: {
+          anyOf: [{ type: 'object' }, { type: 'string' }],
+          description:
+            'Optional full marketplace job spec. Stored off-chain as canonical JSON with a sha256 integrity hash; use for long requirements, scope, examples, and notes.',
+        },
+        fullDescription: {
+          type: 'string',
+          description: 'Optional long-form job description stored in the marketplace jobSpec object.',
+        },
+        acceptanceCriteria: {
+          anyOf: [{ type: 'array', items: { type: 'string' } }, { type: 'string' }],
+          description: 'Optional acceptance criteria stored in the marketplace jobSpec object.',
+        },
+        deliverables: {
+          anyOf: [{ type: 'array', items: { type: 'string' } }, { type: 'string' }],
+          description: 'Optional expected deliverables stored in the marketplace jobSpec object.',
+        },
+        constraints: {
+          anyOf: [{ type: 'object' }, { type: 'array' }, { type: 'string' }],
+          description: 'Optional constraints for the jobSpec, such as prohibited actions, required tooling, or security requirements.',
+        },
+        attachments: {
+          anyOf: [
+            { type: 'array', items: { anyOf: [{ type: 'string' }, { type: 'object' }] } },
+            { type: 'string' },
+          ],
+          description: 'Optional external attachment URLs. Only https, ipfs, ar, or arweave URLs are accepted; local file paths and insecure http URLs are rejected.',
         },
         reward: {
           type: 'string',
@@ -1793,9 +2226,12 @@ export function createCreateTaskTool(
           description: 'Unix timestamp seconds. Default now + 1 hour.',
         },
         taskType: {
-          type: 'number',
-          enum: [0, 1, 2, 3],
-          description: '0=Exclusive, 1=Collaborative, 2=Competitive, 3=BidExclusive (default 0)',
+          anyOf: [
+            { type: 'number', enum: [0, 1, 2, 3] },
+            { type: 'string' },
+          ],
+          description:
+            'Task type: 0/exclusive, 1/collaborative, 2/competitive, or 3/bid-exclusive (default exclusive)',
         },
         minReputation: {
           type: 'number',
@@ -1803,7 +2239,18 @@ export function createCreateTaskTool(
         },
         constraintHash: {
           type: 'string',
-          description: 'Optional 32-byte hex string for private tasks',
+          description:
+            'Optional 32-byte hex string for private tasks. Omit when validationMode="creator-review".',
+        },
+        validationMode: {
+          type: 'string',
+          enum: ['auto', 'creator-review'],
+          description: 'Task validation mode. Use "creator-review" to hold payout until creator approval.',
+        },
+        reviewWindowSecs: {
+          type: 'number',
+          description:
+            `Creator review window in seconds for validationMode="creator-review" (default ${DEFAULT_CREATOR_REVIEW_WINDOW_SECS}).`,
         },
         taskId: {
           type: 'string',
@@ -1859,10 +2306,30 @@ export function createCreateTaskTool(
         const requiredCapabilitiesRangeErr = validateU64(requiredCapabilities, 'requiredCapabilities');
         if (requiredCapabilitiesRangeErr) return requiredCapabilitiesRangeErr;
 
-        const [taskType, taskTypeErr] = parseBoundedNumber(args.taskType, 'taskType', 0, 3, 0);
+        const [taskType, taskTypeErr] = parseTaskTypeInput(args.taskType, TaskType.Exclusive);
         if (taskTypeErr) return taskTypeErr;
         const [maxWorkers, maxWorkersErr] = parseBoundedNumber(args.maxWorkers, 'maxWorkers', 1, 100, 1);
         if (maxWorkersErr) return maxWorkersErr;
+
+        const [minReputation, minReputationErr] = parseBoundedNumber(
+          args.minReputation,
+          'minReputation',
+          0,
+          MAX_REPUTATION,
+          0,
+        );
+        if (minReputationErr) return minReputationErr;
+
+        const [validationMode, validationModeErr] = parseTaskValidationMode(args.validationMode);
+        if (validationModeErr) return validationModeErr;
+        if (
+          validationMode === TaskValidationMode.CreatorReview &&
+          taskType !== TaskType.Exclusive
+        ) {
+          return errorResult(
+            'validationMode="creator-review" is only supported when taskType is 0/exclusive',
+          );
+        }
 
         const now = Math.floor(Date.now() / 1000);
         const [deadline, deadlineErr] = parseBoundedNumber(
@@ -1874,9 +2341,37 @@ export function createCreateTaskTool(
         );
         if (deadlineErr) return deadlineErr;
 
-        // The public CLI surface still restricts creation to public tasks with
-        // default reputation gating. We pass null/default values for the extra
-        // canonical fields unless the caller opts into a known public reward mint.
+        const [reviewWindowSecs, reviewWindowSecsErr] = parseBoundedNumber(
+          args.reviewWindowSecs,
+          'reviewWindowSecs',
+          1,
+          Number.MAX_SAFE_INTEGER,
+          DEFAULT_CREATOR_REVIEW_WINDOW_SECS,
+        );
+        if (reviewWindowSecsErr) return reviewWindowSecsErr;
+        if (
+          !isOptionalPlaceholder(args.reviewWindowSecs) &&
+          validationMode !== TaskValidationMode.CreatorReview
+        ) {
+          return errorResult('reviewWindowSecs is only valid when validationMode is "creator-review"');
+        }
+
+        const [customConstraintHash, constraintHashErr] = parseOptionalHexBytes(
+          args.constraintHash,
+          'constraintHash',
+          TASK_ID_BYTES,
+        );
+        if (constraintHashErr) return constraintHashErr;
+        if (
+          validationMode === TaskValidationMode.CreatorReview &&
+          customConstraintHash !== null
+        ) {
+          return errorResult(
+            'Do not provide constraintHash with validationMode="creator-review"; creator-review tasks are configured through validation settings',
+          );
+        }
+        const constraintHash = customConstraintHash;
+
         const [rewardMint, rewardMintErr] = parseKnownRewardMint(args.rewardMint);
         if (rewardMintErr) return rewardMintErr;
         const [creatorAgentPda, creatorAgentErr] = await resolveCreatorAgentPda(
@@ -1888,6 +2383,47 @@ export function createCreateTaskTool(
           return (
             creatorAgentErr ?? errorResult("Unable to resolve creatorAgentPda")
           );
+        }
+
+        let storedJobSpec: Awaited<ReturnType<typeof persistMarketplaceJobSpec>> | null = null;
+        if (hasMarketplaceJobSpecInput(args)) {
+          try {
+            storedJobSpec = await persistMarketplaceJobSpec(
+              {
+                description: args.description as string,
+                jobSpec: args.jobSpec,
+                fullDescription: args.fullDescription,
+                acceptanceCriteria: args.acceptanceCriteria,
+                deliverables: args.deliverables,
+                constraints: args.constraints,
+                attachments: args.attachments,
+                context: {
+                  rewardLamports: reward.toString(),
+                  requiredCapabilities: requiredCapabilities.toString(),
+                  rewardMint: rewardMint?.toBase58() ?? null,
+                  maxWorkers,
+                  deadline,
+                  taskType,
+                  minReputation,
+                  validationMode:
+                    validationMode === TaskValidationMode.CreatorReview
+                      ? 'creator-review'
+                      : 'auto',
+                  reviewWindowSecs:
+                    validationMode === TaskValidationMode.CreatorReview
+                      ? reviewWindowSecs
+                      : null,
+                  creatorAgentPda: creatorAgentPda.toBase58(),
+                },
+              },
+              options.jobSpecStoreDir
+                ? { rootDir: options.jobSpecStoreDir }
+                : undefined,
+            );
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            return errorResult(`Invalid jobSpec metadata: ${message}`);
+          }
         }
 
         const taskPda = findTaskPda(creator, taskId, program.programId);
@@ -1909,8 +2445,8 @@ export function createCreateTaskTool(
             maxWorkers,
             new BN(deadline),
             taskType,
-            null,
-            0,
+            constraintHash ? toAnchorBytes(constraintHash) : null,
+            minReputation,
             rewardMint,
           )
           .accountsPartial({
@@ -1926,6 +2462,79 @@ export function createCreateTaskTool(
           })
           .rpc();
 
+        let validationTransactionSignature: string | null = null;
+        let taskValidationConfigPda: string | null = null;
+        let taskAttestorConfigPda: string | null = null;
+        if (validationMode === TaskValidationMode.CreatorReview) {
+          try {
+            const ops = new TaskOperations({
+              program,
+              agentId: new Uint8Array(TASK_ID_BYTES),
+              logger,
+            });
+            const validationResult = await ops.configureTaskValidation(
+              taskPda,
+              { taskId } as OnChainTask,
+              TaskValidationMode.CreatorReview,
+              reviewWindowSecs,
+            );
+            validationTransactionSignature =
+              validationResult.transactionSignature ?? null;
+            taskValidationConfigPda =
+              validationResult.taskValidationConfigPda.toBase58();
+            taskAttestorConfigPda =
+              validationResult.taskAttestorConfigPda?.toBase58() ?? null;
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            return errorResult(
+              `Task was created at ${taskPda.toBase58()} but creator-review validation configuration failed: ${message}`,
+            );
+          }
+        }
+
+        let taskJobSpecPda: string | null = null;
+        let jobSpecTransactionSignature: string | null = null;
+        if (storedJobSpec) {
+          try {
+            const published = await setTaskJobSpecPointer(
+              program,
+              creator,
+              taskPda,
+              storedJobSpec.hash,
+              storedJobSpec.uri,
+            );
+            taskJobSpecPda = published.taskJobSpecPda.toBase58();
+            jobSpecTransactionSignature = published.transactionSignature;
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            return errorResult(
+              `Task was created at ${taskPda.toBase58()} but job spec metadata publishing failed: ${message}`,
+            );
+          }
+        }
+
+        let jobSpecTaskLinkPath: string | null = null;
+        let jobSpecLinkWarning: string | null = null;
+        if (storedJobSpec) {
+          try {
+            jobSpecTaskLinkPath = await linkMarketplaceJobSpecToTask(
+              {
+                hash: storedJobSpec.hash,
+                uri: storedJobSpec.uri,
+                taskPda: taskPda.toBase58(),
+                taskId: bytesToHex(taskId),
+                transactionSignature: jobSpecTransactionSignature ?? txSignature,
+              },
+              options.jobSpecStoreDir
+                ? { rootDir: options.jobSpecStoreDir }
+                : undefined,
+            );
+          } catch (error) {
+            jobSpecLinkWarning =
+              error instanceof Error ? error.message : String(error);
+          }
+        }
+
         // Mark as created to prevent LLM from calling again
         recentCreateTaskCalls.set(dedupKey, Date.now());
         // Clean up old entries
@@ -1938,10 +2547,39 @@ export function createCreateTaskTool(
             taskPda: taskPda.toBase58(),
             escrowPda: escrowPda.toBase58(),
             taskId: bytesToHex(taskId),
+            taskType: taskTypeToString(taskType),
+            taskTypeId: taskType,
+            taskTypeKey: taskTypeToKey(taskType),
             creatorAgentPda: creatorAgentPda.toBase58(),
+            authorityRateLimitPda: authorityRateLimitPda.toBase58(),
             rewardMint: rewardMint?.toBase58() ?? null,
             rewardSymbol: getRewardSymbol(rewardMint),
+            constraintHash: constraintHash ? bytesToHex(constraintHash) : null,
+            minReputation,
+            validationMode:
+              validationMode === TaskValidationMode.CreatorReview
+                ? 'creator-review'
+                : 'auto',
+            reviewWindowSecs:
+              validationMode === TaskValidationMode.CreatorReview
+                ? reviewWindowSecs
+                : null,
+            validationConfigured:
+              validationMode === TaskValidationMode.CreatorReview,
+            taskValidationConfigPda,
+            taskAttestorConfigPda,
+            taskJobSpecPda,
+            jobSpecHash: storedJobSpec?.hash ?? null,
+            jobSpecUri: storedJobSpec?.uri ?? null,
+            jobSpecPath: storedJobSpec?.path ?? null,
+            jobSpecTaskLinkPath,
+            jobSpecIntegrity: storedJobSpec
+              ? { algorithm: 'sha256', canonicalization: 'json-stable-v1' }
+              : null,
+            jobSpecTransactionSignature,
+            jobSpecLinkWarning,
             transactionSignature: txSignature,
+            validationTransactionSignature,
           }),
         };
       } catch (error) {

--- a/runtime/src/tools/agenc/types.ts
+++ b/runtime/src/tools/agenc/types.ts
@@ -8,6 +8,31 @@
  */
 
 /**
+ * JSON-safe representation of verified task marketplace metadata.
+ */
+export interface SerializedTaskJobSpec {
+  source: "on-chain" | "local-task-link";
+  taskJobSpecPda?: string | null;
+  creator?: string | null;
+  jobSpecHash: string;
+  jobSpecUri: string;
+  createdAt?: number;
+  updatedAt?: number;
+  verified: boolean;
+  error?: string;
+  jobSpecPath?: string | null;
+  jobSpecTaskLinkPath?: string | null;
+  transactionSignature?: string | null;
+  integrity?: {
+    algorithm: string;
+    canonicalization: string;
+    payloadHash: string;
+    uri: string;
+  } | null;
+  payload?: unknown;
+}
+
+/**
  * JSON-safe representation of an on-chain Task.
  */
 export interface SerializedTask {
@@ -16,6 +41,8 @@ export interface SerializedTask {
   creator: string;
   status: string;
   taskType: string;
+  taskTypeId: number;
+  taskTypeKey: string;
   rewardAmount: string;
   rewardSol: string;
   requiredCapabilities: string[];
@@ -24,12 +51,19 @@ export interface SerializedTask {
   deadline: number;
   isPrivate: boolean;
   createdAt: number;
+  completedAt: number;
   completions: number;
   requiredCompletions: number;
   description: string;
+  descriptionHex: string;
+  constraintHash: string;
+  result: string;
+  resultText: string | null;
   rewardMint: string | null;
   /** Optional symbol for known reward mints (SOL, USDC, USDT, etc.) */
   rewardSymbol?: string;
+  /** Optional verified marketplace job spec metadata for this task. */
+  jobSpec?: SerializedTaskJobSpec | null;
   /** Escrow token ATA (present when task is token-denominated and requested by detail view) */
   escrowTokenAccount?: string | null;
   /** Escrow token balance in base units (present when task is token-denominated and requested by detail view) */

--- a/runtime/tests/marketplace-cli.integration.test.ts
+++ b/runtime/tests/marketplace-cli.integration.test.ts
@@ -1,4 +1,7 @@
 import { createHash } from "node:crypto";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import type { Connection } from "@solana/web3.js";
 import { Keypair, LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
@@ -296,6 +299,66 @@ afterAll(() => {
 });
 
 describeIfProtocolWorkspace("marketplace CLI integration", () => {
+  it("surfaces local job spec metadata in task list and detail", async () => {
+    const jobSpecStoreDir = await mkdtemp(
+      join(tmpdir(), "agenc-market-job-spec-"),
+    );
+    const createPayload = await runMarketCommand(
+      runMarketTaskCreateCommand,
+      {
+        description: "LiteSVM job spec task",
+        reward: String(LAMPORTS_PER_SOL / 20),
+        requiredCapabilities: "1",
+        creatorAgentPda: creator.agentPda.toBase58(),
+        fullDescription: "Execute the extended marketplace job specification.",
+        acceptanceCriteria: ["reads local spec", "verifies integrity"],
+        deliverables: ["result report"],
+        constraints: { maxRuntimeSecs: 120 },
+        attachments: ["https://example.com/spec.md"],
+        jobSpecStoreDir,
+      },
+      creator.agentPda.toBase58(),
+    );
+    const createdTask = asRecord(createPayload.result);
+    const taskPda = expectString(createdTask.taskPda);
+    registerLiteSVMProgramAccount(baseCtx.connection, new PublicKey(taskPda));
+
+    const detailPayload = await runMarketCommand(runMarketTaskDetailCommand, {
+      taskPda,
+      jobSpecStoreDir,
+    });
+    const detailTask = asRecord(detailPayload.task);
+    const detailSpec = asRecord(detailTask.jobSpec);
+    expect(detailSpec.available).toBe(true);
+    expect(expectString(detailSpec.jobSpecHash)).toBe(
+      expectString(createdTask.jobSpecHash),
+    );
+    const payload = asRecord(detailSpec.payload);
+    expect(payload.fullDescription).toBe(
+      "Execute the extended marketplace job specification.",
+    );
+    expect(expectArray(payload.acceptanceCriteria)).toContain(
+      "reads local spec",
+    );
+
+    const listPayload = await runMarketCommand(runMarketTasksListCommand, {
+      statuses: ["open"],
+      jobSpecStoreDir,
+    });
+    const summary = asRecord(
+      expectArray(listPayload.tasks)
+        .map(asRecord)
+        .find((task) => expectString(task.taskPda) === taskPda),
+    );
+    const summarySpec = asRecord(summary.jobSpec);
+    expect(summarySpec.available).toBe(true);
+    expect(expectString(summarySpec.jobSpecHash)).toBe(
+      expectString(createdTask.jobSpecHash),
+    );
+    expect(expectString(summarySpec.jobSpecUri)).toBe(
+      expectString(createdTask.jobSpecUri),
+    );
+  });
   it("runs task lifecycle commands against LiteSVM", async () => {
     const createPayload = await runMarketCommand(
       runMarketTaskCreateCommand,


### PR DESCRIPTION
## Summary
- Adds marketplace job spec support for tasks: full off-chain job details, acceptance criteria, deliverables, constraints, and attachments can now be stored separately from the short on-chain task description.
- Persists job specs as canonical JSON with sha256 integrity metadata, content-addressed local storage, task-to-spec links, and on-chain `task_job_spec` pointer publication/resolution.
- Extends marketplace task creation/list/detail flows across the CLI, TUI, webchat handler, and AgenC tools so job spec hashes/URIs are returned and broadcast with created tasks.
- Adds `agenc.getJobSpec` plus job-spec enrichment for `agenc.listTasks` and `agenc.getTask`, preferring on-chain pointers and falling back to the local task-link cache.
- Expands task creation options for task type aliases, reward mint, min reputation, constraint hash, creator-review validation mode, review windows, and creator agent PDA handling.
- Updates task serialization/IDL helpers and PDA coverage for the new marketplace/runtime fields, including authority rate limit helpers.

## Safety notes
- This PR was rebuilt from a clean `origin/main` base at `00d99bc9` on branch `codex/pr-324-clean-main`.
- It intentionally does not change `runtime/src/task/operations.ts`, so it does not overwrite the runtime contract work already merged into `main`.
- Scope is limited to marketplace job spec support and the related CLI/tool/webchat serialization paths.

## Validation
- `npm run typecheck` from `runtime`
- `npm run test -- src/agent/pda.test.ts src/idl.test.ts src/tools/agenc/tools.test.ts src/channels/webchat/handlers.test.ts tests/marketplace-cli.integration.test.ts`
- `npm run build` from `runtime` (passed; only existing Rollup/Vite warnings were emitted)