### PR TITLE
fix(tools): rename to taskDescription to avoid JSON Schema collision

### DIFF
--- a/runtime/src/tools/agenc/tools-task-templates.test.ts
+++ b/runtime/src/tools/agenc/tools-task-templates.test.ts
@@ -110,7 +110,7 @@ describe("agenc task template tools", () => {
     });
 
     const result = await tool.execute({
-      description: "Devnet ABI warning task",
+      taskDescription: "Devnet ABI warning task",
       reward: "1",
       requiredCapabilities: "1",
       taskId: "11".repeat(32),
@@ -139,6 +139,32 @@ describe("agenc task template tools", () => {
     expect(createTaskAccountsPartial.mock.calls[0]?.[0]).not.toHaveProperty(
       "authorityRateLimit",
     );
+  });
+
+  it("uses taskDescription (not description) as the input schema property name", () => {
+    const tool = createCreateTaskTool(
+      {
+        provider: { publicKey: new PublicKey("11111111111111111111111111111111") },
+      } as never,
+      createLogger() as never,
+    );
+
+    const props = tool.inputSchema.properties as Record<string, unknown>;
+    expect(props).toHaveProperty("taskDescription");
+    expect(props).not.toHaveProperty("description");
+  });
+
+  it("requires taskDescription (not description) in the input schema", () => {
+    const tool = createCreateTaskTool(
+      {
+        provider: { publicKey: new PublicKey("11111111111111111111111111111111") },
+      } as never,
+      createLogger() as never,
+    );
+
+    const required = tool.inputSchema.required as string[];
+    expect(required).toContain("taskDescription");
+    expect(required).not.toContain("description");
   });
 
   it("lists approved task templates", async () => {

--- a/runtime/src/tools/agenc/tools.ts
+++ b/runtime/src/tools/agenc/tools.ts
@@ -2559,7 +2559,7 @@ export function createCreateTaskTool(
     inputSchema: {
       type: 'object',
       properties: {
-        description: {
+        taskDescription: {
           type: 'string',
           description: `Short on-chain task title/summary (max ${DESCRIPTION_BYTES} UTF-8 bytes). Put the long marketplace job details in jobSpec/fullDescription.`,
         },
@@ -2647,7 +2647,7 @@ export function createCreateTaskTool(
           description: 'Optional creator agent PDA (base58). Auto-resolved when omitted.',
         },
       },
-      required: ['description', 'reward', 'requiredCapabilities'],
+      required: ['taskDescription', 'reward', 'requiredCapabilities'],
     },
     async execute(args: Record<string, unknown>): Promise<ToolResult> {
       try {
@@ -2662,7 +2662,7 @@ export function createCreateTaskTool(
         const creator = program.provider.publicKey;
 
         // Dedup guard — prevent LLM from calling createTask multiple times
-        const dedupKey = `${creator.toBase58()}|${String(args.description ?? '').trim().toLowerCase()}`;
+        const dedupKey = `${creator.toBase58()}|${String(args.taskDescription ?? args.description ?? '').trim().toLowerCase()}`;
         const dedupNow = Date.now();
         const lastCall = recentCreateTaskCalls.get(dedupKey);
         if (lastCall && dedupNow - lastCall < CREATE_TASK_DEDUP_TTL_MS) {
@@ -2675,7 +2675,7 @@ export function createCreateTaskTool(
         const [taskId, taskIdErr] = parseTaskId(args.taskId);
         if (taskIdErr || !taskId) return taskIdErr ?? errorResult('Invalid taskId');
 
-        const [descBytes, descErr] = parseTaskDescription(args.description);
+        const [descBytes, descErr] = parseTaskDescription(args.taskDescription ?? args.description);
         if (descErr || !descBytes) return descErr ?? errorResult('Invalid description');
 
         const [reward, rewardErr] = parseBigIntInput(args.reward, 'reward');
@@ -2781,7 +2781,7 @@ export function createCreateTaskTool(
           try {
             storedJobSpec = await persistMarketplaceJobSpec(
               {
-                description: args.description as string,
+                description: (args.taskDescription ?? args.description) as string,
                 jobSpec: args.jobSpec,
                 fullDescription: args.fullDescription,
                 acceptanceCriteria: args.acceptanceCriteria,


### PR DESCRIPTION
Closes #455

## Summary

The `create_task` tool in `runtime/src/tools/agenc/tools.ts` used `description` as the input field name for the task description. This collides with the JSON Schema `description` keyword at the schema level, causing some LLM provider SDKs and schema validators to silently ignore or misroute the field.

## Changes

**`runtime/src/tools/agenc/tools.ts`** (+4 lines, -4 lines):
- Schema property renamed: `description` → `taskDescription`
- - `required` array updated: `'description'` → `'taskDescription'`
- - Dedup key updated with backwards-compat fallback: `args.taskDescription ?? args.description ?? ''`
- - `parseTaskDescription` call updated with backwards-compat fallback: `args.taskDescription ?? args.description`
**`runtime/src/tools/agenc/tools-task-templates.test.ts`** (+26 lines):
- 2 new tests asserting `taskDescription` is present and `description` is absent in both schema properties and required array
## Test results

- 35/35 targeted tests passing (src/tools/agenc/)
- - Full suite: 21 failures (baseline: 21) — no regressions
- - TypeScript: 0 errors