### PR TITLE
fix(runtime/gateway): prevent premature background run completion for coding domains

### DIFF
--- a/runtime/src/gateway/background-run-supervisor-helpers.ts
+++ b/runtime/src/gateway/background-run-supervisor-helpers.ts
@@ -1172,6 +1172,31 @@ export function buildFallbackDecision(run: ActiveBackgroundRun, actorResult: Cha
     actorResult.completionState === "completed" &&
     hasCompletedWorkflowState(actorResult)
   ) {
+    // For coding domains (generic/workspace/pipeline): only declare
+    // the run truly completed when the actor stopped WITHOUT
+    // requesting any tools. If the actor called tools this cycle, it
+    // was still doing work — the upstream pattern is that the loop
+    // continues as long as the model uses tools. When the actor
+    // genuinely finishes (text-only output, no tool calls), that's
+    // the real completion signal.
+    // Non-coding domains (managed_process, browser, etc.) can
+    // legitimately complete after one cycle with tool calls.
+    const isCodingDomain =
+      run.contract.domain === "workspace" ||
+      run.contract.domain === "pipeline";
+    if (isCodingDomain && actorResult.toolCalls.length > 0) {
+      return {
+        state: "working",
+        userUpdate: truncate(
+          actorResult.content || `Background run cycle ${run.cycleCount} completed.`,
+          MAX_USER_UPDATE_CHARS,
+        ),
+        internalSummary:
+          actorResult.content || "Cycle completed with tool calls; continuing.",
+        nextCheckMs: MIN_POLL_INTERVAL_MS,
+        shouldNotifyUser: true,
+      };
+    }
     const detail =
       actorResult.stopReasonDetail ??
       actorResult.content ??

--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -296,8 +296,9 @@ function buildActorPrompt(run: ActiveBackgroundRun): string {
     recentHistory +
     recentToolEvidence +
     firstCycleGuidance +
-    "Take the next best bounded step toward this objective. " +
-    "Use tools when necessary. If the task is already running independently, verify its current state instead of narrating.\n"
+    "Continue from where you left off. Do not stop until the full objective is satisfied. " +
+    "Use tools to make progress. If you completed a phase or milestone, continue to the next one immediately without stopping. " +
+    "Only stop calling tools when the ENTIRE objective is done, not just one part of it.\n"
   );
 }
 
@@ -3682,7 +3683,10 @@ export class BackgroundRunSupervisor {
   }
 
   private shouldUseActorLoopParity(run: ActiveBackgroundRun): boolean {
-    return run.contract.domain === "workspace";
+    return (
+      run.contract.domain === "workspace" ||
+      run.contract.domain === "pipeline"
+    );
   }
 
   private async resolveCycleDecision(params: {


### PR DESCRIPTION
## Problem

Background run stops after M0 even though user said "implement all of PLAN.md." The decision model and fallback logic both declare "completed" after one clean cycle.

## What the reference runtime does

No decision model. No completion validation. Purely model-driven: loop continues as long as the model requests tools. When the model stops, the user says "keep going."

## Fixes

1. **Skip decision model for workspace/pipeline domains** — extend `shouldUseActorLoopParity`. Saves 2-5s/cycle of extra LLM overhead.

2. **Don't declare completed when actor called tools** — for coding domains, if the actor ran tools this cycle, return "working" to keep cycling. Completion = actor stops WITHOUT tools (text-only final summary).

3. **Fix actor prompt** — replace "Take the next best bounded step" with "Continue from where you left off. Do not stop until the full objective is satisfied."

## Test plan

- [x] Supervisor: 70 tests pass
- [x] Build clean