### PR TITLE
feat(runtime): USD cost tracking + current xAI catalog IDs

### DIFF
--- a/runtime/src/gateway/chat-usage.ts
+++ b/runtime/src/gateway/chat-usage.ts
@@ -23,6 +23,13 @@ interface ChatUsageSection {
 export interface ChatUsagePayload {
   readonly sessionId?: string;
   readonly totalTokens: number;
+  /**
+   * Cumulative USD cost for the current session, or `undefined` when
+   * the provider/model is not in the pricing table. Undefined is
+   * distinguished from zero so the TUI can skip the cost chip instead
+   * of falsely asserting "$0.0000" for unpriced providers.
+   */
+  readonly sessionCostUsd?: number;
   readonly budget: number;
   readonly compacted: boolean;
   readonly provider?: string;
@@ -56,6 +63,7 @@ export interface ChatUsagePayload {
 interface BuildChatUsagePayloadInput {
   readonly sessionId?: string;
   readonly totalTokens: number;
+  readonly sessionCostUsd?: number;
   readonly sessionTokenBudget: number;
   readonly compacted: boolean;
   readonly provider?: string;
@@ -118,6 +126,11 @@ export function buildChatUsagePayload(
   const payload: ChatUsagePayload = {
     ...(input.sessionId ? { sessionId: input.sessionId } : {}),
     totalTokens: normalizeNonNegativeInt(input.totalTokens),
+    ...(typeof input.sessionCostUsd === "number" &&
+    Number.isFinite(input.sessionCostUsd) &&
+    input.sessionCostUsd >= 0
+      ? { sessionCostUsd: Number(input.sessionCostUsd.toFixed(6)) }
+      : {}),
     budget: normalizeNonNegativeInt(input.sessionTokenBudget),
     compacted: input.compacted === true,
     ...(input.provider ? { provider: input.provider } : {}),

--- a/runtime/src/gateway/context-window.test.ts
+++ b/runtime/src/gateway/context-window.test.ts
@@ -21,15 +21,15 @@ describe("normalizeGrokModel", () => {
   });
 
   it("maps superseded 0304 experimental models to 0309 canonical models", () => {
-    expect(normalizeGrokModel("grok-4.20-experimental-beta-0304-reasoning")).toBe("grok-4.20-beta-0309-reasoning");
-    expect(normalizeGrokModel("grok-4.20-experimental-beta-0304-non-reasoning")).toBe("grok-4.20-beta-0309-non-reasoning");
-    expect(normalizeGrokModel("grok-4.20-multi-agent-experimental-beta-0304")).toBe("grok-4.20-multi-agent-beta-0309");
+    expect(normalizeGrokModel("grok-4.20-experimental-beta-0304-reasoning")).toBe("grok-4.20-0309-reasoning");
+    expect(normalizeGrokModel("grok-4.20-experimental-beta-0304-non-reasoning")).toBe("grok-4.20-0309-non-reasoning");
+    expect(normalizeGrokModel("grok-4.20-multi-agent-experimental-beta-0304")).toBe("grok-4.20-multi-agent-0309");
   });
 
-  it("maps stale non-beta 4.20 IDs to the current beta catalog IDs", () => {
-    expect(normalizeGrokModel("grok-4.20-0309-reasoning")).toBe("grok-4.20-beta-0309-reasoning");
-    expect(normalizeGrokModel("grok-4.20-0309-non-reasoning")).toBe("grok-4.20-beta-0309-non-reasoning");
-    expect(normalizeGrokModel("grok-4.20-multi-agent-0309")).toBe("grok-4.20-multi-agent-beta-0309");
+  it("maps legacy beta-infixed 4.20 IDs to the current non-beta canonical IDs", () => {
+    expect(normalizeGrokModel("grok-4.20-beta-0309-reasoning")).toBe("grok-4.20-0309-reasoning");
+    expect(normalizeGrokModel("grok-4.20-beta-0309-non-reasoning")).toBe("grok-4.20-0309-non-reasoning");
+    expect(normalizeGrokModel("grok-4.20-multi-agent-beta-0309")).toBe("grok-4.20-multi-agent-0309");
   });
 });
 
@@ -41,10 +41,10 @@ describe("inferGrokContextWindowTokens", () => {
     expect(inferGrokContextWindowTokens("grok-4-fast")).toBe(2_000_000);
     expect(inferGrokContextWindowTokens("grok-4-fast-reasoning")).toBe(2_000_000);
     expect(inferGrokContextWindowTokens("grok-4-fast-non-reasoning")).toBe(2_000_000);
-    expect(inferGrokContextWindowTokens("grok-4.20-beta-0309-reasoning")).toBe(2_000_000);
-    expect(inferGrokContextWindowTokens("grok-4.20-beta-0309-non-reasoning")).toBe(2_000_000);
-    expect(inferGrokContextWindowTokens("grok-4.20-multi-agent-beta-0309")).toBe(2_000_000);
     expect(inferGrokContextWindowTokens("grok-4.20-0309-reasoning")).toBe(2_000_000);
+    expect(inferGrokContextWindowTokens("grok-4.20-0309-non-reasoning")).toBe(2_000_000);
+    expect(inferGrokContextWindowTokens("grok-4.20-multi-agent-0309")).toBe(2_000_000);
+    expect(inferGrokContextWindowTokens("grok-4.20-beta-0309-reasoning")).toBe(2_000_000);
   });
 
   it("resolves model-specific windows for non-fast variants", () => {
@@ -68,12 +68,12 @@ describe("listKnownGrokModels", () => {
     });
   });
 
-  it("includes current 0309 beta models with aliases from superseded variants", () => {
+  it("includes current 0309 canonical models with aliases from superseded and legacy-beta variants", () => {
     const models = listKnownGrokModels();
-    const reasoning = models.find((e) => e.id === "grok-4.20-beta-0309-reasoning");
+    const reasoning = models.find((e) => e.id === "grok-4.20-0309-reasoning");
     expect(reasoning).toBeDefined();
     expect(reasoning!.contextWindowTokens).toBe(2_000_000);
-    expect(reasoning!.aliases).toContain("grok-4.20-0309-reasoning");
+    expect(reasoning!.aliases).toContain("grok-4.20-beta-0309-reasoning");
     expect(reasoning!.aliases).toContain("grok-4.20-reasoning");
     expect(reasoning!.aliases).toContain("grok-4.20-experimental-beta-0304-reasoning");
   });

--- a/runtime/src/gateway/context-window.ts
+++ b/runtime/src/gateway/context-window.ts
@@ -21,29 +21,31 @@ const LEGACY_GROK_MODEL_ALIASES: Record<string, string> = {
   "grok-4": "grok-4-1-fast-reasoning",
   "grok-4-fast-reasoning": "grok-4-1-fast-reasoning",
   "grok-4-fast-non-reasoning": "grok-4-1-fast-non-reasoning",
-  // Superseded Grok 4.20 aliases -> current live 0309 beta catalog IDs.
-  "grok-4.20-experimental-beta-0304-reasoning":
-    "grok-4.20-beta-0309-reasoning",
+  // xAI dropped the "-beta-" infix on the 4.20 line (Apr 2026 catalog);
+  // the current catalog publishes non-beta IDs. Keep the old beta names
+  // as legacy aliases that rewrite to the current canonical IDs.
+  "grok-4.20-beta-0309-reasoning": "grok-4.20-0309-reasoning",
+  "grok-4.20-beta-0309-non-reasoning": "grok-4.20-0309-non-reasoning",
+  "grok-4.20-multi-agent-beta-0309": "grok-4.20-multi-agent-0309",
+  "grok-4.20-experimental-beta-0304-reasoning": "grok-4.20-0309-reasoning",
   "grok-4.20-experimental-beta-0304-non-reasoning":
-    "grok-4.20-beta-0309-non-reasoning",
+    "grok-4.20-0309-non-reasoning",
   "grok-4.20-multi-agent-experimental-beta-0304":
-    "grok-4.20-multi-agent-beta-0309",
-  "grok-4.20-0309-reasoning": "grok-4.20-beta-0309-reasoning",
-  "grok-4.20-0309-non-reasoning": "grok-4.20-beta-0309-non-reasoning",
-  "grok-4.20-multi-agent-0309": "grok-4.20-multi-agent-beta-0309",
-  "grok-4.20-reasoning": "grok-4.20-beta-0309-reasoning",
-  "grok-4.20-non-reasoning": "grok-4.20-beta-0309-non-reasoning",
-  "grok-4.20-multi-agent": "grok-4.20-multi-agent-beta-0309",
-  "grok-4.20-beta-latest-reasoning": "grok-4.20-beta-0309-reasoning",
-  "grok-4.20-beta-latest-non-reasoning": "grok-4.20-beta-0309-non-reasoning",
-  "grok-4.20-multi-agent-beta-latest": "grok-4.20-multi-agent-beta-0309",
+    "grok-4.20-multi-agent-0309",
+  "grok-4.20-reasoning": "grok-4.20-0309-reasoning",
+  "grok-4.20-non-reasoning": "grok-4.20-0309-non-reasoning",
+  "grok-4.20-multi-agent": "grok-4.20-multi-agent-0309",
+  "grok-4.20-beta-latest-reasoning": "grok-4.20-0309-reasoning",
+  "grok-4.20-beta-latest-non-reasoning": "grok-4.20-0309-non-reasoning",
+  "grok-4.20-multi-agent-beta-latest": "grok-4.20-multi-agent-0309",
 };
 
 const KNOWN_GROK_MODEL_IDS = [
-  // Chat / language models (source: live /models catalog, April 11 2026)
-  "grok-4.20-beta-0309-reasoning",
-  "grok-4.20-beta-0309-non-reasoning",
-  "grok-4.20-multi-agent-beta-0309",
+  // Chat / language models (source: live xAI catalog, April 19 2026).
+  // The "-beta-" infix was dropped; these non-beta IDs are canonical now.
+  "grok-4.20-0309-reasoning",
+  "grok-4.20-0309-non-reasoning",
+  "grok-4.20-multi-agent-0309",
   "grok-4-1-fast-reasoning",
   "grok-4-1-fast-non-reasoning",
   "grok-4-fast-reasoning",
@@ -66,13 +68,10 @@ const GROK_CONTEXT_WINDOW_BY_PREFIX: ReadonlyArray<{
   readonly prefix: string;
   readonly contextWindowTokens: number;
 }> = [
-  // Source: live /models catalog (retrieved April 11, 2026)
-  { prefix: "grok-4.20-multi-agent-beta-0309", contextWindowTokens: 2_000_000 },
-  { prefix: "grok-4.20-beta-0309-reasoning", contextWindowTokens: 2_000_000 },
-  {
-    prefix: "grok-4.20-beta-0309-non-reasoning",
-    contextWindowTokens: 2_000_000,
-  },
+  // Source: live xAI catalog (retrieved April 19, 2026)
+  { prefix: "grok-4.20-multi-agent-0309", contextWindowTokens: 2_000_000 },
+  { prefix: "grok-4.20-0309-reasoning", contextWindowTokens: 2_000_000 },
+  { prefix: "grok-4.20-0309-non-reasoning", contextWindowTokens: 2_000_000 },
   { prefix: "grok-4-1-fast", contextWindowTokens: 2_000_000 },
   { prefix: "grok-4-fast", contextWindowTokens: 2_000_000 },
   { prefix: "grok-4-1-fast-reasoning", contextWindowTokens: 2_000_000 },

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -5591,6 +5591,10 @@ export class DaemonManager {
     const session = this._webSessionManager?.get(sessionId);
 
     const totalTokens = executor.getSessionTokenUsage(sessionId);
+    const sessionCostUsd =
+      typeof executor.getSessionCostUsd === "function"
+        ? executor.getSessionCostUsd(sessionId)
+        : undefined;
     // Show per-call context window occupancy (from the last model
     // response's input_tokens), not cumulative lifetime total. This
     // matches the reference runtime's getCurrentUsage() which reads
@@ -5613,6 +5617,7 @@ export class DaemonManager {
     const payload = buildChatUsagePayload({
       sessionId,
       totalTokens,
+      sessionCostUsd,
       sessionTokenBudget: resolveSessionTokenBudget(
         effectiveLlmConfig,
         contextWindowTokens,

--- a/runtime/src/gateway/voice-bridge.ts
+++ b/runtime/src/gateway/voice-bridge.ts
@@ -877,6 +877,10 @@ export class VoiceBridge {
         payload: buildChatUsagePayload({
           sessionId,
           totalTokens: chatExecutor.getSessionTokenUsage(sessionId),
+          sessionCostUsd:
+            typeof chatExecutor.getSessionCostUsd === "function"
+              ? chatExecutor.getSessionCostUsd(sessionId)
+              : undefined,
           sessionTokenBudget: this.config.sessionTokenBudget ?? 0,
           compacted: result.compacted ?? false,
           contextWindowTokens: this.config.contextWindowTokens,

--- a/runtime/src/llm/chat-executor-init.ts
+++ b/runtime/src/llm/chat-executor-init.ts
@@ -114,6 +114,7 @@ export interface InitializeExecutionContextDependencies {
   readonly progressProvider: MemoryRetriever | undefined;
   // Session state + thresholds
   readonly sessionTokens: Map<string, number>;
+  readonly sessionCostUsd?: Map<string, number>;
   readonly lastCallInputTokens?: Map<string, number>;
   readonly sessionTokenBudget: number | undefined;
   readonly sessionCompactionThreshold: number | undefined;

--- a/runtime/src/llm/chat-executor-model-orchestration.ts
+++ b/runtime/src/llm/chat-executor-model-orchestration.ts
@@ -59,6 +59,7 @@ import {
 } from "./run-budget.js";
 import { canonicalizeProviderModel } from "../gateway/model-route.js";
 import { trackTokenUsage } from "./chat-executor-state.js";
+import { computeGrokCallCostUsd } from "./grok/pricing.js";
 import type {
   ChatCallUsageRecord,
   CooldownEntry,
@@ -145,6 +146,7 @@ export interface CallModelForPhaseDependencies {
   readonly allowedTools: Set<string> | null;
   readonly defaultRunClass: RuntimeRunClass | undefined;
   readonly sessionTokens: Map<string, number>;
+  readonly sessionCostUsd?: Map<string, number>;
   readonly lastCallInputTokens?: Map<string, number>;
   readonly sessionTokenBudget: number | undefined;
   readonly sessionCompactionThreshold: number | undefined;
@@ -409,6 +411,19 @@ export async function callModelForPhase(
     next.response.usage.totalTokens,
     deps.maxTrackedSessions,
   );
+  if (deps.sessionCostUsd && next.providerName === "grok") {
+    const callCost = computeGrokCallCostUsd(
+      next.response.usage,
+      next.response.model,
+    );
+    if (typeof callCost === "number" && callCost > 0) {
+      const prior = deps.sessionCostUsd.get(ctx.sessionId) ?? 0;
+      deps.sessionCostUsd.set(
+        ctx.sessionId,
+        Number((prior + callCost).toFixed(6)),
+      );
+    }
+  }
   if (deps.lastCallInputTokens) {
     deps.lastCallInputTokens.set(
       ctx.sessionId,

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -202,6 +202,7 @@ export class ChatExecutor {
 
   private readonly cooldowns = new Map<string, CooldownEntry>();
   private readonly sessionTokens = new Map<string, number>();
+  private readonly sessionCostUsd = new Map<string, number>();
   private readonly lastCallInputTokens = new Map<string, number>();
 
   private static normalizeRequestTimeoutMs(timeoutMs: number | undefined): number {
@@ -352,6 +353,7 @@ export class ChatExecutor {
       progressProvider: this.progressProvider,
       // Session state + thresholds
       sessionTokens: this.sessionTokens,
+      sessionCostUsd: this.sessionCostUsd,
       lastCallInputTokens: this.lastCallInputTokens,
       sessionTokenBudget: this.sessionTokenBudget,
       sessionCompactionThreshold: this.sessionCompactionThreshold,
@@ -391,6 +393,7 @@ export class ChatExecutor {
       allowedTools: this.allowedTools,
       defaultRunClass: this.defaultRunClass,
       sessionTokens: this.sessionTokens,
+      sessionCostUsd: this.sessionCostUsd,
       lastCallInputTokens: this.lastCallInputTokens,
       sessionTokenBudget: this.sessionTokenBudget,
       sessionCompactionThreshold: this.sessionCompactionThreshold,
@@ -482,6 +485,16 @@ export class ChatExecutor {
     return this.sessionTokens.get(sessionId) ?? 0;
   }
 
+  /**
+   * Get the accumulated USD cost for a session, or `undefined` when no
+   * priced call has been recorded yet. Undefined is distinguished from
+   * zero so the TUI can skip rendering the chip for unpriced providers
+   * instead of falsely asserting "$0.0000".
+   */
+  getSessionCostUsd(sessionId: string): number | undefined {
+    return this.sessionCostUsd.get(sessionId);
+  }
+
   /** Get the input token count from the most recent model call for a session. */
   getLastCallInputTokens(sessionId: string): number {
     return this.lastCallInputTokens.get(sessionId) ?? 0;
@@ -490,11 +503,13 @@ export class ChatExecutor {
   /** Reset token usage for a specific session. */
   resetSessionTokens(sessionId: string): void {
     this.sessionTokens.delete(sessionId);
+    this.sessionCostUsd.delete(sessionId);
   }
 
   /** Clear all session token tracking. */
   clearAllSessionTokens(): void {
     this.sessionTokens.clear();
+    this.sessionCostUsd.clear();
   }
 
   /** Clear all provider cooldowns. */

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -82,9 +82,9 @@ const VISION_MODELS_WITH_TOOLS = new Set([
   "grok-4-0709",
   "grok-4-1-fast-reasoning",
   "grok-4-1-fast-non-reasoning",
-  "grok-4.20-beta-0309-reasoning",
-  "grok-4.20-beta-0309-non-reasoning",
-  "grok-4.20-multi-agent-beta-0309",
+  "grok-4.20-0309-reasoning",
+  "grok-4.20-0309-non-reasoning",
+  "grok-4.20-multi-agent-0309",
 ]);
 
 const XAI_RESPONSES_TRIM_PRIORITY_TOOL_NAMES = new Set([

--- a/runtime/src/llm/grok/pricing.test.ts
+++ b/runtime/src/llm/grok/pricing.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { computeGrokCallCostUsd, getGrokModelPricing } from "./pricing.js";
+
+describe("getGrokModelPricing", () => {
+  it("returns the catalog price for a canonical 4.20 model", () => {
+    expect(getGrokModelPricing("grok-4.20-0309-non-reasoning")).toEqual({
+      inputPricePer1M: 2.0,
+      outputPricePer1M: 6.0,
+    });
+  });
+
+  it("returns the catalog price for a 4-1-fast model", () => {
+    expect(getGrokModelPricing("grok-4-1-fast-reasoning")).toEqual({
+      inputPricePer1M: 0.2,
+      outputPricePer1M: 0.5,
+    });
+  });
+
+  it("resolves legacy beta-infixed IDs through the canonical alias map", () => {
+    expect(getGrokModelPricing("grok-4.20-beta-0309-non-reasoning")).toEqual({
+      inputPricePer1M: 2.0,
+      outputPricePer1M: 6.0,
+    });
+    expect(getGrokModelPricing("grok-4.20-multi-agent-beta-0309")).toEqual({
+      inputPricePer1M: 2.0,
+      outputPricePer1M: 6.0,
+    });
+  });
+
+  it("returns undefined for unpriced or unknown models", () => {
+    expect(getGrokModelPricing("grok-3-mini")).toBeUndefined();
+    expect(getGrokModelPricing("grok-unknown-model")).toBeUndefined();
+    expect(getGrokModelPricing("")).toBeUndefined();
+    expect(getGrokModelPricing(undefined)).toBeUndefined();
+  });
+});
+
+describe("computeGrokCallCostUsd", () => {
+  it("splits input and output pricing for a 4.20 model", () => {
+    // 1k prompt * $2/1M + 500 completion * $6/1M = 0.002 + 0.003 = 0.005
+    expect(
+      computeGrokCallCostUsd(
+        { promptTokens: 1_000, completionTokens: 500 },
+        "grok-4.20-0309-reasoning",
+      ),
+    ).toBe(0.005);
+  });
+
+  it("uses fast pricing for 4-1-fast models", () => {
+    // 1M prompt * $0.20/1M + 1M completion * $0.50/1M = 0.20 + 0.50 = 0.70
+    expect(
+      computeGrokCallCostUsd(
+        { promptTokens: 1_000_000, completionTokens: 1_000_000 },
+        "grok-4-1-fast-non-reasoning",
+      ),
+    ).toBe(0.7);
+  });
+
+  it("returns undefined for unpriced models (callers should skip, not show $0)", () => {
+    expect(
+      computeGrokCallCostUsd(
+        { promptTokens: 1_000, completionTokens: 500 },
+        "grok-3-mini",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("treats missing/negative tokens as zero", () => {
+    expect(
+      computeGrokCallCostUsd(
+        { promptTokens: NaN, completionTokens: -5 },
+        "grok-4.20-0309-non-reasoning",
+      ),
+    ).toBe(0);
+  });
+});

--- a/runtime/src/llm/grok/pricing.ts
+++ b/runtime/src/llm/grok/pricing.ts
@@ -1,0 +1,84 @@
+/**
+ * xAI model pricing table and USD cost helpers.
+ *
+ * Source: developer console catalog (retrieved April 19, 2026). Prices
+ * are USD per 1,000,000 tokens for input and output respectively. When
+ * a model is not in this table, cost is reported as `undefined` rather
+ * than guessed — the TUI skips rendering the cost chip in that case.
+ *
+ * Update the table in one place (this module) when xAI changes rates.
+ */
+
+import type { LLMUsage } from "../types.js";
+import { normalizeGrokModel } from "../../gateway/context-window.js";
+
+export interface GrokModelPricing {
+  /** USD per 1,000,000 input (prompt) tokens. */
+  readonly inputPricePer1M: number;
+  /** USD per 1,000,000 output (completion) tokens. */
+  readonly outputPricePer1M: number;
+}
+
+const GROK_PRICING_BY_CANONICAL_ID: Readonly<Record<string, GrokModelPricing>> =
+  Object.freeze({
+    // Grok 4.20 family — $2.00 input / $6.00 output per 1M
+    "grok-4.20-0309-reasoning": {
+      inputPricePer1M: 2.0,
+      outputPricePer1M: 6.0,
+    },
+    "grok-4.20-0309-non-reasoning": {
+      inputPricePer1M: 2.0,
+      outputPricePer1M: 6.0,
+    },
+    "grok-4.20-multi-agent-0309": {
+      inputPricePer1M: 2.0,
+      outputPricePer1M: 6.0,
+    },
+    // Grok 4.1 fast family — $0.20 input / $0.50 output per 1M
+    "grok-4-1-fast-reasoning": {
+      inputPricePer1M: 0.2,
+      outputPricePer1M: 0.5,
+    },
+    "grok-4-1-fast-non-reasoning": {
+      inputPricePer1M: 0.2,
+      outputPricePer1M: 0.5,
+    },
+  });
+
+/**
+ * Look up per-1M USD pricing for a grok model, applying legacy-alias
+ * normalization so the old "-beta-" IDs resolve to the current catalog.
+ * Returns `undefined` when the (canonicalized) model is not priced.
+ */
+export function getGrokModelPricing(
+  model: string | undefined,
+): GrokModelPricing | undefined {
+  if (typeof model !== "string" || model.length === 0) {
+    return undefined;
+  }
+  const canonical = normalizeGrokModel(model) ?? model;
+  return GROK_PRICING_BY_CANONICAL_ID[canonical];
+}
+
+/**
+ * Compute the USD cost of a single LLM call given its usage record and
+ * the model ID it ran against. Returns `undefined` when pricing is not
+ * available for the model — callers should drop the field rather than
+ * display `$0.0000` as a false assertion of zero cost.
+ */
+export function computeGrokCallCostUsd(
+  usage: Pick<LLMUsage, "promptTokens" | "completionTokens">,
+  model: string | undefined,
+): number | undefined {
+  const pricing = getGrokModelPricing(model);
+  if (!pricing) return undefined;
+  const promptTokens = Number.isFinite(usage.promptTokens)
+    ? Math.max(0, usage.promptTokens)
+    : 0;
+  const completionTokens = Number.isFinite(usage.completionTokens)
+    ? Math.max(0, usage.completionTokens)
+    : 0;
+  const inputCost = (promptTokens * pricing.inputPricePer1M) / 1_000_000;
+  const outputCost = (completionTokens * pricing.outputPricePer1M) / 1_000_000;
+  return Number((inputCost + outputCost).toFixed(6));
+}

--- a/runtime/src/llm/grok/xai-strict-filter.test.ts
+++ b/runtime/src/llm/grok/xai-strict-filter.test.ts
@@ -112,44 +112,44 @@ function functionCallBlock(name: string, args: string): Record<string, unknown> 
 
 describe("resolveDocumentedXaiModel", () => {
   it("returns canonical ID for known catalog entries", () => {
-    expect(resolveDocumentedXaiModel("grok-4.20-beta-0309-reasoning")).toBe(
-      "grok-4.20-beta-0309-reasoning",
+    expect(resolveDocumentedXaiModel("grok-4.20-0309-reasoning")).toBe(
+      "grok-4.20-0309-reasoning",
     );
     expect(resolveDocumentedXaiModel("grok-4-1-fast-non-reasoning")).toBe(
       "grok-4-1-fast-non-reasoning",
     );
-    expect(resolveDocumentedXaiModel("grok-4.20-multi-agent-beta-0309")).toBe(
-      "grok-4.20-multi-agent-beta-0309",
+    expect(resolveDocumentedXaiModel("grok-4.20-multi-agent-0309")).toBe(
+      "grok-4.20-multi-agent-0309",
     );
   });
 
   it("resolves bare-name aliases to canonical", () => {
     expect(resolveDocumentedXaiModel("grok-4.20-reasoning")).toBe(
-      "grok-4.20-beta-0309-reasoning",
+      "grok-4.20-0309-reasoning",
     );
     expect(resolveDocumentedXaiModel("grok-4.20-multi-agent")).toBe(
-      "grok-4.20-multi-agent-beta-0309",
+      "grok-4.20-multi-agent-0309",
     );
   });
 
   it("resolves -latest aliases to canonical", () => {
     expect(resolveDocumentedXaiModel("grok-4.20-reasoning-latest")).toBe(
-      "grok-4.20-beta-0309-reasoning",
+      "grok-4.20-0309-reasoning",
     );
     expect(
       resolveDocumentedXaiModel("grok-4-1-fast-non-reasoning-latest"),
     ).toBe("grok-4-1-fast-non-reasoning");
   });
 
-  it("resolves stale non-beta 4.20 IDs to current beta catalog IDs", () => {
-    expect(resolveDocumentedXaiModel("grok-4.20-0309-reasoning")).toBe(
-      "grok-4.20-beta-0309-reasoning",
+  it("resolves legacy beta-infixed 4.20 IDs to current non-beta canonical IDs", () => {
+    expect(resolveDocumentedXaiModel("grok-4.20-beta-0309-reasoning")).toBe(
+      "grok-4.20-0309-reasoning",
     );
-    expect(resolveDocumentedXaiModel("grok-4.20-0309-non-reasoning")).toBe(
-      "grok-4.20-beta-0309-non-reasoning",
+    expect(resolveDocumentedXaiModel("grok-4.20-beta-0309-non-reasoning")).toBe(
+      "grok-4.20-0309-non-reasoning",
     );
-    expect(resolveDocumentedXaiModel("grok-4.20-multi-agent-0309")).toBe(
-      "grok-4.20-multi-agent-beta-0309",
+    expect(resolveDocumentedXaiModel("grok-4.20-multi-agent-beta-0309")).toBe(
+      "grok-4.20-multi-agent-0309",
     );
   });
 
@@ -192,10 +192,10 @@ describe("model capability flags", () => {
   });
 
   it("modelSupportsReasoningEffort: only multi-agent", () => {
-    expect(modelSupportsReasoningEffort("grok-4.20-multi-agent-beta-0309")).toBe(
+    expect(modelSupportsReasoningEffort("grok-4.20-multi-agent-0309")).toBe(
       true,
     );
-    expect(modelSupportsReasoningEffort("grok-4.20-beta-0309-reasoning")).toBe(false);
+    expect(modelSupportsReasoningEffort("grok-4.20-0309-reasoning")).toBe(false);
     expect(modelSupportsReasoningEffort("grok-4-1-fast-reasoning")).toBe(false);
     expect(modelSupportsReasoningEffort("grok-4-1-fast-non-reasoning")).toBe(
       false,
@@ -228,7 +228,7 @@ describe("validateXaiRequestPreFlight (pass cases)", () => {
     expect(() =>
       validateXaiRequestPreFlight(
         plainTextRequest({
-          model: "grok-4.20-multi-agent-beta-0309",
+          model: "grok-4.20-multi-agent-0309",
           reasoning: { effort: "high" },
         }),
       ),
@@ -240,7 +240,7 @@ describe("validateXaiRequestPreFlight (pass cases)", () => {
       expect(() =>
         validateXaiRequestPreFlight(
           plainTextRequest({
-            model: "grok-4.20-multi-agent-beta-0309",
+            model: "grok-4.20-multi-agent-0309",
             reasoning: { effort },
           }),
         ),
@@ -365,7 +365,7 @@ describe("validateXaiRequestPreFlight (reject cases)", () => {
     expect(() =>
       validateXaiRequestPreFlight(
         plainTextRequest({
-          model: "grok-4.20-multi-agent-beta-0309",
+          model: "grok-4.20-multi-agent-0309",
           frequency_penalty: 1.0,
         }),
       ),
@@ -902,7 +902,7 @@ describe("multi-agent specific restrictions", () => {
     expect(() =>
       validateXaiRequestPreFlight(
         plainTextRequest({
-          model: "grok-4.20-multi-agent-beta-0309",
+          model: "grok-4.20-multi-agent-0309",
           max_output_tokens: 1024,
         }),
       ),
@@ -924,7 +924,7 @@ describe("multi-agent specific restrictions", () => {
     expect(() =>
       validateXaiRequestPreFlight(
         plainTextRequest({
-          model: "grok-4.20-multi-agent-beta-0309",
+          model: "grok-4.20-multi-agent-0309",
           tools: [functionTool("system.bash")],
         }),
       ),
@@ -935,7 +935,7 @@ describe("multi-agent specific restrictions", () => {
     expect(() =>
       validateXaiRequestPreFlight(
         plainTextRequest({
-          model: "grok-4.20-multi-agent-beta-0309",
+          model: "grok-4.20-multi-agent-0309",
           tools: [{ type: "web_search" }, { type: "x_search" }],
         }),
       ),

--- a/runtime/src/llm/grok/xai-strict-filter.ts
+++ b/runtime/src/llm/grok/xai-strict-filter.ts
@@ -162,12 +162,12 @@ const SERVER_SIDE_TOOL_CALL_OUTPUT_TYPES: ReadonlySet<string> = new Set([
  * compatibility rule for undocumented 200s.
  */
 const DOCUMENTED_XAI_MODEL_IDS: ReadonlySet<string> = new Set([
-  // Grok 4 family — current
-  "grok-4.20-beta-0309-reasoning",
-  "grok-4.20-beta-0309-non-reasoning",
+  // Grok 4 family — current (xAI dropped the -beta- infix in Apr 2026)
+  "grok-4.20-0309-reasoning",
+  "grok-4.20-0309-non-reasoning",
   "grok-4-1-fast-reasoning",
   "grok-4-1-fast-non-reasoning",
-  "grok-4.20-multi-agent-beta-0309",
+  "grok-4.20-multi-agent-0309",
   "grok-4-0709",
   // Grok 3 family — still in xAI catalog per release notes (April 2025)
   "grok-3",
@@ -196,22 +196,22 @@ const DOCUMENTED_XAI_MODEL_IDS: ReadonlySet<string> = new Set([
  */
 const DOCUMENTED_XAI_MODEL_ALIASES: ReadonlyMap<string, string> = new Map([
   // bare names → canonical
-  ["grok-4.20-reasoning", "grok-4.20-beta-0309-reasoning"],
-  ["grok-4.20-non-reasoning", "grok-4.20-beta-0309-non-reasoning"],
-  ["grok-4.20-multi-agent", "grok-4.20-multi-agent-beta-0309"],
+  ["grok-4.20-reasoning", "grok-4.20-0309-reasoning"],
+  ["grok-4.20-non-reasoning", "grok-4.20-0309-non-reasoning"],
+  ["grok-4.20-multi-agent", "grok-4.20-multi-agent-0309"],
   ["grok-4-fast-reasoning", "grok-4-1-fast-reasoning"],
   ["grok-4-fast-non-reasoning", "grok-4-1-fast-non-reasoning"],
   // -latest aliases → canonical
-  ["grok-4.20-reasoning-latest", "grok-4.20-beta-0309-reasoning"],
-  ["grok-4.20-non-reasoning-latest", "grok-4.20-beta-0309-non-reasoning"],
-  ["grok-4.20-multi-agent-latest", "grok-4.20-multi-agent-beta-0309"],
-  ["grok-4.20-beta-latest-reasoning", "grok-4.20-beta-0309-reasoning"],
-  ["grok-4.20-beta-latest-non-reasoning", "grok-4.20-beta-0309-non-reasoning"],
-  ["grok-4.20-multi-agent-beta-latest", "grok-4.20-multi-agent-beta-0309"],
-  // Previous non-beta spelling seen in local autocomplete before xAI exposed beta IDs.
-  ["grok-4.20-0309-reasoning", "grok-4.20-beta-0309-reasoning"],
-  ["grok-4.20-0309-non-reasoning", "grok-4.20-beta-0309-non-reasoning"],
-  ["grok-4.20-multi-agent-0309", "grok-4.20-multi-agent-beta-0309"],
+  ["grok-4.20-reasoning-latest", "grok-4.20-0309-reasoning"],
+  ["grok-4.20-non-reasoning-latest", "grok-4.20-0309-non-reasoning"],
+  ["grok-4.20-multi-agent-latest", "grok-4.20-multi-agent-0309"],
+  // Legacy beta-infixed IDs from earlier xAI catalog — remap to current canonical
+  ["grok-4.20-beta-0309-reasoning", "grok-4.20-0309-reasoning"],
+  ["grok-4.20-beta-0309-non-reasoning", "grok-4.20-0309-non-reasoning"],
+  ["grok-4.20-multi-agent-beta-0309", "grok-4.20-multi-agent-0309"],
+  ["grok-4.20-beta-latest-reasoning", "grok-4.20-0309-reasoning"],
+  ["grok-4.20-beta-latest-non-reasoning", "grok-4.20-0309-non-reasoning"],
+  ["grok-4.20-multi-agent-beta-latest", "grok-4.20-multi-agent-0309"],
   ["grok-4-1-fast-reasoning-latest", "grok-4-1-fast-reasoning"],
   ["grok-4-1-fast-non-reasoning-latest", "grok-4-1-fast-non-reasoning"],
 ]);
@@ -251,7 +251,7 @@ export function modelSupportsFunctionCalling(canonicalModel: string): boolean {
  * automatically and **return an error** if `reasoning.effort` is sent.
  */
 export function modelSupportsReasoningEffort(canonicalModel: string): boolean {
-  return canonicalModel === "grok-4.20-multi-agent-beta-0309";
+  return canonicalModel === "grok-4.20-multi-agent-0309";
 }
 
 /**
@@ -314,7 +314,7 @@ export class XaiUnknownModelError extends LLMProviderError {
         `catalog (developers/models). xAI silently aliases unknown model IDs, ` +
         `which produces unverifiable behavior. Set llm.model in config.json to ` +
         `one of the documented IDs (e.g. "grok-4-1-fast-non-reasoning", ` +
-        `"grok-4.20-beta-0309-reasoning", "grok-4.20-multi-agent-beta-0309").`,
+        `"grok-4.20-0309-reasoning", "grok-4.20-multi-agent-0309").`,
       400,
     );
     this.name = "XaiUnknownModelError";
@@ -358,7 +358,7 @@ export class XaiUndocumentedFieldError extends LLMProviderError {
  *
  *   1. Undocumented or empty `model`.
  *   2. `reasoning` field on a model that doesn't accept `reasoning.effort`
- *      (everything except `grok-4.20-multi-agent-beta-0309`).
+ *      (everything except `grok-4.20-multi-agent-0309`).
  *   3. `presence_penalty` / `frequency_penalty` / `stop` on a reasoning
  *      variant.
  *   4. Any top-level field not in
@@ -388,7 +388,7 @@ export function validateXaiRequestPreFlight(
   if ("reasoning" in params && !modelSupportsReasoningEffort(canonicalModel)) {
     throw new XaiUndocumentedFieldError(
       "reasoning",
-      `is only supported on grok-4.20-multi-agent-beta-0309 (where it controls ` +
+      `is only supported on grok-4.20-multi-agent-0309 (where it controls ` +
         `agent count); current model is ${canonicalModel}, which reasons ` +
         `automatically and returns an error if reasoning.effort is sent`,
     );

--- a/runtime/src/onboarding/xai-validation.js
+++ b/runtime/src/onboarding/xai-validation.js
@@ -6,27 +6,28 @@ const LEGACY_GROK_MODEL_ALIASES = Object.freeze({
   "grok-4": "grok-4-1-fast-reasoning",
   "grok-4-fast-reasoning": "grok-4-1-fast-reasoning",
   "grok-4-fast-non-reasoning": "grok-4-1-fast-non-reasoning",
-  "grok-4.20-experimental-beta-0304-reasoning":
-    "grok-4.20-beta-0309-reasoning",
+  // xAI dropped the "-beta-" infix (Apr 2026). Keep the old names as
+  // legacy aliases that rewrite to the current canonical IDs.
+  "grok-4.20-beta-0309-reasoning": "grok-4.20-0309-reasoning",
+  "grok-4.20-beta-0309-non-reasoning": "grok-4.20-0309-non-reasoning",
+  "grok-4.20-multi-agent-beta-0309": "grok-4.20-multi-agent-0309",
+  "grok-4.20-experimental-beta-0304-reasoning": "grok-4.20-0309-reasoning",
   "grok-4.20-experimental-beta-0304-non-reasoning":
-    "grok-4.20-beta-0309-non-reasoning",
+    "grok-4.20-0309-non-reasoning",
   "grok-4.20-multi-agent-experimental-beta-0304":
-    "grok-4.20-multi-agent-beta-0309",
-  "grok-4.20-0309-reasoning": "grok-4.20-beta-0309-reasoning",
-  "grok-4.20-0309-non-reasoning": "grok-4.20-beta-0309-non-reasoning",
-  "grok-4.20-multi-agent-0309": "grok-4.20-multi-agent-beta-0309",
-  "grok-4.20-reasoning": "grok-4.20-beta-0309-reasoning",
-  "grok-4.20-non-reasoning": "grok-4.20-beta-0309-non-reasoning",
-  "grok-4.20-multi-agent": "grok-4.20-multi-agent-beta-0309",
-  "grok-4.20-beta-latest-reasoning": "grok-4.20-beta-0309-reasoning",
-  "grok-4.20-beta-latest-non-reasoning": "grok-4.20-beta-0309-non-reasoning",
-  "grok-4.20-multi-agent-beta-latest": "grok-4.20-multi-agent-beta-0309",
+    "grok-4.20-multi-agent-0309",
+  "grok-4.20-reasoning": "grok-4.20-0309-reasoning",
+  "grok-4.20-non-reasoning": "grok-4.20-0309-non-reasoning",
+  "grok-4.20-multi-agent": "grok-4.20-multi-agent-0309",
+  "grok-4.20-beta-latest-reasoning": "grok-4.20-0309-reasoning",
+  "grok-4.20-beta-latest-non-reasoning": "grok-4.20-0309-non-reasoning",
+  "grok-4.20-multi-agent-beta-latest": "grok-4.20-multi-agent-0309",
 });
 
 const KNOWN_GROK_CHAT_MODELS = new Set([
-  "grok-4.20-multi-agent-beta-0309",
-  "grok-4.20-beta-0309-reasoning",
-  "grok-4.20-beta-0309-non-reasoning",
+  "grok-4.20-multi-agent-0309",
+  "grok-4.20-0309-reasoning",
+  "grok-4.20-0309-non-reasoning",
   "grok-4-1-fast-reasoning",
   "grok-4-1-fast-non-reasoning",
   "grok-4-fast-reasoning",

--- a/runtime/src/watch/agenc-watch-format-payloads.mjs
+++ b/runtime/src/watch/agenc-watch-format-payloads.mjs
@@ -240,6 +240,12 @@ export function summarizeUsage(payload) {
   const parts = [];
   const prompt = formatCompactNumber(payload.promptTokens);
   const sessionTotal = formatCompactNumber(payload.totalTokens);
+  const sessionCost =
+    typeof payload.sessionCostUsd === "number" &&
+    Number.isFinite(payload.sessionCostUsd) &&
+    payload.sessionCostUsd >= 0
+      ? formatSessionCostUsd(payload.sessionCostUsd)
+      : null;
   const effectiveWindow = formatCompactNumber(
     payload.effectiveContextWindowTokens ?? payload.contextWindowTokens,
   );
@@ -251,11 +257,21 @@ export function summarizeUsage(payload) {
   const maxOutput = formatCompactNumber(payload.maxOutputTokens);
   if (prompt) parts.push(`${prompt} current`);
   if (sessionTotal) parts.push(`${sessionTotal} session total`);
+  if (sessionCost) parts.push(`${sessionCost} session`);
   if (effectiveWindow) parts.push(`${effectiveWindow} effective`);
   if (percentUsed) parts.push(percentUsed);
   if (maxOutput) parts.push(`${maxOutput} max out`);
   if (payload.compacted) parts.push("compacted");
   return parts.length > 0 ? parts.join(" / ") : null;
+}
+
+function formatSessionCostUsd(value) {
+  // Below 1¢: show micro-dollar precision so early session activity is
+  // visible (e.g. "$0.0042"). At 1¢ or more: round to the cent.
+  if (value < 0.01) {
+    return `$${value.toFixed(4)}`;
+  }
+  return `$${value.toFixed(2)}`;
 }
 
 export function firstMeaningfulLine(value) {

--- a/runtime/src/watch/agenc-watch-helpers.mjs
+++ b/runtime/src/watch/agenc-watch-helpers.mjs
@@ -5,9 +5,9 @@ export const DEFAULT_INPUT_BATCH_DELAY_MS = 45;
  * Kept in sync with runtime/src/gateway/context-window.ts KNOWN_GROK_MODEL_IDS.
  */
 export const KNOWN_CHAT_MODELS = Object.freeze([
-  "grok-4.20-multi-agent-beta-0309",
-  "grok-4.20-beta-0309-reasoning",
-  "grok-4.20-beta-0309-non-reasoning",
+  "grok-4.20-multi-agent-0309",
+  "grok-4.20-0309-reasoning",
+  "grok-4.20-0309-non-reasoning",
   "grok-4-1-fast-reasoning",
   "grok-4-1-fast-non-reasoning",
   "grok-4-fast-reasoning",

--- a/runtime/src/watch/agenc-watch-session-utils.mjs
+++ b/runtime/src/watch/agenc-watch-session-utils.mjs
@@ -8,15 +8,16 @@
 import { sanitizeInlineText } from "./agenc-watch-text-utils.mjs";
 
 const GROK_MODEL_ALIASES = new Map([
-  ["grok-4.20-0309-reasoning", "grok-4.20-beta-0309-reasoning"],
-  ["grok-4.20-0309-non-reasoning", "grok-4.20-beta-0309-non-reasoning"],
-  ["grok-4.20-multi-agent-0309", "grok-4.20-multi-agent-beta-0309"],
-  ["grok-4.20-reasoning", "grok-4.20-beta-0309-reasoning"],
-  ["grok-4.20-non-reasoning", "grok-4.20-beta-0309-non-reasoning"],
-  ["grok-4.20-multi-agent", "grok-4.20-multi-agent-beta-0309"],
-  ["grok-4.20-beta-latest-reasoning", "grok-4.20-beta-0309-reasoning"],
-  ["grok-4.20-beta-latest-non-reasoning", "grok-4.20-beta-0309-non-reasoning"],
-  ["grok-4.20-multi-agent-beta-latest", "grok-4.20-multi-agent-beta-0309"],
+  // Legacy beta-infixed IDs (pre-Apr 2026 xAI catalog) remap to current canonical.
+  ["grok-4.20-beta-0309-reasoning", "grok-4.20-0309-reasoning"],
+  ["grok-4.20-beta-0309-non-reasoning", "grok-4.20-0309-non-reasoning"],
+  ["grok-4.20-multi-agent-beta-0309", "grok-4.20-multi-agent-0309"],
+  ["grok-4.20-reasoning", "grok-4.20-0309-reasoning"],
+  ["grok-4.20-non-reasoning", "grok-4.20-0309-non-reasoning"],
+  ["grok-4.20-multi-agent", "grok-4.20-multi-agent-0309"],
+  ["grok-4.20-beta-latest-reasoning", "grok-4.20-0309-reasoning"],
+  ["grok-4.20-beta-latest-non-reasoning", "grok-4.20-0309-non-reasoning"],
+  ["grok-4.20-multi-agent-beta-latest", "grok-4.20-multi-agent-0309"],
 ]);
 
 function canonicalizeProviderModel(provider, model) {


### PR DESCRIPTION
## Summary

- Swap Grok 4.20 canonical IDs to the non-beta forms that match the current xAI catalog (Apr 2026). The old \`grok-4.20-beta-0309-*\` spellings become legacy aliases that rewrite to the new canonical IDs.
- New pricing module \`runtime/src/llm/grok/pricing.ts\` with the xAI rate table (\$2/\$6 per 1M for 4.20 family, \$0.20/\$0.50 for 4-1-fast). \`computeGrokCallCostUsd\` splits input/output tokens and returns undefined for unpriced models so the UI can skip the chip.
- ChatExecutor accumulates a session USD cost in parallel with \`sessionTokens\` and exposes \`getSessionCostUsd(sessionId)\`. Threaded into \`ChatUsagePayload.sessionCostUsd\` and into both \`daemon.ts buildSessionUsageSnapshot\` and \`voice-bridge.ts\`.
- TUI \`summarizeUsage\` renders a new \`\$X.XX session\` segment. Micro-precision below 1¢ so early-session burn is visible.

Before: \`usage 2.9K current / 18.4K session total / 2M effective / 0.1% used\`
After:  \`usage 2.9K current / 18.4K session total / \$0.0042 session / 2M effective / 0.1% used\`

## Test plan

- [x] \`npx vitest run src/llm/grok/pricing.test.ts\` — 8/8
- [x] \`npx vitest run src/gateway/context-window.test.ts src/gateway/chat-usage.test.ts src/llm/grok/\` — 173/173
- [x] \`npx tsc --noEmit\` — clean
- [x] Full runtime build