### PR TITLE
Normalize published job spec URIs to the canonical hash

### DIFF
--- a/runtime/src/marketplace/job-spec-store.ts
+++ b/runtime/src/marketplace/job-spec-store.ts
@@ -648,6 +648,22 @@ export function normalizeJobSpecReferenceUri(input: string, hash: string, field:
   if (!parsed.hostname) {
     throw new Error(`${field} must include a hostname`);
   }
+  if (uri.includes("{hash}")) {
+    return uri.replaceAll("{hash}", hash);
+  }
+
+  const segments = parsed.pathname.split("/");
+  const lastSegment = segments.at(-1) ?? "";
+  if (HASH_RE.test(lastSegment) && lastSegment !== hash) {
+    segments[segments.length - 1] = hash;
+    parsed.pathname = segments.join("/");
+    return parsed.toString();
+  }
+  if (parsed.pathname.endsWith("/")) {
+    parsed.pathname = `${parsed.pathname}${hash}`;
+    return parsed.toString();
+  }
+
   return uri;
 }
 

--- a/runtime/src/tools/agenc/tools-task-templates.test.ts
+++ b/runtime/src/tools/agenc/tools-task-templates.test.ts
@@ -133,7 +133,7 @@ describe("agenc task template tools", () => {
     expect(payload.jobSpecPublishWarning).toContain("InstructionFallbackNotFound");
     expect(setTaskJobSpec).toHaveBeenCalledWith(
       expect.any(Array),
-      "https://marketplace-devnet.agenc.tech/api/job-specs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      `https://marketplace-devnet.agenc.tech/api/job-specs/${payload.jobSpecHash}`,
     );
     expect(setTaskJobSpecAccountsPartial).toHaveBeenCalledOnce();
     expect(createTaskAccountsPartial).toHaveBeenCalledWith(

--- a/runtime/src/tools/agenc/tools.test.ts
+++ b/runtime/src/tools/agenc/tools.test.ts
@@ -180,6 +180,7 @@ async function linkTrustedRemoteJobSpecForTask(
   taskPda: PublicKey,
   task: OnChainTask,
   jobSpecStoreDir: string,
+  uri = 'https://trusted.example/job-spec.json',
 ) {
   const stored = await persistMarketplaceJobSpec(
     {
@@ -192,7 +193,7 @@ async function linkTrustedRemoteJobSpecForTask(
   await linkMarketplaceJobSpecToTask(
     {
       hash: stored.hash,
-      uri: 'https://trusted.example/job-spec.json',
+      uri,
       taskPda: taskPda.toBase58(),
       taskId: Buffer.from(task.taskId).toString('hex'),
       transactionSignature: 'remote-job-spec-test',
@@ -369,6 +370,41 @@ describe('agenc query tools', () => {
     expect(result.isError).toBeUndefined();
     expect(fetchSpy).toHaveBeenCalledOnce();
     expect(parsed.verified).toBe(true);
+    expect(parsed.payload.title).toBeTruthy();
+  });
+
+  it('agenc.getJobSpec normalizes trusted remote URIs that end with a stale hash segment', async () => {
+    const taskPda = PublicKey.unique();
+    const task = makeTaskRecord({ status: OnChainTaskStatus.Open, currentWorkers: 0 });
+    const jobSpecStoreDir = await mkdtemp(join(tmpdir(), 'agenc-tool-job-spec-'));
+    const remoteEnvelope = await linkTrustedRemoteJobSpecForTask(
+      taskPda,
+      task,
+      jobSpecStoreDir,
+      'https://trusted.example/api/job-specs/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    );
+    const fetchSpy = vi.fn(async (input: string | URL) => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => null },
+      text: async () => JSON.stringify(remoteEnvelope),
+    }));
+    vi.stubGlobal('fetch', fetchSpy);
+    const tool = createGetJobSpecTool(silentLogger, {
+      jobSpecStoreDir,
+      allowRemoteJobSpecResolution: true,
+    });
+
+    const result = await tool.execute({ taskPda: taskPda.toBase58() });
+    const parsed = parseJson(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `https://trusted.example/api/job-specs/${remoteEnvelope.integrity.payloadHash}`,
+      expect.any(Object),
+    );
+    expect(parsed.jobSpecHash).toBe(remoteEnvelope.integrity.payloadHash);
     expect(parsed.payload.title).toBeTruthy();
   });
 


### PR DESCRIPTION
## Summary
- normalize trusted remote job-spec URLs to the canonical runtime hash when publishing and resolving
- fix the storefront integration case where the client hands core a stale pre-runtime hash in the URL path
- add regression coverage for stale-hash remote resolution and publication

## Validation
- ./node_modules/.bin/tsc -p runtime/tsconfig.json --noEmit
- npm exec --workspace=@tetsuo-ai/runtime vitest run src/tools/agenc/tools.test.ts src/tools/agenc/tools-task-templates.test.ts