### PR TITLE
fix(runtime/router): filter grok models by structured-output capability

### DIFF
--- a/runtime/src/llm/model-routing-policy.test.ts
+++ b/runtime/src/llm/model-routing-policy.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildModelRoutingPolicy,
+  resolveModelRoute,
+} from "./model-routing-policy.js";
+import type { LLMProvider } from "./types.js";
+
+const NOOP_ECONOMICS_POLICY = {} as Parameters<
+  typeof buildModelRoutingPolicy
+>[0]["economicsPolicy"];
+
+function makeProvider(name: string): LLMProvider {
+  return {
+    name,
+    chat: (async () => ({})) as unknown as LLMProvider["chat"],
+    chatStream: (async () => ({})) as unknown as LLMProvider["chatStream"],
+    healthCheck: (async () => true) as unknown as LLMProvider["healthCheck"],
+  };
+}
+
+describe("model-routing-policy — xAI structured-output capability", () => {
+  it("marks grok-code-fast-1 as NOT supporting structured outputs with tools", () => {
+    const policy = buildModelRoutingPolicy({
+      providers: [makeProvider("grok")],
+      economicsPolicy: NOOP_ECONOMICS_POLICY,
+      providerConfigs: [
+        { provider: "grok", model: "grok-code-fast-1" },
+      ],
+    });
+    expect(policy.providers[0]?.supportsStructuredOutputWithTools).toBe(false);
+  });
+
+  it("marks grok-4 family models as supporting structured outputs with tools", () => {
+    const policy = buildModelRoutingPolicy({
+      providers: [makeProvider("grok")],
+      economicsPolicy: NOOP_ECONOMICS_POLICY,
+      providerConfigs: [
+        { provider: "grok", model: "grok-4-1-fast-non-reasoning" },
+      ],
+    });
+    expect(policy.providers[0]?.supportsStructuredOutputWithTools).toBe(true);
+  });
+
+  it("reorders a capable grok-4 model ahead of grok-code-fast-1 when structured outputs are required", () => {
+    const codeFast = makeProvider("grok");
+    const grok4 = makeProvider("grok");
+    const policy = buildModelRoutingPolicy({
+      providers: [codeFast, grok4],
+      economicsPolicy: NOOP_ECONOMICS_POLICY,
+      providerConfigs: [
+        { provider: "grok", model: "grok-code-fast-1" },
+        { provider: "grok", model: "grok-4-1-fast-non-reasoning" },
+      ],
+    });
+
+    const decision = resolveModelRoute({
+      policy,
+      runClass: "executor",
+      requirements: { structuredOutputRequired: true },
+    });
+
+    expect(decision.selectedModel).toBe("grok-4-1-fast-non-reasoning");
+    expect(decision.rerouted).toBe(true);
+    expect(decision.reason).toBe("structured_output_capability");
+  });
+
+  it("leaves grok-code-fast-1 selected when no capable grok-4 is configured, even if structured outputs are required", () => {
+    const codeFast = makeProvider("grok");
+    const policy = buildModelRoutingPolicy({
+      providers: [codeFast],
+      economicsPolicy: NOOP_ECONOMICS_POLICY,
+      providerConfigs: [
+        { provider: "grok", model: "grok-code-fast-1" },
+      ],
+    });
+
+    const decision = resolveModelRoute({
+      policy,
+      runClass: "executor",
+      requirements: { structuredOutputRequired: true },
+    });
+
+    expect(decision.selectedModel).toBe("grok-code-fast-1");
+    expect(decision.rerouted).toBe(false);
+  });
+
+  it("does not reorder when structured outputs are NOT required, even with mixed grok models", () => {
+    const codeFast = makeProvider("grok");
+    const grok4 = makeProvider("grok");
+    const policy = buildModelRoutingPolicy({
+      providers: [codeFast, grok4],
+      economicsPolicy: NOOP_ECONOMICS_POLICY,
+      providerConfigs: [
+        { provider: "grok", model: "grok-code-fast-1" },
+        { provider: "grok", model: "grok-4-1-fast-non-reasoning" },
+      ],
+    });
+
+    const decision = resolveModelRoute({
+      policy,
+      runClass: "executor",
+      requirements: { structuredOutputRequired: false },
+    });
+
+    expect(decision.selectedModel).toBe("grok-code-fast-1");
+    expect(decision.rerouted).toBe(false);
+  });
+
+  it("preserves non-grok structured-output defaulting (enabled unless explicitly disabled)", () => {
+    const anthropic = makeProvider("anthropic");
+    const policy = buildModelRoutingPolicy({
+      providers: [anthropic],
+      economicsPolicy: NOOP_ECONOMICS_POLICY,
+      providerConfigs: [
+        { provider: "anthropic", model: "claude-sonnet" },
+      ],
+    });
+    expect(policy.providers[0]?.supportsStructuredOutputWithTools).toBe(true);
+
+    const policyDisabled = buildModelRoutingPolicy({
+      providers: [anthropic],
+      economicsPolicy: NOOP_ECONOMICS_POLICY,
+      providerConfigs: [
+        {
+          provider: "anthropic",
+          model: "claude-sonnet",
+          structuredOutputs: { enabled: false },
+        },
+      ],
+    });
+    expect(policyDisabled.providers[0]?.supportsStructuredOutputWithTools).toBe(
+      false,
+    );
+  });
+});

--- a/runtime/src/llm/model-routing-policy.ts
+++ b/runtime/src/llm/model-routing-policy.ts
@@ -4,6 +4,7 @@ import type {
   RuntimeEconomicsPolicy,
   RuntimeRunClass,
 } from "./run-budget.js";
+import { supportsXaiStructuredOutputsWithTools } from "./structured-output.js";
 
 interface ProviderRouteDescriptor {
   readonly index: number;
@@ -120,9 +121,18 @@ function buildProviderDescriptor(
     providerConfigs,
   );
   const model = config?.model;
+  // xAI exposes structured outputs on all Grok models, but structured
+  // outputs combined with tools are Grok-4 family only. Treating every
+  // "grok" descriptor as capable caused the router to route tool-using
+  // structured-output calls to grok-code-fast-1, where the adapter's
+  // fail-closed boundary would then reject the request and the runtime
+  // would bake the provider error into conversation history. Check the
+  // model family here so prioritizeStructuredOutputProviders() actually
+  // reorders capable Grok-4 models ahead of incompatible ones.
   const supportsStructuredOutputWithTools =
-    provider.name === "grok" ||
-    config?.structuredOutputs?.enabled !== false;
+    provider.name === "grok"
+      ? supportsXaiStructuredOutputsWithTools(model)
+      : config?.structuredOutputs?.enabled !== false;
 
   return {
     index,


### PR DESCRIPTION
## Summary

- `buildProviderDescriptor` marked every `grok` provider as `supportsStructuredOutputWithTools` regardless of the model name, so the router would keep `grok-code-fast-1` selected for tool-using structured-output calls.
- The adapter's fail-closed assertion (`assertXaiStructuredOutputToolCompatibility`) then threw `LLMProviderError`; that class is not retry-eligible, so the error text leaked up into subsequent cycles' conversation history as fake `assistant` turns, corrupting the background run.
- Route descriptors now call `supportsXaiStructuredOutputsWithTools(model)` from `structured-output.ts`, so `prioritizeStructuredOutputProviders()` can actually reorder capable Grok-4 models ahead of incompatible ones.
- Non-grok descriptors keep the previous config-opt-in default.

## Test plan

- [x] `vitest run src/llm/model-routing-policy.test.ts` — 6 new cases pass (grok-code-fast-1 incapable, grok-4 capable, reorder on `structuredOutputRequired`, no reorder without it, fallback when only incapable grok is configured, non-grok opt-in/opt-out).
- [x] `vitest run src/llm/chat-executor-fallback.test.ts src/llm/chat-executor-routing-state.test.ts src/llm/grok/adapter.test.ts` — 104 existing tests pass, no regressions.
- [x] `npm run typecheck && npm run build` — clean.