### PR TITLE
fix(runtime/grok): emit placeholder content for empty-content assistant tool calls

### DIFF
--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -2117,7 +2117,10 @@ describe("GrokProvider", () => {
     ]);
 
     const params = mockCreate.mock.calls[0][0];
-    expect(params.input[2]).toEqual({
+    // Index shifts by 1 because assistant messages with empty content
+    // + toolCalls now emit a placeholder message before function_call
+    // items to satisfy xAI's "each message must have content" rule.
+    expect(params.input[3]).toEqual({
       type: "function_call_output",
       call_id: "call_1",
       output: "result data",
@@ -2151,6 +2154,10 @@ describe("GrokProvider", () => {
 
     const params = mockCreate.mock.calls[0][0];
     expect(params.input[1]).toEqual({
+      role: "assistant",
+      content: "Calling tool.",
+    });
+    expect(params.input[2]).toEqual({
       type: "function_call",
       call_id: "call_1",
       name: "desktop.bash",

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -2401,6 +2401,16 @@ export class GrokProvider implements LLMProvider {
           role,
           content: normalizedContent,
         });
+      } else if (toolCalls.length > 0) {
+        // xAI requires every message to have at least one content
+        // element. When an assistant message carries tool calls but
+        // has empty content (e.g. at-mention file injection preludes),
+        // emit a minimal placeholder so the function_call items are
+        // not orphaned.
+        items.push({
+          role,
+          content: "Calling tool.",
+        });
       }
       for (const tc of toolCalls) {
         const functionData = (tc.function as Record<string, unknown> | undefined) ?? {};


### PR DESCRIPTION
## Problem

Background runs with @PLAN.md at-mention files get stuck in a 400 error loop because assistant messages with `content: ""` + toolCalls produce orphaned `function_call` items without a parent message.

## Fix

Adapter-boundary fix: when an assistant message has empty content but toolCalls, emit `{role: "assistant", content: "Calling tool."}` before the function_call items. Handles both old persisted history and new messages.

## Test plan

- [x] Adapter suite: 90 tests pass (2 updated for new item ordering)
- [x] Build clean