### PR TITLE
fix(watch): frame/render CRITICAL — art race, selective-diff bg, OSC 8 hyperlinks

### DIFF
--- a/runtime/src/watch/agenc-watch-app.mjs
+++ b/runtime/src/watch/agenc-watch-app.mjs
@@ -2052,9 +2052,26 @@ function readArtPanelConfig() {
   }
 }
 
+let artRefreshQueued = false;
 async function refreshArtPanel() {
-  if (artRefreshPending) return;
+  if (artRefreshPending) {
+    // Queue one follow-up refresh so a resize that arrives mid-flight
+    // gets rendered at the new dimensions. Previously the pending flag
+    // dropped the resize and `artPanelBodyRevision` was stamped with
+    // the current `currentBodyRevision` at the end of the async work,
+    // so subsequent frames saw equal revisions and never re-triggered.
+    // Art could get stuck at old dimensions after a resize.
+    artRefreshQueued = true;
+    return;
+  }
   artRefreshPending = true;
+  // Capture the revision at refresh start. The async render may take
+  // longer than the user's resize-to-settle interval, and we must
+  // detect whether the body grew under us before stamping the panel
+  // revision. Otherwise stamping the post-refresh revision (which is
+  // the NEW one, not the one we actually rendered) hides the stale
+  // dimensions from the next render.
+  const revisionAtStart = Number(watchState.currentBodyRevision) || 0;
   try {
     const cfg = readArtPanelConfig();
     if (!cfg) {
@@ -2106,13 +2123,21 @@ async function refreshArtPanel() {
     const rows = await artRenderer.render({ cols: artCols, rows: bodyHeight });
     watchState.artPanelRows = rows;
     watchState.artPanelCols = artCols;
-    watchState.artPanelBodyRevision = Number(watchState.currentBodyRevision) || 0;
+    // Stamp the revision we ACTUALLY rendered at, not whatever
+    // currentBodyRevision has drifted to while we were rendering. If
+    // those differ, the next scheduleRender() will see the mismatch
+    // and fire another refresh (via the queued flag).
+    watchState.artPanelBodyRevision = revisionAtStart;
     scheduleRender();
   } catch {
     watchState.artPanelRows = null;
     watchState.artPanelCols = 0;
   } finally {
     artRefreshPending = false;
+    if (artRefreshQueued) {
+      artRefreshQueued = false;
+      void refreshArtPanel();
+    }
   }
 }
 

--- a/runtime/src/watch/agenc-watch-frame.mjs
+++ b/runtime/src/watch/agenc-watch-frame.mjs
@@ -181,21 +181,46 @@ export function createWatchFrameController(dependencies = {}) {
     const cells = new Array(width);
     let index = 0;
     let activeSgr = "";
+    // Pending OSC 8 hyperlink prefix attached to the next cell. OSC
+    // sequences are zero-width metadata — previously splitAnsiCells
+    // only matched SGR (`\x1b[...m`) and fell through to the cell
+    // branch, counting every OSC byte as a literal content cell. That
+    // corrupted column math in `compositeRowWithArt`, shifted art
+    // occlusion by the OSC byte count, and poisoned all
+    // `visibleLength`-based truncation. Skip OSC sequences and carry
+    // the bytes forward so hyperlink state still reaches the output.
+    let pendingHyperlink = "";
     let col = 0;
     while (index < row.length && col < width) {
       if (row[index] === "\x1b") {
-        const match = row.slice(index).match(/^\x1b\[[0-9;]*m/);
-        if (match) {
-          if (match[0] === "\x1b[0m" || match[0] === "\x1b[m") {
+        const sgrMatch = row.slice(index).match(/^\x1b\[[0-9;]*m/);
+        if (sgrMatch) {
+          if (sgrMatch[0] === "\x1b[0m" || sgrMatch[0] === "\x1b[m") {
             activeSgr = "";
           } else {
-            activeSgr += match[0];
+            activeSgr += sgrMatch[0];
           }
-          index += match[0].length;
+          index += sgrMatch[0].length;
+          continue;
+        }
+        // OSC 8 hyperlink: `\x1b]8;params;url\x07` opens, `\x1b]8;;\x07`
+        // closes. Terminator is BEL (`\x07`) or ST (`\x1b\\`).
+        const oscMatch = row
+          .slice(index)
+          .match(/^\x1b\]8;[^\x07\x1b]*(?:\x07|\x1b\\)/);
+        if (oscMatch) {
+          pendingHyperlink += oscMatch[0];
+          index += oscMatch[0].length;
           continue;
         }
       }
-      cells[col] = { sgr: activeSgr, char: row[index] };
+      cells[col] = {
+        sgr: pendingHyperlink
+          ? `${activeSgr}${pendingHyperlink}`
+          : activeSgr,
+        char: row[index],
+      };
+      pendingHyperlink = "";
       index += 1;
       col += 1;
     }
@@ -4128,7 +4153,15 @@ export function createWatchFrameController(dependencies = {}) {
         if (nextFrameLines[rowIndex] === frameState.lastRenderedFrameLines[rowIndex]) {
           continue;
         }
-        stdout.write(`\x1b[${rowIndex + 1};1H\x1b[2K${nextFrameLines[rowIndex]}`);
+        // Re-prime the panel background before clearing the row.
+        // `\x1b[2K` erases to the terminal's default bg, not the panel
+        // bg the full-clear path uses. Without the leading panelBg the
+        // cleared cells flash terminal-default color for one frame
+        // before the new line's SGR sequences repaint them. Write
+        // panelBg first so the erase uses it, then the new row.
+        stdout.write(
+          `\x1b[${rowIndex + 1};1H${color.panelBg}\x1b[2K${nextFrameLines[rowIndex]}`,
+        );
       }
     }
     frameState.lastRenderedFrameLines = nextFrameLines;


### PR DESCRIPTION
## Summary

Three CRITICAL correctness bugs from the frame/render cluster in \`TUI-BUGS.md\`. Visual-rendering paths that silently produce wrong output rather than crash — users see them, can't file them.

## What's fixed

- **Art panel refresh race** (\`agenc-watch-app.mjs:2055\`): \`refreshArtPanel()\` dropped any resize mid-flight, then stamped the new \`currentBodyRevision\` onto \`artPanelBodyRevision\` even though rendering used pre-resize dimensions. Subsequent frames saw equal revisions and never re-triggered. Fix: capture revision at start, stamp that value, queue one follow-up refresh for any mid-flight resize.

- **Selective-diff row bg** (\`agenc-watch-frame.mjs:4132\`): the diff-rewrite path wrote \`\\x1b[2K\` to clear rows before painting new content. \`\\x1b[2K\` clears to terminal DEFAULT bg, not the panel bg the full-clear uses. Rows flashed terminal-default color for one frame per update. Fix: prime \`color.panelBg\` before the erase.

- **\`splitAnsiCells\` OSC 8 hyperlinks** (\`agenc-watch-frame.mjs:180\`): OSC 8 escapes (\`\\x1b]8;;url\\x07text\\x1b]8;;\\x07\`) were counted as literal content cells because the matcher only recognized SGR. Corrupted column math in \`compositeRowWithArt\`, shifted art occlusion by OSC byte count, poisoned every \`visibleLength\`-based truncation. Fix: skip OSC sequences as zero-width metadata and carry hyperlink bytes forward as a pending prefix attached to the next cell.

## Test plan

- [x] 377/387 watch tests pass; 10 pre-existing failures unchanged