### PR TITLE
fix(runtime): remove interactive failure budget

### DIFF
--- a/runtime/src/gateway/daemon-text-channel-turn.test.ts
+++ b/runtime/src/gateway/daemon-text-channel-turn.test.ts
@@ -252,7 +252,7 @@ describe("executeTextChannelTurn", () => {
     );
     expect(execute).toHaveBeenCalledOnce();
     expect(execute).toHaveBeenCalledWith(
-      expect.objectContaining({ maxToolRounds: 3, maxFailureBudgetPerRequest: 4 }),
+      expect.objectContaining({ maxToolRounds: 3 }),
     );
     expect(recordToolRoutingOutcome).toHaveBeenCalledWith(
       "session:test",

--- a/runtime/src/gateway/daemon-text-channel-turn.ts
+++ b/runtime/src/gateway/daemon-text-channel-turn.ts
@@ -288,7 +288,6 @@ export async function executeTextChannelTurn(
       : {}),
     toolHandler,
     maxToolRounds: effectiveMaxToolRounds,
-    maxFailureBudgetPerRequest: 4,
     ...(sessionStateful ? { stateful: sessionStateful } : {}),
     ...(structuredOutput ? { structuredOutput } : {}),
     ...(isConcordiaGenerateAgentsTurn

--- a/runtime/src/gateway/daemon-webchat-turn.test.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.test.ts
@@ -427,7 +427,7 @@ You have broad access to this machine via the system.bash tool.`,
       content: "reply",
     });
     expect(execute).toHaveBeenCalledWith(
-      expect.objectContaining({ maxToolRounds: 3, maxFailureBudgetPerRequest: 4 }),
+      expect.objectContaining({ maxToolRounds: 3 }),
     );
     expect(webChat.pushToSession).toHaveBeenCalledWith(
       "session:test",

--- a/runtime/src/gateway/daemon-webchat-turn.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.ts
@@ -313,7 +313,6 @@ export async function executeWebChatConversationTurn(
       onStreamChunk: sessionStreamCallback,
       signal: abortController.signal,
       maxToolRounds: effectiveMaxToolRounds,
-      maxFailureBudgetPerRequest: 4,
       ...(sessionStateful ? { stateful: sessionStateful } : {}),
       toolRouting: toolRoutingDecision
         ? {

--- a/runtime/src/gateway/voice-bridge.test.ts
+++ b/runtime/src/gateway/voice-bridge.test.ts
@@ -269,7 +269,6 @@ describe("VoiceBridge delegation", () => {
       expect.objectContaining({
         sessionId: "session-1",
         systemPrompt: "You are a helpful assistant.",
-        maxFailureBudgetPerRequest: 4,
       }),
     );
     expect(send).toHaveBeenCalledWith(
@@ -364,7 +363,6 @@ describe("VoiceBridge delegation", () => {
 
     expect(execute).toHaveBeenCalledWith(
       expect.objectContaining({
-        maxFailureBudgetPerRequest: 4,
         trace: expect.objectContaining({
           includeProviderPayloads: true,
           onProviderTraceEvent: expect.any(Function),

--- a/runtime/src/gateway/voice-bridge.ts
+++ b/runtime/src/gateway/voice-bridge.ts
@@ -809,7 +809,6 @@ export class VoiceBridge {
         sessionId,
         toolHandler: delegationToolHandler,
         maxToolRounds: MAX_DELEGATION_TOOL_ROUNDS,
-        maxFailureBudgetPerRequest: 4,
         signal: abortController.signal,
         ...(providerTrace ? { trace: providerTrace } : {}),
       });


### PR DESCRIPTION
## Summary
- remove the hard-coded failed-tool-call budget from interactive web, text, and voice entrypoints
- let those paths inherit the executor default failure budget instead of forcing `4`
- update the entrypoint tests to match the new runtime contract

## Validation
- `npm exec --workspace=@tetsuo-ai/runtime -- vitest run src/gateway/daemon-webchat-turn.test.ts src/gateway/daemon-text-channel-turn.test.ts src/gateway/voice-bridge.test.ts`
- `npm exec --workspace=@tetsuo-ai/runtime -- tsc --noEmit --pretty false`