### PR TITLE
refactor(runtime): split public tasks from runtime handles

### DIFF
--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -101,3 +101,10 @@
 - **What worked:** Moving verifier ownership fully into the parent completion flow, removing task-progress from the completion gate, and hardening the verifier envelope write-root handling aligned the runtime with the intended execution model while keeping the delegated verifier contract explicit and test-covered.
 - **What didn't:** The final cleanup exposed a build-only type hole in the verifier envelope path, so the branch needed one last guard before the source build and daemon restart were clean end to end.
 - **Rule added to CLAUDE.md:** no
+
+## PR #376: refactor(runtime): split public tasks from runtime handles
+- **Date:** 2026-04-15
+- **Files changed:** `runtime/src/tools/system/task-tracker.ts`, `runtime/src/gateway/{daemon-command-registry,daemon-session-state,tool-handler-factory-coordinator,tool-handler-factory-delegation}.ts`, `runtime/src/runtime-contract/types.ts`, `runtime/src/gateway/*.test.ts`, `runtime/src/tools/system/task-tracker.test.ts`
+- **What worked:** Splitting lightweight session tasks from runtime handles let the public `task.*` workflow return only session-task fields while delegated and coordinator flows moved to path-first background handles, which brought the runtime surface into one consistent model without losing durable runtime state internally.
+- **What didn't:** The original task tracker and tests assumed one mixed surface, so separating the handle tools required a second factory plus coordinated fixture updates across delegation, coordinator, and daemon command tests before the suite settled.
+- **Rule added to CLAUDE.md:** no

--- a/runtime/src/gateway/coordinator-tool.test.ts
+++ b/runtime/src/gateway/coordinator-tool.test.ts
@@ -498,14 +498,18 @@ describe("coordinator_mode", () => {
     ) as {
       success?: boolean;
       workerId?: string;
-      task?: { id?: string };
+      taskId?: string;
+      outputPath?: string;
+      backgroundHandle?: { id?: string };
     };
 
     expect(spawned.success).toBe(true);
     expect(spawned.workerId).toBeTruthy();
-    expect(spawned.task?.id).toBeTruthy();
+    expect(spawned.taskId).toBeTruthy();
+    expect(spawned.outputPath).toMatch(/output\.json$/);
+    expect(spawned.backgroundHandle?.id).toBe(spawned.taskId);
 
-    await waitForTaskTerminal(taskStore, "session-a", String(spawned.task?.id));
+    await waitForTaskTerminal(taskStore, "session-a", String(spawned.taskId));
 
     const listed = JSON.parse(
       await executeCoordinatorModeTool({
@@ -582,10 +586,10 @@ describe("coordinator_mode", () => {
       }),
     ) as {
       workerId?: string;
-      task?: { id?: string };
+      taskId?: string;
     };
 
-    await waitForTaskTerminal(taskStore, "session-a", String(initial.task?.id));
+    await waitForTaskTerminal(taskStore, "session-a", String(initial.taskId));
 
     const followUp = JSON.parse(
       await executeCoordinatorModeTool({
@@ -613,31 +617,35 @@ describe("coordinator_mode", () => {
     ) as {
       success?: boolean;
       workerId?: string;
-      task?: {
+      taskId?: string;
+      outputPath?: string;
+      backgroundHandle?: {
         id?: string;
         kind?: string;
         status?: string;
-        waitTool?: string;
-        outputTool?: string;
+        outputPath?: string;
+        outputReady?: boolean;
       };
     };
 
     expect(followUp.success).toBe(true);
     expect(followUp.workerId).toBe(initial.workerId);
-    expect(followUp.task).toEqual(
+    expect(followUp.outputPath).toMatch(/output\.json$/);
+    expect(followUp.backgroundHandle).toEqual(
       expect.objectContaining({
+        id: followUp.taskId,
         kind: "worker_assignment",
         status: "pending",
-        waitTool: "task.wait",
-        outputTool: "task.output",
+        outputPath: followUp.outputPath,
+        outputReady: false,
       }),
     );
 
-    await waitForTaskTerminal(taskStore, "session-a", String(followUp.task?.id));
+    await waitForTaskTerminal(taskStore, "session-a", String(followUp.taskId));
 
     const completed = await taskStore.getTask(
       "session-a",
-      String(followUp.task?.id),
+      String(followUp.taskId),
     );
     expect(completed).toMatchObject({
       status: "completed",

--- a/runtime/src/gateway/daemon-command-registry.ts
+++ b/runtime/src/gateway/daemon-command-registry.ts
@@ -3326,7 +3326,7 @@ export function createDaemonCommandRegistry(
         jsonArgs = parseCommandJsonArgs(cmdCtx.args);
       } catch (error) {
         await cmdCtx.reply(
-          `Usage: /tasks [list|get <taskId>|wait <taskId>|output <taskId>]\n${toErrorMessage(error)}`,
+          `Usage: /tasks [list|get <taskId>]\n${toErrorMessage(error)}`,
         );
         return;
       }
@@ -3363,9 +3363,7 @@ export function createDaemonCommandRegistry(
           ? jsonArgs.taskId.trim()
           : cmdCtx.argv[1]?.trim();
       if (!taskId) {
-        await cmdCtx.reply(
-          "Usage: /tasks [list|get <taskId>|wait <taskId>|output <taskId>]",
-        );
+        await cmdCtx.reply("Usage: /tasks [list|get <taskId>]");
         return;
       }
 
@@ -3388,71 +3386,7 @@ export function createDaemonCommandRegistry(
         return;
       }
 
-      if (subcommand === "wait") {
-        const result = await executeStructuredTool(
-          baseToolHandler,
-          "task.wait",
-          {
-            [TASK_LIST_ARG]: cmdCtx.sessionId,
-            taskId,
-            ...(typeof jsonArgs?.timeoutMs === "number"
-              ? { timeoutMs: jsonArgs.timeoutMs }
-              : {}),
-            ...(parseIntegerFlag(cmdCtx.argv, "timeout")
-              ? { timeoutMs: parseIntegerFlag(cmdCtx.argv, "timeout") }
-              : {}),
-          },
-        );
-        await cmdCtx.replyResult({
-          text: formatTaskDetailReply(result),
-          viewKind: "tasks",
-          data: {
-            kind: "tasks",
-            subcommand,
-            taskId,
-            result: asRecord(result),
-          },
-        });
-        return;
-      }
-
-      if (subcommand === "output") {
-        const result = await executeStructuredTool(
-          baseToolHandler,
-          "task.output",
-          {
-            [TASK_LIST_ARG]: cmdCtx.sessionId,
-            taskId,
-            ...(jsonArgs?.block === true ? { block: true } : {}),
-            ...(typeof jsonArgs?.timeoutMs === "number"
-              ? { timeoutMs: jsonArgs.timeoutMs }
-              : {}),
-            ...(hasInlineFlag(cmdCtx.argv, "block") ? { block: true } : {}),
-            ...(parseIntegerFlag(cmdCtx.argv, "timeout")
-              ? { timeoutMs: parseIntegerFlag(cmdCtx.argv, "timeout") }
-              : {}),
-          },
-        );
-        const text =
-          typeof result.output === "string"
-            ? result.output
-            : formatTaskDetailReply(result);
-        await cmdCtx.replyResult({
-          text,
-          viewKind: "tasks",
-          data: {
-            kind: "tasks",
-            subcommand,
-            taskId,
-            result: asRecord(result),
-          },
-        });
-        return;
-      }
-
-      await cmdCtx.reply(
-        "Usage: /tasks [list|get <taskId>|wait <taskId>|output <taskId>]",
-      );
+      await cmdCtx.reply("Usage: /tasks [list|get <taskId>]");
     },
   });
   commandRegistry.register({

--- a/runtime/src/gateway/daemon-session-state.ts
+++ b/runtime/src/gateway/daemon-session-state.ts
@@ -157,8 +157,6 @@ function buildRuntimeTaskHandle(task: Task): RuntimeTaskHandle {
       : {}),
     ...(task.outputReady !== undefined ? { outputReady: task.outputReady } : {}),
     ...(task.outputRef?.path ? { outputPath: task.outputRef.path } : {}),
-    waitTool: "task.wait",
-    outputTool: "task.output",
   };
 }
 

--- a/runtime/src/gateway/tool-handler-factory-coordinator.ts
+++ b/runtime/src/gateway/tool-handler-factory-coordinator.ts
@@ -666,6 +666,9 @@ async function executePersistentCoordinatorAction(
         workerId: worker.workerId,
         assignment: prepared.assignment,
       });
+      const outputPath = params.taskStore
+        ? params.taskStore.getTaskOutputPath(params.sessionId, queued.task.id)
+        : undefined;
       return JSON.stringify({
         success: true,
         action: "spawn",
@@ -675,14 +678,15 @@ async function executePersistentCoordinatorAction(
           ? { workerSessionId: queued.worker.continuationSessionId }
           : {}),
         worker: queued.worker,
-        task: {
+        taskId: queued.task.id,
+        ...(outputPath ? { outputPath } : {}),
+        backgroundHandle: {
           id: queued.task.id,
           kind: queued.task.kind,
           status: queued.task.status,
           summary: queued.task.summary,
           outputReady: queued.task.outputReady ?? false,
-          waitTool: "task.wait",
-          outputTool: "task.output",
+          ...(outputPath ? { outputPath } : {}),
         },
       });
     }
@@ -714,6 +718,9 @@ async function executePersistentCoordinatorAction(
         workerId: worker.workerId,
         assignment: prepared.assignment,
       });
+      const outputPath = params.taskStore
+        ? params.taskStore.getTaskOutputPath(params.sessionId, queued.task.id)
+        : undefined;
       return JSON.stringify({
         success: true,
         action: input.action,
@@ -723,14 +730,15 @@ async function executePersistentCoordinatorAction(
           ? { workerSessionId: queued.worker.continuationSessionId }
           : {}),
         worker: queued.worker,
-        task: {
+        taskId: queued.task.id,
+        ...(outputPath ? { outputPath } : {}),
+        backgroundHandle: {
           id: queued.task.id,
           kind: queued.task.kind,
           status: queued.task.status,
           summary: queued.task.summary,
           outputReady: queued.task.outputReady ?? false,
-          waitTool: "task.wait",
-          outputTool: "task.output",
+          ...(outputPath ? { outputPath } : {}),
         },
       });
     }

--- a/runtime/src/gateway/tool-handler-factory-delegation.ts
+++ b/runtime/src/gateway/tool-handler-factory-delegation.ts
@@ -964,6 +964,7 @@ export async function executeDelegationTool(
   });
 
   if (asyncTaskHandlesEnabled && taskStore && runtimeTaskId) {
+    const outputPath = taskStore.getTaskOutputPath(sessionId, runtimeTaskId);
     void subAgentManager
       .waitForResult(childSessionId)
       .then((childResult) =>
@@ -1021,6 +1022,7 @@ export async function executeDelegationTool(
       subagentSessionId: childSessionId,
       objective,
       taskId: runtimeTaskId,
+      outputPath,
       runtimeResult: buildDelegatedRuntimeResult({
         surface: "direct_child",
         workerSessionId: childSessionId,
@@ -1033,24 +1035,16 @@ export async function executeDelegationTool(
         ownedArtifacts: admittedInput.delegationAdmission?.ownedArtifacts,
         executionLocation: localExecutionLocation,
       }),
-      task: {
+      backgroundHandle: {
         id: runtimeTaskId,
         kind: "subagent",
         status: "in_progress",
         summary: "Delegated worker running.",
-        externalRef: {
-          kind: "subagent",
-          id: childSessionId,
-          sessionId: childSessionId,
-        },
+        outputPath,
         executionLocation: localExecutionLocation,
         outputReady: false,
-        waitTool: "task.wait",
-        outputTool: "task.output",
         ...(verifierRequirement ? { verifierRequirement } : {}),
       },
-      waitTool: "task.wait",
-      outputTool: "task.output",
       ...(verifierRequirement ? { verifierRequirement } : {}),
     });
   }

--- a/runtime/src/gateway/tool-handler-factory.test.ts
+++ b/runtime/src/gateway/tool-handler-factory.test.ts
@@ -481,21 +481,13 @@ describe("createSessionToolHandler", () => {
       __agencTaskActorKind: "main",
       [TASK_LIST_ARG]: "session-b",
     });
-    expect(sessionACreate.taskRuntime).toMatchObject({
-      fullTask: expect.objectContaining({
-        subject: "Session A task",
-      }),
-      runtimeMetadata: expect.objectContaining({
-        hasRuntimeMetadata: false,
-      }),
+    expect(sessionACreate.task).toMatchObject({
+      id: "1",
+      subject: "Session A task",
     });
-    expect(sessionBCreate.taskRuntime).toMatchObject({
-      fullTask: expect.objectContaining({
-        subject: "Session B task",
-      }),
-      runtimeMetadata: expect.objectContaining({
-        hasRuntimeMetadata: false,
-      }),
+    expect(sessionBCreate.task).toMatchObject({
+      id: "1",
+      subject: "Session B task",
     });
 
     const executingMessages = sentMessages.filter(
@@ -546,11 +538,9 @@ describe("createSessionToolHandler", () => {
     );
 
     expect(sessionATasks).toMatchObject({
-      count: 1,
       tasks: [{ subject: "Session A task" }],
     });
     expect(sessionBTasks).toMatchObject({
-      count: 1,
       tasks: [{ subject: "Session B task" }],
     });
   });
@@ -2102,7 +2092,8 @@ describe("createSessionToolHandler", () => {
         readonly success?: boolean;
         readonly status?: string;
         readonly taskId?: string;
-        readonly task?: Record<string, unknown>;
+        readonly outputPath?: string;
+        readonly backgroundHandle?: Record<string, unknown>;
         readonly runtimeResult?: {
           readonly status?: string;
           readonly taskId?: string;
@@ -2118,12 +2109,13 @@ describe("createSessionToolHandler", () => {
         taskId: parsed.taskId,
         outputReady: false,
       });
-      expect(parsed.task).toMatchObject({
+      expect(parsed.outputPath).toMatch(/output\.json$/);
+      expect(parsed.backgroundHandle).toMatchObject({
         id: parsed.taskId,
         kind: "subagent",
         status: "in_progress",
-        waitTool: "task.wait",
-        outputTool: "task.output",
+        outputPath: parsed.outputPath,
+        outputReady: false,
       });
 
       const waited = await taskStore.waitForTask("session-parent", parsed.taskId!, {

--- a/runtime/src/runtime-contract/types.ts
+++ b/runtime/src/runtime-contract/types.ts
@@ -229,8 +229,6 @@ export interface RuntimeTaskHandle {
   readonly executionLocation?: RuntimeExecutionLocation;
   readonly outputReady?: boolean;
   readonly outputPath?: string;
-  readonly waitTool?: "task.wait";
-  readonly outputTool?: "task.output";
 }
 
 export interface RuntimeContractStatusSnapshot {

--- a/runtime/src/tools/system/task-tracker.test.ts
+++ b/runtime/src/tools/system/task-tracker.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   TASK_ACTOR_KIND_ARG,
   TASK_ACTOR_NAME_ARG,
+  createRuntimeTaskHandleTools,
   createTaskTrackerTools,
   TaskStore,
   type TaskTrackerToolOptions,
@@ -79,8 +80,6 @@ describe("task-tracker", () => {
   let list: Tool;
   let get: Tool;
   let update: Tool;
-  let wait: Tool;
-  let output: Tool;
   let toolOptions: TaskTrackerToolOptions;
 
   beforeEach(() => {
@@ -92,20 +91,16 @@ describe("task-tracker", () => {
     list = findTool(tools, "task.list");
     get = findTool(tools, "task.get");
     update = findTool(tools, "task.update");
-    wait = findTool(tools, "task.wait");
-    output = findTool(tools, "task.output");
   });
 
   describe("registration metadata", () => {
-    it("exposes the six task tracker tools", () => {
+    it("exposes the four public session task tools", () => {
       const names = tools.map((t) => t.name).sort();
       expect(names).toEqual([
         "task.create",
         "task.get",
         "task.list",
-        "task.output",
         "task.update",
-        "task.wait",
       ]);
     });
 
@@ -135,7 +130,6 @@ describe("task-tracker", () => {
       const task = (result.body.task as Record<string, unknown>);
       expect(task.id).toBe("1");
       expect(task.subject).toBe("Write the spec");
-      expect(task.status).toBe("pending");
       expect(store.list(DEFAULT_TASK_LIST_ID)).toHaveLength(1);
     });
 
@@ -177,21 +171,13 @@ describe("task-tracker", () => {
       const stored = store.list(DEFAULT_TASK_LIST_ID)[0];
       expect(stored.activeForm).toBe("Running the build");
       expect(stored.metadata).toEqual({ priority: "high", tags: ["ci"] });
-      expect(result.body.taskRuntime).toMatchObject({
-        fullTask: expect.objectContaining({
-          subject: "Run the build",
-        }),
-        runtimeMetadata: {
-          hasRuntimeMetadata: false,
-          milestoneIds: [],
-          verification: false,
-          malformed: false,
-          errors: [],
-        },
+      expect(result.body.task).toMatchObject({
+        id: "1",
+        subject: "Run the build",
       });
     });
 
-    it("returns normalized runtime metadata alongside the compact task summary", async () => {
+    it("keeps metadata on the stored task without exposing runtime payloads", async () => {
       const result = await callTool(create, {
         subject: "Implement phase 1",
         description: "Ship the first milestone",
@@ -206,24 +192,11 @@ describe("task-tracker", () => {
       expect(result.body.task).toMatchObject({
         id: "1",
         subject: "Implement phase 1",
-        status: "pending",
       });
-      expect(result.body.taskRuntime).toMatchObject({
-        fullTask: expect.objectContaining({
-          id: "1",
-          metadata: {
-            _runtime: {
-              milestoneIds: ["phase_1"],
-              verification: true,
-            },
-          },
-        }),
-        runtimeMetadata: {
-          hasRuntimeMetadata: true,
+      expect(store.get(DEFAULT_TASK_LIST_ID, "1")?.metadata).toEqual({
+        _runtime: {
           milestoneIds: ["phase_1"],
           verification: true,
-          malformed: false,
-          errors: [],
         },
       });
     });
@@ -238,39 +211,31 @@ describe("task-tracker", () => {
 
     it("returns all visible tasks by default", async () => {
       const result = await callTool(list, {});
-      expect(result.body.count).toBe(3);
       const tasks = result.body.tasks as Array<Record<string, unknown>>;
       expect(tasks.map((t) => t.subject)).toEqual(["A", "B", "C"]);
     });
 
-    it("filters by status", async () => {
-      await callTool(update, { taskId: "1", status: "in_progress" });
-      await callTool(update, { taskId: "2", status: "completed" });
-      const inProgress = await callTool(list, { status: "in_progress" });
-      expect(inProgress.body.count).toBe(1);
-      expect((inProgress.body.tasks as Array<Record<string, unknown>>)[0].id).toBe("1");
-      const completed = await callTool(list, { status: "completed" });
-      expect(completed.body.count).toBe(1);
-      const pending = await callTool(list, { status: "pending" });
-      expect(pending.body.count).toBe(1);
+    it("hides blockers that are already completed", async () => {
+      await callTool(update, { taskId: "1", status: "completed" });
+      await callTool(update, { taskId: "2", addBlockedBy: ["1", "3"] });
+
+      const listed = await callTool(list, {});
+      const task = (listed.body.tasks as Array<Record<string, unknown>>).find(
+        (entry) => entry.id === "2",
+      );
+      expect(task?.blockedBy).toEqual(["3"]);
     });
 
     it("ignores deleted tasks", async () => {
       await callTool(update, { taskId: "2", status: "deleted" });
       const result = await callTool(list, {});
-      expect(result.body.count).toBe(2);
       const ids = (result.body.tasks as Array<Record<string, unknown>>).map((t) => t.id);
       expect(ids).toEqual(["1", "3"]);
     });
 
-    it("ignores invalid status filter values", async () => {
-      const result = await callTool(list, { status: "garbage" });
-      expect(result.body.count).toBe(3);
-    });
-
     it("returns empty for an unknown task list", async () => {
       const result = await callTool(list, { [TASK_LIST_ARG]: "unknown-session" });
-      expect(result.body.count).toBe(0);
+      expect(result.body.tasks).toEqual([]);
     });
   });
 
@@ -367,36 +332,19 @@ describe("task-tracker", () => {
       });
     });
 
-    it("returns the full task with description, metadata, timestamps", async () => {
+    it("returns the lightweight public task view", async () => {
       const result = await callTool(get, { taskId: "1" });
       const task = result.body.task as Record<string, unknown>;
       expect(task.id).toBe("1");
       expect(task.description).toBe("Tail daemon log for the last hour");
-      expect(task.activeForm).toBe("Inspecting logs");
-      expect(task.metadata).toEqual({ severity: "warn" });
       expect(task.blocks).toEqual([]);
       expect(task.blockedBy).toEqual([]);
-      expect(typeof task.createdAt).toBe("number");
-      expect(typeof task.updatedAt).toBe("number");
-      expect(result.body.taskRuntime).toMatchObject({
-        fullTask: expect.objectContaining({
-          id: "1",
-          description: "Tail daemon log for the last hour",
-        }),
-        runtimeMetadata: {
-          hasRuntimeMetadata: false,
-          milestoneIds: [],
-          verification: false,
-          malformed: false,
-          errors: [],
-        },
-      });
     });
 
-    it("returns an error when the task does not exist", async () => {
+    it("returns null when the task does not exist", async () => {
       const result = await callTool(get, { taskId: "999" });
-      expect(result.raw.isError).toBe(true);
-      expect(result.body.error).toMatch(/not found/);
+      expect(result.raw.isError).toBeUndefined();
+      expect(result.body.task).toBeNull();
     });
 
     it("rejects empty taskId", async () => {
@@ -407,7 +355,7 @@ describe("task-tracker", () => {
     it("treats deleted tasks as not found", async () => {
       await callTool(update, { taskId: "1", status: "deleted" });
       const result = await callTool(get, { taskId: "1" });
-      expect(result.raw.isError).toBe(true);
+      expect(result.body.task).toBeNull();
     });
   });
 
@@ -418,9 +366,24 @@ describe("task-tracker", () => {
 
     it("transitions through pending -> in_progress -> completed", async () => {
       const start = await callTool(update, { taskId: "1", status: "in_progress" });
-      expect((start.body.task as Record<string, unknown>).status).toBe("in_progress");
+      expect(start.body).toMatchObject({
+        success: true,
+        taskId: "1",
+        statusChange: {
+          from: "pending",
+          to: "in_progress",
+        },
+      });
       const done = await callTool(update, { taskId: "1", status: "completed" });
-      expect((done.body.task as Record<string, unknown>).status).toBe("completed");
+      expect(done.body).toMatchObject({
+        success: true,
+        taskId: "1",
+        statusChange: {
+          from: "in_progress",
+          to: "completed",
+        },
+      });
+      expect(store.get(DEFAULT_TASK_LIST_ID, "1")?.status).toBe("completed");
     });
 
     it("auto-claims an in-progress task for a subagent actor when no owner is set", async () => {
@@ -431,11 +394,15 @@ describe("task-tracker", () => {
         [TASK_ACTOR_NAME_ARG]: "worker-alpha",
       });
 
-      expect(start.body.task).toMatchObject({
-        id: "1",
-        status: "in_progress",
-        owner: "worker-alpha",
+      expect(start.body).toMatchObject({
+        success: true,
+        taskId: "1",
+        statusChange: {
+          from: "pending",
+          to: "in_progress",
+        },
       });
+      expect(store.get(DEFAULT_TASK_LIST_ID, "1")?.owner).toBe("worker-alpha");
     });
 
     it("merges metadata shallowly and deletes keys set to null", async () => {
@@ -454,8 +421,8 @@ describe("task-tracker", () => {
       expect(merged?.metadata).toEqual({ retries: 3 });
     });
 
-    it("surfaces malformed runtime metadata in the additive taskRuntime payload", async () => {
-      const result = await callTool(update, {
+    it("preserves malformed runtime metadata on the stored task without exposing it publicly", async () => {
+      await callTool(update, {
         taskId: "1",
         metadata: {
           _runtime: {
@@ -465,33 +432,12 @@ describe("task-tracker", () => {
         },
       });
 
-      expect(result.body.task).toMatchObject({
-        id: "1",
-        status: "pending",
+      expect(store.get(DEFAULT_TASK_LIST_ID, "1")?.metadata).toEqual({
+        _runtime: {
+          milestoneIds: ["phase_1", "phase_1", ""],
+          verification: "yes",
+        },
       });
-      expect(result.body.taskRuntime).toMatchObject({
-        fullTask: expect.objectContaining({
-          id: "1",
-        }),
-      });
-      expect(result.body.taskRuntime).toMatchObject({
-        runtimeMetadata: expect.objectContaining({
-          hasRuntimeMetadata: true,
-          malformed: true,
-          milestoneIds: ["phase_1"],
-          verification: false,
-        }),
-      });
-      expect(
-        ((result.body.taskRuntime as Record<string, unknown>).runtimeMetadata as Record<string, unknown>)
-          .errors,
-      ).toEqual(
-        expect.arrayContaining([
-          expect.stringContaining("verification must be a boolean"),
-          expect.stringContaining("cannot contain duplicates"),
-          expect.stringContaining("cannot contain empty strings"),
-        ]),
-      );
     });
 
     it("appends unique blockedBy ids", async () => {
@@ -508,14 +454,21 @@ describe("task-tracker", () => {
 
     it("rejects updates to non-existent task", async () => {
       const result = await callTool(update, { taskId: "404", status: "completed" });
-      expect(result.raw.isError).toBe(true);
-      expect(result.body.error).toMatch(/not found/);
+      expect(result.body).toMatchObject({
+        success: false,
+        taskId: "404",
+        error: "Task not found",
+      });
     });
 
     it("rejects updates to deleted tasks", async () => {
       await callTool(update, { taskId: "1", status: "deleted" });
       const result = await callTool(update, { taskId: "1", status: "completed" });
-      expect(result.raw.isError).toBe(true);
+      expect(result.body).toMatchObject({
+        success: false,
+        taskId: "1",
+        error: "Task not found",
+      });
     });
 
     it("rejects non-array addBlocks", async () => {
@@ -547,9 +500,13 @@ describe("task-tracker", () => {
       const result = await callTool(update, { taskId: "1", status: "completed" });
 
       expect(result.raw.isError).toBeUndefined();
-      expect(result.body.task).toMatchObject({
-        id: "1",
-        status: "completed",
+      expect(result.body).toMatchObject({
+        success: true,
+        taskId: "1",
+        statusChange: {
+          from: "pending",
+          to: "completed",
+        },
       });
       expect(store.get(DEFAULT_TASK_LIST_ID, "1")?.status).toBe("completed");
       expect(guardCalled).toBe(false);
@@ -611,7 +568,7 @@ describe("task-tracker", () => {
       const stored = store.get(DEFAULT_TASK_LIST_ID, "1");
       expect(stored?.status).toBe("pending");
       expect(stored?.metadata).toEqual({ changedBy: "guard" });
-      expect((result.body.task as Record<string, unknown> | undefined)?.revision).toBeUndefined();
+      expect(result.body.task).toBeUndefined();
     });
 
     it("appends a verification nudge when the main actor closes 3+ tasks without a verification step", async () => {
@@ -623,7 +580,6 @@ describe("task-tracker", () => {
       const result = await callTool(update, { taskId: "3", status: "completed" });
 
       expect(result.body.verificationNudgeNeeded).toBe(true);
-      expect(result.body.message).toContain("Run the verifier");
     });
 
     it("does not append the verification nudge for subagent actors", async () => {
@@ -650,12 +606,14 @@ describe("task-tracker", () => {
       });
 
       expect(result.body.verificationNudgeNeeded).toBeUndefined();
-      expect(String(result.body.message)).not.toContain("Run the verifier");
     });
   });
 
   describe("task.wait and task.output", () => {
     it("returns terminal state and persisted output for runtime-managed tasks", async () => {
+      const runtimeTools = createRuntimeTaskHandleTools(store);
+      const wait = findTool(runtimeTools, "task.wait");
+      const output = findTool(runtimeTools, "task.output");
       const runtimeTask = await store.createRuntimeTask({
         listId: DEFAULT_TASK_LIST_ID,
         kind: "subagent",
@@ -745,8 +703,6 @@ describe("task-tracker", () => {
 
       const a = await callTool(list, { [TASK_LIST_ARG]: "session-a" });
       const b = await callTool(list, { [TASK_LIST_ARG]: "session-b" });
-      expect(a.body.count).toBe(2);
-      expect(b.body.count).toBe(1);
 
       const aIds = (a.body.tasks as Array<Record<string, unknown>>).map((t) => t.id);
       const bIds = (b.body.tasks as Array<Record<string, unknown>>).map((t) => t.id);
@@ -803,16 +759,19 @@ describe("task-tracker", () => {
           return () => now++;
         })(),
       });
-      const tracedTools = createTaskTrackerTools(tracedStore, {
-        onTaskAccessEvent: async (event) => {
-          accessEvents.push({
-            type: event.type,
-            taskId: event.taskId,
-            ready: event.ready,
-            until: event.until,
-          });
-        },
-      });
+      const tracedTools = [
+        ...createTaskTrackerTools(tracedStore),
+        ...createRuntimeTaskHandleTools(tracedStore, {
+          onTaskAccessEvent: async (event) => {
+            accessEvents.push({
+              type: event.type,
+              taskId: event.taskId,
+              ready: event.ready,
+              until: event.until,
+            });
+          },
+        }),
+      ];
       const tracedCreate = findTool(tracedTools, "task.create");
       const tracedWait = findTool(tracedTools, "task.wait");
       const tracedOutput = findTool(tracedTools, "task.output");

--- a/runtime/src/tools/system/task-tracker.ts
+++ b/runtime/src/tools/system/task-tracker.ts
@@ -56,8 +56,6 @@ export const TASK_TRACKER_TOOL_NAMES: ReadonlySet<string> = new Set([
   "task.list",
   "task.get",
   "task.update",
-  "task.wait",
-  "task.output",
 ]);
 
 export type TaskStatus =
@@ -473,18 +471,6 @@ function isTaskStatus(value: unknown): value is TaskStatus {
   );
 }
 
-function isFilterableStatus(
-  value: unknown,
-): value is Exclude<TaskStatus, "deleted"> {
-  return (
-    value === "pending" ||
-    value === "in_progress" ||
-    value === "completed" ||
-    value === "failed" ||
-    value === "cancelled"
-  );
-}
-
 function asPlainObject(
   value: unknown,
 ): Record<string, unknown> | undefined {
@@ -544,16 +530,42 @@ function okResult(data: unknown): ToolResult {
   return { content: safeStringify(data) };
 }
 
-function summarizeTask(task: Task): Record<string, unknown> {
+type PublicTaskStatus = "pending" | "in_progress" | "completed";
+
+function isPublicTaskStatus(status: TaskStatus): status is PublicTaskStatus {
+  return (
+    status === "pending" ||
+    status === "in_progress" ||
+    status === "completed"
+  );
+}
+
+function isPublicSessionTask(task: Task): boolean {
+  return (
+    task.kind === "manual" &&
+    isPublicTaskStatus(task.status) &&
+    task.metadata?._internal !== true
+  );
+}
+
+function summarizePublicTask(task: Task): Record<string, unknown> {
   return {
     id: task.id,
-    kind: task.kind,
     subject: task.subject,
     status: task.status,
-    ...(task.summary !== undefined ? { summary: task.summary } : {}),
     ...(task.owner !== undefined ? { owner: task.owner } : {}),
-    ...(task.blockedBy.length > 0 ? { blockedBy: task.blockedBy } : {}),
-    ...(task.outputReady !== undefined ? { outputReady: task.outputReady } : {}),
+    blockedBy: task.blockedBy,
+  };
+}
+
+function detailPublicTask(task: Task): Record<string, unknown> {
+  return {
+    id: task.id,
+    subject: task.subject,
+    description: task.description,
+    status: task.status,
+    blocks: task.blocks,
+    blockedBy: task.blockedBy,
   };
 }
 
@@ -951,6 +963,10 @@ export class TaskStore {
 
   private outputPathFor(listId: string, taskId: string): string {
     return join(this.outputDirFor(listId, taskId), "output.json");
+  }
+
+  getTaskOutputPath(listId: string, taskId: string): string {
+    return this.outputPathFor(listId, taskId);
   }
 
   private async runExclusive<T>(
@@ -1810,25 +1826,23 @@ export class TaskStore {
 }
 
 const TASK_CREATE_DESCRIPTION =
-  "Create a structured task in the current session's durable task list. Use proactively for " +
+  "Create a structured task in the current session's task list. Use proactively for " +
   "multi-step work (3+ steps), complex tasks that require planning, or when the user " +
   "supplies multiple things to do. Mark a task in_progress with task.update BEFORE " +
-  "starting work, and completed only once the work is fully done. Runtime-managed " +
-  "milestone tracking uses metadata._runtime.milestoneIds and metadata._runtime.verification. " +
-  "If description is omitted, the runtime falls back to the subject text.";
+  "starting work, and completed only once the work is fully done. If description is " +
+  "omitted, the runtime falls back to the subject text.";
 
 const TASK_LIST_DESCRIPTION =
-  "List tasks in the current session's task list. Returns id, kind, subject, status, owner, " +
-  "summary, blockedBy, and outputReady for each visible task. Use the optional `status` filter " +
-  "to narrow the result to pending / in_progress / completed / failed / cancelled.";
+  "List tasks in the current session's task list. Returns each task's id, subject, status, " +
+  "optional owner, and unresolved blockedBy ids.";
 
 const TASK_GET_DESCRIPTION =
-  "Fetch a single task by id with its full description, metadata, runtime linkage, events, " +
-  "output readiness, and timestamps. Use this when task.list does not give you enough detail.";
+  "Fetch a single task by id with its description, status, blocks, and blockedBy ids. " +
+  "Returns null when the task does not exist.";
 
 const TASK_UPDATE_DESCRIPTION =
   "Update a task's status, subject, description, owner, activeForm, metadata, or blocks. " +
-  "Status transitions include pending, in_progress, completed, failed, cancelled, and deleted. " +
+  "Status transitions include pending, in_progress, completed, and deleted. " +
   "Use status 'deleted' to permanently hide the task from list/get. Metadata is merged shallowly; " +
   "pass a key with value null to delete that key. addBlocks / addBlockedBy append unique ids.";
 
@@ -1848,15 +1862,6 @@ export function createTaskTrackerTools(
   options: TaskTrackerToolOptions = {},
 ): Tool[] {
   const taskStore = store ?? new TaskStore();
-  const emitTaskAccessEvent = async (
-    event: TaskTrackerAccessNotification,
-  ): Promise<void> => {
-    try {
-      await options.onTaskAccessEvent?.(event);
-    } catch {
-      // Access tracing must not affect tool behavior.
-    }
-  };
 
   const taskCreate: Tool = {
     name: "task.create",
@@ -1881,8 +1886,7 @@ export function createTaskTrackerTools(
         },
         metadata: {
           type: "object",
-          description:
-            "Arbitrary metadata to attach to the task. Runtime-managed milestone tracking uses metadata._runtime.milestoneIds and metadata._runtime.verification.",
+          description: "Arbitrary metadata to attach to the task.",
         },
       },
       required: ["subject"],
@@ -1902,9 +1906,10 @@ export function createTaskTrackerTools(
       });
 
       return okResult({
-        message: `Task #${task.id} created: ${task.subject}`,
-        task: summarizeTask(task),
-        taskRuntime: taskRuntime(task),
+        task: {
+          id: task.id,
+          subject: task.subject,
+        },
       });
     },
   };
@@ -1914,22 +1919,20 @@ export function createTaskTrackerTools(
     description: TASK_LIST_DESCRIPTION,
     inputSchema: {
       type: "object",
-      properties: {
-        status: {
-          type: "string",
-          enum: ["pending", "in_progress", "completed", "failed", "cancelled"],
-          description: "Optional status filter.",
-        },
-      },
+      properties: {},
     },
     async execute(args) {
-      const filter = isFilterableStatus(args.status)
-        ? { status: args.status }
-        : undefined;
-      const tasks = await taskStore.listTasks(resolveListId(args), filter);
+      const tasks = (await taskStore.listTasks(resolveListId(args))).filter(
+        isPublicSessionTask,
+      );
+      const resolvedTaskIds = new Set(
+        tasks.filter((task) => task.status === "completed").map((task) => task.id),
+      );
       return okResult({
-        count: tasks.length,
-        tasks: tasks.map(summarizeTask),
+        tasks: tasks.map((task) => ({
+          ...summarizePublicTask(task),
+          blockedBy: task.blockedBy.filter((id) => !resolvedTaskIds.has(id)),
+        })),
       });
     },
   };
@@ -1951,10 +1954,13 @@ export function createTaskTrackerTools(
       const taskId = asNonEmptyString(args.taskId);
       if (!taskId) return errorResult("taskId must be a non-empty string");
       const task = await taskStore.getTask(resolveListId(args), taskId);
-      if (!task) return errorResult(`task ${taskId} not found`);
+      if (!task || !isPublicSessionTask(task)) {
+        return okResult({
+          task: null,
+        });
+      }
       return okResult({
-        task: fullTask(task),
-        taskRuntime: taskRuntime(task),
+        task: detailPublicTask(task),
       });
     },
   };
@@ -2008,19 +2014,27 @@ export function createTaskTrackerTools(
       const listId = resolveListId(args);
       const actor = resolveTaskActor(args);
       const patch: TaskUpdatePatch = {};
+      const updatedFields: string[] = [];
 
       if (args.status !== undefined) {
-        if (!isTaskStatus(args.status)) {
+        if (
+          args.status !== "pending" &&
+          args.status !== "in_progress" &&
+          args.status !== "completed" &&
+          args.status !== "deleted"
+        ) {
           return errorResult(
-            "status must be one of: pending, in_progress, completed, failed, cancelled, deleted",
+            "status must be one of: pending, in_progress, completed, deleted",
           );
         }
         patch.status = args.status;
+        updatedFields.push("status");
       }
       if (args.subject !== undefined) {
         const next = asNonEmptyString(args.subject);
         if (next === undefined) return errorResult("subject must be a non-empty string");
         patch.subject = next;
+        updatedFields.push("subject");
       }
       if (args.description !== undefined) {
         const next = asNonEmptyString(args.description);
@@ -2028,18 +2042,21 @@ export function createTaskTrackerTools(
           return errorResult("description must be a non-empty string");
         }
         patch.description = next;
+        updatedFields.push("description");
       }
       if (args.activeForm !== undefined) {
         if (typeof args.activeForm !== "string") {
           return errorResult("activeForm must be a string");
         }
         patch.activeForm = args.activeForm;
+        updatedFields.push("activeForm");
       }
       if (args.owner !== undefined) {
         if (typeof args.owner !== "string") {
           return errorResult("owner must be a string");
         }
         patch.owner = args.owner;
+        updatedFields.push("owner");
       }
       if (args.metadata !== undefined) {
         const metadata = asPlainObject(args.metadata);
@@ -2047,6 +2064,7 @@ export function createTaskTrackerTools(
           return errorResult("metadata must be a plain object");
         }
         patch.metadata = metadata;
+        updatedFields.push("metadata");
       }
       if (args.addBlocks !== undefined) {
         if (!Array.isArray(args.addBlocks) ||
@@ -2054,6 +2072,7 @@ export function createTaskTrackerTools(
           return errorResult("addBlocks must be an array of strings");
         }
         patch.addBlocks = args.addBlocks as string[];
+        updatedFields.push("addBlocks");
       }
       if (args.addBlockedBy !== undefined) {
         if (!Array.isArray(args.addBlockedBy) ||
@@ -2061,10 +2080,18 @@ export function createTaskTrackerTools(
           return errorResult("addBlockedBy must be an array of strings");
         }
         patch.addBlockedBy = args.addBlockedBy as string[];
+        updatedFields.push("addBlockedBy");
       }
 
       const current = await taskStore.readTaskState(listId, taskId);
-      if (!current) return errorResult(`task ${taskId} not found`);
+      if (!current || current.task.kind !== "manual") {
+        return okResult({
+          success: false,
+          taskId,
+          updatedFields: [],
+          error: "Task not found",
+        });
+      }
 
       if (
         patch.status === "in_progress" &&
@@ -2082,6 +2109,9 @@ export function createTaskTrackerTools(
           (actor.kind === "subagent" ? actor.name : undefined);
         if (autoOwner) {
           patch.owner = autoOwner;
+          if (!updatedFields.includes("owner")) {
+            updatedFields.push("owner");
+          }
         }
       }
 
@@ -2126,24 +2156,55 @@ export function createTaskTrackerTools(
         patch,
         isTransitioningToCompleted ? current.revision : undefined,
       );
-      if (!task) return errorResult(`task ${taskId} not found`);
+      if (!task || task.kind !== "manual") {
+        return okResult({
+          success: false,
+          taskId,
+          updatedFields: [],
+          error: "Task not found",
+        });
+      }
       const allTasks =
         patch.status === "completed"
-          ? await taskStore.listTasks(listId)
+          ? (await taskStore.listTasks(listId)).filter(isPublicSessionTask)
           : [];
       const verificationNudgeNeeded = shouldEmitVerificationNudge({
         tasks: allTasks,
         actorKind: actor.kind,
       });
       return okResult({
-        message: verificationNudgeNeeded
-          ? `Task #${task.id} updated\n\nNOTE: You just closed out 3+ tasks and none of them was a verification step. Run the verifier before writing the final summary.`
-          : `Task #${task.id} updated`,
-        task: summarizeTask(task),
-        taskRuntime: taskRuntime(task),
+        success: true,
+        taskId: task.id,
+        updatedFields,
+        ...(patch.status !== undefined
+          ? {
+              statusChange: {
+                from: current.task.status,
+                to: patch.status,
+              },
+            }
+          : {}),
         ...(verificationNudgeNeeded ? { verificationNudgeNeeded: true } : {}),
       });
     },
+  };
+
+  return [taskCreate, taskList, taskGet, taskUpdate];
+}
+
+export function createRuntimeTaskHandleTools(
+  store?: TaskStore,
+  options: Pick<TaskTrackerToolOptions, "onTaskAccessEvent"> = {},
+): Tool[] {
+  const taskStore = store ?? new TaskStore();
+  const emitTaskAccessEvent = async (
+    event: TaskTrackerAccessNotification,
+  ): Promise<void> => {
+    try {
+      await options.onTaskAccessEvent?.(event);
+    } catch {
+      // Access tracing must not affect tool behavior.
+    }
   };
 
   const taskWait: Tool = {
@@ -2284,5 +2345,5 @@ export function createTaskTrackerTools(
     },
   };
 
-  return [taskCreate, taskList, taskGet, taskUpdate, taskWait, taskOutput];
+  return [taskWait, taskOutput];
 }


### PR DESCRIPTION
## Summary
- split the public task workflow into lightweight session tasks only
- return path-first runtime handles for delegated and coordinator work instead of exposing wait/output tools on the public task surface
- keep runtime worker and verifier state on separate handle surfaces while updating the daemon and runtime-contract snapshots

Fixes #375

## Test plan
- ./node_modules/.bin/vitest run runtime/src/gateway/top-level-verifier.test.ts runtime/src/llm/completion-validators.test.ts runtime/src/runtime-contract/types.test.ts runtime/src/tools/system/verification.test.ts runtime/src/llm/hooks/stop-hooks.test.ts runtime/src/llm/chat-executor-continuation.test.ts runtime/src/llm/chat-executor-artifact-evidence.test.ts runtime/src/gateway/shell-profile.test.ts runtime/src/gateway/daemon-text-channel-turn.test.ts runtime/src/gateway/tool-handler-factory.test.ts runtime/src/gateway/daemon-command-registry.test.ts runtime/src/gateway/coordinator-tool.test.ts runtime/src/tools/system/task-tracker.test.ts runtime/src/gateway/daemon-session-state.test.ts runtime/src/gateway/system-prompt-builder.test.ts runtime/src/llm/request-task-progress.test.ts
- npm run techdebt