### PR TITLE
Add launch controls for compiled marketplace jobs

### DIFF
--- a/runtime/src/task/compiled-job-chat-handler.test.ts
+++ b/runtime/src/task/compiled-job-chat-handler.test.ts
@@ -354,4 +354,64 @@ describe("compiled job chat task handler", () => {
       'Compiled job type "product_comparison_report" is not enabled for this task handler',
     );
   });
+
+  it("honors the global compiled-job pause switch", async () => {
+    const provider = createMockProvider([
+      {
+        content: "unused",
+        toolCalls: [],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        model: "mock-model",
+        finishReason: "stop",
+      },
+    ]);
+    const executor = new ChatExecutor({ providers: [provider] });
+    const registry = new ToolRegistry();
+    registry.register(createTool("system.httpGet"));
+    registry.register(createTool("system.pdfExtractText"));
+
+    const handler = createCompiledJobChatTaskHandler({
+      chatExecutor: executor,
+      toolRegistry: registry,
+      launchControls: {
+        paused: true,
+      },
+    });
+
+    await expect(handler(createContext())).rejects.toThrow(
+      "Compiled marketplace job execution is paused by runtime launch controls",
+    );
+    expect(provider.chat).not.toHaveBeenCalled();
+    expect(provider.chatStream).not.toHaveBeenCalled();
+  });
+
+  it("honors per-job launch allowlists from env", async () => {
+    const provider = createMockProvider([
+      {
+        content: "unused",
+        toolCalls: [],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        model: "mock-model",
+        finishReason: "stop",
+      },
+    ]);
+    const executor = new ChatExecutor({ providers: [provider] });
+    const registry = new ToolRegistry();
+    registry.register(createTool("system.httpGet"));
+    registry.register(createTool("system.pdfExtractText"));
+
+    const handler = createCompiledJobChatTaskHandler({
+      chatExecutor: executor,
+      toolRegistry: registry,
+      env: {
+        AGENC_COMPILED_JOB_ENABLED_TYPES: "product_comparison_report",
+      },
+    });
+
+    await expect(handler(createContext())).rejects.toThrow(
+      'Compiled job type "web_research_brief" is not enabled in runtime launch controls',
+    );
+    expect(provider.chat).not.toHaveBeenCalled();
+    expect(provider.chatStream).not.toHaveBeenCalled();
+  });
 });

--- a/runtime/src/task/compiled-job-chat-handler.ts
+++ b/runtime/src/task/compiled-job-chat-handler.ts
@@ -9,6 +9,11 @@ import {
 import { createGatewayMessage, type GatewayMessage } from "../gateway/message.js";
 import { silentLogger, type Logger } from "../utils/logger.js";
 import type { ToolRegistry } from "../tools/registry.js";
+import {
+  evaluateCompiledJobLaunchAccess,
+  resolveCompiledJobLaunchControls,
+  type CompiledJobLaunchControls,
+} from "./compiled-job-launch-controls.js";
 import type { TaskExecutionContext, TaskExecutionResult, TaskHandler } from "./types.js";
 
 const DEFAULT_SUPPORTED_JOB_TYPES = ["web_research_brief"] as const;
@@ -26,6 +31,8 @@ export interface CompiledJobChatTaskHandlerOptions {
   readonly toolRegistry: ToolRegistry;
   readonly logger?: Logger;
   readonly supportedJobTypes?: readonly string[];
+  readonly launchControls?: Partial<CompiledJobLaunchControls>;
+  readonly env?: NodeJS.ProcessEnv;
   readonly channel?: string;
   readonly senderId?: string;
   readonly senderName?: string;
@@ -44,15 +51,24 @@ export function createCompiledJobChatTaskHandler(
   const supportedJobTypes = [
     ...(options.supportedJobTypes ?? DEFAULT_SUPPORTED_JOB_TYPES),
   ];
+  const launchControls = resolveCompiledJobLaunchControls({
+    base: options.launchControls,
+    env: options.env,
+  });
 
   return async (context: TaskExecutionContext): Promise<TaskExecutionResult> => {
     const { compiledJob, compiledJobRuntime } = requireCompiledJobContext(
       context,
     );
 
-    if (!supportedJobTypes.includes(compiledJob.jobType)) {
+    const launchDecision = evaluateCompiledJobLaunchAccess({
+      jobType: compiledJob.jobType,
+      supportedJobTypes,
+      controls: launchControls,
+    });
+    if (!launchDecision.allowed) {
       throw new Error(
-        `Compiled job type "${compiledJob.jobType}" is not enabled for this task handler`,
+        launchDecision.message ?? "Compiled job launch controls denied execution",
       );
     }
 

--- a/runtime/src/task/compiled-job-launch-controls.test.ts
+++ b/runtime/src/task/compiled-job-launch-controls.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateCompiledJobLaunchAccess,
+  resolveCompiledJobLaunchControls,
+} from "./compiled-job-launch-controls.js";
+
+describe("compiled job launch controls", () => {
+  it("defaults to launch-enabled execution with no per-job overrides", () => {
+    const controls = resolveCompiledJobLaunchControls();
+
+    expect(controls).toEqual({
+      executionEnabled: true,
+      paused: false,
+      enabledJobTypes: [],
+      disabledJobTypes: [],
+    });
+  });
+
+  it("reads global pause and job lists from env", () => {
+    const controls = resolveCompiledJobLaunchControls({
+      env: {
+        AGENC_COMPILED_JOB_EXECUTION_ENABLED: "true",
+        AGENC_COMPILED_JOB_EXECUTION_PAUSED: "yes",
+        AGENC_COMPILED_JOB_ENABLED_TYPES:
+          "web_research_brief, product_comparison_report",
+        AGENC_COMPILED_JOB_DISABLED_TYPES: "lead_list_building",
+      },
+    });
+
+    expect(controls).toEqual({
+      executionEnabled: true,
+      paused: true,
+      enabledJobTypes: [
+        "web_research_brief",
+        "product_comparison_report",
+      ],
+      disabledJobTypes: ["lead_list_building"],
+    });
+  });
+
+  it("rejects execution when the global kill switch is off", () => {
+    const decision = evaluateCompiledJobLaunchAccess({
+      jobType: "web_research_brief",
+      supportedJobTypes: ["web_research_brief"],
+      controls: resolveCompiledJobLaunchControls({
+        base: { executionEnabled: false },
+      }),
+    });
+
+    expect(decision).toEqual({
+      allowed: false,
+      message:
+        "Compiled marketplace job execution is disabled by runtime launch controls",
+    });
+  });
+
+  it("rejects execution when a job type is not in the enabled launch set", () => {
+    const decision = evaluateCompiledJobLaunchAccess({
+      jobType: "web_research_brief",
+      supportedJobTypes: ["web_research_brief", "product_comparison_report"],
+      controls: resolveCompiledJobLaunchControls({
+        base: {
+          enabledJobTypes: ["product_comparison_report"],
+        },
+      }),
+    });
+
+    expect(decision).toEqual({
+      allowed: false,
+      message:
+        'Compiled job type "web_research_brief" is not enabled in runtime launch controls',
+    });
+  });
+});

--- a/runtime/src/task/compiled-job-launch-controls.ts
+++ b/runtime/src/task/compiled-job-launch-controls.ts
@@ -1,0 +1,140 @@
+export interface CompiledJobLaunchControls {
+  readonly executionEnabled: boolean;
+  readonly paused: boolean;
+  readonly enabledJobTypes: readonly string[];
+  readonly disabledJobTypes: readonly string[];
+}
+
+export interface ResolveCompiledJobLaunchControlsOptions {
+  readonly base?: Partial<CompiledJobLaunchControls>;
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+export interface CompiledJobLaunchDecision {
+  readonly allowed: boolean;
+  readonly message?: string;
+}
+
+const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
+const FALSE_VALUES = new Set(["0", "false", "no", "off"]);
+
+export function resolveCompiledJobLaunchControls(
+  options: ResolveCompiledJobLaunchControlsOptions = {},
+): CompiledJobLaunchControls {
+  const envControls = readCompiledJobLaunchControlsFromEnv(options.env);
+  const base = options.base ?? {};
+  return {
+    executionEnabled:
+      base.executionEnabled ?? envControls.executionEnabled ?? true,
+    paused: base.paused ?? envControls.paused ?? false,
+    enabledJobTypes: normalizeJobTypeList(
+      base.enabledJobTypes ?? envControls.enabledJobTypes,
+    ),
+    disabledJobTypes: normalizeJobTypeList(
+      base.disabledJobTypes ?? envControls.disabledJobTypes,
+    ),
+  };
+}
+
+export function evaluateCompiledJobLaunchAccess(input: {
+  readonly jobType: string;
+  readonly supportedJobTypes: readonly string[];
+  readonly controls: CompiledJobLaunchControls;
+}): CompiledJobLaunchDecision {
+  if (!input.supportedJobTypes.includes(input.jobType)) {
+    return {
+      allowed: false,
+      message: `Compiled job type "${input.jobType}" is not enabled for this task handler`,
+    };
+  }
+  if (!input.controls.executionEnabled) {
+    return {
+      allowed: false,
+      message:
+        "Compiled marketplace job execution is disabled by runtime launch controls",
+    };
+  }
+  if (input.controls.paused) {
+    return {
+      allowed: false,
+      message:
+        "Compiled marketplace job execution is paused by runtime launch controls",
+    };
+  }
+  if (
+    input.controls.enabledJobTypes.length > 0 &&
+    !input.controls.enabledJobTypes.includes(input.jobType)
+  ) {
+    return {
+      allowed: false,
+      message: `Compiled job type "${input.jobType}" is not enabled in runtime launch controls`,
+    };
+  }
+  if (input.controls.disabledJobTypes.includes(input.jobType)) {
+    return {
+      allowed: false,
+      message: `Compiled job type "${input.jobType}" is disabled by runtime launch controls`,
+    };
+  }
+  return { allowed: true };
+}
+
+function readCompiledJobLaunchControlsFromEnv(
+  env: NodeJS.ProcessEnv | undefined,
+): Partial<CompiledJobLaunchControls> {
+  if (!env) {
+    return {};
+  }
+  return {
+    ...(parseBooleanEnv(env.AGENC_COMPILED_JOB_EXECUTION_ENABLED) !== undefined
+      ? {
+          executionEnabled: parseBooleanEnv(
+            env.AGENC_COMPILED_JOB_EXECUTION_ENABLED,
+          ),
+        }
+      : {}),
+    ...(parseBooleanEnv(env.AGENC_COMPILED_JOB_EXECUTION_PAUSED) !== undefined
+      ? {
+          paused: parseBooleanEnv(env.AGENC_COMPILED_JOB_EXECUTION_PAUSED),
+        }
+      : {}),
+    ...(env.AGENC_COMPILED_JOB_ENABLED_TYPES !== undefined
+      ? {
+          enabledJobTypes: normalizeJobTypeList(
+            env.AGENC_COMPILED_JOB_ENABLED_TYPES,
+          ),
+        }
+      : {}),
+    ...(env.AGENC_COMPILED_JOB_DISABLED_TYPES !== undefined
+      ? {
+          disabledJobTypes: normalizeJobTypeList(
+            env.AGENC_COMPILED_JOB_DISABLED_TYPES,
+          ),
+        }
+      : {}),
+  };
+}
+
+function parseBooleanEnv(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (TRUE_VALUES.has(normalized)) return true;
+  if (FALSE_VALUES.has(normalized)) return false;
+  return undefined;
+}
+
+function normalizeJobTypeList(
+  value: readonly string[] | string | undefined,
+): string[] {
+  if (Array.isArray(value)) {
+    return uniqueNonEmptyStrings(value);
+  }
+  if (typeof value === "string") {
+    return uniqueNonEmptyStrings(value.split(","));
+  }
+  return [];
+}
+
+function uniqueNonEmptyStrings(input: readonly string[]): string[] {
+  return [...new Set(input.map((entry) => entry.trim()).filter(Boolean))];
+}

--- a/runtime/src/task/index.ts
+++ b/runtime/src/task/index.ts
@@ -9,6 +9,7 @@ export * from "./filters.js";
 export * from "./compiled-job.js";
 export * from "./compiled-job-chat-handler.js";
 export * from "./compiled-job-enforcement.js";
+export * from "./compiled-job-launch-controls.js";
 export * from "./compiled-job-runtime.js";
 export * from "./operations.js";
 export * from "./discovery.js";


### PR DESCRIPTION
## Summary
- add runtime launch controls for compiled marketplace execution, including a global enable switch, a global pause switch, and per-job-type allow/deny lists
- enforce those launch controls in the compiled job chat handler before any job execution begins
- cover the new controls with focused tests for env parsing, pause behavior, and per-job allowlists

## Testing
- `npm run typecheck --workspace=@tetsuo-ai/runtime`
- `npm exec --workspace=@tetsuo-ai/runtime vitest run src/task/compiled-job-launch-controls.test.ts src/task/compiled-job-chat-handler.test.ts src/task/compiled-job-enforcement.test.ts src/task/compiled-job-runtime.test.ts src/task/executor.test.ts`

Refs: tetsuo-ai/AgenC#1557
