### PR TITLE
fix(runtime): suppress full-catalog tools on no-tool calls

### DIFF
--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -192,3 +192,10 @@
 - **What worked:** Passing the resolved advertised tool bundle into background actor cycles and child-session launches kept both paths on the same scoped tool surface as foreground turns, which prevents provider-side trimming from broad fallback catalogs.
 - **What didn't:** Background and child execution had each kept their own fallback path to the executor-wide allowlist, so fixing the live overflow required patching both call sites and adding dedicated regressions instead of relying on the earlier foreground-only routing work.
 - **Rule added to CLAUDE.md:** no
+
+## PR #408: fix(runtime): suppress full-catalog tools on no-tool calls
+- **Date:** 2026-04-15
+- **Files changed:** `runtime/src/llm/{model-only-options,chat-executor-fallback,executor}.ts`, `runtime/src/llm/grok/adapter.ts`, `runtime/src/gateway/{background-run-supervisor,daemon-command-registry,heartbeat-actions}.ts`, `runtime/src/memory/{reflection,ingestion}.ts`, `runtime/src/autonomous/{self-learning,desktop-awareness,desktop-executor}.ts`, and the matching runtime tests
+- **What worked:** Centralizing model-only provider options and forcing explicit empty allowlists on helper calls, recovery turns, and legacy executor requests closed the remaining full-catalog attachment paths without widening the normal routed-tool surfaces.
+- **What didn't:** The overflow issue was spread across multiple helper call sites plus two separate fail-open fallbacks in executor and provider layers, so fixing it required a broad parity pass and direct regression coverage instead of a single routing tweak.
+- **Rule added to CLAUDE.md:** no

--- a/runtime/src/autonomous/desktop-awareness.test.ts
+++ b/runtime/src/autonomous/desktop-awareness.test.ts
@@ -132,6 +132,8 @@ describe("createDesktopAwarenessAction", () => {
     expect(llm.chat).toHaveBeenCalledWith(
       expect.any(Array),
       expect.objectContaining({
+        toolRouting: { allowedToolNames: [] },
+        parallelToolCalls: false,
         trace: expect.objectContaining({
           includeProviderPayloads: true,
           onProviderTraceEvent: expect.any(Function),

--- a/runtime/src/autonomous/desktop-awareness.ts
+++ b/runtime/src/autonomous/desktop-awareness.ts
@@ -11,6 +11,7 @@
 import type { HeartbeatAction, HeartbeatContext, HeartbeatResult } from "../gateway/heartbeat.js";
 import type { MemoryBackend } from "../memory/types.js";
 import type { LLMProvider } from "../llm/types.js";
+import { buildModelOnlyChatOptions } from "../llm/model-only-options.js";
 import { createProviderTraceEventLogger } from "../llm/provider-trace-logger.js";
 import type { Tool } from "../tools/types.js";
 
@@ -74,7 +75,8 @@ export function createDesktopAwarenessAction(
 
         const llmResult = await llm.chat([
           { role: "user", content: analysisPrompt },
-        ], config.traceProviderPayloads === true
+        ], buildModelOnlyChatOptions(
+          config.traceProviderPayloads === true
           ? {
             trace: {
               includeProviderPayloads: true,
@@ -89,7 +91,8 @@ export function createDesktopAwarenessAction(
               }),
             },
           }
-          : undefined);
+          : undefined,
+        ));
 
         const analysis = llmResult.content ?? "Unable to analyze desktop.";
 

--- a/runtime/src/autonomous/desktop-executor.ts
+++ b/runtime/src/autonomous/desktop-executor.ts
@@ -16,6 +16,7 @@ import type { ChatExecutor } from "../llm/chat-executor.js";
 import type { ToolCallRecord } from "../llm/chat-executor-types.js";
 import { executeChatToLegacyResult } from "../llm/execute-chat.js";
 import { createPromptEnvelope } from "../llm/prompt-envelope.js";
+import { buildModelOnlyChatOptions } from "../llm/model-only-options.js";
 import type { ToolHandler, LLMProvider } from "../llm/types.js";
 import {
   createExecutionTraceEventLogger,
@@ -461,7 +462,7 @@ export class DesktopExecutor {
             `{"success": true/false, "confidence": 0.0-1.0, "description": "what you observe"}`;
           const verifyResult = await this.llm.chat([
             { role: "user", content: verifyPrompt },
-          ], {
+          ], buildModelOnlyChatOptions({
             trace: this.buildProviderTraceOptions({
               goalId,
               sessionId,
@@ -469,7 +470,7 @@ export class DesktopExecutor {
               traceId: `${sessionId}:verify:${stepNumber}:${verifyStart}`,
               stepNumber,
             }),
-          });
+          }));
 
           verification = parseVerification(verifyResult.content);
         } catch {

--- a/runtime/src/autonomous/self-learning.ts
+++ b/runtime/src/autonomous/self-learning.ts
@@ -14,6 +14,7 @@ import type {
   HeartbeatResult,
 } from "../gateway/heartbeat.js";
 import type { LLMProvider } from "../llm/types.js";
+import { buildModelOnlyChatOptions } from "../llm/model-only-options.js";
 import { createProviderTraceEventLogger } from "../llm/provider-trace-logger.js";
 import type { MemoryBackend } from "../memory/types.js";
 import { entryToMessage } from "../memory/types.js";
@@ -137,7 +138,8 @@ export function createSelfLearningAction(
             role: "user",
             content: `Analyze these ${entries.length} recent interactions:\n\n${formatted}`,
           },
-        ], config.traceProviderPayloads === true
+        ], buildModelOnlyChatOptions(
+          config.traceProviderPayloads === true
           ? {
             trace: {
               includeProviderPayloads: true,
@@ -152,7 +154,8 @@ export function createSelfLearningAction(
               }),
             },
           }
-          : undefined);
+          : undefined,
+        ));
 
         if (!response.content) {
           return { hasOutput: false, quiet: true };

--- a/runtime/src/gateway/background-run-supervisor.test.ts
+++ b/runtime/src/gateway/background-run-supervisor.test.ts
@@ -963,6 +963,8 @@ describe("background-run-supervisor", () => {
       expect.any(Array),
       expect.objectContaining({
         toolChoice: "none",
+        toolRouting: { allowedToolNames: [] },
+        parallelToolCalls: false,
         trace: expect.objectContaining({
           includeProviderPayloads: true,
           onProviderTraceEvent: expect.any(Function),

--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -14,6 +14,7 @@ import type { ChatExecutor } from "../llm/chat-executor.js";
 import type { ChatExecutorResult } from "../llm/chat-executor-types.js";
 import { executeChatToLegacyResult } from "../llm/execute-chat.js";
 import { normalizePromptEnvelope } from "../llm/prompt-envelope.js";
+import { buildModelOnlyChatOptions } from "../llm/model-only-options.js";
 import type { LLMProvider, ToolHandler } from "../llm/types.js";
 import type { Logger } from "../utils/logger.js";
 import { silentLogger } from "../utils/logger.js";
@@ -4227,10 +4228,10 @@ export class BackgroundRunSupervisor {
             ),
           }),
         },
-      ], {
+      ], buildModelOnlyChatOptions({
         toolChoice: "none",
         ...(providerTrace ?? {}),
-      });
+      }));
       return parseDecision(response.content);
     } catch (error) {
       this.logger.debug("Background run decision evaluation failed", {
@@ -4299,10 +4300,10 @@ export class BackgroundRunSupervisor {
             observedTargets: run.observedTargets,
           }),
         },
-      ], {
+      ], buildModelOnlyChatOptions({
         toolChoice: "none",
         ...(providerTrace ?? {}),
-      });
+      }));
       const parsed =
         parseCarryForwardState(response.content, now) ??
         buildFallbackCarryForwardState({
@@ -4464,10 +4465,10 @@ export class BackgroundRunSupervisor {
       const response = await this.supervisorLlm.chat([
         { role: "system", content: CONTRACT_SYSTEM_PROMPT },
         { role: "user", content: buildContractPrompt(objective) },
-      ], {
+      ], buildModelOnlyChatOptions({
         toolChoice: "none",
         ...(providerTrace ?? {}),
-      });
+      }));
       return parseContract(response.content, objective) ?? buildFallbackContract(objective);
     } catch (error) {
       this.logger.debug("Background run contract planning failed", {

--- a/runtime/src/gateway/daemon-command-registry.ts
+++ b/runtime/src/gateway/daemon-command-registry.ts
@@ -20,6 +20,7 @@ import type {
   LLMStoredResponse,
   ToolHandler,
 } from "../llm/types.js";
+import { buildModelOnlyChatOptions } from "../llm/model-only-options.js";
 import type { MemoryBackend } from "../memory/types.js";
 import { SlashCommandRegistry, createDefaultCommands } from "./commands.js";
 import {
@@ -5016,7 +5017,7 @@ export function createDaemonCommandRegistry(
               },
               { role: "user", content: prompt },
             ],
-            evalProviderTrace,
+            buildModelOnlyChatOptions(evalProviderTrace),
           );
           const durationMs = Date.now() - started;
           if (response.finishReason === "error" || response.error) {

--- a/runtime/src/gateway/heartbeat-actions.test.ts
+++ b/runtime/src/gateway/heartbeat-actions.test.ts
@@ -206,6 +206,11 @@ describe("createSummaryAction", () => {
     expect(result.output).toBe("A concise summary.");
 
     const chatCall = (llm.chat as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const chatOptions = (llm.chat as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(chatOptions).toEqual(expect.objectContaining({
+      toolRouting: { allowedToolNames: [] },
+      parallelToolCalls: false,
+    }));
     expect(chatCall[0].role).toBe("system");
     expect(chatCall[0].content).toContain("concise summarizer");
     expect(chatCall[1].role).toBe("user");

--- a/runtime/src/gateway/heartbeat-actions.ts
+++ b/runtime/src/gateway/heartbeat-actions.ts
@@ -24,6 +24,7 @@ import type { TaskScanner } from "../autonomous/scanner.js";
 import type { MemoryBackend } from "../memory/types.js";
 import { entryToMessage } from "../memory/types.js";
 import type { LLMProvider } from "../llm/types.js";
+import { buildModelOnlyChatOptions } from "../llm/model-only-options.js";
 import { createProviderTraceEventLogger } from "../llm/provider-trace-logger.js";
 
 // ============================================================================
@@ -131,7 +132,8 @@ export function createSummaryAction(
             role: "user",
             content: `Summarize this conversation:\n\n${formatted}`,
           },
-        ], config.traceProviderPayloads === true
+        ], buildModelOnlyChatOptions(
+          config.traceProviderPayloads === true
           ? {
             trace: {
               includeProviderPayloads: true,
@@ -146,7 +148,8 @@ export function createSummaryAction(
               }),
             },
           }
-          : undefined);
+          : undefined,
+        ));
 
         if (!response.content) return QUIET;
 
@@ -305,7 +308,8 @@ export function createProactiveCommsAction(
             role: "user",
             content: `Recent activity:\n${formatted}\n\nShould I proactively message users?`,
           },
-        ], config.traceProviderPayloads === true
+        ], buildModelOnlyChatOptions(
+          config.traceProviderPayloads === true
           ? {
             trace: {
               includeProviderPayloads: true,
@@ -319,7 +323,8 @@ export function createProactiveCommsAction(
               }),
             },
           }
-          : undefined);
+          : undefined,
+        ));
 
         if (
           !response.content ||

--- a/runtime/src/llm/chat-executor-fallback.test.ts
+++ b/runtime/src/llm/chat-executor-fallback.test.ts
@@ -283,4 +283,25 @@ describe("callWithFallback", () => {
     expect(serializedMessages[0]).not.toHaveProperty("runtimeOnly");
     expect(serializedMessages[1]).not.toHaveProperty("runtimeOnly");
   });
+  it("passes an explicit empty allowlist for no-tool recovery turns", async () => {
+    const provider = createMockProvider();
+
+    await callWithFallback(
+      createDeps(provider),
+      [{ role: "user", content: "reply with exactly ACK" }],
+      undefined,
+      undefined,
+      {
+        callPhase: "initial",
+        toolChoice: "none",
+      },
+    );
+
+    const options = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[1];
+    expect(options).toEqual(expect.objectContaining({
+      toolChoice: "none",
+      toolRouting: { allowedToolNames: [] },
+    }));
+  });
+
 });

--- a/runtime/src/llm/chat-executor-fallback.ts
+++ b/runtime/src/llm/chat-executor-fallback.ts
@@ -179,7 +179,9 @@ export async function callWithFallback(
     hasStatefulSessionId && options?.statefulResumeAnchor !== undefined;
   const hasStatefulHistoryCompacted =
     hasStatefulSessionId && options?.statefulHistoryCompacted === true;
-  const hasRoutedToolNames = options?.routedToolNames !== undefined;
+  const resolvedRoutedToolNames =
+    options?.routedToolNames ?? (options?.toolChoice === "none" ? [] : undefined);
+  const hasRoutedToolNames = resolvedRoutedToolNames !== undefined;
   const hasToolChoice = options?.toolChoice !== undefined;
   const hasStructuredOutput = options?.structuredOutput !== undefined;
   const hasAbortSignal = options?.signal !== undefined;
@@ -212,7 +214,7 @@ export async function callWithFallback(
           }
           : {}),
         ...(hasRoutedToolNames
-          ? { toolRouting: { allowedToolNames: options?.routedToolNames } }
+          ? { toolRouting: { allowedToolNames: resolvedRoutedToolNames } }
           : {}),
         ...(hasToolChoice ? { toolChoice: options?.toolChoice } : {}),
         ...(hasStructuredOutput

--- a/runtime/src/llm/executor.test.ts
+++ b/runtime/src/llm/executor.test.ts
@@ -716,4 +716,55 @@ describe("LLMTaskExecutor", () => {
       expect(firstCall.ttlMs).toBe(customTtl);
     });
   });
+  it("passes an explicit empty tool allowlist when no tool handler is configured", async () => {
+    const provider = createMockProvider();
+    const executor = new LLMTaskExecutor({ provider });
+
+    await executor.execute(createMockTask());
+
+    expect(provider.chat).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({
+        toolRouting: { allowedToolNames: [] },
+        parallelToolCalls: false,
+      }),
+    );
+  });
+
+  it("passes configured allowed tools through to provider follow-up calls", async () => {
+    const toolCallResponse: LLMResponse = {
+      content: "",
+      toolCalls: [{ id: "call_1", name: "lookup", arguments: "{}" }],
+      usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      model: "mock-model",
+      finishReason: "tool_calls",
+    };
+    const finalResponse: LLMResponse = {
+      content: "final answer",
+      toolCalls: [],
+      usage: { promptTokens: 20, completionTokens: 10, totalTokens: 30 },
+      model: "mock-model",
+      finishReason: "stop",
+    };
+    const chat = vi
+      .fn<[LLMMessage[], LLMChatOptions?], Promise<LLMResponse>>()
+      .mockResolvedValueOnce(toolCallResponse)
+      .mockResolvedValueOnce(finalResponse);
+    const provider = createMockProvider({ chat });
+    const executor = new LLMTaskExecutor({
+      provider,
+      toolHandler: vi.fn().mockResolvedValue("ok"),
+      allowedTools: ["lookup"],
+    });
+
+    await executor.execute(createMockTask());
+
+    expect(chat.mock.calls[0]?.[1]).toEqual(expect.objectContaining({
+      toolRouting: { allowedToolNames: ["lookup"] },
+    }));
+    expect(chat.mock.calls[1]?.[1]).toEqual(expect.objectContaining({
+      toolRouting: { allowedToolNames: ["lookup"] },
+    }));
+  });
+
 });

--- a/runtime/src/llm/executor.ts
+++ b/runtime/src/llm/executor.ts
@@ -21,6 +21,7 @@ import type { MetricsProvider } from "../task/types.js";
 import { TELEMETRY_METRIC_NAMES } from "../telemetry/metric-names.js";
 import type { MemoryGraph, MemoryGraphResult } from "../memory/graph.js";
 import { createProviderTraceEventLogger } from "./provider-trace-logger.js";
+import { buildModelOnlyChatOptions } from "./model-only-options.js";
 import { assertValidLLMResponse } from "./response-validation.js";
 import {
   createPromptEnvelope,
@@ -125,6 +126,25 @@ export class LLMTaskExecutor implements TaskExecutor {
     this.traceProviderPayloads = config.traceProviderPayloads ?? false;
   }
 
+  private buildToolRoutingOptions() {
+    if (!this.toolHandler) {
+      return buildModelOnlyChatOptions();
+    }
+    if (this.allowedTools) {
+      return { toolRouting: { allowedToolNames: [...this.allowedTools] } };
+    }
+    return undefined;
+  }
+
+  private mergeProviderChatOptions(
+    traceOptions: ReturnType<LLMTaskExecutor["buildProviderTraceOptions"]>,
+  ) {
+    return {
+      ...(this.buildToolRoutingOptions() ?? {}),
+      ...(traceOptions ?? {}),
+    };
+  }
+
   private buildProviderTraceOptions(params: {
     sessionId: string;
     taskPda: string;
@@ -188,13 +208,16 @@ export class LLMTaskExecutor implements TaskExecutor {
           await this.provider.chatStream(
             messages,
             this.onStreamChunk,
-            initialTrace,
+            this.mergeProviderChatOptions(initialTrace),
           ),
         );
       } else {
         response = assertValidLLMResponse(
           this.provider.name,
-          await this.provider.chat(messages, initialTrace),
+          await this.provider.chat(
+              messages,
+              this.mergeProviderChatOptions(initialTrace),
+            ),
         );
       }
       this.recordLLMMetrics(response, Date.now() - chatStart);
@@ -304,13 +327,16 @@ export class LLMTaskExecutor implements TaskExecutor {
             await this.provider.chatStream(
               messages,
               this.onStreamChunk,
-              followupTrace,
+              this.mergeProviderChatOptions(followupTrace),
             ),
           );
         } else {
           response = assertValidLLMResponse(
             this.provider.name,
-            await this.provider.chat(messages, followupTrace),
+            await this.provider.chat(
+              messages,
+              this.mergeProviderChatOptions(followupTrace),
+            ),
           );
         }
         this.recordLLMMetrics(response, Date.now() - chatStart);

--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -411,6 +411,42 @@ describe("GrokProvider", () => {
     });
   });
 
+  it("suppresses tools when toolChoice none is set without an explicit allowlist", async () => {
+    mockCreate.mockResolvedValueOnce(makeCompletion());
+
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "system.bash",
+            description: "run command",
+            parameters: {
+              type: "object",
+              properties: { command: { type: "string" } },
+            },
+          },
+        },
+      ],
+    });
+
+    const response = await provider.chat(
+      [{ role: "user", content: "reply with exactly ACK" }],
+      { toolChoice: "none" },
+    );
+
+    const params = mockCreate.mock.calls.at(-1)?.[0];
+    expect(params.tools).toBeUndefined();
+    expect(response.requestMetrics).toMatchObject({
+      toolCount: 0,
+      toolResolution: "all_tools_empty_filter",
+      toolSuppressionReason: "tool_choice_none",
+      toolsAttached: false,
+    });
+  });
+
+
   it("normalizes forced function tool_choice for the Responses API", async () => {
     mockCreate.mockResolvedValueOnce(makeCompletion());
 

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -1629,6 +1629,7 @@ export class GrokProvider implements LLMProvider {
     if (!this.statefulConfig.enabled || !sessionId) {
       const toolSelection = this.resolveResponseTools(
         options?.toolRouting?.allowedToolNames,
+        options?.toolChoice,
       );
       const built = this.buildParams(messages, {
         store: false,
@@ -1766,6 +1767,7 @@ export class GrokProvider implements LLMProvider {
 
     const toolSelection = this.resolveResponseTools(
       options?.toolRouting?.allowedToolNames,
+      options?.toolChoice,
     );
     const statefulInput =
       continued && anchorMatched && anchorRelevantMessageIndex !== undefined
@@ -2160,6 +2162,7 @@ export class GrokProvider implements LLMProvider {
 
   private resolveResponseTools(
     allowedToolNames?: readonly string[],
+    toolChoice?: LLMToolChoice,
   ): ToolSelectionDiagnostics {
     const providerNativeTools = this.providerNativeTools;
     const providerCatalogToolCount =
@@ -2173,6 +2176,19 @@ export class GrokProvider implements LLMProvider {
       ...providerNativeTools.map((definition) => definition.payload),
     ];
     if (allowedToolNames === undefined) {
+      if (toolChoice === "none") {
+        return {
+          tools: [],
+          chars: 0,
+          requestedToolNames: [],
+          resolvedToolNames: [],
+          missingRequestedToolNames: [],
+          providerCatalogToolCount,
+          toolResolution: "all_tools_empty_filter",
+          toolsAttached: false,
+          toolSuppressionReason: "tool_choice_none",
+        };
+      }
       return {
         tools: fullCatalogTools,
         chars: this.toolChars,

--- a/runtime/src/llm/model-only-options.ts
+++ b/runtime/src/llm/model-only-options.ts
@@ -1,0 +1,23 @@
+import type { LLMChatOptions } from "./types.js";
+
+type ModelOnlyChatOptions = Omit<
+  LLMChatOptions,
+  "toolRouting" | "parallelToolCalls"
+>;
+
+/**
+ * Build a model-only provider call contract.
+ *
+ * Model-only helper prompts must never advertise the runtime tool catalog.
+ * Keep this centralized so helper/model-only call sites do not regress to the
+ * provider's full-catalog fallback behavior.
+ */
+export function buildModelOnlyChatOptions(
+  options?: ModelOnlyChatOptions,
+): LLMChatOptions {
+  return {
+    ...(options ?? {}),
+    toolRouting: { allowedToolNames: [] },
+    parallelToolCalls: false,
+  };
+}

--- a/runtime/src/memory/ingestion.ts
+++ b/runtime/src/memory/ingestion.ts
@@ -23,6 +23,7 @@ import type {
 } from "./structured.js";
 import { NoopEntityExtractor } from "./structured.js";
 import type { LLMProvider, LLMMessage } from "../llm/types.js";
+import { buildModelOnlyChatOptions } from "../llm/model-only-options.js";
 import { createProviderTraceEventLogger } from "../llm/provider-trace-logger.js";
 import type { HookHandler, HookContext, HookResult } from "../gateway/hooks.js";
 import type { Logger } from "../utils/logger.js";
@@ -376,7 +377,8 @@ export class MemoryIngestionEngine {
         const response = await this.llmProvider.chat([
           { role: "system", content: SUMMARY_PROMPT },
           { role: "user", content: conversationText },
-        ], this.traceProviderPayloads
+        ], buildModelOnlyChatOptions(
+          this.traceProviderPayloads
           ? {
             trace: {
               includeProviderPayloads: true,
@@ -391,7 +393,8 @@ export class MemoryIngestionEngine {
               }),
             },
           }
-          : undefined);
+          : undefined,
+        ));
         summary = normalizeSummary(response.content, this.maxSummaryChars);
 
         // Store summary with embedding in vector store

--- a/runtime/src/memory/reflection.ts
+++ b/runtime/src/memory/reflection.ts
@@ -10,6 +10,7 @@
  */
 
 import type { LLMProvider, LLMMessage } from "../llm/types.js";
+import { buildModelOnlyChatOptions } from "../llm/model-only-options.js";
 import type { AgentIdentityManager, AgentBelief } from "./agent-identity.js";
 import type { Logger } from "../utils/logger.js";
 
@@ -65,7 +66,7 @@ export async function runReflection(params: {
     const response = await llmProvider.chat([
       { role: "system", content: REFLECTION_SYSTEM_PROMPT },
       { role: "user", content: historyText },
-    ]);
+    ], buildModelOnlyChatOptions());
 
     const content = response.content.trim();
     const jsonMatch = content.match(/\{[\s\S]*\}/);


### PR DESCRIPTION
## Summary
- suppress tools for model-only helper calls through a shared empty-tool contract
- fail closed for no-tool recovery turns and legacy task executor provider calls
- add a provider-side safeguard so `toolChoice: "none"` never falls back to the full catalog

## Testing
- `./node_modules/.bin/tsc -p runtime/tsconfig.json --noEmit`
- `./node_modules/.bin/vitest run runtime/src/gateway/daemon-command-registry.test.ts runtime/src/gateway/background-run-supervisor.test.ts runtime/src/gateway/heartbeat-actions.test.ts runtime/src/autonomous/desktop-awareness.test.ts runtime/src/autonomous/desktop-executor.test.ts runtime/src/llm/chat-executor-fallback.test.ts runtime/src/llm/executor.test.ts runtime/src/llm/grok/adapter.test.ts runtime/src/gateway/sub-agent.test.ts runtime/src/gateway/tool-routing.test.ts runtime/src/llm/chat-executor-routing-state.test.ts`
- `npm run techdebt`