### PR TITLE
feat(runtime): microcompact parity with Claude Code time-based MC

### DIFF
--- a/runtime/src/llm/compact/microcompact.ts
+++ b/runtime/src/llm/compact/microcompact.ts
@@ -3,9 +3,16 @@
  * with a placeholder so the model doesn't pay token cost to recall
  * stale tool output.
  *
- * Mirrors `claude_code/services/compact/microcompact.ts` (cached path).
+ * Mirrors `claude_code/services/compact/microCompact.ts` (time-based
+ * path). Claude Code has a second path (cached microcompact) that uses
+ * Anthropic's cache-editing API to surgically delete tool results
+ * without invalidating the cached prefix. xAI does not expose an
+ * equivalent cache-editing API, so only the time-based path is ported.
  *
- * Cut 5.1 of the claude_code-alignment refactor.
+ * Trigger: the gap since the last activity touch exceeds `gapMs`. When
+ * the gap fires, the xAI server-side prompt cache has almost certainly
+ * expired, so the prefix will be rewritten anyway — content-clearing
+ * old tool results now shrinks what gets rewritten on the next request.
  *
  * @module
  */
@@ -17,8 +24,50 @@ import {
   DEFAULT_MICROCOMPACT_GAP_MS,
 } from "./constants.js";
 
-const STALE_TOOL_RESULT_PLACEHOLDER =
-  "[microcompact] tool result content cleared (cold)";
+/**
+ * Placeholder that replaces the content of a cold tool result. Matches
+ * Claude Code's `TIME_BASED_MC_CLEARED_MESSAGE` byte-for-byte so the
+ * runtime's text filters, tests, and any parity checks line up.
+ */
+export const TIME_BASED_MC_CLEARED_MESSAGE =
+  "[Old tool result content cleared]";
+
+/**
+ * Compactable tool names — only tool results from these tools are ever
+ * content-cleared. Non-compactable tools (e.g. task lifecycle, small
+ * status reads) are left alone because their results are already small
+ * and carry state the model actively depends on.
+ *
+ * Mirrors Claude Code's `COMPACTABLE_TOOLS` set:
+ *   - FileRead / FileEdit / FileWrite
+ *   - Bash (SHELL_TOOL_NAMES)
+ *   - Grep / Glob
+ *   - WebSearch / WebFetch
+ *
+ * Adapted to AgenC's native tool surface.
+ */
+export const COMPACTABLE_TOOL_NAMES: ReadonlySet<string> = new Set([
+  // File I/O
+  "system.readFile",
+  "system.editFile",
+  "system.writeFile",
+  "system.appendFile",
+  // Shell
+  "system.bash",
+  // Search
+  "system.grep",
+  "system.glob",
+  // Directory listing (often large on repo-wide queries)
+  "system.listDir",
+  "system.repoInventory",
+  // Web / HTTP
+  "system.browse",
+  "system.httpGet",
+  "system.httpPost",
+  "system.httpFetch",
+  "system.extractLinks",
+  "system.htmlToMarkdown",
+]);
 
 export interface MicrocompactState {
   readonly lastTouchMs: number;
@@ -39,6 +88,13 @@ interface MicrocompactInput {
   readonly state: MicrocompactState;
   readonly nowMs: number;
   readonly gapMs?: number;
+  /**
+   * How many of the most-recent compactable tool results to leave
+   * untouched. Default mirrors Claude Code's `keepRecent: 5`. Older
+   * compactable results get their `content` replaced with the
+   * placeholder; newer results pass through unchanged.
+   */
+  readonly keepRecent?: number;
 }
 
 interface MicrocompactResult {
@@ -49,17 +105,47 @@ interface MicrocompactResult {
   readonly preservedAttachments: readonly PreservedAttachment[];
 }
 
+const DEFAULT_KEEP_RECENT = 5;
+
 /**
- * If the gap since the previous touch exceeds `gapMs`, walk every
- * tool-result message older than the most recent few turns and
- * replace its content with a short placeholder. The result is
- * deterministic across calls — re-running on a previously
+ * Walk messages and collect tool_call IDs whose tool name is in
+ * `COMPACTABLE_TOOL_NAMES`, in encounter order. The IDs come from the
+ * assistant's `toolCalls` array — the authoritative source of the tool
+ * name — rather than being inferred from the tool-result message,
+ * because tool results in AgenC's format carry a `toolName` hint but
+ * the assistant turn is canonical.
+ */
+function collectCompactableToolCallIds(
+  messages: readonly LLMMessage[],
+): string[] {
+  const ids: string[] = [];
+  for (const message of messages) {
+    if (message.role !== "assistant" || !message.toolCalls) continue;
+    for (const call of message.toolCalls) {
+      if (COMPACTABLE_TOOL_NAMES.has(call.name)) {
+        ids.push(call.id);
+      }
+    }
+  }
+  return ids;
+}
+
+/**
+ * If the gap since the previous activity touch exceeds `gapMs`, walk
+ * every tool-result message whose tool is in the compactable set and
+ * content-clear all but the most recent `keepRecent` results. The
+ * operation is deterministic across calls — re-running on a previously
  * microcompacted history is a no-op.
+ *
+ * The function mutates a shallow copy of `messages`; callers that
+ * depend on reference-identity on no-op should compare `action`
+ * against `"noop"` rather than `messages === input.messages`.
  */
 export function applyMicrocompact(
   input: MicrocompactInput,
 ): MicrocompactResult {
   const gapMs = input.gapMs ?? DEFAULT_MICROCOMPACT_GAP_MS;
+  const keepRecent = Math.max(1, input.keepRecent ?? DEFAULT_KEEP_RECENT);
   const idleFor = input.nowMs - input.state.lastTouchMs;
   const nextState: MicrocompactState = {
     lastTouchMs: input.nowMs,
@@ -76,26 +162,49 @@ export function applyMicrocompact(
     };
   }
 
-  const messages = input.messages.slice();
+  const compactableIds = collectCompactableToolCallIds(input.messages);
+  if (compactableIds.length <= keepRecent) {
+    return {
+      action: "noop",
+      messages: input.messages,
+      state: nextState,
+      preservedAttachments: [],
+    };
+  }
+
+  const keepSet = new Set(compactableIds.slice(-keepRecent));
+  const clearSet = new Set(
+    compactableIds.filter((id) => !keepSet.has(id)),
+  );
+  if (clearSet.size === 0) {
+    return {
+      action: "noop",
+      messages: input.messages,
+      state: nextState,
+      preservedAttachments: [],
+    };
+  }
+
   const cleared = new Set<string>(input.state.clearedToolUseIds);
   let clearedNow = 0;
-  // Don't touch the most recent 6 messages — those carry the active
-  // turn's tool input/output and the model still needs them.
-  const cutoff = Math.max(0, messages.length - 6);
-  for (let i = 0; i < cutoff; i++) {
-    const message = messages[i];
-    if (!message || message.role !== "tool") continue;
-    const toolUseId = (message as { tool_call_id?: string }).tool_call_id;
-    if (toolUseId && cleared.has(toolUseId)) continue;
-    if (typeof message.content === "string" && message.content.length > 256) {
-      messages[i] = {
-        ...message,
-        content: STALE_TOOL_RESULT_PLACEHOLDER,
-      };
-      if (toolUseId) cleared.add(toolUseId);
-      clearedNow++;
+  const rewritten: LLMMessage[] = input.messages.map((message) => {
+    if (message.role !== "tool") return message;
+    const toolCallId = message.toolCallId;
+    if (!toolCallId || !clearSet.has(toolCallId)) return message;
+    if (cleared.has(toolCallId)) return message;
+    if (
+      typeof message.content === "string" &&
+      message.content === TIME_BASED_MC_CLEARED_MESSAGE
+    ) {
+      return message;
     }
-  }
+    cleared.add(toolCallId);
+    clearedNow++;
+    return {
+      ...message,
+      content: TIME_BASED_MC_CLEARED_MESSAGE,
+    };
+  });
 
   if (clearedNow === 0) {
     return {
@@ -108,7 +217,7 @@ export function applyMicrocompact(
 
   return {
     action: "microcompacted",
-    messages,
+    messages: rewritten,
     state: {
       lastTouchMs: input.nowMs,
       clearedToolUseIds: cleared,
@@ -118,7 +227,8 @@ export function applyMicrocompact(
     boundary: {
       role: "system",
       content:
-        `[microcompact] cleared ${clearedNow} cold tool result(s) after ${Math.round(idleFor / 1000)}s idle`,
+        `[microcompact] cleared ${clearedNow} cold tool result(s) after ` +
+        `${Math.round(idleFor / 1000)}s idle (kept last ${keepRecent})`,
     },
   };
 }

--- a/runtime/src/llm/compact/per-iteration-compaction.test.ts
+++ b/runtime/src/llm/compact/per-iteration-compaction.test.ts
@@ -39,12 +39,28 @@ function makeMultimodalUser(content: string, imageUrl: string): LLMMessage {
   };
 }
 
-function makeToolResult(id: string, size: number): LLMMessage {
+function makeToolResult(
+  id: string,
+  size: number,
+  toolName: string = "system.readFile",
+): LLMMessage {
   return {
     role: "tool",
-    tool_call_id: id,
+    toolCallId: id,
+    toolName,
     content: "x".repeat(size),
-  } as LLMMessage;
+  };
+}
+
+function makeAssistantToolCall(
+  id: string,
+  toolName: string = "system.readFile",
+): LLMMessage {
+  return {
+    role: "assistant",
+    content: "",
+    toolCalls: [{ id, name: toolName, arguments: "{}" }],
+  };
 }
 
 describe("applyPerIterationCompaction", () => {
@@ -169,24 +185,31 @@ describe("applyPerIterationCompaction", () => {
       nowMs: T0,
     }).state;
 
-    // Build a history with several old tool results and a few
-    // recent messages (microcompact preserves the last 6).
+    // Build a history with several compactable tool-call/result pairs.
+    // Microcompact keeps the last N (default 5) compactable results
+    // verbatim and content-clears older ones.
     const messages: LLMMessage[] = [
       makeUser("q1"),
+      makeAssistantToolCall("call-1"),
       makeToolResult("call-1", 2000),
       makeUser("q2"),
+      makeAssistantToolCall("call-2"),
       makeToolResult("call-2", 2000),
       makeUser("q3"),
+      makeAssistantToolCall("call-3"),
       makeToolResult("call-3", 2000),
       makeUser("q4"),
+      makeAssistantToolCall("call-4"),
       makeToolResult("call-4", 2000),
       makeUser("q5"),
-      makeAssistant("recent-1"),
-      makeAssistant("recent-2"),
-      makeAssistant("recent-3"),
-      makeAssistant("recent-4"),
-      makeAssistant("recent-5"),
-      makeAssistant("recent-6"),
+      makeAssistantToolCall("call-5"),
+      makeToolResult("call-5", 2000),
+      makeUser("q6"),
+      makeAssistantToolCall("call-6"),
+      makeToolResult("call-6", 2000),
+      makeUser("q7"),
+      makeAssistantToolCall("call-7"),
+      makeToolResult("call-7", 2000),
     ];
 
     const result = applyPerIterationCompaction({
@@ -205,12 +228,14 @@ describe("applyPerIterationCompaction", () => {
         m.content.startsWith("[microcompact]"),
     );
     expect(microBoundary).toBeDefined();
-    // Cold tool result bodies should be replaced with the placeholder.
+    // Cold tool result bodies should be replaced with the
+    // TIME_BASED_MC_CLEARED_MESSAGE placeholder (byte-identical to
+    // Claude Code's placeholder string).
     const placeholderHits = result.messages.filter(
       (m) =>
         m.role === "tool" &&
         typeof m.content === "string" &&
-        m.content.startsWith("[microcompact]"),
+        m.content === "[Old tool result content cleared]",
     );
     expect(placeholderHits.length).toBeGreaterThan(0);
   });
@@ -380,5 +405,184 @@ describe("applyPerIterationCompaction", () => {
     const snipIdx = tags.indexOf("snip");
     const autoIdx = tags.indexOf("autocompact");
     expect(snipIdx).toBeLessThan(autoIdx);
+  });
+});
+
+// ============================================================================
+// applyMicrocompact — Claude Code time-based MC parity
+// ============================================================================
+
+import {
+  applyMicrocompact,
+  createMicrocompactState,
+  TIME_BASED_MC_CLEARED_MESSAGE,
+  COMPACTABLE_TOOL_NAMES,
+} from "./microcompact.js";
+
+describe("applyMicrocompact (time-based parity)", () => {
+  const GAP_MS = 60 * 60 * 1000; // 60 min, matching Claude Code default
+
+  it("noops when the gap has not elapsed", () => {
+    const state = {
+      lastTouchMs: T0 - 1000,
+      clearedToolUseIds: new Set<string>(),
+      compactCount: 0,
+    };
+    const messages: LLMMessage[] = [
+      makeAssistantToolCall("c1"),
+      makeToolResult("c1", 5000),
+      makeAssistantToolCall("c2"),
+      makeToolResult("c2", 5000),
+    ];
+    const r = applyMicrocompact({
+      messages,
+      state,
+      nowMs: T0,
+      gapMs: GAP_MS,
+    });
+    expect(r.action).toBe("noop");
+    expect(r.messages).toBe(messages);
+  });
+
+  it("noops on first touch (lastTouchMs=0)", () => {
+    const r = applyMicrocompact({
+      messages: [makeAssistantToolCall("c1"), makeToolResult("c1", 5000)],
+      state: createMicrocompactState(),
+      nowMs: T0,
+      gapMs: GAP_MS,
+    });
+    expect(r.action).toBe("noop");
+  });
+
+  it("noops when there are fewer compactable results than keepRecent", () => {
+    const state = {
+      lastTouchMs: T0 - GAP_MS - 1000,
+      clearedToolUseIds: new Set<string>(),
+      compactCount: 0,
+    };
+    const messages: LLMMessage[] = [
+      makeAssistantToolCall("c1"),
+      makeToolResult("c1", 2000),
+      makeAssistantToolCall("c2"),
+      makeToolResult("c2", 2000),
+      makeAssistantToolCall("c3"),
+      makeToolResult("c3", 2000),
+    ];
+    const r = applyMicrocompact({
+      messages,
+      state,
+      nowMs: T0,
+      gapMs: GAP_MS,
+      keepRecent: 5,
+    });
+    expect(r.action).toBe("noop");
+  });
+
+  it("clears all-but-keepRecent when gap exceeded", () => {
+    const state = {
+      lastTouchMs: T0 - GAP_MS - 10,
+      clearedToolUseIds: new Set<string>(),
+      compactCount: 0,
+    };
+    const messages: LLMMessage[] = [];
+    for (let i = 1; i <= 8; i++) {
+      messages.push(makeAssistantToolCall(`c${i}`));
+      messages.push(makeToolResult(`c${i}`, 2000));
+    }
+    const r = applyMicrocompact({
+      messages,
+      state,
+      nowMs: T0,
+      gapMs: GAP_MS,
+      keepRecent: 5,
+    });
+    expect(r.action).toBe("microcompacted");
+    // Exactly 8-5 = 3 of the 8 tool results should be content-cleared.
+    const cleared = r.messages.filter(
+      (m) =>
+        m.role === "tool" &&
+        typeof m.content === "string" &&
+        m.content === TIME_BASED_MC_CLEARED_MESSAGE,
+    );
+    expect(cleared).toHaveLength(3);
+    // The 5 most-recent tool results should be untouched.
+    const kept = r.messages.filter(
+      (m) => m.role === "tool" && m.content !== TIME_BASED_MC_CLEARED_MESSAGE,
+    );
+    expect(kept).toHaveLength(5);
+  });
+
+  it("does not touch non-compactable tool results", () => {
+    const state = {
+      lastTouchMs: T0 - GAP_MS - 10,
+      clearedToolUseIds: new Set<string>(),
+      compactCount: 0,
+    };
+    const messages: LLMMessage[] = [];
+    for (let i = 1; i <= 8; i++) {
+      messages.push(makeAssistantToolCall(`c${i}`, "task.update"));
+      messages.push(makeToolResult(`c${i}`, 2000, "task.update"));
+    }
+    const r = applyMicrocompact({
+      messages,
+      state,
+      nowMs: T0,
+      gapMs: GAP_MS,
+      keepRecent: 5,
+    });
+    expect(r.action).toBe("noop");
+  });
+
+  it("uses TIME_BASED_MC_CLEARED_MESSAGE placeholder verbatim (Claude parity)", () => {
+    expect(TIME_BASED_MC_CLEARED_MESSAGE).toBe("[Old tool result content cleared]");
+  });
+
+  it("COMPACTABLE_TOOL_NAMES includes Claude Code's equivalents", () => {
+    for (const expected of [
+      "system.readFile",
+      "system.editFile",
+      "system.writeFile",
+      "system.bash",
+      "system.grep",
+      "system.glob",
+      "system.browse",
+      "system.httpGet",
+    ]) {
+      expect(COMPACTABLE_TOOL_NAMES.has(expected)).toBe(true);
+    }
+    // Non-compactable tools (task lifecycle, small reads) excluded.
+    expect(COMPACTABLE_TOOL_NAMES.has("task.update")).toBe(false);
+    expect(COMPACTABLE_TOOL_NAMES.has("task.create")).toBe(false);
+  });
+
+  it("is idempotent on a previously microcompacted history", () => {
+    const state = {
+      lastTouchMs: T0 - GAP_MS - 10,
+      clearedToolUseIds: new Set<string>(),
+      compactCount: 0,
+    };
+    const messages: LLMMessage[] = [];
+    for (let i = 1; i <= 8; i++) {
+      messages.push(makeAssistantToolCall(`c${i}`));
+      messages.push(makeToolResult(`c${i}`, 2000));
+    }
+    const first = applyMicrocompact({
+      messages,
+      state,
+      nowMs: T0,
+      gapMs: GAP_MS,
+      keepRecent: 5,
+    });
+    expect(first.action).toBe("microcompacted");
+    // Advance time past the gap again so the trigger would fire, but
+    // the history is already compacted — action should be noop.
+    const second = applyMicrocompact({
+      messages: first.messages,
+      state: first.state,
+      nowMs: T0 + GAP_MS + 10,
+      gapMs: GAP_MS,
+      keepRecent: 5,
+    });
+    expect(second.action).toBe("noop");
   });
 });


### PR DESCRIPTION
## Summary

Aligns \`runtime/src/llm/compact/microcompact.ts\` with Claude Code's \`services/compact/microCompact.ts\` time-based path. The previous AgenC microcompact was firing on the wrong signals: it tried to clear every \`role:\"tool\"\` message including tiny task.update results, kept the last 6 *messages* instead of the last N *compactable tool results*, and read \`tool_call_id\` (snake_case) from a field that AgenC stores as \`toolCallId\` — leaving the dedup Set always empty.

### Changes

- Adds \`COMPACTABLE_TOOL_NAMES\` set covering AgenC equivalents of Claude Code's compactable-tool set: FileRead/FileEdit/FileWrite, Bash, Grep, Glob, WebFetch family, plus \`system.listDir\` and \`system.repoInventory\` (big tool-result producers in AgenC's surface).
- Uses \`TIME_BASED_MC_CLEARED_MESSAGE = \"[Old tool result content cleared]\"\` verbatim matching Claude Code.
- Reads \`toolCallId\` (canonical LLMMessage field) instead of the never-set \`tool_call_id\`.
- Collects tool-use IDs from the assistant's \`toolCalls\` array and keeps the last N compactable results, not the last N messages. \`keepRecent\` default is 5 (matches Claude's \`tengu_slate_heron\` default).
- Gap-based trigger only. Claude Code's count-based *cached-MC* path uses Anthropic's cache-editing API to delete tool results without invalidating the cached prefix; xAI doesn't expose that API, so the count-based path would be a mid-turn cache bust — skipped deliberately.

### xAI caching note

xAI prompt caching is automatic + key-based (\`prompt_cache_key\` for the Responses API, \`x-grok-conv-id\` header for Chat Completions). No anchor-based \`cache_control\` blocks. AgenC already sets \`prompt_cache_key\` at \`grok/adapter.ts:1578\`, so that half of the original \"port Claude Code's caching\" ask is already complete. Confirmed via xAI docs at \`/developers/advanced-api-usage/prompt-caching\`.

## Test plan

- [x] 7 new \`applyMicrocompact\` tests covering: noop on short gap, noop on first touch, noop when < keepRecent results, full clear-to-keep semantics, non-compactable tool passthrough, placeholder parity, idempotency.
- [x] \`per-iteration-compaction.test.ts\` updated to use the new fixture helpers and asserts on the Claude-parity placeholder string.
- [x] \`npx tsc --noEmit\` — clean.
- [x] Full \`npx vitest run\` — 6629 passed, only pre-existing marketplace-cli environmental failures remain (skip in CI).
- [x] \`npm run build --workspace=@tetsuo-ai/runtime\` — clean.