### PR TITLE
Task system: tracker cleanup, handle tools, prompt surface, and panel

### DIFF
--- a/runtime/src/gateway/daemon-session-state.ts
+++ b/runtime/src/gateway/daemon-session-state.ts
@@ -124,6 +124,7 @@ export type PersistedWebSessionRuntimeState = PersistedSessionReplayState;
 const MAX_STATUS_SNAPSHOT_TASKS = 20;
 const MAX_STATUS_SNAPSHOT_WORKERS = 10;
 const MAX_STATUS_SNAPSHOT_MILESTONES = 20;
+const MAX_STATUS_SNAPSHOT_RECENT_COMPLETED = 3;
 
 function isTerminalStopReason(
   value: unknown,
@@ -155,6 +156,9 @@ function buildRuntimeTaskHandle(task: Task): RuntimeTaskHandle {
     kind: task.kind,
     status: task.status,
     updatedAt: task.updatedAt,
+    ...(task.subject !== undefined ? { subject: task.subject } : {}),
+    ...(task.activeForm !== undefined ? { activeForm: task.activeForm } : {}),
+    ...(task.owner !== undefined ? { owner: task.owner } : {}),
     ...(task.summary !== undefined ? { summary: task.summary } : {}),
     ...(task.externalRef !== undefined
       ? { externalRef: { ...task.externalRef } }
@@ -1215,19 +1219,30 @@ export async function buildRuntimeContractStatusSnapshotForSession(params: {
     return undefined;
   }
 
-  const tasks = params.taskStore
-    ? (await params.taskStore.listTasks(params.sessionId)).filter(
-        (task) =>
-          task.status !== "deleted" &&
-          task.status !== "completed" &&
-          task.status !== "failed" &&
-          task.status !== "cancelled",
-      )
+  const allTasks = params.taskStore
+    ? await params.taskStore.listTasks(params.sessionId)
     : [];
+  const tasks = allTasks.filter(
+    (task) =>
+      task.status !== "deleted" &&
+      task.status !== "completed" &&
+      task.status !== "failed" &&
+      task.status !== "cancelled",
+  );
   const openTasks = tasks
     .sort((left, right) => right.updatedAt - left.updatedAt)
     .map(buildRuntimeTaskHandle);
   const truncatedTasks = openTasks.slice(0, MAX_STATUS_SNAPSHOT_TASKS);
+  const recentCompletedTasks = allTasks
+    .filter(
+      (task) =>
+        task.status === "completed" ||
+        task.status === "failed" ||
+        task.status === "cancelled",
+    )
+    .sort((left, right) => right.updatedAt - left.updatedAt)
+    .slice(0, MAX_STATUS_SNAPSHOT_RECENT_COMPLETED)
+    .map(buildRuntimeTaskHandle);
 
   const workers = params.workerManager
     ? (await params.workerManager.listWorkers(params.sessionId)).filter(
@@ -1272,6 +1287,9 @@ export async function buildRuntimeContractStatusSnapshotForSession(params: {
       0,
       remainingMilestones.length - truncatedMilestones.length,
     ),
+    ...(recentCompletedTasks.length > 0
+      ? { recentCompletedTasks }
+      : {}),
   };
 }
 

--- a/runtime/src/gateway/daemon-text-channel-turn.ts
+++ b/runtime/src/gateway/daemon-text-channel-turn.ts
@@ -328,11 +328,16 @@ export async function executeTextChannelTurn(
   const tasksForAttachment = params.readTasksForSession
     ? await params.readTasksForSession(msg.sessionId)
     : [];
+  const sessionActiveTaskContextForAttachment =
+    buildSessionActiveTaskContext(session);
   const runtimeAttachments = collectAttachments({
     history: historyBeforeAttachments,
     activeToolNames: new Set<string>(advertisedToolNames),
     todos: todosForAttachment,
     tasks: tasksForAttachment,
+    ...(sessionActiveTaskContextForAttachment
+      ? { activeTaskContext: sessionActiveTaskContextForAttachment }
+      : {}),
   });
   const effectiveHistory =
     runtimeAttachments.messages.length > 0
@@ -410,7 +415,7 @@ export async function executeTextChannelTurn(
   }
 
   const sessionStateful = buildSessionStatefulOptions(session);
-  const sessionActiveTaskContext = buildSessionActiveTaskContext(session);
+  const sessionActiveTaskContext = sessionActiveTaskContextForAttachment;
   const isConcordiaGenerateAgentsTurn = isConcordiaGenerateAgentsMessage(msg);
   const structuredOutput =
     buildConcordiaGenerateAgentsStructuredOutput(msg);

--- a/runtime/src/gateway/daemon-tool-registry.ts
+++ b/runtime/src/gateway/daemon-tool-registry.ts
@@ -41,6 +41,7 @@ import { createServerTools } from "../tools/system/server.js";
 import { createSqliteTools } from "../tools/system/sqlite.js";
 import { createSpreadsheetTools } from "../tools/system/spreadsheet.js";
 import {
+  createRuntimeTaskHandleTools,
   createTaskTrackerTools,
   SessionTaskStore,
   TaskStore,
@@ -434,6 +435,47 @@ export async function createDaemonToolRegistry(
               : hookResult.blockingMessage,
         };
       },
+      ...(traceConfig.enabled
+        ? {
+            onTaskAccessEvent: async (event) => {
+              logTraceEvent(
+                logger,
+                `runtime_contract.task.${event.type}`,
+                {
+                  traceId: buildRuntimeContractTaskTraceId(
+                    event.listId,
+                    event.taskId,
+                  ),
+                  sessionId: event.listId,
+                  taskId: event.taskId,
+                  timestamp: event.timestamp,
+                  ...(event.until ? { until: event.until } : {}),
+                  ...(event.timeoutMs !== undefined
+                    ? { timeoutMs: event.timeoutMs }
+                    : {}),
+                  ...(event.includeEvents !== undefined
+                    ? { includeEvents: event.includeEvents }
+                    : {}),
+                  ...(event.maxBytes !== undefined
+                    ? { maxBytes: event.maxBytes }
+                    : {}),
+                  ...(event.ready !== undefined ? { ready: event.ready } : {}),
+                  ...(event.task
+                    ? {
+                        taskStatus: event.task.status,
+                        taskOutputReady: event.task.outputReady === true,
+                      }
+                    : {}),
+                },
+                traceConfig.maxChars,
+              );
+            },
+          }
+        : {}),
+    }),
+  );
+  registry.registerAll(
+    createRuntimeTaskHandleTools(taskTrackerStore, {
       ...(traceConfig.enabled
         ? {
             onTaskAccessEvent: async (event) => {

--- a/runtime/src/gateway/daemon-webchat-turn.ts
+++ b/runtime/src/gateway/daemon-webchat-turn.ts
@@ -461,6 +461,9 @@ export async function executeWebChatConversationTurn(
       activeToolNames: new Set<string>(advertisedToolNames),
       todos: todosForAttachment,
       tasks: tasksForAttachment,
+      ...(sessionActiveTaskContext
+        ? { activeTaskContext: sessionActiveTaskContext }
+        : {}),
     });
     const effectiveHistory =
       runtimeAttachments.messages.length > 0

--- a/runtime/src/gateway/task-panel.test.ts
+++ b/runtime/src/gateway/task-panel.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import type { RuntimeTaskHandle } from "../runtime-contract/types.js";
+import {
+  buildTaskPanelView,
+  buildTaskPanelViewFromSnapshot,
+  formatTaskPanelLines,
+} from "./task-panel.js";
+
+function handle(
+  overrides: Partial<RuntimeTaskHandle> & Pick<RuntimeTaskHandle, "id" | "status">,
+): RuntimeTaskHandle {
+  return {
+    kind: "manual",
+    ...overrides,
+  };
+}
+
+describe("buildTaskPanelView", () => {
+  it("partitions by status and sorts by updatedAt desc", () => {
+    const view = buildTaskPanelView({
+      openTasks: [
+        handle({
+          id: "1",
+          status: "pending",
+          subject: "Older pending",
+          updatedAt: 10,
+        }),
+        handle({
+          id: "2",
+          status: "in_progress",
+          subject: "Older in-progress",
+          activeForm: "Running older",
+          updatedAt: 20,
+        }),
+        handle({
+          id: "3",
+          status: "in_progress",
+          subject: "Newest",
+          activeForm: "Running newest",
+          updatedAt: 100,
+        }),
+        handle({
+          id: "4",
+          status: "pending",
+          subject: "Newer pending",
+          updatedAt: 50,
+        }),
+      ],
+    });
+
+    expect(view.inProgress.map((t) => t.id)).toEqual(["3", "2"]);
+    expect(view.pending.map((t) => t.id)).toEqual(["4", "1"]);
+  });
+
+  it("prefers activeForm when in_progress, subject otherwise", () => {
+    const view = buildTaskPanelView({
+      openTasks: [
+        handle({
+          id: "1",
+          status: "in_progress",
+          subject: "Run tests",
+          activeForm: "Running tests",
+        }),
+        handle({
+          id: "2",
+          status: "pending",
+          subject: "Ship it",
+          activeForm: "Shipping it",
+        }),
+      ],
+    });
+    expect(view.inProgress[0]?.label).toBe("Running tests");
+    expect(view.pending[0]?.label).toBe("Ship it");
+  });
+
+  it("falls back to summary then kind when neither subject nor activeForm is set", () => {
+    const view = buildTaskPanelView({
+      openTasks: [
+        handle({
+          id: "1",
+          status: "pending",
+          summary: "summary-only",
+        }),
+        handle({ id: "2", status: "pending", kind: "verifier" }),
+      ],
+    });
+    expect(view.pending[0]?.label).toBe("summary-only");
+    expect(view.pending[1]?.label).toBe("verifier task");
+  });
+
+  it("passes through recent-completed tail without filtering", () => {
+    const view = buildTaskPanelView({
+      openTasks: [],
+      recentCompletedTasks: [
+        handle({ id: "9", status: "completed", subject: "Old win", updatedAt: 1 }),
+        handle({ id: "10", status: "failed", subject: "New loss", updatedAt: 2 }),
+      ],
+    });
+    expect(view.recentCompleted.map((t) => t.id)).toEqual(["10", "9"]);
+  });
+
+  it("propagates omittedTaskCount onto the view", () => {
+    const view = buildTaskPanelView({
+      openTasks: [],
+      omittedTaskCount: 5,
+    });
+    expect(view.omittedOpenCount).toBe(5);
+  });
+});
+
+describe("buildTaskPanelViewFromSnapshot", () => {
+  it("returns undefined when the snapshot is missing", () => {
+    expect(buildTaskPanelViewFromSnapshot(undefined)).toBeUndefined();
+  });
+});
+
+describe("formatTaskPanelLines", () => {
+  it("returns an empty array when the panel is empty and no empty message is set", () => {
+    const lines = formatTaskPanelLines({
+      inProgress: [],
+      pending: [],
+      recentCompleted: [],
+      omittedOpenCount: 0,
+    });
+    expect(lines).toEqual([]);
+  });
+
+  it("emits a header plus an entry per task with status icons", () => {
+    const lines = formatTaskPanelLines(
+      buildTaskPanelView({
+        openTasks: [
+          handle({
+            id: "1",
+            status: "in_progress",
+            subject: "s",
+            activeForm: "Running migration",
+            owner: "agent-a",
+          }),
+          handle({ id: "2", status: "pending", subject: "Write docs" }),
+        ],
+      }),
+    );
+    expect(lines[0]).toBe("Tasks");
+    expect(lines.some((line) => line.includes("Running migration"))).toBe(true);
+    expect(lines.some((line) => line.includes("(agent-a)"))).toBe(true);
+    expect(lines.some((line) => line.startsWith("o #2"))).toBe(true);
+  });
+
+  it("emits an overflow marker when omittedOpenCount > 0", () => {
+    const lines = formatTaskPanelLines(
+      buildTaskPanelView({
+        openTasks: [handle({ id: "1", status: "pending", subject: "t" })],
+        omittedTaskCount: 7,
+      }),
+    );
+    expect(lines.some((line) => line.includes("+7 more not shown"))).toBe(true);
+  });
+
+  it("emits a recent-completed section when tail entries exist", () => {
+    const lines = formatTaskPanelLines(
+      buildTaskPanelView({
+        openTasks: [],
+        recentCompletedTasks: [
+          handle({ id: "9", status: "completed", subject: "Shipped feature" }),
+        ],
+      }),
+    );
+    expect(lines).toContain("Recently completed");
+    expect(lines.some((line) => line.includes("Shipped feature"))).toBe(true);
+  });
+
+  it("truncates labels that exceed maxLabelLength", () => {
+    const longLabel = "x".repeat(200);
+    const lines = formatTaskPanelLines(
+      buildTaskPanelView({
+        openTasks: [
+          handle({ id: "1", status: "pending", subject: longLabel }),
+        ],
+      }),
+      { maxLabelLength: 20 },
+    );
+    const entryLine = lines.find((line) => line.startsWith("o #1"));
+    expect(entryLine).toBeDefined();
+    expect(entryLine!.length).toBeLessThanOrEqual(40);
+    expect(entryLine).toContain("\u2026");
+  });
+
+  it("shows [output ready] when the task has finalized output", () => {
+    const lines = formatTaskPanelLines(
+      buildTaskPanelView({
+        openTasks: [
+          handle({
+            id: "1",
+            status: "in_progress",
+            subject: "Delegated work",
+            outputReady: true,
+          }),
+        ],
+      }),
+    );
+    expect(lines.some((line) => line.includes("[output ready]"))).toBe(true);
+  });
+});

--- a/runtime/src/gateway/task-panel.ts
+++ b/runtime/src/gateway/task-panel.ts
@@ -1,0 +1,186 @@
+/**
+ * Read-only task-panel formatter for any rendering surface (TUI, web,
+ * dashboard, future clients). Pure function — given the open-task list
+ * and the recent-completed tail from a
+ * {@link ../runtime-contract/types.js#RuntimeContractStatusSnapshot},
+ * produce a stable structured view the renderer can lay out.
+ *
+ * No ANSI, no widths, no column math. Those belong to the renderer so
+ * they can adapt to terminal width, theme, or HTML. This module only
+ * decides: which tasks appear, in what order, with what label.
+ *
+ * Ordering contract:
+ *   1. in_progress tasks first, most recently updated first
+ *   2. pending tasks next, most recently updated first
+ *   3. recent-completed tail last (already pre-truncated by the
+ *      snapshot builder — this module only renders what it receives)
+ *
+ * Each entry's display label is:
+ *   - activeForm when the task is in_progress and activeForm is set
+ *   - subject otherwise
+ *   - summary as a last-resort fallback when neither subject nor
+ *     activeForm is populated (runtime-only tasks may lack both)
+ *
+ * @module
+ */
+
+import type {
+  RuntimeContractStatusSnapshot,
+  RuntimeTaskHandle,
+} from "../runtime-contract/types.js";
+
+export interface TaskPanelEntry {
+  readonly id: string;
+  readonly status: string;
+  readonly kind: string;
+  readonly label: string;
+  readonly owner?: string;
+  readonly outputReady?: boolean;
+  readonly updatedAt?: number;
+}
+
+export interface TaskPanelView {
+  readonly inProgress: readonly TaskPanelEntry[];
+  readonly pending: readonly TaskPanelEntry[];
+  readonly recentCompleted: readonly TaskPanelEntry[];
+  readonly omittedOpenCount: number;
+}
+
+function chooseLabel(handle: RuntimeTaskHandle): string {
+  if (handle.status === "in_progress" && handle.activeForm) {
+    return handle.activeForm;
+  }
+  if (handle.subject && handle.subject.length > 0) return handle.subject;
+  if (handle.summary && handle.summary.length > 0) return handle.summary;
+  return `${handle.kind} task`;
+}
+
+function toEntry(handle: RuntimeTaskHandle): TaskPanelEntry {
+  return {
+    id: handle.id,
+    status: handle.status,
+    kind: handle.kind,
+    label: chooseLabel(handle),
+    ...(handle.owner !== undefined ? { owner: handle.owner } : {}),
+    ...(handle.outputReady !== undefined
+      ? { outputReady: handle.outputReady }
+      : {}),
+    ...(handle.updatedAt !== undefined ? { updatedAt: handle.updatedAt } : {}),
+  };
+}
+
+function byUpdatedAtDesc(a: RuntimeTaskHandle, b: RuntimeTaskHandle): number {
+  return (b.updatedAt ?? 0) - (a.updatedAt ?? 0);
+}
+
+export interface BuildTaskPanelViewInput {
+  readonly openTasks: readonly RuntimeTaskHandle[];
+  readonly recentCompletedTasks?: readonly RuntimeTaskHandle[];
+  readonly omittedTaskCount?: number;
+}
+
+export function buildTaskPanelView(
+  input: BuildTaskPanelViewInput,
+): TaskPanelView {
+  const inProgress = input.openTasks
+    .filter((task) => task.status === "in_progress")
+    .slice()
+    .sort(byUpdatedAtDesc)
+    .map(toEntry);
+  const pending = input.openTasks
+    .filter((task) => task.status === "pending")
+    .slice()
+    .sort(byUpdatedAtDesc)
+    .map(toEntry);
+  const recentCompleted = (input.recentCompletedTasks ?? [])
+    .slice()
+    .sort(byUpdatedAtDesc)
+    .map(toEntry);
+  return {
+    inProgress,
+    pending,
+    recentCompleted,
+    omittedOpenCount: input.omittedTaskCount ?? 0,
+  };
+}
+
+export function buildTaskPanelViewFromSnapshot(
+  snapshot: RuntimeContractStatusSnapshot | undefined,
+): TaskPanelView | undefined {
+  if (!snapshot) return undefined;
+  return buildTaskPanelView({
+    openTasks: snapshot.openTasks,
+    ...(snapshot.recentCompletedTasks
+      ? { recentCompletedTasks: snapshot.recentCompletedTasks }
+      : {}),
+    omittedTaskCount: snapshot.omittedTaskCount,
+  });
+}
+
+const STATUS_ICON: Readonly<Record<string, string>> = {
+  in_progress: "*",
+  pending: "o",
+  completed: "x",
+  failed: "!",
+  cancelled: "-",
+  deleted: "-",
+};
+
+function iconFor(status: string): string {
+  return STATUS_ICON[status] ?? "?";
+}
+
+export interface FormatTaskPanelLinesOptions {
+  readonly showHeader?: boolean;
+  readonly maxLabelLength?: number;
+  readonly emptyMessage?: string;
+}
+
+function truncate(value: string, max: number): string {
+  if (max <= 3) return value.slice(0, max);
+  if (value.length <= max) return value;
+  return `${value.slice(0, max - 1)}\u2026`;
+}
+
+/**
+ * Convenience formatter that emits simple text lines suitable for a
+ * minimal panel. Renderers with richer styling primitives should use
+ * {@link buildTaskPanelView} directly and style the entries themselves.
+ */
+export function formatTaskPanelLines(
+  view: TaskPanelView,
+  options: FormatTaskPanelLinesOptions = {},
+): readonly string[] {
+  const maxLabel = options.maxLabelLength ?? 72;
+  const showHeader = options.showHeader ?? true;
+  const lines: string[] = [];
+  const isEmpty =
+    view.inProgress.length === 0 &&
+    view.pending.length === 0 &&
+    view.recentCompleted.length === 0;
+  if (isEmpty) {
+    if (options.emptyMessage) lines.push(options.emptyMessage);
+    return lines;
+  }
+  const renderEntry = (entry: TaskPanelEntry): void => {
+    const icon = iconFor(entry.status);
+    const owner = entry.owner ? ` (${entry.owner})` : "";
+    const ready = entry.outputReady ? " [output ready]" : "";
+    lines.push(
+      `${icon} #${entry.id} ${truncate(entry.label, maxLabel)}${owner}${ready}`,
+    );
+  };
+  if (showHeader && (view.inProgress.length > 0 || view.pending.length > 0)) {
+    lines.push("Tasks");
+  }
+  for (const entry of view.inProgress) renderEntry(entry);
+  for (const entry of view.pending) renderEntry(entry);
+  if (view.omittedOpenCount > 0) {
+    lines.push(`  (+${view.omittedOpenCount} more not shown)`);
+  }
+  if (view.recentCompleted.length > 0) {
+    if (showHeader) lines.push("Recently completed");
+    for (const entry of view.recentCompleted) renderEntry(entry);
+  }
+  return lines;
+}

--- a/runtime/src/gateway/tool-handler-factory.ts
+++ b/runtime/src/gateway/tool-handler-factory.ts
@@ -21,6 +21,7 @@ import {
 import {
   TASK_ACTOR_KIND_ARG,
   TASK_ACTOR_NAME_ARG,
+  TASK_HANDLE_TOOL_NAMES,
   TASK_LIST_ARG,
   TASK_TRACKER_TOOL_NAMES,
 } from "../tools/system/task-tracker.js";
@@ -358,7 +359,10 @@ function applySessionTaskListId(
   args: Record<string, unknown>,
   sessionId: string | undefined,
 ): Record<string, unknown> {
-  if (!TASK_TRACKER_TOOL_NAMES.has(toolName)) {
+  if (
+    !TASK_TRACKER_TOOL_NAMES.has(toolName) &&
+    !TASK_HANDLE_TOOL_NAMES.has(toolName)
+  ) {
     return args;
   }
   if (!sessionId || sessionId.trim().length === 0) {
@@ -376,7 +380,10 @@ function applyTaskActorContext(
   isSubAgentSession: boolean,
   subAgentInfo: DelegationSubAgentInfo,
 ): Record<string, unknown> {
-  if (!TASK_TRACKER_TOOL_NAMES.has(toolName)) {
+  if (
+    !TASK_TRACKER_TOOL_NAMES.has(toolName) &&
+    !TASK_HANDLE_TOOL_NAMES.has(toolName)
+  ) {
     return args;
   }
   const actorName =

--- a/runtime/src/llm/active-task-context-prompt.test.ts
+++ b/runtime/src/llm/active-task-context-prompt.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACTIVE_TASK_CONTEXT_HEADER_PREFIX,
+  buildActiveTaskContextMessage,
+  shouldInjectActiveTaskContext,
+} from "./active-task-context-prompt.js";
+import type { ActiveTaskContext } from "./turn-execution-contract-types.js";
+import type { LLMMessage } from "./types.js";
+
+function contextOf(
+  overrides: Partial<ActiveTaskContext> = {},
+): ActiveTaskContext {
+  return {
+    version: 1,
+    taskLineageId: "lineage-a",
+    contractFingerprint: "fp-1",
+    turnClass: "workflow_implementation",
+    ownerMode: "workflow_owner",
+    sourceArtifacts: ["/w/a.ts"],
+    targetArtifacts: ["/w/b.ts"],
+    ...overrides,
+  };
+}
+
+describe("shouldInjectActiveTaskContext", () => {
+  it("returns false when there is no context", () => {
+    expect(
+      shouldInjectActiveTaskContext({
+        history: [],
+        activeTaskContext: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("injects on first turn with a context", () => {
+    expect(
+      shouldInjectActiveTaskContext({
+        history: [],
+        activeTaskContext: contextOf(),
+      }),
+    ).toBe(true);
+  });
+
+  it("skips injection when the prior block fingerprint matches", () => {
+    const context = contextOf({ contractFingerprint: "abc" });
+    const prior = buildActiveTaskContextMessage(context);
+    expect(
+      shouldInjectActiveTaskContext({
+        history: [prior],
+        activeTaskContext: context,
+      }),
+    ).toBe(false);
+  });
+
+  it("re-injects when the fingerprint changes", () => {
+    const oldContext = contextOf({ contractFingerprint: "abc" });
+    const prior = buildActiveTaskContextMessage(oldContext);
+    expect(
+      shouldInjectActiveTaskContext({
+        history: [prior],
+        activeTaskContext: contextOf({ contractFingerprint: "xyz" }),
+      }),
+    ).toBe(true);
+  });
+
+  it("re-injects only based on the most recent block", () => {
+    const old = buildActiveTaskContextMessage(
+      contextOf({ contractFingerprint: "old" }),
+    );
+    const current = buildActiveTaskContextMessage(
+      contextOf({ contractFingerprint: "current" }),
+    );
+    expect(
+      shouldInjectActiveTaskContext({
+        history: [old, current],
+        activeTaskContext: contextOf({ contractFingerprint: "current" }),
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("buildActiveTaskContextMessage", () => {
+  it("includes workspaceRoot and both artifact lists", () => {
+    const msg = buildActiveTaskContextMessage(
+      contextOf({
+        workspaceRoot: "/w",
+        sourceArtifacts: ["/w/a.ts", "/w/b.ts"],
+        targetArtifacts: ["/w/out.ts"],
+      }),
+    );
+    const content =
+      typeof msg.content === "string"
+        ? msg.content
+        : msg.content.map((c) => (c.type === "text" ? c.text : "")).join("");
+    expect(content).toContain(ACTIVE_TASK_CONTEXT_HEADER_PREFIX);
+    expect(content).toContain("workspaceRoot: /w");
+    expect(content).toContain("sourceArtifacts: /w/a.ts, /w/b.ts");
+    expect(content).toContain("targetArtifacts: /w/out.ts");
+  });
+
+  it("shows (none) for empty artifact lists", () => {
+    const msg = buildActiveTaskContextMessage(
+      contextOf({ sourceArtifacts: [], targetArtifacts: [] }),
+    );
+    const content = msg.content as string;
+    expect(content).toContain("sourceArtifacts: (none)");
+    expect(content).toContain("targetArtifacts: (none)");
+  });
+
+  it("truncates long artifact lists and counts the overflow", () => {
+    const sources = Array.from({ length: 12 }, (_, i) => `/w/s${i}.ts`);
+    const msg = buildActiveTaskContextMessage(contextOf({ sourceArtifacts: sources }));
+    const content = msg.content as string;
+    expect(content).toContain("/w/s0.ts");
+    expect(content).toContain("/w/s7.ts");
+    expect(content).toContain("+4 more");
+  });
+
+  it("carries user role and runtime-only merge boundary plus anchor preserve", () => {
+    const msg = buildActiveTaskContextMessage(contextOf());
+    expect(msg.role).toBe("user");
+    expect(msg.runtimeOnly?.mergeBoundary).toBe("user_context");
+    expect(msg.runtimeOnly?.anchorPreserve).toBe(true);
+  });
+
+  it("omits optional fields when the context does not supply them", () => {
+    const msg = buildActiveTaskContextMessage(contextOf());
+    const content = msg.content as string;
+    expect(content).not.toContain("workspaceRoot:");
+    expect(content).not.toContain("displayArtifact:");
+  });
+
+  it("embeds the contract fingerprint so subsequent turns can dedup", () => {
+    const msg = buildActiveTaskContextMessage(
+      contextOf({ contractFingerprint: "deadbeef" }),
+    );
+    const content = msg.content as string;
+    expect(content).toContain("context-fingerprint:deadbeef");
+  });
+});
+
+describe("idempotent across consecutive turns", () => {
+  it("a second collectAttachments-like call with identical context yields no new block", () => {
+    const context = contextOf({ contractFingerprint: "same" });
+    const first = buildActiveTaskContextMessage(context);
+    const history: LLMMessage[] = [first];
+    expect(
+      shouldInjectActiveTaskContext({
+        history,
+        activeTaskContext: context,
+      }),
+    ).toBe(false);
+  });
+});

--- a/runtime/src/llm/active-task-context-prompt.ts
+++ b/runtime/src/llm/active-task-context-prompt.ts
@@ -1,0 +1,120 @@
+/**
+ * Injects the current `ActiveTaskContext` into the model's prompt as a
+ * compact system-reminder user message.
+ *
+ * Sibling of `task-reminder.ts`. Unlike the task reminder (which throttles
+ * on turn-count), this block is a "current state" signal: it surfaces
+ * the workspace and artifact fields that back workflow ownership so the
+ * model can reason about which files the current task is supposed to
+ * read or write.
+ *
+ * Dedup strategy: each block carries a fingerprint derived from the
+ * context's `contractFingerprint`. `shouldInjectActiveTaskContext`
+ * scans the most recent matching header in history and skips injection
+ * when the fingerprint matches the current context. This means:
+ *   - first turn with a context: inject.
+ *   - follow-up turns with the same context: no duplicate.
+ *   - when the context changes: a new block is injected with the new
+ *     fingerprint, so the model always sees the freshest state.
+ *
+ * Only the fields the model can act on are surfaced: `workspaceRoot`,
+ * `displayArtifact`, `sourceArtifacts`, `targetArtifacts`. `turnClass`
+ * and `ownerMode` stay internal to the runtime contract because they
+ * are validator-facing, not model-facing.
+ *
+ * @module
+ */
+
+import type { ActiveTaskContext } from "./turn-execution-contract-types.js";
+import type { LLMMessage } from "./types.js";
+
+export const ACTIVE_TASK_CONTEXT_HEADER_PREFIX =
+  "The current task context is:";
+
+const FINGERPRINT_TAG_PREFIX = "context-fingerprint:";
+const ARTIFACT_LIST_LIMIT = 8;
+
+function stringContent(message: LLMMessage): string {
+  if (typeof message.content === "string") return message.content;
+  return message.content
+    .map((part) => (part.type === "text" ? part.text : ""))
+    .join("");
+}
+
+function extractMostRecentFingerprint(
+  history: readonly LLMMessage[],
+): string | undefined {
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const message = history[index]!;
+    if (message.role !== "user") continue;
+    const content = stringContent(message);
+    if (!content.includes(ACTIVE_TASK_CONTEXT_HEADER_PREFIX)) continue;
+    const marker = content.indexOf(FINGERPRINT_TAG_PREFIX);
+    if (marker === -1) return "";
+    const tail = content.slice(marker + FINGERPRINT_TAG_PREFIX.length);
+    const end = tail.search(/[\s>]/);
+    return end === -1 ? tail : tail.slice(0, end);
+  }
+  return undefined;
+}
+
+export interface ShouldInjectActiveTaskContextParams {
+  readonly history: readonly LLMMessage[];
+  readonly activeTaskContext: ActiveTaskContext | undefined;
+}
+
+export function shouldInjectActiveTaskContext(
+  params: ShouldInjectActiveTaskContextParams,
+): boolean {
+  if (!params.activeTaskContext) return false;
+  const fingerprint = params.activeTaskContext.contractFingerprint;
+  if (!fingerprint) return true;
+  const previous = extractMostRecentFingerprint(params.history);
+  if (previous === undefined) return true;
+  return previous !== fingerprint;
+}
+
+function truncatedArtifactList(
+  artifacts: readonly string[],
+  max: number,
+): string {
+  if (artifacts.length === 0) return "(none)";
+  if (artifacts.length <= max) return artifacts.join(", ");
+  const visible = artifacts.slice(0, max).join(", ");
+  const extra = artifacts.length - max;
+  return `${visible}, ... (+${extra} more)`;
+}
+
+export function buildActiveTaskContextMessage(
+  context: ActiveTaskContext,
+): LLMMessage {
+  const lines: string[] = [ACTIVE_TASK_CONTEXT_HEADER_PREFIX];
+  if (context.workspaceRoot) {
+    lines.push(`- workspaceRoot: ${context.workspaceRoot}`);
+  }
+  if (context.displayArtifact) {
+    lines.push(`- displayArtifact: ${context.displayArtifact}`);
+  }
+  lines.push(
+    `- sourceArtifacts: ${truncatedArtifactList(
+      context.sourceArtifacts,
+      ARTIFACT_LIST_LIMIT,
+    )}`,
+  );
+  lines.push(
+    `- targetArtifacts: ${truncatedArtifactList(
+      context.targetArtifacts,
+      ARTIFACT_LIST_LIMIT,
+    )}`,
+  );
+  const body = lines.join("\n");
+  const fingerprint = context.contractFingerprint ?? "";
+  const content =
+    `<system-reminder>\n${body}\n` +
+    `<${FINGERPRINT_TAG_PREFIX}${fingerprint}>\n</system-reminder>`;
+  return {
+    role: "user",
+    content,
+    runtimeOnly: { mergeBoundary: "user_context", anchorPreserve: true },
+  };
+}

--- a/runtime/src/llm/attachment-injection.ts
+++ b/runtime/src/llm/attachment-injection.ts
@@ -26,6 +26,7 @@
 
 import type { LLMMessage } from "./types.js";
 import type { TodoItem } from "../tools/system/todo-store.js";
+import type { ActiveTaskContext } from "./turn-execution-contract-types.js";
 import {
   buildTodoReminderMessage,
   shouldInjectTodoReminder,
@@ -39,6 +40,10 @@ import {
   buildVerifyReminderMessage,
   shouldInjectVerifyReminder,
 } from "./verify-reminder.js";
+import {
+  buildActiveTaskContextMessage,
+  shouldInjectActiveTaskContext,
+} from "./active-task-context-prompt.js";
 
 export interface AttachmentContext {
   readonly history: readonly LLMMessage[];
@@ -61,6 +66,14 @@ export interface AttachmentContext {
    */
   readonly mutatingEditsSinceLastVerifierSpawn?: number;
   readonly assistantTurnsSinceLastVerifyReminder?: number;
+  /**
+   * Current turn-execution contract. Surfaces workspace root and the
+   * source/target artifact lists to the model via a compact
+   * system-reminder block. Injection is fingerprint-deduplicated
+   * against history so the block refreshes when the context changes
+   * but does not accumulate when it stays the same.
+   */
+  readonly activeTaskContext?: ActiveTaskContext;
 }
 
 export interface AttachmentInjectionResult {
@@ -97,6 +110,14 @@ export function collectAttachments(
     })
   ) {
     messages.push(buildVerifyReminderMessage());
+  }
+  if (
+    shouldInjectActiveTaskContext({
+      history: ctx.history,
+      activeTaskContext: ctx.activeTaskContext,
+    })
+  ) {
+    messages.push(buildActiveTaskContextMessage(ctx.activeTaskContext!));
   }
   return { messages };
 }

--- a/runtime/src/runtime-contract/types.ts
+++ b/runtime/src/runtime-contract/types.ts
@@ -197,6 +197,16 @@ export interface RuntimeTaskHandle {
   readonly kind: string;
   readonly status: string;
   readonly updatedAt?: number;
+  /** Brief, human-readable task title (e.g. "Run migration"). */
+  readonly subject?: string;
+  /**
+   * Present-continuous form of the subject shown while the task is
+   * in_progress (e.g. "Running migration"). When absent, renderers
+   * should fall back to the subject.
+   */
+  readonly activeForm?: string;
+  /** Agent id or name currently claiming the task. */
+  readonly owner?: string;
   readonly summary?: string;
   readonly externalRef?: {
     readonly kind: string;
@@ -226,6 +236,12 @@ export interface RuntimeContractStatusSnapshot {
   readonly omittedTaskCount: number;
   readonly omittedWorkerCount: number;
   readonly omittedMilestoneCount: number;
+  /**
+   * Small tail of tasks that recently reached a terminal status. Used
+   * by read-only panels to show "just-completed" context alongside
+   * {@link openTasks}. Kept bounded so snapshots stay small.
+   */
+  readonly recentCompletedTasks?: readonly RuntimeTaskHandle[];
 }
 
 export type RuntimeMailboxDirection = "parent_to_worker" | "worker_to_parent";

--- a/runtime/src/tools/system/task-tracker.test.ts
+++ b/runtime/src/tools/system/task-tracker.test.ts
@@ -492,15 +492,12 @@ describe("task-tracker", () => {
       expect(result.raw.isError).toBe(true);
     });
 
-    it("allows ordinary task completion even when a completion guard is configured", async () => {
-      let guardCalled = false;
+    it("invokes the completion guard on every completion transition", async () => {
+      let guardCalled = 0;
       tools = createTaskTrackerTools(store, {
         onBeforeTaskComplete: async () => {
-          guardCalled = true;
-          return {
-            outcome: "block",
-            message: "completion blocked",
-          };
+          guardCalled += 1;
+          return { outcome: "allow" };
         },
       });
       update = findTool(tools, "task.update");
@@ -517,7 +514,51 @@ describe("task-tracker", () => {
         },
       });
       expect(store.get(DEFAULT_TASK_LIST_ID, "1")?.status).toBe("completed");
-      expect(guardCalled).toBe(false);
+      expect(guardCalled).toBe(1);
+    });
+
+    it("invokes the completion guard for tasks with unresolved blockedBy entries", async () => {
+      await callTool(create, { subject: "Blocker", description: "blocker" });
+      await callTool(update, { taskId: "1", addBlockedBy: ["2"] });
+
+      let guardCalled = 0;
+      tools = createTaskTrackerTools(store, {
+        onBeforeTaskComplete: async () => {
+          guardCalled += 1;
+          return { outcome: "allow" };
+        },
+      });
+      update = findTool(tools, "task.update");
+
+      const result = await callTool(update, { taskId: "1", status: "completed" });
+
+      expect(result.raw.isError).toBeUndefined();
+      expect(result.body).toMatchObject({
+        success: true,
+        statusChange: { from: "pending", to: "completed" },
+      });
+      expect(guardCalled).toBe(1);
+    });
+
+    it("lets the completion guard block ordinary (non-verification) completions", async () => {
+      let guardCalled = false;
+      tools = createTaskTrackerTools(store, {
+        onBeforeTaskComplete: async () => {
+          guardCalled = true;
+          return {
+            outcome: "block",
+            message: "completion blocked",
+          };
+        },
+      });
+      update = findTool(tools, "task.update");
+
+      const result = await callTool(update, { taskId: "1", status: "completed" });
+
+      expect(result.raw.isError).toBe(true);
+      expect(result.body.error).toContain("completion blocked");
+      expect(store.get(DEFAULT_TASK_LIST_ID, "1")?.status).toBe("pending");
+      expect(guardCalled).toBe(true);
     });
 
     it("still blocks explicit verification tasks when the completion guard rejects them", async () => {

--- a/runtime/src/tools/system/task-tracker.test.ts
+++ b/runtime/src/tools/system/task-tracker.test.ts
@@ -5,10 +5,14 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   TASK_ACTOR_KIND_ARG,
   TASK_ACTOR_NAME_ARG,
+  TASK_EVENT_RETENTION_CAP,
   TASK_HANDLE_MAX_TIMEOUT_MS,
   TASK_HANDLE_TOOL_NAMES,
+  compactDeletedTasksInPlace,
   createRuntimeTaskHandleTools,
   createTaskTrackerTools,
+  detectBlockCycleForPatch,
+  pruneTaskEventsInPlace,
   SessionTaskStore,
   TaskStore,
   type TaskTrackerToolOptions,
@@ -18,6 +22,7 @@ import {
   isOpenTaskStatus,
   listOpenTasksForSession,
 } from "./task-tracker.js";
+import type { Task } from "./task-tracker.js";
 import type { Tool, ToolResult } from "../types.js";
 import type { MemoryBackend } from "../../memory/types.js";
 
@@ -1052,6 +1057,238 @@ describe("task-tracker", () => {
     it("treats terminal statuses as closed", () => {
       expect(isOpenTaskStatus("completed")).toBe(false);
       expect(isOpenTaskStatus("deleted")).toBe(false);
+    });
+  });
+
+  describe("metadata._internal invariant", () => {
+    it("rejects task.create with metadata._internal set", async () => {
+      const result = await callTool(create, {
+        subject: "Malicious internal task",
+        description: "should not be allowed",
+        metadata: { _internal: true },
+      });
+      expect(result.raw.isError).toBe(true);
+      expect(result.body.error).toContain("_internal");
+    });
+
+    it("rejects task.update metadata patches that include _internal", async () => {
+      await callTool(create, { subject: "Normal", description: "normal" });
+      const result = await callTool(update, {
+        taskId: "1",
+        metadata: { _internal: true },
+      });
+      expect(result.raw.isError).toBe(true);
+      expect(result.body.error).toContain("_internal");
+    });
+  });
+
+  describe("block cycle detection", () => {
+    beforeEach(async () => {
+      await callTool(create, { subject: "A", description: "a" });
+      await callTool(create, { subject: "B", description: "b" });
+      await callTool(create, { subject: "C", description: "c" });
+    });
+
+    it("rejects a self-block via addBlocks", async () => {
+      const result = await callTool(update, {
+        taskId: "1",
+        addBlocks: ["1"],
+      });
+      expect(result.raw.isError).toBe(true);
+      expect(result.body.error).toContain("cannot block itself");
+    });
+
+    it("rejects a self-block via addBlockedBy", async () => {
+      const result = await callTool(update, {
+        taskId: "1",
+        addBlockedBy: ["1"],
+      });
+      expect(result.raw.isError).toBe(true);
+      expect(result.body.error).toContain("blocked by itself");
+    });
+
+    it("rejects a direct 2-task cycle", async () => {
+      await callTool(update, { taskId: "1", addBlocks: ["2"] });
+      const result = await callTool(update, {
+        taskId: "2",
+        addBlocks: ["1"],
+      });
+      expect(result.raw.isError).toBe(true);
+      expect(result.body.error).toContain("cycle");
+    });
+
+    it("rejects an indirect 3-task cycle", async () => {
+      await callTool(update, { taskId: "1", addBlocks: ["2"] });
+      await callTool(update, { taskId: "2", addBlocks: ["3"] });
+      const result = await callTool(update, {
+        taskId: "3",
+        addBlocks: ["1"],
+      });
+      expect(result.raw.isError).toBe(true);
+      expect(result.body.error).toContain("cycle");
+    });
+
+    it("allows non-cyclic additions", async () => {
+      await callTool(update, { taskId: "1", addBlocks: ["2"] });
+      const result = await callTool(update, {
+        taskId: "2",
+        addBlocks: ["3"],
+      });
+      expect(result.raw.isError).toBeUndefined();
+      expect(result.body.success).toBe(true);
+    });
+  });
+
+  describe("pruneTaskEventsInPlace", () => {
+    function buildTaskWithEvents(count: number): Task {
+      const events = [
+        {
+          id: "ev-0",
+          type: "created" as const,
+          summary: "created",
+          timestamp: 0,
+        },
+      ];
+      for (let i = 1; i <= count; i += 1) {
+        events.push({
+          id: `ev-${i}`,
+          type: "updated" as const,
+          summary: `update ${i}`,
+          timestamp: i,
+        });
+      }
+      events.push({
+        id: `ev-final`,
+        type: "completed" as const,
+        summary: "done",
+        timestamp: count + 1,
+      });
+      return {
+        id: "1",
+        kind: "manual",
+        ownerSessionId: "list-a",
+        subject: "s",
+        description: "d",
+        status: "completed",
+        blocks: [],
+        blockedBy: [],
+        events,
+        createdAt: 0,
+        updatedAt: count + 1,
+      };
+    }
+
+    it("is a no-op when events are below the retention cap", () => {
+      const task = buildTaskWithEvents(5);
+      const mutated = pruneTaskEventsInPlace(task);
+      expect(mutated).toBe(false);
+      expect(task.events).toHaveLength(7);
+    });
+
+    it("preserves the created event and all transition events when pruning", () => {
+      const task = buildTaskWithEvents(TASK_EVENT_RETENTION_CAP + 20);
+      const mutated = pruneTaskEventsInPlace(task);
+      expect(mutated).toBe(true);
+      expect(task.events[0]?.type).toBe("created");
+      expect(task.events.some((event) => event.type === "completed")).toBe(true);
+      expect(task.events.length).toBeLessThanOrEqual(TASK_EVENT_RETENTION_CAP);
+    });
+
+    it("inserts a single truncation marker event when pruning happens", () => {
+      const task = buildTaskWithEvents(TASK_EVENT_RETENTION_CAP + 40);
+      pruneTaskEventsInPlace(task);
+      const markers = task.events.filter(
+        (event) =>
+          event.type === "updated" &&
+          event.summary === "Event log truncated to retention cap",
+      );
+      expect(markers).toHaveLength(1);
+
+      pruneTaskEventsInPlace(task);
+      const markersAgain = task.events.filter(
+        (event) =>
+          event.type === "updated" &&
+          event.summary === "Event log truncated to retention cap",
+      );
+      expect(markersAgain).toHaveLength(1);
+    });
+  });
+
+  describe("compactDeletedTasksInPlace", () => {
+    it("removes only deleted entries and preserves order", () => {
+      const tasks = [
+        { status: "pending" },
+        { status: "deleted" },
+        { status: "completed" },
+        { status: "deleted" },
+        { status: "in_progress" },
+      ];
+      const removed = compactDeletedTasksInPlace(tasks);
+      expect(removed).toBe(2);
+      expect(tasks.map((t) => t.status)).toEqual([
+        "pending",
+        "completed",
+        "in_progress",
+      ]);
+    });
+
+    it("is a no-op when nothing is deleted", () => {
+      const tasks = [{ status: "pending" }, { status: "completed" }];
+      expect(compactDeletedTasksInPlace(tasks)).toBe(0);
+    });
+  });
+
+  describe("detectBlockCycleForPatch helper", () => {
+    it("flags direct self-blocks", () => {
+      expect(
+        detectBlockCycleForPatch({
+          tasks: [],
+          taskId: "1",
+          addBlocks: ["1"],
+        }),
+      ).toMatch(/cannot block itself/);
+    });
+
+    it("flags cycles formed via addBlockedBy", () => {
+      expect(
+        detectBlockCycleForPatch({
+          tasks: [{ id: "1", blocks: ["2"], blockedBy: [] }],
+          taskId: "2",
+          addBlocks: ["1"],
+        }),
+      ).toMatch(/cycle/);
+    });
+
+    it("returns undefined for non-cyclic additions", () => {
+      expect(
+        detectBlockCycleForPatch({
+          tasks: [{ id: "1", blocks: [], blockedBy: [] }],
+          taskId: "1",
+          addBlocks: ["2"],
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("soft-delete compaction", () => {
+    it("removes deleted tasks from the backing list on the next GC sweep", async () => {
+      await callTool(create, { subject: "A", description: "a" });
+      await callTool(create, { subject: "B", description: "b" });
+      await callTool(update, { taskId: "1", status: "deleted" });
+
+      const rawBeforeGc = store.get(DEFAULT_TASK_LIST_ID, "1");
+      expect(rawBeforeGc).toBeUndefined();
+
+      // Drive 50 more persists so the interval (50) triggers compaction.
+      for (let i = 0; i < 50; i += 1) {
+        await callTool(update, {
+          taskId: "2",
+          description: `revision ${i}`,
+        });
+      }
+      const listed = store.list(DEFAULT_TASK_LIST_ID);
+      expect(listed).toHaveLength(1);
+      expect(listed[0]?.id).toBe("2");
     });
   });
 });

--- a/runtime/src/tools/system/task-tracker.test.ts
+++ b/runtime/src/tools/system/task-tracker.test.ts
@@ -5,6 +5,8 @@ import { describe, it, expect, beforeEach } from "vitest";
 import {
   TASK_ACTOR_KIND_ARG,
   TASK_ACTOR_NAME_ARG,
+  TASK_HANDLE_MAX_TIMEOUT_MS,
+  TASK_HANDLE_TOOL_NAMES,
   createRuntimeTaskHandleTools,
   createTaskTrackerTools,
   SessionTaskStore,
@@ -739,6 +741,77 @@ describe("task-tracker", () => {
         worktreePath: "/tmp/worktree-1",
       });
       expect(persistedOutput.body.events).toBeInstanceOf(Array);
+    });
+
+    it("clamps a model-supplied timeoutMs to the handle-tool cap", async () => {
+      const runtimeStore = new TaskStore();
+      const observed: number[] = [];
+      const originalWait = runtimeStore.waitForTask.bind(runtimeStore);
+      runtimeStore.waitForTask = (async (
+        listId: string,
+        taskId: string,
+        options?: { timeoutMs?: number },
+      ) => {
+        if (options?.timeoutMs !== undefined) observed.push(options.timeoutMs);
+        return originalWait(listId, taskId, options);
+      }) as typeof runtimeStore.waitForTask;
+      const tools = createRuntimeTaskHandleTools(runtimeStore);
+      const wait = findTool(tools, "task.wait");
+      const runtimeTask = await runtimeStore.createRuntimeTask({
+        listId: DEFAULT_TASK_LIST_ID,
+        kind: "subagent",
+        subject: "Delegated",
+        description: "delegated",
+      });
+      await runtimeStore.finalizeRuntimeTask({
+        listId: DEFAULT_TASK_LIST_ID,
+        taskId: runtimeTask.id,
+        status: "completed",
+        summary: "done",
+      });
+
+      await callTool(wait, {
+        taskId: runtimeTask.id,
+        until: "terminal",
+        timeoutMs: 10 * 60 * 1000,
+      });
+
+      expect(observed).toHaveLength(1);
+      expect(observed[0]).toBeLessThanOrEqual(TASK_HANDLE_MAX_TIMEOUT_MS);
+    });
+
+    it("returns not found when a task belongs to a different session listId", async () => {
+      const runtimeStore = new TaskStore();
+      const tools = createRuntimeTaskHandleTools(runtimeStore);
+      const output = findTool(tools, "task.output");
+      const otherTask = await runtimeStore.createRuntimeTask({
+        listId: "session-other",
+        kind: "subagent",
+        subject: "Someone else's task",
+        description: "not reachable from session-mine",
+      });
+      await runtimeStore.finalizeRuntimeTask({
+        listId: "session-other",
+        taskId: otherTask.id,
+        status: "completed",
+        summary: "done",
+        output: "secret",
+      });
+
+      const result = await callTool(output, {
+        [TASK_LIST_ARG]: "session-mine",
+        taskId: otherTask.id,
+      });
+
+      expect(result.raw.isError).toBe(true);
+      expect(result.body.error).toContain("not found");
+    });
+
+    it("exports stable handle tool names matching the registered tools", () => {
+      const runtimeStore = new TaskStore();
+      const tools = createRuntimeTaskHandleTools(runtimeStore);
+      const registered = new Set(tools.map((t) => t.name));
+      expect(registered).toEqual(TASK_HANDLE_TOOL_NAMES);
     });
   });
 

--- a/runtime/src/tools/system/task-tracker.ts
+++ b/runtime/src/tools/system/task-tracker.ts
@@ -61,6 +61,26 @@ export const TASK_TRACKER_TOOL_NAMES: ReadonlySet<string> = new Set([
   "task.update",
 ]);
 
+/**
+ * Tool names for the runtime task-handle surface (task.wait, task.output).
+ * These are separate from {@link TASK_TRACKER_TOOL_NAMES} because they
+ * operate against {@link TaskStore} (runtime tasks) rather than
+ * {@link SessionTaskStore} (session tasks), but they share the same
+ * session-scoped listId injection so the model can only reach tasks
+ * created under its own session.
+ */
+export const TASK_HANDLE_TOOL_NAMES: ReadonlySet<string> = new Set([
+  "task.wait",
+  "task.output",
+]);
+
+/**
+ * Maximum blocking timeout a model-facing task handle tool will accept,
+ * in milliseconds. Larger values are clamped to this cap. Keeps async
+ * delegation reads from tying up a turn indefinitely.
+ */
+export const TASK_HANDLE_MAX_TIMEOUT_MS = 60_000;
+
 export type TaskStatus =
   | "pending"
   | "in_progress"
@@ -2808,10 +2828,14 @@ export function createRuntimeTaskHandleTools(
     async execute(args) {
       const taskId = asNonEmptyString(args.taskId);
       if (!taskId) return errorResult("taskId must be a non-empty string");
-      const timeoutMs =
+      const requestedTimeoutMs =
         args.timeoutMs === undefined
           ? undefined
           : asPositiveInt(args.timeoutMs) ?? 0;
+      const timeoutMs =
+        requestedTimeoutMs === undefined
+          ? undefined
+          : Math.min(requestedTimeoutMs, TASK_HANDLE_MAX_TIMEOUT_MS);
       const until =
         args.until === "terminal" || args.until === "output_ready"
           ? args.until
@@ -2890,8 +2914,12 @@ export function createRuntimeTaskHandleTools(
       const taskId = asNonEmptyString(args.taskId);
       if (!taskId) return errorResult("taskId must be a non-empty string");
       const listId = resolveListId(args);
-      const timeoutMs =
+      const requestedTimeoutMs =
         args.timeoutMs !== undefined ? asPositiveInt(args.timeoutMs) ?? 0 : undefined;
+      const timeoutMs =
+        requestedTimeoutMs === undefined
+          ? undefined
+          : Math.min(requestedTimeoutMs, TASK_HANDLE_MAX_TIMEOUT_MS);
       const includeEvents = args.includeEvents === true;
       const maxBytes =
         args.maxBytes !== undefined

--- a/runtime/src/tools/system/task-tracker.ts
+++ b/runtime/src/tools/system/task-tracker.ts
@@ -477,20 +477,6 @@ function cloneStoredTask(task: StoredTask): StoredTask {
   };
 }
 
-function isExplicitCompletionFlow(params: {
-  readonly task: SessionTask;
-  readonly patch: TaskUpdatePatch;
-}): boolean {
-  const mergedMetadata =
-    params.patch.metadata !== undefined
-      ? {
-          ...(params.task.metadata ?? {}),
-          ...params.patch.metadata,
-        }
-      : params.task.metadata;
-  return normalizeRequestTaskRuntimeMetadata(mergedMetadata).verification;
-}
-
 function cloneTaskList(list: TaskListEntry): TaskListEntry {
   return {
     version: list.version,
@@ -2657,13 +2643,7 @@ export function createTaskTrackerTools(
 
       const isTransitioningToCompleted =
         patch.status === "completed" && current.task.status !== "completed";
-      const shouldGuardCompletion =
-        isTransitioningToCompleted &&
-        isExplicitCompletionFlow({
-          task: current.task,
-          patch,
-        });
-      if (shouldGuardCompletion && options.onBeforeTaskComplete) {
+      if (isTransitioningToCompleted && options.onBeforeTaskComplete) {
         const guardResult = await options.onBeforeTaskComplete({
           listId,
           taskId,

--- a/runtime/src/tools/system/task-tracker.ts
+++ b/runtime/src/tools/system/task-tracker.ts
@@ -38,6 +38,26 @@ const DEFAULT_OUTPUT_MAX_BYTES = 64 * 1024;
 const MAX_OUTPUT_MAX_BYTES = 512 * 1024;
 
 /**
+ * Cap on the per-task event log. The first `created` event and every
+ * status-transition event (started/completed/failed/cancelled/deleted/
+ * output_ready) are always retained; "updated" and "ref_attached"
+ * entries are the only ones pruned when the log exceeds this cap. A
+ * single marker event is inserted when pruning happens so downstream
+ * readers can see that the log was compacted.
+ */
+export const TASK_EVENT_RETENTION_CAP = 64;
+const TASK_EVENT_TRUNCATION_MARKER_SUMMARY =
+  "Event log truncated to retention cap";
+
+/**
+ * Number of persist calls between soft-delete compaction sweeps. A
+ * tombstoned task (status=\`deleted\`) is retained until the next sweep
+ * so in-flight readers can still resolve the id; once the sweep runs,
+ * the entry is removed from the backing array.
+ */
+export const TASK_SOFT_DELETE_GC_INTERVAL = 50;
+
+/**
  * Magic arg key used by the gateway to thread the current session id
  * into task tools.
  */
@@ -135,7 +155,6 @@ export interface Task {
   readonly id: string;
   readonly kind: TaskKind;
   readonly ownerSessionId: string;
-  readonly parentTaskId?: string;
   subject: string;
   description: string;
   status: TaskStatus;
@@ -194,7 +213,6 @@ export interface TaskUpdatePatch {
 export interface RuntimeTaskCreateParams extends TaskCreateInput {
   readonly listId: string;
   readonly kind: TaskKind;
-  readonly parentTaskId?: string;
   readonly owner?: string;
   readonly status?: Exclude<TaskStatus, "deleted">;
   readonly summary?: string;
@@ -453,7 +471,6 @@ function cloneTask(task: Task | StoredTask): Task {
     id: task.id,
     kind: task.kind,
     ownerSessionId: task.ownerSessionId,
-    ...(task.parentTaskId !== undefined ? { parentTaskId: task.parentTaskId } : {}),
     subject: task.subject,
     description: task.description,
     status: task.status,
@@ -531,6 +548,154 @@ function createEmptySessionTaskList(listId: string): SessionTaskListEntry {
     tasks: [],
     nextTaskId: 1,
   };
+}
+
+const STATUS_TRANSITION_EVENT_TYPES: ReadonlySet<TaskEventType> = new Set([
+  "started",
+  "completed",
+  "failed",
+  "cancelled",
+  "deleted",
+  "output_ready",
+]);
+
+/**
+ * Truncate a task's event log in place when it exceeds
+ * {@link TASK_EVENT_RETENTION_CAP}. The first \`created\` event and every
+ * status-transition event are always preserved. Remaining slots are
+ * filled with the most recent non-transition events (e.g. \`updated\`,
+ * \`ref_attached\`). When any events are dropped, a single marker event
+ * is inserted once so subsequent readers can tell the log was
+ * compacted. Returns true when mutation happened.
+ */
+export function pruneTaskEventsInPlace(task: Task): boolean {
+  if (task.events.length <= TASK_EVENT_RETENTION_CAP) return false;
+  const createdIndex = task.events.findIndex((event) => event.type === "created");
+  const createdEvent = createdIndex >= 0 ? task.events[createdIndex] : undefined;
+  const transitionEvents = task.events.filter((event) =>
+    STATUS_TRANSITION_EVENT_TYPES.has(event.type),
+  );
+  const otherEvents = task.events.filter(
+    (event) =>
+      event.type !== "created" &&
+      !STATUS_TRANSITION_EVENT_TYPES.has(event.type),
+  );
+  const alreadyMarked = task.events.some(
+    (event) =>
+      event.type === "updated" &&
+      event.summary === TASK_EVENT_TRUNCATION_MARKER_SUMMARY,
+  );
+  const preservedCount =
+    (createdEvent ? 1 : 0) +
+    transitionEvents.length +
+    (alreadyMarked ? 0 : 1);
+  const slotsForOthers = Math.max(
+    0,
+    TASK_EVENT_RETENTION_CAP - preservedCount,
+  );
+  const keptOthers = otherEvents.slice(-slotsForOthers);
+  const dropped = task.events.length - (
+    (createdEvent ? 1 : 0) + transitionEvents.length + keptOthers.length
+  );
+  if (dropped <= 0) return false;
+  const rebuilt: TaskEventRecord[] = [];
+  if (createdEvent) rebuilt.push(createdEvent);
+  if (!alreadyMarked) {
+    const markerTimestamp =
+      createdEvent?.timestamp !== undefined
+        ? createdEvent.timestamp + 1
+        : (task.events[0]?.timestamp ?? Date.now());
+    rebuilt.push({
+      id: `${markerTimestamp.toString(36)}-truncation-marker`,
+      type: "updated",
+      summary: TASK_EVENT_TRUNCATION_MARKER_SUMMARY,
+      timestamp: markerTimestamp,
+      data: { droppedEventCount: dropped },
+    });
+  }
+  const tailSorted = [...transitionEvents, ...keptOthers].sort(
+    (a, b) => a.timestamp - b.timestamp,
+  );
+  rebuilt.push(...tailSorted);
+  task.events.length = 0;
+  for (const event of rebuilt) task.events.push(event);
+  return true;
+}
+
+/**
+ * Compact a list by removing soft-deleted tasks. Used by the periodic
+ * GC sweep. Returns the number of entries removed.
+ */
+export function compactDeletedTasksInPlace(
+  tasks: { status: string }[],
+): number {
+  const before = tasks.length;
+  const kept = tasks.filter((task) => task.status !== "deleted");
+  if (kept.length === before) return 0;
+  tasks.length = 0;
+  for (const task of kept) tasks.push(task as unknown as typeof tasks[number]);
+  return before - kept.length;
+}
+
+/**
+ * Detect whether adding the proposed addBlocks / addBlockedBy entries
+ * to a task would produce a cycle in the block relation. Edges are
+ * interpreted as "A blocks B", derived from the union of
+ * \`task.blocks\` entries and the reverse \`task.blockedBy\` entries.
+ * Returns a short message when the patch must be rejected, or
+ * \`undefined\` when it is safe to apply.
+ *
+ * Direct self-loops (taskId appears in its own addBlocks or
+ * addBlockedBy) are rejected up front. Indirect cycles are found via
+ * DFS on the merged graph with the proposed edges already applied.
+ */
+export function detectBlockCycleForPatch(params: {
+  readonly tasks: readonly {
+    readonly id: string;
+    readonly blocks: readonly string[];
+    readonly blockedBy: readonly string[];
+  }[];
+  readonly taskId: string;
+  readonly addBlocks?: readonly string[];
+  readonly addBlockedBy?: readonly string[];
+}): string | undefined {
+  const addBlocks = params.addBlocks ?? [];
+  const addBlockedBy = params.addBlockedBy ?? [];
+  if (addBlocks.includes(params.taskId)) {
+    return `task ${params.taskId} cannot block itself`;
+  }
+  if (addBlockedBy.includes(params.taskId)) {
+    return `task ${params.taskId} cannot be blocked by itself`;
+  }
+  if (addBlocks.length === 0 && addBlockedBy.length === 0) return undefined;
+  const graph = new Map<string, Set<string>>();
+  const edge = (from: string, to: string): void => {
+    let neighbours = graph.get(from);
+    if (!neighbours) {
+      neighbours = new Set<string>();
+      graph.set(from, neighbours);
+    }
+    neighbours.add(to);
+  };
+  for (const task of params.tasks) {
+    for (const blocked of task.blocks) edge(task.id, blocked);
+    for (const blocker of task.blockedBy) edge(blocker, task.id);
+  }
+  for (const blocked of addBlocks) edge(params.taskId, blocked);
+  for (const blocker of addBlockedBy) edge(blocker, params.taskId);
+  const visited = new Set<string>();
+  const stack = [...(graph.get(params.taskId) ?? [])];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    if (node === params.taskId) {
+      return `adding these dependencies would create a cycle involving task ${params.taskId}`;
+    }
+    if (visited.has(node)) continue;
+    visited.add(node);
+    const next = graph.get(node);
+    if (next) for (const neighbour of next) stack.push(neighbour);
+  }
+  return undefined;
 }
 
 function isTaskStatus(value: unknown): value is TaskStatus {
@@ -643,7 +808,6 @@ function fullTask(task: Task): Record<string, unknown> {
     id: task.id,
     kind: task.kind,
     ownerSessionId: task.ownerSessionId,
-    ...(task.parentTaskId !== undefined ? { parentTaskId: task.parentTaskId } : {}),
     subject: task.subject,
     description: task.description,
     status: task.status,
@@ -833,9 +997,6 @@ function coerceStoredTask(value: unknown, ownerSessionId: string): StoredTask | 
     kind,
     ownerSessionId:
       asNonEmptyString(raw.ownerSessionId) ?? ownerSessionId,
-    ...(asNonEmptyString(raw.parentTaskId)
-      ? { parentTaskId: asNonEmptyString(raw.parentTaskId) }
-      : {}),
     subject,
     description,
     status,
@@ -1079,6 +1240,7 @@ export class SessionTaskStore {
   private readonly lists = new Map<string, SessionTaskListEntry>();
   private readonly loadedLists = new Set<string>();
   private readonly queue = new Map<string, Promise<void>>();
+  private readonly persistCountByList = new Map<string, number>();
 
   constructor(options?: SessionTaskStoreOptions) {
     this.memoryBackend = options?.memoryBackend;
@@ -1184,6 +1346,11 @@ export class SessionTaskStore {
   }
 
   private async persistList(list: SessionTaskListEntry): Promise<void> {
+    const nextCount = (this.persistCountByList.get(list.id) ?? 0) + 1;
+    this.persistCountByList.set(list.id, nextCount);
+    if (nextCount % TASK_SOFT_DELETE_GC_INTERVAL === 0) {
+      compactDeletedTasksInPlace(list.tasks);
+    }
     if (!this.memoryBackend) {
       await this.persistListToDisk(list);
       return;
@@ -1383,6 +1550,7 @@ export class TaskStore {
   private readonly lists = new Map<string, TaskListEntry>();
   private readonly loadedLists = new Set<string>();
   private readonly queue = new Map<string, Promise<void>>();
+  private readonly persistCountByList = new Map<string, number>();
 
   constructor(options?: TaskStoreOptions) {
     this.memoryBackend = options?.memoryBackend;
@@ -1454,6 +1622,14 @@ export class TaskStore {
   }
 
   private async persistList(list: TaskListEntry): Promise<void> {
+    for (const task of list.tasks) {
+      pruneTaskEventsInPlace(task);
+    }
+    const nextCount = (this.persistCountByList.get(list.id) ?? 0) + 1;
+    this.persistCountByList.set(list.id, nextCount);
+    if (nextCount % TASK_SOFT_DELETE_GC_INTERVAL === 0) {
+      compactDeletedTasksInPlace(list.tasks);
+    }
     if (!this.memoryBackend) {
       return;
     }
@@ -1743,7 +1919,6 @@ export class TaskStore {
         id,
         kind: params.kind,
         ownerSessionId: params.listId,
-        ...(params.parentTaskId ? { parentTaskId: params.parentTaskId } : {}),
         subject: params.subject,
         description: params.description,
         status: params.status ?? "in_progress",
@@ -2337,7 +2512,10 @@ const TASK_UPDATE_DESCRIPTION = `Use this tool to update a task in the task list
 
 **Delete tasks:**
 - When a task is no longer relevant or was created in error
-- Setting status to \`deleted\` permanently removes the task
+- Setting status to \`deleted\` hides the task from future task.list / task.get
+  responses. The task is retained internally (with status=\`deleted\`) so that
+  event history and output references stay valid for in-flight readers, and
+  the runtime reclaims the entry during a background compaction pass.
 
 **Update task details:**
 - When requirements change or become clearer
@@ -2358,7 +2536,8 @@ const TASK_UPDATE_DESCRIPTION = `Use this tool to update a task in the task list
 
 Status progresses: \`pending\` → \`in_progress\` → \`completed\`
 
-Use \`deleted\` to permanently remove a task.
+Use \`deleted\` to retire a task. It is filtered out of subsequent listings but
+the underlying entry is retained until the next compaction sweep.
 
 ## Staleness
 
@@ -2443,6 +2622,11 @@ export function createTaskTrackerTools(
       const description = asNonEmptyString(args.description) ?? subject;
       const activeForm = asNonEmptyString(args.activeForm);
       const metadata = asPlainObject(args.metadata);
+      if (metadata && "_internal" in metadata) {
+        return errorResult(
+          "metadata._internal is reserved for runtime-created tasks and cannot be set via task.create",
+        );
+      }
 
       const task = await taskStore.createTask(resolveListId(args), {
         subject,
@@ -2609,6 +2793,11 @@ export function createTaskTrackerTools(
         if (metadata === undefined) {
           return errorResult("metadata must be a plain object");
         }
+        if ("_internal" in metadata) {
+          return errorResult(
+            "metadata._internal is reserved for runtime-created tasks and cannot be set via task.update",
+          );
+        }
         patch.metadata = metadata;
         updatedFields.push("metadata");
       }
@@ -2637,6 +2826,17 @@ export function createTaskTrackerTools(
           updatedFields: [],
           error: "Task not found",
         });
+      }
+
+      if (patch.addBlocks || patch.addBlockedBy) {
+        const existingTasks = await taskStore.listTasks(listId);
+        const cycleReason = detectBlockCycleForPatch({
+          tasks: existingTasks,
+          taskId,
+          ...(patch.addBlocks ? { addBlocks: patch.addBlocks } : {}),
+          ...(patch.addBlockedBy ? { addBlockedBy: patch.addBlockedBy } : {}),
+        });
+        if (cycleReason) return errorResult(cycleReason);
       }
 
       if (


### PR DESCRIPTION
## Summary

Phased rollout of the task-system plan under `TASK-SYSTEM-PLAN.md`
(local-only doc). Five independently-shippable commits on this
branch; each passes tests; aggregate suite for the touched subtrees
is green at 3110 tests / 172 files / 0 failures.

### Phases

- **fix(task-tracker): always invoke completion guard on task completion**
  (`f37b605`) Removes the narrow `isExplicitCompletionFlow` gate so
  every pending-to-completed transition calls `onBeforeTaskComplete`
  when a guard is configured. Preserves the optimistic-revision
  recheck. Existing test that asserted the skipped-guard behavior is
  rewritten; new test covers unresolved-`blockedBy` completion.

- **feat(llm): surface ActiveTaskContext into the model prompt**
  (`f1d7990`) New `active-task-context-prompt.ts` injects a compact
  system-reminder user message carrying `workspaceRoot`,
  `displayArtifact`, `sourceArtifacts`, `targetArtifacts`. Dedup via
  the existing `contractFingerprint`. Wired through
  `collectAttachments` so both text-channel and webchat turns share
  the injection. `turnClass` / `ownerMode` stay internal.

- **feat(task-tracker): register runtime task handle tools and scope them per session**
  (`37cb692`) `createRuntimeTaskHandleTools` is now wired into the
  daemon catalog (previously named in `ALWAYS_INLINE_TOOL_NAMES` but
  never instantiated). Introduces `TASK_HANDLE_TOOL_NAMES` so the
  handler factory threads the session task-list id and actor context
  for `task.wait` / `task.output`. Clamps `timeoutMs` to a 60s cap.

- **fix(task-tracker): seam cleanup for task store invariants**
  (`e78ea4b`) Drops the dead `parentTaskId` field. Rejects
  `metadata._internal` on public create/update. Detects and rejects
  block-relation cycles on `addBlocks` / `addBlockedBy`. Adds bounded
  event-log retention (cap 64, preserves `created` and all
  status-transition events, single truncation marker). Soft-delete
  compaction every 50 persists. Corrects the `task.update`
  description drift that claimed `deleted` permanently removes a
  task.

- **feat(task-panel): read-only task panel data + formatter for rendering surfaces**
  (`5dedacc`) Extends `RuntimeTaskHandle` with optional
  `subject` / `activeForm` / `owner`. Adds
  `RuntimeContractStatusSnapshot.recentCompletedTasks` (bounded to 3).
  New `runtime/src/gateway/task-panel.ts` with pure
  `buildTaskPanelView` (in_progress -> pending -> recent completed,
  sorted by `updatedAt`) and minimal `formatTaskPanelLines`. The
  in-flight TUI rebuild can adopt this without further backend
  changes.

### Deliberately out of scope

`asyncTasksEnabled` public-tool gating. Investigation showed the
public `task.*` management tools (`create` / `update` / `list` /
`get`) are already not advertised to the model (`tool-routing.ts`
keeps only `task.wait` / `task.output` in the always-inline set).
The flag still drives real behavior in `taskLayer.effective` and the
worker layer, so nothing on the public surface remains to gate. See
the Phase 4 commit body for the full reasoning.

## Test plan

- [x] `npm run typecheck --workspace=@tetsuo-ai/runtime` clean
- [x] Broad test pass across `src/tools/system`, `src/gateway`,
      `src/llm`, `src/runtime-contract`: 3110 passed, 3 skipped, 0
      failures (172 test files)
- [x] Targeted coverage added for each phase: completion-guard path,
      fingerprint-dedup injection, handle-tool clamp + cross-session
      isolation, parentTaskId removal, cycle detection,
      event retention, soft-delete GC, panel formatter