### PR TITLE
fix(runtime): accept partial-read snapshots for system.editFile

### DIFF
--- a/runtime/src/tools/system/filesystem.test.ts
+++ b/runtime/src/tools/system/filesystem.test.ts
@@ -1043,22 +1043,24 @@ describe("system.editFile", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(parseResult(result).error).toContain("fully read");
+    expect(parseResult(result).error).toContain("has not been read in this session");
     expect(mockWriteFile).not.toHaveBeenCalled();
   });
 
-  it("rejects edit after a partial read snapshot", async () => {
+  it("accepts edit after a partial read snapshot whose window is still present", async () => {
     const before = `int main(void) { return 0; }\n`;
     setupExistingFile(before);
     clearSessionReadState("session-partial-edit");
     seedSessionReadState("session-partial-edit", [
       {
         path: "/workspace/no-read.c",
-        content: before,
+        // Partial snapshot captures only the body of main, not the whole file.
+        content: "int main(void) { return 0; }",
         timestamp: 1_000,
         viewKind: "partial",
       },
     ]);
+    mockWriteFile.mockResolvedValueOnce(undefined);
 
     const result = await tool.execute({
       path: "/workspace/no-read.c",
@@ -1067,8 +1069,37 @@ describe("system.editFile", () => {
       __agencSessionId: "session-partial-edit",
     });
 
+    expect(result.isError).toBeUndefined();
+    expect(parseResult(result).replacements).toBe(1);
+    expect(mockWriteFile).toHaveBeenCalledTimes(1);
+    const [, written] = mockWriteFile.mock.calls[0];
+    expect((written as Buffer).toString()).toBe(
+      `int main(void) { return 1; }\n`,
+    );
+  });
+
+  it("rejects edit when the partial window is no longer present in the file (external drift)", async () => {
+    // File on disk has diverged from the partial window the model saw.
+    setupExistingFile(`int other(void) { return 42; }\n`);
+    clearSessionReadState("session-partial-drift");
+    seedSessionReadState("session-partial-drift", [
+      {
+        path: "/workspace/drift.c",
+        content: "int main(void) { return 0; }",
+        timestamp: 1_000,
+        viewKind: "partial",
+      },
+    ]);
+
+    const result = await tool.execute({
+      path: "/workspace/drift.c",
+      old_string: "return 42",
+      new_string: "return 0",
+      __agencSessionId: "session-partial-drift",
+    });
+
     expect(result.isError).toBe(true);
-    expect(parseResult(result).error).toContain("fully read");
+    expect(parseResult(result).error).toContain("modified since it was last read");
     expect(mockWriteFile).not.toHaveBeenCalled();
   });
 
@@ -1083,7 +1114,7 @@ describe("system.editFile", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(parseResult(result).error).toContain("fully read");
+    expect(parseResult(result).error).toContain("has not been read in this session");
     expect(mockWriteFile).not.toHaveBeenCalled();
   });
 
@@ -1449,7 +1480,7 @@ describe("system.editFile", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(parseResult(result).error).toContain("fully read");
+    expect(parseResult(result).error).toContain("has not been read in this session");
   });
 });
 

--- a/runtime/src/tools/system/filesystem.ts
+++ b/runtime/src/tools/system/filesystem.ts
@@ -945,6 +945,13 @@ function hasFileChangedSinceSnapshot(params: {
   if (params.snapshot?.content == null) {
     return false;
   }
+  if (params.snapshot.viewKind === "partial") {
+    // Partial reads captured only a line window. Treat the file as
+    // drifted when the exact window the model saw is no longer a
+    // verbatim substring of the current content — that signals an
+    // external mutation overlapped the viewed region.
+    return !params.currentContent.includes(params.snapshot.content);
+  }
   return params.currentContent !== params.snapshot.content;
 }
 
@@ -1522,8 +1529,12 @@ function createAppendFileTool(
  *   - The file MUST have been read in this session via
  *     `system.readFile` (or written via `system.writeFile` /
  *     `system.editFile` which auto-record the new content as "read").
- *     The Read-before-Edit rule is enforced at the tool boundary
- *     before any filesystem mutation.
+ *     Either a full read or a line-windowed partial read (via
+ *     `offset`/`limit`) is accepted — the tool's own `old_string`
+ *     existence and uniqueness checks are what keep replacements
+ *     safe, not the width of the prior read. `system.writeFile`
+ *     still requires a full snapshot because it overwrites the
+ *     whole file.
  *   - `old_string` MUST appear EXACTLY ONCE in the file unless
  *     `replace_all === true`. If zero matches: returns an error
  *     pointing the model at the actual file content. If multiple
@@ -1550,6 +1561,7 @@ function createEditFileTool(
       "expose the model to JSON-escape mistakes in nested string literals like #include directives, shell " +
       "single-quotes, or printf format strings. The file must exist and must have been read in this session " +
       "(via system.readFile, or implicitly via a prior system.writeFile / system.editFile in the same session). " +
+      "A line-windowed read (with offset/limit) is accepted — a full read is not required for editFile. " +
       "old_string must match exactly once unless replace_all is true. If old_string is not unique, narrow it " +
       "with more surrounding context or pass replace_all: true. Use the smallest old_string that is clearly " +
       "unique — usually 2-4 adjacent lines are enough. Preserve the exact indentation and whitespace from the " +
@@ -1633,17 +1645,25 @@ function createEditFileTool(
           );
         }
 
-        // Read-before-Edit enforcement (Claude Code FileEditTool prompt:5
-        // pattern). Same rule as system.writeFile: the model must have
-        // called system.readFile on this path in the current session.
+        // Read-before-Edit enforcement. The model must have called
+        // system.readFile on this path in the current session, but
+        // either a full or a partial read (offset/limit line window)
+        // suffices: system.editFile is surgical — old_string must
+        // match verbatim against the file's current bytes, and the
+        // uniqueness check below prevents collateral replacements.
+        // Partial reads give the model enough context to identify
+        // the region it is editing without forcing an unnecessary
+        // full re-read of large source files. system.writeFile still
+        // requires a full snapshot because it overwrites the entire
+        // file.
         const sessionId = resolveSessionId(args);
         const readSnapshot = getSessionReadSnapshot(sessionId, resolved!);
-        if (requiresFullReadSnapshot(readSnapshot)) {
+        if (readSnapshot === undefined) {
           return errorResult(
-            `File must be fully read before editing it. ` +
+            `File has not been read in this session. ` +
               `Call system.readFile on "${args.path}" before calling system.editFile. ` +
-              `The Read-before-Edit rule exists so you have the literal current contents of the file ` +
-              `(including any prior escape mistakes) in your context before generating the new edit.`,
+              `A line-windowed read (via offset/limit) is sufficient — the Read-before-Edit rule ` +
+              `only requires that you have seen the current contents before generating the edit.`,
           );
         }
 


### PR DESCRIPTION
## Summary

Live background runs showed a 74% editFile failure rate (2014+ "fully read before editing" rejections in daemon logs) driven by the read-before-edit gate refusing to accept line-windowed reads. Models paginate large sources with `offset`/`limit` (viewKind=partial), then every subsequent `system.editFile` call loops on the same error without learning to re-read the full file.

`system.editFile` is surgical: `old_string` must match verbatim against the current file bytes, and the uniqueness / exact-match checks are the real safety net — not the width of the prior read. A partial read is enough context for the model to identify what it is replacing.

## Changes

- `system.editFile` now requires **any** snapshot (full or partial) for the path, not specifically a full snapshot.
- `hasFileChangedSinceSnapshot` is partial-aware: for partial reads, the file is considered drifted when the exact window the model saw is no longer a verbatim substring of the current content — so external mutations still invalidate the snapshot.
- `system.writeFile` and `system.appendFile` unchanged — both still require a full snapshot because they touch the whole file.
- Tool description updated to document that line-windowed reads are sufficient for editFile.

## Test plan

- [x] `npx vitest run src/tools/system/filesystem.test.ts` — 119 tests pass (including 2 new cases for partial-read success + partial-window drift rejection).
- [x] `npx tsc --noEmit` clean.
- [ ] Live validation: restart daemon, run a background task that paginates a large source, confirm editFile no longer loops on the fully-read gate.