### PR TITLE
fix(watch): TUI scroll cluster — re-pin tolerance, j/k default, history restore, wheel render

### DIFF
--- a/runtime/src/watch/agenc-watch-event-store.mjs
+++ b/runtime/src/watch/agenc-watch-event-store.mjs
@@ -207,10 +207,21 @@ export function createWatchEventStore(dependencies = {}) {
     if (!Array.isArray(history)) {
       return;
     }
+    // Preserve the user's manual scroll position across a history
+    // restore. Previously this unconditionally reset
+    // transcriptScrollOffset=0 and transcriptFollowMode=true so every
+    // reconnect/history replay dumped the user back at the bottom
+    // mid-read. If they were actively following (at bottom) we still
+    // want to stay pinned; otherwise keep their offset and mode.
+    const wasFollowingAtRestore =
+      watchState.transcriptFollowMode === true &&
+      (watchState.transcriptScrollOffset ?? 0) === 0;
     events.length = 0;
     clearAgentStreamingPreview();
-    watchState.transcriptScrollOffset = 0;
-    watchState.transcriptFollowMode = true;
+    if (wasFollowingAtRestore) {
+      watchState.transcriptScrollOffset = 0;
+      watchState.transcriptFollowMode = true;
+    }
     watchState.detailScrollOffset = 0;
     for (const entry of history.slice(-maxEvents)) {
       const sender = String(entry?.sender ?? "").toLowerCase();

--- a/runtime/src/watch/agenc-watch-frame.mjs
+++ b/runtime/src/watch/agenc-watch-frame.mjs
@@ -3707,11 +3707,20 @@ export function createWatchFrameController(dependencies = {}) {
   }
 
   function scrollTranscriptBy(delta) {
-    watchState.transcriptScrollOffset = applyViewportScrollDelta(
+    const nextOffset = applyViewportScrollDelta(
       watchState.transcriptScrollOffset,
       delta,
     );
-    watchState.transcriptFollowMode = watchState.transcriptScrollOffset === 0;
+    watchState.transcriptScrollOffset = nextOffset;
+    // Re-engage follow mode on near-bottom landings (tolerance of 2
+    // rows). Exact-0 match punished users who overshot the bottom with
+    // the wheel or ended up at offset=1 after content coalesced — they
+    // stayed unpinned and new content piled up below their viewport.
+    const STICKY_BOTTOM_TOLERANCE = 2;
+    watchState.transcriptFollowMode = nextOffset <= STICKY_BOTTOM_TOLERANCE;
+    if (watchState.transcriptFollowMode) {
+      watchState.transcriptScrollOffset = 0;
+    }
     scheduleRender();
   }
 

--- a/runtime/src/watch/agenc-watch-input.mjs
+++ b/runtime/src/watch/agenc-watch-input.mjs
@@ -441,10 +441,14 @@ export function createWatchInputController(dependencies = {}) {
     while (index < input.length) {
       const mouseWheel = parseMouseWheelSequence(input, index);
       if (mouseWheel) {
+        // Only trigger a render when an actual wheel scroll fired —
+        // non-wheel mouse events (clicks, drags) were previously
+        // flagged as mutations and forced a full re-render each time
+        // the user moved the cursor across the terminal.
         if (mouseWheel.isWheel && mouseWheel.delta !== 0) {
           scrollCurrentViewBy(mouseWheel.delta);
+          didMutate = true;
         }
-        didMutate = true;
         index += mouseWheel.length;
         continue;
       }
@@ -533,6 +537,24 @@ export function createWatchInputController(dependencies = {}) {
       if (char === "\x1b") {
         index = handleTerminalEscapeSequence(input, index);
         didMutate = true;
+        continue;
+      }
+      // `j` / `k` scroll the transcript when the composer is empty,
+      // regardless of keybinding profile. Previously these only
+      // scrolled in vim-normal mode, leaving default-profile users
+      // with no single-key scroll path. When the composer has text,
+      // fall through so they insert as literal characters.
+      if (
+        (char === "j" || char === "k") &&
+        typeof watchState.composerInput === "string" &&
+        watchState.composerInput.length === 0 &&
+        !hasActiveComposerPalette() &&
+        !hasActiveMarketTaskBrowser() &&
+        !isVimNormalMode()
+      ) {
+        scrollCurrentViewBy(char === "k" ? 1 : -1);
+        didMutate = true;
+        index += 1;
         continue;
       }
       if (isVimNormalMode()) {

--- a/runtime/tests/watch/agenc-watch-event-store.test.mjs
+++ b/runtime/tests/watch/agenc-watch-event-store.test.mjs
@@ -113,9 +113,28 @@ test("event store restores transcript history and clears stale expanded selectio
   assert.equal(events[1].renderMode, "markdown");
   assert.equal(events[1].canonicalReply, true);
   assert.equal(events[1].timestamp, "history:2026-03-14T00:00:01.000Z");
-  assert.equal(watchState.transcriptScrollOffset, 0);
+  // Harness starts with transcriptScrollOffset=12, transcriptFollowMode=false
+  // (user was manually scrolled up). History restore must preserve that
+  // scroll state — the prior behavior unconditionally snapped to
+  // bottom, which yanked users mid-read on reconnect/replay.
+  assert.equal(watchState.transcriptScrollOffset, 12);
+  assert.equal(watchState.transcriptFollowMode, false);
   assert.equal(watchState.detailScrollOffset, 0);
   assert.equal(watchState.expandedEventId, null);
+});
+
+test("event store history restore keeps a follow-mode user pinned at bottom", () => {
+  const { store, watchState } = createHarness();
+  watchState.transcriptScrollOffset = 0;
+  watchState.transcriptFollowMode = true;
+
+  store.restoreTranscriptFromHistory([
+    { sender: "user", content: "hi", timestamp: "2026-03-14T00:00:00.000Z" },
+    { sender: "assistant", content: "there", timestamp: "2026-03-14T00:00:01.000Z" },
+  ]);
+
+  assert.equal(watchState.transcriptScrollOffset, 0);
+  assert.equal(watchState.transcriptFollowMode, true);
 });
 
 test("event store preserves full truncated assistant history as detail body", () => {


### PR DESCRIPTION
## Summary

Four remaining scroll-cluster bugs from \`TUI-BUGS.md\`. The four already-landed fixes (DECSET 1007 off, \`commitAgentMessage\` force-snap, arrow-key scroll, PageUp/PageDown modifier forms) are intact.

## What's fixed

- **Bug 3 — Re-pin heuristic**: \`scrollTranscriptBy\` re-engages follow mode when scroll offset lands within **2 rows of bottom**, not only at exact-0. Wheel overshoots and coalesce drift no longer strand the viewport just above bottom.

- **Bug 6 — j/k default profile**: A \`j\`/\`k\` handler sits ahead of the \`isVimNormalMode()\` block so default-profile users with an empty composer can single-key scroll the transcript. Non-empty composer still inserts \`j\`/\`k\` literally.

- **Bug 7 — History restore**: \`restoreTranscriptFromHistory\` preserves the user's \`transcriptScrollOffset\` and \`transcriptFollowMode\` when they were manually scrolled at restore time. Only snaps to bottom when already pinned.

- **Bug 8 — Wheel non-wheel didMutate**: Only flag \`didMutate=true\` on actual wheel scrolls (\`isWheel && delta !== 0\`). Click/drag mouse events no longer force an unnecessary re-render on every cursor movement.

## Test plan

- [x] Existing transcript-restore test updated to reflect the preserved-scroll behavior
- [x] New test added: \"event store history restore keeps a follow-mode user pinned at bottom\"
- [x] 377/387 watch tests pass; 10 pre-existing failures (frame-snapshot chrome, model-matcher catalog, live-replay bootstrap, markdown-stream table reply, etc.) unchanged