### PR TITLE
Add live devnet claim contention smoke

### DIFF
--- a/runtime/docs/marketplace-mainnet-v1-readiness.md
+++ b/runtime/docs/marketplace-mainnet-v1-readiness.md
@@ -12,6 +12,7 @@ Included in mainnet v1:
 - public task creation
 - task discovery/list/detail
 - worker claim
+- exclusive claim contention
 - worker completion
 - buyer-facing artifact/result reference through the fixed on-chain result rail
 - reviewed-public creator review flow
@@ -41,6 +42,7 @@ not green just because one lower-level unit test passed.
 | Preflight | RPC reachable, program ID selected, signer policy guard works | Required |
 | Public lifecycle | create -> list/detail -> claim -> complete -> final task state | Required |
 | Reviewed-public lifecycle | create with creator review -> submit result -> accept/reject/timeout -> settlement | Required |
+| Exclusive claim contention | two workers race to claim one exclusive reviewed-public task -> exactly one wins -> loser is rejected cleanly | Required |
 | Artifact/result rail | worker submits artifact file or URI -> digest committed in resultData -> reader reconstructs reference | Required |
 | Dispute lifecycle | open dispute -> 3 arbiter votes -> resolve -> final task/dispute state | Required |
 | Explorer visibility | new/updated PDAs appear in explorer/indexing within expected polling window | Required |
@@ -62,6 +64,7 @@ Useful lane commands:
 npm run smoke:marketplace:mainnet-v1:devnet -- --mode preflight
 npm run smoke:marketplace:mainnet-v1:devnet -- --mode public
 npm run smoke:marketplace:mainnet-v1:devnet -- --mode reviewed-public
+npm run smoke:marketplace:mainnet-v1:devnet -- --mode contention
 npm run smoke:marketplace:mainnet-v1:devnet -- --mode artifact
 npm run smoke:marketplace:mainnet-v1:devnet -- --mode dispute
 npm run smoke:marketplace:mainnet-v1:devnet -- --mode explorer
@@ -83,6 +86,7 @@ The live protocol lanes require funded devnet signers:
 ```bash
 export CREATOR_WALLET=/path/to/creator.json
 export WORKER_WALLET=/path/to/worker.json
+export WORKER_B_WALLET=/path/to/worker-b.json
 export ARBITER_A_WALLET=/path/to/arbiter-a.json
 export ARBITER_B_WALLET=/path/to/arbiter-b.json
 export ARBITER_C_WALLET=/path/to/arbiter-c.json
@@ -109,6 +113,17 @@ That flow creates a creator-review task, claims it, completes it with
 detail reconstructs the buyer-facing artifact digest from on-chain `resultData`.
 It also checks `tasks.list` visibility after create, claim, and accept so the
 explorer/indexing lane is covered without requiring the storefront.
+
+The exclusive claim contention lane can also be run directly:
+
+```bash
+npm run smoke:marketplace:devnet -- --flow claim-contention
+```
+
+That flow creates an exclusive creator-review task with `maxWorkers=1`, submits
+two concurrent worker claims from distinct agents, asserts exactly one claim
+wins, asserts the second worker is rejected cleanly, and verifies the task is
+visible as `in_progress` with `currentWorkers=1`.
 
 The operator lane runs:
 

--- a/scripts/marketplace-devnet-smoke.ts
+++ b/scripts/marketplace-devnet-smoke.ts
@@ -38,6 +38,7 @@ import {
 } from "../runtime/src/cli/marketplace-cli.js";
 import type { BaseCliOptions, CliRuntimeContext } from "../runtime/src/cli/types.js";
 import { DisputeOperations } from "../runtime/src/dispute/operations.js";
+import { TaskOperations } from "../runtime/src/task/operations.js";
 import { createAgencTools } from "../runtime/src/tools/agenc/index.js";
 
 const DEFAULT_RPC_URL =
@@ -114,12 +115,46 @@ interface ReviewedPublicArtifactSmokeArtifact {
   }>;
 }
 
+interface ClaimContentionSmokeArtifact {
+  version: 1;
+  kind: "marketplace-claim-contention-devnet-smoke";
+  createdAt: string;
+  rpcUrl: string;
+  programId: string;
+  runId: string;
+  description: string;
+  rewardLamports: string;
+  creatorAgentPda: string;
+  taskPda: string;
+  winner: {
+    label: string;
+    workerAgentPda: string;
+    workerClaimPda: string;
+    transactionSignature: string;
+  };
+  rejected: {
+    label: string;
+    workerAgentPda: string;
+    error: string;
+    raceError?: string;
+  };
+  taskStatus: string;
+  currentWorkers: number;
+  maxWorkers: number;
+  visibilityChecks: Array<{
+    stage: string;
+    status: string;
+    taskPda: string;
+    observedAt: string;
+  }>;
+}
+
 type MarketRunner = (
   context: CliRuntimeContext,
   options: Record<string, unknown>,
 ) => Promise<0 | 1 | 2>;
 
-type InitialFlow = "dispute" | "reviewed-public-artifact";
+type InitialFlow = "dispute" | "reviewed-public-artifact" | "claim-contention";
 
 let activeSignerKey: string | null = null;
 
@@ -139,6 +174,7 @@ function usage(): void {
 Environment:
   CREATOR_WALLET                Required for all initial flows.
   WORKER_WALLET                 Required for all initial flows.
+  WORKER_B_WALLET               Required for --flow claim-contention.
   ARBITER_A_WALLET              Required for --flow dispute.
   ARBITER_B_WALLET              Required for --flow dispute.
   ARBITER_C_WALLET              Required for --flow dispute.
@@ -151,7 +187,7 @@ Environment:
 Flags:
   --resume <path>               Resume a previously-created artifact and resolve.
   --artifact <path>             Custom output path for the resume artifact.
-  --flow <name>                 Initial flow: dispute | reviewed-public-artifact.
+  --flow <name>                 Initial flow: dispute | reviewed-public-artifact | claim-contention.
   --help                        Show this message.
 `);
 }
@@ -184,7 +220,7 @@ function getFlagValue(flag: string): string | null {
 
 function parseInitialFlow(): InitialFlow {
   const raw = getFlagValue("--flow") ?? "dispute";
-  if (raw === "dispute" || raw === "reviewed-public-artifact") {
+  if (raw === "dispute" || raw === "reviewed-public-artifact" || raw === "claim-contention") {
     return raw;
   }
   throw new Error(`Unsupported --flow ${raw}`);
@@ -721,6 +757,22 @@ async function writeReviewedPublicArtifact(
   return filePath;
 }
 
+async function writeClaimContentionArtifact(
+  artifact: ClaimContentionSmokeArtifact,
+  explicitPath?: string | null,
+): Promise<string> {
+  const filePath =
+    explicitPath ??
+    path.join(
+      ARTIFACT_DIR,
+      `marketplace-claim-contention-devnet-smoke-${Date.now()}.json`,
+    );
+
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(artifact, null, 2)}\n`, "utf8");
+  return filePath;
+}
+
 async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -960,6 +1012,235 @@ async function runReviewedPublicArtifactFlow(params: {
   console.log(`[artifact] ${savedPath}`);
 }
 
+async function runClaimContentionFlow(params: {
+  baseOptions: BaseCliOptions;
+  rpcUrl: string;
+  programId: string;
+  rewardLamports: bigint;
+  runId: string;
+  creator: AgentActor;
+  workerA: AgentActor;
+  workerB: AgentActor;
+  artifactPath?: string | null;
+}): Promise<void> {
+  const {
+    baseOptions,
+    rpcUrl,
+    programId,
+    rewardLamports,
+    runId,
+    creator,
+    workerA,
+    workerB,
+    artifactPath,
+  } = params;
+  const description = `claim contention smoke ${runId}`;
+  const visibilityChecks: ClaimContentionSmokeArtifact["visibilityChecks"] = [];
+
+  const createOutput = await runMarketCommand(
+    baseOptions,
+    runMarketTaskCreateCommand as MarketRunner,
+    {
+      description,
+      reward: rewardLamports.toString(),
+      requiredCapabilities: AgentCapabilities.COMPUTE.toString(),
+      creatorAgentPda: creator.agentPda.toBase58(),
+      validationMode: "creator-review",
+      reviewWindowSecs: 3_600,
+      maxWorkers: 1,
+      fullDescription:
+        "Live devnet smoke for exclusive reviewed-public claim contention.",
+      acceptanceCriteria: [
+        "Exactly one worker can claim the exclusive task.",
+        "A competing worker is rejected cleanly.",
+        "Explorer/list visibility reflects one in-progress worker.",
+      ],
+      deliverables: ["Claim contention evidence artifact"],
+      constraints: ["No Private ZK and no storefront dependencies."],
+    },
+    creator.agentPda.toBase58(),
+  );
+  const createResult = asRecord(createOutput.result, "contentionCreate.result");
+  const taskPda = getStringField(
+    createResult,
+    "taskPda",
+    "contentionCreate.result",
+  );
+  console.log(`[contention] created ${taskPda}`);
+  visibilityChecks.push(
+    await assertTaskVisibleInList(baseOptions, taskPda, "open", "after-create"),
+  );
+
+  const taskKey = new PublicKey(taskPda);
+  const workerAOps = new TaskOperations({
+    program: workerA.program,
+    agentId: workerA.agentId,
+    logger: silentLogger,
+  });
+  const workerBOps = new TaskOperations({
+    program: workerB.program,
+    agentId: workerB.agentId,
+    logger: silentLogger,
+  });
+  const taskBeforeClaim = await workerAOps.fetchTask(taskKey);
+  if (!taskBeforeClaim) {
+    throw new Error(`Claim contention task ${taskPda} was not fetchable before claim`);
+  }
+
+  function isExpectedContentionRejection(message: string): boolean {
+    return /Task has reached maximum workers|Task is not open for claims|Task not claimable|TaskFullyClaimed|TaskNotOpen|AlreadyClaimed/i.test(
+      message,
+    );
+  }
+
+  async function verifyPostRaceRejection(
+    label: string,
+    ops: TaskOperations,
+  ): Promise<string> {
+    const freshTask = await ops.fetchTask(taskKey);
+    if (!freshTask) {
+      throw new Error(`Claim contention task ${taskPda} was not fetchable after race`);
+    }
+
+    let rejection: string | null = null;
+    try {
+      await ops.claimTask(taskKey, freshTask);
+    } catch (error) {
+      rejection = error instanceof Error ? error.message : stringifyUnknown(error);
+    }
+
+    if (!rejection) {
+      throw new Error(`${label} was able to claim ${taskPda} after contention winner was accepted`);
+    }
+    if (!isExpectedContentionRejection(rejection)) {
+      throw new Error(`${label} post-race rejection was not a clean marketplace rejection: ${rejection}`);
+    }
+    return rejection;
+  }
+
+  async function attemptClaim(label: string, actor: AgentActor, ops: TaskOperations) {
+    try {
+      const result = await ops.claimTask(taskKey, taskBeforeClaim);
+      return {
+        status: "fulfilled" as const,
+        label,
+        actor,
+        result,
+      };
+    } catch (error) {
+      return {
+        status: "rejected" as const,
+        label,
+        actor,
+        error: error instanceof Error ? error.message : stringifyUnknown(error),
+      };
+    }
+  }
+
+  const attempts = await Promise.all([
+    attemptClaim("worker-a", workerA, workerAOps),
+    attemptClaim("worker-b", workerB, workerBOps),
+  ]);
+  const fulfilled = attempts.filter((attempt) => attempt.status === "fulfilled");
+  const rejected = attempts.filter((attempt) => attempt.status === "rejected");
+
+  if (fulfilled.length !== 1 || rejected.length !== 1) {
+    throw new Error(
+      `Expected exactly one winning claim and one rejected claim, got fulfilled=${fulfilled.length} rejected=${rejected.length}: ${stringifyUnknown(attempts)}`,
+    );
+  }
+
+  const winner = fulfilled[0];
+  const loser = rejected[0];
+  if (winner.status !== "fulfilled" || loser.status !== "rejected") {
+    throw new Error("Claim contention result partition failed");
+  }
+
+  console.log(
+    `[contention] winner=${winner.label} claim=${winner.result.claimPda.toBase58()}`,
+  );
+  console.log(`[contention] rejected=${loser.label} error=${loser.error}`);
+
+  const raceError = loser.error;
+  const cleanRejectionError = isExpectedContentionRejection(raceError)
+    ? raceError
+    : await verifyPostRaceRejection(
+        loser.label,
+        loser.label === "worker-a" ? workerAOps : workerBOps,
+      );
+  if (cleanRejectionError !== raceError) {
+    console.log(
+      `[contention] post-race rejection confirmed for ${loser.label}: ${cleanRejectionError}`,
+    );
+  }
+
+  visibilityChecks.push(
+    await assertTaskVisibleInList(baseOptions, taskPda, "in_progress", "after-contention"),
+  );
+
+  const detailOutput = await runMarketCommand(
+    baseOptions,
+    runMarketTaskDetailCommand as MarketRunner,
+    {
+      taskPda,
+    },
+  );
+  const task = asRecord(detailOutput.task, "contentionDetail.task");
+  const taskStatus = getStringField(task, "status", "contentionDetail.task");
+  const currentWorkers = getNumberField(
+    task,
+    "currentWorkers",
+    "contentionDetail.task",
+  );
+  const maxWorkers = getNumberField(task, "maxWorkers", "contentionDetail.task");
+
+  if (taskStatus !== "in_progress") {
+    throw new Error(`Claim contention task ${taskPda} status=${taskStatus}, expected in_progress`);
+  }
+  if (currentWorkers !== 1 || maxWorkers !== 1) {
+    throw new Error(
+      `Claim contention worker counts invalid: currentWorkers=${currentWorkers}, maxWorkers=${maxWorkers}`,
+    );
+  }
+
+  const savedPath = await writeClaimContentionArtifact(
+    {
+      version: 1,
+      kind: "marketplace-claim-contention-devnet-smoke",
+      createdAt: new Date().toISOString(),
+      rpcUrl,
+      programId,
+      runId,
+      description,
+      rewardLamports: rewardLamports.toString(),
+      creatorAgentPda: creator.agentPda.toBase58(),
+      taskPda,
+      winner: {
+        label: winner.label,
+        workerAgentPda: winner.actor.agentPda.toBase58(),
+        workerClaimPda: winner.result.claimPda.toBase58(),
+        transactionSignature: winner.result.transactionSignature ?? "",
+      },
+      rejected: {
+        label: loser.label,
+        workerAgentPda: loser.actor.agentPda.toBase58(),
+        error: cleanRejectionError,
+        ...(cleanRejectionError === raceError ? {} : { raceError }),
+      },
+      taskStatus,
+      currentWorkers,
+      maxWorkers,
+      visibilityChecks,
+    },
+    artifactPath,
+  );
+
+  console.log(
+    `[ok] claim contention complete for ${taskPda}: winner=${winner.label}, rejected=${loser.label}`,
+  );
+  console.log(`[artifact] ${savedPath}`);
+}
+
 async function initial(): Promise<void> {
   const rpcUrl = process.env.AGENC_RPC_URL ?? DEFAULT_RPC_URL;
   const programId = parseOptionalProgramId();
@@ -1073,6 +1354,107 @@ async function initial(): Promise<void> {
         runId,
         creator,
         worker,
+        artifactPath,
+      });
+      return;
+    } finally {
+      resetMarketplaceCliProgramContextOverrides();
+    }
+  }
+
+  if (flow === "claim-contention") {
+    const workerBSigner = createSignerContext(
+      "worker-b",
+      env("WORKER_B_WALLET"),
+      connection,
+      programId,
+    );
+    ensureDistinctWallets([creatorSigner, workerSigner, workerBSigner]);
+    await Promise.all([
+      ensureBalance(
+        connection,
+        "creator",
+        creatorSigner.keypair.publicKey,
+        creatorStake + rewardLamports + DEFAULT_FEE_BUFFER_LAMPORTS,
+      ),
+      ensureBalance(
+        connection,
+        "worker-a",
+        workerSigner.keypair.publicKey,
+        workerStake + DEFAULT_FEE_BUFFER_LAMPORTS,
+      ),
+      ensureBalance(
+        connection,
+        "worker-b",
+        workerBSigner.keypair.publicKey,
+        workerStake + DEFAULT_FEE_BUFFER_LAMPORTS,
+      ),
+    ]);
+
+    console.log(`[config] rpc: ${rpcUrl}`);
+    console.log(`[config] program: ${readOnlyProgram.programId.toBase58()}`);
+    console.log(`[config] flow: ${flow}`);
+    console.log(`[config] reward lamports: ${rewardLamports.toString()}`);
+    console.log(`[config] creator wallet: ${creatorSigner.keypair.publicKey.toBase58()}`);
+    console.log(`[config] worker-a wallet: ${workerSigner.keypair.publicKey.toBase58()}`);
+    console.log(`[config] worker-b wallet: ${workerBSigner.keypair.publicKey.toBase58()}`);
+
+    const creator = await registerOrLoadAgent(
+      creatorSigner,
+      connection,
+      programId,
+      AgentCapabilities.COMPUTE,
+      creatorStake,
+      maxBigInt(protocolConfig.minAgentStake, protocolConfig.minStakeForDispute),
+    );
+    const workerA = await registerOrLoadAgent(
+      workerSigner,
+      connection,
+      programId,
+      AgentCapabilities.COMPUTE,
+      workerStake,
+      workerStake,
+    );
+    const workerB = await registerOrLoadAgent(
+      workerBSigner,
+      connection,
+      programId,
+      AgentCapabilities.COMPUTE,
+      workerStake,
+      workerStake,
+    );
+
+    console.log(`[agent] creator: ${creator.agentPda.toBase58()}`);
+    console.log(`[agent] worker-a: ${workerA.agentPda.toBase58()}`);
+    console.log(`[agent] worker-b: ${workerB.agentPda.toBase58()}`);
+
+    const runtime: SmokeRuntime = {
+      connection,
+      readOnlyProgram,
+      signersByKey: new Map<string, SignerContext>([
+        [creator.agentPda.toBase58(), creator],
+        [workerA.agentPda.toBase58(), workerA],
+        [workerB.agentPda.toBase58(), workerB],
+      ]),
+    };
+    installMarketplaceCliOverrides(runtime);
+
+    const baseOptions = buildBaseOptions(
+      rpcUrl,
+      readOnlyProgram.programId.toBase58(),
+    );
+    const runId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+    try {
+      await runClaimContentionFlow({
+        baseOptions,
+        rpcUrl,
+        programId: readOnlyProgram.programId.toBase58(),
+        rewardLamports,
+        runId,
+        creator,
+        workerA,
+        workerB,
         artifactPath,
       });
       return;

--- a/scripts/marketplace-mainnet-v1-devnet.ts
+++ b/scripts/marketplace-mainnet-v1-devnet.ts
@@ -13,6 +13,7 @@ type Mode =
   | "preflight"
   | "public"
   | "reviewed-public"
+  | "contention"
   | "artifact"
   | "dispute"
   | "explorer"
@@ -51,6 +52,7 @@ const VALID_MODES = new Set<Mode>([
   "preflight",
   "public",
   "reviewed-public",
+  "contention",
   "artifact",
   "dispute",
   "explorer",
@@ -69,6 +71,7 @@ Modes:
   preflight          RPC reachability and mutation signer-policy hardening.
   public             Public protocol lifecycle using the plain devnet smoke.
   reviewed-public    Creator-review lifecycle gate using the live artifact smoke.
+  contention         Live devnet exclusive-claim contention gate.
   artifact           Buyer-facing artifact rail gate, local tests plus live devnet smoke.
   dispute            Dispute lifecycle using the plain devnet smoke.
   explorer           Explorer/indexing visibility using the live artifact smoke.
@@ -88,6 +91,7 @@ Flags:
 Required env for live protocol lanes:
   CREATOR_WALLET
   WORKER_WALLET
+  WORKER_B_WALLET
   ARBITER_A_WALLET
   ARBITER_B_WALLET
   ARBITER_C_WALLET
@@ -228,6 +232,19 @@ async function runReviewedPublic(): Promise<LaneResult> {
   );
 }
 
+async function runContention(): Promise<LaneResult> {
+  return runChild(
+    "exclusive-claim-contention-live-devnet",
+    true,
+    "tsx",
+    [
+      "scripts/marketplace-devnet-smoke.ts",
+      "--flow",
+      "claim-contention",
+    ],
+  );
+}
+
 async function runExplorer(): Promise<LaneResult> {
   return runChild(
     "explorer-indexing-visibility",
@@ -310,6 +327,7 @@ async function runAll(options: CliOptions): Promise<LaneResult[]> {
   results.push(await runPreflight());
   results.push(await runPublic());
   results.push(await runReviewedPublic());
+  results.push(await runContention());
   results.push(...(await runArtifact()));
   results.push(await runDispute());
   results.push(await runExplorer());
@@ -329,6 +347,8 @@ async function runSelected(options: CliOptions): Promise<LaneResult[]> {
       return [await runPublic()];
     case "reviewed-public":
       return [await runReviewedPublic()];
+    case "contention":
+      return [await runContention()];
     case "artifact":
       return runArtifact();
     case "dispute":
@@ -356,6 +376,7 @@ async function writeArtifact(artifactPath: string, results: LaneResult[], option
         "core protocol task lifecycle",
         "CLI/runtime task creation and completion",
         "reviewed-public settlement",
+        "exclusive claim contention",
         "artifact result rail",
         "dispute lifecycle",
         "explorer/indexing visibility",


### PR DESCRIPTION
## Summary
- Adds `--flow claim-contention` to the live devnet marketplace smoke.
- Adds `--mode contention` to the mainnet-v1 readiness runner.
- Documents exclusive claim contention as required mainnet-v1 evidence.

## What the new smoke proves
- Creates an exclusive creator-review task with `maxWorkers=1`.
- Sends two worker claim attempts against the same task.
- Requires exactly one winning claim.
- Confirms the losing worker is rejected by the protocol after the race with `Task has reached maximum workers` / equivalent marketplace rejection.
- Verifies task visibility after create and after contention, ending with `status=in_progress`, `currentWorkers=1`, `maxWorkers=1`.

## Validation
- `npm run smoke:marketplace:mainnet-v1:devnet -- --help`
- `npx tsx scripts/marketplace-devnet-smoke.ts --help`
- `npm run typecheck --workspace=@tetsuo-ai/runtime`
- `CREATOR_WALLET=/Users/tetsuoarena/.config/solana/id.json WORKER_WALLET=/tmp/agenc-mainnet-v1-worker.hDtqMG/worker.json WORKER_B_WALLET=/tmp/agenc-mainnet-v1-worker-b.4HU2oh/worker.json npm run smoke:marketplace:mainnet-v1:devnet -- --mode contention`

Live devnet contention evidence:
- task: `45UxYqRPrfTwHC7uMKBtTfpJgCu3RBDj4kutFNuBWPjb`
- winner worker: `CDXpHemDgBbAZvHiYng84qK99rGrUp76vc8R7NdfQbNh`
- winner claim: `6kxrwNDhLsYiNnA61r6DpEaBnH4EWWok5RAEmsYnuiT3`
- winner tx: `NLjZAkSYQRFAGrzW71PgJRhE21Ch2RmURA9BiKvP1ST911krMeFzNYYxnrJe5eCwiU5EyoGzJPAYmkeXofwntF8`
- rejected worker: `DXBwxXJ4EDHeBtgjrUKDeuZfjYUczBx9TNgeR8kRLd9x`
- clean rejection: `Task not claimable: Task has reached maximum workers`
- final visible state: `in_progress`, `currentWorkers=1`, `maxWorkers=1`
