### PR TITLE
Alias-aware session lookup so workflow.enterPlan actually flips the stage

### DIFF
--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -4069,7 +4069,14 @@ export class DaemonManager {
       resolveStopHookRuntime: () =>
         buildStopHookRuntime(this.gateway?.config.llm?.stopHooks),
       setSessionWorkflowStage: async ({ sessionId, stage, objective }) => {
-        const session = this._webSessionManager?.get(sessionId);
+        // Use alias-aware lookup: webchat tools receive
+        // `msg.sessionId` as the `__agencSessionId` arg, which is the
+        // `senderId` that `sessionMgr.getOrCreate` hashes into a
+        // different internal `session.id`. A direct `.get(sessionId)`
+        // always misses and the stage never actually flips.
+        const session =
+          this._webSessionManager?.getByIdOrSenderId(sessionId) ??
+          this._webSessionManager?.get(sessionId);
         if (!session) {
           return {
             applied: false,
@@ -6513,7 +6520,15 @@ export class DaemonManager {
     sessionId: string | undefined,
   ): SessionWorkflowStage | undefined {
     if (!sessionId) return undefined;
-    const metadata = this._webSessionManager?.get(sessionId)?.metadata;
+    // Alias-aware lookup mirrors `setSessionWorkflowStage` so reads
+    // and writes both hit the same session record. Without this the
+    // plan-mode catalog filter reads `undefined` and always treats
+    // the stage as not-plan, even right after `workflow.enterPlan`
+    // successfully flipped it.
+    const session =
+      this._webSessionManager?.getByIdOrSenderId(sessionId) ??
+      this._webSessionManager?.get(sessionId);
+    const metadata = session?.metadata;
     if (!metadata) return undefined;
     return resolveSessionWorkflowState(metadata).stage;
   }

--- a/runtime/src/gateway/session.ts
+++ b/runtime/src/gateway/session.ts
@@ -464,6 +464,27 @@ export class SessionManager {
     return this.sessions.get(sessionId);
   }
 
+  /**
+   * Lookup a session whose internal derived ID **or** lookup
+   * `senderId` matches the given key. Webchat tools receive
+   * `__agencSessionId` equal to the client-side `msg.sessionId`
+   * (which is the `senderId` passed to `getOrCreate`), not the
+   * internal id that `deriveSessionId` hashes it into — so a plain
+   * `get(msg.sessionId)` always misses. This helper bridges both
+   * keys, preferring the exact internal-id match.
+   */
+  getByIdOrSenderId(key: string): Session | undefined {
+    const direct = this.sessions.get(key);
+    if (direct) return direct;
+    for (const [id, session] of this.sessions) {
+      const params = this.lookups.get(id);
+      if (params?.senderId === key) {
+        return session;
+      }
+    }
+    return undefined;
+  }
+
   /** Clear a session's history but preserve metadata. */
   reset(sessionId: string): boolean {
     const session = this.sessions.get(sessionId);


### PR DESCRIPTION
Fifth in the plan-mode fix chain — see commit message for full context. After this: webchat tools that operate on session metadata (workflow stage today, others in the future) resolve correctly via either the internal derived session.id OR the client-visible senderId.