### PR TITLE
fix(runtime): only block on unresolved shell failures

### DIFF
--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -46,3 +46,10 @@
 - **What worked:** Giving deterministic acceptance-probe recovery a bounded multi-attempt budget for workflow-owned coding turns let trivial compile/build failures self-heal through several repair turns, while the new “no successful workspace mutations since last probe” check stops the loop as soon as it stops making real progress.
 - **What didn't:** The first full-executor regression accidentally used a `.txt` target, which this runtime classifies as documentation-only, and the short final success string also tripped the stop gate; the test had to be corrected before it was actually exercising the intended coding repair path.
 - **Rule added to CLAUDE.md:** no
+
+## PR #343: fix(runtime): only block on unresolved shell failures
+- **Date:** 2026-04-14
+- **Files changed:** `runtime/src/llm/chat-executor-stop-gate.ts`, `runtime/src/llm/chat-executor-stop-gate.test.ts`
+- **What worked:** Switching the bash-side stop-gate detector from “any failed shell call in the turn” to “latest unresolved shell failure” restored Claude-style stop-hook semantics, so honest recoveries no longer get blocked by stale failures that were already repaired later in the same turn.
+- **What didn't:** The first stop-gate patch promoted turn-ledger history to a permanent blocker, which was stricter than Claude’s hook model and caused the runtime to stop on already-fixed failures until the detector was made resolution-aware.
+- **Rule added to CLAUDE.md:** no

--- a/runtime/src/llm/chat-executor-stop-gate.test.ts
+++ b/runtime/src/llm/chat-executor-stop-gate.test.ts
@@ -81,6 +81,67 @@ function readFile(path: string): ToolCallRecord {
   };
 }
 
+function verificationFailure(params: {
+  probeId?: string;
+  command?: string;
+  error: string;
+}): ToolCallRecord {
+  return {
+    name: "verification.runProbe",
+    args: {
+      probeId: params.probeId ?? "build",
+      cwd: "/tmp/workspace",
+      __runtimeAcceptanceProbe: true,
+    },
+    result: JSON.stringify({
+      error: params.error,
+      __agencVerification: {
+        probeId: params.probeId ?? "build",
+        category: "build",
+        profile: "default",
+        repoLocal: true,
+        cwd: "/tmp/workspace",
+        command: params.command ?? "cmake --build build",
+        writesTempOnly: false,
+      },
+    }),
+    isError: true,
+    durationMs: 1,
+    synthetic: true,
+  };
+}
+
+function verificationSuccess(params: {
+  probeId?: string;
+  command?: string;
+} = {}): ToolCallRecord {
+  return {
+    name: "verification.runProbe",
+    args: {
+      probeId: params.probeId ?? "build",
+      cwd: "/tmp/workspace",
+      __runtimeAcceptanceProbe: true,
+    },
+    result: JSON.stringify({
+      exitCode: 0,
+      stdout: "ok",
+      stderr: "",
+      __agencVerification: {
+        probeId: params.probeId ?? "build",
+        category: "build",
+        profile: "default",
+        repoLocal: true,
+        cwd: "/tmp/workspace",
+        command: params.command ?? "cmake --build build",
+        writesTempOnly: false,
+      },
+    }),
+    isError: false,
+    durationMs: 1,
+    synthetic: true,
+  };
+}
+
 function successfulWrite(path: string, content: string): ToolCallRecord {
   return {
     name: "system.writeFile",
@@ -763,6 +824,64 @@ describe("evaluateTurnEndStopGate — false_success_after_failed_bash", () => {
         bashFailure({ command: "make", stderr: "syntax error" }),
       ],
     });
+    expect(decision.shouldIntervene).toBe(false);
+  });
+});
+
+describe("evaluateTurnEndStopGate — false_success_after_failed_verification", () => {
+  it("fires when the latest verification probe failed and the final text claims completion", () => {
+    const decision = evaluateTurnEndStopGate({
+      finalContent:
+        "All phases of PLAN.md have been completed. The workspace is fully implemented and verified.",
+      allToolCalls: [
+        successfulWrite("/tmp/workspace/include/utils.h", "#include <stdio.h>\n"),
+        verificationFailure({
+          command: "cmake --build build",
+          error: "include/utils.h:25:18: error: unknown type name 'FILE'",
+        }),
+      ],
+    });
+
+    expect(decision.shouldIntervene).toBe(true);
+    expect(decision.reason).toBe("false_success_after_failed_verification");
+    expect(decision.blockingMessage).toMatch(/verification\/probe step/i);
+    expect(decision.blockingMessage).toMatch(/cmake --build build/);
+    expect(decision.evidence.failedVerificationCallCount).toBe(1);
+  });
+
+  it("does not fire when a later verification probe succeeded", () => {
+    const decision = evaluateTurnEndStopGate({
+      finalContent:
+        "All phases of PLAN.md have been completed. The workspace is fully implemented and verified. " +
+        "I reran the final build and verification probes after the source edits, " +
+        "confirmed the binary builds cleanly, and observed the success output directly.",
+      allToolCalls: [
+        verificationFailure({
+          command: "cmake --build build",
+          error: "first build failed",
+        }),
+        successfulWrite("/tmp/workspace/include/utils.h", "#include <stdio.h>\n"),
+        verificationSuccess({
+          command: "cmake --build build",
+        }),
+      ],
+    });
+
+    expect(decision.shouldIntervene).toBe(false);
+  });
+
+  it("does not fire when the final reply honestly reports the verification failure", () => {
+    const decision = evaluateTurnEndStopGate({
+      finalContent:
+        "I did not complete the plan. The latest verification probe failed on cmake --build build with unknown type name FILE.",
+      allToolCalls: [
+        verificationFailure({
+          command: "cmake --build build",
+          error: "unknown type name 'FILE'",
+        }),
+      ],
+    });
+
     expect(decision.shouldIntervene).toBe(false);
   });
 });

--- a/runtime/src/llm/chat-executor-stop-gate.test.ts
+++ b/runtime/src/llm/chat-executor-stop-gate.test.ts
@@ -758,9 +758,9 @@ describe("evaluateTurnEndStopGate — false_success_after_failed_bash", () => {
     });
     expect(decision.shouldIntervene).toBe(true);
     expect(decision.reason).toBe("false_success_after_failed_bash");
-    expect(decision.evidence.failedShellCallCount).toBe(2);
+    expect(decision.evidence.failedShellCallCount).toBe(1);
     expect(decision.blockingMessage).toMatch(/Failing shell commands/);
-    expect(decision.blockingMessage).toMatch(/cmake/);
+    expect(decision.blockingMessage).toMatch(/make -j2/);
   });
 
   it("fires on 'all tests pass' phrasing", () => {
@@ -811,6 +811,27 @@ describe("evaluateTurnEndStopGate — false_success_after_failed_bash", () => {
       ],
     });
     expect(decision.shouldIntervene).toBe(false);
+  });
+
+  it("does NOT fire when an earlier shell failure was followed by a later shell success", () => {
+    const decision = evaluateTurnEndStopGate({
+      finalContent:
+        "Phase 0 bootstrap complete. The build succeeded for all source " +
+        "files. The binary is ready at build/agenc. All tests pass " +
+        "with strict assertions.",
+      allToolCalls: [
+        bashFailure({
+          command: "cd build && ./agenc-shell --help",
+          stderr: "No such file or directory",
+        }),
+        bashSuccess(
+          "cd build && cmake .. && make -j2 2>&1 | tail -30",
+          "[100%] Built target agenc-shell",
+        ),
+      ],
+    });
+    expect(decision.shouldIntervene).toBe(false);
+    expect(decision.evidence.failedShellCallCount).toBe(0);
   });
 
   it("does NOT fire when failures are present but the model is reporting them, not claiming success", () => {
@@ -956,7 +977,7 @@ describe("evaluateTurnEndStopGate — blocking message contents", () => {
     );
   });
 
-  it("evidence caps shown failures at 3 even when many are present", () => {
+  it("evidence reports only the latest unresolved shell failure", () => {
     const calls: ToolCallRecord[] = [];
     for (let i = 0; i < 10; i++) {
       calls.push(
@@ -970,13 +991,13 @@ describe("evaluateTurnEndStopGate — blocking message contents", () => {
         "with strict assertions.",
       allToolCalls: calls,
     });
-    expect(decision.evidence.failedShellCallCount).toBe(10);
-    expect(decision.evidence.failureExcerpts).toHaveLength(3);
-    // The blocking message lists at most 3 commands, not 10.
+    expect(decision.evidence.failedShellCallCount).toBe(1);
+    expect(decision.evidence.failureExcerpts).toHaveLength(1);
     const matchCount = (
       decision.blockingMessage?.match(/make target_/g) ?? []
     ).length;
-    expect(matchCount).toBe(3);
+    expect(matchCount).toBe(1);
+    expect(decision.blockingMessage).toMatch(/make target_9/);
   });
 });
 

--- a/runtime/src/llm/chat-executor-stop-gate.ts
+++ b/runtime/src/llm/chat-executor-stop-gate.ts
@@ -654,19 +654,25 @@ function buildArtifactEvidenceBlockingMessage(params: {
 // Detectors
 // ---------------------------------------------------------------------------
 
-function findFailedShellCalls(
+function findUnresolvedShellFailures(
   allToolCalls: readonly ToolCallRecord[],
 ): ToolCallRecord[] {
-  const out: ToolCallRecord[] = [];
-  for (const call of allToolCalls) {
-    if (call.args.__runtimeAcceptanceProbe === true) {
-      continue;
-    }
-    if (call.isError && isShellLikeTool(call.name)) {
-      out.push(call);
-    }
+  const shellCalls = allToolCalls.filter(
+    (call) =>
+      call.args.__runtimeAcceptanceProbe !== true &&
+      isShellLikeTool(call.name),
+  );
+  if (shellCalls.length === 0) {
+    return [];
   }
-  return out;
+  const lastShellCall = shellCalls.at(-1);
+  if (
+    !lastShellCall ||
+    !didToolCallFail(lastShellCall.isError, lastShellCall.result)
+  ) {
+    return [];
+  }
+  return [lastShellCall];
 }
 
 function findRefusedCalls(
@@ -708,9 +714,9 @@ function findRefusedCalls(
  *      the turn made at least one tool call (so the turn was substantive,
  *      not a one-line greeting).
  *
- *   3. `false_success_after_failed_bash` — at least one
- *      `system.bash` / `desktop.bash` call returned `isError: true` AND
- *      the final text matches `FALSE_SUCCESS_RE` AND does NOT match
+ *   3. `false_success_after_failed_bash` — the latest shell-like call in
+ *      the turn is still failing AND the final text matches
+ *      `FALSE_SUCCESS_RE` AND does NOT match
  *      `FAILURE_ACKNOWLEDGMENT_RE`.
  */
 export function evaluateTurnEndStopGate(
@@ -718,7 +724,7 @@ export function evaluateTurnEndStopGate(
 ): StopGateInterventionDecision {
   const finalContent = params.finalContent ?? "";
   const allToolCalls = params.allToolCalls ?? [];
-  const failedShellCalls = findFailedShellCalls(allToolCalls);
+  const failedShellCalls = findUnresolvedShellFailures(allToolCalls);
   const failedVerificationCalls = findUnresolvedVerificationFailures(allToolCalls);
   const refusedCalls = findRefusedCalls(allToolCalls);
 

--- a/runtime/src/llm/chat-executor-stop-gate.ts
+++ b/runtime/src/llm/chat-executor-stop-gate.ts
@@ -67,7 +67,7 @@ import { resolveWorkflowEvidenceFromRequiredToolEvidence } from "./turn-executio
  * claims as well as opening sentences.
  */
 const FALSE_SUCCESS_RE =
-  /\b(?:build\s+(?:succeeded|successful|complete|completed|finished)|build\s+is\s+(?:successful|complete|finished)|phase\s+\d+\s+(?:complete|completed|done|finished|passed|implemented)|phase\s+\d+\s+(?:bootstrap|implementation)\s+(?:complete|completed|finished)|tests?\s+(?:passed|succeeded|all\s+pass(?:ed|ing)?)|all\s+tests?\s+pass(?:ed|ing)?|binary\s+(?:is\s+)?(?:exists|ready|built|compiled)|all\s+phases?\s+(?:complete|completed|done|finished|implemented)|task\s+(?:complete|completed|done|finished)|implementation\s+(?:complete|completed|done|finished)|successfully\s+(?:built|compiled|implemented|completed|finished)|v\d+(?:\.\d+)*\s+complete|ready\s+to\s+ship|done\s+with\s+phase)/i;
+  /\b(?:build\s+(?:succeeded|successful|complete|completed|finished)|build\s+is\s+(?:successful|complete|finished)|phase\s+\d+\s+(?:complete|completed|done|finished|passed|implemented)|phase\s+\d+\s+(?:bootstrap|implementation)\s+(?:complete|completed|finished)|tests?\s+(?:passed|succeeded|all\s+pass(?:ed|ing)?)|all\s+tests?\s+pass(?:ed|ing)?|binary\s+(?:is\s+)?(?:exists|ready|built|compiled)|all\s+phases?\s+(?:complete|completed|done|finished|implemented)|all\s+phases?\s+of\s+[^\n]{0,120}?\s+have\s+been\s+(?:complete|completed|done|finished|implemented)|all\s+phases?\b(?:[^.!?\n]{0,80})\b(?:complete|completed|done|finished|implemented)|task\s+(?:complete|completed|done|finished)|implementation\s+(?:complete|completed|done|finished)|successfully\s+(?:built|compiled|implemented|completed|finished)|v\d+(?:\.\d+)*\s+complete|ready\s+to\s+ship|done\s+with\s+phase)/i;
 
 /**
  * Honest-acknowledgment phrases. If the final message contains BOTH a
@@ -189,7 +189,7 @@ const MID_TASK_PERMISSION_QUESTION_RE =
  * are not forced into a recovery loop.
  */
 const TERMINAL_COMPLETION_RE =
-  /\b(?:task\s+(?:complete|completed|done|finished)|all\s+phases?\s+(?:complete|completed|done|finished|implemented)|implementation\s+(?:complete|completed|done|finished)|nothing\s+(?:more|else)\s+to\s+(?:do|implement)|session\s+(?:complete|done|finished)|finished\s+the\s+(?:task|work|implementation|plan)|project\s+(?:complete|completed|done|finished))/i;
+  /\b(?:task\s+(?:complete|completed|done|finished)|all\s+phases?\s+(?:complete|completed|done|finished|implemented)|all\s+phases?\s+of\s+[^\n]{0,120}?\s+have\s+been\s+(?:complete|completed|done|finished|implemented)|all\s+phases?\b(?:[^.!?\n]{0,80})\b(?:complete|completed|done|finished|implemented)|implementation\s+(?:complete|completed|done|finished)|nothing\s+(?:more|else)\s+to\s+(?:do|implement)|session\s+(?:complete|done|finished)|finished\s+the\s+(?:task|work|implementation|plan)|project\s+(?:complete|completed|done|finished))/i;
 
 /**
  * Tool names whose failures count as "this turn had a failed shell
@@ -215,6 +215,7 @@ const SHELL_LIKE_TOOL_NAMES: ReadonlySet<string> = new Set([
  */
 export type StopGateInterventionReason =
   | "false_success_after_failed_bash"
+  | "false_success_after_failed_verification"
   | "false_success_after_anti_fab_refusal"
   | "truncated_success_claim"
   | "narrated_future_tool_work";
@@ -222,12 +223,16 @@ export type StopGateInterventionReason =
 export interface StopGateEvidence {
   /** Number of `system.bash` / `desktop.bash` calls in the turn that returned `isError: true`. */
   readonly failedShellCallCount: number;
+  /** Number of verification/probe calls whose latest observed result is still failing. */
+  readonly failedVerificationCallCount: number;
   /** Number of tool calls in the turn that the runtime refused (anti-fab, contract, envelope, etc.). */
   readonly refusedToolCallCount: number;
   /** Length of the final assistant text in characters. */
   readonly finalContentLength: number;
   /** Up to 3 truncated failure-text excerpts to surface in the blocking message. */
   readonly failureExcerpts: readonly string[];
+  /** Up to 3 verification/probe failure excerpts to surface in the blocking message. */
+  readonly verificationFailureExcerpts: readonly string[];
   /** Up to 3 refused-call reasons to surface in the blocking message. */
   readonly refusalExcerpts: readonly string[];
 }
@@ -319,10 +324,68 @@ function summarizeRefusedCall(record: ToolCallRecord): string {
   return `${record.name}${target ? ` on \`${truncate(target, 100)}\`` : ""}: ${truncate(reason, 200)}`;
 }
 
+function isVerificationLikeToolCall(record: ToolCallRecord): boolean {
+  if (record.name === "verification.runProbe") {
+    return true;
+  }
+  if (record.args?.__runtimeAcceptanceProbe === true) {
+    return true;
+  }
+  try {
+    const parsed = JSON.parse(record.result) as Record<string, unknown>;
+    return (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "__agencVerification" in parsed
+    );
+  } catch {
+    return false;
+  }
+}
+
+function findUnresolvedVerificationFailures(
+  allToolCalls: readonly ToolCallRecord[],
+): ToolCallRecord[] {
+  const verificationCalls = allToolCalls.filter(isVerificationLikeToolCall);
+  if (verificationCalls.length === 0) {
+    return [];
+  }
+  const lastVerificationCall = verificationCalls.at(-1);
+  if (
+    !lastVerificationCall ||
+    !didToolCallFail(lastVerificationCall.isError, lastVerificationCall.result)
+  ) {
+    return [];
+  }
+  return [lastVerificationCall];
+}
+
+function summarizeVerificationFailureCall(record: ToolCallRecord): string {
+  let label =
+    typeof record.args?.probeId === "string" && record.args.probeId.trim().length > 0
+      ? record.args.probeId.trim()
+      : record.name;
+  try {
+    const parsed = JSON.parse(record.result) as Record<string, unknown>;
+    const verification =
+      typeof parsed.__agencVerification === "object" &&
+      parsed.__agencVerification !== null
+        ? parsed.__agencVerification as Record<string, unknown>
+        : null;
+    if (verification && typeof verification.command === "string") {
+      label = verification.command.trim();
+    }
+  } catch {
+    // Fall back to probe id / tool name when result is not structured JSON.
+  }
+  return `\`${truncate(label, 100)}\` → ${truncate(extractToolFailureText(record), 200)}`;
+}
+
 function buildBlockingMessage(params: {
   readonly reason: StopGateInterventionReason;
   readonly finalContent: string;
   readonly failedShellCalls: readonly ToolCallRecord[];
+  readonly failedVerificationCalls: readonly ToolCallRecord[];
   readonly refusedCalls: readonly ToolCallRecord[];
 }): string {
   const lines: string[] = [];
@@ -342,6 +405,14 @@ function buildBlockingMessage(params: {
           `tool call(s) in this turn. A refused write means the runtime ` +
           `prevented you from masking a prior failure — claiming success ` +
           `now papers over the same failure.`,
+      );
+      break;
+    case "false_success_after_failed_verification":
+      lines.push(
+        `Your final reply claims the work is complete, but the latest ` +
+          `verification/probe step in this turn still FAILED. Completion ` +
+          `cannot pass while the most recent grounded verification result ` +
+          `is red.`,
       );
       break;
     case "truncated_success_claim":
@@ -375,6 +446,13 @@ function buildBlockingMessage(params: {
     lines.push(`Failing shell commands (up to 3 shown):`);
     for (const call of params.failedShellCalls.slice(0, 3)) {
       lines.push(`  • ${summarizeFailedShellCall(call)}`);
+    }
+  }
+  if (params.failedVerificationCalls.length > 0) {
+    lines.push("");
+    lines.push(`Failing verification/probe steps (up to 3 shown):`);
+    for (const call of params.failedVerificationCalls.slice(0, 3)) {
+      lines.push(`  • ${summarizeVerificationFailureCall(call)}`);
     }
   }
   if (params.refusedCalls.length > 0) {
@@ -641,13 +719,18 @@ export function evaluateTurnEndStopGate(
   const finalContent = params.finalContent ?? "";
   const allToolCalls = params.allToolCalls ?? [];
   const failedShellCalls = findFailedShellCalls(allToolCalls);
+  const failedVerificationCalls = findUnresolvedVerificationFailures(allToolCalls);
   const refusedCalls = findRefusedCalls(allToolCalls);
 
   const evidence: StopGateEvidence = {
     failedShellCallCount: failedShellCalls.length,
+    failedVerificationCallCount: failedVerificationCalls.length,
     refusedToolCallCount: refusedCalls.length,
     finalContentLength: finalContent.length,
     failureExcerpts: failedShellCalls
+      .slice(0, 3)
+      .map((c) => truncate(extractToolFailureText(c), 200)),
+    verificationFailureExcerpts: failedVerificationCalls
       .slice(0, 3)
       .map((c) => truncate(extractToolFailureText(c), 200)),
     refusalExcerpts: refusedCalls
@@ -691,6 +774,24 @@ export function evaluateTurnEndStopGate(
         reason: "false_success_after_anti_fab_refusal",
         finalContent,
         failedShellCalls,
+        failedVerificationCalls,
+        refusedCalls,
+      }),
+      evidence,
+    };
+  }
+
+  // Detector 1.5: the latest verification/probe step in the turn still
+  // failed, but the model is now claiming completion anyway.
+  if (failedVerificationCalls.length > 0 && !acknowledgesFailure) {
+    return {
+      shouldIntervene: true,
+      reason: "false_success_after_failed_verification",
+      blockingMessage: buildBlockingMessage({
+        reason: "false_success_after_failed_verification",
+        finalContent,
+        failedShellCalls,
+        failedVerificationCalls,
         refusedCalls,
       }),
       evidence,
@@ -710,6 +811,7 @@ export function evaluateTurnEndStopGate(
         reason: "truncated_success_claim",
         finalContent,
         failedShellCalls,
+        failedVerificationCalls,
         refusedCalls,
       }),
       evidence,
@@ -726,6 +828,7 @@ export function evaluateTurnEndStopGate(
         reason: "false_success_after_failed_bash",
         finalContent,
         failedShellCalls,
+        failedVerificationCalls,
         refusedCalls,
       }),
       evidence,
@@ -949,6 +1052,7 @@ function maybeFireNarratedFutureToolWork(params: {
       reason: "narrated_future_tool_work",
       finalContent: params.finalContent,
       failedShellCalls: params.failedShellCalls,
+      failedVerificationCalls: [],
       refusedCalls: params.refusedCalls,
     }),
     evidence: params.evidence,

--- a/runtime/src/llm/completion-validators.test.ts
+++ b/runtime/src/llm/completion-validators.test.ts
@@ -218,6 +218,46 @@ describe("completion-validators", () => {
     expect(result.maxAttempts).toBe(3);
   });
 
+  it("blocks finalization when the latest verification probe still failed", async () => {
+    const flags = makeFlags({ stopHooksEnabled: true });
+    const validators = buildCompletionValidators({
+      ctx: makeCtx({
+        flags,
+        finalContent:
+          "All phases of PLAN.md have been completed. The workspace is fully implemented and verified.",
+        allToolCalls: [
+          successfulWrite("/tmp/workspace/include/utils.h"),
+          syntheticAcceptanceProbe({
+            error: "include/utils.h:25:18: error: unknown type name 'FILE'",
+            __agencVerification: {
+              probeId: "build",
+              category: "build",
+              profile: "default",
+              repoLocal: true,
+              cwd: "/tmp/workspace",
+              command: "cmake --build build",
+              writesTempOnly: false,
+            },
+          }),
+        ],
+      }),
+      runtimeContractFlags: flags,
+      stopHookRuntime: buildStopHookRuntime({
+        enabled: true,
+      }),
+    });
+
+    const stopValidator = validators.find(
+      (validator) => validator.id === "turn_end_stop_gate",
+    );
+    const result = await stopValidator!.execute();
+
+    expect(result.outcome).toBe("retry_with_blocking_message");
+    expect(result.reason).toBe("false_success_after_failed_verification");
+    expect(result.blockingMessage).toContain("cmake --build build");
+    expect(result.stopHookResult?.outcome).toBe("retry_with_blocking_message");
+  });
+
   it("uses the shared correction budget for narrated future tool work when stop hooks are not configured", async () => {
     const validators = buildCompletionValidators({
       ctx: makeCtx({

--- a/runtime/src/llm/hooks/stop-hooks.test.ts
+++ b/runtime/src/llm/hooks/stop-hooks.test.ts
@@ -24,6 +24,32 @@ function bashFailure(command: string, stderr: string): ToolCallRecord {
   };
 }
 
+function verificationFailure(error: string): ToolCallRecord {
+  return {
+    name: "verification.runProbe",
+    args: {
+      probeId: "build",
+      cwd: "/tmp/workspace",
+      __runtimeAcceptanceProbe: true,
+    },
+    result: JSON.stringify({
+      error,
+      __agencVerification: {
+        probeId: "build",
+        category: "build",
+        profile: "default",
+        repoLocal: true,
+        cwd: "/tmp/workspace",
+        command: "cmake --build build",
+        writesTempOnly: false,
+      },
+    }),
+    isError: true,
+    durationMs: 1,
+    synthetic: true,
+  };
+}
+
 describe("stop-hooks", () => {
   it("returns undefined when stop hooks are disabled", () => {
     expect(buildStopHookRuntime(undefined)).toBeUndefined();
@@ -51,6 +77,30 @@ describe("stop-hooks", () => {
     expect(result.reason).toBe("false_success_after_failed_bash");
     expect(result.blockingMessage).toMatch(/Failing shell commands/);
     expect(result.hookOutcomes[0]?.hookId).toBe(BUILTIN_TURN_END_STOP_GATE_ID);
+  });
+
+  it("blocks completion when the latest verification probe still failed", async () => {
+    const runtime = buildStopHookRuntime({ enabled: true });
+    const result = await runStopHookPhase({
+      runtime,
+      phase: "Stop",
+      matchKey: "session-verify",
+      context: {
+        phase: "Stop",
+        sessionId: "session-verify",
+        finalContent:
+          "All phases of PLAN.md have been completed. The workspace is fully implemented and verified.",
+        allToolCalls: [
+          verificationFailure(
+            "include/utils.h:25:18: error: unknown type name 'FILE'",
+          ),
+        ],
+      },
+    });
+
+    expect(result.outcome).toBe("retry_with_blocking_message");
+    expect(result.reason).toBe("false_success_after_failed_verification");
+    expect(result.blockingMessage).toMatch(/verification\/probe step/i);
   });
 
   it("honors configured hook ordering and merges evidence by hook id", async () => {


### PR DESCRIPTION
## Summary
- align the built-in turn-end stop gate with Claude-style stop-hook semantics for shell failures
- stop treating historical failed `system.bash` calls as permanent blockers once later shell recovery succeeds in the same turn
- keep verification blocking on the latest unresolved probe and add regression coverage for recovered shell failures

## Testing
- npm --prefix agenc-core/runtime run typecheck
- cd agenc-core/runtime && npx vitest run src/llm/chat-executor-stop-gate.test.ts src/llm/hooks/stop-hooks.test.ts src/llm/completion-validators.test.ts
- npm --prefix agenc-core/runtime run build
- cd /home/tetsuo/git/AgenC && npm run techdebt