### PR TITLE
Align runtime with launch-control account gates

### DIFF
--- a/runtime/src/dispute/operations.test.ts
+++ b/runtime/src/dispute/operations.test.ts
@@ -1106,6 +1106,14 @@ describe("DisputeOperations", () => {
       expect(result.transactionSignature).toBe("mock-signature");
       expect(result.disputePda.equals(disputePda)).toBe(true);
       expect(program.methods.cancelDispute).toHaveBeenCalled();
+      expect(program._methodBuilder.accountsPartial).toHaveBeenCalledWith(
+        expect.objectContaining({
+          protocolConfig: findProtocolPda(program.programId),
+          dispute: disputePda,
+          task: taskPda,
+          authority: program.provider.publicKey,
+        }),
+      );
       expect(program._methodBuilder.remainingAccounts).toHaveBeenCalledWith([
         { pubkey: defendant, isSigner: false, isWritable: true },
       ]);

--- a/runtime/src/dispute/operations.ts
+++ b/runtime/src/dispute/operations.ts
@@ -825,9 +825,9 @@ export class DisputeOperations {
       }
       this.buildCancelDisputeIntent(disputePda, taskPda, dispute);
 
-      const signature = await this.program.methods
-        .cancelDispute()
+      const signature = await (this.program.methods.cancelDispute() as any)
         .accountsPartial({
+          protocolConfig: this.protocolPda,
           dispute: disputePda,
           task: taskPda,
           authority: this.program.provider.publicKey,

--- a/runtime/src/idl.ts
+++ b/runtime/src/idl.ts
@@ -366,6 +366,39 @@ const MARKETPLACE_ACCOUNT_LAYOUT_OVERRIDES = {
       address: "11111111111111111111111111111111",
     },
   ],
+  cancel_dispute: [
+    {
+      name: "protocol_config",
+      pda: {
+        seeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108] }],
+      },
+    },
+    {
+      name: "dispute",
+      writable: true,
+      pda: {
+        seeds: [
+          { kind: "const", value: [100, 105, 115, 112, 117, 116, 101] },
+          { kind: "account", path: "dispute.dispute_id", account: "Dispute" },
+        ],
+      },
+    },
+    {
+      name: "task",
+      writable: true,
+      pda: {
+        seeds: [
+          { kind: "const", value: [116, 97, 115, 107] },
+          { kind: "account", path: "task.creator", account: "Task" },
+          { kind: "account", path: "task.task_id", account: "Task" },
+        ],
+      },
+    },
+    {
+      name: "authority",
+      signer: true,
+    },
+  ],
 } as const;
 
 const LEGACY_CREATE_TASK_ACCOUNT_LAYOUT = [
@@ -1045,8 +1078,13 @@ const TASK_JOB_SPEC_INSTRUCTIONS = [
     discriminator: [134, 102, 102, 86, 31, 164, 202, 193],
     accounts: [
       {
+        name: "protocol_config",
+        pda: {
+          seeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108] }],
+        },
+      },
+      {
         name: "task",
-        writable: true,
         pda: {
           seeds: [
             { kind: "const", value: [116, 97, 115, 107] },

--- a/runtime/src/marketplace/task-job-spec.ts
+++ b/runtime/src/marketplace/task-job-spec.ts
@@ -1,6 +1,7 @@
 import { SystemProgram, PublicKey } from "@solana/web3.js";
 import type { Program } from "@coral-xyz/anchor";
 import type { AgencCoordination } from "../types/agenc_coordination.js";
+import { findProtocolPda } from "../agent/pda.js";
 import { bytesToHex, hexToBytes } from "../utils/encoding.js";
 import {
   resolveMarketplaceJobSpecReference,
@@ -84,11 +85,13 @@ export async function setTaskJobSpecPointer(
   jobSpecHash: string | Uint8Array | number[],
   jobSpecUri: string,
 ): Promise<{ taskJobSpecPda: PublicKey; transactionSignature: string }> {
+  const protocolPda = findProtocolPda(program.programId);
   const taskJobSpecPda = findTaskJobSpecPda(taskPda, program.programId);
   const jobSpecHashBytes = normalizeJobSpecHash(jobSpecHash);
   const transactionSignature = await (program.methods as any)
     .setTaskJobSpec(Array.from(jobSpecHashBytes), jobSpecUri)
     .accountsPartial({
+      protocolConfig: protocolPda,
       task: taskPda,
       taskJobSpec: taskJobSpecPda,
       creator,

--- a/runtime/src/tools/agenc/index.test.ts
+++ b/runtime/src/tools/agenc/index.test.ts
@@ -1,5 +1,5 @@
-import { Connection, Keypair } from "@solana/web3.js";
-import { describe, expect, it } from "vitest";
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   createAgencMutationTools,
@@ -7,7 +7,10 @@ import {
   createAgencTools,
   type MarketplaceSignerPolicy,
 } from "./index.js";
-import { evaluateMarketplaceSignerPolicyForIntent } from "./signer-policy.js";
+import {
+  evaluateMarketplaceSignerPolicyForIntent,
+  wrapMarketplaceSignerPolicy,
+} from "./signer-policy.js";
 import type { MarketplaceTransactionIntent } from "../../task/transaction-intent.js";
 import { keypairToWallet } from "../../types/wallet.js";
 import { silentLogger } from "../../utils/logger.js";
@@ -71,6 +74,29 @@ describe("AgenC protocol tool factory", () => {
     expect(toolNames).not.toContain("agenc.completeTask");
     expect(toolNames).not.toContain("agenc.initiateDispute");
     expect(createAgencMutationTools(makeContext())).toEqual([]);
+  });
+
+  it("denies direct signer-policy wrapper execution when policy is missing", async () => {
+    const execute = vi.fn(async () => ({ content: "executed" }));
+    const wrapped = wrapMarketplaceSignerPolicy(
+      {
+        name: "agenc.completeTask",
+        description: "Complete task",
+        inputSchema: {},
+        execute,
+      },
+      {
+        programId: PublicKey.unique(),
+        signer: PublicKey.unique(),
+        logger: silentLogger,
+      },
+    );
+
+    const result = await wrapped.execute({ taskPda: PublicKey.unique().toBase58() });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("POLICY_REQUIRED");
+    expect(execute).not.toHaveBeenCalled();
   });
 
   it("can explicitly opt into marketplace mutation tools with a signer policy", () => {

--- a/runtime/src/tools/agenc/signer-policy.ts
+++ b/runtime/src/tools/agenc/signer-policy.ts
@@ -366,7 +366,18 @@ export function wrapMarketplaceSignerPolicy(
   },
 ): Tool {
   if (!params.policy) {
-    return tool;
+    return {
+      ...tool,
+      async execute(_args: Record<string, unknown>): Promise<ToolResult> {
+        params.logger.warn?.(
+          `Marketplace signer policy denied ${tool.name}: signer policy is required`,
+        );
+        return errorResult("Marketplace signer policy is required for mutation tools", {
+          toolName: tool.name,
+          denialCode: "POLICY_REQUIRED",
+        });
+      },
+    };
   }
   return {
     ...tool,

--- a/runtime/src/tools/agenc/tools-task-templates.test.ts
+++ b/runtime/src/tools/agenc/tools-task-templates.test.ts
@@ -158,6 +158,11 @@ describe("agenc task template tools", () => {
       `https://marketplace-devnet.agenc.tech/api/job-specs/${payload.jobSpecHash}`,
     );
     expect(setTaskJobSpecAccountsPartial).toHaveBeenCalledOnce();
+    expect(setTaskJobSpecAccountsPartial).toHaveBeenCalledWith(
+      expect.objectContaining({
+        protocolConfig: expect.any(PublicKey),
+      }),
+    );
     expect(createTaskAccountsPartial).toHaveBeenCalledWith(
       expect.objectContaining({
         creatorAgent: creatorAgentPda,


### PR DESCRIPTION
## Summary
- pass the protocol config PDA when publishing task job-spec metadata and cancelling disputes
- update local IDL overrides for the new protocol launch-control account layouts from agenc-protocol#35
- make the signer-policy wrapper fail closed when called without a policy, with regression coverage

## Validation
- /Users/tetsuoarena/agenc-core/runtime/node_modules/.bin/vitest run src/dispute/operations.test.ts src/tools/agenc/index.test.ts src/tools/agenc/tools-task-templates.test.ts
- npm run typecheck --workspace=@tetsuo-ai/runtime

## Deployment note
This runtime change depends on the program layout merged in tetsuo-ai/agenc-protocol#35. Deploy the upgraded protocol before deploying this runtime to an environment that still uses the old on-chain account layout.