### PR TITLE
Guard reviewed task creation on unsupported devnet programs

### DIFF
--- a/runtime/src/tools/agenc/tools-task-templates.test.ts
+++ b/runtime/src/tools/agenc/tools-task-templates.test.ts
@@ -25,7 +25,10 @@ function createAgentRegistrationData(agentIdSeed: number) {
   return data;
 }
 
-function createMockTaskCreateProgram(jobSpecPublishError: Error) {
+function createMockTaskCreateProgram(
+  jobSpecPublishError: Error,
+  creatorReviewProbeError?: Error,
+) {
   const creator = PublicKey.unique();
   const creatorAgentPda = PublicKey.unique();
   const createTaskRpc = vi.fn(async () => "create-task-tx");
@@ -39,6 +42,16 @@ function createMockTaskCreateProgram(jobSpecPublishError: Error) {
   }));
   const setTaskJobSpec = vi.fn(() => ({
     accountsPartial: setTaskJobSpecAccountsPartial,
+  }));
+  const configureTaskValidationSimulate = vi.fn(async () => {
+    if (creatorReviewProbeError) throw creatorReviewProbeError;
+    throw new Error("Account does not exist");
+  });
+  const configureTaskValidationAccountsPartial = vi.fn(() => ({
+    simulate: configureTaskValidationSimulate,
+  }));
+  const configureTaskValidation = vi.fn(() => ({
+    accountsPartial: configureTaskValidationAccountsPartial,
   }));
 
   const program = {
@@ -56,6 +69,7 @@ function createMockTaskCreateProgram(jobSpecPublishError: Error) {
     },
     methods: {
       createTask,
+      configureTaskValidation,
       setTaskJobSpec,
     },
   };
@@ -64,7 +78,10 @@ function createMockTaskCreateProgram(jobSpecPublishError: Error) {
     program,
     creator,
     creatorAgentPda,
+    createTask,
     createTaskAccountsPartial,
+    configureTaskValidationAccountsPartial,
+    configureTaskValidationSimulate,
     setTaskJobSpecAccountsPartial,
   };
 }
@@ -139,6 +156,34 @@ describe("agenc task template tools", () => {
     expect(createTaskAccountsPartial.mock.calls[0]?.[0]).not.toHaveProperty(
       "authorityRateLimit",
     );
+  });
+
+  it("fails before task creation when the deployed program does not support creator-review validation", async () => {
+    const unsupportedInstructionError = new Error(
+      "InstructionFallbackNotFound\nFallback functions are not supported.",
+    );
+    const { program, createTask } = createMockTaskCreateProgram(
+      new Error("job spec publish should not run"),
+      unsupportedInstructionError,
+    );
+    const tool = createCreateTaskTool(program as never, createLogger() as never, {
+      allowRawTaskCreation: true,
+    });
+
+    const result = await tool.execute({
+      taskDescription: "Reviewed task blocked by old devnet ABI",
+      reward: "1",
+      requiredCapabilities: "1",
+      taskId: "12".repeat(32),
+      validationMode: "creator-review",
+      reviewWindowSecs: 3600,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content)).toMatchObject({
+      error: expect.stringContaining("does not support creator-review task validation yet"),
+    });
+    expect(createTask).not.toHaveBeenCalled();
   });
 
   it("uses taskDescription (not description) as the input schema property name", () => {

--- a/runtime/src/tools/agenc/tools.ts
+++ b/runtime/src/tools/agenc/tools.ts
@@ -537,6 +537,72 @@ function isUnsupportedJobSpecMetadataInstructionError(message: string): boolean 
   );
 }
 
+function isUnsupportedCreatorReviewInstructionError(message: string): boolean {
+  return isUnsupportedJobSpecMetadataInstructionError(message);
+}
+
+function createPlaceholderPublicKey(seed: number): PublicKey {
+  return new PublicKey(new Uint8Array(32).fill(seed));
+}
+
+async function assertCreatorReviewInstructionSupported(
+  program: Program<AgencCoordination>,
+  creator: PublicKey,
+  reviewWindowSecs: number,
+): Promise<void> {
+  const methods = program.methods as unknown as {
+    configureTaskValidation: (
+      validationMode: number,
+      reviewWindow: BN,
+      validatorQuorum: number,
+      attestor: PublicKey | null,
+    ) => {
+      accountsPartial: (accounts: Record<string, unknown>) => {
+        simulate?: () => Promise<unknown>;
+      };
+    };
+  };
+
+  if (typeof methods.configureTaskValidation !== 'function') {
+    throw new Error(
+      `Local runtime build does not expose configureTaskValidation for creator-review tasks on program ${program.programId.toBase58()}.`,
+    );
+  }
+
+  const probeTask = createPlaceholderPublicKey(11);
+  const probeValidationConfig = createPlaceholderPublicKey(12);
+  const probeAttestorConfig = createPlaceholderPublicKey(13);
+  const protocolPda = findProtocolPda(program.programId);
+
+  try {
+    const builder = methods
+      .configureTaskValidation(
+        Number(TaskValidationMode.CreatorReview),
+        new BN(reviewWindowSecs.toString()),
+        0,
+        null,
+      )
+      .accountsPartial({
+        task: probeTask,
+        taskValidationConfig: probeValidationConfig,
+        taskAttestorConfig: probeAttestorConfig,
+        protocolConfig: protocolPda,
+        creator,
+        systemProgram: SystemProgram.programId,
+      });
+
+    if (typeof builder.simulate !== 'function') return;
+    await builder.simulate();
+  } catch (error) {
+    const message = formatUnknownError(error);
+    if (isUnsupportedCreatorReviewInstructionError(message)) {
+      throw new Error(
+        `The deployed marketplace program ${program.programId.toBase58()} does not support creator-review task validation yet. Upgrade the protocol deployment or switch this task to validationMode="auto". Underlying error: ${message}`,
+      );
+    }
+  }
+}
+
 function formatJobSpecPublishWarning(error: unknown): string {
   const message = formatUnknownError(error);
   if (isUnsupportedJobSpecMetadataInstructionError(message)) {
@@ -2745,6 +2811,17 @@ export function createCreateTaskTool(
           validationMode !== TaskValidationMode.CreatorReview
         ) {
           return errorResult('reviewWindowSecs is only valid when validationMode is "creator-review"');
+        }
+        if (validationMode === TaskValidationMode.CreatorReview) {
+          try {
+            await assertCreatorReviewInstructionSupported(
+              program,
+              creator,
+              reviewWindowSecs,
+            );
+          } catch (error) {
+            return errorResult(formatUnknownError(error));
+          }
         }
 
         const [customConstraintHash, constraintHashErr] = parseOptionalHexBytes(


### PR DESCRIPTION
## Summary
- probe creator-review instruction support before creating raw marketplace tasks
- fail cleanly when the deployed program does not support `configure_task_validation`
- cover the unsupported-program path in task tool tests

## Why
This prevents `public_review` task creation from leaving orphan tasks on-chain when the target devnet program is still on an older ABI.