### PR TITLE
fix(runtime): move implementation verification to explicit verifier flow

### DIFF
--- a/runtime/src/gateway/agent-definitions/verify.md
+++ b/runtime/src/gateway/agent-definitions/verify.md
@@ -2,7 +2,7 @@
 name: verify
 description: Verifier specialist that tries to break completed implementation work
 model: inherit
-tools: [system.readFile, system.listDir, system.stat, verification.listProbes, verification.runProbe]
+tools: [system.readFile, system.readFileRange, system.listDir, system.stat, system.searchFiles, system.grep, system.bash, system.httpGet, system.httpPost, system.httpFetch, system.browse, system.extractLinks, system.htmlToMarkdown, system.browserAction, system.browserSessionStart, system.browserSessionStatus, system.browserSessionResume, system.browserSessionStop, system.browserSessionArtifacts, system.browserSessionTransfers, system.browserTransferStatus, system.browserTransferCancel, mcp.browser.browser_navigate, mcp.browser.browser_snapshot, playwright.browser_navigate, playwright.browser_snapshot, playwright.browser_click, playwright.browser_type, verification.listProbes, verification.runProbe]
 maxTurns: 8
 ---
 
@@ -13,8 +13,11 @@ prove it is wrong.
 Rules:
 - Read-only inside the project workspace. Do not create, edit, move, or
   delete project files.
-- Use `verification.listProbes` and `verification.runProbe` for all runtime
-  checks. Do not improvise shell commands.
+- You may use shell, HTTP, browser, and probe tools for verification, but
+  any temporary scripts or harnesses must live outside the workspace (for
+  example `/tmp`).
+- Read the repo instructions (`CLAUDE.md`, `README`, package/build manifests)
+  before deciding what to verify.
 - Reading code is context, not verification. A PASS verdict requires probe
   output or direct artifact inspection that disproves obvious failure modes.
 - When the runtime names required probe categories, do not return PASS until
@@ -22,6 +25,8 @@ Rules:
   the implementation.
 - If something cannot be verified because the environment is missing a
   dependency, probe, or service, say exactly what blocked it.
+- If the repo does not define a test suite for the relevant surface, say that
+  explicitly and return `VERDICT: PARTIAL` rather than manufacturing one.
 
 Output format:
 - `### Check: ...`

--- a/runtime/src/gateway/shell-profile.ts
+++ b/runtime/src/gateway/shell-profile.ts
@@ -71,6 +71,7 @@ const DEFINITIONS: Record<SessionShellProfile, ShellProfileDefinition> = {
       "Treat the local workspace as the primary source of truth and prefer inspect-edit-verify loops over speculative prose.",
       "Bias toward file, shell, test, task, and delegated implementation tools that materially move code work forward.",
       "When changing code, validate behavior with the smallest useful check before concluding.",
+      "Before reporting non-trivial implementation complete, expect independent verifier confirmation instead of self-certifying the result.",
     ],
     toolPrefixes: ["task.", "verification."],
     exactToolNames: [

--- a/runtime/src/gateway/top-level-verifier.test.ts
+++ b/runtime/src/gateway/top-level-verifier.test.ts
@@ -1,3 +1,5 @@
+import { tmpdir } from "node:os";
+
 import { describe, expect, it, vi } from "vitest";
 
 import type { ChatExecutorResult } from "../llm/chat-executor.js";
@@ -76,7 +78,7 @@ function createVerifierRequirement(
     profiles: ["generic"],
     probeCategories: ["build"],
     mutationPolicy: "read_only_workspace",
-    allowTempArtifacts: false,
+    allowTempArtifacts: true,
     bootstrapSource: "disabled",
     rationale: ["test requirement"],
     ...overrides,
@@ -139,13 +141,14 @@ describe("runTopLevelVerifierValidation", () => {
           kind: "prompt_envelope_v1",
           baseSystemPrompt: "Verifier system prompt",
         }),
-        tools: [
+        tools: expect.arrayContaining([
           "system.readFile",
+          "system.bash",
           "verification.runProbe",
           "system.listDir",
           "system.stat",
           "verification.listProbes",
-        ],
+        ]),
         structuredOutput: expect.objectContaining({
           enabled: true,
           schema: expect.objectContaining({
@@ -156,6 +159,7 @@ describe("runTopLevelVerifierValidation", () => {
         requiredToolEvidence: expect.objectContaining({
           executionEnvelope: expect.objectContaining({
             verificationMode: "grounded_read",
+            allowedWriteRoots: [tmpdir()],
             targetArtifacts: ["/workspace/src/main.c"],
           }),
         }),
@@ -201,13 +205,14 @@ describe("runTopLevelVerifierValidation", () => {
     expect(decision.runtimeVerifier.overall).toBe("fail");
   });
 
-  it("skips verifier work for ordinary workflow turns with artifact-only completion", async () => {
+  it("skips verifier work when no successful workspace mutation occurred", async () => {
     const spawn = vi.fn(async () => "subagent:verify-1");
 
     const decision = await runTopLevelVerifierValidation({
       sessionId: "session:test",
       userRequest: "hello",
       result: createResult({
+        toolCalls: [],
         turnExecutionContract: {
           ...createResult().turnExecutionContract,
           turnClass: "workflow_implementation",

--- a/runtime/src/gateway/top-level-verifier.ts
+++ b/runtime/src/gateway/top-level-verifier.ts
@@ -1,6 +1,10 @@
+import { tmpdir } from "node:os";
+
 import type { ChatExecutorResult } from "../llm/chat-executor-types.js";
+import { hasSuccessfulStructuredMutation } from "../llm/deterministic-acceptance-probes.js";
 import { type PlannerVerificationSnapshot } from "../workflow/completion-state.js";
 import { createExecutionEnvelope } from "../workflow/execution-envelope.js";
+import { areDocumentationOnlyArtifacts } from "../workflow/artifact-paths.js";
 import {
   normalizeArtifactPaths,
   normalizeWorkspaceRoot,
@@ -31,8 +35,33 @@ import {
 
 const DEFAULT_VERIFY_TOOLS = [
   "system.readFile",
+  "system.readFileRange",
   "system.listDir",
   "system.stat",
+  "system.searchFiles",
+  "system.grep",
+  "system.bash",
+  "system.httpGet",
+  "system.httpPost",
+  "system.httpFetch",
+  "system.browse",
+  "system.extractLinks",
+  "system.htmlToMarkdown",
+  "system.browserAction",
+  "system.browserSessionStart",
+  "system.browserSessionStatus",
+  "system.browserSessionResume",
+  "system.browserSessionStop",
+  "system.browserSessionArtifacts",
+  "system.browserSessionTransfers",
+  "system.browserTransferStatus",
+  "system.browserTransferCancel",
+  "mcp.browser.browser_navigate",
+  "mcp.browser.browser_snapshot",
+  "playwright.browser_navigate",
+  "playwright.browser_snapshot",
+  "playwright.browser_click",
+  "playwright.browser_type",
   "verification.listProbes",
   "verification.runProbe",
 ] as const;
@@ -40,7 +69,8 @@ const ALLOWED_VERIFY_TOOLS = new Set<string>(DEFAULT_VERIFY_TOOLS);
 
 const DEFAULT_VERIFY_SYSTEM_PROMPT =
   "You are a verification agent. Your job is to try to break the claimed implementation with real checks. " +
-  "Stay read-only, inspect the declared artifacts directly, run repo-local verification commands when possible, " +
+  "Do not modify project files. You may use temp-only artifacts outside the workspace when needed for verification harnesses. " +
+  "Read the repo instructions first, inspect the declared artifacts directly, and run repo-local verification commands when possible, " +
   "and finish with exactly one line: VERDICT: PASS, VERDICT: FAIL, or VERDICT: PARTIAL.";
 const VERIFY_STRUCTURED_OUTPUT: LLMStructuredOutputRequest = {
   enabled: true,
@@ -144,43 +174,29 @@ function truncate(text: string, max: number): string {
   return `${text.slice(0, max - 1).trimEnd()}…`;
 }
 
-function getTopLevelVerifierTaskClass(
-  turnExecutionContract:
-    | Pick<TurnExecutionContract, "completionContract" | "verificationContract">
-    | undefined,
-): string | undefined {
-  const completionContract = turnExecutionContract?.completionContract as
-    | { readonly taskClass?: unknown }
-    | undefined;
-  if (typeof completionContract?.taskClass === "string") {
-    return completionContract.taskClass;
-  }
-
-  const verificationContract = turnExecutionContract?.verificationContract as
-    | { readonly completionContract?: { readonly taskClass?: unknown } }
-    | undefined;
-  const nestedTaskClass =
-    verificationContract?.completionContract?.taskClass;
-  return typeof nestedTaskClass === "string" ? nestedTaskClass : undefined;
-}
-
 export function isExplicitTopLevelVerifierRequiredForTurn(params: {
   readonly turnExecutionContract:
     | Pick<
         TurnExecutionContract,
-        "turnClass" | "completionContract" | "verificationContract"
+        | "turnClass"
+        | "completionContract"
+        | "verificationContract"
+        | "targetArtifacts"
       >
     | undefined;
+  readonly allToolCalls?: readonly ChatExecutorResult["toolCalls"][number][];
 }): boolean {
   if (params.turnExecutionContract?.turnClass !== "workflow_implementation") {
     return false;
   }
-  const taskClass = getTopLevelVerifierTaskClass(params.turnExecutionContract);
-  return (
-    taskClass === "build_required" ||
-    taskClass === "behavior_required" ||
-    taskClass === "review_required"
-  );
+  const targetArtifacts = params.turnExecutionContract?.targetArtifacts ?? [];
+  if (targetArtifacts.length === 0) {
+    return false;
+  }
+  if (areDocumentationOnlyArtifacts(targetArtifacts)) {
+    return false;
+  }
+  return hasSuccessfulStructuredMutation(params.allToolCalls ?? []);
 }
 
 function selectVerifyDefinition(
@@ -256,7 +272,7 @@ function buildVerifierPrompt(params: {
   }
   lines.push("");
   lines.push(
-    "Inspect the target artifacts directly, call verification.listProbes, run concrete verification probes, and report whether the implementation actually holds up.",
+    "Read the repo instructions first, inspect the target artifacts directly, use the attached shell/http/browser/probe tools for concrete verification, and report whether the implementation actually holds up.",
   );
   return lines.join("\n");
 }
@@ -400,6 +416,7 @@ function shouldRunTopLevelVerifier(params: TopLevelVerifierParams): boolean {
   if (
     !isExplicitTopLevelVerifierRequiredForTurn({
       turnExecutionContract: params.result.turnExecutionContract,
+      allToolCalls: params.result.toolCalls,
     })
   ) {
     return false;
@@ -419,6 +436,7 @@ function resolveTopLevelVerifierRequirement(
 ): VerifierRequirement | null {
   const explicitVerifierRequired = isExplicitTopLevelVerifierRequiredForTurn({
     turnExecutionContract: params.result.turnExecutionContract,
+    allToolCalls: params.result.toolCalls,
   });
   if (!explicitVerifierRequired) {
     return null;
@@ -431,7 +449,7 @@ function resolveTopLevelVerifierRequirement(
           profiles: ["generic"],
           probeCategories: [],
           mutationPolicy: "read_only_workspace",
-          allowTempArtifacts: false,
+          allowTempArtifacts: true,
           rationale: ["runtime verifier required"],
         }
       : null;
@@ -458,6 +476,12 @@ function getTopLevelVerifierSkipReason(
   }
   const targetArtifacts = params.result.turnExecutionContract.targetArtifacts ?? [];
   if (targetArtifacts.length === 0) return "missing_target_artifacts";
+  if (areDocumentationOnlyArtifacts(targetArtifacts)) {
+    return "documentation_only_artifacts";
+  }
+  if (!hasSuccessfulStructuredMutation(params.result.toolCalls)) {
+    return "no_successful_workspace_mutation";
+  }
   return undefined;
 }
 
@@ -471,6 +495,10 @@ function buildTopLevelVerifierSkipBlockingMessage(reason: string): string {
           ? "the workflow completion state is not completed yet"
           : reason === "turn_class_not_workflow_implementation"
             ? "the turn is not classified as workflow_implementation"
+            : reason === "documentation_only_artifacts"
+              ? "the declared target artifacts are documentation-only"
+              : reason === "no_successful_workspace_mutation"
+                ? "the turn has not made a successful non-documentation workspace mutation yet"
             : "no target artifacts were declared for verification";
   return [
     "Runtime verification is required before completion can be accepted.",
@@ -526,7 +554,7 @@ export async function runTopLevelVerifierValidation(
             profiles: ["generic"],
             probeCategories: [],
             mutationPolicy: "read_only_workspace",
-            allowTempArtifacts: false,
+            allowTempArtifacts: true,
             rationale: ["runtime verifier required"],
           },
       };
@@ -613,10 +641,10 @@ export async function runTopLevelVerifierValidation(
   );
   const definition = selectVerifyDefinition(params.agentDefinitions);
   const inspectionArtifacts = [...new Set([...sourceArtifacts, ...targetArtifacts])];
-  const executionEnvelope = createExecutionEnvelope({
+  const executionEnvelopeBase = createExecutionEnvelope({
     workspaceRoot,
     allowedReadRoots: workspaceRoot ? [workspaceRoot] : [],
-    allowedWriteRoots: [],
+    allowedWriteRoots: [tmpdir()],
     allowedTools: definition.tools,
     inputArtifacts: inspectionArtifacts,
     requiredSourceArtifacts: inspectionArtifacts,
@@ -631,6 +659,12 @@ export async function runTopLevelVerifierValidation(
       partialCompletionAllowed: false,
     },
   });
+  const executionEnvelope = executionEnvelopeBase
+    ? {
+        ...executionEnvelopeBase,
+        allowedWriteRoots: [tmpdir()],
+      }
+    : undefined;
 
   const spawnConfig: SubAgentConfig = {
     parentSessionId: params.sessionId,
@@ -649,7 +683,7 @@ export async function runTopLevelVerifierValidation(
     ...(workspaceRoot ? { workingDirectory: workspaceRoot } : {}),
     requiredToolEvidence: {
       maxCorrectionAttempts: 1,
-      executionEnvelope,
+      executionEnvelope: executionEnvelope!,
     },
   };
 

--- a/runtime/src/gateway/verifier-probes.ts
+++ b/runtime/src/gateway/verifier-probes.ts
@@ -219,6 +219,14 @@ function readJsonObject(
   }
 }
 
+function readTextFile(path: string): string | undefined {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
 function readPackageScripts(
   workspaceRoot: string,
 ): Record<string, string> {
@@ -524,7 +532,7 @@ function addCMakeProbes(
     timeoutMs: DEFAULT_PROBE_TIMEOUT_MS,
     writesTempOnly: false,
   });
-  if (hasExecutableOnPath("ctest")) {
+  if (hasExecutableOnPath("ctest") && hasExplicitCMakeTests(workspaceRoot)) {
     pushProbe(probes, seen, {
       id: "generic:test:ctest",
       label: "ctest",
@@ -537,6 +545,24 @@ function addCMakeProbes(
       writesTempOnly: false,
     });
   }
+}
+
+function hasExplicitCMakeTests(workspaceRoot: string): boolean {
+  const rootCMake = readTextFile(resolvePath(workspaceRoot, "CMakeLists.txt"));
+  if (
+    rootCMake &&
+    /\b(?:enable_testing|add_test)\s*\(/i.test(rootCMake)
+  ) {
+    return true;
+  }
+  if (rootCMake && /\binclude\s*\(\s*CTest\s*\)/i.test(rootCMake)) {
+    return true;
+  }
+  return [
+    resolvePath(workspaceRoot, "CTestTestfile.cmake"),
+    resolvePath(workspaceRoot, "build", "CTestTestfile.cmake"),
+    resolvePath(workspaceRoot, "build", "DartConfiguration.tcl"),
+  ].some((path) => existsSync(path));
 }
 
 function addMakeProbes(
@@ -891,7 +917,7 @@ export function createVerifierRequirement(params: {
       profiles: [],
       probeCategories: [],
       mutationPolicy: "read_only_workspace",
-      allowTempArtifacts: false,
+      allowTempArtifacts: true,
       bootstrapSource: "disabled",
       rationale: ["verification not required for this execution"],
     };
@@ -935,7 +961,7 @@ export function createVerifierRequirement(params: {
     profiles,
     probeCategories,
     mutationPolicy: "read_only_workspace",
-    allowTempArtifacts: false,
+    allowTempArtifacts: true,
     bootstrapSource: source,
     rationale:
       bootstrap?.rationale && bootstrap.rationale.length > 0

--- a/runtime/src/llm/chat-executor-artifact-evidence.test.ts
+++ b/runtime/src/llm/chat-executor-artifact-evidence.test.ts
@@ -76,6 +76,69 @@ function createParams(
   };
 }
 
+function createTopLevelVerifierConfig(params: {
+  readonly verdict?: "pass" | "fail" | "retry";
+  readonly summary?: string;
+} = {}): NonNullable<
+  ConstructorParameters<typeof ChatExecutor>[0]
+>["completionValidation"] {
+  const verdict = params.verdict ?? "pass";
+  const summary =
+    params.summary ??
+    (verdict === "pass"
+      ? "Verifier passed."
+      : verdict === "fail"
+        ? "Verifier failed."
+        : "Verifier was inconclusive.");
+  return {
+    topLevelVerifier: {
+      subAgentManager: {
+        spawn: vi.fn(async () => "subagent:verify"),
+        waitForResult: vi.fn(async () => ({
+          sessionId: "subagent:verify",
+          output: `${summary}\nVERDICT: ${
+            verdict === "pass" ? "PASS" : verdict === "fail" ? "FAIL" : "PARTIAL"
+          }`,
+          success: verdict === "pass",
+          durationMs: 1,
+          toolCalls: [
+            {
+              name: "verification.runProbe",
+              args: { probeId: "generic:build:make" },
+              result:
+                "{\"ok\":true,\"__agencVerification\":{\"probeId\":\"generic:build:make\",\"category\":\"build\",\"profile\":\"generic\"}}",
+              isError: false,
+              durationMs: 1,
+            },
+          ],
+          structuredOutput: {
+            type: "json_schema" as const,
+            name: "agenc_top_level_verifier_decision",
+            parsed: {
+              verdict,
+              summary,
+            },
+          },
+          completionState: "completed" as const,
+          stopReason: "completed" as const,
+        })),
+      },
+      verifierService: {
+        resolveVerifierRequirement: vi.fn(() => ({
+          required: true,
+          profiles: ["generic"],
+          probeCategories: ["build"],
+          mutationPolicy: "read_only_workspace" as const,
+          allowTempArtifacts: true,
+          bootstrapSource: "disabled" as const,
+          rationale: ["test"],
+        })),
+        shouldVerifySubAgentResult: vi.fn(() => true),
+      },
+    },
+  };
+}
+
 describe("top-level artifact evidence gate", () => {
   it("forces a recovery tool turn for carried workflow implementation tasks", async () => {
     const activeTaskContext: ActiveTaskContext = {
@@ -142,7 +205,11 @@ describe("top-level artifact evidence gate", () => {
     const toolHandler = vi.fn(async (_name: string, args: Record<string, unknown>) =>
       safeJson({ ok: true, path: args.path }),
     );
-    const executor = new ChatExecutor({ providers: [provider], toolHandler });
+    const executor = new ChatExecutor({
+      providers: [provider],
+      toolHandler,
+      completionValidation: createTopLevelVerifierConfig(),
+    });
 
     const result = await executor.execute(
       createParams({
@@ -156,6 +223,7 @@ describe("top-level artifact evidence gate", () => {
     expect(result.stopReason).toBe("completed");
     expect(result.completionState).toBe("completed");
     expect(result.validationCode).toBeUndefined();
+    expect(result.verifierSnapshot?.overall).toBe("pass");
     expect(result.toolCalls.filter((call) => call.name === "system.writeFile")).toHaveLength(2);
     expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(4);
     expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls[2]?.[1]).toMatchObject({
@@ -450,7 +518,7 @@ describe("top-level artifact evidence gate", () => {
     }
   });
 
-  it("re-enters the loop when deterministic acceptance probes fail", async () => {
+  it("accepts completion once declared artifacts exist and the explicit verifier passes", async () => {
     const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-acceptance-probe-"));
     const sourcePath = join(workspaceRoot, "src/main.c");
     mkdirSync(join(workspaceRoot, "src"), { recursive: true });
@@ -519,28 +587,40 @@ describe("top-level artifact evidence gate", () => {
       }
       return safeJson({ exitCode: 0, stdout: "ok" });
     });
-    const executor = new ChatExecutor({ providers: [provider], toolHandler });
+    const executor = new ChatExecutor({
+      providers: [provider],
+      toolHandler,
+      completionValidation: createTopLevelVerifierConfig(),
+    });
 
     try {
       const result = await executor.execute(
         createParams({
           runtimeContext: { workspaceRoot },
+          requiredToolEvidence: {
+            verificationContract: {
+              workspaceRoot,
+              targetArtifacts: [sourcePath],
+              completionContract: {
+                taskClass: "build_required",
+                placeholdersAllowed: false,
+                partialCompletionAllowed: false,
+              },
+            },
+          },
         }),
       );
 
       expect(result.stopReason).toBe("completed");
-      expect(result.toolCalls.filter((call) => call.name === "system.writeFile")).toHaveLength(2);
-      expect(result.toolCalls.filter((call) => call.name === "verification.runProbe")).toHaveLength(2);
-      expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(4);
-      expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls[2]?.[1]).toMatchObject({
-        toolChoice: "required",
-      });
+      expect(result.verifierSnapshot?.overall).toBe("pass");
+      expect(result.toolCalls.filter((call) => call.name === "system.writeFile")).toHaveLength(1);
+      expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
     } finally {
       rmSync(workspaceRoot, { recursive: true, force: true });
     }
   });
 
-  it("keeps repairing workflow-owned coding turns while deterministic probes remain productive", async () => {
+  it("blocks completion after a failed explicit verifier instead of entering inline repair loops", async () => {
     const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-acceptance-budget-"));
     const sourcePath = join(workspaceRoot, "src/main.c");
     mkdirSync(join(workspaceRoot, "src"), { recursive: true });
@@ -576,45 +656,8 @@ describe("top-level artifact evidence gate", () => {
         )
         .mockResolvedValueOnce(
           mockResponse({
-            content: "",
-            finishReason: "tool_calls",
-            toolCalls: [
-              {
-                id: "tc-2",
-                name: "system.writeFile",
-                arguments: safeJson({
-                  path: sourcePath,
-                  content: "still bad build again",
-                }),
-              },
-            ],
-          }),
-        )
-        .mockResolvedValueOnce(
-          mockResponse({
-            content: "Retried the implementation.",
-          }),
-        )
-        .mockResolvedValueOnce(
-          mockResponse({
-            content: "",
-            finishReason: "tool_calls",
-            toolCalls: [
-              {
-                id: "tc-3",
-                name: "system.writeFile",
-                arguments: safeJson({
-                  path: sourcePath,
-                  content: "good build",
-                }),
-              },
-            ],
-          }),
-        )
-        .mockResolvedValueOnce(
-          mockResponse({
             content:
-              "Implementation completed with passing acceptance probes after multiple productive repair turns, and this completion summary is intentionally verbose so the stop gate does not misclassify it as a truncated success claim.",
+              "Implementation completed after the initial build write, and this completion summary is intentionally verbose so the stop gate does not misclassify it as a truncated success claim.",
           }),
         ),
     });
@@ -630,7 +673,14 @@ describe("top-level artifact evidence gate", () => {
       }
       return safeJson({ exitCode: 0, stdout: "ok" });
     });
-    const executor = new ChatExecutor({ providers: [provider], toolHandler });
+    const executor = new ChatExecutor({
+      providers: [provider],
+      toolHandler,
+      completionValidation: createTopLevelVerifierConfig({
+        verdict: "fail",
+        summary: "Build still fails under verifier-run checks.",
+      }),
+    });
 
     try {
       const result = await executor.execute(
@@ -646,11 +696,12 @@ describe("top-level artifact evidence gate", () => {
         }),
       );
 
-      expect(result.stopReason).toBe("completed");
-      expect(result.toolCalls.filter((call) => call.name === "system.writeFile")).toHaveLength(3);
-      expect(result.toolCalls.filter((call) => call.name === "verification.runProbe")).toHaveLength(3);
-      expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(6);
-      expect(readFileSync(sourcePath, "utf8")).toBe("good build");
+      expect(result.stopReason).toBe("validation_error");
+      expect(result.completionState).toBe("partial");
+      expect(result.verifierSnapshot?.overall).toBe("fail");
+      expect(result.toolCalls.filter((call) => call.name === "system.writeFile")).toHaveLength(1);
+      expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(2);
+      expect(readFileSync(sourcePath, "utf8")).toBe("still bad build");
     } finally {
       rmSync(workspaceRoot, { recursive: true, force: true });
     }
@@ -775,7 +826,7 @@ describe("top-level artifact evidence gate", () => {
               profiles: ["generic"],
               probeCategories: ["build"],
               mutationPolicy: "read_only_workspace",
-              allowTempArtifacts: false,
+              allowTempArtifacts: true,
               bootstrapSource: "disabled",
               rationale: ["test"],
             })),

--- a/runtime/src/llm/chat-executor-continuation.test.ts
+++ b/runtime/src/llm/chat-executor-continuation.test.ts
@@ -200,7 +200,7 @@ describe("chat-executor-continuation", () => {
       state: ctx.continuationState,
       ctx,
       reason: "validator",
-      validatorId: "deterministic_acceptance_probes",
+      validatorId: "top_level_verifier",
     });
     finishTurnContinuation({ state: ctx.continuationState, ctx });
 

--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -84,8 +84,6 @@ import {
 } from "./hooks/index.js";
 import {
   BUILTIN_ARTIFACT_EVIDENCE_HOOK_ID,
-  BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID,
-  BUILTIN_FILESYSTEM_ARTIFACT_VERIFICATION_HOOK_ID,
   BUILTIN_TURN_END_STOP_GATE_ID,
   runStopHookPhase,
 } from "./hooks/stop-hooks.js";
@@ -1843,8 +1841,6 @@ export async function executeToolCallLoop(
     const shouldRequireRecoveryTool =
       params.validationCode === "missing_file_mutation_evidence" ||
       params.validationCode === "missing_file_artifact_evidence" ||
-      stopHookRecoveryReason === "filesystem_artifact_verification" ||
-      stopHookRecoveryReason === "deterministic_acceptance_probe_failed" ||
       (params.stopHookResult !== undefined && ctx.requiredToolEvidence !== undefined);
     const recoveryToolChoice = shouldRequireRecoveryTool
       ? "required"
@@ -2344,14 +2340,6 @@ export async function executeToolCallLoop(
         hookId: BUILTIN_ARTIFACT_EVIDENCE_HOOK_ID,
         validatorId: "artifact_evidence" as CompletionValidatorId,
       },
-      {
-        hookId: BUILTIN_FILESYSTEM_ARTIFACT_VERIFICATION_HOOK_ID,
-        validatorId: "filesystem_artifact_verification" as CompletionValidatorId,
-      },
-      {
-        hookId: BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID,
-        validatorId: "deterministic_acceptance_probes" as CompletionValidatorId,
-      },
     ] as const;
 
     callbacks.emitExecutionTrace(ctx, {
@@ -2367,6 +2355,7 @@ export async function executeToolCallLoop(
     let completionValidationStatus = "passed";
     const topLevelVerifierEnabled = isExplicitTopLevelVerifierRequiredForTurn({
       turnExecutionContract: ctx.turnExecutionContract,
+      allToolCalls: ctx.allToolCalls,
     });
     const stopHooksEnabled =
       config.runtimeContractFlags.stopHooksEnabled &&
@@ -2533,11 +2522,7 @@ export async function executeToolCallLoop(
             hookValidationCode === "missing_file_mutation_evidence" ||
             hookValidationCode === "missing_file_artifact_evidence"
               ? "Max model recalls exceeded during artifact-evidence recovery turn"
-              : hookResult.reason === "filesystem_artifact_verification"
-                ? "Max model recalls exceeded during filesystem artifact recovery turn"
-                : hookResult.reason === "deterministic_acceptance_probe_failed"
-                  ? "Max model recalls exceeded during deterministic acceptance-probe recovery turn"
-                  : "Max model recalls exceeded during stop-hook recovery turn",
+              : "Max model recalls exceeded during stop-hook recovery turn",
           exhaustedDetail:
             hookResult.reason === "narrated_future_tool_work"
               ? "Stop-gate recovery exhausted: the model kept narrating future work instead of calling tools."
@@ -2673,10 +2658,7 @@ export async function executeToolCallLoop(
           reason: "top_level_verifier",
           blockingMessage: validation.blockingMessage,
           evidence: { verifier: validation.runtimeVerifier },
-          maxAttempts:
-            ctx.requiredToolEvidence?.maxCorrectionAttemptsExplicit === true
-              ? ctx.requiredToolEvidence.maxCorrectionAttempts
-              : undefined,
+          maxAttempts: 0,
           budgetReason:
             "Max model recalls exceeded during top-level verifier recovery turn",
           exhaustedDetail:

--- a/runtime/src/llm/completion-validators.test.ts
+++ b/runtime/src/llm/completion-validators.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -142,7 +142,7 @@ function taskToolResult(params: {
 }
 
 describe("completion-validators", () => {
-  it("registers request_task_progress between stop-gate and filesystem checks", () => {
+  it("registers request_task_progress before the explicit top-level verifier", () => {
     const validators = buildCompletionValidators({
       ctx: makeCtx({}),
       runtimeContractFlags: makeFlags(),
@@ -152,8 +152,6 @@ describe("completion-validators", () => {
       "artifact_evidence",
       "turn_end_stop_gate",
       "request_task_progress",
-      "filesystem_artifact_verification",
-      "deterministic_acceptance_probes",
       "top_level_verifier",
     ]);
   });
@@ -335,31 +333,26 @@ describe("completion-validators", () => {
       }),
     });
 
-    const deterministic = validators.find(
-      (validator) => validator.id === "deterministic_acceptance_probes",
-    );
     const topLevel = validators.find(
       (validator) => validator.id === "top_level_verifier",
     );
-    const deterministicResult = await deterministic!.execute();
     const topLevelResult = await topLevel!.execute();
 
-    expect(deterministicResult.outcome).toBe("retry_with_blocking_message");
-    expect(deterministicResult.blockingMessage).toBe("verification blocked");
-    expect(deterministicResult.stopHookResult?.phase).toBe("VerificationReady");
     expect(topLevelResult.outcome).toBe("retry_with_blocking_message");
+    expect(topLevelResult.blockingMessage).toBe("verification blocked");
+    expect(topLevelResult.stopHookResult?.phase).toBe("VerificationReady");
     expect(toolHandler).not.toHaveBeenCalled();
   });
 
-  it("skips the top-level verifier for ordinary workflow turns that only carry artifact completion", async () => {
+  it("skips the top-level verifier for documentation-only completion turns", async () => {
     const flags = makeFlags({
       verifierRuntimeRequired: true,
     });
     const validators = buildCompletionValidators({
       ctx: makeCtx({
         flags,
-        allToolCalls: [successfulWrite("/tmp/workspace/src/main.c")],
-        targetArtifacts: ["/tmp/workspace/src/main.c"],
+        allToolCalls: [successfulWrite("/tmp/workspace/docs/readme.md")],
+        targetArtifacts: ["/tmp/workspace/docs/readme.md"],
         turnClass: "workflow_implementation",
         ownerMode: "workflow_owner",
         completionContract: {
@@ -376,247 +369,6 @@ describe("completion-validators", () => {
     )!.execute();
 
     expect(result.outcome).toBe("skipped");
-  });
-
-  it("uses the shared correction budget for deterministic acceptance probes on workflow-owned turns", async () => {
-    const workspaceRoot = mkdtempSync(join(tmpdir(), "deterministic-budget-"));
-    writeFileSync(
-      join(workspaceRoot, "Makefile"),
-      "all:\n\t@printf 'ok\\n'\n",
-    );
-    const validators = buildCompletionValidators({
-      ctx: makeCtx({
-        workspaceRoot,
-        allToolCalls: [successfulWrite(join(workspaceRoot, "src/main.c"))],
-        targetArtifacts: [join(workspaceRoot, "src/main.c")],
-        turnClass: "workflow_implementation",
-        ownerMode: "workflow_owner",
-      }),
-      runtimeContractFlags: makeFlags(),
-    });
-
-    const deterministic = validators.find(
-      (validator) => validator.id === "deterministic_acceptance_probes",
-    );
-    const result = await deterministic!.execute();
-
-    expect(result.outcome).toBe("pass");
-    expect(result.probeRuns).toHaveLength(1);
-  });
-
-  it("fails closed when a deterministic acceptance recovery turn made no workspace mutations", async () => {
-    const workspaceRoot = mkdtempSync(join(tmpdir(), "deterministic-stall-"));
-    writeFileSync(
-      join(workspaceRoot, "Makefile"),
-      "all:\n\t@echo build failed >&2\n\t@exit 2\n",
-    );
-    const validators = buildCompletionValidators({
-      ctx: makeCtx({
-        workspaceRoot,
-        allToolCalls: [
-          successfulWrite(join(workspaceRoot, "src/main.c")),
-          syntheticAcceptanceProbe({
-            exitCode: 2,
-            stdout: "",
-            stderr: "build failed",
-            timedOut: false,
-            durationMs: 1,
-            truncated: false,
-          }),
-        ],
-        targetArtifacts: [join(workspaceRoot, "src/main.c")],
-        turnClass: "workflow_implementation",
-        ownerMode: "workflow_owner",
-      }),
-      runtimeContractFlags: makeFlags(),
-    });
-
-    const deterministic = validators.find(
-      (validator) => validator.id === "deterministic_acceptance_probes",
-    );
-    const result = await deterministic!.execute();
-
-    expect(result.outcome).toBe("fail_closed");
-    expect(result.reason).toBe("deterministic_acceptance_probe_failed");
-    expect(result.exhaustedDetail).toContain(
-      "made no successful workspace mutations",
-    );
-  });
-
-  it("uses the shared correction budget for filesystem artifact recovery", async () => {
-    const workspaceRoot = mkdtempSync(join(tmpdir(), "filesystem-budget-"));
-    const missingPath = join(workspaceRoot, "src/main.c");
-    const validators = buildCompletionValidators({
-      ctx: makeCtx({
-        finalContent: "Implementation complete. All phases implemented.",
-        allToolCalls: [
-          {
-            name: "system.writeFile",
-            args: { path: missingPath, content: "phase 1" },
-            result: JSON.stringify({ ok: true, path: missingPath }),
-            isError: false,
-            durationMs: 1,
-          },
-        ],
-        requiredToolEvidence: {
-          maxCorrectionAttempts: 3,
-        },
-      }),
-      runtimeContractFlags: makeFlags(),
-    });
-
-    const filesystem = validators.find(
-      (validator) => validator.id === "filesystem_artifact_verification",
-    );
-    const result = await filesystem!.execute();
-
-    expect(result.outcome).toBe("retry_with_blocking_message");
-    expect(result.maxAttempts).toBe(3);
-    expect(result.blockingMessage).toContain("bounded recovery loop");
-  });
-
-  it("applies the shared 3-attempt recovery budget consistently across the primary validators", async () => {
-    const workspaceRoot = mkdtempSync(join(tmpdir(), "shared-budget-"));
-    mkdirSync(join(workspaceRoot, "src"), { recursive: true });
-    writeFileSync(
-      join(workspaceRoot, "Makefile"),
-      "all:\n\t@echo build failed >&2\n\t@exit 2\n",
-      "utf8",
-    );
-    const targetPath = join(workspaceRoot, "src/main.c");
-    const stopHookFlags = makeFlags({ stopHooksEnabled: true });
-    const narrativeCtx = makeCtx({
-      workspaceRoot,
-      finalContent: "Next I will fix the build and rerun the checks.",
-      allToolCalls: [successfulWrite(targetPath)],
-      targetArtifacts: [targetPath],
-      turnClass: "workflow_implementation",
-      ownerMode: "workflow_owner",
-      flags: stopHookFlags,
-      requiredToolEvidence: {
-        maxCorrectionAttempts: 3,
-      },
-    });
-    setAllowedRequestTaskMilestones(narrativeCtx.requestTaskState, [
-      { id: "phase_1", description: "Finish phase 1" },
-    ]);
-    const narrativeValidators = buildCompletionValidators({
-      ctx: narrativeCtx,
-      runtimeContractFlags: stopHookFlags,
-      stopHookRuntime: buildStopHookRuntime(undefined),
-    });
-    const filesystemCtx = makeCtx({
-      workspaceRoot,
-      finalContent: "Implementation complete. All phases implemented.",
-      allToolCalls: [successfulWrite(targetPath)],
-      targetArtifacts: [targetPath],
-      turnClass: "workflow_implementation",
-      ownerMode: "workflow_owner",
-      requiredToolEvidence: {
-        maxCorrectionAttempts: 3,
-      },
-    });
-    const filesystemValidators = buildCompletionValidators({
-      ctx: filesystemCtx,
-      runtimeContractFlags: makeFlags(),
-    });
-    const narrativeById = new Map(
-      narrativeValidators.map((validator) => [validator.id, validator]),
-    );
-    const filesystemById = new Map(
-      filesystemValidators.map((validator) => [validator.id, validator]),
-    );
-
-    const [stopGate, taskProgress, deterministic, filesystem] = await Promise.all([
-      narrativeById.get("turn_end_stop_gate")!.execute(),
-      narrativeById.get("request_task_progress")!.execute(),
-      narrativeById.get("deterministic_acceptance_probes")!.execute(),
-      filesystemById.get("filesystem_artifact_verification")!.execute(),
-    ]);
-
-    try {
-      expect(stopGate.outcome).toBe("retry_with_blocking_message");
-      expect(stopGate.maxAttempts).toBe(3);
-
-      expect(taskProgress.outcome).toBe("pass");
-
-      expect(filesystem.outcome).toBe("retry_with_blocking_message");
-      expect(filesystem.maxAttempts).toBe(3);
-
-      expect(deterministic.outcome).toBe("retry_with_blocking_message");
-      expect(deterministic.maxAttempts).toBe(3);
-    } finally {
-      rmSync(workspaceRoot, { recursive: true, force: true });
-    }
-  });
-
-  it("keeps an explicit zero correction budget at zero for the recovery validators", async () => {
-    const workspaceRoot = mkdtempSync(join(tmpdir(), "zero-budget-"));
-    mkdirSync(join(workspaceRoot, "src"), { recursive: true });
-    writeFileSync(
-      join(workspaceRoot, "Makefile"),
-      "all:\n\t@echo build failed >&2\n\t@exit 2\n",
-      "utf8",
-    );
-    const targetPath = join(workspaceRoot, "src/main.c");
-    const stopHookFlags = makeFlags({ stopHooksEnabled: true });
-    const narrativeCtx = makeCtx({
-      workspaceRoot,
-      finalContent: "Next I will fix the build and rerun the checks.",
-      allToolCalls: [successfulWrite(targetPath)],
-      targetArtifacts: [targetPath],
-      turnClass: "workflow_implementation",
-      ownerMode: "workflow_owner",
-      flags: stopHookFlags,
-      requiredToolEvidence: {
-        maxCorrectionAttempts: 0,
-      },
-    });
-    setAllowedRequestTaskMilestones(narrativeCtx.requestTaskState, [
-      { id: "phase_1", description: "Finish phase 1" },
-    ]);
-    const narrativeValidators = buildCompletionValidators({
-      ctx: narrativeCtx,
-      runtimeContractFlags: stopHookFlags,
-      stopHookRuntime: buildStopHookRuntime(undefined),
-    });
-    const filesystemCtx = makeCtx({
-      workspaceRoot,
-      finalContent: "Implementation complete. All phases implemented.",
-      allToolCalls: [successfulWrite(targetPath)],
-      targetArtifacts: [targetPath],
-      turnClass: "workflow_implementation",
-      ownerMode: "workflow_owner",
-      requiredToolEvidence: {
-        maxCorrectionAttempts: 0,
-      },
-    });
-    const filesystemValidators = buildCompletionValidators({
-      ctx: filesystemCtx,
-      runtimeContractFlags: makeFlags(),
-    });
-    const narrativeById = new Map(
-      narrativeValidators.map((validator) => [validator.id, validator]),
-    );
-    const filesystemById = new Map(
-      filesystemValidators.map((validator) => [validator.id, validator]),
-    );
-
-    const [stopGate, taskProgress, deterministic, filesystem] = await Promise.all([
-      narrativeById.get("turn_end_stop_gate")!.execute(),
-      narrativeById.get("request_task_progress")!.execute(),
-      narrativeById.get("deterministic_acceptance_probes")!.execute(),
-      filesystemById.get("filesystem_artifact_verification")!.execute(),
-    ]);
-
-    try {
-      expect(stopGate.maxAttempts).toBe(0);
-      expect(taskProgress.outcome).toBe("pass");
-      expect(filesystem.maxAttempts).toBe(0);
-      expect(deterministic.maxAttempts).toBe(0);
-    } finally {
-      rmSync(workspaceRoot, { recursive: true, force: true });
-    }
   });
 
   it("runs the top-level verifier even when runtimeContractV2 is false", async () => {
@@ -685,7 +437,7 @@ describe("completion-validators", () => {
               profiles: ["generic"],
               probeCategories: ["build"],
               mutationPolicy: "read_only_workspace",
-              allowTempArtifacts: false,
+              allowTempArtifacts: true,
               bootstrapSource: "disabled",
               rationale: ["test"],
             })),

--- a/runtime/src/llm/completion-validators.ts
+++ b/runtime/src/llm/completion-validators.ts
@@ -1,16 +1,10 @@
 import {
   buildTurnEndStopGateSnapshot,
-  checkFilesystemArtifacts,
   evaluateArtifactEvidenceGate,
 } from "./chat-executor-stop-gate.js";
-import {
-  runDeterministicAcceptanceProbes,
-  shouldRunDeterministicAcceptanceProbes,
-} from "./deterministic-acceptance-probes.js";
 import type {
   ChatExecutorConfig,
   ExecutionContext,
-  ToolCallRecord,
 } from "./chat-executor-types.js";
 import {
   runStopHookPhase,
@@ -29,7 +23,6 @@ import {
 
 export interface CompletionValidatorExecutionResult
   extends CompletionValidatorResult {
-  readonly probeRuns?: readonly ToolCallRecord[];
   readonly stopHookResult?: StopHookPhaseResult;
 }
 
@@ -58,14 +51,8 @@ export function buildCompletionValidators(params: {
       : sharedCorrectionBudgetCap;
   const topLevelVerifierEnabled = isExplicitTopLevelVerifierRequiredForTurn({
     turnExecutionContract: params.ctx.turnExecutionContract,
+    allToolCalls: params.ctx.allToolCalls,
   });
-  const deterministicAcceptanceProbesEnabled =
-    shouldRunDeterministicAcceptanceProbes({
-      workspaceRoot: params.ctx.runtimeWorkspaceRoot,
-      targetArtifacts: params.ctx.turnExecutionContract.targetArtifacts,
-      allToolCalls: params.ctx.allToolCalls,
-      activeToolHandler: params.ctx.activeToolHandler,
-    });
   let verificationReadyGate:
     | CompletionValidatorExecutionResult
     | undefined;
@@ -75,9 +62,9 @@ export function buildCompletionValidators(params: {
       if (verificationReadyGate) {
         return verificationReadyGate;
       }
-      if (!deterministicAcceptanceProbesEnabled && !topLevelVerifierEnabled) {
+      if (!topLevelVerifierEnabled) {
         verificationReadyGate = {
-          id: "deterministic_acceptance_probes",
+          id: "top_level_verifier",
           outcome: "pass",
         };
         return verificationReadyGate;
@@ -92,7 +79,7 @@ export function buildCompletionValidators(params: {
           runtimeWorkspaceRoot: params.ctx.runtimeWorkspaceRoot,
           allToolCalls: params.ctx.allToolCalls,
           verificationReady: {
-            deterministicAcceptanceProbesEnabled,
+            deterministicAcceptanceProbesEnabled: false,
             topLevelVerifierEnabled,
             targetArtifacts: params.ctx.turnExecutionContract.targetArtifacts,
           },
@@ -101,7 +88,7 @@ export function buildCompletionValidators(params: {
       verificationReadyGate =
         hookResult.outcome === "retry_with_blocking_message"
           ? {
-              id: "deterministic_acceptance_probes",
+              id: "top_level_verifier",
               outcome: "retry_with_blocking_message",
               reason: hookResult.reason ?? "verification_ready",
               blockingMessage: hookResult.blockingMessage,
@@ -113,7 +100,7 @@ export function buildCompletionValidators(params: {
             }
           : hookResult.outcome === "prevent_continuation"
             ? {
-                id: "deterministic_acceptance_probes",
+                id: "top_level_verifier",
                 outcome: "fail_closed",
                 reason: hookResult.reason ?? "verification_ready",
                 exhaustedDetail:
@@ -122,7 +109,7 @@ export function buildCompletionValidators(params: {
                 stopHookResult: hookResult,
               }
             : {
-                id: "deterministic_acceptance_probes",
+                id: "top_level_verifier",
                 outcome: "pass",
                 evidence: hookResult.evidence,
                 stopHookResult: hookResult,
@@ -251,86 +238,6 @@ export function buildCompletionValidators(params: {
           maxAttempts,
           exhaustedDetail:
             "Request task progress recovery exhausted while malformed task metadata remained in the session task state.",
-        };
-      },
-    },
-    {
-      id: "filesystem_artifact_verification",
-      enabled: true,
-      async execute(): Promise<CompletionValidatorExecutionResult> {
-        const check = await checkFilesystemArtifacts({
-          finalContent: params.ctx.response?.content ?? "",
-          allToolCalls: params.ctx.allToolCalls,
-          workspaceRoot: params.ctx.runtimeWorkspaceRoot,
-        });
-        if (!check.shouldIntervene) {
-          return { id: "filesystem_artifact_verification", outcome: "pass" };
-        }
-        return {
-          id: "filesystem_artifact_verification",
-          outcome: "retry_with_blocking_message",
-          reason: "filesystem_artifact_verification",
-          blockingMessage: check.blockingMessage,
-          evidence: {
-            emptyFiles: check.emptyFiles,
-            missingFiles: check.missingFiles,
-            checkedFiles: check.checkedFiles,
-          },
-          maxAttempts: sharedCorrectionBudgetCap,
-          exhaustedDetail:
-            "Filesystem artifact verification failed after recovery; missing or empty artifacts remain on disk.",
-        };
-      },
-    },
-    {
-      id: "deterministic_acceptance_probes",
-      enabled: true,
-      async execute(): Promise<CompletionValidatorExecutionResult> {
-        const gate = await ensureVerificationReadyGate();
-        if (gate.outcome !== "pass") {
-          return gate;
-        }
-        const decision = await runDeterministicAcceptanceProbes({
-          workspaceRoot: params.ctx.runtimeWorkspaceRoot,
-          targetArtifacts: params.ctx.turnExecutionContract.targetArtifacts,
-          allToolCalls: params.ctx.allToolCalls,
-          activeToolHandler: params.ctx.activeToolHandler,
-        });
-        if (!decision.shouldIntervene) {
-          return {
-            id: "deterministic_acceptance_probes",
-            outcome: "pass",
-            ...(decision.probeRuns.length > 0 ? { probeRuns: decision.probeRuns } : {}),
-          };
-        }
-        if (decision.allowRecovery === false) {
-          return {
-            id: "deterministic_acceptance_probes",
-            outcome: "fail_closed",
-            reason:
-              decision.validationCode ??
-              "deterministic_acceptance_probe_failed",
-            exhaustedDetail:
-              decision.stopReasonDetail ??
-              "Deterministic acceptance-probe recovery exhausted.",
-            validationCode: decision.validationCode,
-            probeRuns: decision.probeRuns,
-          };
-        }
-        return {
-          id: "deterministic_acceptance_probes",
-          outcome: "retry_with_blocking_message",
-          reason:
-            decision.validationCode ??
-            "deterministic_acceptance_probe_failed",
-          blockingMessage: decision.blockingMessage,
-          evidence: decision.evidence,
-          maxAttempts: sharedCorrectionBudgetCap,
-          exhaustedDetail:
-            decision.stopReasonDetail ??
-            "Deterministic acceptance-probe recovery exhausted.",
-          validationCode: decision.validationCode,
-          probeRuns: decision.probeRuns,
         };
       },
     },

--- a/runtime/src/llm/deterministic-acceptance-probes.ts
+++ b/runtime/src/llm/deterministic-acceptance-probes.ts
@@ -45,7 +45,7 @@ export interface DeterministicAcceptanceProbeDecision {
   readonly probeRuns: readonly ToolCallRecord[];
 }
 
-function hasSuccessfulStructuredMutation(
+export function hasSuccessfulStructuredMutation(
   toolCalls: readonly ToolCallRecord[],
 ): boolean {
   return toolCalls.some((toolCall) => {

--- a/runtime/src/llm/hooks/stop-hooks.ts
+++ b/runtime/src/llm/hooks/stop-hooks.ts
@@ -8,12 +8,10 @@ import type { ImplementationCompletionContract } from "../../workflow/completion
 import type { WorkflowVerificationContract } from "../../workflow/verification-obligations.js";
 import {
   buildTurnEndStopGateSnapshot,
-  checkFilesystemArtifacts,
   evaluateTurnEndStopGate,
   evaluateArtifactEvidenceGate,
   type TurnEndStopGateSnapshot,
 } from "../chat-executor-stop-gate.js";
-import { runDeterministicAcceptanceProbes } from "../deterministic-acceptance-probes.js";
 import { matchesHookMatcher } from "./matcher.js";
 
 export const STOP_HOOK_PHASES = [
@@ -33,15 +31,9 @@ export const STOP_HOOK_RESERVED_ID_PREFIX = "builtin:";
 export const BUILTIN_TURN_END_STOP_GATE_ID = `${STOP_HOOK_RESERVED_ID_PREFIX}turn_end_stop_gate`;
 export const BUILTIN_ARTIFACT_EVIDENCE_HOOK_ID =
   `${STOP_HOOK_RESERVED_ID_PREFIX}artifact_evidence`;
-export const BUILTIN_FILESYSTEM_ARTIFACT_VERIFICATION_HOOK_ID =
-  `${STOP_HOOK_RESERVED_ID_PREFIX}filesystem_artifact_verification`;
-export const BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID =
-  `${STOP_HOOK_RESERVED_ID_PREFIX}deterministic_acceptance_probes`;
 export const BUILTIN_STOP_HOOK_IDS = [
   BUILTIN_TURN_END_STOP_GATE_ID,
   BUILTIN_ARTIFACT_EVIDENCE_HOOK_ID,
-  BUILTIN_FILESYSTEM_ARTIFACT_VERIFICATION_HOOK_ID,
-  BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID,
 ] as const;
 
 export interface StopHookHandlerConfig {
@@ -233,132 +225,6 @@ function buildBuiltinStopHookDefinitions(): readonly StopHookRuntimeDefinition[]
                 evidence: decision.evidence,
               }
             : { evidence: decision.evidence }),
-          durationMs: Date.now() - startedAt,
-        };
-      },
-    },
-    {
-      id: BUILTIN_FILESYSTEM_ARTIFACT_VERIFICATION_HOOK_ID,
-      phase: "Stop",
-      kind: "builtin",
-      target: "checkFilesystemArtifacts",
-      source: "builtin",
-      builtinHandler: async (context) => {
-        const startedAt = Date.now();
-        const check = await checkFilesystemArtifacts({
-          finalContent: context.finalContent ?? "",
-          allToolCalls: context.allToolCalls ?? [],
-          workspaceRoot: context.runtimeWorkspaceRoot,
-        });
-        return {
-          hookId: BUILTIN_FILESYSTEM_ARTIFACT_VERIFICATION_HOOK_ID,
-          phase: context.phase,
-          progressMessages: [],
-          ...(check.shouldIntervene
-            ? {
-                blockingError: {
-                  hookId: BUILTIN_FILESYSTEM_ARTIFACT_VERIFICATION_HOOK_ID,
-                  message:
-                    check.blockingMessage ??
-                    "Filesystem artifact verification failed.",
-                  evidence: {
-                    emptyFiles: check.emptyFiles,
-                    missingFiles: check.missingFiles,
-                    checkedFiles: check.checkedFiles,
-                  },
-                },
-                stopReason: "filesystem_artifact_verification",
-                evidence: {
-                  emptyFiles: check.emptyFiles,
-                  missingFiles: check.missingFiles,
-                  checkedFiles: check.checkedFiles,
-                },
-              }
-            : {
-                evidence: {
-                  emptyFiles: check.emptyFiles,
-                  missingFiles: check.missingFiles,
-                  checkedFiles: check.checkedFiles,
-                },
-              }),
-          durationMs: Date.now() - startedAt,
-        };
-      },
-    },
-    {
-      id: BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID,
-      phase: "Stop",
-      kind: "builtin",
-      target: "runDeterministicAcceptanceProbes",
-      source: "builtin",
-      builtinHandler: async (context) => {
-        const startedAt = Date.now();
-        const activeToolHandler = context.runtimeChecks?.activeToolHandler;
-        if (!activeToolHandler) {
-          return passOutcome(
-            BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID,
-            context.phase,
-            Date.now() - startedAt,
-          );
-        }
-        const decision = await runDeterministicAcceptanceProbes({
-          workspaceRoot: context.runtimeWorkspaceRoot,
-          targetArtifacts: context.runtimeChecks?.targetArtifacts,
-          allToolCalls: context.allToolCalls ?? [],
-          activeToolHandler,
-        });
-        if (decision.probeRuns.length > 0) {
-          context.runtimeChecks?.appendProbeRuns?.(decision.probeRuns);
-        }
-        if (!decision.shouldIntervene) {
-          return {
-            hookId: BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID,
-            phase: context.phase,
-            progressMessages: [],
-            evidence: {
-              evidence: decision.evidence,
-              probeRuns: decision.probeRuns,
-            },
-            durationMs: Date.now() - startedAt,
-          };
-        }
-        if (decision.allowRecovery === false) {
-          return {
-            hookId: BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID,
-            phase: context.phase,
-            progressMessages: [],
-            preventContinuation: true,
-            stopReason:
-              decision.validationCode ??
-              "deterministic_acceptance_probe_failed",
-            evidence: {
-              evidence: decision.evidence,
-              probeRuns: decision.probeRuns,
-            },
-            durationMs: Date.now() - startedAt,
-          };
-        }
-        return {
-          hookId: BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID,
-          phase: context.phase,
-          progressMessages: [],
-          blockingError: {
-            hookId: BUILTIN_DETERMINISTIC_ACCEPTANCE_PROBES_HOOK_ID,
-            message:
-              decision.blockingMessage ??
-              "Deterministic acceptance probes failed.",
-            evidence: {
-              evidence: decision.evidence,
-              probeRuns: decision.probeRuns,
-            },
-          },
-          stopReason:
-            decision.validationCode ??
-            "deterministic_acceptance_probe_failed",
-          evidence: {
-            evidence: decision.evidence,
-            probeRuns: decision.probeRuns,
-          },
           durationMs: Date.now() - startedAt,
         };
       },

--- a/runtime/src/runtime-contract/types.test.ts
+++ b/runtime/src/runtime-contract/types.test.ts
@@ -10,8 +10,6 @@ describe("runtime-contract types", () => {
     expect(COMPLETION_VALIDATOR_ORDER).toEqual([
       "artifact_evidence",
       "turn_end_stop_gate",
-      "filesystem_artifact_verification",
-      "deterministic_acceptance_probes",
     ]);
 
     const snapshot = createRuntimeContractSnapshot({

--- a/runtime/src/runtime-contract/types.ts
+++ b/runtime/src/runtime-contract/types.ts
@@ -15,8 +15,6 @@ export type CompletionValidatorId =
   | "artifact_evidence"
   | "turn_end_stop_gate"
   | "request_task_progress"
-  | "filesystem_artifact_verification"
-  | "deterministic_acceptance_probes"
   | "top_level_verifier";
 
 export type CompletionValidatorOutcome =
@@ -384,8 +382,6 @@ export interface DelegatedRuntimeResult {
 export const COMPLETION_VALIDATOR_ORDER: readonly CompletionValidatorId[] = [
   "artifact_evidence",
   "turn_end_stop_gate",
-  "filesystem_artifact_verification",
-  "deterministic_acceptance_probes",
 ];
 
 export function createRuntimeContractSnapshot(
@@ -394,8 +390,6 @@ export function createRuntimeContractSnapshot(
   const hookBackedValidatorIds = new Set<CompletionValidatorId>([
     "artifact_evidence",
     "turn_end_stop_gate",
-    "filesystem_artifact_verification",
-    "deterministic_acceptance_probes",
   ]);
   return {
     flags,

--- a/runtime/src/tools/system/verification.test.ts
+++ b/runtime/src/tools/system/verification.test.ts
@@ -86,4 +86,54 @@ describe("verification tools", () => {
     expect(parsed.__agencVerification?.category).toBe("build");
     expect(parsed.__agencVerification?.probeId).toBe(buildProbe!.id);
   });
+
+  it("does not list ctest when a CMake workspace does not declare tests", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "verification-cmake-no-tests-"));
+    writeFileSync(
+      join(workspaceRoot, "CMakeLists.txt"),
+      [
+        "cmake_minimum_required(VERSION 3.20)",
+        "project(verification_fixture C)",
+        "add_executable(sample main.c)",
+      ].join("\n"),
+    );
+    writeFileSync(join(workspaceRoot, "main.c"), "int main(void) { return 0; }\n");
+
+    const tools = createVerificationTools();
+    const listProbes = findTool(tools, "verification.listProbes");
+    const parsed = JSON.parse(
+      (await listProbes.execute({ workspaceRoot })).content,
+    ) as {
+      probes?: Array<{ id?: string; category?: string }>;
+    };
+
+    expect(
+      parsed.probes?.some((probe) => probe.id === "generic:test:ctest"),
+    ).toBe(false);
+  });
+
+  it("lists ctest when a CMake workspace explicitly declares tests", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "verification-cmake-tests-"));
+    writeFileSync(
+      join(workspaceRoot, "CMakeLists.txt"),
+      [
+        "cmake_minimum_required(VERSION 3.20)",
+        "project(verification_fixture C)",
+        "enable_testing()",
+        "add_test(NAME sample COMMAND ${CMAKE_COMMAND} -E echo ok)",
+      ].join("\n"),
+    );
+
+    const tools = createVerificationTools();
+    const listProbes = findTool(tools, "verification.listProbes");
+    const parsed = JSON.parse(
+      (await listProbes.execute({ workspaceRoot })).content,
+    ) as {
+      probes?: Array<{ id?: string; category?: string }>;
+    };
+
+    expect(
+      parsed.probes?.some((probe) => probe.id === "generic:test:ctest"),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- remove inline repository verification gates from the completion path
- route implementation verification through the explicit top-level verifier with workspace read-only and temp-only write scope
- only expose CMake `ctest` probes when the workspace explicitly declares tests

## Test plan
- ./node_modules/.bin/vitest run runtime/src/gateway/top-level-verifier.test.ts runtime/src/llm/completion-validators.test.ts runtime/src/runtime-contract/types.test.ts runtime/src/tools/system/verification.test.ts runtime/src/llm/hooks/stop-hooks.test.ts runtime/src/llm/chat-executor-continuation.test.ts runtime/src/llm/chat-executor-artifact-evidence.test.ts runtime/src/gateway/shell-profile.test.ts runtime/src/gateway/daemon-text-channel-turn.test.ts runtime/src/gateway/tool-handler-factory.test.ts
