### PR TITLE
Bind sharedCommandCatalog in surface bridge (fix missing /plan, /mcp, /plugin, ...)

### DIFF
--- a/runtime/src/watch/agenc-watch-state.mjs
+++ b/runtime/src/watch/agenc-watch-state.mjs
@@ -131,6 +131,7 @@ const DEFAULT_BOUND_STATE_KEYS = Object.freeze([
   "configuredModelRoute",
   "lastStatusFeedFingerprint",
   "eventCategoryFilter",
+  "sharedCommandCatalog",
 ]);
 
 function normalizeStoredValue(value) {

--- a/runtime/src/watch/agenc-watch-surface-bridge.mjs
+++ b/runtime/src/watch/agenc-watch-surface-bridge.mjs
@@ -23,6 +23,13 @@ const REQUIRED_STATE_KEYS = Object.freeze([
   "configuredModelRoute",
   "lastStatusFeedFingerprint",
   "manualSessionsQuery",
+  // Without this key here, `state.sharedCommandCatalog = ...` in the
+  // session-command-catalog dispatch case writes a plain own property
+  // on the bridge proxy instead of forwarding to real watchState, and
+  // the autocomplete read from watchState.sharedCommandCatalog always
+  // sees the initial []. Observed: /plan never appeared in the TUI
+  // slash-command palette because of this exact miss.
+  "sharedCommandCatalog",
 ]);
 
 const REQUIRED_HELPER_KEYS = Object.freeze([


### PR DESCRIPTION
## Summary

TUI slash-command autocomplete was missing every daemon-contributed command — \`/plan\`, \`/agents\`, \`/market\`, \`/mcp\`, \`/plugin\`, \`/skills\`, \`/permissions\`, etc. Only the ~22 locally-declared base commands appeared. User screenshot: typing \`/plan\` rendered \"No matching slash command.\"

## Root cause (instrumented)

The TUI surface dispatch at \`agenc-watch-surface-dispatch.mjs:275\` writes \`state.sharedCommandCatalog = <catalog>\` when the daemon responds to \`session.command.catalog.get\`. But \`state\` there is the **bridge proxy** built by \`createWatchSurfaceDispatchBridge\`, which only wires getter/setter forwarding for keys enumerated in \`REQUIRED_STATE_KEYS\`. \`sharedCommandCatalog\` wasn't in that list, so:

1. \`state.sharedCommandCatalog = nextCatalog\` → writes a plain own property on the proxy object (no setter trap).
2. Read path is \`watchState.sharedCommandCatalog\` (via \`currentWatchCommands()\` in \`agenc-watch-app.mjs:1193\`).
3. The real \`watchState\` was never written to. Read always returns the initial \`[]\`.
4. \`mergeWatchCommandCatalog(baseCommands, [])\` = base commands only, no daemon-contributed entries.

Instrumented logs captured live:
\`\`\`
[10:39:21.164Z] received catalog: entries=37 hasPlan=true
[10:39:21.947Z] input=\"/\"  shared=0  merged=35  hasPlan=false  result=[... 35 base commands, no /plan]
\`\`\`

Dispatch fires and gets the 37-entry catalog. 500ms later the autocomplete reads 0.

## Fix

Add \`sharedCommandCatalog\` to both sync'd lists:
- \`REQUIRED_STATE_KEYS\` in \`agenc-watch-surface-bridge.mjs\`
- \`DEFAULT_BOUND_STATE_KEYS\` in \`agenc-watch-state.mjs\`

Two entries, one bug, nothing else changes. The two lists being out-of-sync like this is itself a code smell worth tracking, but scope-cut here.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] Existing 7 tests in \`tests/watch/agenc-watch-surface-bridge.test.mjs\` green (harness iterates \`REQUIRED_STATE_KEYS\` to build bindings, auto-picks up the new key)
- [ ] Rebuild + restart TUI, type \`/p\` — autocomplete should show \`/pause, /permissions, /pipeline, /plan, /plugin, /policy, /profile, /progress\` instead of just \`/pause\`