### PR TITLE
fix(web): stop stuck thinking after completed turn

### DIFF
--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -4,3 +4,10 @@
 - **What worked:** Replacing heuristic artifact/workflow escalation with a direct-owner artifact contract fixed the route class, stale verification inheritance, conditional no-op semantics, and explicit `@artifact` normalization in one coherent runtime path.
 - **What didn't:** Artifact-intent classifier precedence and workspace-grounding phrase detection were still too narrow at first, which let explicit `@PLAN.md` repair requests drift into grounded-plan-generation or artifact-only review until the classifier and grounding detector were tightened.
 - **Rule added to CLAUDE.md:** no
+
+## PR #327: fix(web): stop stuck thinking after completed turn
+- **Date:** 2026-04-12
+- **Files changed:** `web/src/hooks/useChat.ts`, `web/src/hooks/useChat.test.ts`
+- **What worked:** Moving typing-state ownership back to the top-level chat lifecycle fixed the stuck-thinking race without disturbing delegated timeline rendering, and the regression tests cover both late subagent traffic and terminal `chat.response`.
+- **What didn't:** The UI hook had quietly treated subagent lifecycle events as a second source of truth for run completion, which made the bug look like a runtime/executor issue until the webchat state path was traced end to end.
+- **Rule added to CLAUDE.md:** no

--- a/web/src/hooks/useChat.test.ts
+++ b/web/src/hooks/useChat.test.ts
@@ -353,6 +353,68 @@ describe("useChat session lifecycle", () => {
       sections: [{ id: "memory", label: "Memory", tokens: 800, percent: 31.2 }],
     });
   });
+
+  it("keeps typing cleared when late subagent events arrive after the final chat message", () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useChat({ send, connected: true }));
+
+    act(() => {
+      result.current.handleMessage({
+        type: "chat.typing",
+        payload: { active: true },
+      } as WSMessage);
+    });
+
+    expect(result.current.isTyping).toBe(true);
+
+    act(() => {
+      result.current.handleMessage({
+        type: "chat.message",
+        payload: {
+          content: "Finished the task.",
+          timestamp: 1000,
+        },
+      } as WSMessage);
+    });
+
+    expect(result.current.isTyping).toBe(false);
+
+    act(() => {
+      result.current.handleMessage({
+        type: "subagents.progress",
+        payload: {
+          sessionId: "session-parent",
+          parentSessionId: "session-parent",
+          subagentSessionId: "subagent:child-1",
+          timestamp: 1100,
+          data: { objective: "late event flush" },
+        },
+      } as WSMessage);
+    });
+
+    expect(result.current.isTyping).toBe(false);
+  });
+
+  it("treats chat.response as a terminal typing signal", () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useChat({ send, connected: true }));
+
+    act(() => {
+      result.current.handleMessage({
+        type: "chat.typing",
+        payload: { active: true },
+      } as WSMessage);
+      result.current.handleMessage({
+        type: "chat.response",
+        payload: {
+          completionState: "completed",
+          stopReason: "completed",
+        },
+      } as WSMessage);
+    });
+
+    expect(result.current.isTyping).toBe(false);
+  });
 });
 
 describe("useChat subagent lifecycle timeline", () => {

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -630,16 +630,6 @@ export function useChat({ send, connected }: UseChatOptions): UseChatReturn {
     const subagentEvent = parseSubagentEvent(msg);
     if (subagentEvent) {
       appendSubagentLifecycle(subagentEvent);
-      if (
-        subagentEvent.type === WS_SUBAGENTS_COMPLETED ||
-        subagentEvent.type === WS_SUBAGENTS_FAILED ||
-        subagentEvent.type === WS_SUBAGENTS_CANCELLED ||
-        subagentEvent.type === WS_SUBAGENTS_SYNTHESIZED
-      ) {
-        setIsTyping(false);
-      } else {
-        setIsTyping(true);
-      }
       return;
     }
 
@@ -681,6 +671,16 @@ export function useChat({ send, connected }: UseChatOptions): UseChatReturn {
       case WS_CHAT_TYPING: {
         const payload = (msg.payload ?? msg) as Record<string, unknown>;
         setIsTyping(!!payload.active);
+        break;
+      }
+
+      case 'chat.response': {
+        // chat.typing / chat.message are the authoritative top-level run
+        // lifecycle signals. Late subagent lifecycle events can legitimately
+        // arrive after completion, so force the spinner down on the terminal
+        // response envelope instead of letting delegated traffic reopen it.
+        pendingMsgIdRef.current = null;
+        setIsTyping(false);
         break;
       }
 


### PR DESCRIPTION
## Summary
- stop subagent lifecycle events from controlling the top-level typing spinner
- treat `chat.response` as a terminal signal so late delegated lifecycle traffic cannot reopen a completed run
- add regression coverage for late subagent events after the final chat message

## Test plan
- `npm run test --workspace=@tetsuo-ai/web -- src/hooks/useChat.test.ts`
- `npm run typecheck --workspace=@tetsuo-ai/web`