### PR TITLE
Add CLI route support for reviewed task settlement

### DIFF
--- a/runtime/src/cli/index.test.ts
+++ b/runtime/src/cli/index.test.ts
@@ -41,6 +41,8 @@ const {
   runMarketTasksListCommand,
   runMarketTaskCreateCommand,
   runMarketTaskClaimCommand,
+  runMarketTaskAcceptCommand,
+  runMarketTaskRejectCommand,
   runMarketGovernanceVoteCommand,
   runMarketInspectCommand,
   runMarketReputationSummaryCommand,
@@ -48,6 +50,8 @@ const {
   runMarketTasksListCommand: vi.fn(async () => 0),
   runMarketTaskCreateCommand: vi.fn(async () => 0),
   runMarketTaskClaimCommand: vi.fn(async () => 0),
+  runMarketTaskAcceptCommand: vi.fn(async () => 0),
+  runMarketTaskRejectCommand: vi.fn(async () => 0),
   runMarketGovernanceVoteCommand: vi.fn(async () => 0),
   runMarketInspectCommand: vi.fn(async () => 0),
   runMarketReputationSummaryCommand: vi.fn(async () => 0),
@@ -103,6 +107,8 @@ vi.mock("./marketplace-cli.js", async () => {
     runMarketTasksListCommand,
     runMarketTaskCreateCommand,
     runMarketTaskClaimCommand,
+    runMarketTaskAcceptCommand,
+    runMarketTaskRejectCommand,
     runMarketGovernanceVoteCommand,
     runMarketInspectCommand,
     runMarketReputationSummaryCommand,
@@ -838,6 +844,69 @@ describe("runtime root CLI", () => {
         requiredCapabilities: "1",
         validationMode: "creator-review",
         reviewWindowSecs: 120,
+      }),
+    );
+  });
+
+  it("routes market task acceptance through the root CLI command surface", async () => {
+    const stdout = captureStream();
+    const stderr = captureStream();
+
+    const code = await runCli({
+      argv: [
+        "market",
+        "tasks",
+        "accept",
+        "Task111111111111111111111111111111111111111",
+        "--worker-agent-pda",
+        "Agent11111111111111111111111111111111111111",
+        "--output",
+        "json",
+      ],
+      stdout: stdout.stream,
+      stderr: stderr.stream,
+    });
+
+    expect(code).toBe(0);
+    expect(stderr.data()).toBe("");
+    expect(runMarketTaskAcceptCommand).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        taskPda: "Task111111111111111111111111111111111111111",
+        workerAgentPda: "Agent11111111111111111111111111111111111111",
+      }),
+    );
+  });
+
+  it("routes market task rejection through the root CLI command surface", async () => {
+    const stdout = captureStream();
+    const stderr = captureStream();
+
+    const code = await runCli({
+      argv: [
+        "market",
+        "tasks",
+        "reject",
+        "Task111111111111111111111111111111111111111",
+        "--worker-agent-pda",
+        "Agent11111111111111111111111111111111111111",
+        "--reason",
+        "Need another pass on the delivery",
+        "--output",
+        "json",
+      ],
+      stdout: stdout.stream,
+      stderr: stderr.stream,
+    });
+
+    expect(code).toBe(0);
+    expect(stderr.data()).toBe("");
+    expect(runMarketTaskRejectCommand).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        taskPda: "Task111111111111111111111111111111111111111",
+        workerAgentPda: "Agent11111111111111111111111111111111111111",
+        reason: "Need another pass on the delivery",
       }),
     );
   });

--- a/runtime/src/cli/marketplace-cli.ts
+++ b/runtime/src/cli/marketplace-cli.ts
@@ -111,6 +111,15 @@ export interface MarketTaskCompleteOptions extends MarketTaskDetailOptions {
   workerAgentPda?: string;
 }
 
+export interface MarketTaskAcceptOptions extends MarketTaskDetailOptions {
+  workerAgentPda?: string;
+}
+
+export interface MarketTaskRejectOptions extends MarketTaskDetailOptions {
+  workerAgentPda?: string;
+  reason: string;
+}
+
 export interface MarketTaskDisputeOptions extends MarketTaskDetailOptions {
   evidence: string;
   resolutionType?: string;
@@ -197,6 +206,8 @@ export type MarketCommandOptions =
   | MarketTaskCancelOptions
   | MarketTaskClaimOptions
   | MarketTaskCompleteOptions
+  | MarketTaskAcceptOptions
+  | MarketTaskRejectOptions
   | MarketTaskDisputeOptions
   | MarketSkillsListOptions
   | MarketSkillDetailOptions
@@ -1311,6 +1322,148 @@ export async function runMarketTaskCompleteCommand(
     context.error({
       status: "error",
       code: "MARKET_TASK_COMPLETE_FAILED",
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return 1;
+  }
+}
+
+export async function runMarketTaskAcceptCommand(
+  context: CliRuntimeContext,
+  options: MarketTaskAcceptOptions,
+): Promise<CliStatusCode> {
+  if (!requireRpcUrl(context, options)) return 1;
+
+  try {
+    const { program } = await createSignerProgramContext(options);
+    const taskPda = new PublicKey(options.taskPda);
+    const workerAgentPda = options.workerAgentPda?.trim();
+    if (!workerAgentPda) {
+      context.error({
+        status: "error",
+        code: "MARKET_TASK_ACCEPT_FAILED",
+        message:
+          "market tasks accept requires --worker-agent-pda <agentPda>",
+      });
+      return 1;
+    }
+
+    const ops = new TaskOperations({
+      program,
+      agentId: ZERO_AGENT_ID,
+      logger: silentLogger,
+    });
+    const task = await ops.fetchTask(taskPda);
+    if (!task) {
+      context.error({
+        status: "error",
+        code: "MARKET_TASK_NOT_FOUND",
+        message: `Task not found: ${options.taskPda}`,
+      });
+      return 1;
+    }
+
+    const result = await ops.acceptTaskResult(
+      taskPda,
+      task,
+      new PublicKey(workerAgentPda),
+    );
+
+    context.output({
+      status: "ok",
+      command: "market.tasks.accept",
+      schema: "market.tasks.accept.output.v1",
+      result: {
+        taskPda: taskPda.toBase58(),
+        workerAgentPda,
+        taskId: Buffer.from(result.taskId).toString("hex"),
+        transactionSignature: result.transactionSignature,
+      },
+    });
+    return 0;
+  } catch (error) {
+    context.error({
+      status: "error",
+      code: "MARKET_TASK_ACCEPT_FAILED",
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return 1;
+  }
+}
+
+export async function runMarketTaskRejectCommand(
+  context: CliRuntimeContext,
+  options: MarketTaskRejectOptions,
+): Promise<CliStatusCode> {
+  if (!requireRpcUrl(context, options)) return 1;
+
+  try {
+    const { program } = await createSignerProgramContext(options);
+    const taskPda = new PublicKey(options.taskPda);
+    const workerAgentPda = options.workerAgentPda?.trim();
+    if (!workerAgentPda) {
+      context.error({
+        status: "error",
+        code: "MARKET_TASK_REJECT_FAILED",
+        message:
+          "market tasks reject requires --worker-agent-pda <agentPda>",
+      });
+      return 1;
+    }
+
+    const rejectionReason = options.reason.trim();
+    if (!rejectionReason) {
+      context.error({
+        status: "error",
+        code: "MARKET_TASK_REJECT_FAILED",
+        message: "market tasks reject requires --reason <text>",
+      });
+      return 1;
+    }
+
+    const ops = new TaskOperations({
+      program,
+      agentId: ZERO_AGENT_ID,
+      logger: silentLogger,
+    });
+    const task = await ops.fetchTask(taskPda);
+    if (!task) {
+      context.error({
+        status: "error",
+        code: "MARKET_TASK_NOT_FOUND",
+        message: `Task not found: ${options.taskPda}`,
+      });
+      return 1;
+    }
+
+    const rejectionHash = createHash("sha256")
+      .update(rejectionReason)
+      .digest();
+    const result = await ops.rejectTaskResult(
+      taskPda,
+      task,
+      new PublicKey(workerAgentPda),
+      rejectionHash,
+    );
+
+    context.output({
+      status: "ok",
+      command: "market.tasks.reject",
+      schema: "market.tasks.reject.output.v1",
+      result: {
+        taskPda: taskPda.toBase58(),
+        workerAgentPda,
+        taskId: Buffer.from(result.taskId).toString("hex"),
+        taskSubmissionPda: result.taskSubmissionPda.toBase58(),
+        rejectionHash: rejectionHash.toString("hex"),
+        transactionSignature: result.transactionSignature,
+      },
+    });
+    return 0;
+  } catch (error) {
+    context.error({
+      status: "error",
+      code: "MARKET_TASK_REJECT_FAILED",
       message: error instanceof Error ? error.message : String(error),
     });
     return 1;

--- a/runtime/src/cli/route-support.ts
+++ b/runtime/src/cli/route-support.ts
@@ -80,6 +80,8 @@ import type {
   MarketSkillsListOptions,
   MarketTaskClaimOptions,
   MarketTaskCompleteOptions,
+  MarketTaskAcceptOptions,
+  MarketTaskRejectOptions,
   MarketTaskDetailOptions,
   MarketTaskDisputeOptions,
   MarketTasksListOptions,
@@ -103,10 +105,12 @@ import {
   runMarketSkillPurchaseCommand,
   runMarketSkillRateCommand,
   runMarketSkillsListCommand,
+  runMarketTaskAcceptCommand,
   runMarketTaskClaimCommand,
   runMarketTaskCompleteCommand,
   runMarketTaskDetailCommand,
   runMarketTaskDisputeCommand,
+  runMarketTaskRejectCommand,
   runMarketTasksListCommand,
 } from "./marketplace-cli.js";
 import type { MarketTuiOptions } from "./marketplace-tui.js";
@@ -629,6 +633,8 @@ type MarketCommand =
   | "tasks.cancel"
   | "tasks.claim"
   | "tasks.complete"
+  | "tasks.accept"
+  | "tasks.reject"
   | "tasks.dispute"
   | "skills.list"
   | "skills.detail"
@@ -674,6 +680,8 @@ const MARKET_COMMAND_OPTIONS: Record<MarketCommand, Set<string>> = {
   "tasks.cancel": new Set(),
   "tasks.claim": new Set(["worker-agent-pda", "job-spec-store-dir"]),
   "tasks.complete": new Set(["proof-hash", "result-data", "worker-agent-pda"]),
+  "tasks.accept": new Set(["worker-agent-pda"]),
+  "tasks.reject": new Set(["worker-agent-pda", "reason"]),
   "tasks.dispute": new Set([
     "evidence",
     "resolution-type",
@@ -749,6 +757,18 @@ const MARKET_COMMANDS: Record<MarketCommand, MarketCommandDescriptor> = {
     description: "Complete a marketplace task",
     commandOptions: MARKET_COMMAND_OPTIONS["tasks.complete"],
     run: runMarketTaskCompleteCommand as MarketCommandDescriptor["run"],
+  },
+  "tasks.accept": {
+    name: "tasks.accept",
+    description: "Accept a creator-reviewed marketplace task submission",
+    commandOptions: MARKET_COMMAND_OPTIONS["tasks.accept"],
+    run: runMarketTaskAcceptCommand as MarketCommandDescriptor["run"],
+  },
+  "tasks.reject": {
+    name: "tasks.reject",
+    description: "Reject a creator-reviewed marketplace task submission",
+    commandOptions: MARKET_COMMAND_OPTIONS["tasks.reject"],
+    run: runMarketTaskRejectCommand as MarketCommandDescriptor["run"],
   },
   "tasks.dispute": {
     name: "tasks.dispute",
@@ -856,6 +876,8 @@ function validateMarketCommand(name: string): name is MarketCommand {
     name === "tasks.cancel" ||
     name === "tasks.claim" ||
     name === "tasks.complete" ||
+    name === "tasks.accept" ||
+    name === "tasks.reject" ||
     name === "tasks.dispute" ||
     name === "skills.list" ||
     name === "skills.detail" ||
@@ -2974,6 +2996,44 @@ function normalizeAndValidateMarketCommand(
         resultData: parseOptionalStringFlag(parsed.flags["result-data"]),
         workerAgentPda: parseOptionalStringFlag(parsed.flags["worker-agent-pda"]),
       } as MarketTaskCompleteOptions;
+      break;
+    }
+    case "tasks.accept": {
+      const taskPda = parsed.positional[3];
+      if (!taskPda) {
+        throw createCliError(
+          "market tasks accept requires <taskPda>",
+          ERROR_CODES.MISSING_TARGET,
+        );
+      }
+      options = {
+        ...base,
+        taskPda,
+        workerAgentPda: parseOptionalStringFlag(parsed.flags["worker-agent-pda"]),
+      } as MarketTaskAcceptOptions;
+      break;
+    }
+    case "tasks.reject": {
+      const taskPda = parsed.positional[3];
+      const reason = parseOptionalStringFlag(parsed.flags.reason);
+      if (!taskPda) {
+        throw createCliError(
+          "market tasks reject requires <taskPda>",
+          ERROR_CODES.MISSING_TARGET,
+        );
+      }
+      if (!reason) {
+        throw createCliError(
+          "market tasks reject requires --reason <text>",
+          ERROR_CODES.MISSING_REQUIRED_OPTION,
+        );
+      }
+      options = {
+        ...base,
+        taskPda,
+        reason,
+        workerAgentPda: parseOptionalStringFlag(parsed.flags["worker-agent-pda"]),
+      } as MarketTaskRejectOptions;
       break;
     }
     case "tasks.dispute": {


### PR DESCRIPTION
## Summary
- register tasks.accept and tasks.reject in the runtime CLI route support table
- wire the reviewed-task accept/reject command option parsing through the market command router
- cover the new routes in CLI tests so storefront creator-review settlement can call them reliably

## Testing
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm exec --workspace=@tetsuo-ai/runtime vitest run src/cli/index.test.ts