### PR TITLE
Add fail-closed compiled job dependency fallbacks

### DIFF
--- a/runtime/src/task/compiled-job-chat-handler.test.ts
+++ b/runtime/src/task/compiled-job-chat-handler.test.ts
@@ -18,6 +18,7 @@ import {
   createCompiledJobExecutionRuntime,
 } from "./compiled-job-runtime.js";
 import { createCompiledJobExecutionGovernor } from "./compiled-job-execution-governor.js";
+import type { CompiledJobDependencyCheck } from "./compiled-job-dependencies.js";
 import {
   createCompiledJobChatTaskHandler,
 } from "./compiled-job-chat-handler.js";
@@ -716,6 +717,151 @@ describe("compiled job chat task handler", () => {
       "Compiled job execution blocked",
       expect.objectContaining({
         reason: "execution_global_concurrency_limit",
+      }),
+    );
+  });
+
+  it("fails closed when a runtime dependency check denies execution", async () => {
+    const provider = createMockProvider([
+      {
+        content: "unused",
+        toolCalls: [],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        model: "mock-model",
+        finishReason: "stop",
+      },
+    ]);
+    const executor = new ChatExecutor({ providers: [provider] });
+    const registry = new ToolRegistry();
+    registry.register(createTool("system.httpGet"));
+    registry.register(createTool("system.pdfExtractText"));
+
+    const dependencyChecks: readonly CompiledJobDependencyCheck[] = [
+      () => ({
+        allowed: false,
+        reason: "dependency_network_broker_unavailable",
+        message: "Compiled job network broker is unavailable",
+        dependency: "network_broker",
+      }),
+    ];
+    const handler = createCompiledJobChatTaskHandler({
+      chatExecutor: executor,
+      toolRegistry: registry,
+      dependencyChecks,
+    });
+
+    await expect(handler(createContext())).rejects.toThrow(
+      "Compiled job network broker is unavailable",
+    );
+    expect(provider.chat).not.toHaveBeenCalled();
+    expect(provider.chatStream).not.toHaveBeenCalled();
+  });
+
+  it("records telemetry when dependency preflight denies execution", async () => {
+    const provider = createMockProvider([
+      {
+        content: "unused",
+        toolCalls: [],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        model: "mock-model",
+        finishReason: "stop",
+      },
+    ]);
+    const executor = new ChatExecutor({ providers: [provider] });
+    const registry = new ToolRegistry();
+    registry.register(createTool("system.httpGet"));
+    registry.register(createTool("system.pdfExtractText"));
+    const metrics = createRecordingMetricsProvider();
+    const warn = vi.fn();
+
+    const handler = createCompiledJobChatTaskHandler({
+      chatExecutor: executor,
+      toolRegistry: registry,
+      logger: { ...silentLogger, warn },
+      dependencyChecks: [
+        () => ({
+          allowed: false,
+          reason: "dependency_review_broker_unavailable",
+          message: "Compiled job review broker is unavailable",
+          dependency: "review_broker",
+        }),
+      ],
+    });
+    const context = createContext(undefined, {
+      metrics: metrics.provider,
+    });
+
+    await expect(handler(context)).rejects.toThrow(
+      "Compiled job review broker is unavailable",
+    );
+
+    expect(metrics.counterCalls).toContainEqual({
+      name: METRIC_NAMES.COMPILED_JOB_BLOCKED,
+      value: 1,
+      labels: expect.objectContaining({
+        reason: "dependency_review_broker_unavailable",
+        job_type: "web_research_brief",
+      }),
+    });
+    expect(warn).toHaveBeenCalledWith(
+      "Compiled job execution blocked",
+      expect.objectContaining({
+        reason: "dependency_review_broker_unavailable",
+        message: "Compiled job review broker is unavailable",
+        dependency: "review_broker",
+      }),
+    );
+  });
+
+  it("records telemetry when dependency preflight throws", async () => {
+    const provider = createMockProvider([
+      {
+        content: "unused",
+        toolCalls: [],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+        model: "mock-model",
+        finishReason: "stop",
+      },
+    ]);
+    const executor = new ChatExecutor({ providers: [provider] });
+    const registry = new ToolRegistry();
+    registry.register(createTool("system.httpGet"));
+    registry.register(createTool("system.pdfExtractText"));
+    const metrics = createRecordingMetricsProvider();
+    const warn = vi.fn();
+
+    const handler = createCompiledJobChatTaskHandler({
+      chatExecutor: executor,
+      toolRegistry: registry,
+      logger: { ...silentLogger, warn },
+      dependencyChecks: [
+        () => {
+          throw new Error("sandbox pool exhausted");
+        },
+      ],
+    });
+    const context = createContext(undefined, {
+      metrics: metrics.provider,
+    });
+
+    await expect(handler(context)).rejects.toThrow(
+      "Compiled job dependency preflight failed: sandbox pool exhausted",
+    );
+
+    expect(metrics.counterCalls).toContainEqual({
+      name: METRIC_NAMES.COMPILED_JOB_BLOCKED,
+      value: 1,
+      labels: expect.objectContaining({
+        reason: "dependency_preflight_failed",
+        job_type: "web_research_brief",
+      }),
+    });
+    expect(warn).toHaveBeenCalledWith(
+      "Compiled job execution blocked",
+      expect.objectContaining({
+        reason: "dependency_preflight_failed",
+        message:
+          "Compiled job dependency preflight failed: sandbox pool exhausted",
       }),
     );
   });

--- a/runtime/src/task/compiled-job-chat-handler.ts
+++ b/runtime/src/task/compiled-job-chat-handler.ts
@@ -29,6 +29,11 @@ import {
   type CompiledJobExecutionDenyReason,
   type CompiledJobExecutionGovernor,
 } from "./compiled-job-execution-governor.js";
+import {
+  evaluateCompiledJobDependencyChecks,
+  type CompiledJobDependencyCheck,
+  type CompiledJobDependencyDenyReason,
+} from "./compiled-job-dependencies.js";
 import type {
   MetricsProvider,
   TaskExecutionContext,
@@ -50,6 +55,7 @@ type CompiledJobBlockReason =
   | CompiledJobLaunchDenyReason
   | CompiledJobVersionDenyReason
   | CompiledJobExecutionDenyReason
+  | CompiledJobDependencyDenyReason
   | "runtime_missing_required_tools"
   | "runtime_side_effect_tools_blocked";
 
@@ -62,6 +68,7 @@ export interface CompiledJobChatTaskHandlerOptions {
   readonly versionControls?: Partial<CompiledJobVersionControls>;
   readonly executionBudgetControls?: Partial<CompiledJobExecutionBudgetControls>;
   readonly executionGovernor?: CompiledJobExecutionGovernor;
+  readonly dependencyChecks?: readonly CompiledJobDependencyCheck[];
   readonly env?: NodeJS.ProcessEnv;
   readonly channel?: string;
   readonly senderId?: string;
@@ -103,6 +110,22 @@ export function createCompiledJobChatTaskHandler(
       context,
     );
     const metrics = context.metrics ?? new NoopMetrics();
+
+    const dependencyDecision = await evaluateCompiledJobDependencyChecks({
+      context,
+      checks: options.dependencyChecks,
+    });
+    if (!dependencyDecision.allowed) {
+      const message =
+        dependencyDecision.message ??
+        "Compiled job dependency preflight denied execution";
+      recordCompiledJobBlockedRun(context, logger, metrics, {
+        reason: dependencyDecision.reason ?? "dependency_preflight_failed",
+        message,
+        dependency: dependencyDecision.dependency,
+      });
+      throw new Error(message);
+    }
 
     const versionDecision = evaluateCompiledJobVersionAccess({
       compilerVersion: compiledJob.audit.compilerVersion,
@@ -224,6 +247,7 @@ function recordCompiledJobBlockedRun(
     readonly message: string;
     readonly blockedToolNames?: readonly string[];
     readonly missingToolNames?: readonly string[];
+    readonly dependency?: string;
   },
 ): void {
   const compiledJob = context.compiledJob;
@@ -250,6 +274,7 @@ function recordCompiledJobBlockedRun(
     compiledPlanHash: compiledJob.audit.compiledPlanHash,
     blockedToolNames: input.blockedToolNames,
     missingToolNames: input.missingToolNames,
+    dependency: input.dependency,
   });
 }
 

--- a/runtime/src/task/compiled-job-dependencies.ts
+++ b/runtime/src/task/compiled-job-dependencies.ts
@@ -1,0 +1,63 @@
+import type { TaskExecutionContext } from "./types.js";
+
+export type CompiledJobDependencyDenyReason =
+  | "dependency_preflight_failed"
+  | "dependency_chat_executor_unavailable"
+  | "dependency_tool_registry_unavailable"
+  | "dependency_policy_runtime_unavailable"
+  | "dependency_network_broker_unavailable"
+  | "dependency_sandbox_unavailable"
+  | "dependency_review_broker_unavailable";
+
+export interface CompiledJobDependencyDecision {
+  readonly allowed: boolean;
+  readonly reason?: CompiledJobDependencyDenyReason;
+  readonly message?: string;
+  readonly dependency?: string;
+}
+
+export type CompiledJobDependencyCheck = (
+  context: TaskExecutionContext,
+) =>
+  | CompiledJobDependencyDecision
+  | Promise<CompiledJobDependencyDecision>;
+
+export interface EvaluateCompiledJobDependencyChecksOptions {
+  readonly context: TaskExecutionContext;
+  readonly checks?: readonly CompiledJobDependencyCheck[];
+}
+
+export async function evaluateCompiledJobDependencyChecks(
+  options: EvaluateCompiledJobDependencyChecksOptions,
+): Promise<CompiledJobDependencyDecision> {
+  for (const check of options.checks ?? []) {
+    try {
+      const decision = await check(options.context);
+      if (!decision.allowed) {
+        return {
+          allowed: false,
+          reason: decision.reason ?? "dependency_preflight_failed",
+          message:
+            decision.message ??
+            "Compiled job dependency preflight denied execution",
+          ...(decision.dependency ? { dependency: decision.dependency } : {}),
+        };
+      }
+    } catch (error) {
+      return {
+        allowed: false,
+        reason: "dependency_preflight_failed",
+        message: formatDependencyPreflightError(error),
+      };
+    }
+  }
+
+  return { allowed: true };
+}
+
+function formatDependencyPreflightError(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return `Compiled job dependency preflight failed: ${error.message}`;
+  }
+  return "Compiled job dependency preflight failed";
+}

--- a/runtime/src/telemetry/compiled-job-alerts.test.ts
+++ b/runtime/src/telemetry/compiled-job-alerts.test.ts
@@ -79,6 +79,34 @@ describe("CompiledJobAlertSink", () => {
     });
   });
 
+  it("surfaces dependency failure spikes through the same blocked-run alerts", () => {
+    const sink = new CompiledJobAlertSink({
+      totalBlockedThreshold: 99,
+      blockedReasonThreshold: 2,
+      now: () => 2_500,
+    });
+    const telemetry = new UnifiedTelemetryCollector({ sinks: [sink] });
+
+    telemetry.counter(METRIC_NAMES.COMPILED_JOB_BLOCKED, 2, {
+      reason: "dependency_network_broker_unavailable",
+      job_type: "web_research_brief",
+    });
+
+    telemetry.flush();
+
+    expect(sink.getRecentAlerts()).toContainEqual({
+      id: "compiled_job.blocked_reason_spike:dependency_network_broker_unavailable:2500",
+      severity: "warn",
+      code: "compiled_job.blocked_reason_spike",
+      message:
+        "Compiled job blocked-run spike detected for dependency_network_broker_unavailable: 2 blocked runs since the last telemetry flush",
+      createdAt: 2_500,
+      delta: 2,
+      threshold: 2,
+      reason: "dependency_network_broker_unavailable",
+    });
+  });
+
   it("dedupes repeated alerts inside the dedupe window", () => {
     let now = 10_000;
     const sink = new CompiledJobAlertSink({


### PR DESCRIPTION
## Summary
- add explicit compiled-job dependency preflight checks with named deny reasons
- fail closed in the compiled-job chat handler when runtime dependencies are unavailable
- prove dependency failures flow through the existing blocked-run telemetry and alert path

## Testing
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm exec --workspace=@tetsuo-ai/runtime vitest run src/task/compiled-job-chat-handler.test.ts src/task/compiled-job-launch-controls.test.ts src/task/compiled-job-execution-governor.test.ts src/task/metrics.test.ts src/task/executor.test.ts src/telemetry/compiled-job-alerts.test.ts