### PR TITLE
refactor(runtime): reduce loop and completion gate state

### DIFF
--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -66,3 +66,10 @@
 - **What worked:** Matching Claude’s stale-file contract made edit retries fail fast with an explicit reread requirement instead of grinding through repeated `old_string not found` misses, and removing the repeated-failure breaker let failing tool rounds continue under the normal hook and round budgets instead of a hidden three-strikes fuse.
 - **What didn't:** AgenC still had dead breaker config, state, and tests after the stop path was removed, so the parity fix wasn’t complete until the dormant breaker surface was deleted as well.
 - **Rule added to CLAUDE.md:** no
+
+## PR #348: refactor(runtime): reduce loop and completion gate state
+- **Date:** 2026-04-14
+- **Files changed:** `runtime/src/llm/chat-executor-tool-loop.ts`, `runtime/src/llm/hooks/stop-hooks.ts`, `runtime/src/runtime-contract/types.ts`, `runtime/src/gateway/top-level-verifier.ts`, `runtime/src/llm/completion-validators.ts`, `runtime/src/workflow/request-task-runtime.ts`, `runtime/src/tools/system/filesystem.ts`, `runtime/src/gateway/tool-handler-factory.ts`, `runtime/src/llm/compact/*`
+- **What worked:** Collapsing finalization onto the built-in stop-hook chain removed the second completion engine after hooks, while the file-tool cleanup and compaction attachment side-channel simplified the runtime around one message-centric loop with fewer hidden gates.
+- **What didn't:** The refactor touched several dependent runtime surfaces at once, so type and test fallout showed up in hook typing and validator snapshot expectations before the reduced contract settled.
+- **Rule added to CLAUDE.md:** no

--- a/runtime/src/gateway/tool-handler-factory.test.ts
+++ b/runtime/src/gateway/tool-handler-factory.test.ts
@@ -3107,7 +3107,7 @@ describe("createSessionToolHandler", () => {
     rmSync(workspaceRoot, { recursive: true, force: true });
   });
 
-  it("blocks destructive writeFile overwrites after reading a larger document", async () => {
+  it("allows writeFile overwrites after reading a larger document", async () => {
     const workspaceRoot = createTempDir("agenc-overwrite-guard-");
     const planPath = join(workspaceRoot, "PLAN.md");
     const originalPlan =
@@ -3145,11 +3145,10 @@ describe("createSessionToolHandler", () => {
       content: "## Post-Review Updates\n\n- Add jobs.\n",
     });
     expect(JSON.parse(writeResult)).toEqual({
-      error:
-        `Refusing destructive overwrite of previously-read file "${planPath}". ` +
-        "Preserve the existing content when revising the file, or use system.appendFile for an additive update.",
+      path: planPath,
+      bytesWritten: 42,
     });
-    expect(baseHandler).toHaveBeenCalledTimes(1);
+    expect(baseHandler).toHaveBeenCalledTimes(2);
 
     rmSync(workspaceRoot, { recursive: true, force: true });
   });

--- a/runtime/src/gateway/tool-handler-factory.ts
+++ b/runtime/src/gateway/tool-handler-factory.ts
@@ -644,16 +644,6 @@ interface DefaultWorkingDirectoryApplication {
   };
 }
 
-interface RecentFileObservation {
-  readonly path: string;
-  readonly content?: string;
-  readonly observedAtSeq: number;
-}
-
-const RECENT_FILE_OBSERVATION_LIMIT = 12;
-const DESTRUCTIVE_OVERWRITE_MAX_AGE = 4;
-const DESTRUCTIVE_OVERWRITE_LENGTH_RATIO = 0.6;
-
 function tryParseJsonRecord(value: string): Record<string, unknown> | undefined {
   try {
     const parsed = JSON.parse(value) as unknown;
@@ -664,22 +654,6 @@ function tryParseJsonRecord(value: string): Record<string, unknown> | undefined 
     return undefined;
   }
   return undefined;
-}
-
-function resolveFilesystemTargetPath(
-  args: Record<string, unknown>,
-  defaultWorkingDirectory?: string,
-): string | undefined {
-  const rawPath = typeof args.path === 'string' ? args.path.trim() : '';
-  if (rawPath.length === 0) return undefined;
-  if (isAbsolute(rawPath) || rawPath.startsWith('~')) {
-    return rawPath;
-  }
-  const cwd = typeof args.cwd === 'string' && args.cwd.trim().length > 0
-    ? args.cwd.trim()
-    : defaultWorkingDirectory?.trim();
-  if (!cwd) return undefined;
-  return resolvePath(cwd, rawPath);
 }
 
 function resolveToolTargetPaths(
@@ -1111,57 +1085,6 @@ function isRepoLocalVerificationHarnessPath(
     /(?:^|\/)(?:run|verify|smoke|integration|e2e)[-_]?tests?\.(?:sh|bash|zsh)$/iu
       .test(relativePath)
   );
-}
-
-function collectMeaningfulLines(value: string): string[] {
-  return value
-    .split(/\r?\n/u)
-    .map((line) => line.trim())
-    .filter((line) => line.length >= 16);
-}
-
-function hasSufficientLineOverlap(
-  previousContent: string,
-  nextContent: string,
-): boolean {
-  const previousLines = collectMeaningfulLines(previousContent);
-  if (previousLines.length === 0) {
-    return false;
-  }
-  const nextLines = new Set(collectMeaningfulLines(nextContent));
-  if (nextLines.size === 0) {
-    return false;
-  }
-  const overlapCount = previousLines.filter((line) => nextLines.has(line)).length;
-  return overlapCount / previousLines.length >= 0.25;
-}
-
-function isPotentiallyDestructiveOverwrite(
-  previousContent: string,
-  nextContent: string,
-): boolean {
-  const previous = previousContent.trim();
-  const next = nextContent.trim();
-  if (previous.length === 0 || next.length === 0) {
-    return false;
-  }
-  if (next === previous) {
-    return false;
-  }
-  if (next.length >= previous.length * DESTRUCTIVE_OVERWRITE_LENGTH_RATIO) {
-    return false;
-  }
-  return !hasSufficientLineOverlap(previous, next);
-}
-
-function buildRecentFileObservationMap(
-  observations: readonly RecentFileObservation[],
-): Map<string, RecentFileObservation> {
-  const map = new Map<string, RecentFileObservation>();
-  for (const observation of observations) {
-    map.set(observation.path, observation);
-  }
-  return map;
 }
 
 function applyDefaultWorkingDirectory(
@@ -2510,7 +2433,6 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
   // Per-message duplicate guard to avoid opening the same GUI app twice when
   // the model emits repeated desktop.bash launch calls in one turn.
   const seenGuiLaunches = new Set<string>();
-  const recentFileObservations: RecentFileObservation[] = [];
   const nextToolCallId = (): string =>
     `tool-${Date.now().toString(36)}-${++toolCallSeq}`;
 
@@ -2617,7 +2539,6 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
     const effectiveScopedFilesystemRoot =
       subAgentExecutionContext?.workspaceRoot ?? scopedFilesystemRoot;
     const toolCallId = nextToolCallId();
-    const fileObservationMap = buildRecentFileObservationMap(recentFileObservations);
     const delegationObjective = extractDelegationObjective(normalizedArgs);
 
     if (
@@ -3080,31 +3001,6 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
             })
           : routedHandler;
 
-    if (toolName === 'system.writeFile') {
-      const targetPath = resolveFilesystemTargetPath(
-        executionArgs,
-        effectiveDefaultWorkingDirectory,
-      );
-      const previousObservation =
-        targetPath ? fileObservationMap.get(targetPath) : undefined;
-      const nextContent =
-        typeof executionArgs.content === 'string' ? executionArgs.content : undefined;
-      if (
-        previousObservation?.content &&
-        nextContent &&
-        toolCallSeq - previousObservation.observedAtSeq <= DESTRUCTIVE_OVERWRITE_MAX_AGE &&
-        isPotentiallyDestructiveOverwrite(previousObservation.content, nextContent)
-      ) {
-        const destructiveOverwriteError =
-          `Refusing destructive overwrite of previously-read file "${targetPath}". ` +
-          "Preserve the existing content when revising the file, or use system.appendFile for an additive update.";
-        return sendRecordedImmediateToolError(
-          JSON.stringify({ error: destructiveOverwriteError }),
-          destructiveOverwriteError,
-        );
-      }
-    }
-
     // 6. Execute and time
     if (effectLedger && effectRecord) {
       effectRecord =
@@ -3165,47 +3061,6 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
     const durationMs = Date.now() - start;
     incidentDiagnostics?.clearDomain("tool");
     const isError = didToolCallFail(false, result);
-    if (!isError) {
-      if (toolName === 'system.readFile') {
-        const parsed = tryParseJsonRecord(result);
-        const observedPath =
-          typeof parsed?.path === 'string'
-            ? parsed.path
-            : resolveFilesystemTargetPath(executionArgs, effectiveDefaultWorkingDirectory);
-        if (observedPath) {
-          const nextObservation: RecentFileObservation = {
-            path: observedPath,
-            content: typeof parsed?.content === 'string' ? parsed.content : undefined,
-            observedAtSeq: toolCallSeq,
-          };
-          recentFileObservations.push(nextObservation);
-          if (recentFileObservations.length > RECENT_FILE_OBSERVATION_LIMIT) {
-            recentFileObservations.splice(
-              0,
-              recentFileObservations.length - RECENT_FILE_OBSERVATION_LIMIT,
-            );
-          }
-        }
-      } else if (toolName === 'system.writeFile') {
-        const targetPath = resolveFilesystemTargetPath(
-          executionArgs,
-          effectiveDefaultWorkingDirectory,
-        );
-        if (targetPath && typeof executionArgs.content === 'string') {
-          recentFileObservations.push({
-            path: targetPath,
-            content: executionArgs.content,
-            observedAtSeq: toolCallSeq,
-          });
-          if (recentFileObservations.length > RECENT_FILE_OBSERVATION_LIMIT) {
-            recentFileObservations.splice(
-              0,
-              recentFileObservations.length - RECENT_FILE_OBSERVATION_LIMIT,
-            );
-          }
-        }
-      }
-    }
 
     if (effectLedger && effectRecord) {
       const postExecutionSnapshots =

--- a/runtime/src/gateway/top-level-verifier.test.ts
+++ b/runtime/src/gateway/top-level-verifier.test.ts
@@ -46,6 +46,11 @@ function createResult(
       sourceArtifacts: ["/workspace/PLAN.md"],
       targetArtifacts: ["/workspace/src/main.c"],
       delegationPolicy: "direct_owner",
+      completionContract: {
+        taskClass: "build_required",
+        placeholdersAllowed: false,
+        partialCompletionAllowed: false,
+      },
       contractFingerprint: "contract-1",
       taskLineageId: "task-1",
     },
@@ -193,7 +198,7 @@ describe("runTopLevelVerifierValidation", () => {
     expect(decision.runtimeVerifier.overall).toBe("fail");
   });
 
-  it("skips verifier work for non-workflow turns even when the runtime flag is enabled", async () => {
+  it("skips verifier work for ordinary workflow turns with artifact-only completion", async () => {
     const spawn = vi.fn(async () => "subagent:verify-1");
 
     const decision = await runTopLevelVerifierValidation({
@@ -202,9 +207,13 @@ describe("runTopLevelVerifierValidation", () => {
       result: createResult({
         turnExecutionContract: {
           ...createResult().turnExecutionContract,
-          turnClass: "dialogue",
-          ownerMode: "none",
-          targetArtifacts: [],
+          turnClass: "workflow_implementation",
+          ownerMode: "workflow_owner",
+          completionContract: {
+            taskClass: "artifact_only",
+            placeholdersAllowed: false,
+            partialCompletionAllowed: true,
+          },
         },
       }),
       subAgentManager: { spawn, waitForResult: vi.fn(async () => null) },

--- a/runtime/src/gateway/top-level-verifier.ts
+++ b/runtime/src/gateway/top-level-verifier.ts
@@ -13,6 +13,7 @@ import {
   extractVerificationProbeCoverage,
   type VerifierRequirement,
 } from "./verifier-probes.js";
+import type { TurnExecutionContract } from "../llm/turn-execution-contract-types.js";
 import type {
   SubAgentConfig,
   SubAgentManager,
@@ -26,7 +27,6 @@ import {
   reportManagedRemoteJob,
   startManagedRemoteJob,
 } from "./remote-execution-handles.js";
-import { isRuntimeVerifierRequiredForTurn } from "./runtime-verifier-requirement.js";
 
 const DEFAULT_VERIFY_TOOLS = [
   "system.readFile",
@@ -141,6 +141,45 @@ export interface TopLevelVerifierTraceEvent {
 function truncate(text: string, max: number): string {
   if (text.length <= max) return text;
   return `${text.slice(0, max - 1).trimEnd()}…`;
+}
+
+function getTopLevelVerifierTaskClass(
+  turnExecutionContract:
+    | Pick<TurnExecutionContract, "completionContract" | "verificationContract">
+    | undefined,
+): string | undefined {
+  const completionContract = turnExecutionContract?.completionContract as
+    | { readonly taskClass?: unknown }
+    | undefined;
+  if (typeof completionContract?.taskClass === "string") {
+    return completionContract.taskClass;
+  }
+
+  const verificationContract = turnExecutionContract?.verificationContract as
+    | { readonly completionContract?: { readonly taskClass?: unknown } }
+    | undefined;
+  const nestedTaskClass =
+    verificationContract?.completionContract?.taskClass;
+  return typeof nestedTaskClass === "string" ? nestedTaskClass : undefined;
+}
+
+export function isExplicitTopLevelVerifierRequiredForTurn(params: {
+  readonly turnExecutionContract:
+    | Pick<
+        TurnExecutionContract,
+        "turnClass" | "completionContract" | "verificationContract"
+      >
+    | undefined;
+}): boolean {
+  if (params.turnExecutionContract?.turnClass !== "workflow_implementation") {
+    return false;
+  }
+  const taskClass = getTopLevelVerifierTaskClass(params.turnExecutionContract);
+  return (
+    taskClass === "build_required" ||
+    taskClass === "behavior_required" ||
+    taskClass === "review_required"
+  );
 }
 
 function selectVerifyDefinition(
@@ -357,8 +396,7 @@ function shouldRunTopLevelVerifier(params: TopLevelVerifierParams): boolean {
   if (params.result.stopReason !== "completed") return false;
   if (params.result.completionState !== "completed") return false;
   if (
-    !isRuntimeVerifierRequiredForTurn({
-      flags: params.result.runtimeContractSnapshot?.flags,
+    !isExplicitTopLevelVerifierRequiredForTurn({
       turnExecutionContract: params.result.turnExecutionContract,
     })
   ) {
@@ -377,15 +415,14 @@ function shouldRunTopLevelVerifier(params: TopLevelVerifierParams): boolean {
 function resolveTopLevelVerifierRequirement(
   params: TopLevelVerifierParams,
 ): VerifierRequirement | null {
-  const runtimeRequired = isRuntimeVerifierRequiredForTurn({
-    flags: params.result.runtimeContractSnapshot?.flags,
+  const explicitVerifierRequired = isExplicitTopLevelVerifierRequiredForTurn({
     turnExecutionContract: params.result.turnExecutionContract,
   });
-  if (!runtimeRequired) {
+  if (!explicitVerifierRequired) {
     return null;
   }
   if (!params.verifierService) {
-    return runtimeRequired
+    return explicitVerifierRequired
       ? {
           required: true,
           bootstrapSource: "fallback",

--- a/runtime/src/llm/chat-executor-recovery.test.ts
+++ b/runtime/src/llm/chat-executor-recovery.test.ts
@@ -768,27 +768,6 @@ describe("chat-executor-recovery", () => {
     expect(hint?.message).toContain("rerun `npm install`");
   });
 
-  it("flags destructive writeFile overwrites with whole-file rewrite guidance", () => {
-    const hint = inferRecoveryHint({
-      name: "system.writeFile",
-      args: {
-        path: "/tmp/workspace/src/lexer.c",
-        content: "advance(lexer); // skip backslash",
-      },
-      result: JSON.stringify({
-        error:
-          'Refusing destructive overwrite of previously-read file "/tmp/workspace/src/lexer.c". Preserve the existing content when revising the file, or use system.appendFile for an additive update.',
-      }),
-      isError: true,
-      durationMs: 2,
-    });
-
-    expect(hint).toBeDefined();
-    expect(hint?.key).toBe("system-writefile-destructive-overwrite");
-    expect(hint?.message).toContain("rewrite the COMPLETE file body");
-    expect(hint?.message).toContain("system.appendFile");
-  });
-
   it("flags repo-local verification harness shadow copies and redirects to direct bounded verification", () => {
     const hint = inferRecoveryHint({
       name: "system.writeFile",

--- a/runtime/src/llm/chat-executor-recovery.ts
+++ b/runtime/src/llm/chat-executor-recovery.ts
@@ -1764,19 +1764,6 @@ export function inferRecoveryHint(
   }
 
   if (
-    call.name === "system.writeFile" &&
-    failureTextLower.includes("refusing destructive overwrite of previously-read file")
-  ) {
-    return {
-      key: "system-writefile-destructive-overwrite",
-      message:
-        "This `system.writeFile` call tried to replace a previously-read file with partial or destructive content. " +
-        "Re-read the current file contents, preserve the unchanged sections, and rewrite the COMPLETE file body in one `system.writeFile` call. " +
-        "Do not send only the changed snippet unless you are using an additive tool like `system.appendFile`.",
-    };
-  }
-
-  if (
     call.name === "system.browse" ||
     call.name === "system.httpGet" ||
     call.name === "system.httpPost" ||

--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -61,7 +61,7 @@ import {
   ANTI_FABRICATION_HARNESS_OVERWRITE_REASON,
   evaluateWriteOverFailedVerification,
 } from "./verification-target-guard.js";
-import { buildCompletionValidators } from "./completion-validators.js";
+import { buildTurnEndStopGateSnapshot } from "./chat-executor-stop-gate.js";
 import {
   checkTurnContinuationBudget,
   countTurnCompletionTokens,
@@ -80,7 +80,13 @@ import {
   dispatchHooks,
   defaultHookExecutor,
 } from "./hooks/index.js";
-import { runStopHookPhase } from "./hooks/stop-hooks.js";
+import {
+  BUILTIN_ARTIFACT_EVIDENCE_HOOK_ID,
+  BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID,
+  BUILTIN_FILESYSTEM_ARTIFACT_VERIFICATION_HOOK_ID,
+  BUILTIN_TURN_END_STOP_GATE_ID,
+  runStopHookPhase,
+} from "./hooks/stop-hooks.js";
 import type { CanUseToolFn } from "./can-use-tool.js";
 import {
   partitionToolCalls,
@@ -115,9 +121,7 @@ import type { DelegationOutputValidationCode } from "../utils/delegation-validat
 import {
   type CompletionValidatorId,
   updateRuntimeContractValidatorSnapshot,
-  updateRuntimeContractVerifierStage,
   updateRuntimeContractToolProtocolSnapshot,
-  updateRuntimeContractVerifierVerdict,
 } from "../runtime-contract/types.js";
 import {
   getPendingToolProtocolCalls,
@@ -132,7 +136,6 @@ import {
 } from "./tool-protocol-state.js";
 import {
   getRemainingRequestTaskMilestones,
-  noteRequestTaskVerifierAttempt,
   REQUEST_TASK_PROGRESS_NO_IN_PROGRESS_KEY,
   REQUEST_TASK_PROGRESS_NO_TASK_YET_KEY,
   type RequestTaskObservationResult,
@@ -2079,24 +2082,35 @@ export async function executeToolCallLoop(
     const continuationSummary = ctx.continuationState.active
       ? emitContinuationEvaluation()
       : undefined;
-    const allValidators = buildCompletionValidators({
-      ctx,
-      runtimeContractFlags: config.runtimeContractFlags,
-      stopHookRuntime: config.stopHookRuntime,
-      completionValidation: config.completionValidation,
-    });
-    const validators = allValidators.filter(
-      (validator) => validator.id !== "turn_end_stop_gate",
-    );
+    const stopHookValidators = [
+      {
+        hookId: BUILTIN_TURN_END_STOP_GATE_ID,
+        validatorId: "turn_end_stop_gate" as CompletionValidatorId,
+      },
+      {
+        hookId: BUILTIN_ARTIFACT_EVIDENCE_HOOK_ID,
+        validatorId: "artifact_evidence" as CompletionValidatorId,
+      },
+      {
+        hookId: BUILTIN_FILESYSTEM_ARTIFACT_VERIFICATION_HOOK_ID,
+        validatorId: "filesystem_artifact_verification" as CompletionValidatorId,
+      },
+      {
+        hookId: BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID,
+        validatorId: "deterministic_acceptance_probes" as CompletionValidatorId,
+      },
+    ] as const;
+    const skippedValidators = [
+      "request_task_progress",
+      "top_level_verifier",
+    ] as const satisfies readonly CompletionValidatorId[];
+
     callbacks.emitExecutionTrace(ctx, {
       type: "completion_validation_started",
       phase: "tool_followup",
       callIndex: ctx.callIndex,
       payload: {
-        validatorOrder: [
-          "turn_end_stop_gate",
-          ...validators.map((validator) => validator.id),
-        ],
+        validatorOrder: stopHookValidators.map((entry) => entry.validatorId),
         runtimeContract: ctx.runtimeContractSnapshot,
       },
     });
@@ -2105,20 +2119,23 @@ export async function executeToolCallLoop(
     const stopHooksEnabled =
       config.runtimeContractFlags.stopHooksEnabled &&
       config.stopHookRuntime !== undefined;
-    callbacks.emitExecutionTrace(ctx, {
-      type: "completion_validator_started",
-      phase: "tool_followup",
-      callIndex: ctx.callIndex,
-      payload: {
-        validatorId: "turn_end_stop_gate",
-        enabled: stopHooksEnabled,
-        runtimeContract: ctx.runtimeContractSnapshot,
-      },
-    });
-    if (!stopHooksEnabled) {
+
+    for (const entry of stopHookValidators) {
+      callbacks.emitExecutionTrace(ctx, {
+        type: "completion_validator_started",
+        phase: "tool_followup",
+        callIndex: ctx.callIndex,
+        payload: {
+          validatorId: entry.validatorId,
+          enabled: stopHooksEnabled,
+          runtimeContract: ctx.runtimeContractSnapshot,
+        },
+      });
+    }
+    for (const validatorId of skippedValidators) {
       ctx.runtimeContractSnapshot = updateRuntimeContractValidatorSnapshot({
         snapshot: ctx.runtimeContractSnapshot,
-        id: "turn_end_stop_gate",
+        id: validatorId,
         enabled: false,
         executed: false,
         outcome: "skipped",
@@ -2128,12 +2145,35 @@ export async function executeToolCallLoop(
         phase: "tool_followup",
         callIndex: ctx.callIndex,
         payload: {
-          validatorId: "turn_end_stop_gate",
+          validatorId,
           enabled: false,
           outcome: "skipped",
           runtimeContract: ctx.runtimeContractSnapshot,
         },
       });
+    }
+
+    if (!stopHooksEnabled) {
+      for (const entry of stopHookValidators) {
+        ctx.runtimeContractSnapshot = updateRuntimeContractValidatorSnapshot({
+          snapshot: ctx.runtimeContractSnapshot,
+          id: entry.validatorId,
+          enabled: false,
+          executed: false,
+          outcome: "skipped",
+        });
+        callbacks.emitExecutionTrace(ctx, {
+          type: "completion_validator_finished",
+          phase: "tool_followup",
+          callIndex: ctx.callIndex,
+          payload: {
+            validatorId: entry.validatorId,
+            enabled: false,
+            outcome: "skipped",
+            runtimeContract: ctx.runtimeContractSnapshot,
+          },
+        });
+      }
     } else {
       const hookResult = await runStopHookPhase({
         runtime: config.stopHookRuntime,
@@ -2145,6 +2185,18 @@ export async function executeToolCallLoop(
           runtimeWorkspaceRoot: ctx.runtimeWorkspaceRoot,
           finalContent: ctx.response?.content ?? "",
           allToolCalls: ctx.allToolCalls,
+          turnEndSnapshot: buildTurnEndStopGateSnapshot(ctx.allToolCalls),
+          runtimeChecks: {
+            requiredToolEvidence: ctx.requiredToolEvidence,
+            targetArtifacts: ctx.turnExecutionContract.targetArtifacts,
+            activeToolHandler: ctx.activeToolHandler,
+            appendProbeRuns: (runs) => {
+              for (const run of runs) {
+                const observation = callbacks.appendToolRecord(ctx, run);
+                reconcileRequestTaskReminderState(ctx, callbacks, observation);
+              }
+            },
+          },
         },
       });
       callbacks.emitExecutionTrace(ctx, {
@@ -2162,6 +2214,46 @@ export async function executeToolCallLoop(
           evidence: hookResult.evidence,
         },
       });
+
+      const hookOutcomes = new Map(
+        hookResult.hookOutcomes.map((outcome) => [outcome.hookId, outcome]),
+      );
+      for (const entry of stopHookValidators) {
+        const outcome = hookOutcomes.get(entry.hookId);
+        const snapshotOutcome =
+          !outcome
+            ? "skipped"
+            : outcome.preventContinuation
+              ? "fail_closed"
+              : outcome.blockingError
+                ? "retry_with_blocking_message"
+                : "pass";
+        const reason =
+          outcome?.stopReason ??
+          outcome?.blockingError?.hookId ??
+          outcome?.hookId;
+        ctx.runtimeContractSnapshot = updateRuntimeContractValidatorSnapshot({
+          snapshot: ctx.runtimeContractSnapshot,
+          id: entry.validatorId,
+          enabled: true,
+          executed: outcome !== undefined,
+          outcome: snapshotOutcome,
+          reason,
+        });
+        callbacks.emitExecutionTrace(ctx, {
+          type: "completion_validator_finished",
+          phase: "tool_followup",
+          callIndex: ctx.callIndex,
+          payload: {
+            validatorId: entry.validatorId,
+            enabled: true,
+            outcome: snapshotOutcome,
+            reason,
+            runtimeContract: ctx.runtimeContractSnapshot,
+          },
+        });
+      }
+
       if (hookResult.outcome !== "pass") {
         callbacks.emitExecutionTrace(ctx, {
           type: "stop_hook_blocked",
@@ -2176,46 +2268,8 @@ export async function executeToolCallLoop(
           },
         });
       }
-      if (hookResult.outcome === "pass") {
-        ctx.runtimeContractSnapshot = updateRuntimeContractValidatorSnapshot({
-          snapshot: ctx.runtimeContractSnapshot,
-          id: "turn_end_stop_gate",
-          enabled: true,
-          executed: true,
-          outcome: "pass",
-        });
-        callbacks.emitExecutionTrace(ctx, {
-          type: "completion_validator_finished",
-          phase: "tool_followup",
-          callIndex: ctx.callIndex,
-          payload: {
-            validatorId: "turn_end_stop_gate",
-            enabled: true,
-            outcome: "pass",
-            runtimeContract: ctx.runtimeContractSnapshot,
-          },
-        });
-      } else if (hookResult.outcome === "prevent_continuation") {
-        ctx.runtimeContractSnapshot = updateRuntimeContractValidatorSnapshot({
-          snapshot: ctx.runtimeContractSnapshot,
-          id: "turn_end_stop_gate",
-          enabled: true,
-          executed: true,
-          outcome: "fail_closed",
-          reason: hookResult.reason,
-        });
-        callbacks.emitExecutionTrace(ctx, {
-          type: "completion_validator_finished",
-          phase: "tool_followup",
-          callIndex: ctx.callIndex,
-          payload: {
-            validatorId: "turn_end_stop_gate",
-            enabled: true,
-            outcome: "fail_closed",
-            reason: hookResult.reason,
-            runtimeContract: ctx.runtimeContractSnapshot,
-          },
-        });
+
+      if (hookResult.outcome === "prevent_continuation") {
         completionValidationStatus = "fail_closed";
         callbacks.setStopReason(
           ctx,
@@ -2228,27 +2282,7 @@ export async function executeToolCallLoop(
             content: "",
           };
         }
-      } else {
-        ctx.runtimeContractSnapshot = updateRuntimeContractValidatorSnapshot({
-          snapshot: ctx.runtimeContractSnapshot,
-          id: "turn_end_stop_gate",
-          enabled: true,
-          executed: true,
-          outcome: "retry_with_blocking_message",
-          reason: hookResult.reason,
-        });
-        callbacks.emitExecutionTrace(ctx, {
-          type: "completion_validator_finished",
-          phase: "tool_followup",
-          callIndex: ctx.callIndex,
-          payload: {
-            validatorId: "turn_end_stop_gate",
-            enabled: true,
-            outcome: "retry_with_blocking_message",
-            reason: hookResult.reason,
-            runtimeContract: ctx.runtimeContractSnapshot,
-          },
-        });
+      } else if (hookResult.outcome === "retry_with_blocking_message") {
         const stopHookRecovery = await attemptCompletionRecovery({
           reason: hookResult.reason ?? "turn_end_stop_gate",
           blockingMessage: hookResult.blockingMessage,
@@ -2260,7 +2294,13 @@ export async function executeToolCallLoop(
                 ? ctx.requiredToolEvidence.maxCorrectionAttempts
                 : undefined,
           budgetReason:
-            "Max model recalls exceeded during stop-hook recovery turn",
+            hookResult.reason === "artifact_evidence"
+              ? "Max model recalls exceeded during artifact-evidence recovery turn"
+              : hookResult.reason === "filesystem_artifact_verification"
+                ? "Max model recalls exceeded during filesystem artifact recovery turn"
+                : hookResult.reason === "deterministic_acceptance_probe_failed"
+                  ? "Max model recalls exceeded during deterministic acceptance-probe recovery turn"
+                  : "Max model recalls exceeded during stop-hook recovery turn",
           exhaustedDetail:
             hookResult.reason === "narrated_future_tool_work"
               ? "Stop-hook recovery exhausted: the model kept narrating future work instead of calling tools."
@@ -2288,251 +2328,6 @@ export async function executeToolCallLoop(
         }
       }
     }
-    if (completionValidationStatus === "fail_closed") {
-      callbacks.emitExecutionTrace(ctx, {
-        type: "completion_validation_finished",
-        phase: "tool_followup",
-        callIndex: ctx.callIndex,
-        payload: {
-          status: completionValidationStatus,
-          stopReason: ctx.stopReason,
-          validationCode: ctx.validationCode,
-          runtimeContract: ctx.runtimeContractSnapshot,
-        },
-      });
-    } else {
-    for (const validator of validators) {
-      callbacks.emitExecutionTrace(ctx, {
-        type: "completion_validator_started",
-        phase: "tool_followup",
-        callIndex: ctx.callIndex,
-        payload: {
-          validatorId: validator.id,
-          enabled: validator.enabled,
-          runtimeContract: ctx.runtimeContractSnapshot,
-        },
-      });
-      if (!validator.enabled) {
-        if (validator.id === "top_level_verifier") {
-          ctx.runtimeContractSnapshot = updateRuntimeContractVerifierStage({
-            snapshot: ctx.runtimeContractSnapshot,
-            verifierStages: {
-              ...ctx.runtimeContractSnapshot.verifierStages,
-              stageStatus: ctx.runtimeContractSnapshot.flags.verifierRuntimeRequired
-                ? "skipped"
-                : "inactive",
-              ...(ctx.runtimeContractSnapshot.flags.verifierRuntimeRequired
-                ? { skipReason: "validator_disabled" }
-                : { skipReason: "runtime_not_required" }),
-            },
-          });
-        }
-        ctx.runtimeContractSnapshot = updateRuntimeContractValidatorSnapshot({
-          snapshot: ctx.runtimeContractSnapshot,
-          id: validator.id,
-          enabled: false,
-          executed: false,
-          outcome: "skipped",
-        });
-        callbacks.emitExecutionTrace(ctx, {
-          type: "completion_validator_finished",
-          phase: "tool_followup",
-          callIndex: ctx.callIndex,
-          payload: {
-            validatorId: validator.id,
-            enabled: false,
-            outcome: "skipped",
-            runtimeContract: ctx.runtimeContractSnapshot,
-          },
-        });
-        continue;
-      }
-
-      if (validator.id === "top_level_verifier") {
-        ctx.runtimeContractSnapshot = updateRuntimeContractVerifierStage({
-          snapshot: ctx.runtimeContractSnapshot,
-          verifierStages: {
-            ...ctx.runtimeContractSnapshot.verifierStages,
-            stageStatus: "running",
-            skipReason: undefined,
-          },
-        });
-      }
-
-      const validation = await validator.execute();
-      if (validation.stopHookResult) {
-        callbacks.emitExecutionTrace(ctx, {
-          type: "stop_hook_execution_finished",
-          phase: "tool_followup",
-          callIndex: ctx.callIndex,
-          payload: {
-            validatorId: validator.id,
-            stopHookPhase: validation.stopHookResult.phase,
-            outcome: validation.stopHookResult.outcome,
-            reason: validation.stopHookResult.reason,
-            stopReason: validation.stopHookResult.stopReason,
-            hookIds: validation.stopHookResult.hookOutcomes.map(
-              (outcome) => outcome.hookId,
-            ),
-            progressMessages: validation.stopHookResult.progressMessages,
-            evidence: validation.stopHookResult.evidence,
-          },
-        });
-        if (validation.stopHookResult.outcome !== "pass") {
-          callbacks.emitExecutionTrace(ctx, {
-            type: "stop_hook_blocked",
-            phase: "tool_followup",
-            callIndex: ctx.callIndex,
-            payload: {
-              validatorId: validator.id,
-              stopHookPhase: validation.stopHookResult.phase,
-              outcome: validation.stopHookResult.outcome,
-              reason: validation.stopHookResult.reason,
-              stopReason: validation.stopHookResult.stopReason,
-              validationCode: validation.validationCode,
-            },
-          });
-        }
-      }
-      if (validation.probeRuns) {
-        for (const run of validation.probeRuns) {
-          const observation = callbacks.appendToolRecord(ctx, run);
-          reconcileRequestTaskReminderState(ctx, callbacks, observation);
-        }
-      }
-      if (validation.verifier) {
-        ctx.verifierSnapshot = {
-          performed: validation.verifier.attempted,
-          overall: validation.verifier.overall,
-        };
-        if (validation.verifier.attempted) {
-          noteRequestTaskVerifierAttempt(ctx.requestTaskState);
-        }
-        ctx.runtimeContractSnapshot = updateRuntimeContractVerifierVerdict({
-          snapshot: ctx.runtimeContractSnapshot,
-          verifier: validation.verifier,
-        });
-      }
-      if (validator.id === "top_level_verifier") {
-        const verifierStageStatus =
-          validation.outcome === "pass"
-            ? "passed"
-            : validation.outcome === "fail_closed"
-              ? "failed"
-              : validation.outcome === "retry_with_blocking_message"
-                ? validation.verifier?.overall === "fail"
-                  ? "failed"
-                  : "retry"
-                : "skipped";
-        ctx.runtimeContractSnapshot = updateRuntimeContractVerifierStage({
-          snapshot: ctx.runtimeContractSnapshot,
-          verifierStages: {
-            ...ctx.runtimeContractSnapshot.verifierStages,
-            ...(validation.verifierTaskId
-              ? { taskId: validation.verifierTaskId }
-              : {}),
-            ...(validation.verifierRequirement
-              ? {
-                  bootstrapSource: validation.verifierRequirement.bootstrapSource,
-                  profiles: validation.verifierRequirement.profiles,
-                  probeCategories: validation.verifierRequirement.probeCategories,
-                }
-              : {}),
-            ...(validation.verifierLauncherKind
-              ? { launcherKind: validation.verifierLauncherKind }
-              : {}),
-            stageStatus: verifierStageStatus,
-            ...(validation.outcome === "skipped" && validation.reason
-              ? { skipReason: validation.reason }
-              : verifierStageStatus === "skipped"
-                ? { skipReason: "validator_skipped" }
-                : { skipReason: undefined }),
-          },
-        });
-      }
-      ctx.runtimeContractSnapshot = updateRuntimeContractValidatorSnapshot({
-        snapshot: ctx.runtimeContractSnapshot,
-        id: validator.id,
-        enabled: true,
-        executed: validation.outcome !== "skipped",
-        outcome: validation.outcome,
-        reason: validation.reason,
-        validationCode: validation.validationCode,
-      });
-      callbacks.emitExecutionTrace(ctx, {
-        type: "completion_validator_finished",
-        phase: "tool_followup",
-        callIndex: ctx.callIndex,
-        payload: {
-          validatorId: validator.id,
-          outcome: validation.outcome,
-          reason: validation.reason,
-          validationCode: validation.validationCode,
-          verifierTaskId: validation.verifierTaskId,
-          verifierLauncherKind: validation.verifierLauncherKind,
-          exhaustedDetail: validation.exhaustedDetail,
-          runtimeContract: ctx.runtimeContractSnapshot,
-        },
-      });
-
-      if (
-        validation.outcome === "pass" ||
-        validation.outcome === "skipped"
-      ) {
-        continue;
-      }
-
-      if (validation.outcome === "fail_closed") {
-        completionValidationStatus = "fail_closed";
-        callbacks.setStopReason(
-          ctx,
-          "validation_error",
-          validation.exhaustedDetail ?? "Completion validation failed closed.",
-        );
-        if (validation.validationCode) {
-          ctx.validationCode = validation.validationCode;
-        }
-        if (ctx.response) {
-          ctx.response = {
-            ...ctx.response,
-            content: "",
-          };
-        }
-        break;
-      }
-
-      const budgetReason =
-        validator.id === "artifact_evidence"
-          ? "Max model recalls exceeded during artifact-evidence recovery turn"
-          : validator.id === "turn_end_stop_gate"
-            ? "Max model recalls exceeded during stop-gate recovery turn"
-            : validator.id === "request_task_progress"
-              ? "Max model recalls exceeded during request-task progress recovery turn"
-              : validator.id === "filesystem_artifact_verification"
-              ? "Max model recalls exceeded during filesystem artifact recovery turn"
-              : validator.id === "deterministic_acceptance_probes"
-                ? "Max model recalls exceeded during deterministic acceptance-probe recovery turn"
-                : "Max model recalls exceeded during top-level verifier recovery turn";
-
-      await attemptCompletionRecovery({
-        reason: validation.reason ?? validator.id,
-        blockingMessage: validation.blockingMessage,
-        evidence: validation.evidence,
-        maxAttempts: validation.maxAttempts,
-        budgetReason,
-        exhaustedDetail:
-          validation.exhaustedDetail ??
-          `${validator.id} recovery exhausted.`,
-        validationCode: validation.validationCode,
-        validatorId: validator.id,
-        stopHookResult: validation.stopHookResult,
-        continuationSummary,
-      });
-      completionValidationStatus = shouldContinueAfterStopGate
-        ? "recovery_requested"
-        : "recovery_exhausted";
-      break;
-    }
 
     callbacks.emitExecutionTrace(ctx, {
       type: "completion_validation_finished",
@@ -2554,7 +2349,6 @@ export async function executeToolCallLoop(
     if (requestedBudgetContinuation) {
       continue;
     }
-  }
   }
   } while (shouldContinueAfterStopGate);
 

--- a/runtime/src/llm/compact/attachment-preservation.test.ts
+++ b/runtime/src/llm/compact/attachment-preservation.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_SNIP_GAP_MS } from "./constants.js";
+import {
+  applyReactiveCompact,
+  createReactiveCompactState,
+} from "./reactive-compact.js";
+import { applySnip, createSnipState } from "./snip.js";
+import type { LLMMessage } from "../types.js";
+
+function makeMultimodalUser(content: string, imageUrl: string): LLMMessage {
+  return {
+    role: "user",
+    content: [
+      { type: "text", text: content },
+      { type: "image_url", image_url: { url: imageUrl } },
+    ],
+  };
+}
+
+function makeUser(content: string): LLMMessage {
+  return { role: "user", content };
+}
+
+describe("preserved attachments", () => {
+  it("preserves attachments from snipped multimodal messages", () => {
+    let state = createSnipState();
+    state = applySnip({
+      messages: [makeUser("seed")],
+      state,
+      nowMs: 1_000_000_000,
+    }).state;
+
+    const messages: LLMMessage[] = [makeMultimodalUser("look", "https://example.com/a.png")];
+    for (let i = 0; i < 40; i++) {
+      messages.push(makeUser(`q${i}`));
+    }
+
+    const result = applySnip({
+      messages,
+      state,
+      nowMs: 1_000_000_000 + DEFAULT_SNIP_GAP_MS + 1,
+    });
+
+    expect(result.action).toBe("snipped");
+    expect(result.preservedAttachments).toHaveLength(1);
+    expect(result.preservedAttachments[0]).toMatchObject({
+      messageIndex: 0,
+      role: "user",
+      content: messages[0]?.content,
+    });
+  });
+
+  it("preserves attachments from reactive trims", () => {
+    const messages: LLMMessage[] = [
+      makeMultimodalUser("look", "https://example.com/b.png"),
+      makeUser("q1"),
+      makeUser("q2"),
+      makeUser("q3"),
+      makeUser("q4"),
+      makeUser("q5"),
+      makeUser("q6"),
+      makeUser("q7"),
+    ];
+
+    const result = applyReactiveCompact({
+      messages,
+      state: createReactiveCompactState(),
+      nowMs: 1_000_000_000,
+    });
+
+    expect(result.action).toBe("trimmed");
+    expect(result.preservedAttachments).toHaveLength(1);
+    expect(result.preservedAttachments[0]).toMatchObject({
+      messageIndex: 0,
+      role: "user",
+      content: messages[0]?.content,
+    });
+  });
+});

--- a/runtime/src/llm/compact/attachments.ts
+++ b/runtime/src/llm/compact/attachments.ts
@@ -1,0 +1,37 @@
+/**
+ * Message-attachment helpers for the compact pipeline.
+ *
+ * Compaction layers are message-centric: if they have to drop a
+ * message that carried multimodal content, the content is surfaced
+ * here as an explicit side channel so the caller can preserve it
+ * separately from the trimmed message list.
+ *
+ * @module
+ */
+
+import type { LLMContentPart, LLMMessage } from "../types.js";
+
+export interface PreservedAttachment {
+  readonly messageIndex: number;
+  readonly role: LLMMessage["role"];
+  readonly content: readonly LLMContentPart[];
+}
+
+export function collectPreservedAttachments(
+  messages: readonly LLMMessage[],
+  startIndex = 0,
+): readonly PreservedAttachment[] {
+  const preserved: PreservedAttachment[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    if (!message || !Array.isArray(message.content) || message.content.length === 0) {
+      continue;
+    }
+    preserved.push({
+      messageIndex: startIndex + i,
+      role: message.role,
+      content: message.content,
+    });
+  }
+  return preserved;
+}

--- a/runtime/src/llm/compact/index.ts
+++ b/runtime/src/llm/compact/index.ts
@@ -39,6 +39,10 @@ export {
   type ReactiveCompactState,
 } from "./reactive-compact.js";
 export {
+  collectPreservedAttachments,
+  type PreservedAttachment,
+} from "./attachments.js";
+export {
   tokenCountWithEstimation,
   type TokenCountInput,
 } from "./token-count.js";
@@ -67,6 +71,10 @@ import {
   createReactiveCompactState,
   type ReactiveCompactState,
 } from "./reactive-compact.js";
+import {
+  collectPreservedAttachments,
+  type PreservedAttachment,
+} from "./attachments.js";
 
 /**
  * Per-iteration compaction state composed across all four layers.
@@ -120,6 +128,7 @@ export interface PerIterationCompactionResult {
   readonly messages: readonly LLMMessage[];
   readonly state: PerIterationCompactionState;
   readonly boundaries: readonly LLMMessage[];
+  readonly preservedAttachments: readonly PreservedAttachment[];
 }
 
 /**
@@ -155,6 +164,7 @@ export function applyPerIterationCompaction(
 ): PerIterationCompactionResult {
   const nowMs = input.nowMs;
   const boundaries: LLMMessage[] = [];
+  const preservedAttachments: PreservedAttachment[] = [];
   let currentMessages: readonly LLMMessage[] = input.messages;
   let snipState = input.state.snip;
   let microState = input.state.microcompact;
@@ -175,6 +185,9 @@ export function applyPerIterationCompaction(
     // autocompact threshold check reads this value to short-circuit
     // a borderline trigger after a successful snip.
     const dropped = currentMessages.length - snipResult.messages.length;
+    preservedAttachments.push(
+      ...collectPreservedAttachments(currentMessages.slice(0, dropped)),
+    );
     snipTokensFreed = Math.max(0, dropped) * APPROX_TOKENS_PER_SNIPPED_MESSAGE;
     currentMessages = snipResult.messages;
     if (snipResult.boundary) boundaries.push(snipResult.boundary);
@@ -238,6 +251,7 @@ export function applyPerIterationCompaction(
       reactiveCompact: input.state.reactiveCompact,
     },
     boundaries,
+    preservedAttachments,
   };
 }
 

--- a/runtime/src/llm/compact/microcompact.ts
+++ b/runtime/src/llm/compact/microcompact.ts
@@ -11,6 +11,7 @@
  */
 
 import type { LLMMessage } from "../types.js";
+import type { PreservedAttachment } from "./attachments.js";
 import {
   COMPACT_BOUNDARY_SUBTYPE,
   DEFAULT_MICROCOMPACT_GAP_MS,
@@ -45,6 +46,7 @@ interface MicrocompactResult {
   readonly messages: readonly LLMMessage[];
   readonly state: MicrocompactState;
   readonly boundary?: LLMMessage;
+  readonly preservedAttachments: readonly PreservedAttachment[];
 }
 
 /**
@@ -66,7 +68,12 @@ export function applyMicrocompact(
   };
 
   if (input.state.lastTouchMs === 0 || idleFor < gapMs) {
-    return { action: "noop", messages: input.messages, state: nextState };
+    return {
+      action: "noop",
+      messages: input.messages,
+      state: nextState,
+      preservedAttachments: [],
+    };
   }
 
   const messages = input.messages.slice();
@@ -91,7 +98,12 @@ export function applyMicrocompact(
   }
 
   if (clearedNow === 0) {
-    return { action: "noop", messages: input.messages, state: nextState };
+    return {
+      action: "noop",
+      messages: input.messages,
+      state: nextState,
+      preservedAttachments: [],
+    };
   }
 
   return {
@@ -102,6 +114,7 @@ export function applyMicrocompact(
       clearedToolUseIds: cleared,
       compactCount: input.state.compactCount + 1,
     },
+    preservedAttachments: [],
     boundary: {
       role: "system",
       content:

--- a/runtime/src/llm/compact/per-iteration-compaction.test.ts
+++ b/runtime/src/llm/compact/per-iteration-compaction.test.ts
@@ -29,6 +29,16 @@ function makeUser(content: string): LLMMessage {
   return { role: "user", content };
 }
 
+function makeMultimodalUser(content: string, imageUrl: string): LLMMessage {
+  return {
+    role: "user",
+    content: [
+      { type: "text", text: content },
+      { type: "image_url", image_url: { url: imageUrl } },
+    ],
+  };
+}
+
 function makeToolResult(id: string, size: number): LLMMessage {
   return {
     role: "tool",
@@ -51,6 +61,7 @@ describe("applyPerIterationCompaction", () => {
     expect(result.action).toBe("noop");
     expect(result.messages).toBe(messages);
     expect(result.boundaries).toEqual([]);
+    expect(result.preservedAttachments).toEqual([]);
     // State timestamps updated even on noop so the next call has a
     // baseline to compute idleness against.
     expect(result.state.snip.lastTouchMs).toBe(T0);
@@ -80,6 +91,7 @@ describe("applyPerIterationCompaction", () => {
 
     expect(result.action).toBe("noop");
     expect(result.boundaries).toEqual([]);
+    expect(result.preservedAttachments).toEqual([]);
   });
 
   it("snips after the snip gap elapses on a long history", () => {
@@ -112,6 +124,39 @@ describe("applyPerIterationCompaction", () => {
     );
     expect(snipBoundary).toBeDefined();
     expect(result.state.snip.snipCount).toBe(1);
+  });
+
+  it("surfaces preserved attachments when snip drops a multimodal message", () => {
+    let state = createPerIterationCompactionState();
+    state = applyPerIterationCompaction({
+      messages: [makeUser("seed")],
+      state,
+      nowMs: T0,
+    }).state;
+
+    const attachmentMessage = makeMultimodalUser(
+      "see this",
+      "https://example.com/asset.png",
+    );
+    const history: LLMMessage[] = [attachmentMessage];
+    for (let i = 0; i < 45; i++) {
+      history.push(makeUser(`q${i}`), makeAssistant(`a${i}`));
+    }
+
+    const result = applyPerIterationCompaction({
+      messages: history,
+      state,
+      nowMs: T0 + DEFAULT_SNIP_GAP_MS + 1,
+    });
+
+    expect(result.action).toBe("compacted");
+    expect(result.messages).not.toContain(attachmentMessage);
+    expect(result.preservedAttachments).toHaveLength(1);
+    expect(result.preservedAttachments[0]).toMatchObject({
+      messageIndex: 0,
+      role: "user",
+      content: attachmentMessage.content,
+    });
   });
 
   it("microcompacts cold tool results after the microcompact gap", () => {

--- a/runtime/src/llm/compact/reactive-compact.ts
+++ b/runtime/src/llm/compact/reactive-compact.ts
@@ -14,6 +14,10 @@
  */
 
 import type { LLMMessage } from "../types.js";
+import {
+  collectPreservedAttachments,
+  type PreservedAttachment,
+} from "./attachments.js";
 import { COMPACT_BOUNDARY_SUBTYPE } from "./constants.js";
 
 const REACTIVE_COMPACT_TRIM_FRACTIONS = [0.25, 0.5, 0.75] as const;
@@ -38,6 +42,7 @@ interface ReactiveCompactResult {
   readonly messages: readonly LLMMessage[];
   readonly state: ReactiveCompactState;
   readonly boundary?: LLMMessage;
+  readonly preservedAttachments: readonly PreservedAttachment[];
 }
 
 /**
@@ -54,6 +59,7 @@ export function applyReactiveCompact(
       action: "exhausted",
       messages: input.messages,
       state: input.state,
+      preservedAttachments: [],
     };
   }
   const fraction =
@@ -64,6 +70,7 @@ export function applyReactiveCompact(
       action: "noop",
       messages: input.messages,
       state: input.state,
+      preservedAttachments: [],
     };
   }
 
@@ -75,6 +82,9 @@ export function applyReactiveCompact(
       attemptIndex: input.state.attemptIndex + 1,
       lastTriggerMs: input.nowMs ?? Date.now(),
     },
+    preservedAttachments: collectPreservedAttachments(
+      input.messages.slice(0, dropCount),
+    ),
     boundary: {
       role: "system",
       content:

--- a/runtime/src/llm/compact/snip.ts
+++ b/runtime/src/llm/compact/snip.ts
@@ -14,6 +14,10 @@
 
 import type { LLMMessage } from "../types.js";
 import {
+  collectPreservedAttachments,
+  type PreservedAttachment,
+} from "./attachments.js";
+import {
   COMPACT_BOUNDARY_SUBTYPE,
   DEFAULT_SNIP_GAP_MS,
   DEFAULT_SNIP_KEEP_RECENT,
@@ -41,6 +45,7 @@ interface SnipResult {
   readonly messages: readonly LLMMessage[];
   readonly state: SnipState;
   readonly boundary?: LLMMessage;
+  readonly preservedAttachments: readonly PreservedAttachment[];
 }
 
 export function applySnip(input: SnipInput): SnipResult {
@@ -65,6 +70,7 @@ export function applySnip(input: SnipInput): SnipResult {
       action: "noop",
       messages,
       state: nextState,
+      preservedAttachments: [],
     };
   }
 
@@ -76,6 +82,7 @@ export function applySnip(input: SnipInput): SnipResult {
     messages: trimmed,
     state: { ...nextState, snipCount: input.state.snipCount + 1 },
     boundary: makeBoundary(dropped, idleFor),
+    preservedAttachments: collectPreservedAttachments(messages.slice(0, dropped)),
   };
 }
 

--- a/runtime/src/llm/completion-validators.test.ts
+++ b/runtime/src/llm/completion-validators.test.ts
@@ -41,6 +41,7 @@ function makeCtx(params: {
   readonly turnClass?: string;
   readonly ownerMode?: string;
   readonly flags?: RuntimeContractFlags;
+  readonly completionContract?: Record<string, unknown>;
   readonly requiredToolEvidence?: ExecutionContext["requiredToolEvidence"];
 }): ExecutionContext {
   const flags = params.flags ?? makeFlags();
@@ -66,6 +67,7 @@ function makeCtx(params: {
       turnClass: params.turnClass ?? "dialogue",
       ownerMode: params.ownerMode ?? "none",
       targetArtifacts: params.targetArtifacts ?? [],
+      ...(params.completionContract ? { completionContract: params.completionContract } : {}),
     },
     runtimeContractSnapshot: createRuntimeContractSnapshot(flags),
     requiredToolEvidence: params.requiredToolEvidence
@@ -313,6 +315,11 @@ describe("completion-validators", () => {
         turnClass: "workflow_implementation",
         ownerMode: "workflow_owner",
         flags,
+        completionContract: {
+          taskClass: "build_required",
+          placeholdersAllowed: false,
+          partialCompletionAllowed: false,
+        },
       }),
       runtimeContractFlags: flags,
       stopHookRuntime: buildStopHookRuntime({
@@ -344,7 +351,7 @@ describe("completion-validators", () => {
     expect(toolHandler).not.toHaveBeenCalled();
   });
 
-  it("skips the top-level verifier on dialogue turns even when runtime verification is globally enabled", async () => {
+  it("skips the top-level verifier for ordinary workflow turns that only carry artifact completion", async () => {
     const flags = makeFlags({
       verifierRuntimeRequired: true,
     });
@@ -353,6 +360,13 @@ describe("completion-validators", () => {
         flags,
         allToolCalls: [successfulWrite("/tmp/workspace/src/main.c")],
         targetArtifacts: ["/tmp/workspace/src/main.c"],
+        turnClass: "workflow_implementation",
+        ownerMode: "workflow_owner",
+        completionContract: {
+          taskClass: "artifact_only",
+          placeholdersAllowed: false,
+          partialCompletionAllowed: false,
+        },
       }),
       runtimeContractFlags: flags,
     });
@@ -524,8 +538,7 @@ describe("completion-validators", () => {
       expect(stopGate.outcome).toBe("retry_with_blocking_message");
       expect(stopGate.maxAttempts).toBe(3);
 
-      expect(taskProgress.outcome).toBe("retry_with_blocking_message");
-      expect(taskProgress.maxAttempts).toBe(3);
+      expect(taskProgress.outcome).toBe("pass");
 
       expect(filesystem.outcome).toBe("retry_with_blocking_message");
       expect(filesystem.maxAttempts).toBe(3);
@@ -598,7 +611,7 @@ describe("completion-validators", () => {
 
     try {
       expect(stopGate.maxAttempts).toBe(0);
-      expect(taskProgress.maxAttempts).toBe(0);
+      expect(taskProgress.outcome).toBe("pass");
       expect(filesystem.maxAttempts).toBe(0);
       expect(deterministic.maxAttempts).toBe(0);
     } finally {
@@ -624,6 +637,11 @@ describe("completion-validators", () => {
       sourceArtifacts: ["/tmp/workspace/PLAN.md"],
       targetArtifacts: ["/tmp/workspace/src/main.c"],
       delegationPolicy: "direct_owner",
+      completionContract: {
+        taskClass: "build_required",
+        placeholdersAllowed: false,
+        partialCompletionAllowed: false,
+      },
       contractFingerprint: "contract-1",
       taskLineageId: "task-1",
     } as any;
@@ -685,7 +703,7 @@ describe("completion-validators", () => {
     expect(result.verifier?.overall).toBe("pass");
   });
 
-  it("blocks finalization when request milestones remain open without an in_progress task", async () => {
+  it("does not block finalization when request milestones remain open without an in_progress task", async () => {
     const ctx = makeCtx({});
     setAllowedRequestTaskMilestones(ctx.requestTaskState, [
       { id: "phase_1", description: "Finish phase 1" },
@@ -699,8 +717,7 @@ describe("completion-validators", () => {
       (validator) => validator.id === "request_task_progress",
     )!.execute();
 
-    expect(result.outcome).toBe("retry_with_blocking_message");
-    expect(result.blockingMessage).toContain("no task is marked in_progress");
+    expect(result.outcome).toBe("pass");
   });
 
   it("blocks malformed runtime milestone metadata before allowing completion", async () => {
@@ -735,7 +752,7 @@ describe("completion-validators", () => {
     expect(result.blockingMessage).toContain("#1");
   });
 
-  it("requires a verification task after three completed non-verification tasks", async () => {
+  it("does not require a verification task after three completed non-verification tasks", async () => {
     const ctx = makeCtx({});
     for (const id of ["1", "2", "3"]) {
       observeRequestTaskToolRecord(
@@ -755,7 +772,6 @@ describe("completion-validators", () => {
       (validator) => validator.id === "request_task_progress",
     )!.execute();
 
-    expect(result.outcome).toBe("retry_with_blocking_message");
-    expect(result.blockingMessage).toContain("verification task");
+    expect(result.outcome).toBe("pass");
   });
 });

--- a/runtime/src/llm/completion-validators.ts
+++ b/runtime/src/llm/completion-validators.ts
@@ -22,9 +22,10 @@ import type {
   CompletionValidatorId,
   RuntimeContractFlags,
 } from "../runtime-contract/types.js";
-import { isRuntimeVerifierRequiredForTurn } from "../gateway/runtime-verifier-requirement.js";
-import { runTopLevelVerifierValidation } from "../gateway/top-level-verifier.js";
-import { getRemainingRequestTaskMilestones } from "./request-task-progress.js";
+import {
+  isExplicitTopLevelVerifierRequiredForTurn,
+  runTopLevelVerifierValidation,
+} from "../gateway/top-level-verifier.js";
 
 export interface CompletionValidatorExecutionResult
   extends CompletionValidatorResult {
@@ -55,8 +56,7 @@ export function buildCompletionValidators(params: {
           params.stopHookRuntime.maxAttempts,
         )
       : sharedCorrectionBudgetCap;
-  const topLevelVerifierEnabled = isRuntimeVerifierRequiredForTurn({
-    flags: params.runtimeContractFlags,
+  const topLevelVerifierEnabled = isExplicitTopLevelVerifierRequiredForTurn({
     turnExecutionContract: params.ctx.turnExecutionContract,
   });
   const deterministicAcceptanceProbesEnabled =
@@ -221,115 +221,36 @@ export function buildCompletionValidators(params: {
       enabled: true,
       async execute(): Promise<CompletionValidatorExecutionResult> {
         const requestTaskState = params.ctx.requestTaskState;
-        const remainingMilestones = getRemainingRequestTaskMilestones(
-          requestTaskState,
-        );
         const hasMalformedTaskMetadata =
           requestTaskState.malformedTasks.length > 0;
-        const verificationPressure =
-          requestTaskState.completedNonVerificationTaskIdsSinceVerification
-            .length >= 3 &&
-          requestTaskState.verificationTaskIds.length === 0 &&
-          params.ctx.verifierSnapshot?.performed !== true;
-        const hasMilestoneContract =
-          requestTaskState.allowedMilestones.length > 0;
-
-        if (
-          !hasMalformedTaskMetadata &&
-          !verificationPressure &&
-          (!hasMilestoneContract || remainingMilestones.length === 0)
-        ) {
+        if (!hasMalformedTaskMetadata) {
           return { id: "request_task_progress", outcome: "pass" };
         }
 
         const maxAttempts = sharedCorrectionBudgetCap;
-        if (hasMalformedTaskMetadata) {
-          const allowedIds = requestTaskState.allowedMilestones.map(
-            (milestone) => milestone.id,
-          );
-          const malformedDetails = requestTaskState.malformedTasks
-            .map(
-              (task) =>
-                `#${task.taskId}: ${task.errors.join("; ")}`,
-            )
-            .join("\n");
-          return {
-            id: "request_task_progress",
-            outcome: "retry_with_blocking_message",
-            reason: "request_task_progress",
-            blockingMessage:
-              "Task runtime metadata is malformed and must be corrected before finalization.\n" +
-              `${malformedDetails}\n` +
-              (allowedIds.length > 0
-                ? `Allowed request milestone ids: ${allowedIds.join(", ")}`
-                : "Remove or correct malformed `metadata._runtime` fields before continuing."),
-            evidence: {
-              malformedTasks: requestTaskState.malformedTasks,
-              allowedMilestoneIds: allowedIds,
-            },
-            maxAttempts,
-            exhaustedDetail:
-              "Request task progress recovery exhausted while malformed task metadata remained in the session task state.",
-          };
-        }
-
-        if (
-          hasMilestoneContract &&
-          remainingMilestones.length > 0 &&
-          requestTaskState.inProgressTaskIds.length === 0
-        ) {
-          return {
-            id: "request_task_progress",
-            outcome: "retry_with_blocking_message",
-            reason: "request_task_progress",
-            blockingMessage:
-              "Request milestones are still open, but no task is marked in_progress. Update one task to in_progress before you continue.\n" +
-              "Remaining milestones:\n" +
-              remainingMilestones
-                .map((milestone) => `- ${milestone.id}: ${milestone.description}`)
-                .join("\n"),
-            evidence: {
-              remainingMilestones,
-              inProgressTaskIds: requestTaskState.inProgressTaskIds,
-            },
-            maxAttempts,
-            exhaustedDetail:
-              "Request task progress recovery exhausted while request milestones remained open without an active in_progress task.",
-          };
-        }
-
-        if (verificationPressure) {
-          return {
-            id: "request_task_progress",
-            outcome: "retry_with_blocking_message",
-            reason: "request_task_progress",
-            blockingMessage:
-              "Three or more non-verification tasks have been completed since the last verification anchor. Before finalizing, create or update a verification task with `metadata._runtime.verification: true` and continue with verification work.",
-            evidence: {
-              completedNonVerificationTaskIdsSinceVerification:
-                requestTaskState.completedNonVerificationTaskIdsSinceVerification,
-              verificationTaskIds: requestTaskState.verificationTaskIds,
-              verifierAttempted: params.ctx.verifierSnapshot?.performed === true,
-            },
-            maxAttempts,
-            exhaustedDetail:
-              "Request task progress recovery exhausted after repeated attempts to finalize without a verification task or verifier run.",
-          };
-        }
-
+        const allowedIds = requestTaskState.allowedMilestones.map(
+          (milestone) => milestone.id,
+        );
+        const malformedDetails = requestTaskState.malformedTasks
+          .map((task) => `#${task.taskId}: ${task.errors.join("; ")}`)
+          .join("\n");
         return {
           id: "request_task_progress",
           outcome: "retry_with_blocking_message",
           reason: "request_task_progress",
           blockingMessage:
-            "Request milestones are still open. Continue the implementation and close the matching milestone-linked tasks before finalizing.\n" +
-            remainingMilestones
-              .map((milestone) => `- ${milestone.id}: ${milestone.description}`)
-              .join("\n"),
-          evidence: { remainingMilestones },
+            "Task runtime metadata is malformed and must be corrected before finalization.\n" +
+            `${malformedDetails}\n` +
+            (allowedIds.length > 0
+              ? `Allowed request milestone ids: ${allowedIds.join(", ")}`
+              : "Remove or correct malformed `metadata._runtime` fields before continuing."),
+          evidence: {
+            malformedTasks: requestTaskState.malformedTasks,
+            allowedMilestoneIds: allowedIds,
+          },
           maxAttempts,
           exhaustedDetail:
-            "Request task progress recovery exhausted while request milestones were still incomplete.",
+            "Request task progress recovery exhausted while malformed task metadata remained in the session task state.",
         };
       },
     },

--- a/runtime/src/llm/hooks/stop-hooks.ts
+++ b/runtime/src/llm/hooks/stop-hooks.ts
@@ -1,11 +1,19 @@
 import { spawn } from "node:child_process";
 
+import type { ToolHandler } from "../types.js";
 import type { ToolCallRecord } from "../chat-executor-types.js";
+import type { DelegationContractSpec } from "../../utils/delegation-validation.js";
+import type { ExecutionEnvelope } from "../../workflow/execution-envelope.js";
+import type { ImplementationCompletionContract } from "../../workflow/completion-contract.js";
+import type { WorkflowVerificationContract } from "../../workflow/verification-obligations.js";
 import {
   buildTurnEndStopGateSnapshot,
+  checkFilesystemArtifacts,
   evaluateTurnEndStopGate,
+  evaluateArtifactEvidenceGate,
   type TurnEndStopGateSnapshot,
 } from "../chat-executor-stop-gate.js";
+import { runDeterministicAcceptanceProbes } from "../deterministic-acceptance-probes.js";
 import { matchesHookMatcher } from "./matcher.js";
 
 export const STOP_HOOK_PHASES = [
@@ -23,7 +31,18 @@ export type StopHookConfigKind = (typeof STOP_HOOK_CONFIG_KINDS)[number];
 export const STOP_HOOK_DEFAULT_TIMEOUT_MS = 5_000;
 export const STOP_HOOK_RESERVED_ID_PREFIX = "builtin:";
 export const BUILTIN_TURN_END_STOP_GATE_ID = `${STOP_HOOK_RESERVED_ID_PREFIX}turn_end_stop_gate`;
-export const BUILTIN_STOP_HOOK_IDS = [BUILTIN_TURN_END_STOP_GATE_ID] as const;
+export const BUILTIN_ARTIFACT_EVIDENCE_HOOK_ID =
+  `${STOP_HOOK_RESERVED_ID_PREFIX}artifact_evidence`;
+export const BUILTIN_FILESYSTEM_ARTIFACT_VERIFICATION_HOOK_ID =
+  `${STOP_HOOK_RESERVED_ID_PREFIX}filesystem_artifact_verification`;
+export const BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID =
+  `${STOP_HOOK_RESERVED_ID_PREFIX}deterministic_acceptance_probes`;
+export const BUILTIN_STOP_HOOK_IDS = [
+  BUILTIN_TURN_END_STOP_GATE_ID,
+  BUILTIN_ARTIFACT_EVIDENCE_HOOK_ID,
+  BUILTIN_FILESYSTEM_ARTIFACT_VERIFICATION_HOOK_ID,
+  BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID,
+] as const;
 
 export interface StopHookHandlerConfig {
   readonly id: string;
@@ -61,6 +80,19 @@ export interface StopHookContext {
   readonly finalContent?: string;
   readonly allToolCalls?: readonly ToolCallRecord[];
   readonly turnEndSnapshot?: TurnEndStopGateSnapshot;
+  readonly runtimeChecks?: {
+    readonly requiredToolEvidence?: {
+      readonly maxCorrectionAttempts?: number;
+      readonly delegationSpec?: DelegationContractSpec;
+      readonly unsafeBenchmarkMode?: boolean;
+      readonly verificationContract?: WorkflowVerificationContract;
+      readonly completionContract?: ImplementationCompletionContract;
+      readonly executionEnvelope?: ExecutionEnvelope;
+    };
+    readonly targetArtifacts?: readonly string[];
+    readonly activeToolHandler?: ToolHandler;
+    readonly appendProbeRuns?: (runs: readonly ToolCallRecord[]) => void;
+  };
   readonly verificationReady?: {
     readonly deterministicAcceptanceProbesEnabled: boolean;
     readonly topLevelVerifierEnabled: boolean;
@@ -169,6 +201,167 @@ function buildBuiltinStopHookDefinitions(): readonly StopHookRuntimeDefinition[]
         };
       },
     },
+    {
+      id: BUILTIN_ARTIFACT_EVIDENCE_HOOK_ID,
+      phase: "Stop",
+      kind: "builtin",
+      target: "evaluateArtifactEvidenceGate",
+      source: "builtin",
+      builtinHandler: async (context) => {
+        const startedAt = Date.now();
+        const decision = evaluateArtifactEvidenceGate({
+          requiredToolEvidence: context.runtimeChecks?.requiredToolEvidence,
+          runtimeContext: {
+            workspaceRoot: context.runtimeWorkspaceRoot,
+          },
+          allToolCalls: context.allToolCalls ?? [],
+        });
+        return {
+          hookId: BUILTIN_ARTIFACT_EVIDENCE_HOOK_ID,
+          phase: context.phase,
+          progressMessages: [],
+          ...(decision.shouldIntervene
+            ? {
+                blockingError: {
+                  hookId: BUILTIN_ARTIFACT_EVIDENCE_HOOK_ID,
+                  message:
+                    decision.blockingMessage ??
+                    "Artifact evidence is incomplete.",
+                  evidence: decision.evidence,
+                },
+                stopReason: decision.validationCode,
+                evidence: decision.evidence,
+              }
+            : { evidence: decision.evidence }),
+          durationMs: Date.now() - startedAt,
+        };
+      },
+    },
+    {
+      id: BUILTIN_FILESYSTEM_ARTIFACT_VERIFICATION_HOOK_ID,
+      phase: "Stop",
+      kind: "builtin",
+      target: "checkFilesystemArtifacts",
+      source: "builtin",
+      builtinHandler: async (context) => {
+        const startedAt = Date.now();
+        const check = await checkFilesystemArtifacts({
+          finalContent: context.finalContent ?? "",
+          allToolCalls: context.allToolCalls ?? [],
+        });
+        return {
+          hookId: BUILTIN_FILESYSTEM_ARTIFACT_VERIFICATION_HOOK_ID,
+          phase: context.phase,
+          progressMessages: [],
+          ...(check.shouldIntervene
+            ? {
+                blockingError: {
+                  hookId: BUILTIN_FILESYSTEM_ARTIFACT_VERIFICATION_HOOK_ID,
+                  message:
+                    check.blockingMessage ??
+                    "Filesystem artifact verification failed.",
+                  evidence: {
+                    emptyFiles: check.emptyFiles,
+                    missingFiles: check.missingFiles,
+                    checkedFiles: check.checkedFiles,
+                  },
+                },
+                stopReason: "filesystem_artifact_verification",
+                evidence: {
+                  emptyFiles: check.emptyFiles,
+                  missingFiles: check.missingFiles,
+                  checkedFiles: check.checkedFiles,
+                },
+              }
+            : {
+                evidence: {
+                  emptyFiles: check.emptyFiles,
+                  missingFiles: check.missingFiles,
+                  checkedFiles: check.checkedFiles,
+                },
+              }),
+          durationMs: Date.now() - startedAt,
+        };
+      },
+    },
+    {
+      id: BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID,
+      phase: "Stop",
+      kind: "builtin",
+      target: "runDeterministicAcceptanceProbes",
+      source: "builtin",
+      builtinHandler: async (context) => {
+        const startedAt = Date.now();
+        const activeToolHandler = context.runtimeChecks?.activeToolHandler;
+        if (!activeToolHandler) {
+          return passOutcome(
+            BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID,
+            context.phase,
+            Date.now() - startedAt,
+          );
+        }
+        const decision = await runDeterministicAcceptanceProbes({
+          workspaceRoot: context.runtimeWorkspaceRoot,
+          targetArtifacts: context.runtimeChecks?.targetArtifacts,
+          allToolCalls: context.allToolCalls ?? [],
+          activeToolHandler,
+        });
+        if (decision.probeRuns.length > 0) {
+          context.runtimeChecks?.appendProbeRuns?.(decision.probeRuns);
+        }
+        if (!decision.shouldIntervene) {
+          return {
+            hookId: BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID,
+            phase: context.phase,
+            progressMessages: [],
+            evidence: {
+              evidence: decision.evidence,
+              probeRuns: decision.probeRuns,
+            },
+            durationMs: Date.now() - startedAt,
+          };
+        }
+        if (decision.allowRecovery === false) {
+          return {
+            hookId: BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID,
+            phase: context.phase,
+            progressMessages: [],
+            preventContinuation: true,
+            stopReason:
+              decision.validationCode ??
+              "deterministic_acceptance_probe_failed",
+            evidence: {
+              evidence: decision.evidence,
+              probeRuns: decision.probeRuns,
+            },
+            durationMs: Date.now() - startedAt,
+          };
+        }
+        return {
+          hookId: BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID,
+          phase: context.phase,
+          progressMessages: [],
+          blockingError: {
+            hookId: BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID,
+            message:
+              decision.blockingMessage ??
+              "Deterministic acceptance probes failed.",
+            evidence: {
+              evidence: decision.evidence,
+              probeRuns: decision.probeRuns,
+            },
+          },
+          stopReason:
+            decision.validationCode ??
+            "deterministic_acceptance_probe_failed",
+          evidence: {
+            evidence: decision.evidence,
+            probeRuns: decision.probeRuns,
+          },
+          durationMs: Date.now() - startedAt,
+        };
+      },
+    },
   ];
 }
 
@@ -225,39 +418,40 @@ export async function runStopHookPhase(params: {
     };
   }
 
-  const outcomes = await Promise.all(
-    matched.map((definition) =>
-      runStopHookDefinition(definition, params.context),
-    ),
-  );
+  const outcomes: StopHookOutcome[] = [];
+  for (const definition of matched) {
+    const outcome = await runStopHookDefinition(definition, params.context);
+    outcomes.push(outcome);
+    const progressMessages = outcomes.flatMap(
+      (candidate) => candidate.progressMessages,
+    );
+    if (outcome.preventContinuation) {
+      return {
+        phase: params.phase,
+        outcome: "prevent_continuation",
+        reason: outcome.hookId,
+        stopReason:
+          outcome.stopReason ??
+          outcome.blockingError?.message ??
+          "Runtime stop hook prevented continuation.",
+        evidence: mergeStopHookEvidence(outcomes),
+        progressMessages,
+        hookOutcomes: outcomes,
+      };
+    }
+    if (outcome.blockingError) {
+      return {
+        phase: params.phase,
+        outcome: "retry_with_blocking_message",
+        reason: outcome.stopReason ?? outcome.hookId,
+        blockingMessage: outcome.blockingError.message,
+        evidence: mergeStopHookEvidence(outcomes),
+        progressMessages,
+        hookOutcomes: outcomes,
+      };
+    }
+  }
   const progressMessages = outcomes.flatMap((outcome) => outcome.progressMessages);
-  const preventOutcome = outcomes.find((outcome) => outcome.preventContinuation);
-  if (preventOutcome) {
-    return {
-      phase: params.phase,
-      outcome: "prevent_continuation",
-      reason: preventOutcome.hookId,
-      stopReason:
-        preventOutcome.stopReason ??
-        preventOutcome.blockingError?.message ??
-        "Runtime stop hook prevented continuation.",
-      evidence: mergeStopHookEvidence(outcomes),
-      progressMessages,
-      hookOutcomes: outcomes,
-    };
-  }
-  const blockingOutcome = outcomes.find((outcome) => outcome.blockingError);
-  if (blockingOutcome?.blockingError) {
-    return {
-      phase: params.phase,
-      outcome: "retry_with_blocking_message",
-      reason: blockingOutcome.stopReason ?? blockingOutcome.hookId,
-      blockingMessage: blockingOutcome.blockingError.message,
-      evidence: mergeStopHookEvidence(outcomes),
-      progressMessages,
-      hookOutcomes: outcomes,
-    };
-  }
   return {
     phase: params.phase,
     outcome: "pass",

--- a/runtime/src/runtime-contract/types.test.ts
+++ b/runtime/src/runtime-contract/types.test.ts
@@ -6,7 +6,7 @@ import {
 } from "./types.js";
 
 describe("runtime-contract types", () => {
-  it("includes request_task_progress in the validator order and snapshot", () => {
+  it("keeps the reduced hook-backed validator snapshot shape", () => {
     expect(COMPLETION_VALIDATOR_ORDER).toEqual([
       "artifact_evidence",
       "turn_end_stop_gate",
@@ -33,6 +33,13 @@ describe("runtime-contract types", () => {
       COMPLETION_VALIDATOR_ORDER,
     );
     expect(
+      snapshot.validators.find((validator) => validator.id === "request_task_progress"),
+    ).toMatchObject({
+      enabled: false,
+      executed: false,
+      outcome: "skipped",
+    });
+    expect(
       snapshot.validators.find((validator) => validator.id === "top_level_verifier"),
     ).toMatchObject({
       enabled: false,
@@ -49,7 +56,7 @@ describe("runtime-contract types", () => {
     });
   });
 
-  it("enables the top-level verifier whenever runtime verification is required", () => {
+  it("keeps top-level verifier advisory in the runtime snapshot", () => {
     const snapshot = createRuntimeContractSnapshot({
       runtimeContractV2: false,
       stopHooksEnabled: false,
@@ -65,7 +72,7 @@ describe("runtime-contract types", () => {
     expect(
       snapshot.validators.find((validator) => validator.id === "top_level_verifier"),
     ).toMatchObject({
-      enabled: true,
+      enabled: false,
       executed: false,
       outcome: "skipped",
     });

--- a/runtime/src/runtime-contract/types.ts
+++ b/runtime/src/runtime-contract/types.ts
@@ -393,14 +393,18 @@ export const COMPLETION_VALIDATOR_ORDER: readonly CompletionValidatorId[] = [
 export function createRuntimeContractSnapshot(
   flags: RuntimeContractFlags,
 ): RuntimeContractSnapshot {
+  const hookBackedValidatorIds = new Set<CompletionValidatorId>([
+    "artifact_evidence",
+    "turn_end_stop_gate",
+    "filesystem_artifact_verification",
+    "deterministic_acceptance_probes",
+  ]);
   return {
     flags,
     validatorOrder: [...COMPLETION_VALIDATOR_ORDER],
     validators: COMPLETION_VALIDATOR_ORDER.map((id) => ({
       id,
-      enabled: id === "top_level_verifier"
-        ? flags.verifierRuntimeRequired
-        : true,
+      enabled: hookBackedValidatorIds.has(id) && flags.stopHooksEnabled,
       executed: false,
       outcome: "skipped",
     })),

--- a/runtime/src/tools/system/filesystem.test.ts
+++ b/runtime/src/tools/system/filesystem.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   createFilesystemTools,
+  clearSessionReadState,
   safePath,
   isPathAllowed,
 } from "./filesystem.js";
@@ -84,6 +88,19 @@ function findTool(tools: Tool[], name: string): Tool {
 
 function parseResult(result: { content: string }) {
   return JSON.parse(result.content);
+}
+
+function walkJsonFiles(root: string): string[] {
+  const entries: string[] = [];
+  for (const name of readdirSync(root, { withFileTypes: true })) {
+    const fullPath = join(root, name.name);
+    if (name.isDirectory()) {
+      entries.push(...walkJsonFiles(fullPath));
+    } else if (name.isFile() && name.name.endsWith(".json")) {
+      entries.push(fullPath);
+    }
+  }
+  return entries;
 }
 
 const ALLOWED_PATHS = ["/workspace"];
@@ -440,6 +457,38 @@ describe("system.readFile", () => {
     expect(result.isError).toBe(true);
     expect(parseResult(result).error).toContain("exceeds limit");
   });
+
+  it("persists a bounded local history snapshot outside the repo tree", async () => {
+    const historyRoot = mkdtempSync(join(tmpdir(), "agenc-filesystem-history-"));
+    const previousHistoryRoot = process.env.AGENC_FILESYSTEM_HISTORY_ROOT;
+    process.env.AGENC_FILESYSTEM_HISTORY_ROOT = historyRoot;
+    try {
+      for (let index = 0; index < 9; index++) {
+        const content = `line ${index}\n`;
+        mockStat.mockResolvedValueOnce({
+          isFile: () => true,
+          isDirectory: () => false,
+          size: content.length,
+        } as never);
+        mockReadFile.mockResolvedValueOnce(Buffer.from(content));
+        await tool.execute({
+          path: "/workspace/history.txt",
+          __agencSessionId: "session-history",
+        });
+      }
+
+      const snapshotFiles = walkJsonFiles(historyRoot);
+      expect(snapshotFiles).toHaveLength(1);
+      const snapshots = JSON.parse(readFileSync(snapshotFiles[0]!, "utf8"));
+      expect(snapshots).toHaveLength(8);
+      expect(snapshots[0].content).toBe("line 1\n");
+      expect(snapshots.at(-1).content).toBe("line 8\n");
+    } finally {
+      clearSessionReadState("session-history");
+      process.env.AGENC_FILESYSTEM_HISTORY_ROOT = previousHistoryRoot;
+      rmSync(historyRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 // ============================================================================
@@ -521,6 +570,7 @@ describe("system.writeFile", () => {
       isDirectory: () => false,
       size: 5,
     } as never);
+    mockReadFile.mockResolvedValueOnce(Buffer.from("hello"));
     mockMkdir.mockResolvedValueOnce(undefined);
     mockWriteFile.mockResolvedValueOnce(undefined);
 
@@ -808,13 +858,13 @@ describe("system.editFile", () => {
     expect(parseResult(result).error).toContain("Re-read the file");
   });
 
-  it("rejects edit when the file changed after it was read", async () => {
+  it("rejects edit when the file contents changed after it was read", async () => {
     const before = `int main(void) { return 0; }\n`;
     const after = `int main(void) { return 1; }\n`;
     setupExistingFileWithMtime(before, 1000);
     await readFirst("/workspace/main.c");
 
-    setupExistingFileWithMtime(after, 2000);
+    setupExistingFileWithMtime(after, 1000);
 
     const result = await tool.execute({
       path: "/workspace/main.c",

--- a/runtime/src/tools/system/filesystem.ts
+++ b/runtime/src/tools/system/filesystem.ts
@@ -35,6 +35,9 @@
  */
 
 import {
+  createHash,
+} from "node:crypto";
+import {
   readFile,
   writeFile,
   appendFile,
@@ -46,7 +49,14 @@ import {
   rename,
   realpath,
 } from "node:fs/promises";
-import { resolve, dirname, basename } from "node:path";
+import {
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { resolve, dirname, basename, join } from "node:path";
+import { tmpdir } from "node:os";
 import { resolveSessionWorkspaceRoot } from "../../gateway/host-workspace.js";
 import type { Tool, ToolResult } from "../types.js";
 import { safeStringify } from "../types.js";
@@ -97,6 +107,10 @@ export const SESSION_ID_ARG = "__agencSessionId";
  *     when the target path EXISTS — creating a new file does not
  *     require a prior read (Claude Code's FileWriteTool.ts:191-196
  *     uses the same ENOENT escape hatch)
+ *   - The latest snapshots are also mirrored into a bounded local
+ *     history cache under a temp-root outside the tracked workspace
+ *     tree so recent source-of-truth content is available for
+ *     inspection without polluting repo files.
  *   - The set lives for the lifetime of the daemon process; explicit
  *     cleanup is handled by `clearSessionReadState(sessionId)` when
  *     a session ends, called from the gateway's session lifecycle
@@ -110,6 +124,71 @@ interface SessionReadSnapshot {
 }
 
 const sessionReadState = new Map<string, Map<string, SessionReadSnapshot>>();
+const LOCAL_FILE_HISTORY_MAX_ENTRIES = 8;
+
+function resolveLocalFileHistoryRoot(): string {
+  const configuredRoot = process.env.AGENC_FILESYSTEM_HISTORY_ROOT?.trim();
+  return configuredRoot && configuredRoot.length > 0
+    ? configuredRoot
+    : join(tmpdir(), "agenc", "filesystem-history");
+}
+
+function hashString(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function resolveLocalHistorySessionDir(sessionId: string): string {
+  return join(resolveLocalFileHistoryRoot(), hashString(sessionId));
+}
+
+function resolveLocalHistoryFilePath(
+  sessionId: string,
+  canonicalPath: string,
+): string {
+  return join(resolveLocalHistorySessionDir(sessionId), `${hashString(canonicalPath)}.json`);
+}
+
+function persistLocalFileHistorySnapshot(
+  sessionId: string | undefined,
+  canonicalPath: string,
+  snapshot: SessionReadSnapshot,
+): void {
+  if (!sessionId || sessionId.trim().length === 0) return;
+  if (snapshot.content === undefined) return;
+  try {
+    const historyFile = resolveLocalHistoryFilePath(sessionId, canonicalPath);
+    mkdirSync(dirname(historyFile), { recursive: true });
+
+    let entries: Array<SessionReadSnapshot & { readonly recordedAt: number }> = [];
+    try {
+      const raw = readFileSync(historyFile, "utf8");
+      const parsed = JSON.parse(raw) as unknown;
+      if (Array.isArray(parsed)) {
+        entries = parsed.filter(
+          (entry): entry is SessionReadSnapshot & { readonly recordedAt: number } =>
+            typeof entry === "object" &&
+            entry !== null &&
+            typeof (entry as { recordedAt?: unknown }).recordedAt === "number" &&
+            typeof (entry as { content?: unknown }).content === "string",
+        );
+      }
+    } catch {
+      // Best effort only. Missing or corrupt local history should not block writes.
+    }
+
+    entries.push({
+      content: snapshot.content,
+      timestamp: snapshot.timestamp,
+      recordedAt: Date.now(),
+    });
+    if (entries.length > LOCAL_FILE_HISTORY_MAX_ENTRIES) {
+      entries = entries.slice(-LOCAL_FILE_HISTORY_MAX_ENTRIES);
+    }
+    writeFileSync(historyFile, `${JSON.stringify(entries, null, 2)}\n`, "utf8");
+  } catch {
+    // Best effort only. Local history is an ergonomics aid, not part of the tool contract.
+  }
+}
 
 export function recordSessionRead(
   sessionId: string | undefined,
@@ -124,10 +203,12 @@ export function recordSessionRead(
     sessionReadState.set(sessionId, fileMap);
   }
   const previous = fileMap.get(canonicalPath);
-  fileMap.set(canonicalPath, {
+  const nextSnapshot = {
     ...(previous ?? {}),
     ...(snapshot ?? {}),
-  });
+  };
+  fileMap.set(canonicalPath, nextSnapshot);
+  persistLocalFileHistorySnapshot(sessionId, canonicalPath, nextSnapshot);
 }
 
 export function hasSessionRead(
@@ -156,6 +237,14 @@ export function getSessionReadSnapshot(
  */
 export function clearSessionReadState(sessionId: string): void {
   sessionReadState.delete(sessionId);
+  try {
+    rmSync(resolveLocalHistorySessionDir(sessionId), {
+      recursive: true,
+      force: true,
+    });
+  } catch {
+    // Best effort cleanup.
+  }
 }
 
 /**
@@ -693,17 +782,9 @@ function getFileTimestampMs(fileStats: { mtimeMs?: number }): number | undefined
 
 function hasFileChangedSinceSnapshot(params: {
   readonly snapshot: SessionReadSnapshot | undefined;
-  readonly currentTimestamp: number | undefined;
   readonly currentContent: string;
 }): boolean {
-  if (
-    params.snapshot?.timestamp === undefined ||
-    params.snapshot.content === undefined ||
-    params.currentTimestamp === undefined
-  ) {
-    return false;
-  }
-  if (params.currentTimestamp <= params.snapshot.timestamp) {
+  if (params.snapshot?.content === undefined) {
     return false;
   }
   return params.currentContent !== params.snapshot.content;
@@ -889,14 +970,12 @@ function createWriteFileTool(
           );
         }
 
-        if (targetExists && readSnapshot?.timestamp !== undefined) {
+        if (targetExists && readSnapshot?.content !== undefined) {
           const existingBuffer = await readFile(resolved!);
           const existingContent = existingBuffer.toString("utf-8");
-          const existingStat = await stat(resolved!);
           if (
             hasFileChangedSinceSnapshot({
               snapshot: readSnapshot,
-              currentTimestamp: getFileTimestampMs(existingStat),
               currentContent: existingContent,
             })
           ) {
@@ -1196,13 +1275,7 @@ function createEditFileTool(
           );
         }
         const existingContent = existingBuffer.toString("utf-8");
-        if (
-          hasFileChangedSinceSnapshot({
-            snapshot: readSnapshot,
-            currentTimestamp: getFileTimestampMs(fileStats),
-            currentContent: existingContent,
-          })
-        ) {
+        if (hasFileChangedSinceSnapshot({ snapshot: readSnapshot, currentContent: existingContent })) {
           return errorResult(
             `File has been modified since it was last read. Read "${args.path}" again before editing it.`,
           );

--- a/runtime/src/workflow/request-task-runtime.ts
+++ b/runtime/src/workflow/request-task-runtime.ts
@@ -216,6 +216,6 @@ export function buildRequestMilestoneRuntimeInstruction(
     `${milestoneLines}\n` +
     "When you use task.create/task.update for this request, attach milestone ids in " +
     "`metadata._runtime.milestoneIds` and mark verification tasks with " +
-    "`metadata._runtime.verification: true`. Keep one task in_progress until all request milestones are complete."
+    "`metadata._runtime.verification: true`."
   );
 }


### PR DESCRIPTION
## Summary
- collapse runtime completion onto the built-in stop-hook path plus budget continuation
- demote task and verifier gating for ordinary implementation turns
- simplify file tool contracts and preserve dropped multimodal attachments during compaction

## Validation
- npm --prefix runtime run typecheck
- cd runtime && npx vitest run src/llm/hooks/stop-hooks.test.ts src/llm/chat-executor-stop-gate.test.ts src/llm/chat-executor-request.test.ts src/llm/chat-executor.test.ts src/runtime-contract/types.test.ts src/gateway/top-level-verifier.test.ts src/llm/completion-validators.test.ts src/llm/compact/per-iteration-compaction.test.ts src/llm/compact/attachment-preservation.test.ts src/tools/system/filesystem.test.ts src/gateway/tool-handler-factory.test.ts src/llm/chat-executor-recovery.test.ts
- cd runtime && npx vitest run src/gateway/daemon-text-channel-turn.test.ts src/gateway/gateway.test.ts src/workflow/completion-state.test.ts
- npm --prefix runtime run build
- npm run techdebt