### PR TITLE
Use marketplace agent kit policy evaluator

### DIFF
--- a/runtime/src/task/transaction-intent.ts
+++ b/runtime/src/task/transaction-intent.ts
@@ -37,18 +37,24 @@ export interface MarketplaceTransactionIntent {
   readonly taskPda?: string;
   readonly taskId?: string;
   readonly claimPda?: string;
+  readonly submissionPda?: string;
   readonly workerPda?: string;
   readonly disputePda?: string;
   readonly disputeId?: string;
   readonly jobSpecHash?: string | null;
   readonly rewardLamports?: string;
   readonly rewardMint?: string | null;
+  readonly taskType?: string | null;
   readonly constraintHash?: string | null;
   readonly validationMode?: string | null;
+  readonly artifactSha256?: string | null;
   readonly reviewWindowSecs?: string | null;
   readonly validatorQuorum?: number | null;
   readonly evidenceHash?: string | null;
   readonly resolutionType?: string | null;
+  readonly requiresCreatorReview?: boolean;
+  readonly jobSpecVerified?: boolean;
+  readonly hasArtifactDelivery?: boolean;
   readonly accountMetas: readonly MarketplaceTransactionAccountMeta[];
 }
 

--- a/runtime/src/tools/agenc/index.test.ts
+++ b/runtime/src/tools/agenc/index.test.ts
@@ -247,6 +247,7 @@ describe("AgenC protocol tool factory", () => {
       name: string;
       policy: MarketplaceSignerPolicy;
       code: string;
+      intent?: MarketplaceTransactionIntent;
     }> = [
       {
         name: "wrong program",
@@ -310,12 +311,98 @@ describe("AgenC protocol tool factory", () => {
         },
         code: "ACCOUNT_META_PUBKEY_MISMATCH",
       },
+      {
+        name: "token reward denied",
+        policy: {
+          allowedTools: ["agenc.completeTask"],
+          denyTokenRewards: true,
+        },
+        intent: {
+          ...intent,
+          rewardMint: "TokenMint1111111111111111111111111111111111",
+        },
+        code: "TOKEN_REWARD_DENIED",
+      },
+      {
+        name: "wrong task type",
+        policy: {
+          allowedTools: ["agenc.completeTask"],
+          allowedTaskTypes: ["Exclusive"],
+        },
+        intent: {
+          ...intent,
+          taskType: "Collaborative",
+        },
+        code: "TASK_TYPE_NOT_ALLOWED",
+      },
+      {
+        name: "wrong validation mode",
+        policy: {
+          allowedTools: ["agenc.completeTask"],
+          allowedValidationModes: ["CreatorReview"],
+        },
+        intent: {
+          ...intent,
+          validationMode: "Auto",
+        },
+        code: "VALIDATION_MODE_NOT_ALLOWED",
+      },
+      {
+        name: "artifact without creator review",
+        policy: {
+          allowedTools: ["agenc.completeTask"],
+          requireCreatorReviewForArtifacts: true,
+        },
+        intent: {
+          ...intent,
+          hasArtifactDelivery: true,
+          requiresCreatorReview: false,
+        },
+        code: "CREATOR_REVIEW_REQUIRED_FOR_ARTIFACT",
+      },
+      {
+        name: "public auto-settle artifact",
+        policy: {
+          allowedTools: ["agenc.completeTask"],
+          denyPublicAutoSettleArtifacts: true,
+        },
+        intent: {
+          ...intent,
+          hasArtifactDelivery: true,
+        },
+        code: "PUBLIC_AUTO_SETTLE_ARTIFACT_DENIED",
+      },
+      {
+        name: "unverified job spec claim",
+        policy: {
+          allowedTools: ["agenc.claimTask"],
+          requireJobSpecVerification: true,
+        },
+        intent: {
+          ...intent,
+          kind: "claim_task_with_job_spec",
+          jobSpecVerified: false,
+        },
+        code: "JOB_SPEC_VERIFICATION_REQUIRED",
+      },
+      {
+        name: "private zk completion",
+        policy: {
+          allowedTools: ["agenc.completeTask"],
+          denyPrivateZk: true,
+        },
+        intent: {
+          ...intent,
+          kind: "complete_task_private",
+        },
+        code: "PRIVATE_ZK_DENIED",
+      },
     ];
 
     for (const testCase of cases) {
       const decision = evaluateMarketplaceSignerPolicyForIntent(
         testCase.policy,
-        intent,
+        testCase.intent ?? intent,
       );
       expect(decision.allowed, testCase.name).toBe(false);
       expect(decision.code, testCase.name).toBe(testCase.code);

--- a/runtime/src/tools/agenc/signer-policy.ts
+++ b/runtime/src/tools/agenc/signer-policy.ts
@@ -1,4 +1,9 @@
 import type { PublicKey } from "@solana/web3.js";
+import {
+  evaluateMarketplaceSignerPolicyForIntent as evaluateAgentKitMarketplaceSignerPolicyForIntent,
+  type MarketplaceSignerPolicy as AgentKitMarketplaceSignerPolicy,
+  type MarketplaceTransactionIntent as AgentKitMarketplaceTransactionIntent,
+} from "agenc-marketplace-agent-kit/policy";
 
 import type { MarketplaceTransactionIntent } from "../../task/transaction-intent.js";
 import type { Tool, ToolResult } from "../types.js";
@@ -41,6 +46,20 @@ export interface MarketplaceSignerPolicy {
     readonly isSigner?: boolean;
     readonly isWritable?: boolean;
   }[];
+  /** Restrict task creation/completion to canary-safe task types, e.g. Exclusive. */
+  readonly allowedTaskTypes?: readonly string[];
+  /** Restrict validation modes, e.g. CreatorReview only for reviewed-public canary. */
+  readonly allowedValidationModes?: readonly string[];
+  /** Require artifact delivery intents to use CreatorReview/manual validation. */
+  readonly requireCreatorReviewForArtifacts?: boolean;
+  /** Require claim intents to prove verified job-spec metadata. */
+  readonly requireJobSpecVerification?: boolean;
+  /** Deny Private ZK completion intents by policy. */
+  readonly denyPrivateZk?: boolean;
+  /** Deny SPL/token reward intents by policy. */
+  readonly denyTokenRewards?: boolean;
+  /** Deny public auto-settle artifact completion intents by policy. */
+  readonly denyPublicAutoSettleArtifacts?: boolean;
 }
 
 export interface MarketplaceSignerPolicyEvaluation {
@@ -279,6 +298,41 @@ function toolNameForIntent(kind: MarketplaceTransactionIntent["kind"]): string {
   }
 }
 
+function toAgentKitMarketplaceIntent(
+  intent: MarketplaceTransactionIntent,
+): AgentKitMarketplaceTransactionIntent {
+  return {
+    kind: intent.kind as AgentKitMarketplaceTransactionIntent["kind"],
+    toolName: toolNameForIntent(intent.kind),
+    programId: intent.programId,
+    signer: intent.signer,
+    ...(intent.taskPda ? { taskPda: intent.taskPda } : {}),
+    ...(intent.taskId ? { taskId: intent.taskId } : {}),
+    ...(intent.claimPda ? { claimPda: intent.claimPda } : {}),
+    ...(intent.submissionPda ? { submissionPda: intent.submissionPda } : {}),
+    ...(intent.workerPda ? { workerPda: intent.workerPda } : {}),
+    ...(intent.disputePda ? { disputePda: intent.disputePda } : {}),
+    ...(intent.disputeId ? { disputeId: intent.disputeId } : {}),
+    ...(intent.jobSpecHash !== undefined ? { jobSpecHash: intent.jobSpecHash } : {}),
+    ...(intent.rewardLamports ? { rewardLamports: intent.rewardLamports } : {}),
+    rewardMint: intent.rewardMint ?? "SOL",
+    ...(intent.taskType !== undefined ? { taskType: intent.taskType } : {}),
+    ...(intent.validationMode !== undefined ? { validationMode: intent.validationMode } : {}),
+    ...(intent.artifactSha256 !== undefined ? { artifactSha256: intent.artifactSha256 } : {}),
+    ...(intent.constraintHash !== undefined ? { constraintHash: intent.constraintHash } : {}),
+    ...(intent.requiresCreatorReview !== undefined
+      ? { requiresCreatorReview: intent.requiresCreatorReview }
+      : {}),
+    ...(intent.jobSpecVerified !== undefined
+      ? { jobSpecVerified: intent.jobSpecVerified }
+      : {}),
+    ...(intent.hasArtifactDelivery !== undefined
+      ? { hasArtifactDelivery: intent.hasArtifactDelivery }
+      : {}),
+    accountMetas: intent.accountMetas,
+  };
+}
+
 export function evaluateMarketplaceSignerPolicyForIntent(
   policy: MarketplaceSignerPolicy,
   intent: MarketplaceTransactionIntent,
@@ -305,52 +359,12 @@ export function evaluateMarketplaceSignerPolicyForIntent(
     return baseDecision;
   }
 
-  for (const expected of policy.expectedAccountMetas ?? []) {
-    const actual = intent.accountMetas.find(
-      (account) => account.name === expected.name,
-    );
-    if (!actual) {
-      return {
-        allowed: false,
-        code: "ACCOUNT_META_MISSING",
-        reason: `Required account meta ${expected.name} is missing from transaction intent`,
-        metadata: { accountName: expected.name },
-      };
-    }
-    if (expected.pubkey && actual.pubkey !== expected.pubkey) {
-      return {
-        allowed: false,
-        code: "ACCOUNT_META_PUBKEY_MISMATCH",
-        reason: `Account meta ${expected.name} pubkey does not match signer policy`,
-        metadata: {
-          accountName: expected.name,
-          expectedPubkey: expected.pubkey,
-          actualPubkey: actual.pubkey,
-        },
-      };
-    }
-    if (
-      expected.isSigner !== undefined &&
-      actual.isSigner !== expected.isSigner
-    ) {
-      return {
-        allowed: false,
-        code: "ACCOUNT_META_SIGNER_MISMATCH",
-        reason: `Account meta ${expected.name} signer flag does not match signer policy`,
-        metadata: { accountName: expected.name },
-      };
-    }
-    if (
-      expected.isWritable !== undefined &&
-      actual.isWritable !== expected.isWritable
-    ) {
-      return {
-        allowed: false,
-        code: "ACCOUNT_META_WRITABLE_MISMATCH",
-        reason: `Account meta ${expected.name} writable flag does not match signer policy`,
-        metadata: { accountName: expected.name },
-      };
-    }
+  const agentKitDecision = evaluateAgentKitMarketplaceSignerPolicyForIntent(
+    policy as AgentKitMarketplaceSignerPolicy,
+    toAgentKitMarketplaceIntent(intent),
+  );
+  if (!agentKitDecision.allowed) {
+    return agentKitDecision;
   }
 
   return baseDecision;


### PR DESCRIPTION
## Summary
- Delegate final marketplace transaction-intent evaluation to `agenc-marketplace-agent-kit/policy` while preserving the existing `agenc.*` tool names and legacy pre-execution arg checks.
- Extend runtime marketplace intent/policy shapes with canary hardening fields for task type, validation mode, artifact review requirements, job-spec verification, token reward denial, private ZK denial, and public auto-settle artifact denial.
- Add runtime coverage for the new denial cases.

## Safety notes
- No npm publish.
- No new mutation tools or public surfaces.
- The private runtime package still does not add `agenc-marketplace-agent-kit` to its published package manifest; the kit remains a root devDependency tarball until publishing is approved.

## Validation
- `npm run typecheck --workspace=@tetsuo-ai/runtime`
- `npm run test --workspace=@tetsuo-ai/runtime -- --run src/tools/agenc/index.test.ts`
- `npm run check:private-kernel-distribution:local`
- `npm run build:private-kernel`
