### PR TITLE
Fail closed marketplace mutation safety gates

### DIFF
--- a/runtime/src/tools/agenc/index.test.ts
+++ b/runtime/src/tools/agenc/index.test.ts
@@ -22,6 +22,26 @@ function makeContext(marketplaceSignerPolicy?: MarketplaceSignerPolicy) {
   };
 }
 
+const ALLOW_ALL_MUTATION_TOOLS_POLICY: MarketplaceSignerPolicy = {
+  allowedTools: [
+    "agenc.createTaskFromTemplate",
+    "agenc.submitTaskTemplateProposal",
+    "agenc.registerAgent",
+    "agenc.createTask",
+    "agenc.claimTask",
+    "agenc.completeTask",
+    "agenc.registerSkill",
+    "agenc.purchaseSkill",
+    "agenc.rateSkill",
+    "agenc.createProposal",
+    "agenc.voteProposal",
+    "agenc.initiateDispute",
+    "agenc.resolveDispute",
+    "agenc.stakeReputation",
+    "agenc.delegateReputation",
+  ],
+};
+
 function names(tools: ReturnType<typeof createAgencTools>): string[] {
   return tools.map((tool) => tool.name).sort();
 }
@@ -40,9 +60,24 @@ describe("AgenC protocol tool factory", () => {
     expect(toolNames).not.toContain("agenc.stakeReputation");
   });
 
-  it("can explicitly opt into marketplace mutation tools", () => {
+  it("does not expose signer-backed mutation tools without a signer policy", () => {
     const toolNames = names(
       createAgencTools(makeContext(), { includeMutationTools: true }),
+    );
+
+    expect(toolNames).toContain("agenc.inspectMarketplace");
+    expect(toolNames).not.toContain("agenc.createTask");
+    expect(toolNames).not.toContain("agenc.claimTask");
+    expect(toolNames).not.toContain("agenc.completeTask");
+    expect(toolNames).not.toContain("agenc.initiateDispute");
+    expect(createAgencMutationTools(makeContext())).toEqual([]);
+  });
+
+  it("can explicitly opt into marketplace mutation tools with a signer policy", () => {
+    const toolNames = names(
+      createAgencTools(makeContext(ALLOW_ALL_MUTATION_TOOLS_POLICY), {
+        includeMutationTools: true,
+      }),
     );
 
     expect(toolNames).toContain("agenc.createTask");
@@ -55,7 +90,9 @@ describe("AgenC protocol tool factory", () => {
 
   it("exposes separate read-only and mutation surfaces", () => {
     const readOnlyNames = names(createAgencReadOnlyTools(makeContext()));
-    const mutationNames = names(createAgencMutationTools(makeContext()));
+    const mutationNames = names(
+      createAgencMutationTools(makeContext(ALLOW_ALL_MUTATION_TOOLS_POLICY)),
+    );
 
     expect(readOnlyNames).toContain("agenc.listTasks");
     expect(readOnlyNames).not.toContain("agenc.createTask");

--- a/runtime/src/tools/agenc/index.ts
+++ b/runtime/src/tools/agenc/index.ts
@@ -195,6 +195,13 @@ export function createAgencReadOnlyTools(context: ToolContext): Tool[] {
  * signer policy/approval gates are configured.
  */
 export function createAgencMutationTools(context: ToolContext): Tool[] {
+  if (!context.marketplaceSignerPolicy) {
+    context.logger.warn?.(
+      "AgenC mutation tools require marketplaceSignerPolicy; refusing to register signer-backed tools",
+    );
+    return [];
+  }
+
   const program = createAgencProgram(context, { signerBacked: true });
   const tools = [
     createCreateTaskFromTemplateTool(program, context.logger),

--- a/runtime/src/tools/agenc/mutation-tools.test.ts
+++ b/runtime/src/tools/agenc/mutation-tools.test.ts
@@ -12,6 +12,7 @@ import { GovernanceOperations } from '../../governance/operations.js';
 import { DisputeOperations } from '../../dispute/operations.js';
 import { ReputationEconomyOperations } from '../../reputation/economy.js';
 import { TaskOperations } from '../../task/operations.js';
+import { MANUAL_VALIDATION_SENTINEL } from '../../task/types.js';
 import {
   findBidBookPda,
   findBidPda,
@@ -267,7 +268,7 @@ describe('agenc mutation tools', () => {
     expect(String(parseJson(result).error)).toContain('proofHash');
   });
 
-  it('agenc.completeTask commits artifact files through resultData and proofHash', async () => {
+  it('agenc.completeTask commits reviewed-public artifact files through resultData and proofHash', async () => {
     const rootDir = await makeTempDir();
     const artifactFile = path.join(rootDir, 'delivery.md');
     const content = '# Delivery\n\nReport for buyer review.\n';
@@ -277,7 +278,7 @@ describe('agenc mutation tools', () => {
     vi.spyOn(TaskOperations.prototype, 'fetchTask').mockResolvedValue({
       creator: CREATOR_WALLET,
       taskType: TaskType.Exclusive,
-      constraintHash: new Uint8Array(32),
+      constraintHash: new Uint8Array(MANUAL_VALIDATION_SENTINEL),
     } as never);
     const completeSpy = vi
       .spyOn(TaskOperations.prototype, 'completeTask')
@@ -306,6 +307,30 @@ describe('agenc mutation tools', () => {
     });
     const resultData = completeSpy.mock.calls[0]?.[3] as Uint8Array;
     expect(decodeMarketplaceArtifactSha256FromResultData(resultData)).toBe(sha256);
+  });
+
+  it('agenc.completeTask blocks buyer-facing artifacts on public auto-settle tasks', async () => {
+    const rootDir = await makeTempDir();
+    const artifactFile = path.join(rootDir, 'delivery.md');
+    await writeFile(artifactFile, '# Delivery\n', 'utf8');
+    const program = createMockProgram();
+    vi.spyOn(TaskOperations.prototype, 'fetchTask').mockResolvedValue({
+      creator: CREATOR_WALLET,
+      taskType: TaskType.Exclusive,
+      constraintHash: new Uint8Array(32),
+    } as never);
+    const completeSpy = vi.spyOn(TaskOperations.prototype, 'completeTask');
+
+    const tool = createCompleteTaskTool(program as never, silentLogger);
+    const result = await tool.execute({
+      taskPda: TASK_PDA.toBase58(),
+      artifactFile,
+      workerAgentPda: AGENT_PDA.toBase58(),
+    });
+
+    expect(result.isError).toBe(true);
+    expect(String(parseJson(result).error)).toContain('creator-review');
+    expect(completeSpy).not.toHaveBeenCalled();
   });
 
   it('agenc.completeTask fails closed for buyer-facing artifacts on private ZK tasks', async () => {

--- a/runtime/src/tools/agenc/mutation-tools.ts
+++ b/runtime/src/tools/agenc/mutation-tools.ts
@@ -26,7 +26,11 @@ import {
   findBidderMarketStatePda,
   findClaimPda,
 } from '../../task/pda.js';
-import { isPrivateTask, parseOnChainTaskClaim } from '../../task/types.js';
+import {
+  isManualValidationTask,
+  isPrivateTask,
+  parseOnChainTaskClaim,
+} from '../../task/types.js';
 import {
   hasMarketplaceArtifactDeliveryInput,
   prepareMarketplaceArtifactDelivery,
@@ -748,6 +752,11 @@ export function createCompleteTaskTool(
           }
           if (isPrivateTask(task)) {
             return errorResult('Buyer-facing artifact delivery is disabled for private ZK tasks');
+          }
+          if (!isManualValidationTask(task)) {
+            return errorResult(
+              'Buyer-facing artifact delivery requires creator-review validation before settlement',
+            );
           }
           const preparedArtifact = await prepareMarketplaceArtifactDelivery({
             artifactFile: typeof args.artifactFile === 'string' ? args.artifactFile : undefined,


### PR DESCRIPTION
## Summary
- require `marketplaceSignerPolicy` before registering signer-backed AgenC mutation tools
- block buyer-facing artifact delivery on public auto-settle tasks; artifacts now require reviewed-public / creator-review validation
- add regression coverage for both fail-closed gates

## Validation
- `npm --workspace=@tetsuo-ai/runtime exec vitest run src/tools/agenc/index.test.ts src/tools/agenc/mutation-tools.test.ts`
- `npm run typecheck --workspace=@tetsuo-ai/runtime`
- `git diff --check`

## Mainnet readiness context
This closes the immediate code-side risk from the audit where hosted mutation tools could be registered without signer policy and artifact delivery could be used on public auto-settle tasks without creator review.