### PR TITLE
refactor(runtime): Phase 5 — task system mutex gate (TodoWrite is model-facing; task.* is runtime-internal)

### DIFF
--- a/runtime/src/gateway/shell-profile.ts
+++ b/runtime/src/gateway/shell-profile.ts
@@ -41,10 +41,14 @@ const GENERAL_DEFAULT_TOOL_NAMES = [
   "system.browse",
   "system.extractLinks",
   "system.htmlToMarkdown",
-  "task.create",
-  "task.list",
-  "task.get",
-  "task.update",
+  // Only the read-only task handles are exposed to the model —
+  // task.wait + task.output for picking up delegated subagent /
+  // verifier / background-run results. The write surface
+  // (task.create/list/get/update) is reserved for runtime-internal
+  // use via TaskStore direct calls. Model-facing planning goes
+  // through TodoWrite.
+  "task.wait",
+  "task.output",
   "TodoWrite",
   "execute_with_agent",
   "coordinator",
@@ -120,7 +124,7 @@ const DEFINITIONS: Record<SessionShellProfile, ShellProfileDefinition> = {
       "When changing code, validate behavior with the smallest useful check before concluding.",
       "Before reporting non-trivial implementation complete, expect independent verifier confirmation instead of self-certifying the result.",
     ],
-    toolPrefixes: ["task.", "verification."],
+    toolPrefixes: ["verification."],
     exactToolNames: [
       "system.readFile",
       "system.writeFile",
@@ -147,6 +151,8 @@ const DEFINITIONS: Record<SessionShellProfile, ShellProfileDefinition> = {
       "system.symbolReferences",
       "system.searchTools",
       "TodoWrite",
+      "task.wait",
+      "task.output",
       "execute_with_agent",
       "coordinator",
       "workflow.enterPlan",
@@ -168,9 +174,11 @@ const DEFINITIONS: Record<SessionShellProfile, ShellProfileDefinition> = {
       "De-emphasize mutating tools unless the user explicitly asks for edits or execution changes.",
       "Use delegation primarily for bounded investigation, synthesis, and source-backed analysis.",
     ],
-    toolPrefixes: ["system.browse", "system.http", "playwright.", "browser_", "task."],
+    toolPrefixes: ["system.browse", "system.http", "playwright.", "browser_"],
     exactToolNames: [
       "TodoWrite",
+      "task.wait",
+      "task.output",
       "execute_with_agent",
       "workflow.enterPlan",
       "workflow.exitPlan",
@@ -191,9 +199,11 @@ const DEFINITIONS: Record<SessionShellProfile, ShellProfileDefinition> = {
       "De-emphasize mutating tools until you have enough evidence to justify the change.",
       "Prefer explicit checks, logs, tests, and run output over intuition.",
     ],
-    toolPrefixes: ["system.", "desktop.", "task."],
+    toolPrefixes: ["system.", "desktop."],
     exactToolNames: [
       "TodoWrite",
+      "task.wait",
+      "task.output",
       "execute_with_agent",
       "workflow.enterPlan",
       "workflow.exitPlan",
@@ -214,9 +224,11 @@ const DEFINITIONS: Record<SessionShellProfile, ShellProfileDefinition> = {
       "Prefer reading the current code and docs surface before rewriting user-facing guidance.",
       "Keep structure and wording clear, but still verify referenced commands or paths when they matter.",
     ],
-    toolPrefixes: ["system.", "task."],
+    toolPrefixes: ["system."],
     exactToolNames: [
       "TodoWrite",
+      "task.wait",
+      "task.output",
       "execute_with_agent",
       "workflow.enterPlan",
       "workflow.exitPlan",
@@ -237,9 +249,11 @@ const DEFINITIONS: Record<SessionShellProfile, ShellProfileDefinition> = {
       "Prefer the existing structured runtime surfaces before ad hoc shell orchestration when both can solve the task.",
       "Keep awareness of system state, long-running handles, and operational visibility.",
     ],
-    toolPrefixes: ["agenc.", "system.", "social.", "wallet.", "task."],
+    toolPrefixes: ["agenc.", "system.", "social.", "wallet."],
     exactToolNames: [
       "TodoWrite",
+      "task.wait",
+      "task.output",
       "execute_with_agent",
       "coordinator",
       "workflow.enterPlan",

--- a/runtime/src/gateway/tool-routing.test.ts
+++ b/runtime/src/gateway/tool-routing.test.ts
@@ -263,15 +263,23 @@ describe("buildAdvertisedToolBundle — plan-mode filter", () => {
       workflowStage: "plan",
     });
     // Mutating tools are dropped except the plan-mode allow-list
-    // (workflow.exitPlan + task.* stay so the model can finalize).
+    // (workflow.exitPlan + task.wait/task.output + TodoWrite stay
+    // so the model can finalize a plan, draft a todo list, and pick
+    // up delegated subagent results).
     expect(toolNames).toContain("system.readFile");
     expect(toolNames).toContain("system.grep");
     expect(toolNames).toContain("system.listDir");
     expect(toolNames).toContain("system.searchTools");
     expect(toolNames).toContain("workflow.enterPlan");
     expect(toolNames).toContain("workflow.exitPlan");
-    expect(toolNames).toContain("task.create");
-    expect(toolNames).toContain("task.list");
+    // Write-surface task tools are no longer model-advertised under
+    // the Phase 5 mutex gate. TodoWrite is the model-facing planning
+    // affordance; task.* is runtime-internal except for the
+    // read-only wait/output handles.
+    expect(toolNames).not.toContain("task.create");
+    expect(toolNames).not.toContain("task.list");
+    expect(toolNames).not.toContain("task.get");
+    expect(toolNames).not.toContain("task.update");
     expect(toolNames).not.toContain("system.writeFile");
     expect(toolNames).not.toContain("system.editFile");
     expect(toolNames).not.toContain("system.bash");
@@ -332,8 +340,6 @@ describe("buildAdvertisedToolBundle — plan-mode filter", () => {
     for (const essential of [
       "workflow.enterPlan",
       "workflow.exitPlan",
-      "task.create",
-      "task.list",
       "TodoWrite",
       "execute_with_agent",
       "system.searchTools",

--- a/runtime/src/gateway/tool-routing.ts
+++ b/runtime/src/gateway/tool-routing.ts
@@ -78,10 +78,14 @@ const ALWAYS_INLINE_TOOL_NAMES = new Set([
   "system.searchTools",
   "execute_with_agent",
   "coordinator",
-  "task.create",
-  "task.list",
-  "task.get",
-  "task.update",
+  // Phase 5 task-system mutex gate: only task.wait / task.output
+  // stay advertised to the model (read-only handles for picking up
+  // delegated subagent / verifier / background-run results). The
+  // write surface (task.create / task.list / task.get / task.update)
+  // is reserved for runtime-internal TaskStore calls. Model-facing
+  // planning goes through TodoWrite.
+  "task.wait",
+  "task.output",
   // Read-only marketplace browse surfaces — inexpensive schemas, often
   // the first thing the model reaches for, and they bootstrap further
   // discovery via `system.searchTools("select:agenc.<name>")`.
@@ -188,10 +192,8 @@ const PLAN_MODE_ALWAYS_ALLOWED = new Set([
   "workflow.enterPlan",
   "workflow.exitPlan",
   "TodoWrite",
-  "task.create",
-  "task.list",
-  "task.get",
-  "task.update",
+  "task.wait",
+  "task.output",
   "execute_with_agent",
   "system.searchTools",
 ]);


### PR DESCRIPTION
Traces showed the model using BOTH `task.create`/`update`/`list`/`get` (29 calls) AND `TodoWrite` (1 call) in a single turn — two task systems with near-identical descriptions, no mutex gate.

Pick TodoWrite as the sole model-facing planning affordance (lighter, upstream-contract match). Reserve `task.create`/`list`/`get`/`update` for runtime-internal use via TaskStore direct calls (the delegation/verifier/background-run paths already go through the store). Keep `task.wait` and `task.output` advertised to the model — they are the read-only handles that pick up delegated subagent/verifier/background-run results, which TodoWrite cannot replace.

- BASE + every shell profile: drop `task.` prefix; swap task.create/list/get/update for task.wait + task.output in exactToolNames.
- tool-routing.ts: ALWAYS_INLINE_TOOL_NAMES + PLAN_MODE_ALWAYS_ALLOWED updated to match.
- Reminder gate (task-reminder.ts) already keyed on task.update being advertised — naturally goes quiet.
- 2512 runtime tests pass.