### PR TITLE
fix(runtime/gateway): set historyCompacted flag on background run stateful continuation

### DIFF
--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -3811,6 +3811,9 @@ export class BackgroundRunSupervisor {
                   }
                   : {}),
               },
+              ...(run.compaction.refreshCount > 0
+                ? { historyCompacted: true }
+                : {}),
             }
             : undefined,
           toolHandler: cycleToolHandler,


### PR DESCRIPTION
## Problem

Background run cycles always fall back to full-replay because the Grok adapter's reconciliation hash mismatches after trimHistory(). Token cost grows linearly with cycle count (~15K per cycle for full replay).

## Root cause

The adapter at adapter.ts:1724 has a ready-made escape hatch: when `historyCompacted === true`, it trusts the previousResponseId and continues with stateful delta. But the background run supervisor never set this flag.

## Fix

Set `historyCompacted: true` on the stateful object when `run.compaction.refreshCount > 0` (i.e., the carry-forward system has compacted at least once). Three lines added.

## Impact

Token usage per cycle: ~15K (full replay) -> ~1-2K (stateful delta only).

## Test plan

- [x] Supervisor suite: 70 tests pass
- [x] Adapter suite: 90 tests pass
- [x] Build clean