### PR TITLE
fix(runtime): gate top-level verifier to workflow turns

### DIFF
--- a/runtime/src/gateway/runtime-verifier-requirement.test.ts
+++ b/runtime/src/gateway/runtime-verifier-requirement.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { isRuntimeVerifierRequiredForTurn } from "./runtime-verifier-requirement.js";
+
+describe("isRuntimeVerifierRequiredForTurn", () => {
+  it("returns true only for workflow implementation turns with target artifacts", () => {
+    expect(
+      isRuntimeVerifierRequiredForTurn({
+        flags: { verifierRuntimeRequired: true },
+        turnExecutionContract: {
+          turnClass: "workflow_implementation",
+          targetArtifacts: ["/workspace/src/main.c"],
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for dialogue turns even when the runtime flag is enabled", () => {
+    expect(
+      isRuntimeVerifierRequiredForTurn({
+        flags: { verifierRuntimeRequired: true },
+        turnExecutionContract: {
+          turnClass: "dialogue",
+          targetArtifacts: ["/workspace/src/main.c"],
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when no target artifacts were declared", () => {
+    expect(
+      isRuntimeVerifierRequiredForTurn({
+        flags: { verifierRuntimeRequired: true },
+        turnExecutionContract: {
+          turnClass: "workflow_implementation",
+          targetArtifacts: [],
+        },
+      }),
+    ).toBe(false);
+  });
+});

--- a/runtime/src/gateway/runtime-verifier-requirement.ts
+++ b/runtime/src/gateway/runtime-verifier-requirement.ts
@@ -1,0 +1,19 @@
+import type { TurnExecutionContract } from "../llm/turn-execution-contract-types.js";
+import type { RuntimeContractFlags } from "../runtime-contract/types.js";
+
+export function isRuntimeVerifierRequiredForTurn(params: {
+  readonly flags:
+    | Pick<RuntimeContractFlags, "verifierRuntimeRequired">
+    | undefined;
+  readonly turnExecutionContract:
+    | Pick<TurnExecutionContract, "turnClass" | "targetArtifacts">
+    | undefined;
+}): boolean {
+  if (params.flags?.verifierRuntimeRequired !== true) {
+    return false;
+  }
+  if (params.turnExecutionContract?.turnClass !== "workflow_implementation") {
+    return false;
+  }
+  return (params.turnExecutionContract.targetArtifacts?.length ?? 0) > 0;
+}

--- a/runtime/src/gateway/top-level-verifier.test.ts
+++ b/runtime/src/gateway/top-level-verifier.test.ts
@@ -280,6 +280,62 @@ describe("runTopLevelVerifierValidation", () => {
     expect(decision.summary).toContain("required probe categories");
   });
 
+  it("blocks PASS verdicts backed only by weak green verification probes", async () => {
+    const spawn = vi.fn(async () => "subagent:verify-weak");
+    const waitForResult = vi.fn(async () => ({
+      sessionId: "subagent:verify-weak",
+      output: "All good.\nVERDICT: PASS",
+      success: true,
+      durationMs: 20,
+      toolCalls: [
+        {
+          name: "verification.runProbe",
+          args: { probeId: "tests:ctest" },
+          result: JSON.stringify({
+            ok: true,
+            exitCode: 0,
+            stdout: "",
+            stderr: "No tests were found!!!",
+            __agencVerification: {
+              probeId: "tests:ctest",
+              category: "build",
+              profile: "generic",
+            },
+          }),
+          isError: false,
+          durationMs: 2,
+        },
+      ],
+      structuredOutput: {
+        type: "json_schema",
+        name: "agenc_top_level_verifier_decision",
+        parsed: {
+          verdict: "pass",
+          summary: "Verifier thinks the build is correct.",
+        },
+      },
+      completionState: "completed",
+      stopReason: "completed",
+    }));
+
+    const decision = await runTopLevelVerifierValidation({
+      sessionId: "session:test",
+      userRequest: "Implement every phase from PLAN.md",
+      result: createResult(),
+      subAgentManager: { spawn, waitForResult },
+      verifierService: createVerifierService(
+        createVerifierRequirement({
+          profiles: ["generic"],
+          probeCategories: ["build"],
+        }),
+      ),
+    });
+
+    expect(decision.outcome).toBe("retry_with_blocking_message");
+    expect(decision.summary).toContain("weak green results");
+    expect(decision.summary).toContain("tests:ctest");
+  });
+
   it("records remote-job verifier handles when remote isolation is enabled", async () => {
     const spawn = vi.fn(async () => "subagent:verify-remote");
     const waitForResult = vi.fn(async () => ({

--- a/runtime/src/gateway/top-level-verifier.test.ts
+++ b/runtime/src/gateway/top-level-verifier.test.ts
@@ -193,7 +193,7 @@ describe("runTopLevelVerifierValidation", () => {
     expect(decision.runtimeVerifier.overall).toBe("fail");
   });
 
-  it("skips verifier workers for non-workflow turns", async () => {
+  it("blocks required verifier work for non-workflow turns instead of silently skipping", async () => {
     const spawn = vi.fn(async () => "subagent:verify-1");
 
     const decision = await runTopLevelVerifierValidation({
@@ -209,6 +209,42 @@ describe("runTopLevelVerifierValidation", () => {
       }),
       subAgentManager: { spawn, waitForResult: vi.fn(async () => null) },
       verifierService: createVerifierService(),
+    });
+
+    expect(spawn).not.toHaveBeenCalled();
+    expect(decision.outcome).toBe("retry_with_blocking_message");
+    expect(decision.runtimeVerifier.overall).toBe("retry");
+  });
+
+  it("still skips verifier workers when runtime verification is not required", async () => {
+    const spawn = vi.fn(async () => "subagent:verify-1");
+
+    const decision = await runTopLevelVerifierValidation({
+      sessionId: "session:test",
+      userRequest: "hello",
+      result: createResult({
+        runtimeContractSnapshot: createRuntimeContractSnapshot({
+          runtimeContractV2: false,
+          stopHooksEnabled: false,
+          asyncTasksEnabled: false,
+          persistentWorkersEnabled: false,
+          mailboxEnabled: false,
+          verifierRuntimeRequired: false,
+          verifierProjectBootstrap: false,
+          workerIsolationWorktree: false,
+          workerIsolationRemote: false,
+        }),
+        turnExecutionContract: {
+          ...createResult().turnExecutionContract,
+          turnClass: "dialogue",
+          ownerMode: "none",
+          targetArtifacts: [],
+        },
+      }),
+      subAgentManager: { spawn, waitForResult: vi.fn(async () => null) },
+      verifierService: createVerifierService(
+        createVerifierRequirement({ required: false }),
+      ),
     });
 
     expect(spawn).not.toHaveBeenCalled();

--- a/runtime/src/gateway/top-level-verifier.test.ts
+++ b/runtime/src/gateway/top-level-verifier.test.ts
@@ -33,7 +33,7 @@ function createResult(
       asyncTasksEnabled: false,
       persistentWorkersEnabled: false,
       mailboxEnabled: false,
-      verifierRuntimeRequired: false,
+      verifierRuntimeRequired: true,
       verifierProjectBootstrap: false,
       workerIsolationWorktree: false,
       workerIsolationRemote: false,
@@ -193,7 +193,7 @@ describe("runTopLevelVerifierValidation", () => {
     expect(decision.runtimeVerifier.overall).toBe("fail");
   });
 
-  it("blocks required verifier work for non-workflow turns instead of silently skipping", async () => {
+  it("skips verifier work for non-workflow turns even when the runtime flag is enabled", async () => {
     const spawn = vi.fn(async () => "subagent:verify-1");
 
     const decision = await runTopLevelVerifierValidation({
@@ -212,8 +212,8 @@ describe("runTopLevelVerifierValidation", () => {
     });
 
     expect(spawn).not.toHaveBeenCalled();
-    expect(decision.outcome).toBe("retry_with_blocking_message");
-    expect(decision.runtimeVerifier.overall).toBe("retry");
+    expect(decision.outcome).toBe("skipped");
+    expect(decision.runtimeVerifier.overall).toBe("skipped");
   });
 
   it("still skips verifier workers when runtime verification is not required", async () => {

--- a/runtime/src/gateway/top-level-verifier.ts
+++ b/runtime/src/gateway/top-level-verifier.ts
@@ -26,6 +26,7 @@ import {
   reportManagedRemoteJob,
   startManagedRemoteJob,
 } from "./remote-execution-handles.js";
+import { isRuntimeVerifierRequiredForTurn } from "./runtime-verifier-requirement.js";
 
 const DEFAULT_VERIFY_TOOLS = [
   "system.readFile",
@@ -355,16 +356,18 @@ function shouldRunTopLevelVerifier(params: TopLevelVerifierParams): boolean {
   if (isSubAgentSessionId(params.sessionId)) return false;
   if (params.result.stopReason !== "completed") return false;
   if (params.result.completionState !== "completed") return false;
-  if (params.result.turnExecutionContract.turnClass !== "workflow_implementation") {
+  if (
+    !isRuntimeVerifierRequiredForTurn({
+      flags: params.result.runtimeContractSnapshot?.flags,
+      turnExecutionContract: params.result.turnExecutionContract,
+    })
+  ) {
     return false;
   }
-  const targetArtifacts = params.result.turnExecutionContract.targetArtifacts ?? [];
-  if (targetArtifacts.length === 0) return false;
   if (!params.verifierService) return true;
   return params.verifierService.resolveVerifierRequirement({
     requested: true,
-    runtimeRequired:
-      params.result.runtimeContractSnapshot?.flags.verifierRuntimeRequired,
+    runtimeRequired: true,
     projectBootstrap:
       params.result.runtimeContractSnapshot?.flags.verifierProjectBootstrap,
     workspaceRoot: params.result.turnExecutionContract.workspaceRoot,
@@ -374,8 +377,15 @@ function shouldRunTopLevelVerifier(params: TopLevelVerifierParams): boolean {
 function resolveTopLevelVerifierRequirement(
   params: TopLevelVerifierParams,
 ): VerifierRequirement | null {
+  const runtimeRequired = isRuntimeVerifierRequiredForTurn({
+    flags: params.result.runtimeContractSnapshot?.flags,
+    turnExecutionContract: params.result.turnExecutionContract,
+  });
+  if (!runtimeRequired) {
+    return null;
+  }
   if (!params.verifierService) {
-    return params.result.runtimeContractSnapshot?.flags.verifierRuntimeRequired
+    return runtimeRequired
       ? {
           required: true,
           bootstrapSource: "fallback",
@@ -389,8 +399,7 @@ function resolveTopLevelVerifierRequirement(
   }
   return params.verifierService.resolveVerifierRequirement({
     requested: true,
-    runtimeRequired:
-      params.result.runtimeContractSnapshot?.flags.verifierRuntimeRequired,
+    runtimeRequired: true,
     projectBootstrap:
       params.result.runtimeContractSnapshot?.flags.verifierProjectBootstrap,
     workspaceRoot: params.result.turnExecutionContract.workspaceRoot,

--- a/runtime/src/gateway/top-level-verifier.ts
+++ b/runtime/src/gateway/top-level-verifier.ts
@@ -371,6 +371,67 @@ function shouldRunTopLevelVerifier(params: TopLevelVerifierParams): boolean {
   }).required;
 }
 
+function resolveTopLevelVerifierRequirement(
+  params: TopLevelVerifierParams,
+): VerifierRequirement | null {
+  if (!params.verifierService) {
+    return params.result.runtimeContractSnapshot?.flags.verifierRuntimeRequired
+      ? {
+          required: true,
+          bootstrapSource: "fallback",
+          profiles: ["generic"],
+          probeCategories: [],
+          mutationPolicy: "read_only_workspace",
+          allowTempArtifacts: false,
+          rationale: ["runtime verifier required"],
+        }
+      : null;
+  }
+  return params.verifierService.resolveVerifierRequirement({
+    requested: true,
+    runtimeRequired:
+      params.result.runtimeContractSnapshot?.flags.verifierRuntimeRequired,
+    projectBootstrap:
+      params.result.runtimeContractSnapshot?.flags.verifierProjectBootstrap,
+    workspaceRoot: params.result.turnExecutionContract.workspaceRoot,
+  });
+}
+
+function getTopLevelVerifierSkipReason(
+  params: TopLevelVerifierParams,
+): string | undefined {
+  if (isSubAgentSessionId(params.sessionId)) return "subagent_session";
+  if (params.result.stopReason !== "completed") return "stop_reason_not_completed";
+  if (params.result.completionState !== "completed") {
+    return "completion_state_not_completed";
+  }
+  if (params.result.turnExecutionContract.turnClass !== "workflow_implementation") {
+    return "turn_class_not_workflow_implementation";
+  }
+  const targetArtifacts = params.result.turnExecutionContract.targetArtifacts ?? [];
+  if (targetArtifacts.length === 0) return "missing_target_artifacts";
+  return undefined;
+}
+
+function buildTopLevelVerifierSkipBlockingMessage(reason: string): string {
+  const detail =
+    reason === "subagent_session"
+      ? "the verifier cannot run from a subagent session"
+      : reason === "stop_reason_not_completed"
+        ? "the turn has not reached a completed stop reason yet"
+        : reason === "completion_state_not_completed"
+          ? "the workflow completion state is not completed yet"
+          : reason === "turn_class_not_workflow_implementation"
+            ? "the turn is not classified as workflow_implementation"
+            : "no target artifacts were declared for verification";
+  return [
+    "Runtime verification is required before completion can be accepted.",
+    "",
+    `Verifier launch is currently blocked because ${detail}.`,
+    "Continue with tool calls until the implementation is in a verifiable completed state and target artifacts are declared.",
+  ].join("\n");
+}
+
 export async function runTopLevelVerifierValidation(
   params: TopLevelVerifierParams,
 ): Promise<TopLevelVerifierValidationResult> {
@@ -389,6 +450,50 @@ export async function runTopLevelVerifierValidation(
       });
     }
   };
+  const verifierRequirement = resolveTopLevelVerifierRequirement(params);
+  const verifierRequired = verifierRequirement?.required === true;
+  const skipReason = getTopLevelVerifierSkipReason(params);
+  if (skipReason) {
+    if (verifierRequired) {
+      const summary = `Top-level verifier is required but cannot run yet (${skipReason}).`;
+      await emitTraceEvent({
+        type: "skipped",
+        summary,
+      });
+      return {
+        outcome: "retry_with_blocking_message",
+        verifier: { performed: false, overall: "retry" },
+        runtimeVerifier: {
+          attempted: false,
+          overall: "retry",
+          summary,
+        },
+        summary,
+        blockingMessage: buildTopLevelVerifierSkipBlockingMessage(skipReason),
+        exhaustedDetail: summary,
+        verifierRequirement:
+          verifierRequirement ?? {
+            required: true,
+            bootstrapSource: "fallback",
+            profiles: ["generic"],
+            probeCategories: [],
+            mutationPolicy: "read_only_workspace",
+            allowTempArtifacts: false,
+            rationale: ["runtime verifier required"],
+          },
+      };
+    }
+    await emitTraceEvent({
+      type: "skipped",
+      summary: "Top-level verifier skipped.",
+    });
+    return {
+      outcome: "skipped",
+      verifier: { performed: false, overall: "skipped" },
+      runtimeVerifier: { attempted: false, overall: "skipped" },
+      summary: "Top-level verifier skipped.",
+    };
+  }
   if (!shouldRunTopLevelVerifier(params)) {
     await emitTraceEvent({
       type: "skipped",
@@ -440,14 +545,16 @@ export async function runTopLevelVerifierValidation(
   const workspaceRoot = normalizeWorkspaceRoot(
     params.result.turnExecutionContract.workspaceRoot,
   );
-  const verifierRequirement = params.verifierService.resolveVerifierRequirement({
-    requested: true,
-    runtimeRequired:
-      params.result.runtimeContractSnapshot?.flags.verifierRuntimeRequired,
-    projectBootstrap:
-      params.result.runtimeContractSnapshot?.flags.verifierProjectBootstrap,
-    workspaceRoot,
-  });
+  const effectiveVerifierRequirement =
+    verifierRequirement ??
+    params.verifierService.resolveVerifierRequirement({
+      requested: true,
+      runtimeRequired:
+        params.result.runtimeContractSnapshot?.flags.verifierRuntimeRequired,
+      projectBootstrap:
+        params.result.runtimeContractSnapshot?.flags.verifierProjectBootstrap,
+      workspaceRoot,
+    });
   const sourceArtifacts = normalizeArtifactPaths(
     params.result.turnExecutionContract.sourceArtifacts ?? [],
     workspaceRoot,
@@ -486,7 +593,7 @@ export async function runTopLevelVerifierValidation(
       sourceArtifacts,
       targetArtifacts,
       assistantContent: params.result.content,
-      verifierRequirement,
+      verifierRequirement: effectiveVerifierRequirement,
     }),
     systemPrompt: definition.systemPrompt,
     tools: definition.tools,
@@ -516,7 +623,7 @@ export async function runTopLevelVerifierValidation(
       },
       summary: "Remote verifier isolation is enabled but unavailable.",
       exhaustedDetail: "Remote verifier isolation is enabled but unavailable.",
-      verifierRequirement,
+      verifierRequirement: effectiveVerifierRequirement,
       launcherKind: "remote_job",
     };
   }
@@ -552,7 +659,7 @@ export async function runTopLevelVerifierValidation(
         },
         summary: `Remote verifier handle could not be started: ${message}`,
         exhaustedDetail: `Remote verifier handle could not be started: ${message}`,
-        verifierRequirement,
+        verifierRequirement: effectiveVerifierRequirement,
         launcherKind: "remote_job",
       };
     }
@@ -570,8 +677,8 @@ export async function runTopLevelVerifierValidation(
         metadata: {
           _runtime: {
             verification: true,
-            verifierProfiles: verifierRequirement.profiles,
-            verifierProbeCategories: verifierRequirement.probeCategories,
+            verifierProfiles: effectiveVerifierRequirement.profiles,
+            verifierProbeCategories: effectiveVerifierRequirement.probeCategories,
           },
         },
         summary: "Runtime verifier started.",
@@ -663,7 +770,7 @@ export async function runTopLevelVerifierValidation(
       },
       summary: "Top-level verifier worker could not be started.",
       exhaustedDetail: "Top-level verifier worker could not be started.",
-      verifierRequirement,
+      verifierRequirement: effectiveVerifierRequirement,
       launcherKind: remoteJobHandle ? "remote_job" : "subagent",
       ...(verifierTaskId ? { taskId: verifierTaskId } : {}),
     };
@@ -691,13 +798,13 @@ export async function runTopLevelVerifierValidation(
   const coverage = extractVerificationProbeCoverage(verifierResult?.toolCalls ?? []);
   const missingCategories =
     parsed.snapshot.overall === "pass"
-      ? verifierRequirement.probeCategories.filter(
+      ? effectiveVerifierRequirement.probeCategories.filter(
           (category) => !coverage.categories.includes(category),
         )
       : [];
   const missingProfiles =
     parsed.snapshot.overall === "pass"
-      ? verifierRequirement.profiles.filter(
+      ? effectiveVerifierRequirement.profiles.filter(
           (profile) =>
             profile !== "generic" &&
             !coverage.profiles.includes(profile),
@@ -705,7 +812,7 @@ export async function runTopLevelVerifierValidation(
       : [];
   const coverageBlocked =
     parsed.snapshot.overall === "pass" &&
-    verifierRequirement.required &&
+    effectiveVerifierRequirement.required &&
     (coverage.probeIds.length === 0 ||
       missingCategories.length > 0 ||
       missingProfiles.length > 0 ||
@@ -797,7 +904,7 @@ export async function runTopLevelVerifierValidation(
       runtimeVerifier,
       summary: effectiveParsed.summary,
       exhaustedDetail: `Top-level verifier retry: ${effectiveParsed.summary}`,
-      verifierRequirement,
+      verifierRequirement: effectiveVerifierRequirement,
       launcherKind: remoteJobHandle ? "remote_job" : "subagent",
       ...(verifierTaskId ? { taskId: verifierTaskId } : {}),
     };
@@ -808,7 +915,7 @@ export async function runTopLevelVerifierValidation(
       verifier: effectiveParsed.snapshot,
       runtimeVerifier,
       summary: effectiveParsed.summary,
-      verifierRequirement,
+      verifierRequirement: effectiveVerifierRequirement,
       launcherKind: remoteJobHandle ? "remote_job" : "subagent",
       ...(verifierTaskId ? { taskId: verifierTaskId } : {}),
     };
@@ -824,7 +931,7 @@ export async function runTopLevelVerifierValidation(
     }),
     exhaustedDetail:
       `Top-level verifier ${effectiveParsed.snapshot.overall}: ${effectiveParsed.summary}`,
-    verifierRequirement,
+    verifierRequirement: effectiveVerifierRequirement,
     launcherKind: remoteJobHandle ? "remote_job" : "subagent",
     ...(verifierTaskId ? { taskId: verifierTaskId } : {}),
   };

--- a/runtime/src/gateway/top-level-verifier.ts
+++ b/runtime/src/gateway/top-level-verifier.ts
@@ -238,6 +238,8 @@ function buildVerifierBlockingMessage(params: {
 function buildVerifierCoverageSummary(params: {
   readonly missingCategories: readonly string[];
   readonly missingProfiles: readonly string[];
+  readonly weakProbeIds: readonly string[];
+  readonly failedProbeIds: readonly string[];
 }): string {
   const parts: string[] = [];
   if (params.missingCategories.length > 0) {
@@ -248,6 +250,16 @@ function buildVerifierCoverageSummary(params: {
   if (params.missingProfiles.length > 0) {
     parts.push(
       `required verifier profiles were not exercised: ${params.missingProfiles.join(", ")}`,
+    );
+  }
+  if (params.weakProbeIds.length > 0) {
+    parts.push(
+      `verification probes reported weak green results: ${params.weakProbeIds.join(", ")}`,
+    );
+  }
+  if (params.failedProbeIds.length > 0) {
+    parts.push(
+      `verification probes still failed: ${params.failedProbeIds.join(", ")}`,
     );
   }
   if (parts.length === 0) {
@@ -696,7 +708,9 @@ export async function runTopLevelVerifierValidation(
     verifierRequirement.required &&
     (coverage.probeIds.length === 0 ||
       missingCategories.length > 0 ||
-      missingProfiles.length > 0);
+      missingProfiles.length > 0 ||
+      coverage.weakProbeIds.length > 0 ||
+      coverage.failedProbeIds.length > 0);
   const effectiveParsed = coverageBlocked
     ? {
         snapshot: { performed: true, overall: "retry" } as const,
@@ -706,6 +720,8 @@ export async function runTopLevelVerifierValidation(
               ? ["at least one verification probe"]
               : missingCategories,
           missingProfiles,
+          weakProbeIds: coverage.weakProbeIds,
+          failedProbeIds: coverage.failedProbeIds,
         }),
       }
     : parsed;

--- a/runtime/src/gateway/verifier-probes.ts
+++ b/runtime/src/gateway/verifier-probes.ts
@@ -62,6 +62,23 @@ export interface VerificationProbeCoverage {
   readonly probeIds: readonly string[];
   readonly categories: readonly AcceptanceProbeCategory[];
   readonly profiles: readonly VerifierProfileKind[];
+  readonly weakProbeIds: readonly string[];
+  readonly failedProbeIds: readonly string[];
+}
+
+export type VerificationProbeVerdict =
+  | "pass"
+  | "weak_pass"
+  | "fail"
+  | "not_verification";
+
+export interface VerificationProbeAssessment {
+  readonly verdict: VerificationProbeVerdict;
+  readonly probeId?: string;
+  readonly category?: AcceptanceProbeCategory;
+  readonly profile?: VerifierProfileKind;
+  readonly command?: string;
+  readonly reason?: string;
 }
 
 const DEFAULT_PROBE_TIMEOUT_MS = 120_000;
@@ -91,6 +108,104 @@ function isPlainObject(
   value: unknown,
 ): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const WEAK_VERIFICATION_PATTERNS: ReadonlyArray<{
+  readonly reason: string;
+  readonly pattern: RegExp;
+}> = [
+  {
+    reason: "no_tests_found",
+    pattern: /\bno tests were found!?/i,
+  },
+];
+
+function parseVerificationMetadata(
+  result: string,
+): {
+  readonly parsed: Record<string, unknown>;
+  readonly metadata: Record<string, unknown>;
+} | null {
+  try {
+    const parsed = JSON.parse(result) as unknown;
+    if (!isPlainObject(parsed)) {
+      return null;
+    }
+    const metadata =
+      isPlainObject(parsed.__agencVerification)
+        ? parsed.__agencVerification
+        : parsed;
+    return { parsed, metadata };
+  } catch {
+    return null;
+  }
+}
+
+export function classifyVerificationProbeResult(
+  result: string,
+): VerificationProbeAssessment {
+  const parsedResult = parseVerificationMetadata(result);
+  if (!parsedResult) {
+    return { verdict: "not_verification" };
+  }
+
+  const { parsed, metadata } = parsedResult;
+  const probeId =
+    typeof metadata.probeId === "string" && metadata.probeId.trim().length > 0
+      ? metadata.probeId.trim()
+      : undefined;
+  const category =
+    typeof metadata.category === "string"
+      ? metadata.category.trim() as AcceptanceProbeCategory
+      : undefined;
+  const profile =
+    typeof metadata.profile === "string"
+      ? metadata.profile.trim() as VerifierProfileKind
+      : undefined;
+  const command =
+    typeof metadata.command === "string" && metadata.command.trim().length > 0
+      ? metadata.command.trim()
+      : undefined;
+
+  if (
+    (typeof parsed.error === "string" && parsed.error.trim().length > 0) ||
+    parsed.timedOut === true ||
+    (typeof parsed.exitCode === "number" && parsed.exitCode !== 0)
+  ) {
+    return {
+      verdict: "fail",
+      probeId,
+      category,
+      profile,
+      command,
+    };
+  }
+
+  const stdout =
+    typeof parsed.stdout === "string" ? parsed.stdout.trim() : "";
+  const stderr =
+    typeof parsed.stderr === "string" ? parsed.stderr.trim() : "";
+  const combinedText = `${stdout}\n${stderr}`.trim();
+  for (const weakPattern of WEAK_VERIFICATION_PATTERNS) {
+    if (weakPattern.pattern.test(combinedText)) {
+      return {
+        verdict: "weak_pass",
+        probeId,
+        category,
+        profile,
+        command,
+        reason: weakPattern.reason,
+      };
+    }
+  }
+
+  return {
+    verdict: "pass",
+    probeId,
+    category,
+    profile,
+    command,
+  };
 }
 
 function readJsonObject(
@@ -718,6 +833,8 @@ export function extractVerificationProbeCoverage(
   const probeIds = new Set<string>();
   const categories = new Set<AcceptanceProbeCategory>();
   const profiles = new Set<VerifierProfileKind>();
+  const weakProbeIds = new Set<string>();
+  const failedProbeIds = new Set<string>();
 
   for (const toolCall of toolCalls) {
     if (toolCall.name !== "verification.runProbe") {
@@ -726,33 +843,24 @@ export function extractVerificationProbeCoverage(
     if (typeof toolCall.result !== "string") {
       continue;
     }
-    try {
-      const parsed = JSON.parse(toolCall.result) as Record<string, unknown>;
-      const metadata =
-        isPlainObject(parsed.__agencVerification)
-          ? parsed.__agencVerification
-          : parsed;
-      const probeId =
-        typeof metadata.probeId === "string" ? metadata.probeId.trim() : "";
-      const category =
-        typeof metadata.category === "string"
-          ? metadata.category.trim() as AcceptanceProbeCategory
-          : undefined;
-      const profile =
-        typeof metadata.profile === "string"
-          ? metadata.profile.trim() as VerifierProfileKind
-          : undefined;
-      if (probeId) {
-        probeIds.add(probeId);
+    const assessment = classifyVerificationProbeResult(toolCall.result);
+    if (assessment.verdict === "not_verification") {
+      continue;
+    }
+    if (assessment.probeId) {
+      probeIds.add(assessment.probeId);
+      if (assessment.verdict === "weak_pass") {
+        weakProbeIds.add(assessment.probeId);
       }
-      if (category) {
-        categories.add(category);
+      if (assessment.verdict === "fail") {
+        failedProbeIds.add(assessment.probeId);
       }
-      if (profile) {
-        profiles.add(profile);
-      }
-    } catch {
-      // Ignore malformed probe outputs; coverage is best effort.
+    }
+    if (assessment.category) {
+      categories.add(assessment.category);
+    }
+    if (assessment.profile) {
+      profiles.add(assessment.profile);
     }
   }
 
@@ -760,6 +868,8 @@ export function extractVerificationProbeCoverage(
     probeIds: [...probeIds],
     categories: [...categories],
     profiles: [...profiles],
+    weakProbeIds: [...weakProbeIds],
+    failedProbeIds: [...failedProbeIds],
   };
 }
 

--- a/runtime/src/llm/chat-executor-request.ts
+++ b/runtime/src/llm/chat-executor-request.ts
@@ -160,6 +160,7 @@ export async function executeRequest(
     completedRequestMilestoneIds: ctx.completedRequestMilestoneIds,
     validationCode: ctx.validationCode,
     verifier: ctx.verifierSnapshot,
+    runtimeVerifierRequired: ctx.runtimeContractSnapshot.flags.verifierRuntimeRequired,
   });
 
   const durationMs = Date.now() - ctx.startTime;

--- a/runtime/src/llm/chat-executor-request.ts
+++ b/runtime/src/llm/chat-executor-request.ts
@@ -31,6 +31,7 @@ import { sanitizeFinalContent } from "./chat-executor-text.js";
 import { summarizeStateful } from "./chat-executor-recovery.js";
 import { dispatchHooks, defaultHookExecutor } from "./hooks/index.js";
 import { resolveWorkflowCompletionState } from "../workflow/completion-state.js";
+import { isRuntimeVerifierRequiredForTurn } from "../gateway/runtime-verifier-requirement.js";
 import { deriveWorkflowProgressSnapshot } from "../workflow/completion-progress.js";
 import { buildRuntimeEconomicsSummary } from "./run-budget.js";
 import { deriveActiveTaskContext } from "./turn-execution-contract.js";
@@ -160,7 +161,10 @@ export async function executeRequest(
     completedRequestMilestoneIds: ctx.completedRequestMilestoneIds,
     validationCode: ctx.validationCode,
     verifier: ctx.verifierSnapshot,
-    runtimeVerifierRequired: ctx.runtimeContractSnapshot.flags.verifierRuntimeRequired,
+    runtimeVerifierRequired: isRuntimeVerifierRequiredForTurn({
+      flags: ctx.runtimeContractSnapshot.flags,
+      turnExecutionContract: ctx.turnExecutionContract,
+    }),
   });
 
   const durationMs = Date.now() - ctx.startTime;

--- a/runtime/src/llm/chat-executor-stop-gate.test.ts
+++ b/runtime/src/llm/chat-executor-stop-gate.test.ts
@@ -142,6 +142,39 @@ function verificationSuccess(params: {
   };
 }
 
+function verificationWeakPass(params: {
+  probeId?: string;
+  command?: string;
+  stderr?: string;
+} = {}): ToolCallRecord {
+  return {
+    name: "verification.runProbe",
+    args: {
+      probeId: params.probeId ?? "generic:test:ctest",
+      cwd: "/tmp/workspace",
+      __runtimeAcceptanceProbe: true,
+    },
+    result: JSON.stringify({
+      exitCode: 0,
+      stdout: "Internal ctest changing into directory: /tmp/workspace/build",
+      stderr: params.stderr ?? "No tests were found!!!",
+      __agencVerification: {
+        probeId: params.probeId ?? "generic:test:ctest",
+        category: "test",
+        profile: "generic",
+        repoLocal: true,
+        cwd: "/tmp/workspace",
+        command:
+          params.command ?? "ctest --test-dir build --output-on-failure",
+        writesTempOnly: false,
+      },
+    }),
+    isError: false,
+    durationMs: 1,
+    synthetic: true,
+  };
+}
+
 function successfulWrite(path: string, content: string): ToolCallRecord {
   return {
     name: "system.writeFile",
@@ -813,6 +846,23 @@ describe("evaluateTurnEndStopGate — false_success_after_failed_bash", () => {
     expect(decision.shouldIntervene).toBe(false);
   });
 
+  it("fires when the reply still claims terminal completion despite acknowledging remaining shell gaps", () => {
+    const decision = evaluateTurnEndStopGate({
+      finalContent:
+        "Implementation of Agenc Shell per PLAN.md is complete. " +
+        "Leak cleanup is the only remaining gap and does not block core functionality.",
+      allToolCalls: [
+        bashFailure({
+          command: "cd build && ./agenc-shell -c 'echo hello'",
+          stderr: "LeakSanitizer: detected memory leaks",
+        }),
+      ],
+    });
+
+    expect(decision.shouldIntervene).toBe(true);
+    expect(decision.reason).toBe("false_success_after_failed_bash");
+  });
+
   it("does NOT fire when an earlier shell failure was followed by a later shell success", () => {
     const decision = evaluateTurnEndStopGate({
       finalContent:
@@ -904,6 +954,21 @@ describe("evaluateTurnEndStopGate — false_success_after_failed_verification", 
     });
 
     expect(decision.shouldIntervene).toBe(false);
+  });
+
+  it("fires when the latest verification result is only a weak pass but the reply claims full completion", () => {
+    const decision = evaluateTurnEndStopGate({
+      finalContent:
+        "Implementation of Agenc Shell per PLAN.md is complete and fully verified.",
+      allToolCalls: [
+        successfulWrite("/tmp/workspace/tests/CMakeLists.txt", "add_test(NAME smoke COMMAND smoke)\n"),
+        verificationWeakPass(),
+      ],
+    });
+
+    expect(decision.shouldIntervene).toBe(true);
+    expect(decision.reason).toBe("false_success_after_failed_verification");
+    expect(decision.evidence.failedVerificationCallCount).toBe(1);
   });
 });
 

--- a/runtime/src/llm/chat-executor-stop-gate.ts
+++ b/runtime/src/llm/chat-executor-stop-gate.ts
@@ -67,7 +67,7 @@ import { resolveWorkflowEvidenceFromRequiredToolEvidence } from "./turn-executio
  * claims as well as opening sentences.
  */
 const FALSE_SUCCESS_RE =
-  /\b(?:build\s+(?:succeeded|successful|complete|completed|finished)|build\s+is\s+(?:successful|complete|finished)|phase\s+\d+\s+(?:complete|completed|done|finished|passed|implemented)|phase\s+\d+\s+(?:bootstrap|implementation)\s+(?:complete|completed|finished)|tests?\s+(?:passed|succeeded|all\s+pass(?:ed|ing)?)|all\s+tests?\s+pass(?:ed|ing)?|binary\s+(?:is\s+)?(?:exists|ready|built|compiled)|all\s+phases?\s+(?:complete|completed|done|finished|implemented)|all\s+phases?\s+of\s+[^\n]{0,120}?\s+have\s+been\s+(?:complete|completed|done|finished|implemented)|all\s+phases?\b(?:[^.!?\n]{0,80})\b(?:complete|completed|done|finished|implemented)|task\s+(?:complete|completed|done|finished)|implementation\s+(?:complete|completed|done|finished)|successfully\s+(?:built|compiled|implemented|completed|finished)|v\d+(?:\.\d+)*\s+complete|ready\s+to\s+ship|done\s+with\s+phase)/i;
+  /\b(?:build\s+(?:succeeded|successful|complete|completed|finished)|build\s+is\s+(?:successful|complete|finished)|phase\s+\d+\s+(?:complete|completed|done|finished|passed|implemented)|phase\s+\d+\s+(?:bootstrap|implementation)\s+(?:complete|completed|finished)|tests?\s+(?:passed|succeeded|all\s+pass(?:ed|ing)?)|all\s+tests?\s+pass(?:ed|ing)?|binary\s+(?:is\s+)?(?:exists|ready|built|compiled)|all\s+phases?\s+(?:complete|completed|done|finished|implemented)|all\s+phases?\s+of\s+[^\n]{0,120}?\s+have\s+been\s+(?:complete|completed|done|finished|implemented)|all\s+phases?\b(?:[^.!?\n]{0,80})\b(?:complete|completed|done|finished|implemented)|task\s+(?:complete|completed|done|finished)|implementation\s+(?:complete|completed|done|finished)|implementation\s+of\s+[^\n]{0,160}?\s+(?:is\s+)?(?:complete|completed|done|finished)|(?:fully|successfully)\s+verified|successfully\s+(?:built|compiled|implemented|completed|finished)|v\d+(?:\.\d+)*\s+complete|ready\s+to\s+ship|done\s+with\s+phase)/i;
 
 /**
  * Honest-acknowledgment phrases. If the final message contains BOTH a
@@ -189,7 +189,7 @@ const MID_TASK_PERMISSION_QUESTION_RE =
  * are not forced into a recovery loop.
  */
 const TERMINAL_COMPLETION_RE =
-  /\b(?:task\s+(?:complete|completed|done|finished)|all\s+phases?\s+(?:complete|completed|done|finished|implemented)|all\s+phases?\s+of\s+[^\n]{0,120}?\s+have\s+been\s+(?:complete|completed|done|finished|implemented)|all\s+phases?\b(?:[^.!?\n]{0,80})\b(?:complete|completed|done|finished|implemented)|implementation\s+(?:complete|completed|done|finished)|nothing\s+(?:more|else)\s+to\s+(?:do|implement)|session\s+(?:complete|done|finished)|finished\s+the\s+(?:task|work|implementation|plan)|project\s+(?:complete|completed|done|finished))/i;
+  /\b(?:task\s+(?:complete|completed|done|finished)|all\s+phases?\s+(?:complete|completed|done|finished|implemented)|all\s+phases?\s+of\s+[^\n]{0,120}?\s+have\s+been\s+(?:complete|completed|done|finished|implemented)|all\s+phases?\b(?:[^.!?\n]{0,80})\b(?:complete|completed|done|finished|implemented)|implementation\s+(?:complete|completed|done|finished)|implementation\s+of\s+[^\n]{0,160}?\s+(?:is\s+)?(?:complete|completed|done|finished)|nothing\s+(?:more|else)\s+to\s+(?:do|implement)|session\s+(?:complete|done|finished)|finished\s+the\s+(?:task|work|implementation|plan)|project\s+(?:complete|completed|done|finished))/i;
 
 /**
  * Tool names whose failures count as "this turn had a failed shell
@@ -272,7 +272,16 @@ export interface EvaluateTurnEndStopGateParams {
   /** The model's about-to-be-final assistant text. */
   readonly finalContent: string;
   /** The full tool ledger for the turn (`ctx.allToolCalls`, turn-scoped). */
-  readonly allToolCalls: readonly ToolCallRecord[];
+  readonly allToolCalls?: readonly ToolCallRecord[];
+  /** Optional precomputed unresolved execution snapshot for stop-hook evaluation. */
+  readonly snapshot?: TurnEndStopGateSnapshot;
+}
+
+export interface TurnEndStopGateSnapshot {
+  readonly unresolvedShellFailures: readonly ToolCallRecord[];
+  readonly unresolvedVerificationFailures: readonly ToolCallRecord[];
+  readonly unresolvedRefusals: readonly ToolCallRecord[];
+  readonly toolCallCount: number;
 }
 
 export interface EvaluateArtifactEvidenceGateParams {
@@ -322,6 +331,44 @@ function summarizeRefusedCall(record: ToolCallRecord): string {
         : "";
   const reason = typeof record.result === "string" ? record.result : "";
   return `${record.name}${target ? ` on \`${truncate(target, 100)}\`` : ""}: ${truncate(reason, 200)}`;
+}
+
+function getRefusalTargetPath(record: ToolCallRecord): string | undefined {
+  if (typeof record.args?.path === "string" && record.args.path.trim().length > 0) {
+    return record.args.path;
+  }
+  if (
+    typeof record.args?.destination === "string" &&
+    record.args.destination.trim().length > 0
+  ) {
+    return record.args.destination;
+  }
+  return undefined;
+}
+
+function isSuccessfulMutationForPath(
+  record: ToolCallRecord,
+  targetPath: string,
+): boolean {
+  if (didToolCallFail(record.isError, record.result)) {
+    return false;
+  }
+  if (record.name === "desktop.text_editor") {
+    const command =
+      typeof record.args?.command === "string"
+        ? record.args.command.trim().toLowerCase()
+        : "";
+    if (command === "view") {
+      return false;
+    }
+  }
+  const candidatePaths = [
+    typeof record.args?.path === "string" ? record.args.path : undefined,
+    typeof record.args?.destination === "string"
+      ? record.args.destination
+      : undefined,
+  ].filter((value): value is string => typeof value === "string" && value.length > 0);
+  return candidatePaths.includes(targetPath);
 }
 
 function isVerificationLikeToolCall(record: ToolCallRecord): boolean {
@@ -678,13 +725,35 @@ function findUnresolvedShellFailures(
 function findRefusedCalls(
   allToolCalls: readonly ToolCallRecord[],
 ): ToolCallRecord[] {
-  const out: ToolCallRecord[] = [];
-  for (const call of allToolCalls) {
-    if (looksLikeRefusal(call)) {
-      out.push(call);
+  for (let index = allToolCalls.length - 1; index >= 0; index -= 1) {
+    const call = allToolCalls[index];
+    if (!looksLikeRefusal(call)) {
+      continue;
+    }
+    const targetPath = getRefusalTargetPath(call);
+    if (!targetPath) {
+      return [call];
+    }
+    const resolved = allToolCalls
+      .slice(index + 1)
+      .some((laterCall) => isSuccessfulMutationForPath(laterCall, targetPath));
+    if (!resolved) {
+      return [call];
     }
   }
-  return out;
+  return [];
+}
+
+export function buildTurnEndStopGateSnapshot(
+  allToolCalls: readonly ToolCallRecord[],
+): TurnEndStopGateSnapshot {
+  return {
+    unresolvedShellFailures: findUnresolvedShellFailures(allToolCalls),
+    unresolvedVerificationFailures:
+      findUnresolvedVerificationFailures(allToolCalls),
+    unresolvedRefusals: findRefusedCalls(allToolCalls),
+    toolCallCount: allToolCalls.length,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -724,9 +793,10 @@ export function evaluateTurnEndStopGate(
 ): StopGateInterventionDecision {
   const finalContent = params.finalContent ?? "";
   const allToolCalls = params.allToolCalls ?? [];
-  const failedShellCalls = findUnresolvedShellFailures(allToolCalls);
-  const failedVerificationCalls = findUnresolvedVerificationFailures(allToolCalls);
-  const refusedCalls = findRefusedCalls(allToolCalls);
+  const snapshot = params.snapshot ?? buildTurnEndStopGateSnapshot(allToolCalls);
+  const failedShellCalls = snapshot.unresolvedShellFailures;
+  const failedVerificationCalls = snapshot.unresolvedVerificationFailures;
+  const refusedCalls = snapshot.unresolvedRefusals;
 
   const evidence: StopGateEvidence = {
     failedShellCallCount: failedShellCalls.length,
@@ -753,6 +823,7 @@ export function evaluateTurnEndStopGate(
   }
 
   const claimsSuccess = FALSE_SUCCESS_RE.test(finalContent);
+  const claimsTerminalCompletion = TERMINAL_COMPLETION_RE.test(finalContent);
   if (!claimsSuccess) {
     // Skip the success-claim detectors but still check the
     // narrated-future-tool-work detector below — narration without a
@@ -769,10 +840,12 @@ export function evaluateTurnEndStopGate(
   }
 
   const acknowledgesFailure = FAILURE_ACKNOWLEDGMENT_RE.test(finalContent);
+  const shouldBlockClaimAgainstCurrentState =
+    claimsTerminalCompletion || !acknowledgesFailure;
 
   // Detector 1: anti-fab refusal + success claim. The runtime literally
   // told the model to stop and it's now claiming success — highest signal.
-  if (refusedCalls.length > 0 && !acknowledgesFailure) {
+  if (refusedCalls.length > 0 && shouldBlockClaimAgainstCurrentState) {
     return {
       shouldIntervene: true,
       reason: "false_success_after_anti_fab_refusal",
@@ -789,7 +862,10 @@ export function evaluateTurnEndStopGate(
 
   // Detector 1.5: the latest verification/probe step in the turn still
   // failed, but the model is now claiming completion anyway.
-  if (failedVerificationCalls.length > 0 && !acknowledgesFailure) {
+  if (
+    failedVerificationCalls.length > 0 &&
+    shouldBlockClaimAgainstCurrentState
+  ) {
     return {
       shouldIntervene: true,
       reason: "false_success_after_failed_verification",
@@ -808,7 +884,7 @@ export function evaluateTurnEndStopGate(
   // 14-token truncation bug from the 2026-04-09 incident.
   if (
     finalContent.length < TRUNCATED_SUCCESS_MAX_CHARS &&
-    allToolCalls.length > 0
+    snapshot.toolCallCount > 0
   ) {
     return {
       shouldIntervene: true,
@@ -826,7 +902,7 @@ export function evaluateTurnEndStopGate(
 
   // Detector 3: failed shell call + success claim + no honest
   // acknowledgment. The classic false-success-after-failure pattern.
-  if (failedShellCalls.length > 0 && !acknowledgesFailure) {
+  if (failedShellCalls.length > 0 && shouldBlockClaimAgainstCurrentState) {
     return {
       shouldIntervene: true,
       reason: "false_success_after_failed_bash",

--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -89,6 +89,7 @@ import {
   dispatchHooks,
   defaultHookExecutor,
 } from "./hooks/index.js";
+import { runStopHookPhase } from "./hooks/stop-hooks.js";
 import type { CanUseToolFn } from "./can-use-tool.js";
 import {
   partitionToolCalls,
@@ -2156,23 +2157,228 @@ export async function executeToolCallLoop(
     const continuationSummary = ctx.continuationState.active
       ? emitContinuationEvaluation()
       : undefined;
-    const validators = buildCompletionValidators({
+    const allValidators = buildCompletionValidators({
       ctx,
       runtimeContractFlags: config.runtimeContractFlags,
       stopHookRuntime: config.stopHookRuntime,
       completionValidation: config.completionValidation,
     });
+    const validators = allValidators.filter(
+      (validator) => validator.id !== "turn_end_stop_gate",
+    );
     callbacks.emitExecutionTrace(ctx, {
       type: "completion_validation_started",
       phase: "tool_followup",
       callIndex: ctx.callIndex,
       payload: {
-        validatorOrder: validators.map((validator) => validator.id),
+        validatorOrder: [
+          "turn_end_stop_gate",
+          ...validators.map((validator) => validator.id),
+        ],
         runtimeContract: ctx.runtimeContractSnapshot,
       },
     });
 
     let completionValidationStatus = "passed";
+    const stopHooksEnabled =
+      config.runtimeContractFlags.stopHooksEnabled &&
+      config.stopHookRuntime !== undefined;
+    callbacks.emitExecutionTrace(ctx, {
+      type: "completion_validator_started",
+      phase: "tool_followup",
+      callIndex: ctx.callIndex,
+      payload: {
+        validatorId: "turn_end_stop_gate",
+        enabled: stopHooksEnabled,
+        runtimeContract: ctx.runtimeContractSnapshot,
+      },
+    });
+    if (!stopHooksEnabled) {
+      ctx.runtimeContractSnapshot = updateRuntimeContractValidatorSnapshot({
+        snapshot: ctx.runtimeContractSnapshot,
+        id: "turn_end_stop_gate",
+        enabled: false,
+        executed: false,
+        outcome: "skipped",
+      });
+      callbacks.emitExecutionTrace(ctx, {
+        type: "completion_validator_finished",
+        phase: "tool_followup",
+        callIndex: ctx.callIndex,
+        payload: {
+          validatorId: "turn_end_stop_gate",
+          enabled: false,
+          outcome: "skipped",
+          runtimeContract: ctx.runtimeContractSnapshot,
+        },
+      });
+    } else {
+      const hookResult = await runStopHookPhase({
+        runtime: config.stopHookRuntime,
+        phase: "Stop",
+        matchKey: ctx.sessionId,
+        context: {
+          phase: "Stop",
+          sessionId: ctx.sessionId,
+          runtimeWorkspaceRoot: ctx.runtimeWorkspaceRoot,
+          finalContent: ctx.response?.content ?? "",
+          allToolCalls: ctx.allToolCalls,
+        },
+      });
+      callbacks.emitExecutionTrace(ctx, {
+        type: "stop_hook_execution_finished",
+        phase: "tool_followup",
+        callIndex: ctx.callIndex,
+        payload: {
+          validatorId: "turn_end_stop_gate",
+          stopHookPhase: hookResult.phase,
+          outcome: hookResult.outcome,
+          reason: hookResult.reason,
+          stopReason: hookResult.stopReason,
+          hookIds: hookResult.hookOutcomes.map((outcome) => outcome.hookId),
+          progressMessages: hookResult.progressMessages,
+          evidence: hookResult.evidence,
+        },
+      });
+      if (hookResult.outcome !== "pass") {
+        callbacks.emitExecutionTrace(ctx, {
+          type: "stop_hook_blocked",
+          phase: "tool_followup",
+          callIndex: ctx.callIndex,
+          payload: {
+            validatorId: "turn_end_stop_gate",
+            stopHookPhase: hookResult.phase,
+            outcome: hookResult.outcome,
+            reason: hookResult.reason,
+            stopReason: hookResult.stopReason,
+          },
+        });
+      }
+      if (hookResult.outcome === "pass") {
+        ctx.runtimeContractSnapshot = updateRuntimeContractValidatorSnapshot({
+          snapshot: ctx.runtimeContractSnapshot,
+          id: "turn_end_stop_gate",
+          enabled: true,
+          executed: true,
+          outcome: "pass",
+        });
+        callbacks.emitExecutionTrace(ctx, {
+          type: "completion_validator_finished",
+          phase: "tool_followup",
+          callIndex: ctx.callIndex,
+          payload: {
+            validatorId: "turn_end_stop_gate",
+            enabled: true,
+            outcome: "pass",
+            runtimeContract: ctx.runtimeContractSnapshot,
+          },
+        });
+      } else if (hookResult.outcome === "prevent_continuation") {
+        ctx.runtimeContractSnapshot = updateRuntimeContractValidatorSnapshot({
+          snapshot: ctx.runtimeContractSnapshot,
+          id: "turn_end_stop_gate",
+          enabled: true,
+          executed: true,
+          outcome: "fail_closed",
+          reason: hookResult.reason,
+        });
+        callbacks.emitExecutionTrace(ctx, {
+          type: "completion_validator_finished",
+          phase: "tool_followup",
+          callIndex: ctx.callIndex,
+          payload: {
+            validatorId: "turn_end_stop_gate",
+            enabled: true,
+            outcome: "fail_closed",
+            reason: hookResult.reason,
+            runtimeContract: ctx.runtimeContractSnapshot,
+          },
+        });
+        completionValidationStatus = "fail_closed";
+        callbacks.setStopReason(
+          ctx,
+          "validation_error",
+          hookResult.stopReason ?? "Stop-hook chain prevented completion.",
+        );
+        if (ctx.response) {
+          ctx.response = {
+            ...ctx.response,
+            content: "",
+          };
+        }
+      } else {
+        ctx.runtimeContractSnapshot = updateRuntimeContractValidatorSnapshot({
+          snapshot: ctx.runtimeContractSnapshot,
+          id: "turn_end_stop_gate",
+          enabled: true,
+          executed: true,
+          outcome: "retry_with_blocking_message",
+          reason: hookResult.reason,
+        });
+        callbacks.emitExecutionTrace(ctx, {
+          type: "completion_validator_finished",
+          phase: "tool_followup",
+          callIndex: ctx.callIndex,
+          payload: {
+            validatorId: "turn_end_stop_gate",
+            enabled: true,
+            outcome: "retry_with_blocking_message",
+            reason: hookResult.reason,
+            runtimeContract: ctx.runtimeContractSnapshot,
+          },
+        });
+        const stopHookRecovery = await attemptCompletionRecovery({
+          reason: hookResult.reason ?? "turn_end_stop_gate",
+          blockingMessage: hookResult.blockingMessage,
+          evidence: hookResult.evidence,
+          maxAttempts:
+            config.stopHookRuntime?.maxAttemptsExplicit === true
+              ? config.stopHookRuntime.maxAttempts
+              : ctx.requiredToolEvidence?.maxCorrectionAttemptsExplicit === true
+                ? ctx.requiredToolEvidence.maxCorrectionAttempts
+                : undefined,
+          budgetReason:
+            "Max model recalls exceeded during stop-hook recovery turn",
+          exhaustedDetail:
+            hookResult.reason === "narrated_future_tool_work"
+              ? "Stop-hook recovery exhausted: the model kept narrating future work instead of calling tools."
+              : "Stop-hook recovery exhausted after the model continued to emit an invalid completion summary.",
+          validatorId: "turn_end_stop_gate",
+          stopHookResult: hookResult,
+          continuationSummary,
+        });
+        completionValidationStatus = stopHookRecovery
+          ? "recovery_requested"
+          : "recovery_exhausted";
+        callbacks.emitExecutionTrace(ctx, {
+          type: "completion_validation_finished",
+          phase: "tool_followup",
+          callIndex: ctx.callIndex,
+          payload: {
+            status: completionValidationStatus,
+            stopReason: ctx.stopReason,
+            validationCode: ctx.validationCode,
+            runtimeContract: ctx.runtimeContractSnapshot,
+          },
+        });
+        if (stopHookRecovery) {
+          continue;
+        }
+      }
+    }
+    if (completionValidationStatus === "fail_closed") {
+      callbacks.emitExecutionTrace(ctx, {
+        type: "completion_validation_finished",
+        phase: "tool_followup",
+        callIndex: ctx.callIndex,
+        payload: {
+          status: completionValidationStatus,
+          stopReason: ctx.stopReason,
+          validationCode: ctx.validationCode,
+          runtimeContract: ctx.runtimeContractSnapshot,
+        },
+      });
+    } else {
     for (const validator of validators) {
       callbacks.emitExecutionTrace(ctx, {
         type: "completion_validator_started",
@@ -2427,6 +2633,7 @@ export async function executeToolCallLoop(
       continue;
     }
   }
+  }
   } while (shouldContinueAfterStopGate);
 
   if (hasPendingToolProtocol(ctx.toolProtocolState)) {
@@ -2459,14 +2666,6 @@ export async function executeToolCallLoop(
   }
 
   ctx.finalContent = ctx.response?.content ?? "";
-  if (
-    !ctx.finalContent &&
-    ctx.lastModelStreamedContent.trim().length > 0 &&
-    ctx.allToolCalls.length > 0 &&
-    ctx.stopReason === "completed"
-  ) {
-    ctx.finalContent = ctx.lastModelStreamedContent;
-  }
   const missingFinalToolFollowupAnswer =
     !ctx.finalContent &&
     ctx.allToolCalls.length > 0 &&

--- a/runtime/src/llm/chat-executor-tool-utils.test.ts
+++ b/runtime/src/llm/chat-executor-tool-utils.test.ts
@@ -54,6 +54,25 @@ describe("chat-executor-tool-utils", () => {
       ).toBe(true);
     });
 
+    it("returns true for weak verification passes with no executed tests", () => {
+      expect(
+        didToolCallFail(
+          false,
+          JSON.stringify({
+            exitCode: 0,
+            stdout: "Internal ctest changing into directory: /workspace/build",
+            stderr: "No tests were found!!!",
+            __agencVerification: {
+              probeId: "generic:test:ctest",
+              category: "test",
+              profile: "generic",
+              command: "ctest --test-dir build --output-on-failure",
+            },
+          }),
+        ),
+      ).toBe(true);
+    });
+
     it("returns true for MCP plain-text failure signatures", () => {
       expect(
         didToolCallFail(

--- a/runtime/src/llm/chat-executor-tool-utils.ts
+++ b/runtime/src/llm/chat-executor-tool-utils.ts
@@ -7,6 +7,7 @@
 import type { LLMToolCall, LLMMessage, ToolHandler } from "./types.js";
 import type { ToolCallRecord, ToolCallAction, ToolLoopState, RecoveryHint, LLMRetryPolicyOverrides } from "./chat-executor-types.js";
 import type { LLMRetryPolicyMatrix } from "./policy.js";
+import { classifyVerificationProbeResult } from "../gateway/verifier-probes.js";
 import { resolveRuntimeTimeoutMs } from "./runtime-limit-policy.js";
 import { DEFAULT_LLM_RETRY_POLICY_MATRIX } from "./policy.js";
 import type { LLMFailureClass, LLMRetryPolicyRule } from "./policy.js";
@@ -47,6 +48,13 @@ interface ToolArgumentRepairResult {
 
 export function didToolCallFail(isError: boolean, result: string): boolean {
   if (isError) return true;
+  const verificationAssessment = classifyVerificationProbeResult(result);
+  if (
+    verificationAssessment.verdict === "fail" ||
+    verificationAssessment.verdict === "weak_pass"
+  ) {
+    return true;
+  }
   try {
     const parsed = JSON.parse(result) as unknown;
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -804,7 +804,7 @@ describe("ChatExecutor", () => {
       );
     });
 
-    it("uses streamed post-tool content when the terminal provider payload is empty", async () => {
+    it("fails closed when the terminal provider payload is empty after tool use", async () => {
       const toolHandler = vi
         .fn()
         .mockResolvedValue('{"status":"requires_input"}');
@@ -838,14 +838,14 @@ describe("ChatExecutor", () => {
       });
       const result = await executor.execute(createParams());
 
-      expect(result.stopReason).toBe("completed");
+      expect(result.stopReason).toBe("no_progress");
       expect(result.content).toBe(
-        "Yes, but your signer wallet already has registered agents.",
+        "Model returned empty content after tool follow-up; refusing to surface raw tool output as the final answer.",
       );
       expect(onStreamChunk).toHaveBeenCalledWith(
         expect.objectContaining({ content: "Yes, but your signer wallet " }),
       );
-      expect(result.content).not.toContain("Model returned empty content");
+      expect(result.content).toContain("Model returned empty content");
     });
 
     it("continues after a successful tool turn while token budget remains", async () => {

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -27,7 +27,10 @@ import {
   type ModelRoutingPolicy,
 } from "./model-routing-policy.js";
 import type { HookRegistry } from "./hooks/index.js";
-import type { StopHookRuntime } from "./hooks/stop-hooks.js";
+import {
+  buildStopHookRuntime,
+  type StopHookRuntime,
+} from "./hooks/stop-hooks.js";
 import type { CanUseToolFn } from "./can-use-tool.js";
 import type { IsConcurrencySafeFn } from "./tool-orchestration.js";
 import type {
@@ -312,7 +315,7 @@ export class ChatExecutor {
     this.defaultRunClass = config.defaultRunClass;
     this.runtimeContractFlags = config.runtimeContractFlags ?? {
       runtimeContractV2: false,
-      stopHooksEnabled: false,
+      stopHooksEnabled: true,
       asyncTasksEnabled: false,
       persistentWorkersEnabled: false,
       mailboxEnabled: false,
@@ -321,7 +324,11 @@ export class ChatExecutor {
       workerIsolationWorktree: false,
       workerIsolationRemote: false,
     };
-    this.stopHookRuntime = config.stopHookRuntime;
+    this.stopHookRuntime =
+      config.stopHookRuntime ??
+      (this.runtimeContractFlags.stopHooksEnabled
+        ? buildStopHookRuntime({})
+        : undefined);
     this.completionValidation = config.completionValidation;
     this.hookRegistry = config.hookRegistry;
     this.canUseTool = config.canUseTool;

--- a/runtime/src/llm/completion-validators.test.ts
+++ b/runtime/src/llm/completion-validators.test.ts
@@ -310,6 +310,8 @@ describe("completion-validators", () => {
         activeToolHandler: toolHandler,
         allToolCalls: [successfulWrite(join(workspaceRoot, "src/main.c"))],
         targetArtifacts: [join(workspaceRoot, "src/main.c")],
+        turnClass: "workflow_implementation",
+        ownerMode: "workflow_owner",
         flags,
       }),
       runtimeContractFlags: flags,
@@ -340,6 +342,26 @@ describe("completion-validators", () => {
     expect(deterministicResult.stopHookResult?.phase).toBe("VerificationReady");
     expect(topLevelResult.outcome).toBe("retry_with_blocking_message");
     expect(toolHandler).not.toHaveBeenCalled();
+  });
+
+  it("skips the top-level verifier on dialogue turns even when runtime verification is globally enabled", async () => {
+    const flags = makeFlags({
+      verifierRuntimeRequired: true,
+    });
+    const validators = buildCompletionValidators({
+      ctx: makeCtx({
+        flags,
+        allToolCalls: [successfulWrite("/tmp/workspace/src/main.c")],
+        targetArtifacts: ["/tmp/workspace/src/main.c"],
+      }),
+      runtimeContractFlags: flags,
+    });
+
+    const result = await validators.find(
+      (validator) => validator.id === "top_level_verifier",
+    )!.execute();
+
+    expect(result.outcome).toBe("skipped");
   });
 
   it("uses the shared correction budget for deterministic acceptance probes on workflow-owned turns", async () => {

--- a/runtime/src/llm/completion-validators.ts
+++ b/runtime/src/llm/completion-validators.ts
@@ -1,4 +1,5 @@
 import {
+  buildTurnEndStopGateSnapshot,
   checkFilesystemArtifacts,
   evaluateArtifactEvidenceGate,
 } from "./chat-executor-stop-gate.js";
@@ -160,6 +161,9 @@ export function buildCompletionValidators(params: {
       enabled: true,
       async execute(): Promise<CompletionValidatorExecutionResult> {
         if (params.runtimeContractFlags.stopHooksEnabled && params.stopHookRuntime) {
+          const turnEndSnapshot = buildTurnEndStopGateSnapshot(
+            params.ctx.allToolCalls,
+          );
           const hookResult = await runStopHookPhase({
             runtime: params.stopHookRuntime,
             phase: "Stop",
@@ -170,6 +174,7 @@ export function buildCompletionValidators(params: {
               runtimeWorkspaceRoot: params.ctx.runtimeWorkspaceRoot,
               finalContent: params.ctx.response?.content ?? "",
               allToolCalls: params.ctx.allToolCalls,
+              turnEndSnapshot,
             },
           });
           if (hookResult.outcome === "pass") {

--- a/runtime/src/llm/completion-validators.ts
+++ b/runtime/src/llm/completion-validators.ts
@@ -22,6 +22,7 @@ import type {
   CompletionValidatorId,
   RuntimeContractFlags,
 } from "../runtime-contract/types.js";
+import { isRuntimeVerifierRequiredForTurn } from "../gateway/runtime-verifier-requirement.js";
 import { runTopLevelVerifierValidation } from "../gateway/top-level-verifier.js";
 import { getRemainingRequestTaskMilestones } from "./request-task-progress.js";
 
@@ -54,8 +55,10 @@ export function buildCompletionValidators(params: {
           params.stopHookRuntime.maxAttempts,
         )
       : sharedCorrectionBudgetCap;
-  const topLevelVerifierEnabled =
-    params.runtimeContractFlags.verifierRuntimeRequired;
+  const topLevelVerifierEnabled = isRuntimeVerifierRequiredForTurn({
+    flags: params.runtimeContractFlags,
+    turnExecutionContract: params.ctx.turnExecutionContract,
+  });
   const deterministicAcceptanceProbesEnabled =
     shouldRunDeterministicAcceptanceProbes({
       workspaceRoot: params.ctx.runtimeWorkspaceRoot,

--- a/runtime/src/llm/hooks/stop-hooks.ts
+++ b/runtime/src/llm/hooks/stop-hooks.ts
@@ -1,7 +1,11 @@
 import { spawn } from "node:child_process";
 
 import type { ToolCallRecord } from "../chat-executor-types.js";
-import { evaluateTurnEndStopGate } from "../chat-executor-stop-gate.js";
+import {
+  buildTurnEndStopGateSnapshot,
+  evaluateTurnEndStopGate,
+  type TurnEndStopGateSnapshot,
+} from "../chat-executor-stop-gate.js";
 import { matchesHookMatcher } from "./matcher.js";
 
 export const STOP_HOOK_PHASES = [
@@ -56,6 +60,7 @@ export interface StopHookContext {
   readonly runtimeWorkspaceRoot?: string;
   readonly finalContent?: string;
   readonly allToolCalls?: readonly ToolCallRecord[];
+  readonly turnEndSnapshot?: TurnEndStopGateSnapshot;
   readonly verificationReady?: {
     readonly deterministicAcceptanceProbesEnabled: boolean;
     readonly topLevelVerifierEnabled: boolean;
@@ -138,7 +143,10 @@ function buildBuiltinStopHookDefinitions(): readonly StopHookRuntimeDefinition[]
         const startedAt = Date.now();
         const decision = evaluateTurnEndStopGate({
           finalContent: context.finalContent ?? "",
-          allToolCalls: context.allToolCalls ?? [],
+          allToolCalls: context.allToolCalls,
+          snapshot:
+            context.turnEndSnapshot ??
+            buildTurnEndStopGateSnapshot(context.allToolCalls ?? []),
         });
         return {
           hookId: BUILTIN_TURN_END_STOP_GATE_ID,

--- a/runtime/src/workflow/completion-state.test.ts
+++ b/runtime/src/workflow/completion-state.test.ts
@@ -145,6 +145,27 @@ describe("completion-state", () => {
     ).toBe("needs_verification");
   });
 
+  it("keeps runtime-required work in needs_verification when verifier is skipped", () => {
+    expect(
+      resolveWorkflowCompletionState({
+        stopReason: "completed",
+        toolCalls: [
+          {
+            name: "system.writeFile",
+            args: { path: "/workspace/src/runner.js" },
+            result: JSON.stringify({ ok: true }),
+            isError: false,
+          },
+        ],
+        verifier: {
+          performed: false,
+          overall: "skipped",
+        },
+        runtimeVerifierRequired: true,
+      }),
+    ).toBe("needs_verification");
+  });
+
   it("keeps request-level multi-phase work partial when local verification passes but planner milestones remain", () => {
     expect(
       resolveWorkflowCompletionState({

--- a/runtime/src/workflow/completion-state.ts
+++ b/runtime/src/workflow/completion-state.ts
@@ -56,6 +56,7 @@ export function resolveWorkflowCompletionState(input: {
   readonly completedRequestMilestoneIds?: readonly string[];
   readonly validationCode?: DelegationOutputValidationCode;
   readonly verifier?: PlannerVerificationSnapshot;
+  readonly runtimeVerifierRequired?: boolean;
 }): WorkflowCompletionState {
   const verifier = input.verifier;
   const completionContract =
@@ -75,6 +76,9 @@ export function resolveWorkflowCompletionState(input: {
     }
     if (verifier?.overall === "retry" || verifier?.overall === "fail") {
       return hasProgress ? "partial" : "blocked";
+    }
+    if (input.runtimeVerifierRequired && verifier?.overall !== "pass") {
+      return "needs_verification";
     }
     if (
       requiresPassedVerificationForCompletion(completionContract) &&


### PR DESCRIPTION
## Summary
- gate top-level verifier requirement to real workflow implementation turns
- stop dialogue turns from inheriting a mandatory verifier they cannot run
- keep completion-state and validator wiring aligned with the effective per-turn verifier requirement

## Testing
- `cd runtime && npx vitest run src/gateway/runtime-verifier-requirement.test.ts src/gateway/top-level-verifier.test.ts src/llm/completion-validators.test.ts src/llm/chat-executor-request.test.ts`
- `cd runtime && npm run typecheck`
- `cd runtime && npm run build`
- `cd /home/tetsuo/git/AgenC && npm run techdebt`
