### PR TITLE
fix(runtime): defer specialist tools and normalize model routing

### DIFF
--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -164,3 +164,10 @@
 - **What worked:** Carrying interactive context as an explicit request payload, persisting it through replay and transcript metadata, and restoring read-state during hydration made resume and child/verifier launches reuse one consistent execution-location and prompt snapshot path.
 - **What didn't:** The new path had to be threaded through session replay, transcript projection, executor init, and child launch points together, because any one missing handoff would have left resume state coherent in one surface and stale in another.
 - **Rule added to CLAUDE.md:** no
+
+## PR #404: fix(runtime): defer specialist tools and normalize model routing
+- **Date:** 2026-04-15
+- **Files changed:** `runtime/src/gateway/{daemon,daemon-webchat-turn,daemon-text-channel-turn,channel-wiring,daemon-command-registry,tool-routing,shell-profile,interactive-context,chat-usage,model-route}.ts`, `runtime/src/llm/{chat-executor-types,chat-executor-fallback,chat-executor-model-orchestration,chat-executor-request,chat-executor-tool-loop}.ts`, `runtime/src/llm/grok/{adapter,xai-strict-filter}.ts`, `runtime/src/watch/{agenc-watch-session-utils,agenc-watch-surface-dispatch}.mjs`, `runtime/src/gateway/{daemon,tool-routing}.test.ts`, `runtime/src/llm/grok/xai-strict-filter.test.ts`
+- **What worked:** Moving non-default tools behind runtime-side discovery kept the default advertised bundle small while preserving later-turn access through persisted discovered tool state, and shared model-route normalization removed alias-only mismatch noise across runtime and watch surfaces.
+- **What didn't:** The runtime had previously treated the callable tool universe and the advertised tool bundle as the same thing, so the fix needed coordinated daemon, executor, and watch updates before the provider-cap behavior and route display lined up cleanly.
+- **Rule added to CLAUDE.md:** no

--- a/runtime/src/gateway/channel-wiring.ts
+++ b/runtime/src/gateway/channel-wiring.ts
@@ -117,6 +117,11 @@ export interface ChannelWiringDeps {
     history: readonly LLMMessage[],
     shellProfile?: SessionShellProfile,
   ): ToolRoutingDecision | undefined;
+  resolveAdvertisedToolNames?(
+    sessionId: string,
+    shellProfile: SessionShellProfile,
+    discoveredToolNames?: readonly string[],
+  ): readonly string[];
 
   recordToolRoutingOutcome(
     sessionId: string,
@@ -343,13 +348,23 @@ async function wireTelegram(
         includeTraceArtifacts: true,
         includePlannerSummaryInTrace: true,
         persistToDaemonMemory: true,
-        buildToolRoutingDecision: (sessionId, content, history) =>
+        buildToolRoutingDecision: (sessionId, content, history, _advertisedToolNames) =>
           deps.buildToolRoutingDecision(
             sessionId,
             content,
             history,
             resolveSessionShellProfile(session.metadata),
           ),
+        resolveAdvertisedToolNames: (
+          sessionId,
+          shellProfile,
+          discoveredToolNames,
+        ) =>
+          deps.resolveAdvertisedToolNames?.(
+            sessionId,
+            shellProfile,
+            discoveredToolNames,
+          ) ?? [],
         recordToolRoutingOutcome: (sessionId, summary) => {
           deps.recordToolRoutingOutcome(sessionId, summary);
         },
@@ -544,13 +559,23 @@ export async function wireExternalChannel(
         turnTraceId,
         memoryBackend: deps.memoryBackend,
         persistToDaemonMemory: channelName !== "concordia",
-        buildToolRoutingDecision: (sessionId, content, history) =>
+        buildToolRoutingDecision: (sessionId, content, history, _advertisedToolNames) =>
           deps.buildToolRoutingDecision(
             sessionId,
             content,
             history,
             resolveSessionShellProfile(session.metadata),
           ),
+        resolveAdvertisedToolNames: (
+          sessionId,
+          shellProfile,
+          discoveredToolNames,
+        ) =>
+          deps.resolveAdvertisedToolNames?.(
+            sessionId,
+            shellProfile,
+            discoveredToolNames,
+          ) ?? [],
         recordToolRoutingOutcome: (sessionId, summary) => {
           deps.recordToolRoutingOutcome(sessionId, summary);
         },

--- a/runtime/src/gateway/chat-usage.ts
+++ b/runtime/src/gateway/chat-usage.ts
@@ -24,6 +24,8 @@ export interface ChatUsagePayload {
   readonly compacted: boolean;
   readonly provider?: string;
   readonly model?: string;
+  readonly configuredModel?: string;
+  readonly resolvedModel?: string;
   readonly usedFallback?: boolean;
   readonly contextWindowTokens?: number;
   readonly promptTokens?: number;
@@ -51,6 +53,8 @@ interface BuildChatUsagePayloadInput {
   readonly compacted: boolean;
   readonly provider?: string;
   readonly model?: string;
+  readonly configuredModel?: string;
+  readonly resolvedModel?: string;
   readonly usedFallback?: boolean;
   readonly contextWindowTokens?: number;
   readonly callUsage?: readonly ChatCallUsageRecord[];
@@ -111,6 +115,8 @@ export function buildChatUsagePayload(
     compacted: input.compacted === true,
     ...(input.provider ? { provider: input.provider } : {}),
     ...(input.model ? { model: input.model } : {}),
+    ...(input.configuredModel ? { configuredModel: input.configuredModel } : {}),
+    ...(input.resolvedModel ? { resolvedModel: input.resolvedModel } : {}),
     ...(input.usedFallback === true ? { usedFallback: true } : {}),
     ...(input.economicsSummary
       ? {

--- a/runtime/src/gateway/daemon-command-registry.ts
+++ b/runtime/src/gateway/daemon-command-registry.ts
@@ -38,6 +38,10 @@ import {
   type SessionShellProfile,
 } from "./session.js";
 import {
+  formatModelRouteModelLabel,
+  normalizeModelRouteSnapshot,
+} from "./model-route.js";
+import {
   formatSessionWorkflowStage,
   formatSessionWorktreeMode,
   resolveSessionWorkflowState,
@@ -1611,6 +1615,8 @@ export interface CommandRegistryDaemonContext {
   getSessionModelInfo(sessionId: string): {
     provider: string;
     model: string;
+    configuredModel?: string;
+    resolvedModel?: string;
     usedFallback: boolean;
   } | undefined;
   handleConfigReload(): Promise<void>;
@@ -3956,6 +3962,9 @@ export function createDaemonCommandRegistry(
           taskResult: tasks,
           childInfos: ctx.listSubAgentInfo(resolvedSessionId),
         });
+        const modelLabel = modelInfo
+          ? `${modelInfo.provider}:${formatModelRouteModelLabel(modelInfo)}${modelInfo.usedFallback ? " (fallback)" : ""}`
+          : "unknown";
         await cmdCtx.replyResult({
           text: [
             "Shell session:",
@@ -3969,11 +3978,7 @@ export function createDaemonCommandRegistry(
               : []),
             `  Workspace root: ${workspaceRoot}`,
             `  History messages: ${session?.history.length ?? 0}`,
-            `  Model: ${
-              modelInfo
-                ? `${modelInfo.provider}:${modelInfo.model}${modelInfo.usedFallback ? " (fallback)" : ""}`
-                : "unknown"
-            }`,
+            `  Model: ${modelLabel}`,
             "",
             formatWorkflowOwnershipReply(ownership),
           ].join("\n"),
@@ -3990,7 +3995,7 @@ export function createDaemonCommandRegistry(
               historyMessages: session?.history.length ?? 0,
               ...(modelInfo
                 ? {
-                    model: `${modelInfo.provider}:${modelInfo.model}${modelInfo.usedFallback ? " (fallback)" : ""}`,
+                    model: modelLabel,
                   }
                 : {}),
               ownership: ownership.map((entry) => ({ ...entry })),
@@ -5515,11 +5520,21 @@ export function createDaemonCommandRegistry(
       const arg = cmdCtx.args.trim();
       const argLower = arg.toLowerCase();
       const configuredPrimaryProvider = ctx.gateway?.config.llm?.provider ?? "none";
+      const configuredPrimaryRoute = normalizeModelRouteSnapshot({
+        provider: configuredPrimaryProvider,
+        configuredModel:
+          ctx.gateway?.config.llm?.model ??
+          (configuredPrimaryProvider === "grok"
+            ? DEFAULT_GROK_MODEL
+            : "unknown"),
+        resolvedModel:
+          configuredPrimaryProvider === "grok"
+            ? normalizeGrokModel(ctx.gateway?.config.llm?.model) ??
+              DEFAULT_GROK_MODEL
+            : ctx.gateway?.config.llm?.model ?? "unknown",
+      });
       const configuredPrimaryModel =
-        configuredPrimaryProvider === "grok"
-          ? normalizeGrokModel(ctx.gateway?.config.llm?.model) ??
-            DEFAULT_GROK_MODEL
-          : ctx.gateway?.config.llm?.model ?? "unknown";
+        formatModelRouteModelLabel(configuredPrimaryRoute);
       const configuredFallbacks =
         ctx.gateway?.config.llm?.fallback?.map((entry) => (
           `${entry.provider}:${
@@ -5537,7 +5552,7 @@ export function createDaemonCommandRegistry(
         const lines = [
           "Model routing:",
           last
-            ? `  Last completion: ${last.model} (provider: ${last.provider}${last.usedFallback ? ", fallback used" : ""})`
+            ? `  Last completion: ${formatModelRouteModelLabel(last)} (provider: ${last.provider}${last.usedFallback ? ", fallback used" : ""})`
             : "  Last completion: none recorded for this session",
           `  Primary: ${configuredPrimaryProvider}:${configuredPrimaryModel}`,
           `  Fallbacks: ${configuredFallbacks.length > 0 ? configuredFallbacks.join(", ") : "none"}`,
@@ -5552,7 +5567,7 @@ export function createDaemonCommandRegistry(
             {
               label: "Last Completion",
               value: last
-                ? `${last.provider}:${last.model}${last.usedFallback ? " (fallback)" : ""}`
+                ? `${last.provider}:${formatModelRouteModelLabel(last)}${last.usedFallback ? " (fallback)" : ""}`
                 : "none recorded",
             },
             {

--- a/runtime/src/gateway/daemon-text-channel-turn.ts
+++ b/runtime/src/gateway/daemon-text-channel-turn.ts
@@ -17,6 +17,7 @@ import { hasActionableStatefulFallback } from "../llm/chat-executor-recovery.js"
 import type { GatewayMessage } from "./message.js";
 import {
   resolveSessionShellProfile,
+  type SessionShellProfile,
   type Session,
   type SessionManager,
 } from "./session.js";
@@ -83,6 +84,12 @@ import {
 const CONCORDIA_GENERATED_AGENTS_SCHEMA_NAME =
   "concordia_generated_agents";
 
+function uniqueToolNames(toolNames: readonly string[]): readonly string[] {
+  return Array.from(
+    new Set(toolNames.map((toolName) => toolName.trim()).filter(Boolean)),
+  );
+}
+
 function buildConcordiaGenerateAgentsStructuredOutput(
   msg: GatewayMessage,
 ): LLMStructuredOutputRequest | undefined {
@@ -130,7 +137,8 @@ function buildInteractiveTurnState(params: {
   readonly runtimeWorkspaceRoot?: string;
   readonly baseSystemPrompt: string;
   readonly readSeeds: readonly import("../tools/system/filesystem.js").SessionReadSeedEntry[];
-  readonly routedToolNames?: readonly string[];
+  readonly advertisedToolNames: readonly string[];
+  readonly discoveredToolNames?: readonly string[];
 }): InteractiveContextState {
   const existing =
     params.session.metadata["interactiveContextState"] as
@@ -157,9 +165,19 @@ function buildInteractiveTurnState(params: {
       sessionStartContextMessages:
         existing?.cacheSafePromptSnapshot?.sessionStartContextMessages ?? [],
       toolScopeFingerprint: buildInteractiveToolScopeFingerprint(
-        params.routedToolNames,
+        params.advertisedToolNames,
       ),
     }),
+    ...(params.advertisedToolNames.length > 0
+      ? { defaultAdvertisedToolNames: params.advertisedToolNames }
+      : existing?.defaultAdvertisedToolNames
+        ? { defaultAdvertisedToolNames: existing.defaultAdvertisedToolNames }
+        : {}),
+    ...(params.discoveredToolNames && params.discoveredToolNames.length > 0
+      ? { discoveredToolNames: params.discoveredToolNames }
+      : existing?.discoveredToolNames
+        ? { discoveredToolNames: existing.discoveredToolNames }
+        : {}),
     ...(existing?.summaryRef ? { summaryRef: existing.summaryRef } : {}),
     ...(existing?.forkCarryover ? { forkCarryover: existing.forkCarryover } : {}),
   };
@@ -184,7 +202,13 @@ interface ExecuteTextChannelTurnParams {
     sessionId: string,
     content: string,
     history: Session["history"],
+    advertisedToolNames: readonly string[],
   ) => ToolRoutingDecision | undefined;
+  readonly resolveAdvertisedToolNames?: (
+    sessionId: string,
+    shellProfile: SessionShellProfile,
+    discoveredToolNames?: readonly string[],
+  ) => readonly string[];
   readonly recordToolRoutingOutcome: (
     sessionId: string,
     summary: ChatToolRoutingSummary | undefined,
@@ -219,15 +243,28 @@ export async function executeTextChannelTurn(
     includeTraceArtifacts = false,
     includePlannerSummaryInTrace = false,
     buildToolRoutingDecision,
+    resolveAdvertisedToolNames,
     recordToolRoutingOutcome,
     persistToDaemonMemory = shouldPersistToDaemonMemory(msg),
     taskStore = null,
   } = params;
 
+  const shellProfile = resolveSessionShellProfile(session.metadata);
+  const existingInteractiveState =
+    session.metadata["interactiveContextState"] as
+      | InteractiveContextState
+      | undefined;
+  const advertisedToolNames =
+    resolveAdvertisedToolNames?.(
+      msg.sessionId,
+      shellProfile,
+      existingInteractiveState?.discoveredToolNames,
+    ) ?? [];
   const toolRoutingDecision = buildToolRoutingDecision(
     msg.sessionId,
     msg.content,
     session.history,
+    advertisedToolNames,
   );
   if (memoryBackend) {
     await appendTranscriptBatch(memoryBackend, msg.sessionId, [
@@ -240,7 +277,7 @@ export async function executeTextChannelTurn(
   }
   const profileAwareSystemPrompt = appendShellProfilePromptSection({
     systemPrompt,
-    profile: resolveSessionShellProfile(session.metadata),
+    profile: shellProfile,
   });
   const effectiveSystemPrompt = filterSystemPromptForToolRouting({
     systemPrompt: profileAwareSystemPrompt,
@@ -264,7 +301,8 @@ export async function executeTextChannelTurn(
     runtimeWorkspaceRoot,
     baseSystemPrompt: effectiveSystemPrompt,
     readSeeds: atMentionAttachments.readSeeds,
-    routedToolNames: toolRoutingDecision?.routedToolNames,
+    advertisedToolNames,
+    discoveredToolNames: existingInteractiveState?.discoveredToolNames,
   });
   persistSessionInteractiveContext(session, interactiveTurnState);
   const sessionInteractiveContext = buildSessionInteractiveContext(session, {
@@ -354,6 +392,12 @@ export async function executeTextChannelTurn(
     defaultMaxToolRounds,
     toolRoutingDecision,
   );
+  const routedToolNames =
+    toolRoutingDecision?.routedToolNames ?? advertisedToolNames;
+  const expandedToolNames = uniqueToolNames([
+    ...advertisedToolNames,
+    ...(toolRoutingDecision?.expandedToolNames ?? []),
+  ]);
   // Phase E: text-channel caller now drains the Phase C generator
   // via executeChatToLegacyResult. Identical semantics to the
   // direct chatExecutor.execute() call under the adapter shape —
@@ -384,13 +428,13 @@ export async function executeTextChannelTurn(
     ...(isConcordiaGenerateAgentsTurn
       ? { contextInjection: { memory: false } }
       : {}),
-    toolRouting: toolRoutingDecision
-      ? {
-          routedToolNames: toolRoutingDecision.routedToolNames,
-          expandedToolNames: toolRoutingDecision.expandedToolNames,
-          expandOnMiss: true,
-        }
-      : undefined,
+    toolRouting: {
+      advertisedToolNames,
+      routedToolNames,
+      expandedToolNames,
+      expandOnMiss: true,
+      persistDiscovery: true,
+    },
     ...(traceConfig.enabled
       ? {
           trace: {
@@ -586,9 +630,12 @@ export async function executeTextChannelTurn(
         result.sessionStartContextMessages ??
         interactiveTurnState.cacheSafePromptSnapshot?.sessionStartContextMessages,
       toolScopeFingerprint: buildInteractiveToolScopeFingerprint(
-        toolRoutingDecision?.routedToolNames,
+        advertisedToolNames,
       ),
     }),
+    discoveredToolNames:
+      result.toolDiscoverySummary?.discoveredToolNames ??
+      interactiveTurnState.discoveredToolNames,
   });
   sessionMgr.appendMessage(session.id, {
     role: "user",

--- a/runtime/src/gateway/daemon-webchat-turn.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.ts
@@ -65,6 +65,7 @@ import type { GatewayMessage } from "./message.js";
 import {
   resolveSessionShellProfile,
   SESSION_SHELL_PROFILE_METADATA_KEY,
+  type SessionShellProfile,
   type Session,
   type SessionManager,
 } from "./session.js";
@@ -111,7 +112,13 @@ interface ExecuteWebChatConversationTurnParams {
     sessionId: string,
     content: string,
     history: Session["history"],
+    advertisedToolNames: readonly string[],
   ) => ToolRoutingDecision | undefined;
+  readonly resolveAdvertisedToolNames?: (
+    sessionId: string,
+    shellProfile: SessionShellProfile,
+    discoveredToolNames?: readonly string[],
+  ) => readonly string[];
   readonly recordToolRoutingOutcome: (
     sessionId: string,
     summary: ChatToolRoutingSummary | undefined,
@@ -134,6 +141,10 @@ interface ExecuteWebChatConversationTurnParams {
     readonly effectiveHistory: readonly import("../llm/types.js").LLMMessage[];
     readonly executionEnvelope?: ExecutionEnvelope;
   }) => Promise<boolean>;
+}
+
+function uniqueToolNames(toolNames: readonly string[]): readonly string[] {
+  return Array.from(new Set(toolNames.map((toolName) => toolName.trim()).filter(Boolean)));
 }
 
 async function resolveWebChatTurnWorkspaceRoot(params: {
@@ -165,7 +176,8 @@ function buildInteractiveTurnState(params: {
   readonly runtimeWorkspaceRoot?: string;
   readonly baseSystemPrompt: string;
   readonly readSeeds: readonly import("../tools/system/filesystem.js").SessionReadSeedEntry[];
-  readonly routedToolNames?: readonly string[];
+  readonly advertisedToolNames: readonly string[];
+  readonly discoveredToolNames?: readonly string[];
 }): InteractiveContextState {
   const existing =
     params.session.metadata["interactiveContextState"] as
@@ -192,9 +204,19 @@ function buildInteractiveTurnState(params: {
       sessionStartContextMessages:
         existing?.cacheSafePromptSnapshot?.sessionStartContextMessages ?? [],
       toolScopeFingerprint: buildInteractiveToolScopeFingerprint(
-        params.routedToolNames,
+        params.advertisedToolNames,
       ),
     }),
+    ...(params.advertisedToolNames.length > 0
+      ? { defaultAdvertisedToolNames: params.advertisedToolNames }
+      : existing?.defaultAdvertisedToolNames
+        ? { defaultAdvertisedToolNames: existing.defaultAdvertisedToolNames }
+        : {}),
+    ...(params.discoveredToolNames && params.discoveredToolNames.length > 0
+      ? { discoveredToolNames: params.discoveredToolNames }
+      : existing?.discoveredToolNames
+        ? { discoveredToolNames: existing.discoveredToolNames }
+        : {}),
     ...(existing?.summaryRef ? { summaryRef: existing.summaryRef } : {}),
     ...(existing?.forkCarryover ? { forkCarryover: existing.forkCarryover } : {}),
   };
@@ -221,6 +243,7 @@ export async function executeWebChatConversationTurn(
     traceConfig,
     turnTraceId,
     buildToolRoutingDecision,
+    resolveAdvertisedToolNames,
     recordToolRoutingOutcome,
     getSessionTokenUsage,
     onModelInfo,
@@ -240,10 +263,22 @@ export async function executeWebChatConversationTurn(
       shellProfile:
         msg.metadata?.[SESSION_SHELL_PROFILE_METADATA_KEY],
     });
+    const shellProfile = resolveSessionShellProfile(session.metadata);
+    const existingInteractiveState =
+      session.metadata["interactiveContextState"] as
+        | InteractiveContextState
+        | undefined;
+    const advertisedToolNames =
+      resolveAdvertisedToolNames?.(
+        msg.sessionId,
+        shellProfile,
+        existingInteractiveState?.discoveredToolNames,
+      ) ?? [];
     const toolRoutingDecision = buildToolRoutingDecision(
       msg.sessionId,
       msg.content,
       session.history,
+      advertisedToolNames,
     );
     await appendTranscriptBatch(memoryBackend, msg.sessionId, [
       createTranscriptMessageEvent({
@@ -254,7 +289,7 @@ export async function executeWebChatConversationTurn(
     ]);
     const profileAwareSystemPrompt = appendShellProfilePromptSection({
       systemPrompt: getSystemPrompt(),
-      profile: resolveSessionShellProfile(session.metadata),
+      profile: shellProfile,
     });
     const effectiveSystemPrompt = filterSystemPromptForToolRouting({
       systemPrompt: profileAwareSystemPrompt,
@@ -352,12 +387,19 @@ export async function executeWebChatConversationTurn(
       workspaceRoot: runtimeWorkspaceRoot,
     });
     seedSessionReadState(msg.sessionId, atMentionAttachments.readSeeds);
+    const routedToolNames =
+      toolRoutingDecision?.routedToolNames ?? advertisedToolNames;
+    const expandedToolNames = uniqueToolNames([
+      ...advertisedToolNames,
+      ...(toolRoutingDecision?.expandedToolNames ?? []),
+    ]);
     const interactiveTurnState = buildInteractiveTurnState({
       session,
       runtimeWorkspaceRoot,
       baseSystemPrompt: effectiveSystemPrompt,
       readSeeds: atMentionAttachments.readSeeds,
-      routedToolNames: toolRoutingDecision?.routedToolNames,
+      advertisedToolNames,
+      discoveredToolNames: existingInteractiveState?.discoveredToolNames,
     });
     persistSessionInteractiveContext(session, interactiveTurnState);
     const sessionInteractiveContext = buildSessionInteractiveContext(session, {
@@ -418,13 +460,13 @@ export async function executeWebChatConversationTurn(
       ...(sessionInteractiveContext
         ? { interactiveContext: sessionInteractiveContext }
         : {}),
-      toolRouting: toolRoutingDecision
-        ? {
-            routedToolNames: toolRoutingDecision.routedToolNames,
-            expandedToolNames: toolRoutingDecision.expandedToolNames,
-            expandOnMiss: true,
-          }
-        : undefined,
+      toolRouting: {
+        advertisedToolNames,
+        routedToolNames,
+        expandedToolNames,
+        expandOnMiss: true,
+        persistDiscovery: true,
+      },
       trace: {
         ...(traceConfig.enabled && traceConfig.includeProviderPayloads
           ? {
@@ -615,6 +657,9 @@ export async function executeWebChatConversationTurn(
     persistSessionStartContextMessages(session, result);
     persistSessionInteractiveContext(session, {
       ...interactiveTurnState,
+      discoveredToolNames:
+        result.toolDiscoverySummary?.discoveredToolNames ??
+        interactiveTurnState.discoveredToolNames,
       cacheSafePromptSnapshot: buildInteractivePromptSnapshot({
         baseSystemPrompt: effectiveSystemPrompt,
         systemContextBlocks: [],
@@ -623,7 +668,7 @@ export async function executeWebChatConversationTurn(
           result.sessionStartContextMessages ??
           interactiveTurnState.cacheSafePromptSnapshot?.sessionStartContextMessages,
         toolScopeFingerprint: buildInteractiveToolScopeFingerprint(
-          toolRoutingDecision?.routedToolNames,
+          advertisedToolNames,
         ),
       }),
     });
@@ -683,6 +728,8 @@ export async function executeWebChatConversationTurn(
         compacted: result.compacted ?? false,
         provider: result.provider,
         model: result.model,
+        configuredModel: result.configuredModel,
+        resolvedModel: result.resolvedModel,
         usedFallback: result.usedFallback,
         contextWindowTokens,
         callUsage: result.callUsage,

--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -2586,7 +2586,6 @@ describe("DaemonManager", () => {
     }];
 
     expect((dm as any).getAdvertisedToolNames()).toEqual([
-      "desktop.bash",
       "web_search",
     ]);
   });

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -206,8 +206,8 @@ import {
 } from "./session.js";
 import {
   coerceSessionShellProfile,
-  getShellProfilePreferredToolNames,
 } from "./shell-profile.js";
+import { coerceInteractiveContextState } from "./interactive-context.js";
 import type { DelegationContractSpec } from "../utils/delegation-validation.js";
 import {
   getDefaultWorkspacePath,
@@ -231,7 +231,6 @@ import {
 import { ProgressTracker, summarizeToolResult } from "./progress.js";
 import {
   inferContextWindowTokens,
-  normalizeGrokModel,
 } from "./context-window.js";
 import {
   buildModelRoutingPolicy,
@@ -254,7 +253,15 @@ import {
   type ExternalChannelRegistry,
 } from "./channel-wiring.js";
 import { createChannelHostServices } from "../plugins/channel-host-services.js";
-import { buildStaticToolRoutingDecision } from "./tool-routing.js";
+import {
+  buildAdvertisedToolBundle,
+  buildStaticToolRoutingDecision,
+} from "./tool-routing.js";
+import {
+  canonicalizeProviderModel,
+  formatModelRouteModelLabel,
+  normalizeModelRouteSnapshot,
+} from "./model-route.js";
 import type { ProactiveCommunicator } from "./proactive.js";
 import {
   loadAgentDefinitions,
@@ -1139,6 +1146,8 @@ export class DaemonManager {
     {
       provider: string;
       model: string;
+      configuredModel?: string;
+      resolvedModel?: string;
       usedFallback: boolean;
       updatedAt: number;
     }
@@ -2209,7 +2218,7 @@ export class DaemonManager {
     this._chatExecutor = createChatExecutor({
       providers,
       toolHandler: baseToolHandler,
-      allowedTools: this.getAdvertisedToolNames(),
+      allowedTools: this.getCallableToolNames(),
       skillInjector,
       memoryRetriever,
       learningProvider,
@@ -2532,6 +2541,7 @@ export class DaemonManager {
                 }).allowed
                   ? effectiveProfile
                   : DEFAULT_SESSION_SHELL_PROFILE,
+                this.getDiscoveredToolNamesForSession(sessionId),
               ),
               shellProfile: effectiveProfile,
             });
@@ -3602,10 +3612,26 @@ export class DaemonManager {
               }).allowed
                 ? effectiveProfile
                 : DEFAULT_SESSION_SHELL_PROFILE,
+              this.getDiscoveredToolNamesForSession(sessionId),
             ),
             shellProfile: effectiveProfile,
           });
         },
+      resolveAdvertisedToolNames: (sessionId, shellProfile, discoveredToolNames) =>
+        this.getAdvertisedToolNames(
+          undefined,
+          this.evaluateShellFeatureAdmission({
+            sessionId,
+            feature: "codingCommands",
+            domain: "shell",
+          }).allowed
+            ? this.resolveEffectiveShellProfile({
+                sessionId,
+                preferred: shellProfile,
+              })
+            : DEFAULT_SESSION_SHELL_PROFILE,
+          discoveredToolNames,
+        ),
       recordToolRoutingOutcome: () => {
         /* no-op: static routing, nothing to record */
       },
@@ -3841,7 +3867,7 @@ export class DaemonManager {
       fallbackBehavior: resolvedSubAgentConfig.fallbackBehavior,
       unsafeBenchmarkMode: resolvedSubAgentConfig.unsafeBenchmarkMode,
       resolveAvailableToolNames: () =>
-        this.getAdvertisedToolNames(
+        this.getCallableToolNames(
           this._subAgentToolCatalog.map((tool) => tool.name),
         ),
     });
@@ -3899,7 +3925,7 @@ export class DaemonManager {
       this._chatExecutor = createChatExecutor({
         providers,
         toolHandler: this._baseToolHandler!,
-        allowedTools: this.getAdvertisedToolNames(),
+        allowedTools: this.getCallableToolNames(),
         skillInjector,
         memoryRetriever,
         learningProvider,
@@ -6396,25 +6422,58 @@ export class DaemonManager {
     return event.sessionId;
   }
 
-  private getAdvertisedToolNames(
-    toolNames: readonly string[] = this._llmTools.map(
-      (tool) => tool.function.name,
-    ),
-    shellProfile: SessionShellProfile = DEFAULT_SESSION_SHELL_PROFILE,
+  private getCallableToolNames(
+    toolNames?: readonly string[],
   ): readonly string[] {
+    const baseToolNames =
+      toolNames ??
+      this._llmTools.map((tool) => tool.function.name);
     const providerNative = getProviderNativeAdvertisedToolNames(this._primaryLlmConfig);
-    const merged = Array.from(new Set([...toolNames, ...providerNative]));
-    if (shellProfile === DEFAULT_SESSION_SHELL_PROFILE) {
-      return merged;
-    }
-    const preferred = getShellProfilePreferredToolNames({
-      profile: shellProfile,
-      availableToolNames: merged,
+    return Array.from(new Set([...baseToolNames, ...providerNative]));
+  }
+
+  private getDiscoveredToolNamesForSession(
+    sessionId: string,
+  ): readonly string[] {
+    const metadata = this._webSessionManager?.get(sessionId)?.metadata;
+    const interactiveState = coerceInteractiveContextState(
+      metadata?.interactiveContextState,
+    );
+    return interactiveState?.discoveredToolNames ?? [];
+  }
+
+  private getAdvertisedToolNames(
+    toolNames?: readonly string[],
+    shellProfile: SessionShellProfile = DEFAULT_SESSION_SHELL_PROFILE,
+    discoveredToolNames?: readonly string[],
+  ): readonly string[] {
+    const resolvedToolNames = this.getCallableToolNames(toolNames);
+    const allowedToolNames = new Set(resolvedToolNames);
+    const providerNative = getProviderNativeAdvertisedToolNames(this._primaryLlmConfig)
+      .filter((toolName) => allowedToolNames.has(toolName));
+    const fullCatalog = this._toolRegistry?.listCatalog() ?? [];
+    const filteredCatalog =
+      fullCatalog.length > 0
+        ? fullCatalog.filter((entry) => allowedToolNames.has(entry.name))
+        : resolvedToolNames.map((toolName) => ({
+            name: toolName,
+            description: "",
+            inputSchema: {},
+            metadata: {
+              family: "other",
+              source: providerNative.includes(toolName)
+                ? ("provider_native" as const)
+                : ("builtin" as const),
+              hiddenByDefault: false,
+              mutating: false,
+            },
+          }));
+    return buildAdvertisedToolBundle({
+      toolCatalog: filteredCatalog,
+      providerNativeToolNames: providerNative,
+      shellProfile,
+      discoveredToolNames,
     });
-    if (!preferred.includes("system.searchTools") && merged.includes("system.searchTools")) {
-      return [...preferred, "system.searchTools"];
-    }
-    return preferred;
   }
 
   private relaySubAgentLifecycleEvent(
@@ -6842,6 +6901,7 @@ export class DaemonManager {
       availableToolNames: this.getAdvertisedToolNames(
         undefined,
         advertisedShellProfile,
+        this.getDiscoveredToolNamesForSession(sessionId),
       ),
       defaultWorkingDirectory: this._hostWorkspacePath ?? undefined,
       workspaceAliasRoot: this._hostWorkspacePath ?? undefined,
@@ -6967,6 +7027,7 @@ export class DaemonManager {
       availableToolNames: this.getAdvertisedToolNames(
         undefined,
         advertisedShellProfile,
+        this.getDiscoveredToolNamesForSession(sessionId),
       ),
       defaultWorkingDirectory: this._hostWorkspacePath ?? undefined,
       workspaceAliasRoot: this._hostWorkspacePath ?? undefined,
@@ -7111,24 +7172,36 @@ export class DaemonManager {
     if (MODEL_QUERY_RE.test(msg.content)) {
       const last = this._sessionModelInfo.get(msg.sessionId);
       if (last) {
+        const modelLabel = formatModelRouteModelLabel(last);
         await webChat.send({
           sessionId: msg.sessionId,
           content:
-            `Last completion model: ${last.model} ` +
+            `Last completion model: ${modelLabel} ` +
             `(provider: ${last.provider}${last.usedFallback ? ", fallback used" : ""})`,
         });
         return;
       }
 
       const configuredProvider = this.gateway?.config.llm?.provider ?? "none";
-      const configuredModel =
-        normalizeGrokModel(this.gateway?.config.llm?.model) ??
-        (configuredProvider === "grok" ? DEFAULT_GROK_MODEL : "unknown");
+      const configuredRoute = normalizeModelRouteSnapshot({
+        provider: configuredProvider,
+        configuredModel:
+          this.gateway?.config.llm?.model ??
+          (configuredProvider === "grok" ? DEFAULT_GROK_MODEL : "unknown"),
+        resolvedModel:
+          canonicalizeProviderModel(
+            configuredProvider,
+            this.gateway?.config.llm?.model,
+          ) ??
+          (configuredProvider === "grok" ? DEFAULT_GROK_MODEL : "unknown"),
+      });
       await webChat.send({
         sessionId: msg.sessionId,
         content:
           `No completion recorded yet for this session. ` +
-          `Configured primary is ${configuredProvider}:${configuredModel}.`,
+          `Configured primary is ${configuredProvider}:${
+            formatModelRouteModelLabel(configuredRoute)
+          }.`,
       });
       return;
     }
@@ -7435,24 +7508,52 @@ export class DaemonManager {
                     metadata: sessionMgr.get(sessionId)?.metadata ?? {},
                   })
                 : DEFAULT_SESSION_SHELL_PROFILE,
+              this.getDiscoveredToolNamesForSession(sessionId),
             ),
             shellProfile: this.resolveEffectiveShellProfile({
               sessionId,
               metadata: sessionMgr.get(sessionId)?.metadata ?? {},
             }),
           }),
+        resolveAdvertisedToolNames: (sessionId, shellProfile, discoveredToolNames) =>
+          this.getAdvertisedToolNames(
+            undefined,
+            shellProfile === DEFAULT_SESSION_SHELL_PROFILE
+              ? this.evaluateShellFeatureAdmission({
+                  sessionId,
+                  feature: "codingCommands",
+                  domain: "shell",
+                }).allowed
+                ? this.resolveEffectiveShellProfile({
+                    sessionId,
+                    metadata: sessionMgr.get(sessionId)?.metadata ?? {},
+                  })
+                : DEFAULT_SESSION_SHELL_PROFILE
+              : shellProfile,
+            discoveredToolNames,
+          ),
         recordToolRoutingOutcome: () => {
           /* no-op */
         },
         getSessionTokenUsage: (sessionId) =>
           chatExecutor.getSessionTokenUsage(sessionId),
         onModelInfo: (result) => {
-          if (!result.model) return;
-          this._sessionModelInfo.set(msg.sessionId, {
+          const route = normalizeModelRouteSnapshot({
             provider: result.provider,
             model: result.model,
+            configuredModel: result.configuredModel,
+            resolvedModel: result.resolvedModel,
             usedFallback: result.usedFallback,
             updatedAt: Date.now(),
+          });
+          if (!route) return;
+          this._sessionModelInfo.set(msg.sessionId, {
+            provider: route.provider,
+            model: route.model,
+            configuredModel: route.configuredModel,
+            resolvedModel: route.resolvedModel,
+            usedFallback: route.usedFallback,
+            updatedAt: route.updatedAt,
           });
         },
         taskStore: this._taskTrackerStore,

--- a/runtime/src/gateway/interactive-context.ts
+++ b/runtime/src/gateway/interactive-context.ts
@@ -44,6 +44,8 @@ export interface InteractiveContextState {
   readonly version: 1;
   readonly executionLocation?: InteractiveContextExecutionLocation;
   readonly readSeeds: readonly SessionReadSeedEntry[];
+  readonly defaultAdvertisedToolNames?: readonly string[];
+  readonly discoveredToolNames?: readonly string[];
   readonly cacheSafePromptSnapshot?: InteractiveContextPromptSnapshot;
   readonly summaryRef?: InteractiveContextSummaryRef;
   readonly forkCarryover?: InteractiveContextForkCarryover;
@@ -115,6 +117,22 @@ function cloneReadSeeds(
         : {}),
       ...(entry.viewKind ? { viewKind: entry.viewKind } : {}),
     }));
+}
+
+function cloneToolNames(
+  toolNames: readonly string[] | undefined,
+): readonly string[] {
+  if (!toolNames || toolNames.length === 0) {
+    return [];
+  }
+  return Array.from(
+    new Set(
+      toolNames
+        .filter((toolName): toolName is string => typeof toolName === "string")
+        .map((toolName) => toolName.trim())
+        .filter((toolName) => toolName.length > 0),
+    ),
+  );
 }
 
 export function buildInteractiveToolScopeFingerprint(
@@ -295,6 +313,16 @@ export function coerceInteractiveContextState(
       ? (record.readSeeds as readonly SessionReadSeedEntry[])
       : [],
   );
+  const defaultAdvertisedToolNames = cloneToolNames(
+    Array.isArray(record.defaultAdvertisedToolNames)
+      ? (record.defaultAdvertisedToolNames as readonly string[])
+      : [],
+  );
+  const discoveredToolNames = cloneToolNames(
+    Array.isArray(record.discoveredToolNames)
+      ? (record.discoveredToolNames as readonly string[])
+      : [],
+  );
   const cacheSafePromptSnapshot = coercePromptSnapshot(
     record.cacheSafePromptSnapshot,
   );
@@ -304,6 +332,10 @@ export function coerceInteractiveContextState(
     version: 1,
     readSeeds,
     ...(executionLocation ? { executionLocation } : {}),
+    ...(defaultAdvertisedToolNames.length > 0
+      ? { defaultAdvertisedToolNames }
+      : {}),
+    ...(discoveredToolNames.length > 0 ? { discoveredToolNames } : {}),
     ...(cacheSafePromptSnapshot ? { cacheSafePromptSnapshot } : {}),
     ...(summaryRef ? { summaryRef } : {}),
     ...(forkCarryover ? { forkCarryover } : {}),
@@ -325,6 +357,16 @@ export function cloneInteractiveContextState(
             state.executionLocation,
           )!,
         }
+      : {}),
+    ...(state.defaultAdvertisedToolNames
+      ? {
+          defaultAdvertisedToolNames: cloneToolNames(
+            state.defaultAdvertisedToolNames,
+          ),
+        }
+      : {}),
+    ...(state.discoveredToolNames
+      ? { discoveredToolNames: cloneToolNames(state.discoveredToolNames) }
       : {}),
     ...(state.cacheSafePromptSnapshot
       ? {

--- a/runtime/src/gateway/model-route.ts
+++ b/runtime/src/gateway/model-route.ts
@@ -1,0 +1,124 @@
+import { normalizeGrokModel } from "./context-window.js";
+
+export interface ModelRouteSnapshot {
+  readonly provider: string;
+  readonly model: string;
+  readonly configuredModel?: string;
+  readonly resolvedModel?: string;
+  readonly usedFallback: boolean;
+  readonly source?: string;
+  readonly updatedAt: number;
+}
+
+function normalizeText(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function canonicalizeProviderModel(
+  provider: unknown,
+  model: unknown,
+): string | undefined {
+  const normalizedModel = normalizeText(model);
+  if (!normalizedModel) {
+    return undefined;
+  }
+  const normalizedProvider = normalizeText(provider)?.toLowerCase();
+  if (normalizedProvider === "grok") {
+    return normalizeGrokModel(normalizedModel) ?? normalizedModel;
+  }
+  return normalizedModel;
+}
+
+export function normalizeModelRouteSnapshot(
+  input: {
+    readonly provider?: unknown;
+    readonly llmProvider?: unknown;
+    readonly model?: unknown;
+    readonly llmModel?: unknown;
+    readonly configuredModel?: unknown;
+    readonly resolvedModel?: unknown;
+    readonly usedFallback?: unknown;
+    readonly source?: unknown;
+    readonly updatedAt?: unknown;
+  } = {},
+  nowMs: () => number = Date.now,
+): ModelRouteSnapshot | null {
+  const provider =
+    normalizeText(input.provider) ??
+    normalizeText(input.llmProvider) ??
+    "unknown";
+  const configuredModel =
+    normalizeText(input.configuredModel) ??
+    normalizeText(input.model) ??
+    normalizeText(input.llmModel);
+  const resolvedModel =
+    canonicalizeProviderModel(
+      provider,
+      input.resolvedModel ??
+        input.model ??
+        input.llmModel ??
+        input.configuredModel,
+    );
+  if (!configuredModel && !resolvedModel) {
+    return null;
+  }
+  const source = normalizeText(input.source);
+  const updatedAt =
+    typeof input.updatedAt === "number" && Number.isFinite(input.updatedAt)
+      ? input.updatedAt
+      : nowMs();
+  const model = resolvedModel ?? configuredModel ?? "unknown";
+  return {
+    provider,
+    model,
+    ...(configuredModel ? { configuredModel } : {}),
+    ...(resolvedModel ? { resolvedModel } : {}),
+    usedFallback: input.usedFallback === true,
+    ...(source ? { source } : {}),
+    updatedAt,
+  };
+}
+
+export function formatModelRouteModelLabel(
+  route: Pick<ModelRouteSnapshot, "model" | "configuredModel" | "resolvedModel"> | null | undefined,
+): string {
+  if (!route) {
+    return "unknown";
+  }
+  const configuredModel = normalizeText(route.configuredModel);
+  const resolvedModel = normalizeText(route.resolvedModel) ?? normalizeText(route.model);
+  if (
+    configuredModel &&
+    resolvedModel &&
+    configuredModel !== resolvedModel
+  ) {
+    return `${configuredModel} (${resolvedModel})`;
+  }
+  return resolvedModel ?? configuredModel ?? "unknown";
+}
+
+export function modelRouteSnapshotsMatch(
+  left: Pick<ModelRouteSnapshot, "provider" | "configuredModel" | "resolvedModel" | "model"> | null | undefined,
+  right: Pick<ModelRouteSnapshot, "provider" | "configuredModel" | "resolvedModel" | "model"> | null | undefined,
+): boolean {
+  const leftProvider = normalizeText(left?.provider);
+  const rightProvider = normalizeText(right?.provider);
+  const leftResolved =
+    canonicalizeProviderModel(leftProvider, left?.resolvedModel ?? left?.model) ??
+    normalizeText(left?.configuredModel);
+  const rightResolved =
+    canonicalizeProviderModel(rightProvider, right?.resolvedModel ?? right?.model) ??
+    normalizeText(right?.configuredModel);
+  return Boolean(
+    leftProvider &&
+      rightProvider &&
+      leftResolved &&
+      rightResolved &&
+      leftProvider === rightProvider &&
+      leftResolved === rightResolved,
+  );
+}

--- a/runtime/src/gateway/shell-profile.ts
+++ b/runtime/src/gateway/shell-profile.ts
@@ -10,6 +10,53 @@ export type SessionShellProfile =
 
 export const DEFAULT_SESSION_SHELL_PROFILE: SessionShellProfile = "general";
 
+const GENERAL_DEFAULT_TOOL_NAMES = [
+  "system.readFile",
+  "system.readFileRange",
+  "system.writeFile",
+  "system.appendFile",
+  "system.editFile",
+  "system.listDir",
+  "system.stat",
+  "system.mkdir",
+  "system.move",
+  "system.delete",
+  "system.bash",
+  "system.grep",
+  "system.glob",
+  "system.searchFiles",
+  "system.repoInventory",
+  "system.gitStatus",
+  "system.gitDiff",
+  "system.gitShow",
+  "system.gitBranchInfo",
+  "system.gitChangeSummary",
+  "system.gitWorktreeList",
+  "system.gitWorktreeStatus",
+  "system.applyPatch",
+  "system.symbolSearch",
+  "system.symbolDefinition",
+  "system.symbolReferences",
+  "system.searchTools",
+  "system.httpGet",
+  "system.httpPost",
+  "system.httpFetch",
+  "system.browse",
+  "system.extractLinks",
+  "system.htmlToMarkdown",
+  "verification.listProbes",
+  "verification.runProbe",
+  "task.create",
+  "task.list",
+  "task.get",
+  "task.update",
+  "execute_with_agent",
+  "coordinator",
+  "web_search",
+  "x_search",
+  "file_search",
+] as const;
+
 const SESSION_SHELL_PROFILES = [
   "general",
   "coding",
@@ -52,11 +99,12 @@ const DEFINITIONS: Record<SessionShellProfile, ShellProfileDefinition> = {
     promptHeading: "General Shell Defaults",
     promptRules: [
       "Handle mixed operator, coding, research, and workflow requests without assuming one narrow mode.",
-      "Prefer direct progress with the current tool surface, but do not over-specialize toward repository work unless the user is clearly doing coding.",
+      "Prefer direct progress with the current default tool bundle, but use system.searchTools to discover non-default tools before trying them.",
       "Keep delegation, tool choice, and verification proportional to the task.",
       "When a general turn becomes non-trivial implementation work, expect independent verifier confirmation before reporting completion instead of self-certifying the result.",
     ],
     toolPrefixes: [],
+    exactToolNames: GENERAL_DEFAULT_TOOL_NAMES,
     delegationDefault: "balanced",
     approvalHints: {
       readOnlyBias: false,
@@ -264,10 +312,6 @@ export function getShellProfilePreferredToolNames(params: {
   availableToolNames: readonly string[];
 }): readonly string[] {
   const definition = getShellProfileDefinition(params.profile);
-  if (definition.name === "general") {
-    return params.availableToolNames;
-  }
-
   const matches = params.availableToolNames.filter((toolName) => {
     if (definition.exactToolNames?.includes(toolName)) {
       return true;

--- a/runtime/src/gateway/tool-routing.test.ts
+++ b/runtime/src/gateway/tool-routing.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { buildStaticToolRoutingDecision } from "./tool-routing.js";
+import {
+  buildAdvertisedToolBundle,
+  buildStaticToolRoutingDecision,
+} from "./tool-routing.js";
 
 const TOOLS = [
   "system.readFile",
@@ -111,5 +114,100 @@ describe("buildStaticToolRoutingDecision", () => {
       "playwright.browser_click",
     ]);
     expect(decision?.diagnostics.clusterKey).toBe("shell-profile:coding:expanded");
+  });
+});
+
+describe("buildAdvertisedToolBundle", () => {
+  it("keeps deferred specialist tools out of the default general bundle", () => {
+    const toolNames = buildAdvertisedToolBundle({
+      shellProfile: "general",
+      toolCatalog: [
+        {
+          name: "system.readFile",
+          description: "Read files",
+          inputSchema: {},
+          metadata: {
+            family: "filesystem",
+            source: "builtin",
+            hiddenByDefault: false,
+            mutating: false,
+          },
+        },
+        {
+          name: "system.searchTools",
+          description: "Discover tools",
+          inputSchema: {},
+          metadata: {
+            family: "meta",
+            source: "builtin",
+            hiddenByDefault: false,
+            mutating: false,
+          },
+        },
+        {
+          name: "mcp.remote.inspect",
+          description: "Inspect remote MCP state",
+          inputSchema: {},
+          metadata: {
+            family: "remote",
+            source: "mcp",
+            hiddenByDefault: false,
+            mutating: false,
+          },
+        },
+        {
+          name: "system.remoteSession.start",
+          description: "Start a remote session",
+          inputSchema: {},
+          metadata: {
+            family: "remote",
+            source: "builtin",
+            hiddenByDefault: false,
+            mutating: true,
+          },
+        },
+      ],
+    });
+
+    expect(toolNames).toEqual([
+      "system.readFile",
+      "system.searchTools",
+    ]);
+  });
+
+  it("re-advertises discovered deferred tools on later turns", () => {
+    const toolNames = buildAdvertisedToolBundle({
+      shellProfile: "general",
+      discoveredToolNames: ["mcp.remote.inspect"],
+      toolCatalog: [
+        {
+          name: "system.searchTools",
+          description: "Discover tools",
+          inputSchema: {},
+          metadata: {
+            family: "meta",
+            source: "builtin",
+            hiddenByDefault: false,
+            mutating: false,
+          },
+        },
+        {
+          name: "mcp.remote.inspect",
+          description: "Inspect remote MCP state",
+          inputSchema: {},
+          metadata: {
+            family: "remote",
+            source: "mcp",
+            hiddenByDefault: false,
+            mutating: false,
+          },
+        },
+      ],
+    });
+
+    expect(toolNames).toEqual([
+      "system.searchTools",
+      "mcp.remote.inspect",
+    ]);
   });
 });

--- a/runtime/src/gateway/tool-routing.ts
+++ b/runtime/src/gateway/tool-routing.ts
@@ -1,9 +1,9 @@
 /**
- * Tool routing — claude_code-shaped static allowed tools (Cut 4.2).
+ * Tool routing — static allowed tools (Cut 4.2).
  *
  * Replaces the previous 1,848-LOC `ToolRouter` machinery whose entire
  * job was per-phase narrowing of the tool set during planner-driven
- * turns. claude_code exposes a single static tool list per query, so
+ * turns. The runtime now exposes a single static tool list per query, so
  * the runtime no longer maintains per-cluster routing caches, schema
  * cost ledgers, or invalidation signals.
  *
@@ -25,6 +25,7 @@ import {
   getShellProfilePreferredToolNames,
   type SessionShellProfile,
 } from "./shell-profile.js";
+import type { ToolCatalogEntry } from "../tools/types.js";
 
 export interface ToolRoutingDecision {
   readonly routedToolNames: readonly string[];
@@ -71,6 +72,103 @@ const FAMILY_PREFIXES: Readonly<Record<string, readonly string[]>> = {
   sandbox: ["system.sandbox"],
   operator: ["agenc.", "social.", "wallet."],
 };
+
+const ALWAYS_INLINE_TOOL_NAMES = new Set([
+  "system.searchTools",
+  "execute_with_agent",
+  "coordinator",
+  "task.create",
+  "task.list",
+  "task.get",
+  "task.update",
+  "verification.listProbes",
+  "verification.runProbe",
+]);
+
+const DEFERRED_NAME_PREFIXES = [
+  "mcp.",
+  "mcp:",
+  "system.remoteJob",
+  "system.remoteSession",
+  "system.sandbox",
+  "system.server",
+  "system.process",
+  "system.research",
+  "social.",
+  "wallet.",
+];
+
+const DEFERRED_NAME_PATTERNS = [
+  /^playwright\.browser_(?:session|attach|connect|transfer|share|handoff|close|tabs?)/i,
+  /^browser_(?:session|attach|connect|transfer|share|handoff|close|tabs?)/i,
+];
+
+function uniqueToolNames(toolNames: readonly string[]): readonly string[] {
+  return Array.from(
+    new Set(toolNames.map((toolName) => toolName.trim()).filter(Boolean)),
+  );
+}
+
+function isDeferredToolName(toolName: string): boolean {
+  if (ALWAYS_INLINE_TOOL_NAMES.has(toolName)) {
+    return false;
+  }
+  return (
+    DEFERRED_NAME_PREFIXES.some((prefix) => toolName.startsWith(prefix)) ||
+    DEFERRED_NAME_PATTERNS.some((pattern) => pattern.test(toolName))
+  );
+}
+
+function isDeferredCatalogEntry(entry: ToolCatalogEntry): boolean {
+  if (ALWAYS_INLINE_TOOL_NAMES.has(entry.name)) {
+    return false;
+  }
+  if (entry.metadata.hiddenByDefault || entry.metadata.source === "mcp") {
+    return true;
+  }
+  if (entry.metadata.family === "operator" && entry.metadata.mutating) {
+    return true;
+  }
+  return isDeferredToolName(entry.name);
+}
+
+export function buildAdvertisedToolBundle(params: {
+  readonly toolCatalog: readonly ToolCatalogEntry[];
+  readonly providerNativeToolNames?: readonly string[];
+  readonly shellProfile?: SessionShellProfile;
+  readonly discoveredToolNames?: readonly string[];
+  readonly explicitAllowedToolNames?: readonly string[];
+}): readonly string[] {
+  if (params.explicitAllowedToolNames && params.explicitAllowedToolNames.length > 0) {
+    return uniqueToolNames(params.explicitAllowedToolNames);
+  }
+
+  const profile = params.shellProfile ?? "general";
+  const inlineCatalogToolNames = params.toolCatalog
+    .filter((entry) => !isDeferredCatalogEntry(entry))
+    .map((entry) => entry.name);
+  const preferredInlineToolNames = getShellProfilePreferredToolNames({
+    profile,
+    availableToolNames: inlineCatalogToolNames,
+  });
+  const effectiveInlineToolNames =
+    preferredInlineToolNames.length > 0
+      ? preferredInlineToolNames
+      : inlineCatalogToolNames;
+  const providerNativeToolNames = (params.providerNativeToolNames ?? []).filter(
+    (toolName) => !isDeferredToolName(toolName),
+  );
+  const discoveredToolNames = (params.discoveredToolNames ?? []).filter(
+    (toolName) =>
+      params.toolCatalog.some((entry) => entry.name === toolName) ||
+      (params.providerNativeToolNames ?? []).includes(toolName),
+  );
+  return uniqueToolNames([
+    ...effectiveInlineToolNames,
+    ...providerNativeToolNames,
+    ...discoveredToolNames,
+  ]);
+}
 
 function estimateToolSchemaChars(toolNames: readonly string[]): number {
   return toolNames.reduce((total, toolName) => total + toolName.length, 0);

--- a/runtime/src/llm/chat-executor-fallback.ts
+++ b/runtime/src/llm/chat-executor-fallback.ts
@@ -320,6 +320,8 @@ export async function callWithFallback(
           )
           : await provider.chat(serializedBoundedMessages, providerChatOptions);
         const response = assertValidLLMResponse(provider.name, rawResponse);
+        const configuredModel =
+          (await provider.getExecutionProfile?.())?.model;
 
         if (response.finishReason === "error") {
           throw (
@@ -351,6 +353,7 @@ export async function callWithFallback(
         return {
           response,
           providerName: provider.name,
+          configuredModel,
           usedFallback: i > 0,
           durationMs: Math.max(1, Date.now() - callStartedAt),
           beforeBudget,

--- a/runtime/src/llm/chat-executor-model-orchestration.ts
+++ b/runtime/src/llm/chat-executor-model-orchestration.ts
@@ -57,6 +57,7 @@ import {
   type RuntimeEconomicsPolicy,
   type RuntimeRunClass,
 } from "./run-budget.js";
+import { canonicalizeProviderModel } from "../gateway/model-route.js";
 import { trackTokenUsage } from "./chat-executor-state.js";
 import type {
   ChatCallUsageRecord,
@@ -424,6 +425,11 @@ export async function callModelForPhase(
   ctx.lastModelStreamedContent = next.streamedContent;
   ctx.providerName = next.providerName;
   ctx.responseModel = next.response.model;
+  ctx.configuredModel = next.configuredModel;
+  ctx.resolvedModel = canonicalizeProviderModel(
+    next.providerName,
+    next.response.model ?? next.configuredModel,
+  );
   ctx.providerEvidence = mergeProviderEvidence(
     ctx.providerEvidence,
     next.response.providerEvidence,

--- a/runtime/src/llm/chat-executor-request.ts
+++ b/runtime/src/llm/chat-executor-request.ts
@@ -320,6 +320,8 @@ export async function executeRequest(
       content: finalContent,
       provider: ctx.providerName,
       model: ctx.responseModel,
+      configuredModel: ctx.configuredModel,
+      resolvedModel: ctx.resolvedModel,
       usedFallback: ctx.usedFallback,
       toolCalls: ctx.allToolCalls,
       providerEvidence: ctx.providerEvidence,
@@ -338,6 +340,14 @@ export async function executeRequest(
           expanded: ctx.routedToolsExpanded,
         }
         : undefined,
+      ...(ctx.toolDiscoveryEnabled
+        ? {
+            toolDiscoverySummary: {
+              advertisedToolNames: ctx.defaultAdvertisedToolNames,
+              discoveredToolNames: ctx.discoveredToolNames,
+            },
+          }
+        : {}),
       plannerSummary,
       economicsSummary: buildRuntimeEconomicsSummary(
         deps.economicsPolicy,

--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -825,6 +825,36 @@ function enforceTopLevelExecutionEnvelope(params: {
   return undefined;
 }
 
+function extractDiscoveredToolNamesFromSearchResult(
+  toolName: string,
+  result: string,
+): readonly string[] {
+  if (toolName !== "system.searchTools") {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(result) as { results?: unknown };
+    if (!Array.isArray(parsed.results)) {
+      return [];
+    }
+    return Array.from(
+      new Set(
+        parsed.results
+          .map((entry) =>
+            typeof entry === "object" &&
+            entry !== null &&
+            typeof (entry as { name?: unknown }).name === "string"
+              ? String((entry as { name: string }).name).trim()
+              : "",
+          )
+          .filter((toolName) => toolName.length > 0),
+      ),
+    );
+  } catch {
+    return [];
+  }
+}
+
 export async function executeSingleToolCall(
   ctx: ExecutionContext,
   toolCall: LLMToolCall,
@@ -1281,6 +1311,24 @@ export async function executeSingleToolCall(
     durationMs: exec.durationMs,
     toolCallId: toolCall.id,
   });
+  if (!exec.toolFailed && ctx.toolDiscoveryEnabled) {
+    const discoveredToolNames = extractDiscoveredToolNamesFromSearchResult(
+      toolCall.name,
+      result,
+    );
+    if (discoveredToolNames.length > 0) {
+      ctx.discoveredToolNames = Array.from(
+        new Set([...ctx.discoveredToolNames, ...discoveredToolNames]),
+      );
+      applyActiveRoutedToolNames(ctx, [
+        ...ctx.activeRoutedToolNames,
+        ...discoveredToolNames,
+      ]);
+      loopState.activeRoutedToolSet = buildActiveRoutedToolSet(
+        ctx.activeRoutedToolNames,
+      );
+    }
+  }
   callbacks.emitExecutionTrace(ctx, {
     type: "tool_dispatch_finished",
     phase: "tool_followup",

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -236,12 +236,16 @@ export interface ChatExecuteParams {
   readonly interactiveContext?: InteractiveContextRequest;
   /** Optional per-turn tool-routing subset and expansion policy. */
   readonly toolRouting?: {
+    /** Effective advertised bundle for this turn before any lexical narrowing. */
+    readonly advertisedToolNames?: readonly string[];
     /** Initial routed subset for this turn. */
     readonly routedToolNames?: readonly string[];
     /** One-turn expanded subset used on suspected routing misses. */
     readonly expandedToolNames?: readonly string[];
     /** Enable one-turn expansion retry on routed-tool misses. */
     readonly expandOnMiss?: boolean;
+    /** Enable discovery-driven widening for later model recalls in the same turn. */
+    readonly persistDiscovery?: boolean;
   };
   /** Require at least one successful tool call before accepting a final answer. */
   readonly requiredToolEvidence?: {
@@ -349,12 +353,19 @@ export interface ChatToolRoutingSummary {
   readonly expanded: boolean;
 }
 
+export interface ChatToolDiscoverySummary {
+  readonly advertisedToolNames: readonly string[];
+  readonly discoveredToolNames: readonly string[];
+}
+
 /** Result returned from ChatExecutor.execute(). */
 export interface ChatExecutorResult {
   readonly content: string;
   readonly provider: string;
   /** Actual model identifier returned by the provider for the final response. */
   readonly model?: string;
+  readonly configuredModel?: string;
+  readonly resolvedModel?: string;
   readonly usedFallback: boolean;
   readonly toolCalls: readonly ToolCallRecord[];
   readonly providerEvidence?: LLMProviderEvidence;
@@ -370,6 +381,8 @@ export interface ChatExecutorResult {
   readonly statefulSummary?: ChatStatefulSummary;
   /** Per-turn dynamic tool-routing diagnostics for this execution. */
   readonly toolRoutingSummary?: ChatToolRoutingSummary;
+  /** Discovery-driven deferred-tool state captured for this execution. */
+  readonly toolDiscoverySummary?: ChatToolDiscoverySummary;
   /** Planner/executor routing summary and ROI diagnostics. */
   readonly plannerSummary?: ChatPlannerSummary;
   /** Runtime-owned economics summary for routing, ceilings, and downgrades. */
@@ -582,6 +595,7 @@ export interface CooldownEntry {
 export interface FallbackResult {
   response: LLMResponse;
   providerName: string;
+  configuredModel?: string;
   usedFallback: boolean;
   beforeBudget: ChatPromptShape;
   afterBudget: ChatPromptShape;
@@ -657,6 +671,8 @@ export interface ExecutionContext {
   readonly requestDeadlineAt: number;
   readonly initialRoutedToolNames: readonly string[];
   readonly expandedRoutedToolNames: readonly string[];
+  readonly defaultAdvertisedToolNames: readonly string[];
+  readonly toolDiscoveryEnabled: boolean;
   readonly canExpandOnRoutingMiss: boolean;
   readonly hasHistory: boolean;
   readonly plannerDecision: PlannerDecision;
@@ -691,6 +707,8 @@ export interface ExecutionContext {
   usedFallback: boolean;
   providerName: string;
   responseModel?: string;
+  configuredModel?: string;
+  resolvedModel?: string;
   response?: LLMResponse;
   finalContent: string;
   lastModelStreamedContent: string;
@@ -706,6 +724,7 @@ export interface ExecutionContext {
   validationCode?: DelegationOutputValidationCode;
   activeRoutedToolNames: readonly string[];
   transientRoutedToolNames: readonly string[] | undefined;
+  discoveredToolNames: readonly string[];
   routedToolsExpanded: boolean;
   routedToolMisses: number;
   plannerSummaryState: FullPlannerSummaryState;
@@ -805,6 +824,9 @@ export function buildDefaultExecutionContext(
         : Number.POSITIVE_INFINITY,
     initialRoutedToolNames: params.initialRoutedToolNames,
     expandedRoutedToolNames: params.expandedRoutedToolNames,
+    defaultAdvertisedToolNames:
+      params.toolRouting?.advertisedToolNames ?? params.initialRoutedToolNames,
+    toolDiscoveryEnabled: params.toolRouting?.persistDiscovery === true,
     canExpandOnRoutingMiss: Boolean(
       params.toolRouting?.expandOnMiss &&
       params.expandedRoutedToolNames.length > 0,
@@ -852,6 +874,8 @@ export function buildDefaultExecutionContext(
     usedFallback: false,
     providerName: config.providerName,
     responseModel: undefined,
+    configuredModel: undefined,
+    resolvedModel: undefined,
     response: undefined,
     finalContent: "",
     lastModelStreamedContent: "",
@@ -868,6 +892,7 @@ export function buildDefaultExecutionContext(
     validationCode: undefined,
     activeRoutedToolNames: params.initialRoutedToolNames,
     transientRoutedToolNames: undefined,
+    discoveredToolNames: [],
     routedToolsExpanded: false,
     routedToolMisses: 0,
     plannerSummaryState: {

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -827,6 +827,7 @@ export class GrokProvider implements LLMProvider {
     string,
     ProviderNativeToolDefinition
   >();
+  private readonly warnedPostFlightAnomalies = new Set<string>();
   private readonly toolChars: number;
   private readonly statefulConfig: ResolvedLLMStatefulResponsesConfig;
   private readonly statefulSessions = new Map<string, StatefulSessionAnchor>();
@@ -881,6 +882,27 @@ export class GrokProvider implements LLMProvider {
         (sum, definition) => sum + definition.schemaChars,
         0,
       );
+  }
+
+  private logPostFlightAnomaly(anomaly: {
+    code: string;
+    message: string;
+    evidence?: Record<string, unknown>;
+  }): void {
+    const warningKey =
+      anomaly.code === "model_silently_aliased"
+        ? `${anomaly.code}:${String(anomaly.evidence?.requestedModel ?? "")}:${String(anomaly.evidence?.responseModel ?? "")}`
+        : undefined;
+    if (warningKey) {
+      if (this.warnedPostFlightAnomalies.has(warningKey)) {
+        return;
+      }
+      this.warnedPostFlightAnomalies.add(warningKey);
+    }
+    console.warn(
+      `[GrokProvider] xAI post-flight anomaly (${anomaly.code}): ${anomaly.message}`,
+      anomaly.evidence,
+    );
   }
 
   async chat(
@@ -1327,10 +1349,7 @@ export class GrokProvider implements LLMProvider {
               );
             }
             if (anomaly.code === "truncated_response_mid_sentence") continue;
-            console.warn(
-              `[GrokProvider] xAI post-flight anomaly (${anomaly.code}): ${anomaly.message}`,
-              anomaly.evidence,
-            );
+            this.logPostFlightAnomaly(anomaly);
           }
 
           this.emitToolCallNormalizationIssues(
@@ -2077,10 +2096,9 @@ export class GrokProvider implements LLMProvider {
       // with tools. The previous "graceful fallback" silently stripped the
       // structured output and continued, which masked configuration errors
       // (e.g. a planner step routed to grok-code-fast-1 instead of a Grok 4
-      // model). The CLAUDE.md learned rule "xAI Compatibility: Treat
-      // undocumented 200s as untrusted until semantics are proven" applies:
-      // raise the assertion at the adapter boundary so the user fixes the
-      // config instead of getting a degraded run.
+      // model). The runtime compatibility rule for undocumented 200s
+      // applies here: raise the assertion at the adapter boundary so the
+      // user fixes the config instead of getting a degraded run.
       assertXaiStructuredOutputToolCompatibility({
         providerName: this.name,
         model: typeof params.model === "string" ? params.model : this.config.model,
@@ -2664,10 +2682,7 @@ export class GrokProvider implements LLMProvider {
         // response that bypassed the mitigation. Either way the
         // truncation has already been logged; don't re-log here.
         if (anomaly.code === "truncated_response_mid_sentence") continue;
-        console.warn(
-          `[GrokProvider] xAI post-flight anomaly (${anomaly.code}): ${anomaly.message}`,
-          anomaly.evidence,
-        );
+        this.logPostFlightAnomaly(anomaly);
       }
     }
 

--- a/runtime/src/llm/grok/xai-strict-filter.test.ts
+++ b/runtime/src/llm/grok/xai-strict-filter.test.ts
@@ -693,10 +693,10 @@ describe("validateXaiResponsePostFlight (silent-drop detection — the bug we hi
 });
 
 describe("validateXaiResponsePostFlight (model aliasing)", () => {
-  it("detects silent server alias when requested ≠ response and not in alias map", () => {
+  it("detects a true model mismatch after canonical normalization", () => {
     const result = validateXaiResponsePostFlight({
       request: { ...plainTextRequest(), model: "grok-4.20-beta-0309-reasoning" },
-      response: responseWith({ model: "grok-4.20-0309-reasoning" }),
+      response: responseWith({ model: "grok-code-fast-1" }),
     });
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
@@ -705,8 +705,18 @@ describe("validateXaiResponsePostFlight (model aliasing)", () => {
     });
     expect(result[0]?.evidence).toMatchObject({
       requestedModel: "grok-4.20-beta-0309-reasoning",
-      responseModel: "grok-4.20-0309-reasoning",
+      responseModel: "grok-code-fast-1",
     });
+  });
+
+  it("does NOT flag canonical alias-equivalent model IDs as silent aliasing", () => {
+    const result = validateXaiResponsePostFlight({
+      request: { ...plainTextRequest(), model: "grok-4.20-beta-0309-reasoning" },
+      response: responseWith({ model: "grok-4.20-0309-reasoning" }),
+    });
+    expect(
+      result.find((a) => a.code === "model_silently_aliased"),
+    ).toBeUndefined();
   });
 
   it("does NOT flag documented bare-name alias as silent aliasing", () => {

--- a/runtime/src/llm/grok/xai-strict-filter.ts
+++ b/runtime/src/llm/grok/xai-strict-filter.ts
@@ -19,17 +19,15 @@
  * The validators exist because the OpenAI Node SDK is a thin HTTP client
  * with no xAI-specific schema validation. xAI accepts almost any request
  * body, returns 200, and the failure surfaces as semantic degradation that
- * the runtime never catches. The CLAUDE.md learned rule
- * **"xAI Compatibility: Treat undocumented 200s as untrusted until
- * semantics are proven"** captures the failure class this module enforces.
+ * the runtime never catches. The runtime compatibility rule
+ * **"Treat undocumented 200s as untrusted until semantics are proven"**
+ * captures the failure class this module enforces.
  *
  * Every field, model ID, and shape constraint in this file was sourced
  * directly from `mcp__xai-docs__get_doc_page` against `developers/models`,
  * `developers/model-capabilities/text/generate-text`,
  * `developers/model-capabilities/text/reasoning`, and
- * `developers/tools/function-calling` on 2026-04-09. See
- * `/home/tetsuo/.claude/plans/ethereal-twirling-cerf.md` for the source
- * citations and the failure modes this module is designed to catch.
+ * `developers/tools/function-calling` on 2026-04-09.
  *
  * Three real failures from 2026-04-09 that this filter would have caught
  * before the user ever saw them:
@@ -54,6 +52,7 @@
 
 import { LLMProviderError } from "../errors.js";
 import type { LLMFailureClass, LLMPipelineStopReason } from "../policy.js";
+import { canonicalizeProviderModel } from "../../gateway/model-route.js";
 
 // ---------------------------------------------------------------------------
 // Section A — documented xAI Responses API contract
@@ -159,8 +158,8 @@ const SERVER_SIDE_TOOL_CALL_OUTPUT_TYPES: ReadonlySet<string> = new Set([
  *
  * The validator rejects any `model` value that does not appear here OR in
  * {@link DOCUMENTED_XAI_MODEL_ALIASES}. xAI silently aliases unknown model
- * IDs server-side, which we treat as untrusted under the CLAUDE.md
- * "xAI Compatibility: Treat undocumented 200s as untrusted" rule.
+ * IDs server-side, which we treat as untrusted under the runtime
+ * compatibility rule for undocumented 200s.
  */
 const DOCUMENTED_XAI_MODEL_IDS: ReadonlySet<string> = new Set([
   // Grok 4 family — current
@@ -902,10 +901,19 @@ export function validateXaiResponsePostFlight(params: {
     typeof params.request.model === "string" ? params.request.model : "";
   const responseModel =
     typeof params.response.model === "string" ? params.response.model : "";
+  const requestedCanonicalModel = canonicalizeProviderModel(
+    "grok",
+    requestedModel,
+  );
+  const responseCanonicalModel = canonicalizeProviderModel(
+    "grok",
+    responseModel,
+  );
   if (
     requestedModel.length > 0 &&
     responseModel.length > 0 &&
-    requestedModel !== responseModel
+    requestedModel !== responseModel &&
+    requestedCanonicalModel !== responseCanonicalModel
   ) {
     const expectedAlias = DOCUMENTED_XAI_MODEL_ALIASES.get(requestedModel);
     if (expectedAlias !== responseModel) {
@@ -917,7 +925,16 @@ export function validateXaiResponsePostFlight(params: {
           `the response payload. This may be a silent server-side alias ` +
           `that the documented alias map does not cover. Verify the ` +
           `configured model is in the xAI catalog.`,
-        evidence: { requestedModel, responseModel },
+        evidence: {
+          requestedModel,
+          responseModel,
+          ...(requestedCanonicalModel
+            ? { requestedCanonicalModel }
+            : {}),
+          ...(responseCanonicalModel
+            ? { responseCanonicalModel }
+            : {}),
+        },
       });
     }
   }

--- a/runtime/src/watch/agenc-watch-session-utils.mjs
+++ b/runtime/src/watch/agenc-watch-session-utils.mjs
@@ -7,6 +7,48 @@
 
 import { sanitizeInlineText } from "./agenc-watch-text-utils.mjs";
 
+const GROK_MODEL_ALIASES = new Map([
+  ["grok-4.20-0309-reasoning", "grok-4.20-beta-0309-reasoning"],
+  ["grok-4.20-0309-non-reasoning", "grok-4.20-beta-0309-non-reasoning"],
+  ["grok-4.20-multi-agent-0309", "grok-4.20-multi-agent-beta-0309"],
+  ["grok-4.20-reasoning", "grok-4.20-beta-0309-reasoning"],
+  ["grok-4.20-non-reasoning", "grok-4.20-beta-0309-non-reasoning"],
+  ["grok-4.20-multi-agent", "grok-4.20-multi-agent-beta-0309"],
+  ["grok-4.20-beta-latest-reasoning", "grok-4.20-beta-0309-reasoning"],
+  ["grok-4.20-beta-latest-non-reasoning", "grok-4.20-beta-0309-non-reasoning"],
+  ["grok-4.20-multi-agent-beta-latest", "grok-4.20-multi-agent-beta-0309"],
+]);
+
+function canonicalizeProviderModel(provider, model) {
+  const normalizedProvider = sanitizeInlineText(provider ?? "").toLowerCase();
+  const normalizedModel = sanitizeInlineText(model ?? "");
+  if (!normalizedModel) {
+    return null;
+  }
+  if (normalizedProvider === "grok") {
+    return GROK_MODEL_ALIASES.get(normalizedModel) ?? normalizedModel;
+  }
+  return normalizedModel;
+}
+
+function formatCanonicalModelLabel(route) {
+  if (!route) {
+    return "unknown";
+  }
+  const configuredModel = sanitizeInlineText(route.configuredModel ?? "");
+  const resolvedModel =
+    sanitizeInlineText(route.resolvedModel ?? "") ||
+    sanitizeInlineText(route.model ?? "");
+  if (
+    configuredModel &&
+    resolvedModel &&
+    configuredModel !== resolvedModel
+  ) {
+    return `${configuredModel} (${resolvedModel})`;
+  }
+  return resolvedModel || configuredModel || "unknown";
+}
+
 export function normalizeSessionValue(value) {
   const text = sanitizeInlineText(String(value ?? ""));
   if (!text) {
@@ -30,22 +72,32 @@ export function normalizeModelRoute(input = {}, nowMs) {
     input.provider ??
       input.llmProvider ??
       "",
-  );
-  const model = sanitizeInlineText(
-    input.model ??
+  ) || "unknown";
+  const configuredModel = sanitizeInlineText(
+    input.configuredModel ??
+      input.model ??
       input.llmModel ??
       "",
   );
+  const resolvedModel = canonicalizeProviderModel(
+    provider,
+    input.resolvedModel ??
+      input.model ??
+      input.llmModel ??
+      input.configuredModel,
+  );
+  if (!configuredModel && !resolvedModel) {
+    return null;
+  }
   const source = sanitizeInlineText(
     input.source ??
       "",
   );
-  if (!provider && !model) {
-    return null;
-  }
   return {
-    provider: provider || "unknown",
-    model: model || "unknown",
+    provider,
+    model: resolvedModel || configuredModel || "unknown",
+    ...(configuredModel ? { configuredModel } : {}),
+    ...(resolvedModel ? { resolvedModel } : {}),
     usedFallback: input.usedFallback === true,
     ...(source ? { source } : {}),
     updatedAt: Number.isFinite(Number(input.updatedAt))
@@ -59,7 +111,7 @@ export function formatModelRouteLabel(route, { includeProvider = true } = {}) {
     return "routing pending";
   }
   const provider = sanitizeInlineText(route.provider ?? "");
-  const model = sanitizeInlineText(route.model ?? "");
+  const model = formatCanonicalModelLabel(route);
   const parts = [];
   if (model) {
     parts.push(model);
@@ -77,6 +129,27 @@ export function modelRouteTone(route, hasLiveRoute) {
   if (!route) return "slate";
   if (route.usedFallback) return "amber";
   return hasLiveRoute ? "teal" : "slate";
+}
+
+export function modelRoutesMatch(left, right) {
+  const leftProvider = sanitizeInlineText(left?.provider ?? "");
+  const rightProvider = sanitizeInlineText(right?.provider ?? "");
+  const leftModel = canonicalizeProviderModel(
+    leftProvider,
+    left?.resolvedModel ?? left?.model ?? left?.configuredModel,
+  );
+  const rightModel = canonicalizeProviderModel(
+    rightProvider,
+    right?.resolvedModel ?? right?.model ?? right?.configuredModel,
+  );
+  return Boolean(
+    leftProvider &&
+      rightProvider &&
+      leftModel &&
+      rightModel &&
+      leftProvider === rightProvider &&
+      leftModel === rightModel,
+  );
 }
 
 export function shouldSurfaceTransientStatus(value) {

--- a/runtime/src/watch/agenc-watch-surface-dispatch.mjs
+++ b/runtime/src/watch/agenc-watch-surface-dispatch.mjs
@@ -67,9 +67,19 @@ function preferredRunSurfaceState(payload, priorState) {
 
 function modelRoutesMatch(left, right) {
   const leftProvider = String(left?.provider ?? "").trim();
-  const leftModel = String(left?.model ?? "").trim();
+  const leftModel = String(
+    left?.resolvedModel ??
+      left?.model ??
+      left?.configuredModel ??
+      "",
+  ).trim();
   const rightProvider = String(right?.provider ?? "").trim();
-  const rightModel = String(right?.model ?? "").trim();
+  const rightModel = String(
+    right?.resolvedModel ??
+      right?.model ??
+      right?.configuredModel ??
+      "",
+  ).trim();
   return Boolean(
     leftProvider &&
     leftModel &&


### PR DESCRIPTION
## Summary
- move non-default tools behind runtime-side discovery and persist discovered tool state for interactive sessions
- advertise a smaller default bundle while keeping discovered tools available on later recalls and later turns
- normalize configured versus resolved model IDs across runtime, session, and watch surfaces and suppress alias-only mismatch noise

Fixes #403

## Test plan
- [x] `./node_modules/.bin/tsc -p runtime/tsconfig.json --noEmit`
- [x] `./node_modules/.bin/vitest run runtime/src/gateway/daemon.test.ts runtime/src/gateway/daemon-webchat-turn.test.ts runtime/src/gateway/daemon-text-channel-turn.test.ts runtime/src/gateway/tool-routing.test.ts runtime/src/llm/grok/xai-strict-filter.test.ts`
- [x] `./node_modules/.bin/vitest run runtime/src/gateway/daemon-command-registry.test.ts runtime/src/gateway/channel-wiring.test.ts`
- [x] `node --test runtime/tests/watch/agenc-watch-surface-dispatch.test.mjs runtime/tests/watch/agenc-watch-frame.test.mjs runtime/tests/watch/agenc-watch-frame-snapshot.test.mjs runtime/tests/watch/agenc-watch-live-replay.test.mjs`
- [x] `npm run techdebt`