### PR TITLE
fix(tui): wrap long prompt input tokens

### DIFF
--- a/runtime/scripts/check-tui-e2e/scenarios/88-long-token-input-wrap.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/88-long-token-input-wrap.mjs
@@ -1,0 +1,30 @@
+export const meta = {
+  description: "long unbroken prompt input wraps inside the prompt box",
+  args: ["--yolo"],
+  useTempHome: true,
+  timeoutMs: 30_000,
+};
+
+export default async function run(session) {
+  await session.start();
+  await session.waitForPrompt({ idleWindow: 800, timeout: 10_000 });
+
+  const input = "a".repeat(260);
+  await session.type(input, { perCharMs: 1 });
+  await session.waitForIdle({ idleWindow: 800, timeout: 10_000 });
+
+  const inputLines = session.latestFrame
+    .split("\n")
+    .filter((line) => /a{10}/.test(line));
+
+  if (inputLines.length < 2) {
+    throw new Error(
+      `expected long token input to wrap across prompt lines, got ${inputLines.length}: ${JSON.stringify(inputLines)}`,
+    );
+  }
+
+  const truncatedLine = inputLines.find((line) => line.includes("\u2026"));
+  if (truncatedLine !== undefined) {
+    throw new Error(`long token input was truncated: ${truncatedLine}`);
+  }
+}

--- a/runtime/src/tui/components/PromptInput/utils.ts
+++ b/runtime/src/tui/components/PromptInput/utils.ts
@@ -35,7 +35,11 @@ export function getNewlineInstructions(): string {
 }
 
 export function clampPromptTextInputColumns(columns: number): number {
-  return Math.max(0, columns - 3)
+  // Bordered prompt layout consumes: left/right border (2), horizontal
+  // padding (2), and the prompt glyph cell (1). TextCursor subtracts one
+  // more display column internally for the cursor, so return the editable
+  // area plus that cursor column.
+  return Math.max(0, columns - 5)
 }
 
 export function pasteReferenceLineThreshold(rows: number): number {

--- a/runtime/tests/tui/components/PromptInput/utils.test.ts
+++ b/runtime/tests/tui/components/PromptInput/utils.test.ts
@@ -53,9 +53,9 @@ describe('PromptInput vim mode config', () => {
 describe('PromptInput terminal geometry helpers', () => {
   test('clamps input columns to a valid width', () => {
     expect(clampPromptTextInputColumns(0)).toBe(0)
-    expect(clampPromptTextInputColumns(2)).toBe(0)
-    expect(clampPromptTextInputColumns(3)).toBe(0)
-    expect(clampPromptTextInputColumns(80)).toBe(77)
+    expect(clampPromptTextInputColumns(4)).toBe(0)
+    expect(clampPromptTextInputColumns(5)).toBe(0)
+    expect(clampPromptTextInputColumns(80)).toBe(75)
   })
 
   test('keeps paste threshold usable on tiny terminal heights', () => {


### PR DESCRIPTION
## Summary
- Fix prompt input column calculation so long unbroken text wraps inside the bordered input box instead of truncating at the right edge.
- Add a PTY e2e regression that types a long no-space token and fails if it renders as a single truncated line.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/components/PromptInput/utils.test.ts
- npm --workspace=@tetsuo-ai/runtime run build
- npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 88-long-token-input-wrap
- npm --workspace=@tetsuo-ai/runtime run check:tui-runtime-startup
- node ~/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core --fast