### PR TITLE
fix(runtime/gateway): override blocked verdict when actor executed tools successfully

### DIFF
--- a/runtime/src/channels/webchat/plugin.ts
+++ b/runtime/src/channels/webchat/plugin.ts
@@ -615,7 +615,8 @@ export class WebChatChannel
     const isHighFrequencyPoll =
       response.type === "status.update" ||
       response.type === "chat.session.list" ||
-      response.type === "session.command.catalog";
+      response.type === "session.command.catalog" ||
+      response.type === "watch.cockpit";
     if (isHighFrequencyPoll) {
       return;
     }

--- a/runtime/src/gateway/background-run-supervisor-helpers.ts
+++ b/runtime/src/gateway/background-run-supervisor-helpers.ts
@@ -1277,6 +1277,35 @@ export function groundDecision(
     };
   }
 
+  // Upstream reference runtime pattern: tool errors flow back into
+  // history and the model adapts on the next iteration. There is no
+  // "blocked" concept for a cycle where the actor executed tools.
+  // A decision model claiming "blocked" after the actor successfully
+  // ran tools (even if the underlying command failed — e.g. cmake
+  // exit-code 1) is a supervisor artefact that upstream does not have.
+  // Override it to "working" so the next cycle lets the model retry.
+  if (
+    decision.state === "blocked" &&
+    actorResult.toolCalls.length > 0 &&
+    successfulToolCalls.length > 0
+  ) {
+    return {
+      state: "working",
+      userUpdate: truncate(
+        decision.userUpdate ||
+        actorResult.content ||
+        "Cycle had tool activity; retrying with error context.",
+        MAX_USER_UPDATE_CHARS,
+      ),
+      internalSummary:
+        `Overrode blocked decision: actor executed ${actorResult.toolCalls.length} tool calls ` +
+        `(${successfulToolCalls.length} ok, ${failedToolCalls.length} failed). ` +
+        `Error context flows to next cycle.`,
+      nextCheckMs: DEFAULT_POLL_INTERVAL_MS,
+      shouldNotifyUser: true,
+    };
+  }
+
   if (
     decision.state === "completed" &&
     run.contract.requiresUserStop


### PR DESCRIPTION
## Problem

Background run supervisor parks runs as "blocked" indefinitely when a build command fails (e.g. cmake returns exit code 1). The user sees "ruminating..." for 5+ minutes with zero progress.

**Root cause:** A separate decision model evaluates each cycle and can return `state: "blocked"`. When the actor model ran cmake and it failed, the decision model saw the failure text and claimed "blocked". The supervisor parked the run — removed it from active tracking, released the lease, and stopped cycling.

## What the reference runtime does

No decision model. No blocked state. Tool errors flow into history as `tool_result` with `is_error: true`, the loop continues unconditionally (`while (true)`), and the model sees the error on the next call and adapts. The human sees the result immediately.

## Fix

In `groundDecision()`, override the decision model's "blocked" call when the actor DID execute tools with at least one successful dispatch. The error context flows to the next cycle and the model retries with a different approach.

"Blocked" is preserved for genuinely stuck scenarios: no tool calls at all, waiting on external approval, zero evidence of any progress.

Also adds `watch.cockpit` to the status-poll trace suppression list.

## Test plan

- [x] Background-run supervisor suite: 70 tests pass
- [x] `npx tsc --noEmit` clean
- [x] Build clean