### PR TITLE
fix(runtime): normalize filesystem artifact verification paths

### DIFF
--- a/runtime/src/llm/chat-executor-stop-gate.test.ts
+++ b/runtime/src/llm/chat-executor-stop-gate.test.ts
@@ -406,6 +406,26 @@ describe("checkFilesystemArtifacts", () => {
     );
     expect(decision.checkedFiles).not.toContain(deletedPath);
   });
+
+  it("resolves relative write paths against the workspace root before statting", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-filesystem-relative-"));
+    mkdirSync(join(workspaceRoot, "src"), { recursive: true });
+
+    const relativePath = "src/main.c";
+    const absolutePath = join(workspaceRoot, relativePath);
+    writeFileSync(absolutePath, "int main(void) { return 0; }\n", "utf8");
+
+    const decision = await checkFilesystemArtifacts({
+      finalContent: "All phases completed. Task complete.",
+      allToolCalls: [successfulWrite(relativePath, "int main(void) { return 0; }\n")],
+      workspaceRoot,
+    });
+
+    expect(decision.shouldIntervene).toBe(false);
+    expect(decision.emptyFiles).toEqual([]);
+    expect(decision.missingFiles).toEqual([]);
+    expect(decision.checkedFiles).toEqual([absolutePath]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/runtime/src/llm/chat-executor-stop-gate.ts
+++ b/runtime/src/llm/chat-executor-stop-gate.ts
@@ -1224,6 +1224,7 @@ export interface FilesystemArtifactCheckResult {
 export async function checkFilesystemArtifacts(params: {
   readonly finalContent: string;
   readonly allToolCalls: readonly ToolCallRecord[];
+  readonly workspaceRoot?: string;
 }): Promise<FilesystemArtifactCheckResult> {
   const noIntervention: FilesystemArtifactCheckResult = {
     shouldIntervene: false,
@@ -1240,12 +1241,12 @@ export async function checkFilesystemArtifacts(params: {
 
   // Collect all file paths the model wrote/edited with non-empty content.
   const writtenPaths = new Set<string>();
+  const rawWrittenPathsByNormalizedPath = new Map<string, Set<string>>();
   for (const call of params.allToolCalls) {
     if (!FILE_WRITE_TOOL_NAMES.has(call.name)) continue;
     if (call.isError) continue; // failed writes don't count
 
-    const path =
-      typeof call.args?.path === "string" ? call.args.path : undefined;
+    const path = normalizeToolPath(call.args?.path, params.workspaceRoot);
     if (!path) continue;
 
     // For writeFile/appendFile: check if content was non-empty.
@@ -1260,6 +1261,13 @@ export async function checkFilesystemArtifacts(params: {
     }
 
     writtenPaths.add(path);
+    const rawPath =
+      typeof call.args?.path === "string" ? call.args.path : undefined;
+    if (rawPath) {
+      const rawPaths = rawWrittenPathsByNormalizedPath.get(path) ?? new Set<string>();
+      rawPaths.add(rawPath);
+      rawWrittenPathsByNormalizedPath.set(path, rawPaths);
+    }
   }
 
   if (writtenPaths.size === 0) {
@@ -1270,8 +1278,7 @@ export async function checkFilesystemArtifacts(params: {
   const deletedPaths = new Set<string>();
   for (const call of params.allToolCalls) {
     if (FILE_DELETE_TOOL_NAMES.has(call.name) && !call.isError) {
-      const path =
-        typeof call.args?.path === "string" ? call.args.path : undefined;
+      const path = normalizeToolPath(call.args?.path, params.workspaceRoot);
       if (path) deletedPaths.add(path);
     }
     // Also check for `rm` in bash commands.
@@ -1281,7 +1288,11 @@ export async function checkFilesystemArtifacts(params: {
       // Simple heuristic: if bash command contains `rm` and a written
       // path, exclude that path. Not perfect but catches the common case.
       for (const writtenPath of writtenPaths) {
-        if (cmd.includes("rm") && cmd.includes(writtenPath)) {
+        const rawWrittenPaths = rawWrittenPathsByNormalizedPath.get(writtenPath);
+        const matchesRawPath = rawWrittenPaths
+          ? [...rawWrittenPaths].some((rawPath) => cmd.includes(rawPath))
+          : false;
+        if (cmd.includes("rm") && (cmd.includes(writtenPath) || matchesRawPath)) {
           deletedPaths.add(writtenPath);
         }
       }

--- a/runtime/src/llm/completion-validators.ts
+++ b/runtime/src/llm/completion-validators.ts
@@ -261,6 +261,7 @@ export function buildCompletionValidators(params: {
         const check = await checkFilesystemArtifacts({
           finalContent: params.ctx.response?.content ?? "",
           allToolCalls: params.ctx.allToolCalls,
+          workspaceRoot: params.ctx.runtimeWorkspaceRoot,
         });
         if (!check.shouldIntervene) {
           return { id: "filesystem_artifact_verification", outcome: "pass" };

--- a/runtime/src/llm/hooks/stop-hooks.ts
+++ b/runtime/src/llm/hooks/stop-hooks.ts
@@ -248,6 +248,7 @@ function buildBuiltinStopHookDefinitions(): readonly StopHookRuntimeDefinition[]
         const check = await checkFilesystemArtifacts({
           finalContent: context.finalContent ?? "",
           allToolCalls: context.allToolCalls ?? [],
+          workspaceRoot: context.runtimeWorkspaceRoot,
         });
         return {
           hookId: BUILTIN_FILESYSTEM_ARTIFACT_VERIFICATION_HOOK_ID,


### PR DESCRIPTION
## Summary
- resolve relative write and delete paths against the runtime workspace root before filesystem artifact verification
- keep the bash rm heuristic working by tracking the raw written path alongside the normalized path
- add a regression test covering relative writes inside a workspace

## Test plan
- ./node_modules/.bin/vitest run runtime/src/llm/chat-executor-stop-gate.test.ts runtime/src/llm/completion-validators.test.ts