### PR TITLE
fix(watch): separate final reply from transcript feed

### DIFF
--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -150,3 +150,10 @@
 - **What worked:** Promoting explicit full-plan implementation requests into durable workflow execution, making request milestones authoritative for strict runs, and allowing milestone checkpoint summaries to continue instead of tripping narrated-future-work made long implementation sessions persist progress instead of dying after the first honest checkpoint.
 - **What didn't:** The durable path needed wiring at multiple layers because request milestones were previously telemetry-only, background-run actor cycles were missing runtime evidence context, and stale verifier state could survive later mutations unless it was explicitly invalidated.
 - **Rule added to CLAUDE.md:** no
+
+## PR #400: fix(watch): separate final reply from transcript feed
+- **Date:** 2026-04-15
+- **Files changed:** `runtime/src/watch/{agenc-watch-event-store,agenc-watch-frame}.mjs`, `runtime/tests/watch/{agenc-watch-event-store,agenc-watch-frame}.test.mjs`, `runtime/tests/watch/fixtures/agenc-watch-live-replay.fixture.mjs`
+- **What worked:** Promoting the accepted agent reply to a canonical block while hiding ordinary agent rows from the scrolling transcript makes the cockpit read like a final answer plus supporting detail instead of a blended stream of provisional output and tool chatter.
+- **What didn't:** The frame logic needed coordinated changes to transcript slicing, hidden-line markers, export behavior, and replay fixtures, so the UI adjustment touched more than just the renderer and needed full watch-suite coverage to prove it stayed stable.
+- **Rule added to CLAUDE.md:** no

--- a/runtime/src/watch/agenc-watch-event-store.mjs
+++ b/runtime/src/watch/agenc-watch-event-store.mjs
@@ -237,6 +237,7 @@ export function createWatchEventStore(dependencies = {}) {
         body: normalized.body,
         bodyTruncated: normalized.bodyTruncated,
         renderMode: kind === "agent" ? "markdown" : undefined,
+        canonicalReply: kind === "agent",
       };
       preserveFullDetailBody(restoredEvent, normalized, entry?.content ?? "(empty)");
       events.push(restoredEvent);
@@ -341,6 +342,7 @@ export function createWatchEventStore(dependencies = {}) {
       result = pushEvent("agent", "Agent Reply", safeContent, "cyan", {
         renderMode: "markdown",
         streamState: "complete",
+        canonicalReply: true,
       });
       updateLatestAgentSummary(result);
     } else {
@@ -364,6 +366,7 @@ export function createWatchEventStore(dependencies = {}) {
       target.tone = "cyan";
       target.renderMode = "markdown";
       target.streamState = "complete";
+      target.canonicalReply = true;
       updateLatestAgentSummary(target);
       updateActivity(timestamp);
       result = target;

--- a/runtime/src/watch/agenc-watch-frame.mjs
+++ b/runtime/src/watch/agenc-watch-frame.mjs
@@ -137,7 +137,7 @@ export function createWatchFrameController(dependencies = {}) {
     renderPanel,
     row,
   });
-  const hiddenTranscriptKinds = new Set(["status"]);
+  const hiddenTranscriptKinds = new Set(["status", "agent"]);
   const transcriptBlockInset = "  ";
   const transcriptBodyInset = "    ";
   // Medium gray so the user-prompt rounded pill stands out clearly against
@@ -832,6 +832,55 @@ export function createWatchFrameController(dependencies = {}) {
     return rows;
   }
 
+  function storedEventBodyText(event) {
+    if (!event || typeof event !== "object") {
+      return "";
+    }
+    if (typeof event.detailBody === "string" && event.detailBody.length > 0) {
+      return event.detailBody;
+    }
+    return typeof event.body === "string" ? event.body : "";
+  }
+
+  function canonicalReplyRows(width) {
+    const replyEvent = currentCanonicalReplyEvent();
+    if (!replyEvent) {
+      return [];
+    }
+    const fullReplyLines = fullAgentTranscriptLines(replyEvent, width);
+    const previewLines = eventPreviewLines(replyEvent, Math.max(12, width - 4));
+    const previewSplit = splitTranscriptPreviewForHeadline(replyEvent, previewLines);
+    const headline = previewSplit.headline || eventHeadline(replyEvent, previewLines);
+    const replySplit =
+      fullReplyLines.length > 0
+        ? isTableDisplayMode(fullReplyLines[0]?.mode)
+          ? { headline, bodyLines: fullReplyLines }
+          : splitTranscriptPreviewForHeadline(replyEvent, fullReplyLines)
+        : previewSplit;
+    const rows = [
+      ...transcriptChatRows([replySplit.headline || headline], width, {
+        marker: "●",
+        markerTone: color.ink,
+        textTone: color.ink,
+      }),
+    ];
+    const bodyLines = fullReplyLines.length > 0 ? replySplit.bodyLines : previewSplit.bodyLines;
+    for (const line of bodyLines) {
+      const plain = sanitizeDisplayText(
+        typeof line === "string" ? line : displayLinePlainText(line),
+      );
+      if (plain.length === 0) {
+        rows.push(fitAnsi(transcriptBodyInset, width));
+        continue;
+      }
+      rows.push(fitAnsi(renderEventBodyLine(replyEvent, line, {
+        inline: true,
+        prefix: transcriptBodyInset,
+      }), width));
+    }
+    return rows;
+  }
+
   function activePlanEntries(limit = 10) {
     return [...subagentPlanSteps.values()]
       .sort((left, right) => left.order - right.order)
@@ -883,8 +932,28 @@ export function createWatchFrameController(dependencies = {}) {
     );
   }
 
+  function currentCanonicalReplyEvent() {
+    for (let index = events.length - 1; index >= 0; index -= 1) {
+      const candidate = events[index];
+      if (!candidate || candidate.kind !== "agent") {
+        continue;
+      }
+      if (candidate.canonicalReply === true) {
+        return candidate;
+      }
+    }
+    for (let index = events.length - 1; index >= 0; index -= 1) {
+      const candidate = events[index];
+      if (candidate?.kind === "agent") {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
   function shouldShowIdleTranscript() {
-    return visibleTranscriptEvents().length === 0 &&
+    return !currentCanonicalReplyEvent() &&
+      visibleTranscriptEvents().length === 0 &&
       sanitizeInlineText(currentInputValue(), "").length === 0;
   }
 
@@ -2986,17 +3055,40 @@ export function createWatchFrameController(dependencies = {}) {
   }
 
   function activityPanelLines(width, targetHeight) {
+    const replyRows = canonicalReplyRows(width);
     const transcriptView = flattenTranscriptView(width);
+    const hasTranscript = transcriptView.rows.length > 0;
+    const reservedTranscriptRows = hasTranscript
+      ? Math.min(Math.max(1, transcriptView.rows.length), Math.max(0, Math.min(1, targetHeight - 1)))
+      : 0;
+    const availableReplyRows = replyRows.length > 0
+      ? Math.max(0, targetHeight - (hasTranscript ? reservedTranscriptRows + 1 : 0))
+      : 0;
+    const visibleReplyRows = availableReplyRows > 0
+      ? replyRows.slice(0, availableReplyRows)
+      : [];
+    const transcriptTargetHeight = Math.max(
+      0,
+      targetHeight - visibleReplyRows.length - (visibleReplyRows.length > 0 && hasTranscript ? 1 : 0),
+    );
     const sliced = sliceViewportRowsFromBottom(
       transcriptView.rows,
-      targetHeight,
+      transcriptTargetHeight,
       watchState.transcriptScrollOffset,
     );
     watchState.transcriptScrollOffset = sliced.normalizedOffset;
+    const lines = [...visibleReplyRows];
+    if (visibleReplyRows.length > 0 && sliced.rows.length > 0) {
+      lines.push(blankRow(width));
+    }
+    lines.push(...sliced.rows);
     return {
-      lines: [...sliced.rows],
+      lines,
       hiddenAbove: sliced.hiddenAbove,
       hiddenBelow: sliced.hiddenBelow,
+      transcriptStartIndex: visibleReplyRows.length > 0 && sliced.rows.length > 0
+        ? visibleReplyRows.length + 1
+        : visibleReplyRows.length,
     };
   }
 
@@ -3216,13 +3308,26 @@ export function createWatchFrameController(dependencies = {}) {
       ].filter(Boolean).join("\n\n").trim();
     }
 
-    return events
-      .map((event) => [
-        `[${event.timestamp}] ${sanitizeDisplayText(event.title)}`,
-        event.body,
-      ].join("\n"))
-      .join("\n\n")
-      .trim();
+    const sections = [];
+    const replyEvent = currentCanonicalReplyEvent();
+    if (replyEvent) {
+      sections.push(
+        [
+          `[${replyEvent.timestamp}] ${sanitizeDisplayText(replyEvent.title)}`,
+          storedEventBodyText(replyEvent),
+        ].join("\n"),
+      );
+    }
+
+    sections.push(
+      ...visibleTranscriptEvents()
+        .map((event) => [
+          `[${event.timestamp}] ${sanitizeDisplayText(event.title)}`,
+          storedEventBodyText(event),
+        ].join("\n"))
+        .filter((block) => block.trim().length > 0),
+    );
+    return sections.join("\n\n").trim();
   }
 
   function exportViewText(text, mode = watchState.expandedEventId ? "detail" : "transcript") {
@@ -3583,10 +3688,23 @@ export function createWatchFrameController(dependencies = {}) {
         : activityPanelLines(transcriptWidth, transcriptHeight);
       diffNavigation = transcriptView.diffNavigation ?? null;
       const transcriptLines = [...transcriptView.lines];
+      const transcriptStartIndex = Math.max(
+        0,
+        Math.min(
+          transcriptLines.length - 1,
+          Number.isFinite(Number(transcriptView.transcriptStartIndex))
+            ? Number(transcriptView.transcriptStartIndex)
+            : 0,
+        ),
+      );
       if (!watchState.expandedEventId && transcriptLines.length > 0) {
         if (transcriptView.hiddenAbove > 0) {
           const aboveText = `${color.fog}▲ ${transcriptView.hiddenAbove} more line${transcriptView.hiddenAbove === 1 ? "" : "s"} above${color.reset}`;
-          transcriptLines[0] = paintSurface(aboveText, transcriptWidth, color.panelBg);
+          transcriptLines[transcriptStartIndex] = paintSurface(
+            aboveText,
+            transcriptWidth,
+            color.panelBg,
+          );
         }
         if (transcriptView.hiddenBelow > 0) {
           const belowText = `${color.fog}▼ ${transcriptView.hiddenBelow} more line${transcriptView.hiddenBelow === 1 ? "" : "s"} below${color.reset}`;

--- a/runtime/tests/watch/agenc-watch-event-store.test.mjs
+++ b/runtime/tests/watch/agenc-watch-event-store.test.mjs
@@ -92,6 +92,7 @@ test("event store streams and commits agent replies with summary side effects", 
   assert.equal(events[0].title, "Agent Reply");
   assert.equal(events[0].streamState, "complete");
   assert.equal(events[0].body, "hello world");
+  assert.equal(events[0].canonicalReply, true);
   assert.equal(watchState.agentStreamingText, null);
   assert.equal(watchState.agentStreamingPreview, null);
   assert.equal(watchState.latestAgentSummary, "hello world");
@@ -110,6 +111,7 @@ test("event store restores transcript history and clears stale expanded selectio
   assert.equal(events.length, 2);
   assert.equal(events[0].title, "Prompt");
   assert.equal(events[1].renderMode, "markdown");
+  assert.equal(events[1].canonicalReply, true);
   assert.equal(events[1].timestamp, "history:2026-03-14T00:00:01.000Z");
   assert.equal(watchState.transcriptScrollOffset, 0);
   assert.equal(watchState.detailScrollOffset, 0);

--- a/runtime/tests/watch/agenc-watch-frame.test.mjs
+++ b/runtime/tests/watch/agenc-watch-frame.test.mjs
@@ -881,12 +881,12 @@ test("frame controller renders user transcript rows as shaded blocks without div
     new RegExp(`\\x1b\\[48;5;238m\\s+<soft>otra linea<reset>`),
   );
 
-  const assistantRow = lines.findIndex((line, index) =>
-    index > firstUserRow && line.includes("respuesta corta")
-  );
+  const assistantRow = lines.findIndex((line) => line.includes("respuesta corta"));
   assert.notEqual(assistantRow, -1);
+  const betweenStart = Math.min(firstUserRow, assistantRow) + 1;
+  const betweenEnd = Math.max(firstUserRow, assistantRow);
   assert.equal(
-    lines.slice(firstUserRow + 2, assistantRow).some((line) => /^─+$/.test(line)),
+    lines.slice(betweenStart, betweenEnd).some((line) => /^─+$/.test(line)),
     false,
   );
 });

--- a/runtime/tests/watch/fixtures/agenc-watch-live-replay.fixture.mjs
+++ b/runtime/tests/watch/fixtures/agenc-watch-live-replay.fixture.mjs
@@ -108,17 +108,18 @@ export const WATCH_LIVE_REPLAY_FIXTURES = Object.freeze({
           runPhase: "queued",
           latestTool: null,
           latestToolState: null,
-          eventCount: 3,
+          eventCount: 2,
           expandedEventId: null,
         },
         frameExpectation: {
           containsInOrder: [
             "AgenC",
             "show me a linked list in c",
-            "● Linked List in C",
-            "code · c",
-            "#include <stdio.h>",
             "\n>",
+          ],
+          notContains: [
+            "● Linked List in C",
+            "#include <stdio.h>",
           ],
         },
       },


### PR DESCRIPTION
## Summary
- render the accepted final agent reply as a canonical block instead of as another transcript row
- keep the transcript/detail feed focused on tools and operator context below the accepted reply
- update watch tests and replay fixtures to match the canonical reply display model

## Verification
- node --test runtime/tests/watch/agenc-watch-event-store.test.mjs runtime/tests/watch/agenc-watch-frame.test.mjs runtime/tests/watch/agenc-watch-frame-snapshot.test.mjs runtime/tests/watch/agenc-watch-surface-dispatch.test.mjs runtime/tests/watch/agenc-watch-live-replay.test.mjs