### PR TITLE
fix(runtime): keep multi-phase implementation runs durable

### DIFF
--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -143,3 +143,10 @@
 - **What worked:** Threading the runtime workspace root all the way into delegated child launches and top-level verifier execution stopped child sessions from drifting back to the umbrella repo, while the richer shell-agent launcher path preserved the intended child scope and handle metadata.
 - **What didn't:** The runtime already had most of the workspace plumbing, but one omitted handoff in the completion loop meant the verifier silently fell back to stale contract roots, so the failure only showed up at the very end of otherwise-correct runs.
 - **Rule added to CLAUDE.md:** no
+
+## PR #399: fix(runtime): keep multi-phase implementation runs durable
+- **Date:** 2026-04-15
+- **Files changed:** `runtime/src/gateway/{background-run-workflow-context,background-run-supervisor,background-run-supervisor-types,daemon,daemon-webchat-turn}.ts`, `runtime/src/workflow/completion-progress.ts`, `runtime/src/llm/{chat-executor-ctx-helpers,chat-executor-stop-gate}.ts`, `runtime/src/llm/hooks/stop-hooks.ts`, `runtime/src/gateway/*.test.ts`, `runtime/src/workflow/completion-progress.test.ts`, `runtime/src/llm/*.test.ts`
+- **What worked:** Promoting explicit full-plan implementation requests into durable workflow execution, making request milestones authoritative for strict runs, and allowing milestone checkpoint summaries to continue instead of tripping narrated-future-work made long implementation sessions persist progress instead of dying after the first honest checkpoint.
+- **What didn't:** The durable path needed wiring at multiple layers because request milestones were previously telemetry-only, background-run actor cycles were missing runtime evidence context, and stale verifier state could survive later mutations unless it was explicitly invalidated.
+- **Rule added to CLAUDE.md:** no

--- a/runtime/src/gateway/background-run-supervisor-types.ts
+++ b/runtime/src/gateway/background-run-supervisor-types.ts
@@ -8,7 +8,10 @@
  */
 
 import type { ChatExecutor } from "../llm/chat-executor.js";
-import type { ChatExecutorResult } from "../llm/chat-executor-types.js";
+import type {
+  ChatExecuteParams,
+  ChatExecutorResult,
+} from "../llm/chat-executor-types.js";
 import type { PromptEnvelopeV1 } from "../llm/prompt-envelope.js";
 import type { LLMMessage, LLMProvider, ToolHandler } from "../llm/types.js";
 import type { GatewayMessage } from "./message.js";
@@ -153,6 +156,15 @@ export interface BackgroundRunSupervisorConfig {
     cycleIndex: number;
     shellProfile: SessionShellProfile;
   }) => ToolHandler;
+  readonly resolveExecutionContext?: (params: {
+    readonly sessionId: string;
+    readonly objective: string;
+    readonly shellProfile: SessionShellProfile;
+    readonly history: readonly LLMMessage[];
+  }) => Promise<{
+    readonly runtimeContext?: ChatExecuteParams["runtimeContext"];
+    readonly requiredToolEvidence?: ChatExecuteParams["requiredToolEvidence"];
+  } | undefined>;
   readonly buildToolRoutingDecision?: (
     sessionId: string,
     messageText: string,

--- a/runtime/src/gateway/background-run-supervisor.test.ts
+++ b/runtime/src/gateway/background-run-supervisor.test.ts
@@ -8,6 +8,7 @@ import type { LLMProvider, ToolHandler } from "../llm/types.js";
 import { InMemoryBackend } from "../memory/in-memory/backend.js";
 import { SqliteBackend } from "../memory/sqlite/backend.js";
 import { PolicyEngine } from "../policy/engine.js";
+import type { Logger } from "../utils/logger.js";
 import {
   BackgroundRunSupervisor,
   inferBackgroundRunIntent,
@@ -77,6 +78,16 @@ function createRunStore() {
   return new BackgroundRunStore({
     memoryBackend: new InMemoryBackend(),
   });
+}
+
+function createLoggerStub(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    setLevel: vi.fn(),
+  };
 }
 
 function deferred<T>() {
@@ -424,6 +435,101 @@ describe("background-run-supervisor", () => {
     expect(
       isBackgroundRunStatusRequest("what is the status of the server you started"),
     ).toBe(false);
+  });
+
+  it("passes resolved workflow execution context into actor cycles", async () => {
+    const execute = vi.fn(async (params: any) =>
+      makeResult({
+        content: "Completed M0 and continuing with M1 next.",
+        toolCalls: [
+          {
+            name: "system.writeFile",
+            args: { path: "/tmp/workspace/src/main.c" },
+            result: JSON.stringify({ ok: true }),
+            isError: false,
+            durationMs: 1,
+          },
+        ],
+        completionState: "partial",
+        stopReason: "completed",
+        ...(params.runtimeContext
+          ? { runtimeWorkspaceRoot: params.runtimeContext.workspaceRoot }
+          : {}),
+      })
+    );
+    const resolveExecutionContext = vi.fn(async () => ({
+      runtimeContext: {
+        workspaceRoot: "/tmp/workspace",
+      },
+      requiredToolEvidence: {
+        verificationContract: {
+          workspaceRoot: "/tmp/workspace",
+          requestCompletion: {
+            requiredMilestones: [
+              { id: "M0", description: "Bootstrap" },
+              { id: "M1", description: "Lexer" },
+            ],
+          },
+          completionContract: {
+            taskClass: "artifact_only",
+            placeholdersAllowed: false,
+            partialCompletionAllowed: false,
+            placeholderTaxonomy: "implementation",
+          },
+        },
+        completionContract: {
+          taskClass: "artifact_only",
+          placeholdersAllowed: false,
+          partialCompletionAllowed: false,
+          placeholderTaxonomy: "implementation",
+        },
+      },
+    }));
+    const supervisor = new BackgroundRunSupervisor({
+      chatExecutor: { execute } as any,
+      supervisorLlm: { chat: vi.fn(async () => ({ content: "" })) } as any,
+      getSystemPrompt: () => "system",
+      createToolHandler: () => vi.fn(async () => JSON.stringify({ ok: true })),
+      resolveExecutionContext,
+      publishUpdate: vi.fn(async () => undefined),
+      runStore: createRunStore(),
+      logger: createLoggerStub(),
+    });
+
+    await supervisor.startRun({
+      sessionId: "session:workflow-context",
+      objective: "Read PLAN.md and implement all phases in full.",
+      options: {
+        contract: {
+          domain: "workspace",
+          kind: "finite",
+          successCriteria: ["All milestones complete."],
+          completionCriteria: ["Implementation is complete."],
+          blockedCriteria: ["Verification is blocked."],
+          nextCheckMs: 1_000,
+          requiresUserStop: false,
+        },
+      },
+    });
+
+    await eventuallyAsync(async () => {
+      expect(resolveExecutionContext).toHaveBeenCalled();
+      expect(execute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runtimeContext: { workspaceRoot: "/tmp/workspace" },
+          requiredToolEvidence: expect.objectContaining({
+            verificationContract: expect.objectContaining({
+              requestCompletion: {
+                requiredMilestones: [
+                  { id: "M0", description: "Bootstrap" },
+                  { id: "M1", description: "Lexer" },
+                ],
+              },
+            }),
+          }),
+        }),
+      );
+    });
   });
 
   it("does not misparse natural-language durable server objectives as native process commands", async () => {

--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -486,6 +486,7 @@ export class BackgroundRunSupervisor {
   private readonly supervisorLlm: LLMProvider;
   private readonly getSystemPrompt: () => string;
   private readonly createToolHandler: BackgroundRunSupervisorConfig["createToolHandler"];
+  private readonly resolveExecutionContext?: BackgroundRunSupervisorConfig["resolveExecutionContext"];
   private readonly buildToolRoutingDecision?: BackgroundRunSupervisorConfig["buildToolRoutingDecision"];
   private readonly seedHistoryForSession?: BackgroundRunSupervisorConfig["seedHistoryForSession"];
   private readonly isSessionBusy?: BackgroundRunSupervisorConfig["isSessionBusy"];
@@ -524,6 +525,7 @@ export class BackgroundRunSupervisor {
     this.supervisorLlm = config.supervisorLlm;
     this.getSystemPrompt = config.getSystemPrompt;
     this.createToolHandler = config.createToolHandler;
+    this.resolveExecutionContext = config.resolveExecutionContext;
     this.buildToolRoutingDecision = config.buildToolRoutingDecision;
     this.seedHistoryForSession = config.seedHistoryForSession;
     this.isSessionBusy = config.isSessionBusy;
@@ -3633,6 +3635,13 @@ export class BackgroundRunSupervisor {
           run.internalHistory,
           run.shellProfile ?? DEFAULT_SESSION_SHELL_PROFILE,
         );
+        const resolvedExecutionContext =
+          await this.resolveExecutionContext?.({
+            sessionId,
+            objective: run.objective,
+            shellProfile: run.shellProfile ?? DEFAULT_SESSION_SHELL_PROFILE,
+            history: run.internalHistory,
+          });
         const toolRoutingDecision = applyRunToolScopeDecision({
           allowedTools: getScopedAllowedTools(run),
           toolRoutingDecision: baseToolRoutingDecision,
@@ -3648,6 +3657,8 @@ export class BackgroundRunSupervisor {
           history: run.internalHistory,
           promptEnvelope: actorPromptEnvelope,
           sessionId,
+          runtimeContext: resolvedExecutionContext?.runtimeContext,
+          requiredToolEvidence: resolvedExecutionContext?.requiredToolEvidence,
           requestTimeoutMs: BACKGROUND_RUN_ACTOR_REQUEST_TIMEOUT_MS,
           stateful: run.carryForward?.providerContinuation
             ? {

--- a/runtime/src/gateway/background-run-workflow-context.ts
+++ b/runtime/src/gateway/background-run-workflow-context.ts
@@ -1,0 +1,211 @@
+import { access, readFile } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { join } from "node:path";
+
+import type { ChatExecuteParams } from "../llm/chat-executor-types.js";
+import type { LLMMessage } from "../llm/types.js";
+import type { ImplementationCompletionContract } from "../workflow/completion-contract.js";
+import { normalizeWorkspaceRoot } from "../workflow/path-normalization.js";
+import type { WorkflowRequestMilestone } from "../workflow/request-completion.js";
+import type { WorkflowVerificationContract } from "../workflow/verification-obligations.js";
+import { resolveAtMentionAttachments } from "./at-mention-attachments.js";
+
+const FULL_IMPLEMENTATION_RE =
+  /\b(?:implement|complete|finish|build)\b[\s\S]{0,160}\b(?:in full|fully|entirely|the full plan|all phases|every phase)\b/i;
+const DO_NOT_STOP_RE =
+  /\b(?:do not stop|don't stop|without stopping|until complete|until it's complete|until it is complete|keep going until)\b/i;
+const PLAN_REFERENCE_RE = /(?:^|\s)@?PLAN\.md\b/i;
+const PHASED_REQUEST_RE =
+  /\b(?:all phases|every phase|phase-by-phase|milestones?|m\d+\b)\b/i;
+
+const MILESTONE_HEADING_RE =
+  /^\s*(?:[-*]\s+)?(?:#{1,6}\s*)?(M\d+)\b(?:\s*[:\-]\s*|\s+)(.+?)\s*$/i;
+const PHASE_HEADING_RE =
+  /^\s*(?:[-*]\s+)?(?:#{1,6}\s*)?Phase\s+([A-Za-z0-9._-]+)\b(?:\s*[:\-]\s*|\s+)(.+?)\s*$/i;
+
+const STRICT_IMPLEMENTATION_COMPLETION_CONTRACT: ImplementationCompletionContract = {
+  taskClass: "artifact_only",
+  placeholdersAllowed: false,
+  partialCompletionAllowed: false,
+  placeholderTaxonomy: "implementation",
+};
+
+export interface BackgroundRunWorkflowContext {
+  readonly historyPrelude: readonly LLMMessage[];
+  readonly runtimeContext?: ChatExecuteParams["runtimeContext"];
+  readonly requiredToolEvidence?: ChatExecuteParams["requiredToolEvidence"];
+}
+
+export function shouldPromoteImplementationBackgroundRun(
+  content: string,
+): boolean {
+  const trimmed = content.trim();
+  if (trimmed.length === 0) {
+    return false;
+  }
+  return (
+    FULL_IMPLEMENTATION_RE.test(trimmed) ||
+    (PLAN_REFERENCE_RE.test(trimmed) &&
+      (DO_NOT_STOP_RE.test(trimmed) || PHASED_REQUEST_RE.test(trimmed))) ||
+    (DO_NOT_STOP_RE.test(trimmed) &&
+      /\b(?:implement|build|complete|finish)\b/i.test(trimmed) &&
+      PHASED_REQUEST_RE.test(trimmed))
+  );
+}
+
+export async function buildBackgroundRunWorkflowContext(params: {
+  readonly objective: string;
+  readonly workspaceRoot?: string;
+}): Promise<BackgroundRunWorkflowContext> {
+  const workspaceRoot = normalizeWorkspaceRoot(params.workspaceRoot);
+  const atMentionAttachments = workspaceRoot
+    ? await resolveAtMentionAttachments({
+        content: params.objective,
+        workspaceRoot,
+      })
+    : {
+        historyPrelude: [] as const,
+        executionEnvelope: undefined,
+      };
+  const requestMilestones = workspaceRoot
+    ? await deriveRequestMilestones({
+        objective: params.objective,
+        workspaceRoot,
+      })
+    : [];
+  const strictWorkflowRequest =
+    shouldPromoteImplementationBackgroundRun(params.objective) ||
+    requestMilestones.length > 0;
+  const completionContract = strictWorkflowRequest
+    ? STRICT_IMPLEMENTATION_COMPLETION_CONTRACT
+    : undefined;
+  const verificationContract = buildVerificationContract({
+    workspaceRoot,
+    requestMilestones,
+    completionContract,
+  });
+
+  return {
+    historyPrelude: atMentionAttachments.historyPrelude,
+    runtimeContext: workspaceRoot ? { workspaceRoot } : undefined,
+    requiredToolEvidence:
+      verificationContract || completionContract || atMentionAttachments.executionEnvelope
+        ? {
+            ...(verificationContract
+              ? { verificationContract }
+              : {}),
+            ...(completionContract
+              ? { completionContract }
+              : {}),
+            ...(atMentionAttachments.executionEnvelope
+              ? {
+                  executionEnvelope: {
+                    ...atMentionAttachments.executionEnvelope,
+                    ...(completionContract
+                      ? { completionContract }
+                      : {}),
+                  },
+                }
+              : {}),
+          }
+        : undefined,
+  };
+}
+
+function buildVerificationContract(params: {
+  readonly workspaceRoot?: string;
+  readonly requestMilestones: readonly WorkflowRequestMilestone[];
+  readonly completionContract?: ImplementationCompletionContract;
+}): WorkflowVerificationContract | undefined {
+  if (
+    !params.workspaceRoot &&
+    params.requestMilestones.length === 0 &&
+    !params.completionContract
+  ) {
+    return undefined;
+  }
+  return {
+    ...(params.workspaceRoot ? { workspaceRoot: params.workspaceRoot } : {}),
+    ...(params.requestMilestones.length > 0
+      ? {
+          requestCompletion: {
+            requiredMilestones: params.requestMilestones,
+          },
+        }
+      : {}),
+    ...(params.completionContract
+      ? { completionContract: params.completionContract }
+      : {}),
+  };
+}
+
+async function deriveRequestMilestones(params: {
+  readonly objective: string;
+  readonly workspaceRoot: string;
+}): Promise<readonly WorkflowRequestMilestone[]> {
+  if (
+    !PLAN_REFERENCE_RE.test(params.objective) &&
+    !PHASED_REQUEST_RE.test(params.objective)
+  ) {
+    return [];
+  }
+
+  const candidatePaths = [
+    join(params.workspaceRoot, "PLAN.md"),
+    join(params.workspaceRoot, "plan.md"),
+  ];
+  for (const path of candidatePaths) {
+    try {
+      await access(path, fsConstants.R_OK);
+    } catch {
+      continue;
+    }
+    const content = await readFile(path, "utf8").catch(() => undefined);
+    if (typeof content !== "string" || content.trim().length === 0) {
+      continue;
+    }
+    const milestones = parseRequestMilestones(content);
+    if (milestones.length > 0) {
+      return milestones;
+    }
+  }
+  return [];
+}
+
+function parseRequestMilestones(
+  content: string,
+): readonly WorkflowRequestMilestone[] {
+  const milestones = new Map<string, WorkflowRequestMilestone>();
+  for (const rawLine of content.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (line.length === 0) {
+      continue;
+    }
+    const milestoneMatch = line.match(MILESTONE_HEADING_RE);
+    if (milestoneMatch?.[1] && milestoneMatch[2]) {
+      const id = milestoneMatch[1].toUpperCase();
+      if (!milestones.has(id)) {
+        milestones.set(id, {
+          id,
+          description: milestoneMatch[2].trim(),
+        });
+      }
+      continue;
+    }
+    const phaseMatch = line.match(PHASE_HEADING_RE);
+    if (phaseMatch?.[1] && phaseMatch[2]) {
+      const phaseId = normalizePhaseId(phaseMatch[1]);
+      if (!milestones.has(phaseId)) {
+        milestones.set(phaseId, {
+          id: phaseId,
+          description: phaseMatch[2].trim(),
+        });
+      }
+    }
+  }
+  return [...milestones.values()];
+}
+
+function normalizePhaseId(rawPhase: string): string {
+  return `phase_${rawPhase.trim().toLowerCase().replace(/[^a-z0-9]+/g, "_")}`;
+}

--- a/runtime/src/gateway/daemon-webchat-turn.test.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.test.ts
@@ -1018,4 +1018,96 @@ You have broad access to this machine via the system.bash tool.`,
     );
   });
 
+  it("promotes explicit full-plan implementation requests into durable workflow execution", async () => {
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "agenc-webchat-bg-"));
+    const planPath = join(workspaceRoot, "PLAN.md");
+    writeFileSync(
+      planPath,
+      ["# PLAN", "## M0 Bootstrap", "## M1 Lexer", "## M2 Parser"].join("\n"),
+      "utf8",
+    );
+
+    const logger = createLoggerStub();
+    const memoryBackend = createMemoryBackendStub();
+    const session = createSession();
+    const sessionMgr = {
+      getOrCreate: vi.fn(() => session),
+      appendMessage: vi.fn(),
+      compact: vi.fn(async () => undefined),
+    } as any;
+    const webChat = {
+      createAbortController: vi.fn(() => new AbortController()),
+      clearAbortController: vi.fn(),
+      send: vi.fn(async () => undefined),
+      pushToSession: vi.fn(),
+      broadcastEvent: vi.fn(),
+      loadSessionWorkspaceRoot: vi.fn(async () => workspaceRoot),
+    } as any;
+    const hooks = {
+      dispatch: vi.fn(async () => ({ completed: true, payload: {} })),
+    } as any;
+    const signals = {
+      signalThinking: vi.fn(),
+      signalIdle: vi.fn(),
+    };
+    const execute = vi.fn(async () => createResult());
+    const maybeStartBackgroundRun = vi.fn(async (params) => {
+      expect(params.runtimeWorkspaceRoot).toBe(workspaceRoot);
+      expect(params.effectiveHistory).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            role: "tool",
+            toolName: "system.readFile",
+          }),
+        ]),
+      );
+      return true;
+    });
+
+    const result = await executeWebChatConversationTurn({
+      logger,
+      msg: {
+        sessionId: "session:durable-webchat",
+        senderId: "operator-1",
+        channel: "webchat",
+        content: "Read @PLAN.md and implement all phases in full without stopping.",
+      },
+      webChat,
+      chatExecutor: { execute } as any,
+      sessionMgr,
+      getSystemPrompt: () => "system",
+      sessionToolHandler: vi.fn() as any,
+      sessionStreamCallback: vi.fn(),
+      signals,
+      hooks,
+      memoryBackend,
+      sessionTokenBudget: 16_000,
+      defaultMaxToolRounds: 3,
+      contextWindowTokens: 64_000,
+      traceConfig: {
+        enabled: false,
+        includeHistory: true,
+        includeSystemPrompt: true,
+        includeToolArgs: true,
+        includeToolResults: true,
+        includeProviderPayloads: false,
+        maxChars: 20_000,
+      },
+      turnTraceId: "trace-durable-webchat",
+      buildToolRoutingDecision: () => undefined,
+      recordToolRoutingOutcome: vi.fn(),
+      getSessionTokenUsage: () => 0,
+      onModelInfo: vi.fn(),
+      onSubagentSynthesis: vi.fn(),
+      maybeStartBackgroundRun,
+    });
+
+    expect(result).toBeUndefined();
+    expect(maybeStartBackgroundRun).toHaveBeenCalledOnce();
+    expect(execute).not.toHaveBeenCalled();
+    expect(webChat.clearAbortController).toHaveBeenCalledWith(
+      "session:durable-webchat",
+    );
+  });
+
 });

--- a/runtime/src/gateway/daemon-webchat-turn.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.ts
@@ -76,6 +76,7 @@ import type { PersistentWorkerManager } from "./persistent-worker-manager.js";
 import type { SubAgentManager } from "./sub-agent.js";
 import type { TaskStore } from "../tools/system/task-tracker.js";
 import { seedSessionReadState } from "../tools/system/filesystem.js";
+import type { ExecutionEnvelope } from "../workflow/execution-envelope.js";
 
 interface WebChatTurnSignals {
   signalThinking: (sessionId: string) => void;
@@ -119,6 +120,13 @@ interface ExecuteWebChatConversationTurnParams {
   readonly workerManager?: PersistentWorkerManager | null;
   readonly agentDefinitions?: readonly AgentDefinition[];
   readonly taskStore?: TaskStore | null;
+  readonly maybeStartBackgroundRun?: (params: {
+    readonly session: Session;
+    readonly objective: string;
+    readonly runtimeWorkspaceRoot?: string;
+    readonly effectiveHistory: readonly import("../llm/types.js").LLMMessage[];
+    readonly executionEnvelope?: ExecutionEnvelope;
+  }) => Promise<boolean>;
 }
 
 async function resolveWebChatTurnWorkspaceRoot(params: {
@@ -301,6 +309,19 @@ export async function executeWebChatConversationTurn(
       atMentionAttachments.historyPrelude.length > 0
         ? [...session.history, ...atMentionAttachments.historyPrelude]
         : session.history;
+    if (
+      params.maybeStartBackgroundRun &&
+      await params.maybeStartBackgroundRun({
+        session,
+        objective: effectiveMessage.content,
+        runtimeWorkspaceRoot,
+        effectiveHistory,
+        executionEnvelope: atMentionAttachments.executionEnvelope,
+      })
+    ) {
+      webChat.clearAbortController(msg.sessionId);
+      return undefined;
+    }
 
     // Phase E: webchat streaming caller migrated to drain the
     // Phase C generator. onStreamChunk pass-through is handled

--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -1663,6 +1663,93 @@ describe("webchat background-run routing", () => {
     executeWebChatConversationTurnSpy.mockRestore();
   });
 
+  it("promotes explicit full-plan implementation requests into background supervision", async () => {
+    const dm = new DaemonManager({ configPath: "/tmp/config.json" });
+    const startRun = vi.fn(async () => undefined);
+    const getStatusSnapshot = vi.fn(() => undefined);
+
+    (dm as any).gateway = {
+      config: {
+        autonomy: {
+          enabled: true,
+          featureFlags: { backgroundRuns: true, canaryRollout: false },
+        },
+      },
+    };
+    (dm as any)._backgroundRunSupervisor = {
+      getStatusSnapshot,
+      startRun,
+    };
+
+    const executeWebChatConversationTurnSpy = vi
+      .spyOn(dm as any, "executeWebChatConversationTurn")
+      .mockImplementation(async (params: any) => {
+        const started = await params.maybeStartBackgroundRun?.({
+          session: { metadata: {} },
+          objective: params.msg.content,
+          runtimeWorkspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
+          effectiveHistory: [],
+        });
+        expect(started).toBe(true);
+        return undefined;
+      });
+
+    const webChat = {
+      send: vi.fn(async () => undefined),
+      pushToSession: vi.fn(),
+      broadcastEvent: vi.fn(),
+    } as any;
+    const commandRegistry = { dispatch: vi.fn(async () => false) } as any;
+    const hooks = {
+      dispatch: vi.fn(async () => ({ completed: true, payload: {} })),
+    } as any;
+    const sessionMgr = {
+      getOrCreate: vi.fn(() => ({ metadata: {} })),
+    } as any;
+    const memoryBackend = { addEntry: vi.fn(async () => undefined) } as any;
+
+    await (dm as any).handleWebChatInboundMessage(
+      {
+        sessionId: "session-background-implementation",
+        senderId: "operator-1",
+        channel: "webchat",
+        content: "Read @PLAN.md and implement all phases in full without stopping.",
+      },
+      {
+        webChat,
+        commandRegistry,
+        getChatExecutor: () => ({ execute: vi.fn() }),
+        getLoggingConfig: () => ({}),
+        hooks,
+        sessionMgr,
+        getSystemPrompt: () => "",
+        baseToolHandler: vi.fn(),
+        approvalEngine: undefined,
+        memoryBackend,
+        signals: {} as any,
+        sessionTokenBudget: 16_000,
+        contextWindowTokens: 64_000,
+      },
+    );
+
+    expect(startRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "session-background-implementation",
+        objective: "Read @PLAN.md and implement all phases in full without stopping.",
+        options: expect.objectContaining({
+          seedHistory: expect.arrayContaining([
+            expect.objectContaining({
+              role: "user",
+              content: "Read @PLAN.md and implement all phases in full without stopping.",
+            }),
+          ]),
+        }),
+      }),
+    );
+    expect(executeWebChatConversationTurnSpy).toHaveBeenCalledOnce();
+    executeWebChatConversationTurnSpy.mockRestore();
+  });
+
 });
 
 describe("ensureChromiumCompatShims", () => {
@@ -2720,8 +2807,26 @@ describe("DaemonManager", () => {
         },
       },
     ];
+    const launchShellAgentTask = vi.fn(async () => ({
+      role: {
+        id: "shell",
+        displayName: "Shell",
+        description: "shell",
+      },
+      sessionId: "subagent:child-webchat",
+      output: JSON.stringify({
+        stdout: `${sessionWorkspaceRoot}\n`,
+        stderr: "",
+        exitCode: 0,
+      }),
+      success: true,
+      status: "completed",
+      waited: true,
+      outputPath: undefined,
+      name: undefined,
+    }));
+    (dm as any).launchShellAgentTask = launchShellAgentTask;
     (dm as any)._subAgentManager = {
-      spawn: vi.fn(async () => "subagent:child-webchat"),
       getResult: vi.fn(() => ({
         sessionId: "subagent:child-webchat",
         output: JSON.stringify({
@@ -2794,11 +2899,11 @@ describe("DaemonManager", () => {
     expect(webChat.loadSessionWorkspaceRoot).toHaveBeenCalledWith(
       "session-project-root",
     );
-    expect((dm as any)._subAgentManager.spawn).toHaveBeenCalledWith(
+    expect(launchShellAgentTask).toHaveBeenCalledWith(
       expect.objectContaining({
         parentSessionId: "session-project-root",
+        workspaceRoot: sessionWorkspaceRoot,
         workingDirectory: sessionWorkspaceRoot,
-        workingDirectorySource: "execution_envelope",
         tools: ["system.bash"],
         delegationSpec: expect.objectContaining({
           executionContext: expect.objectContaining({

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -290,6 +290,10 @@ import {
   isBackgroundRunStatusRequest,
   isBackgroundRunStopRequest,
 } from "./background-run-supervisor.js";
+import {
+  buildBackgroundRunWorkflowContext,
+  shouldPromoteImplementationBackgroundRun,
+} from "./background-run-workflow-context.js";
 import type { RuntimeFaultInjector } from "../eval/fault-injection.js";
 
 function firstSurfaceSummaryLine(value: unknown): string | undefined {
@@ -426,6 +430,19 @@ export {
   DEFAULT_GROK_MODEL,
   DEFAULT_GROK_FALLBACK_MODEL,
 } from "./llm-provider-manager.js";
+
+function effectiveHistoryForBackgroundRun(params: {
+  readonly history: readonly import("../llm/types.js").LLMMessage[];
+  readonly objective: string;
+}): readonly import("../llm/types.js").LLMMessage[] {
+  return [
+    ...params.history,
+    {
+      role: "user",
+      content: params.objective,
+    },
+  ];
+}
 
 // ============================================================================
 // Constants
@@ -2476,6 +2493,23 @@ export class DaemonManager {
             hookMetadata: { backgroundRunId: runId },
             shellProfile,
           }),
+        resolveExecutionContext: async ({
+          sessionId,
+          objective,
+        }) => {
+          const workspaceRoot =
+            typeof webChat.loadSessionWorkspaceRoot === "function"
+              ? await webChat.loadSessionWorkspaceRoot(sessionId)
+              : undefined;
+          return buildBackgroundRunWorkflowContext({
+            objective,
+            workspaceRoot:
+              typeof workspaceRoot === "string" &&
+              workspaceRoot.trim().length > 0
+                ? workspaceRoot.trim()
+                : undefined,
+          });
+        },
         buildToolRoutingDecision: (sessionId, content, _history, shellProfile) =>
           {
             const effectiveProfile = this.resolveEffectiveShellProfile({
@@ -7262,6 +7296,47 @@ export class DaemonManager {
       traceConfig,
       turnTraceId,
       workerManager: this._persistentWorkerManager,
+      maybeStartBackgroundRun: async ({
+        session,
+        objective,
+        effectiveHistory,
+      }) => {
+        if (
+          !this._backgroundRunSupervisor ||
+          !shouldPromoteImplementationBackgroundRun(objective)
+        ) {
+          return false;
+        }
+        const admission = this.evaluateBackgroundRunAdmission({
+          sessionId: msg.sessionId,
+          domain: "workspace",
+        });
+        if (!admission.allowed) {
+          await webChat.send({
+            sessionId: msg.sessionId,
+            content: formatBackgroundRunAdmissionDenied(admission.reason),
+          });
+          return true;
+        }
+        const shellProfile = this.resolveEffectiveShellProfile({
+          sessionId: msg.sessionId,
+          metadata: session.metadata ?? {},
+        });
+        await this._backgroundRunSupervisor.startRun({
+          sessionId: msg.sessionId,
+          objective,
+          options: {
+            seedHistory: [
+              ...effectiveHistoryForBackgroundRun({
+                history: effectiveHistory,
+                objective,
+              }),
+            ],
+            shellProfile,
+          },
+        });
+        return true;
+      },
     });
   }
 
@@ -7282,6 +7357,9 @@ export class DaemonManager {
     traceConfig: ResolvedTraceLoggingConfig;
     turnTraceId: string;
     workerManager?: PersistentWorkerManager | null;
+    maybeStartBackgroundRun?: Parameters<
+      typeof runWebChatConversationTurn
+    >[0]["maybeStartBackgroundRun"];
   }): Promise<ChatExecutorResult | undefined> {
     const {
       msg,
@@ -7300,6 +7378,7 @@ export class DaemonManager {
       traceConfig,
       turnTraceId,
       workerManager,
+      maybeStartBackgroundRun,
     } = params;
 
     this._activeSessionTraceIds.set(msg.sessionId, turnTraceId);
@@ -7359,6 +7438,7 @@ export class DaemonManager {
         },
         taskStore: this._taskTrackerStore,
         workerManager,
+        maybeStartBackgroundRun,
         onSubagentSynthesis: (result) => {
           if (
             this._subagentActivityTraceBySession.get(msg.sessionId) !== turnTraceId

--- a/runtime/src/llm/chat-executor-ctx-helpers.test.ts
+++ b/runtime/src/llm/chat-executor-ctx-helpers.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it, vi } from "vitest";
 
 import { ChatExecutor } from "./chat-executor.js";
 import type { ChatExecuteParams } from "./chat-executor.js";
+import { appendToolRecord } from "./chat-executor-ctx-helpers.js";
 import { createPromptEnvelope } from "./prompt-envelope.js";
+import { createRequestTaskProgressState } from "./request-task-progress.js";
 import type {
   LLMChatOptions,
   LLMMessage,
@@ -11,6 +13,7 @@ import type {
   StreamProgressCallback,
 } from "./types.js";
 import type { GatewayMessage } from "../gateway/message.js";
+import { createRuntimeContractSnapshot } from "../runtime-contract/types.js";
 
 // ============================================================================
 // Shared helpers
@@ -86,6 +89,51 @@ function createParams(
 // ============================================================================
 
 describe("ChatExecutor ctx-helpers behavior", () => {
+  describe("verifier invalidation after workspace mutation", () => {
+    it("clears stale verifier state after a successful file mutation", () => {
+      const ctx: any = {
+        allToolCalls: [],
+        failedToolCalls: 0,
+        verifierSnapshot: {
+          overall: "pass",
+          summary: "stale-pass",
+        },
+        runtimeContractSnapshot: createRuntimeContractSnapshot({
+          runtimeContractV2: true,
+          stopHooksEnabled: true,
+          asyncTasksEnabled: true,
+          persistentWorkersEnabled: true,
+          mailboxEnabled: true,
+          verifierRuntimeRequired: true,
+          verifierProjectBootstrap: false,
+          workerIsolationWorktree: false,
+          workerIsolationRemote: false,
+        }),
+        requestTaskState: createRequestTaskProgressState(),
+        completedRequestMilestoneIds: [],
+      };
+
+      appendToolRecord(ctx, {
+        name: "system.writeFile",
+        args: { path: "/tmp/workspace/src/main.c" },
+        result: safeJson({ ok: true }),
+        isError: false,
+        durationMs: 1,
+      });
+
+      expect(ctx.verifierSnapshot).toBeUndefined();
+      expect(ctx.runtimeContractSnapshot.verifier).toEqual({
+        attempted: false,
+        overall: "skipped",
+        summary: "invalidated_after_workspace_mutation",
+      });
+      expect(ctx.runtimeContractSnapshot.verifierStages.stageStatus).toBe(
+        "pending",
+      );
+      expect(ctx.runtimeContractSnapshot.verifierStages.skipReason).toBeUndefined();
+    });
+  });
+
   describe("tool loop stop reason and recovery hints", () => {
     it("does not hard-stop the loop just because the same tool call keeps failing", async () => {
       // Simulate the LLM calling desktop.bash with "mkdir" (no directory),

--- a/runtime/src/llm/chat-executor-ctx-helpers.ts
+++ b/runtime/src/llm/chat-executor-ctx-helpers.ts
@@ -30,6 +30,19 @@ import type {
 import type { LLMMessage } from "./types.js";
 import type { LLMPipelineStopReason } from "./policy.js";
 import type { PromptBudgetSection } from "./prompt-budget.js";
+import {
+  updateRuntimeContractVerifierStage,
+  updateRuntimeContractVerifierVerdict,
+} from "../runtime-contract/types.js";
+
+const VERIFIER_INVALIDATING_MUTATION_TOOLS = new Set([
+  "system.applyPatch",
+  "system.appendFile",
+  "system.editFile",
+  "system.move",
+  "system.writeFile",
+  "desktop.text_editor",
+]);
 
 /**
  * Push a tool call record onto the ctx's tool call ledger and
@@ -50,6 +63,29 @@ export function appendToolRecord(
   }
   if (didToolCallFail(record.isError, record.result)) {
     return undefined;
+  }
+  if (VERIFIER_INVALIDATING_MUTATION_TOOLS.has(record.name)) {
+    ctx.verifierSnapshot = undefined;
+    ctx.runtimeContractSnapshot = updateRuntimeContractVerifierVerdict({
+      snapshot: ctx.runtimeContractSnapshot,
+      verifier: {
+        attempted: false,
+        overall: "skipped",
+        summary: "invalidated_after_workspace_mutation",
+      },
+    });
+    const previousStage = ctx.runtimeContractSnapshot.verifierStages;
+    ctx.runtimeContractSnapshot = updateRuntimeContractVerifierStage({
+      snapshot: ctx.runtimeContractSnapshot,
+      verifierStages: {
+        ...previousStage,
+        stageStatus:
+          previousStage.runtimeRequired === true ? "pending" : "inactive",
+        ...(previousStage.runtimeRequired === true
+          ? { skipReason: undefined }
+          : { skipReason: previousStage.skipReason ?? "runtime_not_required" }),
+      },
+    });
   }
   const observation = observeRequestTaskToolRecord(ctx.requestTaskState, record);
   if (observation) {

--- a/runtime/src/llm/chat-executor-stop-gate.test.ts
+++ b/runtime/src/llm/chat-executor-stop-gate.test.ts
@@ -462,6 +462,41 @@ describe("evaluateTurnEndStopGate — narrated_future_tool_work", () => {
     expect(decision.blockingMessage).toContain("Next tool calls will");
   });
 
+  it("allows milestone checkpoints for strict workflow-owned implementation runs", () => {
+    const decision = evaluateTurnEndStopGate({
+      finalContent:
+        "M0 bootstrap is complete. Next I will implement M1 lexer support.",
+      allToolCalls: [
+        bashSuccess("mkdir -p src"),
+        bashSuccess("touch src/main.c"),
+      ],
+      requiredToolEvidence: {
+        completionContract: {
+          taskClass: "artifact_only",
+          placeholdersAllowed: false,
+          partialCompletionAllowed: false,
+          placeholderTaxonomy: "implementation",
+        },
+        verificationContract: {
+          requestCompletion: {
+            requiredMilestones: [
+              { id: "M0", description: "Bootstrap" },
+              { id: "M1", description: "Lexer" },
+            ],
+          },
+          completionContract: {
+            taskClass: "artifact_only",
+            placeholdersAllowed: false,
+            partialCompletionAllowed: false,
+            placeholderTaxonomy: "implementation",
+          },
+        },
+      },
+    });
+
+    expect(decision.shouldIntervene).toBe(false);
+  });
+
   it("fires on 'Now I will write the parser'", () => {
     // No success-claim prefix and length > TRUNCATED_SUCCESS_MAX_CHARS
     // so truncated_success_claim does not pre-empt narrated.

--- a/runtime/src/llm/chat-executor-stop-gate.ts
+++ b/runtime/src/llm/chat-executor-stop-gate.ts
@@ -275,6 +275,8 @@ export interface EvaluateTurnEndStopGateParams {
   readonly allToolCalls?: readonly ToolCallRecord[];
   /** Optional precomputed unresolved execution snapshot for stop-hook evaluation. */
   readonly snapshot?: TurnEndStopGateSnapshot;
+  readonly requiredToolEvidence?: ChatExecuteParams["requiredToolEvidence"];
+  readonly runtimeContext?: ChatExecuteParams["runtimeContext"];
 }
 
 export interface TurnEndStopGateSnapshot {
@@ -310,6 +312,20 @@ function looksLikeRefusal(record: ToolCallRecord): boolean {
 function truncate(text: string, max: number): string {
   if (text.length <= max) return text;
   return `${text.slice(0, max).trimEnd()}…`;
+}
+
+function shouldAllowWorkflowCheckpoint(params: {
+  readonly requiredToolEvidence?: ChatExecuteParams["requiredToolEvidence"];
+}): boolean {
+  const requestCompletion =
+    params.requiredToolEvidence?.verificationContract?.requestCompletion;
+  const completionContract =
+    params.requiredToolEvidence?.completionContract ??
+    params.requiredToolEvidence?.verificationContract?.completionContract;
+  return (
+    (requestCompletion?.requiredMilestones.length ?? 0) > 0 &&
+    completionContract?.partialCompletionAllowed === false
+  );
 }
 
 function summarizeFailedShellCall(record: ToolCallRecord): string {
@@ -855,6 +871,7 @@ export function evaluateTurnEndStopGate(
       failedShellCalls,
       refusedCalls,
       evidence,
+      requiredToolEvidence: params.requiredToolEvidence,
     });
   }
 
@@ -948,6 +965,7 @@ export function evaluateTurnEndStopGate(
     failedShellCalls,
     refusedCalls,
     evidence,
+    requiredToolEvidence: params.requiredToolEvidence,
   });
 }
 
@@ -1133,6 +1151,7 @@ function maybeFireNarratedFutureToolWork(params: {
   readonly failedShellCalls: readonly ToolCallRecord[];
   readonly refusedCalls: readonly ToolCallRecord[];
   readonly evidence: StopGateEvidence;
+  readonly requiredToolEvidence?: ChatExecuteParams["requiredToolEvidence"];
 }): StopGateInterventionDecision {
   const trimmed = params.finalContent.trimEnd();
   if (params.allToolCalls.length === 0) {
@@ -1144,6 +1163,13 @@ function maybeFireNarratedFutureToolWork(params: {
   const narrated = NARRATED_FUTURE_TOOL_WORK_RE.test(params.finalContent);
   const permissionQuestion = MID_TASK_PERMISSION_QUESTION_RE.test(trimmed);
   if (!narrated && !permissionQuestion) {
+    return { shouldIntervene: false, evidence: params.evidence };
+  }
+  if (
+    shouldAllowWorkflowCheckpoint({
+      requiredToolEvidence: params.requiredToolEvidence,
+    })
+  ) {
     return { shouldIntervene: false, evidence: params.evidence };
   }
   return {

--- a/runtime/src/llm/hooks/stop-hooks.ts
+++ b/runtime/src/llm/hooks/stop-hooks.ts
@@ -171,6 +171,10 @@ function buildBuiltinStopHookDefinitions(): readonly StopHookRuntimeDefinition[]
           snapshot:
             context.turnEndSnapshot ??
             buildTurnEndStopGateSnapshot(context.allToolCalls ?? []),
+          requiredToolEvidence: context.runtimeChecks?.requiredToolEvidence,
+          runtimeContext: {
+            workspaceRoot: context.runtimeWorkspaceRoot,
+          },
         });
         return {
           hookId: BUILTIN_TURN_END_STOP_GATE_ID,

--- a/runtime/src/workflow/completion-progress.test.ts
+++ b/runtime/src/workflow/completion-progress.test.ts
@@ -481,7 +481,7 @@ describe("completion-progress", () => {
     });
   });
 
-  it("keeps milestone telemetry without turning it into a completion requirement", () => {
+  it("downgrades strict workflow completion when required milestones remain", () => {
     const snapshot = deriveWorkflowProgressSnapshot({
       stopReason: "completed",
       completionState: "completed",
@@ -506,7 +506,7 @@ describe("completion-progress", () => {
     });
 
     expect(snapshot).toMatchObject({
-      completionState: "completed",
+      completionState: "partial",
       requiredRequirements: [],
       satisfiedRequirements: [],
       remainingRequirements: [],

--- a/runtime/src/workflow/completion-progress.ts
+++ b/runtime/src/workflow/completion-progress.ts
@@ -6,7 +6,6 @@ import {
   type WorkflowRequestMilestone,
 } from "./request-completion.js";
 import type {
-  PlannerVerificationSnapshot,
   WorkflowCompletionState,
 } from "./completion-state.js";
 import type { WorkflowVerificationContract } from "./verification-obligations.js";
@@ -71,7 +70,6 @@ export function deriveWorkflowProgressSnapshot(params: {
   readonly completedRequestMilestoneIds?: readonly string[];
   readonly updatedAt: number;
   readonly contractFingerprint?: string;
-  readonly verifier?: PlannerVerificationSnapshot;
 }): WorkflowProgressSnapshot | undefined {
   const mergedContract = mergeVerificationContract({
     verificationContract: params.verificationContract,
@@ -101,18 +99,26 @@ export function deriveWorkflowProgressSnapshot(params: {
   const satisfiedRequirements = new Set<WorkflowProgressRequirement>(
     reusableEvidence.map((entry) => entry.requirement),
   );
-  const remainingRequirements = [...requiredRequirements];
+  const remainingRequirements = [...requiredRequirements].filter(
+    (requirement) => !satisfiedRequirements.has(requirement),
+  );
+  const completionState = resolveDerivedCompletionState({
+    latest: params.completionState,
+    remainingRequirements,
+    remainingMilestones: requestCompletion?.remainingMilestones,
+    completionContract: mergedContract?.completionContract,
+  });
   if (
     !mergedContract &&
     reusableEvidence.length === 0 &&
     remainingRequirements.length === 0 &&
-    params.completionState === "completed"
+    completionState === "completed"
   ) {
     return undefined;
   }
 
   return {
-    completionState: params.completionState,
+    completionState,
     stopReason: params.stopReason,
     stopReasonDetail: params.stopReasonDetail,
     validationCode: params.validationCode,
@@ -329,7 +335,12 @@ function resolveMergedCompletionState(params: {
 }): WorkflowCompletionState {
   const latest = params.next.completionState;
   if (params.remainingRequirements.length === 0) {
-    return latest;
+    return resolveDerivedCompletionState({
+      latest,
+      remainingRequirements: params.remainingRequirements,
+      remainingMilestones: params.next.remainingMilestones,
+      completionContract: params.next.completionContract,
+    });
   }
   if (latest === "blocked") {
     return "blocked";
@@ -338,4 +349,21 @@ function resolveMergedCompletionState(params: {
     return params.previous?.completionState === "blocked" ? "blocked" : "partial";
   }
   return latest;
+}
+
+function resolveDerivedCompletionState(params: {
+  readonly latest: WorkflowCompletionState;
+  readonly remainingRequirements: readonly WorkflowProgressRequirement[];
+  readonly remainingMilestones?: readonly WorkflowRequestMilestone[];
+  readonly completionContract?: ImplementationCompletionContract;
+}): WorkflowCompletionState {
+  if (
+    params.latest === "completed" &&
+    params.completionContract?.partialCompletionAllowed === false &&
+    (params.remainingRequirements.length > 0 ||
+      (params.remainingMilestones?.length ?? 0) > 0)
+  ) {
+    return "partial";
+  }
+  return params.latest;
 }


### PR DESCRIPTION
## Summary
- promote explicit full-plan implementation requests into durable background workflow execution
- make milestone completion authoritative so strict workflow runs stay partial until required milestones are done
- allow milestone checkpoint summaries to continue workflow-owned runs and invalidate stale verifier state after later mutations

## Verification
- ./node_modules/.bin/tsc -p runtime/tsconfig.json --noEmit
- ./node_modules/.bin/vitest run runtime/src/gateway/daemon.test.ts runtime/src/gateway/daemon-webchat-turn.test.ts runtime/src/gateway/background-run-supervisor.test.ts
- ./node_modules/.bin/vitest run runtime/src/workflow/completion-progress.test.ts runtime/src/llm/chat-executor-stop-gate.test.ts runtime/src/llm/chat-executor-ctx-helpers.test.ts
- ./node_modules/.bin/vitest run runtime/src/llm/chat-executor-artifact-evidence.test.ts runtime/src/gateway/top-level-verifier.test.ts runtime/src/llm/chat-executor-request.test.ts
- npm run techdebt