### PR TITLE
fix(watch): scroll works — drop alt-scroll mode, arrow-key bindings, don't force-snap on every reply

### DIFF
--- a/runtime/src/watch/agenc-watch-event-store.mjs
+++ b/runtime/src/watch/agenc-watch-event-store.mjs
@@ -381,12 +381,24 @@ export function createWatchEventStore(dependencies = {}) {
       result = target;
     }
     clearAgentStreamingPreview();
-    // Force-snap to the new reply AFTER any nested wrapper has run. This
-    // line MUST be outside withPreservedManualTranscriptViewport — the
-    // wrapper's cleanup overwrote it in PR #310, which is exactly why
-    // agent replies were still invisible despite landing in events[].
-    watchState.transcriptFollowMode = true;
-    watchState.transcriptScrollOffset = 0;
+    // Respect the user's scroll position. Previously this path force-
+    // snapped transcriptFollowMode=true / transcriptScrollOffset=0 on
+    // every agent reply to guarantee visibility (PR #310 regression
+    // fix). That fix cured invisible-message at the cost of making
+    // manual scroll impossible — any time the user scrolled up to
+    // read earlier context, the next reply yanked them back to
+    // bottom. Only snap when the user is ALREADY following at
+    // bottom; otherwise leave their manual viewport alone and trust
+    // the scrollback + the reply appearing at the bottom of the
+    // committed events list. The reply still lands visibly in events[]
+    // so the invisible-message regression cannot recur.
+    const wasFollowingAtCommit =
+      watchState.transcriptFollowMode === true &&
+      (watchState.transcriptScrollOffset ?? 0) === 0;
+    if (wasFollowingAtCommit) {
+      watchState.transcriptFollowMode = true;
+      watchState.transcriptScrollOffset = 0;
+    }
     scheduleRender();
     return result;
   }

--- a/runtime/src/watch/agenc-watch-input.mjs
+++ b/runtime/src/watch/agenc-watch-input.mjs
@@ -316,6 +316,16 @@ export function createWatchInputController(dependencies = {}) {
       { seq: "\x1bf", run: () => moveComposerCursorByWord(1) },
       { seq: "\x1b[5~", run: () => scrollCurrentViewBy(12) },
       { seq: "\x1b[6~", run: () => scrollCurrentViewBy(-12) },
+      // Modifier forms emitted by modern terminals for Shift/Ctrl/Alt+
+      // PageUp/PageDown (`\x1b[5;2~` etc). Without these the modifier
+      // combinations fall into consumeUnknownEscapeSequence and scroll
+      // silently fails for those keystrokes.
+      { seq: "\x1b[5;2~", run: () => scrollCurrentViewBy(24) },
+      { seq: "\x1b[5;3~", run: () => scrollCurrentViewBy(24) },
+      { seq: "\x1b[5;5~", run: () => scrollCurrentViewBy(24) },
+      { seq: "\x1b[6;2~", run: () => scrollCurrentViewBy(-24) },
+      { seq: "\x1b[6;3~", run: () => scrollCurrentViewBy(-24) },
+      { seq: "\x1b[6;5~", run: () => scrollCurrentViewBy(-24) },
       { seq: "\x1b[3~", run: () => {
         deleteComposerForward();
       } },
@@ -328,6 +338,19 @@ export function createWatchInputController(dependencies = {}) {
           navigateComposerPalette(-1);
           return;
         }
+        // When the composer is empty and no palette is active, the
+        // user's intent on arrow-up is to scroll the transcript, not
+        // to navigate composer history (which only has meaning when
+        // there IS composer text to replace). Previously every plain
+        // Up arrow went straight to navigateComposer and the user
+        // had no keyboard-scroll path short of PageUp.
+        if (
+          typeof watchState.composerInput === "string" &&
+          watchState.composerInput.length === 0
+        ) {
+          scrollCurrentViewBy(3);
+          return;
+        }
         navigateComposer(-1);
       } },
       { seq: "\x1b[B", run: () => {
@@ -337,6 +360,13 @@ export function createWatchInputController(dependencies = {}) {
         }
         if (hasActiveComposerPalette()) {
           navigateComposerPalette(1);
+          return;
+        }
+        if (
+          typeof watchState.composerInput === "string" &&
+          watchState.composerInput.length === 0
+        ) {
+          scrollCurrentViewBy(-3);
           return;
         }
         navigateComposer(1);

--- a/runtime/src/watch/agenc-watch-terminal-sequences.mjs
+++ b/runtime/src/watch/agenc-watch-terminal-sequences.mjs
@@ -2,14 +2,22 @@ export function buildAltScreenEnterSequence({ enableMouseTracking = false } = {}
   if (!enableMouseTracking) {
     return "\x1b[?1049h\x1b[?2004h\x1b[?25h";
   }
-  return "\x1b[?1049h\x1b[?1000h\x1b[?1002h\x1b[?1006h\x1b[?1007h\x1b[?2004h\x1b[?25h";
+  // DECSET 1007 ("alternate scroll mode") translates wheel events into
+  // arrow-key escapes while the alt screen is active, which suppresses
+  // the SGR 1006 mouse reports that `parseMouseWheelSequence` expects
+  // and misroutes wheel scroll to composer history navigation. Drop it
+  // so the wheel actually emits as `\x1b[<N;x;yM|m` and the input
+  // handler can dispatch to `scrollCurrentViewBy`.
+  return "\x1b[?1049h\x1b[?1000h\x1b[?1002h\x1b[?1006h\x1b[?2004h\x1b[?25h";
 }
 
 export function buildAltScreenLeaveSequence({ enableMouseTracking = false } = {}) {
   if (!enableMouseTracking) {
     return "\x1b[?25h\x1b[?2004l\x1b[?1049l";
   }
-  return "\x1b[?25h\x1b[?2004l\x1b[?1007l\x1b[?1006l\x1b[?1002l\x1b[?1000l\x1b[?1049l";
+  // DECRST 1007 omitted deliberately — we never enabled it. See
+  // buildAltScreenEnterSequence for the rationale.
+  return "\x1b[?25h\x1b[?2004l\x1b[?1006l\x1b[?1002l\x1b[?1000l\x1b[?1049l";
 }
 
 export function supportsTerminalHyperlinks({

--- a/runtime/tests/watch/agenc-watch-terminal-sequences.test.mjs
+++ b/runtime/tests/watch/agenc-watch-terminal-sequences.test.mjs
@@ -22,10 +22,22 @@ test("terminal sequences leave mouse tracking disabled by default", () => {
   assert.match(buildAltScreenLeaveSequence(), /\?2004l/);
 });
 
-test("terminal sequences opt into alternate scroll and mouse tracking explicitly", () => {
-  assert.match(buildAltScreenEnterSequence({ enableMouseTracking: true }), /\?1007h/);
+test("terminal sequences enable SGR mouse reporting without alternate scroll mode (1007)", () => {
+  // 1007 (DECSET alternate scroll mode) translates wheel events into
+  // arrow-key escapes, which suppresses SGR 1006 mouse reports and
+  // misroutes wheel scroll to composer history. We deliberately opt
+  // INTO 1000/1002/1006 for mouse tracking but skip 1007.
+  const enter = buildAltScreenEnterSequence({ enableMouseTracking: true });
+  assert.match(enter, /\?1000h/);
+  assert.match(enter, /\?1002h/);
+  assert.match(enter, /\?1006h/);
+  assert.doesNotMatch(enter, /\?1007h/);
   assert.match(buildAltScreenEnterSequence(), /\?2004h/);
-  assert.match(buildAltScreenLeaveSequence({ enableMouseTracking: true }), /\?1007l/);
+  const leave = buildAltScreenLeaveSequence({ enableMouseTracking: true });
+  assert.match(leave, /\?1000l/);
+  assert.match(leave, /\?1002l/);
+  assert.match(leave, /\?1006l/);
+  assert.doesNotMatch(leave, /\?1007l/);
   assert.match(buildAltScreenLeaveSequence(), /\?2004l/);
 });
 


### PR DESCRIPTION
Fixes the user's active complaint: scrolling up/down in the TUI did not work.

## Root causes (six parallel audit agents, see TUI-BUGS.md)

1. **`\x1b[?1007h` alt-scroll mode was enabled.** DECSET 1007 translates wheel events into arrow-key escapes while the alt screen is active, which suppressed the SGR 1006 mouse reports that `parseMouseWheelSequence` expects. The wheel was scrolling composer history, not the transcript.

2. **`commitAgentMessage` force-snapped to bottom on every agent reply.** The comment at `event-store.mjs:337-344` acknowledges the UX cost: *"the small UX cost of a forced snap on agent reply"* — that cost IS what the user reported.

3. **No arrow-key scroll binding.** Up/Down unconditionally routed to `navigateComposer` (history), even when the composer was empty and there was no history to navigate.

## What ships

- **`agenc-watch-terminal-sequences.mjs`** — drop `?1007h`/`?1007l` from the mouse-tracking alt-screen sequences. Keep `?1000/1002/1006` so SGR mouse reports still arrive.
- **`agenc-watch-event-store.mjs commitAgentMessage`** — snap only when `wasFollowingAtCommit` (`followMode && scrollOffset===0`). Reply still lands in `events[]` visibly; invisible-message regression from PR #310 cannot recur.
- **`agenc-watch-input.mjs`** — plain Up/Down scrolls the transcript when the composer is empty and no palette is active. Added modifier-form PageUp/Down (`\x1b[5;2~` etc) so Shift/Ctrl/Alt+PageUp/Down also scroll.
- **Test update** — `agenc-watch-terminal-sequences.test.mjs` now asserts `?1007` is deliberately omitted.

## Full bug inventory

See `TUI-BUGS.md` in the repo. 60+ additional issues documented across six categories (render, input, event-store, transport, markdown, scroll). Rest will ship in follow-up PRs ordered by severity.

## Test plan

- [x] runtime LLM + gateway suites: 2513/2516 pass (3 pre-existing skips)
- [x] `tests/watch`: 376/386 pass. Same 10 failures on `main` without this PR — all pre-existing.
- [ ] Visual: wheel scrolls the transcript; Up/Down arrows scroll when composer is empty; agent replies don't yank scroll-up readers back to bottom.