### PR TITLE
fix(runtime): continue coding recoveries within budget

### DIFF
--- a/runtime/src/llm/chat-executor-artifact-evidence.test.ts
+++ b/runtime/src/llm/chat-executor-artifact-evidence.test.ts
@@ -271,6 +271,96 @@ describe("top-level artifact evidence gate", () => {
     });
   });
 
+  it("keeps retrying narrated future-work stop-gate recoveries within the coding correction budget", async () => {
+    const targetPath = `${WORKSPACE_ROOT}/src/main.c`;
+    const provider = createMockProvider("primary", {
+      chat: vi
+        .fn<[LLMMessage[], LLMChatOptions?], Promise<LLMResponse>>()
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "",
+            finishReason: "tool_calls",
+            toolCalls: [
+              {
+                id: "tc-1",
+                name: "system.writeFile",
+                arguments: safeJson({
+                  path: targetPath,
+                  content: "phase 1",
+                }),
+              },
+            ],
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "Build succeeded and all phases were fully implemented.",
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "Next I will fix the build and write the remaining files.",
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "I will now update the failing source files and rerun the build.",
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "",
+            finishReason: "tool_calls",
+            toolCalls: [
+              {
+                id: "tc-2",
+                name: "system.writeFile",
+                arguments: safeJson({
+                  path: targetPath,
+                  content: "phase 2",
+                }),
+              },
+            ],
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            content:
+              "Implementation completed with a successful rebuild after the recovery turns, and this summary is intentionally explicit enough to avoid stop-gate truncation handling.",
+          }),
+        ),
+    });
+    let writeAttempts = 0;
+    const toolHandler = vi.fn(async (name: string, args: Record<string, unknown>) => {
+      if (name !== "system.writeFile") {
+        return safeJson({ ok: true });
+      }
+      writeAttempts += 1;
+      writeFileSync(String(args.path), String(args.content ?? ""), "utf8");
+      return safeJson({ ok: true, path: String(args.path) });
+    });
+    const executor = new ChatExecutor({ providers: [provider], toolHandler });
+
+    const result = await executor.execute(
+      createParams({
+        requiredToolEvidence: {
+          maxCorrectionAttempts: 3,
+        },
+      }),
+    );
+
+    expect(result.stopReason).toBe("completed");
+    expect(writeAttempts).toBe(2);
+    expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(6);
+    expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls[2]?.[1]).toMatchObject({
+      toolChoice: "required",
+    });
+    expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls[3]?.[1]).toMatchObject({
+      toolChoice: "required",
+    });
+    expect(readFileSync(targetPath, "utf8")).toBe("phase 2");
+  });
+
   it("re-enters the loop when deterministic acceptance probes fail", async () => {
     const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-acceptance-probe-"));
     const sourcePath = join(workspaceRoot, "src/main.c");

--- a/runtime/src/llm/chat-executor-stop-gate.test.ts
+++ b/runtime/src/llm/chat-executor-stop-gate.test.ts
@@ -189,7 +189,7 @@ describe("evaluateTurnEndStopGate — narrated_future_tool_work", () => {
     expect(decision.shouldIntervene).toBe(true);
     expect(decision.reason).toBe("narrated_future_tool_work");
     expect(decision.blockingMessage).toContain("NARRATED");
-    expect(decision.blockingMessage).toContain("ONE recovery turn");
+    expect(decision.blockingMessage).toContain("bounded recovery loop");
     expect(decision.blockingMessage).toContain("Next tool calls will");
   });
 
@@ -343,7 +343,7 @@ describe("evaluateTurnEndStopGate — narrated_future_tool_work", () => {
     // Verify the blocking message references the actual narration so the
     // model sees what triggered the recovery.
     expect(decision.blockingMessage).toContain("NARRATED");
-    expect(decision.blockingMessage).toContain("ONE recovery turn");
+    expect(decision.blockingMessage).toContain("bounded recovery loop");
   });
 
   it("fires on bare 'Continue?' permission question at end", () => {
@@ -650,7 +650,7 @@ describe("evaluateTurnEndStopGate — detector priority", () => {
 // ---------------------------------------------------------------------------
 
 describe("evaluateTurnEndStopGate — blocking message contents", () => {
-  it("includes 'ONE recovery turn' instruction", () => {
+  it("includes bounded recovery loop instruction", () => {
     const decision = evaluateTurnEndStopGate({
       finalContent:
         "Phase 0 bootstrap complete. The build succeeded for all source " +
@@ -661,7 +661,7 @@ describe("evaluateTurnEndStopGate — blocking message contents", () => {
         bashFailure({ command: "make", stderr: "boom" }),
       ],
     });
-    expect(decision.blockingMessage).toMatch(/ONE recovery turn/);
+    expect(decision.blockingMessage).toMatch(/bounded recovery loop/);
     expect(decision.blockingMessage).toMatch(/\(a\) Make tool calls/);
     expect(decision.blockingMessage).toMatch(/\(b\) Retract the success claim/);
     expect(decision.blockingMessage).toMatch(/Do NOT repeat the success claim/);

--- a/runtime/src/llm/chat-executor-stop-gate.ts
+++ b/runtime/src/llm/chat-executor-stop-gate.ts
@@ -388,7 +388,10 @@ function buildBlockingMessage(params: {
   lines.push("");
   if (params.reason === "narrated_future_tool_work") {
     lines.push(
-      `You have ONE recovery turn. In this turn you MUST:`,
+      `You are in a bounded recovery loop. Keep using tools until the work is actually complete or you hit a concrete blocker. In each recovery turn you MUST:`,
+    );
+    lines.push(
+      `  • Resume directly. No apology, no recap, no summary of prior work.`,
     );
     lines.push(
       `  • Call the tools you said you were going to call. ` +
@@ -407,7 +410,10 @@ function buildBlockingMessage(params: {
     );
   } else {
     lines.push(
-      `You have ONE recovery turn. Either:`,
+      `You are in a bounded recovery loop. In each recovery turn, either:`,
+    );
+    lines.push(
+      `  • Resume directly. No apology, no recap, no summary of prior work.`,
     );
     lines.push(
       `  (a) Make tool calls to actually fix the underlying causes, or`,
@@ -1129,10 +1135,12 @@ export async function checkFilesystemArtifacts(params: {
     `  (a) The write silently failed (check the tool result for errors)\n` +
     `  (b) A later operation overwrote the file with empty content\n` +
     `  (c) The file was never actually written despite the tool call\n\n` +
-    `You have ONE recovery turn. Re-read each empty/missing file with ` +
-    `system.readFile, then use system.writeFile or system.editFile to ` +
-    `write the actual implementation. Do NOT claim completion again ` +
-    `until every file has real content verified via tool results.`;
+    `You are in a bounded recovery loop. Resume directly with tool calls. ` +
+    `No apology, no recap, no summary of prior work. Re-read each empty/missing ` +
+    `file with system.readFile, then use system.writeFile or ` +
+    `system.editFile to write the actual implementation. Do NOT claim ` +
+    `completion again until every file has real content verified via ` +
+    `tool results.`;
 
   return {
     shouldIntervene: true,

--- a/runtime/src/llm/completion-validators.test.ts
+++ b/runtime/src/llm/completion-validators.test.ts
@@ -41,6 +41,7 @@ function makeCtx(params: {
   readonly turnClass?: string;
   readonly ownerMode?: string;
   readonly flags?: RuntimeContractFlags;
+  readonly requiredToolEvidence?: ExecutionContext["requiredToolEvidence"];
 }): ExecutionContext {
   const flags = params.flags ?? makeFlags();
   return {
@@ -67,6 +68,7 @@ function makeCtx(params: {
       targetArtifacts: params.targetArtifacts ?? [],
     },
     runtimeContractSnapshot: createRuntimeContractSnapshot(flags),
+    requiredToolEvidence: params.requiredToolEvidence,
   } as unknown as ExecutionContext;
 }
 
@@ -177,6 +179,64 @@ describe("completion-validators", () => {
     expect(result.blockingMessage).toBe("configured block");
     expect(result.maxAttempts).toBe(3);
     expect(result.stopHookResult?.phase).toBe("Stop");
+  });
+
+  it("lets the stop-hook path inherit the larger coding correction budget", async () => {
+    const flags = makeFlags({ stopHooksEnabled: true });
+    const validators = buildCompletionValidators({
+      ctx: makeCtx({
+        flags,
+        finalContent:
+          "The build is still failing. Next I will fix the linker errors.",
+        allToolCalls: [successfulWrite("/tmp/workspace/src/main.c")],
+        targetArtifacts: ["/tmp/workspace/src/main.c"],
+        turnClass: "workflow_implementation",
+        ownerMode: "workflow_owner",
+        requiredToolEvidence: {
+          maxCorrectionAttempts: 3,
+        },
+      }),
+      runtimeContractFlags: flags,
+      stopHookRuntime: buildStopHookRuntime({
+        enabled: true,
+      }),
+    });
+
+    const stopValidator = validators.find(
+      (validator) => validator.id === "turn_end_stop_gate",
+    );
+    const result = await stopValidator!.execute();
+
+    expect(result.outcome).toBe("retry_with_blocking_message");
+    expect(result.reason).toBe("narrated_future_tool_work");
+    expect(result.maxAttempts).toBe(3);
+  });
+
+  it("uses the shared correction budget for narrated future tool work when stop hooks are not configured", async () => {
+    const validators = buildCompletionValidators({
+      ctx: makeCtx({
+        finalContent:
+          "The current build still has failures. Next I will fix the linker errors and then rerun the build.",
+        allToolCalls: [successfulWrite("/tmp/workspace/src/main.c")],
+        turnClass: "workflow_implementation",
+        ownerMode: "workflow_owner",
+        targetArtifacts: ["/tmp/workspace/src/main.c"],
+        requiredToolEvidence: {
+          maxCorrectionAttempts: 3,
+        },
+      }),
+      runtimeContractFlags: makeFlags({ stopHooksEnabled: true }),
+    });
+
+    const stopValidator = validators.find(
+      (validator) => validator.id === "turn_end_stop_gate",
+    );
+    const result = await stopValidator!.execute();
+
+    expect(result.outcome).toBe("retry_with_blocking_message");
+    expect(result.reason).toBe("narrated_future_tool_work");
+    expect(result.maxAttempts).toBe(3);
+    expect(result.blockingMessage).toContain("bounded recovery loop");
   });
 
   it("gates the verification stage before deterministic probes run", async () => {
@@ -298,6 +358,38 @@ describe("completion-validators", () => {
     expect(result.exhaustedDetail).toContain(
       "made no successful workspace mutations",
     );
+  });
+
+  it("uses the shared correction budget for filesystem artifact recovery", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "filesystem-budget-"));
+    const missingPath = join(workspaceRoot, "src/main.c");
+    const validators = buildCompletionValidators({
+      ctx: makeCtx({
+        finalContent: "Implementation complete. All phases implemented.",
+        allToolCalls: [
+          {
+            name: "system.writeFile",
+            args: { path: missingPath, content: "phase 1" },
+            result: JSON.stringify({ ok: true, path: missingPath }),
+            isError: false,
+            durationMs: 1,
+          },
+        ],
+        requiredToolEvidence: {
+          maxCorrectionAttempts: 3,
+        },
+      }),
+      runtimeContractFlags: makeFlags(),
+    });
+
+    const filesystem = validators.find(
+      (validator) => validator.id === "filesystem_artifact_verification",
+    );
+    const result = await filesystem!.execute();
+
+    expect(result.outcome).toBe("retry_with_blocking_message");
+    expect(result.maxAttempts).toBe(3);
+    expect(result.blockingMessage).toContain("bounded recovery loop");
   });
 
   it("runs the top-level verifier even when runtimeContractV2 is false", async () => {

--- a/runtime/src/llm/completion-validators.ts
+++ b/runtime/src/llm/completion-validators.ts
@@ -45,6 +45,12 @@ export function buildCompletionValidators(params: {
   readonly stopHookRuntime?: StopHookRuntime;
   readonly completionValidation?: ChatExecutorConfig["completionValidation"];
 }): readonly CompletionValidator[] {
+  const sharedCorrectionBudget =
+    params.ctx.requiredToolEvidence?.maxCorrectionAttempts ?? 1;
+  const stopHookRetryBudget = Math.max(
+    sharedCorrectionBudget,
+    params.stopHookRuntime?.maxAttempts ?? 1,
+  );
   const topLevelVerifierEnabled =
     params.runtimeContractFlags.verifierRuntimeRequired;
   const deterministicAcceptanceProbesEnabled =
@@ -94,7 +100,7 @@ export function buildCompletionValidators(params: {
               reason: hookResult.reason ?? "verification_ready",
               blockingMessage: hookResult.blockingMessage,
               evidence: hookResult.evidence,
-              maxAttempts: params.stopHookRuntime?.maxAttempts ?? 1,
+              maxAttempts: stopHookRetryBudget,
               exhaustedDetail:
                 "Verification-ready recovery exhausted after stop-hook intervention.",
               stopHookResult: hookResult,
@@ -192,7 +198,7 @@ export function buildCompletionValidators(params: {
             reason: hookResult.reason ?? "turn_end_stop_gate",
             blockingMessage: hookResult.blockingMessage,
             evidence: hookResult.evidence,
-            maxAttempts: params.stopHookRuntime.maxAttempts,
+            maxAttempts: stopHookRetryBudget,
             exhaustedDetail:
               hookResult.reason === "narrated_future_tool_work"
                 ? "Stop-gate recovery exhausted: the model kept narrating future work instead of calling tools."
@@ -213,7 +219,7 @@ export function buildCompletionValidators(params: {
           reason: decision.reason ?? "turn_end_stop_gate",
           blockingMessage: decision.blockingMessage,
           evidence: decision.evidence,
-          maxAttempts: 1,
+          maxAttempts: sharedCorrectionBudget,
           exhaustedDetail:
             decision.reason === "narrated_future_tool_work"
               ? "Stop-gate recovery exhausted: the model kept narrating future work instead of calling tools."
@@ -247,8 +253,7 @@ export function buildCompletionValidators(params: {
           return { id: "request_task_progress", outcome: "pass" };
         }
 
-        const maxAttempts =
-          params.ctx.requiredToolEvidence?.maxCorrectionAttempts ?? 1;
+        const maxAttempts = sharedCorrectionBudget;
         if (hasMalformedTaskMetadata) {
           const allowedIds = requestTaskState.allowedMilestones.map(
             (milestone) => milestone.id,
@@ -360,7 +365,7 @@ export function buildCompletionValidators(params: {
             missingFiles: check.missingFiles,
             checkedFiles: check.checkedFiles,
           },
-          maxAttempts: 1,
+          maxAttempts: sharedCorrectionBudget,
           exhaustedDetail:
             "Filesystem artifact verification failed after recovery; missing or empty artifacts remain on disk.",
         };
@@ -469,7 +474,7 @@ export function buildCompletionValidators(params: {
           outcome: validation.outcome,
           reason: "top_level_verifier",
           blockingMessage: validation.blockingMessage,
-          maxAttempts: params.ctx.requiredToolEvidence?.maxCorrectionAttempts ?? 1,
+          maxAttempts: sharedCorrectionBudget,
           exhaustedDetail: validation.exhaustedDetail,
           verifier: validation.runtimeVerifier,
           verifierTaskId: validation.taskId,


### PR DESCRIPTION
## Summary
- let stop-gate recoveries inherit the same bounded correction budget as coding turns
- remove remaining one-shot recovery wording and copy Claude-style direct-resume nudges
- cover fallback, stop-hook, filesystem-artifact, and executor recovery paths with tests

## Testing
- npm --prefix runtime run typecheck
- cd runtime && npx vitest run src/llm/completion-validators.test.ts src/llm/chat-executor-stop-gate.test.ts src/llm/chat-executor-artifact-evidence.test.ts src/llm/chat-executor.test.ts src/llm/chat-executor-request.test.ts