### PR TITLE
fix(runtime/watch): stop cutting tool output to 2 lines, show cross-session activity, tick during silent gaps

### DIFF
--- a/runtime/src/watch/agenc-watch-frame.mjs
+++ b/runtime/src/watch/agenc-watch-frame.mjs
@@ -120,7 +120,52 @@ export function createWatchFrameController(dependencies = {}) {
     lastRenderedFrameLines: [],
     lastRenderedFrameWidth: 0,
     lastRenderedFrameHeight: 0,
+    // Interval that force-ticks the renderer while a run is active
+    // so spinners, elapsed-time, and "Thinking" verbs refresh even
+    // during long silent gaps (a 20s provider call emits no
+    // intermediate events; without this the UI looks frozen).
+    activeRunTicker: null,
   };
+
+  // Re-render cadence while a run is in-flight. 500 ms is fast
+  // enough for smooth spinner animation and once-per-second elapsed
+  // time changes, slow enough to keep CPU cost negligible.
+  const ACTIVE_RUN_TICK_INTERVAL_MS = 500;
+
+  function ensureActiveRunTicker() {
+    const shouldRun =
+      watchState?.activeRunStartedAtMs != null ||
+      (typeof hasActiveSurfaceRun === "function" && hasActiveSurfaceRun());
+    if (shouldRun && !frameState.activeRunTicker) {
+      frameState.activeRunTicker = setInterval(() => {
+        // Re-check on every tick; if the run ended between ticks, stop.
+        const stillActive =
+          watchState?.activeRunStartedAtMs != null ||
+          (typeof hasActiveSurfaceRun === "function" && hasActiveSurfaceRun());
+        if (!stillActive) {
+          if (frameState.activeRunTicker) {
+            clearInterval(frameState.activeRunTicker);
+            frameState.activeRunTicker = null;
+          }
+          return;
+        }
+        // Kick a render regardless of whether new events arrived — the
+        // whole point of the ticker is to keep animated state fresh
+        // during silent provider calls.
+        if (!frameState.renderPending) {
+          frameState.renderPending = true;
+          setTimer(render, 0);
+        }
+      }, ACTIVE_RUN_TICK_INTERVAL_MS);
+      // Don't keep the Node process alive just for animation ticks.
+      if (typeof frameState.activeRunTicker?.unref === "function") {
+        frameState.activeRunTicker.unref();
+      }
+    } else if (!shouldRun && frameState.activeRunTicker) {
+      clearInterval(frameState.activeRunTicker);
+      frameState.activeRunTicker = null;
+    }
+  }
 
   // Split an ANSI-colored row into an array of per-cell entries
   // `{sgr, char}` up to `width` columns. `sgr` is the FULL active
@@ -4002,6 +4047,13 @@ export function createWatchFrameController(dependencies = {}) {
   }
 
   function scheduleRender() {
+    // Make sure the active-run ticker reflects current run state: a
+    // brand-new activeRunStartedAtMs (e.g. the first event of a new
+    // actor turn) should start the steady tick immediately, and a
+    // cycle boundary that cleared activeRunStartedAtMs should stop
+    // it. Putting this here is cheap — O(1) per render call — and
+    // avoids a separate wiring point in every state-mutation site.
+    ensureActiveRunTicker();
     if (frameState.renderPending) {
       return;
     }

--- a/runtime/src/watch/agenc-watch-transcript-cards.mjs
+++ b/runtime/src/watch/agenc-watch-transcript-cards.mjs
@@ -68,24 +68,44 @@ export function computeTranscriptPreviewMaxLines({
   if (eventKind === "market") {
     return latestIsCurrent ? 8 : 6;
   }
-  if (eventKind === "subagent") {
-    return 2;
-  }
+  // Tool and subagent outputs are where code and file contents land. The
+  // old 2-line cap reduced an editFile diff, a readFile of a 200-line
+  // source file, or a bash build log to "first line + ellipsis", which
+  // is exactly what made every non-trivial tool result look "cut off".
+  // Use the same proportional sizing as `sourceInlineBudget` so tool
+  // output respects the viewport instead of a hard cap.
   if (
+    eventKind === "tool" ||
+    eventKind === "tool result" ||
+    eventKind === "tool error" ||
     eventKind === "subagent tool" ||
     eventKind === "subagent tool result" ||
     eventKind === "subagent error"
   ) {
-    return 2;
+    return Math.min(
+      maxPreviewSourceLines,
+      Math.max(
+        latestIsCurrent ? 20 : 10,
+        Math.floor(viewport * (latestIsCurrent ? 0.55 : 0.3)),
+      ),
+    );
+  }
+  if (eventKind === "subagent") {
+    // Subagent status cards are lighter than their tool output — a
+    // short summary is enough — but 2 was too aggressive; show the
+    // full summary headline + progress lines.
+    return latestIsCurrent ? 6 : 4;
   }
   if (eventKind === "you" || eventKind === "operator" || eventKind === "queued") {
     return 3;
   }
-  if (eventKind === "tool" || eventKind === "tool result" || eventKind === "tool error") {
-    return 2;
-  }
   if (eventKind === "error" || eventKind === "approval") {
     return 3;
   }
+  // Keep the conservative default for unrecognized event kinds. The
+  // tool/subagent cases above are where the "code is cut off"
+  // symptom lives; unknown kinds are rare and a tight default
+  // prevents spam when new event types are added without explicit
+  // sizing.
   return 2;
 }

--- a/runtime/src/watch/agenc-watch-transport.mjs
+++ b/runtime/src/watch/agenc-watch-transport.mjs
@@ -221,7 +221,26 @@ export function createWatchTransportController(dependencies = {}) {
       return;
     }
     const normalizedMessage = normalizeOperatorMessage(msg);
-    if (shouldIgnoreOperatorMessage(normalizedMessage, watchState.sessionId)) {
+    // The watch TUI is a daemon-wide observation surface by design —
+    // the operator wants to see cross-session activity, not only
+    // events scoped to the watcher's own chat session. Passing
+    // `null` disables `shouldIgnoreOperatorMessage`'s per-session
+    // gate (the function short-circuits to "do not ignore" when the
+    // active session id is empty). `subagents.*` / `planner_*` /
+    // other session-scoped lifecycle events therefore flow through
+    // the dispatch pipeline regardless of which session the user is
+    // currently composing chat for. Operators that want the old
+    // per-session-only view can still enable it by setting
+    // `AGENC_WATCH_SCOPE_SESSION=1` in the environment.
+    const scopeToSession =
+      typeof process !== "undefined" &&
+      process?.env?.AGENC_WATCH_SCOPE_SESSION === "1";
+    if (
+      shouldIgnoreOperatorMessage(
+        normalizedMessage,
+        scopeToSession ? watchState.sessionId : null,
+      )
+    ) {
       return;
     }
     const surfaceEvent = projectOperatorSurfaceEvent(normalizedMessage);


### PR DESCRIPTION
## Summary

Three concrete rendering bugs in the watch TUI that together made it look frozen while the daemon was actively working:

1. **Tool output hard-capped to 2 lines.** `computeTranscriptPreviewMaxLines` in \`agenc-watch-transcript-cards.mjs:71-90\` returned \`2\` for every tool / tool-result / tool-error / subagent / subagent-tool / subagent-tool-result / subagent-error event. The renderer in \`agenc-watch-frame.mjs:2797-2804\` then overwrote the last line with an ellipsis, so every non-trivial tool output (readFile of a 200-line source, editFile of a block, bash build log) was visible as exactly one line + \"…\". Replaced the hard-cap with proportional viewport sizing — for a common 28-row viewport, a live tool result now shows ~15 lines instead of 1.

2. **Cross-session subagent events silently dropped.** The watch's transport at \`agenc-watch-transport.mjs:224\` called \`shouldIgnoreOperatorMessage(msg, watchState.sessionId)\`, which drops every \`subagents.*\` / \`planner_*\` event whose \`sessionIds\` don't include the operator's own chat session. When a background run spawned subagents in a different session than the one the TUI was composing chat for, every subagent progress event was silently discarded — TUI looked idle. The watch is a daemon-wide observation surface by design, so the transport now passes \`null\` to disable the per-session gate. \`operator-events.ts\` stays unchanged so chat channels that legitimately need session scoping keep their behavior. Operators who want the old per-session-only view can set \`AGENC_WATCH_SCOPE_SESSION=1\`.

3. **No re-render during silent provider calls.** The frame controller only re-rendered on new events. During a 20-second LLM call emitting no intermediate events, the spinner, \"Thinking\" verb, and elapsed-time label all froze. Added a 500 ms ticker in \`agenc-watch-frame.mjs\` that force-ticks \`scheduleRender()\` whenever \`watchState.activeRunStartedAtMs != null\` or \`hasActiveSurfaceRun()\` returns true, clearing itself automatically when the run ends. Interval is \`unref()\`'d so it doesn't keep Node alive. Hooked up inside \`scheduleRender()\` so every existing mutation path gets the ticker for free.

## Test plan

- [x] \`npx tsc --noEmit\` clean.
- [x] \`npm run build\` clean.
- [x] \`npx vitest run src/channels/webchat/operator-events.test.ts\` — 12/12 pass.
- [x] \`node --test tests/watch/*.test.mjs\` — 380/386 pass. Same 6 failures on main (verified with \`git stash\` + re-run). Zero regressions introduced.
- [ ] Live: restart daemon + open TUI, spawn a background run, verify (a) code blocks render at their real length, (b) subagent progress from other sessions appears, (c) spinner animates during long provider calls.