### PR TITLE
fix(runtime/llm): clear readFileState after compaction

### DIFF
--- a/runtime/src/llm/chat-executor-in-flight-compaction.ts
+++ b/runtime/src/llm/chat-executor-in-flight-compaction.ts
@@ -42,6 +42,7 @@ import {
   markAutocompactFailure,
   markAutocompactSuccess,
 } from "./compact/autocompact.js";
+import { runPostCompactCleanup } from "./compact/post-compact-cleanup.js";
 
 /**
  * Dependency struct for `maybeCompactInFlightCallInput`.
@@ -223,6 +224,7 @@ export async function maybeCompactInFlightCallInput(
     ctx.messageSections = [...nextSections];
     ctx.compacted = true;
     ctx.compactedArtifactContext = compacted.artifactContext;
+    runPostCompactCleanup(ctx.sessionId);
     ctx.perIterationCompaction = {
       ...ctx.perIterationCompaction,
       autocompact: markAutocompactSuccess(

--- a/runtime/src/llm/chat-executor-init.ts
+++ b/runtime/src/llm/chat-executor-init.ts
@@ -31,6 +31,7 @@
 
 import { collectContextSections } from "./chat-executor-context-injection.js";
 import { compactHistory } from "./chat-executor-history-compaction.js";
+import { runPostCompactCleanup } from "./compact/post-compact-cleanup.js";
 import { renderArtifactContextPrompt } from "./context-compaction.js";
 import {
   pushMessage,
@@ -249,6 +250,7 @@ export async function initializeExecutionContext(
       compactedArtifactContext = compactedResult.artifactContext;
       helpers.resetSessionTokens(sessionId);
       compacted = true;
+      runPostCompactCleanup(sessionId);
     } catch {
       deps.cooldowns.clear();
       for (const [providerName, cooldown] of cooldownSnapshot.entries()) {

--- a/runtime/src/llm/compact/post-compact-cleanup.ts
+++ b/runtime/src/llm/compact/post-compact-cleanup.ts
@@ -1,0 +1,17 @@
+/**
+ * Post-compaction cleanup.
+ *
+ * The reference runtime clears `context.readFileState` and
+ * `context.loadedNestedMemoryPaths` after compaction so that
+ * post-compact tool calls get fresh file content instead of stale
+ * `FILE_UNCHANGED_STUB` responses for files whose content was just
+ * summarized away.
+ *
+ * @module
+ */
+
+import { clearSessionReadCache } from "../../tools/system/filesystem.js";
+
+export function runPostCompactCleanup(sessionId: string): void {
+  clearSessionReadCache(sessionId);
+}


### PR DESCRIPTION
## Problem

Post-compaction tool calls get stale FILE_UNCHANGED_STUB responses because readFileState isn't cleared when context is compacted. The model can't access real file bytes after summarization.

## Fix

New `compact/post-compact-cleanup.ts` calls `clearSessionReadCache(sessionId)` after compaction. Wired into in-flight compaction and init-time compaction paths.

## Test plan

- [x] In-flight compaction + init tests: 14 pass
- [x] Build clean