### PR TITLE
fix(runtime): unify file reads and unblock verifier retries

### DIFF
--- a/runtime/src/gateway/sub-agent.test.ts
+++ b/runtime/src/gateway/sub-agent.test.ts
@@ -1097,6 +1097,49 @@ describe("SubAgentManager", () => {
       }
     });
 
+    it("honors an explicit child maxToolRounds override", async () => {
+      const executeSpy = vi.spyOn(ChatExecutor.prototype, "execute")
+        .mockResolvedValueOnce({
+          content: "VERDICT: PASS",
+          provider: "mock",
+          model: "mock",
+          usedFallback: false,
+          toolCalls: [],
+          tokenUsage: {
+            promptTokens: 1,
+            completionTokens: 1,
+            totalTokens: 2,
+          },
+          callUsage: [],
+          durationMs: 1,
+          compacted: false,
+          stopReason: "completed",
+          completionState: "completed",
+        });
+
+      try {
+        const manager = new SubAgentManager(makeManagerConfig({
+          resolveDefaultMaxToolRounds: () => 1,
+        }));
+        const sessionId = await manager.spawn({
+          parentSessionId: "p",
+          task: "verify the implementation",
+          maxToolRounds: 0,
+          tools: ["system.readFile", "verification.runProbe"],
+        });
+        await settle();
+
+        expect(manager.getResult(sessionId)?.success).toBe(true);
+        const handleConfig = (manager as unknown as {
+          handles: Map<string, { config: { maxToolRounds?: number } }>;
+        }).handles.get(sessionId)?.config;
+        expect(handleConfig?.maxToolRounds).toBe(0);
+        expect(executeSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        executeSpy.mockRestore();
+      }
+    });
+
     it("preserves child completion progress and refuses completion when the workflow state needs verification", async () => {
       const executeSpy = vi.spyOn(ChatExecutor.prototype, "execute")
         .mockResolvedValueOnce({

--- a/runtime/src/gateway/sub-agent.ts
+++ b/runtime/src/gateway/sub-agent.ts
@@ -183,6 +183,7 @@ export interface SubAgentConfig {
   };
   readonly continuationSessionId?: string;
   readonly timeoutMs?: number;
+  readonly maxToolRounds?: number;
   readonly toolBudgetPerRequest?: number;
   readonly workingDirectory?: string;
   readonly workingDirectorySource?: "execution_envelope";
@@ -1170,8 +1171,11 @@ export class SubAgentManager {
         resolvedExecutionBudget?.providerProfile;
       const defaultMaxToolRounds = this.config.resolveDefaultMaxToolRounds?.();
       const effectiveMaxToolRounds =
-        typeof defaultMaxToolRounds === "number" &&
-          Number.isFinite(defaultMaxToolRounds)
+        typeof handle.config.maxToolRounds === "number" &&
+          Number.isFinite(handle.config.maxToolRounds)
+          ? normalizeRuntimeLimit(handle.config.maxToolRounds, 0)
+          : typeof defaultMaxToolRounds === "number" &&
+              Number.isFinite(defaultMaxToolRounds)
           ? resolveMaxToolRoundsForToolNames(
               Math.max(1, Math.floor(defaultMaxToolRounds)),
               handle.config.tools,

--- a/runtime/src/gateway/system-prompt-builder.ts
+++ b/runtime/src/gateway/system-prompt-builder.ts
@@ -185,7 +185,7 @@ export function buildDesktopContext(
       "- For web browsing, ALWAYS use the browser navigation/snapshot tools first; do not start with tab-state inspection.\n\n" +
       "Desktop tips:\n" +
       '- Launch GUI apps: desktop.bash with "app >/dev/null 2>&1 &" (MUST redirect output and background to avoid hanging)\n' +
-      '- For coding workflows, prefer the native tools first: system.grep, system.glob, system.searchFiles, system.git*, system.readFileRange, system.applyPatch, and system.symbol*. Use system.repoInventory only when you specifically need repo/worktree inventory.\n' +
+      '- For coding workflows, prefer the native tools first: system.grep, system.glob, system.searchFiles, system.git*, system.readFile (use offset/limit for targeted reads), system.applyPatch, and system.symbol*. Use system.repoInventory only when you specifically need repo/worktree inventory.\n' +
       '- Use system.searchTools when you need to discover mixed-mode tools outside the default coding bundle.\n' +
       "- Take screenshots only when you need to inspect visual state or verify a GUI action\n" +
       "- system.bash = host machine; desktop.bash = inside the Docker container\n" +

--- a/runtime/src/gateway/top-level-verifier.test.ts
+++ b/runtime/src/gateway/top-level-verifier.test.ts
@@ -153,6 +153,7 @@ describe("runTopLevelVerifierValidation", () => {
             strict: true,
           }),
         }),
+        maxToolRounds: 0,
         requiredToolEvidence: expect.objectContaining({
           executionEnvelope: expect.objectContaining({
             verificationMode: "grounded_read",

--- a/runtime/src/gateway/top-level-verifier.ts
+++ b/runtime/src/gateway/top-level-verifier.ts
@@ -43,7 +43,6 @@ import type { ToolCatalogEntry } from "../tools/types.js";
 
 const DEFAULT_VERIFY_TOOLS = [
   "system.readFile",
-  "system.readFileRange",
   "system.listDir",
   "system.stat",
   "system.searchFiles",
@@ -837,6 +836,7 @@ export async function runTopLevelVerifierValidation(
     promptEnvelope: definition.promptEnvelope,
     tools: definition.tools,
     structuredOutput: VERIFY_STRUCTURED_OUTPUT,
+    maxToolRounds: 0,
     ...(workspaceRoot ? { workingDirectory: workspaceRoot } : {}),
     requiredToolEvidence: {
       maxCorrectionAttempts: 1,

--- a/runtime/src/tools/system/filesystem.test.ts
+++ b/runtime/src/tools/system/filesystem.test.ts
@@ -6,6 +6,7 @@ import {
   createFilesystemTools,
   clearSessionReadState,
   clearSessionReadCache,
+  hasSessionRead,
   seedSessionReadState,
   safePath,
   isPathAllowed,
@@ -391,6 +392,60 @@ describe("system.readFile", () => {
     expect(parsed.encoding).toBe("utf-8");
     expect(parsed.content).toBe("hello world");
     expect(parsed.size).toBe(11);
+    expect(parsed.startLine).toBe(1);
+    expect(parsed.totalLines).toBe(1);
+    expect(parsed.lineCount).toBe(1);
+  });
+
+  it("reads a targeted text window via offset and limit", async () => {
+    const content = "line 1\nline 2\nline 3\nline 4";
+    mockStat.mockResolvedValueOnce({
+      isFile: () => true,
+      isDirectory: () => false,
+      size: content.length,
+      mtimeMs: 1_700,
+    } as never);
+    mockReadFile.mockResolvedValueOnce(Buffer.from(content));
+
+    const result = await tool.execute({
+      path: "/workspace/test.txt",
+      offset: 2,
+      limit: 2,
+      __agencSessionId: "session-read-window",
+    });
+    const parsed = parseResult(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed.content).toBe("line 2\nline 3");
+    expect(parsed.startLine).toBe(2);
+    expect(parsed.endLine).toBe(3);
+    expect(parsed.totalLines).toBe(4);
+    expect(parsed.lineCount).toBe(2);
+    expect(hasSessionRead("session-read-window", "/workspace/test.txt")).toBe(false);
+    clearSessionReadState("session-read-window");
+  });
+
+  it("accepts compatibility startLine/endLine arguments on the main read tool", async () => {
+    const content = "alpha\nbeta\ngamma\ndelta";
+    mockStat.mockResolvedValueOnce({
+      isFile: () => true,
+      isDirectory: () => false,
+      size: content.length,
+    } as never);
+    mockReadFile.mockResolvedValueOnce(Buffer.from(content));
+
+    const result = await tool.execute({
+      path: "/workspace/test.txt",
+      startLine: 3,
+      endLine: 4,
+    });
+    const parsed = parseResult(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed.content).toBe("gamma\ndelta");
+    expect(parsed.startLine).toBe(3);
+    expect(parsed.endLine).toBe(4);
+    expect(parsed.lineCount).toBe(2);
   });
 
   it("auto-detects binary content", async () => {
@@ -406,6 +461,25 @@ describe("system.readFile", () => {
     const parsed = parseResult(result);
 
     expect(parsed.encoding).toBe("base64");
+  });
+
+  it("rejects line-window arguments for binary reads", async () => {
+    const binary = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01, 0x02]);
+    mockStat.mockResolvedValueOnce({
+      isFile: () => true,
+      isDirectory: () => false,
+      size: binary.length,
+    } as never);
+    mockReadFile.mockResolvedValueOnce(binary);
+
+    const result = await tool.execute({
+      path: "/workspace/image.png",
+      offset: 2,
+      limit: 3,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain("Line-based reads are only supported");
   });
 
   it("rejects files exceeding size limit", async () => {

--- a/runtime/src/tools/system/filesystem.ts
+++ b/runtime/src/tools/system/filesystem.ts
@@ -941,6 +941,89 @@ function isBinaryContent(buffer: Buffer): boolean {
   return false;
 }
 
+function normalizeIntegerArg(
+  value: unknown,
+): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.trunc(value);
+  }
+  if (typeof value === "string" && /^-?\d+$/.test(value.trim())) {
+    return Number.parseInt(value.trim(), 10);
+  }
+  return undefined;
+}
+
+function resolveReadWindow(args: Record<string, unknown>): {
+  readonly startLine?: number;
+  readonly limit?: number;
+} {
+  const explicitOffset = normalizeIntegerArg(args.offset);
+  const explicitLimit = normalizeIntegerArg(args.limit);
+  const compatStartLine = normalizeIntegerArg(args.startLine);
+  const compatEndLine = normalizeIntegerArg(args.endLine);
+
+  if (
+    explicitOffset === undefined &&
+    explicitLimit === undefined &&
+    compatStartLine === undefined &&
+    compatEndLine === undefined
+  ) {
+    return {};
+  }
+
+  const startLine =
+    explicitOffset !== undefined
+      ? Math.max(1, explicitOffset)
+      : Math.max(1, compatStartLine ?? 1);
+  const limit =
+    explicitLimit !== undefined
+      ? Math.max(1, explicitLimit)
+      : compatEndLine !== undefined
+        ? Math.max(1, compatEndLine - startLine + 1)
+        : undefined;
+
+  return {
+    startLine,
+    ...(limit === undefined ? {} : { limit }),
+  };
+}
+
+function sliceTextByLines(params: {
+  readonly text: string;
+  readonly startLine: number;
+  readonly limit?: number;
+}): {
+  readonly content: string;
+  readonly startLine: number;
+  readonly endLine: number;
+  readonly totalLines: number;
+  readonly lineCount: number;
+  readonly viewKind: SessionReadViewKind;
+} {
+  const lines = params.text.split(/\r?\n/);
+  const totalLines = lines.length;
+  const boundedStartLine = Math.max(1, params.startLine);
+  const boundedEndLine =
+    params.limit === undefined
+      ? totalLines
+      : Math.min(totalLines, boundedStartLine + params.limit - 1);
+  const selected =
+    totalLines === 0 || boundedStartLine > totalLines
+      ? []
+      : lines.slice(boundedStartLine - 1, boundedEndLine);
+  return {
+    content: selected.join("\n"),
+    startLine: boundedStartLine,
+    endLine: Math.max(boundedStartLine, boundedEndLine),
+    totalLines,
+    lineCount: selected.length,
+    viewKind:
+      boundedStartLine === 1 && selected.length === totalLines
+        ? "full"
+        : "partial",
+  };
+}
+
 // ============================================================================
 // Tool Factories
 // ============================================================================
@@ -952,7 +1035,8 @@ function createReadFileTool(
   return {
     name: "system.readFile",
     description:
-      "Read a file from the filesystem. Returns text content (UTF-8) by default, or base64 for binary files. Gated by path allowlist and size limits.",
+      "Read a file from the filesystem. Returns text content (UTF-8) by default, or base64 for binary files. " +
+      "For text files, optional line-window reads are supported via offset/limit. Gated by path allowlist and size limits.",
     inputSchema: {
       type: "object",
       properties: {
@@ -965,6 +1049,30 @@ function createReadFileTool(
           enum: ["utf-8", "base64"],
           description:
             "Output encoding (default: auto-detect — utf-8 for text, base64 for binary)",
+        },
+        offset: {
+          type: "integer",
+          minimum: 1,
+          description:
+            "Optional 1-indexed starting line for text reads. Use with limit to target a portion of a file.",
+        },
+        limit: {
+          type: "integer",
+          minimum: 1,
+          description:
+            "Optional number of lines to return for text reads.",
+        },
+        startLine: {
+          type: "integer",
+          minimum: 1,
+          description:
+            "Compatibility alias for offset on text reads.",
+        },
+        endLine: {
+          type: "integer",
+          minimum: 1,
+          description:
+            "Compatibility alias for the inclusive end line on text reads.",
         },
       },
       required: ["path"],
@@ -1005,17 +1113,61 @@ function createReadFileTool(
             `File size ${buffer.length} bytes exceeds limit of ${maxReadBytes} bytes`,
           );
         }
+        const readWindow = resolveReadWindow(args);
         const forceEncoding = args.encoding as string | undefined;
         const binary =
           forceEncoding === "base64" ||
           (!forceEncoding && isBinaryContent(buffer));
+
+        if (binary && readWindow.startLine !== undefined) {
+          return errorResult(
+            "Line-based reads are only supported for UTF-8 text files. Omit offset/limit for binary reads.",
+          );
+        }
+
+        if (!binary && readWindow.startLine !== undefined) {
+          const text = buffer.toString("utf-8");
+          const sliced = sliceTextByLines({
+            text,
+            startLine: readWindow.startLine,
+            ...(readWindow.limit === undefined
+              ? {}
+              : { limit: readWindow.limit }),
+          });
+          recordSessionRead(resolveSessionId(args), resolved!, {
+            content: sliced.content,
+            timestamp: getFileTimestampMs(fileStats),
+            viewKind: sliced.viewKind,
+          });
+          return {
+            content: safeStringify({
+              path: args.path,
+              size: buffer.length,
+              encoding: "utf-8",
+              content: sliced.content,
+              startLine: sliced.startLine,
+              endLine: sliced.endLine,
+              totalLines: sliced.totalLines,
+              lineCount: sliced.lineCount,
+            }),
+          };
+        }
+
+        const textContent = binary ? undefined : buffer.toString("utf-8");
+        const fullTextMetadata =
+          textContent === undefined
+            ? undefined
+            : sliceTextByLines({
+                text: textContent,
+                startLine: 1,
+              });
 
         // Record the read in the per-session readFileState so
         // subsequent system.writeFile / system.editFile calls on this
         // path satisfy the Read-before-Write rule. See PR #314 and
         // the SESSION_ID_ARG comment for the rationale.
         recordSessionRead(resolveSessionId(args), resolved!, {
-          content: binary ? null : buffer.toString("utf-8"),
+          content: binary ? null : textContent ?? "",
           timestamp: getFileTimestampMs(fileStats),
           viewKind: "full",
         });
@@ -1027,7 +1179,15 @@ function createReadFileTool(
             encoding: binary ? "base64" : "utf-8",
             content: binary
               ? buffer.toString("base64")
-              : buffer.toString("utf-8"),
+              : textContent ?? "",
+            ...(fullTextMetadata
+              ? {
+                  startLine: 1,
+                  endLine: fullTextMetadata.endLine,
+                  totalLines: fullTextMetadata.totalLines,
+                  lineCount: fullTextMetadata.lineCount,
+                }
+              : {}),
           }),
         };
       } catch (err) {


### PR DESCRIPTION
## Summary
- unify the main file read tool so targeted text reads use offset/limit on the same surface
- keep partial reads compatible with existing read-before-write safeguards
- remove the verifier child's one-round tool cap so retry verification can finish

## Test plan
- ./node_modules/.bin/vitest run runtime/src/tools/system/filesystem.test.ts runtime/src/gateway/top-level-verifier.test.ts runtime/src/gateway/sub-agent.test.ts runtime/src/gateway/system-prompt-builder.test.ts
- ./node_modules/.bin/tsc -p runtime/tsconfig.json --noEmit