### PR TITLE
fix(runtime): cache-preservation compaction threshold (xAI prompt-cache cliff)

### DIFF
--- a/runtime/src/llm/chat-executor-in-flight-compaction.ts
+++ b/runtime/src/llm/chat-executor-in-flight-compaction.ts
@@ -98,11 +98,29 @@ export async function maybeCompactInFlightCallInput(
     contextWindowTokens: deps.promptBudget.contextWindowTokens,
     maxOutputTokens: deps.promptBudget.maxOutputTokens,
     lastResponseUsage: ctx.response?.usage,
+    ...(deps.promptBudget.cachePreservationThresholdTokens !== undefined
+      ? {
+          cachePreservationThresholdTokens:
+            deps.promptBudget.cachePreservationThresholdTokens,
+        }
+      : {}),
   });
   const statefulHistoryCompacted =
     input.statefulHistoryCompacted === true || ctx.compacted;
+  // Two independent triggers both route into the same compaction
+  // path: autocompact protects against hitting the model's context
+  // window, cache-preservation protects against the xAI prompt-cache
+  // cliff at ~20K input tokens per call. Either one firing is enough
+  // to compact. See DEFAULT_CACHE_PRESERVATION_THRESHOLD_TOKENS for
+  // the cache cliff evidence.
+  const shouldCompactForContextWindow =
+    compactionState.isAboveAutocompactThreshold;
+  const shouldCompactForCachePreservation =
+    compactionState.isAboveCachePreservationThreshold;
+  const shouldCompact =
+    shouldCompactForContextWindow || shouldCompactForCachePreservation;
   if (
-    compactionState.isAboveAutocompactThreshold &&
+    shouldCompact &&
     shouldSkipHistoryCompactionForCircuitBreaker(
       ctx.perIterationCompaction.autocompact.consecutiveFailures,
     )
@@ -114,9 +132,7 @@ export async function maybeCompactInFlightCallInput(
       statefulHistoryCompacted,
     };
   }
-  if (
-    !compactionState.isAboveAutocompactThreshold
-  ) {
+  if (!shouldCompact) {
     return {
       callMessages: input.callMessages,
       callReconciliationMessages: input.callReconciliationMessages,

--- a/runtime/src/llm/compact/context-window.ts
+++ b/runtime/src/llm/compact/context-window.ts
@@ -12,6 +12,39 @@ export const ERROR_THRESHOLD_BUFFER_TOKENS = 20_000;
 export const MANUAL_COMPACT_BUFFER_TOKENS = 3_000;
 export const DEFAULT_AUTOCOMPACT_THRESHOLD_TOKENS = 120_000;
 
+/**
+ * Cache-preservation compaction threshold. The xAI server-side prompt
+ * cache reliably retains the full conversation prefix only when the
+ * per-call input stays under roughly 20K tokens for the grok-4.x
+ * family. Empirically (trace session_2ea674f...18bac08d, 2026-04-19):
+ *
+ *   ci=4 (11.5K in) → cached 11.2K tokens (97% hit)
+ *   ci=8 (14.8K in) → cached 14.8K tokens (99% hit)
+ *   ci=10 (15.2K in) → cached 15.2K tokens (99% hit)
+ *   ci=37 (28.7K in) → cached 9.0K tokens (31% — stuck at system+tools)
+ *   ci=41 (29.1K in) → cached 9.0K tokens (31% — permanent ceiling)
+ *
+ * Once the conversation prefix is evicted past ~20K input tokens, the
+ * xAI cache never repopulates beyond the system+tools baseline — the
+ * rest of the turn pays full input token cost forever. Triggering
+ * history compaction at a much lower threshold than
+ * `DEFAULT_AUTOCOMPACT_THRESHOLD_TOKENS` (which guards only against
+ * hitting the model's context window) keeps the working set in the
+ * cache-eligible zone.
+ *
+ * Set conservatively to 18K tokens: below the observed cliff at 20K,
+ * above the typical system+tools baseline of ~9K so a fresh session
+ * doesn't immediately trigger compaction on its first tool call.
+ *
+ * This is a floor, not a cap — if a provider has a higher autocompact
+ * threshold from its own config, the floor still fires first because
+ * the runtime takes the MIN of both thresholds when deciding whether
+ * a compact is due. Callers can override via
+ * `PromptBudgetConfig.cachePreservationThresholdTokens` (set to 0 to
+ * disable).
+ */
+export const DEFAULT_CACHE_PRESERVATION_THRESHOLD_TOKENS = 18_000;
+
 const BOUNDARY_PREFIXES = [
   "[snip]",
   "[microcompact]",
@@ -32,12 +65,25 @@ export interface CurrentContextUsageSnapshot {
   readonly currentTokens: number;
   readonly effectiveContextWindowTokens?: number;
   readonly autocompactThresholdTokens: number;
+  /**
+   * Lower threshold that fires to keep the per-call input inside the
+   * xAI prompt-cache sweet spot. See
+   * `DEFAULT_CACHE_PRESERVATION_THRESHOLD_TOKENS` for the rationale.
+   */
+  readonly cachePreservationThresholdTokens: number;
   readonly warningThresholdTokens?: number;
   readonly errorThresholdTokens?: number;
   readonly blockingThresholdTokens?: number;
   readonly percentUsed?: number;
   readonly freeTokens?: number;
   readonly isAboveAutocompactThreshold: boolean;
+  /**
+   * True when `currentTokens >= cachePreservationThresholdTokens`.
+   * Gates the cache-preservation compaction layer so older tool
+   * results fold into a summary before the request crosses the xAI
+   * cache cliff at ~20K input tokens per call.
+   */
+  readonly isAboveCachePreservationThreshold: boolean;
   readonly isAtBlockingLimit: boolean;
   readonly sections: readonly CurrentContextUsageSection[];
 }
@@ -210,6 +256,12 @@ export function buildCurrentContextUsageSnapshot(params: {
   readonly contextWindowTokens?: number;
   readonly maxOutputTokens?: number;
   readonly lastResponseUsage?: LLMUsage;
+  /**
+   * Override for the cache-preservation threshold. When `undefined`,
+   * falls back to `DEFAULT_CACHE_PRESERVATION_THRESHOLD_TOKENS`. Set
+   * to `0` to disable cache-preservation compaction entirely.
+   */
+  readonly cachePreservationThresholdTokens?: number;
 }): CurrentContextUsageSnapshot {
   const currentTokens = tokenCountWithEstimation({
     messages: params.messages,
@@ -223,6 +275,12 @@ export function buildCurrentContextUsageSnapshot(params: {
     contextWindowTokens: params.contextWindowTokens,
     maxOutputTokens: params.maxOutputTokens,
   });
+  const cachePreservationThresholdTokens =
+    typeof params.cachePreservationThresholdTokens === "number" &&
+    Number.isFinite(params.cachePreservationThresholdTokens) &&
+    params.cachePreservationThresholdTokens >= 0
+      ? Math.floor(params.cachePreservationThresholdTokens)
+      : DEFAULT_CACHE_PRESERVATION_THRESHOLD_TOKENS;
   const warningThresholdTokens =
     effectiveContextWindowTokens !== undefined
       ? Math.max(0, autocompactThresholdTokens - WARNING_THRESHOLD_BUFFER_TOKENS)
@@ -251,12 +309,16 @@ export function buildCurrentContextUsageSnapshot(params: {
     currentTokens,
     effectiveContextWindowTokens,
     autocompactThresholdTokens,
+    cachePreservationThresholdTokens,
     warningThresholdTokens,
     errorThresholdTokens,
     blockingThresholdTokens,
     freeTokens,
     percentUsed,
     isAboveAutocompactThreshold: currentTokens >= autocompactThresholdTokens,
+    isAboveCachePreservationThreshold:
+      cachePreservationThresholdTokens > 0 &&
+      currentTokens >= cachePreservationThresholdTokens,
     isAtBlockingLimit:
       blockingThresholdTokens !== undefined &&
       currentTokens >= blockingThresholdTokens,

--- a/runtime/src/llm/prompt-budget.ts
+++ b/runtime/src/llm/prompt-budget.ts
@@ -43,6 +43,16 @@ export interface PromptBudgetConfig {
   readonly memoryRoleContracts?: PromptBudgetMemoryRoleContracts;
   /** Upper bound for additive runtime hint system messages per execution. */
   readonly maxRuntimeHints?: number;
+  /**
+   * Override for the cache-preservation compaction threshold (tokens).
+   * When undefined, the runtime uses
+   * `DEFAULT_CACHE_PRESERVATION_THRESHOLD_TOKENS`. Set to `0` to
+   * disable cache-preservation compaction entirely and rely only on
+   * the traditional context-window autocompact threshold. See
+   * `DEFAULT_CACHE_PRESERVATION_THRESHOLD_TOKENS` in
+   * `./compact/context-window.ts` for the empirical rationale.
+   */
+  readonly cachePreservationThresholdTokens?: number;
 }
 
 interface PromptBudgetModelProfile {


### PR DESCRIPTION
Adds an aggressive early compaction trigger keyed to the xAI prompt-cache cliff observed at ~20K input tokens per call.

## Evidence (trace session_2ea674f...18bac08d, 2026-04-19)

| ci | input tokens | cached | hit % |
|----|---|---|---|
| 4  | 11.5K | 11.2K | 97% |
| 8  | 14.8K | 14.8K | 99% |
| 10 | 15.2K | 15.2K | 99% |
| 37 | 28.7K | 9.0K  | 31% (stuck) |
| 41 | 29.1K | 9.0K  | 31% (permanent ceiling) |

After ~20K input tokens per call, the xAI cache evicts the conversation prefix and never repopulates it. The short system+tools prefix keeps caching at ~9K, but the rest of every subsequent call pays full uncached input rates forever. Cross-referenced against xAI's caching docs (MCP): our implementation follows every documented best practice (stable `prompt_cache_key`, byte-identical prefix, no message reordering, no tools-array changes). The cliff is xAI server-side, and the only client-side defense is to keep per-call input inside the cacheable zone.

## Change

- `DEFAULT_CACHE_PRESERVATION_THRESHOLD_TOKENS = 18_000` (below the observed cliff, above the ~9K system+tools baseline so fresh sessions don't compact on their first tool call).
- New `isAboveCachePreservationThreshold` on `CurrentContextUsageSnapshot`.
- `maybeCompactInFlightCallInput` triggers compaction on EITHER the existing autocompact threshold (context-window protection) OR the cache-preservation threshold — whichever fires first.
- Configurable per-call via `PromptBudgetConfig.cachePreservationThresholdTokens`. Set to `0` to disable.

## Test plan

- [x] runtime LLM suite: 858/858 pass
- [ ] Re-run a multi-phase turn (implement + verify) and compare cached_tokens curve: expect hit rate to stay in the 90%+ range instead of collapsing to the 31% baseline after call ~37