### PR TITLE
fix(llm): generate unique tool call IDs in Ollama adapter

### DIFF
--- a/runtime/src/llm/ollama/adapter.test.ts
+++ b/runtime/src/llm/ollama/adapter.test.ts
@@ -157,6 +157,66 @@ describe("OllamaProvider", () => {
     expect(result.finishReason).toBe("tool_calls");
   });
 
+  it("assigns unique IDs to duplicate-named tool calls (non-streaming)", async () => {
+    const response = makeResponse({
+      message: {
+        content: "",
+        role: "assistant",
+        tool_calls: [
+          { function: { name: "search", arguments: { q: "first" } } },
+          { function: { name: "search", arguments: { q: "second" } } },
+        ],
+      },
+    });
+    mockChat.mockResolvedValueOnce(response);
+
+    const provider = new OllamaProvider({});
+    const result = await provider.chat([{ role: "user", content: "test" }]);
+
+    expect(result.toolCalls).toHaveLength(2);
+    expect(result.toolCalls[0].name).toBe("search");
+    expect(result.toolCalls[1].name).toBe("search");
+    expect(result.toolCalls[0].id).not.toBe(result.toolCalls[1].id);
+    expect(result.toolCalls[0].id).not.toBe("search");
+    expect(result.toolCalls[1].id).not.toBe("search");
+  });
+
+  it("assigns unique IDs to duplicate-named tool calls (streaming)", async () => {
+    const chunks = [
+      {
+        message: {
+          content: "",
+          role: "assistant",
+          tool_calls: [
+            { function: { name: "search", arguments: { q: "first" } } },
+            { function: { name: "search", arguments: { q: "second" } } },
+          ],
+        },
+        model: "llama3",
+        prompt_eval_count: 5,
+        eval_count: 10,
+      },
+    ];
+    mockChat.mockResolvedValueOnce(
+      (async function* () {
+        for (const c of chunks) yield c;
+      })(),
+    );
+
+    const provider = new OllamaProvider({});
+    const result = await provider.chatStream(
+      [{ role: "user", content: "test" }],
+      () => undefined,
+    );
+
+    expect(result.toolCalls).toHaveLength(2);
+    expect(result.toolCalls[0].name).toBe("search");
+    expect(result.toolCalls[1].name).toBe("search");
+    expect(result.toolCalls[0].id).not.toBe(result.toolCalls[1].id);
+    expect(result.toolCalls[0].id).not.toBe("search");
+    expect(result.toolCalls[1].id).not.toBe("search");
+  });
+
   it("handles streaming via async iterable", async () => {
     const chunks = [
       { message: { content: "Hello" }, model: "llama3" },

--- a/runtime/src/llm/ollama/adapter.ts
+++ b/runtime/src/llm/ollama/adapter.ts
@@ -7,6 +7,7 @@
  * @module
  */
 
+import { randomUUID } from "node:crypto";
 import type {
   LLMChatOptions,
   LLMProvider,
@@ -355,7 +356,7 @@ export class OllamaProvider implements LLMProvider {
         if (chunk.message?.tool_calls) {
           for (const tc of chunk.message.tool_calls) {
             const validated = validateToolCall({
-              id: tc.function?.name ?? `call_${toolCalls.length}`,
+              id: randomUUID(),
               name: tc.function?.name ?? "",
               arguments: JSON.stringify(tc.function?.arguments ?? {}),
             });
@@ -646,9 +647,9 @@ export class OllamaProvider implements LLMProvider {
     const content = message.content ?? "";
 
     const toolCalls: LLMToolCall[] = (message.tool_calls ?? [])
-      .map((tc: any, i: number) =>
+      .map((tc: any) =>
         validateToolCall({
-          id: tc.function?.name ?? `call_${i}`,
+          id: randomUUID(),
           name: tc.function?.name ?? "",
           arguments: JSON.stringify(tc.function?.arguments ?? {}),
         }),


### PR DESCRIPTION
Closes #417

## Summary

The Ollama adapter assigned the tool function name as the tool call ID instead of generating a unique ID per invocation. When the same tool was called more than once in a multi-step sequence, the runtime received duplicate tool call IDs and rejected the turn with `assistant_tool_call_id_duplicate`.

This is the same bug fixed in PR #402 for the `openai-compat` provider.

## Changes

**`runtime/src/llm/ollama/adapter.ts`** (+3 lines, -2 lines):
- Streaming path (~line 362): replaced `tc.function?.name ?? \`call_${toolCalls.length}\`` with `crypto.randomUUID()`
- - Non-streaming `parseResponse` (~line 678): replaced `tc.function?.name ?? \`call_${i}\`` with `crypto.randomUUID()`
- - Added `import crypto from "node:crypto"` at top
**`runtime/src/llm/ollama/adapter.test.ts`** (+60 lines):
- Two new regression tests: assert that two same-named tool calls get different IDs, and that neither ID equals the tool name
- - Both streaming and non-streaming paths covered
## Test results

- 30/30 Ollama adapter tests passing (28 existing + 2 new)
- - 21 pre-existing upstream failures on `upstream/main` — none in changed files, confirmed identical before and after this change
- - 0 regressions introduced
## Reproduction

Configure the Ollama provider with any tool-capable model (e.g. `qwen2.5:14b`). Run any multi-step task that invokes the same tool twice:

```
Invalid tool-turn sequence (assistant_tool_call_id_duplicate) at message[2]:
assistant tool_calls contains duplicate id "system.bash"
```

Single-turn tool calls were unaffected. Multi-step tasks (write → compile → run) failed immediately.