### PR TITLE
fix(grok): recover silent tool drops with forced replay

### DIFF
--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -2627,6 +2627,201 @@ describe("GrokProvider", () => {
     expect(response.content).toBe("Recovered after retry");
   });
 
+  it("retries direct silent tool drops with tool_choice required", async () => {
+    mockCreate
+      .mockResolvedValueOnce(
+        makeCompletion({
+          id: "resp_silent_drop_initial",
+          output_text: "I will call system.bash to inspect the build.",
+          output: [
+            {
+              type: "message",
+              content: [
+                {
+                  type: "output_text",
+                  text: "I will call system.bash to inspect the build.",
+                },
+              ],
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeCompletion({
+          id: "resp_silent_drop_retry",
+          output_text: "",
+          output: [
+            {
+              type: "function_call",
+              call_id: "call_silent_drop_1",
+              name: "system.bash",
+              arguments: '{"command":"pwd"}',
+            },
+          ],
+        }),
+      );
+
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      model: "grok-4.20-beta-0309-reasoning",
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "system.bash",
+            description: "run command",
+            parameters: {
+              type: "object",
+              properties: { command: { type: "string" } },
+            },
+          },
+        },
+      ],
+    });
+
+    const response = await provider.chat([
+      { role: "user", content: "inspect the build" },
+      {
+        role: "assistant",
+        content: "",
+        phase: "commentary",
+        toolCalls: [
+          {
+            id: "call_silent_drop_seed",
+            name: "system.bash",
+            arguments: '{"command":"echo seeded"}',
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: "seeded",
+        toolCallId: "call_silent_drop_seed",
+        toolName: "system.bash",
+      },
+    ]);
+
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+    expect(mockCreate.mock.calls[1][0].tool_choice).toBe("required");
+    expect(mockCreate.mock.calls[1][0].stream).toBe(false);
+    expect(response.toolCalls).toMatchObject([
+      {
+        id: "call_silent_drop_1",
+        name: "system.bash",
+        arguments: '{"command":"pwd"}',
+      },
+    ]);
+  });
+
+  it("retries silent tool drops that happen on the tool_choice none mitigation path", async () => {
+    mockCreate
+      .mockResolvedValueOnce(
+        makeCompletion({
+          id: "resp_truncated_initial",
+          output_text: "Continuing with tool calls to fix the build",
+          output: [
+            {
+              type: "message",
+              content: [
+                {
+                  type: "output_text",
+                  text: "Continuing with tool calls to fix the build",
+                },
+              ],
+            },
+          ],
+          usage: {
+            input_tokens: 100,
+            output_tokens: 22,
+            total_tokens: 122,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeCompletion({
+          id: "resp_truncated_retry_none",
+          output_text: "I will call system.bash to inspect the build.",
+          output: [
+            {
+              type: "message",
+              content: [
+                {
+                  type: "output_text",
+                  text: "I will call system.bash to inspect the build.",
+                },
+              ],
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeCompletion({
+          id: "resp_truncated_retry_required",
+          output_text: "",
+          output: [
+            {
+              type: "function_call",
+              call_id: "call_recovered_1",
+              name: "system.bash",
+              arguments: '{"command":"ls"}',
+            },
+          ],
+        }),
+      );
+
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      model: "grok-4.20-beta-0309-reasoning",
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "system.bash",
+            description: "run command",
+            parameters: {
+              type: "object",
+              properties: { command: { type: "string" } },
+            },
+          },
+        },
+      ],
+    });
+
+    const response = await provider.chat([
+      { role: "user", content: "inspect the build" },
+      {
+        role: "assistant",
+        content: "",
+        phase: "commentary",
+        toolCalls: [
+          {
+            id: "call_truncation_seed",
+            name: "system.bash",
+            arguments: '{"command":"echo seeded"}',
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: "seeded",
+        toolCallId: "call_truncation_seed",
+        toolName: "system.bash",
+      },
+    ]);
+
+    expect(mockCreate).toHaveBeenCalledTimes(3);
+    expect(mockCreate.mock.calls[1][0].tool_choice).toBe("none");
+    expect(mockCreate.mock.calls[2][0].tool_choice).toBe("required");
+    expect(mockCreate.mock.calls[2][0].stream).toBe(false);
+    expect(response.toolCalls).toMatchObject([
+      {
+        id: "call_recovered_1",
+        name: "system.bash",
+        arguments: '{"command":"ls"}',
+      },
+    ]);
+  });
+
   it("keeps previous_response_id continuity when replayed tool-call arguments are sanitized", async () => {
     const rawArguments = JSON.stringify({
       path: "packages/core/src/routing.test.ts",

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -938,14 +938,27 @@ export class GrokProvider implements LLMProvider {
         // Auto-mitigate the xAI mid-sentence truncation bug by
         // replaying with tool_choice="none" when the strict filter
         // detects the trigger pattern. See report.txt §4.4.
-        const mitigatedResponse = await this.maybeRetryMidSentenceTruncation(
+        const truncationMitigatedResponse = await this.maybeRetryMidSentenceTruncation(
           client,
           activePlan.params as Record<string, unknown>,
           originalResponse as Record<string, unknown>,
           options,
           "chat",
         );
-        const response = (mitigatedResponse ?? originalResponse) as typeof originalResponse;
+        const silentDropMitigatedResponse =
+          await this.maybeRetrySilentToolDrop(
+            client,
+            activePlan.params as Record<string, unknown>,
+            (truncationMitigatedResponse ??
+              originalResponse) as Record<string, unknown>,
+            options,
+            "chat",
+          );
+        const response = (
+          silentDropMitigatedResponse ??
+          truncationMitigatedResponse ??
+          originalResponse
+        ) as typeof originalResponse;
         const responseMeta = buildProviderResponseMeta({
           response: result.response,
           requestId: result.requestId,
@@ -1217,13 +1230,25 @@ export class GrokProvider implements LLMProvider {
           // text. A secondary onChunk is emitted with the corrected
           // content so UIs that re-render on the latest delta show
           // the corrected version. See report.txt §4.4.
-          const mitigatedResponse = await this.maybeRetryMidSentenceTruncation(
+          const truncationMitigatedResponse =
+            await this.maybeRetryMidSentenceTruncation(
             client,
             params,
             response as Record<string, unknown>,
             options,
             "chat_stream",
           );
+          const silentDropMitigatedResponse =
+            await this.maybeRetrySilentToolDrop(
+              client,
+              params,
+              (truncationMitigatedResponse ??
+                response) as Record<string, unknown>,
+              options,
+              "chat_stream",
+            );
+          const mitigatedResponse =
+            silentDropMitigatedResponse ?? truncationMitigatedResponse;
           if (mitigatedResponse) {
             response = mitigatedResponse;
             // Reset stream-accumulated tool calls; the mitigation
@@ -2489,10 +2514,105 @@ export class GrokProvider implements LLMProvider {
         return undefined;
       }
 
+      const silentDropRecovered = await this.maybeRetrySilentToolDrop(
+        client,
+        retryParams,
+        retryResponse,
+        options,
+        transport,
+      );
+      if (silentDropRecovered) {
+        return silentDropRecovered;
+      }
+
       return retryResponse;
     } catch (err) {
       console.warn(
         `[GrokProvider] xAI mid-sentence truncation retry failed:`,
+        err instanceof Error ? err.message : String(err),
+      );
+      return undefined;
+    }
+  }
+
+  private async maybeRetrySilentToolDrop(
+    client: unknown,
+    originalParams: Record<string, unknown>,
+    originalResponse: Record<string, unknown>,
+    options: LLMChatOptions | undefined,
+    transport: "chat" | "chat_stream",
+  ): Promise<Record<string, unknown> | undefined> {
+    const anomalies = validateXaiResponsePostFlight({
+      request: originalParams,
+      response: originalResponse,
+    });
+    const silentDrop = anomalies.find(
+      (a) => a.code === "silent_tool_drop_promised_in_text",
+    );
+    if (!silentDrop) return undefined;
+
+    const retryParams: Record<string, unknown> = {
+      ...originalParams,
+      tool_choice: "required",
+      stream: false,
+    };
+
+    emitProviderTraceEvent(options, {
+      kind: "request",
+      transport,
+      provider: this.name,
+      model: String(retryParams.model ?? this.config.model),
+      payload:
+        cloneProviderTracePayload(retryParams) ??
+        { error: "provider_retry_request_trace_unavailable" },
+      context: {
+        retryReason: "xai_silent_tool_drop_mitigation",
+        originalEvidence: silentDrop.evidence,
+      } as unknown as ReturnType<typeof buildProviderRequestTraceContext>,
+    });
+
+    try {
+      const retryResult = await createWithResponseMetadata<
+        Record<string, unknown>
+      >(client, retryParams, undefined);
+      const retryResponse = retryResult.data;
+
+      emitProviderTraceEvent(options, {
+        kind: "response",
+        transport,
+        provider: this.name,
+        model: String(
+          (retryResponse as { model?: unknown }).model ?? retryParams.model,
+        ),
+        payload:
+          cloneProviderTracePayload(retryResponse) ??
+          { error: "provider_retry_response_trace_unavailable" },
+        context: {
+          retryReason: "xai_silent_tool_drop_mitigation",
+        } as unknown as ReturnType<typeof buildProviderResponseTraceContext>,
+      });
+
+      const retryAnomalies = validateXaiResponsePostFlight({
+        request: retryParams,
+        response: retryResponse,
+      });
+      const retryStillBroken = retryAnomalies.some(
+        (a) =>
+          a.code === "silent_tool_drop_promised_in_text" ||
+          a.code === "truncated_response_mid_sentence",
+      );
+      if (retryStillBroken) {
+        console.warn(
+          `[GrokProvider] xAI silent-tool-drop retry with tool_choice="required" ` +
+            `also returned a broken tool transition; falling through to original.`,
+        );
+        return undefined;
+      }
+
+      return retryResponse;
+    } catch (err) {
+      console.warn(
+        `[GrokProvider] xAI silent-tool-drop retry failed:`,
         err instanceof Error ? err.message : String(err),
       );
       return undefined;


### PR DESCRIPTION
## Summary
- recover xAI silent-tool-drop tool followups with a second-stage forced replay
- preserve the existing tool_choice `none` truncation mitigation, but escalate to `required` when the retry still promises tools with zero function calls
- add adapter regressions for direct silent drops and the truncation-mitigation silent-drop path

## Verification
- `cd runtime && npx vitest run src/llm/grok/adapter.test.ts`
- `cd runtime && npm run typecheck`
- `cd runtime && npm run build`
- `cd /home/tetsuo/git/AgenC && npm run techdebt`