### PR TITLE
Stabilize compaction prefix, re-attach recent files, stall tripwire

### DIFF
--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -22,11 +22,7 @@ import { getCompactPrompt, formatCompactSummary } from "../llm/compact/prompt.js
 import type { LLMMessage, LLMProvider, ToolHandler } from "../llm/types.js";
 import { partitionByAnchorPreserve } from "../llm/types.js";
 import { collectAttachments } from "../llm/attachment-injection.js";
-import {
-  clearSessionReadCache,
-  snapshotTopRecentReads,
-  type SessionReadSnapshotExport,
-} from "../tools/system/filesystem.js";
+import { reattachRecentFilesOnCompaction } from "../llm/compact/post-compact-attachments.js";
 import {
   containsVerdictMarkerInToolResult,
   isMutatingTool,
@@ -256,34 +252,10 @@ import {
 } from "../eval/fault-injection.js";
 import { hasStopHookHandlers, runStopHookPhase } from "../llm/hooks/stop-hooks.js";
 
-// ---------------------------------------------------------------------------
-// Post-compaction file re-attachment budget
-// ---------------------------------------------------------------------------
-//
-// Mirrors the reference runtime's POST_COMPACT_MAX_FILES_TO_RESTORE +
-// 50K-token / 5K-per-file envelope. Chars are a cheap proxy for tokens
-// at the grok/claude tokenizer ratio (~4 chars/token) — over-budget
-// files get truncated at read-time; the compacted prompt's total bytes
-// remain bounded.
-//
-const POST_COMPACT_MAX_FILES_TO_REATTACH = 5;
-const POST_COMPACT_PER_FILE_BUDGET_CHARS = 20_000;
-const POST_COMPACT_TOTAL_BUDGET_CHARS = 200_000;
-
-function buildAnchorFileMessage(
-  snapshot: SessionReadSnapshotExport,
-): LLMMessage {
-  const header =
-    `<anchor-file path="${snapshot.path}" viewKind="${snapshot.viewKind ?? "full"}">`;
-  const footer = "</anchor-file>";
-  return {
-    role: "system",
-    content:
-      `${header}\n${snapshot.content}\n${footer}\n` +
-      `[reattached from pre-compaction read cache; refer to the anchor-file ` +
-      `block above instead of re-calling system.readFile for this path]`,
-  };
-}
+// Post-compaction file re-attachment helpers now live in the shared
+// compact module so the chat-executor in-flight path and this
+// background-run path produce byte-identical anchor messages for the
+// same snapshot input. See `src/llm/compact/post-compact-attachments.ts`.
 
 // ---------------------------------------------------------------------------
 // Domain-dependent free functions (kept here to avoid circular deps)
@@ -4661,22 +4633,7 @@ export class BackgroundRunSupervisor {
   private reattachRecentFilesOnCompaction(
     sessionId: string,
   ): LLMMessage[] {
-    const snapshots = snapshotTopRecentReads({
-      sessionId,
-      maxFiles: POST_COMPACT_MAX_FILES_TO_REATTACH,
-      perFileBudgetChars: POST_COMPACT_PER_FILE_BUDGET_CHARS,
-      totalBudgetChars: POST_COMPACT_TOTAL_BUDGET_CHARS,
-    });
-    // Unconditionally clear the cache: the compacted prompt no longer
-    // contains the prior raw tool_result bytes, so a later
-    // FILE_UNCHANGED_STUB reply would point at content that has been
-    // summarized away. Re-attachments below supply the bytes that
-    // matter; the cache will refill naturally on next read.
-    clearSessionReadCache(sessionId);
-    if (snapshots.length === 0) {
-      return [];
-    }
-    return snapshots.map((s) => buildAnchorFileMessage(s));
+    return [...reattachRecentFilesOnCompaction(sessionId)];
   }
 
   private async compactInternalHistory(

--- a/runtime/src/llm/chat-executor-history-compaction.ts
+++ b/runtime/src/llm/chat-executor-history-compaction.ts
@@ -23,6 +23,7 @@ import { callWithFallback } from "./chat-executor-fallback.js";
 import {
   compactHistoryIntoArtifactContext,
   createCompactBoundaryMessage,
+  isCompactBoundaryMessage,
 } from "./context-compaction.js";
 import { MAX_COMPACT_INPUT } from "./chat-executor-constants.js";
 import type { ArtifactCompactionState } from "../memory/artifact-store.js";
@@ -54,6 +55,10 @@ export interface SessionMemoryCompactionResult {
   readonly history: readonly LLMMessage[];
   readonly artifactContext: ArtifactCompactionState;
   readonly postCompactTokenCount: number;
+  /** The newly-minted boundary message (the one produced by this pass). */
+  readonly boundaryMessage: LLMMessage;
+  /** Count of messages in `history` that come AFTER `boundaryMessage`. */
+  readonly retainedAfterNewBoundaryCount: number;
 }
 
 const DEFAULT_SESSION_MEMORY_COMPACT_KEEP_TAIL = 3;
@@ -83,6 +88,8 @@ export async function compactHistory(
 ): Promise<{
   readonly history: readonly LLMMessage[];
   readonly artifactContext?: ArtifactCompactionState;
+  readonly boundaryMessage?: LLMMessage;
+  readonly retainedAfterNewBoundaryCount?: number;
 }> {
   const effectiveKeepTailCount = Math.max(1, options?.keepTailCount ?? 5);
   if (history.length <= effectiveKeepTailCount) {
@@ -94,7 +101,14 @@ export async function compactHistory(
 
   let narrativeSummary: string | undefined;
   const toSummarize = history.slice(0, history.length - effectiveKeepTailCount);
-  let historyText = toSummarize
+  // Skip pre-existing compact boundary markers — they have already been
+  // summarized and re-feeding them to the summarizer produces nested
+  // "summary of a summary" text that still changes turn-to-turn and
+  // invalidates the provider's prompt cache past the first boundary.
+  const summarizableMessages = toSummarize.filter(
+    (message) => !isCompactBoundaryMessage(message),
+  );
+  let historyText = summarizableMessages
     .map((message) => {
       const content =
         typeof message.content === "string"
@@ -169,9 +183,18 @@ export async function compactHistory(
     }
   }
 
+  const newBoundaryIndex = compacted.compactedHistory.indexOf(
+    compacted.boundaryMessage,
+  );
+  const retainedAfterNewBoundaryCount =
+    newBoundaryIndex >= 0
+      ? compacted.compactedHistory.length - newBoundaryIndex - 1
+      : Math.max(0, compacted.compactedHistory.length - 1);
   return {
     history: compacted.compactedHistory,
     artifactContext: compacted.state,
+    boundaryMessage: compacted.boundaryMessage,
+    retainedAfterNewBoundaryCount,
   };
 }
 
@@ -206,10 +229,19 @@ export function trySessionMemoryCompaction(params: {
   ) {
     return null;
   }
+  const newBoundaryIndex = compacted.compactedHistory.indexOf(
+    compacted.boundaryMessage,
+  );
+  const retainedAfterNewBoundaryCount =
+    newBoundaryIndex >= 0
+      ? compacted.compactedHistory.length - newBoundaryIndex - 1
+      : Math.max(0, compacted.compactedHistory.length - 1);
   return {
     history: compacted.compactedHistory,
     artifactContext: compacted.state,
     postCompactTokenCount,
+    boundaryMessage: compacted.boundaryMessage,
+    retainedAfterNewBoundaryCount,
   };
 }
 

--- a/runtime/src/llm/chat-executor-in-flight-compaction.ts
+++ b/runtime/src/llm/chat-executor-in-flight-compaction.ts
@@ -43,6 +43,7 @@ import {
   markAutocompactSuccess,
 } from "./compact/autocompact.js";
 import { runPostCompactCleanup } from "./compact/post-compact-cleanup.js";
+import { reattachRecentFilesOnCompaction } from "./compact/post-compact-attachments.js";
 
 /**
  * Dependency struct for `maybeCompactInFlightCallInput`.
@@ -180,30 +181,89 @@ export async function maybeCompactInFlightCallInput(
           keepTailCount: inFlightKeepTailCount,
         },
       );
-    const retainedTailCount = Math.max(0, compacted.history.length - 1);
+    // Derive the number of items kept AFTER the newly-minted boundary
+    // (preserved-multimodal + keep-tail messages). Falls back to the
+    // legacy "everything except index 0" assumption for shapes that do
+    // not expose the new-boundary split (e.g. the trivial-history
+    // early-exit path).
+    const retainedAfterNewBoundaryCount =
+      compacted.retainedAfterNewBoundaryCount ??
+      Math.max(0, compacted.history.length - 1);
+    const newBoundaryMessage: LLMMessage =
+      compacted.boundaryMessage ??
+      ({
+        role: "system" as const,
+        content:
+          typeof compacted.history[0]?.content === "string"
+            ? (compacted.history[0].content as string)
+            : "",
+      });
+    // Snapshot the top-N most-recently-read files and build anchor
+    // messages to re-inject their bytes immediately after the boundary.
+    // Mirrors Claude Code's `createPostCompactFileAttachments`: after
+    // compaction, the raw tool_result bytes are gone from the prompt,
+    // so the model would otherwise re-call `system.readFile` for the
+    // same paths round after round. Anchors short-circuit that. Also
+    // clears the in-memory read cache so the FILE_UNCHANGED_STUB
+    // short-circuit does not point at content that has been
+    // summarized away.
+    const anchorFileMessages = reattachRecentFilesOnCompaction(ctx.sessionId);
     const replayTailReconciliationMessages = (
       input.callReconciliationMessages ?? ctx.reconciliationMessages
     ).slice(replayTailStartIndex);
     const replayTailSections = (
       input.callSections ?? ctx.messageSections
     ).slice(replayTailStartIndex);
+    const anchorReconciliationMessages: readonly LLMMessage[] = anchorFileMessages.map(
+      (message) => ({
+        role: "system" as const,
+        content:
+          typeof message.content === "string"
+            ? (message.content as string)
+            : "",
+      }),
+    );
+    const anchorSections: readonly PromptBudgetSection[] = anchorFileMessages.map(
+      () => "memory_working",
+    );
     const compactedReconciliationMessages: readonly LLMMessage[] = [
       {
         role: "system",
         content:
-          typeof compacted.history[0]?.content === "string"
-            ? compacted.history[0].content
+          typeof newBoundaryMessage.content === "string"
+            ? newBoundaryMessage.content
             : "",
       },
-      ...replayTailReconciliationMessages.slice(-retainedTailCount),
+      ...anchorReconciliationMessages,
+      ...replayTailReconciliationMessages.slice(-retainedAfterNewBoundaryCount),
     ];
     const compactedSections: readonly PromptBudgetSection[] = [
       "memory_working",
-      ...replayTailSections.slice(-retainedTailCount),
+      ...anchorSections,
+      ...replayTailSections.slice(-retainedAfterNewBoundaryCount),
     ];
+    // Build the final compacted history. Structure:
+    //   [...head, ...priorBoundaries, newBoundary, ...anchors, ...preserved, ...toKeep]
+    // The prior boundaries (if any) come from `compacted.history` up to
+    // the new boundary. Anchors are spliced immediately after the new
+    // boundary so they sit inside the cacheable prefix but before the
+    // recent tail.
+    const newBoundaryIndex = compacted.history.indexOf(newBoundaryMessage);
+    const beforeNewBoundary =
+      newBoundaryIndex >= 0
+        ? compacted.history.slice(0, newBoundaryIndex + 1)
+        : [compacted.history[0]].filter(
+            (entry): entry is LLMMessage => entry !== undefined,
+          );
+    const afterNewBoundary =
+      newBoundaryIndex >= 0
+        ? compacted.history.slice(newBoundaryIndex + 1)
+        : compacted.history.slice(1);
     const nextMessages = [
       ...input.callMessages.slice(0, replayTailStartIndex),
-      ...compacted.history,
+      ...beforeNewBoundary,
+      ...anchorFileMessages,
+      ...afterNewBoundary,
     ];
     const nextReconciliationMessages = [
       ...(input.callReconciliationMessages ?? ctx.reconciliationMessages).slice(
@@ -224,6 +284,11 @@ export async function maybeCompactInFlightCallInput(
     ctx.messageSections = [...nextSections];
     ctx.compacted = true;
     ctx.compactedArtifactContext = compacted.artifactContext;
+    // NOTE: we already cleared the read cache inside
+    // `reattachRecentFilesOnCompaction`. `runPostCompactCleanup` is
+    // retained for any additional per-session cleanup the compact
+    // module may grow in the future (currently it only clears the
+    // read cache, which is now a no-op on second call).
     runPostCompactCleanup(ctx.sessionId);
     ctx.perIterationCompaction = {
       ...ctx.perIterationCompaction,

--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -89,6 +89,30 @@ import { executeSingleToolCall } from "./chat-executor-single-tool-dispatch.js";
 import { evaluateTurnEndStopGate } from "./chat-executor-stop-gate-evaluation.js";
 
 // ============================================================================
+// Stall-escalation tripwire
+// ============================================================================
+
+/**
+ * Number of times one recovery-hint key may fire in a single turn before
+ * the loop escalates to a text-only user handoff. Chosen to match the
+ * existing `FAILED_TOOL_RECOVERY_STREAK`: after three rounds of the same
+ * specific diagnostic, the model is not recovering on its own.
+ */
+const STALL_HINT_REPEAT_LIMIT = 3;
+
+/**
+ * Recovery-hint key prefixes that count toward the stall tripwire. Kept
+ * narrow to observed pathological loops (build-fail → edit → rebuild at
+ * the same compiler location) so generic/advisory hint keys do not
+ * short-circuit healthy long-running turns.
+ */
+const STALL_ESCALATION_HINT_PREFIXES: readonly string[] = [
+  "system-bash-compiler-diagnostic",
+  "system-bash-compiler-interface-drift",
+  "system-bash-compiler-header-ordering",
+];
+
+// ============================================================================
 // Callback interfaces
 // ============================================================================
 
@@ -309,6 +333,16 @@ export async function executeToolCallLoop(
   };
   let consecutiveFailedToolCalls = 0;
   let forcedFailureRecoveryUsed = false;
+
+  // Per-turn stall-escalation state. Tracks how many times each
+  // recovery-hint key has fired so a model stuck in a repeating
+  // build-fail → edit → rebuild cycle is forced to summarize for the
+  // user instead of burning more rounds. Keys matching
+  // `STALL_ESCALATION_HINT_PREFIXES` count toward the cap — other keys
+  // are tracked for observability only.
+  const hintKeyRepeatCounts = new Map<string, number>();
+  let stallEscalationTriggered = false;
+  let stallEscalationKey: string | undefined;
 
   // Turn-end completion validation now shares one turn-local
   // continuation controller instead of per-validator attempt maps.
@@ -551,6 +585,64 @@ export async function executeToolCallLoop(
     )) {
       callbacks.pushMessage(ctx, msg, "system_runtime");
     }
+
+    // Stall-escalation tripwire: track per-turn repetition of specific
+    // failure-diagnostic hint keys. When the same key fires
+    // `STALL_HINT_REPEAT_LIMIT` times, the model is stuck in a loop
+    // text-only hints cannot break (e.g. build-fail → edit → rebuild
+    // at the same compiler location, flailing between permutations of
+    // the same fix). Inject a strong system message instructing the
+    // model to summarize for the user, then force the next provider
+    // call to be text-only so the loop ends cleanly on the model's
+    // response instead of burning another round of tool calls.
+    let stallEscalatedThisRound = false;
+    if (!stallEscalationTriggered) {
+      for (const hint of recoveryHints) {
+        if (
+          !STALL_ESCALATION_HINT_PREFIXES.some((prefix) =>
+            hint.key.startsWith(prefix),
+          )
+        ) {
+          continue;
+        }
+        const nextCount = (hintKeyRepeatCounts.get(hint.key) ?? 0) + 1;
+        hintKeyRepeatCounts.set(hint.key, nextCount);
+        if (nextCount >= STALL_HINT_REPEAT_LIMIT) {
+          stallEscalatedThisRound = true;
+          stallEscalationTriggered = true;
+          stallEscalationKey = hint.key;
+        }
+      }
+    }
+    if (stallEscalatedThisRound && stallEscalationKey) {
+      const repeatCount =
+        hintKeyRepeatCounts.get(stallEscalationKey) ?? STALL_HINT_REPEAT_LIMIT;
+      const stallMessage: import("./types.js").LLMMessage = {
+        role: "system",
+        content:
+          `STALL DETECTED: the same failure-recovery hint has fired ${repeatCount} ` +
+          `times this turn without the underlying error changing ` +
+          `(\`${stallEscalationKey}\`). ` +
+          `Stop calling tools immediately. Reply to the user in plain text with: ` +
+          `(a) the exact error or failure you keep hitting, ` +
+          `(b) every fix approach you already tried in this turn and the outcome of each, ` +
+          `(c) your best hypothesis for what is actually blocking progress. ` +
+          `Wait for the user's guidance before invoking any more tools.`,
+      };
+      callbacks.pushMessage(ctx, stallMessage, "system_runtime");
+      callbacks.emitExecutionTrace(ctx, {
+        type: "stall_escalated",
+        phase: "tool_followup",
+        callIndex: ctx.callIndex + 1,
+        payload: {
+          hintKey: stallEscalationKey,
+          repeatCount,
+          repeatLimit: STALL_HINT_REPEAT_LIMIT,
+          hintKeyCounts: Object.fromEntries(hintKeyRepeatCounts),
+        },
+      });
+    }
+
     // Routing expansion on miss.
     if (loopState.expandAfterRound && ctx.expandedRoutedToolNames.length > 0) {
       const previousRoutedToolNames = [...ctx.activeRoutedToolNames];
@@ -601,7 +693,9 @@ export async function executeToolCallLoop(
         onStreamChunk: ctx.activeStreamCallback,
         structuredOutput: ctx.structuredOutput,
         promptCacheKey: ctx.sessionId,
-        ...(shouldForceFailureRecovery ? { toolChoice: "none" as const } : {}),
+        ...(shouldForceFailureRecovery || stallEscalatedThisRound
+          ? { toolChoice: "none" as const }
+          : {}),
         budgetReason:
           "Max model recalls exceeded while following up after tool calls",
       }),
@@ -633,6 +727,30 @@ export async function executeToolCallLoop(
         ctx.response = { ...nextResponse, content: "" };
         break;
       }
+    }
+    if (stallEscalatedThisRound) {
+      ctx.response = nextResponse;
+      if (responseHasToolCalls(nextResponse)) {
+        // Model ignored `toolChoice: none` after stall escalation.
+        // Close the turn anyway — continuing would defeat the tripwire.
+        emitToolProtocolViolation(
+          ctx,
+          callbacks,
+          "tool_choice_none_ignored_after_stall_escalation",
+          {
+            toolNames: nextResponse.toolCalls.map((toolCall) => toolCall.name),
+            finishReason: nextResponse.finishReason,
+            stallHintKey: stallEscalationKey ?? null,
+          },
+        );
+        sealPendingToolProtocol(ctx, callbacks, "stall_escalated");
+      }
+      callbacks.setStopReason(
+        ctx,
+        "no_progress",
+        `Stall escalation: recovery hint \`${stallEscalationKey}\` fired ${STALL_HINT_REPEAT_LIMIT}+ times without progress. Handed back to the user with a model-written summary.`,
+      );
+      break;
     }
     ctx.response = nextResponse;
     failClosedOnMalformedToolContinuation(ctx, callbacks);

--- a/runtime/src/llm/chat-executor-trace-inventory.test.ts
+++ b/runtime/src/llm/chat-executor-trace-inventory.test.ts
@@ -109,6 +109,7 @@ describe("chat execution trace inventory", () => {
       "recovery_hints_injected",
       "route_expanded",
       "runtime_contract_snapshot",
+      "stall_escalated",
       "stop_gate_intervention",
       "stop_hook_blocked",
       "stop_hook_execution_finished",

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -170,6 +170,7 @@ export const CHAT_EXECUTION_TRACE_EVENT_TYPES = [
   "recovery_hints_injected",
   "route_expanded",
   "runtime_contract_snapshot",
+  "stall_escalated",
   "stop_hook_blocked",
   "stop_hook_execution_finished",
   "stop_hook_exhausted",

--- a/runtime/src/llm/compact/post-compact-attachments.test.ts
+++ b/runtime/src/llm/compact/post-compact-attachments.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  clearSessionReadState,
+  seedSessionReadState as seedRead,
+} from "../../tools/system/filesystem.js";
+import {
+  buildAnchorFileMessage,
+  POST_COMPACT_MAX_FILES_TO_REATTACH,
+  POST_COMPACT_PER_FILE_BUDGET_CHARS,
+  POST_COMPACT_TOTAL_BUDGET_CHARS,
+  reattachRecentFilesOnCompaction,
+} from "./post-compact-attachments.js";
+
+describe("post-compact-attachments", () => {
+  const sessionId = "session-post-compact";
+
+  beforeEach(() => {
+    clearSessionReadState(sessionId);
+  });
+
+  it("returns an empty list when the session has no recent reads", () => {
+    const out = reattachRecentFilesOnCompaction(sessionId);
+    expect(out).toEqual([]);
+  });
+
+  it("emits an anchor-file system message per top-N most-recent file", () => {
+    seedRead(sessionId, [
+      { path: "/ws/a.ts", content: "A body", timestamp: 100, viewKind: "full" },
+      { path: "/ws/b.ts", content: "B body", timestamp: 300, viewKind: "full" },
+      { path: "/ws/c.ts", content: "C body", timestamp: 200, viewKind: "full" },
+    ]);
+
+    const anchors = reattachRecentFilesOnCompaction(sessionId, {
+      maxFiles: 2,
+    });
+
+    expect(anchors).toHaveLength(2);
+    // Anchors arrive newest-first, matching snapshotTopRecentReads.
+    expect(anchors.every((m) => m.role === "system")).toBe(true);
+    expect(String(anchors[0]?.content)).toContain(`<anchor-file path="/ws/b.ts"`);
+    expect(String(anchors[0]?.content)).toContain("B body");
+    expect(String(anchors[0]?.content)).toContain("</anchor-file>");
+    expect(String(anchors[0]?.content)).toContain(
+      "refer to the anchor-file block above",
+    );
+  });
+
+  it("clears the in-memory read cache so a later read returns full content, not a stub", () => {
+    seedRead(sessionId, [
+      { path: "/ws/only.ts", content: "only", timestamp: 1, viewKind: "full" },
+    ]);
+    // First call returns anchors and clears the cache.
+    const first = reattachRecentFilesOnCompaction(sessionId);
+    expect(first).toHaveLength(1);
+    // Second call with no intervening reads returns nothing because
+    // the cache was cleared.
+    const second = reattachRecentFilesOnCompaction(sessionId);
+    expect(second).toEqual([]);
+  });
+
+  it("buildAnchorFileMessage wraps content verbatim in the anchor-file tag", () => {
+    const message = buildAnchorFileMessage({
+      path: "/ws/foo.ts",
+      content: "export const x = 1;",
+      timestamp: 42,
+      viewKind: "full",
+    });
+    expect(message.role).toBe("system");
+    const text = String(message.content);
+    expect(text).toContain(`<anchor-file path="/ws/foo.ts" viewKind="full">`);
+    expect(text).toContain("export const x = 1;");
+    expect(text).toContain("</anchor-file>");
+  });
+
+  it("exposes the shared budget constants expected by callers", () => {
+    expect(POST_COMPACT_MAX_FILES_TO_REATTACH).toBe(5);
+    expect(POST_COMPACT_PER_FILE_BUDGET_CHARS).toBe(20_000);
+    expect(POST_COMPACT_TOTAL_BUDGET_CHARS).toBe(200_000);
+  });
+});

--- a/runtime/src/llm/compact/post-compact-attachments.ts
+++ b/runtime/src/llm/compact/post-compact-attachments.ts
@@ -1,0 +1,88 @@
+/**
+ * Post-compaction file re-attachment helpers.
+ *
+ * After a compaction pass summarizes older tool history, the raw bytes
+ * of files the model had recently read disappear from the prompt. The
+ * model then burns follow-up rounds re-calling `system.readFile` for
+ * paths it was just looking at. Mirrors the reference runtime's
+ * `createPostCompactFileAttachments` pattern: snapshot the top-N
+ * most-recently-read files, clear the per-session read cache, and
+ * re-inject the file contents as `<anchor-file>` system messages that
+ * sit just after the compaction boundary in the new prompt.
+ *
+ * The chars-per-file and total-chars budgets are conservative. Over the
+ * grok/claude ~4-chars-per-token ratio these roughly match upstream's
+ * 5K/file + 50K envelope. The helpers are shared between the chat
+ * executor's in-flight compaction path and the background-run
+ * supervisor's internal compaction path so both exits produce
+ * byte-identical anchor messages for the same snapshot input.
+ *
+ * @module
+ */
+
+import {
+  clearSessionReadCache,
+  snapshotTopRecentReads,
+  type SessionReadSnapshotExport,
+} from "../../tools/system/filesystem.js";
+import type { LLMMessage } from "../types.js";
+
+export const POST_COMPACT_MAX_FILES_TO_REATTACH = 5;
+export const POST_COMPACT_PER_FILE_BUDGET_CHARS = 20_000;
+export const POST_COMPACT_TOTAL_BUDGET_CHARS = 200_000;
+
+/**
+ * Wrap a file snapshot as a `system`-role anchor message whose content
+ * block is a well-known `<anchor-file>` tagged region. The anchor tag
+ * gives the model a stable, easy-to-scan re-reference point and tells
+ * it explicitly not to re-invoke `system.readFile` for the attached
+ * path.
+ */
+export function buildAnchorFileMessage(
+  snapshot: SessionReadSnapshotExport,
+): LLMMessage {
+  const header =
+    `<anchor-file path="${snapshot.path}" viewKind="${snapshot.viewKind ?? "full"}">`;
+  const footer = "</anchor-file>";
+  return {
+    role: "system",
+    content:
+      `${header}\n${snapshot.content}\n${footer}\n` +
+      `[reattached from pre-compaction read cache; refer to the anchor-file ` +
+      `block above instead of re-calling system.readFile for this path]`,
+  };
+}
+
+/**
+ * Snapshot the top-N most-recently-read files for this session,
+ * build their anchor messages, and clear the session's in-memory read
+ * cache. Safe to call when no reads have happened — returns an empty
+ * array.
+ *
+ * The caller inserts the returned messages into the compacted history
+ * immediately after the compaction boundary so the attached content
+ * stays inside the cacheable prefix but outside the recent-tail slice
+ * that changes every round.
+ */
+export function reattachRecentFilesOnCompaction(
+  sessionId: string,
+  options?: {
+    readonly maxFiles?: number;
+    readonly perFileBudgetChars?: number;
+    readonly totalBudgetChars?: number;
+  },
+): readonly LLMMessage[] {
+  const snapshots = snapshotTopRecentReads({
+    sessionId,
+    maxFiles: options?.maxFiles ?? POST_COMPACT_MAX_FILES_TO_REATTACH,
+    perFileBudgetChars:
+      options?.perFileBudgetChars ?? POST_COMPACT_PER_FILE_BUDGET_CHARS,
+    totalBudgetChars:
+      options?.totalBudgetChars ?? POST_COMPACT_TOTAL_BUDGET_CHARS,
+  });
+  clearSessionReadCache(sessionId);
+  if (snapshots.length === 0) {
+    return [];
+  }
+  return snapshots.map((snapshot) => buildAnchorFileMessage(snapshot));
+}

--- a/runtime/src/llm/context-compaction.test.ts
+++ b/runtime/src/llm/context-compaction.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { compactHistoryIntoArtifactContext } from "./context-compaction.js";
+import {
+  compactHistoryIntoArtifactContext,
+  createCompactBoundaryMessage,
+  isCompactBoundaryMessage,
+} from "./context-compaction.js";
 import type { LLMMessage } from "./types.js";
 
 function multimodalMessage(): LLMMessage {
@@ -260,5 +264,100 @@ describe("context compaction", () => {
     });
 
     expect(compacted.compactedHistory.slice(1, 5)).toEqual(history);
+  });
+
+  it("preserves a pre-existing boundary verbatim across re-compaction", () => {
+    const priorBoundary = createCompactBoundaryMessage({
+      boundaryId: "snapshot:priorboundary1",
+      source: "executor_compaction",
+      sourceMessageCount: 12,
+      retainedTailCount: 3,
+      summaryText: "earlier summary text",
+    });
+    const history: LLMMessage[] = [
+      priorBoundary,
+      { role: "assistant", content: "work after prior boundary" },
+      { role: "assistant", content: "more work" },
+      { role: "user", content: "continue" },
+      { role: "assistant", content: "will do" },
+    ];
+
+    const compacted = compactHistoryIntoArtifactContext({
+      sessionId: "session-rec",
+      history,
+      keepTailCount: 1,
+      source: "executor_compaction",
+    });
+
+    // Prior boundary must appear verbatim at its original relative
+    // position so the prefix hash seen by the provider cache does not
+    // drift across successive compactions.
+    expect(compacted.compactedHistory[0]).toEqual(priorBoundary);
+    // The new boundary is the second message (after the prior one).
+    expect(compacted.boundaryMessage).toBe(compacted.compactedHistory[1]);
+    expect(isCompactBoundaryMessage(compacted.compactedHistory[1]!)).toBe(true);
+  });
+
+  it("excludes prior-boundary content from the new boundary's hash", () => {
+    const priorBoundaryA = createCompactBoundaryMessage({
+      boundaryId: "snapshot:aaaaaaaa",
+      source: "executor_compaction",
+      sourceMessageCount: 9,
+      retainedTailCount: 2,
+      summaryText: "summary A",
+    });
+    const priorBoundaryB = createCompactBoundaryMessage({
+      boundaryId: "snapshot:bbbbbbbb",
+      source: "executor_compaction",
+      sourceMessageCount: 11,
+      retainedTailCount: 3,
+      summaryText: "summary B — totally different text",
+    });
+    const nonBoundaryTail: LLMMessage[] = [
+      { role: "assistant", content: "identical work item 1" },
+      { role: "assistant", content: "identical work item 2" },
+      { role: "user", content: "same user prompt" },
+    ];
+
+    const compactedWithA = compactHistoryIntoArtifactContext({
+      sessionId: "session-hash",
+      history: [priorBoundaryA, ...nonBoundaryTail],
+      keepTailCount: 1,
+      source: "executor_compaction",
+    });
+    const compactedWithB = compactHistoryIntoArtifactContext({
+      sessionId: "session-hash",
+      history: [priorBoundaryB, ...nonBoundaryTail],
+      keepTailCount: 1,
+      source: "executor_compaction",
+    });
+
+    // The new boundary's hash is derived from the non-boundary content
+    // only, so swapping the prior boundary produces the same
+    // snapshotId. This is what keeps the xAI prompt_cache_key prefix
+    // match region stable across successive compactions that carry
+    // different prior-summary text forward.
+    expect(compactedWithA.state.snapshotId).toBe(compactedWithB.state.snapshotId);
+  });
+
+  it("isCompactBoundaryMessage recognizes both boundary shapes", () => {
+    const executorBoundary = createCompactBoundaryMessage({
+      boundaryId: "snapshot:aa",
+      source: "executor_compaction",
+      sourceMessageCount: 1,
+      retainedTailCount: 1,
+    });
+    const reactiveBoundary: LLMMessage = {
+      role: "system",
+      content: "[reactive-compact] trimmed 5 oldest messages (attempt 1)",
+    };
+    const regularSystem: LLMMessage = {
+      role: "system",
+      content: "You are a helpful assistant.",
+    };
+
+    expect(isCompactBoundaryMessage(executorBoundary)).toBe(true);
+    expect(isCompactBoundaryMessage(reactiveBoundary)).toBe(true);
+    expect(isCompactBoundaryMessage(regularSystem)).toBe(false);
   });
 });

--- a/runtime/src/llm/context-compaction.ts
+++ b/runtime/src/llm/context-compaction.ts
@@ -87,6 +87,54 @@ export function createCompactBoundaryMessage(params: {
   };
 }
 
+/**
+ * True when `message` is a compact boundary marker produced by a prior
+ * compaction pass. Used to keep pre-existing boundaries verbatim across
+ * subsequent compactions so the prefix (and xAI `prompt_cache_key`
+ * match region) stays stable. Mirrors Claude Code's "anchor-preserved"
+ * message pattern: once a boundary is placed, it is not re-summarized.
+ */
+export function isCompactBoundaryMessage(message: LLMMessage): boolean {
+  if (message.role !== "system") return false;
+  const text =
+    typeof message.content === "string"
+      ? message.content
+      : message.content
+          .filter((part): part is { type: "text"; text: string } => part.type === "text")
+          .map((part) => part.text)
+          .join("");
+  const trimmed = text.trimStart();
+  return (
+    trimmed.startsWith("[boundary] replay:") ||
+    trimmed.startsWith("[reactive-compact]")
+  );
+}
+
+/**
+ * Split a candidate-for-compaction slice into prior boundary messages
+ * (which must be preserved verbatim in the output) and the remaining
+ * messages that can be summarized/hashed. Preserving prior boundaries
+ * keeps the cacheable prefix stable across successive compactions
+ * instead of rehashing it every time.
+ */
+function partitionBoundariesFromCompactable(
+  messages: readonly LLMMessage[],
+): {
+  readonly priorBoundaries: readonly LLMMessage[];
+  readonly compactable: readonly LLMMessage[];
+} {
+  const priorBoundaries: LLMMessage[] = [];
+  const compactable: LLMMessage[] = [];
+  for (const message of messages) {
+    if (isCompactBoundaryMessage(message)) {
+      priorBoundaries.push(message);
+      continue;
+    }
+    compactable.push(message);
+  }
+  return { priorBoundaries, compactable };
+}
+
 function extractText(message: LLMMessage): string {
   if (typeof message.content === "string") {
     return message.content;
@@ -540,9 +588,15 @@ export function compactHistoryIntoArtifactContext(
   );
   const toCompact = input.history.slice(0, retainedTailStartIndex);
   const toKeep = input.history.slice(retainedTailStartIndex);
-  const preservedMessages = collectPreservedMessages(toCompact);
+  // Separate pre-existing boundary messages from the messages that will
+  // actually be hashed/summarized into the new boundary. Prior
+  // boundaries are preserved verbatim in the output so the cacheable
+  // prefix remains byte-identical across successive compactions.
+  const { priorBoundaries, compactable: compactableToCompact } =
+    partitionBoundariesFromCompactable(toCompact);
+  const preservedMessages = collectPreservedMessages(compactableToCompact);
   const now = Date.now();
-  const records = toCompact
+  const records = compactableToCompact
     .map((message, index) => {
       const normalizedContent = normalizeArtifactContent(message);
       return {
@@ -582,9 +636,11 @@ export function compactHistoryIntoArtifactContext(
     tags: record.tags,
   }));
   const historyDigest = sha256Hex(
-    toCompact.map((message) => `${message.role}:${extractText(message)}`).join("\n"),
+    compactableToCompact
+      .map((message) => `${message.role}:${extractText(message)}`)
+      .join("\n"),
   );
-  const openLoops = collectOpenLoops(toCompact);
+  const openLoops = collectOpenLoops(compactableToCompact);
   const narrativeSummary = sanitizeNarrativeSummary(
     input.narrativeSummary && input.narrativeSummary.trim().length > 0
       ? truncateText(input.narrativeSummary, 320)
@@ -599,7 +655,7 @@ export function compactHistoryIntoArtifactContext(
     createdAt: now,
     source: input.source,
     historyDigest,
-    sourceMessageCount: toCompact.length,
+    sourceMessageCount: compactableToCompact.length,
     retainedTailCount: toKeep.length,
     ...(narrativeSummary ? { narrativeSummary } : {}),
     openLoops,
@@ -609,12 +665,13 @@ export function compactHistoryIntoArtifactContext(
   const boundaryMessage = createCompactBoundaryMessage({
     boundaryId: state.snapshotId,
     source: input.source,
-    sourceMessageCount: toCompact.length,
+    sourceMessageCount: compactableToCompact.length,
     retainedTailCount: toKeep.length,
     summaryText,
   });
   return {
     compactedHistory: [
+      ...priorBoundaries,
       boundaryMessage,
       ...preservedMessages,
       ...toKeep,

--- a/runtime/src/llm/tool-protocol-state.ts
+++ b/runtime/src/llm/tool-protocol-state.ts
@@ -9,6 +9,7 @@ export type ToolProtocolRepairReason =
   | "request_cancelled"
   | "request_timeout"
   | "round_aborted"
+  | "stall_escalated"
   | "validation_recovery";
 
 export interface PendingToolProtocolCall {


### PR DESCRIPTION
## Summary

Three related fixes that address a traced session which burned ~\$7 on one user turn (176 provider calls, ~3M total tokens, cache hit rate fell to ~22% after compaction fired). Hard evidence from the trace file drove each fix.

**What the trace showed:** by call 170 the input had 35 visible `function_call` items, **0 `user` messages**, and was missing the earliest edits at calls 152, 161, 167. Compaction silently destroyed the evidence the model needed to notice it was permuting the same `#include` additions/removals in a loop at `tokens.c:79:20`. The model could not see its own earlier attempts — they had been summarized away. xAI's prompt cache never recovered past ~9K tokens because the boundary region shifted byte-for-byte on every compaction pass.

### Commit 1 — `fix(runtime): stabilize compaction prefix and re-attach recent files`

1. **Preserve prior boundaries across re-compaction.** Previously each compaction re-hashed and re-embedded every prior boundary's text into the new boundary, so the cacheable prefix drifted on every pass. Now prior boundary markers are detected, excluded from the summary/digest input, and emitted verbatim at their original relative position. Successive compactions append a fresh boundary instead of rewriting history.
2. **Re-attach recently-read files after in-flight compaction.** The mechanism existed in `background-run-supervisor.ts` but was never wired into the main chat-executor path. Extracted shared helpers to `src/llm/compact/post-compact-attachments.ts` and called them from `maybeCompactInFlightCallInput`. Top-5 recently-read files are spliced as `<anchor-file>` system messages immediately after the new boundary — inside the cacheable prefix, outside the recent tail. Mirrors Claude Code's `createPostCompactFileAttachments`.
3. **Explicit boundary accounting.** Compaction helpers now return `boundaryMessage` and `retainedAfterNewBoundaryCount` so callers splice correctly when prior boundaries are present (the legacy `compacted.history[0]` assumption no longer holds).

### Commit 2 — `feat(runtime): stall-escalation tripwire for repeated build-fail loops`

Recovery hints are advisory. The trace showed the same `system-bash-compiler-diagnostic:tokens.c:79:20` hint firing 23 times in one turn with no ceiling. Added a per-turn tripwire: when any hint key matching `system-bash-compiler-{diagnostic,interface-drift,header-ordering}` fires 3 times, inject a strong system message instructing the model to summarize for the user, force `toolChoice: \"none\"` on the next call, set stop reason `no_progress`, and emit a new `stall_escalated` trace event. If the provider defies `toolChoice: none`, a protocol violation is emitted and the turn is force-closed.

Tripwire is a safety net alongside the compaction fix — on the traced session it would have fired around call 40-50 instead of 176.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] 14 new unit tests (context-compaction + post-compact-attachments) green
- [x] 171 existing compaction-adjacent tests green
- [x] Full runtime suite: 6642 passed, 5 pre-existing marketplace integration failures verified unrelated (`git stash` + rerun shows same failures on main)
- [ ] Deploy to daemon, reproduce the same build-fail loop, confirm: (a) xAI `cached_tokens` stays high across compaction, (b) stall tripwire fires around call ~40-50 with `stall_escalated` trace event, (c) final response is a text summary instead of continued tool calls