### PR TITLE
refactor(runtime): stabilize background continuation and verifier reuse

### DIFF
--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -171,3 +171,10 @@
 - **What worked:** Moving non-default tools behind runtime-side discovery kept the default advertised bundle small while preserving later-turn access through persisted discovered tool state, and shared model-route normalization removed alias-only mismatch noise across runtime and watch surfaces.
 - **What didn't:** The runtime had previously treated the callable tool universe and the advertised tool bundle as the same thing, so the fix needed coordinated daemon, executor, and watch updates before the provider-cap behavior and route display lined up cleanly.
 - **Rule added to CLAUDE.md:** no
+
+## PR #405: refactor(runtime): stabilize background continuation and verifier reuse
+- **Date:** 2026-04-15
+- **Files changed:** `runtime/src/gateway/{background-run-store,background-run-supervisor,background-run-supervisor-types,run-domains,sub-agent,top-level-verifier}.ts`, `runtime/src/llm/{chat-executor-tool-loop,chat-executor-types}.ts`, `runtime/src/llm/grok/adapter.ts`, `runtime/src/llm/provider-capabilities.ts`, and the matching runtime tests
+- **What worked:** Persisting interactive continuation state for background runs, reusing verifier child sessions, keeping workspace runs from self-completing on weak evidence, and carrying child resume anchors across restarts removed the repeated verifier respawns and the long-run replay drift.
+- **What didn't:** The continuation behavior was split across provider defaults, background-run state, child-session persistence, and verifier verdict parsing, so closing the gap required coordinated changes and test updates instead of a single runtime toggle.
+- **Rule added to CLAUDE.md:** no

--- a/runtime/src/gateway/background-run-store.ts
+++ b/runtime/src/gateway/background-run-store.ts
@@ -23,11 +23,13 @@ import {
   loadTranscript,
   recoverTranscriptHistory,
 } from "./session-transcript.js";
+import type { InteractiveContextState } from "./interactive-context.js";
 import {
   coerceSessionShellProfile,
   DEFAULT_SESSION_SHELL_PROFILE,
   type SessionShellProfile,
 } from "./shell-profile.js";
+import { coerceInteractiveContextState } from "./interactive-context.js";
 import type { Logger } from "../utils/logger.js";
 import { silentLogger } from "../utils/logger.js";
 import { KeyedAsyncQueue } from "../utils/keyed-async-queue.js";
@@ -316,6 +318,11 @@ export interface BackgroundRunCompactionState {
   readonly lastProviderAnchorAt?: number;
 }
 
+export type BackgroundRunContinuationMode =
+  | "provider_continuation"
+  | "transcript_resume"
+  | "full_replay_fallback";
+
 export interface BackgroundRunRecentSnapshot {
   readonly version: typeof AGENT_RUN_SCHEMA_VERSION;
   readonly runId: string;
@@ -344,6 +351,9 @@ export interface BackgroundRunRecentSnapshot {
   readonly fenceToken: number;
   readonly preferredWorkerId?: string;
   readonly workerAffinityKey?: string;
+  readonly continuationMode?: BackgroundRunContinuationMode;
+  readonly verifierSessionId?: string;
+  readonly verifierStage?: RuntimeVerifierStage;
 }
 
 export interface PersistedBackgroundRun {
@@ -369,6 +379,10 @@ export interface PersistedBackgroundRun {
   readonly lastWakeReason?: BackgroundRunLastWakeReason;
   readonly completionProgress?: WorkflowProgressSnapshot;
   readonly carryForward?: BackgroundRunCarryForwardState;
+  readonly interactiveContextState?: InteractiveContextState;
+  readonly continuationMode?: BackgroundRunContinuationMode;
+  readonly verifierSessionId?: string;
+  readonly verifierStage?: RuntimeVerifierStage;
   readonly blocker?: BackgroundRunBlockerState;
   readonly approvalState: BackgroundRunApprovalState;
   readonly budgetState: BackgroundRunBudgetState;
@@ -384,6 +398,15 @@ export interface PersistedBackgroundRun {
   readonly leaseOwnerId?: string;
   readonly leaseExpiresAt?: number;
 }
+
+type RuntimeVerifierStage =
+  | "inactive"
+  | "pending"
+  | "running"
+  | "passed"
+  | "retry"
+  | "failed"
+  | "skipped";
 
 export interface BackgroundRunDispatchItem {
   readonly version: typeof AGENT_RUN_SCHEMA_VERSION;
@@ -1972,8 +1995,33 @@ interface CoercedRunCore {
   readonly contract: BackgroundRunContract;
   readonly completionProgress?: WorkflowProgressSnapshot;
   readonly carryForward?: BackgroundRunCarryForwardState;
+  readonly interactiveContextState?: InteractiveContextState;
   readonly pendingSignals: BackgroundRunSignal[];
   readonly observedTargets: BackgroundRunObservedTarget[];
+}
+
+function isBackgroundRunContinuationMode(
+  value: unknown,
+): value is BackgroundRunContinuationMode {
+  return (
+    value === "provider_continuation" ||
+    value === "transcript_resume" ||
+    value === "full_replay_fallback"
+  );
+}
+
+function isRuntimeVerifierStage(
+  value: unknown,
+): value is NonNullable<PersistedBackgroundRun["verifierStage"]> {
+  return (
+    value === "inactive" ||
+    value === "pending" ||
+    value === "running" ||
+    value === "passed" ||
+    value === "retry" ||
+    value === "failed" ||
+    value === "skipped"
+  );
 }
 
 function coerceRunCore(value: unknown): CoercedRunCore | undefined {
@@ -2006,6 +2054,9 @@ function coerceRunCore(value: unknown): CoercedRunCore | undefined {
     contract,
     completionProgress: coerceCompletionProgress(raw.completionProgress),
     carryForward: coerceCarryForward(raw.carryForward),
+    interactiveContextState: coerceInteractiveContextState(
+      raw.interactiveContextState,
+    ),
     pendingSignals: Array.isArray(raw.pendingSignals)
       ? raw.pendingSignals
         .map((item) => coerceSignal(item))
@@ -2199,7 +2250,14 @@ function coerceRunLineage(value: unknown): BackgroundRunLineage | undefined {
 function coerceRun(value: unknown): PersistedBackgroundRun | undefined {
   const core = coerceRunCore(value);
   if (!core) return undefined;
-  const { raw, contract, carryForward, pendingSignals, observedTargets } = core;
+  const {
+    raw,
+    contract,
+    carryForward,
+    interactiveContextState,
+    pendingSignals,
+    observedTargets,
+  } = core;
   const id = raw.id as string;
   const sessionId = raw.sessionId as string;
   const objective = raw.objective as string;
@@ -2256,6 +2314,17 @@ function coerceRun(value: unknown): PersistedBackgroundRun | undefined {
         : undefined,
     completionProgress: core.completionProgress,
     carryForward,
+    interactiveContextState,
+    continuationMode: isBackgroundRunContinuationMode(raw.continuationMode)
+      ? raw.continuationMode
+      : undefined,
+    verifierSessionId:
+      typeof raw.verifierSessionId === "string"
+        ? raw.verifierSessionId
+        : undefined,
+    verifierStage: isRuntimeVerifierStage(raw.verifierStage)
+      ? raw.verifierStage
+      : undefined,
     blocker: durableState.blocker,
     approvalState: durableState.approvalState,
     budgetState: durableState.budgetState,

--- a/runtime/src/gateway/background-run-supervisor-types.ts
+++ b/runtime/src/gateway/background-run-supervisor-types.ts
@@ -34,6 +34,7 @@ import {
   AGENT_RUN_SCHEMA_VERSION,
 } from "./agent-run-contract.js";
 import {
+  type BackgroundRunContinuationMode,
   type BackgroundRunApprovalState,
   type BackgroundRunBlockerState,
   type BackgroundRunBudgetState,
@@ -50,6 +51,7 @@ import {
   type PersistedBackgroundRun,
   BackgroundRunStore,
 } from "./background-run-store.js";
+import type { InteractiveContextState } from "./interactive-context.js";
 import type { BackgroundRunLineage } from "./subrun-contract.js";
 import type {
   BackgroundRunEventRecord,
@@ -77,6 +79,16 @@ export interface BackgroundRunStatusSnapshot {
   readonly blockerSummary?: string;
   readonly watchCount: number;
   readonly fenceToken: number;
+  readonly continuationMode?: BackgroundRunContinuationMode;
+  readonly verifierSessionId?: string;
+  readonly verifierStage?:
+    | "inactive"
+    | "pending"
+    | "running"
+    | "passed"
+    | "retry"
+    | "failed"
+    | "skipped";
 }
 
 export interface BackgroundRunAlert {
@@ -128,6 +140,17 @@ export interface ActiveBackgroundRun {
   lastWakeReason?: BackgroundRunLastWakeReason;
   completionProgress?: WorkflowProgressSnapshot;
   carryForward?: BackgroundRunCarryForwardState;
+  interactiveContextState?: InteractiveContextState;
+  continuationMode?: BackgroundRunContinuationMode;
+  verifierSessionId?: string;
+  verifierStage?:
+    | "inactive"
+    | "pending"
+    | "running"
+    | "passed"
+    | "retry"
+    | "failed"
+    | "skipped";
   blocker?: BackgroundRunBlockerState;
   approvalState: BackgroundRunApprovalState;
   budgetState: BackgroundRunBudgetState;
@@ -273,6 +296,9 @@ export function toStatusSnapshot(params: {
     blockerSummary: run.blocker?.summary,
     watchCount: run.watchRegistrations.length,
     fenceToken: run.fenceToken,
+    continuationMode: run.continuationMode,
+    verifierSessionId: run.verifierSessionId,
+    verifierStage: run.verifierStage,
   };
 }
 
@@ -301,6 +327,10 @@ export function toPersistedRun(run: ActiveBackgroundRun): PersistedBackgroundRun
     lastWakeReason: run.lastWakeReason,
     completionProgress: run.completionProgress,
     carryForward: run.carryForward,
+    interactiveContextState: run.interactiveContextState,
+    continuationMode: run.continuationMode,
+    verifierSessionId: run.verifierSessionId,
+    verifierStage: run.verifierStage,
     blocker: run.blocker,
     approvalState: run.approvalState,
     budgetState: run.budgetState,
@@ -349,6 +379,9 @@ export function toRecentSnapshot(
     fenceToken: run.fenceToken,
     preferredWorkerId: run.preferredWorkerId,
     workerAffinityKey: run.workerAffinityKey,
+    continuationMode: run.continuationMode,
+    verifierSessionId: run.verifierSessionId,
+    verifierStage: run.verifierStage,
   };
 }
 
@@ -377,6 +410,10 @@ export function toActiveRun(run: PersistedBackgroundRun): ActiveBackgroundRun {
     lastWakeReason: run.lastWakeReason,
     completionProgress: run.completionProgress,
     carryForward: run.carryForward,
+    interactiveContextState: run.interactiveContextState,
+    continuationMode: run.continuationMode,
+    verifierSessionId: run.verifierSessionId,
+    verifierStage: run.verifierStage,
     blocker: run.blocker,
     approvalState: run.approvalState,
     budgetState: run.budgetState,

--- a/runtime/src/gateway/background-run-supervisor.test.ts
+++ b/runtime/src/gateway/background-run-supervisor.test.ts
@@ -24,6 +24,7 @@ import {
   deriveDefaultBackgroundRunMaxCycles,
 } from "./background-run-store.js";
 import { AGENT_RUN_SCHEMA_VERSION } from "./agent-run-contract.js";
+import { createRuntimeContractSnapshot } from "../runtime-contract/types.js";
 
 function makeResult(
   overrides: Partial<ChatExecutorResult> = {},
@@ -639,6 +640,122 @@ describe("background-run-supervisor", () => {
       2,
       "session-natural-language-server",
       "HTTP server is running in the background.",
+    );
+  });
+
+  it("passes interactive context into background actor cycles and reuses verifier child sessions", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce(
+        makeResult({
+          callUsage: [
+            makeCallUsageRecord({
+              statefulDiagnostics: {
+                enabled: true,
+                attempted: true,
+                continued: true,
+                store: true,
+                fallbackToStateless: true,
+                previousResponseId: "resp-bg-1",
+                responseId: "resp-bg-2",
+              },
+            }),
+          ],
+          runtimeContractSnapshot: {
+            ...createRuntimeContractSnapshot({
+              runtimeContractV2: false,
+              stopHooksEnabled: false,
+              asyncTasksEnabled: false,
+              persistentWorkersEnabled: false,
+              mailboxEnabled: false,
+              verifierRuntimeRequired: true,
+              verifierProjectBootstrap: false,
+              workerIsolationWorktree: false,
+              workerIsolationRemote: false,
+            }),
+            verifierStages: {
+              ...createRuntimeContractSnapshot({
+                runtimeContractV2: false,
+                stopHooksEnabled: false,
+                asyncTasksEnabled: false,
+                persistentWorkersEnabled: false,
+                mailboxEnabled: false,
+                verifierRuntimeRequired: true,
+                verifierProjectBootstrap: false,
+                workerIsolationWorktree: false,
+                workerIsolationRemote: false,
+              }).verifierStages,
+              taskId: "subagent:verify-bg-1",
+              stageStatus: "retry",
+            },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(makeResult());
+    const resolveExecutionContext = vi.fn(async () => ({
+      runtimeContext: { workspaceRoot: "/tmp/workspace" },
+    }));
+    const supervisor = new BackgroundRunSupervisor({
+      chatExecutor: { execute } as any,
+      supervisorLlm: {
+        chat: vi.fn(async () => ({
+          content:
+            '{"state":"working","userUpdate":"Cycle still running.","internalSummary":"verification pending","nextCheckMs":4000,"shouldNotifyUser":true}',
+        })),
+      } as any,
+      getSystemPrompt: () => "system prompt",
+      createToolHandler: () => vi.fn(async () => JSON.stringify({ ok: true })),
+      resolveExecutionContext,
+      publishUpdate: vi.fn(async () => undefined),
+      runStore: createRunStore(),
+      logger: createLoggerStub(),
+    });
+
+    await supervisor.startRun({
+      sessionId: "session:bg-interactive",
+      objective: "Read PLAN.md and implement all phases in full.",
+      options: {
+        silent: true,
+        contract: {
+          domain: "workspace",
+          kind: "finite",
+          successCriteria: ["Implementation is complete."],
+          completionCriteria: ["Verification passes."],
+          blockedCriteria: ["Verification fails."],
+          nextCheckMs: 1_000,
+          requiresUserStop: false,
+        },
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await eventuallyAsync(async () => {
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+    expect(execute).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        interactiveContext: expect.objectContaining({
+          state: expect.objectContaining({
+            executionLocation: expect.objectContaining({
+              workspaceRoot: "/tmp/workspace",
+              workingDirectory: "/tmp/workspace",
+            }),
+            cacheSafePromptSnapshot: expect.objectContaining({
+              baseSystemPrompt: expect.stringContaining("system prompt"),
+            }),
+          }),
+        }),
+        runtimeVerifierContinuationSessionId: undefined,
+      }),
+    );
+
+    await (supervisor as any).executeCycle("session:bg-interactive");
+    expect(execute).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        runtimeVerifierContinuationSessionId: "subagent:verify-bg-1",
+      }),
     );
   });
 
@@ -3189,34 +3306,6 @@ describe("background-run-supervisor", () => {
       expectedUpdate: "Application window launched and focused. Objective satisfied.",
     },
     {
-      label: "workspace",
-      record: makePersistedRunRecord({
-        sessionId: "session-workspace-recover",
-        objective: "Run `git status --short` in the workspace and tell me when the command succeeds.",
-        contract: {
-          domain: "workspace",
-          successCriteria: ["Execute the workspace command successfully."],
-          completionCriteria: ["Verify the command succeeds in the workspace."],
-          blockedCriteria: ["Workspace tooling is missing."],
-        },
-        pendingSignals: [
-          {
-            id: "sig-workspace-recover",
-            type: "tool_result",
-            content: "Tool result observed for desktop.bash.",
-            timestamp: 2,
-            data: {
-              category: "generic",
-              toolName: "desktop.bash",
-              command: "git status --short",
-              failed: false,
-            },
-          },
-        ],
-      }),
-      expectedUpdate: "Tool result observed for desktop.bash. Objective satisfied.",
-    },
-    {
       label: "research",
       record: makePersistedRunRecord({
         sessionId: "session-research-recover",
@@ -5333,7 +5422,7 @@ describe("background-run-supervisor", () => {
     expect(supervisor.hasActiveRun("session-browser-grounding")).toBe(true);
   });
 
-  it("completes workspace runs deterministically from internal command evidence", async () => {
+  it("keeps workspace implementation runs active after internal command evidence", async () => {
     const publishUpdate = vi.fn(async () => undefined);
     const execute = vi.fn().mockResolvedValueOnce(
       makeResult({
@@ -5391,8 +5480,11 @@ describe("background-run-supervisor", () => {
     });
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(supervisor.getStatusSnapshot("session-workspace-complete")).toBeUndefined();
-    expect(publishUpdate).toHaveBeenLastCalledWith(
+    expect(supervisor.getStatusSnapshot("session-workspace-complete")).toMatchObject({
+      sessionId: "session-workspace-complete",
+      state: "working",
+    });
+    expect(publishUpdate).not.toHaveBeenCalledWith(
       "session-workspace-complete",
       "Tool result observed for system.bash. Objective satisfied.",
     );

--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -71,6 +71,14 @@ import {
 } from "./background-run-store.js";
 import { BackgroundRunWakeBus } from "./background-run-wake-bus.js";
 import type { RunDomainRetryPolicy } from "./run-domains.js";
+import {
+  buildInteractivePromptSnapshot,
+  buildInteractiveToolScopeFingerprint,
+  cloneInteractiveContextState,
+  normalizeInteractiveExecutionLocation,
+  type InteractiveContextRequest,
+  type InteractiveContextState,
+} from "./interactive-context.js";
 
 // --- Re-export from extracted constants ---
 import {
@@ -288,6 +296,97 @@ function buildActorPrompt(run: ActiveBackgroundRun): string {
     "Take the next best bounded step toward this objective. " +
     "Use tools when necessary. If the task is already running independently, verify its current state instead of narrating.\n"
   );
+}
+
+function resolveRunWorkspaceRoot(
+  run: ActiveBackgroundRun,
+  runtimeWorkspaceRoot?: string,
+): string | undefined {
+  return (
+    runtimeWorkspaceRoot ??
+    run.interactiveContextState?.executionLocation?.workspaceRoot ??
+    run.lineage?.scope.workspaceRoot
+  );
+}
+
+function buildBackgroundRunInteractiveContextState(params: {
+  readonly run: ActiveBackgroundRun;
+  readonly promptEnvelope: ReturnType<typeof normalizePromptEnvelope>;
+  readonly runtimeWorkspaceRoot?: string;
+  readonly advertisedToolNames?: readonly string[];
+}): InteractiveContextState {
+  const executionLocation = normalizeInteractiveExecutionLocation({
+    mode:
+      params.run.lineage?.scope.workspaceRoot ||
+      params.run.interactiveContextState?.executionLocation?.mode === "worktree"
+        ? params.run.interactiveContextState?.executionLocation?.mode ?? "local"
+        : "local",
+    workspaceRoot: resolveRunWorkspaceRoot(
+      params.run,
+      params.runtimeWorkspaceRoot,
+    ),
+    workingDirectory: resolveRunWorkspaceRoot(
+      params.run,
+      params.runtimeWorkspaceRoot,
+    ),
+    gitRoot: params.run.interactiveContextState?.executionLocation?.gitRoot,
+    worktreePath:
+      params.run.interactiveContextState?.executionLocation?.worktreePath,
+    worktreeRef:
+      params.run.interactiveContextState?.executionLocation?.worktreeRef,
+  });
+  const existing = params.run.interactiveContextState;
+  const advertisedToolNames =
+    params.advertisedToolNames && params.advertisedToolNames.length > 0
+      ? params.advertisedToolNames
+      : existing?.defaultAdvertisedToolNames ?? [];
+  const discoveredToolNames = existing?.discoveredToolNames ?? [];
+  return {
+    version: 1,
+    readSeeds: existing?.readSeeds ?? [],
+    ...(executionLocation ? { executionLocation } : {}),
+    cacheSafePromptSnapshot: buildInteractivePromptSnapshot({
+      baseSystemPrompt: params.promptEnvelope.baseSystemPrompt,
+      systemContextBlocks: params.promptEnvelope.systemSections,
+      userContextBlocks: params.promptEnvelope.userSections,
+      sessionStartContextMessages:
+        existing?.cacheSafePromptSnapshot?.sessionStartContextMessages ?? [],
+      toolScopeFingerprint: buildInteractiveToolScopeFingerprint([
+        ...advertisedToolNames,
+        ...discoveredToolNames,
+      ]),
+    }),
+    ...(advertisedToolNames.length > 0
+      ? { defaultAdvertisedToolNames: advertisedToolNames }
+      : {}),
+    ...(discoveredToolNames.length > 0 ? { discoveredToolNames } : {}),
+    ...(existing?.summaryRef ? { summaryRef: existing.summaryRef } : {}),
+    ...(existing?.forkCarryover ? { forkCarryover: existing.forkCarryover } : {}),
+  };
+}
+
+function resolveBackgroundContinuationMode(
+  actorResult: ChatExecutorResult,
+): "provider_continuation" | "transcript_resume" | "full_replay_fallback" {
+  const latestUsage = [...actorResult.callUsage].reverse().find(Boolean);
+  const diagnostics = latestUsage?.statefulDiagnostics;
+  if (diagnostics?.continued === true && diagnostics.previousResponseId) {
+    return "provider_continuation";
+  }
+  if (
+    diagnostics?.fallbackReason === "store_disabled" ||
+    diagnostics?.fallbackReason === "missing_previous_response_id" ||
+    diagnostics?.fallbackReason === "state_reconciliation_mismatch"
+  ) {
+    return "transcript_resume";
+  }
+  if (
+    diagnostics?.attempted === true &&
+    diagnostics.continued !== true
+  ) {
+    return "full_replay_fallback";
+  }
+  return "transcript_resume";
 }
 
 function formatCompletionProgressState(
@@ -1755,6 +1854,10 @@ export class BackgroundRunSupervisor {
       lastWakeReason: "start",
       completionProgress: undefined,
       carryForward: undefined,
+      interactiveContextState: undefined,
+      continuationMode: undefined,
+      verifierSessionId: undefined,
+      verifierStage: "inactive",
       blocker: undefined,
       approvalState: { status: "none" },
       budgetState: buildInitialBudgetState(contract, now),
@@ -3646,6 +3749,17 @@ export class BackgroundRunSupervisor {
           allowedTools: getScopedAllowedTools(run),
           toolRoutingDecision: baseToolRoutingDecision,
         });
+        const interactiveContextState = buildBackgroundRunInteractiveContextState({
+          run,
+          promptEnvelope: actorPromptEnvelope,
+          runtimeWorkspaceRoot: resolvedExecutionContext?.runtimeContext?.workspaceRoot,
+          advertisedToolNames:
+            toolRoutingDecision?.routedToolNames ??
+            run.interactiveContextState?.defaultAdvertisedToolNames,
+        });
+        run.interactiveContextState = cloneInteractiveContextState(
+          interactiveContextState,
+        );
         const abortSignal = run.abortController?.signal;
         if (!abortSignal) {
           throw new Error("Background cycle missing abort signal");
@@ -3659,10 +3773,18 @@ export class BackgroundRunSupervisor {
           sessionId,
           runtimeContext: resolvedExecutionContext?.runtimeContext,
           requiredToolEvidence: resolvedExecutionContext?.requiredToolEvidence,
+          interactiveContext: {
+            state: interactiveContextState,
+            ...(typeof run.carryForward?.summary === "string" &&
+            run.carryForward.summary.trim().length > 0
+              ? { summaryText: run.carryForward.summary.trim() }
+              : {}),
+          } satisfies InteractiveContextRequest,
           requestTimeoutMs: BACKGROUND_RUN_ACTOR_REQUEST_TIMEOUT_MS,
+          runtimeVerifierContinuationSessionId: run.verifierSessionId,
           stateful: run.carryForward?.providerContinuation
             ? {
-              resumeAnchor: {
+                resumeAnchor: {
                 previousResponseId: run.carryForward.providerContinuation.responseId,
                 ...(run.carryForward.providerContinuation.reconciliationHash
                   ? {
@@ -3700,6 +3822,10 @@ export class BackgroundRunSupervisor {
         run.lastVerifiedAt = this.now();
         recordToolEvidence(run, actorResult.toolCalls);
         recordProviderCompactionArtifacts(run, actorResult);
+        run.continuationMode = resolveBackgroundContinuationMode(actorResult);
+        const verifierStages = actorResult.runtimeContractSnapshot?.verifierStages;
+        run.verifierSessionId = verifierStages?.taskId ?? run.verifierSessionId;
+        run.verifierStage = verifierStages?.stageStatus ?? run.verifierStage;
         const providerContinuation = extractLatestProviderContinuation(
           actorResult,
           run.lastVerifiedAt,

--- a/runtime/src/gateway/llm-stateful-defaults.ts
+++ b/runtime/src/gateway/llm-stateful-defaults.ts
@@ -48,7 +48,7 @@ export function resolveGatewayStatefulResponses(
   const enabled = statefulResponses?.enabled ?? true;
   if (statefulResponses?.enabled === undefined) usedDefaults = true;
 
-  const store = statefulResponses?.store ?? false;
+  const store = statefulResponses?.store ?? true;
   if (statefulResponses?.store === undefined) usedDefaults = true;
 
   const fallbackToStateless = statefulResponses?.fallbackToStateless ?? true;

--- a/runtime/src/gateway/run-domains.test.ts
+++ b/runtime/src/gateway/run-domains.test.ts
@@ -143,7 +143,7 @@ describe("run-domains", () => {
     });
   });
 
-  it("workspace domain completes deterministic build/test objectives from command signals", () => {
+  it("workspace domain does not self-complete implementation objectives from generic command signals", () => {
     const domain = createWorkspaceRunDomain();
     const run = makeRun({
       objective: "Run the workspace test suite successfully.",
@@ -173,42 +173,8 @@ describe("run-domains", () => {
     });
 
     expect(domain.detectDeterministicVerification(run)).toMatchObject({
-      state: "success",
-    });
-  });
-
-  it("workspace domain completes finite workspace command objectives from generic shell evidence", () => {
-    const domain = createWorkspaceRunDomain();
-    const run = makeRun({
-      objective: "Run `git status --short` in the workspace and tell me when the command succeeds.",
-      contract: {
-        domain: "workspace",
-        kind: "finite",
-        successCriteria: ["Execute the workspace command successfully."],
-        completionCriteria: ["Verify the command succeeds in the workspace."],
-        blockedCriteria: ["Workspace tooling is missing."],
-        nextCheckMs: 4_000,
-        requiresUserStop: false,
-      },
-      pendingSignals: [
-        {
-          id: "sig-workspace-command",
-          type: "tool_result",
-          content: "Tool result observed for desktop.bash.",
-          timestamp: 3,
-          data: {
-            category: "generic",
-            toolName: "desktop.bash",
-            command: "git status --short",
-            failed: false,
-          },
-        },
-      ],
-    });
-
-    expect(domain.detectDeterministicVerification(run)).toMatchObject({
-      state: "success",
-      userUpdate: "Tool result observed for desktop.bash. Objective satisfied.",
+      state: "safe_to_continue",
+      safeToContinue: true,
     });
   });
 

--- a/runtime/src/gateway/run-domains.ts
+++ b/runtime/src/gateway/run-domains.ts
@@ -488,30 +488,12 @@ function workspaceCompletionSatisfied(
   run: RunDomainRun,
   info: ParsedDomainSignal,
 ): boolean {
-  if (!allowsDeterministicCompletion(run)) {
-    return false;
-  }
-  const corpus = criteriaCorpus(run);
-  if (
-    /\b(file|write|update|create|modify|patch|save)\b/.test(corpus) &&
-    workspaceSignalMatches(info) &&
-    (Boolean(info.path) || info.category === "filesystem")
-  ) {
-    return true;
-  }
-  if (
-    /\b(build|test|lint|typecheck|compile|format)\b/.test(corpus) &&
-    commandLooksLikeBuildOrTest(info.command)
-  ) {
-    return true;
-  }
-  if (
-    /\b(run|execute|command|shell|bash|workspace)\b/.test(corpus) &&
-    typeof info.command === "string" &&
-    info.command.trim().length > 0
-  ) {
-    return true;
-  }
+  void run;
+  void info;
+  // Workspace implementation runs must not self-complete on weak filesystem
+  // or generic shell evidence. Explicit one-shot command execution is handled
+  // by executeWorkspaceNativeCycle(), and all other workspace objectives need
+  // stronger actor/verifier-backed completion.
   return false;
 }
 

--- a/runtime/src/gateway/sub-agent.test.ts
+++ b/runtime/src/gateway/sub-agent.test.ts
@@ -2315,7 +2315,43 @@ describe("SubAgentManager", () => {
           usedFallback: false,
           toolCalls: [],
           tokenUsage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
-          callUsage: [],
+          callUsage: [
+            {
+              callIndex: 1,
+              phase: "initial",
+              provider: "mock-llm",
+              model: "mock-llm",
+              finishReason: "stop",
+              usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+              beforeBudget: {
+                messageCount: 1,
+                systemMessages: 1,
+                userMessages: 0,
+                assistantMessages: 0,
+                toolMessages: 0,
+                estimatedChars: 20,
+                systemPromptChars: 10,
+              },
+              afterBudget: {
+                messageCount: 1,
+                systemMessages: 1,
+                userMessages: 0,
+                assistantMessages: 0,
+                toolMessages: 0,
+                estimatedChars: 20,
+                systemPromptChars: 10,
+              },
+              statefulDiagnostics: {
+                enabled: true,
+                attempted: true,
+                continued: true,
+                store: true,
+                fallbackToStateless: true,
+                responseId: "resp-child-1",
+                reconciliationHash: "hash-child-1",
+              },
+            },
+          ],
           durationMs: 10,
           compacted: false,
           stopReason: "completed",
@@ -2377,6 +2413,12 @@ describe("SubAgentManager", () => {
             { role: "user", content: "Store the token for later recall" },
             { role: "assistant", content: "CHILD-STORED-S1" },
           ],
+          stateful: {
+            resumeAnchor: {
+              previousResponseId: "resp-child-1",
+              reconciliationHash: "hash-child-1",
+            },
+          },
         });
       } finally {
         executeSpy.mockRestore();
@@ -2392,7 +2434,43 @@ describe("SubAgentManager", () => {
           usedFallback: false,
           toolCalls: [],
           tokenUsage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
-          callUsage: [],
+          callUsage: [
+            {
+              callIndex: 1,
+              phase: "initial",
+              provider: "mock-llm",
+              model: "mock-llm",
+              finishReason: "stop",
+              usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+              beforeBudget: {
+                messageCount: 1,
+                systemMessages: 1,
+                userMessages: 0,
+                assistantMessages: 0,
+                toolMessages: 0,
+                estimatedChars: 20,
+                systemPromptChars: 10,
+              },
+              afterBudget: {
+                messageCount: 1,
+                systemMessages: 1,
+                userMessages: 0,
+                assistantMessages: 0,
+                toolMessages: 0,
+                estimatedChars: 20,
+                systemPromptChars: 10,
+              },
+              statefulDiagnostics: {
+                enabled: true,
+                attempted: true,
+                continued: true,
+                store: true,
+                fallbackToStateless: true,
+                responseId: "resp-child-persisted-1",
+                reconciliationHash: "hash-child-persisted-1",
+              },
+            },
+          ],
           durationMs: 10,
           compacted: false,
           stopReason: "completed",
@@ -2460,6 +2538,12 @@ describe("SubAgentManager", () => {
             { role: "user", content: "Store the token for later recall" },
             { role: "assistant", content: "STORED-CHILD-RESULT" },
           ],
+          stateful: {
+            resumeAnchor: {
+              previousResponseId: "resp-child-persisted-1",
+              reconciliationHash: "hash-child-persisted-1",
+            },
+          },
         });
       } finally {
         executeSpy.mockRestore();

--- a/runtime/src/gateway/sub-agent.ts
+++ b/runtime/src/gateway/sub-agent.ts
@@ -39,6 +39,7 @@ import type {
   LLMProviderExecutionProfile,
   LLMMessage,
   LLMProviderEvidence,
+  LLMStatefulResumeAnchor,
   LLMStructuredOutputResult,
   LLMUsage,
   ToolHandler,
@@ -77,6 +78,8 @@ import {
   subAgentTranscriptStreamId,
 } from "./session-transcript.js";
 import {
+  buildInteractivePromptSnapshot,
+  buildInteractiveToolScopeFingerprint,
   normalizeInteractiveExecutionLocation,
   sameInteractiveExecutionLocation,
 } from "./interactive-context.js";
@@ -329,6 +332,7 @@ interface SubAgentHandle {
   timeoutTimer: ReturnType<typeof setTimeout> | null;
   execution: Promise<void>;
   finishedAt: number | null;
+  statefulResumeAnchor?: LLMStatefulResumeAnchor;
 }
 
 interface PersistedSubAgentState {
@@ -342,6 +346,7 @@ interface PersistedSubAgentState {
   readonly result: SubAgentResult | null;
   readonly startedAt: number;
   readonly finishedAt: number | null;
+  readonly statefulResumeAnchor?: LLMStatefulResumeAnchor;
 }
 
 interface LegacySubAgentConfigRecord extends Record<string, unknown> {
@@ -370,12 +375,44 @@ function normalizeSubAgentConfig(
   config: SubAgentConfig,
   managerPromptEnvelope?: PromptEnvelopeV1,
 ): SubAgentConfig {
+  const promptEnvelope = normalizeSubAgentPromptEnvelope(
+    config.promptEnvelope,
+    managerPromptEnvelope?.baseSystemPrompt ?? DEFAULT_SUB_AGENT_SYSTEM_PROMPT,
+  );
+  const workspaceRoot = resolveSubAgentWorkspaceRoot(config);
+  const workingDirectory = resolveSubAgentWorkingDirectory(config);
+  const normalizedExecutionLocation = normalizeInteractiveExecutionLocation(
+    config.executionLocation ?? {
+      mode: "local",
+      workspaceRoot,
+      workingDirectory,
+    },
+  );
+  const interactiveContext =
+    config.interactiveContext ??
+    (workspaceRoot || workingDirectory
+      ? {
+          state: {
+            version: 1 as const,
+            readSeeds: [],
+            ...(normalizedExecutionLocation
+              ? { executionLocation: normalizedExecutionLocation }
+              : {}),
+            cacheSafePromptSnapshot: buildInteractivePromptSnapshot({
+              baseSystemPrompt: promptEnvelope.baseSystemPrompt,
+              systemContextBlocks: promptEnvelope.systemSections,
+              userContextBlocks: promptEnvelope.userSections,
+              toolScopeFingerprint: buildInteractiveToolScopeFingerprint(
+                config.tools ?? [],
+              ),
+            }),
+          },
+        }
+      : undefined);
   return {
     ...config,
-    promptEnvelope: normalizeSubAgentPromptEnvelope(
-      config.promptEnvelope,
-      managerPromptEnvelope?.baseSystemPrompt ?? DEFAULT_SUB_AGENT_SYSTEM_PROMPT,
-    ),
+    promptEnvelope,
+    ...(interactiveContext ? { interactiveContext } : {}),
   };
 }
 
@@ -456,6 +493,28 @@ function coercePersistedSubAgentState(
       typeof raw.finishedAt === "number" && Number.isFinite(raw.finishedAt)
         ? raw.finishedAt
         : null,
+    ...(raw.statefulResumeAnchor &&
+    typeof raw.statefulResumeAnchor === "object" &&
+    !Array.isArray(raw.statefulResumeAnchor) &&
+    typeof (raw.statefulResumeAnchor as Record<string, unknown>).previousResponseId ===
+      "string"
+      ? {
+          statefulResumeAnchor: {
+            previousResponseId: (
+              raw.statefulResumeAnchor as Record<string, unknown>
+            ).previousResponseId as string,
+            ...(typeof (
+              raw.statefulResumeAnchor as Record<string, unknown>
+            ).reconciliationHash === "string"
+              ? {
+                  reconciliationHash: (
+                    raw.statefulResumeAnchor as Record<string, unknown>
+                  ).reconciliationHash as string,
+                }
+              : {}),
+          } satisfies LLMStatefulResumeAnchor,
+        }
+      : {}),
   };
 }
 
@@ -474,6 +533,27 @@ function normalizeStringList(values: readonly string[] | undefined): readonly st
     .map((value) => value.trim())
     .filter((value) => value.length > 0)
     .sort((left, right) => left.localeCompare(right));
+}
+
+function extractStatefulResumeAnchor(
+  result: ChatExecutorResult | null | undefined,
+): LLMStatefulResumeAnchor | undefined {
+  if (!result) {
+    return undefined;
+  }
+  const latestUsage = [...result.callUsage]
+    .reverse()
+    .find((entry) => entry.statefulDiagnostics?.responseId);
+  const responseId = latestUsage?.statefulDiagnostics?.responseId?.trim();
+  if (!responseId) {
+    return undefined;
+  }
+  const reconciliationHash =
+    latestUsage?.statefulDiagnostics?.reconciliationHash?.trim();
+  return {
+    previousResponseId: responseId,
+    ...(reconciliationHash ? { reconciliationHash } : {}),
+  };
 }
 
 function stableConfigFragment(value: unknown): string {
@@ -767,6 +847,7 @@ export class SubAgentManager {
       timeoutTimer: null,
       execution: Promise.resolve(),
       finishedAt: null,
+      statefulResumeAnchor: continuationHandle?.statefulResumeAnchor,
     };
 
     this.handles.set(sessionId, handle);
@@ -1035,6 +1116,9 @@ export class SubAgentManager {
       result: handle.result ? cloneJson(handle.result) : null,
       startedAt: handle.startedAt,
       finishedAt: handle.finishedAt,
+      ...(handle.statefulResumeAnchor
+        ? { statefulResumeAnchor: handle.statefulResumeAnchor }
+        : {}),
     };
     await memoryBackend.set(subAgentStateKey(handle.sessionId), persisted);
   }
@@ -1099,6 +1183,7 @@ export class SubAgentManager {
       timeoutTimer: null,
       execution: Promise.resolve(),
       finishedAt: persisted.finishedAt,
+      statefulResumeAnchor: persisted.statefulResumeAnchor,
     };
   }
 
@@ -1430,6 +1515,13 @@ export class SubAgentManager {
                 },
               }
               : {}),
+            ...(handle.statefulResumeAnchor
+              ? {
+                  stateful: {
+                    resumeAnchor: handle.statefulResumeAnchor,
+                  },
+                }
+              : undefined),
             ...(typeof effectiveToolBudgetPerRequest === "number"
               ? { toolBudgetPerRequest: effectiveToolBudgetPerRequest }
               : {}),
@@ -1481,6 +1573,8 @@ export class SubAgentManager {
         user: { role: "user", content: handle.config.prompt ?? handle.task },
         assistant: { role: "assistant", content: output },
       });
+      handle.statefulResumeAnchor =
+        extractStatefulResumeAnchor(resultOrAbort) ?? handle.statefulResumeAnchor;
 
       this.markTerminalState(handle, terminalStatus, {
         sessionId: handle.sessionId,

--- a/runtime/src/gateway/top-level-verifier.test.ts
+++ b/runtime/src/gateway/top-level-verifier.test.ts
@@ -169,6 +169,34 @@ describe("runTopLevelVerifierValidation", () => {
     expect(decision.blockingMessage).toContain("Runtime verification blocked completion");
   });
 
+  it("reuses a prior verifier child session when a continuation session is provided", async () => {
+    const spawn = vi.fn(async () => "subagent:verify-1");
+    const waitForResult = vi.fn(async () => ({
+      sessionId: "subagent:verify-1",
+      output: "VERDICT: PARTIAL",
+      success: false,
+      durationMs: 10,
+      toolCalls: [],
+      completionState: "completed",
+      stopReason: "completed",
+    }));
+
+    await runTopLevelVerifierValidation({
+      sessionId: "session:test",
+      userRequest: "Implement every phase from PLAN.md",
+      result: createResult(),
+      subAgentManager: { spawn, waitForResult },
+      verifierService: createVerifierService(),
+      continuationSessionId: "subagent:verify-prev",
+    });
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        continuationSessionId: "subagent:verify-prev",
+      }),
+    );
+  });
+
   it("inherits the parent tool surface minus mutating tools for verifier runs", async () => {
     const spawn = vi.fn(async () => "subagent:verify-tools");
     const waitForResult = vi.fn(async () => ({
@@ -598,7 +626,7 @@ describe("runTopLevelVerifierValidation", () => {
     expect(decision.runtimeVerifier.overall).toBe("pass");
   });
 
-  it("accepts PASS verdicts even when the verifier includes weak green probe output", async () => {
+  it("rejects PASS verdicts when the verifier includes weak green probe output", async () => {
     const spawn = vi.fn(async () => "subagent:verify-weak");
     const waitForResult = vi.fn(async () => ({
       sessionId: "subagent:verify-weak",
@@ -649,9 +677,9 @@ describe("runTopLevelVerifierValidation", () => {
       ),
     });
 
-    expect(decision.outcome).toBe("pass");
-    expect(decision.summary).toContain("Verifier thinks the build is correct.");
-    expect(decision.runtimeVerifier.overall).toBe("pass");
+    expect(decision.outcome).toBe("retry_with_blocking_message");
+    expect(decision.summary).toContain("weak or contradictory");
+    expect(decision.runtimeVerifier.overall).toBe("retry");
   });
 
   it("records remote-job verifier handles when remote isolation is enabled", async () => {

--- a/runtime/src/gateway/top-level-verifier.ts
+++ b/runtime/src/gateway/top-level-verifier.ts
@@ -23,6 +23,7 @@ import type { DelegationVerifierService } from "./delegation-runtime.js";
 import { isSubAgentSessionId } from "./delegation-runtime.js";
 import {
   type VerifierRequirement,
+  extractVerificationProbeCoverage,
 } from "./verifier-probes.js";
 import type { TurnExecutionContract } from "../llm/turn-execution-contract-types.js";
 import type {
@@ -160,6 +161,7 @@ interface TopLevelVerifierParams {
   readonly agentDefinitions?: readonly AgentDefinition[];
   readonly availableToolNames?: readonly string[];
   readonly parentAllowedTools?: readonly string[];
+  readonly continuationSessionId?: string;
   readonly logger?: Logger;
   readonly onTraceEvent?: (
     event: TopLevelVerifierTraceEvent,
@@ -566,6 +568,14 @@ function parseVerifierSnapshot(result: SubAgentResult | null): {
   return { snapshot, summary };
 }
 
+function verifierPassHasWeakProbeEvidence(result: SubAgentResult | null): boolean {
+  if (!result?.toolCalls?.length) {
+    return false;
+  }
+  const coverage = extractVerificationProbeCoverage(result.toolCalls);
+  return coverage.failedProbeIds.length > 0 || coverage.weakProbeIds.length > 0;
+}
+
 function toRuntimeVerifierVerdict(params: {
   readonly snapshot: PlannerVerificationSnapshot;
   readonly summary: string;
@@ -955,6 +965,9 @@ export async function runTopLevelVerifierValidation(
   try {
     childSessionId = await subAgentManager.spawn({
       ...spawnConfig,
+      ...(params.continuationSessionId
+        ? { continuationSessionId: params.continuationSessionId }
+        : {}),
       ...(workspaceRoot ? { workingDirectorySource: "execution_envelope" as const } : {}),
       ...(verifierDelegationSpec ? { delegationSpec: verifierDelegationSpec } : {}),
       requireToolCall: true,
@@ -1050,7 +1063,35 @@ export async function runTopLevelVerifierValidation(
       verifier: effectiveParsed.snapshot,
       runtimeVerifier,
       summary: effectiveParsed.summary,
+      taskId: childSessionId,
       exhaustedDetail: `Top-level verifier retry: ${effectiveParsed.summary}`,
+      verifierRequirement: effectiveVerifierRequirement,
+      launcherKind: remoteJobHandle ? "remote_job" : "subagent",
+    };
+  }
+  if (
+    effectiveParsed.snapshot.overall === "pass" &&
+    verifierPassHasWeakProbeEvidence(verifierResult)
+  ) {
+    return {
+      outcome: "retry_with_blocking_message",
+      verifier: { performed: true, overall: "retry" },
+      runtimeVerifier: {
+        attempted: true,
+        overall: "retry",
+        summary:
+          "Runtime verifier reported PASS, but probe output was weak or contradictory.",
+      },
+      summary:
+        "Runtime verifier reported PASS, but probe output was weak or contradictory.",
+      taskId: childSessionId,
+      blockingMessage: buildVerifierBlockingMessage({
+        summary:
+          "Probe output was weak or contradictory. Strengthen verification until the probes produce grounded evidence.",
+        verdict: "retry",
+      }),
+      exhaustedDetail:
+        "Top-level verifier retry: probe output was weak or contradictory.",
       verifierRequirement: effectiveVerifierRequirement,
       launcherKind: remoteJobHandle ? "remote_job" : "subagent",
     };
@@ -1061,6 +1102,7 @@ export async function runTopLevelVerifierValidation(
       verifier: effectiveParsed.snapshot,
       runtimeVerifier,
       summary: effectiveParsed.summary,
+      taskId: childSessionId,
       verifierRequirement: effectiveVerifierRequirement,
       launcherKind: remoteJobHandle ? "remote_job" : "subagent",
     };
@@ -1070,6 +1112,7 @@ export async function runTopLevelVerifierValidation(
     verifier: effectiveParsed.snapshot,
     runtimeVerifier,
     summary: effectiveParsed.summary,
+    taskId: childSessionId,
     blockingMessage: buildVerifierBlockingMessage({
       summary: effectiveParsed.summary,
       verdict: runtimeVerifier.overall,

--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -2667,6 +2667,9 @@ export async function executeToolCallLoop(
           parentAllowedTools: config.allowedTools
             ? [...config.allowedTools]
             : undefined,
+          continuationSessionId:
+            ctx.runtimeVerifierContinuationSessionId ??
+            ctx.runtimeContractSnapshot.verifierStages.taskId,
           logger: config.completionValidation?.topLevelVerifier?.logger,
           onTraceEvent:
             config.completionValidation?.topLevelVerifier?.onTraceEvent,

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -234,6 +234,8 @@ export interface ChatExecuteParams {
   };
   /** Optional replay/hydration context for interactive resume/fork parity. */
   readonly interactiveContext?: InteractiveContextRequest;
+  /** Optional durable verifier child session to resume instead of spawning a new verifier worker. */
+  readonly runtimeVerifierContinuationSessionId?: string;
   /** Optional per-turn tool-routing subset and expansion policy. */
   readonly toolRouting?: {
     /** Effective advertised bundle for this turn before any lexical narrowing. */
@@ -678,6 +680,7 @@ export interface ExecutionContext {
   readonly plannerDecision: PlannerDecision;
   readonly toolRouting?: ChatExecuteParams["toolRouting"];
   readonly stateful?: ChatExecuteParams["stateful"];
+  readonly runtimeVerifierContinuationSessionId?: string;
   readonly requiredToolEvidence?: {
     readonly maxCorrectionAttempts: number;
     readonly maxCorrectionAttemptsExplicit: boolean;
@@ -766,6 +769,7 @@ interface BuildExecutionContextParams {
   readonly streamCallback?: StreamProgressCallback;
   readonly toolRouting?: ChatExecuteParams["toolRouting"];
   readonly stateful?: ChatExecuteParams["stateful"];
+  readonly runtimeVerifierContinuationSessionId?: string;
   readonly requiredToolEvidence?: ChatExecuteParams["requiredToolEvidence"];
   readonly trace?: ChatExecuteParams["trace"];
   readonly initialRoutedToolNames: readonly string[];
@@ -835,6 +839,8 @@ export function buildDefaultExecutionContext(
     plannerDecision: params.plannerDecision,
     toolRouting: params.toolRouting,
     stateful: params.stateful,
+    runtimeVerifierContinuationSessionId:
+      params.runtimeVerifierContinuationSessionId,
     trace: params.trace,
     defaultRunClass: config.defaultRunClass,
     requiredToolEvidence: params.requiredToolEvidence

--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -2375,15 +2375,12 @@ describe("GrokProvider", () => {
 
     const firstParams = mockCreate.mock.calls[0][0];
     const secondParams = mockCreate.mock.calls[1][0];
-    expect(firstParams.store).toBe(false);
-    expect(secondParams.store).toBe(false);
-    expect(secondParams.previous_response_id).toBeUndefined();
-    expect(second.stateful?.attempted).toBe(false);
-    expect(second.stateful?.continued).toBe(false);
-    expect(second.stateful?.fallbackReason).toBe("store_disabled");
-    expect(
-      second.stateful?.events?.some((event) => event.reason === "store_disabled"),
-    ).toBe(true);
+    expect(firstParams.store).toBe(true);
+    expect(secondParams.store).toBe(true);
+    expect(secondParams.previous_response_id).toBe("resp_default_store_1");
+    expect(second.stateful?.attempted).toBe(true);
+    expect(second.stateful?.continued).toBe(true);
+    expect(second.stateful?.fallbackReason).toBeUndefined();
     expect(second.stateful?.responseId).toBe("resp_default_store_2");
   });
 

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -1667,8 +1667,7 @@ export class GrokProvider implements LLMProvider {
     const persistedResumeAnchor = options?.stateful?.resumeAnchor;
     const memoryAnchor = this.statefulSessions.get(sessionId);
     const anchor = memoryAnchor ?? (
-      persistedResumeAnchor?.previousResponseId &&
-      persistedResumeAnchor.reconciliationHash
+      persistedResumeAnchor?.previousResponseId
         ? {
             responseId: persistedResumeAnchor.previousResponseId,
             reconciliationHash: persistedResumeAnchor.reconciliationHash,
@@ -1701,18 +1700,25 @@ export class GrokProvider implements LLMProvider {
         detail: `session=${sessionId}`,
       });
 
-      const anchorRelativeIndex = reconciliation.chain.lastIndexOf(
-        anchor.reconciliationHash,
-      );
-      anchorMatched = anchorRelativeIndex >= 0;
-      if (anchorMatched) {
-        anchorRelevantMessageIndex =
-          reconciliation.messageCountUsed - reconciliation.chain.length +
-          anchorRelativeIndex;
+      if (anchor.reconciliationHash) {
+        const anchorRelativeIndex = reconciliation.chain.lastIndexOf(
+          anchor.reconciliationHash,
+        );
+        anchorMatched = anchorRelativeIndex >= 0;
+        if (anchorMatched) {
+          anchorRelevantMessageIndex =
+            reconciliation.messageCountUsed - reconciliation.chain.length +
+            anchorRelativeIndex;
+        }
       }
       if (anchorMatched) {
         continued = true;
         appendStatefulEvent(events, "stateful_continuation_success");
+      } else if (!anchor.reconciliationHash) {
+        continued = true;
+        appendStatefulEvent(events, "stateful_continuation_success", {
+          detail: `session=${sessionId}; reconciliation_hash=missing`,
+        });
       } else if (historyCompacted) {
         continued = true;
         compactedHistoryTrusted = true;
@@ -1979,7 +1985,7 @@ export class GrokProvider implements LLMProvider {
     const params: Record<string, unknown> = {
       model,
       input,
-      store: options?.store ?? this.statefulConfig?.store ?? false,
+      store: options?.store ?? this.statefulConfig?.store ?? true,
     };
     if (options?.previousResponseId) {
       params.previous_response_id = options.previousResponseId;

--- a/runtime/src/llm/provider-capabilities.test.ts
+++ b/runtime/src/llm/provider-capabilities.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { resolveLLMStatefulResponsesConfig } from "./provider-capabilities.js";
 
 describe("resolveLLMStatefulResponsesConfig", () => {
-  it("defaults store=false when stateful responses are enabled without an explicit store override", () => {
+  it("defaults store=true when stateful responses are enabled without an explicit store override", () => {
     expect(
       resolveLLMStatefulResponsesConfig({
         enabled: true,
@@ -11,7 +11,7 @@ describe("resolveLLMStatefulResponsesConfig", () => {
       }),
     ).toMatchObject({
       enabled: true,
-      store: false,
+      store: true,
       fallbackToStateless: true,
     });
   });

--- a/runtime/src/llm/provider-capabilities.ts
+++ b/runtime/src/llm/provider-capabilities.ts
@@ -30,7 +30,7 @@ export function resolveLLMStatefulResponsesConfig(
   const enabled = config?.enabled === true;
   return {
     enabled,
-    store: config?.store ?? false,
+    store: config?.store ?? true,
     fallbackToStateless: config?.fallbackToStateless ?? true,
     reconciliationWindow: Math.min(
       MAX_STATEFUL_RECONCILIATION_WINDOW,


### PR DESCRIPTION
## Summary
- persist background-run interactive continuation state and verifier child reuse
- stop workspace runs from self-completing on weak evidence
- carry child resume anchors across restarts and tighten verifier pass handling

## Validation
- `./node_modules/.bin/tsc -p runtime/tsconfig.json --noEmit`
- `./node_modules/.bin/vitest run runtime/src/gateway/background-run-store.test.ts runtime/src/gateway/background-run-supervisor.test.ts runtime/src/gateway/top-level-verifier.test.ts runtime/src/gateway/sub-agent.test.ts runtime/src/llm/grok/adapter.test.ts runtime/src/llm/provider-capabilities.test.ts runtime/src/gateway/run-domains.test.ts`
- `npm run techdebt`