### PR TITLE
fix(runtime): align continuation controller with claude loop

### DIFF
--- a/runtime/src/gateway/subagent-query.test.ts
+++ b/runtime/src/gateway/subagent-query.test.ts
@@ -184,4 +184,72 @@ describe("runSubagentToLegacyResult (Phase K)", () => {
       }),
     ).rejects.toThrow();
   });
+
+  it("preserves shared continuation behavior for subagent turns", async () => {
+    const provider: LLMProvider = {
+      name: "mock-subagent-provider",
+      chat: vi
+        .fn<[LLMMessage[], LLMChatOptions?], Promise<LLMResponse>>()
+        .mockResolvedValueOnce({
+          content: "",
+          toolCalls: [
+            { id: "tc-1", name: "system.listDir", arguments: '{"path":"."}' },
+          ],
+          usage: { promptTokens: 20, completionTokens: 50, totalTokens: 70 },
+          model: "mock-model",
+          finishReason: "tool_calls",
+        })
+        .mockResolvedValueOnce({
+          content: "Next I will continue with the remaining work.",
+          toolCalls: [],
+          usage: { promptTokens: 20, completionTokens: 100, totalTokens: 120 },
+          model: "mock-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content: "Bootstrap complete. Continuing.",
+          toolCalls: [],
+          usage: { promptTokens: 20, completionTokens: 100, totalTokens: 120 },
+          model: "mock-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content: "Subagent finished the remaining work.",
+          toolCalls: [],
+          usage: { promptTokens: 20, completionTokens: 1_900, totalTokens: 1_920 },
+          model: "mock-model",
+          finishReason: "stop",
+        }),
+      chatStream: vi
+        .fn<
+          [LLMMessage[], StreamProgressCallback, LLMChatOptions?],
+          Promise<LLMResponse>
+        >()
+        .mockRejectedValue(new Error("unused")),
+      healthCheck: vi.fn<[], Promise<boolean>>().mockResolvedValue(true),
+    };
+    const executor = new ChatExecutor({
+      providers: [provider],
+      toolHandler: vi.fn(async () => '{"ok":true}'),
+    });
+
+    const result = await runSubagentToLegacyResult(executor, {
+      sessionId: "continued-child",
+      params: {
+        message: makeMessage("continue the task"),
+        history: [],
+        systemPrompt: "System",
+        sessionId: "continued-child",
+      },
+    });
+
+    expect(result.legacyResult?.content).toBe("Subagent finished the remaining work.");
+    expect(result.legacyResult?.callUsage.map((entry) => entry.phase)).toEqual([
+      "initial",
+      "tool_followup",
+      "tool_followup",
+      "tool_followup",
+    ]);
+    expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(4);
+  });
 });

--- a/runtime/src/llm/chat-executor-artifact-evidence.test.ts
+++ b/runtime/src/llm/chat-executor-artifact-evidence.test.ts
@@ -223,7 +223,7 @@ describe("top-level artifact evidence gate", () => {
     expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
   });
 
-  it("fails closed when stop-gate recovery is spent on another text-only completion claim", async () => {
+  it("fails closed when an explicit correction cap is spent on another text-only completion claim", async () => {
     const provider = createMockProvider("primary", {
       chat: vi
         .fn<[LLMMessage[], LLMChatOptions?], Promise<LLMResponse>>()
@@ -261,12 +261,93 @@ describe("top-level artifact evidence gate", () => {
     );
     const executor = new ChatExecutor({ providers: [provider], toolHandler });
 
-    const result = await executor.execute(createParams());
+    const result = await executor.execute(
+      createParams({
+        requiredToolEvidence: {
+          maxCorrectionAttempts: 1,
+        },
+      }),
+    );
 
     expect(result.stopReason).toBe("validation_error");
     expect(result.content).toContain("Stop-gate recovery exhausted");
     expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(3);
     expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls[2]?.[1]).toMatchObject({
+      toolChoice: "required",
+    });
+  });
+
+  it("exhausts repeated narration-only recoveries after three non-productive continuations", async () => {
+    const provider = createMockProvider("primary", {
+      chat: vi
+        .fn<[LLMMessage[], LLMChatOptions?], Promise<LLMResponse>>()
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "",
+            finishReason: "tool_calls",
+            toolCalls: [
+              {
+                id: "tc-1",
+                name: "system.bash",
+                arguments: safeJson({
+                  command: "make",
+                  args: [],
+                }),
+              },
+            ],
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "Build succeeded and all phases were fully implemented.",
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "Next I will fix the build and write the remaining files.",
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "I will now update the failing source files and rerun the build.",
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "I will now update the failing source files and rerun the build.",
+          }),
+        ),
+    });
+    const toolHandler = vi.fn(async (name: string) =>
+      name === "system.bash"
+        ? safeJson({ exitCode: 2, stdout: "", stderr: "link failed" })
+        : safeJson({ ok: true }),
+    );
+    const executor = new ChatExecutor({ providers: [provider], toolHandler });
+
+    const result = await executor.execute(
+      createParams({
+        runtimeContext: {
+          workspaceRoot: WORKSPACE_ROOT,
+        },
+        requiredToolEvidence: {
+          maxCorrectionAttempts: 3,
+        },
+      }),
+    );
+
+    expect(result.stopReason).toBe("validation_error");
+    expect(result.content).toContain("Stop-gate recovery exhausted");
+    expect(result.toolCalls.filter((call) => call.name === "system.bash")).toHaveLength(1);
+    expect(result.toolCalls.filter((call) => call.name === "system.writeFile")).toHaveLength(0);
+    expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(5);
+    expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls[2]?.[1]).toMatchObject({
+      toolChoice: "required",
+    });
+    expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls[3]?.[1]).toMatchObject({
+      toolChoice: "required",
+    });
+    expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls[4]?.[1]).toMatchObject({
       toolChoice: "required",
     });
   });

--- a/runtime/src/llm/chat-executor-continuation.test.ts
+++ b/runtime/src/llm/chat-executor-continuation.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  checkTurnContinuationBudget,
+  countTurnCompletionTokens,
   createTurnContinuationState,
   finishTurnContinuation,
   shouldStopForDiminishingReturns,
@@ -120,5 +122,90 @@ describe("chat-executor-continuation", () => {
     expect(ctx.continuationState.continuationCount).toBe(3);
     expect(ctx.continuationState.consecutiveLowProgressStalls).toBe(3);
     expect(shouldStopForDiminishingReturns(ctx.continuationState)).toBe(true);
+  });
+
+  it("continues while the turn stays below the token budget threshold", () => {
+    const ctx = makeCtx({
+      callUsage: [makeCallUsageRecord(300)],
+    });
+
+    const decision = checkTurnContinuationBudget({
+      state: ctx.continuationState,
+      budget: 1_000,
+      globalTurnTokens: countTurnCompletionTokens(ctx.callUsage),
+      eligible: true,
+    });
+
+    expect(decision.action).toBe("continue");
+    if (decision.action !== "continue") {
+      throw new Error("Expected continuation");
+    }
+    expect(decision.continuationCount).toBe(1);
+    expect(decision.turnTokens).toBe(300);
+    expect(ctx.continuationState.budget.lastGlobalOutputTokens).toBe(300);
+  });
+
+  it("stops token-budget continuation after repeated low-delta continuations", () => {
+    const ctx = makeCtx();
+
+    let globalTurnTokens = 100;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const decision = checkTurnContinuationBudget({
+        state: ctx.continuationState,
+        budget: 2_000,
+        globalTurnTokens,
+        eligible: true,
+      });
+      expect(decision.action).toBe("continue");
+      globalTurnTokens += 100;
+    }
+
+    const stopDecision = checkTurnContinuationBudget({
+      state: ctx.continuationState,
+      budget: 2_000,
+      globalTurnTokens,
+      eligible: true,
+    });
+
+    expect(stopDecision.action).toBe("stop");
+    if (stopDecision.action !== "stop") {
+      throw new Error("Expected stop");
+    }
+    expect(stopDecision.completionEvent?.diminishingReturns).toBe(true);
+    expect(stopDecision.completionEvent?.continuationCount).toBe(3);
+  });
+
+  it("keeps token-budget stalls from poisoning validator recovery diminishing returns", () => {
+    const ctx = makeCtx();
+
+    const budgetDecision = checkTurnContinuationBudget({
+      state: ctx.continuationState,
+      budget: 2_000,
+      globalTurnTokens: 100,
+      eligible: true,
+    });
+    expect(budgetDecision.action).toBe("continue");
+    if (budgetDecision.action !== "continue") {
+      throw new Error("Expected token-budget continuation");
+    }
+
+    startTurnContinuation({
+      state: ctx.continuationState,
+      ctx,
+      reason: "token_budget",
+    });
+    finishTurnContinuation({ state: ctx.continuationState, ctx });
+
+    startTurnContinuation({
+      state: ctx.continuationState,
+      ctx,
+      reason: "validator",
+      validatorId: "deterministic_acceptance_probes",
+    });
+    finishTurnContinuation({ state: ctx.continuationState, ctx });
+
+    expect(ctx.continuationState.continuationCount).toBe(1);
+    expect(ctx.continuationState.consecutiveLowProgressStalls).toBe(1);
+    expect(shouldStopForDiminishingReturns(ctx.continuationState)).toBe(false);
   });
 });

--- a/runtime/src/llm/chat-executor-continuation.test.ts
+++ b/runtime/src/llm/chat-executor-continuation.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createTurnContinuationState,
+  finishTurnContinuation,
+  shouldStopForDiminishingReturns,
+  startTurnContinuation,
+} from "./chat-executor-continuation.js";
+import type {
+  ChatCallUsageRecord,
+  ExecutionContext,
+  ToolCallRecord,
+} from "./chat-executor-types.js";
+
+function makeCallUsageRecord(
+  completionTokens: number,
+): ChatCallUsageRecord {
+  return {
+    callIndex: 1,
+    phase: "tool_followup",
+    provider: "test",
+    model: "test-model",
+    finishReason: "stop",
+    usage: {
+      promptTokens: 10,
+      completionTokens,
+      totalTokens: completionTokens + 10,
+    },
+    durationMs: 1,
+    beforeBudget: { tokens: 0, messages: 0, toolSchemas: 0 },
+    afterBudget: { tokens: 0, messages: 0, toolSchemas: 0 },
+  };
+}
+
+function makeToolCall(overrides: Partial<ToolCallRecord> = {}): ToolCallRecord {
+  return {
+    name: "system.writeFile",
+    args: { path: "src/main.c", content: "ok" },
+    result: JSON.stringify({ ok: true }),
+    isError: false,
+    durationMs: 1,
+    ...overrides,
+  };
+}
+
+function makeCtx(params: {
+  readonly callUsage?: readonly ChatCallUsageRecord[];
+  readonly allToolCalls?: readonly ToolCallRecord[];
+} = {}): ExecutionContext {
+  return {
+    callUsage: [...(params.callUsage ?? [])],
+    allToolCalls: [...(params.allToolCalls ?? [])],
+    continuationState: createTurnContinuationState(),
+  } as unknown as ExecutionContext;
+}
+
+describe("chat-executor-continuation", () => {
+  it("treats real tool activity as productive continuation progress", () => {
+    const ctx = makeCtx();
+    const active = startTurnContinuation({
+      state: ctx.continuationState,
+      ctx,
+      reason: "turn_end_stop_gate",
+      validatorId: "turn_end_stop_gate",
+    });
+
+    ctx.allToolCalls.push(makeToolCall());
+
+    const summary = finishTurnContinuation({
+      state: ctx.continuationState,
+      ctx,
+    });
+
+    expect(active.attempt).toBe(1);
+    expect(summary?.productive).toBe(true);
+    expect(summary?.toolCallsIssued).toBe(true);
+    expect(summary?.successfulWorkspaceMutation).toBe(true);
+    expect(ctx.continuationState.consecutiveLowProgressStalls).toBe(0);
+  });
+
+  it("flags low-progress narration-only continuation cycles", () => {
+    const ctx = makeCtx();
+    startTurnContinuation({
+      state: ctx.continuationState,
+      ctx,
+      reason: "artifact_evidence",
+      validatorId: "artifact_evidence",
+    });
+
+    ctx.callUsage.push(makeCallUsageRecord(120));
+
+    const summary = finishTurnContinuation({
+      state: ctx.continuationState,
+      ctx,
+    });
+
+    expect(summary?.productive).toBe(false);
+    expect(summary?.lowProgressStall).toBe(true);
+    expect(summary?.outputTokenDelta).toBe(120);
+    expect(ctx.continuationState.consecutiveLowProgressStalls).toBe(1);
+  });
+
+  it("stops for diminishing returns after three low-progress continuation cycles", () => {
+    const ctx = makeCtx();
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      startTurnContinuation({
+        state: ctx.continuationState,
+        ctx,
+        reason: "turn_end_stop_gate",
+        validatorId: "turn_end_stop_gate",
+      });
+      ctx.callUsage.push(makeCallUsageRecord(100));
+      finishTurnContinuation({
+        state: ctx.continuationState,
+        ctx,
+      });
+    }
+
+    expect(ctx.continuationState.continuationCount).toBe(3);
+    expect(ctx.continuationState.consecutiveLowProgressStalls).toBe(3);
+    expect(shouldStopForDiminishingReturns(ctx.continuationState)).toBe(true);
+  });
+});

--- a/runtime/src/llm/chat-executor-continuation.ts
+++ b/runtime/src/llm/chat-executor-continuation.ts
@@ -12,6 +12,7 @@ import {
 
 const LOW_PROGRESS_TOKEN_DELTA = 500;
 const MIN_DIMINISHING_RETURNS_CONTINUATIONS = 3;
+const CONTINUATION_COMPLETION_THRESHOLD = 0.9;
 
 const SUCCESSFUL_MUTATION_TOOL_NAMES = new Set([
   "system.applyPatch",
@@ -47,12 +48,51 @@ export interface TurnContinuationCycleSummary {
   readonly lowProgressStall: boolean;
 }
 
-export interface TurnContinuationState {
+export interface TurnContinuationBudgetState {
   continuationCount: number;
+  lastDeltaTokens: number;
+  lastGlobalOutputTokens: number;
+  readonly startedAt: number;
+}
+
+export interface TurnContinuationBudgetCompletionEvent {
+  readonly continuationCount: number;
+  readonly pct: number;
+  readonly turnTokens: number;
+  readonly budget: number;
+  readonly diminishingReturns: boolean;
+  readonly durationMs: number;
+}
+
+export type TurnContinuationBudgetDecision =
+  | {
+      readonly action: "continue";
+      readonly nudgeMessage: string;
+      readonly continuationCount: number;
+      readonly pct: number;
+      readonly turnTokens: number;
+      readonly budget: number;
+    }
+  | {
+      readonly action: "stop";
+      readonly completionEvent: TurnContinuationBudgetCompletionEvent | null;
+    };
+
+export interface TurnContinuationState {
+  /**
+   * Recovery continuation attempts only. Token-budget continuation keeps its own
+   * separate tracker so low-budget nudges do not poison validator recovery caps.
+   */
+  continuationCount: number;
+  /**
+   * Recovery continuation low-progress streak only. Token-budget continuation
+   * uses its own diminishing-returns tracker.
+   */
   consecutiveLowProgressStalls: number;
   lastContinuationReason?: string;
   active?: TurnContinuationActiveState;
   readonly history: TurnContinuationCycleSummary[];
+  readonly budget: TurnContinuationBudgetState;
 }
 
 export function createTurnContinuationState(): TurnContinuationState {
@@ -60,6 +100,16 @@ export function createTurnContinuationState(): TurnContinuationState {
     continuationCount: 0,
     consecutiveLowProgressStalls: 0,
     history: [],
+    budget: createTurnContinuationBudgetState(),
+  };
+}
+
+export function createTurnContinuationBudgetState(): TurnContinuationBudgetState {
+  return {
+    continuationCount: 0,
+    lastDeltaTokens: 0,
+    lastGlobalOutputTokens: 0,
+    startedAt: Date.now(),
   };
 }
 
@@ -70,7 +120,10 @@ export function startTurnContinuation(params: {
   readonly validatorId?: CompletionValidatorId;
   readonly tighterCap?: number;
 }): TurnContinuationActiveState {
-  const attempt = params.state.continuationCount + 1;
+  const attempt =
+    params.reason === "token_budget"
+      ? params.state.budget.continuationCount
+      : params.state.continuationCount + 1;
   const active: TurnContinuationActiveState = {
     reason: params.reason,
     validatorId: params.validatorId,
@@ -81,7 +134,9 @@ export function startTurnContinuation(params: {
     baselineToolCallIndex: params.ctx.allToolCalls.length,
     baselineDiagnosticFingerprint: buildDiagnosticFingerprint(params.ctx),
   };
-  params.state.continuationCount = attempt;
+  if (params.reason !== "token_budget") {
+    params.state.continuationCount = attempt;
+  }
   params.state.lastContinuationReason = params.reason;
   params.state.active = active;
   return active;
@@ -135,9 +190,11 @@ export function finishTurnContinuation(params: {
     lowProgressStall,
   };
   params.state.history.push(summary);
-  params.state.consecutiveLowProgressStalls = lowProgressStall
-    ? params.state.consecutiveLowProgressStalls + 1
-    : 0;
+  if (active.reason !== "token_budget") {
+    params.state.consecutiveLowProgressStalls = lowProgressStall
+      ? params.state.consecutiveLowProgressStalls + 1
+      : 0;
+  }
   params.state.active = undefined;
   return summary;
 }
@@ -149,6 +206,79 @@ export function shouldStopForDiminishingReturns(
     state.continuationCount >= MIN_DIMINISHING_RETURNS_CONTINUATIONS &&
     state.consecutiveLowProgressStalls >= 2
   );
+}
+
+export function countTurnCompletionTokens(
+  callUsage: readonly ChatCallUsageRecord[],
+): number {
+  return countCompletionTokensSince(callUsage, 0);
+}
+
+export function checkTurnContinuationBudget(params: {
+  readonly state: TurnContinuationState;
+  readonly budget: number | null;
+  readonly globalTurnTokens: number;
+  readonly eligible: boolean;
+}): TurnContinuationBudgetDecision {
+  if (!params.eligible || params.budget === null || params.budget <= 0) {
+    return { action: "stop", completionEvent: null };
+  }
+
+  const tracker = params.state.budget;
+  const turnTokens = params.globalTurnTokens;
+  const pct = Math.round((turnTokens / params.budget) * 100);
+  const deltaSinceLastCheck =
+    params.globalTurnTokens - tracker.lastGlobalOutputTokens;
+  const isDiminishing =
+    tracker.continuationCount >= MIN_DIMINISHING_RETURNS_CONTINUATIONS &&
+    deltaSinceLastCheck < LOW_PROGRESS_TOKEN_DELTA &&
+    tracker.lastDeltaTokens < LOW_PROGRESS_TOKEN_DELTA;
+
+  if (!isDiminishing && turnTokens < params.budget * CONTINUATION_COMPLETION_THRESHOLD) {
+    tracker.continuationCount += 1;
+    tracker.lastDeltaTokens = deltaSinceLastCheck;
+    tracker.lastGlobalOutputTokens = params.globalTurnTokens;
+    return {
+      action: "continue",
+      nudgeMessage: buildTurnContinuationBudgetMessage(
+        pct,
+        turnTokens,
+        params.budget,
+      ),
+      continuationCount: tracker.continuationCount,
+      pct,
+      turnTokens,
+      budget: params.budget,
+    };
+  }
+
+  if (isDiminishing || tracker.continuationCount > 0) {
+    return {
+      action: "stop",
+      completionEvent: {
+        continuationCount: tracker.continuationCount,
+        pct,
+        turnTokens,
+        budget: params.budget,
+        diminishingReturns: isDiminishing,
+        durationMs: Date.now() - tracker.startedAt,
+      },
+    };
+  }
+
+  return { action: "stop", completionEvent: null };
+}
+
+export function buildTurnContinuationBudgetMessage(
+  pct: number,
+  turnTokens: number,
+  budget: number,
+): string {
+  const format = (value: number): string =>
+    new Intl.NumberFormat("en-US").format(value);
+  return `Stopped at ${pct}% of token target (${format(turnTokens)} / ${format(
+    budget,
+  )}). Keep working - do not summarize.`;
 }
 
 export function buildDiagnosticFingerprint(ctx: ExecutionContext): string {

--- a/runtime/src/llm/chat-executor-continuation.ts
+++ b/runtime/src/llm/chat-executor-continuation.ts
@@ -1,0 +1,177 @@
+import type {
+  CompletionValidatorId,
+} from "../runtime-contract/types.js";
+import type {
+  ChatCallUsageRecord,
+  ExecutionContext,
+} from "./chat-executor-types.js";
+import {
+  didToolCallFail,
+  extractToolFailureText,
+} from "./chat-executor-tool-utils.js";
+
+const LOW_PROGRESS_TOKEN_DELTA = 500;
+const MIN_DIMINISHING_RETURNS_CONTINUATIONS = 3;
+
+const SUCCESSFUL_MUTATION_TOOL_NAMES = new Set([
+  "system.applyPatch",
+  "system.appendFile",
+  "system.editFile",
+  "system.mkdir",
+  "system.move",
+  "system.writeFile",
+  "desktop.text_editor",
+]);
+
+export interface TurnContinuationActiveState {
+  readonly reason: string;
+  readonly validatorId?: CompletionValidatorId;
+  readonly startedAt: number;
+  readonly attempt: number;
+  readonly tighterCap?: number;
+  readonly baselineCallUsageIndex: number;
+  readonly baselineToolCallIndex: number;
+  readonly baselineDiagnosticFingerprint: string;
+}
+
+export interface TurnContinuationCycleSummary {
+  readonly reason: string;
+  readonly validatorId?: CompletionValidatorId;
+  readonly attempt: number;
+  readonly outputTokenDelta: number;
+  readonly toolCallsIssued: boolean;
+  readonly successfulWorkspaceMutation: boolean;
+  readonly diagnosticFingerprintChanged: boolean;
+  readonly materiallyIncreasedOutput: boolean;
+  readonly productive: boolean;
+  readonly lowProgressStall: boolean;
+}
+
+export interface TurnContinuationState {
+  continuationCount: number;
+  consecutiveLowProgressStalls: number;
+  lastContinuationReason?: string;
+  active?: TurnContinuationActiveState;
+  readonly history: TurnContinuationCycleSummary[];
+}
+
+export function createTurnContinuationState(): TurnContinuationState {
+  return {
+    continuationCount: 0,
+    consecutiveLowProgressStalls: 0,
+    history: [],
+  };
+}
+
+export function startTurnContinuation(params: {
+  readonly state: TurnContinuationState;
+  readonly ctx: ExecutionContext;
+  readonly reason: string;
+  readonly validatorId?: CompletionValidatorId;
+  readonly tighterCap?: number;
+}): TurnContinuationActiveState {
+  const attempt = params.state.continuationCount + 1;
+  const active: TurnContinuationActiveState = {
+    reason: params.reason,
+    validatorId: params.validatorId,
+    startedAt: Date.now(),
+    attempt,
+    tighterCap: params.tighterCap,
+    baselineCallUsageIndex: params.ctx.callUsage.length,
+    baselineToolCallIndex: params.ctx.allToolCalls.length,
+    baselineDiagnosticFingerprint: buildDiagnosticFingerprint(params.ctx),
+  };
+  params.state.continuationCount = attempt;
+  params.state.lastContinuationReason = params.reason;
+  params.state.active = active;
+  return active;
+}
+
+export function finishTurnContinuation(params: {
+  readonly state: TurnContinuationState;
+  readonly ctx: ExecutionContext;
+}): TurnContinuationCycleSummary | undefined {
+  const active = params.state.active;
+  if (!active) {
+    return undefined;
+  }
+  const outputTokenDelta = countCompletionTokensSince(
+    params.ctx.callUsage,
+    active.baselineCallUsageIndex,
+  );
+  const continuationToolCalls = params.ctx.allToolCalls.slice(
+    active.baselineToolCallIndex,
+  );
+  const toolCallsIssued = continuationToolCalls.length > 0;
+  const successfulWorkspaceMutation = continuationToolCalls.some(
+    (call) =>
+      SUCCESSFUL_MUTATION_TOOL_NAMES.has(call.name) &&
+      !didToolCallFail(call.isError, call.result),
+  );
+  const nextDiagnosticFingerprint = buildDiagnosticFingerprint(params.ctx);
+  const diagnosticFingerprintChanged =
+    nextDiagnosticFingerprint !== active.baselineDiagnosticFingerprint;
+  const materiallyIncreasedOutput = outputTokenDelta >= LOW_PROGRESS_TOKEN_DELTA;
+  const productive =
+    toolCallsIssued ||
+    successfulWorkspaceMutation ||
+    diagnosticFingerprintChanged ||
+    materiallyIncreasedOutput;
+  const lowProgressStall =
+    !toolCallsIssued &&
+    !successfulWorkspaceMutation &&
+    !diagnosticFingerprintChanged &&
+    outputTokenDelta < LOW_PROGRESS_TOKEN_DELTA;
+  const summary: TurnContinuationCycleSummary = {
+    reason: active.reason,
+    validatorId: active.validatorId,
+    attempt: active.attempt,
+    outputTokenDelta,
+    toolCallsIssued,
+    successfulWorkspaceMutation,
+    diagnosticFingerprintChanged,
+    materiallyIncreasedOutput,
+    productive,
+    lowProgressStall,
+  };
+  params.state.history.push(summary);
+  params.state.consecutiveLowProgressStalls = lowProgressStall
+    ? params.state.consecutiveLowProgressStalls + 1
+    : 0;
+  params.state.active = undefined;
+  return summary;
+}
+
+export function shouldStopForDiminishingReturns(
+  state: TurnContinuationState,
+): boolean {
+  return (
+    state.continuationCount >= MIN_DIMINISHING_RETURNS_CONTINUATIONS &&
+    state.consecutiveLowProgressStalls >= 2
+  );
+}
+
+export function buildDiagnosticFingerprint(ctx: ExecutionContext): string {
+  const failures = ctx.allToolCalls
+    .filter((call) => didToolCallFail(call.isError, call.result))
+    .slice(-12)
+    .map((call) => {
+      const text = extractToolFailureText(call)
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, 200);
+      return `${call.name}:${text}`;
+    });
+  return failures.join("\n");
+}
+
+function countCompletionTokensSince(
+  callUsage: readonly ChatCallUsageRecord[],
+  baselineIndex: number,
+): number {
+  let total = 0;
+  for (const entry of callUsage.slice(baselineIndex)) {
+    total += entry.usage.completionTokens;
+  }
+  return total;
+}

--- a/runtime/src/llm/chat-executor-init.ts
+++ b/runtime/src/llm/chat-executor-init.ts
@@ -92,6 +92,7 @@ export interface InitializeExecutionContextDependencies {
   readonly maxModelRecallsPerRequest: number;
   readonly maxFailureBudgetPerRequest: number;
   readonly requestTimeoutMs: number;
+  readonly turnOutputTokenBudget: number | null;
   // Routing + enforcement
   readonly allowedTools: Set<string> | null;
   readonly plannerEnabled: boolean;
@@ -284,6 +285,12 @@ export async function initializeExecutionContext(
       requestTimeoutMs: normalizeInitRequestTimeoutMs(
         params.requestTimeoutMs ?? deps.requestTimeoutMs,
       ),
+      turnOutputTokenBudget:
+        typeof deps.promptBudget.maxOutputTokens === "number" &&
+          Number.isFinite(deps.promptBudget.maxOutputTokens) &&
+          deps.promptBudget.maxOutputTokens > 0
+          ? Math.max(1, Math.floor(deps.promptBudget.maxOutputTokens))
+          : null,
       providerName: deps.providers[0]?.name ?? "unknown",
       plannerEnabled: deps.plannerEnabled,
       defaultRunClass: deps.defaultRunClass,

--- a/runtime/src/llm/chat-executor-stop-gate.test.ts
+++ b/runtime/src/llm/chat-executor-stop-gate.test.ts
@@ -1,8 +1,14 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, it, expect } from "vitest";
 
 import type { ToolCallRecord } from "./chat-executor-types.js";
 import {
   __TESTING__,
+  checkFilesystemArtifacts,
+  evaluateArtifactEvidenceGate,
   evaluateTurnEndStopGate,
 } from "./chat-executor-stop-gate.js";
 
@@ -70,6 +76,16 @@ function readFile(path: string): ToolCallRecord {
     name: "system.readFile",
     args: { path },
     result: JSON.stringify({ path, size: 100, encoding: "utf-8", content: "..." }),
+    isError: false,
+    durationMs: 1,
+  };
+}
+
+function successfulWrite(path: string, content: string): ToolCallRecord {
+  return {
+    name: "system.writeFile",
+    args: { path, content },
+    result: JSON.stringify({ ok: true, path }),
     isError: false,
     durationMs: 1,
   };
@@ -156,6 +172,145 @@ describe("evaluateTurnEndStopGate (pass cases)", () => {
       allToolCalls: [bashSuccess("cmake .."), bashSuccess("make")],
     });
     expect(decision.shouldIntervene).toBe(false);
+  });
+});
+
+describe("evaluateArtifactEvidenceGate", () => {
+  it("bypasses artifact enforcement in unsafe benchmark mode", () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-benchmark-"));
+    const targetPath = join(workspaceRoot, "src/main.c");
+
+    const decision = evaluateArtifactEvidenceGate({
+      requiredToolEvidence: {
+        unsafeBenchmarkMode: true,
+        verificationContract: {
+          workspaceRoot,
+          targetArtifacts: [targetPath],
+        },
+      },
+      runtimeContext: { workspaceRoot },
+      allToolCalls: [],
+    });
+
+    expect(decision.shouldIntervene).toBe(false);
+    expect(decision.evidence.requiredTargetArtifacts).toEqual([]);
+  });
+
+  it("reports missing_successful_tool_evidence when a workflow turn has no successful tools", () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-artifact-evidence-"));
+    const targetPath = join(workspaceRoot, "src/main.c");
+
+    const decision = evaluateArtifactEvidenceGate({
+      requiredToolEvidence: {
+        verificationContract: {
+          workspaceRoot,
+          targetArtifacts: [targetPath],
+        },
+      },
+      runtimeContext: { workspaceRoot },
+      allToolCalls: [
+        bashFailure({
+          command: "make",
+          stderr: "build failed",
+        }),
+      ],
+    });
+
+    expect(decision.shouldIntervene).toBe(true);
+    expect(decision.validationCode).toBe("missing_successful_tool_evidence");
+    expect(decision.stopReasonDetail).toContain("no successful tool calls");
+    expect(decision.evidence.missingArtifacts).toEqual([targetPath]);
+  });
+
+  it("reports missing_file_artifact_evidence for grounded-read workflows that inspect the wrong file", () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-artifact-grounded-"));
+    mkdirSync(join(workspaceRoot, "src"), { recursive: true });
+    const targetPath = join(workspaceRoot, "src/main.c");
+    const otherPath = join(workspaceRoot, "src/other.c");
+    writeFileSync(otherPath, "int other(void) { return 0; }\n", "utf8");
+
+    const decision = evaluateArtifactEvidenceGate({
+      requiredToolEvidence: {
+        verificationContract: {
+          workspaceRoot,
+          targetArtifacts: [targetPath],
+          verificationMode: "grounded_read",
+        },
+      },
+      runtimeContext: { workspaceRoot },
+      allToolCalls: [
+        readFile(otherPath),
+      ],
+    });
+
+    expect(decision.shouldIntervene).toBe(true);
+    expect(decision.validationCode).toBe("missing_file_artifact_evidence");
+    expect(decision.evidence.inspectedArtifacts).toEqual([otherPath]);
+    expect(decision.evidence.missingArtifacts).toEqual([targetPath]);
+  });
+});
+
+describe("checkFilesystemArtifacts", () => {
+  it("flags empty and missing files while skipping same-turn deletions", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-filesystem-"));
+    mkdirSync(join(workspaceRoot, "src"), { recursive: true });
+
+    const emptyPath = join(workspaceRoot, "src/empty.c");
+    const missingPath = join(workspaceRoot, "src/missing.c");
+    const deletedPath = join(workspaceRoot, "src/deleted.c");
+    const healthyPath = join(workspaceRoot, "src/healthy.c");
+
+    writeFileSync(emptyPath, "seed", "utf8");
+    writeFileSync(emptyPath, "", "utf8");
+
+    writeFileSync(deletedPath, "remove me", "utf8");
+    rmSync(deletedPath);
+
+    writeFileSync(healthyPath, "int healthy(void) { return 0; }\n", "utf8");
+
+    const decision = await checkFilesystemArtifacts({
+      finalContent: "Task complete. All phases implemented.",
+      allToolCalls: [
+        {
+          name: "system.editFile",
+          args: { path: emptyPath, old_string: "seed", new_string: "updated" },
+          result: JSON.stringify({ ok: true, path: emptyPath }),
+          isError: false,
+          durationMs: 1,
+        },
+        {
+          name: "system.appendFile",
+          args: { path: missingPath, content: "append" },
+          result: JSON.stringify({ ok: true, path: missingPath }),
+          isError: false,
+          durationMs: 1,
+        },
+        {
+          name: "desktop.text_editor",
+          args: { path: deletedPath, command: "edit", content: "remove me" },
+          result: JSON.stringify({ ok: true, path: deletedPath }),
+          isError: false,
+          durationMs: 1,
+        },
+        successfulWrite(healthyPath, "int healthy(void) { return 0; }\n"),
+        {
+          name: "system.delete",
+          args: { path: deletedPath },
+          result: JSON.stringify({ ok: true, path: deletedPath }),
+          isError: false,
+          durationMs: 1,
+        },
+      ],
+    });
+
+    expect(decision.shouldIntervene).toBe(true);
+    expect(decision.emptyFiles).toEqual([emptyPath]);
+    expect(decision.missingFiles).toEqual([missingPath]);
+    expect(decision.deletedFiles).toContain(deletedPath);
+    expect(decision.checkedFiles).toEqual(
+      expect.arrayContaining([emptyPath, missingPath, healthyPath]),
+    );
+    expect(decision.checkedFiles).not.toContain(deletedPath);
   });
 });
 

--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -72,6 +72,8 @@ import {
 } from "./verification-target-guard.js";
 import { buildCompletionValidators } from "./completion-validators.js";
 import {
+  checkTurnContinuationBudget,
+  countTurnCompletionTokens,
   finishTurnContinuation,
   shouldStopForDiminishingReturns,
   startTurnContinuation,
@@ -108,6 +110,8 @@ import {
   checkRequestTimeout,
   clearRuntimeInstructionKey,
   emitExecutionTrace,
+  getRemainingRequestMs,
+  hasModelRecallBudget,
   maybePushRuntimeInstruction,
   maybePushKeyedRuntimeInstruction,
   pushMessage,
@@ -1540,6 +1544,31 @@ export async function executeToolCallLoop(
     });
     return summary;
   };
+  const resolveTurnOutputTokenBudget = (): number | null => {
+    for (let index = ctx.callUsage.length - 1; index >= 0; index -= 1) {
+      const maxOutputTokens = ctx.callUsage[index]?.budgetDiagnostics?.model.maxOutputTokens;
+      if (
+        typeof maxOutputTokens === "number" &&
+        Number.isFinite(maxOutputTokens) &&
+        maxOutputTokens > 0
+      ) {
+        return Math.max(1, Math.floor(maxOutputTokens));
+      }
+    }
+    return ctx.turnOutputTokenBudget;
+  };
+  const shouldAllowBudgetContinuation = (): boolean => {
+    const structuredOutputActive =
+      ctx.structuredOutput?.schema !== undefined &&
+      ctx.structuredOutput.enabled !== false;
+    if (structuredOutputActive) {
+      return false;
+    }
+    if (ctx.continuationState.history.length === 0) {
+      return false;
+    }
+    return true;
+  };
   const attemptCompletionRecovery = async (params: {
     readonly reason: string;
     readonly blockingMessage?: string;
@@ -1550,8 +1579,8 @@ export async function executeToolCallLoop(
     readonly validationCode?: DelegationOutputValidationCode;
     readonly validatorId?: CompletionValidatorId;
     readonly stopHookResult?: import("./hooks/stop-hooks.js").StopHookPhaseResult;
+    readonly continuationSummary?: ReturnType<typeof finishTurnContinuation>;
   }): Promise<boolean> => {
-    const continuationSummary = emitContinuationEvaluation();
     const continuationCap =
       params.maxAttempts !== undefined
         ? Math.max(0, params.maxAttempts)
@@ -1593,7 +1622,7 @@ export async function executeToolCallLoop(
           attempt: ctx.continuationState.continuationCount,
           maxAttempts: continuationCap,
           exhaustedDetail: params.exhaustedDetail,
-          continuationSummary,
+          continuationSummary: params.continuationSummary,
           stopCause: shouldExhaustForDiminishingReturns
             ? "diminishing_returns"
             : continuationCap !== undefined &&
@@ -1696,7 +1725,6 @@ export async function executeToolCallLoop(
         statefulSessionId: ctx.sessionId,
         statefulResumeAnchor: ctx.stateful?.resumeAnchor,
         statefulHistoryCompacted: ctx.stateful?.historyCompacted,
-        toolChoice: "required",
         budgetReason: params.budgetReason,
       }),
     );
@@ -1729,6 +1757,111 @@ export async function executeToolCallLoop(
       return false;
     }
     ctx.response = recoveryResponse;
+    failClosedOnMalformedToolContinuation(ctx, callbacks);
+    shouldContinueAfterStopGate = true;
+    return true;
+  };
+  const attemptTokenBudgetContinuation = async (params: {
+    readonly continuationSummary?: ReturnType<typeof finishTurnContinuation>;
+  }): Promise<boolean> => {
+    const decision = checkTurnContinuationBudget({
+      state: ctx.continuationState,
+      budget: resolveTurnOutputTokenBudget(),
+      globalTurnTokens: countTurnCompletionTokens(ctx.callUsage),
+      eligible: shouldAllowBudgetContinuation(),
+    });
+    if (decision.action === "stop") {
+      if (decision.completionEvent) {
+        callbacks.emitExecutionTrace(ctx, {
+          type: "continuation_stopped",
+          phase: "tool_followup",
+          callIndex: ctx.callIndex,
+          payload: {
+            reason: "token_budget",
+            continuationSummary: params.continuationSummary,
+            completionEvent: decision.completionEvent,
+            stopCause: decision.completionEvent.diminishingReturns
+              ? "diminishing_returns"
+              : "token_budget_completed",
+          },
+        });
+      }
+      return false;
+    }
+    if (!hasModelRecallBudget(ctx) || getRemainingRequestMs(ctx) <= 0) {
+      callbacks.emitExecutionTrace(ctx, {
+        type: "continuation_stopped",
+        phase: "tool_followup",
+        callIndex: ctx.callIndex,
+        payload: {
+          reason: "token_budget",
+          continuationSummary: params.continuationSummary,
+          stopCause: !hasModelRecallBudget(ctx)
+            ? "model_recall_budget_exhausted"
+            : "request_timeout_exhausted",
+          turnTokens: decision.turnTokens,
+          budget: decision.budget,
+          pct: decision.pct,
+          continuationCount: decision.continuationCount,
+        },
+      });
+      return false;
+    }
+    sealPendingToolProtocol(ctx, callbacks, "validation_recovery");
+    const activeContinuation = startTurnContinuation({
+      state: ctx.continuationState,
+      ctx,
+      reason: "token_budget",
+    });
+    callbacks.emitExecutionTrace(ctx, {
+      type: "continuation_started",
+      phase: "tool_followup",
+      callIndex: ctx.callIndex,
+      payload: {
+        reason: "token_budget",
+        attempt: activeContinuation.attempt,
+        continuationCount: decision.continuationCount,
+        turnTokens: decision.turnTokens,
+        budget: decision.budget,
+        pct: decision.pct,
+      },
+    });
+    callbacks.pushMessage(
+      ctx,
+      {
+        role: "user",
+        content: decision.nudgeMessage,
+      },
+      "system_runtime",
+    );
+    await runPerIterationCompactionBeforeModelCall(
+      ctx,
+      config,
+      callbacks,
+      "tool_followup",
+    );
+    const continuationResponse = await callModelWithReactiveCompact(
+      ctx,
+      callbacks,
+      "tool_followup",
+      () => ({
+        phase: "tool_followup",
+        callMessages: ctx.messages,
+        callSections: ctx.messageSections,
+        onStreamChunk: ctx.activeStreamCallback,
+        structuredOutput: ctx.structuredOutput,
+        statefulSessionId: ctx.sessionId,
+        statefulResumeAnchor: ctx.stateful?.resumeAnchor,
+        statefulHistoryCompacted: ctx.stateful?.historyCompacted,
+        budgetReason:
+          "Max model recalls exceeded during token-budget continuation",
+      }),
+    );
+    if (!continuationResponse) {
+      ctx.continuationState.active = undefined;
+      return false;
+    }
+    ctx.response = continuationResponse;
     failClosedOnMalformedToolContinuation(ctx, callbacks);
     shouldContinueAfterStopGate = true;
     return true;
@@ -2030,6 +2163,9 @@ export async function executeToolCallLoop(
     !hasPendingToolProtocol(ctx.toolProtocolState) &&
     ctx.stopReason === "completed"
   ) {
+    const continuationSummary = ctx.continuationState.active
+      ? emitContinuationEvaluation()
+      : undefined;
     const validators = buildCompletionValidators({
       ctx,
       runtimeContractFlags: config.runtimeContractFlags,
@@ -2272,6 +2408,7 @@ export async function executeToolCallLoop(
         validationCode: validation.validationCode,
         validatorId: validator.id,
         stopHookResult: validation.stopHookResult,
+        continuationSummary,
       });
       completionValidationStatus = shouldContinueAfterStopGate
         ? "recovery_requested"
@@ -2291,6 +2428,12 @@ export async function executeToolCallLoop(
       },
     });
     if (shouldContinueAfterStopGate) {
+      continue;
+    }
+    const requestedBudgetContinuation = await attemptTokenBudgetContinuation({
+      continuationSummary,
+    });
+    if (requestedBudgetContinuation) {
       continue;
     }
   }

--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -71,6 +71,11 @@ import {
   evaluateWriteOverFailedVerification,
 } from "./verification-target-guard.js";
 import { buildCompletionValidators } from "./completion-validators.js";
+import {
+  finishTurnContinuation,
+  shouldStopForDiminishingReturns,
+  startTurnContinuation,
+} from "./chat-executor-continuation.js";
 import { evaluateShellWorkspaceWritePolicy } from "./shell-write-policy.js";
 import {
   sanitizeToolCallsForReplay,
@@ -1498,17 +1503,44 @@ export async function executeToolCallLoop(
     consecutiveFailCount: 0,
   };
 
-  // Turn-end completion validation: each validator gets a bounded
-  // number of recovery recalls. A recovery reply that spends its turn
-  // narrating instead of calling tools no longer consumes a global
-  // one-shot boolean and exits the loop as "completed" on the next
-  // pass. Instead, the same validator re-fires until its own attempt
-  // budget is exhausted, at which point the turn fails closed with
-  // `validation_error`.
-  const completionValidationAttempts = new Map<string, number>();
+  // Turn-end completion validation now shares one turn-local
+  // continuation controller instead of per-validator attempt maps.
+  // Continuations keep going while request/model/tool budgets allow and
+  // the last continuation cycle was still productive. Explicit
+  // per-validator caps remain supported only as tighter ceilings.
   let shouldContinueAfterStopGate = false;
+  const emitContinuationEvaluation = (): ReturnType<
+    typeof finishTurnContinuation
+  > => {
+    const summary = finishTurnContinuation({
+      state: ctx.continuationState,
+      ctx,
+    });
+    if (!summary) {
+      return undefined;
+    }
+    callbacks.emitExecutionTrace(ctx, {
+      type: "continuation_evaluated",
+      phase: "tool_followup",
+      callIndex: ctx.callIndex,
+      payload: {
+        reason: summary.reason,
+        validatorId: summary.validatorId,
+        attempt: summary.attempt,
+        outputTokenDelta: summary.outputTokenDelta,
+        toolCallsIssued: summary.toolCallsIssued,
+        successfulWorkspaceMutation: summary.successfulWorkspaceMutation,
+        diagnosticFingerprintChanged: summary.diagnosticFingerprintChanged,
+        materiallyIncreasedOutput: summary.materiallyIncreasedOutput,
+        productive: summary.productive,
+        lowProgressStall: summary.lowProgressStall,
+        consecutiveLowProgressStalls:
+          ctx.continuationState.consecutiveLowProgressStalls,
+      },
+    });
+    return summary;
+  };
   const attemptCompletionRecovery = async (params: {
-    readonly attemptKey?: string;
     readonly reason: string;
     readonly blockingMessage?: string;
     readonly evidence?: unknown;
@@ -1519,29 +1551,64 @@ export async function executeToolCallLoop(
     readonly validatorId?: CompletionValidatorId;
     readonly stopHookResult?: import("./hooks/stop-hooks.js").StopHookPhaseResult;
   }): Promise<boolean> => {
-    const maxAttempts = Math.max(0, params.maxAttempts ?? 1);
-    const attemptKey = params.attemptKey ?? params.reason;
-    const attempts = completionValidationAttempts.get(attemptKey) ?? 0;
-    if (!params.blockingMessage || attempts >= maxAttempts) {
+    const continuationSummary = emitContinuationEvaluation();
+    const continuationCap =
+      params.maxAttempts !== undefined
+        ? Math.max(0, params.maxAttempts)
+        : undefined;
+    const shouldExhaustForDiminishingReturns =
+      shouldStopForDiminishingReturns(ctx.continuationState);
+    if (
+      !params.blockingMessage ||
+      (continuationCap !== undefined &&
+        ctx.continuationState.continuationCount >= continuationCap) ||
+      shouldExhaustForDiminishingReturns
+    ) {
       if (params.stopHookResult) {
         callbacks.emitExecutionTrace(ctx, {
           type: "stop_hook_exhausted",
           phase: "tool_followup",
           callIndex: ctx.callIndex,
           payload: {
-            validatorId: params.validatorId ?? attemptKey,
+            validatorId: params.validatorId ?? params.reason,
             stopHookPhase: params.stopHookResult.phase,
             outcome: params.stopHookResult.outcome,
             reason: params.stopHookResult.reason,
             stopReason: params.stopHookResult.stopReason,
             exhaustedDetail: params.exhaustedDetail,
             validationCode: params.validationCode,
-            attempts,
-            maxAttempts,
+            attempts: ctx.continuationState.continuationCount,
+            maxAttempts: continuationCap,
+            diminishingReturns: shouldExhaustForDiminishingReturns,
           },
         });
       }
-      callbacks.setStopReason(ctx, "validation_error", params.exhaustedDetail);
+      callbacks.emitExecutionTrace(ctx, {
+        type: "continuation_stopped",
+        phase: "tool_followup",
+        callIndex: ctx.callIndex,
+        payload: {
+          reason: params.reason,
+          validatorId: params.validatorId,
+          attempt: ctx.continuationState.continuationCount,
+          maxAttempts: continuationCap,
+          exhaustedDetail: params.exhaustedDetail,
+          continuationSummary,
+          stopCause: shouldExhaustForDiminishingReturns
+            ? "diminishing_returns"
+            : continuationCap !== undefined &&
+                ctx.continuationState.continuationCount >= continuationCap
+              ? "continuation_cap"
+              : "blocking_message_unavailable",
+        },
+      });
+      callbacks.setStopReason(
+        ctx,
+        "validation_error",
+        shouldExhaustForDiminishingReturns
+          ? `${params.exhaustedDetail} Runtime continuation controller stopped after repeated low-progress recoveries.`
+          : params.exhaustedDetail,
+      );
       if (params.validationCode) {
         ctx.validationCode = params.validationCode;
       }
@@ -1554,33 +1621,50 @@ export async function executeToolCallLoop(
       return false;
     }
 
-    completionValidationAttempts.set(attemptKey, attempts + 1);
     sealPendingToolProtocol(ctx, callbacks, "validation_recovery");
+    const activeContinuation = startTurnContinuation({
+      state: ctx.continuationState,
+      ctx,
+      reason: params.reason,
+      validatorId: params.validatorId,
+      tighterCap: continuationCap,
+    });
     if (params.stopHookResult) {
       callbacks.emitExecutionTrace(ctx, {
         type: "stop_hook_retry_requested",
         phase: "tool_followup",
         callIndex: ctx.callIndex,
         payload: {
-          validatorId: params.validatorId ?? attemptKey,
+          validatorId: params.validatorId ?? params.reason,
           stopHookPhase: params.stopHookResult.phase,
           outcome: params.stopHookResult.outcome,
           reason: params.stopHookResult.reason,
           stopReason: params.stopHookResult.stopReason,
-          attempt: attempts + 1,
-          maxAttempts,
+          attempt: activeContinuation.attempt,
+          maxAttempts: continuationCap,
           validationCode: params.validationCode,
         },
       });
     }
+    callbacks.emitExecutionTrace(ctx, {
+      type: "continuation_started",
+      phase: "tool_followup",
+      callIndex: ctx.callIndex,
+      payload: {
+        reason: params.reason,
+        validatorId: params.validatorId,
+        attempt: activeContinuation.attempt,
+        maxAttempts: continuationCap,
+      },
+    });
     callbacks.emitExecutionTrace(ctx, {
       type: "stop_gate_intervention",
       phase: "tool_followup",
       callIndex: ctx.callIndex,
       payload: {
         reason: params.reason,
-        attempt: attempts + 1,
-        maxAttempts,
+        attempt: activeContinuation.attempt,
+        maxAttempts: continuationCap,
         finalContentPreview: (ctx.response?.content ?? "").slice(0, 240),
         ...(params.evidence !== undefined ? { evidence: params.evidence } : {}),
       },
@@ -1617,21 +1701,22 @@ export async function executeToolCallLoop(
       }),
     );
     if (!recoveryResponse) {
+      ctx.continuationState.active = undefined;
       if (params.stopHookResult) {
         callbacks.emitExecutionTrace(ctx, {
           type: "stop_hook_exhausted",
           phase: "tool_followup",
           callIndex: ctx.callIndex,
           payload: {
-            validatorId: params.validatorId ?? attemptKey,
+            validatorId: params.validatorId ?? params.reason,
             stopHookPhase: params.stopHookResult.phase,
             outcome: params.stopHookResult.outcome,
             reason: params.stopHookResult.reason,
             stopReason: params.stopHookResult.stopReason,
             exhaustedDetail: params.exhaustedDetail,
             validationCode: params.validationCode,
-            attempt: attempts + 1,
-            maxAttempts,
+            attempt: activeContinuation.attempt,
+            maxAttempts: continuationCap,
           },
         });
       }
@@ -2176,11 +2261,10 @@ export async function executeToolCallLoop(
                 : "Max model recalls exceeded during top-level verifier recovery turn";
 
       await attemptCompletionRecovery({
-        attemptKey: validator.id,
         reason: validation.reason ?? validator.id,
         blockingMessage: validation.blockingMessage,
         evidence: validation.evidence,
-        maxAttempts: validation.maxAttempts ?? 1,
+        maxAttempts: validation.maxAttempts,
         budgetReason,
         exhaustedDetail:
           validation.exhaustedDetail ??

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -85,6 +85,10 @@ import {
   createRequestTaskProgressState,
   type RequestTaskProgressState,
 } from "./request-task-progress.js";
+import {
+  createTurnContinuationState,
+  type TurnContinuationState,
+} from "./chat-executor-continuation.js";
 
 // ============================================================================
 // Error classes
@@ -151,6 +155,9 @@ export interface ToolCallRecord {
 }
 
 type ChatExecutionTraceEventType =
+  | "continuation_evaluated"
+  | "continuation_started"
+  | "continuation_stopped"
   | "completion_validator_finished"
   | "completion_validator_started"
   | "completion_validation_finished"
@@ -230,7 +237,7 @@ export interface ChatExecuteParams {
   };
   /** Require at least one successful tool call before accepting a final answer. */
   readonly requiredToolEvidence?: {
-    /** Bounded number of correction recalls before failing the turn. Default: 1. */
+    /** Optional tighter ceiling for productive continuation recovery loops. */
     readonly maxCorrectionAttempts?: number;
     /** Optional delegated output contract used for phase-specific validation. */
     readonly delegationSpec?: DelegationContractSpec;
@@ -655,6 +662,7 @@ export interface ExecutionContext {
   readonly stateful?: ChatExecuteParams["stateful"];
   readonly requiredToolEvidence?: {
     readonly maxCorrectionAttempts: number;
+    readonly maxCorrectionAttemptsExplicit: boolean;
     readonly delegationSpec?: DelegationContractSpec;
     readonly unsafeBenchmarkMode?: boolean;
     readonly verificationContract?: WorkflowVerificationContract;
@@ -703,6 +711,7 @@ export interface ExecutionContext {
   requestTaskState: RequestTaskProgressState;
   completedRequestMilestoneIds: readonly string[];
   economicsState: RuntimeEconomicsState;
+  continuationState: TurnContinuationState;
   /**
    * Per-iteration compaction state composed across snip, microcompact,
    * and autocompact layers. Replaced on every provider call in
@@ -806,6 +815,8 @@ export function buildDefaultExecutionContext(
           0,
           Math.floor(params.requiredToolEvidence.maxCorrectionAttempts ?? 1),
         ),
+        maxCorrectionAttemptsExplicit:
+          params.requiredToolEvidence.maxCorrectionAttempts !== undefined,
         delegationSpec: params.requiredToolEvidence.delegationSpec,
         unsafeBenchmarkMode: params.requiredToolEvidence.unsafeBenchmarkMode,
         verificationContract: params.requiredToolEvidence.verificationContract,
@@ -869,6 +880,7 @@ export function buildDefaultExecutionContext(
     requestTaskState: createRequestTaskProgressState(),
     completedRequestMilestoneIds: [],
     economicsState,
+    continuationState: createTurnContinuationState(),
     perIterationCompaction: createPerIterationCompactionState(),
   };
 }

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -651,6 +651,7 @@ export interface ExecutionContext {
   readonly effectiveMaxModelRecalls: number;
   readonly effectiveFailureBudget: number;
   readonly effectiveRequestTimeoutMs: number;
+  readonly turnOutputTokenBudget: number | null;
   readonly startTime: number;
   readonly requestDeadlineAt: number;
   readonly initialRoutedToolNames: readonly string[];
@@ -758,6 +759,7 @@ interface BuildExecutionContextConfig {
   readonly maxFailureBudgetPerRequest: number;
   /** End-to-end request timeout in milliseconds. 0 = unlimited. */
   readonly requestTimeoutMs: number;
+  readonly turnOutputTokenBudget: number | null;
   readonly providerName: string;
   readonly plannerEnabled: boolean;
   readonly defaultRunClass?: RuntimeRunClass;
@@ -792,6 +794,7 @@ export function buildDefaultExecutionContext(
     effectiveMaxModelRecalls: config.maxModelRecallsPerRequest,
     effectiveFailureBudget: config.maxFailureBudgetPerRequest,
     effectiveRequestTimeoutMs: config.requestTimeoutMs,
+    turnOutputTokenBudget: config.turnOutputTokenBudget,
     startTime,
     requestDeadlineAt:
       config.requestTimeoutMs > 0

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -848,6 +848,184 @@ describe("ChatExecutor", () => {
       expect(result.content).not.toContain("Model returned empty content");
     });
 
+    it("continues after a successful tool turn while token budget remains", async () => {
+      const toolHandler = vi.fn().mockResolvedValue('{"ok":true}');
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                { id: "tc-1", name: "system.listDir", arguments: '{"path":"."}' },
+              ],
+              usage: {
+                promptTokens: 25,
+                completionTokens: 50,
+                totalTokens: 75,
+              },
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "Next I will continue with the remaining implementation work.",
+              finishReason: "stop",
+              usage: {
+                promptTokens: 30,
+                completionTokens: 100,
+                totalTokens: 130,
+              },
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "Bootstrap complete. Continuing with the remaining work.",
+              finishReason: "stop",
+              usage: {
+                promptTokens: 30,
+                completionTokens: 100,
+                totalTokens: 130,
+              },
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "Finished the remaining implementation details.",
+              finishReason: "stop",
+              usage: {
+                promptTokens: 30,
+                completionTokens: 1_900,
+                totalTokens: 1_930,
+              },
+            }),
+          ),
+      });
+
+      const executor = new ChatExecutor({ providers: [provider], toolHandler });
+      const result = await executor.execute(createParams());
+
+      expect(result.stopReason).toBe("completed");
+      expect(result.content).toBe("Finished the remaining implementation details.");
+      expect(result.callUsage.map((entry) => entry.phase)).toEqual([
+        "initial",
+        "tool_followup",
+        "tool_followup",
+        "tool_followup",
+      ]);
+      expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(4);
+      expect(
+        (provider.chat as ReturnType<typeof vi.fn>).mock.calls[2]?.[1]?.toolChoice,
+      ).toBeUndefined();
+    });
+
+    it("does not apply token-budget continuation to structured-output turns", async () => {
+      const toolHandler = vi.fn().mockResolvedValue('{"ok":true}');
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                { id: "tc-1", name: "system.listDir", arguments: '{"path":"."}' },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: '{"status":"done"}',
+              finishReason: "stop",
+              usage: {
+                promptTokens: 20,
+                completionTokens: 100,
+                totalTokens: 120,
+              },
+            }),
+          ),
+      });
+
+      const executor = new ChatExecutor({ providers: [provider], toolHandler });
+      const result = await executor.execute(
+        createParams({
+          structuredOutput: {
+            enabled: true,
+            schema: {
+              type: "json_schema",
+              name: "structured_turn",
+              strict: true,
+              schema: {
+                type: "object",
+                additionalProperties: false,
+                required: ["status"],
+                properties: {
+                  status: { type: "string" },
+                },
+              },
+            },
+          },
+        }),
+      );
+
+      expect(result.stopReason).toBe("completed");
+      expect(result.content).toBe('{"status":"done"}');
+      expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+    });
+
+    it("does not apply token-budget continuation when structured output is default-enabled", async () => {
+      const toolHandler = vi.fn().mockResolvedValue('{"ok":true}');
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                { id: "tc-1", name: "system.listDir", arguments: '{"path":"."}' },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: '{"status":"done"}',
+              finishReason: "stop",
+              usage: {
+                promptTokens: 20,
+                completionTokens: 100,
+                totalTokens: 120,
+              },
+            }),
+          ),
+      });
+
+      const executor = new ChatExecutor({ providers: [provider], toolHandler });
+      const result = await executor.execute(
+        createParams({
+          structuredOutput: {
+            schema: {
+              type: "json_schema",
+              name: "structured_turn",
+              strict: true,
+              schema: {
+                type: "object",
+                additionalProperties: false,
+                required: ["status"],
+                properties: {
+                  status: { type: "string" },
+                },
+              },
+            },
+          },
+        }),
+      );
+
+      expect(result.stopReason).toBe("completed");
+      expect(result.content).toBe('{"status":"done"}');
+      expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+    });
+
     it("surfaces timeout detail instead of summarizing tool output when tool follow-up never starts", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-04-08T00:00:00.000Z"));

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -363,6 +363,12 @@ export class ChatExecutor {
       maxModelRecallsPerRequest: this.maxModelRecallsPerRequest,
       maxFailureBudgetPerRequest: this.maxFailureBudgetPerRequest,
       requestTimeoutMs: this.requestTimeoutMs,
+      turnOutputTokenBudget:
+        typeof this.promptBudget.maxOutputTokens === "number" &&
+          Number.isFinite(this.promptBudget.maxOutputTokens) &&
+          this.promptBudget.maxOutputTokens > 0
+          ? Math.max(1, Math.floor(this.promptBudget.maxOutputTokens))
+          : null,
       // Routing + enforcement
       allowedTools: this.allowedTools,
       plannerEnabled: this.plannerEnabled,

--- a/runtime/src/llm/completion-validators.test.ts
+++ b/runtime/src/llm/completion-validators.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -68,7 +68,13 @@ function makeCtx(params: {
       targetArtifacts: params.targetArtifacts ?? [],
     },
     runtimeContractSnapshot: createRuntimeContractSnapshot(flags),
-    requiredToolEvidence: params.requiredToolEvidence,
+    requiredToolEvidence: params.requiredToolEvidence
+      ? {
+          ...params.requiredToolEvidence,
+          maxCorrectionAttemptsExplicit:
+            params.requiredToolEvidence.maxCorrectionAttempts !== undefined,
+        }
+      : undefined,
   } as unknown as ExecutionContext;
 }
 
@@ -390,6 +396,145 @@ describe("completion-validators", () => {
     expect(result.outcome).toBe("retry_with_blocking_message");
     expect(result.maxAttempts).toBe(3);
     expect(result.blockingMessage).toContain("bounded recovery loop");
+  });
+
+  it("applies the shared 3-attempt recovery budget consistently across the primary validators", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "shared-budget-"));
+    mkdirSync(join(workspaceRoot, "src"), { recursive: true });
+    writeFileSync(
+      join(workspaceRoot, "Makefile"),
+      "all:\n\t@echo build failed >&2\n\t@exit 2\n",
+      "utf8",
+    );
+    const targetPath = join(workspaceRoot, "src/main.c");
+    const narrativeCtx = makeCtx({
+      workspaceRoot,
+      finalContent: "Next I will fix the build and rerun the checks.",
+      allToolCalls: [successfulWrite(targetPath)],
+      targetArtifacts: [targetPath],
+      turnClass: "workflow_implementation",
+      ownerMode: "workflow_owner",
+      requiredToolEvidence: {
+        maxCorrectionAttempts: 3,
+      },
+    });
+    setAllowedRequestTaskMilestones(narrativeCtx.requestTaskState, [
+      { id: "phase_1", description: "Finish phase 1" },
+    ]);
+    const narrativeValidators = buildCompletionValidators({
+      ctx: narrativeCtx,
+      runtimeContractFlags: makeFlags(),
+    });
+    const filesystemCtx = makeCtx({
+      workspaceRoot,
+      finalContent: "Implementation complete. All phases implemented.",
+      allToolCalls: [successfulWrite(targetPath)],
+      targetArtifacts: [targetPath],
+      turnClass: "workflow_implementation",
+      ownerMode: "workflow_owner",
+      requiredToolEvidence: {
+        maxCorrectionAttempts: 3,
+      },
+    });
+    const filesystemValidators = buildCompletionValidators({
+      ctx: filesystemCtx,
+      runtimeContractFlags: makeFlags(),
+    });
+    const narrativeById = new Map(
+      narrativeValidators.map((validator) => [validator.id, validator]),
+    );
+    const filesystemById = new Map(
+      filesystemValidators.map((validator) => [validator.id, validator]),
+    );
+
+    const [stopGate, taskProgress, deterministic, filesystem] = await Promise.all([
+      narrativeById.get("turn_end_stop_gate")!.execute(),
+      narrativeById.get("request_task_progress")!.execute(),
+      narrativeById.get("deterministic_acceptance_probes")!.execute(),
+      filesystemById.get("filesystem_artifact_verification")!.execute(),
+    ]);
+
+    try {
+      expect(stopGate.outcome).toBe("retry_with_blocking_message");
+      expect(stopGate.maxAttempts).toBe(3);
+
+      expect(taskProgress.outcome).toBe("retry_with_blocking_message");
+      expect(taskProgress.maxAttempts).toBe(3);
+
+      expect(filesystem.outcome).toBe("retry_with_blocking_message");
+      expect(filesystem.maxAttempts).toBe(3);
+
+      expect(deterministic.outcome).toBe("retry_with_blocking_message");
+      expect(deterministic.maxAttempts).toBe(3);
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps an explicit zero correction budget at zero for the recovery validators", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "zero-budget-"));
+    mkdirSync(join(workspaceRoot, "src"), { recursive: true });
+    writeFileSync(
+      join(workspaceRoot, "Makefile"),
+      "all:\n\t@echo build failed >&2\n\t@exit 2\n",
+      "utf8",
+    );
+    const targetPath = join(workspaceRoot, "src/main.c");
+    const narrativeCtx = makeCtx({
+      workspaceRoot,
+      finalContent: "Next I will fix the build and rerun the checks.",
+      allToolCalls: [successfulWrite(targetPath)],
+      targetArtifacts: [targetPath],
+      turnClass: "workflow_implementation",
+      ownerMode: "workflow_owner",
+      requiredToolEvidence: {
+        maxCorrectionAttempts: 0,
+      },
+    });
+    setAllowedRequestTaskMilestones(narrativeCtx.requestTaskState, [
+      { id: "phase_1", description: "Finish phase 1" },
+    ]);
+    const narrativeValidators = buildCompletionValidators({
+      ctx: narrativeCtx,
+      runtimeContractFlags: makeFlags(),
+    });
+    const filesystemCtx = makeCtx({
+      workspaceRoot,
+      finalContent: "Implementation complete. All phases implemented.",
+      allToolCalls: [successfulWrite(targetPath)],
+      targetArtifacts: [targetPath],
+      turnClass: "workflow_implementation",
+      ownerMode: "workflow_owner",
+      requiredToolEvidence: {
+        maxCorrectionAttempts: 0,
+      },
+    });
+    const filesystemValidators = buildCompletionValidators({
+      ctx: filesystemCtx,
+      runtimeContractFlags: makeFlags(),
+    });
+    const narrativeById = new Map(
+      narrativeValidators.map((validator) => [validator.id, validator]),
+    );
+    const filesystemById = new Map(
+      filesystemValidators.map((validator) => [validator.id, validator]),
+    );
+
+    const [stopGate, taskProgress, deterministic, filesystem] = await Promise.all([
+      narrativeById.get("turn_end_stop_gate")!.execute(),
+      narrativeById.get("request_task_progress")!.execute(),
+      narrativeById.get("deterministic_acceptance_probes")!.execute(),
+      filesystemById.get("filesystem_artifact_verification")!.execute(),
+    ]);
+
+    try {
+      expect(stopGate.maxAttempts).toBe(0);
+      expect(taskProgress.maxAttempts).toBe(0);
+      expect(filesystem.maxAttempts).toBe(0);
+      expect(deterministic.maxAttempts).toBe(0);
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
   });
 
   it("runs the top-level verifier even when runtimeContractV2 is false", async () => {

--- a/runtime/src/llm/completion-validators.ts
+++ b/runtime/src/llm/completion-validators.ts
@@ -25,8 +25,6 @@ import type {
 import { runTopLevelVerifierValidation } from "../gateway/top-level-verifier.js";
 import { getRemainingRequestTaskMilestones } from "./request-task-progress.js";
 
-const DEFAULT_DETERMINISTIC_ACCEPTANCE_PROBE_ATTEMPTS = 3;
-
 export interface CompletionValidatorExecutionResult
   extends CompletionValidatorResult {
   readonly probeRuns?: readonly ToolCallRecord[];
@@ -45,12 +43,17 @@ export function buildCompletionValidators(params: {
   readonly stopHookRuntime?: StopHookRuntime;
   readonly completionValidation?: ChatExecutorConfig["completionValidation"];
 }): readonly CompletionValidator[] {
-  const sharedCorrectionBudget =
-    params.ctx.requiredToolEvidence?.maxCorrectionAttempts ?? 1;
-  const stopHookRetryBudget = Math.max(
-    sharedCorrectionBudget,
-    params.stopHookRuntime?.maxAttempts ?? 1,
-  );
+  const sharedCorrectionBudgetCap =
+    params.ctx.requiredToolEvidence?.maxCorrectionAttemptsExplicit === true
+      ? params.ctx.requiredToolEvidence.maxCorrectionAttempts
+      : undefined;
+  const stopHookRetryBudgetCap =
+    params.stopHookRuntime?.maxAttemptsExplicit === true
+      ? Math.max(
+          sharedCorrectionBudgetCap ?? 0,
+          params.stopHookRuntime.maxAttempts,
+        )
+      : sharedCorrectionBudgetCap;
   const topLevelVerifierEnabled =
     params.runtimeContractFlags.verifierRuntimeRequired;
   const deterministicAcceptanceProbesEnabled =
@@ -100,7 +103,7 @@ export function buildCompletionValidators(params: {
               reason: hookResult.reason ?? "verification_ready",
               blockingMessage: hookResult.blockingMessage,
               evidence: hookResult.evidence,
-              maxAttempts: stopHookRetryBudget,
+              maxAttempts: stopHookRetryBudgetCap,
               exhaustedDetail:
                 "Verification-ready recovery exhausted after stop-hook intervention.",
               stopHookResult: hookResult,
@@ -145,7 +148,7 @@ export function buildCompletionValidators(params: {
           reason: decision.validationCode ?? "artifact_evidence_gate",
           blockingMessage: decision.blockingMessage,
           evidence: decision.evidence,
-          maxAttempts: params.ctx.requiredToolEvidence?.maxCorrectionAttempts ?? 0,
+          maxAttempts: sharedCorrectionBudgetCap,
           exhaustedDetail:
             decision.stopReasonDetail ??
             "Artifact-evidence recovery exhausted.",
@@ -198,7 +201,7 @@ export function buildCompletionValidators(params: {
             reason: hookResult.reason ?? "turn_end_stop_gate",
             blockingMessage: hookResult.blockingMessage,
             evidence: hookResult.evidence,
-            maxAttempts: stopHookRetryBudget,
+            maxAttempts: stopHookRetryBudgetCap,
             exhaustedDetail:
               hookResult.reason === "narrated_future_tool_work"
                 ? "Stop-gate recovery exhausted: the model kept narrating future work instead of calling tools."
@@ -219,7 +222,7 @@ export function buildCompletionValidators(params: {
           reason: decision.reason ?? "turn_end_stop_gate",
           blockingMessage: decision.blockingMessage,
           evidence: decision.evidence,
-          maxAttempts: sharedCorrectionBudget,
+          maxAttempts: sharedCorrectionBudgetCap,
           exhaustedDetail:
             decision.reason === "narrated_future_tool_work"
               ? "Stop-gate recovery exhausted: the model kept narrating future work instead of calling tools."
@@ -253,7 +256,7 @@ export function buildCompletionValidators(params: {
           return { id: "request_task_progress", outcome: "pass" };
         }
 
-        const maxAttempts = sharedCorrectionBudget;
+        const maxAttempts = sharedCorrectionBudgetCap;
         if (hasMalformedTaskMetadata) {
           const allowedIds = requestTaskState.allowedMilestones.map(
             (milestone) => milestone.id,
@@ -365,7 +368,7 @@ export function buildCompletionValidators(params: {
             missingFiles: check.missingFiles,
             checkedFiles: check.checkedFiles,
           },
-          maxAttempts: sharedCorrectionBudget,
+          maxAttempts: sharedCorrectionBudgetCap,
           exhaustedDetail:
             "Filesystem artifact verification failed after recovery; missing or empty artifacts remain on disk.",
         };
@@ -414,9 +417,7 @@ export function buildCompletionValidators(params: {
             "deterministic_acceptance_probe_failed",
           blockingMessage: decision.blockingMessage,
           evidence: decision.evidence,
-          maxAttempts:
-            params.ctx.requiredToolEvidence?.maxCorrectionAttempts ??
-            DEFAULT_DETERMINISTIC_ACCEPTANCE_PROBE_ATTEMPTS,
+          maxAttempts: sharedCorrectionBudgetCap,
           exhaustedDetail:
             decision.stopReasonDetail ??
             "Deterministic acceptance-probe recovery exhausted.",
@@ -474,7 +475,7 @@ export function buildCompletionValidators(params: {
           outcome: validation.outcome,
           reason: "top_level_verifier",
           blockingMessage: validation.blockingMessage,
-          maxAttempts: sharedCorrectionBudget,
+          maxAttempts: sharedCorrectionBudgetCap,
           exhaustedDetail: validation.exhaustedDetail,
           verifier: validation.runtimeVerifier,
           verifierTaskId: validation.taskId,

--- a/runtime/src/llm/execute-chat.test.ts
+++ b/runtime/src/llm/execute-chat.test.ts
@@ -240,6 +240,97 @@ describe("executeChat (Phase C async generator)", () => {
     expect(terminal.reason).toBe("stop_reason_end_turn");
   });
 
+  it("preserves shared continuation behavior through the executeChat adapter", async () => {
+    const provider: LLMProvider = {
+      name: "mock-continuation",
+      chat: vi
+        .fn<[LLMMessage[], LLMChatOptions?], Promise<LLMResponse>>()
+        .mockResolvedValueOnce({
+          content: "",
+          toolCalls: [
+            { id: "tc-1", name: "system.listDir", arguments: '{"path":"."}' },
+          ],
+          usage: {
+            promptTokens: 20,
+            completionTokens: 50,
+            totalTokens: 70,
+          },
+          model: "mock-model",
+          finishReason: "tool_calls",
+        })
+        .mockResolvedValueOnce({
+          content: "Next I will continue with the remaining work.",
+          toolCalls: [],
+          usage: {
+            promptTokens: 20,
+            completionTokens: 100,
+            totalTokens: 120,
+          },
+          model: "mock-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content: "Bootstrap complete. Continuing.",
+          toolCalls: [],
+          usage: {
+            promptTokens: 20,
+            completionTokens: 100,
+            totalTokens: 120,
+          },
+          model: "mock-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content: "Finished the remaining implementation details.",
+          toolCalls: [],
+          usage: {
+            promptTokens: 20,
+            completionTokens: 1_900,
+            totalTokens: 1_920,
+          },
+          model: "mock-model",
+          finishReason: "stop",
+        }),
+      chatStream: vi
+        .fn<
+          [LLMMessage[], StreamProgressCallback, LLMChatOptions?],
+          Promise<LLMResponse>
+        >()
+        .mockRejectedValue(new Error("unused")),
+      healthCheck: vi.fn<[], Promise<boolean>>().mockResolvedValue(true),
+    };
+    const executor = new ChatExecutor({
+      providers: [provider],
+      toolHandler: vi.fn(async () => '{"ok":true}'),
+    });
+
+    const { events, terminal } = await collect(
+      executeChat(executor, {
+        message: makeMessage("continue the task"),
+        history: [],
+        systemPrompt: "You are a test.",
+        sessionId: "session-continuation",
+      }),
+    );
+
+    const assistants = events.filter(
+      (event) => event.type === "assistant",
+    ) as AssistantMessage[];
+    expect(assistants.at(-1)?.content).toBe(
+      "Finished the remaining implementation details.",
+    );
+    expect(terminal.finalContent).toBe(
+      "Finished the remaining implementation details.",
+    );
+    expect(terminal.legacyResult?.callUsage.map((entry) => entry.phase)).toEqual([
+      "initial",
+      "tool_followup",
+      "tool_followup",
+      "tool_followup",
+    ]);
+    expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(4);
+  });
+
   it("drains provider stream chunks into stream_chunk events when chatStream is used", async () => {
     const chunks: LLMStreamChunk[] = [
       { content: "a", done: false },

--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -2546,6 +2546,87 @@ describe("GrokProvider", () => {
     expect(third.stateful?.fallbackReason).toBeUndefined();
   });
 
+  it("retries reasoning-only completed tool followups with tool_choice none", async () => {
+    mockCreate
+      .mockResolvedValueOnce(
+        makeCompletion({
+          id: "resp_reasoning_only_initial",
+          output_text: "",
+          output: [
+            {
+              type: "reasoning",
+              id: "rs_reasoning_only",
+              summary: [
+                {
+                  type: "summary_text",
+                  text:
+                    "The final recovery turn must be direct. The ledger shows repeated failed tool calls.",
+                },
+              ],
+              status: "completed",
+            },
+          ],
+          usage: {
+            input_tokens: 34492,
+            output_tokens: 280,
+            total_tokens: 34772,
+            output_tokens_details: { reasoning_tokens: 280 },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeCompletion({
+          id: "resp_reasoning_only_retry",
+          output_text: "Recovered after retry",
+        }),
+      );
+
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      model: "grok-4.20-beta-0309-reasoning",
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "system.bash",
+            description: "run command",
+            parameters: {
+              type: "object",
+              properties: { command: { type: "string" } },
+            },
+          },
+        },
+      ],
+    });
+
+    const response = await provider.chat([
+      { role: "user", content: "find the token" },
+      {
+        role: "assistant",
+        content: "",
+        phase: "commentary",
+        toolCalls: [
+          {
+            id: "call_reasoning_only_1",
+            name: "system.bash",
+            arguments: '{"command":"echo TOKEN=ONYX-SHARD-58"}',
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: "TOKEN=ONYX-SHARD-58",
+        toolCallId: "call_reasoning_only_1",
+        toolName: "system.bash",
+      },
+    ]);
+
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+    expect(mockCreate.mock.calls[1][0].tool_choice).toBe("none");
+    expect(mockCreate.mock.calls[1][0].stream).toBe(false);
+    expect(response.content).toBe("Recovered after retry");
+  });
+
   it("keeps previous_response_id continuity when replayed tool-call arguments are sanitized", async () => {
     const rawArguments = JSON.stringify({
       path: "packages/core/src/routing.test.ts",

--- a/runtime/src/llm/grok/xai-strict-filter.test.ts
+++ b/runtime/src/llm/grok/xai-strict-filter.test.ts
@@ -801,6 +801,45 @@ describe("validateXaiResponsePostFlight (mid-sentence truncation bug)", () => {
     expect(anomaly?.evidence.messageTextTail).toContain("pkg-config).\n2");
   });
 
+  it("detects reasoning-only completed responses with no visible assistant text", () => {
+    const request = toolFollowupRequest({
+      model: "grok-4.20-beta-0309-reasoning",
+      tools: [functionTool("system.bash"), functionTool("system.editFile")],
+    });
+    const result = validateXaiResponsePostFlight({
+      request,
+      response: responseWith({
+        model: "grok-4.20-beta-0309-reasoning",
+        status: "completed",
+        incomplete_details: null,
+        output: [
+          reasoningBlock(
+            "The final recovery turn must be direct. The ledger shows repeated failed tool calls.",
+          ),
+        ],
+        usage: {
+          input_tokens: 34492,
+          output_tokens: 280,
+          total_tokens: 34772,
+          output_tokens_details: { reasoning_tokens: 280 },
+        },
+      }),
+    });
+    const anomaly = result.find(
+      (a) => a.code === "truncated_response_mid_sentence",
+    );
+    expect(anomaly).toBeDefined();
+    expect(anomaly?.severity).toBe("warn");
+    expect(anomaly?.evidence).toMatchObject({
+      outputTokens: 280,
+      priorFunctionCallOutputCount: 1,
+      toolChoice: "auto",
+      reasoningBlockCount: 1,
+      variant: "reasoning_only",
+    });
+    expect(anomaly?.evidence.assistantMessageTextTail).toBe("");
+  });
+
   it("does NOT flag when text ends with a period", () => {
     const request = toolFollowupRequest({
       tools: [functionTool("system.bash")],

--- a/runtime/src/llm/grok/xai-strict-filter.ts
+++ b/runtime/src/llm/grok/xai-strict-filter.ts
@@ -762,6 +762,42 @@ function extractMessageText(output: unknown): string {
   return parts.join("\n");
 }
 
+function extractAssistantMessageText(output: unknown): string {
+  if (!Array.isArray(output)) return "";
+  const parts: string[] = [];
+  for (const item of output) {
+    if (!item || typeof item !== "object") continue;
+    if ((item as { type?: unknown }).type !== "message") continue;
+    const content = (item as { content?: unknown }).content;
+    if (!Array.isArray(content)) continue;
+    for (const block of content) {
+      if (
+        block &&
+        typeof block === "object" &&
+        typeof (block as { text?: unknown }).text === "string"
+      ) {
+        parts.push((block as { text: string }).text);
+      }
+    }
+  }
+  return parts.join("\n");
+}
+
+function countReasoningOutputBlocks(output: unknown): number {
+  if (!Array.isArray(output)) return 0;
+  let count = 0;
+  for (const item of output) {
+    if (
+      item &&
+      typeof item === "object" &&
+      (item as { type?: unknown }).type === "reasoning"
+    ) {
+      count++;
+    }
+  }
+  return count;
+}
+
 /**
  * Count output blocks whose `type` is one of the documented tool-call
  * output types ({@link SERVER_SIDE_TOOL_CALL_OUTPUT_TYPES}). The
@@ -832,6 +868,8 @@ export function validateXaiResponsePostFlight(params: {
   // so a response with any of these is NOT a silent tool drop.
   const toolCallBlockCount = countToolCallOutputBlocks(output);
   const messageText = extractMessageText(output);
+  const assistantMessageText = extractAssistantMessageText(output);
+  const reasoningBlockCount = countReasoningOutputBlocks(output);
 
   // 1. Silent tool drop (incoming).
   if (
@@ -946,9 +984,12 @@ export function validateXaiResponsePostFlight(params: {
     usage && typeof usage === "object"
       ? Number((usage as { output_tokens?: unknown }).output_tokens) || 0
       : 0;
-  // Two variants of the same xAI decoder bug:
+  // Three variants of the same xAI decoder bug:
   //   (a) Mid-sentence truncation: text present but cut off mid-word
   //   (b) Empty-output truncation: output_tokens === 0, output === []
+  //   (c) Reasoning-only truncation: output_tokens > 0 but the response
+  //       contains only `reasoning` blocks and no visible assistant
+  //       message/output_text for the user
   // Both share the same trigger shape (completed + null incomplete +
   // tools + auto + prior fn_output + zero tool-call blocks). Variant
   // (b) was not caught in PR #306 because the condition required
@@ -956,9 +997,16 @@ export function validateXaiResponsePostFlight(params: {
   // 03:31:42 call_6 returned output:[] with 0 tokens while the prior
   // calls (2-5) were all productive writeFile sequences.
   const isMidSentenceTruncation =
-    messageText.length > 0 && !endsWithTerminalPunctuation(messageText);
+    assistantMessageText.length > 0 &&
+    !endsWithTerminalPunctuation(assistantMessageText);
   const isEmptyOutputTruncation =
-    messageText.length === 0 && outputTokens === 0;
+    assistantMessageText.length === 0 &&
+    reasoningBlockCount === 0 &&
+    outputTokens === 0;
+  const isReasoningOnlyTruncation =
+    assistantMessageText.length === 0 &&
+    reasoningBlockCount > 0 &&
+    outputTokens > 0;
   if (
     responseStatus === "completed" &&
     (responseIncomplete === null || responseIncomplete === undefined) &&
@@ -966,7 +1014,9 @@ export function validateXaiResponsePostFlight(params: {
     effChoice === "auto" &&
     priorFnOutputCount > 0 &&
     toolCallBlockCount === 0 &&
-    (isMidSentenceTruncation || isEmptyOutputTruncation)
+    (isMidSentenceTruncation ||
+      isEmptyOutputTruncation ||
+      isReasoningOnlyTruncation)
   ) {
     anomalies.push({
       code: "truncated_response_mid_sentence",
@@ -981,6 +1031,16 @@ export function validateXaiResponsePostFlight(params: {
             `${sentTools.length} tools in scope, and tool_choice="auto" ` +
             `produced zero output. The adapter will retry with ` +
             `tool_choice="none".`
+          : isReasoningOnlyTruncation
+            ? `xAI /v1/responses returned status="completed" with ` +
+              `incomplete_details=null and ${outputTokens} output tokens, ` +
+              `but produced only reasoning blocks and no visible assistant ` +
+              `message/output_text. This is a reasoning-only variant of the ` +
+              `xAI decoder tool-mode → text-mode transition bug: a turn with ` +
+              `${priorFnOutputCount} prior function_call_output items, ` +
+              `${sentTools.length} tools in scope, and tool_choice="auto" ` +
+              `ended with hidden reasoning instead of user-visible text. The ` +
+              `adapter will retry with tool_choice="none".`
           : `xAI /v1/responses returned status="completed" with ` +
             `incomplete_details=null, but the text-only response ends without ` +
             `terminal punctuation after ${outputTokens} output tokens. ` +
@@ -993,11 +1053,17 @@ export function validateXaiResponsePostFlight(params: {
       evidence: {
         outputTokens,
         messageTextTail: messageText.slice(-120),
+        assistantMessageTextTail: assistantMessageText.slice(-120),
         priorFunctionCallOutputCount: priorFnOutputCount,
         sentToolCount: sentTools.length,
         toolCallBlockCount,
+        reasoningBlockCount,
         toolChoice: effChoice,
-        variant: isEmptyOutputTruncation ? "empty_output" : "mid_sentence",
+        variant: isEmptyOutputTruncation
+          ? "empty_output"
+          : isReasoningOnlyTruncation
+            ? "reasoning_only"
+            : "mid_sentence",
       },
     });
   }

--- a/runtime/src/llm/hooks/stop-hooks.ts
+++ b/runtime/src/llm/hooks/stop-hooks.ts
@@ -122,6 +122,7 @@ interface StopHookRuntimeDefinition {
 
 export interface StopHookRuntime {
   readonly maxAttempts: number;
+  readonly maxAttemptsExplicit: boolean;
   readonly definitionsByPhase: ReadonlyMap<StopHookPhase, readonly StopHookRuntimeDefinition[]>;
 }
 
@@ -185,6 +186,7 @@ export function buildStopHookRuntime(
   }
   return {
     maxAttempts: normalizeMaxAttempts(config.maxAttempts),
+    maxAttemptsExplicit: config.maxAttempts !== undefined,
     definitionsByPhase,
   };
 }

--- a/runtime/src/tools/system/task-tracker.test.ts
+++ b/runtime/src/tools/system/task-tracker.test.ts
@@ -150,10 +150,19 @@ describe("task-tracker", () => {
       expect(result.body.error).toMatch(/subject/);
     });
 
-    it("rejects empty description", async () => {
+    it("falls back to the subject when description is omitted", async () => {
+      const result = await callTool(create, { subject: "x" });
+      expect(result.raw.isError).toBeUndefined();
+      expect(result.body.task).toMatchObject({
+        subject: "x",
+      });
+      expect(store.list(DEFAULT_TASK_LIST_ID)[0]?.description).toBe("x");
+    });
+
+    it("falls back to the subject when description is empty", async () => {
       const result = await callTool(create, { subject: "x", description: "" });
-      expect(result.raw.isError).toBe(true);
-      expect(result.body.error).toMatch(/description/);
+      expect(result.raw.isError).toBeUndefined();
+      expect(store.list(DEFAULT_TASK_LIST_ID)[0]?.description).toBe("x");
     });
 
     it("preserves activeForm and metadata when provided", async () => {

--- a/runtime/src/tools/system/task-tracker.ts
+++ b/runtime/src/tools/system/task-tracker.ts
@@ -1758,7 +1758,8 @@ const TASK_CREATE_DESCRIPTION =
   "multi-step work (3+ steps), complex tasks that require planning, or when the user " +
   "supplies multiple things to do. Mark a task in_progress with task.update BEFORE " +
   "starting work, and completed only once the work is fully done. Runtime-managed " +
-  "milestone tracking uses metadata._runtime.milestoneIds and metadata._runtime.verification.";
+  "milestone tracking uses metadata._runtime.milestoneIds and metadata._runtime.verification. " +
+  "If description is omitted, the runtime falls back to the subject text.";
 
 const TASK_LIST_DESCRIPTION =
   "List tasks in the current session's task list. Returns id, kind, subject, status, owner, " +
@@ -1814,7 +1815,8 @@ export function createTaskTrackerTools(
         },
         description: {
           type: "string",
-          description: "What needs to be done. Include enough detail to act on later.",
+          description:
+            "What needs to be done. Include enough detail to act on later. Optional; when omitted, the runtime reuses the subject.",
         },
         activeForm: {
           type: "string",
@@ -1827,13 +1829,12 @@ export function createTaskTrackerTools(
             "Arbitrary metadata to attach to the task. Runtime-managed milestone tracking uses metadata._runtime.milestoneIds and metadata._runtime.verification.",
         },
       },
-      required: ["subject", "description"],
+      required: ["subject"],
     },
     async execute(args) {
       const subject = asNonEmptyString(args.subject);
       if (!subject) return errorResult("subject must be a non-empty string");
-      const description = asNonEmptyString(args.description);
-      if (!description) return errorResult("description must be a non-empty string");
+      const description = asNonEmptyString(args.description) ?? subject;
       const activeForm = asNonEmptyString(args.activeForm);
       const metadata = asPlainObject(args.metadata);
 


### PR DESCRIPTION
## Summary
- align AgenC continuation budgeting and recovery flow more closely with Claude Code's shared loop behavior
- keep token-budget continuation separate from validator recovery state so low-budget nudges do not poison later recoveries
- add shared-adapter and subagent regressions for the continuation controller

## Testing
- npm --prefix agenc-core/runtime run typecheck
- cd agenc-core/runtime && npx vitest run src/llm/chat-executor-continuation.test.ts src/llm/chat-executor.test.ts src/llm/execute-chat.test.ts src/gateway/subagent-query.test.ts src/llm/chat-executor-request.test.ts src/llm/chat-executor-stop-gate.test.ts
- cd agenc-core/runtime && npx vitest run src/gateway/daemon-text-channel-turn.test.ts src/gateway/daemon-webchat-turn.test.ts src/gateway/background-run-supervisor.test.ts src/gateway/voice-bridge.test.ts
- npm --prefix agenc-core/runtime run build