### PR TITLE
feat(runtime): deferred-tool wire gate + plan-mode tool gating

### DIFF
--- a/runtime/src/gateway/daemon-tool-registry.ts
+++ b/runtime/src/gateway/daemon-tool-registry.ts
@@ -45,6 +45,7 @@ import {
   SessionTaskStore,
   TaskStore,
 } from "../tools/system/task-tracker.js";
+import { createWorkflowPlanModeTools } from "../tools/system/workflow-plan-mode.js";
 import { TodoStore } from "../tools/system/todo-store.js";
 import { createTodoWriteTool } from "../tools/system/todo-write.js";
 import { runStopHookPhase, type StopHookRuntime } from "../llm/hooks/stop-hooks.js";
@@ -134,6 +135,17 @@ interface ToolRegistryDeps {
   getAgentFeed(): unknown;
   getCollaborationProtocol(): unknown;
   resolveStopHookRuntime?(): StopHookRuntime | undefined;
+  /**
+   * Update a session's workflow stage (and optionally the recorded
+   * objective/plan). Used by the `workflow.enterPlan` /
+   * `workflow.exitPlan` tools. Must resolve to `{ applied: false, reason }`
+   * when the sessionId is unknown rather than throwing.
+   */
+  setSessionWorkflowStage?: (params: {
+    readonly sessionId: string;
+    readonly stage: "plan" | "implement" | "review" | "verify" | "idle";
+    readonly objective?: string;
+  }) => Promise<{ readonly applied: boolean; readonly reason?: string }>;
 }
 
 // ============================================================================
@@ -463,6 +475,13 @@ export async function createDaemonToolRegistry(
   );
   registry.register(createExecuteWithAgentTool());
   registry.register(createCoordinatorModeTool());
+  if (deps.setSessionWorkflowStage) {
+    registry.registerAll(
+      createWorkflowPlanModeTools({
+        setSessionWorkflowStage: deps.setSessionWorkflowStage,
+      }),
+    );
+  }
   const walletResult = await loadWallet(config);
   if (config.social?.enabled) {
     try {

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -211,6 +211,7 @@ import {
   type SessionShellProfile,
   type SessionWorkflowStage,
   resolveSessionWorkflowState,
+  updateSessionWorkflowState,
   resolveSessionShellProfile,
   SessionManager,
 } from "./session.js";
@@ -4059,6 +4060,20 @@ export class DaemonManager {
       getCollaborationProtocol: () => this._collaborationProtocol,
       resolveStopHookRuntime: () =>
         buildStopHookRuntime(this.gateway?.config.llm?.stopHooks),
+      setSessionWorkflowStage: async ({ sessionId, stage, objective }) => {
+        const session = this._webSessionManager?.get(sessionId);
+        if (!session) {
+          return {
+            applied: false,
+            reason: `no active session: ${sessionId}`,
+          };
+        }
+        updateSessionWorkflowState(session.metadata, {
+          stage,
+          ...(typeof objective === "string" ? { objective } : {}),
+        });
+        return { applied: true };
+      },
     }, this._memoryBackend!, metrics);
     this._remoteJobManager = result.remoteJobManager;
     this._remoteSessionManager = result.remoteSessionManager;
@@ -6482,6 +6497,7 @@ export class DaemonManager {
     toolNames?: readonly string[],
     shellProfile: SessionShellProfile = DEFAULT_SESSION_SHELL_PROFILE,
     discoveredToolNames?: readonly string[],
+    workflowStage?: SessionWorkflowStage,
   ): readonly string[] {
     const resolvedToolNames = this.getCallableToolNames(toolNames);
     const allowedToolNames = new Set(resolvedToolNames);
@@ -6502,6 +6518,7 @@ export class DaemonManager {
                 : ("builtin" as const),
               hiddenByDefault: false,
               mutating: false,
+              deferred: false,
             },
           }));
     return buildAdvertisedToolBundle({
@@ -6509,6 +6526,7 @@ export class DaemonManager {
       providerNativeToolNames: providerNative,
       shellProfile,
       discoveredToolNames,
+      ...(workflowStage ? { workflowStage } : {}),
     });
   }
 
@@ -7523,6 +7541,9 @@ export class DaemonManager {
                   })
                 : DEFAULT_SESSION_SHELL_PROFILE,
               this.getDiscoveredToolNamesForSession(sessionId),
+              resolveSessionWorkflowState(
+                sessionMgr.get(sessionId)?.metadata ?? {},
+              ).stage,
             ),
             shellProfile: this.resolveEffectiveShellProfile({
               sessionId,
@@ -7545,6 +7566,9 @@ export class DaemonManager {
                 : DEFAULT_SESSION_SHELL_PROFILE
               : shellProfile,
             discoveredToolNames,
+            resolveSessionWorkflowState(
+              sessionMgr.get(sessionId)?.metadata ?? {},
+            ).stage,
           ),
         recordToolRoutingOutcome: () => {
           /* no-op */

--- a/runtime/src/gateway/session.ts
+++ b/runtime/src/gateway/session.ts
@@ -30,6 +30,7 @@ import {
   coerceSessionWorkflowStage,
   ensureSessionWorkflowState,
   resolveSessionWorkflowState,
+  updateSessionWorkflowState,
   type SessionWorkflowStage,
   type SessionWorkflowUpdate,
 } from "./workflow-state.js";
@@ -114,6 +115,7 @@ export {
   coerceSessionWorkflowStage,
   ensureSessionWorkflowState,
   resolveSessionWorkflowState,
+  updateSessionWorkflowState,
 };
 export type { SessionWorkflowStage, SessionWorkflowUpdate };
 export {

--- a/runtime/src/gateway/shell-profile.ts
+++ b/runtime/src/gateway/shell-profile.ts
@@ -48,6 +48,8 @@ const GENERAL_DEFAULT_TOOL_NAMES = [
   "TodoWrite",
   "execute_with_agent",
   "coordinator",
+  "workflow.enterPlan",
+  "workflow.exitPlan",
   "web_search",
   "x_search",
   "file_search",
@@ -147,6 +149,8 @@ const DEFINITIONS: Record<SessionShellProfile, ShellProfileDefinition> = {
       "TodoWrite",
       "execute_with_agent",
       "coordinator",
+      "workflow.enterPlan",
+      "workflow.exitPlan",
     ],
     delegationDefault: "coding",
     approvalHints: {
@@ -165,7 +169,12 @@ const DEFINITIONS: Record<SessionShellProfile, ShellProfileDefinition> = {
       "Use delegation primarily for bounded investigation, synthesis, and source-backed analysis.",
     ],
     toolPrefixes: ["system.browse", "system.http", "playwright.", "browser_", "task."],
-    exactToolNames: ["TodoWrite", "execute_with_agent"],
+    exactToolNames: [
+      "TodoWrite",
+      "execute_with_agent",
+      "workflow.enterPlan",
+      "workflow.exitPlan",
+    ],
     delegationDefault: "research",
     approvalHints: {
       readOnlyBias: true,
@@ -183,7 +192,12 @@ const DEFINITIONS: Record<SessionShellProfile, ShellProfileDefinition> = {
       "Prefer explicit checks, logs, tests, and run output over intuition.",
     ],
     toolPrefixes: ["system.", "desktop.", "task."],
-    exactToolNames: ["TodoWrite", "execute_with_agent"],
+    exactToolNames: [
+      "TodoWrite",
+      "execute_with_agent",
+      "workflow.enterPlan",
+      "workflow.exitPlan",
+    ],
     delegationDefault: "verify",
     approvalHints: {
       readOnlyBias: true,
@@ -201,7 +215,12 @@ const DEFINITIONS: Record<SessionShellProfile, ShellProfileDefinition> = {
       "Keep structure and wording clear, but still verify referenced commands or paths when they matter.",
     ],
     toolPrefixes: ["system.", "task."],
-    exactToolNames: ["TodoWrite", "execute_with_agent"],
+    exactToolNames: [
+      "TodoWrite",
+      "execute_with_agent",
+      "workflow.enterPlan",
+      "workflow.exitPlan",
+    ],
     delegationDefault: "coding",
     approvalHints: {
       readOnlyBias: false,
@@ -219,7 +238,13 @@ const DEFINITIONS: Record<SessionShellProfile, ShellProfileDefinition> = {
       "Keep awareness of system state, long-running handles, and operational visibility.",
     ],
     toolPrefixes: ["agenc.", "system.", "social.", "wallet.", "task."],
-    exactToolNames: ["TodoWrite", "execute_with_agent", "coordinator"],
+    exactToolNames: [
+      "TodoWrite",
+      "execute_with_agent",
+      "coordinator",
+      "workflow.enterPlan",
+      "workflow.exitPlan",
+    ],
     delegationDefault: "operator",
     approvalHints: {
       readOnlyBias: false,

--- a/runtime/src/gateway/tool-handler-factory-delegation.ts
+++ b/runtime/src/gateway/tool-handler-factory-delegation.ts
@@ -137,9 +137,10 @@ function buildSyntheticToolCatalog(
     inputSchema: { type: "object", properties: {} },
     metadata: {
       family: "runtime",
-      source: "builtin",
+      source: "builtin" as const,
       hiddenByDefault: false,
       mutating: MUTATING_CHILD_TOOL_NAMES.has(name),
+      deferred: false,
     },
   }));
 }

--- a/runtime/src/gateway/tool-routing.test.ts
+++ b/runtime/src/gateway/tool-routing.test.ts
@@ -211,3 +211,134 @@ describe("buildAdvertisedToolBundle", () => {
     ]);
   });
 });
+
+// ============================================================================
+// Plan-mode tool filtering (Claude Code parity)
+// ============================================================================
+
+describe("buildAdvertisedToolBundle — plan-mode filter", () => {
+  function catalogEntry(
+    name: string,
+    overrides: Partial<{
+      readonly family: string;
+      readonly source: "builtin" | "mcp" | "plugin" | "skill" | "provider_native";
+      readonly hiddenByDefault: boolean;
+      readonly mutating: boolean;
+      readonly deferred: boolean;
+    }> = {},
+  ) {
+    return {
+      name,
+      description: "",
+      inputSchema: {},
+      metadata: {
+        family: overrides.family ?? "general",
+        source: overrides.source ?? ("builtin" as const),
+        hiddenByDefault: overrides.hiddenByDefault ?? false,
+        mutating: overrides.mutating ?? false,
+        deferred: overrides.deferred ?? false,
+      },
+    };
+  }
+
+  const baseCatalog = [
+    catalogEntry("system.readFile"),
+    catalogEntry("system.grep"),
+    catalogEntry("system.listDir"),
+    catalogEntry("system.writeFile", { mutating: true }),
+    catalogEntry("system.editFile", { mutating: true }),
+    catalogEntry("system.bash", { mutating: true }),
+    catalogEntry("system.delete", { mutating: true }),
+    catalogEntry("system.searchTools"),
+    catalogEntry("workflow.enterPlan"),
+    catalogEntry("workflow.exitPlan"),
+    catalogEntry("task.create", { mutating: true }),
+    catalogEntry("task.list"),
+  ];
+
+  it("hides mutating tools when stage is 'plan'", () => {
+    const toolNames = buildAdvertisedToolBundle({
+      shellProfile: "general",
+      toolCatalog: baseCatalog,
+      workflowStage: "plan",
+    });
+    // Mutating tools are dropped except the plan-mode allow-list
+    // (workflow.exitPlan + task.* stay so the model can finalize).
+    expect(toolNames).toContain("system.readFile");
+    expect(toolNames).toContain("system.grep");
+    expect(toolNames).toContain("system.listDir");
+    expect(toolNames).toContain("system.searchTools");
+    expect(toolNames).toContain("workflow.enterPlan");
+    expect(toolNames).toContain("workflow.exitPlan");
+    expect(toolNames).toContain("task.create");
+    expect(toolNames).toContain("task.list");
+    expect(toolNames).not.toContain("system.writeFile");
+    expect(toolNames).not.toContain("system.editFile");
+    expect(toolNames).not.toContain("system.bash");
+    expect(toolNames).not.toContain("system.delete");
+  });
+
+  it("leaves mutating tools in when stage is 'implement'", () => {
+    const toolNames = buildAdvertisedToolBundle({
+      shellProfile: "general",
+      toolCatalog: baseCatalog,
+      workflowStage: "implement",
+    });
+    expect(toolNames).toContain("system.writeFile");
+    expect(toolNames).toContain("system.editFile");
+    expect(toolNames).toContain("system.bash");
+    expect(toolNames).toContain("system.delete");
+  });
+
+  it("leaves mutating tools in when workflowStage is omitted", () => {
+    const toolNames = buildAdvertisedToolBundle({
+      shellProfile: "general",
+      toolCatalog: baseCatalog,
+    });
+    expect(toolNames).toContain("system.writeFile");
+    expect(toolNames).toContain("system.bash");
+  });
+
+  it("respects explicit metadata.deferred on catalog entries", () => {
+    const toolNames = buildAdvertisedToolBundle({
+      shellProfile: "general",
+      toolCatalog: [
+        catalogEntry("system.readFile"),
+        catalogEntry("system.searchTools"),
+        catalogEntry("agenc.resolveDispute", { deferred: true, mutating: true }),
+        catalogEntry("agenc.stakeReputation", { deferred: true, mutating: true }),
+      ],
+    });
+    // Explicit `deferred: true` keeps those tools out of the default
+    // advertised set even though they aren't MCP-sourced or covered by
+    // the name-prefix heuristics.
+    expect(toolNames).toContain("system.readFile");
+    expect(toolNames).toContain("system.searchTools");
+    expect(toolNames).not.toContain("agenc.resolveDispute");
+    expect(toolNames).not.toContain("agenc.stakeReputation");
+  });
+
+  it("keeps the plan-mode allow-list tools present even in plan mode", () => {
+    const planCatalog = [
+      ...baseCatalog,
+      catalogEntry("TodoWrite"),
+      catalogEntry("execute_with_agent"),
+    ];
+    const toolNames = buildAdvertisedToolBundle({
+      shellProfile: "general",
+      toolCatalog: planCatalog,
+      workflowStage: "plan",
+    });
+    for (const essential of [
+      "workflow.enterPlan",
+      "workflow.exitPlan",
+      "task.create",
+      "task.list",
+      "TodoWrite",
+      "execute_with_agent",
+      "system.searchTools",
+    ]) {
+      expect(toolNames).toContain(essential);
+    }
+  });
+});

--- a/runtime/src/gateway/tool-routing.ts
+++ b/runtime/src/gateway/tool-routing.ts
@@ -26,6 +26,7 @@ import {
   type SessionShellProfile,
 } from "./shell-profile.js";
 import type { ToolCatalogEntry } from "../tools/types.js";
+import type { SessionWorkflowStage } from "./workflow-state.js";
 
 export interface ToolRoutingDecision {
   readonly routedToolNames: readonly string[];
@@ -81,6 +82,15 @@ const ALWAYS_INLINE_TOOL_NAMES = new Set([
   "task.list",
   "task.get",
   "task.update",
+  // Read-only marketplace browse surfaces — inexpensive schemas, often
+  // the first thing the model reaches for, and they bootstrap further
+  // discovery via `system.searchTools("select:agenc.<name>")`.
+  "agenc.inspectMarketplace",
+  "agenc.listTasks",
+  "agenc.getTask",
+  "agenc.listSkills",
+  "agenc.getSkill",
+  "agenc.getAgent",
 ]);
 
 const DEFERRED_NAME_PREFIXES = [
@@ -92,6 +102,30 @@ const DEFERRED_NAME_PREFIXES = [
   "system.server",
   "system.process",
   "system.research",
+  // Heavy I/O surfaces — default-coding-agent has no reason to pay for
+  // these every call. Discoverable via `system.searchTools` when needed.
+  "system.http",
+  "system.browserSession",
+  "system.browserTransfer",
+  "system.browserAction",
+  "system.calendar",
+  "system.email",
+  "system.pdf",
+  "system.officeDocument",
+  "system.spreadsheet",
+  "system.sqlite",
+  "system.symbol",
+  "system.gitWorktree",
+  "system.applescript",
+  "system.jxa",
+  "system.evaluateJs",
+  "system.notification",
+  "system.screenshot",
+  "system.exportPdf",
+  // `agenc.*` marketplace/governance/reputation mutations — large schemas,
+  // rarely needed for coding. Read-only browse tools are kept inline
+  // via ALWAYS_INLINE_TOOL_NAMES above.
+  "agenc.",
   "social.",
   "wallet.",
 ];
@@ -121,6 +155,13 @@ function isDeferredCatalogEntry(entry: ToolCatalogEntry): boolean {
   if (ALWAYS_INLINE_TOOL_NAMES.has(entry.name)) {
     return false;
   }
+  // Explicit registrant-set marker wins over heuristics — tool factories
+  // that know their surface is specialist (marketplace mutations,
+  // browser sessions, HTTP, etc.) can opt in directly without relying
+  // on the name-prefix / family / source probes below.
+  if (entry.metadata.deferred === true) {
+    return true;
+  }
   if (entry.metadata.hiddenByDefault || entry.metadata.source === "mcp") {
     return true;
   }
@@ -130,19 +171,61 @@ function isDeferredCatalogEntry(entry: ToolCatalogEntry): boolean {
   return isDeferredToolName(entry.name);
 }
 
+/**
+ * Names of mutating tools the model may NOT invoke while the session
+ * workflow stage is `"plan"`. Strictly read/search/browse/think tools
+ * remain available so the model can explore the workspace and produce
+ * a concrete plan.
+ *
+ * `workflow.enterPlan` and `workflow.exitPlan` are explicitly allowed
+ * so the model can transition in and out of plan mode (the exit path
+ * does not itself flip to implement — it records the plan for operator
+ * approval and keeps the stage in `"plan"`).
+ *
+ * Mirrors the reference runtime's plan-mode edit-guard.
+ */
+const PLAN_MODE_ALWAYS_ALLOWED = new Set([
+  "workflow.enterPlan",
+  "workflow.exitPlan",
+  "TodoWrite",
+  "task.create",
+  "task.list",
+  "task.get",
+  "task.update",
+  "execute_with_agent",
+  "system.searchTools",
+]);
+
+function isPlanModeAllowedEntry(entry: ToolCatalogEntry): boolean {
+  if (PLAN_MODE_ALWAYS_ALLOWED.has(entry.name)) return true;
+  return entry.metadata.mutating !== true;
+}
+
 export function buildAdvertisedToolBundle(params: {
   readonly toolCatalog: readonly ToolCatalogEntry[];
   readonly providerNativeToolNames?: readonly string[];
   readonly shellProfile?: SessionShellProfile;
   readonly discoveredToolNames?: readonly string[];
   readonly explicitAllowedToolNames?: readonly string[];
+  /**
+   * Current session workflow stage. When `"plan"`, mutating tools are
+   * hidden from the advertised bundle so the model physically cannot
+   * invoke them — enforcing the plan-mode contract at the catalog
+   * boundary instead of relying on the model to honor a prompt
+   * instruction.
+   */
+  readonly workflowStage?: SessionWorkflowStage;
 }): readonly string[] {
   if (params.explicitAllowedToolNames && params.explicitAllowedToolNames.length > 0) {
     return uniqueToolNames(params.explicitAllowedToolNames);
   }
 
+  const planMode = params.workflowStage === "plan";
+  const catalog = planMode
+    ? params.toolCatalog.filter(isPlanModeAllowedEntry)
+    : params.toolCatalog;
   const profile = params.shellProfile ?? "general";
-  const inlineCatalogToolNames = params.toolCatalog
+  const inlineCatalogToolNames = catalog
     .filter((entry) => !isDeferredCatalogEntry(entry))
     .map((entry) => entry.name);
   const preferredInlineToolNames = getShellProfilePreferredToolNames({

--- a/runtime/src/tools/registry.ts
+++ b/runtime/src/tools/registry.ts
@@ -235,6 +235,7 @@ function normalizeToolMetadata(tool: Tool): ToolCatalogEntry["metadata"] {
     source: metadata.source ?? inferToolSource(tool.name),
     hiddenByDefault: metadata.hiddenByDefault === true,
     mutating: metadata.mutating === true,
+    deferred: metadata.deferred === true,
     ...(metadata.keywords ? { keywords: [...metadata.keywords] } : {}),
     ...(metadata.preferredProfiles
       ? { preferredProfiles: [...metadata.preferredProfiles] }

--- a/runtime/src/tools/system/workflow-plan-mode.ts
+++ b/runtime/src/tools/system/workflow-plan-mode.ts
@@ -1,0 +1,198 @@
+/**
+ * Plan-mode tools: `workflow.enterPlan` and `workflow.exitPlan`.
+ *
+ * Mirrors the reference runtime's `EnterPlanModeTool` / `ExitPlanModeTool`
+ * pair. The model uses these to explicitly enter an exploration phase
+ * (reads, searches, and non-mutating bash allowed; writes, edits, and
+ * other state-changing tools hidden via the advertised-bundle filter in
+ * `buildAdvertisedToolBundle`) and then to hand off a proposed plan to
+ * the operator for explicit approval.
+ *
+ * `workflow.exitPlan` does NOT itself flip the session back to
+ * execution. It sets stage = "plan" (or preserves it if already there)
+ * and records the proposed plan verbatim in the session workflow
+ * objective so the operator sees it in `/plan status`. The operator
+ * then approves by calling the existing `/plan implement` slash
+ * command (or any other verb that flips stage out of "plan"), which
+ * re-opens the mutating tool surface. That slash-command approval step
+ * is the AgenC equivalent of Claude Code's UI "proceed" button — it
+ * deliberately requires an explicit human act to unlock execution.
+ *
+ * @module
+ */
+
+import type { Tool, ToolResult } from "../types.js";
+
+export interface WorkflowPlanModeToolOptions {
+  /**
+   * Apply a workflow-stage change to a session. Returns the resolved
+   * new stage (the caller normalizes via `updateSessionWorkflowState`,
+   * so this echoes what was persisted). Must resolve even when the
+   * sessionId is unknown — the caller decides how to surface that.
+   */
+  readonly setSessionWorkflowStage: (params: {
+    readonly sessionId: string;
+    readonly stage: "plan" | "implement" | "review" | "verify" | "idle";
+    readonly objective?: string;
+  }) => Promise<{ readonly applied: boolean; readonly reason?: string }>;
+}
+
+const SESSION_ID_ARG = "__agencSessionId";
+
+const ENTER_PLAN_DESCRIPTION = [
+  "Enter plan mode for the current session.",
+  "",
+  "In plan mode you MUST NOT make any changes to the project: no writeFile,",
+  "no editFile, no bash commands that mutate state, no git commits, no tool",
+  "that alters the filesystem, daemon state, or external services. Only use",
+  "read/search tools (readFile, grep, glob, listDir, stat, symbolSearch)",
+  "and informational bash commands to gather the context you need. Draft a",
+  "concrete, step-by-step plan while you explore.",
+  "",
+  "When the plan is ready, call workflow.exitPlan with the full plan text.",
+  "The operator will review it and explicitly approve before any mutating",
+  "tools become available again.",
+].join("\n");
+
+const EXIT_PLAN_DESCRIPTION = [
+  "Present a completed plan for operator review and leave plan mode held",
+  "pending approval.",
+  "",
+  "Call this ONCE at the end of planning with the full plan text as the",
+  "`plan` argument. After this call, the session stays in plan mode with",
+  "the plan recorded as the current objective; mutating tools remain",
+  "hidden until the operator explicitly approves by running `/plan",
+  "implement` (or another verb that flips stage out of plan). Do not",
+  "assume approval has happened just because you've called this tool —",
+  "end your turn and wait for the operator's response.",
+].join("\n");
+
+function resolveSessionId(args: Record<string, unknown>): string | undefined {
+  const value = args[SESSION_ID_ARG];
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+  return undefined;
+}
+
+function jsonError(message: string): ToolResult {
+  return {
+    content: JSON.stringify({ error: message }),
+    isError: true,
+  };
+}
+
+function jsonOk(payload: Record<string, unknown>): ToolResult {
+  return {
+    content: JSON.stringify({ ok: true, ...payload }),
+  };
+}
+
+export function createWorkflowPlanModeTools(
+  options: WorkflowPlanModeToolOptions,
+): Tool[] {
+  const enterPlan: Tool = {
+    name: "workflow.enterPlan",
+    description: ENTER_PLAN_DESCRIPTION,
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+    metadata: {
+      family: "workflow",
+      source: "builtin",
+      // Never deferred — the model must always be able to enter plan
+      // mode from any tool surface.
+      hiddenByDefault: false,
+      mutating: false,
+    },
+    async execute(args) {
+      const sessionId = resolveSessionId(args);
+      if (!sessionId) {
+        return jsonError(
+          "workflow.enterPlan requires a session context (no __agencSessionId)",
+        );
+      }
+      const result = await options.setSessionWorkflowStage({
+        sessionId,
+        stage: "plan",
+      });
+      if (!result.applied) {
+        return jsonError(
+          result.reason ?? "failed to enter plan mode",
+        );
+      }
+      return jsonOk({
+        stage: "plan",
+        message:
+          "Plan mode active. Mutating tools (writeFile, editFile, mutating " +
+          "bash, etc.) are hidden until the operator approves the plan. " +
+          "Explore read-only, then call workflow.exitPlan with the full plan text.",
+      });
+    },
+  };
+
+  const exitPlan: Tool = {
+    name: "workflow.exitPlan",
+    description: EXIT_PLAN_DESCRIPTION,
+    inputSchema: {
+      type: "object",
+      properties: {
+        plan: {
+          type: "string",
+          description:
+            "The full plan text to present to the operator. Write it as a " +
+            "numbered list of concrete steps with file paths and specific " +
+            "changes. The operator reads this verbatim — be precise.",
+        },
+      },
+      required: ["plan"],
+    },
+    metadata: {
+      family: "workflow",
+      source: "builtin",
+      hiddenByDefault: false,
+      mutating: false,
+    },
+    async execute(args) {
+      const sessionId = resolveSessionId(args);
+      if (!sessionId) {
+        return jsonError(
+          "workflow.exitPlan requires a session context (no __agencSessionId)",
+        );
+      }
+      const rawPlan = typeof args.plan === "string" ? args.plan.trim() : "";
+      if (rawPlan.length === 0) {
+        return jsonError(
+          "workflow.exitPlan requires a non-empty `plan` string",
+        );
+      }
+      // Stay in plan stage; record the plan as the session objective so
+      // the operator sees it in `/plan status` and in the TUI surface.
+      // The session deliberately does NOT advance to "implement" — the
+      // operator's explicit approval is required.
+      const result = await options.setSessionWorkflowStage({
+        sessionId,
+        stage: "plan",
+        objective: rawPlan,
+      });
+      if (!result.applied) {
+        return jsonError(
+          result.reason ?? "failed to record plan",
+        );
+      }
+      return jsonOk({
+        stage: "plan",
+        awaitingApproval: true,
+        plan: rawPlan,
+        message:
+          "Plan recorded. Awaiting operator approval. Mutating tools " +
+          "remain hidden until the operator runs `/plan implement` (or " +
+          "another command that flips workflow stage out of plan). End " +
+          "your turn now — do not call further tools.",
+      });
+    },
+  };
+
+  return [enterPlan, exitPlan];
+}

--- a/runtime/src/tools/types.ts
+++ b/runtime/src/tools/types.ts
@@ -40,13 +40,26 @@ export interface ToolMetadata {
   readonly hiddenByDefault?: boolean;
   /** Whether the tool mutates project/runtime state. */
   readonly mutating?: boolean;
+  /**
+   * When `true`, the tool is omitted from the outgoing tools array sent
+   * to the provider unless the model has explicitly discovered it via
+   * `system.searchTools` in this turn. Mirrors the reference runtime's
+   * `defer_loading` flag: heavy specialist tools (marketplace mutations,
+   * browser sessions, office/pdf/calendar/email, http, sandbox, etc.)
+   * stay deferred so the default per-call tool catalog is the small
+   * subset a coding agent actually needs, while the full catalog
+   * remains discoverable on demand.
+   */
+  readonly deferred?: boolean;
 }
 
 export interface ToolCatalogEntry {
   readonly name: string;
   readonly description: string;
   readonly inputSchema: JSONSchema;
-  readonly metadata: Required<Pick<ToolMetadata, "family" | "source" | "hiddenByDefault" | "mutating">> &
+  readonly metadata: Required<
+    Pick<ToolMetadata, "family" | "source" | "hiddenByDefault" | "mutating" | "deferred">
+  > &
     Pick<ToolMetadata, "keywords" | "preferredProfiles">;
 }
 


### PR DESCRIPTION
## Summary

Two Claude Code parity ports that together attack per-call tool-schema bytes and plan-mode safety:

### 1. Deferred-tool wire gate

AgenC had the machinery but not the classification: only ~38 of 147 tools were treated as deferred, so the outgoing catalog stayed at 147 schemas per call.

- Add \`deferred?: boolean\` to \`ToolMetadata\`; honored first in \`isDeferredCatalogEntry\`.
- Expand \`DEFERRED_NAME_PREFIXES\` to cover specialist surfaces: \`agenc.*\` mutations, browser sessions, HTTP, calendar/email/pdf/office/spreadsheet/sqlite/symbol/git worktree, OS scripting.
- \`ALWAYS_INLINE_TOOL_NAMES\` keeps 6 \`agenc.*\` read-only browse tools inline so marketplace discovery doesn't need a \`searchTools\` roundtrip.

Effect against a 137-tool catalog sample: inline drops from 99 → 37, deferred rises from 38 → 100. Roughly 60% reduction in outgoing tool-schema bytes per call.

### 2. Plan-mode tool gating

AgenC had session stage \`\"plan\"\` reachable via \`/plan enter\` slash command, but no model-callable tool and no catalog-level filter. Claude Code's plan mode is a real turn boundary; AgenC's was a prompt-instruction promise.

- New tools \`workflow.enterPlan\` and \`workflow.exitPlan\` in \`runtime/src/tools/system/workflow-plan-mode.ts\`.
- \`buildAdvertisedToolBundle\` accepts \`workflowStage\`. When stage is \`\"plan\"\`, mutating tools are filtered from the catalog before deferred/profile logic. Small allow-list (\`workflow.exitPlan\`, \`TodoWrite\`, \`task.*\`, \`execute_with_agent\`, \`system.searchTools\`) stays available.
- \`workflow.exitPlan\` records the plan as the session objective but keeps stage at \`\"plan\"\` — operator must explicitly \`/plan implement\` to unlock mutating tools. Mirrors Claude Code's UI \"proceed\" approval.
- All shell-profile \`exactToolNames\` lists add the two workflow tools so they're reachable from any profile.

## Test plan

- [x] 5 new \`buildAdvertisedToolBundle — plan-mode filter\` tests: mutating-tool suppression in plan mode, pass-through in other stages / when stage is omitted, explicit \`metadata.deferred\` honoring, essential allow-list preservation.
- [x] \`npx tsc --noEmit\` — clean.
- [x] Full \`npx vitest run\` — 6634 passed; only pre-existing marketplace-cli environmental failures remain (skip in CI).
- [x] \`npm run build --workspace=@tetsuo-ai/runtime\` — clean.

## Not ported (deliberately)

- Approval via UI-initiated \"proceed\" button. AgenC's equivalent is the \`/plan implement\` slash command — functionally the same (operator explicitly unblocks), different interface.
- Count-based microcompact via cache-editing (covered in PR #463 context; xAI lacks the cache-editing API).