### PR TITLE
fix(runtime/llm): fail-closed on reasoning_effort for models that don't accept it

### DIFF
--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -41,6 +41,7 @@ import {
 } from "./xai-strict-filter.js";
 import { ensureLazyImport } from "../lazy-import.js";
 import {
+  assertXaiReasoningEffortCompatibility,
   assertXaiStructuredOutputToolCompatibility,
   resolveLLMStatefulResponsesConfig,
   type ResolvedLLMStatefulResponsesConfig,
@@ -2019,6 +2020,11 @@ export class GrokProvider implements LLMProvider {
     const reasoningEffort =
       options?.reasoningEffort ?? this.config.reasoningEffort;
     if (reasoningEffort) {
+      assertXaiReasoningEffortCompatibility({
+        providerName: this.name,
+        model,
+        reasoningEffortRequested: true,
+      });
       params.reasoning = { effort: reasoningEffort };
     }
     const includeEncryptedReasoning =

--- a/runtime/src/llm/provider-capabilities.test.ts
+++ b/runtime/src/llm/provider-capabilities.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveLLMStatefulResponsesConfig } from "./provider-capabilities.js";
+import {
+  assertXaiReasoningEffortCompatibility,
+  resolveLLMStatefulResponsesConfig,
+} from "./provider-capabilities.js";
+import {
+  supportsXaiReasoningEffortParam,
+} from "./structured-output.js";
+import { LLMProviderError } from "./errors.js";
 
 describe("resolveLLMStatefulResponsesConfig", () => {
   it("defaults store=true when stateful responses are enabled without an explicit store override", () => {
@@ -26,5 +33,89 @@ describe("resolveLLMStatefulResponsesConfig", () => {
       enabled: true,
       store: true,
     });
+  });
+});
+
+describe("supportsXaiReasoningEffortParam", () => {
+  it.each([
+    ["grok-4.20-multi-agent-beta-0309", true],
+    ["grok-4.20-multi-agent", true],
+    ["grok-4-20-multi-agent", true],
+  ])("accepts multi-agent variant %s", (model, expected) => {
+    expect(supportsXaiReasoningEffortParam(model)).toBe(expected);
+  });
+
+  it.each([
+    ["grok-code-fast-1", false],
+    ["grok-4-1-fast-non-reasoning", false],
+    ["grok-4-1-fast-reasoning", false],
+    ["grok-4.20-beta-0309-reasoning", false],
+    ["grok-4.20-beta-0309-non-reasoning", false],
+    ["grok-4-0709", false],
+    ["grok-3", false],
+    ["", false],
+  ])("rejects non-multi-agent variant %s", (model, expected) => {
+    expect(supportsXaiReasoningEffortParam(model)).toBe(expected);
+  });
+
+  it("rejects undefined model", () => {
+    expect(supportsXaiReasoningEffortParam(undefined)).toBe(false);
+  });
+});
+
+describe("assertXaiReasoningEffortCompatibility", () => {
+  it("is a no-op when reasoningEffort is not requested", () => {
+    expect(() =>
+      assertXaiReasoningEffortCompatibility({
+        providerName: "grok",
+        model: "grok-code-fast-1",
+        reasoningEffortRequested: false,
+      }),
+    ).not.toThrow();
+  });
+
+  it("is a no-op on multi-agent variants that accept the field", () => {
+    expect(() =>
+      assertXaiReasoningEffortCompatibility({
+        providerName: "grok",
+        model: "grok-4.20-multi-agent-beta-0309",
+        reasoningEffortRequested: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it.each([
+    "grok-code-fast-1",
+    "grok-4-1-fast-non-reasoning",
+    "grok-4-1-fast-reasoning",
+    "grok-4.20-beta-0309-reasoning",
+  ])(
+    "throws LLMProviderError when reasoning_effort is requested on unsupported model %s",
+    (model) => {
+      expect(() =>
+        assertXaiReasoningEffortCompatibility({
+          providerName: "grok",
+          model,
+          reasoningEffortRequested: true,
+        }),
+      ).toThrow(LLMProviderError);
+      expect(() =>
+        assertXaiReasoningEffortCompatibility({
+          providerName: "grok",
+          model,
+          reasoningEffortRequested: true,
+        }),
+      ).toThrow(/grok-4\.20-multi-agent/);
+    },
+  );
+
+  it("surfaces the model name in the error message", () => {
+    const run = () =>
+      assertXaiReasoningEffortCompatibility({
+        providerName: "grok",
+        model: "grok-code-fast-1",
+        reasoningEffortRequested: true,
+      });
+    expect(run).toThrow(/requested grok-code-fast-1/);
   });
 });

--- a/runtime/src/llm/provider-capabilities.ts
+++ b/runtime/src/llm/provider-capabilities.ts
@@ -4,7 +4,10 @@ import type {
   LLMStatefulResponsesConfig,
 } from "./types.js";
 import { LLMProviderError } from "./errors.js";
-import { supportsXaiStructuredOutputsWithTools } from "./structured-output.js";
+import {
+  supportsXaiReasoningEffortParam,
+  supportsXaiStructuredOutputsWithTools,
+} from "./structured-output.js";
 
 const DEFAULT_STATEFUL_RECONCILIATION_WINDOW = 48;
 const MAX_STATEFUL_RECONCILIATION_WINDOW = 256;
@@ -111,6 +114,37 @@ export function assertXaiStructuredOutputToolCompatibility(input: {
   throw new LLMProviderError(
     input.providerName,
     `xAI structured outputs with tools require a Grok 4 model; requested ${input.model ?? "unknown model"}`,
+    400,
+  );
+}
+
+/**
+ * Fail-closed gate for the xAI `reasoning_effort` request parameter.
+ *
+ * Per xAI docs, only `grok-4.20-multi-agent*` accepts `reasoning_effort`
+ * (and there it controls agent count, not thinking depth). Every other
+ * current Grok 4 model returns an API error when the field is sent.
+ *
+ * Rather than let the request hit xAI and bounce with a provider error
+ * that the tool loop would then bake into history (wasted round-trip,
+ * confusing surface), refuse at request-build time with a clear
+ * LLMProviderError the caller can either catch + strip the field or
+ * surface as a config mistake.
+ */
+export function assertXaiReasoningEffortCompatibility(input: {
+  readonly providerName: string;
+  readonly model?: string;
+  readonly reasoningEffortRequested: boolean;
+}): void {
+  if (!input.reasoningEffortRequested) {
+    return;
+  }
+  if (supportsXaiReasoningEffortParam(input.model)) {
+    return;
+  }
+  throw new LLMProviderError(
+    input.providerName,
+    `xAI reasoning_effort is only supported on grok-4.20-multi-agent models; requested ${input.model ?? "unknown model"}. Remove reasoningEffort from the llm config or switch to a multi-agent variant.`,
     400,
   );
 }

--- a/runtime/src/llm/structured-output.ts
+++ b/runtime/src/llm/structured-output.ts
@@ -1,9 +1,16 @@
 /**
- * Structured-output helpers shared by provider adapters and planner/verifier flows.
+ * Structured-output + capability helpers shared by provider adapters and
+ * planner / verifier flows.
  *
  * xAI MCP source of truth:
  * - Structured outputs are supported by all language models.
  * - Structured outputs with tools are only supported by the Grok 4 family.
+ * - `reasoning_effort` is not supported by `grok-4.20` or `grok-4-1-fast`.
+ *   Per xAI docs (developers/model-capabilities/text/reasoning), the
+ *   ONLY model that accepts a `reasoning` parameter is
+ *   `grok-4.20-multi-agent` — and there it controls agent count, not
+ *   thinking depth. Sending `reasoning_effort` on any other current
+ *   Grok 4 model returns an API error.
  *
  * @module
  */
@@ -18,6 +25,21 @@ export function supportsXaiStructuredOutputsWithTools(
 ): boolean {
   if (typeof model !== "string") return false;
   return /^grok-4(?:[.-]|$)/i.test(model.trim());
+}
+
+/**
+ * Returns true when the xAI model accepts the `reasoning_effort`
+ * request parameter. Only `grok-4.20-multi-agent*` variants accept it.
+ *
+ * All other Grok 4 reasoning models reason automatically and reject
+ * the parameter with an API error; non-reasoning Grok 4 models
+ * (`*-non-reasoning`) naturally reject it too.
+ */
+export function supportsXaiReasoningEffortParam(
+  model: string | undefined,
+): boolean {
+  if (typeof model !== "string") return false;
+  return /^grok-4[.-]20-multi-agent/i.test(model.trim());
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Root cause of slow AgenC turns

Live trace evidence (captured 2026-04-16 from the running daemon) showed each model call with **805 reasoning tokens out of 832 total output tokens** — 97% of output was Grok thinking, driving 10-16s per call and 60-120s per coding turn.

The config default was `grok-code-fast-1`, an always-reasoning model. xAI applied `reasoning.effort: medium` server-side regardless of whether AgenC asked for it.

## xAI docs (authoritative)

From `developers/model-capabilities/text/reasoning`:

> `reasoning_effort` is **not** supported by `grok-4.20` or `grok-4-1-fast`. Specifying `reasoning_effort` on these models will return an error. These models reason automatically without any configuration.
>
> The only model that accepts the `reasoning` parameter is `grok-4.20-multi-agent`, where it controls **how many agents** collaborate on a request — not how hard the model thinks.

Before this change, any user who set `llm.reasoningEffort` on a standard Grok 4 model would have the adapter pass it through, xAI would reject with a provider error, and the tool loop would bake the error into history.

## Changes

- **`structured-output.ts`** — add `supportsXaiReasoningEffortParam(model)` family check. Returns true only for `grok-4.20-multi-agent*` variants.
- **`provider-capabilities.ts`** — add `assertXaiReasoningEffortCompatibility`, a fail-closed preflight gate that throws `LLMProviderError` with a clear message when `reasoning_effort` is requested on an unsupported model. Mirrors the existing structured-output gate pattern.
- **`grok/adapter.ts`** — wire the gate in right before `params.reasoning` is written. Catches misconfigurations at request-build time rather than at xAI's server boundary.
- **`provider-capabilities.test.ts`** — 19 new assertions covering the capability check + the gate's no-op / throw paths across every current Grok 4 variant + legacy IDs.

## Operational fix

Users who want fast Grok coding should switch `~/.agenc/config.json` `llm.model` from `grok-code-fast-1` (reasoning-always) to `grok-4-1-fast-non-reasoning` (no reasoning tokens, identical pricing, faster per-call).

## Test plan

- [x] `npx tsc --noEmit` green
- [x] 6,543 passing / 9 pre-existing failures / zero new regressions
- [x] Naming audit clean
- [x] Daemon rebuilt + restarted with new model; verification traces pending