### PR TITLE
feat(runtime/tui): surface sub-agent activity via progress tracker + header overlay

### DIFF
--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -83,6 +83,7 @@ import {
 import {
   SubAgentManager,
 } from "./sub-agent.js";
+import { SubAgentProgressTracker } from "./sub-agent-progress.js";
 import {
   DelegationPolicyEngine,
   DelegationVerifierService,
@@ -1060,6 +1061,8 @@ export class DaemonManager {
   private _delegationPolicyEngine: DelegationPolicyEngine | null = null;
   private _delegationVerifierService: DelegationVerifierService | null = null;
   private _subAgentLifecycleEmitter: SubAgentLifecycleEmitter | null = null;
+  private readonly _subAgentProgressTracker: SubAgentProgressTracker =
+    new SubAgentProgressTracker();
   private _delegationTrajectorySink: InMemoryDelegationTrajectorySink | null =
     null;
   private _subAgentLifecycleUnsubscribe: (() => void) | null = null;
@@ -1206,6 +1209,7 @@ export class DaemonManager {
         policyEngine: this._delegationPolicyEngine,
         verifier: this._delegationVerifierService,
         lifecycleEmitter: this._subAgentLifecycleEmitter,
+        progressTracker: this._subAgentProgressTracker,
         launchShellAgentTask: async (params) =>
           this.launchShellAgentTask({
             parentSessionId: params.parentSessionId,
@@ -6649,6 +6653,14 @@ export class DaemonManager {
     if (!lifecycleEmitter) return;
     this._subAgentLifecycleUnsubscribe = lifecycleEmitter.on((event) => {
       this.relaySubAgentLifecycleEvent(webChat, event);
+      if (
+        event.subagentSessionId &&
+        (event.type === "subagents.completed" ||
+          event.type === "subagents.failed" ||
+          event.type === "subagents.cancelled")
+      ) {
+        this._subAgentProgressTracker.detach(event.subagentSessionId);
+      }
     });
   }
 

--- a/runtime/src/gateway/delegation-runtime.ts
+++ b/runtime/src/gateway/delegation-runtime.ts
@@ -12,6 +12,7 @@ import {
   type SubAgentManager,
 } from "./sub-agent.js";
 import type { PersistentWorkerManager } from "./persistent-worker-manager.js";
+import type { SubAgentProgressTracker } from "./sub-agent-progress.js";
 import type { GatewaySubagentFallbackBehavior } from "./types.js";
 import type { DelegationContractSpec } from "../utils/delegation-validation.js";
 import {
@@ -269,6 +270,16 @@ export interface DelegationToolCompositionContext {
   readonly policyEngine: DelegationPolicyEngine | null;
   readonly verifier: DelegationVerifierService | null;
   readonly lifecycleEmitter: SubAgentLifecycleEmitter | null;
+  /**
+   * Per-sub-agent progress aggregator. When present, tool-handler emit
+   * sites call `onToolExecuting` / `onToolResult` and then emit an
+   * enriched `subagents.progress` event carrying
+   * `payload.progress = SubAgentAgentProgress` so UIs can render
+   * live tool counts, tokens, and last-tool name under the spawning
+   * `execute_with_agent` card — mirrors `AgentProgressLine` in
+   * `../claude_code/components/AgentProgressLine.tsx`.
+   */
+  readonly progressTracker?: SubAgentProgressTracker | null;
   readonly launchShellAgentTask?: (params: {
     readonly parentSessionId: string;
     readonly roleId: string;

--- a/runtime/src/gateway/sub-agent-progress.test.ts
+++ b/runtime/src/gateway/sub-agent-progress.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import {
+  RECENT_ACTIVITIES_CAP,
+  SubAgentProgressTracker,
+} from "./sub-agent-progress.js";
+
+function makeTracker(options?: ConstructorParameters<typeof SubAgentProgressTracker>[0]) {
+  let clock = 1_000_000;
+  const tracker = new SubAgentProgressTracker({
+    emitIntervalMs: 0,
+    now: () => clock,
+    ...options,
+  });
+  return {
+    tracker,
+    advance: (ms: number) => {
+      clock += ms;
+    },
+    setClock: (value: number) => {
+      clock = value;
+    },
+    get clock() {
+      return clock;
+    },
+  };
+}
+
+describe("SubAgentProgressTracker", () => {
+  it("accumulates tool rounds and reports lastToolName + recentActivities", () => {
+    const h = makeTracker();
+    h.tracker.attach({
+      subagentSessionId: "sa-1",
+      parentSessionId: "session-parent",
+      parentToolCallId: "parent-call-1",
+    });
+    h.tracker.onToolExecuting({
+      subagentSessionId: "sa-1",
+      toolName: "system.readFile",
+      args: { path: "/tmp/a.txt" },
+    });
+    h.advance(10);
+    h.tracker.onToolResult({
+      subagentSessionId: "sa-1",
+      toolName: "system.readFile",
+      isError: false,
+      durationMs: 10,
+    });
+    h.advance(5);
+    h.tracker.onToolExecuting({
+      subagentSessionId: "sa-1",
+      toolName: "system.bash",
+      args: { command: "ls" },
+    });
+    h.advance(3);
+    h.tracker.onToolResult({
+      subagentSessionId: "sa-1",
+      toolName: "system.bash",
+      isError: true,
+      durationMs: 3,
+    });
+    const snap = h.tracker.flushSnapshot("sa-1")!;
+    expect(snap.toolUseCount).toBe(2);
+    expect(snap.lastToolName).toBe("system.bash");
+    expect(snap.recentActivities.map((a) => a.toolName)).toEqual([
+      "system.readFile",
+      "system.bash",
+    ]);
+    expect(snap.recentActivities[0]?.isError).toBe(false);
+    expect(snap.recentActivities[0]?.durationMs).toBe(10);
+    expect(snap.recentActivities[1]?.isError).toBe(true);
+    expect(snap.lastActivity?.toolName).toBe("system.bash");
+  });
+
+  it("caps recentActivities at RECENT_ACTIVITIES_CAP", () => {
+    const h = makeTracker();
+    for (let i = 0; i < RECENT_ACTIVITIES_CAP + 4; i += 1) {
+      h.tracker.onToolExecuting({
+        subagentSessionId: "sa-cap",
+        toolName: `tool-${i}`,
+      });
+    }
+    const snap = h.tracker.flushSnapshot("sa-cap")!;
+    expect(snap.toolUseCount).toBe(RECENT_ACTIVITIES_CAP + 4);
+    expect(snap.recentActivities).toHaveLength(RECENT_ACTIVITIES_CAP);
+    expect(snap.recentActivities[0]?.toolName).toBe("tool-4");
+    expect(snap.recentActivities[RECENT_ACTIVITIES_CAP - 1]?.toolName).toBe(
+      `tool-${RECENT_ACTIVITIES_CAP + 3}`,
+    );
+  });
+
+  it("computes tokenCount = latestInputTokens + cumulativeOutputTokens", () => {
+    const h = makeTracker();
+    h.tracker.onProviderUsage({
+      subagentSessionId: "sa-tok",
+      inputTokens: 1_000,
+      outputTokens: 50,
+    });
+    h.tracker.onProviderUsage({
+      subagentSessionId: "sa-tok",
+      inputTokens: 1_200,
+      outputTokens: 30,
+    });
+    h.tracker.onProviderUsage({
+      subagentSessionId: "sa-tok",
+      inputTokens: 1_500,
+      outputTokens: 40,
+    });
+    const snap = h.tracker.flushSnapshot("sa-tok")!;
+    // latestInputTokens = 1500, cumulativeOutputTokens = 50 + 30 + 40 = 120
+    expect(snap.tokenCount).toBe(1_620);
+  });
+
+  it("debounces snapshots by emitIntervalMs", () => {
+    const h = makeTracker({ emitIntervalMs: 250 });
+    h.tracker.onToolExecuting({
+      subagentSessionId: "sa-deb",
+      toolName: "a",
+    });
+    // First emission is due immediately (lastEmittedAt starts at 0).
+    expect(h.tracker.consumeSnapshotIfDue("sa-deb")).not.toBeNull();
+    h.advance(100);
+    h.tracker.onToolExecuting({
+      subagentSessionId: "sa-deb",
+      toolName: "b",
+    });
+    expect(h.tracker.consumeSnapshotIfDue("sa-deb")).toBeNull();
+    h.advance(200); // total 300ms since last emit
+    h.tracker.onToolExecuting({
+      subagentSessionId: "sa-deb",
+      toolName: "c",
+    });
+    expect(h.tracker.consumeSnapshotIfDue("sa-deb")).not.toBeNull();
+  });
+
+  it("flushSnapshot bypasses debounce", () => {
+    const h = makeTracker({ emitIntervalMs: 60_000 });
+    h.tracker.onToolExecuting({ subagentSessionId: "sa-f", toolName: "x" });
+    expect(h.tracker.consumeSnapshotIfDue("sa-f")).not.toBeNull();
+    h.advance(10);
+    expect(h.tracker.consumeSnapshotIfDue("sa-f")).toBeNull();
+    expect(h.tracker.flushSnapshot("sa-f")).not.toBeNull();
+  });
+
+  it("detach releases the bucket", () => {
+    const h = makeTracker();
+    h.tracker.onToolExecuting({ subagentSessionId: "sa-d", toolName: "x" });
+    expect(h.tracker.getBucketForTesting("sa-d")).toBeDefined();
+    h.tracker.detach("sa-d");
+    expect(h.tracker.getBucketForTesting("sa-d")).toBeUndefined();
+    expect(h.tracker.flushSnapshot("sa-d")).toBeNull();
+  });
+
+  it("ensures buckets lazily when a tool event arrives without attach", () => {
+    const h = makeTracker();
+    h.tracker.onToolExecuting({
+      subagentSessionId: "sa-lazy",
+      toolName: "x",
+    });
+    const snap = h.tracker.flushSnapshot("sa-lazy")!;
+    expect(snap.toolUseCount).toBe(1);
+    expect(snap.lastToolName).toBe("x");
+  });
+
+  it("elapsedMs reflects startedAt on attach", () => {
+    const h = makeTracker();
+    h.tracker.attach({ subagentSessionId: "sa-e" });
+    h.advance(1_234);
+    const snap = h.tracker.flushSnapshot("sa-e")!;
+    expect(snap.elapsedMs).toBe(1_234);
+  });
+});

--- a/runtime/src/gateway/sub-agent-progress.ts
+++ b/runtime/src/gateway/sub-agent-progress.ts
@@ -1,0 +1,257 @@
+/**
+ * Per-sub-agent progress tracker that mirrors Claude Code's
+ * `ProgressTracker` (see
+ * `../claude_code/tasks/LocalAgentTask/LocalAgentTask.tsx`).
+ *
+ * For every live sub-agent session the tracker maintains:
+ *   - `toolUseCount` — number of tool rounds dispatched by the child.
+ *   - `latestInputTokens` / `cumulativeOutputTokens` — matches Claude's
+ *     token accounting: Claude's API reports `input_tokens` as the
+ *     cumulative-per-turn number and `output_tokens` as per-turn, so we
+ *     keep the latest input and sum outputs.
+ *   - `recentActivities` — ring buffer (cap 5) of the most recent tool
+ *     activities for the "last: <tool>" line.
+ *
+ * The tracker does not do any I/O. Callers wire its output to whichever
+ * event bus the UI subscribes to.
+ */
+
+export interface SubAgentToolActivity {
+  readonly toolName: string;
+  readonly args?: Record<string, unknown> | undefined;
+  readonly isError?: boolean;
+  readonly durationMs?: number;
+  readonly ts: number;
+}
+
+export interface SubAgentAgentProgress {
+  readonly toolUseCount: number;
+  readonly tokenCount: number;
+  readonly lastToolName?: string;
+  readonly lastActivity?: SubAgentToolActivity;
+  readonly recentActivities: readonly SubAgentToolActivity[];
+  readonly elapsedMs: number;
+  readonly summary?: string;
+}
+
+interface TrackerBucket {
+  readonly subagentSessionId: string;
+  readonly parentSessionId?: string;
+  readonly parentToolCallId?: string;
+  readonly startedAt: number;
+  toolUseCount: number;
+  latestInputTokens: number;
+  cumulativeOutputTokens: number;
+  recentActivities: SubAgentToolActivity[];
+  lastToolName?: string;
+  lastEmittedAt: number;
+  summary?: string;
+}
+
+/** Maximum entries kept in `recentActivities` per bucket. */
+export const RECENT_ACTIVITIES_CAP = 5;
+
+/** Default debounce between emitted progress snapshots per session. */
+export const DEFAULT_PROGRESS_EMIT_INTERVAL_MS = 250;
+
+export interface SubAgentProgressTrackerOptions {
+  /**
+   * Debounce in ms between emitted progress snapshots per
+   * `subagentSessionId`. Defaults to 250ms. Set to 0 to emit on every
+   * round (useful for tests).
+   */
+  readonly emitIntervalMs?: number;
+  /** Clock injection for deterministic testing. */
+  readonly now?: () => number;
+}
+
+export class SubAgentProgressTracker {
+  private readonly buckets = new Map<string, TrackerBucket>();
+  private readonly emitIntervalMs: number;
+  private readonly now: () => number;
+
+  constructor(options: SubAgentProgressTrackerOptions = {}) {
+    this.emitIntervalMs =
+      options.emitIntervalMs ?? DEFAULT_PROGRESS_EMIT_INTERVAL_MS;
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  /**
+   * Start (or continue) tracking a sub-agent session. Idempotent.
+   */
+  attach(params: {
+    subagentSessionId: string;
+    parentSessionId?: string;
+    parentToolCallId?: string;
+  }): void {
+    if (this.buckets.has(params.subagentSessionId)) return;
+    const now = this.now();
+    this.buckets.set(params.subagentSessionId, {
+      subagentSessionId: params.subagentSessionId,
+      parentSessionId: params.parentSessionId,
+      parentToolCallId: params.parentToolCallId,
+      startedAt: now,
+      toolUseCount: 0,
+      latestInputTokens: 0,
+      cumulativeOutputTokens: 0,
+      recentActivities: [],
+      lastEmittedAt: 0,
+    });
+  }
+
+  /**
+   * Record a tool dispatch starting. Increments `toolUseCount` and
+   * records the activity.
+   */
+  onToolExecuting(params: {
+    subagentSessionId: string;
+    parentSessionId?: string;
+    parentToolCallId?: string;
+    toolName: string;
+    args?: Record<string, unknown>;
+  }): void {
+    const bucket = this.ensureBucket(params);
+    bucket.toolUseCount += 1;
+    bucket.lastToolName = params.toolName;
+    const activity: SubAgentToolActivity = {
+      toolName: params.toolName,
+      args: params.args,
+      ts: this.now(),
+    };
+    bucket.recentActivities.push(activity);
+    while (bucket.recentActivities.length > RECENT_ACTIVITIES_CAP) {
+      bucket.recentActivities.shift();
+    }
+  }
+
+  /**
+   * Record a tool result. Updates the latest activity with
+   * `isError`/`durationMs` so the "last" line reflects the completed
+   * round.
+   */
+  onToolResult(params: {
+    subagentSessionId: string;
+    parentSessionId?: string;
+    parentToolCallId?: string;
+    toolName: string;
+    isError?: boolean;
+    durationMs?: number;
+  }): void {
+    const bucket = this.ensureBucket(params);
+    const last = bucket.recentActivities[bucket.recentActivities.length - 1];
+    if (last && last.toolName === params.toolName) {
+      const annotated: SubAgentToolActivity = {
+        ...last,
+        ...(params.isError !== undefined ? { isError: params.isError } : {}),
+        ...(params.durationMs !== undefined
+          ? { durationMs: params.durationMs }
+          : {}),
+      };
+      bucket.recentActivities[bucket.recentActivities.length - 1] = annotated;
+    }
+  }
+
+  /**
+   * Update token accounting from provider usage. `inputTokens` is taken
+   * as the latest cumulative-per-turn value; `outputTokens` is summed.
+   */
+  onProviderUsage(params: {
+    subagentSessionId: string;
+    parentSessionId?: string;
+    parentToolCallId?: string;
+    inputTokens?: number;
+    outputTokens?: number;
+  }): void {
+    const bucket = this.ensureBucket(params);
+    if (typeof params.inputTokens === "number" && params.inputTokens >= 0) {
+      bucket.latestInputTokens = params.inputTokens;
+    }
+    if (typeof params.outputTokens === "number" && params.outputTokens >= 0) {
+      bucket.cumulativeOutputTokens += params.outputTokens;
+    }
+  }
+
+  /**
+   * Attach an opaque summary string (e.g. a short verifier finding).
+   */
+  setSummary(subagentSessionId: string, summary: string | undefined): void {
+    const bucket = this.buckets.get(subagentSessionId);
+    if (!bucket) return;
+    bucket.summary = summary;
+  }
+
+  /**
+   * Consume-if-ready: returns a snapshot for emission when the debounce
+   * window has elapsed, otherwise returns `null`. Callers use this
+   * after every tool round so emission stays bounded.
+   */
+  consumeSnapshotIfDue(subagentSessionId: string): SubAgentAgentProgress | null {
+    const bucket = this.buckets.get(subagentSessionId);
+    if (!bucket) return null;
+    const now = this.now();
+    if (
+      this.emitIntervalMs > 0 &&
+      now - bucket.lastEmittedAt < this.emitIntervalMs
+    ) {
+      return null;
+    }
+    bucket.lastEmittedAt = now;
+    return this.buildSnapshot(bucket);
+  }
+
+  /**
+   * Force a snapshot regardless of debounce (use at completion or when
+   * the caller knows the child is about to report).
+   */
+  flushSnapshot(subagentSessionId: string): SubAgentAgentProgress | null {
+    const bucket = this.buckets.get(subagentSessionId);
+    if (!bucket) return null;
+    bucket.lastEmittedAt = this.now();
+    return this.buildSnapshot(bucket);
+  }
+
+  /**
+   * Release the bucket. Safe to call multiple times.
+   */
+  detach(subagentSessionId: string): void {
+    this.buckets.delete(subagentSessionId);
+  }
+
+  /** Test helper. */
+  getBucketForTesting(subagentSessionId: string): TrackerBucket | undefined {
+    return this.buckets.get(subagentSessionId);
+  }
+
+  private ensureBucket(params: {
+    subagentSessionId: string;
+    parentSessionId?: string;
+    parentToolCallId?: string;
+  }): TrackerBucket {
+    let bucket = this.buckets.get(params.subagentSessionId);
+    if (!bucket) {
+      this.attach(params);
+      bucket = this.buckets.get(params.subagentSessionId);
+    }
+    if (!bucket) {
+      throw new Error(
+        `SubAgentProgressTracker: bucket for ${params.subagentSessionId} missing after attach`,
+      );
+    }
+    return bucket;
+  }
+
+  private buildSnapshot(bucket: TrackerBucket): SubAgentAgentProgress {
+    const tokenCount = bucket.latestInputTokens + bucket.cumulativeOutputTokens;
+    const recent = bucket.recentActivities.slice();
+    const last = recent[recent.length - 1];
+    return {
+      toolUseCount: bucket.toolUseCount,
+      tokenCount,
+      ...(bucket.lastToolName ? { lastToolName: bucket.lastToolName } : {}),
+      ...(last ? { lastActivity: last } : {}),
+      recentActivities: recent,
+      elapsedMs: this.now() - bucket.startedAt,
+      ...(bucket.summary ? { summary: bucket.summary } : {}),
+    };
+  }
+}

--- a/runtime/src/gateway/sub-agent.ts
+++ b/runtime/src/gateway/sub-agent.ts
@@ -175,6 +175,14 @@ export type SubAgentStatus =
 
 export interface SubAgentConfig {
   readonly parentSessionId: string;
+  /**
+   * Parent's tool-call id for the `execute_with_agent` invocation that
+   * spawned this sub-agent. Used by lifecycle event consumers (TUI,
+   * webchat UI) to thread child progress under the correct parent tool
+   * card. Matches the `parentToolUseID` concept in
+   * `../claude_code/utils/messages.ts::createProgressMessage`.
+   */
+  readonly parentToolCallId?: string;
   readonly shellProfile?: SessionShellProfile;
   readonly task: string;
   readonly role?: string;
@@ -299,6 +307,7 @@ interface ResolvedSubAgentExecutionBudget {
 export interface SubAgentInfo {
   readonly sessionId: string;
   readonly parentSessionId: string;
+  readonly parentToolCallId?: string;
   readonly depth: number;
   readonly status: SubAgentStatus;
   readonly startedAt: number;
@@ -887,6 +896,9 @@ export class SubAgentManager {
     return {
       sessionId: handle.sessionId,
       parentSessionId: handle.parentSessionId,
+      ...(handle.config.parentToolCallId
+        ? { parentToolCallId: handle.config.parentToolCallId }
+        : {}),
       depth: handle.depth,
       status: handle.status,
       startedAt: handle.startedAt,

--- a/runtime/src/gateway/tool-handler-factory-delegation.ts
+++ b/runtime/src/gateway/tool-handler-factory-delegation.ts
@@ -1307,6 +1307,7 @@ export async function executeDelegationTool(
   try {
     childSessionId = await subAgentManager.spawn({
       parentSessionId: sessionId,
+      ...(toolCallId ? { parentToolCallId: toolCallId } : {}),
       ...(params.shellProfile ? { shellProfile: params.shellProfile } : {}),
       task: objective,
       ...(input.forkContext === true
@@ -1548,6 +1549,7 @@ export async function executeDelegationTool(
             objective,
             elapsedMs: now - startedAt,
             toolCallId,
+            parentToolCallId: toolCallId,
           },
         });
         lastProgressAt = now;

--- a/runtime/src/gateway/tool-handler-factory.test.ts
+++ b/runtime/src/gateway/tool-handler-factory.test.ts
@@ -1795,6 +1795,169 @@ describe("createSessionToolHandler", () => {
     expect(resultPayload?.subagentSessionId).toBe("subagent:test-session");
   });
 
+  it("threads parentToolCallId from SubAgentInfo onto tool lifecycle events", async () => {
+    // Regression: sub-agent tool events previously carried only
+    // `subagentSessionId`, so the TUI could not correlate child activity
+    // to the spawning parent `execute_with_agent` tool card. Threading
+    // `parentToolCallId` through `SubAgentManager.getInfo()` onto the
+    // payload closes that gap.
+    const sentMessages: ControlResponse[] = [];
+    const send = vi.fn((msg: ControlResponse): void => {
+      sentMessages.push(msg);
+    });
+    const lifecycleEvents: Array<Record<string, unknown>> = [];
+
+    const policyEngine = {
+      evaluate: vi.fn(() => ({ allowed: true, threshold: 0.7 })),
+      isDelegationTool: vi.fn(() => false),
+      snapshot: vi.fn(() => ({ spawnDecisionThreshold: 0.7 })),
+    };
+    const verifier = {
+      resolveVerifierRequirement: vi.fn(() => ({
+        required: false,
+        profiles: [],
+        probeCategories: [],
+        mutationPolicy: "read_only_workspace",
+        allowTempArtifacts: false,
+        bootstrapSource: "disabled",
+        rationale: [],
+      })),
+      shouldVerifySubAgentResult: vi.fn(() => false),
+    };
+    const subAgentManager = {
+      getInfo: vi.fn(() => ({
+        sessionId: "subagent:child-42",
+        parentSessionId: "session-parent",
+        parentToolCallId: "parent-call-id-789",
+        depth: 1,
+        status: "running",
+        startedAt: Date.now() - 10,
+        task: "inspect",
+      })),
+    };
+    const lifecycleEmitter = {
+      emit: vi.fn((event: Record<string, unknown>) => {
+        lifecycleEvents.push(event);
+      }),
+    };
+
+    const handler = createSessionToolHandler({
+      sessionId: "subagent:child-42",
+      baseHandler: vi.fn(async () => "ok"),
+      routerId: "router-a",
+      send,
+      delegation: () => ({
+        subAgentManager: subAgentManager as any,
+        policyEngine: policyEngine as any,
+        verifier: verifier as any,
+        lifecycleEmitter: lifecycleEmitter as any,
+      }),
+    });
+
+    await handler("system.health", { verbose: true });
+
+    expect(lifecycleEvents).toHaveLength(2);
+    const executingPayload = lifecycleEvents[0].payload as {
+      parentToolCallId?: string;
+    };
+    const resultPayload = lifecycleEvents[1].payload as {
+      parentToolCallId?: string;
+    };
+    expect(executingPayload.parentToolCallId).toBe("parent-call-id-789");
+    expect(resultPayload.parentToolCallId).toBe("parent-call-id-789");
+  });
+
+  it("emits enriched subagents.progress when a progressTracker is wired into delegation context", async () => {
+    // When the delegation context supplies a SubAgentProgressTracker,
+    // every sub-agent tool round produces an additional
+    // `subagents.progress` event carrying payload.progress with
+    // toolUseCount, tokenCount, lastToolName, and recentActivities.
+    // The TUI consumes this to render an AgentProgressLine-equivalent
+    // row under the spawning execute_with_agent card.
+    const { SubAgentProgressTracker } = await import("./sub-agent-progress.js");
+    const progressTracker = new SubAgentProgressTracker({ emitIntervalMs: 0 });
+    const sentMessages: ControlResponse[] = [];
+    const send = vi.fn((msg: ControlResponse): void => {
+      sentMessages.push(msg);
+    });
+    const lifecycleEvents: Array<Record<string, unknown>> = [];
+
+    const policyEngine = {
+      evaluate: vi.fn(() => ({ allowed: true, threshold: 0.7 })),
+      isDelegationTool: vi.fn(() => false),
+      snapshot: vi.fn(() => ({ spawnDecisionThreshold: 0.7 })),
+    };
+    const verifier = {
+      resolveVerifierRequirement: vi.fn(() => ({
+        required: false,
+        profiles: [],
+        probeCategories: [],
+        mutationPolicy: "read_only_workspace",
+        allowTempArtifacts: false,
+        bootstrapSource: "disabled",
+        rationale: [],
+      })),
+      shouldVerifySubAgentResult: vi.fn(() => false),
+    };
+    const subAgentManager = {
+      getInfo: vi.fn(() => ({
+        sessionId: "subagent:child-7",
+        parentSessionId: "session-parent",
+        parentToolCallId: "parent-call-progress",
+        depth: 1,
+        status: "running",
+        startedAt: Date.now() - 10,
+        task: "inspect",
+      })),
+    };
+    const lifecycleEmitter = {
+      emit: vi.fn((event: Record<string, unknown>) => {
+        lifecycleEvents.push(event);
+      }),
+    };
+
+    const handler = createSessionToolHandler({
+      sessionId: "subagent:child-7",
+      baseHandler: vi.fn(async () => "ok"),
+      routerId: "router-a",
+      send,
+      delegation: () => ({
+        subAgentManager: subAgentManager as any,
+        policyEngine: policyEngine as any,
+        verifier: verifier as any,
+        lifecycleEmitter: lifecycleEmitter as any,
+        progressTracker,
+      }),
+    });
+
+    await handler("system.readFile", { path: "/tmp/a.txt" });
+
+    // Expect: tool.executing → progress (on executing) → tool.result → progress (on result)
+    const types = lifecycleEvents.map((event) => event.type);
+    expect(types).toEqual([
+      "subagents.tool.executing",
+      "subagents.progress",
+      "subagents.tool.result",
+      "subagents.progress",
+    ]);
+    const lastProgress = lifecycleEvents[3] as {
+      payload?: {
+        progress?: {
+          toolUseCount?: number;
+          lastToolName?: string;
+          recentActivities?: Array<{ toolName: string; isError?: boolean }>;
+        };
+        parentToolCallId?: string;
+      };
+    };
+    expect(lastProgress.payload?.parentToolCallId).toBe("parent-call-progress");
+    expect(lastProgress.payload?.progress?.toolUseCount).toBe(1);
+    expect(lastProgress.payload?.progress?.lastToolName).toBe("system.readFile");
+    expect(lastProgress.payload?.progress?.recentActivities?.[0]?.toolName).toBe(
+      "system.readFile",
+    );
+  });
+
   it("executes execute_with_agent via SubAgentManager instead of base handler", async () => {
     const sentMessages: ControlResponse[] = [];
     const send = vi.fn((msg: ControlResponse): void => {

--- a/runtime/src/gateway/tool-handler-factory.ts
+++ b/runtime/src/gateway/tool-handler-factory.ts
@@ -2578,6 +2578,7 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
     const policyEngine = delegationContext?.policyEngine ?? null;
     const verifier = delegationContext?.verifier ?? null;
     const lifecycleEmitter = delegationContext?.lifecycleEmitter ?? null;
+    const progressTracker = delegationContext?.progressTracker ?? null;
     const unsafeBenchmarkMode = delegationContext?.unsafeBenchmarkMode === true;
     const subAgentInfo = isSubAgentSession
       ? subAgentManager?.getInfo(sessionIdentity) ?? null
@@ -2878,8 +2879,46 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
         sessionId,
         subagentSessionId: sessionId,
         toolName,
-        payload: { args: normalizedArgs, toolCallId },
+        payload: {
+          args: normalizedArgs,
+          toolCallId,
+          ...(subAgentInfo?.parentToolCallId
+            ? { parentToolCallId: subAgentInfo.parentToolCallId }
+            : {}),
+        },
       });
+      if (progressTracker) {
+        progressTracker.onToolExecuting({
+          subagentSessionId: sessionId,
+          ...(subAgentInfo?.parentSessionId
+            ? { parentSessionId: subAgentInfo.parentSessionId }
+            : {}),
+          ...(subAgentInfo?.parentToolCallId
+            ? { parentToolCallId: subAgentInfo.parentToolCallId }
+            : {}),
+          toolName,
+          args: normalizedArgs,
+        });
+        const snapshot = progressTracker.consumeSnapshotIfDue(sessionId);
+        if (snapshot) {
+          lifecycleEmitter.emit({
+            type: "subagents.progress",
+            timestamp: Date.now(),
+            sessionId,
+            ...(subAgentInfo?.parentSessionId
+              ? { parentSessionId: subAgentInfo.parentSessionId }
+              : {}),
+            subagentSessionId: sessionId,
+            toolName,
+            payload: {
+              progress: snapshot,
+              ...(subAgentInfo?.parentToolCallId
+                ? { parentToolCallId: subAgentInfo.parentToolCallId }
+                : {}),
+            },
+          });
+        }
+      }
     }
 
     if (
@@ -3239,11 +3278,47 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
           durationMs,
           isError,
           toolCallId,
+          ...(subAgentInfo?.parentToolCallId
+            ? { parentToolCallId: subAgentInfo.parentToolCallId }
+            : {}),
           ...(verifierRequirement
             ? { verifierRequirement }
             : {}),
         },
       });
+      if (progressTracker) {
+        progressTracker.onToolResult({
+          subagentSessionId: sessionId,
+          ...(subAgentInfo?.parentSessionId
+            ? { parentSessionId: subAgentInfo.parentSessionId }
+            : {}),
+          ...(subAgentInfo?.parentToolCallId
+            ? { parentToolCallId: subAgentInfo.parentToolCallId }
+            : {}),
+          toolName,
+          isError,
+          durationMs,
+        });
+        const snapshot = progressTracker.flushSnapshot(sessionId);
+        if (snapshot) {
+          lifecycleEmitter.emit({
+            type: "subagents.progress",
+            timestamp: Date.now(),
+            sessionId,
+            ...(subAgentInfo?.parentSessionId
+              ? { parentSessionId: subAgentInfo.parentSessionId }
+              : {}),
+            subagentSessionId: sessionId,
+            toolName,
+            payload: {
+              progress: snapshot,
+              ...(subAgentInfo?.parentToolCallId
+                ? { parentToolCallId: subAgentInfo.parentToolCallId }
+                : {}),
+            },
+          });
+        }
+      }
     }
 
     // 8. Hook: tool:after (progress tracking)

--- a/runtime/src/watch/agenc-watch-app.mjs
+++ b/runtime/src/watch/agenc-watch-app.mjs
@@ -2054,6 +2054,10 @@ function handleSubagentLifecycleMessage(type, payload) {
   return watchSubagentController.handleSubagentLifecycleMessage(type, payload);
 }
 
+function getActiveSubagentProgress(parentToolCallId) {
+  return watchSubagentController.getActiveSubagentProgress(parentToolCallId);
+}
+
 function handlePlannerTraceEvent(type, payload) {
   return watchPlannerController.handlePlannerTraceEvent(type, payload);
 }

--- a/runtime/src/watch/agenc-watch-frame.mjs
+++ b/runtime/src/watch/agenc-watch-frame.mjs
@@ -1087,11 +1087,50 @@ export function createWatchFrameController(dependencies = {}) {
     // show a `—` placeholder so the tool row doesn't echo the phase row.
     const rawLatestTool = sanitizeInlineText(overview.latestTool, "");
     const hasMeaningfulTool = rawLatestTool.length > 0 && rawLatestTool !== "idle";
-    const toolCell = stat(
-      "tool",
-      hasMeaningfulTool ? rawLatestTool : "—",
-      hasMeaningfulTool ? stateTone(overview.latestToolState) : "slate",
+
+    // Sub-agent tool overlay: when the parent is dispatched into an
+    // `execute_with_agent` delegation the parent session's
+    // `latestTool` goes idle while the child runs. Surface the child's
+    // most recent tool name so the cockpit reflects actual activity.
+    // Mirrors the live `lastToolName` field in
+    // `../claude_code/components/AgentProgressLine.tsx`.
+    const activeSubagentMap =
+      watchState.activeSubagentProgressByParentToolCallId instanceof Map
+        ? watchState.activeSubagentProgressByParentToolCallId
+        : null;
+    let subagentOverlayToolName = null;
+    let subagentOverlayTone = null;
+    let subagentOverlayExtras = null;
+    if (activeSubagentMap && activeSubagentMap.size > 0) {
+      let bestEntry = null;
+      for (const entry of activeSubagentMap.values()) {
+        if (!bestEntry || (entry?.lastUpdatedAt ?? 0) > (bestEntry.lastUpdatedAt ?? 0)) {
+          bestEntry = entry;
+        }
+      }
+      if (bestEntry && typeof bestEntry.lastToolName === "string") {
+        subagentOverlayToolName = bestEntry.lastToolName.trim();
+        const lastActivityError = bestEntry.lastActivity?.isError === true;
+        subagentOverlayTone = lastActivityError ? "red" : "cyan";
+        subagentOverlayExtras = bestEntry;
+      }
+    }
+    const shouldOverlaySubagent = Boolean(
+      subagentOverlayToolName &&
+        (!hasMeaningfulTool || rawLatestTool === "execute_with_agent"),
     );
+    const toolCellValue = shouldOverlaySubagent
+      ? `execute_with_agent › ${truncate(subagentOverlayToolName, 18)}`
+      : hasMeaningfulTool
+        ? rawLatestTool
+        : "—";
+    const toolCellTone = shouldOverlaySubagent
+      ? subagentOverlayTone ?? "cyan"
+      : hasMeaningfulTool
+        ? stateTone(overview.latestToolState)
+        : "slate";
+    const toolCell = stat("tool", toolCellValue, toolCellTone);
+    void subagentOverlayExtras;
 
     // ── Pad right column to uniform width ────────────────────────────────
     const rightColumnCells = [runCell, statusCell, phaseCell, toolCell];

--- a/runtime/src/watch/agenc-watch-state.mjs
+++ b/runtime/src/watch/agenc-watch-state.mjs
@@ -524,6 +524,15 @@ export function createWatchState({
     connectionState: "connecting",
     latestTool: null,
     latestToolState: null,
+    // Active sub-agent progress indexed by the parent's
+    // execute_with_agent tool-call id. Populated from
+    // `subagents.progress` events carrying payload.progress +
+    // payload.parentToolCallId. Mirrors
+    // `progressMessagesByToolUseID` in
+    // `../claude_code/utils/messages.ts::buildMessageLookups`.
+    activeSubagentProgressByParentToolCallId: new Map(),
+    // Reverse index so we can clean up when a sub-agent terminates.
+    parentToolCallIdBySubagentSession: new Map(),
     latestAgentSummary: null,
     agentStreamingText: null,
     agentStreamingPreview: null,

--- a/runtime/src/watch/agenc-watch-subagents.mjs
+++ b/runtime/src/watch/agenc-watch-subagents.mjs
@@ -91,6 +91,16 @@ export function createWatchSubagentController(dependencies = {}) {
     assertFunction(name, value);
   }
 
+  function clearActiveSubagentProgress(subagentSessionId) {
+    if (!subagentSessionId) return;
+    const parentToolCallId =
+      watchState.parentToolCallIdBySubagentSession.get(subagentSessionId);
+    if (parentToolCallId) {
+      watchState.activeSubagentProgressByParentToolCallId.delete(parentToolCallId);
+    }
+    watchState.parentToolCallIdBySubagentSession.delete(subagentSessionId);
+  }
+
   function subagentPayloadData(payload) {
     if (
       payload &&
@@ -334,6 +344,37 @@ export function createWatchSubagentController(dependencies = {}) {
         );
         return;
       case "subagents.progress": {
+        // Upsert the parent-keyed progress map when the enriched
+        // payload shape is present (see
+        // `SubAgentProgressTracker` in
+        // `runtime/src/gateway/sub-agent-progress.ts`). Mirrors the
+        // `progressMessagesByToolUseID` index in
+        // `../claude_code/utils/messages.ts::buildMessageLookups`.
+        const parentToolCallId =
+          typeof data.parentToolCallId === "string"
+            ? data.parentToolCallId
+            : null;
+        const subagentSessionId = payload?.subagentSessionId ?? null;
+        const snapshot = data.progress;
+        if (
+          parentToolCallId &&
+          subagentSessionId &&
+          snapshot &&
+          typeof snapshot === "object"
+        ) {
+          watchState.activeSubagentProgressByParentToolCallId.set(
+            parentToolCallId,
+            {
+              ...snapshot,
+              subagentSessionId,
+              lastUpdatedAt: Date.now(),
+            },
+          );
+          watchState.parentToolCallIdBySubagentSession.set(
+            subagentSessionId,
+            parentToolCallId,
+          );
+        }
         const liveActivity = getSubagentLiveActivity(payload?.subagentSessionId);
         const elapsedSeconds = Number.isFinite(Number(data.elapsedMs))
           ? Math.round(Number(data.elapsedMs) / 1000)
@@ -453,6 +494,7 @@ export function createWatchSubagentController(dependencies = {}) {
         clearSubagentHeartbeatEvents(payload?.subagentSessionId);
         clearSubagentLiveActivity(payload?.subagentSessionId);
         clearSubagentToolArgs(watchState, payload?.subagentSessionId);
+        clearActiveSubagentProgress(payload?.subagentSessionId);
         const toolCallCount = Number.isFinite(Number(data.toolCalls)) ? Number(data.toolCalls) : 0;
         const durationSec = Number.isFinite(Number(data.durationMs))
           ? Math.round(Number(data.durationMs) / 1000)
@@ -584,6 +626,7 @@ export function createWatchSubagentController(dependencies = {}) {
         clearSubagentHeartbeatEvents(payload?.subagentSessionId);
         clearSubagentLiveActivity(payload?.subagentSessionId);
         clearSubagentToolArgs(watchState, payload?.subagentSessionId);
+        clearActiveSubagentProgress(payload?.subagentSessionId);
         updateSubagentPlanStep({
           stepName,
           objective,
@@ -626,6 +669,7 @@ export function createWatchSubagentController(dependencies = {}) {
         clearSubagentHeartbeatEvents(payload?.subagentSessionId);
         clearSubagentLiveActivity(payload?.subagentSessionId);
         clearSubagentToolArgs(watchState, payload?.subagentSessionId);
+        clearActiveSubagentProgress(payload?.subagentSessionId);
         updateSubagentPlanStep({
           stepName,
           objective,
@@ -767,8 +811,16 @@ export function createWatchSubagentController(dependencies = {}) {
     return true;
   }
 
+  function getActiveSubagentProgress(parentToolCallId) {
+    if (!parentToolCallId) return null;
+    return (
+      watchState.activeSubagentProgressByParentToolCallId.get(parentToolCallId) ?? null
+    );
+  }
+
   return {
     resetDelegationState,
     handleSubagentLifecycleMessage,
+    getActiveSubagentProgress,
   };
 }

--- a/runtime/tests/watch/agenc-watch-frame.test.mjs
+++ b/runtime/tests/watch/agenc-watch-frame.test.mjs
@@ -658,6 +658,81 @@ test("frame controller routes file tag palette rows through ansi-aware fitting",
   );
 });
 
+test("frame controller overlays child tool name when a subagent progress entry is active", () => {
+  const harness = createWatchFrameHarness({
+    width: 140,
+    height: 40,
+    watchState: {
+      activeSubagentProgressByParentToolCallId: new Map([
+        [
+          "parent-call-xyz",
+          {
+            subagentSessionId: "subagent:child-1",
+            toolUseCount: 4,
+            tokenCount: 12345,
+            lastToolName: "system.bash",
+            lastActivity: { toolName: "system.bash", isError: false, ts: 1 },
+            recentActivities: [{ toolName: "system.bash", ts: 1 }],
+            elapsedMs: 1200,
+            lastUpdatedAt: Date.now(),
+          },
+        ],
+      ]),
+      parentToolCallIdBySubagentSession: new Map([
+        ["subagent:child-1", "parent-call-xyz"],
+      ]),
+    },
+    dependencies: {
+      currentSurfaceSummary() {
+        return {
+          overview: {
+            connectionState: "live",
+            sessionToken: "12345678",
+            phaseLabel: "thinking",
+            queuedInputCount: 0,
+            // Parent session's latestTool is the execute_with_agent
+            // delegation call. Without the overlay the header would
+            // show only "execute_with_agent" (uninformative once the
+            // child is working).
+            latestTool: "execute_with_agent",
+            latestToolState: "running",
+            usage: "",
+            lastActivityAt: "",
+            activeAgentCount: 1,
+            planCount: 0,
+            transcriptMode: "follow",
+            fallbackState: "standby",
+            runtimeState: "healthy",
+            runtimeLabel: "live",
+            activeLine: "",
+            durableActiveTotal: 0,
+            durableQueuedSignalsTotal: 0,
+            durableRunsState: "ready",
+          },
+          routeLabel: "grok-4",
+          providerLabel: "grok",
+          objective: "",
+          routeState: "primary",
+          routeTone: "teal",
+          recentTools: [],
+          attention: {
+            approvalAlertCount: 0,
+            errorAlertCount: 0,
+            queuedInputCount: 0,
+            items: [],
+          },
+        };
+      },
+    },
+  });
+
+  const snapshot = harness.controller.buildVisibleFrameSnapshot();
+  const hasOverlay = snapshot.lines.some((line) =>
+    String(line).includes("execute_with_agent › system.bash"),
+  );
+  assert.equal(hasOverlay, true);
+});
+
 test("frame controller keeps the full usage summary visible in the header", () => {
   const usage = "80k in · 12k out · 3 cached · 41% window";
   const harness = createWatchFrameHarness({

--- a/runtime/tests/watch/agenc-watch-subagents.test.mjs
+++ b/runtime/tests/watch/agenc-watch-subagents.test.mjs
@@ -6,6 +6,8 @@ import { createWatchSubagentController } from "../../src/watch/agenc-watch-subag
 function createSubagentHarness() {
   const watchState = {
     sessionId: "sess-1",
+    activeSubagentProgressByParentToolCallId: new Map(),
+    parentToolCallIdBySubagentSession: new Map(),
   };
   const recentSubagentLifecycleFingerprints = new Map();
   const subagentLiveActivity = new Map();
@@ -227,4 +229,72 @@ test("subagent controller preserves rich completion truth on synthesized results
         entry.body.includes("completion state: needs verification"),
     ),
   );
+});
+
+test("subagent controller upserts activeSubagentProgress keyed by parentToolCallId", () => {
+  const { controller, watchState } = createSubagentHarness();
+
+  controller.handleSubagentLifecycleMessage("subagents.progress", {
+    subagentSessionId: "child-prog-1",
+    data: {
+      parentToolCallId: "parent-call-xyz",
+      progress: {
+        toolUseCount: 3,
+        tokenCount: 4200,
+        lastToolName: "system.bash",
+        recentActivities: [{ toolName: "system.bash", ts: 1 }],
+        elapsedMs: 900,
+      },
+    },
+  });
+
+  const entry = controller.getActiveSubagentProgress("parent-call-xyz");
+  assert.ok(entry);
+  assert.equal(entry.toolUseCount, 3);
+  assert.equal(entry.lastToolName, "system.bash");
+  assert.equal(entry.subagentSessionId, "child-prog-1");
+  assert.equal(
+    watchState.parentToolCallIdBySubagentSession.get("child-prog-1"),
+    "parent-call-xyz",
+  );
+});
+
+test("subagent controller clears activeSubagentProgress on terminal events", () => {
+  const { controller } = createSubagentHarness();
+
+  controller.handleSubagentLifecycleMessage("subagents.progress", {
+    subagentSessionId: "child-term",
+    data: {
+      parentToolCallId: "parent-call-term",
+      progress: {
+        toolUseCount: 1,
+        tokenCount: 10,
+        lastToolName: "system.stat",
+        recentActivities: [],
+        elapsedMs: 5,
+      },
+    },
+  });
+  assert.ok(controller.getActiveSubagentProgress("parent-call-term"));
+
+  controller.handleSubagentLifecycleMessage("subagents.completed", {
+    subagentSessionId: "child-term",
+    data: { output: "done" },
+  });
+  assert.equal(controller.getActiveSubagentProgress("parent-call-term"), null);
+});
+
+test("subagent controller ignores progress events without parentToolCallId", () => {
+  const { controller } = createSubagentHarness();
+
+  controller.handleSubagentLifecycleMessage("subagents.progress", {
+    subagentSessionId: "child-heartbeat",
+    data: {
+      // heartbeat-only emit (no progress object, no parentToolCallId)
+      elapsedMs: 500,
+      objective: "wait",
+    },
+  });
+
+  assert.equal(controller.getActiveSubagentProgress("parent-nope"), null);
 });

--- a/runtime/tests/watch/fixtures/agenc-watch-frame-harness.mjs
+++ b/runtime/tests/watch/fixtures/agenc-watch-frame-harness.mjs
@@ -40,6 +40,8 @@ export function createWatchFrameHarness(overrides = {}) {
     activeRunStartedAtMs: null,
     bootstrapAttempts: 0,
     marketTaskBrowser: null,
+    activeSubagentProgressByParentToolCallId: new Map(),
+    parentToolCallIdBySubagentSession: new Map(),
     ...overrides.watchState,
   };
   const transportState = {


### PR DESCRIPTION
## Summary

- During long `execute_with_agent` delegations the TUI cockpit previously showed `tool: —` / `phase: thinking` while the child sub-agent was firing tool calls every 1–2s. Sub-agent lifecycle events reached a separate controller but never updated the header.
- Brings AgenC to parity with the `AgentProgressLine` pattern used in `../claude_code` (`utils/task/sdkProgress.ts`, `tasks/LocalAgentTask/LocalAgentTask.tsx::ProgressTracker`, `components/AgentProgressLine.tsx`).
- Parent `execute_with_agent` tool-call id is now threaded through `SubAgentConfig` / `SubAgentInfo` and onto the `subagents.tool.executing` / `subagents.tool.result` / `subagents.progress` event payloads, so UIs can correlate child activity to the spawning parent tool card.
- New `SubAgentProgressTracker` (`runtime/src/gateway/sub-agent-progress.ts`) aggregates `toolUseCount`, `latestInputTokens`, `cumulativeOutputTokens`, `recentActivities` (ring cap 5), `lastToolName` per sub-agent session. Debounced at 250ms with flush-on-result.
- TUI `watchState` gains `activeSubagentProgressByParentToolCallId` + reverse index. The frame renderer overlays the header `tool:` cell as `execute_with_agent › <lastToolName>` whenever an active progress entry exists.

## Known follow-ups (out of scope)

- Nested `AgentProgressLine` row under the parent event card (needs event-block refactor).
- Provider-usage hook for the sub-agent chat-executor so `tokenCount` is populated.
- Web dashboard (`CockpitPanel`) parity — events already arrive there; rendering change is a separate PR.

## Test plan

- [x] `vitest run src/gateway/sub-agent-progress.test.ts` — 8 new cases (accumulator semantics, ring cap, token math, debounce/flush, detach, lazy creation, elapsed).
- [x] `vitest run src/gateway/tool-handler-factory.test.ts` — 101 cases incl. two new: `parentToolCallId` propagation onto `subagents.tool.executing` / `subagents.tool.result`, and enriched `subagents.progress` emission when a `progressTracker` is in the delegation context.
- [x] `node --test tests/watch/agenc-watch-subagents.test.mjs` — 7 cases incl. three new: map upsert on enriched progress, cleanup on terminal events, heartbeat-only payload ignored.
- [x] `node --test tests/watch/agenc-watch-frame.test.mjs` — 30 cases incl. new header-overlay assertion.
- [x] Full `npm run typecheck && npm run build` clean; `npm run test:watch-node` green (the single pre-existing `markdown stream replay: table_reply_commits_header_before_partial_row` failure also fails on `main` with this branch stashed).
- [x] Full `npx vitest run` — 6717 pass / 6 skipped / 9 pre-existing failures identical to `main`.
- [x] `agenc-runtime restart` — new daemon pid up, `grep supportsXai` / progress-tracker strings present in installed bundle.