### PR TITLE
fix(runtime): simplify workspace background supervision

### DIFF
--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -199,3 +199,10 @@
 - **What worked:** Centralizing model-only provider options and forcing explicit empty allowlists on helper calls, recovery turns, and legacy executor requests closed the remaining full-catalog attachment paths without widening the normal routed-tool surfaces.
 - **What didn't:** The overflow issue was spread across multiple helper call sites plus two separate fail-open fallbacks in executor and provider layers, so fixing it required a broad parity pass and direct regression coverage instead of a single routing tweak.
 - **Rule added to CLAUDE.md:** no
+
+## PR #409: fix(runtime): simplify workspace background supervision
+- **Date:** 2026-04-16
+- **Files changed:** `runtime/src/gateway/{background-run-supervisor,background-run-supervisor-helpers}.ts`, `runtime/src/gateway/background-run-supervisor.test.ts`
+- **What worked:** Letting workspace background runs follow the actor result directly removed the extra supervisor decision and carry-forward model passes, cut the user-facing heartbeat spam, and tightened fallback completion so false successes without verified evidence get blocked.
+- **What didn't:** The only stale failure after the runtime change was a test that still expected heartbeat publishes, so the suite needed one expectation update to match the new non-publishing heartbeat behavior.
+- **Rule added to CLAUDE.md:** no

--- a/runtime/src/gateway/background-run-supervisor-helpers.ts
+++ b/runtime/src/gateway/background-run-supervisor-helpers.ts
@@ -1137,6 +1137,42 @@ function shouldTreatStopReasonAsBoundedStep(
   );
 }
 
+function hasVerifierPassedOrSkipped(
+  actorResult: ChatExecutorResult,
+): boolean {
+  const verifierStages = actorResult.runtimeContractSnapshot?.verifierStages;
+  if (!verifierStages) {
+    return false;
+  }
+  if (verifierStages.runtimeRequired === true) {
+    return verifierStages.stageStatus === "passed";
+  }
+  return (
+    verifierStages.stageStatus === "inactive" ||
+    verifierStages.stageStatus === "skipped"
+  );
+}
+
+function hasVerifierInFlight(
+  actorResult: ChatExecutorResult,
+): boolean {
+  const stage = actorResult.runtimeContractSnapshot?.verifierStages?.stageStatus;
+  return stage === "pending" || stage === "running" || stage === "retry";
+}
+
+function hasCompletedWorkflowState(
+  actorResult: ChatExecutorResult,
+): boolean {
+  const progress = actorResult.completionProgress;
+  if (!progress) {
+    return actorResult.toolCalls.length === 0;
+  }
+  return (
+    progress.completionState === "completed" &&
+    progress.remainingRequirements.length === 0
+  );
+}
+
 export function buildFallbackDecision(run: ActiveBackgroundRun, actorResult: ChatExecutorResult): BackgroundRunDecision {
   if (shouldTreatStopReasonAsBoundedStep(actorResult)) {
     const detail =
@@ -1154,12 +1190,60 @@ export function buildFallbackDecision(run: ActiveBackgroundRun, actorResult: Cha
       shouldNotifyUser: true,
     };
   }
+  if (hasVerifierInFlight(actorResult)) {
+    const detail =
+      actorResult.stopReasonDetail ??
+      actorResult.content ??
+      "Verification is still in progress.";
+    return {
+      state: "working",
+      userUpdate: truncate(
+        actorResult.content || "Verification is still in progress.",
+        MAX_USER_UPDATE_CHARS,
+      ),
+      internalSummary: detail,
+      nextCheckMs: MIN_POLL_INTERVAL_MS,
+      shouldNotifyUser: true,
+    };
+  }
+  if (
+    actorResult.stopReason === "completed" &&
+    actorResult.completionState === "completed" &&
+    hasVerifierPassedOrSkipped(actorResult) &&
+    hasCompletedWorkflowState(actorResult)
+  ) {
+    const detail =
+      actorResult.stopReasonDetail ??
+      actorResult.content ??
+      "Background run completed successfully.";
+    return {
+      state: "completed",
+      userUpdate: truncate(
+        actorResult.content || "Background run completed successfully.",
+        MAX_USER_UPDATE_CHARS,
+      ),
+      internalSummary: detail,
+      shouldNotifyUser: true,
+    };
+  }
   if (actorResult.stopReason !== "completed") {
     const detail = actorResult.stopReasonDetail ?? actorResult.content ?? "Background run did not complete cleanly.";
     return {
       state: "failed",
       userUpdate: truncate(detail, MAX_USER_UPDATE_CHARS),
       internalSummary: detail,
+      shouldNotifyUser: true,
+    };
+  }
+  if (actorResult.toolCalls.length === 0 && !run.lastToolEvidence) {
+    return {
+      state: "blocked",
+      userUpdate: truncate(
+        "Background run cannot mark itself complete without verified tool evidence.",
+        MAX_USER_UPDATE_CHARS,
+      ),
+      internalSummary:
+        "Rejected completion because there is no verified tool evidence in the current or previous cycle.",
       shouldNotifyUser: true,
     };
   }

--- a/runtime/src/gateway/background-run-supervisor.test.ts
+++ b/runtime/src/gateway/background-run-supervisor.test.ts
@@ -2264,7 +2264,7 @@ describe("background-run-supervisor", () => {
     expect(snapshot?.nextCheckAt).toBeTypeOf("number");
   });
 
-  it("publishes a runtime heartbeat while a background cycle is still running", async () => {
+  it("keeps a runtime heartbeat scheduled while a background cycle is still running", async () => {
     let resolveExecute: ((result: ChatExecutorResult) => void) | undefined;
     const publishUpdate = vi.fn(async () => undefined);
     const execute = vi.fn(
@@ -2301,12 +2301,11 @@ describe("background-run-supervisor", () => {
     });
     await vi.advanceTimersByTimeAsync(8_000);
 
-    expect(publishUpdate).toHaveBeenNthCalledWith(
-      2,
-      "session-running-heartbeat",
-      expect.stringContaining("Still working on the current background cycle."),
-    );
+    expect(publishUpdate).toHaveBeenCalledTimes(1);
     expect(supervisor.getStatusSnapshot("session-running-heartbeat")?.state).toBe("running");
+    expect(
+      supervisor.getStatusSnapshot("session-running-heartbeat")?.nextHeartbeatAt,
+    ).toBeTypeOf("number");
 
     resolveExecute?.(
       makeResult({

--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -3313,7 +3313,6 @@ export class BackgroundRunSupervisor {
         phase: "background_run",
         detail: `Background run cycle ${run.cycleCount} is still in progress`,
       });
-      await this.publishUpdate(sessionId, content);
       this.scheduleHeartbeat(run, ACTIVE_CYCLE_HEARTBEAT_REPEAT_MS);
       return;
     }
@@ -3332,7 +3331,6 @@ export class BackgroundRunSupervisor {
             ? `Next verification in ~${Math.max(1, Math.ceil((run.nextCheckAt - this.now()) / 1000))}s`
             : "Background run waiting for next verification",
       });
-    await this.publishUpdate(sessionId, content);
     try {
       await this.persistRun(run);
     } catch (error) {
@@ -3681,6 +3679,10 @@ export class BackgroundRunSupervisor {
     return true;
   }
 
+  private shouldUseActorLoopParity(run: ActiveBackgroundRun): boolean {
+    return run.contract.domain === "workspace";
+  }
+
   private async resolveCycleDecision(params: {
     run: ActiveBackgroundRun;
     sessionId: string;
@@ -3887,7 +3889,11 @@ export class BackgroundRunSupervisor {
               ? domainDecision
               : undefined
           ) ??
-          (await this.evaluateDecision(run, actorResult)) ??
+          (
+            this.shouldUseActorLoopParity(run)
+              ? undefined
+              : await this.evaluateDecision(run, actorResult)
+          ) ??
           buildFallbackDecision(run, actorResult);
         decision = groundDecision(run, actorResult, decision, domainDecision);
       }
@@ -4089,7 +4095,11 @@ export class BackgroundRunSupervisor {
     }
 
     const signalDrivenCompletion = buildDeterministicRunDomainDecision(run);
-    if (signalDrivenCompletion && signalDrivenCompletion.state !== "working") {
+    if (
+      !this.shouldUseActorLoopParity(run) &&
+      signalDrivenCompletion &&
+      signalDrivenCompletion.state !== "working"
+    ) {
       decision = signalDrivenCompletion;
     }
 
@@ -4264,114 +4274,17 @@ export class BackgroundRunSupervisor {
       extractLatestProviderContinuation(actorResult, now) ??
       previousCarryForward?.providerContinuation;
     let finalReason: CarryForwardRefreshReason = refreshReason;
-
-    try {
-      const providerTrace =
-        this.traceProviderPayloads
-          ? {
-            trace: {
-              includeProviderPayloads: true as const,
-              onProviderTraceEvent: createProviderTraceEventLogger({
-                logger: this.logger,
-                traceLabel: "background_run.provider",
-                traceId: `background:${run.sessionId}:${run.id}:${run.cycleCount}:carry_forward`,
-                sessionId: run.sessionId,
-                staticFields: {
-                  runId: run.id,
-                  cycleCount: run.cycleCount,
-                  phase: "carry_forward",
-                },
-              }),
-            },
-          }
-          : undefined;
-      const response = await this.supervisorLlm.chat([
-        { role: "system", content: CARRY_FORWARD_SYSTEM_PROMPT },
-        {
-          role: "user",
-          content: buildCarryForwardPrompt({
-            objective: run.objective,
-            contract: run.contract,
-            previous: previousCarryForward,
-            actorResult,
-            latestUpdate: run.lastUserUpdate,
-            latestToolEvidence: run.lastToolEvidence,
-            pendingSignals,
-            observedTargets: run.observedTargets,
-          }),
-        },
-      ], buildModelOnlyChatOptions({
-        toolChoice: "none",
-        ...(providerTrace ?? {}),
-      }));
-      const parsed =
-        parseCarryForwardState(response.content, now) ??
-        buildFallbackCarryForwardState({
-          previous: previousCarryForward,
-          latestUpdate: run.lastUserUpdate,
-          latestToolEvidence: run.lastToolEvidence,
-          pendingSignals,
-          now,
-        });
-      const driftReason = detectCarryForwardDrift({
-        candidate: parsed,
-        actorResult,
+    if (this.shouldUseActorLoopParity(run)) {
+      const fallbackState = buildFallbackCarryForwardState({
         previous: previousCarryForward,
-      });
-      if (driftReason) {
-        finalReason = "repair";
-        run.carryForward = repairCarryForwardState({
-          previous: previousCarryForward,
-          latestUpdate: run.lastUserUpdate,
-          latestToolEvidence: run.lastToolEvidence,
-          pendingSignals,
-          actorResult,
-          now,
-          reason: driftReason,
-          providerContinuation,
-        });
-        this.logger.warn("Background run carry-forward drift detected", {
-          sessionId: run.sessionId,
-          runId: run.id,
-          reason: driftReason,
-        });
-      } else {
-        run.carryForward = {
-          ...parsed,
-          artifacts: previousCarryForward?.artifacts ?? [],
-          memoryAnchors: buildCarryForwardAnchors({
-            previous: previousCarryForward?.memoryAnchors ?? [],
-            providerContinuation,
-            pendingSignals,
-            actorResult,
-            now,
-          }),
-          providerContinuation,
-          summaryHealth: {
-            status: "healthy",
-            driftCount: previousCarryForward?.summaryHealth.driftCount ?? 0,
-            lastDriftAt: previousCarryForward?.summaryHealth.lastDriftAt,
-            lastRepairAt: previousCarryForward?.summaryHealth.lastRepairAt,
-            lastDriftReason: previousCarryForward?.summaryHealth.lastDriftReason,
-          },
-          lastCompactedAt: now,
-        };
-      }
-    } catch (error) {
-      this.logger.debug("Background run carry-forward refresh failed", {
-        sessionId: run.sessionId,
-        runId: run.id,
-        error: toErrorMessage(error),
-      });
-      run.carryForward = buildFallbackCarryForwardState({
-        previous: previousCarryForward,
-        latestUpdate: run.lastUserUpdate,
+        latestUpdate: actorResult?.content ?? run.lastUserUpdate,
         latestToolEvidence: run.lastToolEvidence,
         pendingSignals,
         now,
       });
       run.carryForward = {
-        ...run.carryForward,
+        ...fallbackState,
+        artifacts: previousCarryForward?.artifacts ?? [],
         memoryAnchors: buildCarryForwardAnchors({
           previous: previousCarryForward?.memoryAnchors ?? [],
           providerContinuation,
@@ -4380,11 +4293,137 @@ export class BackgroundRunSupervisor {
           now,
         }),
         providerContinuation,
-        summaryHealth: previousCarryForward?.summaryHealth ?? {
+        summaryHealth: {
           status: "healthy",
-          driftCount: 0,
+          driftCount: previousCarryForward?.summaryHealth.driftCount ?? 0,
+          lastDriftAt: previousCarryForward?.summaryHealth.lastDriftAt,
+          lastRepairAt: previousCarryForward?.summaryHealth.lastRepairAt,
+          lastDriftReason: previousCarryForward?.summaryHealth.lastDriftReason,
         },
+        lastCompactedAt: now,
       };
+    } else {
+      try {
+        const providerTrace =
+          this.traceProviderPayloads
+            ? {
+              trace: {
+                includeProviderPayloads: true as const,
+                onProviderTraceEvent: createProviderTraceEventLogger({
+                  logger: this.logger,
+                  traceLabel: "background_run.provider",
+                  traceId: `background:${run.sessionId}:${run.id}:${run.cycleCount}:carry_forward`,
+                  sessionId: run.sessionId,
+                  staticFields: {
+                    runId: run.id,
+                    cycleCount: run.cycleCount,
+                    phase: "carry_forward",
+                  },
+                }),
+              },
+            }
+            : undefined;
+        const response = await this.supervisorLlm.chat([
+          { role: "system", content: CARRY_FORWARD_SYSTEM_PROMPT },
+          {
+            role: "user",
+            content: buildCarryForwardPrompt({
+              objective: run.objective,
+              contract: run.contract,
+              previous: previousCarryForward,
+              actorResult,
+              latestUpdate: run.lastUserUpdate,
+              latestToolEvidence: run.lastToolEvidence,
+              pendingSignals,
+              observedTargets: run.observedTargets,
+            }),
+          },
+        ], buildModelOnlyChatOptions({
+          toolChoice: "none",
+          ...(providerTrace ?? {}),
+        }));
+        const parsed =
+          parseCarryForwardState(response.content, now) ??
+          buildFallbackCarryForwardState({
+            previous: previousCarryForward,
+            latestUpdate: run.lastUserUpdate,
+            latestToolEvidence: run.lastToolEvidence,
+            pendingSignals,
+            now,
+          });
+        const driftReason = detectCarryForwardDrift({
+          candidate: parsed,
+          actorResult,
+          previous: previousCarryForward,
+        });
+        if (driftReason) {
+          finalReason = "repair";
+          run.carryForward = repairCarryForwardState({
+            previous: previousCarryForward,
+            latestUpdate: run.lastUserUpdate,
+            latestToolEvidence: run.lastToolEvidence,
+            pendingSignals,
+            actorResult,
+            now,
+            reason: driftReason,
+            providerContinuation,
+          });
+          this.logger.warn("Background run carry-forward drift detected", {
+            sessionId: run.sessionId,
+            runId: run.id,
+            reason: driftReason,
+          });
+        } else {
+          run.carryForward = {
+            ...parsed,
+            artifacts: previousCarryForward?.artifacts ?? [],
+            memoryAnchors: buildCarryForwardAnchors({
+              previous: previousCarryForward?.memoryAnchors ?? [],
+              providerContinuation,
+              pendingSignals,
+              actorResult,
+              now,
+            }),
+            providerContinuation,
+            summaryHealth: {
+              status: "healthy",
+              driftCount: previousCarryForward?.summaryHealth.driftCount ?? 0,
+              lastDriftAt: previousCarryForward?.summaryHealth.lastDriftAt,
+              lastRepairAt: previousCarryForward?.summaryHealth.lastRepairAt,
+              lastDriftReason: previousCarryForward?.summaryHealth.lastDriftReason,
+            },
+            lastCompactedAt: now,
+          };
+        }
+      } catch (error) {
+        this.logger.debug("Background run carry-forward refresh failed", {
+          sessionId: run.sessionId,
+          runId: run.id,
+          error: toErrorMessage(error),
+        });
+        run.carryForward = buildFallbackCarryForwardState({
+          previous: previousCarryForward,
+          latestUpdate: run.lastUserUpdate,
+          latestToolEvidence: run.lastToolEvidence,
+          pendingSignals,
+          now,
+        });
+        run.carryForward = {
+          ...run.carryForward,
+          memoryAnchors: buildCarryForwardAnchors({
+            previous: previousCarryForward?.memoryAnchors ?? [],
+            providerContinuation,
+            pendingSignals,
+            actorResult,
+            now,
+          }),
+          providerContinuation,
+          summaryHealth: previousCarryForward?.summaryHealth ?? {
+            status: "healthy",
+            driftCount: 0,
+          },
+        };
+      }
     }
 
     run.compaction = {
@@ -4405,13 +4444,6 @@ export class BackgroundRunSupervisor {
       lastProviderAnchorAt:
         providerContinuation?.updatedAt ?? run.compaction.lastProviderAnchorAt,
     };
-    if (finalReason === "repair") {
-      this.logger.info("Background run repaired carry-forward state", {
-        sessionId: run.sessionId,
-        runId: run.id,
-        refreshCount: run.compaction.refreshCount,
-      });
-    }
     const latestProviderCompactionArtifact = [...run.carryForward.artifacts]
       .reverse()
       .find((artifact) =>


### PR DESCRIPTION
## Summary
- remove user-facing background heartbeat updates
- skip extra supervisor decision and carry-forward model passes for workspace background runs
- tighten fallback completion so workspace runs need verified evidence before completing

## Verification
- ./node_modules/.bin/tsc -p runtime/tsconfig.json --noEmit
- ./node_modules/.bin/vitest run runtime/src/gateway/background-run-supervisor.test.ts
- ./node_modules/.bin/vitest run runtime/src/gateway/background-run-control.test.ts runtime/src/gateway/background-run-store.test.ts runtime/src/gateway/background-run-notifier.test.ts runtime/src/gateway/background-run-wake-bus.test.ts
- ./node_modules/.bin/vitest run runtime/src/gateway/background-run-supervisor.test.ts runtime/src/gateway/run-domains.test.ts
- npm run techdebt