### PR TITLE
fix(webchat): recover stale implicit console sessions

### DIFF
--- a/runtime/src/channels/webchat/plugin.test.ts
+++ b/runtime/src/channels/webchat/plugin.test.ts
@@ -482,6 +482,79 @@ describe("WebChatChannel", () => {
       });
     });
 
+    it("rebinds a stale implicit session before executing commands", async () => {
+      const send = vi.fn<(response: ControlResponse) => void>();
+      const registry = new SlashCommandRegistry({ logger: silentLogger });
+      registry.register({
+        name: "session",
+        description: "structured session test",
+        global: true,
+        metadata: { viewKind: "session", clients: ["console"], category: "session" },
+        handler: async (ctx) => {
+          await ctx.replyResult({
+            text: `Recovered session ${ctx.sessionId}`,
+            viewKind: "session",
+            data: {
+              kind: "session",
+              subcommand: "status",
+              currentSession: {
+                sessionId: ctx.sessionId,
+              },
+            },
+          });
+        },
+      });
+      const memoryBackend = new InMemoryBackend();
+      const channel = new WebChatChannel(
+        createDeps({ commandRegistry: registry, memoryBackend }),
+      );
+      await channel.initialize(createContext());
+      await channel.start();
+
+      (
+        channel as unknown as {
+          clientOwnerKeys: Map<string, string>;
+          clientSessions: Map<string, string>;
+        }
+      ).clientOwnerKeys.set("client_1", "owner:test");
+      (
+        channel as unknown as {
+          clientOwnerKeys: Map<string, string>;
+          clientSessions: Map<string, string>;
+        }
+      ).clientSessions.set("client_1", "session:stale-bound");
+
+      channel.handleMessage(
+        "client_1",
+        "session.command.execute",
+        msg(
+          "session.command.execute",
+          {
+            content: "/session",
+            client: "console",
+          },
+          "cmd-stale-bound",
+        ),
+        send,
+      );
+
+      await vi.waitFor(() => {
+        expect(findResponse(send, "error", "cmd-stale-bound")).toBeUndefined();
+        expect(findResponse(send, "session.command.result", "cmd-stale-bound")?.payload)
+          .toMatchObject({
+            commandName: "session",
+            viewKind: "session",
+            data: {
+              kind: "session",
+              subcommand: "status",
+              currentSession: {
+                sessionId: expect.not.stringContaining("session:stale-bound"),
+              },
+            },
+          });
+      });
+    });
+
     it("builds the command catalog with session policy scope and effective profile coercion", async () => {
       const memoryBackend = new InMemoryBackend();
       const registry = new SlashCommandRegistry({ logger: silentLogger });

--- a/runtime/src/channels/webchat/plugin.ts
+++ b/runtime/src/channels/webchat/plugin.ts
@@ -1355,6 +1355,10 @@ export class WebChatChannel
     const request = (payload ?? {}) as unknown as SessionCommandExecutePayload;
     const content =
       typeof request.content === "string" ? request.content.trim() : "";
+    const requestedSessionId =
+      typeof request.sessionId === "string" && request.sessionId.trim().length > 0
+        ? request.sessionId.trim()
+        : null;
     if (!content.startsWith("/")) {
       send({
         type: "error",
@@ -1373,18 +1377,24 @@ export class WebChatChannel
       return;
     }
 
-    let targetSessionId =
-      typeof request.sessionId === "string" && request.sessionId.trim().length > 0
-        ? request.sessionId.trim()
-        : this.clientSessions.get(clientId);
+    let targetSessionId = requestedSessionId ?? this.clientSessions.get(clientId);
     if (!targetSessionId) {
       targetSessionId = this.ensureSession(clientId, ownerKey);
     }
-    const authorized = await this.isAuthorizedSession(
+    let authorized = await this.isAuthorizedSession(
       targetSessionId,
       ownerKey,
       clientId,
     );
+    if (!authorized && !requestedSessionId) {
+      this.clearClientSessionBinding(clientId, targetSessionId);
+      targetSessionId = this.ensureSession(clientId, ownerKey);
+      authorized = await this.isAuthorizedSession(
+        targetSessionId,
+        ownerKey,
+        clientId,
+      );
+    }
     if (!authorized) {
       send({
         type: "error",
@@ -1730,6 +1740,14 @@ export class WebChatChannel
     this.clientSessions.set(clientId, sessionId);
     this.sessionClients.set(sessionId, clientId);
     this.sessionOwners.set(sessionId, ownerKey);
+  }
+
+  private clearClientSessionBinding(clientId: string, sessionId?: string): void {
+    const boundSessionId = sessionId ?? this.clientSessions.get(clientId);
+    if (boundSessionId) {
+      this.sessionClients.delete(boundSessionId);
+    }
+    this.clientSessions.delete(clientId);
   }
 
   private buildSeenMessageKey(ownerKey: string, messageId: string): string {


### PR DESCRIPTION
## Summary
- recover `session.command.execute` when the console is implicitly bound to a stale webchat session
- mint a fresh implicit session instead of surfacing another missing-session bootstrap error
- add coverage for the exact stale-bound-session path seen in daemon logs

## Verification
- `cd runtime && npx vitest run src/channels/webchat/plugin.test.ts`
- `cd runtime && node --test tests/watch/agenc-watch-surface-dispatch.test.mjs tests/watch/agenc-watch-app.test.mjs`
- `cd runtime && npm run typecheck`
- `cd runtime && npm run build`
- local smoke: `agenc console` from `stream-test/agenc-shell` reaches `Ready` instead of looping on `session bootstrap not complete`
