### PR TITLE
feat(runtime): remove bg-run auto-promotion + port compact-and-reattach

### DIFF
--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -23,6 +23,11 @@ import type { LLMMessage, LLMProvider, ToolHandler } from "../llm/types.js";
 import { partitionByAnchorPreserve } from "../llm/types.js";
 import { collectAttachments } from "../llm/attachment-injection.js";
 import {
+  clearSessionReadCache,
+  snapshotTopRecentReads,
+  type SessionReadSnapshotExport,
+} from "../tools/system/filesystem.js";
+import {
   containsVerdictMarkerInToolResult,
   isMutatingTool,
   isVerifierSpawnFromRecord,
@@ -250,6 +255,35 @@ import {
   type RuntimeFaultInjector,
 } from "../eval/fault-injection.js";
 import { hasStopHookHandlers, runStopHookPhase } from "../llm/hooks/stop-hooks.js";
+
+// ---------------------------------------------------------------------------
+// Post-compaction file re-attachment budget
+// ---------------------------------------------------------------------------
+//
+// Mirrors the reference runtime's POST_COMPACT_MAX_FILES_TO_RESTORE +
+// 50K-token / 5K-per-file envelope. Chars are a cheap proxy for tokens
+// at the grok/claude tokenizer ratio (~4 chars/token) — over-budget
+// files get truncated at read-time; the compacted prompt's total bytes
+// remain bounded.
+//
+const POST_COMPACT_MAX_FILES_TO_REATTACH = 5;
+const POST_COMPACT_PER_FILE_BUDGET_CHARS = 20_000;
+const POST_COMPACT_TOTAL_BUDGET_CHARS = 200_000;
+
+function buildAnchorFileMessage(
+  snapshot: SessionReadSnapshotExport,
+): LLMMessage {
+  const header =
+    `<anchor-file path="${snapshot.path}" viewKind="${snapshot.viewKind ?? "full"}">`;
+  const footer = "</anchor-file>";
+  return {
+    role: "system",
+    content:
+      `${header}\n${snapshot.content}\n${footer}\n` +
+      `[reattached from pre-compaction read cache; refer to the anchor-file ` +
+      `block above instead of re-calling system.readFile for this path]`,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Domain-dependent free functions (kept here to avoid circular deps)
@@ -4614,6 +4648,37 @@ export class BackgroundRunSupervisor {
     return Math.ceil(totalChars / this.compactionCharPerToken);
   }
 
+  /**
+   * Snapshot the top-N most-recently read files for this session, clear
+   * the in-memory read cache so the FILE_UNCHANGED_STUB short-circuit
+   * doesn't lie post-compaction, and return the snapshots as
+   * system-role anchor messages that re-embed the content verbatim in
+   * the compacted tail. Mirrors the reference runtime's
+   * compact-and-re-attach pattern — drop tool results from the summary
+   * but re-inject the actual bytes of the most relevant files so the
+   * next cycle does not have to re-read them.
+   */
+  private reattachRecentFilesOnCompaction(
+    sessionId: string,
+  ): LLMMessage[] {
+    const snapshots = snapshotTopRecentReads({
+      sessionId,
+      maxFiles: POST_COMPACT_MAX_FILES_TO_REATTACH,
+      perFileBudgetChars: POST_COMPACT_PER_FILE_BUDGET_CHARS,
+      totalBudgetChars: POST_COMPACT_TOTAL_BUDGET_CHARS,
+    });
+    // Unconditionally clear the cache: the compacted prompt no longer
+    // contains the prior raw tool_result bytes, so a later
+    // FILE_UNCHANGED_STUB reply would point at content that has been
+    // summarized away. Re-attachments below supply the bytes that
+    // matter; the cache will refill naturally on next read.
+    clearSessionReadCache(sessionId);
+    if (snapshots.length === 0) {
+      return [];
+    }
+    return snapshots.map((s) => buildAnchorFileMessage(s));
+  }
+
   private async compactInternalHistory(
     run: ActiveBackgroundRun,
     history: LLMMessage[],
@@ -4656,6 +4721,7 @@ export class BackgroundRunSupervisor {
     // normal compaction output) and skip the provider call.
     if (toActuallySummarize.length === 0) {
       breakProviderContinuation();
+      const anchorFiles = this.reattachRecentFilesOnCompaction(run.sessionId);
       return [
         {
           role: "system",
@@ -4663,6 +4729,7 @@ export class BackgroundRunSupervisor {
             "[previous messages compacted; anchor-preserved reminders retained]",
         } as LLMMessage,
         ...anchorPreserved,
+        ...anchorFiles,
         ...kept,
       ];
     }
@@ -4712,9 +4779,11 @@ export class BackgroundRunSupervisor {
         return history;
       }
       breakProviderContinuation();
+      const anchorFiles = this.reattachRecentFilesOnCompaction(run.sessionId);
       return [
         { role: "system", content: summary } as LLMMessage,
         ...anchorPreserved,
+        ...anchorFiles,
         ...kept,
       ];
     } catch {

--- a/runtime/src/gateway/background-run-workflow-context.ts
+++ b/runtime/src/gateway/background-run-workflow-context.ts
@@ -13,10 +13,6 @@ import {
   type AnchorFileRegistration,
 } from "./at-mention-attachments.js";
 
-const FULL_IMPLEMENTATION_RE =
-  /\b(?:implement|complete|finish|build)\b[\s\S]{0,160}\b(?:in full|fully|entirely|the full plan|all phases|every phase)\b/i;
-const DO_NOT_STOP_RE =
-  /\b(?:do not stop|don't stop|without stopping|until complete|until it's complete|until it is complete|keep going until)\b/i;
 const PLAN_REFERENCE_RE = /(?:^|\s)@?PLAN\.md\b/i;
 const PHASED_REQUEST_RE =
   /\b(?:all phases|every phase|phase-by-phase|milestones?|m\d+\b)\b/i;
@@ -40,23 +36,6 @@ export interface BackgroundRunWorkflowContext {
   readonly anchorRegistrations: readonly AnchorFileRegistration[];
 }
 
-export function shouldPromoteImplementationBackgroundRun(
-  content: string,
-): boolean {
-  const trimmed = content.trim();
-  if (trimmed.length === 0) {
-    return false;
-  }
-  return (
-    FULL_IMPLEMENTATION_RE.test(trimmed) ||
-    (PLAN_REFERENCE_RE.test(trimmed) &&
-      (DO_NOT_STOP_RE.test(trimmed) || PHASED_REQUEST_RE.test(trimmed))) ||
-    (DO_NOT_STOP_RE.test(trimmed) &&
-      /\b(?:implement|build|complete|finish)\b/i.test(trimmed) &&
-      PHASED_REQUEST_RE.test(trimmed))
-  );
-}
-
 export async function buildBackgroundRunWorkflowContext(params: {
   readonly objective: string;
   readonly workspaceRoot?: string;
@@ -78,12 +57,15 @@ export async function buildBackgroundRunWorkflowContext(params: {
         workspaceRoot,
       })
     : [];
-  const strictWorkflowRequest =
-    shouldPromoteImplementationBackgroundRun(params.objective) ||
-    requestMilestones.length > 0;
-  const completionContract = strictWorkflowRequest
-    ? STRICT_IMPLEMENTATION_COMPLETION_CONTRACT
-    : undefined;
+  // Strict implementation contract only applies when the objective
+  // actually references milestones parsed out of PLAN.md. Earlier logic
+  // also promoted on regex hits against the raw objective text, but that
+  // classifier was too aggressive and is gone — explicit bg-run entry
+  // with a milestone-bearing PLAN is the only trigger.
+  const completionContract =
+    requestMilestones.length > 0
+      ? STRICT_IMPLEMENTATION_COMPLETION_CONTRACT
+      : undefined;
   const verificationContract = buildVerificationContract({
     workspaceRoot,
     requestMilestones,

--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -1430,7 +1430,7 @@ describe("webchat background-run routing", () => {
     executeWebChatConversationTurnSpy.mockRestore();
   });
 
-  it("promotes explicit full-plan implementation requests into background supervision", async () => {
+  it("never auto-promotes a webchat message into a background run from objective text alone", async () => {
     const dm = new DaemonManager({ configPath: "/tmp/config.json" });
     const startRun = vi.fn(async () => undefined);
     const getStatusSnapshot = vi.fn(() => undefined);
@@ -1457,7 +1457,7 @@ describe("webchat background-run routing", () => {
           runtimeWorkspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
           effectiveHistory: [],
         });
-        expect(started).toBe(true);
+        expect(started).toBe(false);
         return undefined;
       });
 
@@ -1499,20 +1499,7 @@ describe("webchat background-run routing", () => {
       },
     );
 
-    expect(startRun).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionId: "session-background-implementation",
-        objective: "Read @PLAN.md and implement all phases in full without stopping.",
-        options: expect.objectContaining({
-          seedHistory: expect.arrayContaining([
-            expect.objectContaining({
-              role: "user",
-              content: "Read @PLAN.md and implement all phases in full without stopping.",
-            }),
-          ]),
-        }),
-      }),
-    );
+    expect(startRun).not.toHaveBeenCalled();
     expect(executeWebChatConversationTurnSpy).toHaveBeenCalledOnce();
     executeWebChatConversationTurnSpy.mockRestore();
   });

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -307,10 +307,7 @@ import {
   isBackgroundRunStatusRequest,
   isBackgroundRunStopRequest,
 } from "./background-run-supervisor.js";
-import {
-  buildBackgroundRunWorkflowContext,
-  shouldPromoteImplementationBackgroundRun,
-} from "./background-run-workflow-context.js";
+import { buildBackgroundRunWorkflowContext } from "./background-run-workflow-context.js";
 import type { RuntimeFaultInjector } from "../eval/fault-injection.js";
 
 function firstSurfaceSummaryLine(value: unknown): string | undefined {
@@ -448,19 +445,6 @@ export {
   DEFAULT_GROK_MODEL,
   DEFAULT_GROK_FALLBACK_MODEL,
 } from "./llm-provider-manager.js";
-
-function effectiveHistoryForBackgroundRun(params: {
-  readonly history: readonly import("../llm/types.js").LLMMessage[];
-  readonly objective: string;
-}): readonly import("../llm/types.js").LLMMessage[] {
-  return [
-    ...params.history,
-    {
-      role: "user",
-      content: params.objective,
-    },
-  ];
-}
 
 // ============================================================================
 // Constants
@@ -7448,47 +7432,17 @@ export class DaemonManager {
       traceConfig,
       turnTraceId,
       workerManager: this._persistentWorkerManager,
-      maybeStartBackgroundRun: async ({
-        session,
-        objective,
-        effectiveHistory,
-      }) => {
-        if (
-          !this._backgroundRunSupervisor ||
-          !shouldPromoteImplementationBackgroundRun(objective)
-        ) {
-          return false;
-        }
-        const admission = this.evaluateBackgroundRunAdmission({
-          sessionId: msg.sessionId,
-          domain: "workspace",
-        });
-        if (!admission.allowed) {
-          await webChat.send({
-            sessionId: msg.sessionId,
-            content: formatBackgroundRunAdmissionDenied(admission.reason),
-          });
-          return true;
-        }
-        const shellProfile = this.resolveEffectiveShellProfile({
-          sessionId: msg.sessionId,
-          metadata: session.metadata ?? {},
-        });
-        await this._backgroundRunSupervisor.startRun({
-          sessionId: msg.sessionId,
-          objective,
-          options: {
-            seedHistory: [
-              ...effectiveHistoryForBackgroundRun({
-                history: effectiveHistory,
-                objective,
-              }),
-            ],
-            shellProfile,
-          },
-        });
-        return true;
-      },
+      // Background runs are never auto-started from user text. A prior
+      // regex classifier (`shouldPromoteImplementationBackgroundRun`)
+      // promoted any prompt containing `@PLAN.md` + a milestone token
+      // (e.g. `M0`) into a persistent bg-run, which then looped forever
+      // because the completion gate requires tool-based artifact
+      // evidence that a conversational prompt can never produce. Claude
+      // Code's reference design has no such promotion path: every user
+      // turn stays foreground and ends when the model stops emitting
+      // tool calls. Explicit bg-run entry points (slash command, etc.)
+      // remain available through other code paths.
+      maybeStartBackgroundRun: async () => false,
     });
   }
 

--- a/runtime/src/tools/system/filesystem.test.ts
+++ b/runtime/src/tools/system/filesystem.test.ts
@@ -2473,3 +2473,102 @@ describe("system.readFile FILE_UNCHANGED_STUB", () => {
     expect(JSON.parse(result.content as string).content).toBe(content);
   });
 });
+
+
+// ============================================================================
+// snapshotTopRecentReads — compact-and-re-attach support
+// ============================================================================
+
+import { snapshotTopRecentReads, seedSessionReadState as seedRead } from "./filesystem.js";
+
+describe("snapshotTopRecentReads", () => {
+  const sessionId = "session-snapshot-top";
+
+  beforeEach(() => {
+    clearSessionReadState(sessionId);
+  });
+
+  it("returns top-N by most recent timestamp, newest first", () => {
+    seedRead(sessionId, [
+      { path: "/ws/a.ts", content: "A", timestamp: 100, viewKind: "full" },
+      { path: "/ws/b.ts", content: "B", timestamp: 300, viewKind: "full" },
+      { path: "/ws/c.ts", content: "C", timestamp: 200, viewKind: "full" },
+    ]);
+    const out = snapshotTopRecentReads({
+      sessionId,
+      maxFiles: 2,
+      perFileBudgetChars: 100,
+      totalBudgetChars: 1000,
+    });
+    expect(out.map((s) => s.path)).toEqual(["/ws/b.ts", "/ws/c.ts"]);
+    expect(out[0]?.content).toBe("B");
+  });
+
+  it("truncates any single file to the per-file budget", () => {
+    const big = "x".repeat(5000);
+    seedRead(sessionId, [
+      { path: "/ws/big.ts", content: big, timestamp: 10, viewKind: "full" },
+    ]);
+    const out = snapshotTopRecentReads({
+      sessionId,
+      maxFiles: 3,
+      perFileBudgetChars: 100,
+      totalBudgetChars: 10_000,
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]?.content.length).toBe(100);
+  });
+
+  it("stops adding files once the total budget is exhausted", () => {
+    seedRead(sessionId, [
+      { path: "/ws/a.ts", content: "x".repeat(60), timestamp: 5, viewKind: "full" },
+      { path: "/ws/b.ts", content: "y".repeat(60), timestamp: 4, viewKind: "full" },
+      { path: "/ws/c.ts", content: "z".repeat(60), timestamp: 3, viewKind: "full" },
+    ]);
+    const out = snapshotTopRecentReads({
+      sessionId,
+      maxFiles: 10,
+      perFileBudgetChars: 200,
+      totalBudgetChars: 130,
+    });
+    expect(out.map((s) => s.path)).toEqual(["/ws/a.ts", "/ws/b.ts"]);
+  });
+
+  it("skips entries with missing content or timestamp", () => {
+    seedRead(sessionId, [
+      { path: "/ws/no-ts.ts", content: "keep-me", viewKind: "full" }, // no timestamp → skip
+      { path: "/ws/no-content.ts", timestamp: 50, viewKind: "full" }, // no content → skip
+      { path: "/ws/real.ts", content: "real", timestamp: 25, viewKind: "full" },
+    ]);
+    const out = snapshotTopRecentReads({
+      sessionId,
+      maxFiles: 5,
+      perFileBudgetChars: 100,
+      totalBudgetChars: 1000,
+    });
+    expect(out.map((s) => s.path)).toEqual(["/ws/real.ts"]);
+  });
+
+  it("returns empty array for an unknown or empty session", () => {
+    const out = snapshotTopRecentReads({
+      sessionId: "does-not-exist",
+      maxFiles: 5,
+      perFileBudgetChars: 100,
+      totalBudgetChars: 1000,
+    });
+    expect(out).toEqual([]);
+  });
+
+  it("preserves viewKind in the exported snapshot", () => {
+    seedRead(sessionId, [
+      { path: "/ws/x.ts", content: "x", timestamp: 1, viewKind: "line_window" },
+    ]);
+    const out = snapshotTopRecentReads({
+      sessionId,
+      maxFiles: 1,
+      perFileBudgetChars: 100,
+      totalBudgetChars: 100,
+    });
+    expect(out[0]?.viewKind).toBe("line_window");
+  });
+});

--- a/runtime/src/tools/system/filesystem.ts
+++ b/runtime/src/tools/system/filesystem.ts
@@ -397,6 +397,70 @@ export function clearSessionReadCache(sessionId: string): void {
   sessionReadState.delete(sessionId);
 }
 
+export interface SessionReadSnapshotExport {
+  readonly path: string;
+  readonly content: string;
+  readonly timestamp: number;
+  readonly viewKind?: SessionReadViewKind;
+}
+
+/**
+ * Return the top-N most-recently-read file snapshots for a session,
+ * truncated to fit a total character budget with a per-file cap.
+ * Entries without content (unknown timestamp or null content) are
+ * skipped. The caller typically uses this right before
+ * `clearSessionReadCache` during compaction, then re-injects the
+ * returned content back into the prompt as anchor messages — matching
+ * the reference runtime's compact-and-re-attach pattern.
+ */
+export function snapshotTopRecentReads(params: {
+  readonly sessionId: string;
+  readonly maxFiles: number;
+  readonly perFileBudgetChars: number;
+  readonly totalBudgetChars: number;
+}): readonly SessionReadSnapshotExport[] {
+  const { sessionId, maxFiles, perFileBudgetChars, totalBudgetChars } = params;
+  if (maxFiles <= 0 || perFileBudgetChars <= 0 || totalBudgetChars <= 0) {
+    return [];
+  }
+  const fileMap = sessionReadState.get(sessionId);
+  if (!fileMap || fileMap.size === 0) {
+    return [];
+  }
+  const entries: SessionReadSnapshotExport[] = [];
+  for (const [path, snapshot] of fileMap) {
+    if (
+      typeof snapshot.content !== "string" ||
+      snapshot.content.length === 0 ||
+      typeof snapshot.timestamp !== "number" ||
+      !Number.isFinite(snapshot.timestamp)
+    ) {
+      continue;
+    }
+    entries.push({
+      path,
+      content: snapshot.content,
+      timestamp: snapshot.timestamp,
+      ...(snapshot.viewKind ? { viewKind: snapshot.viewKind } : {}),
+    });
+  }
+  entries.sort((a, b) => b.timestamp - a.timestamp);
+  const kept: SessionReadSnapshotExport[] = [];
+  let usedChars = 0;
+  for (const entry of entries) {
+    if (kept.length >= maxFiles) break;
+    const slice = entry.content.length > perFileBudgetChars
+      ? entry.content.slice(0, perFileBudgetChars)
+      : entry.content;
+    if (usedChars + slice.length > totalBudgetChars) {
+      continue;
+    }
+    kept.push({ ...entry, content: slice });
+    usedChars += slice.length;
+  }
+  return kept;
+}
+
 /**
  * Resolve the session ID from tool args (injected by the gateway via
  * `applySessionId`). Returns `undefined` when no session ID is present


### PR DESCRIPTION
## Summary

Compound fix for the bug where a plain prompt (e.g. \`\"can you read @PLAN.md and come up with a plan to implement M0\"\`) auto-elevated into a persistent background run that looped forever reading the same file. Traced against the reference runtime in \`../claude_code\`.

### Routing — gut the regex classifier

- \`shouldPromoteImplementationBackgroundRun\` (regex on user text for \`@PLAN.md\` + milestone tokens like \`M0\`) is deleted.
- \`daemon.ts\` \`maybeStartBackgroundRun\` callback now unconditionally returns false. No bg-run is ever auto-started from objective text — matching Claude Code's single-turn termination model.
- The strict implementation contract inside \`buildBackgroundRunWorkflowContext\` now only triggers on actual parsed PLAN.md milestones, not regex on raw text.

### Compaction — port the compact-and-reattach pattern

- New exported \`snapshotTopRecentReads\` in \`filesystem.ts\`: returns top-N most-recently-read file snapshots with per-file + total char budgets.
- \`background-run-supervisor.compactInternalHistory\` now snapshots → clears session read cache → re-injects each snapshot as a system-role \`<anchor-file>\` message in the compacted tail (between summary and preserved tail).
- Budget: 5 files max, 20K chars per file, 200K chars total.
- Mirrors reference runtime (\`compact.ts:521, 532-548\`): summary drops raw tool_result blocks, but the bytes of the most relevant files survive verbatim so cycle N+1 doesn't have to re-read.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`vitest run src/tools/system/filesystem.test.ts src/gateway/daemon.test.ts src/gateway/background-run-supervisor.test.ts\` — 330/330
- [x] Full \`npx vitest run\` — 6621 passed, only pre-existing marketplace-cli environmental failures (skip in CI)
- [x] Full \`npm run build --workspace=@tetsuo-ai/runtime\` — clean