### PR TITLE
test(tui): expand runtime coverage

### DIFF
--- a/runtime/tests/tui/components/CoordinatorAgentStatus.render.test.tsx
+++ b/runtime/tests/tui/components/CoordinatorAgentStatus.render.test.tsx
@@ -1,0 +1,208 @@
+import { PassThrough } from "node:stream";
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createRoot } from "../ink/root.js";
+import { Text } from "../ink.js";
+import {
+  CoordinatorTaskPanel,
+  useCoordinatorTaskCount,
+} from "./CoordinatorAgentStatus.js";
+
+const coordinatorMock = vi.hoisted(() => ({
+  appState: {
+    agentNameRegistry: new Map<string, string>(),
+    coordinatorTaskIndex: 0,
+    footerSelection: "chat",
+    tasks: {} as Record<string, any>,
+    viewingAgentTaskId: undefined as string | undefined,
+  },
+  evicted: [] as string[],
+  setAppStateCalls: [] as unknown[],
+  terminalColumns: 96,
+}));
+
+vi.mock("../state/AppState.js", () => ({
+  useAppState: (selector: (state: typeof coordinatorMock.appState) => unknown) =>
+    selector(coordinatorMock.appState),
+  useSetAppState: () => (update: unknown) => {
+    coordinatorMock.setAppStateCalls.push(update);
+  },
+}));
+
+vi.mock("../hooks/useTerminalSize", () => ({
+  useTerminalSize: () => ({
+    columns: coordinatorMock.terminalColumns,
+    rows: 24,
+  }),
+}));
+
+vi.mock("../state/teammateViewHelpers", () => ({
+  enterTeammateView: (taskId: string, setAppState: (update: unknown) => void) =>
+    setAppState({ enter: taskId }),
+  exitTeammateView: (setAppState: (update: unknown) => void) =>
+    setAppState({ exit: true }),
+}));
+
+vi.mock("../../utils/task/framework", () => ({
+  evictTerminalTask: (taskId: string, setAppState: (update: unknown) => void) => {
+    coordinatorMock.evicted.push(taskId);
+    setAppState({ evict: taskId });
+  },
+}));
+
+function makeTask(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    agentType: "worker",
+    description: `Work for ${id}`,
+    diskLoaded: false,
+    id,
+    isBackgrounded: true,
+    lastReportedTokenCount: 0,
+    messages: [],
+    pendingMessages: [],
+    progress: undefined,
+    prompt: "do work",
+    retain: false,
+    startTime: 1_000,
+    status: "running",
+    totalPausedMs: 0,
+    type: "local_agent",
+    ...overrides,
+  };
+}
+
+async function renderToText(node: React.ReactNode, waitMs = 30): Promise<string> {
+  let output = "";
+  const stdout = new PassThrough();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    setRawMode: (mode: boolean) => void;
+    ref: () => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.ref = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number }).columns = coordinatorMock.terminalColumns;
+
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  });
+
+  try {
+    root.render(node);
+    if (vi.isFakeTimers()) {
+      await vi.advanceTimersByTimeAsync(waitMs);
+    } else {
+      await new Promise(resolve => setTimeout(resolve, waitMs));
+    }
+    return stripAnsi(output);
+  } finally {
+    root.unmount();
+    stdin.end();
+  }
+}
+
+function CountProbe() {
+  return <Text>{useCoordinatorTaskCount()}</Text>;
+}
+
+beforeEach(() => {
+  vi.useRealTimers();
+  coordinatorMock.appState.agentNameRegistry = new Map();
+  coordinatorMock.appState.coordinatorTaskIndex = 0;
+  coordinatorMock.appState.footerSelection = "chat";
+  coordinatorMock.appState.tasks = {};
+  coordinatorMock.appState.viewingAgentTaskId = undefined;
+  coordinatorMock.evicted = [];
+  coordinatorMock.setAppStateCalls = [];
+  coordinatorMock.terminalColumns = 96;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("CoordinatorTaskPanel rendering", () => {
+  test("renders nothing when no visible panel agent tasks exist", async () => {
+    coordinatorMock.appState.tasks = {
+      hidden: makeTask("hidden", { evictAfter: 0 }),
+      main: makeTask("main", { agentType: "main-session" }),
+    };
+
+    expect((await renderToText(<CoordinatorTaskPanel />)).trim()).toBe("");
+    expect((await renderToText(<CountProbe />)).trim()).toBe("0");
+  });
+
+  test("renders sorted running and terminal agents with names, status, tokens, queues, and selection hints", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(11_000);
+    coordinatorMock.appState.footerSelection = "tasks";
+    coordinatorMock.appState.coordinatorTaskIndex = 2;
+    coordinatorMock.appState.viewingAgentTaskId = "agent-b";
+    coordinatorMock.appState.agentNameRegistry = new Map([
+      ["Fixer", "agent-b"],
+      ["Reviewer", "agent-a"],
+    ]);
+    coordinatorMock.appState.tasks = {
+      agentB: makeTask("agent-b", {
+        description: "long running branch fixer",
+        pendingMessages: ["one", "two"],
+        progress: {
+          lastActivity: { activityDescription: "editing" },
+          summary: "Applying patch",
+          tokenCount: 12_500,
+        },
+        startTime: 1_000,
+      }),
+      agentA: makeTask("agent-a", {
+        description: "finished review",
+        endTime: 9_000,
+        pendingMessages: ["queued"],
+        startTime: 2_000,
+        status: "completed",
+        totalPausedMs: 1_000,
+      }),
+    };
+
+    const output = await renderToText(<CoordinatorTaskPanel />);
+
+    expect(output).toContain("AGENTS");
+    expect(output).toContain("2 active");
+    expect(output).toContain("orchestrator");
+    expect(output.indexOf("Fixer:")).toBeLessThan(output.indexOf("Reviewer:"));
+    expect(output).toContain("Fixer:");
+    expect(output).toContain("Applying patch");
+    expect(output).toContain("12.5k tokens");
+    expect(output).toContain("2 queued");
+    expect(output).toContain("Reviewer:");
+    expect(output).toContain("finished review");
+    expect(output).toContain("1 queued");
+    expect(output).toContain("x to clear");
+    await expect(renderToText(<CountProbe />)).resolves.toContain("3");
+  });
+
+  test("evicts expired panel tasks on the interval tick", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(20_000);
+    coordinatorMock.appState.tasks = {
+      expired: makeTask("expired", { evictAfter: 19_000 }),
+      retained: makeTask("retained", { evictAfter: undefined }),
+    };
+
+    await renderToText(<CoordinatorTaskPanel />, 1_050);
+
+    expect(coordinatorMock.evicted).toContain("expired");
+    expect(coordinatorMock.evicted).not.toContain("retained");
+    expect(coordinatorMock.setAppStateCalls).toContainEqual({ evict: "expired" });
+  });
+});

--- a/runtime/tests/tui/components/MessageRow.logic.test.tsx
+++ b/runtime/tests/tui/components/MessageRow.logic.test.tsx
@@ -1,0 +1,265 @@
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  allToolsResolved,
+  areMessageRowPropsEqual,
+  hasContentAfterIndex,
+  isMessageStreaming,
+  type Props,
+} from "./MessageRow.js";
+
+const rowMock = vi.hoisted(() => ({
+  collapsibleToolNames: new Set<string>(["Read", "Grep", "GroupedRead"]),
+}));
+
+vi.mock("../../utils/collapseReadSearch.js", () => ({
+  getDisplayMessageFromCollapsed: (message: any) => message.displayMessage ?? message,
+  getToolSearchOrReadInfo: (name: string) => ({
+    isCollapsible: rowMock.collapsibleToolNames.has(name),
+  }),
+  getToolUseIdsFromCollapsedGroup: (message: { toolUseIds?: string[] }) =>
+    message.toolUseIds ?? [],
+  hasAnyToolInProgress: (message: { toolUseIds?: string[] }, ids: Set<string>) =>
+    (message.toolUseIds ?? []).some(id => ids.has(id)),
+}));
+
+vi.mock("../../utils/messages.js", () => ({
+  EMPTY_STRING_SET: new Set<string>(),
+  getProgressMessagesFromLookup: () => [],
+  getSiblingToolUseIDsFromLookup: () => new Set<string>(),
+  getToolUseID: (message: any) => {
+    const block = message?.message?.content?.[0];
+    return block?.id ?? null;
+  },
+}));
+
+vi.mock("./Message.js", () => ({
+  Message: () => null,
+  hasThinkingContent: (message: any) =>
+    message?.message?.content?.some((block: any) =>
+      block.type === "thinking" || block.type === "redacted_thinking",
+    ) ?? false,
+}));
+
+vi.mock("./Messages.js", () => ({
+  shouldRenderStatically: () => true,
+}));
+
+vi.mock("./MessageModel.js", () => ({
+  MessageModel: () => null,
+}));
+
+vi.mock("./MessageTimestamp.js", () => ({
+  MessageTimestamp: () => null,
+}));
+
+vi.mock("./OffscreenFreeze.js", () => ({
+  OffscreenFreeze: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+function assistantBlock(block: Record<string, unknown>, overrides: Record<string, unknown> = {}) {
+  return {
+    message: { content: [block], model: "gpt-test" },
+    timestamp: "2026-05-20T00:00:00.000Z",
+    type: "assistant",
+    uuid: `assistant-${String(block.id ?? block.type)}`,
+    ...overrides,
+  };
+}
+
+function userBlock(block: Record<string, unknown>) {
+  return {
+    message: { content: [block] },
+    type: "user",
+    uuid: `user-${String(block.type)}`,
+  };
+}
+
+function groupedToolUse(id: string, toolName = "GroupedRead") {
+  return {
+    displayMessage: assistantBlock({ text: "group display", type: "text" }),
+    messages: [assistantBlock({ id, input: {}, name: toolName, type: "tool_use" })],
+    toolName,
+    type: "grouped_tool_use",
+    uuid: `group-${id}`,
+  };
+}
+
+function collapsed(ids: string[], overrides: Record<string, unknown> = {}) {
+  return {
+    displayMessage: assistantBlock({ text: "collapsed display", type: "text" }),
+    messages: [],
+    readCount: 1,
+    searchCount: 0,
+    toolUseIds: ids,
+    type: "collapsed_read_search",
+    uuid: `collapsed-${ids.join("-")}`,
+    ...overrides,
+  };
+}
+
+function baseProps(overrides: Partial<Props> = {}): Props {
+  return {
+    canAnimate: true,
+    columns: 80,
+    commands: [],
+    hasContentAfter: false,
+    inProgressToolUseIDs: new Set<string>(),
+    isLoading: false,
+    isUserContinuation: false,
+    lastThinkingBlockId: null,
+    latestBashOutputUUID: null,
+    lookups: {
+      resolvedToolUseIDs: new Set<string>(),
+    } as any,
+    message: assistantBlock({ text: "hello", type: "text" }) as any,
+    screen: "default" as any,
+    streamingToolUseIDs: new Set<string>(),
+    tools: {} as any,
+    verbose: false,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  rowMock.collapsibleToolNames = new Set(["Read", "Grep", "GroupedRead"]);
+});
+
+describe("hasContentAfterIndex", () => {
+  test("skips transient non-content messages and returns false at the end", () => {
+    const messages = [
+      collapsed(["read-1"]),
+      assistantBlock({ text: "thinking", type: "thinking" }),
+      assistantBlock({ text: "redacted", type: "redacted_thinking" }),
+      assistantBlock({ id: "read-1", input: {}, name: "Read", type: "tool_use" }),
+      assistantBlock({ id: "streaming-shell", input: {}, name: "Bash", type: "tool_use" }),
+      { type: "system", uuid: "system" },
+      { type: "attachment", uuid: "attachment" },
+      userBlock({ tool_use_id: "read-1", type: "tool_result" }),
+      groupedToolUse("grouped-1"),
+    ] as any[];
+
+    expect(
+      hasContentAfterIndex(messages, 0, {} as any, new Set(["streaming-shell"])),
+    ).toBe(false);
+  });
+
+  test("detects assistant, user, and non-collapsible grouped content", () => {
+    expect(
+      hasContentAfterIndex(
+        [collapsed(["read-1"]), assistantBlock({ text: "real", type: "text" })] as any[],
+        0,
+        {} as any,
+        new Set(),
+      ),
+    ).toBe(true);
+    expect(
+      hasContentAfterIndex(
+        [collapsed(["read-1"]), userBlock({ text: "real", type: "text" })] as any[],
+        0,
+        {} as any,
+        new Set(),
+      ),
+    ).toBe(true);
+
+    rowMock.collapsibleToolNames.delete("GroupedRead");
+    expect(
+      hasContentAfterIndex([collapsed(["read-1"]), groupedToolUse("grouped-1")] as any[], 0, {} as any, new Set()),
+    ).toBe(true);
+  });
+});
+
+describe("message streaming and resolution helpers", () => {
+  test("detects streaming grouped, collapsed, and single tool-use messages", () => {
+    expect(isMessageStreaming(groupedToolUse("grouped-1") as any, new Set(["grouped-1"]))).toBe(true);
+    expect(isMessageStreaming(collapsed(["read-1"]) as any, new Set(["read-1"]))).toBe(true);
+    expect(
+      isMessageStreaming(
+        assistantBlock({ id: "tool-1", input: {}, name: "Bash", type: "tool_use" }) as any,
+        new Set(["tool-1"]),
+      ),
+    ).toBe(true);
+    expect(isMessageStreaming(assistantBlock({ text: "done", type: "text" }) as any, new Set())).toBe(false);
+  });
+
+  test("detects resolved grouped, collapsed, server, normal, and text messages", () => {
+    expect(allToolsResolved(groupedToolUse("grouped-1") as any, new Set(["grouped-1"]))).toBe(true);
+    expect(allToolsResolved(groupedToolUse("grouped-1") as any, new Set())).toBe(false);
+    expect(allToolsResolved(collapsed(["read-1", "read-2"]) as any, new Set(["read-1", "read-2"]))).toBe(true);
+    expect(allToolsResolved(collapsed(["read-1", "read-2"]) as any, new Set(["read-1"]))).toBe(false);
+    expect(
+      allToolsResolved(
+        assistantBlock({ id: "server-1", name: "web_search", type: "server_tool_use" }) as any,
+        new Set(["server-1"]),
+      ),
+    ).toBe(true);
+    expect(
+      allToolsResolved(
+        assistantBlock({ id: "tool-1", input: {}, name: "Bash", type: "tool_use" }) as any,
+        new Set(["tool-1"]),
+      ),
+    ).toBe(true);
+    expect(allToolsResolved(assistantBlock({ text: "done", type: "text" }) as any, new Set())).toBe(true);
+  });
+});
+
+describe("areMessageRowPropsEqual", () => {
+  test("rejects prop changes that affect rendering", () => {
+    const message = assistantBlock({ text: "hello", type: "text" }) as any;
+    const prev = baseProps({ message });
+
+    expect(areMessageRowPropsEqual(prev, baseProps({ message: assistantBlock({ text: "new", type: "text" }) as any }))).toBe(false);
+    expect(areMessageRowPropsEqual(prev, baseProps({ message, screen: "transcript" as any }))).toBe(false);
+    expect(areMessageRowPropsEqual(prev, baseProps({ message, verbose: true }))).toBe(false);
+    expect(areMessageRowPropsEqual(prev, baseProps({ columns: 120, message }))).toBe(false);
+    expect(areMessageRowPropsEqual(baseProps({ latestBashOutputUUID: "other", message }), baseProps({ latestBashOutputUUID: message.uuid, message }))).toBe(false);
+  });
+
+  test("keeps thinking rows sensitive to the active thinking block", () => {
+    const message = assistantBlock({ text: "thinking", type: "thinking" }) as any;
+
+    expect(
+      areMessageRowPropsEqual(
+        baseProps({ lastThinkingBlockId: "old", message }),
+        baseProps({ lastThinkingBlockId: "new", message }),
+      ),
+    ).toBe(false);
+    const textMessage = baseProps().message;
+    expect(
+      areMessageRowPropsEqual(
+        baseProps({ lastThinkingBlockId: "old", message: textMessage }),
+        baseProps({ lastThinkingBlockId: "new", message: textMessage }),
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects active or unresolved rows and accepts static resolved rows", () => {
+    const message = assistantBlock({ id: "tool-1", input: {}, name: "Bash", type: "tool_use" }) as any;
+    const resolved = baseProps({
+      lookups: { resolvedToolUseIDs: new Set(["tool-1"]) } as any,
+      message,
+    });
+
+    expect(
+      areMessageRowPropsEqual(
+        baseProps({ message, streamingToolUseIDs: new Set(["tool-1"]) }),
+        resolved,
+      ),
+    ).toBe(false);
+    expect(
+      areMessageRowPropsEqual(
+        baseProps({ lookups: { resolvedToolUseIDs: new Set() } as any, message }),
+        resolved,
+      ),
+    ).toBe(false);
+    expect(areMessageRowPropsEqual(resolved, resolved)).toBe(true);
+  });
+
+  test("never memo-skips collapsed prompt rows", () => {
+    const message = collapsed(["read-1"]) as any;
+    const props = baseProps({ message });
+
+    expect(areMessageRowPropsEqual(props, props)).toBe(false);
+  });
+});

--- a/runtime/tests/tui/components/PromptInput/PromptInputFooterLeftSide.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInputFooterLeftSide.render.test.tsx
@@ -1,0 +1,436 @@
+import { PassThrough } from "node:stream";
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { Text } from "../../ink.js";
+import { createRoot } from "../../ink/root.js";
+import { PromptInputFooterLeftSide } from "./PromptInputFooterLeftSide.js";
+
+const footerMock = vi.hoisted(() => ({
+  appState: {
+    expandedView: "none" as "none" | "tasks" | "teammates",
+    notifications: { current: null as null | { key: string } },
+    remoteSessionUrl: undefined as string | undefined,
+    tasks: {} as Record<string, any>,
+    teamContext: undefined as undefined | { teammates: Record<string, { name: string }> },
+    viewingAgentTaskId: undefined as string | undefined,
+    viewSelectionMode: "normal",
+  },
+  copyOnSelect: true,
+  featureFlags: new Set<string>(),
+  fullscreen: false,
+  globalConfig: {
+    editorMode: "normal",
+    prStatusFooterEnabled: true,
+    tui: { vimMode: false },
+  } as Record<string, any>,
+  hasSelection: false,
+  inProcessEnabled: false,
+  isCoordinator: false,
+  isRemoteMode: false,
+  isXterm: false,
+  platform: "linux",
+  prStatus: {
+    number: null as number | null,
+    reviewState: null as string | null,
+    url: null as string | null,
+  },
+  proactiveActive: false,
+  proactiveNextTickAt: null as number | null,
+  selectionState: { lastPressHadAlt: false } as { lastPressHadAlt?: boolean },
+  swarmsEnabled: false,
+  tasksV2: undefined as undefined | Array<Record<string, unknown>>,
+  terminalColumns: 100,
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: (name: string) => footerMock.featureFlags.has(name),
+}));
+
+vi.mock("../../../coordinator/coordinatorMode.js", () => ({
+  isCoordinatorMode: () => footerMock.isCoordinator,
+}));
+
+vi.mock("../../keybindings/useShortcutDisplay.js", () => ({
+  useShortcutDisplay: (_id: string, _scope: string, fallback: string) => fallback,
+}));
+
+vi.mock("../../../utils/config.js", () => ({
+  getGlobalConfig: () => footerMock.globalConfig,
+}));
+
+vi.mock("../../../utils/permissions/PermissionMode.js", () => ({
+  getModeColor: () => "mode",
+  isDefaultMode: (mode: string | undefined) => mode === undefined || mode === "default",
+}));
+
+vi.mock("../tasks/BackgroundTaskStatus.js", () => ({
+  BackgroundTaskStatus: (props: {
+    isLeaderIdle?: boolean;
+    isViewingTeammate?: boolean;
+    tasksSelected?: boolean;
+    teammateFooterIndex?: number;
+  }) => (
+    <Text>
+      TASKS selected:{String(props.tasksSelected)} viewing:{String(props.isViewingTeammate)} idle:{String(props.isLeaderIdle)} index:{String(props.teammateFooterIndex)}
+    </Text>
+  ),
+}));
+
+vi.mock("../../../tasks/types.js", () => ({
+  isBackgroundTask: (task: any) =>
+    task?.type === "background_task" || task?.type === "in_process_teammate",
+}));
+
+vi.mock("../tasks/taskStatusUtils.js", () => ({
+  shouldHideTasksFooter: (tasks: Record<string, any>, showSpinnerTree: boolean) =>
+    showSpinnerTree && Object.values(tasks).some(task => task.type === "in_process_teammate"),
+}));
+
+vi.mock("../../../utils/agentSwarmsEnabled.js", () => ({
+  isAgentSwarmsEnabled: () => footerMock.swarmsEnabled,
+}));
+
+vi.mock("../teams/TeamStatus.js", () => ({
+  TeamStatus: (props: { showHint?: boolean; teamsSelected?: boolean }) => (
+    <Text>TEAM selected:{String(props.teamsSelected)} hint:{String(props.showHint)}</Text>
+  ),
+}));
+
+vi.mock("../../../utils/swarm/backends/registry.js", () => ({
+  isInProcessEnabled: () => footerMock.inProcessEnabled,
+}));
+
+vi.mock("../../state/AppState.js", () => ({
+  useAppState: (selector: (state: typeof footerMock.appState) => unknown) =>
+    selector(footerMock.appState),
+  useAppStateStore: () => ({
+    getState: () => ({ remoteSessionUrl: footerMock.appState.remoteSessionUrl }),
+  }),
+}));
+
+vi.mock("../../../bootstrap/state.js", () => ({
+  flushInteractionTime: () => {},
+  getIsRemoteMode: () => footerMock.isRemoteMode,
+}));
+
+vi.mock("./HistorySearchInput.js", () => ({
+  default: (props: { historyFailedMatch?: boolean; value: string }) => (
+    <Text>SEARCH {props.value} failed:{String(props.historyFailedMatch)}</Text>
+  ),
+}));
+
+vi.mock("../../hooks/usePrStatus.js", () => ({
+  usePrStatus: () => footerMock.prStatus,
+}));
+
+vi.mock("../design-system/KeyboardShortcutHint.js", () => ({
+  KeyboardShortcutHint: ({ action, shortcut }: { action: string; shortcut: string }) => (
+    <Text>{shortcut} to {action}</Text>
+  ),
+}));
+
+vi.mock("../design-system/Byline.js", () => ({
+  Byline: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("../../hooks/useTerminalSize.js", () => ({
+  useTerminalSize: () => ({ columns: footerMock.terminalColumns, rows: 24 }),
+}));
+
+vi.mock("../../hooks/useTasksV2.js", () => ({
+  useTasksV2: () => footerMock.tasksV2,
+}));
+
+vi.mock("../../../utils/fullscreen.js", () => ({
+  isFullscreenEnvEnabled: () => footerMock.fullscreen,
+}));
+
+vi.mock("../../ink/terminal.js", () => ({
+  SYNC_OUTPUT_SUPPORTED: false,
+  isXtermJs: () => footerMock.isXterm,
+  shouldSkipMainScreenSyncMarkers: () => true,
+  shouldUseMainScreenRewrite: () => false,
+  supportsExtendedKeys: () => false,
+  writeDiffToTerminal: (
+    terminal: { stdout: { write: (chunk: string) => void } },
+    diff: Array<{ content?: string; str?: string; type: string }>,
+  ) => {
+    terminal.stdout.write(
+      diff
+        .map(patch => (patch.type === "stdout" ? patch.content ?? "" : patch.type === "styleStr" ? patch.str ?? "" : ""))
+        .join(""),
+    );
+  },
+}));
+
+vi.mock("../../ink/hooks/use-selection.js", () => ({
+  useHasSelection: () => footerMock.hasSelection,
+  useSelection: () => ({
+    getState: () => footerMock.selectionState,
+  }),
+}));
+
+vi.mock("../../../utils/platform.js", () => ({
+  getPlatform: () => footerMock.platform,
+}));
+
+vi.mock("../PrBadge.js", () => ({
+  PrBadge: ({ number, reviewState }: { number: number; reviewState?: string }) => (
+    <Text>PR#{number}:{reviewState}</Text>
+  ),
+}));
+
+vi.mock("./proactiveAdapter.js", () => ({
+  getPromptInputProactiveNextTickAt: () => footerMock.proactiveNextTickAt,
+  isPromptInputProactiveActive: () => footerMock.proactiveActive,
+  subscribeToPromptInputProactiveChanges: () => () => {},
+}));
+
+function defaultProps(
+  overrides: Partial<React.ComponentProps<typeof PromptInputFooterLeftSide>> = {},
+): React.ComponentProps<typeof PromptInputFooterLeftSide> {
+  return {
+    exitMessage: { show: false },
+    historyFailedMatch: false,
+    historyQuery: "",
+    isLoading: false,
+    isSearching: false,
+    mode: "prompt",
+    setHistoryQuery: () => {},
+    suppressHint: false,
+    tasksSelected: false,
+    teamsSelected: false,
+    toolPermissionContext: { mode: "default" } as any,
+    vimMode: undefined,
+    ...overrides,
+  };
+}
+
+async function renderToText(node: React.ReactNode): Promise<string> {
+  let output = "";
+  const stdout = new PassThrough();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    setRawMode: (mode: boolean) => void;
+    ref: () => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.ref = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number }).columns = footerMock.terminalColumns;
+
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  });
+
+  try {
+    root.render(node);
+    await new Promise(resolve => setTimeout(resolve, 30));
+    return stripAnsi(output);
+  } finally {
+    root.unmount();
+    stdin.end();
+  }
+}
+
+beforeEach(() => {
+  footerMock.appState.expandedView = "none";
+  footerMock.appState.notifications = { current: null };
+  footerMock.appState.remoteSessionUrl = undefined;
+  footerMock.appState.tasks = {};
+  footerMock.appState.teamContext = undefined;
+  footerMock.appState.viewingAgentTaskId = undefined;
+  footerMock.appState.viewSelectionMode = "normal";
+  footerMock.copyOnSelect = true;
+  footerMock.featureFlags.clear();
+  footerMock.fullscreen = false;
+  footerMock.globalConfig = {
+    editorMode: "normal",
+    prStatusFooterEnabled: true,
+    tui: { vimMode: false },
+  };
+  footerMock.hasSelection = false;
+  footerMock.inProcessEnabled = false;
+  footerMock.isCoordinator = false;
+  footerMock.isRemoteMode = false;
+  footerMock.isXterm = false;
+  footerMock.platform = "linux";
+  footerMock.prStatus = { number: null, reviewState: null, url: null };
+  footerMock.proactiveActive = false;
+  footerMock.proactiveNextTickAt = null;
+  footerMock.selectionState = { lastPressHadAlt: false };
+  footerMock.swarmsEnabled = false;
+  footerMock.tasksV2 = undefined;
+  footerMock.terminalColumns = 100;
+});
+
+describe("PromptInputFooterLeftSide rendering", () => {
+  test("prioritizes exit, paste, search, and vim states", async () => {
+    await expect(
+      renderToText(<PromptInputFooterLeftSide {...defaultProps({ exitMessage: { show: true, key: "ctrl-c" } })} />),
+    ).resolves.toContain("Press the same key again to exit");
+
+    await expect(
+      renderToText(<PromptInputFooterLeftSide {...defaultProps({ isPasting: true })} />),
+    ).resolves.toContain("Pasting text");
+
+    await expect(
+      renderToText(
+        <PromptInputFooterLeftSide
+          {...defaultProps({
+            historyFailedMatch: true,
+            historyQuery: "needle",
+            isSearching: true,
+          })}
+        />,
+      ),
+    ).resolves.toContain("SEARCH needle failed:true");
+
+    footerMock.globalConfig = { editorMode: "vim", tui: { vimMode: true } };
+    await expect(
+      renderToText(<PromptInputFooterLeftSide {...defaultProps({ vimMode: "NORMAL" })} />),
+    ).resolves.toContain("-- NORMAL --");
+  });
+
+  test("renders bash mode, permission mode, remote, and PR status branches", async () => {
+    await expect(
+      renderToText(<PromptInputFooterLeftSide {...defaultProps({ mode: "bash" })} />),
+    ).resolves.toContain("! for bash mode");
+
+    await expect(
+      renderToText(
+        <PromptInputFooterLeftSide
+          {...defaultProps({
+            toolPermissionContext: { mode: "bypassPermissions" } as any,
+          })}
+        />,
+      ),
+    ).resolves.toContain("YOLO");
+
+    footerMock.isRemoteMode = true;
+    footerMock.appState.remoteSessionUrl = "https://example.invalid/session";
+    footerMock.prStatus = {
+      number: 12,
+      reviewState: "approved",
+      url: "https://example.invalid/pr/12",
+    };
+    const remoteOutput = await renderToText(
+      <PromptInputFooterLeftSide
+        {...defaultProps({
+          toolPermissionContext: { mode: "bypassPermissions" } as any,
+        })}
+      />,
+    );
+    expect(remoteOutput).toContain("remote");
+    expect(remoteOutput).toContain("PR#12:approved");
+    expect(remoteOutput).not.toContain("YOLO");
+  });
+
+  test("renders task, team, teammate, and loading hints", async () => {
+    footerMock.swarmsEnabled = true;
+    footerMock.appState.teamContext = {
+      teammates: {
+        lead: { name: "team-lead" },
+        reviewer: { name: "Reviewer" },
+      },
+    };
+    footerMock.tasksV2 = [{ id: "task-1" }];
+    let output = await renderToText(
+      <PromptInputFooterLeftSide
+        {...defaultProps({
+          isLoading: true,
+          teamsSelected: true,
+        })}
+      />,
+    );
+    expect(output).toContain("TEAM selected:true");
+    expect(output).toContain("esc to interrupt");
+    expect(output).toContain("ctrl+t to show tasks");
+
+    footerMock.appState.tasks = {
+      teammate: { status: "running", type: "in_process_teammate" },
+    };
+    output = await renderToText(
+      <PromptInputFooterLeftSide
+        {...defaultProps({
+          isLoading: false,
+          tasksSelected: true,
+          teammateFooterIndex: 1,
+        })}
+      />,
+    );
+    expect(output).toContain("TASKS selected:true viewing:false idle:true index:1");
+    expect(output).toContain("ctrl+t to show tasks");
+
+    footerMock.appState.viewSelectionMode = "viewing-agent";
+    footerMock.appState.viewingAgentTaskId = "teammate";
+    footerMock.appState.tasks.teammate.status = "completed";
+    output = await renderToText(<PromptInputFooterLeftSide {...defaultProps()} />);
+    expect(output).toContain("viewing:true");
+    expect(output).toContain("esc to return to team lead");
+  });
+
+  test("renders proactive, kill-agent, task-management, and selection hints", async () => {
+    footerMock.featureFlags.add("PROACTIVE");
+    footerMock.proactiveActive = true;
+    footerMock.proactiveNextTickAt = Date.now() + 2_000;
+    await expect(renderToText(<PromptInputFooterLeftSide {...defaultProps()} />)).resolves.toContain("waiting");
+
+    footerMock.featureFlags.clear();
+    footerMock.proactiveActive = false;
+    footerMock.proactiveNextTickAt = null;
+    footerMock.appState.tasks = {
+      local: { status: "running", type: "local_agent" },
+    };
+    footerMock.appState.notifications = { current: null };
+    await expect(renderToText(<PromptInputFooterLeftSide {...defaultProps()} />)).resolves.toContain(
+      "ctrl+x ctrl+k to stop agents",
+    );
+
+    footerMock.appState.notifications = { current: { key: "kill-agents-confirm" } };
+    await expect(renderToText(<PromptInputFooterLeftSide {...defaultProps()} />)).resolves.not.toContain(
+      "stop agents",
+    );
+
+    footerMock.appState.tasks = { bg: { status: "running", type: "background_task" } };
+    footerMock.appState.notifications = { current: null };
+    await expect(
+      renderToText(<PromptInputFooterLeftSide {...defaultProps({ tasksSelected: true })} />),
+    ).resolves.toContain("Enter to view tasks");
+
+    footerMock.fullscreen = true;
+    footerMock.hasSelection = true;
+    footerMock.copyOnSelect = false;
+    footerMock.globalConfig.copyOnSelect = false;
+    await expect(renderToText(<PromptInputFooterLeftSide {...defaultProps({ suppressHint: true })} />)).resolves.toContain(
+      "ctrl+c to copy",
+    );
+
+    footerMock.copyOnSelect = true;
+    footerMock.globalConfig.copyOnSelect = true;
+    footerMock.isXterm = true;
+    footerMock.platform = "macos";
+    footerMock.selectionState = { lastPressHadAlt: true };
+    await expect(renderToText(<PromptInputFooterLeftSide {...defaultProps({ suppressHint: true })} />)).resolves.toContain(
+      "macOptionClickForcesSelection",
+    );
+  });
+
+  test("keeps fullscreen footer height stable when no parts are visible", async () => {
+    expect((await renderToText(<PromptInputFooterLeftSide {...defaultProps({ suppressHint: true })} />)).trim()).toBe("");
+
+    footerMock.fullscreen = true;
+    const output = await renderToText(<PromptInputFooterLeftSide {...defaultProps({ suppressHint: true })} />);
+    expect(output.trim()).toBe("");
+  });
+});

--- a/runtime/tests/tui/components/diff/StructuredDiff/Fallback.test.tsx
+++ b/runtime/tests/tui/components/diff/StructuredDiff/Fallback.test.tsx
@@ -1,0 +1,161 @@
+import { PassThrough } from "node:stream";
+import type { StructuredPatchHunk } from "diff";
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { describe, expect, test } from "vitest";
+
+import { createRoot } from "../../../ink/root.js";
+import {
+  calculateWordDiffs,
+  numberDiffLines,
+  processAdjacentLines,
+  StructuredDiffFallback,
+  transformLinesToObjects,
+  type LineObject,
+} from "./Fallback.js";
+
+async function renderToText(node: React.ReactNode): Promise<string> {
+  let output = "";
+  const stdout = new PassThrough();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    setRawMode: (mode: boolean) => void;
+    ref: () => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.ref = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number }).columns = 100;
+
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  });
+
+  try {
+    root.render(node);
+    await new Promise(resolve => setTimeout(resolve, 30));
+    return stripAnsi(output);
+  } finally {
+    root.unmount();
+    stdin.end();
+  }
+}
+
+function compact(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+describe("StructuredDiffFallback helpers", () => {
+  test("transforms diff lines into typed line objects", () => {
+    expect(transformLinesToObjects(["+added", "-removed", " unchanged"])).toEqual([
+      { code: "added", i: 0, originalCode: "added", type: "add" },
+      { code: "removed", i: 0, originalCode: "removed", type: "remove" },
+      { code: "unchanged", i: 0, originalCode: "unchanged", type: "nochange" },
+    ]);
+  });
+
+  test("pairs adjacent remove/add lines for word diffs and preserves unmatched lines", () => {
+    const lines = transformLinesToObjects([
+      "-const oldName = value.old",
+      "-const oldOnly = true",
+      "+const newName = value.new",
+      " context",
+      "-deleteOnly()",
+      "+insertOnly()",
+      "+extraAdd()",
+    ]);
+
+    const processed = processAdjacentLines(lines);
+
+    expect(processed.map(line => line.type)).toEqual([
+      "remove",
+      "remove",
+      "add",
+      "nochange",
+      "remove",
+      "add",
+      "add",
+    ]);
+    expect(processed[0]?.wordDiff).toBe(true);
+    expect(processed[0]?.matchedLine).toBe(processed[2]);
+    expect(processed[1]?.wordDiff).toBeUndefined();
+    expect(processed[4]?.matchedLine).toBe(processed[5]);
+    expect(processed[6]?.wordDiff).toBeUndefined();
+  });
+
+  test("numbers no-change, add, and remove runs like unified diff rows", () => {
+    const diff: LineObject[] = [
+      { code: "same", i: 0, originalCode: "same", type: "nochange" },
+      { code: "added", i: 0, originalCode: "added", type: "add" },
+      { code: "removed-a", i: 0, originalCode: "removed-a", type: "remove" },
+      { code: "removed-b", i: 0, originalCode: "removed-b", type: "remove" },
+      { code: "same-again", i: 0, originalCode: "same-again", type: "nochange" },
+    ];
+
+    expect(numberDiffLines(diff, 10).map(line => [line.type, line.i])).toEqual([
+      ["nochange", 10],
+      ["add", 11],
+      ["remove", 12],
+      ["remove", 13],
+      ["nochange", 12],
+    ]);
+  });
+
+  test("calculates word diffs while preserving spaces", () => {
+    const parts = calculateWordDiffs("return oldValue + 1", "return newValue + 1");
+
+    expect(parts.map(part => part.value).join("")).toContain("return ");
+    expect(parts.some(part => part.removed && part.value === "oldValue")).toBe(true);
+    expect(parts.some(part => part.added && part.value === "newValue")).toBe(true);
+  });
+});
+
+describe("StructuredDiffFallback rendering", () => {
+  test("renders word-level add/remove pairs with line numbers", async () => {
+    const patch = {
+      lines: [
+        " function example() {",
+        "-  return value.oldName;",
+        "+  return value.newName;",
+        " }",
+      ],
+      oldStart: 20,
+    } as StructuredPatchHunk;
+
+    const output = compact(
+      await renderToText(<StructuredDiffFallback dim={false} patch={patch} width={80} />),
+    );
+
+    expect(output).toContain("20 function example()");
+    expect(output).toContain("- return value.oldName;");
+    expect(output).toContain("+ return value.newName;");
+    expect(output).toContain("22 }");
+  });
+
+  test("falls back to full-line rendering for dimmed or heavily changed rows", async () => {
+    const patch = {
+      lines: [
+        "-short",
+        "+a completely different and much longer replacement line",
+        " unchanged context that should wrap when the width is narrow",
+      ],
+      oldStart: 3,
+    } as StructuredPatchHunk;
+
+    const output = compact(
+      await renderToText(<StructuredDiffFallback dim patch={patch} width={24} />),
+    );
+
+    expect(output).toContain("3 -short");
+    expect(output).toContain("3 +a completely");
+    expect(output).toContain("4 unchanged");
+  });
+});

--- a/runtime/tests/tui/components/spinner/Spinner.render.test.tsx
+++ b/runtime/tests/tui/components/spinner/Spinner.render.test.tsx
@@ -1,0 +1,537 @@
+import { PassThrough } from "node:stream";
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createRoot } from "../../ink/root.js";
+import {
+  BriefIdleStatus,
+  Spinner,
+  SpinnerWithVerb,
+} from "./Spinner.js";
+
+const spinnerMock = vi.hoisted(() => ({
+  activity: {
+    ended: [] as string[],
+    started: [] as string[],
+  },
+  appState: {
+    effortValue: "medium",
+    expandedView: undefined as string | undefined,
+    isBriefOnly: false,
+    remoteBackgroundTaskCount: 0,
+    remoteConnectionStatus: "connected",
+    selectedIPAgentIndex: 0,
+    tasks: {} as Record<string, any>,
+    viewingAgentTaskId: undefined as string | undefined,
+    viewSelectionMode: "normal",
+  },
+  currentTurnTokenBudget: null as number | null,
+  featureFlags: new Set<string>(),
+  getKairosActive: false,
+  getUserMsgOptIn: false,
+  growthbookBrief: false,
+  localAgents: [] as Array<{ id: string; summary: string }>,
+  outputTokens: 0,
+  settings: {
+    prefersReducedMotion: false,
+    spinnerTipsEnabled: true,
+  } as { prefersReducedMotion?: boolean; spinnerTipsEnabled?: boolean },
+  tasksV2: undefined as any[] | undefined,
+  terminalColumns: 80,
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: (name: string) => spinnerMock.featureFlags.has(name),
+}));
+
+vi.mock("../../../bootstrap/state.js", () => ({
+  flushInteractionTime: () => {},
+  getCurrentTurnTokenBudget: () => spinnerMock.currentTurnTokenBudget,
+  getKairosActive: () => spinnerMock.getKairosActive,
+  getTurnOutputTokens: () => spinnerMock.outputTokens,
+  getUserMsgOptIn: () => spinnerMock.getUserMsgOptIn,
+}));
+
+vi.mock("../../../services/analytics/growthbook.js", () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: () => spinnerMock.growthbookBrief,
+}));
+
+vi.mock("../../../utils/activityManager.js", () => ({
+  activityManager: {
+    endCLIActivity: (id: string) => {
+      spinnerMock.activity.ended.push(id);
+    },
+    startCLIActivity: (id: string) => {
+      spinnerMock.activity.started.push(id);
+    },
+  },
+}));
+
+vi.mock("../../../constants/spinnerVerbs.js", () => ({
+  getSpinnerVerbs: () => ["Working"],
+}));
+
+vi.mock("../MessageResponse.js", async () => {
+  const React = await import("react");
+  const { Box } = await vi.importActual<typeof import("../../ink.js")>("../../ink.js");
+  return {
+    MessageResponse: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(Box, { flexDirection: "column" }, children),
+  };
+});
+
+vi.mock("../TaskListV2.js", async () => {
+  const React = await import("react");
+  const { Text } = await vi.importActual<typeof import("../../ink.js")>("../../ink.js");
+  return {
+    TaskListV2: ({ tasks }: { tasks: unknown[] }) =>
+      React.createElement(Text, null, `TASKS:${tasks.length}`),
+  };
+});
+
+vi.mock("../../hooks/useTasksV2.js", () => ({
+  useTasksV2: () => spinnerMock.tasksV2,
+}));
+
+vi.mock("../../state/AppState.js", () => ({
+  useAppState: (selector: (state: typeof spinnerMock.appState) => unknown) =>
+    selector(spinnerMock.appState),
+}));
+
+vi.mock("../../hooks/useTerminalSize.js", () => ({
+  useTerminalSize: () => ({ columns: spinnerMock.terminalColumns, rows: 24 }),
+}));
+
+vi.mock("../../hooks/useSettings.js", () => ({
+  useSettings: () => spinnerMock.settings,
+}));
+
+vi.mock("../../../tasks/InProcessTeammateTask/types.js", () => ({
+  isInProcessTeammateTask: (task: any) => task?.type === "in_process_teammate",
+}));
+
+vi.mock("../../../tasks/types.js", () => ({
+  isBackgroundTask: (task: any) => task?.type === "background_task",
+}));
+
+vi.mock("../../../tasks/InProcessTeammateTask/InProcessTeammateTask.js", () => ({
+  getAllInProcessTeammateTasks: (tasks: Record<string, any>) =>
+    Object.values(tasks ?? {}).filter(task => task?.type === "in_process_teammate"),
+}));
+
+vi.mock("../../../utils/effort.js", () => ({
+  getEffortSuffix: (_model: string, effort: string) => `:${effort}`,
+}));
+
+vi.mock("../../../utils/model/model.js", () => ({
+  getMainLoopModel: () => "gpt-test",
+}));
+
+vi.mock("../../state/selectors.js", () => ({
+  getViewedTeammateTask: ({ viewingAgentTaskId, tasks }: any) =>
+    viewingAgentTaskId ? tasks?.[viewingAgentTaskId] : undefined,
+}));
+
+vi.mock("./SpinnerAnimationRow.js", async () => {
+  const React = await import("react");
+  const { Text } = await vi.importActual<typeof import("../../ink.js")>("../../ink.js");
+  return {
+    SpinnerAnimationRow: (props: any) =>
+      React.createElement(
+        Text,
+        null,
+        [
+          "ROW",
+          props.mode,
+          props.reducedMotion ? "reduced" : "motion",
+          props.message,
+          `tokens:${props.teammateTokens}`,
+          `thinking:${String(props.thinkingStatus)}`,
+          props.spinnerSuffix ? `suffix:${props.spinnerSuffix}` : "",
+          props.effortSuffix,
+        ].filter(Boolean).join(" "),
+      ),
+  };
+});
+
+vi.mock("./TeammateSpinnerTree.js", async () => {
+  const React = await import("react");
+  const { Text } = await vi.importActual<typeof import("../../ink.js")>("../../ink.js");
+  return {
+    TeammateSpinnerTree: (props: any) =>
+      React.createElement(
+        Text,
+        null,
+        `TREE selected:${props.selectedIndex ?? "none"} idle:${String(props.allIdle)} leader:${props.leaderVerb ?? props.leaderIdleText ?? ""} tokens:${props.leaderTokenCount}`,
+      ),
+  };
+});
+
+vi.mock("./agentActivity.js", () => ({
+  formatRunningAgentSummary: (agents: Array<{ summary: string }>) =>
+    agents.map(agent => agent.summary).join(", "),
+  getActiveLocalAgentTasks: () => spinnerMock.localAgents,
+}));
+
+function makeRef<T>(current: T): React.RefObject<T> {
+  return { current };
+}
+
+function defaultSpinnerProps(
+  overrides: Partial<React.ComponentProps<typeof SpinnerWithVerb>> = {},
+): React.ComponentProps<typeof SpinnerWithVerb> {
+  return {
+    loadingStartTimeRef: makeRef(Date.now() - 10_000),
+    mode: "responding",
+    pauseStartTimeRef: makeRef(null),
+    responseLengthRef: makeRef(4096),
+    totalPausedMsRef: makeRef(0),
+    verbose: false,
+    ...overrides,
+  };
+}
+
+function makeTeammate(overrides: Record<string, any> = {}) {
+  return {
+    id: "teammate-1",
+    isIdle: false,
+    progress: { tokenCount: 128 },
+    spinnerVerb: "Reviewing",
+    startTime: Date.now() - 3_000,
+    status: "running",
+    type: "in_process_teammate",
+    ...overrides,
+  };
+}
+
+async function renderToText(node: React.ReactNode): Promise<string> {
+  let output = "";
+  const stdout = new PassThrough();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    setRawMode: (mode: boolean) => void;
+    ref: () => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.ref = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number }).columns = spinnerMock.terminalColumns;
+
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  });
+
+  try {
+    root.render(node);
+    await new Promise(resolve => setTimeout(resolve, 30));
+    return stripAnsi(output);
+  } finally {
+    root.unmount();
+    stdin.end();
+  }
+}
+
+async function renderSequenceToText(
+  nodes: React.ReactNode[],
+  advanceMs = 30,
+): Promise<string> {
+  let output = "";
+  const stdout = new PassThrough();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    setRawMode: (mode: boolean) => void;
+    ref: () => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.ref = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number }).columns = spinnerMock.terminalColumns;
+
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  });
+
+  try {
+    for (const node of nodes) {
+      root.render(node);
+      if (vi.isFakeTimers()) {
+        await vi.advanceTimersByTimeAsync(advanceMs);
+      } else {
+        await new Promise(resolve => setTimeout(resolve, advanceMs));
+      }
+    }
+    return stripAnsi(output);
+  } finally {
+    root.unmount();
+    stdin.end();
+  }
+}
+
+beforeEach(() => {
+  vi.useRealTimers();
+  spinnerMock.activity.ended = [];
+  spinnerMock.activity.started = [];
+  spinnerMock.appState.effortValue = "medium";
+  spinnerMock.appState.expandedView = undefined;
+  spinnerMock.appState.isBriefOnly = false;
+  spinnerMock.appState.remoteBackgroundTaskCount = 0;
+  spinnerMock.appState.remoteConnectionStatus = "connected";
+  spinnerMock.appState.selectedIPAgentIndex = 0;
+  spinnerMock.appState.tasks = {};
+  spinnerMock.appState.viewingAgentTaskId = undefined;
+  spinnerMock.appState.viewSelectionMode = "normal";
+  spinnerMock.currentTurnTokenBudget = null;
+  spinnerMock.featureFlags.clear();
+  spinnerMock.getKairosActive = false;
+  spinnerMock.getUserMsgOptIn = false;
+  spinnerMock.growthbookBrief = false;
+  spinnerMock.localAgents = [];
+  spinnerMock.outputTokens = 0;
+  spinnerMock.settings = {
+    prefersReducedMotion: false,
+    spinnerTipsEnabled: true,
+  };
+  spinnerMock.tasksV2 = undefined;
+  spinnerMock.terminalColumns = 80;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("Spinner rendering", () => {
+  test("renders the compact static spinner glyph", async () => {
+    const output = await renderToText(<Spinner />);
+
+    expect(output).toContain("◐");
+  });
+
+  test("routes brief-only mode to the brief spinner with background status", async () => {
+    spinnerMock.featureFlags.add("KAIROS_BRIEF");
+    spinnerMock.getKairosActive = true;
+    spinnerMock.appState.isBriefOnly = true;
+    spinnerMock.appState.remoteBackgroundTaskCount = 3;
+    spinnerMock.terminalColumns = 64;
+
+    const output = await renderToText(
+      <SpinnerWithVerb {...defaultSpinnerProps({ overrideMessage: "Summarizing" })} />,
+    );
+
+    expect(output).toContain("Summarizing");
+    expect(output).toContain("3 in background");
+    expect(spinnerMock.activity.started).toContain("spinner-responding");
+  });
+
+  test("shows brief connection warnings and hides overflowing right text", async () => {
+    spinnerMock.featureFlags.add("KAIROS");
+    spinnerMock.getUserMsgOptIn = true;
+    spinnerMock.growthbookBrief = true;
+    spinnerMock.appState.isBriefOnly = true;
+    spinnerMock.appState.remoteConnectionStatus = "disconnected";
+    spinnerMock.appState.remoteBackgroundTaskCount = 12;
+    spinnerMock.terminalColumns = 18;
+
+    const output = await renderToText(<SpinnerWithVerb {...defaultSpinnerProps()} />);
+
+    expect(output).toContain("Disconnected");
+    expect(output).not.toContain("12 in background");
+  });
+
+  test("renders the full spinner row with next task, tip, budget, and teammate tokens", async () => {
+    spinnerMock.featureFlags.add("TOKEN_BUDGET");
+    spinnerMock.currentTurnTokenBudget = 10_000;
+    spinnerMock.outputTokens = 5_000;
+    spinnerMock.appState.tasks = {
+      teammate: makeTeammate({ progress: { tokenCount: 2500 } }),
+    };
+    spinnerMock.tasksV2 = [
+      { activeForm: "Editing", blockedBy: [], id: "current", status: "running", subject: "current" },
+      { blockedBy: ["done"], id: "next", status: "pending", subject: "write tests" },
+      { blockedBy: ["current"], id: "blocked", status: "pending", subject: "blocked" },
+      { blockedBy: [], id: "done", status: "completed", subject: "done" },
+    ];
+
+    const output = await renderToText(
+      <SpinnerWithVerb
+        {...defaultSpinnerProps({
+          spinnerSuffix: "tail",
+          spinnerTip: "keep coverage moving",
+        })}
+      />,
+    );
+
+    expect(output).toContain("ROW responding");
+    expect(output).toContain("Editing");
+    expect(output).toContain("tokens:2500");
+    expect(output).toContain("suffix:tail");
+    expect(output).toContain("Target: 5.0k / 10.0k (50%)");
+    expect(output).toContain("Next: write tests");
+    expect(output).not.toContain("Tip: keep coverage moving");
+  });
+
+  test("shows expanded task list instead of tips when task view is active", async () => {
+    spinnerMock.appState.expandedView = "tasks";
+    spinnerMock.tasksV2 = [
+      { blockedBy: [], id: "task-1", status: "running", subject: "first task" },
+    ];
+
+    const output = await renderToText(
+      <SpinnerWithVerb {...defaultSpinnerProps({ spinnerTip: "hidden tip" })} />,
+    );
+
+    expect(output).toContain("TASKS:1");
+    expect(output).not.toContain("hidden tip");
+  });
+
+  test("shows teammate tree mode with selection state", async () => {
+    spinnerMock.appState.expandedView = "teammates";
+    spinnerMock.appState.selectedIPAgentIndex = 2;
+    spinnerMock.appState.viewSelectionMode = "selecting-agent";
+    spinnerMock.appState.tasks = {
+      teammate: makeTeammate(),
+    };
+
+    const output = await renderToText(<SpinnerWithVerb {...defaultSpinnerProps()} />);
+
+    expect(output).toContain("TREE selected:2");
+    expect(output).toContain("tokens:1024");
+  });
+
+  test("uses a foregrounded running teammate spinner verb", async () => {
+    spinnerMock.appState.viewingAgentTaskId = "teammate";
+    spinnerMock.appState.tasks = {
+      teammate: makeTeammate({ spinnerVerb: "Investigating" }),
+    };
+
+    const output = await renderToText(
+      <SpinnerWithVerb {...defaultSpinnerProps({ overrideMessage: "Leader message" })} />,
+    );
+
+    expect(output).toContain("Investigating");
+    expect(output).not.toContain("Leader message");
+  });
+
+  test("shows static leader idle status while agents continue running", async () => {
+    spinnerMock.localAgents = [{ id: "agent-1", summary: "Fixer working" }];
+
+    const output = await renderToText(
+      <SpinnerWithVerb {...defaultSpinnerProps({ leaderIsIdle: true })} />,
+    );
+
+    expect(output).toContain("Idle");
+    expect(output).toContain("agents running");
+    expect(output).toContain("Fixer working");
+    expect(output).not.toContain("ROW responding");
+  });
+
+  test("shows static leader idle status while teammates continue running", async () => {
+    spinnerMock.appState.tasks = {
+      teammate: makeTeammate({ isIdle: false }),
+    };
+
+    const output = await renderToText(
+      <SpinnerWithVerb {...defaultSpinnerProps({ leaderIsIdle: true })} />,
+    );
+
+    expect(output).toContain("Idle");
+    expect(output).toContain("teammates running");
+    expect(output).not.toContain("agents running");
+  });
+
+  test("shows static foregrounded teammate idle status", async () => {
+    spinnerMock.appState.viewingAgentTaskId = "teammate";
+    spinnerMock.appState.expandedView = "teammates";
+    spinnerMock.appState.tasks = {
+      teammate: makeTeammate({ isIdle: true }),
+    };
+
+    const output = await renderToText(<SpinnerWithVerb {...defaultSpinnerProps()} />);
+
+    expect(output).toContain("Worked for");
+    expect(output).toContain("TREE selected:0");
+  });
+
+  test("shows idle instead of worked-for when other teammates remain active", async () => {
+    spinnerMock.appState.viewingAgentTaskId = "idle";
+    spinnerMock.appState.tasks = {
+      idle: makeTeammate({ id: "idle", isIdle: true }),
+      active: makeTeammate({ id: "active", isIdle: false }),
+    };
+
+    const output = await renderToText(<SpinnerWithVerb {...defaultSpinnerProps()} />);
+
+    expect(output).toContain("Idle");
+    expect(output).not.toContain("Worked for");
+  });
+
+  test("shows explicit tips, long-context tips, and complete budget text", async () => {
+    const tipOutput = await renderToText(
+      <SpinnerWithVerb {...defaultSpinnerProps({ spinnerTip: "prefer focused tests" })} />,
+    );
+    expect(tipOutput).toContain("Tip: prefer focused tests");
+
+    const longContextOutput = await renderToText(
+      <SpinnerWithVerb
+        {...defaultSpinnerProps({
+          loadingStartTimeRef: makeRef(Date.now() - 1_900_000),
+          spinnerTip: "overridden tip",
+        })}
+      />,
+    );
+    expect(longContextOutput).toContain("Tip: Use /clear to start fresh");
+    expect(longContextOutput).not.toContain("overridden tip");
+
+    spinnerMock.featureFlags.add("TOKEN_BUDGET");
+    spinnerMock.currentTurnTokenBudget = 5000;
+    spinnerMock.outputTokens = 6000;
+    const budgetOutput = await renderToText(<SpinnerWithVerb {...defaultSpinnerProps()} />);
+    expect(budgetOutput).toContain("Target: 6.0k used (5.0k min");
+  });
+
+  test("tracks thinking status across mode transitions", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+
+    const thinkingProps = defaultSpinnerProps({ mode: "thinking" });
+    const respondingProps = defaultSpinnerProps({ mode: "responding" });
+    const output = await renderSequenceToText([
+      <SpinnerWithVerb {...thinkingProps} />,
+      <SpinnerWithVerb {...respondingProps} />,
+    ], 2100);
+
+    expect(output).toContain("thinking:thinking");
+    expect(output).toContain("thinking:2100");
+  });
+
+  test("renders brief idle placeholder, warnings, background counts, and local agents", async () => {
+    const emptyOutput = await renderToText(<BriefIdleStatus />);
+    expect(emptyOutput.trim()).toBe("");
+
+    spinnerMock.appState.remoteConnectionStatus = "reconnecting";
+    spinnerMock.appState.remoteBackgroundTaskCount = 4;
+    spinnerMock.terminalColumns = 60;
+    await expect(renderToText(<BriefIdleStatus />)).resolves.toContain("Reconnecting");
+    await expect(renderToText(<BriefIdleStatus />)).resolves.toContain("4 in background");
+
+    spinnerMock.localAgents = [{ id: "agent-1", summary: "Agent active" }];
+    const localOutput = await renderToText(<BriefIdleStatus />);
+    expect(localOutput).toContain("1 agent running");
+  });
+});

--- a/runtime/tests/tui/message-renderers/CollapsedReadSearchContent.render.test.tsx
+++ b/runtime/tests/tui/message-renderers/CollapsedReadSearchContent.render.test.tsx
@@ -1,0 +1,418 @@
+import { PassThrough } from "node:stream";
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { Text } from "../ink.js";
+import { createRoot } from "../ink/root.js";
+import { CollapsedReadSearchContent } from "./CollapsedReadSearchContent.js";
+
+const collapsedMock = vi.hoisted(() => ({
+  featureFlags: new Set<string>(["TEAMMEM"]),
+  fullscreen: false,
+  selectedBg: undefined as string | undefined,
+  teamMemHasOps: false,
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: (name: string) => collapsedMock.featureFlags.has(name),
+}));
+
+vi.mock("../../utils/fullscreen.js", () => ({
+  isFullscreenEnvEnabled: () => collapsedMock.fullscreen,
+}));
+
+vi.mock("../../utils/collapseReadSearch.js", async importOriginal => {
+  const actual = await importOriginal<typeof import("../../utils/collapseReadSearch.js")>();
+  return {
+    ...actual,
+    getToolUseIdsFromCollapsedGroup: (message: { toolUseIds?: string[] }) =>
+      message.toolUseIds ?? [],
+  };
+});
+
+vi.mock("../glyphs.js", () => ({
+  selectAgenCTuiGlyphs: () => ({
+    ellipsis: "...",
+    responseGutter: ">",
+    separator: "·",
+  }),
+}));
+
+vi.mock("../hooks/useMinDisplayTime", () => ({
+  useMinDisplayTime: (value: string | undefined) => value,
+}));
+
+vi.mock("../components/messageActions", () => ({
+  useSelectedMessageBg: () => collapsedMock.selectedBg,
+}));
+
+vi.mock("../components/CtrlOToExpand", () => {
+  return {
+    CtrlOToExpand: () => "[expand]",
+  };
+});
+
+vi.mock("../components/ToolUseLoader", () => {
+  return {
+    ToolUseLoader: (props: { isError?: boolean; isUnresolved?: boolean; shouldAnimate?: boolean }) =>
+      `LOADER:${props.shouldAnimate ? "anim" : "static"}:${props.isUnresolved ? "pending" : "done"}:${props.isError ? "error" : "ok"}`,
+  };
+});
+
+vi.mock("../components/PrBadge", () => {
+  return {
+    PrBadge: ({ number }: { number: number }) => `PR#${number}`,
+  };
+});
+
+vi.mock("../../tools/Tool", async importOriginal => {
+  const actual = await importOriginal<typeof import("../../tools/Tool")>();
+  return {
+    ...actual,
+    findToolByName: (tools: Record<string, unknown> | undefined, name: string) =>
+      tools?.[name] ?? null,
+  };
+});
+
+vi.mock("../../tools/REPLTool/primitiveTools", () => ({
+  getReplPrimitiveTools: () => ({}),
+}));
+
+vi.mock("./teamMemCollapsed", () => {
+  return {
+    TeamMemCountParts: ({
+      hasPrecedingParts,
+      isActiveGroup,
+    }: {
+      hasPrecedingParts: boolean;
+      isActiveGroup: boolean;
+    }) => collapsedMock.teamMemHasOps
+      ? `${hasPrecedingParts ? ", " : ""}${isActiveGroup ? "syncing" : "synced"} team memory`
+      : null,
+    checkHasTeamMemOps: () => collapsedMock.teamMemHasOps,
+  };
+});
+
+function schema<T>(data: T, success = true) {
+  return {
+    safeParse: () => success ? { data, success: true } : { success: false },
+  };
+}
+
+function makeTool(options: {
+  inputSuccess?: boolean;
+  outputSuccess?: boolean;
+} = {}) {
+  return {
+    inputSchema: schema({ path: "src/app.ts" }, options.inputSuccess ?? true),
+    outputSchema: schema({ lines: 7 }, options.outputSuccess ?? true),
+    renderToolResultMessage: (result: { lines: number }) => <Text>result:{result.lines}</Text>,
+    renderToolUseMessage: (input: { path: string }) => `read ${input.path}`,
+    renderToolUseTag: (input: { path: string }) => <Text>[tag:{input.path}]</Text>,
+    userFacingName: (input: { path: string } | undefined) => input ? "Read file" : "Read",
+  };
+}
+
+function makeAssistantToolUse(id: string, name = "read_file") {
+  return {
+    message: {
+      content: [
+        {
+          id,
+          input: { path: "src/app.ts" },
+          name,
+          type: "tool_use",
+        },
+      ],
+    },
+    type: "assistant",
+  };
+}
+
+function makeMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    bashCount: 0,
+    gitOpBashCount: 0,
+    hookCount: 0,
+    listCount: 0,
+    mcpCallCount: 0,
+    memoryReadCount: 0,
+    memorySearchCount: 0,
+    memoryWriteCount: 0,
+    messages: [],
+    readCount: 0,
+    readFilePaths: [],
+    replCount: 0,
+    searchArgs: [],
+    searchCount: 0,
+    toolUseIds: [] as string[],
+    ...overrides,
+  };
+}
+
+function makeLookups(overrides: Record<string, unknown> = {}) {
+  return {
+    erroredToolUseIDs: new Set<string>(),
+    progressMessagesByToolUseID: new Map<string, any[]>(),
+    resolvedToolUseIDs: new Set<string>(),
+    toolResultByToolUseID: new Map<string, any>(),
+    ...overrides,
+  };
+}
+
+async function renderToText(node: React.ReactNode): Promise<string> {
+  let output = "";
+  const stdout = new PassThrough();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    setRawMode: (mode: boolean) => void;
+    ref: () => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.ref = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number }).columns = 120;
+
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  });
+
+  try {
+    root.render(node);
+    await new Promise(resolve => setTimeout(resolve, 30));
+    return stripAnsi(output);
+  } finally {
+    root.unmount();
+    stdin.end();
+  }
+}
+
+function renderCollapsed(options: {
+  inProgress?: string[];
+  isActiveGroup?: boolean;
+  lookups?: ReturnType<typeof makeLookups>;
+  message?: ReturnType<typeof makeMessage>;
+  shouldAnimate?: boolean;
+  tools?: Record<string, unknown>;
+  verbose?: boolean;
+} = {}) {
+  return renderToText(
+    <CollapsedReadSearchContent
+      inProgressToolUseIDs={new Set(options.inProgress ?? [])}
+      isActiveGroup={options.isActiveGroup}
+      lookups={options.lookups ?? makeLookups()}
+      message={options.message ?? makeMessage()}
+      shouldAnimate={options.shouldAnimate ?? true}
+      tools={options.tools ?? {}}
+      verbose={options.verbose ?? false}
+    />,
+  );
+}
+
+beforeEach(() => {
+  collapsedMock.featureFlags.clear();
+  collapsedMock.featureFlags.add("TEAMMEM");
+  collapsedMock.fullscreen = false;
+  collapsedMock.selectedBg = undefined;
+  collapsedMock.teamMemHasOps = false;
+});
+
+describe("CollapsedReadSearchContent rendering", () => {
+  test("renders nothing for empty non-memory and non-tool groups", async () => {
+    const output = await renderCollapsed();
+
+    expect(output.trim()).toBe("");
+  });
+
+  test("summarizes active fullscreen operations, hints, hooks, and team memory", async () => {
+    collapsedMock.fullscreen = true;
+    collapsedMock.teamMemHasOps = true;
+    const lookups = makeLookups({
+      erroredToolUseIDs: new Set(["bash-1"]),
+      progressMessagesByToolUseID: new Map([
+        [
+          "bash-1",
+          [
+            {
+              data: {
+                elapsedTimeSeconds: 3,
+                totalLines: 2,
+                type: "bash_progress",
+              },
+            },
+          ],
+        ],
+      ]),
+    });
+
+    const output = await renderCollapsed({
+      inProgress: ["bash-1"],
+      isActiveGroup: true,
+      lookups,
+      message: makeMessage({
+        bashCount: 3,
+        branches: [{ action: "rebased", ref: "main" }],
+        commits: [
+          { kind: "committed", sha: "abc123" },
+          { kind: "amended", sha: "def456" },
+          { kind: "cherry-picked", sha: "fedcba" },
+        ],
+        gitOpBashCount: 1,
+        hookCount: 2,
+        hookTotalMs: 1250,
+        latestDisplayHint: "npm test",
+        listCount: 2,
+        mcpCallCount: 2,
+        mcpServerNames: ["agenc.ai docs"],
+        memoryReadCount: 1,
+        memorySearchCount: 1,
+        memoryWriteCount: 2,
+        prs: [{ action: "created", number: 42, url: "https://example.invalid/pr/42" }],
+        pushes: [{ branch: "feature/a" }, { branch: "feature/a" }],
+        readCount: 1,
+        replCount: 1,
+        searchCount: 2,
+        toolUseIds: ["bash-1"],
+      }),
+    });
+
+    expect(output).toContain("Committed abc123");
+    expect(output).toContain("amended commit def456");
+    expect(output).toContain("cherry-picked fedcba");
+    expect(output).toContain("pushed to feature/a");
+    expect(output).toContain("rebased onto main");
+    expect(output).toContain("created PR#42");
+    expect(output).toContain("searching for 2 patterns");
+    expect(output).toContain("reading 1 file");
+    expect(output).toContain("listing 2 directories");
+    expect(output).toContain("REPL'ing 1 time");
+    expect(output).toContain("querying docs 2 times");
+    expect(output.replace(/\s+/g, " ")).toContain("running 2 bash commands");
+    expect(output).toContain("recalling 1 memory");
+    expect(output).toContain("searching memories");
+    expect(output).toContain("writing 2 memories");
+    expect(output).toContain("syncing team memory");
+    expect(output).toContain("npm test (3s · 2 lines)");
+    expect(output).toContain("Ran 2 PreToolUse hooks");
+    expect(output).toContain("[expand]");
+  });
+
+  test("uses fallback read/search hints and finalized past tense", async () => {
+    const readOutput = await renderCollapsed({
+      message: makeMessage({
+        readCount: 2,
+        readFilePaths: ["/tmp/first.ts", "/repo/src/final.ts"],
+      }),
+    });
+    expect(readOutput).toContain("Read 2 files");
+    expect(readOutput).not.toContain("final.ts");
+
+    const searchOutput = await renderCollapsed({
+      isActiveGroup: true,
+      message: makeMessage({
+        searchArgs: ["needle"],
+        searchCount: 1,
+      }),
+    });
+    expect(searchOutput).toContain("Searching for 1 pattern");
+    expect(searchOutput).toContain('"needle"');
+  });
+
+  test("uses active REPL progress as the displayed hint", async () => {
+    const lookups = makeLookups({
+      progressMessagesByToolUseID: new Map([
+        [
+          "repl-1",
+          [
+            {
+              data: {
+                phase: "start",
+                toolInput: { pattern: "TODO" },
+                toolName: "grep",
+                type: "repl_tool_call",
+              },
+            },
+          ],
+        ],
+      ]),
+    });
+
+    const output = await renderCollapsed({
+      inProgress: ["repl-1"],
+      isActiveGroup: true,
+      lookups,
+      message: makeMessage({
+        replCount: 1,
+        toolUseIds: ["repl-1"],
+      }),
+    });
+
+    expect(output).toContain('"TODO"');
+  });
+
+  test("renders verbose tool uses, resolved results, hooks, and recalled memories", async () => {
+    const lookups = makeLookups({
+      resolvedToolUseIDs: new Set(["tool-1"]),
+      toolResultByToolUseID: new Map([
+        ["tool-1", { toolUseResult: { lines: 7 }, type: "user" }],
+      ]),
+    });
+    const output = await renderCollapsed({
+      lookups,
+      message: makeMessage({
+        hookCount: 1,
+        hookInfos: [{ command: "lint", durationMs: 750 }],
+        hookTotalMs: 750,
+        messages: [
+          makeAssistantToolUse("tool-1"),
+          {
+            messages: [
+              makeAssistantToolUse("tool-2", "missing_tool"),
+              { message: { content: [{ text: "plain", type: "text" }] }, type: "assistant" },
+            ],
+            type: "grouped_tool_use",
+          },
+        ],
+        relevantMemories: [{ content: "remembered note", path: "/notes/team.md" }],
+      }),
+      tools: { read_file: makeTool() },
+      verbose: true,
+    });
+
+    expect(output).toContain("Read file");
+    expect(output).toContain("read src/app.ts");
+    expect(output).toContain("[tag:src/app.ts]");
+    expect(output).toContain("result:7");
+    expect(output).toContain("Ran 1 PreToolUse hook");
+    expect(output).toContain("lint");
+    expect(output).toContain("Recalled team.md");
+    expect(output).toContain("remembered note");
+    expect(output).not.toContain("missing_tool");
+  });
+
+  test("keeps verbose unresolved and parse-failed tool calls minimal", async () => {
+    const output = await renderCollapsed({
+      inProgress: ["tool-1"],
+      lookups: makeLookups({
+        erroredToolUseIDs: new Set(["tool-1"]),
+      }),
+      message: makeMessage({
+        messages: [makeAssistantToolUse("tool-1")],
+      }),
+      tools: { read_file: makeTool({ inputSuccess: false, outputSuccess: false }) },
+      verbose: true,
+    });
+
+    expect(output).toContain("Read");
+    expect(output).not.toContain("result:");
+  });
+});


### PR DESCRIPTION
## Summary
- add focused TUI render/logic coverage for spinner, collapsed search content, structured diff fallback, message rows, coordinator agent panel, and prompt footer left side
- exercise additional mode, task, team, proactive, selection, and status rendering branches

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/PromptInput/PromptInputFooterLeftSide.render.test.tsx
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- npm --workspace=@tetsuo-ai/runtime run typecheck -- --pretty false