### PR TITLE
fix(watch): markdown CRITICAL — emphasis word-boundary, ANSI line markers, trailing-table guard

### DIFF
--- a/runtime/src/watch/agenc-watch-markdown-parse.mjs
+++ b/runtime/src/watch/agenc-watch-markdown-parse.mjs
@@ -21,6 +21,12 @@ export function stripTerminalControlSequences(value) {
   return String(value ?? "")
     .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "")
     .replace(/\x1bP[\s\S]*?\x1b\\/g, "")
+    // Screen/line-erasing CSI commands must leave a newline behind —
+    // otherwise `line1\x1b[2Jline2` collapses to `line1line2` and
+    // transcript/tool output silently glues unrelated output
+    // together. Handle the common erase/cursor-move sequences
+    // explicitly before the catch-all strip.
+    .replace(/\x1b\[(?:2J|H|2K|0K|1K|K|\d*;\d*H|\d*;\d*f)/g, "\n")
     .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "")
     .replace(/[\x00-\x08\x0b-\x1a\x1c-\x1f\x7f]/g, "");
 }
@@ -53,12 +59,27 @@ export function normalizeInlineMarkdown(value) {
       return `${normalizedLabel} (${normalizedUrl})`;
     })
     .replace(/<((?:https?:\/\/|mailto:)[^>]+)>/g, "$1")
-    .replace(/`([^`]*)`/g, "'$1'")
-    .replace(/\*\*(.*?)\*\*/g, "$1")
-    .replace(/__(.*?)__/g, "$1")
-    .replace(/\*(.*?)\*/g, "$1")
-    .replace(/_(.*?)_/g, "$1")
-    .replace(/~~(.*?)~~/g, "$1")
+    // Code span: require the backticks to NOT be adjacent to another
+    // backtick. `` `x`y`z` `` used to match the outer span and drop
+    // the middle `y` pair because the greedy scanner left the
+    // adjacent pairs orphaned. Negative lookbehind/lookahead on
+    // backticks plus requiring non-empty content avoids both the
+    // empty-span and chained-adjacent-backtick failure modes.
+    .replace(/(?<!`)`([^`\n]+)`(?!`)/g, "'$1'")
+    // Bold: require the inner content to not start or end with the
+    // delimiter so `** *a*** ` doesn't over-merge.
+    .replace(/\*\*(?!\s)([^*\n]+?)(?<!\s)\*\*/g, "$1")
+    // Bold with underscores: require a non-word boundary around the
+    // outer `__` so `foo__bar__baz` is left alone.
+    .replace(/(^|[^A-Za-z0-9_])__(?!\s)([^_\n]+?)(?<!\s)__(?=[^A-Za-z0-9_]|$)/g, "$1$2")
+    // Italic with asterisks: single `*` must not be flanked by
+    // whitespace on the open side AND a word-character on the open
+    // side (opposite for close).
+    .replace(/(?<!\*)\*(?!\s|\*)([^*\n]+?)(?<!\s)\*(?!\*)/g, "$1")
+    // Italic with underscores: same word-boundary rule as __ so
+    // `foo_bar_baz.py` is preserved.
+    .replace(/(^|[^A-Za-z0-9_])_(?!\s)([^_\n]+?)(?<!\s)_(?=[^A-Za-z0-9_]|$)/g, "$1$2")
+    .replace(/~~(?!\s)([^~\n]+?)(?<!\s)~~/g, "$1")
     .replace(/\\([\\`*_{}\[\]()#+\-.!>])/g, "$1");
 }
 

--- a/runtime/src/watch/agenc-watch-markdown-stream.mjs
+++ b/runtime/src/watch/agenc-watch-markdown-stream.mjs
@@ -24,7 +24,16 @@ function findTrailingTableCandidateStart(rawLines) {
   while (index >= 0 && looksLikeTableLine(rawLines[index])) {
     index -= 1;
   }
-  return index === endIndex ? -1 : index + 1;
+  const candidateStart = index + 1;
+  // Require at least two `|`-leading lines to treat the tail as a
+  // trailing table. A single `| foo |` line below a stable paragraph
+  // is more likely prose than an incomplete table header; the
+  // previous detector held such a line back as preview forever
+  // because it never resolved to a header+separator pair.
+  if (candidateStart > endIndex || endIndex - candidateStart < 1) {
+    return -1;
+  }
+  return candidateStart;
 }
 
 function hasPotentiallyIncompleteInlineMarkdown(rawLine) {


### PR DESCRIPTION
## Summary

Three CRITICAL markdown/rich-text bugs from the cluster. All three silently corrupted displayed text.

## What's fixed

- **Greedy emphasis regexes** (\`markdown-parse.mjs:57\`): \`foo_bar_baz.py\` lost its underscores, \`\`\`\`x\`y\`z\`\`\`\` became \`'x'y'z'\`. Tightened each delimiter with word-boundary / non-flanking-backtick checks.

- **ANSI strip without line markers** (\`markdown-parse.mjs:20\`): \`line1\\x1b[2Jline2\` collapsed to \`line1line2\`. Screen/line-erasing CSI sequences now normalize to a newline before the catch-all strip.

- **Trailing-table detector** (\`markdown-stream.mjs:18\`): a single \`|\`-leading tail line was held back as incomplete-table preview forever. Now requires at least two \`|\`-leading lines to trigger.

## Test plan

- [x] 377/387 watch tests pass; 10 pre-existing failures unchanged