### PR TITLE
Support published remote task job spec pointers

### DIFF
--- a/runtime/src/cli/marketplace-cli.ts
+++ b/runtime/src/cli/marketplace-cli.ts
@@ -86,6 +86,7 @@ export interface MarketTaskCreateOptions extends BaseCliOptions {
   reviewWindowSecs?: number;
   creatorAgentPda?: string;
   jobSpec?: unknown;
+  jobSpecPublishUri?: string;
   fullDescription?: string;
   acceptanceCriteria?: string[];
   deliverables?: string[];
@@ -97,6 +98,7 @@ export interface MarketTaskCreateOptions extends BaseCliOptions {
 export interface MarketTaskDetailOptions extends BaseCliOptions {
   taskPda: string;
   jobSpecStoreDir?: string;
+  allowRemoteJobSpecResolution?: boolean;
 }
 
 export interface MarketTaskCancelOptions extends MarketTaskDetailOptions {}
@@ -509,8 +511,12 @@ type SerializedResolvedJobSpec = {
 
 function getJobSpecStoreOptions(
   rootDir?: string,
+  allowRemoteJobSpecResolution = false,
 ): MarketplaceJobSpecStoreOptions {
-  return rootDir ? { rootDir } : {};
+  return {
+    ...(rootDir ? { rootDir } : {}),
+    ...(allowRemoteJobSpecResolution ? { allowRemote: true } : {}),
+  };
 }
 
 function serializeJobSpecPointer(
@@ -584,8 +590,9 @@ async function enrichTaskDetailWithJobSpec<T extends { taskPda: string }>(
   task: T,
   rootDir?: string,
   program?: MarketProgram,
+  allowRemoteJobSpecResolution = false,
 ): Promise<T & { jobSpec: SerializedResolvedJobSpec | null }> {
-  const storeOptions = getJobSpecStoreOptions(rootDir);
+  const storeOptions = getJobSpecStoreOptions(rootDir, allowRemoteJobSpecResolution);
   if (program) {
     const taskPda = new PublicKey(task.taskPda);
     const onChainSpec = await resolveOnChainTaskJobSpecForTask(
@@ -1103,6 +1110,7 @@ export async function runMarketTaskCreateCommand(
       reviewWindowSecs: options.reviewWindowSecs,
       creatorAgentPda: options.creatorAgentPda,
       jobSpec: options.jobSpec,
+      jobSpecPublishUri: options.jobSpecPublishUri,
       fullDescription: options.fullDescription,
       acceptanceCriteria: options.acceptanceCriteria,
       deliverables: options.deliverables,
@@ -1174,6 +1182,7 @@ export async function runMarketTaskDetailCommand(
         taskDetail,
         options.jobSpecStoreDir,
         program,
+        options.allowRemoteJobSpecResolution,
       ),
     });
     return 0;
@@ -1248,12 +1257,17 @@ export async function runMarketTaskClaimCommand(
     const tool = createClaimTaskTool(
       program,
       silentLogger,
-      options.jobSpecStoreDir
-        ? {
-            jobSpecStoreDir: options.jobSpecStoreDir,
-            claimJobSpecVerification: "required",
-          }
-        : {},
+      {
+        ...(options.jobSpecStoreDir
+          ? {
+              jobSpecStoreDir: options.jobSpecStoreDir,
+            }
+          : {}),
+        ...(options.allowRemoteJobSpecResolution
+          ? { allowRemoteJobSpecResolution: true }
+          : {}),
+        claimJobSpecVerification: "required",
+      },
     );
     const result = await tool.execute({
       taskPda: options.taskPda,

--- a/runtime/src/cli/route-support.ts
+++ b/runtime/src/cli/route-support.ts
@@ -668,6 +668,7 @@ const MARKET_COMMAND_OPTIONS: Record<MarketCommand, Set<string>> = {
     "review-window-secs",
     "creator-agent-pda",
     "job-spec",
+    "job-spec-publish-uri",
     "full-description",
     "acceptance-criteria",
     "deliverables",
@@ -676,9 +677,9 @@ const MARKET_COMMAND_OPTIONS: Record<MarketCommand, Set<string>> = {
     "attachments",
     "job-spec-store-dir",
   ]),
-  "tasks.detail": new Set(["job-spec-store-dir"]),
+  "tasks.detail": new Set(["job-spec-store-dir", "allow-remote-job-spec"]),
   "tasks.cancel": new Set(),
-  "tasks.claim": new Set(["worker-agent-pda", "job-spec-store-dir"]),
+  "tasks.claim": new Set(["worker-agent-pda", "job-spec-store-dir", "allow-remote-job-spec"]),
   "tasks.complete": new Set(["proof-hash", "result-data", "worker-agent-pda"]),
   "tasks.accept": new Set(["worker-agent-pda"]),
   "tasks.reject": new Set(["worker-agent-pda", "reason"]),
@@ -1242,12 +1243,14 @@ export function buildHelp(): string {
     "      --review-window-secs <n>              Review window for creator-review task creation",
     "      --creator-agent-pda <pda>             Explicit creator agent PDA for task creation",
     "      --job-spec <text>                    Full off-chain job spec text for task creation",
+    "      --job-spec-publish-uri <url>         Published URI for the task job-spec pointer",
     "      --full-description <text>            Detailed off-chain task description",
     "      --acceptance-criteria <items>        Comma/newline-separated acceptance criteria",
     "      --deliverables <items>               Comma/newline-separated deliverables",
     "      --constraints <json>                 JSON constraints stored in the off-chain job spec",
     "      --attachment <url>                   Off-chain job spec attachment URL (repeatable)",
     "      --job-spec-store-dir <path>          Local content-addressed job spec store override",
+    "      --allow-remote-job-spec              Allow trusted remote https job spec resolution",
     "      --query <text>                        Text filter for skills list",
     "      --tags <t1,t2>                        Tag filter for skills list",
     "      --limit <n>                           Limit skills list results",
@@ -2922,6 +2925,7 @@ function normalizeAndValidateMarketCommand(
         reviewWindowSecs: parseOptionalNumberFlag(parsed.flags["review-window-secs"]),
         creatorAgentPda: parseOptionalStringFlag(parsed.flags["creator-agent-pda"]),
         jobSpec: parseOptionalStringFlag(parsed.flags["job-spec"]),
+        jobSpecPublishUri: parseOptionalStringFlag(parsed.flags["job-spec-publish-uri"]),
         fullDescription: parseOptionalStringFlag(parsed.flags["full-description"]),
         acceptanceCriteria: parseStringListFlag(parsed.flags["acceptance-criteria"]),
         deliverables: parseStringListFlag(parsed.flags.deliverables),
@@ -2949,6 +2953,7 @@ function normalizeAndValidateMarketCommand(
         jobSpecStoreDir: parseOptionalStringFlag(
           parsed.flags["job-spec-store-dir"],
         ),
+        allowRemoteJobSpecResolution: normalizeBool(parsed.flags["allow-remote-job-spec"], false),
       } as MarketTaskDetailOptions;
       break;
     }
@@ -2978,6 +2983,7 @@ function normalizeAndValidateMarketCommand(
         jobSpecStoreDir: parseOptionalStringFlag(
           parsed.flags["job-spec-store-dir"],
         ),
+        allowRemoteJobSpecResolution: normalizeBool(parsed.flags["allow-remote-job-spec"], false),
       } as MarketTaskClaimOptions;
       break;
     }

--- a/runtime/src/marketplace/job-spec-store.ts
+++ b/runtime/src/marketplace/job-spec-store.ts
@@ -628,7 +628,7 @@ function canonicalJobSpecUri(hash: string): string {
   return `agenc://job-spec/sha256/${hash}`;
 }
 
-function normalizeJobSpecReferenceUri(input: string, hash: string, field: string): string {
+export function normalizeJobSpecReferenceUri(input: string, hash: string, field: string): string {
   const uri = normalizeBoundedString(input, field, MAX_JOB_SPEC_URI_BYTES);
   const canonicalUri = canonicalJobSpecUri(hash);
   if (uri === canonicalUri) return uri;

--- a/runtime/src/tools/agenc/mutation-tools.ts
+++ b/runtime/src/tools/agenc/mutation-tools.ts
@@ -589,6 +589,7 @@ export function createClaimTaskTool(
   logger: Logger,
   options: {
     jobSpecStoreDir?: string;
+    allowRemoteJobSpecResolution?: boolean;
     claimJobSpecVerification?: "when-present" | "required" | "disabled";
   } = {},
 ): Tool {
@@ -627,6 +628,9 @@ export function createClaimTaskTool(
           logger,
           ...(options.jobSpecStoreDir
             ? { jobSpecStoreDir: options.jobSpecStoreDir }
+            : {}),
+          ...(options.allowRemoteJobSpecResolution
+            ? { allowRemoteJobSpecResolution: true }
             : {}),
           ...(options.claimJobSpecVerification
             ? { claimJobSpecVerification: options.claimJobSpecVerification }

--- a/runtime/src/tools/agenc/tools-task-templates.test.ts
+++ b/runtime/src/tools/agenc/tools-task-templates.test.ts
@@ -65,6 +65,7 @@ function createMockTaskCreateProgram(jobSpecPublishError: Error) {
     creator,
     creatorAgentPda,
     createTaskAccountsPartial,
+    setTaskJobSpec,
     setTaskJobSpecAccountsPartial,
   };
 }
@@ -102,6 +103,7 @@ describe("agenc task template tools", () => {
       creator,
       creatorAgentPda,
       createTaskAccountsPartial,
+      setTaskJobSpec,
       setTaskJobSpecAccountsPartial,
     } = createMockTaskCreateProgram(unsupportedInstructionError);
     const tool = createCreateTaskTool(program as never, createLogger() as never, {
@@ -117,6 +119,7 @@ describe("agenc task template tools", () => {
       jobSpec: {
         fullDescription: "Exercise unsupported job spec metadata on devnet.",
       },
+      jobSpecPublishUri: "https://marketplace-devnet.agenc.tech/api/job-specs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     });
     const payload = JSON.parse(result.content);
 
@@ -128,6 +131,10 @@ describe("agenc task template tools", () => {
     expect(payload.jobSpecPublishWarning).toContain("Task was created");
     expect(payload.jobSpecPublishWarning).toContain("does not support");
     expect(payload.jobSpecPublishWarning).toContain("InstructionFallbackNotFound");
+    expect(setTaskJobSpec).toHaveBeenCalledWith(
+      expect.any(Array),
+      "https://marketplace-devnet.agenc.tech/api/job-specs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    );
     expect(setTaskJobSpecAccountsPartial).toHaveBeenCalledOnce();
     expect(createTaskAccountsPartial).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/runtime/src/tools/agenc/tools.test.ts
+++ b/runtime/src/tools/agenc/tools.test.ts
@@ -27,7 +27,10 @@ import {
   createListTasksTool,
   createListSkillsTool,
 } from './tools.js';
-import { linkMarketplaceJobSpecToTask } from '../../marketplace/job-spec-store.js';
+import {
+  linkMarketplaceJobSpecToTask,
+  persistMarketplaceJobSpec,
+} from '../../marketplace/job-spec-store.js';
 
 function parseJson(result: ToolResult) {
   return JSON.parse(result.content) as Record<string, any>;
@@ -173,6 +176,42 @@ async function linkRemoteJobSpecForTask(
   );
 }
 
+async function linkTrustedRemoteJobSpecForTask(
+  taskPda: PublicKey,
+  task: OnChainTask,
+  jobSpecStoreDir: string,
+) {
+  const stored = await persistMarketplaceJobSpec(
+    {
+      description: 'Remote audit task',
+      fullDescription: 'Resolve from trusted storefront.',
+      acceptanceCriteria: ['Produce a verified payload'],
+    },
+    { rootDir: jobSpecStoreDir },
+  );
+  await linkMarketplaceJobSpecToTask(
+    {
+      hash: stored.hash,
+      uri: 'https://trusted.example/job-spec.json',
+      taskPda: taskPda.toBase58(),
+      taskId: Buffer.from(task.taskId).toString('hex'),
+      transactionSignature: 'remote-job-spec-test',
+    },
+    { rootDir: jobSpecStoreDir },
+  );
+  return {
+    schemaVersion: 1,
+    kind: 'agenc.marketplace.jobSpecEnvelope',
+    integrity: {
+      algorithm: 'sha256',
+      canonicalization: 'json-stable-v1',
+      payloadHash: stored.hash,
+      uri: stored.uri,
+    },
+    payload: stored.payload,
+  };
+}
+
 function createMockProgram() {
   const firstSkillPda = PublicKey.unique();
   const secondSkillPda = PublicKey.unique();
@@ -304,6 +343,33 @@ describe('agenc query tools', () => {
     expect(result.isError).toBe(true);
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(parsed.error).toMatch(/allowRemote=true/);
+  });
+
+  it('agenc.getJobSpec resolves remote job specs when explicitly allowed', async () => {
+    const taskPda = PublicKey.unique();
+    const task = makeTaskRecord({ status: OnChainTaskStatus.Open, currentWorkers: 0 });
+    const jobSpecStoreDir = await mkdtemp(join(tmpdir(), 'agenc-tool-job-spec-'));
+    const remoteEnvelope = await linkTrustedRemoteJobSpecForTask(taskPda, task, jobSpecStoreDir);
+    const fetchSpy = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => null },
+      text: async () => JSON.stringify(remoteEnvelope),
+    }));
+    vi.stubGlobal('fetch', fetchSpy);
+    const tool = createGetJobSpecTool(silentLogger, {
+      jobSpecStoreDir,
+      allowRemoteJobSpecResolution: true,
+    });
+
+    const result = await tool.execute({ taskPda: taskPda.toBase58() });
+    const parsed = parseJson(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(parsed.verified).toBe(true);
+    expect(parsed.payload.title).toBeTruthy();
   });
 
   it('agenc.listTasks payload enrichment does not fetch remote job specs by default', async () => {

--- a/runtime/src/tools/agenc/tools.ts
+++ b/runtime/src/tools/agenc/tools.ts
@@ -77,6 +77,7 @@ import { createProgram } from '../../idl.js';
 import {
   hasMarketplaceJobSpecInput,
   linkMarketplaceJobSpecToTask,
+  normalizeJobSpecReferenceUri,
   persistMarketplaceJobSpec,
   readMarketplaceJobSpecPointerForTask,
   resolveMarketplaceJobSpecReference,
@@ -151,10 +152,12 @@ export interface TaskTemplateToolOptions extends CreateTaskToolOptions {
 
 export interface GetJobSpecToolOptions {
   readonly jobSpecStoreDir?: string;
+  readonly allowRemoteJobSpecResolution?: boolean;
 }
 export interface TaskJobSpecQueryToolOptions {
   readonly program?: Program<AgencCoordination>;
   readonly jobSpecStoreDir?: string;
+  readonly allowRemoteJobSpecResolution?: boolean;
 }
 
 const KNOWN_MINTS: Record<string, { symbol: string; decimals: number }> = {
@@ -533,8 +536,15 @@ function shouldRetryLegacyCreateTask(err: unknown): boolean {
 }
 
 
-function getJobSpecStoreOptions(rootDir?: string): { rootDir: string } | undefined {
-  return rootDir ? { rootDir } : undefined;
+function getJobSpecStoreOptions(
+  rootDir?: string,
+  allowRemoteJobSpecResolution = false,
+): { rootDir?: string; allowRemote?: boolean } | undefined {
+  if (!rootDir && !allowRemoteJobSpecResolution) return undefined;
+  return {
+    ...(rootDir ? { rootDir } : {}),
+    ...(allowRemoteJobSpecResolution ? { allowRemote: true } : {}),
+  };
 }
 
 function formatUnknownError(error: unknown): string {
@@ -590,7 +600,10 @@ async function buildTaskJobSpecView(
   options: TaskJobSpecQueryToolOptions,
   includePayload: boolean,
 ): Promise<SerializedTaskJobSpec | null> {
-  const storeOptions = getJobSpecStoreOptions(options.jobSpecStoreDir);
+  const storeOptions = getJobSpecStoreOptions(
+    options.jobSpecStoreDir,
+    options.allowRemoteJobSpecResolution,
+  );
 
   if (options.program) {
     const onChainPointer = await fetchTaskJobSpecPointer(options.program, taskPda);
@@ -668,7 +681,10 @@ async function resolveTaskJobSpecPayloadOrThrow(
   taskPda: PublicKey,
   options: TaskJobSpecQueryToolOptions,
 ): Promise<Record<string, unknown>> {
-  const storeOptions = getJobSpecStoreOptions(options.jobSpecStoreDir);
+  const storeOptions = getJobSpecStoreOptions(
+    options.jobSpecStoreDir,
+    options.allowRemoteJobSpecResolution,
+  );
   const taskAddress = taskPda.toBase58();
   const localPointer = await readMarketplaceJobSpecPointerForTask(
     taskAddress,
@@ -2580,6 +2596,11 @@ export function createCreateTaskTool(
           description:
             'Optional full marketplace job spec. Stored off-chain as canonical JSON with a sha256 integrity hash; use for long requirements, scope, examples, and notes.',
         },
+        jobSpecPublishUri: {
+          type: 'string',
+          description:
+            'Optional published URI for the task job-spec pointer. Must be either the canonical agenc:// URI for the resulting hash or an absolute https URL that serves the canonical envelope.',
+        },
         fullDescription: {
           type: 'string',
           description: 'Optional long-form job description stored in the marketplace jobSpec object.',
@@ -2759,12 +2780,12 @@ export function createCreateTaskTool(
           return errorResult('reviewWindowSecs is only valid when validationMode is "creator-review"');
         }
 
-        const [customConstraintHash, constraintHashErr] = parseOptionalHexBytes(
-          args.constraintHash,
-          'constraintHash',
-          TASK_ID_BYTES,
-        );
-        if (constraintHashErr) return constraintHashErr;
+	        const [customConstraintHash, constraintHashErr] = parseOptionalHexBytes(
+	          args.constraintHash,
+	          'constraintHash',
+	          TASK_ID_BYTES,
+	        );
+	        if (constraintHashErr) return constraintHashErr;
         if (
           validationMode === TaskValidationMode.CreatorReview &&
           customConstraintHash !== null
@@ -2773,7 +2794,13 @@ export function createCreateTaskTool(
             'Do not provide constraintHash with validationMode="creator-review"; creator-review tasks are configured through validation settings',
           );
         }
-        const constraintHash = customConstraintHash;
+	        const constraintHash = customConstraintHash;
+
+	        const [jobSpecPublishUri, jobSpecPublishUriErr] = parseOptionalString(
+	          args.jobSpecPublishUri,
+	          'jobSpecPublishUri',
+	        );
+	        if (jobSpecPublishUriErr) return jobSpecPublishUriErr;
 
         const [rewardMint, rewardMintErr] = parseKnownRewardMint(args.rewardMint);
         if (rewardMintErr) return rewardMintErr;
@@ -2923,24 +2950,33 @@ export function createCreateTaskTool(
           }
         }
 
-        let taskJobSpecPda: string | null = null;
-        let jobSpecTransactionSignature: string | null = null;
-        let jobSpecPublishWarning: string | null = null;
-        if (storedJobSpec) {
-          try {
-            const published = await setTaskJobSpecPointer(
-              program,
-              creator,
-              taskPda,
-              storedJobSpec.hash,
-              storedJobSpec.uri,
-            );
-            taskJobSpecPda = published.taskJobSpecPda.toBase58();
-            jobSpecTransactionSignature = published.transactionSignature;
-          } catch (error) {
-            jobSpecPublishWarning = formatJobSpecPublishWarning(error);
-          }
-        }
+	        let taskJobSpecPda: string | null = null;
+	        let jobSpecTransactionSignature: string | null = null;
+	        let jobSpecPublishWarning: string | null = null;
+	        if (storedJobSpec) {
+	          try {
+	            const publishedJobSpecUri = normalizeJobSpecReferenceUri(
+	              jobSpecPublishUri ?? storedJobSpec.uri,
+	              storedJobSpec.hash,
+	              'jobSpecPublishUri',
+	            );
+	            const published = await setTaskJobSpecPointer(
+	              program,
+	              creator,
+	              taskPda,
+	              storedJobSpec.hash,
+	              publishedJobSpecUri,
+	            );
+	            taskJobSpecPda = published.taskJobSpecPda.toBase58();
+	            jobSpecTransactionSignature = published.transactionSignature;
+	            storedJobSpec = {
+	              ...storedJobSpec,
+	              uri: publishedJobSpecUri,
+	            };
+	          } catch (error) {
+	            jobSpecPublishWarning = formatJobSpecPublishWarning(error);
+	          }
+	        }
 
         let jobSpecTaskLinkPath: string | null = null;
         let jobSpecLinkWarning: string | null = null;


### PR DESCRIPTION
## Summary
- allow task creation to publish trusted remote job-spec URIs on-chain
- wire opt-in remote job-spec resolution through detail and claim flows
- expose the new CLI flags for published URIs and remote resolution
- add tests for published pointer handling and trusted remote resolution

## Validation
- ./node_modules/.bin/tsc -p runtime/tsconfig.json --noEmit
- npm exec --workspace=@tetsuo-ai/runtime vitest run src/tools/agenc/tools.test.ts src/tools/agenc/tools-task-templates.test.ts src/tools/agenc/mutation-tools.test.ts
- npm exec --workspace=@tetsuo-ai/runtime vitest run src/cli/index.test.ts