### PR TITLE
fix(watch): transport/dispatch — backoff jitter, force-close on error, catalog preservation, subagent retire

### DIFF
--- a/runtime/src/watch/agenc-watch-subagents.mjs
+++ b/runtime/src/watch/agenc-watch-subagents.mjs
@@ -519,6 +519,13 @@ export function createWatchSubagentController(dependencies = {}) {
           "green",
           baseMetadata,
         );
+        // Retire any still-open planner DAG nodes for this subagent.
+        // Previously only `subagents.synthesized` retired nodes, so a
+        // completion event that arrived without a matching synth
+        // left the plan step stuck in a running state forever — the
+        // plan DAG UI kept a spinner for a child that had actually
+        // finished.
+        retirePlannerDagOpenNodes("completed", outputLine || `tool calls ${toolCallCount}`);
         return;
       }
       case "subagents.acceptance_probe.started": {

--- a/runtime/src/watch/agenc-watch-surface-dispatch.mjs
+++ b/runtime/src/watch/agenc-watch-surface-dispatch.mjs
@@ -273,10 +273,17 @@ function handleSessionSurfaceEvent(surfaceEvent, state, api) {
       return handleSessionListResult({ sessions: surfaceEvent.payloadList ?? [] }, state, api);
     }
     case "session.command.catalog":
-      state.sharedCommandCatalog = Array.isArray(surfaceEvent.payloadList)
-        ? surfaceEvent.payloadList
-        : [];
-      api.setTransientStatus("command catalog updated");
+      // Preserve the existing catalog on a malformed payload. Previously
+      // this silently replaced it with [] on any non-array, emptying
+      // the slash-command palette and giving no error UI. Keep what
+      // we had so the palette keeps working until a well-formed
+      // response arrives.
+      if (Array.isArray(surfaceEvent.payloadList)) {
+        state.sharedCommandCatalog = surfaceEvent.payloadList;
+        api.setTransientStatus("command catalog updated");
+      } else {
+        api.setTransientStatus("command catalog update ignored (malformed payload)");
+      }
       return true;
     case "chat.history": {
       const history = surfaceEvent.payloadList ?? [];

--- a/runtime/src/watch/agenc-watch-transport.mjs
+++ b/runtime/src/watch/agenc-watch-transport.mjs
@@ -176,10 +176,19 @@ export function createWatchTransportController(dependencies = {}) {
     if (shuttingDown() || transportState.reconnectTimer) {
       return;
     }
-    const delayMs = Math.min(
+    // Exponential backoff with jitter. Previously this was linear
+    // (`min * attempts`) and capped at `reconnectMaxDelayMs` after
+    // ~5 attempts, so a downed daemon got hammered at the cap every
+    // 5s forever. Exponential gives the server room to recover and
+    // jitter avoids a thundering herd when many watch clients
+    // reconnect simultaneously.
+    const attempt = Math.max(1, transportState.reconnectAttempts);
+    const exponential = Math.min(
       reconnectMaxDelayMs,
-      reconnectMinDelayMs * Math.max(1, transportState.reconnectAttempts),
+      reconnectMinDelayMs * Math.pow(2, Math.min(6, attempt - 1)),
     );
+    const jitter = Math.floor(Math.random() * Math.max(100, exponential * 0.3));
+    const delayMs = Math.min(reconnectMaxDelayMs, exponential + jitter);
     transportState.reconnectTimer = setTimeoutFn(() => {
       transportState.reconnectTimer = null;
       connect();
@@ -275,9 +284,18 @@ export function createWatchTransportController(dependencies = {}) {
     } else {
       setTransientStatus("websocket reconnecting");
     }
-    if (!transportState.isOpen) {
-      scheduleReconnect();
+    // Mark the socket as closed and schedule a reconnect. Some WS
+    // implementations skip `close` on hard errors, so relying on
+    // `!isOpen` alone (which stayed `true` until the close fired)
+    // meant reconnect was never scheduled after certain transport
+    // errors. Force the state transition here so the reconnect
+    // timer always kicks.
+    if (transportState.isOpen) {
+      transportState.isOpen = false;
+      transportState.ws = null;
+      transportState.connectionState = "reconnecting";
     }
+    scheduleReconnect();
   }
 
   function attachSocket(socket) {


### PR DESCRIPTION
## Summary

Four transport/dispatch bugs from the cluster: 2 HIGH + 1 MEDIUM + 1 LOW. The remaining transport bugs (bootstrap timeout, id-based response routing, hard-coded event filter, chat.stream ordering guard, session-scoped resume reset) need deeper structural work and are deferred.

## What's fixed

- **HIGH — reconnect backoff** (\`transport.mjs:179\`): replaced linear \`min * attempts\` (cap 5s) with exponential backoff + jitter.
- **HIGH — handleSocketError reconnect leak** (\`transport.mjs:277\`): some WS impls skip \`close\` on hard errors; \`!transportState.isOpen\` guard left reconnect un-scheduled. Force state to closed and always schedule.
- **MEDIUM — malformed catalog silently empties palette** (\`surface-dispatch.mjs:275\`): preserve existing catalog on non-array payload.
- **LOW — \`subagents.completed\` did not retire DAG nodes** (\`subagents.mjs:493\`): call \`retirePlannerDagOpenNodes\` on completed too, so plan-step spinners don't hang after out-of-order lifecycle events.

## Test plan

- [x] 377/387 watch tests pass; 10 pre-existing failures unchanged