### PR TITLE
feat(runtime): harden transcript continuity

### DIFF
--- a/runtime/src/channels/webchat/plugin.ts
+++ b/runtime/src/channels/webchat/plugin.ts
@@ -46,8 +46,8 @@ import { safeStringify } from "../../tools/types.js";
 import { summarizeTracePayloadForPreview } from "../../utils/trace-payload-serialization.js";
 import {
   forkTranscript,
-  historyFromTranscript,
   loadTranscript,
+  recoverTranscriptHistory,
 } from "../../gateway/session-transcript.js";
 import type {
   WebChatHandler,
@@ -2650,8 +2650,8 @@ export class WebChatChannel
         () => undefined,
       );
       const transcriptHistory = transcript
-        ? transcriptMessagesToHistoryItems(
-            historyFromTranscript(transcript),
+          ? transcriptMessagesToHistoryItems(
+            recoverTranscriptHistory(transcript),
             options,
           )
         : [];

--- a/runtime/src/channels/webchat/plugin.ts
+++ b/runtime/src/channels/webchat/plugin.ts
@@ -41,8 +41,14 @@ import {
   type PersistedSessionReplayState,
 } from "../../gateway/daemon-session-state.js";
 import type { ActiveTaskContext } from "../../llm/turn-execution-contract-types.js";
+import type { LLMMessage } from "../../llm/types.js";
 import { safeStringify } from "../../tools/types.js";
 import { summarizeTracePayloadForPreview } from "../../utils/trace-payload-serialization.js";
+import {
+  forkTranscript,
+  historyFromTranscript,
+  loadTranscript,
+} from "../../gateway/session-transcript.js";
 import type {
   WebChatHandler,
   WebChatDeps,
@@ -84,6 +90,43 @@ function compactPreview(content: string, maxChars = 140): string | undefined {
   const compact = content.replace(/\s+/g, " ").trim();
   if (compact.length === 0) return undefined;
   return compact.slice(0, maxChars);
+}
+
+function stringifyHistoryContent(content: LLMMessage["content"]): string {
+  return typeof content === "string" ? content : JSON.stringify(content);
+}
+
+function transcriptMessageToHistoryItem(
+  message: LLMMessage,
+): SessionHistoryItem | undefined {
+  if (message.role !== "user" && message.role !== "assistant" && message.role !== "tool") {
+    return undefined;
+  }
+  return {
+    content: stringifyHistoryContent(message.content),
+    sender:
+      message.role === "assistant"
+        ? "agent"
+        : message.role === "tool"
+          ? "tool"
+          : "user",
+    timestamp: Date.now(),
+    ...(message.toolName ? { toolName: message.toolName } : {}),
+  };
+}
+
+function transcriptMessagesToHistoryItems(
+  messages: readonly LLMMessage[],
+  options?: {
+    includeTools?: boolean;
+  },
+): SessionHistoryItem[] {
+  return messages
+    .map((message) => transcriptMessageToHistoryItem(message))
+    .filter((item): item is SessionHistoryItem => {
+      if (!item) return false;
+      return options?.includeTools === true || item.sender !== "tool";
+    });
 }
 
 async function resolveGitSnapshot(
@@ -2104,15 +2147,29 @@ export class WebChatChannel
     );
 
     await Promise.resolve(this.deps.hydrateSessionContext?.(targetSessionId));
+    const continuityHistory = await this.loadSessionHistory(
+      targetSessionId,
+      undefined,
+      {
+        includeTools: false,
+      },
+    );
     const replayContext = this.deps.memoryBackend
       ? await loadPersistedSessionReplayContext(
           this.deps.memoryBackend,
           targetSessionId,
         )
       : undefined;
+    const persistedMessageCount = persisted?.messageCount ?? 0;
+    const resolvedMessageCount =
+      persistedMessageCount > 0
+        ? persistedMessageCount
+        : continuityHistory.length > 0
+          ? continuityHistory.length
+          : replayContext?.history.length ?? 0;
     return {
       sessionId: targetSessionId,
-      messageCount: replayContext?.history.length ?? 0,
+      messageCount: resolvedMessageCount,
       ...(workspaceRoot ? { workspaceRoot } : {}),
       ...(replayContext?.state?.snapshot.shellProfile
         ? { shellProfile: replayContext.state.snapshot.shellProfile }
@@ -2255,12 +2312,16 @@ export class WebChatChannel
           session.sessionId,
         )
       : undefined;
+    const continuityHistory = await this.loadSessionHistory(session.sessionId, undefined, {
+      includeTools: false,
+    });
     const workspaceRoot = session.metadata?.workspaceRoot;
     const { repoRoot, branch, head } = await resolveGitSnapshot(workspaceRoot);
     const runtimeStatus = runtimeState?.snapshot.runtimeContractStatusSnapshot as
       | unknown
       | undefined;
     const pendingApprovalCount = this.countPendingApprovals(session.sessionId);
+    const storedMessageCount = session.messageCount;
     const preview =
       runtimeState?.snapshot.workflowState?.objective ??
       session.label ??
@@ -2271,7 +2332,12 @@ export class WebChatChannel
       sessionId: session.sessionId,
       label: session.label,
       preview: compactPreview(preview) ?? session.label,
-      messageCount: session.messageCount,
+      messageCount:
+        storedMessageCount > 0
+          ? storedMessageCount
+          : continuityHistory.length > 0
+            ? continuityHistory.length
+            : 0,
       createdAt: session.createdAt,
       updatedAt: session.updatedAt,
       lastActiveAt: session.lastActiveAt,
@@ -2279,7 +2345,12 @@ export class WebChatChannel
       resumabilityState: this.resolveResumabilityState({
         connected,
         workspaceRoot,
-        messageCount: session.messageCount,
+        messageCount:
+          storedMessageCount > 0
+            ? storedMessageCount
+            : continuityHistory.length > 0
+              ? continuityHistory.length
+              : 0,
         runtimeState,
       }),
       shellProfile: runtimeState?.snapshot.shellProfile ?? "general",
@@ -2458,7 +2529,18 @@ export class WebChatChannel
       }
     }
 
-    if (!forkSource && this.deps.memoryBackend) {
+    if (this.deps.memoryBackend) {
+      const forkedTranscript = await forkTranscript(
+        this.deps.memoryBackend,
+        sourceSessionId,
+        targetSessionId,
+      );
+      if (forkedTranscript) {
+        forkSource = "history";
+      }
+    }
+
+    if (this.deps.memoryBackend) {
       const forkedRuntimeState = await forkSessionReplayState(
         this.deps.memoryBackend,
         {
@@ -2467,10 +2549,10 @@ export class WebChatChannel
           ...(params?.shellProfile ? { shellProfile: params.shellProfile } : {}),
           ...(params?.objective
             ? { workflowState: { objective: params.objective } }
-            : {}),
+          : {}),
         },
       );
-      if (forkedRuntimeState) {
+      if (forkedRuntimeState && !forkSource) {
         forkSource = "runtime_state";
       }
     }
@@ -2564,6 +2646,54 @@ export class WebChatChannel
     },
   ): Promise<SessionHistoryItem[]> {
     if (this.deps.memoryBackend) {
+      const transcript = await loadTranscript(this.deps.memoryBackend, sessionId).catch(
+        () => undefined,
+      );
+      const transcriptHistory = transcript
+        ? transcriptMessagesToHistoryItems(
+            historyFromTranscript(transcript),
+            options,
+          )
+        : [];
+      if (transcriptHistory.length > 0) {
+        const nonToolHistory = transcriptHistory
+          .filter((entry) => entry.sender !== "tool")
+          .map((entry) => ({
+            content: entry.content,
+            sender: entry.sender === "agent" ? ("agent" as const) : ("user" as const),
+            timestamp: entry.timestamp,
+          }));
+        if (nonToolHistory.length > 0) {
+          this.sessionHistory.set(sessionId, nonToolHistory);
+        }
+        return typeof limit === "number" && limit > 0
+          ? transcriptHistory.slice(-limit)
+          : transcriptHistory;
+      }
+
+      const replayContext = await loadPersistedSessionReplayContext(
+        this.deps.memoryBackend,
+        sessionId,
+      ).catch(() => undefined);
+      const replayHistory = replayContext
+        ? transcriptMessagesToHistoryItems(replayContext.history, options)
+        : [];
+      if (replayHistory.length > 0) {
+        const nonToolHistory = replayHistory
+          .filter((entry) => entry.sender !== "tool")
+          .map((entry) => ({
+            content: entry.content,
+            sender: entry.sender === "agent" ? ("agent" as const) : ("user" as const),
+            timestamp: entry.timestamp,
+          }));
+        if (nonToolHistory.length > 0) {
+          this.sessionHistory.set(sessionId, nonToolHistory);
+        }
+        return typeof limit === "number" && limit > 0
+          ? replayHistory.slice(-limit)
+          : replayHistory;
+      }
+
       const entries = await this.deps.memoryBackend.getThread(sessionId, limit);
       const history = entries
         .filter((entry) =>

--- a/runtime/src/gateway/background-run-operator.ts
+++ b/runtime/src/gateway/background-run-operator.ts
@@ -14,9 +14,9 @@ import type {
   BackgroundRunBudgetState,
   BackgroundRunCompactionState,
   BackgroundRunContract,
+  BackgroundRunLastWakeReason,
   BackgroundRunObservedTarget,
   BackgroundRunState,
-  BackgroundRunWakeReason,
   BackgroundRunWatchRegistration,
 } from "./background-run-store.js";
 import type { PolicyEvaluationScope } from "../policy/types.js";
@@ -77,7 +77,7 @@ export interface BackgroundRunOperatorSummary {
   readonly fenceToken: number;
   readonly lastUserUpdate?: string;
   readonly lastToolEvidence?: string;
-  readonly lastWakeReason?: BackgroundRunWakeReason;
+  readonly lastWakeReason?: BackgroundRunLastWakeReason;
   readonly carryForwardSummary?: string;
   readonly blockerSummary?: string;
   readonly completionState?: WorkflowProgressSnapshot["completionState"];
@@ -216,7 +216,7 @@ export function buildBackgroundRunExplanation(params: {
   readonly approval: BackgroundRunApprovalState;
   readonly nextCheckAt?: number;
   readonly nextHeartbeatAt?: number;
-  readonly lastWakeReason?: BackgroundRunWakeReason;
+  readonly lastWakeReason?: BackgroundRunLastWakeReason;
   readonly requiresUserStop: boolean;
   readonly now?: number;
 }): { currentPhase: string; explanation: string; unsafeToContinue: boolean } {

--- a/runtime/src/gateway/background-run-store.test.ts
+++ b/runtime/src/gateway/background-run-store.test.ts
@@ -153,6 +153,54 @@ describe("BackgroundRunStore", () => {
     expect(await store.listRuns()).toEqual([]);
   });
 
+  it("rebuilds run history from the durable conversation transcript", async () => {
+    const backend = new InMemoryBackend();
+    const store = new BackgroundRunStore({ memoryBackend: backend });
+    const run = makeRun({
+      internalHistory: [
+        { role: "user", content: "Check the server status." },
+        { role: "assistant", content: "I am checking the server status now.", phase: "commentary" },
+      ],
+    });
+
+    await store.saveRun(run);
+    await backend.set("background-run:session:session-1", {
+      ...run,
+      internalHistory: [],
+    });
+
+    await expect(store.loadRun(run.sessionId)).resolves.toMatchObject({
+      internalHistory: run.internalHistory,
+    });
+  });
+
+  it("forks durable conversation history between run sessions", async () => {
+    const backend = new InMemoryBackend();
+    const store = new BackgroundRunStore({ memoryBackend: backend });
+
+    await store.seedConversationHistory("source", [
+      { role: "user", content: "Monitor the worker." },
+      { role: "assistant", content: "Monitoring started.", phase: "commentary" },
+    ]);
+
+    expect(await store.forkConversationHistory("source", "target")).toBe(true);
+
+    await store.saveRun(
+      makeRun({
+        id: "bg-target",
+        sessionId: "target",
+        internalHistory: [],
+      }),
+    );
+
+    await expect(store.loadRun("target")).resolves.toMatchObject({
+      internalHistory: [
+        { role: "user", content: "Monitor the worker." },
+        { role: "assistant", content: "Monitoring started.", phase: "commentary" },
+      ],
+    });
+  });
+
   it("preserves canonical delegated scope in durable lineage records", async () => {
     const backend = new InMemoryBackend();
     const store = new BackgroundRunStore({ memoryBackend: backend });

--- a/runtime/src/gateway/background-run-store.ts
+++ b/runtime/src/gateway/background-run-store.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { LLMMessage } from "../llm/types.js";
 import type { MemoryBackend, MemoryEntry } from "../memory/types.js";
 import type { PolicyEvaluationScope } from "../policy/types.js";
@@ -12,6 +13,16 @@ import {
   isSubrunRedundancyPattern,
   isSubrunRole,
 } from "./subrun-contract.js";
+import {
+  appendTranscriptBatch,
+  backgroundRunTranscriptStreamId,
+  createTranscriptHistorySnapshotEvent,
+  createTranscriptMessageEvent,
+  deleteTranscript,
+  forkTranscript,
+  loadTranscript,
+  recoverTranscriptHistory,
+} from "./session-transcript.js";
 import {
   coerceSessionShellProfile,
   DEFAULT_SESSION_SHELL_PROFILE,
@@ -118,6 +129,7 @@ export interface BackgroundRunManagedProcessLaunchSpec {
 }
 
 export type BackgroundRunWakeReason = AgentRunWakeReason;
+export type BackgroundRunLastWakeReason = BackgroundRunWakeReason | "resume";
 
 export interface BackgroundRunSignal {
   readonly id: string;
@@ -322,7 +334,7 @@ export interface BackgroundRunRecentSnapshot {
   readonly nextHeartbeatAt?: number;
   readonly lastUserUpdate?: string;
   readonly lastToolEvidence?: string;
-  readonly lastWakeReason?: BackgroundRunWakeReason;
+  readonly lastWakeReason?: BackgroundRunLastWakeReason;
   readonly pendingSignals: number;
   readonly carryForwardSummary?: string;
   readonly blockerSummary?: string;
@@ -354,7 +366,7 @@ export interface PersistedBackgroundRun {
   readonly lastUserUpdate?: string;
   readonly lastToolEvidence?: string;
   readonly lastHeartbeatContent?: string;
-  readonly lastWakeReason?: BackgroundRunWakeReason;
+  readonly lastWakeReason?: BackgroundRunLastWakeReason;
   readonly completionProgress?: WorkflowProgressSnapshot;
   readonly carryForward?: BackgroundRunCarryForwardState;
   readonly blocker?: BackgroundRunBlockerState;
@@ -593,6 +605,16 @@ interface BackgroundRunStoreConfig {
 
 function cloneJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function isBackgroundRunLastWakeReason(
+  value: unknown,
+): value is BackgroundRunLastWakeReason {
+  return value === "resume" || isAgentRunWakeReason(value);
+}
+
+function digestHistory(history: readonly LLMMessage[]): string {
+  return createHash("sha256").update(JSON.stringify(history)).digest("hex");
 }
 
 function backgroundRunKey(sessionId: string): string {
@@ -1703,7 +1725,7 @@ function coerceRecentSnapshot(
         ? raw.lastToolEvidence
         : undefined,
     lastWakeReason:
-      isAgentRunWakeReason(raw.lastWakeReason)
+      isBackgroundRunLastWakeReason(raw.lastWakeReason)
         ? raw.lastWakeReason
         : undefined,
     pendingSignals: raw.pendingSignals,
@@ -2229,7 +2251,7 @@ function coerceRun(value: unknown): PersistedBackgroundRun | undefined {
         ? raw.lastHeartbeatContent
         : undefined,
     lastWakeReason:
-      isAgentRunWakeReason(raw.lastWakeReason)
+      isBackgroundRunLastWakeReason(raw.lastWakeReason)
         ? raw.lastWakeReason
         : undefined,
     completionProgress: core.completionProgress,
@@ -2285,6 +2307,69 @@ export class BackgroundRunStore {
     return this.memoryBackend.get(backgroundRunKey(sessionId));
   }
 
+  private async loadConversationHistory(
+    sessionId: string,
+  ): Promise<readonly LLMMessage[]> {
+    const transcript = await loadTranscript(
+      this.memoryBackend,
+      backgroundRunTranscriptStreamId(sessionId),
+    );
+    return recoverTranscriptHistory(transcript);
+  }
+
+  private async syncConversationHistory(params: {
+    readonly sessionId: string;
+    readonly history: readonly LLMMessage[];
+    readonly reason: "save_run" | "save_checkpoint" | "seed" | "fork";
+  }): Promise<void> {
+    const current = await this.loadConversationHistory(params.sessionId);
+    const desired = cloneJson(params.history);
+    if (current.length > 0 && desired.length === 0) {
+      return;
+    }
+    if (JSON.stringify(current) === JSON.stringify(desired)) {
+      return;
+    }
+
+    const currentLength = current.length;
+    const incremental =
+      currentLength > 0 &&
+      desired.length >= currentLength &&
+      JSON.stringify(desired.slice(0, currentLength)) === JSON.stringify(current);
+    if (incremental) {
+      const tail = desired.slice(currentLength);
+      if (tail.length > 0) {
+        await appendTranscriptBatch(
+          this.memoryBackend,
+          backgroundRunTranscriptStreamId(params.sessionId),
+          tail.map((message, index) =>
+            createTranscriptMessageEvent({
+              surface: "background",
+              message,
+              dedupeKey:
+                `background:${params.sessionId}:${currentLength + index}:${message.role}`,
+            })
+          ),
+        );
+      }
+      return;
+    }
+
+    await appendTranscriptBatch(
+      this.memoryBackend,
+      backgroundRunTranscriptStreamId(params.sessionId),
+      [
+        createTranscriptHistorySnapshotEvent({
+          surface: "background",
+          history: desired,
+          reason: params.reason === "fork" ? "fork" : "compaction",
+          dedupeKey:
+            `background:snapshot:${params.sessionId}:${params.reason}:${digestHistory(desired).slice(0, 16)}`,
+        }),
+      ],
+    );
+  }
+
   private async loadRawWakeQueue(sessionId: string): Promise<unknown> {
     return this.memoryBackend.get(backgroundRunWakeQueueKey(sessionId));
   }
@@ -2324,6 +2409,11 @@ export class BackgroundRunStore {
       throw new Error("Invalid persisted BackgroundRun record");
     }
     await this.queue.run(run.sessionId, async () => {
+      await this.syncConversationHistory({
+        sessionId: run.sessionId,
+        history: validated.internalHistory,
+        reason: "save_run",
+      });
       const current = await this.loadRun(run.sessionId);
       if (current && validated.leaseOwnerId !== undefined) {
         if (current.fenceToken > validated.fenceToken) {
@@ -2363,7 +2453,15 @@ export class BackgroundRunStore {
       }
       return undefined;
     }
-    return run;
+    if (!run) return undefined;
+    const transcriptHistory = await this.loadConversationHistory(sessionId);
+    if (transcriptHistory.length === 0) {
+      return run;
+    }
+    return {
+      ...run,
+      internalHistory: transcriptHistory,
+    };
   }
 
   async deleteRun(sessionId: string): Promise<void> {
@@ -2414,6 +2512,11 @@ export class BackgroundRunStore {
       throw new Error("Invalid BackgroundRun checkpoint");
     }
     await this.queue.run(run.sessionId, async () => {
+      await this.syncConversationHistory({
+        sessionId: run.sessionId,
+        history: validated.internalHistory,
+        reason: "save_checkpoint",
+      });
       await this.memoryBackend.set(
         backgroundRunCheckpointKey(run.sessionId),
         cloneJson(validated),
@@ -2423,7 +2526,16 @@ export class BackgroundRunStore {
 
   async loadCheckpoint(sessionId: string): Promise<PersistedBackgroundRun | undefined> {
     const value = await this.memoryBackend.get(backgroundRunCheckpointKey(sessionId));
-    return coerceRun(value);
+    const run = coerceRun(value);
+    if (!run) return undefined;
+    const transcriptHistory = await this.loadConversationHistory(sessionId);
+    if (transcriptHistory.length === 0) {
+      return run;
+    }
+    return {
+      ...run,
+      internalHistory: transcriptHistory,
+    };
   }
 
   async listCheckpoints(): Promise<readonly PersistedBackgroundRun[]> {
@@ -2444,6 +2556,71 @@ export class BackgroundRunStore {
   async deleteCheckpoint(sessionId: string): Promise<void> {
     await this.queue.run(sessionId, async () => {
       await this.memoryBackend.delete(backgroundRunCheckpointKey(sessionId));
+    });
+  }
+
+  async resetConversationHistory(sessionId: string): Promise<void> {
+    await this.queue.run(sessionId, async () => {
+      await deleteTranscript(
+        this.memoryBackend,
+        backgroundRunTranscriptStreamId(sessionId),
+      );
+    });
+  }
+
+  async seedConversationHistory(
+    sessionId: string,
+    history: readonly LLMMessage[],
+  ): Promise<void> {
+    await this.queue.run(sessionId, async () => {
+      await deleteTranscript(
+        this.memoryBackend,
+        backgroundRunTranscriptStreamId(sessionId),
+      );
+      await this.syncConversationHistory({
+        sessionId,
+        history,
+        reason: "seed",
+      });
+    });
+  }
+
+  async appendConversationTurn(
+    sessionId: string,
+    messages: readonly LLMMessage[],
+  ): Promise<void> {
+    if (messages.length === 0) return;
+    await this.queue.run(sessionId, async () => {
+      const current = await this.loadConversationHistory(sessionId);
+      await appendTranscriptBatch(
+        this.memoryBackend,
+        backgroundRunTranscriptStreamId(sessionId),
+        messages.map((message, index) =>
+          createTranscriptMessageEvent({
+            surface: "background",
+            message,
+            dedupeKey:
+              `background:${sessionId}:${current.length + index}:${message.role}`,
+          })
+        ),
+      );
+    });
+  }
+
+  async forkConversationHistory(
+    sourceSessionId: string,
+    targetSessionId: string,
+  ): Promise<boolean> {
+    return this.queue.run(targetSessionId, async () => {
+      await deleteTranscript(
+        this.memoryBackend,
+        backgroundRunTranscriptStreamId(targetSessionId),
+      );
+      return forkTranscript(
+        this.memoryBackend,
+        backgroundRunTranscriptStreamId(sourceSessionId),
+        backgroundRunTranscriptStreamId(targetSessionId),
+      );
     });
   }
 

--- a/runtime/src/gateway/background-run-supervisor-types.ts
+++ b/runtime/src/gateway/background-run-supervisor-types.ts
@@ -36,11 +36,11 @@ import {
   type BackgroundRunCarryForwardState,
   type BackgroundRunCompactionState,
   type BackgroundRunContract,
+  type BackgroundRunLastWakeReason,
   type BackgroundRunObservedTarget,
   type BackgroundRunRecentSnapshot,
   type BackgroundRunSignal,
   type BackgroundRunState,
-  type BackgroundRunWakeReason,
   type BackgroundRunWatchRegistration,
   type BackgroundRunWorkerPool,
   type PersistedBackgroundRun,
@@ -67,7 +67,7 @@ export interface BackgroundRunStatusSnapshot {
   readonly nextCheckAt?: number;
   readonly nextHeartbeatAt?: number;
   readonly lastUserUpdate?: string;
-  readonly lastWakeReason?: BackgroundRunWakeReason;
+  readonly lastWakeReason?: BackgroundRunLastWakeReason;
   readonly pendingSignals: number;
   readonly carryForwardSummary?: string;
   readonly blockerSummary?: string;
@@ -121,7 +121,7 @@ export interface ActiveBackgroundRun {
   lastUserUpdate?: string;
   lastToolEvidence?: string;
   lastHeartbeatContent?: string;
-  lastWakeReason?: BackgroundRunWakeReason;
+  lastWakeReason?: BackgroundRunLastWakeReason;
   completionProgress?: WorkflowProgressSnapshot;
   carryForward?: BackgroundRunCarryForwardState;
   blocker?: BackgroundRunBlockerState;

--- a/runtime/src/gateway/background-run-supervisor.test.ts
+++ b/runtime/src/gateway/background-run-supervisor.test.ts
@@ -1830,6 +1830,9 @@ describe("background-run-supervisor", () => {
     expect(execute).toHaveBeenCalledTimes(1);
 
     await supervisor.resumeRun("session-pause-resume");
+    expect(
+      supervisor.getStatusSnapshot("session-pause-resume")?.lastWakeReason,
+    ).toBe("resume");
     await vi.advanceTimersByTimeAsync(0);
 
     expect(execute).toHaveBeenCalledTimes(2);

--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -1716,6 +1716,7 @@ export class BackgroundRunSupervisor {
     }
     await this.cancelRun(params.sessionId, "Replaced by a new background run.");
     await this.runStore.deleteCheckpoint(params.sessionId);
+    await this.runStore.resetConversationHistory(params.sessionId);
     if (params.options?.lineage) {
       assertValidBackgroundRunLineage(params.options.lineage);
     }
@@ -1777,6 +1778,10 @@ export class BackgroundRunSupervisor {
       abortController: null,
     };
     run.policyScope = this.resolveRunPolicyScope(run);
+    await this.runStore.seedConversationHistory(
+      params.sessionId,
+      run.internalHistory,
+    );
 
     await this.persistRun(run, {
       type: "run_started",
@@ -2039,7 +2044,7 @@ export class BackgroundRunSupervisor {
       assertAgentRunStateTransition(persistedRun.state, "working", "resumeRun persisted");
       persistedRun.state = "working";
       persistedRun.updatedAt = this.now();
-      persistedRun.lastWakeReason = "user_input";
+      persistedRun.lastWakeReason = "resume";
       persistedRun.lastUserUpdate = truncate(reason, MAX_USER_UPDATE_CHARS);
       persistedRun.lastHeartbeatContent = undefined;
       persistedRun.preferredWorkerId = this.instanceId;
@@ -2070,7 +2075,7 @@ export class BackgroundRunSupervisor {
     assertAgentRunStateTransition(run.state, "working", "resumeRun");
     run.state = "working";
     run.updatedAt = this.now();
-    run.lastWakeReason = "user_input";
+    run.lastWakeReason = "resume";
     run.lastUserUpdate = truncate(reason, MAX_USER_UPDATE_CHARS);
     run.lastHeartbeatContent = undefined;
     clearRunBlockers(run);
@@ -2771,6 +2776,7 @@ export class BackgroundRunSupervisor {
       summary: truncate(`Background run retried: ${reason}`, 200),
       timestamp: now,
     });
+    await this.runStore.seedConversationHistory(sessionId, run.internalHistory);
     await this.runStore.saveCheckpoint(toPersistedRun(run));
     await this.publishUpdate(sessionId, run.lastUserUpdate);
     await this.enqueueDispatchForSession({
@@ -2951,6 +2957,7 @@ export class BackgroundRunSupervisor {
         sourceRunId: source.id,
       },
     });
+    await this.runStore.forkConversationHistory(sessionId, targetSessionId);
     await this.runStore.saveCheckpoint(toPersistedRun(run));
     await this.publishUpdate(targetSessionId, run.lastUserUpdate);
     await this.enqueueDispatchForSession({
@@ -3671,6 +3678,10 @@ export class BackgroundRunSupervisor {
 
         run.internalHistory = trimHistory([
           ...run.internalHistory,
+          { role: "user", content: actorPrompt },
+          { role: "assistant", content: actorResult.content, phase: "commentary" },
+        ]);
+        await this.runStore.appendConversationTurn(sessionId, [
           { role: "user", content: actorPrompt },
           { role: "assistant", content: actorResult.content, phase: "commentary" },
         ]);

--- a/runtime/src/gateway/daemon-text-channel-turn.ts
+++ b/runtime/src/gateway/daemon-text-channel-turn.ts
@@ -38,6 +38,12 @@ import {
   persistSessionRuntimeContractStatusSnapshot,
   persistSessionStatefulContinuation,
 } from "./daemon-session-state.js";
+import {
+  appendTranscriptBatch,
+  createTranscriptHistorySnapshotEvent,
+  createTranscriptMessageEvent,
+  createTranscriptMetadataProjectionEvent,
+} from "./session-transcript.js";
 import type { AgentDefinition } from "./agent-loader.js";
 import type { DelegationVerifierService } from "./delegation-runtime.js";
 import type { PersistentWorkerManager } from "./persistent-worker-manager.js";
@@ -172,6 +178,15 @@ export async function executeTextChannelTurn(
     msg.content,
     session.history,
   );
+  if (memoryBackend) {
+    await appendTranscriptBatch(memoryBackend, msg.sessionId, [
+      createTranscriptMessageEvent({
+        surface: "text",
+        message: { role: "user", content: msg.content },
+        dedupeKey: `${channelName}:user:${turnTraceId}`,
+      }),
+    ]);
+  }
   const profileAwareSystemPrompt = appendShellProfilePromptSection({
     systemPrompt,
     profile: resolveSessionShellProfile(session.metadata),
@@ -477,6 +492,31 @@ export async function executeTextChannelTurn(
     role: "assistant",
     content: result.content,
   });
+  if (memoryBackend) {
+    await appendTranscriptBatch(memoryBackend, msg.sessionId, [
+      createTranscriptMessageEvent({
+        surface: "text",
+        message: { role: "assistant", content: result.content },
+        dedupeKey: `${channelName}:assistant:${turnTraceId}`,
+      }),
+      createTranscriptMetadataProjectionEvent({
+        surface: "text",
+        key: "session.metadata",
+        value: session.metadata,
+        dedupeKey: `${channelName}:metadata:${turnTraceId}`,
+      }),
+      ...(result.compacted
+        ? [
+            createTranscriptHistorySnapshotEvent({
+              surface: "text",
+              history: session.history,
+              reason: "compaction",
+              dedupeKey: `${channelName}:snapshot:${turnTraceId}`,
+            }),
+          ]
+        : []),
+    ]);
+  }
 
   if (memoryBackend && persistToDaemonMemory) {
     const persistenceOptions = buildDaemonMemoryEntryOptions(

--- a/runtime/src/gateway/daemon-webchat-turn.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.ts
@@ -28,6 +28,12 @@ import {
   persistSessionStatefulContinuation,
   persistWebSessionRuntimeState,
 } from "./daemon-session-state.js";
+import {
+  appendTranscriptBatch,
+  createTranscriptHistorySnapshotEvent,
+  createTranscriptMessageEvent,
+  createTranscriptMetadataProjectionEvent,
+} from "./session-transcript.js";
 import { filterSystemPromptForToolRouting } from "./system-prompt-routing.js";
 import {
   buildRuntimeContractSessionTraceId,
@@ -180,6 +186,13 @@ export async function executeWebChatConversationTurn(
       msg.content,
       session.history,
     );
+    await appendTranscriptBatch(memoryBackend, msg.sessionId, [
+      createTranscriptMessageEvent({
+        surface: "webchat",
+        message: { role: "user", content: msg.content },
+        dedupeKey: `webchat:user:${turnTraceId}`,
+      }),
+    ]);
     const profileAwareSystemPrompt = appendShellProfilePromptSection({
       systemPrompt: getSystemPrompt(),
       profile: resolveSessionShellProfile(session.metadata),
@@ -509,6 +522,29 @@ export async function executeWebChatConversationTurn(
       role: "assistant",
       content: result.content,
     });
+    await appendTranscriptBatch(memoryBackend, msg.sessionId, [
+      createTranscriptMessageEvent({
+        surface: "webchat",
+        message: { role: "assistant", content: result.content },
+        dedupeKey: `webchat:assistant:${turnTraceId}`,
+      }),
+      createTranscriptMetadataProjectionEvent({
+        surface: "webchat",
+        key: "session.metadata",
+        value: session.metadata,
+        dedupeKey: `webchat:metadata:${turnTraceId}`,
+      }),
+      ...(result.compacted
+        ? [
+            createTranscriptHistorySnapshotEvent({
+              surface: "webchat",
+              history: session.history,
+              reason: "compaction",
+              dedupeKey: `webchat:snapshot:${turnTraceId}`,
+            }),
+          ]
+        : []),
+    ]);
 
     await webChat.send({
       sessionId: msg.sessionId,

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -106,6 +106,11 @@ import {
   createChatExecutor,
   buildPermissionRulesFromAllowDeny,
 } from "./chat-executor-factory.js";
+import {
+  ToolPermissionEvaluator,
+  evaluatorToCanUseTool,
+} from "../policy/tool-permission-evaluator.js";
+import { BudgetStateService } from "../policy/budget-state.js";
 import { resolveRuntimeContractFlags } from "../runtime-contract/flags.js";
 import {
   normalizeToolCallArguments,
@@ -169,8 +174,8 @@ import { createMemoryRetrievers } from "./memory-retriever-factory.js";
 import { createMemoryBackend } from "./memory-backend-factory.js";
 import {
   deleteTranscript,
-  historyFromTranscript,
   loadTranscript,
+  recoverTranscriptHistory,
 } from "./session-transcript.js";
 // loadWallet moved to ./daemon-tool-registry.ts and ./daemon-feature-wiring.ts
 import {
@@ -1518,6 +1523,19 @@ export class DaemonManager {
       logger: this.logger,
     });
     this._sessionIsolationManager = isolationManager;
+    const subAgentPermissionRules = buildPermissionRulesFromAllowDeny({
+      toolAllowList: config.policy?.toolAllowList,
+      toolDenyList: config.policy?.toolDenyList,
+    });
+    const subAgentCanUseTool =
+      subAgentPermissionRules.length > 0
+        ? evaluatorToCanUseTool(
+            new ToolPermissionEvaluator({
+              rules: subAgentPermissionRules,
+              budgetState: new BudgetStateService(),
+            }),
+          )
+        : undefined;
 
     this._subAgentManager = new SubAgentManager({
       createContext: async (sessionIdentity: SubAgentSessionIdentity) => {
@@ -1552,6 +1570,8 @@ export class DaemonManager {
       sessionCompactionThreshold: subAgentSessionCompactionThreshold,
       economicsMode: config.llm?.economicsMode ?? "enforce",
       onCompaction: this.handleCompaction,
+      ...(this._memoryBackend ? { memoryBackend: this._memoryBackend } : {}),
+      ...(subAgentCanUseTool ? { canUseTool: subAgentCanUseTool } : {}),
       resolveExecutionBudget: async ({ selectedProvider }) =>
         this.resolveProviderExecutionBudget(selectedProvider),
       resolveDefaultMaxToolRounds: () => this._defaultForegroundMaxToolRounds,
@@ -4148,7 +4168,7 @@ export class DaemonManager {
         return undefined;
       },
     );
-    const transcriptHistory = historyFromTranscript(transcript);
+    const transcriptHistory = recoverTranscriptHistory(transcript);
     const replayContext =
       transcriptHistory.length > 0
         ? undefined

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -167,6 +167,11 @@ import {
 import type { MemoryBackend } from "../memory/types.js";
 import { createMemoryRetrievers } from "./memory-retriever-factory.js";
 import { createMemoryBackend } from "./memory-backend-factory.js";
+import {
+  deleteTranscript,
+  historyFromTranscript,
+  loadTranscript,
+} from "./session-transcript.js";
 // loadWallet moved to ./daemon-tool-registry.ts and ./daemon-feature-wiring.ts
 import {
   clearWebSessionReplayState,
@@ -4093,6 +4098,12 @@ export class DaemonManager {
         error: toErrorMessage(error),
       });
     });
+    await deleteTranscript(memoryBackend, webSessionId).catch((error: unknown) => {
+      this.logger.debug("Failed to delete web session transcript", {
+        sessionId: webSessionId,
+        error: toErrorMessage(error),
+      });
+    });
     await clearWebSessionReplayState(memoryBackend, webSessionId).catch(
       (error: unknown) => {
         this.logger.debug("Failed to delete web session replay state", {
@@ -4128,19 +4139,33 @@ export class DaemonManager {
       scope: "dm",
       workspaceId: "default",
     });
-    const replayContext = await loadPersistedSessionReplayContext(
-      memoryBackend,
-      webSessionId,
-    ).catch((error) => {
-      this.logger.debug("Failed to hydrate web session from replay state", {
-        sessionId: webSessionId,
-        error: toErrorMessage(error),
-      });
-      return {
-        history: [],
-      };
-    });
-    const history = replayContext.history;
+    const transcript = await loadTranscript(memoryBackend, webSessionId).catch(
+      (error) => {
+        this.logger.debug("Failed to hydrate web session transcript", {
+          sessionId: webSessionId,
+          error: toErrorMessage(error),
+        });
+        return undefined;
+      },
+    );
+    const transcriptHistory = historyFromTranscript(transcript);
+    const replayContext =
+      transcriptHistory.length > 0
+        ? undefined
+        : await loadPersistedSessionReplayContext(
+            memoryBackend,
+            webSessionId,
+          ).catch((error) => {
+            this.logger.debug("Failed to hydrate web session from replay state", {
+              sessionId: webSessionId,
+              error: toErrorMessage(error),
+            });
+            return {
+              history: [],
+            };
+          });
+    const history =
+      transcriptHistory.length > 0 ? transcriptHistory : replayContext?.history ?? [];
     const historiesMatch =
       session.history.length === history.length &&
       session.history.every((message, index) => {

--- a/runtime/src/gateway/session-transcript.test.ts
+++ b/runtime/src/gateway/session-transcript.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { InMemoryBackend } from "../memory/in-memory/backend.js";
+import {
+  appendTranscriptBatch,
+  createTranscriptHistorySnapshotEvent,
+  createTranscriptMessageEvent,
+  createTranscriptMetadataProjectionEvent,
+  forkTranscript,
+  historyFromTranscript,
+  loadTranscript,
+} from "./session-transcript.js";
+
+describe("session transcript adapter", () => {
+  it("round-trips transcript events through transcript-capable backends", async () => {
+    const backend = new InMemoryBackend();
+
+    await appendTranscriptBatch(backend, "session-1", [
+      createTranscriptMessageEvent({
+        surface: "webchat",
+        message: { role: "user", content: "hello" },
+        dedupeKey: "user-1",
+      }),
+      createTranscriptMetadataProjectionEvent({
+        surface: "webchat",
+        key: "session.metadata",
+        value: { shellProfile: "general" },
+        dedupeKey: "meta-1",
+      }),
+      createTranscriptHistorySnapshotEvent({
+        surface: "webchat",
+        history: [
+          { role: "user", content: "hello" },
+          { role: "assistant", content: "hi" },
+        ],
+        reason: "compaction",
+        dedupeKey: "snapshot-1",
+      }),
+      createTranscriptMessageEvent({
+        surface: "webchat",
+        message: { role: "assistant", content: "post-compact" },
+        dedupeKey: "assistant-1",
+      }),
+    ]);
+
+    const transcript = await loadTranscript(backend, "session-1");
+    expect(transcript).toBeDefined();
+    expect(transcript?.events.map((event) => event.kind)).toEqual([
+      "message",
+      "metadata_projection",
+      "history_snapshot",
+      "message",
+    ]);
+    expect(historyFromTranscript(transcript)).toEqual([
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+      { role: "assistant", content: "post-compact" },
+    ]);
+  });
+
+  it("forks transcript streams without reusing event ids", async () => {
+    const backend = new InMemoryBackend();
+
+    await appendTranscriptBatch(backend, "source", [
+      createTranscriptMessageEvent({
+        surface: "text",
+        message: { role: "user", content: "fork me" },
+      }),
+    ]);
+
+    expect(await forkTranscript(backend, "source", "target")).toBe(true);
+
+    const source = await loadTranscript(backend, "source");
+    const target = await loadTranscript(backend, "target");
+    expect(historyFromTranscript(target)).toEqual(historyFromTranscript(source));
+    expect(target?.events[0]?.eventId).not.toBe(source?.events[0]?.eventId);
+  });
+});

--- a/runtime/src/gateway/session-transcript.ts
+++ b/runtime/src/gateway/session-transcript.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { LLMMessage } from "../llm/types.js";
+import { repairToolTurnSequence } from "../llm/tool-turn-validator.js";
 import type {
   MemoryBackend,
   TranscriptCapableMemoryBackend,
@@ -11,6 +12,8 @@ import type {
 } from "../memory/types.js";
 
 const TRANSCRIPT_KV_PREFIX = "transcript:v1:";
+const SUBAGENT_TRANSCRIPT_PREFIX = "subagent-session:";
+const BACKGROUND_RUN_TRANSCRIPT_PREFIX = "background-run-session:";
 
 export type SessionTranscriptEvent =
   | SessionTranscriptMessageEvent
@@ -74,6 +77,98 @@ function cloneEvent(event: SessionTranscriptEvent): SessionTranscriptEvent {
 
 function cloneUnknown<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function isWhitespaceOnlyMessage(message: LLMMessage): boolean {
+  if (typeof message.content === "string") {
+    return message.content.trim().length === 0;
+  }
+  if (!Array.isArray(message.content)) {
+    return false;
+  }
+  return message.content.every((part) =>
+    part.type === "text" ? part.text.trim().length === 0 : false
+  );
+}
+
+function dropWhitespaceOnlyAssistantMessages(
+  history: readonly LLMMessage[],
+): readonly LLMMessage[] {
+  if (history.length === 0) return history;
+  const filtered = history.filter((message, index) => {
+    if (message.role !== "assistant") return true;
+    if (message.toolCalls && message.toolCalls.length > 0) return true;
+    const isLast = index === history.length - 1;
+    if (isLast) return true;
+    return !isWhitespaceOnlyMessage(message);
+  });
+  return filtered.length === history.length ? history : filtered;
+}
+
+function dropUnresolvedToolTurns(
+  history: readonly LLMMessage[],
+): readonly LLMMessage[] {
+  const issued = new Set<string>();
+  const resolved = new Set<string>();
+  for (const message of history) {
+    if (message.role === "assistant" && message.toolCalls) {
+      for (const toolCall of message.toolCalls) {
+        const id = toolCall.id?.trim();
+        if (id) issued.add(id);
+      }
+    }
+    if (message.role === "tool") {
+      const id = message.toolCallId?.trim();
+      if (id) resolved.add(id);
+    }
+  }
+  if (issued.size === resolved.size) {
+    let allResolved = true;
+    for (const id of issued) {
+      if (!resolved.has(id)) {
+        allResolved = false;
+        break;
+      }
+    }
+    if (allResolved) {
+      return history;
+    }
+  }
+
+  const next: LLMMessage[] = [];
+  for (const message of history) {
+    if (
+      message.role === "assistant" &&
+      message.toolCalls &&
+      message.toolCalls.length > 0
+    ) {
+      const unresolvedCalls = message.toolCalls.filter((toolCall) => {
+        const id = toolCall.id?.trim();
+        return id ? !resolved.has(id) : true;
+      });
+      if (unresolvedCalls.length === message.toolCalls.length) {
+        continue;
+      }
+      if (unresolvedCalls.length > 0) {
+        next.push({
+          ...cloneMessage(message),
+          toolCalls: message.toolCalls.filter((toolCall) => {
+            const id = toolCall.id?.trim();
+            return id ? resolved.has(id) : false;
+          }),
+        });
+        continue;
+      }
+    }
+    if (message.role === "tool") {
+      const id = message.toolCallId?.trim();
+      if (id && !issued.has(id)) {
+        continue;
+      }
+    }
+    next.push(cloneMessage(message));
+  }
+  return next;
 }
 
 function normalizeSurface(
@@ -395,6 +490,14 @@ export async function listTranscriptStreams(
   return keys.map((key) => key.slice(TRANSCRIPT_KV_PREFIX.length));
 }
 
+export function subAgentTranscriptStreamId(sessionId: string): string {
+  return `${SUBAGENT_TRANSCRIPT_PREFIX}${sessionId}`;
+}
+
+export function backgroundRunTranscriptStreamId(sessionId: string): string {
+  return `${BACKGROUND_RUN_TRANSCRIPT_PREFIX}${sessionId}`;
+}
+
 export function historyFromTranscript(
   document: SessionTranscriptDocument | undefined,
 ): readonly LLMMessage[] {
@@ -410,6 +513,15 @@ export function historyFromTranscript(
     }
   }
   return history;
+}
+
+export function recoverTranscriptHistory(
+  document: SessionTranscriptDocument | undefined,
+): readonly LLMMessage[] {
+  const history = historyFromTranscript(document);
+  const withoutWhitespace = dropWhitespaceOnlyAssistantMessages(history);
+  const withoutUnresolved = dropUnresolvedToolTurns(withoutWhitespace);
+  return repairToolTurnSequence(withoutUnresolved);
 }
 
 export function createTranscriptMessageEvent(params: {

--- a/runtime/src/gateway/session-transcript.ts
+++ b/runtime/src/gateway/session-transcript.ts
@@ -1,0 +1,492 @@
+import { randomUUID } from "node:crypto";
+import type { LLMMessage } from "../llm/types.js";
+import type {
+  MemoryBackend,
+  TranscriptCapableMemoryBackend,
+  TranscriptEvent,
+  TranscriptEventInput,
+  TranscriptMessagePayload,
+  TranscriptMetadataProjectionPayload,
+  TranscriptCustomPayload,
+} from "../memory/types.js";
+
+const TRANSCRIPT_KV_PREFIX = "transcript:v1:";
+
+export type SessionTranscriptEvent =
+  | SessionTranscriptMessageEvent
+  | SessionTranscriptHistorySnapshotEvent
+  | SessionTranscriptMetadataProjectionEvent;
+
+export interface SessionTranscriptBaseEvent {
+  readonly version: 1;
+  readonly seq?: number;
+  readonly eventId: string;
+  readonly dedupeKey?: string;
+  readonly timestamp: number;
+  readonly surface:
+    | "webchat"
+    | "text"
+    | "voice"
+    | "subagent"
+    | "background"
+    | "system";
+}
+
+export interface SessionTranscriptMessageEvent
+  extends SessionTranscriptBaseEvent {
+  readonly kind: "message";
+  readonly message: LLMMessage;
+}
+
+export interface SessionTranscriptHistorySnapshotEvent
+  extends SessionTranscriptBaseEvent {
+  readonly kind: "history_snapshot";
+  readonly reason: "migration" | "compaction" | "fork";
+  readonly history: readonly LLMMessage[];
+  readonly boundaryId?: string;
+}
+
+export interface SessionTranscriptMetadataProjectionEvent
+  extends SessionTranscriptBaseEvent {
+  readonly kind: "metadata_projection";
+  readonly key: string;
+  readonly value: unknown;
+}
+
+export interface SessionTranscriptDocument {
+  readonly version: 1;
+  readonly streamId: string;
+  readonly nextSeq: number;
+  readonly events: readonly SessionTranscriptEvent[];
+}
+
+function transcriptKey(streamId: string): string {
+  return `${TRANSCRIPT_KV_PREFIX}${streamId}`;
+}
+
+function cloneMessage(message: LLMMessage): LLMMessage {
+  return JSON.parse(JSON.stringify(message)) as LLMMessage;
+}
+
+function cloneEvent(event: SessionTranscriptEvent): SessionTranscriptEvent {
+  return JSON.parse(JSON.stringify(event)) as SessionTranscriptEvent;
+}
+
+function cloneUnknown<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function normalizeSurface(
+  value: unknown,
+): SessionTranscriptBaseEvent["surface"] {
+  switch (value) {
+    case "webchat":
+    case "text":
+    case "voice":
+    case "subagent":
+    case "background":
+    case "system":
+      return value;
+    default:
+      return "system";
+  }
+}
+
+function normalizeDocument(
+  streamId: string,
+  value: unknown,
+): SessionTranscriptDocument {
+  if (
+    value &&
+    typeof value === "object" &&
+    (value as { version?: unknown }).version === 1 &&
+    Array.isArray((value as { events?: unknown }).events)
+  ) {
+    const candidate = value as SessionTranscriptDocument;
+    return {
+      version: 1,
+      streamId,
+      nextSeq:
+        typeof candidate.nextSeq === "number" && Number.isFinite(candidate.nextSeq)
+          ? candidate.nextSeq
+          : candidate.events.length + 1,
+      events: candidate.events.map((event) => cloneEvent(event)),
+    };
+  }
+  return {
+    version: 1,
+    streamId,
+    nextSeq: 1,
+    events: [],
+  };
+}
+
+function toStoredTranscriptInput(
+  event: SessionTranscriptEvent,
+): TranscriptEventInput {
+  const metadata = { surface: event.surface } satisfies Record<string, unknown>;
+  switch (event.kind) {
+    case "message":
+      return {
+        version: 1,
+        eventId: event.eventId,
+        dedupeKey: event.dedupeKey,
+        timestamp: event.timestamp,
+        metadata,
+        kind: "message",
+        payload: {
+          role: event.message.role,
+          content: cloneUnknown(event.message.content),
+          ...(event.message.phase ? { phase: event.message.phase } : {}),
+          ...(event.message.toolCalls
+            ? { toolCalls: cloneUnknown(event.message.toolCalls) }
+            : {}),
+          ...(event.message.toolCallId
+            ? { toolCallId: event.message.toolCallId }
+            : {}),
+          ...(event.message.toolName ? { toolName: event.message.toolName } : {}),
+        },
+      };
+    case "metadata_projection":
+      return {
+        version: 1,
+        eventId: event.eventId,
+        dedupeKey: event.dedupeKey,
+        timestamp: event.timestamp,
+        metadata,
+        kind: "metadata_projection",
+        payload: {
+          key: event.key,
+          value: cloneUnknown(event.value),
+        },
+      };
+    case "history_snapshot":
+      return {
+        version: 1,
+        eventId: event.eventId,
+        dedupeKey: event.dedupeKey,
+        timestamp: event.timestamp,
+        metadata,
+        kind: "custom",
+        payload: {
+          name: "history_snapshot",
+          data: {
+            reason: event.reason,
+            ...(event.boundaryId ? { boundaryId: event.boundaryId } : {}),
+            history: event.history.map((message) => cloneMessage(message)),
+          },
+        },
+      };
+  }
+}
+
+function fromStoredTranscriptEvent(
+  event: TranscriptEvent,
+): SessionTranscriptEvent | undefined {
+  const surface = normalizeSurface(event.metadata?.surface);
+  switch (event.kind) {
+    case "message": {
+      const payload = event.payload as TranscriptMessagePayload;
+      return {
+        version: 1,
+        seq: event.seq,
+        eventId: event.eventId,
+        ...(event.dedupeKey ? { dedupeKey: event.dedupeKey } : {}),
+        timestamp: event.timestamp,
+        surface,
+        kind: "message",
+        message: {
+          role: payload.role,
+          content: cloneUnknown(payload.content),
+          ...(payload.phase ? { phase: payload.phase } : {}),
+          ...(payload.toolCalls
+            ? { toolCalls: cloneUnknown(payload.toolCalls) }
+            : {}),
+          ...(payload.toolCallId
+            ? { toolCallId: payload.toolCallId }
+            : {}),
+          ...(payload.toolName ? { toolName: payload.toolName } : {}),
+        },
+      };
+    }
+    case "metadata_projection": {
+      const payload = event.payload as TranscriptMetadataProjectionPayload;
+      return {
+        version: 1,
+        seq: event.seq,
+        eventId: event.eventId,
+        ...(event.dedupeKey ? { dedupeKey: event.dedupeKey } : {}),
+        timestamp: event.timestamp,
+        surface,
+        kind: "metadata_projection",
+        key: payload.key,
+        value: cloneUnknown(payload.value),
+      };
+    }
+    case "custom": {
+      const payload = event.payload as TranscriptCustomPayload;
+      if (payload.name !== "history_snapshot") {
+        return undefined;
+      }
+      if (
+        !payload.data ||
+        typeof payload.data !== "object" ||
+        !Array.isArray((payload.data as { history?: unknown }).history)
+      ) {
+        return undefined;
+      }
+      return {
+        version: 1,
+        seq: event.seq,
+        eventId: event.eventId,
+        ...(event.dedupeKey ? { dedupeKey: event.dedupeKey } : {}),
+        timestamp: event.timestamp,
+        surface,
+        kind: "history_snapshot",
+        reason:
+          (payload.data as { reason?: unknown }).reason === "migration" ||
+          (payload.data as { reason?: unknown }).reason === "fork"
+            ? ((payload.data as { reason: "migration" | "fork" }).reason)
+            : "compaction",
+        history: (payload.data as { history: readonly LLMMessage[] }).history.map(
+          (message) => cloneMessage(message),
+        ),
+        ...((payload.data as { boundaryId?: unknown }).boundaryId &&
+        typeof (payload.data as { boundaryId?: unknown }).boundaryId ===
+          "string"
+          ? {
+              boundaryId: (payload.data as { boundaryId: string }).boundaryId,
+            }
+          : {}),
+      };
+    }
+    default:
+      return undefined;
+  }
+}
+
+async function appendTranscriptBatchFallback(
+  memoryBackend: MemoryBackend,
+  streamId: string,
+  events: readonly SessionTranscriptEvent[],
+): Promise<SessionTranscriptEvent[]> {
+  const key = transcriptKey(streamId);
+  const current = normalizeDocument(
+    streamId,
+    await memoryBackend.get<SessionTranscriptDocument>(key),
+  );
+  const existingEventIds = new Set(current.events.map((event) => event.eventId));
+  const existingDedupeKeys = new Set(
+    current.events
+      .map((event) => event.dedupeKey)
+      .filter((value): value is string => typeof value === "string"),
+  );
+
+  let nextSeq = current.nextSeq;
+  const appended: SessionTranscriptEvent[] = [];
+  const mergedEvents = [...current.events];
+  for (const event of events) {
+    if (existingEventIds.has(event.eventId)) {
+      continue;
+    }
+    if (event.dedupeKey && existingDedupeKeys.has(event.dedupeKey)) {
+      continue;
+    }
+    const normalized: SessionTranscriptEvent = {
+      ...cloneEvent(event),
+      seq: nextSeq++,
+    };
+    mergedEvents.push(normalized);
+    appended.push(normalized);
+    existingEventIds.add(normalized.eventId);
+    if (normalized.dedupeKey) {
+      existingDedupeKeys.add(normalized.dedupeKey);
+    }
+  }
+
+  await memoryBackend.set(key, {
+    version: 1,
+    streamId,
+    nextSeq,
+    events: mergedEvents,
+  } satisfies SessionTranscriptDocument);
+  return appended;
+}
+
+export async function appendTranscriptBatch(
+  memoryBackend: MemoryBackend,
+  streamId: string,
+  events: readonly SessionTranscriptEvent[],
+): Promise<SessionTranscriptEvent[]> {
+  const capable = memoryBackend as MemoryBackend & TranscriptCapableMemoryBackend;
+  if (typeof capable.appendTranscript === "function") {
+    const stored = await capable.appendTranscript(
+      streamId,
+      events.map((event) => toStoredTranscriptInput(event)),
+    );
+    return stored
+      .map((event) => fromStoredTranscriptEvent(event))
+      .filter((event): event is SessionTranscriptEvent => event !== undefined);
+  }
+  return appendTranscriptBatchFallback(memoryBackend, streamId, events);
+}
+
+export async function loadTranscript(
+  memoryBackend: MemoryBackend,
+  streamId: string,
+  afterSeq?: number,
+): Promise<SessionTranscriptDocument | undefined> {
+  const capable = memoryBackend as MemoryBackend & TranscriptCapableMemoryBackend;
+  if (typeof capable.loadTranscript === "function") {
+    const stored = await capable.loadTranscript(streamId, {
+      ...(afterSeq === undefined ? {} : { afterSeq }),
+    });
+    if (stored.length === 0) {
+      return undefined;
+    }
+    return {
+      version: 1,
+      streamId,
+      nextSeq: stored[stored.length - 1]!.seq + 1,
+      events: stored
+        .map((event) => fromStoredTranscriptEvent(event))
+        .filter((event): event is SessionTranscriptEvent => event !== undefined),
+    };
+  }
+
+  const document = normalizeDocument(
+    streamId,
+    await memoryBackend.get<SessionTranscriptDocument>(transcriptKey(streamId)),
+  );
+  if (document.events.length === 0) {
+    return undefined;
+  }
+  if (afterSeq === undefined) {
+    return document;
+  }
+  return {
+    ...document,
+    events: document.events.filter((event) => (event.seq ?? 0) > afterSeq),
+  };
+}
+
+export async function deleteTranscript(
+  memoryBackend: MemoryBackend,
+  streamId: string,
+): Promise<boolean> {
+  const capable = memoryBackend as MemoryBackend & TranscriptCapableMemoryBackend;
+  if (typeof capable.deleteTranscript === "function") {
+    return (await capable.deleteTranscript(streamId)) > 0;
+  }
+  return memoryBackend.delete(transcriptKey(streamId));
+}
+
+export async function listTranscriptStreams(
+  memoryBackend: MemoryBackend,
+  prefix?: string,
+): Promise<string[]> {
+  const capable = memoryBackend as MemoryBackend & TranscriptCapableMemoryBackend;
+  if (typeof capable.listTranscriptStreams === "function") {
+    return capable.listTranscriptStreams(prefix);
+  }
+  const keys = await memoryBackend.listKeys(
+    `${TRANSCRIPT_KV_PREFIX}${prefix ?? ""}`,
+  );
+  return keys.map((key) => key.slice(TRANSCRIPT_KV_PREFIX.length));
+}
+
+export function historyFromTranscript(
+  document: SessionTranscriptDocument | undefined,
+): readonly LLMMessage[] {
+  if (!document) return [];
+  let history: LLMMessage[] = [];
+  for (const event of document.events) {
+    if (event.kind === "history_snapshot") {
+      history = event.history.map((message) => cloneMessage(message));
+      continue;
+    }
+    if (event.kind === "message") {
+      history.push(cloneMessage(event.message));
+    }
+  }
+  return history;
+}
+
+export function createTranscriptMessageEvent(params: {
+  readonly surface: SessionTranscriptBaseEvent["surface"];
+  readonly message: LLMMessage;
+  readonly dedupeKey?: string;
+  readonly timestamp?: number;
+}): SessionTranscriptMessageEvent {
+  return {
+    version: 1,
+    eventId: randomUUID(),
+    ...(params.dedupeKey ? { dedupeKey: params.dedupeKey } : {}),
+    timestamp: params.timestamp ?? Date.now(),
+    surface: params.surface,
+    kind: "message",
+    message: cloneMessage(params.message),
+  };
+}
+
+export function createTranscriptHistorySnapshotEvent(params: {
+  readonly surface: SessionTranscriptBaseEvent["surface"];
+  readonly history: readonly LLMMessage[];
+  readonly reason: SessionTranscriptHistorySnapshotEvent["reason"];
+  readonly dedupeKey?: string;
+  readonly timestamp?: number;
+  readonly boundaryId?: string;
+}): SessionTranscriptHistorySnapshotEvent {
+  return {
+    version: 1,
+    eventId: randomUUID(),
+    ...(params.dedupeKey ? { dedupeKey: params.dedupeKey } : {}),
+    timestamp: params.timestamp ?? Date.now(),
+    surface: params.surface,
+    kind: "history_snapshot",
+    reason: params.reason,
+    history: params.history.map((message) => cloneMessage(message)),
+    ...(params.boundaryId ? { boundaryId: params.boundaryId } : {}),
+  };
+}
+
+export function createTranscriptMetadataProjectionEvent(params: {
+  readonly surface: SessionTranscriptBaseEvent["surface"];
+  readonly key: string;
+  readonly value: unknown;
+  readonly dedupeKey?: string;
+  readonly timestamp?: number;
+}): SessionTranscriptMetadataProjectionEvent {
+  return {
+    version: 1,
+    eventId: randomUUID(),
+    ...(params.dedupeKey ? { dedupeKey: params.dedupeKey } : {}),
+    timestamp: params.timestamp ?? Date.now(),
+    surface: params.surface,
+    kind: "metadata_projection",
+    key: params.key,
+    value: cloneUnknown(params.value),
+  };
+}
+
+export async function forkTranscript(
+  memoryBackend: MemoryBackend,
+  sourceStreamId: string,
+  targetStreamId: string,
+): Promise<boolean> {
+  const loaded = await loadTranscript(memoryBackend, sourceStreamId);
+  if (!loaded || loaded.events.length === 0) {
+    return false;
+  }
+  await appendTranscriptBatch(
+    memoryBackend,
+    targetStreamId,
+    loaded.events.map((event) => ({
+      ...cloneEvent(event),
+      eventId: randomUUID(),
+      seq: undefined,
+      dedupeKey: undefined,
+    })),
+  );
+  return true;
+}

--- a/runtime/src/gateway/sub-agent.test.ts
+++ b/runtime/src/gateway/sub-agent.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./sub-agent.js";
 import { SubAgentSpawnError } from "./errors.js";
 import { ChatExecutor } from "../llm/chat-executor.js";
+import { InMemoryBackend } from "../memory/in-memory/backend.js";
 import type {
   IsolatedSessionContext,
   SubAgentSessionIdentity,
@@ -2225,6 +2226,89 @@ describe("SubAgentManager", () => {
           history: [
             { role: "user", content: "Store the token for later recall" },
             { role: "assistant", content: "CHILD-STORED-S1" },
+          ],
+        });
+      } finally {
+        executeSpy.mockRestore();
+      }
+    });
+
+    it("reuses a persisted terminal child session after manager restart", async () => {
+      const executeSpy = vi
+        .spyOn(ChatExecutor.prototype, "execute")
+        .mockResolvedValueOnce({
+          content: "STORED-CHILD-RESULT",
+          provider: "mock-llm",
+          usedFallback: false,
+          toolCalls: [],
+          tokenUsage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+          callUsage: [],
+          durationMs: 10,
+          compacted: false,
+          stopReason: "completed",
+          completionState: "completed",
+          completionProgress: {
+            completionState: "completed",
+            stopReason: "completed",
+            requiredRequirements: [],
+            satisfiedRequirements: [],
+            remainingRequirements: [],
+            reusableEvidence: [],
+            updatedAt: 1_700_000_000_000,
+          },
+        } as any)
+        .mockResolvedValueOnce({
+          content: "RECALLED-RESULT",
+          provider: "mock-llm",
+          usedFallback: false,
+          toolCalls: [],
+          tokenUsage: { promptTokens: 12, completionTokens: 4, totalTokens: 16 },
+          callUsage: [],
+          durationMs: 12,
+          compacted: false,
+          stopReason: "completed",
+          completionState: "completed",
+          completionProgress: {
+            completionState: "completed",
+            stopReason: "completed",
+            requiredRequirements: [],
+            satisfiedRequirements: [],
+            remainingRequirements: [],
+            reusableEvidence: [],
+            updatedAt: 1_700_000_000_001,
+          },
+        } as any);
+      const memoryBackend = new InMemoryBackend();
+      const firstManager = new SubAgentManager(
+        makeManagerConfig({ memoryBackend }),
+      );
+
+      try {
+        const firstSessionId = await firstManager.spawn({
+          parentSessionId: "parent-1",
+          task: "Store the token for later recall",
+          prompt: "Store the token for later recall",
+        });
+        await settle();
+
+        const secondManager = new SubAgentManager(
+          makeManagerConfig({ memoryBackend }),
+        );
+        const secondSessionId = await secondManager.spawn({
+          parentSessionId: "parent-1",
+          task: "Recall the token",
+          prompt: "Recall the token",
+          continuationSessionId: firstSessionId,
+        });
+        await settle();
+
+        expect(secondSessionId).toBe(firstSessionId);
+        expect(executeSpy).toHaveBeenCalledTimes(2);
+        expect(executeSpy.mock.calls[1]?.[0]).toMatchObject({
+          sessionId: firstSessionId,
+          history: [
+            { role: "user", content: "Store the token for later recall" },
+            { role: "assistant", content: "STORED-CHILD-RESULT" },
           ],
         });
       } finally {

--- a/runtime/src/gateway/sub-agent.ts
+++ b/runtime/src/gateway/sub-agent.ts
@@ -13,6 +13,7 @@ import type {
   IsolatedSessionContext,
   SubAgentSessionIdentity,
 } from "./session-isolation.js";
+import type { MemoryBackend } from "../memory/types.js";
 import { createGatewayMessage } from "./message.js";
 import { ChatExecutor } from "../llm/chat-executor.js";
 import { runSubagentToLegacyResult } from "./subagent-query.js";
@@ -62,6 +63,14 @@ import {
   type SessionShellProfile,
 } from "./shell-profile.js";
 import type { RuntimeExecutionLocation } from "../runtime-contract/types.js";
+import type { CanUseToolFn } from "../llm/can-use-tool.js";
+import {
+  appendTranscriptBatch,
+  createTranscriptMessageEvent,
+  loadTranscript,
+  recoverTranscriptHistory,
+  subAgentTranscriptStreamId,
+} from "./session-transcript.js";
 
 // ============================================================================
 // Constants
@@ -79,6 +88,7 @@ const DEFAULT_MAX_SUB_AGENT_DEPTH = 4;
 export const DEFAULT_MAX_RETAINED_TERMINAL_SUB_AGENTS = 256;
 export const DEFAULT_TERMINAL_SUB_AGENT_RETENTION_MS = 6 * 60 * 60 * 1000; // 6h
 export const SUB_AGENT_SESSION_PREFIX = "subagent:";
+const SUB_AGENT_STATE_KEY_PREFIX = "sub-agent:state:";
 
 const DEFAULT_SUB_AGENT_SYSTEM_PROMPT =
   "You are a sub-agent. Execute only the assigned delegated contract, stay within the provided scope, " +
@@ -256,6 +266,8 @@ export interface SubAgentManagerConfig {
   readonly sessionCompactionThreshold?: number;
   readonly economicsMode?: RuntimeBudgetMode;
   readonly onCompaction?: (sessionId: string, summary: string) => void;
+  readonly memoryBackend?: MemoryBackend;
+  readonly canUseTool?: CanUseToolFn;
 }
 
 interface ResolvedSubAgentExecutionBudget {
@@ -301,6 +313,76 @@ interface SubAgentHandle {
   timeoutTimer: ReturnType<typeof setTimeout> | null;
   execution: Promise<void>;
   finishedAt: number | null;
+}
+
+interface PersistedSubAgentState {
+  readonly version: 1;
+  readonly sessionId: string;
+  readonly parentSessionId: string;
+  readonly depth: number;
+  readonly task: string;
+  readonly config: SubAgentConfig;
+  readonly status: SubAgentStatus;
+  readonly result: SubAgentResult | null;
+  readonly startedAt: number;
+  readonly finishedAt: number | null;
+}
+
+function subAgentStateKey(sessionId: string): string {
+  return `${SUB_AGENT_STATE_KEY_PREFIX}${sessionId}`;
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function coercePersistedSubAgentState(
+  value: unknown,
+): PersistedSubAgentState | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const raw = value as Record<string, unknown>;
+  if (
+    raw.version !== 1 ||
+    typeof raw.sessionId !== "string" ||
+    typeof raw.parentSessionId !== "string" ||
+    typeof raw.depth !== "number" ||
+    typeof raw.task !== "string" ||
+    !raw.config ||
+    typeof raw.config !== "object" ||
+    typeof raw.status !== "string" ||
+    typeof raw.startedAt !== "number"
+  ) {
+    return undefined;
+  }
+  if (
+    raw.status !== "running" &&
+    raw.status !== "completed" &&
+    raw.status !== "cancelled" &&
+    raw.status !== "timed_out" &&
+    raw.status !== "failed"
+  ) {
+    return undefined;
+  }
+  return {
+    version: 1,
+    sessionId: raw.sessionId,
+    parentSessionId: raw.parentSessionId,
+    depth: raw.depth,
+    task: raw.task,
+    config: cloneJson(raw.config as SubAgentConfig),
+    status: raw.status,
+    result:
+      raw.result && typeof raw.result === "object"
+        ? cloneJson(raw.result as SubAgentResult)
+        : null,
+    startedAt: raw.startedAt,
+    finishedAt:
+      typeof raw.finishedAt === "number" && Number.isFinite(raw.finishedAt)
+        ? raw.finishedAt
+        : null,
+  };
 }
 
 function mapChatCompletionToSubAgentStatus(input: {
@@ -492,7 +574,7 @@ export class SubAgentManager {
         `max concurrent sub-agents reached (${this.maxConcurrent})`,
       );
     }
-    const continuationHandle = this.resolveContinuationHandle(config);
+    const continuationHandle = await this.resolveContinuationHandle(config);
     const parentDepth = this.resolveSessionDepth(config.parentSessionId);
     const depth = continuationHandle
       ? continuationHandle.depth
@@ -529,6 +611,7 @@ export class SubAgentManager {
     };
 
     this.handles.set(sessionId, handle);
+    await this.persistHandleState(handle);
 
     // Fire-and-forget execution
     handle.execution = this.executeSubAgent(handle).catch(() => {
@@ -787,6 +870,82 @@ export class SubAgentManager {
     }, timeoutMs);
   }
 
+  private async persistHandleState(handle: SubAgentHandle): Promise<void> {
+    const memoryBackend = this.config.memoryBackend;
+    if (!memoryBackend) return;
+    const persisted: PersistedSubAgentState = {
+      version: 1,
+      sessionId: handle.sessionId,
+      parentSessionId: handle.parentSessionId,
+      depth: handle.depth,
+      task: handle.task,
+      config: cloneJson(handle.config),
+      status: handle.status,
+      result: handle.result ? cloneJson(handle.result) : null,
+      startedAt: handle.startedAt,
+      finishedAt: handle.finishedAt,
+    };
+    await memoryBackend.set(subAgentStateKey(handle.sessionId), persisted);
+  }
+
+  private async appendConversationTurn(
+    handle: SubAgentHandle,
+    turn: {
+      readonly user: LLMMessage;
+      readonly assistant: LLMMessage;
+    },
+  ): Promise<void> {
+    handle.history = [...handle.history, cloneJson(turn.user), cloneJson(turn.assistant)];
+    const memoryBackend = this.config.memoryBackend;
+    if (!memoryBackend) return;
+    await appendTranscriptBatch(
+      memoryBackend,
+      subAgentTranscriptStreamId(handle.sessionId),
+      [
+        createTranscriptMessageEvent({
+          surface: "subagent",
+          message: turn.user,
+          dedupeKey: `subagent:user:${handle.sessionId}:${handle.history.length - 1}`,
+        }),
+        createTranscriptMessageEvent({
+          surface: "subagent",
+          message: turn.assistant,
+          dedupeKey: `subagent:assistant:${handle.sessionId}:${handle.history.length}`,
+        }),
+      ],
+    );
+  }
+
+  private async loadPersistedContinuationHandle(
+    continuationSessionId: string,
+  ): Promise<SubAgentHandle | undefined> {
+    const memoryBackend = this.config.memoryBackend;
+    if (!memoryBackend) return undefined;
+    const persisted = coercePersistedSubAgentState(
+      await memoryBackend.get(subAgentStateKey(continuationSessionId)),
+    );
+    if (!persisted) return undefined;
+    const transcript = await loadTranscript(
+      memoryBackend,
+      subAgentTranscriptStreamId(continuationSessionId),
+    );
+    return {
+      sessionId: persisted.sessionId,
+      parentSessionId: persisted.parentSessionId,
+      depth: persisted.depth,
+      task: persisted.task,
+      config: cloneJson(persisted.config),
+      history: [...recoverTranscriptHistory(transcript)],
+      startedAt: persisted.startedAt,
+      status: persisted.status,
+      result: persisted.result ? cloneJson(persisted.result) : null,
+      abortController: new AbortController(),
+      timeoutTimer: null,
+      execution: Promise.resolve(),
+      finishedAt: persisted.finishedAt,
+    };
+  }
+
   private async executeSubAgent(handle: SubAgentHandle): Promise<void> {
     const workspaceId =
       handle.config.workspace ?? this.config.defaultWorkspaceId ?? "default";
@@ -940,6 +1099,7 @@ export class SubAgentManager {
         }),
         resolveHostWorkspaceRoot: () =>
           handle.config.workingDirectory ?? null,
+        ...(this.config.canUseTool ? { canUseTool: this.config.canUseTool } : {}),
         ...(typeof effectiveMaxToolRounds === "number"
           ? { maxToolRounds: effectiveMaxToolRounds }
           : {}),
@@ -1130,13 +1290,10 @@ export class SubAgentManager {
           ? resultOrAbort.content
           : resultOrAbort.stopReasonDetail;
 
-      if (success) {
-        handle.history = [
-          ...handle.history,
-          { role: "user", content: handle.config.prompt ?? handle.task },
-          { role: "assistant", content: output },
-        ];
-      }
+      await this.appendConversationTurn(handle, {
+        user: { role: "user", content: handle.config.prompt ?? handle.task },
+        assistant: { role: "assistant", content: output },
+      });
 
       this.markTerminalState(handle, terminalStatus, {
         sessionId: handle.sessionId,
@@ -1189,6 +1346,7 @@ export class SubAgentManager {
         stopReason: "tool_error",
         stopReasonDetail: failedOutput,
       });
+      await this.persistHandleState(handle);
 
       this.logger.error(
         `Sub-agent ${handle.sessionId} failed: ${failedOutput}`,
@@ -1221,6 +1379,11 @@ export class SubAgentManager {
     handle.status = status;
     handle.result = result;
     handle.finishedAt = Date.now();
+    void this.persistHandleState(handle).catch((error) => {
+      this.logger.warn(
+        `Failed to persist sub-agent state for ${handle.sessionId}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
     this.pruneTerminalHandles();
   }
 
@@ -1257,13 +1420,15 @@ export class SubAgentManager {
     return sessionId.startsWith(SUB_AGENT_SESSION_PREFIX) ? 1 : 0;
   }
 
-  private resolveContinuationHandle(
+  private async resolveContinuationHandle(
     config: SubAgentConfig,
-  ): SubAgentHandle | undefined {
+  ): Promise<SubAgentHandle | undefined> {
     const continuationSessionId = config.continuationSessionId?.trim();
     if (!continuationSessionId) return undefined;
 
-    const existing = this.handles.get(continuationSessionId);
+    const existing =
+      this.handles.get(continuationSessionId) ??
+      (await this.loadPersistedContinuationHandle(continuationSessionId));
     if (!existing) {
       throw new SubAgentSpawnError(
         config.parentSessionId,

--- a/runtime/src/gateway/voice-bridge.ts
+++ b/runtime/src/gateway/voice-bridge.ts
@@ -50,6 +50,10 @@ import {
 import type { ResolvedTraceLoggingConfig } from "./daemon-trace.js";
 import { normalizeToolCallArguments } from "../llm/chat-executor-tool-utils.js";
 import { toErrorMessage } from "../utils/async.js";
+import {
+  appendTranscriptBatch,
+  createTranscriptMessageEvent,
+} from "./session-transcript.js";
 
 const DEFAULT_MAX_SESSIONS = 10;
 
@@ -760,6 +764,15 @@ export class VoiceBridge {
       const delegationToolHandler = this.buildSessionToolHandler(sessionId, send);
 
       const chatExecutor = this.requireChatExecutor();
+      if (this.config.memoryBackend) {
+        await appendTranscriptBatch(this.config.memoryBackend, sessionId, [
+          createTranscriptMessageEvent({
+            surface: "voice",
+            message: { role: "user", content: task },
+            dedupeKey: `voice:user:${traceId}`,
+          }),
+        ]);
+      }
       const providerTrace =
         this.config.traceProviderPayloads === true && this.logger
           ? {
@@ -808,6 +821,15 @@ export class VoiceBridge {
         task,
         result.content,
       );
+      if (this.config.memoryBackend) {
+        await appendTranscriptBatch(this.config.memoryBackend, sessionId, [
+          createTranscriptMessageEvent({
+            surface: "voice",
+            message: { role: "assistant", content: result.content },
+            dedupeKey: `voice:assistant:${traceId}`,
+          }),
+        ]);
+      }
 
       // Dispatch outbound hook
       if (this.config.hooks) {

--- a/runtime/src/llm/context-compaction.ts
+++ b/runtime/src/llm/context-compaction.ts
@@ -2,7 +2,10 @@ import { createHash } from "node:crypto";
 
 import type { LLMMessage } from "./types.js";
 import { extractToolFailureTextFromResult } from "./chat-executor-tool-utils.js";
-import { findToolTurnValidationIssue } from "./tool-turn-validator.js";
+import {
+  findToolTurnValidationIssue,
+  repairToolTurnSequence,
+} from "./tool-turn-validator.js";
 import { collectPreservedMessages } from "./compact/attachments.js";
 import type {
   ArtifactCompactionState,
@@ -420,7 +423,19 @@ function findSafeRetainedTailStartIndex(
   );
 
   while (startIndex > 0) {
-    const issue = findToolTurnValidationIssue(history.slice(startIndex));
+    const candidate = history.slice(startIndex).map((message) =>
+      message.role === "tool" &&
+      (!message.toolCallId || message.toolCallId.trim().length === 0)
+        ? {
+            role: "assistant" as const,
+            content: extractText(message),
+            ...(message.phase ? { phase: message.phase } : {}),
+          }
+        : message,
+    );
+    const issue = findToolTurnValidationIssue(
+      repairToolTurnSequence(candidate),
+    );
     if (!issue) {
       return startIndex;
     }

--- a/runtime/src/memory/in-memory/backend.test.ts
+++ b/runtime/src/memory/in-memory/backend.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { InMemoryBackend } from "./backend.js";
 import { MemoryBackendError } from "../errors.js";
+import { isTranscriptCapableMemoryBackend } from "../transcript.js";
 
 describe("InMemoryBackend", () => {
   let backend: InMemoryBackend;
@@ -249,6 +250,56 @@ describe("InMemoryBackend", () => {
 
       const sessions = await backend.listSessions("task-");
       expect(sessions).toHaveLength(2);
+    });
+  });
+
+  describe("transcript capability", () => {
+    it("advertises transcript support", () => {
+      expect(isTranscriptCapableMemoryBackend(backend)).toBe(true);
+    });
+
+    it("round-trips transcript events in sequence order", async () => {
+      const appended = await backend.appendTranscript("stream-1", [
+        {
+          eventId: "evt-1",
+          kind: "message",
+          payload: { role: "user", content: "hello" },
+          timestamp: 100,
+        },
+        {
+          eventId: "evt-2",
+          kind: "compact_boundary",
+          payload: { boundaryId: "b-1", summaryText: "summary" },
+          timestamp: 200,
+        },
+      ]);
+
+      expect(appended.map((event) => event.seq)).toEqual([1, 2]);
+
+      const loaded = await backend.loadTranscript("stream-1");
+      expect(loaded).toEqual(appended);
+      expect(await backend.listTranscriptStreams()).toContain("stream-1");
+    });
+
+    it("deduplicates repeated transcript appends by event id", async () => {
+      const first = await backend.appendTranscript("stream-1", [
+        {
+          eventId: "evt-1",
+          kind: "message",
+          payload: { role: "assistant", content: "hi" },
+        },
+      ]);
+
+      const second = await backend.appendTranscript("stream-1", [
+        {
+          eventId: "evt-1",
+          kind: "message",
+          payload: { role: "assistant", content: "hi" },
+        },
+      ]);
+
+      expect(second).toEqual(first);
+      expect(await backend.loadTranscript("stream-1")).toHaveLength(1);
     });
   });
 

--- a/runtime/src/memory/in-memory/backend.ts
+++ b/runtime/src/memory/in-memory/backend.ts
@@ -16,10 +16,18 @@ import type {
   MemoryQuery,
   AddEntryOptions,
   MemoryBackendConfig,
+  TranscriptCapableMemoryBackend,
+  TranscriptEvent,
+  TranscriptEventInput,
+  TranscriptLoadOptions,
 } from "../types.js";
 import { MemoryBackendError } from "../errors.js";
 import type { MetricsProvider } from "../../task/types.js";
 import { TELEMETRY_METRIC_NAMES } from "../../telemetry/metric-names.js";
+import {
+  applyTranscriptLoadOptions,
+  materializeTranscriptEvent,
+} from "../transcript.js";
 
 /**
  * Configuration for the in-memory backend
@@ -39,10 +47,13 @@ interface KVEntry {
 const DEFAULT_MAX_ENTRIES_PER_SESSION = 1000;
 const DEFAULT_MAX_TOTAL_ENTRIES = 100_000;
 
-export class InMemoryBackend implements MemoryBackend {
+export class InMemoryBackend
+  implements MemoryBackend, TranscriptCapableMemoryBackend
+{
   readonly name = "in-memory";
 
   private readonly threads = new Map<string, MemoryEntry[]>();
+  private readonly transcripts = new Map<string, TranscriptEvent[]>();
   private readonly kv = new Map<string, KVEntry>();
   private readonly logger: Logger;
   private readonly defaultTtlMs: number;
@@ -206,6 +217,65 @@ export class InMemoryBackend implements MemoryBackend {
     return sessions.filter((s) => s.startsWith(prefix));
   }
 
+  async appendTranscript(
+    streamId: string,
+    events: readonly TranscriptEventInput[],
+  ): Promise<TranscriptEvent[]> {
+    this.ensureOpen();
+    const start = Date.now();
+    let stream = this.transcripts.get(streamId);
+    if (!stream) {
+      stream = [];
+      this.transcripts.set(streamId, stream);
+    }
+
+    const appended: TranscriptEvent[] = [];
+    let nextSeq = stream.length > 0 ? stream[stream.length - 1]!.seq : 0;
+
+    for (const event of events) {
+      const existing = stream.find((candidate) => candidate.eventId === event.eventId);
+      if (existing) {
+        appended.push(existing);
+        continue;
+      }
+      nextSeq += 1;
+      const stored = materializeTranscriptEvent(streamId, nextSeq, event);
+      stream.push(stored);
+      appended.push(stored);
+    }
+
+    this.recordMemoryMetrics("appendTranscript", Date.now() - start);
+    return appended;
+  }
+
+  async loadTranscript(
+    streamId: string,
+    options: TranscriptLoadOptions = {},
+  ): Promise<TranscriptEvent[]> {
+    this.ensureOpen();
+    const start = Date.now();
+    const stream = this.transcripts.get(streamId) ?? [];
+    const result = applyTranscriptLoadOptions(stream, options);
+    this.recordMemoryMetrics("loadTranscript", Date.now() - start);
+    return result;
+  }
+
+  async deleteTranscript(streamId: string): Promise<number> {
+    this.ensureOpen();
+    const stream = this.transcripts.get(streamId);
+    if (!stream) return 0;
+    const count = stream.length;
+    this.transcripts.delete(streamId);
+    return count;
+  }
+
+  async listTranscriptStreams(prefix?: string): Promise<string[]> {
+    this.ensureOpen();
+    const streams = Array.from(this.transcripts.keys());
+    if (!prefix) return streams;
+    return streams.filter((streamId) => streamId.startsWith(prefix));
+  }
+
   // ---------- Key-Value Operations ----------
 
   async set(key: string, value: unknown, ttlMs?: number): Promise<void> {
@@ -265,6 +335,7 @@ export class InMemoryBackend implements MemoryBackend {
   async clear(): Promise<void> {
     this.ensureOpen();
     this.threads.clear();
+    this.transcripts.clear();
     this.kv.clear();
     this.totalEntries = 0;
     this.logger.debug("Cleared all memory");
@@ -273,6 +344,7 @@ export class InMemoryBackend implements MemoryBackend {
   async close(): Promise<void> {
     this.closed = true;
     this.threads.clear();
+    this.transcripts.clear();
     this.kv.clear();
     this.totalEntries = 0;
     this.logger.debug("In-memory backend closed");

--- a/runtime/src/memory/redis/backend.test.ts
+++ b/runtime/src/memory/redis/backend.test.ts
@@ -4,6 +4,7 @@ import {
   MemorySerializationError,
   MemoryBackendError,
 } from "../errors.js";
+import { isTranscriptCapableMemoryBackend } from "../transcript.js";
 
 // Mock ioredis
 const mockZadd = vi.fn().mockResolvedValue(1);
@@ -57,6 +58,84 @@ vi.mock("ioredis", () => {
 
 // Import after mock
 import { RedisBackend } from "./backend.js";
+
+function installTranscriptRedisStore(): void {
+  type StoredTranscriptEvent = {
+    seq: number;
+    json: string;
+  };
+
+  const transcriptEntries = new Map<string, StoredTranscriptEvent[]>();
+  const transcriptStreams = new Set<string>();
+
+  mockZadd.mockImplementation(async (key: string, score: number, member: string) => {
+    const stream = transcriptEntries.get(key) ?? [];
+    stream.push({ seq: score, json: member });
+    stream.sort((a, b) => a.seq - b.seq);
+    transcriptEntries.set(key, stream);
+    return 1;
+  });
+
+  mockSadd.mockImplementation(async (key: string, value: string) => {
+    if (key.includes("transcript-streams")) {
+      transcriptStreams.add(value);
+    }
+    return 1;
+  });
+
+  mockZrangebyscore.mockImplementation(
+    async (key: string, min: string, max: string) => {
+      if (!key.includes("transcript:")) return [];
+      const stream = transcriptEntries.get(key) ?? [];
+      const minSeq = min === "-inf" ? Number.NEGATIVE_INFINITY : Number(min);
+      const maxSeq = max === "+inf" ? Number.POSITIVE_INFINITY : Number(max);
+      return stream
+        .filter((entry) => entry.seq >= minSeq && entry.seq <= maxSeq)
+        .map((entry) => entry.json);
+    },
+  );
+
+  mockZrevrangebyscore.mockImplementation(async (key: string) => {
+    if (!key.includes("transcript:")) return [];
+    const stream = [...(transcriptEntries.get(key) ?? [])].sort(
+      (a, b) => b.seq - a.seq,
+    );
+    return stream.map((entry) => entry.json);
+  });
+
+  mockZcard.mockImplementation(async (key: string) => {
+    if (!key.includes("transcript:")) return 0;
+    return (transcriptEntries.get(key) ?? []).length;
+  });
+
+  mockDel.mockImplementation(async (...keys: string[]) => {
+    let removed = 0;
+    for (const key of keys) {
+      if (key.includes("transcript:")) {
+        removed += transcriptEntries.get(key)?.length ?? 0;
+        transcriptEntries.delete(key);
+      } else if (key.includes("transcript-streams")) {
+        transcriptStreams.clear();
+        removed += 1;
+      }
+    }
+    return removed || 1;
+  });
+
+  mockSrem.mockImplementation(async (key: string, value: string) => {
+    if (key.includes("transcript-streams")) {
+      transcriptStreams.delete(value);
+    }
+    return 1;
+  });
+
+  mockSmembers.mockImplementation(async (key: string) => {
+    if (key.includes("transcript-streams")) {
+      return [...transcriptStreams.values()];
+    }
+    return [];
+  });
+}
 
 describe("RedisBackend", () => {
   beforeEach(() => {
@@ -426,6 +505,60 @@ describe("RedisBackend", () => {
     });
   });
 
+  describe("transcript capability", () => {
+    it("advertises transcript support", () => {
+      const backend = new RedisBackend();
+      expect(isTranscriptCapableMemoryBackend(backend)).toBe(true);
+    });
+
+    it("round-trips transcript events", async () => {
+      installTranscriptRedisStore();
+      const backend = new RedisBackend();
+
+      const appended = await backend.appendTranscript("stream-1", [
+        {
+          eventId: "evt-1",
+          kind: "message",
+          payload: { role: "user", content: "hello" },
+          timestamp: 100,
+        },
+        {
+          eventId: "evt-2",
+          kind: "context_collapse",
+          payload: { collapseId: "c-1", summary: "summary" },
+          timestamp: 200,
+        },
+      ]);
+
+      expect(appended.map((event) => event.seq)).toEqual([1, 2]);
+      expect(await backend.loadTranscript("stream-1")).toEqual(appended);
+      expect(await backend.listTranscriptStreams()).toEqual(["stream-1"]);
+    });
+
+    it("deduplicates transcript events by event id", async () => {
+      installTranscriptRedisStore();
+      const backend = new RedisBackend();
+
+      const first = await backend.appendTranscript("stream-1", [
+        {
+          eventId: "evt-1",
+          kind: "message",
+          payload: { role: "assistant", content: "hi" },
+        },
+      ]);
+      const second = await backend.appendTranscript("stream-1", [
+        {
+          eventId: "evt-1",
+          kind: "message",
+          payload: { role: "assistant", content: "hi" },
+        },
+      ]);
+
+      expect(second).toEqual(first);
+      expect(await backend.loadTranscript("stream-1")).toHaveLength(1);
+    });
+  });
+
   describe("KV operations", () => {
     it("set with TTL uses PX flag", async () => {
       const backend = new RedisBackend();
@@ -521,7 +654,7 @@ describe("RedisBackend", () => {
 
   describe("lifecycle", () => {
     it("clear deletes all thread and KV keys", async () => {
-      mockSmembers.mockResolvedValueOnce(["s1", "s2"]);
+      mockSmembers.mockResolvedValueOnce(["s1", "s2"]).mockResolvedValueOnce([]);
       mockScan.mockResolvedValueOnce([
         "0",
         ["agenc:memory:kv:a", "agenc:memory:kv:b"],

--- a/runtime/src/memory/redis/backend.ts
+++ b/runtime/src/memory/redis/backend.ts
@@ -15,6 +15,10 @@ import type {
   MemoryEntry,
   MemoryQuery,
   AddEntryOptions,
+  TranscriptCapableMemoryBackend,
+  TranscriptEvent,
+  TranscriptEventInput,
+  TranscriptLoadOptions,
 } from "../types.js";
 import type { RedisBackendConfig } from "./types.js";
 import {
@@ -25,6 +29,10 @@ import {
 import { ensureLazyBackend } from "../lazy-import.js";
 import type { MetricsProvider } from "../../task/types.js";
 import { TELEMETRY_METRIC_NAMES } from "../../telemetry/metric-names.js";
+import {
+  applyTranscriptLoadOptions,
+  materializeTranscriptEvent,
+} from "../transcript.js";
 
 async function scanKeys(client: any, pattern: string): Promise<string[]> {
   const keys: string[] = [];
@@ -37,7 +45,9 @@ async function scanKeys(client: any, pattern: string): Promise<string[]> {
   return keys;
 }
 
-export class RedisBackend implements MemoryBackend {
+export class RedisBackend
+  implements MemoryBackend, TranscriptCapableMemoryBackend
+{
   readonly name = "redis";
 
   private client: any = null;
@@ -73,8 +83,16 @@ export class RedisBackend implements MemoryBackend {
     return `${this.prefix}kv:${key}`;
   }
 
+  private transcriptKey(streamId: string): string {
+    return `${this.prefix}transcript:${streamId}`;
+  }
+
   private get sessionsKey(): string {
     return `${this.prefix}sessions`;
+  }
+
+  private get transcriptStreamsKey(): string {
+    return `${this.prefix}transcript-streams`;
   }
 
   // ---------- Thread Operations ----------
@@ -233,6 +251,93 @@ export class RedisBackend implements MemoryBackend {
     return sessions.filter((s: string) => s.startsWith(prefix));
   }
 
+  async appendTranscript(
+    streamId: string,
+    events: readonly TranscriptEventInput[],
+  ): Promise<TranscriptEvent[]> {
+    const client = await this.ensureClient();
+    const start = Date.now();
+    const key = this.transcriptKey(streamId);
+    const existingEvents = await this.loadTranscript(streamId);
+    const existingById = new Map(
+      existingEvents.map((event) => [event.eventId, event] as const),
+    );
+    let nextSeq =
+      existingEvents.length > 0
+        ? existingEvents[existingEvents.length - 1]!.seq
+        : 0;
+
+    const appended: TranscriptEvent[] = [];
+    for (const event of events) {
+      const existing = existingById.get(event.eventId);
+      if (existing) {
+        appended.push(existing);
+        continue;
+      }
+
+      nextSeq += 1;
+      const stored = materializeTranscriptEvent(streamId, nextSeq, event);
+      let json: string;
+      try {
+        json = JSON.stringify(stored);
+      } catch (err) {
+        throw new MemorySerializationError(
+          this.name,
+          `Failed to serialize transcript event: ${(err as Error).message}`,
+        );
+      }
+
+      await client.zadd(key, stored.seq, json);
+      await client.sadd(this.transcriptStreamsKey, streamId);
+      existingById.set(stored.eventId, stored);
+      appended.push(stored);
+    }
+
+    this.recordMemoryMetrics("appendTranscript", Date.now() - start);
+    return appended;
+  }
+
+  async loadTranscript(
+    streamId: string,
+    options: TranscriptLoadOptions = {},
+  ): Promise<TranscriptEvent[]> {
+    const client = await this.ensureClient();
+    const start = Date.now();
+    const key = this.transcriptKey(streamId);
+
+    let members: string[];
+    if ((options.order ?? "asc") === "desc") {
+      members = await client.zrevrangebyscore(key, "+inf", "-inf");
+    } else {
+      members = await client.zrangebyscore(key, "-inf", "+inf");
+    }
+
+    const parsed = members
+      .map((member: string) => this.parseTranscriptEvent(member))
+      .filter(Boolean) as TranscriptEvent[];
+    const result = applyTranscriptLoadOptions(parsed, options);
+    this.recordMemoryMetrics("loadTranscript", Date.now() - start);
+    return result;
+  }
+
+  async deleteTranscript(streamId: string): Promise<number> {
+    const client = await this.ensureClient();
+    const key = this.transcriptKey(streamId);
+    const count = await client.zcard(key);
+    if (count > 0) {
+      await client.del(key);
+      await client.srem(this.transcriptStreamsKey, streamId);
+    }
+    return count;
+  }
+
+  async listTranscriptStreams(prefix?: string): Promise<string[]> {
+    const client = await this.ensureClient();
+    const streams: string[] = await client.smembers(this.transcriptStreamsKey);
+    if (!prefix) return streams;
+    return streams.filter((streamId: string) => streamId.startsWith(prefix));
+  }
+
   // ---------- Key-Value Operations ----------
 
   async set(key: string, value: unknown, ttlMs?: number): Promise<void> {
@@ -310,6 +415,14 @@ export class RedisBackend implements MemoryBackend {
       await client.del(this.threadKey(sessionId));
     }
     await client.del(this.sessionsKey);
+
+    const transcriptStreams: string[] = await client.smembers(
+      this.transcriptStreamsKey,
+    );
+    for (const streamId of transcriptStreams) {
+      await client.del(this.transcriptKey(streamId));
+    }
+    await client.del(this.transcriptStreamsKey);
 
     // Delete all KV keys
     const kvKeys: string[] = await scanKeys(client, `${this.prefix}kv:*`);
@@ -430,6 +543,15 @@ export class RedisBackend implements MemoryBackend {
       return JSON.parse(json) as MemoryEntry;
     } catch {
       this.logger.warn(`Failed to parse entry: ${json.slice(0, 100)}`);
+      return null;
+    }
+  }
+
+  private parseTranscriptEvent(json: string): TranscriptEvent | null {
+    try {
+      return JSON.parse(json) as TranscriptEvent;
+    } catch {
+      this.logger.warn(`Failed to parse transcript event: ${json.slice(0, 100)}`);
       return null;
     }
   }

--- a/runtime/src/memory/sqlite/backend.test.ts
+++ b/runtime/src/memory/sqlite/backend.test.ts
@@ -4,6 +4,7 @@ import {
   MemorySerializationError,
   MemoryBackendError,
 } from "../errors.js";
+import { isTranscriptCapableMemoryBackend } from "../transcript.js";
 
 // Mock better-sqlite3
 const mockRun = vi.fn().mockReturnValue({ changes: 0 });
@@ -29,6 +30,105 @@ vi.mock("better-sqlite3", () => {
 
 // Import after mock
 import { SqliteBackend } from "./backend.js";
+
+function installTranscriptMockStore(): void {
+  type StoredRow = {
+    stream_id: string;
+    seq: number;
+    event_id: string;
+    kind: string;
+    payload: string;
+    metadata: string | null;
+    timestamp: number;
+    version: number;
+    dedupe_key: string | null;
+  };
+
+  const rowsByStream = new Map<string, StoredRow[]>();
+
+  mockPrepare.mockImplementation((sql: string) => ({
+    run: (...args: any[]) => {
+      if (sql.includes("INSERT INTO memory_transcript_events")) {
+        const row: StoredRow = {
+          stream_id: args[0],
+          seq: args[1],
+          event_id: args[2],
+          kind: args[3],
+          payload: args[4],
+          metadata: args[5],
+          timestamp: args[6],
+          version: args[7],
+          dedupe_key: args[8],
+        };
+        const stream = rowsByStream.get(row.stream_id) ?? [];
+        stream.push(row);
+        stream.sort((a, b) => a.seq - b.seq);
+        rowsByStream.set(row.stream_id, stream);
+        return { changes: 1 };
+      }
+
+      if (sql === "DELETE FROM memory_transcript_events WHERE stream_id = ?") {
+        const streamId = args[0];
+        const count = (rowsByStream.get(streamId) ?? []).length;
+        rowsByStream.delete(streamId);
+        return { changes: count };
+      }
+
+      return mockRun(...args);
+    },
+    get: (...args: any[]) => {
+      if (sql.includes("MAX(seq) AS max_seq")) {
+        const stream = rowsByStream.get(args[0]) ?? [];
+        return {
+          max_seq: stream.length > 0 ? stream[stream.length - 1]!.seq : 0,
+        };
+      }
+
+      if (
+        sql ===
+        "SELECT * FROM memory_transcript_events WHERE stream_id = ? AND event_id = ?"
+      ) {
+        const stream = rowsByStream.get(args[0]) ?? [];
+        return stream.find((row) => row.event_id === args[1]);
+      }
+
+      return mockGet(...args);
+    },
+    all: (...args: any[]) => {
+      if (sql.includes("SELECT * FROM memory_transcript_events WHERE")) {
+        const stream = [...(rowsByStream.get(args[0]) ?? [])];
+        let results = stream;
+        let paramIndex = 1;
+        if (sql.includes("seq > ?")) {
+          const afterSeq = args[paramIndex++];
+          results = results.filter((row) => row.seq > afterSeq);
+        }
+        if (sql.includes("ORDER BY seq DESC")) {
+          results = [...results].sort((a, b) => b.seq - a.seq);
+        }
+        if (sql.includes("LIMIT ?")) {
+          const limit = args[paramIndex];
+          results = results.slice(0, limit);
+        }
+        return results;
+      }
+
+      if (sql.includes("SELECT DISTINCT stream_id FROM memory_transcript_events")) {
+        const prefixArg = args[0];
+        const streamIds = [...rowsByStream.keys()]
+          .filter((streamId) =>
+            typeof prefixArg === "string"
+              ? streamId.startsWith(prefixArg.replace(/%$/, ""))
+              : true,
+          )
+          .sort();
+        return streamIds.map((stream_id) => ({ stream_id }));
+      }
+
+      return mockAll(...args);
+    },
+  }));
+}
 
 describe("SqliteBackend", () => {
   beforeEach(() => {
@@ -333,6 +433,60 @@ describe("SqliteBackend", () => {
     });
   });
 
+  describe("transcript capability", () => {
+    it("advertises transcript support", () => {
+      const backend = new SqliteBackend();
+      expect(isTranscriptCapableMemoryBackend(backend)).toBe(true);
+    });
+
+    it("round-trips transcript events", async () => {
+      installTranscriptMockStore();
+      const backend = new SqliteBackend();
+
+      const appended = await backend.appendTranscript("stream-1", [
+        {
+          eventId: "evt-1",
+          kind: "message",
+          payload: { role: "user", content: "hello" },
+          timestamp: 100,
+        },
+        {
+          eventId: "evt-2",
+          kind: "metadata_projection",
+          payload: { key: "shellProfile", value: "default" },
+          timestamp: 200,
+        },
+      ]);
+
+      expect(appended.map((event) => event.seq)).toEqual([1, 2]);
+      expect(await backend.loadTranscript("stream-1")).toEqual(appended);
+      expect(await backend.listTranscriptStreams()).toEqual(["stream-1"]);
+    });
+
+    it("deduplicates transcript events by event id", async () => {
+      installTranscriptMockStore();
+      const backend = new SqliteBackend();
+
+      const first = await backend.appendTranscript("stream-1", [
+        {
+          eventId: "evt-1",
+          kind: "message",
+          payload: { role: "assistant", content: "hi" },
+        },
+      ]);
+      const second = await backend.appendTranscript("stream-1", [
+        {
+          eventId: "evt-1",
+          kind: "message",
+          payload: { role: "assistant", content: "hi" },
+        },
+      ]);
+
+      expect(second).toEqual(first);
+      expect(await backend.loadTranscript("stream-1")).toHaveLength(1);
+    });
+  });
+
   describe("KV operations", () => {
     it("set uses INSERT OR REPLACE", async () => {
       const backend = new SqliteBackend();
@@ -401,8 +555,14 @@ describe("SqliteBackend", () => {
         (c: any[]) =>
           typeof c[0] === "string" && c[0] === "DELETE FROM memory_kv",
       );
+      const transcriptDeleteCalls = mockPrepare.mock.calls.filter(
+        (c: any[]) =>
+          typeof c[0] === "string" &&
+          c[0] === "DELETE FROM memory_transcript_events",
+      );
       expect(deleteCalls.length).toBe(1);
       expect(kvDeleteCalls.length).toBe(1);
+      expect(transcriptDeleteCalls.length).toBe(1);
     });
 
     it("close calls db.close()", async () => {

--- a/runtime/src/memory/sqlite/backend.ts
+++ b/runtime/src/memory/sqlite/backend.ts
@@ -15,6 +15,10 @@ import type {
   MemoryEntry,
   MemoryQuery,
   AddEntryOptions,
+  TranscriptCapableMemoryBackend,
+  TranscriptEvent,
+  TranscriptEventInput,
+  TranscriptLoadOptions,
 } from "../types.js";
 import type { SqliteBackendConfig } from "./types.js";
 import {
@@ -27,13 +31,19 @@ import type { MetricsProvider } from "../../task/types.js";
 import { TELEMETRY_METRIC_NAMES } from "../../telemetry/metric-names.js";
 import type { EncryptionProvider } from "../encryption.js";
 import { createAES256GCMProvider } from "../encryption.js";
+import {
+  applyTranscriptLoadOptions,
+  materializeTranscriptEvent,
+} from "../transcript.js";
 
 /** Security H-2: escape SQL LIKE wildcards in prefix parameters. */
 function escapeLikePrefix(prefix: string): string {
   return prefix.replace(/%/g, "\\%").replace(/_/g, "\\_");
 }
 
-export class SqliteBackend implements MemoryBackend {
+export class SqliteBackend
+  implements MemoryBackend, TranscriptCapableMemoryBackend
+{
   readonly name: string = "sqlite";
 
   protected db: any = null;
@@ -274,6 +284,117 @@ export class SqliteBackend implements MemoryBackend {
     return rows.map((r: any) => r.session_id);
   }
 
+  async appendTranscript(
+    streamId: string,
+    events: readonly TranscriptEventInput[],
+  ): Promise<TranscriptEvent[]> {
+    const db = await this.ensureDb();
+    const start = Date.now();
+
+    const getMaxSeqStmt = db.prepare(
+      "SELECT COALESCE(MAX(seq), 0) AS max_seq FROM memory_transcript_events WHERE stream_id = ?",
+    );
+    const getExistingStmt = db.prepare(
+      "SELECT * FROM memory_transcript_events WHERE stream_id = ? AND event_id = ?",
+    );
+    const insertStmt = db.prepare(
+      `INSERT INTO memory_transcript_events (stream_id, seq, event_id, kind, payload, metadata, timestamp, version, dedupe_key)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+
+    let nextSeq = Number(getMaxSeqStmt.get(streamId)?.max_seq ?? 0);
+    const appended: TranscriptEvent[] = [];
+
+    for (const event of events) {
+      const existingRow = getExistingStmt.get(streamId, event.eventId);
+      if (existingRow) {
+        appended.push(this.rowToTranscriptEvent(existingRow));
+        continue;
+      }
+
+      nextSeq += 1;
+      const stored = materializeTranscriptEvent(streamId, nextSeq, event);
+      const payloadJson = this.encryptField(JSON.stringify(stored.payload));
+      const metadataJson = stored.metadata
+        ? this.encryptField(JSON.stringify(stored.metadata))
+        : null;
+
+      insertStmt.run(
+        streamId,
+        stored.seq,
+        stored.eventId,
+        stored.kind,
+        payloadJson,
+        metadataJson,
+        stored.timestamp,
+        stored.version,
+        stored.dedupeKey ?? null,
+      );
+      appended.push(stored);
+    }
+
+    this.recordMemoryMetrics("appendTranscript", Date.now() - start);
+    return appended;
+  }
+
+  async loadTranscript(
+    streamId: string,
+    options: TranscriptLoadOptions = {},
+  ): Promise<TranscriptEvent[]> {
+    const db = await this.ensureDb();
+    const start = Date.now();
+    const conditions = ["stream_id = ?"];
+    const params: unknown[] = [streamId];
+
+    if (options.afterSeq !== undefined) {
+      conditions.push("seq > ?");
+      params.push(options.afterSeq);
+    }
+
+    const order = options.order === "desc" ? "DESC" : "ASC";
+    let sql = `SELECT * FROM memory_transcript_events WHERE ${conditions.join(" AND ")} ORDER BY seq ${order}`;
+    if (options.limit !== undefined && options.limit > 0) {
+      sql += " LIMIT ?";
+      params.push(options.limit);
+    }
+
+    const rows = db.prepare(sql).all(...params);
+    const result = applyTranscriptLoadOptions(
+      rows.map((row: any) => this.rowToTranscriptEvent(row)),
+      options,
+    );
+    this.recordMemoryMetrics("loadTranscript", Date.now() - start);
+    return result;
+  }
+
+  async deleteTranscript(streamId: string): Promise<number> {
+    const db = await this.ensureDb();
+    const result = db
+      .prepare("DELETE FROM memory_transcript_events WHERE stream_id = ?")
+      .run(streamId);
+    return result.changes;
+  }
+
+  async listTranscriptStreams(prefix?: string): Promise<string[]> {
+    const db = await this.ensureDb();
+    if (prefix) {
+      const rows = db
+        .prepare(
+          `SELECT DISTINCT stream_id FROM memory_transcript_events
+           WHERE stream_id LIKE ? ORDER BY stream_id ASC`,
+        )
+        .all(`${escapeLikePrefix(prefix)}%`);
+      return rows.map((row: any) => row.stream_id);
+    }
+
+    const rows = db
+      .prepare(
+        "SELECT DISTINCT stream_id FROM memory_transcript_events ORDER BY stream_id ASC",
+      )
+      .all();
+    return rows.map((row: any) => row.stream_id);
+  }
+
   // ---------- Key-Value Operations ----------
 
   async set(key: string, value: unknown, ttlMs?: number): Promise<void> {
@@ -364,6 +485,7 @@ export class SqliteBackend implements MemoryBackend {
   async clear(): Promise<void> {
     const db = await this.ensureDb();
     db.prepare("DELETE FROM memory_entries").run();
+    db.prepare("DELETE FROM memory_transcript_events").run();
     db.prepare("DELETE FROM memory_kv").run();
     this.logger.debug("Cleared all memory");
   }
@@ -492,6 +614,24 @@ export class SqliteBackend implements MemoryBackend {
         value TEXT NOT NULL,
         expires_at INTEGER
       );
+
+      CREATE TABLE IF NOT EXISTS memory_transcript_events (
+        stream_id TEXT NOT NULL,
+        seq INTEGER NOT NULL,
+        event_id TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        payload TEXT NOT NULL,
+        metadata TEXT,
+        timestamp INTEGER NOT NULL,
+        version INTEGER NOT NULL,
+        dedupe_key TEXT,
+        PRIMARY KEY (stream_id, seq),
+        UNIQUE(stream_id, event_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_transcript_stream_seq ON memory_transcript_events(stream_id, seq);
+      CREATE INDEX IF NOT EXISTS idx_transcript_stream_timestamp ON memory_transcript_events(stream_id, timestamp);
+      CREATE INDEX IF NOT EXISTS idx_transcript_stream_dedupe ON memory_transcript_events(stream_id, dedupe_key);
     `);
     // Schema migration: add scoping columns to existing DBs
     this.migrateSchemaIfNeeded();
@@ -577,6 +717,45 @@ export class SqliteBackend implements MemoryBackend {
     if (row.channel) (entry as any).channel = row.channel;
 
     return entry;
+  }
+
+  private rowToTranscriptEvent(row: any): TranscriptEvent {
+    let payload: TranscriptEvent["payload"];
+    try {
+      payload = JSON.parse(this.decryptField(row.payload)) as TranscriptEvent["payload"];
+    } catch (err) {
+      throw new MemorySerializationError(
+        this.name,
+        `Failed to deserialize transcript payload: ${(err as Error).message}`,
+      );
+    }
+
+    let metadata: Record<string, unknown> | undefined;
+    if (row.metadata) {
+      try {
+        metadata = JSON.parse(this.decryptField(row.metadata)) as Record<
+          string,
+          unknown
+        >;
+      } catch (err) {
+        throw new MemorySerializationError(
+          this.name,
+          `Failed to deserialize transcript metadata: ${(err as Error).message}`,
+        );
+      }
+    }
+
+    return {
+      version: row.version,
+      streamId: row.stream_id,
+      seq: row.seq,
+      eventId: row.event_id,
+      kind: row.kind,
+      payload,
+      timestamp: row.timestamp,
+      metadata,
+      dedupeKey: row.dedupe_key ?? undefined,
+    };
   }
 
   private encryptField(plaintext: string): string {

--- a/runtime/src/memory/transcript.ts
+++ b/runtime/src/memory/transcript.ts
@@ -1,0 +1,55 @@
+import type {
+  MemoryBackend,
+  TranscriptCapableMemoryBackend,
+  TranscriptEvent,
+  TranscriptEventInput,
+  TranscriptLoadOptions,
+  TranscriptEventVersion,
+} from "./types.js";
+import { TRANSCRIPT_EVENT_VERSION } from "./types.js";
+
+export function isTranscriptCapableMemoryBackend(
+  backend: MemoryBackend,
+): backend is MemoryBackend & TranscriptCapableMemoryBackend {
+  const candidate = backend as Partial<TranscriptCapableMemoryBackend>;
+  return (
+    typeof candidate.appendTranscript === "function" &&
+    typeof candidate.loadTranscript === "function" &&
+    typeof candidate.deleteTranscript === "function" &&
+    typeof candidate.listTranscriptStreams === "function"
+  );
+}
+
+export function materializeTranscriptEvent(
+  streamId: string,
+  seq: number,
+  input: TranscriptEventInput,
+): TranscriptEvent {
+  return {
+    version: (input.version ?? TRANSCRIPT_EVENT_VERSION) as TranscriptEventVersion,
+    streamId,
+    seq,
+    eventId: input.eventId,
+    kind: input.kind,
+    payload: input.payload as TranscriptEvent["payload"],
+    timestamp: input.timestamp ?? Date.now(),
+    metadata: input.metadata,
+    dedupeKey: input.dedupeKey,
+  };
+}
+
+export function applyTranscriptLoadOptions(
+  events: readonly TranscriptEvent[],
+  options: TranscriptLoadOptions = {},
+): TranscriptEvent[] {
+  const filtered = events.filter((event) =>
+    options.afterSeq === undefined ? true : event.seq > options.afterSeq,
+  );
+  const order = options.order ?? "asc";
+  const ordered =
+    order === "desc" ? [...filtered].sort((a, b) => b.seq - a.seq) : filtered;
+  if (options.limit !== undefined && options.limit > 0) {
+    return ordered.slice(0, options.limit);
+  }
+  return ordered;
+}

--- a/runtime/src/memory/types.ts
+++ b/runtime/src/memory/types.ts
@@ -194,6 +194,126 @@ export interface MemoryBackend {
 }
 
 /**
+ * Versioned transcript event schema version supported by the built-in
+ * transcript-capable backends.
+ */
+export const TRANSCRIPT_EVENT_VERSION = 1 as const;
+
+export type TranscriptEventVersion = typeof TRANSCRIPT_EVENT_VERSION;
+
+export type TranscriptEventKind =
+  | "message"
+  | "compact_boundary"
+  | "metadata_projection"
+  | "content_replacement"
+  | "context_collapse"
+  | "custom";
+
+export interface TranscriptMessagePayload {
+  readonly role: MemoryRole;
+  readonly content: LLMMessage["content"];
+  readonly phase?: LLMMessage["phase"];
+  readonly toolCalls?: LLMMessage["toolCalls"];
+  readonly toolCallId?: string;
+  readonly toolName?: string;
+}
+
+export interface TranscriptCompactBoundaryPayload {
+  readonly boundaryId: string;
+  readonly source?: string;
+  readonly summaryText?: string;
+  readonly sourceMessageCount?: number;
+  readonly retainedTailCount?: number;
+  readonly headEventId?: string;
+  readonly anchorEventId?: string;
+  readonly tailEventId?: string;
+}
+
+export interface TranscriptMetadataProjectionPayload {
+  readonly key: string;
+  readonly value: unknown;
+}
+
+export interface TranscriptContentReplacementPayload {
+  readonly replacementId: string;
+  readonly target: string;
+  readonly value: unknown;
+}
+
+export interface TranscriptContextCollapsePayload {
+  readonly collapseId: string;
+  readonly summary: string;
+  readonly detail?: string;
+}
+
+export interface TranscriptCustomPayload {
+  readonly name: string;
+  readonly data?: unknown;
+}
+
+export interface TranscriptEventPayloadMap {
+  readonly message: TranscriptMessagePayload;
+  readonly compact_boundary: TranscriptCompactBoundaryPayload;
+  readonly metadata_projection: TranscriptMetadataProjectionPayload;
+  readonly content_replacement: TranscriptContentReplacementPayload;
+  readonly context_collapse: TranscriptContextCollapsePayload;
+  readonly custom: TranscriptCustomPayload;
+}
+
+export type TranscriptEventPayload = {
+  [K in TranscriptEventKind]: TranscriptEventPayloadMap[K];
+}[TranscriptEventKind];
+
+export type TranscriptEvent<
+  K extends TranscriptEventKind = TranscriptEventKind,
+> = {
+  readonly version: TranscriptEventVersion;
+  readonly streamId: string;
+  readonly seq: number;
+  readonly eventId: string;
+  readonly kind: K;
+  readonly payload: TranscriptEventPayloadMap[K];
+  readonly timestamp: number;
+  readonly metadata?: Record<string, unknown>;
+  readonly dedupeKey?: string;
+};
+
+export type TranscriptEventInput<
+  K extends TranscriptEventKind = TranscriptEventKind,
+> = {
+  readonly version?: TranscriptEventVersion;
+  readonly eventId: string;
+  readonly kind: K;
+  readonly payload: TranscriptEventPayloadMap[K];
+  readonly timestamp?: number;
+  readonly metadata?: Record<string, unknown>;
+  readonly dedupeKey?: string;
+};
+
+export interface TranscriptLoadOptions {
+  readonly afterSeq?: number;
+  readonly limit?: number;
+  readonly order?: "asc" | "desc";
+}
+
+/**
+ * Optional, non-breaking transcript storage capability. Backends that do not
+ * implement this continue to satisfy `MemoryBackend`.
+ */
+export interface TranscriptCapableMemoryBackend {
+  appendTranscript(
+    streamId: string,
+    events: readonly TranscriptEventInput[],
+  ): Promise<TranscriptEvent[]>;
+  loadTranscript(
+    streamId: string,
+    options?: TranscriptLoadOptions,
+  ): Promise<TranscriptEvent[]>;
+  deleteTranscript(streamId: string): Promise<number>;
+  listTranscriptStreams(prefix?: string): Promise<string[]>;
+}
+
+/**
  * Shared configuration for all memory backends
  */
 export interface MemoryBackendConfig {

--- a/runtime/src/tools/system/coding.test.ts
+++ b/runtime/src/tools/system/coding.test.ts
@@ -6,6 +6,7 @@ import { join, resolve as resolvePath } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { ToolRegistry } from "../registry.js";
+import { seedSessionReadState } from "./filesystem.js";
 import { createCodingTools } from "./coding.js";
 
 function byName(name: string) {
@@ -97,7 +98,7 @@ describe("createCodingTools", () => {
     expect(parsed.results.some((entry) => entry.name === "system.searchTools")).toBe(true);
   });
 
-  it("supports readFileRange followed by applyPatch under read-before-write rules", async () => {
+  it("requires a full read before applyPatch on existing files", async () => {
     const root = await createRepoFixture();
     createdRoots.push(root);
     const tools = createCodingTools({
@@ -117,6 +118,31 @@ describe("createCodingTools", () => {
       __agencSessionId: "session-1",
     });
     expect(before.isError).not.toBe(true);
+
+    const blocked = await applyPatch!.execute({
+      path: root,
+      patch: [
+        "--- a/src/app.ts",
+        "+++ b/src/app.ts",
+        "@@ -1,3 +1,3 @@",
+        " export function greet(name: string): string {",
+        "-  return `Hello, ${name}`;",
+        "+  return `Hi, ${name}`;",
+        " }",
+        "",
+      ].join("\n"),
+      __agencSessionId: "session-1",
+    });
+    expect(blocked.isError).toBe(true);
+    expect(blocked.content).toContain("Call system.readFile on");
+
+    seedSessionReadState("session-1", [
+      {
+        path: join(root, "src", "app.ts"),
+        content: await readFile(join(root, "src", "app.ts"), "utf8"),
+        viewKind: "full",
+      },
+    ]);
 
     const patch = [
       "--- a/src/app.ts",

--- a/runtime/src/tools/system/coding.ts
+++ b/runtime/src/tools/system/coding.ts
@@ -1457,7 +1457,10 @@ export function createCodingTools(config: CodingToolConfig): readonly Tool[] {
         normalizePositiveInteger(args.endLine, startLine + 50, lines.length || startLine),
       );
       const selected = lines.slice(startLine - 1, endLine);
-      recordSessionRead(resolveSessionId(args), safe.resolved);
+      recordSessionRead(resolveSessionId(args), safe.resolved, {
+        content: selected.join("\n"),
+        viewKind: "partial",
+      });
       return okResult({
         path: safe.resolved,
         startLine,
@@ -1516,7 +1519,7 @@ export function createCodingTools(config: CodingToolConfig): readonly Tool[] {
         const existingStat = await stat(resolvedTarget).catch(() => undefined);
         if (existingStat && !hasSessionRead(sessionId, resolvedTarget)) {
           return errorResult(
-            `Call system.readFile or system.readFileRange on "${targetPath}" before system.applyPatch.`,
+            `Call system.readFile on "${targetPath}" before system.applyPatch.`,
           );
         }
 


### PR DESCRIPTION
## Summary
- persist child-session continuation state through transcript-backed history plus durable session metadata
- make background-run conversation history transcript-backed and preserve it across retry and fork flows
- tighten transcript/session compaction recovery so historical tool messages no longer block artifact-backed compaction

## Validation
- `npm exec --workspace=@tetsuo-ai/runtime -- vitest run src/gateway/sub-agent.test.ts src/gateway/background-run-store.test.ts src/gateway/background-run-supervisor.test.ts src/gateway/session-transcript.test.ts`
- `npm exec --workspace=@tetsuo-ai/runtime -- vitest run src/gateway/daemon.test.ts src/channels/webchat/plugin.test.ts src/gateway/daemon-webchat-turn.test.ts src/gateway/daemon-text-channel-turn.test.ts src/gateway/voice-bridge.test.ts`
- `npm exec --workspace=@tetsuo-ai/runtime -- vitest run src/gateway/session.test.ts tests/regression/orchestration/context-compaction.integration.test.ts src/eval/long-horizon-suite.test.ts`
- `npx tsc --noEmit --pretty false -p runtime`
- `npm run build --workspace=@tetsuo-ai/runtime`

## Notes
- `npm exec --workspace=@tetsuo-ai/runtime -- vitest run` still reports unrelated existing failures in marketplace, channel wiring, and ctx-helper surfaces outside this patch.