### PR TITLE
fix(runtime): break stateful chain on compaction + show per-call usage

### DIFF
--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -4242,6 +4242,17 @@ export class BackgroundRunSupervisor {
         ...run.compaction,
         refreshCount: run.compaction.refreshCount + 1,
       };
+      // Break the xAI stateful chain so the server starts fresh
+      // with just the compacted history. Without this, the server
+      // accumulates ALL prior messages and input_tokens grows
+      // unbounded (~166K+ observed) even though local history is
+      // trimmed to 12 messages.
+      if (run.carryForward) {
+        run.carryForward = {
+          ...run.carryForward,
+          providerContinuation: undefined,
+        };
+      }
       return [
         { role: "system", content: summary } as LLMMessage,
         ...kept,

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -5535,6 +5535,15 @@ export class DaemonManager {
     const stateful = session ? buildSessionStatefulOptions(session) : undefined;
 
     const totalTokens = executor.getSessionTokenUsage(sessionId);
+    // Show per-call context window occupancy (from the last model
+    // response's input_tokens), not cumulative lifetime total. This
+    // matches the reference runtime's getCurrentUsage() which reads
+    // the last API response. Falls back to the message-based estimate
+    // when no model call has happened yet.
+    const lastCallTokens =
+      typeof executor.getLastCallInputTokens === "function"
+        ? executor.getLastCallInputTokens(sessionId)
+        : 0;
 
     const usageSnapshot = buildCurrentContextUsageSnapshot({
       messages: buildCurrentApiView({
@@ -5557,15 +5566,9 @@ export class DaemonManager {
       model: effectiveLlmConfig?.model,
       contextWindowTokens,
     });
-    // The web session's history only has the initial prompt (~2.6K
-    // tokens). During a background run, the real context grows with
-    // every model call but session.history doesn't reflect that.
-    // Use the higher of the snapshot estimate and the executor's
-    // tracked total so the TUI's "current" number moves.
-    const effectivePromptTokens = Math.max(
-      usageSnapshot.currentTokens,
-      totalTokens,
-    );
+    const effectivePromptTokens = lastCallTokens > 0
+      ? lastCallTokens
+      : Math.max(usageSnapshot.currentTokens, totalTokens);
     const effectivePercentUsed =
       usageSnapshot.effectiveContextWindowTokens
         ? effectivePromptTokens / usageSnapshot.effectiveContextWindowTokens

--- a/runtime/src/llm/chat-executor-init.ts
+++ b/runtime/src/llm/chat-executor-init.ts
@@ -115,6 +115,7 @@ export interface InitializeExecutionContextDependencies {
   readonly progressProvider: MemoryRetriever | undefined;
   // Session state + thresholds
   readonly sessionTokens: Map<string, number>;
+  readonly lastCallInputTokens?: Map<string, number>;
   readonly sessionTokenBudget: number | undefined;
   readonly sessionCompactionThreshold: number | undefined;
   readonly cooldowns: Map<string, CooldownEntry>;

--- a/runtime/src/llm/chat-executor-model-orchestration.ts
+++ b/runtime/src/llm/chat-executor-model-orchestration.ts
@@ -152,6 +152,7 @@ export interface CallModelForPhaseDependencies {
   readonly allowedTools: Set<string> | null;
   readonly defaultRunClass: RuntimeRunClass | undefined;
   readonly sessionTokens: Map<string, number>;
+  readonly lastCallInputTokens?: Map<string, number>;
   readonly sessionTokenBudget: number | undefined;
   readonly sessionCompactionThreshold: number | undefined;
   readonly maxTrackedSessions: number;
@@ -442,6 +443,12 @@ export async function callModelForPhase(
     next.response.usage.totalTokens,
     deps.maxTrackedSessions,
   );
+  if (deps.lastCallInputTokens) {
+    deps.lastCallInputTokens.set(
+      ctx.sessionId,
+      next.response.usage.promptTokens || next.response.usage.totalTokens,
+    );
+  }
   recordRuntimeModelCall({
     policy: deps.economicsPolicy,
     state: ctx.economicsState,

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -203,6 +203,7 @@ export class ChatExecutor {
 
   private readonly cooldowns = new Map<string, CooldownEntry>();
   private readonly sessionTokens = new Map<string, number>();
+  private readonly lastCallInputTokens = new Map<string, number>();
 
   private static normalizeRequestTimeoutMs(timeoutMs: number | undefined): number {
     return normalizeRuntimeLimit(timeoutMs, DEFAULT_REQUEST_TIMEOUT_MS);
@@ -352,6 +353,7 @@ export class ChatExecutor {
       progressProvider: this.progressProvider,
       // Session state + thresholds
       sessionTokens: this.sessionTokens,
+      lastCallInputTokens: this.lastCallInputTokens,
       sessionTokenBudget: this.sessionTokenBudget,
       sessionCompactionThreshold: this.sessionCompactionThreshold,
       cooldowns: this.cooldowns,
@@ -478,6 +480,11 @@ export class ChatExecutor {
   /** Get accumulated token usage for a session. */
   getSessionTokenUsage(sessionId: string): number {
     return this.sessionTokens.get(sessionId) ?? 0;
+  }
+
+  /** Get the input token count from the most recent model call for a session. */
+  getLastCallInputTokens(sessionId: string): number {
+    return this.lastCallInputTokens.get(sessionId) ?? 0;
   }
 
   /** Reset token usage for a specific session. */


### PR DESCRIPTION
## Problems

1. **Server-side context grows unbounded** — xAI's stateful API accumulates ALL prior messages server-side via previous_response_id chain. Per-call input_tokens grew from 152K → 166K despite local history being only 8 messages (20-40K chars).

2. **Usage display shows cumulative lifetime total** (climbing to 3M) instead of per-call context window occupancy. The reference runtime shows the last API response's input_tokens.

## Fixes

**Break stateful chain on compaction:** When compactInternalHistory() fires, clear `run.carryForward.providerContinuation`. The next cycle starts a fresh server-side conversation. Per-call tokens drop from ~166K back to ~10K.

**Per-call usage display:** New `lastCallInputTokens` Map on ChatExecutor tracks the most recent response's `promptTokens`. `buildSessionUsageSnapshot()` uses this as "current" instead of cumulative total.

## Test plan

- [x] Supervisor: 70 tests pass
- [x] Daemon: 141 tests pass
- [x] Build clean