### PR TITLE
fix devnet task tool argument repair

### DIFF
--- a/runtime/src/llm/chat-executor-tool-utils.test.ts
+++ b/runtime/src/llm/chat-executor-tool-utils.test.ts
@@ -203,6 +203,56 @@ describe("chat-executor-tool-utils", () => {
       });
       expect(repaired.repairedFields).toEqual(["constraintHash", "taskId"]);
     });
+
+    it("normalizes human-friendly agenc.createTask arguments from model output", () => {
+      const repaired = repairToolCallArgumentsFromMessageText(
+        "agenc.createTask",
+        {
+          fullDescription: "Write one fun fact about Solana devnet.",
+          reward: "0.01",
+          requiredCapabilities: '["INFERENCE"]',
+          taskId: "random-tech-fact-001",
+          rewardMint: "So11111111111111111111111111111111111111112",
+        },
+        "create a random task",
+      );
+
+      expect(repaired.args).toEqual({
+        description: "Write one fun fact about Solana devnet.",
+        fullDescription: "Write one fun fact about Solana devnet.",
+        reward: "10000000",
+        requiredCapabilities: "2",
+      });
+      expect(repaired.repairedFields).toEqual([
+        "taskId",
+        "rewardMint",
+        "description",
+        "reward",
+        "requiredCapabilities",
+      ]);
+    });
+
+    it("falls back to COMPUTE for tag-like agenc.createTask capabilities", () => {
+      const repaired = repairToolCallArgumentsFromMessageText(
+        "agenc.createTask",
+        {
+          description: "Random joke task",
+          reward: "1 SOL",
+          requiredCapabilities: "meme, relationship, humor",
+        },
+        "create a random task",
+      );
+
+      expect(repaired.args).toEqual({
+        description: "Random joke task",
+        reward: "1000000000",
+        requiredCapabilities: "1",
+      });
+      expect(repaired.repairedFields).toEqual([
+        "reward",
+        "requiredCapabilities",
+      ]);
+    });
   });
 
   describe("summarizeToolArgumentChanges", () => {

--- a/runtime/src/llm/chat-executor-tool-utils.ts
+++ b/runtime/src/llm/chat-executor-tool-utils.ts
@@ -563,6 +563,22 @@ const AGENC_CREATE_TASK_OMITTABLE_REPAIR_FIELD_ALIASES: Record<
   rewardMint: ["rewardMint", "reward_mint"],
   taskId: ["taskId", "task_id"],
 };
+const AGENC_CREATE_TASK_DESCRIPTION_BYTES = 64;
+const AGENC_CREATE_TASK_LAMPORTS_PER_SOL = 1_000_000_000n;
+const AGENC_CREATE_TASK_WRAPPED_SOL_MINT =
+  "So11111111111111111111111111111111111111112";
+const AGENC_CREATE_TASK_CAPABILITY_BITS: Record<string, bigint> = {
+  COMPUTE: 1n << 0n,
+  INFERENCE: 1n << 1n,
+  STORAGE: 1n << 2n,
+  NETWORK: 1n << 3n,
+  SENSOR: 1n << 4n,
+  ACTUATOR: 1n << 5n,
+  COORDINATOR: 1n << 6n,
+  ARBITER: 1n << 7n,
+  VALIDATOR: 1n << 8n,
+  AGGREGATOR: 1n << 9n,
+};
 
 function escapeToolArgumentRegexLiteral(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -584,6 +600,176 @@ function messageForbidsAgencCreateTaskArgument(
   return false;
 }
 
+function setRepairedAgencCreateTaskField(
+  args: Record<string, unknown>,
+  nextArgs: Record<string, unknown>,
+  field: string,
+  value: unknown,
+  repairedFields: string[],
+): Record<string, unknown> {
+  const output = nextArgs === args ? { ...args } : nextArgs;
+  output[field] = value;
+  repairedFields.push(field);
+  return output;
+}
+
+function deleteRepairedAgencCreateTaskField(
+  args: Record<string, unknown>,
+  nextArgs: Record<string, unknown>,
+  field: string,
+  repairedFields: string[],
+): Record<string, unknown> {
+  const output = nextArgs === args ? { ...args } : nextArgs;
+  delete output[field];
+  repairedFields.push(field);
+  return output;
+}
+
+function normalizeAgencCreateTaskText(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function hasAgencCreateTaskNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function truncateAgencCreateTaskUtf8(value: string, maxBytes: number): string {
+  const normalized = normalizeAgencCreateTaskText(value);
+  if (new TextEncoder().encode(normalized).length <= maxBytes) {
+    return normalized;
+  }
+
+  let output = "";
+  const encoder = new TextEncoder();
+  for (const char of normalized) {
+    const candidate = output + char;
+    if (encoder.encode(candidate).length > maxBytes) break;
+    output = candidate;
+  }
+  return output.trim();
+}
+
+function readAgencCreateTaskJobSpecField(
+  value: unknown,
+  fields: readonly string[],
+): string | null {
+  if (typeof value === "string") {
+    try {
+      return readAgencCreateTaskJobSpecField(JSON.parse(value) as unknown, fields);
+    } catch {
+      return value.trim().length > 0 ? value : null;
+    }
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  for (const field of fields) {
+    const fieldValue = record[field];
+    if (hasAgencCreateTaskNonEmptyString(fieldValue)) {
+      return fieldValue;
+    }
+  }
+  return null;
+}
+
+function recoverAgencCreateTaskDescription(
+  args: Record<string, unknown>,
+): string | null {
+  const candidates = [
+    args.title,
+    args.summary,
+    readAgencCreateTaskJobSpecField(args.jobSpec, [
+      "title",
+      "summary",
+      "description",
+      "fullDescription",
+    ]),
+    args.fullDescription,
+  ];
+
+  for (const candidate of candidates) {
+    if (hasAgencCreateTaskNonEmptyString(candidate)) {
+      return truncateAgencCreateTaskUtf8(
+        candidate,
+        AGENC_CREATE_TASK_DESCRIPTION_BYTES,
+      );
+    }
+  }
+  return null;
+}
+
+function isValidAgencCreateTaskHexBytes(value: unknown, bytes: number): boolean {
+  return (
+    typeof value === "string" &&
+    new RegExp(`^[0-9a-fA-F]{${bytes * 2}}$`).test(value.trim())
+  );
+}
+
+function decimalSolToLamports(value: string): string | null {
+  const normalized = value.trim().toLowerCase();
+  const match = /^(\d+)(?:\.(\d{1,9}))?\s*(sol)?$/.exec(normalized);
+  if (!match) return null;
+  const [, whole, fraction = "", suffix] = match;
+  if (!suffix && !normalized.includes(".")) return null;
+  const paddedFraction = fraction.padEnd(9, "0");
+  return (
+    BigInt(whole) * AGENC_CREATE_TASK_LAMPORTS_PER_SOL +
+    BigInt(paddedFraction || "0")
+  ).toString();
+}
+
+function recoverAgencCreateTaskReward(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  return decimalSolToLamports(value);
+}
+
+function collectAgencCreateTaskCapabilityNames(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => collectAgencCreateTaskCapabilityNames(item));
+  }
+  if (typeof value !== "string") return [];
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return [];
+  if (/^\d+$/.test(trimmed)) return [];
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (parsed !== value) {
+      const parsedNames = collectAgencCreateTaskCapabilityNames(parsed);
+      if (parsedNames.length > 0) return parsedNames;
+    }
+  } catch {
+    // Treat non-JSON strings as human-friendly capability labels below.
+  }
+
+  return trimmed
+    .split(/[^A-Za-z0-9]+/g)
+    .map((part) => part.trim().toUpperCase())
+    .filter(Boolean);
+}
+
+function recoverAgencCreateTaskRequiredCapabilities(value: unknown): string | null {
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) {
+    return null;
+  }
+  if (typeof value === "string" && /^\d+$/.test(value.trim())) return null;
+
+  const names = collectAgencCreateTaskCapabilityNames(value);
+  if (names.length === 0) return null;
+
+  let bitmask = 0n;
+  for (const name of names) {
+    bitmask |= AGENC_CREATE_TASK_CAPABILITY_BITS[name] ?? 0n;
+  }
+
+  // Unknown labels like "smoke-test" are usually task tags, not capabilities.
+  // Fall back to COMPUTE so the random task remains createable.
+  return (bitmask || AGENC_CREATE_TASK_CAPABILITY_BITS.COMPUTE).toString();
+}
+
 function repairAgencCreateTaskArgumentsFromMessageText(
   args: Record<string, unknown>,
   messageText: string,
@@ -601,6 +787,95 @@ function repairAgencCreateTaskArgumentsFromMessageText(
       delete nextArgs[field];
       repairedFields.push(field);
     }
+  }
+
+  if (
+    "taskId" in nextArgs &&
+    !isValidAgencCreateTaskHexBytes(nextArgs.taskId, 32)
+  ) {
+    nextArgs = deleteRepairedAgencCreateTaskField(
+      args,
+      nextArgs,
+      "taskId",
+      repairedFields,
+    );
+  }
+
+  if (
+    "constraintHash" in nextArgs &&
+    !isValidAgencCreateTaskHexBytes(nextArgs.constraintHash, 32)
+  ) {
+    nextArgs = deleteRepairedAgencCreateTaskField(
+      args,
+      nextArgs,
+      "constraintHash",
+      repairedFields,
+    );
+  }
+
+  if (
+    typeof nextArgs.rewardMint === "string" &&
+    ["SOL", AGENC_CREATE_TASK_WRAPPED_SOL_MINT].includes(
+      nextArgs.rewardMint.trim(),
+    )
+  ) {
+    nextArgs = deleteRepairedAgencCreateTaskField(
+      args,
+      nextArgs,
+      "rewardMint",
+      repairedFields,
+    );
+  }
+
+  if (!hasAgencCreateTaskNonEmptyString(nextArgs.description)) {
+    const description = recoverAgencCreateTaskDescription(nextArgs);
+    if (description) {
+      nextArgs = setRepairedAgencCreateTaskField(
+        args,
+        nextArgs,
+        "description",
+        description,
+        repairedFields,
+      );
+    }
+  } else {
+    const truncatedDescription = truncateAgencCreateTaskUtf8(
+      nextArgs.description,
+      AGENC_CREATE_TASK_DESCRIPTION_BYTES,
+    );
+    if (truncatedDescription !== nextArgs.description) {
+      nextArgs = setRepairedAgencCreateTaskField(
+        args,
+        nextArgs,
+        "description",
+        truncatedDescription,
+        repairedFields,
+      );
+    }
+  }
+
+  const reward = recoverAgencCreateTaskReward(nextArgs.reward);
+  if (reward) {
+    nextArgs = setRepairedAgencCreateTaskField(
+      args,
+      nextArgs,
+      "reward",
+      reward,
+      repairedFields,
+    );
+  }
+
+  const requiredCapabilities = recoverAgencCreateTaskRequiredCapabilities(
+    nextArgs.requiredCapabilities,
+  );
+  if (requiredCapabilities) {
+    nextArgs = setRepairedAgencCreateTaskField(
+      args,
+      nextArgs,
+      "requiredCapabilities",
+      requiredCapabilities,
+      repairedFields,
+    );
   }
 
   return { args: nextArgs, repairedFields };

--- a/runtime/src/tools/agenc/tools.ts
+++ b/runtime/src/tools/agenc/tools.ts
@@ -462,12 +462,25 @@ async function resolveCreatorAgentPda(
   creator: PublicKey,
   providedCreatorAgentPda?: unknown,
 ): Promise<[PublicKey | null, ToolResult | null]> {
+  const matches = await findSignerAgentChoices(program, creator);
+
   if (!isOptionalPlaceholder(providedCreatorAgentPda)) {
     const [pda, err] = parseBase58(providedCreatorAgentPda);
-    return [pda, err];
-  }
+    if (pda && matches.some((match) => match.agentPda === pda.toBase58())) {
+      return [pda, null];
+    }
 
-  const matches = await findSignerAgentChoices(program, creator);
+    if (matches.length === 1) {
+      return [new PublicKey(matches[0]!.agentPda), null];
+    }
+
+    if (matches.length > 1) {
+      return [null, ambiguousSignerAgentsResult(creator, matches)];
+    }
+
+    if (err) return [null, err];
+    return [null, errorResult('creatorAgentPda is not registered for signer wallet. Run `agenc-runtime agent register --rpc <url>` first, or provide one of this signer wallet\'s agent PDA values.')];
+  }
 
   if (matches.length === 0) {
     return [null, errorResult('No agent registration found for signer wallet. Run `agenc-runtime agent register --rpc <url>` first, or provide creatorAgentPda.')];


### PR DESCRIPTION
## Summary

Fixes the `agenc.createTask` tool path so agent-created devnet tasks survive common model-friendly argument shapes instead of failing strict on-chain validation.

## Changes

- Normalize human-friendly task tool arguments: decimal SOL rewards, capability names/arrays/tag-like strings, invalid slug `taskId`s, native SOL reward mints, and missing short `description` values recovered from richer fields.
- Tighten creator agent PDA resolution so wallet pubkeys or human labels are not accepted as creator agent PDAs, with a safe fallback to the signer’s single registered agent.
- Add regression coverage for the failed devnet argument shapes.

## Validation

- `npx vitest run src/llm/chat-executor-tool-utils.test.ts`
- `npm run typecheck --workspace=@tetsuo-ai/runtime`
- `npm run build --workspace=@tetsuo-ai/runtime`

Build completed with existing CSS optimizer and chunk-size warnings only.