### PR TITLE
fix(runtime): align final reply acceptance and verifier root

### DIFF
--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -108,3 +108,10 @@
 - **What worked:** Splitting lightweight session tasks from runtime handles let the public `task.*` workflow return only session-task fields while delegated and coordinator flows moved to path-first background handles, which brought the runtime surface into one consistent model without losing durable runtime state internally.
 - **What didn't:** The original task tracker and tests assumed one mixed surface, so separating the handle tools required a second factory plus coordinated fixture updates across delegation, coordinator, and daemon command tests before the suite settled.
 - **Rule added to CLAUDE.md:** no
+
+## PR #379: fix(runtime): align final reply acceptance and verifier root
+- **Date:** 2026-04-15
+- **Files changed:** `runtime/src/gateway/top-level-verifier.ts`, `runtime/src/llm/{chat-executor-request,chat-executor-types}.ts`, `runtime/src/watch/{agenc-watch-event-store,agenc-watch-frame}.mjs`, `runtime/src/gateway/top-level-verifier.test.ts`, `runtime/src/llm/chat-executor-request.test.ts`
+- **What worked:** Keeping streamed assistant text provisional until the accepted final reply arrives stops the cockpit from presenting rejected completion summaries as real answers, and threading the execution workspace root into the final result fixes verifier runs that were inspecting the wrong repo root.
+- **What didn't:** The watch transcript had been conflating provider stream text with committed replies, so getting the behavior right required changing the presentation contract rather than adding another stop-hook patch.
+- **Rule added to CLAUDE.md:** no

--- a/runtime/src/gateway/top-level-verifier.test.ts
+++ b/runtime/src/gateway/top-level-verifier.test.ts
@@ -310,6 +310,64 @@ describe("runTopLevelVerifierValidation", () => {
     expect(decision.runtimeVerifier.overall).toBe("pass");
   });
 
+  it("uses the execution workspace root instead of a stale contract root", async () => {
+    const spawn = vi.fn(async () => "subagent:verify-workspace");
+    const waitForResult = vi.fn(async () => ({
+      sessionId: "subagent:verify-workspace",
+      output: "All good.\nVERDICT: PASS",
+      success: true,
+      durationMs: 10,
+      toolCalls: [],
+      structuredOutput: {
+        type: "json_schema",
+        name: "agenc_top_level_verifier_decision",
+        parsed: {
+          verdict: "pass",
+          summary: "Workspace-root verification passed.",
+        },
+      },
+      completionState: "completed",
+      stopReason: "completed",
+    }));
+
+    await runTopLevelVerifierValidation({
+      sessionId: "session:test",
+      userRequest: "Finish the shell implementation and verify it",
+      result: createResult({
+        runtimeWorkspaceRoot: "/runtime-workspace",
+        toolCalls: [
+          {
+            name: "system.writeFile",
+            args: { path: "src/main.c" },
+            result: '{"ok":true}',
+            isError: false,
+            durationMs: 5,
+          },
+        ],
+        turnExecutionContract: {
+          ...createResult().turnExecutionContract,
+          workspaceRoot: "/stale-contract-root",
+          sourceArtifacts: ["/stale-contract-root/PLAN.md"],
+          targetArtifacts: [],
+        },
+      }),
+      subAgentManager: { spawn, waitForResult },
+      verifierService: createVerifierService(),
+    });
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workingDirectory: "/runtime-workspace",
+        requiredToolEvidence: expect.objectContaining({
+          executionEnvelope: expect.objectContaining({
+            allowedReadRoots: ["/runtime-workspace"],
+            targetArtifacts: ["/runtime-workspace/src/main.c"],
+          }),
+        }),
+      }),
+    );
+  });
+
   it("still runs verifier work when target artifacts are declared without structured writes", async () => {
     const spawn = vi.fn(async () => "subagent:verify-1");
     const waitForResult = vi.fn(async () => ({

--- a/runtime/src/gateway/top-level-verifier.ts
+++ b/runtime/src/gateway/top-level-verifier.ts
@@ -132,6 +132,7 @@ interface TopLevelVerifierParams {
     | "content"
     | "stopReason"
     | "completionState"
+    | "runtimeWorkspaceRoot"
     | "turnExecutionContract"
     | "toolCalls"
     | "stopReasonDetail"
@@ -514,6 +515,7 @@ function shouldRunTopLevelVerifier(params: TopLevelVerifierParams): boolean {
   const verifierArtifacts = resolveTopLevelVerifierArtifacts({
     turnExecutionContract: params.result.turnExecutionContract,
     allToolCalls: params.result.toolCalls,
+    workspaceRoot: params.result.runtimeWorkspaceRoot,
   });
   if (
     verifierArtifacts.targetArtifacts.length === 0 ||
@@ -537,6 +539,7 @@ function resolveTopLevelVerifierRequirement(
   const verifierArtifacts = resolveTopLevelVerifierArtifacts({
     turnExecutionContract: params.result.turnExecutionContract,
     allToolCalls: params.result.toolCalls,
+    workspaceRoot: params.result.runtimeWorkspaceRoot,
   });
   if (
     verifierArtifacts.targetArtifacts.length === 0 ||
@@ -575,6 +578,7 @@ function getTopLevelVerifierSkipReason(
   const targetArtifacts = resolveTopLevelVerifierArtifacts({
     turnExecutionContract: params.result.turnExecutionContract,
     allToolCalls: params.result.toolCalls,
+    workspaceRoot: params.result.runtimeWorkspaceRoot,
   }).targetArtifacts;
   if (targetArtifacts.length === 0) return "missing_target_artifacts";
   if (areDocumentationOnlyArtifacts(targetArtifacts)) {
@@ -715,6 +719,7 @@ export async function runTopLevelVerifierValidation(
   const verifierArtifacts = resolveTopLevelVerifierArtifacts({
     turnExecutionContract: params.result.turnExecutionContract,
     allToolCalls: params.result.toolCalls,
+    workspaceRoot: params.result.runtimeWorkspaceRoot,
   });
   const workspaceRoot = verifierArtifacts.workspaceRoot;
   const effectiveVerifierRequirement =

--- a/runtime/src/llm/chat-executor-request.test.ts
+++ b/runtime/src/llm/chat-executor-request.test.ts
@@ -192,6 +192,21 @@ describe("ChatExecutor request assembly", () => {
   });
 
   describe("stateful session wiring and result assembly", () => {
+    it("returns the resolved runtime workspace root with the final result", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(mockResponse({ content: "ok" })),
+      });
+      const executor = new ChatExecutor({ providers: [provider] });
+
+      const result = await executor.execute(
+        createParams({
+          runtimeContext: { workspaceRoot: "/tmp/runtime-workspace-root" },
+        }),
+      );
+
+      expect(result.runtimeWorkspaceRoot).toBe("/tmp/runtime-workspace-root");
+    });
+
     it("does not inject a request milestone contract before the first model call", async () => {
       const provider = createMockProvider("primary", {
         chat: vi.fn().mockResolvedValue(mockResponse({ content: "ok" })),

--- a/runtime/src/llm/chat-executor-request.ts
+++ b/runtime/src/llm/chat-executor-request.ts
@@ -347,6 +347,7 @@ export async function executeRequest(
       completionState,
       verifierSnapshot: terminal.verifierSnapshot,
       runtimeContractSnapshot: terminal.runtimeContractSnapshot,
+      runtimeWorkspaceRoot: ctx.runtimeWorkspaceRoot,
       completionProgress,
       turnExecutionContract: ctx.turnExecutionContract,
       activeTaskContext: deriveActiveTaskContext(ctx.turnExecutionContract),

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -381,6 +381,8 @@ export interface ChatExecutorResult {
   readonly verifierSnapshot?: import("../workflow/completion-state.js").PlannerVerificationSnapshot;
   /** Runtime-contract telemetry captured during execution. Not consulted for final completion decisions. */
   readonly runtimeContractSnapshot?: RuntimeContractSnapshot;
+  /** Resolved workspace root used for this execution, when available. */
+  readonly runtimeWorkspaceRoot?: string;
   /** Single preflight execution contract that governed this turn. */
   readonly turnExecutionContract: TurnExecutionContract;
   /** Typed task carryover emitted for the next compatible turn, when applicable. */

--- a/runtime/src/watch/agenc-watch-event-store.mjs
+++ b/runtime/src/watch/agenc-watch-event-store.mjs
@@ -294,32 +294,24 @@ export function createWatchEventStore(dependencies = {}) {
   }
 
   function appendAgentStreamChunk(chunk, { done = false } = {}) {
+    void done;
     const safeChunk = stripTerminalControlSequences(sanitizeLargeText(chunk ?? ""));
     return withPreservedManualTranscriptViewport(({ shouldFollow }) => {
       const timestamp = nowStamp();
-      const target = findLatestStreamingAgentEvent();
-      if (target) {
-        const createdAtMs = nowMs();
-        if (safeChunk) {
-          updateExistingEventBody(target, `${storedEventBody(target)}${safeChunk}`);
-        }
-        target.timestamp = timestamp;
-        target.createdAtMs = createdAtMs;
-        target.title = "Agent Reply · live";
-        target.streamState = nextAgentStreamState({ done });
-        updateLatestAgentSummary(target);
-      } else {
-        const nextStreamingText = `${watchState.agentStreamingText ?? ""}${safeChunk}`;
-        watchState.agentStreamingText = nextStreamingText || null;
-        watchState.agentStreamingPreview = deriveStreamingPreviewText(nextStreamingText);
-        if (safeChunk && introDismissKinds.has("agent")) {
-          dismissIntro();
-        }
+      // Keep provider stream text provisional until a final chat.message
+      // arrives. The runtime can still reject a streamed "done" summary
+      // during stop hooks or verification, so committing it into the
+      // transcript early makes the UI lie about turn completion.
+      const nextStreamingText = `${watchState.agentStreamingText ?? ""}${safeChunk}`;
+      watchState.agentStreamingText = nextStreamingText || null;
+      watchState.agentStreamingPreview = deriveStreamingPreviewText(nextStreamingText);
+      if (safeChunk && introDismissKinds.has("agent")) {
+        dismissIntro();
       }
       updateActivity(timestamp);
       followTranscriptIfNeeded(shouldFollow);
       scheduleRender();
-      return target ?? watchState.agentStreamingPreview;
+      return watchState.agentStreamingPreview;
     });
   }
 

--- a/runtime/src/watch/agenc-watch-frame.mjs
+++ b/runtime/src/watch/agenc-watch-frame.mjs
@@ -2880,24 +2880,11 @@ export function createWatchFrameController(dependencies = {}) {
   }
 
   function buildStreamingPreviewBlock(width) {
-    const previewText =
-      typeof watchState.agentStreamingPreview === "string"
-        ? watchState.agentStreamingPreview.trimEnd()
-        : "";
-    if (!previewText) {
-      return [];
-    }
-    const previewEvent = {
-      id: "__streaming_preview__",
-      kind: "agent",
-      title: "Agent Reply · live",
-      tone: "cyan",
-      body: previewText,
-      bodyTruncated: false,
-      renderMode: "markdown",
-      streamState: "streaming",
-    };
-    return renderEventBlock(previewEvent, width, { showBody: true });
+    void width;
+    // The transcript should only show committed agent replies. Provisional
+    // provider stream text can still be rejected by verification or stop
+    // hooks, so leave streaming content out of the transcript surface.
+    return [];
   }
 
   function flattenTranscriptView(width) {


### PR DESCRIPTION
## Summary
- keep streamed assistant text provisional until the accepted final reply is emitted
- route top-level verifier workspace resolution through the execution workspace root
- add regression coverage for final-result workspace propagation and verifier root selection

Fixes #379

## Test plan
- `./node_modules/.bin/vitest run runtime/src/gateway/top-level-verifier.test.ts runtime/src/llm/chat-executor-request.test.ts`
- `npm run build --workspace=@tetsuo-ai/runtime`
- `npm run techdebt`