### PR TITLE
fix(watch): suppress canonical-reply pin in manual scroll mode

### DIFF
--- a/runtime/src/watch/agenc-watch-frame.mjs
+++ b/runtime/src/watch/agenc-watch-frame.mjs
@@ -3320,7 +3320,24 @@ export function createWatchFrameController(dependencies = {}) {
   }
 
   function activityPanelLines(width, targetHeight) {
-    const replyRows = canonicalReplyRows(width);
+    // The canonical-reply pin keeps the latest agent reply visible
+    // at the top of the panel during follow mode (default UX). But
+    // it ALSO takes most of the panel height, leaving only a tiny
+    // (~6-row) scrollback window — and the agent reply is already
+    // rendered as a regular event inside the transcript anyway.
+    // Result: users wheel-up and `sliced.normalizedOffset` clamps
+    // them at maxOffset within seconds; they see "scroll doesn't
+    // work."
+    //
+    // Fix: suppress the pin when the user is in manual-scroll mode
+    // (transcriptFollowMode === false). The transcript region
+    // expands to the full panel height and the user can scroll
+    // freely through the reply (still rendered in the transcript)
+    // and any earlier content. Returning to follow mode (scroll to
+    // bottom) restores the pin.
+    const replyRows = watchState.transcriptFollowMode
+      ? canonicalReplyRows(width)
+      : [];
     const transcriptView = flattenTranscriptView(width);
     const hasTranscript = transcriptView.rows.length > 0;
     const reservedTranscriptRows = hasTranscript


### PR DESCRIPTION
Trace evidence (collected by a temporary debug tap to /tmp/agenc-scroll-debug.log) shows user wheel-up was mutating offset correctly:

```
2026-04-19T17:57:58.168Z scrollTranscriptBy(3) 6->15 mode=false   ← scroll request reaches mutator
2026-04-19T17:57:58.189Z scrollTranscriptBy(3) 6->15 mode=false   ← but next chunk starts at 6 again
2026-04-19T17:57:58.189Z scrollTranscriptBy(3) 9->15 mode=false       (offset got clamped to 6 by render write-back)
```

Wheel works, mode flag is correct. The render-time `sliced.normalizedOffset` write-back at line 3344 was clamping offset to `maxOffset=6` because the canonical-reply pin took most of the activity-panel height, leaving only ~6 rows of transcript scrollback.

## Root cause

`canonicalReplyRows()` pins the latest agent reply at the top of the panel even though the same reply is ALSO rendered as a regular event (kind: 'agent' with forced `showBody`) inside the transcript. The pin duplicates the reply AND eats most of the panel height.

## Fix

Suppress the pin when the user is in **manual scroll mode** (`transcriptFollowMode === false`). The transcript expands to the full panel height; the agent reply is still rendered (as a transcript event) and the user can scroll freely through it and any prior content. Returning to bottom re-engages follow mode and the pin reappears.

## Test plan

- [x] tests/watch: 376/386 (same 10 pre-existing failures verified)
- [ ] Visual: wheel up should now actually move the viewport up through the entire transcript including long agent replies; wheel back to bottom restores the pinned reply on top.