### PR TITLE
feat(runtime): move reminder triggers to runtime state; preserve anchors through compaction

### DIFF
--- a/runtime/src/gateway/background-run-store.ts
+++ b/runtime/src/gateway/background-run-store.ts
@@ -383,6 +383,13 @@ export interface PersistedBackgroundRun {
   readonly cycleCount: number;
   readonly stableWorkingCycles: number;
   readonly consecutiveErrorCycles: number;
+  /**
+   * Persisted runtime counters for the `verify_reminder` trigger.
+   * Optional because records persisted before this field landed
+   * need a deserialization default — see `toActiveRun`.
+   */
+  readonly mutatingEditsSinceLastVerifierSpawn?: number;
+  readonly assistantTurnsSinceLastVerifyReminder?: number;
   readonly anchorFiles: readonly PersistedAnchorFileSnapshot[];
   readonly nextCheckAt?: number;
   readonly nextHeartbeatAt?: number;

--- a/runtime/src/gateway/background-run-supervisor-types.ts
+++ b/runtime/src/gateway/background-run-supervisor-types.ts
@@ -155,6 +155,20 @@ export interface ActiveBackgroundRun {
   cycleCount: number;
   stableWorkingCycles: number;
   consecutiveErrorCycles: number;
+  /**
+   * Runtime counters backing the `verify_reminder` trigger. These are
+   * persisted state rather than scan-derived from history because their
+   * anchors are singular past events — a verifier spawn, a prior
+   * reminder emission — that history compaction can summarize away.
+   * Separation of "runtime bookkeeping state" from "model-visible
+   * context" matches the reference runtime's `AppState.pendingPlanVerification`
+   * pattern and the SOTA position from ESAA / LangGraph / OpenAI
+   * Assistants runs. Read by `collectAttachments` at the start of the
+   * next cycle; written at the end of the current cycle after
+   * `recordToolEvidence`.
+   */
+  mutatingEditsSinceLastVerifierSpawn: number;
+  assistantTurnsSinceLastVerifyReminder: number;
   anchorFiles: AnchorFileSnapshot[];
   nextCheckAt?: number;
   nextHeartbeatAt?: number;
@@ -372,6 +386,10 @@ export function toPersistedRun(run: ActiveBackgroundRun): PersistedBackgroundRun
     cycleCount: run.cycleCount,
     stableWorkingCycles: run.stableWorkingCycles,
     consecutiveErrorCycles: run.consecutiveErrorCycles,
+    mutatingEditsSinceLastVerifierSpawn:
+      run.mutatingEditsSinceLastVerifierSpawn,
+    assistantTurnsSinceLastVerifyReminder:
+      run.assistantTurnsSinceLastVerifyReminder,
     anchorFiles: [...run.anchorFiles],
     nextCheckAt: run.nextCheckAt,
     nextHeartbeatAt: run.nextHeartbeatAt,
@@ -455,6 +473,20 @@ export function toActiveRun(run: PersistedBackgroundRun): ActiveBackgroundRun {
     cycleCount: run.cycleCount,
     stableWorkingCycles: run.stableWorkingCycles,
     consecutiveErrorCycles: run.consecutiveErrorCycles,
+    // Explicit defaults for runs persisted before the counters landed:
+    //   - edit counter defaults to 0 so only post-upgrade mutating
+    //     tool calls accrue toward the verify_reminder threshold.
+    //   - turn counter defaults to Infinity so the first reminder
+    //     fires as soon as the edit threshold hits after an upgrade
+    //     (no spurious 10-turn delay on first boot after this PR).
+    mutatingEditsSinceLastVerifierSpawn:
+      typeof run.mutatingEditsSinceLastVerifierSpawn === "number"
+        ? run.mutatingEditsSinceLastVerifierSpawn
+        : 0,
+    assistantTurnsSinceLastVerifyReminder:
+      typeof run.assistantTurnsSinceLastVerifyReminder === "number"
+        ? run.assistantTurnsSinceLastVerifyReminder
+        : Number.POSITIVE_INFINITY,
     anchorFiles: [...run.anchorFiles],
     nextCheckAt: run.nextCheckAt,
     nextHeartbeatAt: run.nextHeartbeatAt,

--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -17,6 +17,7 @@ import { normalizePromptEnvelope } from "../llm/prompt-envelope.js";
 import { buildModelOnlyChatOptions } from "../llm/model-only-options.js";
 import { getCompactPrompt, formatCompactSummary } from "../llm/compact/prompt.js";
 import type { LLMMessage, LLMProvider, ToolHandler } from "../llm/types.js";
+import { partitionByAnchorPreserve } from "../llm/types.js";
 import { collectAttachments } from "../llm/attachment-injection.js";
 import type { Logger } from "../utils/logger.js";
 import { silentLogger } from "../utils/logger.js";
@@ -4263,21 +4264,16 @@ export class BackgroundRunSupervisor {
     }
     const toSummarize = history.slice(0, -keepTail);
     const kept = history.slice(-keepTail);
-    try {
-      const historyText = toSummarize
-        .map((m) => `[${m.role}]: ${typeof m.content === "string" ? m.content : JSON.stringify(m.content)}`)
-        .join("\n\n");
-      const response = await this.supervisorLlm.chat(
-        [
-          { role: "system", content: getCompactPrompt() },
-          { role: "user", content: historyText },
-        ],
-        buildModelOnlyChatOptions({ toolChoice: "none" }),
-      );
-      const summary = formatCompactSummary(response.content).trim();
-      if (summary.length === 0) {
-        return history;
-      }
+    // Anchor-marked messages survive compaction boundaries —
+    // upstream's `messagesToKeep` pattern. Runtime-injected
+    // reminders rely on their own prior presence as a re-emission
+    // anti-spam anchor; if compaction summarized them away, the
+    // next cycle would re-inject immediately.
+    const { anchorPreserved, rest: toActuallySummarize } =
+      partitionByAnchorPreserve(toSummarize);
+    // Breaking the xAI stateful chain is independent of whether
+    // summarization actually runs — any compaction pass clears it.
+    const breakProviderContinuation = (): void => {
       run.compaction = {
         ...run.compaction,
         refreshCount: run.compaction.refreshCount + 1,
@@ -4293,8 +4289,42 @@ export class BackgroundRunSupervisor {
           providerContinuation: undefined,
         };
       }
+    };
+    // All summarizable messages were anchor-preserved → nothing to
+    // ask the summarizer model. Emit a stub system message so the
+    // result always starts with a system role (consistent with the
+    // normal compaction output) and skip the provider call.
+    if (toActuallySummarize.length === 0) {
+      breakProviderContinuation();
+      return [
+        {
+          role: "system",
+          content:
+            "[previous messages compacted; anchor-preserved reminders retained]",
+        } as LLMMessage,
+        ...anchorPreserved,
+        ...kept,
+      ];
+    }
+    try {
+      const historyText = toActuallySummarize
+        .map((m) => `[${m.role}]: ${typeof m.content === "string" ? m.content : JSON.stringify(m.content)}`)
+        .join("\n\n");
+      const response = await this.supervisorLlm.chat(
+        [
+          { role: "system", content: getCompactPrompt() },
+          { role: "user", content: historyText },
+        ],
+        buildModelOnlyChatOptions({ toolChoice: "none" }),
+      );
+      const summary = formatCompactSummary(response.content).trim();
+      if (summary.length === 0) {
+        return history;
+      }
+      breakProviderContinuation();
       return [
         { role: "system", content: summary } as LLMMessage,
+        ...anchorPreserved,
         ...kept,
       ];
     } catch {

--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -19,6 +19,12 @@ import { getCompactPrompt, formatCompactSummary } from "../llm/compact/prompt.js
 import type { LLMMessage, LLMProvider, ToolHandler } from "../llm/types.js";
 import { partitionByAnchorPreserve } from "../llm/types.js";
 import { collectAttachments } from "../llm/attachment-injection.js";
+import {
+  containsVerdictMarkerInToolResult,
+  isMutatingTool,
+  isVerifierSpawnFromRecord,
+  messageContainsVerifyReminderPrefix,
+} from "../llm/verify-reminder.js";
 import type { Logger } from "../utils/logger.js";
 import { silentLogger } from "../utils/logger.js";
 import { toErrorMessage } from "../utils/async.js";
@@ -1867,6 +1873,10 @@ export class BackgroundRunSupervisor {
       cycleCount: 0,
       stableWorkingCycles: 0,
       consecutiveErrorCycles: 0,
+      mutatingEditsSinceLastVerifierSpawn: 0,
+      // Infinity so the first verify_reminder is eligible to fire as
+      // soon as the edit threshold is reached on a fresh run.
+      assistantTurnsSinceLastVerifyReminder: Number.POSITIVE_INFINITY,
       anchorFiles: initialAnchorFiles,
       lastVerifiedAt: undefined,
       lastUserUpdate: undefined,
@@ -3885,6 +3895,31 @@ export class BackgroundRunSupervisor {
         ]);
         run.lastVerifiedAt = this.now();
         recordToolEvidence(run, actorResult.toolCalls);
+        // Update runtime counters that back the verify_reminder trigger.
+        // These live on ActiveBackgroundRun, not in LLM history —
+        // compaction-safe. Read at the start of the NEXT cycle by
+        // `collectAttachments` in `prepareCycleContext`. One-cycle
+        // latency is acceptable given the 10-turn reminder cadence.
+        //
+        // Verifier spawn and VERDICT-result resets target only the
+        // edit counter. The turn counter resets exclusively when the
+        // reminder actually fires (see prepareCycleContext below) so
+        // that spawning a verifier does not suppress the reminder for
+        // the following 10 turns — if the model fails to verify and
+        // keeps making edits after a spawn, the reminder fires again
+        // once the next edit threshold crosses.
+        for (const call of actorResult.toolCalls) {
+          if (isMutatingTool(call.name)) {
+            run.mutatingEditsSinceLastVerifierSpawn += 1;
+          }
+          if (isVerifierSpawnFromRecord(call)) {
+            run.mutatingEditsSinceLastVerifierSpawn = 0;
+          }
+          if (containsVerdictMarkerInToolResult(call)) {
+            run.mutatingEditsSinceLastVerifierSpawn = 0;
+          }
+        }
+        run.assistantTurnsSinceLastVerifyReminder += 1;
         recordProviderCompactionArtifacts(run, actorResult);
         run.continuationMode = resolveBackgroundContinuationMode(actorResult);
         const verifierStages = actorResult.runtimeContractSnapshot?.verifierStages;
@@ -4063,9 +4098,23 @@ export class BackgroundRunSupervisor {
       activeToolNames,
       todos,
       tasks,
+      mutatingEditsSinceLastVerifierSpawn:
+        run.mutatingEditsSinceLastVerifierSpawn,
+      assistantTurnsSinceLastVerifyReminder:
+        run.assistantTurnsSinceLastVerifyReminder,
     });
     for (const attachment of attachments.messages) {
       run.internalHistory.push(attachment);
+    }
+    // Reset the turn counter if a verify_reminder was just emitted.
+    // Scans up to ~3 messages (the attachment payload is tiny) —
+    // cheaper than extending AttachmentInjectionResult and keeping
+    // the webchat/text-channel call sites in sync with a field they
+    // would never use.
+    if (
+      attachments.messages.some((m) => messageContainsVerifyReminderPrefix(m))
+    ) {
+      run.assistantTurnsSinceLastVerifyReminder = 0;
     }
 
     return {

--- a/runtime/src/llm/attachment-injection.test.ts
+++ b/runtime/src/llm/attachment-injection.test.ts
@@ -165,36 +165,14 @@ describe("collectAttachments", () => {
     expect(todoIdx).toBeLessThan(taskIdx);
   });
 
-  it("emits the verify_reminder after 3+ mutating edits without a verifier spawn", () => {
-    const history: LLMMessage[] = [
-      ...buildStaleHistory(),
-      {
-        role: "assistant",
-        content: "",
-        toolCalls: [
-          { id: "w1", name: "system.writeFile", arguments: "{}" },
-        ],
-      },
-      {
-        role: "assistant",
-        content: "",
-        toolCalls: [
-          { id: "w2", name: "system.editFile", arguments: "{}" },
-        ],
-      },
-      {
-        role: "assistant",
-        content: "",
-        toolCalls: [
-          { id: "w3", name: "system.writeFile", arguments: "{}" },
-        ],
-      },
-    ];
+  it("emits the verify_reminder when counters exceed threshold and execute_with_agent is advertised", () => {
     const result = collectAttachments({
-      history,
+      history: buildStaleHistory(),
       activeToolNames: new Set([TODO_WRITE_TOOL_NAME, "execute_with_agent"]),
       todos: [],
       tasks: [],
+      mutatingEditsSinceLastVerifierSpawn: 5,
+      assistantTurnsSinceLastVerifyReminder: 12,
     });
     const verifyMsg = result.messages.find((m) =>
       (m.content as string).includes("You have made unverified file edits"),
@@ -202,36 +180,60 @@ describe("collectAttachments", () => {
     expect(verifyMsg).toBeDefined();
   });
 
-  it("does not emit verify_reminder when execute_with_agent is not available", () => {
-    const history: LLMMessage[] = [
-      ...buildStaleHistory(),
-      {
-        role: "assistant",
-        content: "",
-        toolCalls: [
-          { id: "w1", name: "system.writeFile", arguments: "{}" },
-        ],
-      },
-      {
-        role: "assistant",
-        content: "",
-        toolCalls: [
-          { id: "w2", name: "system.writeFile", arguments: "{}" },
-        ],
-      },
-      {
-        role: "assistant",
-        content: "",
-        toolCalls: [
-          { id: "w3", name: "system.writeFile", arguments: "{}" },
-        ],
-      },
-    ];
+  it("does not emit verify_reminder when counters are omitted (interactive surface)", () => {
     const result = collectAttachments({
-      history,
+      history: buildStaleHistory(),
+      activeToolNames: new Set([TODO_WRITE_TOOL_NAME, "execute_with_agent"]),
+      todos: [],
+      tasks: [],
+    });
+    expect(
+      result.messages.some((m) =>
+        (m.content as string).includes("You have made unverified file edits"),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not emit verify_reminder when execute_with_agent is not advertised", () => {
+    const result = collectAttachments({
+      history: buildStaleHistory(),
       activeToolNames: new Set([TODO_WRITE_TOOL_NAME]),
       todos: [],
       tasks: [],
+      mutatingEditsSinceLastVerifierSpawn: 100,
+      assistantTurnsSinceLastVerifyReminder: 100,
+    });
+    expect(
+      result.messages.some((m) =>
+        (m.content as string).includes("You have made unverified file edits"),
+      ),
+    ).toBe(false);
+  });
+
+  it("suppresses verify_reminder when edit counter is below threshold", () => {
+    const result = collectAttachments({
+      history: buildStaleHistory(),
+      activeToolNames: new Set([TODO_WRITE_TOOL_NAME, "execute_with_agent"]),
+      todos: [],
+      tasks: [],
+      mutatingEditsSinceLastVerifierSpawn: 2,
+      assistantTurnsSinceLastVerifyReminder: 100,
+    });
+    expect(
+      result.messages.some((m) =>
+        (m.content as string).includes("You have made unverified file edits"),
+      ),
+    ).toBe(false);
+  });
+
+  it("suppresses verify_reminder when turn counter is below cadence", () => {
+    const result = collectAttachments({
+      history: buildStaleHistory(),
+      activeToolNames: new Set([TODO_WRITE_TOOL_NAME, "execute_with_agent"]),
+      todos: [],
+      tasks: [],
+      mutatingEditsSinceLastVerifierSpawn: 10,
+      assistantTurnsSinceLastVerifyReminder: 3,
     });
     expect(
       result.messages.some((m) =>

--- a/runtime/src/llm/attachment-injection.ts
+++ b/runtime/src/llm/attachment-injection.ts
@@ -45,6 +45,22 @@ export interface AttachmentContext {
   readonly activeToolNames: ReadonlySet<string>;
   readonly todos: readonly TodoItem[];
   readonly tasks: readonly ReminderTaskView[];
+  /**
+   * Runtime counters that back the `verify_reminder` trigger. Supplied
+   * by the background-run supervisor (where they live on
+   * `ActiveBackgroundRun`); omitted by interactive (webchat,
+   * text-channel) call sites where the reminder is out of scope —
+   * interactive turns are short-horizon and do not accumulate
+   * unverified edits the way background runs do.
+   *
+   * Separating these counters from history (rather than scanning for
+   * an anchor event such as an `execute_with_agent` tool_use with
+   * `verifierObligations`) matches the reference runtime's
+   * `AppState.pendingPlanVerification` pattern and survives history
+   * compaction.
+   */
+  readonly mutatingEditsSinceLastVerifierSpawn?: number;
+  readonly assistantTurnsSinceLastVerifyReminder?: number;
 }
 
 export interface AttachmentInjectionResult {

--- a/runtime/src/llm/attachment-injection.ts
+++ b/runtime/src/llm/attachment-injection.ts
@@ -89,8 +89,11 @@ export function collectAttachments(
   }
   if (
     shouldInjectVerifyReminder({
-      history: ctx.history,
       activeToolNames: ctx.activeToolNames,
+      mutatingEditsSinceLastVerifierSpawn:
+        ctx.mutatingEditsSinceLastVerifierSpawn,
+      assistantTurnsSinceLastVerifyReminder:
+        ctx.assistantTurnsSinceLastVerifyReminder,
     })
   ) {
     messages.push(buildVerifyReminderMessage());

--- a/runtime/src/llm/task-reminder.test.ts
+++ b/runtime/src/llm/task-reminder.test.ts
@@ -199,10 +199,11 @@ describe("buildTaskReminderMessage", () => {
     expect(content).toContain("NEVER mention this reminder");
   });
 
-  it("emits user role with runtime-only user_context merge boundary", () => {
+  it("emits user role with runtime-only user_context merge boundary and anchorPreserve", () => {
     const msg = buildTaskReminderMessage([]);
     expect(msg.role).toBe("user");
     expect(msg.runtimeOnly?.mergeBoundary).toBe("user_context");
+    expect(msg.runtimeOnly?.anchorPreserve).toBe(true);
   });
 
   it("appends the task list when tasks exist", () => {

--- a/runtime/src/llm/task-reminder.ts
+++ b/runtime/src/llm/task-reminder.ts
@@ -129,6 +129,6 @@ export function buildTaskReminderMessage(
   return {
     role: "user",
     content: `<system-reminder>\n${TASK_REMINDER_HEADER}${list}\n</system-reminder>`,
-    runtimeOnly: { mergeBoundary: "user_context" },
+    runtimeOnly: { mergeBoundary: "user_context", anchorPreserve: true },
   };
 }

--- a/runtime/src/llm/todo-reminder.test.ts
+++ b/runtime/src/llm/todo-reminder.test.ts
@@ -232,5 +232,6 @@ describe("buildTodoReminderMessage", () => {
   it("marks the runtime-only merge boundary so downstream surfaces filter it", () => {
     const message = buildTodoReminderMessage([]);
     expect(message.runtimeOnly?.mergeBoundary).toBe("user_context");
+    expect(message.runtimeOnly?.anchorPreserve).toBe(true);
   });
 });

--- a/runtime/src/llm/todo-reminder.ts
+++ b/runtime/src/llm/todo-reminder.ts
@@ -148,6 +148,6 @@ export function buildTodoReminderMessage(
   return {
     role: "user",
     content: `<system-reminder>\n${TODO_REMINDER_HEADER}${list}\n</system-reminder>`,
-    runtimeOnly: { mergeBoundary: "user_context" },
+    runtimeOnly: { mergeBoundary: "user_context", anchorPreserve: true },
   };
 }

--- a/runtime/src/llm/types.test.ts
+++ b/runtime/src/llm/types.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { validateToolCall, validateToolCallDetailed } from "./types.js";
+import {
+  isAnchorPreserved,
+  partitionByAnchorPreserve,
+  validateToolCall,
+  validateToolCallDetailed,
+  type LLMMessage,
+} from "./types.js";
 
 describe("validateToolCall", () => {
   it("accepts a valid tool call payload", () => {
@@ -87,5 +93,76 @@ describe("validateToolCall", () => {
       code: "non_object_arguments",
       message: "Tool call arguments must decode to a JSON object.",
     });
+  });
+});
+
+describe("isAnchorPreserved", () => {
+  it("returns true only when runtimeOnly.anchorPreserve === true", () => {
+    const yes: LLMMessage = {
+      role: "user",
+      content: "x",
+      runtimeOnly: { anchorPreserve: true },
+    };
+    const noUndefined: LLMMessage = { role: "user", content: "x" };
+    const noExplicitFalse: LLMMessage = {
+      role: "user",
+      content: "x",
+      runtimeOnly: { anchorPreserve: false },
+    };
+    const noOtherRuntimeOnly: LLMMessage = {
+      role: "user",
+      content: "x",
+      runtimeOnly: { mergeBoundary: "user_context" },
+    };
+    expect(isAnchorPreserved(yes)).toBe(true);
+    expect(isAnchorPreserved(noUndefined)).toBe(false);
+    expect(isAnchorPreserved(noExplicitFalse)).toBe(false);
+    expect(isAnchorPreserved(noOtherRuntimeOnly)).toBe(false);
+  });
+});
+
+describe("partitionByAnchorPreserve", () => {
+  const mk = (
+    id: string,
+    preserve: boolean,
+  ): LLMMessage => ({
+    role: "user",
+    content: id,
+    ...(preserve
+      ? { runtimeOnly: { anchorPreserve: true } }
+      : {}),
+  });
+
+  it("splits into anchor-preserved and rest, preserving within-subset order", () => {
+    const history = [
+      mk("a", false),
+      mk("b", true),
+      mk("c", false),
+      mk("d", true),
+      mk("e", false),
+    ];
+    const { anchorPreserved, rest } = partitionByAnchorPreserve(history);
+    expect(anchorPreserved.map((m) => m.content)).toEqual(["b", "d"]);
+    expect(rest.map((m) => m.content)).toEqual(["a", "c", "e"]);
+  });
+
+  it("returns two empty arrays for empty input", () => {
+    const { anchorPreserved, rest } = partitionByAnchorPreserve([]);
+    expect(anchorPreserved).toEqual([]);
+    expect(rest).toEqual([]);
+  });
+
+  it("returns all-rest when no message is anchor-preserved", () => {
+    const history = [mk("a", false), mk("b", false)];
+    const { anchorPreserved, rest } = partitionByAnchorPreserve(history);
+    expect(anchorPreserved).toEqual([]);
+    expect(rest.map((m) => m.content)).toEqual(["a", "b"]);
+  });
+
+  it("returns all-anchor-preserved when every message is marked", () => {
+    const history = [mk("a", true), mk("b", true)];
+    const { anchorPreserved, rest } = partitionByAnchorPreserve(history);
+    expect(anchorPreserved.map((m) => m.content)).toEqual(["a", "b"]);
+    expect(rest).toEqual([]);
   });
 });

--- a/runtime/src/llm/types.ts
+++ b/runtime/src/llm/types.ts
@@ -45,6 +45,18 @@ export interface LLMMessage {
    */
   runtimeOnly?: {
     readonly mergeBoundary?: "user_context";
+    /**
+     * When `true`, this message is preserved across compaction
+     * boundaries. Compaction extracts anchor-marked messages from
+     * the segment being summarized and retains them alongside the
+     * kept tail — matches upstream's `messagesToKeep` pattern at
+     * `services/compact/compact.ts`. Reserved for messages the
+     * runtime depends on for trigger anchoring (e.g. injected
+     * reminders whose re-emission gates scan for prior-injection
+     * headers in history). Use sparingly; anchor messages that
+     * accumulate indefinitely inflate post-compact history.
+     */
+    readonly anchorPreserve?: boolean;
   };
   /** For assistant messages that request tool execution */
   toolCalls?: LLMToolCall[];
@@ -737,4 +749,34 @@ export function validateToolCallDetailed(
 
 export function validateToolCall(raw: unknown): LLMToolCall | null {
   return validateToolCallDetailed(raw).toolCall;
+}
+
+/**
+ * Returns `true` if the message should survive compaction boundaries.
+ * Compaction callers partition history into `anchorPreserved` (retained
+ * alongside the kept tail) and the rest (summarized into a single
+ * system message). Matches upstream's `messagesToKeep` pattern.
+ */
+export function isAnchorPreserved(message: LLMMessage): boolean {
+  return message.runtimeOnly?.anchorPreserve === true;
+}
+
+/**
+ * Split a history slice into the anchor-preserved subset and the rest.
+ * Order is preserved within each subset. Used by compaction to decide
+ * what to summarize (non-anchor) vs what to retain verbatim (anchor).
+ */
+export function partitionByAnchorPreserve(
+  messages: readonly LLMMessage[],
+): { anchorPreserved: LLMMessage[]; rest: LLMMessage[] } {
+  const anchorPreserved: LLMMessage[] = [];
+  const rest: LLMMessage[] = [];
+  for (const message of messages) {
+    if (isAnchorPreserved(message)) {
+      anchorPreserved.push(message);
+    } else {
+      rest.push(message);
+    }
+  }
+  return { anchorPreserved, rest };
 }

--- a/runtime/src/llm/verify-reminder.test.ts
+++ b/runtime/src/llm/verify-reminder.test.ts
@@ -5,257 +5,217 @@ import {
   VERIFY_REMINDER_HEADER_PREFIX,
   VERIFY_REMINDER_TURNS_BETWEEN_REMINDERS,
   buildVerifyReminderMessage,
-  getMutatingEditsSinceLastVerifierSpawn,
-  getTurnsSinceLastVerifyReminder,
+  containsVerdictMarkerInToolResult,
+  isMutatingTool,
+  isVerifierSpawnFromRecord,
+  messageContainsVerifyReminderPrefix,
   shouldInjectVerifyReminder,
 } from "./verify-reminder.js";
 
-function userText(content: string): LLMMessage {
-  return { role: "user", content };
-}
-
-function assistantText(content: string): LLMMessage {
-  return { role: "assistant", content };
-}
-
-function toolResult(content: string, toolCallId = "call-1"): LLMMessage {
-  return { role: "tool", content, toolCallId };
-}
-
-function assistantMutation(toolName: string): LLMMessage {
-  return {
-    role: "assistant",
-    content: "",
-    toolCalls: [
-      {
-        id: `call-${toolName}-${Math.random()}`,
-        name: toolName,
-        arguments: "{}",
-      },
-    ],
-  };
-}
-
-function assistantVerifierSpawn(
-  obligations: readonly string[] = ["build passes"],
-): LLMMessage {
-  return {
-    role: "assistant",
-    content: "",
-    toolCalls: [
-      {
-        id: "call-ewa",
-        name: "execute_with_agent",
-        arguments: JSON.stringify({
-          task: "verify the implementation",
-          delegationAdmission: { verifierObligations: obligations },
-        }),
-      },
-    ],
-  };
-}
-
-describe("getMutatingEditsSinceLastVerifierSpawn", () => {
-  it("returns 0 for empty history", () => {
-    expect(getMutatingEditsSinceLastVerifierSpawn([])).toBe(0);
-  });
-
-  it("counts writeFile/editFile/appendFile/mkdir/move/delete", () => {
-    const history: LLMMessage[] = [
-      assistantMutation("system.writeFile"),
-      assistantMutation("system.editFile"),
-      assistantMutation("system.appendFile"),
-      assistantMutation("system.mkdir"),
-      assistantMutation("system.move"),
-      assistantMutation("system.delete"),
-    ];
-    expect(getMutatingEditsSinceLastVerifierSpawn(history)).toBe(6);
-  });
-
-  it("does NOT count task.*, readFile, listDir, bash, or non-mutating tools", () => {
-    const history: LLMMessage[] = [
-      assistantMutation("system.readFile"),
-      assistantMutation("system.listDir"),
-      assistantMutation("system.bash"),
-      assistantMutation("task.create"),
-      assistantMutation("task.update"),
-      assistantMutation("TodoWrite"),
-    ];
-    expect(getMutatingEditsSinceLastVerifierSpawn(history)).toBe(0);
-  });
-
-  it("stops counting at the most recent execute_with_agent spawn with verifierObligations", () => {
-    const history: LLMMessage[] = [
-      assistantMutation("system.writeFile"),
-      assistantMutation("system.editFile"),
-      assistantVerifierSpawn(["build passes"]),
-      assistantMutation("system.writeFile"),
-    ];
-    // Only the write after the spawn is counted.
-    expect(getMutatingEditsSinceLastVerifierSpawn(history)).toBe(1);
-  });
-
-  it("ignores execute_with_agent calls without verifierObligations", () => {
-    const bareSpawn: LLMMessage = {
-      role: "assistant",
-      content: "",
-      toolCalls: [
-        {
-          id: "call-ewa-bare",
-          name: "execute_with_agent",
-          arguments: JSON.stringify({ task: "do a thing" }),
-        },
-      ],
-    };
-    const history: LLMMessage[] = [
-      assistantMutation("system.writeFile"),
-      bareSpawn,
-      assistantMutation("system.writeFile"),
-    ];
-    expect(getMutatingEditsSinceLastVerifierSpawn(history)).toBe(2);
-  });
-
-  it("stops counting at a tool-role message containing VERDICT: PASS", () => {
-    const history: LLMMessage[] = [
-      assistantMutation("system.writeFile"),
-      assistantMutation("system.editFile"),
-      toolResult("some output...\n\nVERDICT: PASS\n"),
-      assistantMutation("system.writeFile"),
-    ];
-    expect(getMutatingEditsSinceLastVerifierSpawn(history)).toBe(1);
-  });
-
-  it("recognizes FAIL and PARTIAL verdict markers too", () => {
-    for (const verdict of ["VERDICT: FAIL", "VERDICT: PARTIAL"]) {
-      const history: LLMMessage[] = [
-        assistantMutation("system.writeFile"),
-        toolResult(`output\n${verdict}\n`),
-        assistantMutation("system.editFile"),
-      ];
-      expect(getMutatingEditsSinceLastVerifierSpawn(history)).toBe(1);
+describe("isMutatingTool", () => {
+  it("identifies structured file-modification tools", () => {
+    for (const name of [
+      "system.writeFile",
+      "system.editFile",
+      "system.appendFile",
+      "system.mkdir",
+      "system.move",
+      "system.delete",
+    ]) {
+      expect(isMutatingTool(name)).toBe(true);
     }
   });
 
-  it("does NOT treat VERDICT text in assistant messages as a terminator", () => {
-    // Gaming-resistance: only role === "tool" messages reset the counter.
-    const history: LLMMessage[] = [
-      assistantMutation("system.writeFile"),
-      assistantMutation("system.editFile"),
-      assistantText("I've done the work. VERDICT: PASS"),
-      assistantMutation("system.writeFile"),
-    ];
-    expect(getMutatingEditsSinceLastVerifierSpawn(history)).toBe(3);
-  });
-
-  it("does NOT treat VERDICT text in user messages as a terminator", () => {
-    const history: LLMMessage[] = [
-      assistantMutation("system.writeFile"),
-      userText("user wrote: VERDICT: PASS"),
-      assistantMutation("system.editFile"),
-    ];
-    expect(getMutatingEditsSinceLastVerifierSpawn(history)).toBe(2);
+  it("does NOT count read-only or shell tools", () => {
+    for (const name of [
+      "system.readFile",
+      "system.listDir",
+      "system.stat",
+      "system.grep",
+      "system.bash",
+      "task.create",
+      "task.update",
+      "TodoWrite",
+      "execute_with_agent",
+    ]) {
+      expect(isMutatingTool(name)).toBe(false);
+    }
   });
 });
 
-describe("getTurnsSinceLastVerifyReminder", () => {
-  it("returns Infinity when no reminder has been injected", () => {
+describe("isVerifierSpawnFromRecord", () => {
+  const args = (payload: Record<string, unknown>) => payload;
+
+  it("returns true for execute_with_agent with non-empty verifierObligations", () => {
     expect(
-      getTurnsSinceLastVerifyReminder([
-        userText("u1"),
-        assistantText("a1"),
-      ]),
-    ).toBe(Number.POSITIVE_INFINITY);
+      isVerifierSpawnFromRecord({
+        name: "execute_with_agent",
+        args: args({
+          task: "verify",
+          delegationAdmission: { verifierObligations: ["build passes"] },
+        }),
+      }),
+    ).toBe(true);
   });
 
-  it("detects a prior reminder via the header prefix", () => {
-    const reminder: LLMMessage = {
-      role: "user",
-      content: `<system-reminder>\n${VERIFY_REMINDER_HEADER_PREFIX} ...\n</system-reminder>`,
-    };
-    const history: LLMMessage[] = [
-      userText("other"),
-      reminder,
-      assistantText("a"),
-      assistantText("b"),
-    ];
-    expect(getTurnsSinceLastVerifyReminder(history)).toBe(2);
-  });
-});
-
-describe("shouldInjectVerifyReminder", () => {
-  const activeTools = new Set<string>(["execute_with_agent"]);
-
-  it("returns false when execute_with_agent is not in the toolset", () => {
-    const history: LLMMessage[] = [
-      assistantMutation("system.writeFile"),
-      assistantMutation("system.writeFile"),
-      assistantMutation("system.writeFile"),
-    ];
+  it("returns false for execute_with_agent without verifierObligations", () => {
     expect(
-      shouldInjectVerifyReminder({
-        history,
-        activeToolNames: new Set<string>(),
+      isVerifierSpawnFromRecord({
+        name: "execute_with_agent",
+        args: args({ task: "something" }),
       }),
     ).toBe(false);
   });
 
-  it("returns false when under the edit threshold", () => {
-    const history: LLMMessage[] = [
-      assistantMutation("system.writeFile"),
-      assistantMutation("system.writeFile"),
-    ];
+  it("returns false for execute_with_agent with empty verifierObligations array", () => {
     expect(
-      shouldInjectVerifyReminder({ history, activeToolNames: activeTools }),
+      isVerifierSpawnFromRecord({
+        name: "execute_with_agent",
+        args: args({ delegationAdmission: { verifierObligations: [] } }),
+      }),
     ).toBe(false);
   });
 
-  it("returns true at exactly the edit threshold with no recent reminder", () => {
-    const history: LLMMessage[] = Array.from(
-      { length: VERIFY_REMINDER_EDIT_THRESHOLD },
-      () => assistantMutation("system.writeFile"),
-    );
+  it("returns false for non execute_with_agent tools even with the field", () => {
     expect(
-      shouldInjectVerifyReminder({ history, activeToolNames: activeTools }),
+      isVerifierSpawnFromRecord({
+        name: "task.create",
+        args: args({
+          delegationAdmission: { verifierObligations: ["x"] },
+        }),
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("containsVerdictMarkerInToolResult", () => {
+  it("matches VERDICT: PASS|FAIL|PARTIAL only in execute_with_agent results", () => {
+    for (const verdict of ["VERDICT: PASS", "VERDICT: FAIL", "VERDICT: PARTIAL"]) {
+      expect(
+        containsVerdictMarkerInToolResult({
+          name: "execute_with_agent",
+          result: `some output\n${verdict}\n`,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("does NOT match VERDICT strings in unrelated tool results (scoping)", () => {
+    for (const toolName of ["system.bash", "system.grep", "system.readFile"]) {
+      expect(
+        containsVerdictMarkerInToolResult({
+          name: toolName,
+          result: "here is some grep output containing VERDICT: PASS",
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("returns false when execute_with_agent result has no marker", () => {
+    expect(
+      containsVerdictMarkerInToolResult({
+        name: "execute_with_agent",
+        result: "subagent completed; no verdict line",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("messageContainsVerifyReminderPrefix", () => {
+  it("matches the header prefix in string content", () => {
+    const msg: LLMMessage = {
+      role: "user",
+      content: `<system-reminder>\n${VERIFY_REMINDER_HEADER_PREFIX} More text\n</system-reminder>`,
+    };
+    expect(messageContainsVerifyReminderPrefix(msg)).toBe(true);
+  });
+
+  it("matches the header prefix in content parts", () => {
+    const msg: LLMMessage = {
+      role: "user",
+      content: [
+        { type: "text", text: "before" },
+        {
+          type: "text",
+          text: `<system-reminder>\n${VERIFY_REMINDER_HEADER_PREFIX} …\n</system-reminder>`,
+        },
+      ],
+    };
+    expect(messageContainsVerifyReminderPrefix(msg)).toBe(true);
+  });
+
+  it("returns false when the prefix is not present", () => {
+    expect(
+      messageContainsVerifyReminderPrefix({
+        role: "user",
+        content: "ordinary user message",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("shouldInjectVerifyReminder", () => {
+  const active = new Set<string>(["execute_with_agent"]);
+
+  it("returns false when execute_with_agent is not advertised", () => {
+    expect(
+      shouldInjectVerifyReminder({
+        activeToolNames: new Set<string>(),
+        mutatingEditsSinceLastVerifierSpawn: 999,
+        assistantTurnsSinceLastVerifyReminder: 999,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when the edit counter is undefined (interactive surface)", () => {
+    expect(
+      shouldInjectVerifyReminder({
+        activeToolNames: active,
+        mutatingEditsSinceLastVerifierSpawn: undefined,
+        assistantTurnsSinceLastVerifyReminder: 999,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when edit counter is below the threshold", () => {
+    expect(
+      shouldInjectVerifyReminder({
+        activeToolNames: active,
+        mutatingEditsSinceLastVerifierSpawn: VERIFY_REMINDER_EDIT_THRESHOLD - 1,
+        assistantTurnsSinceLastVerifyReminder: 999,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when turn counter is below the between-reminders cadence", () => {
+    expect(
+      shouldInjectVerifyReminder({
+        activeToolNames: active,
+        mutatingEditsSinceLastVerifierSpawn: VERIFY_REMINDER_EDIT_THRESHOLD,
+        assistantTurnsSinceLastVerifyReminder:
+          VERIFY_REMINDER_TURNS_BETWEEN_REMINDERS - 1,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true at exactly threshold edits and threshold turns", () => {
+    expect(
+      shouldInjectVerifyReminder({
+        activeToolNames: active,
+        mutatingEditsSinceLastVerifierSpawn: VERIFY_REMINDER_EDIT_THRESHOLD,
+        assistantTurnsSinceLastVerifyReminder:
+          VERIFY_REMINDER_TURNS_BETWEEN_REMINDERS,
+      }),
     ).toBe(true);
   });
 
-  it("suppresses when a reminder was injected within the last 10 turns", () => {
-    const reminder: LLMMessage = {
-      role: "user",
-      content: `<system-reminder>\n${VERIFY_REMINDER_HEADER_PREFIX}\n</system-reminder>`,
-    };
-    const history: LLMMessage[] = [
-      assistantMutation("system.writeFile"),
-      assistantMutation("system.editFile"),
-      assistantMutation("system.writeFile"),
-      reminder,
-      ...Array.from(
-        { length: VERIFY_REMINDER_TURNS_BETWEEN_REMINDERS - 1 },
-        (_, i) => assistantText(`x${i}`),
-      ),
-    ];
+  it("treats undefined turn counter as infinity (first-emission eligibility)", () => {
     expect(
-      shouldInjectVerifyReminder({ history, activeToolNames: activeTools }),
-    ).toBe(false);
-  });
-
-  it("resumes firing once the last reminder is past the 10-turn window", () => {
-    const reminder: LLMMessage = {
-      role: "user",
-      content: `<system-reminder>\n${VERIFY_REMINDER_HEADER_PREFIX}\n</system-reminder>`,
-    };
-    const history: LLMMessage[] = [
-      reminder,
-      ...Array.from(
-        { length: VERIFY_REMINDER_TURNS_BETWEEN_REMINDERS + 1 },
-        (_, i) => assistantText(`x${i}`),
-      ),
-      assistantMutation("system.writeFile"),
-      assistantMutation("system.editFile"),
-      assistantMutation("system.writeFile"),
-    ];
-    expect(
-      shouldInjectVerifyReminder({ history, activeToolNames: activeTools }),
+      shouldInjectVerifyReminder({
+        activeToolNames: active,
+        mutatingEditsSinceLastVerifierSpawn: VERIFY_REMINDER_EDIT_THRESHOLD,
+        assistantTurnsSinceLastVerifyReminder: undefined,
+      }),
     ).toBe(true);
   });
 });

--- a/runtime/src/llm/verify-reminder.test.ts
+++ b/runtime/src/llm/verify-reminder.test.ts
@@ -278,9 +278,10 @@ describe("buildVerifyReminderMessage", () => {
     expect(content).toContain("PARTIAL");
   });
 
-  it("emits user role with runtime-only user_context merge boundary", () => {
+  it("emits user role with runtime-only user_context merge boundary and anchorPreserve", () => {
     const msg = buildVerifyReminderMessage();
     expect(msg.role).toBe("user");
     expect(msg.runtimeOnly?.mergeBoundary).toBe("user_context");
+    expect(msg.runtimeOnly?.anchorPreserve).toBe(true);
   });
 });

--- a/runtime/src/llm/verify-reminder.ts
+++ b/runtime/src/llm/verify-reminder.ts
@@ -4,24 +4,31 @@
  * Plan-mode-less equivalent of the reference runtime's
  * `verify_plan_reminder` (upstream: plan mode state with
  * `verificationStarted && !verificationCompleted`). AgenC has no plan
- * mode, so the trigger is substituted with a cumulative-edit signal:
- * fires when the model has issued at least `VERIFY_REMINDER_EDIT_THRESHOLD`
- * mutating file-modification tool calls since the most recent verifier
- * spawn, and at least `VERIFY_REMINDER_TURNS_BETWEEN_REMINDERS`
- * assistant turns have elapsed since the last verify reminder.
+ * mode, so the trigger is substituted with a cumulative-edit signal
+ * driven by persisted runtime counters on `ActiveBackgroundRun` —
+ * compaction-safe by design. Matches the reference runtime's
+ * `AppState.pendingPlanVerification` separation of runtime state from
+ * model-visible history.
  *
- * The counter resets when EITHER:
- *   (a) The model spawns `execute_with_agent` with a non-empty
- *       `delegationAdmission.verifierObligations` array. This is the
- *       structured contract the model cannot synthesize without an
- *       actual verifier spawn round-trip.
- *   (b) A `role === "tool"` message contains `VERDICT: PASS|FAIL|PARTIAL`.
- *       Scoping to `role === "tool"` prevents the model from gaming
- *       the reset by typing the string itself — tool messages are
- *       runtime-controlled, not model-authored.
+ * Trigger: fires when `execute_with_agent` is in the active toolset
+ * AND the run has accumulated at least `VERIFY_REMINDER_EDIT_THRESHOLD`
+ * mutating edits since the most recent verifier spawn AND at least
+ * `VERIFY_REMINDER_TURNS_BETWEEN_REMINDERS` assistant turns have
+ * elapsed since the last verify reminder.
  *
- * Counter model mirrors `todo-reminder.ts` — scan-derived, no
- * persisted fields, compaction/crash/resume safe.
+ * Counter updates live on the supervisor side (see
+ * `background-run-supervisor.ts`). This module exposes the helpers
+ * the supervisor uses to mutate counters (`isMutatingTool`,
+ * `isVerifierSpawnFromRecord`, `containsVerdictMarkerInToolResult`,
+ * `messageContainsVerifyReminderPrefix`) alongside the trigger
+ * predicate itself.
+ *
+ * The emitted reminder carries `runtimeOnly.anchorPreserve: true`
+ * so that the message survives history compaction — its presence in
+ * history is not a trigger anchor (that is the supervisor's counter)
+ * but preserving it keeps the model's context stable across compact
+ * boundaries instead of silently losing a still-live pointer to the
+ * verification obligation.
  *
  * @module
  */
@@ -68,52 +75,6 @@ export const MUTATING_TOOL_NAMES: ReadonlySet<string> = new Set([
 
 const EXECUTE_WITH_AGENT_TOOL_NAME = "execute_with_agent";
 
-export function isMutatingTool(name: string): boolean {
-  return MUTATING_TOOL_NAMES.has(name);
-}
-
-/**
- * Detect a verifier spawn from an already-parsed `ToolCallRecord`
- * (supervisor-side shape; args is `Record<string, unknown>`). The
- * corresponding `LLMMessage`/raw-JSON-arguments path used by the
- * history scan functions below is intentionally separate to avoid
- * type ambiguity across two parsing models in the same module.
- */
-export function isVerifierSpawnFromRecord(call: {
-  readonly name: string;
-  readonly args: Record<string, unknown>;
-}): boolean {
-  if (call.name !== EXECUTE_WITH_AGENT_TOOL_NAME) return false;
-  return hasVerifierObligations(call.args);
-}
-
-/**
- * Detect a `VERDICT: PASS|FAIL|PARTIAL` marker in a verifier tool's
- * own tool_result. Scoped to `execute_with_agent` results only so an
- * unrelated tool (e.g. a `grep` hit that happens to contain the word
- * "VERDICT") cannot spuriously reset the edit counter.
- */
-export function containsVerdictMarkerInToolResult(call: {
-  readonly name: string;
-  readonly result: string;
-}): boolean {
-  if (call.name !== EXECUTE_WITH_AGENT_TOOL_NAME) return false;
-  return VERDICT_MARKERS.some((marker) => call.result.includes(marker));
-}
-
-/**
- * Returns `true` if the message content contains the static verify-
- * reminder header prefix. Used by the supervisor to detect whether
- * a just-emitted reminder came through `collectAttachments` so the
- * turn counter can be reset.
- */
-export function messageContainsVerifyReminderPrefix(
-  message: LLMMessage,
-): boolean {
-  const content = stringContent(message);
-  return content.includes(VERIFY_REMINDER_HEADER_PREFIX);
-}
-
 const VERDICT_MARKERS: readonly string[] = [
   "VERDICT: PASS",
   "VERDICT: FAIL",
@@ -125,27 +86,6 @@ function stringContent(message: LLMMessage): string {
   return message.content
     .map((part) => (part.type === "text" ? part.text : ""))
     .join("");
-}
-
-function countAssistantTurnsBetween(
-  history: readonly LLMMessage[],
-  startExclusive: number,
-  endExclusive: number,
-): number {
-  let count = 0;
-  for (let index = startExclusive + 1; index < endExclusive; index += 1) {
-    if (history[index]?.role === "assistant") count += 1;
-  }
-  return count;
-}
-
-function parseToolCallArguments(raw: string | undefined): unknown {
-  if (typeof raw !== "string" || raw.length === 0) return undefined;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return undefined;
-  }
 }
 
 function hasVerifierObligations(toolCallArguments: unknown): boolean {
@@ -161,73 +101,86 @@ function hasVerifierObligations(toolCallArguments: unknown): boolean {
   return Array.isArray(obligations) && obligations.length > 0;
 }
 
-function messageIsVerifierSpawn(message: LLMMessage): boolean {
-  if (message.role !== "assistant") return false;
-  const calls = message.toolCalls ?? [];
-  return calls.some((call) => {
-    if (call.name !== EXECUTE_WITH_AGENT_TOOL_NAME) return false;
-    return hasVerifierObligations(parseToolCallArguments(call.arguments));
-  });
-}
-
-function messageIsVerifierVerdict(message: LLMMessage): boolean {
-  if (message.role !== "tool") return false;
-  const content = stringContent(message);
-  return VERDICT_MARKERS.some((marker) => content.includes(marker));
+export function isMutatingTool(name: string): boolean {
+  return MUTATING_TOOL_NAMES.has(name);
 }
 
 /**
- * Count mutating tool-use invocations in assistant history, scanning
- * backwards, stopping at the most recent verifier-spawn or verdict
- * terminator. If no terminator is encountered, returns the count
- * across the full visible history.
+ * Detect a verifier spawn from an already-parsed `ToolCallRecord`
+ * (supervisor-side shape; `args` is `Record<string, unknown>`).
+ * Returns true only for `execute_with_agent` calls whose
+ * `delegationAdmission.verifierObligations` is a non-empty array.
  */
-export function getMutatingEditsSinceLastVerifierSpawn(
-  history: readonly LLMMessage[],
-): number {
-  let count = 0;
-  for (let index = history.length - 1; index >= 0; index -= 1) {
-    const message = history[index]!;
-    if (messageIsVerifierSpawn(message) || messageIsVerifierVerdict(message)) {
-      return count;
-    }
-    if (message.role !== "assistant") continue;
-    for (const call of message.toolCalls ?? []) {
-      if (MUTATING_TOOL_NAMES.has(call.name)) count += 1;
-    }
-  }
-  return count;
+export function isVerifierSpawnFromRecord(call: {
+  readonly name: string;
+  readonly args: Record<string, unknown>;
+}): boolean {
+  if (call.name !== EXECUTE_WITH_AGENT_TOOL_NAME) return false;
+  return hasVerifierObligations(call.args);
 }
 
-export function getTurnsSinceLastVerifyReminder(
-  history: readonly LLMMessage[],
-): number {
-  for (let index = history.length - 1; index >= 0; index -= 1) {
-    const message = history[index]!;
-    if (message.role !== "user") continue;
-    const content = stringContent(message);
-    if (content.includes(VERIFY_REMINDER_HEADER_PREFIX)) {
-      return countAssistantTurnsBetween(history, index, history.length);
-    }
-  }
-  return Number.POSITIVE_INFINITY;
+/**
+ * Detect a `VERDICT: PASS|FAIL|PARTIAL` marker in a verifier tool's
+ * own tool_result. Scoped to `execute_with_agent` results only so an
+ * unrelated tool (e.g. a `grep` hit containing the word "VERDICT")
+ * cannot spuriously reset the edit counter.
+ */
+export function containsVerdictMarkerInToolResult(call: {
+  readonly name: string;
+  readonly result: string;
+}): boolean {
+  if (call.name !== EXECUTE_WITH_AGENT_TOOL_NAME) return false;
+  return VERDICT_MARKERS.some((marker) => call.result.includes(marker));
+}
+
+/**
+ * Returns `true` if the message content contains the static verify-
+ * reminder header prefix. Used by the supervisor to detect whether
+ * a just-emitted reminder came through `collectAttachments` so that
+ * the turn counter can be reset on the same tick the reminder fires.
+ */
+export function messageContainsVerifyReminderPrefix(
+  message: LLMMessage,
+): boolean {
+  const content = stringContent(message);
+  return content.includes(VERIFY_REMINDER_HEADER_PREFIX);
 }
 
 export interface ShouldInjectVerifyReminderParams {
-  readonly history: readonly LLMMessage[];
   readonly activeToolNames: ReadonlySet<string>;
+  /**
+   * Mutating edits the run has accumulated since the most recent
+   * verifier spawn. `undefined` (e.g. webchat / text-channel turns
+   * that do not maintain this counter) means "not applicable" —
+   * the reminder is unconditionally suppressed on those surfaces.
+   */
+  readonly mutatingEditsSinceLastVerifierSpawn: number | undefined;
+  /**
+   * Assistant turns elapsed since the last verify reminder emission.
+   * `undefined` means "never emitted on this surface" and the counter
+   * is treated as effectively infinite for the gate below.
+   */
+  readonly assistantTurnsSinceLastVerifyReminder: number | undefined;
 }
 
 export function shouldInjectVerifyReminder(
   params: ShouldInjectVerifyReminderParams,
 ): boolean {
   if (!params.activeToolNames.has(EXECUTE_WITH_AGENT_TOOL_NAME)) return false;
-  const edits = getMutatingEditsSinceLastVerifierSpawn(params.history);
-  if (edits < VERIFY_REMINDER_EDIT_THRESHOLD) return false;
-  const turnsSinceReminder = getTurnsSinceLastVerifyReminder(params.history);
-  if (turnsSinceReminder < VERIFY_REMINDER_TURNS_BETWEEN_REMINDERS) {
+  // Counters are supplied only by background-run surfaces. When
+  // undefined, the reminder is off by design — interactive turns are
+  // short-horizon and do not accumulate unverified edits the way
+  // background runs do.
+  if (params.mutatingEditsSinceLastVerifierSpawn === undefined) return false;
+  if (
+    params.mutatingEditsSinceLastVerifierSpawn < VERIFY_REMINDER_EDIT_THRESHOLD
+  ) {
     return false;
   }
+  const turns =
+    params.assistantTurnsSinceLastVerifyReminder ??
+    Number.POSITIVE_INFINITY;
+  if (turns < VERIFY_REMINDER_TURNS_BETWEEN_REMINDERS) return false;
   return true;
 }
 

--- a/runtime/src/llm/verify-reminder.ts
+++ b/runtime/src/llm/verify-reminder.ts
@@ -180,6 +180,6 @@ export function buildVerifyReminderMessage(): LLMMessage {
   return {
     role: "user",
     content: `<system-reminder>\n${VERIFY_REMINDER_HEADER}\n</system-reminder>`,
-    runtimeOnly: { mergeBoundary: "user_context" },
+    runtimeOnly: { mergeBoundary: "user_context", anchorPreserve: true },
   };
 }

--- a/runtime/src/llm/verify-reminder.ts
+++ b/runtime/src/llm/verify-reminder.ts
@@ -48,7 +48,16 @@ const VERIFY_REMINDER_HEADER =
   "elsewhere. Make sure that you NEVER mention this reminder to the " +
   "user.";
 
-const MUTATING_TOOL_NAMES: ReadonlySet<string> = new Set([
+/**
+ * Tool names that count toward the "unverified edits" threshold.
+ *
+ * Explicitly excludes `system.bash`: shell-sourced mutations are not
+ * individually trackable (one `bash` call can create many files or
+ * none), so the runtime delegates shell-level verification to the
+ * verifier-obligation contract at the run level rather than trying
+ * to count shell mutations as equivalent to structured file writes.
+ */
+export const MUTATING_TOOL_NAMES: ReadonlySet<string> = new Set([
   "system.writeFile",
   "system.editFile",
   "system.appendFile",
@@ -58,6 +67,52 @@ const MUTATING_TOOL_NAMES: ReadonlySet<string> = new Set([
 ]);
 
 const EXECUTE_WITH_AGENT_TOOL_NAME = "execute_with_agent";
+
+export function isMutatingTool(name: string): boolean {
+  return MUTATING_TOOL_NAMES.has(name);
+}
+
+/**
+ * Detect a verifier spawn from an already-parsed `ToolCallRecord`
+ * (supervisor-side shape; args is `Record<string, unknown>`). The
+ * corresponding `LLMMessage`/raw-JSON-arguments path used by the
+ * history scan functions below is intentionally separate to avoid
+ * type ambiguity across two parsing models in the same module.
+ */
+export function isVerifierSpawnFromRecord(call: {
+  readonly name: string;
+  readonly args: Record<string, unknown>;
+}): boolean {
+  if (call.name !== EXECUTE_WITH_AGENT_TOOL_NAME) return false;
+  return hasVerifierObligations(call.args);
+}
+
+/**
+ * Detect a `VERDICT: PASS|FAIL|PARTIAL` marker in a verifier tool's
+ * own tool_result. Scoped to `execute_with_agent` results only so an
+ * unrelated tool (e.g. a `grep` hit that happens to contain the word
+ * "VERDICT") cannot spuriously reset the edit counter.
+ */
+export function containsVerdictMarkerInToolResult(call: {
+  readonly name: string;
+  readonly result: string;
+}): boolean {
+  if (call.name !== EXECUTE_WITH_AGENT_TOOL_NAME) return false;
+  return VERDICT_MARKERS.some((marker) => call.result.includes(marker));
+}
+
+/**
+ * Returns `true` if the message content contains the static verify-
+ * reminder header prefix. Used by the supervisor to detect whether
+ * a just-emitted reminder came through `collectAttachments` so the
+ * turn counter can be reset.
+ */
+export function messageContainsVerifyReminderPrefix(
+  message: LLMMessage,
+): boolean {
+  const content = stringContent(message);
+  return content.includes(VERIFY_REMINDER_HEADER_PREFIX);
+}
 
 const VERDICT_MARKERS: readonly string[] = [
   "VERDICT: PASS",


### PR DESCRIPTION
## Summary

Fixes a confirmed live bug in verify_reminder plus the silent-failure class that surrounds it.

**Observed bug.** Across 383 provider.requests spanning 25 minutes of a background run, zero contained the verify_reminder header despite 200+ mutating edits. Cause: the history-scan trigger anchored on a one-shot event (the initial \`execute_with_agent\` tool_use) that history compaction summarizes away by cycle 15+. The counter walks past the end of compacted history, finds no terminator, and returns less than the 3-edit threshold every time.

**Silent-failure class.** task_reminder and todo_reminder use the same scan pattern. They work today only because their anchors (the TodoWrite tool_use, the task.create/update tool_use) get re-emitted frequently enough to survive in the 10-turn uncompacted tail. Change model behavior or tighten compaction and they break the same way — invisibly.

## Root cause

AgenC derives long-horizon trigger decisions from scanning LLM history. The reference runtime at \`/home/tetsuo/git/claude_code/\` uses a hybrid: persisted flags in \`AppState.pendingPlanVerification\` (compaction-independent) PLUS history scans that anchor on structurally preserved \`plan_mode_exit\` attachments (compaction keeps them via \`messagesToKeep\`). SOTA research (ESAA, LangGraph reducers, OpenAI Assistants runs, Microsoft Agent Framework, Anthropic Agent SDK) converges on the same principle — runtime invariants belong in runtime state, not derived from the model-visible prompt.

## Fix — three coupled commits

**1. \`feat(runtime): add anchorPreserve marker and preserve anchors through compaction\`**
- Adds \`runtimeOnly.anchorPreserve?: boolean\` to \`LLMMessage\`
- \`compactInternalHistory\` partitions history into anchor-preserved vs summarizable; anchor messages pass through unchanged between the summary system message and the kept tail (mirrors upstream's \`messagesToKeep\`)
- All three reminder builders (todo, task, verify) now emit anchor-preserved messages — their re-emission anti-spam gate needs the prior reminder to survive compaction
- Edge cases handled: all-anchor-preserved input prepends a stub system message; summarization failure path unchanged

**2. \`feat(runtime/gateway): add persisted counters for verify_reminder to ActiveBackgroundRun\`**
- Adds \`mutatingEditsSinceLastVerifierSpawn\` (increments on writeFile/editFile/appendFile/mkdir/move/delete; resets on \`execute_with_agent\` with verifierObligations or on VERDICT marker in an execute_with_agent tool_result) and \`assistantTurnsSinceLastVerifyReminder\` (increments per actor turn; resets only when the reminder actually fires — spawning a verifier does not suppress the next reminder)
- Counter mutations run in the supervisor at the end of each cycle after \`recordToolEvidence\`; counters are read at the start of the next cycle by \`collectAttachments\` — one-cycle latency is immaterial against the 10-turn reminder cadence
- \`system.bash\` explicitly excluded from the mutating set (shell-sourced mutations aren't individually trackable); VERDICT markers only honored in \`execute_with_agent\` results (a grep hit containing \"VERDICT\" should not reset the counter)
- Persistence: both fields on \`PersistedBackgroundRun\`, explicit defaults in \`toActiveRun\` for runs persisted before this PR (0 for edits, +Infinity for turns so the first reminder is immediately eligible after upgrade)

**3. \`feat(runtime/llm): drive verify_reminder from persisted counters instead of history scan\`**
- Rewrites \`shouldInjectVerifyReminder\` to read counters from \`AttachmentContext\` directly; removes the scan functions and their anchor terminators
- Interactive surfaces (webchat, text-channel) omit the counters; the reminder suppresses there by design — interactive turns are short-horizon and don't accumulate unverified edits the way background runs do
- Runtime helpers (\`isMutatingTool\`, \`isVerifierSpawnFromRecord\`, \`containsVerdictMarkerInToolResult\`, \`messageContainsVerifyReminderPrefix\`) remain exported so the supervisor has a single source of truth for the \"what counts\" contract

## Test plan

- [x] \`npm run typecheck\` clean
- [x] 79 unit tests in \`types.test.ts\`, \`verify-reminder.test.ts\`, \`todo-reminder.test.ts\`, \`task-reminder.test.ts\`, \`attachment-injection.test.ts\` pass — rewritten to cover counter-driven triggering, anchor preservation, scoped VERDICT detection, and backward-compat defaults
- [x] \`partitionByAnchorPreserve\` unit-tested on empty / all-rest / all-preserved / mixed inputs
- [x] Pre-existing stateful-transport test failures in this repo (32 failures in \`chat-executor-request.test.ts\` / \`chat-executor-state.test.ts\` / \`chat-executor-usage.test.ts\` / \`grok/adapter.test.ts\`) are untouched and unrelated
- [ ] Post-merge integration: restart daemon, start a background run, observe \`mutatingEditsSinceLastVerifierSpawn\` climbing in run snapshots; verify the reminder fires on the first cycle where counters cross threshold after the model stops touching the verifier

## Hazards

All documented in the plan. Principal risks:
- Anchor accumulation over very long runs (>500 turns) — acknowledged, bounded by cadence, follow-up if observed
- Counter drift across crash/resume — both fields persisted, covered by round-trip test
- VERDICT false-match on grep output — scoped to \`execute_with_agent\` results, regression test included

## Base note

Based on \`refactor/stateless-transport\`. Will rebase to \`main\` once #441 lands.