### PR TITLE
Centralize L0 side-effect blocking for compiled marketplace jobs

### DIFF
--- a/runtime/src/task/compiled-job-chat-handler.test.ts
+++ b/runtime/src/task/compiled-job-chat-handler.test.ts
@@ -274,6 +274,53 @@ describe("compiled job chat task handler", () => {
     expect(provider.chatStream).not.toHaveBeenCalled();
   });
 
+  it("fails closed when L0 runtime detects blocked side-effect tools", async () => {
+    const provider = createMockProvider([
+      {
+        content: "unused",
+        toolCalls: [],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        model: "mock-model",
+        finishReason: "stop",
+      },
+    ]);
+    const executor = new ChatExecutor({
+      providers: [provider],
+      allowedTools: ["system.httpGet", "system.pdfExtractText", "x.post"],
+    });
+    const registry = new ToolRegistry();
+    registry.register(createTool("system.httpGet"));
+    registry.register(createTool("system.pdfExtractText"));
+    registry.register(createTool("x.post"));
+
+    const baseContext = createContext();
+    const compiledJobEnforcement = {
+      ...baseContext.compiledJobEnforcement!,
+      allowedRuntimeTools: [
+        ...baseContext.compiledJobEnforcement!.allowedRuntimeTools,
+        "x.post",
+      ],
+    };
+    const handler = createCompiledJobChatTaskHandler({
+      chatExecutor: executor,
+      toolRegistry: registry,
+    });
+
+    await expect(
+      handler({
+        ...baseContext,
+        compiledJobEnforcement,
+        compiledJobRuntime: createCompiledJobExecutionRuntime(
+          compiledJobEnforcement,
+        ),
+      }),
+    ).rejects.toThrow(
+      "Compiled job runtime blocked side-effect tools for L0 execution: x.post",
+    );
+    expect(provider.chat).not.toHaveBeenCalled();
+    expect(provider.chatStream).not.toHaveBeenCalled();
+  });
+
   it("rejects unsupported compiled job types for the first launch runner", async () => {
     const provider = createMockProvider([
       {

--- a/runtime/src/task/compiled-job-chat-handler.ts
+++ b/runtime/src/task/compiled-job-chat-handler.ts
@@ -60,6 +60,11 @@ export function createCompiledJobChatTaskHandler(
       options.toolRegistry,
       logger,
     );
+    if (scopedTooling.blockedToolNames.length > 0) {
+      throw new Error(
+        `Compiled job runtime blocked side-effect tools for ${compiledJob.policy.riskTier} execution: ${scopedTooling.blockedToolNames.join(", ")}`,
+      );
+    }
     if (scopedTooling.missingToolNames.length > 0) {
       throw new Error(
         `Compiled job runtime is missing required tools: ${scopedTooling.missingToolNames.join(", ")}`,

--- a/runtime/src/task/compiled-job-enforcement.test.ts
+++ b/runtime/src/task/compiled-job-enforcement.test.ts
@@ -80,6 +80,12 @@ describe("compiled job enforcement", () => {
       skills: false,
       memory: false,
     });
+    expect(enforcement.sideEffectPolicy).toEqual({
+      riskTier: "L0",
+      approvalRequired: false,
+      humanReviewGate: "none",
+      allowedMutatingRuntimeTools: [],
+    });
     expect(enforcement.chat.maxToolRounds).toBe(40);
     expect(enforcement.chat.toolBudgetPerRequest).toBe(40);
     expect(enforcement.chat.requestTimeoutMs).toBe(600_000);
@@ -164,6 +170,12 @@ describe("compiled job enforcement", () => {
       "/tmp/agenc-job",
     ]);
     expect(enforcement.runtimePolicy.networkAccess).toBeUndefined();
+    expect(enforcement.sideEffectPolicy.allowedMutatingRuntimeTools).toEqual([
+      "system.writeFile",
+      "system.appendFile",
+      "system.editFile",
+      "system.mkdir",
+    ]);
   });
 
   it("creates a policy engine that enforces domain and tool restrictions", () => {

--- a/runtime/src/task/compiled-job-enforcement.ts
+++ b/runtime/src/task/compiled-job-enforcement.ts
@@ -57,6 +57,14 @@ export interface CompiledJobEnforcement {
   readonly runtimePolicy: RuntimePolicyConfig;
   readonly chat: CompiledJobChatExecutionPolicy;
   readonly scope: PolicyEvaluationScope;
+  readonly sideEffectPolicy: CompiledJobSideEffectPolicy;
+}
+
+export interface CompiledJobSideEffectPolicy {
+  readonly riskTier: CompiledJob["policy"]["riskTier"];
+  readonly approvalRequired: boolean;
+  readonly humanReviewGate: CompiledJob["policy"]["humanReviewGate"];
+  readonly allowedMutatingRuntimeTools: readonly string[];
 }
 
 export function resolveCompiledJobEnforcement(
@@ -118,6 +126,12 @@ export function resolveCompiledJobEnforcement(
       ? options.workspaceRoot
       : undefined,
   });
+  const sideEffectPolicy: CompiledJobSideEffectPolicy = {
+    riskTier: compiledJob.policy.riskTier,
+    approvalRequired: compiledJob.policy.approvalRequired,
+    humanReviewGate: compiledJob.policy.humanReviewGate,
+    allowedMutatingRuntimeTools: resolveAllowedMutatingRuntimeTools(compiledJob),
+  };
 
   return {
     allowedRuntimeTools,
@@ -125,6 +139,7 @@ export function resolveCompiledJobEnforcement(
     executionEnvelope,
     runtimePolicy,
     scope,
+    sideEffectPolicy,
     chat: {
       contextInjection: {
         skills: false,
@@ -232,6 +247,26 @@ function resolveRuntimeToolNames(compiledJob: CompiledJob): readonly string[] {
   if (compiledJob.policy.networkPolicy !== "allowlist_only") {
     for (const runtimeTool of NETWORK_RUNTIME_TOOLS) {
       toolNames.delete(runtimeTool);
+    }
+  }
+
+  return [...toolNames];
+}
+
+function resolveAllowedMutatingRuntimeTools(
+  compiledJob: CompiledJob,
+): readonly string[] {
+  const toolNames = new Set<string>();
+
+  if (compiledJob.policy.writeScope === "workspace_only") {
+    for (const runtimeTool of WORKSPACE_WRITE_RUNTIME_TOOLS) {
+      toolNames.add(runtimeTool);
+    }
+  }
+
+  if (compiledJob.policy.allowedTools.includes("run_approved_checks")) {
+    for (const runtimeTool of APPROVED_CHECK_RUNTIME_TOOLS) {
+      toolNames.add(runtimeTool);
     }
   }
 

--- a/runtime/src/task/compiled-job-runtime.test.ts
+++ b/runtime/src/task/compiled-job-runtime.test.ts
@@ -63,7 +63,10 @@ function createCompiledJob(overrides: Partial<CompiledJob> = {}): CompiledJob {
   };
 }
 
-function createTool(name: string): Tool {
+function createTool(
+  name: string,
+  input: Partial<Pick<Tool, "metadata" | "execute">> = {},
+): Tool {
   return {
     name,
     description: `${name} test tool`,
@@ -72,7 +75,11 @@ function createTool(name: string): Tool {
       properties: {},
       additionalProperties: true,
     },
+    metadata: input.metadata,
     async execute(args: Record<string, unknown>) {
+      if (input.execute) {
+        return input.execute(args);
+      }
       return { content: JSON.stringify({ ok: true, name, args }) };
     },
   };
@@ -90,6 +97,7 @@ describe("compiled job execution runtime", () => {
 
     expect(scoped.allowedToolNames).toEqual(["system.httpGet"]);
     expect(scoped.missingToolNames).toEqual(["system.pdfExtractText"]);
+    expect(scoped.blockedToolNames).toEqual([]);
     expect(scoped.llmTools.map((tool) => tool.function.name)).toEqual([
       "system.httpGet",
     ]);
@@ -160,5 +168,122 @@ describe("compiled job execution runtime", () => {
     expect(params.requiredToolEvidence?.executionEnvelope).toEqual(
       enforcement.executionEnvelope,
     );
+  });
+
+  it("blocks external side-effect tools from L0 execution even if they leak into the runtime allowlist", () => {
+    const baseEnforcement = resolveCompiledJobEnforcement(createCompiledJob());
+    const enforcement = {
+      ...baseEnforcement,
+      allowedRuntimeTools: [
+        ...baseEnforcement.allowedRuntimeTools,
+        "x.post",
+        "agenc.purchaseSkill",
+        "system.writeFile",
+      ],
+    };
+    const runtime = createCompiledJobExecutionRuntime(enforcement);
+    const registry = new ToolRegistry();
+    registry.register(createTool("system.httpGet"));
+    registry.register(createTool("system.pdfExtractText"));
+    registry.register(
+      createTool("x.post", {
+        metadata: { mutating: true },
+      }),
+    );
+    registry.register(
+      createTool("agenc.purchaseSkill", {
+        metadata: { mutating: true },
+      }),
+    );
+    registry.register(
+      createTool("system.writeFile", {
+        metadata: { mutating: true },
+      }),
+    );
+
+    const scoped = runtime.buildScopedTooling(registry);
+
+    expect(scoped.allowedToolNames).toEqual([
+      "system.httpGet",
+      "system.pdfExtractText",
+    ]);
+    expect(scoped.blockedToolNames).toEqual([
+      "x.post",
+      "agenc.purchaseSkill",
+      "system.writeFile",
+    ]);
+
+    const params = runtime.applyChatExecuteParams({
+      message: { role: "user", content: "research" },
+      history: [],
+      promptEnvelope: {
+        kind: "prompt_envelope_v1",
+        baseSystemPrompt: "You are a careful task worker.",
+        systemSections: [],
+        userSections: [],
+      },
+      sessionId: "task:test",
+      toolRouting: {
+        advertisedToolNames: enforcement.allowedRuntimeTools,
+        routedToolNames: enforcement.allowedRuntimeTools,
+        expandedToolNames: enforcement.allowedRuntimeTools,
+        expandOnMiss: false,
+        persistDiscovery: false,
+      },
+    });
+
+    expect(params.toolRouting).toEqual({
+      advertisedToolNames: ["system.httpGet", "system.pdfExtractText"],
+      routedToolNames: ["system.httpGet", "system.pdfExtractText"],
+      expandedToolNames: ["system.httpGet", "system.pdfExtractText"],
+      expandOnMiss: false,
+      persistDiscovery: false,
+    });
+  });
+
+  it("keeps explicit local workspace mutations available for workspace_only jobs", () => {
+    const enforcement = resolveCompiledJobEnforcement(
+      createCompiledJob({
+        jobType: "spreadsheet_cleanup_classification",
+        policy: {
+          ...createCompiledJob().policy,
+          allowedTools: ["normalize_table", "classify_rows", "generate_csv"],
+          writeScope: "workspace_only",
+          networkPolicy: "off",
+          allowedDomains: [],
+          allowedDataSources: ["provided spreadsheet only"],
+          maxToolCalls: 30,
+          maxFetches: 0,
+        },
+        audit: {
+          ...createCompiledJob().audit,
+          templateId: "spreadsheet_cleanup_classification",
+        },
+      }),
+      {
+        workspaceRoot: "/tmp/agenc-job",
+      },
+    );
+    const runtime = createCompiledJobExecutionRuntime(enforcement);
+    const registry = new ToolRegistry();
+    for (const toolName of enforcement.allowedRuntimeTools) {
+      registry.register(
+        createTool(toolName, {
+          metadata:
+            toolName === "system.writeFile" ||
+            toolName === "system.appendFile" ||
+            toolName === "system.editFile" ||
+            toolName === "system.mkdir"
+              ? { mutating: true }
+              : undefined,
+        }),
+      );
+    }
+
+    const scoped = runtime.buildScopedTooling(registry);
+
+    expect(scoped.missingToolNames).toEqual([]);
+    expect(scoped.blockedToolNames).toEqual([]);
+    expect(scoped.allowedToolNames).toEqual(enforcement.allowedRuntimeTools);
   });
 });

--- a/runtime/src/task/compiled-job-runtime.ts
+++ b/runtime/src/task/compiled-job-runtime.ts
@@ -1,15 +1,18 @@
 import type { ChatExecuteParams } from "../llm/chat-executor-types.js";
 import type { LLMTool, ToolHandler } from "../llm/types.js";
+import type { Tool } from "../tools/types.js";
 import { ToolRegistry } from "../tools/registry.js";
 import { silentLogger, type Logger } from "../utils/logger.js";
 import {
   createCompiledJobPolicyEngine,
   type CompiledJobEnforcement,
+  type CompiledJobSideEffectPolicy,
 } from "./compiled-job-enforcement.js";
 
 export interface CompiledJobScopedTooling {
   readonly allowedToolNames: readonly string[];
   readonly missingToolNames: readonly string[];
+  readonly blockedToolNames: readonly string[];
   readonly llmTools: readonly LLMTool[];
   readonly toolHandler: ToolHandler;
 }
@@ -22,6 +25,37 @@ export interface CompiledJobExecutionRuntime {
   ): CompiledJobScopedTooling;
   applyChatExecuteParams(params: ChatExecuteParams): ChatExecuteParams;
 }
+
+const L0_BLOCKED_TOOL_PREFIXES = [
+  "agenc.",
+  "desktop.",
+  "social.",
+  "verification.",
+  "wallet.",
+  "x.",
+] as const;
+
+const L0_BLOCKED_SYSTEM_TOOLS = new Set([
+  "system.appendFile",
+  "system.browserSessionResume",
+  "system.bash",
+  "system.delete",
+  "system.editFile",
+  "system.evaluateJs",
+  "system.mkdir",
+  "system.move",
+  "system.processStart",
+  "system.processStop",
+  "system.remoteJobCancel",
+  "system.remoteJobResume",
+  "system.remoteJobStart",
+  "system.sandboxExec",
+  "system.sandboxStart",
+  "system.sandboxStop",
+  "system.serverStart",
+  "system.serverStop",
+  "system.writeFile",
+]);
 
 export function createCompiledJobExecutionRuntime(
   enforcement: CompiledJobEnforcement,
@@ -37,11 +71,17 @@ export function createCompiledJobExecutionRuntime(
         policyEngine: createCompiledJobPolicyEngine(enforcement, logger),
       });
       const missingToolNames: string[] = [];
+      const blockedToolNames: string[] = [];
+      const baseToolNames = resolveAdvertisedRuntimeToolNames(enforcement);
 
-      for (const toolName of enforcement.allowedRuntimeTools) {
+      for (const toolName of baseToolNames.allowedToolNames) {
         const tool = registry.get(toolName);
         if (!tool) {
           missingToolNames.push(toolName);
+          continue;
+        }
+        if (shouldBlockRegisteredTool(tool, enforcement.sideEffectPolicy)) {
+          blockedToolNames.push(tool.name);
           continue;
         }
         scopedRegistry.register(tool);
@@ -51,6 +91,10 @@ export function createCompiledJobExecutionRuntime(
       return {
         allowedToolNames,
         missingToolNames,
+        blockedToolNames: uniqueToolNames([
+          ...baseToolNames.blockedToolNames,
+          ...blockedToolNames,
+        ]),
         llmTools: scopedRegistry.toLLMTools(),
         toolHandler: scopedRegistry.createToolHandler(),
       };
@@ -123,9 +167,17 @@ function mergeToolRouting(
   base: ChatExecuteParams["toolRouting"],
   enforcement: CompiledJobEnforcement,
 ): ChatExecuteParams["toolRouting"] {
-  const allowed = enforcement.chat.toolRouting?.advertisedToolNames?.length
-    ? [...enforcement.chat.toolRouting.advertisedToolNames]
-    : [...enforcement.allowedRuntimeTools];
+  const safeToolNames = resolveAdvertisedRuntimeToolNames(enforcement)
+    .allowedToolNames;
+  const allowed =
+    enforcement.chat.toolRouting?.advertisedToolNames?.length &&
+    enforcement.chat.toolRouting.advertisedToolNames.length > 0
+      ? uniqueToolNames(
+          enforcement.chat.toolRouting.advertisedToolNames.filter((toolName) =>
+            safeToolNames.includes(toolName),
+          ),
+        )
+      : [...safeToolNames];
   const allowedSet = new Set(allowed);
   const filterAllowed = (names: readonly string[] | undefined): string[] =>
     uniqueToolNames(
@@ -191,4 +243,66 @@ function mergeBooleanGate(
 
 function uniqueToolNames(input: readonly string[]): string[] {
   return [...new Set(input)];
+}
+
+function resolveAdvertisedRuntimeToolNames(
+  enforcement: CompiledJobEnforcement,
+): {
+  readonly allowedToolNames: readonly string[];
+  readonly blockedToolNames: readonly string[];
+} {
+  const allowedToolNames: string[] = [];
+  const blockedToolNames: string[] = [];
+
+  for (const toolName of enforcement.allowedRuntimeTools) {
+    if (shouldBlockToolName(toolName, enforcement.sideEffectPolicy)) {
+      blockedToolNames.push(toolName);
+      continue;
+    }
+    allowedToolNames.push(toolName);
+  }
+
+  return {
+    allowedToolNames: uniqueToolNames(allowedToolNames),
+    blockedToolNames: uniqueToolNames(blockedToolNames),
+  };
+}
+
+function shouldBlockRegisteredTool(
+  tool: Tool,
+  sideEffectPolicy: CompiledJobSideEffectPolicy,
+): boolean {
+  if (!isStrictL0SideEffectPolicy(sideEffectPolicy)) {
+    return false;
+  }
+  if (sideEffectPolicy.allowedMutatingRuntimeTools.includes(tool.name)) {
+    return false;
+  }
+  return tool.metadata?.mutating === true;
+}
+
+function shouldBlockToolName(
+  toolName: string,
+  sideEffectPolicy: CompiledJobSideEffectPolicy,
+): boolean {
+  if (!isStrictL0SideEffectPolicy(sideEffectPolicy)) {
+    return false;
+  }
+  if (sideEffectPolicy.allowedMutatingRuntimeTools.includes(toolName)) {
+    return false;
+  }
+  if (L0_BLOCKED_SYSTEM_TOOLS.has(toolName)) {
+    return true;
+  }
+  return L0_BLOCKED_TOOL_PREFIXES.some((prefix) => toolName.startsWith(prefix));
+}
+
+function isStrictL0SideEffectPolicy(
+  sideEffectPolicy: CompiledJobSideEffectPolicy,
+): boolean {
+  return (
+    sideEffectPolicy.riskTier === "L0" &&
+    sideEffectPolicy.approvalRequired !== true &&
+    sideEffectPolicy.humanReviewGate === "none"
+  );
 }


### PR DESCRIPTION
## Summary
- add a central `sideEffectPolicy` to compiled job enforcement so marketplace L0 runs know which local mutations are explicitly allowed
- filter blocked side-effect tools out of the advertised/runtime tool set for strict L0 jobs and fail closed if any such tools leak into the compiled job runner
- cover the new behavior with runtime enforcement tests, including a positive path for `workspace_only` local writes

## Testing
- `npm run typecheck --workspace=@tetsuo-ai/runtime`
- `npm exec --workspace=@tetsuo-ai/runtime vitest run src/task/compiled-job-enforcement.test.ts src/task/compiled-job-runtime.test.ts src/task/compiled-job-chat-handler.test.ts src/task/executor.test.ts`

Refs: tetsuo-ai/AgenC#1557
