### PR TITLE
Fail closed marketplace signing tools

### DIFF
--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -151,6 +151,23 @@ const executor = new LLMTaskExecutor({
 });
 ```
 
+`createAgencTools()` is intentionally read-only by default. Signer-backed marketplace
+mutation tools such as `agenc.createTask`, `agenc.claimTask`, and
+`agenc.completeTask` must be enabled explicitly:
+
+```typescript
+registry.registerAll(
+  createAgencTools(
+    { connection, wallet, logger },
+    { includeMutationTools: true },
+  ),
+);
+```
+
+For daemon/gateway deployments, mutation tools are still fail-closed unless
+`policy.marketplaceSigningToolsEnabled: true`, a wallet is loaded, and gateway
+approvals are enabled.
+
 ### Memory Integration
 
 ```typescript

--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -168,6 +168,28 @@ For daemon/gateway deployments, mutation tools are still fail-closed unless
 `policy.marketplaceSigningToolsEnabled: true`, a wallet is loaded, and gateway
 approvals are enabled.
 
+Daemon signing should also include a local signer capability policy. Without one,
+the daemon registers mutation tools behind approvals but denies every marketplace
+signature attempt:
+
+```json
+{
+  "policy": {
+    "marketplaceSigningToolsEnabled": true,
+    "marketplaceSignerPolicy": {
+      "allowedTools": ["agenc.claimTask", "agenc.completeTask"],
+      "allowedProgramIds": ["2jdBSJ8U5ixfwgs1bRLPtRRnpZAPm8Xv1tEdu8yjHJC7"],
+      "allowedTaskPdas": ["..."],
+      "maxRewardLamports": "100000000",
+      "allowedRewardMints": ["SOL"]
+    }
+  },
+  "approvals": {
+    "enabled": true
+  }
+}
+```
+
 ### Memory Integration
 
 ```typescript

--- a/runtime/src/cli/agent-cli.ts
+++ b/runtime/src/cli/agent-cli.ts
@@ -4,7 +4,7 @@ import type {
   CliRuntimeContext,
   CliStatusCode,
 } from "./types.js";
-import { createAgencTools } from "../tools/agenc/index.js";
+import { createAgencMutationTools } from "../tools/agenc/index.js";
 import {
   getDefaultKeypairPath,
   keypairToWallet,
@@ -60,7 +60,7 @@ export async function runAgentRegisterCommand(
       ...context.logger,
       setLevel: () => {},
     };
-    const tool = createAgencTools({
+    const tool = createAgencMutationTools({
       connection: new Connection(options.rpcUrl, "confirmed"),
       wallet,
       programId: options.programId

--- a/runtime/src/gateway/config-watcher.test.ts
+++ b/runtime/src/gateway/config-watcher.test.ts
@@ -584,6 +584,13 @@ describe("validateGatewayConfig policy bundles", () => {
         defaultProjectId: "project-x",
         simulationMode: "shadow",
         marketplaceSigningToolsEnabled: true,
+        marketplaceSignerPolicy: {
+          allowedTools: ["agenc.claimTask"],
+          allowedProgramIds: ["11111111111111111111111111111111"],
+          maxRewardLamports: "100000000",
+          maxStakeLamports: "10000000",
+          allowedRewardMints: ["SOL"],
+        },
         networkAccess: {
           allowHosts: ["api.example.com"],
           denyHosts: ["blocked.example.com"],
@@ -684,6 +691,11 @@ describe("validateGatewayConfig policy bundles", () => {
         enabled: true,
         simulationMode: "preview",
         marketplaceSigningToolsEnabled: "yes" as unknown as boolean,
+        marketplaceSignerPolicy: {
+          allowedTools: "agenc.claimTask" as unknown as string[],
+          maxRewardLamports: "0.1",
+          maxStakeLamports: 100 as unknown as string,
+        },
         networkAccess: {
           allowHosts: "api.example.com" as unknown as string[],
         },
@@ -751,6 +763,15 @@ describe("validateGatewayConfig policy bundles", () => {
     );
     expect(result.errors).toContain(
       "policy.marketplaceSigningToolsEnabled must be a boolean",
+    );
+    expect(result.errors).toContain(
+      "policy.marketplaceSignerPolicy.allowedTools must be an array of strings",
+    );
+    expect(result.errors).toContain(
+      "policy.marketplaceSignerPolicy.maxRewardLamports must be a decimal string",
+    );
+    expect(result.errors).toContain(
+      "policy.marketplaceSignerPolicy.maxStakeLamports must be a decimal string",
     );
     expect(result.errors).toContain(
       "policy.networkAccess.allowHosts must be an array of strings",

--- a/runtime/src/gateway/config-watcher.test.ts
+++ b/runtime/src/gateway/config-watcher.test.ts
@@ -583,6 +583,7 @@ describe("validateGatewayConfig policy bundles", () => {
         defaultTenantId: "tenant-a",
         defaultProjectId: "project-x",
         simulationMode: "shadow",
+        marketplaceSigningToolsEnabled: true,
         networkAccess: {
           allowHosts: ["api.example.com"],
           denyHosts: ["blocked.example.com"],
@@ -682,6 +683,7 @@ describe("validateGatewayConfig policy bundles", () => {
       policy: {
         enabled: true,
         simulationMode: "preview",
+        marketplaceSigningToolsEnabled: "yes" as unknown as boolean,
         networkAccess: {
           allowHosts: "api.example.com" as unknown as string[],
         },
@@ -746,6 +748,9 @@ describe("validateGatewayConfig policy bundles", () => {
     expect(result.valid).toBe(false);
     expect(result.errors).toContain(
       "policy.simulationMode must be one of: off, shadow",
+    );
+    expect(result.errors).toContain(
+      "policy.marketplaceSigningToolsEnabled must be a boolean",
     );
     expect(result.errors).toContain(
       "policy.networkAccess.allowHosts must be an array of strings",

--- a/runtime/src/gateway/config-watcher.ts
+++ b/runtime/src/gateway/config-watcher.ts
@@ -757,6 +757,37 @@ function validatePolicySectionAtPath(
   ) {
     errors.push(`${path}.marketplaceSigningToolsEnabled must be a boolean`);
   }
+  if (policy.marketplaceSignerPolicy !== undefined) {
+    if (!isRecord(policy.marketplaceSignerPolicy)) {
+      errors.push(`${path}.marketplaceSignerPolicy must be an object`);
+    } else {
+      const signerPolicy = policy.marketplaceSignerPolicy;
+      for (const key of [
+        "allowedTools",
+        "allowedProgramIds",
+        "allowedTaskPdas",
+        "allowedTemplateIds",
+        "allowedJobSpecHashes",
+        "allowedRewardMints",
+      ]) {
+        if (
+          signerPolicy[key] !== undefined &&
+          !isStringArray(signerPolicy[key])
+        ) {
+          errors.push(`${path}.marketplaceSignerPolicy.${key} must be an array of strings`);
+        }
+      }
+      for (const key of ["maxRewardLamports", "maxStakeLamports"]) {
+        if (
+          signerPolicy[key] !== undefined &&
+          (typeof signerPolicy[key] !== "string" ||
+            !/^\d+$/.test(signerPolicy[key]))
+        ) {
+          errors.push(`${path}.marketplaceSignerPolicy.${key} must be a decimal string`);
+        }
+      }
+    }
+  }
   if (
     policy.credentialAllowList !== undefined &&
     !isStringArray(policy.credentialAllowList)

--- a/runtime/src/gateway/config-watcher.ts
+++ b/runtime/src/gateway/config-watcher.ts
@@ -752,6 +752,12 @@ function validatePolicySectionAtPath(
     errors.push(`${path}.toolDenyList must be an array of strings`);
   }
   if (
+    policy.marketplaceSigningToolsEnabled !== undefined &&
+    typeof policy.marketplaceSigningToolsEnabled !== "boolean"
+  ) {
+    errors.push(`${path}.marketplaceSigningToolsEnabled must be a boolean`);
+  }
+  if (
     policy.credentialAllowList !== undefined &&
     !isStringArray(policy.credentialAllowList)
   ) {

--- a/runtime/src/gateway/daemon-tool-registry.ts
+++ b/runtime/src/gateway/daemon-tool-registry.ts
@@ -84,6 +84,45 @@ import {
 const CHROMIUM_SHIM_DIR_SEGMENTS = [".agenc", "bin"] as const;
 const DEFAULT_SANDBOX_MAX_TRACKED_JOBS_ENV =
   "AGENC_SYSTEM_SANDBOX_MAX_TRACKED_JOBS";
+const MARKETPLACE_SIGNING_TOOLS_ENABLED_ENV =
+  "AGENC_MARKETPLACE_SIGNING_TOOLS_ENABLED";
+
+function readBooleanFlag(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return (
+    normalized === "1" ||
+    normalized === "true" ||
+    normalized === "yes" ||
+    normalized === "on"
+  );
+}
+
+function shouldRegisterMarketplaceMutationTools(params: {
+  readonly config: GatewayConfig;
+  readonly walletAvailable: boolean;
+  readonly logger: Logger;
+}): boolean {
+  const requested =
+    params.config.policy?.marketplaceSigningToolsEnabled === true ||
+    readBooleanFlag(process.env[MARKETPLACE_SIGNING_TOOLS_ENABLED_ENV]);
+  if (!requested) {
+    return false;
+  }
+  if (!params.walletAvailable) {
+    params.logger.warn?.(
+      "Marketplace signing tools requested but no wallet is loaded; registering read-only AgenC tools.",
+    );
+    return false;
+  }
+  if (params.config.approvals?.enabled !== true) {
+    params.logger.warn?.(
+      "Marketplace signing tools requested but gateway approvals are disabled; registering read-only AgenC tools.",
+    );
+    return false;
+  }
+  return true;
+}
 
 function prependPathEntry(
   pathValue: string | undefined,
@@ -802,13 +841,21 @@ export async function createDaemonToolRegistry(
         : undefined;
 
       const { createAgencTools } = await import("../tools/agenc/index.js");
+      const includeMutationTools = shouldRegisterMarketplaceMutationTools({
+        config,
+        walletAvailable: walletResult?.wallet !== undefined,
+        logger,
+      });
       registry.registerAll(
-        createAgencTools({
-          connection: connMgr.getConnection(),
-          wallet: walletResult?.wallet,
-          ...(configuredProgramId ? { programId: configuredProgramId } : {}),
-          logger,
-        }),
+        createAgencTools(
+          {
+            connection: connMgr.getConnection(),
+            wallet: walletResult?.wallet,
+            ...(configuredProgramId ? { programId: configuredProgramId } : {}),
+            logger,
+          },
+          { includeMutationTools },
+        ),
       );
     } catch (error) {
       logger.warn?.("AgenC protocol tools unavailable:", error);

--- a/runtime/src/gateway/daemon-tool-registry.ts
+++ b/runtime/src/gateway/daemon-tool-registry.ts
@@ -852,6 +852,12 @@ export async function createDaemonToolRegistry(
             connection: connMgr.getConnection(),
             wallet: walletResult?.wallet,
             ...(configuredProgramId ? { programId: configuredProgramId } : {}),
+            ...(includeMutationTools
+              ? {
+                  marketplaceSignerPolicy:
+                    config.policy?.marketplaceSignerPolicy ?? { allowedTools: [] },
+                }
+              : {}),
             logger,
           },
           { includeMutationTools },

--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -2138,11 +2138,73 @@ describe("DaemonManager", () => {
       expect.objectContaining({
         programId: expect.any(PublicKey),
       }),
+      { includeMutationTools: false },
     );
     const registrationArgs = mockCreateAgencTools.mock.calls[0]?.[0] as {
       programId?: PublicKey;
     };
     expect(registrationArgs.programId?.toBase58()).toBe(programId);
+  });
+
+  it("keeps agenc marketplace mutation tools disabled unless signer policy gates are enabled", async () => {
+    const walletPublicKey = new PublicKey("11111111111111111111111111111111");
+    vi.mocked(loadWallet).mockResolvedValueOnce({
+      keypair: {} as never,
+      agentId: new Uint8Array(32),
+      wallet: {
+        publicKey: walletPublicKey,
+        signTransaction: vi.fn(),
+        signAllTransactions: vi.fn(),
+      },
+    });
+    const dm = new DaemonManager({ configPath: "/tmp/config.json" });
+
+    await (dm as any).createToolRegistry({
+      desktop: { enabled: false },
+      connection: {
+        rpcUrl: "http://localhost:8899",
+      },
+      policy: {
+        marketplaceSigningToolsEnabled: true,
+      },
+    });
+
+    expect(mockCreateAgencTools).toHaveBeenCalledWith(
+      expect.any(Object),
+      { includeMutationTools: false },
+    );
+  });
+
+  it("registers agenc marketplace mutation tools only with explicit opt-in and approvals", async () => {
+    const walletPublicKey = new PublicKey("11111111111111111111111111111111");
+    vi.mocked(loadWallet).mockResolvedValueOnce({
+      keypair: {} as never,
+      agentId: new Uint8Array(32),
+      wallet: {
+        publicKey: walletPublicKey,
+        signTransaction: vi.fn(),
+        signAllTransactions: vi.fn(),
+      },
+    });
+    const dm = new DaemonManager({ configPath: "/tmp/config.json" });
+
+    await (dm as any).createToolRegistry({
+      desktop: { enabled: false },
+      connection: {
+        rpcUrl: "http://localhost:8899",
+      },
+      approvals: {
+        enabled: true,
+      },
+      policy: {
+        marketplaceSigningToolsEnabled: true,
+      },
+    });
+
+    expect(mockCreateAgencTools).toHaveBeenCalledWith(
+      expect.any(Object),
+      { includeMutationTools: true },
+    );
   });
 
   it("preserves durable web-session task tracker state during session reset", async () => {

--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -2202,7 +2202,50 @@ describe("DaemonManager", () => {
     });
 
     expect(mockCreateAgencTools).toHaveBeenCalledWith(
-      expect.any(Object),
+      expect.objectContaining({
+        marketplaceSignerPolicy: { allowedTools: [] },
+      }),
+      { includeMutationTools: true },
+    );
+  });
+
+  it("passes configured marketplace signer policy into agenc mutation tools", async () => {
+    const walletPublicKey = new PublicKey("11111111111111111111111111111111");
+    vi.mocked(loadWallet).mockResolvedValueOnce({
+      keypair: {} as never,
+      agentId: new Uint8Array(32),
+      wallet: {
+        publicKey: walletPublicKey,
+        signTransaction: vi.fn(),
+        signAllTransactions: vi.fn(),
+      },
+    });
+    const dm = new DaemonManager({ configPath: "/tmp/config.json" });
+
+    await (dm as any).createToolRegistry({
+      desktop: { enabled: false },
+      connection: {
+        rpcUrl: "http://localhost:8899",
+      },
+      approvals: {
+        enabled: true,
+      },
+      policy: {
+        marketplaceSigningToolsEnabled: true,
+        marketplaceSignerPolicy: {
+          allowedTools: ["agenc.claimTask"],
+          allowedTaskPdas: ["Task111111111111111111111111111111111111"],
+        },
+      },
+    });
+
+    expect(mockCreateAgencTools).toHaveBeenCalledWith(
+      expect.objectContaining({
+        marketplaceSignerPolicy: {
+          allowedTools: ["agenc.claimTask"],
+          allowedTaskPdas: ["Task111111111111111111111111111111111111"],
+        },
+      }),
       { includeMutationTools: true },
     );
   });

--- a/runtime/src/gateway/types.ts
+++ b/runtime/src/gateway/types.ts
@@ -439,6 +439,11 @@ export interface GatewayPolicyConfig {
   simulationMode?: "off" | "shadow";
   toolAllowList?: string[];
   toolDenyList?: string[];
+  /**
+   * Opt into registering signer-backed AgenC marketplace mutation tools in the
+   * daemon. This still requires gateway approvals to be enabled.
+   */
+  marketplaceSigningToolsEnabled?: boolean;
   credentialAllowList?: string[];
   networkAccess?: {
     allowHosts?: string[];

--- a/runtime/src/gateway/types.ts
+++ b/runtime/src/gateway/types.ts
@@ -15,6 +15,7 @@ import type { SocialPeerDirectoryEntry } from "../social/types.js";
 import type { LLMXaiCapabilitySurface } from "../llm/types.js";
 import type { StopHookRuntimeConfig } from "../llm/hooks/stop-hooks.js";
 import type { UserHooksSettings } from "../llm/hooks/user-config.js";
+import type { MarketplaceSignerPolicy } from "../tools/agenc/index.js";
 
 // ============================================================================
 // Gateway Configuration
@@ -444,6 +445,11 @@ export interface GatewayPolicyConfig {
    * daemon. This still requires gateway approvals to be enabled.
    */
   marketplaceSigningToolsEnabled?: boolean;
+  /**
+   * Capability envelope checked at the local signer boundary before any
+   * signer-backed AgenC marketplace mutation tool executes.
+   */
+  marketplaceSignerPolicy?: MarketplaceSignerPolicy;
   credentialAllowList?: string[];
   networkAccess?: {
     allowHosts?: string[];

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -909,6 +909,7 @@ export {
   createAgencReadOnlyTools,
   createAgencMutationTools,
   type CreateAgencToolsOptions,
+  type MarketplaceSignerPolicy,
   createListTasksTool,
   createGetTaskTool,
   createGetTokenBalanceTool,

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -906,6 +906,9 @@ export {
   JUPITER_ACTION_SCHEMAS,
   // Built-in AgenC tools
   createAgencTools,
+  createAgencReadOnlyTools,
+  createAgencMutationTools,
+  type CreateAgencToolsOptions,
   createListTasksTool,
   createGetTaskTool,
   createGetTokenBalanceTool,

--- a/runtime/src/tools/agenc/index.test.ts
+++ b/runtime/src/tools/agenc/index.test.ts
@@ -5,16 +5,18 @@ import {
   createAgencMutationTools,
   createAgencReadOnlyTools,
   createAgencTools,
+  type MarketplaceSignerPolicy,
 } from "./index.js";
 import { keypairToWallet } from "../../types/wallet.js";
 import { silentLogger } from "../../utils/logger.js";
 
-function makeContext() {
+function makeContext(marketplaceSignerPolicy?: MarketplaceSignerPolicy) {
   const keypair = Keypair.generate();
   return {
     connection: new Connection("http://localhost:8899", "confirmed"),
     wallet: keypairToWallet(keypair),
     logger: silentLogger,
+    marketplaceSignerPolicy,
   };
 }
 
@@ -57,5 +59,33 @@ describe("AgenC protocol tool factory", () => {
     expect(readOnlyNames).not.toContain("agenc.createTask");
     expect(mutationNames).toContain("agenc.createTask");
     expect(mutationNames).not.toContain("agenc.listTasks");
+  });
+
+  it("denies mutation execution before signing when signer policy does not allow the tool", async () => {
+    const registerTool = createAgencMutationTools(
+      makeContext({ allowedTools: ["agenc.claimTask"] }),
+    ).find((tool) => tool.name === "agenc.registerAgent");
+
+    expect(registerTool).toBeDefined();
+    const result = await registerTool!.execute({ stakeAmount: "1" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("MARKETPLACE_SIGNER_POLICY_DENIED");
+    expect(result.content).toContain("TOOL_NOT_ALLOWED");
+  });
+
+  it("enforces signer policy lamport caps before execution", async () => {
+    const registerTool = createAgencMutationTools(
+      makeContext({
+        allowedTools: ["agenc.registerAgent"],
+        maxStakeLamports: "1",
+      }),
+    ).find((tool) => tool.name === "agenc.registerAgent");
+
+    expect(registerTool).toBeDefined();
+    const result = await registerTool!.execute({ stakeAmount: "2" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("STAKE_LIMIT_EXCEEDED");
   });
 });

--- a/runtime/src/tools/agenc/index.test.ts
+++ b/runtime/src/tools/agenc/index.test.ts
@@ -1,0 +1,61 @@
+import { Connection, Keypair } from "@solana/web3.js";
+import { describe, expect, it } from "vitest";
+
+import {
+  createAgencMutationTools,
+  createAgencReadOnlyTools,
+  createAgencTools,
+} from "./index.js";
+import { keypairToWallet } from "../../types/wallet.js";
+import { silentLogger } from "../../utils/logger.js";
+
+function makeContext() {
+  const keypair = Keypair.generate();
+  return {
+    connection: new Connection("http://localhost:8899", "confirmed"),
+    wallet: keypairToWallet(keypair),
+    logger: silentLogger,
+  };
+}
+
+function names(tools: ReturnType<typeof createAgencTools>): string[] {
+  return tools.map((tool) => tool.name).sort();
+}
+
+describe("AgenC protocol tool factory", () => {
+  it("is read-only by default even when a wallet is present", () => {
+    const toolNames = names(createAgencTools(makeContext()));
+
+    expect(toolNames).toContain("agenc.inspectMarketplace");
+    expect(toolNames).toContain("agenc.getTask");
+    expect(toolNames).toContain("agenc.getProtocolConfig");
+    expect(toolNames).not.toContain("agenc.createTask");
+    expect(toolNames).not.toContain("agenc.claimTask");
+    expect(toolNames).not.toContain("agenc.completeTask");
+    expect(toolNames).not.toContain("agenc.purchaseSkill");
+    expect(toolNames).not.toContain("agenc.stakeReputation");
+  });
+
+  it("can explicitly opt into marketplace mutation tools", () => {
+    const toolNames = names(
+      createAgencTools(makeContext(), { includeMutationTools: true }),
+    );
+
+    expect(toolNames).toContain("agenc.createTask");
+    expect(toolNames).toContain("agenc.createTaskFromTemplate");
+    expect(toolNames).toContain("agenc.claimTask");
+    expect(toolNames).toContain("agenc.completeTask");
+    expect(toolNames).toContain("agenc.initiateDispute");
+    expect(toolNames).toContain("agenc.resolveDispute");
+  });
+
+  it("exposes separate read-only and mutation surfaces", () => {
+    const readOnlyNames = names(createAgencReadOnlyTools(makeContext()));
+    const mutationNames = names(createAgencMutationTools(makeContext()));
+
+    expect(readOnlyNames).toContain("agenc.listTasks");
+    expect(readOnlyNames).not.toContain("agenc.createTask");
+    expect(mutationNames).toContain("agenc.createTask");
+    expect(mutationNames).not.toContain("agenc.listTasks");
+  });
+});

--- a/runtime/src/tools/agenc/index.ts
+++ b/runtime/src/tools/agenc/index.ts
@@ -12,6 +12,7 @@ import type { Tool, ToolContext } from "../types.js";
 import { TaskOperations } from "../../task/operations.js";
 import { createProgram, createReadOnlyProgram } from "../../idl.js";
 import { AnchorProvider } from "@coral-xyz/anchor";
+import { wrapMarketplaceSignerPolicy } from "./signer-policy.js";
 import {
   createListTasksTool,
   createInspectMarketplaceTool,
@@ -97,6 +98,10 @@ export {
   createStakeReputationTool,
   createDelegateReputationTool,
 } from "./mutation-tools.js";
+export {
+  wrapMarketplaceSignerPolicy,
+  type MarketplaceSignerPolicy,
+} from "./signer-policy.js";
 
 export interface CreateAgencToolsOptions {
   /**
@@ -189,7 +194,7 @@ export function createAgencReadOnlyTools(context: ToolContext): Tool[] {
  */
 export function createAgencMutationTools(context: ToolContext): Tool[] {
   const program = createAgencProgram(context, { signerBacked: true });
-  return [
+  const tools = [
     createCreateTaskFromTemplateTool(program, context.logger),
     createSubmitTaskTemplateProposalTool(context.logger),
     createRegisterAgentTool(program, context.logger),
@@ -206,6 +211,14 @@ export function createAgencMutationTools(context: ToolContext): Tool[] {
     createStakeReputationTool(program, context.logger),
     createDelegateReputationTool(program, context.logger),
   ];
+  return tools.map((tool) =>
+    wrapMarketplaceSignerPolicy(tool, {
+      policy: context.marketplaceSignerPolicy,
+      programId: program.programId,
+      signer: program.provider.publicKey,
+      logger: context.logger,
+    }),
+  );
 }
 
 /**

--- a/runtime/src/tools/agenc/index.ts
+++ b/runtime/src/tools/agenc/index.ts
@@ -1,5 +1,9 @@
 /**
- * Built-in AgenC protocol query tools.
+ * Built-in AgenC protocol tools.
+ *
+ * The default export surface is intentionally read-only. Signing/mutation tools
+ * must be opted into explicitly so daemon/webchat contexts fail closed when a
+ * wallet is loaded but signer policy is not configured.
  *
  * @module
  */
@@ -94,8 +98,54 @@ export {
   createDelegateReputationTool,
 } from "./mutation-tools.js";
 
+export interface CreateAgencToolsOptions {
+  /**
+   * Include tools that can mutate protocol state or require a signer-backed
+   * program context. Defaults to false.
+   */
+  readonly includeMutationTools?: boolean;
+}
+
+function createAgencProgram(
+  context: ToolContext,
+  options: { readonly signerBacked?: boolean } = {},
+) {
+  return (
+    context.program ??
+    (() => {
+      if (options.signerBacked === true && context.wallet) {
+        const provider = new AnchorProvider(
+          context.connection,
+          context.wallet,
+          { commitment: "confirmed" },
+        );
+        return context.programId
+          ? createProgram(provider, context.programId)
+          : createProgram(provider);
+      }
+      return context.programId
+        ? createReadOnlyProgram(context.connection, context.programId)
+        : createReadOnlyProgram(context.connection);
+    })()
+  );
+}
+
+function createTaskOperations(context: ToolContext) {
+  // Dummy agentId — built-in query tools do not reference agentId.
+  const dummyAgentId = new Uint8Array(32);
+  const program = createAgencProgram(context, { signerBacked: false });
+  return {
+    program,
+    ops: new TaskOperations({
+      program,
+      agentId: dummyAgentId,
+      logger: context.logger,
+    }),
+  };
+}
+
 /**
- * Create all built-in AgenC protocol tools.
+ * Create read-only built-in AgenC protocol tools.
  *
  * The factory creates a single `TaskOperations` instance shared by
  * all tools. If no program is provided in the context, a read-only
@@ -110,34 +160,8 @@ export {
  * registry.registerAll(tools);
  * ```
  */
-export function createAgencTools(context: ToolContext): Tool[] {
-  const program =
-    context.program ??
-    (() => {
-      if (context.wallet) {
-        const provider = new AnchorProvider(
-          context.connection,
-          context.wallet,
-          { commitment: "confirmed" },
-        );
-        return context.programId
-          ? createProgram(provider, context.programId)
-          : createProgram(provider);
-      }
-      return context.programId
-        ? createReadOnlyProgram(context.connection, context.programId)
-        : createReadOnlyProgram(context.connection);
-    })();
-
-  // Dummy agentId — built-in tools only use query methods that don't reference agentId
-  const dummyAgentId = new Uint8Array(32);
-
-  const ops = new TaskOperations({
-    program,
-    agentId: dummyAgentId,
-    logger: context.logger,
-  });
-
+export function createAgencReadOnlyTools(context: ToolContext): Tool[] {
+  const { program, ops } = createTaskOperations(context);
   return [
     createInspectMarketplaceTool(program, context.logger),
     createListTasksTool(ops, context.logger, { program }),
@@ -153,6 +177,19 @@ export function createAgencTools(context: ToolContext): Tool[] {
     createGetTokenBalanceTool(program, context.logger),
     createListApprovedTaskTemplatesTool(context.logger),
     createGetApprovedTaskTemplateTool(context.logger),
+    createGetAgentTool(program, context.logger),
+    createGetProtocolConfigTool(program, context.logger),
+  ];
+}
+
+/**
+ * Create AgenC protocol tools that can mutate state or require signer-backed
+ * execution. Daemon/webchat callers should only register these after explicit
+ * signer policy/approval gates are configured.
+ */
+export function createAgencMutationTools(context: ToolContext): Tool[] {
+  const program = createAgencProgram(context, { signerBacked: true });
+  return [
     createCreateTaskFromTemplateTool(program, context.logger),
     createSubmitTaskTemplateProposalTool(context.logger),
     createRegisterAgentTool(program, context.logger),
@@ -168,7 +205,19 @@ export function createAgencTools(context: ToolContext): Tool[] {
     createResolveDisputeTool(program, context.logger),
     createStakeReputationTool(program, context.logger),
     createDelegateReputationTool(program, context.logger),
-    createGetAgentTool(program, context.logger),
-    createGetProtocolConfigTool(program, context.logger),
   ];
+}
+
+/**
+ * Create built-in AgenC protocol tools. Defaults to the read-only surface.
+ */
+export function createAgencTools(
+  context: ToolContext,
+  options: CreateAgencToolsOptions = {},
+): Tool[] {
+  const readOnlyTools = createAgencReadOnlyTools(context);
+  if (options.includeMutationTools !== true) {
+    return readOnlyTools;
+  }
+  return [...readOnlyTools, ...createAgencMutationTools(context)];
 }

--- a/runtime/src/tools/agenc/signer-policy.ts
+++ b/runtime/src/tools/agenc/signer-policy.ts
@@ -1,0 +1,243 @@
+import type { PublicKey } from "@solana/web3.js";
+
+import type { Tool, ToolResult } from "../types.js";
+import { safeStringify } from "../types.js";
+import type { Logger } from "../../utils/logger.js";
+
+export interface MarketplaceSignerPolicy {
+  /**
+   * Exact mutating tool names allowed to reach signer-backed execution.
+   * When omitted or empty, all marketplace signing attempts are denied.
+   */
+  readonly allowedTools?: readonly string[];
+  /** Restrict signing to one or more marketplace program IDs. */
+  readonly allowedProgramIds?: readonly string[];
+  /** Restrict task-scoped actions to specific task PDAs. */
+  readonly allowedTaskPdas?: readonly string[];
+  /** Restrict task creation to specific approved template IDs. */
+  readonly allowedTemplateIds?: readonly string[];
+  /** Restrict task creation/claim paths to specific job spec hashes. */
+  readonly allowedJobSpecHashes?: readonly string[];
+  /** Max task reward/rewardLamports accepted by local signer policy. */
+  readonly maxRewardLamports?: string;
+  /** Max stake/delegation/purchase amount accepted by local signer policy. */
+  readonly maxStakeLamports?: string;
+  /**
+   * Reward mint allowlist. Use "SOL" for native SOL / omitted rewardMint.
+   */
+  readonly allowedRewardMints?: readonly string[];
+}
+
+interface MarketplaceSignerPolicyEvaluation {
+  readonly allowed: boolean;
+  readonly code?: string;
+  readonly reason?: string;
+  readonly metadata?: Record<string, unknown>;
+}
+
+function errorResult(
+  message: string,
+  metadata: Record<string, unknown>,
+): ToolResult {
+  return {
+    content: safeStringify({
+      error: message,
+      code: "MARKETPLACE_SIGNER_POLICY_DENIED",
+      ...metadata,
+    }),
+    isError: true,
+  };
+}
+
+function normalizeList(values: readonly string[] | undefined): Set<string> {
+  return new Set(
+    (values ?? [])
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0),
+  );
+}
+
+function readString(args: Record<string, unknown>, keys: readonly string[]): string | null {
+  for (const key of keys) {
+    const value = args[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+function readBigInt(args: Record<string, unknown>, keys: readonly string[]): bigint | null {
+  const value = readString(args, keys);
+  if (!value || !/^\d+$/.test(value)) {
+    return null;
+  }
+  return BigInt(value);
+}
+
+function parseLimit(value: string | undefined, field: string): bigint | null {
+  if (value === undefined) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error(`${field} must be a non-negative integer string`);
+  }
+  return BigInt(trimmed);
+}
+
+function evaluateMarketplaceSignerPolicy(params: {
+  readonly policy: MarketplaceSignerPolicy;
+  readonly toolName: string;
+  readonly args: Record<string, unknown>;
+  readonly programId: PublicKey;
+  readonly signer?: PublicKey | null;
+}): MarketplaceSignerPolicyEvaluation {
+  const allowedTools = normalizeList(params.policy.allowedTools);
+  if (!allowedTools.has(params.toolName)) {
+    return {
+      allowed: false,
+      code: "TOOL_NOT_ALLOWED",
+      reason: `${params.toolName} is not allowed by marketplace signer policy`,
+    };
+  }
+
+  const allowedProgramIds = normalizeList(params.policy.allowedProgramIds);
+  const programId = params.programId.toBase58();
+  if (allowedProgramIds.size > 0 && !allowedProgramIds.has(programId)) {
+    return {
+      allowed: false,
+      code: "PROGRAM_NOT_ALLOWED",
+      reason: `Program ${programId} is not allowed by marketplace signer policy`,
+      metadata: { programId },
+    };
+  }
+
+  const allowedTaskPdas = normalizeList(params.policy.allowedTaskPdas);
+  const taskPda = readString(params.args, ["taskPda"]);
+  if (allowedTaskPdas.size > 0 && taskPda && !allowedTaskPdas.has(taskPda)) {
+    return {
+      allowed: false,
+      code: "TASK_NOT_ALLOWED",
+      reason: `Task ${taskPda} is not allowed by marketplace signer policy`,
+      metadata: { taskPda },
+    };
+  }
+
+  const allowedTemplateIds = normalizeList(params.policy.allowedTemplateIds);
+  const templateId = readString(params.args, ["templateId"]);
+  if (allowedTemplateIds.size > 0 && templateId && !allowedTemplateIds.has(templateId)) {
+    return {
+      allowed: false,
+      code: "TEMPLATE_NOT_ALLOWED",
+      reason: `Template ${templateId} is not allowed by marketplace signer policy`,
+      metadata: { templateId },
+    };
+  }
+
+  const allowedJobSpecHashes = normalizeList(params.policy.allowedJobSpecHashes);
+  const jobSpecHash = readString(params.args, ["jobSpecHash"]);
+  if (
+    allowedJobSpecHashes.size > 0 &&
+    jobSpecHash &&
+    !allowedJobSpecHashes.has(jobSpecHash)
+  ) {
+    return {
+      allowed: false,
+      code: "JOB_SPEC_HASH_NOT_ALLOWED",
+      reason: `Job spec hash ${jobSpecHash} is not allowed by marketplace signer policy`,
+      metadata: { jobSpecHash },
+    };
+  }
+
+  const reward = readBigInt(params.args, ["reward", "rewardLamports"]);
+  const maxReward = parseLimit(params.policy.maxRewardLamports, "maxRewardLamports");
+  if (reward !== null && maxReward !== null && reward > maxReward) {
+    return {
+      allowed: false,
+      code: "REWARD_LIMIT_EXCEEDED",
+      reason: `Reward ${reward.toString()} exceeds signer policy max ${maxReward.toString()}`,
+      metadata: { rewardLamports: reward.toString(), maxRewardLamports: maxReward.toString() },
+    };
+  }
+
+  const stakeAmount = readBigInt(params.args, [
+    "stakeAmount",
+    "amount",
+    "price",
+    "delegationAmount",
+  ]);
+  const maxStake = parseLimit(params.policy.maxStakeLamports, "maxStakeLamports");
+  if (stakeAmount !== null && maxStake !== null && stakeAmount > maxStake) {
+    return {
+      allowed: false,
+      code: "STAKE_LIMIT_EXCEEDED",
+      reason: `Amount ${stakeAmount.toString()} exceeds signer policy max ${maxStake.toString()}`,
+      metadata: { amountLamports: stakeAmount.toString(), maxStakeLamports: maxStake.toString() },
+    };
+  }
+
+  const allowedRewardMints = normalizeList(params.policy.allowedRewardMints);
+  const rewardMint = readString(params.args, ["rewardMint"]) ?? "SOL";
+  if (allowedRewardMints.size > 0 && !allowedRewardMints.has(rewardMint)) {
+    return {
+      allowed: false,
+      code: "REWARD_MINT_NOT_ALLOWED",
+      reason: `Reward mint ${rewardMint} is not allowed by marketplace signer policy`,
+      metadata: { rewardMint },
+    };
+  }
+
+  return {
+    allowed: true,
+    metadata: {
+      toolName: params.toolName,
+      programId,
+      signer: params.signer?.toBase58() ?? null,
+    },
+  };
+}
+
+export function wrapMarketplaceSignerPolicy(
+  tool: Tool,
+  params: {
+    readonly policy?: MarketplaceSignerPolicy;
+    readonly programId: PublicKey;
+    readonly signer?: PublicKey | null;
+    readonly logger: Logger;
+  },
+): Tool {
+  if (!params.policy) {
+    return tool;
+  }
+  return {
+    ...tool,
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      let decision: MarketplaceSignerPolicyEvaluation;
+      try {
+        decision = evaluateMarketplaceSignerPolicy({
+          policy: params.policy!,
+          toolName: tool.name,
+          args,
+          programId: params.programId,
+          signer: params.signer,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return errorResult(message, { toolName: tool.name });
+      }
+      if (!decision.allowed) {
+        params.logger.warn?.(
+          `Marketplace signer policy denied ${tool.name}: ${decision.reason ?? decision.code ?? "denied"}`,
+        );
+        return errorResult(decision.reason ?? `${tool.name} denied by signer policy`, {
+          toolName: tool.name,
+          denialCode: decision.code ?? "DENIED",
+          ...(decision.metadata ?? {}),
+        });
+      }
+      params.logger.info?.(`Marketplace signer policy approved ${tool.name}`);
+      return tool.execute(args);
+    },
+  };
+}

--- a/runtime/src/tools/index.ts
+++ b/runtime/src/tools/index.ts
@@ -46,6 +46,7 @@ export {
   createAgencReadOnlyTools,
   createAgencMutationTools,
   type CreateAgencToolsOptions,
+  type MarketplaceSignerPolicy,
   createListTasksTool,
   createGetTaskTool,
   createGetTokenBalanceTool,

--- a/runtime/src/tools/index.ts
+++ b/runtime/src/tools/index.ts
@@ -43,6 +43,9 @@ export {
 // Built-in AgenC tools
 export {
   createAgencTools,
+  createAgencReadOnlyTools,
+  createAgencMutationTools,
+  type CreateAgencToolsOptions,
   createListTasksTool,
   createGetTaskTool,
   createGetTokenBalanceTool,

--- a/runtime/src/tools/types.ts
+++ b/runtime/src/tools/types.ts
@@ -13,6 +13,7 @@ import type { AgencCoordination } from "../types/agenc_coordination.js";
 import type { Wallet } from "../types/wallet.js";
 import type { Logger } from "../utils/logger.js";
 import type { PolicyEngine } from "../policy/engine.js";
+import type { MarketplaceSignerPolicy } from "./agenc/signer-policy.js";
 
 /**
  * JSON Schema type alias.
@@ -113,6 +114,8 @@ export interface ToolContext {
   readonly programId?: PublicKey;
   /** Logger instance */
   readonly logger: Logger;
+  /** Optional local signer policy for signer-backed AgenC marketplace tools. */
+  readonly marketplaceSignerPolicy?: MarketplaceSignerPolicy;
 }
 
 /**

--- a/scripts/marketplace-devnet-smoke.ts
+++ b/scripts/marketplace-devnet-smoke.ts
@@ -455,12 +455,15 @@ async function registerOrLoadAgent(
     };
   }
 
-  const registerTool = createAgencTools({
-    connection,
-    wallet: keypairToWallet(signer.keypair),
-    programId,
-    logger: silentLogger,
-  }).find((tool) => tool.name === "agenc.registerAgent");
+  const registerTool = createAgencTools(
+    {
+      connection,
+      wallet: keypairToWallet(signer.keypair),
+      programId,
+      logger: silentLogger,
+    },
+    { includeMutationTools: true },
+  ).find((tool) => tool.name === "agenc.registerAgent");
 
   if (!registerTool) {
     throw new Error("agenc.registerAgent tool is not available");

--- a/scripts/marketplace-tui-devnet-smoke.ts
+++ b/scripts/marketplace-tui-devnet-smoke.ts
@@ -582,12 +582,15 @@ async function registerOrLoadAgent(
     };
   }
 
-  const registerTool = createAgencTools({
-    connection,
-    wallet: keypairToWallet(signer.keypair),
-    programId,
-    logger: silentLogger,
-  }).find((tool) => tool.name === "agenc.registerAgent");
+  const registerTool = createAgencTools(
+    {
+      connection,
+      wallet: keypairToWallet(signer.keypair),
+      programId,
+      logger: silentLogger,
+    },
+    { includeMutationTools: true },
+  ).find((tool) => tool.name === "agenc.registerAgent");
 
   if (!registerTool) {
     throw new Error("agenc.registerAgent tool is not available");
@@ -747,12 +750,15 @@ async function executeToolJson(
   args: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
   return withRpcRateLimitRetry(toolName, async () => {
-    const tool = createAgencTools({
-      connection,
-      wallet: keypairToWallet(signer.keypair),
-      programId,
-      logger: silentLogger,
-    }).find((entry) => entry.name === toolName);
+    const tool = createAgencTools(
+      {
+        connection,
+        wallet: keypairToWallet(signer.keypair),
+        programId,
+        logger: silentLogger,
+      },
+      { includeMutationTools: true },
+    ).find((entry) => entry.name === toolName);
 
     if (!tool) {
       throw new Error(`${toolName} is not available`);

--- a/scripts/verified-attestation-devnet-smoke.ts
+++ b/scripts/verified-attestation-devnet-smoke.ts
@@ -174,12 +174,15 @@ async function ensureCreatorAgent(
 
   // No agent — register one.
   info("no creator agent found; registering one");
-  const tools = createAgencTools({
-    connection,
-    wallet: keypairToWallet(creator),
-    programId: program.programId,
-    logger: silentLogger,
-  });
+  const tools = createAgencTools(
+    {
+      connection,
+      wallet: keypairToWallet(creator),
+      programId: program.programId,
+      logger: silentLogger,
+    },
+    { includeMutationTools: true },
+  );
   const registerTool = tools.find((t) => t.name === "agenc.registerAgent");
   if (!registerTool) throw new Error("agenc.registerAgent tool unavailable");
   const result = await registerTool.execute({


### PR DESCRIPTION
## Summary
- make `createAgencTools()` fail closed to read-only tools by default
- expose explicit `createAgencReadOnlyTools()` / `createAgencMutationTools()` surfaces
- require daemon marketplace signing tools to have explicit policy opt-in, loaded wallet, and gateway approvals
- add `MarketplaceSignerPolicy` wrapper that denies signer-backed marketplace mutations before execution unless capability envelope allows the exact tool/program/task/template/hash/lamport/mint constraints
- default daemon signer policy to deny-all when signing tools are enabled without a configured envelope
- update devnet smoke scripts to opt into mutation tools intentionally
- document the new signer-backed tool wiring and policy config

Covers Phase 1 and the first signer-boundary guard from Phase 2 of #543.

## Validation
- `npx vitest run runtime/src/tools/agenc/index.test.ts runtime/src/gateway/daemon.test.ts runtime/src/gateway/config-watcher.test.ts` — 177 passed
- `npx tsc --noEmit -p runtime/tsconfig.json`
- `npx tsx scripts/marketplace-devnet-smoke.ts --help`
- `npx tsx scripts/marketplace-tui-devnet-smoke.ts --help`
- real devnet: `npx tsx scripts/verified-attestation-devnet-smoke.ts --help` (script has no help handler and ran full smoke)
  - task PDA: `2q4JQx2Rn5ZFf4rqANV481NU4KoDEpGdUisUxKdwgCFW`
  - create tx: `4XevPnnrDaafZAY3hyNYxEzzXogNE7aHvHND3vRq93JiZrb5f3wF3U23bxdkEURNdeGUyuJJhnLUYDayAve6t9Wq`
  - set job spec tx: `6nspPBW28tXvaXuMaPm1PyUXiFZSTSCb5Q99oMKGagJad1kAyQc76Gkj3bP1JuQUgz9wSDAjnhgnHYShpaVVUMt`
  - passed create, replay rejection, issuer-key reread, no-key unverified reread, tampered signature rejection, cross-link attestation swap rejection, and pre-submit no-marker checks
