### PR TITLE
Add rate limits for compiled marketplace jobs

### DIFF
--- a/runtime/src/policy/budget-state.ts
+++ b/runtime/src/policy/budget-state.ts
@@ -55,12 +55,14 @@ interface BudgetLedger {
   readonly runtimeMs: SlidingWindowState;
 }
 
-function createBudgetLedger(config: {
+export interface BudgetStateConfig {
   rateWindowMs?: number;
   tokenWindowMs?: number;
   lamportWindowMs?: number;
   runtimeWindowMs?: number;
-} = {}): BudgetLedger {
+}
+
+function createBudgetLedger(config: BudgetStateConfig = {}): BudgetLedger {
   return {
     toolCallRate: createSlidingWindow(config.rateWindowMs ?? 60_000),
     tokenSpend: createSlidingWindow(config.tokenWindowMs ?? 60 * 60 * 1000),
@@ -75,6 +77,7 @@ function createBudgetLedger(config: {
  */
 export class BudgetStateService {
   private readonly bySession = new Map<string, BudgetLedger>();
+  constructor(private readonly config: BudgetStateConfig = {}) {}
 
   recordToolCall(sessionId: string, nowMs: number): void {
     const ledger = this.ensure(sessionId);
@@ -144,7 +147,7 @@ export class BudgetStateService {
   private ensure(sessionId: string): BudgetLedger {
     let ledger = this.bySession.get(sessionId);
     if (!ledger) {
-      ledger = createBudgetLedger();
+      ledger = createBudgetLedger(this.config);
       this.bySession.set(sessionId, ledger);
     }
     return ledger;

--- a/runtime/src/task/compiled-job-chat-handler.test.ts
+++ b/runtime/src/task/compiled-job-chat-handler.test.ts
@@ -17,6 +17,7 @@ import type { CompiledJob } from "./compiled-job.js";
 import {
   createCompiledJobExecutionRuntime,
 } from "./compiled-job-runtime.js";
+import { createCompiledJobExecutionGovernor } from "./compiled-job-execution-governor.js";
 import {
   createCompiledJobChatTaskHandler,
 } from "./compiled-job-chat-handler.js";
@@ -413,5 +414,107 @@ describe("compiled job chat task handler", () => {
     );
     expect(provider.chat).not.toHaveBeenCalled();
     expect(provider.chatStream).not.toHaveBeenCalled();
+  });
+
+  it("enforces execution concurrency limits before dispatching the model", async () => {
+    let releaseFirstExecution: (() => void) | undefined;
+    const provider = createMockProvider([
+      {
+        content: "",
+        toolCalls: [],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        model: "mock-model",
+        finishReason: "stop",
+      },
+      {
+        content: "",
+        toolCalls: [],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        model: "mock-model",
+        finishReason: "stop",
+      },
+    ]);
+    provider.chat.mockImplementationOnce(
+      async () =>
+        await new Promise((resolve) => {
+          releaseFirstExecution = () => {
+            resolve({
+              content: "Research brief with citations",
+              toolCalls: [],
+              usage: {
+                promptTokens: 8,
+                completionTokens: 6,
+                totalTokens: 14,
+              },
+              model: "mock-model",
+              finishReason: "stop",
+            });
+          };
+        }),
+    );
+    provider.chatStream.mockImplementationOnce(
+      async (_messages, onChunk) =>
+        await new Promise((resolve) => {
+          releaseFirstExecution = () => {
+            onChunk({ content: "", done: true } satisfies LLMStreamChunk);
+            resolve({
+              content: "Research brief with citations",
+              toolCalls: [],
+              usage: {
+                promptTokens: 8,
+                completionTokens: 6,
+                totalTokens: 14,
+              },
+              model: "mock-model",
+              finishReason: "stop",
+            });
+          };
+        }),
+    );
+    provider.chatStream.mockImplementationOnce(async (_messages, onChunk) => {
+      onChunk({ content: "", done: true } satisfies LLMStreamChunk);
+      return {
+        content: "Research brief with citations",
+        toolCalls: [],
+        usage: { promptTokens: 8, completionTokens: 6, totalTokens: 14 },
+        model: "mock-model",
+        finishReason: "stop",
+      };
+    });
+
+    const executor = new ChatExecutor({
+      providers: [provider],
+      allowedTools: ["system.httpGet", "system.pdfExtractText"],
+    });
+    const registry = new ToolRegistry();
+    registry.register(createTool("system.httpGet"));
+    registry.register(createTool("system.pdfExtractText"));
+
+    const handler = createCompiledJobChatTaskHandler({
+      chatExecutor: executor,
+      toolRegistry: registry,
+      executionGovernor: createCompiledJobExecutionGovernor({
+        controls: {
+          maxConcurrentRuns: 1,
+        },
+      }),
+    });
+
+    const firstRun = handler(createContext());
+    await vi.waitFor(() => {
+      expect(
+        provider.chat.mock.calls.length + provider.chatStream.mock.calls.length,
+      ).toBeGreaterThan(0);
+    });
+
+    await expect(handler(createContext())).rejects.toThrow(
+      "Compiled marketplace job concurrency limit reached (1/1 active)",
+    );
+
+    releaseFirstExecution?.();
+    await expect(firstRun).resolves.toMatchObject({
+      proofHash: expect.any(Uint8Array),
+      resultData: expect.any(Uint8Array),
+    });
   });
 });

--- a/runtime/src/task/compiled-job-chat-handler.ts
+++ b/runtime/src/task/compiled-job-chat-handler.ts
@@ -14,6 +14,12 @@ import {
   resolveCompiledJobLaunchControls,
   type CompiledJobLaunchControls,
 } from "./compiled-job-launch-controls.js";
+import {
+  createCompiledJobExecutionGovernor,
+  resolveCompiledJobExecutionBudgetControls,
+  type CompiledJobExecutionBudgetControls,
+  type CompiledJobExecutionGovernor,
+} from "./compiled-job-execution-governor.js";
 import type { TaskExecutionContext, TaskExecutionResult, TaskHandler } from "./types.js";
 
 const DEFAULT_SUPPORTED_JOB_TYPES = ["web_research_brief"] as const;
@@ -32,6 +38,8 @@ export interface CompiledJobChatTaskHandlerOptions {
   readonly logger?: Logger;
   readonly supportedJobTypes?: readonly string[];
   readonly launchControls?: Partial<CompiledJobLaunchControls>;
+  readonly executionBudgetControls?: Partial<CompiledJobExecutionBudgetControls>;
+  readonly executionGovernor?: CompiledJobExecutionGovernor;
   readonly env?: NodeJS.ProcessEnv;
   readonly channel?: string;
   readonly senderId?: string;
@@ -55,6 +63,14 @@ export function createCompiledJobChatTaskHandler(
     base: options.launchControls,
     env: options.env,
   });
+  const executionGovernor =
+    options.executionGovernor ??
+    createCompiledJobExecutionGovernor({
+      controls: resolveCompiledJobExecutionBudgetControls({
+        base: options.executionBudgetControls,
+        env: options.env,
+      }),
+    });
 
   return async (context: TaskExecutionContext): Promise<TaskExecutionResult> => {
     const { compiledJob, compiledJobRuntime } = requireCompiledJobContext(
@@ -71,55 +87,67 @@ export function createCompiledJobChatTaskHandler(
         launchDecision.message ?? "Compiled job launch controls denied execution",
       );
     }
-
-    const scopedTooling = compiledJobRuntime.buildScopedTooling(
-      options.toolRegistry,
-      logger,
-    );
-    if (scopedTooling.blockedToolNames.length > 0) {
+    const executionDecision = executionGovernor.acquire(compiledJob.jobType);
+    if (!executionDecision.allowed) {
       throw new Error(
-        `Compiled job runtime blocked side-effect tools for ${compiledJob.policy.riskTier} execution: ${scopedTooling.blockedToolNames.join(", ")}`,
+        executionDecision.message ??
+          "Compiled job execution budgets denied execution",
       );
     }
-    if (scopedTooling.missingToolNames.length > 0) {
-      throw new Error(
-        `Compiled job runtime is missing required tools: ${scopedTooling.missingToolNames.join(", ")}`,
+    const executionLease = executionDecision.lease;
+
+    try {
+      const scopedTooling = compiledJobRuntime.buildScopedTooling(
+        options.toolRegistry,
+        logger,
       );
+      if (scopedTooling.blockedToolNames.length > 0) {
+        throw new Error(
+          `Compiled job runtime blocked side-effect tools for ${compiledJob.policy.riskTier} execution: ${scopedTooling.blockedToolNames.join(", ")}`,
+        );
+      }
+      if (scopedTooling.missingToolNames.length > 0) {
+        throw new Error(
+          `Compiled job runtime is missing required tools: ${scopedTooling.missingToolNames.join(", ")}`,
+        );
+      }
+
+      const message =
+        options.buildMessage?.(context) ??
+        buildCompiledJobTaskMessage(context, {
+          channel: options.channel,
+          senderId: options.senderId,
+          senderName: options.senderName,
+        });
+      const promptEnvelope = normalizePromptEnvelope(
+        options.buildPromptEnvelope?.(context) ??
+          buildCompiledJobTaskPromptEnvelope(context),
+      );
+
+      const result = await executeChatToLegacyResult(
+        options.chatExecutor,
+        compiledJobRuntime.applyChatExecuteParams({
+          message,
+          history: [],
+          promptEnvelope,
+          sessionId: message.sessionId,
+          toolHandler: scopedTooling.toolHandler,
+          signal: context.signal,
+        }),
+      );
+
+      const finalContent = result.content.trim();
+      if (finalContent.length === 0) {
+        throw new Error("Compiled job execution returned empty output");
+      }
+
+      return {
+        proofHash: sha256Bytes(finalContent),
+        resultData: fixedWidthUtf8(finalContent, RESULT_DATA_BYTES),
+      };
+    } finally {
+      executionLease?.release();
     }
-
-    const message =
-      options.buildMessage?.(context) ??
-      buildCompiledJobTaskMessage(context, {
-        channel: options.channel,
-        senderId: options.senderId,
-        senderName: options.senderName,
-      });
-    const promptEnvelope = normalizePromptEnvelope(
-      options.buildPromptEnvelope?.(context) ??
-        buildCompiledJobTaskPromptEnvelope(context),
-    );
-
-    const result = await executeChatToLegacyResult(
-      options.chatExecutor,
-      compiledJobRuntime.applyChatExecuteParams({
-        message,
-        history: [],
-        promptEnvelope,
-        sessionId: message.sessionId,
-        toolHandler: scopedTooling.toolHandler,
-        signal: context.signal,
-      }),
-    );
-
-    const finalContent = result.content.trim();
-    if (finalContent.length === 0) {
-      throw new Error("Compiled job execution returned empty output");
-    }
-
-    return {
-      proofHash: sha256Bytes(finalContent),
-      resultData: fixedWidthUtf8(finalContent, RESULT_DATA_BYTES),
-    };
   };
 }
 

--- a/runtime/src/task/compiled-job-execution-governor.test.ts
+++ b/runtime/src/task/compiled-job-execution-governor.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  createCompiledJobExecutionGovernor,
+  resolveCompiledJobExecutionBudgetControls,
+} from "./compiled-job-execution-governor.js";
+
+describe("compiled job execution governor", () => {
+  it("reads concurrency and rate limits from env", () => {
+    const controls = resolveCompiledJobExecutionBudgetControls({
+      env: {
+        AGENC_COMPILED_JOB_MAX_CONCURRENT: "4",
+        AGENC_COMPILED_JOB_MAX_CONCURRENT_BY_TYPE:
+          "web_research_brief=2,product_comparison_report=1",
+        AGENC_COMPILED_JOB_RATE_LIMIT: "12/60000",
+        AGENC_COMPILED_JOB_RATE_LIMIT_BY_TYPE:
+          "web_research_brief=6/60000,product_comparison_report=3/60000",
+      },
+    });
+
+    expect(controls).toEqual({
+      maxConcurrentRuns: 4,
+      maxConcurrentRunsByJobType: {
+        web_research_brief: 2,
+        product_comparison_report: 1,
+      },
+      executionRateLimit: {
+        limit: 12,
+        windowMs: 60_000,
+      },
+      executionRateLimitByJobType: {
+        web_research_brief: {
+          limit: 6,
+          windowMs: 60_000,
+        },
+        product_comparison_report: {
+          limit: 3,
+          windowMs: 60_000,
+        },
+      },
+    });
+  });
+
+  it("enforces global concurrency and releases slots", () => {
+    const governor = createCompiledJobExecutionGovernor({
+      controls: {
+        maxConcurrentRuns: 1,
+      },
+    });
+
+    const first = governor.acquire("web_research_brief");
+    const second = governor.acquire("web_research_brief");
+
+    expect(first.allowed).toBe(true);
+    expect(second).toEqual({
+      allowed: false,
+      message: "Compiled marketplace job concurrency limit reached (1/1 active)",
+    });
+
+    first.lease?.release();
+
+    const third = governor.acquire("web_research_brief");
+    expect(third.allowed).toBe(true);
+  });
+
+  it("enforces per-job rate limits with a sliding window", () => {
+    let nowMs = 1_000;
+    const governor = createCompiledJobExecutionGovernor({
+      controls: {
+        executionRateLimitByJobType: {
+          web_research_brief: {
+            limit: 2,
+            windowMs: 60_000,
+          },
+        },
+      },
+      now: () => nowMs,
+    });
+
+    const first = governor.acquire("web_research_brief");
+    first.lease?.release();
+    const second = governor.acquire("web_research_brief");
+    second.lease?.release();
+    const blocked = governor.acquire("web_research_brief");
+
+    expect(blocked).toEqual({
+      allowed: false,
+      message:
+        'Compiled job type "web_research_brief" rate limit exceeded (2/2 per 60000ms)',
+    });
+
+    nowMs += 60_001;
+    const reset = governor.acquire("web_research_brief");
+    expect(reset.allowed).toBe(true);
+  });
+});

--- a/runtime/src/task/compiled-job-execution-governor.ts
+++ b/runtime/src/task/compiled-job-execution-governor.ts
@@ -1,0 +1,326 @@
+import { BudgetStateService } from "../policy/budget-state.js";
+
+export interface CompiledJobExecutionRateLimit {
+  readonly limit: number;
+  readonly windowMs: number;
+}
+
+export interface CompiledJobExecutionBudgetControls {
+  readonly maxConcurrentRuns?: number;
+  readonly maxConcurrentRunsByJobType?: Readonly<Record<string, number>>;
+  readonly executionRateLimit?: CompiledJobExecutionRateLimit;
+  readonly executionRateLimitByJobType?: Readonly<
+    Record<string, CompiledJobExecutionRateLimit>
+  >;
+}
+
+export interface ResolveCompiledJobExecutionBudgetControlsOptions {
+  readonly base?: Partial<CompiledJobExecutionBudgetControls>;
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+export interface CompiledJobExecutionLease {
+  release(): void;
+}
+
+export interface CompiledJobExecutionDecision {
+  readonly allowed: boolean;
+  readonly message?: string;
+  readonly lease?: CompiledJobExecutionLease;
+}
+
+export interface CompiledJobExecutionGovernor {
+  acquire(jobType: string): CompiledJobExecutionDecision;
+}
+
+export interface CreateCompiledJobExecutionGovernorOptions {
+  readonly controls?: CompiledJobExecutionBudgetControls;
+  readonly now?: () => number;
+}
+
+const GLOBAL_RATE_BUCKET = "__compiled_job_global__";
+export function resolveCompiledJobExecutionBudgetControls(
+  options: ResolveCompiledJobExecutionBudgetControlsOptions = {},
+): CompiledJobExecutionBudgetControls {
+  const envControls = readCompiledJobExecutionBudgetControlsFromEnv(options.env);
+  const base = options.base ?? {};
+  return {
+    ...(resolvePositiveInteger(
+      base.maxConcurrentRuns ?? envControls.maxConcurrentRuns,
+    ) !== undefined
+      ? {
+          maxConcurrentRuns: resolvePositiveInteger(
+            base.maxConcurrentRuns ?? envControls.maxConcurrentRuns,
+          ),
+        }
+      : {}),
+    maxConcurrentRunsByJobType: normalizePositiveIntegerMap(
+      base.maxConcurrentRunsByJobType ?? envControls.maxConcurrentRunsByJobType,
+    ),
+    ...(normalizeRateLimit(
+      base.executionRateLimit ?? envControls.executionRateLimit,
+    )
+      ? {
+          executionRateLimit: normalizeRateLimit(
+            base.executionRateLimit ?? envControls.executionRateLimit,
+          ),
+        }
+      : {}),
+    executionRateLimitByJobType: normalizeRateLimitMap(
+      base.executionRateLimitByJobType ??
+        envControls.executionRateLimitByJobType,
+    ),
+  };
+}
+
+export function createCompiledJobExecutionGovernor(
+  options: CreateCompiledJobExecutionGovernorOptions = {},
+): CompiledJobExecutionGovernor {
+  const controls = options.controls ?? {};
+  const now = options.now ?? (() => Date.now());
+  const globalRateState = controls.executionRateLimit
+    ? new BudgetStateService({
+        rateWindowMs: controls.executionRateLimit.windowMs,
+      })
+    : null;
+  const perJobRateState = new Map<string, BudgetStateService>();
+  const activeByJobType = new Map<string, number>();
+  let activeGlobal = 0;
+
+  const getPerJobRateState = (
+    jobType: string,
+  ): BudgetStateService | null => {
+    const rateLimit = controls.executionRateLimitByJobType?.[jobType];
+    if (!rateLimit) return null;
+    let state = perJobRateState.get(jobType);
+    if (!state) {
+      state = new BudgetStateService({
+        rateWindowMs: rateLimit.windowMs,
+      });
+      perJobRateState.set(jobType, state);
+    }
+    return state;
+  };
+
+  return {
+    acquire(jobType: string): CompiledJobExecutionDecision {
+      const nowMs = now();
+      const maxConcurrentRuns = controls.maxConcurrentRuns;
+      if (
+        maxConcurrentRuns !== undefined &&
+        activeGlobal >= maxConcurrentRuns
+      ) {
+        return {
+          allowed: false,
+          message:
+            `Compiled marketplace job concurrency limit reached ` +
+            `(${activeGlobal}/${maxConcurrentRuns} active)`,
+        };
+      }
+
+      const perJobConcurrentLimit =
+        controls.maxConcurrentRunsByJobType?.[jobType];
+      const activeForJobType = activeByJobType.get(jobType) ?? 0;
+      if (
+        perJobConcurrentLimit !== undefined &&
+        activeForJobType >= perJobConcurrentLimit
+      ) {
+        return {
+          allowed: false,
+          message:
+            `Compiled job type "${jobType}" concurrency limit reached ` +
+            `(${activeForJobType}/${perJobConcurrentLimit} active)`,
+        };
+      }
+
+      const globalRateLimit = controls.executionRateLimit;
+      const globalRate = globalRateState?.toolCallRate(
+        GLOBAL_RATE_BUCKET,
+        nowMs,
+      );
+      if (
+        globalRateLimit &&
+        globalRate !== undefined &&
+        globalRate >= globalRateLimit.limit
+      ) {
+        return {
+          allowed: false,
+          message:
+            `Compiled marketplace job rate limit exceeded ` +
+            `(${globalRate}/${globalRateLimit.limit} per ${globalRateLimit.windowMs}ms)`,
+        };
+      }
+
+      const perJobRateLimit = controls.executionRateLimitByJobType?.[jobType];
+      const perJobRateStateForType = getPerJobRateState(jobType);
+      const perJobRate = perJobRateStateForType?.toolCallRate(jobType, nowMs);
+      if (
+        perJobRateLimit &&
+        perJobRate !== undefined &&
+        perJobRate >= perJobRateLimit.limit
+      ) {
+        return {
+          allowed: false,
+          message:
+            `Compiled job type "${jobType}" rate limit exceeded ` +
+            `(${perJobRate}/${perJobRateLimit.limit} per ${perJobRateLimit.windowMs}ms)`,
+        };
+      }
+
+      globalRateState?.recordToolCall(GLOBAL_RATE_BUCKET, nowMs);
+      perJobRateStateForType?.recordToolCall(jobType, nowMs);
+
+      activeGlobal += 1;
+      activeByJobType.set(jobType, activeForJobType + 1);
+      let released = false;
+
+      return {
+        allowed: true,
+        lease: {
+          release(): void {
+            if (released) return;
+            released = true;
+            activeGlobal = Math.max(0, activeGlobal - 1);
+            const current = activeByJobType.get(jobType) ?? 0;
+            if (current <= 1) {
+              activeByJobType.delete(jobType);
+              return;
+            }
+            activeByJobType.set(jobType, current - 1);
+          },
+        },
+      };
+    },
+  };
+}
+
+function readCompiledJobExecutionBudgetControlsFromEnv(
+  env: NodeJS.ProcessEnv | undefined,
+): Partial<CompiledJobExecutionBudgetControls> {
+  if (!env) {
+    return {};
+  }
+  return {
+    ...(resolvePositiveInteger(env.AGENC_COMPILED_JOB_MAX_CONCURRENT) !==
+    undefined
+      ? {
+          maxConcurrentRuns: resolvePositiveInteger(
+            env.AGENC_COMPILED_JOB_MAX_CONCURRENT,
+          ),
+        }
+      : {}),
+    ...(env.AGENC_COMPILED_JOB_MAX_CONCURRENT_BY_TYPE !== undefined
+      ? {
+          maxConcurrentRunsByJobType: normalizePositiveIntegerMap(
+            env.AGENC_COMPILED_JOB_MAX_CONCURRENT_BY_TYPE,
+          ),
+        }
+      : {}),
+    ...(normalizeRateLimit(env.AGENC_COMPILED_JOB_RATE_LIMIT) !== undefined
+      ? {
+          executionRateLimit: normalizeRateLimit(
+            env.AGENC_COMPILED_JOB_RATE_LIMIT,
+          ),
+        }
+      : {}),
+    ...(env.AGENC_COMPILED_JOB_RATE_LIMIT_BY_TYPE !== undefined
+      ? {
+          executionRateLimitByJobType: normalizeRateLimitMap(
+            env.AGENC_COMPILED_JOB_RATE_LIMIT_BY_TYPE,
+          ),
+        }
+      : {}),
+  };
+}
+
+function resolvePositiveInteger(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value > 0 ? value : undefined;
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseInt(value.trim(), 10);
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function normalizePositiveIntegerMap(
+  value: Readonly<Record<string, number>> | string | undefined,
+): Record<string, number> {
+  if (typeof value === "string") {
+    return parseJobTypeMap<number>(value, (raw) => {
+      const parsed = resolvePositiveInteger(raw);
+      return parsed ? { ok: true, value: parsed } : { ok: false };
+    });
+  }
+  if (!value) return {};
+  const result: Record<string, number> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    const parsed = resolvePositiveInteger(raw);
+    if (!parsed) continue;
+    result[key.trim()] = parsed;
+  }
+  return result;
+}
+
+function normalizeRateLimit(
+  value: CompiledJobExecutionRateLimit | string | undefined,
+): CompiledJobExecutionRateLimit | undefined {
+  if (typeof value === "string") {
+    const parsed = parseRateLimitString(value);
+    return parsed ?? undefined;
+  }
+  if (!value) return undefined;
+  const limit = resolvePositiveInteger(value.limit);
+  const windowMs = resolvePositiveInteger(value.windowMs);
+  if (!limit || !windowMs) return undefined;
+  return { limit, windowMs };
+}
+
+function normalizeRateLimitMap(
+  value:
+    | Readonly<Record<string, CompiledJobExecutionRateLimit>>
+    | string
+    | undefined,
+): Record<string, CompiledJobExecutionRateLimit> {
+  if (typeof value === "string") {
+    return parseJobTypeMap<CompiledJobExecutionRateLimit>(value, (raw) => {
+      const parsed = parseRateLimitString(raw);
+      return parsed ? { ok: true, value: parsed } : { ok: false };
+    });
+  }
+  if (!value) return {};
+  const result: Record<string, CompiledJobExecutionRateLimit> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    const parsed = normalizeRateLimit(raw);
+    if (!parsed) continue;
+    result[key.trim()] = parsed;
+  }
+  return result;
+}
+
+function parseRateLimitString(
+  value: string,
+): CompiledJobExecutionRateLimit | null {
+  const [limitRaw, windowRaw] = value.split("/");
+  const limit = resolvePositiveInteger(limitRaw);
+  const windowMs = resolvePositiveInteger(windowRaw);
+  if (!limit || !windowMs) return null;
+  return { limit, windowMs };
+}
+
+function parseJobTypeMap<T>(
+  value: string,
+  parseValue: (raw: string) => { ok: true; value: T } | { ok: false },
+): Record<string, T> {
+  const result: Record<string, T> = {};
+  for (const entry of value.split(",")) {
+    const [jobTypeRaw, rawValue] = entry.split("=");
+    const jobType = jobTypeRaw?.trim();
+    if (!jobType || !rawValue) continue;
+    const parsed = parseValue(rawValue.trim());
+    if (!parsed.ok) continue;
+    result[jobType] = parsed.value;
+  }
+  return result;
+}

--- a/runtime/src/task/index.ts
+++ b/runtime/src/task/index.ts
@@ -9,6 +9,7 @@ export * from "./filters.js";
 export * from "./compiled-job.js";
 export * from "./compiled-job-chat-handler.js";
 export * from "./compiled-job-enforcement.js";
+export * from "./compiled-job-execution-governor.js";
 export * from "./compiled-job-launch-controls.js";
 export * from "./compiled-job-runtime.js";
 export * from "./operations.js";


### PR DESCRIPTION
## Summary
- add a compiled-job execution governor that enforces global and per-job concurrency/rate limits for marketplace execution
- wire those execution budget controls into the compiled job chat handler so jobs are rejected before model dispatch when the runtime is saturated
- extend the runtime budget service to support configurable sliding windows and cover the new launch controls with focused governor and handler tests

## Testing
- `npm run typecheck --workspace=@tetsuo-ai/runtime`
- `npm exec --workspace=@tetsuo-ai/runtime vitest run src/task/compiled-job-execution-governor.test.ts src/task/compiled-job-chat-handler.test.ts src/task/compiled-job-launch-controls.test.ts src/task/compiled-job-enforcement.test.ts src/task/compiled-job-runtime.test.ts src/task/executor.test.ts`

Refs: tetsuo-ai/AgenC#1557
