### PR TITLE
feat(runtime/watch): surface session total tokens in TUI usage chip

### DIFF
--- a/runtime/src/watch/agenc-watch-format-payloads.mjs
+++ b/runtime/src/watch/agenc-watch-format-payloads.mjs
@@ -239,6 +239,7 @@ export function summarizeUsage(payload) {
   }
   const parts = [];
   const prompt = formatCompactNumber(payload.promptTokens);
+  const sessionTotal = formatCompactNumber(payload.totalTokens);
   const effectiveWindow = formatCompactNumber(
     payload.effectiveContextWindowTokens ?? payload.contextWindowTokens,
   );
@@ -249,6 +250,7 @@ export function summarizeUsage(payload) {
       : null;
   const maxOutput = formatCompactNumber(payload.maxOutputTokens);
   if (prompt) parts.push(`${prompt} current`);
+  if (sessionTotal) parts.push(`${sessionTotal} session total`);
   if (effectiveWindow) parts.push(`${effectiveWindow} effective`);
   if (percentUsed) parts.push(percentUsed);
   if (maxOutput) parts.push(`${maxOutput} max out`);


### PR DESCRIPTION
## Summary

- Adds a \"N session total\" segment to the TUI usage header so lifetime session token consumption is visible alongside per-turn context occupancy.
- Daemon side was already populating ChatUsagePayload.totalTokens from executor.getSessionTokenUsage(sessionId); summarizeUsage just wasn't rendering it.
- Two-line edit to runtime/src/watch/agenc-watch-format-payloads.mjs.

Before: usage 2.9K current / 2M effective / 0.1% used
After:  usage 2.9K current / 18.4K session total / 2M effective / 0.1% used

## Test plan

- [x] node --test tests/watch/agenc-watch-format-payloads.test.mjs (5/5 pass)
- [x] npm run build --workspace=@tetsuo-ai/runtime (clean)
- [ ] Verified against the live TUI after merge