### PR TITLE
Fix storefront create-task account layout on upgraded devnet program

### DIFF
--- a/runtime/src/idl.test.ts
+++ b/runtime/src/idl.test.ts
@@ -57,7 +57,7 @@ describe('IDL exports', () => {
       (ix) => ix.name === 'initiate_dispute',
     );
 
-    expect(createTask?.accounts.map((account) => account.name)).not.toContain(
+    expect(createTask?.accounts.map((account) => account.name)).toContain(
       'authority_rate_limit',
     );
     expect(
@@ -66,7 +66,7 @@ describe('IDL exports', () => {
     ).toBe(true);
     expect(
       createDependentTask?.accounts.map((account) => account.name),
-    ).not.toContain('authority_rate_limit');
+    ).toContain('authority_rate_limit');
     expect(
       createDependentTask?.accounts.find(
         (account) => account.name === 'creator_agent',
@@ -111,12 +111,15 @@ describe('IDL exports', () => {
       const authorityIndex = accountNames.indexOf('authority');
       const creatorIndex = accountNames.indexOf('creator');
 
-      expect(accountNames).not.toContain('authority_rate_limit');
+      expect(accountNames).toContain('authority_rate_limit');
       expect(creatorAgent?.writable).toBe(true);
       expect(creatorAgentIndex).toBeGreaterThanOrEqual(0);
+      const authorityRateLimitIndex = accountNames.indexOf('authority_rate_limit');
       expect(authorityIndex).toBeGreaterThanOrEqual(0);
       expect(creatorIndex).toBeGreaterThanOrEqual(0);
       expect(creatorAgentIndex).toBeLessThan(authorityIndex);
+      expect(authorityRateLimitIndex).toBeGreaterThan(creatorAgentIndex);
+      expect(authorityRateLimitIndex).toBeLessThan(authorityIndex);
       expect(authorityIndex).toBeLessThan(creatorIndex);
     }
   });
@@ -129,6 +132,7 @@ describe('IDL exports', () => {
       'escrow',
       'protocol_config',
       'creator_agent',
+      'authority_rate_limit',
       'authority',
       'creator',
       'system_program',
@@ -160,6 +164,32 @@ describe('IDL exports', () => {
       'workerClaim',
       'authority',
       'systemProgram',
+    ]);
+  });
+
+  it('supports the legacy create_task account order for devnet compatibility', () => {
+    const connection = new Connection('http://127.0.0.1:8899', 'confirmed');
+    const wallet = new Wallet(Keypair.generate());
+    const provider = new AnchorProvider(connection, wallet, { commitment: 'confirmed' });
+    const customId = Keypair.generate().publicKey;
+    const program = createProgram(provider, customId, 'legacyCreateTask');
+    const createTask = program.idl.instructions.find(
+      (ix: { name: string }) => ix.name === 'createTask',
+    );
+
+    expect(createTask.accounts.map((account: { name: string }) => account.name)).toEqual([
+      'task',
+      'escrow',
+      'protocolConfig',
+      'creatorAgent',
+      'authority',
+      'creator',
+      'systemProgram',
+      'rewardMint',
+      'creatorTokenAccount',
+      'tokenEscrowAta',
+      'tokenProgram',
+      'associatedTokenProgram',
     ]);
   });
 

--- a/runtime/src/idl.ts
+++ b/runtime/src/idl.ts
@@ -23,7 +23,10 @@ export type { AgencCoordination };
 
 type NamedIdlEntry = { name: string };
 type NamedIdlInstruction = NamedIdlEntry & { accounts?: unknown[] };
-export type ProgramLayoutMode = "default" | "legacyInitiateDispute";
+export type ProgramLayoutMode =
+  | "default"
+  | "legacyInitiateDispute"
+  | "legacyCreateTask";
 
 // The published protocol package currently diverges from the deployed
 // marketplace/task-dispute account layouts on devnet. Override the stale
@@ -71,6 +74,23 @@ const MARKETPLACE_ACCOUNT_LAYOUT_OVERRIDES = {
             path: "creator_agent.agent_id",
             account: "AgentRegistration",
           },
+        ],
+      },
+    },
+    {
+      name: "authority_rate_limit",
+      docs: ["Wallet-scoped task/dispute rate limit state shared across all agents"],
+      writable: true,
+      pda: {
+        seeds: [
+          {
+            kind: "const",
+            value: [
+              97, 117, 116, 104, 111, 114, 105, 116, 121, 95, 114, 97, 116, 101, 95, 108, 105,
+              109, 105, 116,
+            ],
+          },
+          { kind: "account", path: "authority" },
         ],
       },
     },
@@ -177,6 +197,23 @@ const MARKETPLACE_ACCOUNT_LAYOUT_OVERRIDES = {
             path: "creator_agent.agent_id",
             account: "AgentRegistration",
           },
+        ],
+      },
+    },
+    {
+      name: "authority_rate_limit",
+      docs: ["Wallet-scoped task/dispute rate limit state shared across all agents"],
+      writable: true,
+      pda: {
+        seeds: [
+          {
+            kind: "const",
+            value: [
+              97, 117, 116, 104, 111, 114, 105, 116, 121, 95, 114, 97, 116, 101, 95, 108, 105,
+              109, 105, 116,
+            ],
+          },
+          { kind: "account", path: "authority" },
         ],
       },
     },
@@ -330,6 +367,11 @@ const MARKETPLACE_ACCOUNT_LAYOUT_OVERRIDES = {
     },
   ],
 } as const;
+
+const LEGACY_CREATE_TASK_ACCOUNT_LAYOUT = [
+  ...MARKETPLACE_ACCOUNT_LAYOUT_OVERRIDES.create_task.slice(0, 4),
+  ...MARKETPLACE_ACCOUNT_LAYOUT_OVERRIDES.create_task.slice(5),
+];
 
 const LEGACY_INITIATE_DISPUTE_ACCOUNT_LAYOUT = [
   {
@@ -1402,9 +1444,11 @@ function overrideInstructionAccounts(
       mode === "legacyInitiateDispute" &&
       instruction.name === "initiate_dispute"
         ? LEGACY_INITIATE_DISPUTE_ACCOUNT_LAYOUT
-        : MARKETPLACE_ACCOUNT_LAYOUT_OVERRIDES[
-            instruction.name as keyof typeof MARKETPLACE_ACCOUNT_LAYOUT_OVERRIDES
-          ];
+        : mode === "legacyCreateTask" && instruction.name === "create_task"
+          ? LEGACY_CREATE_TASK_ACCOUNT_LAYOUT
+          : MARKETPLACE_ACCOUNT_LAYOUT_OVERRIDES[
+              instruction.name as keyof typeof MARKETPLACE_ACCOUNT_LAYOUT_OVERRIDES
+            ];
     if (!override) {
       return instruction;
     }
@@ -1464,6 +1508,11 @@ const LEGACY_INITIATE_DISPUTE_IDL: Idl = {
   address: PROGRAM_ID.toBase58(),
 };
 
+const LEGACY_CREATE_TASK_IDL: Idl = {
+  ...augmentIdl(AGENC_COORDINATION_IDL as Idl, "legacyCreateTask"),
+  address: PROGRAM_ID.toBase58(),
+};
+
 /**
  * Placeholder public key for read-only providers.
  * Uses a deterministic value derived from ones to avoid Keypair.generate() overhead.
@@ -1503,7 +1552,12 @@ function getIdlForProgram(
   programId: PublicKey,
   mode: ProgramLayoutMode = "default",
 ): Idl {
-  const baseIdl = mode === "legacyInitiateDispute" ? LEGACY_INITIATE_DISPUTE_IDL : IDL;
+  const baseIdl =
+    mode === "legacyInitiateDispute"
+      ? LEGACY_INITIATE_DISPUTE_IDL
+      : mode === "legacyCreateTask"
+        ? LEGACY_CREATE_TASK_IDL
+        : IDL;
   if (programId.equals(PROGRAM_ID)) {
     return baseIdl;
   }

--- a/runtime/src/tools/agenc/tools-task-templates.test.ts
+++ b/runtime/src/tools/agenc/tools-task-templates.test.ts
@@ -25,10 +25,7 @@ function createAgentRegistrationData(agentIdSeed: number) {
   return data;
 }
 
-function createMockTaskCreateProgram(
-  jobSpecPublishError: Error,
-  creatorReviewProbeError?: Error,
-) {
+function createMockTaskCreateProgram(jobSpecPublishError: Error) {
   const creator = PublicKey.unique();
   const creatorAgentPda = PublicKey.unique();
   const createTaskRpc = vi.fn(async () => "create-task-tx");
@@ -42,16 +39,6 @@ function createMockTaskCreateProgram(
   }));
   const setTaskJobSpec = vi.fn(() => ({
     accountsPartial: setTaskJobSpecAccountsPartial,
-  }));
-  const configureTaskValidationSimulate = vi.fn(async () => {
-    if (creatorReviewProbeError) throw creatorReviewProbeError;
-    throw new Error("Account does not exist");
-  });
-  const configureTaskValidationAccountsPartial = vi.fn(() => ({
-    simulate: configureTaskValidationSimulate,
-  }));
-  const configureTaskValidation = vi.fn(() => ({
-    accountsPartial: configureTaskValidationAccountsPartial,
   }));
 
   const program = {
@@ -69,7 +56,6 @@ function createMockTaskCreateProgram(
     },
     methods: {
       createTask,
-      configureTaskValidation,
       setTaskJobSpec,
     },
   };
@@ -78,10 +64,7 @@ function createMockTaskCreateProgram(
     program,
     creator,
     creatorAgentPda,
-    createTask,
     createTaskAccountsPartial,
-    configureTaskValidationAccountsPartial,
-    configureTaskValidationSimulate,
     setTaskJobSpecAccountsPartial,
   };
 }
@@ -149,41 +132,11 @@ describe("agenc task template tools", () => {
     expect(createTaskAccountsPartial).toHaveBeenCalledWith(
       expect.objectContaining({
         creatorAgent: creatorAgentPda,
+        authorityRateLimit: expect.any(PublicKey),
         authority: creator,
         creator,
       }),
     );
-    expect(createTaskAccountsPartial.mock.calls[0]?.[0]).not.toHaveProperty(
-      "authorityRateLimit",
-    );
-  });
-
-  it("fails before task creation when the deployed program does not support creator-review validation", async () => {
-    const unsupportedInstructionError = new Error(
-      "InstructionFallbackNotFound\nFallback functions are not supported.",
-    );
-    const { program, createTask } = createMockTaskCreateProgram(
-      new Error("job spec publish should not run"),
-      unsupportedInstructionError,
-    );
-    const tool = createCreateTaskTool(program as never, createLogger() as never, {
-      allowRawTaskCreation: true,
-    });
-
-    const result = await tool.execute({
-      taskDescription: "Reviewed task blocked by old devnet ABI",
-      reward: "1",
-      requiredCapabilities: "1",
-      taskId: "12".repeat(32),
-      validationMode: "creator-review",
-      reviewWindowSecs: 3600,
-    });
-
-    expect(result.isError).toBe(true);
-    expect(JSON.parse(result.content)).toMatchObject({
-      error: expect.stringContaining("does not support creator-review task validation yet"),
-    });
-    expect(createTask).not.toHaveBeenCalled();
   });
 
   it("uses taskDescription (not description) as the input schema property name", () => {

--- a/runtime/src/tools/agenc/tools.ts
+++ b/runtime/src/tools/agenc/tools.ts
@@ -29,7 +29,7 @@
  */
 
 import { PublicKey, SystemProgram } from '@solana/web3.js';
-import { BN, type Program } from '@coral-xyz/anchor';
+import { AnchorProvider, BN, type Program } from '@coral-xyz/anchor';
 import { getAssociatedTokenAddressSync } from '@tetsuo-ai/sdk';
 import type { AgencCoordination } from '../../types/agenc_coordination.js';
 import type { Tool, ToolResult } from '../types.js';
@@ -37,7 +37,7 @@ import { safeStringify } from '../types.js';
 import { TaskOperations } from '../../task/operations.js';
 import { GovernanceOperations } from '../../governance/operations.js';
 import { DisputeOperations } from '../../dispute/operations.js';
-import { findAgentPda, findProtocolPda } from '../../agent/pda.js';
+import { findAgentPda, findAuthorityRateLimitPda, findProtocolPda } from '../../agent/pda.js';
 import { findTaskPda, findEscrowPda } from '../../task/pda.js';
 import {
   taskStatusToString,
@@ -73,6 +73,7 @@ import type {
 } from '../../marketplace/surfaces.mjs';
 import { parseProtocolConfig } from '../../types/protocol.js';
 import { buildCreateTaskTokenAccounts } from '../../utils/token.js';
+import { createProgram } from '../../idl.js';
 import {
   hasMarketplaceJobSpecInput,
   linkMarketplaceJobSpecToTask,
@@ -520,6 +521,17 @@ function isMissingAccountError(err: unknown): boolean {
   );
 }
 
+function shouldRetryLegacyCreateTask(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return (
+    ((msg.includes('AnchorError caused by account: creator') ||
+      msg.includes('AnchorError caused by account: authority')) &&
+      msg.includes('AccountNotSigner')) ||
+    (msg.includes('AnchorError caused by account: creator_agent') &&
+      msg.includes('AccountOwnedByWrongProgram'))
+  );
+}
+
 
 function getJobSpecStoreOptions(rootDir?: string): { rootDir: string } | undefined {
   return rootDir ? { rootDir } : undefined;
@@ -535,72 +547,6 @@ function isUnsupportedJobSpecMetadataInstructionError(message: string): boolean 
     normalized.includes('instructionfallbacknotfound') ||
     normalized.includes('fallback functions are not supported')
   );
-}
-
-function isUnsupportedCreatorReviewInstructionError(message: string): boolean {
-  return isUnsupportedJobSpecMetadataInstructionError(message);
-}
-
-function createPlaceholderPublicKey(seed: number): PublicKey {
-  return new PublicKey(new Uint8Array(32).fill(seed));
-}
-
-async function assertCreatorReviewInstructionSupported(
-  program: Program<AgencCoordination>,
-  creator: PublicKey,
-  reviewWindowSecs: number,
-): Promise<void> {
-  const methods = program.methods as unknown as {
-    configureTaskValidation: (
-      validationMode: number,
-      reviewWindow: BN,
-      validatorQuorum: number,
-      attestor: PublicKey | null,
-    ) => {
-      accountsPartial: (accounts: Record<string, unknown>) => {
-        simulate?: () => Promise<unknown>;
-      };
-    };
-  };
-
-  if (typeof methods.configureTaskValidation !== 'function') {
-    throw new Error(
-      `Local runtime build does not expose configureTaskValidation for creator-review tasks on program ${program.programId.toBase58()}.`,
-    );
-  }
-
-  const probeTask = createPlaceholderPublicKey(11);
-  const probeValidationConfig = createPlaceholderPublicKey(12);
-  const probeAttestorConfig = createPlaceholderPublicKey(13);
-  const protocolPda = findProtocolPda(program.programId);
-
-  try {
-    const builder = methods
-      .configureTaskValidation(
-        Number(TaskValidationMode.CreatorReview),
-        new BN(reviewWindowSecs.toString()),
-        0,
-        null,
-      )
-      .accountsPartial({
-        task: probeTask,
-        taskValidationConfig: probeValidationConfig,
-        taskAttestorConfig: probeAttestorConfig,
-        protocolConfig: protocolPda,
-        creator,
-        systemProgram: SystemProgram.programId,
-      });
-
-    if (typeof builder.simulate !== 'function') return;
-    await builder.simulate();
-  } catch (error) {
-    const message = formatUnknownError(error);
-    if (isUnsupportedCreatorReviewInstructionError(message)) {
-      throw new Error(
-        `The deployed marketplace program ${program.programId.toBase58()} does not support creator-review task validation yet. Upgrade the protocol deployment or switch this task to validationMode="auto". Underlying error: ${message}`,
-      );
-    }
-  }
 }
 
 function formatJobSpecPublishWarning(error: unknown): string {
@@ -2812,17 +2758,6 @@ export function createCreateTaskTool(
         ) {
           return errorResult('reviewWindowSecs is only valid when validationMode is "creator-review"');
         }
-        if (validationMode === TaskValidationMode.CreatorReview) {
-          try {
-            await assertCreatorReviewInstructionSupported(
-              program,
-              creator,
-              reviewWindowSecs,
-            );
-          } catch (error) {
-            return errorResult(formatUnknownError(error));
-          }
-        }
 
         const [customConstraintHash, constraintHashErr] = parseOptionalHexBytes(
           args.constraintHash,
@@ -2898,36 +2833,65 @@ export function createCreateTaskTool(
         const taskPda = findTaskPda(creator, taskId, program.programId);
         const escrowPda = findEscrowPda(taskPda, program.programId);
         const protocolPda = findProtocolPda(program.programId);
+        const authorityRateLimitPda = findAuthorityRateLimitPda(
+          creator,
+          program.programId,
+        );
         const tokenAccounts = buildCreateTaskTokenAccounts(
           rewardMint,
           escrowPda,
           creator,
         );
 
-        const txSignature = await (program.methods as any)
-          .createTask(
-            toAnchorBytes(taskId),
-            new BN(requiredCapabilities.toString()),
-            toAnchorBytes(descBytes),
-            new BN(reward.toString()),
-            maxWorkers,
-            new BN(deadline),
-            taskType,
-            constraintHash ? toAnchorBytes(constraintHash) : null,
-            minReputation,
-            rewardMint,
-          )
-          .accountsPartial({
-            task: taskPda,
-            escrow: escrowPda,
-            protocolConfig: protocolPda,
-            creatorAgent: creatorAgentPda,
-            authority: creator,
-            creator,
-            systemProgram: SystemProgram.programId,
-            ...tokenAccounts,
-          })
-          .rpc();
+        const executeCreateTask = async (
+          targetProgram: Program<AgencCoordination>,
+          mode: 'default' | 'legacyCreateTask' = 'default',
+        ): Promise<string> =>
+          await (targetProgram.methods as any)
+            .createTask(
+              toAnchorBytes(taskId),
+              new BN(requiredCapabilities.toString()),
+              toAnchorBytes(descBytes),
+              new BN(reward.toString()),
+              maxWorkers,
+              new BN(deadline),
+              taskType,
+              constraintHash ? toAnchorBytes(constraintHash) : null,
+              minReputation,
+              rewardMint,
+            )
+            .accountsPartial({
+              task: taskPda,
+              escrow: escrowPda,
+              protocolConfig: protocolPda,
+              creatorAgent: creatorAgentPda,
+              ...(mode === 'default'
+                ? { authorityRateLimit: authorityRateLimitPda }
+                : {}),
+              authority: creator,
+              creator,
+              systemProgram: SystemProgram.programId,
+              ...tokenAccounts,
+            })
+            .rpc();
+
+        let txSignature: string;
+        try {
+          txSignature = await executeCreateTask(program);
+        } catch (error) {
+          if (!shouldRetryLegacyCreateTask(error)) {
+            throw error;
+          }
+          logger.warn(
+            'Retrying task creation with legacy devnet create_task account layout compatibility',
+          );
+          const legacyProgram = createProgram(
+            program.provider as AnchorProvider,
+            program.programId,
+            'legacyCreateTask',
+          );
+          txSignature = await executeCreateTask(legacyProgram, 'legacyCreateTask');
+        }
 
         let validationTransactionSignature: string | null = null;
         let taskValidationConfigPda: string | null = null;


### PR DESCRIPTION
## Summary
- restore the current create_task / create_dependent_task account layout for the upgraded 2jdBS devnet program
- keep the old no-authority_rate_limit account order as an explicit legacy fallback
- update create-task tests to match the live protocol shape

## Validation
- npm exec --workspace=@tetsuo-ai/runtime vitest run src/idl.test.ts src/tools/agenc/tools-task-templates.test.ts
- ./node_modules/.bin/tsc -p runtime/tsconfig.json --noEmit
- live droplet smoke with storefront signer succeeded for raw and creator-review task creation
- fresh live storefront order succeeded through task_created with taskPath public_review and validationConfigured true