### PR TITLE
fix(tui): make agent panel transient

### DIFF
--- a/runtime/src/tui/components/CoordinatorAgentStatus.tsx
+++ b/runtime/src/tui/components/CoordinatorAgentStatus.tsx
@@ -2,9 +2,9 @@ import { c as _c } from "react-compiler-runtime";
 /**
  * CoordinatorTaskPanel — Steerable list of background agents.
  *
- * Renders below the prompt input footer whenever local_agent tasks exist.
- * Visibility is driven by evictAfter: undefined (running/retained) shows
- * always; a timestamp shows until passed. Enter to view/steer, x to dismiss.
+ * Renders below the prompt input footer when agent tasks appear, when the
+ * tasks footer is selected, or while a task is being viewed. Enter to
+ * view/steer, x to dismiss.
  */
 
 import figures from 'figures';
@@ -19,6 +19,8 @@ import { isPanelAgentTask, type LocalAgentTaskState } from '../../tasks/LocalAge
 import { formatDuration, formatNumber } from '../../utils/format';
 import { evictTerminalTask } from '../../utils/task/framework';
 import { isTerminalStatus } from './tasks/taskStatusUtils';
+
+export const AGENT_PANEL_TRANSIENT_MS = 5_000;
 
 /**
  * Which panel-managed tasks currently have a visible row.
@@ -37,19 +39,34 @@ export function getCoordinatorTaskCount(tasks: AppState['tasks']): number {
   return visibleTasks.length === 0 ? 0 : visibleTasks.length + 1;
 }
 
+export function getCoordinatorTaskPanelVisibilityKey(
+  visibleTasks: readonly LocalAgentTaskState[],
+): string {
+  return visibleTasks
+    .map(task => `${task.id}:${task.status}:${task.startTime}:${task.endTime ?? ''}`)
+    .join('|');
+}
+
 export function shouldShowCoordinatorTaskPanel({
   visibleTasks,
   footerSelection,
   viewingAgentTaskId,
+  transientVisibleUntil,
+  now,
 }: {
   visibleTasks: readonly LocalAgentTaskState[];
   footerSelection: AppState['footerSelection'];
   viewingAgentTaskId?: string;
+  transientVisibleUntil: number;
+  now: number;
 }): boolean {
   if (visibleTasks.length === 0) {
     return false;
   }
   if (footerSelection === 'tasks') {
+    return true;
+  }
+  if (now < transientVisibleUntil) {
     return true;
   }
   return viewingAgentTaskId !== undefined && visibleTasks.some(task => task.id === viewingAgentTaskId);
@@ -66,6 +83,18 @@ export function CoordinatorTaskPanel(): React.ReactNode {
   const setAppState = useSetAppState();
   const visibleTasks = getVisibleAgentTasks(tasks);
   const hasTasks = Object.values(tasks).some(isPanelAgentTask);
+  const visibilityKey = getCoordinatorTaskPanelVisibilityKey(visibleTasks);
+  const visibilityKeyRef = React.useRef('');
+  const transientVisibleUntilRef = React.useRef(0);
+  const now = Date.now();
+
+  if (visibleTasks.length === 0) {
+    visibilityKeyRef.current = '';
+    transientVisibleUntilRef.current = 0;
+  } else if (visibilityKeyRef.current !== visibilityKey) {
+    visibilityKeyRef.current = visibilityKey;
+    transientVisibleUntilRef.current = now + AGENT_PANEL_TRANSIENT_MS;
+  }
 
   // 1s tick: re-render for elapsed time + evict tasks past their deadline.
   // The eviction deletes from prev.tasks, which makes useCoordinatorTaskCount
@@ -95,6 +124,8 @@ export function CoordinatorTaskPanel(): React.ReactNode {
     visibleTasks,
     footerSelection,
     viewingAgentTaskId,
+    transientVisibleUntil: transientVisibleUntilRef.current,
+    now,
   })) {
     return null;
   }

--- a/runtime/src/tui/components/CoordinatorAgentStatus.tsx
+++ b/runtime/src/tui/components/CoordinatorAgentStatus.tsx
@@ -37,12 +37,31 @@ export function getCoordinatorTaskCount(tasks: AppState['tasks']): number {
   return visibleTasks.length === 0 ? 0 : visibleTasks.length + 1;
 }
 
+export function shouldShowCoordinatorTaskPanel({
+  visibleTasks,
+  footerSelection,
+  viewingAgentTaskId,
+}: {
+  visibleTasks: readonly LocalAgentTaskState[];
+  footerSelection: AppState['footerSelection'];
+  viewingAgentTaskId?: string;
+}): boolean {
+  if (visibleTasks.length === 0) {
+    return false;
+  }
+  if (footerSelection === 'tasks') {
+    return true;
+  }
+  return viewingAgentTaskId !== undefined && visibleTasks.some(task => task.id === viewingAgentTaskId);
+}
+
 export function CoordinatorTaskPanel(): React.ReactNode {
   const tasks = useAppState(s => s.tasks);
   const viewingAgentTaskId = useAppState(s_0 => s_0.viewingAgentTaskId);
   const agentNameRegistry = useAppState(s_1 => s_1.agentNameRegistry);
   const coordinatorTaskIndex = useAppState(s_2 => s_2.coordinatorTaskIndex);
-  const tasksSelected = useAppState(s_3 => s_3.footerSelection === 'tasks');
+  const footerSelection = useAppState(s_3 => s_3.footerSelection);
+  const tasksSelected = footerSelection === 'tasks';
   const selectedIndex = tasksSelected ? coordinatorTaskIndex : undefined;
   const setAppState = useSetAppState();
   const visibleTasks = getVisibleAgentTasks(tasks);
@@ -72,7 +91,11 @@ export function CoordinatorTaskPanel(): React.ReactNode {
     for (const [n, id] of agentNameRegistry) inv.set(id, n);
     return inv;
   }, [agentNameRegistry]);
-  if (visibleTasks.length === 0) {
+  if (!shouldShowCoordinatorTaskPanel({
+    visibleTasks,
+    footerSelection,
+    viewingAgentTaskId,
+  })) {
     return null;
   }
   return <Box flexDirection="column" marginTop={1} borderStyle="single" borderColor="promptBorder" paddingX={1} backgroundColor="clawd_background">

--- a/runtime/tests/tui/components/CoordinatorAgentStatus.test.ts
+++ b/runtime/tests/tui/components/CoordinatorAgentStatus.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "vitest";
 import {
+  AGENT_PANEL_TRANSIENT_MS,
   getCoordinatorTaskCount,
+  getCoordinatorTaskPanelVisibilityKey,
   getVisibleAgentTasks,
   shouldShowCoordinatorTaskPanel,
 } from "./CoordinatorAgentStatus.js";
@@ -35,7 +37,7 @@ describe("CoordinatorAgentStatus", () => {
     expect(getCoordinatorTaskCount(tasks)).toBe(0);
   });
 
-  test("keeps the panel collapsed while agent tasks run in the background", () => {
+  test("opens the panel while a new agent task is in its transient display window", () => {
     const visibleTasks = getVisibleAgentTasks({
       a: task("a"),
       b: task("b"),
@@ -45,6 +47,23 @@ describe("CoordinatorAgentStatus", () => {
       visibleTasks,
       footerSelection: null,
       viewingAgentTaskId: undefined,
+      transientVisibleUntil: 1_000 + AGENT_PANEL_TRANSIENT_MS,
+      now: 1_000,
+    })).toBe(true);
+  });
+
+  test("collapses the panel after the transient display window expires", () => {
+    const visibleTasks = getVisibleAgentTasks({
+      a: task("a"),
+      b: task("b"),
+    });
+
+    expect(shouldShowCoordinatorTaskPanel({
+      visibleTasks,
+      footerSelection: null,
+      viewingAgentTaskId: undefined,
+      transientVisibleUntil: 1_000 + AGENT_PANEL_TRANSIENT_MS,
+      now: 1_000 + AGENT_PANEL_TRANSIENT_MS,
     })).toBe(false);
   });
 
@@ -57,6 +76,8 @@ describe("CoordinatorAgentStatus", () => {
       visibleTasks,
       footerSelection: "tasks",
       viewingAgentTaskId: undefined,
+      transientVisibleUntil: 0,
+      now: 1_000,
     })).toBe(true);
   });
 
@@ -69,6 +90,21 @@ describe("CoordinatorAgentStatus", () => {
       visibleTasks,
       footerSelection: null,
       viewingAgentTaskId: "a",
+      transientVisibleUntil: 0,
+      now: 1_000,
     })).toBe(true);
+  });
+
+  test("changes the transient visibility key when an agent reaches terminal state", () => {
+    const running = getVisibleAgentTasks({
+      a: task("a", { status: "running" }),
+    });
+    const completed = getVisibleAgentTasks({
+      a: task("a", { status: "completed", endTime: 10 }),
+    });
+
+    expect(getCoordinatorTaskPanelVisibilityKey(running)).not.toBe(
+      getCoordinatorTaskPanelVisibilityKey(completed),
+    );
   });
 });

--- a/runtime/tests/tui/components/CoordinatorAgentStatus.test.ts
+++ b/runtime/tests/tui/components/CoordinatorAgentStatus.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   getCoordinatorTaskCount,
   getVisibleAgentTasks,
+  shouldShowCoordinatorTaskPanel,
 } from "./CoordinatorAgentStatus.js";
 
 const task = (id: string, extra: Record<string, unknown> = {}) => ({
@@ -32,5 +33,42 @@ describe("CoordinatorAgentStatus", () => {
 
     expect(getVisibleAgentTasks(tasks)).toEqual([]);
     expect(getCoordinatorTaskCount(tasks)).toBe(0);
+  });
+
+  test("keeps the panel collapsed while agent tasks run in the background", () => {
+    const visibleTasks = getVisibleAgentTasks({
+      a: task("a"),
+      b: task("b"),
+    });
+
+    expect(shouldShowCoordinatorTaskPanel({
+      visibleTasks,
+      footerSelection: null,
+      viewingAgentTaskId: undefined,
+    })).toBe(false);
+  });
+
+  test("shows the panel when the tasks footer is selected", () => {
+    const visibleTasks = getVisibleAgentTasks({
+      a: task("a"),
+    });
+
+    expect(shouldShowCoordinatorTaskPanel({
+      visibleTasks,
+      footerSelection: "tasks",
+      viewingAgentTaskId: undefined,
+    })).toBe(true);
+  });
+
+  test("shows the panel while viewing one of its agents", () => {
+    const visibleTasks = getVisibleAgentTasks({
+      a: task("a"),
+    });
+
+    expect(shouldShowCoordinatorTaskPanel({
+      visibleTasks,
+      footerSelection: null,
+      viewingAgentTaskId: "a",
+    })).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- show the AGENTS coordinator panel when agent rows first appear or change state
- auto-collapse the panel after the transient display window instead of leaving it expanded indefinitely
- keep the panel accessible when the tasks footer is selected or an agent is actively being viewed

## Test plan
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/components/CoordinatorAgentStatus.test.ts tests/tui/state/collabAgentTaskSync.test.ts`
- `node ~/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm --workspace=@tetsuo-ai/runtime run build`