### PR TITLE
Per-call advertised tool catalog refresh (make plan mode actually gate mid-turn)

### DIFF
--- a/runtime/src/gateway/daemon-webchat-turn.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.ts
@@ -492,6 +492,30 @@ export async function executeWebChatConversationTurn(
         expandedToolNames,
         expandOnMiss: true,
         persistDiscovery: true,
+        // Re-read the advertised catalog from live session state
+        // between provider calls. This is what makes
+        // `workflow.enterPlan`'s stage flip from `idle → plan`
+        // actually take effect on the next provider call — without
+        // this, the catalog is frozen at the top of the user turn.
+        ...(resolveAdvertisedToolNames
+          ? {
+              resolveAdvertisedToolNames: () => {
+                const latestProfile =
+                  resolveSessionShellProfile(session.metadata);
+                const latestInteractive =
+                  session.metadata["interactiveContextState"] as
+                    | InteractiveContextState
+                    | undefined;
+                return (
+                  resolveAdvertisedToolNames(
+                    msg.sessionId,
+                    latestProfile,
+                    latestInteractive?.discoveredToolNames,
+                  ) ?? []
+                );
+              },
+            }
+          : {}),
       },
       trace: {
         ...(traceConfig.enabled && traceConfig.includeProviderPayloads

--- a/runtime/src/llm/chat-executor-tool-loop.ts
+++ b/runtime/src/llm/chat-executor-tool-loop.ts
@@ -670,6 +670,37 @@ export async function executeToolCallLoop(
       }
     }
 
+    // Re-resolve the advertised tool catalog against the current
+    // session state before the next follow-up call. Tools dispatched
+    // in the round above may have changed the session workflow stage
+    // (for example `workflow.enterPlan` flipping stage `idle → plan`),
+    // and plan mode's catalog filter must take effect on the very
+    // next provider call — not on the next user turn. Without this
+    // re-resolve the advertised catalog is frozen at turn start and
+    // plan mode cannot actually gate mutating tools mid-turn.
+    const resolveAdvertisedToolNames = ctx.toolRouting?.resolveAdvertisedToolNames;
+    if (resolveAdvertisedToolNames) {
+      const nextAdvertised = resolveAdvertisedToolNames();
+      const prev = ctx.activeRoutedToolNames;
+      const changed =
+        nextAdvertised.length !== prev.length ||
+        nextAdvertised.some((name, index) => name !== prev[index]);
+      if (changed) {
+        const previousRoutedToolNames = [...prev];
+        applyActiveRoutedToolNames(ctx, nextAdvertised);
+        callbacks.emitExecutionTrace(ctx, {
+          type: "route_expanded",
+          phase: "tool_followup",
+          callIndex: ctx.callIndex + 1,
+          payload: {
+            previousRoutedToolNames,
+            nextRoutedToolNames: ctx.activeRoutedToolNames,
+            reason: "session_state_refresh",
+          },
+        });
+      }
+    }
+
     // Phase A wire-up: run the layered compaction chain before the
     // follow-up provider call. Phase I wire-up: wrap the call in
     // reactive compaction recovery so a 413 triggers a retry with

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -250,6 +250,20 @@ export interface ChatExecuteParams {
     readonly expandOnMiss?: boolean;
     /** Enable discovery-driven widening for later model recalls in the same turn. */
     readonly persistDiscovery?: boolean;
+    /**
+     * Optional callback invoked before each follow-up provider call to
+     * re-resolve the advertised tool catalog against the current
+     * session state. When provided and it returns a list that differs
+     * from the initial `advertisedToolNames`, the executor updates
+     * `activeRoutedToolNames` for the next call. Primary motivation:
+     * workflow-stage changes made by tools mid-turn (e.g.
+     * `workflow.enterPlan` flipping stage from `idle` → `plan`) must
+     * take effect on the very next provider call, not just on the
+     * next user turn. Without this hook the catalog is frozen at turn
+     * start and plan mode can't actually gate mutating tools until a
+     * follow-up user message.
+     */
+    readonly resolveAdvertisedToolNames?: () => readonly string[];
   };
   /** Require at least one successful tool call before accepting a final answer. */
   readonly requiredToolEvidence?: {


### PR DESCRIPTION
## Summary

Completes the plan-mode enforcement chain. Plan-mode was still bypassed in practice because the advertised tool catalog is frozen at the top of each user turn — when the model calls \`workflow.enterPlan\` at call 1 to flip stage \`idle → plan\`, call 2 of the same turn still reuses the pre-computed catalog and happily advertises \`editFile\`, \`writeFile\`, \`mkdir\`, mutating \`bash\`, etc.

**Live trace from the last investigation turn:**
\`\`\`
call=1 workflow.enterPlan ✓ (stage → plan)
call=2 tools advertised: 24 (all 24, including mutating ones)  ← freeze
\`\`\`

## Fix

Opt-in resolver callback threaded through three layers:

1. **\`ChatExecuteParams.toolRouting.resolveAdvertisedToolNames?: () => readonly string[]\`** — optional callback. When set, executor re-invokes between provider calls.

2. **Chat executor tool loop** re-resolves right before \`runPerIterationCompactionBeforeModelCall\` so both compaction and the follow-up provider call see the updated catalog. Updates \`ctx.activeRoutedToolNames\` if result differs. Emits \`route_expanded\` trace event with \`reason: \"session_state_refresh\"\` for observability.

3. **Daemon webchat turn** passes a closure that re-reads session's current shell profile + interactive state and calls \`resolveAdvertisedToolNames(sessionId, profile, discovered)\` fresh. The catalog builder already reads \`workflowStage\` from session metadata (PR #466), so the plan-mode filter now fires mid-turn.

## Chain of plan-mode fixes

- PR #464 — workflow tools + catalog filter
- PR #466 — thread \`workflowStage\` into webchat catalog builder
- PR #467 — fix \`__agencSessionId\` injection so \`workflow.enterPlan\` actually runs
- **PR #469 (this)** — make the stage flip take effect mid-turn

## Test plan

- [x] \`npx tsc --noEmit\` clean in \`runtime/\`
- [x] 87 tests in chat-executor-tool-loop, chat-executor, chat-executor-routing-state, daemon-webchat-turn, tool-routing — all green
- [ ] Rebuild + restart, run \`\"come up with a /plan for M1\"\`, confirm from trace: call 1 advertises 24 tools → model calls \`workflow.enterPlan\` → call 2 advertises the plan-mode-filtered subset (no \`editFile\`/\`writeFile\`/\`mkdir\`/mutating\`bash\`)
- [ ] Confirm \`route_expanded\` trace event fires with \`reason: \"session_state_refresh\"\` on the catalog flip