### PR TITLE
support macOS public runtime artifacts

### DIFF
--- a/.github/workflows/package-pack-smoke.yml
+++ b/.github/workflows/package-pack-smoke.yml
@@ -96,6 +96,34 @@ jobs:
       - name: Run public agenc install smoke test
         run: npm run smoke:public-agenc-install -- --skip-build
 
+  public-install-macos-arm64:
+    runs-on: macos-14
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install workspace dependencies
+        run: npm install --no-fund
+
+      - name: Build private-kernel packages
+        run: AGENC_SKIP_DASHBOARD_BUILD=1 npm run build:private-kernel
+
+      - name: Build dashboard surface
+        run: AGENC_DASHBOARD_BASE=/ui/ npm run build --workspace=@tetsuo-ai/web
+
+      - name: Sync dashboard assets
+        run: npm run sync:dashboard-assets
+
+      - name: Run public agenc install smoke test on macOS arm64
+        run: npm run smoke:public-agenc-install -- --skip-build
+
   public-install-min-node:
     runs-on: ubuntu-latest
     permissions:

--- a/docs/architecture/guides/public-runtime-release-channel.md
+++ b/docs/architecture/guides/public-runtime-release-channel.md
@@ -35,29 +35,30 @@ The public runtime artifact channel is:
 
 Release flow:
 
-1. `agenc-core` CI builds the runtime artifact for the supported tuple.
+1. `agenc-core` CI builds runtime artifacts for each supported tuple.
 2. CI builds the dashboard bundle with base `/ui/` and syncs it into
    `runtime/dist/dashboard/`.
-3. CI signs the manifest for that artifact.
-4. CI attaches the artifact to the corresponding GitHub Release.
+3. CI signs the manifest for the complete artifact set.
+4. CI attaches the artifacts to the corresponding GitHub Release.
 5. CI embeds the signed manifest, signature, public key, and trust policy into
    the published `@tetsuo-ai/agenc` wrapper package.
 
 Phase 2 keeps local smoke/rehearsal on `file://` manifests, but the production
 release contract is GitHub Releases.
 
-## Supported tuple
+## Supported tuples
 
 Current public wrapper support is intentionally narrow:
 
-- platform: `linux`
-- arch: `x64`
+- Linux `x64`
+- macOS `arm64` (Apple Silicon)
 - Node: `>=18.0.0`
 
-The current release gate validates that tuple on:
+The current release gate validates:
 
-- Node `18` minimum-floor CI
-- Node `20` mainline CI
+- Linux `x64` on Node `18` minimum-floor CI
+- Linux `x64` on Node `20` mainline CI
+- macOS `arm64` on Node `20` CI
 
 Anything else must fail clearly as unsupported. Broader platform support should
 only be added once release CI and smoke coverage exist for those tuples.

--- a/docs/architecture/guides/public-wrapper-devnet-marketplace-rehearsal.md
+++ b/docs/architecture/guides/public-wrapper-devnet-marketplace-rehearsal.md
@@ -14,20 +14,22 @@ It is intentionally narrower than the full runtime/operator surface:
 `agenc-runtime` still exists as a compatibility alias after the runtime is
 installed, but public release and onboarding docs should use `agenc ...`.
 
-## Supported target
+## Supported targets
 
 Current public wrapper support is intentionally narrow:
 
 - Linux `x64`
+- macOS `arm64` (Apple Silicon)
 - Node `>=18.0.0`
 
-Current release gates validate that tuple on:
+Current release gates validate:
 
-- Node `18` minimum-floor CI
-- Node `20` mainline CI
+- Linux `x64` on Node `18` minimum-floor CI
+- Linux `x64` on Node `20` mainline CI
+- macOS `arm64` on Node `20` CI
 
-Do not present macOS or Windows wrapper install as supported for this rehearsal
-until release CI proves those tuples.
+Do not present Windows or macOS `x64` wrapper install as supported
+for this rehearsal until release CI proves those tuples.
 
 ## Manual prerequisites
 
@@ -134,7 +136,7 @@ Use a second signer when the rehearsal specifically needs to prove:
 
 This guide does not claim support for:
 
-- macOS or Windows public wrapper install
+- Windows or macOS `x64` public wrapper install
 - private task or `constraintHash` flows
 - dispute resolution from the public wrapper using creator/worker keys
 - source-checkout-only commands as part of the public release path

--- a/docs/architecture/guides/runtime-install-matrix.md
+++ b/docs/architecture/guides/runtime-install-matrix.md
@@ -77,19 +77,18 @@ Evidence in the current repo:
 
 ### macOS
 
-Status: source/runtime development is plausible, but the public
-`@tetsuo-ai/agenc` wrapper install path is **not yet** claimed as supported.
+Status: supported for local CLI/daemon operation and for the public
+`@tetsuo-ai/agenc` wrapper install path on Apple Silicon `arm64`.
 
 Evidence in the current repo:
 
 - service install flow emits `launchd` plists
 - operator/runtime paths support standard macOS home-directory layout
+- package smoke validates the public wrapper install path on macOS `arm64` CI
 
-Why it is not yet claimed publicly:
+Still not claimed publicly:
 
-- the public wrapper/runtime artifact flow is not validated on macOS release CI
-- Phase 2 intentionally avoids overclaiming support beyond the tested release
-  tuple
+- macOS `x64` / Intel wrapper install artifacts
 
 ### Windows
 

--- a/packages/agenc/lib/runtime-manager.js
+++ b/packages/agenc/lib/runtime-manager.js
@@ -27,7 +27,7 @@ const GENERATED_PUBLIC_KEY_BASENAME = "agenc-runtime-public-key.pem";
 const GENERATED_TRUST_POLICY_BASENAME = "agenc-runtime-trust-policy.json";
 const DEFAULT_LOCK_TIMEOUT_MS = 30_000;
 const LOCK_POLL_INTERVAL_MS = 100;
-const SUPPORTED_PLATFORM_ARCH = new Set(["linux-x64"]);
+const SUPPORTED_PLATFORM_ARCH = new Set(["darwin-arm64", "linux-x64"]);
 
 export class RuntimeInstallError extends Error {
   constructor(message, code = "runtime_install_error") {

--- a/packages/agenc/tests/runtime-manager.test.mjs
+++ b/packages/agenc/tests/runtime-manager.test.mjs
@@ -44,7 +44,7 @@ async function createFixtureContext(t) {
   return {
     packageRoot,
     homeDir,
-    async stageEmbeddedRelease(runtimeVersion) {
+    async stageEmbeddedRelease(runtimeVersion, artifactTargets = [{ platform: "linux", arch: "x64" }]) {
       const artifactStageDir = path.join(root, `artifact-stage-${runtimeVersion}`);
       const runtimeBinDir = path.join(
         artifactStageDir,
@@ -70,37 +70,42 @@ async function createFixtureContext(t) {
         });
       }
 
-      const artifactPath = path.join(
-        root,
-        `agenc-runtime-${runtimeVersion}-linux-x64.tar.gz`,
-      );
-      execFileSync("tar", ["-czf", artifactPath, "-C", artifactStageDir, "."], {
-        stdio: ["ignore", "pipe", "pipe"],
-      });
-      const artifactSha = sha256(await readFile(artifactPath));
+      const artifacts = [];
+      const artifactPaths = [];
+      for (const { platform, arch } of artifactTargets) {
+        const platformArch = `${platform}-${arch}`;
+        const artifactPath = path.join(
+          root,
+          `agenc-runtime-${runtimeVersion}-${platformArch}.tar.gz`,
+        );
+        execFileSync("tar", ["-czf", artifactPath, "-C", artifactStageDir, "."], {
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        const artifactSha = sha256(await readFile(artifactPath));
+        artifactPaths.push(artifactPath);
+        artifacts.push({
+          platform,
+          arch,
+          nodeRange: ">=18.0.0",
+          runtimeVersion,
+          url: pathToFileURL(artifactPath).href,
+          sha256: artifactSha,
+          bins: {
+            agenc: "node_modules/@tetsuo-ai/runtime/dist/bin/agenc.js",
+            "agenc-runtime":
+              "node_modules/@tetsuo-ai/runtime/dist/bin/agenc-runtime.js",
+            daemon: "node_modules/@tetsuo-ai/runtime/dist/bin/daemon.js",
+            "agenc-watch":
+              "node_modules/@tetsuo-ai/runtime/dist/bin/agenc-watch.js",
+          },
+        });
+      }
 
       const manifest = {
         manifestVersion: 1,
         wrapperVersion: "0.1.0",
         keyId: "local-dev",
-        artifacts: [
-          {
-            platform: "linux",
-            arch: "x64",
-            nodeRange: ">=18.0.0",
-            runtimeVersion,
-            url: pathToFileURL(artifactPath).href,
-            sha256: artifactSha,
-            bins: {
-              agenc: "node_modules/@tetsuo-ai/runtime/dist/bin/agenc.js",
-              "agenc-runtime":
-                "node_modules/@tetsuo-ai/runtime/dist/bin/agenc-runtime.js",
-              daemon: "node_modules/@tetsuo-ai/runtime/dist/bin/daemon.js",
-              "agenc-watch":
-                "node_modules/@tetsuo-ai/runtime/dist/bin/agenc-watch.js",
-            },
-          },
-        ],
+        artifacts,
       };
       const manifestBytes = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
       const signature = sign(null, manifestBytes, privateKey).toString("base64");
@@ -129,7 +134,7 @@ async function createFixtureContext(t) {
         "utf8",
       );
 
-      return { artifactPath, runtimeVersion };
+      return { artifactPath: artifactPaths[0], artifactPaths, runtimeVersion };
     },
   };
 }
@@ -169,6 +174,29 @@ test("ensureRuntimeInstalled installs the runtime artifact under ~/.agenc/runtim
     installed.releaseDir,
   );
   assert.ok(installed.bins.agenc.startsWith(installed.currentDir));
+});
+
+test("ensureRuntimeInstalled selects darwin-arm64 from a multi-artifact manifest", async (t) => {
+  const fixture = await createFixtureContext(t);
+  await fixture.stageEmbeddedRelease("0.1.0", [
+    { platform: "linux", arch: "x64" },
+    { platform: "darwin", arch: "arm64" },
+  ]);
+
+  const installed = await ensureRuntimeInstalled({
+    packageRoot: fixture.packageRoot,
+    homeDir: fixture.homeDir,
+    platform: "darwin",
+    arch: "arm64",
+    nodeVersion: "20.0.0",
+  });
+
+  await stat(installed.bins.agenc);
+  await stat(installed.bins["agenc-runtime"]);
+  assert.equal(installed.selectedArtifact.platform, "darwin");
+  assert.equal(installed.selectedArtifact.arch, "arm64");
+  assert.match(installed.releaseDir, /releases\/0\.1\.0\/darwin-arm64$/u);
+  assert.equal(await readlink(installed.currentDir), installed.releaseDir);
 });
 
 test("ensureRuntimeInstalled force=true advances the stable current pointer on upgrade", async (t) => {

--- a/scripts/build-public-runtime-artifacts.mjs
+++ b/scripts/build-public-runtime-artifacts.mjs
@@ -13,7 +13,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const runtimeDir = path.join(repoRoot, "runtime");
 const wrapperDir = path.join(repoRoot, "packages", "agenc");
 const wrapperGeneratedDir = path.join(wrapperDir, "generated");
-const supportedPlatformArch = new Set(["linux-x64"]);
+const supportedPlatformArch = new Set(["darwin-arm64", "linux-x64"]);
 
 function parseArgs(argv) {
   const options = {
@@ -24,6 +24,7 @@ function parseArgs(argv) {
     releaseRepository: "tetsuo-ai/agenc-core",
     releaseTag: null,
     runtimeVersionOverride: null,
+    mergeManifestFiles: [],
     allowMissingBundledExternalPlugins: false,
     skipBuild: false,
   };
@@ -52,6 +53,9 @@ function parseArgs(argv) {
       case "--runtime-version-override":
         options.runtimeVersionOverride = argv[++index];
         break;
+      case "--merge-manifest":
+        options.mergeManifestFiles.push(path.resolve(argv[++index]));
+        break;
       case "--allow-missing-bundled-external-plugins":
         options.allowMissingBundledExternalPlugins = true;
         break;
@@ -76,6 +80,91 @@ function run(command, args, cwd, env = process.env) {
 
 function sha256(buffer) {
   return createHash("sha256").update(buffer).digest("hex");
+}
+
+function toPlatformArch(platform, arch) {
+  return `${platform}-${arch}`;
+}
+
+const requiredRuntimeBins = ["agenc", "agenc-runtime", "daemon", "agenc-watch"];
+
+function validateArtifactEntry(artifact, source, { runtimeVersion }) {
+  if (typeof artifact !== "object" || artifact === null || Array.isArray(artifact)) {
+    throw new Error(`[public-runtime] artifact from ${source} must be an object`);
+  }
+
+  const platform = typeof artifact.platform === "string" ? artifact.platform.trim() : "";
+  const arch = typeof artifact.arch === "string" ? artifact.arch.trim() : "";
+  const platformArch = toPlatformArch(platform, arch);
+  if (!supportedPlatformArch.has(platformArch)) {
+    throw new Error(
+      `[public-runtime] artifact from ${source} targets unsupported tuple ${platformArch}; supported public runtime artifact targets: ${Array.from(supportedPlatformArch).sort().join(", ")}`,
+    );
+  }
+
+  if (artifact.runtimeVersion !== runtimeVersion) {
+    throw new Error(
+      `[public-runtime] artifact ${platformArch} from ${source} has runtimeVersion ${artifact.runtimeVersion}; expected ${runtimeVersion}`,
+    );
+  }
+
+  const url = typeof artifact.url === "string" ? artifact.url.trim() : "";
+  const sha256Digest = typeof artifact.sha256 === "string" ? artifact.sha256.trim() : "";
+  if (!url || !sha256Digest) {
+    throw new Error(`[public-runtime] artifact ${platformArch} from ${source} must declare url and sha256`);
+  }
+
+  if (typeof artifact.bins !== "object" || artifact.bins === null || Array.isArray(artifact.bins)) {
+    throw new Error(`[public-runtime] artifact ${platformArch} from ${source} must declare bins`);
+  }
+  for (const binName of requiredRuntimeBins) {
+    if (typeof artifact.bins[binName] !== "string" || artifact.bins[binName].length === 0) {
+      throw new Error(`[public-runtime] artifact ${platformArch} from ${source} must declare bins.${binName}`);
+    }
+  }
+
+  return {
+    platform,
+    arch,
+    nodeRange: artifact.nodeRange ?? ">=18.0.0",
+    runtimeVersion: artifact.runtimeVersion,
+    url,
+    sha256: sha256Digest,
+    bins: Object.fromEntries(requiredRuntimeBins.map((binName) => [binName, artifact.bins[binName]])),
+  };
+}
+
+async function readMergedManifestArtifacts(options, { runtimeVersion, wrapperVersion }) {
+  const artifacts = [];
+  for (const manifestPath of options.mergeManifestFiles) {
+    const manifest = await readJson(manifestPath);
+    if (manifest.wrapperVersion !== wrapperVersion) {
+      throw new Error(
+        `[public-runtime] merge manifest ${manifestPath} has wrapperVersion ${manifest.wrapperVersion}; expected ${wrapperVersion}`,
+      );
+    }
+    if (!Array.isArray(manifest.artifacts)) {
+      throw new Error(`[public-runtime] merge manifest ${manifestPath} must declare artifacts`);
+    }
+    for (const artifact of manifest.artifacts) {
+      artifacts.push(
+        validateArtifactEntry(artifact, manifestPath, { runtimeVersion }),
+      );
+    }
+  }
+  return artifacts;
+}
+
+function mergeArtifactEntries(artifacts) {
+  const merged = new Map();
+  for (const artifact of artifacts) {
+    merged.set(toPlatformArch(artifact.platform, artifact.arch), artifact);
+  }
+  return [...merged.values()].sort((left, right) =>
+    toPlatformArch(left.platform, left.arch).localeCompare(
+      toPlatformArch(right.platform, right.arch),
+    ),
+  );
 }
 
 async function readJson(filePath) {
@@ -230,7 +319,7 @@ async function main() {
     options.runtimeVersionOverride ?? runtimePackage.version;
   const platform = process.platform;
   const arch = process.arch;
-  const platformArch = `${platform}-${arch}`;
+  const platformArch = toPlatformArch(platform, arch);
 
   if (!supportedPlatformArch.has(platformArch)) {
     throw new Error(
@@ -371,6 +460,23 @@ async function main() {
       : pathToFileURL(artifactPath).href;
 
     const keys = await buildKeys(options);
+    const currentArtifact = {
+      platform,
+      arch,
+      nodeRange: runtimePackage.engines?.node ?? ">=18.0.0",
+      runtimeVersion,
+      url: artifactUrl,
+      sha256: artifactSha,
+      bins: metadata.bins,
+    };
+    const mergedArtifacts = mergeArtifactEntries([
+      ...(await readMergedManifestArtifacts(options, {
+        runtimeVersion,
+        wrapperVersion: wrapperPackage.version,
+      })),
+      currentArtifact,
+    ]);
+
     const manifest = {
       manifestVersion: 1,
       wrapperVersion: wrapperPackage.version,
@@ -379,17 +485,7 @@ async function main() {
       releaseChannel: options.artifactBaseUrl ? "github-releases" : "local-dev",
       releaseRepository: options.releaseRepository,
       releaseTag: options.releaseTag ?? `agenc-v${wrapperPackage.version}`,
-      artifacts: [
-        {
-          platform,
-          arch,
-          nodeRange: runtimePackage.engines?.node ?? ">=18.0.0",
-          runtimeVersion,
-          url: artifactUrl,
-          sha256: artifactSha,
-          bins: metadata.bins,
-        },
-      ],
+      artifacts: mergedArtifacts,
     };
     const manifestBytes = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
     const signature = sign(null, manifestBytes, keys.privateKeyPem).toString("base64");
@@ -453,6 +549,14 @@ async function main() {
           wrapperVersion: wrapperPackage.version,
           artifactSha256: artifactSha,
           artifactUrl,
+          artifactCount: manifest.artifacts.length,
+          artifacts: manifest.artifacts.map((artifact) => ({
+            platform: artifact.platform,
+            arch: artifact.arch,
+            runtimeVersion: artifact.runtimeVersion,
+            url: artifact.url,
+            sha256: artifact.sha256,
+          })),
           bundledExternalPlugins: bundledExternalPlugins.map((plugin) => ({
             name: plugin.name,
             version: plugin.version,

--- a/scripts/public-agenc-install-smoke.mjs
+++ b/scripts/public-agenc-install-smoke.mjs
@@ -173,6 +173,9 @@ async function main() {
   );
   const initialRuntimeVersion = runtimePackage.version;
   const upgradedRuntimeVersion = bumpPatchVersion(initialRuntimeVersion);
+  const expectedPlatform = process.platform;
+  const expectedArch = process.arch;
+  const expectedPlatformArch = expectedPlatform + "-" + expectedArch;
 
   try {
     if (!options.skipBuild) {
@@ -235,8 +238,8 @@ async function main() {
     assert.equal(wherePayload.installed, true);
     assert.equal(typeof wherePayload.releaseDir, "string");
     assert.equal(typeof wherePayload.currentDir, "string");
-    assert.equal(wherePayload.selectedArtifact?.platform, "linux");
-    assert.equal(wherePayload.selectedArtifact?.arch, "x64");
+    assert.equal(wherePayload.selectedArtifact?.platform, expectedPlatform);
+    assert.equal(wherePayload.selectedArtifact?.arch, expectedArch);
     assert.equal(wherePayload.selectedArtifact?.runtimeVersion, initialRuntimeVersion);
     assert.equal(wherePayload.trustPolicy?.releaseChannel, "local-dev");
 
@@ -307,7 +310,7 @@ async function main() {
     assert.notEqual(upgradedWherePayload.releaseDir, currentSymlinkTargetV1);
     assert.match(
       upgradedWherePayload.releaseDir,
-      new RegExp(`releases/${upgradedRuntimeVersion.replace(/\./gu, "\\.")}/linux-x64$`, "u"),
+      new RegExp("releases/" + upgradedRuntimeVersion.replace(/\./gu, "\\.") + "/" + expectedPlatformArch + "$", "u"),
     );
     const upgradedCurrentDirStat = await lstat(upgradedWherePayload.currentDir);
     assert.equal(upgradedCurrentDirStat.isSymbolicLink(), true);


### PR DESCRIPTION
## Summary

Adds macOS Apple Silicon (`darwin-arm64`) support to the public runtime artifact path and keeps Linux x64 support intact.

- Allows the wrapper/runtime installer to select `darwin-arm64` artifacts from multi-artifact manifests.
- Adds manifest merge support to the public runtime artifact builder so per-platform artifacts can be combined into one signed manifest.
- Makes the public install smoke test host-platform aware.
- Adds a macOS 14 arm64 GitHub Actions smoke job and updates support docs to reflect Linux x64 plus macOS arm64.

## Validation

- `node --check scripts/build-public-runtime-artifacts.mjs`
- `node --check scripts/public-agenc-install-smoke.mjs`
- `node --check packages/agenc/tests/runtime-manager.test.mjs`
- `git diff --check`
- `npm run test --workspace=packages/agenc`
- `npm run smoke:public-agenc-install` on local macOS `darwin-arm64`, completed with `smoke-ok`.

## Notes

This still does not claim support for Windows or macOS x64/Intel public wrapper runtime artifacts.
