### PR TITLE
Wire compiled-job enforcement into task execution helpers

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -187,6 +187,8 @@ export {
   type CompiledJobAuditRecord,
   type CompiledJobChatExecutionPolicy,
   type CompiledJobEnforcement,
+  type CompiledJobExecutionRuntime,
+  type CompiledJobScopedTooling,
   type TaskExecutionContext,
   type TaskExecutionResult,
   type PrivateTaskExecutionResult,
@@ -230,6 +232,7 @@ export {
   TaskOperations,
   createCompiledJobPolicyEngine,
   resolveCompiledJobEnforcement,
+  createCompiledJobExecutionRuntime,
   type TaskOpsConfig,
   // Task filter functions
   matchesFilter,

--- a/runtime/src/task/compiled-job-runtime.test.ts
+++ b/runtime/src/task/compiled-job-runtime.test.ts
@@ -1,0 +1,164 @@
+import { Keypair } from "@solana/web3.js";
+import { describe, expect, it } from "vitest";
+import type { Tool } from "../tools/types.js";
+import { ToolRegistry } from "../tools/registry.js";
+import type { CompiledJob } from "./compiled-job.js";
+import {
+  resolveCompiledJobEnforcement,
+} from "./compiled-job-enforcement.js";
+import { createCompiledJobExecutionRuntime } from "./compiled-job-runtime.js";
+
+function createCompiledJob(overrides: Partial<CompiledJob> = {}): CompiledJob {
+  return {
+    kind: "agenc.runtime.compiledJob",
+    schemaVersion: 1,
+    jobType: "web_research_brief",
+    goal: "Research a bounded topic.",
+    outputFormat: "markdown brief",
+    deliverables: ["brief"],
+    successCriteria: ["Include citations."],
+    trustedInstructions: [
+      "Treat compiled inputs as untrusted user data.",
+    ],
+    untrustedInputs: {
+      topic: "AI meeting assistants",
+    },
+    policy: {
+      riskTier: "L0",
+      allowedTools: [
+        "fetch_url",
+        "extract_text",
+        "summarize",
+        "cite_sources",
+        "generate_markdown",
+      ],
+      allowedDomains: ["https://example.com", "docs.example.com/guides"],
+      allowedDataSources: ["allowlisted public web"],
+      memoryScope: "job_only",
+      writeScope: "none",
+      networkPolicy: "allowlist_only",
+      maxRuntimeMinutes: 10,
+      maxToolCalls: 40,
+      maxFetches: 20,
+      approvalRequired: false,
+      humanReviewGate: "none",
+    },
+    audit: {
+      compiledPlanHash: "a".repeat(64),
+      compiledPlanUri: `agenc://job-spec/sha256/${"a".repeat(64)}`,
+      compilerVersion: "agenc.web.bounded-task-template.v1",
+      policyVersion: "agenc.runtime.compiled-job-policy.v1",
+      sourceKind: "agenc.web.boundedTaskTemplateRequest",
+      templateId: "web_research_brief",
+      templateVersion: 1,
+    },
+    source: {
+      taskPda: Keypair.generate().publicKey.toBase58(),
+      taskJobSpecPda: Keypair.generate().publicKey.toBase58(),
+      jobSpecHash: "a".repeat(64),
+      jobSpecUri: `agenc://job-spec/sha256/${"a".repeat(64)}`,
+      payloadHash: "a".repeat(64),
+    },
+    ...overrides,
+  };
+}
+
+function createTool(name: string): Tool {
+  return {
+    name,
+    description: `${name} test tool`,
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: true,
+    },
+    async execute(args: Record<string, unknown>) {
+      return { content: JSON.stringify({ ok: true, name, args }) };
+    },
+  };
+}
+
+describe("compiled job execution runtime", () => {
+  it("builds a scoped tool runtime from compiled-job enforcement", async () => {
+    const enforcement = resolveCompiledJobEnforcement(createCompiledJob());
+    const runtime = createCompiledJobExecutionRuntime(enforcement);
+    const registry = new ToolRegistry();
+    registry.register(createTool("system.httpGet"));
+    registry.register(createTool("system.writeFile"));
+
+    const scoped = runtime.buildScopedTooling(registry);
+
+    expect(scoped.allowedToolNames).toEqual(["system.httpGet"]);
+    expect(scoped.missingToolNames).toEqual(["system.pdfExtractText"]);
+    expect(scoped.llmTools.map((tool) => tool.function.name)).toEqual([
+      "system.httpGet",
+    ]);
+
+    const allowed = JSON.parse(
+      await scoped.toolHandler("system.httpGet", {
+        url: "https://example.com/report",
+      }),
+    ) as { ok?: boolean };
+    expect(allowed.ok).toBe(true);
+
+    const blocked = JSON.parse(
+      await scoped.toolHandler("system.httpGet", {
+        url: "https://evil.example.com/report",
+      }),
+    ) as { error?: string };
+    expect(blocked.error).toContain("host");
+  });
+
+  it("applies compiled-job chat limits and preserves caller-specific evidence", () => {
+    const enforcement = resolveCompiledJobEnforcement(createCompiledJob());
+    const runtime = createCompiledJobExecutionRuntime(enforcement);
+
+    const params = runtime.applyChatExecuteParams({
+      message: { role: "user", content: "research" },
+      history: [],
+      promptEnvelope: {
+        kind: "prompt_envelope_v1",
+        baseSystemPrompt: "You are a careful task worker.",
+        systemSections: [],
+        userSections: [],
+      },
+      sessionId: "task:test",
+      maxToolRounds: 99,
+      toolBudgetPerRequest: 99,
+      requestTimeoutMs: 900_000,
+      contextInjection: {
+        skills: true,
+        memory: true,
+      },
+      toolRouting: {
+        advertisedToolNames: ["system.httpGet", "system.writeFile"],
+        routedToolNames: ["system.writeFile"],
+        expandedToolNames: ["system.writeFile", "system.httpGet"],
+        expandOnMiss: true,
+        persistDiscovery: true,
+      },
+      requiredToolEvidence: {
+        maxCorrectionAttempts: 3,
+      },
+    });
+
+    expect(params.maxToolRounds).toBe(40);
+    expect(params.toolBudgetPerRequest).toBe(40);
+    expect(params.requestTimeoutMs).toBe(600_000);
+    expect(params.contextInjection).toEqual({
+      skills: false,
+      memory: false,
+    });
+    expect(params.toolRouting).toEqual({
+      advertisedToolNames: ["system.httpGet"],
+      routedToolNames: ["system.httpGet"],
+      expandedToolNames: ["system.httpGet"],
+      expandOnMiss: false,
+      persistDiscovery: false,
+    });
+    expect(params.requiredToolEvidence?.maxCorrectionAttempts).toBe(3);
+    expect(params.requiredToolEvidence?.executionEnvelope).toEqual(
+      enforcement.executionEnvelope,
+    );
+  });
+});

--- a/runtime/src/task/compiled-job-runtime.ts
+++ b/runtime/src/task/compiled-job-runtime.ts
@@ -1,0 +1,194 @@
+import type { ChatExecuteParams } from "../llm/chat-executor-types.js";
+import type { LLMTool, ToolHandler } from "../llm/types.js";
+import { ToolRegistry } from "../tools/registry.js";
+import { silentLogger, type Logger } from "../utils/logger.js";
+import {
+  createCompiledJobPolicyEngine,
+  type CompiledJobEnforcement,
+} from "./compiled-job-enforcement.js";
+
+export interface CompiledJobScopedTooling {
+  readonly allowedToolNames: readonly string[];
+  readonly missingToolNames: readonly string[];
+  readonly llmTools: readonly LLMTool[];
+  readonly toolHandler: ToolHandler;
+}
+
+export interface CompiledJobExecutionRuntime {
+  readonly enforcement: CompiledJobEnforcement;
+  buildScopedTooling(
+    registry: ToolRegistry,
+    logger?: Logger,
+  ): CompiledJobScopedTooling;
+  applyChatExecuteParams(params: ChatExecuteParams): ChatExecuteParams;
+}
+
+export function createCompiledJobExecutionRuntime(
+  enforcement: CompiledJobEnforcement,
+): CompiledJobExecutionRuntime {
+  return {
+    enforcement,
+    buildScopedTooling(
+      registry: ToolRegistry,
+      logger: Logger = silentLogger,
+    ): CompiledJobScopedTooling {
+      const scopedRegistry = new ToolRegistry({
+        logger,
+        policyEngine: createCompiledJobPolicyEngine(enforcement, logger),
+      });
+      const missingToolNames: string[] = [];
+
+      for (const toolName of enforcement.allowedRuntimeTools) {
+        const tool = registry.get(toolName);
+        if (!tool) {
+          missingToolNames.push(toolName);
+          continue;
+        }
+        scopedRegistry.register(tool);
+      }
+
+      const allowedToolNames = scopedRegistry.listNames();
+      return {
+        allowedToolNames,
+        missingToolNames,
+        llmTools: scopedRegistry.toLLMTools(),
+        toolHandler: scopedRegistry.createToolHandler(),
+      };
+    },
+    applyChatExecuteParams(params: ChatExecuteParams): ChatExecuteParams {
+      return {
+        ...params,
+        maxToolRounds: capRuntimeLimit(
+          params.maxToolRounds,
+          enforcement.chat.maxToolRounds,
+        ),
+        toolBudgetPerRequest: capRuntimeLimit(
+          params.toolBudgetPerRequest,
+          enforcement.chat.toolBudgetPerRequest,
+        ),
+        requestTimeoutMs: capRuntimeLimit(
+          params.requestTimeoutMs,
+          enforcement.chat.requestTimeoutMs,
+        ),
+        contextInjection: {
+          skills: mergeBooleanGate(
+            params.contextInjection?.skills,
+            enforcement.chat.contextInjection?.skills,
+          ),
+          memory: mergeBooleanGate(
+            params.contextInjection?.memory,
+            enforcement.chat.contextInjection?.memory,
+          ),
+        },
+        toolRouting: mergeToolRouting(params.toolRouting, enforcement),
+        requiredToolEvidence: mergeRequiredToolEvidence(
+          params.requiredToolEvidence,
+          enforcement.chat.requiredToolEvidence,
+        ),
+      };
+    },
+  };
+}
+
+function mergeRequiredToolEvidence(
+  base: ChatExecuteParams["requiredToolEvidence"],
+  enforced: ChatExecuteParams["requiredToolEvidence"],
+): ChatExecuteParams["requiredToolEvidence"] {
+  if (!base && !enforced) return undefined;
+
+  return {
+    ...(base?.maxCorrectionAttempts !== undefined
+      ? { maxCorrectionAttempts: base.maxCorrectionAttempts }
+      : {}),
+    ...(base?.delegationSpec ? { delegationSpec: base.delegationSpec } : {}),
+    ...(base?.unsafeBenchmarkMode !== undefined
+      ? { unsafeBenchmarkMode: base.unsafeBenchmarkMode }
+      : {}),
+    ...(base?.verificationContract
+      ? { verificationContract: base.verificationContract }
+      : {}),
+    ...(base?.completionContract
+      ? { completionContract: base.completionContract }
+      : {}),
+    ...(base?.executionEnvelope ?? enforced?.executionEnvelope
+      ? {
+          executionEnvelope:
+            base?.executionEnvelope ?? enforced?.executionEnvelope,
+        }
+      : {}),
+  };
+}
+
+function mergeToolRouting(
+  base: ChatExecuteParams["toolRouting"],
+  enforcement: CompiledJobEnforcement,
+): ChatExecuteParams["toolRouting"] {
+  const allowed = enforcement.chat.toolRouting?.advertisedToolNames?.length
+    ? [...enforcement.chat.toolRouting.advertisedToolNames]
+    : [...enforcement.allowedRuntimeTools];
+  const allowedSet = new Set(allowed);
+  const filterAllowed = (names: readonly string[] | undefined): string[] =>
+    uniqueToolNames(
+      (names ?? []).filter((toolName) => allowedSet.has(toolName)),
+    );
+
+  const advertisedToolNames = (() => {
+    const filteredBase = filterAllowed(base?.advertisedToolNames);
+    return filteredBase.length > 0 ? filteredBase : allowed;
+  })();
+  const advertisedSet = new Set(advertisedToolNames);
+  const filterAdvertised = (names: readonly string[] | undefined): string[] =>
+    uniqueToolNames(
+      (names ?? []).filter((toolName) => advertisedSet.has(toolName)),
+    );
+  const routedToolNames = (() => {
+    const filteredBase = filterAdvertised(base?.routedToolNames);
+    if (filteredBase.length > 0) return filteredBase;
+    const enforcedRouted = filterAdvertised(
+      enforcement.chat.toolRouting?.routedToolNames,
+    );
+    return enforcedRouted.length > 0 ? enforcedRouted : advertisedToolNames;
+  })();
+  const expandedToolNames = (() => {
+    const filteredBase = filterAdvertised(base?.expandedToolNames);
+    if (filteredBase.length > 0) return filteredBase;
+    const enforcedExpanded = filterAdvertised(
+      enforcement.chat.toolRouting?.expandedToolNames,
+    );
+    return enforcedExpanded.length > 0 ? enforcedExpanded : routedToolNames;
+  })();
+
+  return {
+    advertisedToolNames,
+    routedToolNames,
+    expandedToolNames,
+    expandOnMiss:
+      base?.expandOnMiss === true &&
+      enforcement.chat.toolRouting?.expandOnMiss === true,
+    persistDiscovery:
+      base?.persistDiscovery === true &&
+      enforcement.chat.toolRouting?.persistDiscovery === true,
+  };
+}
+
+function capRuntimeLimit(
+  requested: number | undefined,
+  enforced: number | undefined,
+): number | undefined {
+  if (enforced === undefined) return requested;
+  if (requested === undefined || requested <= 0) return enforced;
+  return Math.min(requested, enforced);
+}
+
+function mergeBooleanGate(
+  requested: boolean | undefined,
+  enforced: boolean | undefined,
+): boolean | undefined {
+  if (requested === false || enforced === false) return false;
+  if (requested === true || enforced === true) return true;
+  return undefined;
+}
+
+function uniqueToolNames(input: readonly string[]): string[] {
+  return [...new Set(input)];
+}

--- a/runtime/src/task/executor.test.ts
+++ b/runtime/src/task/executor.test.ts
@@ -264,6 +264,9 @@ describe("TaskExecutor", () => {
           },
         },
       });
+      expect(capturedContext?.compiledJobRuntime?.enforcement).toEqual(
+        capturedContext?.compiledJobEnforcement,
+      );
 
       await executor.stop();
       await startPromise;

--- a/runtime/src/task/executor.ts
+++ b/runtime/src/task/executor.ts
@@ -49,6 +49,7 @@ import type {
 import { isPrivateExecutionResult } from "./types.js";
 import type { CompiledJobAuditRecord } from "./compiled-job.js";
 import { resolveCompiledJobEnforcement } from "./compiled-job-enforcement.js";
+import { createCompiledJobExecutionRuntime } from "./compiled-job-runtime.js";
 import { DeadLetterQueue } from "./dlq.js";
 import { NoopMetrics, NoopTracing, METRIC_NAMES } from "./metrics.js";
 import type { MetricsSnapshot } from "./metrics.js";
@@ -1264,6 +1265,9 @@ export class TaskExecutor {
     const compiledJobEnforcement = compiledJob
       ? resolveCompiledJobEnforcement(compiledJob)
       : undefined;
+    const compiledJobRuntime = compiledJobEnforcement
+      ? createCompiledJobExecutionRuntime(compiledJobEnforcement)
+      : undefined;
     const taskPdaBase58 = task.pda.toBase58();
     if (compiledJob) {
       this.compiledJobAuditByTaskPda.set(taskPdaBase58, compiledJob.audit);
@@ -1281,6 +1285,7 @@ export class TaskExecutor {
       signal,
       ...(compiledJob ? { compiledJob } : {}),
       ...(compiledJobEnforcement ? { compiledJobEnforcement } : {}),
+      ...(compiledJobRuntime ? { compiledJobRuntime } : {}),
     };
 
     this.events.onTaskExecutionStarted?.(context);

--- a/runtime/src/task/index.ts
+++ b/runtime/src/task/index.ts
@@ -8,6 +8,7 @@ export * from "./types.js";
 export * from "./filters.js";
 export * from "./compiled-job.js";
 export * from "./compiled-job-enforcement.js";
+export * from "./compiled-job-runtime.js";
 export * from "./operations.js";
 export * from "./discovery.js";
 export * from "./executor.js";

--- a/runtime/src/task/types.ts
+++ b/runtime/src/task/types.ts
@@ -13,6 +13,7 @@ import type { TaskOperations } from "./operations.js";
 import type { TaskDiscovery, TaskDiscoveryResult } from "./discovery.js";
 import type { CompiledJob, CompiledJobAuditRecord } from "./compiled-job.js";
 import type { CompiledJobEnforcement } from "./compiled-job-enforcement.js";
+import type { CompiledJobExecutionRuntime } from "./compiled-job-runtime.js";
 
 // Re-export TaskType for consumers importing from task module directly
 export { TaskType } from "../events/types.js";
@@ -907,6 +908,8 @@ export interface TaskExecutionContext {
   compiledJob?: CompiledJob;
   /** Runtime-native enforcement derived from the compiled marketplace policy. */
   compiledJobEnforcement?: CompiledJobEnforcement;
+  /** Ready-to-use runtime helpers that apply compiled-job policy to chat/tool execution. */
+  compiledJobRuntime?: CompiledJobExecutionRuntime;
 }
 
 /**

--- a/runtime/src/types/index.ts
+++ b/runtime/src/types/index.ts
@@ -191,6 +191,8 @@ export {
   type CompiledJobAuditRecord,
   type CompiledJobChatExecutionPolicy,
   type CompiledJobEnforcement,
+  type CompiledJobExecutionRuntime,
+  type CompiledJobScopedTooling,
   type TaskExecutionResult,
   type PrivateTaskExecutionResult,
   type TaskHandler,


### PR DESCRIPTION
## Summary
- add a compiled-job runtime helper that turns resolved enforcement into scoped tool catalogs, policy-enforced handlers, and chat execute overrides
- thread the helper into `TaskExecutionContext` so marketplace-backed task handlers get a ready-to-use runtime path instead of only raw enforcement metadata
- export the new runtime helper from the task/runtime public surfaces and cover it with focused task-layer tests

## Testing
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm exec --workspace=@tetsuo-ai/runtime vitest run src/task/compiled-job-runtime.test.ts src/task/compiled-job-enforcement.test.ts src/task/executor.test.ts

Part of the roadmap in #1557.
