### PR TITLE
[codex] Add declassification disposition and lock dashboard/connector contracts

### DIFF
--- a/docs/DECLASSIFICATION_DISPOSITION.md
+++ b/docs/DECLASSIFICATION_DISPOSITION.md
@@ -1,0 +1,79 @@
+# AgenC Core Declassification Disposition
+
+This document is the public-scrub inventory for `agenc-core` before any
+repository visibility change. It implements the disposition table required by
+`agenc-core#9` and follows ADR-003: AgenC is moving toward a public framework
+product, but genuine service-side or operational-advantage surfaces must stay
+private or be replaced before the visibility flip.
+
+## Disposition Table
+
+| Surface | Current owner | Keep public | Move out | Replace | Delete | Blocking dependency |
+| --- | --- | --- | --- | --- | --- | --- |
+| `packages/agenc/` public wrapper | Runtime / Package owners | Yes | No | No | No | Keep release docs aligned to supported public platforms. |
+| `runtime/` daemon, TUI, tools, and gateway | Runtime Architecture | Conditional | No | Yes, package identity/docs | No | Finish public product contract and security scope signoff for daemon, webchat, tools, and policy surfaces. |
+| `web/` dashboard | Web / Runtime Architecture | Yes | No | No | No | Confirm all state/actions are daemon-backed and document auth/origin/session rules. |
+| `mobile/` client work | Product / Mobile | Conditional | No | No | No | Classify release posture and remove local-only assumptions before public launch. |
+| `mcp/` runtime MCP package | Runtime Architecture | Conditional | No | Yes, docs | No | Reclassify from private-kernel package to supported public operator package or keep transitional notice. |
+| `docs-mcp/` package | Docs / Runtime Architecture | Conditional | No | Yes, docs | No | Decide whether it is public docs tooling or internal contributor tooling. |
+| `contracts/desktop-tool-contracts/` | Desktop / Runtime Architecture | Yes | No | No | No | Keep as public ABI if desktop bridge remains public. |
+| Desktop server package / desktop bridge docs | Desktop owners | Conditional | Maybe | Yes | No | Security review for REST/VNC/noVNC exposure and sandbox auth. |
+| `examples/` | Developer Experience | Yes | No | No | No | Ensure examples do not require private registry or internal services. |
+| `docs/PRIVATE_KERNEL_DISTRIBUTION.md` | Platform Architecture | No | Maybe | Yes | No | Replace with public package/release distribution policy; move Cloudsmith private-kernel mechanics to private ops if still needed. |
+| `docs/PRIVATE_KERNEL_SUPPORT_POLICY.md` | Platform Architecture | No | Maybe | Yes | No | Replace private-kernel posture with public-framework support policy. |
+| `docs/PRIVATE_REGISTRY_SETUP.md` | Platform Architecture | No | Yes | No | No | Move Cloudsmith/Verdaccio private registry setup to private ops repo before visibility flip. |
+| `config/private-kernel-distribution*.json` | Platform Architecture | No | Yes | No | No | Private registry topology must leave public repo or become inert examples without hosted endpoints. |
+| `containers/private-registry/` | Platform Architecture | No | Yes | No | No | Move private registry reference backend and CI fixtures to private ops repo. |
+| `.github/workflows/private-kernel-cloudsmith.yml` | Platform Architecture | No | Yes | No | No | Remove or move protected Cloudsmith validation workflow. |
+| `.github/workflows/private-kernel-registry.yml` | Platform Architecture | No | Yes | No | No | Move Verdaccio private-registry validation to private ops repo. |
+| `.github/workflows/package-pack-smoke.yml` | Runtime / Release | Conditional | No | Yes | No | Replace private-kernel checks with public wrapper/runtime package smoke checks. |
+| `.github/workflows/release.yml` | Release Engineering | Yes | No | Yes | No | Ensure release builds publish only public artifacts and do not rely on private-kernel naming. |
+| Private/proof harnesses under `tools/proof-harness` if present | Protocol / Runtime QA | Conditional | Maybe | Yes | No | Decide whether harness is public validation tooling or private operator harness; remove internal wallet paths. |
+| Runtime credentials/policy/session credential code | Runtime Security | Yes | No | No | No | Keep code public, but verify examples/tests never expose real secrets and docs explain safe configuration. |
+| `docs/security/*` and audit docs | Security owners | Yes | No | No | No | Scope claims must stay explicit; no on-chain audit artifact may imply whole-product signoff. |
+| `.claude/notes/` | Internal agents / PM | No | Yes | No | Maybe | Move internal planning notes to private planning repo or convert durable public ADRs. |
+| `.claude/notes/pr-log.md` | Internal agents / PM | No | Yes | No | Maybe | Scrub private run details before visibility flip. |
+| `artifacts/` generated bundles | Surface owners | Conditional | Maybe | Maybe | Maybe | Inventory each artifact for paths, wallets, local operator names, benchmark hosts, or internal service references. |
+| `docs/devnet-h200-benchmark-plan.md` | ML / Protocol validation | Conditional | Maybe | Yes | No | Remove private hardware/operator assumptions or move to private infra docs. |
+| `docs/MAINNET_*`, deployment, and emergency docs | Protocol / Release | Conditional | Maybe | Yes | No | Scrub credentials, deploy-wallet assumptions, and private operator paths; keep public runbook only if safe. |
+
+## Classification By Area
+
+Runtime-side packages:
+`@tetsuo-ai/agenc` is the intended public install identity. Runtime-side
+packages previously described as private-kernel surfaces need a final
+classification before public visibility: public product package, public
+operator package, private ops package, or deprecated transitional package.
+
+Private-boundary CI:
+Cloudsmith and Verdaccio private-kernel workflows are not public-product gates.
+They should be moved to private ops or replaced with public package smoke gates.
+Release workflows may stay only if they build and publish public artifacts.
+
+Private-kernel docs and policies:
+Private-kernel docs currently explain an old transition state. Replace them
+with public-framework support, release, and security-scope docs. If the private
+registry remains operational, move its mechanics out of `agenc-core`.
+
+Internal-only tools and services:
+Proving backends, premium ranking/search/coordination services, anti-abuse
+services, internal service credentials, private registry infrastructure, and
+admin/ops tooling are not part of the public repo surface. Keep only public
+contracts, local-safe examples, and sanitized runbooks.
+
+## Public Doc Sweep Plan
+
+1. Rewrite `docs/CODEBASE_MAP.md` so `runtime/` is no longer described as a
+   private kernel package unless that is still the explicit product decision.
+2. Replace private-kernel distribution/support docs with public-framework
+   support and release-channel docs.
+3. Move Cloudsmith/Verdaccio private registry setup and config to a private ops
+   repository, or mark examples inert and remove hosted endpoints.
+4. Update `docs/COMMANDS_AND_VALIDATION.md` to use public package/runtime smoke
+   commands instead of private-kernel gates.
+5. Re-run a secret/path sweep over docs, workflows, configs, artifacts, and
+   `.claude/notes`.
+6. Update `docs/SECURITY_SCOPE_MATRIX.md` for the exact release commit and
+   require named owner signoff for any deferred public surface risk.
+7. Add a final visibility-flip checklist PR that deletes/moves blocked surfaces
+   and links this table row-by-row.

--- a/docs/DOCS_INDEX.md
+++ b/docs/DOCS_INDEX.md
@@ -11,6 +11,7 @@ This is the repo-level developer-documentation entrypoint for `agenc-core`.
 - [../runtime/docs/MARKETPLACE_OPERATOR_SURFACE.md](../runtime/docs/MARKETPLACE_OPERATOR_SURFACE.md) - MARKET/TOOLS split and runtime marketplace routing
 - [../runtime/docs/compiled-job-phase1-launch-readiness.md](../runtime/docs/compiled-job-phase1-launch-readiness.md) - compiled marketplace Phase 1 runbook, retention posture, and launch checklist
 - [./architecture/guides/public-wrapper-devnet-marketplace-rehearsal.md](./architecture/guides/public-wrapper-devnet-marketplace-rehearsal.md) - supported public-wrapper devnet marketplace rehearsal path
+- [DECLASSIFICATION_DISPOSITION.md](./DECLASSIFICATION_DISPOSITION.md) - agenc-core public-scrub inventory and declassification disposition table
 - [./architecture/README.md](./architecture/README.md) - architecture-focused reading path
 
 ## Primary Package Docs

--- a/docs/PLUGIN_KIT.md
+++ b/docs/PLUGIN_KIT.md
@@ -16,3 +16,13 @@ Canonical public docs:
 
 The private runtime host implementation for plugin-backed channels remains in
 the AgenC runtime.
+
+Runtime host ABI contract:
+
+- `plugin_api_version`: `1.0.0`
+- `host_api_version`: `1.0.0`
+
+Channel adapter manifests use the snake-case fields above. AgenC connector
+status payloads expose the same pair under `abi` for both built-in V1
+connectors such as Telegram and hosted channel plugins, so operators can verify
+compatibility through `agenc connector status` and the daemon-backed dashboard.

--- a/docs/architecture/product-contract.md
+++ b/docs/architecture/product-contract.md
@@ -95,6 +95,13 @@ Primary responsibilities:
 
 The web dashboard is a daemon client, not a separate runtime.
 
+`web/` is the dashboard product surface. `agenc ui` opens the dashboard that the
+daemon serves at `/ui/`; `agenc ui --no-open` prints the same URL without
+launching a browser. Browser state and actions must flow through the daemon
+control plane. Same-origin loopback is the default access path, and configs with
+`auth.secret` must set `auth.localBypass=true` before `agenc ui` will open the
+dashboard.
+
 ## Public install surface
 
 The public user-facing install identity is the scoped npm package
@@ -181,6 +188,15 @@ Connectors and plugins must share one public host contract:
 
 - `plugin_api_version`
 - `host_api_version`
+
+The current V1 host ABI pair is:
+
+- `plugin_api_version`: `1.0.0`
+- `host_api_version`: `1.0.0`
+
+Connector status payloads expose this pair under `abi`, and the web dashboard
+renders it beside connector health/restart state so CLI, TUI, and web are
+reading the same daemon-reported lifecycle contract.
 
 First-party connectors may ship built-in first, but they cannot create a second
 incompatible lifecycle model.

--- a/packages/agenc/README.md
+++ b/packages/agenc/README.md
@@ -112,6 +112,18 @@ Connector health and pending-restart state are exposed through both:
 - `agenc connector status telegram`
 - `agenc ui` on the dashboard status view
 
+Connector status also reports the public host ABI pair from
+`@tetsuo-ai/plugin-kit`:
+
+- `plugin_api_version`
+- `host_api_version`
+
+Telegram is built in for V1, but it follows the same connector lifecycle and ABI
+contract as hosted channel plugins. Secrets are written only to the canonical
+operator config (`~/.agenc/config.json`) via the same daemon config path used by
+the CLI and dashboard. Re-run `connector add telegram` with a new token to
+rotate, and use `connector remove telegram` to remove the configured secret.
+
 ## Wrapper-local runtime management
 
 ```bash

--- a/runtime/src/cli/connectors.test.ts
+++ b/runtime/src/cli/connectors.test.ts
@@ -265,6 +265,10 @@ describe("connector CLI lifecycle", () => {
               active: true,
               health: "healthy",
               mode: "polling",
+              abi: {
+                plugin_api_version: "1.0.0",
+                host_api_version: "1.0.0",
+              },
               pendingRestart: true,
               summary: "Config changed on disk; restart the daemon to apply connector changes.",
             },
@@ -298,6 +302,10 @@ describe("connector CLI lifecycle", () => {
           name: "telegram",
           active: true,
           pendingRestart: true,
+          abi: {
+            plugin_api_version: "1.0.0",
+            host_api_version: "1.0.0",
+          },
         }),
       ],
     });

--- a/runtime/src/gateway/channel-status.test.ts
+++ b/runtime/src/gateway/channel-status.test.ts
@@ -55,4 +55,33 @@ describe("buildGatewayChannelStatus", () => {
 
     expect(status.summary).toBe("Connector config differs from the live daemon state.");
   });
+
+  it("keeps abi attached for a hosted plugin still live after disk removal (pending restart)", () => {
+    // Regression: a non-telegram hosted plugin connector that was removed from
+    // disk but is still active in the live daemon must keep its ABI on the
+    // channel-status surface — the read of `targetConfig` alone would drop it
+    // and inconsistently hide ABI from a connector that is still running.
+    const status = buildGatewayChannelStatus("custom-plugin", {
+      targetConfig: undefined,
+      liveConfig: {
+        type: "plugin",
+        enabled: true,
+      },
+      active: true,
+      health: "healthy",
+      pendingRestart: true,
+      gatewayRunning: true,
+    });
+
+    expect(status.configured).toBe(false);
+    expect(status.active).toBe(true);
+    expect(status.pendingRestart).toBe(true);
+    expect(status.abi).toEqual({
+      plugin_api_version: "1.0.0",
+      host_api_version: "1.0.0",
+    });
+    expect(status.summary).toBe(
+      "Live daemon still has this connector active; restart required to remove it.",
+    );
+  });
 });

--- a/runtime/src/gateway/channel-status.test.ts
+++ b/runtime/src/gateway/channel-status.test.ts
@@ -15,6 +15,10 @@ describe("buildGatewayChannelStatus", () => {
     });
 
     expect(status.mode).toBe("polling");
+    expect(status.abi).toEqual({
+      plugin_api_version: "1.0.0",
+      host_api_version: "1.0.0",
+    });
     expect(status.summary).toBe("Connector is active and healthy.");
   });
 

--- a/runtime/src/gateway/channel-status.ts
+++ b/runtime/src/gateway/channel-status.ts
@@ -41,9 +41,15 @@ export function buildGatewayChannelStatus(
   const configured = targetConfig !== undefined;
   const enabled = configured && targetConfig.enabled !== false;
   const mode = inferGatewayChannelMode(name, targetConfig);
-  const abi = isConnectorStatusCandidate(name, targetConfig)
-    ? buildGatewayConnectorAbiStatus()
-    : undefined;
+  // Hosted plugin connectors that have been removed from disk but are still
+  // running in the live daemon (pending restart) only show up via `liveConfig`
+  // — fall back to it so the ABI stays attached for the channel-status surface
+  // until the operator actually restarts.
+  const abi =
+    isConnectorStatusCandidate(name, targetConfig) ||
+    isConnectorStatusCandidate(name, params.liveConfig)
+      ? buildGatewayConnectorAbiStatus()
+      : undefined;
 
   let summary: string | undefined;
   if (params.pendingRestart && params.active && !configured) {

--- a/runtime/src/gateway/channel-status.ts
+++ b/runtime/src/gateway/channel-status.ts
@@ -1,4 +1,5 @@
 import type { GatewayChannelConfig, GatewayChannelStatus } from "./types.js";
+import { buildGatewayConnectorAbiStatus } from "./connector-abi.js";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -18,6 +19,13 @@ function inferGatewayChannelMode(
   return isRecord(config.webhook) ? "webhook" : "polling";
 }
 
+function isConnectorStatusCandidate(
+  name: string,
+  config: GatewayChannelConfig | undefined,
+): boolean {
+  return name === "telegram" || (isRecord(config) && config.type === "plugin");
+}
+
 export function buildGatewayChannelStatus(
   name: string,
   params: {
@@ -33,6 +41,9 @@ export function buildGatewayChannelStatus(
   const configured = targetConfig !== undefined;
   const enabled = configured && targetConfig.enabled !== false;
   const mode = inferGatewayChannelMode(name, targetConfig);
+  const abi = isConnectorStatusCandidate(name, targetConfig)
+    ? buildGatewayConnectorAbiStatus()
+    : undefined;
 
   let summary: string | undefined;
   if (params.pendingRestart && params.active && !configured) {
@@ -67,6 +78,7 @@ export function buildGatewayChannelStatus(
     health: params.health,
     pendingRestart: params.pendingRestart,
     ...(mode ? { mode } : {}),
+    ...(abi ? { abi } : {}),
     ...(summary ? { summary } : {}),
   };
 }

--- a/runtime/src/gateway/connector-abi.ts
+++ b/runtime/src/gateway/connector-abi.ts
@@ -1,0 +1,18 @@
+import {
+  CHANNEL_ADAPTER_HOST_API_VERSION,
+  CHANNEL_ADAPTER_PLUGIN_API_VERSION,
+} from "@tetsuo-ai/plugin-kit";
+
+import type { GatewayConnectorAbiStatus } from "./types.js";
+
+export const AGENC_CONNECTOR_PLUGIN_API_VERSION =
+  CHANNEL_ADAPTER_PLUGIN_API_VERSION;
+export const AGENC_CONNECTOR_HOST_API_VERSION =
+  CHANNEL_ADAPTER_HOST_API_VERSION;
+
+export function buildGatewayConnectorAbiStatus(): GatewayConnectorAbiStatus {
+  return {
+    plugin_api_version: AGENC_CONNECTOR_PLUGIN_API_VERSION,
+    host_api_version: AGENC_CONNECTOR_HOST_API_VERSION,
+  };
+}

--- a/runtime/src/gateway/types.ts
+++ b/runtime/src/gateway/types.ts
@@ -711,6 +711,11 @@ export type GatewayState = "stopped" | "starting" | "running" | "stopping";
 export type GatewayChannelHealth = "healthy" | "unhealthy" | "unknown";
 export type GatewayChannelMode = "polling" | "webhook";
 
+export interface GatewayConnectorAbiStatus {
+  readonly plugin_api_version: string;
+  readonly host_api_version: string;
+}
+
 export interface GatewayChannelStatus {
   readonly name: string;
   readonly configured: boolean;
@@ -718,6 +723,7 @@ export interface GatewayChannelStatus {
   readonly active: boolean;
   readonly health: GatewayChannelHealth;
   readonly mode?: GatewayChannelMode;
+  readonly abi?: GatewayConnectorAbiStatus;
   readonly pendingRestart: boolean;
   readonly summary?: string;
 }

--- a/web/README.md
+++ b/web/README.md
@@ -1,9 +1,25 @@
 # @tetsuo-ai/web
 
-Private dashboard/client surface for AgenC operators.
+Daemon-backed dashboard surface for AgenC operators.
 
 This workspace owns the web dashboard build under `src/`, static assets under
 `public/`, and browser-facing tests under `tests/`.
+
+The dashboard is the public `agenc ui` product surface. It is always a client
+of the local daemon/gateway mounted at `/ui/`; it must not create a second
+runtime, independent session store, connector service, or marketplace authority.
+`agenc ui` opens the loopback daemon URL (`http://127.0.0.1:<port>/ui/`) and
+`agenc ui --no-open` prints the same URL for SSH and automation handoff.
+
+Access rules:
+
+- WebSocket state/actions must come from the daemon control plane.
+- The browser connects back to the same daemon origin unless an explicit test
+  URL is provided.
+- If `auth.secret` is configured, local dashboard access requires
+  `auth.localBypass=true`; otherwise `agenc ui` fails before opening a browser.
+- TUI, CLI, shell, and web sessions all share the same daemon session and policy
+  authority.
 
 Current shell split:
 

--- a/web/src/components/dashboard/AgentStatusView.test.tsx
+++ b/web/src/components/dashboard/AgentStatusView.test.tsx
@@ -93,6 +93,10 @@ describe('AgentStatusView', () => {
               active: false,
               health: 'unknown',
               mode: 'polling',
+              abi: {
+                plugin_api_version: '1.0.0',
+                host_api_version: '1.0.0',
+              },
               pendingRestart: true,
               summary: 'Config changed on disk; restart the daemon to apply connector changes.',
             },
@@ -107,5 +111,6 @@ describe('AgentStatusView', () => {
     expect(
       screen.getByText('Config changed on disk; restart the daemon to apply connector changes.'),
     ).toBeTruthy();
+    expect(screen.getByText('ABI plugin 1.0.0 / host 1.0.0')).toBeTruthy();
   });
 });

--- a/web/src/components/dashboard/AgentStatusView.tsx
+++ b/web/src/components/dashboard/AgentStatusView.tsx
@@ -260,6 +260,11 @@ export function AgentStatusView({ status, onRefresh }: AgentStatusViewProps) {
                       {channel.summary ? (
                         <div className="mt-1 text-[11px] text-bbs-gray break-all">{channel.summary}</div>
                       ) : null}
+                      {channel.abi ? (
+                        <div className="mt-1 text-[10px] text-bbs-gray break-all">
+                          ABI plugin {channel.abi.plugin_api_version} / host {channel.abi.host_api_version}
+                        </div>
+                      ) : null}
                     </div>
                     <span className={`ml-auto ${
                       channel.active


### PR DESCRIPTION
## Summary

This PR now covers the remaining non-marketplace issue set from the original branch: `#9`, `#7`, and `#6`.

- Adds the declassification disposition table and links it from the docs index. **This is groundwork for `#9` — it inventories what still needs to move/replace/delete before public visibility, but does not itself complete the scrub.** See "Scope" below.
- Exposes the connector host ABI pair (`plugin_api_version`, `host_api_version`) through daemon connector status, CLI/web status tests, and dashboard rendering.
- Locks `web/` documentation to the daemon-backed `agenc ui` product surface with loopback, `--no-open`, shared daemon/session authority, and `auth.localBypass` rules.

`#354` marketplace task-template work has been removed from this PR because that ticket is already being handled separately and needs devnet end-to-end validation.

## Why

The public-framework transition needs explicit product boundaries before broad exposure: public-scrub disposition needs a durable repo artifact, the dashboard must remain a daemon client rather than a second runtime authority, and connectors need a visible ABI contract that Telegram follows alongside hosted channel plugins.

## Scope vs. `#9`

`#9` acceptance is "the repo can change visibility without leaking internal-only service tooling/docs/configs, and public-facing docs/CI no longer assert the old private-kernel posture." That requires actually removing/moving/replacing material — not just inventorying it. The head of this branch still contains, for example, `.github/workflows/private-kernel-cloudsmith.yml`, `docs/PRIVATE_REGISTRY_SETUP.md`, the private-kernel sections of `docs/COMMANDS_AND_VALIDATION.md`, and the private-registry containers — all of which are listed in `docs/DECLASSIFICATION_DISPOSITION.md` as still needing to move/replace/delete.

This PR therefore lands the disposition artifact and leaves `#9` open for the actual scrub. The follow-up work is enumerated in `docs/DECLASSIFICATION_DISPOSITION.md`.

## Validation

- `npm --prefix runtime run test -- src/gateway/channel-status.test.ts src/cli/connectors.test.ts src/cli/ui.test.ts`
- `npm --prefix web run test -- src/components/dashboard/AgentStatusView.test.tsx src/hooks/useAgentStatus.test.ts`
- `npm --prefix runtime run typecheck`
- `npm --prefix runtime run build`
- `npm --prefix web run typecheck`
- `git diff --check origin/main...HEAD`

Refs #9.
Closes #7.
Closes #6.