### PR TITLE
Document marketplace agent kit integration guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ External builders should target:
 - `@tetsuo-ai/sdk`
 - `@tetsuo-ai/protocol`
 - `@tetsuo-ai/plugin-kit`
+- `agenc-marketplace-agent-kit` for framework-neutral marketplace agent
+  integrations and local-only MCP/CLI tooling while the public scoped npm
+  packages are being finalized.
 
 Implementation packages in this repo remain non-builder surfaces:
 
@@ -60,6 +63,11 @@ Implementation packages in this repo remain non-builder surfaces:
 - `@tetsuo-ai/mcp` - Private kernel MCP package; not a public extension target.
 - `@tetsuo-ai/docs-mcp` - Private kernel documentation package; not a supported public builder target.
 - `@tetsuo-ai/desktop-tool-contracts` - Private kernel contract package; not a public plugin surface.
+
+Marketplace agent integrations must not depend on `@tetsuo-ai/runtime` or
+`@tetsuo-ai/mcp`. The private runtime may wrap public marketplace helper
+packages internally, but external agent frameworks should use the public
+marketplace agent kit, protocol, and SDK surfaces instead.
 
 ### Public Product Install Surface
 

--- a/runtime/docs/MODULE_MAP.md
+++ b/runtime/docs/MODULE_MAP.md
@@ -53,7 +53,10 @@ This file is the navigation guide for `runtime/src/`.
 
 - `dispute/` - dispute operations
 - `governance/` - governance support
-- `marketplace/` - protocol marketplace serialization helpers used by the operator CLI, TUI, and web transport
+- `marketplace/` - protocol marketplace serialization helpers used by the
+  operator CLI, TUI, and web transport. Artifact helpers are wrapped from the
+  public marketplace agent kit; job-spec storage still owns private task-link
+  and verified-attestation behavior in core.
 - `reputation/` - reputation mechanics
 - `social/` - social/feed surfaces
 

--- a/runtime/docs/marketplace-transaction-intents.md
+++ b/runtime/docs/marketplace-transaction-intents.md
@@ -3,6 +3,12 @@
 Marketplace signer policy should inspect an intent preview before any signer
 boundary calls `.rpc()`.
 
+The private runtime keeps legacy `agenc.*` tool names for compatibility, but
+the final intent-level policy evaluation delegates to the public
+`agenc-marketplace-agent-kit/policy` evaluator. That keeps core aligned with
+the framework-neutral Codex/Claude/Hermes marketplace agent kit without making
+external integrations depend on `@tetsuo-ai/runtime` or the private MCP package.
+
 The intent object is normalized so UI, SDK, daemon policy, and CLI bridges can
 reason about the same data:
 
@@ -14,6 +20,15 @@ reason about the same data:
 - `taskPda` / `taskId`: task identity when known.
 - `jobSpecHash`: off-chain job specification hash when the flow is bound to one.
 - `rewardLamports` / `rewardMint`: payout amount and mint.
+- `taskType`: task type when known; canary policy should restrict this to
+  `Exclusive`.
+- `validationMode`: validation mode when known; canary policy should restrict
+  this to `CreatorReview`.
+- `hasArtifactDelivery` / `artifactSha256`: artifact commitment metadata when
+  an artifact rail is used.
+- `requiresCreatorReview`: whether the final intent is routed through
+  CreatorReview/manual validation.
+- `jobSpecVerified`: whether the claim path used verified job-spec metadata.
 - `constraintHash`: private ZK circuit/constraint hash when used.
 - `accountMetas`: named accounts with pubkey, signer flag, and writable flag.
 
@@ -24,9 +39,27 @@ Use `buildCreateTaskIntent()` before create-task submission and
 
 Then call `evaluateMarketplaceSignerPolicyForIntent(policy, intent)`. A policy
 can reject wrong program IDs, task PDAs, job spec hashes, constraint hashes,
-reward caps, reward mints, or mutated account metas before the signer is used.
+reward caps, reward mints, task types, validation modes, public auto-settle
+artifact attempts, missing job-spec verification, private ZK completion, or
+mutated account metas before the signer is used.
+
+For the reviewed-public canary, signer policies should include:
+
+- `allowedTaskTypes: ["Exclusive"]`
+- `allowedValidationModes: ["CreatorReview"]`
+- `allowedRewardMints: ["SOL"]`
+- `maxRewardLamports: "50000000"`
+- `requireCreatorReviewForArtifacts: true`
+- `requireJobSpecVerification: true`
+- `denyPrivateZk: true`
+- `denyTokenRewards: true`
+- `denyPublicAutoSettleArtifacts: true`
 
 The CLI also honors `AGENC_MARKETPLACE_SIGNER_POLICY` as a JSON policy envelope
 for `market tasks create`, `market tasks claim`, and `market tasks complete`.
 Storefront bridges should set this env var per order instead of relying on a
 long-lived unrestricted runtime signer.
+
+Do not expose signer-backed marketplace tools through a remote public HTTP MCP
+server. Signer mode is local-only by default; use low-balance hot wallets and
+policy allowlists as the fund-protection boundary.


### PR DESCRIPTION
## Summary
- Add `agenc-marketplace-agent-kit` to the public builder entry-point guidance while scoped npm packages are finalized.
- Document that external marketplace agent integrations must not depend on private `@tetsuo-ai/runtime` or `@tetsuo-ai/mcp` surfaces.
- Update marketplace transaction-intent docs with the public kit policy bridge and the canary hardening fields.
- Note that artifact helpers now wrap the public kit while job-spec task-link/verified-attestation behavior remains core-owned.

## Safety notes
- Documentation only.
- No npm publish.
- No runtime/package manifest changes.

## Validation
- `git diff --check`
