### PR TITLE
 fix watch table rendering

### DIFF
--- a/runtime/src/watch/agenc-watch-event-display.mjs
+++ b/runtime/src/watch/agenc-watch-event-display.mjs
@@ -296,6 +296,56 @@ export function buildSourcePreviewDisplayLines(event, { cwd, maxChars = 72 } = {
   return lines.concat(contentLines.map((line) => createDisplayLine(line, "code")));
 }
 
+function limitDisplayLines(lines, maxLines = Infinity) {
+  const normalizedMaxLines = Number.isFinite(Number(maxLines))
+    ? Math.max(0, Number(maxLines))
+    : Infinity;
+  return Number.isFinite(normalizedMaxLines)
+    ? lines.slice(0, normalizedMaxLines)
+    : lines;
+}
+
+function markdownRenderOptionsForWidth(width) {
+  const numericWidth = Number(width);
+  if (!Number.isFinite(numericWidth)) {
+    return {};
+  }
+  return {
+    targetWidth: Math.max(24, Math.floor(numericWidth)),
+    fillWidth: true,
+  };
+}
+
+function buildUncachedEventDisplayLines(event, deps = {}, { markdownOptions = {} } = {}) {
+  if (isDiffRenderableEvent(event)) {
+    const diffLines = buildDiffDisplayLines(event, {
+      cwd: deps.cwd,
+      maxPathChars: 72,
+    });
+    if (diffLines.length > 0) {
+      return normalizeDisplayLines(diffLines);
+    }
+  }
+  if (isSourcePreviewEvent(event)) {
+    return normalizeDisplayLines(
+      buildSourcePreviewDisplayLines(event, { cwd: deps.cwd }),
+    );
+  }
+  if (isMarkdownRenderableEvent(event)) {
+    return normalizeDisplayLines(
+      (event?.streamState === "streaming"
+        ? buildStreamingMarkdownDisplayLines
+        : buildMarkdownDisplayLines)(
+        stripTerminalControlSequences(sanitizeLargeText(event.body ?? "")),
+        markdownOptions,
+      ),
+    );
+  }
+  return normalizeDisplayLines(
+    eventBodyLines(event.body).map((line) => createDisplayLine(line, "plain")),
+  );
+}
+
 /**
  * Build display lines for an event, using cached results when possible.
  *
@@ -310,34 +360,7 @@ export function buildEventDisplayLines(event, renderCache, deps, maxLines = Infi
     renderCache,
     event,
     signature,
-    () => {
-      if (isDiffRenderableEvent(event)) {
-        const diffLines = buildDiffDisplayLines(event, {
-          cwd: deps.cwd,
-          maxPathChars: 72,
-        });
-        if (diffLines.length > 0) {
-          return normalizeDisplayLines(diffLines);
-        }
-      }
-      if (isSourcePreviewEvent(event)) {
-        return normalizeDisplayLines(
-          buildSourcePreviewDisplayLines(event, { cwd: deps.cwd }),
-        );
-      }
-      if (isMarkdownRenderableEvent(event)) {
-        return normalizeDisplayLines(
-          (event?.streamState === "streaming"
-            ? buildStreamingMarkdownDisplayLines
-            : buildMarkdownDisplayLines)(
-            stripTerminalControlSequences(sanitizeLargeText(event.body ?? "")),
-          ),
-        );
-      }
-      return normalizeDisplayLines(
-        eventBodyLines(event.body).map((line) => createDisplayLine(line, "plain")),
-      );
-    },
+    () => buildUncachedEventDisplayLines(event, deps),
     { maxLines },
   );
 }
@@ -355,7 +378,12 @@ export function wrapEventDisplayLines(event, renderCache, deps, width, maxLines 
     width,
     maxLines,
     () => wrapDisplayLines(
-      buildEventDisplayLines(event, renderCache, deps, maxLines),
+      limitDisplayLines(
+        buildUncachedEventDisplayLines(event, deps, {
+          markdownOptions: markdownRenderOptionsForWidth(width),
+        }),
+        maxLines,
+      ),
       width,
     ),
   );

--- a/runtime/src/watch/agenc-watch-frame.mjs
+++ b/runtime/src/watch/agenc-watch-frame.mjs
@@ -2729,15 +2729,40 @@ export function createWatchFrameController(dependencies = {}) {
       normalized === "paragraph" ||
       normalized === "list" ||
       normalized === "quote" ||
-      normalized === "heading" ||
+      normalized === "heading";
+  }
+
+  function isTableDisplayMode(mode) {
+    const normalized = String(mode ?? "");
+    return normalized === "table-divider" ||
       normalized === "table-header" ||
       normalized === "table-row";
   }
 
 
+  function shouldUseWidthAwareAgentLines(baseLines, widthAwareLines) {
+    if (!Array.isArray(widthAwareLines) || widthAwareLines.length === 0) {
+      return false;
+    }
+    const anchor = (Array.isArray(baseLines) ? baseLines : [])
+      .map((line) => displayLinePlainText(line).trim())
+      .find((line) => line.length > 0);
+    if (!anchor) {
+      return true;
+    }
+    const widthAwareText = widthAwareLines
+      .map((line) => displayLinePlainText(line))
+      .join("\n");
+    return widthAwareText.includes(anchor.slice(0, Math.min(anchor.length, 18)));
+  }
+
   function fullAgentTranscriptLines(event, width) {
     const previewWidth = Math.max(12, width - 4);
-    const displayLines = buildEventDisplayLines(eventDetailVariant(event), Infinity);
+    const baseLines = buildEventDisplayLines(eventDetailVariant(event), Infinity);
+    const widthAwareLines = wrapEventDisplayLines(eventDetailVariant(event), previewWidth, Infinity);
+    const displayLines = shouldUseWidthAwareAgentLines(baseLines, widthAwareLines)
+      ? widthAwareLines
+      : baseLines;
     if (!Array.isArray(displayLines) || displayLines.length === 0) {
       return [];
     }
@@ -2798,14 +2823,38 @@ export function createWatchFrameController(dependencies = {}) {
       const fullAgentLines = fullAgentTranscriptLines(event, width);
       const agentSplit =
         fullAgentLines.length > 0
-          ? splitTranscriptPreviewForHeadline(event, fullAgentLines)
+          ? isTableDisplayMode(fullAgentLines[0]?.mode)
+            ? { headline, bodyLines: fullAgentLines }
+            : splitTranscriptPreviewForHeadline(event, fullAgentLines)
           : previewSplit;
       rows.push(
-        ...transcriptChatRows([agentSplit.headline || headline, ...agentSplit.bodyLines], width, {
+        ...transcriptChatRows([agentSplit.headline || headline], width, {
           marker: "●",
           markerTone: color.ink,
           textTone: color.ink,
-          preserveBlankLines: fullAgentLines.length > 0,
+        }),
+      );
+      if (fullAgentLines.length > 0) {
+        for (const line of agentSplit.bodyLines) {
+          const plain = sanitizeDisplayText(
+            typeof line === "string" ? line : displayLinePlainText(line),
+          );
+          if (plain.length === 0) {
+            rows.push(fitAnsi(transcriptBodyInset, width));
+            continue;
+          }
+          rows.push(fitAnsi(renderEventBodyLine(event, line, {
+            inline: true,
+            prefix: transcriptBodyInset,
+          }), width));
+        }
+        return rows;
+      }
+      rows.push(
+        ...transcriptChatRows(agentSplit.bodyLines, width, {
+          marker: "●",
+          markerTone: color.ink,
+          textTone: color.ink,
         }),
       );
       return rows;
@@ -2938,7 +2987,7 @@ export function createWatchFrameController(dependencies = {}) {
   }
 
   function detailViewportState(event, width, targetHeight) {
-    const body = wrapEventDisplayLines(eventDetailVariant(event), width);
+    const body = wrapEventDisplayLines(eventDetailVariant(event), Math.max(12, width - 2));
     const metaRows = event?.title && buildTranscriptEventSummary(event).meta !== sanitizeDisplayText(event.title)
       ? 1
       : 0;

--- a/runtime/src/watch/agenc-watch-markdown-parse.mjs
+++ b/runtime/src/watch/agenc-watch-markdown-parse.mjs
@@ -68,12 +68,125 @@ function normalizeInlineWhitespace(value) {
     .trim();
 }
 
-function truncateCell(value, maxWidth = 24) {
-  const text = String(value ?? "");
-  if (text.length <= maxWidth) {
-    return text;
+const TABLE_TARGET_WIDTH = 88;
+const TABLE_SAFETY_MARGIN = 4;
+const TABLE_MIN_COLUMN_WIDTH = 3;
+const TABLE_MAX_ROW_LINES = 4;
+
+function normalizeTableLayoutOptions(options = {}) {
+  const hasExplicitTargetWidth =
+    Object.prototype.hasOwnProperty.call(options, "targetWidth") ||
+    Object.prototype.hasOwnProperty.call(options, "tableTargetWidth") ||
+    Object.prototype.hasOwnProperty.call(options, "width");
+  const rawTargetWidth = hasExplicitTargetWidth
+    ? options.targetWidth ?? options.tableTargetWidth ?? options.width
+    : TABLE_TARGET_WIDTH;
+  const numericTargetWidth = Number(rawTargetWidth);
+  const targetWidth = Number.isFinite(numericTargetWidth)
+    ? Math.max(24, Math.floor(numericTargetWidth))
+    : TABLE_TARGET_WIDTH;
+  const fillWidth = options.fillWidth === true ||
+    options.fillTables === true ||
+    (hasExplicitTargetWidth && options.fillWidth !== false && options.fillTables !== false);
+  const safetyMargin = hasExplicitTargetWidth ? 0 : TABLE_SAFETY_MARGIN;
+  return {
+    targetWidth,
+    fillWidth,
+    safetyMargin,
+  };
+}
+
+function distributeWidthRemainder(widths, remainder) {
+  const output = widths.map((width) => Math.max(TABLE_MIN_COLUMN_WIDTH, width));
+  let remaining = Math.max(0, Math.floor(remainder));
+  let index = 0;
+  while (remaining > 0 && output.length > 0) {
+    output[index % output.length] += 1;
+    remaining -= 1;
+    index += 1;
   }
-  return `${text.slice(0, Math.max(1, maxWidth - 1)).trimEnd()}…`;
+  return output;
+}
+
+function displayWidth(value) {
+  return Array.from(String(value ?? "")).length;
+}
+
+function sliceDisplay(value, start, end = Infinity) {
+  return Array.from(String(value ?? "")).slice(start, end).join("");
+}
+
+function padAligned(value, targetWidth, align = "left") {
+  const text = String(value ?? "");
+  const padding = Math.max(0, targetWidth - displayWidth(text));
+  if (align === "right") {
+    return `${" ".repeat(padding)}${text}`;
+  }
+  if (align === "center") {
+    const left = Math.floor(padding / 2);
+    return `${" ".repeat(left)}${text}${" ".repeat(padding - left)}`;
+  }
+  return `${text}${" ".repeat(padding)}`;
+}
+
+function hardWrapWord(word, width) {
+  const output = [];
+  let remaining = String(word ?? "");
+  while (displayWidth(remaining) > width) {
+    output.push(sliceDisplay(remaining, 0, width));
+    remaining = sliceDisplay(remaining, width);
+  }
+  if (remaining.length > 0) {
+    output.push(remaining);
+  }
+  return output;
+}
+
+function wrapCellText(value, width, { hard = false } = {}) {
+  const text = String(value ?? "")
+    .trimEnd()
+    .replace(/\s+/g, " ");
+  if (!text) {
+    return [""];
+  }
+  const normalizedWidth = Math.max(1, Number(width) || 1);
+  const words = text.split(" ").filter((word) => word.length > 0);
+  const lines = [];
+  let current = "";
+
+  for (const word of words) {
+    const wordParts = hard && displayWidth(word) > normalizedWidth
+      ? hardWrapWord(word, normalizedWidth)
+      : [word];
+    for (const part of wordParts) {
+      if (!current) {
+        current = part;
+        continue;
+      }
+      const candidate = `${current} ${part}`;
+      if (displayWidth(candidate) <= normalizedWidth) {
+        current = candidate;
+      } else {
+        lines.push(current);
+        current = part;
+      }
+    }
+  }
+
+  if (current) {
+    lines.push(current);
+  }
+  return lines.length > 0 ? lines : [""];
+}
+
+function longestWordWidth(value) {
+  const words = String(value ?? "")
+    .split(/\s+/)
+    .filter(Boolean);
+  if (words.length === 0) {
+    return TABLE_MIN_COLUMN_WIDTH;
+  }
+  return Math.max(TABLE_MIN_COLUMN_WIDTH, ...words.map(displayWidth));
 }
 
 function normalizeTableMatrix(headers, rows) {
@@ -91,50 +204,11 @@ function normalizeTableMatrix(headers, rows) {
   };
 }
 
-function shouldStackTable(headers, rows) {
-  const matrix = normalizeTableMatrix(headers, rows);
-  if (matrix.columnCount > 4) {
-    return true;
-  }
-  const widths = Array.from({ length: matrix.columnCount }, (_, index) =>
-    Math.max(
-      3,
-      ...[matrix.headers, ...matrix.rows].map((row) => String(row[index] ?? "").length),
-    ),
-  );
-  const estimatedWidth = widths.reduce((sum, width) => sum + width, 0) + Math.max(0, matrix.columnCount - 1) * 3;
-  return estimatedWidth > 88;
-}
-
-function buildStackedTableDisplayLines(headers, rows) {
-  const matrix = normalizeTableMatrix(headers, rows);
-  const headerText = matrix.headers.join(" · ");
-  const divider = "─".repeat(Math.max(12, Math.min(88, headerText.length)));
-  const lines = [
-    createDisplayLine(headerText, "table-header"),
-    createDisplayLine(divider, "table-divider"),
-  ];
-
-  for (const [rowIndex, row] of matrix.rows.entries()) {
-    lines.push(
-      createDisplayLine(
-        `${rowIndex + 1}. ${matrix.headers[0]}: ${row[0] || "—"}`,
-        "table-row",
-        { continuationPrefix: "   " },
-      ),
-    );
-    for (let index = 1; index < matrix.columnCount; index += 1) {
-      lines.push(
-        createDisplayLine(
-          `   ${matrix.headers[index]}: ${row[index] || "—"}`,
-          "table-row",
-          { continuationPrefix: "   " },
-        ),
-      );
-    }
-  }
-
-  return lines;
+function normalizeTableAlignments(alignments, columnCount) {
+  return Array.from({ length: columnCount }, (_, index) => {
+    const value = String(alignments?.[index] ?? "left").toLowerCase();
+    return value === "right" || value === "center" ? value : "left";
+  });
 }
 
 export function parseTableRow(rawLine) {
@@ -156,28 +230,181 @@ export function isTableSeparator(rawLine) {
   return /^\s*\|(?:\s*:?-{3,}:?\s*\|)+\s*$/.test(String(rawLine ?? ""));
 }
 
-export function buildTableDisplayLines(headers, rows) {
-  if (shouldStackTable(headers, rows)) {
-    return buildStackedTableDisplayLines(headers, rows);
+export function parseTableAlignment(rawLine) {
+  const cells = parseTableRow(rawLine);
+  if (!cells) {
+    return [];
+  }
+  return cells.map((cell) => {
+    const value = String(cell ?? "").trim();
+    const left = value.startsWith(":");
+    const right = value.endsWith(":");
+    if (left && right) return "center";
+    if (right) return "right";
+    return "left";
+  });
+}
+
+function buildVerticalTableDisplayLines(headers, rows, options = {}) {
+  const { targetWidth } = normalizeTableLayoutOptions(options);
+  const separator = "─".repeat(Math.min(targetWidth - 1, 40));
+  const lines = [];
+  rows.forEach((row, rowIndex) => {
+    if (rowIndex > 0) {
+      lines.push(createDisplayLine(separator, "table-divider"));
+    }
+    headers.forEach((header, columnIndex) => {
+      const label = String(header ?? `Column ${columnIndex + 1}`).trim();
+      const value = String(row[columnIndex] ?? "")
+        .replace(/\n+/g, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+      const firstLineWidth = Math.max(10, targetWidth - displayWidth(label) - 3);
+      const continuationWidth = Math.max(10, targetWidth - 3);
+      const firstPass = wrapCellText(value, firstLineWidth);
+      const firstLine = firstPass[0] ?? "";
+      const wrapped = firstPass.length <= 1 || continuationWidth <= firstLineWidth
+        ? firstPass
+        : [
+            firstLine,
+            ...wrapCellText(
+              firstPass.slice(1).map((line) => line.trim()).join(" "),
+              continuationWidth,
+            ),
+          ];
+      lines.push(createDisplayLine(`${label}: ${wrapped[0] ?? ""}`, "table-row"));
+      for (const continuation of wrapped.slice(1)) {
+        if (continuation.trim()) {
+          lines.push(createDisplayLine(`  ${continuation}`, "table-row"));
+        }
+      }
+    });
+  });
+  return lines;
+}
+
+export function buildTableDisplayLines(headers, rows, alignments = [], options = {}) {
+  const { targetWidth, fillWidth, safetyMargin } = normalizeTableLayoutOptions(options);
+  const normalized = normalizeTableMatrix(headers, rows);
+  const columnCount = normalized.columnCount;
+  const align = normalizeTableAlignments(alignments, columnCount);
+  const matrix = [normalized.headers, ...normalized.rows];
+  const minWidths = Array.from({ length: columnCount }, (_, index) =>
+    Math.max(...matrix.map((row) => longestWordWidth(row[index]))),
+  );
+  const idealWidths = Array.from({ length: columnCount }, (_, index) =>
+    Math.max(TABLE_MIN_COLUMN_WIDTH, ...matrix.map((row) => displayWidth(row[index]))),
+  );
+  const borderOverhead = 1 + columnCount * 3;
+  const availableWidth = Math.max(
+    targetWidth - borderOverhead - safetyMargin,
+    columnCount * TABLE_MIN_COLUMN_WIDTH,
+  );
+  const totalMin = minWidths.reduce((sum, width) => sum + width, 0);
+  const totalIdeal = idealWidths.reduce((sum, width) => sum + width, 0);
+  let needsHardWrap = false;
+  let columnWidths;
+
+  if (totalIdeal <= availableWidth) {
+    columnWidths = idealWidths;
+    if (fillWidth) {
+      columnWidths = distributeWidthRemainder(
+        columnWidths,
+        availableWidth - columnWidths.reduce((sum, width) => sum + width, 0),
+      );
+    }
+  } else if (totalMin <= availableWidth) {
+    const extraSpace = availableWidth - totalMin;
+    const overflows = idealWidths.map((ideal, index) => ideal - minWidths[index]);
+    const totalOverflow = overflows.reduce((sum, overflow) => sum + overflow, 0);
+    columnWidths = minWidths.map((minWidth, index) => {
+      if (totalOverflow === 0) {
+        return minWidth;
+      }
+      return minWidth + Math.floor((overflows[index] / totalOverflow) * extraSpace);
+    });
+    if (fillWidth) {
+      columnWidths = distributeWidthRemainder(
+        columnWidths,
+        availableWidth - columnWidths.reduce((sum, width) => sum + width, 0),
+      );
+    }
+  } else {
+    needsHardWrap = true;
+    const scaleFactor = availableWidth / totalMin;
+    columnWidths = minWidths.map((width) =>
+      Math.max(Math.floor(width * scaleFactor), TABLE_MIN_COLUMN_WIDTH),
+    );
+    if (fillWidth) {
+      columnWidths = distributeWidthRemainder(
+        columnWidths,
+        availableWidth - columnWidths.reduce((sum, width) => sum + width, 0),
+      );
+    }
   }
 
-  const matrix = [headers, ...rows].map((row) =>
-    row.map((cell) => truncateCell(cell)),
+  const wrappedRows = matrix.map((row) =>
+    row.map((cell, index) =>
+      wrapCellText(cell, columnWidths[index], { hard: needsHardWrap })
+    ),
   );
-  const columnCount = Math.max(...matrix.map((row) => row.length), 0);
-  const widths = Array.from({ length: columnCount }, (_, index) =>
-    Math.max(3, ...matrix.map((row) => String(row[index] ?? "").length)),
-  );
-  const renderRow = (row) =>
-    row
-      .map((cell, index) => String(cell ?? "").padEnd(widths[index], " "))
-      .join(" │ ");
-  const divider = widths.map((width) => "─".repeat(width)).join("─┼─");
-  return [
-    createDisplayLine(renderRow(headers), "table-header"),
-    createDisplayLine(divider, "table-divider"),
-    ...rows.map((row) => createDisplayLine(renderRow(row), "table-row")),
+  const maxRowLines = Math.max(1, ...wrappedRows.flatMap((row) => row.map((cellLines) => cellLines.length)));
+  if (maxRowLines > TABLE_MAX_ROW_LINES) {
+    return buildVerticalTableDisplayLines(normalized.headers, normalized.rows, options);
+  }
+
+  const renderBorderLine = (type) => {
+    const [left, mid, cross, right] = {
+      top: ["┌", "─", "┬", "┐"],
+      middle: ["├", "─", "┼", "┤"],
+      bottom: ["└", "─", "┴", "┘"],
+    }[type];
+    return `${left}${columnWidths
+      .map((width) => mid.repeat(width + 2))
+      .join(cross)}${right}`;
+  };
+  const renderRowLines = (row, isHeader) => {
+    const cellLines = row.map((cell, index) =>
+      wrapCellText(cell, columnWidths[index], { hard: needsHardWrap })
+    );
+    const rowHeight = Math.max(1, ...cellLines.map((lines) => lines.length));
+    const offsets = cellLines.map((lines) => Math.floor((rowHeight - lines.length) / 2));
+    const output = [];
+    for (let lineIndex = 0; lineIndex < rowHeight; lineIndex += 1) {
+      let line = "│";
+      for (let columnIndex = 0; columnIndex < columnCount; columnIndex += 1) {
+        const localIndex = lineIndex - offsets[columnIndex];
+        const cellLine = localIndex >= 0 && localIndex < cellLines[columnIndex].length
+          ? cellLines[columnIndex][localIndex]
+          : "";
+        line += ` ${padAligned(
+          cellLine,
+          columnWidths[columnIndex],
+          isHeader ? "center" : align[columnIndex],
+        )} │`;
+      }
+      output.push(line);
+    }
+    return output;
+  };
+
+  const lines = [
+    createDisplayLine(renderBorderLine("top"), "table-divider"),
+    ...renderRowLines(normalized.headers, true).map((line) =>
+      createDisplayLine(line, "table-header")
+    ),
+    createDisplayLine(renderBorderLine("middle"), "table-divider"),
   ];
+  normalized.rows.forEach((row, rowIndex) => {
+    lines.push(
+      ...renderRowLines(row, false).map((line) => createDisplayLine(line, "table-row")),
+    );
+    if (rowIndex < normalized.rows.length - 1) {
+      lines.push(createDisplayLine(renderBorderLine("middle"), "table-divider"));
+    }
+  });
+  lines.push(createDisplayLine(renderBorderLine("bottom"), "table-divider"));
+  return lines;
 }
 
 export function normalizeDisplayLineCollection(lines) {
@@ -442,11 +669,19 @@ function appendCodeFenceLines(lines, token, lastSourceEnd) {
   return nextSourceEnd(token.map, lastSourceEnd);
 }
 
-function consumeTable(tokens, startIndex) {
+function tokenTableAlignment(token) {
+  const style = String(attributeValue(token, "style") ?? "");
+  const match = style.match(/text-align\s*:\s*(left|right|center)/i);
+  return match?.[1]?.toLowerCase() ?? "left";
+}
+
+function consumeTable(tokens, startIndex, options = {}) {
   let headers = [];
+  let alignments = [];
   const rows = [];
   let currentRow = [];
   let currentCell = "";
+  let currentCellAlign = "left";
   let inHeader = false;
   let index = startIndex + 1;
   while (index < tokens.length) {
@@ -458,6 +693,10 @@ function consumeTable(tokens, startIndex) {
       case "thead_close":
         inHeader = false;
         break;
+      case "th_open":
+      case "td_open":
+        currentCellAlign = tokenTableAlignment(token);
+        break;
       case "inline":
         currentCell = normalizeInlineWhitespace(
           renderInlineTokens(token.children ?? []).text,
@@ -466,7 +705,11 @@ function consumeTable(tokens, startIndex) {
       case "th_close":
       case "td_close":
         currentRow.push(currentCell);
+        if (inHeader) {
+          alignments.push(currentCellAlign);
+        }
         currentCell = "";
+        currentCellAlign = "left";
         break;
       case "tr_close":
         if (currentRow.length > 0) {
@@ -482,7 +725,7 @@ function consumeTable(tokens, startIndex) {
         return {
           nextIndex: index + 1,
           lines: headers.length > 0
-            ? buildTableDisplayLines(headers, rows)
+            ? buildTableDisplayLines(headers, rows, alignments, options)
             : [createDisplayLine("(empty)", "paragraph")],
         };
       default:
@@ -493,12 +736,12 @@ function consumeTable(tokens, startIndex) {
   return {
     nextIndex: index,
     lines: headers.length > 0
-      ? buildTableDisplayLines(headers, rows)
+      ? buildTableDisplayLines(headers, rows, alignments, options)
       : [createDisplayLine("(empty)", "paragraph")],
   };
 }
 
-export function buildMarkdownDisplayLines(value) {
+export function buildMarkdownDisplayLines(value, options = {}) {
   const source = normalizeMarkdownSource(value);
   if (source.trim().length === 0) {
     return [createDisplayLine("(empty)", "paragraph")];
@@ -585,7 +828,7 @@ export function buildMarkdownDisplayLines(value) {
         break;
       case "table_open": {
         maybeInsertGapLine(lines, lastSourceEnd, token.map);
-        const table = consumeTable(tokens, index);
+        const table = consumeTable(tokens, index, options);
         lines.push(...table.lines);
         lastSourceEnd = nextSourceEnd(token.map, lastSourceEnd);
         index = table.nextIndex;

--- a/runtime/src/watch/agenc-watch-markdown-stream.mjs
+++ b/runtime/src/watch/agenc-watch-markdown-stream.mjs
@@ -2,6 +2,7 @@ import {
   buildTableDisplayLines,
   buildMarkdownDisplayLines,
   createDisplayLine,
+  parseTableAlignment,
   isTableSeparator,
   normalizeDisplayLineCollection,
   normalizeInlineMarkdown,
@@ -85,7 +86,7 @@ function commonPrefixLength(left, right) {
   return index;
 }
 
-function buildStreamingMarkdownState(value) {
+function buildStreamingMarkdownState(value, options = {}) {
   const source = normalizeMarkdownSource(value);
   if (source.trim().length === 0) {
     return {
@@ -107,9 +108,10 @@ function buildStreamingMarkdownState(value) {
     }
 
     const headerCells = parseTableRow(rawLines[trailingTableStart]);
-    const separatorComplete = isTableSeparator(rawLines[trailingTableStart + 1] ?? "");
+    const separatorLine = rawLines[trailingTableStart + 1] ?? "";
+    const separatorComplete = isTableSeparator(separatorLine);
     const stableSource = rawLines.slice(0, trailingTableStart).join("\n");
-    const stableLines = stableSource ? buildMarkdownDisplayLines(stableSource) : [];
+    const stableLines = stableSource ? buildMarkdownDisplayLines(stableSource, options) : [];
 
     if (!headerCells || !separatorComplete) {
       const previewLines = rawLines
@@ -142,7 +144,12 @@ function buildStreamingMarkdownState(value) {
     return {
       completeLines: normalizeDisplayLineCollection([
         ...stableLines,
-        ...buildTableDisplayLines(headerCells, completedRows),
+        ...buildTableDisplayLines(
+          headerCells,
+          completedRows,
+          parseTableAlignment(separatorLine),
+          options,
+        ),
       ]),
       previewLines: previewLines.filter((line) => String(line.text ?? "").trim().length > 0),
     };
@@ -150,7 +157,7 @@ function buildStreamingMarkdownState(value) {
 
   if (source.endsWith("\n")) {
     return {
-      completeLines: buildMarkdownDisplayLines(source),
+      completeLines: buildMarkdownDisplayLines(source, options),
       previewLines: [],
     };
   }
@@ -160,7 +167,7 @@ function buildStreamingMarkdownState(value) {
     const stableSource = rawLines.slice(0, -1).join("\n");
     const tail = normalizeStreamingTailText(lastLine);
     return {
-      completeLines: stableSource ? buildMarkdownDisplayLines(stableSource) : [],
+      completeLines: stableSource ? buildMarkdownDisplayLines(stableSource, options) : [],
       previewLines: tail ? [createDisplayLine(tail, "stream-tail")] : [],
     };
   }
@@ -169,13 +176,13 @@ function buildStreamingMarkdownState(value) {
   if (lastNewlineIndex === -1) {
     return {
       completeLines: [],
-      previewLines: buildMarkdownDisplayLines(source),
+      previewLines: buildMarkdownDisplayLines(source, options),
     };
   }
 
   const stableSource = source.slice(0, lastNewlineIndex + 1);
-  const stableLines = buildMarkdownDisplayLines(stableSource);
-  const fullLines = buildMarkdownDisplayLines(source);
+  const stableLines = buildMarkdownDisplayLines(stableSource, options);
+  const fullLines = buildMarkdownDisplayLines(source, options);
   const prefixLength = commonPrefixLength(stableLines, fullLines);
 
   return {
@@ -184,7 +191,7 @@ function buildStreamingMarkdownState(value) {
   };
 }
 
-export function createMarkdownStreamCollector() {
+export function createMarkdownStreamCollector(options = {}) {
   let buffer = "";
   let committedLines = [];
 
@@ -211,7 +218,7 @@ export function createMarkdownStreamCollector() {
   }
 
   function commitCompleteLines() {
-    const { completeLines } = buildStreamingMarkdownState(buffer);
+    const { completeLines } = buildStreamingMarkdownState(buffer, options);
     const prefixLength = commonPrefixLength(committedLines, completeLines);
     const nextLines =
       prefixLength < committedLines.length
@@ -222,12 +229,12 @@ export function createMarkdownStreamCollector() {
   }
 
   function previewPendingLines() {
-    const { previewLines } = buildStreamingMarkdownState(buffer);
+    const { previewLines } = buildStreamingMarkdownState(buffer, options);
     return previewLines;
   }
 
   function snapshot() {
-    const state = buildStreamingMarkdownState(buffer);
+    const state = buildStreamingMarkdownState(buffer, options);
     committedLines = state.completeLines;
     return normalizeDisplayLineCollection([
       ...state.completeLines,
@@ -236,7 +243,7 @@ export function createMarkdownStreamCollector() {
   }
 
   function finalizeAndDrain() {
-    const rendered = buildMarkdownDisplayLines(buffer);
+    const rendered = buildMarkdownDisplayLines(buffer, options);
     const prefixLength = commonPrefixLength(committedLines, rendered);
     const lines = rendered.slice(prefixLength);
     clear();
@@ -254,8 +261,8 @@ export function createMarkdownStreamCollector() {
   };
 }
 
-export function buildStreamingMarkdownDisplayLines(value) {
-  const state = buildStreamingMarkdownState(value);
+export function buildStreamingMarkdownDisplayLines(value, options = {}) {
+  const state = buildStreamingMarkdownState(value, options);
   return normalizeDisplayLineCollection([
     ...state.completeLines,
     ...state.previewLines,

--- a/runtime/src/watch/agenc-watch-rich-text.mjs
+++ b/runtime/src/watch/agenc-watch-rich-text.mjs
@@ -30,6 +30,7 @@ const DEFAULT_COLOR = Object.freeze({
   red: "\x1b[38;5;203m",
   border: "\x1b[38;5;54m",
   borderStrong: "\x1b[38;5;99m",
+  tableHeaderBg: "\x1b[48;5;236m",
 });
 
 const SOURCE_TOKEN_RE =
@@ -154,6 +155,93 @@ function styleInlineSegment(segment, color, baseTone, enableHyperlinks) {
 function renderInlineSegments(segments, fallbackText, color, baseTone, enableHyperlinks) {
   return normalizeRenderableSegments(segments, fallbackText)
     .map((segment) => styleInlineSegment(segment, color, baseTone, enableHyperlinks))
+    .join("");
+}
+
+const TABLE_VERTICAL_BORDER = "\u2502";
+const TABLE_NUMERIC_CELL_RE = /^[+-]?(?:[$\u20ac\u00a3\u00a5]\s*)?\d[\d,]*(?:\.\d+)?%?$/u;
+const TABLE_DATE_CELL_RE = /^\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2}(?::\d{2})?)?$/u;
+const TABLE_POSITIVE_CELL_RE = /^(active|success|succeeded|done|ok|yes|pass|passed|healthy|running|complete|completed|open)$/iu;
+const TABLE_NEGATIVE_CELL_RE = /^(inactive|failed|failure|error|no|down|blocked|critical|closed)$/iu;
+const TABLE_PENDING_CELL_RE = /^(pending|waiting|queued|review|warn|warning|partial|paused|idle)$/iu;
+
+function isTableDisplayMode(mode) {
+  const normalized = String(mode ?? "");
+  return normalized === "table-divider" ||
+    normalized === "table-header" ||
+    normalized === "table-row";
+}
+
+function tableCellTone(value, color, { isHeader = false } = {}) {
+  const trimmed = String(value ?? "").trim();
+  if (isHeader) {
+    return `${colorValue(color, "teal")}${colorValue(color, "bold")}`;
+  }
+  if (trimmed.length === 0) {
+    return colorValue(color, "softInk");
+  }
+  if (TABLE_POSITIVE_CELL_RE.test(trimmed)) {
+    return colorValue(color, "green");
+  }
+  if (TABLE_NEGATIVE_CELL_RE.test(trimmed)) {
+    return colorValue(color, "red");
+  }
+  if (TABLE_PENDING_CELL_RE.test(trimmed)) {
+    return colorValue(color, "yellow");
+  }
+  if (TABLE_DATE_CELL_RE.test(trimmed)) {
+    return colorValue(color, "cyan");
+  }
+  if (TABLE_NUMERIC_CELL_RE.test(trimmed)) {
+    return colorValue(color, "yellow");
+  }
+  return colorValue(color, "ink");
+}
+
+function tableHeaderBackground(color) {
+  return colorValue(color, "tableHeaderBg") ||
+    colorValue(color, "panelMessageBg") ||
+    colorValue(color, "panelHiBg");
+}
+
+function renderTableCell(rawCell, color, { isHeader = false } = {}) {
+  const cell = String(rawCell ?? "");
+  const match = cell.match(/^(\s*)(.*?)(\s*)$/su);
+  const leading = match?.[1] ?? "";
+  const content = match?.[2] ?? cell;
+  const trailing = match?.[3] ?? "";
+  const headerBg = isHeader ? tableHeaderBackground(color) : "";
+  if (content.length === 0) {
+    return headerBg ? `${headerBg}${cell}${colorValue(color, "reset")}` : cell;
+  }
+  const tone = tableCellTone(content, color, { isHeader });
+  if (headerBg) {
+    const reset = colorValue(color, "reset");
+    return `${headerBg}${leading}${tone}${content}${reset}${headerBg}${trailing}${reset}`;
+  }
+  return `${leading}${tone}${content}${colorValue(color, "reset")}${trailing}`;
+}
+
+function renderTableDividerLine(text, color) {
+  return `${colorValue(color, "borderStrong")}${colorValue(color, "bold")}${text}${colorValue(color, "reset")}`;
+}
+
+function renderTableDataLine(text, color, { isHeader = false } = {}) {
+  const source = String(text ?? "");
+  if (!source.includes(TABLE_VERTICAL_BORDER)) {
+    return renderTableCell(source, color, { isHeader });
+  }
+  const borderTone = `${colorValue(color, "borderStrong")}${isHeader ? colorValue(color, "bold") : ""}`;
+  const reset = colorValue(color, "reset");
+  const parts = source.split(TABLE_VERTICAL_BORDER);
+  return parts
+    .map((part, index) => {
+      const border = index === 0 ? "" : `${borderTone}${TABLE_VERTICAL_BORDER}${reset}`;
+      if (part.length === 0 && (index === 0 || index === parts.length - 1)) {
+        return border;
+      }
+      return `${border}${renderTableCell(part, color, { isHeader })}`;
+    })
     .join("");
 }
 
@@ -378,6 +466,10 @@ export function wrapRichDisplayLines(lines, width) {
       wrapped.push(createDisplayLine("", "blank"));
       continue;
     }
+    if (isTableDisplayMode(entry.mode)) {
+      wrapped.push(entry);
+      continue;
+    }
     const chunks = wrapPlainTextLine(
       plainText,
       width,
@@ -462,11 +554,11 @@ export function renderDisplayLine(
     case "rule":
       return `${colorValue(color, "borderStrong")}${text}${colorValue(color, "reset")}`;
     case "table-header":
-      return `${colorValue(color, "teal")}${colorValue(color, "bold")}${text}${colorValue(color, "reset")}`;
+      return renderTableDataLine(text, color, { isHeader: true });
     case "table-divider":
-      return `${colorValue(color, "borderStrong")}${text}${colorValue(color, "reset")}`;
+      return renderTableDividerLine(text, color);
     case "table-row":
-      return `${colorValue(color, "softInk")}${renderInlineSegments(entry.inlineSegments, text, color, colorValue(color, "softInk"), enableHyperlinks)}${colorValue(color, "reset")}`;
+      return renderTableDataLine(text, color);
     case "stream-tail":
       return `${colorValue(color, "softInk")}${renderInlineSegments(entry.inlineSegments, text, color, colorValue(color, "softInk"), enableHyperlinks)}${colorValue(color, "reset")}`;
     case "paragraph":

--- a/runtime/src/watch/agenc-watch-ui-primitives.mjs
+++ b/runtime/src/watch/agenc-watch-ui-primitives.mjs
@@ -39,6 +39,7 @@ export const color = {
   panelAltBg: "\x1b[48;5;233m",
   panelHiBg: "\x1b[48;5;234m",
   panelMessageBg: "\x1b[48;5;236m",
+  tableHeaderBg: "\x1b[48;5;236m",
 };
 
 /** Tone-to-fg/bg mapping. */
@@ -77,6 +78,7 @@ const WATCH_THEME_PRESETS = Object.freeze({
     panelAltBg: "\x1b[48;5;233m",
     panelHiBg: "\x1b[48;5;234m",
     panelMessageBg: "\x1b[48;5;236m",
+    tableHeaderBg: "\x1b[48;5;236m",
   }),
   aurora: Object.freeze({
     border: "\x1b[38;5;31m",
@@ -98,6 +100,7 @@ const WATCH_THEME_PRESETS = Object.freeze({
     panelAltBg: "\x1b[48;5;236m",
     panelHiBg: "\x1b[48;5;237m",
     panelMessageBg: "\x1b[48;5;239m",
+    tableHeaderBg: "\x1b[48;5;238m",
   }),
   ember: Object.freeze({
     border: "\x1b[38;5;94m",
@@ -119,6 +122,7 @@ const WATCH_THEME_PRESETS = Object.freeze({
     panelAltBg: "\x1b[48;5;235m",
     panelHiBg: "\x1b[48;5;236m",
     panelMessageBg: "\x1b[48;5;238m",
+    tableHeaderBg: "\x1b[48;5;238m",
   }),
 });
 
@@ -142,6 +146,7 @@ const THEME_KEYS = Object.freeze([
   "panelAltBg",
   "panelHiBg",
   "panelMessageBg",
+  "tableHeaderBg",
 ]);
 
 const TONE_KEYS = Object.freeze([

--- a/runtime/tests/regression/orchestration/context-compaction.integration.test.ts
+++ b/runtime/tests/regression/orchestration/context-compaction.integration.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { SqliteBackend } from "../../../src/memory/sqlite/backend.js";
 import { ChatExecutor } from "../../../src/llm/chat-executor.js";
+import { createPromptEnvelope } from "../../../src/llm/prompt-envelope.js";
 import type { LLMMessage, LLMProvider, LLMResponse } from "../../../src/llm/types.js";
 import {
   SessionManager,
@@ -183,7 +184,7 @@ describe("context compaction integration", () => {
         "Update AGENC.md from the compacted shell context and keep it accurate.",
       ),
       history: resumed.history,
-      systemPrompt: "You are a helpful assistant.",
+      promptEnvelope: createPromptEnvelope("You are a helpful assistant."),
       sessionId: "session-1",
       stateful,
       // After the regex pre-call classifier rip-out, implementation-class

--- a/runtime/tests/watch/agenc-watch-frame.test.mjs
+++ b/runtime/tests/watch/agenc-watch-frame.test.mjs
@@ -1069,3 +1069,58 @@ test("frame controller does not add blank rows between wrapped lines of one para
   assert.equal(continuationRows.some((line) => String(line).trim().length === 0), false);
   assert.equal(String(lines[nextParagraphRow - 1] ?? "").trim().length, 0);
 });
+
+test("frame controller keeps agent table rows contiguous and rendered", () => {
+  const harness = createWatchFrameHarness({
+    width: 90,
+    height: 34,
+    previewLines: 20,
+    events: [
+      {
+        id: "evt-agent-table",
+        kind: "agent",
+        title: "Agent Reply",
+        body: "ignored",
+        timestamp: "15:15:01",
+      },
+    ],
+    dependencies: {
+      isMarkdownRenderableEvent(event) {
+        return event?.kind === "agent";
+      },
+      buildEventDisplayLines() {
+        return [
+          createDisplayLine("┌────────┬────────┬───────┐", "table-divider"),
+          createDisplayLine("│ Name   │ Status │ Score │", "table-header"),
+          createDisplayLine("├────────┼────────┼───────┤", "table-divider"),
+          createDisplayLine("│ Elena  │ Active │ 92.1  │", "table-row"),
+          createDisplayLine("└────────┴────────┴───────┘", "table-divider"),
+        ];
+      },
+      wrapDisplayLines(lines) {
+        return lines;
+      },
+      renderEventBodyLine(_event, line) {
+        return `<render:${line?.mode}>${line?.text ?? ""}`;
+      },
+    },
+  });
+
+  const lines = harness.controller.buildVisibleFrameSnapshot().lines.map((line) => String(line));
+  const topRow = lines.findIndex((line) => line.includes("┌────────"));
+  const headerRow = lines.findIndex((line) => line.includes("│ Name"));
+  const dividerRow = lines.findIndex((line) => line.includes("├────────"));
+  const dataRow = lines.findIndex((line) => line.includes("│ Elena"));
+  const bottomRow = lines.findIndex((line) => line.includes("└────────"));
+  const tableRows = lines.slice(topRow, bottomRow + 1);
+
+  assert.notEqual(topRow, -1);
+  assert.notEqual(headerRow, -1);
+  assert.notEqual(dividerRow, -1);
+  assert.notEqual(dataRow, -1);
+  assert.notEqual(bottomRow, -1);
+  assert.deepEqual([headerRow, dividerRow, dataRow, bottomRow], [topRow + 1, topRow + 2, topRow + 3, topRow + 4]);
+  assert.equal(tableRows.some((line) => line.trim().length === 0), false);
+  assert.ok(lines.some((line) => line.includes("<render:table-divider>┌")));
+  assert.ok(lines.some((line) => line.includes("<render:table-header>│ Name")));
+});

--- a/runtime/tests/watch/agenc-watch-markdown-module-split.test.mjs
+++ b/runtime/tests/watch/agenc-watch-markdown-module-split.test.mjs
@@ -1,7 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { buildMarkdownDisplayLines } from "../../src/watch/agenc-watch-markdown-parse.mjs";
+import {
+  buildMarkdownDisplayLines,
+  buildTableDisplayLines,
+} from "../../src/watch/agenc-watch-markdown-parse.mjs";
 import {
   buildStreamingMarkdownDisplayLines,
   createMarkdownStreamCollector,
@@ -40,8 +43,10 @@ test("markdown stream module preserves incremental table sanitization and collec
     .map((line) => ({ mode: line.mode, text: line.text }));
 
   assert.deepEqual(preview, [
-    { mode: "table-header", text: "Name │ Value" },
-    { mode: "table-divider", text: "─────┼──────" },
+    { mode: "table-divider", text: "┌──────┬───────┐" },
+    { mode: "table-header", text: "│ Name │ Value │" },
+    { mode: "table-divider", text: "├──────┼───────┤" },
+    { mode: "table-divider", text: "└──────┴───────┘" },
     { mode: "stream-tail", text: "alp" },
   ]);
 
@@ -50,4 +55,18 @@ test("markdown stream module preserves incremental table sanitization and collec
     direct.filter((line) => line.mode !== "blank").map((line) => ({ mode: line.mode, text: line.text })),
     preview,
   );
+});
+
+test("markdown table renderer can fill an explicit terminal width", () => {
+  const lines = buildTableDisplayLines(
+    ["Name", "Value"],
+    [["alpha", "42"]],
+    [],
+    { targetWidth: 40, fillWidth: true },
+  );
+
+  const tableLines = lines.filter((line) => line.mode !== "blank");
+  assert.equal(tableLines[0].text.length, 40);
+  assert.equal(tableLines[1].text.length, 40);
+  assert.equal(tableLines.at(-1).text.length, 40);
 });

--- a/runtime/tests/watch/agenc-watch-rich-text.test.mjs
+++ b/runtime/tests/watch/agenc-watch-rich-text.test.mjs
@@ -65,14 +65,16 @@ Paragraph with [docs](https://example.com/docs), ![diagram](asset.png), and \`np
         mode: "paragraph",
         text: "Paragraph with docs (https://example.com/docs), image: diagram (asset.png), and 'npm test'.",
       },
-      { mode: "table-header", text: "Name  │ Value" },
-      { mode: "table-divider", text: "──────┼──────" },
-      { mode: "table-row", text: "alpha │ 42   " },
+      { mode: "table-divider", text: "┌───────┬───────┐" },
+      { mode: "table-header", text: "│ Name  │ Value │" },
+      { mode: "table-divider", text: "├───────┼───────┤" },
+      { mode: "table-row", text: "│ alpha │ 42    │" },
+      { mode: "table-divider", text: "└───────┴───────┘" },
     ]),
   );
 });
 
-test("buildMarkdownDisplayLines falls back to ordered stacked rows for wide tables", () => {
+test("buildMarkdownDisplayLines keeps wide tables in horizontal table form", () => {
   const lines = buildMarkdownDisplayLines(`
 | Name | Owner | Status | Notes | Updated |
 | --- | --- | --- | --- | --- |
@@ -86,13 +88,38 @@ test("buildMarkdownDisplayLines falls back to ordered stacked rows for wide tabl
   assert.equal(
     JSON.stringify(actual),
     JSON.stringify([
-      { mode: "table-header", text: "Name · Owner · Status · Notes · Updated" },
-      { mode: "table-divider", text: "───────────────────────────────────────" },
-      { mode: "table-row", text: "1. Name: Governance Sync" },
-      { mode: "table-row", text: "   Owner: team-ops" },
-      { mode: "table-row", text: "   Status: active" },
-      { mode: "table-row", text: "   Notes: Keeps proposal state and votes aligned across surfaces" },
-      { mode: "table-row", text: "   Updated: today" },
+      { mode: "table-divider", text: "┌──────────────┬──────────┬────────┬────────────────────────────────────┬─────────┐" },
+      { mode: "table-header", text: "│     Name     │  Owner   │ Status │               Notes                │ Updated │" },
+      { mode: "table-divider", text: "├──────────────┼──────────┼────────┼────────────────────────────────────┼─────────┤" },
+      { mode: "table-row", text: "│ Governance   │ team-ops │ active │ Keeps proposal state and votes     │ today   │" },
+      { mode: "table-row", text: "│ Sync         │          │        │ aligned across surfaces            │         │" },
+      { mode: "table-divider", text: "└──────────────┴──────────┴────────┴────────────────────────────────────┴─────────┘" },
+    ]),
+  );
+});
+
+test("buildMarkdownDisplayLines keeps multi-column markdown tables visible", () => {
+  const lines = buildMarkdownDisplayLines(`
+| ID | Name    | Age | Department   | Salary    | City      | Performance |
+|----|---------|-----|--------------|-----------|-----------|-------------|
+| 1  | Frank   | 31  | Engineering  | $162,196  | Tokyo     | 3.6         |
+| 2  | Bob     | 30  | Research     | $76,395   | Sydney    | 3.9         |
+`);
+
+  const actual = lines
+    .filter((line) => line.mode !== "blank")
+    .map((line) => ({ mode: line.mode, text: line.text }));
+
+  assert.equal(
+    JSON.stringify(actual),
+    JSON.stringify([
+      { mode: "table-divider", text: "┌─────┬───────┬─────┬─────────────┬──────────┬────────┬─────────────┐" },
+      { mode: "table-header", text: "│ ID  │ Name  │ Age │ Department  │  Salary  │  City  │ Performance │" },
+      { mode: "table-divider", text: "├─────┼───────┼─────┼─────────────┼──────────┼────────┼─────────────┤" },
+      { mode: "table-row", text: "│ 1   │ Frank │ 31  │ Engineering │ $162,196 │ Tokyo  │ 3.6         │" },
+      { mode: "table-divider", text: "├─────┼───────┼─────┼─────────────┼──────────┼────────┼─────────────┤" },
+      { mode: "table-row", text: "│ 2   │ Bob   │ 30  │ Research    │ $76,395  │ Sydney │ 3.9         │" },
+      { mode: "table-divider", text: "└─────┴───────┴─────┴─────────────┴──────────┴────────┴─────────────┘" },
     ]),
   );
 });
@@ -221,8 +248,10 @@ test("buildStreamingMarkdownDisplayLines keeps partial table rows sanitized whil
   assert.equal(
     JSON.stringify(actual),
     JSON.stringify([
-      { mode: "table-header", text: "Component │ Status" },
-      { mode: "table-divider", text: "──────────┼───────" },
+      { mode: "table-divider", text: "┌───────────┬────────┐" },
+      { mode: "table-header", text: "│ Component │ Status │" },
+      { mode: "table-divider", text: "├───────────┼────────┤" },
+      { mode: "table-divider", text: "└───────────┴────────┘" },
       { mode: "stream-tail", text: "Input" },
     ]),
   );
@@ -233,6 +262,38 @@ test("highlightSourceLine and renderDisplayLine add ansi styling for code and he
   const heading = renderDisplayLine({ text: "Heading", mode: "heading" });
   assert.match(code, /\x1b\[[0-9;]*mconst\x1b\[[0-9;]*m/);
   assert.match(heading, /\x1b\[[0-9;]*mHeading\x1b\[[0-9;]*m/);
+});
+
+test("renderDisplayLine styles table borders, headers, and semantic cells", () => {
+  const color = {
+    reset: "</>",
+    bold: "<bold>",
+    borderStrong: "<border>",
+    teal: "<teal>",
+    green: "<green>",
+    yellow: "<yellow>",
+    cyan: "<cyan>",
+    ink: "<ink>",
+    softInk: "<soft>",
+    red: "<red>",
+    magenta: "<magenta>",
+    fog: "<fog>",
+    tableHeaderBg: "<header-bg>",
+  };
+
+  const divider = renderDisplayLine({ text: "┌──────┬────────┐", mode: "table-divider" }, { color });
+  const header = renderDisplayLine({ text: "│ Name │ Status │", mode: "table-header" }, { color });
+  const row = renderDisplayLine(
+    { text: "│ Elena │ Active │ 92.1 │ 2025-01-03 │", mode: "table-row" },
+    { color },
+  );
+
+  assert.match(divider, /^<border><bold>┌/);
+  assert.ok(header.includes("<border><bold>│</><header-bg> <teal><bold>Name</><header-bg> </>"));
+  assert.ok(row.includes("<border>│</> <ink>Elena</>"));
+  assert.ok(row.includes("<green>Active</>"));
+  assert.ok(row.includes("<yellow>92.1</>"));
+  assert.ok(row.includes("<cyan>2025-01-03</>"));
 });
 
 test("renderDisplayLine emits OSC 8 hyperlinks for structured file-link entries", () => {


### PR DESCRIPTION
## Summary

- Adds a distinct background color for markdown table header cells in the watch TUI so headers stand apart from body rows.
- Makes markdown tables fill the available CLI/frame width when the renderer receives panel width information.
- Propagates table width options through streaming markdown and event display wrapping, avoiding compact cached table rows in the final frame.
- Extends tests for width-aware table rendering, contiguous table rows in the frame, and header background styling.

## Root Cause

Tables were rendered with a compact default target before the frame width was known, then reused from cached display lines. Header cells also only used foreground/bold styling, so the row did not visually separate enough from body content.

## Validation

- `node --test runtime/tests/watch/agenc-watch-rich-text.test.mjs runtime/tests/watch/agenc-watch-frame.test.mjs runtime/tests/watch/agenc-watch-markdown-module-split.test.mjs`
- `git diff --check`
- `npm run build --workspace=@tetsuo-ai/runtime`
