### PR TITLE
Add compiled-job version controls

### DIFF
--- a/runtime/src/task/compiled-job-chat-handler.test.ts
+++ b/runtime/src/task/compiled-job-chat-handler.test.ts
@@ -475,6 +475,65 @@ describe("compiled job chat task handler", () => {
     );
   });
 
+  it("records telemetry when version controls block a compiled job", async () => {
+    const provider = createMockProvider([
+      {
+        content: "unused",
+        toolCalls: [],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        model: "mock-model",
+        finishReason: "stop",
+      },
+    ]);
+    const executor = new ChatExecutor({ providers: [provider] });
+    const registry = new ToolRegistry();
+    registry.register(createTool("system.httpGet"));
+    registry.register(createTool("system.pdfExtractText"));
+    const metrics = createRecordingMetricsProvider();
+    const warn = vi.fn();
+
+    const handler = createCompiledJobChatTaskHandler({
+      chatExecutor: executor,
+      toolRegistry: registry,
+      logger: { ...silentLogger, warn },
+      versionControls: {
+        enabledCompilerVersions: ["agenc.approved-task-template.v1"],
+      },
+    });
+
+    const context = createContext(undefined, {
+      metrics: metrics.provider,
+    });
+
+    await expect(handler(context)).rejects.toThrow(
+      'Compiled job compiler version "agenc.web.bounded-task-template.v1" is not enabled in runtime version controls',
+    );
+
+    expect(metrics.counterCalls).toContainEqual({
+      name: METRIC_NAMES.COMPILED_JOB_BLOCKED,
+      value: 1,
+      labels: {
+        reason: "compiler_version_not_enabled",
+        job_type: "web_research_brief",
+        risk_tier: "L0",
+        template_id: "web_research_brief",
+        compiler_version: "agenc.web.bounded-task-template.v1",
+        policy_version: "agenc.runtime.compiled-job-policy.v1",
+      },
+    });
+    expect(warn).toHaveBeenCalledWith(
+      "Compiled job execution blocked",
+      expect.objectContaining({
+        reason: "compiler_version_not_enabled",
+        message:
+          'Compiled job compiler version "agenc.web.bounded-task-template.v1" is not enabled in runtime version controls',
+        taskPda: context.taskPda.toBase58(),
+      }),
+    );
+    expect(provider.chat).not.toHaveBeenCalled();
+    expect(provider.chatStream).not.toHaveBeenCalled();
+  });
+
   it("honors per-job launch allowlists from env", async () => {
     const provider = createMockProvider([
       {

--- a/runtime/src/task/compiled-job-chat-handler.ts
+++ b/runtime/src/task/compiled-job-chat-handler.ts
@@ -17,6 +17,12 @@ import {
   type CompiledJobLaunchDenyReason,
 } from "./compiled-job-launch-controls.js";
 import {
+  evaluateCompiledJobVersionAccess,
+  resolveCompiledJobVersionControls,
+  type CompiledJobVersionControls,
+  type CompiledJobVersionDenyReason,
+} from "./compiled-job-version-controls.js";
+import {
   createCompiledJobExecutionGovernor,
   resolveCompiledJobExecutionBudgetControls,
   type CompiledJobExecutionBudgetControls,
@@ -42,6 +48,7 @@ const DEFAULT_SYSTEM_PROMPT =
 
 type CompiledJobBlockReason =
   | CompiledJobLaunchDenyReason
+  | CompiledJobVersionDenyReason
   | CompiledJobExecutionDenyReason
   | "runtime_missing_required_tools"
   | "runtime_side_effect_tools_blocked";
@@ -52,6 +59,7 @@ export interface CompiledJobChatTaskHandlerOptions {
   readonly logger?: Logger;
   readonly supportedJobTypes?: readonly string[];
   readonly launchControls?: Partial<CompiledJobLaunchControls>;
+  readonly versionControls?: Partial<CompiledJobVersionControls>;
   readonly executionBudgetControls?: Partial<CompiledJobExecutionBudgetControls>;
   readonly executionGovernor?: CompiledJobExecutionGovernor;
   readonly env?: NodeJS.ProcessEnv;
@@ -77,6 +85,10 @@ export function createCompiledJobChatTaskHandler(
     base: options.launchControls,
     env: options.env,
   });
+  const versionControls = resolveCompiledJobVersionControls({
+    base: options.versionControls,
+    env: options.env,
+  });
   const executionGovernor =
     options.executionGovernor ??
     createCompiledJobExecutionGovernor({
@@ -91,6 +103,22 @@ export function createCompiledJobChatTaskHandler(
       context,
     );
     const metrics = context.metrics ?? new NoopMetrics();
+
+    const versionDecision = evaluateCompiledJobVersionAccess({
+      compilerVersion: compiledJob.audit.compilerVersion,
+      policyVersion: compiledJob.audit.policyVersion,
+      controls: versionControls,
+    });
+    if (!versionDecision.allowed) {
+      const message =
+        versionDecision.message ??
+        "Compiled job version controls denied execution";
+      recordCompiledJobBlockedRun(context, logger, metrics, {
+        reason: versionDecision.reason ?? "compiler_version_disabled",
+        message,
+      });
+      throw new Error(message);
+    }
 
     const launchDecision = evaluateCompiledJobLaunchAccess({
       jobType: compiledJob.jobType,

--- a/runtime/src/task/compiled-job-version-controls.test.ts
+++ b/runtime/src/task/compiled-job-version-controls.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateCompiledJobVersionAccess,
+  resolveCompiledJobVersionControls,
+} from "./compiled-job-version-controls.js";
+
+describe("compiled job version controls", () => {
+  it("defaults to no version restrictions", () => {
+    const controls = resolveCompiledJobVersionControls();
+
+    expect(controls).toEqual({
+      enabledCompilerVersions: [],
+      disabledCompilerVersions: [],
+      enabledPolicyVersions: [],
+      disabledPolicyVersions: [],
+    });
+  });
+
+  it("reads compiler and policy version lists from env", () => {
+    const controls = resolveCompiledJobVersionControls({
+      env: {
+        AGENC_COMPILED_JOB_ENABLED_COMPILER_VERSIONS:
+          "agenc.web.bounded-task-template.v1, agenc.approved-task-template.v1",
+        AGENC_COMPILED_JOB_DISABLED_COMPILER_VERSIONS:
+          "agenc.legacy-template.v1",
+        AGENC_COMPILED_JOB_ENABLED_POLICY_VERSIONS:
+          "agenc.runtime.compiled-job-policy.v1",
+        AGENC_COMPILED_JOB_DISABLED_POLICY_VERSIONS:
+          "agenc.runtime.compiled-job-policy.v0",
+      },
+    });
+
+    expect(controls).toEqual({
+      enabledCompilerVersions: [
+        "agenc.web.bounded-task-template.v1",
+        "agenc.approved-task-template.v1",
+      ],
+      disabledCompilerVersions: ["agenc.legacy-template.v1"],
+      enabledPolicyVersions: ["agenc.runtime.compiled-job-policy.v1"],
+      disabledPolicyVersions: ["agenc.runtime.compiled-job-policy.v0"],
+    });
+  });
+
+  it("rejects compiler versions outside the enabled allowlist", () => {
+    const decision = evaluateCompiledJobVersionAccess({
+      compilerVersion: "agenc.web.bounded-task-template.v1",
+      policyVersion: "agenc.runtime.compiled-job-policy.v1",
+      controls: resolveCompiledJobVersionControls({
+        base: {
+          enabledCompilerVersions: ["agenc.approved-task-template.v1"],
+        },
+      }),
+    });
+
+    expect(decision).toEqual({
+      allowed: false,
+      reason: "compiler_version_not_enabled",
+      message:
+        'Compiled job compiler version "agenc.web.bounded-task-template.v1" is not enabled in runtime version controls',
+    });
+  });
+
+  it("rejects disabled policy versions", () => {
+    const decision = evaluateCompiledJobVersionAccess({
+      compilerVersion: "agenc.web.bounded-task-template.v1",
+      policyVersion: "agenc.runtime.compiled-job-policy.v1",
+      controls: resolveCompiledJobVersionControls({
+        base: {
+          disabledPolicyVersions: ["agenc.runtime.compiled-job-policy.v1"],
+        },
+      }),
+    });
+
+    expect(decision).toEqual({
+      allowed: false,
+      reason: "policy_version_disabled",
+      message:
+        'Compiled job policy version "agenc.runtime.compiled-job-policy.v1" is disabled by runtime version controls',
+    });
+  });
+});

--- a/runtime/src/task/compiled-job-version-controls.ts
+++ b/runtime/src/task/compiled-job-version-controls.ts
@@ -1,0 +1,146 @@
+export interface CompiledJobVersionControls {
+  readonly enabledCompilerVersions: readonly string[];
+  readonly disabledCompilerVersions: readonly string[];
+  readonly enabledPolicyVersions: readonly string[];
+  readonly disabledPolicyVersions: readonly string[];
+}
+
+export type CompiledJobVersionDenyReason =
+  | "compiler_version_not_enabled"
+  | "compiler_version_disabled"
+  | "policy_version_not_enabled"
+  | "policy_version_disabled";
+
+export interface ResolveCompiledJobVersionControlsOptions {
+  readonly base?: Partial<CompiledJobVersionControls>;
+  readonly env?: NodeJS.ProcessEnv;
+}
+
+export interface CompiledJobVersionDecision {
+  readonly allowed: boolean;
+  readonly reason?: CompiledJobVersionDenyReason;
+  readonly message?: string;
+}
+
+export function resolveCompiledJobVersionControls(
+  options: ResolveCompiledJobVersionControlsOptions = {},
+): CompiledJobVersionControls {
+  const envControls = readCompiledJobVersionControlsFromEnv(options.env);
+  const base = options.base ?? {};
+  return {
+    enabledCompilerVersions: normalizeStringList(
+      base.enabledCompilerVersions ?? envControls.enabledCompilerVersions,
+    ),
+    disabledCompilerVersions: normalizeStringList(
+      base.disabledCompilerVersions ?? envControls.disabledCompilerVersions,
+    ),
+    enabledPolicyVersions: normalizeStringList(
+      base.enabledPolicyVersions ?? envControls.enabledPolicyVersions,
+    ),
+    disabledPolicyVersions: normalizeStringList(
+      base.disabledPolicyVersions ?? envControls.disabledPolicyVersions,
+    ),
+  };
+}
+
+export function evaluateCompiledJobVersionAccess(input: {
+  readonly compilerVersion: string;
+  readonly policyVersion: string;
+  readonly controls: CompiledJobVersionControls;
+}): CompiledJobVersionDecision {
+  if (
+    input.controls.enabledCompilerVersions.length > 0 &&
+    !input.controls.enabledCompilerVersions.includes(input.compilerVersion)
+  ) {
+    return {
+      allowed: false,
+      reason: "compiler_version_not_enabled",
+      message:
+        `Compiled job compiler version "${input.compilerVersion}" ` +
+        "is not enabled in runtime version controls",
+    };
+  }
+  if (input.controls.disabledCompilerVersions.includes(input.compilerVersion)) {
+    return {
+      allowed: false,
+      reason: "compiler_version_disabled",
+      message:
+        `Compiled job compiler version "${input.compilerVersion}" ` +
+        "is disabled by runtime version controls",
+    };
+  }
+  if (
+    input.controls.enabledPolicyVersions.length > 0 &&
+    !input.controls.enabledPolicyVersions.includes(input.policyVersion)
+  ) {
+    return {
+      allowed: false,
+      reason: "policy_version_not_enabled",
+      message:
+        `Compiled job policy version "${input.policyVersion}" ` +
+        "is not enabled in runtime version controls",
+    };
+  }
+  if (input.controls.disabledPolicyVersions.includes(input.policyVersion)) {
+    return {
+      allowed: false,
+      reason: "policy_version_disabled",
+      message:
+        `Compiled job policy version "${input.policyVersion}" ` +
+        "is disabled by runtime version controls",
+    };
+  }
+  return { allowed: true };
+}
+
+function readCompiledJobVersionControlsFromEnv(
+  env: NodeJS.ProcessEnv | undefined,
+): Partial<CompiledJobVersionControls> {
+  if (!env) return {};
+  return {
+    ...(env.AGENC_COMPILED_JOB_ENABLED_COMPILER_VERSIONS !== undefined
+      ? {
+          enabledCompilerVersions: normalizeStringList(
+            env.AGENC_COMPILED_JOB_ENABLED_COMPILER_VERSIONS,
+          ),
+        }
+      : {}),
+    ...(env.AGENC_COMPILED_JOB_DISABLED_COMPILER_VERSIONS !== undefined
+      ? {
+          disabledCompilerVersions: normalizeStringList(
+            env.AGENC_COMPILED_JOB_DISABLED_COMPILER_VERSIONS,
+          ),
+        }
+      : {}),
+    ...(env.AGENC_COMPILED_JOB_ENABLED_POLICY_VERSIONS !== undefined
+      ? {
+          enabledPolicyVersions: normalizeStringList(
+            env.AGENC_COMPILED_JOB_ENABLED_POLICY_VERSIONS,
+          ),
+        }
+      : {}),
+    ...(env.AGENC_COMPILED_JOB_DISABLED_POLICY_VERSIONS !== undefined
+      ? {
+          disabledPolicyVersions: normalizeStringList(
+            env.AGENC_COMPILED_JOB_DISABLED_POLICY_VERSIONS,
+          ),
+        }
+      : {}),
+  };
+}
+
+function normalizeStringList(
+  value: readonly string[] | string | undefined,
+): string[] {
+  if (Array.isArray(value)) {
+    return uniqueNonEmptyStrings(value);
+  }
+  if (typeof value === "string") {
+    return uniqueNonEmptyStrings(value.split(","));
+  }
+  return [];
+}
+
+function uniqueNonEmptyStrings(input: readonly string[]): string[] {
+  return [...new Set(input.map((entry) => entry.trim()).filter(Boolean))];
+}

--- a/runtime/src/task/index.ts
+++ b/runtime/src/task/index.ts
@@ -12,6 +12,7 @@ export * from "./compiled-job-enforcement.js";
 export * from "./compiled-job-execution-governor.js";
 export * from "./compiled-job-launch-controls.js";
 export * from "./compiled-job-runtime.js";
+export * from "./compiled-job-version-controls.js";
 export * from "./operations.js";
 export * from "./discovery.js";
 export * from "./executor.js";


### PR DESCRIPTION
## Summary
- add runtime controls for allowed and disabled compiled-job compiler and policy versions
- gate compiled marketplace execution on version controls before launch and budget checks
- extend blocked-run telemetry coverage so version denials are observable and testable

## Testing
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm exec --workspace=@tetsuo-ai/runtime vitest run src/task/compiled-job-version-controls.test.ts src/task/compiled-job-chat-handler.test.ts src/task/compiled-job-launch-controls.test.ts src/task/compiled-job-execution-governor.test.ts src/task/metrics.test.ts src/task/executor.test.ts