### PR TITLE
fix(runtime): stop-gate report-aware suppression + per-session serialization + repeat-read defenses

### DIFF
--- a/runtime/src/gateway/daemon-webchat-turn.test.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.test.ts
@@ -801,6 +801,11 @@ You have broad access to this machine via the system.bash tool.`,
       expect.objectContaining({
         runtimeContext: {
           workspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
+          // workflowStage is plumbed through so the chat-executor stop-gate
+          // can suppress the narrated_future_tool_work detector when the
+          // session is in plan mode (PR #481) and so user-asked-for-report
+          // suppression has access to the live session stage if needed.
+          workflowStage: "idle",
         },
         message: expect.objectContaining({
           metadata: expect.objectContaining({

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -1033,6 +1033,26 @@ export class DaemonManager {
     | null = null;
   private _sessionCredentialBroker: SessionCredentialBroker | null = null;
   private _webSessionManager: SessionManager | null = null;
+  /**
+   * Per-session inbound serialization queue. Two messages on the same
+   * session that arrive close together (e.g. the TUI dispatching `/plan
+   * {oneshot:true}` followed by the actual chat text 60ms later, or
+   * any user double-tap) used to interleave async handlers because
+   * `handleWebChatInboundMessage` was fire-and-forget. The chat
+   * handler's session.metadata read could race the command handler's
+   * write, breaking the one-shot plan-mode flag and any other
+   * mid-handler state.
+   *
+   * Each session keeps a tail Promise; new inbound work chains onto
+   * the tail so messages are processed strictly in arrival order on
+   * each session. Cross-session work remains parallel. Cleared when a
+   * session's chain settles to keep the map bounded.
+   *
+   * Replaces the 300ms `setTimeout` band-aid in PR #476 with a real
+   * runtime-level guarantee.
+   */
+  private readonly _webSessionInboundChain: Map<string, Promise<void>> =
+    new Map();
   private _telemetry: UnifiedTelemetryCollector | null = null;
   private _incidentDiagnostics: RuntimeIncidentDiagnostics | null = null;
   private _hookDispatcher: HookDispatcher | null = null;
@@ -6715,8 +6735,20 @@ export class DaemonManager {
   private createWebChatMessageHandler(
     params: WebChatMessageHandlerDeps,
   ): (msg: GatewayMessage) => Promise<void> {
-    return async (msg: GatewayMessage): Promise<void> =>
-      this.handleWebChatInboundMessage(msg, params);
+    return (msg: GatewayMessage): Promise<void> => {
+      const key = msg.sessionId;
+      const prior = this._webSessionInboundChain.get(key) ?? Promise.resolve();
+      const next = prior
+        .catch(() => undefined)
+        .then(() => this.handleWebChatInboundMessage(msg, params));
+      this._webSessionInboundChain.set(key, next);
+      void next.finally(() => {
+        if (this._webSessionInboundChain.get(key) === next) {
+          this._webSessionInboundChain.delete(key);
+        }
+      });
+      return next;
+    };
   }
 
   private createTracedSessionToolHandler(params: {

--- a/runtime/src/llm/chat-executor-recovery.ts
+++ b/runtime/src/llm/chat-executor-recovery.ts
@@ -1128,6 +1128,11 @@ export function buildRecoveryHints(
     emittedHints.add(roundHint.key);
     hints.push(roundHint);
   }
+  const repeatReadHint = inferRepeatReadFileHint(recentCalls);
+  if (repeatReadHint && !emittedHints.has(repeatReadHint.key)) {
+    emittedHints.add(repeatReadHint.key);
+    hints.push(repeatReadHint);
+  }
   for (const call of roundCalls) {
     const hint = inferRecoveryHint(call);
     if (!hint) continue;
@@ -1136,6 +1141,58 @@ export function buildRecoveryHints(
     hints.push(hint);
   }
   return hints;
+}
+
+/**
+ * Repeat-read-on-success detector. Every other recovery-hint branch
+ * gates on `didToolCallFail`, so a model that cheerfully calls
+ * `system.readFile` on the same path 9 times in one turn (because it
+ * keeps deciding the prior content might be stale) emits zero hints
+ * and zero stall escalations. PR #481 fixed the cost driver
+ * (truncated tool results making prior reads look incomplete), but
+ * the runtime still has no defense if the model self-induces a read
+ * loop for any other reason.
+ *
+ * When the same file path appears as a successful `system.readFile`
+ * target three or more times in the recent-call window, inject a
+ * single hint reminding the model that the prior content is still in
+ * its context. The hint is keyed by tool+path so it dedupes across
+ * rounds and only nudges once per loop.
+ */
+function inferRepeatReadFileHint(
+  recentCalls: readonly ToolCallRecord[],
+): RecoveryHint | undefined {
+  const REPEAT_READ_THRESHOLD = 3;
+  const counts = new Map<string, number>();
+  for (const call of recentCalls) {
+    if (call.tool !== "system.readFile") continue;
+    if (didToolCallFail(call.isError, call.result)) continue;
+    const argsObject =
+      call.args && typeof call.args === "object"
+        ? (call.args as Record<string, unknown>)
+        : undefined;
+    const path = argsObject?.path;
+    if (typeof path !== "string" || path.length === 0) continue;
+    counts.set(path, (counts.get(path) ?? 0) + 1);
+  }
+  let loopedPath: string | undefined;
+  let loopedCount = 0;
+  for (const [path, count] of counts) {
+    if (count < REPEAT_READ_THRESHOLD) continue;
+    if (count > loopedCount) {
+      loopedPath = path;
+      loopedCount = count;
+    }
+  }
+  if (!loopedPath) return undefined;
+  return {
+    key: `system-readfile-repeat:${loopedPath}`,
+    message:
+      `You have called system.readFile on \`${loopedPath}\` ${loopedCount} times in this turn. ` +
+      "The full content from the most recent successful read is still in your conversation context — " +
+      "use the prior tool_result instead of re-reading. If you genuinely need a different region, " +
+      "pass an explicit `offset`/`limit` to read a different slice; otherwise move on to the next step.",
+  };
 }
 
 function inferRoundRecoveryHint(

--- a/runtime/src/llm/chat-executor-stop-gate-evaluation.ts
+++ b/runtime/src/llm/chat-executor-stop-gate-evaluation.ts
@@ -170,6 +170,7 @@ export async function evaluateTurnEndStopGate(
         sessionId: ctx.sessionId,
         runtimeWorkspaceRoot: ctx.runtimeWorkspaceRoot,
         finalContent: ctx.response?.content ?? "",
+        userMessageText: ctx.messageText,
         allToolCalls: ctx.allToolCalls,
         turnEndSnapshot: buildTurnEndStopGateSnapshot(ctx.allToolCalls),
         runtimeChecks: {

--- a/runtime/src/llm/chat-executor-stop-gate.ts
+++ b/runtime/src/llm/chat-executor-stop-gate.ts
@@ -193,6 +193,42 @@ const TERMINAL_COMPLETION_RE =
   /\b(?:task\s+(?:complete|completed|done|finished)|all\s+phases?\s+(?:complete|completed|done|finished|implemented)|all\s+phases?\s+of\s+[^\n]{0,120}?\s+have\s+been\s+(?:complete|completed|done|finished|implemented)|all\s+phases?\b(?:[^.!?\n]{0,80})\b(?:complete|completed|done|finished|implemented)|implementation\s+(?:complete|completed|done|finished)|implementation\s+of\s+[^\n]{0,160}?\s+(?:is\s+)?(?:complete|completed|done|finished)|nothing\s+(?:more|else)\s+to\s+(?:do|implement)|session\s+(?:complete|done|finished)|finished\s+the\s+(?:task|work|implementation|plan)|project\s+(?:complete|completed|done|finished))/i;
 
 /**
+ * Patterns in the user's most recent message that explicitly request a
+ * textual report, list, summary, or gap analysis. When detected, the
+ * narration detector is suppressed for the resulting turn — the user
+ * asked for prose enumerating future or incomplete work, so an answer
+ * that mentions Phase 2, what's incomplete, or next milestones is
+ * exactly the requested output rather than a checkpoint.
+ *
+ * Observed false positive (PR pre-trace at 2026-04-19T08:06): user
+ * asked "verify Phase 1 builds and tests pass and report what's
+ * incomplete from the plan", model produced a full Verification
+ * Result + gap enumeration, stop-gate matched "Phase 2 (Token Model
+ * & Lexer Core) – only partially done" against
+ * NARRATED_FUTURE_TOOL_WORK_RE and pumped 2 retry rounds before the
+ * model surrendered with a watered-down "M1 Phase 1 is complete"
+ * handwave that DROPPED the requested gap enumeration entirely.
+ */
+const REPORT_REQUEST_RE =
+  /\b(?:report|list|enumerate|summari[sz]e|tell\s+me|explain|describe|what['']s\s+(?:incomplete|missing|left|remaining|unfinished|next|done|complete|finished|covered)|what\s+(?:is|are)\s+(?:incomplete|missing|left|remaining|unfinished|next|done|complete|finished|covered)|gaps?\b|status\s+(?:report|update|of|on))/i;
+
+/**
+ * Detects structured report output: a response that has at least two
+ * markdown headings (bold or hash) AND at least three bulleted list
+ * items. The combination is a strong signal that the model is producing
+ * a deliberate textual report rather than an off-the-cuff checkpoint.
+ * Used as a softener for the narration detector when the response also
+ * shows substantive prior tool work in the same turn.
+ */
+function looksLikeStructuredReport(finalContent: string): boolean {
+  const headingMatches =
+    finalContent.match(/(?:^|\n)\s*(?:#{1,6}\s+\S|\*\*[^*\n]{2,80}\*\*)/g) ?? [];
+  const bulletMatches =
+    finalContent.match(/(?:^|\n)\s*(?:[-*+]\s+\S|\d+\.\s+\S)/g) ?? [];
+  return headingMatches.length >= 2 && bulletMatches.length >= 3;
+}
+
+/**
  * Tool names whose failures count as "this turn had a failed shell
  * command", which is the strongest signal that a success claim is fake.
  * Reading file errors and lookup failures are excluded to avoid
@@ -278,6 +314,13 @@ export interface EvaluateTurnEndStopGateParams {
   readonly snapshot?: TurnEndStopGateSnapshot;
   readonly requiredToolEvidence?: ChatExecuteParams["requiredToolEvidence"];
   readonly runtimeContext?: ChatExecuteParams["runtimeContext"];
+  /**
+   * The user's most recent inbound message text for this turn. When the
+   * user explicitly asked for a report/list/gap-analysis the narration
+   * detector is suppressed because the answer is the requested output,
+   * not a checkpoint.
+   */
+  readonly userMessageText?: string;
 }
 
 export interface TurnEndStopGateSnapshot {
@@ -873,6 +916,9 @@ export function evaluateTurnEndStopGate(
       refusedCalls,
       evidence,
       requiredToolEvidence: params.requiredToolEvidence,
+      ...(typeof params.userMessageText === "string"
+        ? { userMessageText: params.userMessageText }
+        : {}),
     });
   }
 
@@ -967,6 +1013,9 @@ export function evaluateTurnEndStopGate(
     refusedCalls,
     evidence,
     requiredToolEvidence: params.requiredToolEvidence,
+    ...(typeof params.userMessageText === "string"
+      ? { userMessageText: params.userMessageText }
+      : {}),
   });
 }
 
@@ -1153,6 +1202,7 @@ function maybeFireNarratedFutureToolWork(params: {
   readonly refusedCalls: readonly ToolCallRecord[];
   readonly evidence: StopGateEvidence;
   readonly requiredToolEvidence?: ChatExecuteParams["requiredToolEvidence"];
+  readonly userMessageText?: string;
 }): StopGateInterventionDecision {
   const trimmed = params.finalContent.trimEnd();
   if (params.allToolCalls.length === 0) {
@@ -1164,6 +1214,30 @@ function maybeFireNarratedFutureToolWork(params: {
   const narrated = NARRATED_FUTURE_TOOL_WORK_RE.test(params.finalContent);
   const permissionQuestion = MID_TASK_PERMISSION_QUESTION_RE.test(trimmed);
   if (!narrated && !permissionQuestion) {
+    return { shouldIntervene: false, evidence: params.evidence };
+  }
+  // The user explicitly asked for a textual report/list/gap-analysis
+  // reply. Whatever the model produced — including phrasing like "Phase
+  // 2 is the next milestone" or "X is partially done" — is the
+  // requested deliverable, not a checkpoint to recover from. Skip the
+  // narration detector entirely so we don't pump retry rounds against
+  // the user's own request.
+  if (
+    typeof params.userMessageText === "string" &&
+    REPORT_REQUEST_RE.test(params.userMessageText)
+  ) {
+    return { shouldIntervene: false, evidence: params.evidence };
+  }
+  // Structured-report softener: when the model produced a multi-heading
+  // bulleted report AND the turn already did substantive tool work
+  // (>= 5 calls), trust that the prose is the deliberate report and
+  // skip the narration detector. This catches gap-enumeration outputs
+  // even when the user's prompt didn't use the explicit "report"
+  // wording the regex above looks for.
+  if (
+    params.allToolCalls.length >= 5 &&
+    looksLikeStructuredReport(params.finalContent)
+  ) {
     return { shouldIntervene: false, evidence: params.evidence };
   }
   if (

--- a/runtime/src/llm/hooks/stop-hooks.ts
+++ b/runtime/src/llm/hooks/stop-hooks.ts
@@ -70,6 +70,13 @@ export interface StopHookContext {
   readonly sessionId: string;
   readonly runtimeWorkspaceRoot?: string;
   readonly finalContent?: string;
+  /**
+   * The user's most recent inbound message text for this turn. Used by
+   * the turn_end_stop_gate's narration detector to suppress
+   * intervention when the user explicitly asked for a textual report,
+   * list, gap analysis, or "what's incomplete" enumeration.
+   */
+  readonly userMessageText?: string;
   readonly allToolCalls?: readonly ToolCallRecord[];
   readonly turnEndSnapshot?: TurnEndStopGateSnapshot;
   readonly runtimeChecks?: {
@@ -175,6 +182,9 @@ function buildBuiltinStopHookDefinitions(): readonly StopHookRuntimeDefinition[]
           runtimeContext: {
             workspaceRoot: context.runtimeWorkspaceRoot,
           },
+          ...(typeof context.userMessageText === "string"
+            ? { userMessageText: context.userMessageText }
+            : {}),
         });
         return {
           hookId: BUILTIN_TURN_END_STOP_GATE_ID,

--- a/runtime/src/tools/system/filesystem.ts
+++ b/runtime/src/tools/system/filesystem.ts
@@ -127,6 +127,16 @@ interface SessionReadSnapshot {
   readonly content?: string | null;
   readonly timestamp?: number;
   readonly viewKind?: SessionReadViewKind;
+  /**
+   * For partial reads (`viewKind === "partial"`), the exact line offset
+   * the model passed. Stored so a subsequent read with the identical
+   * `(offset, limit)` and unchanged mtime can serve from the cache
+   * stub — matches Claude Code's range-aware FILE_UNCHANGED dedup
+   * (claude_code/tools/FileReadTool/FileReadTool.ts:547-573).
+   */
+  readonly readOffset?: number;
+  /** For partial reads, the exact line limit the model passed. */
+  readonly readLimit?: number;
 }
 
 export interface SessionReadSeedEntry {
@@ -1226,32 +1236,44 @@ function createReadFileTool(
         }
 
         // Cache-hit short-circuit: if this session already read this
-        // path in full and the file's mtime is unchanged, return the
-        // FILE_UNCHANGED_STUB instead of re-reading. Mirrors the
-        // upstream reference runtime's readFileCache. Only fires for
-        // full-file reads (no offset/limit narrowing) to keep the
-        // semantics simple; partial reads always go through the
-        // normal path.
+        // path and the file's mtime is unchanged, return the
+        // FILE_UNCHANGED_STUB instead of re-reading. Mirrors Claude
+        // Code's range-aware FILE_UNCHANGED dedup
+        // (claude_code/tools/FileReadTool/FileReadTool.ts:547-573):
+        // full reads dedup against a prior full read; partial reads
+        // dedup only when the exact `(offset, limit)` matches the
+        // prior partial read for the same path. A different slice
+        // always falls through.
         const cacheHitSessionId = resolveSessionId(args);
         const requestedReadWindow = resolveReadWindow(args);
-        if (
-          cacheHitSessionId &&
+        const requestedIsFull =
           requestedReadWindow.startLine === undefined &&
-          requestedReadWindow.limit === undefined
-        ) {
+          requestedReadWindow.limit === undefined;
+        if (cacheHitSessionId) {
           const priorSnapshot = getSessionReadSnapshot(
             cacheHitSessionId,
             resolved!,
           );
           const priorTimestamp = priorSnapshot?.timestamp;
           const currentTimestamp = getFileTimestampMs(fileStats);
-          if (
+          const mtimeMatches =
             priorSnapshot !== undefined &&
-            priorSnapshot.viewKind === "full" &&
             typeof priorTimestamp === "number" &&
             typeof currentTimestamp === "number" &&
-            priorTimestamp === currentTimestamp
-          ) {
+            priorTimestamp === currentTimestamp;
+          const priorIsFull =
+            priorSnapshot?.viewKind === "full" &&
+            priorSnapshot.readOffset === undefined &&
+            priorSnapshot.readLimit === undefined;
+          const partialRangeMatches =
+            priorSnapshot?.viewKind === "partial" &&
+            !requestedIsFull &&
+            priorSnapshot.readOffset === requestedReadWindow.startLine &&
+            priorSnapshot.readLimit === requestedReadWindow.limit;
+          const cacheEligible =
+            mtimeMatches &&
+            ((requestedIsFull && priorIsFull) || partialRangeMatches);
+          if (cacheEligible) {
             // The stub assumes the model still has the prior content in
             // context. After compaction or aggressive history rotation
             // that breaks; the model then loops, re-reading the same
@@ -1303,6 +1325,12 @@ function createReadFileTool(
             content: sliced.content,
             timestamp: getFileTimestampMs(fileStats),
             viewKind: sliced.viewKind,
+            ...(readWindow.startLine !== undefined
+              ? { readOffset: readWindow.startLine }
+              : {}),
+            ...(readWindow.limit !== undefined
+              ? { readLimit: readWindow.limit }
+              : {}),
           });
           return {
             content: safeStringify({


### PR DESCRIPTION
Five coordinated fixes from a follow-up trace audit after PR #481.

## Background

Three runs after PR #481 cleared the read-loop runaway, a verify turn cost $35 and 41 model calls because the stop-gate fired twice on the model's gap-enumeration answer (`'Phase 2 ... only partially done'` matched `NARRATED_FUTURE_TOOL_WORK_RE`). The model paid for two retry rounds and then surrendered with a watered-down 'M1 Phase 1 is complete' handwave that DROPPED the requested gap enumeration entirely. Plus a few latent risks the trace investigation surfaced.

## What this ships

1. **Stop-gate report-aware suppression** (`chat-executor-stop-gate.ts`). When the user message matches `REPORT_REQUEST_RE` (report, list, enumerate, what's incomplete, gaps, status), the narration detector skips. Plumbed via new `userMessageText` field on `StopHookContext` -> `EvaluateTurnEndStopGateParams` -> `maybeFireNarratedFutureToolWork`.

2. **Structured-report softener** (`chat-executor-stop-gate.ts`). When the response has `>= 2` markdown headings AND `>= 3` bullet items AND the turn already did `>= 5` tool calls, trust the prose.

3. **Per-session inbound serialization** (`daemon.ts`). New `_webSessionInboundChain` map queues messages per session. Replaces the 300ms setTimeout in PR #476 with a real runtime-level guarantee. Cross-session work stays parallel.

4. **Repeat-readFile-on-success recovery hint** (`chat-executor-recovery.ts`). First success-case hint in the runtime; all others gate on `didToolCallFail`. Threshold: 3 successful reads of the same path. Hint is keyed by tool+path so it dedupes.

5. **Range-aware FILE_UNCHANGED dedup** (`tools/system/filesystem.ts`). Ports Claude Code's exact `(offset, limit)` match alongside our existing full-read dedup. SessionReadSnapshot gains `readOffset`/`readLimit` fields.

## Test plan

- [x] runtime LLM + gateway + filesystem suites: 2638/2641 pass (3 skipped, all pre-existing)
- [x] Updated daemon-webchat-turn test for the new `workflowStage` field in `runtimeContext` (added in PR #481)
- [ ] Re-run `verify Phase 1 builds and tests pass and report what's incomplete from the plan` — stop-gate should NOT fire, model's gap enumeration should survive, expect <30 calls and <$25