### PR TITLE
fix(runtime): gate continuation budgets like claude

### DIFF
--- a/runtime/src/gateway/subagent-query.test.ts
+++ b/runtime/src/gateway/subagent-query.test.ts
@@ -185,7 +185,7 @@ describe("runSubagentToLegacyResult (Phase K)", () => {
     ).rejects.toThrow();
   });
 
-  it("preserves shared continuation behavior for subagent turns", async () => {
+  it("keeps token-budget continuation disabled for subagent turns", async () => {
     const provider: LLMProvider = {
       name: "mock-subagent-provider",
       chat: vi
@@ -212,13 +212,6 @@ describe("runSubagentToLegacyResult (Phase K)", () => {
           usage: { promptTokens: 20, completionTokens: 100, totalTokens: 120 },
           model: "mock-model",
           finishReason: "stop",
-        })
-        .mockResolvedValueOnce({
-          content: "Subagent finished the remaining work.",
-          toolCalls: [],
-          usage: { promptTokens: 20, completionTokens: 1_900, totalTokens: 1_920 },
-          model: "mock-model",
-          finishReason: "stop",
         }),
       chatStream: vi
         .fn<
@@ -234,22 +227,22 @@ describe("runSubagentToLegacyResult (Phase K)", () => {
     });
 
     const result = await runSubagentToLegacyResult(executor, {
-      sessionId: "continued-child",
+      sessionId: "subagent:continued-child",
       params: {
         message: makeMessage("continue the task"),
         history: [],
         systemPrompt: "System",
-        sessionId: "continued-child",
+        sessionId: "subagent:continued-child",
+        turnOutputTokenBudget: 2_000,
       },
     });
 
-    expect(result.legacyResult?.content).toBe("Subagent finished the remaining work.");
+    expect(result.legacyResult?.content).toBe("Bootstrap complete. Continuing.");
     expect(result.legacyResult?.callUsage.map((entry) => entry.phase)).toEqual([
       "initial",
       "tool_followup",
       "tool_followup",
-      "tool_followup",
     ]);
-    expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(4);
+    expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(3);
   });
 });

--- a/runtime/src/llm/chat-executor-init.ts
+++ b/runtime/src/llm/chat-executor-init.ts
@@ -286,11 +286,13 @@ export async function initializeExecutionContext(
         params.requestTimeoutMs ?? deps.requestTimeoutMs,
       ),
       turnOutputTokenBudget:
-        typeof deps.promptBudget.maxOutputTokens === "number" &&
-          Number.isFinite(deps.promptBudget.maxOutputTokens) &&
-          deps.promptBudget.maxOutputTokens > 0
-          ? Math.max(1, Math.floor(deps.promptBudget.maxOutputTokens))
-          : null,
+        typeof params.turnOutputTokenBudget === "number" &&
+          Number.isFinite(params.turnOutputTokenBudget) &&
+          params.turnOutputTokenBudget > 0
+          ? Math.max(1, Math.floor(params.turnOutputTokenBudget))
+          : params.turnOutputTokenBudget === null
+            ? null
+            : deps.turnOutputTokenBudget,
       providerName: deps.providers[0]?.name ?? "unknown",
       plannerEnabled: deps.plannerEnabled,
       defaultRunClass: deps.defaultRunClass,

--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -1545,16 +1545,6 @@ export async function executeToolCallLoop(
     return summary;
   };
   const resolveTurnOutputTokenBudget = (): number | null => {
-    for (let index = ctx.callUsage.length - 1; index >= 0; index -= 1) {
-      const maxOutputTokens = ctx.callUsage[index]?.budgetDiagnostics?.model.maxOutputTokens;
-      if (
-        typeof maxOutputTokens === "number" &&
-        Number.isFinite(maxOutputTokens) &&
-        maxOutputTokens > 0
-      ) {
-        return Math.max(1, Math.floor(maxOutputTokens));
-      }
-    }
     return ctx.turnOutputTokenBudget;
   };
   const shouldAllowBudgetContinuation = (): boolean => {
@@ -1564,7 +1554,7 @@ export async function executeToolCallLoop(
     if (structuredOutputActive) {
       return false;
     }
-    if (ctx.continuationState.history.length === 0) {
+    if (ctx.sessionId.startsWith("subagent:")) {
       return false;
     }
     return true;

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -219,6 +219,8 @@ export interface ChatExecuteParams {
   readonly maxModelRecallsPerRequest?: number;
   /** Per-call end-to-end timeout in milliseconds — overrides the constructor default. 0 = unlimited. */
   readonly requestTimeoutMs?: number;
+  /** Optional explicit per-turn output-token continuation budget. Null disables Claude-style budget continuation. */
+  readonly turnOutputTokenBudget?: number | null;
   /** Per-call context injection controls for bounded/system-owned executions. */
   readonly contextInjection?: {
     /** When false, skip skill/system context injection for this call. */

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -949,6 +949,7 @@ describe("ChatExecutor", () => {
       const executor = new ChatExecutor({ providers: [provider], toolHandler });
       const result = await executor.execute(
         createParams({
+          turnOutputTokenBudget: 2_000,
           structuredOutput: {
             enabled: true,
             schema: {
@@ -1003,6 +1004,7 @@ describe("ChatExecutor", () => {
       const executor = new ChatExecutor({ providers: [provider], toolHandler });
       const result = await executor.execute(
         createParams({
+          turnOutputTokenBudget: 2_000,
           structuredOutput: {
             schema: {
               type: "json_schema",

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -363,12 +363,7 @@ export class ChatExecutor {
       maxModelRecallsPerRequest: this.maxModelRecallsPerRequest,
       maxFailureBudgetPerRequest: this.maxFailureBudgetPerRequest,
       requestTimeoutMs: this.requestTimeoutMs,
-      turnOutputTokenBudget:
-        typeof this.promptBudget.maxOutputTokens === "number" &&
-          Number.isFinite(this.promptBudget.maxOutputTokens) &&
-          this.promptBudget.maxOutputTokens > 0
-          ? Math.max(1, Math.floor(this.promptBudget.maxOutputTokens))
-          : null,
+      turnOutputTokenBudget: null,
       // Routing + enforcement
       allowedTools: this.allowedTools,
       plannerEnabled: this.plannerEnabled,

--- a/runtime/src/llm/execute-chat.test.ts
+++ b/runtime/src/llm/execute-chat.test.ts
@@ -310,6 +310,7 @@ describe("executeChat (Phase C async generator)", () => {
         history: [],
         systemPrompt: "You are a test.",
         sessionId: "session-continuation",
+        turnOutputTokenBudget: 2_000,
       }),
     );
 


### PR DESCRIPTION
## Summary
- gate token-budget continuation behind an explicit per-turn budget instead of the generic model max-output ceiling
- remove the remaining forced `toolChoice: required` recovery mismatch and keep subagent sessions out of budget continuation
- update shared adapter and subagent tests to reflect Claude-style budget scoping

## Testing
- npm --prefix agenc-core/runtime run typecheck
- cd agenc-core/runtime && npx vitest run src/llm/chat-executor.test.ts src/llm/execute-chat.test.ts src/gateway/subagent-query.test.ts src/llm/chat-executor-continuation.test.ts src/llm/chat-executor-request.test.ts src/llm/chat-executor-stop-gate.test.ts