### PR TITLE
fix(watch): hydrate usage header state

### DIFF
--- a/runtime/src/channels/webchat/operator-events.test.ts
+++ b/runtime/src/channels/webchat/operator-events.test.ts
@@ -153,6 +153,19 @@ describe("operator event normalization", () => {
     expect(shouldIgnoreOperatorMessage(message, "other-session")).toBe(true);
   });
 
+  it("treats chat.usage as a session-scoped event when a session id is present", () => {
+    const message = {
+      type: "chat.usage",
+      payload: {
+        sessionId: "session:abc123",
+        totalTokens: 1234,
+      },
+    };
+
+    expect(shouldIgnoreOperatorMessage(message, "session:abc123")).toBe(false);
+    expect(shouldIgnoreOperatorMessage(message, "other-session")).toBe(true);
+  });
+
   it("does not ignore shared session command results during bootstrap", () => {
     const message = {
       type: "session.command.result",

--- a/runtime/src/channels/webchat/operator-events.ts
+++ b/runtime/src/channels/webchat/operator-events.ts
@@ -71,6 +71,7 @@ const SESSION_SCOPED_TYPES = new Set([
   "chat.stream",
   "chat.typing",
   "chat.cancelled",
+  "chat.usage",
   "session.command.result",
   "run.inspect",
   "run.updated",

--- a/runtime/src/channels/webchat/plugin.test.ts
+++ b/runtime/src/channels/webchat/plugin.test.ts
@@ -839,6 +839,42 @@ describe("WebChatChannel", () => {
       expect(gatewayMsg.scope).toBe("dm");
     });
 
+    it("includes a usage snapshot in the session payload when available", async () => {
+      deps = createDeps({
+        getSessionUsageSnapshot: (sessionId) => ({
+          sessionId,
+          totalTokens: 1250,
+          budget: 16000,
+          compacted: false,
+          contextWindowTokens: 64000,
+        }),
+      });
+      context = createContext();
+      channel = new WebChatChannel(deps);
+      await channel.initialize(context);
+      await channel.start();
+
+      const send = vi.fn<(response: ControlResponse) => void>();
+      channel.handleMessage(
+        "client_1",
+        "chat.message",
+        msg("chat.message", { content: "Hello usage!" }, "req-usage-1"),
+        send,
+      );
+
+      expect(findResponse(send, "chat.session", "req-usage-1")).toEqual(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            sessionId: expect.any(String),
+            usage: expect.objectContaining({
+              totalTokens: 1250,
+              contextWindowTokens: 64000,
+            }),
+          }),
+        }),
+      );
+    });
+
     it("should forward and persist policy context for the session", async () => {
       const memoryBackend = new InMemoryBackend();
       deps = createDeps({ memoryBackend });

--- a/runtime/src/channels/webchat/plugin.ts
+++ b/runtime/src/channels/webchat/plugin.ts
@@ -50,6 +50,7 @@ import {
   metadataFromTranscript,
   recoverTranscriptHistory,
 } from "../../gateway/session-transcript.js";
+import type { ChatUsagePayload } from "../../gateway/chat-usage.js";
 import type {
   WebChatHandler,
   WebChatDeps,
@@ -1993,12 +1994,14 @@ export class WebChatChannel
   private buildChatSessionPayload(
     sessionId: string,
     workspaceRoot?: string,
-  ): { sessionId: string; workspaceRoot?: string } {
+  ): { sessionId: string; workspaceRoot?: string; usage?: ChatUsagePayload } {
     const resolvedWorkspaceRoot =
       workspaceRoot ?? this.sessionWorkspaceRoots.get(sessionId);
+    const usage = this.deps.getSessionUsageSnapshot?.(sessionId) ?? null;
     return {
       sessionId,
       ...(resolvedWorkspaceRoot ? { workspaceRoot: resolvedWorkspaceRoot } : {}),
+      ...(usage ? { usage } : {}),
     };
   }
 

--- a/runtime/src/channels/webchat/types.ts
+++ b/runtime/src/channels/webchat/types.ts
@@ -44,6 +44,7 @@ import type { SessionShellProfile } from "../../gateway/shell-profile.js";
 import type { SessionWorkflowState } from "../../gateway/workflow-state.js";
 import type { SlashCommandRegistry } from "../../gateway/commands.js";
 import type { ActiveTaskContext } from "../../llm/turn-execution-contract-types.js";
+import type { ChatUsagePayload } from "../../gateway/chat-usage.js";
 
 // ============================================================================
 // WebChatDeps (dependency injection)
@@ -187,6 +188,8 @@ export interface WebChatDeps {
   connection?: import("@solana/web3.js").Connection;
   /** Optional callback to broadcast events to all subscribed WS clients. */
   broadcastEvent?: (eventType: string, data: Record<string, unknown>) => void;
+  /** Optional callback to resolve the latest usage snapshot for one session. */
+  getSessionUsageSnapshot?: (sessionId: string) => ChatUsagePayload | null;
   /** Optional desktop sandbox manager for desktop.* handlers. */
   desktopManager?: import("../../desktop/manager.js").DesktopSandboxManager;
   /**

--- a/runtime/src/gateway/chat-usage.ts
+++ b/runtime/src/gateway/chat-usage.ts
@@ -17,7 +17,8 @@ interface ChatUsageSection {
   readonly percent: number;
 }
 
-interface ChatUsagePayload {
+export interface ChatUsagePayload {
+  readonly sessionId?: string;
   readonly totalTokens: number;
   readonly budget: number;
   readonly compacted: boolean;
@@ -44,6 +45,7 @@ interface ChatUsagePayload {
 }
 
 interface BuildChatUsagePayloadInput {
+  readonly sessionId?: string;
   readonly totalTokens: number;
   readonly sessionTokenBudget: number;
   readonly compacted: boolean;
@@ -103,6 +105,7 @@ export function buildChatUsagePayload(
   input: BuildChatUsagePayloadInput,
 ): ChatUsagePayload {
   const payload: ChatUsagePayload = {
+    ...(input.sessionId ? { sessionId: input.sessionId } : {}),
     totalTokens: normalizeNonNegativeInt(input.totalTokens),
     budget: normalizeNonNegativeInt(input.sessionTokenBudget),
     compacted: input.compacted === true,

--- a/runtime/src/gateway/daemon-webchat-turn.test.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.test.ts
@@ -431,7 +431,10 @@ You have broad access to this machine via the system.bash tool.`,
     );
     expect(webChat.pushToSession).toHaveBeenCalledWith(
       "session:test",
-      expect.objectContaining({ type: "chat.usage" }),
+      expect.objectContaining({
+        type: "chat.usage",
+        payload: expect.objectContaining({ sessionId: "session:test" }),
+      }),
     );
     expect(webChat.broadcastEvent).toHaveBeenCalledWith("chat.response", {
       sessionId: "session:test",

--- a/runtime/src/gateway/daemon-webchat-turn.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.ts
@@ -560,6 +560,7 @@ export async function executeWebChatConversationTurn(
     webChat.pushToSession(msg.sessionId, {
       type: "chat.usage",
       payload: buildChatUsagePayload({
+        sessionId: msg.sessionId,
         totalTokens: getSessionTokenUsage(msg.sessionId),
         sessionTokenBudget,
         compacted: result.compacted ?? false,

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -129,6 +129,7 @@ import {
   DEFAULT_GROK_MODEL,
   type LLMProviderConfigCatalogEntry,
 } from "./llm-provider-manager.js";
+import { buildChatUsagePayload } from "./chat-usage.js";
 import type {
   ChatExecutorResult,
   DeterministicPipelineExecutor,
@@ -2257,6 +2258,26 @@ export class DaemonManager {
       hooks,
       voiceBridge,
       memoryBackend,
+      getSessionUsageSnapshot: (sessionId) => {
+        const contextWindowTokens =
+          this._resolvedContextWindowTokens ?? inferContextWindowTokens(config.llm);
+        const executor = this._chatExecutor;
+        if (!executor) {
+          return null;
+        }
+        return buildChatUsagePayload({
+          sessionId,
+          totalTokens: executor.getSessionTokenUsage(sessionId),
+          sessionTokenBudget: resolveSessionTokenBudget(
+            config.llm,
+            contextWindowTokens,
+          ),
+          compacted: false,
+          provider: config.llm?.provider,
+          model: config.llm?.model,
+          contextWindowTokens,
+        });
+      },
       approvalEngine: approvalEngine ?? undefined,
       skillToggle,
       connection: this._connectionManager?.getConnection(),

--- a/runtime/src/gateway/voice-bridge.test.ts
+++ b/runtime/src/gateway/voice-bridge.test.ts
@@ -275,6 +275,7 @@ describe("VoiceBridge delegation", () => {
     expect(send).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "chat.usage",
+        payload: expect.objectContaining({ sessionId: "session-1" }),
       }),
     );
     expect(result).toContain("Task completed");

--- a/runtime/src/gateway/voice-bridge.ts
+++ b/runtime/src/gateway/voice-bridge.ts
@@ -873,6 +873,7 @@ export class VoiceBridge {
       send({
         type: "chat.usage",
         payload: buildChatUsagePayload({
+          sessionId,
           totalTokens: chatExecutor.getSessionTokenUsage(sessionId),
           sessionTokenBudget: this.config.sessionTokenBudget ?? 0,
           compacted: result.compacted ?? false,

--- a/runtime/src/watch/agenc-watch-surface-dispatch.mjs
+++ b/runtime/src/watch/agenc-watch-surface-dispatch.mjs
@@ -84,6 +84,45 @@ function isRecord(value) {
   return typeof value === "object" && value !== null;
 }
 
+function syncUsageSummaryFromPayload(state, api, payload) {
+  if (!isRecord(payload) || !isRecord(payload.usage)) {
+    return;
+  }
+  const usageSummary = api.summarizeUsage(payload.usage);
+  if (usageSummary) {
+    state.lastUsageSummary = usageSummary;
+  }
+}
+
+function syncUsageSummaryFromContextResult(state, payload) {
+  if (!isRecord(payload) || payload.commandName !== "context") {
+    return;
+  }
+  const metrics = Array.isArray(payload.metrics) ? payload.metrics : [];
+  const usedMetric = metrics.find((entry) =>
+    isRecord(entry) && typeof entry.label === "string" && entry.label.trim().toLowerCase() === "used"
+  );
+  const contextMetric = metrics.find((entry) =>
+    isRecord(entry) &&
+    typeof entry.label === "string" &&
+    entry.label.trim().toLowerCase() === "context window"
+  );
+  const usedValue =
+    isRecord(usedMetric) && typeof usedMetric.value === "string"
+      ? usedMetric.value.trim()
+      : "";
+  const contextValue =
+    isRecord(contextMetric) && typeof contextMetric.value === "string"
+      ? contextMetric.value.trim()
+      : "";
+  if (!usedValue) {
+    return;
+  }
+  state.lastUsageSummary = contextValue
+    ? `${usedValue} / ${contextValue}`
+    : usedValue;
+}
+
 function requestSharedCommandCatalog(api, sessionId = null) {
   api.send(
     "session.command.catalog.get",
@@ -203,6 +242,7 @@ function handleSessionSurfaceEvent(surfaceEvent, state, api) {
       state.cockpitUpdatedAt = 0;
       state.cockpitFingerprint = null;
       api.resetLiveRunSurface();
+      syncUsageSummaryFromPayload(state, api, payload);
       state.runDetail = null;
       state.runState = "idle";
       state.runPhase = null;
@@ -217,6 +257,7 @@ function handleSessionSurfaceEvent(surfaceEvent, state, api) {
       }
       return true;
     case "chat.session.resumed":
+      syncUsageSummaryFromPayload(state, api, payload);
       return handleSessionResumeResult(payload, { resumed: { sessionId: payload.sessionId } }, state, api);
     case "chat.session.list": {
       return handleSessionListResult({ sessions: surfaceEvent.payloadList ?? [] }, state, api);
@@ -282,6 +323,7 @@ function handleChatSurfaceEvent(surfaceEvent, state, api) {
         state.sessionId = payload.sessionId.trim();
         api.persistSessionId(state.sessionId);
       }
+      syncUsageSummaryFromContextResult(state, payload);
       api.setTransientStatus(`/${commandName} ready`);
       api.eventStore.pushEvent("operator", `/${commandName}`, content, "teal");
       api.requestCockpit(`/${commandName}`);

--- a/runtime/tests/watch/agenc-watch-surface-dispatch.test.mjs
+++ b/runtime/tests/watch/agenc-watch-surface-dispatch.test.mjs
@@ -132,6 +132,42 @@ test("dispatchOperatorSurfaceEvent handles session-ready events", () => {
   ]);
 });
 
+test("dispatchOperatorSurfaceEvent seeds usage summary from session payloads", () => {
+  const { api, state } = createHarness({
+    api: {
+      summarizeUsage: (value) => `${value.totalTokens} total / ${value.contextWindowTokens} ctx`,
+    },
+  });
+
+  dispatchOperatorSurfaceEvent(
+    {
+      family: "session",
+      type: "chat.session",
+      payload: {
+        sessionId: "session-usage",
+        usage: {
+          totalTokens: 1200,
+          contextWindowTokens: 64000,
+        },
+      },
+      payloadRecord: {
+        sessionId: "session-usage",
+        usage: {
+          totalTokens: 1200,
+          contextWindowTokens: 64000,
+        },
+      },
+      payloadList: null,
+      isSessionScoped: false,
+      message: { error: undefined },
+    },
+    null,
+    api,
+  );
+
+  assert.equal(state.lastUsageSummary, "1200 total / 64000 ctx");
+});
+
 test("dispatchOperatorSurfaceEvent resumes sessions by restoring history and inspecting the run", () => {
   const { api, state, calls } = createHarness({
     state: { bootstrapReady: true },
@@ -192,6 +228,44 @@ test("dispatchOperatorSurfaceEvent restores bootstrap history before marking the
     ["requestRunInspect", "history restore", { force: true }],
     ["requestCockpit", "history restore"],
   ]);
+});
+
+test("dispatchOperatorSurfaceEvent updates usage summary from /context results", () => {
+  const { api, state } = createHarness({
+    state: { sessionId: "session-ctx" },
+  });
+
+  dispatchOperatorSurfaceEvent(
+    {
+      family: "chat",
+      type: "session.command.result",
+      payload: {
+        commandName: "context",
+        sessionId: "session-ctx",
+        metrics: [
+          { label: "Context Window", value: "64,000 tokens" },
+          { label: "Used", value: "1,250 tokens (2.0%)" },
+        ],
+        content: "context report",
+      },
+      payloadRecord: {
+        commandName: "context",
+        sessionId: "session-ctx",
+        metrics: [
+          { label: "Context Window", value: "64,000 tokens" },
+          { label: "Used", value: "1,250 tokens (2.0%)" },
+        ],
+        content: "context report",
+      },
+      payloadList: null,
+      isSessionScoped: true,
+      message: {},
+    },
+    null,
+    api,
+  );
+
+  assert.equal(state.lastUsageSummary, "1,250 tokens (2.0%) / 64,000 tokens");
 });
 
 test("dispatchOperatorSurfaceEvent restores resumed history without blocking session input", () => {


### PR DESCRIPTION
## Summary
- carry session-scoped usage payloads through webchat and voice usage events
- seed the watch header usage summary from session bootstrap/resume payloads
- update the watch header from `/context` results when they are returned

## Validation
- `node --test runtime/tests/watch/agenc-watch-surface-dispatch.test.mjs`
- `npm exec --workspace=@tetsuo-ai/runtime -- vitest run src/channels/webchat/operator-events.test.ts src/channels/webchat/plugin.test.ts src/gateway/daemon-webchat-turn.test.ts src/gateway/voice-bridge.test.ts`
- `npm exec --workspace=@tetsuo-ai/runtime -- tsc --noEmit --pretty false`