### PR TITLE
Fix plan-mode tool enforcement in webchat paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,8 @@ claude.md
 AGENTS.md
 agents.md
 CONCORDIA_TODO.MD
+TODO.MD
+TODO.md
 
 # Playwright outputs
 **/test-results/

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -2526,6 +2526,9 @@ export class DaemonManager {
                   ? effectiveProfile
                   : DEFAULT_SESSION_SHELL_PROFILE,
                 this.getDiscoveredToolNamesForSession(sessionId),
+                resolveSessionWorkflowState(
+                  sessionMgr.get(sessionId)?.metadata ?? {},
+                ).stage,
               ),
               shellProfile: effectiveProfile,
             });
@@ -2545,6 +2548,9 @@ export class DaemonManager {
                 })
               : DEFAULT_SESSION_SHELL_PROFILE,
             discoveredToolNames,
+            resolveSessionWorkflowState(
+              sessionMgr.get(sessionId)?.metadata ?? {},
+            ).stage,
           ),
         seedHistoryForSession: (sessionId) =>
           sessionMgr.get(sessionId)?.history ?? [],
@@ -3630,6 +3636,7 @@ export class DaemonManager {
                 ? effectiveProfile
                 : DEFAULT_SESSION_SHELL_PROFILE,
               this.getDiscoveredToolNamesForSession(sessionId),
+              this.resolveSessionWorkflowStage(sessionId),
             ),
             shellProfile: effectiveProfile,
           });
@@ -3648,6 +3655,7 @@ export class DaemonManager {
               })
             : DEFAULT_SESSION_SHELL_PROFILE,
           discoveredToolNames,
+          this.resolveSessionWorkflowStage(sessionId),
         ),
       recordToolRoutingOutcome: () => {
         /* no-op: static routing, nothing to record */
@@ -6493,6 +6501,23 @@ export class DaemonManager {
     return interactiveState?.discoveredToolNames ?? [];
   }
 
+  /**
+   * Resolve the current workflow stage for a session so the tool
+   * catalog filter can apply plan-mode restrictions. Returns
+   * `undefined` when the session is unknown, letting callers pass the
+   * value through to `getAdvertisedToolNames` (which treats
+   * `undefined` as "no plan-mode filtering"). Mirrors how the text
+   * channel paths already read the stage at their call sites.
+   */
+  private resolveSessionWorkflowStage(
+    sessionId: string | undefined,
+  ): SessionWorkflowStage | undefined {
+    if (!sessionId) return undefined;
+    const metadata = this._webSessionManager?.get(sessionId)?.metadata;
+    if (!metadata) return undefined;
+    return resolveSessionWorkflowState(metadata).stage;
+  }
+
   private getAdvertisedToolNames(
     toolNames?: readonly string[],
     shellProfile: SessionShellProfile = DEFAULT_SESSION_SHELL_PROFILE,
@@ -6964,6 +6989,7 @@ export class DaemonManager {
         undefined,
         advertisedShellProfile,
         this.getDiscoveredToolNamesForSession(sessionId),
+        this.resolveSessionWorkflowStage(sessionId),
       ),
       defaultWorkingDirectory: this._hostWorkspacePath ?? undefined,
       workspaceAliasRoot: this._hostWorkspacePath ?? undefined,
@@ -7090,6 +7116,7 @@ export class DaemonManager {
         undefined,
         advertisedShellProfile,
         this.getDiscoveredToolNamesForSession(sessionId),
+        this.resolveSessionWorkflowStage(sessionId),
       ),
       defaultWorkingDirectory: this._hostWorkspacePath ?? undefined,
       workspaceAliasRoot: this._hostWorkspacePath ?? undefined,


### PR DESCRIPTION
## Summary

Plan mode was designed to hide mutating tools (`editFile`, `writeFile`, mutating `bash`) from the advertised catalog when a session is in the `"plan"` workflow stage — see filter at \`tool-routing.ts:223\`. The filter itself worked and is unit-tested. But **six webchat/generic call sites in \`daemon.ts\` never threaded the session's current stage through to the builder**, so \`buildAdvertisedToolBundle\` always saw \`workflowStage: undefined\` and the filter was dead code.

Observed consequence in a real trace: user typed \`"come up with a /plan for M1"\`, model called \`workflow.enterPlan\` at call 4 (success), then made **86 \`editFile\` + 40 \`bash\` + 4 \`writeFile\` calls from call 13 onward**. 130 total calls, $4.75 on one turn. \`workflow.exitPlan\` was never called — plan mode was nominally active the entire time.

## What changed

Added a private helper \`resolveSessionWorkflowStage(sessionId)\` on the daemon that reads the current stage from \`_webSessionManager\` (returns \`undefined\` when the session is unknown — matches how \`getAdvertisedToolNames\` already treats the missing arg). Threaded it through six call sites:

- webchat \`buildToolRoutingDecision\` callback
- webchat \`resolveAdvertisedToolNames\` callback
- generic \`buildToolRoutingDecision\` callback
- generic \`resolveAdvertisedToolNames\` callback
- \`createWebChatSessionToolHandler\` catalog
- \`createTextChannelSessionToolHandler\` catalog

The equivalent text-channel path at \`daemon.ts:7544\` already read the stage inline (\`resolveSessionWorkflowState(sessionMgr.get(sessionId)?.metadata).stage\`) so only the webchat side was broken.

Also added \`TODO.MD\` / \`TODO.md\` to \`.gitignore\` for working-notes hygiene.

## Scope notes

Originally scoped as a three-fix PR. Two items were cut after deeper investigation:

1. **\`x-grok-conv-id\` HTTP header** — turned out to be unnecessary. AgenC uses the Responses API exclusively (\`client.responses.create(...)\` at \`adapter.ts:618\`, zero references to Chat Completions anywhere). Per xAI docs the \`prompt_cache_key\` body field (which we already set) is \"functionally identical\" to \`x-grok-conv-id\`. The trace label \`transport: \"chat\"\` is just our internal function name (\`chat()\` vs \`chatStream()\`), not the HTTP endpoint.

2. **Intent-based model routing** — requires touching \`model-routing-policy.ts\` (302 LOC), \`chat-executor-config.ts\`, \`chat-executor-model-orchestration.ts\`, and \`daemon.ts\` simultaneously. Deferred to a follow-up PR; tracked in local \`TODO.MD\`.

## Test plan

- [x] \`npx tsc --noEmit\` clean in \`runtime/\`
- [x] 162 tests in \`src/gateway/tool-routing.test.ts\` + \`src/gateway/daemon.test.ts\` green
- [x] 1655 tests across \`src/gateway/\` green — no regressions
- [ ] Deploy to daemon, run the same \`"come up with a /plan for M1"\` prompt, confirm: (a) \`workflow.enterPlan\` fires, (b) subsequent calls advertise the plan-mode-filtered catalog (no \`editFile\`/\`writeFile\`/mutating-bash), (c) model stops making mutating calls or escalates via \`workflow.exitPlan\`