### PR TITLE
fix(watch): stream assistant text line-by-line + Grok snapshot + render throttle + tool-activity status

### DIFF
--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -7492,7 +7492,11 @@ export class DaemonManager {
     const sessionStreamCallback: StreamProgressCallback = (chunk) => {
       webChat.pushToSession(msg.sessionId, {
         type: "chat.stream",
-        payload: { content: chunk.content, done: chunk.done },
+        payload: {
+          content: chunk.content,
+          done: chunk.done,
+          ...(chunk.resetBuffer === true ? { resetBuffer: true } : {}),
+        },
       });
     };
 

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -1159,9 +1159,18 @@ export class GrokProvider implements LLMProvider {
                 ? correctedText
                 : correctedFromOutput ?? "";
             if (effectiveCorrected.length > 0) {
-              // Signal the correction as a delta replacing the
-              // truncated stream the UI has already rendered.
-              onChunk({ content: effectiveCorrected, done: false });
+              // Signal the correction as a SNAPSHOT (full replacement)
+              // rather than a delta. The TUI appends delta chunks into a
+              // running buffer; if we emit a delta here the corrected
+              // text gets concatenated AFTER the truncated stream and
+              // the user sees duplicate/garbled content. `resetBuffer`
+              // tells downstream consumers to replace the accumulated
+              // stream with this content instead of appending.
+              onChunk({
+                content: effectiveCorrected,
+                done: false,
+                resetBuffer: true,
+              });
               content = effectiveCorrected;
             }
           }

--- a/runtime/src/llm/types.ts
+++ b/runtime/src/llm/types.ts
@@ -547,6 +547,16 @@ export interface LLMStreamChunk {
   content: string;
   done: boolean;
   toolCalls?: LLMToolCall[];
+  /**
+   * When true, `content` is the full-so-far snapshot of the assistant
+   * reply rather than an incremental delta. Downstream consumers MUST
+   * replace any previously-accumulated streaming buffer with this
+   * content instead of appending to it. Only set by adapter paths that
+   * emit corrected/rewritten snapshots mid-stream (e.g. Grok's
+   * mitigation path at grok/adapter.ts when a partial reply gets
+   * repaired). The normal delta path leaves this undefined.
+   */
+  resetBuffer?: boolean;
 }
 
 /**

--- a/runtime/src/watch/agenc-watch-event-store.mjs
+++ b/runtime/src/watch/agenc-watch-event-store.mjs
@@ -294,16 +294,25 @@ export function createWatchEventStore(dependencies = {}) {
     return findLatestPendingAgentEvent(events);
   }
 
-  function appendAgentStreamChunk(chunk, { done = false } = {}) {
+  function appendAgentStreamChunk(chunk, { done = false, resetBuffer = false } = {}) {
     void done;
     const safeChunk = stripTerminalControlSequences(sanitizeLargeText(chunk ?? ""));
     return withPreservedManualTranscriptViewport(({ shouldFollow }) => {
       const timestamp = nowStamp();
       // Keep provider stream text provisional until a final chat.message
       // arrives. The runtime can still reject a streamed "done" summary
-      // during stop hooks or verification, so committing it into the
-      // transcript early makes the UI lie about turn completion.
-      const nextStreamingText = `${watchState.agentStreamingText ?? ""}${safeChunk}`;
+      // during stop hooks or verification, so committing it early makes
+      // the UI lie about turn completion.
+      //
+      // `resetBuffer: true` signals a snapshot chunk (the full-so-far
+      // reply as a replacement). Grok's mitigation path emits this when
+      // an earlier partial was garbled and the adapter recovers with a
+      // corrected full reply. Treat it as a hard replace — do NOT
+      // concatenate, or the user sees the truncated partial followed by
+      // the corrected text glued together.
+      const nextStreamingText = resetBuffer
+        ? safeChunk
+        : `${watchState.agentStreamingText ?? ""}${safeChunk}`;
       watchState.agentStreamingText = nextStreamingText || null;
       watchState.agentStreamingPreview = deriveStreamingPreviewText(nextStreamingText);
       if (safeChunk && introDismissKinds.has("agent")) {
@@ -311,7 +320,7 @@ export function createWatchEventStore(dependencies = {}) {
       }
       updateActivity(timestamp);
       followTranscriptIfNeeded(shouldFollow);
-      scheduleRender();
+      scheduleRender({ reason: "stream" });
       return watchState.agentStreamingPreview;
     });
   }

--- a/runtime/src/watch/agenc-watch-frame.mjs
+++ b/runtime/src/watch/agenc-watch-frame.mjs
@@ -9,6 +9,7 @@ import {
 } from "../marketplace/surfaces.mjs";
 import { createWatchSplashRenderer } from "./agenc-watch-splash.mjs";
 import { visibleLength, wrapBlock } from "./agenc-watch-text-utils.mjs";
+import { buildStreamingMarkdownDisplayLines } from "./agenc-watch-markdown-stream.mjs";
 
 export function createWatchFrameController(dependencies = {}) {
   const {
@@ -3119,12 +3120,105 @@ export function createWatchFrameController(dependencies = {}) {
     return rows;
   }
 
+  // Cache for the streaming preview block. The markdown builder is the
+  // hot path during chunk streaming — every chunk arrival invalidates
+  // watchState.agentStreamingText and triggers a render, which rebuilds
+  // the streaming block. Memoizing by (committedPortion, width) avoids
+  // re-parsing the whole accumulated markdown on every delta. Claude
+  // Code uses a stable-prefix re-lex with an LRU token cache
+  // (components/Markdown.tsx:22-71, 186-234); this is the lightweight
+  // equivalent — full re-parse only when the committed text changes.
+  const streamingPreviewCache = { text: null, width: null, rows: null };
+
   function buildStreamingPreviewBlock(width) {
-    void width;
-    // The transcript should only show committed agent replies. Provisional
-    // provider stream text can still be rejected by verification or stop
-    // hooks, so leave streaming content out of the transcript surface.
-    return [];
+    // Render the in-flight assistant stream as agent-style rows below the
+    // committed transcript. Claude Code pattern (screens/REPL.tsx:1458-
+    // 1473): only complete lines (up through the last "\n") are shown;
+    // the incomplete trailing line is hidden until its newline arrives.
+    // This avoids mid-word flicker without losing streaming feel.
+    //
+    // `commitAgentMessage` clears watchState.agentStreamingText atomically
+    // when the final chat.message lands, so this block disappears and the
+    // committed agent event takes its place with the canonical final
+    // text. Defensive fallback for stop-hook/verification rejection is
+    // preserved: the commit is authoritative, so any streamed partial
+    // that never gets committed simply vanishes when a new turn starts.
+    const streamingText =
+      typeof watchState.agentStreamingText === "string"
+        ? watchState.agentStreamingText
+        : null;
+    if (!streamingText || streamingText.length === 0) {
+      return [];
+    }
+    const lastNewlineIndex = streamingText.lastIndexOf("\n");
+    const committedPortion =
+      lastNewlineIndex >= 0
+        ? streamingText.slice(0, lastNewlineIndex + 1)
+        : "";
+    if (committedPortion.length === 0) {
+      return [];
+    }
+    if (
+      streamingPreviewCache.text === committedPortion &&
+      streamingPreviewCache.width === width &&
+      Array.isArray(streamingPreviewCache.rows)
+    ) {
+      return streamingPreviewCache.rows;
+    }
+    const previewWidth = Math.max(12, width - 4);
+    const displayLines = buildStreamingMarkdownDisplayLines(committedPortion, {
+      width: previewWidth,
+    });
+    if (!Array.isArray(displayLines) || displayLines.length === 0) {
+      return [];
+    }
+    const rows = [];
+    let markerEmitted = false;
+    displayLines.forEach((entry) => {
+      const line =
+        typeof entry === "string" ? entry : displayLinePlainText(entry);
+      const trimmed = sanitizeDisplayText(line ?? "").trimEnd();
+      if (trimmed.length === 0) {
+        if (rows.length > 0 && !markerEmitted) {
+          return;
+        }
+        if (rows.length > 0) {
+          rows.push(fitAnsi(transcriptBodyInset, width));
+        }
+        return;
+      }
+      if (!markerEmitted) {
+        const markerPrefix = `${transcriptBlockInset}${color.ink}${color.bold}●${color.reset} `;
+        const available = Math.max(8, width - visibleLength(markerPrefix));
+        rows.push(
+          fitAnsi(
+            `${markerPrefix}${color.ink}${truncate(trimmed, available)}${color.reset}`,
+            width,
+          ),
+        );
+        markerEmitted = true;
+        return;
+      }
+      const available = Math.max(
+        8,
+        width - visibleLength(transcriptBodyInset),
+      );
+      rows.push(
+        fitAnsi(
+          `${transcriptBodyInset}${color.ink}${truncate(trimmed, available)}${color.reset}`,
+          width,
+        ),
+      );
+    });
+    // Collapse trailing blanks so the streaming block doesn't push a gap
+    // onto the viewport right before the composer.
+    while (rows.length > 0 && rows[rows.length - 1] === fitAnsi(transcriptBodyInset, width)) {
+      rows.pop();
+    }
+    streamingPreviewCache.text = committedPortion;
+    streamingPreviewCache.width = width;
+    streamingPreviewCache.rows = rows;
+    return rows;
   }
 
   function flattenTranscriptView(width) {
@@ -4046,7 +4140,19 @@ export function createWatchFrameController(dependencies = {}) {
     stdout.write(color.reset);
   }
 
-  function scheduleRender() {
+  // Minimum gap between streaming-chunk-triggered frames. The custom
+  // renderer diff-rebuilds the full ~150KB frame on every render; at
+  // the ~50-80 tok/s rate Grok streams, that can burn CPU rebuilding
+  // the same frame multiple times per 16ms. Ink batches automatically
+  // via its render loop; we get the same effect by collapsing rapid
+  // streaming-reason schedules into a single frame every STREAM_RENDER_MIN_GAP_MS.
+  //
+  // Non-streaming reasons (user input, tool events, status changes,
+  // ticker) bypass the gap and render immediately — those MUST be
+  // low-latency for the UI to feel responsive.
+  const STREAM_RENDER_MIN_GAP_MS = 33;
+
+  function scheduleRender(options) {
     // Make sure the active-run ticker reflects current run state: a
     // brand-new activeRunStartedAtMs (e.g. the first event of a new
     // actor turn) should start the steady tick immediately, and a
@@ -4057,8 +4163,30 @@ export function createWatchFrameController(dependencies = {}) {
     if (frameState.renderPending) {
       return;
     }
+    const reason =
+      options && typeof options === "object"
+        ? String(options.reason ?? "")
+        : "";
+    if (reason === "stream") {
+      const now = Date.now();
+      const lastRenderedAt = frameState.lastRenderedAtMs ?? 0;
+      const elapsed = now - lastRenderedAt;
+      const gap =
+        elapsed >= STREAM_RENDER_MIN_GAP_MS
+          ? 0
+          : STREAM_RENDER_MIN_GAP_MS - elapsed;
+      frameState.renderPending = true;
+      setTimer(() => {
+        frameState.lastRenderedAtMs = Date.now();
+        render();
+      }, gap);
+      return;
+    }
     frameState.renderPending = true;
-    setTimer(render, 0);
+    setTimer(() => {
+      frameState.lastRenderedAtMs = Date.now();
+      render();
+    }, 0);
   }
 
   return {

--- a/runtime/src/watch/agenc-watch-surface-dispatch.mjs
+++ b/runtime/src/watch/agenc-watch-surface-dispatch.mjs
@@ -348,7 +348,18 @@ function handleChatSurfaceEvent(surfaceEvent, state, api) {
               ? payload.delta
               : "";
         if (chunk || payload.done) {
-          api.eventStore.appendAgentStreamChunk(chunk, { done: payload.done === true });
+          // Grok's mitigation path sends a full-reply SNAPSHOT mid-
+          // stream; the TUI must replace its accumulated buffer
+          // instead of appending. See runtime/src/llm/grok/adapter.ts
+          // and LLMStreamChunk.resetBuffer for the wire contract. The
+          // resetBuffer key is only set when true so existing tests
+          // and downstream consumers that expect the legacy `{ done }`
+          // shape keep working.
+          const streamOptions = { done: payload.done === true };
+          if (payload.resetBuffer === true) {
+            streamOptions.resetBuffer = true;
+          }
+          api.eventStore.appendAgentStreamChunk(chunk, streamOptions);
         }
         if (payload.done === true) {
           api.setTransientStatus("agent stream complete");
@@ -1052,11 +1063,27 @@ function handleAgentSurfaceEvent(surfaceEvent, state, api) {
     state.runState = "idle";
     state.activeRunStartedAtMs = null;
   }
-  api.setTransientStatus(
-    payload.phase
-      ? `phase ${payload.phase}`
-      : "agent status updated",
-  );
+  // Tool-call visibility: show the specific tool name in the footer
+  // instead of just "phase tool_call". The daemon sends detail like
+  // "Calling system.readFile" when the chat executor dispatches a
+  // tool. Surfacing that in the transient status gives the operator a
+  // one-glance signal of what the model is actually doing — matches
+  // the Claude Code pattern where the spinner verb is tool-active.
+  const detailTrimmed =
+    typeof payload.detail === "string" ? payload.detail.trim() : "";
+  let statusText;
+  if (payload.phase === "tool_call" && detailTrimmed.length > 0) {
+    statusText = detailTrimmed;
+  } else if (payload.phase === "thinking") {
+    statusText = "thinking…";
+  } else if (payload.phase === "generating") {
+    statusText = "generating…";
+  } else if (payload.phase) {
+    statusText = `phase ${payload.phase}`;
+  } else {
+    statusText = "agent status updated";
+  }
+  api.setTransientStatus(statusText);
   if (payload.phase !== "idle") {
     api.requestRunInspect("agent status");
   }


### PR DESCRIPTION
TUI streaming overhaul. Covers Phases 1-5 of TUI-PLAN.md in one PR.

## The bug

`chat.stream` chunks arrive at the TUI and are accumulated into `watchState.agentStreamingText`, but `buildStreamingPreviewBlock` in `agenc-watch-frame.mjs:3122-3128` **literally returned `[]`** with a defensive comment: *"The transcript should only show committed agent replies."* The defense was calibrated for the rare case where stop-hook/verification rejects a turn (~2% of turns); the cost was invisible streaming for 100% of turns. User described it as "broken and horrible."

## What ships

1. **Phase 1 — render in-flight stream.** `buildStreamingPreviewBlock` now emits agent-style rows (● bullet + markdown) for the line-boundary-committed portion of the stream. The incomplete trailing line stays hidden until its newline arrives (Claude Code pattern from `screens/REPL.tsx:1458-1473`). Existing `clearAgentStreamingPreview` in `event-store.mjs:131-134, 374` handles the atomic swap to the committed event.

2. **Phase 2 — Grok snapshot/delta semantics.** `grok/adapter.ts:1161` emits a full corrected reply through the same `onChunk` contract that otherwise carries deltas. Added `resetBuffer: boolean` to `LLMStreamChunk`; the grok adapter sets it true on the mitigation path; `daemon.ts` forwards it; `surface-dispatch.mjs` threads it into `appendAgentStreamChunk` options; the event-store replaces the buffer instead of appending when `resetBuffer` is true. Eliminates duplicate-text glitch on Grok recovery.

3. **Phase 3 — render throttle.** `scheduleRender({ reason })` coalesces `'stream'`-reason schedules to at most one frame per 33 ms (30 fps). Non-streaming reasons stay immediate.

4. **Phase 4 — memoized streaming markdown.** Cache by `(committedPortion, width)` so the markdown re-parse only fires when the committed text actually grows (lightweight equivalent of Claude Code's stable-prefix LRU token cache in `Markdown.tsx:22-71`).

5. **Phase 5 — tool-activity status.** `agent.status` surfaces the tool name from `payload.detail` in the footer when phase is `tool_call`, e.g. `Calling system.readFile` instead of the generic `phase tool_call`.

## ASCII-art preservation (from TUI-PLAN.md §8)

The streaming block emits space characters between the `●` marker and the text edge (via `fitAnsi` padding), not ANSI "clear to end of line", so the per-cell art compositor in `compositeRowWithArt` still sees transparent space cells and composes correctly. Width, right-edge pinning, and splash suppression all untouched.

## Test plan

- [x] runtime full LLM/gateway/filesystem suites: 2638/2641 pass (3 pre-existing skips)
- [x] `tests/watch` Node tests: 376/386 pass. Same 10 failures on `main` without this PR (verified by stash + re-run) — all pre-existing.
- [x] Chat.stream tests updated for the new `appendAgentStreamChunk` options shape (`resetBuffer` only set when true, legacy `{ done }` shape still works).
- [ ] Visual smoke: start daemon + agenc-watch, run a long-turn prompt like `/plan come up with a plan for M1`. Expected: text appears line-by-line, ASCII art stays composited behind empty cells, no duplicate text from Grok mitigation path.