### PR TITLE
fix(tui): sync subagent status lifecycle

### DIFF
--- a/runtime/scripts/check-tui-e2e/scenarios/23-slash-agents.mjs
+++ b/runtime/scripts/check-tui-e2e/scenarios/23-slash-agents.mjs
@@ -12,7 +12,7 @@ export default async function (session) {
   await session.start();
   await session.waitForPrompt({ timeout: 15_000 });
   await session.submitSlashCommand("/agents");
-  await session.waitFor(/Agents/, { timeout: 15_000 });
+  await session.waitFor(/AGENTS[\s\S]*registered/, { timeout: 15_000 });
   await session.waitForIdle({ timeout: 15_000 });
 
   if (/▶/u.test(session.text)) {

--- a/runtime/src/agents/control.ts
+++ b/runtime/src/agents/control.ts
@@ -766,6 +766,10 @@ export class AgentControl {
     await this.shutdown(threadId, "closed_by_tool");
   }
 
+  async markThreadSpawnEdgeClosed(threadId: ThreadId): Promise<void> {
+    await this.setThreadSpawnEdgeStatus(threadId, "closed");
+  }
+
   interruptAgent(threadId: ThreadId): void {
     this.interrupt(threadId, "interrupt");
   }

--- a/runtime/src/agents/delegate.ts
+++ b/runtime/src/agents/delegate.ts
@@ -239,6 +239,11 @@ export async function delegate(
       try {
         return await execute(thread);
       } finally {
+        await markAsyncThreadSpawnEdgeClosed({
+          control: opts.control,
+          thread,
+          parent: opts.parent,
+        });
         await teardown({
           thread,
           control: opts.control,
@@ -274,6 +279,31 @@ export async function delegate(
     result,
     thread,
   };
+}
+
+async function markAsyncThreadSpawnEdgeClosed(opts: {
+  readonly control: AgentControl;
+  readonly thread: AgentThread;
+  readonly parent: Session;
+}): Promise<void> {
+  const markClosed = (
+    opts.control as {
+      readonly markThreadSpawnEdgeClosed?: (
+        threadId: string,
+      ) => Promise<void> | void;
+    }
+  ).markThreadSpawnEdgeClosed;
+  if (typeof markClosed !== "function") return;
+  try {
+    await markClosed.call(opts.control, opts.thread.threadId);
+  } catch (err) {
+    emitWarning(
+      opts.parent.eventLog,
+      opts.parent.nextInternalSubId(),
+      "thread_spawn_edge_close_failed",
+      err instanceof Error ? err.message : String(err),
+    );
+  }
 }
 
 async function runToCompletion(

--- a/runtime/src/agents/v2/spawn.ts
+++ b/runtime/src/agents/v2/spawn.ts
@@ -15,6 +15,7 @@ import {
   BackgroundTaskError,
   backgroundTaskLifecycle,
   registerAgentThreadTask,
+  type BackgroundTaskSnapshot,
 } from "../../tasks/index.js";
 import { syncBackgroundTaskSnapshotToAppState } from "../../tasks/app-state-bridge.js";
 import {
@@ -415,6 +416,29 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
     if (thread === undefined) {
       return json({ error: "spawn_agent did not return an agent thread" }, true);
     }
+    const live = thread.live;
+    const emitTaskStatus = (snapshot: BackgroundTaskSnapshot): void => {
+      if (snapshot.status === "pending") return;
+      emit(session, {
+        type: "collab_agent_status",
+        payload: {
+          callId,
+          senderThreadId: current.threadId,
+          threadId: live.agentId,
+          agentPath: live.agentPath,
+          agentNickname: live.nickname,
+          agentRole: live.role.name,
+          agentRoleDisplayName: formatAgentRoleLabel(live.role.name),
+          prompt,
+          model: model ?? session.sessionConfiguration.collaborationMode.model,
+          reasoningEffort:
+            reasoningEffort ??
+            session.sessionConfiguration.collaborationMode.reasoningEffort,
+          status: snapshot.status,
+          ...(snapshot.error !== undefined ? { error: snapshot.error } : {}),
+        },
+      });
+    };
     try {
       registerAgentThreadTask(backgroundTaskLifecycle, thread, {
         toolUseId: callId,
@@ -430,6 +454,7 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
             ).appStateBridge,
             snapshot,
           );
+          emitTaskStatus(snapshot);
         },
       });
     } catch (error) {
@@ -440,7 +465,6 @@ export function createSpawnAgentTool(opts: MultiAgentV2Options): Tool {
         throw error;
       }
     }
-    const live = thread.live;
     emit(session, {
       type: "collab_agent_spawn_end",
       payload: {

--- a/runtime/src/app-server/background-agent-runner.ts
+++ b/runtime/src/app-server/background-agent-runner.ts
@@ -2697,6 +2697,7 @@ function toolRequestInputFromPayload(
 const COLLAB_AGENT_SESSION_EVENT_TYPES: ReadonlySet<string> = new Set([
   "collab_agent_spawn_begin",
   "collab_agent_spawn_end",
+  "collab_agent_status",
   "collab_agent_interaction_begin",
   "collab_agent_interaction_end",
   "collab_waiting_begin",

--- a/runtime/src/session/event-log.ts
+++ b/runtime/src/session/event-log.ts
@@ -382,6 +382,28 @@ export interface CollabAgentSpawnEndEvent {
   readonly status: AgentStatus;
 }
 
+export type CollabAgentTaskStatus =
+  | "pending"
+  | "running"
+  | "completed"
+  | "failed"
+  | "killed";
+
+export interface CollabAgentStatusEvent {
+  readonly callId: string;
+  readonly senderThreadId: string;
+  readonly threadId: string;
+  readonly agentPath?: string;
+  readonly agentNickname?: string;
+  readonly agentRole?: string;
+  readonly agentRoleDisplayName?: string;
+  readonly prompt?: string;
+  readonly model?: string;
+  readonly reasoningEffort?: string;
+  readonly status: AgentStatus | CollabAgentTaskStatus;
+  readonly error?: string;
+}
+
 export interface CollabAgentInteractionBeginEvent {
   readonly callId: string;
   readonly senderThreadId: string;
@@ -697,6 +719,10 @@ export type EventMsg =
       readonly payload: CollabAgentSpawnEndEvent;
     }
   | {
+      readonly type: "collab_agent_status";
+      readonly payload: CollabAgentStatusEvent;
+    }
+  | {
       readonly type: "collab_agent_interaction_begin";
       readonly payload: CollabAgentInteractionBeginEvent;
     }
@@ -865,6 +891,7 @@ export const KNOWN_EVENT_TYPES = Object.freeze(
     "protocol_stake",
     "collab_agent_spawn_begin",
     "collab_agent_spawn_end",
+    "collab_agent_status",
     "collab_agent_interaction_begin",
     "collab_agent_interaction_end",
     "collab_waiting_begin",

--- a/runtime/src/tui/components/App.tsx
+++ b/runtime/src/tui/components/App.tsx
@@ -1005,11 +1005,16 @@ function startupModel(props: AgenCTuiProps): string | null {
   return props.model ?? props.session.sessionConfiguration?.collaborationMode?.model ?? null;
 }
 function initialState(props: AgenCTuiProps): any {
+  const agentDefinitions = listAgentRoleDefinitions();
   return {
     ...getDefaultAppState(),
     mainLoopModel: startupModel(props),
     mainLoopModelForSession: startupModel(props),
-    toolPermissionContext: initialPermissionContext(props)
+    toolPermissionContext: initialPermissionContext(props),
+    agentDefinitions: {
+      activeAgents: [...agentDefinitions],
+      allAgents: [...agentDefinitions],
+    }
   };
 }
 function useSyncedPermissionContext(session) {

--- a/runtime/src/tui/state/collabAgentTaskSync.ts
+++ b/runtime/src/tui/state/collabAgentTaskSync.ts
@@ -1,5 +1,8 @@
 import type { LocalAgentTaskState, TaskState, TaskStatus } from "../../tasks/types.js";
 
+// Inlined from framework.ts; importing it creates a cycle through task UI.
+const PANEL_GRACE_MS = 30_000;
+
 export type SetAppStateWithTasks = (
   updater: (prev: { readonly tasks?: Record<string, TaskState> }) => unknown,
 ) => void;
@@ -131,6 +134,28 @@ function patchFromEvent(event: unknown): CollabAgentTaskPatch | null {
     };
   }
 
+  if (type === "collab_agent_status") {
+    const id = stringField(payload, "threadId");
+    if (!id) return null;
+    const status = collabStatusToTaskStatus(payload.status);
+    return {
+      id,
+      status,
+      requiresExisting: true,
+      title:
+        stringField(payload, "agentNickname") ??
+        stringField(payload, "agentPath"),
+      prompt: stringField(payload, "prompt"),
+      role:
+        stringField(payload, "agentRoleDisplayName") ??
+        stringField(payload, "agentRole"),
+      model: stringField(payload, "model"),
+      error:
+        collabStatusError(payload.status) ??
+        (status === "failed" ? stringField(payload, "error") : undefined),
+    };
+  }
+
   if (
     type === "collab_agent_interaction_begin" ||
     type === "collab_agent_interaction_end"
@@ -210,6 +235,10 @@ function applyPatch(
     patch.status === "completed" ||
     patch.status === "failed" ||
     patch.status === "killed";
+  const evictAfter =
+    ended && previousAgent?.retain !== true
+      ? previousAgent?.evictAfter ?? now + PANEL_GRACE_MS
+      : previousAgent?.evictAfter;
   return {
     id: patch.id,
     type: "local_agent",
@@ -218,7 +247,7 @@ function applyPatch(
     startTime: previousAgent?.startTime ?? now,
     outputFile: previousAgent?.outputFile ?? outputUri(patch.id),
     outputOffset: previousAgent?.outputOffset ?? 0,
-    notified: previousAgent?.notified ?? false,
+    notified: ended ? true : previousAgent?.notified ?? false,
     agentId: patch.id,
     prompt,
     agentType: patch.role ?? previousAgent?.agentType ?? "agent",
@@ -246,9 +275,7 @@ function applyPatch(
       ? { unregisterCleanup: previousAgent.unregisterCleanup }
       : {}),
     ...(previousAgent?.result !== undefined ? { result: previousAgent.result } : {}),
-    ...(previousAgent?.evictAfter !== undefined
-      ? { evictAfter: previousAgent.evictAfter }
-      : {}),
+    ...(evictAfter !== undefined ? { evictAfter } : {}),
   };
 }
 

--- a/runtime/tests/agents/delegate.test.ts
+++ b/runtime/tests/agents/delegate.test.ts
@@ -85,6 +85,7 @@ describe("delegate lifecycle recovery", () => {
     const control = {
       spawn: vi.fn(async () => live),
       shutdown: vi.fn(async () => {}),
+      markThreadSpawnEdgeClosed: vi.fn(async () => {}),
       resumeAgentFromRollout: vi.fn(),
     };
     mockRunAgent.mockImplementationOnce(() =>
@@ -110,6 +111,7 @@ describe("delegate lifecycle recovery", () => {
     }
     await outcome.thread.join();
     expect(control.shutdown).not.toHaveBeenCalled();
+    expect(control.markThreadSpawnEdgeClosed).toHaveBeenCalledWith("thread-bg");
   });
 
   it("records summary cache params and tool transcript events from async runs", async () => {

--- a/runtime/tests/app-server/background-agent-runner.contract.test.ts
+++ b/runtime/tests/app-server/background-agent-runner.contract.test.ts
@@ -211,6 +211,32 @@ describe("AgenC delegate background-agent runner", () => {
         },
       },
     });
+
+    expect(
+      daemonEventFromUnboundSessionEvent({
+        id: "agent-status",
+        msg: {
+          type: "collab_agent_status",
+          payload: {
+            callId: "call-agent",
+            senderThreadId: "root",
+            threadId: "thread-agent",
+            agentNickname: "Librarian",
+            status: "completed",
+          },
+        },
+      }),
+    ).toEqual({
+      id: "agent-status",
+      type: "collab_agent_status",
+      payload: {
+        callId: "call-agent",
+        senderThreadId: "root",
+        threadId: "thread-agent",
+        agentNickname: "Librarian",
+        status: "completed",
+      },
+    });
   });
 
   it("bridges tool_progress session events for live daemon snapshots", () => {

--- a/runtime/tests/bin/model-facing-tools.test.ts
+++ b/runtime/tests/bin/model-facing-tools.test.ts
@@ -2233,6 +2233,8 @@ describe("model-facing tools", () => {
 
   it("mirrors spawned V2 agents into AppState tasks for TUI spinners and task UI", async () => {
     const session = fakeSession();
+    const emit = vi.fn();
+    (session as unknown as { emit: typeof emit }).emit = emit;
     let appState: unknown = { tasks: {} };
     (
       session as Session & {
@@ -2292,6 +2294,26 @@ describe("model-facing tools", () => {
       isBackgrounded: true,
     });
     expect(isBackgroundTask(task)).toBe(true);
+    expect(
+      emit.mock.calls.map((call: readonly unknown[]) => {
+        const envelope = call[0] as { msg?: { type?: string } } | undefined;
+        return envelope?.msg?.type;
+      }),
+    ).toContain("collab_agent_status");
+    const statusEnvelope = emit.mock.calls.find((call: readonly unknown[]) => {
+      const envelope = call[0] as { msg?: { type?: string } } | undefined;
+      return envelope?.msg?.type === "collab_agent_status";
+    })?.[0] as
+      | {
+          msg?: {
+            payload?: { threadId?: string; status?: string };
+          };
+        }
+      | undefined;
+    expect(statusEnvelope?.msg?.payload).toMatchObject({
+      threadId: "thread-visible-1",
+      status: "running",
+    });
   });
 
   it("launches spawn_agent with a workspace markdown role from the canonical role registry", async () => {

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -342,7 +342,29 @@ vi.mock("../../commands.js", () => ({
 }));
 
 vi.mock("../../agents/role-definitions.js", () => ({
-  listAgentRoleDefinitions: () => [],
+  listAgentRoleDefinitions: () => [
+    {
+      agentType: "default",
+      whenToUse: "Default agent.",
+      source: "built-in",
+      baseDir: "built-in",
+      getSystemPrompt: () => "",
+    },
+    {
+      agentType: "explorer",
+      whenToUse: "Explore code.",
+      source: "built-in",
+      baseDir: "built-in",
+      getSystemPrompt: () => "",
+    },
+    {
+      agentType: "worker",
+      whenToUse: "Execute work.",
+      source: "built-in",
+      baseDir: "built-in",
+      getSystemPrompt: () => "",
+    },
+  ],
 }));
 
 vi.mock("../keybindings/KeybindingProviderSetup.js", async () => {
@@ -802,6 +824,31 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
         setVimMode: expect.any(Function),
       }),
     );
+  });
+
+  test("hydrates the TUI app state with registered agent roles", async () => {
+    const { AgenCTuiApp } = await import("./App.js");
+    providerProbe.appStateProps.length = 0;
+
+    await renderApp(
+      <AgenCTuiApp
+        session={createSession()}
+        configStore={{}}
+        isInteractive={false}
+      />,
+    );
+
+    const initial = providerProbe.appStateProps.at(-1)?.initialState as {
+      agentDefinitions?: {
+        activeAgents?: Array<{ agentType?: string }>;
+        allAgents?: Array<{ agentType?: string }>;
+      };
+    };
+    const active = initial.agentDefinitions?.activeAgents?.map(agent => agent.agentType);
+    const all = initial.agentDefinitions?.allAgents?.map(agent => agent.agentType);
+
+    expect(active).toEqual(expect.arrayContaining(["default", "explorer", "worker"]));
+    expect(all).toEqual(expect.arrayContaining(["default", "explorer", "worker"]));
   });
 
   test("prioritizes a pending permission overlay over an elicitation overlay", async () => {

--- a/runtime/tests/tui/state/collabAgentTaskSync.test.ts
+++ b/runtime/tests/tui/state/collabAgentTaskSync.test.ts
@@ -121,6 +121,92 @@ describe("syncCollabAgentEventToAppState", () => {
     });
   });
 
+  it("updates spawned agent tasks from live collab status events", () => {
+    const spawned = applyEvent(baseState(), {
+      type: "collab_agent_spawn_end",
+      payload: {
+        newThreadId: "agent_1",
+        newAgentNickname: "Librarian",
+        newAgentRoleDisplayName: "Default",
+        prompt: "inspect the queue",
+        status: { status: "pending_init" },
+      },
+    });
+
+    const running = applyEvent(spawned, {
+      type: "collab_agent_status",
+      payload: {
+        callId: "call-agent",
+        senderThreadId: "root",
+        threadId: "agent_1",
+        agentNickname: "Librarian",
+        agentRoleDisplayName: "Default",
+        status: "running",
+      },
+    });
+
+    const completed = applyEvent(running, {
+      type: "collab_agent_status",
+      payload: {
+        callId: "call-agent",
+        senderThreadId: "root",
+        threadId: "agent_1",
+        status: "completed",
+      },
+    });
+
+    expect(running.tasks.agent_1).toMatchObject({
+      status: "running",
+      description: "Librarian",
+      agentType: "Default",
+    });
+    expect(completed.tasks.agent_1).toMatchObject({
+      status: "completed",
+      description: "Librarian",
+      endTime: 1234,
+      evictAfter: 31234,
+      notified: true,
+    });
+  });
+
+  it("keeps terminal retained agent tasks visible until the view releases them", () => {
+    const spawned = applyEvent(baseState(), {
+      type: "collab_agent_spawn_end",
+      payload: {
+        newThreadId: "agent_1",
+        newAgentNickname: "Librarian",
+        status: { status: "running" },
+      },
+    });
+    const retained = {
+      ...spawned,
+      tasks: {
+        ...spawned.tasks,
+        agent_1: {
+          ...spawned.tasks.agent_1!,
+          retain: true,
+        },
+      },
+    };
+
+    const completed = applyEvent(retained, {
+      type: "collab_agent_status",
+      payload: {
+        callId: "call-agent",
+        senderThreadId: "root",
+        threadId: "agent_1",
+        status: "completed",
+      },
+    });
+
+    expect(completed.tasks.agent_1).toMatchObject({
+      status: "completed",
+      retain: true,
+      notified: true,
+    });
+    expect(completed.tasks.agent_1).not.toHaveProperty("evictAfter");
+  });
+
   it("updates spawned agents from collab wait completion summaries", () => {
     const firstSpawn = applyEvent(baseState(), {
       type: "collab_agent_spawn_end",
@@ -163,12 +249,16 @@ describe("syncCollabAgentEventToAppState", () => {
       status: "completed",
       description: "ChromeRider",
       endTime: 1234,
+      evictAfter: 31234,
+      notified: true,
     });
     expect(completed.tasks.agent_2).toMatchObject({
       status: "failed",
       description: "Quickhack",
       error: "review failed",
       endTime: 1234,
+      evictAfter: 31234,
+      notified: true,
     });
     expect(completed.tasks.missing).toBeUndefined();
   });
@@ -206,6 +296,21 @@ describe("syncCollabAgentEventToAppState", () => {
         turnId: "turn_1",
         status: "idle",
         runStatus: "completed",
+      },
+    });
+
+    expect(next).toBe(state);
+  });
+
+  it("does not invent tasks from live collab status for unknown agent ids", () => {
+    const state = baseState();
+    const next = applyEvent(state, {
+      type: "collab_agent_status",
+      payload: {
+        callId: "call-agent",
+        senderThreadId: "root",
+        threadId: "agent_1",
+        status: "completed",
       },
     });
 


### PR DESCRIPTION
## Summary
- hydrate the TUI app state with registered agent roles so `/agents` shows the available roles
- emit live `collab_agent_status` events from spawned agents and bridge them through the daemon session event stream
- sync running/completed/failed agent states into the TUI task panel and close durable async spawn edges after completion
- add terminal eviction handling so completed agent rows disappear after the existing panel grace window unless actively retained

## Test plan
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/state/collabAgentTaskSync.test.ts tests/tui/components/CoordinatorAgentStatus.test.ts tests/tui/state/teammateViewHelpers.test.ts`
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/bin/model-facing-tools.test.ts tests/tui/components/App.render.test.tsx tests/app-server/background-agent-runner.contract.test.ts tests/agents/delegate.test.ts`
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/agents tests/tool-registry.test.ts tests/session/agenc-delegate.test.ts tests/session/agent-task-lifecycle.test.ts tests/app-server/agent-cli.contract.test.ts tests/app-server/agent-lifecycle.contract.test.ts`
- `npm --workspace=@tetsuo-ai/runtime run build`
- `npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 03-subagent-completion --filter 23-slash-agents`
- `npm --workspace=@tetsuo-ai/runtime run check:tui-e2e -- --filter 23-slash-agents`
- `node ~/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`