### PR TITLE
Expand marketplace transaction intent coverage

### DIFF
--- a/runtime/src/dispute/operations.test.ts
+++ b/runtime/src/dispute/operations.test.ts
@@ -394,6 +394,94 @@ describe("DisputeOperations", () => {
     });
   });
 
+  describe("transaction intent previews", () => {
+    it("previews dispute mutation account intents", async () => {
+      const taskPda = randomPubkey();
+      const disputePda = randomPubkey();
+      const workerClaimPda = randomPubkey();
+      const workerAgentPda = randomPubkey();
+      const arbiterVotes = [
+        { votePda: randomPubkey(), arbiterAgentPda: randomPubkey() },
+      ];
+      program.account.dispute.fetchNullable.mockResolvedValue(
+        mockRawDispute({ defendant: workerAgentPda }),
+      );
+
+      await expect(
+        ops.previewInitiateDisputeIntent({
+          disputeId: randomBytes(32),
+          taskPda,
+          taskId: randomBytes(32),
+          evidenceHash: randomBytes(32),
+          resolutionType: ResolutionType.Refund,
+          evidence: "buyer-visible evidence",
+          workerAgentPda,
+          workerClaimPda,
+        }),
+      ).resolves.toMatchObject({
+        kind: "initiate_dispute",
+        taskPda: taskPda.toBase58(),
+      });
+
+      await expect(
+        ops.previewVoteDisputeIntent({
+          disputePda,
+          taskPda,
+          approve: true,
+          workerClaimPda,
+        }),
+      ).resolves.toMatchObject({
+        kind: "vote_dispute",
+        disputePda: disputePda.toBase58(),
+      });
+
+      await expect(
+        ops.previewResolveDisputeIntent({
+          disputePda,
+          taskPda,
+          creatorPubkey: randomPubkey(),
+          workerClaimPda,
+          workerAgentPda,
+          workerAuthority: randomPubkey(),
+          arbiterVotes,
+        }),
+      ).resolves.toMatchObject({
+        kind: "resolve_dispute",
+        disputePda: disputePda.toBase58(),
+      });
+
+      await expect(ops.previewCancelDisputeIntent(disputePda, taskPda)).resolves.toMatchObject({
+        kind: "cancel_dispute",
+        disputePda: disputePda.toBase58(),
+      });
+      await expect(
+        ops.previewExpireDisputeIntent({
+          disputePda,
+          taskPda,
+          creatorPubkey: randomPubkey(),
+          workerClaimPda,
+          workerAgentPda,
+          workerAuthority: randomPubkey(),
+          arbiterVotes,
+        }),
+      ).resolves.toMatchObject({
+        kind: "expire_dispute",
+        disputePda: disputePda.toBase58(),
+      });
+      await expect(
+        ops.previewApplySlashIntent({
+          disputePda,
+          taskPda,
+          workerClaimPda,
+          workerAgentPda,
+        }),
+      ).resolves.toMatchObject({
+        kind: "apply_dispute_slash",
+        disputePda: disputePda.toBase58(),
+      });
+    });
+  });
+
   describe("fetchDispute", () => {
     it("returns parsed dispute when found", async () => {
       const disputePda = randomPubkey();

--- a/runtime/src/dispute/operations.ts
+++ b/runtime/src/dispute/operations.ts
@@ -43,6 +43,12 @@ import {
 import { fetchTreasury } from "../utils/treasury.js";
 import { deriveClaimPda, deriveEscrowPda, deriveTaskSubmissionPda } from "../task/pda.js";
 import {
+  accountMetaToIntentMeta,
+  hexBytes,
+  namedAccountMeta,
+  type MarketplaceTransactionIntent,
+} from "../task/transaction-intent.js";
+import {
   buildResolveDisputeTokenAccounts,
   buildExpireDisputeTokenAccounts,
   buildApplyDisputeSlashTokenAccounts,
@@ -364,6 +370,141 @@ export class DisputeOperations {
     }
   }
 
+  async previewInitiateDisputeIntent(
+    params: InitiateDisputeParams,
+  ): Promise<MarketplaceTransactionIntent> {
+    const { address: disputePda } = deriveDisputePda(
+      params.disputeId,
+      this.program.programId,
+    );
+    const { address: derivedClaimPda } = deriveClaimPda(
+      params.taskPda,
+      this.agentPda,
+      this.program.programId,
+    );
+    const initiatorClaimPda =
+      params.initiatorClaimPda === undefined
+        ? derivedClaimPda
+        : params.initiatorClaimPda;
+    const taskSubmissionClaimPda =
+      params.workerClaimPda ?? initiatorClaimPda ?? null;
+    const taskSubmissionPda = await this.resolveExistingTaskSubmissionPda(
+      taskSubmissionClaimPda,
+    );
+    return this.buildInitiateDisputeIntent(
+      params,
+      disputePda,
+      initiatorClaimPda,
+      taskSubmissionPda,
+      this.buildRemainingAccounts(undefined, params.defendantWorkers),
+    );
+  }
+
+  async previewVoteDisputeIntent(
+    params: VoteDisputeParams,
+  ): Promise<MarketplaceTransactionIntent> {
+    const dispute = await this.fetchDispute(params.disputePda);
+    const { address: votePda } = deriveVotePda(
+      params.disputePda,
+      this.agentPda,
+      this.program.programId,
+    );
+    const { address: authVotePda } = deriveAuthorityVotePda(
+      params.disputePda,
+      this.program.provider.publicKey!,
+      this.program.programId,
+    );
+    return this.buildVoteDisputeIntent(params, dispute, votePda, authVotePda);
+  }
+
+  async previewResolveDisputeIntent(
+    params: ResolveDisputeParams,
+  ): Promise<MarketplaceTransactionIntent> {
+    const { address: escrowPda } = deriveEscrowPda(
+      params.taskPda,
+      this.program.programId,
+    );
+    const rawTask = (await this.program.account.task.fetch(
+      params.taskPda,
+    )) as { rewardMint: PublicKey | null };
+    const treasury = await this.getTreasury();
+    const tokenAccounts = buildResolveDisputeTokenAccounts(
+      rawTask.rewardMint ?? null,
+      escrowPda,
+      params.creatorPubkey,
+      params.workerAuthority ?? null,
+      treasury,
+    );
+    const remainingAccounts = this.buildRemainingAccounts(
+      params.arbiterVotes,
+      params.extraWorkers,
+      params.acceptedBidSettlement,
+    );
+    return this.buildResolveDisputeIntent(
+      params,
+      escrowPda,
+      treasury,
+      tokenAccounts,
+      remainingAccounts,
+    );
+  }
+
+  async previewCancelDisputeIntent(
+    disputePda: PublicKey,
+    taskPda: PublicKey,
+  ): Promise<MarketplaceTransactionIntent> {
+    const dispute = await this.fetchDispute(disputePda);
+    return this.buildCancelDisputeIntent(disputePda, taskPda, dispute);
+  }
+
+  async previewExpireDisputeIntent(
+    params: ExpireDisputeParams,
+  ): Promise<MarketplaceTransactionIntent> {
+    const { address: escrowPda } = deriveEscrowPda(
+      params.taskPda,
+      this.program.programId,
+    );
+    const rawTask = (await this.program.account.task.fetch(
+      params.taskPda,
+    )) as { rewardMint: PublicKey | null };
+    const tokenAccounts = buildExpireDisputeTokenAccounts(
+      rawTask.rewardMint ?? null,
+      escrowPda,
+      params.creatorPubkey,
+      params.workerAuthority ?? null,
+    );
+    const remainingAccounts = this.buildRemainingAccounts(
+      params.arbiterVotes,
+      params.extraWorkers,
+      params.acceptedBidSettlement,
+    );
+    return this.buildExpireDisputeIntent(
+      params,
+      escrowPda,
+      tokenAccounts,
+      remainingAccounts,
+    );
+  }
+
+  async previewApplySlashIntent(
+    params: ApplySlashParams,
+  ): Promise<MarketplaceTransactionIntent> {
+    const treasury = await this.getTreasury();
+    const { address: escrowPda } = deriveEscrowPda(
+      params.taskPda,
+      this.program.programId,
+    );
+    const rawTask = (await this.program.account.task.fetch(
+      params.taskPda,
+    )) as { rewardMint: PublicKey | null };
+    const tokenAccounts = buildApplyDisputeSlashTokenAccounts(
+      rawTask.rewardMint ?? null,
+      escrowPda,
+      treasury,
+    );
+    return this.buildApplySlashIntent(params, escrowPda, treasury, tokenAccounts);
+  }
+
   // ==========================================================================
   // Transaction Operations
   // ==========================================================================
@@ -422,6 +563,13 @@ export class DisputeOperations {
       const remainingAccounts = this.buildRemainingAccounts(
         undefined,
         params.defendantWorkers,
+      );
+      this.buildInitiateDisputeIntent(
+        params,
+        disputePda,
+        initiatorClaimPda,
+        taskSubmissionPda,
+        remainingAccounts,
       );
       const signature = await this.buildInitiateDisputeBuilder(
         this.program,
@@ -514,6 +662,7 @@ export class DisputeOperations {
     this.logger.info(
       `Voting ${params.approve ? "for" : "against"} dispute ${params.disputePda.toBase58()}`,
     );
+    this.buildVoteDisputeIntent(params, dispute, votePda, authVotePda);
 
     try {
       const signature = await this.program.methods
@@ -592,6 +741,13 @@ export class DisputeOperations {
         params.extraWorkers,
         params.acceptedBidSettlement,
       );
+      this.buildResolveDisputeIntent(
+        params,
+        escrowPda,
+        treasury,
+        tokenAccounts,
+        remainingAccounts,
+      );
 
       const builder = this.program.methods.resolveDispute().accountsPartial({
         dispute: params.disputePda,
@@ -667,6 +823,7 @@ export class DisputeOperations {
           "Dispute not found",
         );
       }
+      this.buildCancelDisputeIntent(disputePda, taskPda, dispute);
 
       const signature = await this.program.methods
         .cancelDispute()
@@ -733,6 +890,12 @@ export class DisputeOperations {
         params.extraWorkers,
         params.acceptedBidSettlement,
       );
+      this.buildExpireDisputeIntent(
+        params,
+        escrowPda,
+        tokenAccounts,
+        remainingAccounts,
+      );
 
       const builder = this.program.methods.expireDispute().accountsPartial({
         dispute: params.disputePda,
@@ -798,6 +961,7 @@ export class DisputeOperations {
         escrowPda,
         treasury,
       );
+      this.buildApplySlashIntent(params, escrowPda, treasury, tokenAccounts);
 
       const signature = await this.program.methods
         .applyDisputeSlash()
@@ -833,6 +997,232 @@ export class DisputeOperations {
   // ==========================================================================
   // Private Helpers
   // ==========================================================================
+
+  private buildInitiateDisputeIntent(
+    params: InitiateDisputeParams,
+    disputePda: PublicKey,
+    initiatorClaimPda: PublicKey | null,
+    taskSubmissionPda: PublicKey | null,
+    remainingAccounts: AccountMeta[],
+  ): MarketplaceTransactionIntent {
+    return {
+      kind: "initiate_dispute",
+      programId: this.program.programId.toBase58(),
+      signer: this.program.provider.publicKey?.toBase58() ?? null,
+      taskPda: params.taskPda.toBase58(),
+      taskId: hexBytes(params.taskId),
+      disputePda: disputePda.toBase58(),
+      disputeId: hexBytes(params.disputeId),
+      claimPda: initiatorClaimPda?.toBase58(),
+      workerPda: params.workerAgentPda?.toBase58(),
+      evidenceHash: hexBytes(params.evidenceHash),
+      resolutionType: String(params.resolutionType),
+      accountMetas: [
+        namedAccountMeta("dispute", disputePda, true),
+        namedAccountMeta("task", params.taskPda, true),
+        namedAccountMeta("agent", this.agentPda, true),
+        namedAccountMeta("authorityRateLimit", this.authorityRateLimitPda, true),
+        namedAccountMeta("protocolConfig", this.protocolPda, false),
+        ...(initiatorClaimPda
+          ? [namedAccountMeta("initiatorClaim", initiatorClaimPda, true)]
+          : []),
+        ...(params.workerAgentPda
+          ? [namedAccountMeta("workerAgent", params.workerAgentPda, true)]
+          : []),
+        ...(params.workerClaimPda
+          ? [namedAccountMeta("workerClaim", params.workerClaimPda, true)]
+          : []),
+        ...(taskSubmissionPda
+          ? [namedAccountMeta("taskSubmission", taskSubmissionPda, true)]
+          : []),
+        ...(this.program.provider.publicKey
+          ? [namedAccountMeta("authority", this.program.provider.publicKey, true, true)]
+          : []),
+        namedAccountMeta("systemProgram", SystemProgram.programId, false),
+        ...remainingAccounts.map((account, index) =>
+          accountMetaToIntentMeta(`remaining.${index}`, account),
+        ),
+      ],
+    };
+  }
+
+  private buildVoteDisputeIntent(
+    params: VoteDisputeParams,
+    dispute: OnChainDispute | null,
+    votePda: PublicKey,
+    authVotePda: PublicKey,
+  ): MarketplaceTransactionIntent {
+    return {
+      kind: "vote_dispute",
+      programId: this.program.programId.toBase58(),
+      signer: this.program.provider.publicKey?.toBase58() ?? null,
+      taskPda: params.taskPda.toBase58(),
+      disputePda: params.disputePda.toBase58(),
+      workerPda: dispute?.defendant.toBase58(),
+      accountMetas: [
+        namedAccountMeta("dispute", params.disputePda, true),
+        namedAccountMeta("task", params.taskPda, true),
+        ...(params.workerClaimPda
+          ? [namedAccountMeta("workerClaim", params.workerClaimPda, true)]
+          : []),
+        ...(dispute?.defendant
+          ? [namedAccountMeta("defendantAgent", dispute.defendant, false)]
+          : []),
+        namedAccountMeta("vote", votePda, true),
+        namedAccountMeta("authorityVote", authVotePda, true),
+        namedAccountMeta("arbiter", this.agentPda, true),
+        namedAccountMeta("protocolConfig", this.protocolPda, false),
+        ...(this.program.provider.publicKey
+          ? [namedAccountMeta("authority", this.program.provider.publicKey, true, true)]
+          : []),
+        namedAccountMeta("systemProgram", SystemProgram.programId, false),
+      ],
+    };
+  }
+
+  private buildResolveDisputeIntent(
+    params: ResolveDisputeParams,
+    escrowPda: PublicKey,
+    treasury: PublicKey,
+    tokenAccounts: Record<string, PublicKey | null | undefined>,
+    remainingAccounts: AccountMeta[],
+  ): MarketplaceTransactionIntent {
+    return {
+      kind: "resolve_dispute",
+      programId: this.program.programId.toBase58(),
+      signer: this.program.provider.publicKey?.toBase58() ?? null,
+      taskPda: params.taskPda.toBase58(),
+      disputePda: params.disputePda.toBase58(),
+      claimPda: params.workerClaimPda?.toBase58(),
+      workerPda: params.workerAgentPda?.toBase58(),
+      accountMetas: [
+        namedAccountMeta("dispute", params.disputePda, true),
+        namedAccountMeta("task", params.taskPda, true),
+        namedAccountMeta("escrow", escrowPda, true),
+        namedAccountMeta("protocolConfig", this.protocolPda, false),
+        ...(this.program.provider.publicKey
+          ? [namedAccountMeta("authority", this.program.provider.publicKey, true, true)]
+          : []),
+        namedAccountMeta("creator", params.creatorPubkey, true),
+        ...(params.workerClaimPda
+          ? [namedAccountMeta("workerClaim", params.workerClaimPda, true)]
+          : []),
+        ...(params.workerAgentPda
+          ? [namedAccountMeta("worker", params.workerAgentPda, true)]
+          : []),
+        ...(params.workerAuthority
+          ? [namedAccountMeta("workerWallet", params.workerAuthority, true)]
+          : []),
+        namedAccountMeta("treasury", treasury, true),
+        namedAccountMeta("systemProgram", SystemProgram.programId, false),
+        ...Object.entries(tokenAccounts)
+          .filter((entry): entry is [string, PublicKey] => entry[1] instanceof PublicKey)
+          .map(([name, pubkey]) => namedAccountMeta(name, pubkey, true)),
+        ...remainingAccounts.map((account, index) =>
+          accountMetaToIntentMeta(`remaining.${index}`, account),
+        ),
+      ],
+    };
+  }
+
+  private buildCancelDisputeIntent(
+    disputePda: PublicKey,
+    taskPda: PublicKey,
+    dispute: OnChainDispute | null,
+  ): MarketplaceTransactionIntent {
+    return {
+      kind: "cancel_dispute",
+      programId: this.program.programId.toBase58(),
+      signer: this.program.provider.publicKey?.toBase58() ?? null,
+      taskPda: taskPda.toBase58(),
+      disputePda: disputePda.toBase58(),
+      workerPda: dispute?.defendant.toBase58(),
+      accountMetas: [
+        namedAccountMeta("dispute", disputePda, true),
+        namedAccountMeta("task", taskPda, true),
+        ...(this.program.provider.publicKey
+          ? [namedAccountMeta("authority", this.program.provider.publicKey, true, true)]
+          : []),
+        ...(dispute?.defendant
+          ? [namedAccountMeta("defendant", dispute.defendant, true)]
+          : []),
+      ],
+    };
+  }
+
+  private buildExpireDisputeIntent(
+    params: ExpireDisputeParams,
+    escrowPda: PublicKey,
+    tokenAccounts: Record<string, PublicKey | null | undefined>,
+    remainingAccounts: AccountMeta[],
+  ): MarketplaceTransactionIntent {
+    return {
+      kind: "expire_dispute",
+      programId: this.program.programId.toBase58(),
+      signer: this.program.provider.publicKey?.toBase58() ?? null,
+      taskPda: params.taskPda.toBase58(),
+      disputePda: params.disputePda.toBase58(),
+      claimPda: params.workerClaimPda?.toBase58(),
+      workerPda: params.workerAgentPda?.toBase58(),
+      accountMetas: [
+        namedAccountMeta("dispute", params.disputePda, true),
+        namedAccountMeta("task", params.taskPda, true),
+        namedAccountMeta("escrow", escrowPda, true),
+        namedAccountMeta("protocolConfig", this.protocolPda, false),
+        namedAccountMeta("creator", params.creatorPubkey, true),
+        ...(this.program.provider.publicKey
+          ? [namedAccountMeta("authority", this.program.provider.publicKey, true, true)]
+          : []),
+        ...(params.workerClaimPda
+          ? [namedAccountMeta("workerClaim", params.workerClaimPda, true)]
+          : []),
+        ...(params.workerAgentPda
+          ? [namedAccountMeta("worker", params.workerAgentPda, true)]
+          : []),
+        ...(params.workerAuthority
+          ? [namedAccountMeta("workerWallet", params.workerAuthority, true)]
+          : []),
+        ...Object.entries(tokenAccounts)
+          .filter((entry): entry is [string, PublicKey] => entry[1] instanceof PublicKey)
+          .map(([name, pubkey]) => namedAccountMeta(name, pubkey, true)),
+        ...remainingAccounts.map((account, index) =>
+          accountMetaToIntentMeta(`remaining.${index}`, account),
+        ),
+      ],
+    };
+  }
+
+  private buildApplySlashIntent(
+    params: ApplySlashParams,
+    escrowPda: PublicKey,
+    treasury: PublicKey,
+    tokenAccounts: Record<string, PublicKey | null | undefined>,
+  ): MarketplaceTransactionIntent {
+    return {
+      kind: "apply_dispute_slash",
+      programId: this.program.programId.toBase58(),
+      signer: this.program.provider.publicKey?.toBase58() ?? null,
+      taskPda: params.taskPda.toBase58(),
+      disputePda: params.disputePda.toBase58(),
+      claimPda: params.workerClaimPda.toBase58(),
+      workerPda: params.workerAgentPda.toBase58(),
+      accountMetas: [
+        namedAccountMeta("dispute", params.disputePda, true),
+        namedAccountMeta("task", params.taskPda, true),
+        namedAccountMeta("escrow", escrowPda, true),
+        namedAccountMeta("workerClaim", params.workerClaimPda, true),
+        namedAccountMeta("workerAgent", params.workerAgentPda, true),
+        namedAccountMeta("protocolConfig", this.protocolPda, false),
+        namedAccountMeta("treasury", treasury, true),
+        ...(this.program.provider.publicKey
+          ? [namedAccountMeta("authority", this.program.provider.publicKey, true, true)]
+          : []),
+        ...Object.entries(tokenAccounts)
+          .filter((entry): entry is [string, PublicKey] => entry[1] instanceof PublicKey)
+          .map(([name, pubkey]) => namedAccountMeta(name, pubkey, true)),
+      ],
+    };
+  }
 
   private recordDisputeMetrics(operation: string, durationMs: number): void {
     if (!this.metrics) return;

--- a/runtime/src/task/operations.test.ts
+++ b/runtime/src/task/operations.test.ts
@@ -1360,6 +1360,61 @@ describe("TaskOperations", () => {
       expect(result.taskAttestorConfigPda).toBeInstanceOf(PublicKey);
     });
 
+    it("previews creator-review configuration and settlement mutation intents", async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createParsedTask({
+        constraintHash: new Uint8Array(MANUAL_VALIDATION_SENTINEL),
+      });
+      const workerPda = Keypair.generate().publicKey;
+      const workerAuthority = Keypair.generate().publicKey;
+      mocks.agentRegistrationFetch.mockResolvedValue(
+        createMockRawAgentRegistration(workerAuthority),
+      );
+
+      await expect(
+        ops.previewConfigureTaskValidationIntent(
+          taskPda,
+          task,
+          TaskValidationMode.CreatorReview,
+          900,
+        ),
+      ).resolves.toMatchObject({
+        kind: "configure_task_validation",
+        taskPda: taskPda.toBase58(),
+        validationMode: String(TaskValidationMode.CreatorReview),
+        reviewWindowSecs: "900",
+      });
+
+      await expect(ops.previewSubmitTaskResultIntent(taskPda, task)).resolves.toMatchObject({
+        kind: "submit_task_result",
+        taskPda: taskPda.toBase58(),
+      });
+      await expect(
+        ops.previewAcceptTaskResultIntent(taskPda, task, workerPda),
+      ).resolves.toMatchObject({
+        kind: "accept_task_result",
+        workerPda: workerPda.toBase58(),
+      });
+      await expect(
+        ops.previewRejectTaskResultIntent(taskPda, task, workerPda),
+      ).resolves.toMatchObject({
+        kind: "reject_task_result",
+        workerPda: workerPda.toBase58(),
+      });
+      await expect(
+        ops.previewAutoAcceptTaskResultIntent(taskPda, task, workerPda),
+      ).resolves.toMatchObject({
+        kind: "auto_accept_task_result",
+        workerPda: workerPda.toBase58(),
+      });
+      await expect(
+        ops.previewValidateTaskResultIntent(taskPda, task, workerPda, workerPda),
+      ).resolves.toMatchObject({
+        kind: "validate_task_result",
+        workerPda: workerPda.toBase58(),
+      });
+    });
+
     it("submits a task result for creator review", async () => {
       const taskPda = Keypair.generate().publicKey;
       const task = createParsedTask();

--- a/runtime/src/task/operations.ts
+++ b/runtime/src/task/operations.ts
@@ -681,6 +681,14 @@ export class TaskOperations {
       this.program.programId,
     ).address;
     const protocolPda = findProtocolPda(this.program.programId);
+    await this.previewConfigureTaskValidationIntent(
+      taskPda,
+      task,
+      mode,
+      reviewWindowSecs,
+      validatorQuorum,
+      attestor,
+    );
 
     const methods = this.program.methods as unknown as {
       configureTaskValidation: (
@@ -733,6 +741,55 @@ export class TaskOperations {
     }
   }
 
+  async previewConfigureTaskValidationIntent(
+    taskPda: PublicKey,
+    task: OnChainTask,
+    mode: TaskValidationMode | number,
+    reviewWindowSecs: number | bigint,
+    validatorQuorum = 0,
+    attestor?: PublicKey | null,
+  ): Promise<MarketplaceTransactionIntent> {
+    const creator = this.program.provider.publicKey;
+    if (!creator) {
+      throw new ValidationError(
+        "Program provider does not have a public key for task validation",
+      );
+    }
+
+    const taskValidationConfigPda = deriveTaskValidationConfigPda(
+      taskPda,
+      this.program.programId,
+    ).address;
+    const taskAttestorConfigPda = deriveTaskAttestorConfigPda(
+      taskPda,
+      this.program.programId,
+    ).address;
+    const protocolPda = findProtocolPda(this.program.programId);
+
+    return {
+      kind: "configure_task_validation",
+      programId: this.program.programId.toBase58(),
+      signer: creator.toBase58(),
+      taskPda: taskPda.toBase58(),
+      taskId: hexBytes(task.taskId),
+      rewardLamports: task.rewardAmount.toString(),
+      rewardMint: task.rewardMint?.toBase58() ?? null,
+      constraintHash: hexBytes(task.constraintHash),
+      validationMode: String(Number(mode)),
+      reviewWindowSecs: reviewWindowSecs.toString(),
+      validatorQuorum,
+      accountMetas: [
+        namedAccountMeta("task", taskPda, true),
+        namedAccountMeta("taskValidationConfig", taskValidationConfigPda, true),
+        namedAccountMeta("taskAttestorConfig", taskAttestorConfigPda, true),
+        namedAccountMeta("protocolConfig", protocolPda, false),
+        namedAccountMeta("creator", creator, true, true),
+        namedAccountMeta("systemProgram", SystemProgram.programId, false),
+        ...(attestor ? [namedAccountMeta("attestor", attestor, false)] : []),
+      ],
+    };
+  }
+
   /**
    * Submit a result for Task Validation V2 manual validation.
    *
@@ -776,6 +833,7 @@ export class TaskOperations {
       this.program.programId,
     ).address;
     const protocolPda = findProtocolPda(this.program.programId);
+    await this.previewSubmitTaskResultIntent(taskPda, task);
 
     const methods = this.program.methods as unknown as {
       submitTaskResult: (
@@ -823,6 +881,57 @@ export class TaskOperations {
         err instanceof Error ? err.message : String(err),
       );
     }
+  }
+
+  async previewSubmitTaskResultIntent(
+    taskPda: PublicKey,
+    task: OnChainTask,
+  ): Promise<MarketplaceTransactionIntent> {
+    const authority = this.program.provider.publicKey;
+    if (!authority) {
+      throw new ValidationError(
+        "Program provider does not have a public key for task submission",
+      );
+    }
+
+    const workerPda = this.getAgentPda();
+    const { address: claimPda } = deriveClaimPda(
+      taskPda,
+      workerPda,
+      this.program.programId,
+    );
+    const taskValidationConfigPda = deriveTaskValidationConfigPda(
+      taskPda,
+      this.program.programId,
+    ).address;
+    const taskSubmissionPda = deriveTaskSubmissionPda(
+      claimPda,
+      this.program.programId,
+    ).address;
+    const protocolPda = findProtocolPda(this.program.programId);
+
+    return {
+      kind: "submit_task_result",
+      programId: this.program.programId.toBase58(),
+      signer: authority.toBase58(),
+      taskPda: taskPda.toBase58(),
+      taskId: hexBytes(task.taskId),
+      claimPda: claimPda.toBase58(),
+      workerPda: workerPda.toBase58(),
+      rewardLamports: task.rewardAmount.toString(),
+      rewardMint: task.rewardMint?.toBase58() ?? null,
+      constraintHash: hexBytes(task.constraintHash),
+      accountMetas: [
+        namedAccountMeta("task", taskPda, true),
+        namedAccountMeta("claim", claimPda, true),
+        namedAccountMeta("taskValidationConfig", taskValidationConfigPda, true),
+        namedAccountMeta("taskSubmission", taskSubmissionPda, true),
+        namedAccountMeta("protocolConfig", protocolPda, false),
+        namedAccountMeta("worker", workerPda, false),
+        namedAccountMeta("authority", authority, true, true),
+        namedAccountMeta("systemProgram", SystemProgram.programId, false),
+      ],
+    };
   }
 
   /**
@@ -877,6 +986,7 @@ export class TaskOperations {
       options,
       workerAuthority,
     );
+    await this.previewAcceptTaskResultIntent(taskPda, task, workerPda, options);
 
     const methods = this.program.methods as unknown as {
       acceptTaskResult: () => {
@@ -928,6 +1038,83 @@ export class TaskOperations {
     }
   }
 
+  async previewAcceptTaskResultIntent(
+    taskPda: PublicKey,
+    task: OnChainTask,
+    workerPda: PublicKey,
+    options?: TaskCompletionOptions,
+  ): Promise<MarketplaceTransactionIntent> {
+    const creator = this.program.provider.publicKey;
+    if (!creator) {
+      throw new ValidationError(
+        "Program provider does not have a public key for task acceptance",
+      );
+    }
+
+    const { address: claimPda } = deriveClaimPda(
+      taskPda,
+      workerPda,
+      this.program.programId,
+    );
+    const { address: escrowPda } = deriveEscrowPda(
+      taskPda,
+      this.program.programId,
+    );
+    const taskValidationConfigPda = deriveTaskValidationConfigPda(
+      taskPda,
+      this.program.programId,
+    ).address;
+    const taskSubmissionPda = deriveTaskSubmissionPda(
+      claimPda,
+      this.program.programId,
+    ).address;
+    const protocolPda = findProtocolPda(this.program.programId);
+    const treasury = await this.getProtocolTreasury();
+    const workerAuthority = await this.getWorkerAuthority(workerPda);
+    const tokenAccounts = buildCompleteTaskTokenAccounts(
+      task.rewardMint,
+      escrowPda,
+      workerAuthority,
+      treasury,
+    );
+    const remainingAccounts = this.buildTaskCompletionRemainingAccounts(
+      options,
+      workerAuthority,
+    );
+
+    return {
+      kind: "accept_task_result",
+      programId: this.program.programId.toBase58(),
+      signer: creator.toBase58(),
+      taskPda: taskPda.toBase58(),
+      taskId: hexBytes(task.taskId),
+      claimPda: claimPda.toBase58(),
+      workerPda: workerPda.toBase58(),
+      rewardLamports: task.rewardAmount.toString(),
+      rewardMint: task.rewardMint?.toBase58() ?? null,
+      constraintHash: hexBytes(task.constraintHash),
+      accountMetas: [
+        namedAccountMeta("task", taskPda, true),
+        namedAccountMeta("claim", claimPda, true),
+        namedAccountMeta("escrow", escrowPda, true),
+        namedAccountMeta("taskValidationConfig", taskValidationConfigPda, true),
+        namedAccountMeta("taskSubmission", taskSubmissionPda, true),
+        namedAccountMeta("worker", workerPda, true),
+        namedAccountMeta("protocolConfig", protocolPda, false),
+        namedAccountMeta("treasury", treasury, true),
+        namedAccountMeta("creator", creator, true, true),
+        namedAccountMeta("workerAuthority", workerAuthority, true),
+        namedAccountMeta("systemProgram", SystemProgram.programId, false),
+        ...Object.entries(tokenAccounts)
+          .filter((entry): entry is [string, PublicKey] => entry[1] instanceof PublicKey)
+          .map(([name, pubkey]) => namedAccountMeta(name, pubkey, true)),
+        ...remainingAccounts.map((account, index) =>
+          accountMetaToIntentMeta(`remaining.${index}`, account),
+        ),
+      ],
+    };
+  }
+
   /**
    * Reject a pending Task Validation V2 submission.
    *
@@ -966,6 +1153,7 @@ export class TaskOperations {
       this.program.programId,
     ).address;
     const protocolPda = findProtocolPda(this.program.programId);
+    await this.previewRejectTaskResultIntent(taskPda, task, workerPda);
 
     const methods = this.program.methods as unknown as {
       rejectTaskResult: (rejectionHashBytes: number[]) => {
@@ -1008,6 +1196,58 @@ export class TaskOperations {
         err instanceof Error ? err.message : String(err),
       );
     }
+  }
+
+  async previewRejectTaskResultIntent(
+    taskPda: PublicKey,
+    task: OnChainTask,
+    workerPda: PublicKey,
+  ): Promise<MarketplaceTransactionIntent> {
+    const creator = this.program.provider.publicKey;
+    if (!creator) {
+      throw new ValidationError(
+        "Program provider does not have a public key for task rejection",
+      );
+    }
+
+    const { address: claimPda } = deriveClaimPda(
+      taskPda,
+      workerPda,
+      this.program.programId,
+    );
+    const taskValidationConfigPda = deriveTaskValidationConfigPda(
+      taskPda,
+      this.program.programId,
+    ).address;
+    const taskSubmissionPda = deriveTaskSubmissionPda(
+      claimPda,
+      this.program.programId,
+    ).address;
+    const protocolPda = findProtocolPda(this.program.programId);
+    const workerAuthority = await this.getWorkerAuthority(workerPda);
+
+    return {
+      kind: "reject_task_result",
+      programId: this.program.programId.toBase58(),
+      signer: creator.toBase58(),
+      taskPda: taskPda.toBase58(),
+      taskId: hexBytes(task.taskId),
+      claimPda: claimPda.toBase58(),
+      workerPda: workerPda.toBase58(),
+      rewardLamports: task.rewardAmount.toString(),
+      rewardMint: task.rewardMint?.toBase58() ?? null,
+      constraintHash: hexBytes(task.constraintHash),
+      accountMetas: [
+        namedAccountMeta("task", taskPda, true),
+        namedAccountMeta("claim", claimPda, true),
+        namedAccountMeta("taskValidationConfig", taskValidationConfigPda, true),
+        namedAccountMeta("taskSubmission", taskSubmissionPda, true),
+        namedAccountMeta("worker", workerPda, true),
+        namedAccountMeta("protocolConfig", protocolPda, false),
+        namedAccountMeta("creator", creator, true, true),
+        namedAccountMeta("workerAuthority", workerAuthority, false),
+      ],
+    };
   }
 
   /**
@@ -1062,6 +1302,12 @@ export class TaskOperations {
       options,
       workerAuthority,
     );
+    await this.previewAutoAcceptTaskResultIntent(
+      taskPda,
+      task,
+      workerPda,
+      options,
+    );
 
     const methods = this.program.methods as unknown as {
       autoAcceptTaskResult: () => {
@@ -1112,6 +1358,84 @@ export class TaskOperations {
         err instanceof Error ? err.message : String(err),
       );
     }
+  }
+
+  async previewAutoAcceptTaskResultIntent(
+    taskPda: PublicKey,
+    task: OnChainTask,
+    workerPda: PublicKey,
+    options?: TaskCompletionOptions,
+  ): Promise<MarketplaceTransactionIntent> {
+    const authority = this.program.provider.publicKey;
+    if (!authority) {
+      throw new ValidationError(
+        "Program provider does not have a public key for auto-acceptance",
+      );
+    }
+
+    const { address: claimPda } = deriveClaimPda(
+      taskPda,
+      workerPda,
+      this.program.programId,
+    );
+    const { address: escrowPda } = deriveEscrowPda(
+      taskPda,
+      this.program.programId,
+    );
+    const taskValidationConfigPda = deriveTaskValidationConfigPda(
+      taskPda,
+      this.program.programId,
+    ).address;
+    const taskSubmissionPda = deriveTaskSubmissionPda(
+      claimPda,
+      this.program.programId,
+    ).address;
+    const protocolPda = findProtocolPda(this.program.programId);
+    const treasury = await this.getProtocolTreasury();
+    const workerAuthority = await this.getWorkerAuthority(workerPda);
+    const tokenAccounts = buildCompleteTaskTokenAccounts(
+      task.rewardMint,
+      escrowPda,
+      workerAuthority,
+      treasury,
+    );
+    const remainingAccounts = this.buildTaskCompletionRemainingAccounts(
+      options,
+      workerAuthority,
+    );
+
+    return {
+      kind: "auto_accept_task_result",
+      programId: this.program.programId.toBase58(),
+      signer: authority.toBase58(),
+      taskPda: taskPda.toBase58(),
+      taskId: hexBytes(task.taskId),
+      claimPda: claimPda.toBase58(),
+      workerPda: workerPda.toBase58(),
+      rewardLamports: task.rewardAmount.toString(),
+      rewardMint: task.rewardMint?.toBase58() ?? null,
+      constraintHash: hexBytes(task.constraintHash),
+      accountMetas: [
+        namedAccountMeta("task", taskPda, true),
+        namedAccountMeta("claim", claimPda, true),
+        namedAccountMeta("escrow", escrowPda, true),
+        namedAccountMeta("taskValidationConfig", taskValidationConfigPda, true),
+        namedAccountMeta("taskSubmission", taskSubmissionPda, true),
+        namedAccountMeta("worker", workerPda, true),
+        namedAccountMeta("protocolConfig", protocolPda, false),
+        namedAccountMeta("treasury", treasury, true),
+        namedAccountMeta("creator", task.creator, true),
+        namedAccountMeta("workerAuthority", workerAuthority, true),
+        namedAccountMeta("authority", authority, true, true),
+        namedAccountMeta("systemProgram", SystemProgram.programId, false),
+        ...Object.entries(tokenAccounts)
+          .filter((entry): entry is [string, PublicKey] => entry[1] instanceof PublicKey)
+          .map(([name, pubkey]) => namedAccountMeta(name, pubkey, true)),
+        ...remainingAccounts.map((account, index) =>
+          accountMetaToIntentMeta(`remaining.${index}`, account),
+        ),
+      ],
+    };
   }
 
   /**
@@ -1179,6 +1503,13 @@ export class TaskOperations {
       options,
       workerAuthority,
     );
+    await this.previewValidateTaskResultIntent(
+      taskPda,
+      task,
+      workerPda,
+      validatorAgentPda,
+      options,
+    );
 
     const methods = this.program.methods as unknown as {
       validateTaskResult: (approved: boolean) => {
@@ -1233,6 +1564,101 @@ export class TaskOperations {
         err instanceof Error ? err.message : String(err),
       );
     }
+  }
+
+  async previewValidateTaskResultIntent(
+    taskPda: PublicKey,
+    task: OnChainTask,
+    workerPda: PublicKey,
+    validatorAgentPda?: PublicKey | null,
+    options?: TaskCompletionOptions,
+  ): Promise<MarketplaceTransactionIntent> {
+    const reviewer = this.program.provider.publicKey;
+    if (!reviewer) {
+      throw new ValidationError(
+        "Program provider does not have a public key for task validation voting",
+      );
+    }
+
+    const { address: claimPda } = deriveClaimPda(
+      taskPda,
+      workerPda,
+      this.program.programId,
+    );
+    const { address: escrowPda } = deriveEscrowPda(
+      taskPda,
+      this.program.programId,
+    );
+    const taskValidationConfigPda = deriveTaskValidationConfigPda(
+      taskPda,
+      this.program.programId,
+    ).address;
+    const taskAttestorConfigPda = deriveTaskAttestorConfigPda(
+      taskPda,
+      this.program.programId,
+    ).address;
+    const taskSubmissionPda = deriveTaskSubmissionPda(
+      claimPda,
+      this.program.programId,
+    ).address;
+    const taskValidationVotePda = deriveTaskValidationVotePda(
+      taskSubmissionPda,
+      reviewer,
+      this.program.programId,
+    ).address;
+    const protocolPda = findProtocolPda(this.program.programId);
+    const treasury = await this.getProtocolTreasury();
+    const workerAuthority = await this.getWorkerAuthority(workerPda);
+    const tokenAccounts = buildCompleteTaskTokenAccounts(
+      task.rewardMint,
+      escrowPda,
+      workerAuthority,
+      treasury,
+    );
+    const remainingAccounts = this.buildTaskCompletionRemainingAccounts(
+      options,
+      workerAuthority,
+    );
+
+    return {
+      kind: "validate_task_result",
+      programId: this.program.programId.toBase58(),
+      signer: reviewer.toBase58(),
+      taskPda: taskPda.toBase58(),
+      taskId: hexBytes(task.taskId),
+      claimPda: claimPda.toBase58(),
+      workerPda: workerPda.toBase58(),
+      rewardLamports: task.rewardAmount.toString(),
+      rewardMint: task.rewardMint?.toBase58() ?? null,
+      constraintHash: hexBytes(task.constraintHash),
+      accountMetas: [
+        namedAccountMeta("task", taskPda, true),
+        namedAccountMeta("claim", claimPda, true),
+        namedAccountMeta("escrow", escrowPda, true),
+        namedAccountMeta("taskValidationConfig", taskValidationConfigPda, true),
+        ...(validatorAgentPda
+          ? []
+          : [namedAccountMeta("taskAttestorConfig", taskAttestorConfigPda, false)]),
+        namedAccountMeta("taskSubmission", taskSubmissionPda, true),
+        namedAccountMeta("taskValidationVote", taskValidationVotePda, true),
+        namedAccountMeta("worker", workerPda, true),
+        namedAccountMeta("protocolConfig", protocolPda, false),
+        ...(validatorAgentPda
+          ? [namedAccountMeta("validatorAgent", validatorAgentPda, false)]
+          : []),
+        namedAccountMeta("treasury", treasury, true),
+        namedAccountMeta("creator", task.creator, true),
+        namedAccountMeta("workerAuthority", workerAuthority, true),
+        namedAccountMeta("reviewer", reviewer, true, true),
+        namedAccountMeta("systemProgram", SystemProgram.programId, false),
+        ...Object.entries(tokenAccounts)
+          .filter((entry): entry is [string, PublicKey] => entry[1] instanceof PublicKey)
+          .map(([name, pubkey]) => namedAccountMeta(name, pubkey, true)),
+        ...remainingAccounts.map((account, index) =>
+          accountMetaToIntentMeta(`remaining.${index}`, account),
+        ),
+      ],
+    };
   }
 
   /**
@@ -1350,6 +1776,10 @@ export class TaskOperations {
     task: OnChainTask,
     options?: TaskCompletionOptions,
   ): Promise<MarketplaceTransactionIntent> {
+    if (isManualValidationTask(task)) {
+      return this.previewSubmitTaskResultIntent(taskPda, task);
+    }
+
     const workerPda = this.getAgentPda();
     const { address: claimPda } = deriveClaimPda(
       taskPda,
@@ -1373,7 +1803,7 @@ export class TaskOperations {
       this.program.provider.publicKey ?? undefined,
     );
     return {
-      kind: isManualValidationTask(task) ? "submit_task_result" : "complete_task",
+      kind: "complete_task",
       programId: this.program.programId.toBase58(),
       signer: this.program.provider.publicKey?.toBase58() ?? null,
       taskPda: taskPda.toBase58(),

--- a/runtime/src/task/transaction-intent.ts
+++ b/runtime/src/task/transaction-intent.ts
@@ -10,7 +10,18 @@ export type MarketplaceTransactionIntentKind =
   | "claim_task_with_job_spec"
   | "complete_task"
   | "complete_task_private"
-  | "submit_task_result";
+  | "submit_task_result"
+  | "configure_task_validation"
+  | "accept_task_result"
+  | "reject_task_result"
+  | "auto_accept_task_result"
+  | "validate_task_result"
+  | "initiate_dispute"
+  | "vote_dispute"
+  | "resolve_dispute"
+  | "cancel_dispute"
+  | "expire_dispute"
+  | "apply_dispute_slash";
 
 export interface MarketplaceTransactionAccountMeta {
   readonly name: string;
@@ -25,10 +36,19 @@ export interface MarketplaceTransactionIntent {
   readonly signer: string | null;
   readonly taskPda?: string;
   readonly taskId?: string;
+  readonly claimPda?: string;
+  readonly workerPda?: string;
+  readonly disputePda?: string;
+  readonly disputeId?: string;
   readonly jobSpecHash?: string | null;
   readonly rewardLamports?: string;
   readonly rewardMint?: string | null;
   readonly constraintHash?: string | null;
+  readonly validationMode?: string | null;
+  readonly reviewWindowSecs?: string | null;
+  readonly validatorQuorum?: number | null;
+  readonly evidenceHash?: string | null;
+  readonly resolutionType?: string | null;
   readonly accountMetas: readonly MarketplaceTransactionAccountMeta[];
 }
 

--- a/runtime/src/tools/agenc/index.test.ts
+++ b/runtime/src/tools/agenc/index.test.ts
@@ -166,6 +166,37 @@ describe("AgenC protocol tool factory", () => {
     expect(denied.code).toBe("CONSTRAINT_HASH_NOT_ALLOWED");
   });
 
+  it("evaluates dispute transaction intent previews against signer policy", () => {
+    const intent: MarketplaceTransactionIntent = {
+      kind: "resolve_dispute",
+      programId: "Market11111111111111111111111111111111111111",
+      signer: "Signer11111111111111111111111111111111111111",
+      taskPda: "Task111111111111111111111111111111111111111",
+      disputePda: "Dispute111111111111111111111111111111111111",
+      accountMetas: [],
+    };
+
+    expect(
+      evaluateMarketplaceSignerPolicyForIntent(
+        {
+          allowedTools: ["agenc.resolveDispute"],
+          allowedDisputePdas: [intent.disputePda!],
+        },
+        intent,
+      ).allowed,
+    ).toBe(true);
+
+    const denied = evaluateMarketplaceSignerPolicyForIntent(
+      {
+        allowedTools: ["agenc.resolveDispute"],
+        allowedDisputePdas: ["OtherDispute1111111111111111111111111111111"],
+      },
+      intent,
+    );
+    expect(denied.allowed).toBe(false);
+    expect(denied.code).toBe("DISPUTE_NOT_ALLOWED");
+  });
+
   it("rejects intent previews that violate signer policy bounds", () => {
     const intent: MarketplaceTransactionIntent = {
       kind: "complete_task",

--- a/runtime/src/tools/agenc/signer-policy.ts
+++ b/runtime/src/tools/agenc/signer-policy.ts
@@ -15,6 +15,8 @@ export interface MarketplaceSignerPolicy {
   readonly allowedProgramIds?: readonly string[];
   /** Restrict task-scoped actions to specific task PDAs. */
   readonly allowedTaskPdas?: readonly string[];
+  /** Restrict dispute-scoped actions to specific dispute PDAs. */
+  readonly allowedDisputePdas?: readonly string[];
   /** Restrict task creation to specific approved template IDs. */
   readonly allowedTemplateIds?: readonly string[];
   /** Restrict task creation/claim paths to specific job spec hashes. */
@@ -137,6 +139,21 @@ function evaluateMarketplaceSignerPolicy(params: {
     };
   }
 
+  const allowedDisputePdas = normalizeList(params.policy.allowedDisputePdas);
+  const disputePda = readString(params.args, ["disputePda"]);
+  if (
+    allowedDisputePdas.size > 0 &&
+    disputePda &&
+    !allowedDisputePdas.has(disputePda)
+  ) {
+    return {
+      allowed: false,
+      code: "DISPUTE_NOT_ALLOWED",
+      reason: `Dispute ${disputePda} is not allowed by marketplace signer policy`,
+      metadata: { disputePda },
+    };
+  }
+
   const allowedTemplateIds = normalizeList(params.policy.allowedTemplateIds);
   const templateId = readString(params.args, ["templateId"]);
   if (allowedTemplateIds.size > 0 && templateId && !allowedTemplateIds.has(templateId)) {
@@ -237,6 +254,28 @@ function toolNameForIntent(kind: MarketplaceTransactionIntent["kind"]): string {
     case "complete_task_private":
     case "submit_task_result":
       return "agenc.completeTask";
+    case "configure_task_validation":
+      return "agenc.configureTaskValidation";
+    case "accept_task_result":
+      return "agenc.acceptTaskResult";
+    case "reject_task_result":
+      return "agenc.rejectTaskResult";
+    case "auto_accept_task_result":
+      return "agenc.autoAcceptTaskResult";
+    case "validate_task_result":
+      return "agenc.validateTaskResult";
+    case "initiate_dispute":
+      return "agenc.initiateDispute";
+    case "vote_dispute":
+      return "agenc.voteDispute";
+    case "resolve_dispute":
+      return "agenc.resolveDispute";
+    case "cancel_dispute":
+      return "agenc.cancelDispute";
+    case "expire_dispute":
+      return "agenc.expireDispute";
+    case "apply_dispute_slash":
+      return "agenc.applyDisputeSlash";
   }
 }
 
@@ -255,6 +294,7 @@ export function evaluateMarketplaceSignerPolicyForIntent(
     signer,
     args: {
       ...(intent.taskPda ? { taskPda: intent.taskPda } : {}),
+      ...(intent.disputePda ? { disputePda: intent.disputePda } : {}),
       ...(intent.jobSpecHash ? { jobSpecHash: intent.jobSpecHash } : {}),
       ...(intent.constraintHash ? { constraintHash: intent.constraintHash } : {}),
       ...(intent.rewardLamports ? { reward: intent.rewardLamports } : {}),


### PR DESCRIPTION
## Summary
- add transaction-intent kinds and metadata for reviewed-public validation and dispute mutations
- add preview methods for configure/submit/accept/reject/auto-accept/validate task-result flows
- add preview methods for initiate/vote/resolve/cancel/expire/slash dispute flows
- extend signer policy with dispute PDA allowlists and dispute intent tool mappings

## Validation
- `npm --workspace=@tetsuo-ai/runtime exec vitest run src/task/operations.test.ts src/dispute/operations.test.ts src/tools/agenc/index.test.ts`
- `npm run typecheck --workspace=@tetsuo-ai/runtime`
- `git diff --check`

## Mainnet readiness context
This addresses the audit gap where review/dispute actions did not have first-class transaction intent previews or signer-policy mapping coverage.