### PR TITLE
fix(watch): reduce streaming and trace noise

### DIFF
--- a/runtime/src/channels/webchat/plugin.test.ts
+++ b/runtime/src/channels/webchat/plugin.test.ts
@@ -1379,6 +1379,40 @@ describe("WebChatChannel", () => {
       );
     });
 
+    it("does not trace outbound chat.stream frames", async () => {
+      const logger = {
+        ...silentLogger,
+        info: vi.fn(),
+      };
+      context = createContext({ logger });
+      channel = new WebChatChannel(deps);
+      await channel.initialize(context);
+      await channel.start();
+
+      const send = vi.fn<(response: ControlResponse) => void>();
+      channel.handleMessage(
+        "client_1",
+        "chat.message",
+        msg("chat.message", { content: "Hello" }),
+        send,
+      );
+
+      channel["traceOutboundControlResponse"](
+        "client_1",
+        "client_1",
+        send,
+        {
+          type: "chat.stream",
+          payload: { content: "partial", done: false },
+        },
+      );
+
+      const outboundLines = logger.info.mock.calls
+        .map((call) => call[0])
+        .filter((line) => typeof line === "string" && line.includes("[trace] webchat.ws.outbound "));
+      expect(outboundLines.some((line) => line.includes("\"type\":\"chat.stream\""))).toBe(false);
+    });
+
     it("should not throw for unmapped session", async () => {
       // No prior messages — no session mapping
       await expect(

--- a/runtime/src/channels/webchat/plugin.ts
+++ b/runtime/src/channels/webchat/plugin.ts
@@ -593,6 +593,9 @@ export class WebChatChannel
     sessionId: string | undefined,
     response: ControlResponse,
   ): void {
+    if (response.type === "chat.stream") {
+      return;
+    }
     const payload = response.payload;
     const payloadSessionId =
       payload &&

--- a/runtime/src/gateway/daemon-trace.test.ts
+++ b/runtime/src/gateway/daemon-trace.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   buildRuntimeContractSessionTraceId,
   buildRuntimeContractTaskTraceId,
   buildRuntimeContractVerifierTraceId,
   buildRuntimeContractWorkerTraceId,
+  logExecutionTraceEvent,
+  logProviderPayloadTraceEvent,
 } from "./daemon-trace.js";
 
 describe("runtime contract trace ids", () => {
@@ -24,5 +26,84 @@ describe("runtime contract trace ids", () => {
     expect(buildRuntimeContractVerifierTraceId("session-a", "11")).toBe(
       "contract:task:session-a:11",
     );
+  });
+});
+
+describe("trace log filtering", () => {
+  it("drops provider stream_event chatter from daemon trace logs", () => {
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      setLevel: vi.fn(),
+    };
+
+    logProviderPayloadTraceEvent({
+      logger,
+      channelName: "webchat",
+      traceId: "trace-1",
+      sessionId: "session-1",
+      traceConfig: {
+        enabled: true,
+        includeHistory: true,
+        includeSystemPrompt: true,
+        includeToolArgs: true,
+        includeToolResults: true,
+        includeProviderPayloads: true,
+        maxChars: 20_000,
+      },
+      event: {
+        kind: "stream_event",
+        provider: "grok",
+        model: "grok-4",
+        transport: "chat",
+        payload: { type: "response.output_text.delta", delta: "hel" },
+      },
+    });
+
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("summarizes tool_dispatch_finished result previews", () => {
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      setLevel: vi.fn(),
+    };
+
+    logExecutionTraceEvent({
+      logger,
+      channelName: "webchat",
+      traceId: "trace-2",
+      sessionId: "session-2",
+      traceConfig: {
+        enabled: true,
+        includeHistory: true,
+        includeSystemPrompt: true,
+        includeToolArgs: true,
+        includeToolResults: true,
+        includeProviderPayloads: false,
+        maxChars: 20_000,
+      },
+      event: {
+        type: "tool_dispatch_finished",
+        phase: "tool_followup",
+        callIndex: 1,
+        payload: {
+          tool: "system.readFile",
+          isError: false,
+          result: "line one\nline two\nline three",
+        },
+      },
+    });
+
+    const line = logger.info.mock.calls[0]?.[0] as string;
+    expect(line).toContain('"resultPreview"');
+    expect(line).toContain('"resultOmitted":true');
+    expect(line).not.toContain('"result":"line one');
   });
 });

--- a/runtime/src/gateway/daemon-trace.ts
+++ b/runtime/src/gateway/daemon-trace.ts
@@ -263,6 +263,9 @@ export function logProviderPayloadTraceEvent(params: {
 }): void {
   const { logger, channelName, traceId, sessionId, traceConfig, event } =
     params;
+  if (event.kind === "stream_event") {
+    return;
+  }
   logTraceEvent(
     logger,
     `${channelName}.provider.${event.kind}`,
@@ -300,6 +303,34 @@ export function logProviderPayloadTraceEvent(params: {
   );
 }
 
+function summarizeExecutionTracePayloadPreview(
+  event: ChatExecutionTraceEvent,
+  maxChars: number,
+): unknown {
+  if (
+    event.type !== "tool_dispatch_finished" ||
+    !event.payload ||
+    typeof event.payload !== "object" ||
+    Array.isArray(event.payload)
+  ) {
+    return summarizeTraceValue(event.payload, maxChars);
+  }
+  const payload = { ...event.payload } as Record<string, unknown>;
+  if ("result" in payload) {
+    const rawResult = payload.result;
+    delete payload.result;
+    payload.resultPreview =
+      typeof rawResult === "string"
+        ? summarizeTraceTextForPreview(
+            sanitizeToolResultTextForTrace(rawResult),
+            Math.min(maxChars, 480),
+          )
+        : summarizeTraceValue(rawResult, Math.min(maxChars, 480));
+    payload.resultOmitted = true;
+  }
+  return summarizeTraceValue(payload, maxChars);
+}
+
 export function logExecutionTraceEvent(params: {
   logger: Logger;
   channelName: string;
@@ -318,7 +349,10 @@ export function logExecutionTraceEvent(params: {
       sessionId,
       ...(event.callIndex !== undefined ? { callIndex: event.callIndex } : {}),
       ...(event.phase !== undefined ? { callPhase: event.phase } : {}),
-      payloadPreview: summarizeTraceValue(event.payload, traceConfig.maxChars),
+      payloadPreview: summarizeExecutionTracePayloadPreview(
+        event,
+        traceConfig.maxChars,
+      ),
     },
     traceConfig.maxChars,
     {

--- a/runtime/src/llm/provider-trace-logger.test.ts
+++ b/runtime/src/llm/provider-trace-logger.test.ts
@@ -167,6 +167,72 @@ describe("createProviderTraceEventLogger", () => {
     rmSync(payloadArtifactMatch![1], { force: true });
   });
 
+  it("suppresses high-volume provider stream events from the normal logger", () => {
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      setLevel: vi.fn(),
+    };
+
+    const logEvent = createProviderTraceEventLogger({
+      logger,
+      traceLabel: "webchat.provider",
+      traceId: "trace-stream",
+      sessionId: "session-stream",
+    });
+
+    logEvent({
+      kind: "stream_event",
+      transport: "chat",
+      provider: "grok",
+      model: "grok-test",
+      payload: { type: "response.output_text.delta", delta: "hel" },
+    });
+
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("summarizes tool_dispatch_finished results in the log preview", () => {
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      setLevel: vi.fn(),
+    };
+
+    const logEvent = createExecutionTraceEventLogger({
+      logger,
+      traceLabel: "webchat.executor",
+      traceId: "trace-tool-result",
+      sessionId: "session-tool-result",
+    });
+
+    logEvent({
+      type: "tool_dispatch_finished",
+      phase: "tool_followup",
+      callIndex: 1,
+      payload: {
+        tool: "system.readFile",
+        isError: false,
+        result: "line one\nline two\nline three",
+      },
+    });
+
+    const line = logger.info.mock.calls[0]?.[0] as string;
+    expect(line).toContain('"resultPreview"');
+    expect(line).toContain('"resultOmitted":true');
+    expect(line).not.toContain('"result":"line one');
+    const payloadArtifactMatch = line.match(
+      /"payloadArtifact":\{"path":"([^"]+)"/,
+    );
+    expect(payloadArtifactMatch?.[1]).toBeTruthy();
+    rmSync(payloadArtifactMatch![1], { force: true });
+  });
+
   it("summarizes ANSI-heavy terminal payloads in the log preview while keeping the artifact payload", () => {
     const logger = {
       info: vi.fn(),

--- a/runtime/src/llm/provider-trace-logger.ts
+++ b/runtime/src/llm/provider-trace-logger.ts
@@ -2,7 +2,9 @@ import type { Logger } from "../utils/logger.js";
 import { persistTracePayloadArtifact } from "../utils/trace-payload-store.js";
 import {
   formatTracePayloadForLog,
+  sanitizeTraceTextForLogSnippet,
   summarizeTracePayloadForPreview,
+  summarizeTraceTextForPreview,
 } from "../utils/trace-payload-serialization.js";
 import { recordObservabilityTraceEvent } from "../observability/observability.js";
 import type { LLMProviderTraceEvent } from "./types.js";
@@ -20,6 +22,34 @@ function formatProviderTracePayloadForLog(
   maxChars = DEFAULT_MAX_CHARS,
 ): string {
   return formatTracePayloadForLog(payload, maxChars);
+}
+
+function summarizeExecutionPayloadPreview(
+  event: ChatExecutionTraceEvent,
+  maxChars: number,
+): unknown {
+  if (
+    event.type !== "tool_dispatch_finished" ||
+    !event.payload ||
+    typeof event.payload !== "object" ||
+    Array.isArray(event.payload)
+  ) {
+    return summarizeTracePayloadForPreview(event.payload, maxChars);
+  }
+  const payload = { ...event.payload } as Record<string, unknown>;
+  if ("result" in payload) {
+    const rawResult = payload.result;
+    delete payload.result;
+    payload.resultPreview =
+      typeof rawResult === "string"
+        ? summarizeTraceTextForPreview(
+            sanitizeTraceTextForLogSnippet(rawResult, maxChars),
+            Math.min(maxChars, 480),
+          )
+        : summarizeTracePayloadForPreview(rawResult, Math.min(maxChars, 480));
+    payload.resultOmitted = true;
+  }
+  return summarizeTracePayloadForPreview(payload, maxChars);
 }
 
 export function createProviderTraceEventLogger(params: {
@@ -40,6 +70,9 @@ export function createProviderTraceEventLogger(params: {
   } = params;
 
   return (event: LLMProviderTraceEvent): void => {
+    if (event.kind === "stream_event") {
+      return;
+    }
     const eventName = `${traceLabel}.${event.kind}`;
     const payloadArtifact = persistTracePayloadArtifact({
       traceId,
@@ -122,7 +155,7 @@ export function createExecutionTraceEventLogger(params: {
       ...(staticFields ?? {}),
       ...(event.callIndex !== undefined ? { callIndex: event.callIndex } : {}),
       ...(event.phase !== undefined ? { callPhase: event.phase } : {}),
-      payloadPreview: summarizeTracePayloadForPreview(event.payload, maxChars),
+      payloadPreview: summarizeExecutionPayloadPreview(event, maxChars),
       ...(payloadArtifact ? { payloadArtifact } : {}),
     };
     recordObservabilityTraceEvent({

--- a/runtime/src/watch/agenc-watch-app.mjs
+++ b/runtime/src/watch/agenc-watch-app.mjs
@@ -1684,6 +1684,8 @@ function shouldShowSplash() {
 
 function resetLiveRunSurface() {
   watchState.latestAgentSummary = null;
+  watchState.agentStreamingText = null;
+  watchState.agentStreamingPreview = null;
   // Intentionally preserve `latestTool`, `latestToolState`, and
   // `lastUsageSummary` across run boundaries. The server only emits
   // `chat.usage` at completion, and tool events fire mid-stream — wiping
@@ -2031,13 +2033,15 @@ function handleToolResult(toolName, isError, result, toolArgs) {
     return;
   }
   pushEvent(
-    isError ? "tool error" : "tool result",
+    "tool result",
     descriptor.title,
     descriptor.body,
     descriptor.tone,
     descriptorEventMetadata(descriptor, {
       toolName,
       toolArgs: args,
+      toolState: isError ? "error" : "ok",
+      isError,
     }),
   );
 }

--- a/runtime/src/watch/agenc-watch-event-store.mjs
+++ b/runtime/src/watch/agenc-watch-event-store.mjs
@@ -115,6 +115,24 @@ export function createWatchEventStore(dependencies = {}) {
       sanitizeInlineText(storedEventBody(event)) || watchState.latestAgentSummary;
   }
 
+  function deriveStreamingPreviewText(value) {
+    const text = typeof value === "string" ? value : "";
+    if (!text) {
+      return null;
+    }
+    const lastNewlineIndex = text.lastIndexOf("\n");
+    if (lastNewlineIndex < 0) {
+      return null;
+    }
+    const preview = text.slice(0, lastNewlineIndex + 1);
+    return preview.length > 0 ? preview : null;
+  }
+
+  function clearAgentStreamingPreview() {
+    watchState.agentStreamingText = null;
+    watchState.agentStreamingPreview = null;
+  }
+
   function shouldCoalesceRenderedEvent(previousEvent, nextEvent) {
     if (!previousEvent || !nextEvent) {
       return false;
@@ -190,6 +208,7 @@ export function createWatchEventStore(dependencies = {}) {
       return;
     }
     events.length = 0;
+    clearAgentStreamingPreview();
     watchState.transcriptScrollOffset = 0;
     watchState.transcriptFollowMode = true;
     watchState.detailScrollOffset = 0;
@@ -278,48 +297,29 @@ export function createWatchEventStore(dependencies = {}) {
     const safeChunk = stripTerminalControlSequences(sanitizeLargeText(chunk ?? ""));
     return withPreservedManualTranscriptViewport(({ shouldFollow }) => {
       const timestamp = nowStamp();
-      const createdAtMs = nowMs();
-      let target = findLatestStreamingAgentEvent();
-      if (!target) {
-        if (!safeChunk) {
-          return null;
+      const target = findLatestStreamingAgentEvent();
+      if (target) {
+        const createdAtMs = nowMs();
+        if (safeChunk) {
+          updateExistingEventBody(target, `${storedEventBody(target)}${safeChunk}`);
         }
-        const normalized = normalizeEventBody(safeChunk || "(streaming)");
-        target = {
-          id: nextId("evt"),
-          kind: "agent",
-          title: "Agent Reply · live",
-          tone: "cyan",
-          timestamp,
-          createdAtMs,
-          body: normalized.body,
-          bodyTruncated: normalized.bodyTruncated,
-          renderMode: "markdown",
-          streamState: nextAgentStreamState({ done }),
-        };
-        preserveFullDetailBody(target, normalized, safeChunk || "(streaming)");
-        events.push(target);
-        if (introDismissKinds.has("agent")) {
-          dismissIntro();
-        }
-        trimBoundedHistory();
-      } else if (safeChunk) {
-        updateExistingEventBody(target, `${storedEventBody(target)}${safeChunk}`);
         target.timestamp = timestamp;
         target.createdAtMs = createdAtMs;
         target.title = "Agent Reply · live";
         target.streamState = nextAgentStreamState({ done });
+        updateLatestAgentSummary(target);
       } else {
-        target.timestamp = timestamp;
-        target.createdAtMs = createdAtMs;
-        target.title = done ? "Agent Reply · live" : target.title;
-        target.streamState = done ? nextAgentStreamState({ done }) : target.streamState;
+        const nextStreamingText = `${watchState.agentStreamingText ?? ""}${safeChunk}`;
+        watchState.agentStreamingText = nextStreamingText || null;
+        watchState.agentStreamingPreview = deriveStreamingPreviewText(nextStreamingText);
+        if (safeChunk && introDismissKinds.has("agent")) {
+          dismissIntro();
+        }
       }
-      updateLatestAgentSummary(target);
       updateActivity(timestamp);
       followTranscriptIfNeeded(shouldFollow);
       scheduleRender();
-      return target;
+      return target ?? watchState.agentStreamingPreview;
     });
   }
 
@@ -350,6 +350,7 @@ export function createWatchEventStore(dependencies = {}) {
         renderMode: "markdown",
         streamState: "complete",
       });
+      updateLatestAgentSummary(result);
     } else {
       // Always overwrite the streaming target body with the canonical
       // commit content when it is non-empty. The previous fallback chain
@@ -375,6 +376,7 @@ export function createWatchEventStore(dependencies = {}) {
       updateActivity(timestamp);
       result = target;
     }
+    clearAgentStreamingPreview();
     // Force-snap to the new reply AFTER any nested wrapper has run. This
     // line MUST be outside withPreservedManualTranscriptViewport — the
     // wrapper's cleanup overwrote it in PR #310, which is exactly why
@@ -389,7 +391,17 @@ export function createWatchEventStore(dependencies = {}) {
     return withPreservedManualTranscriptViewport(({ shouldFollow }) => {
       const target = findLatestStreamingAgentEvent();
       if (!target) {
-        return false;
+        const hadPreview =
+          typeof watchState.agentStreamingText === "string" ||
+          typeof watchState.agentStreamingPreview === "string";
+        if (!hadPreview) {
+          return false;
+        }
+        clearAgentStreamingPreview();
+        updateActivity(nowStamp());
+        followTranscriptIfNeeded(shouldFollow);
+        scheduleRender();
+        return true;
       }
       target.title = reason === "error" ? "Agent Reply Interrupted" : "Agent Reply Cancelled";
       target.tone = reason === "error" ? "red" : "amber";
@@ -397,6 +409,7 @@ export function createWatchEventStore(dependencies = {}) {
       target.timestamp = nowStamp();
       target.createdAtMs = nowMs();
       updateLatestAgentSummary(target);
+      clearAgentStreamingPreview();
       updateActivity(target.timestamp);
       followTranscriptIfNeeded(shouldFollow);
       scheduleRender();
@@ -482,7 +495,9 @@ export function createWatchEventStore(dependencies = {}) {
         return false;
       }
       const normalized = normalizeEventBody(body);
-      lastEvent.kind = isError ? "tool error" : "tool result";
+      lastEvent.kind = "tool result";
+      lastEvent.toolState = isError ? "error" : "ok";
+      lastEvent.isError = isError;
       lastEvent.title = descriptor?.title ?? toolName;
       lastEvent.tone = descriptor?.tone ?? (isError ? "red" : "green");
       lastEvent.timestamp = nowStamp();
@@ -527,7 +542,9 @@ export function createWatchEventStore(dependencies = {}) {
         return false;
       }
       const normalized = normalizeEventBody(body);
-      lastEvent.kind = isError ? "subagent error" : "subagent tool result";
+      lastEvent.kind = "subagent tool result";
+      lastEvent.toolState = isError ? "error" : "ok";
+      lastEvent.isError = isError;
       lastEvent.title = descriptor?.title ?? toolName;
       lastEvent.tone = descriptor?.tone ?? (isError ? "red" : "green");
       lastEvent.timestamp = nowStamp();
@@ -544,6 +561,7 @@ export function createWatchEventStore(dependencies = {}) {
 
   function clearLiveTranscriptView() {
     events.length = 0;
+    clearAgentStreamingPreview();
     resetDelegationState();
     watchState.expandedEventId = null;
     watchState.transcriptScrollOffset = 0;

--- a/runtime/src/watch/agenc-watch-frame.mjs
+++ b/runtime/src/watch/agenc-watch-frame.mjs
@@ -2830,9 +2830,37 @@ export function createWatchFrameController(dependencies = {}) {
     return rows;
   }
 
+  function buildStreamingPreviewBlock(width) {
+    const previewText =
+      typeof watchState.agentStreamingPreview === "string"
+        ? watchState.agentStreamingPreview.trimEnd()
+        : "";
+    if (!previewText) {
+      return [];
+    }
+    const previewEvent = {
+      id: "__streaming_preview__",
+      kind: "agent",
+      title: "Agent Reply · live",
+      tone: "cyan",
+      body: previewText,
+      bodyTruncated: false,
+      renderMode: "markdown",
+      streamState: "streaming",
+    };
+    return renderEventBlock(previewEvent, width, { showBody: true });
+  }
+
   function flattenTranscriptView(width) {
     const transcriptEvents = visibleTranscriptEvents();
+    const streamingPreviewBlock = buildStreamingPreviewBlock(width);
     if (transcriptEvents.length === 0) {
+      if (streamingPreviewBlock.length > 0) {
+        return {
+          rows: streamingPreviewBlock,
+          ranges: new Map(),
+        };
+      }
       if (shouldShowIdleTranscript()) {
         return {
           rows: splashRenderer.renderIdleState(width),
@@ -2878,6 +2906,12 @@ export function createWatchFrameController(dependencies = {}) {
       rows.push(...block);
       ranges.set(event.id, { start, end: rows.length });
     });
+    if (streamingPreviewBlock.length > 0) {
+      if (rows.length > 0) {
+        rows.push(blankRow(width));
+      }
+      rows.push(...streamingPreviewBlock);
+    }
     return { rows, ranges };
   }
 

--- a/runtime/src/watch/agenc-watch-state.mjs
+++ b/runtime/src/watch/agenc-watch-state.mjs
@@ -525,6 +525,8 @@ export function createWatchState({
     latestTool: null,
     latestToolState: null,
     latestAgentSummary: null,
+    agentStreamingText: null,
+    agentStreamingPreview: null,
     currentObjective: null,
     runDetail: null,
     activeRunStartedAtMs: null,

--- a/runtime/src/watch/agenc-watch-surface-dispatch.mjs
+++ b/runtime/src/watch/agenc-watch-surface-dispatch.mjs
@@ -298,10 +298,7 @@ function handleChatSurfaceEvent(surfaceEvent, state, api) {
         if (chunk || payload.done) {
           api.eventStore.appendAgentStreamChunk(chunk, { done: payload.done === true });
         }
-        const statusPreview = api.sanitizeInlineText(chunk);
-        if (statusPreview) {
-          api.setTransientStatus(`streaming: ${api.truncate(statusPreview, 72)}`);
-        } else if (payload.done === true) {
+        if (payload.done === true) {
           api.setTransientStatus("agent stream complete");
         } else {
           api.setTransientStatus("agent streaming…");

--- a/runtime/src/watch/agenc-watch-surface-summary.mjs
+++ b/runtime/src/watch/agenc-watch-surface-summary.mjs
@@ -38,6 +38,34 @@ const BADGE_MAP = Object.freeze({
   voice: { label: "VOICE", tone: "purple" },
 });
 
+function badgeForEvent(event) {
+  const kind = event?.kind;
+  const fallbackBadge = BADGE_MAP[kind] ?? {
+    label: sanitizeText(kind ?? "event", "event").toUpperCase().slice(0, 10),
+    tone: "slate",
+  };
+  const toolState = toolStateFromEvent(event);
+  if (
+    (kind === "tool result" || kind === "subagent tool result") &&
+    toolState === "error"
+  ) {
+    return {
+      label: "ERROR",
+      tone: "red",
+    };
+  }
+  if (
+    (kind === "tool" || kind === "subagent tool") &&
+    toolState === "error"
+  ) {
+    return {
+      label: "ERROR",
+      tone: "red",
+    };
+  }
+  return fallbackBadge;
+}
+
 function sanitizeText(value, fallback = "") {
   const text = String(value ?? "").replace(/\s+/g, " ").trim();
   return text.length > 0 ? text : fallback;
@@ -257,6 +285,17 @@ function toolStateFromKind(kind) {
   }
 }
 
+function toolStateFromEvent(event) {
+  const explicitState = sanitizeText(event?.toolState ?? "", "");
+  if (explicitState) {
+    return explicitState;
+  }
+  if (event?.isError === true) {
+    return "error";
+  }
+  return toolStateFromKind(event?.kind);
+}
+
 function eventMetaLabel(event) {
   if (event.kind === "agent") {
     const title = sanitizeText(event.title ?? "", event.kind);
@@ -348,10 +387,7 @@ export function shouldShowWatchSplash({
 }
 
 export function buildTranscriptEventSummary(event, previewLines = []) {
-  const badge = BADGE_MAP[event?.kind] ?? {
-    label: sanitizeText(event?.kind ?? "event", "event").toUpperCase().slice(0, 10),
-    tone: "slate",
-  };
+  const badge = badgeForEvent(event);
   const title = sanitizeText(event?.title ?? "", badge.label);
   const meta = eventMetaLabel(event ?? {});
   return {
@@ -361,7 +397,7 @@ export function buildTranscriptEventSummary(event, previewLines = []) {
     meta,
     previewLines: Array.isArray(previewLines) ? previewLines : [],
     hasBody: sanitizeText(event?.body ?? "").length > 0,
-    toolState: toolStateFromKind(event?.kind),
+    toolState: toolStateFromEvent(event),
   };
 }
 
@@ -723,8 +759,8 @@ export function buildWatchSurfaceSummary({
       title: sanitizeText(event.title, event.kind),
       meta: eventMetaLabel(event),
       timestamp: sanitizeText(event.timestamp, "--:--:--"),
-      state: toolStateFromKind(event.kind),
-      tone: stateTone(toolStateFromKind(event.kind)),
+      state: toolStateFromEvent(event),
+      tone: stateTone(toolStateFromEvent(event)),
     }));
   const recentAlerts = recentEvents
     .filter((event) => ALERT_EVENT_KINDS.has(event.kind))

--- a/runtime/tests/watch/agenc-watch-event-store.test.mjs
+++ b/runtime/tests/watch/agenc-watch-event-store.test.mjs
@@ -11,6 +11,8 @@ function createHarness(overrides = {}) {
     detailScrollOffset: 4,
     lastActivityAt: null,
     latestAgentSummary: null,
+    agentStreamingText: null,
+    agentStreamingPreview: null,
     expandedEventId: "evt-stale",
   };
   const calls = [];
@@ -79,14 +81,21 @@ test("event store streams and commits agent replies with summary side effects", 
 
   store.appendAgentStreamChunk("hello ");
   store.appendAgentStreamChunk("world", { done: true });
+
+  assert.equal(events.length, 0);
+  assert.equal(watchState.agentStreamingText, "hello world");
+  assert.equal(watchState.agentStreamingPreview, null);
+
   store.commitAgentMessage("hello world");
 
   assert.equal(events.length, 1);
   assert.equal(events[0].title, "Agent Reply");
   assert.equal(events[0].streamState, "complete");
   assert.equal(events[0].body, "hello world");
+  assert.equal(watchState.agentStreamingText, null);
+  assert.equal(watchState.agentStreamingPreview, null);
   assert.equal(watchState.latestAgentSummary, "hello world");
-  assert.equal(watchState.lastActivityAt, "12:00:03");
+  assert.equal(watchState.lastActivityAt, "12:00:04");
   assert.equal(watchState.transcriptFollowMode, true);
 });
 
@@ -146,9 +155,17 @@ test("event store appends streaming chunks from preserved full assistant body", 
   store.appendAgentStreamChunk("56789");
   store.appendAgentStreamChunk("abcdef", { done: true });
 
-  assert.equal(events.length, 1);
-  assert.equal(events[0].body, "0123456…");
-  assert.equal(events[0].detailBody, "0123456789abcdef");
+  assert.equal(events.length, 0);
+});
+
+test("event store line-buffers the streaming preview until the next newline", () => {
+  const { store, watchState } = createHarness();
+
+  store.appendAgentStreamChunk("hello");
+  assert.equal(watchState.agentStreamingPreview, null);
+
+  store.appendAgentStreamChunk("\nworld");
+  assert.equal(watchState.agentStreamingPreview, "hello\n");
 });
 
 test("event store clears live transcript view and delegation state", () => {
@@ -186,6 +203,24 @@ test("event store replaces latest tool results and clears subagent heartbeats", 
   assert.equal(store.clearSubagentHeartbeatEvents("sub-1"), true);
 
   assert.equal(events[0].kind, "tool result");
+  assert.equal(events[0].toolState, "ok");
   assert.equal(events[0].previewMode, "source");
   assert.equal(events.some((event) => event.subagentHeartbeat), false);
+});
+
+test("event store keeps failed tool completions on the tool result path", () => {
+  const { store, events } = createHarness();
+
+  store.pushEvent("tool", "Run edit", "body", "yellow", { toolName: "system.editFile" });
+  assert.equal(
+    store.replaceLatestToolEvent("system.editFile", true, "No-op edit rejected", {
+      title: "Edit failed",
+      tone: "red",
+    }),
+    true,
+  );
+
+  assert.equal(events[0].kind, "tool result");
+  assert.equal(events[0].toolState, "error");
+  assert.equal(events[0].isError, true);
 });

--- a/runtime/tests/watch/agenc-watch-surface-dispatch.test.mjs
+++ b/runtime/tests/watch/agenc-watch-surface-dispatch.test.mjs
@@ -837,7 +837,7 @@ test("dispatchOperatorSurfaceEvent accepts content-based chat.stream payloads", 
 
   assert.deepEqual(calls, [
     ["appendAgentStreamChunk", "partial", { done: false }],
-    ["status", "streaming: partial"],
+    ["status", "agent streaming…"],
   ]);
 });
 
@@ -860,7 +860,7 @@ test("dispatchOperatorSurfaceEvent retains delta fallback for older chat.stream 
 
   assert.deepEqual(calls, [
     ["appendAgentStreamChunk", "legacy", { done: false }],
-    ["status", "streaming: legacy"],
+    ["status", "agent streaming…"],
   ]);
 });
 

--- a/runtime/tests/watch/agenc-watch-surface-summary.test.mjs
+++ b/runtime/tests/watch/agenc-watch-surface-summary.test.mjs
@@ -205,7 +205,14 @@ test("buildWatchSurfaceSummary derives route, alerts, and recent tool timeline",
       { kind: "approval", title: "Resolver needed", timestamp: "15:30:01" },
       { kind: "tool", title: "Run pwd", toolName: "system.bash", timestamp: "15:30:02" },
       { kind: "tool result", title: "Ran pwd", toolName: "system.bash", timestamp: "15:30:03" },
-      { kind: "tool error", title: "Command failed", toolName: "system.readFile", timestamp: "15:30:04" },
+      {
+        kind: "tool result",
+        title: "Command failed",
+        toolName: "system.readFile",
+        toolState: "error",
+        isError: true,
+        timestamp: "15:30:04",
+      },
     ],
     planCount: 3,
     activeAgentCount: 1,
@@ -295,6 +302,21 @@ test("buildTranscriptEventSummary assigns visible badge and tool state", () => {
   assert.equal(summary.meta, "system.writeFile 12345678");
   assert.equal(summary.toolState, "ok");
   assert.deepEqual(summary.previewLines, ["line 1", "line 2"]);
+});
+
+test("buildTranscriptEventSummary marks failed tool results without changing the event path", () => {
+  const summary = buildTranscriptEventSummary({
+    kind: "tool result",
+    title: "Search failed",
+    toolName: "system.grep",
+    timestamp: "15:31:02",
+    body: "Search failed: path missing",
+    toolState: "error",
+    isError: true,
+  });
+
+  assert.deepEqual(summary.badge, { label: "ERROR", tone: "red" });
+  assert.equal(summary.toolState, "error");
 });
 
 test("buildTranscriptEventSummary omits generic meta labels for agent and prompt cards", () => {


### PR DESCRIPTION
## Summary
- move live watch streaming into an ephemeral preview instead of mutating transcript history per chunk
- keep failed tool completions on the tool-result path and tighten watch badge/status handling
- suppress high-volume stream and result payload trace noise in normal operator logs

## Validation
- `node --test runtime/tests/watch/agenc-watch-event-store.test.mjs runtime/tests/watch/agenc-watch-surface-dispatch.test.mjs runtime/tests/watch/agenc-watch-surface-summary.test.mjs`
- `npm exec --workspace=@tetsuo-ai/runtime -- vitest run src/llm/provider-trace-logger.test.ts src/gateway/daemon-trace.test.ts src/channels/webchat/plugin.test.ts`
- `npm exec --workspace=@tetsuo-ai/runtime -- tsc --noEmit --pretty false`
- `npm run build --workspace=@tetsuo-ai/runtime`