### PR TITLE
fix(runtime): keep background and child tool bundles scoped

### DIFF
--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -185,3 +185,10 @@
 - **What worked:** Moving local compaction onto current-view effective-window accounting made the executor, `/context`, daemon status, and watch header all agree on the same pressure signal, and the targeted executor test updates kept the runtime behavior verified against the new threshold model instead of the old cumulative-budget assumptions.
 - **What didn't:** A few compaction tests were still asserting cumulative token spend and an older per-iteration threshold shape, so the parity pass needed both runtime code changes and fixture recalibration before the suite reflected the intended behavior.
 - **Rule added to CLAUDE.md:** no
+
+## PR #407: fix(runtime): keep background and child tool bundles scoped
+- **Date:** 2026-04-15
+- **Files changed:** `runtime/src/gateway/{background-run-supervisor,background-run-supervisor-types,daemon,sub-agent}.ts`, `runtime/src/gateway/{background-run-supervisor,sub-agent}.test.ts`
+- **What worked:** Passing the resolved advertised tool bundle into background actor cycles and child-session launches kept both paths on the same scoped tool surface as foreground turns, which prevents provider-side trimming from broad fallback catalogs.
+- **What didn't:** Background and child execution had each kept their own fallback path to the executor-wide allowlist, so fixing the live overflow required patching both call sites and adding dedicated regressions instead of relying on the earlier foreground-only routing work.
+- **Rule added to CLAUDE.md:** no

--- a/runtime/src/gateway/background-run-supervisor-types.ts
+++ b/runtime/src/gateway/background-run-supervisor-types.ts
@@ -194,6 +194,11 @@ export interface BackgroundRunSupervisorConfig {
     history: readonly LLMMessage[],
     shellProfile: SessionShellProfile,
   ) => ToolRoutingDecision | undefined;
+  readonly resolveAdvertisedToolNames?: (
+    sessionId: string,
+    shellProfile: SessionShellProfile,
+    discoveredToolNames?: readonly string[],
+  ) => readonly string[];
   readonly seedHistoryForSession?: (sessionId: string) => readonly LLMMessage[];
   readonly isSessionBusy?: (sessionId: string) => boolean;
   readonly onStatus?: (

--- a/runtime/src/gateway/background-run-supervisor.test.ts
+++ b/runtime/src/gateway/background-run-supervisor.test.ts
@@ -845,6 +845,71 @@ describe("background-run-supervisor", () => {
     expect(remainingMs).toBeLessThanOrEqual(4_000);
   });
 
+  it("passes the advertised tool bundle to actor cycles when no narrower route is active", async () => {
+    const execute = vi.fn(async () =>
+      makeResult({
+        content: "Still working.",
+      }),
+    );
+    const supervisorLlm: LLMProvider = {
+      name: "supervisor",
+      chat: vi.fn(async () => ({
+        content:
+          '{"state":"working","userUpdate":"Still working.","internalSummary":"verified running","nextCheckMs":4000,"shouldNotifyUser":false}',
+        toolCalls: [],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        model: "supervisor-model",
+        finishReason: "stop",
+      })),
+      chatStream: vi.fn(),
+      healthCheck: vi.fn(async () => true),
+    };
+
+    const supervisor = new BackgroundRunSupervisor({
+      chatExecutor: { execute } as any,
+      supervisorLlm,
+      getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
+      createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
+      buildToolRoutingDecision: () => undefined,
+      resolveAdvertisedToolNames: () => [
+        "system.bash",
+        "system.readFile",
+        "system.searchTools",
+      ],
+      publishUpdate: vi.fn(async () => undefined),
+    });
+
+    await supervisor.startRun({
+      sessionId: "session-routing",
+      objective: "Keep implementing until the workspace build is complete.",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    await eventually(() => {
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+
+    expect(execute.mock.calls[0]?.[0]?.toolRouting).toEqual({
+      advertisedToolNames: [
+        "system.bash",
+        "system.readFile",
+        "system.searchTools",
+      ],
+      routedToolNames: [
+        "system.bash",
+        "system.readFile",
+        "system.searchTools",
+      ],
+      expandedToolNames: [
+        "system.bash",
+        "system.readFile",
+        "system.searchTools",
+      ],
+      expandOnMiss: true,
+      persistDiscovery: true,
+    });
+  });
+
   it("passes provider trace options to actor and supervisor calls when enabled", async () => {
     const publishUpdate = vi.fn(async () => undefined);
     const execute = vi.fn(async () =>

--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -587,6 +587,7 @@ export class BackgroundRunSupervisor {
   private readonly createToolHandler: BackgroundRunSupervisorConfig["createToolHandler"];
   private readonly resolveExecutionContext?: BackgroundRunSupervisorConfig["resolveExecutionContext"];
   private readonly buildToolRoutingDecision?: BackgroundRunSupervisorConfig["buildToolRoutingDecision"];
+  private readonly resolveAdvertisedToolNames?: BackgroundRunSupervisorConfig["resolveAdvertisedToolNames"];
   private readonly seedHistoryForSession?: BackgroundRunSupervisorConfig["seedHistoryForSession"];
   private readonly isSessionBusy?: BackgroundRunSupervisorConfig["isSessionBusy"];
   private readonly onStatus?: BackgroundRunSupervisorConfig["onStatus"];
@@ -626,6 +627,7 @@ export class BackgroundRunSupervisor {
     this.createToolHandler = config.createToolHandler;
     this.resolveExecutionContext = config.resolveExecutionContext;
     this.buildToolRoutingDecision = config.buildToolRoutingDecision;
+    this.resolveAdvertisedToolNames = config.resolveAdvertisedToolNames;
     this.seedHistoryForSession = config.seedHistoryForSession;
     this.isSessionBusy = config.isSessionBusy;
     this.onStatus = config.onStatus;
@@ -3732,6 +3734,14 @@ export class BackgroundRunSupervisor {
         actorResult = nativeCycle.actorResult;
         decision = toDecisionFromDomainVerification(nativeCycle.verification);
       } else {
+        const advertisedToolNames =
+          this.resolveAdvertisedToolNames?.(
+            sessionId,
+            run.shellProfile ?? DEFAULT_SESSION_SHELL_PROFILE,
+            run.interactiveContextState?.discoveredToolNames,
+          ) ??
+          run.interactiveContextState?.defaultAdvertisedToolNames ??
+          [];
         const baseToolRoutingDecision = this.buildToolRoutingDecision?.(
           sessionId,
           actorPrompt,
@@ -3753,9 +3763,7 @@ export class BackgroundRunSupervisor {
           run,
           promptEnvelope: actorPromptEnvelope,
           runtimeWorkspaceRoot: resolvedExecutionContext?.runtimeContext?.workspaceRoot,
-          advertisedToolNames:
-            toolRoutingDecision?.routedToolNames ??
-            run.interactiveContextState?.defaultAdvertisedToolNames,
+          advertisedToolNames,
         });
         run.interactiveContextState = cloneInteractiveContextState(
           interactiveContextState,
@@ -3766,6 +3774,14 @@ export class BackgroundRunSupervisor {
         }
         // Phase E: background-run supervisor migrated to drain the
         // Phase C generator inside the cycle loop.
+        const routedToolNames =
+          toolRoutingDecision?.routedToolNames ?? advertisedToolNames;
+        const expandedToolNames = Array.from(
+          new Set([
+            ...advertisedToolNames,
+            ...(toolRoutingDecision?.expandedToolNames ?? []),
+          ]),
+        );
         actorResult = await executeChatToLegacyResult(this.chatExecutor, {
           message: toRunMessage(actorPrompt, sessionId, run.id, run.cycleCount),
           history: run.internalHistory,
@@ -3800,13 +3816,16 @@ export class BackgroundRunSupervisor {
           maxToolRounds: BACKGROUND_RUN_MAX_TOOL_ROUNDS,
           toolBudgetPerRequest: BACKGROUND_RUN_MAX_TOOL_BUDGET,
           maxModelRecallsPerRequest: BACKGROUND_RUN_MAX_MODEL_RECALLS,
-          toolRouting: toolRoutingDecision
-            ? {
-              routedToolNames: toolRoutingDecision.routedToolNames,
-              expandedToolNames: toolRoutingDecision.expandedToolNames,
-              expandOnMiss: true,
-            }
-            : undefined,
+          toolRouting:
+            routedToolNames.length > 0 || expandedToolNames.length > 0
+              ? {
+                advertisedToolNames,
+                routedToolNames,
+                expandedToolNames,
+                expandOnMiss: true,
+                persistDiscovery: true,
+              }
+              : undefined,
           ...(actorTrace ? { trace: actorTrace } : {}),
         });
 

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -2551,6 +2551,22 @@ export class DaemonManager {
               shellProfile: effectiveProfile,
             });
           },
+        resolveAdvertisedToolNames: (sessionId, shellProfile, discoveredToolNames) =>
+          this.getAdvertisedToolNames(
+            undefined,
+            this.evaluateShellFeatureAdmission({
+              sessionId,
+              feature: "codingCommands",
+              domain: "shell",
+            }).allowed
+              ? this.resolveEffectiveShellProfile({
+                  sessionId,
+                  metadata: sessionMgr.get(sessionId)?.metadata ?? {},
+                  preferred: shellProfile,
+                })
+              : DEFAULT_SESSION_SHELL_PROFILE,
+            discoveredToolNames,
+          ),
         seedHistoryForSession: (sessionId) =>
           sessionMgr.get(sessionId)?.history ?? [],
         isSessionBusy: (sessionId) =>

--- a/runtime/src/gateway/sub-agent.test.ts
+++ b/runtime/src/gateway/sub-agent.test.ts
@@ -577,6 +577,45 @@ describe("SubAgentManager", () => {
       expect(grokProvider.chat).toHaveBeenCalledTimes(1);
     });
 
+    it("advertises the resolved child tool bundle instead of the full executor catalog", async () => {
+      const executeSpy = vi
+        .spyOn(ChatExecutor.prototype, "execute")
+        .mockResolvedValue({
+          content: "sub-agent output",
+          toolCalls: [],
+          providerEvidence: undefined,
+          tokenUsage: undefined,
+          stopReason: "completed",
+          stopReasonDetail: undefined,
+          callUsage: [],
+          finalPromptShape: undefined,
+          statefulSummary: undefined,
+          toolRoutingSummary: undefined,
+          plannerSummary: undefined,
+          model: "mock",
+        } as any);
+      const manager = new SubAgentManager(makeManagerConfig());
+
+      try {
+        await manager.spawn({
+          parentSessionId: "p",
+          task: "inspect the workspace",
+          tools: ["tool.a", "tool.b"],
+        });
+        await settle();
+
+        expect(executeSpy).toHaveBeenCalledTimes(1);
+        expect((executeSpy.mock.calls[0]?.[0] as any).toolRouting).toEqual({
+          advertisedToolNames: ["tool.a", "tool.b"],
+          routedToolNames: ["tool.a", "tool.b"],
+          expandedToolNames: ["tool.a", "tool.b"],
+          persistDiscovery: true,
+        });
+      } finally {
+        executeSpy.mockRestore();
+      }
+    });
+
     it("passes workspace override to createContext", async () => {
       const createContext = vi.fn(async () => makeMockContext());
       const manager = new SubAgentManager(makeManagerConfig({ createContext }));

--- a/runtime/src/gateway/sub-agent.ts
+++ b/runtime/src/gateway/sub-agent.ts
@@ -1471,17 +1471,14 @@ export class SubAgentManager {
             }
           : undefined;
 
-      // When the spawn comes from the orchestrator pipeline (has an
-      // execution context with explicit tool scope), pass the resolved
-      // tools as routedToolNames so the sub-agent's ChatExecutor uses
-      // the full scope instead of re-deriving a narrower set from
-      // message content heuristics.  Direct spawns (no delegation spec)
-      // continue to use the ChatExecutor's default routing.
-      const spawnRoutedTools =
-        handle.config.delegationSpec &&
-        handle.config.tools &&
-        handle.config.tools.length > 0
-          ? [...handle.config.tools]
+      // Child sessions should advertise the resolved child tool bundle
+      // directly instead of falling back to the parent executor's broad
+      // allowlist. That keeps child prompts cache-stable and avoids
+      // provider-side tool trimming when the role already resolved a
+      // concrete tool set.
+      const spawnAdvertisedTools =
+        handle.config.tools && handle.config.tools.length > 0
+          ? [...new Set(handle.config.tools)]
           : undefined;
       const runtimeWorkspaceRoot = resolveSubAgentWorkspaceRoot(handle.config);
 
@@ -1505,8 +1502,15 @@ export class SubAgentManager {
               baseSystemPrompt,
             },
             sessionId: handle.sessionId,
-            ...(spawnRoutedTools
-              ? { toolRouting: { routedToolNames: spawnRoutedTools } }
+            ...(spawnAdvertisedTools
+              ? {
+                  toolRouting: {
+                    advertisedToolNames: spawnAdvertisedTools,
+                    routedToolNames: spawnAdvertisedTools,
+                    expandedToolNames: spawnAdvertisedTools,
+                    persistDiscovery: true,
+                  },
+                }
               : {}),
             ...(runtimeWorkspaceRoot
               ? {


### PR DESCRIPTION
## Summary
- pass the resolved advertised tool bundle into background actor cycles instead of falling back to the full executor allowlist
- pass the resolved child tool bundle into child-session launches so child prompts stay scoped to their assigned tools
- add regression coverage for both background and child execution paths

## Verification
- ./node_modules/.bin/vitest run runtime/src/gateway/background-run-supervisor.test.ts runtime/src/gateway/sub-agent.test.ts runtime/src/gateway/tool-routing.test.ts runtime/src/llm/chat-executor-routing-state.test.ts
- ./node_modules/.bin/tsc -p runtime/tsconfig.json --noEmit
- npm run techdebt