### PR TITLE
fix(watch): markdown HIGH — displayWidth, surrogate-safe wrap

### DIFF
--- a/runtime/src/watch/agenc-watch-markdown-parse.mjs
+++ b/runtime/src/watch/agenc-watch-markdown-parse.mjs
@@ -129,8 +129,42 @@ function distributeWidthRemainder(widths, remainder) {
   return output;
 }
 
+// Minimal per-codepoint column width. Mirrors the helper in
+// agenc-watch-text-utils.mjs so table-cell alignment accounts for
+// combining marks (width 0), CJK/emoji (width 2), and fullwidth
+// forms. Previously `displayWidth` counted code points, which made
+// CJK table columns misaligned by a factor of 2.
+function codePointColumnWidth(codePoint) {
+  if (codePoint < 0x20) return 0;
+  if (codePoint >= 0x0300 && codePoint <= 0x036F) return 0;
+  if (codePoint >= 0x200B && codePoint <= 0x200F) return 0;
+  if (codePoint >= 0x202A && codePoint <= 0x202E) return 0;
+  if (codePoint >= 0x2060 && codePoint <= 0x2064) return 0;
+  if (codePoint === 0xFEFF) return 0;
+  if (codePoint >= 0xFE00 && codePoint <= 0xFE0F) return 0;
+  if (codePoint >= 0xE0100 && codePoint <= 0xE01EF) return 0;
+  if (codePoint >= 0x1100 && codePoint <= 0x115F) return 2;
+  if (codePoint >= 0x2E80 && codePoint <= 0x303E) return 2;
+  if (codePoint >= 0x3041 && codePoint <= 0x33FF) return 2;
+  if (codePoint >= 0x3400 && codePoint <= 0x4DBF) return 2;
+  if (codePoint >= 0x4E00 && codePoint <= 0x9FFF) return 2;
+  if (codePoint >= 0xA000 && codePoint <= 0xA4CF) return 2;
+  if (codePoint >= 0xAC00 && codePoint <= 0xD7A3) return 2;
+  if (codePoint >= 0xF900 && codePoint <= 0xFAFF) return 2;
+  if (codePoint >= 0xFE30 && codePoint <= 0xFE4F) return 2;
+  if (codePoint >= 0xFF00 && codePoint <= 0xFF60) return 2;
+  if (codePoint >= 0xFFE0 && codePoint <= 0xFFE6) return 2;
+  if (codePoint >= 0x1F300 && codePoint <= 0x1FAFF) return 2;
+  return 1;
+}
+
 function displayWidth(value) {
-  return Array.from(String(value ?? "")).length;
+  const text = String(value ?? "");
+  let width = 0;
+  for (const codePoint of text) {
+    width += codePointColumnWidth(codePoint.codePointAt(0));
+  }
+  return width;
 }
 
 function sliceDisplay(value, start, end = Infinity) {

--- a/runtime/src/watch/agenc-watch-rich-text.mjs
+++ b/runtime/src/watch/agenc-watch-rich-text.mjs
@@ -396,6 +396,20 @@ function wrapPlainTextLine(text, width, continuationPrefix = "", inlineSegments 
       splitAt = spaceIndex;
     }
     splitAt = adjustSplitForInlineReference(inlineSegments, splitAt, sourceStart);
+    // Never split inside a UTF-16 surrogate pair — that would emit an
+    // unpaired high surrogate to the terminal, producing a replacement
+    // glyph and corrupting the downstream cell math. If the split
+    // index lands between a high and low surrogate, back off one
+    // code unit.
+    if (splitAt > 0 && splitAt < remaining.length) {
+      const highSurrogate = remaining.charCodeAt(splitAt - 1);
+      if (highSurrogate >= 0xd800 && highSurrogate <= 0xdbff) {
+        const lowSurrogate = remaining.charCodeAt(splitAt);
+        if (lowSurrogate >= 0xdc00 && lowSurrogate <= 0xdfff) {
+          splitAt -= 1;
+        }
+      }
+    }
     const visibleChunk = remaining.slice(0, splitAt);
     const trimmedChunk = visibleChunk.trimEnd();
     const trailingTrim = visibleChunk.length - trimmedChunk.length;


### PR DESCRIPTION
## Summary

Two markdown/rich-text HIGH bugs. Column-width correctness + wrap-point safety.

## What's fixed

- **displayWidth code-point vs cell count** (\`markdown-parse.mjs:132\`): table-cell alignment misaligned for CJK/emoji. Replaced with per-codepoint column-width walk.

- **wrapPlainTextLine surrogate pair split** (\`rich-text.mjs:390\`): wrap point could land between a high and low surrogate, emitting an unpaired half to the terminal. Back off one code unit at surrogate boundaries.

## Deferred

Remaining HIGH/MEDIUM markdown bugs need deeper parser rewrites and are tracked in \`TUI-BUGS.md\`: full markdown re-parse LRU, incomplete fenced code block detection, GFM tables without outer pipes, syntax highlight language dispatch, box-drawing ASCII fallback, \`(empty)\` placeholder leak, \`wrapRichDisplayLines\` tables unwrapped.

## Test plan

- [x] 377/387 watch tests pass; 10 pre-existing failures unchanged