### PR TITLE
refactor(runtime): reduce source-parity drift

### DIFF
--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -73,3 +73,10 @@
 - **What worked:** Collapsing finalization onto the built-in stop-hook chain removed the second completion engine after hooks, while the file-tool cleanup and compaction attachment side-channel simplified the runtime around one message-centric loop with fewer hidden gates.
 - **What didn't:** The refactor touched several dependent runtime surfaces at once, so type and test fallout showed up in hook typing and validator snapshot expectations before the reduced contract settled.
 - **Rule added to CLAUDE.md:** no
+
+## PR #349: refactor(runtime): reduce source-parity drift
+- **Date:** 2026-04-14
+- **Files changed:** `runtime/src/tools/system/task-tracker.ts`, `runtime/src/llm/chat-executor-request.ts`, `runtime/src/llm/hooks/types.ts`, `runtime/src/llm/context-compaction.ts`, `runtime/src/tools/system/filesystem.ts`, `runtime/src/gateway/tool-handler-factory.ts`, `runtime/src/workflow/completion-state.ts`, `runtime/src/workflow/completion-progress.ts`, `runtime/src/runtime-contract/types.ts`
+- **What worked:** Demoting normal-turn task and verifier gates, rebuilding compacted history with preserved messages, and rehydrating file read state removed the biggest runtime drifts from the source loop without regressing the explicit verification paths.
+- **What didn't:** The broad reduction exposed lingering assumptions in progress snapshots and validator ordering, so several workflow and runtime-contract tests had to be updated after the code changes were already green in isolation.
+- **Rule added to CLAUDE.md:** no

--- a/runtime/src/gateway/session.test.ts
+++ b/runtime/src/gateway/session.test.ts
@@ -43,6 +43,20 @@ function msg(role: LLMMessage["role"], content: string): LLMMessage {
   return { role, content };
 }
 
+function multimodalMsg(
+  role: LLMMessage["role"],
+  text: string,
+  imageUrl: string,
+): LLMMessage {
+  return {
+    role,
+    content: [
+      { type: "text", text },
+      { type: "image_url", image_url: { url: imageUrl } },
+    ],
+  } as LLMMessage;
+}
+
 describe("SessionManager", () => {
   let manager: SessionManager;
 
@@ -388,6 +402,31 @@ describe("SessionManager", () => {
       expect(
         session.metadata[SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY],
       ).toBe(true);
+    });
+
+    it("reconstructs compacted history with preserved multimodal messages", async () => {
+      const mgr = new SessionManager(makeConfig({ compaction: "summarize" }));
+      const session = mgr.getOrCreate(makeParams());
+      const preserved = multimodalMsg(
+        "user",
+        "see the attached image",
+        "https://example.com/diagram.png",
+      );
+      session.history.push(
+        preserved,
+        msg("assistant", "Working on the image."),
+        msg("assistant", "Tail message."),
+        msg("user", "Follow-up."),
+      );
+
+      const result = await mgr.compact(session.id);
+      expect(result).not.toBeNull();
+      expect(result!.messagesRemoved).toBe(2);
+      expect(result!.messagesRetained).toBe(4);
+      expect(session.history[0].role).toBe("system");
+      expect(session.history[1]).toMatchObject(preserved);
+      expect(session.history[2]).toEqual(msg("assistant", "Tail message."));
+      expect(session.history[3]).toEqual(msg("user", "Follow-up."));
     });
 
     it("'summarize' with summarizer calls callback", async () => {

--- a/runtime/src/gateway/tool-handler-factory.test.ts
+++ b/runtime/src/gateway/tool-handler-factory.test.ts
@@ -369,6 +369,46 @@ describe("createSessionToolHandler", () => {
     });
   });
 
+  it("preserves a seeded session id for replayed filesystem mutations when the handler session id is absent", async () => {
+    const baseHandler = vi.fn(async (toolName: string, args: Record<string, unknown>) =>
+      JSON.stringify({ toolName, args }),
+    );
+    const handler = createSessionToolHandler({
+      sessionId: undefined as unknown as string,
+      baseHandler,
+      routerId: "router-a",
+      send: vi.fn(),
+      defaultWorkingDirectory: "/workspace",
+    });
+
+    const result = await handler("system.writeFile", {
+      path: "/workspace/replayed.txt",
+      content: "hello",
+      [SESSION_ID_ARG]: "seeded-session",
+    });
+    const parsed = JSON.parse(result) as {
+      toolName: string;
+      args: Record<string, unknown>;
+    };
+
+    expect(parsed).toMatchObject({
+      toolName: "system.writeFile",
+      args: expect.objectContaining({
+        path: "/workspace/replayed.txt",
+        content: "hello",
+        [SESSION_ID_ARG]: "seeded-session",
+      }),
+    });
+    expect(baseHandler).toHaveBeenCalledWith(
+      "system.writeFile",
+      expect.objectContaining({
+        path: "/workspace/replayed.txt",
+        content: "hello",
+        [SESSION_ID_ARG]: "seeded-session",
+      }),
+    );
+  });
+
   it("injects session task-list ids on the gateway path and strips spoofed internal args", async () => {
     const taskStore = new TaskStore();
     const taskTools = new Map(

--- a/runtime/src/gateway/tool-handler-factory.ts
+++ b/runtime/src/gateway/tool-handler-factory.ts
@@ -2438,7 +2438,14 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
 
   return async (name: string, args: Record<string, unknown>): Promise<string> => {
     const toolName = normalizeToolName(name);
-    const isSubAgentSession = isSubAgentSessionId(sessionId);
+    const normalizedToolCallArgs = normalizeToolCallArguments(toolName, args);
+    const seededSessionId =
+      typeof normalizedToolCallArgs[SESSION_ID_ARG] === "string" &&
+      normalizedToolCallArgs[SESSION_ID_ARG].trim().length > 0
+        ? normalizedToolCallArgs[SESSION_ID_ARG].trim()
+        : undefined;
+    const sessionIdentity = sessionId ?? seededSessionId;
+    const isSubAgentSession = isSubAgentSessionId(sessionIdentity);
     const workspaceContext = (await resolveWorkspaceContext?.()) ?? {};
     const defaultWorkingDirectory =
       workspaceContext.defaultWorkingDirectory ?? config.defaultWorkingDirectory;
@@ -2449,9 +2456,7 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
       config.workspaceAliasRoot ??
       scopedFilesystemRoot ??
       defaultWorkingDirectory;
-    const normalizedToolArgs = stripInternalToolArgs(
-      normalizeToolCallArguments(toolName, args),
-    );
+    const normalizedToolArgs = stripInternalToolArgs(normalizedToolCallArgs);
     const {
       args: normalizedArgs,
       missingDefaultWorkingDirectory,
@@ -2496,11 +2501,11 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
     const lifecycleEmitter = delegationContext?.lifecycleEmitter ?? null;
     const unsafeBenchmarkMode = delegationContext?.unsafeBenchmarkMode === true;
     const subAgentInfo = isSubAgentSession
-      ? subAgentManager?.getInfo(sessionId) ?? null
+      ? subAgentManager?.getInfo(sessionIdentity) ?? null
       : null;
     const subAgentExecutionContext =
       isSubAgentSession && typeof subAgentManager?.getExecutionContext === "function"
-        ? subAgentManager.getExecutionContext(sessionId)
+        ? subAgentManager.getExecutionContext(sessionIdentity)
         : undefined;
     const parentSessionId = subAgentInfo?.parentSessionId;
     const policyScope = resolvePolicyScope?.();
@@ -2929,8 +2934,8 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
       executionArgs,
       delegatedParentAllowedRoots,
     );
-    executionArgs = applySessionTaskListId(toolName, executionArgs, sessionId);
-    executionArgs = applySessionId(toolName, executionArgs, sessionId);
+    executionArgs = applySessionTaskListId(toolName, executionArgs, sessionIdentity);
+    executionArgs = applySessionId(toolName, executionArgs, sessionIdentity);
     executionArgs = applyAdvertisedToolNames(
       toolName,
       executionArgs,

--- a/runtime/src/llm/chat-executor-request.test.ts
+++ b/runtime/src/llm/chat-executor-request.test.ts
@@ -11,6 +11,9 @@ import type {
 } from "./types.js";
 import type { GatewayMessage } from "../gateway/message.js";
 import type { ArtifactCompactionState } from "../memory/artifact-store.js";
+import * as hooks from "./hooks/index.js";
+import { HookRegistry } from "./hooks/index.js";
+import { LLMProviderError } from "./errors.js";
 
 // ============================================================================
 // Shared helpers
@@ -577,6 +580,57 @@ describe("ChatExecutor request assembly", () => {
       expect(result.statefulSummary).toBeDefined();
       expect(result.statefulSummary?.fallbackReasons.store_disabled).toBe(1);
       expect(result.statefulSummary?.attemptedCalls).toBe(0);
+    });
+
+    it("dispatches StopFailure with api error context before rethrowing", async () => {
+      const dispatchHooksSpy = vi
+        .spyOn(hooks, "dispatchHooks")
+        .mockResolvedValue({ action: "noop", outcomes: [] });
+
+      try {
+        const provider = createMockProvider("primary", {
+          chat: vi
+            .fn()
+            .mockRejectedValue(
+              new LLMProviderError("primary", "Bad request", 400),
+            ),
+        });
+        const executor = new ChatExecutor({
+          providers: [provider],
+          hookRegistry: new HookRegistry([
+            {
+              event: "StopFailure",
+              kind: "http",
+              target: "https://example.invalid/stop-failure",
+            },
+          ]),
+        });
+
+        const caught = await executor.execute(createParams()).catch((error) => error);
+        expect(caught).toBeInstanceOf(LLMProviderError);
+        const stopFailureCalls = dispatchHooksSpy.mock.calls.filter(
+          ([input]) => input.event === "StopFailure",
+        );
+        expect(stopFailureCalls).toHaveLength(1);
+        expect(stopFailureCalls[0]?.[0]).toMatchObject({
+          event: "StopFailure",
+          matchKey: "session-1",
+          context: expect.objectContaining({
+            event: "StopFailure",
+            sessionId: "session-1",
+            stopReason: "provider_error",
+            stopReasonDetail: expect.stringContaining("provider_error"),
+            failure: expect.objectContaining({
+              name: "LLMProviderError",
+              message: expect.stringContaining("Bad request"),
+              providerName: "primary",
+              statusCode: 400,
+            }),
+          }),
+        });
+      } finally {
+        dispatchHooksSpy.mockRestore();
+      }
     });
   });
 });

--- a/runtime/src/llm/chat-executor-request.test.ts
+++ b/runtime/src/llm/chat-executor-request.test.ts
@@ -191,7 +191,7 @@ describe("ChatExecutor request assembly", () => {
   });
 
   describe("stateful session wiring and result assembly", () => {
-    it("injects the request milestone contract before the first model call", async () => {
+    it("does not inject a request milestone contract before the first model call", async () => {
       const provider = createMockProvider("primary", {
         chat: vi.fn().mockResolvedValue(mockResponse({ content: "ok" })),
       });
@@ -225,10 +225,7 @@ describe("ChatExecutor request assembly", () => {
           message.content.includes("Request milestone contract:"),
       );
 
-      expect(instruction).toBeDefined();
-      expect(String(instruction?.content)).toContain("phase_1: Finish phase 1");
-      expect(String(instruction?.content)).toContain("metadata._runtime.milestoneIds");
-      expect(String(instruction?.content)).toContain("metadata._runtime.verification");
+      expect(instruction).toBeUndefined();
     });
 
     it("passes stateful session options through provider calls", async () => {

--- a/runtime/src/llm/chat-executor-request.ts
+++ b/runtime/src/llm/chat-executor-request.ts
@@ -48,8 +48,85 @@ import type {
   ChatPlannerSummary,
   ExecutionContext,
 } from "./chat-executor-types.js";
-import type { HookRegistry } from "./hooks/index.js";
+import type { HookContext, HookRegistry } from "./hooks/index.js";
 import type { RuntimeEconomicsPolicy } from "./run-budget.js";
+
+interface HookFailureDetail {
+  readonly name?: string;
+  readonly message: string;
+  readonly stopReason?: string;
+  readonly stopReasonDetail?: string;
+  readonly failureClass?: string;
+  readonly providerName?: string;
+  readonly statusCode?: number;
+  readonly timeoutMs?: number;
+}
+
+function readStringField(
+  value: unknown,
+  key: string,
+): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const candidate = (value as Record<string, unknown>)[key];
+  return typeof candidate === "string" && candidate.length > 0
+    ? candidate
+    : undefined;
+}
+
+function readNumberField(
+  value: unknown,
+  key: string,
+): number | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const candidate = (value as Record<string, unknown>)[key];
+  return typeof candidate === "number" && Number.isFinite(candidate)
+    ? candidate
+    : undefined;
+}
+
+function buildHookLifecycleContext(
+  ctx: ExecutionContext,
+  event: "Stop" | "StopFailure",
+  failure?: HookFailureDetail,
+): HookContext {
+  const stopReason = readStringField(failure ?? ctx, "stopReason") ?? ctx.stopReason;
+  const stopReasonDetail =
+    readStringField(failure ?? ctx, "stopReasonDetail") ?? ctx.stopReasonDetail;
+  return {
+    event,
+    sessionId: ctx.sessionId,
+    messages: ctx.messages,
+    ...(ctx.finalContent ? { finalContent: ctx.finalContent } : {}),
+    ...(stopReason ? { stopReason } : {}),
+    ...(stopReasonDetail ? { stopReasonDetail } : {}),
+    ...(failure ? { failure } : {}),
+  };
+}
+
+function buildHookFailureDetail(error: unknown): HookFailureDetail {
+  const message = error instanceof Error ? error.message : String(error);
+  const name = readStringField(error, "name") ?? (error instanceof Error ? error.name : undefined);
+  const stopReason = readStringField(error, "stopReason");
+  const stopReasonDetail = readStringField(error, "stopReasonDetail");
+  const failureClass = readStringField(error, "failureClass");
+  const providerName = readStringField(error, "providerName");
+  const statusCode = readNumberField(error, "statusCode");
+  const timeoutMs = readNumberField(error, "timeoutMs");
+  return {
+    ...(name ? { name } : {}),
+    message,
+    ...(stopReason ? { stopReason } : {}),
+    ...(stopReasonDetail ? { stopReasonDetail } : {}),
+    ...(failureClass ? { failureClass } : {}),
+    ...(providerName ? { providerName } : {}),
+    ...(statusCode !== undefined ? { statusCode } : {}),
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+  };
+}
 
 /**
  * Dependency struct for `executeRequest`. Extends the init deps
@@ -148,7 +225,28 @@ export async function executeRequest(
     });
   }
 
-  await helpers.executeToolCallLoop(ctx);
+  try {
+    await helpers.executeToolCallLoop(ctx);
+  } catch (error) {
+    if (deps.hookRegistry) {
+      const failure = buildHookFailureDetail(error);
+      try {
+        await dispatchHooks({
+          registry: deps.hookRegistry,
+          event: "StopFailure",
+          matchKey: ctx.sessionId,
+          executor: defaultHookExecutor,
+          context: buildHookLifecycleContext(ctx, "StopFailure", failure),
+        });
+      } catch (hookError) {
+        if (hookError instanceof Error && error instanceof Error) {
+          (hookError as Error & { cause?: unknown }).cause ??= error;
+        }
+        throw hookError;
+      }
+    }
+    throw error;
+  }
 
   checkRequestTimeout(ctx, "finalization");
 
@@ -199,11 +297,18 @@ export async function executeRequest(
       event: stopEvent,
       matchKey: ctx.sessionId,
       executor: defaultHookExecutor,
-      context: {
-        event: stopEvent,
-        sessionId: ctx.sessionId,
-        messages: ctx.messages,
-      },
+      context: buildHookLifecycleContext(
+        ctx,
+        stopEvent,
+        stopEvent === "StopFailure"
+          ? buildHookFailureDetail({
+              name: "StopFailure",
+              message: ctx.stopReasonDetail ?? "Execution ended in failure.",
+              stopReason: ctx.stopReason,
+              stopReasonDetail: ctx.stopReasonDetail,
+            })
+          : undefined,
+      ),
     });
   }
 

--- a/runtime/src/llm/chat-executor-request.ts
+++ b/runtime/src/llm/chat-executor-request.ts
@@ -20,7 +20,6 @@
 import {
   checkRequestTimeout,
   emitExecutionTrace,
-  pushMessage,
 } from "./chat-executor-ctx-helpers.js";
 import {
   initializeExecutionContext,
@@ -31,17 +30,10 @@ import { sanitizeFinalContent } from "./chat-executor-text.js";
 import { summarizeStateful } from "./chat-executor-recovery.js";
 import { dispatchHooks, defaultHookExecutor } from "./hooks/index.js";
 import { resolveWorkflowCompletionState } from "../workflow/completion-state.js";
-import { isRuntimeVerifierRequiredForTurn } from "../gateway/runtime-verifier-requirement.js";
 import { deriveWorkflowProgressSnapshot } from "../workflow/completion-progress.js";
 import { buildRuntimeEconomicsSummary } from "./run-budget.js";
 import { deriveActiveTaskContext } from "./turn-execution-contract.js";
 import { resolveWorkflowEvidenceFromRequiredToolEvidence } from "./turn-execution-contract.js";
-import {
-  setAllowedRequestTaskMilestones,
-} from "./request-task-progress.js";
-import {
-  buildRequestMilestoneRuntimeInstruction,
-} from "../workflow/request-task-runtime.js";
 import type {
   ChatExecuteParams,
   ChatExecutorResult,
@@ -186,26 +178,6 @@ export async function executeRequest(
       activeTaskContext: deriveActiveTaskContext(ctx.turnExecutionContract),
     },
   });
-  setAllowedRequestTaskMilestones(
-    ctx.requestTaskState,
-    workflowEvidence.verificationContract?.requestCompletion?.requiredMilestones,
-  );
-  ctx.completedRequestMilestoneIds = [
-    ...ctx.requestTaskState.completedMilestoneIds,
-  ];
-  const milestoneInstruction = buildRequestMilestoneRuntimeInstruction(
-    workflowEvidence.verificationContract?.requestCompletion,
-  );
-  if (milestoneInstruction) {
-    pushMessage(
-      ctx,
-      {
-        role: "system",
-        content: milestoneInstruction,
-      },
-      "system_runtime",
-    );
-  }
 
   // Phase H: dispatch SessionStart the first time a session is
   // observed. `sessionTokens` is a per-session Map the executor
@@ -255,14 +227,9 @@ export async function executeRequest(
     stopReason: ctx.stopReason,
     toolCalls: ctx.allToolCalls,
     verificationContract: workflowEvidence.verificationContract,
-    completionContract: workflowEvidence.completionContract,
     completedRequestMilestoneIds: ctx.completedRequestMilestoneIds,
     validationCode: ctx.validationCode,
     verifier: ctx.verifierSnapshot,
-    runtimeVerifierRequired: isRuntimeVerifierRequiredForTurn({
-      flags: ctx.runtimeContractSnapshot.flags,
-      turnExecutionContract: ctx.turnExecutionContract,
-    }),
   });
 
   const durationMs = Date.now() - ctx.startTime;

--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -2100,10 +2100,6 @@ export async function executeToolCallLoop(
         validatorId: "deterministic_acceptance_probes" as CompletionValidatorId,
       },
     ] as const;
-    const skippedValidators = [
-      "request_task_progress",
-      "top_level_verifier",
-    ] as const satisfies readonly CompletionValidatorId[];
 
     callbacks.emitExecutionTrace(ctx, {
       type: "completion_validation_started",
@@ -2132,27 +2128,6 @@ export async function executeToolCallLoop(
         },
       });
     }
-    for (const validatorId of skippedValidators) {
-      ctx.runtimeContractSnapshot = updateRuntimeContractValidatorSnapshot({
-        snapshot: ctx.runtimeContractSnapshot,
-        id: validatorId,
-        enabled: false,
-        executed: false,
-        outcome: "skipped",
-      });
-      callbacks.emitExecutionTrace(ctx, {
-        type: "completion_validator_finished",
-        phase: "tool_followup",
-        callIndex: ctx.callIndex,
-        payload: {
-          validatorId,
-          enabled: false,
-          outcome: "skipped",
-          runtimeContract: ctx.runtimeContractSnapshot,
-        },
-      });
-    }
-
     if (!stopHooksEnabled) {
       for (const entry of stopHookValidators) {
         ctx.runtimeContractSnapshot = updateRuntimeContractValidatorSnapshot({

--- a/runtime/src/llm/compact/attachments.ts
+++ b/runtime/src/llm/compact/attachments.ts
@@ -35,3 +35,23 @@ export function collectPreservedAttachments(
   }
   return preserved;
 }
+
+export function collectPreservedMessages(
+  messages: readonly LLMMessage[],
+): readonly LLMMessage[] {
+  const preserved: LLMMessage[] = [];
+  for (const message of messages) {
+    if (!message || !Array.isArray(message.content)) {
+      continue;
+    }
+    preserved.push({
+      ...message,
+      content: message.content.map((part) =>
+        part.type === "text"
+          ? { type: "text", text: part.text }
+          : { type: "image_url", image_url: { url: part.image_url.url } },
+      ),
+    });
+  }
+  return preserved;
+}

--- a/runtime/src/llm/context-compaction.test.ts
+++ b/runtime/src/llm/context-compaction.test.ts
@@ -3,6 +3,16 @@ import { describe, expect, it } from "vitest";
 import { compactHistoryIntoArtifactContext } from "./context-compaction.js";
 import type { LLMMessage } from "./types.js";
 
+function multimodalMessage(): LLMMessage {
+  return {
+    role: "user",
+    content: [
+      { type: "text", text: "See the attached diagram." },
+      { type: "image_url", image_url: { url: "https://example.com/diagram.png" } },
+    ],
+  };
+}
+
 describe("context compaction", () => {
   it("preserves unresolved stub work even when the narrative summary falsely claims closure", () => {
     const history: LLMMessage[] = [
@@ -165,5 +175,32 @@ describe("context compaction", () => {
     expect(compacted.summaryText).toContain("has no member named 'next'");
     expect(compacted.summaryText).toContain("did you mean 'Redir'");
     expect(compacted.summaryText).toContain("TOK_REDIR_IN");
+  });
+
+  it("rebuilds the compacted history with preserved multimodal messages", () => {
+    const history: LLMMessage[] = [
+      multimodalMessage(),
+      {
+        role: "assistant",
+        content: "Continuing with the image context.",
+      },
+      {
+        role: "user",
+        content: "Wrap up the remaining work.",
+      },
+    ];
+
+    const compacted = compactHistoryIntoArtifactContext({
+      sessionId: "session-4",
+      history,
+      keepTailCount: 1,
+      source: "session_compaction",
+    });
+
+    expect(compacted.compactedHistory).toHaveLength(3);
+    expect(compacted.compactedHistory[0]?.role).toBe("system");
+    expect(compacted.compactedHistory[1]).toMatchObject(history[0]);
+    expect(compacted.compactedHistory[1]?.content).toEqual(history[0].content);
+    expect(compacted.compactedHistory[2]).toEqual(history[2]);
   });
 });

--- a/runtime/src/llm/context-compaction.ts
+++ b/runtime/src/llm/context-compaction.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import type { LLMMessage } from "./types.js";
 import { extractToolFailureTextFromResult } from "./chat-executor-tool-utils.js";
 import { findToolTurnValidationIssue } from "./tool-turn-validator.js";
+import { collectPreservedMessages } from "./compact/attachments.js";
 import type {
   ArtifactCompactionState,
   ContextArtifactKind,
@@ -459,6 +460,7 @@ export function compactHistoryIntoArtifactContext(
   );
   const toCompact = input.history.slice(0, retainedTailStartIndex);
   const toKeep = input.history.slice(retainedTailStartIndex);
+  const preservedMessages = collectPreservedMessages(toCompact);
   const now = Date.now();
   const records = toCompact
     .map((message, index) => {
@@ -530,6 +532,7 @@ export function compactHistoryIntoArtifactContext(
         role: "system",
         content: summaryText,
       },
+      ...preservedMessages,
       ...toKeep,
     ],
     state,

--- a/runtime/src/llm/hooks/types.ts
+++ b/runtime/src/llm/hooks/types.ts
@@ -59,6 +59,17 @@ interface HookContextBase {
   readonly depth?: number;
 }
 
+interface HookFailureContext {
+  readonly name?: string;
+  readonly message: string;
+  readonly stopReason?: string;
+  readonly stopReasonDetail?: string;
+  readonly failureClass?: string;
+  readonly providerName?: string;
+  readonly statusCode?: number;
+  readonly timeoutMs?: number;
+}
+
 interface PreToolUseContext extends HookContextBase {
   readonly event: "PreToolUse";
   readonly toolCall: LLMToolCall;
@@ -80,6 +91,10 @@ interface PostToolUseFailureContext extends HookContextBase {
 interface SessionLifecycleContext extends HookContextBase {
   readonly event: "SessionStart" | "Stop" | "StopFailure";
   readonly messages: readonly LLMMessage[];
+  readonly finalContent?: string;
+  readonly stopReason?: string;
+  readonly stopReasonDetail?: string;
+  readonly failure?: HookFailureContext;
 }
 
 interface CompactContext extends HookContextBase {

--- a/runtime/src/runtime-contract/types.test.ts
+++ b/runtime/src/runtime-contract/types.test.ts
@@ -10,10 +10,8 @@ describe("runtime-contract types", () => {
     expect(COMPLETION_VALIDATOR_ORDER).toEqual([
       "artifact_evidence",
       "turn_end_stop_gate",
-      "request_task_progress",
       "filesystem_artifact_verification",
       "deterministic_acceptance_probes",
-      "top_level_verifier",
     ]);
 
     const snapshot = createRuntimeContractSnapshot({
@@ -32,20 +30,6 @@ describe("runtime-contract types", () => {
     expect(snapshot.validators.map((validator) => validator.id)).toEqual(
       COMPLETION_VALIDATOR_ORDER,
     );
-    expect(
-      snapshot.validators.find((validator) => validator.id === "request_task_progress"),
-    ).toMatchObject({
-      enabled: false,
-      executed: false,
-      outcome: "skipped",
-    });
-    expect(
-      snapshot.validators.find((validator) => validator.id === "top_level_verifier"),
-    ).toMatchObject({
-      enabled: false,
-      executed: false,
-      outcome: "skipped",
-    });
     expect(snapshot.mailboxLayer).toEqual({
       configured: false,
       effective: false,
@@ -56,7 +40,7 @@ describe("runtime-contract types", () => {
     });
   });
 
-  it("keeps top-level verifier advisory in the runtime snapshot", () => {
+  it("omits task and verifier completion gates from the runtime snapshot order", () => {
     const snapshot = createRuntimeContractSnapshot({
       runtimeContractV2: false,
       stopHooksEnabled: false,
@@ -69,13 +53,12 @@ describe("runtime-contract types", () => {
       workerIsolationRemote: false,
     });
 
-    expect(
-      snapshot.validators.find((validator) => validator.id === "top_level_verifier"),
-    ).toMatchObject({
-      enabled: false,
-      executed: false,
-      outcome: "skipped",
-    });
+    expect(snapshot.validators.map((validator) => validator.id)).not.toContain(
+      "top_level_verifier",
+    );
+    expect(snapshot.validators.map((validator) => validator.id)).not.toContain(
+      "request_task_progress",
+    );
     expect(snapshot).not.toHaveProperty("legacyTopLevelVerifierMode");
   });
 });

--- a/runtime/src/runtime-contract/types.ts
+++ b/runtime/src/runtime-contract/types.ts
@@ -384,10 +384,8 @@ export interface DelegatedRuntimeResult {
 export const COMPLETION_VALIDATOR_ORDER: readonly CompletionValidatorId[] = [
   "artifact_evidence",
   "turn_end_stop_gate",
-  "request_task_progress",
   "filesystem_artifact_verification",
   "deterministic_acceptance_probes",
-  "top_level_verifier",
 ];
 
 export function createRuntimeContractSnapshot(

--- a/runtime/src/tools/system/filesystem.test.ts
+++ b/runtime/src/tools/system/filesystem.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   createFilesystemTools,
   clearSessionReadState,
+  clearSessionReadCache,
   safePath,
   isPathAllowed,
 } from "./filesystem.js";
@@ -533,6 +534,8 @@ describe("system.writeFile", () => {
 
   it("rejects writing an existing file when not previously read in session", async () => {
     // File exists at the target path
+    const sessionId = "session-write-no-read";
+    clearSessionReadState(sessionId);
     mockStat.mockResolvedValueOnce({
       isFile: () => true,
       isDirectory: () => false,
@@ -542,7 +545,7 @@ describe("system.writeFile", () => {
     const result = await tool.execute({
       path: "/workspace/existing.c",
       content: "new content",
-      __agencSessionId: "session-A",
+      __agencSessionId: sessionId,
     });
 
     expect(result.isError).toBe(true);
@@ -584,22 +587,22 @@ describe("system.writeFile", () => {
     expect(mockWriteFile).toHaveBeenCalled();
   });
 
-  it("allows writing an existing file when no session id is provided (test/eval harness path)", async () => {
-    // No __agencSessionId in args -> Read-before-Write check is skipped
+  it("rejects writing an existing file when no session id is provided", async () => {
+    // No __agencSessionId in args -> fail closed unless a seed exists
     mockStat.mockResolvedValueOnce({
       isFile: () => true,
       isDirectory: () => false,
       size: 100,
     } as never);
-    mockMkdir.mockResolvedValueOnce(undefined);
-    mockWriteFile.mockResolvedValueOnce(undefined);
 
     const result = await tool.execute({
       path: "/workspace/existing.c",
       content: "new content",
     });
 
-    expect(result.isError).toBeUndefined();
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain("File has not been read yet");
+    expect(mockWriteFile).not.toHaveBeenCalled();
   });
 
   it("allows writing a new (non-existent) file without a prior read", async () => {
@@ -616,6 +619,51 @@ describe("system.writeFile", () => {
 
     expect(result.isError).toBeUndefined();
     expect(mockWriteFile).toHaveBeenCalled();
+  });
+
+  it("rehydrates read state from the local history cache after an in-memory reset", async () => {
+    const historyRoot = mkdtempSync(join(tmpdir(), "agenc-filesystem-history-"));
+    const previousHistoryRoot = process.env.AGENC_FILESYSTEM_HISTORY_ROOT;
+    process.env.AGENC_FILESYSTEM_HISTORY_ROOT = historyRoot;
+    try {
+      const readTool = findTool(createFilesystemTools(CONFIG), "system.readFile");
+      const sessionId = "session-rehydrate";
+
+      mockStat.mockResolvedValueOnce({
+        isFile: () => true,
+        isDirectory: () => false,
+        size: 5,
+      } as never);
+      mockReadFile.mockResolvedValueOnce(Buffer.from("hello"));
+      await readTool.execute({
+        path: "/workspace/rehydrate.txt",
+        __agencSessionId: sessionId,
+      });
+
+      clearSessionReadCache(sessionId);
+
+      mockStat.mockResolvedValueOnce({
+        isFile: () => true,
+        isDirectory: () => false,
+        size: 5,
+      } as never);
+      mockReadFile.mockResolvedValueOnce(Buffer.from("hello"));
+      mockMkdir.mockResolvedValueOnce(undefined);
+      mockWriteFile.mockResolvedValueOnce(undefined);
+
+      const result = await tool.execute({
+        path: "/workspace/rehydrate.txt",
+        content: "world",
+        __agencSessionId: sessionId,
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(mockWriteFile).toHaveBeenCalledTimes(1);
+    } finally {
+      clearSessionReadState("session-rehydrate");
+      process.env.AGENC_FILESYSTEM_HISTORY_ROOT = previousHistoryRoot;
+      rmSync(historyRoot, { recursive: true, force: true });
+    }
   });
 
   it("rejects content exceeding size limit", async () => {
@@ -748,6 +796,21 @@ describe("system.editFile", () => {
       old_string: "return 0",
       new_string: "return 1",
       __agencSessionId: "session-no-read",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain("File has not been read yet");
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects edit when no session id is provided", async () => {
+    const before = `int main(void) { return 0; }\n`;
+    setupExistingFile(before);
+
+    const result = await tool.execute({
+      path: "/workspace/no-session.c",
+      old_string: "return 0",
+      new_string: "return 1",
     });
 
     expect(result.isError).toBe(true);
@@ -1636,6 +1699,9 @@ describe("system.writeFile base64 size pre-check", () => {
   it("rejects oversized base64 string before regex/decode", async () => {
     // 200 bytes decoded → ~268 chars base64, well above 100-byte limit
     const oversizedB64 = Buffer.alloc(200).toString("base64");
+    mockStat.mockRejectedValueOnce(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" }) as never,
+    );
 
     const result = await tool.execute({
       path: "/workspace/big.bin",

--- a/runtime/src/tools/system/filesystem.ts
+++ b/runtime/src/tools/system/filesystem.ts
@@ -28,8 +28,8 @@
  * generating the next write, which is the highest-leverage structural
  * defense against the Grok JSON-escape bug. The rule is skipped for
  * non-existent files (creating new files does not require a prior
- * read) and skipped entirely when no session ID is present in tool
- * args (e.g. unit tests, eval harness).
+ * read) and can be rehydrated from the persisted local history cache
+ * after compaction or restart.
  *
  * @module
  */
@@ -119,7 +119,7 @@ export const SESSION_ID_ARG = "__agencSessionId";
  * happens via the helpers below; tools never see the underlying Set.
  */
 interface SessionReadSnapshot {
-  readonly content?: string;
+  readonly content?: string | null;
   readonly timestamp?: number;
 }
 
@@ -154,7 +154,6 @@ function persistLocalFileHistorySnapshot(
   snapshot: SessionReadSnapshot,
 ): void {
   if (!sessionId || sessionId.trim().length === 0) return;
-  if (snapshot.content === undefined) return;
   try {
     const historyFile = resolveLocalHistoryFilePath(sessionId, canonicalPath);
     mkdirSync(dirname(historyFile), { recursive: true });
@@ -165,11 +164,16 @@ function persistLocalFileHistorySnapshot(
       const parsed = JSON.parse(raw) as unknown;
       if (Array.isArray(parsed)) {
         entries = parsed.filter(
-          (entry): entry is SessionReadSnapshot & { readonly recordedAt: number } =>
-            typeof entry === "object" &&
-            entry !== null &&
-            typeof (entry as { recordedAt?: unknown }).recordedAt === "number" &&
-            typeof (entry as { content?: unknown }).content === "string",
+          (entry): entry is SessionReadSnapshot & { readonly recordedAt: number } => {
+            if (typeof entry !== "object" || entry === null) return false;
+            if (
+              typeof (entry as { recordedAt?: unknown }).recordedAt !== "number"
+            ) {
+              return false;
+            }
+            const content = (entry as { content?: unknown }).content;
+            return typeof content === "string" || content === null;
+          },
         );
       }
     } catch {
@@ -177,7 +181,7 @@ function persistLocalFileHistorySnapshot(
     }
 
     entries.push({
-      content: snapshot.content,
+      content: snapshot.content ?? null,
       timestamp: snapshot.timestamp,
       recordedAt: Date.now(),
     });
@@ -188,6 +192,72 @@ function persistLocalFileHistorySnapshot(
   } catch {
     // Best effort only. Local history is an ergonomics aid, not part of the tool contract.
   }
+}
+
+function loadPersistedSessionReadSnapshot(
+  sessionId: string,
+  canonicalPath: string,
+): SessionReadSnapshot | undefined {
+  try {
+    const historyFile = resolveLocalHistoryFilePath(sessionId, canonicalPath);
+    const raw = readFileSync(historyFile, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed) || parsed.length === 0) {
+      return undefined;
+    }
+
+    for (let index = parsed.length - 1; index >= 0; index--) {
+      const entry = parsed[index];
+      if (typeof entry !== "object" || entry === null) continue;
+      const content = (entry as { content?: unknown }).content;
+      const timestampValue = (entry as { timestamp?: unknown }).timestamp;
+      const recordedAtValue = (entry as { recordedAt?: unknown }).recordedAt;
+      const timestamp =
+        typeof timestampValue === "number" && Number.isFinite(timestampValue)
+          ? timestampValue
+          : typeof recordedAtValue === "number" && Number.isFinite(recordedAtValue)
+            ? recordedAtValue
+            : undefined;
+      if (typeof content === "string") {
+        return timestamp === undefined ? { content } : { content, timestamp };
+      }
+      if (content === null) {
+        return timestamp === undefined
+          ? { content: null }
+          : { content: null, timestamp };
+      }
+    }
+  } catch {
+    // Best effort only. Missing or corrupt local history should not block rehydration.
+  }
+  return undefined;
+}
+
+function rehydrateSessionReadSnapshot(
+  sessionId: string | undefined,
+  canonicalPath: string,
+): SessionReadSnapshot | undefined {
+  if (!sessionId || sessionId.trim().length === 0) {
+    return undefined;
+  }
+
+  const existingSnapshot = sessionReadState.get(sessionId)?.get(canonicalPath);
+  if (existingSnapshot) {
+    return existingSnapshot;
+  }
+
+  const persistedSnapshot = loadPersistedSessionReadSnapshot(sessionId, canonicalPath);
+  if (!persistedSnapshot) {
+    return undefined;
+  }
+
+  let fileMap = sessionReadState.get(sessionId);
+  if (!fileMap) {
+    fileMap = new Map();
+    sessionReadState.set(sessionId, fileMap);
+  }
+  fileMap.set(canonicalPath, persistedSnapshot);
+  return persistedSnapshot;
 }
 
 export function recordSessionRead(
@@ -215,19 +285,14 @@ export function hasSessionRead(
   sessionId: string | undefined,
   canonicalPath: string,
 ): boolean {
-  if (!sessionId || sessionId.trim().length === 0) return false;
-  const fileMap = sessionReadState.get(sessionId);
-  if (!fileMap) return false;
-  return fileMap.has(canonicalPath);
+  return rehydrateSessionReadSnapshot(sessionId, canonicalPath) !== undefined;
 }
 
 export function getSessionReadSnapshot(
   sessionId: string | undefined,
   canonicalPath: string,
 ): SessionReadSnapshot | undefined {
-  if (!sessionId || sessionId.trim().length === 0) return undefined;
-  const fileMap = sessionReadState.get(sessionId);
-  return fileMap?.get(canonicalPath);
+  return rehydrateSessionReadSnapshot(sessionId, canonicalPath);
 }
 
 /**
@@ -248,11 +313,19 @@ export function clearSessionReadState(sessionId: string): void {
 }
 
 /**
+ * Clear only the in-memory read cache for a session. The persisted local
+ * history snapshot remains available for transcript/compaction rehydration.
+ */
+export function clearSessionReadCache(sessionId: string): void {
+  sessionReadState.delete(sessionId);
+}
+
+/**
  * Resolve the session ID from tool args (injected by the gateway via
  * `applySessionId`). Returns `undefined` when no session ID is present
  * — that signals "tool was called outside a chat session" (e.g. eval
- * harness, direct unit test) and Read-before-Write enforcement is
- * skipped in that case so non-session callers stay functional.
+ * harness, direct unit test) and mutation guards fail closed unless the
+ * caller has seeded a session id into the tool args.
  */
 export function resolveSessionId(args: Record<string, unknown>): string | undefined {
   const value = args[SESSION_ID_ARG];
@@ -784,7 +857,7 @@ function hasFileChangedSinceSnapshot(params: {
   readonly snapshot: SessionReadSnapshot | undefined;
   readonly currentContent: string;
 }): boolean {
-  if (params.snapshot?.content === undefined) {
+  if (params.snapshot?.content == null) {
     return false;
   }
   return params.currentContent !== params.snapshot.content;
@@ -872,7 +945,7 @@ function createReadFileTool(
         // path satisfy the Read-before-Write rule. See PR #314 and
         // the SESSION_ID_ARG comment for the rationale.
         recordSessionRead(resolveSessionId(args), resolved!, {
-          content: binary ? undefined : buffer.toString("utf-8"),
+          content: binary ? null : buffer.toString("utf-8"),
           timestamp: getFileTimestampMs(fileStats),
         });
 
@@ -962,7 +1035,7 @@ function createWriteFileTool(
           // prior read required.
         }
         const readSnapshot = getSessionReadSnapshot(sessionId, resolved!);
-        if (targetExists && sessionId !== undefined && !hasSessionRead(sessionId, resolved!)) {
+        if (targetExists && readSnapshot === undefined) {
           return errorResult(
             `File has not been read yet. Read it first before writing to it. ` +
               `Call system.readFile on "${args.path}" before calling system.writeFile, ` +
@@ -1030,7 +1103,7 @@ function createWriteFileTool(
         const updatedStat = await stat(resolved!).catch(() => undefined);
         recordSessionRead(sessionId, resolved!, {
           content:
-            encoding === "base64" ? undefined : data.toString("utf-8"),
+            encoding === "base64" ? null : data.toString("utf-8"),
           timestamp: getFileTimestampMs(updatedStat ?? {}) ?? Date.now(),
         });
 
@@ -1254,7 +1327,7 @@ function createEditFileTool(
         // called system.readFile on this path in the current session.
         const sessionId = resolveSessionId(args);
         const readSnapshot = getSessionReadSnapshot(sessionId, resolved!);
-        if (sessionId !== undefined && !hasSessionRead(sessionId, resolved!)) {
+        if (readSnapshot === undefined) {
           return errorResult(
             `File has not been read yet. Read it first before editing it. ` +
               `Call system.readFile on "${args.path}" before calling system.editFile. ` +

--- a/runtime/src/tools/system/task-tracker.test.ts
+++ b/runtime/src/tools/system/task-tracker.test.ts
@@ -514,23 +514,60 @@ describe("task-tracker", () => {
       expect(result.raw.isError).toBe(true);
     });
 
-    it("blocks completion when the runtime completion guard rejects it", async () => {
+    it("allows ordinary task completion even when a completion guard is configured", async () => {
+      let guardCalled = false;
       tools = createTaskTrackerTools(store, {
-        onBeforeTaskComplete: async () => ({
-          outcome: "block",
-          message: "completion blocked",
-        }),
+        onBeforeTaskComplete: async () => {
+          guardCalled = true;
+          return {
+            outcome: "block",
+            message: "completion blocked",
+          };
+        },
       });
       update = findTool(tools, "task.update");
 
       const result = await callTool(update, { taskId: "1", status: "completed" });
 
+      expect(result.raw.isError).toBeUndefined();
+      expect(result.body.task).toMatchObject({
+        id: "1",
+        status: "completed",
+      });
+      expect(store.get(DEFAULT_TASK_LIST_ID, "1")?.status).toBe("completed");
+      expect(guardCalled).toBe(false);
+    });
+
+    it("still blocks explicit verification tasks when the completion guard rejects them", async () => {
+      let guardCalled = false;
+      tools = createTaskTrackerTools(store, {
+        onBeforeTaskComplete: async () => {
+          guardCalled = true;
+          return {
+            outcome: "block",
+            message: "completion blocked",
+          };
+        },
+      });
+      update = findTool(tools, "task.update");
+
+      const result = await callTool(update, {
+        taskId: "1",
+        status: "completed",
+        metadata: {
+          _runtime: {
+            verification: true,
+          },
+        },
+      });
+
       expect(result.raw.isError).toBe(true);
       expect(result.body.error).toContain("completion blocked");
       expect(store.get(DEFAULT_TASK_LIST_ID, "1")?.status).toBe("pending");
+      expect(guardCalled).toBe(true);
     });
 
-    it("rejects stale completion when the task changes during the guard", async () => {
+    it("rejects stale completion when an explicit verification task changes during the guard", async () => {
       tools = createTaskTrackerTools(store, {
         onBeforeTaskComplete: async () => {
           store.update(DEFAULT_TASK_LIST_ID, "1", {
@@ -544,7 +581,12 @@ describe("task-tracker", () => {
       const result = await callTool(update, {
         taskId: "1",
         status: "completed",
-        metadata: { ready: true },
+        metadata: {
+          ready: true,
+          _runtime: {
+            verification: true,
+          },
+        },
       });
 
       expect(result.raw.isError).toBe(true);

--- a/runtime/src/tools/system/task-tracker.ts
+++ b/runtime/src/tools/system/task-tracker.ts
@@ -412,6 +412,29 @@ function cloneStoredTask(task: StoredTask): StoredTask {
   };
 }
 
+function isExplicitCompletionFlow(params: {
+  readonly task: Task;
+  readonly patch: TaskUpdatePatch;
+}): boolean {
+  if (params.task.kind === "verifier") {
+    return true;
+  }
+  if (params.task.externalRef?.kind === "verifier") {
+    return true;
+  }
+  if (params.task.verifierVerdict !== undefined) {
+    return true;
+  }
+  const mergedMetadata =
+    params.patch.metadata !== undefined
+      ? {
+          ...(params.task.metadata ?? {}),
+          ...params.patch.metadata,
+        }
+      : params.task.metadata;
+  return normalizeRequestTaskRuntimeMetadata(mergedMetadata).verification;
+}
+
 function cloneTaskList(list: TaskListEntry): TaskListEntry {
   return {
     version: list.version,
@@ -2011,7 +2034,13 @@ export function createTaskTrackerTools(
 
       const isTransitioningToCompleted =
         patch.status === "completed" && current.task.status !== "completed";
-      if (isTransitioningToCompleted && options.onBeforeTaskComplete) {
+      const shouldGuardCompletion =
+        isTransitioningToCompleted &&
+        isExplicitCompletionFlow({
+          task: current.task,
+          patch,
+        });
+      if (shouldGuardCompletion && options.onBeforeTaskComplete) {
         const guardResult = await options.onBeforeTaskComplete({
           listId,
           taskId,

--- a/runtime/src/workflow/completion-progress.test.ts
+++ b/runtime/src/workflow/completion-progress.test.ts
@@ -5,7 +5,7 @@ import {
 } from "./completion-progress.js";
 
 describe("completion-progress", () => {
-  it("derives reusable verification evidence and remaining verifier work", () => {
+  it("derives reusable verification evidence without adding verifier-only requirements", () => {
     const snapshot = deriveWorkflowProgressSnapshot({
       stopReason: "completed",
       completionState: "needs_verification",
@@ -43,7 +43,7 @@ describe("completion-progress", () => {
     expect(snapshot).toMatchObject({
       completionState: "needs_verification",
       satisfiedRequirements: ["build_verification"],
-      remainingRequirements: ["workflow_verifier_pass"],
+      remainingRequirements: [],
       reusableEvidence: [
         expect.objectContaining({
           requirement: "build_verification",
@@ -107,7 +107,6 @@ describe("completion-progress", () => {
       completionState: "completed",
       satisfiedRequirements: expect.arrayContaining([
         "build_verification",
-        "workflow_verifier_pass",
       ]),
       remainingRequirements: [],
     });
@@ -173,12 +172,12 @@ describe("completion-progress", () => {
     });
 
     expect(direct).toMatchObject({
-      requiredRequirements: ["workflow_verifier_pass"],
-      remainingRequirements: ["workflow_verifier_pass"],
+      requiredRequirements: [],
+      remainingRequirements: [],
     });
     expect(planner).toMatchObject({
-      requiredRequirements: ["workflow_verifier_pass"],
-      remainingRequirements: ["workflow_verifier_pass"],
+      requiredRequirements: [],
+      remainingRequirements: [],
     });
   });
 
@@ -239,10 +238,7 @@ describe("completion-progress", () => {
 
     expect(merged).toMatchObject({
       completionState: "completed",
-      satisfiedRequirements: expect.arrayContaining([
-        "build_verification",
-        "workflow_verifier_pass",
-      ]),
+      satisfiedRequirements: expect.arrayContaining(["build_verification"]),
       remainingRequirements: [],
     });
   });
@@ -311,7 +307,7 @@ describe("completion-progress", () => {
     expect(merged).toMatchObject({
       completionState: "completed",
       requiredRequirements: [],
-      satisfiedRequirements: ["workflow_verifier_pass"],
+      satisfiedRequirements: [],
       remainingRequirements: [],
     });
     expect(merged?.reusableEvidence).toEqual([]);
@@ -357,8 +353,8 @@ describe("completion-progress", () => {
     const next = {
       completionState: "completed" as const,
       stopReason: "completed" as const,
-      requiredRequirements: ["workflow_verifier_pass"] as const,
-      satisfiedRequirements: ["workflow_verifier_pass"] as const,
+      requiredRequirements: [] as const,
+      satisfiedRequirements: [] as const,
       remainingRequirements: [] as const,
       reusableEvidence: [] as const,
       updatedAt: 15,
@@ -369,13 +365,13 @@ describe("completion-progress", () => {
 
     expect(merged).toMatchObject({
       completionState: "completed",
-      satisfiedRequirements: ["workflow_verifier_pass"],
+      satisfiedRequirements: [],
       remainingRequirements: [],
     });
     expect(merged?.reusableEvidence).toEqual([]);
   });
 
-  it("preserves needs-verification carryover when a later snapshot blocks before verifier closure", () => {
+  it("keeps reusable evidence but does not preserve verifier-only carryover when a later snapshot blocks", () => {
     const previous = deriveWorkflowProgressSnapshot({
       stopReason: "completed",
       completionState: "needs_verification",
@@ -427,8 +423,8 @@ describe("completion-progress", () => {
     });
 
     expect(merged).toMatchObject({
-      completionState: "needs_verification",
-      remainingRequirements: ["workflow_verifier_pass"],
+      completionState: "blocked",
+      remainingRequirements: [],
       stopReason: "validation_error",
       stopReasonDetail: "Verification artifacts are still missing",
     });

--- a/runtime/src/workflow/completion-progress.ts
+++ b/runtime/src/workflow/completion-progress.ts
@@ -79,9 +79,6 @@ export function deriveWorkflowProgressSnapshot(params: {
     completionContract: params.completionContract,
   });
   const requiredRequirements = new Set<WorkflowProgressRequirement>();
-  if (params.completionState === "needs_verification") {
-    requiredRequirements.add("workflow_verifier_pass");
-  }
   const requestCompletion = resolveWorkflowRequestCompletionStatus({
     contract: mergedContract?.requestCompletion,
     completedMilestoneIds: params.completedRequestMilestoneIds,
@@ -109,12 +106,6 @@ export function deriveWorkflowProgressSnapshot(params: {
   const satisfiedRequirements = new Set<WorkflowProgressRequirement>(
     reusableEvidence.map((entry) => entry.requirement),
   );
-  if (
-    params.completionState === "completed" &&
-    (!params.verifier || params.verifier.overall === "pass")
-  ) {
-    satisfiedRequirements.add("workflow_verifier_pass");
-  }
   if (requestCompletion && requestCompletion.remainingMilestones.length === 0) {
     satisfiedRequirements.add("request_milestones");
   }
@@ -349,9 +340,6 @@ function resolveMergedCompletionState(params: {
   const latest = params.next.completionState;
   if (params.remainingRequirements.length === 0) {
     return latest;
-  }
-  if (params.remainingRequirements.includes("workflow_verifier_pass")) {
-    return "needs_verification";
   }
   if (latest === "blocked") {
     return "blocked";

--- a/runtime/src/workflow/completion-state.test.ts
+++ b/runtime/src/workflow/completion-state.test.ts
@@ -45,7 +45,7 @@ describe("completion-state", () => {
     ).toBe("partial");
   });
 
-  it("marks missing behavior harness as needs_verification when implementation progress exists", () => {
+  it("marks missing behavior harness as partial when implementation progress exists", () => {
     expect(
       resolveWorkflowCompletionState({
         stopReason: "validation_error",
@@ -71,7 +71,7 @@ describe("completion-state", () => {
           },
         },
       }),
-    ).toBe("needs_verification");
+    ).toBe("partial");
   });
 
   it("uses the same completion semantics for planner and direct implementation when the workflow contract matches", () => {
@@ -114,7 +114,7 @@ describe("completion-state", () => {
     ).toBe("completed");
   });
 
-  it("keeps behavior-required work in needs_verification when verification is skipped", () => {
+  it("keeps behavior-required work completed when verification is skipped on a normal turn", () => {
     expect(
       resolveWorkflowCompletionState({
         stopReason: "completed",
@@ -142,10 +142,10 @@ describe("completion-state", () => {
           overall: "skipped",
         },
       }),
-    ).toBe("needs_verification");
+    ).toBe("completed");
   });
 
-  it("keeps runtime-required work in needs_verification when verifier is skipped", () => {
+  it("keeps runtime-required work completed when verifier is skipped on a normal turn", () => {
     expect(
       resolveWorkflowCompletionState({
         stopReason: "completed",
@@ -161,12 +161,11 @@ describe("completion-state", () => {
           performed: false,
           overall: "skipped",
         },
-        runtimeVerifierRequired: true,
       }),
-    ).toBe("needs_verification");
+    ).toBe("completed");
   });
 
-  it("keeps request-level multi-phase work partial when local verification passes but planner milestones remain", () => {
+  it("keeps request-level multi-phase work completed when planner milestones remain advisory", () => {
     expect(
       resolveWorkflowCompletionState({
         stopReason: "completed",
@@ -207,6 +206,6 @@ describe("completion-state", () => {
           overall: "pass",
         },
       }),
-    ).toBe("partial");
+    ).toBe("completed");
   });
 });

--- a/runtime/src/workflow/completion-state.ts
+++ b/runtime/src/workflow/completion-state.ts
@@ -1,6 +1,5 @@
 import { didToolCallFail } from "../llm/chat-executor-tool-utils.js";
 import type { DelegationOutputValidationCode } from "../utils/delegation-validation.js";
-import type { ImplementationCompletionContract } from "./completion-contract.js";
 import { resolveWorkflowRequestCompletionStatus } from "./request-completion.js";
 import type { WorkflowVerificationContract } from "./verification-obligations.js";
 
@@ -22,19 +21,6 @@ interface CompletionStateToolCall {
   readonly isError: boolean;
 }
 
-function requiresPassedVerificationForCompletion(
-  completionContract: ImplementationCompletionContract | undefined,
-): boolean {
-  switch (completionContract?.taskClass) {
-    case "behavior_required":
-    case "build_required":
-    case "review_required":
-      return true;
-    default:
-      return false;
-  }
-}
-
 export function resolvePipelineCompletionState(input: {
   readonly status: "running" | "completed" | "failed" | "halted";
   readonly completedSteps: number;
@@ -52,15 +38,11 @@ export function resolveWorkflowCompletionState(input: {
   readonly stopReason: string;
   readonly toolCalls: readonly CompletionStateToolCall[];
   readonly verificationContract?: WorkflowVerificationContract;
-  readonly completionContract?: ImplementationCompletionContract;
   readonly completedRequestMilestoneIds?: readonly string[];
   readonly validationCode?: DelegationOutputValidationCode;
   readonly verifier?: PlannerVerificationSnapshot;
-  readonly runtimeVerifierRequired?: boolean;
 }): WorkflowCompletionState {
   const verifier = input.verifier;
-  const completionContract =
-    input.completionContract ?? input.verificationContract?.completionContract;
   const successfulToolCalls = input.toolCalls.filter(
     (toolCall) => !didToolCallFail(toolCall.isError, toolCall.result),
   );
@@ -71,20 +53,8 @@ export function resolveWorkflowCompletionState(input: {
   });
 
   if (input.stopReason === "completed") {
-    if ((requestCompletion?.remainingMilestones.length ?? 0) > 0) {
-      return hasProgress ? "partial" : "blocked";
-    }
     if (verifier?.overall === "retry" || verifier?.overall === "fail") {
       return hasProgress ? "partial" : "blocked";
-    }
-    if (input.runtimeVerifierRequired && verifier?.overall !== "pass") {
-      return "needs_verification";
-    }
-    if (
-      requiresPassedVerificationForCompletion(completionContract) &&
-      verifier?.overall !== "pass"
-    ) {
-      return "needs_verification";
     }
     return "completed";
   }
@@ -94,7 +64,11 @@ export function resolveWorkflowCompletionState(input: {
   }
 
   if (input.validationCode === "missing_behavior_harness" && hasProgress) {
-    return "needs_verification";
+    return "partial";
+  }
+
+  if ((requestCompletion?.remainingMilestones.length ?? 0) > 0 && hasProgress) {
+    return "partial";
   }
 
   return hasProgress ? "partial" : "blocked";


### PR DESCRIPTION
## Summary
- demote task and verifier completion gating for normal coding turns
- preserve compacted message streams and tighten filesystem mutation state recovery
- enrich stop-failure hooks with provider error context and reduce loop-owned validator ordering

## Validation
- `cd agenc-core/runtime && npx vitest run src/workflow/completion-state.test.ts src/workflow/completion-progress.test.ts src/runtime-contract/types.test.ts src/llm/chat-executor-request.test.ts src/tools/system/task-tracker.test.ts src/llm/context-compaction.test.ts src/gateway/session.test.ts src/tools/system/filesystem.test.ts src/gateway/tool-handler-factory.test.ts`
- `cd agenc-core/runtime && npx vitest run src/llm/chat-executor.test.ts src/llm/hooks/stop-hooks.test.ts src/llm/completion-validators.test.ts src/gateway/daemon-text-channel-turn.test.ts src/gateway/daemon-session-state.test.ts src/gateway/top-level-verifier.test.ts src/runtime-contract/types.test.ts src/workflow/completion-state.test.ts src/workflow/completion-progress.test.ts`
- `cd agenc-core/runtime && npm run typecheck`
- `cd agenc-core/runtime && npm run build`
- `cd /home/tetsuo/git/AgenC && npm run techdebt`