### PR TITLE
fix(watch): preserve session bootstrap control results

### DIFF
--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -32,3 +32,10 @@
 - **What worked:** The console/runtime error was a pure wiring bug: the daemon built the shared slash-command registry but never injected it into `WebChatChannel`, so a one-line dependency fix restored live `session.command.execute` handling immediately once the daemon was rebuilt and restarted.
 - **What didn't:** The symptom initially looked like a stale-daemon issue because the old process was still running, but the new daemon log proved the failure persisted until the missing dependency injection was fixed.
 - **Rule added to CLAUDE.md:** no
+
+## PR #334: fix(watch): preserve session bootstrap control results
+- **Date:** 2026-04-13
+- **Files changed:** `runtime/src/channels/webchat/operator-events.ts`, `runtime/src/channels/webchat/operator-events.test.ts`
+- **What worked:** The remaining console bootstrap deadlock came from over-filtering session-scoped control responses; letting canonical `/session` command results bypass the active-session transcript filter preserved strict event scoping for normal traffic while allowing stale remembered sessions to recover cleanly.
+- **What didn't:** The daemon was healthy and the command registry bug was already fixed, so the second failure looked like “console still broken” until the watch-side session filter was traced against the persisted watch-state bootstrap flow.
+- **Rule added to CLAUDE.md:** no

--- a/runtime/src/channels/webchat/operator-events.test.ts
+++ b/runtime/src/channels/webchat/operator-events.test.ts
@@ -153,6 +153,23 @@ describe("operator event normalization", () => {
     expect(shouldIgnoreOperatorMessage(message, "other-session")).toBe(true);
   });
 
+  it("does not ignore shared session command results during bootstrap", () => {
+    const message = {
+      type: "session.command.result",
+      payload: {
+        commandName: "session",
+        sessionId: "session:fresh-session",
+        data: {
+          kind: "session",
+          subcommand: "list",
+          sessions: [{ sessionId: "session:fresh-session" }],
+        },
+      },
+    };
+
+    expect(shouldIgnoreOperatorMessage(message, "session:stale-session")).toBe(false);
+  });
+
   it("tolerates wrapped events without eventType", () => {
     expect(
       normalizeOperatorMessage({

--- a/runtime/src/channels/webchat/operator-events.ts
+++ b/runtime/src/channels/webchat/operator-events.ts
@@ -247,6 +247,20 @@ function deriveNormalizedData(
   return {};
 }
 
+function isSharedSessionControlResult(
+  normalized: NormalizedOperatorMessage,
+): boolean {
+  if (normalized.type !== "session.command.result") {
+    return false;
+  }
+  const data = isRecord(normalized.data) ? normalized.data : {};
+  if (normalizeText(data.kind) === "session") {
+    return true;
+  }
+  const payload = isRecord(normalized.payload) ? normalized.payload : {};
+  return normalizeText(payload.commandName) === "session";
+}
+
 function pickFirstText(...values: readonly unknown[]): string | undefined {
   for (const value of values) {
     const normalized = normalizeText(value);
@@ -350,6 +364,9 @@ export function shouldIgnoreOperatorMessage(
       ? (message as NormalizedOperatorMessage)
       : normalizeOperatorMessage(message as OperatorMessageEnvelope);
   if (!isSessionScopedType(normalized.type)) {
+    return false;
+  }
+  if (isSharedSessionControlResult(normalized)) {
     return false;
   }
   if (normalized.sessionIds.length === 0) {


### PR DESCRIPTION
## Summary
- stop the watch console from dropping canonical `/session` bootstrap results when a stale persisted session id is present
- keep ordinary session-scoped filtering intact for normal transcript and runtime events
- add a regression test for the bootstrap control-path message shape

## Testing
- `cd runtime && npx vitest run src/channels/webchat/operator-events.test.ts src/channels/webchat/plugin.test.ts`
- `cd runtime && node --test tests/watch/agenc-watch-surface-dispatch.test.mjs tests/watch/agenc-watch-transport.test.mjs`
- `cd runtime && npm run build`
- smoke-tested `agenc console` from `/home/tetsuo/git/stream-test/agenc-shell` against the persisted watch state that was previously stuck in session bootstrap
