### PR TITLE
fix(watch): scroll truly works (follow-mode = mode flag only) + chat.usage carries sessionCostUsd

### DIFF
--- a/runtime/src/gateway/daemon-webchat-turn.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.ts
@@ -129,6 +129,15 @@ interface ExecuteWebChatConversationTurnParams {
     summary: ChatToolRoutingSummary | undefined,
   ) => void;
   readonly getSessionTokenUsage: (sessionId: string) => number;
+  /**
+   * Optional accessor for cumulative USD cost of a session. Returns
+   * `undefined` for unpriced providers / models so the TUI can omit
+   * the cost chip rather than asserting "$0.0000". When omitted on
+   * the deps object (legacy callers), chat.usage payloads will not
+   * carry sessionCostUsd and the TUI's lastUsageSummary loses the
+   * cost line on every turn.
+   */
+  readonly getSessionCostUsd?: (sessionId: string) => number | undefined;
   readonly onModelInfo?: (result: ChatExecutorResult) => void;
   readonly onSubagentSynthesis?: (result: ChatExecutorResult) => void;
   readonly subAgentManager?: Pick<SubAgentManager, "spawn" | "waitForResult"> | null;
@@ -261,6 +270,7 @@ export async function executeWebChatConversationTurn(
     resolveAdvertisedToolNames,
     recordToolRoutingOutcome,
     getSessionTokenUsage,
+    getSessionCostUsd,
     onModelInfo,
     onSubagentSynthesis,
     taskStore = null,
@@ -809,6 +819,15 @@ export async function executeWebChatConversationTurn(
       payload: buildChatUsagePayload({
         sessionId: msg.sessionId,
         totalTokens: getSessionTokenUsage(msg.sessionId),
+        // Pull cumulative cost so the TUI's session cost chip
+        // survives across turns. Without this, every chat.usage
+        // overwrites the previous chat.session's cost-bearing
+        // payload with one that omits sessionCostUsd, and the
+        // displayed "$x session" line silently disappears after
+        // each model call.
+        ...(typeof getSessionCostUsd === "function"
+          ? { sessionCostUsd: getSessionCostUsd(msg.sessionId) }
+          : {}),
         sessionTokenBudget,
         compacted: result.compacted ?? false,
         provider: result.provider,

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -7653,6 +7653,10 @@ export class DaemonManager {
         },
         getSessionTokenUsage: (sessionId) =>
           chatExecutor.getSessionTokenUsage(sessionId),
+        getSessionCostUsd: (sessionId) =>
+          typeof chatExecutor.getSessionCostUsd === "function"
+            ? chatExecutor.getSessionCostUsd(sessionId)
+            : undefined,
         onModelInfo: (result) => {
           const route = normalizeModelRouteSnapshot({
             provider: result.provider,

--- a/runtime/src/watch/agenc-watch-viewport.mjs
+++ b/runtime/src/watch/agenc-watch-viewport.mjs
@@ -6,7 +6,19 @@ export function isTranscriptFollowing({
   transcriptFollowMode,
   transcriptScrollOffset,
 }) {
-  return Boolean(transcriptFollowMode) || Number(transcriptScrollOffset ?? 0) === 0;
+  // Follow mode is the SOLE source of truth for user intent. Previously
+  // the helper returned `mode || offset===0` — but that union flipped
+  // back to `true` whenever content shrank under the user (streaming
+  // preview disappearing, events coalescing) and dragged offset back
+  // to 0, even though `preserveManualTranscriptViewport` had already
+  // recorded `mode=false` to preserve the user's scroll intent. The
+  // very next event arrival saw shouldFollow=true and snapped to
+  // bottom — exactly the "scroll works for a second then breaks"
+  // symptom users still see despite PR #485 + #486. Trust the mode
+  // flag exclusively; `scrollTranscriptBy` keeps it consistent with
+  // offset on intentional scroll-to-bottom.
+  void transcriptScrollOffset;
+  return Boolean(transcriptFollowMode);
 }
 
 export function preserveManualTranscriptViewport({

--- a/runtime/tests/watch/agenc-watch-viewport.test.mjs
+++ b/runtime/tests/watch/agenc-watch-viewport.test.mjs
@@ -54,14 +54,28 @@ test("sliceRowsAroundRange focuses a recent mutation block", () => {
   assert.equal(sliced.hiddenAbove, 4);
 });
 
-test("bottomAlignRows pads short views and isTranscriptFollowing respects offset", () => {
+test("bottomAlignRows pads short views and isTranscriptFollowing trusts mode flag", () => {
   assert.deepEqual(bottomAlignRows(["x", "y"], 4), ["", "", "x", "y"]);
+  // Follow mode is the SOLE source of truth for user intent.
+  // mode=false means "user manually scrolled — do not auto-snap"
+  // regardless of where offset currently sits. The previous "or
+  // offset===0" union flipped follow back on whenever content
+  // shrank under the user's scroll position, causing the next
+  // event to snap to bottom and breaking manual scroll.
   assert.equal(
     isTranscriptFollowing({ transcriptFollowMode: false, transcriptScrollOffset: 2 }),
     false,
   );
   assert.equal(
     isTranscriptFollowing({ transcriptFollowMode: false, transcriptScrollOffset: 0 }),
+    false,
+  );
+  assert.equal(
+    isTranscriptFollowing({ transcriptFollowMode: true, transcriptScrollOffset: 0 }),
+    true,
+  );
+  assert.equal(
+    isTranscriptFollowing({ transcriptFollowMode: true, transcriptScrollOffset: 5 }),
     true,
   );
 });


### PR DESCRIPTION
Two bugs found after PR #486:

## Scroll: still broke after PR #486

PR #486 set `transcriptFollowMode=false` in `preserveManualTranscriptViewport` when content shrank under the user. But `isTranscriptFollowing` was still using:

```js
return Boolean(transcriptFollowMode) || Number(transcriptScrollOffset ?? 0) === 0;
```

The `offset === 0` clause OVERRODE the explicit `mode=false` whenever streaming preview disappearance dragged offset back to 0. The next event arrived, `shouldFollow` captured as `true`, `followTranscriptIfNeeded(true)` snapped to bottom. User reported scroll still breaks for the same reason.

Fix: `isTranscriptFollowing` now uses **mode only**. `scrollTranscriptBy` still sets `mode = (offset===0)` on intentional scroll, so scroll-to-bottom re-engages following naturally.

## Cost chip disappearing across turns

`chat.usage` payloads from `daemon-webchat-turn.ts` did not pass `sessionCostUsd`. `chat.session` (via `buildSessionUsageSnapshot`) did. Result: TUI shows cost briefly after a fresh `chat.session` then loses it on the next `chat.usage`.

Fix: thread `getSessionCostUsd` through the deps so chat.usage carries it consistently.

## Test plan

- [x] runtime viewport tests: pass (updated to assert mode-only semantics)
- [x] tests/watch: 376/386 (same 10 pre-existing failures verified)
- [ ] Visual: scroll up during a model turn, watch the model reply commit + stream end + future events; viewport stays where you put it. Cost chip persists across turns.