### PR TITLE
Harden financial tool governance for token transfer actions

### DIFF
--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -562,18 +562,23 @@ describe("GrokProvider", () => {
     const provider = new GrokProvider({
       apiKey: "test-key",
     });
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
 
-    await provider.chat(
-      [{ role: "user", content: "inspect the repo" }],
-      {
-        trace: {
-          includeProviderPayloads: true,
-          onProviderTraceEvent: (event) => {
-            events.push(event as unknown as Record<string, unknown>);
+    try {
+      await provider.chat(
+        [{ role: "user", content: "inspect the repo" }],
+        {
+          trace: {
+            includeProviderPayloads: true,
+            onProviderTraceEvent: (event) => {
+              events.push(event as unknown as Record<string, unknown>);
+            },
           },
         },
-      },
-    );
+      );
+    } finally {
+      dateNow.mockRestore();
+    }
 
     expect(events[0]).toMatchObject({
       kind: "request",

--- a/runtime/src/policy/tool-governance.test.ts
+++ b/runtime/src/policy/tool-governance.test.ts
@@ -36,6 +36,22 @@ describe("tool-governance", () => {
     expect(classified.riskScore).toBe(0.95);
   });
 
+  it("classifies skill-based token swaps and transfers as irreversible financial actions", () => {
+    for (const toolName of [
+      "jupiter.executeSwap",
+      "jupiter.transferSol",
+      "jupiter.transferToken",
+      "defi.transferToken",
+    ]) {
+      const classified = classifyToolGovernance(toolName, {
+        amount: "1000",
+      });
+
+      expect(classified.policyClass).toBe("irreversible_financial_action");
+      expect(classified.riskScore).toBe(0.95);
+    }
+  });
+
   it("builds a policy action with explicit scope", () => {
     const action = buildToolPolicyAction({
       toolName: "system.processStart",

--- a/runtime/src/policy/tool-governance.ts
+++ b/runtime/src/policy/tool-governance.ts
@@ -15,7 +15,7 @@ export interface ToolGovernanceClassification {
 
 const READ_ACTION_PREFIXES = ["get", "list", "query", "inspect", "read", "status"];
 
-const IRREVERSIBLE_FINANCIAL_RE = /^(wallet\.|agenc\.(?:create|claim|complete|submit|transfer|register|stake|reward)|system\.wallet)/i;
+const IRREVERSIBLE_FINANCIAL_RE = /^(wallet\.|agenc\.(?:create|claim|complete|submit|transfer|register|stake|reward)|system\.wallet|jupiter\.(?:executeSwap|transferSol|transferToken)$|.*\.(?:executeSwap|transferSol|transferToken)$)/i;
 const DESTRUCTIVE_SIDE_EFFECT_RE = /(?:delete|destroy|drop|remove|revoke|terminate|kill|stop|cancel|reset|overwrite|truncate)/i;
 const SECRET_ACCESS_RE = /^(system\.bash|desktop\.bash|system\.evaluateJs|system\.sandbox(?:Start|Exec|Stop)|system\.processStart|desktop\.process_start)/i;
 const NETWORK_OPEN_WORLD_RE = /^(system\.http|system\.remoteJob|system\.research|system\.server|desktop\.bash|system\.bash|mcp\.)/i;


### PR DESCRIPTION
## Summary
- classify Jupiter swap and transfer tools as irreversible financial actions
- cover generic skill-adapted transferSol/transferToken tool names
- add governance tests for skill-based token transfer classification

## Validation
- npm run test -- src/policy/tool-governance.test.ts src/eval/safety-suite.test.ts src/policy/production-profile.test.ts src/gateway/approvals.test.ts src/gateway/system-prompt-routing.test.ts
- npm run build