### PR TITLE
feat(runtime): port full tool-description prompts and add task_reminder + verify_reminder

### DIFF
--- a/runtime/src/gateway/background-run-supervisor-types.ts
+++ b/runtime/src/gateway/background-run-supervisor-types.ts
@@ -237,6 +237,18 @@ export interface BackgroundRunSupervisorConfig {
   ) => Promise<
     readonly import("../tools/system/todo-store.js").TodoItem[]
   >;
+  /**
+   * Optional callback returning the session's current task list. Used by
+   * the shared attachment-injection hook to render the `task_reminder`.
+   * Returns the minimal `ReminderTaskView` shape (`id`, `subject`,
+   * `status`) so both `Task` (TaskStore) and `SessionTask` values are
+   * structurally assignable.
+   */
+  readonly readTasksForSession?: (
+    sessionId: string,
+  ) => Promise<
+    readonly import("../llm/task-reminder.js").ReminderTaskView[]
+  >;
   readonly isSessionBusy?: (sessionId: string) => boolean;
   readonly onStatus?: (
     sessionId: string,

--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -585,6 +585,7 @@ export class BackgroundRunSupervisor {
   private readonly resolveAdvertisedToolNames?: BackgroundRunSupervisorConfig["resolveAdvertisedToolNames"];
   private readonly seedHistoryForSession?: BackgroundRunSupervisorConfig["seedHistoryForSession"];
   private readonly readTodosForSession?: BackgroundRunSupervisorConfig["readTodosForSession"];
+  private readonly readTasksForSession?: BackgroundRunSupervisorConfig["readTasksForSession"];
   private readonly isSessionBusy?: BackgroundRunSupervisorConfig["isSessionBusy"];
   private readonly onStatus?: BackgroundRunSupervisorConfig["onStatus"];
   private readonly publishUpdate: BackgroundRunSupervisorConfig["publishUpdate"];
@@ -626,6 +627,7 @@ export class BackgroundRunSupervisor {
     this.resolveAdvertisedToolNames = config.resolveAdvertisedToolNames;
     this.seedHistoryForSession = config.seedHistoryForSession;
     this.readTodosForSession = config.readTodosForSession;
+    this.readTasksForSession = config.readTasksForSession;
     this.isSessionBusy = config.isSessionBusy;
     this.onStatus = config.onStatus;
     this.publishUpdate = config.publishUpdate;
@@ -4052,10 +4054,14 @@ export class BackgroundRunSupervisor {
     const todos = this.readTodosForSession
       ? await this.readTodosForSession(sessionId)
       : [];
+    const tasks = this.readTasksForSession
+      ? await this.readTasksForSession(sessionId)
+      : [];
     const attachments = collectAttachments({
       history: run.internalHistory,
       activeToolNames,
       todos,
+      tasks,
     });
     for (const attachment of attachments.messages) {
       run.internalHistory.push(attachment);

--- a/runtime/src/gateway/daemon-text-channel-turn.ts
+++ b/runtime/src/gateway/daemon-text-channel-turn.ts
@@ -227,6 +227,11 @@ interface ExecuteTextChannelTurnParams {
   ) => Promise<
     readonly import("../tools/system/todo-store.js").TodoItem[]
   >;
+  readonly readTasksForSession?: (
+    sessionId: string,
+  ) => Promise<
+    readonly import("../llm/task-reminder.js").ReminderTaskView[]
+  >;
 }
 
 export async function executeTextChannelTurn(
@@ -320,10 +325,14 @@ export async function executeTextChannelTurn(
   const todosForAttachment = params.readTodosForSession
     ? await params.readTodosForSession(msg.sessionId)
     : [];
+  const tasksForAttachment = params.readTasksForSession
+    ? await params.readTasksForSession(msg.sessionId)
+    : [];
   const runtimeAttachments = collectAttachments({
     history: historyBeforeAttachments,
     activeToolNames: new Set<string>(advertisedToolNames),
     todos: todosForAttachment,
+    tasks: tasksForAttachment,
   });
   const effectiveHistory =
     runtimeAttachments.messages.length > 0

--- a/runtime/src/gateway/daemon-webchat-turn.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.ts
@@ -139,6 +139,11 @@ interface ExecuteWebChatConversationTurnParams {
   ) => Promise<
     readonly import("../tools/system/todo-store.js").TodoItem[]
   >;
+  readonly readTasksForSession?: (
+    sessionId: string,
+  ) => Promise<
+    readonly import("../llm/task-reminder.js").ReminderTaskView[]
+  >;
   readonly maybeStartBackgroundRun?: (params: {
     readonly session: Session;
     readonly objective: string;
@@ -417,10 +422,14 @@ export async function executeWebChatConversationTurn(
     const todosForAttachment = params.readTodosForSession
       ? await params.readTodosForSession(msg.sessionId)
       : [];
+    const tasksForAttachment = params.readTasksForSession
+      ? await params.readTasksForSession(msg.sessionId)
+      : [];
     const runtimeAttachments = collectAttachments({
       history: historyBeforeAttachments,
       activeToolNames: new Set<string>(advertisedToolNames),
       todos: todosForAttachment,
+      tasks: tasksForAttachment,
     });
     const effectiveHistory =
       runtimeAttachments.messages.length > 0

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -2527,6 +2527,16 @@ export class DaemonManager {
           sessionMgr.get(sessionId)?.history ?? [],
         readTodosForSession: async (sessionId) =>
           this._todoStore ? await this._todoStore.getTodos(sessionId) : [],
+        readTasksForSession: async (sessionId) => {
+          const store = this._taskTrackerStore;
+          if (!store) return [];
+          const tasks = await store.listTasks(sessionId);
+          return tasks.map((task) => ({
+            id: task.id,
+            subject: task.subject,
+            status: task.status,
+          }));
+        },
         isSessionBusy: (sessionId) =>
           this._foregroundSessionLocks.has(sessionId),
         onStatus: (sessionId, payload) => {
@@ -7560,6 +7570,16 @@ export class DaemonManager {
         taskStore: this._taskTrackerStore,
         readTodosForSession: async (sessionId) =>
           this._todoStore ? await this._todoStore.getTodos(sessionId) : [],
+        readTasksForSession: async (sessionId) => {
+          const store = this._taskTrackerStore;
+          if (!store) return [];
+          const tasks = await store.listTasks(sessionId);
+          return tasks.map((task) => ({
+            id: task.id,
+            subject: task.subject,
+            status: task.status,
+          }));
+        },
         workerManager,
         maybeStartBackgroundRun,
         onSubagentSynthesis: (result) => {

--- a/runtime/src/llm/attachment-injection.test.ts
+++ b/runtime/src/llm/attachment-injection.test.ts
@@ -165,6 +165,81 @@ describe("collectAttachments", () => {
     expect(todoIdx).toBeLessThan(taskIdx);
   });
 
+  it("emits the verify_reminder after 3+ mutating edits without a verifier spawn", () => {
+    const history: LLMMessage[] = [
+      ...buildStaleHistory(),
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { id: "w1", name: "system.writeFile", arguments: "{}" },
+        ],
+      },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { id: "w2", name: "system.editFile", arguments: "{}" },
+        ],
+      },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { id: "w3", name: "system.writeFile", arguments: "{}" },
+        ],
+      },
+    ];
+    const result = collectAttachments({
+      history,
+      activeToolNames: new Set([TODO_WRITE_TOOL_NAME, "execute_with_agent"]),
+      todos: [],
+      tasks: [],
+    });
+    const verifyMsg = result.messages.find((m) =>
+      (m.content as string).includes("You have made unverified file edits"),
+    );
+    expect(verifyMsg).toBeDefined();
+  });
+
+  it("does not emit verify_reminder when execute_with_agent is not available", () => {
+    const history: LLMMessage[] = [
+      ...buildStaleHistory(),
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { id: "w1", name: "system.writeFile", arguments: "{}" },
+        ],
+      },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { id: "w2", name: "system.writeFile", arguments: "{}" },
+        ],
+      },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { id: "w3", name: "system.writeFile", arguments: "{}" },
+        ],
+      },
+    ];
+    const result = collectAttachments({
+      history,
+      activeToolNames: new Set([TODO_WRITE_TOOL_NAME]),
+      todos: [],
+      tasks: [],
+    });
+    expect(
+      result.messages.some((m) =>
+        (m.content as string).includes("You have made unverified file edits"),
+      ),
+    ).toBe(false);
+  });
+
   it("returns the same result for identical inputs regardless of caller", () => {
     const ctx = {
       history: buildStaleHistory(),

--- a/runtime/src/llm/attachment-injection.test.ts
+++ b/runtime/src/llm/attachment-injection.test.ts
@@ -4,6 +4,7 @@ import type { TodoItem } from "../tools/system/todo-store.js";
 import { TODO_WRITE_TOOL_NAME } from "../tools/system/todo-write.js";
 import { collectAttachments } from "./attachment-injection.js";
 import { TODO_REMINDER_TURNS_SINCE_WRITE } from "./todo-reminder.js";
+import type { ReminderTaskView } from "./task-reminder.js";
 
 function userText(content: string): LLMMessage {
   return { role: "user", content };
@@ -40,28 +41,32 @@ const SAMPLE_TODOS: TodoItem[] = [
   { content: "one", status: "pending", activeForm: "Working on one" },
 ];
 
+const SAMPLE_TASKS: ReminderTaskView[] = [
+  { id: "t-1", subject: "Example task", status: "pending" },
+];
+
 describe("collectAttachments", () => {
   it("returns an empty message list when TodoWrite is not in the active toolset", () => {
     const result = collectAttachments({
       history: [],
       activeToolNames: new Set<string>(),
       todos: [],
+      tasks: [],
     });
     expect(result.messages).toEqual([]);
   });
 
   it("fires the reminder on empty history when TodoWrite is available (matches upstream)", () => {
-    // With no history: turnsSinceTodoWrite = Infinity,
-    // turnsSinceLastReminder = Infinity, turnsSinceRecentTaskToolUse
-    // = Infinity. All suppression checks pass. Upstream behaves the
-    // same: the reminder exists to nudge the model toward using the
-    // tool at all, not only to surface a stale list.
     const result = collectAttachments({
       history: [],
       activeToolNames: new Set([TODO_WRITE_TOOL_NAME]),
       todos: [],
+      tasks: [],
     });
-    expect(result.messages).toHaveLength(1);
+    expect(result.messages.length).toBeGreaterThanOrEqual(1);
+    expect(
+      (result.messages[0]!.content as string).includes("TodoWrite tool"),
+    ).toBe(true);
   });
 
   it("returns the TodoWrite reminder when its trigger conditions hold", () => {
@@ -69,46 +74,103 @@ describe("collectAttachments", () => {
       history: buildStaleHistory(),
       activeToolNames: new Set([TODO_WRITE_TOOL_NAME]),
       todos: SAMPLE_TODOS,
+      tasks: [],
     });
-    expect(result.messages).toHaveLength(1);
-    const message = result.messages[0]!;
-    expect(message.role).toBe("user");
-    expect(typeof message.content).toBe("string");
-    expect(message.content as string).toContain(
-      "The TodoWrite tool hasn't been used recently",
+    const todoMsg = result.messages.find((m) =>
+      (m.content as string).includes("The TodoWrite tool hasn't been used"),
     );
+    expect(todoMsg).toBeDefined();
   });
 
-  it("suppresses the reminder when TodoWrite is not in the active toolset", () => {
+  it("suppresses the TodoWrite reminder when TodoWrite is not in the active toolset", () => {
     const result = collectAttachments({
       history: buildStaleHistory(),
       activeToolNames: new Set<string>(),
       todos: SAMPLE_TODOS,
+      tasks: [],
     });
-    expect(result.messages).toEqual([]);
+    expect(
+      result.messages.some((m) =>
+        (m.content as string).includes("TodoWrite tool hasn't been used"),
+      ),
+    ).toBe(false);
   });
 
-  it("suppresses the reminder when task.* was used recently", () => {
+  it("does NOT suppress the TodoWrite reminder based on recent task.* use (independent sibling reminder)", () => {
     const history: LLMMessage[] = [
       userText("go"),
       assistantToolCall("task.create"),
-      assistantText("a1"),
+      ...Array.from({ length: TODO_REMINDER_TURNS_SINCE_WRITE + 1 }, (_, i) =>
+        assistantText(`a${i}`),
+      ),
     ];
     const result = collectAttachments({
       history,
       activeToolNames: new Set([TODO_WRITE_TOOL_NAME]),
       todos: SAMPLE_TODOS,
+      tasks: [],
     });
-    expect(result.messages).toEqual([]);
+    expect(
+      result.messages.some((m) =>
+        (m.content as string).includes("TodoWrite tool hasn't been used"),
+      ),
+    ).toBe(true);
+  });
+
+  it("emits the task_reminder when task.update is available and task.* has been stale for 10+ turns", () => {
+    const result = collectAttachments({
+      history: buildStaleHistory(),
+      activeToolNames: new Set([TODO_WRITE_TOOL_NAME, "task.update"]),
+      todos: [],
+      tasks: SAMPLE_TASKS,
+    });
+    const taskMsg = result.messages.find((m) =>
+      (m.content as string).includes("The task tools haven't been used"),
+    );
+    expect(taskMsg).toBeDefined();
+    expect((taskMsg!.content as string)).toContain("#t-1. [pending] Example task");
+  });
+
+  it("emits both reminders on the same turn when both triggers fire", () => {
+    const result = collectAttachments({
+      history: buildStaleHistory(),
+      activeToolNames: new Set([TODO_WRITE_TOOL_NAME, "task.update"]),
+      todos: SAMPLE_TODOS,
+      tasks: SAMPLE_TASKS,
+    });
+    const kinds = result.messages.map((m) => m.content as string);
+    expect(
+      kinds.some((c) => c.includes("TodoWrite tool hasn't been used")),
+    ).toBe(true);
+    expect(
+      kinds.some((c) => c.includes("task tools haven't been used")),
+    ).toBe(true);
+  });
+
+  it("preserves upstream priority: todo_reminder before task_reminder", () => {
+    const result = collectAttachments({
+      history: buildStaleHistory(),
+      activeToolNames: new Set([TODO_WRITE_TOOL_NAME, "task.update"]),
+      todos: SAMPLE_TODOS,
+      tasks: SAMPLE_TASKS,
+    });
+    const todoIdx = result.messages.findIndex((m) =>
+      (m.content as string).includes("TodoWrite"),
+    );
+    const taskIdx = result.messages.findIndex((m) =>
+      (m.content as string).includes("task tools haven't been used"),
+    );
+    expect(todoIdx).toBeGreaterThanOrEqual(0);
+    expect(taskIdx).toBeGreaterThanOrEqual(0);
+    expect(todoIdx).toBeLessThan(taskIdx);
   });
 
   it("returns the same result for identical inputs regardless of caller", () => {
-    // This property is what lets both webchat and background paths
-    // share the hook without drifting.
     const ctx = {
       history: buildStaleHistory(),
       activeToolNames: new Set([TODO_WRITE_TOOL_NAME]),
       todos: SAMPLE_TODOS,
+      tasks: [],
     };
     const first = collectAttachments(ctx);
     const second = collectAttachments(ctx);

--- a/runtime/src/llm/attachment-injection.ts
+++ b/runtime/src/llm/attachment-injection.ts
@@ -9,10 +9,13 @@
  * shared `getAttachments` pipeline; having two independent hooks
  * here would create drift between interactive and background paths.
  *
- * Today the module emits at most one message: the TodoWrite reminder
- * from `todo-reminder.ts`. Future attachments (plan-mode
- * re-attachment, other runtime reminders) land here in the same
- * priority order the upstream runtime uses.
+ * Emitted reminders, in upstream priority order:
+ *   1. `todo_reminder`  — stale TodoWrite list (see `todo-reminder.ts`).
+ *   2. `task_reminder`  — stale task.create/task.update (see
+ *                          `task-reminder.ts`).
+ *
+ * Both reminders can fire on the same turn. Upstream runs them
+ * independently with no mutual suppression, and AgenC matches that.
  *
  * @module
  */
@@ -23,11 +26,17 @@ import {
   buildTodoReminderMessage,
   shouldInjectTodoReminder,
 } from "./todo-reminder.js";
+import {
+  buildTaskReminderMessage,
+  shouldInjectTaskReminder,
+  type ReminderTaskView,
+} from "./task-reminder.js";
 
 export interface AttachmentContext {
   readonly history: readonly LLMMessage[];
   readonly activeToolNames: ReadonlySet<string>;
   readonly todos: readonly TodoItem[];
+  readonly tasks: readonly ReminderTaskView[];
 }
 
 export interface AttachmentInjectionResult {
@@ -45,6 +54,14 @@ export function collectAttachments(
     })
   ) {
     messages.push(buildTodoReminderMessage(ctx.todos));
+  }
+  if (
+    shouldInjectTaskReminder({
+      history: ctx.history,
+      activeToolNames: ctx.activeToolNames,
+    })
+  ) {
+    messages.push(buildTaskReminderMessage(ctx.tasks));
   }
   return { messages };
 }

--- a/runtime/src/llm/attachment-injection.ts
+++ b/runtime/src/llm/attachment-injection.ts
@@ -10,12 +10,16 @@
  * here would create drift between interactive and background paths.
  *
  * Emitted reminders, in upstream priority order:
- *   1. `todo_reminder`  — stale TodoWrite list (see `todo-reminder.ts`).
- *   2. `task_reminder`  — stale task.create/task.update (see
- *                          `task-reminder.ts`).
+ *   1. `todo_reminder`   — stale TodoWrite list (`todo-reminder.ts`).
+ *   2. `task_reminder`   — stale task.create/task.update (`task-reminder.ts`).
+ *   3. `verify_reminder` — cumulative unverified edits since the most
+ *                           recent verifier spawn (`verify-reminder.ts`).
+ *                           Plan-mode-less adaptation of the upstream
+ *                           `verify_plan_reminder`.
  *
- * Both reminders can fire on the same turn. Upstream runs them
- * independently with no mutual suppression, and AgenC matches that.
+ * All three reminders can fire on the same turn. They are independent
+ * by design — each one anchors on a different signal, so a single-
+ * counter deadlock cannot suppress all of them at once.
  *
  * @module
  */
@@ -31,6 +35,10 @@ import {
   shouldInjectTaskReminder,
   type ReminderTaskView,
 } from "./task-reminder.js";
+import {
+  buildVerifyReminderMessage,
+  shouldInjectVerifyReminder,
+} from "./verify-reminder.js";
 
 export interface AttachmentContext {
   readonly history: readonly LLMMessage[];
@@ -62,6 +70,14 @@ export function collectAttachments(
     })
   ) {
     messages.push(buildTaskReminderMessage(ctx.tasks));
+  }
+  if (
+    shouldInjectVerifyReminder({
+      history: ctx.history,
+      activeToolNames: ctx.activeToolNames,
+    })
+  ) {
+    messages.push(buildVerifyReminderMessage());
   }
   return { messages };
 }

--- a/runtime/src/llm/task-reminder.test.ts
+++ b/runtime/src/llm/task-reminder.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+import type { LLMMessage } from "./types.js";
+import {
+  TASK_REMINDER_HEADER_PREFIX,
+  TASK_REMINDER_TURNS_BETWEEN_REMINDERS,
+  TASK_REMINDER_TURNS_SINCE_UPDATE,
+  buildTaskReminderMessage,
+  getTurnsSinceLastTaskReminder,
+  getTurnsSinceTaskManagement,
+  shouldInjectTaskReminder,
+  type ReminderTaskView,
+} from "./task-reminder.js";
+
+function assistantText(content: string): LLMMessage {
+  return { role: "assistant", content };
+}
+
+function userText(content: string): LLMMessage {
+  return { role: "user", content };
+}
+
+function assistantToolCall(toolName: string): LLMMessage {
+  return {
+    role: "assistant",
+    content: "",
+    toolCalls: [
+      { id: `call-${toolName}`, name: toolName, arguments: "{}" },
+    ],
+  };
+}
+
+function buildHistoryWithAssistantTurns(n: number): LLMMessage[] {
+  const history: LLMMessage[] = [];
+  for (let i = 0; i < n; i += 1) {
+    history.push(userText(`user-${i}`));
+    history.push(assistantText(`asst-${i}`));
+  }
+  return history;
+}
+
+describe("getTurnsSinceTaskManagement", () => {
+  it("returns Infinity when no task management call has been made", () => {
+    expect(
+      getTurnsSinceTaskManagement(buildHistoryWithAssistantTurns(5)),
+    ).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("counts assistant turns since the last task.create call", () => {
+    const history: LLMMessage[] = [
+      assistantToolCall("task.create"),
+      assistantText("one"),
+      assistantText("two"),
+      assistantText("three"),
+    ];
+    expect(getTurnsSinceTaskManagement(history)).toBe(3);
+  });
+
+  it("counts assistant turns since the last task.update call", () => {
+    const history: LLMMessage[] = [
+      assistantToolCall("task.update"),
+      assistantText("one"),
+      assistantText("two"),
+    ];
+    expect(getTurnsSinceTaskManagement(history)).toBe(2);
+  });
+
+  it("does NOT count task.list, task.get, task.wait, or task.output", () => {
+    for (const nonMgmtCall of [
+      "task.list",
+      "task.get",
+      "task.wait",
+      "task.output",
+    ]) {
+      const history: LLMMessage[] = [
+        assistantToolCall("task.create"),
+        assistantText("one"),
+        assistantToolCall(nonMgmtCall),
+        assistantText("two"),
+      ];
+      // The last mgmt call is 3 assistant turns back (turns 1,2,3 since create).
+      // The task.list/get/etc turn counts as an assistant turn too but does NOT
+      // reset the counter.
+      expect(getTurnsSinceTaskManagement(history)).toBe(3);
+    }
+  });
+
+  it("picks the most recent management call when multiple exist", () => {
+    const history: LLMMessage[] = [
+      assistantToolCall("task.create"),
+      assistantText("a"),
+      assistantText("b"),
+      assistantToolCall("task.update"),
+      assistantText("c"),
+    ];
+    expect(getTurnsSinceTaskManagement(history)).toBe(1);
+  });
+});
+
+describe("getTurnsSinceLastTaskReminder", () => {
+  it("returns Infinity when no reminder has been injected", () => {
+    expect(
+      getTurnsSinceLastTaskReminder(buildHistoryWithAssistantTurns(5)),
+    ).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("detects a prior reminder via the header prefix", () => {
+    const reminder = `<system-reminder>\n${TASK_REMINDER_HEADER_PREFIX} filler\n</system-reminder>`;
+    const history: LLMMessage[] = [
+      userText("something else"),
+      { role: "user", content: reminder },
+      assistantText("a"),
+      assistantText("b"),
+    ];
+    expect(getTurnsSinceLastTaskReminder(history)).toBe(2);
+  });
+});
+
+describe("shouldInjectTaskReminder", () => {
+  const tools = new Set<string>(["task.update", "task.create"]);
+
+  it("returns false when task.update is not in activeToolNames", () => {
+    expect(
+      shouldInjectTaskReminder({
+        history: buildHistoryWithAssistantTurns(20),
+        activeToolNames: new Set(["task.create"]),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when both thresholds are met", () => {
+    const history = buildHistoryWithAssistantTurns(
+      TASK_REMINDER_TURNS_SINCE_UPDATE,
+    );
+    expect(
+      shouldInjectTaskReminder({ history, activeToolNames: tools }),
+    ).toBe(true);
+  });
+
+  it("suppresses when task.update was called within the last 10 turns", () => {
+    const history: LLMMessage[] = [
+      assistantToolCall("task.update"),
+      ...Array.from({ length: 9 }, (_, i) => assistantText(`x${i}`)),
+    ];
+    expect(
+      shouldInjectTaskReminder({ history, activeToolNames: tools }),
+    ).toBe(false);
+  });
+
+  it("fires once task.update is past the 10-turn window", () => {
+    const history: LLMMessage[] = [
+      assistantToolCall("task.update"),
+      ...Array.from(
+        { length: TASK_REMINDER_TURNS_SINCE_UPDATE },
+        (_, i) => assistantText(`x${i}`),
+      ),
+    ];
+    expect(
+      shouldInjectTaskReminder({ history, activeToolNames: tools }),
+    ).toBe(true);
+  });
+
+  it("suppresses when a reminder was injected within the last 10 turns", () => {
+    const reminder = `<system-reminder>\n${TASK_REMINDER_HEADER_PREFIX}\n</system-reminder>`;
+    const history: LLMMessage[] = [
+      ...buildHistoryWithAssistantTurns(20),
+      { role: "user", content: reminder },
+      ...Array.from(
+        { length: TASK_REMINDER_TURNS_BETWEEN_REMINDERS - 1 },
+        (_, i) => assistantText(`x${i}`),
+      ),
+    ];
+    expect(
+      shouldInjectTaskReminder({ history, activeToolNames: tools }),
+    ).toBe(false);
+  });
+});
+
+describe("buildTaskReminderMessage", () => {
+  const makeTask = (
+    id: string,
+    subject: string,
+    status: string,
+  ): ReminderTaskView => ({ id, subject, status });
+
+  it("wraps the message in system-reminder tags", () => {
+    const msg = buildTaskReminderMessage([]);
+    expect(typeof msg.content).toBe("string");
+    const content = msg.content as string;
+    expect(content.startsWith("<system-reminder>\n")).toBe(true);
+    expect(content.endsWith("\n</system-reminder>")).toBe(true);
+  });
+
+  it("includes the verbatim upstream header", () => {
+    const msg = buildTaskReminderMessage([]);
+    const content = msg.content as string;
+    expect(content).toContain("The task tools haven't been used recently.");
+    expect(content).toContain("task.create");
+    expect(content).toContain("task.update");
+    expect(content).toContain("NEVER mention this reminder");
+  });
+
+  it("emits user role with runtime-only user_context merge boundary", () => {
+    const msg = buildTaskReminderMessage([]);
+    expect(msg.role).toBe("user");
+    expect(msg.runtimeOnly?.mergeBoundary).toBe("user_context");
+  });
+
+  it("appends the task list when tasks exist", () => {
+    const msg = buildTaskReminderMessage([
+      makeTask("abc-1", "Fix auth bug", "pending"),
+      makeTask("abc-2", "Ship release", "in_progress"),
+    ]);
+    const content = msg.content as string;
+    expect(content).toContain("Here are the existing tasks:");
+    expect(content).toContain("#abc-1. [pending] Fix auth bug");
+    expect(content).toContain("#abc-2. [in_progress] Ship release");
+  });
+
+  it("omits the task list section when empty", () => {
+    const msg = buildTaskReminderMessage([]);
+    expect(msg.content as string).not.toContain("Here are the existing tasks");
+  });
+});

--- a/runtime/src/llm/task-reminder.ts
+++ b/runtime/src/llm/task-reminder.ts
@@ -1,0 +1,134 @@
+/**
+ * 10-turn reminder for the `task.*` tool family.
+ *
+ * Sibling of `todo-reminder.ts`. Fires independently — both reminders
+ * can co-exist on the same turn. Upstream runs both without mutual
+ * suppression; AgenC matches that pattern.
+ *
+ * Trigger: `task.update` is in the active toolset AND neither
+ * `task.create` nor `task.update` has been invoked in the last 10
+ * assistant turns AND no task reminder was injected in the last 10
+ * assistant turns. Only management calls count — `task.list`,
+ * `task.get`, `task.wait`, `task.output` do not.
+ *
+ * Counters are scan-derived from the current history — compaction-safe
+ * and session-resume-safe. Mirror of `todo-reminder.ts`.
+ *
+ * @module
+ */
+
+import type { LLMMessage } from "./types.js";
+
+export const TASK_REMINDER_TURNS_SINCE_UPDATE = 10;
+export const TASK_REMINDER_TURNS_BETWEEN_REMINDERS = 10;
+
+export const TASK_REMINDER_HEADER_PREFIX =
+  "The task tools haven't been used recently.";
+
+const TASK_REMINDER_HEADER =
+  "The task tools haven't been used recently. If you're working on " +
+  "tasks that would benefit from tracking progress, consider using " +
+  "task.create to add new tasks and task.update to update task status " +
+  "(set to in_progress when starting, completed when done). Also " +
+  "consider cleaning up the task list if it has become stale. Only " +
+  "use these if relevant to the current work. This is just a gentle " +
+  "reminder - ignore if not applicable. Make sure that you NEVER " +
+  "mention this reminder to the user";
+
+/**
+ * Minimal structural view of a task for reminder rendering. Both
+ * `Task` (TaskStore) and `SessionTask` (SessionTaskStore) are
+ * structurally assignable to this — the daemon wires
+ * `TaskStore.listTasks()` which returns `Task[]`, but the reminder
+ * only needs id/subject/status.
+ */
+export interface ReminderTaskView {
+  readonly id: string;
+  readonly subject: string;
+  readonly status: string;
+}
+
+function stringContent(message: LLMMessage): string {
+  if (typeof message.content === "string") return message.content;
+  return message.content
+    .map((part) => (part.type === "text" ? part.text : ""))
+    .join("");
+}
+
+function countAssistantTurnsBetween(
+  history: readonly LLMMessage[],
+  startExclusive: number,
+  endExclusive: number,
+): number {
+  let count = 0;
+  for (let index = startExclusive + 1; index < endExclusive; index += 1) {
+    if (history[index]?.role === "assistant") count += 1;
+  }
+  return count;
+}
+
+function isTaskManagementCall(name: string): boolean {
+  return name === "task.create" || name === "task.update";
+}
+
+export function getTurnsSinceTaskManagement(
+  history: readonly LLMMessage[],
+): number {
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const message = history[index]!;
+    if (message.role !== "assistant") continue;
+    const hadManagement = (message.toolCalls ?? []).some((call) =>
+      isTaskManagementCall(call.name),
+    );
+    if (hadManagement) {
+      return countAssistantTurnsBetween(history, index, history.length);
+    }
+  }
+  return Number.POSITIVE_INFINITY;
+}
+
+export function getTurnsSinceLastTaskReminder(
+  history: readonly LLMMessage[],
+): number {
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const message = history[index]!;
+    if (message.role !== "user") continue;
+    const content = stringContent(message);
+    if (content.includes(TASK_REMINDER_HEADER_PREFIX)) {
+      return countAssistantTurnsBetween(history, index, history.length);
+    }
+  }
+  return Number.POSITIVE_INFINITY;
+}
+
+export interface ShouldInjectTaskReminderParams {
+  readonly history: readonly LLMMessage[];
+  readonly activeToolNames: ReadonlySet<string>;
+}
+
+export function shouldInjectTaskReminder(
+  params: ShouldInjectTaskReminderParams,
+): boolean {
+  if (!params.activeToolNames.has("task.update")) return false;
+  const turnsSinceManagement = getTurnsSinceTaskManagement(params.history);
+  if (turnsSinceManagement < TASK_REMINDER_TURNS_SINCE_UPDATE) return false;
+  const turnsSinceReminder = getTurnsSinceLastTaskReminder(params.history);
+  if (turnsSinceReminder < TASK_REMINDER_TURNS_BETWEEN_REMINDERS) return false;
+  return true;
+}
+
+export function buildTaskReminderMessage(
+  tasks: readonly ReminderTaskView[],
+): LLMMessage {
+  const list = tasks.length === 0
+    ? ""
+    : "\n\nHere are the existing tasks:\n\n" +
+      tasks
+        .map((task) => `#${task.id}. [${task.status}] ${task.subject}`)
+        .join("\n");
+  return {
+    role: "user",
+    content: `<system-reminder>\n${TASK_REMINDER_HEADER}${list}\n</system-reminder>`,
+    runtimeOnly: { mergeBoundary: "user_context" },
+  };
+}

--- a/runtime/src/llm/todo-reminder.test.ts
+++ b/runtime/src/llm/todo-reminder.test.ts
@@ -8,7 +8,6 @@ import {
   TODO_REMINDER_TURNS_SINCE_WRITE,
   buildTodoReminderMessage,
   getTurnsSinceLastTodoReminder,
-  getTurnsSinceRecentTaskToolUse,
   getTurnsSinceTodoWrite,
   shouldInjectTodoReminder,
 } from "./todo-reminder.js";
@@ -123,25 +122,6 @@ describe("getTurnsSinceLastTodoReminder", () => {
   });
 });
 
-describe("getTurnsSinceRecentTaskToolUse", () => {
-  it("returns Infinity when no task.* tool has been called", () => {
-    expect(
-      getTurnsSinceRecentTaskToolUse(buildHistoryWithAssistantTurns(3)),
-    ).toBe(Number.POSITIVE_INFINITY);
-  });
-
-  it("detects task.create and task.update calls", () => {
-    const history: LLMMessage[] = [
-      userText("go"),
-      assistantToolCall("task.create"),
-      toolResult("call-task.create", "{}"),
-      userText("next"),
-      assistantText("replied"),
-    ];
-    expect(getTurnsSinceRecentTaskToolUse(history)).toBe(1);
-  });
-});
-
 describe("shouldInjectTodoReminder", () => {
   it("returns false when TodoWrite is not in the active toolset", () => {
     const history = buildHistoryWithAssistantTurns(
@@ -172,7 +152,7 @@ describe("shouldInjectTodoReminder", () => {
     ).toBe(false);
   });
 
-  it("returns true when both thresholds are met and no task.* recently used", () => {
+  it("returns true when both thresholds are met", () => {
     const history = buildHistoryWithAssistantTurns(
       TODO_REMINDER_TURNS_SINCE_WRITE + 1,
     );
@@ -184,22 +164,7 @@ describe("shouldInjectTodoReminder", () => {
     ).toBe(true);
   });
 
-  it("suppresses when task.* was used within the last 10 assistant turns", () => {
-    const history: LLMMessage[] = [
-      userText("go"),
-      assistantToolCall("task.create"),
-      toolResult("call-task.create", "{}"),
-      ...buildHistoryWithAssistantTurns(5),
-    ];
-    expect(
-      shouldInjectTodoReminder({
-        history,
-        activeToolNames: DEFAULT_ACTIVE_TOOLS,
-      }),
-    ).toBe(false);
-  });
-
-  it("stops suppressing once task.* is past the 10-turn window", () => {
+  it("does not suppress based on task.* tool-call history (independent sibling reminder)", () => {
     const history: LLMMessage[] = [
       userText("go"),
       assistantToolCall("task.create"),

--- a/runtime/src/llm/todo-reminder.ts
+++ b/runtime/src/llm/todo-reminder.ts
@@ -20,13 +20,15 @@
  *
  * Trigger: both counters must be `>= 10`.
  *
- * Suppression, in order:
+ * Suppression:
  *   - `TodoWrite` not in the active toolset — the model can't act on
  *     the reminder anyway. Matches upstream's tool-availability gate.
- *   - `task.*` tool call in the last 10 assistant turns — the model is
- *     using the richer sub-agent orchestration surface; nagging it
- *     toward TodoWrite would be incoherent. AgenC-specific (upstream
- *     has no `task.*` family).
+ *
+ * No mutual suppression with the `task.*` family. The sibling reminder
+ * in `task-reminder.ts` fires independently — upstream runs both at
+ * once without cross-suppression, and a previous AgenC-specific gate
+ * that suppressed the todo reminder when `task.*` was recently used
+ * was removed when `task-reminder.ts` landed.
  *
  * The emitted message content is the verbatim upstream header text
  * (trailing newline included), followed by the current list rendered
@@ -115,22 +117,6 @@ export function getTurnsSinceLastTodoReminder(
   return Number.POSITIVE_INFINITY;
 }
 
-export function getTurnsSinceRecentTaskToolUse(
-  history: readonly LLMMessage[],
-): number {
-  for (let index = history.length - 1; index >= 0; index -= 1) {
-    const message = history[index]!;
-    if (message.role !== "assistant") continue;
-    const hadTaskCall = (message.toolCalls ?? []).some((call) =>
-      call.name.startsWith("task."),
-    );
-    if (hadTaskCall) {
-      return countAssistantTurnsBetween(history, index, history.length);
-    }
-  }
-  return Number.POSITIVE_INFINITY;
-}
-
 export interface ShouldInjectTodoReminderParams {
   readonly history: readonly LLMMessage[];
   readonly activeToolNames: ReadonlySet<string>;
@@ -140,8 +126,6 @@ export function shouldInjectTodoReminder(
   params: ShouldInjectTodoReminderParams,
 ): boolean {
   if (!params.activeToolNames.has(TODO_WRITE_TOOL_NAME)) return false;
-  const turnsSinceTaskUse = getTurnsSinceRecentTaskToolUse(params.history);
-  if (turnsSinceTaskUse < TODO_REMINDER_TURNS_SINCE_WRITE) return false;
   const turnsSinceWrite = getTurnsSinceTodoWrite(params.history);
   if (turnsSinceWrite < TODO_REMINDER_TURNS_SINCE_WRITE) return false;
   const turnsSinceReminder = getTurnsSinceLastTodoReminder(params.history);

--- a/runtime/src/llm/verify-reminder.test.ts
+++ b/runtime/src/llm/verify-reminder.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from "vitest";
+import type { LLMMessage } from "./types.js";
+import {
+  VERIFY_REMINDER_EDIT_THRESHOLD,
+  VERIFY_REMINDER_HEADER_PREFIX,
+  VERIFY_REMINDER_TURNS_BETWEEN_REMINDERS,
+  buildVerifyReminderMessage,
+  getMutatingEditsSinceLastVerifierSpawn,
+  getTurnsSinceLastVerifyReminder,
+  shouldInjectVerifyReminder,
+} from "./verify-reminder.js";
+
+function userText(content: string): LLMMessage {
+  return { role: "user", content };
+}
+
+function assistantText(content: string): LLMMessage {
+  return { role: "assistant", content };
+}
+
+function toolResult(content: string, toolCallId = "call-1"): LLMMessage {
+  return { role: "tool", content, toolCallId };
+}
+
+function assistantMutation(toolName: string): LLMMessage {
+  return {
+    role: "assistant",
+    content: "",
+    toolCalls: [
+      {
+        id: `call-${toolName}-${Math.random()}`,
+        name: toolName,
+        arguments: "{}",
+      },
+    ],
+  };
+}
+
+function assistantVerifierSpawn(
+  obligations: readonly string[] = ["build passes"],
+): LLMMessage {
+  return {
+    role: "assistant",
+    content: "",
+    toolCalls: [
+      {
+        id: "call-ewa",
+        name: "execute_with_agent",
+        arguments: JSON.stringify({
+          task: "verify the implementation",
+          delegationAdmission: { verifierObligations: obligations },
+        }),
+      },
+    ],
+  };
+}
+
+describe("getMutatingEditsSinceLastVerifierSpawn", () => {
+  it("returns 0 for empty history", () => {
+    expect(getMutatingEditsSinceLastVerifierSpawn([])).toBe(0);
+  });
+
+  it("counts writeFile/editFile/appendFile/mkdir/move/delete", () => {
+    const history: LLMMessage[] = [
+      assistantMutation("system.writeFile"),
+      assistantMutation("system.editFile"),
+      assistantMutation("system.appendFile"),
+      assistantMutation("system.mkdir"),
+      assistantMutation("system.move"),
+      assistantMutation("system.delete"),
+    ];
+    expect(getMutatingEditsSinceLastVerifierSpawn(history)).toBe(6);
+  });
+
+  it("does NOT count task.*, readFile, listDir, bash, or non-mutating tools", () => {
+    const history: LLMMessage[] = [
+      assistantMutation("system.readFile"),
+      assistantMutation("system.listDir"),
+      assistantMutation("system.bash"),
+      assistantMutation("task.create"),
+      assistantMutation("task.update"),
+      assistantMutation("TodoWrite"),
+    ];
+    expect(getMutatingEditsSinceLastVerifierSpawn(history)).toBe(0);
+  });
+
+  it("stops counting at the most recent execute_with_agent spawn with verifierObligations", () => {
+    const history: LLMMessage[] = [
+      assistantMutation("system.writeFile"),
+      assistantMutation("system.editFile"),
+      assistantVerifierSpawn(["build passes"]),
+      assistantMutation("system.writeFile"),
+    ];
+    // Only the write after the spawn is counted.
+    expect(getMutatingEditsSinceLastVerifierSpawn(history)).toBe(1);
+  });
+
+  it("ignores execute_with_agent calls without verifierObligations", () => {
+    const bareSpawn: LLMMessage = {
+      role: "assistant",
+      content: "",
+      toolCalls: [
+        {
+          id: "call-ewa-bare",
+          name: "execute_with_agent",
+          arguments: JSON.stringify({ task: "do a thing" }),
+        },
+      ],
+    };
+    const history: LLMMessage[] = [
+      assistantMutation("system.writeFile"),
+      bareSpawn,
+      assistantMutation("system.writeFile"),
+    ];
+    expect(getMutatingEditsSinceLastVerifierSpawn(history)).toBe(2);
+  });
+
+  it("stops counting at a tool-role message containing VERDICT: PASS", () => {
+    const history: LLMMessage[] = [
+      assistantMutation("system.writeFile"),
+      assistantMutation("system.editFile"),
+      toolResult("some output...\n\nVERDICT: PASS\n"),
+      assistantMutation("system.writeFile"),
+    ];
+    expect(getMutatingEditsSinceLastVerifierSpawn(history)).toBe(1);
+  });
+
+  it("recognizes FAIL and PARTIAL verdict markers too", () => {
+    for (const verdict of ["VERDICT: FAIL", "VERDICT: PARTIAL"]) {
+      const history: LLMMessage[] = [
+        assistantMutation("system.writeFile"),
+        toolResult(`output\n${verdict}\n`),
+        assistantMutation("system.editFile"),
+      ];
+      expect(getMutatingEditsSinceLastVerifierSpawn(history)).toBe(1);
+    }
+  });
+
+  it("does NOT treat VERDICT text in assistant messages as a terminator", () => {
+    // Gaming-resistance: only role === "tool" messages reset the counter.
+    const history: LLMMessage[] = [
+      assistantMutation("system.writeFile"),
+      assistantMutation("system.editFile"),
+      assistantText("I've done the work. VERDICT: PASS"),
+      assistantMutation("system.writeFile"),
+    ];
+    expect(getMutatingEditsSinceLastVerifierSpawn(history)).toBe(3);
+  });
+
+  it("does NOT treat VERDICT text in user messages as a terminator", () => {
+    const history: LLMMessage[] = [
+      assistantMutation("system.writeFile"),
+      userText("user wrote: VERDICT: PASS"),
+      assistantMutation("system.editFile"),
+    ];
+    expect(getMutatingEditsSinceLastVerifierSpawn(history)).toBe(2);
+  });
+});
+
+describe("getTurnsSinceLastVerifyReminder", () => {
+  it("returns Infinity when no reminder has been injected", () => {
+    expect(
+      getTurnsSinceLastVerifyReminder([
+        userText("u1"),
+        assistantText("a1"),
+      ]),
+    ).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("detects a prior reminder via the header prefix", () => {
+    const reminder: LLMMessage = {
+      role: "user",
+      content: `<system-reminder>\n${VERIFY_REMINDER_HEADER_PREFIX} ...\n</system-reminder>`,
+    };
+    const history: LLMMessage[] = [
+      userText("other"),
+      reminder,
+      assistantText("a"),
+      assistantText("b"),
+    ];
+    expect(getTurnsSinceLastVerifyReminder(history)).toBe(2);
+  });
+});
+
+describe("shouldInjectVerifyReminder", () => {
+  const activeTools = new Set<string>(["execute_with_agent"]);
+
+  it("returns false when execute_with_agent is not in the toolset", () => {
+    const history: LLMMessage[] = [
+      assistantMutation("system.writeFile"),
+      assistantMutation("system.writeFile"),
+      assistantMutation("system.writeFile"),
+    ];
+    expect(
+      shouldInjectVerifyReminder({
+        history,
+        activeToolNames: new Set<string>(),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when under the edit threshold", () => {
+    const history: LLMMessage[] = [
+      assistantMutation("system.writeFile"),
+      assistantMutation("system.writeFile"),
+    ];
+    expect(
+      shouldInjectVerifyReminder({ history, activeToolNames: activeTools }),
+    ).toBe(false);
+  });
+
+  it("returns true at exactly the edit threshold with no recent reminder", () => {
+    const history: LLMMessage[] = Array.from(
+      { length: VERIFY_REMINDER_EDIT_THRESHOLD },
+      () => assistantMutation("system.writeFile"),
+    );
+    expect(
+      shouldInjectVerifyReminder({ history, activeToolNames: activeTools }),
+    ).toBe(true);
+  });
+
+  it("suppresses when a reminder was injected within the last 10 turns", () => {
+    const reminder: LLMMessage = {
+      role: "user",
+      content: `<system-reminder>\n${VERIFY_REMINDER_HEADER_PREFIX}\n</system-reminder>`,
+    };
+    const history: LLMMessage[] = [
+      assistantMutation("system.writeFile"),
+      assistantMutation("system.editFile"),
+      assistantMutation("system.writeFile"),
+      reminder,
+      ...Array.from(
+        { length: VERIFY_REMINDER_TURNS_BETWEEN_REMINDERS - 1 },
+        (_, i) => assistantText(`x${i}`),
+      ),
+    ];
+    expect(
+      shouldInjectVerifyReminder({ history, activeToolNames: activeTools }),
+    ).toBe(false);
+  });
+
+  it("resumes firing once the last reminder is past the 10-turn window", () => {
+    const reminder: LLMMessage = {
+      role: "user",
+      content: `<system-reminder>\n${VERIFY_REMINDER_HEADER_PREFIX}\n</system-reminder>`,
+    };
+    const history: LLMMessage[] = [
+      reminder,
+      ...Array.from(
+        { length: VERIFY_REMINDER_TURNS_BETWEEN_REMINDERS + 1 },
+        (_, i) => assistantText(`x${i}`),
+      ),
+      assistantMutation("system.writeFile"),
+      assistantMutation("system.editFile"),
+      assistantMutation("system.writeFile"),
+    ];
+    expect(
+      shouldInjectVerifyReminder({ history, activeToolNames: activeTools }),
+    ).toBe(true);
+  });
+});
+
+describe("buildVerifyReminderMessage", () => {
+  it("wraps the header in system-reminder tags", () => {
+    const msg = buildVerifyReminderMessage();
+    const content = msg.content as string;
+    expect(content.startsWith("<system-reminder>\n")).toBe(true);
+    expect(content.endsWith("\n</system-reminder>")).toBe(true);
+    expect(content).toContain(VERIFY_REMINDER_HEADER_PREFIX);
+  });
+
+  it("includes the contract wording and cannot-self-assign-PARTIAL clause", () => {
+    const msg = buildVerifyReminderMessage();
+    const content = msg.content as string;
+    expect(content).toContain("execute_with_agent");
+    expect(content).toContain("delegationAdmission.verifierObligations");
+    expect(content).toContain("cannot self-assign");
+    expect(content).toContain("PARTIAL");
+  });
+
+  it("emits user role with runtime-only user_context merge boundary", () => {
+    const msg = buildVerifyReminderMessage();
+    expect(msg.role).toBe("user");
+    expect(msg.runtimeOnly?.mergeBoundary).toBe("user_context");
+  });
+});

--- a/runtime/src/llm/verify-reminder.ts
+++ b/runtime/src/llm/verify-reminder.ts
@@ -1,0 +1,185 @@
+/**
+ * Verification reminder for unverified cumulative edits.
+ *
+ * Plan-mode-less equivalent of the reference runtime's
+ * `verify_plan_reminder` (upstream: plan mode state with
+ * `verificationStarted && !verificationCompleted`). AgenC has no plan
+ * mode, so the trigger is substituted with a cumulative-edit signal:
+ * fires when the model has issued at least `VERIFY_REMINDER_EDIT_THRESHOLD`
+ * mutating file-modification tool calls since the most recent verifier
+ * spawn, and at least `VERIFY_REMINDER_TURNS_BETWEEN_REMINDERS`
+ * assistant turns have elapsed since the last verify reminder.
+ *
+ * The counter resets when EITHER:
+ *   (a) The model spawns `execute_with_agent` with a non-empty
+ *       `delegationAdmission.verifierObligations` array. This is the
+ *       structured contract the model cannot synthesize without an
+ *       actual verifier spawn round-trip.
+ *   (b) A `role === "tool"` message contains `VERDICT: PASS|FAIL|PARTIAL`.
+ *       Scoping to `role === "tool"` prevents the model from gaming
+ *       the reset by typing the string itself — tool messages are
+ *       runtime-controlled, not model-authored.
+ *
+ * Counter model mirrors `todo-reminder.ts` — scan-derived, no
+ * persisted fields, compaction/crash/resume safe.
+ *
+ * @module
+ */
+
+import type { LLMMessage } from "./types.js";
+
+export const VERIFY_REMINDER_EDIT_THRESHOLD = 3;
+export const VERIFY_REMINDER_TURNS_BETWEEN_REMINDERS = 10;
+
+export const VERIFY_REMINDER_HEADER_PREFIX =
+  "You have made unverified file edits.";
+
+const VERIFY_REMINDER_HEADER =
+  "You have made unverified file edits. The verification contract " +
+  "requires that independent adversarial verification happens before " +
+  "you report completion. Spawn the verifier with `execute_with_agent`, " +
+  "setting `delegationAdmission.verifierObligations` to the checks you " +
+  "want verified (examples: \"build passes\", \"test suite passes\", " +
+  "\"end-to-end smoke command returns expected output\"). Your own " +
+  "checks, caveats, and a subagent's self-checks do NOT substitute " +
+  "\u2014 only the verifier assigns a verdict; you cannot self-assign " +
+  "PARTIAL. This is a gentle reminder \u2014 ignore only if all " +
+  "changes since the last verification have already been verified " +
+  "elsewhere. Make sure that you NEVER mention this reminder to the " +
+  "user.";
+
+const MUTATING_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "system.writeFile",
+  "system.editFile",
+  "system.appendFile",
+  "system.mkdir",
+  "system.move",
+  "system.delete",
+]);
+
+const EXECUTE_WITH_AGENT_TOOL_NAME = "execute_with_agent";
+
+const VERDICT_MARKERS: readonly string[] = [
+  "VERDICT: PASS",
+  "VERDICT: FAIL",
+  "VERDICT: PARTIAL",
+];
+
+function stringContent(message: LLMMessage): string {
+  if (typeof message.content === "string") return message.content;
+  return message.content
+    .map((part) => (part.type === "text" ? part.text : ""))
+    .join("");
+}
+
+function countAssistantTurnsBetween(
+  history: readonly LLMMessage[],
+  startExclusive: number,
+  endExclusive: number,
+): number {
+  let count = 0;
+  for (let index = startExclusive + 1; index < endExclusive; index += 1) {
+    if (history[index]?.role === "assistant") count += 1;
+  }
+  return count;
+}
+
+function parseToolCallArguments(raw: string | undefined): unknown {
+  if (typeof raw !== "string" || raw.length === 0) return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+function hasVerifierObligations(toolCallArguments: unknown): boolean {
+  if (!toolCallArguments || typeof toolCallArguments !== "object") {
+    return false;
+  }
+  const rec = toolCallArguments as Record<string, unknown>;
+  const admission = rec["delegationAdmission"];
+  if (!admission || typeof admission !== "object") return false;
+  const obligations = (admission as Record<string, unknown>)[
+    "verifierObligations"
+  ];
+  return Array.isArray(obligations) && obligations.length > 0;
+}
+
+function messageIsVerifierSpawn(message: LLMMessage): boolean {
+  if (message.role !== "assistant") return false;
+  const calls = message.toolCalls ?? [];
+  return calls.some((call) => {
+    if (call.name !== EXECUTE_WITH_AGENT_TOOL_NAME) return false;
+    return hasVerifierObligations(parseToolCallArguments(call.arguments));
+  });
+}
+
+function messageIsVerifierVerdict(message: LLMMessage): boolean {
+  if (message.role !== "tool") return false;
+  const content = stringContent(message);
+  return VERDICT_MARKERS.some((marker) => content.includes(marker));
+}
+
+/**
+ * Count mutating tool-use invocations in assistant history, scanning
+ * backwards, stopping at the most recent verifier-spawn or verdict
+ * terminator. If no terminator is encountered, returns the count
+ * across the full visible history.
+ */
+export function getMutatingEditsSinceLastVerifierSpawn(
+  history: readonly LLMMessage[],
+): number {
+  let count = 0;
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const message = history[index]!;
+    if (messageIsVerifierSpawn(message) || messageIsVerifierVerdict(message)) {
+      return count;
+    }
+    if (message.role !== "assistant") continue;
+    for (const call of message.toolCalls ?? []) {
+      if (MUTATING_TOOL_NAMES.has(call.name)) count += 1;
+    }
+  }
+  return count;
+}
+
+export function getTurnsSinceLastVerifyReminder(
+  history: readonly LLMMessage[],
+): number {
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const message = history[index]!;
+    if (message.role !== "user") continue;
+    const content = stringContent(message);
+    if (content.includes(VERIFY_REMINDER_HEADER_PREFIX)) {
+      return countAssistantTurnsBetween(history, index, history.length);
+    }
+  }
+  return Number.POSITIVE_INFINITY;
+}
+
+export interface ShouldInjectVerifyReminderParams {
+  readonly history: readonly LLMMessage[];
+  readonly activeToolNames: ReadonlySet<string>;
+}
+
+export function shouldInjectVerifyReminder(
+  params: ShouldInjectVerifyReminderParams,
+): boolean {
+  if (!params.activeToolNames.has(EXECUTE_WITH_AGENT_TOOL_NAME)) return false;
+  const edits = getMutatingEditsSinceLastVerifierSpawn(params.history);
+  if (edits < VERIFY_REMINDER_EDIT_THRESHOLD) return false;
+  const turnsSinceReminder = getTurnsSinceLastVerifyReminder(params.history);
+  if (turnsSinceReminder < VERIFY_REMINDER_TURNS_BETWEEN_REMINDERS) {
+    return false;
+  }
+  return true;
+}
+
+export function buildVerifyReminderMessage(): LLMMessage {
+  return {
+    role: "user",
+    content: `<system-reminder>\n${VERIFY_REMINDER_HEADER}\n</system-reminder>`,
+    runtimeOnly: { mergeBoundary: "user_context" },
+  };
+}

--- a/runtime/src/tools/system/task-tracker.ts
+++ b/runtime/src/tools/system/task-tracker.ts
@@ -2261,12 +2261,46 @@ export class TaskStore {
   }
 }
 
-const TASK_CREATE_DESCRIPTION =
-  "Create a structured task in the current session's task list. Use proactively for " +
-  "multi-step work (3+ steps), complex tasks that require planning, or when the user " +
-  "supplies multiple things to do. Mark a task in_progress with task.update BEFORE " +
-  "starting work, and completed only once the work is fully done. If description is " +
-  "omitted, the runtime falls back to the subject text.";
+const TASK_CREATE_DESCRIPTION = `Use this tool to create a structured task list for your current coding session. This helps you track progress, organize complex tasks, and demonstrate thoroughness to the user.
+It also helps the user understand the progress of the task and overall progress of their requests.
+
+## When to Use This Tool
+
+Use this tool proactively in these scenarios:
+
+- Complex multi-step tasks - When a task requires 3 or more distinct steps or actions
+- Non-trivial and complex tasks - Tasks that require careful planning or multiple operations
+- Plan mode - When using plan mode, create a task list to track the work
+- User explicitly requests todo list - When the user directly asks you to use the todo list
+- User provides multiple tasks - When users provide a list of things to be done (numbered or comma-separated)
+- After receiving new instructions - Immediately capture user requirements as tasks
+- When you start working on a task - Mark it as in_progress BEFORE beginning work
+- After completing a task - Mark it as completed and add any new follow-up tasks discovered during implementation
+
+## When NOT to Use This Tool
+
+Skip using this tool when:
+- There is only a single, straightforward task
+- The task is trivial and tracking it provides no organizational benefit
+- The task can be completed in less than 3 trivial steps
+- The task is purely conversational or informational
+
+NOTE that you should not use this tool if there is only one trivial task to do. In this case you are better off just doing the task directly.
+
+## Task Fields
+
+- **subject**: A brief, actionable title in imperative form (e.g., "Fix authentication bug in login flow")
+- **description**: What needs to be done
+- **activeForm** (optional): Present continuous form shown in the spinner when the task is in_progress (e.g., "Fixing authentication bug"). If omitted, the spinner shows the subject instead.
+
+All tasks are created with status \`pending\`.
+
+## Tips
+
+- Create tasks with clear, specific subjects that describe the outcome
+- After creating tasks, use task.update to set up dependencies (blocks/blockedBy) if needed
+- Check task.list first to avoid creating duplicate tasks
+`;
 
 const TASK_LIST_DESCRIPTION =
   "List tasks in the current session's task list. Returns each task's id, subject, status, " +
@@ -2276,11 +2310,81 @@ const TASK_GET_DESCRIPTION =
   "Fetch a single task by id with its description, status, blocks, and blockedBy ids. " +
   "Returns null when the task does not exist.";
 
-const TASK_UPDATE_DESCRIPTION =
-  "Update a task's status, subject, description, owner, activeForm, metadata, or blocks. " +
-  "Status transitions include pending, in_progress, completed, and deleted. " +
-  "Use status 'deleted' to permanently hide the task from list/get. Metadata is merged shallowly; " +
-  "pass a key with value null to delete that key. addBlocks / addBlockedBy append unique ids.";
+const TASK_UPDATE_DESCRIPTION = `Use this tool to update a task in the task list.
+
+## When to Use This Tool
+
+**Mark tasks as resolved:**
+- When you have completed the work described in a task
+- When a task is no longer needed or has been superseded
+- IMPORTANT: Always mark your assigned tasks as resolved when you finish them
+- After resolving, call task.list to find your next task
+
+- ONLY mark a task as completed when you have FULLY accomplished it
+- If you encounter errors, blockers, or cannot finish, keep the task as in_progress
+- When blocked, create a new task describing what needs to be resolved
+- Never mark a task as completed if:
+  - Tests are failing
+  - Implementation is partial
+  - You encountered unresolved errors
+  - You couldn't find necessary files or dependencies
+
+**Delete tasks:**
+- When a task is no longer relevant or was created in error
+- Setting status to \`deleted\` permanently removes the task
+
+**Update task details:**
+- When requirements change or become clearer
+- When establishing dependencies between tasks
+
+## Fields You Can Update
+
+- **status**: The task status (see Status Workflow below)
+- **subject**: Change the task title (imperative form, e.g., "Run tests")
+- **description**: Change the task description
+- **activeForm**: Present continuous form shown in spinner when in_progress (e.g., "Running tests")
+- **owner**: Change the task owner (agent name)
+- **metadata**: Merge metadata keys into the task (set a key to null to delete it)
+- **addBlocks**: Mark tasks that cannot start until this one completes
+- **addBlockedBy**: Mark tasks that must complete before this one can start
+
+## Status Workflow
+
+Status progresses: \`pending\` → \`in_progress\` → \`completed\`
+
+Use \`deleted\` to permanently remove a task.
+
+## Staleness
+
+Make sure to read a task's latest state using \`task.get\` before updating it.
+
+## Examples
+
+Mark task as in progress when starting work:
+\`\`\`json
+{"taskId": "1", "status": "in_progress"}
+\`\`\`
+
+Mark task as completed after finishing work:
+\`\`\`json
+{"taskId": "1", "status": "completed"}
+\`\`\`
+
+Delete a task:
+\`\`\`json
+{"taskId": "1", "status": "deleted"}
+\`\`\`
+
+Claim a task by setting owner:
+\`\`\`json
+{"taskId": "1", "owner": "my-name"}
+\`\`\`
+
+Set up task dependencies:
+\`\`\`json
+{"taskId": "2", "addBlockedBy": ["1"]}
+\`\`\`
+`;
 
 const TASK_WAIT_DESCRIPTION =
   "Wait for a task to reach a terminal state or to make output ready. Use this for async " +

--- a/runtime/src/tools/system/todo-write.test.ts
+++ b/runtime/src/tools/system/todo-write.test.ts
@@ -28,7 +28,9 @@ describe("TodoWrite tool", () => {
   it("exposes the expected name and schema", () => {
     const tool = createTodoWriteTool(new TodoStore());
     expect(tool.name).toBe(TODO_WRITE_TOOL_NAME);
-    expect(tool.description).toMatch(/track multi-step work/);
+    expect(tool.description).toMatch(/## When to Use This Tool/);
+    expect(tool.description).toMatch(/Task Completion Requirements/);
+    expect(tool.description).toMatch(/Never mark a task as completed if/);
     const schema = tool.inputSchema as {
       required?: readonly string[];
       additionalProperties?: boolean;

--- a/runtime/src/tools/system/todo-write.ts
+++ b/runtime/src/tools/system/todo-write.ts
@@ -32,17 +32,185 @@ export const TODO_WRITE_TOOL_NAME = "TodoWrite";
 
 export const TODO_WRITE_SESSION_ARG = "__agencTodoSessionId";
 
-const TODO_WRITE_DESCRIPTION =
-  "Use TodoWrite to track multi-step work on the main conversation " +
-  "thread. Replaces the whole todo list atomically. Statuses are " +
-  "`pending`, `in_progress`, `completed` — exactly one item should be " +
-  "`in_progress` at a time. `activeForm` is a present-continuous label " +
-  "(e.g. \"Running tests\"). When every item is marked `completed`, the " +
-  "runtime clears the list. " +
-  "Distinct from the `task.*` tool family, which is for delegating work " +
-  "to subagents with IDs, blocking relationships, and ownership. Use " +
-  "TodoWrite for your own progress; use `task.create` when spawning " +
-  "child agents or managing cross-agent dependencies.";
+const TODO_WRITE_DESCRIPTION = `Use this tool to create and manage a structured task list for your current coding session. This helps you track progress, organize complex tasks, and demonstrate thoroughness to the user.
+It also helps the user understand the progress of the task and overall progress of their requests.
+
+## When to Use This Tool
+Use this tool proactively in these scenarios:
+
+1. Complex multi-step tasks - When a task requires 3 or more distinct steps or actions
+2. Non-trivial and complex tasks - Tasks that require careful planning or multiple operations
+3. User explicitly requests todo list - When the user directly asks you to use the todo list
+4. User provides multiple tasks - When users provide a list of things to be done (numbered or comma-separated)
+5. After receiving new instructions - Immediately capture user requirements as todos
+6. When you start working on a task - Mark it as in_progress BEFORE beginning work. Ideally you should only have one todo as in_progress at a time
+7. After completing a task - Mark it as completed and add any new follow-up tasks discovered during implementation
+
+## When NOT to Use This Tool
+
+Skip using this tool when:
+1. There is only a single, straightforward task
+2. The task is trivial and tracking it provides no organizational benefit
+3. The task can be completed in less than 3 trivial steps
+4. The task is purely conversational or informational
+
+NOTE that you should not use this tool if there is only one trivial task to do. In this case you are better off just doing the task directly.
+
+## Examples of When to Use the Todo List
+
+<example>
+User: I want to add a dark mode toggle to the application settings. Make sure you run the tests and build when you're done!
+Assistant: *Creates todo list with the following items:*
+1. Creating dark mode toggle component in Settings page
+2. Adding dark mode state management (context/store)
+3. Implementing CSS-in-JS styles for dark theme
+4. Updating existing components to support theme switching
+5. Running tests and build process, addressing any failures or errors that occur
+*Begins working on the first task*
+
+<reasoning>
+The assistant used the todo list because:
+1. Adding dark mode is a multi-step feature requiring UI, state management, and styling changes
+2. The user explicitly requested tests and build be run afterward
+3. The assistant inferred that tests and build need to pass by adding "Ensure tests and build succeed" as the final task
+</reasoning>
+</example>
+
+<example>
+User: Help me rename the function getCwd to getCurrentWorkingDirectory across my project
+Assistant: *Uses grep or search tools to locate all instances of getCwd in the codebase*
+I've found 15 instances of 'getCwd' across 8 different files.
+*Creates todo list with specific items for each file that needs updating*
+
+<reasoning>
+The assistant used the todo list because:
+1. First, the assistant searched to understand the scope of the task
+2. Upon finding multiple occurrences across different files, it determined this was a complex task with multiple steps
+3. The todo list helps ensure every instance is tracked and updated systematically
+4. This approach prevents missing any occurrences and maintains code consistency
+</reasoning>
+</example>
+
+
+<example>
+User: I need to implement these features for my e-commerce site: user registration, product catalog, shopping cart, and checkout flow.
+Assistant: *Creates a todo list breaking down each feature into specific tasks based on the project architecture*
+Let's start with user registration. This will involve creating database models, API endpoints, and frontend forms that integrate with your existing authentication system.
+
+<reasoning>
+The assistant used the todo list because:
+1. The user provided multiple complex features to implement in a comma separated list
+2. The todo list helps organize these large features into manageable tasks
+3. This approach allows for tracking progress across the entire implementation
+</reasoning>
+</example>
+
+<example>
+User: Can you help optimize my React application? It's rendering slowly and has performance issues.
+Assistant: *Reviews component structure, render patterns, state management, and data fetching*
+After analyzing your codebase, I've identified several performance issues.
+*Creates todo list with items like: 1) Implementing memoization for expensive calculations in ProductList, 2) Adding virtualization for long lists in Dashboard, 3) Optimizing image loading in Gallery component, 4) Fixing state update loops in ShoppingCart, 5) Reviewing bundle size and implementing code splitting*
+Let's start by implementing memoization for the expensive calculations in your ProductList component.
+
+<reasoning>
+The assistant used the todo list because:
+1. First, the assistant examined the codebase to identify specific performance issues
+2. Based on this analysis, it identified multiple optimization opportunities
+3. Performance optimization is a non-trivial task requiring multiple steps
+4. The todo list helps methodically track improvements across different components
+5. This systematic approach ensures all performance bottlenecks are addressed
+</reasoning>
+</example>
+
+## Examples of When NOT to Use the Todo List
+
+<example>
+User: How do I print 'Hello World' in Python?
+Assistant: In Python, you can print "Hello World" with this simple code:
+
+python
+print("Hello World")
+
+This will output the text "Hello World" to the console when executed.
+
+<reasoning>
+The assistant did not use the todo list because this is a single, trivial task that can be completed in one step. There's no need to track multiple tasks or steps for such a straightforward request.
+</reasoning>
+</example>
+
+<example>
+User: What does the git status command do?
+Assistant: The git status command shows the current state of your working directory and staging area. It displays which changes have been staged, which haven't, and which files aren't being tracked by Git. This is a fundamental command for understanding the current state of your repository before making commits.
+
+<reasoning>
+The assistant did not use the todo list because this is an informational request with no actual coding task to complete. The user is simply asking for an explanation, not for the assistant to perform multiple steps or tasks.
+</reasoning>
+</example>
+
+<example>
+User: Can you add a comment to the calculateTotal function to explain what it does?
+Assistant: Sure, let me add a comment to the calculateTotal function to explain what it does.
+* Uses the system.editFile tool to add a comment to the calculateTotal function *
+
+<reasoning>
+The assistant did not use the todo list because this is a single, straightforward task confined to one location in the code. Adding a comment doesn't require tracking multiple steps or systematic organization.
+</reasoning>
+</example>
+
+<example>
+User: Run npm install for me and tell me what happens.
+Assistant: I'll run the npm install command for you.
+
+*Executes: npm install*
+
+The command completed successfully. Here's the output:
+[Output of npm install command]
+
+All dependencies have been installed according to your package.json file.
+
+<reasoning>
+The assistant did not use the todo list because this is a single command execution with immediate results. There are no multiple steps to track or organize, making the todo list unnecessary for this straightforward task.
+</reasoning>
+</example>
+
+## Task States and Management
+
+1. **Task States**: Use these states to track progress:
+   - pending: Task not yet started
+   - in_progress: Currently working on (limit to ONE task at a time)
+   - completed: Task finished successfully
+
+   **IMPORTANT**: Task descriptions must have two forms:
+   - content: The imperative form describing what needs to be done (e.g., "Run tests", "Build the project")
+   - activeForm: The present continuous form shown during execution (e.g., "Running tests", "Building the project")
+
+2. **Task Management**:
+   - Update task status in real-time as you work
+   - Mark tasks complete IMMEDIATELY after finishing (don't batch completions)
+   - Exactly ONE task must be in_progress at any time (not less, not more)
+   - Complete current tasks before starting new ones
+   - Remove tasks that are no longer relevant from the list entirely
+
+3. **Task Completion Requirements**:
+   - ONLY mark a task as completed when you have FULLY accomplished it
+   - If you encounter errors, blockers, or cannot finish, keep the task as in_progress
+   - When blocked, create a new task describing what needs to be resolved
+   - Never mark a task as completed if:
+     - Tests are failing
+     - Implementation is partial
+     - You encountered unresolved errors
+     - You couldn't find necessary files or dependencies
+
+4. **Task Breakdown**:
+   - Create specific, actionable items
+   - Break complex tasks into smaller, manageable steps
+   - Use clear, descriptive task names
+   - Always provide both forms:
+     - content: "Fix authentication bug"
+     - activeForm: "Fixing authentication bug"
+
+When in doubt, use this tool. Being proactive with task management demonstrates attentiveness and ensures you complete all requirements successfully.
+`;
 
 const TODO_WRITE_SUCCESS_TEXT =
   "Todos have been modified successfully. Ensure that you continue to " +


### PR DESCRIPTION
## Summary

Ships the three missed completion-pressure mechanisms identified during the last audit of upstream prompt surfaces. PR #443 wired the verification contract (adversarial verifier + contract clause + TodoWrite/TaskUpdate completion nudges), but observability of a fresh run showed the model still self-certifying after shrinking the TodoWrite list below the 3-item nudge threshold and ignoring the contract clause across 54 assistant turns. These three additions close the remaining gaps.

## Three mechanisms ported

**1. Full TodoWrite and task.create/task.update tool-description prompts.** Our existing descriptions were 1-sentence summaries; upstream ships ~180-line prompts with explicit \"When to Use / When NOT\", worked examples, Task States and — most importantly — a **Task Completion Requirements** block telling the model:

> Never mark a task as completed if:
>   - Tests are failing
>   - Implementation is partial
>   - You encountered unresolved errors
>   - You couldn't find necessary files or dependencies

The model sees this at every tool-use decision, not just at cycle boundaries. Verbatim port with mechanical substitutions (\`\${FILE_EDIT_TOOL_NAME}\` → \`system.editFile\`, \`TaskCreate\`/\`TaskUpdate\` → \`task.create\`/\`task.update\`). Same treatment for task.create (scenarios + fields + tips) and task.update (status workflow + completion rules + JSON examples).

**2. task_reminder attachment.** A second 10-turn reminder parallel to the existing todo_reminder, gated on task.update rather than TodoWrite. Upstream runs both reminders independently with no mutual suppression. Adding task_reminder as an independent sibling breaks the single-counter deadlock that suppresses all verification nags when the model touches one tool every 9 turns.

Aligns todo_reminder with upstream by dropping the AgenC-specific task.* suppression that was added in PR #442 — mutual suppression is the wrong pattern once both reminders exist. getTurnsSinceRecentTaskToolUse is removed entirely (dead code).

**3. verify_reminder attachment.** Plan-mode-less adaptation of upstream's verify_plan_reminder. Plan mode is deferred, so the trigger is substituted: fires when the model has made >=3 mutating tool calls (writeFile/editFile/appendFile/mkdir/move/delete) since the last verifier spawn AND >=10 assistant turns since the last verify reminder.

Terminators that reset the counter:
- \`execute_with_agent\` with non-empty \`delegationAdmission.verifierObligations\` (structured contract — unsynthesizable without a real verifier spawn)
- \`role === \"tool\"\` message containing \`VERDICT: PASS|FAIL|PARTIAL\` (scoped to tool role so the model can't game the reset by typing the string itself — tool messages are runtime-controlled)

## Commits

1. \`feat(runtime/tools): port full TodoWrite and task.create/task.update tool-description prompts\`
2. \`feat(runtime/llm): add task_reminder attachment and align todo_reminder\`
3. \`feat(runtime/llm): add verify_reminder for cumulative unverified edits\`

## Test plan

- [x] \`npm run typecheck\` clean.
- [x] 117 tests pass across todo-write, task-tracker, todo-reminder, task-reminder, verify-reminder, and attachment-injection suites.
- [x] New unit tests:
  - [x] task-reminder.test.ts: counter semantics (create/update count; list/get/wait/output do not), suppression gates, header emission, list rendering format.
  - [x] verify-reminder.test.ts: mutating-tool counting, verifier-spawn terminator, VERDICT-in-tool-role-only terminator (asserts that VERDICT in assistant or user messages does NOT reset — gaming resistance), turn-since-last-reminder gating.
  - [x] attachment-injection.test.ts: all three reminders routable on the same turn with correct priority (todo → task → verify).
- [x] Existing stateful-transport test failures inherited from PR #441 are untouched and unrelated.
- [ ] Integration (post-merge): \`agenc-runtime restart\`, start a multi-file background run, confirm in the provider.request trace that:
  1. TodoWrite tool description contains the full prompt including \"Task Completion Requirements\".
  2. After 10+ turns without task.create/task.update, the next prompt contains \`The task tools haven't been used recently\`.
  3. After 3+ writeFile/editFile calls without \`execute_with_agent\` + verifierObligations, the next prompt contains \`You have made unverified file edits\`.

## Base note

Based on \`refactor/stateless-transport\` (PR #441) since the task-reminder depends on PR #442's task-tracker wiring. Will rebase to \`main\` when #441 lands.

## Out of scope

- Plan mode (deferred, unchanged).
- Shrink-resistant TodoWrite nudge (the Task Completion Requirements prompt text is the intended mitigation for the shrink pattern — the model is told directly \"Never mark as completed if implementation is partial\" at every TodoWrite decision).