### PR TITLE
fix(runtime): plan-mode stop-gate skip + bounded retries + drop older tool results

### DIFF
--- a/runtime/src/gateway/daemon-webchat-turn.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.ts
@@ -71,6 +71,7 @@ import {
 } from "./session.js";
 import { appendShellProfilePromptSection } from "./shell-profile.js";
 import {
+  resolveSessionWorkflowState,
   updateSessionWorkflowState,
   type SessionWorkflowStage,
 } from "./workflow-state.js";
@@ -480,17 +481,26 @@ export async function executeWebChatConversationTurn(
       history: effectiveHistory,
       promptEnvelope,
       sessionId: msg.sessionId,
-      runtimeContext:
-        typeof runtimeWorkspaceRoot === "string" || sessionActiveTaskContext
-          ? {
-              ...(typeof runtimeWorkspaceRoot === "string"
-                ? { workspaceRoot: runtimeWorkspaceRoot }
-                : {}),
-              ...(sessionActiveTaskContext
-                ? { activeTaskContext: sessionActiveTaskContext }
-                : {}),
-            }
-          : undefined,
+      runtimeContext: (() => {
+        const turnWorkflowStage =
+          resolveSessionWorkflowState(session.metadata).stage;
+        if (
+          typeof runtimeWorkspaceRoot !== "string" &&
+          !sessionActiveTaskContext &&
+          turnWorkflowStage === "idle"
+        ) {
+          return undefined;
+        }
+        return {
+          ...(typeof runtimeWorkspaceRoot === "string"
+            ? { workspaceRoot: runtimeWorkspaceRoot }
+            : {}),
+          ...(sessionActiveTaskContext
+            ? { activeTaskContext: sessionActiveTaskContext }
+            : {}),
+          workflowStage: turnWorkflowStage,
+        };
+      })(),
       ...(atMentionAttachments.executionEnvelope
         ? {
             requiredToolEvidence: {

--- a/runtime/src/llm/chat-executor-completion-recovery.ts
+++ b/runtime/src/llm/chat-executor-completion-recovery.ts
@@ -75,6 +75,18 @@ export interface CompletionRecoveryResult {
   readonly recovered: boolean;
 }
 
+/**
+ * Default cap on stop-hook recovery retries when neither the
+ * stopHookRuntime nor requiredToolEvidence supplies an explicit value.
+ * Without this default the cap was `undefined` (= unlimited), so a
+ * single misclassified `narrated_future_tool_work` rejection could
+ * pump the model into hundreds of `tool_choice: required` rounds with
+ * no exit. Two attempts is enough for a real recovery (one nudge, one
+ * retry) without becoming an infinite retry pump on detector
+ * misfires.
+ */
+const DEFAULT_COMPLETION_RECOVERY_MAX_ATTEMPTS = 2;
+
 export async function attemptCompletionRecovery(
   params: CompletionRecoveryParams,
 ): Promise<CompletionRecoveryResult> {
@@ -82,7 +94,7 @@ export async function attemptCompletionRecovery(
   const continuationCap =
     params.maxAttempts !== undefined
       ? Math.max(0, params.maxAttempts)
-      : undefined;
+      : DEFAULT_COMPLETION_RECOVERY_MAX_ATTEMPTS;
   const shouldExhaustForDiminishingReturns = shouldStopForDiminishingReturns(
     ctx.continuationState,
   );

--- a/runtime/src/llm/chat-executor-stop-gate-evaluation.ts
+++ b/runtime/src/llm/chat-executor-stop-gate-evaluation.ts
@@ -82,6 +82,19 @@ export async function evaluateTurnEndStopGate(
   ) {
     return { shouldContinueLoop: false };
   }
+  // Plan-mode is read-only and the user explicitly asked for a plan as
+  // text (e.g. `/plan come up with a plan for M1`). The
+  // `narrated_future_tool_work` and `truncated_success_claim` detectors
+  // that the stop-gate fires are designed for execution flows where the
+  // assistant should be calling mutation tools instead of describing
+  // them. Forcing plan-mode answers through that gate causes the
+  // detector to reject the plan as a "checkpoint" and pump the model
+  // into endless `tool_choice: required` recovery rounds reading the
+  // same files over and over. Skip the gate entirely when the active
+  // workflow stage is `plan`.
+  if (ctx.runtimeWorkflowStage === "plan") {
+    return { shouldContinueLoop: false };
+  }
 
   const continuationSummary = ctx.continuationState.active
     ? emitContinuationEvaluation()

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -210,6 +210,15 @@ export interface ChatExecuteParams {
     readonly workspaceRoot?: string;
     /** Typed active-task carryover used only when the current turn explicitly continues that task. */
     readonly activeTaskContext?: ActiveTaskContext;
+    /**
+     * Active session workflow stage (idle/plan/implement/review/verify).
+     * When `"plan"`, the stop-gate is suppressed because plan-mode answers
+     * are inherently text-only — the user asked for a plan, the assistant
+     * delivers one as the final reply, and the `narrated_future_tool_work`
+     * detector would otherwise misclassify the plan as a checkpoint and
+     * force endless `tool_choice: required` recovery rounds.
+     */
+    readonly workflowStage?: string;
   };
   /** Per-call tool handler — overrides the constructor handler for this call. */
   readonly toolHandler?: ToolHandler;
@@ -631,6 +640,8 @@ export interface ExecutionContext {
   readonly sessionId: string;
   readonly structuredOutput?: ChatExecuteParams["structuredOutput"];
   readonly runtimeWorkspaceRoot?: string;
+  /** Active workflow stage at turn start (e.g. "plan"); see ChatExecuteParams.runtimeContext.workflowStage. */
+  readonly runtimeWorkflowStage?: string;
   readonly turnExecutionContract: TurnExecutionContract;
   readonly signal?: AbortSignal;
   readonly activeToolHandler?: ToolHandler;
@@ -777,6 +788,7 @@ export function buildDefaultExecutionContext(
     structuredOutput: params.structuredOutput,
     runtimeWorkspaceRoot:
       params.turnExecutionContract.workspaceRoot ?? params.runtimeContext?.workspaceRoot,
+    runtimeWorkflowStage: params.runtimeContext?.workflowStage,
     turnExecutionContract: params.turnExecutionContract,
     signal: params.signal,
     activeToolHandler: params.toolHandler,

--- a/runtime/src/llm/prompt-budget.test.ts
+++ b/runtime/src/llm/prompt-budget.test.ts
@@ -113,6 +113,11 @@ describe("prompt-budget", () => {
 
     expect(result.diagnostics.constrained).toBe(true);
     expect(result.diagnostics.sections.history.droppedMessages).toBeGreaterThan(0);
-    expect(result.diagnostics.sections.tools.truncatedMessages).toBeGreaterThan(0);
+    // Tools section now drops older entries entirely instead of
+    // truncating each message to a misleading prefix. The model gets
+    // the most recent reads in full and an honest absence for the
+    // older ones rather than a useless half-shown clipboard view that
+    // induces re-reads.
+    expect(result.diagnostics.sections.tools.droppedMessages).toBeGreaterThan(0);
   });
 });

--- a/runtime/src/llm/prompt-budget.ts
+++ b/runtime/src/llm/prompt-budget.ts
@@ -168,7 +168,17 @@ const SECTION_BEHAVIOR: Record<PromptBudgetSection, SectionBehavior> = {
   memory_episodic: { dropAllowed: true, newestFirst: true },
   memory_semantic: { dropAllowed: true, newestFirst: true },
   history: { dropAllowed: true, newestFirst: true },
-  tools: { dropAllowed: false, newestFirst: false },
+  // Drop older tool results entirely instead of truncating each one to a
+  // useless prefix. Per-message truncation (the previous
+  // `dropAllowed:false` behavior) divided the tools cap evenly across N
+  // tool messages, so on a turn with 16 readFile results each one was
+  // clipped to ~1.4KB. The model then saw a half-shown prefix of every
+  // prior read and could not tell whether the line it needed was in the
+  // truncated tail — so it re-read the file. Dropping older entries
+  // keeps the most recent reads intact (model has accurate context for
+  // its current reasoning) and the absence of the older entries is
+  // honest signal rather than a misleading prefix.
+  tools: { dropAllowed: true, newestFirst: true },
   user: { dropAllowed: false, newestFirst: false },
   assistant_runtime: { dropAllowed: false, newestFirst: false },
   other: { dropAllowed: true, newestFirst: true },


### PR DESCRIPTION
Three coordinated fixes uncovered by trace investigation of a 97-call plan-mode loop the user had to kill manually.

## Trace evidence

User asked '/plan come up with a plan for M1'. At call 8 the model produced the actual 4374-char plan. The turn_end_stop_gate misclassified it as `narrated_future_tool_work` and injected a blocking 'Call the tools, do not preview' user message. From call 9 onward the non-reasoning Grok complied literally — emitted only `Calling tool.` filler and re-read the same files (lexer.c x9, PLAN.md x7, multiple files x4) for 89 more rounds before the user killed it.

Three compounding bugs, all fixed:

1. **Skip stop-gate in plan mode** (`chat-executor-stop-gate-evaluation.ts`). Plan mode is read-only and the user explicitly asked for a plan as text. The `narrated_future_tool_work` and `truncated_success_claim` detectors target execution flows; firing them on a plan answer is a category error.

2. **Default stop-hook recovery cap to 2** (`chat-executor-completion-recovery.ts`). The cap was `undefined` (= unlimited) unless an opt-in field was set. Two attempts allows one nudge plus one retry without becoming an infinite retry pump on detector misfires.

3. **Drop older tool results entirely** (`prompt-budget.ts`). The tools section was non-droppable, so per-message truncation clipped every prior read to ~1.4KB. The model saw a useless half-shown prefix of every prior `system.readFile` result and could not tell what was in the truncated tail — so it re-read. Dropping older entries keeps the most recent reads in full and gives the model honest absence signal.

Also wires `runtimeContext.workflowStage` through `ChatExecuteParams` so the stop-gate has the signal it needs.

## Test plan

- [x] runtime LLM suite: 858/858 pass
- [x] prompt-budget test updated to reflect new drop-instead-of-truncate behavior
- [ ] Re-run `/plan come up with a plan for M1` and verify turn completes at <20 calls with the actual plan as final reply, not a tool-call loop