### PR TITLE
[codex] Add Codex OAuth LLM provider

### DIFF
--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -64,6 +64,7 @@ const program = createProgram(provider);
 | `llm/anthropic/` | `AnthropicProvider` | Anthropic adapter | `AnthropicProviderConfig` |
 | `llm/ollama/` | `OllamaProvider` | Ollama local adapter | `OllamaProviderConfig` |
 | `llm/openai-compat/` | `OpenAICompatProvider` | OpenAI-compatible local adapter (LM Studio, llama.cpp, vLLM) | `OpenAICompatProviderConfig` |
+| `llm/codex-oauth/` | `CodexOAuthProvider` | OpenAI Codex adapter using Codex CLI ChatGPT OAuth credentials | `CodexOAuthProviderConfig` |
 | `tools/` | `ToolRegistry` | MCP-compatible tool management | `ToolRegistryConfig` |
 | `memory/` | `InMemoryBackend` | Zero-dep memory storage | `InMemoryBackendConfig` |
 | `memory/sqlite/` | `SqliteBackend` | SQLite-backed storage | `SqliteBackendConfig` |
@@ -107,7 +108,7 @@ await runtime.stop();               // set Inactive + cleanup
 ### LLM Provider Selection
 
 ```typescript
-import { GrokProvider, AnthropicProvider, OllamaProvider } from '@tetsuo-ai/runtime';
+import { GrokProvider, AnthropicProvider, OllamaProvider, OpenAICompatProvider, CodexOAuthProvider } from '@tetsuo-ai/runtime';
 
 // Grok (requires: npm install openai)
 const grok = new GrokProvider({ apiKey: process.env.XAI_API_KEY!, model: 'grok-3', tools });
@@ -125,6 +126,12 @@ const local = new OpenAICompatProvider({
   baseUrl: 'http://127.0.0.1:1234/v1',
   apiKey: 'local',             // not validated by local servers
   contextWindowTokens: 32768,  // required — local servers don't expose this
+  tools,
+});
+
+// OpenAI Codex OAuth (requires Codex CLI signed in with ChatGPT)
+const codex = new CodexOAuthProvider({
+  model: 'gpt-5.4',
   tools,
 });
 ```
@@ -381,6 +388,33 @@ catalog: the server's `GET /v1/models` response is the authoritative source of t
 - When running untrusted models, set `workspace.hostPath` to a neutral directory to prevent autonomous file access during initial context loading.
 - LM Studio: set the context window in the model settings to match `contextWindowTokens`. The LM Studio default of 4096 is too small for most system prompts.
 - Use `provider: "ollama"` instead when using Ollama with its native SDK; `openai-compat` is the right choice when Ollama is running in OpenAI-compatibility mode or when using LM Studio / llama.cpp.
+
+### OpenAI Codex OAuth
+
+Use `provider: "codex"` to reuse the ChatGPT OAuth credentials created by the
+OpenAI Codex CLI. AgenC reads `$CODEX_HOME/auth.json` or `~/.codex/auth.json`,
+refreshes stale access tokens with the stored refresh token, and sends Responses
+API requests to the Codex backend.
+
+```json
+{
+  "llm": {
+    "provider": "codex",
+    "model": "gpt-5.4",
+    "timeoutMs": 0
+  }
+}
+```
+
+Optional overrides:
+- `codexHome`: directory containing `auth.json`
+- `codexAuthPath`: exact credential file path, taking precedence over `codexHome`
+- `baseUrl`: Codex backend override; defaults to `https://chatgpt.com/backend-api/codex`
+- `codexClientVersion`: value sent in the Codex `version` header
+
+Codex's backend request contract does not currently expose the generic
+`temperature` or `maxTokens` controls, so this provider omits them from outbound
+requests even if they are present in shared LLM config.
 
 ### LLMTaskExecutorConfig
 

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -129,6 +129,7 @@
     "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.4.0",
     "@types/ws": "^8.18.1",
+    "@vitest/coverage-v8": "^4.1.5",
     "anchor-litesvm": "^0.2.1",
     "bs58": "^6.0.0",
     "litesvm": "^0.6.0",

--- a/runtime/src/gateway/config-watcher.test.ts
+++ b/runtime/src/gateway/config-watcher.test.ts
@@ -82,6 +82,15 @@ describe("validateGatewayConfig desktop resource limits", () => {
     expect(result.valid).toBe(true);
   });
 
+  it("accepts Codex OAuth and OpenAI-compatible LLM providers", () => {
+    for (const provider of ["codex", "openai-compat"]) {
+      const config = makeConfig();
+      config.llm = { provider, model: "gpt-5.4" };
+      const result = validateGatewayConfig(config);
+      expect(result.valid).toBe(true);
+    }
+  });
+
   it("rejects invalid subagent open-question controls", () => {
     const config = makeConfig();
     config.llm = {

--- a/runtime/src/gateway/config-watcher.ts
+++ b/runtime/src/gateway/config-watcher.ts
@@ -85,6 +85,8 @@ const VALID_CLI_OUTPUT_FORMATS: ReadonlySet<string> = new Set([
 const VALID_LLM_PROVIDERS: ReadonlySet<string> = new Set([
   "grok",
   "ollama",
+  "openai-compat",
+  "codex",
 ]);
 const VALID_STOP_HOOK_PHASES = new Set<string>(STOP_HOOK_PHASES);
 const VALID_STOP_HOOK_KINDS = new Set<string>(STOP_HOOK_CONFIG_KINDS);

--- a/runtime/src/gateway/context-window.ts
+++ b/runtime/src/gateway/context-window.ts
@@ -4,6 +4,10 @@ import type {
   LLMContextWindowSource,
   LLMProviderExecutionProfile,
 } from "../llm/types.js";
+import {
+  DEFAULT_CODEX_OAUTH_CONTEXT_WINDOW_TOKENS,
+  DEFAULT_CODEX_OAUTH_MODEL,
+} from "../llm/codex-oauth/types.js";
 
 const DEFAULT_GROK_API_BASE_URL = "https://api.x.ai/v1";
 const DEFAULT_OLLAMA_HOST = "http://localhost:11434";
@@ -675,6 +679,9 @@ export function inferContextWindowTokens(
   if (llmConfig.provider === "ollama") {
     return DEFAULT_OLLAMA_CONTEXT_WINDOW_TOKENS;
   }
+  if (llmConfig.provider === "codex") {
+    return DEFAULT_CODEX_OAUTH_CONTEXT_WINDOW_TOKENS;
+  }
   return undefined;
 }
 
@@ -689,6 +696,9 @@ export async function resolveDynamicContextWindowTokens(
   if (llmConfig.provider === "ollama") {
     return (await resolveDynamicOllamaContextWindow(llmConfig, options))
       ?.contextWindowTokens;
+  }
+  if (llmConfig.provider === "codex") {
+    return DEFAULT_CODEX_OAUTH_CONTEXT_WINDOW_TOKENS;
   }
   return undefined;
 }
@@ -756,6 +766,19 @@ export async function resolveContextWindowProfile(
       model,
       contextWindowTokens: DEFAULT_OLLAMA_CONTEXT_WINDOW_TOKENS,
       contextWindowSource: "ollama_default",
+      maxOutputTokens: normalizeOptionalPositiveInt(llmConfig.maxTokens),
+    };
+  }
+
+  if (llmConfig.provider === "codex") {
+    const model = llmConfig.model?.trim() || DEFAULT_CODEX_OAUTH_MODEL;
+    return {
+      provider: "codex",
+      model,
+      contextWindowTokens:
+        explicit ?? DEFAULT_CODEX_OAUTH_CONTEXT_WINDOW_TOKENS,
+      contextWindowSource:
+        explicit !== undefined ? "explicit_config" : "codex_default",
       maxOutputTokens: normalizeOptionalPositiveInt(llmConfig.maxTokens),
     };
   }

--- a/runtime/src/gateway/llm-provider-manager.ts
+++ b/runtime/src/gateway/llm-provider-manager.ts
@@ -26,6 +26,10 @@ import {
   resolveDefaultGrokCompactionThreshold,
 } from "./llm-stateful-defaults.js";
 import { hasRuntimeLimit } from "../llm/runtime-limit-policy.js";
+import {
+  DEFAULT_CODEX_OAUTH_CONTEXT_WINDOW_TOKENS,
+  DEFAULT_CODEX_OAUTH_MODEL,
+} from "../llm/codex-oauth/types.js";
 
 // ============================================================================
 // Constants
@@ -232,7 +236,12 @@ function findConfiguredLlmConfigForProvider(
 
   const providerName = profile?.provider ?? provider.name;
   const normalizedProvider = providerName.toLowerCase();
-  if (normalizedProvider !== "grok" && normalizedProvider !== "ollama" && normalizedProvider !== "openai-compat") {
+  if (
+    normalizedProvider !== "grok" &&
+    normalizedProvider !== "ollama" &&
+    normalizedProvider !== "openai-compat" &&
+    normalizedProvider !== "codex"
+  ) {
     return primaryLlmConfig;
   }
 
@@ -411,6 +420,26 @@ export async function createSingleLLMProvider(
         ) ?? 32768, // AgenC system prompt requires >14K tokens; 4096 is too small
         timeoutMs,
         maxTokens: normalizeOptionalPositiveInt(maxTokens),
+        tools,
+      });
+    }
+    case "codex": {
+      const { CodexOAuthProvider } = await import(
+        "../llm/codex-oauth/adapter.js"
+      );
+      return new CodexOAuthProvider({
+        model: model ?? DEFAULT_CODEX_OAUTH_MODEL,
+        baseUrl,
+        codexHome: llmConfig.codexHome,
+        codexAuthPath: llmConfig.codexAuthPath,
+        refreshTokenUrl: llmConfig.refreshTokenUrl,
+        codexClientVersion: llmConfig.codexClientVersion,
+        contextWindowTokens:
+          normalizeOptionalPositiveInt(llmConfig.contextWindowTokens) ??
+          DEFAULT_CODEX_OAUTH_CONTEXT_WINDOW_TOKENS,
+        timeoutMs,
+        maxTokens: normalizeOptionalPositiveInt(maxTokens),
+        parallelToolCalls,
         tools,
       });
     }

--- a/runtime/src/gateway/types.ts
+++ b/runtime/src/gateway/types.ts
@@ -21,10 +21,18 @@ import type { UserHooksSettings } from "../llm/hooks/user-config.js";
 // ============================================================================
 
 export interface GatewayLLMConfig extends LLMXaiCapabilitySurface {
-  provider: "grok" | "ollama" | "openai-compat";
+  provider: "grok" | "ollama" | "openai-compat" | "codex";
   apiKey?: string;
   model?: string;
   baseUrl?: string;
+  /** OpenAI Codex OAuth: override `$CODEX_HOME`; defaults to process.env.CODEX_HOME or `~/.codex`. */
+  codexHome?: string;
+  /** OpenAI Codex OAuth: full path to a Codex `auth.json` credential file. */
+  codexAuthPath?: string;
+  /** OpenAI Codex OAuth: token refresh URL override for tests/private deployments. */
+  refreshTokenUrl?: string;
+  /** OpenAI Codex OAuth: version header sent to the Codex backend. */
+  codexClientVersion?: string;
   /** Maximum output tokens per completion (provider request parameter). 0 or undefined = provider default/unset. */
   maxTokens?: number;
   /** Model context window in tokens for adaptive prompt budgeting. 0 or undefined = infer from provider/model metadata. */

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -567,6 +567,14 @@ export {
   type GrokProviderConfig,
   OllamaProvider,
   type OllamaProviderConfig,
+  OpenAICompatProvider,
+  type OpenAICompatProviderConfig,
+  CodexOAuthProvider,
+  type CodexOAuthProviderConfig,
+  DEFAULT_CODEX_CLIENT_VERSION,
+  DEFAULT_CODEX_OAUTH_BASE_URL,
+  DEFAULT_CODEX_OAUTH_CONTEXT_WINDOW_TOKENS,
+  DEFAULT_CODEX_OAUTH_MODEL,
 } from "./llm/index.js";
 
 // Eval and deterministic replay

--- a/runtime/src/llm/codex-oauth/adapter.test.ts
+++ b/runtime/src/llm/codex-oauth/adapter.test.ts
@@ -1,0 +1,377 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LLMTool } from "../types.js";
+
+const mockCreate = vi.fn();
+const mockOpenAIConstructor = vi.fn();
+
+vi.mock("openai", () => {
+  class MockOpenAI {
+    responses = { create: mockCreate };
+
+    constructor(opts: any) {
+      mockOpenAIConstructor(opts);
+    }
+  }
+
+  return {
+    default: MockOpenAI,
+    OpenAI: MockOpenAI,
+  };
+});
+
+import { CodexOAuthProvider } from "./adapter.js";
+import {
+  DEFAULT_CODEX_CLIENT_VERSION,
+  DEFAULT_CODEX_OAUTH_BASE_URL,
+} from "./types.js";
+
+function base64UrlJson(value: unknown): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function makeJwt(payload: Record<string, unknown>): string {
+  return `${base64UrlJson({ alg: "none", typ: "JWT" })}.${base64UrlJson(payload)}.sig`;
+}
+
+function makeIdToken(input: {
+  readonly accountId?: string;
+  readonly fedramp?: boolean;
+} = {}): string {
+  return makeJwt({
+    exp: Math.floor(Date.now() / 1000) + 60 * 60,
+    "https://api.openai.com/auth": {
+      chatgpt_account_id: input.accountId ?? "acct-test",
+      chatgpt_account_is_fedramp: input.fedramp === true,
+    },
+  });
+}
+
+async function writeCodexAuth(
+  codexHome: string,
+  overrides: Record<string, unknown> = {},
+): Promise<void> {
+  await mkdir(codexHome, { recursive: true });
+  await writeFile(
+    join(codexHome, "auth.json"),
+    `${JSON.stringify(
+      {
+        auth_mode: "chatgpt",
+        tokens: {
+          id_token: makeIdToken({ accountId: "acct-test" }),
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          account_id: "acct-test",
+        },
+        last_refresh: new Date().toISOString(),
+        ...overrides,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+function makeTool(
+  name: string,
+  parameters: Record<string, unknown> = {
+    type: "object",
+    properties: {
+      input: { type: "string" },
+    },
+  },
+): LLMTool {
+  return {
+    type: "function",
+    function: {
+      name,
+      description: `Tool ${name}`,
+      parameters,
+    },
+  };
+}
+
+function makeCompletion(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    status: "completed",
+    output_text: "Hello from Codex",
+    output: [
+      {
+        type: "message",
+        content: [{ type: "output_text", text: "Hello from Codex" }],
+      },
+    ],
+    usage: { input_tokens: 12, output_tokens: 4, total_tokens: 16 },
+    model: "gpt-5.4",
+    ...overrides,
+  };
+}
+
+async function* makeStream(...events: unknown[]): AsyncGenerator<unknown> {
+  for (const event of events) {
+    yield event;
+  }
+}
+
+function makeCompletionStream(overrides: Record<string, unknown> = {}): unknown {
+  return makeStream({
+    type: "response.completed",
+    response: makeCompletion(overrides),
+  });
+}
+
+describe("CodexOAuthProvider", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses Codex OAuth credentials to call the Responses API", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "agenc-codex-auth-"));
+    await writeCodexAuth(codexHome);
+    mockCreate.mockResolvedValueOnce(makeCompletionStream());
+
+    const provider = new CodexOAuthProvider({
+      model: "gpt-5.4",
+      codexHome,
+      tools: [makeTool("system.echo")],
+    });
+    const result = await provider.chat([
+      { role: "system", content: "You are helpful." },
+      { role: "user", content: "Hello" },
+    ]);
+
+    expect(mockOpenAIConstructor).toHaveBeenCalledOnce();
+    expect(mockOpenAIConstructor.mock.calls[0][0]).toMatchObject({
+      apiKey: "access-token",
+      baseURL: DEFAULT_CODEX_OAUTH_BASE_URL,
+      defaultHeaders: {
+        "ChatGPT-Account-ID": "acct-test",
+        version: DEFAULT_CODEX_CLIENT_VERSION,
+      },
+    });
+    const params = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+    expect(params).toMatchObject({
+      model: "gpt-5.4",
+      instructions: "You are helpful.",
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "Hello" }],
+        },
+      ],
+      tools: [
+        {
+          type: "function",
+          description: "Tool system.echo",
+        },
+      ],
+      tool_choice: "auto",
+      store: false,
+      stream: true,
+      parallel_tool_calls: false,
+      reasoning: { effort: "medium" },
+      include: ["reasoning.encrypted_content"],
+    });
+    expect(
+      ((params.tools as Array<Record<string, unknown>>)[0]?.name as string) ?? "",
+    ).toMatch(/^system_echo_[a-f0-9]{10}$/);
+    expect(params.prompt_cache_key).toEqual(expect.any(String));
+    expect(params.client_metadata).toMatchObject({
+      "x-codex-installation-id": expect.any(String),
+    });
+    expect(result.content).toBe("Hello from Codex");
+    expect(result.usage).toEqual({
+      promptTokens: 12,
+      completionTokens: 4,
+      totalTokens: 16,
+    });
+  });
+
+  it("refreshes stale Codex OAuth tokens and persists the updated auth file", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "agenc-codex-auth-"));
+    await writeCodexAuth(codexHome, {
+      tokens: {
+        id_token: makeIdToken({ accountId: "acct-old" }),
+        access_token: makeJwt({ exp: Math.floor(Date.now() / 1000) - 60 }),
+        refresh_token: "refresh-token-old",
+        account_id: "acct-old",
+      },
+      last_refresh: "2020-01-01T00:00:00.000Z",
+    });
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id_token: makeIdToken({ accountId: "acct-new", fedramp: true }),
+        access_token: "access-token-new",
+        refresh_token: "refresh-token-new",
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    mockCreate.mockResolvedValueOnce(makeCompletionStream());
+
+    const provider = new CodexOAuthProvider({
+      model: "gpt-5.4",
+      codexHome,
+      refreshTokenUrl: "https://auth.test/oauth/token",
+    });
+    await provider.chat([{ role: "user", content: "Hello" }]);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls[0][0]).toBe("https://auth.test/oauth/token");
+    const refreshBody = JSON.parse(
+      String((fetchMock.mock.calls[0][1] as { body?: unknown }).body),
+    ) as Record<string, unknown>;
+    expect(refreshBody).toMatchObject({
+      grant_type: "refresh_token",
+      refresh_token: "refresh-token-old",
+    });
+    expect(mockOpenAIConstructor.mock.calls[0][0]).toMatchObject({
+      apiKey: "access-token-new",
+      defaultHeaders: {
+        "ChatGPT-Account-ID": "acct-new",
+        "X-OpenAI-Fedramp": "true",
+      },
+    });
+
+    const storedAuth = JSON.parse(
+      await readFile(join(codexHome, "auth.json"), "utf8"),
+    ) as Record<string, any>;
+    expect(storedAuth.tokens.access_token).toBe("access-token-new");
+    expect(storedAuth.tokens.refresh_token).toBe("refresh-token-new");
+    expect(storedAuth.tokens.account_id).toBe("acct-new");
+    expect(typeof storedAuth.last_refresh).toBe("string");
+  });
+
+  it("parses Responses API function calls using the provider call_id", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "agenc-codex-auth-"));
+    await writeCodexAuth(codexHome);
+    mockCreate.mockImplementationOnce(async (params: Record<string, unknown>) => {
+      const providerToolName = String(
+        (params.tools as Array<Record<string, unknown>>)[0]?.name ?? "",
+      );
+      return makeCompletionStream({
+        output_text: "",
+        output: [
+          {
+            type: "function_call",
+            call_id: "call_123",
+            name: providerToolName,
+            arguments: '{"input":"hi"}',
+          },
+        ],
+      });
+    });
+
+    const provider = new CodexOAuthProvider({
+      model: "gpt-5.4",
+      codexHome,
+      tools: [makeTool("system.echo")],
+    });
+    const result = await provider.chat([{ role: "user", content: "Call tool" }]);
+
+    expect(result.finishReason).toBe("tool_calls");
+    expect(result.toolCalls).toEqual([
+      {
+        id: "call_123",
+        name: "system.echo",
+        arguments: '{"input":"hi"}',
+      },
+    ]);
+  });
+
+  it("normalizes nested array schemas before sending tools to Codex", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "agenc-codex-auth-"));
+    await writeCodexAuth(codexHome);
+    mockCreate.mockResolvedValueOnce(makeCompletionStream());
+    const originalParameters: Record<string, any> = {
+      type: "object",
+      properties: {
+        constraints: {
+          anyOf: [
+            { type: "object" },
+            { type: "array" },
+            { type: "string" },
+          ],
+        },
+        nullableArray: {
+          type: ["array", "null"],
+        },
+        stringList: {
+          type: "array",
+          items: { type: "string" },
+        },
+        nestedArray: {
+          type: "array",
+          items: { type: "array" },
+        },
+        literalChoice: {
+          enum: ["fast", "safe"],
+        },
+      },
+    };
+
+    const provider = new CodexOAuthProvider({
+      model: "gpt-5.4",
+      codexHome,
+      tools: [makeTool("agenc.createTask", originalParameters)],
+    });
+
+    await provider.chat([{ role: "user", content: "Create a task" }]);
+
+    const params = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+    const tool = (params.tools as Array<Record<string, unknown>>)[0];
+    const parameters = tool?.parameters as Record<string, any>;
+    expect(parameters.properties.constraints.anyOf[1]).toEqual({
+      type: "array",
+      items: {},
+    });
+    expect(parameters.properties.nullableArray).toEqual({
+      type: ["array", "null"],
+      items: {},
+    });
+    expect(parameters.properties.stringList).toEqual({
+      type: "array",
+      items: { type: "string" },
+    });
+    expect(parameters.properties.nestedArray).toEqual({
+      type: "array",
+      items: { type: "array", items: {} },
+    });
+    expect(parameters.properties.literalChoice).toEqual({
+      enum: ["fast", "safe"],
+    });
+    expect(originalParameters.properties.constraints.anyOf[1]).toEqual({
+      type: "array",
+    });
+    expect(originalParameters.properties.nullableArray).toEqual({
+      type: ["array", "null"],
+    });
+    expect(originalParameters.properties.nestedArray).toEqual({
+      type: "array",
+      items: { type: "array" },
+    });
+  });
+
+  it("treats timeoutMs=0 as unlimited", async () => {
+    const codexHome = await mkdtemp(join(tmpdir(), "agenc-codex-auth-"));
+    await writeCodexAuth(codexHome);
+    mockCreate.mockResolvedValueOnce(makeCompletionStream());
+
+    const provider = new CodexOAuthProvider({
+      model: "gpt-5.4",
+      codexHome,
+      timeoutMs: 0,
+    });
+    await provider.chat([{ role: "user", content: "Hello" }]);
+
+    expect(mockOpenAIConstructor.mock.calls[0][0].timeout).toBeUndefined();
+  });
+});

--- a/runtime/src/llm/codex-oauth/adapter.ts
+++ b/runtime/src/llm/codex-oauth/adapter.ts
@@ -1,0 +1,1009 @@
+/**
+ * OpenAI Codex OAuth LLM provider adapter.
+ *
+ * Reuses Codex CLI ChatGPT OAuth credentials and sends OpenAI Responses API
+ * requests to the Codex backend.
+ *
+ * @module
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import type {
+  LLMChatOptions,
+  LLMMessage,
+  LLMProvider,
+  LLMProviderTraceEvent,
+  LLMRequestMetrics,
+  LLMResponse,
+  LLMTool,
+  LLMToolCall,
+  LLMToolChoice,
+  LLMUsage,
+  StreamProgressCallback,
+} from "../types.js";
+import { validateToolCall } from "../types.js";
+import { LLMProviderError, mapLLMError } from "../errors.js";
+import { ensureLazyImport } from "../lazy-import.js";
+import {
+  buildUnsupportedCompactionDiagnostics,
+  resolveLLMCompactionConfig,
+  type ResolvedLLMCompactionConfig,
+} from "../provider-capabilities.js";
+import { parseStructuredOutputText } from "../structured-output.js";
+import { withTimeout } from "../timeout.js";
+import {
+  repairToolTurnSequence,
+  validateToolTurnSequence,
+} from "../tool-turn-validator.js";
+import { safeStringify } from "../../tools/types.js";
+import {
+  CodexOAuthCredentialManager,
+  type CodexOAuthCredentialHeaders,
+} from "./auth.js";
+import type { CodexOAuthProviderConfig } from "./types.js";
+import {
+  DEFAULT_CODEX_CLIENT_VERSION,
+  DEFAULT_CODEX_OAUTH_BASE_URL,
+  DEFAULT_CODEX_OAUTH_CONTEXT_WINDOW_TOKENS,
+  DEFAULT_CODEX_OAUTH_MODEL,
+} from "./types.js";
+import { sanitizeCodexJsonSchema } from "./schema.js";
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+const CODEX_DEFAULT_REASONING_EFFORT = "medium";
+const CODEX_REASONING_INCLUDE = "reasoning.encrypted_content";
+const CODEX_TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const CODEX_TOOL_NAME_HASH_CHARS = 10;
+const CODEX_MAX_TOOL_NAME_CHARS = 64;
+const CODEX_INSTALLATION_ID_METADATA_KEY = "x-codex-installation-id";
+
+type ResolvedCodexOAuthProviderConfig = CodexOAuthProviderConfig & {
+  readonly model: string;
+  readonly baseUrl: string;
+  readonly codexClientVersion: string;
+  readonly contextWindowTokens: number;
+  readonly parallelToolCalls: boolean;
+};
+
+type ToolResolutionStrategy =
+  | "all_tools_no_filter"
+  | "all_tools_empty_filter"
+  | "subset_exact"
+  | "subset_partial"
+  | "subset_no_resolved_matches";
+
+interface ToolSelectionDiagnostics {
+  readonly tools: Record<string, unknown>[];
+  readonly requestedToolNames: readonly string[];
+  readonly resolvedToolNames: readonly string[];
+  readonly missingRequestedToolNames: readonly string[];
+  readonly providerCatalogToolCount: number;
+  readonly toolResolution: ToolResolutionStrategy;
+  readonly toolsAttached: boolean;
+  readonly toolSuppressionReason?: string;
+}
+
+function normalizeTimeoutMs(timeoutMs: number | undefined): number | undefined {
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
+    return DEFAULT_TIMEOUT_MS;
+  }
+  if (timeoutMs <= 0) return undefined;
+  return Math.max(1, Math.floor(timeoutMs));
+}
+
+function resolveRequestTimeoutMs(
+  providerTimeoutMs: number | undefined,
+  callTimeoutMs: number | undefined,
+): number | undefined {
+  const normalizedProviderTimeoutMs =
+    typeof providerTimeoutMs === "number" &&
+    Number.isFinite(providerTimeoutMs) &&
+    providerTimeoutMs > 0
+      ? Math.max(1, Math.floor(providerTimeoutMs))
+      : undefined;
+  if (
+    typeof callTimeoutMs === "number" &&
+    Number.isFinite(callTimeoutMs) &&
+    callTimeoutMs <= 0
+  ) {
+    return undefined;
+  }
+  const normalizedCallTimeoutMs =
+    typeof callTimeoutMs === "number" &&
+    Number.isFinite(callTimeoutMs) &&
+    callTimeoutMs > 0
+      ? Math.max(1, Math.floor(callTimeoutMs))
+      : undefined;
+  if (normalizedProviderTimeoutMs === undefined) {
+    return normalizedCallTimeoutMs;
+  }
+  if (normalizedCallTimeoutMs === undefined) {
+    return normalizedProviderTimeoutMs;
+  }
+  return Math.max(
+    1,
+    Math.min(normalizedProviderTimeoutMs, normalizedCallTimeoutMs),
+  );
+}
+
+function cloneProviderTracePayload(
+  value: unknown,
+): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(safeStringify(value)) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+function buildProviderTraceErrorPayload(error: unknown): Record<string, unknown> {
+  if (error instanceof Error) {
+    const payload: Record<string, unknown> = {
+      name: error.name,
+      message: error.message,
+    };
+    if (error.stack) payload.stack = error.stack;
+    const status = (error as { status?: unknown }).status;
+    if (
+      typeof status === "string" ||
+      typeof status === "number" ||
+      typeof status === "boolean"
+    ) {
+      payload.status = status;
+    }
+    const code = (error as { code?: unknown }).code;
+    if (
+      typeof code === "string" ||
+      typeof code === "number" ||
+      typeof code === "boolean"
+    ) {
+      payload.code = code;
+    }
+    return payload;
+  }
+  return { error: String(error) };
+}
+
+function emitProviderTraceEvent(
+  options: LLMChatOptions | undefined,
+  event: LLMProviderTraceEvent,
+): void {
+  options?.trace?.onProviderTraceEvent?.(event);
+}
+
+function sanitizeCodexToolName(
+  originalName: string,
+  usedNames: Set<string>,
+): string {
+  const trimmed = originalName.trim();
+  if (
+    trimmed &&
+    CODEX_TOOL_NAME_PATTERN.test(trimmed) &&
+    !usedNames.has(trimmed)
+  ) {
+    usedNames.add(trimmed);
+    return trimmed;
+  }
+
+  const hash = createHash("sha256")
+    .update(originalName)
+    .digest("hex")
+    .slice(0, CODEX_TOOL_NAME_HASH_CHARS);
+  const maxBaseLength =
+    CODEX_MAX_TOOL_NAME_CHARS - CODEX_TOOL_NAME_HASH_CHARS - 1;
+  let base = trimmed
+    .replace(/[^a-zA-Z0-9_-]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, maxBaseLength);
+  if (!base) base = "tool";
+
+  let candidate = `${base}_${hash}`;
+  let suffix = 2;
+  while (usedNames.has(candidate)) {
+    const suffixText = `_${suffix}`;
+    candidate = `${base.slice(
+      0,
+      Math.max(1, CODEX_MAX_TOOL_NAME_CHARS - suffixText.length),
+    )}${suffixText}`;
+    suffix += 1;
+  }
+  usedNames.add(candidate);
+  return candidate;
+}
+
+function resolveCodexToolChoice(
+  toolChoice: LLMToolChoice | undefined,
+  toProviderToolName: (name: string) => string,
+): string {
+  if (toolChoice === undefined || typeof toolChoice === "string") {
+    return toolChoice ?? "auto";
+  }
+  const name = toolChoice.name.trim();
+  return name.length > 0 ? toProviderToolName(name) : "auto";
+}
+
+function estimateContentChars(content: unknown): number {
+  if (typeof content === "string") return content.length;
+  if (content === undefined || content === null) return 0;
+  return safeStringify(content).length;
+}
+
+function collectParamDiagnostics(
+  params: Record<string, unknown>,
+  selection?: ToolSelectionDiagnostics,
+): LLMRequestMetrics {
+  const input = Array.isArray(params.input)
+    ? (params.input as Array<Record<string, unknown>>)
+    : [];
+  const tools = Array.isArray(params.tools)
+    ? (params.tools as Array<Record<string, unknown>>)
+    : [];
+
+  let totalContentChars = 0;
+  let maxMessageChars = 0;
+  let systemMessages = 0;
+  let userMessages = 0;
+  let assistantMessages = 0;
+  let toolMessages = 0;
+  let textParts = 0;
+  let imageParts = 0;
+
+  if (typeof params.instructions === "string" && params.instructions.length > 0) {
+    systemMessages++;
+    totalContentChars += params.instructions.length;
+    maxMessageChars = Math.max(maxMessageChars, params.instructions.length);
+    textParts++;
+  }
+
+  for (const item of input) {
+    const role = String(item.role ?? "");
+    const type = String(item.type ?? "");
+    if (role === "system") systemMessages++;
+    if (role === "user") userMessages++;
+    if (role === "assistant" || type === "function_call") assistantMessages++;
+    if (role === "tool" || type === "function_call_output") toolMessages++;
+    const content =
+      type === "function_call_output"
+        ? item.output
+        : item.content ?? item.arguments;
+    const chars = estimateContentChars(content);
+    totalContentChars += chars;
+    if (chars > maxMessageChars) maxMessageChars = chars;
+    if (Array.isArray(content)) {
+      for (const part of content) {
+        if (
+          part &&
+          typeof part === "object" &&
+          !Array.isArray(part) &&
+          (part as { type?: unknown }).type === "input_image"
+        ) {
+          imageParts++;
+        } else {
+          textParts++;
+        }
+      }
+    } else if (typeof content === "string" && content.length > 0) {
+      textParts++;
+    }
+  }
+
+  let serializedChars = 0;
+  let toolSchemaChars = 0;
+  try {
+    serializedChars = safeStringify(params).length;
+  } catch {
+    serializedChars = -1;
+  }
+  try {
+    toolSchemaChars = safeStringify(tools).length;
+  } catch {
+    toolSchemaChars = -1;
+  }
+
+  return {
+    messageCount: input.length,
+    systemMessages,
+    userMessages,
+    assistantMessages,
+    toolMessages,
+    totalContentChars,
+    maxMessageChars,
+    textParts,
+    imageParts,
+    toolCount: tools.length,
+    toolNames:
+      selection?.resolvedToolNames ??
+      tools
+        .map((tool) =>
+          typeof tool.name === "string" ? tool.name : undefined,
+        )
+        .filter((name): name is string => Boolean(name)),
+    requestedToolNames: selection?.requestedToolNames,
+    missingRequestedToolNames: selection?.missingRequestedToolNames,
+    toolResolution: selection?.toolResolution,
+    providerCatalogToolCount: selection?.providerCatalogToolCount,
+    toolsAttached: selection?.toolsAttached,
+    toolSuppressionReason: selection?.toolSuppressionReason,
+    toolChoice:
+      typeof params.tool_choice === "string"
+        ? params.tool_choice
+        : params.tool_choice === undefined
+          ? undefined
+          : safeStringify(params.tool_choice),
+    toolSchemaChars,
+    serializedChars,
+    store: typeof params.store === "boolean" ? params.store : undefined,
+    parallelToolCalls:
+      typeof params.parallel_tool_calls === "boolean"
+        ? params.parallel_tool_calls
+        : undefined,
+    stream: typeof params.stream === "boolean" ? params.stream : undefined,
+    structuredOutputEnabled:
+      typeof params.text === "object" && params.text !== null,
+  };
+}
+
+export class CodexOAuthProvider implements LLMProvider {
+  readonly name = "codex";
+
+  private client: unknown | null = null;
+  private clientAuthCacheKey: string | null = null;
+  private readonly config: ResolvedCodexOAuthProviderConfig;
+  private readonly tools: readonly LLMTool[];
+  private readonly responseTools: readonly Record<string, unknown>[];
+  private readonly providerToolNameByOriginalName = new Map<string, string>();
+  private readonly originalToolNameByProviderName = new Map<string, string>();
+  private readonly promptCacheKey: string;
+  private readonly installationId: string;
+  private readonly credentials: CodexOAuthCredentialManager;
+  private readonly compactionConfig: ResolvedLLMCompactionConfig;
+
+  constructor(config: CodexOAuthProviderConfig) {
+    this.config = {
+      ...config,
+      model: config.model || DEFAULT_CODEX_OAUTH_MODEL,
+      baseUrl: config.baseUrl ?? DEFAULT_CODEX_OAUTH_BASE_URL,
+      timeoutMs: normalizeTimeoutMs(config.timeoutMs),
+      contextWindowTokens:
+        config.contextWindowTokens ?? DEFAULT_CODEX_OAUTH_CONTEXT_WINDOW_TOKENS,
+      codexClientVersion:
+        config.codexClientVersion ?? DEFAULT_CODEX_CLIENT_VERSION,
+      parallelToolCalls: config.parallelToolCalls ?? false,
+    };
+    this.tools = config.tools ?? [];
+    this.buildToolNameMappings(this.tools);
+    this.responseTools = this.toResponseTools(this.tools);
+    this.promptCacheKey = `agenc-codex-${randomUUID()}`;
+    this.installationId = randomUUID();
+    this.credentials = new CodexOAuthCredentialManager({
+      codexHome: config.codexHome,
+      codexAuthPath: config.codexAuthPath,
+      refreshTokenUrl: config.refreshTokenUrl,
+    });
+    this.compactionConfig = resolveLLMCompactionConfig(undefined);
+  }
+
+  async chat(
+    messages: LLMMessage[],
+    options?: LLMChatOptions,
+  ): Promise<LLMResponse> {
+    return this.chatStream(messages, () => undefined, options);
+  }
+
+  async chatStream(
+    messages: LLMMessage[],
+    onChunk: StreamProgressCallback,
+    options?: LLMChatOptions,
+  ): Promise<LLMResponse> {
+    const client = await this.ensureClient();
+    const toolSelection = this.selectTools(options?.toolRouting?.allowedToolNames);
+    const params: Record<string, unknown> = {
+      ...this.buildParams(messages, options, toolSelection),
+      stream: true,
+    };
+    const requestMetrics = {
+      ...collectParamDiagnostics(params, toolSelection),
+      stream: true,
+    };
+    const requestTimeoutMs = resolveRequestTimeoutMs(
+      this.config.timeoutMs,
+      options?.timeoutMs,
+    );
+    let content = "";
+    let model = this.config.model;
+    const toolCallsById = new Map<string, LLMToolCall>();
+    let terminalResponse: Record<string, unknown> | undefined;
+
+    try {
+      emitProviderTraceEvent(options, {
+        kind: "request",
+        transport: "chat_stream",
+        provider: this.name,
+        model: String(params.model ?? this.config.model),
+        payload:
+          cloneProviderTracePayload(params) ??
+          { error: "provider_request_trace_unavailable" },
+        context: { timeoutMs: requestTimeoutMs },
+      });
+      const stream = await withTimeout(
+        async (signal) =>
+          (client as any).responses.create(params, { signal }),
+        requestTimeoutMs,
+        this.name,
+        options?.signal,
+      );
+
+      for await (const event of stream as AsyncIterable<any>) {
+        emitProviderTraceEvent(options, {
+          kind: "stream_event",
+          transport: "chat_stream",
+          provider: this.name,
+          model,
+          payload:
+            cloneProviderTracePayload(event) ??
+            { type: String(event?.type ?? "stream.event") },
+        });
+        if (event?.type === "response.output_text.delta") {
+          const delta = String(event.delta ?? "");
+          if (delta.length > 0) {
+            content += delta;
+            onChunk({ content: delta, done: false });
+          }
+          continue;
+        }
+        if (event?.type === "response.output_item.done") {
+          const toolCall = this.toToolCall(event.item);
+          if (toolCall) toolCallsById.set(toolCall.id, toolCall);
+          continue;
+        }
+        if (event?.type === "response.completed" || event?.type === "response.failed") {
+          terminalResponse =
+            event.response &&
+            typeof event.response === "object" &&
+            !Array.isArray(event.response)
+              ? (event.response as Record<string, unknown>)
+              : {};
+          if (typeof terminalResponse.model === "string") {
+            model = terminalResponse.model;
+          }
+        }
+      }
+
+      const parsed = terminalResponse
+        ? this.parseResponse(terminalResponse, options)
+        : undefined;
+      if (parsed) {
+        for (const toolCall of parsed.toolCalls) {
+          toolCallsById.set(toolCall.id, toolCall);
+        }
+        if (content.length === 0 && parsed.content.length > 0) {
+          content = parsed.content;
+          onChunk({ content, done: false });
+        }
+        const toolCalls = [...toolCallsById.values()];
+        onChunk({ content: "", done: true, toolCalls });
+        return {
+          ...parsed,
+          content: parsed.content || content,
+          toolCalls,
+          requestMetrics,
+        };
+      }
+
+      const toolCalls = [...toolCallsById.values()];
+      onChunk({ content: "", done: true, toolCalls });
+      return {
+        content,
+        toolCalls,
+        usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        model,
+        requestMetrics,
+        finishReason: toolCalls.length > 0 ? "tool_calls" : "stop",
+        ...this.buildUnsupportedDiagnostics(options),
+      };
+    } catch (err: unknown) {
+      emitProviderTraceEvent(options, {
+        kind: "error",
+        transport: "chat_stream",
+        provider: this.name,
+        model,
+        payload: buildProviderTraceErrorPayload(err),
+      });
+      if (content.length > 0) {
+        const mappedError = this.mapError(err, requestTimeoutMs);
+        const toolCalls = [...toolCallsById.values()];
+        onChunk({ content: "", done: true, toolCalls });
+        return {
+          content,
+          toolCalls,
+          usage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+          model,
+          requestMetrics,
+          finishReason: "error",
+          error: mappedError,
+          partial: true,
+          ...this.buildUnsupportedDiagnostics(options),
+        };
+      }
+      throw this.mapError(err, requestTimeoutMs);
+    }
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      await this.credentials.getAuthHeaders();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getExecutionProfile() {
+    const maxOutputTokens =
+      typeof this.config.maxTokens === "number" && this.config.maxTokens > 0
+        ? this.config.maxTokens
+        : undefined;
+    return {
+      provider: this.name,
+      model: this.config.model,
+      contextWindowTokens:
+        this.config.contextWindowTokens ??
+        DEFAULT_CODEX_OAUTH_CONTEXT_WINDOW_TOKENS,
+      contextWindowSource:
+        this.config.contextWindowTokens !== undefined
+          ? ("explicit_config" as const)
+          : ("codex_default" as const),
+      maxOutputTokens,
+    };
+  }
+
+  private async ensureClient(): Promise<unknown> {
+    const auth = await this.credentials.getAuthHeaders();
+    const defaultHeaders = this.buildDefaultHeaders(auth);
+    const cacheKey = JSON.stringify({
+      baseUrl: this.config.baseUrl,
+      accessToken: auth.accessToken,
+      defaultHeaders,
+    });
+    if (this.client && this.clientAuthCacheKey === cacheKey) {
+      return this.client;
+    }
+    this.client = await ensureLazyImport("openai", this.name, (mod) => {
+      const OpenAI = (mod.OpenAI ?? mod.default) as any;
+      return new OpenAI({
+        apiKey: auth.accessToken,
+        baseURL: this.config.baseUrl,
+        defaultHeaders,
+        timeout: this.config.timeoutMs,
+      });
+    });
+    this.clientAuthCacheKey = cacheKey;
+    return this.client;
+  }
+
+  private buildDefaultHeaders(
+    auth: CodexOAuthCredentialHeaders,
+  ): Record<string, string> {
+    const headers: Record<string, string> = {
+      version: this.config.codexClientVersion ?? DEFAULT_CODEX_CLIENT_VERSION,
+    };
+    for (const [key, value] of Object.entries(auth.headers)) {
+      if (key.toLowerCase() === "authorization") continue;
+      headers[key] = value;
+    }
+    return headers;
+  }
+
+  private buildParams(
+    messages: readonly LLMMessage[],
+    options?: LLMChatOptions,
+    toolSelection?: ToolSelectionDiagnostics,
+  ): Record<string, unknown> {
+    const repairedMessages = repairToolTurnSequence(messages);
+    validateToolTurnSequence(repairedMessages, { providerName: this.name });
+    const instructions = repairedMessages
+      .filter((message) => message.role === "system")
+      .map((message) => this.stringifyContent(message.content).trim())
+      .filter((content) => content.length > 0)
+      .join("\n\n");
+    const input = repairedMessages
+      .filter((message) => message.role !== "system")
+      .flatMap((message) => this.toResponseInputItems(message));
+    const selectedTools =
+      toolSelection ?? this.selectTools(options?.toolRouting?.allowedToolNames);
+    const tools = options?.toolChoice === "none" ? [] : selectedTools.tools;
+    const params: Record<string, unknown> = {
+      model: this.config.model,
+      instructions,
+      input,
+      tools,
+      tool_choice: resolveCodexToolChoice(options?.toolChoice, (name) =>
+        this.toProviderToolName(name),
+      ),
+      parallel_tool_calls:
+        options?.parallelToolCalls ?? this.config.parallelToolCalls,
+      reasoning: {
+        effort: options?.reasoningEffort ?? CODEX_DEFAULT_REASONING_EFFORT,
+      },
+      store: false,
+      stream: true,
+      include: [CODEX_REASONING_INCLUDE],
+      prompt_cache_key: options?.promptCacheKey?.trim() || this.promptCacheKey,
+      client_metadata: {
+        [CODEX_INSTALLATION_ID_METADATA_KEY]: this.installationId,
+      },
+    };
+    const structuredOutputSchema = options?.structuredOutput?.schema;
+    if (
+      options?.structuredOutput?.enabled !== false &&
+      structuredOutputSchema
+    ) {
+      params.text = {
+        format: {
+          type: structuredOutputSchema.type,
+          name: structuredOutputSchema.name,
+          schema: structuredOutputSchema.schema,
+          strict: structuredOutputSchema.strict ?? true,
+        },
+      };
+    }
+    return params;
+  }
+
+  private selectTools(
+    allowedToolNames?: readonly string[],
+  ): ToolSelectionDiagnostics {
+    const providerCatalogToolCount = this.responseTools.length;
+    const providerCatalogToolNames = this.tools.map((tool) => tool.function.name);
+    if (allowedToolNames === undefined) {
+      return {
+        tools: [...this.responseTools],
+        requestedToolNames: [],
+        resolvedToolNames: providerCatalogToolNames,
+        missingRequestedToolNames: [],
+        providerCatalogToolCount,
+        toolResolution: "all_tools_no_filter",
+        toolsAttached: this.responseTools.length > 0,
+      };
+    }
+    if (allowedToolNames.length === 0) {
+      return {
+        tools: [],
+        requestedToolNames: [],
+        resolvedToolNames: [],
+        missingRequestedToolNames: [],
+        providerCatalogToolCount,
+        toolResolution: "all_tools_empty_filter",
+        toolsAttached: false,
+        toolSuppressionReason: "empty_allowlist",
+      };
+    }
+
+    const allowed = new Set(
+      allowedToolNames
+        .map((name) => name.trim())
+        .filter((name) => name.length > 0),
+    );
+    const requestedToolNames = [...allowed];
+    const selected: Record<string, unknown>[] = [];
+    const resolvedToolNames: string[] = [];
+    for (let index = 0; index < this.tools.length; index += 1) {
+      const originalName = this.tools[index]?.function.name ?? "";
+      if (!allowed.has(originalName)) continue;
+      const responseTool = this.responseTools[index];
+      if (!responseTool) continue;
+      selected.push(responseTool);
+      resolvedToolNames.push(originalName);
+    }
+    const missingRequestedToolNames = requestedToolNames.filter(
+      (name) => !resolvedToolNames.includes(name),
+    );
+    if (selected.length === 0) {
+      return {
+        tools: [],
+        requestedToolNames,
+        resolvedToolNames: [],
+        missingRequestedToolNames: requestedToolNames,
+        providerCatalogToolCount,
+        toolResolution: "subset_no_resolved_matches",
+        toolsAttached: false,
+        toolSuppressionReason: "no_allowlist_matches",
+      };
+    }
+
+    return {
+      tools: selected,
+      requestedToolNames,
+      resolvedToolNames,
+      missingRequestedToolNames,
+      providerCatalogToolCount,
+      toolResolution:
+        missingRequestedToolNames.length > 0 ? "subset_partial" : "subset_exact",
+      toolsAttached: true,
+    };
+  }
+
+  private buildToolNameMappings(tools: readonly LLMTool[]): void {
+    const usedNames = new Set<string>();
+    for (const tool of tools) {
+      const originalName = tool.function.name;
+      const providerName = sanitizeCodexToolName(originalName, usedNames);
+      this.providerToolNameByOriginalName.set(originalName, providerName);
+      this.originalToolNameByProviderName.set(providerName, originalName);
+    }
+  }
+
+  private toProviderToolName(originalName: string): string {
+    const mapped = this.providerToolNameByOriginalName.get(originalName);
+    if (mapped) return mapped;
+    const trimmed = originalName.trim();
+    if (trimmed && CODEX_TOOL_NAME_PATTERN.test(trimmed)) return trimmed;
+    return sanitizeCodexToolName(
+      originalName,
+      new Set(this.originalToolNameByProviderName.keys()),
+    );
+  }
+
+  private toOriginalToolName(providerName: string): string {
+    return this.originalToolNameByProviderName.get(providerName) ?? providerName;
+  }
+
+  private toResponseTools(tools: readonly LLMTool[]): Record<string, unknown>[] {
+    return tools.map((tool) => ({
+      type: "function",
+      name: this.toProviderToolName(tool.function.name),
+      description: tool.function.description,
+      parameters: sanitizeCodexJsonSchema(tool.function.parameters),
+    }));
+  }
+
+  private toResponseInputItems(message: LLMMessage): Record<string, unknown>[] {
+    if (message.role === "system") {
+      return [];
+    }
+
+    if (message.role === "tool") {
+      const toolCallId = String(message.toolCallId ?? "").trim();
+      if (!toolCallId) return [];
+      return [
+        {
+          type: "function_call_output",
+          call_id: toolCallId,
+          output: this.stringifyContent(message.content),
+        },
+      ];
+    }
+
+    if (message.role === "assistant") {
+      const items: Record<string, unknown>[] = [];
+      const normalizedContent = this.normalizeResponseMessageContent(
+        message.content,
+        "assistant",
+      );
+      if (normalizedContent !== undefined) {
+        items.push({
+          type: "message",
+          role: "assistant",
+          content: normalizedContent,
+        });
+      } else if ((message.toolCalls ?? []).length > 0) {
+        items.push({
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Calling tool." }],
+        });
+      }
+      for (const toolCall of message.toolCalls ?? []) {
+        items.push({
+          type: "function_call",
+          call_id: toolCall.id,
+          name: this.toProviderToolName(toolCall.name),
+          arguments: toolCall.arguments,
+        });
+      }
+      return items;
+    }
+
+    const normalizedContent = this.normalizeResponseMessageContent(
+      message.content,
+      "user",
+    );
+    if (normalizedContent === undefined) return [];
+    return [{ type: "message", role: message.role, content: normalizedContent }];
+  }
+
+  private normalizeResponseMessageContent(
+    content: LLMMessage["content"],
+    role: "assistant" | "user",
+  ): Array<Record<string, unknown>> | undefined {
+    const textType = role === "assistant" ? "output_text" : "input_text";
+    if (typeof content === "string") {
+      return content.length > 0 ? [{ type: textType, text: content }] : undefined;
+    }
+    const parts: Array<Record<string, unknown>> = [];
+    for (const part of content) {
+      if (part.type === "text") {
+        if (part.text.length > 0) {
+          parts.push({ type: textType, text: part.text });
+        }
+        continue;
+      }
+      if (part.type === "image_url") {
+        parts.push({ type: "input_image", image_url: part.image_url.url });
+      }
+    }
+    return parts.length > 0 ? parts : undefined;
+  }
+
+  private stringifyContent(content: LLMMessage["content"]): string {
+    if (typeof content === "string") return content;
+    const text = content
+      .filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("\n");
+    return text.length > 0 ? text : safeStringify(content);
+  }
+
+  private parseResponse(
+    response: Record<string, unknown>,
+    options?: LLMChatOptions,
+  ): LLMResponse {
+    const toolCalls = this.extractToolCallsFromOutput(response.output);
+    const finishReason = this.mapResponseFinishReason(response, toolCalls);
+    const error = this.extractResponseError(response, finishReason);
+    return {
+      content: this.extractOutputText(response) ?? "",
+      toolCalls,
+      usage: this.parseUsage(response),
+      model: String(response.model ?? this.config.model),
+      finishReason,
+      structuredOutput: this.extractStructuredOutputResult(response, options),
+      ...(error ? { error } : {}),
+      ...this.buildUnsupportedDiagnostics(options),
+    };
+  }
+
+  private extractOutputText(
+    response: Record<string, unknown>,
+  ): string | undefined {
+    const direct = response.output_text;
+    if (typeof direct === "string") return direct;
+    const output = Array.isArray(response.output)
+      ? (response.output as Array<Record<string, unknown>>)
+      : [];
+    const chunks: string[] = [];
+    for (const item of output) {
+      if (!item || typeof item !== "object" || item.type !== "message") {
+        continue;
+      }
+      const content = Array.isArray(item.content)
+        ? (item.content as Array<Record<string, unknown>>)
+        : [];
+      for (const part of content) {
+        if (part.type === "output_text" && typeof part.text === "string") {
+          chunks.push(part.text);
+        }
+      }
+    }
+    return chunks.length > 0 ? chunks.join("") : "";
+  }
+
+  private extractStructuredOutputResult(
+    response: Record<string, unknown>,
+    options?: LLMChatOptions,
+  ): LLMResponse["structuredOutput"] {
+    const schema = options?.structuredOutput?.schema;
+    if (options?.structuredOutput?.enabled === false || !schema) {
+      return undefined;
+    }
+    const rawText = this.extractOutputText(response);
+    if (!rawText || rawText.trim().length === 0) return undefined;
+    return parseStructuredOutputText(rawText, schema.name, schema.schema);
+  }
+
+  private parseUsage(response: Record<string, unknown>): LLMUsage {
+    const usage =
+      response.usage && typeof response.usage === "object"
+        ? (response.usage as Record<string, unknown>)
+        : {};
+    const promptTokens = Number(usage.input_tokens ?? 0);
+    const completionTokens = Number(usage.output_tokens ?? 0);
+    const totalTokens = Number(
+      usage.total_tokens ?? promptTokens + completionTokens,
+    );
+    return {
+      promptTokens: Number.isFinite(promptTokens) ? promptTokens : 0,
+      completionTokens: Number.isFinite(completionTokens) ? completionTokens : 0,
+      totalTokens: Number.isFinite(totalTokens)
+        ? totalTokens
+        : promptTokens + completionTokens,
+    };
+  }
+
+  private toToolCall(item: unknown): LLMToolCall | null {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      return null;
+    }
+    const candidate = item as Record<string, unknown>;
+    if (candidate.type !== "function_call") return null;
+    const providerName = String(candidate.name ?? "");
+    return validateToolCall({
+      id: String(candidate.call_id ?? candidate.id ?? ""),
+      name: this.toOriginalToolName(providerName),
+      arguments: String(candidate.arguments ?? "{}"),
+    });
+  }
+
+  private extractToolCallsFromOutput(output: unknown): LLMToolCall[] {
+    if (!Array.isArray(output)) return [];
+    return output
+      .map((item) => this.toToolCall(item))
+      .filter((toolCall): toolCall is LLMToolCall => toolCall !== null);
+  }
+
+  private mapResponseFinishReason(
+    response: Record<string, unknown>,
+    toolCalls: readonly LLMToolCall[],
+  ): LLMResponse["finishReason"] {
+    if (toolCalls.length > 0) return "tool_calls";
+    const status = String(response.status ?? "");
+    if (status === "failed") return "error";
+    if (status === "incomplete") {
+      const details =
+        response.incomplete_details &&
+        typeof response.incomplete_details === "object" &&
+        !Array.isArray(response.incomplete_details)
+          ? (response.incomplete_details as Record<string, unknown>)
+          : {};
+      const reason = String(details.reason ?? "");
+      if (reason.includes("content_filter")) return "content_filter";
+      return "length";
+    }
+    return "stop";
+  }
+
+  private extractResponseError(
+    response: Record<string, unknown>,
+    finishReason: LLMResponse["finishReason"],
+  ): Error | undefined {
+    if (finishReason !== "error") return undefined;
+    const rawError = response.error;
+    const errorObj =
+      rawError && typeof rawError === "object" && !Array.isArray(rawError)
+        ? (rawError as Record<string, unknown>)
+        : undefined;
+    const message =
+      typeof errorObj?.message === "string" && errorObj.message.length > 0
+        ? errorObj.message
+        : "Codex backend returned failed response status";
+    const codeRaw = errorObj?.code ?? errorObj?.status ?? errorObj?.statusCode;
+    const statusCode =
+      typeof codeRaw === "number"
+        ? codeRaw
+        : Number.parseInt(String(codeRaw ?? ""), 10);
+    return new LLMProviderError(
+      this.name,
+      message,
+      Number.isFinite(statusCode) ? statusCode : undefined,
+    );
+  }
+
+  private buildUnsupportedDiagnostics(
+    _options?: LLMChatOptions,
+  ): Pick<LLMResponse, "compaction"> {
+    return {
+      compaction: buildUnsupportedCompactionDiagnostics({
+        provider: this.name,
+        compaction: this.compactionConfig,
+      }),
+    };
+  }
+
+  private mapError(err: unknown, timeoutMs?: number): Error {
+    return mapLLMError(this.name, err, timeoutMs ?? this.config.timeoutMs ?? 0);
+  }
+}

--- a/runtime/src/llm/codex-oauth/auth.ts
+++ b/runtime/src/llm/codex-oauth/auth.ts
@@ -1,0 +1,340 @@
+/**
+ * Codex CLI OAuth credential loading and refresh helpers.
+ *
+ * Mirrors the Codex CLI's local credential contract closely enough for the
+ * runtime to reuse ChatGPT OAuth credentials without owning the login flow.
+ *
+ * @module
+ */
+
+import { mkdir, readFile, rename, writeFile, chmod } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { homedir } from "node:os";
+import { LLMAuthenticationError, LLMProviderError } from "../errors.js";
+
+const PROVIDER_NAME = "codex";
+const CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const DEFAULT_REFRESH_TOKEN_URL = "https://auth.openai.com/oauth/token";
+const REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR = "CODEX_REFRESH_TOKEN_URL_OVERRIDE";
+const TOKEN_REFRESH_INTERVAL_MS = 8 * 24 * 60 * 60 * 1000;
+const ACCESS_TOKEN_EXPIRY_SKEW_MS = 60_000;
+
+interface CodexTokenData {
+  id_token?: unknown;
+  access_token?: unknown;
+  refresh_token?: unknown;
+  account_id?: unknown;
+  [key: string]: unknown;
+}
+
+interface CodexAuthJson {
+  auth_mode?: unknown;
+  OPENAI_API_KEY?: unknown;
+  tokens?: CodexTokenData | null;
+  last_refresh?: unknown;
+  [key: string]: unknown;
+}
+
+interface CodexAuthTokenState {
+  readonly auth: CodexAuthJson;
+  readonly tokens: CodexTokenData;
+  readonly accessToken: string;
+  readonly refreshToken: string;
+}
+
+interface RefreshResponse {
+  readonly id_token?: unknown;
+  readonly access_token?: unknown;
+  readonly refresh_token?: unknown;
+  readonly account_id?: unknown;
+}
+
+interface CodexIdTokenInfo {
+  readonly accountId?: string;
+  readonly isFedrampAccount: boolean;
+}
+
+export interface CodexOAuthCredentialManagerConfig {
+  readonly codexHome?: string;
+  readonly codexAuthPath?: string;
+  readonly refreshTokenUrl?: string;
+}
+
+export interface CodexOAuthCredentialHeaders {
+  readonly accessToken: string;
+  readonly headers: Readonly<Record<string, string>>;
+}
+
+function normalizeString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function decodeJwtPayload(jwt: string): Record<string, unknown> | undefined {
+  const parts = jwt.split(".");
+  if (parts.length < 3 || !parts[1]) return undefined;
+  const payload = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+  const padded = payload + "=".repeat((4 - (payload.length % 4)) % 4);
+  try {
+    const decoded = Buffer.from(padded, "base64").toString("utf8");
+    const parsed = JSON.parse(decoded) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function extractJwtExpiryMs(jwt: string): number | undefined {
+  const payload = decodeJwtPayload(jwt);
+  const exp = payload?.exp;
+  if (typeof exp !== "number" || !Number.isFinite(exp)) return undefined;
+  return exp * 1000;
+}
+
+function parseDateMs(value: unknown): number | undefined {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return undefined;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function extractAuthClaims(idToken: unknown): Record<string, unknown> | undefined {
+  if (typeof idToken === "string") {
+    const payload = decodeJwtPayload(idToken);
+    const claims = payload?.["https://api.openai.com/auth"];
+    return claims && typeof claims === "object" && !Array.isArray(claims)
+      ? (claims as Record<string, unknown>)
+      : undefined;
+  }
+  if (idToken && typeof idToken === "object" && !Array.isArray(idToken)) {
+    return idToken as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+function extractIdTokenInfo(tokens: CodexTokenData): CodexIdTokenInfo {
+  const claims = extractAuthClaims(tokens.id_token);
+  const accountIdFromClaim = normalizeString(claims?.chatgpt_account_id);
+  const isFedrampAccount = claims?.chatgpt_account_is_fedramp === true;
+  return {
+    accountId: normalizeString(tokens.account_id) ?? accountIdFromClaim,
+    isFedrampAccount,
+  };
+}
+
+function isChatGptAuthMode(authMode: unknown): boolean {
+  const normalized = normalizeString(authMode)?.toLowerCase();
+  if (!normalized) return false;
+  return normalized.includes("chatgpt") || normalized.includes("chat-gpt");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getRefreshTokenUrl(configured?: string): string {
+  return (
+    normalizeString(configured) ??
+    normalizeString(process.env[REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR]) ??
+    DEFAULT_REFRESH_TOKEN_URL
+  );
+}
+
+export function resolveCodexAuthPath(
+  config: Pick<CodexOAuthCredentialManagerConfig, "codexHome" | "codexAuthPath">,
+): string {
+  const explicitPath = normalizeString(config.codexAuthPath);
+  if (explicitPath) return explicitPath;
+  const codexHome =
+    normalizeString(config.codexHome) ??
+    normalizeString(process.env.CODEX_HOME) ??
+    join(homedir(), ".codex");
+  return join(codexHome, "auth.json");
+}
+
+export class CodexOAuthCredentialManager {
+  private readonly authPath: string;
+  private readonly refreshTokenUrl: string;
+
+  constructor(config: CodexOAuthCredentialManagerConfig = {}) {
+    this.authPath = resolveCodexAuthPath(config);
+    this.refreshTokenUrl = getRefreshTokenUrl(config.refreshTokenUrl);
+  }
+
+  async getAuthHeaders(): Promise<CodexOAuthCredentialHeaders> {
+    const state = await this.loadAuthState();
+    const activeState = this.needsRefresh(state.auth, state.accessToken)
+      ? await this.refreshAndPersist(state)
+      : state;
+    const tokenInfo = extractIdTokenInfo(activeState.tokens);
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${activeState.accessToken}`,
+    };
+    if (tokenInfo.accountId) {
+      headers["ChatGPT-Account-ID"] = tokenInfo.accountId;
+    }
+    if (tokenInfo.isFedrampAccount) {
+      headers["X-OpenAI-Fedramp"] = "true";
+    }
+    return {
+      accessToken: activeState.accessToken,
+      headers,
+    };
+  }
+
+  private async loadAuthState(): Promise<CodexAuthTokenState> {
+    let raw: string;
+    try {
+      raw = await readFile(this.authPath, "utf8");
+    } catch (error) {
+      throw new LLMProviderError(
+        PROVIDER_NAME,
+        `Could not read Codex OAuth credentials at ${this.authPath}. Run the Codex CLI login flow first, then point llm.codexHome or llm.codexAuthPath at that credential store. Cause: ${(error as Error).message}`,
+        401,
+      );
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw) as unknown;
+    } catch {
+      throw new LLMProviderError(
+        PROVIDER_NAME,
+        `Codex OAuth credentials at ${this.authPath} are not valid JSON.`,
+        401,
+      );
+    }
+    if (!isRecord(parsed)) {
+      throw new LLMProviderError(
+        PROVIDER_NAME,
+        `Codex OAuth credentials at ${this.authPath} must be a JSON object.`,
+        401,
+      );
+    }
+    const auth = parsed as CodexAuthJson;
+    const tokens = auth.tokens;
+    const hasChatGptMode = isChatGptAuthMode(auth.auth_mode);
+    if (!isRecord(tokens)) {
+      throw new LLMProviderError(
+        PROVIDER_NAME,
+        `Codex credentials at ${this.authPath} do not contain ChatGPT OAuth tokens. Run Codex CLI and choose ChatGPT sign-in instead of API-key auth.`,
+        401,
+      );
+    }
+
+    const accessToken = normalizeString(tokens.access_token);
+    const refreshToken = normalizeString(tokens.refresh_token);
+    if (!accessToken || !refreshToken) {
+      throw new LLMProviderError(
+        PROVIDER_NAME,
+        `Codex credentials at ${this.authPath} are missing access_token or refresh_token values.`,
+        401,
+      );
+    }
+    if (!hasChatGptMode && typeof auth.OPENAI_API_KEY === "string") {
+      throw new LLMProviderError(
+        PROVIDER_NAME,
+        `Codex credentials at ${this.authPath} are API-key based. OpenAI Codex OAuth requires ChatGPT OAuth tokens from the Codex CLI login flow.`,
+        401,
+      );
+    }
+
+    return {
+      auth,
+      tokens,
+      accessToken,
+      refreshToken,
+    };
+  }
+
+  private needsRefresh(auth: CodexAuthJson, accessToken: string): boolean {
+    const nowMs = Date.now();
+    const accessTokenExpiresAt = extractJwtExpiryMs(accessToken);
+    if (accessTokenExpiresAt !== undefined) {
+      return accessTokenExpiresAt <= nowMs + ACCESS_TOKEN_EXPIRY_SKEW_MS;
+    }
+    const lastRefreshMs = parseDateMs(auth.last_refresh);
+    if (lastRefreshMs === undefined) return true;
+    return lastRefreshMs <= nowMs - TOKEN_REFRESH_INTERVAL_MS;
+  }
+
+  private async refreshAndPersist(
+    state: CodexAuthTokenState,
+  ): Promise<CodexAuthTokenState> {
+    const response = await fetch(this.refreshTokenUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        client_id: CODEX_CLIENT_ID,
+        grant_type: "refresh_token",
+        refresh_token: state.refreshToken,
+      }),
+    });
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        throw new LLMAuthenticationError(PROVIDER_NAME, response.status);
+      }
+      throw new LLMProviderError(
+        PROVIDER_NAME,
+        `Failed to refresh Codex OAuth token at ${this.refreshTokenUrl} (HTTP ${response.status}).`,
+        response.status,
+      );
+    }
+
+    const body = (await response.json()) as RefreshResponse;
+    const nextAccessToken = normalizeString(body.access_token);
+    const nextRefreshToken = normalizeString(body.refresh_token);
+    if (!nextAccessToken || !nextRefreshToken) {
+      throw new LLMProviderError(
+        PROVIDER_NAME,
+        "Codex OAuth refresh response did not include access_token and refresh_token.",
+        502,
+      );
+    }
+
+    const nextTokens: CodexTokenData = {
+      ...state.tokens,
+      access_token: nextAccessToken,
+      refresh_token: nextRefreshToken,
+      ...(body.id_token !== undefined ? { id_token: body.id_token } : {}),
+    };
+    const refreshedIdTokenInfo = extractIdTokenInfo({
+      ...nextTokens,
+      account_id: undefined,
+    });
+    const accountId =
+      normalizeString(body.account_id) ??
+      refreshedIdTokenInfo.accountId ??
+      normalizeString(nextTokens.account_id);
+    if (accountId) {
+      nextTokens.account_id = accountId;
+    }
+
+    const nextAuth: CodexAuthJson = {
+      ...state.auth,
+      tokens: nextTokens,
+      last_refresh: new Date().toISOString(),
+    };
+    await this.persistAuth(nextAuth);
+    return {
+      auth: nextAuth,
+      tokens: nextTokens,
+      accessToken: nextAccessToken,
+      refreshToken: nextRefreshToken,
+    };
+  }
+
+  private async persistAuth(auth: CodexAuthJson): Promise<void> {
+    await mkdir(dirname(this.authPath), { recursive: true });
+    const tmpPath = `${this.authPath}.${process.pid}.${Date.now()}.tmp`;
+    await writeFile(tmpPath, `${JSON.stringify(auth, null, 2)}\n`, {
+      mode: 0o600,
+    });
+    await rename(tmpPath, this.authPath);
+    await chmod(this.authPath, 0o600).catch(() => undefined);
+  }
+}

--- a/runtime/src/llm/codex-oauth/index.ts
+++ b/runtime/src/llm/codex-oauth/index.ts
@@ -1,0 +1,8 @@
+export { CodexOAuthProvider } from "./adapter.js";
+export {
+  DEFAULT_CODEX_CLIENT_VERSION,
+  DEFAULT_CODEX_OAUTH_BASE_URL,
+  DEFAULT_CODEX_OAUTH_CONTEXT_WINDOW_TOKENS,
+  DEFAULT_CODEX_OAUTH_MODEL,
+  type CodexOAuthProviderConfig,
+} from "./types.js";

--- a/runtime/src/llm/codex-oauth/schema.test.ts
+++ b/runtime/src/llm/codex-oauth/schema.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeCodexJsonSchema } from "./schema.js";
+
+describe("sanitizeCodexJsonSchema", () => {
+  it("recursively adds missing items to array schemas without mutating input", () => {
+    const original = {
+      type: "object",
+      properties: {
+        constraints: {
+          anyOf: [
+            { type: "object" },
+            { type: "array" },
+            { type: "string" },
+          ],
+        },
+        nullableArray: {
+          type: ["array", "null"],
+        },
+        stringList: {
+          type: "array",
+          items: { type: "string" },
+        },
+        nestedArray: {
+          type: "array",
+          items: { type: "array" },
+        },
+        nonArrayUnion: {
+          type: ["string", "null"],
+        },
+        literalChoice: {
+          enum: ["fast", "safe"],
+        },
+      },
+    };
+
+    const sanitized = sanitizeCodexJsonSchema(original);
+
+    expect(sanitized).toEqual({
+      type: "object",
+      properties: {
+        constraints: {
+          anyOf: [
+            { type: "object" },
+            { type: "array", items: {} },
+            { type: "string" },
+          ],
+        },
+        nullableArray: {
+          type: ["array", "null"],
+          items: {},
+        },
+        stringList: {
+          type: "array",
+          items: { type: "string" },
+        },
+        nestedArray: {
+          type: "array",
+          items: { type: "array", items: {} },
+        },
+        nonArrayUnion: {
+          type: ["string", "null"],
+        },
+        literalChoice: {
+          enum: ["fast", "safe"],
+        },
+      },
+    });
+    expect(original.properties.constraints.anyOf[1]).toEqual({ type: "array" });
+    expect(original.properties.nullableArray).toEqual({
+      type: ["array", "null"],
+    });
+    expect(original.properties.nestedArray).toEqual({
+      type: "array",
+      items: { type: "array" },
+    });
+  });
+
+  it("handles primitive, null, and top-level array values", () => {
+    expect(sanitizeCodexJsonSchema(null)).toBeNull();
+    expect(sanitizeCodexJsonSchema("literal")).toBe("literal");
+    expect(sanitizeCodexJsonSchema([{ type: "array" }, 42])).toEqual([
+      { type: "array", items: {} },
+      42,
+    ]);
+  });
+});

--- a/runtime/src/llm/codex-oauth/schema.ts
+++ b/runtime/src/llm/codex-oauth/schema.ts
@@ -1,0 +1,28 @@
+/**
+ * Codex Responses API schema compatibility helpers.
+ *
+ * @module
+ */
+
+export function sanitizeCodexJsonSchema(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeCodexJsonSchema(entry));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    result[key] = sanitizeCodexJsonSchema(entry);
+  }
+
+  const type = result.type;
+  const declaresArray =
+    type === "array" ||
+    (Array.isArray(type) && type.some((entry) => entry === "array"));
+  if (declaresArray && result.items === undefined) {
+    result.items = {};
+  }
+  return result;
+}

--- a/runtime/src/llm/codex-oauth/types.ts
+++ b/runtime/src/llm/codex-oauth/types.ts
@@ -1,0 +1,38 @@
+/**
+ * OpenAI Codex OAuth provider configuration.
+ *
+ * The provider reuses the local Codex CLI ChatGPT OAuth credential store
+ * (`$CODEX_HOME/auth.json`, falling back to `~/.codex/auth.json`) instead of
+ * requiring an API key in AgenC config.
+ *
+ * @module
+ */
+
+import type { LLMProviderConfig } from "../types.js";
+
+export const DEFAULT_CODEX_OAUTH_BASE_URL =
+  "https://chatgpt.com/backend-api/codex";
+export const DEFAULT_CODEX_OAUTH_MODEL = "gpt-5.4";
+export const DEFAULT_CODEX_OAUTH_CONTEXT_WINDOW_TOKENS = 272_000;
+export const DEFAULT_CODEX_CLIENT_VERSION = "0.124.0";
+
+export interface CodexOAuthProviderConfig
+  extends Omit<LLMProviderConfig, "model">
+{
+  /** Model identifier; defaults to the Codex CLI's current default. */
+  model?: string;
+  /** Override the Codex backend URL. Defaults to ChatGPT's Codex endpoint. */
+  baseUrl?: string;
+  /** Override `$CODEX_HOME`; defaults to process.env.CODEX_HOME or `~/.codex`. */
+  codexHome?: string;
+  /** Full path to a Codex `auth.json` file. Takes precedence over codexHome. */
+  codexAuthPath?: string;
+  /** Override token refresh URL, primarily for tests/private deployments. */
+  refreshTokenUrl?: string;
+  /** Version header sent to the Codex backend. */
+  codexClientVersion?: string;
+  /** Optional operator override for effective context window budgeting. */
+  contextWindowTokens?: number;
+  /** Allow the model to emit multiple tool calls in parallel. */
+  parallelToolCalls?: boolean;
+}

--- a/runtime/src/llm/index.ts
+++ b/runtime/src/llm/index.ts
@@ -136,3 +136,15 @@ export type {
 // Provider adapters
 export { GrokProvider, type GrokProviderConfig } from "./grok/index.js";
 export { OllamaProvider, type OllamaProviderConfig } from "./ollama/index.js";
+export {
+  OpenAICompatProvider,
+  type OpenAICompatProviderConfig,
+} from "./openai-compat/index.js";
+export {
+  CodexOAuthProvider,
+  DEFAULT_CODEX_CLIENT_VERSION,
+  DEFAULT_CODEX_OAUTH_BASE_URL,
+  DEFAULT_CODEX_OAUTH_CONTEXT_WINDOW_TOKENS,
+  DEFAULT_CODEX_OAUTH_MODEL,
+  type CodexOAuthProviderConfig,
+} from "./codex-oauth/index.js";

--- a/runtime/src/llm/openai-compat/index.ts
+++ b/runtime/src/llm/openai-compat/index.ts
@@ -1,0 +1,2 @@
+export { OpenAICompatProvider } from "./adapter.js";
+export type { OpenAICompatProviderConfig } from "./types.js";

--- a/runtime/src/llm/types.ts
+++ b/runtime/src/llm/types.ts
@@ -199,7 +199,8 @@ export type LLMContextWindowSource =
   | "ollama_running_context_length"
   | "ollama_model_info"
   | "ollama_model_parameters"
-  | "ollama_default";
+  | "ollama_default"
+  | "codex_default";
 
 export interface LLMProviderExecutionProfile {
   /** Provider name exposed by the adapter. */


### PR DESCRIPTION
## Summary

- Add `CodexOAuthProvider` that reuses Codex CLI ChatGPT OAuth credentials from `~/.codex/auth.json` or configured paths.
- Send Codex-compatible Responses requests with streaming enabled, reasoning encrypted-content include, prompt cache metadata, and typed message input.
- Sanitize AgenC dotted tool names for the Codex backend while mapping returned tool calls back to original AgenC tool names.
- Normalize Codex tool JSON schemas so nested array schemas always include `items`, including `agenc.createTask.constraints.anyOf`.
- Wire `provider: "codex"` through gateway config validation, provider creation, context-window defaults, exports, and runtime docs.

## Root Cause

The Codex backend rejects generic OpenAI Responses payloads in this OAuth path. It requires `stream: true`, a Codex-shaped request body, and function tool names matching `^[a-zA-Z0-9_-]+$`; AgenC was previously sending generic message content and dotted tool names such as `system.echo`.

Codex also validates function JSON schemas more strictly than the generic tool registry. `agenc.createTask` exposed `constraints.anyOf[1]` as `{ "type": "array" }` without `items`, which caused the reported 400 before the model could answer.

## Validation

- `git diff --cached --check`
- `npm run test --workspace=@tetsuo-ai/runtime -- src/llm/codex-oauth/schema.test.ts src/llm/codex-oauth/adapter.test.ts`
- `npm exec --workspace=@tetsuo-ai/runtime -- vitest run src/llm/codex-oauth/schema.test.ts --coverage.enabled true --coverage.include src/llm/codex-oauth/schema.ts --coverage.reporter text` (100% statements, branches, functions, and lines for the schema-normalization feature)
- `npm run typecheck --workspace=@tetsuo-ai/runtime`
- `npm run build --workspace=@tetsuo-ai/runtime`
- Manual smoke: restarted local daemon with `provider: "codex"` and sent a WebChat turn through `ws://127.0.0.1:3100`, receiving `OK`.
