### PR TITLE
fix(runtime/gateway): non-empty content on at-mention tool prelude messages

### DIFF
--- a/runtime/src/gateway/at-mention-attachments.ts
+++ b/runtime/src/gateway/at-mention-attachments.ts
@@ -78,7 +78,7 @@ function buildToolPrelude(params: {
   return [
     {
       role: "assistant",
-      content: "",
+      content: `Reading ${params.toolName === "system.readFile" ? JSON.parse(JSON.stringify(params.toolArgs)).path ?? "file" : "resource"}`,
       toolCalls: [
         {
           id: params.toolCallId,


### PR DESCRIPTION
## Problem

Background runs using @PLAN.md at-mention files get stuck in a 400 error retry loop:

```
400 "Invalid request content: Each message must have at least one content element."
```

The at-mention injection creates an assistant message with `content: ""` to carry the tool call. On full-replay cycles, xAI rejects the empty content.

## Fix

Set assistant content to `"Reading <path>"` instead of empty string.

## Test plan

- [x] at-mention tests pass
- [x] Build clean