### PR TITLE
fix(watch): recover bootstrap from stale session resumes

### DIFF
--- a/runtime/src/watch/agenc-watch-session-utils.mjs
+++ b/runtime/src/watch/agenc-watch-session-utils.mjs
@@ -314,12 +314,21 @@ export function latestSessionSummary(
   if (!Array.isArray(payload) || payload.length === 0) {
     return null;
   }
+  const resumableSessions = payload.filter((session) => {
+    const resumabilityState = String(session?.resumabilityState ?? "").trim();
+    return (
+      !resumabilityState ||
+      resumabilityState === "active" ||
+      resumabilityState === "disconnected-resumable"
+    );
+  });
+  const eligibleSessions = resumableSessions.length > 0 ? resumableSessions : payload;
   const sameWorkspaceSessions =
     typeof preferredWorkspaceRoot === "string" && preferredWorkspaceRoot
-      ? payload.filter(
+      ? eligibleSessions.filter(
           (session) => session?.workspaceRoot === preferredWorkspaceRoot,
         )
-      : payload;
+      : eligibleSessions;
   if (preferredSessionId) {
     const preferred = sameWorkspaceSessions.find(
       (session) => session?.sessionId === preferredSessionId,
@@ -339,7 +348,7 @@ export function latestSessionSummary(
     return null;
   }
   const candidateSessions =
-    sameWorkspaceSessions.length > 0 ? sameWorkspaceSessions : payload;
+    sameWorkspaceSessions.length > 0 ? sameWorkspaceSessions : eligibleSessions;
   return [...candidateSessions].sort((left, right) => {
     const leftMessageCount = Number(left?.messageCount ?? 0);
     const rightMessageCount = Number(right?.messageCount ?? 0);

--- a/runtime/src/watch/agenc-watch-surface-dispatch.mjs
+++ b/runtime/src/watch/agenc-watch-surface-dispatch.mjs
@@ -1072,20 +1072,29 @@ function handleErrorSurfaceEvent(surfaceEvent, rawMessage, state, api) {
   }
   if (
     (errorMessage === "Not authorized to access this session" || isStaleSessionMissing) &&
-    !state.bootstrapReady &&
-    typeof state.sessionId === "string" &&
-    state.sessionId.trim().length > 0
+    !state.bootstrapReady
   ) {
+    const hadRememberedSession =
+      typeof state.sessionId === "string" && state.sessionId.trim().length > 0;
     state.sessionId = null;
     state.cockpit = null;
     state.cockpitUpdatedAt = 0;
     state.cockpitFingerprint = null;
     api.persistSessionId(null);
-    api.scheduleBootstrap(
-      isStaleSessionMissing
-        ? "stale session missing; retrying bootstrap"
-        : "stale session authorization failed",
-    );
+    if (hadRememberedSession) {
+      api.scheduleBootstrap(
+        isStaleSessionMissing
+          ? "stale session missing; retrying bootstrap"
+          : "stale session authorization failed",
+      );
+    } else {
+      api.setTransientStatus(
+        isStaleSessionMissing
+          ? "bootstrap resume failed; starting a new session"
+          : "bootstrap authorization failed; starting a new session",
+      );
+      api.send("chat.new", api.authPayload());
+    }
     return true;
   }
   api.eventStore.cancelAgentStream("error");

--- a/runtime/tests/watch/agenc-watch-app.test.mjs
+++ b/runtime/tests/watch/agenc-watch-app.test.mjs
@@ -196,6 +196,33 @@ test("latestSessionSummary prefers sessions from the current workspace root", ()
   assert.equal(selected?.sessionId, "session-same");
 });
 
+test("latestSessionSummary skips non-resumable and missing-workspace sessions when resumable options exist", () => {
+  const payload = [
+    {
+      sessionId: "session-missing",
+      workspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
+      messageCount: 20,
+      lastActiveAt: 300,
+      resumabilityState: "missing-workspace",
+    },
+    {
+      sessionId: "session-live",
+      workspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
+      messageCount: 5,
+      lastActiveAt: 200,
+      resumabilityState: "disconnected-resumable",
+    },
+  ];
+
+  const selected = latestSessionSummary(
+    payload,
+    null,
+    "/home/tetsuo/git/stream-test/agenc-shell",
+  );
+
+  assert.equal(selected?.sessionId, "session-live");
+});
+
 test("resolveWatchMouseTrackingEnabled defaults on so the wheel scrolls the in-app transcript", () => {
   // Default ON: empty env, missing var, and explicit truthy values all
   // enable mouse tracking. Without it, wheel events fall through to the

--- a/runtime/tests/watch/agenc-watch-surface-dispatch.test.mjs
+++ b/runtime/tests/watch/agenc-watch-surface-dispatch.test.mjs
@@ -1296,6 +1296,36 @@ test("dispatchOperatorSurfaceEvent clears stale missing sessions during bootstra
   ]);
 });
 
+test("dispatchOperatorSurfaceEvent starts a new session when bootstrap resume fails without a remembered session", () => {
+  const { api, state, calls } = createHarness({
+    state: {
+      sessionId: null,
+      bootstrapReady: false,
+    },
+  });
+
+  dispatchOperatorSurfaceEvent(
+    {
+      family: "error",
+      type: "error",
+      payload: {},
+      payloadRecord: {},
+      payloadList: null,
+      isSessionScoped: false,
+      message: { error: 'Session "session:stale-bootstrap-target" not found' },
+    },
+    null,
+    api,
+  );
+
+  assert.equal(state.sessionId, null);
+  assert.deepEqual(calls, [
+    ["persistSessionId", null],
+    ["status", "bootstrap resume failed; starting a new session"],
+    ["send", "chat.new", { auth: true }],
+  ]);
+});
+
 test("dispatchOperatorSurfaceEvent records unavailable durable-run operator errors", () => {
   const { api, state, calls } = createHarness();
 


### PR DESCRIPTION
## Summary
- stop watch bootstrap from auto-resuming non-resumable continuity records
- fall back to chat.new when bootstrap resume fails without a remembered session
- cover stale bootstrap resume recovery in watch tests

## Testing
- cd runtime && node --test tests/watch/agenc-watch-app.test.mjs tests/watch/agenc-watch-surface-dispatch.test.mjs tests/watch/agenc-watch-transport.test.mjs
- npm --prefix runtime run typecheck