### PR TITLE
fix(watch): frame/render HIGH — terminal clamp, art transparency, ticker staleness, width/ANSI safety

### DIFF
--- a/runtime/src/watch/agenc-watch-app.mjs
+++ b/runtime/src/watch/agenc-watch-app.mjs
@@ -964,11 +964,18 @@ function dismissIntro() {
 }
 
 function termWidth() {
-  return Math.max(74, process.stdout.columns || 100);
+  // Never exceed the real terminal's column count. Previously this
+  // was `Math.max(74, stdout.columns || 100)` — on a 60-column
+  // terminal that returned 74, the renderer drew 74-column rows, but
+  // cursor-positioning escapes still addressed the physical column
+  // grid. Lines wrapped physically, the diff cache's row indices
+  // decorrelated from the real screen, and the frame visibly tore.
+  // Fall back to 100 only when stdout.columns is unavailable (non-TTY).
+  return process.stdout.columns || 100;
 }
 
 function termHeight() {
-  return Math.max(12, process.stdout.rows || 40);
+  return process.stdout.rows || 40;
 }
 
 function currentTranscriptLayout() {

--- a/runtime/src/watch/agenc-watch-frame.mjs
+++ b/runtime/src/watch/agenc-watch-frame.mjs
@@ -133,17 +133,48 @@ export function createWatchFrameController(dependencies = {}) {
   // time changes, slow enough to keep CPU cost negligible.
   const ACTIVE_RUN_TICK_INTERVAL_MS = 500;
 
+  // Safety bound: if the ticker has been running this long without any
+  // activity bump on watchState, assume transport dropped mid-run and
+  // self-stop. Previously the ticker leaned on `hasActiveSurfaceRun()`
+  // (which depends on runPhase !== "idle"), and if the daemon
+  // disconnected before emitting a terminal run event, runPhase
+  // never cleared and the ticker burned 500 ms cycles forever.
+  const ACTIVE_RUN_TICKER_STALENESS_MS = 2 * 60 * 1000;
+
   function ensureActiveRunTicker() {
     const shouldRun =
       watchState?.activeRunStartedAtMs != null ||
       (typeof hasActiveSurfaceRun === "function" && hasActiveSurfaceRun());
     if (shouldRun && !frameState.activeRunTicker) {
+      const tickerStartMs = Date.now();
+      let lastObservedActivityMs = Number(watchState?.lastActivityAt) || tickerStartMs;
       frameState.activeRunTicker = setInterval(() => {
         // Re-check on every tick; if the run ended between ticks, stop.
         const stillActive =
           watchState?.activeRunStartedAtMs != null ||
           (typeof hasActiveSurfaceRun === "function" && hasActiveSurfaceRun());
         if (!stillActive) {
+          if (frameState.activeRunTicker) {
+            clearInterval(frameState.activeRunTicker);
+            frameState.activeRunTicker = null;
+          }
+          return;
+        }
+        // Staleness safety: if nothing has bumped lastActivityAt for
+        // long enough, stop the ticker regardless of runPhase. The
+        // view will still re-render on the next real event or user
+        // input; the animated spinner is not worth a silent CPU leak.
+        const nowMs = Date.now();
+        const currentActivityMs = Number(watchState?.lastActivityAt) || 0;
+        if (currentActivityMs > lastObservedActivityMs) {
+          lastObservedActivityMs = currentActivityMs;
+        }
+        const msSinceActivity = nowMs - lastObservedActivityMs;
+        const msSinceStart = nowMs - tickerStartMs;
+        if (
+          msSinceActivity > ACTIVE_RUN_TICKER_STALENESS_MS &&
+          msSinceStart > ACTIVE_RUN_TICKER_STALENESS_MS
+        ) {
           if (frameState.activeRunTicker) {
             clearInterval(frameState.activeRunTicker);
             frameState.activeRunTicker = null;
@@ -258,10 +289,20 @@ export function createWatchFrameController(dependencies = {}) {
       }
       const artCol = col - leftCols;
       const artCell = artCells[artCol] ?? { sgr: "", char: " " };
-      const source =
-        tuiCell.char !== " " && tuiCell.char !== "\u00a0"
-          ? tuiCell
-          : artCell;
+      // Any space-like glyph should fall through to the art cell.
+      // Previously only ASCII space and NBSP counted as transparent,
+      // so tabs, en/em/figure spaces, zero-width joiners, and BOM-
+      // family invisibles occluded the art strip.
+      const tuiChar = tuiCell.char ?? " ";
+      const isTransparent =
+        tuiChar === " " ||
+        tuiChar === "\t" ||
+        tuiChar === "\u00a0" ||
+        tuiChar === "\u202f" ||
+        tuiChar === "\ufeff" ||
+        (tuiChar >= "\u2000" && tuiChar <= "\u200d") ||
+        tuiChar === "\u3000";
+      const source = isTransparent ? artCell : tuiCell;
       if (source.sgr !== activeSgr) {
         output += "\x1b[0m" + source.sgr;
         activeSgr = source.sgr;

--- a/runtime/src/watch/agenc-watch-text-utils.mjs
+++ b/runtime/src/watch/agenc-watch-text-utils.mjs
@@ -15,7 +15,13 @@ export function sanitizeLargeText(value) {
 }
 
 export function sanitizeInlineText(value) {
-  return sanitizeLargeText(value).replace(/\s+/g, " ").trim();
+  // Strip ANSI / OSC / DCS and control chars before whitespace-collapse.
+  // Previously this function fed model-emitted ANSI straight into the
+  // status line, splash, and footer, where the raw SGR bytes rendered
+  // as garbled control-character cells instead of text.
+  return stripTerminalControlSequences(sanitizeLargeText(value))
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 export function stripTerminalControlSequences(value) {
@@ -131,33 +137,117 @@ export function formatClockLabel(value) {
   });
 }
 
-export function visibleLength(text) {
-  return text.replace(/\x1b\[[0-9;]*m/g, "").length;
+// Minimal East Asian Width / zero-width lookup. Returns the number of
+// terminal columns a single code point consumes. Previously every
+// helper below assumed 1 codepoint = 1 column, so combining
+// diacritics (should be 0), CJK (should be 2), emoji (should be 2),
+// and VS16 (should be 0) all misaligned the column math.
+//
+// The ranges below cover the common cases an agent TUI actually sees:
+// combining marks, zero-width joiners/non-joiners, variation
+// selectors, CJK blocks, Hangul, halfwidth/fullwidth forms, and the
+// main emoji pictograph / symbol planes. Not a full East Asian Width
+// implementation — just enough to stop breaking alignment for the
+// code paths `visibleLength`, `truncateAnsi`, `fitAnsi`, `padAnsi`,
+// and `wrapLine` feed.
+function codePointColumnWidth(codePoint) {
+  if (codePoint < 0x20) return 0;
+  // Combining diacritical marks
+  if (codePoint >= 0x0300 && codePoint <= 0x036F) return 0;
+  // Variation selectors (VS1-16, VS17-256), ZWNJ/ZWJ/ZW space, LTR/RTL marks
+  if (codePoint >= 0x200B && codePoint <= 0x200F) return 0;
+  if (codePoint >= 0x202A && codePoint <= 0x202E) return 0;
+  if (codePoint >= 0x2060 && codePoint <= 0x2064) return 0;
+  if (codePoint === 0xFEFF) return 0;
+  if (codePoint >= 0xFE00 && codePoint <= 0xFE0F) return 0;
+  if (codePoint >= 0xE0100 && codePoint <= 0xE01EF) return 0;
+  // Wide: Hangul Jamo
+  if (codePoint >= 0x1100 && codePoint <= 0x115F) return 2;
+  // Wide: CJK + Hiragana + Katakana + etc.
+  if (codePoint >= 0x2E80 && codePoint <= 0x303E) return 2;
+  if (codePoint >= 0x3041 && codePoint <= 0x33FF) return 2;
+  if (codePoint >= 0x3400 && codePoint <= 0x4DBF) return 2;
+  if (codePoint >= 0x4E00 && codePoint <= 0x9FFF) return 2;
+  if (codePoint >= 0xA000 && codePoint <= 0xA4CF) return 2;
+  if (codePoint >= 0xAC00 && codePoint <= 0xD7A3) return 2;
+  if (codePoint >= 0xF900 && codePoint <= 0xFAFF) return 2;
+  if (codePoint >= 0xFE30 && codePoint <= 0xFE4F) return 2;
+  if (codePoint >= 0xFF00 && codePoint <= 0xFF60) return 2;
+  if (codePoint >= 0xFFE0 && codePoint <= 0xFFE6) return 2;
+  // Emoji pictograph / symbol planes (approximate; covers U+1F300–1FAFF)
+  if (codePoint >= 0x1F300 && codePoint <= 0x1FAFF) return 2;
+  return 1;
 }
 
-export function truncateAnsi(text, maxChars, resetCode = "\x1b[0m") {
-  if (visibleLength(text) <= maxChars) {
-    return text;
-  }
+// Walk the string by code point. Returns { width, units } so callers
+// can step a matching number of JS string units forward when they
+// consumed `width` cells. `units` is 2 for any astral code point
+// (which is a UTF-16 surrogate pair).
+function nextCodePointCell(text, index) {
+  const codePoint = text.codePointAt(index);
+  if (codePoint === undefined) return { codePoint: 0, width: 0, units: 0 };
+  const units = codePoint > 0xFFFF ? 2 : 1;
+  return { codePoint, width: codePointColumnWidth(codePoint), units };
+}
+
+export function visibleLength(text) {
+  const source = String(text ?? "");
   let index = 0;
-  let visible = 0;
-  let output = "";
-  while (index < text.length) {
-    if (text[index] === "\x1b") {
-      const match = text.slice(index).match(/^\x1b\[[0-9;]*m/);
-      if (match) {
-        output += match[0];
-        index += match[0].length;
+  let width = 0;
+  while (index < source.length) {
+    if (source[index] === "\x1b") {
+      const sgr = source.slice(index).match(/^\x1b\[[0-9;]*m/);
+      if (sgr) {
+        index += sgr[0].length;
+        continue;
+      }
+      const osc = source.slice(index).match(/^\x1b\]8;[^\x07\x1b]*(?:\x07|\x1b\\)/);
+      if (osc) {
+        index += osc[0].length;
         continue;
       }
     }
-    if (visible >= Math.max(0, maxChars - 1)) {
+    const cell = nextCodePointCell(source, index);
+    if (cell.units === 0) break;
+    width += cell.width;
+    index += cell.units;
+  }
+  return width;
+}
+
+export function truncateAnsi(text, maxChars, resetCode = "\x1b[0m") {
+  const source = String(text ?? "");
+  if (visibleLength(source) <= maxChars) {
+    return source;
+  }
+  const target = Math.max(0, maxChars - 1);
+  let index = 0;
+  let visible = 0;
+  let output = "";
+  while (index < source.length) {
+    if (source[index] === "\x1b") {
+      const sgr = source.slice(index).match(/^\x1b\[[0-9;]*m/);
+      if (sgr) {
+        output += sgr[0];
+        index += sgr[0].length;
+        continue;
+      }
+      const osc = source.slice(index).match(/^\x1b\]8;[^\x07\x1b]*(?:\x07|\x1b\\)/);
+      if (osc) {
+        output += osc[0];
+        index += osc[0].length;
+        continue;
+      }
+    }
+    const cell = nextCodePointCell(source, index);
+    if (cell.units === 0) break;
+    if (visible + cell.width > target) {
       output += "\u2026";
       break;
     }
-    output += text[index];
-    visible += 1;
-    index += 1;
+    output += source.slice(index, index + cell.units);
+    visible += cell.width;
+    index += cell.units;
   }
   return `${output}${resetCode}`;
 }
@@ -172,22 +262,74 @@ export function padAnsi(text, width) {
   return `${fitted}${" ".repeat(needed)}`;
 }
 
-export function wrapLine(line, width) {
-  if (visibleLength(line) <= width) {
-    return [line];
-  }
-  const stripped = line;
-  const lines = [];
-  let remaining = stripped;
-  while (visibleLength(remaining) > width) {
-    let splitAt = width;
-    const rawSlice = remaining.slice(0, width + 1);
-    const spaceIndex = rawSlice.lastIndexOf(" ");
-    if (spaceIndex > Math.floor(width * 0.45)) {
-      splitAt = spaceIndex;
+// Slice `text` at its nearest "safe" point below `maxWidth` terminal
+// columns, preserving ANSI escape boundaries. Returns
+// { head, rest, visibleWidth, lastSpaceVisibleWidth } so `wrapLine`
+// can decide whether a word-boundary split is preferable.
+function sliceAtVisibleWidth(text, maxWidth) {
+  const source = String(text ?? "");
+  let index = 0;
+  let visible = 0;
+  let lastSpaceIndex = -1;
+  let lastSpaceVisibleWidth = -1;
+  while (index < source.length && visible < maxWidth) {
+    if (source[index] === "\x1b") {
+      const sgr = source.slice(index).match(/^\x1b\[[0-9;]*m/);
+      if (sgr) {
+        index += sgr[0].length;
+        continue;
+      }
+      const osc = source.slice(index).match(/^\x1b\]8;[^\x07\x1b]*(?:\x07|\x1b\\)/);
+      if (osc) {
+        index += osc[0].length;
+        continue;
+      }
     }
-    lines.push(remaining.slice(0, splitAt));
-    remaining = remaining.slice(splitAt).trimStart();
+    const cell = nextCodePointCell(source, index);
+    if (cell.units === 0) break;
+    if (visible + cell.width > maxWidth) break;
+    if (source[index] === " ") {
+      lastSpaceIndex = index;
+      lastSpaceVisibleWidth = visible;
+    }
+    visible += cell.width;
+    index += cell.units;
+  }
+  return {
+    head: source.slice(0, index),
+    rest: source.slice(index),
+    visibleWidth: visible,
+    lastSpaceIndex,
+    lastSpaceVisibleWidth,
+  };
+}
+
+export function wrapLine(line, width) {
+  const source = String(line ?? "");
+  if (visibleLength(source) <= width) {
+    return [source];
+  }
+  const lines = [];
+  let remaining = source;
+  while (visibleLength(remaining) > width) {
+    const sliced = sliceAtVisibleWidth(remaining, width);
+    // Prefer a word-boundary split when the last space landed past
+    // 45% of the line width — otherwise mid-word is visually
+    // smoother than a very short left chunk.
+    if (
+      sliced.lastSpaceIndex > 0 &&
+      sliced.lastSpaceVisibleWidth >= Math.floor(width * 0.45)
+    ) {
+      lines.push(remaining.slice(0, sliced.lastSpaceIndex));
+      remaining = remaining.slice(sliced.lastSpaceIndex + 1);
+      continue;
+    }
+    lines.push(sliced.head);
+    // `sliced.rest` begins at a safe boundary — either the next code
+    // point, past an escape, or after a wide glyph that would have
+    // overflowed. No leading-whitespace trim needed because we did
+    // not break inside a word.
+    remaining = sliced.rest;
   }
   if (remaining.length > 0) {
     lines.push(remaining);


### PR DESCRIPTION
## Summary

Six HIGH-priority bugs from the frame/render cluster in \`TUI-BUGS.md\`. Visual correctness plus a long-running resource leak.

## What's fixed

- **termWidth/termHeight min-clamp** (\`agenc-watch-app.mjs:966\`): on <74-col terminals the returned width exceeded the physical screen; diff cache row indices lost sync and the frame visibly tore. Return real dims; fall back to 100/40 only when \`stdout.columns\`/\`rows\` is unavailable.

- **compositeRowWithArt transparency** (\`agenc-watch-frame.mjs:237\`): only \`" \"\` and \`\\u00a0\` counted as transparent. Tabs, en/em/figure/ideographic spaces, ZWJ/ZWNJ, BOM-family characters occluded the art. Extend the transparency set.

- **activeRunTicker persistence** (\`agenc-watch-frame.mjs:136\`): ticker could run at 500ms forever if transport dropped mid-run and \`runPhase\` never cleared. Add a staleness safety: if \`lastActivityAt\` hasn't bumped for 2 minutes, self-stop.

- **sanitizeInlineText ANSI leak** (\`agenc-watch-text-utils.mjs:17\`): did not strip ANSI before whitespace-collapse; model SGR rendered as garbled control chars in status line, splash, footer. Pipe through \`stripTerminalControlSequences\` first.

- **wrapLine raw-index slicing** (\`agenc-watch-text-utils.mjs:175\`): sliced by JS string index on ANSI-bearing text; breaks landed inside SGR sequences. Rewrite with an ANSI-aware splitter that respects SGR + OSC 8 boundaries.

- **Column-width math** (\`agenc-watch-text-utils.mjs:134\`): \`visibleLength\`/\`truncateAnsi\`/\`fitAnsi\`/\`padAnsi\` assumed 1 codepoint = 1 column. Combining diacritics, VS16, ZWJ, CJK, Hangul, fullwidth/halfwidth, emoji all misaligned. Replace with a per-codepoint column walk + a minimal East Asian Width / zero-width lookup.

## Test plan

- [x] 377/387 watch tests pass; 10 pre-existing failures unchanged