### PR TITLE
feat(runtime): per-traceId JSONL trace artifacts + trace supervisor compaction LLM calls

### DIFF
--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -4359,12 +4359,42 @@ export class BackgroundRunSupervisor {
       const historyText = toActuallySummarize
         .map((m) => `[${m.role}]: ${typeof m.content === "string" ? m.content : JSON.stringify(m.content)}`)
         .join("\n\n");
+      // Trace the supervisor's compaction LLM call alongside the
+      // actor's. Without this, compaction is one of the silent
+      // contributors to the per-cycle gap between actor turn end
+      // and the next request — the call happens, takes 5-15s, and
+      // emits no provider.request/.response trace events. The
+      // wrapping pattern matches `evaluateDecision` /
+      // `refreshCarryForwardState` / `planRunContract` which use the
+      // same `createProviderTraceEventLogger` shape; phase label
+      // `compaction` distinguishes the cause.
+      const providerTrace = this.traceProviderPayloads
+        ? {
+            trace: {
+              includeProviderPayloads: true as const,
+              onProviderTraceEvent: createProviderTraceEventLogger({
+                logger: this.logger,
+                traceLabel: "background_run.provider",
+                traceId: `background:${run.sessionId}:${run.id}:${run.cycleCount}:compaction`,
+                sessionId: run.sessionId,
+                staticFields: {
+                  runId: run.id,
+                  cycleCount: run.cycleCount,
+                  phase: "compaction",
+                },
+              }),
+            },
+          }
+        : undefined;
       const response = await this.supervisorLlm.chat(
         [
           { role: "system", content: getCompactPrompt() },
           { role: "user", content: historyText },
         ],
-        buildModelOnlyChatOptions({ toolChoice: "none" }),
+        buildModelOnlyChatOptions({
+          toolChoice: "none",
+          ...(providerTrace ?? {}),
+        }),
       );
       const summary = formatCompactSummary(response.content).trim();
       if (summary.length === 0) {

--- a/runtime/src/observability/observability.test.ts
+++ b/runtime/src/observability/observability.test.ts
@@ -3,8 +3,12 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
 import { ObservabilityService } from "./observability.js";
-import { persistTracePayloadArtifact } from "../utils/trace-payload-store.js";
+import {
+  awaitTracePayloadDrain,
+  persistTracePayloadArtifact,
+} from "../utils/trace-payload-store.js";
 
 let tempDir = "";
 
@@ -287,5 +291,79 @@ sqliteDescribe("ObservabilityService", () => {
     expect(
       readFileSync(join(tempDir, "daemon.errors.log"), "utf8"),
     ).toContain("webchat.provider.error");
+  });
+
+  it("getArtifact reads a JSONL line by sha256 anchor", async () => {
+    const traceId = "trace-getartifact-jsonl";
+    const ref = persistTracePayloadArtifact({
+      traceId,
+      eventName: "evt.one",
+      payload: { idx: 1, marker: "expected-body" },
+    });
+    expect(ref).toBeDefined();
+    await awaitTracePayloadDrain(traceId);
+
+    const service = createService();
+    const result = await service.getArtifact(ref!.path);
+    const body = result.body as Record<string, unknown>;
+    expect(body.sha256).toBe(ref!.sha256);
+    expect(body.eventName).toBe("evt.one");
+    expect(body.traceId).toBe(traceId);
+    expect(body.payload).toEqual({ idx: 1, marker: "expected-body" });
+
+    rmSync(
+      join(homedir(), ".agenc/trace-payloads", `${traceId}.jsonl`),
+      { force: true },
+    );
+  });
+
+  it("getArtifact reads a legacy per-event JSON file", async () => {
+    // Simulate an old-format artifact: a .json file at any path
+    // under ~/.agenc/trace-payloads, no #sha256= anchor on the ref.
+    const legacyDir = join(homedir(), ".agenc/trace-payloads/legacy-trace");
+    mkdirSync(legacyDir, { recursive: true });
+    const legacyFile = join(legacyDir, "legacy-event.json");
+    writeFileSync(
+      legacyFile,
+      JSON.stringify({
+        eventName: "evt.legacy",
+        traceId: "legacy-trace",
+        payload: { from: "old-format" },
+      }),
+      "utf8",
+    );
+
+    const service = createService();
+    const result = await service.getArtifact(legacyFile);
+    const body = result.body as Record<string, unknown>;
+    expect(body.eventName).toBe("evt.legacy");
+    expect(body.payload).toEqual({ from: "old-format" });
+    expect(result.path).toBe(legacyFile);
+
+    rmSync(legacyDir, { recursive: true, force: true });
+  });
+
+  it("getArtifact throws when sha256 anchor does not match any line", async () => {
+    const traceId = "trace-getartifact-miss";
+    const ref = persistTracePayloadArtifact({
+      traceId,
+      eventName: "evt.one",
+      payload: { idx: 1 },
+    });
+    expect(ref).toBeDefined();
+    await awaitTracePayloadDrain(traceId);
+
+    // Construct an anchored path with the right file but a wrong sha.
+    const wrongSha = "0".repeat(64);
+    const wrongPath = ref!.path.replace(/#sha256=.*/, `#sha256=${wrongSha}`);
+    const service = createService();
+    await expect(service.getArtifact(wrongPath)).rejects.toThrow(
+      /Artifact not found in JSONL/,
+    );
+
+    rmSync(
+      join(homedir(), ".agenc/trace-payloads", `${traceId}.jsonl`),
+      { force: true },
+    );
   });
 });

--- a/runtime/src/observability/sqlite-store.ts
+++ b/runtime/src/observability/sqlite-store.ts
@@ -401,10 +401,35 @@ export class SqliteObservabilityStore {
   }
 
   async getArtifact(path: string): Promise<ObservabilityArtifactResponse> {
-    const resolved = resolvePath(path);
+    const parsed = parseArtifactPath(path);
+    const resolved = resolvePath(parsed.filePath);
     if (!resolved.startsWith(TRACE_ARTIFACT_ROOT)) {
       throw new ObservabilityStoreError("Artifact path is outside trace payload root");
     }
+    if (parsed.kind === "jsonl-anchor") {
+      // New per-traceId JSONL format. Each line is a self-contained
+      // event document with a stored `sha256` field; scan for the
+      // matching one. O(N) over events in this traceId — typically
+      // tens to a few hundred — completes in well under 50ms even
+      // on hundreds of KB of JSONL.
+      const content = await readFile(resolved, "utf8");
+      for (const line of content.split("\n")) {
+        if (line.length === 0) continue;
+        let entry: { sha256?: string } & Record<string, unknown>;
+        try {
+          entry = JSON.parse(line) as typeof entry;
+        } catch {
+          continue;
+        }
+        if (entry.sha256 === parsed.sha256) {
+          return { path, body: entry };
+        }
+      }
+      throw new ObservabilityStoreError(
+        `Artifact not found in JSONL for sha256=${parsed.sha256}`,
+      );
+    }
+    // Legacy per-event file format. Whole file is one JSON object.
     const bodyText = await readFile(resolved, "utf8");
     return {
       path: resolved,
@@ -660,4 +685,30 @@ export class SqliteObservabilityStore {
       issues,
     };
   }
+}
+
+/**
+ * Parse an artifact ref path into its filesystem path and (for the
+ * new JSONL format) its sha256 anchor. The legacy format is a bare
+ * filesystem path with no `#` fragment; the new format appends
+ * `#sha256=<hex>` so the reader can locate the matching JSONL line
+ * without a separate index file. Stripping the fragment before
+ * passing to `resolvePath` is required because `path.resolve` would
+ * otherwise treat `#` as a literal filename character.
+ */
+function parseArtifactPath(input: string): {
+  readonly kind: "jsonl-anchor" | "legacy-file";
+  readonly filePath: string;
+  readonly sha256?: string;
+} {
+  const anchor = "#sha256=";
+  const anchorIdx = input.indexOf(anchor);
+  if (anchorIdx === -1) {
+    return { kind: "legacy-file", filePath: input };
+  }
+  return {
+    kind: "jsonl-anchor",
+    filePath: input.slice(0, anchorIdx),
+    sha256: input.slice(anchorIdx + anchor.length),
+  };
 }

--- a/runtime/src/utils/trace-payload-store.test.ts
+++ b/runtime/src/utils/trace-payload-store.test.ts
@@ -1,46 +1,116 @@
-import { readFileSync, rmSync } from "node:fs";
-import { dirname } from "node:path";
-import { describe, expect, it } from "vitest";
-import { persistTracePayloadArtifact } from "./trace-payload-store.js";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  awaitTracePayloadDrain,
+  persistTracePayloadArtifact,
+  tracePayloadActiveChainCount,
+} from "./trace-payload-store.js";
 
-describe("persistTracePayloadArtifact", () => {
-  it("writes an exact JSON artifact and sanitizes binary-like payload strings", () => {
-    const ref = persistTracePayloadArtifact({
-      traceId: "trace-store-test",
-      eventName: "webchat.provider.request",
-      payload: {
-        message: "hello",
-        image: "data:image/png;base64,AAAA",
-      },
-    });
+const TRACE_PAYLOAD_ROOT = join(homedir(), ".agenc", "trace-payloads");
 
-    expect(ref).toBeDefined();
-    const artifact = JSON.parse(readFileSync(ref!.path, "utf8")) as {
-      eventName: string;
-      traceId: string;
-      payload: {
-        message: string;
-        image: { kind: string; mediaType: string; sha256: string };
-      };
-    };
-    expect(artifact.eventName).toBe("webchat.provider.request");
-    expect(artifact.traceId).toBe("trace-store-test");
-    expect(artifact.payload.message).toBe("hello");
-    expect(artifact.payload.image.kind).toBe("data_url_base64");
-    expect(artifact.payload.image.mediaType).toBe("image/png");
-    expect(artifact.payload.image.sha256).toHaveLength(64);
+interface JsonlLine {
+  readonly sha256: string;
+  readonly eventName: string;
+  readonly traceId: string;
+  readonly capturedAt: string;
+  readonly payload: Record<string, unknown>;
+}
 
-    rmSync(ref!.path, { force: true });
-    rmSync(dirname(ref!.path), { recursive: true, force: true });
+function parseAnchoredPath(input: string): {
+  filePath: string;
+  sha256: string;
+} {
+  const idx = input.indexOf("#sha256=");
+  if (idx === -1) throw new Error(`expected anchored path, got ${input}`);
+  return {
+    filePath: input.slice(0, idx),
+    sha256: input.slice(idx + "#sha256=".length),
+  };
+}
+
+function readJsonlLines(filePath: string): JsonlLine[] {
+  const raw = readFileSync(filePath, "utf8");
+  return raw
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line) as JsonlLine);
+}
+
+function findLineBySha(filePath: string, sha256: string): JsonlLine {
+  const matches = readJsonlLines(filePath).filter(
+    (line) => line.sha256 === sha256,
+  );
+  if (matches.length !== 1) {
+    throw new Error(
+      `expected exactly one line for sha=${sha256}, got ${matches.length}`,
+    );
+  }
+  return matches[0]!;
+}
+
+function cleanupTrace(traceId: string): void {
+  const filePath = join(TRACE_PAYLOAD_ROOT, `${traceId}.jsonl`);
+  if (existsSync(filePath)) rmSync(filePath, { force: true });
+}
+
+describe("persistTracePayloadArtifact (per-traceId JSONL)", () => {
+  const owned: string[] = [];
+
+  afterEach(async () => {
+    await awaitTracePayloadDrain();
+    while (owned.length > 0) {
+      const id = owned.pop()!;
+      cleanupTrace(id);
+    }
   });
 
-  it("preserves repeated references and only marks true cycles as circular", () => {
+  it("returns an anchored ref path with sha256 fragment", async () => {
+    const traceId = "trace-store-anchor";
+    owned.push(traceId);
+    const ref = persistTracePayloadArtifact({
+      traceId,
+      eventName: "webchat.provider.request",
+      payload: { message: "hello" },
+    });
+    expect(ref).toBeDefined();
+    expect(ref!.path).toMatch(/#sha256=[0-9a-f]{64}$/);
+    expect(ref!.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(ref!.bytes).toBeGreaterThan(0);
+  });
+
+  it("round-trips a single payload through the JSONL line", async () => {
+    const traceId = "trace-store-roundtrip";
+    owned.push(traceId);
+    const ref = persistTracePayloadArtifact({
+      traceId,
+      eventName: "webchat.provider.request",
+      payload: { message: "hello", image: "data:image/png;base64,AAAA" },
+    });
+    expect(ref).toBeDefined();
+    await awaitTracePayloadDrain(traceId);
+
+    const { filePath, sha256 } = parseAnchoredPath(ref!.path);
+    const line = findLineBySha(filePath, sha256);
+    expect(line.sha256).toBe(ref!.sha256);
+    expect(line.eventName).toBe("webchat.provider.request");
+    expect(line.traceId).toBe(traceId);
+    expect(line.payload.message).toBe("hello");
+    // sanitizeTracePayloadForArtifact replaces base64 data URLs.
+    expect((line.payload.image as Record<string, unknown>).kind).toBe(
+      "data_url_base64",
+    );
+  });
+
+  it("preserves repeated array references and replaces true cycles", async () => {
+    const traceId = "trace-store-duplicates";
+    owned.push(traceId);
     const shared = ["mcp.example.start"];
     const cyclic: Record<string, unknown> = {};
     cyclic.self = cyclic;
-
     const ref = persistTracePayloadArtifact({
-      traceId: "trace-store-duplicates",
+      traceId,
       eventName: "webchat.provider.request",
       payload: {
         requestedToolNames: shared,
@@ -48,22 +118,121 @@ describe("persistTracePayloadArtifact", () => {
         cyclic,
       },
     });
-
-    expect(ref).toBeDefined();
-    const artifact = JSON.parse(readFileSync(ref!.path, "utf8")) as {
-      payload: {
-        requestedToolNames: string[];
-        missingRequestedToolNames: string[];
-        cyclic: { self: string };
-      };
-    };
-    expect(artifact.payload.requestedToolNames).toEqual(["mcp.example.start"]);
-    expect(artifact.payload.missingRequestedToolNames).toEqual([
+    await awaitTracePayloadDrain(traceId);
+    const { filePath, sha256 } = parseAnchoredPath(ref!.path);
+    const line = findLineBySha(filePath, sha256);
+    expect(line.payload.requestedToolNames).toEqual(["mcp.example.start"]);
+    expect(line.payload.missingRequestedToolNames).toEqual([
       "mcp.example.start",
     ]);
-    expect(artifact.payload.cyclic.self).toBe("[circular]");
+    expect((line.payload.cyclic as { self: string }).self).toBe("[circular]");
+  });
 
-    rmSync(ref!.path, { force: true });
-    rmSync(dirname(ref!.path), { recursive: true, force: true });
+  it("appends multiple events for the same traceId into one JSONL file", async () => {
+    const traceId = "trace-store-many-events";
+    owned.push(traceId);
+    const refs = [
+      persistTracePayloadArtifact({
+        traceId,
+        eventName: "evt.one",
+        payload: { idx: 1 },
+      })!,
+      persistTracePayloadArtifact({
+        traceId,
+        eventName: "evt.two",
+        payload: { idx: 2 },
+      })!,
+      persistTracePayloadArtifact({
+        traceId,
+        eventName: "evt.three",
+        payload: { idx: 3 },
+      })!,
+    ];
+    await awaitTracePayloadDrain(traceId);
+
+    const filePath = parseAnchoredPath(refs[0].path).filePath;
+    const lines = readJsonlLines(filePath);
+    expect(lines).toHaveLength(3);
+    expect(lines.map((l) => l.eventName)).toEqual(["evt.one", "evt.two", "evt.three"]);
+    expect(lines.map((l) => l.payload.idx)).toEqual([1, 2, 3]);
+    // Each ref's sha matches the line at that position.
+    refs.forEach((ref, i) => {
+      expect(lines[i]!.sha256).toBe(ref.sha256);
+    });
+  });
+
+  it("serializes 5 concurrent writes to the same traceId without interleaving", async () => {
+    const traceId = "trace-store-concurrent";
+    owned.push(traceId);
+    const concurrentRefs = await Promise.all(
+      Array.from({ length: 5 }, (_, i) =>
+        Promise.resolve(
+          persistTracePayloadArtifact({
+            traceId,
+            eventName: `evt.${i}`,
+            // Make each line large enough to exceed PIPE_BUF (4 KB)
+            // so a non-serialized append could plausibly interleave.
+            // Vary content so the sanitizer doesn't treat it as a
+            // repeated/binary blob.
+            payload: { idx: i, fill: `chunk-${i}-${"abc".repeat(3000)}` },
+          })!,
+        ),
+      ),
+    );
+    await awaitTracePayloadDrain(traceId);
+
+    const filePath = parseAnchoredPath(concurrentRefs[0].path).filePath;
+    const lines = readJsonlLines(filePath);
+    expect(lines).toHaveLength(5);
+    // Confirm payloads weren't truncated/interleaved.
+    expect(
+      lines.every((line) => {
+        const fill = line.payload.fill as string;
+        return (
+          typeof fill === "string" &&
+          fill.startsWith(`chunk-${line.payload.idx}-`)
+        );
+      }),
+    ).toBe(true);
+    // All sha256s match their refs (1:1).
+    const sortedRefShas = [...concurrentRefs.map((r) => r.sha256)].sort();
+    const sortedLineShas = [...lines.map((l) => l.sha256)].sort();
+    expect(sortedLineShas).toEqual(sortedRefShas);
+  });
+
+  it("isolates distinct traceIds into separate JSONL files", async () => {
+    const a = "trace-store-iso-a";
+    const b = "trace-store-iso-b";
+    owned.push(a, b);
+    const refA = persistTracePayloadArtifact({
+      traceId: a,
+      eventName: "evt.a",
+      payload: { which: "a" },
+    })!;
+    const refB = persistTracePayloadArtifact({
+      traceId: b,
+      eventName: "evt.b",
+      payload: { which: "b" },
+    })!;
+    await awaitTracePayloadDrain();
+
+    const linesA = readJsonlLines(parseAnchoredPath(refA.path).filePath);
+    const linesB = readJsonlLines(parseAnchoredPath(refB.path).filePath);
+    expect(linesA).toHaveLength(1);
+    expect(linesB).toHaveLength(1);
+    expect(linesA[0]!.payload.which).toBe("a");
+    expect(linesB[0]!.payload.which).toBe("b");
+  });
+
+  it("drains the per-traceId chain map after writes complete", async () => {
+    const traceId = "trace-store-cleanup";
+    owned.push(traceId);
+    persistTracePayloadArtifact({
+      traceId,
+      eventName: "evt.cleanup",
+      payload: {},
+    });
+    await awaitTracePayloadDrain(traceId);
+    expect(tracePayloadActiveChainCount()).toBe(0);
   });
 });

--- a/runtime/src/utils/trace-payload-store.ts
+++ b/runtime/src/utils/trace-payload-store.ts
@@ -8,6 +8,13 @@ import { sanitizeTracePayloadForArtifact } from "./trace-payload-serialization.j
 const TRACE_PAYLOAD_ROOT = join(homedir(), ".agenc", "trace-payloads");
 
 export interface TracePayloadArtifactRef {
+  /**
+   * Filesystem path to the artifact, optionally followed by a
+   * `#sha256=<hex>` anchor that names the specific JSONL line within
+   * the per-traceId file (new format). Old per-event refs are bare
+   * file paths without an anchor and remain readable via the legacy
+   * branch in `getArtifact`.
+   */
   readonly path: string;
   readonly sha256: string;
   readonly bytes: number;
@@ -21,6 +28,20 @@ function sanitizeSegment(value: string, fallback: string): string {
   return bounded.length > 0 ? bounded : fallback;
 }
 
+/**
+ * Per-traceId write chain. Each traceId gets a Promise that resolves
+ * once all of its queued appends have flushed to disk. New appends
+ * chain off the current tail so concurrent producers writing to the
+ * same JSONL file never interleave their multi-KB lines (Node's
+ * O_APPEND atomicity only holds under PIPE_BUF / 4096 bytes; real
+ * trace lines often exceed that).
+ *
+ * The map entry is removed in `.finally()` once the chain settles
+ * AND no newer write has replaced it. This keeps map size bounded
+ * to currently-active traceIds.
+ */
+const writeChains = new Map<string, Promise<void>>();
+
 export function persistTracePayloadArtifact(params: {
   traceId?: string;
   eventName: string;
@@ -28,28 +49,81 @@ export function persistTracePayloadArtifact(params: {
 }): TracePayloadArtifactRef | undefined {
   try {
     const sanitizedPayload = sanitizeTracePayloadForArtifact(params.payload);
-    const document = {
+    const traceIdSegment = sanitizeSegment(params.traceId ?? "trace", "trace");
+    const filePath = join(TRACE_PAYLOAD_ROOT, `${traceIdSegment}.jsonl`);
+
+    // Compute sha over the sanitized payload + metadata so it can be
+    // stored on the JSONL line for O(N) lookup on read. Storing the
+    // sha as a field eliminates any drift risk from re-serialization
+    // ordering at read time.
+    const docNoSha = {
       eventName: params.eventName,
       traceId: params.traceId,
       capturedAt: new Date().toISOString(),
       payload: sanitizedPayload,
     };
+    const serializedNoSha = safeStringify(docNoSha);
+    const sha256 = createHash("sha256").update(serializedNoSha).digest("hex");
+    const document = { sha256, ...docNoSha };
     const serialized = safeStringify(document);
-    const sha256 = createHash("sha256").update(serialized).digest("hex");
-    const traceDir = join(
-      TRACE_PAYLOAD_ROOT,
-      sanitizeSegment(params.traceId ?? "trace", "trace"),
-    );
-    mkdirSync(traceDir, { recursive: true });
-    const fileName = `${Date.now()}-${sanitizeSegment(params.eventName, "trace-event")}-${sha256.slice(0, 12)}.json`;
-    const filePath = join(traceDir, fileName);
-    writeFileSync(filePath, `${serialized}\n`, "utf8");
+    const anchoredPath = `${filePath}#sha256=${sha256}`;
+    const bytes = Buffer.byteLength(serialized);
+
+    const previousChain = writeChains.get(traceIdSegment) ?? Promise.resolve();
+    const next: Promise<void> = previousChain
+      .then(() => {
+        mkdirSync(TRACE_PAYLOAD_ROOT, { recursive: true });
+        writeFileSync(filePath, `${serialized}\n`, {
+          encoding: "utf8",
+          flag: "a",
+        });
+      })
+      .catch(() => {
+        // Trace persistence failures must never crash the runtime
+        // path that emitted them. Caller has the ref optimistically;
+        // a missed write surfaces as a benign "Artifact not found"
+        // on the read side rather than as a runtime crash here.
+      })
+      .finally(() => {
+        if (writeChains.get(traceIdSegment) === next) {
+          writeChains.delete(traceIdSegment);
+        }
+      });
+    writeChains.set(traceIdSegment, next);
+
     return {
-      path: filePath,
+      path: anchoredPath,
       sha256,
-      bytes: Buffer.byteLength(serialized),
+      bytes,
     };
   } catch {
     return undefined;
   }
+}
+
+/**
+ * @internal — for tests only. Resolves once the per-traceId write
+ * chain has drained for the given traceId (or all traceIds if none
+ * given). Production callers never need to await — refs are valid
+ * for downstream UI fetches that happen seconds after emission, and
+ * the write chain drains long before then.
+ */
+export async function awaitTracePayloadDrain(
+  traceId?: string,
+): Promise<void> {
+  if (traceId !== undefined) {
+    const seg = sanitizeSegment(traceId, "trace");
+    const chain = writeChains.get(seg);
+    if (chain) await chain;
+    return;
+  }
+  await Promise.all([...writeChains.values()]);
+}
+
+/**
+ * @internal — for tests only. Returns the count of in-flight
+ * per-traceId write chains.
+ */
+export function tracePayloadActiveChainCount(): number {
+  return writeChains.size;
 }


### PR DESCRIPTION
## Summary

Two scoped observability/storage plumbing changes targeting measured pain points from the live daemon.

**1. Per-traceId JSONL trace artifacts.** Replaces per-event JSON files with per-traceId append-only JSONL. A 24-minute background run was producing 72,425 files across 918 MB in \`~/.agenc/trace-payloads/\`; the new layout produces one file per traceId (~10-20 files for a comparable run) at the same total payload bytes.

**2. Wrap \`compactInternalHistory\` in the supervisor trace logger.** Brings the only structurally-unwrapped supervisor LLM call site into consistency with the three already-wrapped sites (\`evaluateDecision\`, \`refreshCarryForwardState\`, \`planRunContract\`). Phase label: \`compaction\`.

Items 1 and 2 from the prior prioritization (removing \`evaluateDecision\` / \`refreshCarryForwardState\` LLM calls entirely) remain deferred per user instruction. This PR is strictly observability/storage plumbing — no behavior change.

## Per-traceId JSONL details

**Writer** (\`runtime/src/utils/trace-payload-store.ts\`):
- Path layout: \`~/.agenc/trace-payloads/<traceId>.jsonl\` (append-only) instead of \`~/.agenc/trace-payloads/<traceId>/<ts>-<event>-<sha>.json\`
- Each line is a self-contained event document; \`sha256\` is now a stored field on each line — no recompute on read.
- Returned ref path includes a \`#sha256=<hex>\` fragment anchoring the specific event's line within the per-traceId file. The fragment is opaque to the WebSocket client (round-tripped unchanged) and stripped before \`resolvePath()\` on the read side.
- Concurrent writes to the same traceId serialize through a per-id Promise chain so multi-KB JSONL lines never interleave (Node's \`O_APPEND\` atomicity only holds under PIPE_BUF / 4096 bytes; real trace lines often exceed that).
- \`Map<string, Promise<void>>\` self-cleans in \`.finally()\` when the chain settles with no newer write — bounded memory.
- Test-only \`awaitTracePayloadDrain()\` exposes the chain so round-trip tests deterministically wait for writes to flush.

**Reader** (\`runtime/src/observability/sqlite-store.ts\`):
- \`getArtifact()\` now dual-mode: jsonl-anchor refs scan the JSONL for the matching line by stored sha256; legacy refs (no fragment) fall back to reading the whole file as one JSON object — keeps existing 72k+ per-event artifacts readable with no migration script.
- New \`parseArtifactPath()\` splits the optional anchor fragment so the existing \`TRACE_ARTIFACT_ROOT\` security check works unchanged.
- Verified that \`TRACE_PAYLOAD_ROOT\` (writer) and \`TRACE_ARTIFACT_ROOT\` (reader) both resolve to \`~/.agenc/trace-payloads\`.

## compactInternalHistory wrap

Same \`createProviderTraceEventLogger\` pattern as the other three supervisor LLM call sites. Phase label \`compaction\`. The wrap is structurally complete; the trace events flow through the same path the others do.

**Open follow-up (documented in commit 2's message):** live daemon traces show 502 \`background_run.provider.*\` events from \`phase: \"actor\"\` and 2 from \`phase: \"contract\"\` — but zero from \`phase: \"decision\"\` / \`phase: \"carry_forward\"\` / \`phase: \"compaction\"\` despite all four wrappings being structurally identical and the config flag being on. Investigation rules out: config flag, options spread, root-path mismatch, and the Grok adapter's emit guard. The remaining hypothesis is the Grok adapter's path handling for tool-less calls (\`toolChoice: \"none\"\` + empty \`toolRouting\`) bypasses the emit site for the supervisor's call shape. That audit is out of scope for this PR — when the adapter-side fix lands, all four call sites are already wired.

## Commits

1. \`feat(runtime): batch trace-payload writes into per-traceId JSONL with sha256-stored line lookup\`
2. \`feat(runtime/gateway): wrap compactInternalHistory in supervisor trace logger\`

## Test plan

- [x] \`npm run typecheck\` clean
- [x] 7 new unit tests in \`trace-payload-store.test.ts\` (anchored-path format, round-trip, concurrent writes serialized at 9KB+ payload sizes, distinct traceIds isolated, chain map self-cleans)
- [x] 3 new tests in \`observability.test.ts\` covering \`getArtifact\` for jsonl-anchor, legacy-file, and not-found cases
- [x] All existing tests in both files still pass
- [ ] Post-merge integration: restart daemon, run a 3-min background objective, confirm \`~/.agenc/trace-payloads/\` contains \`.jsonl\` files (not per-event \`.json\` files); confirm webchat TUI trace panel still loads artifact bodies correctly
- [ ] Disk check: \`du -sh ~/.agenc/trace-payloads\` and \`find ~/.agenc/trace-payloads -type f | wc -l\` — file count should drop ~10-20x

## Out of scope

- Removing the supervisor LLM calls themselves (deferred from prior plan)
- Artifact retention/rotation (follow-up; this PR demonstrates the storage reduction first)
- Grok adapter audit for the silent decision/carry_forward traces (documented as open follow-up)
- Changing the WebSocket wire format — \`path\` remains opaque to the client

Based on \`refactor/stateless-transport\`. Will rebase to \`main\` when #441 lands.