### PR TITLE
fix(watch): give mkdir tool-specific presentation

### DIFF
--- a/runtime/src/watch/agenc-watch-tool-presentation-copy.mjs
+++ b/runtime/src/watch/agenc-watch-tool-presentation-copy.mjs
@@ -91,6 +91,12 @@ export function createWatchToolPresentationCopyBuilder(dependencies = {}) {
           body: data.dirPathDisplay || "(pending directory listing)",
           tone: "slate",
         };
+      case "mkdir-start":
+        return {
+          title: `mkdir ${data.dirPathDisplay || "directory"}`,
+          body: data.dirPathDisplay ? `path: ${data.dirPathDisplay}` : "(pending directory create)",
+          tone: "yellow",
+        };
       case "shell-start":
         return {
           title: `Run ${data.commandText || "command"}`,
@@ -159,6 +165,14 @@ export function createWatchToolPresentationCopyBuilder(dependencies = {}) {
               ? data.entries.join("  ")
               : data.dirPathDisplay || "(directory listed)",
           tone: data.isError ? "red" : "slate",
+        };
+      case "mkdir-result":
+        return {
+          title: `mkdir ${data.dirPathDisplay || "directory"}`,
+          body: data.isError
+            ? (data.errorPreview || "(mkdir failed)")
+            : "Done",
+          tone: data.isError ? "red" : "green",
         };
       case "desktop-editor-result":
         return describeDesktopTextEditorResult(data);

--- a/runtime/src/watch/agenc-watch-tool-presentation-normalizer.mjs
+++ b/runtime/src/watch/agenc-watch-tool-presentation-normalizer.mjs
@@ -283,6 +283,17 @@ export function createWatchToolPresentationNormalizer(dependencies = {}) {
           kind: "list-dir-start",
           dirPathDisplay: compactPathForDisplay(payload.path ?? payload.dir ?? payload.directory),
         };
+      case "system.mkdir": {
+        const dirPathValue = payload.path ?? payload.dir ?? payload.directory;
+        return {
+          kind: "mkdir-start",
+          dirPathDisplay: compactPathForDisplay(dirPathValue),
+          dirPathRaw:
+            typeof dirPathValue === "string" && String(dirPathValue).trim().length > 0
+              ? sanitizeInlineText(String(dirPathValue))
+              : null,
+        };
+      }
       case "system.bash":
         return {
           kind: "shell-start",
@@ -377,6 +388,24 @@ export function createWatchToolPresentationNormalizer(dependencies = {}) {
               .filter(Boolean)
             : [],
         };
+      case "system.mkdir": {
+        const dirPathValue = resultObject.path ?? payload.path ?? payload.dir ?? payload.directory;
+        const errorText =
+          typeof resultObject.error === "string" && resultObject.error.trim().length > 0
+            ? resultObject.error
+            : null;
+        return {
+          kind: "mkdir-result",
+          isError,
+          dirPathDisplay: compactPathForDisplay(dirPathValue),
+          dirPathRaw:
+            typeof dirPathValue === "string" && String(dirPathValue).trim().length > 0
+              ? sanitizeInlineText(String(dirPathValue))
+              : null,
+          errorText,
+          errorPreview: isError ? firstMeaningfulLine(errorText ?? tryPrettyJson(result)) : null,
+        };
+      }
       case "desktop.text_editor":
         return normalizeDesktopTextEditorResult(payload, resultObject, isError);
       case "system.bash":

--- a/runtime/tests/watch/agenc-watch-tool-presentation-normalizer.test.mjs
+++ b/runtime/tests/watch/agenc-watch-tool-presentation-normalizer.test.mjs
@@ -73,3 +73,35 @@ test("normalizer keeps generic result parsing separate from final transcript cop
   assert.match(normalized.prettyResult, /"status": "ready"/);
   assert.match(normalized.prettyResult, /"detail": "daemon ok"/);
 });
+
+test("normalizer classifies mkdir start and result separately from generic tools", () => {
+  const normalizer = createNormalizer();
+
+  assert.deepEqual(
+    normalizer.normalizeToolStart("system.mkdir", {
+      path: "src/ui",
+    }),
+    {
+      kind: "mkdir-start",
+      dirPathDisplay: "src/ui",
+      dirPathRaw: "src/ui",
+    },
+  );
+
+  assert.deepEqual(
+    normalizer.normalizeToolResult(
+      "system.mkdir",
+      { path: "src/ui" },
+      false,
+      '{"path":"src/ui","created":true}',
+    ),
+    {
+      kind: "mkdir-result",
+      isError: false,
+      dirPathDisplay: "src/ui",
+      dirPathRaw: "src/ui",
+      errorText: null,
+      errorPreview: null,
+    },
+  );
+});

--- a/runtime/tests/watch/agenc-watch-tool-presentation.test.mjs
+++ b/runtime/tests/watch/agenc-watch-tool-presentation.test.mjs
@@ -142,3 +142,32 @@ test("tool presentation formats shell results and generic summaries", () => {
   assert.equal(generic.body, "status: ready");
   assert.equal(generic.tone, "green");
 });
+
+test("tool presentation gives system.mkdir a tool-specific row and terse success body", () => {
+  const tools = createToolPresentation();
+
+  assert.deepEqual(
+    tools.describeToolStart("system.mkdir", {
+      path: "src/ui",
+    }),
+    {
+      title: "mkdir src/ui",
+      body: "path: src/ui",
+      tone: "yellow",
+    },
+  );
+
+  assert.deepEqual(
+    tools.describeToolResult(
+      "system.mkdir",
+      { path: "src/ui" },
+      false,
+      JSON.stringify({ path: "src/ui", created: true }),
+    ),
+    {
+      title: "mkdir src/ui",
+      body: "Done",
+      tone: "green",
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- give `system.mkdir` a dedicated watch presentation path instead of falling through the generic tool renderer
- show the target directory in the tool row and use a terse success body instead of raw structured JSON
- add focused watch presentation tests for the mkdir start/result path

## Verification
- `node --test runtime/tests/watch/agenc-watch-tool-presentation-normalizer.test.mjs runtime/tests/watch/agenc-watch-tool-presentation.test.mjs`