### PR TITLE
fix(runtime/llm): remove tool-description truncation caps

### DIFF
--- a/runtime/src/llm/grok/adapter-utils.test.ts
+++ b/runtime/src/llm/grok/adapter-utils.test.ts
@@ -111,31 +111,49 @@ describe("grok adapter utils", () => {
     expect(firstChain.source).toBe("non_system_messages");
   });
 
-  it("collapses oversized tool schemas to an open object", () => {
+  it("passes long descriptions and large schemas through intact and strips nested metadata", () => {
+    // Previously the runtime truncated descriptions at 200 chars and
+    // collapsed schemas over 3000 chars into a generic open object.
+    // Both caps were removed because they silently defeated
+    // model-contract prompts (TodoWrite "Task Completion Requirements"
+    // etc.). This test asserts the current pass-through behavior plus
+    // the still-needed sanitizeSchema metadata strip.
     const hugeProperties = Object.fromEntries(
       Array.from({ length: 400 }, (_, index) => [
         `field_${index}`,
         { type: "string", description: "x".repeat(32) },
       ]),
     );
+    const longDescription = "y".repeat(4000);
     const tool: LLMTool = {
       type: "function",
       function: {
         name: "system.bash",
-        description: "y".repeat(400),
+        description: longDescription,
         parameters: {
           type: "object",
           properties: hugeProperties,
+          required: ["field_0"],
         },
       },
     };
 
     const slim = toSlimTool(tool).tool;
 
-    expect(slim.function.description?.length).toBeLessThanOrEqual(200);
-    expect(slim.function.parameters).toEqual({
-      type: "object",
-      additionalProperties: true,
-    });
+    // Full description preserved.
+    expect(slim.function.description).toBe(longDescription);
+    // Schema preserved (not collapsed to a generic open object).
+    const params = slim.function.parameters as Record<string, unknown>;
+    expect(params.type).toBe("object");
+    expect((params as { properties?: Record<string, unknown> }).properties)
+      .toBeDefined();
+    const props = params.properties as Record<string, unknown>;
+    expect(Object.keys(props).length).toBe(400);
+    // Nested-field descriptions stripped (Grok-schema sanitization).
+    const firstField = props.field_0 as Record<string, unknown>;
+    expect(firstField.type).toBe("string");
+    expect(firstField.description).toBeUndefined();
+    // required array preserved.
+    expect(params.required).toEqual(["field_0"]);
   });
 });

--- a/runtime/src/llm/grok/adapter-utils.ts
+++ b/runtime/src/llm/grok/adapter-utils.ts
@@ -14,9 +14,6 @@ import type {
 import { sanitizeToolCallArgumentsForReplay } from "../chat-executor-tool-utils.js";
 import { safeStringify } from "../../tools/types.js";
 
-const MAX_TOOL_DESCRIPTION_CHARS = 200;
-const MAX_TOOL_SCHEMA_CHARS_PER_TOOL = 3_000;
-const MAX_TOOL_SCHEMA_CHARS_TOTAL = 40_000;
 const MAX_STATEFUL_RECONCILIATION_WINDOW = 256;
 const STATEFUL_HASH_VERSION = "v1";
 const TOOL_METADATA_KEYS = new Set([
@@ -453,6 +450,15 @@ function toolPriority(name: string): number {
   return 3;
 }
 
+/**
+ * Orders tools by priority and sanitizes nested-schema metadata that
+ * the Grok API rejects (stripping per-field `description`, `title`,
+ * `examples`, etc.). Descriptions and parameter schemas are passed
+ * through intact — previous versions truncated descriptions at 200
+ * chars and collapsed >3000-char schemas to a generic open object,
+ * which silently defeated tool prompts like the full TodoWrite
+ * "Task Completion Requirements" text. Those caps are gone.
+ */
 export function slimTools(
   tools: readonly LLMTool[],
 ): { tools: LLMTool[]; chars: number } {
@@ -470,48 +476,16 @@ export function slimTools(
 
   for (const tool of ordered) {
     const sanitizedParams = sanitizeSchema(tool.function.parameters);
-    let normalizedParams = sanitizedParams;
-    if (
-      JSON.stringify(sanitizedParams).length > MAX_TOOL_SCHEMA_CHARS_PER_TOOL
-    ) {
-      normalizedParams = { type: "object", additionalProperties: true };
-    }
-
     const slim: LLMTool = {
       type: "function",
       function: {
         name: tool.function.name,
-        description: truncate(
-          tool.function.description ?? "",
-          MAX_TOOL_DESCRIPTION_CHARS,
-        ),
-        parameters: normalizedParams as Record<string, unknown>,
+        description: tool.function.description ?? "",
+        parameters: sanitizedParams as Record<string, unknown>,
       },
     };
-
-    const slimChars = JSON.stringify(slim).length;
-    if (usedChars + slimChars > MAX_TOOL_SCHEMA_CHARS_TOTAL) {
-      continue;
-    }
     selected.push(slim);
-    usedChars += slimChars;
-  }
-
-  if (selected.length === 0) {
-    const first = ordered[0];
-    const fallbackTool: LLMTool = {
-      type: "function",
-      function: {
-        name: first.function.name,
-        description: truncate(
-          first.function.description ?? "",
-          MAX_TOOL_DESCRIPTION_CHARS,
-        ),
-        parameters: { type: "object", additionalProperties: true },
-      },
-    };
-    const chars = JSON.stringify(fallbackTool).length;
-    return { tools: [fallbackTool], chars };
+    usedChars += JSON.stringify(slim).length;
   }
 
   return { tools: selected, chars: usedChars };
@@ -519,25 +493,14 @@ export function slimTools(
 
 export function toSlimTool(tool: LLMTool): { tool: LLMTool; chars: number } {
   const sanitizedParams = sanitizeSchema(tool.function.parameters);
-  let normalizedParams = sanitizedParams;
-  if (
-    JSON.stringify(sanitizedParams).length > MAX_TOOL_SCHEMA_CHARS_PER_TOOL
-  ) {
-    normalizedParams = { type: "object", additionalProperties: true };
-  }
-
   const slim: LLMTool = {
     type: "function",
     function: {
       name: tool.function.name,
-      description: truncate(
-        tool.function.description ?? "",
-        MAX_TOOL_DESCRIPTION_CHARS,
-      ),
-      parameters: normalizedParams as Record<string, unknown>,
+      description: tool.function.description ?? "",
+      parameters: sanitizedParams as Record<string, unknown>,
     },
   };
-
   return {
     tool: slim,
     chars: JSON.stringify(slim).length,

--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -1462,7 +1462,7 @@ describe("GrokProvider", () => {
     expect(params.parallel_tool_calls).toBe(true);
   });
 
-  it("sanitizes oversized tool schemas and strips verbose metadata", async () => {
+  it("preserves full tool descriptions and strips nested schema metadata Grok rejects", async () => {
     mockCreate.mockResolvedValueOnce(makeCompletion());
 
     const noisyTool: LLMTool = {
@@ -1492,7 +1492,11 @@ describe("GrokProvider", () => {
 
     const params = mockCreate.mock.calls[0][0];
     const tool = params.tools[0];
-    expect(tool.description.length).toBeLessThanOrEqual(200);
+    // Description passes through intact — the 200-char cap was
+    // structurally defeating model-contract prompts.
+    expect(tool.description).toBe("D".repeat(800));
+    // Nested-schema metadata (description, title, etc.) is still
+    // stripped because Grok rejects those fields.
     const paramsJson = JSON.stringify(tool.parameters);
     expect(paramsJson.includes("description")).toBe(false);
   });


### PR DESCRIPTION
## Summary

The Grok adapter was silently truncating every tool description at 200 characters, collapsing schemas over 3000 characters to a generic open object, and dropping tools whose serialized size pushed the total past 40000 characters. None of these are API requirements.

**Observed impact:** PR #444 ported the upstream TodoWrite description verbatim, including a "Task Completion Requirements" block telling the model \"Never mark a task as completed if tests are failing / implementation is partial / you encountered unresolved errors / you couldn't find necessary files or dependencies.\" The 200-char cap chopped this to its first paragraph before sending. Confirmed in a live provider.request trace artifact: the TodoWrite description the model received ended at \"It also h...\".

## Changes

Remove three caps in \`runtime/src/llm/grok/adapter-utils.ts\`:
- \`MAX_TOOL_DESCRIPTION_CHARS = 200\`
- \`MAX_TOOL_SCHEMA_CHARS_PER_TOOL = 3_000\`
- \`MAX_TOOL_SCHEMA_CHARS_TOTAL = 40_000\`

Keep:
- \`sanitizeSchema\` — still strips nested-field \`description\`/\`title\`/\`examples\` etc. (Grok rejects those in JSON Schema).
- Priority ordering for catalog listings.
- \`truncate\` helper — still used for non-tool text (large content sanitization, tool-call argument logging).

## Test plan

- [x] \`npm run typecheck\` clean.
- [x] \`adapter-utils.test.ts\`: existing test for \"collapses oversized tool schemas\" rewritten as \"passes long descriptions and large schemas through intact and strips nested metadata\" — asserts the 4000-char description is preserved byte-for-byte, 400-property schema keeps all 400 properties, \`required\` preserved, nested descriptions stripped.
- [x] \`adapter.test.ts\`: existing \"sanitizes oversized tool schemas and strips verbose metadata\" rewritten as \"preserves full tool descriptions and strips nested schema metadata Grok rejects\" — asserts the 800-char description passes through intact but nested-field descriptions are still stripped.
- [x] Regression test \"keeps tools on follow-up turns even when tool payload is large\" still passes.
- [x] 70 of 90 adapter tests pass; the 20 failures are pre-existing stateful-transport tests unrelated to this change.

## Out of scope

No runtime state changes. No schema changes. Pure behavior fix at the Grok adapter boundary.