### PR TITLE
feat(runtime/tui): right-side ANSI art panel with dynamic reflow

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -119,6 +119,7 @@
     "@tetsuo-ai/protocol": "0.2.0",
     "@tetsuo-ai/sdk": "1.4.0",
     "bn.js": "^5.2.3",
+    "jimp": "^1.6.1",
     "undici": "^7.22.0"
   },
   "devDependencies": {

--- a/runtime/src/watch/agenc-watch-app.mjs
+++ b/runtime/src/watch/agenc-watch-app.mjs
@@ -122,6 +122,7 @@ import {
   writeWatchExportBundle,
 } from "./agenc-watch-export-bundle.mjs";
 import { validateXaiApiKey } from "../onboarding/xai-validation.js";
+import { createAnsiArtRenderer } from "./agenc-watch-art.mjs";
 import {
   buildWatchInsightsReport,
   buildWatchMaintenanceReport,
@@ -417,6 +418,9 @@ let resizeListener = null;
 let startupTimer = null;
 let started = false;
 let disposed = false;
+let artRenderer = null;
+let artRendererImagePath = null;
+let artRefreshPending = false;
 let resolvedExitCode = null;
 let resolveClosed = () => {};
 const closed = new Promise((resolve) => {
@@ -2008,6 +2012,84 @@ function scheduleRender() {
   watchFrameController?.scheduleRender();
 }
 
+// Right-side ANSI art panel: loads the configured image once, then
+// re-rasterizes on terminal resize. Mirrors the ansi_art.py output
+// (standard ramp + 24-bit color) in the runtime TUI. Config lives in
+// gateway `config.watch.art` and is read from the same extensibility
+// surface the rest of the watch UI uses.
+function readArtPanelConfig() {
+  try {
+    const { configSnapshot } = readExtensibilityContext();
+    const cfg = configSnapshot?.config?.watch?.art;
+    if (!cfg || typeof cfg !== "object") return null;
+    const enabled = cfg.enabled === true;
+    const imagePath =
+      typeof cfg.imagePath === "string" && cfg.imagePath.length > 0
+        ? cfg.imagePath
+        : null;
+    const widthFractionRaw = Number(cfg.widthFraction);
+    const widthFraction =
+      Number.isFinite(widthFractionRaw) && widthFractionRaw > 0
+        ? Math.min(0.8, Math.max(0.05, widthFractionRaw))
+        : 0.4;
+    const ramp = typeof cfg.ramp === "string" ? cfg.ramp : "standard";
+    const invert = cfg.invert === true;
+    if (!enabled || !imagePath) return null;
+    return { imagePath, widthFraction, ramp, invert };
+  } catch {
+    return null;
+  }
+}
+
+async function refreshArtPanel() {
+  if (artRefreshPending) return;
+  artRefreshPending = true;
+  try {
+    const cfg = readArtPanelConfig();
+    if (!cfg) {
+      watchState.artPanelRows = null;
+      watchState.artPanelCols = 0;
+      return;
+    }
+    if (!artRenderer || artRendererImagePath !== cfg.imagePath) {
+      artRenderer = await createAnsiArtRenderer({
+        imagePath: cfg.imagePath,
+        ramp: cfg.ramp,
+        invert: cfg.invert,
+      });
+      artRendererImagePath = cfg.imagePath;
+    }
+    if (!artRenderer) {
+      watchState.artPanelRows = null;
+      watchState.artPanelCols = 0;
+      return;
+    }
+    const width = termWidth();
+    const height = termHeight();
+    const artCols = Math.max(
+      10,
+      Math.min(
+        Math.floor(width * 0.6),
+        Math.floor(width * cfg.widthFraction),
+      ),
+    );
+    if (artCols >= width) {
+      watchState.artPanelRows = null;
+      watchState.artPanelCols = 0;
+      return;
+    }
+    const rows = await artRenderer.render({ cols: artCols, rows: height });
+    watchState.artPanelRows = rows;
+    watchState.artPanelCols = artCols;
+    scheduleRender();
+  } catch {
+    watchState.artPanelRows = null;
+    watchState.artPanelCols = 0;
+  } finally {
+    artRefreshPending = false;
+  }
+}
+
 function scheduleReconnect() {
   return watchTransportController.scheduleReconnect();
 }
@@ -2619,11 +2701,13 @@ async function start() {
     };
     resizeListener = () => {
       scheduleRender();
+      void refreshArtPanel();
     };
     process.stdin.on("data", inputListener);
     process.stdout.on("resize", resizeListener);
     connect();
     scheduleRender();
+    void refreshArtPanel();
     ensureActivityPulseTimer();
     startupTimer = setTimeout(() => {
       startupTimer = null;

--- a/runtime/src/watch/agenc-watch-art.mjs
+++ b/runtime/src/watch/agenc-watch-art.mjs
@@ -1,0 +1,154 @@
+/**
+ * Terminal ANSI art renderer for the TUI side panel.
+ *
+ * Port of the reference Python script at `/home/tetsuo/git/ansi-art`
+ * (the 70-char "standard" ramp + luminance → char lookup + 24-bit
+ * foreground color per cell). Loads the source image once via jimp,
+ * caches the decoded RGB buffer, re-rasterizes on terminal resize.
+ */
+
+import { readFileSync } from "node:fs";
+import { Jimp, ResizeStrategy } from "jimp";
+
+// Same ramp as ansi_art.py "standard" — darkest → brightest.
+const STANDARD_RAMP =
+  " .'`^\",:;Il!i><~+_-?][}{1)(|\\/tfjrxnuvczXYUJCLQ0OZmwqpdbkhao*#MW&8%B@$";
+const RAMPS = {
+  standard: STANDARD_RAMP,
+  blocks: " \u2591\u2592\u2593\u2588",
+  simple: " .:-=+*#%@",
+  binary: " @",
+};
+
+// Terminal cells are roughly twice as tall as they are wide; the
+// renderer compresses vertical sampling to compensate. Matches the
+// Python script's default `--char-aspect 0.5`.
+const DEFAULT_CHAR_ASPECT = 0.5;
+
+const ANSI_RESET = "\x1b[0m";
+function fg24(r, g, b) {
+  return `\x1b[38;2;${r};${g};${b}m`;
+}
+
+function pickChar(ramp, luminance01, invert) {
+  let lum = invert ? 1 - luminance01 : luminance01;
+  if (lum < 0) lum = 0;
+  if (lum > 1) lum = 1;
+  const idx = Math.min(ramp.length - 1, Math.floor(lum * (ramp.length - 1)));
+  return ramp[idx];
+}
+
+function luminance(r, g, b) {
+  return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+}
+
+function validateRamp(ramp) {
+  if (typeof ramp !== "string" || ramp.length < 2) return STANDARD_RAMP;
+  return ramp;
+}
+
+/**
+ * Build an art renderer for a single source image. The returned
+ * renderer caches the decoded image; call `.render({cols, rows, …})`
+ * repeatedly on resize without re-decoding.
+ *
+ * Returns `null` when the image cannot be read (file missing /
+ * corrupt). Callers should treat null as "disable the art panel" and
+ * not fall into a render loop.
+ */
+export async function createAnsiArtRenderer({ imagePath, ramp, invert } = {}) {
+  if (typeof imagePath !== "string" || imagePath.length === 0) {
+    return null;
+  }
+  let decoded;
+  try {
+    const buf = readFileSync(imagePath);
+    decoded = await Jimp.read(buf);
+  } catch {
+    return null;
+  }
+  const sourceWidth = decoded.bitmap.width;
+  const sourceHeight = decoded.bitmap.height;
+  if (sourceWidth <= 0 || sourceHeight <= 0) return null;
+
+  const rampString = validateRamp(
+    typeof ramp === "string" ? RAMPS[ramp] ?? ramp : undefined,
+  );
+  const invertFlag = invert === true;
+
+  // Cache the last rasterization keyed by (cols, rows, charAspect) so
+  // the frame renderer can call render() every tick without repeating
+  // the resize/quantize work unless the terminal actually resized.
+  let cacheKey = null;
+  let cacheRows = null;
+
+  async function render({ cols, rows, charAspect = DEFAULT_CHAR_ASPECT } = {}) {
+    const targetCols = Math.max(1, Math.floor(Number(cols)));
+    const targetRows = Math.max(1, Math.floor(Number(rows)));
+    const targetAspect = Number.isFinite(Number(charAspect))
+      ? Math.max(0.1, Number(charAspect))
+      : DEFAULT_CHAR_ASPECT;
+    const key = `${targetCols}:${targetRows}:${targetAspect}`;
+    if (key === cacheKey && cacheRows !== null) return cacheRows;
+
+    // Match ansi_art.py resize: fit width to cols, derive height from
+    // source aspect * char-aspect, then clamp to targetRows so the
+    // right-panel overlay never scrolls past the available terminal
+    // lines.
+    const ratio = sourceHeight / sourceWidth;
+    const naturalRows = Math.max(
+      1,
+      Math.round(ratio * targetCols * targetAspect),
+    );
+    const renderRows = Math.min(targetRows, naturalRows);
+
+    const clone = decoded.clone();
+    clone.resize({
+      w: targetCols,
+      h: renderRows,
+      mode: ResizeStrategy.BILINEAR,
+    });
+    const { width: imgW, height: imgH, data } = clone.bitmap;
+    const out = [];
+    for (let y = 0; y < imgH; y += 1) {
+      let row = "";
+      let lastColor = "";
+      for (let x = 0; x < imgW; x += 1) {
+        const offset = (y * imgW + x) * 4;
+        const r = data[offset];
+        const g = data[offset + 1];
+        const b = data[offset + 2];
+        const lum = luminance(r, g, b);
+        const ch = pickChar(rampString, lum, invertFlag);
+        const color = fg24(r, g, b);
+        if (color !== lastColor) {
+          row += color;
+          lastColor = color;
+        }
+        row += ch;
+      }
+      out.push(row + ANSI_RESET);
+    }
+    // Pad vertically with empty rows so callers can blit one row per
+    // terminal line without length-mismatch bookkeeping.
+    while (out.length < targetRows) {
+      out.push("");
+    }
+    cacheKey = key;
+    cacheRows = out;
+    return out;
+  }
+
+  function invalidate() {
+    cacheKey = null;
+    cacheRows = null;
+  }
+
+  return {
+    render,
+    invalidate,
+    sourceWidth,
+    sourceHeight,
+    rampLength: rampString.length,
+  };
+}

--- a/runtime/src/watch/agenc-watch-frame.mjs
+++ b/runtime/src/watch/agenc-watch-frame.mjs
@@ -8,7 +8,7 @@ import {
   marketTaskBrowserLoadingLabel,
 } from "../marketplace/surfaces.mjs";
 import { createWatchSplashRenderer } from "./agenc-watch-splash.mjs";
-import { visibleLength, wrapBlock } from "./agenc-watch-text-utils.mjs";
+import { padAnsi, visibleLength, wrapBlock } from "./agenc-watch-text-utils.mjs";
 
 export function createWatchFrameController(dependencies = {}) {
   const {
@@ -3785,6 +3785,33 @@ export function createWatchFrameController(dependencies = {}) {
       1,
       Math.min(height, composerStartRow + composerInputOffsetRows + (composer.cursorRow ?? 0)),
     );
+
+    // Right-side ANSI art panel overlay. When `watchState.artPanelRows`
+    // is populated (rasterized by the art controller in
+    // agenc-watch-app.mjs and refreshed on terminal resize), replace
+    // the right strip of each rendered row with the matching art
+    // line. The controller sizes the art to `artPanelCols`, so
+    // `leftCols + artPanelCols === width` by construction.
+    const artPanelRows = Array.isArray(watchState.artPanelRows)
+      ? watchState.artPanelRows
+      : null;
+    const artPanelCols = Number.isFinite(Number(watchState.artPanelCols))
+      ? Math.max(0, Math.floor(Number(watchState.artPanelCols)))
+      : 0;
+    if (
+      artPanelRows &&
+      artPanelRows.length > 0 &&
+      artPanelCols > 0 &&
+      artPanelCols < width
+    ) {
+      const leftCols = width - artPanelCols;
+      for (let rowIndex = 0; rowIndex < nextFrameLines.length; rowIndex += 1) {
+        const leftPart = padAnsi(String(nextFrameLines[rowIndex] ?? ""), leftCols);
+        const artRow = artPanelRows[rowIndex] ?? "";
+        nextFrameLines[rowIndex] = leftPart + artRow;
+      }
+    }
+
     return {
       lines: nextFrameLines,
       width,


### PR DESCRIPTION
## Summary

- Port of the `/home/tetsuo/git/ansi-art` reference renderer (70-char `standard` ramp + per-pixel luminance + 24-bit FG color) into `runtime/src/watch/agenc-watch-art.mjs`. Image decoded once via `jimp`, rasterization cached per `(cols, rows)`.
- Frame integration in `runtime/src/watch/agenc-watch-frame.mjs`: when `watchState.artPanelRows` + `watchState.artPanelCols` are set, each rendered row is clipped via `padAnsi(line, width - artPanelCols)` and the matching art row appended. Paints behind header, cockpit, and composer identically.
- `refreshArtPanel()` in `runtime/src/watch/agenc-watch-app.mjs` reads `config.watch.art` from the existing gateway config surface, runs at TUI startup and on every SIGWINCH. Silently disables when the image path is missing, unset, or decode fails.
- Adds `jimp@^1.6.1` to runtime dependencies (pure-JS, no native build).

## Config

```jsonc
// ~/.agenc/config.json
{
  "watch": {
    "art": {
      "enabled": true,
      "imagePath": "/path/to/image.jpg",
      "widthFraction": 0.4,
      "ramp": "standard",
      "invert": false
    }
  }
}
```

Supported ramps: `standard`, `blocks`, `simple`, `binary`, or any custom string. Default `widthFraction` is `0.4` (clamped to `[0.05, 0.8]`).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run build` clean (`dist/VERSION` stamped at `1e032bf`)
- [ ] Smoke: flip `watch.art.enabled=true` locally, restart daemon + console, confirm the right-column art renders and reflows on terminal resize