### PR TITLE
Fail closed for remote marketplace job specs

### DIFF
--- a/runtime/src/marketplace/job-spec-store.test.ts
+++ b/runtime/src/marketplace/job-spec-store.test.ts
@@ -1,0 +1,174 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  resolveMarketplaceJobSpecReference,
+  verifyMarketplaceJobSpecEnvelope,
+  type MarketplaceJobSpecEnvelope,
+} from "./job-spec-store.js";
+
+function basePayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    kind: "agenc.marketplace.jobSpec",
+    title: "Remote audit task",
+    shortDescription: "Remote audit task",
+    fullDescription: null,
+    acceptanceCriteria: [],
+    deliverables: [],
+    constraints: null,
+    attachments: [],
+    custom: null,
+    context: {},
+    ...overrides,
+  };
+}
+
+function legacyCanonicalJson(value: unknown): string {
+  return JSON.stringify(legacySort(value));
+}
+
+function legacySort(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(legacySort);
+  if (!value || typeof value !== "object") return value;
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort()) {
+    sorted[key] = legacySort((value as Record<string, unknown>)[key]);
+  }
+  return sorted;
+}
+
+function sha256Hex(input: string): string {
+  return createHash("sha256").update(input, "utf8").digest("hex");
+}
+
+function canonicalJobSpecUri(hash: string): string {
+  return `agenc://job-spec/sha256/${hash}`;
+}
+
+function makeEnvelope(payload: Record<string, unknown>): {
+  envelope: MarketplaceJobSpecEnvelope;
+  hash: string;
+} {
+  const hash = sha256Hex(legacyCanonicalJson(payload));
+  return {
+    hash,
+    envelope: {
+      schemaVersion: 1,
+      kind: "agenc.marketplace.jobSpecEnvelope",
+      integrity: {
+        algorithm: "sha256",
+        canonicalization: "json-stable-v1",
+        payloadHash: hash,
+        uri: canonicalJobSpecUri(hash),
+      },
+      payload: payload as MarketplaceJobSpecEnvelope["payload"],
+    },
+  };
+}
+
+function remoteResponse(envelope: MarketplaceJobSpecEnvelope) {
+  const body = JSON.stringify(envelope);
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    headers: {
+      get: (name: string) => (name.toLowerCase() === "content-length" ? String(Buffer.byteLength(body)) : null),
+    },
+    text: async () => body,
+  } as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("marketplace job spec integrity", () => {
+  it("does not fetch remote job spec URIs unless explicitly allowed", async () => {
+    const { envelope, hash } = makeEnvelope(basePayload());
+    const fetchSpy = vi.fn(async () => remoteResponse(envelope));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(
+      resolveMarketplaceJobSpecReference({
+        jobSpecHash: hash,
+        jobSpecUri: "https://attacker.invalid/job-spec.json",
+      }),
+    ).rejects.toThrow(/allowRemote=true/);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("resolves remote job spec URIs only when allowRemote is true", async () => {
+    const { envelope, hash } = makeEnvelope(basePayload());
+    const fetchSpy = vi.fn(async () => remoteResponse(envelope));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const resolved = await resolveMarketplaceJobSpecReference(
+      {
+        jobSpecHash: hash,
+        jobSpecUri: "https://trusted.example/job-spec.json",
+      },
+      { allowRemote: true },
+    );
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(resolved.jobSpecHash).toBe(hash);
+    expect(resolved.payload.title).toBe("Remote audit task");
+  });
+
+  it.each([
+    ["custom.__proto__", { custom: JSON.parse('{"__proto__":{"polluted":true}}') }],
+    ["context.nested.constructor", { context: { nested: { constructor: { polluted: true } } } }],
+    ["constraints[0].prototype", { constraints: [{ prototype: { polluted: true } }] }],
+    [
+      "attachments[0].__proto__",
+      { attachments: [JSON.parse('{"uri":"https://example.com/spec.md","__proto__":{"polluted":true}}')] },
+    ],
+  ])("rejects forbidden payload keys at %s", (_label, overrides) => {
+    const { envelope } = makeEnvelope(basePayload(overrides));
+
+    expect(verifyMarketplaceJobSpecEnvelope(envelope)).toBe(false);
+  });
+
+  it("rejects a local envelope whose canonical hash omitted a forbidden key", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "agenc-job-spec-integrity-"));
+    const objectsDir = join(rootDir, "objects");
+    const { envelope, hash } = makeEnvelope(
+      basePayload({ custom: JSON.parse('{"__proto__":{"polluted":true}}') }),
+    );
+
+    await mkdir(objectsDir, { recursive: true });
+    await writeFile(join(objectsDir, `${hash}.json`), `${JSON.stringify(envelope)}\n`, "utf8");
+
+    await expect(
+      resolveMarketplaceJobSpecReference(
+        { jobSpecHash: hash, jobSpecUri: canonicalJobSpecUri(hash) },
+        { rootDir },
+      ),
+    ).rejects.toThrow(/integrity verification/);
+  });
+
+  it("rejects a remote envelope whose canonical hash omitted a forbidden key", async () => {
+    const { envelope, hash } = makeEnvelope(
+      basePayload({ custom: JSON.parse('{"__proto__":{"polluted":true}}') }),
+    );
+    const fetchSpy = vi.fn(async () => remoteResponse(envelope));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(
+      resolveMarketplaceJobSpecReference(
+        {
+          jobSpecHash: hash,
+          jobSpecUri: "https://trusted.example/job-spec.json",
+        },
+        { allowRemote: true },
+      ),
+    ).rejects.toThrow(/integrity verification/);
+    expect(fetchSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/runtime/src/marketplace/job-spec-store.ts
+++ b/runtime/src/marketplace/job-spec-store.ts
@@ -314,14 +314,16 @@ export async function resolveMarketplaceJobSpecReference(
   );
   const expectedUri = canonicalJobSpecUri(reference.jobSpecHash);
   const isRemote = isRemoteJobSpecUri(jobSpecUri);
-  if (isRemote && options.allowRemote === false) {
-    throw new Error("remote marketplace jobSpec URI resolution is disabled");
-  }
 
   const rootDir = options.rootDir ?? getDefaultMarketplaceJobSpecStoreDir();
   const jobSpecPath = isRemote
     ? jobSpecUri
     : join(rootDir, "objects", `${reference.jobSpecHash}.json`);
+  if (isRemote && options.allowRemote !== true) {
+    throw new Error(
+      "Remote marketplace jobSpec resolution requires allowRemote=true",
+    );
+  }
   const envelope = isRemote
     ? await fetchRemoteMarketplaceJobSpecEnvelope(jobSpecUri, reference.jobSpecHash)
     : await readMarketplaceJobSpecEnvelope(
@@ -396,6 +398,7 @@ export function verifyMarketplaceJobSpecEnvelope(
   if (typeof payloadHash !== "string" || !HASH_RE.test(payloadHash)) return false;
   const expectedUri = `agenc://job-spec/sha256/${payloadHash}`;
   if (candidate.integrity.uri !== expectedUri) return false;
+  if (hasForbiddenMarketplaceJobSpecObjectKey(candidate.payload)) return false;
   return sha256Hex(canonicalJson(candidate.payload)) === payloadHash;
 }
 
@@ -817,11 +820,26 @@ function canonicalJson(value: unknown): string {
 function sortMarketplaceJobSpecJsonValue(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(sortMarketplaceJobSpecJsonValue);
   if (!value || typeof value !== "object") return value;
-  const sorted: Record<string, unknown> = {};
+  const sorted: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
   for (const key of Object.keys(value).sort()) {
     sorted[key] = sortMarketplaceJobSpecJsonValue((value as Record<string, unknown>)[key]);
   }
   return sorted;
+}
+
+function hasForbiddenMarketplaceJobSpecObjectKey(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some(hasForbiddenMarketplaceJobSpecObjectKey);
+  }
+  if (!value || typeof value !== "object") return false;
+
+  for (const key of Object.keys(value)) {
+    if (FORBIDDEN_OBJECT_KEYS.has(key)) return true;
+    if (hasForbiddenMarketplaceJobSpecObjectKey((value as Record<string, unknown>)[key])) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function sha256Hex(input: string): string {

--- a/runtime/src/task/operations.test.ts
+++ b/runtime/src/task/operations.test.ts
@@ -840,7 +840,7 @@ describe("TaskOperations", () => {
       });
 
       await expect(ops.claimTask(taskPda, task)).rejects.toThrow(
-        /remote marketplace jobSpec URI resolution is disabled/,
+        /Task not claimable: Task job spec could not be verified before claim/,
       );
       expect(fetchSpy).not.toHaveBeenCalled();
       expect(mocks.claimTaskBuilder.rpc).not.toHaveBeenCalled();

--- a/runtime/src/tools/agenc/tools.test.ts
+++ b/runtime/src/tools/agenc/tools.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { PublicKey } from '@solana/web3.js';
 import type { ToolResult } from '../types.js';
@@ -14,13 +17,17 @@ import { OnChainTaskStatus, TaskType } from '../../task/types.js';
 import {
   createGetDisputeTool,
   createGetGovernanceProposalTool,
+  createGetJobSpecTool,
+  createGetTaskTool,
   createGetReputationSummaryTool,
   createGetSkillTool,
   createInspectMarketplaceTool,
   createListDisputesTool,
   createListGovernanceProposalsTool,
+  createListTasksTool,
   createListSkillsTool,
 } from './tools.js';
+import { linkMarketplaceJobSpecToTask } from '../../marketplace/job-spec-store.js';
 
 function parseJson(result: ToolResult) {
   return JSON.parse(result.content) as Record<string, any>;
@@ -149,6 +156,23 @@ function makeProposal(status: ProposalStatus, seed: number) {
   };
 }
 
+async function linkRemoteJobSpecForTask(
+  taskPda: PublicKey,
+  task: OnChainTask,
+  jobSpecStoreDir: string,
+) {
+  return linkMarketplaceJobSpecToTask(
+    {
+      hash: 'a'.repeat(64),
+      uri: 'https://attacker.invalid/job-spec.json',
+      taskPda: taskPda.toBase58(),
+      taskId: Buffer.from(task.taskId).toString('hex'),
+      transactionSignature: 'remote-job-spec-test',
+    },
+    { rootDir: jobSpecStoreDir },
+  );
+}
+
 function createMockProgram() {
   const firstSkillPda = PublicKey.unique();
   const secondSkillPda = PublicKey.unique();
@@ -235,9 +259,77 @@ function createMockProgram() {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe('agenc query tools', () => {
+  it('agenc.getTask does not fetch remote job specs by default', async () => {
+    const taskPda = PublicKey.unique();
+    const task = makeTaskRecord({ status: OnChainTaskStatus.Open, currentWorkers: 0 });
+    const jobSpecStoreDir = await mkdtemp(join(tmpdir(), 'agenc-tool-job-spec-'));
+    await linkRemoteJobSpecForTask(taskPda, task, jobSpecStoreDir);
+    const fetchSpy = vi.fn(async () => {
+      throw new Error('fetch should not be called');
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const ops = {
+      fetchTask: vi.fn(async () => task),
+      fetchEscrowTokenBalance: vi.fn(),
+    } as unknown as TaskOperations;
+    const tool = createGetTaskTool(ops, silentLogger, { jobSpecStoreDir });
+
+    const result = await tool.execute({ taskPda: taskPda.toBase58() });
+    const parsed = parseJson(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(parsed.jobSpec.verified).toBe(false);
+    expect(parsed.jobSpec.error).toMatch(/allowRemote=true/);
+  });
+
+  it('agenc.getJobSpec fails closed without fetching remote job specs by default', async () => {
+    const taskPda = PublicKey.unique();
+    const task = makeTaskRecord({ status: OnChainTaskStatus.Open, currentWorkers: 0 });
+    const jobSpecStoreDir = await mkdtemp(join(tmpdir(), 'agenc-tool-job-spec-'));
+    await linkRemoteJobSpecForTask(taskPda, task, jobSpecStoreDir);
+    const fetchSpy = vi.fn(async () => {
+      throw new Error('fetch should not be called');
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const tool = createGetJobSpecTool(silentLogger, { jobSpecStoreDir });
+
+    const result = await tool.execute({ taskPda: taskPda.toBase58() });
+    const parsed = parseJson(result);
+
+    expect(result.isError).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(parsed.error).toMatch(/allowRemote=true/);
+  });
+
+  it('agenc.listTasks payload enrichment does not fetch remote job specs by default', async () => {
+    const taskPda = PublicKey.unique();
+    const task = makeTaskRecord({ status: OnChainTaskStatus.Open, currentWorkers: 0 });
+    const jobSpecStoreDir = await mkdtemp(join(tmpdir(), 'agenc-tool-job-spec-'));
+    await linkRemoteJobSpecForTask(taskPda, task, jobSpecStoreDir);
+    const fetchSpy = vi.fn(async () => {
+      throw new Error('fetch should not be called');
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+    const ops = {
+      fetchClaimableTasks: vi.fn(async () => [{ taskPda, task }]),
+      fetchAllTasks: vi.fn(async () => [{ taskPda, task }]),
+    } as unknown as TaskOperations;
+    const tool = createListTasksTool(ops, silentLogger, { jobSpecStoreDir });
+
+    const result = await tool.execute({ status: 'open', includeJobSpecPayload: true });
+    const parsed = parseJson(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(parsed.tasks[0].jobSpec.verified).toBe(false);
+    expect(parsed.tasks[0].jobSpec.error).toMatch(/allowRemote=true/);
+  });
+
   it('agenc.listSkills filters and sorts marketplace skills', async () => {
     const program = createMockProgram();
     const tool = createListSkillsTool(program as never, silentLogger);

--- a/runtime/tests/job-spec-security.integration.test.ts
+++ b/runtime/tests/job-spec-security.integration.test.ts
@@ -1,0 +1,125 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PublicKey } from "@solana/web3.js";
+import {
+  resetMarketplaceCliProgramContextOverrides,
+  runMarketTaskDetailCommand,
+  setMarketplaceCliProgramContextOverrides,
+} from "../src/cli/marketplace-cli.js";
+import { linkMarketplaceJobSpecToTask } from "../src/marketplace/job-spec-store.js";
+import { silentLogger } from "../src/utils/logger.js";
+
+function fixedBytes(value: string, size: number): Uint8Array {
+  const bytes = new Uint8Array(size);
+  bytes.set(new TextEncoder().encode(value).slice(0, size));
+  return bytes;
+}
+
+function bnLike(value: number | bigint) {
+  return {
+    toNumber: () => Number(value),
+    toString: () => String(value),
+  };
+}
+
+afterEach(() => {
+  resetMarketplaceCliProgramContextOverrides();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("marketplace job spec security integration", () => {
+  it("market.tasks.detail fails closed without fetching remote job specs by default", async () => {
+    const taskPda = PublicKey.unique();
+    const taskId = new Uint8Array(32).fill(7);
+    const jobSpecStoreDir = await mkdtemp(join(tmpdir(), "agenc-cli-job-spec-"));
+    const rawTask = {
+      taskId,
+      creator: PublicKey.unique(),
+      requiredCapabilities: bnLike(1),
+      description: fixedBytes("Remote job spec guard", 64),
+      constraintHash: new Uint8Array(32),
+      rewardAmount: bnLike(1_000_000),
+      maxWorkers: 1,
+      currentWorkers: 0,
+      status: 0,
+      taskType: 0,
+      createdAt: bnLike(1_700_000_000),
+      deadline: bnLike(1_700_010_000),
+      completedAt: bnLike(0),
+      escrow: PublicKey.unique(),
+      result: fixedBytes("", 64),
+      completions: 0,
+      requiredCompletions: 1,
+      bump: 1,
+      rewardMint: null,
+    };
+    const fakeProgram = {
+      programId: PublicKey.unique(),
+      account: {
+        task: {
+          fetch: vi.fn(async () => rawTask),
+        },
+        taskJobSpec: {
+          fetch: vi.fn(async () => {
+            throw new Error("Account does not exist");
+          }),
+        },
+      },
+    };
+    setMarketplaceCliProgramContextOverrides({
+      async createReadOnlyProgramContext() {
+        return { connection: {} as never, program: fakeProgram as never };
+      },
+    });
+    await linkMarketplaceJobSpecToTask(
+      {
+        hash: "c".repeat(64),
+        uri: "https://attacker.invalid/job-spec.json",
+        taskPda: taskPda.toBase58(),
+        taskId: Buffer.from(taskId).toString("hex"),
+        transactionSignature: "remote-job-spec-test",
+      },
+      { rootDir: jobSpecStoreDir },
+    );
+    const fetchSpy = vi.fn(async () => {
+      throw new Error("fetch should not be called");
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    let output: unknown;
+    let error: unknown;
+    const code = await runMarketTaskDetailCommand(
+      {
+        logger: silentLogger,
+        outputFormat: "json",
+        output(value) {
+          output = value;
+        },
+        error(value) {
+          error = value;
+        },
+      },
+      {
+        help: false,
+        outputFormat: "json",
+        strictMode: true,
+        storeType: "memory",
+        idempotencyWindow: 900,
+        rpcUrl: "http://unit.test",
+        taskPda: taskPda.toBase58(),
+        jobSpecStoreDir,
+      },
+    );
+
+    expect(code).toBe(1);
+    expect(output).toBeUndefined();
+    expect(error).toMatchObject({
+      code: "MARKET_TASK_DETAIL_FAILED",
+      message: expect.stringMatching(/allowRemote=true/),
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/runtime/tests/marketplace-cli.integration.test.ts
+++ b/runtime/tests/marketplace-cli.integration.test.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { Connection } from "@solana/web3.js";
 import { Keypair, LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
 import {
@@ -56,6 +56,7 @@ import {
   type RuntimeTestContext,
 } from "./litesvm-setup.js";
 import { registerLiteSVMProgramAccount } from "../../tests/litesvm-connection-proxy.ts";
+import { linkMarketplaceJobSpecToTask } from "../src/marketplace/job-spec-store.js";
 
 interface Actor {
   label: string;
@@ -306,6 +307,7 @@ beforeAll(async () => {
 
 afterEach(() => {
   activeSignerAgentPda = null;
+  vi.unstubAllGlobals();
   if (baseCtx) {
     advanceClock(baseCtx.svm, 61);
   }
@@ -375,6 +377,69 @@ describeIfProtocolWorkspace("marketplace CLI integration", () => {
     expect(expectString(summarySpec.jobSpecUri)).toBe(
       expectString(createdTask.jobSpecUri),
     );
+  });
+
+  it("fails closed without fetching remote job specs in task detail by default", async () => {
+    const jobSpecStoreDir = await mkdtemp(
+      join(tmpdir(), "agenc-market-job-spec-"),
+    );
+    const createPayload = await runMarketCommand(
+      runMarketTaskCreateCommand,
+      {
+        description: "LiteSVM remote job spec guard task",
+        reward: String(LAMPORTS_PER_SOL / 20),
+        requiredCapabilities: "1",
+        creatorAgentPda: creator.agentPda.toBase58(),
+        jobSpecStoreDir,
+      },
+      creator.agentPda.toBase58(),
+    );
+    const createdTask = asRecord(createPayload.result);
+    const taskPda = expectString(createdTask.taskPda);
+    registerLiteSVMProgramAccount(baseCtx.connection, new PublicKey(taskPda));
+
+    await linkMarketplaceJobSpecToTask(
+      {
+        hash: "b".repeat(64),
+        uri: "https://attacker.invalid/job-spec.json",
+        taskPda,
+        taskId: expectString(createdTask.taskId),
+        transactionSignature: "remote-job-spec-test",
+      },
+      { rootDir: jobSpecStoreDir },
+    );
+    const fetchSpy = vi.fn(async () => {
+      throw new Error("fetch should not be called");
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    let output: unknown;
+    let error: unknown;
+    const code = await runMarketTaskDetailCommand(
+      {
+        logger: silentLogger,
+        outputFormat: "json",
+        output(value) {
+          output = value;
+        },
+        error(value) {
+          error = value;
+        },
+      },
+      {
+        ...BASE_OPTIONS,
+        taskPda,
+        jobSpecStoreDir,
+      },
+    );
+
+    expect(code).toBe(1);
+    expect(output).toBeUndefined();
+    expect(error).toMatchObject({
+      code: "MARKET_TASK_DETAIL_FAILED",
+      message: expect.stringMatching(/allowRemote=true/),
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("blocks injected marketplace task prompts until the job spec is locally verified", async () => {


### PR DESCRIPTION
## Summary

- Require explicit `allowRemote: true` before resolving remote marketplace job-spec URIs, preventing CLI/tool read paths from fetching by default.
- Reject forbidden payload keys such as `__proto__`, `constructor`, and `prototype` during envelope verification, including payloads whose legacy canonical hash omitted those keys.
- Add regression coverage for store verification, `agenc.getTask`, `agenc.getJobSpec`, task list enrichment, and `market.tasks.detail` fail-closed behavior.

## Validation

- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run src/marketplace/job-spec-store.test.ts src/tools/agenc/tools.test.ts tests/job-spec-security.integration.test.ts`
- `npm --workspace=@tetsuo-ai/runtime run typecheck`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/marketplace-cli.integration.test.ts` skipped by protocol workspace gate in this checkout.

Fixes #355.
