### PR TITLE
fix(runtime): align child workspace launch flow

### DIFF
--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -136,3 +136,10 @@
 - **What worked:** Making child `cwd` a first-class public delegation field, persisting lightweight session tasks separately, and launching verifier children through the shared child-session contract eliminated the remaining surface mismatches without widening delegated filesystem authority.
 - **What didn't:** The old verifier wrapper and stale task help text had assumptions baked into multiple tests, so the cleanup needed coordinated assertion changes across delegation, verifier, and task-store coverage before the runtime slice was fully green.
 - **Rule added to CLAUDE.md:** no
+
+## PR #398: fix(runtime): align child workspace launch flow
+- **Date:** 2026-04-15
+- **Files changed:** `runtime/src/gateway/{daemon-command-registry,daemon,delegation-runtime,tool-handler-factory,tool-handler-factory-delegation}.ts`, `runtime/src/tools/system/verification.ts`, `runtime/src/llm/chat-executor-tool-loop.ts`, `runtime/src/gateway/*.test.ts`, `runtime/src/tools/system/verification.test.ts`, `runtime/src/llm/chat-executor-artifact-evidence.test.ts`, `.claude/notes/pr-log.md`
+- **What worked:** Threading the runtime workspace root all the way into delegated child launches and top-level verifier execution stopped child sessions from drifting back to the umbrella repo, while the richer shell-agent launcher path preserved the intended child scope and handle metadata.
+- **What didn't:** The runtime already had most of the workspace plumbing, but one omitted handoff in the completion loop meant the verifier silently fell back to stale contract roots, so the failure only showed up at the very end of otherwise-correct runs.
+- **Rule added to CLAUDE.md:** no

--- a/runtime/src/gateway/daemon-command-registry.ts
+++ b/runtime/src/gateway/daemon-command-registry.ts
@@ -1692,11 +1692,19 @@ export interface CommandRegistryDaemonContext {
     taskId?: string;
     shellProfile?: SessionShellProfile;
     toolBundle?: ShellAgentToolBundleName;
+    tools?: readonly string[];
+    requiredCapabilities?: readonly string[];
     workspaceRoot?: string;
     workingDirectory?: string;
+    continuationSessionId?: string;
+    requireToolCall?: boolean;
+    delegationSpec?: Record<string, unknown>;
     worktree?: "auto" | string;
     wait?: boolean;
     timeoutMs?: number;
+    name?: string;
+    createTaskIfMissing?: boolean;
+    unsafeBenchmarkMode?: boolean;
   }): Promise<{
     role: ShellAgentRoleDescriptor;
     sessionId: string;
@@ -1705,6 +1713,8 @@ export interface CommandRegistryDaemonContext {
     success: boolean;
     status: string;
     waited: boolean;
+    outputPath?: string;
+    name?: string;
   }>;
   inspectShellAgentTask(parentSessionId: string, target: string): Promise<{
     sessionId?: string;

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -205,8 +205,10 @@ import {
   SessionManager,
 } from "./session.js";
 import {
+  coerceSessionShellProfile,
   getShellProfilePreferredToolNames,
 } from "./shell-profile.js";
+import type { DelegationContractSpec } from "../utils/delegation-validation.js";
 import {
   getDefaultWorkspacePath,
 } from "./workspace-files.js";
@@ -1169,6 +1171,45 @@ export class DaemonManager {
         policyEngine: this._delegationPolicyEngine,
         verifier: this._delegationVerifierService,
         lifecycleEmitter: this._subAgentLifecycleEmitter,
+        launchShellAgentTask: async (params) =>
+          this.launchShellAgentTask({
+            parentSessionId: params.parentSessionId,
+            roleId: params.roleId,
+            objective: params.objective,
+            ...(params.prompt ? { prompt: params.prompt } : {}),
+            ...(params.shellProfile
+              ? {
+                  shellProfile: coerceSessionShellProfile(params.shellProfile),
+                }
+              : {}),
+            ...(params.tools ? { tools: params.tools } : {}),
+            ...(params.requiredCapabilities
+              ? { requiredCapabilities: params.requiredCapabilities }
+              : {}),
+            ...(params.workspaceRoot ? { workspaceRoot: params.workspaceRoot } : {}),
+            ...(params.workingDirectory
+              ? { workingDirectory: params.workingDirectory }
+              : {}),
+            ...(params.continuationSessionId
+              ? { continuationSessionId: params.continuationSessionId }
+              : {}),
+            ...(params.requireToolCall !== undefined
+              ? { requireToolCall: params.requireToolCall }
+              : {}),
+            ...(params.delegationSpec
+              ? { delegationSpec: params.delegationSpec }
+              : {}),
+            ...(params.worktree ? { worktree: params.worktree } : {}),
+            ...(params.wait !== undefined ? { wait: params.wait } : {}),
+            ...(params.timeoutMs ? { timeoutMs: params.timeoutMs } : {}),
+            ...(params.name ? { name: params.name } : {}),
+            ...(params.createTaskIfMissing !== undefined
+              ? { createTaskIfMissing: params.createTaskIfMissing }
+              : {}),
+            ...(params.unsafeBenchmarkMode !== undefined
+              ? { unsafeBenchmarkMode: params.unsafeBenchmarkMode }
+              : {}),
+          }),
         unsafeBenchmarkMode,
       };
     };
@@ -4505,11 +4546,19 @@ export class DaemonManager {
     readonly taskId?: string;
     readonly shellProfile?: SessionShellProfile;
     readonly toolBundle?: ShellAgentToolBundleName;
+    readonly tools?: readonly string[];
+    readonly requiredCapabilities?: readonly string[];
     readonly workspaceRoot?: string;
     readonly workingDirectory?: string;
+    readonly continuationSessionId?: string;
+    readonly requireToolCall?: boolean;
+    readonly delegationSpec?: DelegationContractSpec;
     readonly worktree?: "auto" | string;
     readonly wait?: boolean;
     readonly timeoutMs?: number;
+    readonly name?: string;
+    readonly createTaskIfMissing?: boolean;
+    readonly unsafeBenchmarkMode?: boolean;
   }): Promise<{
     role: ShellAgentRoleDescriptor;
     sessionId: string;
@@ -4518,6 +4567,8 @@ export class DaemonManager {
     success: boolean;
     status: string;
     waited: boolean;
+    outputPath?: string;
+    name?: string;
   }> {
     const subAgentManager = this._subAgentManager;
     const toolRegistry = this._toolRegistry;
@@ -4550,9 +4601,13 @@ export class DaemonManager {
       throw new Error(admission.reason);
     }
 
+    const resolvedToolNames =
+      params.tools && params.tools.length > 0
+        ? [...params.tools]
+        : [...(resolvedRole.toolNames ?? [])];
     const scope = await this.resolveShellAgentScope({
       parentSessionId: params.parentSessionId,
-      allowedTools: resolvedRole.toolNames,
+      allowedTools: resolvedToolNames,
       workspaceRoot: params.workspaceRoot,
       workingDirectory: params.workingDirectory,
       worktree: params.worktree,
@@ -4585,6 +4640,7 @@ export class DaemonManager {
             toolBundle: resolvedRole.toolBundle,
             shellProfile: resolvedRole.shellProfile,
           },
+          ...(params.name ? { childName: params.name } : {}),
         },
       });
       await taskStore.recordRuntimeProgress({
@@ -4597,7 +4653,7 @@ export class DaemonManager {
           toolBundle: resolvedRole.toolBundle,
         },
       });
-    } else if (taskStore) {
+    } else if (taskStore && params.createTaskIfMissing !== false) {
       const createdTask = await taskStore.createRuntimeTask({
         listId: params.parentSessionId,
         kind: "subagent",
@@ -4611,6 +4667,7 @@ export class DaemonManager {
             toolBundle: resolvedRole.toolBundle,
             shellProfile: resolvedRole.shellProfile,
           },
+          ...(params.name ? { childName: params.name } : {}),
         },
         summary: `${resolvedRole.descriptor.displayName} agent started.`,
         workingDirectory: scope.workingDirectory,
@@ -4633,11 +4690,22 @@ export class DaemonManager {
         ...(resolvedRole.systemPrompt
           ? { promptEnvelope: createPromptEnvelope(resolvedRole.systemPrompt) }
           : {}),
-        ...(resolvedRole.toolNames ? { tools: resolvedRole.toolNames } : {}),
+        ...(resolvedToolNames.length > 0 ? { tools: resolvedToolNames } : {}),
+        ...(params.requiredCapabilities
+          ? { requiredCapabilities: params.requiredCapabilities }
+          : {}),
         workingDirectory: scope.workingDirectory,
         ...(scope.workspaceRoot ? { workspaceRoot: scope.workspaceRoot } : {}),
         executionLocation: scope.executionLocation,
-        ...(scope.executionContext
+        ...(params.continuationSessionId
+          ? { continuationSessionId: params.continuationSessionId }
+          : {}),
+        ...(params.requireToolCall !== undefined
+          ? { requireToolCall: params.requireToolCall }
+          : {}),
+        ...(params.delegationSpec
+          ? { delegationSpec: params.delegationSpec }
+          : scope.executionContext
           ? {
               delegationSpec: {
                 task: params.objective,
@@ -4649,6 +4717,9 @@ export class DaemonManager {
                     : "shell_agent_scope",
               },
             }
+          : {}),
+        ...(params.unsafeBenchmarkMode !== undefined
+          ? { unsafeBenchmarkMode: params.unsafeBenchmarkMode }
           : {}),
         ...(params.timeoutMs ? { timeoutMs: params.timeoutMs } : {}),
       });
@@ -4698,6 +4769,7 @@ export class DaemonManager {
         ...(taskId ? { taskId } : {}),
         ...result,
         waited: true,
+        ...(params.name ? { name: params.name } : {}),
       };
     }
 
@@ -4708,6 +4780,10 @@ export class DaemonManager {
         error: toErrorMessage(error),
       });
     });
+    const outputPath =
+      taskStore && taskId
+        ? taskStore.getTaskOutputPath(params.parentSessionId, taskId)
+        : undefined;
     return {
       role: resolvedRole.descriptor,
       sessionId: childSessionId,
@@ -4716,6 +4792,8 @@ export class DaemonManager {
       success: false,
       status: "running",
       waited: false,
+      ...(outputPath ? { outputPath } : {}),
+      ...(params.name ? { name: params.name } : {}),
     };
   }
 

--- a/runtime/src/gateway/delegation-runtime.ts
+++ b/runtime/src/gateway/delegation-runtime.ts
@@ -13,6 +13,7 @@ import {
 } from "./sub-agent.js";
 import type { PersistentWorkerManager } from "./persistent-worker-manager.js";
 import type { GatewaySubagentFallbackBehavior } from "./types.js";
+import type { DelegationContractSpec } from "../utils/delegation-validation.js";
 import {
   createVerifierRequirement,
   type VerifierRequirement,
@@ -268,6 +269,35 @@ export interface DelegationToolCompositionContext {
   readonly policyEngine: DelegationPolicyEngine | null;
   readonly verifier: DelegationVerifierService | null;
   readonly lifecycleEmitter: SubAgentLifecycleEmitter | null;
+  readonly launchShellAgentTask?: (params: {
+    readonly parentSessionId: string;
+    readonly roleId: string;
+    readonly objective: string;
+    readonly prompt?: string;
+    readonly shellProfile?: string;
+    readonly tools?: readonly string[];
+    readonly requiredCapabilities?: readonly string[];
+    readonly workspaceRoot?: string;
+    readonly workingDirectory?: string;
+    readonly continuationSessionId?: string;
+    readonly requireToolCall?: boolean;
+    readonly delegationSpec?: DelegationContractSpec;
+    readonly worktree?: "auto" | string;
+    readonly wait?: boolean;
+    readonly timeoutMs?: number;
+    readonly name?: string;
+    readonly createTaskIfMissing?: boolean;
+    readonly unsafeBenchmarkMode?: boolean;
+  }) => Promise<{
+    readonly sessionId: string;
+    readonly taskId?: string;
+    readonly output: string;
+    readonly success: boolean;
+    readonly status: string;
+    readonly waited: boolean;
+    readonly outputPath?: string;
+    readonly name?: string;
+  }>;
   readonly unsafeBenchmarkMode?: boolean;
 }
 

--- a/runtime/src/gateway/tool-handler-factory-delegation.ts
+++ b/runtime/src/gateway/tool-handler-factory-delegation.ts
@@ -109,6 +109,7 @@ export interface ExecuteDelegationToolParams {
   readonly taskStore?: TaskStore | null;
   readonly runtimeContractFlags?: RuntimeContractFlags;
   readonly availableToolNames?: readonly string[];
+  readonly launchShellAgentTask?: DelegationContext["launchShellAgentTask"];
   readonly defaultWorkingDirectory?: string;
   readonly parentAllowedReadRoots?: readonly string[];
   readonly parentAllowedWriteRoots?: readonly string[];
@@ -672,6 +673,142 @@ export async function executeDelegationTool(
       args: toolArgs,
       payload,
     });
+  const finalizeDelegationTerminalResult = (resultParams: {
+    readonly objective: string;
+    readonly childSessionId: string;
+    readonly childResult: NonNullable<
+      ReturnType<DelegationSubAgentManager["getResult"]>
+    >;
+    readonly childInfo: ReturnType<DelegationSubAgentManager["getInfo"]>;
+    readonly runtimeTaskId?: string;
+    readonly verifierRequirement: VerifierRequirement | undefined;
+    readonly executionEnvelopeFingerprint?: string;
+    readonly localExecutionLocation: RuntimeExecutionLocation;
+    readonly admittedInput: ExecuteWithAgentInput;
+  }): string => {
+    const failedChildToolCalls = countFailedChildToolCalls(
+      resultParams.childResult.toolCalls,
+    );
+    const verifierVerdict = mapPlannerVerifierSnapshotToRuntimeVerdict(
+      resultParams.childResult.verifierSnapshot,
+    );
+    const terminalOutcome = resolveDelegatedTerminalOutcome({
+      surface: "direct_child",
+      workerSessionId: resultParams.childSessionId,
+      taskId: resultParams.runtimeTaskId,
+      completionState: resultParams.childResult.completionState,
+      completionProgress: resultParams.childResult.completionProgress,
+      stopReason: resultParams.childResult.stopReason,
+      stopReasonDetail: resultParams.childResult.stopReasonDetail,
+      validationCode: resultParams.childResult.validationCode,
+      reportedStatus: resultParams.childInfo?.status,
+      verifierRequirement: resultParams.verifierRequirement,
+      verifierVerdict,
+      executionLocation: resultParams.localExecutionLocation,
+      executionEnvelopeFingerprint:
+        resultParams.childResult.contractFingerprint ??
+        resultParams.executionEnvelopeFingerprint,
+      continuationSessionId: resultParams.childSessionId,
+      ownedArtifacts:
+        resultParams.admittedInput.delegationAdmission?.ownedArtifacts,
+    });
+    const normalizedChildOutput = normalizeDelegatedSessionHandleOutput({
+      childSessionId: resultParams.childSessionId,
+      input: resultParams.admittedInput,
+      output: resultParams.childResult.output,
+    });
+
+    if (terminalOutcome.success) {
+      lifecycleEmitter?.emit({
+        type: "subagents.completed",
+        timestamp: Date.now(),
+        sessionId,
+        parentSessionId: sessionId,
+        subagentSessionId: resultParams.childSessionId,
+        toolName: name,
+        payload: {
+          objective: resultParams.objective,
+          durationMs: resultParams.childResult.durationMs,
+          toolCalls: resultParams.childResult.toolCalls.length,
+          providerName: resultParams.childResult.providerName,
+          output: normalizedChildOutput,
+          toolCallId,
+          runtimeResult: terminalOutcome.runtimeResult,
+        },
+      });
+      return finalizeDelegationResult({
+        success: true,
+        status: terminalOutcome.terminalStatus,
+        subagentSessionId: resultParams.childSessionId,
+        objective: resultParams.objective,
+        ...(resultParams.runtimeTaskId ? { taskId: resultParams.runtimeTaskId } : {}),
+        output: normalizedChildOutput,
+        durationMs: resultParams.childResult.durationMs,
+        toolCalls: resultParams.childResult.toolCalls.length,
+        failedToolCalls: failedChildToolCalls,
+        providerEvidence: resultParams.childResult.providerEvidence,
+        providerName: resultParams.childResult.providerName,
+        tokenUsage: resultParams.childResult.tokenUsage,
+        completionState: terminalOutcome.runtimeResult.completionState,
+        completionProgress: resultParams.childResult.completionProgress,
+        stopReason: resultParams.childResult.stopReason,
+        stopReasonDetail: resultParams.childResult.stopReasonDetail,
+        validationCode: resultParams.childResult.validationCode,
+        runtimeResult: terminalOutcome.runtimeResult,
+        ...(resultParams.verifierRequirement
+          ? { verifierRequirement: resultParams.verifierRequirement }
+          : {}),
+      });
+    }
+
+    const reason =
+      terminalOutcome.failureReason ??
+      parseDelegationFailureReason(resultParams.childResult.output);
+    lifecycleEmitter?.emit({
+      type:
+        terminalOutcome.terminalStatus === "cancelled"
+          ? "subagents.cancelled"
+          : "subagents.failed",
+      timestamp: Date.now(),
+      sessionId,
+      parentSessionId: sessionId,
+      subagentSessionId: resultParams.childSessionId,
+      toolName: name,
+      payload: {
+        objective: resultParams.objective,
+        reason,
+        output: resultParams.childResult.output,
+        durationMs: resultParams.childResult.durationMs,
+        toolCalls: resultParams.childResult.toolCalls.length,
+        failedToolCalls: failedChildToolCalls,
+        toolCallId,
+        runtimeResult: terminalOutcome.runtimeResult,
+      },
+    });
+    return finalizeDelegationResult({
+      success: false,
+      status: terminalOutcome.terminalStatus,
+      subagentSessionId: resultParams.childSessionId,
+      objective: resultParams.objective,
+      ...(resultParams.runtimeTaskId ? { taskId: resultParams.runtimeTaskId } : {}),
+      error: reason,
+      output: resultParams.childResult.output,
+      durationMs: resultParams.childResult.durationMs,
+      toolCalls: resultParams.childResult.toolCalls.length,
+      failedToolCalls: failedChildToolCalls,
+      providerName: resultParams.childResult.providerName,
+      tokenUsage: resultParams.childResult.tokenUsage,
+      completionState: terminalOutcome.runtimeResult.completionState,
+      completionProgress: resultParams.childResult.completionProgress,
+      stopReason: resultParams.childResult.stopReason,
+      stopReasonDetail: resultParams.childResult.stopReasonDetail,
+      validationCode: resultParams.childResult.validationCode,
+      runtimeResult: terminalOutcome.runtimeResult,
+      ...(resultParams.verifierRequirement
+        ? { verifierRequirement: resultParams.verifierRequirement }
+        : {}),
+    });
+  };
   if (!subAgentManager) {
     return finalizeDelegationResult({
       error:
@@ -907,8 +1044,19 @@ export async function executeDelegationTool(
         : {}),
     ...(workingDirectory ? { workingDirectory } : {}),
   };
+  const continuationSessionId = shouldReusePriorChildSession(input)
+    ? resolveRecallContinuationSessionId(input, sessionId, subAgentManager)
+    : input.continuationSessionId;
+  const childPrompt = buildDelegatedChildPrompt(admittedInput, {
+    continuationAuthorized: Boolean(continuationSessionId),
+    workingDirectory,
+  });
+  const canUseShellAgentLauncher =
+    typeof params.launchShellAgentTask === "function" &&
+    input.forkContext !== true;
+
   let runtimeTaskId: string | undefined;
-  if (taskStore && asyncTaskHandlesEnabled) {
+  if (taskStore && asyncTaskHandlesEnabled && !canUseShellAgentLauncher) {
     try {
       const task = await taskStore.createRuntimeTask({
         listId: sessionId,
@@ -993,14 +1141,170 @@ export async function executeDelegationTool(
     });
   }
   let childSessionId: string;
+  if (canUseShellAgentLauncher) {
+    try {
+      const launched = await params.launchShellAgentTask({
+        parentSessionId: sessionId,
+        roleId: childToolProfile.roleId,
+        objective,
+        prompt: childPrompt,
+        ...(params.shellProfile ? { shellProfile: params.shellProfile } : {}),
+        ...(resolvedChildScope.allowedTools.length > 0
+          ? { tools: resolvedChildScope.allowedTools }
+          : {}),
+        ...(input.requiredToolCapabilities
+          ? { requiredCapabilities: input.requiredToolCapabilities }
+          : {}),
+        ...(effectiveExecutionContext?.workspaceRoot
+          ? { workspaceRoot: effectiveExecutionContext.workspaceRoot }
+          : {}),
+        ...(workingDirectory ? { workingDirectory } : {}),
+        ...(continuationSessionId
+          ? { continuationSessionId }
+          : {}),
+        ...(specRequiresSuccessfulToolEvidence(effectiveInput)
+          ? { requireToolCall: true }
+          : {}),
+        delegationSpec: admittedInput,
+        createTaskIfMissing: asyncTaskHandlesEnabled,
+        ...(input.timeoutMs ? { timeoutMs: input.timeoutMs } : {}),
+        ...(unsafeBenchmarkMode ? { unsafeBenchmarkMode: true } : {}),
+        wait: !asyncTaskHandlesEnabled,
+      });
+      childSessionId = launched.sessionId;
+      runtimeTaskId = launched.taskId;
+      lifecycleEmitter?.emit({
+        type: "subagents.spawned",
+        timestamp: Date.now(),
+        sessionId,
+        parentSessionId: sessionId,
+        subagentSessionId: childSessionId,
+        toolName: name,
+        payload: {
+          objective,
+          ...(workingDirectory ? { workingDirectory } : {}),
+          ...(effectiveExecutionContext?.workspaceRoot
+            ? { workingDirectorySource: "execution_envelope" as const }
+            : {}),
+          tools: resolvedChildScope.allowedTools,
+          ...(input.requiredToolCapabilities
+            ? { requiredToolCapabilities: input.requiredToolCapabilities }
+            : {}),
+          ...(resolvedChildScope.removedLowSignalBrowserTools.length
+            ? {
+                removedLowSignalBrowserTools:
+                  resolvedChildScope.removedLowSignalBrowserTools,
+              }
+            : {}),
+          ...(resolvedChildScope.removedByPolicy.length
+            ? { removedByPolicy: resolvedChildScope.removedByPolicy }
+            : {}),
+          ...(resolvedChildScope.removedAsDelegationTools.length
+            ? {
+                removedAsDelegationTools:
+                  resolvedChildScope.removedAsDelegationTools,
+              }
+            : {}),
+          ...(resolvedChildScope.removedAsUnknownTools.length
+            ? { removedAsUnknownTools: resolvedChildScope.removedAsUnknownTools }
+            : {}),
+          ...(resolvedChildScope.semanticFallback.length
+            ? { semanticFallback: resolvedChildScope.semanticFallback }
+            : {}),
+          ...(unsafeBenchmarkMode ? { unsafeBenchmarkMode: true } : {}),
+          toolCallId,
+        },
+      });
+      lifecycleEmitter?.emit({
+        type: "subagents.started",
+        timestamp: Date.now(),
+        sessionId,
+        parentSessionId: sessionId,
+        subagentSessionId: childSessionId,
+        toolName: name,
+        payload: {
+          objective,
+          toolCallId,
+        },
+      });
+
+      if (asyncTaskHandlesEnabled) {
+        return finalizeDelegationResult({
+          success: true,
+          status: "in_progress",
+          subagentSessionId: childSessionId,
+          objective,
+          ...(runtimeTaskId ? { taskId: runtimeTaskId } : {}),
+          ...(launched.outputPath ? { outputPath: launched.outputPath } : {}),
+          runtimeResult: buildDelegatedRuntimeResult({
+            surface: "direct_child",
+            workerSessionId: childSessionId,
+            status: "in_progress",
+            taskId: runtimeTaskId,
+            verifierRequirement,
+            executionEnvelopeFingerprint,
+            continuationSessionId: childSessionId,
+            outputReady: false,
+            ownedArtifacts: admittedInput.delegationAdmission?.ownedArtifacts,
+            executionLocation: localExecutionLocation,
+          }),
+          backgroundHandle: {
+            ...(runtimeTaskId ? { id: runtimeTaskId } : { id: childSessionId }),
+            kind: "subagent",
+            status: "in_progress",
+            summary: "Delegated worker running.",
+            ...(launched.outputPath ? { outputPath: launched.outputPath } : {}),
+            executionLocation: localExecutionLocation,
+            outputReady: false,
+            ...(verifierRequirement ? { verifierRequirement } : {}),
+          },
+          ...(verifierRequirement ? { verifierRequirement } : {}),
+        });
+      }
+
+      const childResult = subAgentManager.getResult(childSessionId);
+      if (!childResult) {
+        return finalizeDelegationResult({
+          success: false,
+          status: "failed",
+          subagentSessionId: childSessionId,
+          objective,
+          ...(runtimeTaskId ? { taskId: runtimeTaskId } : {}),
+          error: "Delegated child completed without an inspectable terminal result",
+        });
+      }
+      return finalizeDelegationTerminalResult({
+        objective,
+        childSessionId,
+        childResult,
+        childInfo: subAgentManager.getInfo(childSessionId),
+        runtimeTaskId,
+        verifierRequirement,
+        executionEnvelopeFingerprint,
+        localExecutionLocation,
+        admittedInput,
+      });
+    } catch (error) {
+      const message = toErrorString(error);
+      lifecycleEmitter?.emit({
+        type: "subagents.failed",
+        timestamp: Date.now(),
+        sessionId,
+        parentSessionId: sessionId,
+        toolName: name,
+        payload: {
+          stage: "spawn",
+          objective,
+          reason: message,
+          toolCallId,
+        },
+      });
+      return finalizeDelegationResult({
+        error: `Failed to spawn sub-agent: ${message}`,
+      });
+    }
+  }
   try {
-    const continuationSessionId = shouldReusePriorChildSession(input)
-      ? resolveRecallContinuationSessionId(input, sessionId, subAgentManager)
-      : input.continuationSessionId;
-    const childPrompt = buildDelegatedChildPrompt(admittedInput, {
-      continuationAuthorized: Boolean(continuationSessionId),
-      workingDirectory,
-    });
     childSessionId = await subAgentManager.spawn({
       parentSessionId: sessionId,
       ...(params.shellProfile ? { shellProfile: params.shellProfile } : {}),

--- a/runtime/src/gateway/tool-handler-factory.test.ts
+++ b/runtime/src/gateway/tool-handler-factory.test.ts
@@ -1951,6 +1951,81 @@ describe("createSessionToolHandler", () => {
     );
   });
 
+  it("executes execute_with_agent via the shell agent launcher when available", async () => {
+    const subAgentManager = {
+      spawn: vi.fn(async () => "subagent:spawn-fallback"),
+      getResult: vi.fn(() => makeCompletedChildResult({
+        sessionId: "subagent:launcher-1",
+        output: '{"summary":"child completed"}',
+        success: true,
+        durationMs: 25,
+        toolCalls: [],
+      })),
+      getInfo: vi.fn(() => ({
+        sessionId: "subagent:launcher-1",
+        parentSessionId: "session-parent",
+        depth: 1,
+        status: "completed",
+        startedAt: Date.now() - 100,
+        task: "Inspect file",
+      })),
+    };
+    const launchShellAgentTask = vi.fn(async () => ({
+      sessionId: "subagent:launcher-1",
+      output: "",
+      success: false,
+      status: "running",
+      waited: true,
+      name: "worker-a",
+    }));
+
+    const handler = createSessionToolHandler({
+      sessionId: "session-parent",
+      baseHandler: vi.fn(async () => "should-not-run"),
+      availableToolNames: ["system.readFile", "system.stat"],
+      routerId: "router-a",
+      defaultWorkingDirectory: "/tmp/project-root",
+      send: vi.fn(),
+      delegation: () => ({
+        subAgentManager: subAgentManager as any,
+        policyEngine: null,
+        verifier: null,
+        lifecycleEmitter: null,
+        launchShellAgentTask: launchShellAgentTask as any,
+      }),
+    });
+
+    const result = await handler("execute_with_agent", {
+      task: "Inspect file",
+      objective: "Inspect file",
+      tools: ["system.readFile"],
+    });
+    const parsed = JSON.parse(result) as {
+      success?: boolean;
+      status?: string;
+      subagentSessionId?: string;
+    };
+
+    expect(parsed).toMatchObject({
+      success: true,
+      status: "completed",
+      subagentSessionId: "subagent:launcher-1",
+    });
+    expect(launchShellAgentTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parentSessionId: "session-parent",
+        roleId: "research",
+        objective: "Inspect file",
+        tools: ["system.readFile"],
+        workspaceRoot: "/tmp/project-root",
+        workingDirectory: "/tmp/project-root",
+        createTaskIfMissing: false,
+        wait: true,
+      }),
+    );
+    expect(subAgentManager.spawn).not.toHaveBeenCalled();
+  });
+
   it("allows explicitly scoped nested delegation from a sub-agent session", async () => {
     const subAgentManager = {
       getInfo: vi.fn((sessionId: string) => ({
@@ -2132,6 +2207,105 @@ describe("createSessionToolHandler", () => {
         completionState: "completed",
         continuationSessionId: "subagent:child-async",
       });
+    } finally {
+      rmSync(outputRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("returns a launcher-backed async handle for execute_with_agent when async task handles are enabled", async () => {
+    const outputRoot = createTempDir("agenc-launcher-task-handle-");
+    const taskStore = new TaskStore({
+      memoryBackend: createMockMemoryBackend(),
+      persistenceRootDir: outputRoot,
+    });
+
+    try {
+      const subAgentManager = {
+        getResult: vi.fn(() => null),
+        getInfo: vi.fn(() => ({
+          sessionId: "subagent:launcher-async",
+          parentSessionId: "session-parent",
+          depth: 1,
+          status: "running",
+          startedAt: Date.now() - 100,
+          task: "Inspect file",
+        })),
+      };
+      const launchShellAgentTask = vi.fn(async () => ({
+        sessionId: "subagent:launcher-async",
+        taskId: "task-123",
+        output: "",
+        success: false,
+        status: "running",
+        waited: false,
+        outputPath: "/tmp/runtime-task/output.json",
+      }));
+
+      const handler = createSessionToolHandler({
+        sessionId: "session-parent",
+        baseHandler: vi.fn(async () => "should-not-run"),
+        taskStore,
+        runtimeContractFlags: {
+          runtimeContractV2: true,
+          stopHooksEnabled: false,
+          asyncTasksEnabled: true,
+          persistentWorkersEnabled: false,
+          mailboxEnabled: false,
+          verifierRuntimeRequired: false,
+          verifierProjectBootstrap: false,
+          workerIsolationWorktree: false,
+          workerIsolationRemote: false,
+        },
+        availableToolNames: ["system.readFile"],
+        routerId: "router-a",
+        send: vi.fn(),
+        defaultWorkingDirectory: "/tmp/project-root",
+        delegation: () => ({
+          subAgentManager: subAgentManager as any,
+          policyEngine: null,
+          verifier: null,
+          lifecycleEmitter: null,
+          launchShellAgentTask: launchShellAgentTask as any,
+        }),
+      });
+
+      const result = await handler("execute_with_agent", {
+        task: "Inspect file",
+        tools: ["system.readFile"],
+      });
+      const parsed = JSON.parse(result) as {
+        success?: boolean;
+        status?: string;
+        taskId?: string;
+        outputPath?: string;
+        backgroundHandle?: {
+          id?: string;
+          outputPath?: string;
+        };
+      };
+
+      expect(parsed).toMatchObject({
+        success: true,
+        status: "in_progress",
+        taskId: "task-123",
+        outputPath: "/tmp/runtime-task/output.json",
+        backgroundHandle: {
+          id: "task-123",
+          outputPath: "/tmp/runtime-task/output.json",
+        },
+      });
+      expect(launchShellAgentTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          parentSessionId: "session-parent",
+          roleId: "research",
+          objective: "Inspect file",
+          tools: ["system.readFile"],
+          workspaceRoot: "/tmp/project-root",
+          workingDirectory: "/tmp/project-root",
+          createTaskIfMissing: true,
+          wait: false,
+        }),
+      );
     } finally {
       rmSync(outputRoot, { recursive: true, force: true });
     }
@@ -3129,6 +3303,54 @@ describe("createSessionToolHandler", () => {
       content: "int main(void) { return 0; }\n",
       [SESSION_ALLOWED_ROOTS_ARG]: ["/tmp/shell-workspace"],
       [SESSION_ID_ARG]: "subagent:child-2",
+    });
+  });
+
+  it("pins delegated verification workspaceRoot to the child workspace when the model passes '.'", async () => {
+    const baseHandler = vi.fn(async () => JSON.stringify({ ok: true }));
+    const workspaceRoot = "/home/tetsuo/git/stream-test/agenc-shell";
+    const subAgentManager = {
+      getInfo: vi.fn(() => ({
+        sessionId: "subagent:verify-child",
+        parentSessionId: "session-parent",
+        depth: 1,
+        status: "running",
+        startedAt: Date.now() - 100,
+        task: "Verify the shell workspace",
+      })),
+      getExecutionContext: vi.fn(() => ({
+        version: "v1",
+        workspaceRoot,
+        allowedReadRoots: [workspaceRoot],
+        allowedWriteRoots: ["/tmp"],
+        targetArtifacts: [join(workspaceRoot, "src", "app", "main.c")],
+      })),
+    };
+
+    const handler = createSessionToolHandler({
+      sessionId: "subagent:verify-child",
+      baseHandler,
+      availableToolNames: ["verification.listProbes"],
+      routerId: "router-a",
+      send: vi.fn(),
+      defaultWorkingDirectory: workspaceRoot,
+      delegation: () => ({
+        subAgentManager: subAgentManager as any,
+        policyEngine: null,
+        verifier: null,
+        lifecycleEmitter: null,
+      }),
+    });
+
+    await handler("verification.listProbes", {
+      workspaceRoot: ".",
+      profiles: ["generic"],
+    });
+
+    expect(baseHandler).toHaveBeenCalledWith("verification.listProbes", {
+      workspaceRoot,
+      profiles: ["generic"],
+      cwd: workspaceRoot,
     });
   });
 

--- a/runtime/src/gateway/tool-handler-factory.ts
+++ b/runtime/src/gateway/tool-handler-factory.ts
@@ -1174,6 +1174,23 @@ function applyDefaultWorkingDirectory(
     nextArgs = { ...nextArgs, cwd: executionWorkingDirectory };
   }
 
+  const workspaceRootValue =
+    typeof nextArgs.workspaceRoot === "string"
+      ? nextArgs.workspaceRoot.trim()
+      : undefined;
+  if (workspaceRootValue && typeof logicalWorkingDirectory === "string") {
+    const normalizedWorkspaceRoot = normalizeEnvelopePath(
+      workspaceRootValue,
+      logicalWorkingDirectory,
+    );
+    if (normalizedWorkspaceRoot !== workspaceRootValue) {
+      if (nextArgs === args) {
+        nextArgs = { ...nextArgs };
+      }
+      nextArgs.workspaceRoot = normalizedWorkspaceRoot;
+    }
+  }
+
   const pathArgKeys = TOOL_PATH_ARG_KEYS[toolName];
   if (!pathArgKeys) {
     return {
@@ -1335,6 +1352,20 @@ function applyWorkspaceAliasTranslation(
     }
   }
 
+  const workspaceRootValue =
+    typeof nextArgs.workspaceRoot === "string"
+      ? nextArgs.workspaceRoot.trim()
+      : undefined;
+  if (workspaceRootValue) {
+    const translatedWorkspaceRoot = translateWorkspaceAliasPath(
+      workspaceRootValue,
+      root,
+    );
+    if (translatedWorkspaceRoot !== workspaceRootValue) {
+      updateArg("workspaceRoot", translatedWorkspaceRoot);
+    }
+  }
+
   if (toolName !== "system.bash" && toolName !== "desktop.bash") {
     return nextArgs;
   }
@@ -1426,6 +1457,16 @@ function validateDelegatedCanonicalToolPaths(
   if (cwdValue && hasWorkspaceAliasPath(cwdValue)) {
     return buildDelegatedWorkspaceAliasLeakError(
       `cwd still uses the logical /workspace alias (${cwdValue})`,
+    );
+  }
+
+  const workspaceRootValue =
+    typeof args.workspaceRoot === "string"
+      ? args.workspaceRoot.trim()
+      : undefined;
+  if (workspaceRootValue && hasWorkspaceAliasPath(workspaceRootValue)) {
+    return buildDelegatedWorkspaceAliasLeakError(
+      `workspaceRoot still uses the logical /workspace alias (${workspaceRootValue})`,
     );
   }
 
@@ -3020,6 +3061,7 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
             taskStore,
             runtimeContractFlags,
             availableToolNames,
+            launchShellAgentTask: delegationContext?.launchShellAgentTask,
             defaultWorkingDirectory: effectiveDefaultWorkingDirectory,
             parentAllowedReadRoots: delegatedParentAllowedRoots,
             parentAllowedWriteRoots: delegatedParentAllowedRoots,

--- a/runtime/src/llm/chat-executor-artifact-evidence.test.ts
+++ b/runtime/src/llm/chat-executor-artifact-evidence.test.ts
@@ -152,6 +152,95 @@ function createTopLevelVerifierConfig(params: {
 }
 
 describe("top-level artifact evidence gate", () => {
+  it("launches the runtime verifier against the active runtime workspace root", async () => {
+    const spawn = vi.fn(async () => "subagent:verify-workspace");
+    const waitForResult = vi.fn(async () => ({
+      sessionId: "subagent:verify-workspace",
+      output: "Workspace-root verification passed.\nVERDICT: PASS",
+      success: true,
+      durationMs: 1,
+      toolCalls: [],
+      structuredOutput: {
+        type: "json_schema" as const,
+        name: "agenc_top_level_verifier_decision",
+        parsed: {
+          verdict: "pass",
+          summary: "Workspace-root verification passed.",
+        },
+      },
+      completionState: "completed" as const,
+      stopReason: "completed" as const,
+    }));
+    const provider = createMockProvider("primary", {
+      chat: vi
+        .fn<[LLMMessage[], LLMChatOptions?], Promise<LLMResponse>>()
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "",
+            finishReason: "tool_calls",
+            toolCalls: [
+              {
+                id: "tc-1",
+                name: "system.writeFile",
+                arguments: safeJson({
+                  path: "src/main.c",
+                  content: "int main(void) { return 0; }\n",
+                }),
+              },
+            ],
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockResponse({
+            content: "Implemented the shell entry point.",
+          }),
+        ),
+    });
+    const toolHandler = vi.fn(async (_name: string, args: Record<string, unknown>) =>
+      safeJson({ ok: true, path: args.path }),
+    );
+    const executor = new ChatExecutor({
+      providers: [provider],
+      toolHandler,
+      completionValidation: {
+        topLevelVerifier: {
+          subAgentManager: { spawn, waitForResult },
+          verifierService: {
+            resolveVerifierRequirement: vi.fn(() => ({
+              required: true,
+              profiles: ["generic"],
+              probeCategories: ["build"],
+              mutationPolicy: "read_only_workspace" as const,
+              allowTempArtifacts: true,
+              bootstrapSource: "disabled" as const,
+              rationale: ["test"],
+            })),
+            shouldVerifySubAgentResult: vi.fn(() => true),
+          },
+        },
+      },
+    });
+
+    await executor.execute(
+      createParams({
+        runtimeContext: { workspaceRoot: WORKSPACE_ROOT },
+      }),
+    );
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceRoot: WORKSPACE_ROOT,
+        workingDirectory: WORKSPACE_ROOT,
+        delegationSpec: expect.objectContaining({
+          executionContext: expect.objectContaining({
+            workspaceRoot: WORKSPACE_ROOT,
+            targetArtifacts: [`${WORKSPACE_ROOT}/src/main.c`],
+          }),
+        }),
+      }),
+    );
+  });
+
   it("forces a recovery tool turn for carried workflow implementation tasks", async () => {
     const activeTaskContext: ActiveTaskContext = {
       version: 1,

--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -2597,6 +2597,7 @@ export async function executeToolCallLoop(
             content: ctx.response?.content ?? "",
             stopReason: ctx.stopReason,
             completionState: ctx.completionState,
+            runtimeWorkspaceRoot: ctx.runtimeWorkspaceRoot,
             turnExecutionContract: ctx.turnExecutionContract,
             toolCalls: ctx.allToolCalls,
             stopReasonDetail: ctx.stopReasonDetail,

--- a/runtime/src/tools/system/verification.test.ts
+++ b/runtime/src/tools/system/verification.test.ts
@@ -136,4 +136,33 @@ describe("verification tools", () => {
       parsed.probes?.some((probe) => probe.id === "generic:test:ctest"),
     ).toBe(true);
   });
+
+  it("resolves relative workspaceRoot against cwd when the caller passes '.'", async () => {
+    const workspaceRoot = mkdtempSync(
+      join(tmpdir(), "verification-relative-workspace-root-"),
+    );
+    writeFileSync(
+      join(workspaceRoot, "package.json"),
+      JSON.stringify({
+        name: "verification-fixture",
+        private: true,
+        scripts: {
+          build: "node -e \"process.stdout.write('build-ok')\"",
+        },
+      }),
+    );
+
+    const tools = createVerificationTools();
+    const listProbes = findTool(tools, "verification.listProbes");
+
+    const parsed = JSON.parse(
+      (await listProbes.execute({ workspaceRoot: ".", cwd: workspaceRoot })).content,
+    ) as {
+      workspaceRoot?: string;
+      probes?: Array<{ category?: string }>;
+    };
+
+    expect(parsed.workspaceRoot).toBe(workspaceRoot);
+    expect(parsed.probes?.some((probe) => probe.category === "build")).toBe(true);
+  });
 });

--- a/runtime/src/tools/system/verification.ts
+++ b/runtime/src/tools/system/verification.ts
@@ -1,7 +1,6 @@
-import { resolve as resolvePath } from "node:path";
-
 import type { Tool, ToolResult } from "../types.js";
 import { safeStringify } from "../types.js";
+import { normalizeEnvelopePath } from "../../workflow/path-normalization.js";
 import {
   buildVerificationProbeDescriptors,
   runVerificationProbe,
@@ -19,13 +18,15 @@ function okResult(data: unknown): ToolResult {
 }
 
 function asWorkspaceRoot(args: Record<string, unknown>): string | undefined {
+  const cwd =
+    typeof args.cwd === "string" && args.cwd.trim().length > 0
+      ? args.cwd.trim()
+      : undefined;
   const value =
     typeof args.workspaceRoot === "string" && args.workspaceRoot.trim().length > 0
       ? args.workspaceRoot.trim()
-      : typeof args.cwd === "string" && args.cwd.trim().length > 0
-        ? args.cwd.trim()
-        : undefined;
-  return value ? resolvePath(value) : undefined;
+      : cwd;
+  return value ? normalizeEnvelopePath(value, cwd) : undefined;
 }
 
 function asProfiles(


### PR DESCRIPTION
## Summary
- route delegated child launches through the richer shell-agent launcher contract
- keep delegated verification workspace roots pinned to the child workspace
- pass the runtime workspace root into top-level verifier execution and cover it with regression tests

## Verification
- npm run techdebt
- ./node_modules/.bin/vitest run runtime/src/gateway/tool-handler-factory.test.ts runtime/src/tools/system/verification.test.ts runtime/src/gateway/top-level-verifier.test.ts runtime/src/gateway/sub-agent.test.ts runtime/src/gateway/daemon-command-registry.test.ts runtime/src/llm/chat-executor-artifact-evidence.test.ts
- ./node_modules/.bin/tsc -p runtime/tsconfig.json --noEmit
- npm run build --workspace=@tetsuo-ai/runtime