### PR TITLE
fix(bash): allow shell mkdir scaffolding

### DIFF
--- a/runtime/src/llm/shell-write-policy.test.ts
+++ b/runtime/src/llm/shell-write-policy.test.ts
@@ -34,6 +34,21 @@ describe("evaluateShellWorkspaceWritePolicy", () => {
     expect(decision.observedTargets).toContain("/workspace/build/build.log");
   });
 
+  it("allows mkdir scaffolding in workspace source paths", () => {
+    const decision = evaluateShellWorkspaceWritePolicy({
+      toolName: "system.bash",
+      args: {
+        command: "mkdir -p src/app include/agenc docs",
+      },
+      workspaceRoot,
+      turnClass: "workflow_implementation",
+    });
+
+    expect(decision.blocked).toBe(false);
+    expect(decision.indeterminate).toBe(false);
+    expect(decision.blockedTargets).toEqual([]);
+  });
+
   it("blocks direct-mode tee writes into workspace source paths", () => {
     const decision = evaluateShellWorkspaceWritePolicy({
       toolName: "system.bash",

--- a/runtime/src/llm/shell-write-policy.ts
+++ b/runtime/src/llm/shell-write-policy.ts
@@ -308,7 +308,10 @@ function collectDirectCommandWriteTargets(params: {
   if (command === "cp" || command === "mv" || command === "install" || command === "ln") {
     return collectDestinationTarget(command, params.args, params.cwd);
   }
-  if (command === "mkdir" || command === "rm" || command === "rmdir" || command === "truncate") {
+  if (command === "mkdir") {
+    return emptyTargetCollection();
+  }
+  if (command === "rm" || command === "rmdir" || command === "truncate") {
     return collectOperandTargets(params.args, params.cwd);
   }
   if (command === "dd") {

--- a/runtime/src/tools/system/bash.test.ts
+++ b/runtime/src/tools/system/bash.test.ts
@@ -1166,6 +1166,26 @@ describe("system.bash tool", () => {
       }
     });
 
+    it("allows mkdir scaffolding in the workspace root", async () => {
+      const workspaceRoot = mkdtempSync(
+        join(tmpdir(), "agenc-bash-mkdir-write-"),
+      );
+
+      try {
+        const tool = createBashTool({ cwd: workspaceRoot });
+        mockSpawnSuccess("");
+
+        const result = await tool.execute({ command: "mkdir -p src/app include/agenc docs" });
+        const parsed = parseContent(result);
+
+        expect(result.isError).toBeUndefined();
+        expect(parsed.exitCode).toBe(0);
+        expect(mockSpawn).toHaveBeenCalledOnce();
+      } finally {
+        rmSync(workspaceRoot, { recursive: true, force: true });
+      }
+    });
+
     it("blocks dangerous inline shell wrapper scripts", async () => {
       const tool = createBashTool();
 


### PR DESCRIPTION
## Summary
- stop classifying `mkdir` as a blocked workspace shell write
- keep the remaining shell workspace write fence intact
- add regression coverage for policy evaluation and bash tool execution

## Validation
- `npm exec --workspace=@tetsuo-ai/runtime -- vitest run src/llm/shell-write-policy.test.ts src/tools/system/bash.test.ts`
- `npm exec --workspace=@tetsuo-ai/runtime -- tsc --noEmit --pretty false`