### PR TITLE
revert(runtime): drop exhaustive-intent override and user-stop completion branch

### DIFF
--- a/runtime/src/gateway/background-run-supervisor-constants.ts
+++ b/runtime/src/gateway/background-run-supervisor-constants.ts
@@ -105,8 +105,6 @@ export const RESUME_REQUEST_RE =
   /^\s*(?:resume|continue|continue\s+it|continue\s+that|unpause|restart\s+the\s+run)\s*$/i;
 export const STATUS_REQUEST_RE =
   /^\s*(?:status|update|progress|how(?:'s|\s+is)\s+it\s+going|what(?:'s|\s+is)\s+the\s+status)\s*$/i;
-export const EXHAUSTIVE_INTENT_RE =
-  /\b(?:in\s+full|implement\s+all\s+of|complete\s+all\s+of|do\s+not\s+stop|don't\s+stop|before\s+(?:you\s+)?stop|do\s+not\s+move\s+on|until\s+(?:it\s+is|it's)\s+(?:all\s+)?done)\b/i;
 
 export const BACKGROUND_ACTOR_SECTION =
   "## Background Run Mode\n" +

--- a/runtime/src/gateway/background-run-supervisor-helpers.test.ts
+++ b/runtime/src/gateway/background-run-supervisor-helpers.test.ts
@@ -130,7 +130,7 @@ describe("applyZeroToolCompletionGuard", () => {
   });
 });
 
-describe("exhaustive-intent override for requiresUserStop", () => {
+describe("contract requiresUserStop defaults", () => {
   const plannedContractJson = (overrides: Record<string, unknown> = {}) =>
     JSON.stringify({
       domain: "workspace",
@@ -144,55 +144,41 @@ describe("exhaustive-intent override for requiresUserStop", () => {
       ...overrides,
     });
 
-  it("parseContract: forces requiresUserStop=true when objective contains 'in full'", () => {
-    const contract = parseContract(
-      plannedContractJson(),
-      "Implement all of PLAN.md in full.",
-    );
-    expect(contract?.requiresUserStop).toBe(true);
-  });
-
-  it("parseContract: forces requiresUserStop=true for 'before you stop'", () => {
-    const contract = parseContract(
-      plannedContractJson(),
-      "Finish the refactor before you stop.",
-    );
-    expect(contract?.requiresUserStop).toBe(true);
-  });
-
-  it("parseContract: forces requiresUserStop=true for 'do not move on'", () => {
-    const contract = parseContract(
-      plannedContractJson(),
-      "Do not move on until the tests pass.",
-    );
-    expect(contract?.requiresUserStop).toBe(true);
-  });
-
-  it("parseContract: leaves requiresUserStop=false for plain objectives", () => {
-    const contract = parseContract(
-      plannedContractJson(),
+  it("parseContract: honors the planner-set boolean verbatim", () => {
+    const withFalse = parseContract(
+      plannedContractJson({ requiresUserStop: false }),
       "Update the README.",
     );
-    expect(contract?.requiresUserStop).toBe(false);
-  });
+    expect(withFalse?.requiresUserStop).toBe(false);
 
-  it("parseContract: preserves planner-set requiresUserStop=true even without the regex match", () => {
-    const contract = parseContract(
+    const withTrue = parseContract(
       plannedContractJson({ requiresUserStop: true }),
       "Update the README.",
     );
-    expect(contract?.requiresUserStop).toBe(true);
+    expect(withTrue?.requiresUserStop).toBe(true);
   });
 
-  it("buildFallbackContract: forces requiresUserStop=true for exhaustive-intent objectives", () => {
-    const contract = buildFallbackContract(
-      "Implement all of the plan in full and do not stop.",
-    );
-    expect(contract.requiresUserStop).toBe(true);
+  it("parseContract: defaults to kind === 'until_stopped' when the planner omits the boolean", () => {
+    const raw = JSON.parse(plannedContractJson()) as Record<string, unknown>;
+    delete raw.requiresUserStop;
+    const finiteContract = parseContract(JSON.stringify(raw), "Update README.");
+    expect(finiteContract?.requiresUserStop).toBe(false);
+
+    raw.kind = "until_stopped";
+    const untilStoppedContract = parseContract(JSON.stringify(raw), "Watch it.");
+    expect(untilStoppedContract?.requiresUserStop).toBe(true);
   });
 
-  it("buildFallbackContract: leaves requiresUserStop=false for plain objectives", () => {
-    const contract = buildFallbackContract("Run npm test");
-    expect(contract.requiresUserStop).toBe(false);
+  it("buildFallbackContract: only sets requiresUserStop=true when UNTIL_STOP_RE matches", () => {
+    expect(buildFallbackContract("Run npm test").requiresUserStop).toBe(false);
+    expect(
+      buildFallbackContract("Keep watching this until I say stop").requiresUserStop,
+    ).toBe(true);
+    // Exhaustive-intent phrasing is no longer special-cased — matches
+    // reference-runtime behavior where only an explicit user-stop
+    // directive flips the flag.
+    expect(
+      buildFallbackContract("Implement @PLAN.md in full").requiresUserStop,
+    ).toBe(false);
   });
 });

--- a/runtime/src/gateway/background-run-supervisor-helpers.ts
+++ b/runtime/src/gateway/background-run-supervisor-helpers.ts
@@ -71,7 +71,6 @@ import {
   UNTIL_STOP_RE,
   CONTINUOUS_RE,
   BACKGROUND_RE,
-  EXHAUSTIVE_INTENT_RE,
 } from "./background-run-supervisor-constants.js";
 
 // ---------------------------------------------------------------------------
@@ -1356,23 +1355,6 @@ export function groundDecision(
 
   if (
     decision.state === "completed" &&
-    run.contract.requiresUserStop
-  ) {
-    return {
-      state: "working",
-      userUpdate: truncate(
-        decision.userUpdate || "Task is still running until you tell me to stop.",
-        MAX_USER_UPDATE_CHARS,
-      ),
-      internalSummary:
-        "Rejected premature completion because the run contract requires an explicit user stop.",
-      nextCheckMs: clampPollIntervalMs(run.contract.nextCheckMs),
-      shouldNotifyUser: decision.shouldNotifyUser,
-    };
-  }
-
-  if (
-    decision.state === "completed" &&
     successfulToolCalls.length === 0 &&
     !run.lastToolEvidence
   ) {
@@ -1502,17 +1484,6 @@ export function applyZeroToolCompletionGuard(
     nextCheckMs: MIN_POLL_INTERVAL_MS,
     shouldNotifyUser: true,
   };
-}
-
-function resolveRequiresUserStop(
-  objective: string | undefined,
-  plannedValue: boolean | undefined,
-  kind: BackgroundRunContract["kind"],
-): boolean {
-  const base =
-    typeof plannedValue === "boolean" ? plannedValue : kind === "until_stopped";
-  if (base) return true;
-  return typeof objective === "string" && EXHAUSTIVE_INTENT_RE.test(objective);
 }
 
 // ---------------------------------------------------------------------------
@@ -1730,13 +1701,10 @@ export function parseContract(
       parsed.blockedCriteria,
       "Block when required tools, permissions, or external preconditions are missing.",
     );
-    const requiresUserStop = resolveRequiresUserStop(
-      objective,
+    const requiresUserStop =
       typeof parsed.requiresUserStop === "boolean"
         ? parsed.requiresUserStop
-        : undefined,
-      kind,
-    );
+        : kind === "until_stopped";
     const normalizedManagedProcessPolicy =
       managedProcessPolicy !== undefined
         ? {
@@ -1786,7 +1754,7 @@ export function buildFallbackContract(objective: string): BackgroundRunContract 
     : continuous
       ? "until_condition"
       : "finite";
-  const requiresUserStop = resolveRequiresUserStop(objective, undefined, kind);
+  const requiresUserStop = kind === "until_stopped";
   const managedProcessPolicyMode = inferManagedProcessPolicyMode(objective);
   const successCriteria = [
     "Use tools to make measurable progress and verify the result.",

--- a/runtime/src/gateway/background-run-supervisor.test.ts
+++ b/runtime/src/gateway/background-run-supervisor.test.ts
@@ -2379,7 +2379,7 @@ describe("background-run-supervisor", () => {
     ).toBe("working");
   });
 
-  it("keeps until-stopped runs working even when the supervisor suggests completion", async () => {
+  it("accepts supervisor-suggested completion for until-stopped runs (no user-stop override)", async () => {
     const publishUpdate = vi.fn(async () => undefined);
     const supervisor = new BackgroundRunSupervisor({
       chatExecutor: {
@@ -2433,7 +2433,9 @@ describe("background-run-supervisor", () => {
     });
     await vi.runOnlyPendingTimersAsync();
 
-    expect(supervisor.getStatusSnapshot("session-until-stop")?.state).toBe("working");
+    expect(
+      (supervisor as any).activeRuns.get("session-until-stop"),
+    ).toBeUndefined();
   });
 
   it("does not expire an until-stopped run just because it exceeds the runtime cap", async () => {


### PR DESCRIPTION
## Summary

- Removes `EXHAUSTIVE_INTENT_RE` + `resolveRequiresUserStop()` + the `groundDecision` branch that forced `completed` decisions back to `working` when `run.contract.requiresUserStop` was set.
- Aligns the actor loop with the reference runtime: `stop_reason: "completed"` with no tool calls is terminal. No runtime override re-invokes the model on a text-only turn.
- Preserves the `requiresUserStop` boolean on `BackgroundRunContract` for managed-process policy and idle-timeout policy — a follow-up can remove it end-to-end if strict schema parity is wanted.

## Why this exists

PR #436 added a regex (`"in full" / "do not stop" / "before you stop" / ...`) that flipped `requiresUserStop: true` for ordinary implementation objectives. That activated a dormant override branch in `groundDecision` (pre-existing since repo bootstrap on 2026-03-17). The override converted the actor's `completed` decision to `working` and wrote the actor's own content into `run.lastUserUpdate`, which the next cycle's `buildActorPrompt` echoed back as `Latest published status:`. Observed symptom: `bg-mo2rwdi6-dfn1ja` reached cycle 80+ with the actor emitting the same "Cycle N Status: Tools disabled" narrative every turn, zero successful tool calls, and no termination.

## Test plan

- [ ] `cd agenc-core/runtime && npm run typecheck` — clean
- [ ] `cd agenc-core/runtime && npm run build` — clean
- [ ] `npx vitest run src/gateway/background-run-supervisor.test.ts` — 70 pass (renamed until-stopped test now asserts the run terminates instead of staying `working`)
- [ ] `npx vitest run src/gateway/` — all pass except the pre-existing `llm-stateful-defaults` failures that already reproduce on `main`
- [ ] Manual: restart the daemon, kick off an objective phrased as "implement @PLAN.md in full", observe that the actor's text-only turn is now terminal and does not loop back on itself; tool-driven cycles still continue to the next iteration as before.

## Scope

- Does NOT remove the `requiresUserStop` field from `BackgroundRunContract` or its managed-process / idle-timeout call sites. That cascades through 32 files including persistence, planner prompt, and ~100 test-fixture lines. If strict schema parity is wanted, a separate PR can handle the sweep.