### PR TITLE
Harden devnet canary drill job spec handling

### DIFF
--- a/runtime/src/dispute/operations.test.ts
+++ b/runtime/src/dispute/operations.test.ts
@@ -1106,6 +1106,14 @@ describe("DisputeOperations", () => {
       expect(result.transactionSignature).toBe("mock-signature");
       expect(result.disputePda.equals(disputePda)).toBe(true);
       expect(program.methods.cancelDispute).toHaveBeenCalled();
+      expect(program._methodBuilder.accountsPartial).toHaveBeenCalledWith(
+        expect.objectContaining({
+          protocolConfig: findProtocolPda(program.programId),
+          dispute: disputePda,
+          task: taskPda,
+          authority: program.provider.publicKey,
+        }),
+      );
       expect(program._methodBuilder.remainingAccounts).toHaveBeenCalledWith([
         { pubkey: defendant, isSigner: false, isWritable: true },
       ]);

--- a/runtime/src/dispute/operations.ts
+++ b/runtime/src/dispute/operations.ts
@@ -825,9 +825,9 @@ export class DisputeOperations {
       }
       this.buildCancelDisputeIntent(disputePda, taskPda, dispute);
 
-      const signature = await this.program.methods
-        .cancelDispute()
+      const signature = await (this.program.methods.cancelDispute() as any)
         .accountsPartial({
+          protocolConfig: this.protocolPda,
           dispute: disputePda,
           task: taskPda,
           authority: this.program.provider.publicKey,

--- a/runtime/src/idl.ts
+++ b/runtime/src/idl.ts
@@ -366,6 +366,39 @@ const MARKETPLACE_ACCOUNT_LAYOUT_OVERRIDES = {
       address: "11111111111111111111111111111111",
     },
   ],
+  cancel_dispute: [
+    {
+      name: "protocol_config",
+      pda: {
+        seeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108] }],
+      },
+    },
+    {
+      name: "dispute",
+      writable: true,
+      pda: {
+        seeds: [
+          { kind: "const", value: [100, 105, 115, 112, 117, 116, 101] },
+          { kind: "account", path: "dispute.dispute_id", account: "Dispute" },
+        ],
+      },
+    },
+    {
+      name: "task",
+      writable: true,
+      pda: {
+        seeds: [
+          { kind: "const", value: [116, 97, 115, 107] },
+          { kind: "account", path: "task.creator", account: "Task" },
+          { kind: "account", path: "task.task_id", account: "Task" },
+        ],
+      },
+    },
+    {
+      name: "authority",
+      signer: true,
+    },
+  ],
 } as const;
 
 const LEGACY_CREATE_TASK_ACCOUNT_LAYOUT = [
@@ -1045,8 +1078,13 @@ const TASK_JOB_SPEC_INSTRUCTIONS = [
     discriminator: [134, 102, 102, 86, 31, 164, 202, 193],
     accounts: [
       {
+        name: "protocol_config",
+        pda: {
+          seeds: [{ kind: "const", value: [112, 114, 111, 116, 111, 99, 111, 108] }],
+        },
+      },
+      {
         name: "task",
-        writable: true,
         pda: {
           seeds: [
             { kind: "const", value: [116, 97, 115, 107] },

--- a/runtime/src/marketplace/task-job-spec.ts
+++ b/runtime/src/marketplace/task-job-spec.ts
@@ -1,6 +1,7 @@
 import { SystemProgram, PublicKey } from "@solana/web3.js";
 import type { Program } from "@coral-xyz/anchor";
 import type { AgencCoordination } from "../types/agenc_coordination.js";
+import { findProtocolPda } from "../agent/pda.js";
 import { bytesToHex, hexToBytes } from "../utils/encoding.js";
 import {
   resolveMarketplaceJobSpecReference,
@@ -84,11 +85,13 @@ export async function setTaskJobSpecPointer(
   jobSpecHash: string | Uint8Array | number[],
   jobSpecUri: string,
 ): Promise<{ taskJobSpecPda: PublicKey; transactionSignature: string }> {
+  const protocolPda = findProtocolPda(program.programId);
   const taskJobSpecPda = findTaskJobSpecPda(taskPda, program.programId);
   const jobSpecHashBytes = normalizeJobSpecHash(jobSpecHash);
   const transactionSignature = await (program.methods as any)
     .setTaskJobSpec(Array.from(jobSpecHashBytes), jobSpecUri)
     .accountsPartial({
+      protocolConfig: protocolPda,
       task: taskPda,
       taskJobSpec: taskJobSpecPda,
       creator,

--- a/runtime/src/task/operations.test.ts
+++ b/runtime/src/task/operations.test.ts
@@ -859,6 +859,46 @@ describe("TaskOperations", () => {
       );
     });
 
+    it("retries required claim-time job spec verification for RPC read-after-write lag", async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createParsedTask();
+      const storeDir = await mkdtemp(join(tmpdir(), "agenc-job-spec-lag-"));
+      const stored = await persistMarketplaceJobSpec(
+        {
+          description: "Verified marketplace task",
+          acceptanceCriteria: ["Do the verified work"],
+          deliverables: ["A short report"],
+        },
+        { rootDir: storeDir },
+      );
+      const jobSpecHashBytes = Uint8Array.from(Buffer.from(stored.hash, "hex"));
+      const opsWithStore = new TaskOperations({
+        program: mockProgram,
+        agentId,
+        logger: silentLogger,
+        jobSpecStoreDir: storeDir,
+        claimJobSpecVerification: "required",
+      });
+
+      mocks.taskJobSpecFetch
+        .mockRejectedValueOnce(new Error("Account does not exist"))
+        .mockResolvedValue({
+          task: taskPda,
+          creator: Keypair.generate().publicKey,
+          jobSpecHash: Array.from(jobSpecHashBytes),
+          jobSpecUri: stored.uri,
+          createdAt: { toNumber: () => 1700000000 },
+          updatedAt: { toNumber: () => 1700000000 },
+          bump: 255,
+        });
+
+      const result = await opsWithStore.claimTask(taskPda, task);
+
+      expect(result.transactionSignature).toBe("claim-with-job-spec-sig");
+      expect(mocks.taskJobSpecFetch).toHaveBeenCalledTimes(2);
+      expect(mocks.claimTaskWithJobSpecRpc).toHaveBeenCalledOnce();
+    });
+
     it("falls back to legacy claimTask when the deployed program lacks claimTaskWithJobSpec", async () => {
       const taskPda = Keypair.generate().publicKey;
       const task = createParsedTask();
@@ -1358,6 +1398,22 @@ describe("TaskOperations", () => {
         }),
       );
       expect(result.taskAttestorConfigPda).toBeInstanceOf(PublicKey);
+    });
+
+    it("configures task validation from post-create task id material", async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = { taskId: new Uint8Array(32).fill(9) } as OnChainTask;
+
+      const result = await ops.configureTaskValidation(
+        taskPda,
+        task,
+        TaskValidationMode.CreatorReview,
+        900,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.transactionSignature).toBe("configure-sig");
+      expect(mocks.configureTaskValidationMethod).toHaveBeenCalledTimes(1);
     });
 
     it("previews creator-review configuration and settlement mutation intents", async () => {

--- a/runtime/src/task/operations.ts
+++ b/runtime/src/task/operations.ts
@@ -108,6 +108,12 @@ const TRUSTED_RISC0_ROUTER_PROGRAM_ID = new PublicKey(
 const TRUSTED_RISC0_VERIFIER_PROGRAM_ID = new PublicKey(
   "3ZrAHZKjk24AKgXFekpYeG7v3Rz7NucLXTB3zxGGTjsc",
 );
+const CLAIM_JOB_SPEC_VERIFY_ATTEMPTS = 5;
+const CLAIM_JOB_SPEC_VERIFY_RETRY_MS = 1_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 // ============================================================================
 // Configuration
@@ -601,39 +607,65 @@ export class TaskOperations {
   ): Promise<OnChainTaskJobSpecPointer | null> {
     if (this.claimJobSpecVerification === "disabled") return null;
 
-    let pointer: Awaited<ReturnType<typeof fetchTaskJobSpecPointer>>;
-    try {
-      pointer = await fetchTaskJobSpecPointer(this.program, taskPda);
-    } catch (err) {
-      throw new TaskNotClaimableError(
-        taskPda,
-        `Unable to verify task job spec metadata before claim: ${formatUnknownError(err)}`,
-      );
-    }
+    const attempts =
+      this.claimJobSpecVerification === "required"
+        ? CLAIM_JOB_SPEC_VERIFY_ATTEMPTS
+        : 1;
+    let lastVerificationError: unknown = null;
 
-    if (!pointer) {
-      if (this.claimJobSpecVerification === "required") {
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      let pointer: Awaited<ReturnType<typeof fetchTaskJobSpecPointer>>;
+      try {
+        pointer = await fetchTaskJobSpecPointer(this.program, taskPda);
+      } catch (err) {
+        lastVerificationError = err;
+        if (attempt >= attempts) {
+          throw new TaskNotClaimableError(
+            taskPda,
+            `Unable to verify task job spec metadata before claim: ${formatUnknownError(err)}`,
+          );
+        }
+        await sleep(CLAIM_JOB_SPEC_VERIFY_RETRY_MS);
+        continue;
+      }
+
+      if (!pointer) {
+        if (this.claimJobSpecVerification !== "required") {
+          return null;
+        }
+        if (attempt < attempts) {
+          await sleep(CLAIM_JOB_SPEC_VERIFY_RETRY_MS);
+          continue;
+        }
         throw new TaskNotClaimableError(
           taskPda,
           "No verified task job spec metadata found before claim",
         );
       }
-      return null;
+
+      try {
+        await resolveMarketplaceJobSpecReference(
+          pointer,
+          this.jobSpecStoreOptions,
+        );
+        return pointer;
+      } catch (err) {
+        lastVerificationError = err;
+        if (attempt < attempts) {
+          await sleep(CLAIM_JOB_SPEC_VERIFY_RETRY_MS);
+          continue;
+        }
+        throw new TaskNotClaimableError(
+          taskPda,
+          `Task job spec could not be verified before claim: ${formatUnknownError(err)}`,
+        );
+      }
     }
 
-    try {
-      await resolveMarketplaceJobSpecReference(
-        pointer,
-        this.jobSpecStoreOptions,
-      );
-    } catch (err) {
-      throw new TaskNotClaimableError(
-        taskPda,
-        `Task job spec could not be verified before claim: ${formatUnknownError(err)}`,
-      );
-    }
-
-    return pointer;
+    throw new TaskNotClaimableError(
+      taskPda,
+      `Task job spec could not be verified before claim: ${formatUnknownError(lastVerificationError)}`,
+    );
   }
 
   async resolveCompiledJobForTask(taskPda: PublicKey): Promise<CompiledJob | null> {
@@ -765,6 +797,8 @@ export class TaskOperations {
       this.program.programId,
     ).address;
     const protocolPda = findProtocolPda(this.program.programId);
+    const rewardAmount = task.rewardAmount;
+    const constraintHash = task.constraintHash;
 
     return {
       kind: "configure_task_validation",
@@ -772,9 +806,11 @@ export class TaskOperations {
       signer: creator.toBase58(),
       taskPda: taskPda.toBase58(),
       taskId: hexBytes(task.taskId),
-      rewardLamports: task.rewardAmount.toString(),
+      ...(rewardAmount !== undefined
+        ? { rewardLamports: rewardAmount.toString() }
+        : {}),
       rewardMint: task.rewardMint?.toBase58() ?? null,
-      constraintHash: hexBytes(task.constraintHash),
+      constraintHash: constraintHash ? hexBytes(constraintHash) : null,
       validationMode: String(Number(mode)),
       reviewWindowSecs: reviewWindowSecs.toString(),
       validatorQuorum,

--- a/runtime/src/tools/agenc/index.test.ts
+++ b/runtime/src/tools/agenc/index.test.ts
@@ -1,5 +1,5 @@
-import { Connection, Keypair } from "@solana/web3.js";
-import { describe, expect, it } from "vitest";
+import { Connection, Keypair, PublicKey } from "@solana/web3.js";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   createAgencMutationTools,
@@ -7,7 +7,10 @@ import {
   createAgencTools,
   type MarketplaceSignerPolicy,
 } from "./index.js";
-import { evaluateMarketplaceSignerPolicyForIntent } from "./signer-policy.js";
+import {
+  evaluateMarketplaceSignerPolicyForIntent,
+  wrapMarketplaceSignerPolicy,
+} from "./signer-policy.js";
 import type { MarketplaceTransactionIntent } from "../../task/transaction-intent.js";
 import { keypairToWallet } from "../../types/wallet.js";
 import { silentLogger } from "../../utils/logger.js";
@@ -71,6 +74,29 @@ describe("AgenC protocol tool factory", () => {
     expect(toolNames).not.toContain("agenc.completeTask");
     expect(toolNames).not.toContain("agenc.initiateDispute");
     expect(createAgencMutationTools(makeContext())).toEqual([]);
+  });
+
+  it("denies direct signer-policy wrapper execution when policy is missing", async () => {
+    const execute = vi.fn(async () => ({ content: "executed" }));
+    const wrapped = wrapMarketplaceSignerPolicy(
+      {
+        name: "agenc.completeTask",
+        description: "Complete task",
+        inputSchema: {},
+        execute,
+      },
+      {
+        programId: PublicKey.unique(),
+        signer: PublicKey.unique(),
+        logger: silentLogger,
+      },
+    );
+
+    const result = await wrapped.execute({ taskPda: PublicKey.unique().toBase58() });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("POLICY_REQUIRED");
+    expect(execute).not.toHaveBeenCalled();
   });
 
   it("can explicitly opt into marketplace mutation tools with a signer policy", () => {

--- a/runtime/src/tools/agenc/signer-policy.ts
+++ b/runtime/src/tools/agenc/signer-policy.ts
@@ -366,7 +366,18 @@ export function wrapMarketplaceSignerPolicy(
   },
 ): Tool {
   if (!params.policy) {
-    return tool;
+    return {
+      ...tool,
+      async execute(_args: Record<string, unknown>): Promise<ToolResult> {
+        params.logger.warn?.(
+          `Marketplace signer policy denied ${tool.name}: signer policy is required`,
+        );
+        return errorResult("Marketplace signer policy is required for mutation tools", {
+          toolName: tool.name,
+          denialCode: "POLICY_REQUIRED",
+        });
+      },
+    };
   }
   return {
     ...tool,

--- a/runtime/src/tools/agenc/tools-task-templates.test.ts
+++ b/runtime/src/tools/agenc/tools-task-templates.test.ts
@@ -158,6 +158,11 @@ describe("agenc task template tools", () => {
       `https://marketplace-devnet.agenc.tech/api/job-specs/${payload.jobSpecHash}`,
     );
     expect(setTaskJobSpecAccountsPartial).toHaveBeenCalledOnce();
+    expect(setTaskJobSpecAccountsPartial).toHaveBeenCalledWith(
+      expect.objectContaining({
+        protocolConfig: expect.any(PublicKey),
+      }),
+    );
     expect(createTaskAccountsPartial).toHaveBeenCalledWith(
       expect.objectContaining({
         creatorAgent: creatorAgentPda,

--- a/scripts/marketplace-devnet-smoke.ts
+++ b/scripts/marketplace-devnet-smoke.ts
@@ -203,6 +203,18 @@ function env(name: string): string {
   return value;
 }
 
+function readMarketplaceSignerPolicyFromEnv(): Record<string, unknown> | undefined {
+  const raw = process.env.AGENC_MARKETPLACE_SIGNER_POLICY?.trim();
+  if (!raw) {
+    return undefined;
+  }
+  const parsed = JSON.parse(raw) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("AGENC_MARKETPLACE_SIGNER_POLICY must be a JSON object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
 function hasFlag(flag: string): boolean {
   return process.argv.includes(flag);
 }
@@ -562,6 +574,7 @@ async function registerOrLoadAgent(
       wallet: keypairToWallet(signer.keypair),
       programId,
       logger: silentLogger,
+      marketplaceSignerPolicy: readMarketplaceSignerPolicyFromEnv(),
     },
     { includeMutationTools: true },
   ).find((tool) => tool.name === "agenc.registerAgent");
@@ -1676,6 +1689,15 @@ async function initial(): Promise<void> {
         reward: rewardLamports.toString(),
         requiredCapabilities: AgentCapabilities.COMPUTE.toString(),
         creatorAgentPda: creator.agentPda.toBase58(),
+        fullDescription:
+          "Live devnet smoke for marketplace dispute lifecycle with verified job spec metadata.",
+        acceptanceCriteria: [
+          "Worker claims the task after verified job spec resolution.",
+          "Creator opens a dispute with evidence.",
+          "Three arbiters vote and protocol authority resolves the dispute.",
+        ],
+        deliverables: ["Dispute lifecycle evidence artifact"],
+        constraints: ["SOL-only smoke; no Private ZK and no storefront dependencies."],
       },
       creator.agentPda.toBase58(),
     );


### PR DESCRIPTION
## Summary
- Allow creator-review validation intent preview to run from post-create task-id material.
- Retry required claim-time job-spec verification to tolerate devnet RPC read-after-write lag.
- Update the devnet marketplace smoke to pass signer policy into agent registration and create dispute tasks with job-spec metadata.

## Validation
- `npm run typecheck --workspace=@tetsuo-ai/runtime`
- `npm run test --workspace=@tetsuo-ai/runtime -- src/task/operations.test.ts`
- Live devnet reviewed-public artifact smoke passed after protocol upgrade.
- Live devnet 10-worker claim contention smoke passed.
- Live devnet dispute open + 3 arbiter votes passed; resolution remains pending until the protocol voting deadline.
- Explorer drill passed against `https://devnet.agenc.tech`.
- Operator drill passed local controls but remains blocked on real alert routing/on-call evidence.