### PR TITLE
Add marketplace mainnet v1 readiness gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "smoke:marketplace:devnet": "tsx scripts/marketplace-devnet-smoke.ts",
   "smoke:marketplace:hardening:devnet": "tsx scripts/marketplace-hardening-devnet-matrix.ts",
   "smoke:marketplace:tui:devnet": "tsx scripts/marketplace-tui-devnet-smoke.ts",
+  "smoke:marketplace:mainnet-v1:devnet": "tsx scripts/marketplace-mainnet-v1-devnet.ts",
   "drill:sandbox:fleet": "tsx scripts/sandbox-fleet-drill.ts",
   "drill:compiled-job:operator-live": "tsx scripts/compiled-job-phase1-operator-drill.ts",
   "build:public-runtime-artifacts": "node scripts/build-public-runtime-artifacts.mjs",

--- a/runtime/docs/compiled-job-phase1-live-drills.md
+++ b/runtime/docs/compiled-job-phase1-live-drills.md
@@ -6,6 +6,7 @@ closed by unit tests, CI gates, or a single devnet smoke.
 Use this together with:
 
 - `runtime/docs/compiled-job-phase1-launch-readiness.md`
+- `runtime/docs/marketplace-mainnet-v1-readiness.md`
 - `runtime/docs/observability-incident-runbook.md`
 - `docs/DEPLOYMENT_CHECKLIST.md`
 
@@ -44,19 +45,19 @@ program and the currently selected RPC provider.
 Baseline command:
 
 ```bash
-npm run soak:marketplace:devnet -- --mode tui --iterations 3 --child-max-wait-seconds 300
+npm run smoke:marketplace:mainnet-v1:devnet -- \
+  --mode soak \
+  --iterations 3 \
+  --child-max-wait-seconds 300
 ```
 
-Full mixed run when plain marketplace dispute deadlines are expected to exceed
-the local wait budget:
+Full launch-scope run:
 
 ```bash
-npm run soak:marketplace:devnet -- \
-  --mode both \
-  --iterations 2 \
-  --child-max-wait-seconds 300 \
-  --max-pending-wait-seconds 0 \
-  --allow-deferred
+npm run smoke:marketplace:mainnet-v1:devnet -- \
+  --mode all \
+  --iterations 3 \
+  --child-max-wait-seconds 300
 ```
 
 Acceptance:
@@ -68,8 +69,8 @@ Acceptance:
 
 Evidence:
 
-- soak artifact JSON written by `scripts/marketplace-devnet-soak.ts`
-- referenced pending-artifact paths for any deferred resumes
+- readiness artifact JSON written by `scripts/marketplace-mainnet-v1-devnet.ts`
+- referenced child smoke artifact paths for any deferred resumes
 
 ## Sandbox Fleet Concurrency Drill
 

--- a/runtime/docs/marketplace-mainnet-v1-readiness.md
+++ b/runtime/docs/marketplace-mainnet-v1-readiness.md
@@ -1,0 +1,129 @@
+# Marketplace Mainnet V1 Readiness
+
+This is the launch gate for the first mainnet marketplace cut that runs through
+core protocol, runtime, SDK, CLI, TUI, and explorer visibility.
+
+Tracking issue: <https://github.com/tetsuo-ai/agenc-core/issues/549>
+
+## Scope
+
+Included in mainnet v1:
+
+- public task creation
+- task discovery/list/detail
+- worker claim
+- worker completion
+- buyer-facing artifact/result reference through the fixed on-chain result rail
+- reviewed-public creator review flow
+- dispute open, vote, and resolve
+- explorer/indexing visibility for task state changes
+- signer, wallet, reward, and mutation-policy controls
+- repeated devnet soak runs
+- operator controls and incident response evidence
+
+Excluded from mainnet v1:
+
+- Private ZK marketplace tasks
+- storefront/no-code checkout
+- AgenC Lab/Telegram buyer rails
+- rich storefront delivery review UI
+
+Those excluded surfaces can ship after the base protocol marketplace is proven
+safe and operable on devnet.
+
+## Required Evidence
+
+Every required lane must have reproducible evidence before mainnet. A lane is
+not green just because one lower-level unit test passed.
+
+| Lane | Required Evidence | Gate |
+| --- | --- | --- |
+| Preflight | RPC reachable, program ID selected, signer policy guard works | Required |
+| Public lifecycle | create -> list/detail -> claim -> complete -> final task state | Required |
+| Reviewed-public lifecycle | create with creator review -> submit result -> accept/reject/timeout -> settlement | Required |
+| Artifact/result rail | worker submits artifact file or URI -> digest committed in resultData -> reader reconstructs reference | Required |
+| Dispute lifecycle | open dispute -> 3 arbiter votes -> resolve -> final task/dispute state | Required |
+| Explorer visibility | new/updated PDAs appear in explorer/indexing within expected polling window | Required |
+| Signer/wallet safety | reward caps, allowed tools, constraint guards, no unsafe default mutation tools | Required |
+| Soak | repeated devnet runs with no unclassified failures | Required |
+| Operator controls | pause/disable/rollback/alert acknowledgement evidence on target runtime host | Required |
+
+## Runner
+
+Use the mainnet-v1 devnet gate:
+
+```bash
+npm run smoke:marketplace:mainnet-v1:devnet -- --mode all
+```
+
+Useful lane commands:
+
+```bash
+npm run smoke:marketplace:mainnet-v1:devnet -- --mode preflight
+npm run smoke:marketplace:mainnet-v1:devnet -- --mode public
+npm run smoke:marketplace:mainnet-v1:devnet -- --mode reviewed-public
+npm run smoke:marketplace:mainnet-v1:devnet -- --mode artifact
+npm run smoke:marketplace:mainnet-v1:devnet -- --mode dispute
+npm run smoke:marketplace:mainnet-v1:devnet -- --mode explorer
+npm run smoke:marketplace:mainnet-v1:devnet -- --mode safety
+npm run smoke:marketplace:mainnet-v1:devnet -- --mode soak --iterations 3
+npm run smoke:marketplace:mainnet-v1:devnet -- --mode operator
+```
+
+The runner writes a JSON evidence artifact under `/tmp` by default. Use
+`--artifact <path>` to pin the evidence into a release folder.
+
+`--allow-pending` is only for roadmap discovery. It must not be used for the
+final mainnet go/no-go run.
+
+## Live Devnet Environment
+
+The live protocol lanes require funded devnet signers:
+
+```bash
+export CREATOR_WALLET=/path/to/creator.json
+export WORKER_WALLET=/path/to/worker.json
+export ARBITER_A_WALLET=/path/to/arbiter-a.json
+export ARBITER_B_WALLET=/path/to/arbiter-b.json
+export ARBITER_C_WALLET=/path/to/arbiter-c.json
+export PROTOCOL_AUTHORITY_WALLET=/path/to/authority.json
+export AGENC_RPC_URL=https://api.devnet.solana.com
+```
+
+Optional:
+
+```bash
+export AGENC_PROGRAM_ID=<program-id>
+export AGENC_REWARD_LAMPORTS=10000000
+export AGENC_MAX_WAIT_SECONDS=300
+```
+
+## Supporting Drills
+
+The mainnet-v1 runner is the top-level gate. These scripts remain useful for
+isolated investigation:
+
+```bash
+npm run smoke:marketplace:devnet
+npm run smoke:marketplace:tui:devnet
+npm run smoke:marketplace:hardening:devnet
+npm run drill:sandbox:fleet
+npm run drill:compiled-job:operator-live
+```
+
+## Go/No-Go Rule
+
+Go:
+
+- every required lane returns `pass`
+- soak evidence is attached
+- operator live-drill evidence is attached
+- no unresolved blocker issue remains for the included launch scope
+
+No-go:
+
+- any required lane returns `fail`
+- any required lane returns `pending`
+- evidence requires storefront, Private ZK, or another excluded surface to make
+  the base marketplace lifecycle work
+- operator controls cannot be executed in the target runtime environment

--- a/runtime/docs/marketplace-mainnet-v1-readiness.md
+++ b/runtime/docs/marketplace-mainnet-v1-readiness.md
@@ -107,6 +107,19 @@ npm run smoke:marketplace:devnet -- --flow reviewed-public-artifact
 That flow creates a creator-review task, claims it, completes it with
 `--artifact-file`, accepts it from the creator side, and asserts that task
 detail reconstructs the buyer-facing artifact digest from on-chain `resultData`.
+It also checks `tasks.list` visibility after create, claim, and accept so the
+explorer/indexing lane is covered without requiring the storefront.
+
+The operator lane runs:
+
+```bash
+npm run smoke:marketplace:mainnet-v1:devnet -- --mode operator
+```
+
+That wraps `scripts/compiled-job-phase1-operator-drill.ts` and only passes when
+the generated host-drill artifact has `overallPassed: true`. A dry local run
+without real alert routing or on-call acknowledgement is expected to fail the
+mainnet gate.
 
 ## Supporting Drills
 

--- a/runtime/docs/marketplace-mainnet-v1-readiness.md
+++ b/runtime/docs/marketplace-mainnet-v1-readiness.md
@@ -98,6 +98,16 @@ export AGENC_REWARD_LAMPORTS=10000000
 export AGENC_MAX_WAIT_SECONDS=300
 ```
 
+The reviewed-public artifact lane can also be run directly:
+
+```bash
+npm run smoke:marketplace:devnet -- --flow reviewed-public-artifact
+```
+
+That flow creates a creator-review task, claims it, completes it with
+`--artifact-file`, accepts it from the creator side, and asserts that task
+detail reconstructs the buyer-facing artifact digest from on-chain `resultData`.
+
 ## Supporting Drills
 
 The mainnet-v1 runner is the top-level gate. These scripts remain useful for

--- a/runtime/src/task/operations.test.ts
+++ b/runtime/src/task/operations.test.ts
@@ -859,6 +859,54 @@ describe("TaskOperations", () => {
       );
     });
 
+    it("falls back to legacy claimTask when the deployed program lacks claimTaskWithJobSpec", async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createParsedTask();
+      const storeDir = await mkdtemp(join(tmpdir(), "agenc-job-spec-"));
+      const stored = await persistMarketplaceJobSpec(
+        {
+          description: "Verified marketplace task",
+          acceptanceCriteria: ["Do the verified work"],
+          deliverables: ["A short report"],
+        },
+        { rootDir: storeDir },
+      );
+      const jobSpecHashBytes = Uint8Array.from(Buffer.from(stored.hash, "hex"));
+      const opsWithStore = new TaskOperations({
+        program: mockProgram,
+        agentId,
+        logger: silentLogger,
+        jobSpecStoreDir: storeDir,
+      });
+
+      mocks.taskJobSpecFetch.mockResolvedValue({
+        task: taskPda,
+        creator: Keypair.generate().publicKey,
+        jobSpecHash: Array.from(jobSpecHashBytes),
+        jobSpecUri: stored.uri,
+        createdAt: { toNumber: () => 1700000000 },
+        updatedAt: { toNumber: () => 1700000000 },
+        bump: 255,
+      });
+      mocks.claimTaskWithJobSpecRpc.mockRejectedValue(
+        new Error(
+          "InstructionFallbackNotFound: Fallback functions are not supported",
+        ),
+      );
+
+      const result = await opsWithStore.claimTask(taskPda, task);
+
+      expect(result.transactionSignature).toBe("claim-sig");
+      expect(mocks.claimTaskWithJobSpecRpc).toHaveBeenCalledOnce();
+      expect(mocks.claimTaskRpc).toHaveBeenCalledOnce();
+      expect(mocks.claimTaskBuilder.accountsPartial).toHaveBeenCalledWith(
+        expect.objectContaining({
+          task: taskPda,
+          systemProgram: SystemProgram.programId,
+        }),
+      );
+    });
+
     it("rejects marketplace claims when on-chain jobSpec metadata cannot be verified", async () => {
       const taskPda = Keypair.generate().publicKey;
       const task = createParsedTask();

--- a/runtime/src/task/operations.ts
+++ b/runtime/src/task/operations.ts
@@ -450,18 +450,34 @@ export class TaskOperations {
       const taskJobSpec = intent.accountMetas.find(
         (account) => account.name === "taskJobSpec",
       )?.pubkey;
-      const signature = taskJobSpec
-        ? await (this.program.methods as any)
+      let signature: string;
+      if (taskJobSpec) {
+        try {
+          signature = await (this.program.methods as any)
             .claimTaskWithJobSpec()
             .accountsPartial({
               ...baseAccounts,
               taskJobSpec: new PublicKey(taskJobSpec),
             })
-            .rpc()
-        : await this.program.methods
+            .rpc();
+        } catch (err) {
+          if (!isInstructionFallbackNotFound(err)) {
+            throw err;
+          }
+          this.logger.warn(
+            `Program ${this.program.programId.toBase58()} does not expose claimTaskWithJobSpec; falling back to legacy claimTask after local job spec verification`,
+          );
+          signature = await this.program.methods
             .claimTask()
             .accountsPartial(baseAccounts)
             .rpc();
+        }
+      } else {
+        signature = await this.program.methods
+          .claimTask()
+          .accountsPartial(baseAccounts)
+          .rpc();
+      }
 
       this.logger.info(`Task claimed: ${signature}`);
 
@@ -1758,4 +1774,12 @@ function isAccountNotFoundError(err: unknown): boolean {
 
 function formatUnknownError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function isInstructionFallbackNotFound(err: unknown): boolean {
+  const message = formatUnknownError(err);
+  return (
+    message.includes("InstructionFallbackNotFound") ||
+    message.includes("Fallback functions are not supported")
+  );
 }

--- a/scripts/marketplace-devnet-smoke.ts
+++ b/scripts/marketplace-devnet-smoke.ts
@@ -130,12 +130,12 @@ function usage(): void {
   npm run smoke:marketplace:devnet -- --resume /tmp/agenc-marketplace-smoke/marketplace-devnet-smoke-....json
 
 Environment:
-  CREATOR_WALLET                Required for initial run.
-  WORKER_WALLET                 Required for initial run.
-  ARBITER_A_WALLET              Required for initial run.
-  ARBITER_B_WALLET              Required for initial run.
-  ARBITER_C_WALLET              Required for initial run.
-  PROTOCOL_AUTHORITY_WALLET     Required in both modes.
+  CREATOR_WALLET                Required for all initial flows.
+  WORKER_WALLET                 Required for all initial flows.
+  ARBITER_A_WALLET              Required for --flow dispute.
+  ARBITER_B_WALLET              Required for --flow dispute.
+  ARBITER_C_WALLET              Required for --flow dispute.
+  PROTOCOL_AUTHORITY_WALLET     Required for --flow dispute and --resume.
   AGENC_RPC_URL                 Optional. Defaults to ${DEFAULT_RPC_URL}
   AGENC_PROGRAM_ID              Optional. Defaults to the runtime program ID.
   AGENC_REWARD_LAMPORTS         Optional. Defaults to ${DEFAULT_REWARD_LAMPORTS.toString()}
@@ -910,6 +910,7 @@ async function initial(): Promise<void> {
     DEFAULT_MAX_WAIT_SECONDS,
   );
   const artifactPath = getFlagValue("--artifact");
+  const flow = parseInitialFlow();
   const connection = new Connection(rpcUrl, "confirmed");
 
   const creatorSigner = createSignerContext(
@@ -924,6 +925,100 @@ async function initial(): Promise<void> {
     connection,
     programId,
   );
+  const readOnlyProgram = programId
+    ? createReadOnlyProgram(connection, programId)
+    : createReadOnlyProgram(connection);
+
+  const protocolConfig = await loadProtocolConfig(readOnlyProgram);
+  await validateProtocolConfigHealth(connection, readOnlyProgram, protocolConfig);
+
+  const creatorStake = maxBigInt(
+    protocolConfig.minAgentStake,
+    protocolConfig.minStakeForDispute * 2n,
+  );
+  const workerStake = protocolConfig.minAgentStake;
+  const arbiterStake = maxBigInt(
+    protocolConfig.minAgentStake,
+    protocolConfig.minArbiterStake,
+  );
+
+  if (flow === "reviewed-public-artifact") {
+    ensureDistinctWallets([creatorSigner, workerSigner]);
+    await Promise.all([
+      ensureBalance(
+        connection,
+        "creator",
+        creatorSigner.keypair.publicKey,
+        creatorStake + rewardLamports + DEFAULT_FEE_BUFFER_LAMPORTS,
+      ),
+      ensureBalance(
+        connection,
+        "worker",
+        workerSigner.keypair.publicKey,
+        workerStake + DEFAULT_FEE_BUFFER_LAMPORTS,
+      ),
+    ]);
+
+    console.log(`[config] rpc: ${rpcUrl}`);
+    console.log(`[config] program: ${readOnlyProgram.programId.toBase58()}`);
+    console.log(`[config] flow: ${flow}`);
+    console.log(`[config] reward lamports: ${rewardLamports.toString()}`);
+    console.log(`[config] creator wallet: ${creatorSigner.keypair.publicKey.toBase58()}`);
+    console.log(`[config] worker wallet: ${workerSigner.keypair.publicKey.toBase58()}`);
+
+    const creator = await registerOrLoadAgent(
+      creatorSigner,
+      connection,
+      programId,
+      AgentCapabilities.COMPUTE,
+      creatorStake,
+      maxBigInt(protocolConfig.minAgentStake, protocolConfig.minStakeForDispute),
+    );
+    const worker = await registerOrLoadAgent(
+      workerSigner,
+      connection,
+      programId,
+      AgentCapabilities.COMPUTE,
+      workerStake,
+      workerStake,
+    );
+
+    console.log(`[agent] creator: ${creator.agentPda.toBase58()}`);
+    console.log(`[agent] worker: ${worker.agentPda.toBase58()}`);
+
+    const runtime: SmokeRuntime = {
+      connection,
+      readOnlyProgram,
+      signersByKey: new Map<string, SignerContext>([
+        [creator.agentPda.toBase58(), creator],
+        [worker.agentPda.toBase58(), worker],
+      ]),
+    };
+    installMarketplaceCliOverrides(runtime);
+
+    const baseOptions = buildBaseOptions(
+      rpcUrl,
+      readOnlyProgram.programId.toBase58(),
+    );
+    const runId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+    try {
+      await runReviewedPublicArtifactFlow({
+        baseOptions,
+        rpcUrl,
+        programId: readOnlyProgram.programId.toBase58(),
+        rewardLamports,
+        runId,
+        creator,
+        worker,
+        artifactPath,
+      });
+      return;
+    } finally {
+      resetMarketplaceCliProgramContextOverrides();
+    }
+  }
+
   const arbiterASigner = createSignerContext(
     "arbiter-a",
     env("ARBITER_A_WALLET"),
@@ -948,10 +1043,6 @@ async function initial(): Promise<void> {
     connection,
     programId,
   );
-  const readOnlyProgram = programId
-    ? createReadOnlyProgram(connection, programId)
-    : createReadOnlyProgram(connection);
-
   ensureDistinctWallets([
     creatorSigner,
     workerSigner,
@@ -960,24 +1051,11 @@ async function initial(): Promise<void> {
     arbiterCSigner,
     authoritySigner,
   ]);
-
-  const protocolConfig = await loadProtocolConfig(readOnlyProgram);
   if (!authoritySigner.keypair.publicKey.equals(protocolConfig.authority)) {
     throw new Error(
       `PROTOCOL_AUTHORITY_WALLET ${authoritySigner.keypair.publicKey.toBase58()} does not match protocol authority ${protocolConfig.authority.toBase58()}`,
     );
   }
-  await validateProtocolConfigHealth(connection, readOnlyProgram, protocolConfig);
-
-  const creatorStake = maxBigInt(
-    protocolConfig.minAgentStake,
-    protocolConfig.minStakeForDispute * 2n,
-  );
-  const workerStake = protocolConfig.minAgentStake;
-  const arbiterStake = maxBigInt(
-    protocolConfig.minAgentStake,
-    protocolConfig.minArbiterStake,
-  );
 
   await Promise.all([
     ensureBalance(
@@ -1020,6 +1098,7 @@ async function initial(): Promise<void> {
 
   console.log(`[config] rpc: ${rpcUrl}`);
   console.log(`[config] program: ${readOnlyProgram.programId.toBase58()}`);
+  console.log(`[config] flow: ${flow}`);
   console.log(`[config] reward lamports: ${rewardLamports.toString()}`);
   console.log(`[config] max wait seconds: ${maxWaitSeconds}`);
   console.log(`[config] creator wallet: ${creatorSigner.keypair.publicKey.toBase58()}`);
@@ -1094,26 +1173,6 @@ async function initial(): Promise<void> {
     readOnlyProgram.programId.toBase58(),
   );
   const runId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
-  const flow = parseInitialFlow();
-
-  if (flow === "reviewed-public-artifact") {
-    try {
-      await runReviewedPublicArtifactFlow({
-        baseOptions,
-        rpcUrl,
-        programId: readOnlyProgram.programId.toBase58(),
-        rewardLamports,
-        runId,
-        creator,
-        worker,
-        artifactPath,
-      });
-      return;
-    } finally {
-      resetMarketplaceCliProgramContextOverrides();
-    }
-  }
-
   const description = `devnet smoke ${runId}`;
 
   try {

--- a/scripts/marketplace-devnet-smoke.ts
+++ b/scripts/marketplace-devnet-smoke.ts
@@ -27,6 +27,7 @@ import {
   resetMarketplaceCliProgramContextOverrides,
   runMarketDisputeDetailCommand,
   runMarketDisputeResolveCommand,
+  runMarketTasksListCommand,
   runMarketTaskAcceptCommand,
   runMarketTaskClaimCommand,
   runMarketTaskCompleteCommand,
@@ -105,6 +106,12 @@ interface ReviewedPublicArtifactSmokeArtifact {
   artifactFile: string;
   artifactSha256: string;
   deliveryArtifact: Record<string, unknown>;
+  visibilityChecks: Array<{
+    stage: string;
+    status: string;
+    taskPda: string;
+    observedAt: string;
+  }>;
 }
 
 type MarketRunner = (
@@ -714,6 +721,50 @@ async function writeReviewedPublicArtifact(
   return filePath;
 }
 
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function assertTaskVisibleInList(
+  baseOptions: BaseCliOptions,
+  taskPda: string,
+  expectedStatus: string,
+  stage: string,
+): Promise<{ stage: string; status: string; taskPda: string; observedAt: string }> {
+  const statuses = ["open", "in_progress", "completed", "cancelled", "disputed"];
+
+  for (let attempt = 1; attempt <= 8; attempt += 1) {
+    const output = await runMarketCommand(
+      baseOptions,
+      runMarketTasksListCommand as MarketRunner,
+      { statuses },
+    );
+    const tasks = Array.isArray(output.tasks)
+      ? (output.tasks as Record<string, unknown>[])
+      : [];
+    const task = tasks.find((entry) => entry.taskPda === taskPda);
+    if (task) {
+      const status = getStringField(task, "status", `${stage}.tasksList`);
+      if (status === expectedStatus) {
+        const observedAt = new Date().toISOString();
+        console.log(`[visible] ${stage}: ${taskPda} status=${status}`);
+        return { stage, status, taskPda, observedAt };
+      }
+      throw new Error(
+        `${stage}: task ${taskPda} is visible but status=${status}, expected ${expectedStatus}`,
+      );
+    }
+
+    if (attempt < 8) {
+      await sleep(1_500);
+    }
+  }
+
+  throw new Error(
+    `${stage}: task ${taskPda} did not appear in tasks.list with status=${expectedStatus}`,
+  );
+}
+
 async function readArtifact(filePath: string): Promise<SmokeArtifact> {
   const parsed = JSON.parse(await readFile(filePath, "utf8")) as unknown;
   const artifact = asRecord(parsed, "artifact");
@@ -770,6 +821,7 @@ async function runReviewedPublicArtifactFlow(params: {
   const artifactSha256 = createHash("sha256")
     .update(artifactBody)
     .digest("hex");
+  const visibilityChecks: ReviewedPublicArtifactSmokeArtifact["visibilityChecks"] = [];
 
   const createOutput = await runMarketCommand(
     baseOptions,
@@ -800,6 +852,9 @@ async function runReviewedPublicArtifactFlow(params: {
     "reviewedCreate.result",
   );
   console.log(`[reviewed] created ${taskPda}`);
+  visibilityChecks.push(
+    await assertTaskVisibleInList(baseOptions, taskPda, "open", "after-create"),
+  );
 
   const claimOutput = await runMarketCommand(
     baseOptions,
@@ -817,6 +872,9 @@ async function runReviewedPublicArtifactFlow(params: {
     "reviewedClaim.result",
   );
   console.log(`[reviewed] claimed ${workerClaimPda}`);
+  visibilityChecks.push(
+    await assertTaskVisibleInList(baseOptions, taskPda, "in_progress", "after-claim"),
+  );
 
   await runMarketCommand(
     baseOptions,
@@ -842,6 +900,9 @@ async function runReviewedPublicArtifactFlow(params: {
     creator.agentPda.toBase58(),
   );
   console.log(`[reviewed] accepted ${taskPda}`);
+  visibilityChecks.push(
+    await assertTaskVisibleInList(baseOptions, taskPda, "completed", "after-accept"),
+  );
 
   const detailOutput = await runMarketCommand(
     baseOptions,
@@ -888,6 +949,7 @@ async function runReviewedPublicArtifactFlow(params: {
       artifactFile,
       artifactSha256,
       deliveryArtifact,
+      visibilityChecks,
     },
     artifactPath,
   );

--- a/scripts/marketplace-devnet-smoke.ts
+++ b/scripts/marketplace-devnet-smoke.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -26,7 +27,9 @@ import {
   resetMarketplaceCliProgramContextOverrides,
   runMarketDisputeDetailCommand,
   runMarketDisputeResolveCommand,
+  runMarketTaskAcceptCommand,
   runMarketTaskClaimCommand,
+  runMarketTaskCompleteCommand,
   runMarketTaskCreateCommand,
   runMarketTaskDetailCommand,
   runMarketTaskDisputeCommand,
@@ -86,10 +89,30 @@ interface SmokeArtifact {
   arbiterVotes: Array<{ votePda: string; arbiterAgentPda: string }>;
 }
 
+interface ReviewedPublicArtifactSmokeArtifact {
+  version: 1;
+  kind: "marketplace-reviewed-public-artifact-devnet-smoke";
+  createdAt: string;
+  rpcUrl: string;
+  programId: string;
+  runId: string;
+  description: string;
+  rewardLamports: string;
+  creatorAgentPda: string;
+  workerAgentPda: string;
+  workerClaimPda: string;
+  taskPda: string;
+  artifactFile: string;
+  artifactSha256: string;
+  deliveryArtifact: Record<string, unknown>;
+}
+
 type MarketRunner = (
   context: CliRuntimeContext,
   options: Record<string, unknown>,
 ) => Promise<0 | 1 | 2>;
+
+type InitialFlow = "dispute" | "reviewed-public-artifact";
 
 let activeSignerKey: string | null = null;
 
@@ -121,6 +144,7 @@ Environment:
 Flags:
   --resume <path>               Resume a previously-created artifact and resolve.
   --artifact <path>             Custom output path for the resume artifact.
+  --flow <name>                 Initial flow: dispute | reviewed-public-artifact.
   --help                        Show this message.
 `);
 }
@@ -149,6 +173,14 @@ function getFlagValue(flag: string): string | null {
   }
 
   return value;
+}
+
+function parseInitialFlow(): InitialFlow {
+  const raw = getFlagValue("--flow") ?? "dispute";
+  if (raw === "dispute" || raw === "reviewed-public-artifact") {
+    return raw;
+  }
+  throw new Error(`Unsupported --flow ${raw}`);
 }
 
 function parseOptionalProgramId(): PublicKey | undefined {
@@ -666,6 +698,22 @@ async function writeArtifact(
   return filePath;
 }
 
+async function writeReviewedPublicArtifact(
+  artifact: ReviewedPublicArtifactSmokeArtifact,
+  explicitPath?: string | null,
+): Promise<string> {
+  const filePath =
+    explicitPath ??
+    path.join(
+      ARTIFACT_DIR,
+      `marketplace-reviewed-public-artifact-devnet-smoke-${Date.now()}.json`,
+    );
+
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
+  return filePath;
+}
+
 async function readArtifact(filePath: string): Promise<SmokeArtifact> {
   const parsed = JSON.parse(await readFile(filePath, "utf8")) as unknown;
   const artifact = asRecord(parsed, "artifact");
@@ -681,6 +729,173 @@ async function readArtifact(filePath: string): Promise<SmokeArtifact> {
   }
 
   return artifact as unknown as SmokeArtifact;
+}
+
+async function runReviewedPublicArtifactFlow(params: {
+  baseOptions: BaseCliOptions;
+  rpcUrl: string;
+  programId: string;
+  rewardLamports: bigint;
+  runId: string;
+  creator: AgentActor;
+  worker: AgentActor;
+  artifactPath?: string | null;
+}): Promise<void> {
+  const {
+    baseOptions,
+    rpcUrl,
+    programId,
+    rewardLamports,
+    runId,
+    creator,
+    worker,
+    artifactPath,
+  } = params;
+  const description = `reviewed artifact smoke ${runId}`;
+  const artifactRoot = path.join(ARTIFACT_DIR, `reviewed-public-${runId}`);
+  const artifactFile = path.join(artifactRoot, "delivery.md");
+  const artifactStoreDir = path.join(artifactRoot, "artifact-store");
+  const artifactBody = [
+    "# Reviewed public artifact smoke",
+    "",
+    `Run: ${runId}`,
+    `Creator agent: ${creator.agentPda.toBase58()}`,
+    `Worker agent: ${worker.agentPda.toBase58()}`,
+    "",
+    "This markdown file is the buyer-facing artifact committed through the protocol result rail.",
+    "",
+  ].join("\n");
+  await mkdir(artifactRoot, { recursive: true });
+  await writeFile(artifactFile, artifactBody, "utf8");
+  const artifactSha256 = createHash("sha256")
+    .update(artifactBody)
+    .digest("hex");
+
+  const createOutput = await runMarketCommand(
+    baseOptions,
+    runMarketTaskCreateCommand as MarketRunner,
+    {
+      description,
+      reward: rewardLamports.toString(),
+      requiredCapabilities: AgentCapabilities.COMPUTE.toString(),
+      creatorAgentPda: creator.agentPda.toBase58(),
+      validationMode: "creator-review",
+      reviewWindowSecs: 3_600,
+      fullDescription:
+        "Live devnet smoke for creator-review artifact settlement without storefront.",
+      acceptanceCriteria: [
+        "Worker submits a real artifact file through the CLI/runtime completion rail.",
+        "Creator accepts the reviewed result.",
+        "Task detail reconstructs the artifact digest from on-chain resultData.",
+      ],
+      deliverables: ["Markdown delivery artifact"],
+      constraints: ["No Private ZK and no storefront dependencies."],
+    },
+    creator.agentPda.toBase58(),
+  );
+  const createResult = asRecord(createOutput.result, "reviewedCreate.result");
+  const taskPda = getStringField(
+    createResult,
+    "taskPda",
+    "reviewedCreate.result",
+  );
+  console.log(`[reviewed] created ${taskPda}`);
+
+  const claimOutput = await runMarketCommand(
+    baseOptions,
+    runMarketTaskClaimCommand as MarketRunner,
+    {
+      taskPda,
+      workerAgentPda: worker.agentPda.toBase58(),
+    },
+    worker.agentPda.toBase58(),
+  );
+  const claimResult = asRecord(claimOutput.result, "reviewedClaim.result");
+  const workerClaimPda = getStringField(
+    claimResult,
+    "claimPda",
+    "reviewedClaim.result",
+  );
+  console.log(`[reviewed] claimed ${workerClaimPda}`);
+
+  await runMarketCommand(
+    baseOptions,
+    runMarketTaskCompleteCommand as MarketRunner,
+    {
+      taskPda,
+      artifactFile,
+      artifactStoreDir,
+      artifactMediaType: "text/markdown",
+      workerAgentPda: worker.agentPda.toBase58(),
+    },
+    worker.agentPda.toBase58(),
+  );
+  console.log(`[reviewed] submitted artifact ${artifactFile}`);
+
+  await runMarketCommand(
+    baseOptions,
+    runMarketTaskAcceptCommand as MarketRunner,
+    {
+      taskPda,
+      workerAgentPda: worker.agentPda.toBase58(),
+    },
+    creator.agentPda.toBase58(),
+  );
+  console.log(`[reviewed] accepted ${taskPda}`);
+
+  const detailOutput = await runMarketCommand(
+    baseOptions,
+    runMarketTaskDetailCommand as MarketRunner,
+    {
+      taskPda,
+    },
+  );
+  const task = asRecord(detailOutput.task, "reviewedDetail.task");
+  const status = getStringField(task, "status", "reviewedDetail.task");
+  if (status !== "completed") {
+    throw new Error(`Reviewed artifact task ${taskPda} ended with status=${status}`);
+  }
+
+  const deliveryArtifact = asRecord(
+    task.deliveryArtifact,
+    "reviewedDetail.task.deliveryArtifact",
+  );
+  const observedSha256 = getStringField(
+    deliveryArtifact,
+    "sha256",
+    "reviewedDetail.task.deliveryArtifact",
+  );
+  if (observedSha256 !== artifactSha256) {
+    throw new Error(
+      `Artifact digest mismatch: expected ${artifactSha256}, got ${observedSha256}`,
+    );
+  }
+
+  const savedPath = await writeReviewedPublicArtifact(
+    {
+      version: 1,
+      kind: "marketplace-reviewed-public-artifact-devnet-smoke",
+      createdAt: new Date().toISOString(),
+      rpcUrl,
+      programId,
+      runId,
+      description,
+      rewardLamports: rewardLamports.toString(),
+      creatorAgentPda: creator.agentPda.toBase58(),
+      workerAgentPda: worker.agentPda.toBase58(),
+      workerClaimPda,
+      taskPda,
+      artifactFile,
+      artifactSha256,
+      deliveryArtifact,
+    },
+    artifactPath,
+  );
+
+  console.log(
+    `[ok] reviewed-public artifact lifecycle complete for ${taskPda}: artifact=${artifactSha256}`,
+  );
+  console.log(`[artifact] ${savedPath}`);
 }
 
 async function initial(): Promise<void> {
@@ -879,6 +1094,26 @@ async function initial(): Promise<void> {
     readOnlyProgram.programId.toBase58(),
   );
   const runId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  const flow = parseInitialFlow();
+
+  if (flow === "reviewed-public-artifact") {
+    try {
+      await runReviewedPublicArtifactFlow({
+        baseOptions,
+        rpcUrl,
+        programId: readOnlyProgram.programId.toBase58(),
+        rewardLamports,
+        runId,
+        creator,
+        worker,
+        artifactPath,
+      });
+      return;
+    } finally {
+      resetMarketplaceCliProgramContextOverrides();
+    }
+  }
+
   const description = `devnet smoke ${runId}`;
 
   try {

--- a/scripts/marketplace-mainnet-v1-devnet.ts
+++ b/scripts/marketplace-mainnet-v1-devnet.ts
@@ -68,13 +68,13 @@ function usage(): void {
 Modes:
   preflight          RPC reachability and mutation signer-policy hardening.
   public             Public protocol lifecycle using the plain devnet smoke.
-  reviewed-public    Creator-review lifecycle gate. Currently required and pending.
-  artifact           Buyer-facing artifact rail gate. Runs local artifact tests, live lane pending.
+  reviewed-public    Creator-review lifecycle gate using the live artifact smoke.
+  artifact           Buyer-facing artifact rail gate, local tests plus live devnet smoke.
   dispute            Dispute lifecycle using the plain devnet smoke.
   explorer           Explorer/indexing visibility gate. Currently required and pending.
   safety             Wallet/signer safety gate using hardening matrix.
   soak               Repeated selected devnet smokes for stability evidence.
-  operator           Operator-control evidence gate. Currently required and pending.
+  operator           Operator-control evidence gate. Currently requires host evidence.
   all                Runs every mainnet-v1 lane.
 
 Flags:
@@ -217,19 +217,29 @@ async function runArtifact(): Promise<LaneResult[]> {
 
   return [
     localArtifactTests,
-    pendingLane(
+    await runChild(
       "artifact-result-rail-live-devnet",
       true,
-      "Missing dedicated live devnet smoke that creates a task, completes through CLI/runtime with --artifact-file or --artifact-uri, re-reads the task, and verifies the artifact digest/reference survives on-chain resultData.",
+      "tsx",
+      [
+        "scripts/marketplace-devnet-smoke.ts",
+        "--flow",
+        "reviewed-public-artifact",
+      ],
     ),
   ];
 }
 
 async function runReviewedPublic(): Promise<LaneResult> {
-  return pendingLane(
+  return runChild(
     "reviewed-public-lifecycle",
     true,
-    "Missing dedicated live devnet smoke for configure creator-review, worker submit result, creator accept/reject, timeout behavior, and final settlement. Existing public/TUI smokes do not prove this lane.",
+    "tsx",
+    [
+      "scripts/marketplace-devnet-smoke.ts",
+      "--flow",
+      "reviewed-public-artifact",
+    ],
   );
 }
 

--- a/scripts/marketplace-mainnet-v1-devnet.ts
+++ b/scripts/marketplace-mainnet-v1-devnet.ts
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+type LaneStatus = "pass" | "fail" | "pending";
+type Mode =
+  | "all"
+  | "preflight"
+  | "public"
+  | "reviewed-public"
+  | "artifact"
+  | "dispute"
+  | "explorer"
+  | "safety"
+  | "soak"
+  | "operator";
+
+interface LaneResult {
+  lane: string;
+  status: LaneStatus;
+  required: boolean;
+  command: string | null;
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+  notes: string;
+  exitCode: number | null;
+}
+
+interface CliOptions {
+  mode: Mode;
+  iterations: number;
+  artifactPath: string;
+  allowPending: boolean;
+  childMaxWaitSeconds: number | null;
+}
+
+const DEFAULT_ARTIFACT_PATH = path.join(
+  os.tmpdir(),
+  "agenc-marketplace-mainnet-v1-devnet",
+  `mainnet-v1-${Date.now()}-${process.pid}-${randomUUID().slice(0, 8)}.json`,
+);
+
+const VALID_MODES = new Set<Mode>([
+  "all",
+  "preflight",
+  "public",
+  "reviewed-public",
+  "artifact",
+  "dispute",
+  "explorer",
+  "safety",
+  "soak",
+  "operator",
+]);
+
+function usage(): void {
+  process.stdout.write(`Usage:
+  npm run smoke:marketplace:mainnet-v1:devnet -- --mode all
+  npm run smoke:marketplace:mainnet-v1:devnet -- --mode preflight
+  npm run smoke:marketplace:mainnet-v1:devnet -- --mode soak --iterations 3
+
+Modes:
+  preflight          RPC reachability and mutation signer-policy hardening.
+  public             Public protocol lifecycle using the plain devnet smoke.
+  reviewed-public    Creator-review lifecycle gate. Currently required and pending.
+  artifact           Buyer-facing artifact rail gate. Runs local artifact tests, live lane pending.
+  dispute            Dispute lifecycle using the plain devnet smoke.
+  explorer           Explorer/indexing visibility gate. Currently required and pending.
+  safety             Wallet/signer safety gate using hardening matrix.
+  soak               Repeated selected devnet smokes for stability evidence.
+  operator           Operator-control evidence gate. Currently required and pending.
+  all                Runs every mainnet-v1 lane.
+
+Flags:
+  --mode <mode>                  Defaults to all.
+  --iterations <n>               Soak iterations. Defaults to 3.
+  --artifact <path>              Evidence JSON output path.
+  --allow-pending                Return success even when required lanes are pending.
+  --child-max-wait-seconds <n>   Pass-through wait budget for child smokes that support it.
+  --help                         Show this help.
+
+Required env for live protocol lanes:
+  CREATOR_WALLET
+  WORKER_WALLET
+  ARBITER_A_WALLET
+  ARBITER_B_WALLET
+  ARBITER_C_WALLET
+  PROTOCOL_AUTHORITY_WALLET
+
+Optional:
+  AGENC_RPC_URL
+  AGENC_PROGRAM_ID
+`);
+}
+
+function getFlagValue(flag: string): string | null {
+  const index = process.argv.indexOf(flag);
+  if (index === -1) return null;
+  return process.argv[index + 1] ?? null;
+}
+
+function hasFlag(flag: string): boolean {
+  return process.argv.includes(flag);
+}
+
+function parsePositiveInteger(value: string | null, fallback: number, name: string): number {
+  if (value === null) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function parseOptions(): CliOptions {
+  if (hasFlag("--help") || hasFlag("-h")) {
+    usage();
+    process.exit(0);
+  }
+
+  const rawMode = getFlagValue("--mode") ?? "all";
+  if (!VALID_MODES.has(rawMode as Mode)) {
+    throw new Error(`Unsupported --mode ${rawMode}`);
+  }
+
+  return {
+    mode: rawMode as Mode,
+    iterations: parsePositiveInteger(getFlagValue("--iterations"), 3, "--iterations"),
+    artifactPath: getFlagValue("--artifact") ?? DEFAULT_ARTIFACT_PATH,
+    allowPending: hasFlag("--allow-pending"),
+    childMaxWaitSeconds: getFlagValue("--child-max-wait-seconds")
+      ? parsePositiveInteger(getFlagValue("--child-max-wait-seconds"), 300, "--child-max-wait-seconds")
+      : null,
+  };
+}
+
+function childWaitArgs(options: CliOptions): string[] {
+  if (options.childMaxWaitSeconds === null) return [];
+  return ["--child-max-wait-seconds", String(options.childMaxWaitSeconds)];
+}
+
+async function runChild(lane: string, required: boolean, command: string, args: string[]): Promise<LaneResult> {
+  const started = Date.now();
+  const startedAt = new Date(started).toISOString();
+  const displayCommand = [command, ...args].join(" ");
+  process.stdout.write(`\n[RUN] ${lane}\n$ ${displayCommand}\n`);
+
+  const exitCode = await new Promise<number | null>((resolve) => {
+    const child = spawn(command, args, {
+      cwd: process.cwd(),
+      env: process.env,
+      stdio: "inherit",
+    });
+    child.on("close", (code) => resolve(code));
+    child.on("error", (error) => {
+      process.stderr.write(`[${lane}] failed to start: ${error.message}\n`);
+      resolve(1);
+    });
+  });
+
+  const finished = Date.now();
+  return {
+    lane,
+    status: exitCode === 0 ? "pass" : "fail",
+    required,
+    command: displayCommand,
+    startedAt,
+    finishedAt: new Date(finished).toISOString(),
+    durationMs: finished - started,
+    notes: exitCode === 0 ? "lane command completed" : "lane command failed",
+    exitCode,
+  };
+}
+
+function pendingLane(lane: string, required: boolean, notes: string): LaneResult {
+  const now = new Date().toISOString();
+  return {
+    lane,
+    status: "pending",
+    required,
+    command: null,
+    startedAt: now,
+    finishedAt: now,
+    durationMs: 0,
+    notes,
+    exitCode: null,
+  };
+}
+
+async function runPreflight(): Promise<LaneResult> {
+  return runChild("preflight", true, "tsx", ["scripts/marketplace-hardening-devnet-matrix.ts"]);
+}
+
+async function runPublic(): Promise<LaneResult> {
+  return runChild("public-task-lifecycle", true, "tsx", ["scripts/marketplace-devnet-smoke.ts"]);
+}
+
+async function runDispute(): Promise<LaneResult> {
+  return runChild("dispute-lifecycle", true, "tsx", ["scripts/marketplace-devnet-smoke.ts"]);
+}
+
+async function runArtifact(): Promise<LaneResult[]> {
+  const localArtifactTests = await runChild("artifact-result-rail-local", true, "npm", [
+    "run",
+    "test",
+    "--workspace=@tetsuo-ai/runtime",
+    "--",
+    "src/marketplace/artifact-delivery.test.ts",
+    "src/tools/agenc/mutation-tools.test.ts",
+  ]);
+
+  return [
+    localArtifactTests,
+    pendingLane(
+      "artifact-result-rail-live-devnet",
+      true,
+      "Missing dedicated live devnet smoke that creates a task, completes through CLI/runtime with --artifact-file or --artifact-uri, re-reads the task, and verifies the artifact digest/reference survives on-chain resultData.",
+    ),
+  ];
+}
+
+async function runReviewedPublic(): Promise<LaneResult> {
+  return pendingLane(
+    "reviewed-public-lifecycle",
+    true,
+    "Missing dedicated live devnet smoke for configure creator-review, worker submit result, creator accept/reject, timeout behavior, and final settlement. Existing public/TUI smokes do not prove this lane.",
+  );
+}
+
+async function runExplorer(): Promise<LaneResult> {
+  return pendingLane(
+    "explorer-indexing-visibility",
+    true,
+    "Missing automated devnet assertion that newly-created, claimed, completed, and disputed task PDAs appear in the explorer/indexing view within the expected polling window.",
+  );
+}
+
+async function runSafety(): Promise<LaneResult> {
+  return runChild("signer-wallet-safety", true, "tsx", ["scripts/marketplace-hardening-devnet-matrix.ts"]);
+}
+
+async function runOperator(): Promise<LaneResult> {
+  return pendingLane(
+    "operator-controls-live-drill",
+    true,
+    "Requires runtime-host evidence for pause/disable/rollback/alert acknowledgement. This cannot be proven by devnet RPC alone.",
+  );
+}
+
+async function runSoak(options: CliOptions): Promise<LaneResult[]> {
+  const results: LaneResult[] = [];
+  for (let index = 1; index <= options.iterations; index += 1) {
+    results.push(
+      await runChild(`soak-tui-${index}`, true, "tsx", [
+        "scripts/marketplace-tui-devnet-smoke.ts",
+        ...childWaitArgs(options),
+      ]),
+    );
+  }
+  return results;
+}
+
+async function runAll(options: CliOptions): Promise<LaneResult[]> {
+  const results: LaneResult[] = [];
+  results.push(await runPreflight());
+  results.push(await runPublic());
+  results.push(await runReviewedPublic());
+  results.push(...(await runArtifact()));
+  results.push(await runDispute());
+  results.push(await runExplorer());
+  results.push(await runSafety());
+  results.push(...(await runSoak(options)));
+  results.push(await runOperator());
+  return results;
+}
+
+async function runSelected(options: CliOptions): Promise<LaneResult[]> {
+  switch (options.mode) {
+    case "all":
+      return runAll(options);
+    case "preflight":
+      return [await runPreflight()];
+    case "public":
+      return [await runPublic()];
+    case "reviewed-public":
+      return [await runReviewedPublic()];
+    case "artifact":
+      return runArtifact();
+    case "dispute":
+      return [await runDispute()];
+    case "explorer":
+      return [await runExplorer()];
+    case "safety":
+      return [await runSafety()];
+    case "soak":
+      return runSoak(options);
+    case "operator":
+      return [await runOperator()];
+  }
+}
+
+async function writeArtifact(artifactPath: string, results: LaneResult[], options: CliOptions): Promise<void> {
+  await mkdir(path.dirname(artifactPath), { recursive: true });
+  const payload = {
+    kind: "agenc.marketplace.mainnetV1DevnetReadiness",
+    schemaVersion: 1,
+    createdAt: new Date().toISOString(),
+    issue: "https://github.com/tetsuo-ai/agenc-core/issues/549",
+    scope: {
+      included: [
+        "core protocol task lifecycle",
+        "CLI/runtime task creation and completion",
+        "reviewed-public settlement",
+        "artifact result rail",
+        "dispute lifecycle",
+        "explorer/indexing visibility",
+        "signer and wallet safety",
+        "operator controls",
+      ],
+      excluded: [
+        "Private ZK marketplace tasks",
+        "storefront/no-code checkout",
+        "AgenC Lab/Telegram buyer rails",
+      ],
+    },
+    options,
+    results,
+  };
+  await writeFile(artifactPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+}
+
+async function main(): Promise<void> {
+  const options = parseOptions();
+  const results = await runSelected(options);
+  await writeArtifact(options.artifactPath, results, options);
+
+  const failures = results.filter((result) => result.required && result.status === "fail");
+  const pending = results.filter((result) => result.required && result.status === "pending");
+
+  process.stdout.write(`\n[artifact] ${options.artifactPath}\n`);
+  process.stdout.write(`[summary] pass=${results.filter((r) => r.status === "pass").length} fail=${failures.length} pending=${pending.length}\n`);
+
+  if (failures.length > 0 || (pending.length > 0 && !options.allowPending)) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/marketplace-mainnet-v1-devnet.ts
+++ b/scripts/marketplace-mainnet-v1-devnet.ts
@@ -2,7 +2,7 @@
 
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
@@ -71,7 +71,7 @@ Modes:
   reviewed-public    Creator-review lifecycle gate using the live artifact smoke.
   artifact           Buyer-facing artifact rail gate, local tests plus live devnet smoke.
   dispute            Dispute lifecycle using the plain devnet smoke.
-  explorer           Explorer/indexing visibility gate. Currently required and pending.
+  explorer           Explorer/indexing visibility using the live artifact smoke.
   safety             Wallet/signer safety gate using hardening matrix.
   soak               Repeated selected devnet smokes for stability evidence.
   operator           Operator-control evidence gate. Currently requires host evidence.
@@ -178,21 +178,6 @@ async function runChild(lane: string, required: boolean, command: string, args: 
   };
 }
 
-function pendingLane(lane: string, required: boolean, notes: string): LaneResult {
-  const now = new Date().toISOString();
-  return {
-    lane,
-    status: "pending",
-    required,
-    command: null,
-    startedAt: now,
-    finishedAt: now,
-    durationMs: 0,
-    notes,
-    exitCode: null,
-  };
-}
-
 async function runPreflight(): Promise<LaneResult> {
   return runChild("preflight", true, "tsx", ["scripts/marketplace-hardening-devnet-matrix.ts"]);
 }
@@ -244,10 +229,15 @@ async function runReviewedPublic(): Promise<LaneResult> {
 }
 
 async function runExplorer(): Promise<LaneResult> {
-  return pendingLane(
+  return runChild(
     "explorer-indexing-visibility",
     true,
-    "Missing automated devnet assertion that newly-created, claimed, completed, and disputed task PDAs appear in the explorer/indexing view within the expected polling window.",
+    "tsx",
+    [
+      "scripts/marketplace-devnet-smoke.ts",
+      "--flow",
+      "reviewed-public-artifact",
+    ],
   );
 }
 
@@ -256,11 +246,50 @@ async function runSafety(): Promise<LaneResult> {
 }
 
 async function runOperator(): Promise<LaneResult> {
-  return pendingLane(
+  const outputPath = path.join(
+    os.tmpdir(),
+    "agenc-marketplace-mainnet-v1-devnet",
+    `operator-live-drill-${Date.now()}-${process.pid}-${randomUUID().slice(0, 8)}.json`,
+  );
+  const result = await runChild(
     "operator-controls-live-drill",
     true,
-    "Requires runtime-host evidence for pause/disable/rollback/alert acknowledgement. This cannot be proven by devnet RPC alone.",
+    "tsx",
+    ["scripts/compiled-job-phase1-operator-drill.ts", "--output", outputPath],
   );
+  if (result.status === "fail") {
+    return result;
+  }
+
+  try {
+    const parsed = JSON.parse(await readFile(outputPath, "utf8")) as {
+      overallPassed?: unknown;
+      alertRoutingStatus?: { status?: unknown };
+      onCallStatus?: { status?: unknown };
+    };
+    if (parsed.overallPassed === true) {
+      return {
+        ...result,
+        notes: `operator live drill passed with artifact ${outputPath}`,
+      };
+    }
+    return {
+      ...result,
+      status: "fail",
+      notes:
+        `operator live drill did not pass; artifact=${outputPath}, ` +
+        `alertRouting=${String(parsed.alertRoutingStatus?.status ?? "unknown")}, ` +
+        `onCall=${String(parsed.onCallStatus?.status ?? "unknown")}`,
+    };
+  } catch (error) {
+    return {
+      ...result,
+      status: "fail",
+      notes: `operator live drill artifact could not be parsed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    };
+  }
 }
 
 async function runSoak(options: CliOptions): Promise<LaneResult[]> {


### PR DESCRIPTION
## Summary
- Adds the marketplace mainnet v1 readiness roadmap doc linked to #549.
- Adds `npm run smoke:marketplace:mainnet-v1:devnet` as the top-level devnet readiness gate.
- Adds `--flow reviewed-public-artifact` to the devnet marketplace smoke so CLI/runtime can prove creator-review + artifact delivery without storefront.
- The reviewed-public artifact smoke also checks `tasks.list` visibility after create, claim, and accept, covering explorer/indexing visibility outside the storefront.
- Operator readiness wraps `compiled-job-phase1-operator-drill.ts` and fails unless the generated host-drill artifact has `overallPassed: true`.
- Adds compatibility fallback for devnet programs that do not expose `claimTaskWithJobSpec`: runtime still verifies the job spec locally, then falls back to legacy `claimTask` only for `InstructionFallbackNotFound`.
- Updates Phase 1 live-drill docs to use the new mainnet-v1 runner instead of the missing soak harness reference.

## Validation
- `npm run smoke:marketplace:mainnet-v1:devnet -- --mode preflight --allow-pending`
- `npm run smoke:marketplace:mainnet-v1:devnet -- --help`
- `npx tsx scripts/marketplace-devnet-smoke.ts --help`
- `npm run test --workspace=@tetsuo-ai/runtime -- src/task/operations.test.ts src/marketplace/artifact-delivery.test.ts src/tools/agenc/mutation-tools.test.ts` — 3 files, 76 tests passed.
- `CREATOR_WALLET=/Users/tetsuoarena/.config/solana/id.json WORKER_WALLET=/tmp/agenc-mainnet-v1-worker.hDtqMG/worker.json npm run smoke:marketplace:mainnet-v1:devnet -- --mode artifact` — passed on live devnet. Task `6knLC9j8iL1PQfqvaaiqCojfhTxjjvrpA6aqZXEWFk7D` completed with artifact digest `f0fbf3b81f3ae0dd76706bfab3bc30b607cd0dd3b1fa86eb38c55cd34d2cbd2d`.
- `CREATOR_WALLET=/Users/tetsuoarena/.config/solana/id.json WORKER_WALLET=/tmp/agenc-mainnet-v1-worker.hDtqMG/worker.json npm run smoke:marketplace:mainnet-v1:devnet -- --mode explorer` — passed on live devnet after cooldown. Task `FM6STcfhGsyVxUDtCnPtRAoZkmVAeECErjLuvHypHXao` was visible as `open`, `in_progress`, then `completed`.
- `npm run smoke:marketplace:mainnet-v1:devnet -- --mode operator --allow-pending` correctly failed the readiness gate because local alert routing/on-call evidence was not configured, while in-host controls passed and wrote an artifact.
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package json ok')"`
- `git diff --check`

## Remaining Mainnet Blocker
- Run `npm run smoke:marketplace:mainnet-v1:devnet -- --mode operator` on the target runtime host with real alert routing and on-call acknowledgement evidence.

This PR does not close #549 yet; it turns the roadmap into an executable gate and proves the artifact/reviewed-public/explorer lanes on live devnet.
