### PR TITLE
Add legacy devnet dispute layout compatibility fallback

### DIFF
--- a/runtime/src/dispute/operations.test.ts
+++ b/runtime/src/dispute/operations.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { PublicKey, Keypair, SystemProgram } from "@solana/web3.js";
 import { DisputeOperations, type DisputeOpsConfig } from "./operations.js";
+import * as idlModule from "../idl.js";
 import {
   parseOnChainDispute,
   parseOnChainDisputeVote,
@@ -31,7 +32,7 @@ import {
 import { PROGRAM_ID, SEEDS } from "@tetsuo-ai/sdk";
 import { silentLogger } from "../utils/logger.js";
 import { generateAgentId } from "../utils/encoding.js";
-import { findAuthorityRateLimitPda } from "../agent/pda.js";
+import { findAuthorityRateLimitPda, findProtocolPda } from "../agent/pda.js";
 import { deriveTaskSubmissionPda } from "../task/pda.js";
 
 // ============================================================================
@@ -112,6 +113,9 @@ function createMockProgram(overrides: Record<string, any> = {}) {
     programId: PROGRAM_ID,
     provider: {
       publicKey: randomPubkey(),
+      connection: {
+        getAccountInfo: vi.fn().mockResolvedValue(null),
+      },
     },
     account: {
       dispute: {
@@ -381,6 +385,7 @@ describe("DisputeOperations", () => {
   const agentId = generateAgentId();
 
   beforeEach(() => {
+    vi.restoreAllMocks();
     program = createMockProgram();
     ops = new DisputeOperations({
       program,
@@ -665,6 +670,47 @@ describe("DisputeOperations", () => {
           }),
         ]),
       );
+    });
+
+    it("retries with the legacy devnet dispute layout when protocol_config appears uninitialized", async () => {
+      const legacyProgram = createMockProgram();
+      const createProgramSpy = vi
+        .spyOn(idlModule, "createProgram")
+        .mockReturnValue(legacyProgram as never);
+
+      program._rpcMock.mockRejectedValueOnce(
+        new Error(
+          "AnchorError caused by account: protocol_config. Error Code: AccountNotInitialized. Error Number: 3012. Error Message: The program expected this account to be already initialized.",
+        ),
+      );
+
+      const result = await ops.initiateDispute({
+        disputeId: randomBytes(32),
+        taskPda: randomPubkey(),
+        taskId: randomBytes(32),
+        evidenceHash: randomBytes(32),
+        resolutionType: 0,
+        evidence: "creator retries with legacy compatibility layout",
+      });
+
+      expect(result.transactionSignature).toBe("mock-signature");
+      expect(createProgramSpy).toHaveBeenCalledWith(
+        program.provider,
+        program.programId,
+        "legacyInitiateDispute",
+      );
+      expect(legacyProgram._methodBuilder.accountsPartial).toHaveBeenCalledWith(
+        expect.objectContaining({
+          protocolConfig: findProtocolPda(program.programId),
+          authority: legacyProgram.provider.publicKey,
+        }),
+      );
+      expect(
+        legacyProgram._methodBuilder.accountsPartial.mock.calls[0][0],
+      ).not.toHaveProperty("authorityRateLimit");
+      expect(
+        legacyProgram._methodBuilder.accountsPartial.mock.calls[0][0],
+      ).not.toHaveProperty("taskSubmission");
     });
 
     it("maps InsufficientEvidence error", async () => {

--- a/runtime/src/dispute/operations.ts
+++ b/runtime/src/dispute/operations.ts
@@ -9,7 +9,7 @@
 
 import { PublicKey, SystemProgram, type AccountMeta } from "@solana/web3.js";
 import { toAnchorBytes } from "../utils/encoding.js";
-import type { Program } from "@coral-xyz/anchor";
+import type { AnchorProvider, Program } from "@coral-xyz/anchor";
 import type { AgencCoordination } from "../types/agenc_coordination.js";
 import type { Logger } from "../utils/logger.js";
 import { silentLogger } from "../utils/logger.js";
@@ -32,6 +32,7 @@ import {
   DISPUTE_STATUS_OFFSET,
   DISPUTE_TASK_OFFSET,
 } from "./types.js";
+import { createProgram } from "../idl.js";
 import { deriveDisputePda, deriveVotePda } from "./pda.js";
 import {
   findAgentPda,
@@ -149,6 +150,63 @@ export class DisputeOperations {
     ).taskSubmission?.fetchNullable?.(taskSubmissionPda);
 
     return taskSubmissionAccount ? taskSubmissionPda : null;
+  }
+
+  private buildInitiateDisputeBuilder(
+    program: Program<AgencCoordination>,
+    params: InitiateDisputeParams,
+    disputePda: PublicKey,
+    initiatorClaimPda: PublicKey | null,
+    taskSubmissionPda: PublicKey | null,
+    remainingAccounts: AccountMeta[],
+    mode: "default" | "legacyInitiateDispute",
+  ) {
+    const builder = (program.methods as any)
+      .initiateDispute(
+        toAnchorBytes(params.disputeId),
+        toAnchorBytes(params.taskId),
+        toAnchorBytes(params.evidenceHash),
+        params.resolutionType,
+        params.evidence,
+      )
+      .accountsPartial({
+        dispute: disputePda,
+        task: params.taskPda,
+        agent: this.agentPda,
+        ...(mode === "default"
+          ? { authorityRateLimit: this.authorityRateLimitPda }
+          : {}),
+        protocolConfig: this.protocolPda,
+        initiatorClaim: initiatorClaimPda ?? null,
+        workerAgent: params.workerAgentPda ?? null,
+        workerClaim: params.workerClaimPda ?? null,
+        ...(mode === "default" ? { taskSubmission: taskSubmissionPda } : {}),
+        authority: program.provider.publicKey,
+        systemProgram: SystemProgram.programId,
+      });
+
+    if (remainingAccounts.length > 0) {
+      builder.remainingAccounts(remainingAccounts);
+    }
+
+    return builder;
+  }
+
+  private async shouldRetryLegacyInitiateDispute(err: unknown): Promise<boolean> {
+    const message = err instanceof Error ? err.message : String(err);
+    if (
+      !message.includes("account: protocol_config") ||
+      !message.includes("AccountNotInitialized")
+    ) {
+      return false;
+    }
+
+    const authorityRateLimitAccount =
+      await this.program.provider.connection.getAccountInfo(
+        this.authorityRateLimitPda,
+        "confirmed",
+      );
+    return authorityRateLimitAccount === null;
   }
 
   // ==========================================================================
@@ -365,43 +423,53 @@ export class DisputeOperations {
         undefined,
         params.defendantWorkers,
       );
-
-      // The runtime patches local IDL account layouts ahead of the published
-      // protocol typings, so this builder needs a narrow escape hatch until the
-      // package catches up.
-      const builder = (this.program.methods as any)
-        .initiateDispute(
-          toAnchorBytes(params.disputeId),
-          toAnchorBytes(params.taskId),
-          toAnchorBytes(params.evidenceHash),
-          params.resolutionType,
-          params.evidence,
-        )
-        .accountsPartial({
-          dispute: disputePda,
-          task: params.taskPda,
-          agent: this.agentPda,
-          authorityRateLimit: this.authorityRateLimitPda,
-          protocolConfig: this.protocolPda,
-          initiatorClaim: initiatorClaimPda ?? null,
-          workerAgent: params.workerAgentPda ?? null,
-          workerClaim: params.workerClaimPda ?? null,
-          taskSubmission: taskSubmissionPda,
-          authority: this.program.provider.publicKey,
-          systemProgram: SystemProgram.programId,
-        });
-
-      if (remainingAccounts.length > 0) {
-        builder.remainingAccounts(remainingAccounts);
-      }
-
-      const signature = await builder.rpc();
+      const signature = await this.buildInitiateDisputeBuilder(
+        this.program,
+        params,
+        disputePda,
+        initiatorClaimPda,
+        taskSubmissionPda,
+        remainingAccounts,
+        "default",
+      ).rpc();
 
       this.logger.info(`Dispute initiated: ${signature}`);
       this.recordDisputeMetrics("initiate", Date.now() - start);
 
       return { disputePda, transactionSignature: signature };
     } catch (err) {
+      if (await this.shouldRetryLegacyInitiateDispute(err)) {
+        this.logger.warn(
+          "Retrying dispute initiation with legacy devnet account layout compatibility",
+        );
+
+        const legacyProgram = createProgram(
+          this.program.provider as AnchorProvider,
+          this.program.programId,
+          "legacyInitiateDispute",
+        );
+        const remainingAccounts = this.buildRemainingAccounts(
+          undefined,
+          params.defendantWorkers,
+        );
+        const signature = await this.buildInitiateDisputeBuilder(
+          legacyProgram,
+          params,
+          disputePda,
+          initiatorClaimPda,
+          taskSubmissionPda,
+          remainingAccounts,
+          "legacyInitiateDispute",
+        ).rpc();
+
+        this.logger.info(
+          `Dispute initiated via legacy compatibility path: ${signature}`,
+        );
+        this.recordDisputeMetrics("initiate", Date.now() - start);
+
+        return { disputePda, transactionSignature: signature };
+      }
+
       const pda = disputePda.toBase58();
       if (isAnchorError(err, AnchorErrorCodes.InsufficientEvidence)) {
         throw new DisputeResolutionError(pda, "Insufficient evidence provided");

--- a/runtime/src/idl.test.ts
+++ b/runtime/src/idl.test.ts
@@ -140,6 +140,29 @@ describe('IDL exports', () => {
     ]);
   });
 
+  it('supports the legacy initiate_dispute account order for devnet compatibility', () => {
+    const connection = new Connection('http://127.0.0.1:8899', 'confirmed');
+    const wallet = new Wallet(Keypair.generate());
+    const provider = new AnchorProvider(connection, wallet, { commitment: 'confirmed' });
+    const customId = Keypair.generate().publicKey;
+    const program = createProgram(provider, customId, 'legacyInitiateDispute');
+    const initiateDispute = program.idl.instructions.find(
+      (ix: { name: string }) => ix.name === 'initiateDispute',
+    );
+
+    expect(initiateDispute.accounts.map((account: { name: string }) => account.name)).toEqual([
+      'dispute',
+      'task',
+      'agent',
+      'protocolConfig',
+      'initiatorClaim',
+      'workerAgent',
+      'workerClaim',
+      'authority',
+      'systemProgram',
+    ]);
+  });
+
   it('has accounts array with entries', () => {
     expect(Array.isArray(IDL.accounts)).toBe(true);
     expect(IDL.accounts.length).toBeGreaterThan(0);

--- a/runtime/src/idl.ts
+++ b/runtime/src/idl.ts
@@ -23,6 +23,7 @@ export type { AgencCoordination };
 
 type NamedIdlEntry = { name: string };
 type NamedIdlInstruction = NamedIdlEntry & { accounts?: unknown[] };
+export type ProgramLayoutMode = "default" | "legacyInitiateDispute";
 
 // The published protocol package currently diverges from the deployed
 // marketplace/task-dispute account layouts on devnet. Override the stale
@@ -329,6 +330,85 @@ const MARKETPLACE_ACCOUNT_LAYOUT_OVERRIDES = {
     },
   ],
 } as const;
+
+const LEGACY_INITIATE_DISPUTE_ACCOUNT_LAYOUT = [
+  {
+    name: "dispute",
+    writable: true,
+    pda: {
+      seeds: [
+        { kind: "const", value: [100, 105, 115, 112, 117, 116, 101] },
+        { kind: "arg", path: "dispute_id" },
+      ],
+    },
+  },
+  {
+    name: "task",
+    writable: true,
+    pda: {
+      seeds: [
+        { kind: "const", value: [116, 97, 115, 107] },
+        { kind: "account", path: "task.creator", account: "Task" },
+        { kind: "account", path: "task.task_id", account: "Task" },
+      ],
+    },
+  },
+  {
+    name: "agent",
+    writable: true,
+    pda: {
+      seeds: [
+        { kind: "const", value: [97, 103, 101, 110, 116] },
+        {
+          kind: "account",
+          path: "agent.agent_id",
+          account: "AgentRegistration",
+        },
+      ],
+    },
+  },
+  {
+    name: "protocol_config",
+    pda: {
+      seeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108] }],
+    },
+  },
+  {
+    name: "initiator_claim",
+    docs: ["Optional: Initiator's claim if they are a worker (not the creator)"],
+    optional: true,
+    pda: {
+      seeds: [
+        { kind: "const", value: [99, 108, 97, 105, 109] },
+        { kind: "account", path: "task" },
+        { kind: "account", path: "agent" },
+      ],
+    },
+  },
+  {
+    name: "worker_agent",
+    docs: [
+      "Optional: Worker agent to be disputed (required when initiator is task creator)",
+    ],
+    writable: true,
+    optional: true,
+  },
+  {
+    name: "worker_claim",
+    docs: ["Optional: Worker's claim (required when worker_agent is provided)"],
+    optional: true,
+  },
+  {
+    name: "authority",
+    writable: true,
+    signer: true,
+    relations: ["agent"],
+  },
+  {
+    name: "system_program",
+    address: "11111111111111111111111111111111",
+  },
+] as const;
 
 // The published protocol package can lag behind the runtime's supported V2 flow.
 // Merge these entries in locally so Program.methods exposes the task validation
@@ -1315,12 +1395,16 @@ function mergeIdlEntries<T extends NamedIdlEntry>(
 
 function overrideInstructionAccounts(
   existing: readonly NamedIdlInstruction[] | undefined,
+  mode: ProgramLayoutMode = "default",
 ): NamedIdlInstruction[] {
   return (existing ?? []).map((instruction) => {
     const override =
-      MARKETPLACE_ACCOUNT_LAYOUT_OVERRIDES[
-        instruction.name as keyof typeof MARKETPLACE_ACCOUNT_LAYOUT_OVERRIDES
-      ];
+      mode === "legacyInitiateDispute" &&
+      instruction.name === "initiate_dispute"
+        ? LEGACY_INITIATE_DISPUTE_ACCOUNT_LAYOUT
+        : MARKETPLACE_ACCOUNT_LAYOUT_OVERRIDES[
+            instruction.name as keyof typeof MARKETPLACE_ACCOUNT_LAYOUT_OVERRIDES
+          ];
     if (!override) {
       return instruction;
     }
@@ -1331,13 +1415,17 @@ function overrideInstructionAccounts(
   });
 }
 
-function augmentIdl(baseIdl: Idl): Idl {
+function augmentIdl(
+  baseIdl: Idl,
+  mode: ProgramLayoutMode = "default",
+): Idl {
   return {
     ...baseIdl,
     instructions: mergeIdlEntries(
       mergeIdlEntries(
         overrideInstructionAccounts(
           baseIdl.instructions as NamedIdlInstruction[] | undefined,
+          mode,
         ) as unknown as NamedIdlEntry[],
         TASK_VALIDATION_V2_INSTRUCTIONS as unknown as NamedIdlEntry[],
       ),
@@ -1368,6 +1456,11 @@ function augmentIdl(baseIdl: Idl): Idl {
  */
 export const IDL: Idl = {
   ...augmentIdl(AGENC_COORDINATION_IDL as Idl),
+  address: PROGRAM_ID.toBase58(),
+};
+
+const LEGACY_INITIATE_DISPUTE_IDL: Idl = {
+  ...augmentIdl(AGENC_COORDINATION_IDL as Idl, "legacyInitiateDispute"),
   address: PROGRAM_ID.toBase58(),
 };
 
@@ -1406,12 +1499,16 @@ export function validateIdl(idl: Idl = IDL): void {
  *
  * @internal
  */
-function getIdlForProgram(programId: PublicKey): Idl {
+function getIdlForProgram(
+  programId: PublicKey,
+  mode: ProgramLayoutMode = "default",
+): Idl {
+  const baseIdl = mode === "legacyInitiateDispute" ? LEGACY_INITIATE_DISPUTE_IDL : IDL;
   if (programId.equals(PROGRAM_ID)) {
-    return IDL;
+    return baseIdl;
   }
   // Create IDL copy with custom program address for local testing
-  return { ...IDL, address: programId.toBase58() };
+  return { ...baseIdl, address: programId.toBase58() };
 }
 
 /**
@@ -1457,12 +1554,13 @@ function createReadOnlyProvider(connection: Connection): AnchorProvider {
 export function createProgram(
   provider: AnchorProvider,
   programId: PublicKey = PROGRAM_ID,
+  mode: ProgramLayoutMode = "default",
 ): Program<AgencCoordination> {
   validateIdl();
   // Cast to AgencCoordination for type-safe Program access
   // Anchor's Program class handles snake_case ↔ camelCase mapping internally
   return new Program<AgencCoordination>(
-    getIdlForProgram(programId) as AgencCoordination,
+    getIdlForProgram(programId, mode) as AgencCoordination,
     provider,
   );
 }
@@ -1485,12 +1583,13 @@ export function createProgram(
 export function createReadOnlyProgram(
   connection: Connection,
   programId: PublicKey = PROGRAM_ID,
+  mode: ProgramLayoutMode = "default",
 ): Program<AgencCoordination> {
   validateIdl();
   // Cast to AgencCoordination for type-safe Program access
   // Anchor's Program class handles snake_case ↔ camelCase mapping internally
   return new Program<AgencCoordination>(
-    getIdlForProgram(programId) as AgencCoordination,
+    getIdlForProgram(programId, mode) as AgencCoordination,
     createReadOnlyProvider(connection),
   );
 }


### PR DESCRIPTION
## Summary
- add a legacy `initiate_dispute` IDL/program layout mode for older devnet dispute flows
- retry dispute initiation with the legacy account layout when devnet returns the known `protocol_config` account initialization drift error
- cover the fallback with focused IDL and dispute operation tests

## Validation
- `npm run typecheck --workspace=@tetsuo-ai/runtime`
- `npm exec --workspace=@tetsuo-ai/runtime vitest run src/idl.test.ts src/dispute/operations.test.ts`

## Live devnet result
Using the current devnet program `2jdBSJ8U5ixfwgs1bRLPtRRnpZAPm8Xv1tEdu8yjHJC7`, the marketplace smoke now gets past the previous dispute-initiation failure and reaches the expected deferred state:
- task created
- task claimed
- dispute opened
- 3 arbiter votes recorded
- artifact written for next-day resolve after voting deadline

Artifact path from the successful run:
- `/var/folders/gd/mvb492r97z1bw8c0nzrwhj_m0000gp/T/agenc-marketplace-smoke/marketplace-devnet-smoke-1776804090763.json`
