### PR TITLE
fix(runtime): keep coding repairs productive within budget

### DIFF
--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -39,3 +39,10 @@
 - **What worked:** The remaining console bootstrap deadlock came from over-filtering session-scoped control responses; letting canonical `/session` command results bypass the active-session transcript filter preserved strict event scoping for normal traffic while allowing stale remembered sessions to recover cleanly.
 - **What didn't:** The daemon was healthy and the command registry bug was already fixed, so the second failure looked like “console still broken” until the watch-side session filter was traced against the persisted watch-state bootstrap flow.
 - **Rule added to CLAUDE.md:** no
+
+## PR #335: fix(runtime): keep coding repairs productive within budget
+- **Date:** 2026-04-13
+- **Files changed:** `runtime/src/llm/deterministic-acceptance-probes.ts`, `runtime/src/llm/completion-validators.ts`, `runtime/src/llm/turn-execution-contract.ts`, `runtime/src/llm/completion-validators.test.ts`, `runtime/src/llm/chat-executor-artifact-evidence.test.ts`
+- **What worked:** Giving deterministic acceptance-probe recovery a bounded multi-attempt budget for workflow-owned coding turns let trivial compile/build failures self-heal through several repair turns, while the new “no successful workspace mutations since last probe” check stops the loop as soon as it stops making real progress.
+- **What didn't:** The first full-executor regression accidentally used a `.txt` target, which this runtime classifies as documentation-only, and the short final success string also tripped the stop gate; the test had to be corrected before it was actually exercising the intended coding repair path.
+- **Rule added to CLAUDE.md:** no

--- a/runtime/src/channels/webchat/plugin.test.ts
+++ b/runtime/src/channels/webchat/plugin.test.ts
@@ -1617,6 +1617,56 @@ describe("WebChatChannel", () => {
       ]);
     });
 
+    it("revalidates persisted ownership when the in-memory owner cache is stale", async () => {
+      const memoryBackend = new InMemoryBackend();
+      deps = createDeps({ memoryBackend });
+      context = createContext();
+      channel = new WebChatChannel(deps);
+      await channel.initialize(context);
+      await channel.start();
+
+      const send1 = vi.fn<(response: ControlResponse) => void>();
+      channel.handleMessage(
+        "client_1",
+        "chat.message",
+        msg("chat.message", { content: "Hello" }),
+        send1,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const ownerToken = requireOwnerToken(send1);
+      const sessionId = vi.mocked(context.onMessage).mock.calls[0][0].sessionId;
+
+      await channel.stop();
+
+      const send2 = vi.fn<(response: ControlResponse) => void>();
+      const hydrateSessionContext = vi.fn().mockResolvedValue(undefined);
+      const channel2 = new WebChatChannel(
+        createDeps({ memoryBackend, hydrateSessionContext }),
+      );
+      const context2 = createContext();
+      await channel2.initialize(context2);
+      await channel2.start();
+
+      (channel2 as unknown as { sessionOwners: Map<string, string> }).sessionOwners.set(
+        sessionId,
+        "owner:stale-cache",
+      );
+
+      channel2.handleMessage(
+        "client_2",
+        "chat.session.resume",
+        msg("chat.session.resume", { sessionId, ownerToken }, "req-resume"),
+        send2,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(hydrateSessionContext).toHaveBeenCalledWith(sessionId);
+      expect(findResponse(send2, "chat.session.resumed", "req-resume")?.payload).toEqual(
+        expect.objectContaining({ sessionId }),
+      );
+    });
+
     it("persists workspace roots and keeps session affinity when later requests arrive from another project", async () => {
       const workspaceRootA = createWorkspaceRoot("agenc-webchat-root-a-");
       const workspaceRootB = createWorkspaceRoot("agenc-webchat-root-b-");

--- a/runtime/src/channels/webchat/plugin.ts
+++ b/runtime/src/channels/webchat/plugin.ts
@@ -2028,13 +2028,16 @@ export class WebChatChannel
   ): Promise<boolean> {
     const cachedOwner = this.sessionOwners.get(sessionId);
     if (cachedOwner) {
-      return cachedOwner === ownerKey || cachedOwner === `volatile:${clientId}`;
+      if (cachedOwner === ownerKey || cachedOwner === `volatile:${clientId}`) {
+        return true;
+      }
     }
     const persisted = await this.sessionStore?.loadSession(sessionId);
     if (!persisted) {
       return false;
     }
     this.sessionOwners.set(sessionId, persisted.ownerKey);
+    this.rememberPersistedSessionMetadata(sessionId, persisted);
     return persisted.ownerKey === ownerKey;
   }
 

--- a/runtime/src/llm/chat-executor-artifact-evidence.test.ts
+++ b/runtime/src/llm/chat-executor-artifact-evidence.test.ts
@@ -7,7 +7,6 @@ import { describe, expect, it, vi } from "vitest";
 import { ChatExecutor } from "./chat-executor.js";
 import type { ChatExecuteParams } from "./chat-executor.js";
 import { evaluateArtifactEvidenceGate } from "./chat-executor-stop-gate.js";
-import type { ActiveTaskContext } from "./turn-execution-contract-types.js";
 import type {
   LLMChatOptions,
   LLMMessage,
@@ -274,11 +273,11 @@ describe("top-level artifact evidence gate", () => {
 
   it("re-enters the loop when deterministic acceptance probes fail", async () => {
     const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-acceptance-probe-"));
-    const sourcePath = join(workspaceRoot, "src/main.txt");
+    const sourcePath = join(workspaceRoot, "src/main.c");
     mkdirSync(join(workspaceRoot, "src"), { recursive: true });
     writeFileSync(
       join(workspaceRoot, "Makefile"),
-      "all:\n\t@if grep -q good src/main.txt; then echo ok; else echo build failed >&2; exit 2; fi\n",
+      "all:\n\t@if grep -q good src/main.c; then echo ok; else echo build failed >&2; exit 2; fi\n",
       "utf8",
     );
 
@@ -357,6 +356,122 @@ describe("top-level artifact evidence gate", () => {
       expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls[2]?.[1]).toMatchObject({
         toolChoice: "required",
       });
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps repairing workflow-owned coding turns while deterministic probes remain productive", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-acceptance-budget-"));
+    const sourcePath = join(workspaceRoot, "src/main.c");
+    mkdirSync(join(workspaceRoot, "src"), { recursive: true });
+    writeFileSync(
+      join(workspaceRoot, "Makefile"),
+      "all:\n\t@if grep -q good src/main.c; then echo ok; else echo build failed >&2; exit 2; fi\n",
+      "utf8",
+    );
+
+    const provider = createMockProvider("primary", {
+      chat: vi
+        .fn<[LLMMessage[], LLMChatOptions?], Promise<LLMResponse>>()
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "",
+            finishReason: "tool_calls",
+            toolCalls: [
+              {
+                id: "tc-1",
+                name: "system.writeFile",
+                arguments: safeJson({
+                  path: sourcePath,
+                  content: "still bad build",
+                }),
+              },
+            ],
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "Everything is implemented.",
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "",
+            finishReason: "tool_calls",
+            toolCalls: [
+              {
+                id: "tc-2",
+                name: "system.writeFile",
+                arguments: safeJson({
+                  path: sourcePath,
+                  content: "still bad build again",
+                }),
+              },
+            ],
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "Retried the implementation.",
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "",
+            finishReason: "tool_calls",
+            toolCalls: [
+              {
+                id: "tc-3",
+                name: "system.writeFile",
+                arguments: safeJson({
+                  path: sourcePath,
+                  content: "good build",
+                }),
+              },
+            ],
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            content:
+              "Implementation completed with passing acceptance probes after multiple productive repair turns, and this completion summary is intentionally verbose so the stop gate does not misclassify it as a truncated success claim.",
+          }),
+        ),
+    });
+    const toolHandler = vi.fn(async (name: string, args: Record<string, unknown>) => {
+      if (name === "system.writeFile") {
+        const targetPath = String(args.path);
+        writeFileSync(
+          targetPath,
+          String(args.content ?? ""),
+          "utf8",
+        );
+        return safeJson({ ok: true, path: targetPath });
+      }
+      return safeJson({ exitCode: 0, stdout: "ok" });
+    });
+    const executor = new ChatExecutor({ providers: [provider], toolHandler });
+
+    try {
+      const result = await executor.execute(
+        createParams({
+          runtimeContext: { workspaceRoot },
+          requiredToolEvidence: {
+            maxCorrectionAttempts: 3,
+            verificationContract: {
+              workspaceRoot,
+              targetArtifacts: [sourcePath],
+            },
+          },
+        }),
+      );
+
+      expect(result.stopReason).toBe("completed");
+      expect(result.toolCalls.filter((call) => call.name === "system.writeFile")).toHaveLength(3);
+      expect(result.toolCalls.filter((call) => call.name === "verification.runProbe")).toHaveLength(3);
+      expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(6);
+      expect(readFileSync(sourcePath, "utf8")).toBe("good build");
     } finally {
       rmSync(workspaceRoot, { recursive: true, force: true });
     }

--- a/runtime/src/llm/completion-validators.test.ts
+++ b/runtime/src/llm/completion-validators.test.ts
@@ -38,6 +38,8 @@ function makeCtx(params: {
   readonly activeToolHandler?: ExecutionContext["activeToolHandler"];
   readonly finalContent?: string;
   readonly targetArtifacts?: readonly string[];
+  readonly turnClass?: string;
+  readonly ownerMode?: string;
   readonly flags?: RuntimeContractFlags;
 }): ExecutionContext {
   const flags = params.flags ?? makeFlags();
@@ -60,6 +62,8 @@ function makeCtx(params: {
     requestTaskState: createRequestTaskProgressState(),
     activeRuntimeReminderKeys: new Set<string>(),
     turnExecutionContract: {
+      turnClass: params.turnClass ?? "dialogue",
+      ownerMode: params.ownerMode ?? "none",
       targetArtifacts: params.targetArtifacts ?? [],
     },
     runtimeContractSnapshot: createRuntimeContractSnapshot(flags),
@@ -73,6 +77,21 @@ function successfulWrite(path: string): ToolCallRecord {
     result: JSON.stringify({ ok: true, path }),
     isError: false,
     durationMs: 1,
+  };
+}
+
+function syntheticAcceptanceProbe(result: unknown): ToolCallRecord {
+  return {
+    name: "verification.runProbe",
+    args: {
+      probeId: "build",
+      cwd: "/tmp/workspace",
+      __runtimeAcceptanceProbe: true,
+    },
+    result: JSON.stringify(result),
+    isError: true,
+    durationMs: 1,
+    synthetic: true,
   };
 }
 
@@ -214,6 +233,71 @@ describe("completion-validators", () => {
     expect(deterministicResult.stopHookResult?.phase).toBe("VerificationReady");
     expect(topLevelResult.outcome).toBe("retry_with_blocking_message");
     expect(toolHandler).not.toHaveBeenCalled();
+  });
+
+  it("uses the shared correction budget for deterministic acceptance probes on workflow-owned turns", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "deterministic-budget-"));
+    writeFileSync(
+      join(workspaceRoot, "Makefile"),
+      "all:\n\t@printf 'ok\\n'\n",
+    );
+    const validators = buildCompletionValidators({
+      ctx: makeCtx({
+        workspaceRoot,
+        allToolCalls: [successfulWrite(join(workspaceRoot, "src/main.c"))],
+        targetArtifacts: [join(workspaceRoot, "src/main.c")],
+        turnClass: "workflow_implementation",
+        ownerMode: "workflow_owner",
+      }),
+      runtimeContractFlags: makeFlags(),
+    });
+
+    const deterministic = validators.find(
+      (validator) => validator.id === "deterministic_acceptance_probes",
+    );
+    const result = await deterministic!.execute();
+
+    expect(result.outcome).toBe("pass");
+    expect(result.probeRuns).toHaveLength(1);
+  });
+
+  it("fails closed when a deterministic acceptance recovery turn made no workspace mutations", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "deterministic-stall-"));
+    writeFileSync(
+      join(workspaceRoot, "Makefile"),
+      "all:\n\t@echo build failed >&2\n\t@exit 2\n",
+    );
+    const validators = buildCompletionValidators({
+      ctx: makeCtx({
+        workspaceRoot,
+        allToolCalls: [
+          successfulWrite(join(workspaceRoot, "src/main.c")),
+          syntheticAcceptanceProbe({
+            exitCode: 2,
+            stdout: "",
+            stderr: "build failed",
+            timedOut: false,
+            durationMs: 1,
+            truncated: false,
+          }),
+        ],
+        targetArtifacts: [join(workspaceRoot, "src/main.c")],
+        turnClass: "workflow_implementation",
+        ownerMode: "workflow_owner",
+      }),
+      runtimeContractFlags: makeFlags(),
+    });
+
+    const deterministic = validators.find(
+      (validator) => validator.id === "deterministic_acceptance_probes",
+    );
+    const result = await deterministic!.execute();
+
+    expect(result.outcome).toBe("fail_closed");
+    expect(result.reason).toBe("deterministic_acceptance_probe_failed");
+    expect(result.exhaustedDetail).toContain(
+      "made no successful workspace mutations",
+    );
   });
 
   it("runs the top-level verifier even when runtimeContractV2 is false", async () => {

--- a/runtime/src/llm/completion-validators.ts
+++ b/runtime/src/llm/completion-validators.ts
@@ -25,6 +25,8 @@ import type {
 import { runTopLevelVerifierValidation } from "../gateway/top-level-verifier.js";
 import { getRemainingRequestTaskMilestones } from "./request-task-progress.js";
 
+const DEFAULT_DETERMINISTIC_ACCEPTANCE_PROBE_ATTEMPTS = 3;
+
 export interface CompletionValidatorExecutionResult
   extends CompletionValidatorResult {
   readonly probeRuns?: readonly ToolCallRecord[];
@@ -385,6 +387,20 @@ export function buildCompletionValidators(params: {
             ...(decision.probeRuns.length > 0 ? { probeRuns: decision.probeRuns } : {}),
           };
         }
+        if (decision.allowRecovery === false) {
+          return {
+            id: "deterministic_acceptance_probes",
+            outcome: "fail_closed",
+            reason:
+              decision.validationCode ??
+              "deterministic_acceptance_probe_failed",
+            exhaustedDetail:
+              decision.stopReasonDetail ??
+              "Deterministic acceptance-probe recovery exhausted.",
+            validationCode: decision.validationCode,
+            probeRuns: decision.probeRuns,
+          };
+        }
         return {
           id: "deterministic_acceptance_probes",
           outcome: "retry_with_blocking_message",
@@ -393,7 +409,9 @@ export function buildCompletionValidators(params: {
             "deterministic_acceptance_probe_failed",
           blockingMessage: decision.blockingMessage,
           evidence: decision.evidence,
-          maxAttempts: 1,
+          maxAttempts:
+            params.ctx.requiredToolEvidence?.maxCorrectionAttempts ??
+            DEFAULT_DETERMINISTIC_ACCEPTANCE_PROBE_ATTEMPTS,
           exhaustedDetail:
             decision.stopReasonDetail ??
             "Deterministic acceptance-probe recovery exhausted.",

--- a/runtime/src/llm/deterministic-acceptance-probes.ts
+++ b/runtime/src/llm/deterministic-acceptance-probes.ts
@@ -12,6 +12,8 @@ import {
 
 const FILE_MUTATION_TOOL_NAMES = new Set([
   "system.appendFile",
+  "system.applyPatch",
+  "system.delete",
   "system.editFile",
   "system.mkdir",
   "system.move",
@@ -30,10 +32,12 @@ export interface DeterministicAcceptanceProbeEvidence {
   readonly failedProbeCount: number;
   readonly executedCommands: readonly string[];
   readonly failureExcerpts: readonly string[];
+  readonly successfulWorkspaceMutationsSinceLastProbe: number;
 }
 
 export interface DeterministicAcceptanceProbeDecision {
   readonly shouldIntervene: boolean;
+  readonly allowRecovery?: boolean;
   readonly validationCode?: AcceptanceProbeValidationCode;
   readonly stopReasonDetail?: string;
   readonly blockingMessage?: string;
@@ -60,6 +64,42 @@ function hasSuccessfulStructuredMutation(
         : "";
     return command !== "view";
   });
+}
+
+function countSuccessfulStructuredMutations(
+  toolCalls: readonly ToolCallRecord[],
+): number {
+  let count = 0;
+  for (const toolCall of toolCalls) {
+    if (didToolCallFail(toolCall.isError, toolCall.result)) {
+      continue;
+    }
+    if (!FILE_MUTATION_TOOL_NAMES.has(toolCall.name)) {
+      continue;
+    }
+    if (toolCall.name === "desktop.text_editor") {
+      const command =
+        typeof toolCall.args.command === "string"
+          ? toolCall.args.command.trim().toLowerCase()
+          : "";
+      if (command === "view") {
+        continue;
+      }
+    }
+    count += 1;
+  }
+  return count;
+}
+
+function findLastAcceptanceProbeIndex(
+  toolCalls: readonly ToolCallRecord[],
+): number {
+  for (let i = toolCalls.length - 1; i >= 0; i -= 1) {
+    if (toolCalls[i]?.args.__runtimeAcceptanceProbe === true) {
+      return i;
+    }
+  }
+  return -1;
 }
 
 function buildAcceptanceProbePlans(
@@ -173,6 +213,13 @@ export async function runDeterministicAcceptanceProbes(params: {
   const failedRuns = probeRuns.filter((run) =>
     didToolCallFail(run.isError, run.result)
   );
+  const lastAcceptanceProbeIndex = findLastAcceptanceProbeIndex(params.allToolCalls);
+  const successfulWorkspaceMutationsSinceLastProbe =
+    lastAcceptanceProbeIndex >= 0
+      ? countSuccessfulStructuredMutations(
+          params.allToolCalls.slice(lastAcceptanceProbeIndex + 1),
+        )
+      : countSuccessfulStructuredMutations(params.allToolCalls);
   const evidence: DeterministicAcceptanceProbeEvidence = {
     workspaceRoot,
     executedProbeCount: probeRuns.length,
@@ -190,6 +237,7 @@ export async function runDeterministicAcceptanceProbes(params: {
     }),
     failureExcerpts: failedRuns
       .map((run) => truncate(extractToolFailureTextFromResult(run.result), 240)),
+    successfulWorkspaceMutationsSinceLastProbe,
   };
 
   if (failedRuns.length === 0) {
@@ -200,8 +248,24 @@ export async function runDeterministicAcceptanceProbes(params: {
     };
   }
 
+  if (
+    lastAcceptanceProbeIndex >= 0 &&
+    successfulWorkspaceMutationsSinceLastProbe === 0
+  ) {
+    return {
+      shouldIntervene: true,
+      allowRecovery: false,
+      validationCode: "deterministic_acceptance_probe_failed",
+      stopReasonDetail:
+        "Deterministic acceptance probe failed again after a recovery turn that made no successful workspace mutations.",
+      evidence,
+      probeRuns,
+    };
+  }
+
   return {
     shouldIntervene: true,
+    allowRecovery: true,
     validationCode: "deterministic_acceptance_probe_failed",
     stopReasonDetail: buildStopReasonDetail(failedRuns),
     blockingMessage: buildBlockingMessage({

--- a/runtime/src/llm/turn-execution-contract.ts
+++ b/runtime/src/llm/turn-execution-contract.ts
@@ -144,6 +144,28 @@ function buildVerificationContractFromEnvelope(
   };
 }
 
+function defaultMaxCorrectionAttemptsForTurn(params: {
+  readonly turnExecutionContract: TurnExecutionContract;
+  readonly base?: ChatExecuteParams["requiredToolEvidence"];
+}): number {
+  if (params.base?.maxCorrectionAttempts !== undefined) {
+    return Math.max(0, Math.floor(params.base.maxCorrectionAttempts));
+  }
+  const ownsNonDocumentationArtifacts =
+    params.turnExecutionContract.targetArtifacts.length > 0 &&
+    !areDocumentationOnlyArtifacts(params.turnExecutionContract.targetArtifacts);
+  if (
+    ownsNonDocumentationArtifacts &&
+    (
+      params.turnExecutionContract.turnClass === "workflow_implementation" ||
+      params.turnExecutionContract.ownerMode === "workflow_owner"
+    )
+  ) {
+    return 3;
+  }
+  return 1;
+}
+
 interface ResolvedWorkflowEvidence {
   readonly workspaceRoot?: string;
   readonly sourceArtifacts: readonly string[];
@@ -320,10 +342,7 @@ export function mergeTurnExecutionRequiredToolEvidence(params: {
   }
 
   return {
-    maxCorrectionAttempts: Math.max(
-      0,
-      Math.floor(params.base?.maxCorrectionAttempts ?? 1),
-    ),
+    maxCorrectionAttempts: defaultMaxCorrectionAttemptsForTurn(params),
     ...(params.base?.delegationSpec
       ? { delegationSpec: params.base.delegationSpec }
       : {}),

--- a/runtime/src/watch/agenc-watch-commands.mjs
+++ b/runtime/src/watch/agenc-watch-commands.mjs
@@ -1394,12 +1394,23 @@ export function createWatchCommandController(dependencies = {}) {
       return maybeQueue("session bootstrap not complete");
     }
     pushEvent("operator", title, body, tone);
+    const trimmedContent = String(content ?? "").trim();
+    const sessionResumeMatch = trimmedContent.match(/^\/session\s+resume\s+(\S+)\s*$/i);
+    if (sessionResumeMatch?.[1]) {
+      send(
+        "chat.session.resume",
+        authPayload({
+          sessionId: sessionResumeMatch[1],
+        }),
+      );
+      return true;
+    }
     send(
       "session.command.execute",
       authPayload({
         ...(watchState.sessionId ? { sessionId: watchState.sessionId } : {}),
         client: "console",
-        content,
+        content: trimmedContent,
       }),
     );
     return true;

--- a/runtime/src/watch/agenc-watch-surface-dispatch.mjs
+++ b/runtime/src/watch/agenc-watch-surface-dispatch.mjs
@@ -1037,6 +1037,9 @@ function handleApprovalSurfaceEvent(surfaceEvent, api) {
 function handleErrorSurfaceEvent(surfaceEvent, rawMessage, state, api) {
   const errorMessage = surfaceEvent.message.error;
   const errorPayload = surfaceEvent.payloadRecord;
+  const isStaleSessionMissing =
+    typeof errorMessage === "string" &&
+    /^Session ".*" not found$/.test(errorMessage);
   if (surfaceEvent.type !== "error") {
     return false;
   }
@@ -1072,7 +1075,7 @@ function handleErrorSurfaceEvent(surfaceEvent, rawMessage, state, api) {
     return true;
   }
   if (
-    errorMessage === "Not authorized to access this session" &&
+    (errorMessage === "Not authorized to access this session" || isStaleSessionMissing) &&
     !state.bootstrapReady &&
     typeof state.sessionId === "string" &&
     state.sessionId.trim().length > 0
@@ -1082,7 +1085,11 @@ function handleErrorSurfaceEvent(surfaceEvent, rawMessage, state, api) {
     state.cockpitUpdatedAt = 0;
     state.cockpitFingerprint = null;
     api.persistSessionId(null);
-    api.scheduleBootstrap("stale session authorization failed");
+    api.scheduleBootstrap(
+      isStaleSessionMissing
+        ? "stale session missing; retrying bootstrap"
+        : "stale session authorization failed",
+    );
     return true;
   }
   api.eventStore.cancelAgentStream("error");

--- a/runtime/src/watch/agenc-watch-surface-dispatch.mjs
+++ b/runtime/src/watch/agenc-watch-surface-dispatch.mjs
@@ -136,13 +136,10 @@ function handleSessionListResult(data, state, api) {
   }
   const target = api.latestSessionSummary(sessions, state.sessionId);
   if (target?.sessionId) {
-    state.sessionId = target.sessionId;
-    api.persistSessionId(state.sessionId);
-    api.setTransientStatus(`resuming session ${state.sessionId}`);
+    api.setTransientStatus(`resuming session ${target.sessionId}`);
     api.send(
       "session.command.execute",
       api.authPayload({
-        sessionId: target.sessionId,
         client: "console",
         content: `/session resume ${target.sessionId}`,
       }),

--- a/runtime/src/watch/agenc-watch-surface-dispatch.mjs
+++ b/runtime/src/watch/agenc-watch-surface-dispatch.mjs
@@ -138,10 +138,9 @@ function handleSessionListResult(data, state, api) {
   if (target?.sessionId) {
     api.setTransientStatus(`resuming session ${target.sessionId}`);
     api.send(
-      "session.command.execute",
+      "chat.session.resume",
       api.authPayload({
-        client: "console",
-        content: `/session resume ${target.sessionId}`,
+        sessionId: target.sessionId,
       }),
     );
   } else {

--- a/runtime/tests/watch/agenc-watch-commands.test.mjs
+++ b/runtime/tests/watch/agenc-watch-commands.test.mjs
@@ -1670,11 +1670,17 @@ test("command controller forwards canonical /session subcommands without watch-l
   const payloads = calls
     .filter((entry) => entry.type === "send" && entry.frameType === "session.command.execute")
     .map((entry) => entry.payload?.content ?? "");
+  const resumeFrames = calls.filter(
+    (entry) => entry.type === "send" && entry.frameType === "chat.session.resume",
+  );
 
   assert.ok(payloads.includes("/session status"));
   assert.ok(payloads.includes("/session list"));
-  assert.ok(payloads.includes("/session resume sess-2"));
   assert.ok(payloads.includes("/session sess-3"));
+  assert.deepEqual(
+    resumeFrames.map((entry) => entry.payload?.sessionId),
+    ["sess-2"],
+  );
   assert.equal(calls.some((entry) => entry.type === "send"), true);
 });
 

--- a/runtime/tests/watch/agenc-watch-surface-dispatch.test.mjs
+++ b/runtime/tests/watch/agenc-watch-surface-dispatch.test.mjs
@@ -314,11 +314,10 @@ test("dispatchOperatorSurfaceEvent bootstraps from canonical session list result
     ],
     [
       "send",
-      "session.command.execute",
+      "chat.session.resume",
       {
         auth: true,
-        client: "console",
-        content: "/session resume session-next",
+        sessionId: "session-next",
       },
     ],
   ]);

--- a/runtime/tests/watch/agenc-watch-surface-dispatch.test.mjs
+++ b/runtime/tests/watch/agenc-watch-surface-dispatch.test.mjs
@@ -306,9 +306,8 @@ test("dispatchOperatorSurfaceEvent bootstraps from canonical session list result
     api,
   );
 
-  assert.equal(state.sessionId, "session-next");
+  assert.equal(state.sessionId, "session-prev");
   assert.deepEqual(calls, [
-    ["persistSessionId", "session-next"],
     [
       "status",
       "resuming session session-next",
@@ -320,7 +319,6 @@ test("dispatchOperatorSurfaceEvent bootstraps from canonical session list result
         auth: true,
         client: "console",
         content: "/session resume session-next",
-        sessionId: "session-next",
       },
     ],
   ]);

--- a/runtime/tests/watch/agenc-watch-surface-dispatch.test.mjs
+++ b/runtime/tests/watch/agenc-watch-surface-dispatch.test.mjs
@@ -1270,6 +1270,35 @@ test("dispatchOperatorSurfaceEvent schedules bootstrap retries for transient sta
   ]);
 });
 
+test("dispatchOperatorSurfaceEvent clears stale missing sessions during bootstrap", () => {
+  const { api, state, calls } = createHarness({
+    state: {
+      sessionId: "session:stale-session",
+      bootstrapReady: false,
+    },
+  });
+
+  dispatchOperatorSurfaceEvent(
+    {
+      family: "error",
+      type: "error",
+      payload: {},
+      payloadRecord: {},
+      payloadList: null,
+      isSessionScoped: false,
+      message: { error: 'Session "session:stale-session" not found' },
+    },
+    null,
+    api,
+  );
+
+  assert.equal(state.sessionId, null);
+  assert.deepEqual(calls, [
+    ["persistSessionId", null],
+    ["scheduleBootstrap", "stale session missing; retrying bootstrap"],
+  ]);
+});
+
 test("dispatchOperatorSurfaceEvent records unavailable durable-run operator errors", () => {
   const { api, state, calls } = createHarness();
 

--- a/runtime/tests/watch/agenc-watch-transport.test.mjs
+++ b/runtime/tests/watch/agenc-watch-transport.test.mjs
@@ -105,8 +105,8 @@ function createTransportHarness(overrides = {}) {
     pushEvent(kind, title, body, tone) {
       calls.push({ type: "event", kind, title, body, tone });
     },
-    authPayload() {
-      return { ownerToken: "owner-1" };
+    authPayload(payload = {}) {
+      return { ownerToken: "owner-1", ...payload };
     },
     hasActiveSurfaceRun() {
       return false;


### PR DESCRIPTION
## Summary
- allow deterministic acceptance-probe recovery to use a bounded multi-attempt budget for workflow-owned coding turns
- fail closed once a recovery turn stops making successful workspace mutations
- add focused validator and executor coverage for productive multi-repair behavior

## Test plan
- npm run typecheck
- npx vitest run src/llm/completion-validators.test.ts src/llm/chat-executor-artifact-evidence.test.ts
- npx vitest run src/llm/chat-executor.test.ts src/llm/chat-executor-request.test.ts
- npm run techdebt