### PR TITLE
Route all webchat session lookups through alias-aware helper

### DIFF
--- a/runtime/src/gateway/daemon-command-registry.test.ts
+++ b/runtime/src/gateway/daemon-command-registry.test.ts
@@ -584,6 +584,7 @@ function makeCommandRegistry(params?: {
     },
     {
       get: () => session,
+      getByIdOrSenderId: () => session,
     } as any,
     (value) => value,
     providers as any,

--- a/runtime/src/gateway/daemon-command-registry.ts
+++ b/runtime/src/gateway/daemon-command-registry.ts
@@ -1960,7 +1960,7 @@ export function createDaemonCommandRegistry(
 
       // Build breakdown
       const sessionId = resolveSessionId(cmdCtx.sessionId);
-      const session = sessionMgr.get(sessionId);
+      const session = sessionMgr.getByIdOrSenderId(sessionId);
       const systemPrompt = ctx.getSystemPrompt();
       const usageSnapshot = buildCurrentContextUsageSnapshot({
         messages: buildCurrentApiView({
@@ -2113,7 +2113,7 @@ export function createDaemonCommandRegistry(
     },
     handler: async (cmdCtx) => {
       const sessionId = resolveSessionId(cmdCtx.sessionId);
-      const session = sessionMgr.get(sessionId);
+      const session = sessionMgr.getByIdOrSenderId(sessionId);
       const historyLen = session?.history.length ?? 0;
       const providerNames =
         providers.map((provider) => provider.name).join(" → ") || "none";
@@ -2187,7 +2187,7 @@ export function createDaemonCommandRegistry(
     },
     handler: async (cmdCtx) => {
       const sessionId = resolveSessionId(cmdCtx.sessionId);
-      const session = sessionMgr.get(sessionId);
+      const session = sessionMgr.getByIdOrSenderId(sessionId);
       if (!session) {
         await cmdCtx.reply("No active session.");
         return;
@@ -2963,7 +2963,7 @@ export function createDaemonCommandRegistry(
           : "No diff content to review.",
       ].join("\n");
       const resolvedSessionId = resolveSessionId(cmdCtx.sessionId);
-      const session = sessionMgr.get(resolvedSessionId);
+      const session = sessionMgr.getByIdOrSenderId(resolvedSessionId);
       const effectiveShellProfile = resolveEffectiveShellProfileForSession({
         ctx,
         sessionId: resolvedSessionId,
@@ -3069,7 +3069,7 @@ export function createDaemonCommandRegistry(
     },
     handler: async (cmdCtx) => {
       const sessionId = resolveSessionId(cmdCtx.sessionId);
-      const session = sessionMgr.get(sessionId);
+      const session = sessionMgr.getByIdOrSenderId(sessionId);
       if (!session) {
         await cmdCtx.reply("No active session.");
         return;
@@ -3416,7 +3416,7 @@ export function createDaemonCommandRegistry(
     },
     handler: async (cmdCtx) => {
       const sessionId = resolveSessionId(cmdCtx.sessionId);
-      const session = sessionMgr.get(sessionId);
+      const session = sessionMgr.getByIdOrSenderId(sessionId);
       if (!session) {
         await cmdCtx.reply("No active session.");
         return;
@@ -3760,7 +3760,7 @@ export function createDaemonCommandRegistry(
     },
     handler: async (cmdCtx) => {
       const resolvedSessionId = resolveSessionId(cmdCtx.sessionId);
-      const session = sessionMgr.get(resolvedSessionId);
+      const session = sessionMgr.getByIdOrSenderId(resolvedSessionId);
       if (!session) {
         await cmdCtx.reply("No active session.");
         return;
@@ -3926,7 +3926,7 @@ export function createDaemonCommandRegistry(
       const webChat = ctx.getWebChatChannel();
       const replyCurrentSession = async (): Promise<void> => {
         const resolvedSessionId = resolveSessionId(cmdCtx.sessionId);
-        const session = sessionMgr.get(resolvedSessionId);
+        const session = sessionMgr.getByIdOrSenderId(resolvedSessionId);
         const workspaceRoot =
           (session?.metadata?.workspaceRoot as string | undefined) ??
           (typeof webChat?.loadSessionWorkspaceRoot === "function"
@@ -4203,7 +4203,7 @@ export function createDaemonCommandRegistry(
       }
       const subcommand = cmdCtx.argv[0]?.toLowerCase() ?? "status";
       const sessionId = resolveSessionId(cmdCtx.sessionId);
-      const session = sessionMgr.get(sessionId);
+      const session = sessionMgr.getByIdOrSenderId(sessionId);
       const responseAnchor = getSessionResumeAnchorResponseId(session);
       const preferredProviderName =
         ctx.getSessionModelInfo(cmdCtx.sessionId)?.provider ??

--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -3729,6 +3729,14 @@ describe("DaemonManager", () => {
           },
         },
       })),
+      getByIdOrSenderId: vi.fn(() => ({
+        metadata: {
+          policyContext: {
+            tenantId: "tenant-session",
+            projectId: "project-session",
+          },
+        },
+      })),
     };
     (dm as any)._policyEngine = { simulate };
     (dm as any)._approvalEngine = {

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -2553,7 +2553,7 @@ export class DaemonManager {
             ).stage,
           ),
         seedHistoryForSession: (sessionId) =>
-          sessionMgr.get(sessionId)?.history ?? [],
+          sessionMgr.getByIdOrSenderId(sessionId)?.history ?? [],
         readTodosForSession: async (sessionId) =>
           this._todoStore ? await this._todoStore.getTodos(sessionId) : [],
         readTasksForSession: async (sessionId) => {
@@ -4076,7 +4076,7 @@ export class DaemonManager {
         // always misses and the stage never actually flips.
         const session =
           this._webSessionManager?.getByIdOrSenderId(sessionId) ??
-          this._webSessionManager?.get(sessionId);
+          this._webSessionManager?.getByIdOrSenderId(sessionId);
         if (!session) {
           return {
             applied: false,
@@ -5454,7 +5454,7 @@ export class DaemonManager {
     workflowStage?: SessionWorkflowStage;
     workflowOwnershipSummary?: string;
   } {
-    const session = this._webSessionManager?.get(sessionId);
+    const session = this._webSessionManager?.getByIdOrSenderId(sessionId);
     const metadata = session?.metadata;
     if (!metadata || typeof metadata !== "object") {
       return {};
@@ -5602,7 +5602,7 @@ export class DaemonManager {
     if (!executor) {
       return null;
     }
-    const session = this._webSessionManager?.get(sessionId);
+    const session = this._webSessionManager?.getByIdOrSenderId(sessionId);
 
     const totalTokens = executor.getSessionTokenUsage(sessionId);
     const sessionCostUsd =
@@ -5909,7 +5909,7 @@ export class DaemonManager {
   private extractSessionPolicyContext(
     sessionId: string,
   ): { tenantId?: string; projectId?: string } | undefined {
-    const metadata = this._webSessionManager?.get(sessionId)?.metadata;
+    const metadata = this._webSessionManager?.getByIdOrSenderId(sessionId)?.metadata;
     if (!metadata || typeof metadata !== "object") {
       return undefined;
     }
@@ -6501,7 +6501,7 @@ export class DaemonManager {
   private getDiscoveredToolNamesForSession(
     sessionId: string,
   ): readonly string[] {
-    const metadata = this._webSessionManager?.get(sessionId)?.metadata;
+    const metadata = this._webSessionManager?.getByIdOrSenderId(sessionId)?.metadata;
     const interactiveState = coerceInteractiveContextState(
       metadata?.interactiveContextState,
     );
@@ -6527,7 +6527,7 @@ export class DaemonManager {
     // successfully flipped it.
     const session =
       this._webSessionManager?.getByIdOrSenderId(sessionId) ??
-      this._webSessionManager?.get(sessionId);
+      this._webSessionManager?.getByIdOrSenderId(sessionId);
     const metadata = session?.metadata;
     if (!metadata) return undefined;
     return resolveSessionWorkflowState(metadata).stage;
@@ -6983,7 +6983,7 @@ export class DaemonManager {
     const inFlightToolArgs = new Map<string, Record<string, unknown>>();
     const effectiveShellProfile = this.resolveEffectiveShellProfile({
       sessionId,
-      metadata: this._webSessionManager?.get(sessionId)?.metadata ?? {},
+      metadata: this._webSessionManager?.getByIdOrSenderId(sessionId)?.metadata ?? {},
       preferred: shellProfile,
     });
     const advertisedShellProfile = this.evaluateShellFeatureAdmission({


### PR DESCRIPTION
Completes #470/#471. 17 inline sessionMgr.get(sessionId) call sites across daemon.ts + daemon-command-registry.ts batch-replaced with getByIdOrSenderId. Fixes /plan slash command and 8 other session-touching slash commands.