### PR TITLE
fix(runtime/webchat): suppress status-poll trace logging

### DIFF
--- a/runtime/src/channels/webchat/plugin.ts
+++ b/runtime/src/channels/webchat/plugin.ts
@@ -606,6 +606,19 @@ export class WebChatChannel
       typeof payload.sessionId === "string"
         ? payload.sessionId
         : undefined;
+    // Suppress trace logging for high-frequency status polling messages.
+    // The UI polls every ~5 seconds; logging each poll at INFO floods
+    // the daemon log with 500+ entries/hour of pure noise while
+    // obscuring actual turn/tool/model events. status.update,
+    // chat.session.list, and session.command.catalog are operational
+    // heartbeats, not diagnostic signals.
+    const isHighFrequencyPoll =
+      response.type === "status.update" ||
+      response.type === "chat.session.list" ||
+      response.type === "session.command.catalog";
+    if (isHighFrequencyPoll) {
+      return;
+    }
     const traceLine = {
       clientId,
       ...(payloadSessionId || sessionId


### PR DESCRIPTION
## Problem

Live daemon log showed **579 status.update events/hour** (87% of all log traffic), each a multi-KB JSON payload with full runtime metrics. The UI polls every ~5 seconds and every poll was logged at INFO, flooding the log at ~1.1 MB/hour even when no coding turns are running.

This makes the daemon log unusable for diagnosing turn latency because the actual provider/tool events are buried in status noise.

## Fix

Skip `[trace] webchat.ws.outbound` logging for three high-frequency poll types:
- `status.update` — UI status bar refresh (~5s interval)
- `chat.session.list` — session catalog on UI connect
- `session.command.catalog` — command palette on UI connect

The messages still reach the UI client over WebSocket. Only the daemon log entry is suppressed.

## Test plan

- [x] Webchat test suite: 106 passing
- [x] `npx tsc --noEmit` clean
- [x] Build clean