### PR TITLE
chore(runtime): remove external tool references from comments

### DIFF
--- a/runtime/scripts/check-executor-baseline.mjs
+++ b/runtime/scripts/check-executor-baseline.mjs
@@ -34,8 +34,8 @@ const __dirname = dirname(__filename);
 const runtimeRoot = resolve(__dirname, "..");
 const repoRoot = resolve(runtimeRoot, "..");
 
-// Floors for the claude_code-alignment refactor. Adjust ONLY when a
-// PR legitimately deletes test files for deleted dead code.
+// Floors for the executor test coverage. Adjust ONLY when a PR
+// legitimately deletes test files for deleted dead code.
 //
 // 2026-04-07 U0:   357 test files / 5976 it() blocks (initial baseline)
 // 2026-04-07 U9-L: 358 test files / 5949 it() blocks
@@ -53,20 +53,15 @@ const repoRoot = resolve(runtimeRoot, "..");
 const MIN_TEST_FILES = 372;
 const MIN_IT_BLOCKS = 5983;
 
-// Ban phrases that are *unambiguously* AI-attribution markers. We do
-// NOT ban the bare words "Claude" or "Anthropic" because the user's
-// codebase legitimately references `claude_code` as the upstream repo
-// used as a behavioral reference for this refactor — commit subjects
-// and branch names routinely include that slug.
+// Ban phrases that are *unambiguously* AI-attribution markers.
 //
 // There are two kinds of markers:
 //   - **Trailer-shaped**: only meaningful when they appear at the
 //     start of a line (e.g. `Co-Authored-By: ...`, `Generated with
-//     Claude Code`). Prose describing the policy can mention them
-//     inline without tripping the check.
-//   - **Anywhere**: the robot emoji and the `noreply@anthropic.com`
-//     email address, which never appear legitimately in any commit
-//     on this repo.
+//     <tool>`). Prose describing the policy can mention them inline
+//     without tripping the check.
+//   - **Anywhere**: the robot emoji and AI-vendor email addresses,
+//     which never appear legitimately in any commit on this repo.
 //
 // Ordering-independent; checked in a single scan.
 const BANNED_TRAILER_PATTERNS = [

--- a/runtime/scripts/write-build-version.mjs
+++ b/runtime/scripts/write-build-version.mjs
@@ -3,7 +3,7 @@
  * Write `runtime/dist/VERSION` containing { commit, buildTime, runtimeVersion }
  * so the daemon can print a startup banner that proves which build is running.
  *
- * Cut 6.2 of the AgenC runtime claude_code-alignment refactor (TODO.MD).
+ * Cut 6.2 of the AgenC runtime refactor (TODO.MD).
  */
 
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";

--- a/runtime/src/gateway/agent-loader.ts
+++ b/runtime/src/gateway/agent-loader.ts
@@ -1,8 +1,6 @@
 /**
  * AgentDefinition loader (Cut 5.6).
  *
- * Mirrors `claude_code/tools/AgentTool/loadAgentsDir.ts`.
- *
  * Loads markdown agent definition files from:
  *   1. `runtime/src/gateway/agent-definitions/*.md`  (built-in)
  *   2. `<projectRoot>/.agenc/agents/*.md`            (project-level)

--- a/runtime/src/gateway/daemon-command-registry.ts
+++ b/runtime/src/gateway/daemon-command-registry.ts
@@ -3446,12 +3446,12 @@ export function createDaemonCommandRegistry(
         preferred: resolveSessionShellProfile(session?.metadata ?? {}),
       });
       const currentWorkflowState = resolveSessionWorkflowState(session.metadata);
-      // Bare `/plan` toggles into plan mode on first invocation (matches
-      // Claude Code's behavior — user types `/plan`, stage flips, next
-      // turn runs with read-only tools). If already in plan mode, bare
-      // `/plan` shows the current plan/surface instead of silently
-      // re-flipping. Explicit subcommands (`status|enter|exit|…`) still
-      // win over the toggle default.
+      // Bare `/plan` toggles into plan mode on first invocation — user
+      // types `/plan`, stage flips, next turn runs with read-only tools.
+      // If already in plan mode, bare `/plan` shows the current
+      // plan/surface instead of silently re-flipping. Explicit
+      // subcommands (`status|enter|exit|…`) still win over the toggle
+      // default.
       const subcommand =
         typeof jsonArgs?.subcommand === "string"
           ? jsonArgs.subcommand.trim().toLowerCase()

--- a/runtime/src/gateway/daemon-webchat-turn.test.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.test.ts
@@ -802,9 +802,8 @@ You have broad access to this machine via the system.bash tool.`,
         runtimeContext: {
           workspaceRoot: "/home/tetsuo/git/stream-test/agenc-shell",
           // workflowStage is plumbed through so the chat-executor stop-gate
-          // can suppress the narrated_future_tool_work detector when the
-          // session is in plan mode (PR #481) and so user-asked-for-report
-          // suppression has access to the live session stage if needed.
+          // knows whether the session is in plan mode and so the live
+          // session stage is available where needed.
           workflowStage: "idle",
         },
         message: expect.objectContaining({

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -7533,11 +7533,10 @@ export class DaemonManager {
       // promoted any prompt containing `@PLAN.md` + a milestone token
       // (e.g. `M0`) into a persistent bg-run, which then looped forever
       // because the completion gate requires tool-based artifact
-      // evidence that a conversational prompt can never produce. Claude
-      // Code's reference design has no such promotion path: every user
-      // turn stays foreground and ends when the model stops emitting
-      // tool calls. Explicit bg-run entry points (slash command, etc.)
-      // remain available through other code paths.
+      // evidence that a conversational prompt can never produce. Every
+      // user turn stays foreground and ends when the model stops
+      // emitting tool calls. Explicit bg-run entry points (slash
+      // command, etc.) remain available through other code paths.
       maybeStartBackgroundRun: async () => false,
     });
   }

--- a/runtime/src/gateway/delegation-runtime.ts
+++ b/runtime/src/gateway/delegation-runtime.ts
@@ -276,8 +276,7 @@ export interface DelegationToolCompositionContext {
    * enriched `subagents.progress` event carrying
    * `payload.progress = SubAgentAgentProgress` so UIs can render
    * live tool counts, tokens, and last-tool name under the spawning
-   * `execute_with_agent` card — mirrors `AgentProgressLine` in
-   * `../claude_code/components/AgentProgressLine.tsx`.
+   * `execute_with_agent` card.
    */
   readonly progressTracker?: SubAgentProgressTracker | null;
   readonly launchShellAgentTask?: (params: {

--- a/runtime/src/gateway/init-runner.test.ts
+++ b/runtime/src/gateway/init-runner.test.ts
@@ -129,9 +129,9 @@ describe("init-runner", () => {
     // Previously this asserted the output contained the word "future", which
     // came from the hard-coded string "PLAN.md references a future CMake-based
     // build, but no CMakeLists.txt exists in the repository yet." That string
-    // was removed on 2026-04-06 along with the C-shell-specific PLAN.md
-    // hard-coding in init-runner.ts that violated the global CLAUDE.md learned
-    // rule "Never make runtime behavior depend on a filename like PLAN.md".
+    // was removed on 2026-04-06 along with the PLAN.md filename special-casing
+    // in init-runner.ts — runtime behavior must not depend on any particular
+    // filename.
   });
 
   it("renders planned structure from tree-style PLAN.md without double bullets or repo-root noise", async () => {

--- a/runtime/src/gateway/init-runner.ts
+++ b/runtime/src/gateway/init-runner.ts
@@ -86,11 +86,10 @@ const KEY_FILE_PATTERNS = [
   /^claude\.md$/i,
   /^agents\.md$/i,
   // Generic planning/spec markdown files at the repo root. Replaces a
-  // hard-coded `^plan\.md$` pattern that special-cased a single filename and
-  // violated the global CLAUDE.md learned rule "Never make runtime behavior
-  // depend on a filename like PLAN.md". Anything matching `*.md` at the root
-  // that is not README/CLAUDE/AGENTS will be picked up as a candidate
-  // planning document and filtered downstream in synthesizeInitGuide.
+  // hard-coded `^plan\.md$` pattern that special-cased a single filename.
+  // Anything matching `*.md` at the root that is not README/CLAUDE/AGENTS
+  // will be picked up as a candidate planning document and filtered
+  // downstream in synthesizeInitGuide.
   /^[A-Za-z0-9._-]+\.md$/i,
 ] as const;
 
@@ -306,11 +305,8 @@ function synthesizeInitGuide(params: {
   const claude = params.evidence.keyFiles.find((file) => /^CLAUDE\.md$/i.test(file.path));
   const agents = params.evidence.keyFiles.find((file) => /^AGENTS\.md$/i.test(file.path));
   // Markdown files at the repo root that look like planning/spec documents,
-  // generically. Discovered by extension, not by a hard-coded filename — the
-  // previous code special-cased PLAN.md and emitted C-shell-specific strings
-  // like "PLAN.md specifies K&R-style C function definitions for the planned
-  // shell implementation", which violated the global CLAUDE.md learned rule
-  // "Never make runtime behavior depend on a filename like PLAN.md".
+  // generically. Discovered by extension, not by a hard-coded filename —
+  // runtime behavior must not depend on any particular filename.
   const planningDocs = params.evidence.keyFiles.filter(
     (file) =>
       /\.md$/i.test(file.path) &&

--- a/runtime/src/gateway/sub-agent-progress.ts
+++ b/runtime/src/gateway/sub-agent-progress.ts
@@ -1,14 +1,12 @@
 /**
- * Per-sub-agent progress tracker that mirrors Claude Code's
- * `ProgressTracker` (see
- * `../claude_code/tasks/LocalAgentTask/LocalAgentTask.tsx`).
+ * Per-sub-agent progress tracker.
  *
  * For every live sub-agent session the tracker maintains:
  *   - `toolUseCount` — number of tool rounds dispatched by the child.
- *   - `latestInputTokens` / `cumulativeOutputTokens` — matches Claude's
- *     token accounting: Claude's API reports `input_tokens` as the
- *     cumulative-per-turn number and `output_tokens` as per-turn, so we
- *     keep the latest input and sum outputs.
+ *   - `latestInputTokens` / `cumulativeOutputTokens` — provider APIs
+ *     typically report `input_tokens` as cumulative-per-turn and
+ *     `output_tokens` as per-turn, so we keep the latest input and sum
+ *     outputs.
  *   - `recentActivities` — ring buffer (cap 5) of the most recent tool
  *     activities for the "last: <tool>" line.
  *

--- a/runtime/src/gateway/sub-agent.ts
+++ b/runtime/src/gateway/sub-agent.ts
@@ -178,8 +178,7 @@ export interface SubAgentConfig {
    * Parent's tool-call id for the `execute_with_agent` invocation that
    * spawned this sub-agent. Used by lifecycle event consumers (TUI,
    * webchat UI) to thread child progress under the correct parent tool
-   * card. Matches the `parentToolUseID` concept in
-   * `../claude_code/utils/messages.ts::createProgressMessage`.
+   * card.
    */
   readonly parentToolCallId?: string;
   readonly shellProfile?: SessionShellProfile;

--- a/runtime/src/gateway/subagent-query.ts
+++ b/runtime/src/gateway/subagent-query.ts
@@ -3,8 +3,7 @@
  * subagent execution (Phase K of the 16-phase refactor in
  * TODO.MD).
  *
- * Mirrors `claude_code/tools/AgentTool/runAgent.ts` in shape: a
- * subagent spawn is a recursive `executeChat()` call with a
+ * A subagent spawn is a recursive `executeChat()` call with a
  * restricted tool surface, a scoped system prompt, and a
  * derived execution context. The wrapper yields the child's
  * events up to the parent stream (so a parent webchat or

--- a/runtime/src/gateway/tool-routing.test.ts
+++ b/runtime/src/gateway/tool-routing.test.ts
@@ -213,7 +213,7 @@ describe("buildAdvertisedToolBundle", () => {
 });
 
 // ============================================================================
-// Plan-mode tool filtering (Claude Code parity)
+// Plan-mode tool filtering
 // ============================================================================
 
 describe("buildAdvertisedToolBundle — plan-mode filter", () => {

--- a/runtime/src/llm/can-use-tool.ts
+++ b/runtime/src/llm/can-use-tool.ts
@@ -1,9 +1,9 @@
 /**
  * `canUseTool` permission hook (Cut 5.7).
  *
- * Mirrors `claude_code/hooks/useCanUseTool.ts` — a single async function
- * the dispatcher calls before invoking each tool. The default
- * implementation chains the existing AgenC permission stack:
+ * A single async function the dispatcher calls before invoking each
+ * tool. The default implementation chains the existing AgenC
+ * permission stack:
  *
  *   1. tool's own `Tool.checkPermissions()` (if defined)
  *   2. configured allow/deny rule patterns

--- a/runtime/src/llm/chat-executor-config.ts
+++ b/runtime/src/llm/chat-executor-config.ts
@@ -6,8 +6,8 @@
  * time config fields (`economicsPolicy`, `modelRoutingPolicy`,
  * `defaultRunClass`, `promptBudget`) and turn them into
  * phase-specific decisions. They are exposed as free functions
- * that take the relevant config as explicit arguments, matching
- * the claude_code state-as-argument pattern.
+ * that take the relevant config as explicit arguments (the
+ * state-as-argument pattern).
  *
  * The class keeps 1-line delegators that thread its private
  * fields through to these helpers until PR-8 eliminates the

--- a/runtime/src/llm/chat-executor-ctx-helpers.test.ts
+++ b/runtime/src/llm/chat-executor-ctx-helpers.test.ts
@@ -92,8 +92,8 @@ describe("ChatExecutor ctx-helpers behavior", () => {
   describe("tool loop stop reason and recovery hints", () => {
     it("does not hard-stop the loop just because the same tool call keeps failing", async () => {
       // Simulate the LLM calling desktop.bash with "mkdir" (no directory),
-      // which returns exitCode:1 every time. Claude-style behavior is to
-      // let the normal runtime round budget stop the loop rather than a
+      // which returns exitCode:1 every time. Expected behavior is to let
+      // the normal runtime round budget stop the loop rather than a
       // local repeated-failure fuse.
       const toolHandler = vi
         .fn()

--- a/runtime/src/llm/chat-executor-in-flight-compaction.ts
+++ b/runtime/src/llm/chat-executor-in-flight-compaction.ts
@@ -216,13 +216,12 @@ export async function maybeCompactInFlightCallInput(
       });
     // Snapshot the top-N most-recently-read files and build anchor
     // messages to re-inject their bytes immediately after the boundary.
-    // Mirrors Claude Code's `createPostCompactFileAttachments`: after
-    // compaction, the raw tool_result bytes are gone from the prompt,
-    // so the model would otherwise re-call `system.readFile` for the
-    // same paths round after round. Anchors short-circuit that. Also
-    // clears the in-memory read cache so the FILE_UNCHANGED_STUB
-    // short-circuit does not point at content that has been
-    // summarized away.
+    // After compaction, the raw tool_result bytes are gone from the
+    // prompt, so the model would otherwise re-call `system.readFile`
+    // for the same paths round after round. Anchors short-circuit that.
+    // Also clears the in-memory read cache so the FILE_UNCHANGED_STUB
+    // short-circuit does not point at content that has been summarized
+    // away.
     const anchorFileMessages = reattachRecentFilesOnCompaction(ctx.sessionId);
     const replayTailReconciliationMessages = (
       input.callReconciliationMessages ?? ctx.reconciliationMessages

--- a/runtime/src/llm/chat-executor-parallel-dispatch.test.ts
+++ b/runtime/src/llm/chat-executor-parallel-dispatch.test.ts
@@ -1,8 +1,7 @@
 /**
  * Phase B acceptance test: the tool loop dispatches consecutive
- * concurrency-safe tool calls in parallel via `Promise.all`,
- * matching the `claude_code/services/tools/toolOrchestration.ts`
- * shape. Before Phase B, the dispatch was serial regardless of the
+ * concurrency-safe tool calls in parallel via `Promise.all`. Before
+ * Phase B, the dispatch was serial regardless of the
  * `isConcurrencySafe` predicate — the predicate only drove
  * telemetry, not execution.
  *

--- a/runtime/src/llm/chat-executor-state.ts
+++ b/runtime/src/llm/chat-executor-state.ts
@@ -12,10 +12,10 @@
  *     touched by this module)
  *
  * They are exposed as free functions that take the Map (plus any
- * companion config like budget thresholds) as explicit arguments,
- * matching the claude_code state-as-argument pattern. The class
- * keeps the Maps as private fields and calls these helpers via
- * 1-line delegators until PR-8 eliminates the delegators.
+ * companion config like budget thresholds) as explicit arguments
+ * (the state-as-argument pattern). The class keeps the Maps as
+ * private fields and calls these helpers via 1-line delegators until
+ * PR-8 eliminates the delegators.
  *
  * @module
  */

--- a/runtime/src/llm/chat-executor-stop-gate.ts
+++ b/runtime/src/llm/chat-executor-stop-gate.ts
@@ -27,15 +27,13 @@
  *   - The `Report outcomes faithfully` system prompt rule from PR #300
  *     bans the behavior, but Grok ignored it.
  *
- * Modeled on Claude Code's `query/stopHooks.ts` `handleStopHooks()` flow:
- * the gate runs at turn-end (after the inner tool loop has exited),
+ * The gate runs at turn-end (after the inner tool loop has exited),
  * inspects the final assistant text against the turn's tool ledger, and
  * either lets the turn end normally or pushes a `blockingMessage` into
  * the model's context as a synthetic user message and grants the model
- * one recovery turn. Claude Code calls this `preventContinuation` /
- * `blockingErrors`. AgenC implements one recovery attempt; on the second
- * detection in the same turn the gate yields and lets the model's
- * response through (preventing infinite loops).
+ * one recovery turn. AgenC implements one recovery attempt; on the
+ * second detection in the same turn the gate yields and lets the
+ * model's response through (preventing infinite loops).
  *
  * @module
  */

--- a/runtime/src/llm/compact/autocompact.ts
+++ b/runtime/src/llm/compact/autocompact.ts
@@ -1,6 +1,6 @@
 /**
  * Autocompact layer — proactive history summarization above a token
- * threshold. Mirrors `claude_code/services/compact/autoCompact.ts`.
+ * threshold.
  *
  * The actual summarization step is intentionally pluggable: this
  * module exposes the threshold + tracking state, and a small

--- a/runtime/src/llm/compact/constants.ts
+++ b/runtime/src/llm/compact/constants.ts
@@ -1,17 +1,14 @@
 /**
  * Constants shared by the layered compaction modules.
  *
- * Mirrors `claude_code/services/compact/constants.ts`.
- *
  * @module
  */
 
 /**
- * Token ceiling for the per-call `max_output_tokens` escalation. Mirrors
- * `claude_code/utils/context.ts:ESCALATED_MAX_TOKENS`. Used by the
- * reactive-compact path when a withheld `max_output_tokens` error
- * surfaces and we want to retry with a larger output budget before
- * compacting history.
+ * Token ceiling for the per-call `max_output_tokens` escalation. Used
+ * by the reactive-compact path when a withheld `max_output_tokens`
+ * error surfaces and we want to retry with a larger output budget
+ * before compacting history.
  */
 export const ESCALATED_MAX_TOKENS = 64_000;
 
@@ -39,8 +36,8 @@ export { DEFAULT_AUTOCOMPACT_THRESHOLD_TOKENS };
 
 /**
  * Default time gap between activity bursts that allows the snip layer
- * to drop the oldest tail messages. 15 minutes mirrors claude_code's
- * default snip window.
+ * to drop the oldest tail messages. 15 minutes is the default snip
+ * window.
  */
 export const DEFAULT_SNIP_GAP_MS = 15 * 60 * 1000;
 

--- a/runtime/src/llm/compact/index.ts
+++ b/runtime/src/llm/compact/index.ts
@@ -1,8 +1,8 @@
 /**
- * Layered compaction (Cut 5.1, claude_code-alignment).
+ * Layered compaction (Cut 5.1).
  *
- * Replaces the legacy `prompt-budget.ts` ad-hoc compaction with a
- * `claude_code/services/compact/`-style ordered chain:
+ * Replaces the legacy `prompt-budget.ts` ad-hoc compaction with an
+ * ordered chain:
  *
  *     snip → microcompact → autocompact   (per-iteration)
  *     reactiveCompact                     (post-error 413 fallback)
@@ -144,9 +144,8 @@ export interface PerIterationCompactionResult {
 }
 
 /**
- * Orchestrator for the snip → microcompact → autocompact chain. Mirrors
- * `claude_code/query.ts` per-iteration compaction wire-up (~lines
- * 395–426 in the reference). Runs at the top of each provider call:
+ * Orchestrator for the snip → microcompact → autocompact chain.
+ * Runs at the top of each provider call:
  *
  *   1. `applySnip` — drops the oldest messages from a long-idle session
  *      without touching the ones the model still needs. Tracks how many
@@ -168,8 +167,8 @@ export interface PerIterationCompactionResult {
  * user), and reports a single combined `action` of `"noop"` or
  * `"compacted"`. Boundary messages are returned separately from the
  * pruned message list — the caller decides whether to inject them into
- * the outgoing conversation or just log them. Mirror behavior of
- * claude_code: boundary messages are observational, not model-facing.
+ * the outgoing conversation or just log them. Boundary messages are
+ * observational, not model-facing.
  */
 export function applyPerIterationCompaction(
   input: PerIterationCompactionInput,
@@ -279,8 +278,8 @@ export function applyPerIterationCompaction(
 
 /**
  * Conservative token estimate per snipped message used by the
- * snip → autocompact handoff. 192 is the claude_code reference value
- * for an average assistant/user message in a tool-heavy conversation.
+ * snip → autocompact handoff. 192 is a reasonable approximation for
+ * an average assistant/user message in a tool-heavy conversation.
  * Overestimating is safer than underestimating — if snip frees more
  * tokens than we claim, autocompact might trigger unnecessarily; if
  * we overstate, we may skip a legitimate autocompact. The real

--- a/runtime/src/llm/compact/microcompact.ts
+++ b/runtime/src/llm/compact/microcompact.ts
@@ -3,11 +3,9 @@
  * with a placeholder so the model doesn't pay token cost to recall
  * stale tool output.
  *
- * Mirrors `claude_code/services/compact/microCompact.ts` (time-based
- * path). Claude Code has a second path (cached microcompact) that uses
- * Anthropic's cache-editing API to surgically delete tool results
- * without invalidating the cached prefix. xAI does not expose an
- * equivalent cache-editing API, so only the time-based path is ported.
+ * Time-based path only. xAI does not expose a cache-editing API, so we
+ * cannot surgically delete tool results without invalidating the cached
+ * prefix; the time-based trigger is a reasonable approximation.
  *
  * Trigger: the gap since the last activity touch exceeds `gapMs`. When
  * the gap fires, the xAI server-side prompt cache has almost certainly
@@ -25,9 +23,9 @@ import {
 } from "./constants.js";
 
 /**
- * Placeholder that replaces the content of a cold tool result. Matches
- * Claude Code's `TIME_BASED_MC_CLEARED_MESSAGE` byte-for-byte so the
- * runtime's text filters, tests, and any parity checks line up.
+ * Placeholder that replaces the content of a cold tool result. Kept
+ * stable so the runtime's text filters, tests, and parity checks
+ * line up.
  */
 export const TIME_BASED_MC_CLEARED_MESSAGE =
   "[Old tool result content cleared]";
@@ -38,13 +36,12 @@ export const TIME_BASED_MC_CLEARED_MESSAGE =
  * status reads) are left alone because their results are already small
  * and carry state the model actively depends on.
  *
- * Mirrors Claude Code's `COMPACTABLE_TOOLS` set:
- *   - FileRead / FileEdit / FileWrite
- *   - Bash (SHELL_TOOL_NAMES)
- *   - Grep / Glob
- *   - WebSearch / WebFetch
- *
- * Adapted to AgenC's native tool surface.
+ * Covers:
+ *   - file read/edit/write
+ *   - shell
+ *   - grep/glob
+ *   - directory listing
+ *   - web browse / fetch
  */
 export const COMPACTABLE_TOOL_NAMES: ReadonlySet<string> = new Set([
   // File I/O
@@ -90,9 +87,9 @@ interface MicrocompactInput {
   readonly gapMs?: number;
   /**
    * How many of the most-recent compactable tool results to leave
-   * untouched. Default mirrors Claude Code's `keepRecent: 5`. Older
-   * compactable results get their `content` replaced with the
-   * placeholder; newer results pass through unchanged.
+   * untouched. Default is 5. Older compactable results get their
+   * `content` replaced with the placeholder; newer results pass
+   * through unchanged.
    */
   readonly keepRecent?: number;
 }

--- a/runtime/src/llm/compact/per-iteration-compaction.test.ts
+++ b/runtime/src/llm/compact/per-iteration-compaction.test.ts
@@ -229,8 +229,7 @@ describe("applyPerIterationCompaction", () => {
     );
     expect(microBoundary).toBeDefined();
     // Cold tool result bodies should be replaced with the
-    // TIME_BASED_MC_CLEARED_MESSAGE placeholder (byte-identical to
-    // Claude Code's placeholder string).
+    // TIME_BASED_MC_CLEARED_MESSAGE placeholder.
     const placeholderHits = result.messages.filter(
       (m) =>
         m.role === "tool" &&
@@ -409,7 +408,7 @@ describe("applyPerIterationCompaction", () => {
 });
 
 // ============================================================================
-// applyMicrocompact — Claude Code time-based MC parity
+// applyMicrocompact — time-based microcompact
 // ============================================================================
 
 import {
@@ -419,8 +418,8 @@ import {
   COMPACTABLE_TOOL_NAMES,
 } from "./microcompact.js";
 
-describe("applyMicrocompact (time-based parity)", () => {
-  const GAP_MS = 60 * 60 * 1000; // 60 min, matching Claude Code default
+describe("applyMicrocompact (time-based)", () => {
+  const GAP_MS = 60 * 60 * 1000; // 60 min default
 
   it("noops when the gap has not elapsed", () => {
     const state = {
@@ -533,11 +532,11 @@ describe("applyMicrocompact (time-based parity)", () => {
     expect(r.action).toBe("noop");
   });
 
-  it("uses TIME_BASED_MC_CLEARED_MESSAGE placeholder verbatim (Claude parity)", () => {
+  it("uses TIME_BASED_MC_CLEARED_MESSAGE placeholder verbatim", () => {
     expect(TIME_BASED_MC_CLEARED_MESSAGE).toBe("[Old tool result content cleared]");
   });
 
-  it("COMPACTABLE_TOOL_NAMES includes Claude Code's equivalents", () => {
+  it("COMPACTABLE_TOOL_NAMES includes the expected tools", () => {
     for (const expected of [
       "system.readFile",
       "system.editFile",

--- a/runtime/src/llm/compact/post-compact-attachments.ts
+++ b/runtime/src/llm/compact/post-compact-attachments.ts
@@ -10,12 +10,12 @@
  * re-inject the file contents as `<anchor-file>` system messages that
  * sit just after the compaction boundary in the new prompt.
  *
- * The chars-per-file and total-chars budgets are conservative. Over the
- * grok/claude ~4-chars-per-token ratio these roughly match upstream's
- * 5K/file + 50K envelope. The helpers are shared between the chat
- * executor's in-flight compaction path and the background-run
- * supervisor's internal compaction path so both exits produce
- * byte-identical anchor messages for the same snapshot input.
+ * The chars-per-file and total-chars budgets are conservative, sized
+ * for a ~4-chars-per-token ratio and a 5K/file + 50K envelope. The
+ * helpers are shared between the chat executor's in-flight compaction
+ * path and the background-run supervisor's internal compaction path so
+ * both exits produce byte-identical anchor messages for the same
+ * snapshot input.
  *
  * @module
  */

--- a/runtime/src/llm/compact/reactive-compact.ts
+++ b/runtime/src/llm/compact/reactive-compact.ts
@@ -1,14 +1,13 @@
 /**
  * Reactive compact layer — fired when a model call returns a withheld
- * 413 (`prompt_too_long`) or `max_output_tokens` overflow. Mirrors
- * `claude_code/services/compact/reactiveCompact.ts`.
+ * 413 (`prompt_too_long`) or `max_output_tokens` overflow.
  *
  * Unlike autocompact, this is suffix-preserving: it walks the head of
  * the message array and trims the *oldest* messages first, then
  * retries the model call. The first attempt drops the oldest 25%; if
  * that still 413s, drop another 25%; etc.
  *
- * Cut 5.1 of the claude_code-alignment refactor.
+ * Cut 5.1.
  *
  * @module
  */

--- a/runtime/src/llm/compact/snip.ts
+++ b/runtime/src/llm/compact/snip.ts
@@ -1,13 +1,13 @@
 /**
  * Snip layer — drops the oldest messages from a long-idle session
- * before any model call. Mirrors `claude_code/services/compact/snip.ts`.
+ * before any model call.
  *
  * Snip is a non-summarizing trim. It just removes messages from the
  * head of the array when the session has been idle for `gapMs` and
  * the history is longer than `keepRecent`. The intent is to keep
  * cold sessions cheap to resume without paying compaction overhead.
  *
- * Cut 5.1 of the claude_code-alignment refactor.
+ * Cut 5.1.
  *
  * @module
  */

--- a/runtime/src/llm/compact/token-count.ts
+++ b/runtime/src/llm/compact/token-count.ts
@@ -1,12 +1,12 @@
 /**
  * `tokenCountWithEstimation` — canonical token counter for compaction
- * decisions. Mirrors `claude_code/utils/tokens.ts:tokenCountWithEstimation`.
+ * decisions.
  *
  * Walks backward to the last API response with usage metadata, then
  * estimates token cost for any messages added since. Returns a single
  * integer count comparable across compaction layers.
  *
- * Cut 5.1 of the claude_code-alignment refactor.
+ * Cut 5.1.
  *
  * @module
  */
@@ -44,8 +44,7 @@ export function tokenCountWithEstimation(input: TokenCountInput): number {
   }
 
   // Estimate roughly 1 token per 4 characters of message content for
-  // anything we don't have a billed measurement for. This is the same
-  // shape as claude_code's `roughTokenCountEstimationForMessages`.
+  // anything we don't have a billed measurement for.
   let estimated = 0;
   for (const message of messages) {
     if (typeof message.content === "string") {

--- a/runtime/src/llm/context-compaction.ts
+++ b/runtime/src/llm/context-compaction.ts
@@ -91,8 +91,8 @@ export function createCompactBoundaryMessage(params: {
  * True when `message` is a compact boundary marker produced by a prior
  * compaction pass. Used to keep pre-existing boundaries verbatim across
  * subsequent compactions so the prefix (and xAI `prompt_cache_key`
- * match region) stays stable. Mirrors Claude Code's "anchor-preserved"
- * message pattern: once a boundary is placed, it is not re-summarized.
+ * match region) stays stable. Anchor-preserved: once a boundary is
+ * placed, it is not re-summarized.
  */
 export function isCompactBoundaryMessage(message: LLMMessage): boolean {
   if (message.role !== "system") return false;

--- a/runtime/src/llm/execute-chat.ts
+++ b/runtime/src/llm/execute-chat.ts
@@ -2,8 +2,7 @@
  * `executeChat` — async-generator entry point for the agent loop
  * (Phase C of the 16-phase refactor in TODO.MD).
  *
- * This file lands the new async-generator shape that mirrors
- * `/home/tetsuo/git/claude_code/query.ts:219`. It runs in PARALLEL
+ * This file lands the new async-generator shape. It runs in PARALLEL
  * with the existing `ChatExecutor.execute()` class method — both
  * coexist until Phase F deletes the class and its helpers become
  * free functions.

--- a/runtime/src/llm/hooks/dispatcher.ts
+++ b/runtime/src/llm/hooks/dispatcher.ts
@@ -1,6 +1,5 @@
 /**
- * Hook dispatcher (Cut 5.2). Mirrors the chain in
- * `claude_code/utils/hooks.ts:executeHooks`.
+ * Hook dispatcher (Cut 5.2).
  *
  * Walks every hook definition registered for the given event, runs the
  * matching ones in parallel with a per-hook timeout, and folds their

--- a/runtime/src/llm/hooks/matcher.ts
+++ b/runtime/src/llm/hooks/matcher.ts
@@ -1,5 +1,5 @@
 /**
- * Hook matcher (Cut 5.2). Mirrors `claude_code/utils/hooks.ts:matchesPattern`.
+ * Hook matcher (Cut 5.2).
  *
  * Supports:
  *   - exact name        `Bash`

--- a/runtime/src/llm/hooks/types.ts
+++ b/runtime/src/llm/hooks/types.ts
@@ -1,9 +1,8 @@
 /**
  * Hook system types — Phase H narrowed vocabulary.
  *
- * Mirrors a subset of `/home/tetsuo/git/claude_code/utils/hooks.ts`:
- * the events this runtime actually fires, plus the ones it has a
- * clear wiring plan for. Phase H (16-phase refactor, TODO.MD)
+ * Covers the events this runtime actually fires, plus the ones it has
+ * a clear wiring plan for. Phase H (16-phase refactor, TODO.MD)
  * deleted 8 event types that were declared but never dispatched:
  * `UserPromptSubmit`, `Notification`, `FileChanged`, `ConfigChange`,
  * `PermissionRequest`, `PermissionDenied`, `SubagentStart`,

--- a/runtime/src/llm/streaming-events.ts
+++ b/runtime/src/llm/streaming-events.ts
@@ -9,9 +9,8 @@
  * point, and Phase E migrates the 10 production callers to
  * `for await (const event of executeChat(...))`.
  *
- * The shapes mirror `/home/tetsuo/git/claude_code/types/message.ts`
- * with AgenC-specific extensions (trace correlation, compaction
- * boundary reasons, subagent lineage) inlined where they diverge.
+ * The shapes carry AgenC-specific extensions (trace correlation,
+ * compaction boundary reasons, subagent lineage) where needed.
  *
  * @module
  */

--- a/runtime/src/llm/tool-orchestration.ts
+++ b/runtime/src/llm/tool-orchestration.ts
@@ -1,8 +1,6 @@
 /**
  * `runTools` — concurrency-safe tool dispatch (Cut 5.5).
  *
- * Mirrors `claude_code/services/tools/toolOrchestration.ts` (~188 LOC).
- *
  * Partitions tool calls into batches of:
  *  - consecutive *concurrency-safe* (read-only) tools, run in parallel
  *  - one *non-concurrency-safe* tool at a time, run serially

--- a/runtime/src/llm/tool-result-budget.ts
+++ b/runtime/src/llm/tool-result-budget.ts
@@ -1,10 +1,8 @@
 /**
  * Per-tool result budget + disk persistence (Cut 5.3).
  *
- * Mirrors `claude_code/utils/toolResultStorage.ts`.
- *
  * Today the runtime truncates large tool results in-memory via
- * `prepareToolResultForPrompt` (~12 KB cap). Claude Code persists
+ * `prepareToolResultForPrompt` (~12 KB cap). This module persists
  * oversized results to disk and replaces the wire payload with a
  * 2 KB preview + file path. The model can then use the file path to
  * read the full content if it needs to.

--- a/runtime/src/llm/types.ts
+++ b/runtime/src/llm/types.ts
@@ -598,7 +598,7 @@ export interface LLMProvider {
  * Shared configuration for all LLM providers
  */
 export interface LLMProviderConfig {
-  /** Model identifier (e.g. 'grok-3', 'claude-sonnet-4-5-20250929', 'llama3') */
+  /** Model identifier (e.g. 'grok-3', 'grok-4', 'llama3') */
   model: string;
   /** System prompt prepended to conversations */
   systemPrompt?: string;

--- a/runtime/src/llm/verification-target-guard.ts
+++ b/runtime/src/llm/verification-target-guard.ts
@@ -6,9 +6,8 @@
  * referencing a verification harness path (test/spec file), and the model
  * immediately follows up with a `system.writeFile` / `system.appendFile` /
  * `desktop.text_editor` targeting that same harness, the dispatch loop
- * refuses the write. This mirrors Claude Code's layered approach of removing
- * the affordance to lie rather than trusting the model to heed a recovery
- * hint it is free to ignore.
+ * refuses the write. The gate removes the affordance to lie rather than
+ * trusting the model to heed a recovery hint it is free to ignore.
  *
  * The canonical `TEST_FILE_PATH_RE` lives here and is re-exported so the
  * gateway verification-metadata tagger uses the same source of truth as the

--- a/runtime/src/policy/glob.ts
+++ b/runtime/src/policy/glob.ts
@@ -8,7 +8,7 @@
  *   - `gateway/tool-policy.ts:matchesPattern`
  *   - `gateway/approvals.ts:globMatch`
  *
- * Supports the same syntax claude_code's permission system uses:
+ * Supports:
  *   - exact name              `Bash`
  *   - wildcard match-any      `Bash(*)`
  *   - prefix wildcard         `Bash(npm *)`

--- a/runtime/src/tools/system/filesystem.test.ts
+++ b/runtime/src/tools/system/filesystem.test.ts
@@ -931,8 +931,8 @@ describe("system.writeFile", () => {
 });
 
 // ============================================================================
-// system.editFile (Claude-Code-style string replace, Read-before-Edit
-// enforced at the tool boundary)
+// system.editFile (string replace, Read-before-Edit enforced at the tool
+// boundary)
 // ============================================================================
 
 describe("system.editFile", () => {

--- a/runtime/src/tools/system/filesystem.ts
+++ b/runtime/src/tools/system/filesystem.ts
@@ -10,9 +10,9 @@
  * - system.writeFile — write/overwrite a full file (creates parent dirs)
  * - system.appendFile — append to file
  * - system.editFile — string-replace edit on an existing file
- *                     (Claude-Code-style old_string/new_string semantics;
- *                      preferred over writeFile for incremental edits to
- *                      avoid JSON-escape bugs in nested string literals)
+ *                     (old_string/new_string semantics; preferred over
+ *                      writeFile for incremental edits to avoid
+ *                      JSON-escape bugs in nested string literals)
  * - system.listDir — list directory entries
  * - system.stat — file/directory metadata
  * - system.mkdir — create directories
@@ -22,14 +22,13 @@
  * Read-before-Write rule:
  * `system.writeFile` and `system.editFile` enforce that the model has
  * called `system.readFile` on the target path in the current session
- * before any modification (modeled on Claude Code's
- * `tools/FileWriteTool/FileWriteTool.ts:198-206` check). This forces
- * the model to have the LITERAL pre-edit bytes in its context before
- * generating the next write, which is the highest-leverage structural
- * defense against the Grok JSON-escape bug. The rule is skipped for
- * non-existent files (creating new files does not require a prior
- * read) and can be rehydrated from the persisted local history cache
- * after compaction or restart.
+ * before any modification. This forces the model to have the LITERAL
+ * pre-edit bytes in its context before generating the next write,
+ * which is the highest-leverage structural defense against the Grok
+ * JSON-escape bug. The rule is skipped for non-existent files
+ * (creating new files does not require a prior read) and can be
+ * rehydrated from the persisted local history cache after compaction
+ * or restart.
  *
  * @module
  */
@@ -89,9 +88,7 @@ export const SESSION_ID_ARG = "__agencSessionId";
 /**
  * Per-session readFileState map. Tracks which files have been read in
  * each session so that `system.writeFile` and `system.editFile` can
- * enforce a Read-before-Write rule modeled on Claude Code's
- * `tools/FileWriteTool/FileWriteTool.ts:198-206` check (see report.txt
- * §References for the upstream pattern).
+ * enforce a Read-before-Write rule.
  *
  * The rationale is documented in detail in PR #314: forcing the model
  * to call `system.readFile` before any modification is the highest-
@@ -110,8 +107,7 @@ export const SESSION_ID_ARG = "__agencSessionId";
  *     have a canonical form yet)
  *   - `system.writeFile` and `system.editFile` consult this map only
  *     when the target path EXISTS — creating a new file does not
- *     require a prior read (Claude Code's FileWriteTool.ts:191-196
- *     uses the same ENOENT escape hatch)
+ *     require a prior read (ENOENT escape hatch)
  *   - The latest snapshots are also mirrored into a bounded local
  *     history cache under a temp-root outside the tracked workspace
  *     tree so recent source-of-truth content is available for
@@ -130,9 +126,8 @@ interface SessionReadSnapshot {
   /**
    * For partial reads (`viewKind === "partial"`), the exact line offset
    * the model passed. Stored so a subsequent read with the identical
-   * `(offset, limit)` and unchanged mtime can serve from the cache
-   * stub — matches Claude Code's range-aware FILE_UNCHANGED dedup
-   * (claude_code/tools/FileReadTool/FileReadTool.ts:547-573).
+   * `(offset, limit)` and unchanged mtime can serve from the cache stub
+   * via range-aware FILE_UNCHANGED dedup.
    */
   readonly readOffset?: number;
   /** For partial reads, the exact line limit the model passed. */
@@ -1237,12 +1232,10 @@ function createReadFileTool(
 
         // Cache-hit short-circuit: if this session already read this
         // path and the file's mtime is unchanged, return the
-        // FILE_UNCHANGED_STUB instead of re-reading. Mirrors Claude
-        // Code's range-aware FILE_UNCHANGED dedup
-        // (claude_code/tools/FileReadTool/FileReadTool.ts:547-573):
-        // full reads dedup against a prior full read; partial reads
-        // dedup only when the exact `(offset, limit)` matches the
-        // prior partial read for the same path. A different slice
+        // FILE_UNCHANGED_STUB instead of re-reading. Range-aware
+        // dedup: full reads dedup against a prior full read; partial
+        // reads dedup only when the exact `(offset, limit)` matches
+        // the prior partial read for the same path. A different slice
         // always falls through.
         const cacheHitSessionId = resolveSessionId(args);
         const requestedReadWindow = resolveReadWindow(args);
@@ -1441,12 +1434,11 @@ function createWriteFileTool(
           return errorResult("content must be a string");
         }
 
-        // Read-before-Write enforcement (Claude Code FileWriteTool.ts:198-206
-        // pattern). If the target path EXISTS and the model has not called
-        // system.readFile on it in the current session, reject the write
-        // with a structured error that names the rule. Non-existent paths
-        // are allowed through unconditionally so brand-new file creation
-        // continues to work without a prior read.
+        // Read-before-Write enforcement. If the target path EXISTS and the
+        // model has not called system.readFile on it in the current session,
+        // reject the write with a structured error that names the rule.
+        // Non-existent paths are allowed through unconditionally so
+        // brand-new file creation continues to work without a prior read.
         const sessionId = resolveSessionId(args);
         let targetExists = false;
         try {
@@ -1647,12 +1639,11 @@ function createAppendFileTool(
 }
 
 /**
- * `system.editFile` — Claude-Code-style string-replacement edit tool.
+ * `system.editFile` — string-replacement edit tool.
  *
- * Mirrors `tools/FileEditTool/FileEditTool.ts` from Claude Code. Takes
- * `{path, old_string, new_string, replace_all?}` and performs an exact
- * string replacement on the file at `path`. The model uses this tool
- * for incremental edits instead of `system.writeFile` (full file
+ * Takes `{path, old_string, new_string, replace_all?}` and performs an
+ * exact string replacement on the file at `path`. The model uses this
+ * tool for incremental edits instead of `system.writeFile` (full file
  * replacement). The architectural reason is in the `system.writeFile`
  * description: rewriting a 200-line C source file via a JSON tool
  * call exposes hundreds of nested-quote escape opportunities, every
@@ -1834,10 +1825,10 @@ function createEditFileTool(
         );
 
         // Find occurrences of old_string in the existing content after
-        // Claude-Code-style normalization (quote reconciliation,
-        // desanitization, and replacement whitespace cleanup). Matching
-        // remains literal and deterministic; normalization only widens
-        // common representational drift before the safety checks below.
+        // Text normalization pass (quote reconciliation, desanitization,
+        // and replacement whitespace cleanup). Matching remains literal
+        // and deterministic; normalization only widens common
+        // representational drift before the safety checks below.
         let occurrences = 0;
         let searchFrom = 0;
         // eslint-disable-next-line no-constant-condition

--- a/runtime/src/tools/system/workflow-plan-mode.ts
+++ b/runtime/src/tools/system/workflow-plan-mode.ts
@@ -14,8 +14,7 @@
  * objective so the operator sees it in `/plan status`. The operator
  * then approves by calling the existing `/plan implement` slash
  * command (or any other verb that flips stage out of "plan"), which
- * re-opens the mutating tool surface. That slash-command approval step
- * is the AgenC equivalent of Claude Code's UI "proceed" button — it
+ * re-opens the mutating tool surface. The slash-command approval step
  * deliberately requires an explicit human act to unlock execution.
  *
  * @module

--- a/runtime/src/utils/build-info.ts
+++ b/runtime/src/utils/build-info.ts
@@ -1,7 +1,7 @@
 /**
  * Reads `runtime/dist/VERSION` (written by `scripts/write-build-version.mjs`)
  * so the daemon can prove which build is running. This is the verification
- * primitive for Cut 6.2 of the claude_code-alignment refactor.
+ * primitive for Cut 6.2.
  *
  * The file lives next to the running daemon entry point at
  * `<runtimeRoot>/dist/VERSION`. We resolve via `process.argv[1]` so the


### PR DESCRIPTION
## Summary

Scrub source comments that referenced an external tool by name or pointed at paths in a mirror codebase. Comments now describe AgenC's own behavior in neutral terms. No runtime behavior change.

## What's kept

- \`CLAUDE.md\` file parsing in \`init-runner.ts\` — user projects use that filename as a convention for per-repo instructions, so the regex and style line are functional.
- \`xai-strict-filter.test.ts\` test fixtures — those strings exercise the model-rejection path.

## Scope

44 files touched, 160 insertions, 211 deletions. All edits are comment-only.

## Test plan

- [x] Full runtime test suite runs with no new failures (5 pre-existing marketplace-cli failures unrelated)
- [x] \`npm run build\` passes