### PR TITLE
fix(watch): preserveManualTranscriptViewport must not auto-engage follow mode

### DIFF
--- a/runtime/src/watch/agenc-watch-viewport.mjs
+++ b/runtime/src/watch/agenc-watch-viewport.mjs
@@ -25,9 +25,21 @@ export function preserveManualTranscriptViewport({
     0,
     Number(transcriptScrollOffset ?? 0) + (Number(afterRows ?? 0) - Number(beforeRows ?? 0)),
   );
+  // CRITICAL: do NOT auto-engage follow mode just because the row-delta
+  // adjustment landed at offset 0. The user actively scrolled up
+  // (that's why shouldFollow was false at entry); content shrinking
+  // under them — e.g. the streaming preview block disappearing on
+  // chat.message commit, or events being collapsed/coalesced — must
+  // not be interpreted as the user opting back into follow mode. If
+  // we flip mode to true here, the very next event arrives, sees
+  // shouldFollow=true via isTranscriptFollowing(), and snaps the
+  // viewport to the bottom — which is exactly the "scroll works for
+  // a second then breaks" symptom users see during long agent turns.
+  // Mode stays false; the user must scroll back to the bottom (or
+  // hit a follow shortcut) to re-engage following intentionally.
   return {
     transcriptScrollOffset: nextOffset,
-    transcriptFollowMode: nextOffset === 0,
+    transcriptFollowMode: false,
   };
 }
 


### PR DESCRIPTION
Follow-up to PR #485. User report: scroll works for a second then breaks.

## Trace

1. User scrolls up: `offset>0`, `followMode=false`.
2. Stream chunks arrive; each runs through `withPreservedManualTranscriptViewport` which adjusts offset for the streaming preview block growing.
3. `chat.message` commits the agent reply and clears the streaming preview (10-50 rows disappear at once).
4. `preserveManualTranscriptViewport` recomputes `nextOffset = offset + (afterRows - beforeRows)`. The row delta is large and negative; `nextOffset` lands at exactly 0.
5. The function was returning `followMode = (nextOffset === 0)`, so mode auto-flipped back to `true`.
6. Next event arrives → `isTranscriptFollowing()` returns true → `followTranscriptIfNeeded(true)` snaps offset to 0.
7. User's viewport snaps to bottom 'for no reason.'

## Fix

The preserve helper exists to honor the user's manual scroll across content changes. Content shrinking under the user is NOT 'user wants to follow again.' Mode stays `false`; only intentional scrolling back to bottom (via wheel, PageDown, or the explicit scroll-to-bottom path in `scrollTranscriptBy`) re-engages following.

## Test plan

- [x] viewport suite: 6/6 pass
- [x] full watch suite: 376/386 (same 10 pre-existing failures verified)