### PR TITLE
fix(runtime/grok): retry stateless on empty-content chain errors

### DIFF
--- a/runtime/src/llm/grok/adapter-utils.ts
+++ b/runtime/src/llm/grok/adapter-utils.ts
@@ -402,6 +402,17 @@ export function isContinuationRetrievalFailure(error: unknown): boolean {
   const status = Number.isFinite(parsedStatus) ? parsedStatus : undefined;
   const message = String(e?.message ?? "").toLowerCase();
 
+  // Empty-content errors from the server-side stateful chain: the
+  // chain accumulated messages with empty content from before our
+  // adapter fixes. The only recovery is to break the chain and
+  // retry without previous_response_id.
+  if (
+    status === 400 &&
+    message.includes("content element")
+  ) {
+    return true;
+  }
+
   if (status === 404 && message.includes("response")) return true;
   if (!message.includes("previous") && !message.includes("response")) {
     return false;


### PR DESCRIPTION
## Problem

Runs crash with `400 "Each message must have at least one content element"` when the xAI server-side stateful chain contains old empty-content messages from before our adapter fixes. The chain is permanent — every continuation from it fails.

## Root cause

The adapter has a `shouldRetryStatelessFromStateful` path that drops `previous_response_id` and retries fresh. But `isContinuationRetrievalFailure` only detected "previous_response_id not found" errors, not content-validation errors.

## Fix

Expand `isContinuationRetrievalFailure` to detect `status === 400 && message.includes("content element")`. The existing retry path then rebuilds the request with `forceStateless: true`, breaking the corrupt chain.

## Test plan

- [x] Adapter suite: 96 tests pass
- [x] Build clean