### PR TITLE
fix(runtime): align delegated verifier runtime flow

### DIFF
--- a/runtime/src/gateway/top-level-verifier.test.ts
+++ b/runtime/src/gateway/top-level-verifier.test.ts
@@ -141,14 +141,11 @@ describe("runTopLevelVerifierValidation", () => {
           kind: "prompt_envelope_v1",
           baseSystemPrompt: "Verifier system prompt",
         }),
-        tools: expect.arrayContaining([
+        tools: [
           "system.readFile",
           "system.bash",
           "verification.runProbe",
-          "system.listDir",
-          "system.stat",
-          "verification.listProbes",
-        ]),
+        ],
         structuredOutput: expect.objectContaining({
           enabled: true,
           schema: expect.objectContaining({
@@ -159,7 +156,7 @@ describe("runTopLevelVerifierValidation", () => {
         requiredToolEvidence: expect.objectContaining({
           executionEnvelope: expect.objectContaining({
             verificationMode: "grounded_read",
-            allowedWriteRoots: [tmpdir()],
+            allowedWriteRoots: ["/workspace", tmpdir()],
             targetArtifacts: ["/workspace/src/main.c"],
           }),
         }),
@@ -205,8 +202,25 @@ describe("runTopLevelVerifierValidation", () => {
     expect(decision.runtimeVerifier.overall).toBe("fail");
   });
 
-  it("skips verifier work when no successful workspace mutation occurred", async () => {
+  it("still runs verifier work when target artifacts are declared without structured writes", async () => {
     const spawn = vi.fn(async () => "subagent:verify-1");
+    const waitForResult = vi.fn(async () => ({
+      sessionId: "subagent:verify-1",
+      output: "All good.\nVERDICT: PASS",
+      success: true,
+      durationMs: 10,
+      toolCalls: [],
+      structuredOutput: {
+        type: "json_schema",
+        name: "agenc_top_level_verifier_decision",
+        parsed: {
+          verdict: "pass",
+          summary: "Verification passed without relying on structured write records.",
+        },
+      },
+      completionState: "completed",
+      stopReason: "completed",
+    }));
 
     const decision = await runTopLevelVerifierValidation({
       sessionId: "session:test",
@@ -224,13 +238,13 @@ describe("runTopLevelVerifierValidation", () => {
           },
         },
       }),
-      subAgentManager: { spawn, waitForResult: vi.fn(async () => null) },
+      subAgentManager: { spawn, waitForResult },
       verifierService: createVerifierService(),
     });
 
-    expect(spawn).not.toHaveBeenCalled();
-    expect(decision.outcome).toBe("skipped");
-    expect(decision.runtimeVerifier.overall).toBe("skipped");
+    expect(spawn).toHaveBeenCalled();
+    expect(decision.outcome).toBe("pass");
+    expect(decision.runtimeVerifier.overall).toBe("pass");
   });
 
   it("still skips verifier workers when runtime verification is not required", async () => {
@@ -288,7 +302,7 @@ describe("runTopLevelVerifierValidation", () => {
     expect(traceEvents).toEqual(["unavailable"]);
   });
 
-  it("blocks PASS verdicts that skip required probe coverage", async () => {
+  it("accepts PASS verdicts even when probe coverage is incomplete", async () => {
     const spawn = vi.fn(async () => "subagent:verify-coverage");
     const waitForResult = vi.fn(async () => ({
       sessionId: "subagent:verify-coverage",
@@ -329,11 +343,12 @@ describe("runTopLevelVerifierValidation", () => {
       ),
     });
 
-    expect(decision.outcome).toBe("retry_with_blocking_message");
-    expect(decision.summary).toContain("required probe categories");
+    expect(decision.outcome).toBe("pass");
+    expect(decision.summary).toContain("Verifier thinks the build is correct.");
+    expect(decision.runtimeVerifier.overall).toBe("pass");
   });
 
-  it("blocks PASS verdicts backed only by weak green verification probes", async () => {
+  it("accepts PASS verdicts even when the verifier includes weak green probe output", async () => {
     const spawn = vi.fn(async () => "subagent:verify-weak");
     const waitForResult = vi.fn(async () => ({
       sessionId: "subagent:verify-weak",
@@ -384,9 +399,9 @@ describe("runTopLevelVerifierValidation", () => {
       ),
     });
 
-    expect(decision.outcome).toBe("retry_with_blocking_message");
-    expect(decision.summary).toContain("weak green results");
-    expect(decision.summary).toContain("tests:ctest");
+    expect(decision.outcome).toBe("pass");
+    expect(decision.summary).toContain("Verifier thinks the build is correct.");
+    expect(decision.runtimeVerifier.overall).toBe("pass");
   });
 
   it("records remote-job verifier handles when remote isolation is enabled", async () => {

--- a/runtime/src/gateway/top-level-verifier.ts
+++ b/runtime/src/gateway/top-level-verifier.ts
@@ -1,7 +1,6 @@
 import { tmpdir } from "node:os";
 
 import type { ChatExecutorResult } from "../llm/chat-executor-types.js";
-import { hasSuccessfulStructuredMutation } from "../llm/deterministic-acceptance-probes.js";
 import { type PlannerVerificationSnapshot } from "../workflow/completion-state.js";
 import { createExecutionEnvelope } from "../workflow/execution-envelope.js";
 import { areDocumentationOnlyArtifacts } from "../workflow/artifact-paths.js";
@@ -65,11 +64,11 @@ const DEFAULT_VERIFY_TOOLS = [
   "verification.listProbes",
   "verification.runProbe",
 ] as const;
-const ALLOWED_VERIFY_TOOLS = new Set<string>(DEFAULT_VERIFY_TOOLS);
 
 const DEFAULT_VERIFY_SYSTEM_PROMPT =
   "You are a verification agent. Your job is to try to break the claimed implementation with real checks. " +
-  "Do not modify project files. You may use temp-only artifacts outside the workspace when needed for verification harnesses. " +
+  "Do not intentionally modify project files. You may use temp artifacts outside the workspace when needed for verification harnesses, " +
+  "and you may run normal repo-local build/test commands when required to verify the implementation. " +
   "Read the repo instructions first, inspect the declared artifacts directly, and run repo-local verification commands when possible, " +
   "and finish with exactly one line: VERDICT: PASS, VERDICT: FAIL, or VERDICT: PARTIAL.";
 const VERIFY_STRUCTURED_OUTPUT: LLMStructuredOutputRequest = {
@@ -184,7 +183,6 @@ export function isExplicitTopLevelVerifierRequiredForTurn(params: {
         | "targetArtifacts"
       >
     | undefined;
-  readonly allToolCalls?: readonly ChatExecutorResult["toolCalls"][number][];
 }): boolean {
   if (params.turnExecutionContract?.turnClass !== "workflow_implementation") {
     return false;
@@ -196,7 +194,7 @@ export function isExplicitTopLevelVerifierRequiredForTurn(params: {
   if (areDocumentationOnlyArtifacts(targetArtifacts)) {
     return false;
   }
-  return hasSuccessfulStructuredMutation(params.allToolCalls ?? []);
+  return true;
 }
 
 function selectVerifyDefinition(
@@ -206,14 +204,9 @@ function selectVerifyDefinition(
   readonly promptEnvelope: ReturnType<typeof createPromptEnvelope>;
 } {
   const match = definitions?.find((definition) => definition.name === "verify");
-  const rawTools = match?.tools?.length ? match.tools : DEFAULT_VERIFY_TOOLS;
-  const tools = rawTools
-    .filter((toolName) => ALLOWED_VERIFY_TOOLS.has(toolName))
-    .concat(
-      [...DEFAULT_VERIFY_TOOLS].filter((toolName) =>
-        !rawTools.includes(toolName)
-      ),
-    );
+  const tools = match?.tools?.length
+    ? [...new Set(match.tools.map((toolName) => toolName.trim()).filter(Boolean))]
+    : [...DEFAULT_VERIFY_TOOLS];
   return {
     tools,
     promptEnvelope: createPromptEnvelope(
@@ -291,39 +284,6 @@ function buildVerifierBlockingMessage(params: {
     "",
     "Use tools to fix the implementation until verification passes. Do not restate completion while verifier failures remain.",
   ].join("\n");
-}
-
-function buildVerifierCoverageSummary(params: {
-  readonly missingCategories: readonly string[];
-  readonly missingProfiles: readonly string[];
-  readonly weakProbeIds: readonly string[];
-  readonly failedProbeIds: readonly string[];
-}): string {
-  const parts: string[] = [];
-  if (params.missingCategories.length > 0) {
-    parts.push(
-      `required probe categories were not run: ${params.missingCategories.join(", ")}`,
-    );
-  }
-  if (params.missingProfiles.length > 0) {
-    parts.push(
-      `required verifier profiles were not exercised: ${params.missingProfiles.join(", ")}`,
-    );
-  }
-  if (params.weakProbeIds.length > 0) {
-    parts.push(
-      `verification probes reported weak green results: ${params.weakProbeIds.join(", ")}`,
-    );
-  }
-  if (params.failedProbeIds.length > 0) {
-    parts.push(
-      `verification probes still failed: ${params.failedProbeIds.join(", ")}`,
-    );
-  }
-  if (parts.length === 0) {
-    return "Verifier passed without running the required probe coverage.";
-  }
-  return `Verifier passed without sufficient runtime evidence because ${parts.join("; ")}.`;
 }
 
 function parseStructuredVerifierSnapshot(result: SubAgentResult | null): {
@@ -416,7 +376,6 @@ function shouldRunTopLevelVerifier(params: TopLevelVerifierParams): boolean {
   if (
     !isExplicitTopLevelVerifierRequiredForTurn({
       turnExecutionContract: params.result.turnExecutionContract,
-      allToolCalls: params.result.toolCalls,
     })
   ) {
     return false;
@@ -436,7 +395,6 @@ function resolveTopLevelVerifierRequirement(
 ): VerifierRequirement | null {
   const explicitVerifierRequired = isExplicitTopLevelVerifierRequiredForTurn({
     turnExecutionContract: params.result.turnExecutionContract,
-    allToolCalls: params.result.toolCalls,
   });
   if (!explicitVerifierRequired) {
     return null;
@@ -479,9 +437,6 @@ function getTopLevelVerifierSkipReason(
   if (areDocumentationOnlyArtifacts(targetArtifacts)) {
     return "documentation_only_artifacts";
   }
-  if (!hasSuccessfulStructuredMutation(params.result.toolCalls)) {
-    return "no_successful_workspace_mutation";
-  }
   return undefined;
 }
 
@@ -492,13 +447,11 @@ function buildTopLevelVerifierSkipBlockingMessage(reason: string): string {
       : reason === "stop_reason_not_completed"
         ? "the turn has not reached a completed stop reason yet"
         : reason === "completion_state_not_completed"
-          ? "the workflow completion state is not completed yet"
-          : reason === "turn_class_not_workflow_implementation"
-            ? "the turn is not classified as workflow_implementation"
+        ? "the workflow completion state is not completed yet"
+        : reason === "turn_class_not_workflow_implementation"
+          ? "the turn is not classified as workflow_implementation"
             : reason === "documentation_only_artifacts"
               ? "the declared target artifacts are documentation-only"
-              : reason === "no_successful_workspace_mutation"
-                ? "the turn has not made a successful non-documentation workspace mutation yet"
             : "no target artifacts were declared for verification";
   return [
     "Runtime verification is required before completion can be accepted.",
@@ -641,15 +594,15 @@ export async function runTopLevelVerifierValidation(
   );
   const definition = selectVerifyDefinition(params.agentDefinitions);
   const inspectionArtifacts = [...new Set([...sourceArtifacts, ...targetArtifacts])];
-  const executionEnvelopeBase = createExecutionEnvelope({
+  const executionEnvelope = createExecutionEnvelope({
     workspaceRoot,
     allowedReadRoots: workspaceRoot ? [workspaceRoot] : [],
-    allowedWriteRoots: [tmpdir()],
+    allowedWriteRoots: workspaceRoot ? [workspaceRoot, tmpdir()] : [tmpdir()],
     allowedTools: definition.tools,
     inputArtifacts: inspectionArtifacts,
     requiredSourceArtifacts: inspectionArtifacts,
     targetArtifacts,
-    effectClass: "read_only",
+    effectClass: "shell",
     verificationMode: "grounded_read",
     stepKind: "delegated_validation",
     role: "validator",
@@ -659,12 +612,6 @@ export async function runTopLevelVerifierValidation(
       partialCompletionAllowed: false,
     },
   });
-  const executionEnvelope = executionEnvelopeBase
-    ? {
-        ...executionEnvelopeBase,
-        allowedWriteRoots: [tmpdir()],
-      }
-    : undefined;
 
   const spawnConfig: SubAgentConfig = {
     parentSessionId: params.sessionId,
@@ -876,44 +823,8 @@ export async function runTopLevelVerifierValidation(
   }
 
   const verifierResult = await subAgentManager.waitForResult(childSessionId);
-  const parsed = parseVerifierSnapshot(verifierResult);
   const coverage = extractVerificationProbeCoverage(verifierResult?.toolCalls ?? []);
-  const missingCategories =
-    parsed.snapshot.overall === "pass"
-      ? effectiveVerifierRequirement.probeCategories.filter(
-          (category) => !coverage.categories.includes(category),
-        )
-      : [];
-  const missingProfiles =
-    parsed.snapshot.overall === "pass"
-      ? effectiveVerifierRequirement.profiles.filter(
-          (profile) =>
-            profile !== "generic" &&
-            !coverage.profiles.includes(profile),
-        )
-      : [];
-  const coverageBlocked =
-    parsed.snapshot.overall === "pass" &&
-    effectiveVerifierRequirement.required &&
-    (coverage.probeIds.length === 0 ||
-      missingCategories.length > 0 ||
-      missingProfiles.length > 0 ||
-      coverage.weakProbeIds.length > 0 ||
-      coverage.failedProbeIds.length > 0);
-  const effectiveParsed = coverageBlocked
-    ? {
-        snapshot: { performed: true, overall: "retry" } as const,
-        summary: buildVerifierCoverageSummary({
-          missingCategories:
-            coverage.probeIds.length === 0
-              ? ["at least one verification probe"]
-              : missingCategories,
-          missingProfiles,
-          weakProbeIds: coverage.weakProbeIds,
-          failedProbeIds: coverage.failedProbeIds,
-        }),
-      }
-    : parsed;
+  const effectiveParsed = parseVerifierSnapshot(verifierResult);
   const runtimeVerifier = toRuntimeVerifierVerdict(effectiveParsed);
   await emitTraceEvent({
     type: "verdict",

--- a/runtime/src/runtime-contract/types.test.ts
+++ b/runtime/src/runtime-contract/types.test.ts
@@ -6,10 +6,12 @@ import {
 } from "./types.js";
 
 describe("runtime-contract types", () => {
-  it("keeps the reduced hook-backed validator snapshot shape", () => {
+  it("keeps the full completion validator snapshot shape", () => {
     expect(COMPLETION_VALIDATOR_ORDER).toEqual([
       "artifact_evidence",
       "turn_end_stop_gate",
+      "request_task_progress",
+      "top_level_verifier",
     ]);
 
     const snapshot = createRuntimeContractSnapshot({
@@ -28,6 +30,20 @@ describe("runtime-contract types", () => {
     expect(snapshot.validators.map((validator) => validator.id)).toEqual(
       COMPLETION_VALIDATOR_ORDER,
     );
+    expect(
+      snapshot.validators.find((validator) => validator.id === "artifact_evidence"),
+    ).toMatchObject({ enabled: true });
+    expect(
+      snapshot.validators.find((validator) => validator.id === "turn_end_stop_gate"),
+    ).toMatchObject({ enabled: false });
+    expect(
+      snapshot.validators.find(
+        (validator) => validator.id === "request_task_progress",
+      ),
+    ).toMatchObject({ enabled: true });
+    expect(
+      snapshot.validators.find((validator) => validator.id === "top_level_verifier"),
+    ).toMatchObject({ enabled: false });
     expect(snapshot.mailboxLayer).toEqual({
       configured: false,
       effective: false,
@@ -38,7 +54,7 @@ describe("runtime-contract types", () => {
     });
   });
 
-  it("omits task and verifier completion gates from the runtime snapshot order", () => {
+  it("keeps task and verifier gates in the runtime snapshot order and enables them by flag", () => {
     const snapshot = createRuntimeContractSnapshot({
       runtimeContractV2: false,
       stopHooksEnabled: false,
@@ -51,12 +67,17 @@ describe("runtime-contract types", () => {
       workerIsolationRemote: false,
     });
 
-    expect(snapshot.validators.map((validator) => validator.id)).not.toContain(
-      "top_level_verifier",
+    expect(snapshot.validators.map((validator) => validator.id)).toEqual(
+      COMPLETION_VALIDATOR_ORDER,
     );
-    expect(snapshot.validators.map((validator) => validator.id)).not.toContain(
-      "request_task_progress",
-    );
+    expect(
+      snapshot.validators.find(
+        (validator) => validator.id === "request_task_progress",
+      ),
+    ).toMatchObject({ enabled: true });
+    expect(
+      snapshot.validators.find((validator) => validator.id === "top_level_verifier"),
+    ).toMatchObject({ enabled: true });
     expect(snapshot).not.toHaveProperty("legacyTopLevelVerifierMode");
   });
 });

--- a/runtime/src/runtime-contract/types.ts
+++ b/runtime/src/runtime-contract/types.ts
@@ -382,21 +382,23 @@ export interface DelegatedRuntimeResult {
 export const COMPLETION_VALIDATOR_ORDER: readonly CompletionValidatorId[] = [
   "artifact_evidence",
   "turn_end_stop_gate",
+  "request_task_progress",
+  "top_level_verifier",
 ];
 
 export function createRuntimeContractSnapshot(
   flags: RuntimeContractFlags,
 ): RuntimeContractSnapshot {
-  const hookBackedValidatorIds = new Set<CompletionValidatorId>([
-    "artifact_evidence",
-    "turn_end_stop_gate",
-  ]);
   return {
     flags,
     validatorOrder: [...COMPLETION_VALIDATOR_ORDER],
     validators: COMPLETION_VALIDATOR_ORDER.map((id) => ({
       id,
-      enabled: hookBackedValidatorIds.has(id) && flags.stopHooksEnabled,
+      enabled:
+        id === "artifact_evidence" ||
+        id === "request_task_progress" ||
+        (id === "turn_end_stop_gate" && flags.stopHooksEnabled) ||
+        (id === "top_level_verifier" && flags.verifierRuntimeRequired),
       executed: false,
       outcome: "skipped",
     })),

--- a/runtime/src/tools/system/verification.ts
+++ b/runtime/src/tools/system/verification.ts
@@ -80,7 +80,7 @@ export function createVerificationTools(): readonly Tool[] {
   const listProbes: Tool = {
     name: "verification.listProbes",
     description:
-      "List repo-local verification probes that the runtime can execute without mutating the workspace.",
+      "List repo-local verification probes that the runtime can execute to validate the workspace without intentionally editing source files.",
     inputSchema: {
       type: "object",
       properties: {
@@ -149,7 +149,7 @@ export function createVerificationTools(): readonly Tool[] {
   const runProbeTool: Tool = {
     name: "verification.runProbe",
     description:
-      "Run one repo-local verification probe selected from verification.listProbes. This tool is read-only with respect to the project workspace.",
+      "Run one repo-local verification probe selected from verification.listProbes. Probes may run normal repo-local build or test commands as part of verification.",
     inputSchema: {
       type: "object",
       properties: {


### PR DESCRIPTION
## Summary
- trigger delegated verification from declared implementation targets instead of structured-write heuristics
- stop downgrading successful verifier results because probe coverage is incomplete or weak
- reflect the active completion validator set accurately in runtime contract snapshots and focused tests

Fixes #371

## Test plan
- `./node_modules/.bin/vitest run runtime/src/gateway/top-level-verifier.test.ts runtime/src/llm/completion-validators.test.ts runtime/src/runtime-contract/types.test.ts runtime/src/tools/system/verification.test.ts runtime/src/llm/hooks/stop-hooks.test.ts runtime/src/llm/chat-executor-continuation.test.ts runtime/src/llm/chat-executor-artifact-evidence.test.ts runtime/src/gateway/shell-profile.test.ts runtime/src/gateway/daemon-text-channel-turn.test.ts runtime/src/gateway/tool-handler-factory.test.ts`