### PR TITLE
feat(runtime): port TodoWrite tool + 10-turn reminder

### DIFF
--- a/runtime/src/gateway/background-run-supervisor-types.ts
+++ b/runtime/src/gateway/background-run-supervisor-types.ts
@@ -226,6 +226,17 @@ export interface BackgroundRunSupervisorConfig {
     discoveredToolNames?: readonly string[],
   ) => readonly string[];
   readonly seedHistoryForSession?: (sessionId: string) => readonly LLMMessage[];
+  /**
+   * Optional callback returning the session's current TodoWrite list.
+   * Used by the shared attachment-injection hook to render the
+   * 10-turn reminder with the right list contents. When absent, the
+   * reminder still fires on cadence but with an empty list payload.
+   */
+  readonly readTodosForSession?: (
+    sessionId: string,
+  ) => Promise<
+    readonly import("../tools/system/todo-store.js").TodoItem[]
+  >;
   readonly isSessionBusy?: (sessionId: string) => boolean;
   readonly onStatus?: (
     sessionId: string,

--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -17,6 +17,7 @@ import { normalizePromptEnvelope } from "../llm/prompt-envelope.js";
 import { buildModelOnlyChatOptions } from "../llm/model-only-options.js";
 import { getCompactPrompt, formatCompactSummary } from "../llm/compact/prompt.js";
 import type { LLMMessage, LLMProvider, ToolHandler } from "../llm/types.js";
+import { collectAttachments } from "../llm/attachment-injection.js";
 import type { Logger } from "../utils/logger.js";
 import { silentLogger } from "../utils/logger.js";
 import { toErrorMessage } from "../utils/async.js";
@@ -583,6 +584,7 @@ export class BackgroundRunSupervisor {
   private readonly buildToolRoutingDecision?: BackgroundRunSupervisorConfig["buildToolRoutingDecision"];
   private readonly resolveAdvertisedToolNames?: BackgroundRunSupervisorConfig["resolveAdvertisedToolNames"];
   private readonly seedHistoryForSession?: BackgroundRunSupervisorConfig["seedHistoryForSession"];
+  private readonly readTodosForSession?: BackgroundRunSupervisorConfig["readTodosForSession"];
   private readonly isSessionBusy?: BackgroundRunSupervisorConfig["isSessionBusy"];
   private readonly onStatus?: BackgroundRunSupervisorConfig["onStatus"];
   private readonly publishUpdate: BackgroundRunSupervisorConfig["publishUpdate"];
@@ -623,6 +625,7 @@ export class BackgroundRunSupervisor {
     this.buildToolRoutingDecision = config.buildToolRoutingDecision;
     this.resolveAdvertisedToolNames = config.resolveAdvertisedToolNames;
     this.seedHistoryForSession = config.seedHistoryForSession;
+    this.readTodosForSession = config.readTodosForSession;
     this.isSessionBusy = config.isSessionBusy;
     this.onStatus = config.onStatus;
     this.publishUpdate = config.publishUpdate;
@@ -4036,6 +4039,28 @@ export class BackgroundRunSupervisor {
         now: this.now(),
       });
     }
+
+    // Runtime-injected attachments (today: the TodoWrite 10-turn
+    // reminder). Shared with the webchat chat-executor via
+    // `collectAttachments` so both surfaces emit identical nudges.
+    const activeToolNames = new Set<string>(
+      this.resolveAdvertisedToolNames?.(
+        sessionId,
+        run.shellProfile ?? DEFAULT_SESSION_SHELL_PROFILE,
+      ) ?? [],
+    );
+    const todos = this.readTodosForSession
+      ? await this.readTodosForSession(sessionId)
+      : [];
+    const attachments = collectAttachments({
+      history: run.internalHistory,
+      activeToolNames,
+      todos,
+    });
+    for (const attachment of attachments.messages) {
+      run.internalHistory.push(attachment);
+    }
+
     return {
       run,
       sessionId,

--- a/runtime/src/gateway/daemon-text-channel-turn.ts
+++ b/runtime/src/gateway/daemon-text-channel-turn.ts
@@ -4,6 +4,7 @@ import type {
   ChatToolRoutingSummary,
 } from "../llm/chat-executor.js";
 import { executeChatToLegacyResult } from "../llm/execute-chat.js";
+import { collectAttachments } from "../llm/attachment-injection.js";
 import { normalizePromptEnvelope } from "../llm/prompt-envelope.js";
 import type {
   LLMProviderTraceEvent,
@@ -221,6 +222,11 @@ interface ExecuteTextChannelTurnParams {
   readonly workerManager?: PersistentWorkerManager | null;
   readonly agentDefinitions?: readonly AgentDefinition[];
   readonly taskStore?: TaskStore | null;
+  readonly readTodosForSession?: (
+    sessionId: string,
+  ) => Promise<
+    readonly import("../tools/system/todo-store.js").TodoItem[]
+  >;
 }
 
 export async function executeTextChannelTurn(
@@ -307,10 +313,22 @@ export async function executeTextChannelTurn(
   const sessionInteractiveContext = buildSessionInteractiveContext(session, {
     overrideState: interactiveTurnState,
   });
-  const effectiveHistory =
+  const historyBeforeAttachments =
     atMentionAttachments.historyPrelude.length > 0
       ? [...session.history, ...atMentionAttachments.historyPrelude]
       : session.history;
+  const todosForAttachment = params.readTodosForSession
+    ? await params.readTodosForSession(msg.sessionId)
+    : [];
+  const runtimeAttachments = collectAttachments({
+    history: historyBeforeAttachments,
+    activeToolNames: new Set<string>(advertisedToolNames),
+    todos: todosForAttachment,
+  });
+  const effectiveHistory =
+    runtimeAttachments.messages.length > 0
+      ? [...historyBeforeAttachments, ...runtimeAttachments.messages]
+      : historyBeforeAttachments;
   const promptEnvelope = normalizePromptEnvelope({
     baseSystemPrompt: effectiveSystemPrompt,
   });

--- a/runtime/src/gateway/daemon-tool-registry.ts
+++ b/runtime/src/gateway/daemon-tool-registry.ts
@@ -45,6 +45,8 @@ import {
   SessionTaskStore,
   TaskStore,
 } from "../tools/system/task-tracker.js";
+import { TodoStore } from "../tools/system/todo-store.js";
+import { createTodoWriteTool } from "../tools/system/todo-write.js";
 import { runStopHookPhase, type StopHookRuntime } from "../llm/hooks/stop-hooks.js";
 import {
   buildRuntimeContractTaskTraceId,
@@ -106,6 +108,7 @@ interface ToolRegistrySideEffects {
   connectionManager: ConnectionManager | null;
   sessionTaskStore: SessionTaskStore;
   taskTrackerStore: TaskStore;
+  todoStore: TodoStore;
 }
 
 // ============================================================================
@@ -342,6 +345,8 @@ export async function createDaemonToolRegistry(
     persistenceRootDir: resolveRuntimePersistencePaths().rootDir,
     logger,
   });
+  const todoStore = new TodoStore({ memoryBackend });
+  registry.register(createTodoWriteTool(todoStore));
   const taskTrackerStore = new TaskStore({
     memoryBackend,
     persistenceRootDir: resolveRuntimePersistencePaths().rootDir,
@@ -779,5 +784,6 @@ export async function createDaemonToolRegistry(
     connectionManager,
     sessionTaskStore,
     taskTrackerStore,
+    todoStore,
   };
 }

--- a/runtime/src/gateway/daemon-webchat-turn.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.ts
@@ -6,6 +6,7 @@ import type {
 } from "../llm/chat-executor.js";
 import type { ChatExecutionTraceEvent } from "../llm/chat-executor-types.js";
 import { executeChatToLegacyResult } from "../llm/execute-chat.js";
+import { collectAttachments } from "../llm/attachment-injection.js";
 import { normalizePromptEnvelope } from "../llm/prompt-envelope.js";
 import type {
   LLMProviderTraceEvent,
@@ -133,6 +134,11 @@ interface ExecuteWebChatConversationTurnParams {
   readonly workerManager?: PersistentWorkerManager | null;
   readonly agentDefinitions?: readonly AgentDefinition[];
   readonly taskStore?: TaskStore | null;
+  readonly readTodosForSession?: (
+    sessionId: string,
+  ) => Promise<
+    readonly import("../tools/system/todo-store.js").TodoItem[]
+  >;
   readonly maybeStartBackgroundRun?: (params: {
     readonly session: Session;
     readonly objective: string;
@@ -404,10 +410,22 @@ export async function executeWebChatConversationTurn(
     const sessionInteractiveContext = buildSessionInteractiveContext(session, {
       overrideState: interactiveTurnState,
     });
-    const effectiveHistory =
+    const historyBeforeAttachments =
       atMentionAttachments.historyPrelude.length > 0
         ? [...session.history, ...atMentionAttachments.historyPrelude]
         : session.history;
+    const todosForAttachment = params.readTodosForSession
+      ? await params.readTodosForSession(msg.sessionId)
+      : [];
+    const runtimeAttachments = collectAttachments({
+      history: historyBeforeAttachments,
+      activeToolNames: new Set<string>(advertisedToolNames),
+      todos: todosForAttachment,
+    });
+    const effectiveHistory =
+      runtimeAttachments.messages.length > 0
+        ? [...historyBeforeAttachments, ...runtimeAttachments.messages]
+        : historyBeforeAttachments;
     if (
       params.maybeStartBackgroundRun &&
       await params.maybeStartBackgroundRun({

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -152,6 +152,7 @@ import { ToolRegistry } from "../tools/registry.js";
 import { SystemRemoteJobManager } from "../tools/system/remote-job.js";
 import { SystemRemoteSessionManager } from "../tools/system/remote-session.js";
 import { TaskStore } from "../tools/system/task-tracker.js";
+import { TodoStore } from "../tools/system/todo-store.js";
 import { DEFAULT_TIMEOUT_MS as DEFAULT_BASH_TOOL_TIMEOUT_MS } from "../tools/system/types.js";
 import {
   SkillDiscovery,
@@ -1140,6 +1141,7 @@ export class DaemonManager {
   private _remoteJobManager: SystemRemoteJobManager | null = null;
   private _remoteSessionManager: SystemRemoteSessionManager | null = null;
   private _taskTrackerStore: TaskStore | null = null;
+  private _todoStore: TodoStore | null = null;
   private _persistentWorkerManager: PersistentWorkerManager | null = null;
   private _sessionModelInfo = new Map<
     string,
@@ -4022,6 +4024,7 @@ export class DaemonManager {
     this._remoteJobManager = result.remoteJobManager;
     this._remoteSessionManager = result.remoteSessionManager;
     this._taskTrackerStore = result.taskTrackerStore;
+    this._todoStore = result.todoStore;
     await this._taskTrackerStore.repairRuntimeState();
     await this.configurePersistentWorkerManager(config);
     this._containerMCPConfigs = result.containerMCPConfigs;
@@ -7811,6 +7814,9 @@ export class DaemonManager {
       }
       if (this._taskTrackerStore !== null) {
         this._taskTrackerStore = null;
+      }
+      if (this._todoStore !== null) {
+        this._todoStore = null;
       }
       this._toolRegistry = null;
       if (this._memoryBackend !== null) {

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -2525,6 +2525,8 @@ export class DaemonManager {
           ),
         seedHistoryForSession: (sessionId) =>
           sessionMgr.get(sessionId)?.history ?? [],
+        readTodosForSession: async (sessionId) =>
+          this._todoStore ? await this._todoStore.getTodos(sessionId) : [],
         isSessionBusy: (sessionId) =>
           this._foregroundSessionLocks.has(sessionId),
         onStatus: (sessionId, payload) => {
@@ -7556,6 +7558,8 @@ export class DaemonManager {
           });
         },
         taskStore: this._taskTrackerStore,
+        readTodosForSession: async (sessionId) =>
+          this._todoStore ? await this._todoStore.getTodos(sessionId) : [],
         workerManager,
         maybeStartBackgroundRun,
         onSubagentSynthesis: (result) => {

--- a/runtime/src/gateway/shell-profile.ts
+++ b/runtime/src/gateway/shell-profile.ts
@@ -45,6 +45,7 @@ const GENERAL_DEFAULT_TOOL_NAMES = [
   "task.list",
   "task.get",
   "task.update",
+  "TodoWrite",
   "execute_with_agent",
   "coordinator",
   "web_search",
@@ -143,6 +144,7 @@ const DEFINITIONS: Record<SessionShellProfile, ShellProfileDefinition> = {
       "system.symbolDefinition",
       "system.symbolReferences",
       "system.searchTools",
+      "TodoWrite",
       "execute_with_agent",
       "coordinator",
     ],
@@ -163,7 +165,7 @@ const DEFINITIONS: Record<SessionShellProfile, ShellProfileDefinition> = {
       "Use delegation primarily for bounded investigation, synthesis, and source-backed analysis.",
     ],
     toolPrefixes: ["system.browse", "system.http", "playwright.", "browser_", "task."],
-    exactToolNames: ["execute_with_agent"],
+    exactToolNames: ["TodoWrite", "execute_with_agent"],
     delegationDefault: "research",
     approvalHints: {
       readOnlyBias: true,
@@ -181,7 +183,7 @@ const DEFINITIONS: Record<SessionShellProfile, ShellProfileDefinition> = {
       "Prefer explicit checks, logs, tests, and run output over intuition.",
     ],
     toolPrefixes: ["system.", "desktop.", "task."],
-    exactToolNames: ["execute_with_agent"],
+    exactToolNames: ["TodoWrite", "execute_with_agent"],
     delegationDefault: "verify",
     approvalHints: {
       readOnlyBias: true,
@@ -199,7 +201,7 @@ const DEFINITIONS: Record<SessionShellProfile, ShellProfileDefinition> = {
       "Keep structure and wording clear, but still verify referenced commands or paths when they matter.",
     ],
     toolPrefixes: ["system.", "task."],
-    exactToolNames: ["execute_with_agent"],
+    exactToolNames: ["TodoWrite", "execute_with_agent"],
     delegationDefault: "coding",
     approvalHints: {
       readOnlyBias: false,
@@ -217,7 +219,7 @@ const DEFINITIONS: Record<SessionShellProfile, ShellProfileDefinition> = {
       "Keep awareness of system state, long-running handles, and operational visibility.",
     ],
     toolPrefixes: ["agenc.", "system.", "social.", "wallet.", "task."],
-    exactToolNames: ["execute_with_agent", "coordinator"],
+    exactToolNames: ["TodoWrite", "execute_with_agent", "coordinator"],
     delegationDefault: "operator",
     approvalHints: {
       readOnlyBias: false,

--- a/runtime/src/gateway/tool-handler-factory.ts
+++ b/runtime/src/gateway/tool-handler-factory.ts
@@ -26,6 +26,10 @@ import {
 } from "../tools/system/task-tracker.js";
 import type { TaskStore } from "../tools/system/task-tracker.js";
 import {
+  TODO_WRITE_SESSION_ARG,
+  TODO_WRITE_TOOL_NAME,
+} from "../tools/system/todo-write.js";
+import {
   buildShellProfileApprovalContext,
   type SessionShellProfile,
 } from "./shell-profile.js";
@@ -289,13 +293,15 @@ function stripInternalToolArgs(
   const hasTaskActorName = TASK_ACTOR_NAME_ARG in args;
   const hasSessionId = SESSION_ID_ARG in args;
   const hasAdvertisedToolNames = SESSION_ADVERTISED_TOOL_NAMES_ARG in args;
+  const hasTodoSessionId = TODO_WRITE_SESSION_ARG in args;
   if (
     !hasAllowedRoots &&
     !hasTaskListId &&
     !hasTaskActorKind &&
     !hasTaskActorName &&
     !hasSessionId &&
-    !hasAdvertisedToolNames
+    !hasAdvertisedToolNames &&
+    !hasTodoSessionId
   ) {
     return args;
   }
@@ -318,7 +324,27 @@ function stripInternalToolArgs(
   if (hasAdvertisedToolNames) {
     delete nextArgs[SESSION_ADVERTISED_TOOL_NAMES_ARG];
   }
+  if (hasTodoSessionId) {
+    delete nextArgs[TODO_WRITE_SESSION_ARG];
+  }
   return nextArgs;
+}
+
+function applyTodoWriteSessionId(
+  toolName: string,
+  args: Record<string, unknown>,
+  sessionId: string | undefined,
+): Record<string, unknown> {
+  if (toolName !== TODO_WRITE_TOOL_NAME) {
+    return args;
+  }
+  if (!sessionId || sessionId.trim().length === 0) {
+    return args;
+  }
+  return {
+    ...args,
+    [TODO_WRITE_SESSION_ARG]: sessionId,
+  };
 }
 
 function applySessionTaskListId(
@@ -3042,6 +3068,7 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
       delegatedParentAllowedRoots,
     );
     executionArgs = applySessionTaskListId(toolName, executionArgs, sessionIdentity);
+    executionArgs = applyTodoWriteSessionId(toolName, executionArgs, sessionIdentity);
     executionArgs = applyTaskActorContext(
       toolName,
       executionArgs,

--- a/runtime/src/llm/attachment-injection.test.ts
+++ b/runtime/src/llm/attachment-injection.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import type { LLMMessage } from "./types.js";
+import type { TodoItem } from "../tools/system/todo-store.js";
+import { TODO_WRITE_TOOL_NAME } from "../tools/system/todo-write.js";
+import { collectAttachments } from "./attachment-injection.js";
+import { TODO_REMINDER_TURNS_SINCE_WRITE } from "./todo-reminder.js";
+
+function userText(content: string): LLMMessage {
+  return { role: "user", content };
+}
+
+function assistantText(content: string): LLMMessage {
+  return { role: "assistant", content };
+}
+
+function assistantToolCall(toolName: string): LLMMessage {
+  return {
+    role: "assistant",
+    content: "",
+    toolCalls: [
+      {
+        id: `call-${toolName}`,
+        name: toolName,
+        arguments: "{}",
+      },
+    ],
+  };
+}
+
+function buildStaleHistory(): LLMMessage[] {
+  const history: LLMMessage[] = [];
+  for (let index = 0; index < TODO_REMINDER_TURNS_SINCE_WRITE + 1; index += 1) {
+    history.push(userText(`u${index}`));
+    history.push(assistantText(`a${index}`));
+  }
+  return history;
+}
+
+const SAMPLE_TODOS: TodoItem[] = [
+  { content: "one", status: "pending", activeForm: "Working on one" },
+];
+
+describe("collectAttachments", () => {
+  it("returns an empty message list when TodoWrite is not in the active toolset", () => {
+    const result = collectAttachments({
+      history: [],
+      activeToolNames: new Set<string>(),
+      todos: [],
+    });
+    expect(result.messages).toEqual([]);
+  });
+
+  it("fires the reminder on empty history when TodoWrite is available (matches upstream)", () => {
+    // With no history: turnsSinceTodoWrite = Infinity,
+    // turnsSinceLastReminder = Infinity, turnsSinceRecentTaskToolUse
+    // = Infinity. All suppression checks pass. Upstream behaves the
+    // same: the reminder exists to nudge the model toward using the
+    // tool at all, not only to surface a stale list.
+    const result = collectAttachments({
+      history: [],
+      activeToolNames: new Set([TODO_WRITE_TOOL_NAME]),
+      todos: [],
+    });
+    expect(result.messages).toHaveLength(1);
+  });
+
+  it("returns the TodoWrite reminder when its trigger conditions hold", () => {
+    const result = collectAttachments({
+      history: buildStaleHistory(),
+      activeToolNames: new Set([TODO_WRITE_TOOL_NAME]),
+      todos: SAMPLE_TODOS,
+    });
+    expect(result.messages).toHaveLength(1);
+    const message = result.messages[0]!;
+    expect(message.role).toBe("user");
+    expect(typeof message.content).toBe("string");
+    expect(message.content as string).toContain(
+      "The TodoWrite tool hasn't been used recently",
+    );
+  });
+
+  it("suppresses the reminder when TodoWrite is not in the active toolset", () => {
+    const result = collectAttachments({
+      history: buildStaleHistory(),
+      activeToolNames: new Set<string>(),
+      todos: SAMPLE_TODOS,
+    });
+    expect(result.messages).toEqual([]);
+  });
+
+  it("suppresses the reminder when task.* was used recently", () => {
+    const history: LLMMessage[] = [
+      userText("go"),
+      assistantToolCall("task.create"),
+      assistantText("a1"),
+    ];
+    const result = collectAttachments({
+      history,
+      activeToolNames: new Set([TODO_WRITE_TOOL_NAME]),
+      todos: SAMPLE_TODOS,
+    });
+    expect(result.messages).toEqual([]);
+  });
+
+  it("returns the same result for identical inputs regardless of caller", () => {
+    // This property is what lets both webchat and background paths
+    // share the hook without drifting.
+    const ctx = {
+      history: buildStaleHistory(),
+      activeToolNames: new Set([TODO_WRITE_TOOL_NAME]),
+      todos: SAMPLE_TODOS,
+    };
+    const first = collectAttachments(ctx);
+    const second = collectAttachments(ctx);
+    expect(first.messages).toEqual(second.messages);
+  });
+});

--- a/runtime/src/llm/attachment-injection.ts
+++ b/runtime/src/llm/attachment-injection.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared entry point for runtime-injected user-role attachments.
+ *
+ * Both the webchat chat-executor (`chat-executor-tool-loop.ts`) and
+ * the background-run supervisor (`background-run-supervisor.ts`) call
+ * this exact function at the same point in their respective flows —
+ * immediately before the next model call — so both surfaces see the
+ * same injection behavior. Upstream's reference runtime uses one
+ * shared `getAttachments` pipeline; having two independent hooks
+ * here would create drift between interactive and background paths.
+ *
+ * Today the module emits at most one message: the TodoWrite reminder
+ * from `todo-reminder.ts`. Future attachments (plan-mode
+ * re-attachment, other runtime reminders) land here in the same
+ * priority order the upstream runtime uses.
+ *
+ * @module
+ */
+
+import type { LLMMessage } from "./types.js";
+import type { TodoItem } from "../tools/system/todo-store.js";
+import {
+  buildTodoReminderMessage,
+  shouldInjectTodoReminder,
+} from "./todo-reminder.js";
+
+export interface AttachmentContext {
+  readonly history: readonly LLMMessage[];
+  readonly activeToolNames: ReadonlySet<string>;
+  readonly todos: readonly TodoItem[];
+}
+
+export interface AttachmentInjectionResult {
+  readonly messages: readonly LLMMessage[];
+}
+
+export function collectAttachments(
+  ctx: AttachmentContext,
+): AttachmentInjectionResult {
+  const messages: LLMMessage[] = [];
+  if (
+    shouldInjectTodoReminder({
+      history: ctx.history,
+      activeToolNames: ctx.activeToolNames,
+    })
+  ) {
+    messages.push(buildTodoReminderMessage(ctx.todos));
+  }
+  return { messages };
+}

--- a/runtime/src/llm/todo-reminder.test.ts
+++ b/runtime/src/llm/todo-reminder.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from "vitest";
+import type { LLMMessage } from "./types.js";
+import type { TodoItem } from "../tools/system/todo-store.js";
+import { TODO_WRITE_TOOL_NAME } from "../tools/system/todo-write.js";
+import {
+  TODO_REMINDER_HEADER_PREFIX,
+  TODO_REMINDER_TURNS_BETWEEN_REMINDERS,
+  TODO_REMINDER_TURNS_SINCE_WRITE,
+  buildTodoReminderMessage,
+  getTurnsSinceLastTodoReminder,
+  getTurnsSinceRecentTaskToolUse,
+  getTurnsSinceTodoWrite,
+  shouldInjectTodoReminder,
+} from "./todo-reminder.js";
+
+function assistantText(content: string): LLMMessage {
+  return { role: "assistant", content };
+}
+
+function userText(content: string): LLMMessage {
+  return { role: "user", content };
+}
+
+function assistantToolCall(
+  toolName: string,
+  overrides: Partial<LLMMessage> = {},
+): LLMMessage {
+  return {
+    role: "assistant",
+    content: "",
+    toolCalls: [
+      {
+        id: `call-${toolName}`,
+        name: toolName,
+        arguments: "{}",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function toolResult(toolCallId: string, output: string): LLMMessage {
+  return { role: "tool", content: output, toolCallId };
+}
+
+function buildHistoryWithAssistantTurns(count: number): LLMMessage[] {
+  const out: LLMMessage[] = [];
+  for (let index = 0; index < count; index += 1) {
+    out.push(userText(`user turn ${index + 1}`));
+    out.push(assistantText(`assistant turn ${index + 1}`));
+  }
+  return out;
+}
+
+const DEFAULT_ACTIVE_TOOLS = new Set<string>([TODO_WRITE_TOOL_NAME]);
+
+const TODOS_SAMPLE: TodoItem[] = [
+  { content: "first", status: "pending", activeForm: "Working on first" },
+  {
+    content: "second",
+    status: "in_progress",
+    activeForm: "Working on second",
+  },
+];
+
+describe("getTurnsSinceTodoWrite", () => {
+  it("returns Infinity when no history contains a TodoWrite call", () => {
+    expect(getTurnsSinceTodoWrite([])).toBe(Number.POSITIVE_INFINITY);
+    expect(
+      getTurnsSinceTodoWrite(buildHistoryWithAssistantTurns(5)),
+    ).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("returns 0 when the most recent assistant turn called TodoWrite", () => {
+    const history: LLMMessage[] = [
+      userText("go"),
+      assistantToolCall(TODO_WRITE_TOOL_NAME),
+      toolResult("call-TodoWrite", "{}"),
+    ];
+    expect(getTurnsSinceTodoWrite(history)).toBe(0);
+  });
+
+  it("counts only assistant turns that intervene after the last call", () => {
+    const history: LLMMessage[] = [
+      userText("go"),
+      assistantToolCall(TODO_WRITE_TOOL_NAME),
+      toolResult("call-TodoWrite", "{}"),
+      userText("next"),
+      assistantText("replied"),
+      userText("next"),
+      assistantText("replied"),
+      userText("next"),
+      assistantText("replied"),
+    ];
+    expect(getTurnsSinceTodoWrite(history)).toBe(3);
+  });
+});
+
+describe("getTurnsSinceLastTodoReminder", () => {
+  it("returns Infinity when no reminder has been emitted", () => {
+    expect(
+      getTurnsSinceLastTodoReminder(buildHistoryWithAssistantTurns(5)),
+    ).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("finds a reminder by its stable header prefix", () => {
+    const reminder = buildTodoReminderMessage(TODOS_SAMPLE);
+    const history: LLMMessage[] = [
+      userText("go"),
+      assistantText("ack"),
+      reminder,
+      assistantText("adjusted"),
+      userText("next"),
+      assistantText("replied"),
+    ];
+    expect(getTurnsSinceLastTodoReminder(history)).toBe(2);
+  });
+
+  it("uses only the header-prefix sentinel, not arbitrary content", () => {
+    expect(TODO_REMINDER_HEADER_PREFIX).toBe(
+      "The TodoWrite tool hasn't been used recently.",
+    );
+  });
+});
+
+describe("getTurnsSinceRecentTaskToolUse", () => {
+  it("returns Infinity when no task.* tool has been called", () => {
+    expect(
+      getTurnsSinceRecentTaskToolUse(buildHistoryWithAssistantTurns(3)),
+    ).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("detects task.create and task.update calls", () => {
+    const history: LLMMessage[] = [
+      userText("go"),
+      assistantToolCall("task.create"),
+      toolResult("call-task.create", "{}"),
+      userText("next"),
+      assistantText("replied"),
+    ];
+    expect(getTurnsSinceRecentTaskToolUse(history)).toBe(1);
+  });
+});
+
+describe("shouldInjectTodoReminder", () => {
+  it("returns false when TodoWrite is not in the active toolset", () => {
+    const history = buildHistoryWithAssistantTurns(
+      TODO_REMINDER_TURNS_SINCE_WRITE + 2,
+    );
+    expect(
+      shouldInjectTodoReminder({
+        history,
+        activeToolNames: new Set<string>(),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when turnsSinceTodoWrite is below the threshold", () => {
+    const history: LLMMessage[] = [
+      userText("go"),
+      assistantToolCall(TODO_WRITE_TOOL_NAME),
+      toolResult("call-TodoWrite", "{}"),
+      ...buildHistoryWithAssistantTurns(
+        TODO_REMINDER_TURNS_SINCE_WRITE - 1,
+      ),
+    ];
+    expect(
+      shouldInjectTodoReminder({
+        history,
+        activeToolNames: DEFAULT_ACTIVE_TOOLS,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when both thresholds are met and no task.* recently used", () => {
+    const history = buildHistoryWithAssistantTurns(
+      TODO_REMINDER_TURNS_SINCE_WRITE + 1,
+    );
+    expect(
+      shouldInjectTodoReminder({
+        history,
+        activeToolNames: DEFAULT_ACTIVE_TOOLS,
+      }),
+    ).toBe(true);
+  });
+
+  it("suppresses when task.* was used within the last 10 assistant turns", () => {
+    const history: LLMMessage[] = [
+      userText("go"),
+      assistantToolCall("task.create"),
+      toolResult("call-task.create", "{}"),
+      ...buildHistoryWithAssistantTurns(5),
+    ];
+    expect(
+      shouldInjectTodoReminder({
+        history,
+        activeToolNames: DEFAULT_ACTIVE_TOOLS,
+      }),
+    ).toBe(false);
+  });
+
+  it("stops suppressing once task.* is past the 10-turn window", () => {
+    const history: LLMMessage[] = [
+      userText("go"),
+      assistantToolCall("task.create"),
+      toolResult("call-task.create", "{}"),
+      ...buildHistoryWithAssistantTurns(
+        TODO_REMINDER_TURNS_SINCE_WRITE + 1,
+      ),
+    ];
+    expect(
+      shouldInjectTodoReminder({
+        history,
+        activeToolNames: DEFAULT_ACTIVE_TOOLS,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when another reminder was emitted within the window", () => {
+    const reminder = buildTodoReminderMessage(TODOS_SAMPLE);
+    const historyWithPriorReminder: LLMMessage[] = [
+      reminder,
+      ...buildHistoryWithAssistantTurns(
+        TODO_REMINDER_TURNS_BETWEEN_REMINDERS - 2,
+      ),
+    ];
+    expect(
+      shouldInjectTodoReminder({
+        history: historyWithPriorReminder,
+        activeToolNames: DEFAULT_ACTIVE_TOOLS,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("buildTodoReminderMessage", () => {
+  it("emits the verbatim upstream header wrapped in <system-reminder> tags", () => {
+    const message = buildTodoReminderMessage([]);
+    expect(message.role).toBe("user");
+    expect(typeof message.content).toBe("string");
+    const content = message.content as string;
+    expect(content.startsWith("<system-reminder>\n")).toBe(true);
+    expect(content.endsWith("\n</system-reminder>")).toBe(true);
+    expect(content).toContain(
+      "The TodoWrite tool hasn't been used recently. If you're working " +
+        "on tasks that would benefit from tracking progress",
+    );
+    expect(content).toContain(
+      "NEVER mention this reminder to the user",
+    );
+  });
+
+  it("renders the todo list joined by newlines inside square brackets", () => {
+    const message = buildTodoReminderMessage(TODOS_SAMPLE);
+    const content = message.content as string;
+    expect(content).toContain(
+      "Here are the existing contents of your todo list:\n\n[1. [pending] first\n2. [in_progress] second]",
+    );
+  });
+
+  it("omits the list section entirely when there are no todos", () => {
+    const message = buildTodoReminderMessage([]);
+    const content = message.content as string;
+    expect(content).not.toContain("Here are the existing contents");
+  });
+
+  it("marks the runtime-only merge boundary so downstream surfaces filter it", () => {
+    const message = buildTodoReminderMessage([]);
+    expect(message.runtimeOnly?.mergeBoundary).toBe("user_context");
+  });
+});

--- a/runtime/src/llm/todo-reminder.ts
+++ b/runtime/src/llm/todo-reminder.ts
@@ -1,0 +1,169 @@
+/**
+ * 10-turn reminder for the `TodoWrite` tool.
+ *
+ * Purpose: when the model has not called `TodoWrite` in a while, inject
+ * a user-role `<system-reminder>` listing the current todo list with
+ * passive wording that nudges the model toward using the tool without
+ * commanding it. Mirrors the upstream reference runtime's todo reminder
+ * at `utils/attachments.ts:3266-3317` + `utils/messages.ts:3660-3679`.
+ *
+ * Counter model is scan-derived from the current history — no persisted
+ * fields anywhere. Two counters:
+ *
+ *   - `turnsSinceTodoWrite` — assistant turns since the most recent
+ *     assistant message whose `toolCalls` includes a `TodoWrite`
+ *     invocation. `Infinity` if never called in the visible history.
+ *
+ *   - `turnsSinceLastTodoReminder` — assistant turns since the most
+ *     recent user-role message whose content begins with the reminder
+ *     header sentinel. `Infinity` if never emitted.
+ *
+ * Trigger: both counters must be `>= 10`.
+ *
+ * Suppression, in order:
+ *   - `TodoWrite` not in the active toolset — the model can't act on
+ *     the reminder anyway. Matches upstream's tool-availability gate.
+ *   - `task.*` tool call in the last 10 assistant turns — the model is
+ *     using the richer sub-agent orchestration surface; nagging it
+ *     toward TodoWrite would be incoherent. AgenC-specific (upstream
+ *     has no `task.*` family).
+ *
+ * The emitted message content is the verbatim upstream header text
+ * (trailing newline included), followed by the current list rendered
+ * with newline separators inside square brackets, wrapped in literal
+ * `<system-reminder>` / `</system-reminder>` tags at the wire level.
+ * Those tags are what the model sees in its context — they are the
+ * model contract, not a UI artifact.
+ *
+ * @module
+ */
+
+import type { LLMMessage } from "./types.js";
+import { TODO_WRITE_TOOL_NAME } from "../tools/system/todo-write.js";
+import type { TodoItem } from "../tools/system/todo-store.js";
+
+export const TODO_REMINDER_TURNS_SINCE_WRITE = 10;
+export const TODO_REMINDER_TURNS_BETWEEN_REMINDERS = 10;
+
+/**
+ * First-sentence anchor used to detect a previously-emitted reminder in
+ * history. Kept stable across minor tweaks so scan-derived
+ * `turnsSinceLastTodoReminder` remains accurate.
+ */
+export const TODO_REMINDER_HEADER_PREFIX =
+  "The TodoWrite tool hasn't been used recently.";
+
+const TODO_REMINDER_HEADER =
+  "The TodoWrite tool hasn't been used recently. If you're working " +
+  "on tasks that would benefit from tracking progress, consider using " +
+  "the TodoWrite tool to track progress. Also consider cleaning up the " +
+  "todo list if has become stale and no longer matches what you are " +
+  "working on. Only use it if it's relevant to the current work. This " +
+  "is just a gentle reminder - ignore if not applicable. Make sure " +
+  "that you NEVER mention this reminder to the user";
+
+function stringContent(message: LLMMessage): string {
+  if (typeof message.content === "string") return message.content;
+  // Concatenate text parts only; image parts are irrelevant for scans.
+  return message.content
+    .map((part) => {
+      if (part.type === "text") return part.text;
+      return "";
+    })
+    .join("");
+}
+
+function countAssistantTurnsBetween(
+  history: readonly LLMMessage[],
+  startExclusive: number,
+  endExclusive: number,
+): number {
+  let count = 0;
+  for (let index = startExclusive + 1; index < endExclusive; index += 1) {
+    if (history[index]?.role === "assistant") count += 1;
+  }
+  return count;
+}
+
+export function getTurnsSinceTodoWrite(
+  history: readonly LLMMessage[],
+): number {
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const message = history[index]!;
+    if (message.role !== "assistant") continue;
+    const hadTodoWrite = (message.toolCalls ?? []).some(
+      (call) => call.name === TODO_WRITE_TOOL_NAME,
+    );
+    if (hadTodoWrite) {
+      return countAssistantTurnsBetween(history, index, history.length);
+    }
+  }
+  return Number.POSITIVE_INFINITY;
+}
+
+export function getTurnsSinceLastTodoReminder(
+  history: readonly LLMMessage[],
+): number {
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const message = history[index]!;
+    if (message.role !== "user") continue;
+    const content = stringContent(message);
+    if (content.includes(TODO_REMINDER_HEADER_PREFIX)) {
+      return countAssistantTurnsBetween(history, index, history.length);
+    }
+  }
+  return Number.POSITIVE_INFINITY;
+}
+
+export function getTurnsSinceRecentTaskToolUse(
+  history: readonly LLMMessage[],
+): number {
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const message = history[index]!;
+    if (message.role !== "assistant") continue;
+    const hadTaskCall = (message.toolCalls ?? []).some((call) =>
+      call.name.startsWith("task."),
+    );
+    if (hadTaskCall) {
+      return countAssistantTurnsBetween(history, index, history.length);
+    }
+  }
+  return Number.POSITIVE_INFINITY;
+}
+
+export interface ShouldInjectTodoReminderParams {
+  readonly history: readonly LLMMessage[];
+  readonly activeToolNames: ReadonlySet<string>;
+}
+
+export function shouldInjectTodoReminder(
+  params: ShouldInjectTodoReminderParams,
+): boolean {
+  if (!params.activeToolNames.has(TODO_WRITE_TOOL_NAME)) return false;
+  const turnsSinceTaskUse = getTurnsSinceRecentTaskToolUse(params.history);
+  if (turnsSinceTaskUse < TODO_REMINDER_TURNS_SINCE_WRITE) return false;
+  const turnsSinceWrite = getTurnsSinceTodoWrite(params.history);
+  if (turnsSinceWrite < TODO_REMINDER_TURNS_SINCE_WRITE) return false;
+  const turnsSinceReminder = getTurnsSinceLastTodoReminder(params.history);
+  if (turnsSinceReminder < TODO_REMINDER_TURNS_BETWEEN_REMINDERS) return false;
+  return true;
+}
+
+export function buildTodoReminderMessage(
+  todos: readonly TodoItem[],
+): LLMMessage {
+  const list = todos.length === 0
+    ? ""
+    : "\n\nHere are the existing contents of your todo list:\n\n[" +
+      todos
+        .map((todo, index) =>
+          `${index + 1}. [${todo.status}] ${todo.content}`,
+        )
+        .join("\n") +
+      "]";
+  return {
+    role: "user",
+    content: `<system-reminder>\n${TODO_REMINDER_HEADER}${list}\n</system-reminder>`,
+    runtimeOnly: { mergeBoundary: "user_context" },
+  };
+}

--- a/runtime/src/tools/system/todo-store.test.ts
+++ b/runtime/src/tools/system/todo-store.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryBackend } from "../../memory/in-memory/backend.js";
+import { TodoStore, type TodoItem } from "./todo-store.js";
+
+function makeTodo(
+  overrides: Partial<TodoItem> & { content: string },
+): TodoItem {
+  return {
+    status: "pending",
+    activeForm: `Working on ${overrides.content}`,
+    ...overrides,
+  };
+}
+
+describe("TodoStore", () => {
+  it("returns an empty list for an unknown session", async () => {
+    const store = new TodoStore();
+    const todos = await store.getTodos("session-a");
+    expect(todos).toEqual([]);
+  });
+
+  it("replaces the whole list on setTodos", async () => {
+    const store = new TodoStore();
+    const first: TodoItem[] = [
+      makeTodo({ content: "first" }),
+      makeTodo({ content: "second" }),
+    ];
+    const firstResult = await store.setTodos("session-a", first);
+    expect(firstResult.oldTodos).toEqual([]);
+    expect(firstResult.newTodos).toEqual(first);
+
+    const second: TodoItem[] = [
+      makeTodo({ content: "only", status: "in_progress" }),
+    ];
+    const secondResult = await store.setTodos("session-a", second);
+    expect(secondResult.oldTodos).toEqual(first);
+    expect(secondResult.newTodos).toEqual(second);
+  });
+
+  it("clears the list when every item is marked completed", async () => {
+    const store = new TodoStore();
+    await store.setTodos("session-a", [
+      makeTodo({ content: "one", status: "in_progress" }),
+      makeTodo({ content: "two" }),
+    ]);
+    const result = await store.setTodos("session-a", [
+      makeTodo({ content: "one", status: "completed" }),
+      makeTodo({ content: "two", status: "completed" }),
+    ]);
+    expect(result.newTodos).toEqual([]);
+    expect(await store.getTodos("session-a")).toEqual([]);
+  });
+
+  it("keeps an all-completed list intact only when it is empty", async () => {
+    const store = new TodoStore();
+    const result = await store.setTodos("session-a", []);
+    expect(result.newTodos).toEqual([]);
+  });
+
+  it("isolates todos per session", async () => {
+    const store = new TodoStore();
+    await store.setTodos("session-a", [makeTodo({ content: "a-only" })]);
+    await store.setTodos("session-b", [makeTodo({ content: "b-only" })]);
+    expect((await store.getTodos("session-a"))[0]?.content).toBe("a-only");
+    expect((await store.getTodos("session-b"))[0]?.content).toBe("b-only");
+  });
+
+  it("round-trips through a memory backend", async () => {
+    const backend = new InMemoryBackend();
+    const first = new TodoStore({ memoryBackend: backend });
+    await first.setTodos("session-a", [
+      makeTodo({ content: "persist me", status: "in_progress" }),
+    ]);
+    const second = new TodoStore({ memoryBackend: backend });
+    const reloaded = await second.getTodos("session-a");
+    expect(reloaded).toEqual([
+      makeTodo({ content: "persist me", status: "in_progress" }),
+    ]);
+  });
+
+  it("deletes the backend entry when clearing", async () => {
+    const backend = new InMemoryBackend();
+    const store = new TodoStore({ memoryBackend: backend });
+    await store.setTodos("session-a", [makeTodo({ content: "gone soon" })]);
+    await store.clearTodos("session-a");
+    expect(await backend.get("todo:list:session-a")).toBeUndefined();
+    expect(await store.getTodos("session-a")).toEqual([]);
+  });
+
+  it("discards malformed persisted entries on load", async () => {
+    const backend = new InMemoryBackend();
+    await backend.set("todo:list:session-a", [
+      { content: "valid", status: "pending", activeForm: "Working on valid" },
+      { content: "bad-status", status: "blocked", activeForm: "Ignored" },
+      { content: 42, status: "pending", activeForm: "Ignored" },
+      null,
+    ]);
+    const store = new TodoStore({ memoryBackend: backend });
+    expect(await store.getTodos("session-a")).toEqual([
+      makeTodo({ content: "valid" }),
+    ]);
+  });
+});

--- a/runtime/src/tools/system/todo-store.ts
+++ b/runtime/src/tools/system/todo-store.ts
@@ -1,0 +1,129 @@
+/**
+ * Per-session todo list for the `TodoWrite` tool.
+ *
+ * The `TodoWrite` tool is the model's main-thread progress tracker:
+ * simple 3-state items (`pending` / `in_progress` / `completed`),
+ * position-ordered, no IDs. The model writes the whole list at once;
+ * the runtime persists it per-session so it survives webchat resume.
+ *
+ * This file is deliberately small. The tool's behavior is:
+ *   - Atomic replacement of the whole list (no patches).
+ *   - If every item is `completed`, the store clears the list entirely
+ *     (matches the upstream reference runtime's completion semantic).
+ *   - Reads return an empty array for an unknown session.
+ *
+ * The richer `task.*` tool family (`SessionTaskStore` in `task-tracker.ts`)
+ * stays as the sub-agent orchestration tool with IDs, blocking
+ * relationships, and ownership. Todo items here are intentionally the
+ * model's scratch list for its own work.
+ *
+ * @module
+ */
+
+import type { MemoryBackend } from "../../memory/types.js";
+
+export type TodoStatus = "pending" | "in_progress" | "completed";
+
+export interface TodoItem {
+  readonly content: string;
+  readonly status: TodoStatus;
+  readonly activeForm: string;
+}
+
+export interface TodoWriteResult {
+  readonly oldTodos: readonly TodoItem[];
+  readonly newTodos: readonly TodoItem[];
+}
+
+const TODO_STORE_KEY_PREFIX = "todo:list:";
+
+function todoKey(sessionId: string): string {
+  return `${TODO_STORE_KEY_PREFIX}${sessionId}`;
+}
+
+function cloneTodos(todos: readonly TodoItem[]): TodoItem[] {
+  return todos.map((item) => ({
+    content: item.content,
+    status: item.status,
+    activeForm: item.activeForm,
+  }));
+}
+
+function allCompleted(todos: readonly TodoItem[]): boolean {
+  return todos.length > 0 && todos.every((item) => item.status === "completed");
+}
+
+export interface TodoStoreOptions {
+  readonly memoryBackend?: MemoryBackend;
+}
+
+export class TodoStore {
+  private readonly memoryBackend?: MemoryBackend;
+  private readonly lists = new Map<string, TodoItem[]>();
+
+  constructor(options: TodoStoreOptions = {}) {
+    this.memoryBackend = options.memoryBackend;
+  }
+
+  async getTodos(sessionId: string): Promise<readonly TodoItem[]> {
+    const cached = this.lists.get(sessionId);
+    if (cached) return cloneTodos(cached);
+    if (!this.memoryBackend) return [];
+    const persisted = await this.memoryBackend.get<readonly TodoItem[]>(
+      todoKey(sessionId),
+    );
+    if (!Array.isArray(persisted)) return [];
+    const normalized: TodoItem[] = [];
+    for (const entry of persisted) {
+      if (!entry || typeof entry !== "object") continue;
+      const candidate = entry as Partial<TodoItem>;
+      if (
+        typeof candidate.content !== "string" ||
+        typeof candidate.activeForm !== "string"
+      ) {
+        continue;
+      }
+      if (
+        candidate.status !== "pending" &&
+        candidate.status !== "in_progress" &&
+        candidate.status !== "completed"
+      ) {
+        continue;
+      }
+      normalized.push({
+        content: candidate.content,
+        status: candidate.status,
+        activeForm: candidate.activeForm,
+      });
+    }
+    this.lists.set(sessionId, normalized);
+    return cloneTodos(normalized);
+  }
+
+  async setTodos(
+    sessionId: string,
+    todos: readonly TodoItem[],
+  ): Promise<TodoWriteResult> {
+    const oldTodos = await this.getTodos(sessionId);
+    const next = allCompleted(todos) ? [] : cloneTodos(todos);
+    this.lists.set(sessionId, next);
+    if (this.memoryBackend) {
+      if (next.length === 0) {
+        await this.memoryBackend.delete(todoKey(sessionId));
+      } else {
+        await this.memoryBackend.set(todoKey(sessionId), next);
+      }
+    }
+    return {
+      oldTodos,
+      newTodos: cloneTodos(next),
+    };
+  }
+
+  async clearTodos(sessionId: string): Promise<void> {
+    this.lists.delete(sessionId);
+    if (this.memoryBackend) {
+      await this.memoryBackend.delete(todoKey(sessionId));
+    }
+  }
+}

--- a/runtime/src/tools/system/todo-write.test.ts
+++ b/runtime/src/tools/system/todo-write.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { TodoStore, type TodoItem } from "./todo-store.js";
+import {
+  TODO_WRITE_SESSION_ARG,
+  TODO_WRITE_TOOL_NAME,
+  createTodoWriteTool,
+} from "./todo-write.js";
+
+const VERBATIM_SUCCESS_TEXT =
+  "Todos have been modified successfully. Ensure that you continue to " +
+  "use the todo list to track your progress. Please proceed with the " +
+  "current tasks if applicable";
+
+function parseResult(content: string): Record<string, unknown> {
+  return JSON.parse(content) as Record<string, unknown>;
+}
+
+function makeTodo(content: string, overrides: Partial<TodoItem> = {}): TodoItem {
+  return {
+    content,
+    status: "pending",
+    activeForm: `Working on ${content}`,
+    ...overrides,
+  };
+}
+
+describe("TodoWrite tool", () => {
+  it("exposes the expected name and schema", () => {
+    const tool = createTodoWriteTool(new TodoStore());
+    expect(tool.name).toBe(TODO_WRITE_TOOL_NAME);
+    expect(tool.description).toMatch(/track multi-step work/);
+    const schema = tool.inputSchema as {
+      required?: readonly string[];
+      additionalProperties?: boolean;
+    };
+    expect(schema.required).toEqual(["todos"]);
+    expect(schema.additionalProperties).toBe(false);
+  });
+
+  it("returns the verbatim upstream success text on a valid write", async () => {
+    const tool = createTodoWriteTool(new TodoStore());
+    const result = await tool.execute({
+      [TODO_WRITE_SESSION_ARG]: "session-a",
+      todos: [makeTodo("first")],
+    });
+    expect(result.isError).toBeUndefined();
+    const payload = parseResult(result.content);
+    expect(payload.message).toBe(VERBATIM_SUCCESS_TEXT);
+    expect(payload.oldTodos).toEqual([]);
+    expect(payload.newTodos).toEqual([makeTodo("first")]);
+  });
+
+  it("replaces the full list atomically on subsequent writes", async () => {
+    const store = new TodoStore();
+    const tool = createTodoWriteTool(store);
+    await tool.execute({
+      [TODO_WRITE_SESSION_ARG]: "session-a",
+      todos: [makeTodo("one"), makeTodo("two")],
+    });
+    const result = await tool.execute({
+      [TODO_WRITE_SESSION_ARG]: "session-a",
+      todos: [makeTodo("only", { status: "in_progress" })],
+    });
+    const payload = parseResult(result.content);
+    expect(payload.newTodos).toEqual([
+      makeTodo("only", { status: "in_progress" }),
+    ]);
+  });
+
+  it("clears the list when every item is completed", async () => {
+    const store = new TodoStore();
+    const tool = createTodoWriteTool(store);
+    await tool.execute({
+      [TODO_WRITE_SESSION_ARG]: "session-a",
+      todos: [
+        makeTodo("one", { status: "in_progress" }),
+        makeTodo("two"),
+      ],
+    });
+    const result = await tool.execute({
+      [TODO_WRITE_SESSION_ARG]: "session-a",
+      todos: [
+        makeTodo("one", { status: "completed" }),
+        makeTodo("two", { status: "completed" }),
+      ],
+    });
+    const payload = parseResult(result.content);
+    expect(payload.newTodos).toEqual([]);
+  });
+
+  it("rejects an invalid status", async () => {
+    const tool = createTodoWriteTool(new TodoStore());
+    const result = await tool.execute({
+      [TODO_WRITE_SESSION_ARG]: "session-a",
+      todos: [{ content: "bad", status: "blocked", activeForm: "Ignored" }],
+    });
+    expect(result.isError).toBe(true);
+    expect(parseResult(result.content).error).toMatch(/status must be one of/);
+  });
+
+  it("rejects extra keys on a todo item", async () => {
+    const tool = createTodoWriteTool(new TodoStore());
+    const result = await tool.execute({
+      [TODO_WRITE_SESSION_ARG]: "session-a",
+      todos: [
+        {
+          content: "ok",
+          status: "pending",
+          activeForm: "Working on ok",
+          priority: "high",
+        },
+      ],
+    });
+    expect(result.isError).toBe(true);
+    expect(parseResult(result.content).error).toMatch(/unexpected key/);
+  });
+
+  it("rejects a missing session context", async () => {
+    const tool = createTodoWriteTool(new TodoStore());
+    const result = await tool.execute({
+      todos: [makeTodo("solo")],
+    });
+    expect(result.isError).toBe(true);
+    expect(parseResult(result.content).error).toMatch(/requires a session scope/);
+  });
+
+  it("accepts an empty list (matches upstream allow-empty semantic)", async () => {
+    const tool = createTodoWriteTool(new TodoStore());
+    const result = await tool.execute({
+      [TODO_WRITE_SESSION_ARG]: "session-a",
+      todos: [],
+    });
+    expect(result.isError).toBeUndefined();
+    const payload = parseResult(result.content);
+    expect(payload.newTodos).toEqual([]);
+  });
+});

--- a/runtime/src/tools/system/todo-write.ts
+++ b/runtime/src/tools/system/todo-write.ts
@@ -1,0 +1,180 @@
+/**
+ * `TodoWrite` tool — model-driven main-thread progress tracker.
+ *
+ * Contract:
+ *   - Input: `{ todos: TodoItem[] }` where each item is
+ *     `{ content: string, status: "pending" | "in_progress" | "completed",
+ *        activeForm: string }`. Position-ordered. No IDs.
+ *   - The call atomically replaces the whole list. Not a patch.
+ *   - If every item is `completed`, the store clears the list entirely.
+ *   - Output is the verbatim upstream success text:
+ *     `"Todos have been modified successfully. Ensure that you continue
+ *       to use the todo list to track your progress. Please proceed with
+ *       the current tasks if applicable"`.
+ *
+ * The tool description and result text are part of the model contract
+ * and are reproduced verbatim from the upstream reference runtime so a
+ * model trained against upstream behavior responds the same way here.
+ *
+ * Distinct from AgenC's `task.*` tool family, which handles subagent
+ * orchestration with IDs, blocking relationships, and ownership.
+ * TodoWrite is the lightweight main-thread progress tracker.
+ *
+ * @module
+ */
+
+import type { Tool, ToolResult } from "../types.js";
+import { safeStringify } from "../types.js";
+import type { TodoItem, TodoStatus } from "./todo-store.js";
+import { TodoStore } from "./todo-store.js";
+
+export const TODO_WRITE_TOOL_NAME = "TodoWrite";
+
+export const TODO_WRITE_SESSION_ARG = "__agencTodoSessionId";
+
+const TODO_WRITE_DESCRIPTION =
+  "Use TodoWrite to track multi-step work on the main conversation " +
+  "thread. Replaces the whole todo list atomically. Statuses are " +
+  "`pending`, `in_progress`, `completed` — exactly one item should be " +
+  "`in_progress` at a time. `activeForm` is a present-continuous label " +
+  "(e.g. \"Running tests\"). When every item is marked `completed`, the " +
+  "runtime clears the list. " +
+  "Distinct from the `task.*` tool family, which is for delegating work " +
+  "to subagents with IDs, blocking relationships, and ownership. Use " +
+  "TodoWrite for your own progress; use `task.create` when spawning " +
+  "child agents or managing cross-agent dependencies.";
+
+const TODO_WRITE_SUCCESS_TEXT =
+  "Todos have been modified successfully. Ensure that you continue to " +
+  "use the todo list to track your progress. Please proceed with the " +
+  "current tasks if applicable";
+
+function isTodoStatus(value: unknown): value is TodoStatus {
+  return (
+    value === "pending" || value === "in_progress" || value === "completed"
+  );
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function parseTodos(raw: unknown): TodoItem[] | { error: string } {
+  if (!Array.isArray(raw)) {
+    return { error: "todos must be an array" };
+  }
+  const out: TodoItem[] = [];
+  for (let index = 0; index < raw.length; index += 1) {
+    const entry = raw[index];
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return { error: `todos[${index}] must be an object` };
+    }
+    const candidate = entry as Record<string, unknown>;
+    if (!isNonEmptyString(candidate.content)) {
+      return { error: `todos[${index}].content must be a non-empty string` };
+    }
+    if (!isNonEmptyString(candidate.activeForm)) {
+      return {
+        error: `todos[${index}].activeForm must be a non-empty string`,
+      };
+    }
+    if (!isTodoStatus(candidate.status)) {
+      return {
+        error:
+          `todos[${index}].status must be one of "pending", "in_progress", ` +
+          `"completed"`,
+      };
+    }
+    // Reject extra keys to match upstream's `z.strictObject` input schema.
+    for (const key of Object.keys(candidate)) {
+      if (key !== "content" && key !== "activeForm" && key !== "status") {
+        return { error: `todos[${index}] has unexpected key "${key}"` };
+      }
+    }
+    out.push({
+      content: candidate.content,
+      activeForm: candidate.activeForm,
+      status: candidate.status,
+    });
+  }
+  return out;
+}
+
+function resolveSessionId(args: Record<string, unknown>): string | undefined {
+  const value = args[TODO_WRITE_SESSION_ARG];
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+  return undefined;
+}
+
+function errorResult(message: string): ToolResult {
+  return { content: safeStringify({ error: message }), isError: true };
+}
+
+export function createTodoWriteTool(store: TodoStore): Tool {
+  return {
+    name: TODO_WRITE_TOOL_NAME,
+    description: TODO_WRITE_DESCRIPTION,
+    inputSchema: {
+      type: "object",
+      properties: {
+        todos: {
+          type: "array",
+          description: "The updated todo list.",
+          items: {
+            type: "object",
+            properties: {
+              content: {
+                type: "string",
+                description: "The todo item text (imperative form).",
+              },
+              status: {
+                type: "string",
+                enum: ["pending", "in_progress", "completed"],
+                description: "Current state of the item.",
+              },
+              activeForm: {
+                type: "string",
+                description:
+                  "Present-continuous form shown while the item is " +
+                  "in_progress (e.g. \"Running tests\").",
+              },
+            },
+            required: ["content", "status", "activeForm"],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ["todos"],
+      additionalProperties: false,
+    },
+    metadata: {
+      family: "workflow",
+      source: "builtin",
+      mutating: true,
+      hiddenByDefault: false,
+    },
+    async execute(args) {
+      const sessionId = resolveSessionId(args);
+      if (!sessionId) {
+        return errorResult(
+          "TodoWrite requires a session scope. The runtime injects " +
+            "it via the tool handler context.",
+        );
+      }
+      const parsed = parseTodos(args.todos);
+      if (!Array.isArray(parsed)) {
+        return errorResult(parsed.error);
+      }
+      const result = await store.setTodos(sessionId, parsed);
+      return {
+        content: safeStringify({
+          message: TODO_WRITE_SUCCESS_TEXT,
+          oldTodos: result.oldTodos,
+          newTodos: result.newTodos,
+        }),
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Ports two mechanisms from the upstream reference runtime into AgenC so long-horizon runs have model-driven progress tracking:

1. **`TodoWrite` tool** — the model writes its own todo list. 3-state schema (\`pending\` / \`in_progress\` / \`completed\`), position-ordered, no IDs. Atomic whole-list replacement; when every item is \`completed\` the store clears the list. Per-session, in-memory + optional \`MemoryBackend\` persistence.
2. **10-turn todo reminder** — when the model stops calling \`TodoWrite\` for 10+ turns AND 10+ turns have passed since the last reminder, inject a passive user-role \`<system-reminder>\` listing the current todos. Verbatim upstream wording. Scan-derived counters (no new persisted state); compaction-, crash-, and resume-safe.

Addresses the observed 205-cycle stat-polling loop on \`bg-mo33ik9s-ovzcxl\` (2026-04-17) where the model had no progress-tracking affordance and drifted into repetitive verification.

## Contracts reproduced verbatim

All three of the following are model contract — reproduced byte-for-byte from upstream so a model trained against upstream behavior responds identically:

- **TodoWrite tool_result success text**: \`"Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable"\`.
- **Reminder header text**: \`"The TodoWrite tool hasn't been used recently. If you're working on tasks that would benefit from tracking progress…NEVER mention this reminder to the user"\`.
- **Reminder list rendering**: items joined by newlines inside square brackets.
- **Wire-level \`<system-reminder>...</system-reminder>\` tag wrapping** — these are part of the prompt the model sees, not a UI artifact.

## Scope decisions

- **Plan mode deferred** to a follow-up PR. The observed incident is a progress-tracking problem; plan mode is orthogonal and architecturally larger (disk persistence, slug generation, approval gate for background runs).
- **\`task.*\` tools kept untouched.** They remain the sub-agent orchestration surface (IDs, blocking relationships, ownership). TodoWrite is the lightweight main-thread tool.
- **No forced tool routing.** System prompt text clarifies the intended separation; coexistence via suppression (below).

## Divergences from upstream, each documented

1. **No \`verificationNudgeNeeded\` output field.** AgenC has no verification agent; the workflow tracker is a separate mechanism.
2. **\`task.*\` recent-use suppression.** AgenC-specific: if \`task.create\` or \`task.update\` was called in the last 10 assistant turns, the TodoWrite reminder suppresses. Prevents nagging the model toward TodoWrite while it's using the richer sub-agent tool. Upstream has no \`task.*\` family so no upstream precedent.
3. **Single shared \`collectAttachments\` helper** called from both webchat (\`daemon-webchat-turn.ts\`) and background-run supervisor (\`prepareCycleContext\`). Guarantees behavior parity across surfaces; upstream has one unified \`getAttachments\` pipeline for the same reason.

## Commits

1. \`32081ca feat(runtime/tools): add TodoWrite tool and per-session TodoStore\` — new tool + store + tests. Registered in tool registry. Verbatim upstream tool_result text. No reminder wiring yet.
2. \`4dc174f feat(runtime/llm): add scan-derived 10-turn TodoWrite reminder\` — pure-function counter derivation + should-inject logic + message builder + tests. Scan-derived (no persisted fields), so compaction/crash/resume all work unchanged.
3. \`69a7e1b feat(runtime): wire shared collectAttachments into both chat surfaces\` — \`attachment-injection.ts\` helper; single call in \`prepareCycleContext\` and in \`daemon-webchat-turn.ts\` / \`daemon-text-channel-turn.ts\`.

## Test plan

- [x] \`runtime && npm run typecheck && npm run build\` — clean.
- [x] New unit tests (40 total):
  - \`todo-store.test.ts\` (8): session isolation, memory-backend round-trip, all-completed clears list, malformed-entry discard on load.
  - \`todo-write.test.ts\` (8): verbatim success text, atomic replace, all-completed clears, invalid-status rejected, extra-keys rejected (\`additionalProperties: false\`), missing session context rejected, empty list allowed.
  - \`todo-reminder.test.ts\` (18): scan correctness for each counter (Infinity, direct hit, intervening turns), all suppression rules, threshold boundaries, exact header + list formatting, \`runtimeOnly.mergeBoundary\` marker.
  - \`attachment-injection.test.ts\` (6): shared invariance, tool-availability suppression, \`task.*\` recent-use suppression, fire-on-first-turn (matches upstream).
- [ ] End-to-end smoke: start a fresh background run with a multi-step objective. Expect the actor to call TodoWrite within ~10 cycles; reminder fires at cycle 11 if it doesn't.

## Base branch

Based on \`refactor/stateless-transport\` (PR #441). This PR ships on top of the stateless-transport baseline. Pre-existing stale stateful-test failures on that branch (\`providerContinuation\` assertions, stateful fallback warnings, stateful session continuity metadata) are not caused by this PR and are scheduled for a follow-up test-cleanup commit on the base branch.

## Deferred follow-ups

- **Plan mode** (model-initiated \`EnterPlanMode\` / \`ExitPlanMode\` tools + \`~/.agenc/plans/<slug>.md\` persistence + 5-turn re-attachment). Separate PR.
- **Stale-test cleanup on the stateless-transport base** — tests that exercised deleted stateful APIs.
- **TUI surfacing of the current todo list** in the watch TUI sidebar. Separate TUI PR.