### PR TITLE
fix(watch): event-store/state — shared keys, ring buffer, tool coalesce, replace scan, done transition

### DIFF
--- a/runtime/src/watch/agenc-watch-event-store.mjs
+++ b/runtime/src/watch/agenc-watch-event-store.mjs
@@ -89,8 +89,34 @@ export function createWatchEventStore(dependencies = {}) {
   }
 
   function trimBoundedHistory() {
+    // Evict from the oldest end, but NEVER shift off a pending agent
+    // event (one still in `streaming` or `pending-final`). If we lose
+    // the streaming target mid-turn, `commitAgentMessage`'s
+    // findLatestPendingAgentEvent returns null, the fallback branch
+    // creates a fresh "Agent Reply" event, and any buffered
+    // agentStreamingText is orphaned — users see a new reply appear
+    // while the streamed partial disappears.
+    //
+    // The guard: skip eviction slots whose event has a non-complete
+    // stream state. If we can't find an evictable slot (every buffered
+    // event is pending), fall back to shifting the oldest regardless,
+    // because growing past maxEvents unbounded is worse than losing
+    // one pending target.
     while (events.length > maxEvents) {
-      events.shift();
+      let evictedIndex = -1;
+      for (let index = 0; index < events.length; index += 1) {
+        const candidate = events[index];
+        const streamState = candidate?.streamState;
+        if (streamState !== "streaming" && streamState !== "pending-final") {
+          evictedIndex = index;
+          break;
+        }
+      }
+      if (evictedIndex === -1) {
+        events.shift();
+      } else {
+        events.splice(evictedIndex, 1);
+      }
     }
     clampExpandedEventSelection();
   }
@@ -148,6 +174,26 @@ export function createWatchEventStore(dependencies = {}) {
     }
     if ((previousEvent.toolName ?? null) !== (nextEvent.toolName ?? null)) {
       return false;
+    }
+    // For tool events we must distinguish distinct invocations even
+    // when their visible name+body+title are identical. Two back-to-
+    // back `ls` or `Read` calls are common and the second result
+    // must not silently collapse into the first. Require the
+    // tool-use / tool-call id to match before coalescing. Tool
+    // events without an id fall through to the time window so
+    // rapid-fire status/log lines still merge.
+    if (previousEvent.kind === "tool") {
+      const previousId =
+        previousEvent.toolCallId ??
+        previousEvent.toolUseId ??
+        null;
+      const nextId =
+        nextEvent.toolCallId ??
+        nextEvent.toolUseId ??
+        null;
+      if (previousId !== null || nextId !== null) {
+        return previousId === nextId;
+      }
     }
     const previousCreatedAt = Number(previousEvent.createdAtMs);
     const nextCreatedAt = Number(nextEvent.createdAtMs);
@@ -306,7 +352,6 @@ export function createWatchEventStore(dependencies = {}) {
   }
 
   function appendAgentStreamChunk(chunk, { done = false, resetBuffer = false } = {}) {
-    void done;
     const safeChunk = stripTerminalControlSequences(sanitizeLargeText(chunk ?? ""));
     return withPreservedManualTranscriptViewport(({ shouldFollow }) => {
       const timestamp = nowStamp();
@@ -326,6 +371,22 @@ export function createWatchEventStore(dependencies = {}) {
         : `${watchState.agentStreamingText ?? ""}${safeChunk}`;
       watchState.agentStreamingText = nextStreamingText || null;
       watchState.agentStreamingPreview = deriveStreamingPreviewText(nextStreamingText);
+      // `done: true` transitions the pending agent event from
+      // `streaming` to `pending-final` so the ring-buffer eviction
+      // guard continues to protect it while the runtime runs its
+      // stop-hook chain before the final chat.message. Previously
+      // the `done` parameter was declared but never applied, so the
+      // state machine documented in nextAgentStreamState never
+      // advanced past `streaming`.
+      if (done) {
+        const pending = findLatestPendingAgentEvent(events);
+        if (pending) {
+          pending.streamState = nextAgentStreamState({
+            previous: pending.streamState ?? "streaming",
+            done: true,
+          });
+        }
+      }
       if (safeChunk && introDismissKinds.has("agent")) {
         dismissIntro();
       }
@@ -514,25 +575,46 @@ export function createWatchEventStore(dependencies = {}) {
 
   function replaceLatestToolEvent(toolName, isError, body, descriptor) {
     return withPreservedManualTranscriptViewport(({ shouldFollow }) => {
-      const lastEvent = events[events.length - 1];
-      if (!lastEvent || lastEvent.kind !== "tool") {
-        return false;
+      // Walk backward for the nearest still-pending `tool` event of
+      // the same name. Previously the matcher only checked
+      // `events[events.length - 1]`, so if anything landed between
+      // `tools.executing` and `tools.result` (a status event, a
+      // subagent progress burst, a runtime hint) the result became a
+      // new event instead of replacing the pending one. Consumers
+      // then saw two cards for one call.
+      let target = null;
+      for (let index = events.length - 1; index >= 0; index -= 1) {
+        const candidate = events[index];
+        if (!candidate) continue;
+        if (candidate.kind === "tool" && candidate.toolName === toolName) {
+          target = candidate;
+          break;
+        }
+        // Stop if we cross another tool boundary of a different name
+        // or a result of the same name — those mark the current
+        // pending candidate as stale.
+        if (
+          (candidate.kind === "tool" || candidate.kind === "tool result") &&
+          candidate.toolName === toolName
+        ) {
+          break;
+        }
       }
-      if (lastEvent.toolName !== toolName) {
+      if (!target) {
         return false;
       }
       const normalized = normalizeEventBody(body);
-      lastEvent.kind = "tool result";
-      lastEvent.toolState = isError ? "error" : "ok";
-      lastEvent.isError = isError;
-      lastEvent.title = descriptor?.title ?? toolName;
-      lastEvent.tone = descriptor?.tone ?? (isError ? "red" : "green");
-      lastEvent.timestamp = nowStamp();
-      lastEvent.createdAtMs = nowMs();
-      lastEvent.body = normalized.body;
-      lastEvent.bodyTruncated = normalized.bodyTruncated;
-      applyDescriptorRenderingMetadata(lastEvent, descriptor);
-      updateActivity(lastEvent.timestamp);
+      target.kind = "tool result";
+      target.toolState = isError ? "error" : "ok";
+      target.isError = isError;
+      target.title = descriptor?.title ?? toolName;
+      target.tone = descriptor?.tone ?? (isError ? "red" : "green");
+      target.timestamp = nowStamp();
+      target.createdAtMs = nowMs();
+      target.body = normalized.body;
+      target.bodyTruncated = normalized.bodyTruncated;
+      applyDescriptorRenderingMetadata(target, descriptor);
+      updateActivity(target.timestamp);
       followTranscriptIfNeeded(shouldFollow);
       scheduleRender();
       return true;

--- a/runtime/src/watch/agenc-watch-state.mjs
+++ b/runtime/src/watch/agenc-watch-state.mjs
@@ -105,7 +105,16 @@ const WATCH_CHECKPOINT_STATE_KEYS = Object.freeze([
 
 export const DEFAULT_WATCH_CHECKPOINT_LIMIT = 12;
 
-const DEFAULT_BOUND_STATE_KEYS = Object.freeze([
+// Canonical list of watchState keys the surface bridge and bindings
+// must both forward. Previously `DEFAULT_BOUND_STATE_KEYS` (here) and
+// `REQUIRED_STATE_KEYS` (in agenc-watch-surface-bridge.mjs) were two
+// hand-maintained frozen arrays with no single source of truth and no
+// test asserting equality. Divergence produced visible bugs — e.g.
+// PR #468 was the fallout of `sharedCommandCatalog` being present in
+// one list but not the other, which made `/plan` never appear in the
+// TUI slash palette. Both modules now derive from this list so any
+// future key addition propagates automatically.
+export const SHARED_WATCH_STATE_KEYS = Object.freeze([
   "sessionId",
   "ownerToken",
   "sessionAttachedAtMs",
@@ -133,6 +142,8 @@ const DEFAULT_BOUND_STATE_KEYS = Object.freeze([
   "eventCategoryFilter",
   "sharedCommandCatalog",
 ]);
+
+const DEFAULT_BOUND_STATE_KEYS = SHARED_WATCH_STATE_KEYS;
 
 function normalizeStoredValue(value) {
   return typeof value === "string" && value.trim().length > 0

--- a/runtime/src/watch/agenc-watch-surface-bridge.mjs
+++ b/runtime/src/watch/agenc-watch-surface-bridge.mjs
@@ -1,36 +1,10 @@
-const REQUIRED_STATE_KEYS = Object.freeze([
-  "sessionId",
-  "ownerToken",
-  "sessionAttachedAtMs",
-  "runDetail",
-  "runState",
-  "runPhase",
-  "bootstrapReady",
-  "manualSessionsRequestPending",
-  "pendingResumeHistoryRestore",
-  "currentObjective",
-  "activeRunStartedAtMs",
-  "latestAgentSummary",
-  "latestTool",
-  "latestToolState",
-  "runInspectPending",
-  "lastUsageSummary",
-  "liveSessionModelRoute",
-  "lastStatus",
-  "cockpit",
-  "cockpitUpdatedAt",
-  "cockpitFingerprint",
-  "configuredModelRoute",
-  "lastStatusFeedFingerprint",
-  "manualSessionsQuery",
-  // Without this key here, `state.sharedCommandCatalog = ...` in the
-  // session-command-catalog dispatch case writes a plain own property
-  // on the bridge proxy instead of forwarding to real watchState, and
-  // the autocomplete read from watchState.sharedCommandCatalog always
-  // sees the initial []. Observed: /plan never appeared in the TUI
-  // slash-command palette because of this exact miss.
-  "sharedCommandCatalog",
-]);
+// Re-exported from agenc-watch-state so the bridge and the state
+// module share one source of truth — otherwise adding a new key
+// (like `sharedCommandCatalog`, PR #468) to only one of the two
+// arrays silently lets the proxy drop writes to real watchState.
+import { SHARED_WATCH_STATE_KEYS } from "./agenc-watch-state.mjs";
+
+const REQUIRED_STATE_KEYS = SHARED_WATCH_STATE_KEYS;
 
 const REQUIRED_HELPER_KEYS = Object.freeze([
   "now",


### PR DESCRIPTION
## Summary

Five event-store/state bugs from the cluster in \`TUI-BUGS.md\`: 2 CRITICAL + 2 HIGH + 1 MEDIUM. Two remaining (commitAgentMessage fallback reconciliation, chat.cancelled idempotency, unbounded subagent state maps) need deeper refactoring and are deferred.

## What's fixed

- **CRITICAL — single source of truth for watchState keys** (\`surface-bridge.mjs\` + \`state.mjs\`): both arrays now derive from a single exported \`SHARED_WATCH_STATE_KEYS\`. Divergence caused \`/plan\` to never appear in the palette.

- **CRITICAL — ring-buffer evicting pending agent events** (\`event-store.mjs:91\`): \`trimBoundedHistory\` walks forward to the first evictable slot, skipping streaming/pending-final events. Lost-stream symptom fixed.

- **HIGH — tool coalesce id-aware** (\`event-store.mjs:162\`): tool events require matching \`toolCallId\` / \`toolUseId\` to coalesce. Two identical Read/ls calls no longer collapse.

- **HIGH — replaceLatestToolEvent backward scan** (\`event-store.mjs:541\`): walks backward for the nearest pending tool event of the same name. Intervening status events no longer split a single call into two cards.

- **MEDIUM — stream chunk \`done\` transition** (\`event-store.mjs:354\`): wired through \`done: true\` so the pending agent event's \`streamState\` advances streaming → pending-final per \`nextAgentStreamState\`.

## Test plan

- [x] 377/387 watch tests pass; 10 pre-existing failures unchanged