### PR TITLE
fix(runtime): default to builtin stop-hook finalization

### DIFF
--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -53,3 +53,9 @@
 - **What worked:** Switching the bash-side stop-gate detector from “any failed shell call in the turn” to “latest unresolved shell failure” restored Claude-style stop-hook semantics, so honest recoveries no longer get blocked by stale failures that were already repaired later in the same turn.
 - **What didn't:** The first stop-gate patch promoted turn-ledger history to a permanent blocker, which was stricter than Claude’s hook model and caused the runtime to stop on already-fixed failures until the detector was made resolution-aware.
 - **Rule added to CLAUDE.md:** no
+## PR #344: fix(runtime): default to builtin stop-hook finalization
+- **Date:** 2026-04-13
+- **Files changed:** `runtime/src/llm/hooks/stop-hooks.ts`, `runtime/src/llm/completion-validators.ts`, `runtime/src/llm/hooks/stop-hooks.test.ts`, `runtime/src/llm/completion-validators.test.ts`
+- **What worked:** Making builtin stop hooks default-on aligned runtime behavior with the existing `stopHooksEnabled` contract and removed the validator-only fallback that was letting false completion leak through.
+- **What didn't:** AgenC had drifted into a split contract where flags defaulted stop hooks on but the actual hook runtime only existed behind explicit config, which made the executor behave unlike Claude until this pass.
+- **Rule added to CLAUDE.md:** no

--- a/runtime/src/llm/completion-validators.test.ts
+++ b/runtime/src/llm/completion-validators.test.ts
@@ -258,7 +258,7 @@ describe("completion-validators", () => {
     expect(result.stopHookResult?.outcome).toBe("retry_with_blocking_message");
   });
 
-  it("uses the shared correction budget for narrated future tool work when stop hooks are not configured", async () => {
+  it("uses the default builtin stop-hook runtime when no explicit stop-hook config is provided", async () => {
     const validators = buildCompletionValidators({
       ctx: makeCtx({
         finalContent:
@@ -272,6 +272,7 @@ describe("completion-validators", () => {
         },
       }),
       runtimeContractFlags: makeFlags({ stopHooksEnabled: true }),
+      stopHookRuntime: buildStopHookRuntime(undefined),
     });
 
     const stopValidator = validators.find(
@@ -447,6 +448,7 @@ describe("completion-validators", () => {
       "utf8",
     );
     const targetPath = join(workspaceRoot, "src/main.c");
+    const stopHookFlags = makeFlags({ stopHooksEnabled: true });
     const narrativeCtx = makeCtx({
       workspaceRoot,
       finalContent: "Next I will fix the build and rerun the checks.",
@@ -454,6 +456,7 @@ describe("completion-validators", () => {
       targetArtifacts: [targetPath],
       turnClass: "workflow_implementation",
       ownerMode: "workflow_owner",
+      flags: stopHookFlags,
       requiredToolEvidence: {
         maxCorrectionAttempts: 3,
       },
@@ -463,7 +466,8 @@ describe("completion-validators", () => {
     ]);
     const narrativeValidators = buildCompletionValidators({
       ctx: narrativeCtx,
-      runtimeContractFlags: makeFlags(),
+      runtimeContractFlags: stopHookFlags,
+      stopHookRuntime: buildStopHookRuntime(undefined),
     });
     const filesystemCtx = makeCtx({
       workspaceRoot,
@@ -520,6 +524,7 @@ describe("completion-validators", () => {
       "utf8",
     );
     const targetPath = join(workspaceRoot, "src/main.c");
+    const stopHookFlags = makeFlags({ stopHooksEnabled: true });
     const narrativeCtx = makeCtx({
       workspaceRoot,
       finalContent: "Next I will fix the build and rerun the checks.",
@@ -527,6 +532,7 @@ describe("completion-validators", () => {
       targetArtifacts: [targetPath],
       turnClass: "workflow_implementation",
       ownerMode: "workflow_owner",
+      flags: stopHookFlags,
       requiredToolEvidence: {
         maxCorrectionAttempts: 0,
       },
@@ -536,7 +542,8 @@ describe("completion-validators", () => {
     ]);
     const narrativeValidators = buildCompletionValidators({
       ctx: narrativeCtx,
-      runtimeContractFlags: makeFlags(),
+      runtimeContractFlags: stopHookFlags,
+      stopHookRuntime: buildStopHookRuntime(undefined),
     });
     const filesystemCtx = makeCtx({
       workspaceRoot,

--- a/runtime/src/llm/completion-validators.ts
+++ b/runtime/src/llm/completion-validators.ts
@@ -1,7 +1,6 @@
 import {
   checkFilesystemArtifacts,
   evaluateArtifactEvidenceGate,
-  evaluateTurnEndStopGate,
 } from "./chat-executor-stop-gate.js";
 import {
   runDeterministicAcceptanceProbes,
@@ -160,10 +159,7 @@ export function buildCompletionValidators(params: {
       id: "turn_end_stop_gate",
       enabled: true,
       async execute(): Promise<CompletionValidatorExecutionResult> {
-        if (
-          params.runtimeContractFlags.stopHooksEnabled &&
-          params.stopHookRuntime
-        ) {
+        if (params.runtimeContractFlags.stopHooksEnabled && params.stopHookRuntime) {
           const hookResult = await runStopHookPhase({
             runtime: params.stopHookRuntime,
             phase: "Stop",
@@ -209,25 +205,7 @@ export function buildCompletionValidators(params: {
             stopHookResult: hookResult,
           };
         }
-        const decision = evaluateTurnEndStopGate({
-          finalContent: params.ctx.response?.content ?? "",
-          allToolCalls: params.ctx.allToolCalls,
-        });
-        if (!decision.shouldIntervene) {
-          return { id: "turn_end_stop_gate", outcome: "pass" };
-        }
-        return {
-          id: "turn_end_stop_gate",
-          outcome: "retry_with_blocking_message",
-          reason: decision.reason ?? "turn_end_stop_gate",
-          blockingMessage: decision.blockingMessage,
-          evidence: decision.evidence,
-          maxAttempts: sharedCorrectionBudgetCap,
-          exhaustedDetail:
-            decision.reason === "narrated_future_tool_work"
-              ? "Stop-gate recovery exhausted: the model kept narrating future work instead of calling tools."
-              : "Stop-gate recovery exhausted after the model continued to emit an invalid completion summary.",
-        };
+        return { id: "turn_end_stop_gate", outcome: "pass" };
       },
     },
     {

--- a/runtime/src/llm/hooks/stop-hooks.test.ts
+++ b/runtime/src/llm/hooks/stop-hooks.test.ts
@@ -51,8 +51,12 @@ function verificationFailure(error: string): ToolCallRecord {
 }
 
 describe("stop-hooks", () => {
-  it("returns undefined when stop hooks are disabled", () => {
-    expect(buildStopHookRuntime(undefined)).toBeUndefined();
+  it("builds the builtin stop-hook runtime by default and disables only on explicit false", () => {
+    const runtime = buildStopHookRuntime(undefined);
+    expect(runtime).toBeDefined();
+    expect(runtime?.definitionsByPhase.get("Stop")?.[0]?.id).toBe(
+      BUILTIN_TURN_END_STOP_GATE_ID,
+    );
     expect(buildStopHookRuntime({ enabled: false })).toBeUndefined();
   });
 

--- a/runtime/src/llm/hooks/stop-hooks.ts
+++ b/runtime/src/llm/hooks/stop-hooks.ts
@@ -167,7 +167,7 @@ function buildBuiltinStopHookDefinitions(): readonly StopHookRuntimeDefinition[]
 export function buildStopHookRuntime(
   config: StopHookRuntimeConfig | undefined,
 ): StopHookRuntime | undefined {
-  if (config?.enabled !== true) {
+  if (config?.enabled === false) {
     return undefined;
   }
   const definitionsByPhase = new Map<StopHookPhase, StopHookRuntimeDefinition[]>();
@@ -176,7 +176,7 @@ export function buildStopHookRuntime(
     list.push(definition);
     definitionsByPhase.set(definition.phase, list);
   }
-  for (const handler of config.handlers ?? []) {
+  for (const handler of config?.handlers ?? []) {
     const list = definitionsByPhase.get(handler.phase) ?? [];
     list.push({
       ...handler,
@@ -185,8 +185,8 @@ export function buildStopHookRuntime(
     definitionsByPhase.set(handler.phase, list);
   }
   return {
-    maxAttempts: normalizeMaxAttempts(config.maxAttempts),
-    maxAttemptsExplicit: config.maxAttempts !== undefined,
+    maxAttempts: normalizeMaxAttempts(config?.maxAttempts),
+    maxAttemptsExplicit: config?.maxAttempts !== undefined,
     definitionsByPhase,
   };
 }


### PR DESCRIPTION
## Summary
- make the builtin stop-hook runtime default-on unless explicitly disabled
- remove the validator-only turn-end stop-gate fallback so finalization blocking comes from hook results
- update runtime tests to cover default builtin stop-hook behavior

## Verification
- `cd agenc-core/runtime && npx vitest run src/llm/hooks/stop-hooks.test.ts src/llm/completion-validators.test.ts src/llm/chat-executor-stop-gate.test.ts`
- `cd agenc-core/runtime && npx vitest run src/runtime-contract/flags.test.ts src/gateway/daemon-text-channel-turn.test.ts src/llm/chat-executor-request.test.ts`
- `cd agenc-core/runtime && npm run typecheck`
- `cd agenc-core/runtime && npm run build`
