### PR TITLE
Update marketplace agent kit policy integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "devDependencies": {
     "@coral-xyz/anchor": "^0.32.1",
     "@solana/web3.js": "^1.98.4",
-    "agenc-marketplace-agent-kit": "https://github.com/tetsuo-ai/agenc-marketplace-agent-kit/archive/421bda6417bfe2c68631e1ec7444c787931ee349.tar.gz",
+    "agenc-marketplace-agent-kit": "https://github.com/tetsuo-ai/agenc-marketplace-agent-kit/archive/9bdba655b06d31cb33d6fc7d9b62a611b1db2cb2.tar.gz",
     "bn.js": "^5.2.3",
     "typescript": "^5.0.0",
     "vitest": "^1.0.0"

--- a/runtime/docs/marketplace-transaction-intents.md
+++ b/runtime/docs/marketplace-transaction-intents.md
@@ -43,6 +43,11 @@ reward caps, reward mints, task types, validation modes, public auto-settle
 artifact attempts, missing job-spec verification, private ZK completion, or
 mutated account metas before the signer is used.
 
+When `expectedAccountMetas` is supplied, the delegated public agent-kit policy
+uses strict account-meta matching by default. That means unexpected extra
+writable or signer accounts are rejected unless `strictAccountMetas: false` is
+set deliberately for a narrow preview-only case.
+
 For the reviewed-public canary, signer policies should include:
 
 - `allowedTaskTypes: ["Exclusive"]`

--- a/runtime/src/tools/agenc/index.test.ts
+++ b/runtime/src/tools/agenc/index.test.ts
@@ -312,6 +312,58 @@ describe("AgenC protocol tool factory", () => {
         code: "ACCOUNT_META_PUBKEY_MISMATCH",
       },
       {
+        name: "unexpected account meta",
+        policy: {
+          allowedTools: ["agenc.completeTask"],
+          expectedAccountMetas: [
+            {
+              name: "task",
+              pubkey: "Task111111111111111111111111111111111111111",
+              isWritable: true,
+            },
+          ],
+        },
+        intent: {
+          ...intent,
+          accountMetas: [
+            ...intent.accountMetas,
+            {
+              name: "unexpectedWritable",
+              pubkey: "Unexpected1111111111111111111111111111111111",
+              isSigner: false,
+              isWritable: true,
+            },
+          ],
+        },
+        code: "ACCOUNT_META_UNEXPECTED",
+      },
+      {
+        name: "unexpected signer account meta",
+        policy: {
+          allowedTools: ["agenc.completeTask"],
+          expectedAccountMetas: [
+            {
+              name: "task",
+              pubkey: "Task111111111111111111111111111111111111111",
+              isWritable: true,
+            },
+          ],
+        },
+        intent: {
+          ...intent,
+          accountMetas: [
+            ...intent.accountMetas,
+            {
+              name: "unexpectedSigner",
+              pubkey: "UnexpectedSigner111111111111111111111111111",
+              isSigner: true,
+              isWritable: false,
+            },
+          ],
+        },
+        code: "ACCOUNT_META_UNEXPECTED",
+      },
+      {
         name: "token reward denied",
         policy: {
           allowedTools: ["agenc.completeTask"],

--- a/runtime/src/tools/agenc/signer-policy.ts
+++ b/runtime/src/tools/agenc/signer-policy.ts
@@ -46,6 +46,12 @@ export interface MarketplaceSignerPolicy {
     readonly isSigner?: boolean;
     readonly isWritable?: boolean;
   }[];
+  /**
+   * When expectedAccountMetas is supplied, require the final intent account-meta
+   * name set to match exactly. Delegated to agenc-marketplace-agent-kit/policy
+   * and defaults to true there.
+   */
+  readonly strictAccountMetas?: boolean;
   /** Restrict task creation/completion to canary-safe task types, e.g. Exclusive. */
   readonly allowedTaskTypes?: readonly string[];
   /** Restrict validation modes, e.g. CreatorReview only for reviewed-public canary. */


### PR DESCRIPTION
## Summary
- pin agenc-core's marketplace agent kit helper dependency to audited commit 9bdba655
- expose strictAccountMetas on the runtime marketplace signer policy shape
- add runtime coverage that delegated agent-kit policy denies unexpected writable/signer account metas
- document strict account-meta behavior in marketplace transaction intent docs

## Verification
- npm run test --workspace=@tetsuo-ai/runtime -- src/tools/agenc/index.test.ts src/marketplace/artifact-delivery.test.ts src/task/transaction-intent.test.ts
- npm run typecheck --workspace=@tetsuo-ai/runtime
- npm run validate:runtime

No npm publish performed.