### PR TITLE
fix(runtime/gateway): signal idle to TUI when background run completes

### DIFF
--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -4804,6 +4804,10 @@ export class BackgroundRunSupervisor {
         run: summary,
       });
     }
+    this.onStatus?.(run.sessionId, {
+      phase: "idle",
+      detail: `Background run ${decision.state}`,
+    });
     const latencyMs = Math.max(0, run.updatedAt - run.createdAt);
     this.recordRunTelemetry(
       TELEMETRY_METRIC_NAMES.BACKGROUND_RUN_LATENCY_MS,


### PR DESCRIPTION
## Problem

After a background run completes, the TUI stays at "reasoning..." indefinitely. No visual indication the run finished.

## Root cause

`finishRun()` persists state, saves checkpoints, sends notifications, records telemetry — but never pushes `agent.status` with `phase: "idle"` to the webchat channel. The TUI's last received status is `phase: "background_run"` and it stays there.

## Fix

Add `onStatus(sessionId, { phase: "idle" })` at the end of `finishRun()`. The TUI receives the phase transition and stops the spinner.

## Test plan

- [x] Supervisor suite: 70 tests pass
- [x] Build clean