### PR TITLE
refactor(runtime): tighten long-session replay and loop finalization

### DIFF
--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -87,3 +87,10 @@
 - **What worked:** Pulling the remaining milestone and verifier pressure out of the normal coding loop, persisting compacted sessions as rebuilt message streams, and enforcing one seeded read-state contract across runtime and desktop editor surfaces removed the largest remaining execution-model drifts without breaking the public result surface.
 - **What didn't:** Session persistence and restore had hidden dependencies on artifact snapshot metadata and reduced replay history, so the refactor needed a dual-read migration path and broader daemon/session test coverage than the original loop-only reduction suggested.
 - **Rule added to CLAUDE.md:** no
+
+## PR #358: refactor(runtime): tighten long-session replay and loop finalization
+- **Date:** 2026-04-14
+- **Files changed:** `runtime/src/llm/chat-executor-{request,tool-loop,types}.ts`, `runtime/src/llm/{context-compaction,shell-write-policy}.ts`, `runtime/src/gateway/{session,daemon-session-state,daemon,tool-handler-factory}.ts`, `runtime/src/channels/webchat/plugin.ts`, `runtime/src/tools/system/{filesystem,bash,task-tracker}.ts`, `runtime/src/workflow/completion-state.ts`, `containers/desktop/server/src/{tools-editor,tools.test.ts}`
+- **What worked:** Moving terminal ownership into the tool loop, persisting replay state as compact-boundary snapshots with hydrated artifact/read-state carryover, and requiring full-file read state before existing-file mutation closed the remaining long-session execution gaps without regressing the explicit verifier path.
+- **What didn't:** Durable compaction still had hidden coupling between session metadata and artifact snapshot persistence, so the replay fix needed extra session/daemon integration coverage and exposed unrelated marketplace CLI and MCP typecheck drift during the broader repo validation run.
+- **Rule added to CLAUDE.md:** no

--- a/.claude/notes/techdebt-2026-04-14.md
+++ b/.claude/notes/techdebt-2026-04-14.md
@@ -1,0 +1,28 @@
+## Tech Debt Report - 2026-04-14
+
+### Critical (Fix Now)
+| Issue | Location | Impact | Suggested Fix |
+|-------|----------|--------|---------------|
+| None in the touched long-session parity surface | n/a | No new critical debt found in the audited runtime/editor files | Keep the focused regression suite in place so replay/read-state drift is caught early |
+
+### High (Fix This Sprint)
+| Issue | Location | Impact | Suggested Fix |
+|-------|----------|--------|---------------|
+| Replay-state normalization is concentrated in two large helpers | `runtime/src/gateway/daemon-session-state.ts:305`, `runtime/src/gateway/daemon-session-state.ts:491` | The replay snapshot builder and coercion/migration path now own a lot of shape logic, which raises review and migration risk | Split snapshot extraction, replay-tail rendering, and legacy migration/coercion into smaller pure helpers with dedicated tests |
+
+### Medium (Backlog)
+| Issue | Location | Impact | Suggested Fix |
+|-------|----------|--------|---------------|
+| Shell write policy repeats operand-walking patterns across command families | `runtime/src/llm/shell-write-policy.ts:105`, `runtime/src/llm/shell-write-policy.ts:208`, `runtime/src/llm/shell-write-policy.ts:272` | New shell-write cases are more likely to drift because path/operand parsing is spread across several helpers | Factor shared operand scanning primitives for direct commands and wrapper commands |
+| Session compaction now stores both artifact state and records in session metadata until replay persistence runs | `runtime/src/gateway/session.ts:566`, `runtime/src/gateway/session.ts:608` | This is correct for durability, but it keeps more structured state resident in memory and increases coupling between compaction and replay persistence | Consider an explicit session-compaction persistence abstraction so metadata only carries the minimum resume handle |
+
+### Duplications Found
+| Pattern | Locations | Lines | Refactor To |
+|---------|-----------|-------|-------------|
+| Replay snapshot field extraction and replay-state coercion mirror many of the same fields | `runtime/src/gateway/daemon-session-state.ts:305-386`, `runtime/src/gateway/daemon-session-state.ts:491-733` | ~325 | Shared field-schema helpers for shell/workflow/runtime-contract/review/verification/task/fork fields |
+| Shell operand parsing branches share repeated `--` / flag-skipping logic | `runtime/src/llm/shell-write-policy.ts:105-131`, `runtime/src/llm/shell-write-policy.ts:178-191`, `runtime/src/llm/shell-write-policy.ts:216-240` | ~65 | One reusable operand iterator with mode flags |
+
+### Summary
+- Total issues: 4
+- Estimated cleanup: 3 files
+- Recommended priority: split the replay-state build/coercion path in `runtime/src/gateway/daemon-session-state.ts` before adding more resume metadata

--- a/containers/desktop/server/src/tools-editor.ts
+++ b/containers/desktop/server/src/tools-editor.ts
@@ -11,12 +11,14 @@ const MAX_FILE_SIZE = 1024 * 1024; // 1MB
 const MAX_UNDO_FILES = 20;
 const SESSION_ID_ARG = "__agencSessionId";
 const LOCAL_FILE_HISTORY_MAX_ENTRIES = 8;
+type SessionReadViewKind = "full" | "partial" | "legacy_unknown";
 
 /** LRU undo buffer — stores the single most recent version per file. */
 const undoBuffer = new Map<string, string>();
 interface SessionReadSnapshot {
   readonly content?: string | null;
   readonly timestamp?: number;
+  readonly viewKind?: SessionReadViewKind;
 }
 
 const sessionReadState = new Map<string, Map<string, SessionReadSnapshot>>();
@@ -85,6 +87,7 @@ function persistLocalFileHistorySnapshot(
     entries.push({
       content: snapshot.content ?? null,
       timestamp: snapshot.timestamp,
+      viewKind: snapshot.viewKind ?? "legacy_unknown",
       recordedAt: Date.now(),
     });
     if (entries.length > LOCAL_FILE_HISTORY_MAX_ENTRIES) {
@@ -110,6 +113,7 @@ function loadPersistedSessionReadSnapshot(
       const entry = parsed[index];
       if (typeof entry !== "object" || entry === null) continue;
       const content = (entry as { content?: unknown }).content;
+      const viewKind = (entry as { viewKind?: unknown }).viewKind;
       const timestampValue = (entry as { timestamp?: unknown }).timestamp;
       const recordedAtValue = (entry as { recordedAt?: unknown }).recordedAt;
       const timestamp =
@@ -119,10 +123,26 @@ function loadPersistedSessionReadSnapshot(
             ? recordedAtValue
             : undefined;
       if (typeof content === "string") {
-        return timestamp === undefined ? { content } : { content, timestamp };
+        return {
+          ...(timestamp === undefined ? { content } : { content, timestamp }),
+          viewKind:
+            viewKind === "full" ||
+            viewKind === "partial" ||
+            viewKind === "legacy_unknown"
+              ? viewKind
+              : "legacy_unknown",
+        };
       }
       if (content === null) {
-        return timestamp === undefined ? { content: null } : { content: null, timestamp };
+        return {
+          ...(timestamp === undefined ? { content: null } : { content: null, timestamp }),
+          viewKind:
+            viewKind === "full" ||
+            viewKind === "partial" ||
+            viewKind === "legacy_unknown"
+              ? viewKind
+              : "legacy_unknown",
+        };
       }
     }
   } catch {
@@ -168,11 +188,17 @@ function recordSessionRead(
     ...(fileMap.get(path) ?? {}),
     ...snapshot,
   };
+  if (nextSnapshot.viewKind === undefined) {
+    nextSnapshot.viewKind = snapshot.viewKind ?? "full";
+  }
   fileMap.set(path, nextSnapshot);
   persistLocalFileHistorySnapshot(sessionId, path, nextSnapshot);
 }
 
-async function readFreshTextSnapshot(path: string): Promise<SessionReadSnapshot> {
+async function readFreshTextSnapshot(
+  path: string,
+  viewKind: SessionReadViewKind,
+): Promise<SessionReadSnapshot> {
   const [content, fileStats] = await Promise.all([
     readFile(path, "utf-8"),
     stat(path),
@@ -183,7 +209,14 @@ async function readFreshTextSnapshot(path: string): Promise<SessionReadSnapshot>
       typeof fileStats.mtimeMs === "number" && Number.isFinite(fileStats.mtimeMs)
         ? fileStats.mtimeMs
         : Date.now(),
+    viewKind,
   };
+}
+
+function requiresFullReadSnapshot(
+  snapshot: SessionReadSnapshot | undefined,
+): boolean {
+  return snapshot?.viewKind !== "full";
 }
 
 function hasFileChangedSinceSnapshot(
@@ -201,10 +234,10 @@ async function loadEditableFile(
   path: string,
 ): Promise<{ content: string } | { error: ToolResult }> {
   const snapshot = getSessionReadSnapshot(sessionId, path);
-  if (!snapshot) {
+  if (requiresFullReadSnapshot(snapshot)) {
     return {
       error: fail(
-        `File has not been read yet. Use view first before modifying ${path}.`,
+        `View the full file before modifying ${path}.`,
       ),
     };
   }
@@ -226,8 +259,12 @@ async function loadEditableFile(
   }
 }
 
-async function recordFreshSnapshot(sessionId: string | undefined, path: string): Promise<void> {
-  const snapshot = await readFreshTextSnapshot(path);
+async function recordFreshSnapshot(
+  sessionId: string | undefined,
+  path: string,
+  viewKind: SessionReadViewKind,
+): Promise<void> {
+  const snapshot = await readFreshTextSnapshot(path, viewKind);
   recordSessionRead(sessionId, path, snapshot);
 }
 
@@ -308,16 +345,25 @@ async function textEditorView(
     }
     const content = await readFile(path, "utf-8");
     const lines = content.split("\n");
-    await recordFreshSnapshot(sessionId, path);
 
     if (viewRange && Array.isArray(viewRange) && viewRange.length === 2) {
       const start = Math.max(1, Number(viewRange[0]));
       const end = Math.min(lines.length, Number(viewRange[1]));
       if (start > end) return fail(`Invalid range: [${start}, ${end}]`);
       const slice = lines.slice(start - 1, end);
+      recordSessionRead(sessionId, path, {
+        content: slice.join("\n"),
+        timestamp: s.mtimeMs,
+        viewKind: "partial",
+      });
       return ok({ output: numberLines(slice.join("\n"), start) });
     }
 
+    recordSessionRead(sessionId, path, {
+      content,
+      timestamp: s.mtimeMs,
+      viewKind: "full",
+    });
     return ok({ output: numberLines(content) });
   } catch (e) {
     return fail(`Failed to read ${path}: ${e instanceof Error ? e.message : e}`);
@@ -344,7 +390,7 @@ async function textEditorCreate(
     }
     await mkdir(dirname(path), { recursive: true });
     await writeFile(path, fileText, "utf-8");
-    await recordFreshSnapshot(sessionId, path);
+    await recordFreshSnapshot(sessionId, path, "full");
     return ok({ output: `File created at ${path} (${fileText.split("\n").length} lines)` });
   } catch (e) {
     return fail(`Failed to create ${path}: ${e instanceof Error ? e.message : e}`);
@@ -388,7 +434,7 @@ async function textEditorStrReplace(
 
     const updated = content.replace(oldStr, newStr);
     await writeFile(path, updated, "utf-8");
-    await recordFreshSnapshot(sessionId, path);
+    await recordFreshSnapshot(sessionId, path, "full");
     return ok({ output: `Replacement applied in ${path}` });
   } catch (e) {
     return fail(`str_replace failed: ${e instanceof Error ? e.message : e}`);
@@ -426,7 +472,7 @@ async function textEditorInsert(
     const newLines = newStr.split("\n");
     lines.splice(insertLine, 0, ...newLines);
     await writeFile(path, lines.join("\n"), "utf-8");
-    await recordFreshSnapshot(sessionId, path);
+    await recordFreshSnapshot(sessionId, path, "full");
     return ok({
       output: `Inserted ${newLines.length} line(s) after line ${insertLine} in ${path}`,
     });
@@ -449,7 +495,7 @@ async function textEditorUndo(
       return loaded.error;
     }
     await writeFile(path, prev, "utf-8");
-    await recordFreshSnapshot(sessionId, path);
+    await recordFreshSnapshot(sessionId, path, "full");
     undoBuffer.delete(path);
     return ok({ output: `Reverted ${path} to previous version` });
   } catch (e) {

--- a/containers/desktop/server/src/tools.test.ts
+++ b/containers/desktop/server/src/tools.test.ts
@@ -330,7 +330,44 @@ test("text_editor requires a prior view before mutating an existing file", async
     });
     assert.equal(result.isError, true);
     const payload = JSON.parse(result.content) as Record<string, unknown>;
-    assert.match(String(payload.error ?? ""), /has not been read yet/i);
+    assert.match(String(payload.error ?? ""), /view the full file before modifying/i);
+  } finally {
+    __textEditorTestHooks.clearSessionReadState(sessionId);
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test("text_editor rejects mutations after a partial view_range read", async () => {
+  const workspace = await mkdtemp(join(tmpdir(), "agenc-text-editor-partial-"));
+  const targetPath = join(workspace, "notes.txt");
+  const sessionId = `session-${Date.now().toString(36)}`;
+
+  try {
+    await executeTool("text_editor", {
+      command: "create",
+      path: targetPath,
+      file_text: "hello\nworld\n",
+      __agencSessionId: sessionId,
+    });
+
+    const viewed = await executeTool("text_editor", {
+      command: "view",
+      path: targetPath,
+      view_range: [1, 1],
+      __agencSessionId: sessionId,
+    });
+    assert.notEqual(viewed.isError, true);
+
+    const result = await executeTool("text_editor", {
+      command: "str_replace",
+      path: targetPath,
+      old_str: "world",
+      new_str: "runtime",
+      __agencSessionId: sessionId,
+    });
+    assert.equal(result.isError, true);
+    const payload = JSON.parse(result.content) as Record<string, unknown>;
+    assert.match(String(payload.error ?? ""), /full file/i);
   } finally {
     __textEditorTestHooks.clearSessionReadState(sessionId);
     await rm(workspace, { recursive: true, force: true });

--- a/runtime/src/channels/webchat/plugin.test.ts
+++ b/runtime/src/channels/webchat/plugin.test.ts
@@ -2123,16 +2123,22 @@ describe("WebChatChannel", () => {
         expect(
           await loadPersistedSessionRuntimeState(memoryBackend, targetSessionId),
         ).toMatchObject({
-          shellProfile: "research",
-          workflowState: expect.objectContaining({
-            objective: "Investigate a variant",
-          }),
+          version: 1,
+          snapshot: {
+            shellProfile: "research",
+            workflowState: expect.objectContaining({
+              objective: "Investigate a variant",
+            }),
+            forkMarker: expect.objectContaining({
+              parentSessionId: "session-source",
+            }),
+          },
         });
         const targetState = await loadPersistedSessionRuntimeState(
           memoryBackend,
           targetSessionId,
         );
-        expect(targetState?.activeTaskContext).toBeUndefined();
+        expect(targetState?.snapshot.activeTaskContext).toBeUndefined();
       } finally {
         rmSync(workspaceRoot, { recursive: true, force: true });
       }

--- a/runtime/src/channels/webchat/plugin.ts
+++ b/runtime/src/channels/webchat/plugin.ts
@@ -35,9 +35,10 @@ import type { GatewayAutonomyConfig } from "../../gateway/types.js";
 import { DEFAULT_WORKSPACE_ID } from "../../gateway/workspace.js";
 import type { ControlMessage, ControlResponse } from "../../gateway/types.js";
 import {
-  forkSessionRuntimeState,
-  loadPersistedSessionRuntimeState,
-  type PersistedSessionRuntimeState,
+  forkSessionReplayState,
+  loadPersistedSessionReplayContext,
+  loadPersistedSessionReplayState,
+  type PersistedSessionReplayState,
 } from "../../gateway/daemon-session-state.js";
 import type { ActiveTaskContext } from "../../llm/turn-execution-contract-types.js";
 import { safeStringify } from "../../tools/types.js";
@@ -2103,19 +2104,18 @@ export class WebChatChannel
     );
 
     await Promise.resolve(this.deps.hydrateSessionContext?.(targetSessionId));
-    const history = await this.loadSessionHistory(targetSessionId);
-    const runtimeState = this.deps.memoryBackend
-      ? await loadPersistedSessionRuntimeState(
+    const replayContext = this.deps.memoryBackend
+      ? await loadPersistedSessionReplayContext(
           this.deps.memoryBackend,
           targetSessionId,
         )
       : undefined;
     return {
       sessionId: targetSessionId,
-      messageCount: history.length,
+      messageCount: replayContext?.history.length ?? 0,
       ...(workspaceRoot ? { workspaceRoot } : {}),
-      ...(runtimeState?.shellProfile
-        ? { shellProfile: runtimeState.shellProfile }
+      ...(replayContext?.state?.snapshot.shellProfile
+        ? { shellProfile: replayContext.state.snapshot.shellProfile }
         : {}),
     };
   }
@@ -2197,7 +2197,7 @@ export class WebChatChannel
     }
     const continuity = await this.buildSessionContinuityRecord(persisted);
     const runtimeState = this.deps.memoryBackend
-      ? await loadPersistedSessionRuntimeState(
+      ? await loadPersistedSessionReplayState(
           this.deps.memoryBackend,
           sessionId,
         )
@@ -2209,7 +2209,7 @@ export class WebChatChannel
     return {
       ...continuity,
       workflowState:
-        runtimeState?.workflowState ?? {
+        runtimeState?.snapshot.workflowState ?? {
           stage: continuity.workflowStage,
           worktreeMode: "off",
           enteredAt: continuity.updatedAt,
@@ -2217,17 +2217,17 @@ export class WebChatChannel
         },
       runtimeState: runtimeState
         ? {
-            ...(runtimeState.activeTaskContext
-              ? { activeTaskContext: runtimeState.activeTaskContext }
+            ...(runtimeState.snapshot.activeTaskContext
+              ? { activeTaskContext: runtimeState.snapshot.activeTaskContext }
               : {}),
-            ...(runtimeState.reviewSurfaceState?.status
-              ? { reviewStatus: runtimeState.reviewSurfaceState.status }
+            ...(runtimeState.snapshot.reviewSurfaceState?.status
+              ? { reviewStatus: runtimeState.snapshot.reviewSurfaceState.status }
               : {}),
-            ...(runtimeState.verificationSurfaceState?.status
-              ? { verificationStatus: runtimeState.verificationSurfaceState.status }
+            ...(runtimeState.snapshot.verificationSurfaceState?.status
+              ? { verificationStatus: runtimeState.snapshot.verificationSurfaceState.status }
               : {}),
-            ...(runtimeState.verificationSurfaceState?.verdict
-              ? { verificationVerdict: runtimeState.verificationSurfaceState.verdict }
+            ...(runtimeState.snapshot.verificationSurfaceState?.verdict
+              ? { verificationVerdict: runtimeState.snapshot.verificationSurfaceState.verdict }
               : {}),
           }
         : undefined,
@@ -2250,19 +2250,19 @@ export class WebChatChannel
     session: PersistedWebChatSession,
   ): Promise<SessionContinuityRecord> {
     const runtimeState = this.deps.memoryBackend
-      ? await loadPersistedSessionRuntimeState(
+      ? await loadPersistedSessionReplayState(
           this.deps.memoryBackend,
           session.sessionId,
         )
       : undefined;
     const workspaceRoot = session.metadata?.workspaceRoot;
     const { repoRoot, branch, head } = await resolveGitSnapshot(workspaceRoot);
-    const runtimeStatus = runtimeState?.runtimeContractStatusSnapshot as
+    const runtimeStatus = runtimeState?.snapshot.runtimeContractStatusSnapshot as
       | unknown
       | undefined;
     const pendingApprovalCount = this.countPendingApprovals(session.sessionId);
     const preview =
-      runtimeState?.workflowState?.objective ??
+      runtimeState?.snapshot.workflowState?.objective ??
       session.label ??
       session.metadata?.lastAssistantOutputPreview ??
       "New conversation";
@@ -2282,8 +2282,8 @@ export class WebChatChannel
         messageCount: session.messageCount,
         runtimeState,
       }),
-      shellProfile: runtimeState?.shellProfile ?? "general",
-      workflowStage: runtimeState?.workflowState?.stage ?? "idle",
+      shellProfile: runtimeState?.snapshot.shellProfile ?? "general",
+      workflowStage: runtimeState?.snapshot.workflowState?.stage ?? "idle",
       ...(workspaceRoot ? { workspaceRoot } : {}),
       ...(repoRoot ? { repoRoot } : {}),
       ...(branch ? { branch } : {}),
@@ -2311,7 +2311,7 @@ export class WebChatChannel
     connected: boolean;
     workspaceRoot?: string;
     messageCount: number;
-    runtimeState?: PersistedSessionRuntimeState;
+    runtimeState?: PersistedSessionReplayState;
   }): SessionResumabilityState {
     if (params.connected) {
       return "active";
@@ -2334,9 +2334,9 @@ export class WebChatChannel
   }
 
   private summarizeActiveTask(
-    runtimeState: PersistedSessionRuntimeState | undefined,
+    runtimeState: PersistedSessionReplayState | undefined,
   ): string | undefined {
-    const activeTaskContext = runtimeState?.activeTaskContext as
+    const activeTaskContext = runtimeState?.snapshot.activeTaskContext as
       | ActiveTaskContext
       | undefined;
     if (activeTaskContext?.taskLineageId) {
@@ -2351,9 +2351,9 @@ export class WebChatChannel
         : activeTaskContext.taskLineageId;
     }
     const snapshot =
-      runtimeState?.runtimeContractStatusSnapshot &&
-      typeof runtimeState.runtimeContractStatusSnapshot === "object"
-        ? (runtimeState.runtimeContractStatusSnapshot as unknown as Record<
+      runtimeState?.snapshot.runtimeContractStatusSnapshot &&
+      typeof runtimeState.snapshot.runtimeContractStatusSnapshot === "object"
+        ? (runtimeState.snapshot.runtimeContractStatusSnapshot as unknown as Record<
             string,
             unknown
           >)
@@ -2459,7 +2459,7 @@ export class WebChatChannel
     }
 
     if (!forkSource && this.deps.memoryBackend) {
-      const forkedRuntimeState = await forkSessionRuntimeState(
+      const forkedRuntimeState = await forkSessionReplayState(
         this.deps.memoryBackend,
         {
           sourceWebSessionId: sourceSessionId,

--- a/runtime/src/eval/delegated-workspace-gate-suite.ts
+++ b/runtime/src/eval/delegated-workspace-gate-suite.ts
@@ -15,7 +15,6 @@ import {
 } from "../workflow/delegated-filesystem-scope.js";
 import { isPathWithinRoot } from "../workflow/path-normalization.js";
 import { resolveWorkflowCompletionState } from "../workflow/completion-state.js";
-import type { WorkflowVerificationContract } from "../workflow/verification-obligations.js";
 import { TrajectoryReplayEngine } from "./replay.js";
 import { parseTrajectoryTrace } from "./types.js";
 
@@ -380,26 +379,11 @@ async function runDegradedProviderRetryBrokenScopeScenario(): Promise<PipelineDe
       targetArtifacts: ["/tmp/agenc-phase7-retry/PLAN.md"],
     },
   });
-  const verificationContract: WorkflowVerificationContract = {
-    workspaceRoot: "/tmp/agenc-phase7-retry",
-    requiredSourceArtifacts: ["/tmp/agenc-phase7-retry/PLAN.md"],
-    targetArtifacts: ["/tmp/agenc-phase7-retry/PLAN.md"],
-    acceptanceCriteria: ["Do not complete until the delegated scope is valid and grounded."],
-    completionContract: {
-      taskClass: "behavior_required",
-      placeholdersAllowed: false,
-      partialCompletionAllowed: false,
-      placeholderTaxonomy: "implementation",
-    },
-  };
   const completionState = resolveWorkflowCompletionState({
     stopReason: "completed",
     toolCalls: [],
-    verificationContract,
-    verifier: {
-      performed: false,
-      overall: "skipped",
-    },
+    requiresVerification: true,
+    verificationSatisfied: false,
   });
   return {
     scenarioId: "degraded_provider_retry_does_not_complete_broken_scope",

--- a/runtime/src/eval/implementation-gate-suite.ts
+++ b/runtime/src/eval/implementation-gate-suite.ts
@@ -560,22 +560,11 @@ async function runDegradedProviderRetryScenario(): Promise<PipelineImplementatio
     systemPrompt: "You are an evaluation harness.",
     sessionId: "phase8-reroute",
   });
-  const verificationContract: WorkflowVerificationContract = {
-    workspaceRoot: "/tmp/phase8-reroute",
-    targetArtifacts: ["/tmp/phase8-reroute/src/runner.js"],
-    acceptanceCriteria: ["Behavior verification must pass before completion."],
-    completionContract: {
-      taskClass: "behavior_required",
-      placeholdersAllowed: false,
-      partialCompletionAllowed: false,
-      placeholderTaxonomy: "implementation",
-    },
-  };
   const completionState = resolveWorkflowCompletionState({
     stopReason: "completed",
     toolCalls: [],
-    verificationContract,
-    verifier: { performed: false, overall: "skipped" },
+    requiresVerification: true,
+    verificationSatisfied: false,
   });
   return {
     scenarioId: "degraded_provider_retry_without_false_completion",
@@ -609,22 +598,11 @@ async function runSafetyIncompleteOutputScenario(): Promise<PipelineImplementati
       targets: ["rm -rf ./src"],
     },
   });
-  const verificationContract: WorkflowVerificationContract = {
-    workspaceRoot: "/tmp/agenc-phase8-safety",
-    targetArtifacts: ["/tmp/agenc-phase8-safety/src/main.c"],
-    acceptanceCriteria: ["Behavior verification must still pass before completion."],
-    completionContract: {
-      taskClass: "behavior_required",
-      placeholdersAllowed: false,
-      partialCompletionAllowed: false,
-      placeholderTaxonomy: "implementation",
-    },
-  };
   const completionState = resolveWorkflowCompletionState({
     stopReason: "completed",
     toolCalls: [],
-    verificationContract,
-    verifier: { performed: false, overall: "skipped" },
+    requiresVerification: true,
+    verificationSatisfied: false,
   });
   const blocked = outcome.status === "deny" || outcome.status === "require_approval";
   return {

--- a/runtime/src/gateway/daemon-session-state.test.ts
+++ b/runtime/src/gateway/daemon-session-state.test.ts
@@ -171,12 +171,16 @@ describe("web session runtime state helpers", () => {
     expect(
       await loadPersistedSessionRuntimeState(memoryBackend, "web-session-artifacts"),
     ).toMatchObject({
-      version: 7,
-      statefulResumeAnchor: {
-        previousResponseId: "resp-123",
-        reconciliationHash: "hash-123",
+      version: 1,
+      boundarySeq: 1,
+      snapshot: {
+        statefulResumeAnchor: {
+          previousResponseId: "resp-123",
+          reconciliationHash: "hash-123",
+        },
+        statefulHistoryCompacted: true,
       },
-      statefulHistoryCompacted: true,
+      tailEvents: expect.any(Array),
     });
 
     const hydrated = createSession();
@@ -219,12 +223,15 @@ describe("web session runtime state helpers", () => {
     await persistSessionRuntimeState(memoryBackend, "web-legacy", hydrated);
     expect(
       await loadPersistedSessionRuntimeState(memoryBackend, "web-legacy"),
-    ).toEqual({
-      version: 7,
-      statefulResumeAnchor: {
-        previousResponseId: "resp-legacy",
+    ).toMatchObject({
+      version: 1,
+      migratedFromLegacyAt: expect.any(Number),
+      snapshot: {
+        statefulResumeAnchor: {
+          previousResponseId: "resp-legacy",
+        },
+        statefulHistoryCompacted: true,
       },
-      statefulHistoryCompacted: true,
     });
   });
   it("persists and hydrates active task context across web-session resume", async () => {
@@ -362,11 +369,11 @@ describe("web session runtime state helpers", () => {
     });
     expect(forked).toBe(true);
     const persisted = await loadPersistedSessionRuntimeState(memoryBackend, "web-target");
-    expect(persisted?.reviewSurfaceState).toMatchObject({
+    expect(persisted?.snapshot.reviewSurfaceState).toMatchObject({
       status: "idle",
       source: "local",
     });
-    expect(persisted?.verificationSurfaceState).toMatchObject({
+    expect(persisted?.snapshot.verificationSurfaceState).toMatchObject({
       status: "idle",
       source: "local",
       verdict: "unknown",
@@ -438,14 +445,20 @@ describe("web session runtime state helpers", () => {
         "web-session-target",
       ),
     ).toMatchObject({
-      shellProfile: "research",
-      workflowState: expect.objectContaining({
-        objective: "Investigate a branch",
-      }),
-      statefulResumeAnchor: {
-        previousResponseId: "resp-123",
+      version: 1,
+      snapshot: {
+        shellProfile: "research",
+        workflowState: expect.objectContaining({
+          objective: "Investigate a branch",
+        }),
+        statefulResumeAnchor: {
+          previousResponseId: "resp-123",
+        },
+        statefulHistoryCompacted: true,
+        forkMarker: expect.objectContaining({
+          parentSessionId: "web-session-source",
+        }),
       },
-      statefulHistoryCompacted: true,
     });
     expect(
       (
@@ -453,7 +466,7 @@ describe("web session runtime state helpers", () => {
           memoryBackend,
           "web-session-target",
         )
-      )?.activeTaskContext,
+      )?.snapshot.activeTaskContext,
     ).toBeUndefined();
   });
 

--- a/runtime/src/gateway/daemon-session-state.ts
+++ b/runtime/src/gateway/daemon-session-state.ts
@@ -17,12 +17,18 @@ import {
   updateRuntimeContractTaskLayer,
   updateRuntimeContractWorkerLayer,
 } from "../runtime-contract/types.js";
+import { createCompactBoundaryMessage } from "../llm/context-compaction.js";
+import type { LLMMessage } from "../llm/types.js";
 import type { Task, TaskStore } from "../tools/system/task-tracker.js";
 import type { PersistentWorkerManager } from "./persistent-worker-manager.js";
 import {
   MemoryArtifactStore,
+  type ArtifactCompactionState,
+  type ContextArtifactRecord,
 } from "../memory/artifact-store.js";
+import { entryToMessage } from "../memory/types.js";
 import {
+  clearStatefulContinuationMetadata,
   DEFAULT_SESSION_SHELL_PROFILE,
   SESSION_SHELL_PROFILE_METADATA_KEY,
   SESSION_ACTIVE_TASK_CONTEXT_METADATA_KEY,
@@ -47,6 +53,7 @@ import {
   resolveSessionWorkflowState,
   type SessionWorkflowState,
 } from "./workflow-state.js";
+import type { PersistedWebChatForkSource } from "../channels/webchat/session-store.js";
 import {
   clearForkedReviewSurfaceState,
   clearForkedVerificationSurfaceState,
@@ -57,20 +64,26 @@ import {
 } from "./watch-cockpit.js";
 
 const WEB_SESSION_RUNTIME_STATE_KEY_PREFIX = "webchat:runtime-state:";
+const WEB_SESSION_REPLAY_STATE_KEY_PREFIX = "webchat:replay-state:";
 
-export interface PersistedSessionRuntimeState {
-  readonly version: 7;
+export interface PersistedSessionReplayForkMarker {
+  readonly parentSessionId: string;
+  readonly source: PersistedWebChatForkSource;
+  readonly forkedAt: number;
+}
+
+export interface PersistedSessionReplaySnapshot {
   readonly shellProfile?: SessionShellProfile;
   readonly workflowState?: SessionWorkflowState;
   readonly statefulResumeAnchor?: LLMStatefulResumeAnchor;
   readonly statefulHistoryCompacted?: boolean;
-  /** Legacy compacted artifact snapshot ids; read during migration, never written. */
   readonly artifactSnapshotId?: string;
   readonly artifactSessionId?: string;
   readonly runtimeContractSnapshot?: RuntimeContractSnapshot;
   readonly runtimeContractStatusSnapshot?: RuntimeContractStatusSnapshot;
   readonly reviewSurfaceState?: ReviewSurfaceState;
   readonly verificationSurfaceState?: VerificationSurfaceState;
+  readonly forkMarker?: PersistedSessionReplayForkMarker;
   /**
    * Active task carryover for the next compatible turn. Round-trips through
    * web-session resume so a paused implementation/artifact-update task can
@@ -80,8 +93,19 @@ export interface PersistedSessionRuntimeState {
   readonly activeTaskContext?: ActiveTaskContext;
 }
 
-/** @deprecated Use PersistedSessionRuntimeState. */
-export type PersistedWebSessionRuntimeState = PersistedSessionRuntimeState;
+export interface PersistedSessionReplayState {
+  readonly version: 1;
+  readonly boundarySeq: number;
+  readonly migratedFromLegacyAt?: number;
+  readonly snapshot: PersistedSessionReplaySnapshot;
+  readonly tailEvents: readonly LLMMessage[];
+}
+
+/** @deprecated Use PersistedSessionReplayState. */
+export type PersistedSessionRuntimeState = PersistedSessionReplayState;
+
+/** @deprecated Use PersistedSessionReplayState. */
+export type PersistedWebSessionRuntimeState = PersistedSessionReplayState;
 
 const SESSION_STATEFUL_LINEAGE_PHASES = new Set([
   "initial",
@@ -228,9 +252,59 @@ function coerceActiveTaskContext(value: unknown): ActiveTaskContext | undefined 
   return undefined;
 }
 
-function buildPersistedSessionRuntimeState(
+function readArtifactCompactionState(
+  metadata: Record<string, unknown>,
+): ArtifactCompactionState | undefined {
+  const candidate = metadata[SESSION_STATEFUL_ARTIFACT_CONTEXT_METADATA_KEY];
+  if (typeof candidate !== "object" || candidate === null) {
+    return undefined;
+  }
+  const record = candidate as Record<string, unknown>;
+  if (record.version !== 1) {
+    return undefined;
+  }
+  if (typeof record.snapshotId !== "string" || record.snapshotId.trim().length === 0) {
+    return undefined;
+  }
+  if (typeof record.sessionId !== "string" || record.sessionId.trim().length === 0) {
+    return undefined;
+  }
+  if (!Array.isArray(record.artifactRefs)) {
+    return undefined;
+  }
+  return candidate as ArtifactCompactionState;
+}
+
+function readArtifactCompactionRecords(
+  metadata: Record<string, unknown>,
+): readonly ContextArtifactRecord[] {
+  const candidate = metadata[SESSION_STATEFUL_ARTIFACT_RECORDS_METADATA_KEY];
+  if (!Array.isArray(candidate)) {
+    return [];
+  }
+  return candidate.filter(
+    (record): record is ContextArtifactRecord =>
+      !!record &&
+      typeof record === "object" &&
+      typeof (record as ContextArtifactRecord).id === "string" &&
+      typeof (record as ContextArtifactRecord).sessionId === "string" &&
+      typeof (record as ContextArtifactRecord).title === "string" &&
+      typeof (record as ContextArtifactRecord).summary === "string" &&
+      typeof (record as ContextArtifactRecord).content === "string",
+  );
+}
+
+function webSessionReplayStateKey(webSessionId: string): string {
+  return `${WEB_SESSION_REPLAY_STATE_KEY_PREFIX}${webSessionId}`;
+}
+
+function cloneReplayTailEvents(tailEvents: readonly LLMMessage[]): readonly LLMMessage[] {
+  return tailEvents.map((event) => JSON.parse(JSON.stringify(event)) as LLMMessage);
+}
+
+function buildPersistedSessionReplaySnapshot(
   session: Session,
-): PersistedSessionRuntimeState | undefined {
+): PersistedSessionReplaySnapshot | undefined {
   const resumeAnchorCandidate =
     session.metadata[SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY];
   const resumeAnchor = isStatefulResumeAnchor(resumeAnchorCandidate)
@@ -241,7 +315,6 @@ function buildPersistedSessionRuntimeState(
   const activeTaskContext = coerceActiveTaskContext(
     session.metadata[SESSION_ACTIVE_TASK_CONTEXT_METADATA_KEY],
   );
-  const hasActiveTaskContext = activeTaskContext !== undefined;
   const runtimeContractSnapshot =
     typeof session.metadata[SESSION_RUNTIME_CONTRACT_SNAPSHOT_METADATA_KEY] === "object" &&
       session.metadata[SESSION_RUNTIME_CONTRACT_SNAPSHOT_METADATA_KEY] !== null
@@ -275,11 +348,21 @@ function buildPersistedSessionRuntimeState(
     workflowState.stage !== "idle" ||
     workflowState.worktreeMode !== "off" ||
     Boolean(workflowState.objective);
+  const artifactContext =
+    typeof session.metadata[SESSION_STATEFUL_ARTIFACT_CONTEXT_METADATA_KEY] === "object" &&
+      session.metadata[SESSION_STATEFUL_ARTIFACT_CONTEXT_METADATA_KEY] !== null
+      ? (session.metadata[SESSION_STATEFUL_ARTIFACT_CONTEXT_METADATA_KEY] as ArtifactCompactionState)
+      : undefined;
+  const artifactSnapshotId = artifactContext?.snapshotId;
+  const artifactSessionId = artifactContext?.sessionId;
+  const hasActiveTaskContext = activeTaskContext !== undefined;
   if (
     !hasPersistedShellProfile &&
     !hasPersistedWorkflowState &&
     !resumeAnchor &&
     !historyCompacted &&
+    !artifactSnapshotId &&
+    !artifactSessionId &&
     !runtimeContractSnapshot &&
     !runtimeContractStatusSnapshot &&
     !reviewSurfaceState &&
@@ -289,26 +372,266 @@ function buildPersistedSessionRuntimeState(
     return undefined;
   }
   return {
-    version: 7,
-    ...(hasPersistedShellProfile ? { shellProfile } : {}),
-    ...(hasPersistedWorkflowState ? { workflowState } : {}),
-    ...(resumeAnchor ? { statefulResumeAnchor: resumeAnchor } : {}),
-    ...(historyCompacted ? { statefulHistoryCompacted: true } : {}),
-    ...(runtimeContractSnapshot ? { runtimeContractSnapshot } : {}),
-    ...(runtimeContractStatusSnapshot ? { runtimeContractStatusSnapshot } : {}),
-    ...(reviewSurfaceState ? { reviewSurfaceState } : {}),
-    ...(verificationSurfaceState ? { verificationSurfaceState } : {}),
-    ...(hasActiveTaskContext ? { activeTaskContext } : {}),
+    shellProfile: hasPersistedShellProfile ? shellProfile : undefined,
+    workflowState: hasPersistedWorkflowState ? workflowState : undefined,
+    statefulResumeAnchor: resumeAnchor,
+    statefulHistoryCompacted: historyCompacted ? true : undefined,
+    artifactSnapshotId,
+    artifactSessionId,
+    runtimeContractSnapshot,
+    runtimeContractStatusSnapshot,
+    reviewSurfaceState,
+    verificationSurfaceState,
+    activeTaskContext: hasActiveTaskContext ? activeTaskContext : undefined,
   };
+}
+
+function buildReplayTailEvents(
+  sessionId: string,
+  snapshot: PersistedSessionReplaySnapshot,
+  boundarySeq: number,
+): readonly LLMMessage[] {
+  const summaryParts: string[] = [];
+  if (snapshot.shellProfile) {
+    summaryParts.push(`shell=${snapshot.shellProfile}`);
+  }
+  if (snapshot.workflowState) {
+    summaryParts.push(`workflow=${snapshot.workflowState.stage}`);
+    if (snapshot.workflowState.objective) {
+      summaryParts.push(`objective=${snapshot.workflowState.objective}`);
+    }
+  }
+  if (snapshot.statefulResumeAnchor) {
+    summaryParts.push(`resume=${snapshot.statefulResumeAnchor.previousResponseId}`);
+  }
+  if (snapshot.statefulHistoryCompacted) {
+    summaryParts.push("history_compacted=true");
+  }
+  if (snapshot.runtimeContractSnapshot) {
+    summaryParts.push("runtime_contract=true");
+  }
+  if (snapshot.runtimeContractStatusSnapshot) {
+    summaryParts.push(
+      `runtime_status=${snapshot.runtimeContractStatusSnapshot.completionState ?? snapshot.runtimeContractStatusSnapshot.stopReason ?? "unknown"}`,
+    );
+  }
+  if (snapshot.reviewSurfaceState?.status) {
+    summaryParts.push(`review=${snapshot.reviewSurfaceState.status}`);
+  }
+  if (snapshot.verificationSurfaceState?.status) {
+    summaryParts.push(`verification=${snapshot.verificationSurfaceState.status}`);
+  }
+  if (snapshot.activeTaskContext?.taskLineageId) {
+    summaryParts.push(`task=${snapshot.activeTaskContext.taskLineageId}`);
+  }
+  if (snapshot.forkMarker) {
+    summaryParts.push(`fork=${snapshot.forkMarker.parentSessionId}`);
+  }
+  if (snapshot.artifactSnapshotId) {
+    summaryParts.push(`artifact=${snapshot.artifactSnapshotId}`);
+  }
+  if (snapshot.artifactSessionId) {
+    summaryParts.push(`artifact_session=${snapshot.artifactSessionId}`);
+  }
+  if (summaryParts.length === 0) {
+    return [];
+  }
+  return [
+    createCompactBoundaryMessage({
+      boundaryId: `${sessionId}:${boundarySeq}`,
+      source: "session_compaction",
+      sourceMessageCount: 0,
+      retainedTailCount: 0,
+      summaryText: summaryParts.join(" | "),
+    }),
+  ];
+}
+
+export function buildSessionReplayHistory(
+  thread: readonly LLMMessage[],
+  replayState: PersistedSessionReplayState | undefined,
+): readonly LLMMessage[] {
+  return [
+    ...thread,
+    ...(replayState?.tailEvents ? cloneReplayTailEvents(replayState.tailEvents) : []),
+  ];
+}
+
+function buildPersistedSessionRuntimeState(
+  session: Session,
+  existing?: PersistedSessionReplayState,
+): PersistedSessionReplayState | undefined {
+  const snapshot = buildPersistedSessionReplaySnapshot(session);
+  if (!snapshot) {
+    return undefined;
+  }
+  const nextBoundarySeq = existing
+    ? existing.boundarySeq + 1
+    : 1;
+  const tailEvents = buildReplayTailEvents(session.id, snapshot, nextBoundarySeq);
+  const next: PersistedSessionReplayState = {
+    version: 1,
+    boundarySeq: nextBoundarySeq,
+    ...(existing?.migratedFromLegacyAt
+      ? { migratedFromLegacyAt: existing.migratedFromLegacyAt }
+      : {}),
+    snapshot,
+    tailEvents,
+  };
+  if (
+    existing &&
+    JSON.stringify(existing.snapshot) === JSON.stringify(next.snapshot) &&
+    JSON.stringify(existing.tailEvents) === JSON.stringify(next.tailEvents)
+  ) {
+    return existing;
+  }
+  return next;
 }
 
 function coercePersistedSessionRuntimeState(
   value: unknown,
-): PersistedSessionRuntimeState | undefined {
+): PersistedSessionReplayState | undefined {
   if (typeof value !== "object" || value === null) return undefined;
   const candidate = value as Record<string, unknown>;
+  if (candidate.version === 1) {
+    const boundarySeq =
+      typeof candidate.boundarySeq === "number" &&
+      Number.isFinite(candidate.boundarySeq) &&
+      candidate.boundarySeq >= 0
+        ? Math.floor(candidate.boundarySeq)
+        : undefined;
+    const snapshotCandidate = candidate.snapshot as
+      | Record<string, unknown>
+      | undefined;
+    const snapshot =
+      snapshotCandidate && typeof snapshotCandidate === "object"
+        ? {
+            ...(coerceSessionShellProfile(snapshotCandidate.shellProfile)
+              ? { shellProfile: coerceSessionShellProfile(snapshotCandidate.shellProfile) }
+              : {}),
+            ...(coerceSessionWorkflowState(snapshotCandidate.workflowState)
+              ? { workflowState: coerceSessionWorkflowState(snapshotCandidate.workflowState) }
+              : {}),
+            ...(isStatefulResumeAnchor(snapshotCandidate.statefulResumeAnchor)
+              ? {
+                  statefulResumeAnchor: cloneResumeAnchor(
+                    snapshotCandidate.statefulResumeAnchor,
+                  ),
+                }
+              : {}),
+            ...(snapshotCandidate.statefulHistoryCompacted === true
+              ? { statefulHistoryCompacted: true }
+              : {}),
+            ...(typeof snapshotCandidate.artifactSnapshotId === "string" &&
+            snapshotCandidate.artifactSnapshotId.trim().length > 0
+              ? { artifactSnapshotId: snapshotCandidate.artifactSnapshotId.trim() }
+              : {}),
+            ...(typeof snapshotCandidate.artifactSessionId === "string" &&
+            snapshotCandidate.artifactSessionId.trim().length > 0
+              ? { artifactSessionId: snapshotCandidate.artifactSessionId.trim() }
+              : {}),
+            ...(typeof snapshotCandidate.runtimeContractSnapshot === "object" &&
+            snapshotCandidate.runtimeContractSnapshot !== null
+              ? {
+                  runtimeContractSnapshot:
+                    snapshotCandidate.runtimeContractSnapshot as RuntimeContractSnapshot,
+                }
+              : {}),
+            ...(normalizeRuntimeContractStatusSnapshot(
+              snapshotCandidate.runtimeContractStatusSnapshot,
+            )
+              ? {
+                  runtimeContractStatusSnapshot:
+                    normalizeRuntimeContractStatusSnapshot(
+                      snapshotCandidate.runtimeContractStatusSnapshot,
+                    ),
+                }
+              : {}),
+            ...(reconcileReviewSurfaceState(
+              coerceReviewSurfaceState(snapshotCandidate.reviewSurfaceState),
+            )
+              ? {
+                  reviewSurfaceState: reconcileReviewSurfaceState(
+                    coerceReviewSurfaceState(snapshotCandidate.reviewSurfaceState),
+                  ),
+                }
+              : {}),
+            ...(reconcileVerificationSurfaceState(
+              coerceVerificationSurfaceState(snapshotCandidate.verificationSurfaceState),
+            )
+              ? {
+                  verificationSurfaceState: reconcileVerificationSurfaceState(
+                    coerceVerificationSurfaceState(
+                      snapshotCandidate.verificationSurfaceState,
+                    ),
+                  ),
+                }
+              : {}),
+            ...(coerceActiveTaskContext(snapshotCandidate.activeTaskContext)
+              ? {
+                  activeTaskContext: coerceActiveTaskContext(
+                    snapshotCandidate.activeTaskContext,
+                  ),
+                }
+              : {}),
+            ...(snapshotCandidate.forkMarker &&
+            typeof snapshotCandidate.forkMarker === "object"
+              ? {
+                  forkMarker: {
+                    parentSessionId: String(
+                      (snapshotCandidate.forkMarker as Record<string, unknown>)
+                        .parentSessionId ?? "",
+                    ).trim(),
+                    source:
+                      (snapshotCandidate.forkMarker as Record<string, unknown>)
+                        .source === "checkpoint" ||
+                      (snapshotCandidate.forkMarker as Record<string, unknown>)
+                        .source === "runtime_state" ||
+                      (snapshotCandidate.forkMarker as Record<string, unknown>)
+                        .source === "history"
+                        ? ((snapshotCandidate.forkMarker as Record<string, unknown>)
+                            .source as PersistedWebChatForkSource)
+                        : undefined,
+                    forkedAt:
+                      typeof (snapshotCandidate.forkMarker as Record<string, unknown>)
+                        .forkedAt === "number" &&
+                      Number.isFinite(
+                        (snapshotCandidate.forkMarker as Record<string, unknown>)
+                          .forkedAt,
+                      )
+                        ? (snapshotCandidate.forkMarker as Record<string, unknown>)
+                            .forkedAt
+                        : undefined,
+                  } as PersistedSessionReplayForkMarker,
+                }
+              : {}),
+          }
+        : undefined;
+    const tailEvents = Array.isArray(candidate.tailEvents)
+      ? candidate.tailEvents.filter(
+          (event): event is LLMMessage =>
+            !!event &&
+            typeof event === "object" &&
+            typeof (event as LLMMessage).role === "string" &&
+            "content" in event,
+        )
+      : [];
+    if (boundarySeq === undefined || !snapshot) {
+      return undefined;
+    }
+    return {
+      version: 1,
+      boundarySeq,
+      ...(typeof candidate.migratedFromLegacyAt === "number" &&
+      Number.isFinite(candidate.migratedFromLegacyAt)
+        ? { migratedFromLegacyAt: candidate.migratedFromLegacyAt }
+        : {}),
+      snapshot: snapshot as PersistedSessionReplaySnapshot,
+      tailEvents: cloneReplayTailEvents(tailEvents),
+    };
+  }
+
   if (
-    candidate.version !== 1 &&
     candidate.version !== 2 &&
     candidate.version !== 3 &&
     candidate.version !== 4 &&
@@ -318,65 +641,95 @@ function coercePersistedSessionRuntimeState(
   ) {
     return undefined;
   }
-  const shellProfile = coerceSessionShellProfile(candidate.shellProfile);
-  const workflowState = coerceSessionWorkflowState(candidate.workflowState);
-  const resumeAnchor = isStatefulResumeAnchor(candidate.statefulResumeAnchor)
-    ? cloneResumeAnchor(candidate.statefulResumeAnchor)
-    : undefined;
-  const historyCompacted =
-    candidate.statefulHistoryCompacted === true ||
-    (typeof candidate.artifactSnapshotId === "string" &&
-      candidate.artifactSnapshotId.trim().length > 0);
-  const artifactSnapshotId =
-    typeof candidate.artifactSnapshotId === "string" &&
-    candidate.artifactSnapshotId.trim().length > 0
-      ? candidate.artifactSnapshotId.trim()
-      : undefined;
-  const artifactSessionId =
-    typeof candidate.artifactSessionId === "string" &&
-    candidate.artifactSessionId.trim().length > 0
-      ? candidate.artifactSessionId.trim()
-      : undefined;
-  const activeTaskContext = coerceActiveTaskContext(candidate.activeTaskContext);
-  const runtimeContractSnapshot =
-    typeof candidate.runtimeContractSnapshot === "object" &&
-      candidate.runtimeContractSnapshot !== null
-      ? (candidate.runtimeContractSnapshot as RuntimeContractSnapshot)
-      : undefined;
-  const runtimeContractStatusSnapshot =
-    normalizeRuntimeContractStatusSnapshot(candidate.runtimeContractStatusSnapshot);
-  const reviewSurfaceState = reconcileReviewSurfaceState(
-    coerceReviewSurfaceState(candidate.reviewSurfaceState),
-  );
-  const verificationSurfaceState = reconcileVerificationSurfaceState(
-    coerceVerificationSurfaceState(candidate.verificationSurfaceState),
-  );
-  if (
-    !shellProfile &&
-    !workflowState &&
-    !resumeAnchor &&
-    !historyCompacted &&
-    !runtimeContractSnapshot &&
-    !runtimeContractStatusSnapshot &&
-    !reviewSurfaceState &&
-    !verificationSurfaceState &&
-    !activeTaskContext
-  ) {
+
+  const snapshot = buildPersistedSessionReplaySnapshot({
+    id: "legacy",
+    workspaceId: "default",
+    history: [],
+    createdAt: 0,
+    lastActiveAt: 0,
+    metadata: {
+      ...(candidate.shellProfile !== undefined
+        ? { [SESSION_SHELL_PROFILE_METADATA_KEY]: candidate.shellProfile }
+        : {}),
+      ...(candidate.workflowState !== undefined
+        ? { [SESSION_WORKFLOW_STATE_METADATA_KEY]: candidate.workflowState }
+        : {}),
+      ...(candidate.statefulResumeAnchor !== undefined
+        ? { [SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY]: candidate.statefulResumeAnchor }
+        : {}),
+      ...(candidate.statefulHistoryCompacted === true ||
+      typeof candidate.artifactSnapshotId === "string"
+        ? { [SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY]: true }
+        : {}),
+      ...(candidate.artifactSnapshotId !== undefined
+        ? {
+            [SESSION_STATEFUL_ARTIFACT_CONTEXT_METADATA_KEY]: {
+              version: 1,
+              snapshotId: candidate.artifactSnapshotId,
+              sessionId:
+                typeof candidate.artifactSessionId === "string"
+                  ? candidate.artifactSessionId
+                  : "",
+              createdAt: 0,
+              source: "session_compaction",
+              historyDigest: "",
+              sourceMessageCount: 0,
+              retainedTailCount: 0,
+              openLoops: [],
+              artifactRefs: [],
+            },
+          }
+        : {}),
+      ...(candidate.artifactSessionId !== undefined
+        ? {
+            [SESSION_STATEFUL_ARTIFACT_RECORDS_METADATA_KEY]: {
+              sessionId: candidate.artifactSessionId,
+            },
+          }
+        : {}),
+      ...(candidate.runtimeContractSnapshot !== undefined
+        ? {
+            [SESSION_RUNTIME_CONTRACT_SNAPSHOT_METADATA_KEY]:
+              candidate.runtimeContractSnapshot,
+          }
+        : {}),
+      ...(candidate.runtimeContractStatusSnapshot !== undefined
+        ? {
+            [SESSION_RUNTIME_CONTRACT_STATUS_SNAPSHOT_METADATA_KEY]:
+              candidate.runtimeContractStatusSnapshot,
+          }
+        : {}),
+      ...(candidate.reviewSurfaceState !== undefined
+        ? {
+            [SESSION_REVIEW_SURFACE_STATE_METADATA_KEY]:
+              candidate.reviewSurfaceState,
+          }
+        : {}),
+      ...(candidate.verificationSurfaceState !== undefined
+        ? {
+            [SESSION_VERIFICATION_SURFACE_STATE_METADATA_KEY]:
+              candidate.verificationSurfaceState,
+          }
+        : {}),
+      ...(candidate.activeTaskContext !== undefined
+        ? {
+            [SESSION_ACTIVE_TASK_CONTEXT_METADATA_KEY]:
+              candidate.activeTaskContext,
+          }
+        : {}),
+    },
+  });
+  if (!snapshot) {
     return undefined;
   }
+  const tailEvents = buildReplayTailEvents("legacy", snapshot, 1);
   return {
-    version: 7,
-    ...(shellProfile ? { shellProfile } : {}),
-    ...(workflowState ? { workflowState } : {}),
-    ...(resumeAnchor ? { statefulResumeAnchor: resumeAnchor } : {}),
-    ...(historyCompacted ? { statefulHistoryCompacted: true } : {}),
-    ...(artifactSnapshotId ? { artifactSnapshotId } : {}),
-    ...(artifactSessionId ? { artifactSessionId } : {}),
-    ...(runtimeContractSnapshot ? { runtimeContractSnapshot } : {}),
-    ...(runtimeContractStatusSnapshot ? { runtimeContractStatusSnapshot } : {}),
-    ...(reviewSurfaceState ? { reviewSurfaceState } : {}),
-    ...(verificationSurfaceState ? { verificationSurfaceState } : {}),
-    ...(activeTaskContext ? { activeTaskContext } : {}),
+    version: 1,
+    boundarySeq: 1,
+    migratedFromLegacyAt: Date.now(),
+    snapshot,
+    tailEvents,
   };
 }
 
@@ -388,14 +741,52 @@ function clonePersistedSessionRuntimeState(
   ) as PersistedSessionRuntimeState;
 }
 
-export async function loadPersistedSessionRuntimeState(
+export async function loadPersistedSessionReplayState(
   memoryBackend: MemoryBackend,
   webSessionId: string,
-): Promise<PersistedSessionRuntimeState | undefined> {
-  return coercePersistedSessionRuntimeState(
+): Promise<PersistedSessionReplayState | undefined> {
+  const replayKey = webSessionReplayStateKey(webSessionId);
+  const persisted = coercePersistedSessionRuntimeState(
+    await memoryBackend.get(replayKey),
+  );
+  if (persisted) {
+    return persisted;
+  }
+
+  const legacy = coercePersistedSessionRuntimeState(
     await memoryBackend.get(webSessionRuntimeStateKey(webSessionId)),
   );
+  if (!legacy) {
+    return undefined;
+  }
+
+  await memoryBackend.set(replayKey, legacy);
+  await memoryBackend.delete(webSessionRuntimeStateKey(webSessionId));
+  return legacy;
 }
+
+export async function loadPersistedSessionReplayContext(
+  memoryBackend: MemoryBackend,
+  webSessionId: string,
+): Promise<{
+  readonly state?: PersistedSessionReplayState;
+  readonly history: readonly LLMMessage[];
+}> {
+  const [state, thread] = await Promise.all([
+    loadPersistedSessionReplayState(memoryBackend, webSessionId),
+    memoryBackend.getThread(webSessionId).catch(() => []),
+  ]);
+  return {
+    state,
+    history: buildSessionReplayHistory(
+      thread.map((entry) => entryToMessage(entry)),
+      state,
+    ),
+  };
+}
+
+/** @deprecated Use loadPersistedSessionReplayState. */
+export const loadPersistedSessionRuntimeState = loadPersistedSessionReplayState;
 
 export function buildSessionStatefulOptions(
   session: Session,
@@ -407,90 +798,138 @@ export function buildSessionStatefulOptions(
     : undefined;
   const historyCompacted =
     session.metadata[SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY] === true;
-  if (!resumeAnchor && !historyCompacted) return undefined;
+  const artifactContext = readArtifactCompactionState(session.metadata);
+  if (!resumeAnchor && !historyCompacted && !artifactContext) return undefined;
   return {
     ...(resumeAnchor ? { resumeAnchor } : {}),
     ...(historyCompacted ? { historyCompacted: true } : {}),
+    ...(artifactContext ? { artifactContext } : {}),
   };
 }
 
-export async function persistSessionRuntimeState(
+export async function persistSessionReplayState(
   memoryBackend: MemoryBackend,
   webSessionId: string,
   session: Session,
 ): Promise<void> {
   const artifactStore = new MemoryArtifactStore(memoryBackend);
-  const persisted = buildPersistedSessionRuntimeState(session);
-  const key = webSessionRuntimeStateKey(webSessionId);
+  const key = webSessionReplayStateKey(webSessionId);
+  const existing = coercePersistedSessionRuntimeState(
+    await memoryBackend.get(key),
+  ) ?? coercePersistedSessionRuntimeState(
+    await memoryBackend.get(webSessionRuntimeStateKey(webSessionId)),
+  );
+  const persisted = buildPersistedSessionRuntimeState(session, existing);
   if (!persisted) {
     await artifactStore.clearSession(session.id);
     await memoryBackend.delete(key);
+    await memoryBackend.delete(webSessionRuntimeStateKey(webSessionId));
     return;
   }
+  const artifactContext = readArtifactCompactionState(session.metadata);
+  const artifactRecords = readArtifactCompactionRecords(session.metadata);
+  if (artifactContext) {
+    await artifactStore.persistSnapshot({
+      state: artifactContext,
+      records: artifactRecords,
+    });
+  } else {
+    await artifactStore.clearSession(session.id);
+  }
   await memoryBackend.set(key, persisted);
+  await memoryBackend.delete(webSessionRuntimeStateKey(webSessionId));
 }
 
-export async function clearSessionRuntimeState(
+/** @deprecated Use persistSessionReplayState. */
+export const persistSessionRuntimeState = persistSessionReplayState;
+
+export async function clearSessionReplayState(
   memoryBackend: MemoryBackend,
   webSessionId: string,
 ): Promise<void> {
   const artifactStore = new MemoryArtifactStore(memoryBackend);
   const persisted = coercePersistedSessionRuntimeState(
+    await memoryBackend.get(webSessionReplayStateKey(webSessionId)),
+  );
+  const legacy = coercePersistedSessionRuntimeState(
     await memoryBackend.get(webSessionRuntimeStateKey(webSessionId)),
   );
-  if (persisted?.artifactSessionId) {
-    await artifactStore.clearSession(persisted.artifactSessionId);
+  const artifactSessionId =
+    persisted?.snapshot.artifactSessionId ?? legacy?.snapshot.artifactSessionId;
+  if (artifactSessionId) {
+    await artifactStore.clearSession(artifactSessionId);
   }
+  await memoryBackend.delete(webSessionReplayStateKey(webSessionId));
   await memoryBackend.delete(webSessionRuntimeStateKey(webSessionId));
 }
 
-export async function hydrateSessionRuntimeState(
+/** @deprecated Use clearSessionReplayState. */
+export const clearSessionRuntimeState = clearSessionReplayState;
+
+export async function hydrateSessionReplayState(
   memoryBackend: MemoryBackend,
   webSessionId: string,
   session: Session,
 ): Promise<void> {
-  const persisted = coercePersistedSessionRuntimeState(
-    await memoryBackend.get(webSessionRuntimeStateKey(webSessionId)),
+  const artifactStore = new MemoryArtifactStore(memoryBackend);
+  const persisted = await loadPersistedSessionReplayState(
+    memoryBackend,
+    webSessionId,
   );
   if (!persisted) return;
-  if (persisted.shellProfile) {
-    session.metadata[SESSION_SHELL_PROFILE_METADATA_KEY] = persisted.shellProfile;
+  clearStatefulContinuationMetadata(session.metadata);
+  if (persisted.snapshot.shellProfile) {
+    session.metadata[SESSION_SHELL_PROFILE_METADATA_KEY] =
+      persisted.snapshot.shellProfile;
   }
-  if (persisted.workflowState) {
-    session.metadata[SESSION_WORKFLOW_STATE_METADATA_KEY] = persisted.workflowState;
+  if (persisted.snapshot.workflowState) {
+    session.metadata[SESSION_WORKFLOW_STATE_METADATA_KEY] =
+      persisted.snapshot.workflowState;
   }
-  if (persisted.statefulResumeAnchor) {
+  if (persisted.snapshot.statefulResumeAnchor) {
     session.metadata[SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY] =
-      cloneResumeAnchor(persisted.statefulResumeAnchor);
+      cloneResumeAnchor(persisted.snapshot.statefulResumeAnchor);
   }
-  if (persisted.statefulHistoryCompacted) {
+  if (persisted.snapshot.statefulHistoryCompacted) {
     session.metadata[SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY] = true;
   }
-  delete session.metadata[SESSION_STATEFUL_ARTIFACT_CONTEXT_METADATA_KEY];
-  delete session.metadata[SESSION_STATEFUL_ARTIFACT_RECORDS_METADATA_KEY];
-  if (persisted.activeTaskContext) {
+  if (persisted.snapshot.artifactSessionId) {
+    const artifactSnapshot = await artifactStore.loadSnapshot(
+      persisted.snapshot.artifactSessionId,
+    );
+    if (artifactSnapshot?.state) {
+      session.metadata[SESSION_STATEFUL_ARTIFACT_CONTEXT_METADATA_KEY] =
+        artifactSnapshot.state;
+      session.metadata[SESSION_STATEFUL_ARTIFACT_RECORDS_METADATA_KEY] =
+        artifactSnapshot.records;
+    }
+  }
+  if (persisted.snapshot.activeTaskContext) {
     session.metadata[SESSION_ACTIVE_TASK_CONTEXT_METADATA_KEY] =
-      persisted.activeTaskContext;
+      persisted.snapshot.activeTaskContext;
   }
-  if (persisted.reviewSurfaceState) {
+  if (persisted.snapshot.reviewSurfaceState) {
     session.metadata[SESSION_REVIEW_SURFACE_STATE_METADATA_KEY] =
-      persisted.reviewSurfaceState;
+      persisted.snapshot.reviewSurfaceState;
   }
-  if (persisted.verificationSurfaceState) {
+  if (persisted.snapshot.verificationSurfaceState) {
     session.metadata[SESSION_VERIFICATION_SURFACE_STATE_METADATA_KEY] =
-      persisted.verificationSurfaceState;
+      persisted.snapshot.verificationSurfaceState;
   }
-  if (persisted.runtimeContractSnapshot) {
+  if (persisted.snapshot.runtimeContractSnapshot) {
     session.metadata[SESSION_RUNTIME_CONTRACT_SNAPSHOT_METADATA_KEY] =
-      persisted.runtimeContractSnapshot;
+      persisted.snapshot.runtimeContractSnapshot;
   }
-  if (persisted.runtimeContractStatusSnapshot) {
+  if (persisted.snapshot.runtimeContractStatusSnapshot) {
     session.metadata[SESSION_RUNTIME_CONTRACT_STATUS_SNAPSHOT_METADATA_KEY] =
-      persisted.runtimeContractStatusSnapshot;
+      persisted.snapshot.runtimeContractStatusSnapshot;
   }
 }
 
-export async function forkSessionRuntimeState(
+/** @deprecated Use hydrateSessionReplayState. */
+export const hydrateSessionRuntimeState = hydrateSessionReplayState;
+
+export async function forkSessionReplayState(
   memoryBackend: MemoryBackend,
   params: {
     sourceWebSessionId: string;
@@ -499,37 +938,30 @@ export async function forkSessionRuntimeState(
     workflowState?: Partial<SessionWorkflowState>;
   },
 ): Promise<boolean> {
-  const persisted = await loadPersistedSessionRuntimeState(
+  const persisted = await loadPersistedSessionReplayState(
     memoryBackend,
     params.sourceWebSessionId,
   );
   if (!persisted) {
     return false;
   }
-  const next = {
-    ...clonePersistedSessionRuntimeState(persisted),
-  } as {
-    version: 7;
-    shellProfile?: SessionShellProfile;
-    workflowState?: SessionWorkflowState;
-    statefulResumeAnchor?: LLMStatefulResumeAnchor;
-    statefulHistoryCompacted?: boolean;
-    artifactSnapshotId?: string;
-    artifactSessionId?: string;
-    runtimeContractSnapshot?: RuntimeContractSnapshot;
-    runtimeContractStatusSnapshot?: RuntimeContractStatusSnapshot;
-    reviewSurfaceState?: ReviewSurfaceState;
-    verificationSurfaceState?: VerificationSurfaceState;
-    activeTaskContext?: ActiveTaskContext;
-  };
+  const nextSnapshot = {
+    ...clonePersistedSessionRuntimeState(persisted).snapshot,
+    reviewSurfaceState: clearForkedReviewSurfaceState(
+      persisted.snapshot.reviewSurfaceState,
+    ),
+    verificationSurfaceState: clearForkedVerificationSurfaceState(
+      persisted.snapshot.verificationSurfaceState,
+    ),
+  } as Record<string, unknown>;
   const mergedWorkflowState = (() => {
-    if (persisted.workflowState) {
+    if (persisted.snapshot.workflowState) {
       const objective =
         params.workflowState?.objective !== undefined
           ? params.workflowState.objective
-          : persisted.workflowState.objective;
+          : persisted.snapshot.workflowState.objective;
       return {
-        ...persisted.workflowState,
+        ...persisted.snapshot.workflowState,
         ...(params.workflowState?.stage
           ? { stage: params.workflowState.stage }
           : {}),
@@ -553,42 +985,61 @@ export async function forkSessionRuntimeState(
     } satisfies SessionWorkflowState;
   })();
 
-  delete next.activeTaskContext;
-  delete next.runtimeContractSnapshot;
-  delete next.runtimeContractStatusSnapshot;
-  next.reviewSurfaceState = clearForkedReviewSurfaceState(
-    persisted.reviewSurfaceState,
-  );
-  next.verificationSurfaceState = clearForkedVerificationSurfaceState(
-    persisted.verificationSurfaceState,
-  );
-
   if (params.shellProfile) {
-    next.shellProfile = params.shellProfile;
+    nextSnapshot.shellProfile = params.shellProfile;
   }
   if (mergedWorkflowState) {
-    next.workflowState = mergedWorkflowState;
+    nextSnapshot.workflowState = mergedWorkflowState;
   }
-  delete next.artifactSessionId;
-  delete next.artifactSnapshotId;
+  delete nextSnapshot.activeTaskContext;
+  delete nextSnapshot.runtimeContractSnapshot;
+  delete nextSnapshot.runtimeContractStatusSnapshot;
+  delete nextSnapshot.artifactSessionId;
+  delete nextSnapshot.artifactSnapshotId;
+  nextSnapshot.forkMarker = {
+    parentSessionId: params.sourceWebSessionId,
+    source: "history",
+    forkedAt: Date.now(),
+  };
+  const boundarySeq = persisted.boundarySeq + 1;
+  const next: PersistedSessionReplayState = {
+    version: 1,
+    ...(persisted.migratedFromLegacyAt
+      ? { migratedFromLegacyAt: persisted.migratedFromLegacyAt }
+      : {}),
+    boundarySeq,
+    snapshot: nextSnapshot as PersistedSessionReplaySnapshot,
+    tailEvents: buildReplayTailEvents(
+    params.targetWebSessionId,
+    nextSnapshot as PersistedSessionReplaySnapshot,
+    boundarySeq,
+  ),
+  };
 
   await memoryBackend.set(
-    webSessionRuntimeStateKey(params.targetWebSessionId),
+    webSessionReplayStateKey(params.targetWebSessionId),
     next,
+  );
+  await memoryBackend.delete(
+    webSessionRuntimeStateKey(params.targetWebSessionId),
   );
   return true;
 }
 
-/** @deprecated Use loadPersistedSessionRuntimeState. */
-export const loadPersistedWebSessionRuntimeState = loadPersistedSessionRuntimeState;
-/** @deprecated Use persistSessionRuntimeState. */
-export const persistWebSessionRuntimeState = persistSessionRuntimeState;
-/** @deprecated Use clearSessionRuntimeState. */
-export const clearWebSessionRuntimeState = clearSessionRuntimeState;
-/** @deprecated Use hydrateSessionRuntimeState. */
-export const hydrateWebSessionRuntimeState = hydrateSessionRuntimeState;
-/** @deprecated Use forkSessionRuntimeState. */
-export const forkWebSessionRuntimeState = forkSessionRuntimeState;
+/** @deprecated Use forkSessionReplayState. */
+export const forkSessionRuntimeState = forkSessionReplayState;
+/** @deprecated Use loadPersistedSessionReplayState. */
+export const loadPersistedWebSessionRuntimeState = loadPersistedSessionReplayState;
+/** @deprecated Use persistSessionReplayState. */
+export const persistWebSessionRuntimeState = persistSessionReplayState;
+/** @deprecated Use clearSessionReplayState. */
+export const clearWebSessionRuntimeState = clearSessionReplayState;
+export const clearWebSessionReplayState = clearSessionReplayState;
+/** @deprecated Use hydrateSessionReplayState. */
+export const hydrateWebSessionRuntimeState = hydrateSessionReplayState;
+export const hydrateWebSessionReplayState = hydrateSessionReplayState;
+/** @deprecated Use forkSessionReplayState. */
+export const forkWebSessionRuntimeState = forkSessionReplayState;
 
 export function resolveSessionStatefulContinuation(
   result: ChatExecutorResult,

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -165,13 +165,13 @@ import {
   type GovernanceAuditEventType,
 } from "../policy/index.js";
 import type { MemoryBackend } from "../memory/types.js";
-import { entryToMessage } from "../memory/types.js";
 import { createMemoryRetrievers } from "./memory-retriever-factory.js";
 import { createMemoryBackend } from "./memory-backend-factory.js";
 // loadWallet moved to ./daemon-tool-registry.ts and ./daemon-feature-wiring.ts
 import {
-  clearWebSessionRuntimeState,
-  hydrateWebSessionRuntimeState,
+  clearWebSessionReplayState,
+  hydrateWebSessionReplayState,
+  loadPersistedSessionReplayContext,
 } from "./daemon-session-state.js";
 import {
   executeWebChatConversationTurn as runWebChatConversationTurn,
@@ -4093,9 +4093,9 @@ export class DaemonManager {
         error: toErrorMessage(error),
       });
     });
-    await clearWebSessionRuntimeState(memoryBackend, webSessionId).catch(
-      (error) => {
-        this.logger.debug("Failed to delete web session runtime state", {
+    await clearWebSessionReplayState(memoryBackend, webSessionId).catch(
+      (error: unknown) => {
+        this.logger.debug("Failed to delete web session replay state", {
           sessionId: webSessionId,
           error: toErrorMessage(error),
         });
@@ -4128,21 +4128,19 @@ export class DaemonManager {
       scope: "dm",
       workspaceId: "default",
     });
-    const thread = await memoryBackend
-      .getThread(webSessionId)
-      .catch((error) => {
-        this.logger.debug("Failed to hydrate web session from memory", {
-          sessionId: webSessionId,
-          error: toErrorMessage(error),
-        });
-        return [];
+    const replayContext = await loadPersistedSessionReplayContext(
+      memoryBackend,
+      webSessionId,
+    ).catch((error) => {
+      this.logger.debug("Failed to hydrate web session from replay state", {
+        sessionId: webSessionId,
+        error: toErrorMessage(error),
       });
-    if (thread.length === 0) {
-      await hydrateWebSessionRuntimeState(memoryBackend, webSessionId, session);
-      return;
-    }
-
-    const history = thread.map((entry) => entryToMessage(entry));
+      return {
+        history: [],
+      };
+    });
+    const history = replayContext.history;
     const historiesMatch =
       session.history.length === history.length &&
       session.history.every((message, index) => {
@@ -4161,7 +4159,7 @@ export class DaemonManager {
     if (!historiesMatch) {
       sessionMgr.replaceHistory(historySessionId, history);
     }
-    await hydrateWebSessionRuntimeState(memoryBackend, webSessionId, session);
+    await hydrateWebSessionReplayState(memoryBackend, webSessionId, session);
   }
 
   private listShellAgentRoles(): readonly ShellAgentRoleDescriptor[] {

--- a/runtime/src/gateway/session.test.ts
+++ b/runtime/src/gateway/session.test.ts
@@ -395,10 +395,13 @@ describe("SessionManager", () => {
       );
       expect(
         session.metadata[SESSION_STATEFUL_ARTIFACT_CONTEXT_METADATA_KEY],
-      ).toBeUndefined();
+      ).toMatchObject({
+        version: 1,
+        artifactRefs: expect.any(Array),
+      });
       expect(
         session.metadata[SESSION_STATEFUL_ARTIFACT_RECORDS_METADATA_KEY],
-      ).toBeUndefined();
+      ).toEqual(expect.any(Array));
       expect(
         session.metadata[SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY],
       ).toBe(true);
@@ -472,7 +475,10 @@ describe("SessionManager", () => {
       );
       expect(
         session.metadata[SESSION_STATEFUL_ARTIFACT_CONTEXT_METADATA_KEY],
-      ).toBeUndefined();
+      ).toMatchObject({
+        version: 1,
+        artifactRefs: expect.any(Array),
+      });
     });
 
     it("dedupes artifact refs across repeated compactions during long sessions", async () => {

--- a/runtime/src/gateway/session.ts
+++ b/runtime/src/gateway/session.ts
@@ -573,8 +573,10 @@ export class SessionManager {
               source: "session_compaction",
               ...(narrativeSummary ? { narrativeSummary } : {}),
             });
-            delete session.metadata[SESSION_STATEFUL_ARTIFACT_CONTEXT_METADATA_KEY];
-            delete session.metadata[SESSION_STATEFUL_ARTIFACT_RECORDS_METADATA_KEY];
+            session.metadata[SESSION_STATEFUL_ARTIFACT_CONTEXT_METADATA_KEY] =
+              compacted.state;
+            session.metadata[SESSION_STATEFUL_ARTIFACT_RECORDS_METADATA_KEY] =
+              compacted.records;
             session.history = [...compacted.compactedHistory];
             result = {
               messagesRemoved: dropCount,
@@ -614,8 +616,10 @@ export class SessionManager {
               source: "session_compaction",
               ...(narrativeSummary ? { narrativeSummary } : {}),
             });
-            delete session.metadata[SESSION_STATEFUL_ARTIFACT_CONTEXT_METADATA_KEY];
-            delete session.metadata[SESSION_STATEFUL_ARTIFACT_RECORDS_METADATA_KEY];
+            session.metadata[SESSION_STATEFUL_ARTIFACT_CONTEXT_METADATA_KEY] =
+              compacted.state;
+            session.metadata[SESSION_STATEFUL_ARTIFACT_RECORDS_METADATA_KEY] =
+              compacted.records;
             session.history = [...compacted.compactedHistory];
             result = {
               messagesRemoved: dropCount,

--- a/runtime/src/gateway/tool-handler-factory.test.ts
+++ b/runtime/src/gateway/tool-handler-factory.test.ts
@@ -462,19 +462,23 @@ describe("createSessionToolHandler", () => {
     };
 
     expect(baseHandler).toHaveBeenNthCalledWith(1, "task.create", {
+      __agencTaskActorKind: "main",
       subject: "Session A task",
       description: "Created through the gateway handler",
       [TASK_LIST_ARG]: "session-a",
     });
     expect(baseHandler).toHaveBeenNthCalledWith(2, "task.create", {
+      __agencTaskActorKind: "main",
       subject: "Session B task",
       description: "Created through the gateway handler",
       [TASK_LIST_ARG]: "session-b",
     });
     expect(baseHandler).toHaveBeenNthCalledWith(3, "task.list", {
+      __agencTaskActorKind: "main",
       [TASK_LIST_ARG]: "session-a",
     });
     expect(baseHandler).toHaveBeenNthCalledWith(4, "task.list", {
+      __agencTaskActorKind: "main",
       [TASK_LIST_ARG]: "session-b",
     });
     expect(sessionACreate.taskRuntime).toMatchObject({

--- a/runtime/src/gateway/tool-handler-factory.ts
+++ b/runtime/src/gateway/tool-handler-factory.ts
@@ -19,6 +19,8 @@ import {
   SESSION_ID_ARG,
 } from "../tools/system/filesystem.js";
 import {
+  TASK_ACTOR_KIND_ARG,
+  TASK_ACTOR_NAME_ARG,
   TASK_LIST_ARG,
   TASK_TRACKER_TOOL_NAMES,
 } from "../tools/system/task-tracker.js";
@@ -294,9 +296,18 @@ function stripInternalToolArgs(
 ): Record<string, unknown> {
   const hasAllowedRoots = SESSION_ALLOWED_ROOTS_ARG in args;
   const hasTaskListId = TASK_LIST_ARG in args;
+  const hasTaskActorKind = TASK_ACTOR_KIND_ARG in args;
+  const hasTaskActorName = TASK_ACTOR_NAME_ARG in args;
   const hasSessionId = SESSION_ID_ARG in args;
   const hasAdvertisedToolNames = SESSION_ADVERTISED_TOOL_NAMES_ARG in args;
-  if (!hasAllowedRoots && !hasTaskListId && !hasSessionId && !hasAdvertisedToolNames) {
+  if (
+    !hasAllowedRoots &&
+    !hasTaskListId &&
+    !hasTaskActorKind &&
+    !hasTaskActorName &&
+    !hasSessionId &&
+    !hasAdvertisedToolNames
+  ) {
     return args;
   }
   const nextArgs = { ...args };
@@ -305,6 +316,12 @@ function stripInternalToolArgs(
   }
   if (hasTaskListId) {
     delete nextArgs[TASK_LIST_ARG];
+  }
+  if (hasTaskActorKind) {
+    delete nextArgs[TASK_ACTOR_KIND_ARG];
+  }
+  if (hasTaskActorName) {
+    delete nextArgs[TASK_ACTOR_NAME_ARG];
   }
   if (hasSessionId) {
     delete nextArgs[SESSION_ID_ARG];
@@ -329,6 +346,26 @@ function applySessionTaskListId(
   return {
     ...args,
     [TASK_LIST_ARG]: sessionId,
+  };
+}
+
+function applyTaskActorContext(
+  toolName: string,
+  args: Record<string, unknown>,
+  isSubAgentSession: boolean,
+  subAgentInfo: DelegationSubAgentInfo,
+): Record<string, unknown> {
+  if (!TASK_TRACKER_TOOL_NAMES.has(toolName)) {
+    return args;
+  }
+  const actorName =
+    isSubAgentSession
+      ? subAgentInfo?.role?.trim() || subAgentInfo?.sessionId?.trim()
+      : undefined;
+  return {
+    ...args,
+    [TASK_ACTOR_KIND_ARG]: isSubAgentSession ? "subagent" : "main",
+    ...(actorName ? { [TASK_ACTOR_NAME_ARG]: actorName } : {}),
   };
 }
 
@@ -2936,6 +2973,12 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
       delegatedParentAllowedRoots,
     );
     executionArgs = applySessionTaskListId(toolName, executionArgs, sessionIdentity);
+    executionArgs = applyTaskActorContext(
+      toolName,
+      executionArgs,
+      isSubAgentSession,
+      subAgentInfo,
+    );
     executionArgs = applySessionId(toolName, executionArgs, sessionIdentity);
     executionArgs = applyAdvertisedToolNames(
       toolName,

--- a/runtime/src/llm/chat-executor-request.ts
+++ b/runtime/src/llm/chat-executor-request.ts
@@ -39,6 +39,7 @@ import type {
   ChatExecutorResult,
   ChatPlannerSummary,
   ExecutionContext,
+  ToolLoopTerminalResult,
 } from "./chat-executor-types.js";
 import type { HookContext, HookRegistry } from "./hooks/index.js";
 import type { RuntimeEconomicsPolicy } from "./run-budget.js";
@@ -84,15 +85,24 @@ function buildHookLifecycleContext(
   ctx: ExecutionContext,
   event: "Stop" | "StopFailure",
   failure?: HookFailureDetail,
+  terminal?: Pick<
+    ToolLoopTerminalResult,
+    "content" | "stopReason" | "stopReasonDetail"
+  >,
 ): HookContext {
-  const stopReason = readStringField(failure ?? ctx, "stopReason") ?? ctx.stopReason;
+  const stopReason =
+    readStringField(failure ?? terminal ?? ctx, "stopReason") ?? ctx.stopReason;
   const stopReasonDetail =
-    readStringField(failure ?? ctx, "stopReasonDetail") ?? ctx.stopReasonDetail;
+    readStringField(failure ?? terminal ?? ctx, "stopReasonDetail") ??
+    ctx.stopReasonDetail;
+  const finalContent =
+    readStringField(terminal, "content") ??
+    (terminal?.content !== undefined ? terminal.content : ctx.finalContent);
   return {
     event,
     sessionId: ctx.sessionId,
     messages: ctx.messages,
-    ...(ctx.finalContent ? { finalContent: ctx.finalContent } : {}),
+    ...(finalContent ? { finalContent } : {}),
     ...(stopReason ? { stopReason } : {}),
     ...(stopReasonDetail ? { stopReasonDetail } : {}),
     ...(failure ? { failure } : {}),
@@ -141,7 +151,9 @@ export interface ExecuteRequestDependencies
  * dispatch can check whether this is a first-touch session.
  */
 export interface ExecuteRequestHelpers extends InitializeExecutionContextHelpers {
-  readonly executeToolCallLoop: (ctx: ExecutionContext) => Promise<void>;
+  readonly executeToolCallLoop: (
+    ctx: ExecutionContext,
+  ) => Promise<ToolLoopTerminalResult>;
   readonly sessionTokens: ReadonlyMap<string, number>;
 }
 
@@ -197,8 +209,125 @@ export async function executeRequest(
     });
   }
 
+  const computeVerificationRequirement = (terminal: ToolLoopTerminalResult): boolean =>
+    ctx.runtimeContractFlags.verifierRuntimeRequired === true &&
+    ctx.turnExecutionContract.turnClass === "workflow_implementation" &&
+    (((ctx.turnExecutionContract.targetArtifacts?.length ?? 0) > 0) ||
+      terminal.mutationDetected);
+
   try {
-    await helpers.executeToolCallLoop(ctx);
+    const terminal = await helpers.executeToolCallLoop(ctx);
+
+    checkRequestTimeout(ctx, "finalization");
+
+    const requiresVerification = computeVerificationRequirement(terminal);
+    const verificationSatisfied =
+      terminal.verifierSnapshot?.performed === true &&
+      terminal.verifierSnapshot.overall === "pass";
+    const completionState =
+      terminal.completionState ??
+      resolveWorkflowCompletionState({
+        stopReason: terminal.stopReason,
+        toolCalls: ctx.allToolCalls,
+        validationCode: terminal.validationCode,
+        requiresVerification,
+        verificationSatisfied,
+      });
+
+    const durationMs = Date.now() - ctx.startTime;
+    const plannerSummary: ChatPlannerSummary = ctx.plannerSummaryState;
+    const finalContent = sanitizeFinalContent(terminal.content);
+    const completionProgress = deriveWorkflowProgressSnapshot({
+      stopReason: terminal.stopReason,
+      completionState,
+      stopReasonDetail: terminal.stopReasonDetail,
+      validationCode: terminal.validationCode,
+      toolCalls: ctx.allToolCalls,
+      verificationContract: workflowEvidence.verificationContract,
+      completionContract: workflowEvidence.completionContract,
+      completedRequestMilestoneIds: ctx.completedRequestMilestoneIds,
+      updatedAt: Date.now(),
+      contractFingerprint: ctx.turnExecutionContract.contractFingerprint,
+    });
+
+    if (deps.hookRegistry) {
+      const stopEvent: "Stop" | "StopFailure" =
+        terminal.stopReason === "completed" || terminal.stopReason === "tool_calls"
+          ? "Stop"
+          : "StopFailure";
+      await dispatchHooks({
+        registry: deps.hookRegistry,
+        event: stopEvent,
+        matchKey: ctx.sessionId,
+        executor: defaultHookExecutor,
+        context: buildHookLifecycleContext(
+          ctx,
+          stopEvent,
+          stopEvent === "StopFailure"
+            ? buildHookFailureDetail({
+                name: "StopFailure",
+                message:
+                  terminal.stopReasonDetail ?? "Execution ended in failure.",
+                stopReason: terminal.stopReason,
+                stopReasonDetail: terminal.stopReasonDetail,
+              })
+            : undefined,
+          {
+            content: finalContent,
+            stopReason: terminal.stopReason,
+            stopReasonDetail: terminal.stopReasonDetail,
+          },
+        ),
+      });
+    }
+
+    emitExecutionTrace(ctx, {
+      type: "runtime_contract_snapshot",
+      phase: "tool_followup",
+      callIndex: ctx.callIndex,
+      payload: {
+        stage: "finalized",
+        runtimeContract: terminal.runtimeContractSnapshot,
+      },
+    });
+
+    return {
+      content: finalContent,
+      provider: ctx.providerName,
+      model: ctx.responseModel,
+      usedFallback: ctx.usedFallback,
+      toolCalls: ctx.allToolCalls,
+      providerEvidence: ctx.providerEvidence,
+      structuredOutput: ctx.response?.structuredOutput,
+      tokenUsage: ctx.cumulativeUsage,
+      callUsage: ctx.callUsage,
+      durationMs,
+      compacted: ctx.compacted,
+      statefulSummary: summarizeStateful(ctx.callUsage),
+      toolRoutingSummary: ctx.toolRouting
+        ? {
+          enabled: true,
+          initialToolCount: ctx.initialRoutedToolNames.length,
+          finalToolCount: ctx.activeRoutedToolNames.length,
+          routeMisses: ctx.routedToolMisses,
+          expanded: ctx.routedToolsExpanded,
+        }
+        : undefined,
+      plannerSummary,
+      economicsSummary: buildRuntimeEconomicsSummary(
+        deps.economicsPolicy,
+        ctx.economicsState,
+      ),
+      stopReason: terminal.stopReason,
+      completionState,
+      verifierSnapshot: terminal.verifierSnapshot,
+      runtimeContractSnapshot: terminal.runtimeContractSnapshot,
+      completionProgress,
+      turnExecutionContract: ctx.turnExecutionContract,
+      activeTaskContext: deriveActiveTaskContext(ctx.turnExecutionContract),
+      stopReasonDetail: terminal.stopReasonDetail,
+      validationCode: terminal.validationCode,
+    };
   } catch (error) {
     if (deps.hookRegistry) {
       const failure = buildHookFailureDetail(error);
@@ -219,108 +348,4 @@ export async function executeRequest(
     }
     throw error;
   }
-
-  checkRequestTimeout(ctx, "finalization");
-
-  // Derive the final completion state from stop reason + tool calls.
-  ctx.completionState = resolveWorkflowCompletionState({
-    stopReason: ctx.stopReason,
-    toolCalls: ctx.allToolCalls,
-    verificationContract: workflowEvidence.verificationContract,
-    validationCode: ctx.validationCode,
-  });
-
-  const durationMs = Date.now() - ctx.startTime;
-  const plannerSummary: ChatPlannerSummary = ctx.plannerSummaryState;
-
-  ctx.finalContent = sanitizeFinalContent(ctx.finalContent);
-  const completionProgress = deriveWorkflowProgressSnapshot({
-    stopReason: ctx.stopReason,
-    completionState: ctx.completionState,
-    stopReasonDetail: ctx.stopReasonDetail,
-    validationCode: ctx.validationCode,
-    toolCalls: ctx.allToolCalls,
-    verificationContract: workflowEvidence.verificationContract,
-    completionContract: workflowEvidence.completionContract,
-    completedRequestMilestoneIds: ctx.completedRequestMilestoneIds,
-    updatedAt: Date.now(),
-    contractFingerprint: ctx.turnExecutionContract.contractFingerprint,
-  });
-
-  // Phase H: dispatch Stop / StopFailure at the terminal path.
-  // Stop fires on completed state; StopFailure on any non-
-  // completed state (budget_exceeded, no_progress, cancelled,
-  // provider_error, timeout, etc.).
-  if (deps.hookRegistry) {
-    const stopEvent: "Stop" | "StopFailure" =
-      ctx.stopReason === "completed" || ctx.stopReason === "tool_calls"
-        ? "Stop"
-        : "StopFailure";
-    await dispatchHooks({
-      registry: deps.hookRegistry,
-      event: stopEvent,
-      matchKey: ctx.sessionId,
-      executor: defaultHookExecutor,
-      context: buildHookLifecycleContext(
-        ctx,
-        stopEvent,
-        stopEvent === "StopFailure"
-          ? buildHookFailureDetail({
-              name: "StopFailure",
-              message: ctx.stopReasonDetail ?? "Execution ended in failure.",
-              stopReason: ctx.stopReason,
-              stopReasonDetail: ctx.stopReasonDetail,
-            })
-          : undefined,
-      ),
-    });
-  }
-
-  emitExecutionTrace(ctx, {
-    type: "runtime_contract_snapshot",
-    phase: "tool_followup",
-    callIndex: ctx.callIndex,
-    payload: {
-      stage: "finalized",
-      runtimeContract: ctx.runtimeContractSnapshot,
-    },
-  });
-
-  return {
-    content: ctx.finalContent,
-    provider: ctx.providerName,
-    model: ctx.responseModel,
-    usedFallback: ctx.usedFallback,
-    toolCalls: ctx.allToolCalls,
-    providerEvidence: ctx.providerEvidence,
-    structuredOutput: ctx.response?.structuredOutput,
-    tokenUsage: ctx.cumulativeUsage,
-    callUsage: ctx.callUsage,
-    durationMs,
-    compacted: ctx.compacted,
-    statefulSummary: summarizeStateful(ctx.callUsage),
-    toolRoutingSummary: ctx.toolRouting
-      ? {
-        enabled: true,
-        initialToolCount: ctx.initialRoutedToolNames.length,
-        finalToolCount: ctx.activeRoutedToolNames.length,
-        routeMisses: ctx.routedToolMisses,
-        expanded: ctx.routedToolsExpanded,
-      }
-      : undefined,
-    plannerSummary,
-    economicsSummary: buildRuntimeEconomicsSummary(
-      deps.economicsPolicy,
-      ctx.economicsState,
-    ),
-    stopReason: ctx.stopReason,
-    completionState: ctx.completionState,
-    verifierSnapshot: ctx.verifierSnapshot,
-    runtimeContractSnapshot: ctx.runtimeContractSnapshot,
-    completionProgress,
-    turnExecutionContract: ctx.turnExecutionContract,
-    activeTaskContext: deriveActiveTaskContext(ctx.turnExecutionContract),
-    stopReasonDetail: ctx.stopReasonDetail,
-    validationCode: ctx.validationCode,
-  };
 }

--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -28,6 +28,7 @@ import type {
   ChatExecutionTraceEvent,
   ChatCallUsageRecord,
   ExecutionContext,
+  ToolLoopTerminalResult,
   ToolLoopState,
   ToolCallAction,
   RecoveryHint,
@@ -45,6 +46,7 @@ import {
   repairToolCallArgumentsFromMessageText,
   parseToolCallArguments,
   executeToolWithRetry,
+  didToolCallFail,
   summarizeToolArgumentChanges,
   buildToolLoopRecoveryMessages,
   buildRoutingExpansionMessage,
@@ -208,6 +210,40 @@ export interface ToolLoopCallbacks {
 }
 
 const TOOL_PROTOCOL_REPAIR_ERROR = "tool_protocol_repair";
+const TERMINAL_MUTATION_TOOL_NAMES = new Set([
+  "system.applyPatch",
+  "system.appendFile",
+  "system.delete",
+  "system.editFile",
+  "system.mkdir",
+  "system.move",
+  "system.writeFile",
+  "desktop.text_editor",
+]);
+
+function detectSuccessfulWorkspaceMutation(
+  toolCalls: readonly ToolCallRecord[],
+): boolean {
+  return toolCalls.some(
+    (call) =>
+      TERMINAL_MUTATION_TOOL_NAMES.has(call.name) &&
+      !didToolCallFail(call.isError, call.result),
+  );
+}
+
+function buildToolLoopTerminalResult(
+  ctx: ExecutionContext,
+): ToolLoopTerminalResult {
+  return {
+    content: ctx.finalContent,
+    stopReason: ctx.stopReason,
+    ...(ctx.stopReasonDetail ? { stopReasonDetail: ctx.stopReasonDetail } : {}),
+    ...(ctx.validationCode ? { validationCode: ctx.validationCode } : {}),
+    ...(ctx.verifierSnapshot ? { verifierSnapshot: ctx.verifierSnapshot } : {}),
+    runtimeContractSnapshot: ctx.runtimeContractSnapshot,
+    mutationDetected: detectSuccessfulWorkspaceMutation(ctx.allToolCalls),
+  };
+}
 
 function syncToolProtocolSnapshot(ctx: ExecutionContext): void {
   ctx.runtimeContractSnapshot = updateRuntimeContractToolProtocolSnapshot({
@@ -1381,7 +1417,7 @@ export async function executeToolCallLoop(
   ctx: ExecutionContext,
   config: ToolLoopConfig,
   callbacks: ToolLoopCallbacks,
-): Promise<void> {
+): Promise<ToolLoopTerminalResult> {
   // Phase A wire-up: run the layered compaction chain before the
   // initial provider call. This is the top-of-iteration insertion
   // point for the layered compaction runtime. Phase H added
@@ -2520,6 +2556,8 @@ export async function executeToolCallLoop(
   if (!ctx.finalContent && ctx.stopReason !== "completed" && ctx.stopReasonDetail) {
     ctx.finalContent = ctx.stopReasonDetail;
   }
+
+  return buildToolLoopTerminalResult(ctx);
 }
 
 // ============================================================================

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -386,6 +386,18 @@ export interface ChatExecutorResult {
   readonly validationCode?: DelegationOutputValidationCode;
 }
 
+/** Authoritative terminal payload returned from the tool loop. */
+export interface ToolLoopTerminalResult {
+  readonly content: string;
+  readonly stopReason: LLMPipelineStopReason;
+  readonly stopReasonDetail?: string;
+  readonly validationCode?: DelegationOutputValidationCode;
+  readonly completionState?: WorkflowCompletionState;
+  readonly verifierSnapshot?: import("../workflow/completion-state.js").PlannerVerificationSnapshot;
+  readonly runtimeContractSnapshot: RuntimeContractSnapshot;
+  readonly mutationDetected: boolean;
+}
+
 /** Minimal pipeline executor interface required by ChatExecutor planner path. */
 export interface DeterministicPipelineExecutor {
   execute(

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -441,7 +441,9 @@ export class ChatExecutor {
   }
 
 
-  private async executeToolCallLoop(ctx: ExecutionContext): Promise<void> {
+  private async executeToolCallLoop(
+    ctx: ExecutionContext,
+  ): Promise<import("./chat-executor-types.js").ToolLoopTerminalResult> {
     // Phase F extraction (PR-5): delegates to the free tool-loop
     // helper. The callback struct wires the pure ctx helpers from
     // chat-executor-ctx-helpers.ts and threads `callModelForPhase`

--- a/runtime/src/llm/context-compaction.test.ts
+++ b/runtime/src/llm/context-compaction.test.ts
@@ -222,6 +222,8 @@ describe("context compaction", () => {
 
     expect(compacted.compactedHistory).toHaveLength(3);
     expect(compacted.compactedHistory[0]?.role).toBe("system");
+    expect(String(compacted.compactedHistory[0]?.content)).toContain("[boundary]");
+    expect(compacted.boundaryMessage).toEqual(compacted.compactedHistory[0]);
     expect(compacted.compactedHistory[1]).toMatchObject(history[0]);
     expect(compacted.compactedHistory[1]?.content).toEqual(history[0].content);
     expect(compacted.compactedHistory[2]).toEqual(history[2]);

--- a/runtime/src/llm/context-compaction.ts
+++ b/runtime/src/llm/context-compaction.ts
@@ -52,10 +52,33 @@ interface ArtifactCompactionInput {
 }
 
 interface ArtifactCompactionOutput {
+  readonly boundaryMessage: LLMMessage;
   readonly compactedHistory: readonly LLMMessage[];
   readonly state: ArtifactCompactionState;
   readonly records: readonly ContextArtifactRecord[];
   readonly summaryText: string;
+}
+
+export function createCompactBoundaryMessage(params: {
+  readonly boundaryId: string;
+  readonly source: "session_compaction" | "executor_compaction";
+  readonly sourceMessageCount: number;
+  readonly retainedTailCount: number;
+  readonly summaryText?: string;
+}): LLMMessage {
+  const content = [
+    `[boundary] replay:${params.boundaryId}`,
+    `source=${params.source}`,
+    `messages=${params.sourceMessageCount}`,
+    `retained=${params.retainedTailCount}`,
+    ...(params.summaryText?.trim().length
+      ? [`summary=${truncateText(params.summaryText, 240)}`]
+      : []),
+  ].join(" ");
+  return {
+    role: "system",
+    content,
+  };
 }
 
 function extractText(message: LLMMessage): string {
@@ -443,8 +466,16 @@ export function compactHistoryIntoArtifactContext(
       openLoops: [],
       artifactRefs: [],
     };
+    const boundaryMessage = createCompactBoundaryMessage({
+      boundaryId: emptyState.snapshotId,
+      source: input.source,
+      sourceMessageCount: input.history.length,
+      retainedTailCount: input.history.length,
+      summaryText: renderSummaryText(emptyState),
+    });
     return {
-      compactedHistory: [...input.history],
+      boundaryMessage,
+      compactedHistory: [boundaryMessage, ...input.history],
       state: emptyState,
       records: [],
       summaryText: renderSummaryText(emptyState),
@@ -523,15 +554,20 @@ export function compactHistoryIntoArtifactContext(
     artifactRefs,
   };
   const summaryText = renderSummaryText(state);
+  const boundaryMessage = createCompactBoundaryMessage({
+    boundaryId: state.snapshotId,
+    source: input.source,
+    sourceMessageCount: toCompact.length,
+    retainedTailCount: toKeep.length,
+    summaryText,
+  });
   return {
     compactedHistory: [
-      {
-        role: "system",
-        content: summaryText,
-      },
+      boundaryMessage,
       ...preservedMessages,
       ...toKeep,
     ],
+    boundaryMessage,
     state,
     records: selectedRecords,
     summaryText,

--- a/runtime/src/llm/shell-write-policy.ts
+++ b/runtime/src/llm/shell-write-policy.ts
@@ -49,9 +49,15 @@ const DYNAMIC_SHELL_TARGET_RE = /(?:[$*?\[\]{}~]|`|\$\(|<\()/;
 
 export interface ShellWorkspaceWritePolicyDecision {
   readonly blocked: boolean;
+  readonly indeterminate: boolean;
   readonly observedTargets: readonly string[];
   readonly blockedTargets: readonly string[];
   readonly message?: string;
+}
+
+interface ShellWriteTargetCollection {
+  targets: string[];
+  indeterminate: boolean;
 }
 
 function isWritePolicyEnabled(turnClass: string | undefined): boolean {
@@ -74,17 +80,55 @@ function resolveWorkingDirectory(
 function normalizeConcreteTargetPath(
   rawPath: string,
   cwd: string,
-): string | undefined {
+): ShellWriteTargetCollection {
   const trimmed = rawPath.trim();
   if (trimmed.length === 0 || trimmed === "-") {
-    return undefined;
+    return { targets: [], indeterminate: false };
   }
   if (DYNAMIC_SHELL_TARGET_RE.test(trimmed)) {
-    return undefined;
+    return { targets: [], indeterminate: true };
   }
-  return trimmed.startsWith("/")
-    ? resolvePath(trimmed)
-    : resolvePath(cwd, trimmed);
+  return {
+    targets: [
+      trimmed.startsWith("/")
+        ? resolvePath(trimmed)
+        : resolvePath(cwd, trimmed),
+    ],
+    indeterminate: false,
+  };
+}
+
+function emptyTargetCollection(): ShellWriteTargetCollection {
+  return { targets: [], indeterminate: false };
+}
+
+function collectOperandTargets(
+  args: readonly string[],
+  cwd: string,
+): ShellWriteTargetCollection {
+  const collection: ShellWriteTargetCollection = {
+    targets: [],
+    indeterminate: false,
+  };
+  let treatRemainingAsOperands = false;
+  for (const token of args) {
+    if (!token) continue;
+    if (!treatRemainingAsOperands && token === "--") {
+      treatRemainingAsOperands = true;
+      continue;
+    }
+    if (!treatRemainingAsOperands && token.startsWith("-")) {
+      continue;
+    }
+    const normalized = normalizeConcreteTargetPath(token, cwd);
+    collection.indeterminate ||= normalized.indeterminate;
+    for (const target of normalized.targets) {
+      if (!collection.targets.includes(target)) {
+        collection.targets = [...collection.targets, target];
+      }
+    }
+  }
+  return collection;
 }
 
 function isWorkspaceGeneratedOutputPath(
@@ -131,11 +175,7 @@ function extractWrappedShellCommand(args: readonly string[]): string | undefined
   return undefined;
 }
 
-function collectTeeTargets(
-  args: readonly string[],
-  cwd: string,
-): readonly string[] {
-  const targets = new Set<string>();
+function hasWrapperScriptOperand(args: readonly string[]): boolean {
   let treatRemainingAsOperands = false;
   for (const token of args) {
     if (!token) continue;
@@ -146,42 +186,30 @@ function collectTeeTargets(
     if (!treatRemainingAsOperands && token.startsWith("-")) {
       continue;
     }
-    const normalized = normalizeConcreteTargetPath(token, cwd);
-    if (normalized) {
-      targets.add(normalized);
-    }
+    return true;
   }
-  return [...targets];
+  return false;
+}
+
+function collectTeeTargets(
+  args: readonly string[],
+  cwd: string,
+): ShellWriteTargetCollection {
+  return collectOperandTargets(args, cwd);
 }
 
 function collectTouchTargets(
   args: readonly string[],
   cwd: string,
-): readonly string[] {
-  const targets = new Set<string>();
-  let treatRemainingAsOperands = false;
-  for (const token of args) {
-    if (!token) continue;
-    if (!treatRemainingAsOperands && token === "--") {
-      treatRemainingAsOperands = true;
-      continue;
-    }
-    if (!treatRemainingAsOperands && token.startsWith("-")) {
-      continue;
-    }
-    const normalized = normalizeConcreteTargetPath(token, cwd);
-    if (normalized) {
-      targets.add(normalized);
-    }
-  }
-  return [...targets];
+): ShellWriteTargetCollection {
+  return collectOperandTargets(args, cwd);
 }
 
 function collectDestinationTarget(
   command: string,
   args: readonly string[],
   cwd: string,
-): readonly string[] {
+): ShellWriteTargetCollection {
   const operands: string[] = [];
   let targetDirectory: string | undefined;
   let treatRemainingAsOperands = false;
@@ -213,29 +241,39 @@ function collectDestinationTarget(
   }
   const explicitTarget = targetDirectory
     ? normalizeConcreteTargetPath(targetDirectory, cwd)
-    : undefined;
-  if (explicitTarget) {
-    return [explicitTarget];
+    : emptyTargetCollection();
+  const collection = {
+    targets: [...explicitTarget.targets],
+    indeterminate: explicitTarget.indeterminate,
+  };
+  if (collection.targets.length > 0 || collection.indeterminate) {
+    if (collection.targets.length > 0) {
+      return collection;
+    }
+    return collection;
   }
   const destination = operands[operands.length - 1];
   if (!destination) {
-    return [];
+    return collection;
   }
   const normalized = normalizeConcreteTargetPath(destination, cwd);
-  if (!normalized) {
-    return [];
+  collection.indeterminate ||= normalized.indeterminate;
+  for (const target of normalized.targets) {
+    if (!collection.targets.includes(target)) {
+      collection.targets.push(target);
+    }
   }
-  if (command === "install" && operands.length <= 1 && !explicitTarget) {
-    return [];
+  if (command === "install" && operands.length <= 1 && !targetDirectory) {
+    return emptyTargetCollection();
   }
-  return [normalized];
+  return collection;
 }
 
 function collectDirectCommandWriteTargets(params: {
   readonly command: string;
   readonly args: readonly string[];
   readonly cwd: string;
-}): readonly string[] {
+}): ShellWriteTargetCollection {
   const command = basename(params.command);
   if (command === "env") {
     const shellIndex = params.args.findIndex((token) =>
@@ -249,14 +287,17 @@ function collectDirectCommandWriteTargets(params: {
       if (nestedCommand) {
         return collectShellCommandWriteTargets(nestedCommand, params.cwd);
       }
+      return { targets: [], indeterminate: true };
     }
-    return [];
+    return emptyTargetCollection();
   }
   if (SHELL_WRAPPER_COMMANDS.has(command)) {
     const nestedCommand = extractWrappedShellCommand(params.args);
     return nestedCommand
       ? collectShellCommandWriteTargets(nestedCommand, params.cwd)
-      : [];
+      : hasWrapperScriptOperand(params.args)
+        ? emptyTargetCollection()
+        : { targets: [], indeterminate: true };
   }
   if (command === "tee") {
     return collectTeeTargets(params.args, params.cwd);
@@ -264,17 +305,46 @@ function collectDirectCommandWriteTargets(params: {
   if (command === "touch") {
     return collectTouchTargets(params.args, params.cwd);
   }
-  if (command === "cp" || command === "mv" || command === "install") {
+  if (command === "cp" || command === "mv" || command === "install" || command === "ln") {
     return collectDestinationTarget(command, params.args, params.cwd);
   }
-  return [];
+  if (command === "mkdir" || command === "rm" || command === "rmdir" || command === "truncate") {
+    return collectOperandTargets(params.args, params.cwd);
+  }
+  if (command === "dd") {
+    const targets = new Set<string>();
+    let indeterminate = false;
+    for (const token of params.args) {
+      if (!token) continue;
+      if (token.startsWith("of=")) {
+        const normalized = normalizeConcreteTargetPath(token.slice(3), params.cwd);
+        indeterminate ||= normalized.indeterminate;
+        for (const target of normalized.targets) {
+          targets.add(target);
+        }
+      }
+      if (token.startsWith("of=") && token.length === 3) {
+        indeterminate = true;
+      }
+    }
+    return { targets: [...targets], indeterminate };
+  }
+  if (command === "sed" || command === "perl") {
+    const inPlace = params.args.some((token) => token === "-i" || token.startsWith("-i"));
+    if (!inPlace) {
+      return emptyTargetCollection();
+    }
+    return collectOperandTargets(params.args, params.cwd);
+  }
+  return emptyTargetCollection();
 }
 
 function collectRedirectionTargets(
   tokens: readonly string[],
   cwd: string,
-): readonly string[] {
+): ShellWriteTargetCollection {
   const targets = new Set<string>();
+  let indeterminate = false;
   for (let i = 0; i < tokens.length; i += 1) {
     const token = tokens[i];
     if (!token || !WRITE_REDIRECT_OPERATORS.has(token)) {
@@ -282,6 +352,7 @@ function collectRedirectionTargets(
     }
     const next = tokens[i + 1];
     if (!next || SHELL_COMMAND_SEPARATORS.has(next) || ALL_REDIRECT_OPERATORS.has(next)) {
+      indeterminate = true;
       continue;
     }
     if (
@@ -291,20 +362,21 @@ function collectRedirectionTargets(
       continue;
     }
     const normalized = normalizeConcreteTargetPath(next, cwd);
-    if (normalized) {
-      targets.add(normalized);
+    indeterminate ||= normalized.indeterminate;
+    for (const target of normalized.targets) {
+      targets.add(target);
     }
   }
-  return [...targets];
+  return { targets: [...targets], indeterminate };
 }
 
 function collectSegmentCommandWriteTargets(
   segment: readonly string[],
   cwd: string,
-): readonly string[] {
+): ShellWriteTargetCollection {
   const stripped = stripRedirections(segment);
   if (stripped.length === 0) {
-    return [];
+    return emptyTargetCollection();
   }
   let commandIndex = 0;
   while (
@@ -315,7 +387,7 @@ function collectSegmentCommandWriteTargets(
   }
   const command = stripped[commandIndex];
   if (!command) {
-    return [];
+    return emptyTargetCollection();
   }
   return collectDirectCommandWriteTargets({
     command,
@@ -327,12 +399,16 @@ function collectSegmentCommandWriteTargets(
 function collectShellCommandWriteTargets(
   commandLine: string,
   cwd: string,
-): readonly string[] {
+): ShellWriteTargetCollection {
   const tokens = tokenizeShellCommand(commandLine);
-  const targets = new Set<string>(collectRedirectionTargets(tokens, cwd));
+  const redirections = collectRedirectionTargets(tokens, cwd);
+  const targets = new Set<string>(redirections.targets);
+  let indeterminate = redirections.indeterminate;
   let segment: string[] = [];
   const flushSegment = (): void => {
-    for (const target of collectSegmentCommandWriteTargets(segment, cwd)) {
+    const collection = collectSegmentCommandWriteTargets(segment, cwd);
+    indeterminate ||= collection.indeterminate;
+    for (const target of collection.targets) {
       targets.add(target);
     }
     segment = [];
@@ -345,7 +421,7 @@ function collectShellCommandWriteTargets(
     segment.push(token);
   }
   flushSegment();
-  return [...targets];
+  return { targets: [...targets], indeterminate };
 }
 
 function buildPolicyMessage(blockedTargets: readonly string[]): string {
@@ -354,47 +430,66 @@ function buildPolicyMessage(blockedTargets: readonly string[]): string {
     "must use structured file tools for project file authoring. Use " +
     "`system.writeFile`, `system.editFile`, `system.appendFile`, " +
     "`desktop.text_editor`, `system.mkdir`, or `system.move` instead of " +
-    "shell redirection, heredocs, `tee`, `cp`, `mv`, `touch`, or `install` " +
-    "for workspace files. Shell writes are only allowed under generated " +
-    "output roots (`build`, `dist`, `logs`, `.cache`, `tmp`, `coverage`)." +
+    "shell redirection, heredocs, `tee`, `cp`, `mv`, `ln`, `touch`, `install`, " +
+    "`rm`, `rmdir`, `truncate`, `dd`, `sed -i`, or `perl -i` for workspace files. " +
+    "Shell writes are only allowed under generated output roots (`build`, `dist`, " +
+    "`logs`, `.cache`, `tmp`, `coverage`)." +
     (blockedTargets.length > 0
       ? ` Blocked target(s): ${blockedTargets.join(", ")}`
       : "")
   );
 }
 
-export function evaluateShellWorkspaceWritePolicy(params: {
+function buildIndeterminatePolicyMessage(
+  observedTargets: readonly string[],
+): string {
+  return (
+    "shell_workspace_file_write_disallowed: Unable to confirm workspace write targets " +
+    "for this shell command. Use structured file tools instead of shell writes, " +
+    "and avoid dynamic shell indirection for file mutations." +
+    (observedTargets.length > 0
+      ? ` Observed target(s): ${observedTargets.join(", ")}`
+      : "")
+  );
+}
+
+export function classifyShellWorkspaceWritePolicy(params: {
   readonly toolName: string;
   readonly args: Record<string, unknown>;
   readonly workspaceRoot?: string;
-  readonly turnClass?: string;
 }): ShellWorkspaceWritePolicyDecision {
-  if (
-    !isWritePolicyEnabled(params.turnClass) ||
-    !params.workspaceRoot ||
-    !SHELL_WORKSPACE_WRITE_TOOL_NAMES.has(params.toolName)
-  ) {
+  if (!SHELL_WORKSPACE_WRITE_TOOL_NAMES.has(params.toolName)) {
     return {
       blocked: false,
+      indeterminate: false,
       observedTargets: [],
       blockedTargets: [],
     };
   }
+  if (!params.workspaceRoot) {
+    return {
+      blocked: true,
+      indeterminate: true,
+      observedTargets: [],
+      blockedTargets: [],
+      message: buildIndeterminatePolicyMessage([]),
+    };
+  }
 
   const cwd = resolveWorkingDirectory(params.workspaceRoot, params.args.cwd);
-  let observedTargets: readonly string[] = [];
+  let collected: ShellWriteTargetCollection = emptyTargetCollection();
   if (Array.isArray(params.args.args)) {
-    observedTargets = collectDirectCommandWriteTargets({
+    collected = collectDirectCommandWriteTargets({
       command:
         typeof params.args.command === "string" ? params.args.command : "",
       args: params.args.args.filter((value): value is string => typeof value === "string"),
       cwd,
     });
   } else if (typeof params.args.command === "string") {
-    observedTargets = collectShellCommandWriteTargets(params.args.command, cwd);
+    collected = collectShellCommandWriteTargets(params.args.command, cwd);
   }
 
-  const blockedTargets = observedTargets.filter((target) => {
+  const blockedTargets = collected.targets.filter((target) => {
     const rel = relative(params.workspaceRoot!, target);
     if (
       rel.length === 0 ||
@@ -407,12 +502,43 @@ export function evaluateShellWorkspaceWritePolicy(params: {
     return !isWorkspaceGeneratedOutputPath(params.workspaceRoot!, target);
   });
 
+  if (collected.indeterminate) {
+    return {
+      blocked: true,
+      indeterminate: true,
+      observedTargets: collected.targets,
+      blockedTargets,
+      message:
+        blockedTargets.length > 0
+          ? `${buildPolicyMessage(blockedTargets)} ${buildIndeterminatePolicyMessage(collected.targets)}`
+          : buildIndeterminatePolicyMessage(collected.targets),
+    };
+  }
+
   return {
     blocked: blockedTargets.length > 0,
-    observedTargets,
+    indeterminate: false,
+    observedTargets: collected.targets,
     blockedTargets,
     ...(blockedTargets.length > 0
       ? { message: buildPolicyMessage(blockedTargets) }
       : {}),
   };
+}
+
+export function evaluateShellWorkspaceWritePolicy(params: {
+  readonly toolName: string;
+  readonly args: Record<string, unknown>;
+  readonly workspaceRoot?: string;
+  readonly turnClass?: string;
+}): ShellWorkspaceWritePolicyDecision {
+  if (!isWritePolicyEnabled(params.turnClass)) {
+    return {
+      blocked: false,
+      indeterminate: false,
+      observedTargets: [],
+      blockedTargets: [],
+    };
+  }
+  return classifyShellWorkspaceWritePolicy(params);
 }

--- a/runtime/src/tools/system/bash.test.ts
+++ b/runtime/src/tools/system/bash.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createBashTool, isCommandAllowed, validateShellCommand } from "./bash.js";
+import { classifyShellWorkspaceWritePolicy } from "../../llm/shell-write-policy.js";
 import { DEFAULT_DENY_LIST, DEFAULT_DENY_PREFIXES, DANGEROUS_SHELL_PATTERNS } from "./types.js";
 import type { Logger } from "../../utils/logger.js";
 
@@ -11,12 +15,16 @@ vi.mock("node:child_process", () => ({
 }));
 
 // Mock fs operations used by shell mode (temp script file)
-vi.mock("node:fs", () => ({
-  existsSync: vi.fn(() => false),
-  statSync: vi.fn(() => ({ isDirectory: () => true })),
-  writeFileSync: vi.fn(),
-  unlinkSync: vi.fn(),
-}));
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    existsSync: vi.fn(() => false),
+    statSync: vi.fn(() => ({ isDirectory: () => true })),
+    writeFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+  };
+});
 
 import { execFile, spawn } from "node:child_process";
 import { statSync, writeFileSync } from "node:fs";
@@ -1121,6 +1129,41 @@ describe("system.bash tool", () => {
       const result = await tool.execute({ command: "dd if=/dev/zero of=/dev/sda bs=1M" });
       expect(result.isError).toBe(true);
       expect(parseContent(result).error).toContain("Raw device");
+    });
+
+    it("fails closed on indeterminate workspace writes", () => {
+      const decision = classifyShellWorkspaceWritePolicy({
+        toolName: "system.bash",
+        workspaceRoot: "/workspace",
+        args: {
+          command: "echo hi > $OUT",
+          cwd: "/workspace",
+        },
+      });
+
+      expect(decision.blocked).toBe(true);
+      expect(decision.indeterminate).toBe(true);
+      expect(decision.message).toContain("Unable to confirm");
+    });
+
+    it("blocks shell writes into the workspace root", async () => {
+      const workspaceRoot = mkdtempSync(
+        join(tmpdir(), "agenc-bash-shell-write-"),
+      );
+
+      try {
+        const tool = createBashTool({ cwd: workspaceRoot });
+        mockSpawnSuccess("");
+
+        const result = await tool.execute({ command: "echo hi > notes.txt" });
+        expect(result.isError).toBe(true);
+        expect(parseContent(result).error).toContain(
+          "shell_workspace_file_write_disallowed",
+        );
+        expect(mockSpawn).not.toHaveBeenCalled();
+      } finally {
+        rmSync(workspaceRoot, { recursive: true, force: true });
+      }
     });
 
     it("blocks dangerous inline shell wrapper scripts", async () => {

--- a/runtime/src/tools/system/bash.ts
+++ b/runtime/src/tools/system/bash.ts
@@ -34,6 +34,7 @@ import {
 } from "./types.js";
 import { silentLogger } from "../../utils/logger.js";
 import type { Logger } from "../../utils/logger.js";
+import { classifyShellWorkspaceWritePolicy } from "../../llm/shell-write-policy.js";
 
 const SHELL_WRAPPER_COMMANDS = new Set([
   "bash",
@@ -756,6 +757,17 @@ export function createBashTool(config?: BashToolConfig): Tool {
       });
       const shellCommand = builtinShellFallback ?? command;
 
+      // Apply cwd — reject per-call override if lockCwd is enabled.
+      let cwd = defaultCwd;
+      if (input.cwd !== undefined) {
+        if (lockCwd) {
+          return errorResult(
+            "Per-call cwd override is disabled (lockCwd is enabled)",
+          );
+        }
+        cwd = input.cwd;
+      }
+
       // Determine execution mode: shell vs direct
       const useShellMode =
         shellModeEnabled &&
@@ -868,15 +880,19 @@ export function createBashTool(config?: BashToolConfig): Tool {
         execArgs = args;
       }
 
-      // Apply cwd — reject per-call override if lockCwd is enabled
-      let cwd = defaultCwd;
-      if (input.cwd !== undefined) {
-        if (lockCwd) {
-          return errorResult(
-            "Per-call cwd override is disabled (lockCwd is enabled)",
-          );
-        }
-        cwd = input.cwd;
+      const workspaceWriteDecision = classifyShellWorkspaceWritePolicy({
+        toolName: "system.bash",
+        args: useShellMode
+          ? { command: shellCommand, cwd }
+          : { command, args: execArgs, cwd },
+        workspaceRoot: cwd,
+      });
+      if (workspaceWriteDecision.blocked) {
+        const rejectionMessage =
+          workspaceWriteDecision.message ??
+          "Shell workspace write policy blocked the command.";
+        logger.warn(`Bash tool shell write denied: ${rejectionMessage}`);
+        return errorResult(rejectionMessage);
       }
 
       const cwdValidationError = validateWorkingDirectory(cwd);

--- a/runtime/src/tools/system/filesystem.test.ts
+++ b/runtime/src/tools/system/filesystem.test.ts
@@ -573,7 +573,7 @@ describe("system.writeFile", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(parseResult(result).error).toContain("File has not been read yet");
+    expect(parseResult(result).error).toContain("fully read");
     expect(mockWriteFile).not.toHaveBeenCalled();
   });
 
@@ -612,6 +612,39 @@ describe("system.writeFile", () => {
     expect(mockWriteFile).toHaveBeenCalled();
   });
 
+  it.each([
+    "partial",
+    "legacy_unknown",
+  ] as const)("rejects %s snapshots for existing-file writes", async (viewKind) => {
+    const sessionId = `session-${viewKind}`;
+    clearSessionReadState(sessionId);
+    seedSessionReadState(sessionId, [
+      {
+        path: "/workspace/existing.c",
+        content: "hello",
+        timestamp: 1_000,
+        viewKind,
+      },
+    ]);
+
+    mockStat.mockResolvedValueOnce({
+      isFile: () => true,
+      isDirectory: () => false,
+      size: 5,
+      mtimeMs: 1_000,
+    } as never);
+
+    const result = await tool.execute({
+      path: "/workspace/existing.c",
+      content: "world",
+      __agencSessionId: sessionId,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain("fully read");
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
   it("rejects writing an existing file when no session id is provided", async () => {
     // No __agencSessionId in args -> fail closed unless a seed exists
     mockStat.mockResolvedValueOnce({
@@ -626,7 +659,7 @@ describe("system.writeFile", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(parseResult(result).error).toContain("File has not been read yet");
+    expect(parseResult(result).error).toContain("fully read");
     expect(mockWriteFile).not.toHaveBeenCalled();
   });
 
@@ -701,6 +734,7 @@ describe("system.writeFile", () => {
         path: "/workspace/seeded.txt",
         content: "hello",
         timestamp: 1_000,
+        viewKind: "full",
       },
     ]);
 
@@ -872,7 +906,32 @@ describe("system.editFile", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(parseResult(result).error).toContain("File has not been read yet");
+    expect(parseResult(result).error).toContain("fully read");
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects edit after a partial read snapshot", async () => {
+    const before = `int main(void) { return 0; }\n`;
+    setupExistingFile(before);
+    clearSessionReadState("session-partial-edit");
+    seedSessionReadState("session-partial-edit", [
+      {
+        path: "/workspace/no-read.c",
+        content: before,
+        timestamp: 1_000,
+        viewKind: "partial",
+      },
+    ]);
+
+    const result = await tool.execute({
+      path: "/workspace/no-read.c",
+      old_string: "return 0",
+      new_string: "return 1",
+      __agencSessionId: "session-partial-edit",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain("fully read");
     expect(mockWriteFile).not.toHaveBeenCalled();
   });
 
@@ -887,7 +946,7 @@ describe("system.editFile", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(parseResult(result).error).toContain("File has not been read yet");
+    expect(parseResult(result).error).toContain("fully read");
     expect(mockWriteFile).not.toHaveBeenCalled();
   });
 
@@ -1253,7 +1312,7 @@ describe("system.editFile", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(parseResult(result).error).toContain("File has not been read yet");
+    expect(parseResult(result).error).toContain("fully read");
   });
 });
 
@@ -1263,15 +1322,18 @@ describe("system.editFile", () => {
 
 describe("system.appendFile", () => {
   let tool: Tool;
+  let readTool: Tool;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockRealpath.mockImplementation(async (p: string) => p as never);
     tool = findTool(createFilesystemTools(CONFIG), "system.appendFile");
+    readTool = findTool(createFilesystemTools(CONFIG), "system.readFile");
   });
 
   it("appends content to a file", async () => {
     mockAppendFile.mockResolvedValueOnce(undefined);
+    setupCreateThenReadback("new line\n");
 
     const result = await tool.execute({
       path: "/workspace/log.txt",
@@ -1281,6 +1343,76 @@ describe("system.appendFile", () => {
 
     expect(result.isError).toBeUndefined();
     expect(parsed.bytesAppended).toBe(9);
+  });
+
+  it("allows appending to an existing file after a full read", async () => {
+    const sessionId = "session-append-full";
+    clearSessionReadState(sessionId);
+    mockStat.mockResolvedValueOnce({
+      isFile: () => true,
+      isDirectory: () => false,
+      size: 5,
+      mtimeMs: 1_000,
+    } as never);
+    mockReadFile.mockResolvedValueOnce(Buffer.from("hello"));
+    await readTool.execute({
+      path: "/workspace/log.txt",
+      __agencSessionId: sessionId,
+    });
+
+    mockStat.mockResolvedValueOnce({
+      isFile: () => true,
+      isDirectory: () => false,
+      size: 5,
+      mtimeMs: 1_000,
+    } as never);
+    mockReadFile.mockResolvedValueOnce(Buffer.from("hello"));
+    mockAppendFile.mockResolvedValueOnce(undefined);
+    mockStat.mockResolvedValueOnce({
+      isFile: () => true,
+      isDirectory: () => false,
+      size: 10,
+      mtimeMs: 2_000,
+    } as never);
+    mockReadFile.mockResolvedValueOnce(Buffer.from("hello\nmore"));
+
+    const result = await tool.execute({
+      path: "/workspace/log.txt",
+      content: "more\n",
+      __agencSessionId: sessionId,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockAppendFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects appending to an existing file after a partial read", async () => {
+    const sessionId = "session-append-partial";
+    clearSessionReadState(sessionId);
+    seedSessionReadState(sessionId, [
+      {
+        path: "/workspace/log.txt",
+        content: "hello",
+        timestamp: 1_000,
+        viewKind: "partial",
+      },
+    ]);
+
+    mockStat.mockResolvedValueOnce({
+      isFile: () => true,
+      isDirectory: () => false,
+      size: 5,
+    } as never);
+
+    const result = await tool.execute({
+      path: "/workspace/log.txt",
+      content: "more\n",
+      __agencSessionId: sessionId,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain("fully read");
+    expect(mockAppendFile).not.toHaveBeenCalled();
   });
 });
 
@@ -1932,6 +2064,7 @@ describe("system.appendFile parent directory creation", () => {
   it("creates parent directories before appending", async () => {
     mockMkdir.mockResolvedValueOnce(undefined);
     mockAppendFile.mockResolvedValueOnce(undefined);
+    setupCreateThenReadback("first line\n");
 
     const result = await tool.execute({
       path: "/workspace/new/nested/log.txt",

--- a/runtime/src/tools/system/filesystem.ts
+++ b/runtime/src/tools/system/filesystem.ts
@@ -66,6 +66,10 @@ const DEFAULT_MAX_WRITE_BYTES = 10_485_760; // 10 MB
 const MAX_LIST_ENTRIES = 10_000;
 const MAX_PATH_LENGTH = 4096;
 export const SESSION_ALLOWED_ROOTS_ARG = "__agencSessionAllowedRoots";
+export type SessionReadViewKind =
+  | "full"
+  | "partial"
+  | "legacy_unknown";
 
 /**
  * Per-session arg name carrying the session identifier into filesystem
@@ -121,12 +125,14 @@ export const SESSION_ID_ARG = "__agencSessionId";
 interface SessionReadSnapshot {
   readonly content?: string | null;
   readonly timestamp?: number;
+  readonly viewKind?: SessionReadViewKind;
 }
 
 export interface SessionReadSeedEntry {
   readonly path: string;
   readonly content?: string | null;
   readonly timestamp?: number;
+  readonly viewKind?: SessionReadViewKind;
 }
 
 const sessionReadState = new Map<string, Map<string, SessionReadSnapshot>>();
@@ -189,6 +195,7 @@ function persistLocalFileHistorySnapshot(
     entries.push({
       content: snapshot.content ?? null,
       timestamp: snapshot.timestamp,
+      viewKind: snapshot.viewKind ?? "legacy_unknown",
       recordedAt: Date.now(),
     });
     if (entries.length > LOCAL_FILE_HISTORY_MAX_ENTRIES) {
@@ -216,6 +223,7 @@ function loadPersistedSessionReadSnapshot(
       const entry = parsed[index];
       if (typeof entry !== "object" || entry === null) continue;
       const content = (entry as { content?: unknown }).content;
+      const viewKind = (entry as { viewKind?: unknown }).viewKind;
       const timestampValue = (entry as { timestamp?: unknown }).timestamp;
       const recordedAtValue = (entry as { recordedAt?: unknown }).recordedAt;
       const timestamp =
@@ -225,12 +233,28 @@ function loadPersistedSessionReadSnapshot(
             ? recordedAtValue
             : undefined;
       if (typeof content === "string") {
-        return timestamp === undefined ? { content } : { content, timestamp };
+        return {
+          ...(timestamp === undefined ? { content } : { content, timestamp }),
+          viewKind:
+            viewKind === "full" ||
+            viewKind === "partial" ||
+            viewKind === "legacy_unknown"
+              ? viewKind
+              : "legacy_unknown",
+        };
       }
       if (content === null) {
-        return timestamp === undefined
-          ? { content: null }
-          : { content: null, timestamp };
+        return {
+          ...(timestamp === undefined
+            ? { content: null }
+            : { content: null, timestamp }),
+          viewKind:
+            viewKind === "full" ||
+            viewKind === "partial" ||
+            viewKind === "legacy_unknown"
+              ? viewKind
+              : "legacy_unknown",
+        };
       }
     }
   } catch {
@@ -279,10 +303,16 @@ export function recordSessionRead(
     sessionReadState.set(sessionId, fileMap);
   }
   const previous = fileMap.get(canonicalPath);
-  const nextSnapshot = {
-    ...(previous ?? {}),
-    ...(snapshot ?? {}),
-  };
+  const nextSnapshot = snapshot
+    ? {
+        ...(previous ?? {}),
+        ...snapshot,
+      }
+    : { viewKind: "full" as SessionReadViewKind };
+  if (nextSnapshot.viewKind === undefined) {
+    nextSnapshot.viewKind =
+      snapshot?.viewKind ?? "full";
+  }
   fileMap.set(canonicalPath, nextSnapshot);
   persistLocalFileHistorySnapshot(sessionId, canonicalPath, nextSnapshot);
 }
@@ -301,15 +331,22 @@ export function seedSessionReadState(
       ...(typeof entry.timestamp === "number" && Number.isFinite(entry.timestamp)
         ? { timestamp: entry.timestamp }
         : {}),
+      viewKind: entry.viewKind ?? "legacy_unknown",
     });
   }
+}
+
+function isFullSessionRead(snapshot: SessionReadSnapshot | undefined): boolean {
+  return snapshot?.viewKind === "full";
 }
 
 export function hasSessionRead(
   sessionId: string | undefined,
   canonicalPath: string,
 ): boolean {
-  return rehydrateSessionReadSnapshot(sessionId, canonicalPath) !== undefined;
+  return isFullSessionRead(
+    rehydrateSessionReadSnapshot(sessionId, canonicalPath),
+  );
 }
 
 export function getSessionReadSnapshot(
@@ -879,6 +916,7 @@ function getFileTimestampMs(fileStats: { mtimeMs?: number }): number | undefined
 
 async function readFreshTextSnapshot(
   path: string,
+  viewKind: SessionReadViewKind,
 ): Promise<SessionReadSnapshot> {
   const [buffer, fileStats] = await Promise.all([
     readFile(path),
@@ -887,7 +925,14 @@ async function readFreshTextSnapshot(
   return {
     content: isBinaryContent(buffer) ? null : buffer.toString("utf-8"),
     timestamp: getFileTimestampMs(fileStats) ?? Date.now(),
+    viewKind,
   };
+}
+
+function requiresFullReadSnapshot(
+  snapshot: SessionReadSnapshot | undefined,
+): boolean {
+  return snapshot?.viewKind !== "full";
 }
 
 function hasFileChangedSinceSnapshot(params: {
@@ -984,6 +1029,7 @@ function createReadFileTool(
         recordSessionRead(resolveSessionId(args), resolved!, {
           content: binary ? null : buffer.toString("utf-8"),
           timestamp: getFileTimestampMs(fileStats),
+          viewKind: "full",
         });
 
         return {
@@ -1072,15 +1118,19 @@ function createWriteFileTool(
           // prior read required.
         }
         const readSnapshot = getSessionReadSnapshot(sessionId, resolved!);
-        if (targetExists && readSnapshot === undefined) {
+        if (targetExists && requiresFullReadSnapshot(readSnapshot)) {
           return errorResult(
-            `File has not been read yet. Read it first before writing to it. ` +
+            `File must be fully read before writing to it. ` +
               `Call system.readFile on "${args.path}" before calling system.writeFile, ` +
               `OR prefer system.editFile (str_replace semantics) for incremental edits.`,
           );
         }
 
-        if (targetExists && readSnapshot?.content !== undefined) {
+        if (
+          targetExists &&
+          readSnapshot?.content !== undefined &&
+          readSnapshot.viewKind === "full"
+        ) {
           const existingBuffer = await readFile(resolved!);
           const existingContent = existingBuffer.toString("utf-8");
           if (
@@ -1137,7 +1187,7 @@ function createWriteFileTool(
         // Successful write counts as the "current state" the model has
         // seen — record the path so subsequent edits to the same file
         // in the same session don't require a redundant readFile.
-        const refreshedSnapshot = await readFreshTextSnapshot(resolved!);
+        const refreshedSnapshot = await readFreshTextSnapshot(resolved!, "full");
         recordSessionRead(sessionId, resolved!, refreshedSnapshot);
 
         return {
@@ -1196,6 +1246,8 @@ function createAppendFileTool(
           );
         }
 
+        const sessionId = resolveSessionId(args);
+
         // Check total resulting file size to prevent disk exhaustion via repeated appends
         try {
           const existing = await stat(resolved!);
@@ -1204,6 +1256,32 @@ function createAppendFileTool(
               `Resulting file size ${existing.size + data.length} bytes exceeds limit of ${maxWriteBytes} bytes`,
             );
           }
+
+          const readSnapshot = getSessionReadSnapshot(sessionId, resolved!);
+          if (requiresFullReadSnapshot(readSnapshot)) {
+            return errorResult(
+              `File must be fully read before appending to it. ` +
+                `Call system.readFile on "${args.path}" before calling system.appendFile.`,
+            );
+          }
+
+          if (
+            readSnapshot?.content !== undefined &&
+            readSnapshot.viewKind === "full"
+          ) {
+            const existingBuffer = await readFile(resolved!);
+            const existingContent = existingBuffer.toString("utf-8");
+            if (
+              hasFileChangedSinceSnapshot({
+                snapshot: readSnapshot,
+                currentContent: existingContent,
+              })
+            ) {
+              return errorResult(
+                `File has been modified since it was last read. Read "${args.path}" again before appending to it.`,
+              );
+            }
+          }
         } catch {
           // File doesn't exist yet — just the append size matters (checked above)
         }
@@ -1211,6 +1289,8 @@ function createAppendFileTool(
         // Create parent directories if needed (consistent with writeFile)
         await mkdir(dirname(resolved!), { recursive: true });
         await appendFile(resolved!, data);
+        const refreshedSnapshot = await readFreshTextSnapshot(resolved!, "full");
+        recordSessionRead(sessionId, resolved!, refreshedSnapshot);
         return {
           content: safeStringify({
             path: args.path,
@@ -1360,9 +1440,9 @@ function createEditFileTool(
         // called system.readFile on this path in the current session.
         const sessionId = resolveSessionId(args);
         const readSnapshot = getSessionReadSnapshot(sessionId, resolved!);
-        if (readSnapshot === undefined) {
+        if (requiresFullReadSnapshot(readSnapshot)) {
           return errorResult(
-            `File has not been read yet. Read it first before editing it. ` +
+            `File must be fully read before editing it. ` +
               `Call system.readFile on "${args.path}" before calling system.editFile. ` +
               `The Read-before-Edit rule exists so you have the literal current contents of the file ` +
               `(including any prior escape mistakes) in your context before generating the new edit.`,
@@ -1452,7 +1532,7 @@ function createEditFileTool(
 
         // Record the post-edit content as "read" so the next edit in
         // this session does not require a redundant readFile.
-        const refreshedSnapshot = await readFreshTextSnapshot(resolved!);
+        const refreshedSnapshot = await readFreshTextSnapshot(resolved!, "full");
         recordSessionRead(sessionId, resolved!, refreshedSnapshot);
 
         return {

--- a/runtime/src/tools/system/task-tracker.test.ts
+++ b/runtime/src/tools/system/task-tracker.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import {
+  TASK_ACTOR_KIND_ARG,
+  TASK_ACTOR_NAME_ARG,
   createTaskTrackerTools,
   TaskStore,
   type TaskTrackerToolOptions,
@@ -421,6 +423,21 @@ describe("task-tracker", () => {
       expect((done.body.task as Record<string, unknown>).status).toBe("completed");
     });
 
+    it("auto-claims an in-progress task for a subagent actor when no owner is set", async () => {
+      const start = await callTool(update, {
+        taskId: "1",
+        status: "in_progress",
+        [TASK_ACTOR_KIND_ARG]: "subagent",
+        [TASK_ACTOR_NAME_ARG]: "worker-alpha",
+      });
+
+      expect(start.body.task).toMatchObject({
+        id: "1",
+        status: "in_progress",
+        owner: "worker-alpha",
+      });
+    });
+
     it("merges metadata shallowly and deletes keys set to null", async () => {
       await callTool(update, {
         taskId: "1",
@@ -595,6 +612,45 @@ describe("task-tracker", () => {
       expect(stored?.status).toBe("pending");
       expect(stored?.metadata).toEqual({ changedBy: "guard" });
       expect((result.body.task as Record<string, unknown> | undefined)?.revision).toBeUndefined();
+    });
+
+    it("appends a verification nudge when the main actor closes 3+ tasks without a verification step", async () => {
+      await callTool(create, { subject: "Second", description: "second task" });
+      await callTool(create, { subject: "Third", description: "third task" });
+
+      await callTool(update, { taskId: "1", status: "completed" });
+      await callTool(update, { taskId: "2", status: "completed" });
+      const result = await callTool(update, { taskId: "3", status: "completed" });
+
+      expect(result.body.verificationNudgeNeeded).toBe(true);
+      expect(result.body.message).toContain("Run the verifier");
+    });
+
+    it("does not append the verification nudge for subagent actors", async () => {
+      await callTool(create, { subject: "Second", description: "second task" });
+      await callTool(create, { subject: "Third", description: "third task" });
+
+      await callTool(update, {
+        taskId: "1",
+        status: "completed",
+        [TASK_ACTOR_KIND_ARG]: "subagent",
+        [TASK_ACTOR_NAME_ARG]: "worker-alpha",
+      });
+      await callTool(update, {
+        taskId: "2",
+        status: "completed",
+        [TASK_ACTOR_KIND_ARG]: "subagent",
+        [TASK_ACTOR_NAME_ARG]: "worker-alpha",
+      });
+      const result = await callTool(update, {
+        taskId: "3",
+        status: "completed",
+        [TASK_ACTOR_KIND_ARG]: "subagent",
+        [TASK_ACTOR_NAME_ARG]: "worker-alpha",
+      });
+
+      expect(result.body.verificationNudgeNeeded).toBeUndefined();
+      expect(String(result.body.message)).not.toContain("Run the verifier");
     });
   });
 

--- a/runtime/src/tools/system/task-tracker.ts
+++ b/runtime/src/tools/system/task-tracker.ts
@@ -39,6 +39,8 @@ const MAX_OUTPUT_MAX_BYTES = 512 * 1024;
  * into task tools.
  */
 export const TASK_LIST_ARG = "__agencTaskListId";
+export const TASK_ACTOR_KIND_ARG = "__agencTaskActorKind";
+export const TASK_ACTOR_NAME_ARG = "__agencTaskActorName";
 
 /**
  * Default task list id used when the gateway has not injected a
@@ -298,6 +300,13 @@ export interface TaskTrackerToolOptions {
   readonly onTaskAccessEvent?: (
     event: TaskTrackerAccessNotification,
   ) => void | Promise<void>;
+  readonly resolveActingOwner?: (params: {
+    readonly listId: string;
+    readonly args: Record<string, unknown>;
+    readonly task: Task;
+    readonly actorKind: "main" | "subagent";
+    readonly actorName?: string;
+  }) => string | undefined | Promise<string | undefined>;
 }
 
 interface TaskStoreOptions {
@@ -501,6 +510,30 @@ function resolveListId(args: Record<string, unknown>): string {
     return value;
   }
   return DEFAULT_TASK_LIST_ID;
+}
+
+function resolveTaskActor(
+  args: Record<string, unknown>,
+): { readonly kind: "main" | "subagent"; readonly name?: string } {
+  const kind = args[TASK_ACTOR_KIND_ARG] === "subagent" ? "subagent" : "main";
+  const name = asNonEmptyString(args[TASK_ACTOR_NAME_ARG]);
+  return name ? { kind, name } : { kind };
+}
+
+function shouldEmitVerificationNudge(params: {
+  readonly tasks: readonly Task[];
+  readonly actorKind: "main" | "subagent";
+}): boolean {
+  if (params.actorKind !== "main" || params.tasks.length < 3) {
+    return false;
+  }
+  if (!params.tasks.every((task) => task.status === "completed")) {
+    return false;
+  }
+  return !params.tasks.some((task) => {
+    const runtimeMetadata = normalizeRequestTaskRuntimeMetadata(task.metadata);
+    return runtimeMetadata.verification || /verif/i.test(task.subject);
+  });
 }
 
 function errorResult(message: string): ToolResult {
@@ -1973,6 +2006,7 @@ export function createTaskTrackerTools(
       const taskId = asNonEmptyString(args.taskId);
       if (!taskId) return errorResult("taskId must be a non-empty string");
       const listId = resolveListId(args);
+      const actor = resolveTaskActor(args);
       const patch: TaskUpdatePatch = {};
 
       if (args.status !== undefined) {
@@ -2032,6 +2066,25 @@ export function createTaskTrackerTools(
       const current = await taskStore.readTaskState(listId, taskId);
       if (!current) return errorResult(`task ${taskId} not found`);
 
+      if (
+        patch.status === "in_progress" &&
+        patch.owner === undefined &&
+        current.task.owner === undefined
+      ) {
+        const autoOwner =
+          (await options.resolveActingOwner?.({
+            listId,
+            args,
+            task: current.task,
+            actorKind: actor.kind,
+            actorName: actor.name,
+          })) ??
+          (actor.kind === "subagent" ? actor.name : undefined);
+        if (autoOwner) {
+          patch.owner = autoOwner;
+        }
+      }
+
       const isTransitioningToCompleted =
         patch.status === "completed" && current.task.status !== "completed";
       const shouldGuardCompletion =
@@ -2074,10 +2127,21 @@ export function createTaskTrackerTools(
         isTransitioningToCompleted ? current.revision : undefined,
       );
       if (!task) return errorResult(`task ${taskId} not found`);
+      const allTasks =
+        patch.status === "completed"
+          ? await taskStore.listTasks(listId)
+          : [];
+      const verificationNudgeNeeded = shouldEmitVerificationNudge({
+        tasks: allTasks,
+        actorKind: actor.kind,
+      });
       return okResult({
-        message: `Task #${task.id} updated`,
+        message: verificationNudgeNeeded
+          ? `Task #${task.id} updated\n\nNOTE: You just closed out 3+ tasks and none of them was a verification step. Run the verifier before writing the final summary.`
+          : `Task #${task.id} updated`,
         task: summarizeTask(task),
         taskRuntime: taskRuntime(task),
+        ...(verificationNudgeNeeded ? { verificationNudgeNeeded: true } : {}),
       });
     },
   };

--- a/runtime/src/workflow/completion-state.test.ts
+++ b/runtime/src/workflow/completion-state.test.ts
@@ -36,11 +36,6 @@ describe("completion-state", () => {
             isError: false,
           },
         ],
-        completionContract: {
-          taskClass: "scaffold_allowed",
-          placeholdersAllowed: true,
-          partialCompletionAllowed: true,
-        },
       }),
     ).toBe("partial");
   });
@@ -58,60 +53,47 @@ describe("completion-state", () => {
             isError: false,
           },
         ],
-        verificationContract: {
-          workspaceRoot: "/workspace",
-          targetArtifacts: ["/workspace/src/shell.c"],
-          acceptanceCriteria: [
-            "Shell job-control behavior is verified with scenario coverage",
-          ],
-          completionContract: {
-            taskClass: "artifact_only",
-            placeholdersAllowed: false,
-            partialCompletionAllowed: false,
-          },
-        },
+        requiresVerification: true,
+        verificationSatisfied: false,
       }),
     ).toBe("partial");
   });
 
-  it("uses the same completion semantics for planner and direct implementation when the workflow contract matches", () => {
+  it("uses the same completion semantics for planner and direct implementation when verification is not required", () => {
     const sharedInput = {
       stopReason: "completed",
       toolCalls: [
         {
           name: "system.writeFile",
           args: { path: "/workspace/src/main.c" },
-          result: JSON.stringify({ ok: true }),
-          isError: false,
-        },
-      ],
-      verificationContract: {
-        workspaceRoot: "/workspace",
-        targetArtifacts: ["/workspace/src/main.c"],
-        verificationMode: "mutation_required" as const,
-        completionContract: {
-          taskClass: "artifact_only" as const,
-          placeholdersAllowed: false,
-          partialCompletionAllowed: false,
-          placeholderTaxonomy: "implementation" as const,
-        },
-      },
-      verifier: {
-        performed: false,
-        overall: "skipped" as const,
-      },
+            result: JSON.stringify({ ok: true }),
+            isError: false,
+          },
+        ],
+      requiresVerification: false,
+      verificationSatisfied: false,
     };
 
     expect(resolveWorkflowCompletionState(sharedInput)).toBe("completed");
+    expect(resolveWorkflowCompletionState({ ...sharedInput })).toBe("completed");
+  });
+
+  it("returns needs_verification when an implementation turn still requires verifier confirmation", () => {
     expect(
       resolveWorkflowCompletionState({
-        ...sharedInput,
-        verificationContract: {
-          ...sharedInput.verificationContract,
-          stepKind: "delegated_write",
-        },
+        stopReason: "completed",
+        toolCalls: [
+          {
+            name: "system.writeFile",
+            args: { path: "/workspace/src/runner.js" },
+            result: JSON.stringify({ ok: true }),
+            isError: false,
+          },
+        ],
+        requiresVerification: true,
+        verificationSatisfied: false,
       }),
-    ).toBe("completed");
+    ).toBe("needs_verification");
   });
 
   it("keeps behavior-required work completed when verification is skipped on a normal turn", () => {
@@ -126,21 +108,8 @@ describe("completion-state", () => {
             isError: false,
           },
         ],
-        verificationContract: {
-          workspaceRoot: "/workspace",
-          targetArtifacts: ["/workspace/src/runner.js"],
-          acceptanceCriteria: ["Behavior verification must pass before completion."],
-          completionContract: {
-            taskClass: "behavior_required",
-            placeholdersAllowed: false,
-            partialCompletionAllowed: false,
-            placeholderTaxonomy: "implementation",
-          },
-        },
-        verifier: {
-          performed: false,
-          overall: "skipped",
-        },
+        requiresVerification: false,
+        verificationSatisfied: false,
       }),
     ).toBe("completed");
   });
@@ -157,10 +126,8 @@ describe("completion-state", () => {
             isError: false,
           },
         ],
-        verifier: {
-          performed: false,
-          overall: "skipped",
-        },
+        requiresVerification: false,
+        verificationSatisfied: false,
       }),
     ).toBe("completed");
   });
@@ -183,28 +150,8 @@ describe("completion-state", () => {
             isError: false,
           },
         ],
-        verificationContract: {
-          workspaceRoot: "/workspace",
-          targetArtifacts: ["/workspace/src/main.c"],
-          verificationMode: "mutation_required",
-          requestCompletion: {
-            requiredMilestones: [
-              { id: "phase_1_impl", description: "Implement phase 1" },
-              { id: "phase_2_verify", description: "Verify phase 2" },
-            ],
-          },
-          completionContract: {
-            taskClass: "build_required",
-            placeholdersAllowed: false,
-            partialCompletionAllowed: false,
-            placeholderTaxonomy: "implementation",
-          },
-        },
-        completedRequestMilestoneIds: ["phase_1_impl"],
-        verifier: {
-          performed: true,
-          overall: "pass",
-        },
+        requiresVerification: true,
+        verificationSatisfied: true,
       }),
     ).toBe("completed");
   });
@@ -221,10 +168,8 @@ describe("completion-state", () => {
             isError: false,
           },
         ],
-        verifier: {
-          performed: true,
-          overall: "fail",
-        },
+        requiresVerification: false,
+        verificationSatisfied: false,
       }),
     ).toBe("completed");
   });

--- a/runtime/src/workflow/completion-state.ts
+++ b/runtime/src/workflow/completion-state.ts
@@ -1,6 +1,5 @@
 import { didToolCallFail } from "../llm/chat-executor-tool-utils.js";
 import type { DelegationOutputValidationCode } from "../utils/delegation-validation.js";
-import type { WorkflowVerificationContract } from "./verification-obligations.js";
 
 export type WorkflowCompletionState =
   | "completed"
@@ -36,10 +35,9 @@ export function resolvePipelineCompletionState(input: {
 export function resolveWorkflowCompletionState(input: {
   readonly stopReason: string;
   readonly toolCalls: readonly CompletionStateToolCall[];
-  readonly verificationContract?: WorkflowVerificationContract;
-  readonly completedRequestMilestoneIds?: readonly string[];
   readonly validationCode?: DelegationOutputValidationCode;
-  readonly verifier?: PlannerVerificationSnapshot;
+  readonly requiresVerification?: boolean;
+  readonly verificationSatisfied?: boolean;
 }): WorkflowCompletionState {
   const successfulToolCalls = input.toolCalls.filter(
     (toolCall) => !didToolCallFail(toolCall.isError, toolCall.result),
@@ -47,6 +45,9 @@ export function resolveWorkflowCompletionState(input: {
   const hasProgress = successfulToolCalls.length > 0;
 
   if (input.stopReason === "completed") {
+    if (input.requiresVerification && !input.verificationSatisfied) {
+      return "needs_verification";
+    }
     return "completed";
   }
 

--- a/runtime/tests/regression/orchestration/context-compaction.integration.test.ts
+++ b/runtime/tests/regression/orchestration/context-compaction.integration.test.ts
@@ -197,19 +197,14 @@ describe("context compaction integration", () => {
     const messages = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as
       | LLMMessage[]
       | undefined;
-    const artifactContextMessage = messages?.find(
-      (message) =>
-        message.role === "system" &&
-        typeof message.content === "string" &&
-        message.content.includes("Compacted artifact context:"),
-    );
-    expect(artifactContextMessage).toBeDefined();
-    expect(String(artifactContextMessage?.content)).toContain("PLAN.md");
-    expect(String(artifactContextMessage?.content)).toContain("parser.test.ts");
-    expect(String(artifactContextMessage?.content).split("\n").length).toBeLessThan(
-      resumed.history
-        .map((message) => String(message.content).split("\n").length)
-        .reduce((sum, count) => sum + count, 0),
-    );
+    expect(messages).toBeDefined();
+    expect(
+      messages?.some(
+        (message) =>
+          message.role === "user" &&
+          typeof message.content === "string" &&
+          message.content.includes("Update AGENC.md from the compacted shell context"),
+      ),
+    ).toBe(true);
   });
 });

--- a/runtime/tests/tools/system/filesystem.integration.test.ts
+++ b/runtime/tests/tools/system/filesystem.integration.test.ts
@@ -118,9 +118,19 @@ describe('Functional: system.appendFile', () => {
     const append = findTool(tools, 'system.appendFile');
     const read = findTool(tools, 'system.readFile');
     const filePath = join(sandbox, 'append.txt');
+    const sessionId = 'append-session';
 
-    await write.execute({ path: filePath, content: 'line1\n' });
-    await append.execute({ path: filePath, content: 'line2\n' });
+    await write.execute({
+      path: filePath,
+      content: 'line1\n',
+      __agencSessionId: sessionId,
+    });
+    await read.execute({ path: filePath, __agencSessionId: sessionId });
+    await append.execute({
+      path: filePath,
+      content: 'line2\n',
+      __agencSessionId: sessionId,
+    });
 
     const rr = await read.execute({ path: filePath });
     expect(parse(rr).content).toBe('line1\nline2\n');


### PR DESCRIPTION
## Summary
- move terminal ownership onto the tool loop and resolve completion state from explicit terminal data
- persist session replay state as compact-boundary snapshots with durable artifact/read-state rehydration
- tighten file mutation and shell write controls to require full-read state across runtime and desktop editor surfaces
- reduce runtime-owned task/verifier drift while keeping explicit verification gating

## Validation
- `npm exec vitest run runtime/src/workflow/completion-state.test.ts runtime/src/llm/chat-executor-request.test.ts runtime/src/llm/chat-executor.test.ts runtime/src/gateway/session.test.ts runtime/src/gateway/daemon-session-state.test.ts runtime/src/gateway/tool-handler-factory.test.ts runtime/src/channels/webchat/plugin.test.ts runtime/src/tools/system/filesystem.test.ts runtime/tests/tools/system/filesystem.integration.test.ts runtime/src/tools/system/bash.test.ts runtime/src/tools/system/task-tracker.test.ts runtime/tests/regression/orchestration/context-compaction.integration.test.ts runtime/src/eval/long-horizon-suite.test.ts`
- `npm run test --workspace=@tetsuo-ai/desktop-server`
- `./node_modules/.bin/tsc -p ./runtime/tsconfig.json --noEmit`
- `npm run build`
- `npm run test` (fails in unrelated runtime marketplace CLI suites; also surfaces unrelated `@tetsuo-ai/mcp` typecheck drift when running root `npm run typecheck`)

## Notes
- No parity claims are based on memory; the changes were audited against `../claude_code` before implementation.
- Techdebt report written to `.claude/notes/techdebt-2026-04-14.md`.