### PR TITLE
fix(runtime/gateway): don't park run as blocked when actor had successful tools

### DIFF
--- a/runtime/src/gateway/background-run-supervisor-helpers.ts
+++ b/runtime/src/gateway/background-run-supervisor-helpers.ts
@@ -1366,7 +1366,15 @@ export function groundDecision(
     completionProgress &&
     (decision.state === "completed" || decision.state === "working")
   ) {
-    if (completionProgress.completionState === "blocked") {
+    // Do NOT park the run as "blocked" when the actor had successful
+    // tool calls. The upstream pattern: tool errors flow into history
+    // and the model adapts on the next cycle. completionProgress
+    // "blocked" from a build failure is the model's problem to solve,
+    // not a reason to stop cycling.
+    if (
+      completionProgress.completionState === "blocked" &&
+      successfulToolCalls.length === 0
+    ) {
       return {
         state: "blocked",
         userUpdate: truncate(


### PR DESCRIPTION
## Problem

Run parks as "blocked" after cmake build failure despite 21 successful tool calls. The completionProgress.completionState check at line 1369 overrides the working state back to blocked, bypassing the PR #420 override.

## Root cause

Two paths produce state: "blocked" in groundDecision:
1. Decision model verdict → overridden by PR #420 (blocked→working when tools succeeded)
2. `completionProgress.completionState === "blocked"` → NOT gated on tool success

Path 2 fires when a build command fails, even though the actor was productively writing files.

## Fix

Gate the completionProgress blocked check on `successfulToolCalls.length === 0`. When the actor had productive work, the error flows to the next cycle.

## Test plan

- [x] Supervisor: 70 tests pass
- [x] Build clean