### PR TITLE
/plan <text> shortcut auto-exits plan mode after the turn

### DIFF
--- a/runtime/src/gateway/daemon-command-registry.ts
+++ b/runtime/src/gateway/daemon-command-registry.ts
@@ -3588,6 +3588,17 @@ export function createDaemonCommandRegistry(
           typeof jsonArgs?.worktreeMode === "string"
             ? jsonArgs.worktreeMode
             : parseInlineFlag(cmdCtx.argv, "worktrees");
+        // `oneshot: true` (set by the TUI's `/plan <free text>`
+        // shortcut) tells the daemon to auto-restore the prior
+        // workflow stage after the next webchat turn completes —
+        // otherwise the user's single-shot `/plan come up with a
+        // plan for X` would leave the session stuck in plan mode for
+        // every subsequent message until they manually `/plan exit`.
+        // Bare `/plan` (no JSON args) keeps its sticky toggle
+        // behavior so an explicit user intent to enter plan mode is
+        // respected.
+        const oneshotRequested = jsonArgs?.oneshot === true;
+        const priorStageBeforeFlip = currentWorkflowState.stage;
         const workflowState = updateSessionWorkflowState(
           session.metadata,
           {
@@ -3603,9 +3614,14 @@ export function createDaemonCommandRegistry(
             ...(objective !== undefined ? { objective } : {}),
           },
         );
+        if (oneshotRequested) {
+          (session.metadata as Record<string, unknown>).__planOneshotPending = true;
+          (session.metadata as Record<string, unknown>).__planOneshotPriorStage =
+            priorStageBeforeFlip;
+        }
         await persistWebSessionRuntimeState(memoryBackend, cmdCtx.sessionId, session);
         await cmdCtx.replyResult({
-          text: `Workflow stage set to ${formatSessionWorkflowStage(workflowState.stage)}.\n\n${formatPlanSurface(workflowState)}`,
+          text: `Workflow stage set to ${formatSessionWorkflowStage(workflowState.stage)}${oneshotRequested ? " (one-shot)" : ""}.\n\n${formatPlanSurface(workflowState)}`,
           viewKind: "workflow",
           data: buildPlanData(workflowState),
         });

--- a/runtime/src/gateway/daemon-webchat-turn.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.ts
@@ -70,6 +70,10 @@ import {
   type SessionManager,
 } from "./session.js";
 import { appendShellProfilePromptSection } from "./shell-profile.js";
+import {
+  updateSessionWorkflowState,
+  type SessionWorkflowStage,
+} from "./workflow-state.js";
 import type { ToolRoutingDecision } from "./tool-routing.js";
 import { resolveTurnMaxToolRounds } from "./tool-round-budget.js";
 import { buildAssistantDelegatedScopeMetadata } from "../utils/delegated-scope-trust.js";
@@ -274,6 +278,22 @@ export async function executeWebChatConversationTurn(
         msg.metadata?.[SESSION_SHELL_PROFILE_METADATA_KEY],
     });
     const shellProfile = resolveSessionShellProfile(session.metadata);
+    // One-shot plan-mode capture: the `/plan {"oneshot":true}` shortcut
+    // sets `__planOneshotPending` on session metadata. Move it to a
+    // turn-local flag here so subsequent turns don't keep auto-
+    // exiting, and remember the prior stage so we can restore it
+    // when this turn ends. See PR #473/#474/#477 et al for the
+    // shortcut wiring.
+    const sessionMetaAny = session.metadata as Record<string, unknown>;
+    const oneshotPlanActive =
+      sessionMetaAny.__planOneshotPending === true;
+    const oneshotPlanPriorStage =
+      typeof sessionMetaAny.__planOneshotPriorStage === "string"
+        ? (sessionMetaAny.__planOneshotPriorStage as string)
+        : undefined;
+    if (oneshotPlanActive) {
+      delete sessionMetaAny.__planOneshotPending;
+    }
     const existingInteractiveState =
       session.metadata["interactiveContextState"] as
         | InteractiveContextState
@@ -750,6 +770,21 @@ export async function executeWebChatConversationTurn(
           ]
         : []),
     ]);
+    // One-shot plan-mode auto-exit: if this turn was kicked off via
+    // `/plan {"oneshot":true}` (see capture above), restore the
+    // workflow stage to whatever it was before the flip so the user
+    // is not stuck in plan mode for every follow-up message. Runs
+    // before the persist so the restored stage is what gets stored.
+    if (oneshotPlanActive) {
+      const validStages = new Set(["idle", "plan", "implement", "review", "verify"]);
+      const restoreStage = (
+        oneshotPlanPriorStage && validStages.has(oneshotPlanPriorStage)
+          ? oneshotPlanPriorStage
+          : "idle"
+      ) as SessionWorkflowStage;
+      updateSessionWorkflowState(session.metadata, { stage: restoreStage });
+      delete (session.metadata as Record<string, unknown>).__planOneshotPriorStage;
+    }
     await persistWebSessionRuntimeState(memoryBackend, msg.sessionId, session);
 
     await webChat.send({

--- a/runtime/src/watch/agenc-watch-commands.mjs
+++ b/runtime/src/watch/agenc-watch-commands.mjs
@@ -1798,11 +1798,19 @@ export function createWatchCommandController(dependencies = {}) {
         const first = parsedSlash.args[0]?.toLowerCase() ?? "";
         if (parsedSlash.args.length > 0 && !workflowSubcommands.has(first)) {
           const freeText = parsedSlash.args.join(" ").trim();
-          dispatchSessionCommand("/plan", {
-            title: "Plan Mode",
-            body: "Entering plan mode before submitting prompt.",
-            allowBootstrapQueue: false,
-          });
+          // `oneshot: true` tells the daemon to auto-restore the prior
+          // workflow stage after this turn completes, so the user's
+          // single `/plan <text>` invocation doesn't leave the session
+          // stuck in plan mode for every subsequent message. Bare
+          // `/plan` (no free text) keeps its sticky toggle behavior.
+          dispatchSessionCommand(
+            '/plan {"subcommand":"enter","oneshot":true}',
+            {
+              title: "Plan Mode",
+              body: "Entering plan mode (one-shot) before submitting prompt.",
+              allowBootstrapQueue: false,
+            },
+          );
           // The daemon's `session.command.execute` and `chat.message`
           // handlers run on separate async paths, so Node's event loop
           // can (and does) interleave the chat handler in the middle


### PR DESCRIPTION
Per Claude Code's prePlanMode restoration semantics. /plan <text> shortcut sets oneshot=true; daemon stashes prior stage and restores it after the next webchat turn ends. Bare /plan stays sticky.