### PR TITLE
fix(runtime): keep verifier children on the active workspace

### DIFF
--- a/runtime/src/gateway/sub-agent.test.ts
+++ b/runtime/src/gateway/sub-agent.test.ts
@@ -1566,6 +1566,57 @@ describe("SubAgentManager", () => {
       }
     });
 
+    it("prefers an explicit child workspace root when working directory is omitted", async () => {
+      const executeSpy = vi.spyOn(ChatExecutor.prototype, "execute")
+        .mockResolvedValueOnce({
+          content: "ok",
+          provider: "mock",
+          model: "mock",
+          usedFallback: false,
+          toolCalls: [],
+          tokenUsage: {
+            promptTokens: 10,
+            completionTokens: 5,
+            totalTokens: 15,
+          },
+          callUsage: [],
+          durationMs: 1,
+          compacted: false,
+          stopReason: "completed",
+          completionState: "completed",
+          completionProgress: {
+            completionState: "completed",
+            stopReason: "completed",
+            requiredRequirements: [],
+            satisfiedRequirements: [],
+            remainingRequirements: [],
+            reusableEvidence: [],
+            updatedAt: 1_700_000_000_000,
+          },
+        });
+
+      try {
+        const manager = new SubAgentManager(makeManagerConfig());
+        const sessionId = await manager.spawn({
+          parentSessionId: "p",
+          task: "Run repo-local verification",
+          workspaceRoot: "/tmp/real-workspace",
+        });
+        await settle();
+
+        expect(manager.getResult(sessionId)?.success).toBe(true);
+        expect(executeSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            runtimeContext: {
+              workspaceRoot: "/tmp/real-workspace",
+            },
+          }),
+        );
+      } finally {
+        executeSpy.mockRestore();
+      }
+    });
+
     it("accepts scaffold summaries that mention script definitions without claiming forbidden execution", async () => {
       const executeSpy = vi.spyOn(ChatExecutor.prototype, "execute")
         .mockResolvedValueOnce({

--- a/runtime/src/gateway/sub-agent.ts
+++ b/runtime/src/gateway/sub-agent.ts
@@ -537,12 +537,40 @@ function normalizeForkContextFingerprint(
   });
 }
 
+function trimConfigPath(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function resolveSubAgentWorkspaceRoot(
+  config: SubAgentConfig,
+): string | undefined {
+  return (
+    trimConfigPath(config.workspaceRoot) ??
+    trimConfigPath(config.executionLocation?.workspaceRoot) ??
+    trimConfigPath(config.workingDirectory) ??
+    trimConfigPath(config.executionLocation?.workingDirectory)
+  );
+}
+
+function resolveSubAgentWorkingDirectory(
+  config: SubAgentConfig,
+): string | undefined {
+  return (
+    trimConfigPath(config.workingDirectory) ??
+    trimConfigPath(config.executionLocation?.workingDirectory) ??
+    resolveSubAgentWorkspaceRoot(config)
+  );
+}
+
 function validateContinuationCompatibility(params: {
   readonly existing: SubAgentConfig;
   readonly next: SubAgentConfig;
 }): string | undefined {
-  const existingWorkingDirectory = params.existing.workingDirectory?.trim();
-  const nextWorkingDirectory = params.next.workingDirectory?.trim();
+  const existingWorkingDirectory = resolveSubAgentWorkingDirectory(
+    params.existing,
+  );
+  const nextWorkingDirectory = resolveSubAgentWorkingDirectory(params.next);
   if (existingWorkingDirectory !== nextWorkingDirectory) {
     return "continuationSessionId cannot change the delegated working directory";
   }
@@ -762,16 +790,12 @@ export class SubAgentManager {
       ...(handle.config.shellProfile
         ? { shellProfile: handle.config.shellProfile }
         : {}),
-      ...(handle.config.workspaceRoot
-        ? { workspaceRoot: handle.config.workspaceRoot }
-        : handle.config.executionLocation?.workspaceRoot
-          ? { workspaceRoot: handle.config.executionLocation.workspaceRoot }
-          : {}),
-      ...(handle.config.workingDirectory
-        ? { workingDirectory: handle.config.workingDirectory }
-        : handle.config.executionLocation?.workingDirectory
-          ? { workingDirectory: handle.config.executionLocation.workingDirectory }
-          : {}),
+      ...(resolveSubAgentWorkspaceRoot(handle.config)
+        ? { workspaceRoot: resolveSubAgentWorkspaceRoot(handle.config) }
+        : {}),
+      ...(resolveSubAgentWorkingDirectory(handle.config)
+        ? { workingDirectory: resolveSubAgentWorkingDirectory(handle.config) }
+        : {}),
       ...(handle.config.executionLocation?.mode
         ? { executionLocation: handle.config.executionLocation.mode }
         : {}),
@@ -851,16 +875,12 @@ export class SubAgentManager {
         ...(handle.config.shellProfile
           ? { shellProfile: handle.config.shellProfile }
           : {}),
-        ...(handle.config.workspaceRoot
-          ? { workspaceRoot: handle.config.workspaceRoot }
-          : handle.config.executionLocation?.workspaceRoot
-            ? { workspaceRoot: handle.config.executionLocation.workspaceRoot }
-            : {}),
-        ...(handle.config.workingDirectory
-          ? { workingDirectory: handle.config.workingDirectory }
-          : handle.config.executionLocation?.workingDirectory
-            ? { workingDirectory: handle.config.executionLocation.workingDirectory }
-            : {}),
+        ...(resolveSubAgentWorkspaceRoot(handle.config)
+          ? { workspaceRoot: resolveSubAgentWorkspaceRoot(handle.config) }
+          : {}),
+        ...(resolveSubAgentWorkingDirectory(handle.config)
+          ? { workingDirectory: resolveSubAgentWorkingDirectory(handle.config) }
+          : {}),
         ...(handle.config.executionLocation?.mode
           ? { executionLocation: handle.config.executionLocation.mode }
           : {}),
@@ -1227,7 +1247,7 @@ export class SubAgentManager {
             : {}),
         }),
         resolveHostWorkspaceRoot: () =>
-          handle.config.workingDirectory ?? null,
+          resolveSubAgentWorkspaceRoot(handle.config) ?? null,
         ...(this.config.canUseTool ? { canUseTool: this.config.canUseTool } : {}),
         ...(typeof effectiveMaxToolRounds === "number"
           ? { maxToolRounds: effectiveMaxToolRounds }
@@ -1351,6 +1371,7 @@ export class SubAgentManager {
         handle.config.tools.length > 0
           ? [...handle.config.tools]
           : undefined;
+      const runtimeWorkspaceRoot = resolveSubAgentWorkspaceRoot(handle.config);
 
       // Phase K: subagent spawn now routes through the generator
       // surface via runSubagentToLegacyResult. Same semantics as
@@ -1375,10 +1396,10 @@ export class SubAgentManager {
             ...(spawnRoutedTools
               ? { toolRouting: { routedToolNames: spawnRoutedTools } }
               : {}),
-            ...(handle.config.workingDirectory
+            ...(runtimeWorkspaceRoot
               ? {
                 runtimeContext: {
-                  workspaceRoot: handle.config.workingDirectory,
+                  workspaceRoot: runtimeWorkspaceRoot,
                 },
               }
               : {}),
@@ -1613,7 +1634,7 @@ export class SubAgentManager {
       allowedToolNames: handle.config.tools
         ? [...handle.config.tools]
         : undefined,
-      workingDirectory: handle.config.workingDirectory,
+      workingDirectory: resolveSubAgentWorkingDirectory(handle.config),
       executionContext: handle.config.delegationSpec?.executionContext,
       desktopRoutingSessionId: this.resolveDesktopRoutingSessionId(
         handle.parentSessionId,

--- a/runtime/src/gateway/top-level-verifier.test.ts
+++ b/runtime/src/gateway/top-level-verifier.test.ts
@@ -358,6 +358,7 @@ describe("runTopLevelVerifierValidation", () => {
 
     expect(spawn).toHaveBeenCalledWith(
       expect.objectContaining({
+        workspaceRoot: "/runtime-workspace",
         workingDirectory: "/runtime-workspace",
         requiredToolEvidence: expect.objectContaining({
           executionEnvelope: expect.objectContaining({
@@ -367,6 +368,86 @@ describe("runTopLevelVerifierValidation", () => {
         }),
       }),
     );
+  });
+
+  it("ignores stale explicit target artifacts outside the active workspace", async () => {
+    const spawn = vi.fn(async () => "subagent:verify-stale-artifacts");
+    const waitForResult = vi.fn(async () => ({
+      sessionId: "subagent:verify-stale-artifacts",
+      output: "All good.\nVERDICT: PASS",
+      success: true,
+      durationMs: 10,
+      toolCalls: [],
+      structuredOutput: {
+        type: "json_schema",
+        name: "agenc_top_level_verifier_decision",
+        parsed: {
+          verdict: "pass",
+          summary: "Active workspace verification passed.",
+        },
+      },
+      completionState: "completed",
+      stopReason: "completed",
+    }));
+
+    await runTopLevelVerifierValidation({
+      sessionId: "session:test",
+      userRequest: "Finish the shell implementation and verify it",
+      result: createResult({
+        runtimeWorkspaceRoot: "/runtime-workspace",
+        toolCalls: [
+          {
+            name: "system.writeFile",
+            args: { path: "src/main.c" },
+            result: '{"ok":true}',
+            isError: false,
+            durationMs: 5,
+          },
+          {
+            name: "system.writeFile",
+            args: { path: "docs/decisions.md" },
+            result: '{"ok":true}',
+            isError: false,
+            durationMs: 5,
+          },
+        ],
+        turnExecutionContract: {
+          ...createResult().turnExecutionContract,
+          workspaceRoot: "/stale-contract-root",
+          sourceArtifacts: [
+            "/home/tetsuo/git/AgenC/PLAN.md",
+          ],
+          targetArtifacts: [
+            "/home/tetsuo/git/AgenC/CMakeLists.txt",
+            "/home/tetsuo/git/AgenC/src/main.c",
+          ],
+        },
+      }),
+      subAgentManager: { spawn, waitForResult },
+      verifierService: createVerifierService(),
+    });
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceRoot: "/runtime-workspace",
+        workingDirectory: "/runtime-workspace",
+        prompt: expect.stringContaining("Workspace root: /runtime-workspace"),
+        requiredToolEvidence: expect.objectContaining({
+          executionEnvelope: expect.objectContaining({
+            allowedReadRoots: ["/runtime-workspace"],
+            targetArtifacts: [
+              "/runtime-workspace/src/main.c",
+              "/runtime-workspace/docs/decisions.md",
+            ],
+            requiredSourceArtifacts: [
+              "/runtime-workspace/src/main.c",
+              "/runtime-workspace/docs/decisions.md",
+            ],
+          }),
+        }),
+      }),
+    );
+    expect(spawn.mock.calls[0]?.[0]?.prompt).not.toContain("/home/tetsuo/git/AgenC");
   });
 
   it("still runs verifier work when target artifacts are declared without structured writes", async () => {

--- a/runtime/src/gateway/top-level-verifier.ts
+++ b/runtime/src/gateway/top-level-verifier.ts
@@ -193,6 +193,14 @@ interface TopLevelVerifierArtifactResolution {
   readonly targetArtifacts: readonly string[];
 }
 
+function constrainArtifactsToWorkspaceRoot(
+  artifacts: readonly string[],
+  workspaceRoot?: string,
+): readonly string[] {
+  if (!workspaceRoot) return artifacts;
+  return artifacts.filter((artifact) => isPathWithinRoot(artifact, workspaceRoot));
+}
+
 function truncate(text: string, max: number): string {
   if (text.length <= max) return text;
   return `${text.slice(0, max - 1).trimEnd()}…`;
@@ -278,12 +286,18 @@ export function resolveTopLevelVerifierArtifacts(params: {
   const workspaceRoot = normalizeWorkspaceRoot(
     params.workspaceRoot ?? params.turnExecutionContract?.workspaceRoot,
   );
-  const sourceArtifacts = normalizeArtifactPaths(
-    params.turnExecutionContract?.sourceArtifacts ?? [],
+  const sourceArtifacts = constrainArtifactsToWorkspaceRoot(
+    normalizeArtifactPaths(
+      params.turnExecutionContract?.sourceArtifacts ?? [],
+      workspaceRoot,
+    ),
     workspaceRoot,
   );
-  const explicitTargetArtifacts = normalizeArtifactPaths(
-    params.turnExecutionContract?.targetArtifacts ?? [],
+  const explicitTargetArtifacts = constrainArtifactsToWorkspaceRoot(
+    normalizeArtifactPaths(
+      params.turnExecutionContract?.targetArtifacts ?? [],
+      workspaceRoot,
+    ),
     workspaceRoot,
   );
   if (explicitTargetArtifacts.length > 0) {
@@ -837,7 +851,12 @@ export async function runTopLevelVerifierValidation(
     tools: definition.tools,
     structuredOutput: VERIFY_STRUCTURED_OUTPUT,
     maxToolRounds: 0,
-    ...(workspaceRoot ? { workingDirectory: workspaceRoot } : {}),
+    ...(workspaceRoot
+      ? {
+          workspaceRoot,
+          workingDirectory: workspaceRoot,
+        }
+      : {}),
     requiredToolEvidence: {
       maxCorrectionAttempts: 1,
       executionEnvelope: executionEnvelope!,


### PR DESCRIPTION
## Summary
- make child workspace root authoritative for sub-agent runtime context and tool routing
- ignore stale explicit verifier artifacts that resolve outside the active workspace
- add verifier and sub-agent regressions for active-workspace propagation

## Validation
- `./node_modules/.bin/vitest run runtime/src/gateway/top-level-verifier.test.ts runtime/src/gateway/sub-agent.test.ts`
- `./node_modules/.bin/tsc -p runtime/tsconfig.json --noEmit`
- `npm run techdebt`