### PR TITLE
feat(llm): add openai-compat provider for locally-hosted LLMs

### DIFF
--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -376,7 +376,7 @@ catalog: the server's `GET /v1/models` response is the authoritative source of t
 ```
 
 **Notes:**
-- `contextWindowTokens` is required — local servers do not expose context window size via API. Set this to match the model's actual context window (e.g. 32768 for Gemma 4 26B).
+- `contextWindowTokens` is required — local servers do not expose context window size via API. The AgenC system prompt alone requires more than 14K tokens, so 32768 is the recommended minimum. Values below 16384 will likely cause failures before the user sends a single message.
 - `apiKey` is passed in the `Authorization` header but is not validated by local servers. Any non-empty string works.
 - When running untrusted models, set `workspace.hostPath` to a neutral directory to prevent autonomous file access during initial context loading.
 - LM Studio: set the context window in the model settings to match `contextWindowTokens`. The LM Studio default of 4096 is too small for most system prompts.

--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -63,6 +63,7 @@ const program = createProgram(provider);
 | `llm/grok/` | `GrokProvider` | xAI Grok adapter (via `openai` SDK) | `GrokProviderConfig` |
 | `llm/anthropic/` | `AnthropicProvider` | Anthropic adapter | `AnthropicProviderConfig` |
 | `llm/ollama/` | `OllamaProvider` | Ollama local adapter | `OllamaProviderConfig` |
+| `llm/openai-compat/` | `OpenAICompatProvider` | OpenAI-compatible local adapter (LM Studio, llama.cpp, vLLM) | `OpenAICompatProviderConfig` |
 | `tools/` | `ToolRegistry` | MCP-compatible tool management | `ToolRegistryConfig` |
 | `memory/` | `InMemoryBackend` | Zero-dep memory storage | `InMemoryBackendConfig` |
 | `memory/sqlite/` | `SqliteBackend` | SQLite-backed storage | `SqliteBackendConfig` |
@@ -116,6 +117,16 @@ const anthropic = new AnthropicProvider({ apiKey: '...', model: 'claude-sonnet-4
 
 // Ollama (requires: npm install ollama + local Ollama server)
 const ollama = new OllamaProvider({ model: 'llama3', tools });
+
+// OpenAI-compatible local server (LM Studio, llama.cpp, vLLM)
+// baseUrl is validated on startup to be a local/LAN address
+const local = new OpenAICompatProvider({
+  model: 'google_gemma-4-26b-a4b-it',
+  baseUrl: 'http://127.0.0.1:1234/v1',
+  apiKey: 'local',             // not validated by local servers
+  contextWindowTokens: 32768,  // required — local servers don't expose this
+  tools,
+});
 ```
 
 All providers implement `LLMProvider`: `chat()`, `chatStream()`, `healthCheck()`.
@@ -335,8 +346,41 @@ Provider-specific additions:
 - **GrokProviderConfig**: `apiKey` (required), `baseURL`, `webSearch`, `searchMode`
 - **AnthropicProviderConfig**: `apiKey` (required)
 - **OllamaProviderConfig**: `baseURL` (default: `http://localhost:11434`)
+- **OpenAICompatProviderConfig**: `baseUrl` (required, must be local/LAN), `apiKey` (required, any string), `contextWindowTokens` (required)
 
 When `GrokProviderConfig.webSearch=true`, the runtime can route provider-native `web_search` into Grok Responses calls without exposing a client-executed tool in the gateway registry. `searchMode="auto"` prefers `web_search` for research/docs/reference comparisons while preserving browser MCP tools for interactive validation; delegated research evidence can be satisfied by provider citations surfaced as `providerEvidence.citations`. This path is model-gated: unsupported Grok models such as `grok-code-fast-1` must suppress `web_search` even when the config flag is set.
+
+### Local Inference (openai-compat)
+
+Use `openai-compat` for any server that exposes the OpenAI `/v1/chat/completions`
+interface locally — LM Studio, llama.cpp server, vLLM, or any compatible runner.
+This provider does **not** require xAI credentials and does not enforce a model
+catalog: the server's `GET /v1/models` response is the authoritative source of truth.
+
+**Startup validation** runs three checks before the provider is returned:
+1. `baseUrl` resolves to a local or LAN address (`127.x`, `10.x`, `192.168.x`, `172.16-31.x`, `localhost`)
+2. `GET {baseUrl}/models` is reachable within 5 seconds
+3. The configured `model` appears in the `/v1/models` response
+
+```json
+{
+  "llm": {
+    "provider": "openai-compat",
+    "model": "google_gemma-4-26b-a4b-it",
+    "baseUrl": "http://127.0.0.1:1234/v1",
+    "apiKey": "local",
+    "contextWindowTokens": 32768,
+    "maxTokens": 4096
+  }
+}
+```
+
+**Notes:**
+- `contextWindowTokens` is required — local servers do not expose context window size via API. Set this to match the model's actual context window (e.g. 32768 for Gemma 4 26B).
+- `apiKey` is passed in the `Authorization` header but is not validated by local servers. Any non-empty string works.
+- When running untrusted models, set `workspace.hostPath` to a neutral directory to prevent autonomous file access during initial context loading.
+- LM Studio: set the context window in the model settings to match `contextWindowTokens`. The LM Studio default of 4096 is too small for most system prompts.
+- Use `provider: "ollama"` instead when using Ollama with its native SDK; `openai-compat` is the right choice when Ollama is running in OpenAI-compatibility mode or when using LM Studio / llama.cpp.
 
 ### LLMTaskExecutorConfig
 

--- a/runtime/src/gateway/llm-provider-manager.ts
+++ b/runtime/src/gateway/llm-provider-manager.ts
@@ -408,7 +408,7 @@ export async function createSingleLLMProvider(
         model: model ?? "local-model",
         contextWindowTokens: normalizeOptionalPositiveInt(
           llmConfig.contextWindowTokens,
-        ) ?? 4096,
+        ) ?? 32768, // AgenC system prompt requires >14K tokens; 4096 is too small
         timeoutMs,
         maxTokens: normalizeOptionalPositiveInt(maxTokens),
         tools,

--- a/runtime/src/gateway/llm-provider-manager.ts
+++ b/runtime/src/gateway/llm-provider-manager.ts
@@ -232,7 +232,7 @@ function findConfiguredLlmConfigForProvider(
 
   const providerName = profile?.provider ?? provider.name;
   const normalizedProvider = providerName.toLowerCase();
-  if (normalizedProvider !== "grok" && normalizedProvider !== "ollama") {
+  if (normalizedProvider !== "grok" && normalizedProvider !== "ollama" && normalizedProvider !== "openai-compat") {
     return primaryLlmConfig;
   }
 
@@ -395,6 +395,22 @@ export async function createSingleLLMProvider(
         timeoutMs,
         maxTokens: normalizeOptionalPositiveInt(maxTokens),
         numCtx: normalizeOptionalPositiveInt(llmConfig.contextWindowTokens),
+        tools,
+      });
+    }
+    case "openai-compat": {
+      const { OpenAICompatProvider } = await import(
+        "../llm/openai-compat/adapter.js"
+      );
+      return new OpenAICompatProvider({
+        baseUrl: baseUrl ?? "http://127.0.0.1:1234/v1",
+        apiKey: apiKey ?? "local",
+        model: model ?? "local-model",
+        contextWindowTokens: normalizeOptionalPositiveInt(
+          llmConfig.contextWindowTokens,
+        ) ?? 4096,
+        timeoutMs,
+        maxTokens: normalizeOptionalPositiveInt(maxTokens),
         tools,
       });
     }

--- a/runtime/src/gateway/types.ts
+++ b/runtime/src/gateway/types.ts
@@ -21,7 +21,7 @@ import type { UserHooksSettings } from "../llm/hooks/user-config.js";
 // ============================================================================
 
 export interface GatewayLLMConfig extends LLMXaiCapabilitySurface {
-  provider: "grok" | "ollama";
+  provider: "grok" | "ollama" | "openai-compat";
   apiKey?: string;
   model?: string;
   baseUrl?: string;

--- a/runtime/src/llm/openai-compat/adapter.live.test.ts
+++ b/runtime/src/llm/openai-compat/adapter.live.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { OpenAICompatProvider } from "./adapter.js";
+
+/**
+ * Live server tests for OpenAICompatProvider.
+ *
+ * Kept in a separate file from adapter.test.ts so that the vi.mock("openai")
+ * hoisted in adapter.test.ts does not replace the real OpenAI SDK here.
+ * The mock would cause all chat completion calls to hit mockCreate instead
+ * of the real HTTP client, producing a 500 from the mock rather than a
+ * real response from the server.
+ *
+ * Run with:
+ *   OPENAI_COMPAT_BASE_URL=http://127.0.0.1:1234/v1 \
+ *   OPENAI_COMPAT_MODEL=google_gemma-4-26b-a4b-it \
+ *   npm run test --workspace=@tetsuo-ai/runtime -- \
+ *     src/llm/openai-compat/adapter.live.test.ts
+ */
+
+const hasLiveServer =
+  !!process.env.OPENAI_COMPAT_BASE_URL && !!process.env.OPENAI_COMPAT_MODEL;
+
+describe.skipIf(!hasLiveServer)("OpenAICompatProvider — live server", () => {
+  function makeProvider() {
+    return new OpenAICompatProvider({
+      model: process.env.OPENAI_COMPAT_MODEL!,
+      baseUrl: process.env.OPENAI_COMPAT_BASE_URL!,
+      apiKey: "local",
+      contextWindowTokens: 32768,
+    } as any);
+  }
+
+  it("basic round-trip returns a non-empty content string", async () => {
+    const provider = makeProvider();
+    const result = await provider.chat([
+      { role: "user", content: "Say 'pong' and nothing else." },
+    ]);
+    expect(typeof result.content).toBe("string");
+    expect(result.content.length).toBeGreaterThan(0);
+  });
+
+  it("chatStream: streams chunks and assembles full content", async () => {
+    const provider = makeProvider();
+    const chunks: string[] = [];
+    const result = await provider.chatStream(
+      [{ role: "user", content: "Count to three." }],
+      (chunk) => {
+        if (chunk.content) chunks.push(chunk.content);
+      },
+    );
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(result.content).toBe(chunks.join(""));
+  });
+});

--- a/runtime/src/llm/openai-compat/adapter.test.ts
+++ b/runtime/src/llm/openai-compat/adapter.test.ts
@@ -563,33 +563,3 @@ describe("OpenAICompatProvider", () => {
     });
   });
 });
-
-// ---------------------------------------------------------------------------
-// live server gate (skipped unless OPENAI_COMPAT_BASE_URL is set)
-// ---------------------------------------------------------------------------
-
-const hasLiveServer =
-  !!process.env.OPENAI_COMPAT_BASE_URL && !!process.env.OPENAI_COMPAT_MODEL;
-
-describe.skipIf(!hasLiveServer)("live server", () => {
-  it("basic round-trip returns a non-empty content string", async () => {
-    const { validateOpenAICompatConfig: real } = await vi.importActual<
-      typeof import("./openai-compat-filter.js")
-    >("./openai-compat-filter.js");
-    vi.mocked(
-      (await import("./openai-compat-filter.js")).validateOpenAICompatConfig,
-    ).mockImplementationOnce(real);
-
-    const provider = new OpenAICompatProvider({
-      model: process.env.OPENAI_COMPAT_MODEL!,
-      baseUrl: process.env.OPENAI_COMPAT_BASE_URL!,
-      apiKey: "local",
-      contextWindowTokens: 32768,
-    } as any);
-    const result = await provider.chat([
-      { role: "user", content: "Say 'pong' and nothing else." },
-    ]);
-    expect(typeof result.content).toBe("string");
-    expect(result.content.length).toBeGreaterThan(0);
-  });
-});

--- a/runtime/src/llm/openai-compat/adapter.test.ts
+++ b/runtime/src/llm/openai-compat/adapter.test.ts
@@ -501,30 +501,6 @@ describe("OpenAICompatProvider", () => {
   });
 
   // -------------------------------------------------------------------------
-  // getCapabilities()
-  // -------------------------------------------------------------------------
-
-  describe("getCapabilities()", () => {
-    it("reports provider name as 'openai-compat'", () => {
-      expect(makeProvider().getCapabilities().provider).toBe("openai-compat");
-    });
-
-    it("reports all stateful capabilities as false", () => {
-      const caps = makeProvider().getCapabilities();
-      expect(caps.stateful.assistantPhase).toBe(false);
-      expect(caps.stateful.previousResponseId).toBe(false);
-      expect(caps.stateful.encryptedReasoning).toBe(false);
-      expect(caps.stateful.storedResponseRetrieval).toBe(false);
-      expect(caps.stateful.storedResponseDeletion).toBe(false);
-      expect(caps.stateful.opaqueCompaction).toBe(false);
-    });
-
-    it("reports deterministicFallback as true", () => {
-      expect(makeProvider().getCapabilities().stateful.deterministicFallback).toBe(true);
-    });
-  });
-
-  // -------------------------------------------------------------------------
   // getExecutionProfile()
   // -------------------------------------------------------------------------
 

--- a/runtime/src/llm/openai-compat/adapter.test.ts
+++ b/runtime/src/llm/openai-compat/adapter.test.ts
@@ -1,0 +1,595 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { LLMMessage, LLMTool } from "../types.js";
+import {
+  LLMAuthenticationError,
+  LLMProviderError,
+  LLMServerError,
+  LLMTimeoutError,
+} from "../errors.js";
+
+// ---------------------------------------------------------------------------
+// Mock setup — must appear before the import of adapter.js so Vitest's mock
+// hoisting applies. The openai mock prevents any real HTTP client from being
+// constructed; the filter mock prevents startup network calls.
+// ---------------------------------------------------------------------------
+
+const mockCreate = vi.fn();
+const mockModelsList = vi.fn();
+
+vi.mock("openai", () => ({
+  OpenAI: class MockOpenAI {
+    chat = { completions: { create: mockCreate } };
+    models = { list: mockModelsList };
+    constructor(_opts: any) {}
+  },
+}));
+
+vi.mock("./openai-compat-filter.js", () => ({
+  validateOpenAICompatConfig: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { OpenAICompatProvider } from "./adapter.js";
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function makeProvider(
+  overrides: Record<string, unknown> = {},
+): OpenAICompatProvider {
+  return new OpenAICompatProvider({
+    model: "test-model",
+    baseUrl: "http://127.0.0.1:1234/v1",
+    apiKey: "local",
+    contextWindowTokens: 4096,
+    ...overrides,
+  } as any);
+}
+
+function makeTool(name: string): LLMTool {
+  return {
+    type: "function",
+    function: {
+      name,
+      description: `Tool ${name}`,
+      parameters: { type: "object", properties: {} },
+    },
+  };
+}
+
+function makeChatResponse(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    choices: [
+      {
+        message: { role: "assistant", content: "Hello!", tool_calls: null },
+        finish_reason: "stop",
+      },
+    ],
+    usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    model: "test-model",
+    ...overrides,
+  };
+}
+
+function makeToolCallResponse(
+  toolName: string,
+  argsJson: string,
+): unknown {
+  return {
+    choices: [
+      {
+        message: {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "server-call-id-1",
+              type: "function",
+              function: { name: toolName, arguments: argsJson },
+            },
+          ],
+        },
+        finish_reason: "tool_calls",
+      },
+    ],
+    usage: { prompt_tokens: 20, completion_tokens: 8, total_tokens: 28 },
+    model: "test-model",
+  };
+}
+
+const USER_MESSAGE: LLMMessage = { role: "user", content: "Hello" };
+
+// ---------------------------------------------------------------------------
+// OpenAICompatProvider
+// ---------------------------------------------------------------------------
+
+describe("OpenAICompatProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // chat() — basic response shape
+  // -------------------------------------------------------------------------
+
+  describe("chat() — basic response", () => {
+    it("sends messages in OpenAI chat format (role + content)", async () => {
+      mockCreate.mockResolvedValueOnce(makeChatResponse());
+      const provider = makeProvider();
+      await provider.chat([USER_MESSAGE]);
+
+      const params = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+      const messages = params.messages as Array<{ role: string; content: string }>;
+      expect(messages).toEqual([{ role: "user", content: "Hello" }]);
+    });
+
+    it("sets model from config in request params", async () => {
+      mockCreate.mockResolvedValueOnce(makeChatResponse());
+      const provider = makeProvider({ model: "my-local-model" });
+      await provider.chat([USER_MESSAGE]);
+
+      const params = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+      expect(params.model).toBe("my-local-model");
+    });
+
+    it("returns finishReason 'stop' when no tool calls", async () => {
+      mockCreate.mockResolvedValueOnce(makeChatResponse());
+      const provider = makeProvider();
+      const result = await provider.chat([USER_MESSAGE]);
+      expect(result.finishReason).toBe("stop");
+    });
+
+    it("returns content from the response message", async () => {
+      mockCreate.mockResolvedValueOnce(
+        makeChatResponse({ choices: [{ message: { role: "assistant", content: "World!", tool_calls: null }, finish_reason: "stop" }] }),
+      );
+      const provider = makeProvider();
+      const result = await provider.chat([USER_MESSAGE]);
+      expect(result.content).toBe("World!");
+    });
+
+    it("maps usage fields correctly", async () => {
+      mockCreate.mockResolvedValueOnce(makeChatResponse());
+      const provider = makeProvider();
+      const result = await provider.chat([USER_MESSAGE]);
+      expect(result.usage).toEqual({
+        promptTokens: 10,
+        completionTokens: 5,
+        totalTokens: 15,
+      });
+    });
+
+    it("reports model from response", async () => {
+      mockCreate.mockResolvedValueOnce(
+        makeChatResponse({ model: "server-reported-model" }),
+      );
+      const provider = makeProvider();
+      const result = await provider.chat([USER_MESSAGE]);
+      expect(result.model).toBe("server-reported-model");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // chat() — tool calls
+  // -------------------------------------------------------------------------
+
+  describe("chat() — tool calls", () => {
+    it("returns finishReason 'tool_calls' when tool calls are present", async () => {
+      mockCreate.mockResolvedValueOnce(
+        makeToolCallResponse("bash", '{"cmd":"ls"}'),
+      );
+      const provider = makeProvider({ tools: [makeTool("bash")] });
+      const result = await provider.chat([USER_MESSAGE]);
+      expect(result.finishReason).toBe("tool_calls");
+    });
+
+    it("parses tool call name and arguments from response", async () => {
+      mockCreate.mockResolvedValueOnce(
+        makeToolCallResponse("bash", '{"cmd":"echo hi"}'),
+      );
+      const provider = makeProvider({ tools: [makeTool("bash")] });
+      const result = await provider.chat([USER_MESSAGE]);
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0].name).toBe("bash");
+      expect(result.toolCalls[0].arguments).toBe('{"cmd":"echo hi"}');
+    });
+
+    it("assigns UUID IDs to tool calls — never the server-provided id", async () => {
+      mockCreate.mockResolvedValueOnce(
+        makeToolCallResponse("bash", "{}"),
+      );
+      const provider = makeProvider({ tools: [makeTool("bash")] });
+      const result = await provider.chat([USER_MESSAGE]);
+      expect(result.toolCalls[0].id).not.toBe("server-call-id-1");
+      expect(result.toolCalls[0].id).toMatch(UUID_RE);
+    });
+
+    it("assigns unique UUID IDs when the same tool is called twice in one turn", async () => {
+      mockCreate.mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              role: "assistant",
+              content: null,
+              tool_calls: [
+                { id: "s1", type: "function", function: { name: "bash", arguments: '{"cmd":"a"}' } },
+                { id: "s2", type: "function", function: { name: "bash", arguments: '{"cmd":"b"}' } },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+        model: "test-model",
+      });
+      const provider = makeProvider({ tools: [makeTool("bash")] });
+      const result = await provider.chat([USER_MESSAGE]);
+      expect(result.toolCalls).toHaveLength(2);
+      expect(result.toolCalls[0].id).toMatch(UUID_RE);
+      expect(result.toolCalls[1].id).toMatch(UUID_RE);
+      expect(result.toolCalls[0].id).not.toBe(result.toolCalls[1].id);
+    });
+
+    it("includes tools array in request params when provider has tools", async () => {
+      mockCreate.mockResolvedValueOnce(makeChatResponse());
+      const tool = makeTool("bash");
+      const provider = makeProvider({ tools: [tool] });
+      await provider.chat([USER_MESSAGE]);
+
+      const params = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+      expect(Array.isArray(params.tools)).toBe(true);
+      expect((params.tools as LLMTool[])[0].function.name).toBe("bash");
+    });
+
+    it("does not include tools in params when provider has no tools", async () => {
+      mockCreate.mockResolvedValueOnce(makeChatResponse());
+      const provider = makeProvider();
+      await provider.chat([USER_MESSAGE]);
+
+      const params = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+      expect(params.tools).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // chat() — tool routing strategies
+  // -------------------------------------------------------------------------
+
+  describe("chat() — tool routing", () => {
+    const catalogTools = [makeTool("bash"), makeTool("read_file"), makeTool("write_file")];
+
+    it("all_tools_no_filter: sends all tools when allowedToolNames is undefined", async () => {
+      mockCreate.mockResolvedValueOnce(makeChatResponse());
+      const provider = makeProvider({ tools: catalogTools });
+      await provider.chat([USER_MESSAGE]);
+
+      const params = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+      expect((params.tools as LLMTool[]).map((t) => t.function.name)).toEqual([
+        "bash",
+        "read_file",
+        "write_file",
+      ]);
+    });
+
+    it("all_tools_empty_filter: sends empty tools array when allowedToolNames is []", async () => {
+      mockCreate.mockResolvedValueOnce(makeChatResponse());
+      const provider = makeProvider({ tools: catalogTools });
+      await provider.chat([USER_MESSAGE], {
+        toolRouting: { allowedToolNames: [] },
+      });
+
+      const params = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+      expect(params.tools).toEqual([]);
+    });
+
+    it("subset_exact: sends only the requested tools when all names match", async () => {
+      mockCreate.mockResolvedValueOnce(makeChatResponse());
+      const provider = makeProvider({ tools: catalogTools });
+      await provider.chat([USER_MESSAGE], {
+        toolRouting: { allowedToolNames: ["bash", "read_file"] },
+      });
+
+      const params = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+      expect((params.tools as LLMTool[]).map((t) => t.function.name)).toEqual([
+        "bash",
+        "read_file",
+      ]);
+    });
+
+    it("subset_partial: sends resolved tools when some requested names are missing from catalog", async () => {
+      mockCreate.mockResolvedValueOnce(makeChatResponse());
+      const provider = makeProvider({ tools: catalogTools });
+      await provider.chat([USER_MESSAGE], {
+        toolRouting: { allowedToolNames: ["bash", "nonexistent_tool"] },
+      });
+
+      const params = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+      expect((params.tools as LLMTool[]).map((t) => t.function.name)).toEqual([
+        "bash",
+      ]);
+    });
+
+    it("subset_no_resolved_matches: sends empty tools array when no requested names match catalog", async () => {
+      mockCreate.mockResolvedValueOnce(makeChatResponse());
+      const provider = makeProvider({ tools: catalogTools });
+      await provider.chat([USER_MESSAGE], {
+        toolRouting: { allowedToolNames: ["nonexistent_a", "nonexistent_b"] },
+      });
+
+      const params = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+      expect(params.tools).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // chat() — error mapping
+  // -------------------------------------------------------------------------
+
+  describe("chat() — error mapping", () => {
+    it("ECONNREFUSED → LLMProviderError", async () => {
+      const err = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:1234"), {
+        code: "ECONNREFUSED",
+      });
+      mockCreate.mockRejectedValue(err);
+      await expect(makeProvider().chat([USER_MESSAGE])).rejects.toThrow(LLMProviderError);
+    });
+
+    it("ECONNREFUSED error message includes the server URL", async () => {
+      const err = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:1234"), {
+        code: "ECONNREFUSED",
+      });
+      mockCreate.mockRejectedValue(err);
+      await expect(makeProvider().chat([USER_MESSAGE])).rejects.toThrow(
+        "127.0.0.1:1234",
+      );
+    });
+
+    it("AbortError → LLMTimeoutError", async () => {
+      const err = Object.assign(new Error("The operation was aborted"), {
+        name: "AbortError",
+      });
+      mockCreate.mockRejectedValue(err);
+      await expect(makeProvider().chat([USER_MESSAGE])).rejects.toThrow(
+        LLMTimeoutError,
+      );
+    });
+
+    it("HTTP 401 → LLMAuthenticationError", async () => {
+      const err = Object.assign(new Error("Unauthorized"), { status: 401 });
+      mockCreate.mockRejectedValue(err);
+      await expect(makeProvider().chat([USER_MESSAGE])).rejects.toThrow(
+        LLMAuthenticationError,
+      );
+    });
+
+    it("HTTP 500 → LLMServerError", async () => {
+      const err = Object.assign(new Error("Internal Server Error"), { status: 500 });
+      mockCreate.mockRejectedValue(err);
+      await expect(makeProvider().chat([USER_MESSAGE])).rejects.toThrow(
+        LLMServerError,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // chat() — per-call timeout override
+  // -------------------------------------------------------------------------
+
+  describe("chat() — timeout", () => {
+    it("does not throw when timeoutMs option is provided (honored by withTimeout)", async () => {
+      mockCreate.mockResolvedValueOnce(makeChatResponse());
+      const provider = makeProvider();
+      await expect(
+        provider.chat([USER_MESSAGE], { timeoutMs: 30_000 }),
+      ).resolves.toBeDefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // chatStream()
+  // -------------------------------------------------------------------------
+
+  describe("chatStream()", () => {
+    it("accumulates content chunks and returns full content", async () => {
+      async function* makeStream() {
+        yield { choices: [{ delta: { content: "Hello" } }], model: "test-model" };
+        yield { choices: [{ delta: { content: ", world!" } }], model: "test-model" };
+        yield { choices: [{ delta: {} }], usage: { prompt_tokens: 5, completion_tokens: 3 } };
+      }
+      mockCreate.mockResolvedValueOnce(makeStream());
+      const chunks: string[] = [];
+      const provider = makeProvider();
+      const result = await provider.chatStream(
+        [USER_MESSAGE],
+        (chunk) => { if (chunk.content) chunks.push(chunk.content); },
+      );
+      expect(chunks).toEqual(["Hello", ", world!"]);
+      expect(result.content).toBe("Hello, world!");
+    });
+
+    it("calls onChunk with done:true at end", async () => {
+      async function* makeStream() {
+        yield { choices: [{ delta: { content: "hi" } }], model: "test-model" };
+      }
+      mockCreate.mockResolvedValueOnce(makeStream());
+      let finalChunk: { done: boolean; toolCalls?: unknown[] } | undefined;
+      const provider = makeProvider();
+      await provider.chatStream([USER_MESSAGE], (chunk) => {
+        if (chunk.done) finalChunk = chunk;
+      });
+      expect(finalChunk?.done).toBe(true);
+    });
+
+    it("returns finishReason 'stop' when no tool call deltas", async () => {
+      async function* makeStream() {
+        yield { choices: [{ delta: { content: "ok" } }], model: "test-model" };
+      }
+      mockCreate.mockResolvedValueOnce(makeStream());
+      const provider = makeProvider();
+      const result = await provider.chatStream([USER_MESSAGE], () => {});
+      expect(result.finishReason).toBe("stop");
+    });
+
+    it("accumulates tool_call deltas and assigns UUID IDs", async () => {
+      async function* makeStream() {
+        yield {
+          choices: [{ delta: { tool_calls: [{ index: 0, function: { name: "bash", arguments: '{"cm' } }] } }],
+          model: "test-model",
+        };
+        yield {
+          choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: 'd":"ls"}' } }] } }],
+          model: "test-model",
+        };
+      }
+      mockCreate.mockResolvedValueOnce(makeStream());
+      const provider = makeProvider({ tools: [makeTool("bash")] });
+      const result = await provider.chatStream([USER_MESSAGE], () => {});
+      expect(result.toolCalls).toHaveLength(1);
+      expect(result.toolCalls[0].name).toBe("bash");
+      expect(result.toolCalls[0].arguments).toBe('{"cmd":"ls"}');
+      expect(result.toolCalls[0].id).toMatch(UUID_RE);
+    });
+
+    it("returns finishReason 'tool_calls' when tool call deltas are present", async () => {
+      async function* makeStream() {
+        yield {
+          choices: [{ delta: { tool_calls: [{ index: 0, function: { name: "bash", arguments: "{}" } }] } }],
+          model: "test-model",
+        };
+      }
+      mockCreate.mockResolvedValueOnce(makeStream());
+      const provider = makeProvider({ tools: [makeTool("bash")] });
+      const result = await provider.chatStream([USER_MESSAGE], () => {});
+      expect(result.finishReason).toBe("tool_calls");
+    });
+
+    it("maps usage from final chunk", async () => {
+      async function* makeStream() {
+        yield { choices: [{ delta: { content: "hi" } }], model: "test-model" };
+        yield {
+          choices: [{ delta: {} }],
+          usage: { prompt_tokens: 12, completion_tokens: 4 },
+        };
+      }
+      mockCreate.mockResolvedValueOnce(makeStream());
+      const provider = makeProvider();
+      const result = await provider.chatStream([USER_MESSAGE], () => {});
+      expect(result.usage.promptTokens).toBe(12);
+      expect(result.usage.completionTokens).toBe(4);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // healthCheck()
+  // -------------------------------------------------------------------------
+
+  describe("healthCheck()", () => {
+    it("returns true when models.list() succeeds", async () => {
+      mockModelsList.mockResolvedValueOnce({ data: [] });
+      const provider = makeProvider();
+      await expect(provider.healthCheck()).resolves.toBe(true);
+    });
+
+    it("returns false when models.list() throws", async () => {
+      mockModelsList.mockRejectedValueOnce(new Error("connection refused"));
+      const provider = makeProvider();
+      await expect(provider.healthCheck()).resolves.toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getCapabilities()
+  // -------------------------------------------------------------------------
+
+  describe("getCapabilities()", () => {
+    it("reports provider name as 'openai-compat'", () => {
+      expect(makeProvider().getCapabilities().provider).toBe("openai-compat");
+    });
+
+    it("reports all stateful capabilities as false", () => {
+      const caps = makeProvider().getCapabilities();
+      expect(caps.stateful.assistantPhase).toBe(false);
+      expect(caps.stateful.previousResponseId).toBe(false);
+      expect(caps.stateful.encryptedReasoning).toBe(false);
+      expect(caps.stateful.storedResponseRetrieval).toBe(false);
+      expect(caps.stateful.storedResponseDeletion).toBe(false);
+      expect(caps.stateful.opaqueCompaction).toBe(false);
+    });
+
+    it("reports deterministicFallback as true", () => {
+      expect(makeProvider().getCapabilities().stateful.deterministicFallback).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getExecutionProfile()
+  // -------------------------------------------------------------------------
+
+  describe("getExecutionProfile()", () => {
+    it("returns contextWindowTokens from config", async () => {
+      const provider = makeProvider({ contextWindowTokens: 32768 });
+      const profile = await provider.getExecutionProfile();
+      expect(profile.contextWindowTokens).toBe(32768);
+    });
+
+    it("reports contextWindowSource as 'explicit_config'", async () => {
+      const profile = await makeProvider().getExecutionProfile();
+      expect(profile.contextWindowSource).toBe("explicit_config");
+    });
+
+    it("returns maxOutputTokens when maxTokens is set in config", async () => {
+      const provider = makeProvider({ maxTokens: 4096 });
+      const profile = await provider.getExecutionProfile();
+      expect(profile.maxOutputTokens).toBe(4096);
+    });
+
+    it("returns undefined maxOutputTokens when maxTokens is not set", async () => {
+      const profile = await makeProvider().getExecutionProfile();
+      expect(profile.maxOutputTokens).toBeUndefined();
+    });
+
+    it("reports provider name as 'openai-compat'", async () => {
+      const profile = await makeProvider().getExecutionProfile();
+      expect(profile.provider).toBe("openai-compat");
+    });
+
+    it("reports model from config", async () => {
+      const provider = makeProvider({ model: "gemma-4-26b" });
+      const profile = await provider.getExecutionProfile();
+      expect(profile.model).toBe("gemma-4-26b");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// live server gate (skipped unless OPENAI_COMPAT_BASE_URL is set)
+// ---------------------------------------------------------------------------
+
+const hasLiveServer =
+  !!process.env.OPENAI_COMPAT_BASE_URL && !!process.env.OPENAI_COMPAT_MODEL;
+
+describe.skipIf(!hasLiveServer)("live server", () => {
+  it("basic round-trip returns a non-empty content string", async () => {
+    const { validateOpenAICompatConfig: real } = await vi.importActual<
+      typeof import("./openai-compat-filter.js")
+    >("./openai-compat-filter.js");
+    vi.mocked(
+      (await import("./openai-compat-filter.js")).validateOpenAICompatConfig,
+    ).mockImplementationOnce(real);
+
+    const provider = new OpenAICompatProvider({
+      model: process.env.OPENAI_COMPAT_MODEL!,
+      baseUrl: process.env.OPENAI_COMPAT_BASE_URL!,
+      apiKey: "local",
+      contextWindowTokens: 32768,
+    } as any);
+    const result = await provider.chat([
+      { role: "user", content: "Say 'pong' and nothing else." },
+    ]);
+    expect(typeof result.content).toBe("string");
+    expect(result.content.length).toBeGreaterThan(0);
+  });
+});

--- a/runtime/src/llm/openai-compat/adapter.ts
+++ b/runtime/src/llm/openai-compat/adapter.ts
@@ -32,9 +32,8 @@ import { LLMProviderError, mapLLMError } from "../errors.js";
 import { ensureLazyImport } from "../lazy-import.js";
 import {
   buildUnsupportedCompactionDiagnostics,
-  buildUnsupportedStatefulDiagnostics,
-  resolveLLMStatefulResponsesConfig,
-  type ResolvedLLMStatefulResponsesConfig,
+  resolveLLMCompactionConfig,
+  type ResolvedLLMCompactionConfig,
 } from "../provider-capabilities.js";
 import { withTimeout } from "../timeout.js";
 import { repairToolTurnSequence, validateToolTurnSequence } from "../tool-turn-validator.js";
@@ -166,7 +165,6 @@ function collectParamDiagnostics(
     toolChoice: undefined,
     toolSchemaChars,
     serializedChars,
-    previousResponseId: undefined,
     store: undefined,
     parallelToolCalls: undefined,
     stream: typeof params.stream === "boolean" ? params.stream : undefined,
@@ -248,7 +246,7 @@ export class OpenAICompatProvider implements LLMProvider {
   private client: unknown | null = null;
   private readonly config: OpenAICompatProviderConfig;
   private readonly tools: LLMTool[];
-  private readonly statefulConfig: ResolvedLLMStatefulResponsesConfig;
+  private readonly compactionConfig: ResolvedLLMCompactionConfig;
   private readonly _validationPromise: Promise<void>;
 
   constructor(config: OpenAICompatProviderConfig) {
@@ -260,9 +258,7 @@ export class OpenAICompatProvider implements LLMProvider {
 
     this.config = config;
     this.tools = config.tools ?? [];
-    // openai-compat has no stateful response support; pass undefined to
-    // get the default disabled config.
-    this.statefulConfig = resolveLLMStatefulResponsesConfig(undefined);
+    this.compactionConfig = resolveLLMCompactionConfig(undefined);
   }
 
   async chat(
@@ -508,21 +504,6 @@ export class OpenAICompatProvider implements LLMProvider {
     }
   }
 
-  getCapabilities() {
-    return {
-      provider: this.name,
-      stateful: {
-        assistantPhase: false,
-        previousResponseId: false,
-        encryptedReasoning: false,
-        storedResponseRetrieval: false,
-        storedResponseDeletion: false,
-        opaqueCompaction: false,
-        deterministicFallback: true,
-      },
-    } as const;
-  }
-
   async getExecutionProfile() {
     return {
       provider: this.name,
@@ -666,20 +647,12 @@ export class OpenAICompatProvider implements LLMProvider {
   }
 
   private buildUnsupportedDiagnostics(
-    options?: LLMChatOptions,
-  ): Pick<LLMResponse, "stateful" | "compaction"> {
-    const hasSessionId =
-      typeof options?.stateful?.sessionId === "string" &&
-      options.stateful.sessionId.trim().length > 0;
+    _options?: LLMChatOptions,
+  ): Pick<LLMResponse, "compaction"> {
     return {
-      stateful: buildUnsupportedStatefulDiagnostics({
-        provider: this.name,
-        config: this.statefulConfig,
-        hasSessionId,
-      }),
       compaction: buildUnsupportedCompactionDiagnostics({
         provider: this.name,
-        config: this.statefulConfig,
+        compaction: this.compactionConfig,
       }),
     };
   }

--- a/runtime/src/llm/openai-compat/adapter.ts
+++ b/runtime/src/llm/openai-compat/adapter.ts
@@ -1,0 +1,776 @@
+/**
+ * OpenAI-compatible local LLM provider adapter.
+ *
+ * Connects to any server exposing the OpenAI /v1/chat/completions interface —
+ * LM Studio, llama.cpp server, vLLM — using the `openai` npm SDK pointed at
+ * a local baseUrl. Does not require xAI credentials or catalog validation.
+ *
+ * Startup validation is kicked off eagerly in the constructor via
+ * {@link validateOpenAICompatConfig} and awaited on first client use. The
+ * provider refuses to initialize if the configured baseUrl is not a local/LAN
+ * address, the server is unreachable, or the configured model is absent from
+ * GET /v1/models.
+ *
+ * @module
+ */
+
+import type {
+  LLMChatOptions,
+  LLMProvider,
+  LLMMessage,
+  LLMProviderTraceEvent,
+  LLMRequestMetrics,
+  LLMResponse,
+  LLMToolCall,
+  LLMUsage,
+  LLMTool,
+  StreamProgressCallback,
+} from "../types.js";
+import { validateToolCall } from "../types.js";
+import type { OpenAICompatProviderConfig } from "./types.js";
+import { LLMProviderError, mapLLMError } from "../errors.js";
+import { ensureLazyImport } from "../lazy-import.js";
+import {
+  buildUnsupportedCompactionDiagnostics,
+  buildUnsupportedStatefulDiagnostics,
+  resolveLLMStatefulResponsesConfig,
+  type ResolvedLLMStatefulResponsesConfig,
+} from "../provider-capabilities.js";
+import { withTimeout } from "../timeout.js";
+import { repairToolTurnSequence, validateToolTurnSequence } from "../tool-turn-validator.js";
+import { safeStringify } from "../../tools/types.js";
+import { validateOpenAICompatConfig } from "./openai-compat-filter.js";
+
+function normalizeTimeoutMs(timeoutMs: number | undefined): number | undefined {
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
+    return undefined;
+  }
+  if (timeoutMs <= 0) {
+    return undefined;
+  }
+  return Math.max(1, Math.floor(timeoutMs));
+}
+
+function resolveRequestTimeoutMs(
+  providerTimeoutMs: number | undefined,
+  callTimeoutMs: number | undefined,
+): number | undefined {
+  const normalizedProviderTimeoutMs = normalizeTimeoutMs(providerTimeoutMs);
+  if (typeof callTimeoutMs === "number" && Number.isFinite(callTimeoutMs) && callTimeoutMs <= 0) {
+    return undefined;
+  }
+  const normalizedCallTimeoutMs = normalizeTimeoutMs(callTimeoutMs);
+  if (normalizedProviderTimeoutMs === undefined) {
+    return normalizedCallTimeoutMs;
+  }
+  if (normalizedCallTimeoutMs === undefined) {
+    return normalizedProviderTimeoutMs;
+  }
+  return Math.max(1, Math.min(normalizedProviderTimeoutMs, normalizedCallTimeoutMs));
+}
+
+type ToolResolutionStrategy =
+  | "all_tools_no_filter"
+  | "all_tools_empty_filter"
+  | "subset_exact"
+  | "subset_partial"
+  | "subset_no_resolved_matches";
+
+interface ToolSelectionDiagnostics {
+  readonly tools: LLMTool[];
+  readonly requestedToolNames: readonly string[];
+  readonly resolvedToolNames: readonly string[];
+  readonly missingRequestedToolNames: readonly string[];
+  readonly providerCatalogToolCount: number;
+  readonly toolResolution: ToolResolutionStrategy;
+  readonly toolsAttached: boolean;
+  readonly toolSuppressionReason?: string;
+}
+
+function collectParamDiagnostics(
+  params: Record<string, unknown>,
+  selection?: ToolSelectionDiagnostics,
+): LLMRequestMetrics {
+  const messages = Array.isArray(params.messages)
+    ? (params.messages as Array<Record<string, unknown>>)
+    : [];
+  const tools = Array.isArray(params.tools)
+    ? (params.tools as Array<Record<string, unknown>>)
+    : [];
+
+  let totalContentChars = 0;
+  let maxMessageChars = 0;
+  let systemMessages = 0;
+  let userMessages = 0;
+  let assistantMessages = 0;
+  let toolMessages = 0;
+
+  for (const message of messages) {
+    const role = String(message.role ?? "");
+    if (role === "system") systemMessages++;
+    if (role === "user") userMessages++;
+    if (role === "assistant") assistantMessages++;
+    if (role === "tool") toolMessages++;
+
+    const content =
+      typeof message.content === "string"
+        ? message.content
+        : safeStringify(message.content ?? "");
+    totalContentChars += content.length;
+    if (content.length > maxMessageChars) {
+      maxMessageChars = content.length;
+    }
+  }
+
+  let serializedChars = 0;
+  let toolSchemaChars = 0;
+  try {
+    serializedChars = safeStringify(params).length;
+  } catch {
+    serializedChars = -1;
+  }
+  try {
+    toolSchemaChars = safeStringify(tools).length;
+  } catch {
+    toolSchemaChars = -1;
+  }
+
+  return {
+    messageCount: messages.length,
+    systemMessages,
+    userMessages,
+    assistantMessages,
+    toolMessages,
+    totalContentChars,
+    maxMessageChars,
+    textParts: 0,
+    imageParts: 0,
+    toolCount: tools.length,
+    toolNames: tools
+      .map((tool) => {
+        const fn = tool.function;
+        return fn &&
+          typeof fn === "object" &&
+          !Array.isArray(fn) &&
+          typeof (fn as Record<string, unknown>).name === "string"
+          ? String((fn as Record<string, unknown>).name)
+          : undefined;
+      })
+      .filter((name): name is string => Boolean(name)),
+    requestedToolNames: selection?.requestedToolNames,
+    missingRequestedToolNames: selection?.missingRequestedToolNames,
+    toolResolution: selection?.toolResolution,
+    providerCatalogToolCount: selection?.providerCatalogToolCount,
+    toolsAttached: selection?.toolsAttached,
+    toolSuppressionReason: selection?.toolSuppressionReason,
+    toolChoice: undefined,
+    toolSchemaChars,
+    serializedChars,
+    previousResponseId: undefined,
+    store: undefined,
+    parallelToolCalls: undefined,
+    stream: typeof params.stream === "boolean" ? params.stream : undefined,
+  };
+}
+
+function cloneProviderTracePayload(
+  value: unknown,
+): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(safeStringify(value)) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+function buildProviderTraceErrorPayload(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    const payload: Record<string, unknown> = {
+      name: error.name,
+      message: error.message,
+    };
+    if (error.stack) payload.stack = error.stack;
+    const status = (error as { status?: unknown }).status;
+    if (
+      typeof status === "string" ||
+      typeof status === "number" ||
+      typeof status === "boolean"
+    ) {
+      payload.status = status;
+    }
+    const code = (error as { code?: unknown }).code;
+    if (
+      typeof code === "string" ||
+      typeof code === "number" ||
+      typeof code === "boolean"
+    ) {
+      payload.code = code;
+    }
+    return payload;
+  }
+  return { error: String(error) };
+}
+
+function emitProviderTraceEvent(
+  options: LLMChatOptions | undefined,
+  event: LLMProviderTraceEvent,
+): void {
+  options?.trace?.onProviderTraceEvent?.(event);
+}
+
+function buildToolSelectionTraceContext(
+  selection: ToolSelectionDiagnostics,
+  timeoutMs?: number,
+): Record<string, unknown> {
+  return {
+    requestedToolNames: selection.requestedToolNames,
+    resolvedToolNames: selection.resolvedToolNames,
+    missingRequestedToolNames: selection.missingRequestedToolNames,
+    toolResolution: selection.toolResolution,
+    providerCatalogToolCount: selection.providerCatalogToolCount,
+    toolsAttached: selection.toolsAttached,
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+  };
+}
+
+/** Accumulated state for a single tool call during streaming. */
+interface StreamingToolCallAccumulator {
+  name: string;
+  arguments: string;
+}
+
+export class OpenAICompatProvider implements LLMProvider {
+  readonly name = "openai-compat";
+
+  private client: unknown | null = null;
+  private readonly config: OpenAICompatProviderConfig;
+  private readonly tools: LLMTool[];
+  private readonly statefulConfig: ResolvedLLMStatefulResponsesConfig;
+  private readonly _validationPromise: Promise<void>;
+
+  constructor(config: OpenAICompatProviderConfig) {
+    // Kick off startup validation eagerly. The promise is awaited in
+    // ensureClient() so the error surfaces on first API call. Three checks
+    // run in order: baseUrl is local/LAN, server is reachable via GET
+    // /v1/models, configured model is present in the response.
+    this._validationPromise = validateOpenAICompatConfig(config);
+
+    this.config = config;
+    this.tools = config.tools ?? [];
+    // openai-compat has no stateful response support; pass undefined to
+    // get the default disabled config.
+    this.statefulConfig = resolveLLMStatefulResponsesConfig(undefined);
+  }
+
+  async chat(
+    messages: LLMMessage[],
+    options?: LLMChatOptions,
+  ): Promise<LLMResponse> {
+    const client = await this.ensureClient();
+    const toolSelection = this.selectTools(options?.toolRouting?.allowedToolNames);
+    const params = this.buildParams(messages, options, toolSelection);
+    const requestMetrics = collectParamDiagnostics(params, toolSelection);
+    const requestTimeoutMs = resolveRequestTimeoutMs(
+      this.config.timeoutMs,
+      options?.timeoutMs,
+    );
+
+    try {
+      emitProviderTraceEvent(options, {
+        kind: "request",
+        transport: "chat",
+        provider: this.name,
+        model: String(params.model ?? this.config.model),
+        payload:
+          cloneProviderTracePayload(params) ??
+          { error: "provider_request_trace_unavailable" },
+        context: buildToolSelectionTraceContext(toolSelection, requestTimeoutMs),
+      });
+      const response = await withTimeout(
+        async (signal) =>
+          (client as any).chat.completions.create(params, { signal }),
+        requestTimeoutMs,
+        this.name,
+        options?.signal,
+      );
+      emitProviderTraceEvent(options, {
+        kind: "response",
+        transport: "chat",
+        provider: this.name,
+        model: String(response?.model ?? params.model ?? this.config.model),
+        payload:
+          cloneProviderTracePayload(response) ??
+          { error: "provider_response_trace_unavailable" },
+      });
+      return {
+        ...this.parseResponse(response, options),
+        requestMetrics,
+      };
+    } catch (err: unknown) {
+      emitProviderTraceEvent(options, {
+        kind: "error",
+        transport: "chat",
+        provider: this.name,
+        model: String(params.model ?? this.config.model),
+        payload: buildProviderTraceErrorPayload(err),
+      });
+      throw this.mapError(err, requestTimeoutMs);
+    }
+  }
+
+  async chatStream(
+    messages: LLMMessage[],
+    onChunk: StreamProgressCallback,
+    options?: LLMChatOptions,
+  ): Promise<LLMResponse> {
+    const client = await this.ensureClient();
+    const toolSelection = this.selectTools(options?.toolRouting?.allowedToolNames);
+    const params: Record<string, unknown> = {
+      ...this.buildParams(messages, options, toolSelection),
+      stream: true,
+    };
+    const requestMetrics = collectParamDiagnostics(params, toolSelection);
+    const requestTimeoutMs = resolveRequestTimeoutMs(
+      this.config.timeoutMs,
+      options?.timeoutMs,
+    );
+    let content = "";
+    let model = this.config.model;
+    let toolCalls: LLMToolCall[] = [];
+    let promptTokens = 0;
+    let completionTokens = 0;
+
+    // Accumulate OpenAI streaming tool_calls by index across chunks.
+    // The id and function.name only appear on the first delta for each
+    // index; function.arguments is distributed across subsequent deltas.
+    const toolCallAccumulator = new Map<number, StreamingToolCallAccumulator>();
+
+    try {
+      emitProviderTraceEvent(options, {
+        kind: "request",
+        transport: "chat_stream",
+        provider: this.name,
+        model: String(params.model ?? this.config.model),
+        payload:
+          cloneProviderTracePayload(params) ??
+          { error: "provider_request_trace_unavailable" },
+        context: buildToolSelectionTraceContext(toolSelection, requestTimeoutMs),
+      });
+      const stream = await withTimeout(
+        async (signal) =>
+          (client as any).chat.completions.create(params, { signal }),
+        requestTimeoutMs,
+        this.name,
+        options?.signal,
+      );
+
+      for await (const chunk of stream as AsyncIterable<any>) {
+        const delta = chunk.choices?.[0]?.delta;
+        if (delta) {
+          if (typeof delta.content === "string" && delta.content.length > 0) {
+            content += delta.content;
+            onChunk({ content: delta.content, done: false });
+          }
+
+          // Accumulate tool call deltas by index
+          if (Array.isArray(delta.tool_calls)) {
+            for (const tc of delta.tool_calls) {
+              const idx =
+                typeof tc.index === "number" ? tc.index : toolCallAccumulator.size;
+              if (!toolCallAccumulator.has(idx)) {
+                toolCallAccumulator.set(idx, { name: "", arguments: "" });
+              }
+              const acc = toolCallAccumulator.get(idx)!;
+              if (typeof tc.function?.name === "string") {
+                acc.name = tc.function.name;
+              }
+              if (typeof tc.function?.arguments === "string") {
+                acc.arguments += tc.function.arguments;
+              }
+            }
+          }
+        }
+
+        if (typeof chunk.model === "string" && chunk.model.length > 0) {
+          model = chunk.model;
+        }
+        if (chunk.usage) {
+          promptTokens = chunk.usage.prompt_tokens ?? 0;
+          completionTokens = chunk.usage.completion_tokens ?? 0;
+        }
+      }
+
+      // Convert accumulated deltas to LLMToolCall objects.
+      // Each call gets a fresh UUID — never reuse the server-provided id or
+      // the function name. Using the function name as an ID (the bug in the
+      // Ollama adapter) produces non-unique IDs when the same tool is called
+      // multiple times in one turn, corrupting tool-result correlation on
+      // follow-up turns.
+      toolCalls = [...toolCallAccumulator.entries()]
+        .sort(([a], [b]) => a - b)
+        .map(([, acc]) =>
+          validateToolCall({
+            id: crypto.randomUUID(),
+            name: acc.name,
+            arguments: acc.arguments.length > 0 ? acc.arguments : "{}",
+          }),
+        )
+        .filter((tc): tc is LLMToolCall => tc !== null);
+
+      const finishReason: LLMResponse["finishReason"] =
+        toolCalls.length > 0 ? "tool_calls" : "stop";
+      onChunk({ content: "", done: true, toolCalls });
+      emitProviderTraceEvent(options, {
+        kind: "response",
+        transport: "chat_stream",
+        provider: this.name,
+        model,
+        payload: {
+          choices: [
+            {
+              message: {
+                content,
+                role: "assistant",
+                ...(toolCalls.length > 0
+                  ? {
+                    tool_calls: toolCalls.map((tc) => ({
+                      type: "function",
+                      function: { name: tc.name, arguments: tc.arguments },
+                    })),
+                  }
+                  : {}),
+              },
+              finish_reason: finishReason,
+            },
+          ],
+          model,
+          usage: {
+            prompt_tokens: promptTokens,
+            completion_tokens: completionTokens,
+          },
+        },
+      });
+
+      return {
+        content,
+        toolCalls,
+        usage: {
+          promptTokens,
+          completionTokens,
+          totalTokens: promptTokens + completionTokens,
+        },
+        model,
+        requestMetrics,
+        finishReason,
+        ...this.buildUnsupportedDiagnostics(options),
+      };
+    } catch (err: unknown) {
+      emitProviderTraceEvent(options, {
+        kind: "error",
+        transport: "chat_stream",
+        provider: this.name,
+        model,
+        payload: buildProviderTraceErrorPayload(err),
+      });
+      if (content.length > 0) {
+        const mappedError = this.mapError(err, requestTimeoutMs);
+        onChunk({ content: "", done: true, toolCalls });
+        return {
+          content,
+          toolCalls,
+          usage: {
+            promptTokens,
+            completionTokens,
+            totalTokens: promptTokens + completionTokens,
+          },
+          model,
+          requestMetrics,
+          finishReason: "error",
+          error: mappedError,
+          partial: true,
+          ...this.buildUnsupportedDiagnostics(options),
+        };
+      }
+      throw this.mapError(err, requestTimeoutMs);
+    }
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      const client = await this.ensureClient();
+      await (client as any).models.list();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  getCapabilities() {
+    return {
+      provider: this.name,
+      stateful: {
+        assistantPhase: false,
+        previousResponseId: false,
+        encryptedReasoning: false,
+        storedResponseRetrieval: false,
+        storedResponseDeletion: false,
+        opaqueCompaction: false,
+        deterministicFallback: true,
+      },
+    } as const;
+  }
+
+  async getExecutionProfile() {
+    return {
+      provider: this.name,
+      model: this.config.model,
+      contextWindowTokens: this.config.contextWindowTokens,
+      contextWindowSource: "explicit_config" as const,
+      maxOutputTokens:
+        typeof this.config.maxTokens === "number" && this.config.maxTokens > 0
+          ? this.config.maxTokens
+          : undefined,
+    };
+  }
+
+  private async ensureClient(): Promise<unknown> {
+    // Surface any startup validation error (baseUrl, reachability, model
+    // presence) before attempting to create the SDK client.
+    await this._validationPromise;
+
+    if (this.client) return this.client;
+
+    this.client = await ensureLazyImport("openai", this.name, (mod) => {
+      const OpenAI = (mod.OpenAI ?? mod.default) as any;
+      return new OpenAI({
+        apiKey: this.config.apiKey,
+        baseURL: this.config.baseUrl,
+      });
+    });
+    return this.client;
+  }
+
+  private buildParams(
+    messages: LLMMessage[],
+    options?: LLMChatOptions,
+    toolSelection?: ToolSelectionDiagnostics,
+  ): Record<string, unknown> {
+    const repairedMessages = repairToolTurnSequence(messages);
+    validateToolTurnSequence(repairedMessages, { providerName: this.name });
+
+    const params: Record<string, unknown> = {
+      model: this.config.model,
+      messages: repairedMessages.map((m) => this.toOpenAIMessage(m)),
+    };
+
+    if (this.config.temperature !== undefined) {
+      params.temperature = this.config.temperature;
+    }
+    if (
+      typeof this.config.maxTokens === "number" &&
+      Number.isFinite(this.config.maxTokens) &&
+      this.config.maxTokens > 0
+    ) {
+      params.max_tokens = this.config.maxTokens;
+    }
+
+    if (this.tools.length > 0) {
+      params.tools = (
+        toolSelection ?? this.selectTools(options?.toolRouting?.allowedToolNames)
+      ).tools;
+    }
+
+    return params;
+  }
+
+  private selectTools(
+    allowedToolNames?: readonly string[],
+  ): ToolSelectionDiagnostics {
+    const providerCatalogToolCount = this.tools.length;
+    const providerCatalogToolNames = this.tools.map((tool) => tool.function.name);
+    if (allowedToolNames === undefined) {
+      return {
+        tools: this.tools,
+        requestedToolNames: [],
+        resolvedToolNames: providerCatalogToolNames,
+        missingRequestedToolNames: [],
+        providerCatalogToolCount,
+        toolResolution: "all_tools_no_filter",
+        toolsAttached: true,
+      };
+    }
+
+    if (allowedToolNames.length === 0) {
+      return {
+        tools: [],
+        requestedToolNames: [],
+        resolvedToolNames: [],
+        missingRequestedToolNames: [],
+        providerCatalogToolCount,
+        toolResolution: "all_tools_empty_filter",
+        toolsAttached: false,
+      };
+    }
+
+    const allowed = new Set(
+      allowedToolNames
+        .map((name) => name.trim())
+        .filter((name) => name.length > 0),
+    );
+    if (allowed.size === 0) {
+      return {
+        tools: [],
+        requestedToolNames: [],
+        resolvedToolNames: [],
+        missingRequestedToolNames: [],
+        providerCatalogToolCount,
+        toolResolution: "all_tools_empty_filter",
+        toolsAttached: false,
+      };
+    }
+
+    const requestedToolNames = [...allowed];
+    const filtered = this.tools.filter((tool) => allowed.has(tool.function.name));
+    const resolvedToolNames = filtered.map((tool) => tool.function.name);
+    const missingRequestedToolNames = requestedToolNames.filter(
+      (name) => !resolvedToolNames.includes(name),
+    );
+    if (filtered.length === 0) {
+      console.warn(
+        `[OpenAICompatAdapter] Tool allowlist resolved to ${requestedToolNames.length} names but zero matched the provider catalog — suppressing all tools for this call (requested: ${requestedToolNames.join(", ")})`,
+      );
+      return {
+        tools: [],
+        requestedToolNames,
+        resolvedToolNames: [],
+        missingRequestedToolNames: requestedToolNames,
+        providerCatalogToolCount,
+        toolResolution: "subset_no_resolved_matches",
+        toolsAttached: false,
+      };
+    }
+
+    return {
+      tools: filtered,
+      requestedToolNames,
+      resolvedToolNames,
+      missingRequestedToolNames,
+      providerCatalogToolCount,
+      toolResolution:
+        missingRequestedToolNames.length > 0 ? "subset_partial" : "subset_exact",
+      toolsAttached: true,
+    };
+  }
+
+  private buildUnsupportedDiagnostics(
+    options?: LLMChatOptions,
+  ): Pick<LLMResponse, "stateful" | "compaction"> {
+    const hasSessionId =
+      typeof options?.stateful?.sessionId === "string" &&
+      options.stateful.sessionId.trim().length > 0;
+    return {
+      stateful: buildUnsupportedStatefulDiagnostics({
+        provider: this.name,
+        config: this.statefulConfig,
+        hasSessionId,
+      }),
+      compaction: buildUnsupportedCompactionDiagnostics({
+        provider: this.name,
+        config: this.statefulConfig,
+      }),
+    };
+  }
+
+  private toOpenAIMessage(msg: LLMMessage): Record<string, unknown> {
+    if (msg.role === "assistant" && msg.toolCalls && msg.toolCalls.length > 0) {
+      return {
+        role: "assistant",
+        content: msg.content,
+        tool_calls: msg.toolCalls.map((tc) => ({
+          id: tc.id,
+          type: "function",
+          function: {
+            name: tc.name,
+            arguments: tc.arguments,
+          },
+        })),
+      };
+    }
+
+    if (msg.role === "tool") {
+      let content: string;
+      if (Array.isArray(msg.content)) {
+        content =
+          msg.content
+            .filter((p) => p.type === "text")
+            .map((p) => (p as { type: "text"; text: string }).text)
+            .join("\n") || "Tool executed successfully.";
+      } else {
+        content = msg.content;
+      }
+      return {
+        role: "tool",
+        content,
+        tool_call_id: msg.toolCallId,
+      };
+    }
+
+    return { role: msg.role, content: msg.content };
+  }
+
+  private parseResponse(response: any, options?: LLMChatOptions): LLMResponse {
+    const choice = response.choices?.[0];
+    const message = choice?.message ?? {};
+    const content = typeof message.content === "string" ? message.content : "";
+
+    const toolCalls: LLMToolCall[] = (message.tool_calls ?? [])
+      .map((tc: any) =>
+        validateToolCall({
+          /**
+           * Generate a fresh UUID rather than using tc.id (the server-assigned
+           * call ID) or tc.function.name. Using the function name as an ID —
+           * the bug present in the Ollama adapter — produces non-unique IDs when
+           * the same tool is called multiple times in one turn, corrupting
+           * tool-result correlation on follow-up turns.
+           */
+          id: crypto.randomUUID(),
+          name: tc.function?.name ?? "",
+          arguments: tc.function?.arguments ?? "{}",
+        }),
+      )
+      .filter((tc: LLMToolCall | null): tc is LLMToolCall => tc !== null);
+
+    const usage: LLMUsage = {
+      promptTokens: response.usage?.prompt_tokens ?? 0,
+      completionTokens: response.usage?.completion_tokens ?? 0,
+      totalTokens:
+        response.usage?.total_tokens ??
+        (response.usage?.prompt_tokens ?? 0) +
+          (response.usage?.completion_tokens ?? 0),
+    };
+
+    return {
+      content,
+      toolCalls,
+      usage,
+      model: response.model ?? this.config.model,
+      finishReason: toolCalls.length > 0 ? "tool_calls" : "stop",
+      ...this.buildUnsupportedDiagnostics(options),
+    };
+  }
+
+  private mapError(err: unknown, timeoutMs?: number): Error {
+    const e = err as any;
+    if (e?.code === "ECONNREFUSED") {
+      return new LLMProviderError(
+        this.name,
+        `Cannot connect to local server at ${this.config.baseUrl}. Is the server running?`,
+      );
+    }
+
+    return mapLLMError(this.name, err, timeoutMs ?? this.config.timeoutMs ?? 0);
+  }
+}

--- a/runtime/src/llm/openai-compat/openai-compat-filter.test.ts
+++ b/runtime/src/llm/openai-compat/openai-compat-filter.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import {
+  validateBaseUrl,
+  validateServerReachable,
+  validateModelPresent,
+  validateOpenAICompatConfig,
+  OpenAICompatServerUnreachableError,
+  OpenAICompatUnknownModelError,
+} from "./openai-compat-filter.js";
+import type { OpenAICompatProviderConfig } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function mockFetchSuccess(body: unknown, status = 200): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 200 ? "OK" : "Error",
+      json: () => Promise.resolve(body),
+    }),
+  );
+}
+
+function mockFetchError(error: Error): void {
+  vi.stubGlobal("fetch", vi.fn().mockRejectedValue(error));
+}
+
+function mockFetchBadJson(): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: () => Promise.reject(new SyntaxError("Unexpected token")),
+    }),
+  );
+}
+
+function validModelsBody(ids: string[]): unknown {
+  return { data: ids.map((id) => ({ id })) };
+}
+
+function minimalConfig(
+  overrides: Partial<OpenAICompatProviderConfig> = {},
+): OpenAICompatProviderConfig {
+  return {
+    model: "test-model",
+    baseUrl: "http://127.0.0.1:1234/v1",
+    apiKey: "local",
+    contextWindowTokens: 4096,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// validateBaseUrl
+// ---------------------------------------------------------------------------
+
+describe("validateBaseUrl", () => {
+  describe("accepts local and LAN addresses", () => {
+    it("accepts 127.0.0.1 (loopback)", () => {
+      expect(() => validateBaseUrl("http://127.0.0.1:1234/v1")).not.toThrow();
+    });
+
+    it("accepts localhost", () => {
+      expect(() => validateBaseUrl("http://localhost:1234/v1")).not.toThrow();
+    });
+
+    it("accepts 192.168.x.x (RFC-1918 class C)", () => {
+      expect(() =>
+        validateBaseUrl("http://192.168.1.100:8080/v1"),
+      ).not.toThrow();
+    });
+
+    it("accepts 10.x.x.x (RFC-1918 class A)", () => {
+      expect(() =>
+        validateBaseUrl("http://10.0.0.1:8080/v1"),
+      ).not.toThrow();
+    });
+
+    it("accepts 172.16.x.x (lower bound of RFC-1918 class B)", () => {
+      expect(() =>
+        validateBaseUrl("http://172.16.0.1:8080/v1"),
+      ).not.toThrow();
+    });
+
+    it("accepts 172.31.x.x (upper bound of RFC-1918 class B)", () => {
+      expect(() =>
+        validateBaseUrl("http://172.31.0.1:8080/v1"),
+      ).not.toThrow();
+    });
+
+    it("accepts ::1 (IPv6 loopback)", () => {
+      expect(() => validateBaseUrl("http://[::1]:1234/v1")).not.toThrow();
+    });
+  });
+
+  describe("rejects public and invalid addresses", () => {
+    it("rejects a public domain", () => {
+      expect(() => validateBaseUrl("http://api.openai.com/v1")).toThrow(Error);
+    });
+
+    it("rejects a public IP", () => {
+      expect(() => validateBaseUrl("http://8.8.8.8:1234/v1")).toThrow(Error);
+    });
+
+    it("rejects 172.15.x.x (just below RFC-1918 class B range)", () => {
+      expect(() =>
+        validateBaseUrl("http://172.15.0.1:8080/v1"),
+      ).toThrow(Error);
+    });
+
+    it("rejects 172.32.x.x (just above RFC-1918 class B range)", () => {
+      expect(() =>
+        validateBaseUrl("http://172.32.0.1:8080/v1"),
+      ).toThrow(Error);
+    });
+
+    it("rejects an invalid URL string", () => {
+      expect(() => validateBaseUrl("not-a-url")).toThrow(Error);
+    });
+
+    it("error message includes the offending hostname for public IP", () => {
+      expect(() => validateBaseUrl("http://8.8.8.8:1234/v1")).toThrow(
+        "8.8.8.8",
+      );
+    });
+
+    it("error message includes the offending hostname for public domain", () => {
+      expect(() => validateBaseUrl("http://api.openai.com/v1")).toThrow(
+        "api.openai.com",
+      );
+    });
+
+    it("does not throw OpenAICompatServerUnreachableError — plain Error only", () => {
+      expect(() => validateBaseUrl("http://8.8.8.8:1234/v1")).not.toThrow(
+        OpenAICompatServerUnreachableError,
+      );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateServerReachable
+// ---------------------------------------------------------------------------
+
+describe("validateServerReachable", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("success cases", () => {
+    it("returns model ID list from a valid /v1/models response", async () => {
+      mockFetchSuccess(validModelsBody(["model-a", "model-b"]));
+      const models = await validateServerReachable("http://127.0.0.1:1234/v1");
+      expect(models).toEqual(["model-a", "model-b"]);
+    });
+
+    it("returns empty array when data array is empty", async () => {
+      mockFetchSuccess({ data: [] });
+      const models = await validateServerReachable("http://127.0.0.1:1234/v1");
+      expect(models).toEqual([]);
+    });
+
+    it("strips trailing slash from baseUrl before appending /models", async () => {
+      mockFetchSuccess(validModelsBody(["model-a"]));
+      await validateServerReachable("http://127.0.0.1:1234/v1/");
+      const calledUrl = (vi.mocked(fetch) as ReturnType<typeof vi.fn>).mock
+        .calls[0][0] as string;
+      expect(calledUrl).toBe("http://127.0.0.1:1234/v1/models");
+    });
+
+    it("skips entries with non-string id fields", async () => {
+      mockFetchSuccess({ data: [{ id: "real-model" }, { id: 42 }, {}] });
+      const models = await validateServerReachable("http://127.0.0.1:1234/v1");
+      expect(models).toEqual(["real-model"]);
+    });
+  });
+
+  describe("throws OpenAICompatServerUnreachableError", () => {
+    it("when fetch throws ECONNREFUSED", async () => {
+      const err = Object.assign(new Error("connect ECONNREFUSED"), {
+        code: "ECONNREFUSED",
+      });
+      mockFetchError(err);
+      await expect(
+        validateServerReachable("http://127.0.0.1:1234/v1"),
+      ).rejects.toThrow(OpenAICompatServerUnreachableError);
+    });
+
+    it("when fetch throws AbortError (timeout)", async () => {
+      const err = Object.assign(new Error("The operation was aborted"), {
+        name: "AbortError",
+      });
+      mockFetchError(err);
+      await expect(
+        validateServerReachable("http://127.0.0.1:1234/v1"),
+      ).rejects.toThrow(OpenAICompatServerUnreachableError);
+    });
+
+    it("AbortError message mentions timeout", async () => {
+      const err = Object.assign(new Error("The operation was aborted"), {
+        name: "AbortError",
+      });
+      mockFetchError(err);
+      await expect(
+        validateServerReachable("http://127.0.0.1:1234/v1"),
+      ).rejects.toThrow("timed out");
+    });
+
+    it("when server returns HTTP 500", async () => {
+      mockFetchSuccess({}, 500);
+      await expect(
+        validateServerReachable("http://127.0.0.1:1234/v1"),
+      ).rejects.toThrow(OpenAICompatServerUnreachableError);
+    });
+
+    it("when server returns HTTP 404", async () => {
+      mockFetchSuccess({}, 404);
+      await expect(
+        validateServerReachable("http://127.0.0.1:1234/v1"),
+      ).rejects.toThrow(OpenAICompatServerUnreachableError);
+    });
+
+    it("when response body is not valid JSON", async () => {
+      mockFetchBadJson();
+      await expect(
+        validateServerReachable("http://127.0.0.1:1234/v1"),
+      ).rejects.toThrow(OpenAICompatServerUnreachableError);
+    });
+
+    it("when response body has no data array", async () => {
+      mockFetchSuccess({ models: ["model-a"] });
+      await expect(
+        validateServerReachable("http://127.0.0.1:1234/v1"),
+      ).rejects.toThrow(OpenAICompatServerUnreachableError);
+    });
+
+    it("when response body is a plain string", async () => {
+      mockFetchSuccess("not an object");
+      await expect(
+        validateServerReachable("http://127.0.0.1:1234/v1"),
+      ).rejects.toThrow(OpenAICompatServerUnreachableError);
+    });
+
+    it("error includes the baseUrl in the message", async () => {
+      const err = new Error("connect ECONNREFUSED");
+      mockFetchError(err);
+      await expect(
+        validateServerReachable("http://127.0.0.1:9999/v1"),
+      ).rejects.toThrow("http://127.0.0.1:9999/v1");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateModelPresent
+// ---------------------------------------------------------------------------
+
+describe("validateModelPresent", () => {
+  const baseUrl = "http://127.0.0.1:1234/v1";
+
+  describe("passes without throwing", () => {
+    it("when model is in availableModels", () => {
+      expect(() =>
+        validateModelPresent("model-a", ["model-a", "model-b"], baseUrl),
+      ).not.toThrow();
+    });
+
+    it("when model is the only entry in the list", () => {
+      expect(() =>
+        validateModelPresent("only-model", ["only-model"], baseUrl),
+      ).not.toThrow();
+    });
+  });
+
+  describe("throws OpenAICompatUnknownModelError", () => {
+    it("when model is not in availableModels", () => {
+      expect(() =>
+        validateModelPresent("missing-model", ["model-a", "model-b"], baseUrl),
+      ).toThrow(OpenAICompatUnknownModelError);
+    });
+
+    it("when availableModels is empty", () => {
+      expect(() =>
+        validateModelPresent("any-model", [], baseUrl),
+      ).toThrow(OpenAICompatUnknownModelError);
+    });
+
+    it("when model is a substring but not an exact match", () => {
+      expect(() =>
+        validateModelPresent("gemma", ["google_gemma-4-26b"], baseUrl),
+      ).toThrow(OpenAICompatUnknownModelError);
+    });
+
+    it("when model is a superstring of an available model", () => {
+      expect(() =>
+        validateModelPresent(
+          "google_gemma-4-26b-extended",
+          ["google_gemma-4-26b"],
+          baseUrl,
+        ),
+      ).toThrow(OpenAICompatUnknownModelError);
+    });
+
+    it("error includes the requested model name", () => {
+      expect(() =>
+        validateModelPresent("missing-model", ["model-a"], baseUrl),
+      ).toThrow("missing-model");
+    });
+
+    it("error includes the baseUrl", () => {
+      expect(() =>
+        validateModelPresent("missing-model", ["model-a"], baseUrl),
+      ).toThrow(baseUrl);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateOpenAICompatConfig
+// ---------------------------------------------------------------------------
+
+describe("validateOpenAICompatConfig", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("throws on invalid baseUrl before hitting the network", async () => {
+    // fetch should never be called — validateBaseUrl is synchronous
+    vi.stubGlobal("fetch", vi.fn());
+    await expect(
+      validateOpenAICompatConfig(
+        minimalConfig({ baseUrl: "http://api.openai.com/v1" }),
+      ),
+    ).rejects.toThrow("api.openai.com");
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it("throws OpenAICompatServerUnreachableError when server unreachable", async () => {
+    mockFetchError(new Error("connect ECONNREFUSED"));
+    await expect(
+      validateOpenAICompatConfig(minimalConfig()),
+    ).rejects.toThrow(OpenAICompatServerUnreachableError);
+  });
+
+  it("throws OpenAICompatUnknownModelError when model not in list", async () => {
+    mockFetchSuccess(validModelsBody(["other-model"]));
+    await expect(
+      validateOpenAICompatConfig(minimalConfig({ model: "test-model" })),
+    ).rejects.toThrow(OpenAICompatUnknownModelError);
+  });
+
+  it("passes when all three checks succeed", async () => {
+    mockFetchSuccess(validModelsBody(["test-model"]));
+    await expect(
+      validateOpenAICompatConfig(minimalConfig({ model: "test-model" })),
+    ).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// live server gate (skipped unless OPENAI_COMPAT_BASE_URL is set)
+// ---------------------------------------------------------------------------
+
+const hasLiveServer = !!process.env.OPENAI_COMPAT_BASE_URL;
+
+describe.skipIf(!hasLiveServer)("live server", () => {
+  it("validateServerReachable returns model list from real server", async () => {
+    const models = await validateServerReachable(
+      process.env.OPENAI_COMPAT_BASE_URL!,
+    );
+    expect(models).toBeInstanceOf(Array);
+    expect(models.length).toBeGreaterThan(0);
+  });
+});

--- a/runtime/src/llm/openai-compat/openai-compat-filter.ts
+++ b/runtime/src/llm/openai-compat/openai-compat-filter.ts
@@ -1,0 +1,228 @@
+/**
+ * Startup validation filter for the openai-compat local LLM provider.
+ *
+ * Three pure validators run in order during provider construction, before
+ * the daemon accepts any requests. All checks are mandatory — there is no
+ * config flag to skip them.
+ *
+ *   1. {@link validateBaseUrl} — confirms the configured baseUrl resolves to
+ *      a local or LAN address. Throws a plain Error on public IPs or external
+ *      hostnames. Prevents accidental routing of local-model config to an
+ *      external service.
+ *
+ *   2. {@link validateServerReachable} — hits GET {baseUrl}/models with a
+ *      5-second timeout. Throws {@link OpenAICompatServerUnreachableError} on
+ *      connection failure, timeout, or non-2xx response. Returns the list of
+ *      model IDs from the server response on success.
+ *
+ *   3. {@link validateModelPresent} — confirms the configured model appears
+ *      in the list returned by step 2. Throws
+ *      {@link OpenAICompatUnknownModelError} if absent. The server's
+ *      /v1/models response is the authoritative source of truth — no separate
+ *      config field is used.
+ *
+ * {@link validateOpenAICompatConfig} is the convenience entry point that calls
+ * all three in order. This is what the adapter calls on construction.
+ *
+ * @module
+ */
+
+import type { OpenAICompatProviderConfig } from "./types.js";
+import {
+  OpenAICompatServerUnreachableError,
+  OpenAICompatUnknownModelError,
+} from "./types.js";
+
+export {
+  OpenAICompatServerUnreachableError,
+  OpenAICompatUnknownModelError,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Section A — baseUrl local-address validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true if the given hostname is a loopback or RFC-1918 private address,
+ * or the literal string "localhost".
+ *
+ * Accepted ranges:
+ *   - localhost
+ *   - ::1 (IPv6 loopback)
+ *   - 127.0.0.0/8
+ *   - 10.0.0.0/8
+ *   - 192.168.0.0/16
+ *   - 172.16.0.0/12  (172.16.x.x – 172.31.x.x)
+ */
+function isLocalHostname(hostname: string): boolean {
+  if (hostname === "localhost" || hostname === "::1") {
+    return true;
+  }
+
+  const parts = hostname.split(".");
+  if (parts.length !== 4) {
+    return false;
+  }
+
+  const octets = parts.map(Number);
+  if (octets.some((o) => !Number.isInteger(o) || o < 0 || o > 255)) {
+    return false;
+  }
+
+  const [a, b] = octets;
+
+  if (a === 127) return true;
+  if (a === 10) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+
+  return false;
+}
+
+/**
+ * Validates that `baseUrl` resolves to a local or LAN address.
+ *
+ * Throws a plain `Error` if the hostname is a public IP or external domain.
+ * The openai-compat provider is intended exclusively for locally-hosted
+ * servers — routing it to an external endpoint would expose credentials and
+ * bypass the startup model-presence check against the wrong server.
+ *
+ * @throws {Error} if the hostname is not a recognized local/LAN address.
+ */
+export function validateBaseUrl(baseUrl: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    throw new Error(
+      `openai-compat: baseUrl "${baseUrl}" is not a valid URL. ` +
+        `Expected a local address such as "http://127.0.0.1:1234/v1".`,
+    );
+  }
+
+  const hostname = parsed.hostname;
+  if (!isLocalHostname(hostname)) {
+    throw new Error(
+      `openai-compat: baseUrl hostname "${hostname}" is not a local or LAN address. ` +
+        `The openai-compat provider only connects to locally-hosted servers ` +
+        `(127.x, 10.x, 192.168.x, 172.16-31.x, localhost). ` +
+        `Use provider "grok" or "ollama" for remote endpoints.`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Section B — server reachability and model list
+// ---------------------------------------------------------------------------
+
+/**
+ * Hits GET {baseUrl}/models with a 5-second timeout using native fetch.
+ *
+ * On success, parses the OpenAI-format response (`data[].id`) and returns
+ * the list of available model ID strings.
+ *
+ * @throws {@link OpenAICompatServerUnreachableError} on connection failure,
+ *   AbortError (timeout), or a non-2xx HTTP response.
+ */
+export async function validateServerReachable(baseUrl: string): Promise<string[]> {
+  const modelsUrl = `${baseUrl.replace(/\/$/, "")}/models`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5_000);
+
+  let response: Response;
+  try {
+    response = await fetch(modelsUrl, { signal: controller.signal });
+  } catch (err: unknown) {
+    clearTimeout(timer);
+    const isTimeout =
+      err instanceof Error && err.name === "AbortError";
+    const cause = isTimeout
+      ? "request timed out after 5 seconds"
+      : err instanceof Error
+        ? err.message
+        : String(err);
+    throw new OpenAICompatServerUnreachableError(baseUrl, cause);
+  }
+  clearTimeout(timer);
+
+  if (!response.ok) {
+    throw new OpenAICompatServerUnreachableError(
+      baseUrl,
+      `GET /models returned HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    throw new OpenAICompatServerUnreachableError(
+      baseUrl,
+      "GET /models response body is not valid JSON",
+    );
+  }
+
+  const data =
+    body !== null &&
+    typeof body === "object" &&
+    "data" in body &&
+    Array.isArray((body as { data: unknown }).data)
+      ? (body as { data: Array<{ id?: unknown }> }).data
+      : null;
+
+  if (data === null) {
+    throw new OpenAICompatServerUnreachableError(
+      baseUrl,
+      'GET /models response did not contain a "data" array (expected OpenAI /v1/models format)',
+    );
+  }
+
+  return data
+    .map((entry) => (typeof entry.id === "string" ? entry.id : null))
+    .filter((id): id is string => id !== null);
+}
+
+// ---------------------------------------------------------------------------
+// Section C — model presence check
+// ---------------------------------------------------------------------------
+
+/**
+ * Confirms that `model` appears in `availableModels` (exact string match).
+ *
+ * The server's /v1/models response is the authoritative source of truth.
+ * No config-side alias resolution is performed — the model ID must match
+ * exactly as returned by the server.
+ *
+ * @throws {@link OpenAICompatUnknownModelError} if the model is not found.
+ */
+export function validateModelPresent(
+  model: string,
+  availableModels: string[],
+  baseUrl: string,
+): void {
+  if (!availableModels.includes(model)) {
+    throw new OpenAICompatUnknownModelError(model, baseUrl);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Section D — convenience entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs all three startup validation checks in order for the given config:
+ *
+ *   1. {@link validateBaseUrl} — local/LAN address check (synchronous)
+ *   2. {@link validateServerReachable} — GET /v1/models reachability (async)
+ *   3. {@link validateModelPresent} — model presence in server response
+ *
+ * Called by the adapter on construction before the provider is returned
+ * to the daemon. Throws on the first failed check.
+ */
+export async function validateOpenAICompatConfig(
+  config: OpenAICompatProviderConfig,
+): Promise<void> {
+  validateBaseUrl(config.baseUrl);
+  const models = await validateServerReachable(config.baseUrl);
+  validateModelPresent(config.model, models, config.baseUrl);
+}

--- a/runtime/src/llm/openai-compat/openai-compat-filter.ts
+++ b/runtime/src/llm/openai-compat/openai-compat-filter.ts
@@ -55,7 +55,7 @@ export {
  *   - 172.16.0.0/12  (172.16.x.x – 172.31.x.x)
  */
 function isLocalHostname(hostname: string): boolean {
-  if (hostname === "localhost" || hostname === "::1") {
+  if (hostname === "localhost" || hostname === "[::1]" || hostname === "::1") {
     return true;
   }
 

--- a/runtime/src/llm/openai-compat/types.ts
+++ b/runtime/src/llm/openai-compat/types.ts
@@ -1,0 +1,92 @@
+/**
+ * OpenAI-compatible local LLM provider configuration types.
+ *
+ * Used by any server exposing the OpenAI /v1/chat/completions interface —
+ * LM Studio, llama.cpp server, vLLM — without requiring xAI credentials.
+ *
+ * @module
+ */
+
+import type { LLMProviderConfig } from "../types.js";
+import { LLMProviderError } from "../errors.js";
+import type { LLMFailureClass, LLMPipelineStopReason } from "../policy.js";
+
+/**
+ * Configuration for the openai-compat local inference provider.
+ */
+export interface OpenAICompatProviderConfig extends LLMProviderConfig {
+  /**
+   * Base URL of the OpenAI-compatible server (e.g. "http://127.0.0.1:1234/v1").
+   * Required. Validated on startup to resolve to a local or LAN address.
+   */
+  baseUrl: string;
+  /**
+   * API key passed in the Authorization header. Local servers do not
+   * validate this value; any non-empty string is accepted.
+   */
+  apiKey: string;
+  /**
+   * Model context window in tokens, used for prompt budget sizing.
+   * Required because local servers do not expose this via a standard API field.
+   */
+  contextWindowTokens: number;
+  /**
+   * End-to-end timeout in milliseconds for one chat request execution.
+   * 0 or undefined = unlimited.
+   */
+  requestTimeoutMs?: number;
+  /**
+   * Timeout in milliseconds for a single tool execution call.
+   * 0 or undefined = unlimited.
+   */
+  toolCallTimeoutMs?: number;
+}
+
+/**
+ * Thrown when the startup reachability check against GET /v1/models fails —
+ * either connection refused, network error, or 5s timeout.
+ *
+ * Maps to `failureClass: "provider_error"` for retry/circuit-breaker handling.
+ */
+export class OpenAICompatServerUnreachableError extends LLMProviderError {
+  public readonly failureClass: LLMFailureClass = "provider_error";
+  public readonly stopReason: LLMPipelineStopReason = "provider_error";
+  public readonly baseUrl: string;
+
+  constructor(baseUrl: string, cause: string) {
+    super(
+      "openai-compat",
+      `Local server at "${baseUrl}" is unreachable. ` +
+        `Ensure the server is running before starting the daemon. ` +
+        `Cause: ${cause}`,
+      503,
+    );
+    this.name = "OpenAICompatServerUnreachableError";
+    this.baseUrl = baseUrl;
+  }
+}
+
+/**
+ * Thrown when the configured model is not present in the server's
+ * GET /v1/models response.
+ *
+ * Maps to `failureClass: "provider_error"` — the server is reachable but
+ * the requested model has not been loaded.
+ */
+export class OpenAICompatUnknownModelError extends LLMProviderError {
+  public readonly failureClass: LLMFailureClass = "provider_error";
+  public readonly stopReason: LLMPipelineStopReason = "provider_error";
+  public readonly requestedModel: string;
+
+  constructor(requestedModel: string, baseUrl: string) {
+    super(
+      "openai-compat",
+      `Model "${requestedModel}" is not available at "${baseUrl}". ` +
+        `Check GET /v1/models on the running server and set llm.model in ` +
+        `config.json to one of the returned model IDs.`,
+      404,
+    );
+    this.name = "OpenAICompatUnknownModelError";
+    this.requestedModel = requestedModel;
+  }
+}


### PR DESCRIPTION
_feat(llm): add openai-compat provider for locally-hosted LLMs_Closes #352

## Summary

Adds an `openai-compat` LLM provider that targets any OpenAI-format inference server (LM Studio, llama.cpp, vLLM, etc.) without requiring xAI credentials. Enables local/LAN model inference with the full AgenC agent runtime.

## Changes

**New files:**
- `runtime/src/llm/openai-compat/types.ts` — `OpenAICompatProviderConfig` interface + two typed error classes (`OpenAICompatConfigError`, `OpenAICompatConnectionError`)
- - `runtime/src/llm/openai-compat/openai-compat-filter.ts` — three pure validators: URL locality check, server reachability (`GET /v1/models`), model presence
- - `runtime/src/llm/openai-compat/adapter.ts` — `OpenAICompatProvider` class implementing the `LLMProvider` interface
- - `runtime/src/llm/openai-compat/adapter.test.ts` — 40 unit tests (openai SDK mocked via `vi.mock`)
- - `runtime/src/llm/openai-compat/openai-compat-filter.test.ts` — 41 unit tests
- - `runtime/src/llm/openai-compat/adapter.live.test.ts` — 2 live integration tests (skipped in CI, require `OPENAI_COMPAT_BASE_URL` + `OPENAI_COMPAT_MODEL`)
**Modified files:**
- `runtime/src/gateway/types.ts` — added `"openai-compat"` to the provider union type
- - `runtime/src/gateway/llm-provider-manager.ts` — registered provider instantiation; `contextWindowTokens` defaults to `32768` (not 4096) because the AgenC system prompt exceeds 14K tokens
- - `docs/RUNTIME_API.md` — new module entry, minimal config example, Local Inference profile, 32768 minimum note
## Design decisions

- **`contextWindowTokens` required in config** — local servers don't expose context size via API. Default fallback is 32768.
- - **Tool call IDs use `crypto.randomUUID()`** — fixes the Ollama-style duplicate-ID bug where the tool name was reused as the call ID across turns.
- - **Three startup checks** — baseUrl must be local/LAN, server must respond to `GET /v1/models`, requested model must be present in the response.
- - **Live tests in a separate file** — `vi.mock("openai")` hoisting in `adapter.test.ts` replaces the real SDK; co-locating live tests would break them.
## Minimal config

```json
{
  "llm": {
    "provider": "openai-compat",
    "model": "google_gemma-4-26b-a4b-it",
    "baseUrl": "http://127.0.0.1:1234/v1",
    "apiKey": "local",
    "contextWindowTokens": 32768
  }
}
```

## Test results

- 81 unit tests passing, 0 failures in new files
- - 2 live tests passing against LM Studio 0.4.9 / Gemma 4 26B
- - 0 regressions (19 pre-existing upstream failures, none in changed files)