### PR TITLE
Inject __agencSessionId for workflow.enterPlan / exitPlan

### DIFF
--- a/runtime/src/gateway/tool-handler-factory.ts
+++ b/runtime/src/gateway/tool-handler-factory.ts
@@ -169,6 +169,12 @@ const SESSION_ID_TOOL_NAMES = new Set([
   "system.writeFile",
   "system.appendFile",
   "system.editFile",
+  // Workflow-stage tools read `__agencSessionId` out of args to call
+  // `setSessionWorkflowStage`. Without injection they fail with
+  // "requires a session context", which in turn leaves the stage at
+  // `implement` and neuters the plan-mode catalog filter downstream.
+  "workflow.enterPlan",
+  "workflow.exitPlan",
 ]);
 const TOOL_PATH_ARG_KEYS: Readonly<Record<string, readonly string[]>> = {
   "desktop.text_editor": ["path"],


### PR DESCRIPTION
## Summary

Follow-up to #466. Plan-mode enforcement still bypassed in a live trace because `workflow.enterPlan` fails at call 1 before the stage can flip:

\`\`\`
call=1 workflow.enterPlan → error: \"workflow.enterPlan requires a session context (no __agencSessionId)\"
\`\`\`

Root cause: \`SESSION_ID_TOOL_NAMES\` in \`tool-handler-factory.ts:166\` is an explicit allowlist of tools that receive the injected \`__agencSessionId\` arg. It covered the 5 filesystem tools but not \`workflow.enterPlan\` / \`workflow.exitPlan\`, which were added in PR #464 and read the same slot out of args.

2-line fix. Adds both workflow tools to the allowlist.

## Impact observed on the failed-enterPlan turn

Same input \`\"come up with a /plan for M1\"\` on merged #465 + #466:
- 40 calls (vs 130 before fixes) — 3.25× reduction
- \$0.51 cost (vs \$4.75) — 9× cheaper
- 87% cache hit rate (vs 50%) — compaction fixes working
- BUT: still produced 7 \`editFile\` + 5 \`mkdir\` + 2 \`writeFile\` calls because plan mode never activated due to this bug

After this fix, plan mode should finally filter mutating tools end-to-end.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] 100 tests in \`tool-handler-factory.test.ts\` green
- [ ] Rebuild + restart daemon, re-run same prompt, confirm \`workflow.enterPlan\` succeeds and subsequent catalog drops mutating tools