### PR TITLE
Add compiled job policy and domain alerts

### DIFF
--- a/runtime/src/task/compiled-job-chat-handler.test.ts
+++ b/runtime/src/task/compiled-job-chat-handler.test.ts
@@ -866,6 +866,165 @@ describe("compiled job chat task handler", () => {
     );
   });
 
+  it("records policy-failure and domain-denial telemetry for blocked domains", async () => {
+    const provider = createMockProvider([
+      {
+        content: "",
+        toolCalls: [
+          {
+            id: "tc-1",
+            name: "system.httpGet",
+            arguments: '{"url":"https://blocked.example.com/report"}',
+          },
+        ],
+        usage: { promptTokens: 12, completionTokens: 4, totalTokens: 16 },
+        model: "mock-model",
+        finishReason: "tool_calls",
+      },
+      {
+        content: "Fallback brief after blocked domain",
+        toolCalls: [],
+        usage: { promptTokens: 8, completionTokens: 6, totalTokens: 14 },
+        model: "mock-model",
+        finishReason: "stop",
+      },
+    ]);
+    const executor = new ChatExecutor({
+      providers: [provider],
+      allowedTools: ["system.httpGet", "system.pdfExtractText"],
+    });
+    const registry = new ToolRegistry();
+    registry.register(createTool("system.httpGet"));
+    registry.register(createTool("system.pdfExtractText"));
+    const metrics = createRecordingMetricsProvider();
+    const warn = vi.fn();
+
+    const handler = createCompiledJobChatTaskHandler({
+      chatExecutor: executor,
+      toolRegistry: registry,
+      logger: { ...silentLogger, warn },
+    });
+    const result = await handler(
+      createContext(undefined, {
+        metrics: metrics.provider,
+      }),
+    );
+
+    expect(decodeFixedBytes(result.resultData!)).toBe(
+      "Fallback brief after blocked domain",
+    );
+    expect(metrics.counterCalls).toContainEqual({
+      name: METRIC_NAMES.COMPILED_JOB_POLICY_FAILURE,
+      value: 1,
+      labels: expect.objectContaining({
+        reason: "network_access_denied",
+        violation_code: "network_access_denied",
+        tool_name: "system.httpGet",
+      }),
+    });
+    expect(metrics.counterCalls).toContainEqual({
+      name: METRIC_NAMES.COMPILED_JOB_DOMAIN_DENIED,
+      value: 1,
+      labels: expect.objectContaining({
+        reason: "network_access_denied",
+        tool_name: "system.httpGet",
+      }),
+    });
+    expect(warn).toHaveBeenCalledWith(
+      "Compiled job policy failure observed",
+      expect.objectContaining({
+        reason: "network_access_denied",
+        violationCode: "network_access_denied",
+        toolName: "system.httpGet",
+      }),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "Compiled job domain denied",
+      expect.objectContaining({
+        reason: "network_access_denied",
+        toolName: "system.httpGet",
+        host: "blocked.example.com",
+      }),
+    );
+  });
+
+  it("records domain-denial telemetry when a tool blocks a redirect target", async () => {
+    const provider = createMockProvider([
+      {
+        content: "",
+        toolCalls: [
+          {
+            id: "tc-1",
+            name: "system.httpGet",
+            arguments: '{"url":"https://example.com/report"}',
+          },
+        ],
+        usage: { promptTokens: 12, completionTokens: 4, totalTokens: 16 },
+        model: "mock-model",
+        finishReason: "tool_calls",
+      },
+      {
+        content: "Fallback brief after redirect block",
+        toolCalls: [],
+        usage: { promptTokens: 8, completionTokens: 6, totalTokens: 14 },
+        model: "mock-model",
+        finishReason: "stop",
+      },
+    ]);
+    const executor = new ChatExecutor({
+      providers: [provider],
+      allowedTools: ["system.httpGet", "system.pdfExtractText"],
+    });
+    const registry = new ToolRegistry();
+    registry.register(
+      createTool("system.httpGet", async () => ({
+        content: JSON.stringify({
+          error: "Domain not in allowed list: redirected.example.com",
+        }),
+        isError: true,
+      })),
+    );
+    registry.register(createTool("system.pdfExtractText"));
+    const metrics = createRecordingMetricsProvider();
+    const warn = vi.fn();
+
+    const handler = createCompiledJobChatTaskHandler({
+      chatExecutor: executor,
+      toolRegistry: registry,
+      logger: { ...silentLogger, warn },
+    });
+    const result = await handler(
+      createContext(undefined, {
+        metrics: metrics.provider,
+      }),
+    );
+
+    expect(decodeFixedBytes(result.resultData!)).toBe(
+      "Fallback brief after redirect block",
+    );
+    expect(
+      metrics.counterCalls.filter(
+        (call) => call.name === METRIC_NAMES.COMPILED_JOB_POLICY_FAILURE,
+      ),
+    ).toHaveLength(0);
+    expect(metrics.counterCalls).toContainEqual({
+      name: METRIC_NAMES.COMPILED_JOB_DOMAIN_DENIED,
+      value: 1,
+      labels: expect.objectContaining({
+        reason: "tool_domain_blocked",
+        tool_name: "system.httpGet",
+      }),
+    });
+    expect(warn).toHaveBeenCalledWith(
+      "Compiled job domain denied",
+      expect.objectContaining({
+        reason: "tool_domain_blocked",
+        toolName: "system.httpGet",
+        host: "redirected.example.com",
+      }),
+    );
+  });
+
   it("records telemetry when L0 runtime blocks side-effect tools", async () => {
     const provider = createMockProvider([
       {

--- a/runtime/src/task/compiled-job-chat-handler.ts
+++ b/runtime/src/task/compiled-job-chat-handler.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import type { ChatExecutor } from "../llm/chat-executor.js";
 import { executeChatToLegacyResult } from "../llm/execute-chat.js";
+import type { ToolHandler } from "../llm/types.js";
 import {
   normalizePromptEnvelope,
   type PromptEnvelopeInput,
@@ -58,6 +59,14 @@ type CompiledJobBlockReason =
   | CompiledJobDependencyDenyReason
   | "runtime_missing_required_tools"
   | "runtime_side_effect_tools_blocked";
+
+type CompiledJobPolicyFailureReason =
+  | "network_access_denied"
+  | "policy_violation";
+
+type CompiledJobDomainDeniedReason =
+  | "network_access_denied"
+  | "tool_domain_blocked";
 
 export interface CompiledJobChatTaskHandlerOptions {
   readonly chatExecutor: ChatExecutor;
@@ -218,7 +227,12 @@ export function createCompiledJobChatTaskHandler(
           history: [],
           promptEnvelope,
           sessionId: message.sessionId,
-          toolHandler: scopedTooling.toolHandler,
+          toolHandler: createObservedCompiledJobToolHandler({
+            context,
+            logger,
+            metrics,
+            toolHandler: scopedTooling.toolHandler,
+          }),
           signal: context.signal,
         }),
       );
@@ -236,6 +250,72 @@ export function createCompiledJobChatTaskHandler(
       executionLease?.release();
     }
   };
+}
+
+function createObservedCompiledJobToolHandler(input: {
+  readonly context: TaskExecutionContext;
+  readonly logger: Logger;
+  readonly metrics: MetricsProvider;
+  readonly toolHandler: ToolHandler;
+}): ToolHandler {
+  return async (name, args) => {
+    const result = await input.toolHandler(name, args);
+    observeCompiledJobToolResult({
+      context: input.context,
+      logger: input.logger,
+      metrics: input.metrics,
+      toolName: name,
+      result,
+    });
+    return result;
+  };
+}
+
+function observeCompiledJobToolResult(input: {
+  readonly context: TaskExecutionContext;
+  readonly logger: Logger;
+  readonly metrics: MetricsProvider;
+  readonly toolName: string;
+  readonly result: string;
+}): void {
+  const parsed = parseToolResultPayload(input.result);
+  if (!parsed) return;
+
+  let domainDeniedRecorded = false;
+  const policyViolation = extractPolicyViolation(parsed);
+  if (policyViolation) {
+    const reason: CompiledJobPolicyFailureReason =
+      policyViolation.code === "network_access_denied"
+        ? "network_access_denied"
+        : "policy_violation";
+    recordCompiledJobPolicyFailure(input.context, input.logger, input.metrics, {
+      reason,
+      toolName: input.toolName,
+      violationCode: policyViolation.code,
+      message: policyViolation.message,
+      host: policyViolation.host,
+    });
+    if (policyViolation.code === "network_access_denied") {
+      domainDeniedRecorded = true;
+      recordCompiledJobDomainDenied(input.context, input.logger, input.metrics, {
+        reason: "network_access_denied",
+        toolName: input.toolName,
+        message: policyViolation.message,
+        host: policyViolation.host,
+      });
+    }
+  }
+
+  if (domainDeniedRecorded) return;
+  const domainDenied = extractDomainDenied(parsed);
+  if (!domainDenied) return;
+
+  recordCompiledJobDomainDenied(input.context, input.logger, input.metrics, {
+    reason: "tool_domain_blocked",
+    toolName: input.toolName,
+    message: domainDenied.message,
+    host: domainDenied.host,
+  });
 }
 
 function recordCompiledJobBlockedRun(
@@ -276,6 +356,182 @@ function recordCompiledJobBlockedRun(
     missingToolNames: input.missingToolNames,
     dependency: input.dependency,
   });
+}
+
+function recordCompiledJobPolicyFailure(
+  context: TaskExecutionContext,
+  logger: Logger,
+  metrics: MetricsProvider,
+  input: {
+    readonly reason: CompiledJobPolicyFailureReason;
+    readonly toolName: string;
+    readonly violationCode: string;
+    readonly message: string;
+    readonly host?: string;
+  },
+): void {
+  const compiledJob = context.compiledJob;
+  if (!compiledJob) return;
+
+  metrics.counter(METRIC_NAMES.COMPILED_JOB_POLICY_FAILURE, 1, {
+    reason: input.reason,
+    violation_code: input.violationCode,
+    job_type: compiledJob.jobType,
+    tool_name: input.toolName,
+    compiler_version: compiledJob.audit.compilerVersion,
+    policy_version: compiledJob.audit.policyVersion,
+  });
+
+  logger.warn("Compiled job policy failure observed", {
+    reason: input.reason,
+    violationCode: input.violationCode,
+    message: input.message,
+    host: input.host,
+    toolName: input.toolName,
+    taskPda: context.taskPda.toBase58(),
+    jobType: compiledJob.jobType,
+    compilerVersion: compiledJob.audit.compilerVersion,
+    policyVersion: compiledJob.audit.policyVersion,
+    compiledPlanHash: compiledJob.audit.compiledPlanHash,
+  });
+}
+
+function recordCompiledJobDomainDenied(
+  context: TaskExecutionContext,
+  logger: Logger,
+  metrics: MetricsProvider,
+  input: {
+    readonly reason: CompiledJobDomainDeniedReason;
+    readonly toolName: string;
+    readonly message: string;
+    readonly host?: string;
+  },
+): void {
+  const compiledJob = context.compiledJob;
+  if (!compiledJob) return;
+
+  metrics.counter(METRIC_NAMES.COMPILED_JOB_DOMAIN_DENIED, 1, {
+    reason: input.reason,
+    job_type: compiledJob.jobType,
+    tool_name: input.toolName,
+    compiler_version: compiledJob.audit.compilerVersion,
+    policy_version: compiledJob.audit.policyVersion,
+  });
+
+  logger.warn("Compiled job domain denied", {
+    reason: input.reason,
+    message: input.message,
+    host: input.host,
+    toolName: input.toolName,
+    taskPda: context.taskPda.toBase58(),
+    jobType: compiledJob.jobType,
+    compilerVersion: compiledJob.audit.compilerVersion,
+    policyVersion: compiledJob.audit.policyVersion,
+    compiledPlanHash: compiledJob.audit.compiledPlanHash,
+  });
+}
+
+function parseToolResultPayload(
+  result: string,
+): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(result) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return undefined;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+function extractPolicyViolation(parsed: Record<string, unknown>): {
+  readonly code: string;
+  readonly message: string;
+  readonly host?: string;
+} | null {
+  const violation = asRecord(parsed.violation);
+  const code = asString(violation?.code);
+  const message =
+    asString(violation?.message) ??
+    asString(parsed.error) ??
+    "Compiled job policy violation";
+  if (!code) return null;
+
+  const metadata = asRecord(violation?.metadata);
+  return {
+    code,
+    message,
+    host: asString(metadata?.host) ?? extractHostFromDomainDeniedMessage(message),
+  };
+}
+
+function extractDomainDenied(parsed: Record<string, unknown>): {
+  readonly message: string;
+  readonly host?: string;
+} | null {
+  const structuredError = asRecord(parsed.error);
+  const structuredCode = asString(structuredError?.code);
+  const structuredMessage =
+    asString(structuredError?.message) ?? asString(parsed.error);
+  if (
+    structuredCode &&
+    (structuredCode.endsWith(".domain_blocked") ||
+      structuredCode.endsWith(".url_blocked") ||
+      structuredCode.endsWith(".health_url_blocked"))
+  ) {
+    return {
+      message: structuredMessage ?? "Compiled job domain denied",
+    };
+  }
+
+  const message = asString(parsed.error);
+  if (!message || !isDomainDeniedMessage(message)) return null;
+
+  return {
+    message,
+    host: extractHostFromDomainDeniedMessage(message),
+  };
+}
+
+function isDomainDeniedMessage(message: string): boolean {
+  return (
+    /Domain not in allowed list:/i.test(message) ||
+    /Domain is blocked:/i.test(message) ||
+    /Private\/loopback address blocked:/i.test(message) ||
+    /SSRF target blocked:/i.test(message) ||
+    /outside the allowed host set/i.test(message)
+  );
+}
+
+function extractHostFromDomainDeniedMessage(
+  message: string,
+): string | undefined {
+  const quotedHost = message.match(/host "([^"]+)"/i);
+  if (quotedHost?.[1]) return quotedHost[1];
+
+  const allowListHost = message.match(/Domain not in allowed list:\s*([^\s]+)/i);
+  if (allowListHost?.[1]) return allowListHost[1];
+
+  const blockedHost = message.match(
+    /(?:Domain is blocked:|SSRF target blocked:|Private\/loopback address blocked:)\s*([^\s]+)/i,
+  );
+  if (blockedHost?.[1]) return blockedHost[1];
+
+  return undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
 }
 
 export function buildCompiledJobTaskPromptEnvelope(

--- a/runtime/src/task/metrics.test.ts
+++ b/runtime/src/task/metrics.test.ts
@@ -278,6 +278,12 @@ describe("METRIC_NAMES", () => {
     expect(METRIC_NAMES.COMPILED_JOB_BLOCKED).toBe(
       "agenc.task.compiled_job.blocked.count",
     );
+    expect(METRIC_NAMES.COMPILED_JOB_POLICY_FAILURE).toBe(
+      "agenc.task.compiled_job.policy_failure.count",
+    );
+    expect(METRIC_NAMES.COMPILED_JOB_DOMAIN_DENIED).toBe(
+      "agenc.task.compiled_job.domain_denied.count",
+    );
   });
 });
 

--- a/runtime/src/task/metrics.ts
+++ b/runtime/src/task/metrics.ts
@@ -35,6 +35,10 @@ export const METRIC_NAMES = {
   CLAIM_RETRIES: "agenc.task.claim_retries.count",
   SUBMIT_RETRIES: "agenc.task.submit_retries.count",
   COMPILED_JOB_BLOCKED: "agenc.task.compiled_job.blocked.count",
+  COMPILED_JOB_POLICY_FAILURE:
+    "agenc.task.compiled_job.policy_failure.count",
+  COMPILED_JOB_DOMAIN_DENIED:
+    "agenc.task.compiled_job.domain_denied.count",
 } as const;
 
 // ============================================================================

--- a/runtime/src/telemetry/compiled-job-alerts.test.ts
+++ b/runtime/src/telemetry/compiled-job-alerts.test.ts
@@ -107,6 +107,66 @@ describe("CompiledJobAlertSink", () => {
     });
   });
 
+  it("emits alerts for compiled-job policy failure spikes", () => {
+    const sink = new CompiledJobAlertSink({
+      totalBlockedThreshold: 99,
+      blockedReasonThreshold: 99,
+      policyFailureThreshold: 2,
+      now: () => 3_000,
+    });
+    const telemetry = new UnifiedTelemetryCollector({ sinks: [sink] });
+
+    telemetry.counter(METRIC_NAMES.COMPILED_JOB_POLICY_FAILURE, 2, {
+      reason: "network_access_denied",
+      violation_code: "network_access_denied",
+      job_type: "web_research_brief",
+    });
+
+    telemetry.flush();
+
+    expect(sink.getRecentAlerts()).toContainEqual({
+      id: "compiled_job.policy_failure_spike:network_access_denied:3000",
+      severity: "warn",
+      code: "compiled_job.policy_failure_spike",
+      message:
+        "Compiled job policy failures spike detected for network_access_denied: 2 events since the last telemetry flush",
+      createdAt: 3_000,
+      delta: 2,
+      threshold: 2,
+      reason: "network_access_denied",
+    });
+  });
+
+  it("emits alerts for compiled-job domain denial spikes", () => {
+    const sink = new CompiledJobAlertSink({
+      totalBlockedThreshold: 99,
+      blockedReasonThreshold: 99,
+      domainDeniedThreshold: 2,
+      now: () => 3_500,
+    });
+    const telemetry = new UnifiedTelemetryCollector({ sinks: [sink] });
+
+    telemetry.counter(METRIC_NAMES.COMPILED_JOB_DOMAIN_DENIED, 2, {
+      reason: "tool_domain_blocked",
+      job_type: "web_research_brief",
+      tool_name: "system.httpGet",
+    });
+
+    telemetry.flush();
+
+    expect(sink.getRecentAlerts()).toContainEqual({
+      id: "compiled_job.domain_denied_spike:tool_domain_blocked:3500",
+      severity: "warn",
+      code: "compiled_job.domain_denied_spike",
+      message:
+        "Compiled job domain denials spike detected for tool_domain_blocked: 2 events since the last telemetry flush",
+      createdAt: 3_500,
+      delta: 2,
+      threshold: 2,
+      reason: "tool_domain_blocked",
+    });
+  });
+
   it("dedupes repeated alerts inside the dedupe window", () => {
     let now = 10_000;
     const sink = new CompiledJobAlertSink({

--- a/runtime/src/telemetry/compiled-job-alerts.ts
+++ b/runtime/src/telemetry/compiled-job-alerts.ts
@@ -5,6 +5,8 @@ import type { TelemetrySink, TelemetrySnapshot } from "./types.js";
 
 const DEFAULT_TOTAL_BLOCKED_THRESHOLD = 10;
 const DEFAULT_REASON_BLOCKED_THRESHOLD = 5;
+const DEFAULT_POLICY_FAILURE_THRESHOLD = 5;
+const DEFAULT_DOMAIN_DENIED_THRESHOLD = 3;
 const DEFAULT_MAX_RECENT_ALERTS = 20;
 const DEFAULT_DEDUPE_WINDOW_MS = 5 * 60_000;
 
@@ -13,7 +15,9 @@ export interface CompiledJobTelemetryAlert {
   readonly severity: "warn" | "error";
   readonly code:
     | "compiled_job.blocked_runs_spike"
-    | "compiled_job.blocked_reason_spike";
+    | "compiled_job.blocked_reason_spike"
+    | "compiled_job.policy_failure_spike"
+    | "compiled_job.domain_denied_spike";
   readonly message: string;
   readonly createdAt: number;
   readonly delta: number;
@@ -24,6 +28,8 @@ export interface CompiledJobTelemetryAlert {
 export interface CompiledJobAlertSinkOptions {
   readonly totalBlockedThreshold?: number;
   readonly blockedReasonThreshold?: number;
+  readonly policyFailureThreshold?: number;
+  readonly domainDeniedThreshold?: number;
   readonly maxRecentAlerts?: number;
   readonly dedupeWindowMs?: number;
   readonly now?: () => number;
@@ -40,6 +46,8 @@ export class CompiledJobAlertSink implements TelemetrySink {
 
   private readonly totalBlockedThreshold: number;
   private readonly blockedReasonThreshold: number;
+  private readonly policyFailureThreshold: number;
+  private readonly domainDeniedThreshold: number;
   private readonly maxRecentAlerts: number;
   private readonly dedupeWindowMs: number;
   private readonly now: () => number;
@@ -53,6 +61,10 @@ export class CompiledJobAlertSink implements TelemetrySink {
       options.totalBlockedThreshold ?? DEFAULT_TOTAL_BLOCKED_THRESHOLD;
     this.blockedReasonThreshold =
       options.blockedReasonThreshold ?? DEFAULT_REASON_BLOCKED_THRESHOLD;
+    this.policyFailureThreshold =
+      options.policyFailureThreshold ?? DEFAULT_POLICY_FAILURE_THRESHOLD;
+    this.domainDeniedThreshold =
+      options.domainDeniedThreshold ?? DEFAULT_DOMAIN_DENIED_THRESHOLD;
     this.maxRecentAlerts = options.maxRecentAlerts ?? DEFAULT_MAX_RECENT_ALERTS;
     this.dedupeWindowMs = options.dedupeWindowMs ?? DEFAULT_DEDUPE_WINDOW_MS;
     this.now = options.now ?? (() => Date.now());
@@ -61,7 +73,21 @@ export class CompiledJobAlertSink implements TelemetrySink {
 
   flush(snapshot: TelemetrySnapshot): void {
     const counters = extractCompiledJobBlockedCounters(snapshot.counters);
-    if (counters.length === 0) {
+    const policyFailureCounters = extractCounterReasonDeltas(
+      snapshot.counters,
+      this.previousCounters,
+      METRIC_NAMES.COMPILED_JOB_POLICY_FAILURE,
+    );
+    const domainDeniedCounters = extractCounterReasonDeltas(
+      snapshot.counters,
+      this.previousCounters,
+      METRIC_NAMES.COMPILED_JOB_DOMAIN_DENIED,
+    );
+    if (
+      counters.length === 0 &&
+      policyFailureCounters.size === 0 &&
+      domainDeniedCounters.size === 0
+    ) {
       return;
     }
 
@@ -122,6 +148,21 @@ export class CompiledJobAlertSink implements TelemetrySink {
         now,
       );
     }
+
+    this.emitMetricReasonAlerts({
+      now,
+      counters: policyFailureCounters,
+      threshold: this.policyFailureThreshold,
+      code: "compiled_job.policy_failure_spike",
+      noun: "policy failures",
+    });
+    this.emitMetricReasonAlerts({
+      now,
+      counters: domainDeniedCounters,
+      threshold: this.domainDeniedThreshold,
+      code: "compiled_job.domain_denied_spike",
+      noun: "domain denials",
+    });
   }
 
   getRecentAlerts(): readonly CompiledJobTelemetryAlert[] {
@@ -159,6 +200,35 @@ export class CompiledJobAlertSink implements TelemetrySink {
       reason: alert.reason,
     });
   }
+
+  private emitMetricReasonAlerts(input: {
+    readonly now: number;
+    readonly counters: ReadonlyMap<string, number>;
+    readonly threshold: number;
+    readonly code:
+      | "compiled_job.policy_failure_spike"
+      | "compiled_job.domain_denied_spike";
+    readonly noun: string;
+  }): void {
+    for (const [reason, delta] of input.counters) {
+      if (delta < input.threshold) continue;
+      this.emitAlert(
+        {
+          id: `${input.code}:${reason}:${input.now}`,
+          severity: delta >= input.threshold * 2 ? "error" : "warn",
+          code: input.code,
+          message:
+            `Compiled job ${input.noun} spike detected for ${reason}: ${delta} events ` +
+            "since the last telemetry flush",
+          createdAt: input.now,
+          delta,
+          threshold: input.threshold,
+          reason,
+        },
+        input.now,
+      );
+    }
+  }
 }
 
 function extractCompiledJobBlockedCounters(
@@ -178,6 +248,31 @@ function extractCompiledJobBlockedCounters(
       value,
       labels: parseCompositeLabels(key),
     }));
+}
+
+function extractCounterReasonDeltas(
+  counters: Record<string, number>,
+  previousCounters: Map<string, number>,
+  metricName: string,
+): Map<string, number> {
+  const deltas = new Map<string, number>();
+  for (const [key, value] of Object.entries(counters).filter(([entryKey]) =>
+    entryKey === metricName || entryKey.startsWith(`${metricName}|`),
+  )) {
+    const previous = previousCounters.get(key);
+    const delta =
+      previous === undefined
+        ? value
+        : value >= previous
+          ? value - previous
+          : value;
+    previousCounters.set(key, value);
+    if (delta <= 0) continue;
+    const labels = parseCompositeLabels(key);
+    const reason = labels.reason ?? "unknown";
+    deltas.set(reason, (deltas.get(reason) ?? 0) + delta);
+  }
+  return deltas;
 }
 
 function parseCompositeLabels(key: string): Record<string, string> {


### PR DESCRIPTION
## Summary
- emit compiled-job telemetry for policy-engine denials during tool execution
- emit compiled-job telemetry for domain denials from policy checks and tool-level domain blocks
- extend the compiled-job alert sink with policy-failure and domain-denial spike alerts

## Testing
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm exec --workspace=@tetsuo-ai/runtime vitest run src/task/compiled-job-chat-handler.test.ts src/task/compiled-job-launch-controls.test.ts src/task/compiled-job-execution-governor.test.ts src/task/metrics.test.ts src/task/executor.test.ts src/telemetry/compiled-job-alerts.test.ts