### PR TITLE
 fix Grok 4.20 model aliases

### DIFF
--- a/runtime/src/gateway/background-run-supervisor.test.ts
+++ b/runtime/src/gateway/background-run-supervisor.test.ts
@@ -6108,6 +6108,12 @@ describe("background-run-supervisor", () => {
       chatStream: vi.fn(),
       healthCheck: vi.fn(async () => true),
     };
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () =>
+        new Response(JSON.stringify({ blockingError: "idle blocked" }), {
+          status: 200,
+        }),
+    );
     const supervisor = new BackgroundRunSupervisor({
       chatExecutor: { execute } as any,
       supervisorLlm,
@@ -6122,8 +6128,8 @@ describe("background-run-supervisor", () => {
             {
               id: "worker-idle-block",
               phase: "WorkerIdle",
-              kind: "command",
-              target: "printf '{\"blockingError\":\"idle blocked\"}'",
+              kind: "http",
+              target: "https://stop-hook.test/worker-idle",
             },
           ],
         }),

--- a/runtime/src/gateway/context-window.test.ts
+++ b/runtime/src/gateway/context-window.test.ts
@@ -21,9 +21,15 @@ describe("normalizeGrokModel", () => {
   });
 
   it("maps superseded 0304 experimental models to 0309 canonical models", () => {
-    expect(normalizeGrokModel("grok-4.20-experimental-beta-0304-reasoning")).toBe("grok-4.20-0309-reasoning");
-    expect(normalizeGrokModel("grok-4.20-experimental-beta-0304-non-reasoning")).toBe("grok-4.20-0309-non-reasoning");
-    expect(normalizeGrokModel("grok-4.20-multi-agent-experimental-beta-0304")).toBe("grok-4.20-multi-agent-0309");
+    expect(normalizeGrokModel("grok-4.20-experimental-beta-0304-reasoning")).toBe("grok-4.20-beta-0309-reasoning");
+    expect(normalizeGrokModel("grok-4.20-experimental-beta-0304-non-reasoning")).toBe("grok-4.20-beta-0309-non-reasoning");
+    expect(normalizeGrokModel("grok-4.20-multi-agent-experimental-beta-0304")).toBe("grok-4.20-multi-agent-beta-0309");
+  });
+
+  it("maps stale non-beta 4.20 IDs to the current beta catalog IDs", () => {
+    expect(normalizeGrokModel("grok-4.20-0309-reasoning")).toBe("grok-4.20-beta-0309-reasoning");
+    expect(normalizeGrokModel("grok-4.20-0309-non-reasoning")).toBe("grok-4.20-beta-0309-non-reasoning");
+    expect(normalizeGrokModel("grok-4.20-multi-agent-0309")).toBe("grok-4.20-multi-agent-beta-0309");
   });
 });
 
@@ -35,9 +41,10 @@ describe("inferGrokContextWindowTokens", () => {
     expect(inferGrokContextWindowTokens("grok-4-fast")).toBe(2_000_000);
     expect(inferGrokContextWindowTokens("grok-4-fast-reasoning")).toBe(2_000_000);
     expect(inferGrokContextWindowTokens("grok-4-fast-non-reasoning")).toBe(2_000_000);
+    expect(inferGrokContextWindowTokens("grok-4.20-beta-0309-reasoning")).toBe(2_000_000);
+    expect(inferGrokContextWindowTokens("grok-4.20-beta-0309-non-reasoning")).toBe(2_000_000);
+    expect(inferGrokContextWindowTokens("grok-4.20-multi-agent-beta-0309")).toBe(2_000_000);
     expect(inferGrokContextWindowTokens("grok-4.20-0309-reasoning")).toBe(2_000_000);
-    expect(inferGrokContextWindowTokens("grok-4.20-0309-non-reasoning")).toBe(2_000_000);
-    expect(inferGrokContextWindowTokens("grok-4.20-multi-agent-0309")).toBe(2_000_000);
   });
 
   it("resolves model-specific windows for non-fast variants", () => {
@@ -61,12 +68,13 @@ describe("listKnownGrokModels", () => {
     });
   });
 
-  it("includes 0309 models with aliases from superseded variants", () => {
+  it("includes current 0309 beta models with aliases from superseded variants", () => {
     const models = listKnownGrokModels();
-    const reasoning = models.find((e) => e.id === "grok-4.20-0309-reasoning");
+    const reasoning = models.find((e) => e.id === "grok-4.20-beta-0309-reasoning");
     expect(reasoning).toBeDefined();
     expect(reasoning!.contextWindowTokens).toBe(2_000_000);
-    expect(reasoning!.aliases).toContain("grok-4.20-beta-0309-reasoning");
+    expect(reasoning!.aliases).toContain("grok-4.20-0309-reasoning");
+    expect(reasoning!.aliases).toContain("grok-4.20-reasoning");
     expect(reasoning!.aliases).toContain("grok-4.20-experimental-beta-0304-reasoning");
   });
 

--- a/runtime/src/gateway/context-window.ts
+++ b/runtime/src/gateway/context-window.ts
@@ -21,25 +21,29 @@ const LEGACY_GROK_MODEL_ALIASES: Record<string, string> = {
   "grok-4": "grok-4-1-fast-reasoning",
   "grok-4-fast-reasoning": "grok-4-1-fast-reasoning",
   "grok-4-fast-non-reasoning": "grok-4-1-fast-non-reasoning",
-  // Superseded Grok 4.20 aliases -> 0309 canonical models
+  // Superseded Grok 4.20 aliases -> current live 0309 beta catalog IDs.
   "grok-4.20-experimental-beta-0304-reasoning":
-    "grok-4.20-0309-reasoning",
+    "grok-4.20-beta-0309-reasoning",
   "grok-4.20-experimental-beta-0304-non-reasoning":
-    "grok-4.20-0309-non-reasoning",
+    "grok-4.20-beta-0309-non-reasoning",
   "grok-4.20-multi-agent-experimental-beta-0304":
-    "grok-4.20-multi-agent-0309",
-  "grok-4.20-beta-0309-reasoning": "grok-4.20-0309-reasoning",
-  "grok-4.20-beta-0309-non-reasoning": "grok-4.20-0309-non-reasoning",
-  "grok-4.20-multi-agent-beta-0309": "grok-4.20-multi-agent-0309",
-  "grok-4.20-beta-latest-reasoning": "grok-4.20-0309-reasoning",
-  "grok-4.20-beta-latest-non-reasoning": "grok-4.20-0309-non-reasoning",
+    "grok-4.20-multi-agent-beta-0309",
+  "grok-4.20-0309-reasoning": "grok-4.20-beta-0309-reasoning",
+  "grok-4.20-0309-non-reasoning": "grok-4.20-beta-0309-non-reasoning",
+  "grok-4.20-multi-agent-0309": "grok-4.20-multi-agent-beta-0309",
+  "grok-4.20-reasoning": "grok-4.20-beta-0309-reasoning",
+  "grok-4.20-non-reasoning": "grok-4.20-beta-0309-non-reasoning",
+  "grok-4.20-multi-agent": "grok-4.20-multi-agent-beta-0309",
+  "grok-4.20-beta-latest-reasoning": "grok-4.20-beta-0309-reasoning",
+  "grok-4.20-beta-latest-non-reasoning": "grok-4.20-beta-0309-non-reasoning",
+  "grok-4.20-multi-agent-beta-latest": "grok-4.20-multi-agent-beta-0309",
 };
 
 const KNOWN_GROK_MODEL_IDS = [
-  // Chat / language models (source: xAI docs, March 14 2026)
-  "grok-4.20-0309-reasoning",
-  "grok-4.20-0309-non-reasoning",
-  "grok-4.20-multi-agent-0309",
+  // Chat / language models (source: live /models catalog, April 11 2026)
+  "grok-4.20-beta-0309-reasoning",
+  "grok-4.20-beta-0309-non-reasoning",
+  "grok-4.20-multi-agent-beta-0309",
   "grok-4-1-fast-reasoning",
   "grok-4-1-fast-non-reasoning",
   "grok-4-fast-reasoning",
@@ -62,11 +66,11 @@ const GROK_CONTEXT_WINDOW_BY_PREFIX: ReadonlyArray<{
   readonly prefix: string;
   readonly contextWindowTokens: number;
 }> = [
-  // Source: xAI Docs MCP page developers/models (retrieved March 14, 2026)
-  { prefix: "grok-4.20-multi-agent-0309", contextWindowTokens: 2_000_000 },
-  { prefix: "grok-4.20-0309-reasoning", contextWindowTokens: 2_000_000 },
+  // Source: live /models catalog (retrieved April 11, 2026)
+  { prefix: "grok-4.20-multi-agent-beta-0309", contextWindowTokens: 2_000_000 },
+  { prefix: "grok-4.20-beta-0309-reasoning", contextWindowTokens: 2_000_000 },
   {
-    prefix: "grok-4.20-0309-non-reasoning",
+    prefix: "grok-4.20-beta-0309-non-reasoning",
     contextWindowTokens: 2_000_000,
   },
   { prefix: "grok-4-1-fast", contextWindowTokens: 2_000_000 },

--- a/runtime/src/gateway/daemon-command-registry.ts
+++ b/runtime/src/gateway/daemon-command-registry.ts
@@ -1541,12 +1541,19 @@ export function createDaemonCommandRegistry(
       }
 
       const normalized = normalizeGrokModel(arg) ?? arg;
-      let match = chatModels.find((m) => m.id === normalized);
+      const normalizedLower = normalized.toLowerCase();
+      let match =
+        chatModels.find((m) => m.id.toLowerCase() === argLower) ??
+        chatModels.find((m) => m.id.toLowerCase() === normalizedLower);
       if (!match) {
+        const argTokens = argLower.split(/[\s_]+/).filter(Boolean);
+        const matchesModelQuery = (value: string): boolean =>
+          value.includes(argLower) ||
+          (argTokens.length > 1 && argTokens.every((token) => value.includes(token)));
         // Try fuzzy: check if any model contains the input
         const fuzzy = chatModels.filter((m) =>
-          m.id.toLowerCase().includes(argLower) ||
-          m.aliases.some((a) => a.toLowerCase().includes(argLower)),
+          matchesModelQuery(m.id.toLowerCase()) ||
+          m.aliases.some((a) => matchesModelQuery(a.toLowerCase())),
         );
         if (fuzzy.length === 1) {
           match = fuzzy[0];

--- a/runtime/src/llm/compact/constants.ts
+++ b/runtime/src/llm/compact/constants.ts
@@ -25,7 +25,7 @@ export const ESCALATED_MAX_TOKENS = 64_000;
  * The previous hardcoded 120K threshold was 6% of a 2M window, causing
  * the model to lose its working memory after ~30 tool calls. Scaling
  * by percentage means the threshold automatically adapts to any model:
- *   - grok-4.20-0309-reasoning (2M): 800K threshold
+ *   - grok-4.20-beta-0309-reasoning (2M): 800K threshold
  *   - grok-4-1-fast (2M): 800K threshold
  *   - grok-3-mini (128K): 51K threshold
  *   - ollama local (32K): 12.8K threshold

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -92,9 +92,9 @@ const VISION_MODELS_WITH_TOOLS = new Set([
   "grok-4-0709",
   "grok-4-1-fast-reasoning",
   "grok-4-1-fast-non-reasoning",
-  "grok-4.20-0309-reasoning",
-  "grok-4.20-0309-non-reasoning",
-  "grok-4.20-multi-agent-0309",
+  "grok-4.20-beta-0309-reasoning",
+  "grok-4.20-beta-0309-non-reasoning",
+  "grok-4.20-multi-agent-beta-0309",
 ]);
 
 interface StatefulSessionAnchor {

--- a/runtime/src/llm/grok/xai-strict-filter.test.ts
+++ b/runtime/src/llm/grok/xai-strict-filter.test.ts
@@ -113,38 +113,48 @@ function functionCallBlock(name: string, args: string): Record<string, unknown> 
 
 describe("resolveDocumentedXaiModel", () => {
   it("returns canonical ID for known catalog entries", () => {
-    expect(resolveDocumentedXaiModel("grok-4.20-0309-reasoning")).toBe(
-      "grok-4.20-0309-reasoning",
+    expect(resolveDocumentedXaiModel("grok-4.20-beta-0309-reasoning")).toBe(
+      "grok-4.20-beta-0309-reasoning",
     );
     expect(resolveDocumentedXaiModel("grok-4-1-fast-non-reasoning")).toBe(
       "grok-4-1-fast-non-reasoning",
     );
-    expect(resolveDocumentedXaiModel("grok-4.20-multi-agent-0309")).toBe(
-      "grok-4.20-multi-agent-0309",
+    expect(resolveDocumentedXaiModel("grok-4.20-multi-agent-beta-0309")).toBe(
+      "grok-4.20-multi-agent-beta-0309",
     );
   });
 
   it("resolves bare-name aliases to canonical", () => {
     expect(resolveDocumentedXaiModel("grok-4.20-reasoning")).toBe(
-      "grok-4.20-0309-reasoning",
+      "grok-4.20-beta-0309-reasoning",
     );
     expect(resolveDocumentedXaiModel("grok-4.20-multi-agent")).toBe(
-      "grok-4.20-multi-agent-0309",
+      "grok-4.20-multi-agent-beta-0309",
     );
   });
 
   it("resolves -latest aliases to canonical", () => {
     expect(resolveDocumentedXaiModel("grok-4.20-reasoning-latest")).toBe(
-      "grok-4.20-0309-reasoning",
+      "grok-4.20-beta-0309-reasoning",
     );
     expect(
       resolveDocumentedXaiModel("grok-4-1-fast-non-reasoning-latest"),
     ).toBe("grok-4-1-fast-non-reasoning");
   });
 
+  it("resolves stale non-beta 4.20 IDs to current beta catalog IDs", () => {
+    expect(resolveDocumentedXaiModel("grok-4.20-0309-reasoning")).toBe(
+      "grok-4.20-beta-0309-reasoning",
+    );
+    expect(resolveDocumentedXaiModel("grok-4.20-0309-non-reasoning")).toBe(
+      "grok-4.20-beta-0309-non-reasoning",
+    );
+    expect(resolveDocumentedXaiModel("grok-4.20-multi-agent-0309")).toBe(
+      "grok-4.20-multi-agent-beta-0309",
+    );
+  });
+
   it("returns null for undocumented IDs", () => {
-    // The exact bug we hit on 2026-04-09: -beta variant doesn't exist.
-    expect(resolveDocumentedXaiModel("grok-4.20-beta-0309-reasoning")).toBeNull();
     expect(resolveDocumentedXaiModel("grok-9.99-flux-capacitor")).toBeNull();
     expect(resolveDocumentedXaiModel("gpt-4")).toBeNull();
     expect(resolveDocumentedXaiModel("claude-opus-4")).toBeNull();
@@ -174,7 +184,7 @@ describe("resolveDocumentedXaiModel", () => {
 
 describe("model capability flags", () => {
   it("modelSupportsFunctionCalling: text models yes, imagine-* no", () => {
-    expect(modelSupportsFunctionCalling("grok-4.20-0309-reasoning")).toBe(true);
+    expect(modelSupportsFunctionCalling("grok-4.20-beta-0309-reasoning")).toBe(true);
     expect(modelSupportsFunctionCalling("grok-4-1-fast-non-reasoning")).toBe(
       true,
     );
@@ -183,10 +193,10 @@ describe("model capability flags", () => {
   });
 
   it("modelSupportsReasoningEffort: only multi-agent", () => {
-    expect(modelSupportsReasoningEffort("grok-4.20-multi-agent-0309")).toBe(
+    expect(modelSupportsReasoningEffort("grok-4.20-multi-agent-beta-0309")).toBe(
       true,
     );
-    expect(modelSupportsReasoningEffort("grok-4.20-0309-reasoning")).toBe(false);
+    expect(modelSupportsReasoningEffort("grok-4.20-beta-0309-reasoning")).toBe(false);
     expect(modelSupportsReasoningEffort("grok-4-1-fast-reasoning")).toBe(false);
     expect(modelSupportsReasoningEffort("grok-4-1-fast-non-reasoning")).toBe(
       false,
@@ -194,10 +204,10 @@ describe("model capability flags", () => {
   });
 
   it("modelIsReasoningVariant catches reasoning + multi-agent", () => {
-    expect(modelIsReasoningVariant("grok-4.20-0309-reasoning")).toBe(true);
+    expect(modelIsReasoningVariant("grok-4.20-beta-0309-reasoning")).toBe(true);
     expect(modelIsReasoningVariant("grok-4-1-fast-reasoning")).toBe(true);
-    expect(modelIsReasoningVariant("grok-4.20-multi-agent-0309")).toBe(true);
-    expect(modelIsReasoningVariant("grok-4.20-0309-non-reasoning")).toBe(false);
+    expect(modelIsReasoningVariant("grok-4.20-multi-agent-beta-0309")).toBe(true);
+    expect(modelIsReasoningVariant("grok-4.20-beta-0309-non-reasoning")).toBe(false);
     expect(modelIsReasoningVariant("grok-4-1-fast-non-reasoning")).toBe(false);
   });
 });
@@ -219,7 +229,7 @@ describe("validateXaiRequestPreFlight (pass cases)", () => {
     expect(() =>
       validateXaiRequestPreFlight(
         plainTextRequest({
-          model: "grok-4.20-multi-agent-0309",
+          model: "grok-4.20-multi-agent-beta-0309",
           reasoning: { effort: "high" },
         }),
       ),
@@ -231,7 +241,7 @@ describe("validateXaiRequestPreFlight (pass cases)", () => {
       expect(() =>
         validateXaiRequestPreFlight(
           plainTextRequest({
-            model: "grok-4.20-multi-agent-0309",
+            model: "grok-4.20-multi-agent-beta-0309",
             reasoning: { effort },
           }),
         ),
@@ -286,10 +296,10 @@ describe("validateXaiRequestPreFlight (pass cases)", () => {
 // ---------------------------------------------------------------------------
 
 describe("validateXaiRequestPreFlight (reject cases)", () => {
-  it("throws XaiUnknownModelError for the exact bug we hit (-beta variant)", () => {
+  it("throws XaiUnknownModelError for unknown Grok variants", () => {
     expect(() =>
       validateXaiRequestPreFlight(
-        plainTextRequest({ model: "grok-4.20-beta-0309-reasoning" }),
+        plainTextRequest({ model: "grok-9.99-flux-capacitor" }),
       ),
     ).toThrow(XaiUnknownModelError);
   });
@@ -315,7 +325,6 @@ describe("validateXaiRequestPreFlight (reject cases)", () => {
       "claude-opus-4",
       "claude-sonnet-3.5",
       "grok-9.99-flux-capacitor",
-      "grok-4.20-beta-0309-reasoning",
     ]) {
       expect(() =>
         validateXaiRequestPreFlight(plainTextRequest({ model: bad })),
@@ -327,7 +336,7 @@ describe("validateXaiRequestPreFlight (reject cases)", () => {
     expect(() =>
       validateXaiRequestPreFlight(
         plainTextRequest({
-          model: "grok-4.20-0309-reasoning",
+          model: "grok-4.20-beta-0309-reasoning",
           reasoning: { effort: "high" },
         }),
       ),
@@ -346,7 +355,7 @@ describe("validateXaiRequestPreFlight (reject cases)", () => {
     expect(() =>
       validateXaiRequestPreFlight(
         plainTextRequest({
-          model: "grok-4.20-0309-reasoning",
+          model: "grok-4.20-beta-0309-reasoning",
           presence_penalty: 0.5,
         }),
       ),
@@ -357,7 +366,7 @@ describe("validateXaiRequestPreFlight (reject cases)", () => {
     expect(() =>
       validateXaiRequestPreFlight(
         plainTextRequest({
-          model: "grok-4.20-multi-agent-0309",
+          model: "grok-4.20-multi-agent-beta-0309",
           frequency_penalty: 1.0,
         }),
       ),
@@ -567,7 +576,7 @@ describe("validateXaiResponsePostFlight (clean cases)", () => {
   it("returns no anomaly when response.model is the documented alias of the requested model", () => {
     const result = validateXaiResponsePostFlight({
       request: { ...plainTextRequest(), model: "grok-4.20-reasoning" },
-      response: responseWith({ model: "grok-4.20-0309-reasoning" }),
+      response: responseWith({ model: "grok-4.20-beta-0309-reasoning" }),
     });
     expect(result).toEqual([]);
   });
@@ -703,7 +712,7 @@ describe("validateXaiResponsePostFlight (model aliasing)", () => {
   it("does NOT flag documented bare-name alias as silent aliasing", () => {
     const result = validateXaiResponsePostFlight({
       request: { ...plainTextRequest(), model: "grok-4.20-reasoning" },
-      response: responseWith({ model: "grok-4.20-0309-reasoning" }),
+      response: responseWith({ model: "grok-4.20-beta-0309-reasoning" }),
     });
     expect(
       result.find((a) => a.code === "model_silently_aliased"),
@@ -1034,11 +1043,11 @@ describe("DOCUMENTED_XAI_RESPONSES_REQUEST_FIELDS", () => {
 // ---------------------------------------------------------------------------
 
 describe("multi-agent specific restrictions", () => {
-  it("rejects max_output_tokens on grok-4.20-multi-agent-0309", () => {
+  it("rejects max_output_tokens on grok-4.20-multi-agent-beta-0309", () => {
     expect(() =>
       validateXaiRequestPreFlight(
         plainTextRequest({
-          model: "grok-4.20-multi-agent-0309",
+          model: "grok-4.20-multi-agent-beta-0309",
           max_output_tokens: 1024,
         }),
       ),
@@ -1060,7 +1069,7 @@ describe("multi-agent specific restrictions", () => {
     expect(() =>
       validateXaiRequestPreFlight(
         plainTextRequest({
-          model: "grok-4.20-multi-agent-0309",
+          model: "grok-4.20-multi-agent-beta-0309",
           tools: [functionTool("system.bash")],
         }),
       ),
@@ -1071,7 +1080,7 @@ describe("multi-agent specific restrictions", () => {
     expect(() =>
       validateXaiRequestPreFlight(
         plainTextRequest({
-          model: "grok-4.20-multi-agent-0309",
+          model: "grok-4.20-multi-agent-beta-0309",
           tools: [{ type: "web_search" }, { type: "x_search" }],
         }),
       ),

--- a/runtime/src/llm/grok/xai-strict-filter.ts
+++ b/runtime/src/llm/grok/xai-strict-filter.ts
@@ -39,9 +39,8 @@
  *      this: tool-followup with empty tools throws
  *      `XaiSilentToolDropError("outgoing_followup_tools_empty")`.
  *
- *   2. Configured model `grok-4.20-beta-0309-reasoning` was silently
- *      aliased server-side because no `-beta` variant exists in the xAI
- *      catalog. Pre-flight rule 1 catches this: throws
+ *   2. Configured model IDs that are not in the current xAI catalog can be
+ *      silently aliased server-side. Pre-flight rule 1 catches this: throws
  *      `XaiUnknownModelError`.
  *
  *   3. Grok returned a response with `reasoning + message` blocks but zero
@@ -154,9 +153,9 @@ const SERVER_SIDE_TOOL_CALL_OUTPUT_TYPES: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Documented xAI model catalog as of 2026-04-09.
+ * xAI model catalog as of 2026-04-11.
  *
- * Source: developers/models page via mcp__xai-docs__get_doc_page.
+ * Source: live daemon /model list response backed by xAI /models.
  *
  * The validator rejects any `model` value that does not appear here OR in
  * {@link DOCUMENTED_XAI_MODEL_ALIASES}. xAI silently aliases unknown model
@@ -165,11 +164,11 @@ const SERVER_SIDE_TOOL_CALL_OUTPUT_TYPES: ReadonlySet<string> = new Set([
  */
 const DOCUMENTED_XAI_MODEL_IDS: ReadonlySet<string> = new Set([
   // Grok 4 family — current
-  "grok-4.20-0309-reasoning",
-  "grok-4.20-0309-non-reasoning",
+  "grok-4.20-beta-0309-reasoning",
+  "grok-4.20-beta-0309-non-reasoning",
   "grok-4-1-fast-reasoning",
   "grok-4-1-fast-non-reasoning",
-  "grok-4.20-multi-agent-0309",
+  "grok-4.20-multi-agent-beta-0309",
   "grok-4-0709",
   // Grok 3 family — still in xAI catalog per release notes (April 2025)
   "grok-3",
@@ -193,20 +192,27 @@ const DOCUMENTED_XAI_MODEL_IDS: ReadonlySet<string> = new Set([
  *   - `<modelname>-<date>` → specific release
  *
  * For each documented model variant, we list the bare-name and `-latest`
- * aliases that resolve to the canonical 0309 release. New releases just
+ * aliases that resolve to the current canonical release. New releases just
  * add new entries to this map.
  */
 const DOCUMENTED_XAI_MODEL_ALIASES: ReadonlyMap<string, string> = new Map([
   // bare names → canonical
-  ["grok-4.20-reasoning", "grok-4.20-0309-reasoning"],
-  ["grok-4.20-non-reasoning", "grok-4.20-0309-non-reasoning"],
-  ["grok-4.20-multi-agent", "grok-4.20-multi-agent-0309"],
+  ["grok-4.20-reasoning", "grok-4.20-beta-0309-reasoning"],
+  ["grok-4.20-non-reasoning", "grok-4.20-beta-0309-non-reasoning"],
+  ["grok-4.20-multi-agent", "grok-4.20-multi-agent-beta-0309"],
   ["grok-4-fast-reasoning", "grok-4-1-fast-reasoning"],
   ["grok-4-fast-non-reasoning", "grok-4-1-fast-non-reasoning"],
   // -latest aliases → canonical
-  ["grok-4.20-reasoning-latest", "grok-4.20-0309-reasoning"],
-  ["grok-4.20-non-reasoning-latest", "grok-4.20-0309-non-reasoning"],
-  ["grok-4.20-multi-agent-latest", "grok-4.20-multi-agent-0309"],
+  ["grok-4.20-reasoning-latest", "grok-4.20-beta-0309-reasoning"],
+  ["grok-4.20-non-reasoning-latest", "grok-4.20-beta-0309-non-reasoning"],
+  ["grok-4.20-multi-agent-latest", "grok-4.20-multi-agent-beta-0309"],
+  ["grok-4.20-beta-latest-reasoning", "grok-4.20-beta-0309-reasoning"],
+  ["grok-4.20-beta-latest-non-reasoning", "grok-4.20-beta-0309-non-reasoning"],
+  ["grok-4.20-multi-agent-beta-latest", "grok-4.20-multi-agent-beta-0309"],
+  // Previous non-beta spelling seen in local autocomplete before xAI exposed beta IDs.
+  ["grok-4.20-0309-reasoning", "grok-4.20-beta-0309-reasoning"],
+  ["grok-4.20-0309-non-reasoning", "grok-4.20-beta-0309-non-reasoning"],
+  ["grok-4.20-multi-agent-0309", "grok-4.20-multi-agent-beta-0309"],
   ["grok-4-1-fast-reasoning-latest", "grok-4-1-fast-reasoning"],
   ["grok-4-1-fast-non-reasoning-latest", "grok-4-1-fast-non-reasoning"],
 ]);
@@ -246,7 +252,7 @@ export function modelSupportsFunctionCalling(canonicalModel: string): boolean {
  * automatically and **return an error** if `reasoning.effort` is sent.
  */
 export function modelSupportsReasoningEffort(canonicalModel: string): boolean {
-  return canonicalModel === "grok-4.20-multi-agent-0309";
+  return canonicalModel === "grok-4.20-multi-agent-beta-0309";
 }
 
 /**
@@ -290,11 +296,8 @@ export function modelIsMultiAgent(canonicalModel: string): boolean {
  * Thrown when the configured `model` is not in the documented xAI catalog.
  *
  * xAI silently aliases unknown model IDs server-side, which produces
- * unverifiable behavior. This is the failure mode that hit
- * `grok-4.20-beta-0309-reasoning` on 2026-04-09 — there is no `-beta`
- * variant in the catalog and no documented alias rule that produces it,
- * but xAI returned 200 anyway with `model: "grok-4.20-0309-reasoning"`
- * in the response payload.
+ * unverifiable behavior. This catches stale or mistyped model IDs before
+ * sending them to the provider.
  *
  * Maps to `failureClass: "provider_error"` via the existing
  * `classifyLLMFailure()` instanceof branch on `LLMProviderError`. Gets
@@ -312,7 +315,7 @@ export class XaiUnknownModelError extends LLMProviderError {
         `catalog (developers/models). xAI silently aliases unknown model IDs, ` +
         `which produces unverifiable behavior. Set llm.model in config.json to ` +
         `one of the documented IDs (e.g. "grok-4-1-fast-non-reasoning", ` +
-        `"grok-4.20-0309-reasoning", "grok-4.20-multi-agent-0309").`,
+        `"grok-4.20-beta-0309-reasoning", "grok-4.20-multi-agent-beta-0309").`,
       400,
     );
     this.name = "XaiUnknownModelError";
@@ -412,7 +415,7 @@ export class XaiSilentToolDropError extends LLMProviderError {
  *
  *   1. Undocumented or empty `model`.
  *   2. `reasoning` field on a model that doesn't accept `reasoning.effort`
- *      (everything except `grok-4.20-multi-agent-0309`).
+ *      (everything except `grok-4.20-multi-agent-beta-0309`).
  *   3. `presence_penalty` / `frequency_penalty` / `stop` on a reasoning
  *      variant.
  *   4. Any top-level field not in
@@ -442,7 +445,7 @@ export function validateXaiRequestPreFlight(
   if ("reasoning" in params && !modelSupportsReasoningEffort(canonicalModel)) {
     throw new XaiUndocumentedFieldError(
       "reasoning",
-      `is only supported on grok-4.20-multi-agent-0309 (where it controls ` +
+      `is only supported on grok-4.20-multi-agent-beta-0309 (where it controls ` +
         `agent count); current model is ${canonicalModel}, which reasons ` +
         `automatically and returns an error if reasoning.effort is sent`,
     );

--- a/runtime/src/onboarding/xai-validation.js
+++ b/runtime/src/onboarding/xai-validation.js
@@ -7,22 +7,26 @@ const LEGACY_GROK_MODEL_ALIASES = Object.freeze({
   "grok-4-fast-reasoning": "grok-4-1-fast-reasoning",
   "grok-4-fast-non-reasoning": "grok-4-1-fast-non-reasoning",
   "grok-4.20-experimental-beta-0304-reasoning":
-    "grok-4.20-0309-reasoning",
+    "grok-4.20-beta-0309-reasoning",
   "grok-4.20-experimental-beta-0304-non-reasoning":
-    "grok-4.20-0309-non-reasoning",
+    "grok-4.20-beta-0309-non-reasoning",
   "grok-4.20-multi-agent-experimental-beta-0304":
-    "grok-4.20-multi-agent-0309",
-  "grok-4.20-beta-0309-reasoning": "grok-4.20-0309-reasoning",
-  "grok-4.20-beta-0309-non-reasoning": "grok-4.20-0309-non-reasoning",
-  "grok-4.20-multi-agent-beta-0309": "grok-4.20-multi-agent-0309",
-  "grok-4.20-beta-latest-reasoning": "grok-4.20-0309-reasoning",
-  "grok-4.20-beta-latest-non-reasoning": "grok-4.20-0309-non-reasoning",
+    "grok-4.20-multi-agent-beta-0309",
+  "grok-4.20-0309-reasoning": "grok-4.20-beta-0309-reasoning",
+  "grok-4.20-0309-non-reasoning": "grok-4.20-beta-0309-non-reasoning",
+  "grok-4.20-multi-agent-0309": "grok-4.20-multi-agent-beta-0309",
+  "grok-4.20-reasoning": "grok-4.20-beta-0309-reasoning",
+  "grok-4.20-non-reasoning": "grok-4.20-beta-0309-non-reasoning",
+  "grok-4.20-multi-agent": "grok-4.20-multi-agent-beta-0309",
+  "grok-4.20-beta-latest-reasoning": "grok-4.20-beta-0309-reasoning",
+  "grok-4.20-beta-latest-non-reasoning": "grok-4.20-beta-0309-non-reasoning",
+  "grok-4.20-multi-agent-beta-latest": "grok-4.20-multi-agent-beta-0309",
 });
 
 const KNOWN_GROK_CHAT_MODELS = new Set([
-  "grok-4.20-multi-agent-0309",
-  "grok-4.20-0309-reasoning",
-  "grok-4.20-0309-non-reasoning",
+  "grok-4.20-multi-agent-beta-0309",
+  "grok-4.20-beta-0309-reasoning",
+  "grok-4.20-beta-0309-non-reasoning",
   "grok-4-1-fast-reasoning",
   "grok-4-1-fast-non-reasoning",
   "grok-4-fast-reasoning",

--- a/runtime/src/watch/agenc-watch-helpers.mjs
+++ b/runtime/src/watch/agenc-watch-helpers.mjs
@@ -5,9 +5,9 @@ export const DEFAULT_INPUT_BATCH_DELAY_MS = 45;
  * Kept in sync with runtime/src/gateway/context-window.ts KNOWN_GROK_MODEL_IDS.
  */
 export const KNOWN_CHAT_MODELS = Object.freeze([
-  "grok-4.20-multi-agent-0309",
-  "grok-4.20-0309-reasoning",
-  "grok-4.20-0309-non-reasoning",
+  "grok-4.20-multi-agent-beta-0309",
+  "grok-4.20-beta-0309-reasoning",
+  "grok-4.20-beta-0309-non-reasoning",
   "grok-4-1-fast-reasoning",
   "grok-4-1-fast-non-reasoning",
   "grok-4-fast-reasoning",
@@ -18,11 +18,18 @@ export const KNOWN_CHAT_MODELS = Object.freeze([
   "grok-3-mini",
 ]);
 
+function modelIdMatchesQuery(id, query) {
+  const haystack = id.toLowerCase();
+  if (haystack.includes(query)) return true;
+  const tokens = query.split(/[\s_]+/).filter(Boolean);
+  return tokens.length > 1 && tokens.every((token) => haystack.includes(token));
+}
+
 export function matchModelNames(query, { limit = 8 } = {}) {
-  const q = (query ?? "").toLowerCase();
+  const q = (query ?? "").trim().toLowerCase();
   if (!q) return KNOWN_CHAT_MODELS.slice(0, limit);
   return KNOWN_CHAT_MODELS
-    .filter((id) => id.toLowerCase().includes(q))
+    .filter((id) => modelIdMatchesQuery(id, q))
     .slice(0, limit);
 }
 

--- a/runtime/tests/watch/agenc-watch-helpers.test.mjs
+++ b/runtime/tests/watch/agenc-watch-helpers.test.mjs
@@ -6,6 +6,7 @@ import {
   buildWatchCommands,
   createOperatorInputBatcher,
   findWatchCommandDefinition,
+  matchModelNames,
   matchWatchCommands,
   parseWatchSlashCommand,
   shouldAutoInspectRun,
@@ -89,6 +90,19 @@ test("matchWatchCommands filters by prefix and aliases", () => {
   assert.equal(findWatchCommandDefinition("/commands")?.name, "/help");
   assert.equal(findWatchCommandDefinition("/copy")?.name, "/export");
   assert.equal(findWatchCommandDefinition("/models")?.name, "/model");
+});
+
+test("matchModelNames suggests current Grok 4.20 beta catalog IDs", () => {
+  assert.deepEqual(matchModelNames("4.20", { limit: 3 }), [
+    "grok-4.20-multi-agent-beta-0309",
+    "grok-4.20-beta-0309-reasoning",
+    "grok-4.20-beta-0309-non-reasoning",
+  ]);
+  assert.deepEqual(matchModelNames("grok 4.20", { limit: 2 }), [
+    "grok-4.20-multi-agent-beta-0309",
+    "grok-4.20-beta-0309-reasoning",
+  ]);
+  assert.deepEqual(matchModelNames("4.20-0309", { limit: 3 }), []);
 });
 
 test("parseWatchSlashCommand resolves canonical command metadata and args", () => {


### PR DESCRIPTION
## Summary
- Align Grok 4.20 model catalogs and aliases with the live beta 0309 IDs returned by `/model list`.
- Make `/model` and watch autocomplete token-match queries like `grok 4.20`.
- Preserve compatibility for stale non-beta `grok-4.20-0309-*` IDs by mapping them to `grok-4.20-beta-0309-*`.

## Root Cause
The console/static autocomplete could resolve `grok 4.20` to stale `grok-4.20-0309-reasoning`, while the daemon's live catalog only accepted the beta 0309 IDs.

## Validation
- `npm run test -- src/gateway/context-window.test.ts src/llm/grok/xai-strict-filter.test.ts src/gateway/daemon-command-registry.test.ts`
- `node --test tests/watch/agenc-watch-helpers.test.mjs`
- `npm run build`
- `git diff --check`
- Restarted daemon from `/Users/tetsuoarena/agenc-core-pr324-clean`, validated PID `70279` and status healthy on port `9101`