### PR TITLE
fix(runtime): repeat-read recovery hint uses ToolCallRecord.name, not .tool

### DIFF
--- a/runtime/src/llm/chat-executor-recovery.ts
+++ b/runtime/src/llm/chat-executor-recovery.ts
@@ -1165,7 +1165,14 @@ function inferRepeatReadFileHint(
   const REPEAT_READ_THRESHOLD = 3;
   const counts = new Map<string, number>();
   for (const call of recentCalls) {
-    if (call.tool !== "system.readFile") continue;
+    // ToolCallRecord uses `name`, not `tool` — the original PR #482
+    // wording assumed `tool` (copying from chat.dispatch events).
+    // With the wrong field, every comparison was `undefined !==
+    // "system.readFile"` → always continue → counts always empty →
+    // hint never fires. Traced in a 126-call session that re-read
+    // lexer.c 19 times, alias.c 15 times, heredoc.c 12 times with
+    // zero recovery_hints_injected events.
+    if (call.name !== "system.readFile") continue;
     if (didToolCallFail(call.isError, call.result)) continue;
     const argsObject =
       call.args && typeof call.args === "object"


### PR DESCRIPTION
PR #482 introduced the first success-case recovery hint in the runtime — `inferRepeatReadFileHint` — but keyed the tool check on `.tool` while `ToolCallRecord` uses `.name`. Every comparison was `undefined !== 'system.readFile'` → `continue` → counts map always empty → hint never fired.

## Daemon-log evidence

126-call session, same turn:

| Path | Reads |
|---|---|
| `src/syntax/lexer.c` | 19 |
| `src/alias/alias.c` | 15 |
| `src/syntax/heredoc.c` | 12 |
| `include/agenc/alias.h` | 10 |

`recovery_hints_injected` events in that session: **zero**. The runtime saw no loop because the comparison never matched. The model had no nudge to stop re-reading.

## Fix

Use `call.name`. One-line fix. 858 LLM tests pass.