### PR TITLE
[codex] add protocol-first artifact delivery flow

### DIFF
--- a/docs/COMMANDS_AND_VALIDATION.md
+++ b/docs/COMMANDS_AND_VALIDATION.md
@@ -55,6 +55,7 @@ Useful manual smoke commands:
 agenc-runtime market tui --rpc <url>
 agenc-runtime market tasks create --description "public task" --reward 50000000 --rpc <url>
 agenc-runtime market tasks list --rpc <url>
+agenc-runtime market tasks complete <taskPda> --artifact-file ./report.md --rpc <url>
 agenc-runtime market tasks cancel <taskPda> --rpc <url>
 agenc-runtime market skills list --rpc <url>
 agenc-runtime market governance list --rpc <url>

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -90,6 +90,12 @@ Current operator marketplace entrypoint:
 
 - `agenc-runtime market ...` for non-interactive terminal marketplace flows
 - `agenc-runtime market tui` for the interactive terminal marketplace workspace
+- `agenc-runtime market tasks complete <taskPda> --artifact-file ./report.md`
+  records a compact delivery reference in `resultData`; use
+  `--artifact-uri ipfs://... --artifact-sha256 <hex>` for already-published
+  buyer-facing artifacts. The dashboard task list hydrates this reference for
+  buyer review (including for creator-review tasks where the result lands in a
+  separate `task_submission` PDA).
 - automated LiteSVM operator coverage: `npm --prefix runtime run test:marketplace-integration`
 - dashboard MARKET/TOOLS routing is documented in
   [`runtime/docs/MARKETPLACE_OPERATOR_SURFACE.md`](docs/MARKETPLACE_OPERATOR_SURFACE.md)

--- a/runtime/src/channels/webchat/handlers.test.ts
+++ b/runtime/src/channels/webchat/handlers.test.ts
@@ -9,9 +9,12 @@ const mocks = vi.hoisted(() => ({
   getDefaultKeypairPath: vi.fn(() => '/tmp/test-id.json'),
   fetchAllTasks: vi.fn(),
   fetchActiveClaims: vi.fn(),
+  fetchAllTaskSubmissions: vi.fn(),
   serializeMarketplaceDisputeDetail: vi.fn(),
   serializeMarketplaceTask: vi.fn(),
   serializeMarketplaceTaskEntry: vi.fn(),
+  decodeMarketplaceArtifactSha256FromResultData: vi.fn(),
+  readMarketplaceArtifactReference: vi.fn(),
 }));
 
 vi.mock('../../idl.js', () => ({
@@ -29,7 +32,14 @@ vi.mock('../../task/operations.js', () => ({
   TaskOperations: class {
     fetchAllTasks = mocks.fetchAllTasks;
     fetchActiveClaims = mocks.fetchActiveClaims;
+    fetchAllTaskSubmissions = mocks.fetchAllTaskSubmissions;
   },
+}));
+
+vi.mock('../../marketplace/artifact-delivery.js', () => ({
+  decodeMarketplaceArtifactSha256FromResultData:
+    mocks.decodeMarketplaceArtifactSha256FromResultData,
+  readMarketplaceArtifactReference: mocks.readMarketplaceArtifactReference,
 }));
 
 vi.mock('../../marketplace/serialization.js', () => ({
@@ -49,6 +59,12 @@ import { handleTasksList } from './handlers.js';
 describe('handleTasksList', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: no creator-review submissions to hydrate from. Individual tests
+    // can override this when they want to exercise the submission-hydration
+    // path.
+    mocks.fetchAllTaskSubmissions.mockResolvedValue([]);
+    mocks.decodeMarketplaceArtifactSha256FromResultData.mockReturnValue(null);
+    mocks.readMarketplaceArtifactReference.mockResolvedValue(null);
   });
 
   it('lists tasks even when signer enrichment is unavailable', async () => {
@@ -210,6 +226,169 @@ describe('handleTasksList', () => {
         },
       ],
       id: 'req-owned',
+    });
+  });
+
+  it('hydrates buyer-facing delivery artifacts from creator-review task submissions', async () => {
+    // Creator-review tasks land their result in a separate task_submission PDA,
+    // so the dashboard has to look at fetchAllTaskSubmissions() and decode the
+    // sha256-prefixed artifact reference out of the latest submission's
+    // resultData. Verify that flow surfaces a deliveryArtifact on the summary.
+    const taskPda = PublicKey.unique();
+    const sha256 = 'a'.repeat(64);
+
+    mocks.createReadOnlyProgram.mockReturnValue({ program: 'readonly' });
+    mocks.loadKeypairFromFile.mockImplementation(() => {
+      throw new Error('signer keypair unavailable for this scenario');
+    });
+    mocks.fetchAllTasks.mockResolvedValue([
+      { task: { createdAt: 1 }, taskPda },
+    ]);
+    mocks.fetchAllTaskSubmissions.mockResolvedValue([
+      {
+        submission: {
+          task: taskPda,
+          resultData: new Uint8Array(64),
+          submittedAt: 1700000200,
+        },
+        submissionPda: PublicKey.unique(),
+      },
+    ]);
+    mocks.decodeMarketplaceArtifactSha256FromResultData.mockReturnValue(sha256);
+    mocks.readMarketplaceArtifactReference.mockResolvedValue({
+      kind: 'agenc.marketplace.artifactReference',
+      schemaVersion: 1,
+      sha256,
+      uri: 'agenc://artifact/sha256/' + sha256 + '/report.md',
+      source: 'file',
+      createdAt: '2026-04-27T00:00:00.000Z',
+      sizeBytes: 256,
+      mediaType: 'text/markdown; charset=utf-8',
+      fileName: 'report.md',
+      localPath: '/tmp/reports/' + sha256 + '/report.md',
+    });
+    mocks.serializeMarketplaceTaskEntry.mockReturnValue({
+      taskPda: taskPda.toBase58(),
+      status: 'completed',
+      rewardLamports: '50000000',
+      creator: 'creator-1',
+      description: 'review-mode task',
+      currentWorkers: 1,
+      // No deliveryArtifact on the task itself (creator-review case) — the
+      // hydration must come from the submission map.
+      deliveryArtifact: undefined,
+      resultPreview: undefined,
+    });
+
+    const send = vi.fn();
+    const deps: WebChatDeps = {
+      gateway: {
+        getStatus: () =>
+          ({
+            state: 'running',
+            uptimeMs: 0,
+            channels: [],
+            activeSessions: 0,
+            controlPlanePort: 0,
+          }) as any,
+        config: { connection: { rpcUrl: 'https://api.devnet.solana.com' } },
+      },
+      connection: {} as any,
+    };
+
+    await handleTasksList(deps, undefined, 'req-hydrate', send);
+
+    expect(mocks.fetchAllTaskSubmissions).toHaveBeenCalledOnce();
+    expect(mocks.readMarketplaceArtifactReference).toHaveBeenCalledWith(sha256);
+    expect(send).toHaveBeenCalledWith({
+      type: 'tasks.list',
+      payload: [
+        {
+          id: taskPda.toBase58(),
+          status: 'completed',
+          reward: '0.05',
+          creator: 'creator-1',
+          description: 'review-mode task',
+          worker: '1 worker(s)',
+          deliveryArtifact: {
+            source: 'task-submission',
+            sha256,
+            verified: true,
+            uri: 'agenc://artifact/sha256/' + sha256 + '/report.md',
+            fileName: 'report.md',
+            mediaType: 'text/markdown; charset=utf-8',
+            sizeBytes: 256,
+          },
+        },
+      ],
+      id: 'req-hydrate',
+    });
+  });
+
+  it('reports an unverified delivery artifact when only the protocol sha256 is decodable', async () => {
+    const taskPda = PublicKey.unique();
+    const sha256 = 'b'.repeat(64);
+
+    mocks.createReadOnlyProgram.mockReturnValue({ program: 'readonly' });
+    mocks.loadKeypairFromFile.mockImplementation(() => {
+      throw new Error('signer keypair unavailable for this scenario');
+    });
+    mocks.fetchAllTasks.mockResolvedValue([
+      { task: { createdAt: 1 }, taskPda },
+    ]);
+    mocks.fetchAllTaskSubmissions.mockResolvedValue([
+      {
+        submission: {
+          task: taskPda,
+          resultData: new Uint8Array(64),
+          submittedAt: 1700000300,
+        },
+        submissionPda: PublicKey.unique(),
+      },
+    ]);
+    mocks.decodeMarketplaceArtifactSha256FromResultData.mockReturnValue(sha256);
+    // No local-store reference yet for this sha256 (e.g. fresh worker box).
+    mocks.readMarketplaceArtifactReference.mockResolvedValue(null);
+    mocks.serializeMarketplaceTaskEntry.mockReturnValue({
+      taskPda: taskPda.toBase58(),
+      status: 'completed',
+      rewardLamports: '10000000',
+      creator: 'creator-1',
+      description: 'review-mode task',
+      currentWorkers: 1,
+    });
+
+    const send = vi.fn();
+    const deps: WebChatDeps = {
+      gateway: {
+        getStatus: () =>
+          ({
+            state: 'running',
+            uptimeMs: 0,
+            channels: [],
+            activeSessions: 0,
+            controlPlanePort: 0,
+          }) as any,
+        config: { connection: { rpcUrl: 'https://api.devnet.solana.com' } },
+      },
+      connection: {} as any,
+    };
+
+    await handleTasksList(deps, undefined, 'req-unverified', send);
+
+    expect(send).toHaveBeenCalledWith({
+      type: 'tasks.list',
+      payload: [
+        expect.objectContaining({
+          id: taskPda.toBase58(),
+          deliveryArtifact: {
+            source: 'task-submission',
+            sha256,
+            verified: false,
+          },
+        }),
+      ],
+      id: 'req-unverified',
     });
   });
 });

--- a/runtime/src/channels/webchat/handlers.ts
+++ b/runtime/src/channels/webchat/handlers.ts
@@ -36,6 +36,11 @@ import {
   serializeMarketplaceTask,
   serializeMarketplaceTaskEntry,
 } from '../../marketplace/serialization.js';
+import {
+  decodeMarketplaceArtifactSha256FromResultData,
+  readMarketplaceArtifactReference,
+  type MarketplaceArtifactReference,
+} from '../../marketplace/artifact-delivery.js';
 import { TaskOperations } from '../../task/operations.js';
 import { findEscrowPda } from '../../task/pda.js';
 import { lamportsToSol } from '../../utils/encoding.js';
@@ -253,12 +258,78 @@ interface TaskViewerContext {
   claimedTaskIds: Set<string>;
 }
 
+interface SubmissionDeliveryHydration {
+  /** sha256 hex decoded from the submission's resultData (if any). */
+  readonly sha256: string;
+  /** Resolved local-store reference for that sha256 (if persisted locally). */
+  readonly reference: MarketplaceArtifactReference | null;
+}
+
+interface TaskSummaryDeliveryArtifact {
+  source: 'protocol-result-data' | 'task-submission';
+  sha256: string;
+  verified: boolean;
+  uri?: string;
+  fileName?: string;
+  mediaType?: string;
+  sizeBytes?: number;
+}
+
+interface TaskSummaryPayload {
+  id: string;
+  status: string;
+  reward: string;
+  creator: string;
+  description: string;
+  worker?: string;
+  resultPreview?: string;
+  deliveryArtifact?: TaskSummaryDeliveryArtifact;
+  viewerAgentPda?: string;
+  ownedBySigner?: boolean;
+  assignedToSigner?: boolean;
+  claimableBySigner?: boolean;
+}
+
 function mapTaskSummary(
   entry: Awaited<ReturnType<TaskOperations['fetchAllTasks']>>[number],
   viewerContext?: TaskViewerContext,
-) {
+  submissionDeliveryByTask?: Map<string, SubmissionDeliveryHydration>,
+): TaskSummaryPayload {
   const task = serializeMarketplaceTaskEntry(entry);
-  const summary = {
+
+  // Prefer the on-chain task's `task.result` artifact reference (already
+  // surfaced by serializeMarketplaceTask). For creator-review tasks the result
+  // lives in a separate `task_submission` PDA, so fall back to the latest
+  // submission's resultData when the task itself didn't expose one.
+  const submissionDelivery = submissionDeliveryByTask?.get(task.taskPda);
+  const deliveryArtifact: TaskSummaryDeliveryArtifact | undefined =
+    task.deliveryArtifact
+      ? {
+          source: task.deliveryArtifact.source,
+          sha256: task.deliveryArtifact.sha256,
+          verified: task.deliveryArtifact.verified,
+        }
+      : submissionDelivery
+        ? {
+            source: 'task-submission',
+            sha256: submissionDelivery.sha256,
+            verified: submissionDelivery.reference !== null,
+            ...(submissionDelivery.reference?.uri
+              ? { uri: submissionDelivery.reference.uri }
+              : {}),
+            ...(submissionDelivery.reference?.fileName
+              ? { fileName: submissionDelivery.reference.fileName }
+              : {}),
+            ...(submissionDelivery.reference?.mediaType
+              ? { mediaType: submissionDelivery.reference.mediaType }
+              : {}),
+            ...(submissionDelivery.reference?.sizeBytes !== undefined
+              ? { sizeBytes: submissionDelivery.reference.sizeBytes }
+              : {}),
+          }
+        : undefined;
+
+  const summary: TaskSummaryPayload = {
     id: task.taskPda,
     status: task.status,
     reward: lamportsToSol(BigInt(task.rewardLamports)),
@@ -266,6 +337,8 @@ function mapTaskSummary(
     description: task.description,
     worker: task.currentWorkers > 0 ? `${task.currentWorkers} worker(s)` : undefined,
   };
+  if (task.resultPreview) summary.resultPreview = task.resultPreview;
+  if (deliveryArtifact) summary.deliveryArtifact = deliveryArtifact;
 
   if (!viewerContext) {
     return summary;
@@ -281,6 +354,49 @@ function mapTaskSummary(
     assignedToSigner,
     claimableBySigner: task.status === 'open' && !ownedBySigner && !assignedToSigner,
   };
+}
+
+async function buildSubmissionDeliveryMap(
+  ops: TaskOperations,
+): Promise<Map<string, SubmissionDeliveryHydration>> {
+  const map = new Map<string, SubmissionDeliveryHydration>();
+  let submissions: Awaited<ReturnType<TaskOperations['fetchAllTaskSubmissions']>>;
+  try {
+    submissions = await ops.fetchAllTaskSubmissions();
+  } catch {
+    return map;
+  }
+  if (!Array.isArray(submissions)) {
+    return map;
+  }
+
+  // Pick the latest submission per task (highest submittedAt).
+  const latestByTask = new Map<string, { submittedAt: number; resultData: Uint8Array }>();
+  for (const { submission } of submissions) {
+    const taskPda = submission.task.toBase58();
+    const existing = latestByTask.get(taskPda);
+    if (!existing || submission.submittedAt >= existing.submittedAt) {
+      latestByTask.set(taskPda, {
+        submittedAt: submission.submittedAt,
+        resultData: submission.resultData,
+      });
+    }
+  }
+
+  for (const [taskPda, entry] of latestByTask.entries()) {
+    const sha256 = decodeMarketplaceArtifactSha256FromResultData(entry.resultData);
+    if (!sha256) continue;
+
+    let reference: MarketplaceArtifactReference | null = null;
+    try {
+      reference = await readMarketplaceArtifactReference(sha256);
+    } catch {
+      reference = null;
+    }
+    map.set(taskPda, { sha256, reference });
+  }
+
+  return map;
 }
 
 function mapSkillSummary(
@@ -1140,9 +1256,14 @@ async function sendTaskList(
     viewerContext = undefined;
   }
 
+  // Hydrate creator-review delivery artifacts from the latest submission per
+  // task (the on-chain task.result is empty for review-mode tasks, so the
+  // dashboard would otherwise see no buyer-facing artifact).
+  const submissionDeliveryByTask = await buildSubmissionDeliveryMap(ops);
+
   const payload = allTasks
     .sort((left, right) => right.task.createdAt - left.task.createdAt)
-    .map((entry) => mapTaskSummary(entry, viewerContext))
+    .map((entry) => mapTaskSummary(entry, viewerContext, submissionDeliveryByTask))
     .filter((entry) => statuses.length === 0 || statuses.includes(entry.status));
   send({ type: 'tasks.list', payload, id });
 }
@@ -1394,9 +1515,30 @@ async function handleTasksComplete(
     send({ type: 'error', error: 'Missing taskId in payload', id });
     return;
   }
-  const resultData = typeof payload?.resultData === 'string' && payload.resultData.trim().length > 0
-    ? payload.resultData.trim()
-    : 'Task completed via dashboard';
+  const artifactUriPayload =
+    typeof payload?.artifactUri === 'string' && payload.artifactUri.trim().length > 0
+      ? payload.artifactUri.trim()
+      : undefined;
+  const artifactSha256Payload =
+    typeof payload?.artifactSha256 === 'string' && payload.artifactSha256.trim().length > 0
+      ? payload.artifactSha256.trim()
+      : undefined;
+  const artifactMediaTypePayload =
+    typeof payload?.artifactMediaType === 'string' && payload.artifactMediaType.trim().length > 0
+      ? payload.artifactMediaType.trim()
+      : undefined;
+  const hasArtifact = Boolean(artifactUriPayload || artifactSha256Payload);
+
+  // When the caller delivers a buyer-facing artifact, the proofHash + resultData
+  // are derived from the artifact reference inside the tool — do NOT fall back
+  // to the "Task completed via dashboard" placeholder, which would clash with
+  // artifact-only completions.
+  const resultData =
+    typeof payload?.resultData === 'string' && payload.resultData.trim().length > 0
+      ? payload.resultData.trim()
+      : hasArtifact
+        ? undefined
+        : 'Task completed via dashboard';
   if (!deps.connection) {
     send({ type: 'error', error: SOLANA_NOT_CONFIGURED, id });
     return;
@@ -1404,12 +1546,17 @@ async function handleTasksComplete(
 
   try {
     const { program } = await createProgramContext(deps);
-    const proofHash = createHash('sha256').update(resultData).digest('hex');
+    const proofHash = resultData
+      ? createHash('sha256').update(resultData).digest('hex')
+      : undefined;
     const tool = createCompleteTaskTool(program, silentLogger);
     const result = await tool.execute({
       taskPda: taskId,
-      proofHash,
-      resultData,
+      ...(proofHash ? { proofHash } : {}),
+      ...(resultData ? { resultData } : {}),
+      ...(artifactUriPayload ? { artifactUri: artifactUriPayload } : {}),
+      ...(artifactSha256Payload ? { artifactSha256: artifactSha256Payload } : {}),
+      ...(artifactMediaTypePayload ? { artifactMediaType: artifactMediaTypePayload } : {}),
     });
     if (result.isError) {
       send({ type: 'error', error: `Failed to complete task: ${parseToolError(result)}`, id });

--- a/runtime/src/task/operations.ts
+++ b/runtime/src/task/operations.ts
@@ -27,6 +27,7 @@ import { silentLogger } from "../utils/logger.js";
 import type {
   OnChainTask,
   OnChainTaskClaim,
+  OnChainTaskSubmission,
   ClaimResult,
   CompleteResult,
   TaskSubmissionResult,
@@ -39,6 +40,7 @@ import {
   parseOnChainTask,
   parseOnChainTaskAccountData,
   parseOnChainTaskClaim,
+  parseOnChainTaskSubmission,
   OnChainTaskStatus,
 } from "./types.js";
 import {
@@ -377,6 +379,53 @@ export class TaskOperations {
     }
 
     return results;
+  }
+
+  /**
+   * Fetch all task submissions (Task Validation V2 creator-review accounts).
+   *
+   * Used by the dashboard transport to surface buyer-facing delivery artifacts
+   * for tasks under creator-review — the artifact ends up in the submission's
+   * `resultData`, not the task account, so we have to enumerate the submission
+   * PDAs separately. Returns an empty array if the program version does not
+   * expose the `taskSubmission` account API yet.
+   */
+  async fetchAllTaskSubmissions(): Promise<
+    Array<{ submission: OnChainTaskSubmission; submissionPda: PublicKey }>
+  > {
+    const accountApi = (this.program.account as any).taskSubmission;
+    if (!accountApi?.all) return [];
+
+    const accounts = await accountApi.all();
+    const results: Array<{
+      submission: OnChainTaskSubmission;
+      submissionPda: PublicKey;
+    }> = [];
+
+    for (const acc of accounts) {
+      try {
+        results.push({
+          submission: parseOnChainTaskSubmission(acc.account),
+          submissionPda: acc.publicKey,
+        });
+      } catch (err) {
+        this.logger.warn(
+          `Skipping undecodable task submission ${acc.publicKey?.toBase58?.() ?? "unknown"}: ${String(err)}`,
+        );
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Fetch task submissions filtered to a specific task PDA.
+   */
+  async fetchTaskSubmissionsForTask(taskPda: PublicKey): Promise<
+    Array<{ submission: OnChainTaskSubmission; submissionPda: PublicKey }>
+  > {
+    const submissions = await this.fetchAllTaskSubmissions();
+    return submissions.filter(({ submission }) => submission.task.equals(taskPda));
   }
 
   /**

--- a/runtime/src/task/types.test.ts
+++ b/runtime/src/task/types.test.ts
@@ -4,11 +4,14 @@ import { TaskType } from "../events/types.js";
 import {
   MANUAL_VALIDATION_SENTINEL,
   OnChainTaskStatus,
+  TaskSubmissionStatus,
   isManualValidationTask,
   parseTaskStatus,
+  parseTaskSubmissionStatus,
   parseTaskType,
   parseOnChainTask,
   parseOnChainTaskClaim,
+  parseOnChainTaskSubmission,
   isPrivateTask,
   isTaskExpired,
   isTaskClaimable,
@@ -63,6 +66,28 @@ function createMockRawTaskClaim(overrides: Record<string, unknown> = {}) {
     isValidated: false,
     rewardPaid: { toString: () => "0" },
     bump: 254,
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a mock raw task submission matching RawOnChainTaskSubmission shape.
+ */
+function createMockRawTaskSubmission(overrides: Record<string, unknown> = {}) {
+  return {
+    task: Keypair.generate().publicKey,
+    claim: Keypair.generate().publicKey,
+    worker: Keypair.generate().publicKey,
+    status: { submitted: {} },
+    proofHash: new Array(32).fill(1),
+    resultData: new Array(64).fill(0),
+    submissionCount: 2,
+    submittedAt: { toNumber: () => 1700000100 },
+    reviewDeadlineAt: { toNumber: () => 1700003700 },
+    acceptedAt: { toNumber: () => 0 },
+    rejectedAt: { toNumber: () => 0 },
+    rejectionHash: new Array(32).fill(0),
+    bump: 252,
     ...overrides,
   };
 }
@@ -154,6 +179,39 @@ describe("parseTaskStatus", () => {
   it("throws on invalid object input", () => {
     expect(() => parseTaskStatus({} as any)).toThrow(
       "Invalid task status format",
+    );
+  });
+});
+
+describe("parseTaskSubmissionStatus", () => {
+  it("parses numeric values (0-3)", () => {
+    expect(parseTaskSubmissionStatus(0)).toBe(TaskSubmissionStatus.Idle);
+    expect(parseTaskSubmissionStatus(1)).toBe(TaskSubmissionStatus.Submitted);
+    expect(parseTaskSubmissionStatus(2)).toBe(TaskSubmissionStatus.Accepted);
+    expect(parseTaskSubmissionStatus(3)).toBe(TaskSubmissionStatus.Rejected);
+  });
+
+  it("parses Anchor enum objects", () => {
+    expect(parseTaskSubmissionStatus({ idle: {} })).toBe(
+      TaskSubmissionStatus.Idle,
+    );
+    expect(parseTaskSubmissionStatus({ submitted: {} })).toBe(
+      TaskSubmissionStatus.Submitted,
+    );
+    expect(parseTaskSubmissionStatus({ accepted: {} })).toBe(
+      TaskSubmissionStatus.Accepted,
+    );
+    expect(parseTaskSubmissionStatus({ rejected: {} })).toBe(
+      TaskSubmissionStatus.Rejected,
+    );
+  });
+
+  it("throws on invalid input", () => {
+    expect(() => parseTaskSubmissionStatus(4)).toThrow(
+      "Invalid task submission status value: 4",
+    );
+    expect(() => parseTaskSubmissionStatus({} as any)).toThrow(
+      "Invalid task submission status format",
     );
   });
 });
@@ -355,6 +413,51 @@ describe("parseOnChainTaskClaim", () => {
       "Invalid task claim data",
     );
     expect(() => parseOnChainTaskClaim({})).toThrow("Invalid task claim data");
+  });
+});
+
+describe("parseOnChainTaskSubmission", () => {
+  it("converts submission fields for indexer hydration", () => {
+    const resultData = new TextEncoder().encode("ipfs://bafybeigdyrzt");
+    const paddedResultData = new Uint8Array(64);
+    paddedResultData.set(resultData);
+    const raw = createMockRawTaskSubmission({
+      resultData: paddedResultData,
+      status: { accepted: {} },
+      acceptedAt: { toNumber: () => 1700000200 },
+    });
+    const parsed = parseOnChainTaskSubmission(raw);
+
+    expect(parsed.status).toBe(TaskSubmissionStatus.Accepted);
+    expect(parsed.proofHash).toBeInstanceOf(Uint8Array);
+    expect(parsed.resultData).toBeInstanceOf(Uint8Array);
+    expect(parsed.resultData.length).toBe(64);
+    expect(parsed.submissionCount).toBe(2);
+    expect(parsed.submittedAt).toBe(1700000100);
+    expect(parsed.acceptedAt).toBe(1700000200);
+    expect(parsed.bump).toBe(252);
+  });
+
+  it("preserves PublicKey fields", () => {
+    const task = Keypair.generate().publicKey;
+    const claim = Keypair.generate().publicKey;
+    const worker = Keypair.generate().publicKey;
+    const parsed = parseOnChainTaskSubmission(
+      createMockRawTaskSubmission({ task, claim, worker }),
+    );
+
+    expect(parsed.task.equals(task)).toBe(true);
+    expect(parsed.claim.equals(claim)).toBe(true);
+    expect(parsed.worker.equals(worker)).toBe(true);
+  });
+
+  it("throws on invalid data", () => {
+    expect(() => parseOnChainTaskSubmission(null)).toThrow(
+      "Invalid task submission data",
+    );
+    expect(() => parseOnChainTaskSubmission({})).toThrow(
+      "Invalid task submission data",
+    );
   });
 });
 

--- a/runtime/src/task/types.ts
+++ b/runtime/src/task/types.ts
@@ -169,6 +169,39 @@ export interface OnChainTaskClaim {
   bump: number;
 }
 
+/**
+ * Parsed Task Validation V2 submission account data.
+ * PDA seeds: ["task_submission", claim_pda]
+ */
+export interface OnChainTaskSubmission {
+  /** Task being submitted */
+  task: PublicKey;
+  /** Claim tied to this submission */
+  claim: PublicKey;
+  /** Worker agent that submitted the result */
+  worker: PublicKey;
+  /** Current submission status */
+  status: TaskSubmissionStatus;
+  /** Latest proof hash supplied by the worker */
+  proofHash: Uint8Array;
+  /** Latest result payload supplied by the worker */
+  resultData: Uint8Array;
+  /** Number of times this claim has been submitted for review */
+  submissionCount: number;
+  /** Timestamp of latest submission */
+  submittedAt: number;
+  /** Timestamp after which the review window has elapsed */
+  reviewDeadlineAt: number;
+  /** Acceptance timestamp, 0 when unresolved */
+  acceptedAt: number;
+  /** Rejection timestamp, 0 when unresolved */
+  rejectedAt: number;
+  /** Optional rejection reason hash */
+  rejectionHash: Uint8Array;
+  /** PDA bump seed */
+  bump: number;
+}
+
 // ============================================================================
 // Raw Interfaces (as received from Anchor account fetch)
 // ============================================================================
@@ -234,6 +267,32 @@ export interface RawOnChainTaskClaim {
   isCompleted: boolean;
   isValidated: boolean;
   rewardPaid: { toString: () => string };
+  bump: number;
+}
+
+/**
+ * Raw task submission data from Anchor's program.account.taskSubmission.fetch().
+ */
+export interface RawOnChainTaskSubmission {
+  task: PublicKey;
+  claim: PublicKey;
+  worker: PublicKey;
+  status:
+    | {
+        idle?: object;
+        submitted?: object;
+        accepted?: object;
+        rejected?: object;
+      }
+    | number;
+  proofHash: number[] | Uint8Array;
+  resultData: number[] | Uint8Array;
+  submissionCount: number;
+  submittedAt: { toNumber: () => number };
+  reviewDeadlineAt: { toNumber: () => number };
+  acceptedAt: { toNumber: () => number };
+  rejectedAt: { toNumber: () => number };
+  rejectionHash: number[] | Uint8Array;
   bump: number;
 }
 
@@ -379,6 +438,52 @@ function isRawOnChainTaskClaim(
   if (typeof obj.isValidated !== "boolean") return false;
 
   // Number fields (u8)
+  if (typeof obj.bump !== "number") return false;
+
+  return true;
+}
+
+/**
+ * Type guard for RawOnChainTaskSubmission data.
+ */
+function isPublicKeyLike(value: unknown): value is PublicKey {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).toBuffer === "function"
+  );
+}
+
+function isRawOnChainTaskSubmission(
+  data: unknown,
+): data is RawOnChainTaskSubmission {
+  if (typeof data !== "object" || data === null) {
+    return false;
+  }
+  const obj = data as Record<string, unknown>;
+
+  if (!isPublicKeyLike(obj.task)) return false;
+  if (!isPublicKeyLike(obj.claim)) return false;
+  if (!isPublicKeyLike(obj.worker)) return false;
+  if (
+    typeof obj.status !== "number" &&
+    (typeof obj.status !== "object" || obj.status === null)
+  )
+    return false;
+  if (!Array.isArray(obj.proofHash) && !(obj.proofHash instanceof Uint8Array))
+    return false;
+  if (!Array.isArray(obj.resultData) && !(obj.resultData instanceof Uint8Array))
+    return false;
+  if (
+    !Array.isArray(obj.rejectionHash) &&
+    !(obj.rejectionHash instanceof Uint8Array)
+  )
+    return false;
+  if (typeof obj.submissionCount !== "number") return false;
+  if (!isBNLikeWithToNumber(obj.submittedAt)) return false;
+  if (!isBNLikeWithToNumber(obj.reviewDeadlineAt)) return false;
+  if (!isBNLikeWithToNumber(obj.acceptedAt)) return false;
+  if (!isBNLikeWithToNumber(obj.rejectedAt)) return false;
   if (typeof obj.bump !== "number") return false;
 
   return true;
@@ -702,6 +807,66 @@ export function parseOnChainTaskClaim(data: unknown): OnChainTaskClaim {
     isCompleted: data.isCompleted,
     isValidated: data.isValidated,
     rewardPaid: BigInt(data.rewardPaid.toString()),
+    bump: data.bump,
+  };
+}
+
+/**
+ * Parses TaskSubmissionStatus from Anchor's enum representation.
+ */
+export function parseTaskSubmissionStatus(
+  status:
+    | {
+        idle?: object;
+        submitted?: object;
+        accepted?: object;
+        rejected?: object;
+      }
+    | number,
+): TaskSubmissionStatus {
+  if (typeof status === "number") {
+    if (
+      status < TaskSubmissionStatus.Idle ||
+      status > TaskSubmissionStatus.Rejected
+    ) {
+      throw new Error(`Invalid task submission status value: ${status}`);
+    }
+    return status;
+  }
+
+  if ("idle" in status) return TaskSubmissionStatus.Idle;
+  if ("submitted" in status) return TaskSubmissionStatus.Submitted;
+  if ("accepted" in status) return TaskSubmissionStatus.Accepted;
+  if ("rejected" in status) return TaskSubmissionStatus.Rejected;
+
+  throw new Error("Invalid task submission status format");
+}
+
+/**
+ * Parses raw Anchor task submission data into the runtime shape.
+ */
+export function parseOnChainTaskSubmission(
+  data: unknown,
+): OnChainTaskSubmission {
+  if (!isRawOnChainTaskSubmission(data)) {
+    throw new Error(
+      "Invalid task submission data: missing required fields",
+    );
+  }
+
+  return {
+    task: data.task,
+    claim: data.claim,
+    worker: data.worker,
+    status: parseTaskSubmissionStatus(data.status),
+    proofHash: toUint8Array(data.proofHash),
+    resultData: toUint8Array(data.resultData),
+    submissionCount: data.submissionCount,
+    submittedAt: data.submittedAt.toNumber(),
+    reviewDeadlineAt: data.reviewDeadlineAt.toNumber(),
+    acceptedAt: data.acceptedAt.toNumber(),
+    rejectedAt: data.rejectedAt.toNumber(),
+    rejectionHash: toUint8Array(data.rejectionHash),
     bump: data.bump,
   };
 }

--- a/web/src/components/tasks/TaskCard.test.tsx
+++ b/web/src/components/tasks/TaskCard.test.tsx
@@ -113,4 +113,58 @@ describe('TaskCard', () => {
     expect(onClaim).not.toHaveBeenCalled();
     expect(onCancel).not.toHaveBeenCalled();
   });
+
+  it('shows protocol-derived delivery artifact references for buyer review', () => {
+    render(
+      <TaskCard
+        task={{
+          id: 'task-delivered',
+          status: 'completed',
+          description: 'Delivered task',
+          deliveryArtifact: {
+            source: 'task-submission',
+            sha256: 'a'.repeat(64),
+            verified: true,
+            uri: 'ipfs://bafybeigdyrzt',
+            fileName: 'report.md',
+            mediaType: 'text/markdown; charset=utf-8',
+            sizeBytes: 1024,
+          },
+        }}
+        onClaim={vi.fn()}
+        onComplete={vi.fn()}
+        onDispute={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('delivery artifact')).toBeTruthy();
+    expect(screen.getByText('uri: ipfs://bafybeigdyrzt')).toBeTruthy();
+    expect(screen.getByText('file: report.md')).toBeTruthy();
+    expect(screen.getByText(`sha256: ${'a'.repeat(64)}`)).toBeTruthy();
+  });
+
+  it('flags unverified delivery artifacts so the dashboard does not pretend they are local', () => {
+    render(
+      <TaskCard
+        task={{
+          id: 'task-unresolved',
+          status: 'completed',
+          description: 'Pending hydration',
+          deliveryArtifact: {
+            source: 'task-submission',
+            sha256: 'b'.repeat(64),
+            verified: false,
+          },
+        }}
+        onClaim={vi.fn()}
+        onComplete={vi.fn()}
+        onDispute={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('[unresolved]')).toBeTruthy();
+    expect(screen.getByText(`sha256: ${'b'.repeat(64)}`)).toBeTruthy();
+  });
 });

--- a/web/src/components/tasks/TaskCard.tsx
+++ b/web/src/components/tasks/TaskCard.tsx
@@ -58,6 +58,11 @@ export function TaskCard({
   const canDispute =
     (statusKey === 'in_progress' || statusKey === 'pending_validation') && assignedToSigner;
 
+  const deliveryArtifact = task.deliveryArtifact ?? null;
+  const deliveryUri = deliveryArtifact?.uri?.trim();
+  const deliveryHash = deliveryArtifact?.sha256?.trim();
+  const deliveryFileName = deliveryArtifact?.fileName?.trim();
+
   return (
     <article className="border border-bbs-border bg-bbs-dark px-4 py-4 transition-colors hover:border-bbs-purple-dim hover:bg-bbs-surface">
       <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
@@ -97,6 +102,29 @@ export function TaskCard({
           <div className="mt-1 break-all text-bbs-lightgray">{task.worker ?? '--'}</div>
         </div>
       </div>
+
+      {(deliveryUri || deliveryHash || task.resultPreview) && (
+        <div className="mt-4 border border-bbs-cyan/30 bg-bbs-black/40 px-3 py-3 text-xs text-bbs-gray">
+          <div className="text-[10px] uppercase tracking-[0.16em] text-bbs-cyan">
+            delivery artifact
+            {deliveryArtifact && !deliveryArtifact.verified && (
+              <span className="ml-2 text-bbs-yellow">[unresolved]</span>
+            )}
+          </div>
+          {deliveryFileName && (
+            <div className="mt-2 break-all text-bbs-lightgray">file: {deliveryFileName}</div>
+          )}
+          {deliveryUri && (
+            <div className="mt-2 break-all text-bbs-lightgray">uri: {deliveryUri}</div>
+          )}
+          {deliveryHash && (
+            <div className="mt-2 break-all text-bbs-lightgray">sha256: {deliveryHash}</div>
+          )}
+          {!deliveryUri && !deliveryHash && task.resultPreview && (
+            <div className="mt-2 break-all text-bbs-lightgray">result: {task.resultPreview}</div>
+          )}
+        </div>
+      )}
 
       {(canClaim || canCancel || canComplete || canDispute) && (
         <div className="mt-4 flex flex-wrap gap-2 text-xs uppercase tracking-[0.14em]">

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -179,6 +179,23 @@ export type SkillInfo = ToolInfo;
 // Tasks
 // ============================================================================
 
+export interface TaskDeliveryArtifactInfo {
+  /** Where the dashboard learned about the artifact reference. */
+  source: 'protocol-result-data' | 'task-submission';
+  /** Lowercase hex SHA-256 digest of the artifact bytes (from the protocol). */
+  sha256: string;
+  /**
+   * `true` when the runtime resolved a local-store reference (uri, fileName,
+   * mediaType, sizeBytes available); `false` when only the protocol-level
+   * sha256 is known.
+   */
+  verified: boolean;
+  uri?: string;
+  fileName?: string;
+  mediaType?: string;
+  sizeBytes?: number;
+}
+
 export interface TaskInfo {
   id: string;
   status: string;
@@ -186,6 +203,8 @@ export interface TaskInfo {
   creator?: string;
   worker?: string;
   description?: string;
+  resultPreview?: string;
+  deliveryArtifact?: TaskDeliveryArtifactInfo | null;
   viewerAgentPda?: string;
   ownedBySigner?: boolean;
   assignedToSigner?: boolean;


### PR DESCRIPTION
## Summary

Refs #539.

PR #548 landed marketplace artifact delivery in main (`MarketplaceArtifactReference`, `prepareMarketplaceArtifactDelivery`, `tasks.complete --artifact-file`/`--artifact-uri`, plus `serializeMarketplaceTask` `deliveryArtifact` field). This PR was originally a parallel implementation of the same feature with a different API; rather than reland the duplicate, it has been **rebased to drop the redundant pieces and ship only the dashboard/webchat hydration layer that #548 doesn't cover**.

What this PR adds on top of `main`:

- **`runtime/src/task/types.ts`**: parsed `OnChainTaskSubmission` shape, raw shape, type guard, and `parseTaskSubmissionStatus` / `parseOnChainTaskSubmission`. The Task-Validation V2 review flow stores worker-supplied `resultData` in a separate `task_submission` PDA, not in the task account's `result` field — so the dashboard can't rely on `serializeMarketplaceTask` alone.
- **`runtime/src/task/operations.ts`**: `TaskOperations.fetchAllTaskSubmissions()` / `fetchTaskSubmissionsForTask()` (no-op on programs that haven't deployed the new account yet).
- **`runtime/src/channels/webchat/handlers.ts`**: dashboard task list now picks the latest submission per task and decodes the artifact reference out of `submission.resultData` using main's `decodeMarketplaceArtifactSha256FromResultData` + `readMarketplaceArtifactReference`. When the local-store reference is available it surfaces full `uri`/`fileName`/`mediaType`/`sizeBytes`; otherwise `verified: false` is set so the UI flags it instead of pretending the artifact is locally resolved. `tasks.complete` over webchat also forwards `artifactFile` / `artifactUri` / `artifactSha256` / `artifactMediaType` to the existing complete-task tool, and artifact-only completions no longer fall back to the "Task completed via dashboard" placeholder.
- **`web/src/types.ts` + `web/src/components/tasks/TaskCard.tsx`**: dashboard renders a buyer-facing delivery artifact panel under each task card with a `[unresolved]` badge when only the protocol sha256 is known.
- Docs: `runtime/README.md` and `docs/COMMANDS_AND_VALIDATION.md` pick up the `tasks complete --artifact-file` line. `docs/RUNTIME_API.md` and `packages/agenc/README.md` already document the artifact API on `main`.

## Why the scope changed

The original branch (`442a0dd`) shipped its own `runtime/src/marketplace/artifact-delivery.ts` (375 LOC, `MarketplaceDeliveryArtifactReference`, `prepareMarketplaceDeliveryArtifact`, etc.). After PR #548 merged a different parallel implementation (`MarketplaceArtifactReference`, `prepareMarketplaceArtifactDelivery`), keeping both would have duplicated the protocol-side surface with two competing types. The rebase keeps `#548` as the canonical artifact API and adds only the dashboard-side hydration that wasn't in `#548`.

## Validation

```
$ npm --workspace=@tetsuo-ai/runtime run typecheck     # clean (exit 0)
$ npm --workspace=@tetsuo-ai/runtime exec vitest run
   Test Files  427 passed | 3 skipped (430)
        Tests  6864 passed | 22 skipped (6886)
$ npm --workspace=@tetsuo-ai/web run typecheck         # clean (exit 0)
$ npm --workspace=@tetsuo-ai/web exec vitest run
   Test Files  40 passed (40)
        Tests  173 passed (173)
$ npm --workspace=@tetsuo-ai/runtime run build         # clean
```

The branch is now `MERGEABLE` against `main` (was `CONFLICTING`).

Refs #539.