### PR TITLE
fix(runtime/gateway): eliminate 5s inter-cycle delay for coding turns

### DIFF
--- a/runtime/src/gateway/background-run-supervisor-constants.ts
+++ b/runtime/src/gateway/background-run-supervisor-constants.ts
@@ -11,7 +11,13 @@ import type { BackgroundRunWorkerPool } from "./background-run-store.js";
 
 export const DEFAULT_POLL_INTERVAL_MS = 8_000;
 export const BUSY_RETRY_INTERVAL_MS = 1_500;
-export const MIN_POLL_INTERVAL_MS = 2_000;
+// Upstream reference runtime loops immediately (zero delay between
+// iterations). The 2-second floor was designed for the old verifier
+// cycle cadence. With the verifier stack removed, active coding
+// cycles should have near-zero inter-iteration delay. Non-coding
+// scenarios (managed-process polling, approval gates) still specify
+// their own explicit nextCheckMs via the contract.
+export const MIN_POLL_INTERVAL_MS = 100;
 export const MAX_POLL_INTERVAL_MS = 60_000;
 export const FAST_FOLLOWUP_POLL_INTERVAL_MS = 4_000;
 export const STABLE_POLL_STEP_MS = 8_000;

--- a/runtime/src/gateway/background-run-supervisor-helpers.ts
+++ b/runtime/src/gateway/background-run-supervisor-helpers.ts
@@ -1215,7 +1215,7 @@ export function buildFallbackDecision(run: ActiveBackgroundRun, actorResult: Cha
         MAX_USER_UPDATE_CHARS,
       ),
       internalSummary: actorResult.content || "Cycle completed with tool calls.",
-      nextCheckMs: DEFAULT_POLL_INTERVAL_MS,
+      nextCheckMs: MIN_POLL_INTERVAL_MS,
       shouldNotifyUser: true,
     };
   }
@@ -1301,8 +1301,30 @@ export function groundDecision(
         `Overrode blocked decision: actor executed ${actorResult.toolCalls.length} tool calls ` +
         `(${successfulToolCalls.length} ok, ${failedToolCalls.length} failed). ` +
         `Error context flows to next cycle.`,
-      nextCheckMs: DEFAULT_POLL_INTERVAL_MS,
+      nextCheckMs: MIN_POLL_INTERVAL_MS,
       shouldNotifyUser: true,
+    };
+  }
+
+  // When the actor executed tools and the decision is "working" on a
+  // coding-pattern domain (generic / workspace / pipeline), force
+  // immediate next-cycle regardless of the decision model's
+  // nextCheckMs. The reference runtime loops with zero delay between
+  // iterations. Non-coding domains (managed_process, remote_session,
+  // approval, etc.) keep their own poll cadence because they
+  // legitimately wait on external state changes.
+  const isCodingDomain =
+    run.contract.domain === "generic" ||
+    run.contract.domain === "workspace" ||
+    run.contract.domain === "pipeline";
+  if (
+    decision.state === "working" &&
+    actorResult.toolCalls.length > 0 &&
+    isCodingDomain
+  ) {
+    return {
+      ...decision,
+      nextCheckMs: MIN_POLL_INTERVAL_MS,
     };
   }
 


### PR DESCRIPTION
## Problem

5-8 second idle gap between every active coding cycle. The TUI shows "contemplating..." while the supervisor waits on a timer before starting the next cycle — even though the model just finished a productive cycle with tool calls.

Traced from live daemon logs: `working_applied` at 03:23:20.656 → next `provider.request` at 03:23:25.704 = **5.05s idle**. Repeats every cycle.

## Root cause

1. `MIN_POLL_INTERVAL_MS` was 2,000ms — even the fastest path had a 2s floor
2. Decision model returned `nextCheckMs: 5000` in its JSON and the supervisor trusted it via `clampPollIntervalMs()`

The reference runtime loops with zero delay. No poll interval, no decision model cadence control.

## Fix

- `MIN_POLL_INTERVAL_MS`: 2000 → 100ms
- `groundDecision()`: force `nextCheckMs = MIN_POLL_INTERVAL_MS` when actor executed tools on a coding domain (generic / workspace / pipeline)
- Non-coding domains (managed_process, remote_session, etc.) keep their own cadence

## Test plan

- [x] Supervisor suite: 70 tests pass (managed-process 5-minute interval tests still pass)
- [x] Build clean