### PR TITLE
fix(runtime): expand TUI coverage and compact recovery

### DIFF
--- a/runtime/src/services/compact/autoCompact.ts
+++ b/runtime/src/services/compact/autoCompact.ts
@@ -24,6 +24,10 @@ export type AutoCompactTrackingState = {
   readonly consecutiveFailures?: number;
 };
 
+export type AutoCompactOptions = {
+  readonly force?: boolean;
+};
+
 export const AUTOCOMPACT_BUFFER_TOKENS = 13_000;
 const WARNING_THRESHOLD_BUFFER_TOKENS = 20_000;
 const ERROR_THRESHOLD_BUFFER_TOKENS = 20_000;
@@ -38,6 +42,7 @@ export async function autoCompactIfNeeded(
   querySource?: string,
   tracking?: AutoCompactTrackingState,
   snipTokensFreed = 0,
+  options: AutoCompactOptions = {},
 ): Promise<{
   readonly wasCompacted: boolean;
   readonly compactionResult?: CompactionResult;
@@ -59,7 +64,7 @@ export async function autoCompactIfNeeded(
     0,
     estimateMessagesTokens(messages, context) - snipTokensFreed,
   );
-  if (tokenCount < autoCompactThreshold(context)) {
+  if (options.force !== true && tokenCount < autoCompactThreshold(context)) {
     return { wasCompacted: false, consecutiveFailures: 0 };
   }
   try {

--- a/runtime/src/services/compact/snipCompact.ts
+++ b/runtime/src/services/compact/snipCompact.ts
@@ -8,6 +8,15 @@
 import type { RuntimeMessage } from "./types.js";
 import { estimateMessagesTokens } from "./_deps/runtime.js";
 
+export function isSnipMarkerMessage(candidate: unknown): boolean {
+  return (
+    typeof candidate === "object" &&
+    candidate !== null &&
+    (candidate as { readonly type?: unknown }).type === "system" &&
+    (candidate as { readonly subtype?: unknown }).subtype === "snip_marker"
+  );
+}
+
 export function snipCompact(
   messages: readonly RuntimeMessage[],
   options: {

--- a/runtime/src/services/compact/snipProjection.ts
+++ b/runtime/src/services/compact/snipProjection.ts
@@ -1,0 +1,34 @@
+import type { RuntimeMessage } from "./types.js";
+
+type SnipMetadata = {
+  readonly removedUuids?: readonly string[];
+};
+
+type SnipCandidate = RuntimeMessage & {
+  readonly snipMetadata?: SnipMetadata;
+  readonly uuid?: string;
+};
+
+export function isSnipBoundaryMessage(candidate: unknown): candidate is SnipCandidate {
+  return (
+    typeof candidate === "object" &&
+    candidate !== null &&
+    (candidate as { readonly type?: unknown }).type === "system" &&
+    (candidate as { readonly subtype?: unknown }).subtype === "snip_boundary"
+  );
+}
+
+export function projectSnippedView<T extends RuntimeMessage>(messages: readonly T[]): T[] {
+  const removed = new Set<string>();
+  for (const message of messages) {
+    if (!isSnipBoundaryMessage(message)) continue;
+    for (const uuid of message.snipMetadata?.removedUuids ?? []) {
+      removed.add(uuid);
+    }
+  }
+  if (removed.size === 0) return [...messages];
+  return messages.filter(message => {
+    const uuid = (message as SnipCandidate).uuid;
+    return uuid === undefined || !removed.has(uuid);
+  });
+}

--- a/runtime/src/session/run-turn.ts
+++ b/runtime/src/session/run-turn.ts
@@ -580,6 +580,7 @@ async function runAgenCAutoCompact(params: {
   readonly reason?: string;
   readonly phase?: string;
   readonly initialContextInjection?: string;
+  readonly force?: boolean;
 }): Promise<AgenCAutoCompactResult> {
   const finishTelemetry = startCompactTelemetry("auto", {
     query_source: params.querySource,
@@ -619,6 +620,7 @@ async function runAgenCAutoCompact(params: {
         params.querySource,
         state.autoCompactTracking,
         state.snipTokensFreed ?? 0,
+        { force: params.force === true },
       );
     }, envForToolUseContext(toolUseContext));
     if (!result.wasCompacted || !result.compactionResult) {
@@ -1815,6 +1817,7 @@ async function runAutoCompact(
     messageHasImageContent(state.messages.at(-1));
   const querySource =
     reason === "model_downshift" ? "model_downshift" : "repl_main_thread";
+  const force = shouldForceAutoCompact(reason, phase);
   try {
     const autoCompactImplOverride = getAutoCompactImplOverride();
     const result = autoCompactImplOverride
@@ -1824,6 +1827,7 @@ async function runAutoCompact(
         state?.autoCompactTracking,
         state?.snipTokensFreed ?? 0,
         initialContextInjection,
+        { force },
       )
       : await runAgenCAutoCompact({
         session,
@@ -1833,6 +1837,7 @@ async function runAutoCompact(
         reason,
         phase,
         initialContextInjection,
+        force,
       });
 
     if (result.wasCompacted && state) {
@@ -1905,6 +1910,13 @@ async function runAutoCompact(
     });
     return false;
   }
+}
+
+function shouldForceAutoCompact(
+  reason: CompactionReason,
+  phase: CompactionPhase,
+): boolean {
+  return reason === "context_limit" && phase === "in_turn";
 }
 
 /**

--- a/runtime/src/tui/components/AgentProgressLine.tsx
+++ b/runtime/src/tui/components/AgentProgressLine.tsx
@@ -114,12 +114,14 @@ export function AgentProgressLine(t0: Props) {
   } else {
     t9 = $[24];
   }
+  const statusText = getStatusText();
+  const shouldShowStatus = !isBackgrounded || taskDescription !== undefined;
   let t10;
-  if ($[25] !== getStatusText || $[26] !== isBackgrounded || $[27] !== isLast) {
-    t10 = !isBackgrounded && <Box paddingLeft={3} flexDirection="row"><Text dimColor={true}>{isLast ? `   ${glyphs.responseGutter}  ` : `${glyphs.treeContinuation}  ${glyphs.responseGutter}  `}</Text><Text dimColor={true}>{getStatusText()}</Text></Box>;
-    $[25] = getStatusText;
-    $[26] = isBackgrounded;
-    $[27] = isLast;
+  if ($[25] !== shouldShowStatus || $[26] !== isLast || $[27] !== statusText) {
+    t10 = shouldShowStatus && <Box paddingLeft={3} flexDirection="row"><Text dimColor={true}>{isLast ? `   ${glyphs.responseGutter}  ` : `${glyphs.treeContinuation}  ${glyphs.responseGutter}  `}</Text><Text dimColor={true}>{statusText}</Text></Box>;
+    $[25] = shouldShowStatus;
+    $[26] = isLast;
+    $[27] = statusText;
     $[28] = t10;
   } else {
     t10 = $[28];

--- a/runtime/src/tui/components/CustomSelect/use-multi-select-state.ts
+++ b/runtime/src/tui/components/CustomSelect/use-multi-select-state.ts
@@ -373,10 +373,13 @@ export function useMultiSelectState<T>({
 
         // Enter or Space toggles selection (including for input fields)
         if (navigation.focusedValue !== undefined) {
-          const newValues = selectedValues.includes(navigation.focusedValue)
-            ? selectedValues.filter(v => v !== navigation.focusedValue)
-            : [...selectedValues, navigation.focusedValue]
-          updateSelectedValues(newValues)
+          const option = options.find(opt => opt.value === navigation.focusedValue)
+          if (option?.disabled !== true) {
+            const newValues = selectedValues.includes(navigation.focusedValue)
+              ? selectedValues.filter(v => v !== navigation.focusedValue)
+              : [...selectedValues, navigation.focusedValue]
+            updateSelectedValues(newValues)
+          }
         }
         return
       }
@@ -385,11 +388,14 @@ export function useMultiSelectState<T>({
       if (!hideIndexes && /^[0-9]+$/.test(normalizedInput)) {
         const index = parseInt(normalizedInput) - 1
         if (index >= 0 && index < options.length) {
-          const value = options[index]!.value
-          const newValues = selectedValues.includes(value)
-            ? selectedValues.filter(v => v !== value)
-            : [...selectedValues, value]
-          updateSelectedValues(newValues)
+          const option = options[index]!
+          if (option.disabled !== true) {
+            const value = option.value
+            const newValues = selectedValues.includes(value)
+              ? selectedValues.filter(v => v !== value)
+              : [...selectedValues, value]
+            updateSelectedValues(newValues)
+          }
         }
         return
       }

--- a/runtime/src/tui/components/DiagnosticsDisplay.tsx
+++ b/runtime/src/tui/components/DiagnosticsDisplay.tsx
@@ -85,7 +85,9 @@ export function DiagnosticsDisplay(t0) {
 }
 function _temp3(file_0, fileIndex) {
   // branding-scan: allow upstream diagnostic URI scheme pending service purge
-  return <React.Fragment key={fileIndex}><MessageResponse><Text dimColor={true} wrap="wrap"><Text bold={true}>{relative(getCwd(), file_0.uri.replace("file://", "").replace("_claude_fs_right:", ""))}</Text>{" "}<Text dimColor={true}>{file_0.uri.startsWith("file://") ? "(file://)" : file_0.uri.startsWith("_claude_fs_right:") ? "(claude_fs_right)" : `(${file_0.uri.split(":")[0]})`}</Text>:</Text></MessageResponse>{file_0.diagnostics.map(_temp2)}</React.Fragment>;
+  const path = file_0.uri.replace("file://", "").replace("_agenc_fs_right:", "").replace("_claude_fs_right:", "");
+  const scheme = file_0.uri.startsWith("file://") ? "file://" : file_0.uri.split(":")[0].replace(/^_/, "");
+  return <React.Fragment key={fileIndex}><MessageResponse><Text dimColor={true} wrap="wrap"><Text bold={true}>{relative(getCwd(), path)}</Text>{" "}<Text dimColor={true}>({scheme})</Text>:</Text></MessageResponse>{file_0.diagnostics.map(_temp2)}</React.Fragment>;
 }
 function _temp2(diagnostic, diagIndex) {
   return <MessageResponse key={diagIndex}><Text dimColor={true} wrap="wrap">{"  "}{DiagnosticTrackingService.getSeveritySymbol(diagnostic.severity)}{" [Line "}{diagnostic.range.start.line + 1}:{diagnostic.range.start.character + 1}{"] "}{diagnostic.message}{diagnostic.code ? ` [${diagnostic.code}]` : ""}{diagnostic.source ? ` (${diagnostic.source})` : ""}</Text></MessageResponse>;

--- a/runtime/src/tui/components/HelpV2/HelpV2.tsx
+++ b/runtime/src/tui/components/HelpV2/HelpV2.tsx
@@ -31,6 +31,7 @@ export function HelpV2(t0: Props): React.ReactNode {
     columns
   } = useModalOrTerminalSize(useTerminalSize());
   const maxHeight = calculateHelpBodyHeight(rows);
+  const paneHeight = Math.min(rows, maxHeight + 5);
   const insideModal = useIsInsideModal();
   let t1;
   if ($[0] !== onClose) {
@@ -115,7 +116,7 @@ export function HelpV2(t0: Props): React.ReactNode {
   } else {
     tabs = $[15];
   }
-  const t5 = insideModal ? undefined : maxHeight;
+  const t5 = insideModal ? undefined : paneHeight;
   let t6;
   if ($[31] !== tabs) {
     t6 = <Tabs title="AgenC Help" color="professionalBlue" defaultTab="general">{tabs}</Tabs>;

--- a/runtime/src/tui/components/Message.tsx
+++ b/runtime/src/tui/components/Message.tsx
@@ -11,6 +11,8 @@ import { isAdvisorBlock } from '../../utils/advisor.js';
 import { isFullscreenEnvEnabled } from '../../utils/fullscreen.js';
 import { logError } from '../../utils/log.js';
 import type { buildMessageLookups } from '../../utils/messages.js';
+import { isSnipMarkerMessage } from '../../services/compact/snipCompact.js';
+import { isSnipBoundaryMessage } from '../../services/compact/snipProjection.js';
 import {
   AdvisorMessage,
   AssistantRedactedThinkingMessage,
@@ -29,8 +31,7 @@ import {
   UserTextMessage,
   UserToolResultMessage,
 } from './Message.renderers.js';
-
-type AnyComponent = React.ComponentType<any>;
+import { SnipBoundaryMessage } from '../message-renderers/SnipBoundaryMessage.js';
 
 export function getToolResultMessageWidth(columns: number): number {
   return Math.max(1, columns - 5);
@@ -292,30 +293,14 @@ function MessageImpl(t0: Props): React.ReactNode {
           return null;
         }
         if (feature("HISTORY_SNIP")) {
-          const {
-            isSnipBoundaryMessage
-          } = require("../../services/compact/snipProjection.js") as { isSnipBoundaryMessage: (candidate: unknown) => boolean };
-          const {
-            isSnipMarkerMessage
-          } = require("../../services/compact/snipCompact.js") as { isSnipMarkerMessage: (candidate: unknown) => boolean };
           if (isSnipBoundaryMessage(message)) {
-            let t2;
-            if ($[65] === Symbol.for("react.memo_cache_sentinel")) {
-              t2 = require("../message-renderers/SnipBoundaryMessage.js");
-              $[65] = t2;
-            } else {
-              t2 = $[65];
-            }
-            const {
-              SnipBoundaryMessage
-            } = t2 as { SnipBoundaryMessage: AnyComponent };
             let t3;
-            if ($[66] !== message) {
+            if ($[65] !== message) {
               t3 = <SnipBoundaryMessage message={message} />;
-              $[66] = message;
-              $[67] = t3;
+              $[65] = message;
+              $[66] = t3;
             } else {
-              t3 = $[67];
+              t3 = $[66];
             }
             return t3;
           }

--- a/runtime/src/tui/components/NativeAutoUpdater.tsx
+++ b/runtime/src/tui/components/NativeAutoUpdater.tsx
@@ -152,7 +152,7 @@ export function NativeAutoUpdater({
 
   // Check every 30 minutes
   useInterval(checkForUpdates, 30 * 60 * 1000);
-  const hasUpdateResult = !!autoUpdaterResult?.version;
+  const hasUpdateResult = autoUpdaterResult?.status === 'install_failed' || !!autoUpdaterResult?.version;
   const hasVersionInfo = !!versions.current && !!versions.latest;
   // Show the component when there is an update result to display or an active
   // check has version info to show.

--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -2049,7 +2049,12 @@ function PromptInput({
   const handleImagePaste = useCallback(() => {
     void getImageFromClipboard().then(imageData => {
       if (imageData) {
-        onImagePaste(imageData.base64, imageData.mediaType);
+        onImagePaste(
+          imageData.base64,
+          imageData.mediaType,
+          undefined,
+          imageData.dimensions,
+        );
       } else {
         const shortcutDisplay = getShortcutDisplay('chat:imagePaste', 'Chat', 'ctrl+v');
         const message = env.isSSH() ? "No image found in clipboard. You're SSH'd; try scp?" : `No image found in clipboard. Use ${shortcutDisplay} to paste images.`;

--- a/runtime/src/tui/components/WorktreeExitDialog.tsx
+++ b/runtime/src/tui/components/WorktreeExitDialog.tsx
@@ -11,14 +11,14 @@ import { Select } from './CustomSelect/select';
 import { Dialog } from './design-system/Dialog';
 import { Spinner } from './spinner/Spinner.js';
 
-// Inline require breaks the cycle this file would otherwise close:
+// Lazy import breaks the cycle this file would otherwise close:
 // sessionStorage → commands → exit → ExitFlow → here. All call sites
-// are inside callbacks, so the lazy require never sees an undefined import.
-function recordWorktreeExit(): void {
-  /* eslint-disable @typescript-eslint/no-require-imports */
-  ;
-  (require('../../utils/sessionStorage') as typeof import('../../utils/sessionStorage')).saveWorktreeState(null);
-  /* eslint-enable @typescript-eslint/no-require-imports */
+// are inside callbacks, so the lazy import never sees an undefined import.
+async function recordWorktreeExit(): Promise<void> {
+  const {
+    saveWorktreeState
+  } = await import('../../utils/sessionStorage.js');
+  saveWorktreeState(null);
 }
 type Props = {
   onDone: (result?: string, options?: {
@@ -62,10 +62,10 @@ export function WorktreeExitDialog({
         // If no changes and no commits, clean up silently
         if (changeLines.length === 0 && count === 0) {
           setStatus('removing');
-          void cleanupWorktree().then(() => {
+          void cleanupWorktree().then(async () => {
             process.chdir(worktreeSession.originalCwd);
             setCwd(worktreeSession.originalCwd);
-            recordWorktreeExit();
+            await recordWorktreeExit();
             getPlansDirectory.cache.clear?.();
             setResultMessage('Worktree removed (no changes)');
           }).catch(error => {
@@ -115,7 +115,7 @@ export function WorktreeExitDialog({
       await keepWorktree();
       process.chdir(worktreeSession.originalCwd);
       setCwd(worktreeSession.originalCwd);
-      recordWorktreeExit();
+      await recordWorktreeExit();
       getPlansDirectory.cache.clear?.();
       if (hasTmux) {
         setResultMessage(`Worktree kept. Your work is saved at ${worktreeSession.worktreePath} on branch ${worktreeSession.worktreeBranch}. Reattach to tmux session with: tmux attach -t ${worktreeSession.tmuxSessionName}`);
@@ -135,7 +135,7 @@ export function WorktreeExitDialog({
       await keepWorktree();
       process.chdir(worktreeSession.originalCwd);
       setCwd(worktreeSession.originalCwd);
-      recordWorktreeExit();
+      await recordWorktreeExit();
       getPlansDirectory.cache.clear?.();
       setResultMessage(`Worktree kept at ${worktreeSession.worktreePath} on branch ${worktreeSession.worktreeBranch}. Tmux session terminated.`);
       setStatus('done');
@@ -152,7 +152,7 @@ export function WorktreeExitDialog({
         await cleanupWorktree();
         process.chdir(worktreeSession.originalCwd);
         setCwd(worktreeSession.originalCwd);
-        recordWorktreeExit();
+        await recordWorktreeExit();
         getPlansDirectory.cache.clear?.();
       } catch (error) {
         logForDebugging(`Failed to clean up worktree: ${error}`, {

--- a/runtime/src/tui/components/memory/selector-options.ts
+++ b/runtime/src/tui/components/memory/selector-options.ts
@@ -86,10 +86,9 @@ function memoryFileLabel(
   }
 
   const displayPath = displayPathFor(file.path);
-  const existsLabel = file.exists ? '' : ' (new)';
   if (depth > 0) {
     const indent = '  '.repeat(depth - 1);
-    return `${indent}L ${displayPath}${existsLabel}`;
+    return `${indent}L ${displayPath}`;
   }
   return displayPath;
 }

--- a/runtime/src/tui/components/tasks/BackgroundTaskStatus.tsx
+++ b/runtime/src/tui/components/tasks/BackgroundTaskStatus.tsx
@@ -104,9 +104,9 @@ export function BackgroundTaskStatus(t0) {
   if (allTeammates || !showSpinnerTree && isViewingTeammate) {
     const selectedIdx = tasksSelected ? teammateFooterIndex : -1;
     let t8;
-    if ($[12] !== teammateEntries || $[13] !== viewingAgentTaskId) {
-      t8 = viewingAgentTaskId ? teammateEntries.findIndex(t_3 => t_3.id === viewingAgentTaskId) + 1 : 0;
-      $[12] = teammateEntries;
+    if ($[12] !== allPills || $[13] !== viewingAgentTaskId) {
+      t8 = viewingAgentTaskId ? allPills.findIndex(t_3 => t_3.taskId === viewingAgentTaskId) : 0;
+      $[12] = allPills;
       $[13] = viewingAgentTaskId;
       $[14] = t8;
     } else {

--- a/runtime/src/tui/hooks/fileSuggestions.ts
+++ b/runtime/src/tui/hooks/fileSuggestions.ts
@@ -812,7 +812,9 @@ export async function generateFileSuggestions(
       query: partialPath,
     }
     const results = await executeFileSuggestionCommand(input)
-    return results.slice(0, MAX_SUGGESTIONS).map(createFileSuggestionItem)
+    return results
+      .slice(0, MAX_SUGGESTIONS)
+      .map(path => createFileSuggestionItem(path))
   }
 
   // If the partial path is empty or just a dot, return current directory suggestions

--- a/runtime/src/tui/hooks/fileSuggestions.ts
+++ b/runtime/src/tui/hooks/fileSuggestions.ts
@@ -54,11 +54,15 @@ let untrackedFetchPromise: Promise<void> | null = null
 
 // Store tracked files so we can rebuild index with untracked
 let cachedTrackedFiles: string[] = []
+// Store the latest normalized untracked files. The background untracked
+// command can finish before the tracked/config/directory cache is ready.
+let cachedUntrackedFiles: string[] = []
 // Store config files so mergeUntrackedIntoNormalizedCache preserves them
 let cachedConfigFiles: string[] = []
 // Store tracked directories so mergeUntrackedIntoNormalizedCache doesn't
 // recompute ~270k path.dirname() calls on each merge
 let cachedTrackedDirs: string[] = []
+let trackedCacheReadyForUntrackedMerge = false
 
 // Cache for project file-picker ignore patterns (keyed by repoRoot:cwd)
 let ignorePatternsCache: ReturnType<typeof ignore> | null = null
@@ -89,8 +93,10 @@ export function clearFileSuggestionCaches(): void {
   cacheGeneration++
   untrackedFetchPromise = null
   cachedTrackedFiles = []
+  cachedUntrackedFiles = []
   cachedConfigFiles = []
   cachedTrackedDirs = []
+  trackedCacheReadyForUntrackedMerge = false
   indexBuildComplete.clear()
   ignorePatternsCache = null
   ignorePatternsCacheKey = null
@@ -171,8 +177,10 @@ function normalizeGitPaths(
 async function mergeUntrackedIntoNormalizedCache(
   normalizedUntracked: string[],
 ): Promise<void> {
+  cachedUntrackedFiles = normalizedUntracked
   if (normalizedUntracked.length === 0) return
   if (!fileIndex || cachedTrackedFiles.length === 0) return
+  if (!trackedCacheReadyForUntrackedMerge) return
 
   const untrackedDirs = await getDirectoryNamesAsync(normalizedUntracked)
   const allPaths = [
@@ -536,6 +544,7 @@ async function getProjectFiles(
 export async function getPathsForSuggestions(): Promise<FileIndex> {
   const signal = AbortSignal.timeout(10_000)
   const index = getFileIndex()
+  trackedCacheReadyForUntrackedMerge = false
 
   try {
     // Check project settings first, then fall back to global config
@@ -574,6 +583,10 @@ export async function getPathsForSuggestions(): Promise<FileIndex> {
       logForDebugging(
         `[FileIndex] skipped index rebuild — tracked paths unchanged`,
       )
+    }
+    trackedCacheReadyForUntrackedMerge = true
+    if (cachedUntrackedFiles.length > 0) {
+      void mergeUntrackedIntoNormalizedCache(cachedUntrackedFiles)
     }
   } catch (error) {
     logError(error)

--- a/runtime/src/tui/hooks/useArrowKeyHistory.tsx
+++ b/runtime/src/tui/hooks/useArrowKeyHistory.tsx
@@ -150,7 +150,6 @@ export function useArrowKeyHistory(onSetInput: (value: string, mode: HistoryMode
       if (historyCacheModeFilter.current !== modeFilter) {
         historyCache.current = [];
         historyCacheModeFilter.current = modeFilter;
-        historyIndexRef.current = 0;
       }
 
       // Load more entries if needed

--- a/runtime/src/tui/hooks/useIdeSelection.ts
+++ b/runtime/src/tui/hooks/useIdeSelection.ts
@@ -91,23 +91,31 @@ export function useIdeSelection(
 
     // Handler function for selection changes
     const selectionChangeHandler = (data: SelectionData) => {
-      if (data.selection?.start && data.selection?.end) {
-        const { start, end } = data.selection
-        let lineCount = end.line - start.line + 1
-        // If on the first character of the line, do not count the line
-        // as being selected.
-        if (end.character === 0) {
-          lineCount--
-        }
-        const selection = {
-          lineCount,
-          lineStart: start.line,
+      if (!data.selection?.start || !data.selection?.end) {
+        onSelect({
+          lineCount: 0,
+          lineStart: undefined,
           text: data.text,
           filePath: data.filePath,
-        }
-
-        onSelect(selection)
+        })
+        return
       }
+
+      const { start, end } = data.selection
+      let lineCount = end.line - start.line + 1
+      // If on the first character of the line, do not count the line
+      // as being selected.
+      if (end.character === 0) {
+        lineCount--
+      }
+      const selection = {
+        lineCount,
+        lineStart: start.line,
+        text: data.text,
+        filePath: data.filePath,
+      }
+
+      onSelect(selection)
     }
 
     // Register notification handler for selection_changed events

--- a/runtime/src/tui/hooks/useInputBuffer.ts
+++ b/runtime/src/tui/hooks/useInputBuffer.ts
@@ -28,8 +28,10 @@ export function useInputBuffer({
   maxBufferSize,
   debounceMs,
 }: UseInputBufferProps): UseInputBufferResult {
-  const [buffer, setBuffer] = useState<BufferEntry[]>([])
-  const [currentIndex, setCurrentIndex] = useState(-1)
+  const [{ buffer, currentIndex }, setBufferState] = useState<{
+    buffer: BufferEntry[]
+    currentIndex: number
+  }>({ buffer: [], currentIndex: -1 })
   const lastPushTime = useRef<number>(0)
   const pendingPush = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -61,15 +63,20 @@ export function useInputBuffer({
 
       lastPushTime.current = now
 
-      setBuffer(prevBuffer => {
+      setBufferState(prevState => {
         // If we're not at the end of the buffer, truncate everything after current position
         const newBuffer =
-          currentIndex >= 0 ? prevBuffer.slice(0, currentIndex + 1) : prevBuffer
+          prevState.currentIndex >= 0
+            ? prevState.buffer.slice(0, prevState.currentIndex + 1)
+            : prevState.buffer
 
         // Don't add if it's the same as the last entry
         const lastEntry = newBuffer[newBuffer.length - 1]
         if (lastEntry && lastEntry.text === text) {
-          return newBuffer
+          return {
+            buffer: newBuffer,
+            currentIndex: newBuffer.length - 1,
+          }
         }
 
         // Add new entry
@@ -79,20 +86,18 @@ export function useInputBuffer({
         ]
 
         // Limit buffer size
-        if (updatedBuffer.length > maxBufferSize) {
-          return updatedBuffer.slice(-maxBufferSize)
+        const limitedBuffer =
+          updatedBuffer.length > maxBufferSize
+            ? updatedBuffer.slice(-maxBufferSize)
+            : updatedBuffer
+
+        return {
+          buffer: limitedBuffer,
+          currentIndex: limitedBuffer.length - 1,
         }
-
-        return updatedBuffer
-      })
-
-      // Update current index to point to the new entry
-      setCurrentIndex(prev => {
-        const newIndex = prev >= 0 ? prev + 1 : buffer.length
-        return Math.min(newIndex, maxBufferSize - 1)
       })
     },
-    [debounceMs, maxBufferSize, currentIndex, buffer.length],
+    [debounceMs, maxBufferSize],
   )
 
   const undo = useCallback((): BufferEntry | undefined => {
@@ -104,7 +109,10 @@ export function useInputBuffer({
     const entry = buffer[targetIndex]
 
     if (entry) {
-      setCurrentIndex(targetIndex)
+      setBufferState(prevState => ({
+        ...prevState,
+        currentIndex: Math.min(targetIndex, prevState.buffer.length - 1),
+      }))
       return entry
     }
 
@@ -112,8 +120,7 @@ export function useInputBuffer({
   }, [buffer, currentIndex])
 
   const clearBuffer = useCallback(() => {
-    setBuffer([])
-    setCurrentIndex(-1)
+    setBufferState({ buffer: [], currentIndex: -1 })
     lastPushTime.current = 0
     if (pendingPush.current) {
       clearTimeout(pendingPush.current)

--- a/runtime/src/tui/ink/ink.tsx
+++ b/runtime/src/tui/ink/ink.tsx
@@ -368,6 +368,15 @@ export default class Ink {
     // layout is updated, causing a mismatch between viewport and content dimensions.
     if (this.currentNode !== null) {
       this.render(this.currentNode);
+      // If only terminal dimensions changed, React may produce no host
+      // mutations and therefore skip resetAfterCommit/onRender entirely.
+      // Alt-screen resize still dirties the frame buffers above, so consume
+      // the pending atomic clear+paint now after layout has been recalculated.
+      if (this.altScreenActive && this.needsEraseBeforePaint) {
+        this.scheduleRender.cancel?.();
+        this.rootNode.onComputeLayout?.();
+        this.onRender();
+      }
     }
   };
   resolveExitPromise: () => void = () => {};

--- a/runtime/src/tui/message-renderers/AssistantToolUseMessage.tsx
+++ b/runtime/src/tui/message-renderers/AssistantToolUseMessage.tsx
@@ -219,16 +219,17 @@ export function AssistantToolUseMessage(t0) {
   } else {
     t14 = $[72];
   }
+  const queuedDetail = typeof t14 === "string" ? <Text dimColor={true}>{t14}</Text> : t14;
   const toolState: ToolState = lookups.erroredToolUseIDs.has(param.id) ? "failed" : isResolved ? "done" : isQueued ? "queued" : "running";
   const toolArgs = typeof renderedToolUseMessage === "string" && renderedToolUseMessage.length > 0 ? renderedToolUseMessage : summarizeToolInput(input_0.data);
   const extraDetail = typeof renderedToolUseMessage === "string" ? null : renderedToolUseMessage;
   let t15;
-  if ($[73] !== extraDetail || $[74] !== t11 || $[75] !== t13 || $[76] !== t14) {
-    t15 = extraDetail || t11 || t13 || t14 ? <Box flexDirection="column">{extraDetail}{t11}{t13}{t14}</Box> : null;
+  if ($[73] !== extraDetail || $[74] !== t11 || $[75] !== t13 || $[76] !== queuedDetail) {
+    t15 = extraDetail || t11 || t13 || queuedDetail ? <Box flexDirection="column">{extraDetail}{t11}{t13}{queuedDetail}</Box> : null;
     $[73] = extraDetail;
     $[74] = t11;
     $[75] = t13;
-    $[76] = t14;
+    $[76] = queuedDetail;
     $[77] = t15;
   } else {
     t15 = $[77];

--- a/runtime/src/tui/message-renderers/SnipBoundaryMessage.tsx
+++ b/runtime/src/tui/message-renderers/SnipBoundaryMessage.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { MessageResponse } from "../components/MessageResponse.js";
+import { Text } from "../ink.js";
+
+export function SnipBoundaryMessage(_props: { readonly message: unknown }): React.ReactNode {
+  return (
+    <MessageResponse>
+      <Text dimColor={true}>Earlier conversation snipped</Text>
+    </MessageResponse>
+  );
+}

--- a/runtime/src/tui/realtime/audio.ts
+++ b/runtime/src/tui/realtime/audio.ts
@@ -108,6 +108,8 @@ export function createProcessRealtimeAudioPlayer(
         reset(active);
         return;
       }
+      queue.shift();
+      queuedBytes -= chunk.length;
       if (!accepted) {
         if (!waitingForDrain) {
           waitingForDrain = true;
@@ -118,8 +120,6 @@ export function createProcessRealtimeAudioPlayer(
         }
         return;
       }
-      queue.shift();
-      queuedBytes -= chunk.length;
     }
   };
 

--- a/runtime/tests/services/compact/autoCompact.test.ts
+++ b/runtime/tests/services/compact/autoCompact.test.ts
@@ -92,6 +92,31 @@ describe("auto compact", () => {
       .toContain("recent request");
   });
 
+  test("force compacts even when local estimation is below threshold", async () => {
+    const messages = [message("small current turn")];
+
+    await expect(autoCompactIfNeeded(messages, {
+      options: { contextWindowTokens: 100_000 },
+    })).resolves.toEqual({
+      wasCompacted: false,
+      consecutiveFailures: 0,
+    });
+
+    const result = await autoCompactIfNeeded(
+      messages,
+      { options: { contextWindowTokens: 100_000 } },
+      undefined,
+      "repl_main_thread",
+      undefined,
+      0,
+      { force: true },
+    );
+
+    expect(result.wasCompacted).toBe(true);
+    expect(result.compactionResult?.summaryMessages[0]?.content)
+      .toContain("small current turn");
+  });
+
   test("prefers session-memory compaction and runs cleanup after success", async () => {
     process.env.AGENC_ENABLE_SESSION_MEMORY_COMPACT = "1";
     const cleanup = {

--- a/runtime/tests/session/run-turn.compact-contract.test.ts
+++ b/runtime/tests/session/run-turn.compact-contract.test.ts
@@ -137,4 +137,81 @@ describe("runTurn compact contract", () => {
       { role: "user", content: "mid compact summary" },
     ]);
   });
+
+  test("mid-turn context-limit compaction forces an estimator-vetoed compact", async () => {
+    const seen: LLMMessage[][] = [];
+    let streamCount = 0;
+    const provider = mkProvider({}, {
+      onChatStream: (messages) => seen.push(messages),
+    });
+    provider.chatStream = async (messages): Promise<LLMResponse> => {
+      seen.push(messages.map((message) => ({ ...message })));
+      streamCount += 1;
+      if (streamCount === 1) {
+        return {
+          content: "need a tool",
+          toolCalls: [{ id: "toolu_force", name: "Read", arguments: "{}" }],
+          usage: {
+            promptTokens: 18_130,
+            completionTokens: 10,
+            totalTokens: 18_140,
+          },
+          model: "test-model",
+          finishReason: "tool_calls",
+        };
+      }
+      return {
+        content: "after forced compact",
+        toolCalls: [],
+        usage: { promptTokens: 5, completionTokens: 5, totalTokens: 10 },
+        model: "test-model",
+        finishReason: "stop",
+      };
+    };
+    const compactImpl = vi.fn<AutoCompactImpl>(async (...args) => {
+      const options = args[5] as { force?: boolean } | undefined;
+      if (options?.force !== true) {
+        return { wasCompacted: false };
+      }
+      return {
+        wasCompacted: true,
+        compactionResult: {
+          message: "forced mid compact summary",
+          replacementHistory: [
+            { role: "user", content: "<compact>forced</compact>" },
+            { role: "user", content: "forced mid compact summary" },
+          ],
+        },
+      };
+    });
+    setAutoCompactImplForTests(compactImpl);
+    const { session, events } = mkSession({
+      provider,
+      modelInfo: { autoCompactTokenLimit: 18_129 } as never,
+    });
+
+    await drain(runTurn(session, mkCtx({
+      modelInfo: {
+        ...mkCtx().modelInfo,
+        autoCompactTokenLimit: 18_129,
+      } as never,
+    }), "start"));
+
+    expect(streamCount).toBe(2);
+    expect(compactImpl).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.any(Object),
+      undefined,
+      0,
+      "before_last_user_message",
+      { force: true },
+    );
+    expect(events.some((event) =>
+      event.msg.type === "error" &&
+      event.msg.payload.cause === "mid_turn_compact_failed"
+    )).toBe(false);
+    expect(seen[1]).toEqual([
+      { role: "user", content: "forced mid compact summary" },
+    ]);
+  });
 });

--- a/runtime/tests/tui/completion-pipeline.wave200-055.coverage.test.ts
+++ b/runtime/tests/tui/completion-pipeline.wave200-055.coverage.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  COMPLETION_PIPELINE_EVENT_LOG_ENV,
+  formatCompletionPipelineRows,
+  gateIndexFor,
+  normalizeCompletionPipelineEvent,
+  readCompletionPipelineState,
+  reduceCompletionPipelineEvents,
+  type CompletionPipelineEvent,
+} from "./completion-pipeline.js";
+
+function pipelineEvent(
+  sequence: number,
+  gateId: string,
+  status: CompletionPipelineEvent["status"],
+  pipelineId = "current",
+): CompletionPipelineEvent {
+  return {
+    pipelineId,
+    sequence,
+    gateId,
+    gateIndex: gateIndexFor(gateId),
+    status,
+    timestamp: new Date(sequence * 1000).toISOString(),
+  };
+}
+
+describe("completion pipeline wave 055 coverage", () => {
+  test("normalizes persisted events and reduces only the latest pipeline", () => {
+    expect(gateIndexFor("custom_gate", 42)).toBe(42);
+    expect(gateIndexFor("custom_gate")).toBe(9);
+    expect(normalizeCompletionPipelineEvent(null)).toBeNull();
+    expect(
+      normalizeCompletionPipelineEvent({
+        pipelineId: " ",
+        gateId: "prep",
+        sequence: 1,
+        status: "started",
+      }),
+    ).toBeNull();
+    expect(
+      normalizeCompletionPipelineEvent({
+        pipelineId: "current",
+        gateId: " ",
+        sequence: 1,
+        status: "started",
+      }),
+    ).toBeNull();
+    expect(
+      normalizeCompletionPipelineEvent({
+        pipelineId: "current",
+        gateId: "prep",
+        sequence: 1.5,
+        status: "started",
+      }),
+    ).toBeNull();
+    expect(
+      normalizeCompletionPipelineEvent({
+        pipelineId: "current",
+        gateId: "prep",
+        sequence: 1,
+        status: "unknown",
+      }),
+    ).toBeNull();
+
+    const normalized = normalizeCompletionPipelineEvent({
+      pipelineId: "current",
+      sequence: 2,
+      gateId: "custom_gate",
+      gateIndex: 42,
+      status: "failed",
+      message: "  stalled\nwhile waiting  ",
+      detail: ` ${"x".repeat(260)} `,
+      timestamp: "not a date",
+    });
+
+    expect(normalized).toMatchObject({
+      pipelineId: "current",
+      sequence: 2,
+      gateId: "custom_gate",
+      gateIndex: 42,
+      status: "failed",
+      message: "stalled while waiting",
+      timestamp: "1970-01-01T00:00:00.000Z",
+    });
+    expect(normalized?.detail).toHaveLength(240);
+    expect(normalized?.detail?.endsWith("\u2026")).toBe(true);
+
+    const env = {
+      [COMPLETION_PIPELINE_EVENT_LOG_ENV]: "logs/events.jsonl",
+    };
+    const readPaths: string[] = [];
+    const state = readCompletionPipelineState({
+      env,
+      cwd: "/tmp/agenc",
+      readFile: (path) => {
+        readPaths.push(path);
+        return [
+          JSON.stringify(pipelineEvent(1, "prep", "started", "stale")),
+          JSON.stringify(pipelineEvent(2, "prep", "succeeded", "stale")),
+          JSON.stringify(pipelineEvent(3, "prep", "started")),
+          JSON.stringify(pipelineEvent(4, "typecheck", "failed")),
+          JSON.stringify(pipelineEvent(5, "typecheck", "started")),
+          JSON.stringify(pipelineEvent(6, "custom_gate", "succeeded")),
+          JSON.stringify(pipelineEvent(7, "custom_gate", "started")),
+          JSON.stringify(pipelineEvent(8, "local_merge", "completed")),
+        ].join("\n");
+      },
+    });
+
+    expect(readPaths).toEqual(["/tmp/agenc/logs/events.jsonl"]);
+    expect(state.pipelineId).toBe("current");
+    expect(state.activeGate).toBeNull();
+    expect(state.ownsPrompt).toBe(false);
+    expect(state.gates.map((gate) => gate.gateId)).toEqual([
+      "prep",
+      "typecheck",
+      "local_merge",
+      "custom_gate",
+    ]);
+    expect(state.gates.find((gate) => gate.gateId === "typecheck")).toMatchObject({
+      status: "failed",
+      started: true,
+    });
+    expect(state.gates.find((gate) => gate.gateId === "custom_gate")).toMatchObject({
+      status: "succeeded",
+      started: true,
+    });
+    expect(formatCompletionPipelineRows(state)).toEqual([
+      "Completion 1/9: Prepare goal running",
+      "Completion 6/9: Typecheck failed",
+      "Completion 9/9: Local merge completed",
+      "Completion ?/9: custom gate ok",
+      "Completion pipeline complete: Completion pipeline finished",
+    ]);
+
+    expect(
+      reduceCompletionPipelineEvents([
+        pipelineEvent(1, "review", "started"),
+        pipelineEvent(2, "review", "cancelled"),
+        pipelineEvent(3, "review", "started"),
+      ]).terminal,
+    ).toMatchObject({
+      status: "cancelled",
+      detail: "Pipeline cancelled",
+    });
+    expect(readCompletionPipelineState({ readFile: () => { throw new Error("nope"); } })).toMatchObject({
+      pipelineId: null,
+      gates: [],
+    });
+  });
+});

--- a/runtime/tests/tui/components/AgentProgressLine.coverage.test.tsx
+++ b/runtime/tests/tui/components/AgentProgressLine.coverage.test.tsx
@@ -1,0 +1,135 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { Box } from "../ink.js";
+import { createRoot } from "../ink/root.js";
+import { AgentProgressLine } from "./AgentProgressLine.js";
+
+type AgentProgressLineProps = React.ComponentProps<typeof AgentProgressLine>;
+
+const originalGlyphMode = process.env.AGENC_TUI_GLYPHS;
+
+afterEach(() => {
+  if (originalGlyphMode === undefined) {
+    delete process.env.AGENC_TUI_GLYPHS;
+  } else {
+    process.env.AGENC_TUI_GLYPHS = originalGlyphMode;
+  }
+});
+
+function createStreams(): {
+  stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdout: PassThrough;
+} {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.resume();
+  (stdout as unknown as { columns: number }).columns = 120;
+  return { stdin, stdout };
+}
+
+async function renderToText(node: React.ReactNode): Promise<string> {
+  let output = "";
+  const { stdin, stdout } = createStreams();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  try {
+    root.render(node);
+    await new Promise(resolve => setTimeout(resolve, 30));
+    return stripAnsi(output);
+  } finally {
+    root.unmount();
+    stdin.end();
+    stdout.end();
+  }
+}
+
+function props(
+  overrides: Partial<AgentProgressLineProps> = {},
+): AgentProgressLineProps {
+  return {
+    agentType: "Agent",
+    isError: false,
+    isLast: false,
+    isResolved: false,
+    shouldAnimate: false,
+    tokens: null,
+    toolUseCount: 0,
+    ...overrides,
+  };
+}
+
+describe("AgentProgressLine coverage", () => {
+  test("renders active, resolved, and backgrounded progress states", async () => {
+    process.env.AGENC_TUI_GLYPHS = "ascii";
+
+    const output = await renderToText(
+      <Box flexDirection="column">
+        <AgentProgressLine
+          {...props({
+            agentType: "reviewer",
+            description: "plan",
+            lastToolInfo: "Reading source",
+            toolUseCount: 1,
+            tokens: 1500,
+          })}
+        />
+        <AgentProgressLine
+          {...props({
+            description: "final checks",
+            hideType: true,
+            isResolved: true,
+            name: "Beta",
+            toolUseCount: 2,
+          })}
+        />
+        <AgentProgressLine
+          {...props({
+            description: "background sync",
+            hideType: true,
+            isAsync: true,
+            isLast: true,
+            isResolved: true,
+            taskDescription: "Indexing repo",
+            tokens: 9000,
+            toolUseCount: 7,
+          })}
+        />
+      </Box>,
+    );
+
+    expect(output).toContain("|- reviewer (plan) · 1 tool use · 1.5k tokens");
+    expect(output).toContain("|  |_  Reading source");
+    expect(output).toContain("|- Beta: final checks · 2 tool uses");
+    expect(output).toContain("|  |_  Done");
+    expect(output).toContain("`- background sync");
+    expect(output).toContain("   |_  Indexing repo");
+    expect(output).not.toContain("7 tool uses");
+    expect(output).not.toContain("9.0k tokens");
+  });
+});

--- a/runtime/tests/tui/components/App.coverage2.test.tsx
+++ b/runtime/tests/tui/components/App.coverage2.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  createElicitationQueue,
+  type McpFormPending,
+  type McpUrlPending,
+} from "./App.js";
+
+describe("App elicitation queue coverage", () => {
+  test("completes queued MCP URL requests without replacing the active prompt", () => {
+    const queue = createElicitationQueue();
+    const activeResolve = vi.fn();
+    const queuedResolve = vi.fn();
+    const active: McpFormPending = {
+      kind: "mcp-form",
+      request: {
+        turnId: "turn-1",
+        serverName: "forms",
+        requestId: "form-1",
+        request: {
+          mode: "form",
+          message: "Provide value",
+          requestedSchema: {
+            type: "object",
+            properties: {},
+          },
+        },
+      },
+      resolve: activeResolve,
+      fields: [],
+      content: {},
+      index: 0,
+    };
+    const queued: McpUrlPending = {
+      kind: "mcp-url",
+      request: {
+        turnId: "turn-1",
+        serverName: "auth",
+        requestId: "url-1",
+        request: {
+          mode: "url",
+          message: "Authorize",
+          elicitationId: "url-1",
+          url: "https://example.test/auth",
+        },
+      },
+      resolve: queuedResolve,
+    };
+
+    expect(queue.enqueue(active)).toBe(active);
+    expect(queue.enqueue(queued)).toBe(active);
+
+    expect(queue.completeMcpUrl("auth", "url-1")).toEqual({
+      handled: true,
+      current: active,
+    });
+
+    expect(queuedResolve).toHaveBeenCalledWith({ action: "accept" });
+    expect(activeResolve).not.toHaveBeenCalled();
+    expect(queue.current()).toBe(active);
+    expect(queue.clear()).toEqual([active]);
+  });
+});

--- a/runtime/tests/tui/components/App.render.test.tsx
+++ b/runtime/tests/tui/components/App.render.test.tsx
@@ -769,6 +769,249 @@ describeWithVitestMocks("AgenCTuiApp render smoke", () => {
     }
   });
 
+  test("formats render health warnings only for sustained low FPS", async () => {
+    const { formatRenderHealthWarning } = await import("./App.js");
+
+    expect(formatRenderHealthWarning(undefined)).toBeNull();
+    expect(
+      formatRenderHealthWarning({
+        averageFps: Number.NaN,
+        low1PctFps: Number.POSITIVE_INFINITY,
+        sampleCount: 10,
+      }),
+    ).toBe("Render health: average 0.0 FPS, 1% low 0.0 FPS");
+    expect(
+      formatRenderHealthWarning({
+        averageFps: 8,
+        low1PctFps: 2,
+        sampleCount: 9,
+      }),
+    ).toBeNull();
+    expect(
+      formatRenderHealthWarning({
+        averageFps: 25,
+        low1PctFps: 15,
+        sampleCount: 20,
+      }),
+    ).toBeNull();
+    expect(
+      formatRenderHealthWarning({
+        averageFps: 18.234,
+        low1PctFps: 30,
+        sampleCount: 20,
+      }),
+    ).toBe("Render health: average 18.2 FPS, 1% low 18.2 FPS");
+  });
+
+  test("formats stopped-agent notifications by count and description", async () => {
+    const { formatAgentsKilledNotification } = await import("./App.js");
+
+    expect(formatAgentsKilledNotification([])).toBeNull();
+    expect(formatAgentsKilledNotification([{ taskId: "task-1" }])).toBe(
+      "Stopped 1 background agent",
+    );
+    expect(
+      formatAgentsKilledNotification([
+        { taskId: "task-1" },
+        { description: " " },
+      ]),
+    ).toBe("Stopped 2 background agents");
+    expect(
+      formatAgentsKilledNotification([{ description: "Fix tests" }]),
+    ).toBe("Stopped background agent: Fix tests");
+    expect(
+      formatAgentsKilledNotification([
+        { description: "Fix tests" },
+        { description: "Review diff" },
+      ]),
+    ).toBe("Stopped 2 background agents: Fix tests, Review diff");
+  });
+
+  test("gates prompt input when another TUI surface owns input", async () => {
+    const { shouldShowPromptInputState } = await import("./App.js");
+
+    expect(
+      shouldShowPromptInputState({
+        isMessageSelectorVisible: false,
+        permissionRequestCount: 0,
+        hasElicitationPrompt: false,
+        completionPipelineOwnsPrompt: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowPromptInputState({
+        isMessageSelectorVisible: true,
+        permissionRequestCount: 0,
+        hasElicitationPrompt: false,
+        completionPipelineOwnsPrompt: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowPromptInputState({
+        isMessageSelectorVisible: false,
+        permissionRequestCount: 1,
+        hasElicitationPrompt: false,
+        completionPipelineOwnsPrompt: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowPromptInputState({
+        isMessageSelectorVisible: false,
+        permissionRequestCount: 0,
+        hasElicitationPrompt: true,
+        completionPipelineOwnsPrompt: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowPromptInputState({
+        isMessageSelectorVisible: false,
+        permissionRequestCount: 0,
+        hasElicitationPrompt: false,
+        completionPipelineOwnsPrompt: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowPromptInputState({
+        isMessageSelectorVisible: false,
+        permissionRequestCount: 0,
+        hasElicitationPrompt: false,
+        completionPipelineOwnsPrompt: false,
+        toolShouldHidePromptInput: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("parses MCP primitive field edge cases", async () => {
+    const { parseMcpField } = await import("./App.js");
+
+    expect(parseMcpField("", { type: "number" })).toEqual({
+      ok: false,
+      message: "must be a number",
+    });
+    expect(parseMcpField("abc", { type: "number" })).toEqual({
+      ok: false,
+      message: "must be a number",
+    });
+    expect(parseMcpField("0", { type: "number", minimum: 1 })).toEqual({
+      ok: false,
+      message: "must be at least 1",
+    });
+    expect(parseMcpField("3", { type: "number", maximum: 2 })).toEqual({
+      ok: false,
+      message: "must be at most 2",
+    });
+    expect(parseMcpField("2", { type: "integer" })).toEqual({
+      ok: true,
+      value: 2,
+    });
+    expect(parseMcpField("YES", { type: "boolean" })).toEqual({
+      ok: true,
+      value: true,
+    });
+    expect(parseMcpField("0", { type: "boolean" })).toEqual({
+      ok: true,
+      value: false,
+    });
+    expect(
+      parseMcpField("one, one", {
+        type: "array",
+        items: { type: "string" },
+        uniqueItems: true,
+      }),
+    ).toEqual({
+      ok: false,
+      message: "must not include duplicate values",
+    });
+    expect(
+      parseMcpField("", {
+        type: "array",
+        items: { type: "string" },
+        minItems: 1,
+      }),
+    ).toEqual({
+      ok: false,
+      message: "must include at least 1 item(s)",
+    });
+    expect(
+      parseMcpField("one, two, three", {
+        type: "array",
+        items: { type: "string" },
+        maxItems: 2,
+      }),
+    ).toEqual({
+      ok: false,
+      message: "must include at most 2 item(s)",
+    });
+    expect(parseMcpField("fallback", undefined)).toEqual({
+      ok: true,
+      value: "fallback",
+    });
+  });
+
+  test("renders elicitation overlays and null prompts", async () => {
+    const { ElicitationOverlay } = await import("./App.js");
+
+    expect(await renderApp(<ElicitationOverlay prompt={null} />)).not.toContain(
+      "MCP:",
+    );
+    const output = await renderApp(
+      <ElicitationOverlay
+        prompt={{
+          title: "MCP: files",
+          message: "Authorize files",
+          detailLines: ["https://127.0.0.1/auth", "Type decline to reject"],
+          placeholder: "Enter to accept",
+        }}
+      />,
+    );
+
+    expect(output).toContain("MCP:");
+    expect(output).toContain("files");
+    expect(output).toContain("Authorize");
+    expect(output).toContain("https://127.0.0.1/auth");
+    expect(output).toContain("Enter");
+    expect(output).toContain("accept");
+  });
+
+  test("subscribes to MCP URL completion events from session events", async () => {
+    const { subscribeToMcpUrlCompletions } = await import("./App.js");
+    let listener: ((event: unknown) => void) | undefined;
+    const unsubscribe = vi.fn();
+    const completeMcpUrl = vi.fn();
+    const session = {
+      subscribeToEvents: vi.fn((callback: (event: unknown) => void) => {
+        listener = callback;
+        return unsubscribe;
+      }),
+    };
+
+    const stop = subscribeToMcpUrlCompletions(session, { completeMcpUrl });
+
+    listener?.(null);
+    listener?.({ type: "other" });
+    listener?.({
+      type: "mcp_elicitation_complete",
+      payload: { serverName: 1, elicitationId: "url-1" },
+    });
+    expect(completeMcpUrl).not.toHaveBeenCalled();
+
+    listener?.({
+      type: "mcp_elicitation_complete",
+      payload: { serverName: "srv", elicitationId: "url-1" },
+    });
+    expect(completeMcpUrl).toHaveBeenCalledWith(
+      "srv",
+      "url-1",
+      expect.objectContaining({ action: "accept" }),
+    );
+
+    stop();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(
+      subscribeToMcpUrlCompletions({}, { completeMcpUrl: vi.fn() }),
+    ).toEqual(expect.any(Function));
+  });
+
   test("App wrapper preserves provider wiring", async () => {
     const { App } = await import("./App.js");
     providerProbe.fpsGetters.length = 0;

--- a/runtime/tests/tui/components/App.wave200-002.coverage.test.tsx
+++ b/runtime/tests/tui/components/App.wave200-002.coverage.test.tsx
@@ -1,0 +1,201 @@
+import { PassThrough } from "node:stream";
+
+import React, { useEffect } from "react";
+import { describe, expect, test } from "vitest";
+
+import type {
+  McpElicitationRequestEvent,
+  McpElicitationResponse,
+} from "../../elicitation/types.js";
+import { createRoot } from "../ink/root.js";
+import {
+  type ElicitationPromptState,
+  type TuiElicitationState,
+  useTuiElicitation,
+} from "./App.js";
+
+type TestSession = {
+  services: {
+    mcpElicitationResolver?: {
+      request(
+        event: McpElicitationRequestEvent,
+        signal?: AbortSignal,
+      ): Promise<McpElicitationResponse | null>;
+    };
+  };
+  subscribeToEvents(callback: (event: unknown) => void): () => void;
+};
+
+function createStreams(): {
+  readonly stdout: PassThrough;
+  readonly stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+} {
+  const stdout = new PassThrough();
+  stdout.resume();
+  (stdout as unknown as { columns: number }).columns = 100;
+  (stdout as unknown as { rows: number }).rows = 24;
+  (stdout as unknown as { isTTY: boolean }).isTTY = true;
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+
+  return { stdin, stdout };
+}
+
+function createSession(): TestSession {
+  return {
+    services: {},
+    subscribeToEvents: () => () => {},
+  };
+}
+
+function mcpFormRequest(): McpElicitationRequestEvent {
+  return {
+    turnId: "turn-1",
+    serverName: "prefs",
+    requestId: "request-1",
+    request: {
+      mode: "form",
+      message: "Configure access",
+      requestedSchema: {
+        type: "object",
+        required: ["color", "scopes"],
+        properties: {
+          color: {
+            type: "string",
+            description: "Pick a color",
+            oneOf: [
+              { const: "red", title: "Red" },
+              { const: "blue", title: "Blue" },
+            ],
+          },
+          scopes: {
+            type: "array",
+            description: "Pick scopes",
+            minItems: 1,
+            items: {
+              type: "string",
+              anyOf: [
+                { const: "read", title: "Read Files" },
+                { const: "write", title: "Write Files" },
+              ],
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  let lastError: unknown;
+  for (let i = 0; i < 20; i++) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await sleep();
+    }
+  }
+  throw lastError;
+}
+
+describe("App MCP elicitation prompt coverage", () => {
+  test("surfaces titled enum details while submitting a multi-field MCP form", async () => {
+    const session = createSession();
+    const prompts: Array<ElicitationPromptState | null> = [];
+    const latest: { current: TuiElicitationState | null } = { current: null };
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    function Harness(): null {
+      const elicitation = useTuiElicitation(session);
+      latest.current = elicitation;
+      useEffect(() => {
+        prompts.push(elicitation.prompt);
+      }, [elicitation.prompt]);
+      return null;
+    }
+
+    try {
+      root.render(<Harness />);
+      await waitFor(() => {
+        expect(session.services.mcpElicitationResolver).toBeDefined();
+      });
+
+      const pending = session.services.mcpElicitationResolver!.request(
+        mcpFormRequest(),
+      );
+
+      await waitFor(() => {
+        expect(prompts.at(-1)).toEqual({
+          title: "MCP: prefs",
+          message: "Configure access (color)",
+          detailLines: [
+            "Pick a color",
+            "Allowed: red (Red), blue (Blue)",
+            "Type decline or cancel to reject this request.",
+          ],
+          placeholder: "Enter value",
+        });
+      });
+
+      expect(latest.current?.submit("red")).toBe(true);
+      await waitFor(() => {
+        expect(prompts.at(-1)).toEqual({
+          title: "MCP: prefs",
+          message: "Configure access (scopes)",
+          detailLines: [
+            "Pick scopes",
+            "Allowed: read (Read Files), write (Write Files)",
+            "Type decline or cancel to reject this request.",
+          ],
+          placeholder: "Enter value",
+        });
+      });
+
+      expect(latest.current?.submit("delete")).toBe(true);
+      await waitFor(() => {
+        expect(prompts.at(-1)?.detailLines[0]).toBe(
+          "Invalid input: scopes delete must be one of: read, write",
+        );
+      });
+
+      expect(latest.current?.submit("read, write")).toBe(true);
+      await expect(pending).resolves.toEqual({
+        action: "accept",
+        content: {
+          color: "red",
+          scopes: ["read", "write"],
+        },
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+});

--- a/runtime/tests/tui/components/AutoModeOptInDialog.coverage.test.tsx
+++ b/runtime/tests/tui/components/AutoModeOptInDialog.coverage.test.tsx
@@ -1,0 +1,165 @@
+import type { ReactNode } from "react";
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { renderToString } from "../../utils/staticRender.js";
+import {
+  AUTO_MODE_DESCRIPTION,
+  AutoModeOptInDialog,
+} from "./AutoModeOptInDialog.js";
+
+type SelectMockProps = {
+  readonly onCancel: () => void;
+  readonly onChange: (value: string) => void;
+  readonly options: Array<{ readonly label: string; readonly value: string }>;
+};
+
+type DialogMockProps = {
+  readonly children: ReactNode;
+  readonly color?: string;
+  readonly onCancel: () => void;
+  readonly title: ReactNode;
+};
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+const harness = vi.hoisted(() => ({
+  dialogProps: undefined as DialogMockProps | undefined,
+  logEvent: vi.fn(),
+  selectProps: undefined as SelectMockProps | undefined,
+  updateSettingsForSource: vi.fn(),
+}));
+
+vi.mock("../../services/analytics/index.js", () => ({
+  logEvent: harness.logEvent,
+}));
+
+vi.mock("../../utils/settings/settings.js", () => ({
+  updateSettingsForSource: harness.updateSettingsForSource,
+}));
+
+vi.mock("./CustomSelect/select", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    Select: (props: SelectMockProps) => {
+      harness.selectProps = props;
+      return ReactActual.createElement(
+        "ink-text",
+        null,
+        props.options.map(option => option.label).join("\n"),
+      );
+    },
+  };
+});
+
+vi.mock("./design-system/Dialog", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    Dialog: (props: DialogMockProps) => {
+      harness.dialogProps = props;
+      return ReactActual.createElement(
+        "ink-box",
+        { flexDirection: "column" },
+        ReactActual.createElement("ink-text", null, props.title),
+        props.children,
+      );
+    },
+  };
+});
+
+describe("AutoModeOptInDialog coverage", () => {
+  beforeEach(() => {
+    harness.dialogProps = undefined;
+    harness.selectProps = undefined;
+    harness.logEvent.mockReset();
+    harness.updateSettingsForSource.mockReset();
+  });
+
+  test("renders exit/go-back decline labels and handles every decision", async () => {
+    const onAccept = vi.fn();
+    const onDecline = vi.fn();
+
+    const exitOutput = await renderToString(
+      <AutoModeOptInDialog
+        onAccept={onAccept}
+        onDecline={onDecline}
+        declineExits
+      />,
+      { columns: 240 },
+    );
+
+    expect(exitOutput).toContain("Enable auto mode?");
+    expect(normalizeWhitespace(exitOutput)).toContain(
+      normalizeWhitespace(AUTO_MODE_DESCRIPTION),
+    );
+    expect(harness.dialogProps).toMatchObject({
+      color: "warning",
+      onCancel: onDecline,
+      title: "Enable auto mode?",
+    });
+    expect(harness.selectProps?.onCancel).toBe(onDecline);
+    expect(harness.selectProps?.options).toEqual([
+      {
+        label: "Yes, and make it my default mode",
+        value: "accept-default",
+      },
+      { label: "Yes, enable auto mode", value: "accept" },
+      { label: "No, exit", value: "decline" },
+    ]);
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      "agenc_auto_mode_opt_in_dialog_shown",
+      {},
+    );
+
+    harness.selectProps?.onChange("accept-default");
+
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      "agenc_auto_mode_opt_in_dialog_accept_default",
+      {},
+    );
+    expect(harness.updateSettingsForSource).toHaveBeenLastCalledWith(
+      "userSettings",
+      {
+        skipAutoPermissionPrompt: true,
+        permissions: { defaultMode: "auto" },
+      },
+    );
+    expect(onAccept).toHaveBeenCalledTimes(1);
+    expect(onDecline).not.toHaveBeenCalled();
+
+    harness.selectProps?.onChange("accept");
+
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      "agenc_auto_mode_opt_in_dialog_accept",
+      {},
+    );
+    expect(harness.updateSettingsForSource).toHaveBeenLastCalledWith(
+      "userSettings",
+      { skipAutoPermissionPrompt: true },
+    );
+    expect(onAccept).toHaveBeenCalledTimes(2);
+    expect(onDecline).not.toHaveBeenCalled();
+
+    harness.selectProps?.onChange("decline");
+
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      "agenc_auto_mode_opt_in_dialog_decline",
+      {},
+    );
+    expect(onDecline).toHaveBeenCalledTimes(1);
+
+    await renderToString(
+      <AutoModeOptInDialog onAccept={onAccept} onDecline={onDecline} />,
+      { columns: 240 },
+    );
+
+    expect(harness.selectProps?.options.at(-1)).toEqual({
+      label: "No, go back",
+      value: "decline",
+    });
+  });
+});

--- a/runtime/tests/tui/components/AutoUpdater.wave200-039.coverage.test.tsx
+++ b/runtime/tests/tui/components/AutoUpdater.wave200-039.coverage.test.tsx
@@ -1,0 +1,243 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { AutoUpdaterResult } from "../../utils/autoUpdater.js";
+
+const harness = vi.hoisted(() => ({
+  getCurrentInstallationType: vi.fn(async () => "unknown"),
+  getGlobalConfig: vi.fn(() => ({ installMethod: "local" })),
+  getLatestVersion: vi.fn(async () => "9.0.0"),
+  getMaxVersion: vi.fn(async () => "2.0.0"),
+  installGlobalPackage: vi.fn(async () => "success"),
+  installOrUpdateAgenCPackage: vi.fn(async () => "install_failed"),
+  intervalDelay: undefined as number | null | undefined,
+  isAutoUpdaterDisabled: vi.fn(() => false),
+  localInstallationExists: vi.fn(async () => true),
+  logEvent: vi.fn(),
+  logForDebugging: vi.fn(),
+  removeInstalledSymlink: vi.fn(async () => {}),
+  shouldSkipVersion: vi.fn(() => false),
+}));
+
+vi.mock("usehooks-ts", () => ({
+  useInterval: (_callback: () => void, delay: number | null) => {
+    harness.intervalDelay = delay;
+  },
+}));
+
+vi.mock("../../services/analytics/index.js", () => ({
+  logEvent: harness.logEvent,
+}));
+
+vi.mock("src/utils/debug.js", () => ({
+  logForDebugging: harness.logForDebugging,
+}));
+
+vi.mock("../../utils/autoUpdater.js", () => ({
+  getLatestVersion: harness.getLatestVersion,
+  getMaxVersion: harness.getMaxVersion,
+  installGlobalPackage: harness.installGlobalPackage,
+  shouldSkipVersion: harness.shouldSkipVersion,
+}));
+
+vi.mock("../../utils/config.js", () => ({
+  getGlobalConfig: harness.getGlobalConfig,
+  isAutoUpdaterDisabled: harness.isAutoUpdaterDisabled,
+}));
+
+vi.mock("../../utils/doctorDiagnostic.js", () => ({
+  getCurrentInstallationType: harness.getCurrentInstallationType,
+}));
+
+vi.mock("../../utils/localInstaller.js", () => ({
+  installOrUpdateAgenCPackage: harness.installOrUpdateAgenCPackage,
+  localInstallationExists: harness.localInstallationExists,
+}));
+
+vi.mock("../../utils/nativeInstaller/installer.js", () => ({
+  removeInstalledSymlink: harness.removeInstalledSymlink,
+}));
+
+vi.mock("../../utils/semver.js", () => {
+  const compareVersions = (left: string, right: string): number => {
+    const leftParts = left.split(".").map(Number);
+    const rightParts = right.split(".").map(Number);
+
+    for (let index = 0; index < 3; index += 1) {
+      const delta = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+      if (delta !== 0) {
+        return delta;
+      }
+    }
+
+    return 0;
+  };
+
+  return {
+    gt: (left: string, right: string) => compareVersions(left, right) > 0,
+    gte: (left: string, right: string) => compareVersions(left, right) >= 0,
+  };
+});
+
+vi.mock("../../utils/settings/settings.js", () => ({
+  getInitialSettings: () => ({ autoUpdatesChannel: "stable" }),
+}));
+
+import { createRoot } from "../ink/root.js";
+import { AutoUpdater } from "./AutoUpdater.js";
+
+const originalGlyphMode = process.env.AGENC_TUI_GLYPHS;
+const originalMacro = (globalThis as Record<string, unknown>).MACRO;
+const originalNodeEnv = process.env.NODE_ENV;
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  readonly stdout: PassThrough;
+};
+
+function createStreams(): TestStreams {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStreams["stdin"];
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number; rows: number }).columns = 240;
+  (stdout as unknown as { columns: number; rows: number }).rows = 24;
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForOutput(
+  readOutput: () => string,
+  expectedText: string,
+): Promise<string> {
+  const deadline = Date.now() + 1000;
+
+  while (Date.now() < deadline) {
+    const plainOutput = stripAnsi(readOutput());
+    if (plainOutput.includes(expectedText)) {
+      return plainOutput;
+    }
+    await sleep(10);
+  }
+
+  return stripAnsi(readOutput());
+}
+
+function Harness(): React.ReactNode {
+  const [isUpdating, setIsUpdating] = React.useState(false);
+  const [autoUpdaterResult, setAutoUpdaterResult] =
+    React.useState<AutoUpdaterResult | null>(null);
+
+  return (
+    <AutoUpdater
+      autoUpdaterResult={autoUpdaterResult}
+      isUpdating={isUpdating}
+      onAutoUpdaterResult={setAutoUpdaterResult}
+      onChangeIsUpdating={setIsUpdating}
+      showSuccessMessage={true}
+      verbose={true}
+    />
+  );
+}
+
+describe("AutoUpdater wave200 coverage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    harness.intervalDelay = undefined;
+    process.env.AGENC_TUI_GLYPHS = "ascii";
+    process.env.NODE_ENV = "production";
+    (globalThis as Record<string, unknown>).MACRO = {
+      PACKAGE_URL: "@tetsuo-ai/agenc",
+      VERSION: "1.0.0",
+    };
+  });
+
+  afterEach(() => {
+    if (originalGlyphMode === undefined) {
+      delete process.env.AGENC_TUI_GLYPHS;
+    } else {
+      process.env.AGENC_TUI_GLYPHS = originalGlyphMode;
+    }
+
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+
+    if (originalMacro === undefined) {
+      delete (globalThis as Record<string, unknown>).MACRO;
+    } else {
+      (globalThis as Record<string, unknown>).MACRO = originalMacro;
+    }
+  });
+
+  test("renders the local repair command when a capped fallback local update fails", async () => {
+    let output = "";
+    const { stdin, stdout } = createStreams();
+    stdout.on("data", chunk => {
+      output += chunk.toString();
+    });
+
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(<Harness />);
+
+      const rendered = await waitForOutput(() => output, "Auto-update failed");
+
+      expect(rendered).toContain("globalVersion: 1.0.0 - latestVersion: 2.0.0");
+      expect(rendered).toContain("ERR Auto-update failed - Try agenc doctor");
+      expect(rendered).toContain(
+        "cd ~/.agenc/local && npm update @tetsuo-ai/agenc",
+      );
+      expect(harness.intervalDelay).toBe(1_800_000);
+      expect(harness.getLatestVersion).toHaveBeenCalledWith("stable");
+      expect(harness.getMaxVersion).toHaveBeenCalledOnce();
+      expect(harness.shouldSkipVersion).toHaveBeenCalledWith("2.0.0");
+      expect(harness.removeInstalledSymlink).toHaveBeenCalledOnce();
+      expect(harness.getCurrentInstallationType).toHaveBeenCalledOnce();
+      expect(harness.installOrUpdateAgenCPackage).toHaveBeenCalledWith("stable");
+      expect(harness.installGlobalPackage).not.toHaveBeenCalled();
+      expect(harness.logForDebugging).toHaveBeenCalledWith(
+        "AutoUpdater: maxVersion 2.0.0 is set, capping update from 9.0.0 to 2.0.0",
+      );
+      expect(harness.logForDebugging).toHaveBeenCalledWith(
+        "AutoUpdater: Unknown installation type, falling back to config",
+      );
+      expect(harness.logEvent).toHaveBeenCalledWith(
+        "tengu_auto_updater_fail",
+        expect.objectContaining({
+          attemptedVersion: "2.0.0",
+          fromVersion: "1.0.0",
+          installationType: "unknown",
+          status: "install_failed",
+          wasMigrated: true,
+        }),
+      );
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+});

--- a/runtime/tests/tui/components/AutoUpdaterWrapper.wave200-146.coverage.test.tsx
+++ b/runtime/tests/tui/components/AutoUpdaterWrapper.wave200-146.coverage.test.tsx
@@ -1,0 +1,245 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  feature: vi.fn((_flag: string) => false),
+  getCurrentInstallationType: vi.fn(async () => "npm-global"),
+  isAutoUpdaterDisabled: vi.fn(() => false),
+  logForDebugging: vi.fn(),
+  rendered: [] as Array<{
+    kind: "standard" | "native" | "package-manager";
+    props: Record<string, unknown>;
+  }>,
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: harness.feature,
+}));
+
+vi.mock("../../utils/config.js", () => ({
+  isAutoUpdaterDisabled: harness.isAutoUpdaterDisabled,
+}));
+
+vi.mock("../../utils/doctorDiagnostic.js", () => ({
+  getCurrentInstallationType: harness.getCurrentInstallationType,
+}));
+
+vi.mock("src/utils/debug.js", () => ({
+  logForDebugging: harness.logForDebugging,
+}));
+
+vi.mock("./AutoUpdater.js", () => ({
+  AutoUpdater: (props: Record<string, unknown>) => {
+    harness.rendered.push({ kind: "standard", props });
+    return null;
+  },
+}));
+
+vi.mock("./NativeAutoUpdater.js", () => ({
+  NativeAutoUpdater: (props: Record<string, unknown>) => {
+    harness.rendered.push({ kind: "native", props });
+    return null;
+  },
+}));
+
+vi.mock("./PackageManagerAutoUpdater.js", () => ({
+  PackageManagerAutoUpdater: (props: Record<string, unknown>) => {
+    harness.rendered.push({ kind: "package-manager", props });
+    return null;
+  },
+}));
+
+import { createRoot } from "../ink/root.js";
+import { AutoUpdaterWrapper } from "./AutoUpdaterWrapper.js";
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (_mode: boolean) => void;
+    unref: () => void;
+  };
+  readonly stdout: PassThrough;
+};
+
+function createStreams(): TestStreams {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStreams["stdin"];
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number; rows: number }).columns = 120;
+  (stdout as unknown as { columns: number; rows: number }).rows = 24;
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  const deadline = Date.now() + 1000;
+  let lastError: unknown;
+
+  while (Date.now() < deadline) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await sleep(10);
+    }
+  }
+
+  if (lastError) {
+    throw lastError;
+  }
+  assertion();
+}
+
+function resetHarness(): void {
+  vi.clearAllMocks();
+  harness.feature.mockReturnValue(false);
+  harness.getCurrentInstallationType.mockResolvedValue("npm-global");
+  harness.isAutoUpdaterDisabled.mockReturnValue(false);
+  harness.rendered = [];
+}
+
+async function renderWrapper(
+  installationType: string,
+  props: {
+    isUpdating?: boolean;
+    showSuccessMessage?: boolean;
+    verbose?: boolean;
+  } = {},
+): Promise<{
+  child: (typeof harness.rendered)[number];
+  callbacks: {
+    onAutoUpdaterResult: ReturnType<typeof vi.fn>;
+    onChangeIsUpdating: ReturnType<typeof vi.fn>;
+  };
+  result: { status: "success"; version: string };
+}> {
+  resetHarness();
+  harness.getCurrentInstallationType.mockResolvedValueOnce(installationType);
+
+  const callbacks = {
+    onAutoUpdaterResult: vi.fn(),
+    onChangeIsUpdating: vi.fn(),
+  };
+  const result = { status: "success" as const, version: "2.0.0" };
+  const { stdin, stdout } = createStreams();
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  try {
+    root.render(
+      <AutoUpdaterWrapper
+        autoUpdaterResult={result}
+        isUpdating={props.isUpdating ?? false}
+        onAutoUpdaterResult={callbacks.onAutoUpdaterResult}
+        onChangeIsUpdating={callbacks.onChangeIsUpdating}
+        showSuccessMessage={props.showSuccessMessage ?? true}
+        verbose={props.verbose ?? false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(harness.rendered).toHaveLength(1);
+    });
+
+    return { callbacks, child: harness.rendered[0]!, result };
+  } finally {
+    root.unmount();
+    stdin.end();
+    stdout.end();
+  }
+}
+
+describe("AutoUpdaterWrapper wave200 coverage", () => {
+  test("routes detected installation types and leaves disabled detection blank", async () => {
+    const packageManager = await renderWrapper("package-manager", {
+      isUpdating: true,
+      showSuccessMessage: false,
+      verbose: true,
+    });
+
+    expect(packageManager.child.kind).toBe("package-manager");
+    expect(packageManager.child.props).toMatchObject({
+      autoUpdaterResult: packageManager.result,
+      isUpdating: true,
+      showSuccessMessage: false,
+      verbose: true,
+    });
+    expect(packageManager.child.props.onAutoUpdaterResult).toBe(
+      packageManager.callbacks.onAutoUpdaterResult,
+    );
+    expect(packageManager.child.props.onChangeIsUpdating).toBe(
+      packageManager.callbacks.onChangeIsUpdating,
+    );
+    expect(harness.logForDebugging).toHaveBeenCalledWith(
+      "AutoUpdaterWrapper: Installation type: package-manager",
+    );
+
+    const native = await renderWrapper("native");
+
+    expect(native.child.kind).toBe("native");
+    expect(harness.logForDebugging).toHaveBeenCalledWith(
+      "AutoUpdaterWrapper: Installation type: native",
+    );
+
+    const standard = await renderWrapper("npm-global");
+
+    expect(standard.child.kind).toBe("standard");
+    expect(harness.logForDebugging).toHaveBeenCalledWith(
+      "AutoUpdaterWrapper: Installation type: npm-global",
+    );
+
+    resetHarness();
+    harness.feature.mockImplementation(
+      (flag) => flag === "SKIP_DETECTION_WHEN_AUTOUPDATES_DISABLED",
+    );
+    harness.isAutoUpdaterDisabled.mockReturnValue(true);
+
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AutoUpdaterWrapper
+          autoUpdaterResult={null}
+          isUpdating={false}
+          onAutoUpdaterResult={vi.fn()}
+          onChangeIsUpdating={vi.fn()}
+          showSuccessMessage={true}
+          verbose={false}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(harness.logForDebugging).toHaveBeenCalledWith(
+          "AutoUpdaterWrapper: Skipping detection, auto-updates disabled",
+        );
+      });
+
+      expect(harness.rendered).toEqual([]);
+      expect(harness.getCurrentInstallationType).not.toHaveBeenCalled();
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+});

--- a/runtime/tests/tui/components/BaseTextInput.coverage.test.tsx
+++ b/runtime/tests/tui/components/BaseTextInput.coverage.test.tsx
@@ -1,0 +1,192 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { describe, expect, test, vi } from "vitest";
+
+import type { BaseInputState } from "../../types/textInputTypes.js";
+import type { TextHighlight } from "../../utils/textHighlighting.js";
+import { createRoot, Text } from "../ink.js";
+import { BaseTextInput } from "./BaseTextInput.js";
+
+const highlightedInputMock = vi.hoisted(() => ({
+  calls: [] as Array<{
+    text: string;
+    highlights: TextHighlight[];
+  }>,
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: () => false,
+}));
+
+vi.mock("../../utils/config.js", () => ({
+  getGlobalConfig: () => ({ theme: "dark" }),
+  saveGlobalConfig: vi.fn(),
+}));
+
+vi.mock("../../utils/systemTheme.js", () => ({
+  getSystemThemeName: () => "dark",
+  resolveThemeSetting: () => "dark",
+}));
+
+vi.mock("./PromptInput/ShimmeredInput.js", async () => {
+  const ReactModule = await import("react");
+  const { Text: InkText } = await import("../ink.js");
+
+  return {
+    HighlightedInput: ({
+      text,
+      highlights,
+    }: {
+      text: string;
+      highlights: TextHighlight[];
+    }) => {
+      highlightedInputMock.calls.push({ text, highlights });
+      return ReactModule.createElement(InkText, null, `highlighted:${text}`);
+    },
+  };
+});
+
+function createInputState(
+  overrides: Partial<BaseInputState> = {},
+): BaseInputState {
+  return {
+    cursorColumn: 4,
+    cursorLine: 0,
+    offset: 4,
+    onInput: vi.fn(),
+    renderedValue: "eview",
+    setOffset: vi.fn(),
+    setValue: vi.fn(),
+    value: "/review",
+    viewportCharEnd: 7,
+    viewportCharOffset: 2,
+    ...overrides,
+  };
+}
+
+const SYNC_START = "\x1B[?2026h";
+const SYNC_END = "\x1B[?2026l";
+
+function extractLastFrame(output: string): string {
+  let lastFrame: string | null = null;
+  let cursor = 0;
+
+  while (cursor < output.length) {
+    const start = output.indexOf(SYNC_START, cursor);
+    if (start === -1) {
+      break;
+    }
+
+    const contentStart = start + SYNC_START.length;
+    const end = output.indexOf(SYNC_END, contentStart);
+    if (end === -1) {
+      break;
+    }
+
+    const frame = output.slice(contentStart, end);
+    if (frame.trim().length > 0) {
+      lastFrame = frame;
+    }
+    cursor = end + SYNC_END.length;
+  }
+
+  return lastFrame ?? output;
+}
+
+function createStreams(): {
+  stdout: PassThrough;
+  stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  getOutput: () => string;
+} {
+  let output = "";
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number }).columns = 80;
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  return { getOutput: () => output, stdin, stdout };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe("BaseTextInput coverage", () => {
+  test("clips visible highlights and preserves command argument hints in the highlighted render path", async () => {
+    highlightedInputMock.calls = [];
+    const onIsPastingChange = vi.fn();
+    const inputState = createInputState();
+    const highlights: TextHighlight[] = [
+      { color: "success", end: 3, priority: 1, start: 1 },
+      { color: "error", end: 5, priority: 3, start: 3 },
+      { color: "warning", dimColor: true, end: 7, priority: 2, start: 4 },
+      { color: "suggestion", end: 9, priority: 1, start: 7 },
+    ];
+    const { getOutput, stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    root.render(
+      <BaseTextInput
+        argumentHint="<target>"
+        columns={80}
+        cursorOffset={inputState.offset}
+        focus={true}
+        highlights={highlights}
+        inputState={inputState}
+        onChange={vi.fn()}
+        onChangeCursorOffset={vi.fn()}
+        onIsPastingChange={onIsPastingChange}
+        showCursor={true}
+        terminalFocus={true}
+        value={inputState.value}
+      >
+        <Text> child</Text>
+      </BaseTextInput>,
+    );
+    await sleep();
+
+    const output = stripAnsi(extractLastFrame(getOutput()));
+
+    try {
+      expect(output).toContain("highlighted:eview <target> child");
+      expect(onIsPastingChange).toHaveBeenCalledWith(false);
+      expect(highlightedInputMock.calls).toEqual([
+        {
+          text: "eview",
+          highlights: [
+            { color: "success", end: 1, priority: 1, start: 0 },
+            { color: "warning", dimColor: true, end: 5, priority: 2, start: 2 },
+          ],
+        },
+      ]);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+});

--- a/runtime/tests/tui/components/BaseTextInput.wave200-097.coverage.test.tsx
+++ b/runtime/tests/tui/components/BaseTextInput.wave200-097.coverage.test.tsx
@@ -1,0 +1,233 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { describe, expect, test, vi } from "vitest";
+
+import type { BaseInputState } from "../../types/textInputTypes.js";
+import { createRoot, Text } from "../ink.js";
+import type { Key } from "../ink.js";
+import { BaseTextInput } from "./BaseTextInput.js";
+
+const pasteHarness = vi.hoisted(() => ({
+  isPasting: false,
+  onInput: undefined as
+    | undefined
+    | ((input: string, key: { return?: boolean }) => void),
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: () => false,
+}));
+
+vi.mock("../../utils/config.js", () => ({
+  getGlobalConfig: () => ({ theme: "dark" }),
+  saveGlobalConfig: vi.fn(),
+}));
+
+vi.mock("../../utils/systemTheme.js", () => ({
+  getSystemThemeName: () => "dark",
+  resolveThemeSetting: () => "dark",
+}));
+
+vi.mock("../hooks/usePasteHandler.js", () => ({
+  usePasteHandler: ({
+    onInput,
+  }: {
+    onInput: (input: string, key: { return?: boolean }) => void;
+  }) => {
+    pasteHarness.onInput = onInput;
+    return {
+      isPasting: pasteHarness.isPasting,
+      wrappedOnInput: vi.fn(),
+    };
+  },
+}));
+
+vi.mock("./PromptInput/ShimmeredInput.js", async () => {
+  const ReactModule = await import("react");
+  const { Text: InkText } = await import("../ink.js");
+
+  return {
+    HighlightedInput: ({ text }: { text: string }) =>
+      ReactModule.createElement(InkText, null, text),
+  };
+});
+
+const SYNC_START = "\x1B[?2026h";
+const SYNC_END = "\x1B[?2026l";
+
+function extractLastFrame(output: string): string {
+  let lastFrame: string | null = null;
+  let cursor = 0;
+
+  while (cursor < output.length) {
+    const start = output.indexOf(SYNC_START, cursor);
+    if (start === -1) {
+      break;
+    }
+
+    const contentStart = start + SYNC_START.length;
+    const end = output.indexOf(SYNC_END, contentStart);
+    if (end === -1) {
+      break;
+    }
+
+    const frame = output.slice(contentStart, end);
+    if (frame.trim().length > 0) {
+      lastFrame = frame;
+    }
+    cursor = end + SYNC_END.length;
+  }
+
+  return lastFrame ?? output;
+}
+
+function createStreams(): {
+  stdout: PassThrough;
+  stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  getOutput: () => string;
+} {
+  let output = "";
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number }).columns = 80;
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  return { getOutput: () => output, stdin, stdout };
+}
+
+function createInputState(
+  overrides: Partial<BaseInputState> = {},
+): BaseInputState {
+  return {
+    cursorColumn: 0,
+    cursorLine: 0,
+    offset: 0,
+    onInput: vi.fn(),
+    renderedValue: "",
+    setOffset: vi.fn(),
+    setValue: vi.fn(),
+    value: "",
+    viewportCharEnd: 0,
+    viewportCharOffset: 0,
+    ...overrides,
+  };
+}
+
+function returnKey(): Key {
+  return { return: true } as Key;
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe("BaseTextInput wave200 coverage", () => {
+  test("renders the plain input path and suppresses return while paste is active", async () => {
+    pasteHarness.isPasting = true;
+    pasteHarness.onInput = undefined;
+    const onInput = vi.fn();
+    const onIsPastingChange = vi.fn();
+    const inputState = createInputState({ onInput });
+    const { getOutput, stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <BaseTextInput
+          columns={80}
+          cursorOffset={0}
+          focus={true}
+          inputState={inputState}
+          onChange={vi.fn()}
+          onChangeCursorOffset={vi.fn()}
+          onIsPastingChange={onIsPastingChange}
+          placeholder="fallback placeholder"
+          placeholderElement={<Text>custom placeholder</Text>}
+          showCursor={true}
+          terminalFocus={true}
+          value=""
+        >
+          <Text> tail</Text>
+        </BaseTextInput>,
+      );
+      await sleep();
+
+      const placeholderFrame = stripAnsi(extractLastFrame(getOutput()));
+      expect(placeholderFrame).toContain("custom placeholder tail");
+      expect(placeholderFrame).not.toContain("fallback placeholder");
+      expect(onIsPastingChange).toHaveBeenCalledWith(true);
+
+      expect(pasteHarness.onInput).toBeDefined();
+      pasteHarness.onInput?.("ignored", returnKey());
+      expect(onInput).not.toHaveBeenCalled();
+
+      pasteHarness.onInput?.("typed", {} as Key);
+      expect(onInput).toHaveBeenCalledWith("typed", {});
+
+      pasteHarness.isPasting = false;
+      const commandState = createInputState({
+        cursorColumn: 6,
+        offset: 6,
+        onInput,
+        renderedValue: "/ship ",
+        value: "/ship ",
+        viewportCharEnd: 6,
+      });
+      root.render(
+        <BaseTextInput
+          argumentHint="<path>"
+          columns={80}
+          cursorOffset={6}
+          focus={true}
+          inputState={commandState}
+          onChange={vi.fn()}
+          onChangeCursorOffset={vi.fn()}
+          onIsPastingChange={onIsPastingChange}
+          placeholder="fallback placeholder"
+          showCursor={true}
+          terminalFocus={true}
+          value="/ship "
+        >
+          <Text> tail</Text>
+        </BaseTextInput>,
+      );
+      await sleep();
+
+      const commandFrame = stripAnsi(extractLastFrame(getOutput()));
+      expect(commandFrame).toContain("/ship <path> tail");
+      expect(commandFrame).not.toContain("/ship  <path>");
+      expect(onIsPastingChange).toHaveBeenCalledWith(false);
+
+      pasteHarness.onInput?.("submitted", returnKey());
+      expect(onInput).toHaveBeenLastCalledWith("submitted", returnKey());
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+});

--- a/runtime/tests/tui/components/BashModeProgress.wave200-138.coverage.test.tsx
+++ b/runtime/tests/tui/components/BashModeProgress.wave200-138.coverage.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import { BashModeProgress } from './BashModeProgress.js'
+
+describe('BashModeProgress wave200-138 coverage', () => {
+  test('renders shell input with pending, compact, and verbose progress states', async () => {
+    const pending = await renderToString(
+      <BashModeProgress input="npm test -- --runInBand" progress={null} verbose={false} />,
+      100,
+    )
+
+    expect(pending).toContain('! npm test -- --runInBand')
+    expect(pending).toContain('Running')
+
+    const compact = await renderToString(
+      <BashModeProgress
+        input="npm test -- --runInBand"
+        progress={{
+          elapsedTimeSeconds: 9,
+          fullOutput: 'setup line\nline one\nline two\nline three\nline four\nline five',
+          output: 'line one\nline two\nline three\nline four\nline five',
+          totalLines: 9,
+        }}
+        verbose={false}
+      />,
+      100,
+    )
+
+    expect(compact).toContain('! npm test -- --runInBand')
+    expect(compact).toContain('line one')
+    expect(compact).toContain('line five')
+    expect(compact).toContain('+4 lines')
+    expect(compact).toContain('(9s)')
+    expect(compact).not.toContain('setup line')
+
+    const verbose = await renderToString(
+      <BashModeProgress
+        input="npm test -- --runInBand"
+        progress={{
+          elapsedTimeSeconds: 12,
+          fullOutput: 'setup line\nfull detail\nfinal full line',
+          output: 'tail detail only',
+          totalLines: 3,
+        }}
+        verbose={true}
+      />,
+      100,
+    )
+
+    expect(verbose).toContain('setup line')
+    expect(verbose).toContain('final full line')
+    expect(verbose).toContain('(12s)')
+    expect(verbose).not.toContain('tail detail only')
+  })
+})

--- a/runtime/tests/tui/components/ClickableImageRef.wave200-092.coverage.test.tsx
+++ b/runtime/tests/tui/components/ClickableImageRef.wave200-092.coverage.test.tsx
@@ -1,0 +1,103 @@
+import { pathToFileURL } from 'node:url'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { renderToAnsiString } from '../../utils/staticRender.js'
+import { Box } from '../ink.js'
+import { ClickableImageRef } from './ClickableImageRef.js'
+
+const imageStoreMock = vi.hoisted(() => ({
+  pathById: new Map<number, string>(),
+}))
+
+vi.mock('../../utils/imageStore.js', () => ({
+  getStoredImagePath: (imageId: number) =>
+    imageStoreMock.pathById.get(imageId) ?? null,
+}))
+
+const hyperlinkEnvKeys = [
+  'FORCE_HYPERLINK',
+  'LC_TERMINAL',
+  'NO_COLOR',
+  'TERM',
+  'TERM_PROGRAM',
+] as const
+const previousHyperlinkEnv = new Map(
+  hyperlinkEnvKeys.map(key => [key, process.env[key]]),
+)
+const osc8Prefix = '\x1B]8;'
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function expectOsc8Link(output: string, url: string, label: string): void {
+  const pattern = [
+    '\\x1B\\]8;[^;\\x07]*;',
+    escapeRegExp(url),
+    '\\x07',
+    escapeRegExp(label),
+    '\\x1B\\]8;;\\x07',
+  ].join('')
+
+  expect(output).toMatch(new RegExp(pattern))
+}
+
+afterEach(() => {
+  imageStoreMock.pathById.clear()
+
+  for (const key of hyperlinkEnvKeys) {
+    const value = previousHyperlinkEnv.get(key)
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+})
+
+function setHyperlinksSupported(supported: boolean): void {
+  process.env.FORCE_HYPERLINK = supported ? '1' : '0'
+  delete process.env.LC_TERMINAL
+  delete process.env.NO_COLOR
+  process.env.TERM = 'xterm-256color'
+  delete process.env.TERM_PROGRAM
+}
+
+describe('ClickableImageRef wave200-092 coverage', () => {
+  test('renders cached images as OSC 8 links and falls back to text when unavailable', async () => {
+    const imagePath = '/tmp/agenc image cache/selected.png'
+    imageStoreMock.pathById.set(7, imagePath)
+    setHyperlinksSupported(true)
+
+    const linkedOutput = await renderToAnsiString(
+      <ClickableImageRef imageId={7} />,
+      { columns: 80 },
+    )
+
+    expectOsc8Link(linkedOutput, pathToFileURL(imagePath).href, '[Image #7]')
+
+    setHyperlinksSupported(false)
+    const unsupportedOutput = await renderToAnsiString(
+      <ClickableImageRef imageId={7} isSelected backgroundColor="warning" />,
+      { columns: 80 },
+    )
+
+    expect(stripAnsi(unsupportedOutput)).toContain('[Image #7]')
+    expect(unsupportedOutput).not.toContain(osc8Prefix)
+
+    imageStoreMock.pathById.clear()
+    setHyperlinksSupported(true)
+    const missingOutput = await renderToAnsiString(
+      <Box>
+        <ClickableImageRef imageId={8} />
+      </Box>,
+      { columns: 80 },
+    )
+
+    expect(stripAnsi(missingOutput)).toContain('[Image #8]')
+    expect(missingOutput).not.toContain(osc8Prefix)
+  })
+})

--- a/runtime/tests/tui/components/ConfigurableShortcutHint.coverage.test.tsx
+++ b/runtime/tests/tui/components/ConfigurableShortcutHint.coverage.test.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { describe, expect, test } from "vitest";
+
+import { renderToString } from "../../utils/staticRender.js";
+import { Box } from "../ink.js";
+import { KeybindingProvider } from "../keybindings/KeybindingContext.js";
+import { parseBindings } from "../keybindings/parser.js";
+import type {
+  KeybindingContextName,
+  ParsedKeystroke,
+} from "../keybindings/types.js";
+import { ConfigurableShortcutHint } from "./ConfigurableShortcutHint.js";
+
+const bindings = parseBindings([
+  {
+    context: "Global",
+    bindings: {
+      "ctrl+shift+o": "app:toggleTranscript",
+    },
+  },
+]);
+
+function ConfiguredKeybindings({
+  children,
+}: {
+  readonly children: React.ReactNode;
+}): React.ReactElement {
+  const activeContexts = React.useMemo(() => new Set<KeybindingContextName>(), []);
+  const handlerRegistryRef = React.useRef(new Map());
+  const pendingChordRef = React.useRef<ParsedKeystroke[] | null>(null);
+
+  return (
+    <KeybindingProvider
+      activeContexts={activeContexts}
+      bindings={bindings}
+      handlerRegistryRef={handlerRegistryRef}
+      pendingChord={pendingChordRef.current}
+      pendingChordRef={pendingChordRef}
+      registerActiveContext={context => activeContexts.add(context)}
+      setPendingChord={pending => {
+        pendingChordRef.current = pending;
+      }}
+      unregisterActiveContext={context => activeContexts.delete(context)}
+    >
+      {children}
+    </KeybindingProvider>
+  );
+}
+
+describe("ConfigurableShortcutHint coverage", () => {
+  test("renders fallback text without a provider and configured text with one", async () => {
+    const output = await renderToString(
+      <Box flexDirection="column">
+        <ConfigurableShortcutHint
+          action="app:toggleTranscript"
+          context="Global"
+          fallback="ctrl+o"
+          description="expand"
+          parens
+          bold
+        />
+        <ConfiguredKeybindings>
+          <ConfigurableShortcutHint
+            action="app:toggleTranscript"
+            context="Global"
+            fallback="ctrl+o"
+            description="expand"
+          />
+        </ConfiguredKeybindings>
+      </Box>,
+      100,
+    );
+
+    expect(output).toContain("(ctrl+o to expand)");
+    expect(output).toContain("ctrl+shift+o to expand");
+  });
+});

--- a/runtime/tests/tui/components/CoordinatorAgentStatus.render.test.tsx
+++ b/runtime/tests/tui/components/CoordinatorAgentStatus.render.test.tsx
@@ -1,0 +1,300 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  columns: 100,
+  entered: [] as string[],
+  evicted: [] as string[],
+  exited: 0,
+  setAppState: vi.fn(),
+  state: {
+    agentNameRegistry: new Map<string, string>(),
+    coordinatorTaskIndex: 0,
+    footerSelection: "none" as "none" | "tasks",
+    tasks: {} as Record<string, unknown>,
+    viewingAgentTaskId: undefined as string | undefined,
+  },
+  reset() {
+    harness.columns = 100;
+    harness.entered = [];
+    harness.evicted = [];
+    harness.exited = 0;
+    harness.setAppState.mockClear();
+    harness.state = {
+      agentNameRegistry: new Map(),
+      coordinatorTaskIndex: 0,
+      footerSelection: "none",
+      tasks: {},
+      viewingAgentTaskId: undefined,
+    };
+  },
+}));
+
+vi.mock("../hooks/useTerminalSize.js", () => ({
+  useTerminalSize: () => ({ columns: harness.columns, rows: 24 }),
+}));
+
+vi.mock("../state/AppState.js", () => ({
+  useAppState: (selector: (state: typeof harness.state) => unknown) =>
+    selector(harness.state),
+  useSetAppState: () => harness.setAppState,
+}));
+
+vi.mock("../state/teammateViewHelpers.js", () => ({
+  enterTeammateView: (taskId: string) => {
+    harness.entered.push(taskId);
+  },
+  exitTeammateView: () => {
+    harness.exited++;
+  },
+}));
+
+vi.mock("../../utils/task/framework.js", () => ({
+  evictTerminalTask: (taskId: string) => {
+    harness.evicted.push(taskId);
+  },
+}));
+
+import { createRoot } from "../ink/root.js";
+import { Box, Text } from "../ink.js";
+import {
+  CoordinatorTaskPanel,
+  useCoordinatorTaskCount,
+} from "./CoordinatorAgentStatus.js";
+
+type AgentTask = {
+  agentId: string;
+  agentType: string;
+  description: string;
+  diskLoaded: boolean;
+  endTime?: number;
+  evictAfter?: number;
+  id: string;
+  isBackgrounded: boolean;
+  lastReportedTokenCount: number;
+  lastReportedToolCount: number;
+  pendingMessages: string[];
+  progress?: {
+    lastActivity?: Record<string, unknown>;
+    summary?: string;
+    tokenCount?: number;
+  };
+  prompt: string;
+  retain: boolean;
+  retrieved: boolean;
+  startTime: number;
+  status: "completed" | "failed" | "killed" | "running";
+  totalPausedMs?: number;
+  type: "local_agent";
+};
+
+function createStreams(): {
+  stdout: PassThrough;
+  stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+} {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.resume();
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function task(id: string, overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    agentId: id,
+    agentType: "worker",
+    description: `${id} description`,
+    diskLoaded: false,
+    id,
+    isBackgrounded: true,
+    lastReportedTokenCount: 0,
+    lastReportedToolCount: 0,
+    pendingMessages: [],
+    prompt: `${id} prompt`,
+    retain: false,
+    retrieved: false,
+    startTime: Date.now() - 8_000,
+    status: "running",
+    type: "local_agent",
+    ...overrides,
+  };
+}
+
+async function renderPanel(
+  element: React.ReactNode = <CoordinatorTaskPanel />,
+): Promise<{
+  dispose: () => Promise<void>;
+  output: () => string;
+}> {
+  let output = "";
+  const { stdin, stdout } = createStreams();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+  root.render(<Box flexDirection="column">{element}</Box>);
+  await sleep();
+  return {
+    dispose: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    },
+    output: () => stripAnsi(output),
+  };
+}
+
+describe("CoordinatorTaskPanel rendering", () => {
+  beforeEach(() => {
+    harness.reset();
+    vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("renders nothing when no panel-managed agents are visible", async () => {
+    harness.state.tasks = {
+      dismissed: task("dismissed", { evictAfter: 0 }),
+      main: task("main", { agentType: "main-session" }),
+    };
+    const rendered = await renderPanel();
+
+    try {
+      expect(rendered.output().trim()).toBe("");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("renders visible agents with names, progress, queued counts, and selection hints", async () => {
+    harness.state.footerSelection = "tasks";
+    harness.state.coordinatorTaskIndex = 1;
+    harness.state.agentNameRegistry = new Map([
+      ["Fixer", "agent-a"],
+      ["Reviewer", "agent-b"],
+    ]);
+    harness.state.tasks = {
+      "agent-b": task("agent-b", {
+        description: "Review final patch",
+        endTime: 997_000,
+        evictAfter: 1_100_000,
+        startTime: 992_000,
+        status: "completed",
+        totalPausedMs: 1_000,
+      }),
+      "agent-a": task("agent-a", {
+        pendingMessages: ["please continue"],
+        progress: {
+          lastActivity: { toolName: "Read" },
+          summary: "Investigating agent lifecycle",
+          tokenCount: 1_200,
+        },
+        startTime: 990_000,
+      }),
+    };
+
+    const rendered = await renderPanel();
+
+    try {
+      const output = rendered.output();
+      expect(output).toContain("AGENTS");
+      expect(output).toContain("2 active");
+      expect(output).toContain("orchestrator");
+      expect(output).toContain("Fixer: Investigating agent lifecycle");
+      expect(output).toContain("1 queued");
+      expect(output).toContain("x to stop");
+      expect(output).toContain("Reviewer: Review final patch");
+      expect(output.indexOf("Fixer")).toBeLessThan(output.indexOf("Reviewer"));
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("uses viewed-agent styling without action hints and truncates narrow descriptions", async () => {
+    harness.columns = 46;
+    harness.state.footerSelection = "tasks";
+    harness.state.coordinatorTaskIndex = 1;
+    harness.state.viewingAgentTaskId = "agent-a";
+    harness.state.agentNameRegistry = new Map([["ChromeLotus", "agent-a"]]);
+    harness.state.tasks = {
+      "agent-a": task("agent-a", {
+        description: "This description is long enough to require truncation in a narrow panel",
+        progress: { tokenCount: 5 },
+      }),
+    };
+
+    const rendered = await renderPanel();
+
+    try {
+      const output = rendered.output();
+      expect(output).toContain("ChromeLotus:");
+      expect(output).toContain("tokens");
+      expect(output).not.toContain("x to stop");
+      expect(output).not.toContain("require truncation in a narrow panel");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("exposes coordinator count through the hook", async () => {
+    harness.state.tasks = {
+      "agent-a": task("agent-a"),
+      hidden: task("hidden", { evictAfter: 0 }),
+    };
+    function CountProbe(): React.ReactNode {
+      return <Text>Count:{useCoordinatorTaskCount()}</Text>;
+    }
+    const rendered = await renderPanel(<CountProbe />);
+
+    try {
+      expect(rendered.output()).toContain("Count:2");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("evicts expired retained terminal agents on the panel tick", async () => {
+    harness.state.tasks = {
+      expired: task("expired", {
+        endTime: 999_000,
+        evictAfter: 999_999,
+        status: "completed",
+      }),
+    };
+    const rendered = await renderPanel();
+
+    try {
+      await sleep(1_075);
+      expect(harness.evicted).toEqual(["expired"]);
+    } finally {
+      await rendered.dispose();
+    }
+  });
+});

--- a/runtime/tests/tui/components/CtrlOToExpand.coverage.test.tsx
+++ b/runtime/tests/tui/components/CtrlOToExpand.coverage.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { describe, expect, test, vi } from 'vitest'
+
+const shortcutMocks = vi.hoisted(() => ({
+  getShortcutDisplay: vi.fn(() => 'cmd+e'),
+}))
+
+vi.mock('../keybindings/shortcutFormat.js', () => ({
+  getShortcutDisplay: shortcutMocks.getShortcutDisplay,
+}))
+
+import { renderToString } from '../../utils/staticRender.js'
+import { Box, Text } from '../ink.js'
+import {
+  CtrlOToExpand,
+  SubAgentProvider,
+  ctrlOToExpand,
+} from './CtrlOToExpand.js'
+import { InVirtualListContext } from './messageActions.js'
+
+describe('CtrlOToExpand coverage', () => {
+  test('renders the expand hint only outside suppressed contexts', async () => {
+    const output = await renderToString(
+      <Box flexDirection="column">
+        <Box>
+          <Text>visible </Text>
+          <CtrlOToExpand />
+        </Box>
+        <Box>
+          <Text>subagent </Text>
+          <SubAgentProvider>
+            <CtrlOToExpand />
+          </SubAgentProvider>
+        </Box>
+        <InVirtualListContext.Provider value={true}>
+          <Box>
+            <Text>virtual </Text>
+            <CtrlOToExpand />
+          </Box>
+        </InVirtualListContext.Provider>
+      </Box>,
+      100,
+    )
+
+    expect(output).toContain('visible (ctrl+o to expand)')
+    expect(output).toContain('subagent')
+    expect(output).toContain('virtual')
+    expect(output.match(/\bto expand\b/g) ?? []).toHaveLength(1)
+
+    expect(stripAnsi(ctrlOToExpand())).toBe('(cmd+e to expand)')
+    expect(shortcutMocks.getShortcutDisplay).toHaveBeenCalledWith(
+      'app:toggleTranscript',
+      'Global',
+      'ctrl+o',
+    )
+  })
+})

--- a/runtime/tests/tui/components/CustomSelect/SelectMulti.test.tsx
+++ b/runtime/tests/tui/components/CustomSelect/SelectMulti.test.tsx
@@ -1,0 +1,322 @@
+import { PassThrough } from 'node:stream'
+
+import figures from 'figures'
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../../ink/root.js'
+import { SelectMulti } from './SelectMulti.js'
+import type { OptionWithDescription } from './select.js'
+
+type InputKey = Partial<{
+  ctrl: boolean
+  downArrow: boolean
+  escape: boolean
+  pageDown: boolean
+  pageUp: boolean
+  return: boolean
+  shift: boolean
+  tab: boolean
+  upArrow: boolean
+}>
+
+type InputEventStub = {
+  stopImmediatePropagation: () => void
+}
+
+type CapturedInput = {
+  handler: (input: string, key: InputKey, event: InputEventStub) => void
+  options: { isActive?: boolean }
+}
+
+const inputMock = vi.hoisted(() => ({
+  current: undefined as CapturedInput | undefined,
+}))
+
+vi.mock('../../ink.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../ink.js')>()
+  return {
+    ...actual,
+    useInput: (
+      handler: CapturedInput['handler'],
+      options: CapturedInput['options'],
+    ) => {
+      inputMock.current = { handler, options }
+    },
+  }
+})
+
+vi.mock('../../../utils/debug.js', () => ({
+  logForDebugging: () => {},
+}))
+vi.mock('../../../bootstrap/state.js', () => ({
+  flushInteractionTime: () => {},
+  getActiveTimeCounter: () => 0,
+  markScrollActivity: () => {},
+  updateLastInteractionTime: () => {},
+}))
+vi.mock('../../../utils/earlyInput.js', () => ({
+  stopCapturingEarlyInput: () => {},
+}))
+vi.mock('../../../utils/envUtils.js', () => ({
+  isEnvTruthy: () => false,
+}))
+vi.mock('../../../utils/fullscreen.js', () => ({
+  isMouseClicksDisabled: () => true,
+}))
+vi.mock('../../../utils/log.js', () => ({
+  logError: () => {},
+}))
+
+const OPTIONS: OptionWithDescription<string>[] = [
+  {
+    value: 'alpha',
+    label: 'Alpha server',
+    description: 'Already selected',
+  },
+  {
+    value: 'beta',
+    label: 'Beta server',
+    description: 'Unavailable option',
+    disabled: true,
+  },
+  {
+    value: 'gamma',
+    label: 'Gamma server',
+    description: 'Hidden below the first page',
+  },
+]
+
+type RenderedSelect = {
+  text: () => string
+  unmount: () => void
+}
+
+async function waitForRender(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 30))
+}
+
+async function renderSelectMulti(node: React.ReactNode): Promise<RenderedSelect> {
+  let output = ''
+  const stdout = new PassThrough()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  root.render(node)
+  await waitForRender()
+
+  return {
+    text: () => stripAnsi(output),
+    unmount: () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    },
+  }
+}
+
+function pressKey(input: string, key: InputKey = {}): InputEventStub {
+  const event = {
+    stopImmediatePropagation: vi.fn(),
+  }
+
+  expect(inputMock.current).toBeDefined()
+  inputMock.current!.handler(input, key, event)
+  return event
+}
+
+function lineContaining(output: string, text: string): string {
+  const line = output
+    .split('\n')
+    .findLast(candidate => candidate.includes(text))
+  expect(line).toBeDefined()
+  return line!
+}
+
+describe('SelectMulti', () => {
+  beforeEach(() => {
+    inputMock.current = undefined
+  })
+
+  test('renders visible rows with indexes, selected checks, descriptions, focus, and scroll hints', async () => {
+    const view = await renderSelectMulti(
+      <SelectMulti
+        options={OPTIONS}
+        defaultValue={['alpha', 'beta']}
+        onCancel={() => {}}
+        visibleOptionCount={2}
+      />,
+    )
+
+    try {
+      const output = view.text()
+
+      expect(output).toContain('1.')
+      expect(output).toContain('Alpha server')
+      expect(output).toContain('Already selected')
+      expect(output).toContain('2.')
+      expect(output).toContain('Beta server')
+      expect(output).toContain('Unavailable option')
+      expect(output).toContain(`[${figures.tick}]`)
+      expect(output).toContain(figures.arrowDown)
+      expect(output).not.toContain('Gamma server')
+      expect(lineContaining(output, 'Alpha server')).toContain(figures.pointer)
+    } finally {
+      view.unmount()
+    }
+  })
+
+  test('honors external focus and hides numeric indexes', async () => {
+    const onFocus = vi.fn()
+    const view = await renderSelectMulti(
+      <SelectMulti
+        options={OPTIONS}
+        focusValue="gamma"
+        hideIndexes={true}
+        onCancel={() => {}}
+        onFocus={onFocus}
+        visibleOptionCount={2}
+      />,
+    )
+
+    try {
+      const output = view.text()
+
+      expect(output).toContain('Beta server')
+      expect(output).toContain('Gamma server')
+      expect(output).not.toContain('1.')
+      expect(output).not.toContain('2.')
+      expect(output).not.toContain('3.')
+      expect(lineContaining(output, 'Gamma server')).toContain(figures.pointer)
+      expect(onFocus).toHaveBeenCalledWith('gamma')
+    } finally {
+      view.unmount()
+    }
+  })
+
+  test('toggles selections, focuses the submit button, submits, and cancels', async () => {
+    const onCancel = vi.fn()
+    const onChange = vi.fn()
+    const onSubmit = vi.fn()
+    const view = await renderSelectMulti(
+      <SelectMulti
+        options={[
+          OPTIONS[0]!,
+          {
+            ...OPTIONS[1]!,
+            disabled: false,
+          },
+        ]}
+        onCancel={onCancel}
+        onChange={onChange}
+        onSubmit={onSubmit}
+        submitButtonText="Import selected"
+      />,
+    )
+
+    try {
+      expect(inputMock.current?.options.isActive).toBe(true)
+
+      pressKey('', { downArrow: true })
+      await waitForRender()
+      pressKey(' ', {})
+      await waitForRender()
+      expect(onChange).toHaveBeenLastCalledWith(['beta'])
+
+      pressKey('', { downArrow: true })
+      await waitForRender()
+      expect(lineContaining(view.text(), 'Import selected')).toContain(
+        figures.pointer,
+      )
+
+      pressKey('', { return: true })
+      expect(onSubmit).toHaveBeenLastCalledWith(['beta'])
+
+      const escapeEvent = pressKey('', { escape: true })
+      expect(onCancel).toHaveBeenCalledTimes(1)
+      expect(escapeEvent.stopImmediatePropagation).toHaveBeenCalledTimes(1)
+    } finally {
+      view.unmount()
+    }
+  })
+
+  test('submits current values directly on return when no submit button is shown', async () => {
+    const onSubmit = vi.fn()
+    const view = await renderSelectMulti(
+      <SelectMulti
+        options={OPTIONS}
+        defaultValue={['alpha']}
+        onCancel={() => {}}
+        onSubmit={onSubmit}
+      />,
+    )
+
+    try {
+      pressKey('', { return: true })
+      expect(onSubmit).toHaveBeenCalledWith(['alpha'])
+    } finally {
+      view.unmount()
+    }
+  })
+
+  test('renders an empty option list and submits an empty selection', async () => {
+    const onSubmit = vi.fn()
+    const view = await renderSelectMulti(
+      <SelectMulti options={[]} onCancel={() => {}} onSubmit={onSubmit} />,
+    )
+
+    try {
+      const output = view.text()
+
+      expect(output).not.toContain('Alpha server')
+      expect(output).not.toContain('1.')
+
+      pressKey('', { return: true })
+      expect(onSubmit).toHaveBeenCalledWith([])
+    } finally {
+      view.unmount()
+    }
+  })
+
+  test('does not toggle disabled options with index keys or focused space', async () => {
+    const onChange = vi.fn()
+    const view = await renderSelectMulti(
+      <SelectMulti
+        options={OPTIONS}
+        focusValue="beta"
+        onCancel={() => {}}
+        onChange={onChange}
+      />,
+    )
+
+    try {
+      pressKey('2', {})
+      expect(onChange).not.toHaveBeenCalled()
+
+      pressKey(' ', {})
+      expect(onChange).not.toHaveBeenCalled()
+    } finally {
+      view.unmount()
+    }
+  })
+})

--- a/runtime/tests/tui/components/CustomSelect/select-input-option.wave200-022.coverage.test.tsx
+++ b/runtime/tests/tui/components/CustomSelect/select-input-option.wave200-022.coverage.test.tsx
@@ -1,0 +1,130 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../../ink/root.js'
+import { SelectInputOption } from './select-input-option.js'
+
+const textInputMock = vi.hoisted(() => ({
+  current: undefined as
+    | undefined
+    | {
+        columns: number
+        cursorOffset: number
+        onChange: (value: string) => void
+        onChangeCursorOffset: (offset: number) => void
+        onPaste: (value: string) => void
+        placeholder?: string
+        value: string
+      },
+}))
+
+vi.mock('../../keybindings/useKeybinding.js', () => ({
+  useKeybinding: () => {},
+  useKeybindings: () => {},
+}))
+
+vi.mock('../TextInput.js', async () => {
+  const ReactActual = await vi.importActual<typeof import('react')>('react')
+
+  return {
+    default: (props: typeof textInputMock.current) => {
+      textInputMock.current = props
+      return ReactActual.createElement(
+        'ink-text',
+        null,
+        props?.value || props?.placeholder || '',
+      )
+    },
+  }
+})
+
+type TestRoot = Awaited<ReturnType<typeof createRoot>>
+
+const mountedRoots: TestRoot[] = []
+
+async function waitForRender(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 30))
+}
+
+async function renderOption(node: React.ReactNode): Promise<TestRoot> {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 80
+
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+  mountedRoots.push(root)
+
+  root.render(node)
+  await waitForRender()
+
+  return root
+}
+
+describe('SelectInputOption unlabeled input coverage', () => {
+  afterEach(() => {
+    textInputMock.current = undefined
+    for (const root of mountedRoots.splice(0)) {
+      root.unmount()
+    }
+  })
+
+  test('routes unlabeled edits and cursor-positioned paste through both change callbacks', async () => {
+    const optionOnChange = vi.fn()
+    const onInputChange = vi.fn()
+
+    await renderOption(
+      <SelectInputOption
+        option={{
+          label: 'Prompt fallback',
+          onChange: optionOnChange,
+          type: 'input',
+        }}
+        isFocused
+        isSelected={false}
+        shouldShowDownArrow={false}
+        shouldShowUpArrow={false}
+        maxIndexWidth={2}
+        index={4}
+        inputValue="abc"
+        onInputChange={onInputChange}
+        onSubmit={() => {}}
+        layout="compact"
+      />,
+    )
+
+    expect(textInputMock.current).toMatchObject({
+      cursorOffset: 3,
+      placeholder: 'Prompt fallback',
+      value: 'abc',
+    })
+
+    textInputMock.current?.onChange('typed')
+    expect(onInputChange).toHaveBeenCalledWith('typed')
+    expect(optionOnChange).toHaveBeenCalledWith('typed')
+
+    textInputMock.current?.onChangeCursorOffset(1)
+    await waitForRender()
+
+    expect(textInputMock.current?.cursorOffset).toBe(1)
+
+    textInputMock.current?.onPaste('!')
+    expect(onInputChange).toHaveBeenLastCalledWith('a!bc')
+    expect(optionOnChange).toHaveBeenLastCalledWith('a!bc')
+  })
+})

--- a/runtime/tests/tui/components/CustomSelect/select.coverage2.test.tsx
+++ b/runtime/tests/tui/components/CustomSelect/select.coverage2.test.tsx
@@ -1,0 +1,193 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../../ink/root.js'
+import { Select, type OptionWithDescription } from './select.js'
+import type { UseSelectProps } from './use-select-input.js'
+
+type CapturedInputOptionProps = {
+  inputValue: string
+  imagesSelected: boolean
+  onInputChange: (value: string) => void
+  onSubmit: (value: string) => void
+  option: OptionWithDescription<string> & { index: number }
+  selectedImageIndex: number
+}
+
+const selectInputOptionMock = vi.hoisted(() => ({
+  props: [] as CapturedInputOptionProps[],
+}))
+
+const selectInputHookMock = vi.hoisted(() => ({
+  props: undefined as UseSelectProps<string> | undefined,
+}))
+
+vi.mock('./select-input-option.js', async () => {
+  const ReactActual = await vi.importActual<typeof import('react')>('react')
+
+  return {
+    SelectInputOption: (props: CapturedInputOptionProps) => {
+      selectInputOptionMock.props.push(props)
+
+      return ReactActual.createElement(
+        'ink-text',
+        null,
+        `input:${props.option.value}=${props.inputValue}`,
+      )
+    },
+  }
+})
+
+vi.mock('./use-select-input.js', () => ({
+  useSelectInput: (props: UseSelectProps<string>) => {
+    selectInputHookMock.props = props
+  },
+}))
+
+vi.mock('../../../utils/debug.js', () => ({
+  logForDebugging: () => {},
+}))
+vi.mock('../../../bootstrap/state.js', () => ({
+  flushInteractionTime: () => {},
+  getActiveTimeCounter: () => 0,
+  markScrollActivity: () => {},
+  updateLastInteractionTime: () => {},
+}))
+vi.mock('../../../utils/earlyInput.js', () => ({
+  stopCapturingEarlyInput: () => {},
+}))
+vi.mock('../../../utils/envUtils.js', () => ({
+  isEnvTruthy: () => false,
+}))
+vi.mock('../../../utils/fullscreen.js', () => ({
+  isMouseClicksDisabled: () => true,
+}))
+vi.mock('../../../utils/log.js', () => ({
+  logError: () => {},
+}))
+
+async function waitForRender(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 30))
+}
+
+type RenderedSelect = {
+  rerender: (node: React.ReactNode) => Promise<void>
+  unmount: () => void
+}
+
+async function renderSelect(node: React.ReactNode): Promise<RenderedSelect> {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 100
+
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  root.render(node)
+  await waitForRender()
+
+  return {
+    rerender: async nextNode => {
+      root.render(nextNode)
+      await waitForRender()
+    },
+    unmount: () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    },
+  }
+}
+
+function latestInputOption(): CapturedInputOptionProps {
+  const props = selectInputOptionMock.props.at(-1)
+  expect(props).toBeDefined()
+  return props!
+}
+
+describe('Select input option coverage', () => {
+  beforeEach(() => {
+    selectInputOptionMock.props = []
+    selectInputHookMock.props = undefined
+  })
+
+  test('wires compact input updates, empty submit cancellation, and image attachment submit state', async () => {
+    const onCancel = vi.fn()
+    const onChange = vi.fn()
+    const options: OptionWithDescription<string>[] = [
+      {
+        type: 'input',
+        value: 'prompt',
+        label: 'Prompt',
+        initialValue: 'seed',
+        onChange: () => {},
+      },
+    ]
+
+    const view = await renderSelect(
+      <Select
+        options={options}
+        defaultFocusValue="prompt"
+        onCancel={onCancel}
+        onChange={onChange}
+      />,
+    )
+
+    try {
+      expect(latestInputOption().inputValue).toBe('seed')
+
+      latestInputOption().onInputChange('typed')
+      await waitForRender()
+      expect(latestInputOption().inputValue).toBe('typed')
+
+      expect(selectInputHookMock.props?.onEnterImageSelection?.()).toBe(false)
+
+      latestInputOption().onSubmit('   ')
+      expect(onCancel).toHaveBeenCalledTimes(1)
+      expect(onChange).not.toHaveBeenCalled()
+
+      latestInputOption().onSubmit('typed')
+      expect(onChange).toHaveBeenCalledWith('prompt')
+
+      await view.rerender(
+        <Select
+          options={options}
+          defaultFocusValue="prompt"
+          onCancel={onCancel}
+          onChange={onChange}
+          pastedContents={{
+            7: {
+              id: 7,
+              type: 'image',
+              content: 'image-bytes',
+            },
+          }}
+        />,
+      )
+
+      expect(selectInputHookMock.props?.onEnterImageSelection?.()).toBe(true)
+      await waitForRender()
+      expect(latestInputOption().imagesSelected).toBe(true)
+      expect(latestInputOption().selectedImageIndex).toBe(0)
+
+      latestInputOption().onSubmit('')
+      expect(onChange).toHaveBeenLastCalledWith('prompt')
+    } finally {
+      view.unmount()
+    }
+  })
+})

--- a/runtime/tests/tui/components/CustomSelect/select.wave200-012.coverage.test.tsx
+++ b/runtime/tests/tui/components/CustomSelect/select.wave200-012.coverage.test.tsx
@@ -1,0 +1,174 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../../ink/root.js'
+import { Select, type OptionWithDescription } from './select.js'
+import type { UseSelectProps } from './use-select-input.js'
+
+type CapturedInputOptionProps = {
+  inputValue: string
+  onInputChange: (value: string) => void
+  option: OptionWithDescription<string> & { index: number }
+}
+
+const selectInputOptionMock = vi.hoisted(() => ({
+  props: [] as CapturedInputOptionProps[],
+}))
+
+const selectInputHookMock = vi.hoisted(() => ({
+  props: undefined as UseSelectProps<string> | undefined,
+}))
+
+vi.mock('./select-input-option.js', async () => {
+  const ReactActual = await vi.importActual<typeof import('react')>('react')
+
+  return {
+    SelectInputOption: (props: CapturedInputOptionProps) => {
+      selectInputOptionMock.props.push(props)
+
+      return ReactActual.createElement(
+        'ink-text',
+        null,
+        `input:${props.option.value}=${props.inputValue}`,
+      )
+    },
+  }
+})
+
+vi.mock('./use-select-input.js', () => ({
+  useSelectInput: (props: UseSelectProps<string>) => {
+    selectInputHookMock.props = props
+  },
+}))
+
+vi.mock('../../../utils/debug.js', () => ({
+  logForDebugging: () => {},
+}))
+vi.mock('../../../bootstrap/state.js', () => ({
+  flushInteractionTime: () => {},
+  getActiveTimeCounter: () => 0,
+  markScrollActivity: () => {},
+  updateLastInteractionTime: () => {},
+}))
+vi.mock('../../../utils/earlyInput.js', () => ({
+  stopCapturingEarlyInput: () => {},
+}))
+vi.mock('../../../utils/envUtils.js', () => ({
+  isEnvTruthy: () => false,
+}))
+vi.mock('../../../utils/fullscreen.js', () => ({
+  isMouseClicksDisabled: () => true,
+}))
+vi.mock('../../../utils/log.js', () => ({
+  logError: () => {},
+}))
+
+async function waitForRender(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 30))
+}
+
+function inputOption(initialValue: string): OptionWithDescription<string> {
+  return {
+    type: 'input',
+    value: 'prompt',
+    label: 'Prompt',
+    initialValue,
+    onChange: () => {},
+  }
+}
+
+function latestInputOption(): CapturedInputOptionProps {
+  const props = selectInputOptionMock.props.at(-1)
+  expect(props).toBeDefined()
+  return props!
+}
+
+type RenderedSelect = {
+  rerender: (node: React.ReactNode) => Promise<void>
+  unmount: () => void
+}
+
+async function renderSelect(node: React.ReactNode): Promise<RenderedSelect> {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 100
+
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  root.render(node)
+  await waitForRender()
+
+  return {
+    rerender: async nextNode => {
+      root.render(nextNode)
+      await waitForRender()
+    },
+    unmount: () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    },
+  }
+}
+
+describe('Select input initial value coverage', () => {
+  beforeEach(() => {
+    selectInputOptionMock.props = []
+    selectInputHookMock.props = undefined
+  })
+
+  test('syncs changed initial values until the user edits the input', async () => {
+    const view = await renderSelect(
+      <Select
+        options={[inputOption('draft one')]}
+        defaultFocusValue="prompt"
+      />,
+    )
+
+    try {
+      expect(latestInputOption().inputValue).toBe('draft one')
+
+      await view.rerender(
+        <Select
+          options={[inputOption('draft two')]}
+          defaultFocusValue="prompt"
+        />,
+      )
+      await waitForRender()
+      expect(latestInputOption().inputValue).toBe('draft two')
+      expect(selectInputHookMock.props?.inputValues?.get('prompt')).toBe(
+        'draft two',
+      )
+
+      latestInputOption().onInputChange('user override')
+      await waitForRender()
+      expect(latestInputOption().inputValue).toBe('user override')
+
+      await view.rerender(
+        <Select
+          options={[inputOption('draft three')]}
+          defaultFocusValue="prompt"
+        />,
+      )
+      await waitForRender()
+      expect(latestInputOption().inputValue).toBe('user override')
+    } finally {
+      view.unmount()
+    }
+  })
+})

--- a/runtime/tests/tui/components/CustomSelect/use-multi-select-state.test.ts
+++ b/runtime/tests/tui/components/CustomSelect/use-multi-select-state.test.ts
@@ -1,0 +1,638 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import Text from '../../ink/components/Text.js'
+import { createRoot } from '../../ink/root.js'
+import type { OptionWithDescription } from './select.js'
+import {
+  type MultiSelectState,
+  type UseMultiSelectStateProps,
+  useMultiSelectState,
+} from './use-multi-select-state.js'
+
+vi.mock('../../../utils/debug.js', () => ({
+  logForDebugging: () => {},
+}))
+vi.mock('../../../bootstrap/state.js', () => ({
+  flushInteractionTime: () => {},
+  getActiveTimeCounter: () => 0,
+  markScrollActivity: () => {},
+  updateLastInteractionTime: () => {},
+}))
+vi.mock('../../../utils/earlyInput.js', () => ({
+  stopCapturingEarlyInput: () => {},
+}))
+vi.mock('../../../utils/envUtils.js', () => ({
+  isEnvTruthy: () => false,
+}))
+vi.mock('../../../utils/fullscreen.js', () => ({
+  isMouseClicksDisabled: () => true,
+}))
+vi.mock('../../../utils/log.js', () => ({
+  logError: () => {},
+}))
+
+type TestStreams = {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+}
+
+type Snapshot = {
+  focusedValue: string | undefined
+  focusedIndex: number
+  visibleFromIndex: number
+  visibleToIndex: number
+  visibleValues: string[]
+  isInInput: boolean
+  selectedValues: string[]
+  inputValues: Record<string, string>
+  isSubmitFocused: boolean
+}
+
+type HarnessProps = UseMultiSelectStateProps<string> & {
+  controlsRef?: { current: MultiSelectState<string> | null }
+  snapshots: Snapshot[]
+}
+
+const DOWN = '\u001B[B'
+const UP = '\u001B[A'
+const PAGE_DOWN = '\u001B[6~'
+const PAGE_UP = '\u001B[5~'
+const SHIFT_TAB = '\u001B[Z'
+const CTRL_ENTER = '\u001B[13;5u'
+const ESCAPE = '\u001B[27u'
+
+function createTestStreams(): TestStreams {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStreams['stdin']
+
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+
+  return { stdout, stdin }
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  label: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await sleep(10)
+  }
+  throw new Error(`Timed out waiting for ${label}`)
+}
+
+function snapshotsMatch(
+  snapshot: Snapshot,
+  expected: Partial<Snapshot>,
+): boolean {
+  return Object.entries(expected).every(([key, value]) => {
+    const actual = snapshot[key as keyof Snapshot]
+    return Array.isArray(value) || typeof value === 'object'
+      ? JSON.stringify(actual) === JSON.stringify(value)
+      : actual === value
+  })
+}
+
+async function expectSnapshot(
+  snapshots: Snapshot[],
+  expected: Partial<Snapshot>,
+): Promise<void> {
+  await waitForCondition(
+    () => snapshots.some(snapshot => snapshotsMatch(snapshot, expected)),
+    `multi-select state ${JSON.stringify(expected)}`,
+  )
+}
+
+function latestSnapshot(snapshots: Snapshot[]): Snapshot {
+  const snapshot = snapshots.at(-1)
+  if (!snapshot) {
+    throw new Error('No multi-select snapshots were captured')
+  }
+  return snapshot
+}
+
+function snapshotOf(state: MultiSelectState<string>): Snapshot {
+  return {
+    focusedValue: state.focusedValue,
+    focusedIndex: state.focusedIndex,
+    visibleFromIndex: state.visibleFromIndex,
+    visibleToIndex: state.visibleToIndex,
+    visibleValues: state.visibleOptions.map(option => option.value),
+    isInInput: state.isInInput,
+    selectedValues: [...state.selectedValues],
+    inputValues: Object.fromEntries(state.inputValues.entries()),
+    isSubmitFocused: state.isSubmitFocused,
+  }
+}
+
+function option(
+  value: string,
+  overrides: Partial<OptionWithDescription<string>> = {},
+): OptionWithDescription<string> {
+  return {
+    value,
+    label: value,
+    ...overrides,
+  } as OptionWithDescription<string>
+}
+
+function inputOption({
+  initialValue,
+  onChange = () => {},
+  value,
+}: {
+  initialValue?: string
+  onChange?: (value: string) => void
+  value: string
+}): OptionWithDescription<string> {
+  return {
+    type: 'input',
+    value,
+    label: value,
+    initialValue,
+    onChange,
+  }
+}
+
+function Harness({
+  controlsRef,
+  snapshots,
+  ...props
+}: HarnessProps): React.ReactNode {
+  const state = useMultiSelectState(props)
+
+  if (controlsRef) {
+    controlsRef.current = state
+  }
+
+  React.useEffect(() => {
+    snapshots.push(snapshotOf(state))
+  }, [snapshots, state])
+
+  return React.createElement(Text, null, state.focusedValue ?? 'none')
+}
+
+async function writeKey(stdin: PassThrough, key: string): Promise<void> {
+  stdin.write(key)
+  await sleep(20)
+}
+
+async function renderHarness(props: HarnessProps): Promise<{
+  root: Awaited<ReturnType<typeof createRoot>>
+  stdin: TestStreams['stdin']
+  stdout: PassThrough
+}> {
+  const { stdout, stdin } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  root.render(React.createElement(Harness, props))
+  await expectSnapshot(props.snapshots, {})
+
+  return { root, stdin, stdout }
+}
+
+async function cleanupHarness(
+  root: Awaited<ReturnType<typeof createRoot>>,
+  stdin: TestStreams['stdin'],
+  stdout: PassThrough,
+): Promise<void> {
+  root.unmount()
+  stdin.end()
+  await sleep(30)
+  stdout.end()
+}
+
+describe('useMultiSelectState', () => {
+  test('initializes focus, visible bounds, selected values, and input values', async () => {
+    const snapshots: Snapshot[] = []
+    const onFocus = vi.fn()
+    const { root, stdin, stdout } = await renderHarness({
+      visibleOptionCount: 2,
+      options: [
+        option('alpha'),
+        inputOption({ value: 'name', initialValue: 'preset' }),
+        option('omega'),
+      ],
+      defaultValue: ['name'],
+      initialFocusLast: true,
+      onFocus,
+      onCancel: () => {},
+      snapshots,
+    })
+
+    try {
+      await expectSnapshot(snapshots, {
+        focusedValue: 'omega',
+        focusedIndex: 3,
+        visibleFromIndex: 1,
+        visibleToIndex: 3,
+        visibleValues: ['name', 'omega'],
+        selectedValues: ['name'],
+        inputValues: { name: 'preset' },
+        isInInput: false,
+        isSubmitFocused: false,
+      })
+      expect(onFocus).toHaveBeenCalledWith('omega')
+    } finally {
+      await cleanupHarness(root, stdin, stdout)
+    }
+  })
+
+  test('toggles selections with space and number keys while preserving bounds', async () => {
+    const snapshots: Snapshot[] = []
+    const onChange = vi.fn()
+    const props: HarnessProps = {
+      visibleOptionCount: 3,
+      options: [option('alpha'), option('beta'), option('gamma')],
+      defaultValue: ['beta'],
+      onChange,
+      onCancel: () => {},
+      snapshots,
+    }
+    const { root, stdin, stdout } = await renderHarness(props)
+
+    try {
+      await expectSnapshot(snapshots, {
+        focusedValue: 'alpha',
+        selectedValues: ['beta'],
+      })
+
+      await writeKey(stdin, ' ')
+      await expectSnapshot(snapshots, {
+        selectedValues: ['beta', 'alpha'],
+      })
+
+      await writeKey(stdin, '　')
+      await expectSnapshot(snapshots, {
+        selectedValues: ['beta'],
+      })
+
+      await writeKey(stdin, '3')
+      await expectSnapshot(snapshots, {
+        selectedValues: ['beta', 'gamma'],
+      })
+
+      await writeKey(stdin, '0')
+      await writeKey(stdin, '9')
+      await sleep(30)
+      expect(latestSnapshot(snapshots).selectedValues).toEqual([
+        'beta',
+        'gamma',
+      ])
+
+      root.render(
+        React.createElement(Harness, {
+          ...props,
+          hideIndexes: true,
+        }),
+      )
+      await sleep(30)
+      await writeKey(stdin, '1')
+      await sleep(30)
+      expect(latestSnapshot(snapshots).selectedValues).toEqual([
+        'beta',
+        'gamma',
+      ])
+
+      expect(onChange).toHaveBeenLastCalledWith(['beta', 'gamma'])
+    } finally {
+      await cleanupHarness(root, stdin, stdout)
+    }
+  })
+
+  test('ignores keyboard input when the multi-select is disabled', async () => {
+    const snapshots: Snapshot[] = []
+    const onCancel = vi.fn()
+    const onChange = vi.fn()
+    const onSubmit = vi.fn()
+    const { root, stdin, stdout } = await renderHarness({
+      isDisabled: true,
+      options: [option('alpha'), option('beta')],
+      onCancel,
+      onChange,
+      onSubmit,
+      snapshots,
+    })
+
+    try {
+      await expectSnapshot(snapshots, {
+        focusedValue: 'alpha',
+        selectedValues: [],
+      })
+
+      await writeKey(stdin, ' ')
+      await writeKey(stdin, '2')
+      await writeKey(stdin, DOWN)
+      await writeKey(stdin, '\r')
+      await writeKey(stdin, ESCAPE)
+      await sleep(30)
+
+      expect(latestSnapshot(snapshots)).toMatchObject({
+        focusedValue: 'alpha',
+        selectedValues: [],
+      })
+      expect(onCancel).not.toHaveBeenCalled()
+      expect(onChange).not.toHaveBeenCalled()
+      expect(onSubmit).not.toHaveBeenCalled()
+    } finally {
+      await cleanupHarness(root, stdin, stdout)
+    }
+  })
+
+  test('does not select disabled options by focus or visible number', async () => {
+    const snapshots: Snapshot[] = []
+    const onChange = vi.fn()
+    const { root, stdin, stdout } = await renderHarness({
+      options: [
+        option('alpha'),
+        option('beta', { disabled: true }),
+        option('gamma'),
+      ],
+      focusValue: 'beta',
+      onChange,
+      onCancel: () => {},
+      snapshots,
+    })
+
+    try {
+      await expectSnapshot(snapshots, {
+        focusedValue: 'beta',
+        selectedValues: [],
+      })
+
+      await writeKey(stdin, ' ')
+      await sleep(30)
+      expect(latestSnapshot(snapshots).selectedValues).toEqual([])
+
+      await writeKey(stdin, '2')
+      await sleep(30)
+      expect(latestSnapshot(snapshots).selectedValues).toEqual([])
+      expect(onChange).not.toHaveBeenCalled()
+    } finally {
+      await cleanupHarness(root, stdin, stdout)
+    }
+  })
+
+  test('navigates with arrows, vi keys, pages, tabs, and boundary callbacks', async () => {
+    const snapshots: Snapshot[] = []
+    const controlsRef = { current: null as MultiSelectState<string> | null }
+    const onDownFromLastItem = vi.fn()
+    const onUpFromFirstItem = vi.fn()
+    const { root, stdin, stdout } = await renderHarness({
+      visibleOptionCount: 2,
+      options: [
+        option('alpha'),
+        option('beta'),
+        option('gamma'),
+        option('delta'),
+      ],
+      submitButtonText: 'Apply',
+      onSubmit: () => {},
+      onDownFromLastItem,
+      onUpFromFirstItem,
+      onCancel: () => {},
+      controlsRef,
+      snapshots,
+    })
+
+    try {
+      await expectSnapshot(snapshots, {
+        focusedValue: 'alpha',
+        visibleValues: ['alpha', 'beta'],
+      })
+
+      await writeKey(stdin, DOWN)
+      await expectSnapshot(snapshots, {
+        focusedValue: 'beta',
+        visibleFromIndex: 0,
+        visibleToIndex: 2,
+      })
+
+      await writeKey(stdin, PAGE_DOWN)
+      await expectSnapshot(snapshots, {
+        focusedValue: 'delta',
+        visibleFromIndex: 2,
+        visibleToIndex: 4,
+        visibleValues: ['gamma', 'delta'],
+      })
+
+      await writeKey(stdin, PAGE_UP)
+      await expectSnapshot(snapshots, {
+        focusedValue: 'beta',
+        visibleFromIndex: 1,
+        visibleToIndex: 3,
+        visibleValues: ['beta', 'gamma'],
+      })
+
+      await writeKey(stdin, 'k')
+      await expectSnapshot(snapshots, {
+        focusedValue: 'alpha',
+        visibleFromIndex: 0,
+      })
+      await writeKey(stdin, UP)
+      expect(onUpFromFirstItem).toHaveBeenCalledTimes(1)
+
+      controlsRef.current?.focusOption('delta')
+      await waitForCondition(
+        () => latestSnapshot(snapshots).focusedValue === 'delta',
+        'focus delta',
+      )
+      await writeKey(stdin, DOWN)
+      await expectSnapshot(snapshots, {
+        isSubmitFocused: true,
+      })
+      await writeKey(stdin, DOWN)
+      expect(onDownFromLastItem).toHaveBeenCalledTimes(1)
+
+      await writeKey(stdin, SHIFT_TAB)
+      await expectSnapshot(snapshots, {
+        focusedValue: 'delta',
+        isSubmitFocused: false,
+      })
+
+      await writeKey(stdin, '\t')
+      await expectSnapshot(snapshots, {
+        isSubmitFocused: true,
+      })
+      await writeKey(stdin, UP)
+      await expectSnapshot(snapshots, {
+        isSubmitFocused: false,
+      })
+
+      await writeKey(stdin, 'j')
+      await expectSnapshot(snapshots, {
+        isSubmitFocused: true,
+      })
+    } finally {
+      await cleanupHarness(root, stdin, stdout)
+    }
+  })
+
+  test('submits, cancels, and resets only when option navigation data changes', async () => {
+    const snapshots: Snapshot[] = []
+    const onCancel = vi.fn()
+    const onSubmit = vi.fn()
+    const props: HarnessProps = {
+      options: [option('alpha'), option('beta')],
+      defaultValue: ['alpha'],
+      onCancel,
+      onSubmit,
+      snapshots,
+    }
+    const { root, stdin, stdout } = await renderHarness(props)
+
+    try {
+      await expectSnapshot(snapshots, {
+        selectedValues: ['alpha'],
+      })
+
+      await writeKey(stdin, ' ')
+      await expectSnapshot(snapshots, {
+        selectedValues: [],
+      })
+
+      root.render(
+        React.createElement(Harness, {
+          ...props,
+          options: [
+            option('alpha', { label: 'Alpha changed' }),
+            option('beta', { label: 'Beta changed' }),
+          ],
+          defaultValue: ['beta'],
+        }),
+      )
+      await sleep(30)
+      expect(latestSnapshot(snapshots).selectedValues).toEqual([])
+
+      root.render(
+        React.createElement(Harness, {
+          ...props,
+          options: [option('alpha'), option('gamma')],
+          defaultValue: ['gamma'],
+        }),
+      )
+      await expectSnapshot(snapshots, {
+        selectedValues: ['gamma'],
+      })
+
+      await writeKey(stdin, '\r')
+      expect(onSubmit).toHaveBeenLastCalledWith(['gamma'])
+
+      await writeKey(stdin, ESCAPE)
+      expect(onCancel).toHaveBeenCalledTimes(1)
+    } finally {
+      await cleanupHarness(root, stdin, stdout)
+    }
+  })
+
+  test('uses submit button focus for final submission', async () => {
+    const snapshots: Snapshot[] = []
+    const onChange = vi.fn()
+    const onSubmit = vi.fn()
+    const { root, stdin, stdout } = await renderHarness({
+      options: [option('alpha'), option('beta')],
+      submitButtonText: 'Apply',
+      onChange,
+      onSubmit,
+      onCancel: () => {},
+      snapshots,
+    })
+
+    try {
+      await writeKey(stdin, '\r')
+      await expectSnapshot(snapshots, {
+        selectedValues: ['alpha'],
+      })
+      expect(onChange).toHaveBeenLastCalledWith(['alpha'])
+      expect(onSubmit).not.toHaveBeenCalled()
+
+      await writeKey(stdin, DOWN)
+      await expectSnapshot(snapshots, {
+        focusedValue: 'beta',
+      })
+      await writeKey(stdin, DOWN)
+      await expectSnapshot(snapshots, {
+        isSubmitFocused: true,
+      })
+      await writeKey(stdin, '\r')
+      expect(onSubmit).toHaveBeenLastCalledWith(['alpha'])
+    } finally {
+      await cleanupHarness(root, stdin, stdout)
+    }
+  })
+
+  test('updates input option values and keeps text input keystrokes local', async () => {
+    const snapshots: Snapshot[] = []
+    const controlsRef = { current: null as MultiSelectState<string> | null }
+    const onInputChange = vi.fn()
+    const onSubmit = vi.fn()
+    const { root, stdin, stdout } = await renderHarness({
+      options: [
+        inputOption({
+          value: 'query',
+          initialValue: 'seed',
+          onChange: onInputChange,
+        }),
+        option('other'),
+      ],
+      focusValue: 'query',
+      onSubmit,
+      onCancel: () => {},
+      controlsRef,
+      snapshots,
+    })
+
+    try {
+      await expectSnapshot(snapshots, {
+        focusedValue: 'query',
+        isInInput: true,
+        inputValues: { query: 'seed' },
+      })
+
+      await writeKey(stdin, '2')
+      await sleep(30)
+      expect(latestSnapshot(snapshots).selectedValues).toEqual([])
+
+      controlsRef.current?.updateInputValue('query', 'abc')
+      await expectSnapshot(snapshots, {
+        selectedValues: ['query'],
+        inputValues: { query: 'abc' },
+      })
+      expect(onInputChange).toHaveBeenLastCalledWith('abc')
+
+      controlsRef.current?.updateInputValue('query', '')
+      await expectSnapshot(snapshots, {
+        selectedValues: [],
+        inputValues: { query: '' },
+      })
+      expect(onInputChange).toHaveBeenLastCalledWith('')
+
+      await writeKey(stdin, CTRL_ENTER)
+      expect(onSubmit).toHaveBeenLastCalledWith([])
+    } finally {
+      await cleanupHarness(root, stdin, stdout)
+    }
+  })
+})

--- a/runtime/tests/tui/components/CustomSelect/use-select-input.coverage.test.ts
+++ b/runtime/tests/tui/components/CustomSelect/use-select-input.coverage.test.ts
@@ -1,0 +1,198 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../../ink/root.js'
+import type { OptionWithDescription } from './select.js'
+import { useSelectInput } from './use-select-input.js'
+import type { SelectState } from './use-select-state.js'
+
+type InputKey = Partial<{
+  ctrl: boolean
+  downArrow: boolean
+  pageDown: boolean
+  pageUp: boolean
+  tab: boolean
+  upArrow: boolean
+}>
+
+type InputEventStub = {
+  stopImmediatePropagation: () => void
+}
+
+type CapturedInput = {
+  handler: (input: string, key: InputKey, event: InputEventStub) => void
+  options: { isActive?: boolean }
+}
+
+const inputMock = vi.hoisted(() => ({
+  current: undefined as CapturedInput | undefined,
+}))
+
+const keybindingMock = vi.hoisted(() => ({
+  current: undefined as
+    | undefined
+    | {
+        handlers: Record<string, () => void>
+        options: { context?: string; isActive?: boolean }
+      },
+}))
+
+const overlayMock = vi.hoisted(() => ({
+  useRegisterOverlay: vi.fn(),
+}))
+
+vi.mock('../../context/overlayContext.js', () => ({
+  useRegisterOverlay: overlayMock.useRegisterOverlay,
+}))
+
+vi.mock('../../ink.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../ink.js')>()
+  return {
+    ...actual,
+    useInput: (
+      handler: CapturedInput['handler'],
+      options: CapturedInput['options'],
+    ) => {
+      inputMock.current = { handler, options }
+    },
+  }
+})
+
+vi.mock('../../keybindings/useKeybinding.js', () => ({
+  useKeybindings: (
+    handlers: Record<string, () => void>,
+    options: { context?: string; isActive?: boolean },
+  ) => {
+    keybindingMock.current = { handlers, options }
+  },
+}))
+
+function createSelectState(
+  overrides: Partial<SelectState<string>> = {},
+): SelectState<string> {
+  return {
+    focusedValue: 'prompt',
+    focusedIndex: 2,
+    visibleFromIndex: 0,
+    visibleToIndex: 3,
+    value: undefined,
+    options: [],
+    visibleOptions: [],
+    isInInput: true,
+    focusNextOption: vi.fn(),
+    focusPreviousOption: vi.fn(),
+    focusNextPage: vi.fn(),
+    focusPreviousPage: vi.fn(),
+    focusOption: vi.fn(),
+    selectFocusedOption: vi.fn(),
+    onChange: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  }
+}
+
+function Harness({
+  options,
+  state,
+}: {
+  options: OptionWithDescription<string>[]
+  state: SelectState<string>
+}): null {
+  useSelectInput({ options, state })
+  return null
+}
+
+async function renderHarness(node: React.ReactNode): Promise<() => void> {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  root.render(node)
+  await new Promise(resolve => setTimeout(resolve, 30))
+
+  return () => {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+  }
+}
+
+function pressKey(input: string, key: InputKey = {}): InputEventStub {
+  const event = {
+    stopImmediatePropagation: vi.fn(),
+  }
+
+  expect(inputMock.current).toBeDefined()
+  inputMock.current!.handler(input, key, event)
+  return event
+}
+
+describe('useSelectInput', () => {
+  const options: OptionWithDescription<string>[] = [
+    { value: 'alpha', label: 'Alpha' },
+    { type: 'input', value: 'prompt', label: 'Prompt', onChange: vi.fn() },
+    { value: 'omega', label: 'Omega' },
+  ]
+
+  beforeEach(() => {
+    inputMock.current = undefined
+    keybindingMock.current = undefined
+    overlayMock.useRegisterOverlay.mockClear()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('lets focused input options keep typed digits while arrow keys still move selection', async () => {
+    const state = createSelectState({ options })
+    const unmount = await renderHarness(
+      React.createElement(Harness, { options, state }),
+    )
+
+    try {
+      expect(overlayMock.useRegisterOverlay).toHaveBeenCalledWith(
+        'select',
+        true,
+      )
+      expect(keybindingMock.current?.options).toEqual({
+        context: 'Select',
+        isActive: true,
+      })
+      expect(keybindingMock.current?.handlers).toEqual({
+        'select:cancel': expect.any(Function),
+      })
+      expect(inputMock.current?.options.isActive).toBe(true)
+
+      const digitEvent = pressKey('1')
+      expect(state.onChange).not.toHaveBeenCalled()
+      expect(state.focusOption).not.toHaveBeenCalled()
+      expect(state.selectFocusedOption).not.toHaveBeenCalled()
+      expect(digitEvent.stopImmediatePropagation).not.toHaveBeenCalled()
+
+      const downEvent = pressKey('', { downArrow: true })
+      expect(state.focusNextOption).toHaveBeenCalledTimes(1)
+      expect(downEvent.stopImmediatePropagation).toHaveBeenCalledTimes(1)
+    } finally {
+      unmount()
+    }
+  })
+})

--- a/runtime/tests/tui/components/CustomSelect/use-select-input.coverage2.test.ts
+++ b/runtime/tests/tui/components/CustomSelect/use-select-input.coverage2.test.ts
@@ -1,0 +1,211 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../../ink/root.js'
+import type { OptionWithDescription } from './select.js'
+import { useSelectInput } from './use-select-input.js'
+import type { SelectState } from './use-select-state.js'
+
+type InputKey = Partial<{
+  ctrl: boolean
+  downArrow: boolean
+  pageDown: boolean
+  pageUp: boolean
+  tab: boolean
+  upArrow: boolean
+}>
+
+type InputEventStub = {
+  stopImmediatePropagation: () => void
+}
+
+type CapturedInput = {
+  handler: (input: string, key: InputKey, event: InputEventStub) => void
+  options: { isActive?: boolean }
+}
+
+const inputMock = vi.hoisted(() => ({
+  current: undefined as CapturedInput | undefined,
+}))
+
+const overlayMock = vi.hoisted(() => ({
+  useRegisterOverlay: vi.fn(),
+}))
+
+vi.mock('../../context/overlayContext.js', () => ({
+  useRegisterOverlay: overlayMock.useRegisterOverlay,
+}))
+
+vi.mock('../../ink.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../ink.js')>()
+  return {
+    ...actual,
+    useInput: (
+      handler: CapturedInput['handler'],
+      options: CapturedInput['options'],
+    ) => {
+      inputMock.current = { handler, options }
+    },
+  }
+})
+
+vi.mock('../../keybindings/useKeybinding.js', () => ({
+  useKeybindings: vi.fn(),
+}))
+
+function createSelectState(
+  options: OptionWithDescription<string>[],
+  overrides: Partial<SelectState<string>> = {},
+): SelectState<string> {
+  return {
+    focusedValue: 'alpha',
+    focusedIndex: 1,
+    visibleFromIndex: 0,
+    visibleToIndex: options.length - 1,
+    value: undefined,
+    options,
+    visibleOptions: [],
+    isInInput: false,
+    focusNextOption: vi.fn(),
+    focusPreviousOption: vi.fn(),
+    focusNextPage: vi.fn(),
+    focusPreviousPage: vi.fn(),
+    focusOption: vi.fn(),
+    selectFocusedOption: vi.fn(),
+    onChange: vi.fn(),
+    ...overrides,
+  }
+}
+
+function Harness({
+  inputValues,
+  options,
+  state,
+}: {
+  inputValues: Map<string, string>
+  options: OptionWithDescription<string>[]
+  state: SelectState<string>
+}): null {
+  useSelectInput({ inputValues, options, state })
+  return null
+}
+
+async function renderHarness(node: React.ReactNode): Promise<() => void> {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  root.render(node)
+  await new Promise(resolve => setTimeout(resolve, 30))
+
+  return () => {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+  }
+}
+
+function pressKey(input: string, key: InputKey = {}): InputEventStub {
+  const event = {
+    stopImmediatePropagation: vi.fn(),
+  }
+
+  expect(inputMock.current).toBeDefined()
+  inputMock.current!.handler(input, key, event)
+  return event
+}
+
+describe('useSelectInput numeric shortcuts', () => {
+  const options: OptionWithDescription<string>[] = [
+    { value: 'alpha', label: 'Alpha' },
+    {
+      type: 'input',
+      value: 'prompt',
+      label: 'Prompt',
+      onChange: vi.fn(),
+    },
+    {
+      type: 'input',
+      value: 'cancel-empty',
+      label: 'Cancel empty',
+      onChange: vi.fn(),
+      allowEmptySubmitToCancel: true,
+    },
+    {
+      type: 'input',
+      value: 'empty-prompt',
+      label: 'Empty prompt',
+      onChange: vi.fn(),
+    },
+    { value: 'disabled', label: 'Disabled', disabled: true },
+  ]
+
+  beforeEach(() => {
+    inputMock.current = undefined
+    overlayMock.useRegisterOverlay.mockClear()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('routes number keys through input option submit and focus rules', async () => {
+    const state = createSelectState(options)
+    const inputValues = new Map<string, string>([
+      ['prompt', 'ready to submit'],
+      ['cancel-empty', ''],
+      ['empty-prompt', '   '],
+    ])
+    const unmount = await renderHarness(
+      React.createElement(Harness, { inputValues, options, state }),
+    )
+
+    try {
+      expect(overlayMock.useRegisterOverlay).toHaveBeenCalledWith(
+        'select',
+        false,
+      )
+      expect(inputMock.current?.options.isActive).toBe(true)
+
+      pressKey('5')
+      expect(state.onChange).not.toHaveBeenCalled()
+      expect(state.focusOption).not.toHaveBeenCalled()
+
+      pressKey('2')
+      expect(state.onChange).toHaveBeenCalledWith('prompt')
+      expect(state.focusOption).not.toHaveBeenCalled()
+
+      pressKey('3')
+      expect(state.onChange).toHaveBeenNthCalledWith(2, 'cancel-empty')
+      expect(state.focusOption).not.toHaveBeenCalled()
+
+      pressKey('4')
+      expect(state.focusOption).toHaveBeenCalledWith('empty-prompt')
+      expect(state.onChange).toHaveBeenCalledTimes(2)
+
+      pressKey('1')
+      expect(state.onChange).toHaveBeenNthCalledWith(3, 'alpha')
+      expect(state.selectFocusedOption).not.toHaveBeenCalled()
+    } finally {
+      unmount()
+    }
+  })
+})

--- a/runtime/tests/tui/components/CustomSelect/use-select-input.wave200-034.coverage.test.ts
+++ b/runtime/tests/tui/components/CustomSelect/use-select-input.wave200-034.coverage.test.ts
@@ -1,0 +1,253 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../../ink/root.js'
+import type { OptionWithDescription } from './select.js'
+import { useSelectInput } from './use-select-input.js'
+import type { SelectState } from './use-select-state.js'
+
+type InputKey = Partial<{
+  ctrl: boolean
+  downArrow: boolean
+  pageDown: boolean
+  pageUp: boolean
+  tab: boolean
+  upArrow: boolean
+}>
+
+type InputEventStub = {
+  stopImmediatePropagation: () => void
+}
+
+type CapturedInput = {
+  handler: (input: string, key: InputKey, event: InputEventStub) => void
+  options: { isActive?: boolean }
+}
+
+type CapturedKeybindings = {
+  handlers: Record<string, () => void>
+  options: { context?: string; isActive?: boolean }
+}
+
+const inputMock = vi.hoisted(() => ({
+  current: undefined as CapturedInput | undefined,
+}))
+
+const keybindingMock = vi.hoisted(() => ({
+  current: undefined as CapturedKeybindings | undefined,
+}))
+
+const overlayMock = vi.hoisted(() => ({
+  useRegisterOverlay: vi.fn(),
+}))
+
+vi.mock('../../context/overlayContext.js', () => ({
+  useRegisterOverlay: overlayMock.useRegisterOverlay,
+}))
+
+vi.mock('../../ink.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../ink.js')>()
+  return {
+    ...actual,
+    useInput: (
+      handler: CapturedInput['handler'],
+      options: CapturedInput['options'],
+    ) => {
+      inputMock.current = { handler, options }
+    },
+  }
+})
+
+vi.mock('../../keybindings/useKeybinding.js', () => ({
+  useKeybindings: (
+    handlers: Record<string, () => void>,
+    options: { context?: string; isActive?: boolean },
+  ) => {
+    keybindingMock.current = { handlers, options }
+  },
+}))
+
+const options: OptionWithDescription<string>[] = [
+  { value: 'alpha', label: 'Alpha' },
+  { value: 'disabled', label: 'Disabled', disabled: true },
+  { value: 'omega', label: 'Omega' },
+]
+
+function createSelectState(
+  overrides: Partial<SelectState<string>> = {},
+): SelectState<string> {
+  return {
+    focusedValue: 'omega',
+    focusedIndex: 2,
+    visibleFromIndex: 0,
+    visibleToIndex: options.length - 1,
+    value: undefined,
+    options,
+    visibleOptions: [],
+    isInInput: false,
+    focusNextOption: vi.fn(),
+    focusPreviousOption: vi.fn(),
+    focusNextPage: vi.fn(),
+    focusPreviousPage: vi.fn(),
+    focusOption: vi.fn(),
+    selectFocusedOption: vi.fn(),
+    onChange: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  }
+}
+
+function Harness({
+  state,
+  onDownFromLastItem,
+  onUpFromFirstItem,
+}: {
+  state: SelectState<string>
+  onDownFromLastItem: () => void
+  onUpFromFirstItem: () => void
+}): null {
+  useSelectInput({
+    disableSelection: 'numeric',
+    isMultiSelect: true,
+    onDownFromLastItem,
+    onUpFromFirstItem,
+    options,
+    state,
+  })
+  return null
+}
+
+async function renderHarness(node: React.ReactNode): Promise<() => void> {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  root.render(node)
+  await new Promise(resolve => setTimeout(resolve, 30))
+
+  return () => {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+  }
+}
+
+function pressInput(input: string, key: InputKey = {}): InputEventStub {
+  const event = {
+    stopImmediatePropagation: vi.fn(),
+  }
+
+  expect(inputMock.current).toBeDefined()
+  inputMock.current!.handler(input, key, event)
+  return event
+}
+
+function handler(name: string): () => void {
+  const fn = keybindingMock.current?.handlers[name]
+  expect(fn).toBeDefined()
+  return fn!
+}
+
+describe('useSelectInput keybinding and non-input input coverage', () => {
+  beforeEach(() => {
+    inputMock.current = undefined
+    keybindingMock.current = undefined
+    overlayMock.useRegisterOverlay.mockClear()
+  })
+
+  test('handles boundary keybindings, accept states, pages, spaces, and numeric suppression', async () => {
+    const state = createSelectState()
+    const onDownFromLastItem = vi.fn()
+    const onUpFromFirstItem = vi.fn()
+
+    const unmount = await renderHarness(
+      React.createElement(Harness, {
+        onDownFromLastItem,
+        onUpFromFirstItem,
+        state,
+      }),
+    )
+
+    try {
+      expect(overlayMock.useRegisterOverlay).toHaveBeenCalledWith(
+        'select',
+        true,
+      )
+      expect(keybindingMock.current?.options).toEqual({
+        context: 'Select',
+        isActive: true,
+      })
+      expect(inputMock.current?.options).toEqual({ isActive: true })
+
+      handler('select:next')()
+      expect(onDownFromLastItem).toHaveBeenCalledTimes(1)
+      expect(state.focusNextOption).not.toHaveBeenCalled()
+
+      state.focusedValue = 'alpha'
+      handler('select:previous')()
+      expect(onUpFromFirstItem).toHaveBeenCalledTimes(1)
+      expect(state.focusPreviousOption).not.toHaveBeenCalled()
+
+      state.focusedValue = 'disabled'
+      handler('select:accept')()
+      expect(state.selectFocusedOption).not.toHaveBeenCalled()
+      expect(state.onChange).not.toHaveBeenCalled()
+
+      state.focusedValue = undefined
+      handler('select:accept')()
+      expect(state.selectFocusedOption).not.toHaveBeenCalled()
+      expect(state.onChange).not.toHaveBeenCalled()
+
+      state.focusedValue = 'alpha'
+      handler('select:accept')()
+      expect(state.selectFocusedOption).toHaveBeenCalledTimes(1)
+      expect(state.onChange).toHaveBeenCalledWith('alpha')
+
+      handler('select:cancel')()
+      expect(state.onCancel).toHaveBeenCalledTimes(1)
+
+      pressInput('', { pageDown: true })
+      expect(state.focusNextPage).toHaveBeenCalledTimes(1)
+
+      pressInput('', { pageUp: true })
+      expect(state.focusPreviousPage).toHaveBeenCalledTimes(1)
+
+      vi.mocked(state.selectFocusedOption).mockClear()
+      vi.mocked(state.onChange).mockClear()
+      pressInput('\u3000')
+      expect(state.selectFocusedOption).toHaveBeenCalledTimes(1)
+      expect(state.onChange).toHaveBeenCalledWith('alpha')
+
+      vi.mocked(state.selectFocusedOption).mockClear()
+      vi.mocked(state.onChange).mockClear()
+      pressInput('2')
+      expect(state.selectFocusedOption).not.toHaveBeenCalled()
+      expect(state.onChange).not.toHaveBeenCalled()
+
+      state.focusedValue = 'disabled'
+      pressInput(' ')
+      expect(state.selectFocusedOption).not.toHaveBeenCalled()
+      expect(state.onChange).not.toHaveBeenCalled()
+    } finally {
+      unmount()
+    }
+  })
+})

--- a/runtime/tests/tui/components/CustomSelect/use-select-navigation.wave200-082.coverage.test.tsx
+++ b/runtime/tests/tui/components/CustomSelect/use-select-navigation.wave200-082.coverage.test.tsx
@@ -1,0 +1,278 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../../ink/root.js'
+import type { OptionWithDescription } from './select.js'
+import {
+  type SelectNavigation,
+  useSelectNavigation,
+} from './use-select-navigation.js'
+
+vi.mock('../../../utils/debug.js', () => ({
+  logForDebugging: () => {},
+}))
+vi.mock('../../../bootstrap/state.js', () => ({
+  flushInteractionTime: () => {},
+  markScrollActivity: () => {},
+  updateLastInteractionTime: () => {},
+}))
+vi.mock('../../../utils/earlyInput.js', () => ({
+  stopCapturingEarlyInput: () => {},
+}))
+vi.mock('../../../utils/envUtils.js', () => ({
+  isEnvTruthy: () => false,
+}))
+vi.mock('../../../utils/fullscreen.js', () => ({
+  isMouseClicksDisabled: () => true,
+}))
+vi.mock('../../../utils/log.js', () => ({
+  logError: () => {},
+}))
+
+type TestStreams = {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+}
+
+type Snapshot = {
+  focusedValue: string | undefined
+  focusedIndex: number
+  visibleFromIndex: number
+  visibleToIndex: number
+  visibleValues: string[]
+}
+
+function createTestStreams(): TestStreams {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStreams['stdin']
+
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+
+  return { stdout, stdin }
+}
+
+function options(values: string[]): OptionWithDescription<string>[] {
+  return values.map(value => ({
+    value,
+    label: value,
+  }))
+}
+
+function snapshotOf(navigation: SelectNavigation<string>): Snapshot {
+  return {
+    focusedValue: navigation.focusedValue,
+    focusedIndex: navigation.focusedIndex,
+    visibleFromIndex: navigation.visibleFromIndex,
+    visibleToIndex: navigation.visibleToIndex,
+    visibleValues: navigation.visibleOptions.map(option => option.value),
+  }
+}
+
+async function waitForNavigation(
+  controlsRef: { current: SelectNavigation<string> | null },
+  expected: Partial<Snapshot>,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < 2_000) {
+    const current = controlsRef.current
+    if (current) {
+      const snapshot = snapshotOf(current)
+      const matches = Object.entries(expected).every(([key, value]) => {
+        const actual = snapshot[key as keyof Snapshot]
+        return Array.isArray(value)
+          ? JSON.stringify(actual) === JSON.stringify(value)
+          : actual === value
+      })
+
+      if (matches) {
+        return
+      }
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+
+  const latest = controlsRef.current ? snapshotOf(controlsRef.current) : null
+  throw new Error(
+    `Timed out waiting for navigation state ${JSON.stringify({
+      expected,
+      latest,
+    })}`,
+  )
+}
+
+function Harness({
+  controlsRef,
+  initialFocusValue,
+  optionItems,
+}: {
+  controlsRef: { current: SelectNavigation<string> | null }
+  initialFocusValue?: string
+  optionItems: OptionWithDescription<string>[]
+}): null {
+  const navigation = useSelectNavigation({
+    visibleOptionCount: 2,
+    options: optionItems,
+    initialFocusValue,
+  })
+
+  controlsRef.current = navigation
+  return null
+}
+
+describe('useSelectNavigation wave200 coverage', () => {
+  test('keeps focus and viewport coherent across empty and reordered options', async () => {
+    const controlsRef = { current: null as SelectNavigation<string> | null }
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    })
+
+    try {
+      root.render(
+        <Harness
+          controlsRef={controlsRef}
+          initialFocusValue="missing"
+          optionItems={[]}
+        />,
+      )
+      await waitForNavigation(controlsRef, {
+        focusedValue: undefined,
+        focusedIndex: 0,
+        visibleFromIndex: 0,
+        visibleToIndex: 0,
+        visibleValues: [],
+      })
+
+      controlsRef.current?.focusNextOption()
+      controlsRef.current?.focusPreviousOption()
+      controlsRef.current?.focusNextPage()
+      controlsRef.current?.focusPreviousPage()
+      controlsRef.current?.focusOption(undefined)
+      await waitForNavigation(controlsRef, {
+        focusedValue: undefined,
+        focusedIndex: 0,
+        visibleFromIndex: 0,
+        visibleToIndex: 0,
+        visibleValues: [],
+      })
+
+      root.render(
+        <Harness
+          controlsRef={controlsRef}
+          initialFocusValue="four"
+          optionItems={options(['one', 'two', 'three', 'four', 'five'])}
+        />,
+      )
+      await waitForNavigation(controlsRef, {
+        focusedValue: 'four',
+        focusedIndex: 4,
+        visibleFromIndex: 2,
+        visibleToIndex: 4,
+        visibleValues: ['three', 'four'],
+      })
+
+      root.render(
+        <Harness
+          controlsRef={controlsRef}
+          initialFocusValue="four"
+          optionItems={options(['four', 'five', 'six'])}
+        />,
+      )
+      await waitForNavigation(controlsRef, {
+        focusedValue: 'four',
+        focusedIndex: 1,
+        visibleFromIndex: 0,
+        visibleToIndex: 2,
+        visibleValues: ['four', 'five'],
+      })
+
+      root.render(
+        <Harness
+          controlsRef={controlsRef}
+          initialFocusValue="four"
+          optionItems={options(['zero', 'one', 'two', 'three', 'four'])}
+        />,
+      )
+      await waitForNavigation(controlsRef, {
+        focusedValue: 'four',
+        focusedIndex: 5,
+        visibleFromIndex: 3,
+        visibleToIndex: 5,
+        visibleValues: ['three', 'four'],
+      })
+
+      controlsRef.current?.focusOption('three')
+      await waitForNavigation(controlsRef, {
+        focusedValue: 'three',
+        focusedIndex: 4,
+        visibleFromIndex: 3,
+        visibleToIndex: 5,
+        visibleValues: ['three', 'four'],
+      })
+
+      controlsRef.current?.focusOption('one')
+      await waitForNavigation(controlsRef, {
+        focusedValue: 'one',
+        focusedIndex: 2,
+        visibleFromIndex: 1,
+        visibleToIndex: 3,
+        visibleValues: ['one', 'two'],
+      })
+
+      controlsRef.current?.focusOption('missing')
+      await waitForNavigation(controlsRef, {
+        focusedValue: 'one',
+        focusedIndex: 2,
+        visibleFromIndex: 1,
+        visibleToIndex: 3,
+        visibleValues: ['one', 'two'],
+      })
+
+      controlsRef.current?.focusPreviousOption()
+      await waitForNavigation(controlsRef, {
+        focusedValue: 'zero',
+        focusedIndex: 1,
+        visibleFromIndex: 0,
+        visibleToIndex: 2,
+        visibleValues: ['zero', 'one'],
+      })
+
+      controlsRef.current?.focusPreviousOption()
+      await waitForNavigation(controlsRef, {
+        focusedValue: 'four',
+        focusedIndex: 5,
+        visibleFromIndex: 3,
+        visibleToIndex: 5,
+        visibleValues: ['three', 'four'],
+      })
+
+      controlsRef.current?.focusNextOption()
+      await waitForNavigation(controlsRef, {
+        focusedValue: 'zero',
+        focusedIndex: 1,
+        visibleFromIndex: 0,
+        visibleToIndex: 2,
+        visibleValues: ['zero', 'one'],
+      })
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+  })
+})

--- a/runtime/tests/tui/components/DiagnosticsDisplay.coverage.test.tsx
+++ b/runtime/tests/tui/components/DiagnosticsDisplay.coverage.test.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import figures from "figures";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { renderToString } from "../../utils/staticRender.js";
+import { DiagnosticsDisplay } from "./DiagnosticsDisplay.js";
+
+const previousGlyphMode = process.env.AGENC_TUI_GLYPHS;
+
+vi.mock("../../utils/cwd.js", () => ({
+  getCwd: () => "/repo",
+}));
+
+afterEach(() => {
+  if (previousGlyphMode === undefined) {
+    delete process.env.AGENC_TUI_GLYPHS;
+  } else {
+    process.env.AGENC_TUI_GLYPHS = previousGlyphMode;
+  }
+});
+
+describe("DiagnosticsDisplay coverage", () => {
+  test("renders verbose AgenC right-file diagnostics with relative paths and metadata", async () => {
+    process.env.AGENC_TUI_GLYPHS = "ascii";
+
+    const output = await renderToString(
+      <DiagnosticsDisplay
+        attachment={{
+          type: "diagnostics",
+          isNew: true,
+          files: [
+            {
+              uri: "_agenc_fs_right:/repo/src/problem.ts",
+              diagnostics: [
+                {
+                  severity: "Error",
+                  range: {
+                    start: { line: 3, character: 7 },
+                    end: { line: 3, character: 19 },
+                  },
+                  message: "Type mismatch",
+                  code: "TS2345",
+                  source: "tsserver",
+                },
+              ],
+            },
+          ],
+        }}
+        verbose={true}
+      />,
+      100,
+    );
+
+    expect(output).toContain("|_ src/problem.ts (agenc_fs_right):");
+    expect(output).toContain(
+      `|_   ${figures.cross} [Line 4:8] Type mismatch [TS2345] (tsserver)`,
+    );
+    expect(output).not.toContain("_agenc_fs_right:");
+  });
+});

--- a/runtime/tests/tui/components/DiagnosticsDisplay.wave200-120.coverage.test.tsx
+++ b/runtime/tests/tui/components/DiagnosticsDisplay.wave200-120.coverage.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { describe, expect, test } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import { DiagnosticsDisplay } from './DiagnosticsDisplay.js'
+
+const diagnostic = {
+  severity: 'Info' as const,
+  range: {
+    start: { line: 0, character: 0 },
+    end: { line: 0, character: 1 },
+  },
+  message: 'Unused value',
+}
+
+describe('DiagnosticsDisplay wave200-120 coverage', () => {
+  test('renders compact empty, singular, and plural diagnostic states', async () => {
+    const empty = await renderToString(
+      <DiagnosticsDisplay
+        attachment={{
+          type: 'diagnostics',
+          isNew: true,
+          files: [],
+        }}
+        verbose={false}
+      />,
+      100,
+    )
+    const singular = await renderToString(
+      <DiagnosticsDisplay
+        attachment={{
+          type: 'diagnostics',
+          isNew: true,
+          files: [
+            {
+              uri: 'file:///repo/src/single.ts',
+              diagnostics: [diagnostic],
+            },
+          ],
+        }}
+        verbose={false}
+      />,
+      100,
+    )
+    const plural = await renderToString(
+      <DiagnosticsDisplay
+        attachment={{
+          type: 'diagnostics',
+          isNew: true,
+          files: [
+            {
+              uri: 'file:///repo/src/first.ts',
+              diagnostics: [diagnostic],
+            },
+            {
+              uri: 'file:///repo/src/second.ts',
+              diagnostics: [diagnostic, diagnostic],
+            },
+          ],
+        }}
+        verbose={false}
+      />,
+      100,
+    )
+
+    expect(empty.trim()).toBe('')
+    expect(stripAnsi(singular)).toContain(
+      'Found 1 new diagnostic issue in 1 file',
+    )
+    expect(stripAnsi(plural)).toContain(
+      'Found 3 new diagnostic issues in 2 files',
+    )
+  })
+})

--- a/runtime/tests/tui/components/ExitFlow.wave200-139.coverage.test.tsx
+++ b/runtime/tests/tui/components/ExitFlow.wave200-139.coverage.test.tsx
@@ -1,0 +1,88 @@
+import type { ReactNode } from "react";
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { renderToString } from "../../utils/staticRender.js";
+
+type WorktreeExitDialogProps = {
+  readonly onCancel?: () => void;
+  readonly onDone: (message?: string) => void | Promise<void>;
+};
+
+const harness = vi.hoisted(() => ({
+  dialogProps: undefined as WorktreeExitDialogProps | undefined,
+  gracefulShutdown: vi.fn(),
+  sample: vi.fn(),
+}));
+
+vi.mock("lodash-es/sample.js", () => ({
+  default: harness.sample,
+}));
+
+vi.mock("../../utils/gracefulShutdown.js", () => ({
+  gracefulShutdown: harness.gracefulShutdown,
+}));
+
+vi.mock("./WorktreeExitDialog", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    WorktreeExitDialog: (props: WorktreeExitDialogProps): ReactNode => {
+      harness.dialogProps = props;
+      return ReactActual.createElement("ink-text", null, "worktree-exit");
+    },
+  };
+});
+
+import { ExitFlow } from "./ExitFlow.js";
+
+describe("ExitFlow coverage", () => {
+  beforeEach(() => {
+    harness.dialogProps = undefined;
+    harness.gracefulShutdown.mockReset();
+    harness.sample.mockReset();
+  });
+
+  test("renders only for worktree exits and completes with explicit or fallback messages", async () => {
+    const onCancel = vi.fn();
+    const onDone = vi.fn();
+
+    const hidden = await renderToString(
+      <ExitFlow showWorktree={false} onDone={onDone} onCancel={onCancel} />,
+      80,
+    );
+
+    expect(hidden.trim()).toBe("");
+    expect(harness.dialogProps).toBeUndefined();
+
+    const shown = await renderToString(
+      <ExitFlow showWorktree={true} onDone={onDone} onCancel={onCancel} />,
+      80,
+    );
+
+    expect(shown).toContain("worktree-exit");
+    expect(harness.dialogProps?.onCancel).toBe(onCancel);
+
+    await harness.dialogProps?.onDone("Preserved worktree");
+
+    expect(onDone).toHaveBeenLastCalledWith("Preserved worktree");
+    expect(harness.sample).not.toHaveBeenCalled();
+    expect(harness.gracefulShutdown).toHaveBeenLastCalledWith(
+      0,
+      "prompt_input_exit",
+    );
+
+    harness.sample.mockReturnValue(undefined);
+
+    await harness.dialogProps?.onDone();
+
+    expect(harness.sample).toHaveBeenCalledWith([
+      "Goodbye!",
+      "See ya!",
+      "Bye!",
+      "Catch you later!",
+    ]);
+    expect(onDone).toHaveBeenLastCalledWith("Goodbye!");
+    expect(harness.gracefulShutdown).toHaveBeenCalledTimes(2);
+  });
+});

--- a/runtime/tests/tui/components/FallbackToolUseErrorMessage.test.tsx
+++ b/runtime/tests/tui/components/FallbackToolUseErrorMessage.test.tsx
@@ -1,0 +1,140 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { describe, expect, test } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import { createRoot } from '../ink/root.js'
+import { FallbackToolUseErrorMessage } from './FallbackToolUseErrorMessage.js'
+
+async function renderError(result: unknown, verbose = false): Promise<string> {
+  return renderToString(
+    <FallbackToolUseErrorMessage result={result as never} verbose={verbose} />,
+    100,
+  )
+}
+
+function createStreams(): {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 100
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+describe('FallbackToolUseErrorMessage', () => {
+  test('renders a generic failure for non-string tool results', async () => {
+    const output = await renderError([{ type: 'text', text: 'ignored' }])
+
+    expect(output).toContain('Tool execution failed')
+  })
+
+  test('condenses validation failures and strips wrapper tags in brief mode', async () => {
+    const output = await renderError(
+      [
+        '<tool_use_error>',
+        '<error>InputValidationError: Missing required field</error>',
+        '<sandbox_violations>blocked path details</sandbox_violations>',
+        '</tool_use_error>',
+      ].join('\n'),
+    )
+
+    expect(output).toContain('Invalid tool parameters')
+    expect(output).not.toContain('InputValidationError')
+    expect(output).not.toContain('blocked path details')
+    expect(output).not.toContain('<error>')
+  })
+
+  test('truncates long errors and keeps an existing Error prefix', async () => {
+    const lines = Array.from({ length: 11 }, (_, index) =>
+      index === 0 ? 'Error: first line' : `line ${index + 1}`,
+    )
+
+    const output = await renderError(lines.join('\n'))
+
+    expect(output).toContain('Error: first line')
+    expect(output).toContain('line 10')
+    expect(output).not.toContain('line 11')
+    expect(output).toContain('+1 line')
+    expect(output).toContain('ctrl+o')
+  })
+
+  test('uses plural truncation text and preserves Cancelled prefixes', async () => {
+    const lines = Array.from({ length: 12 }, (_, index) =>
+      index === 0 ? 'Cancelled: stopped by user' : `cancel line ${index + 1}`,
+    )
+
+    const output = await renderError(lines.join('\n'))
+
+    expect(output).toContain('Cancelled: stopped by user')
+    expect(output).not.toContain('Error: Cancelled')
+    expect(output).toContain('+2 lines')
+  })
+
+  test('adds an Error prefix and shows every line in verbose mode', async () => {
+    const lines = Array.from({ length: 12 }, (_, index) =>
+      index === 0 ? 'plain failure' : `verbose line ${index + 1}`,
+    )
+
+    const output = await renderError(lines.join('\n'), true)
+
+    expect(output).toContain('Error: plain failure')
+    expect(output).toContain('verbose line 12')
+    expect(output).not.toContain('to see all')
+  })
+
+  test('reuses memoized render parts across identical rerenders', async () => {
+    const { stdin, stdout } = createStreams()
+    let output = ''
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+    const renderNode = () => (
+      <FallbackToolUseErrorMessage
+        result={'Error: cached failure'}
+        verbose={false}
+      />
+    )
+
+    try {
+      root.render(renderNode())
+      await sleep()
+      root.render(renderNode())
+      await sleep()
+
+      expect(stripAnsi(output)).toContain('Error: cached failure')
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+})

--- a/runtime/tests/tui/components/FallbackToolUseRejectedMessage.coverage.test.tsx
+++ b/runtime/tests/tui/components/FallbackToolUseRejectedMessage.coverage.test.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { renderToString } from "../../utils/staticRender.js";
+import { FallbackToolUseRejectedMessage } from "./FallbackToolUseRejectedMessage.js";
+
+const previousGlyphMode = process.env.AGENC_TUI_GLYPHS;
+
+afterEach(() => {
+  if (previousGlyphMode === undefined) {
+    delete process.env.AGENC_TUI_GLYPHS;
+  } else {
+    process.env.AGENC_TUI_GLYPHS = previousGlyphMode;
+  }
+});
+
+describe("FallbackToolUseRejectedMessage", () => {
+  test("renders the interrupted fallback inside a response gutter", async () => {
+    process.env.AGENC_TUI_GLYPHS = "ascii";
+
+    const output = await renderToString(<FallbackToolUseRejectedMessage />, 80);
+
+    expect(output).toContain("|_ Interrupted");
+    expect(output).toContain("What should AgenC do instead?");
+  });
+});

--- a/runtime/tests/tui/components/FastIcon.coverage.test.tsx
+++ b/runtime/tests/tui/components/FastIcon.coverage.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import chalk from 'chalk'
+import stripAnsi from 'strip-ansi'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { LIGHTNING_BOLT } from '../../constants/figures.js'
+import { renderToAnsiString, renderToString } from '../../utils/staticRender.js'
+import { FastIcon, getFastIconString } from './FastIcon.js'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../utils/config.js', () => ({
+  getGlobalConfig: () => ({ theme: 'dark' }),
+  saveGlobalConfig: vi.fn(),
+}))
+
+vi.mock('../../utils/systemTheme.js', () => ({
+  getSystemThemeName: () => 'dark',
+  resolveThemeSetting: () => 'dark',
+}))
+
+const originalChalkLevel = chalk.level
+
+afterEach(() => {
+  chalk.level = originalChalkLevel
+})
+
+describe('FastIcon coverage', () => {
+  test('renders active and cooldown icons with matching plain string fallback', async () => {
+    chalk.level = 3
+
+    const activeText = await renderToString(<FastIcon />, 20)
+    const cooldownText = await renderToString(<FastIcon cooldown={true} />, 20)
+
+    expect(activeText).toBe(LIGHTNING_BOLT)
+    expect(cooldownText).toBe(LIGHTNING_BOLT)
+    expect(getFastIconString(false)).toBe(LIGHTNING_BOLT)
+
+    const activeAnsi = await renderToAnsiString(<FastIcon />, {
+      columns: 20,
+      color: true,
+    })
+    const cooldownAnsi = await renderToAnsiString(<FastIcon cooldown={true} />, {
+      columns: 20,
+      color: true,
+    })
+    const activeString = getFastIconString(true, false)
+    const cooldownString = getFastIconString(true, true)
+
+    expect(stripAnsi(activeAnsi)).toBe(LIGHTNING_BOLT)
+    expect(stripAnsi(cooldownAnsi)).toBe(LIGHTNING_BOLT)
+    expect(stripAnsi(activeString)).toBe(LIGHTNING_BOLT)
+    expect(stripAnsi(cooldownString)).toBe(LIGHTNING_BOLT)
+    expect(activeAnsi).toContain('\u001B[')
+    expect(cooldownAnsi).toContain('\u001B[')
+    expect(activeString).toContain('\u001B[')
+    expect(cooldownString).toContain('\u001B[')
+    expect(cooldownAnsi).not.toBe(activeAnsi)
+    expect(cooldownString).not.toBe(activeString)
+  })
+})

--- a/runtime/tests/tui/components/FileEditToolUpdatedMessage.test.tsx
+++ b/runtime/tests/tui/components/FileEditToolUpdatedMessage.test.tsx
@@ -1,0 +1,242 @@
+import { PassThrough } from 'node:stream'
+
+import type { StructuredPatchHunk } from 'diff'
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import { createRoot } from '../ink/root.js'
+import { FileEditToolUpdatedMessage } from './FileEditToolUpdatedMessage.js'
+
+const structuredDiffMock = vi.hoisted(() => ({
+  calls: [] as Array<Record<string, unknown>>,
+}))
+
+vi.mock('../hooks/useTerminalSize', () => ({
+  useTerminalSize: () => ({ columns: 72, rows: 24 }),
+}))
+
+vi.mock('./diff/StructuredDiffList', async () => {
+  const ReactModule = await import('react')
+  return {
+    StructuredDiffList: (props: Record<string, unknown>) => {
+      structuredDiffMock.calls.push(props)
+      return ReactModule.createElement(ReactModule.Fragment)
+    },
+  }
+})
+
+const mixedHunk: StructuredPatchHunk = {
+  oldStart: 1,
+  oldLines: 2,
+  newStart: 1,
+  newLines: 3,
+  lines: [' context', '-old', '+new', '+newer'],
+}
+
+function renderUpdated(
+  overrides: Partial<React.ComponentProps<typeof FileEditToolUpdatedMessage>> = {},
+): Promise<string> {
+  return renderToString(
+    <FileEditToolUpdatedMessage
+      filePath="/repo/src/file.ts"
+      structuredPatch={[mixedHunk]}
+      firstLine="const old = true"
+      fileContent={'const old = true\n'}
+      verbose={false}
+      {...overrides}
+    />,
+    100,
+  )
+}
+
+function createStreams(): {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 100
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+describe('FileEditToolUpdatedMessage', () => {
+  beforeEach(() => {
+    structuredDiffMock.calls = []
+  })
+
+  test('renders addition/removal summary and passes diff props', async () => {
+    const output = await renderUpdated()
+
+    expect(output).toContain('Added 2 lines, removed 1 line')
+    expect(structuredDiffMock.calls).toHaveLength(1)
+    expect(structuredDiffMock.calls[0]).toMatchObject({
+      dim: false,
+      fileContent: 'const old = true\n',
+      filePath: '/repo/src/file.ts',
+      firstLine: 'const old = true',
+      hunks: [mixedHunk],
+      width: 60,
+    })
+  })
+
+  test('renders singular additions without removals', async () => {
+    const output = await renderUpdated({
+      structuredPatch: [
+        {
+          oldStart: 1,
+          oldLines: 0,
+          newStart: 1,
+          newLines: 1,
+          lines: ['+new', ' context'],
+        },
+      ],
+    })
+
+    expect(output).toContain('Added 1 line')
+    expect(output).not.toContain('removed')
+  })
+
+  test('capitalizes removal-only summaries and pluralizes removed lines', async () => {
+    const output = await renderUpdated({
+      structuredPatch: [
+        {
+          oldStart: 1,
+          oldLines: 2,
+          newStart: 1,
+          newLines: 0,
+          lines: ['-old', '-older', ' context'],
+        },
+      ],
+    })
+
+    expect(output).toContain('Removed 2 lines')
+    expect(output).not.toContain('Added')
+  })
+
+  test('uses the preview hint instead of rendering the diff in brief expanded style', async () => {
+    const output = await renderUpdated({ previewHint: '/plan to preview' })
+
+    expect(output).toContain('/plan to preview')
+    expect(structuredDiffMock.calls).toHaveLength(0)
+  })
+
+  test('condensed brief mode returns only the summary when there is no preview hint', async () => {
+    const output = await renderUpdated({ style: 'condensed' })
+
+    expect(output).toContain('Added 2 lines, removed 1 line')
+    expect(structuredDiffMock.calls).toHaveLength(0)
+  })
+
+  test('verbose mode ignores preview hints and renders empty diffs', async () => {
+    const output = await renderUpdated({
+      structuredPatch: [],
+      fileContent: undefined,
+      firstLine: null,
+      previewHint: '/plan to preview',
+      verbose: true,
+    })
+
+    expect(output).not.toContain('/plan to preview')
+    expect(structuredDiffMock.calls).toHaveLength(1)
+    expect(structuredDiffMock.calls[0]).toMatchObject({
+      fileContent: undefined,
+      firstLine: null,
+      hunks: [],
+    })
+  })
+
+  test('reuses memoized render parts across identical rerenders', async () => {
+    const { stdin, stdout } = createStreams()
+    const structuredPatch = [mixedHunk]
+    let output = ''
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+    const renderNode = () => (
+        <FileEditToolUpdatedMessage
+          filePath="/repo/src/file.ts"
+          structuredPatch={structuredPatch}
+          firstLine="const old = true"
+          fileContent={'const old = true\n'}
+          verbose={false}
+      />
+    )
+
+    try {
+      root.render(renderNode())
+      await sleep()
+      root.render(renderNode())
+      await sleep()
+
+      expect(stripAnsi(output)).toContain('Added 2 lines, removed 1 line')
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+
+  test('reuses memoized preview hints across identical rerenders', async () => {
+    const { stdin, stdout } = createStreams()
+    let output = ''
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+    const renderNode = () => (
+      <FileEditToolUpdatedMessage
+        filePath="/repo/src/file.ts"
+        structuredPatch={[mixedHunk]}
+        firstLine="const old = true"
+        fileContent={'const old = true\n'}
+        previewHint="/plan to preview"
+        verbose={false}
+      />
+    )
+
+    try {
+      root.render(renderNode())
+      await sleep()
+      root.render(renderNode())
+      await sleep()
+
+      expect(stripAnsi(output)).toContain('/plan to preview')
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+})

--- a/runtime/tests/tui/components/FileEditToolUseRejectedMessage.wave200-147.coverage.test.tsx
+++ b/runtime/tests/tui/components/FileEditToolUseRejectedMessage.wave200-147.coverage.test.tsx
@@ -1,0 +1,196 @@
+import { PassThrough } from 'node:stream'
+
+import type { StructuredPatchHunk } from 'diff'
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { describe, expect, test, vi } from 'vitest'
+
+const childMocks = vi.hoisted(() => ({
+  diffs: [] as Array<Record<string, unknown>>,
+  highlighted: [] as Array<Record<string, unknown>>,
+}))
+
+vi.mock('../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: 72, rows: 24 }),
+}))
+
+vi.mock('../../utils/cwd.js', () => ({
+  getCwd: () => '/repo',
+}))
+
+vi.mock('./markdown/HighlightedCode.js', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../ink.js')
+
+  return {
+    HighlightedCode: (props: Record<string, unknown>) => {
+      childMocks.highlighted.push(props)
+      return ReactModule.createElement(
+        Text,
+        null,
+        `code:${props.filePath}:${props.width}:${props.code}`,
+      )
+    },
+  }
+})
+
+vi.mock('./diff/StructuredDiffList.js', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../ink.js')
+
+  return {
+    StructuredDiffList: (props: Record<string, unknown>) => {
+      childMocks.diffs.push(props)
+      return ReactModule.createElement(
+        Text,
+        null,
+        `diff:${props.filePath}:${props.firstLine ?? ''}:${props.width}`,
+      )
+    },
+  }
+})
+
+import { createRoot } from '../ink/root.js'
+import { FileEditToolUseRejectedMessage } from './FileEditToolUseRejectedMessage.js'
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 72
+  return { stdin, stdout }
+}
+
+async function waitForOutput(
+  readOutput: () => string,
+  expected: string,
+): Promise<void> {
+  const deadline = Date.now() + 1000
+  while (Date.now() < deadline) {
+    if (readOutput().includes(expected)) return
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+  throw new Error(`Timed out waiting for rendered output: ${expected}`)
+}
+
+describe('FileEditToolUseRejectedMessage wave200-147 coverage', () => {
+  test('reuses memoized render branches across identical rerenders', async () => {
+    childMocks.diffs = []
+    childMocks.highlighted = []
+
+    const patch: StructuredPatchHunk[] = [
+      {
+        oldStart: 1,
+        oldLines: 1,
+        newStart: 1,
+        newLines: 1,
+        lines: ['-const old = true', '+const next = true'],
+      },
+    ]
+    const writeContent = Array.from(
+      { length: 12 },
+      (_, index) => `line ${index + 1}`,
+    ).join('\n')
+    const { stdin, stdout } = createStreams()
+    let output = ''
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+    const readOutput = () => stripAnsi(output)
+
+    try {
+      const renderTwice = async (node: React.ReactNode, expected: string) => {
+        root.render(node)
+        await waitForOutput(readOutput, expected)
+        root.render(node)
+        await waitForOutput(readOutput, expected)
+      }
+
+      await renderTwice(
+        <FileEditToolUseRejectedMessage
+          file_path="/repo/src/condensed.ts"
+          firstLine={null}
+          operation="update"
+          style="condensed"
+          verbose={false}
+        />,
+        'src/condensed.ts',
+      )
+      await renderTwice(
+        <FileEditToolUseRejectedMessage
+          content={writeContent}
+          file_path="/repo/src/new.ts"
+          firstLine={null}
+          operation="write"
+          verbose={false}
+        />,
+        '+2 lines',
+      )
+      await renderTwice(
+        <FileEditToolUseRejectedMessage
+          file_path="/repo/src/no-patch.ts"
+          firstLine={null}
+          operation="update"
+          patch={[]}
+          verbose={false}
+        />,
+        'src/no-patch.ts',
+      )
+      await renderTwice(
+        <FileEditToolUseRejectedMessage
+          fileContent="const old = true"
+          file_path="/repo/src/changed.ts"
+          firstLine="const old = true"
+          operation="update"
+          patch={patch}
+          verbose={false}
+        />,
+        'diff:/repo/src/changed.ts:const old = true:60',
+      )
+
+      expect(readOutput()).toContain('User rejected write to')
+      expect(readOutput()).toContain('code:/repo/src/new.ts:60:line 1')
+      expect(readOutput()).toContain('line 10')
+      expect(readOutput()).not.toContain('line 12')
+      expect(childMocks.highlighted[0]).toMatchObject({
+        dim: true,
+        filePath: '/repo/src/new.ts',
+        width: 60,
+      })
+      expect(childMocks.diffs[0]).toMatchObject({
+        dim: true,
+        fileContent: 'const old = true',
+        filePath: '/repo/src/changed.ts',
+        firstLine: 'const old = true',
+        hunks: patch,
+        width: 60,
+      })
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+  })
+})

--- a/runtime/tests/tui/components/FilePathLink.coverage.test.tsx
+++ b/runtime/tests/tui/components/FilePathLink.coverage.test.tsx
@@ -1,0 +1,53 @@
+import { pathToFileURL } from "node:url";
+
+import React from "react";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { renderToAnsiString } from "../../utils/staticRender.js";
+import { Box } from "../ink.js";
+import { FilePathLink } from "./FilePathLink.js";
+
+const previousForceHyperlink = process.env.FORCE_HYPERLINK;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function expectOsc8Link(output: string, url: string, label: string): void {
+  const pattern = [
+    "\\x1B\\]8;[^;\\x07]*;",
+    escapeRegExp(url),
+    "\\x07",
+    escapeRegExp(label),
+    "\\x1B\\]8;;\\x07",
+  ].join("");
+
+  expect(output).toMatch(new RegExp(pattern));
+}
+
+afterEach(() => {
+  if (previousForceHyperlink === undefined) {
+    delete process.env.FORCE_HYPERLINK;
+  } else {
+    process.env.FORCE_HYPERLINK = previousForceHyperlink;
+  }
+});
+
+describe("FilePathLink coverage", () => {
+  test("renders file paths as OSC 8 links with default and custom labels", async () => {
+    process.env.FORCE_HYPERLINK = "1";
+
+    const defaultPath = "/tmp/agenc workspace/report.md";
+    const customPath = "/tmp/agenc workspace/src/FilePathLink.tsx";
+    const output = await renderToAnsiString(
+      <Box flexDirection="column">
+        <FilePathLink filePath={defaultPath} />
+        <FilePathLink filePath={customPath}>Open source</FilePathLink>
+      </Box>,
+      { columns: 120 },
+    );
+
+    expectOsc8Link(output, pathToFileURL(defaultPath).href, defaultPath);
+    expectOsc8Link(output, pathToFileURL(customPath).href, "Open source");
+  });
+});

--- a/runtime/tests/tui/components/FullscreenLayout.coverage2.test.tsx
+++ b/runtime/tests/tui/components/FullscreenLayout.coverage2.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  computeUnseenDivider,
+  countUnseenAssistantTurns,
+} from "./FullscreenLayout.js";
+
+function assistantMessage(
+  uuid: string,
+  content: readonly Record<string, unknown>[],
+): Record<string, unknown> {
+  return {
+    uuid,
+    type: "assistant",
+    message: {
+      content,
+    },
+  };
+}
+
+describe("FullscreenLayout unseen divider coverage", () => {
+  test("skips invisible divider anchors while counting only visible assistant turns", () => {
+    const messages = [
+      {
+        uuid: "progress-1",
+        type: "progress",
+      },
+      {
+        uuid: "attachment-plan-mode",
+        type: "attachment",
+        attachment: {
+          type: "plan_mode",
+        },
+      },
+      assistantMessage("assistant-tool-only", [
+        {
+          type: "tool_use",
+          id: "toolu_1",
+          name: "Read",
+          input: {},
+        },
+      ]),
+      assistantMessage("assistant-empty-text", [
+        {
+          type: "text",
+          text: "   ",
+        },
+      ]),
+      assistantMessage("assistant-visible-1", [
+        {
+          type: "text",
+          text: "First visible reply",
+        },
+      ]),
+      assistantMessage("assistant-visible-continuation", [
+        {
+          type: "text",
+          text: "same assistant turn",
+        },
+      ]),
+      {
+        uuid: "user-tool-result",
+        type: "user",
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_1",
+              content: "ok",
+            },
+          ],
+        },
+      },
+      assistantMessage("assistant-visible-2", [
+        {
+          type: "text",
+          text: "Second visible reply",
+        },
+      ]),
+    ];
+
+    expect(computeUnseenDivider(messages, null)).toBeUndefined();
+    expect(computeUnseenDivider(messages.slice(0, 2), 0)).toBeUndefined();
+    expect(computeUnseenDivider(messages.slice(0, 3), 0)).toEqual({
+      firstUnseenUuid: "assistant-tool-only",
+      count: 1,
+    });
+    expect(computeUnseenDivider(messages, 0)).toEqual({
+      firstUnseenUuid: "assistant-tool-only",
+      count: 2,
+    });
+    expect(countUnseenAssistantTurns(messages, 0)).toBe(2);
+  });
+});

--- a/runtime/tests/tui/components/FullscreenLayout.render-branches.test.tsx
+++ b/runtime/tests/tui/components/FullscreenLayout.render-branches.test.tsx
@@ -1,0 +1,382 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { describe, expect, test } from "vitest";
+
+import {
+  calculateFullscreenLayoutBudget,
+  FullscreenLayout,
+  ScrollChromeContext,
+} from "./FullscreenLayout.js";
+import { Text } from "../ink.js";
+import { createRoot } from "../ink/root.js";
+import {
+  useModalOrTerminalSize,
+  useModalScrollRef,
+} from "../context/modalContext.js";
+import { renderToString } from "../../utils/staticRender.js";
+
+const SYNC_START = "\x1B[?2026h";
+const SYNC_END = "\x1B[?2026l";
+
+type Viewport = {
+  readonly columns: number;
+  readonly rows: number;
+};
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+function restoreEnv(name: string, previous: string | undefined): void {
+  if (previous === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = previous;
+  }
+}
+
+async function withFullscreenEnv<T>(
+  value: "0" | "1",
+  fn: () => Promise<T>,
+): Promise<T> {
+  const previous = process.env.AGENC_NO_FLICKER;
+  process.env.AGENC_NO_FLICKER = value;
+  try {
+    return await fn();
+  } finally {
+    restoreEnv("AGENC_NO_FLICKER", previous);
+  }
+}
+
+function extractLastFrame(output: string): string {
+  let lastFrame: string | null = null;
+  let cursor = 0;
+
+  while (cursor < output.length) {
+    const start = output.indexOf(SYNC_START, cursor);
+    if (start === -1) break;
+
+    const contentStart = start + SYNC_START.length;
+    const end = output.indexOf(SYNC_END, contentStart);
+    if (end === -1) break;
+
+    const frame = output.slice(contentStart, end);
+    if (frame.trim().length > 0) {
+      lastFrame = frame;
+    }
+    cursor = end + SYNC_END.length;
+  }
+
+  return lastFrame ?? output;
+}
+
+function createTestStreams(viewport: Viewport): {
+  readonly stdin: TestStdin;
+  readonly stdout: PassThrough;
+  readonly getOutput: () => string;
+} {
+  let output = "";
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number; rows: number }).columns =
+    viewport.columns;
+  (stdout as unknown as { columns: number; rows: number }).rows = viewport.rows;
+  stdout.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+
+  return {
+    stdin,
+    stdout,
+    getOutput: () => output,
+  };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function renderFullscreenLayout(
+  node: React.ReactNode,
+  viewport: Viewport,
+): Promise<string> {
+  return withFullscreenEnv("1", () => renderToString(node, viewport));
+}
+
+async function renderFullscreenLayoutLatestFrame(
+  node: React.ReactNode,
+  viewport: Viewport,
+): Promise<string> {
+  return withFullscreenEnv("1", async () => {
+    const { stdin, stdout, getOutput } = createTestStreams(viewport);
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    root.render(node);
+    await sleep();
+    const output = stripAnsi(extractLastFrame(getOutput()));
+    root.unmount();
+    stdin.end();
+    stdout.end();
+    await sleep();
+    return output;
+  });
+}
+
+function makeVisiblePillRefs(): {
+  readonly scrollRef: React.RefObject<unknown>;
+  readonly dividerYRef: React.RefObject<number | null>;
+} {
+  return {
+    scrollRef: {
+      current: {
+        getPendingDelta: () => 0,
+        getScrollTop: () => 0,
+        getViewportHeight: () => 5,
+        subscribe: () => () => {},
+      },
+    } as React.RefObject<unknown>,
+    dividerYRef: { current: 20 },
+  };
+}
+
+function ModalSizeProbe(): React.ReactNode {
+  const size = useModalOrTerminalSize({ rows: 99, columns: 88 });
+  const scrollRef = useModalScrollRef();
+
+  return (
+    <Text>
+      modal context {size.rows}x{size.columns}{" "}
+      {scrollRef === null ? "without-ref" : "with-ref"}
+    </Text>
+  );
+}
+
+function StickyPromptWriter({
+  text,
+}: {
+  readonly text: string;
+}): React.ReactNode {
+  const { setStickyPrompt } = React.useContext(ScrollChromeContext);
+
+  React.useLayoutEffect(() => {
+    setStickyPrompt({ text, scrollTo: () => {} } as never);
+    return () => setStickyPrompt(null);
+  }, [setStickyPrompt, text]);
+
+  return <Text>sticky scroll content</Text>;
+}
+
+describe("FullscreenLayout render branches", () => {
+  test("normalizes non-finite and fractional row budgets before chrome gating", () => {
+    expect(calculateFullscreenLayoutBudget(Number.POSITIVE_INFINITY)).toEqual({
+      showTopChrome: false,
+      showScrollable: false,
+      showBottomChrome: false,
+      bottomMaxHeight: 1,
+    });
+    expect(calculateFullscreenLayoutBudget(-4)).toEqual({
+      showTopChrome: false,
+      showScrollable: false,
+      showBottomChrome: false,
+      bottomMaxHeight: 1,
+    });
+    expect(calculateFullscreenLayoutBudget(7.9)).toEqual({
+      showTopChrome: false,
+      showScrollable: true,
+      showBottomChrome: true,
+      bottomMaxHeight: 3,
+    });
+  });
+
+  test("renders content sequentially when fullscreen is disabled", async () => {
+    const output = await withFullscreenEnv("0", () =>
+      renderToString(
+        <FullscreenLayout
+          scrollable={<Text>sequential scrollable</Text>}
+          bottom={<Text>sequential bottom</Text>}
+          overlay={<Text>sequential overlay</Text>}
+          modal={<Text>sequential modal</Text>}
+        />,
+        { columns: 80, rows: 12 },
+      ),
+    );
+
+    expect(output).toContain("sequential scrollable");
+    expect(output).toContain("sequential bottom");
+    expect(output).toContain("sequential overlay");
+    expect(output).toContain("sequential modal");
+    expect(output.indexOf("sequential scrollable")).toBeLessThan(
+      output.indexOf("sequential bottom"),
+    );
+    expect(output.indexOf("sequential bottom")).toBeLessThan(
+      output.indexOf("sequential overlay"),
+    );
+    expect(output.indexOf("sequential overlay")).toBeLessThan(
+      output.indexOf("sequential modal"),
+    );
+    expect(output).not.toContain("agenc · orchestrator");
+  });
+
+  test.each([
+    {
+      rows: 1,
+      includes: ["budget bottom"],
+      excludes: ["budget scrollable", "agenc · orchestrator", "MODEL", "CTX"],
+    },
+    {
+      rows: 4,
+      includes: ["budget scrollable", "budget bottom"],
+      excludes: ["agenc · orchestrator", "MODEL", "CTX"],
+    },
+    {
+      rows: 5,
+      includes: ["budget scrollable", "budget bottom", "MODEL", "CTX"],
+      excludes: ["agenc · orchestrator"],
+    },
+  ])(
+    "applies fullscreen row-budget render gates at $rows rows",
+    async ({ rows, includes, excludes }) => {
+      const output = await renderFullscreenLayout(
+        <FullscreenLayout
+          scrollable={<Text>budget scrollable</Text>}
+          bottom={<Text>budget bottom</Text>}
+        />,
+        { columns: 80, rows },
+      );
+
+      for (const marker of includes) {
+        expect(output).toContain(marker);
+      }
+      for (const marker of excludes) {
+        expect(output).not.toContain(marker);
+      }
+    },
+  );
+
+  test("provides modal viewport sizing and scroll ref through modal context", async () => {
+    const modalScrollRef = { current: null };
+    const output = await renderFullscreenLayout(
+      <FullscreenLayout
+        scrollable={<Text>modal scrollable</Text>}
+        bottom={<Text>modal bottom</Text>}
+        modal={<ModalSizeProbe />}
+        modalScrollRef={modalScrollRef}
+      />,
+      { columns: 40, rows: 10 },
+    );
+
+    expect(output).toContain("modal context 7x36 with-ref");
+  });
+
+  test("renders bottomFloat inside the fullscreen scroll region", async () => {
+    const output = await renderFullscreenLayout(
+      <FullscreenLayout
+        scrollable={<Text>float scrollable</Text>}
+        bottom={<Text>float bottom</Text>}
+        bottomFloat={<Text>floating branch marker</Text>}
+      />,
+      { columns: 90, rows: 12 },
+    );
+
+    expect(output).toContain("float scrollable");
+    expect(output).toContain("floating branch marker");
+  });
+
+  test.each([
+    [0, "Jump to bottom"],
+    [2, "2 new messages"],
+  ])("renders the new-message pill label for count %i", async (count, label) => {
+    const { scrollRef, dividerYRef } = makeVisiblePillRefs();
+    const output = await renderFullscreenLayout(
+      <FullscreenLayout
+        scrollable={<Text>pill scrollable</Text>}
+        bottom={<Text>pill bottom</Text>}
+        scrollRef={scrollRef}
+        dividerYRef={dividerYRef}
+        newMessageCount={count}
+      />,
+      { columns: 90, rows: 12 },
+    );
+
+    expect(output).toContain(label);
+  });
+
+  test.each([
+    {
+      name: "explicit hide",
+      props: {
+        hidePill: true,
+      },
+    },
+    {
+      name: "active overlay",
+      props: {
+        overlay: <Text>pill suppressing overlay</Text>,
+      },
+    },
+  ])("suppresses the new-message pill for $name", async ({ props }) => {
+    const { scrollRef, dividerYRef } = makeVisiblePillRefs();
+    const output = await renderFullscreenLayout(
+      <FullscreenLayout
+        scrollable={<Text>suppressed pill scrollable</Text>}
+        bottom={<Text>suppressed pill bottom</Text>}
+        scrollRef={scrollRef}
+        dividerYRef={dividerYRef}
+        newMessageCount={3}
+        {...props}
+      />,
+      { columns: 90, rows: 12 },
+    );
+
+    expect(output).not.toContain("new messages");
+    if (props.overlay) {
+      expect(output).toContain("pill suppressing overlay");
+    }
+  });
+
+  test("renders sticky prompt chrome from ScrollChromeContext unless hidden", async () => {
+    const visible = await renderFullscreenLayoutLatestFrame(
+      <FullscreenLayout
+        scrollable={<StickyPromptWriter text="sticky prompt marker" />}
+        bottom={<Text>sticky bottom</Text>}
+      />,
+      { columns: 90, rows: 12 },
+    );
+    const hidden = await renderFullscreenLayoutLatestFrame(
+      <FullscreenLayout
+        scrollable={<StickyPromptWriter text="hidden sticky prompt marker" />}
+        bottom={<Text>hidden sticky bottom</Text>}
+        hideSticky={true}
+      />,
+      { columns: 90, rows: 12 },
+    );
+    const overlaySuppressed = await renderFullscreenLayoutLatestFrame(
+      <FullscreenLayout
+        scrollable={<StickyPromptWriter text="overlay sticky prompt marker" />}
+        bottom={<Text>overlay sticky bottom</Text>}
+        overlay={<Text>sticky suppressing overlay</Text>}
+      />,
+      { columns: 90, rows: 12 },
+    );
+
+    expect(visible).toContain("sticky prompt marker");
+    expect(hidden).not.toContain("hidden sticky prompt marker");
+    expect(hidden).toContain("sticky scroll content");
+    expect(overlaySuppressed).not.toContain("overlay sticky prompt marker");
+    expect(overlaySuppressed).toContain("sticky suppressing overlay");
+  });
+});

--- a/runtime/tests/tui/components/FullscreenLayout.wave200-018.coverage.test.tsx
+++ b/runtime/tests/tui/components/FullscreenLayout.wave200-018.coverage.test.tsx
@@ -1,0 +1,142 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../ink/root.js'
+import type { ScrollBoxHandle } from '../ink/components/ScrollBox.js'
+import { useUnseenDivider } from './FullscreenLayout.js'
+
+type TestScrollHandle = ScrollBoxHandle & {
+  setPendingDelta: (value: number) => void
+  setScrollHeight: (value: number) => void
+  setScrollTop: (value: number) => void
+  setViewportHeight: (value: number) => void
+}
+
+function createScrollHandle(): TestScrollHandle {
+  let pendingDelta = 0
+  let scrollHeight = 30
+  let scrollTop = 20
+  let viewportHeight = 10
+
+  return {
+    getPendingDelta: vi.fn(() => pendingDelta),
+    getScrollHeight: vi.fn(() => scrollHeight),
+    getScrollTop: vi.fn(() => scrollTop),
+    getViewportHeight: vi.fn(() => viewportHeight),
+    scrollToBottom: vi.fn(),
+    setPendingDelta: (value: number) => {
+      pendingDelta = value
+    },
+    setScrollHeight: (value: number) => {
+      scrollHeight = value
+    },
+    setScrollTop: (value: number) => {
+      scrollTop = value
+    },
+    setViewportHeight: (value: number) => {
+      viewportHeight = value
+    },
+  } as unknown as TestScrollHandle
+}
+
+function createStreams(): {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  return { stdin, stdout }
+}
+
+async function sleep(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 25))
+}
+
+describe('useUnseenDivider coverage', () => {
+  test('snapshots the first scroll-away baseline, shifts it, jumps, and clears stale dividers', async () => {
+    let messageCount = 3
+    let latest: ReturnType<typeof useUnseenDivider> | undefined
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    function Harness(): null {
+      latest = useUnseenDivider(messageCount)
+      return null
+    }
+
+    async function render(nextCount = messageCount): Promise<ReturnType<typeof useUnseenDivider>> {
+      messageCount = nextCount
+      root.render(<Harness />)
+      await sleep()
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    }
+
+    try {
+      const handle = createScrollHandle()
+
+      let state = await render()
+      state.onScrollAway(handle)
+      await sleep()
+      expect(state.dividerYRef.current).toBeNull()
+      expect((await render()).dividerIndex).toBeNull()
+
+      handle.setScrollTop(5)
+      state.onScrollAway(handle)
+      await sleep()
+      state = await render()
+      expect(state.dividerIndex).toBe(3)
+      expect(state.dividerYRef.current).toBe(30)
+
+      handle.setScrollHeight(50)
+      state.onScrollAway(handle)
+      await sleep()
+      state = await render(5)
+      expect(state.dividerIndex).toBe(3)
+      expect(state.dividerYRef.current).toBe(30)
+
+      state.shiftDivider(2, 7)
+      await sleep()
+      state = await render()
+      expect(state.dividerIndex).toBe(5)
+      expect(state.dividerYRef.current).toBe(37)
+
+      state.jumpToNew(null)
+      expect(handle.scrollToBottom).not.toHaveBeenCalled()
+      state.jumpToNew(handle)
+      expect(handle.scrollToBottom).toHaveBeenCalledTimes(1)
+
+      state = await render(4)
+      expect(state.dividerIndex).toBeNull()
+      expect(state.dividerYRef.current).toBeNull()
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+})

--- a/runtime/tests/tui/components/GlobalSearchDialog.render.test.tsx
+++ b/runtime/tests/tui/components/GlobalSearchDialog.render.test.tsx
@@ -1,0 +1,387 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type SearchMatch = {
+  file: string
+  line: number
+  text: string
+}
+
+type PickerAction = {
+  action: string
+  handler: (item: SearchMatch) => void
+}
+
+type CapturedPickerProps = {
+  title: string
+  placeholder?: string
+  items: readonly SearchMatch[]
+  visibleCount: number
+  previewPosition: 'bottom' | 'right'
+  onQueryChange: (query: string) => void
+  onFocus?: (item: SearchMatch | undefined) => void
+  onSelect: (item: SearchMatch) => void
+  onTab?: PickerAction
+  onShiftTab?: PickerAction
+  onCancel: () => void
+  emptyMessage?: string | ((query: string) => string)
+  matchLabel?: string
+  selectAction?: string
+  renderItem: (item: SearchMatch, isFocused: boolean) => React.ReactNode
+  renderPreview?: (item: SearchMatch) => React.ReactNode
+}
+
+const harness = vi.hoisted(() => ({
+  cwd: '/workspace/project',
+  logEvent: vi.fn(),
+  openFileInExternalEditor: vi.fn(),
+  pickerProps: undefined as CapturedPickerProps | undefined,
+  readFileInRange: vi.fn(),
+  registerOverlay: vi.fn(),
+  ripGrepStream: vi.fn(),
+  terminal: {
+    columns: 100,
+    rows: 30,
+  },
+}))
+
+vi.mock('../context/overlayContext', () => ({
+  useRegisterOverlay: harness.registerOverlay,
+}))
+
+vi.mock('../hooks/useTerminalSize', () => ({
+  useTerminalSize: () => harness.terminal,
+}))
+
+vi.mock('../../services/analytics/index', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../../utils/cwd', () => ({
+  getCwd: () => harness.cwd,
+}))
+
+vi.mock('../../utils/editor', () => ({
+  openFileInExternalEditor: harness.openFileInExternalEditor,
+}))
+
+vi.mock('../../utils/readFileInRange', () => ({
+  readFileInRange: harness.readFileInRange,
+}))
+
+vi.mock('../../utils/ripgrep', () => ({
+  ripGrepStream: harness.ripGrepStream,
+}))
+
+vi.mock('./design-system/FuzzyPicker', () => ({
+  FuzzyPicker: (props: CapturedPickerProps) => {
+    harness.pickerProps = props
+    return null
+  },
+}))
+
+import { createRoot } from '../ink/root.js'
+import { renderToString } from '../../utils/staticRender.js'
+import { GlobalSearchDialog } from './GlobalSearchDialog.js'
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function resetHarness() {
+  harness.terminal.columns = 100
+  harness.terminal.rows = 30
+  harness.pickerProps = undefined
+  harness.registerOverlay.mockClear()
+  harness.logEvent.mockClear()
+  harness.openFileInExternalEditor.mockReset()
+  harness.openFileInExternalEditor.mockReturnValue(true)
+  harness.readFileInRange.mockReset()
+  harness.readFileInRange.mockResolvedValue({ content: '' })
+  harness.ripGrepStream.mockReset()
+  harness.ripGrepStream.mockResolvedValue(undefined)
+}
+
+function pickerProps(): CapturedPickerProps {
+  const props = harness.pickerProps
+  if (!props) throw new Error('Global search picker props were not captured')
+  return props
+}
+
+function emptyMessage(props: CapturedPickerProps, query: string): string {
+  const message = props.emptyMessage
+  return typeof message === 'function' ? message(query) : message ?? ''
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await sleep(10)
+  }
+  throw new Error(message)
+}
+
+async function waitForRenderedText(
+  node: () => React.ReactNode,
+  predicate: (output: string) => boolean,
+  message: string,
+): Promise<string> {
+  const startedAt = Date.now()
+  let lastOutput = ''
+  while (Date.now() - startedAt < 1000) {
+    lastOutput = await renderToString(node(), 120)
+    if (predicate(lastOutput)) return lastOutput
+    await sleep(10)
+  }
+  throw new Error(`${message}\nLast output:\n${lastOutput}`)
+}
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = harness.terminal.columns
+  ;(stdout as unknown as { rows: number }).rows = harness.terminal.rows
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function renderDialog() {
+  const onDone = vi.fn()
+  const onInsert = vi.fn()
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  root.render(<GlobalSearchDialog onDone={onDone} onInsert={onInsert} />)
+  await waitFor(() => harness.pickerProps !== undefined, 'GlobalSearchDialog did not render')
+
+  return {
+    onDone,
+    onInsert,
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep(25)
+    },
+  }
+}
+
+async function searchFor(query: string, lines: readonly string[]) {
+  harness.ripGrepStream.mockImplementation(
+    async (
+      args: string[],
+      cwd: string,
+      signal: AbortSignal,
+      onLines: (chunk: readonly string[]) => void,
+    ) => {
+      expect(args).toEqual([
+        '-n',
+        '--no-heading',
+        '-i',
+        '-m',
+        '10',
+        '-F',
+        '-e',
+        query,
+      ])
+      expect(cwd).toBe(harness.cwd)
+      expect(signal.aborted).toBe(false)
+      onLines(lines)
+    },
+  )
+
+  pickerProps().onQueryChange(query)
+  await waitFor(
+    () => emptyMessage(pickerProps(), query) === 'Searching...',
+    'Global search did not enter searching state',
+  )
+  await waitFor(
+    () => harness.ripGrepStream.mock.calls.length === 1,
+    'Global search did not invoke ripgrep',
+  )
+}
+
+describe('GlobalSearchDialog render and interactions', () => {
+  beforeEach(() => {
+    resetHarness()
+  })
+
+  it('renders the initial picker state and cancel wiring', async () => {
+    const rendered = await renderDialog()
+
+    try {
+      const props = pickerProps()
+
+      expect(harness.registerOverlay).toHaveBeenCalledWith('global-search')
+      expect(props.title).toBe('Global Search')
+      expect(props.placeholder).toBe('Type to search...')
+      expect(props.items).toEqual([])
+      expect(props.visibleCount).toBe(12)
+      expect(props.previewPosition).toBe('bottom')
+      expect(props.matchLabel).toBe(' ')
+      expect(props.selectAction).toBe('open in editor')
+      expect(props.onTab?.action).toBe('mention')
+      expect(props.onShiftTab?.action).toBe('insert path')
+      expect(emptyMessage(props, '')).toBe('Type to search...')
+
+      props.onCancel()
+      expect(rendered.onDone).toHaveBeenCalledTimes(1)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  it('streams query results, renders matches, and loads focused preview content', async () => {
+    const rendered = await renderDialog()
+
+    try {
+      harness.readFileInRange.mockResolvedValue({
+        content: 'before\nNeedle alpha\ncontext',
+      })
+
+      await searchFor('needle', [
+        '/workspace/project/src/app.tsx:12:Needle alpha',
+        '/tmp/outside.ts:3:needle beta',
+        'not a ripgrep match',
+      ])
+
+      await waitFor(
+        () => pickerProps().items.length === 2 && pickerProps().matchLabel === '2 matches',
+        'Global search results did not render',
+      )
+
+      const props = pickerProps()
+      const first = props.items[0]
+      expect(first).toEqual({
+        file: 'src/app.tsx',
+        line: 12,
+        text: 'Needle alpha',
+      })
+      expect(props.items[1]).toEqual({
+        file: '/tmp/outside.ts',
+        line: 3,
+        text: 'needle beta',
+      })
+
+      const itemOutput = await renderToString(props.renderItem(first, true), 120)
+      expect(itemOutput).toContain('src/app.tsx:12')
+      expect(itemOutput).toContain('Needle alpha')
+
+      props.onFocus?.(first)
+      const loadingOutput = await renderToString(props.renderPreview?.(first), 120)
+      expect(loadingOutput).toContain('Loading...')
+
+      await waitFor(
+        () => harness.readFileInRange.mock.calls.length === 1,
+        'Global search did not request preview content',
+      )
+      expect(harness.readFileInRange).toHaveBeenCalledWith(
+        '/workspace/project/src/app.tsx',
+        7,
+        9,
+        undefined,
+        expect.any(AbortSignal),
+      )
+
+      const previewOutput = await waitForRenderedText(
+        () => pickerProps().renderPreview?.(first),
+        output => output.includes('Needle alpha'),
+        'Global search preview content did not render',
+      )
+      expect(previewOutput).toContain('src/app.tsx:12')
+      expect(previewOutput).toContain('before')
+      expect(previewOutput).toContain('context')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  it('shows no-match state after a completed empty search', async () => {
+    const rendered = await renderDialog()
+
+    try {
+      await searchFor('absent', [])
+
+      await waitFor(
+        () =>
+          pickerProps().items.length === 0 &&
+          emptyMessage(pickerProps(), 'absent') === 'No matches',
+        'Global search did not render the no-match state',
+      )
+      expect(pickerProps().matchLabel).toBe(' ')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  it('opens and inserts the focused match through picker actions', async () => {
+    const rendered = await renderDialog()
+
+    try {
+      await searchFor('needle', ['/workspace/project/src/app.tsx:12:Needle alpha'])
+      await waitFor(
+        () => pickerProps().items.length === 1 && pickerProps().matchLabel === '1 matches',
+        'Global search result did not render for action test',
+      )
+
+      const match = pickerProps().items[0]
+
+      pickerProps().onSelect(match)
+      expect(harness.openFileInExternalEditor).toHaveBeenCalledWith(
+        '/workspace/project/src/app.tsx',
+        12,
+      )
+      expect(harness.logEvent).toHaveBeenCalledWith('agenc_global_search_select', {
+        result_count: 1,
+        opened_editor: true,
+      })
+
+      pickerProps().onTab?.handler(match)
+      expect(rendered.onInsert).toHaveBeenCalledWith('@src/app.tsx#L12 ')
+      expect(harness.logEvent).toHaveBeenCalledWith('agenc_global_search_insert', {
+        result_count: 1,
+        mention: true,
+      })
+
+      pickerProps().onShiftTab?.handler(match)
+      expect(rendered.onInsert).toHaveBeenCalledWith('src/app.tsx:12 ')
+      expect(harness.logEvent).toHaveBeenCalledWith('agenc_global_search_insert', {
+        result_count: 1,
+        mention: false,
+      })
+      expect(rendered.onDone).toHaveBeenCalledTimes(3)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/components/GlobalSearchDialog.wave200-129.coverage.test.tsx
+++ b/runtime/tests/tui/components/GlobalSearchDialog.wave200-129.coverage.test.tsx
@@ -1,0 +1,292 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type SearchMatch = {
+  file: string
+  line: number
+  text: string
+}
+
+type PickerAction = {
+  action: string
+  handler: (item: SearchMatch) => void
+}
+
+type CapturedPickerProps = {
+  items: readonly SearchMatch[]
+  visibleCount: number
+  previewPosition: 'bottom' | 'right'
+  onQueryChange: (query: string) => void
+  onFocus?: (item: SearchMatch | undefined) => void
+  onSelect: (item: SearchMatch) => void
+  onTab?: PickerAction
+  onShiftTab?: PickerAction
+  onCancel: () => void
+  emptyMessage?: string | ((query: string) => string)
+  matchLabel?: string
+  renderItem: (item: SearchMatch, isFocused: boolean) => React.ReactNode
+  renderPreview?: (item: SearchMatch) => React.ReactNode
+}
+
+const harness = vi.hoisted(() => ({
+  cwd: '/workspace/project',
+  logEvent: vi.fn(),
+  openFileInExternalEditor: vi.fn(),
+  pickerProps: undefined as CapturedPickerProps | undefined,
+  readFileInRange: vi.fn(),
+  registerOverlay: vi.fn(),
+  ripGrepStream: vi.fn(),
+  terminal: {
+    columns: 180,
+    rows: 30,
+  },
+}))
+
+vi.mock('../context/overlayContext', () => ({
+  useRegisterOverlay: harness.registerOverlay,
+}))
+
+vi.mock('../hooks/useTerminalSize', () => ({
+  useTerminalSize: () => harness.terminal,
+}))
+
+vi.mock('../../services/analytics/index', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../../utils/cwd', () => ({
+  getCwd: () => harness.cwd,
+}))
+
+vi.mock('../../utils/editor', () => ({
+  openFileInExternalEditor: harness.openFileInExternalEditor,
+}))
+
+vi.mock('../../utils/readFileInRange', () => ({
+  readFileInRange: harness.readFileInRange,
+}))
+
+vi.mock('../../utils/ripgrep', () => ({
+  ripGrepStream: harness.ripGrepStream,
+}))
+
+vi.mock('./design-system/FuzzyPicker', () => ({
+  FuzzyPicker: (props: CapturedPickerProps) => {
+    harness.pickerProps = props
+    return null
+  },
+}))
+
+import { createRoot } from '../ink/root.js'
+import { renderToString } from '../../utils/staticRender.js'
+import { GlobalSearchDialog } from './GlobalSearchDialog.js'
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function resetHarness() {
+  harness.terminal.columns = 180
+  harness.terminal.rows = 30
+  harness.pickerProps = undefined
+  harness.registerOverlay.mockClear()
+  harness.logEvent.mockClear()
+  harness.openFileInExternalEditor.mockReset()
+  harness.openFileInExternalEditor.mockReturnValue(true)
+  harness.readFileInRange.mockReset()
+  harness.ripGrepStream.mockReset()
+  harness.ripGrepStream.mockResolvedValue(undefined)
+}
+
+function pickerProps(): CapturedPickerProps {
+  const props = harness.pickerProps
+  if (!props) throw new Error('Global search picker props were not captured')
+  return props
+}
+
+function emptyMessage(props: CapturedPickerProps, query: string): string {
+  const message = props.emptyMessage
+  return typeof message === 'function' ? message(query) : message ?? ''
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await sleep(10)
+  }
+  throw new Error(message)
+}
+
+async function waitForRenderedText(
+  node: () => React.ReactNode,
+  predicate: (output: string) => boolean,
+  message: string,
+): Promise<string> {
+  const startedAt = Date.now()
+  let lastOutput = ''
+  while (Date.now() - startedAt < 1000) {
+    lastOutput = await renderToString(node(), 120)
+    if (predicate(lastOutput)) return lastOutput
+    await sleep(10)
+  }
+  throw new Error(`${message}\nLast output:\n${lastOutput}`)
+}
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = harness.terminal.columns
+  ;(stdout as unknown as { rows: number }).rows = harness.terminal.rows
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function renderDialog() {
+  const onDone = vi.fn()
+  const onInsert = vi.fn()
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  root.render(<GlobalSearchDialog onDone={onDone} onInsert={onInsert} />)
+  await waitFor(() => harness.pickerProps !== undefined, 'GlobalSearchDialog did not render')
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep(25)
+    },
+  }
+}
+
+describe('GlobalSearchDialog wave 200 worker 129 coverage', () => {
+  beforeEach(() => {
+    resetHarness()
+  })
+
+  it('caps large result streams, reports preview failures, and clears stale matches', async () => {
+    const rendered = await renderDialog()
+
+    try {
+      const query = 'needle'
+      const lines = Array.from(
+        { length: 501 },
+        (_, i) => `/workspace/project/src/file-${i}.ts:${i + 1}:Needle ${i}`,
+      )
+      let searchSignal: AbortSignal | undefined
+
+      harness.readFileInRange.mockRejectedValue(new Error('preview failed'))
+      harness.ripGrepStream.mockImplementation(
+        async (
+          args: string[],
+          cwd: string,
+          signal: AbortSignal,
+          onLines: (chunk: readonly string[]) => void,
+        ) => {
+          expect(args).toEqual([
+            '-n',
+            '--no-heading',
+            '-i',
+            '-m',
+            '10',
+            '-F',
+            '-e',
+            query,
+          ])
+          expect(cwd).toBe(harness.cwd)
+          expect(signal.aborted).toBe(false)
+          searchSignal = signal
+          onLines(lines)
+        },
+      )
+
+      expect(pickerProps().previewPosition).toBe('right')
+
+      pickerProps().onQueryChange(query)
+      await waitFor(
+        () => emptyMessage(pickerProps(), query) === 'Searching...',
+        'Global search did not enter searching state',
+      )
+      await waitFor(
+        () =>
+          pickerProps().items.length === 500 &&
+          pickerProps().matchLabel === '500+ matches',
+        'Global search did not cap and label the large result set',
+      )
+      expect(searchSignal?.aborted).toBe(true)
+      expect(harness.ripGrepStream).toHaveBeenCalledTimes(1)
+
+      const first = pickerProps().items[0]
+      expect(first).toEqual({
+        file: 'src/file-0.ts',
+        line: 1,
+        text: 'Needle 0',
+      })
+      expect(pickerProps().items.at(-1)).toEqual({
+        file: 'src/file-499.ts',
+        line: 500,
+        text: 'Needle 499',
+      })
+
+      pickerProps().onFocus?.(first)
+      await waitFor(
+        () => harness.readFileInRange.mock.calls.length === 1,
+        'Global search did not request focused preview content',
+      )
+      expect(harness.readFileInRange).toHaveBeenCalledWith(
+        '/workspace/project/src/file-0.ts',
+        0,
+        9,
+        undefined,
+        expect.any(AbortSignal),
+      )
+
+      const previewOutput = await waitForRenderedText(
+        () => pickerProps().renderPreview?.(first),
+        output => output.includes('(preview unavailable)'),
+        'Global search did not render the preview failure fallback',
+      )
+      expect(previewOutput).toContain('src/file-0.ts:1')
+
+      pickerProps().onQueryChange('   ')
+      await waitFor(
+        () => pickerProps().items.length === 0 && pickerProps().matchLabel === ' ',
+        'Global search did not clear stale matches for a blank query',
+      )
+      expect(harness.ripGrepStream).toHaveBeenCalledTimes(1)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/components/HelpV2/HelpV2.coverage.test.tsx
+++ b/runtime/tests/tui/components/HelpV2/HelpV2.coverage.test.tsx
@@ -1,0 +1,216 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Command } from "../../../commands.js";
+
+const keybindingMock = vi.hoisted(() => ({
+  groups: [] as Array<{
+    handlers: Record<string, () => void>;
+    options: { context?: string; isActive?: boolean };
+  }>,
+  singles: [] as Array<{
+    action: string;
+    handler: () => void;
+    options: { context?: string; isActive?: boolean };
+  }>,
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: () => false,
+}));
+
+vi.mock("../../keybindings/useKeybinding.js", () => ({
+  useKeybinding: (
+    action: string,
+    handler: () => void,
+    options: { context?: string; isActive?: boolean } = {},
+  ) => {
+    keybindingMock.singles.push({ action, handler, options });
+  },
+  useKeybindings: (
+    handlers: Record<string, () => void>,
+    options: { context?: string; isActive?: boolean } = {},
+  ) => {
+    keybindingMock.groups.push({ handlers, options });
+  },
+}));
+
+vi.mock("../../keybindings/loadUserBindings.js", () => ({
+  isKeybindingCustomizationEnabled: () => false,
+}));
+
+vi.mock("../../../services/analytics/growthbook.js", () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: (_key: string, fallback: unknown) =>
+    fallback,
+}));
+
+vi.mock("../../../utils/fastMode.js", () => ({
+  isFastModeAvailable: () => false,
+  isFastModeEnabled: () => false,
+}));
+
+vi.mock("../../../utils/platform.js", () => ({
+  getPlatform: () => "linux",
+}));
+
+import { createRoot, type Root } from "../../ink.js";
+import { HelpV2 } from "./HelpV2.js";
+
+function sleep(ms = 50): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function testCommand(
+  name: string,
+  description: string,
+  overrides: Partial<Command> = {},
+): Command {
+  return {
+    type: "prompt",
+    name,
+    description,
+    progressMessage: "running",
+    contentLength: description.length,
+    ...overrides,
+  } as Command;
+}
+
+function invokeSingle(action: string): void {
+  const registration = [...keybindingMock.singles]
+    .reverse()
+    .find(
+      candidate =>
+        candidate.action === action && candidate.options.isActive !== false,
+    );
+
+  if (!registration) throw new Error(`No active keybinding for ${action}`);
+  registration.handler();
+}
+
+function invokeGroup(action: string): void {
+  const registration = [...keybindingMock.groups]
+    .reverse()
+    .find(
+      candidate =>
+        candidate.handlers[action] !== undefined &&
+        candidate.options.isActive !== false,
+    );
+
+  if (!registration) throw new Error(`No active keybinding group for ${action}`);
+  registration.handlers[action]?.();
+}
+
+function createStreams(): {
+  stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdout: PassThrough;
+  output: () => string;
+} {
+  let rendered = "";
+  const stdout = new PassThrough();
+  stdout.on("data", chunk => {
+    rendered += chunk.toString();
+  });
+  (stdout as unknown as { columns: number; rows: number }).columns = 120;
+  (stdout as unknown as { columns: number; rows: number }).rows = 24;
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+
+  return {
+    stdin,
+    stdout,
+    output: () => stripAnsi(rendered),
+  };
+}
+
+async function renderHelp(commands: Command[]): Promise<{
+  dispose: () => void;
+  onClose: ReturnType<typeof vi.fn>;
+  output: () => string;
+  root: Root;
+}> {
+  const { stdin, stdout, output } = createStreams();
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+  const onClose = vi.fn();
+
+  root.render(<HelpV2 commands={commands} onClose={onClose} query="deploy" />);
+  await sleep();
+
+  return {
+    root,
+    onClose,
+    output,
+    dispose: () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    },
+  };
+}
+
+describe("HelpV2 coverage", () => {
+  beforeEach(() => {
+    keybindingMock.groups = [];
+    keybindingMock.singles = [];
+  });
+
+  it("routes visible built-in and custom commands through tabs and dismisses via help keybinding", async () => {
+    const harness = await renderHelp([
+      testCommand("help", "Show help"),
+      testCommand("status", "Hidden status command", { isHidden: true }),
+      testCommand("deploy-project", "Deploy the project", { source: "plugin" }),
+      testCommand("internal-project", "Hidden project command", {
+        isHidden: true,
+        source: "plugin",
+      }),
+    ]);
+
+    try {
+      const generalOutput = harness.output();
+      expect(generalOutput).toContain("AgenC Help");
+      expect(generalOutput).toContain("AgenC understands your codebase");
+
+      invokeSingle("help:dismiss");
+      expect(harness.onClose).toHaveBeenCalledWith("Help dialog dismissed", {
+        display: "system",
+      });
+
+      invokeGroup("tabs:next");
+      await sleep();
+
+      expect(harness.output()).toContain("Default commands matching deploy:");
+      expect(harness.output()).toContain("/help");
+      expect(harness.output()).not.toContain("/status");
+
+      invokeGroup("tabs:next");
+      await sleep();
+
+      expect(harness.output()).toContain("Custom commands matching deploy:");
+      expect(harness.output()).toContain("/deploy-project");
+      expect(harness.output()).not.toContain("/internal-project");
+      expect(generalOutput).toContain("esc to cancel");
+    } finally {
+      harness.dispose();
+    }
+  });
+});

--- a/runtime/tests/tui/components/HelpV2/HelpV2.wave200-134.coverage.test.tsx
+++ b/runtime/tests/tui/components/HelpV2/HelpV2.wave200-134.coverage.test.tsx
@@ -1,0 +1,216 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Command } from "../../../commands.js";
+
+const keybindingMock = vi.hoisted(() => ({
+  groups: [] as Array<{
+    handlers: Record<string, () => void>;
+    options: { context?: string; isActive?: boolean };
+  }>,
+  singles: [] as Array<{
+    action: string;
+    handler: () => void;
+    options: { context?: string; isActive?: boolean };
+  }>,
+}));
+
+const exitStateMock = vi.hoisted(() => ({
+  state: {
+    keyName: "ctrl+c",
+    pending: true,
+  },
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: () => false,
+}));
+
+vi.mock("src/tui/hooks/useExitOnCtrlCDWithKeybindings.js", () => ({
+  useExitOnCtrlCDWithKeybindings: () => exitStateMock.state,
+}));
+
+vi.mock("../../keybindings/useShortcutDisplay.js", () => ({
+  useShortcutDisplay: () => "esc",
+}));
+
+vi.mock("../../keybindings/useKeybinding.js", () => ({
+  useKeybinding: (
+    action: string,
+    handler: () => void,
+    options: { context?: string; isActive?: boolean } = {},
+  ) => {
+    keybindingMock.singles.push({ action, handler, options });
+  },
+  useKeybindings: (
+    handlers: Record<string, () => void>,
+    options: { context?: string; isActive?: boolean } = {},
+  ) => {
+    keybindingMock.groups.push({ handlers, options });
+  },
+}));
+
+vi.mock("../../keybindings/loadUserBindings.js", () => ({
+  isKeybindingCustomizationEnabled: () => false,
+}));
+
+vi.mock("../../../services/analytics/growthbook.js", () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: (_key: string, fallback: unknown) =>
+    fallback,
+}));
+
+vi.mock("../../../utils/fastMode.js", () => ({
+  isFastModeAvailable: () => false,
+  isFastModeEnabled: () => false,
+}));
+
+vi.mock("../../../utils/platform.js", () => ({
+  getPlatform: () => "linux",
+}));
+
+import { ModalContext } from "../../context/modalContext.js";
+import { createRoot, type Root } from "../../ink.js";
+import { HelpV2 } from "./HelpV2.js";
+
+function sleep(ms = 50): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function testCommand(name: string, description: string): Command {
+  return {
+    type: "prompt",
+    name,
+    description,
+    progressMessage: "running",
+    contentLength: description.length,
+  } as Command;
+}
+
+function invokeGroup(action: string): void {
+  const registration = [...keybindingMock.groups]
+    .reverse()
+    .find(
+      candidate =>
+        candidate.handlers[action] !== undefined &&
+        candidate.options.isActive !== false,
+    );
+
+  if (!registration) throw new Error(`No active keybinding group for ${action}`);
+  registration.handlers[action]?.();
+}
+
+function createStreams(): {
+  stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdout: PassThrough;
+  output: () => string;
+} {
+  let rendered = "";
+  const stdout = new PassThrough();
+  stdout.on("data", chunk => {
+    rendered += chunk.toString();
+  });
+  stdout.resume();
+  (stdout as unknown as { columns: number; rows: number }).columns = 90;
+  (stdout as unknown as { columns: number; rows: number }).rows = 18;
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+
+  return {
+    stdin,
+    stdout,
+    output: () => stripAnsi(rendered),
+  };
+}
+
+function renderNode(commands: Command[], onClose: () => void): React.ReactNode {
+  return (
+    <ModalContext.Provider
+      value={{ rows: 18, columns: 90, scrollRef: null }}
+    >
+      <HelpV2 commands={commands} onClose={onClose} />
+    </ModalContext.Provider>
+  );
+}
+
+async function renderModalHelp(commands: Command[]): Promise<{
+  dispose: () => void;
+  onClose: ReturnType<typeof vi.fn>;
+  output: () => string;
+  rerender: () => Promise<void>;
+  root: Root;
+}> {
+  const { stdin, stdout, output } = createStreams();
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+  const onClose = vi.fn();
+
+  root.render(renderNode(commands, onClose));
+  await sleep();
+
+  return {
+    root,
+    onClose,
+    output,
+    rerender: async () => {
+      root.render(renderNode(commands, onClose));
+      await sleep();
+    },
+    dispose: () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    },
+  };
+}
+
+describe("HelpV2 wave200 coverage", () => {
+  beforeEach(() => {
+    keybindingMock.groups = [];
+    keybindingMock.singles = [];
+    exitStateMock.state = {
+      keyName: "ctrl+c",
+      pending: true,
+    };
+  });
+
+  it("keeps modal help cached across rerenders while showing no-query command labels and pending exit copy", async () => {
+    const commands = [testCommand("help", "Show help")];
+    const harness = await renderModalHelp(commands);
+
+    try {
+      await harness.rerender();
+      expect(harness.output()).toContain("Press ctrl+c again to exit");
+
+      invokeGroup("tabs:next");
+      await harness.rerender();
+      expect(harness.output()).toContain("Browse default commands:");
+      expect(harness.output()).toContain("/help");
+
+      invokeGroup("tabs:next");
+      await harness.rerender();
+      expect(harness.output()).toContain("No custom commands found");
+    } finally {
+      harness.dispose();
+    }
+  });
+});

--- a/runtime/tests/tui/components/IdeOnboardingDialog.wave200-117.coverage.test.tsx
+++ b/runtime/tests/tui/components/IdeOnboardingDialog.wave200-117.coverage.test.tsx
@@ -1,0 +1,242 @@
+import type { ReactNode } from "react";
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { renderToString } from "../../utils/staticRender.js";
+import {
+  hasIdeOnboardingDialogBeenShown,
+  IdeOnboardingDialog,
+} from "./IdeOnboardingDialog.js";
+
+type TestConfig = {
+  hasIdeOnboardingBeenShown?: Record<string, boolean>;
+};
+
+type DialogMockProps = {
+  children: ReactNode;
+  color?: string;
+  hideInputGuide?: boolean;
+  onCancel: () => void;
+  subtitle?: ReactNode;
+  title: ReactNode;
+};
+
+type KeybindingHandlers = Record<string, () => void>;
+
+const harness = vi.hoisted(() => ({
+  config: {} as TestConfig,
+  dialogProps: undefined as DialogMockProps | undefined,
+  getGlobalConfig: vi.fn(),
+  keybindings: undefined as
+    | undefined
+    | {
+      handlers: KeybindingHandlers;
+      options: unknown;
+    },
+  platform: "linux",
+  saveGlobalConfig: vi.fn(),
+  statusDot: "*",
+  terminal: "agenc-terminal" as string | null,
+  terminalIdeType: "vscode" as string | null,
+  titleStaticPrefix: "*",
+}));
+
+vi.mock("../../utils/config.js", () => ({
+  getGlobalConfig: harness.getGlobalConfig,
+  saveGlobalConfig: harness.saveGlobalConfig,
+}));
+
+vi.mock("../../utils/env.js", async () => {
+  const actual = await vi.importActual<typeof import("../../utils/env.js")>(
+    "../../utils/env.js",
+  );
+
+  return {
+    ...actual,
+    env: new Proxy(actual.env, {
+      get(target, property, receiver) {
+        if (property === "platform") return harness.platform;
+        return Reflect.get(target, property, receiver);
+      },
+    }),
+  };
+});
+
+vi.mock("../../utils/envDynamic.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../utils/envDynamic.js")
+  >("../../utils/envDynamic.js");
+
+  return {
+    ...actual,
+    envDynamic: new Proxy(actual.envDynamic, {
+      get(target, property, receiver) {
+        if (property === "terminal") return harness.terminal;
+        return Reflect.get(target, property, receiver);
+      },
+    }),
+  };
+});
+
+vi.mock("../../utils/ide.js", () => ({
+  getTerminalIdeType: () => harness.terminalIdeType,
+  isJetBrainsIde: (ide: string | null) =>
+    ide === "intellij" || ide === "pycharm",
+  toIDEDisplayName: (ide: string | null) => {
+    if (ide === "intellij") return "IntelliJ IDEA";
+    if (ide === "vscode") return "VS Code";
+    return "IDE";
+  },
+}));
+
+vi.mock("../glyphs.js", () => ({
+  selectAgenCTuiGlyphs: () => ({
+    statusDot: harness.statusDot,
+    titleStaticPrefix: harness.titleStaticPrefix,
+  }),
+}));
+
+vi.mock("../keybindings/useKeybinding.js", () => ({
+  useKeybindings: (handlers: KeybindingHandlers, options: unknown) => {
+    harness.keybindings = { handlers, options };
+  },
+}));
+
+vi.mock("./design-system/Dialog.js", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    Dialog: (props: DialogMockProps) => {
+      harness.dialogProps = props;
+      return ReactActual.createElement(
+        "ink-box",
+        { flexDirection: "column" },
+        props.title,
+        props.subtitle
+          ? ReactActual.createElement("ink-text", null, props.subtitle)
+          : null,
+        props.children,
+      );
+    },
+  };
+});
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+describe("IdeOnboardingDialog wave200 coverage", () => {
+  beforeEach(() => {
+    harness.config = {};
+    harness.dialogProps = undefined;
+    harness.keybindings = undefined;
+    harness.platform = "linux";
+    harness.statusDot = "*";
+    harness.terminal = "agenc-terminal";
+    harness.terminalIdeType = "vscode";
+    harness.titleStaticPrefix = "*";
+    harness.getGlobalConfig.mockReset();
+    harness.getGlobalConfig.mockImplementation(() => harness.config);
+    harness.saveGlobalConfig.mockReset();
+    harness.saveGlobalConfig.mockImplementation(
+      (updater: (current: TestConfig) => TestConfig) => {
+        const next = updater(harness.config);
+        if (next !== harness.config) {
+          harness.config = next;
+        }
+      },
+    );
+  });
+
+  test("renders IDE-specific onboarding and records the terminal as shown", async () => {
+    const onDone = vi.fn();
+
+    expect(hasIdeOnboardingDialogBeenShown()).toBe(false);
+
+    const jetBrainsOutput = normalizeWhitespace(
+      await renderToString(
+        <IdeOnboardingDialog
+          onDone={onDone}
+          installationStatus={{
+            error: null,
+            ideType: "intellij" as never,
+            installed: true,
+            installedVersion: "2.4.6",
+          }}
+        />,
+        { columns: 160, rows: 30 },
+      ),
+    );
+
+    expect(jetBrainsOutput).toContain("* Welcome to AgenC for IntelliJ IDEA");
+    expect(jetBrainsOutput).toContain("installed plugin v2.4.6");
+    expect(jetBrainsOutput).toContain(
+      "* AgenC has context of open files and selected lines",
+    );
+    expect(jetBrainsOutput).toContain(
+      "* Review AgenC's changes +11 -22 in the comfort of your IDE",
+    );
+    expect(jetBrainsOutput).toContain("* Cmd+Esc for Quick Launch");
+    expect(jetBrainsOutput).toContain(
+      "* Ctrl+Alt+K to reference files or lines in your input",
+    );
+    expect(jetBrainsOutput).toContain("Press Enter to continue");
+    expect(harness.dialogProps).toMatchObject({
+      color: "ide",
+      hideInputGuide: true,
+      onCancel: onDone,
+      subtitle: "installed plugin v2.4.6",
+    });
+    expect(harness.keybindings?.options).toEqual({ context: "Confirmation" });
+
+    harness.keybindings?.handlers["confirm:yes"]?.();
+    harness.keybindings?.handlers["confirm:no"]?.();
+
+    expect(onDone).toHaveBeenCalledTimes(2);
+    expect(harness.config.hasIdeOnboardingBeenShown).toEqual({
+      "agenc-terminal": true,
+    });
+    expect(hasIdeOnboardingDialogBeenShown()).toBe(true);
+
+    await renderToString(
+      <IdeOnboardingDialog
+        onDone={onDone}
+        installationStatus={{
+          error: null,
+          ideType: "intellij" as never,
+          installed: true,
+          installedVersion: "2.4.6",
+        }}
+      />,
+      { columns: 160, rows: 30 },
+    );
+
+    expect(harness.config.hasIdeOnboardingBeenShown).toEqual({
+      "agenc-terminal": true,
+    });
+
+    harness.platform = "darwin";
+    harness.terminal = null;
+    harness.terminalIdeType = "vscode";
+    harness.titleStaticPrefix = "";
+
+    const vscodeOutput = normalizeWhitespace(
+      await renderToString(
+        <IdeOnboardingDialog onDone={onDone} installationStatus={null} />,
+        { columns: 160, rows: 30 },
+      ),
+    );
+
+    expect(vscodeOutput).toContain("Welcome to AgenC for VS Code");
+    expect(vscodeOutput).not.toContain("installed extension");
+    expect(vscodeOutput).toContain(
+      "* Cmd+Option+K to reference files or lines in your input",
+    );
+    expect(harness.dialogProps?.subtitle).toBeUndefined();
+    expect(harness.config.hasIdeOnboardingBeenShown).toEqual({
+      "agenc-terminal": true,
+      unknown: true,
+    });
+    expect(hasIdeOnboardingDialogBeenShown()).toBe(true);
+  });
+});

--- a/runtime/tests/tui/components/IdeStatusIndicator.wave200-103.coverage.test.tsx
+++ b/runtime/tests/tui/components/IdeStatusIndicator.wave200-103.coverage.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { describe, expect, test } from "vitest";
+
+import type { MCPServerConnection } from "../../services/mcp/types.js";
+import { renderToString } from "../../utils/staticRender.js";
+import { IdeStatusIndicator } from "./IdeStatusIndicator.js";
+
+function ideClient(type: MCPServerConnection["type"]): MCPServerConnection {
+  return {
+    name: "ide",
+    type,
+    config: {
+      type: "ws-ide",
+      url: "ws://localhost:1234",
+      ideName: "VS Code",
+      scope: "local",
+    },
+  } as unknown as MCPServerConnection;
+}
+
+describe("IdeStatusIndicator coverage", () => {
+  test("renders selection context only when the IDE client is connected", async () => {
+    expect(
+      (
+        await renderToString(
+          <IdeStatusIndicator
+            ideSelection={{ filePath: "/repo/src/app.tsx", lineCount: 0 }}
+            mcpClients={[]}
+          />,
+          80,
+        )
+      ).trim(),
+    ).toBe("");
+
+    expect(
+      (
+        await renderToString(
+          <IdeStatusIndicator
+            ideSelection={{ filePath: "/repo/src/app.tsx", lineCount: 0 }}
+            mcpClients={[ideClient("pending")]}
+          />,
+          80,
+        )
+      ).trim(),
+    ).toBe("");
+
+    expect(
+      (
+        await renderToString(
+          <IdeStatusIndicator
+            ideSelection={undefined}
+            mcpClients={[ideClient("connected")]}
+          />,
+          80,
+        )
+      ).trim(),
+    ).toBe("");
+
+    await expect(
+      renderToString(
+        <IdeStatusIndicator
+          ideSelection={{ text: "selected", lineCount: 1 }}
+          mcpClients={[ideClient("connected")]}
+        />,
+        80,
+      ),
+    ).resolves.toContain("1 line selected");
+
+    await expect(
+      renderToString(
+        <IdeStatusIndicator
+          ideSelection={{ text: "first\nsecond", lineCount: 2 }}
+          mcpClients={[ideClient("connected")]}
+        />,
+        80,
+      ),
+    ).resolves.toContain("2 lines selected");
+
+    await expect(
+      renderToString(
+        <IdeStatusIndicator
+          ideSelection={{ filePath: "/repo/src/app.tsx", lineCount: 0 }}
+          mcpClients={[ideClient("connected")]}
+        />,
+        80,
+      ),
+    ).resolves.toContain("In app.tsx");
+  });
+});

--- a/runtime/tests/tui/components/MCPServerDesktopImportDialog.test.tsx
+++ b/runtime/tests/tui/components/MCPServerDesktopImportDialog.test.tsx
@@ -1,0 +1,350 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type {
+  ConfigScope,
+  McpServerConfig,
+  ScopedMcpServerConfig,
+} from '../../services/mcp/types.js'
+import { createRoot } from '../ink/root.js'
+import { renderToString } from '../../utils/staticRender.js'
+import { MCPServerDesktopImportDialog } from './MCPServerDesktopImportDialog.js'
+
+type SelectOption = {
+  label: string
+  value: string
+}
+
+type CapturedSelectMultiProps = {
+  options: SelectOption[]
+  defaultValue?: string[]
+  onSubmit?: (values: string[]) => Promise<void>
+  onCancel: () => void
+  hideIndexes?: boolean
+}
+
+type CapturedDialogProps = {
+  title: React.ReactNode
+  subtitle?: React.ReactNode
+  children: React.ReactNode
+  onCancel: () => void
+  color?: string
+  hideInputGuide?: boolean
+}
+
+const harness = vi.hoisted(() => ({
+  addMcpConfig: vi.fn(),
+  dialogProps: undefined as CapturedDialogProps | undefined,
+  getAllMcpConfigs: vi.fn(),
+  gracefulShutdown: vi.fn(),
+  selectProps: undefined as CapturedSelectMultiProps | undefined,
+  writeToStdout: vi.fn(),
+}))
+
+vi.mock('../../services/mcp/config.js', () => ({
+  addMcpConfig: harness.addMcpConfig,
+  getAllMcpConfigs: harness.getAllMcpConfigs,
+}))
+
+vi.mock('../../utils/gracefulShutdown.js', () => ({
+  gracefulShutdown: harness.gracefulShutdown,
+}))
+
+vi.mock('src/utils/process.js', () => ({
+  writeToStdout: harness.writeToStdout,
+}))
+
+vi.mock('./design-system/Dialog.js', async () => {
+  const ReactActual = await vi.importActual<typeof import('react')>('react')
+  return {
+    Dialog: (props: CapturedDialogProps) => {
+      harness.dialogProps = props
+      return ReactActual.createElement(
+        ReactActual.Fragment,
+        null,
+        ReactActual.createElement('ink-text', null, String(props.title)),
+        props.subtitle
+          ? ReactActual.createElement('ink-text', null, String(props.subtitle))
+          : null,
+        props.children,
+      )
+    },
+  }
+})
+
+vi.mock('./CustomSelect/SelectMulti.js', async () => {
+  const ReactActual = await vi.importActual<typeof import('react')>('react')
+  return {
+    SelectMulti: (props: CapturedSelectMultiProps) => {
+      harness.selectProps = props
+      return ReactActual.createElement(
+        'ink-text',
+        null,
+        props.options.map(option => option.label).join('\n'),
+      )
+    },
+  }
+})
+
+const DESKTOP_SERVERS = {
+  filesystem: { type: 'stdio', command: 'node', args: ['fs-server.js'] },
+  docs: { type: 'http', url: 'https://docs.example.test/mcp' },
+} satisfies Record<string, McpServerConfig>
+
+function scoped(
+  config: McpServerConfig,
+  scope: ConfigScope = 'user',
+): ScopedMcpServerConfig {
+  return { ...config, scope }
+}
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number; rows: number }).columns = 120
+  ;(stdout as unknown as { columns: number; rows: number }).rows = 30
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await sleep(10)
+  }
+  throw new Error(message)
+}
+
+function selectProps(): CapturedSelectMultiProps {
+  if (!harness.selectProps) {
+    throw new Error('SelectMulti props were not captured')
+  }
+  return harness.selectProps
+}
+
+function dialogProps(): CapturedDialogProps {
+  if (!harness.dialogProps) {
+    throw new Error('Dialog props were not captured')
+  }
+  return harness.dialogProps
+}
+
+async function renderDialog({
+  servers = DESKTOP_SERVERS,
+  existingServers = {},
+  scope = 'user',
+}: {
+  servers?: Record<string, McpServerConfig>
+  existingServers?: Record<string, ScopedMcpServerConfig>
+  scope?: ConfigScope
+} = {}) {
+  harness.getAllMcpConfigs.mockResolvedValue({ servers: existingServers })
+
+  const onDone = vi.fn()
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  root.render(
+    <MCPServerDesktopImportDialog
+      servers={servers}
+      scope={scope}
+      onDone={onDone}
+    />,
+  )
+  await waitFor(
+    () => harness.selectProps !== undefined && harness.dialogProps !== undefined,
+    'MCP server import dialog did not render',
+  )
+
+  return {
+    onDone,
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep(20)
+    },
+  }
+}
+
+describe('MCPServerDesktopImportDialog', () => {
+  beforeEach(() => {
+    harness.addMcpConfig.mockReset()
+    harness.addMcpConfig.mockResolvedValue(undefined)
+    harness.dialogProps = undefined
+    harness.getAllMcpConfigs.mockReset()
+    harness.gracefulShutdown.mockReset()
+    harness.selectProps = undefined
+    harness.writeToStdout.mockReset()
+  })
+
+  it('renders the empty desktop state and cancels as a no-op import', async () => {
+    const rendered = await renderDialog({ servers: {} })
+
+    try {
+      expect(dialogProps().title).toBe('Import MCP Servers from AgenC Desktop')
+      expect(dialogProps().subtitle).toBe(
+        'Found 0 MCP servers in AgenC Desktop.',
+      )
+      expect(dialogProps().color).toBe('success')
+      expect(dialogProps().hideInputGuide).toBe(true)
+      expect(selectProps().options).toEqual([])
+      expect(selectProps().defaultValue).toEqual([])
+      expect(selectProps().hideIndexes).toBe(true)
+
+      selectProps().onCancel()
+
+      expect(harness.addMcpConfig).not.toHaveBeenCalled()
+      expect(harness.writeToStdout).toHaveBeenCalledWith(
+        '\nNo servers were imported.',
+      )
+      expect(rendered.onDone).toHaveBeenCalledOnce()
+      expect(harness.gracefulShutdown).toHaveBeenCalledOnce()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  it('renders collisions after loading existing configs and excludes them from the default selection', async () => {
+    const rendered = await renderDialog({
+      existingServers: {
+        docs: scoped(DESKTOP_SERVERS.docs),
+        docs_1: scoped(DESKTOP_SERVERS.docs),
+      },
+    })
+
+    try {
+      await waitFor(
+        () =>
+          selectProps().options.some(
+            option => option.label === 'docs (already exists)',
+          ),
+        'MCP server import dialog did not render collision state',
+      )
+
+      expect(selectProps().options).toEqual([
+        { label: 'filesystem', value: 'filesystem' },
+        { label: 'docs (already exists)', value: 'docs' },
+      ])
+      expect(selectProps().defaultValue).toEqual(['filesystem'])
+
+      const body = await renderToString(<>{dialogProps().children}</>, 120)
+      expect(body).toContain('Note: Some servers already exist')
+      expect(body).toContain('Please select the servers you want to import')
+      expect(body).toContain('docs (already exists)')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  it('imports selected servers, suffixes collisions, and writes the success result', async () => {
+    const rendered = await renderDialog({
+      existingServers: {
+        docs: scoped(DESKTOP_SERVERS.docs),
+        docs_1: scoped(DESKTOP_SERVERS.docs),
+      },
+      scope: 'project',
+    })
+
+    try {
+      await waitFor(
+        () =>
+          selectProps().options.some(
+            option => option.label === 'docs (already exists)',
+          ),
+        'MCP server import dialog did not load existing server names',
+      )
+
+      await selectProps().onSubmit?.(['docs', 'filesystem'])
+
+      expect(harness.addMcpConfig).toHaveBeenNthCalledWith(
+        1,
+        'docs_2',
+        DESKTOP_SERVERS.docs,
+        'project',
+      )
+      expect(harness.addMcpConfig).toHaveBeenNthCalledWith(
+        2,
+        'filesystem',
+        DESKTOP_SERVERS.filesystem,
+        'project',
+      )
+      expect(stripAnsi(harness.writeToStdout.mock.calls[0]?.[0] ?? '')).toContain(
+        'Successfully imported 2 MCP servers to project config.',
+      )
+      expect(rendered.onDone).toHaveBeenCalledOnce()
+      expect(harness.gracefulShutdown).toHaveBeenCalledOnce()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  it('ignores stale selected names and reports that nothing was imported', async () => {
+    const rendered = await renderDialog()
+
+    try {
+      await selectProps().onSubmit?.(['missing-server'])
+
+      expect(harness.addMcpConfig).not.toHaveBeenCalled()
+      expect(harness.writeToStdout).toHaveBeenCalledWith(
+        '\nNo servers were imported.',
+      )
+      expect(rendered.onDone).toHaveBeenCalledOnce()
+      expect(harness.gracefulShutdown).toHaveBeenCalledOnce()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  it('propagates import errors without completing or shutting down', async () => {
+    harness.addMcpConfig.mockRejectedValueOnce(new Error('write failed'))
+    const rendered = await renderDialog()
+
+    try {
+      await expect(selectProps().onSubmit?.(['filesystem'])).rejects.toThrow(
+        'write failed',
+      )
+
+      expect(harness.writeToStdout).not.toHaveBeenCalled()
+      expect(rendered.onDone).not.toHaveBeenCalled()
+      expect(harness.gracefulShutdown).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/components/Message.coverage.test.tsx
+++ b/runtime/tests/tui/components/Message.coverage.test.tsx
@@ -1,0 +1,166 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  calls: [] as Array<{ name: string; props: Record<string, unknown> }>,
+  features: new Set<string>(),
+  reset() {
+    harness.calls = []
+    harness.features = new Set()
+  },
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => harness.features.has(name),
+}))
+
+vi.mock('../../services/compact/snipProjection.js', () => ({
+  isSnipBoundaryMessage: (message: { readonly subtype?: string }) =>
+    message.subtype === 'snip_boundary',
+}))
+
+vi.mock('../../services/compact/snipCompact.js', () => ({
+  isSnipMarkerMessage: (message: { readonly subtype?: string }) =>
+    message.subtype === 'snip_marker',
+}))
+
+vi.mock('../message-renderers/SnipBoundaryMessage.js', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../ink.js')
+  return {
+    SnipBoundaryMessage: (props: Record<string, unknown>) => {
+      harness.calls.push({ name: 'SnipBoundaryMessage', props })
+      return ReactModule.createElement(Text, null, 'snip boundary')
+    },
+  }
+})
+
+vi.mock('./Message.renderers.js', async () => {
+  const renderer = (name: string) => (props: Record<string, unknown>) => {
+    harness.calls.push({ name, props })
+    return null
+  }
+
+  return {
+    AdvisorMessage: renderer('AdvisorMessage'),
+    AssistantRedactedThinkingMessage: renderer('AssistantRedactedThinkingMessage'),
+    AssistantTextMessage: renderer('AssistantTextMessage'),
+    AssistantThinkingMessage: renderer('AssistantThinkingMessage'),
+    AssistantToolUseMessage: renderer('AssistantToolUseMessage'),
+    AttachmentMessage: renderer('AttachmentMessage'),
+    CollapsedReadSearchContent: renderer('CollapsedReadSearchContent'),
+    CompactBoundaryMessage: renderer('CompactBoundaryMessage'),
+    CompactSummary: renderer('CompactSummary'),
+    ExpandShellOutputProvider: ({ children }: { readonly children?: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    GroupedToolUseContent: renderer('GroupedToolUseContent'),
+    OffscreenFreeze: ({ children }: { readonly children?: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    SystemTextMessage: renderer('SystemTextMessage'),
+    UserImageMessage: renderer('UserImageMessage'),
+    UserTextMessage: renderer('UserTextMessage'),
+    UserToolResultMessage: renderer('UserToolResultMessage'),
+  }
+})
+
+import { createRoot } from '../ink/root.js'
+import { Box } from '../ink.js'
+import type { Props } from './Message.js'
+import { Message } from './Message.js'
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function baseProps(message: Props['message']): Props {
+  return {
+    addMargin: false,
+    commands: [],
+    inProgressToolUseIDs: new Set(),
+    isStatic: false,
+    isTranscriptMode: false,
+    lookups: {
+      erroredToolUseIDs: new Set(),
+      resolvedToolUseIDs: new Set(),
+    },
+    message,
+    progressMessagesForMessage: [],
+    shouldAnimate: false,
+    shouldShowDot: false,
+    tools: [] as never,
+    verbose: false,
+  } as Props
+}
+
+describe('Message HISTORY_SNIP coverage', () => {
+  test('renders snip boundaries and suppresses snip markers when the feature is enabled', async () => {
+    harness.reset()
+    harness.features.add('HISTORY_SNIP')
+
+    const messages = [
+      { subtype: 'snip_boundary', type: 'system', uuid: 'snip-boundary' },
+      { subtype: 'snip_marker', type: 'system', uuid: 'snip-marker' },
+    ] as Array<Props['message']>
+
+    let output = ''
+    const { stdin, stdout } = createStreams()
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    root.render(
+      <Box flexDirection="column">
+        {messages.map(message => (
+          <Message key={message.uuid} {...baseProps(message)} message={message} />
+        ))}
+      </Box>,
+    )
+    await sleep()
+
+    try {
+      expect(stripAnsi(output)).toContain('snip boundary')
+      expect(harness.calls).toHaveLength(1)
+      expect(harness.calls[0]).toMatchObject({
+        name: 'SnipBoundaryMessage',
+        props: { message: messages[0] },
+      })
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+})

--- a/runtime/tests/tui/components/Message.render.test.tsx
+++ b/runtime/tests/tui/components/Message.render.test.tsx
@@ -1,0 +1,359 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  calls: [] as Array<{ name: string; props: Record<string, unknown> }>,
+  features: new Set<string>(),
+  fullscreen: false,
+  logError: vi.fn(),
+  reset() {
+    harness.calls = []
+    harness.features = new Set()
+    harness.fullscreen = false
+    harness.logError.mockClear()
+  },
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => harness.features.has(name),
+}))
+
+vi.mock('../../utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => harness.fullscreen,
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: harness.logError,
+}))
+
+vi.mock('../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: 12, rows: 24 }),
+}))
+
+vi.mock('../../services/compact/snipProjection.js', () => ({
+  isSnipBoundaryMessage: (message: { readonly subtype?: string }) =>
+    message.subtype === 'snip_boundary',
+}))
+
+vi.mock('../../services/compact/snipCompact.js', () => ({
+  isSnipMarkerMessage: (message: { readonly subtype?: string }) =>
+    message.subtype === 'snip_marker',
+}))
+
+vi.mock('../message-renderers/SnipBoundaryMessage.js', async () => {
+  return {
+    SnipBoundaryMessage: (props: Record<string, unknown>) => {
+      harness.calls.push({ name: 'SnipBoundaryMessage', props })
+      return null
+    },
+  }
+})
+
+vi.mock('./Message.renderers.js', async () => {
+  const ReactModule = await import('react')
+  const renderer = (name: string) => (props: Record<string, unknown>) => {
+    harness.calls.push({ name, props })
+    return null
+  }
+  return {
+    AdvisorMessage: renderer('AdvisorMessage'),
+    AssistantRedactedThinkingMessage: renderer('AssistantRedactedThinkingMessage'),
+    AssistantTextMessage: renderer('AssistantTextMessage'),
+    AssistantThinkingMessage: renderer('AssistantThinkingMessage'),
+    AssistantToolUseMessage: renderer('AssistantToolUseMessage'),
+    AttachmentMessage: renderer('AttachmentMessage'),
+    CollapsedReadSearchContent: renderer('CollapsedReadSearchContent'),
+    CompactBoundaryMessage: renderer('CompactBoundaryMessage'),
+    CompactSummary: renderer('CompactSummary'),
+    ExpandShellOutputProvider: ({
+      children,
+    }: {
+      readonly children?: React.ReactNode
+    }) => {
+      harness.calls.push({ name: 'ExpandShellOutputProvider', props: {} })
+      return ReactModule.createElement(ReactModule.Fragment, null, children)
+    },
+    GroupedToolUseContent: renderer('GroupedToolUseContent'),
+    OffscreenFreeze: ({ children }: { readonly children?: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+    SystemTextMessage: renderer('SystemTextMessage'),
+    UserImageMessage: renderer('UserImageMessage'),
+    UserTextMessage: renderer('UserTextMessage'),
+    UserToolResultMessage: renderer('UserToolResultMessage'),
+  }
+})
+
+import { createRoot } from '../ink/root.js'
+import { Box } from '../ink.js'
+import type { Props } from './Message.js'
+import { Message } from './Message.js'
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function baseProps(message: Props['message']): Props {
+  return {
+    addMargin: true,
+    commands: [],
+    inProgressToolUseIDs: new Set(['tool-live']),
+    isStatic: false,
+    isTranscriptMode: false,
+    lookups: {
+      erroredToolUseIDs: new Set(['tool-error']),
+      resolvedToolUseIDs: new Set(['tool-ok']),
+    },
+    message,
+    progressMessagesForMessage: [],
+    shouldAnimate: true,
+    shouldShowDot: true,
+    tools: [] as never,
+    verbose: true,
+  } as Props
+}
+
+async function renderMessages(
+  messages: Array<Props['message']>,
+  overrides: Partial<Props> = {},
+): Promise<{
+  dispose: () => Promise<void>
+  output: () => string
+}> {
+  let output = ''
+  const { stdin, stdout } = createStreams()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  root.render(
+    <Box flexDirection="column">
+      {messages.map(message => (
+        <Message
+          key={message.uuid}
+          {...baseProps(message)}
+          {...overrides}
+          message={message}
+        />
+      ))}
+    </Box>,
+  )
+  await sleep()
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    output: () => stripAnsi(output),
+  }
+}
+
+describe('Message render dispatch', () => {
+  beforeEach(() => {
+    harness.reset()
+  })
+
+  test('routes attachment, user, system, grouped, and collapsed messages to their renderers', async () => {
+    const user = {
+      imagePasteIds: ['paste-1'],
+      message: {
+        content: [
+          { text: 'hello', type: 'text' },
+          { source: { data: 'abc', media_type: 'image/png', type: 'base64' }, type: 'image' },
+          { content: 'done', tool_use_id: 'tool-1', type: 'tool_result' },
+        ],
+      },
+      type: 'user',
+      uuid: 'user-1',
+    } as Props['message']
+    const messages = [
+      {
+        attachment: { message: 'diagnostic', type: 'diagnostics' },
+        type: 'attachment',
+        uuid: 'attachment-1',
+      },
+      user,
+      {
+        isCompactSummary: true,
+        message: { content: [{ text: 'summary', type: 'text' }] },
+        type: 'user',
+        uuid: 'compact-summary',
+      },
+      { subtype: 'compact_boundary', type: 'system', uuid: 'compact-boundary' },
+      { content: 'local command', subtype: 'local_command', type: 'system', uuid: 'local-command' },
+      { content: 'system text', subtype: 'notice', type: 'system', uuid: 'system-text' },
+      {
+        messages: [],
+        toolName: 'Agent',
+        type: 'grouped_tool_use',
+        uuid: 'grouped-tool',
+      },
+      {
+        messages: [],
+        type: 'collapsed_read_search',
+        uuid: 'collapsed-search',
+      },
+    ] as Array<Props['message']>
+
+    const rendered = await renderMessages(messages, {
+      latestBashOutputUUID: 'user-1',
+    })
+
+    try {
+      expect(harness.calls.map(call => call.name)).toEqual(
+        expect.arrayContaining([
+          'ExpandShellOutputProvider',
+          'AttachmentMessage',
+          'UserTextMessage',
+          'UserImageMessage',
+          'UserToolResultMessage',
+          'CompactSummary',
+          'CompactBoundaryMessage',
+          'SystemTextMessage',
+          'GroupedToolUseContent',
+          'CollapsedReadSearchContent',
+        ]),
+      )
+      expect(
+        harness.calls.find(call => call.name === 'UserToolResultMessage')?.props,
+      ).toMatchObject({ width: 7 })
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('routes assistant block variants and logs unknown block types', async () => {
+    const assistant = {
+      advisorModel: 'reviewer-model',
+      message: {
+        content: [
+          { text: 'assistant text', type: 'text' },
+          { id: 'tool-live', input: { command: 'pwd' }, name: 'Bash', type: 'tool_use' },
+          { data: 'hidden', type: 'redacted_thinking' },
+          { thinking: 'working', type: 'thinking' },
+          { id: 'advisor-1', input: {}, name: 'advisor', type: 'server_tool_use' },
+          {
+            content: { text: 'advisor result', type: 'advisor_result' },
+            tool_use_id: 'advisor-1',
+            type: 'advisor_tool_result',
+          },
+          { type: 'unknown_block' },
+        ],
+      },
+      type: 'assistant',
+      uuid: 'assistant-1',
+    } as Props['message']
+
+    const rendered = await renderMessages([assistant], {
+      isTranscriptMode: true,
+      lastThinkingBlockId: 'assistant-1:99',
+    })
+
+    try {
+      expect(harness.calls.map(call => call.name)).toEqual(
+        expect.arrayContaining([
+          'AssistantTextMessage',
+          'AssistantToolUseMessage',
+          'AssistantRedactedThinkingMessage',
+          'AssistantThinkingMessage',
+          'AdvisorMessage',
+        ]),
+      )
+      expect(
+        harness.calls.find(call => call.name === 'AssistantThinkingMessage')?.props,
+      ).toMatchObject({ hideInTranscript: true })
+      expect(harness.logError).toHaveBeenCalledWith(expect.any(Error))
+      expect(harness.calls.some(call => call.name === 'AdvisorMessage')).toBe(true)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('uses the connector-text feature branch when enabled', async () => {
+    harness.features.add('CONNECTOR_TEXT')
+    const messages = [
+      {
+        message: {
+          content: [{ connector_text: 'from connector', type: 'connector_text' }],
+        },
+        type: 'assistant',
+        uuid: 'assistant-connector',
+      },
+    ] as Array<Props['message']>
+
+    const rendered = await renderMessages(messages)
+
+    try {
+      expect(harness.calls.map(call => call.name)).toEqual(
+        expect.arrayContaining(['AssistantTextMessage']),
+      )
+      expect(
+        harness.calls.find(call => call.name === 'AssistantTextMessage')?.props,
+      ).toMatchObject({ param: { text: 'from connector', type: 'text' } })
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('suppresses fullscreen compact boundaries and non-verbose thinking blocks', async () => {
+    harness.fullscreen = true
+    const messages = [
+      { subtype: 'compact_boundary', type: 'system', uuid: 'compact-boundary' },
+      { subtype: 'microcompact_boundary', type: 'system', uuid: 'micro-boundary' },
+      {
+        message: {
+          content: [
+            { data: 'hidden', type: 'redacted_thinking' },
+            { thinking: 'hidden', type: 'thinking' },
+          ],
+        },
+        type: 'assistant',
+        uuid: 'assistant-hidden-thinking',
+      },
+    ] as Array<Props['message']>
+
+    const rendered = await renderMessages(messages, {
+      verbose: false,
+    })
+
+    try {
+      expect(harness.calls).toEqual([])
+      expect(rendered.output()).not.toContain('CompactBoundaryMessage')
+      expect(rendered.output()).not.toContain('AssistantThinkingMessage')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/components/Message.wave200-020.coverage.test.tsx
+++ b/runtime/tests/tui/components/Message.wave200-020.coverage.test.tsx
@@ -1,0 +1,222 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  calls: [] as Array<{ name: string; props: Record<string, unknown> }>,
+  reset() {
+    harness.calls = []
+  },
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => false,
+}))
+
+vi.mock('../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: 24, rows: 12 }),
+}))
+
+vi.mock('./Message.renderers.js', async () => {
+  const ReactModule = await import('react')
+  const renderer = (name: string) => (props: Record<string, unknown>) => {
+    harness.calls.push({ name, props })
+    return null
+  }
+
+  return {
+    AdvisorMessage: renderer('AdvisorMessage'),
+    AssistantRedactedThinkingMessage: renderer('AssistantRedactedThinkingMessage'),
+    AssistantTextMessage: renderer('AssistantTextMessage'),
+    AssistantThinkingMessage: renderer('AssistantThinkingMessage'),
+    AssistantToolUseMessage: renderer('AssistantToolUseMessage'),
+    AttachmentMessage: renderer('AttachmentMessage'),
+    CollapsedReadSearchContent: renderer('CollapsedReadSearchContent'),
+    CompactBoundaryMessage: renderer('CompactBoundaryMessage'),
+    CompactSummary: renderer('CompactSummary'),
+    ExpandShellOutputProvider: ({
+      children,
+    }: {
+      readonly children?: React.ReactNode
+    }) => {
+      harness.calls.push({ name: 'ExpandShellOutputProvider', props: {} })
+      return ReactModule.createElement(ReactModule.Fragment, null, children)
+    },
+    GroupedToolUseContent: renderer('GroupedToolUseContent'),
+    OffscreenFreeze: ({ children }: { readonly children?: React.ReactNode }) => {
+      harness.calls.push({ name: 'OffscreenFreeze', props: {} })
+      return ReactModule.createElement(ReactModule.Fragment, null, children)
+    },
+    SystemTextMessage: renderer('SystemTextMessage'),
+    UserImageMessage: renderer('UserImageMessage'),
+    UserTextMessage: renderer('UserTextMessage'),
+    UserToolResultMessage: renderer('UserToolResultMessage'),
+  }
+})
+
+import { Box } from '../ink.js'
+import { createRoot } from '../ink/root.js'
+import type { Props } from './Message.js'
+import { Message } from './Message.js'
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function baseProps(message: Props['message']): Props {
+  return {
+    addMargin: true,
+    commands: [],
+    inProgressToolUseIDs: new Set(['tool-live']),
+    isStatic: false,
+    isTranscriptMode: true,
+    latestBashOutputUUID: 'user-cache',
+    lookups: {
+      erroredToolUseIDs: new Set(['advisor-error']),
+      resolvedToolUseIDs: new Set(['advisor-1']),
+    },
+    message,
+    progressMessagesForMessage: [],
+    shouldAnimate: true,
+    shouldShowDot: true,
+    tools: [] as never,
+    verbose: true,
+    width: 44,
+  } as Props
+}
+
+describe('Message compiler cache reuse', () => {
+  test('reuses cached child elements when stable message props render again', async () => {
+    harness.reset()
+
+    const messages = [
+      {
+        attachment: { message: 'diagnostic', type: 'diagnostics' },
+        type: 'attachment',
+        uuid: 'attachment-cache',
+      },
+      {
+        message: {
+          content: [
+            { text: 'prompt text', type: 'text' },
+            {
+              source: { data: 'abc', media_type: 'image/png', type: 'base64' },
+              type: 'image',
+            },
+            { content: 'tool result', tool_use_id: 'tool-live', type: 'tool_result' },
+          ],
+        },
+        type: 'user',
+        uuid: 'user-cache',
+      },
+      {
+        message: {
+          content: [
+            { text: 'assistant text', type: 'text' },
+            { id: 'tool-live', input: { command: 'pwd' }, name: 'Bash', type: 'tool_use' },
+            { data: 'hidden', type: 'redacted_thinking' },
+            { thinking: 'visible thinking', type: 'thinking' },
+            { id: 'advisor-1', input: {}, name: 'advisor', type: 'server_tool_use' },
+          ],
+        },
+        advisorModel: 'advisor-model',
+        type: 'assistant',
+        uuid: 'assistant-cache',
+      },
+      { content: 'local command', subtype: 'local_command', type: 'system', uuid: 'local-cache' },
+      { content: 'system text', subtype: 'notice', type: 'system', uuid: 'system-cache' },
+      {
+        messages: [],
+        toolName: 'Agent',
+        type: 'grouped_tool_use',
+        uuid: 'grouped-cache',
+      },
+      {
+        messages: [],
+        type: 'collapsed_read_search',
+        uuid: 'collapsed-cache',
+      },
+    ] as Array<Props['message']>
+    const props = messages.map(message => baseProps(message))
+
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    const renderStableMessages = () => (
+      <Box flexDirection="column">
+        {props.map(messageProps => (
+          <Message key={messageProps.message.uuid} {...messageProps} />
+        ))}
+      </Box>
+    )
+
+    try {
+      root.render(renderStableMessages())
+      await sleep()
+
+      const firstCallNames = harness.calls.map(call => call.name)
+      expect(firstCallNames).toEqual(
+        expect.arrayContaining([
+          'AttachmentMessage',
+          'ExpandShellOutputProvider',
+          'UserTextMessage',
+          'UserImageMessage',
+          'UserToolResultMessage',
+          'AssistantTextMessage',
+          'AssistantToolUseMessage',
+          'AssistantRedactedThinkingMessage',
+          'AssistantThinkingMessage',
+          'AdvisorMessage',
+          'SystemTextMessage',
+          'GroupedToolUseContent',
+          'OffscreenFreeze',
+          'CollapsedReadSearchContent',
+        ]),
+      )
+
+      const callCountAfterFirstRender = harness.calls.length
+      root.render(renderStableMessages())
+      await sleep()
+
+      expect(harness.calls).toHaveLength(callCountAfterFirstRender)
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+})

--- a/runtime/tests/tui/components/MessageModel.wave200-145.coverage.test.tsx
+++ b/runtime/tests/tui/components/MessageModel.wave200-145.coverage.test.tsx
@@ -1,0 +1,213 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { describe, expect, test } from "vitest";
+
+import type { NormalizedMessage } from "../../types/message.js";
+import type { DOMElement, DOMNode } from "../ink/dom.js";
+import instances from "../ink/instances.js";
+import { createRoot } from "../ink/root.js";
+import { stringWidth } from "../ink/stringWidth.js";
+import type { TextStyles } from "../ink/styles.js";
+import { MessageModel } from "./MessageModel.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+type TextSegment = {
+  text: string;
+  styles: TextStyles;
+};
+
+function createStreams(): {
+  stdin: TestStdin;
+  stdout: PassThrough;
+} {
+  const stdin = new PassThrough() as TestStdin;
+  const stdout = new PassThrough();
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number }).columns = 80;
+  (stdout as unknown as { rows: number }).rows = 24;
+  (stdout as unknown as { isTTY: boolean }).isTTY = true;
+  stdout.resume();
+
+  return { stdin, stdout };
+}
+
+function assistantMessage(
+  uuid: string,
+  model: string | undefined,
+  content: Array<Record<string, unknown>>,
+): NormalizedMessage {
+  return {
+    message: {
+      content,
+      ...(model === undefined ? {} : { model }),
+    },
+    type: "assistant",
+    uuid,
+  } as NormalizedMessage;
+}
+
+function userMessage(uuid: string, model: string): NormalizedMessage {
+  return {
+    message: {
+      content: [{ text: "user text", type: "text" }],
+      model,
+    },
+    type: "user",
+    uuid,
+  } as NormalizedMessage;
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream);
+
+  if (!instance?.rootNode) {
+    throw new Error("Ink root node not found");
+  }
+
+  return instance.rootNode;
+}
+
+function collectTextSegments(
+  node: DOMNode,
+  inheritedStyles: TextStyles = {},
+  segments: TextSegment[] = [],
+): TextSegment[] {
+  if (node.nodeName === "#text") {
+    if (node.nodeValue !== "") {
+      segments.push({ text: node.nodeValue, styles: inheritedStyles });
+    }
+    return segments;
+  }
+
+  const nextStyles = node.textStyles
+    ? { ...inheritedStyles, ...node.textStyles }
+    : inheritedStyles;
+
+  for (const child of node.childNodes) {
+    collectTextSegments(child, nextStyles, segments);
+  }
+
+  return segments;
+}
+
+function findBoxWithMinWidth(
+  node: DOMNode,
+  minWidth: number,
+): DOMElement | null {
+  if (node.nodeName === "#text") {
+    return null;
+  }
+
+  if (node.nodeName === "ink-box" && node.style.minWidth === minWidth) {
+    return node;
+  }
+
+  for (const child of node.childNodes) {
+    const found = findBoxWithMinWidth(child, minWidth);
+    if (found) {
+      return found;
+    }
+  }
+
+  return null;
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe("MessageModel wave200 coverage", () => {
+  test("renders only transcript assistant models that accompany text content", async () => {
+    const visibleModel = "gpt-4.1-mini";
+    const hiddenTranscriptModel = "hidden-transcript-model";
+    const hiddenUserModel = "hidden-user-model";
+    const hiddenToolOnlyModel = "hidden-tool-only-model";
+    const messages = [
+      {
+        isTranscriptMode: false,
+        message: assistantMessage("not-transcript", hiddenTranscriptModel, [
+          { text: "not transcript", type: "text" },
+        ]),
+      },
+      {
+        isTranscriptMode: true,
+        message: userMessage("user-message", hiddenUserModel),
+      },
+      {
+        isTranscriptMode: true,
+        message: assistantMessage("missing-model", undefined, [
+          { text: "missing model", type: "text" },
+        ]),
+      },
+      {
+        isTranscriptMode: true,
+        message: assistantMessage("tool-only", hiddenToolOnlyModel, [
+          { id: "tool-1", input: {}, name: "Read", type: "tool_use" },
+        ]),
+      },
+      {
+        isTranscriptMode: true,
+        message: assistantMessage("visible-model", visibleModel, [
+          { id: "tool-2", input: {}, name: "Read", type: "tool_use" },
+          { text: "visible answer", type: "text" },
+        ]),
+      },
+    ];
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+    const renderMessages = () => (
+      <>
+        {messages.map(({ isTranscriptMode, message }) => (
+          <MessageModel
+            key={message.uuid}
+            isTranscriptMode={isTranscriptMode}
+            message={message}
+          />
+        ))}
+      </>
+    );
+
+    try {
+      root.render(renderMessages());
+      await sleep();
+      root.render(renderMessages());
+      await sleep();
+
+      const rootNode = getRootNode(stdout);
+      const segments = collectTextSegments(rootNode);
+
+      expect(segments).toEqual([
+        {
+          text: visibleModel,
+          styles: expect.objectContaining({
+            color: expect.any(String),
+          }),
+        },
+      ]);
+      expect(findBoxWithMinWidth(rootNode, stringWidth(visibleModel) + 8)).not.toBeNull();
+      expect(segments.map(segment => segment.text).join("")).not.toContain(
+        "hidden",
+      );
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+});

--- a/runtime/tests/tui/components/MessageRow.render.test.tsx
+++ b/runtime/tests/tui/components/MessageRow.render.test.tsx
@@ -1,0 +1,498 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  calls: [] as Array<{ name: string; props: Record<string, unknown> }>,
+  collapsibleTools: new Set<string>(),
+  staticMessages: new Set<string>(),
+  reset() {
+    harness.calls = [];
+    harness.collapsibleTools = new Set();
+    harness.staticMessages = new Set();
+  },
+}));
+
+vi.mock("../../utils/collapseReadSearch.js", () => ({
+  getDisplayMessageFromCollapsed: (message: { displayMessage?: unknown }) =>
+    message.displayMessage,
+  getToolSearchOrReadInfo: (name: string) => ({
+    isCollapsible: harness.collapsibleTools.has(name),
+  }),
+  getToolUseIdsFromCollapsedGroup: (message: { toolUseIds?: string[] }) =>
+    message.toolUseIds ?? [],
+  hasAnyToolInProgress: (
+    message: { toolUseIds?: string[] },
+    inProgressToolUseIDs: Set<string>,
+  ) => (message.toolUseIds ?? []).some(id => inProgressToolUseIDs.has(id)),
+}));
+
+vi.mock("../../utils/messages.js", () => ({
+  EMPTY_STRING_SET: new Set<string>(),
+  getProgressMessagesFromLookup: (
+    message: { uuid: string },
+    lookups: { progress?: Record<string, string[]> },
+  ) => lookups.progress?.[message.uuid] ?? [],
+  getSiblingToolUseIDsFromLookup: (
+    message: { uuid: string },
+    lookups: { siblings?: Record<string, string[]> },
+  ) => new Set(lookups.siblings?.[message.uuid] ?? []),
+  getToolUseID: (message: {
+    message?: { content?: Array<{ id?: string; type?: string }> };
+    toolUseID?: string;
+  }) => message.toolUseID ?? message.message?.content?.[0]?.id,
+}));
+
+vi.mock("./Message.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../ink.js");
+  return {
+    hasThinkingContent: (message: {
+      hasThinking?: boolean;
+      message?: { content?: Array<{ type?: string }> };
+    }) =>
+      Boolean(message.hasThinking) ||
+      Boolean(
+        message.message?.content?.some(
+          content =>
+            content.type === "thinking" ||
+            content.type === "redacted_thinking",
+        ),
+      ),
+    Message: (props: Record<string, unknown>) => {
+      const message = props.message as { type: string; uuid: string };
+      harness.calls.push({ name: "Message", props });
+      return ReactModule.createElement(
+        Text,
+        null,
+        `Message:${message.uuid}:${message.type}:${String(props.shouldAnimate)}:${String(props.isStatic)}:${String(props.isActiveCollapsedGroup)}:${String(props.containerWidth ?? "none")}`,
+      );
+    },
+  };
+});
+
+vi.mock("./MessageModel.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../ink.js");
+  return {
+    MessageModel: ({ message }: { readonly message: { uuid: string } }) =>
+      ReactModule.createElement(Text, null, `Model:${message.uuid}`),
+  };
+});
+
+vi.mock("./Messages.js", () => ({
+  shouldRenderStatically: (message: { uuid: string }) =>
+    harness.staticMessages.has(message.uuid),
+}));
+
+vi.mock("./MessageTimestamp.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../ink.js");
+  return {
+    MessageTimestamp: ({ message }: { readonly message: { uuid: string } }) =>
+      ReactModule.createElement(Text, null, `Timestamp:${message.uuid}`),
+  };
+});
+
+vi.mock("./OffscreenFreeze.js", async () => {
+  const ReactModule = await import("react");
+  return {
+    OffscreenFreeze: ({ children }: { readonly children?: React.ReactNode }) => {
+      harness.calls.push({ name: "OffscreenFreeze", props: {} });
+      return ReactModule.createElement(ReactModule.Fragment, null, children);
+    },
+  };
+});
+
+import { createRoot } from "../ink/root.js";
+import {
+  allToolsResolved,
+  areMessageRowPropsEqual,
+  hasContentAfterIndex,
+  isMessageStreaming,
+  MessageRow,
+  type Props,
+} from "./MessageRow.js";
+
+function createStreams(): {
+  stdout: PassThrough;
+  stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+} {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.resume();
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function textBlock(text = "hello"): Record<string, unknown> {
+  return { text, type: "text" };
+}
+
+function toolUseBlock(
+  id: string,
+  name = "Agent",
+  input: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return { id, input, name, type: "tool_use" };
+}
+
+function assistant(
+  uuid: string,
+  content: Record<string, unknown>[],
+  overrides: Record<string, unknown> = {},
+): Props["message"] {
+  return {
+    message: {
+      content,
+      model: overrides.model,
+    },
+    type: "assistant",
+    uuid,
+    ...overrides,
+  } as Props["message"];
+}
+
+function userToolResult(uuid: string): Props["message"] {
+  return {
+    message: { content: [{ content: "done", tool_use_id: "tool-1", type: "tool_result" }] },
+    type: "user",
+    uuid,
+  } as Props["message"];
+}
+
+function groupedMessage(
+  uuid: string,
+  ids: string[],
+  toolName = "Agent",
+): Props["message"] {
+  return {
+    displayMessage: assistant(`${uuid}-display`, [textBlock("grouped display")]),
+    messages: ids.map(id => assistant(`${uuid}-${id}`, [toolUseBlock(id, toolName)])),
+    toolName,
+    type: "grouped_tool_use",
+    uuid,
+  } as Props["message"];
+}
+
+function collapsedMessage(
+  uuid: string,
+  ids: string[],
+  display: Props["message"] = assistant(`${uuid}-display`, [textBlock("collapsed display")]),
+): Props["message"] {
+  return {
+    displayMessage: display,
+    messages: [],
+    toolUseIds: ids,
+    type: "collapsed_read_search",
+    uuid,
+  } as Props["message"];
+}
+
+function baseLookups(overrides: Record<string, unknown> = {}): Props["lookups"] {
+  return {
+    erroredToolUseIDs: new Set<string>(),
+    resolvedToolUseIDs: new Set<string>(),
+    ...overrides,
+  } as Props["lookups"];
+}
+
+function baseProps(message: Props["message"], overrides: Partial<Props> = {}): Props {
+  return {
+    canAnimate: true,
+    columns: 44,
+    commands: [],
+    hasContentAfter: false,
+    inProgressToolUseIDs: new Set<string>(),
+    isLoading: false,
+    isUserContinuation: false,
+    lastThinkingBlockId: null,
+    latestBashOutputUUID: null,
+    lookups: baseLookups(),
+    message,
+    screen: "prompt",
+    streamingToolUseIDs: new Set<string>(),
+    tools: [] as never,
+    verbose: false,
+    ...overrides,
+  };
+}
+
+async function renderRow(props: Props): Promise<{
+  dispose: () => Promise<void>;
+  output: () => string;
+}> {
+  let output = "";
+  const { stdin, stdout } = createStreams();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+  root.render(<MessageRow {...props} />);
+  await sleep();
+  return {
+    dispose: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    },
+    output: () => stripAnsi(output),
+  };
+}
+
+describe("MessageRow helpers", () => {
+  beforeEach(() => {
+    harness.reset();
+  });
+
+  test("finds only non-skippable content after an index", () => {
+    harness.collapsibleTools.add("Read");
+    const messages = [
+      collapsedMessage("current", ["read-live"]),
+      assistant("thinking", [{ type: "thinking" }]),
+      { type: "system", uuid: "system" },
+      { type: "attachment", uuid: "attachment" },
+      userToolResult("tool-result"),
+      assistant("collapsed-read-tool", [toolUseBlock("read-1", "Read")]),
+      assistant("streaming-tool", [toolUseBlock("stream-1", "Agent")]),
+      groupedMessage("grouped-collapsible", ["read-2"], "Read"),
+      groupedMessage("grouped-real", ["agent-2"], "Agent"),
+    ] as Props["message"][];
+
+    expect(
+      hasContentAfterIndex(messages, 0, [] as never, new Set(["stream-1"])),
+    ).toBe(true);
+    expect(
+      hasContentAfterIndex(messages.slice(0, -1), 0, [] as never, new Set(["stream-1"])),
+    ).toBe(false);
+    expect(
+      hasContentAfterIndex(
+        [...messages.slice(0, -1), assistant("text", [textBlock("done")])],
+        0,
+        [] as never,
+        new Set(["stream-1"]),
+      ),
+    ).toBe(true);
+  });
+
+  test("detects streaming and resolved tool state across row variants", () => {
+    const normal = assistant("normal", [toolUseBlock("tool-normal")]);
+    const grouped = groupedMessage("grouped", ["tool-a", "tool-b"]);
+    const collapsed = collapsedMessage("collapsed", ["tool-c", "tool-d"]);
+    const serverTool = assistant("server", [{ id: "server-tool", type: "server_tool_use" }]);
+
+    expect(isMessageStreaming(normal, new Set(["tool-normal"]))).toBe(true);
+    expect(isMessageStreaming(grouped, new Set(["tool-b"]))).toBe(true);
+    expect(isMessageStreaming(collapsed, new Set(["tool-d"]))).toBe(true);
+    expect(isMessageStreaming(assistant("text", [textBlock()]), new Set(["x"]))).toBe(false);
+
+    expect(allToolsResolved(normal, new Set(["tool-normal"]))).toBe(true);
+    expect(allToolsResolved(grouped, new Set(["tool-a", "tool-b"]))).toBe(true);
+    expect(allToolsResolved(collapsed, new Set(["tool-c", "tool-d"]))).toBe(true);
+    expect(allToolsResolved(serverTool, new Set(["server-tool"]))).toBe(true);
+    expect(allToolsResolved(grouped, new Set(["tool-a"]))).toBe(false);
+    expect(allToolsResolved(assistant("text", [textBlock()]), new Set())).toBe(true);
+  });
+
+  test("memo comparator re-renders for dynamic rows and skips static rows", () => {
+    const message = assistant("memo", [toolUseBlock("memo-tool")]);
+    const staticProps = baseProps(message, {
+      latestBashOutputUUID: "other",
+      lookups: baseLookups({ resolvedToolUseIDs: new Set(["memo-tool"]) }),
+    });
+
+    expect(areMessageRowPropsEqual(staticProps, { ...staticProps })).toBe(true);
+    expect(
+      areMessageRowPropsEqual(staticProps, {
+        ...staticProps,
+        columns: staticProps.columns + 1,
+      }),
+    ).toBe(false);
+    expect(
+      areMessageRowPropsEqual(staticProps, {
+        ...staticProps,
+        screen: "transcript",
+      }),
+    ).toBe(false);
+    expect(
+      areMessageRowPropsEqual(staticProps, {
+        ...staticProps,
+        verbose: !staticProps.verbose,
+      }),
+    ).toBe(false);
+    expect(
+      areMessageRowPropsEqual(staticProps, {
+        ...staticProps,
+        latestBashOutputUUID: message.uuid,
+      }),
+    ).toBe(false);
+    expect(
+      areMessageRowPropsEqual(
+        { ...staticProps, streamingToolUseIDs: new Set(["memo-tool"]) },
+        staticProps,
+      ),
+    ).toBe(false);
+    expect(
+      areMessageRowPropsEqual(
+        {
+          ...staticProps,
+          lookups: baseLookups({ resolvedToolUseIDs: new Set<string>() }),
+        },
+        staticProps,
+      ),
+    ).toBe(false);
+
+    const thinking = assistant("thinking-memo", [{ type: "thinking" }]);
+    const thinkingProps = baseProps(thinking);
+    expect(
+      areMessageRowPropsEqual(thinkingProps, {
+        ...thinkingProps,
+        lastThinkingBlockId: "new-thinking",
+      }),
+    ).toBe(false);
+
+    const collapsed = baseProps(collapsedMessage("collapsed-memo", ["tool-1"]), {
+      lookups: baseLookups({ resolvedToolUseIDs: new Set(["tool-1"]) }),
+      screen: "prompt",
+    });
+    expect(areMessageRowPropsEqual(collapsed, collapsed)).toBe(false);
+  });
+});
+
+describe("MessageRow rendering", () => {
+  beforeEach(() => {
+    harness.reset();
+  });
+
+  test("passes prompt row state to the message renderer", async () => {
+    const message = assistant("assistant-live", [toolUseBlock("tool-live")]);
+    harness.staticMessages.add(message.uuid);
+    const rendered = await renderRow(
+      baseProps(message, {
+        inProgressToolUseIDs: new Set(["tool-live"]),
+        isUserContinuation: true,
+        lookups: baseLookups({
+          progress: { [message.uuid]: ["first", "second"] },
+          resolvedToolUseIDs: new Set(["tool-live"]),
+          siblings: { [message.uuid]: ["tool-sibling"] },
+        }),
+      }),
+    );
+
+    try {
+      expect(rendered.output()).toContain("Message:assistant-live:assistant:true:true:false:44");
+      const call = harness.calls.find(item => item.name === "Message");
+      expect(call?.props).toMatchObject({
+        addMargin: true,
+        containerWidth: 44,
+        isActiveCollapsedGroup: false,
+        isStatic: true,
+        isTranscriptMode: false,
+        isUserContinuation: true,
+        progressMessagesForMessage: ["first", "second"],
+        shouldAnimate: true,
+        shouldShowDot: true,
+      });
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("renders transcript metadata and lets metadata rows own width", async () => {
+    const message = assistant(
+      "assistant-transcript",
+      [textBlock("with metadata")],
+      { timestamp: "2026-05-20T00:00:00.000Z", model: "grok-4.3" },
+    );
+    const rendered = await renderRow(
+      baseProps(message, {
+        columns: 60,
+        lookups: baseLookups(),
+        screen: "transcript",
+      }),
+    );
+
+    try {
+      const output = rendered.output();
+      expect(output).toContain("Timestamp:assistant-transcript");
+      expect(output).toContain("Model:assistant-transcript");
+      expect(output).toContain("Message:assistant-transcript:assistant:true:false:false:none");
+      expect(harness.calls.find(item => item.name === "Message")?.props).toMatchObject({
+        addMargin: false,
+        containerWidth: undefined,
+        isTranscriptMode: true,
+      });
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("normalizes grouped and collapsed rows before rendering", async () => {
+    const grouped = groupedMessage("grouped-row", ["tool-a", "tool-live"]);
+    const collapsed = collapsedMessage("collapsed-row", ["read-live"]);
+
+    const groupedRender = await renderRow(
+      baseProps(grouped, {
+        inProgressToolUseIDs: new Set(["tool-live"]),
+      }),
+    );
+    const collapsedRender = await renderRow(
+      baseProps(collapsed, {
+        inProgressToolUseIDs: new Set(["read-live"]),
+        isLoading: true,
+      }),
+    );
+
+    try {
+      expect(groupedRender.output()).toContain("Message:grouped-row:grouped_tool_use:true:false:false:44");
+      expect(collapsedRender.output()).toContain("Message:collapsed-row:collapsed_read_search:true:false:true:44");
+      const groupedCall = harness.calls.find(
+        item =>
+          item.name === "Message" &&
+          (item.props.message as { uuid: string }).uuid === "grouped-row",
+      );
+      const collapsedCall = harness.calls.find(
+        item =>
+          item.name === "Message" &&
+          (item.props.message as { uuid: string }).uuid === "collapsed-row",
+      );
+      expect(groupedCall?.props).toMatchObject({
+        isActiveCollapsedGroup: false,
+        progressMessagesForMessage: [],
+        shouldAnimate: true,
+      });
+      expect(collapsedCall?.props).toMatchObject({
+        isActiveCollapsedGroup: true,
+        progressMessagesForMessage: [],
+        shouldAnimate: true,
+      });
+    } finally {
+      await groupedRender.dispose();
+      await collapsedRender.dispose();
+    }
+  });
+});

--- a/runtime/tests/tui/components/MessageRow.wave200-094.coverage.test.tsx
+++ b/runtime/tests/tui/components/MessageRow.wave200-094.coverage.test.tsx
@@ -1,0 +1,196 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  messageCalls: 0,
+  staticCalls: 0,
+}));
+
+vi.mock("../../utils/collapseReadSearch.js", () => ({
+  getDisplayMessageFromCollapsed: (message: { displayMessage?: unknown }) =>
+    message.displayMessage,
+  getToolSearchOrReadInfo: () => ({ isCollapsible: false }),
+  getToolUseIdsFromCollapsedGroup: (message: { toolUseIds?: string[] }) =>
+    message.toolUseIds ?? [],
+  hasAnyToolInProgress: (
+    message: { toolUseIds?: string[] },
+    inProgressToolUseIDs: Set<string>,
+  ) => (message.toolUseIds ?? []).some(id => inProgressToolUseIDs.has(id)),
+}));
+
+vi.mock("../../utils/messages.js", () => ({
+  EMPTY_STRING_SET: new Set<string>(),
+  getProgressMessagesFromLookup: (
+    message: { uuid: string },
+    lookups: { progress?: Record<string, string[]> },
+  ) => lookups.progress?.[message.uuid] ?? [],
+  getSiblingToolUseIDsFromLookup: (
+    message: { uuid: string },
+    lookups: { siblings?: Record<string, string[]> },
+  ) => new Set(lookups.siblings?.[message.uuid] ?? []),
+  getToolUseID: (message: {
+    message?: { content?: Array<{ id?: string; type?: string }> };
+    toolUseID?: string;
+  }) => message.toolUseID ?? message.message?.content?.[0]?.id,
+}));
+
+vi.mock("./Message.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../ink.js");
+  return {
+    hasThinkingContent: () => false,
+    Message: (props: Record<string, unknown>) => {
+      harness.messageCalls++;
+      const message = props.message as { uuid: string };
+      const progress = props.progressMessagesForMessage as string[];
+      return ReactModule.createElement(
+        Text,
+        null,
+        `message:${message.uuid}:${String(props.shouldAnimate)}:${progress.join(",")}`,
+      );
+    },
+  };
+});
+
+vi.mock("./MessageModel.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../ink.js");
+  return {
+    MessageModel: () => ReactModule.createElement(Text, null, "model"),
+  };
+});
+
+vi.mock("./MessageTimestamp.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../ink.js");
+  return {
+    MessageTimestamp: () => ReactModule.createElement(Text, null, "time"),
+  };
+});
+
+vi.mock("./Messages.js", () => ({
+  shouldRenderStatically: () => {
+    harness.staticCalls++;
+    return false;
+  },
+}));
+
+vi.mock("./OffscreenFreeze.js", async () => {
+  const ReactModule = await import("react");
+  return {
+    OffscreenFreeze: ({ children }: { readonly children?: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+  };
+});
+
+import { createRoot } from "../ink/root.js";
+import { MessageRow, type Props } from "./MessageRow.js";
+
+function createStreams(): {
+  stdout: PassThrough;
+  stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+} {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.resume();
+  return { stdin, stdout };
+}
+
+async function sleep(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 25));
+}
+
+function toolMessage(): Props["message"] {
+  return {
+    message: {
+      content: [
+        {
+          id: "tool-live",
+          input: {},
+          name: "Agent",
+          type: "tool_use",
+        },
+      ],
+    },
+    type: "assistant",
+    uuid: "cache-row",
+  } as Props["message"];
+}
+
+function rowProps(message: Props["message"]): Props {
+  return {
+    canAnimate: true,
+    columns: 52,
+    commands: [],
+    hasContentAfter: false,
+    inProgressToolUseIDs: new Set(["tool-live"]),
+    isLoading: false,
+    isUserContinuation: false,
+    lastThinkingBlockId: null,
+    latestBashOutputUUID: null,
+    lookups: {
+      erroredToolUseIDs: new Set<string>(),
+      progress: { [message.uuid]: ["queued"] },
+      resolvedToolUseIDs: new Set<string>(),
+    } as Props["lookups"],
+    message,
+    screen: "prompt",
+    streamingToolUseIDs: new Set<string>(),
+    tools: [] as never,
+    verbose: false,
+  };
+}
+
+describe("MessageRow wave 094 coverage", () => {
+  beforeEach(() => {
+    harness.messageCalls = 0;
+    harness.staticCalls = 0;
+  });
+
+  test("rerenders unresolved tool rows without rebuilding stable child props", async () => {
+    let output = "";
+    const { stdin, stdout } = createStreams();
+    stdout.on("data", chunk => {
+      output += chunk.toString();
+    });
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+    const props = rowProps(toolMessage());
+
+    try {
+      root.render(<MessageRow {...props} />);
+      await sleep();
+      root.render(<MessageRow {...props} />);
+      await sleep();
+
+      expect(stripAnsi(output)).toContain("message:cache-row:true:queued");
+      expect(harness.staticCalls).toBe(1);
+      expect(harness.messageCalls).toBe(1);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+});

--- a/runtime/tests/tui/components/MessageSelector.coverage.test.tsx
+++ b/runtime/tests/tui/components/MessageSelector.coverage.test.tsx
@@ -1,0 +1,267 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+type CapturedSelectProps = {
+  defaultFocusValue?: string
+  onChange: (value: string) => void | Promise<void>
+  onFocus: (value: string) => void
+  options: Array<{
+    label: string
+    value: string
+  }>
+}
+
+const harness = vi.hoisted(() => ({
+  appState: { fileHistory: { entries: [] } },
+  diffStats: {
+    deletions: 1,
+    filesChanged: ['/tmp/failing.ts'],
+    insertions: 3,
+  },
+  keybindings: {} as Record<string, () => unknown>,
+  logError: vi.fn(),
+  logEvent: vi.fn(),
+  selectProps: null as CapturedSelectProps | null,
+  reset() {
+    harness.diffStats = {
+      deletions: 1,
+      filesChanged: ['/tmp/failing.ts'],
+      insertions: 3,
+    }
+    harness.keybindings = {}
+    harness.logError.mockClear()
+    harness.logEvent.mockClear()
+    harness.selectProps = null
+  },
+}))
+
+vi.mock('../../services/analytics/index.js', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppState: (selector: (state: unknown) => unknown) =>
+    selector(harness.appState),
+}))
+
+vi.mock('../../utils/fileHistory.js', () => ({
+  fileHistoryCanRestore: () => true,
+  fileHistoryEnabled: () => true,
+  fileHistoryGetDiffStats: vi.fn(async () => harness.diffStats),
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: harness.logError,
+}))
+
+vi.mock('src/tui/hooks/useExitOnCtrlCDWithKeybindings.js', () => ({
+  useExitOnCtrlCDWithKeybindings: () => ({
+    keyName: 'ctrl+c',
+    pending: false,
+  }),
+}))
+
+vi.mock('../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: 80, rows: 24 }),
+}))
+
+vi.mock('../keybindings/useKeybinding.js', () => ({
+  useKeybinding: (name: string, handler: () => unknown) => {
+    harness.keybindings[name] = handler
+  },
+  useKeybindings: (handlers: Record<string, () => unknown>) => {
+    Object.assign(harness.keybindings, handlers)
+  },
+}))
+
+vi.mock('./CustomSelect/select', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../ink.js')
+
+  return {
+    Select: (props: CapturedSelectProps) => {
+      harness.selectProps = props
+
+      return ReactModule.createElement(
+        ReactModule.Fragment,
+        null,
+        props.options.map(option =>
+          ReactModule.createElement(Text, { key: option.value }, option.label),
+        ),
+      )
+    },
+  }
+})
+
+import { createRoot } from '../ink/root.js'
+import type { Message, UserMessage } from '../../types/message.js'
+import { MessageSelector } from './MessageSelector.js'
+
+function userMessage(uuid: string, text: string): UserMessage {
+  return {
+    message: { content: [{ text, type: 'text' }] },
+    timestamp: '2026-05-20T00:00:00.000Z',
+    type: 'user',
+    uuid,
+  } as UserMessage
+}
+
+function assistantMessage(uuid: string, text: string): Message {
+  return {
+    message: { content: [{ text, type: 'text' }] },
+    type: 'assistant',
+    uuid,
+  } as Message
+}
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForSelectOption(value: string): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (harness.selectProps?.options.some(option => option.value === value)) {
+      return
+    }
+    await sleep(10)
+  }
+
+  throw new Error(`Timed out waiting for restore option: ${value}`)
+}
+
+async function waitForOutput(
+  output: () => string,
+  expected: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (output().includes(expected)) {
+      return
+    }
+    await sleep(10)
+  }
+
+  throw new Error(`Timed out waiting for output: ${expected}`)
+}
+
+async function renderSelector(props: {
+  messages: Message[]
+  onClose?: () => void
+  onPreRestore?: () => void
+  onRestoreCode?: (message: UserMessage) => Promise<void>
+  onRestoreMessage?: (message: UserMessage) => Promise<void>
+  onSummarize?: (
+    message: UserMessage,
+    feedback?: string,
+    direction?: 'from' | 'up_to',
+  ) => Promise<void>
+  preselectedMessage?: UserMessage
+}): Promise<{
+  dispose: () => Promise<void>
+  output: () => string
+}> {
+  let output = ''
+  const { stdin, stdout } = createStreams()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  root.render(
+    <MessageSelector
+      messages={props.messages}
+      onClose={props.onClose ?? vi.fn()}
+      onPreRestore={props.onPreRestore ?? vi.fn()}
+      onRestoreCode={props.onRestoreCode ?? vi.fn(async () => {})}
+      onRestoreMessage={props.onRestoreMessage ?? vi.fn(async () => {})}
+      onSummarize={props.onSummarize ?? vi.fn(async () => {})}
+      preselectedMessage={props.preselectedMessage}
+    />,
+  )
+  await sleep()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    output: () => stripAnsi(output),
+  }
+}
+
+describe('MessageSelector coverage', () => {
+  beforeEach(() => {
+    harness.reset()
+  })
+
+  test('reports code-only restore failures without restoring the conversation', async () => {
+    const selected = userMessage('user-1', 'restore only the code')
+    const onPreRestore = vi.fn()
+    const onRestoreCode = vi.fn(async () => {
+      throw new Error('restore exploded')
+    })
+    const onRestoreMessage = vi.fn(async () => {})
+    const onClose = vi.fn()
+    const rendered = await renderSelector({
+      messages: [selected, assistantMessage('assistant-1', 'reply')],
+      onClose,
+      onPreRestore,
+      onRestoreCode,
+      onRestoreMessage,
+      preselectedMessage: selected,
+    })
+
+    try {
+      await waitForSelectOption('code')
+      harness.selectProps?.onFocus('code')
+      await sleep()
+
+      expect(rendered.output()).toContain('The conversation will be unchanged.')
+      expect(rendered.output()).toContain('The code will be restored')
+
+      await harness.selectProps?.onChange('code')
+      await waitForOutput(rendered.output, 'Failed to restore the code:')
+
+      expect(onPreRestore).toHaveBeenCalledTimes(1)
+      expect(onRestoreCode).toHaveBeenCalledWith(selected)
+      expect(onRestoreMessage).not.toHaveBeenCalled()
+      expect(onClose).not.toHaveBeenCalled()
+      expect(harness.logError).toHaveBeenCalledWith(expect.any(Error))
+      expect(rendered.output()).toContain('Error: restore exploded')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/components/MessageSelector.coverage2.test.tsx
+++ b/runtime/tests/tui/components/MessageSelector.coverage2.test.tsx
@@ -1,0 +1,184 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  appState: { fileHistory: { entries: [] } },
+  logEvent: vi.fn(),
+  reset() {
+    harness.logEvent.mockClear()
+  },
+}))
+
+vi.mock('../../services/analytics/index.js', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppState: (selector: (state: unknown) => unknown) =>
+    selector(harness.appState),
+}))
+
+vi.mock('../../utils/fileHistory.js', () => ({
+  fileHistoryCanRestore: () => false,
+  fileHistoryEnabled: () => true,
+  fileHistoryGetDiffStats: vi.fn(async () => ({
+    deletions: 0,
+    filesChanged: [],
+    insertions: 0,
+  })),
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: vi.fn(),
+}))
+
+vi.mock('src/tui/hooks/useExitOnCtrlCDWithKeybindings.js', () => ({
+  useExitOnCtrlCDWithKeybindings: () => ({
+    keyName: 'ctrl+c',
+    pending: false,
+  }),
+}))
+
+vi.mock('../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: 80, rows: 24 }),
+}))
+
+vi.mock('../keybindings/useKeybinding.js', () => ({
+  useKeybinding: vi.fn(),
+  useKeybindings: vi.fn(),
+}))
+
+vi.mock('./CustomSelect/select', () => ({
+  Select: () => null,
+}))
+
+import { createRoot } from '../ink/root.js'
+import type { Message, UserMessage } from '../../types/message.js'
+import { MessageSelector } from './MessageSelector.js'
+
+function userMessage(uuid: string, text: string): UserMessage {
+  return {
+    message: { content: [{ text, type: 'text' }] },
+    timestamp: '2026-05-20T00:00:00.000Z',
+    type: 'user',
+    uuid,
+  } as UserMessage
+}
+
+function assistantMessage(uuid: string, text: string): Message {
+  return {
+    message: { content: [{ text, type: 'text' }] },
+    type: 'assistant',
+    uuid,
+  } as Message
+}
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForOutput(
+  output: () => string,
+  expected: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (output().includes(expected)) {
+      return
+    }
+    await sleep(10)
+  }
+
+  throw new Error(`Timed out waiting for output: ${expected}`)
+}
+
+async function renderSelector(messages: Message[]): Promise<{
+  dispose: () => Promise<void>
+  output: () => string
+}> {
+  let output = ''
+  const { stdin, stdout } = createStreams()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  root.render(
+    <MessageSelector
+      messages={messages}
+      onClose={vi.fn()}
+      onPreRestore={vi.fn()}
+      onRestoreCode={vi.fn(async () => {})}
+      onRestoreMessage={vi.fn(async () => {})}
+      onSummarize={vi.fn(async () => {})}
+    />,
+  )
+  await sleep()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    output: () => stripAnsi(output),
+  }
+}
+
+describe('MessageSelector coverage for non-restorable pick-list rows', () => {
+  beforeEach(() => {
+    harness.reset()
+  })
+
+  test('shows terminal input text with a no-code-restore warning', async () => {
+    const rendered = await renderSelector([
+      userMessage('user-1', '<bash-input>npm test</bash-input>'),
+      assistantMessage('assistant-1', 'done'),
+    ])
+
+    try {
+      await waitForOutput(rendered.output, 'No code restore')
+
+      expect(rendered.output()).toContain('! npm test')
+      expect(rendered.output()).toContain('No code restore')
+      expect(rendered.output()).toContain('(current)')
+      expect(harness.logEvent).toHaveBeenCalledWith(
+        'agenc_message_selector_opened',
+        {},
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/components/MessageSelector.render.test.tsx
+++ b/runtime/tests/tui/components/MessageSelector.render.test.tsx
@@ -1,0 +1,316 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  appState: { fileHistory: { entries: [] } },
+  diffStats: {
+    deletions: 2,
+    filesChanged: ['/tmp/foo.ts', '/tmp/bar.ts'],
+    insertions: 5,
+  },
+  fileHistoryEnabled: true,
+  keybindings: {} as Record<string, () => unknown>,
+  logError: vi.fn(),
+  logEvent: vi.fn(),
+  selectProps: null as null | {
+    onCancel: () => void
+    onChange: (value: string) => void
+    onFocus: (value: string) => void
+    options: Array<{
+      label: string
+      onChange?: (value: string) => void
+      value: string
+    }>
+  },
+  reset() {
+    harness.diffStats = {
+      deletions: 2,
+      filesChanged: ['/tmp/foo.ts', '/tmp/bar.ts'],
+      insertions: 5,
+    }
+    harness.fileHistoryEnabled = true
+    harness.keybindings = {}
+    harness.logError.mockClear()
+    harness.logEvent.mockClear()
+    harness.selectProps = null
+  },
+}))
+
+vi.mock('../../services/analytics/index.js', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppState: (selector: (state: unknown) => unknown) =>
+    selector(harness.appState),
+}))
+
+vi.mock('../../utils/fileHistory.js', () => ({
+  fileHistoryCanRestore: () => true,
+  fileHistoryEnabled: () => harness.fileHistoryEnabled,
+  fileHistoryGetDiffStats: vi.fn(async () => harness.diffStats),
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: harness.logError,
+}))
+
+vi.mock('src/tui/hooks/useExitOnCtrlCDWithKeybindings.js', () => ({
+  useExitOnCtrlCDWithKeybindings: () => ({
+    keyName: 'ctrl+c',
+    pending: false,
+  }),
+}))
+
+vi.mock('../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: 80, rows: 24 }),
+}))
+
+vi.mock('../keybindings/useKeybinding.js', () => ({
+  useKeybinding: (name: string, handler: () => unknown) => {
+    harness.keybindings[name] = handler
+  },
+  useKeybindings: (handlers: Record<string, () => unknown>) => {
+    Object.assign(harness.keybindings, handlers)
+  },
+}))
+
+vi.mock('./CustomSelect/select', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../ink.js')
+  return {
+    Select: (props: typeof harness.selectProps) => {
+      harness.selectProps = props
+      return ReactModule.createElement(
+        ReactModule.Fragment,
+        null,
+        props?.options.map(option =>
+          ReactModule.createElement(Text, { key: option.value }, option.label),
+        ),
+      )
+    },
+  }
+})
+
+import { createRoot } from '../ink/root.js'
+import type { Message, UserMessage } from '../../types/message.js'
+import { MessageSelector } from './MessageSelector.js'
+
+function userMessage(uuid: string, text: string): UserMessage {
+  return {
+    message: { content: [{ text, type: 'text' }] },
+    timestamp: '2026-05-20T00:00:00.000Z',
+    type: 'user',
+    uuid,
+  } as UserMessage
+}
+
+function assistantMessage(uuid: string, text: string): Message {
+  return {
+    message: { content: [{ text, type: 'text' }] },
+    type: 'assistant',
+    uuid,
+  } as Message
+}
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderSelector(props: {
+  messages: Message[]
+  onClose?: () => void
+  onPreRestore?: () => void
+  onRestoreCode?: (message: UserMessage) => Promise<void>
+  onRestoreMessage?: (message: UserMessage) => Promise<void>
+  onSummarize?: (
+    message: UserMessage,
+    feedback?: string,
+    direction?: 'from' | 'up_to',
+  ) => Promise<void>
+  preselectedMessage?: UserMessage
+}): Promise<{
+  dispose: () => Promise<void>
+  output: () => string
+}> {
+  let output = ''
+  const { stdin, stdout } = createStreams()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  root.render(
+    <MessageSelector
+      messages={props.messages}
+      onClose={props.onClose ?? vi.fn()}
+      onPreRestore={props.onPreRestore ?? vi.fn()}
+      onRestoreCode={props.onRestoreCode ?? vi.fn(async () => {})}
+      onRestoreMessage={props.onRestoreMessage ?? vi.fn(async () => {})}
+      onSummarize={props.onSummarize ?? vi.fn(async () => {})}
+      preselectedMessage={props.preselectedMessage}
+    />,
+  )
+  await sleep()
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    output: () => stripAnsi(output),
+  }
+}
+
+describe('MessageSelector render paths', () => {
+  beforeEach(() => {
+    harness.reset()
+  })
+
+  test('renders the empty state and closes through the confirmation escape binding', async () => {
+    harness.fileHistoryEnabled = false
+    const onClose = vi.fn()
+    const rendered = await renderSelector({ messages: [], onClose })
+
+    try {
+      expect(rendered.output()).toContain('Nothing to rewind to yet.')
+      harness.keybindings['confirm:no']?.()
+      expect(harness.logEvent).toHaveBeenCalledWith(
+        'agenc_message_selector_cancelled',
+        {},
+      )
+      expect(onClose).toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('selects an earlier message and directly restores conversation when file history is disabled', async () => {
+    harness.fileHistoryEnabled = false
+    const first = userMessage('user-1', 'restore from this prompt')
+    const messages = [first, assistantMessage('assistant-1', 'reply')]
+    const onPreRestore = vi.fn()
+    const onRestoreMessage = vi.fn(async () => {})
+    const onClose = vi.fn()
+    const rendered = await renderSelector({
+      messages,
+      onClose,
+      onPreRestore,
+      onRestoreMessage,
+    })
+
+    try {
+      expect(rendered.output()).toContain(
+        'Restore and fork the conversation to the point before',
+      )
+      harness.keybindings['messageSelector:up']?.()
+      await sleep()
+      harness.keybindings['messageSelector:select']?.()
+      await sleep()
+
+      expect(onPreRestore).toHaveBeenCalled()
+      expect(onRestoreMessage).toHaveBeenCalledWith(first)
+      expect(onClose).toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('confirms preselected code and conversation restore with diff stats', async () => {
+    const selected = userMessage('user-1', 'restore code too')
+    const onPreRestore = vi.fn()
+    const onRestoreCode = vi.fn(async () => {})
+    const onRestoreMessage = vi.fn(async () => {})
+    const onClose = vi.fn()
+    const rendered = await renderSelector({
+      messages: [selected, assistantMessage('assistant-1', 'reply')],
+      onClose,
+      onPreRestore,
+      onRestoreCode,
+      onRestoreMessage,
+      preselectedMessage: selected,
+    })
+
+    try {
+      await sleep()
+      expect(rendered.output()).toContain('Restore code and conversation')
+      expect(rendered.output()).toContain('foo.ts and bar.ts')
+
+      harness.selectProps?.onFocus('both')
+      harness.selectProps?.onChange('both')
+      await sleep()
+
+      expect(onPreRestore).toHaveBeenCalled()
+      expect(onRestoreCode).toHaveBeenCalledWith(selected)
+      expect(onRestoreMessage).toHaveBeenCalledWith(selected)
+      expect(onClose).toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('submits summarize-up-to feedback and renders summarize failures', async () => {
+    const selected = userMessage('user-1', 'summarize this region')
+    const onSummarize = vi.fn(async () => {
+      throw new Error('summary failed')
+    })
+    const rendered = await renderSelector({
+      messages: [selected, assistantMessage('assistant-1', 'reply')],
+      onSummarize,
+      preselectedMessage: selected,
+    })
+
+    try {
+      await sleep()
+      const summarizeUpTo = harness.selectProps?.options.find(
+        option => option.value === 'summarize_up_to',
+      )
+      summarizeUpTo?.onChange?.('keep this decision')
+      await sleep()
+      harness.selectProps?.onFocus('summarize_up_to')
+      harness.selectProps?.onChange('summarize_up_to')
+      await sleep()
+
+      expect(onSummarize).toHaveBeenCalledWith(
+        selected,
+        'keep this decision',
+        'up_to',
+      )
+      expect(harness.logError).toHaveBeenCalledWith(expect.any(Error))
+      expect(rendered.output()).toContain('Failed to summarize:')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/components/MessageSelector.wave200-013.coverage.test.tsx
+++ b/runtime/tests/tui/components/MessageSelector.wave200-013.coverage.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Message, UserMessage } from '../../types/message.js'
+import { buildMessageSelectorFileHistoryMetadata } from './MessageSelector.js'
+
+function userMessage(uuid: string, text: string): UserMessage {
+  return {
+    message: { content: [{ type: 'text', text }] },
+    timestamp: '2026-05-20T00:00:00.000Z',
+    type: 'user',
+    uuid,
+  } as UserMessage
+}
+
+function toolResultMessage(uuid: string, toolUseResult?: unknown): Message {
+  return {
+    message: {
+      content: [{ content: 'done', tool_use_id: uuid, type: 'tool_result' }],
+    },
+    toolUseResult,
+    type: 'user',
+    uuid,
+  } as Message
+}
+
+describe('MessageSelector file history metadata coverage', () => {
+  it('builds per-message diff stats from bounded tool-result windows', () => {
+    const first = userMessage('user-1', 'restore from here')
+    const second = userMessage('user-2', 'restore later')
+    const missingNext = userMessage('missing-next', 'missing from transcript')
+    const current = userMessage('current-message', '')
+
+    const metadata = buildMessageSelectorFileHistoryMetadata({
+      canRestoreMessage: () => true,
+      currentUUID: current.uuid as never,
+      fileHistory: {} as never,
+      isFileHistoryEnabled: true,
+      messageOptions: [first, second, missingNext, current],
+      messages: [
+        first,
+        toolResultMessage('ignored-no-result'),
+        toolResultMessage('created-file', {
+          content: 'alpha\nbeta',
+          filePath: '/tmp/new-file.ts',
+          structuredPatch: [],
+          type: 'create',
+        }),
+        toolResultMessage('edited-file', {
+          filePath: '/tmp/edited-file.ts',
+          structuredPatch: [
+            {
+              lines: [' context', '+added', '-removed', '+another'],
+              newLines: 3,
+              newStart: 1,
+              oldLines: 2,
+              oldStart: 1,
+            },
+          ],
+        }),
+        toolResultMessage('ignored-no-file', { structuredPatch: [] }),
+        second,
+        toolResultMessage('after-second', {
+          filePath: '/tmp/after-second.ts',
+          structuredPatch: [
+            {
+              lines: ['+after', '-before'],
+              newLines: 1,
+              newStart: 1,
+              oldLines: 1,
+              oldStart: 1,
+            },
+          ],
+        }),
+      ],
+    })
+
+    expect(metadata).toEqual({
+      'missing-next': undefined,
+      'user-1': {
+        deletions: 1,
+        filesChanged: ['/tmp/new-file.ts', '/tmp/edited-file.ts'],
+        insertions: 4,
+      },
+      'user-2': {
+        deletions: 1,
+        filesChanged: ['/tmp/after-second.ts'],
+        insertions: 1,
+      },
+    })
+  })
+})

--- a/runtime/tests/tui/components/MessageTimestamp.wave200-108.coverage.test.tsx
+++ b/runtime/tests/tui/components/MessageTimestamp.wave200-108.coverage.test.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { describe, expect, test } from "vitest";
+
+import type { NormalizedMessage } from "../../types/message.js";
+import { renderToString } from "../../utils/staticRender.js";
+import { Box } from "../ink.js";
+import { MessageTimestamp } from "./MessageTimestamp.js";
+
+function assistantMessage(
+  content: Array<Record<string, unknown>>,
+  timestamp?: string,
+): NormalizedMessage {
+  return {
+    message: { content },
+    timestamp,
+    type: "assistant",
+    uuid: `assistant-${timestamp ?? "missing"}`,
+  } as NormalizedMessage;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+describe("MessageTimestamp wave200 coverage", () => {
+  test("renders only transcript assistant text messages with a formatted timestamp", async () => {
+    const timestamp = new Date(2026, 4, 20, 9, 4).toISOString();
+    const expectedTimestamp = new Date(timestamp).toLocaleTimeString("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: true,
+    });
+
+    const output = await renderToString(
+      <Box flexDirection="column">
+        <MessageTimestamp
+          message={assistantMessage([{ text: "not transcript", type: "text" }], timestamp)}
+          isTranscriptMode={false}
+        />
+        <MessageTimestamp
+          message={assistantMessage([{ text: "missing timestamp", type: "text" }])}
+          isTranscriptMode={true}
+        />
+        <MessageTimestamp
+          message={{
+            message: { content: [{ text: "not assistant", type: "text" }] },
+            timestamp,
+            type: "user",
+            uuid: "user-message",
+          } as NormalizedMessage}
+          isTranscriptMode={true}
+        />
+        <MessageTimestamp
+          message={assistantMessage(
+            [{ id: "tool-use", input: {}, name: "Read", type: "tool_use" }],
+            timestamp,
+          )}
+          isTranscriptMode={true}
+        />
+        <MessageTimestamp
+          message={assistantMessage(
+            [
+              { id: "first-tool", input: {}, name: "Read", type: "tool_use" },
+              { text: "shown", type: "text" },
+            ],
+            timestamp,
+          )}
+          isTranscriptMode={true}
+        />
+      </Box>,
+      { columns: 40 },
+    );
+
+    expect(output).toContain(expectedTimestamp);
+    expect(output.match(new RegExp(escapeRegExp(expectedTimestamp), "g"))).toHaveLength(1);
+  });
+});

--- a/runtime/tests/tui/components/Messages.coverage2.test.tsx
+++ b/runtime/tests/tui/components/Messages.coverage2.test.tsx
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+import { shouldRenderStatically } from './Messages.js'
+
+function lookups(
+  resolvedToolUseIDs: string[] = [],
+  inProgressPostHooks: string[] = [],
+) {
+  return {
+    siblingToolUseIDs: new Map(),
+    progressMessagesByToolUseID: new Map(),
+    inProgressHookCounts: new Map(
+      inProgressPostHooks.map(id => [id, new Map([['PostToolUse', 1]])]),
+    ),
+    resolvedHookCounts: new Map(),
+    toolResultByToolUseID: new Map(),
+    toolUseByToolUseID: new Map(),
+    normalizedMessageCount: 0,
+    resolvedToolUseIDs: new Set(resolvedToolUseIDs),
+    erroredToolUseIDs: new Set(),
+  } as Parameters<typeof shouldRenderStatically>[5]
+}
+
+const emptyIDs = new Set<string>()
+
+describe('shouldRenderStatically', () => {
+  it('keeps unresolved tool, hook, and grouped rows dynamic on the main screen', () => {
+    const settledLookups = lookups([
+      'server-done',
+      'tool-done',
+      'tool-sibling',
+      'group-one',
+      'group-two',
+    ])
+    const pendingHookLookups = lookups(['tool-hook'], ['tool-hook'])
+
+    expect(
+      shouldRenderStatically(
+        { subtype: 'api_error', type: 'system', uuid: 'api-error' } as never,
+        emptyIDs,
+        emptyIDs,
+        emptyIDs,
+        'transcript',
+        settledLookups,
+      ),
+    ).toBe(true)
+
+    expect(
+      shouldRenderStatically(
+        {
+          message: { content: [{ id: 'server-done', type: 'server_tool_use' }] },
+          type: 'assistant',
+          uuid: 'server-done-message',
+        } as never,
+        emptyIDs,
+        emptyIDs,
+        emptyIDs,
+        'main',
+        settledLookups,
+      ),
+    ).toBe(true)
+    expect(
+      shouldRenderStatically(
+        {
+          message: { content: [{ id: 'server-pending', type: 'server_tool_use' }] },
+          type: 'assistant',
+          uuid: 'server-pending-message',
+        } as never,
+        emptyIDs,
+        emptyIDs,
+        emptyIDs,
+        'main',
+        settledLookups,
+      ),
+    ).toBe(false)
+
+    expect(
+      shouldRenderStatically(
+        {
+          message: { content: [{ id: 'tool-streaming', type: 'tool_use' }] },
+          type: 'assistant',
+          uuid: 'streaming-tool-message',
+        } as never,
+        new Set(['tool-streaming']),
+        emptyIDs,
+        emptyIDs,
+        'main',
+        settledLookups,
+      ),
+    ).toBe(false)
+    expect(
+      shouldRenderStatically(
+        {
+          message: { content: [{ id: 'tool-running', type: 'tool_use' }] },
+          type: 'assistant',
+          uuid: 'running-tool-message',
+        } as never,
+        emptyIDs,
+        new Set(['tool-running']),
+        emptyIDs,
+        'main',
+        settledLookups,
+      ),
+    ).toBe(false)
+
+    expect(
+      shouldRenderStatically(
+        {
+          message: {
+            content: [{ tool_use_id: 'tool-hook', type: 'tool_result' }],
+          },
+          type: 'user',
+          uuid: 'hooked-tool-result',
+        } as never,
+        emptyIDs,
+        emptyIDs,
+        emptyIDs,
+        'main',
+        pendingHookLookups,
+      ),
+    ).toBe(false)
+    expect(
+      shouldRenderStatically(
+        {
+          message: {
+            content: [{ tool_use_id: 'tool-done', type: 'tool_result' }],
+          },
+          type: 'user',
+          uuid: 'settled-tool-result',
+        } as never,
+        emptyIDs,
+        emptyIDs,
+        new Set(['tool-done', 'tool-sibling']),
+        'main',
+        settledLookups,
+      ),
+    ).toBe(true)
+    expect(
+      shouldRenderStatically(
+        {
+          message: {
+            content: [{ tool_use_id: 'tool-done', type: 'tool_result' }],
+          },
+          type: 'user',
+          uuid: 'missing-sibling-result',
+        } as never,
+        emptyIDs,
+        emptyIDs,
+        new Set(['tool-done', 'missing-sibling']),
+        'main',
+        settledLookups,
+      ),
+    ).toBe(false)
+
+    expect(
+      shouldRenderStatically(
+        { subtype: 'api_error', type: 'system', uuid: 'main-api-error' } as never,
+        emptyIDs,
+        emptyIDs,
+        emptyIDs,
+        'main',
+        settledLookups,
+      ),
+    ).toBe(false)
+    expect(
+      shouldRenderStatically(
+        { subtype: 'notice', type: 'system', uuid: 'notice' } as never,
+        emptyIDs,
+        emptyIDs,
+        emptyIDs,
+        'main',
+        settledLookups,
+      ),
+    ).toBe(true)
+
+    expect(
+      shouldRenderStatically(
+        {
+          messages: [
+            { message: { content: [{ id: 'group-one', type: 'tool_use' }] } },
+            { message: { content: [{ id: 'group-two', type: 'tool_use' }] } },
+          ],
+          type: 'grouped_tool_use',
+          uuid: 'settled-group',
+        } as never,
+        emptyIDs,
+        emptyIDs,
+        emptyIDs,
+        'main',
+        settledLookups,
+      ),
+    ).toBe(true)
+    expect(
+      shouldRenderStatically(
+        {
+          messages: [
+            { message: { content: [{ id: 'group-one', type: 'tool_use' }] } },
+            { message: { content: [{ id: 'group-pending', type: 'tool_use' }] } },
+          ],
+          type: 'grouped_tool_use',
+          uuid: 'pending-group',
+        } as never,
+        emptyIDs,
+        emptyIDs,
+        emptyIDs,
+        'main',
+        settledLookups,
+      ),
+    ).toBe(false)
+
+    expect(
+      shouldRenderStatically(
+        { messages: [], type: 'collapsed_read_search', uuid: 'collapsed' } as never,
+        emptyIDs,
+        emptyIDs,
+        emptyIDs,
+        'main',
+        settledLookups,
+      ),
+    ).toBe(false)
+  })
+})

--- a/runtime/tests/tui/components/Messages.wave200-007.coverage.test.tsx
+++ b/runtime/tests/tui/components/Messages.wave200-007.coverage.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+import { computeSliceStart, type SliceAnchor } from './Messages.js'
+
+const messages = Array.from({ length: 12 }, (_, index) => ({
+  uuid: `message-${index}`,
+}))
+
+function anchor(current: SliceAnchor): { current: SliceAnchor } {
+  return { current }
+}
+
+describe('computeSliceStart coverage', () => {
+  test('keeps, heals, advances, and clears the slice anchor', () => {
+    const existing = anchor({ uuid: 'message-2', idx: 2 })
+
+    expect(computeSliceStart(messages.slice(0, 8), existing, 5, 2)).toBe(2)
+    expect(existing.current).toEqual({ uuid: 'message-2', idx: 2 })
+
+    const stale = anchor({ uuid: 'removed-message', idx: 7 })
+
+    expect(computeSliceStart(messages, stale, 5, 1)).toBe(7)
+    expect(stale.current).toEqual({ uuid: 'message-7', idx: 7 })
+
+    const advanced = anchor({ uuid: 'removed-message', idx: 0 })
+
+    expect(computeSliceStart(messages, advanced, 5, 1)).toBe(7)
+    expect(advanced.current).toEqual({ uuid: 'message-7', idx: 7 })
+
+    const emptied = anchor({ uuid: 'removed-message', idx: 4 })
+
+    expect(computeSliceStart([], emptied, 5, 1)).toBe(0)
+    expect(emptied.current).toBeNull()
+  })
+})

--- a/runtime/tests/tui/components/ModelPicker.wave200-021.coverage.test.tsx
+++ b/runtime/tests/tui/components/ModelPicker.wave200-021.coverage.test.tsx
@@ -1,0 +1,248 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createRoot } from "../ink/root.js";
+import { ModelPicker } from "./ModelPicker.js";
+
+type AppState = {
+  effortValue?: string;
+  fastMode: boolean;
+};
+
+type SelectProps = {
+  defaultFocusValue: string | undefined;
+  defaultValue: string;
+  onCancel: () => void;
+  onChange: (value: string) => void;
+  onFocus: (value: string) => void;
+  options: Array<{ label: string; value: string }>;
+  visibleOptionCount: number;
+};
+
+type ModelPickerKeybindings = {
+  "modelPicker:decreaseEffort": () => void;
+  "modelPicker:increaseEffort": () => void;
+};
+
+const appStateMock = vi.hoisted(() => ({
+  setAppState: vi.fn(),
+  state: {
+    effortValue: "max" as string | undefined,
+    fastMode: false,
+  },
+}));
+
+const fastModeMock = vi.hoisted(() => ({
+  available: true,
+  cooldown: false,
+  enabled: true,
+}));
+
+const keybindingsMock = vi.hoisted(() => ({
+  current: undefined as ModelPickerKeybindings | undefined,
+}));
+
+const selectPropsMock = vi.hoisted(() => ({
+  current: undefined as SelectProps | undefined,
+}));
+
+const settingsMock = vi.hoisted(() => ({
+  updateSettingsForSource: vi.fn(),
+}));
+
+vi.mock("src/tui/hooks/useExitOnCtrlCDWithKeybindings.js", () => ({
+  useExitOnCtrlCDWithKeybindings: () => ({
+    keyName: "Ctrl+D",
+    pending: false,
+  }),
+}));
+
+vi.mock("../keybindings/useKeybinding.js", () => ({
+  useKeybindings: (bindings: ModelPickerKeybindings) => {
+    keybindingsMock.current = bindings;
+  },
+}));
+
+vi.mock("../state/AppState.js", () => ({
+  useAppState: (selector: (state: AppState) => unknown) =>
+    selector(appStateMock.state),
+  useSetAppState: () => (updater: (state: AppState) => AppState) => {
+    appStateMock.setAppState(updater);
+    appStateMock.state = updater(appStateMock.state);
+  },
+}));
+
+vi.mock("../../services/analytics/index.js", () => ({
+  logEvent: () => {},
+}));
+
+vi.mock("../../utils/fastMode.js", () => ({
+  FAST_MODE_MODEL_DISPLAY: "fast-model",
+  isFastModeAvailable: () => fastModeMock.available,
+  isFastModeCooldown: () => fastModeMock.cooldown,
+  isFastModeEnabled: () => fastModeMock.enabled,
+}));
+
+vi.mock("../../utils/effort.js", () => ({
+  convertEffortValueToLevel: (value: string | undefined) => value,
+  getDefaultEffortForModel: (model: string) => {
+    if (model === "basic-mini") return undefined;
+    if (model === "max-model") return "max";
+    return "medium";
+  },
+  modelSupportsEffort: (model: string) => model !== "basic-mini",
+  modelSupportsMaxEffort: (model: string) => model === "max-model",
+  resolvePickerEffortPersistence: (
+    effort: string | undefined,
+    defaultEffort: string,
+    _persistedEffort: string | undefined,
+    hasToggledEffort: boolean,
+  ) => (hasToggledEffort ? effort : defaultEffort),
+  toPersistableEffort: (effort: string | undefined) => effort,
+}));
+
+vi.mock("../../utils/model/model.js", () => ({
+  getDefaultMainLoopModel: () => "standard-model",
+  modelDisplayString: (model: string) => `Display ${model}`,
+  parseUserSpecifiedModel: (model: string) => model,
+}));
+
+vi.mock("../../utils/model/modelOptions.js", () => ({
+  getModelOptions: () => [
+    {
+      value: "standard-model",
+      label: "Standard Model",
+      description: "No max effort",
+    },
+    {
+      value: "max-model",
+      label: "Max Model",
+      description: "Supports max effort",
+    },
+    {
+      value: "basic-mini",
+      label: "Basic Mini",
+      description: "No effort support",
+    },
+  ],
+}));
+
+vi.mock("../../utils/settings/settings.js", () => ({
+  getSettingsForSource: () => ({ effortLevel: "medium" }),
+  updateSettingsForSource: settingsMock.updateSettingsForSource,
+}));
+
+vi.mock("./CustomSelect/select.js", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+  return {
+    Select: (props: SelectProps) => {
+      selectPropsMock.current = props;
+      return ReactActual.createElement(
+        "ink-text",
+        null,
+        props.options
+          .slice(0, props.visibleOptionCount)
+          .map(option => option.label)
+          .join("\n"),
+      );
+    },
+  };
+});
+
+const waitForRender = () => new Promise(resolve => setTimeout(resolve, 30));
+
+describe("ModelPicker coverage worker 021", () => {
+  beforeEach(() => {
+    appStateMock.setAppState.mockReset();
+    appStateMock.state = {
+      effortValue: "max",
+      fastMode: false,
+    };
+    fastModeMock.available = true;
+    fastModeMock.cooldown = false;
+    fastModeMock.enabled = true;
+    keybindingsMock.current = undefined;
+    selectPropsMock.current = undefined;
+    settingsMock.updateSettingsForSource.mockReset();
+  });
+
+  test("cycles effort keybindings and keeps unsupported selections from returning effort", async () => {
+    const onSelect = vi.fn();
+    let output = "";
+    const stdout = new PassThrough();
+    stdout.on("data", chunk => {
+      output += chunk.toString();
+    });
+    (stdout as unknown as { columns: number }).columns = 120;
+
+    const stdin = new PassThrough() as PassThrough & {
+      isTTY: boolean;
+      ref: () => void;
+      setRawMode: (mode: boolean) => void;
+      unref: () => void;
+    };
+    stdin.isTTY = true;
+    stdin.ref = () => {};
+    stdin.setRawMode = () => {};
+    stdin.unref = () => {};
+
+    const root = await createRoot({
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      patchConsole: false,
+    });
+
+    try {
+      root.render(
+        <ModelPicker
+          initial="standard-model"
+          isStandaloneCommand
+          onSelect={onSelect}
+        />,
+      );
+      await waitForRender();
+
+      expect(stripAnsi(output)).toContain("High effort");
+      expect(stripAnsi(output)).toContain("Use /fast");
+      expect(selectPropsMock.current?.defaultFocusValue).toBe("standard-model");
+
+      keybindingsMock.current?.["modelPicker:increaseEffort"]();
+      await waitForRender();
+      selectPropsMock.current?.onChange("standard-model");
+      expect(onSelect).toHaveBeenLastCalledWith("standard-model", "low");
+      expect(settingsMock.updateSettingsForSource).toHaveBeenLastCalledWith(
+        "userSettings",
+        { effortLevel: "low" },
+      );
+
+      selectPropsMock.current?.onFocus("max-model");
+      await waitForRender();
+      keybindingsMock.current?.["modelPicker:decreaseEffort"]();
+      await waitForRender();
+      selectPropsMock.current?.onChange("max-model");
+      expect(onSelect).toHaveBeenLastCalledWith("max-model", "max");
+      expect(settingsMock.updateSettingsForSource).toHaveBeenLastCalledWith(
+        "userSettings",
+        { effortLevel: "max" },
+      );
+
+      selectPropsMock.current?.onFocus("basic-mini");
+      await waitForRender();
+      keybindingsMock.current?.["modelPicker:increaseEffort"]();
+      await waitForRender();
+      selectPropsMock.current?.onChange("basic-mini");
+      expect(onSelect).toHaveBeenLastCalledWith("basic-mini", undefined);
+
+      selectPropsMock.current?.onCancel();
+      expect(appStateMock.setAppState).toHaveBeenCalledTimes(3);
+      expect(appStateMock.state.effortValue).toBe("max");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+});

--- a/runtime/tests/tui/components/NativeAutoUpdater.wave200-053.coverage.test.tsx
+++ b/runtime/tests/tui/components/NativeAutoUpdater.wave200-053.coverage.test.tsx
@@ -1,0 +1,218 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  installLatest: vi.fn(),
+  intervalDelay: undefined as number | null | undefined,
+  isAutoUpdaterDisabled: vi.fn(() => false),
+  logError: vi.fn(),
+  logEvent: vi.fn(),
+  logForDebugging: vi.fn(),
+  updateResults: [] as Array<{ status: string; version: string | null }>,
+  updatingStates: [] as boolean[],
+}));
+
+vi.mock("usehooks-ts", () => ({
+  useInterval: (_callback: () => void, delay: number | null) => {
+    harness.intervalDelay = delay;
+  },
+}));
+
+vi.mock("../hooks/useUpdateNotification.js", () => ({
+  useUpdateNotification: (version: string | null | undefined) =>
+    version ? "9.9.9" : null,
+}));
+
+vi.mock("../../services/analytics/index.js", () => ({
+  logEvent: harness.logEvent,
+}));
+
+vi.mock("src/utils/debug.js", () => ({
+  logForDebugging: harness.logForDebugging,
+}));
+
+vi.mock("../../utils/log.js", () => ({
+  logError: harness.logError,
+}));
+
+vi.mock("../../utils/config.js", () => ({
+  isAutoUpdaterDisabled: harness.isAutoUpdaterDisabled,
+}));
+
+vi.mock("../../utils/nativeInstaller/installer.js", () => ({
+  installLatest: harness.installLatest,
+}));
+
+vi.mock("../../utils/settings/settings.js", () => ({
+  getInitialSettings: () => ({ autoUpdatesChannel: "nightly" }),
+}));
+
+import { createRoot } from "../ink/root.js";
+import { NativeAutoUpdater } from "./NativeAutoUpdater.js";
+
+const originalGlyphMode = process.env.AGENC_TUI_GLYPHS;
+const originalMacro = (globalThis as Record<string, unknown>).MACRO;
+const originalNodeEnv = process.env.NODE_ENV;
+
+type AutoUpdaterResult = {
+  status: "success" | "install_failed";
+  version: string | null;
+};
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  readonly stdout: PassThrough;
+};
+
+function createStreams(): TestStreams {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStreams["stdin"];
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number; rows: number }).columns = 120;
+  (stdout as unknown as { columns: number; rows: number }).rows = 24;
+
+  return { stdin, stdout };
+}
+
+function NativeAutoUpdaterHarness(): React.ReactNode {
+  const [isUpdating, setIsUpdating] = React.useState(false);
+  const [autoUpdaterResult, setAutoUpdaterResult] =
+    React.useState<AutoUpdaterResult | null>(null);
+  const onAutoUpdaterResult = React.useCallback((result: AutoUpdaterResult) => {
+    harness.updateResults.push(result);
+    setAutoUpdaterResult(result);
+  }, []);
+  const onChangeIsUpdating = React.useCallback((nextIsUpdating: boolean) => {
+    harness.updatingStates.push(nextIsUpdating);
+    setIsUpdating(nextIsUpdating);
+  }, []);
+
+  return (
+    <NativeAutoUpdater
+      autoUpdaterResult={autoUpdaterResult}
+      isUpdating={isUpdating}
+      onAutoUpdaterResult={onAutoUpdaterResult}
+      onChangeIsUpdating={onChangeIsUpdating}
+      showSuccessMessage={true}
+      verbose={true}
+    />
+  );
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForOutput(
+  readOutput: () => string,
+  expectedText: string,
+): Promise<string> {
+  const deadline = Date.now() + 1000;
+
+  while (Date.now() < deadline) {
+    const plainOutput = stripAnsi(readOutput());
+    if (plainOutput.includes(expectedText)) {
+      return plainOutput;
+    }
+    await sleep(10);
+  }
+
+  return stripAnsi(readOutput());
+}
+
+describe("NativeAutoUpdater installer failure coverage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    harness.intervalDelay = undefined;
+    harness.updateResults = [];
+    harness.updatingStates = [];
+    process.env.AGENC_TUI_GLYPHS = "ascii";
+    process.env.NODE_ENV = "production";
+    (globalThis as Record<string, unknown>).MACRO = {
+      VERSION: "1.0.0",
+    };
+  });
+
+  afterEach(() => {
+    if (originalGlyphMode === undefined) {
+      delete process.env.AGENC_TUI_GLYPHS;
+    } else {
+      process.env.AGENC_TUI_GLYPHS = originalGlyphMode;
+    }
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+    if (originalMacro === undefined) {
+      delete (globalThis as Record<string, unknown>).MACRO;
+    } else {
+      (globalThis as Record<string, unknown>).MACRO = originalMacro;
+    }
+  });
+
+  test("reports and renders an installer failure from the active update check", async () => {
+    const installError = new Error("network outage while installing");
+    harness.installLatest.mockRejectedValueOnce(installError);
+
+    let output = "";
+    const { stdin, stdout } = createStreams();
+    stdout.on("data", (chunk) => {
+      output += chunk.toString();
+    });
+
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(<NativeAutoUpdaterHarness />);
+
+      const rendered = await waitForOutput(() => output, "Auto-update failed");
+
+      expect(harness.intervalDelay).toBe(1_800_000);
+      expect(harness.isAutoUpdaterDisabled).toHaveBeenCalledOnce();
+      expect(harness.installLatest).toHaveBeenCalledWith("nightly");
+      expect(harness.logError).toHaveBeenCalledWith(installError);
+      expect(harness.logEvent).toHaveBeenCalledWith(
+        "tengu_native_auto_updater_start",
+        {},
+      );
+      expect(harness.logEvent).toHaveBeenCalledWith(
+        "tengu_native_auto_updater_fail",
+        expect.objectContaining({
+          error_checksum: false,
+          error_disk_full: false,
+          error_network: true,
+          error_not_found: false,
+          error_npm: false,
+          error_permission: false,
+          error_timeout: false,
+        }),
+      );
+      expect(harness.updateResults).toEqual([
+        { status: "install_failed", version: null },
+      ]);
+      expect(harness.updatingStates).toEqual([true, false]);
+      expect(rendered).toContain("ERR Auto-update failed - Try /status");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+});

--- a/runtime/tests/tui/components/PackageManagerAutoUpdater.coverage.test.tsx
+++ b/runtime/tests/tui/components/PackageManagerAutoUpdater.coverage.test.tsx
@@ -1,0 +1,182 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  getLatestVersionFromGcs: vi.fn(async () => "9.0.0"),
+  getMaxVersion: vi.fn(async () => "2.0.0"),
+  getPackageManager: vi.fn(async () => "homebrew"),
+  intervalDelay: undefined as number | null | undefined,
+  isAutoUpdaterDisabled: vi.fn(() => false),
+  logForDebugging: vi.fn(),
+  shouldSkipVersion: vi.fn(() => false),
+}));
+
+vi.mock("usehooks-ts", () => ({
+  useInterval: (_callback: () => void, delay: number | null) => {
+    harness.intervalDelay = delay;
+  },
+}));
+
+vi.mock("../../utils/autoUpdater.js", () => ({
+  getLatestVersionFromGcs: harness.getLatestVersionFromGcs,
+  getMaxVersion: harness.getMaxVersion,
+  shouldSkipVersion: harness.shouldSkipVersion,
+}));
+
+vi.mock("../../utils/config.js", () => ({
+  isAutoUpdaterDisabled: harness.isAutoUpdaterDisabled,
+}));
+
+vi.mock("../../utils/nativeInstaller/packageManagers.js", () => ({
+  getPackageManager: harness.getPackageManager,
+}));
+
+vi.mock("../../utils/semver.js", () => {
+  const compareVersions = (left: string, right: string): number => {
+    const leftParts = left.split(".").map(Number);
+    const rightParts = right.split(".").map(Number);
+
+    for (let index = 0; index < 3; index += 1) {
+      const delta = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+      if (delta !== 0) {
+        return delta;
+      }
+    }
+
+    return 0;
+  };
+
+  return {
+    gt: (left: string, right: string) => compareVersions(left, right) > 0,
+    gte: (left: string, right: string) => compareVersions(left, right) >= 0,
+  };
+});
+
+vi.mock("../../utils/settings/settings.js", () => ({
+  getInitialSettings: () => ({ autoUpdatesChannel: "stable" }),
+}));
+
+vi.mock("src/utils/debug.js", () => ({
+  logForDebugging: harness.logForDebugging,
+}));
+
+import { createRoot } from "../ink/root.js";
+import { PackageManagerAutoUpdater } from "./PackageManagerAutoUpdater.js";
+
+const originalMacro = (globalThis as Record<string, unknown>).MACRO;
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  readonly stdout: PassThrough;
+};
+
+function createStreams(): TestStreams {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStreams["stdin"];
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number; rows: number }).columns = 120;
+  (stdout as unknown as { columns: number; rows: number }).rows = 24;
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForOutput(
+  readOutput: () => string,
+  expectedText: string,
+): Promise<string> {
+  const deadline = Date.now() + 1000;
+
+  while (Date.now() < deadline) {
+    const plainOutput = stripAnsi(readOutput());
+    if (plainOutput.includes(expectedText)) {
+      return plainOutput;
+    }
+    await sleep(10);
+  }
+
+  return stripAnsi(readOutput());
+}
+
+describe("PackageManagerAutoUpdater coverage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    harness.intervalDelay = undefined;
+    (globalThis as Record<string, unknown>).MACRO = {
+      VERSION: "1.0.0",
+    };
+  });
+
+  afterEach(() => {
+    if (originalMacro === undefined) {
+      delete (globalThis as Record<string, unknown>).MACRO;
+    } else {
+      (globalThis as Record<string, unknown>).MACRO = originalMacro;
+    }
+  });
+
+  test("renders the capped Homebrew update command from the async check", async () => {
+    let output = "";
+    const { stdin, stdout } = createStreams();
+    stdout.on("data", chunk => {
+      output += chunk.toString();
+    });
+
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <PackageManagerAutoUpdater
+          autoUpdaterResult={null}
+          isUpdating={false}
+          onAutoUpdaterResult={() => {}}
+          onChangeIsUpdating={() => {}}
+          showSuccessMessage={false}
+          verbose={true}
+        />,
+      );
+
+      const rendered = await waitForOutput(() => output, "brew upgrade");
+
+      expect(rendered).toContain("currentVersion: 1.0.0");
+      expect(rendered).toContain("Update available! Run:");
+      expect(rendered).toContain("brew upgrade agenc-code");
+      expect(rendered).not.toContain("your package manager update command");
+      expect(harness.intervalDelay).toBe(1_800_000);
+      expect(harness.isAutoUpdaterDisabled).toHaveBeenCalledOnce();
+      expect(harness.getPackageManager).toHaveBeenCalledOnce();
+      expect(harness.getLatestVersionFromGcs).toHaveBeenCalledWith("stable");
+      expect(harness.getMaxVersion).toHaveBeenCalledOnce();
+      expect(harness.shouldSkipVersion).toHaveBeenCalledWith("2.0.0");
+      expect(harness.logForDebugging).toHaveBeenCalledWith(
+        "PackageManagerAutoUpdater: maxVersion 2.0.0 is set, capping update from 9.0.0 to 2.0.0",
+      );
+      expect(harness.logForDebugging).toHaveBeenCalledWith(
+        "PackageManagerAutoUpdater: Update available 1.0.0 -> 2.0.0",
+      );
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+});

--- a/runtime/tests/tui/components/PrBadge.coverage.test.tsx
+++ b/runtime/tests/tui/components/PrBadge.coverage.test.tsx
@@ -1,0 +1,170 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import type { PrReviewState } from '../../utils/ghPrStatus.js'
+import { getTheme } from '../../utils/theme.js'
+import type { DOMElement } from '../ink/dom.js'
+import instances from '../ink/instances.js'
+import { createRoot } from '../ink/root.js'
+import { squashTextNodesToSegments } from '../ink/squash-text-nodes.js'
+import { PrBadge } from './PrBadge.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  setRawMode: (mode: boolean) => void
+  ref: () => void
+  unref: () => void
+}
+
+const previousForceHyperlink = process.env.FORCE_HYPERLINK
+
+function createTestStreams(): {
+  stdout: PassThrough
+  stdin: TestStdin
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStdin
+
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+  ;(stdout as unknown as { rows: number }).rows = 24
+  ;(stdout as unknown as { isTTY: boolean }).isTTY = true
+
+  return { stdout, stdin }
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+  if (!instance?.rootNode) throw new Error('Ink root node not found')
+  return instance.rootNode
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+afterEach(() => {
+  if (previousForceHyperlink === undefined) {
+    delete process.env.FORCE_HYPERLINK
+  } else {
+    process.env.FORCE_HYPERLINK = previousForceHyperlink
+  }
+})
+
+describe('PrBadge coverage', () => {
+  test('renders review-state colors, hyperlink styling, and unreviewed bold fallback', async () => {
+    process.env.FORCE_HYPERLINK = '1'
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    })
+
+    const statusCases: Array<{
+      number: number
+      state: PrReviewState
+      color: 'success' | 'error' | 'warning' | 'merged' | undefined
+    }> = [
+      { number: 101, state: 'approved', color: 'success' },
+      { number: 102, state: 'changes_requested', color: 'error' },
+      { number: 103, state: 'pending', color: 'warning' },
+      { number: 104, state: 'merged', color: 'merged' },
+      { number: 105, state: 'draft', color: undefined },
+    ]
+    const theme = getTheme('dark')
+
+    try {
+      root.render(
+        <>
+          {statusCases.map(({ number, state }) => (
+            <PrBadge
+              key={number}
+              number={number}
+              url={`https://example.test/pull/${number}`}
+              reviewState={state}
+            />
+          ))}
+          <PrBadge
+            number={106}
+            url="https://example.test/pull/106"
+            bold={true}
+          />
+        </>,
+      )
+      await sleep(25)
+
+      const segments = squashTextNodesToSegments(getRootNode(stdout))
+
+      expect(segments.map(segment => segment.text).join('')).toContain(
+        'PR #101PR #102PR #103PR #104PR #105PR #106',
+      )
+
+      for (const { number, color } of statusCases) {
+        const url = `https://example.test/pull/${number}`
+        const numberSegments = segments.filter(
+          segment => segment.hyperlink === url,
+        )
+        expect(numberSegments.map(segment => segment.text).join('')).toBe(
+          `#${number}`,
+        )
+
+        const [hashSegment, digitsSegment] = numberSegments
+        expect(hashSegment).toMatchObject({
+          hyperlink: url,
+          styles: expect.objectContaining({ underline: true }),
+        })
+        expect(digitsSegment).toMatchObject({
+          hyperlink: url,
+          styles: expect.objectContaining({ underline: true }),
+        })
+
+        if (color === undefined) {
+          expect(hashSegment?.styles).toMatchObject({
+            color: theme.inactive,
+            underline: true,
+          })
+          expect(digitsSegment?.styles).toMatchObject(hashSegment!.styles)
+        } else {
+          expect(hashSegment?.styles).toMatchObject({
+            color: theme[color],
+            underline: true,
+          })
+          expect(digitsSegment?.styles).toMatchObject(hashSegment!.styles)
+        }
+      }
+
+      const prLabels = segments.filter(segment => segment.text === 'PR')
+      expect(prLabels.slice(0, 5).map(segment => segment.styles.color)).toEqual(
+        Array.from({ length: 5 }, () => theme.inactive),
+      )
+
+      const boldFallback = segments.filter(
+        segment => segment.hyperlink === 'https://example.test/pull/106',
+      )
+      expect(boldFallback.map(segment => segment.text).join('')).toBe('#106')
+      expect(boldFallback[0]).toMatchObject({
+        styles: expect.objectContaining({
+          bold: true,
+          underline: true,
+        }),
+      })
+      expect(boldFallback[1]).toMatchObject({
+        hyperlink: boldFallback[0]?.hyperlink,
+        styles: boldFallback[0]?.styles,
+      })
+      expect(boldFallback[0]?.styles.color).toBeUndefined()
+      expect(prLabels.at(-1)?.styles.color).toBeUndefined()
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep(25)
+    }
+  })
+})

--- a/runtime/tests/tui/components/PromptInput/HistorySearchInput.wave200-127.coverage.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/HistorySearchInput.wave200-127.coverage.test.tsx
@@ -1,0 +1,172 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+type CapturedTextInputProps = {
+  columns: number
+  cursorOffset: number
+  dimColor: boolean
+  focus: boolean
+  multiline: boolean
+  onChange: (value: string) => void
+  onChangeCursorOffset: (offset: number) => void
+  showCursor: boolean
+  value: string
+}
+
+const textInputMock = vi.hoisted(() => ({
+  current: undefined as CapturedTextInputProps | undefined,
+}))
+
+vi.mock('../TextInput.js', async () => {
+  const ReactActual = await vi.importActual<typeof import('react')>('react')
+
+  return {
+    default: (props: CapturedTextInputProps) => {
+      textInputMock.current = props
+      return ReactActual.createElement('ink-text', null, `input:${props.value}`)
+    },
+  }
+})
+
+import { createRoot } from '../../ink/root.js'
+import type { DOMElement, DOMNode } from '../../ink/dom.js'
+import instances from '../../ink/instances.js'
+import HistorySearchInput from './HistorySearchInput.js'
+
+type TestRoot = Awaited<ReturnType<typeof createRoot>>
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+const mountedRoots: TestRoot[] = []
+
+afterEach(() => {
+  textInputMock.current = undefined
+
+  for (const root of mountedRoots.splice(0)) {
+    root.unmount()
+  }
+})
+
+function collectText(node: DOMNode): string {
+  if (node.nodeName === '#text') return node.nodeValue
+  return node.childNodes.map(collectText).join('')
+}
+
+function createStreams(): {
+  stdin: TestStdin
+  stdout: PassThrough
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStdin
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  ;(stdout as unknown as { columns: number; rows: number }).columns = 80
+  ;(stdout as unknown as { columns: number; rows: number }).rows = 24
+
+  return { stdin, stdout }
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+  if (!instance?.rootNode) throw new Error('Ink root node not found')
+  return instance.rootNode
+}
+
+async function waitForRender(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 30))
+}
+
+async function mountHistorySearch(
+  props: React.ComponentProps<typeof HistorySearchInput>,
+): Promise<{
+  rerender: (next: React.ComponentProps<typeof HistorySearchInput>) => void
+  text: () => string
+}> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  mountedRoots.push(root)
+
+  root.render(<HistorySearchInput {...props} />)
+  await waitForRender()
+
+  return {
+    rerender: next => root.render(<HistorySearchInput {...next} />),
+    text: () => collectText(getRootNode(stdout)),
+  }
+}
+
+describe('HistorySearchInput wave200-127 coverage', () => {
+  test('renders search and failed-match states while forwarding input edits', async () => {
+    const onChange = vi.fn()
+    const onFailedChange = vi.fn()
+    const view = await mountHistorySearch({
+      historyFailedMatch: false,
+      onChange,
+      value: 'build',
+    })
+
+    expect(view.text()).toContain('search prompts:')
+    expect(view.text()).toContain('input:build')
+    expect(textInputMock.current).toMatchObject({
+      columns: 6,
+      cursorOffset: 5,
+      dimColor: true,
+      focus: true,
+      multiline: false,
+      showCursor: true,
+      value: 'build',
+    })
+    expect(textInputMock.current?.onChange).toBe(onChange)
+
+    textInputMock.current?.onChange('deploy')
+    expect(onChange).toHaveBeenCalledWith('deploy')
+    expect(() => textInputMock.current?.onChangeCursorOffset(1)).not.toThrow()
+
+    view.rerender({
+      historyFailedMatch: false,
+      onChange,
+      value: 'build',
+    })
+    await waitForRender()
+
+    expect(view.text()).toContain('search prompts:')
+    expect(view.text()).toContain('input:build')
+
+    view.rerender({
+      historyFailedMatch: true,
+      onChange: onFailedChange,
+      value: 'deploy now',
+    })
+    await waitForRender()
+
+    expect(view.text()).toContain('no matching prompt:')
+    expect(view.text()).toContain('input:deploy now')
+    expect(textInputMock.current).toMatchObject({
+      columns: 11,
+      cursorOffset: 10,
+      dimColor: true,
+      focus: true,
+      multiline: false,
+      showCursor: true,
+      value: 'deploy now',
+    })
+    expect(textInputMock.current?.onChange).toBe(onFailedChange)
+
+    textInputMock.current?.onChange('fallback')
+    expect(onFailedChange).toHaveBeenCalledWith('fallback')
+  })
+})

--- a/runtime/tests/tui/components/PromptInput/Notifications.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/Notifications.test.tsx
@@ -1,0 +1,491 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  appState: {
+    isBriefOnly: false,
+    notifications: {
+      current: null as
+        | null
+        | {
+            color?: string
+            key: string
+            text?: string
+            jsx?: React.ReactNode
+          },
+      queue: [] as unknown[],
+    },
+  },
+  autoUpdaterProps: [] as Array<Record<string, unknown>>,
+  compactWarning: false,
+  editor: undefined as string | undefined,
+  envHookNotifier: null as null | ((text: string, isError?: boolean) => void),
+  features: new Set<string>(),
+  helperConfigured: false,
+  helperElapsedMs: 0,
+  ideStatus: 'disconnected' as 'connected' | 'disconnected',
+  logEvent: vi.fn(),
+  mcpClientsSeen: undefined as unknown,
+  model: 'gpt-5.4',
+  removeNotification: vi.fn(),
+  subscriptionType: 'pro' as 'enterprise' | 'pro' | 'team',
+  tokenUsage: 1234,
+  usingOverage: false,
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => harness.features.has(name),
+}))
+
+vi.mock('../../../services/analytics/index.js', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../../../services/compact/autoCompact.js', () => ({
+  calculateTokenWarningState: (tokenUsage: number, model: string) => ({
+    isAboveWarningThreshold: harness.compactWarning,
+    model,
+    tokenUsage,
+  }),
+}))
+
+vi.mock('../../../utils/auth.js', () => ({
+  getApiKeyHelperElapsedMs: () => harness.helperElapsedMs,
+  getConfiguredApiKeyHelper: () =>
+    harness.helperConfigured ? 'echo helper' : null,
+  getSubscriptionType: () => harness.subscriptionType,
+}))
+
+vi.mock('../../../utils/editor.js', () => ({
+  getExternalEditor: () => harness.editor,
+}))
+
+vi.mock('../../../utils/envUtils.js', () => ({
+  isEnvTruthy: (value: string | undefined) =>
+    value === '1' || value === 'true' || value === 'yes',
+}))
+
+vi.mock('../../../utils/format.js', () => ({
+  formatDuration: (ms: number) => `${ms}ms`,
+}))
+
+vi.mock('../../../utils/hooks/fileChangedWatcher.js', () => ({
+  setEnvHookNotifier: (
+    notifier: null | ((text: string, isError?: boolean) => void),
+  ) => {
+    harness.envHookNotifier = notifier
+  },
+}))
+
+vi.mock('../../../utils/ide.js', () => ({
+  toIDEDisplayName: (editor: string) => `IDE:${editor}`,
+}))
+
+vi.mock('../../../utils/messages.js', () => ({
+  getMessagesAfterCompactBoundary: (messages: unknown[]) => messages,
+}))
+
+vi.mock('../../../utils/tokens.js', () => ({
+  tokenCountFromLastAPIResponse: () => harness.tokenUsage,
+}))
+
+vi.mock('../../context/notifications.js', () => ({
+  useNotifications: () => ({
+    addNotification: harness.addNotification,
+    removeNotification: harness.removeNotification,
+  }),
+}))
+
+vi.mock('../../hooks/useIdeConnectionStatus.js', () => ({
+  useIdeConnectionStatus: (mcpClients: unknown) => {
+    harness.mcpClientsSeen = mcpClients
+    return { status: harness.ideStatus }
+  },
+}))
+
+vi.mock('../../hooks/useMainLoopModel.js', () => ({
+  useMainLoopModel: () => harness.model,
+}))
+
+vi.mock('../../rate-limits/agenc-ai-limits.js', () => ({
+  useAgenCAiLimits: () => ({ isUsingOverage: harness.usingOverage }),
+}))
+
+vi.mock('../../state/AppState.js', () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+}))
+
+vi.mock('../AutoUpdaterWrapper.js', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../../ink.js')
+  return {
+    AutoUpdaterWrapper: (props: Record<string, unknown>) => {
+      harness.autoUpdaterProps.push(props)
+      const result = props.autoUpdaterResult as undefined | { status?: string }
+      return ReactModule.createElement(
+        Text,
+        null,
+        `AutoUpdater:${String(props.verbose)}:${String(props.isUpdating)}:${String(props.showSuccessMessage)}:${result?.status ?? 'none'}`,
+      )
+    },
+  }
+})
+
+vi.mock('../ConfigurableShortcutHint.js', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../../ink.js')
+  return {
+    ConfigurableShortcutHint: ({
+      description,
+      fallback,
+    }: {
+      description: string
+      fallback: string
+    }) =>
+      ReactModule.createElement(Text, null, `${fallback}:${description}`),
+  }
+})
+
+vi.mock('../IdeStatusIndicator.js', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../../ink.js')
+  return {
+    IdeStatusIndicator: ({
+      ideSelection,
+      mcpClients,
+    }: {
+      ideSelection?: { filePath?: string; text?: string }
+      mcpClients?: unknown[]
+    }) =>
+      ReactModule.createElement(
+        Text,
+        null,
+        `IDE:${ideSelection?.filePath ?? ideSelection?.text ?? 'none'}:${mcpClients?.length ?? 0}`,
+      ),
+  }
+})
+
+vi.mock('../../cost/MemoryUsageIndicator.js', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../../ink.js')
+  return {
+    MemoryUsageIndicator: () =>
+      ReactModule.createElement(Text, null, 'MemoryUsage'),
+  }
+})
+
+vi.mock('../SentryErrorBoundary.js', () => ({
+  SentryErrorBoundary: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}))
+
+vi.mock('../../cost/TokenWarning.js', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../../ink.js')
+  return {
+    TokenWarning: ({
+      model,
+      tokenUsage,
+    }: {
+      model: string
+      tokenUsage: number
+    }) => ReactModule.createElement(Text, null, `TokenWarning:${tokenUsage}:${model}`),
+  }
+})
+
+vi.mock('./SandboxPromptFooterHint.js', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../../ink.js')
+  return {
+    SandboxPromptFooterHint: () =>
+      ReactModule.createElement(Text, null, 'SandboxHint'),
+  }
+})
+
+import { createRoot } from '../../ink/root.js'
+import { Text } from '../../ink.js'
+import { Notifications } from './Notifications.js'
+
+type RenderedNotifications = {
+  dispose: () => Promise<void>
+  output: () => string
+  rerender: (overrides?: Partial<NotificationsProps>) => Promise<void>
+}
+
+type NotificationsProps = React.ComponentProps<typeof Notifications>
+
+const originalRemote = process.env.AGENC_REMOTE
+
+function resetHarness() {
+  harness.addNotification.mockClear()
+  harness.appState.isBriefOnly = false
+  harness.appState.notifications = { current: null, queue: [] }
+  harness.autoUpdaterProps = []
+  harness.compactWarning = false
+  harness.editor = undefined
+  harness.envHookNotifier = null
+  harness.features = new Set()
+  harness.helperConfigured = false
+  harness.helperElapsedMs = 0
+  harness.ideStatus = 'disconnected'
+  harness.logEvent.mockClear()
+  harness.mcpClientsSeen = undefined
+  harness.model = 'gpt-5.4'
+  harness.removeNotification.mockClear()
+  harness.subscriptionType = 'pro'
+  harness.tokenUsage = 1234
+  harness.usingOverage = false
+}
+
+function baseProps(): NotificationsProps {
+  return {
+    apiKeyStatus: 'valid',
+    autoUpdaterResult: null,
+    debug: false,
+    ideSelection: undefined,
+    isAutoUpdating: false,
+    messages: [],
+    mcpClients: undefined,
+    onAutoUpdaterResult: vi.fn(),
+    onChangeIsUpdating: vi.fn(),
+    verbose: false,
+  }
+}
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+  ;(stdout as unknown as { columns: number; rows: number }).columns = 120
+  ;(stdout as unknown as { columns: number; rows: number }).rows = 30
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderNotifications(
+  overrides: Partial<NotificationsProps> = {},
+): Promise<RenderedNotifications> {
+  let props = { ...baseProps(), ...overrides } as NotificationsProps
+  let output = ''
+  const { stdin, stdout } = createStreams()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  const render = () => {
+    root.render(<Notifications {...props} />)
+  }
+
+  render()
+  await sleep()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    output: () => stripAnsi(output),
+    rerender: async next => {
+      props = { ...props, ...next }
+      render()
+      await sleep()
+    },
+  }
+}
+
+beforeEach(() => {
+  resetHarness()
+  if (originalRemote === undefined) {
+    delete process.env.AGENC_REMOTE
+  } else {
+    process.env.AGENC_REMOTE = originalRemote
+  }
+})
+
+afterEach(() => {
+  if (originalRemote === undefined) {
+    delete process.env.AGENC_REMOTE
+  } else {
+    process.env.AGENC_REMOTE = originalRemote
+  }
+  vi.restoreAllMocks()
+})
+
+describe('Notifications', () => {
+  test('renders status rows and wires env hook notifications', async () => {
+    harness.appState.notifications.current = {
+      color: 'success',
+      key: 'plain',
+      text: 'Plain notice',
+    }
+    harness.usingOverage = true
+    const rendered = await renderNotifications({
+      debug: true,
+      mcpClients: [{ name: 'server-a' }] as never,
+      verbose: true,
+    })
+
+    try {
+      expect(rendered.output()).toContain('IDE:none:1')
+      expect(rendered.output()).toContain('Plain notice')
+      expect(rendered.output()).toContain('Now using extra usage')
+      expect(rendered.output()).toContain('Debug mode')
+      expect(rendered.output()).toContain('1234 tokens')
+      expect(rendered.output()).toContain('TokenWarning:1234:gpt-5.4')
+      expect(rendered.output()).toContain('AutoUpdater:true:false:true:none')
+      expect(rendered.output()).toContain('MemoryUsage')
+      expect(rendered.output()).toContain('SandboxHint')
+      expect(harness.mcpClientsSeen).toEqual([{ name: 'server-a' }])
+
+      expect(harness.envHookNotifier).toEqual(expect.any(Function))
+      harness.envHookNotifier?.('env changed', false)
+      harness.envHookNotifier?.('env failed', true)
+      expect(harness.addNotification).toHaveBeenCalledWith({
+        key: 'env-hook',
+        text: 'env changed',
+        color: undefined,
+        priority: 'low',
+        timeoutMs: 5000,
+      })
+      expect(harness.addNotification).toHaveBeenCalledWith({
+        key: 'env-hook',
+        text: 'env failed',
+        color: 'error',
+        priority: 'medium',
+        timeoutMs: 8000,
+      })
+    } finally {
+      await rendered.dispose()
+    }
+
+    expect(harness.envHookNotifier).toBeNull()
+  })
+
+  test('shows external editor hint and suppresses updater when an IDE selection owns the footer', async () => {
+    harness.appState.notifications.current = {
+      jsx: <Text>JSX notice</Text>,
+      key: 'jsx',
+    }
+    harness.editor = 'vscode'
+    harness.ideStatus = 'connected'
+    const rendered = await renderNotifications({
+      autoUpdaterResult: { status: 'success' } as never,
+      ideSelection: { filePath: 'src/app.ts', lineCount: 0, text: '' } as never,
+      isInputWrapped: true,
+    })
+
+    try {
+      expect(rendered.output()).toContain('IDE:src/app.ts')
+      expect(rendered.output()).toContain('JSX notice')
+      expect(rendered.output()).not.toContain('AutoUpdater:')
+      expect(harness.autoUpdaterProps).toHaveLength(0)
+      expect(harness.logEvent).toHaveBeenCalledWith(
+        'agenc_external_editor_hint_shown',
+        {},
+      )
+      expect(harness.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'external-editor-hint',
+          priority: 'immediate',
+          timeoutMs: 5000,
+        }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('renders auth failures and compact auto-updater state without editor hints', async () => {
+    process.env.AGENC_REMOTE = 'true'
+    harness.compactWarning = true
+    harness.editor = 'vscode'
+    const rendered = await renderNotifications({
+      apiKeyStatus: 'invalid',
+      autoUpdaterResult: { status: 'success' } as never,
+      isInputWrapped: true,
+      verbose: true,
+    })
+
+    try {
+      expect(rendered.output()).toContain('Authentication error · Try again')
+      expect(rendered.output()).not.toContain('1234 tokens')
+      expect(rendered.output()).toContain('AutoUpdater:true:false:false:success')
+      expect(harness.removeNotification).toHaveBeenCalledWith(
+        'external-editor-hint',
+      )
+      expect(harness.logEvent).not.toHaveBeenCalledWith(
+        'agenc_external_editor_hint_shown',
+        {},
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('renders local missing-auth copy', async () => {
+    const rendered = await renderNotifications({
+      apiKeyStatus: 'missing',
+    })
+
+    try {
+      expect(rendered.output()).toContain('Not logged in · Run /login')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('shows slow apiKeyHelper notice and suppresses team overage in brief mode', async () => {
+    harness.appState.isBriefOnly = true
+    harness.features.add('KAIROS')
+    harness.helperConfigured = true
+    harness.helperElapsedMs = 12_000
+    harness.subscriptionType = 'team'
+    harness.usingOverage = true
+    const rendered = await renderNotifications()
+
+    try {
+      await sleep(1100)
+
+      expect(rendered.output()).toContain('apiKeyHelper is taking a while')
+      expect(rendered.output()).toContain('(12000ms)')
+      expect(rendered.output()).not.toContain('Now using extra usage')
+      expect(rendered.output()).not.toContain('TokenWarning:')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/components/PromptInput/Notifications.wave200-144.coverage.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/Notifications.wave200-144.coverage.test.tsx
@@ -1,0 +1,371 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  appState: {
+    isBriefOnly: false,
+    notifications: {
+      current: null as null | {
+        color?: string;
+        jsx?: unknown;
+        key: string;
+        text?: string;
+      },
+      queue: [] as unknown[],
+    },
+  },
+  autoUpdaterProps: [] as Array<Record<string, unknown>>,
+  compactWarning: false,
+  editor: undefined as string | undefined,
+  envHookNotifier: null as null | ((text: string, isError?: boolean) => void),
+  helperConfigured: false,
+  helperElapsedMs: 0,
+  ideStatus: "disconnected" as "connected" | "disconnected",
+  logEvent: vi.fn(),
+  mcpClientsSeen: undefined as unknown,
+  model: "gpt-5.4",
+  removeNotification: vi.fn(),
+  subscriptionType: "pro" as "enterprise" | "pro" | "team",
+  tokenUsage: 1776,
+  usingOverage: undefined as boolean | undefined,
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: () => false,
+}));
+
+vi.mock("../../../services/analytics/index.js", () => ({
+  logEvent: harness.logEvent,
+}));
+
+vi.mock("../../../services/compact/autoCompact.js", () => ({
+  calculateTokenWarningState: (tokenUsage: number, model: string) => ({
+    isAboveWarningThreshold: harness.compactWarning,
+    model,
+    tokenUsage,
+  }),
+}));
+
+vi.mock("../../../utils/auth.js", () => ({
+  getApiKeyHelperElapsedMs: () => harness.helperElapsedMs,
+  getConfiguredApiKeyHelper: () =>
+    harness.helperConfigured ? "echo helper" : null,
+  getSubscriptionType: () => harness.subscriptionType,
+}));
+
+vi.mock("../../../utils/editor.js", () => ({
+  getExternalEditor: () => harness.editor,
+}));
+
+vi.mock("../../../utils/envUtils.js", () => ({
+  isEnvTruthy: (value: string | undefined) =>
+    value === "1" || value === "true" || value === "yes",
+}));
+
+vi.mock("../../../utils/format.js", () => ({
+  formatDuration: (ms: number) => `${ms}ms`,
+}));
+
+vi.mock("../../../utils/hooks/fileChangedWatcher.js", () => ({
+  setEnvHookNotifier: (
+    notifier: null | ((text: string, isError?: boolean) => void),
+  ) => {
+    harness.envHookNotifier = notifier;
+  },
+}));
+
+vi.mock("../../../utils/ide.js", () => ({
+  toIDEDisplayName: (editor: string) => `IDE:${editor}`,
+}));
+
+vi.mock("../../../utils/messages.js", () => ({
+  getMessagesAfterCompactBoundary: (messages: unknown[]) => messages,
+}));
+
+vi.mock("../../../utils/tokens.js", () => ({
+  tokenCountFromLastAPIResponse: () => harness.tokenUsage,
+}));
+
+vi.mock("../../context/notifications.js", () => ({
+  useNotifications: () => ({
+    addNotification: harness.addNotification,
+    removeNotification: harness.removeNotification,
+  }),
+}));
+
+vi.mock("../../hooks/useIdeConnectionStatus.js", () => ({
+  useIdeConnectionStatus: (mcpClients: unknown) => {
+    harness.mcpClientsSeen = mcpClients;
+    return { status: harness.ideStatus };
+  },
+}));
+
+vi.mock("../../hooks/useMainLoopModel.js", () => ({
+  useMainLoopModel: () => harness.model,
+}));
+
+vi.mock("../../rate-limits/agenc-ai-limits.js", () => ({
+  useAgenCAiLimits: () => ({ isUsingOverage: harness.usingOverage }),
+}));
+
+vi.mock("../../state/AppState.js", () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+}));
+
+vi.mock("../AutoUpdaterWrapper.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../ink.js");
+
+  return {
+    AutoUpdaterWrapper: (props: Record<string, unknown>) => {
+      harness.autoUpdaterProps.push(props);
+      return ReactModule.createElement(Text, null, "AutoUpdater");
+    },
+  };
+});
+
+vi.mock("../ConfigurableShortcutHint.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../ink.js");
+
+  return {
+    ConfigurableShortcutHint: ({
+      description,
+      fallback,
+    }: {
+      description: string;
+      fallback: string;
+    }) => ReactModule.createElement(Text, null, `${fallback}:${description}`),
+  };
+});
+
+vi.mock("../IdeStatusIndicator.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../ink.js");
+
+  return {
+    IdeStatusIndicator: ({
+      ideSelection,
+      mcpClients,
+    }: {
+      ideSelection?: { filePath?: string; text?: string };
+      mcpClients?: unknown[];
+    }) =>
+      ReactModule.createElement(
+        Text,
+        null,
+        `IDE:${ideSelection?.filePath ?? ideSelection?.text ?? "none"}:${mcpClients?.length ?? 0}`,
+      ),
+  };
+});
+
+vi.mock("../../cost/MemoryUsageIndicator.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../ink.js");
+
+  return {
+    MemoryUsageIndicator: () =>
+      ReactModule.createElement(Text, null, "MemoryUsage"),
+  };
+});
+
+vi.mock("../SentryErrorBoundary.js", () => ({
+  SentryErrorBoundary: ({ children }: { children: React.ReactNode }) =>
+    children,
+}));
+
+vi.mock("../../cost/TokenWarning.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../ink.js");
+
+  return {
+    TokenWarning: ({
+      model,
+      tokenUsage,
+    }: {
+      model: string;
+      tokenUsage: number;
+    }) =>
+      ReactModule.createElement(Text, null, `TokenWarning:${tokenUsage}:${model}`),
+  };
+});
+
+vi.mock("./SandboxPromptFooterHint.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../ink.js");
+
+  return {
+    SandboxPromptFooterHint: () =>
+      ReactModule.createElement(Text, null, "SandboxHint"),
+  };
+});
+
+import { createRoot } from "../../ink/root.js";
+import { Notifications } from "./Notifications.js";
+
+type NotificationsProps = React.ComponentProps<typeof Notifications>;
+
+type RenderedNotifications = {
+  dispose: () => Promise<void>;
+  output: () => string;
+  rerender: () => Promise<void>;
+};
+
+function resetHarness() {
+  harness.addNotification.mockClear();
+  harness.appState.isBriefOnly = false;
+  harness.appState.notifications = { current: null, queue: [] };
+  harness.autoUpdaterProps = [];
+  harness.compactWarning = false;
+  harness.editor = undefined;
+  harness.envHookNotifier = null;
+  harness.helperConfigured = false;
+  harness.helperElapsedMs = 0;
+  harness.ideStatus = "disconnected";
+  harness.logEvent.mockClear();
+  harness.mcpClientsSeen = undefined;
+  harness.model = "gpt-5.4";
+  harness.removeNotification.mockClear();
+  harness.subscriptionType = "pro";
+  harness.tokenUsage = 1776;
+  harness.usingOverage = undefined;
+}
+
+function baseProps(): NotificationsProps {
+  return {
+    apiKeyStatus: "valid",
+    autoUpdaterResult: null,
+    debug: false,
+    ideSelection: undefined,
+    isAutoUpdating: false,
+    messages: [],
+    mcpClients: undefined,
+    onAutoUpdaterResult: vi.fn(),
+    onChangeIsUpdating: vi.fn(),
+    verbose: false,
+  };
+}
+
+function createStreams(): {
+  stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdout: PassThrough;
+} {
+  const stdout = new PassThrough();
+  stdout.resume();
+  (stdout as unknown as { columns: number; rows: number }).columns = 120;
+  (stdout as unknown as { columns: number; rows: number }).rows = 30;
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function renderNotifications(
+  props: NotificationsProps,
+): Promise<RenderedNotifications> {
+  let output = "";
+  const { stdin, stdout } = createStreams();
+  stdout.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  const render = () => {
+    root.render(<Notifications {...props} />);
+  };
+
+  render();
+  await sleep();
+
+  return {
+    dispose: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    },
+    output: () => stripAnsi(output),
+    rerender: async () => {
+      render();
+      await sleep();
+    },
+  };
+}
+
+beforeEach(() => {
+  resetHarness();
+});
+
+describe("Notifications wave200-144 coverage", () => {
+  test("keeps a text-selection editor hint single across an unchanged narrow rerender", async () => {
+    harness.editor = "vscode";
+    harness.ideStatus = "connected";
+
+    const mcpClients = [{ name: "ide" }];
+    const props = {
+      ...baseProps(),
+      autoUpdaterResult: { status: "success" },
+      ideSelection: {
+        lineCount: 2,
+        text: "selected text",
+      },
+      isInputWrapped: true,
+      isNarrow: true,
+      mcpClients,
+    } as NotificationsProps;
+
+    const rendered = await renderNotifications(props);
+
+    try {
+      expect(rendered.output()).toContain("IDE:selected text:1");
+      expect(rendered.output()).toContain("TokenWarning:1776:gpt-5.4");
+      expect(rendered.output()).not.toContain("AutoUpdater");
+      expect(harness.autoUpdaterProps).toHaveLength(0);
+      expect(harness.mcpClientsSeen).toBe(mcpClients);
+
+      await rendered.rerender();
+      await rendered.rerender();
+
+      expect(harness.addNotification).toHaveBeenCalledTimes(1);
+      expect(harness.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: "external-editor-hint",
+          priority: "immediate",
+          timeoutMs: 5000,
+        }),
+      );
+      expect(harness.logEvent).toHaveBeenCalledTimes(1);
+      expect(harness.removeNotification).not.toHaveBeenCalled();
+    } finally {
+      await rendered.dispose();
+    }
+  });
+});

--- a/runtime/tests/tui/components/PromptInput/PromptInput.coverage2.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.coverage2.test.tsx
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../../utils/config.js', () => ({
+  getGlobalConfig: () => ({}),
+  saveGlobalConfig: () => {},
+}))
+
+vi.mock('../../history/history.js', () => ({
+  formatImageRef: () => '',
+  formatPastedTextRef: () => '',
+  getPastedTextRefNumLines: () => 0,
+  parseReferences: () => [],
+}))
+
+vi.mock('../../../utils/messageQueueManager.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../utils/messageQueueManager.js')>(
+    '../../../utils/messageQueueManager.js',
+  )
+  return actual
+})
+
+import {
+  getCommandQueue,
+  resetCommandQueue,
+} from '../../../utils/messageQueueManager.js'
+import { applyBusyInputSubmissionPolicy } from './PromptInput.js'
+
+describe('PromptInput busy bash coverage', () => {
+  afterEach(() => {
+    resetCommandQueue()
+  })
+
+  test('swallows empty bash submissions while busy without queueing or clearing input state', () => {
+    const addNotification = vi.fn()
+    const setInput = vi.fn()
+    const setCursorOffset = vi.fn()
+    const clearBuffer = vi.fn()
+    const resetHistory = vi.fn()
+    const onModeChange = vi.fn()
+
+    expect(
+      applyBusyInputSubmissionPolicy({
+        isLoading: true,
+        mode: 'bash',
+        input: ' \n\t ',
+        addNotification,
+        setInput,
+        setCursorOffset,
+        clearBuffer,
+        resetHistory,
+        onModeChange,
+      }),
+    ).toBe(true)
+
+    expect(getCommandQueue()).toEqual([])
+    expect(addNotification).not.toHaveBeenCalled()
+    expect(setInput).not.toHaveBeenCalled()
+    expect(setCursorOffset).not.toHaveBeenCalled()
+    expect(clearBuffer).not.toHaveBeenCalled()
+    expect(resetHistory).not.toHaveBeenCalled()
+    expect(onModeChange).not.toHaveBeenCalled()
+  })
+})

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -1,0 +1,725 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => {
+  const appState = {
+    coordinatorTaskIndex: -1,
+    effortValue: undefined,
+    expandedView: 'transcript',
+    fastMode: false,
+    footerSelection: null as null | 'tasks' | 'teams',
+    isBriefOnly: false,
+    mainLoopModel: 'gpt-5.4',
+    mainLoopModelForSession: null,
+    mcp: { clients: [] },
+    promptSuggestion: {
+      acceptedAt: 0,
+      generationRequestId: null,
+      promptId: null,
+      shownAt: 0,
+      text: null,
+    },
+    speculation: { status: 'inactive' },
+    speculationSessionTimeSavedMs: 0,
+    tasks: {},
+    teamContext: undefined,
+    thinkingEnabled: true,
+    toolPermissionContext: {
+      isAutoModeAvailable: true,
+      isBypassPermissionsModeAvailable: true,
+      mode: 'default',
+    },
+    viewingAgentTaskId: null,
+    viewSelectionMode: null,
+  }
+
+  return {
+    addNotification: vi.fn(),
+    appState,
+    baseProps: undefined as undefined | Record<string, unknown>,
+    clearBuffer: vi.fn(),
+    logEvent: vi.fn(),
+    onRender: vi.fn(),
+    pushToBuffer: vi.fn(),
+    removeNotification: vi.fn(),
+    reset: () => {
+      harness.addNotification.mockClear()
+      harness.clearBuffer.mockClear()
+      harness.logEvent.mockClear()
+      harness.onRender.mockClear()
+      harness.pushToBuffer.mockClear()
+      harness.removeNotification.mockClear()
+      harness.baseProps = undefined
+      appState.coordinatorTaskIndex = -1
+      appState.footerSelection = null
+      appState.promptSuggestion = {
+        acceptedAt: 0,
+        generationRequestId: null,
+        promptId: null,
+        shownAt: 0,
+        text: null,
+      }
+      appState.speculation = { status: 'inactive' }
+      appState.viewingAgentTaskId = null
+      appState.viewSelectionMode = null
+    },
+    setAppState: vi.fn((updater: unknown) => {
+      const next =
+        typeof updater === 'function'
+          ? (updater as (prev: typeof appState) => typeof appState)(appState)
+          : updater
+      Object.assign(appState, next)
+    }),
+    setPastedContents: vi.fn(),
+    undo: vi.fn(),
+  }
+})
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../../services/analytics/index.js', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../../../services/analytics/growthbook.js', () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: () => null,
+}))
+
+vi.mock('../../../services/PromptSuggestion/promptSuggestion.js', () => ({
+  abortPromptSuggestion: vi.fn(),
+  logSuggestionSuppressed: vi.fn(),
+}))
+
+vi.mock('../../../services/PromptSuggestion/runtime.js', () => ({
+  logEvent: vi.fn(),
+}))
+
+vi.mock('../../../services/PromptSuggestion/speculation.js', () => ({
+  abortSpeculation: vi.fn(),
+}))
+
+vi.mock('../../context/notifications.js', () => ({
+  useNotifications: () => ({
+    addNotification: harness.addNotification,
+    removeNotification: harness.removeNotification,
+  }),
+}))
+
+vi.mock('../../context/overlayContext.js', () => ({
+  useIsModalOverlayActive: () => false,
+  useRegisterOverlay: vi.fn(),
+}))
+
+vi.mock('../../context/promptOverlayContext.js', () => ({
+  useSetPromptOverlayDialog: vi.fn(),
+}))
+
+vi.mock('../../hooks/useCommandQueue.js', () => ({
+  useCommandQueue: () => [],
+}))
+
+vi.mock('../../hooks/useIdeAtMentioned.js', () => ({
+  useIdeAtMentioned: vi.fn(),
+}))
+
+vi.mock('../../hooks/useArrowKeyHistory.js', () => ({
+  useArrowKeyHistory: () => ({
+    dismissSearchHint: vi.fn(),
+    historyIndex: 0,
+    onHistoryDown: vi.fn(() => false),
+    onHistoryUp: vi.fn(),
+    resetHistory: vi.fn(),
+  }),
+}))
+
+vi.mock('../../hooks/useDoublePress.js', () => ({
+  useDoublePress: (_single: () => void, doublePress: () => void) => doublePress,
+}))
+
+vi.mock('../../hooks/useHistorySearch.js', () => ({
+  useHistorySearch: () => ({
+    historyFailedMatch: false,
+    historyMatch: null,
+    historyQuery: '',
+    setHistoryQuery: vi.fn(),
+  }),
+}))
+
+vi.mock('../../hooks/useInputBuffer.js', () => ({
+  useInputBuffer: () => ({
+    canUndo: false,
+    clearBuffer: harness.clearBuffer,
+    pushToBuffer: harness.pushToBuffer,
+    undo: harness.undo,
+  }),
+}))
+
+vi.mock('../../hooks/useMainLoopModel.js', () => ({
+  useMainLoopModel: () => 'gpt-5.4',
+}))
+
+vi.mock('../../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: 100, rows: 30 }),
+}))
+
+vi.mock('../../hooks/useTypeahead.js', () => ({
+  useTypeahead: () => ({
+    commandArgumentHint: undefined,
+    inlineGhostText: undefined,
+    maxColumnWidth: 0,
+    selectedSuggestion: -1,
+    suggestionType: undefined,
+    suggestions: [],
+  }),
+}))
+
+vi.mock('../../ink/hooks/use-terminal-focus.js', () => ({
+  useTerminalFocus: () => true,
+}))
+
+vi.mock('../../ink.js', async () => {
+  const ReactModule = await import('react')
+  return {
+    Box: ({ children }: { readonly children?: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+    Text: ({ children }: { readonly children?: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+    useInput: vi.fn(),
+  }
+})
+
+vi.mock('../../keybindings/KeybindingContext.js', () => ({
+  useOptionalKeybindingContext: () => null,
+}))
+
+vi.mock('../../keybindings/shortcutFormat.js', () => ({
+  getShortcutDisplay: () => 'ctrl+v',
+}))
+
+vi.mock('../../keybindings/useKeybinding.js', () => ({
+  useKeybinding: vi.fn(),
+  useKeybindings: vi.fn(),
+}))
+
+vi.mock('../../glyphs.js', () => ({
+  selectAgenCTuiGlyphs: () => ({ horizontal: '-' }),
+}))
+
+vi.mock('../../state/AppState.js', () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+  useAppStateStore: () => ({ getState: () => harness.appState }),
+  useSetAppState: () => harness.setAppState,
+}))
+
+vi.mock('../../state/selectors.js', () => ({
+  getActiveAgentForInput: () => ({ type: 'leader' }),
+  getViewedTeammateTask: () => undefined,
+}))
+
+vi.mock('../../state/teammateViewHelpers.js', () => ({
+  enterTeammateView: vi.fn(),
+  exitTeammateView: vi.fn(),
+  stopOrDismissAgent: vi.fn(),
+}))
+
+vi.mock('../../../commands.js', () => ({
+  hasCommand: () => false,
+}))
+
+vi.mock('../../../tasks/InProcessTeammateTask/InProcessTeammateTask.js', () => ({
+  getRunningTeammatesSorted: () => [],
+}))
+
+vi.mock('../../../tasks/types.js', () => ({
+  isBackgroundTask: () => false,
+}))
+
+vi.mock('../../../tools/AgentTool/agentColorManager.js', () => ({
+  AGENT_COLORS: ['cyan', 'purple'],
+  AGENT_COLOR_TO_THEME_COLOR: { cyan: 'accent', purple: 'secondary' },
+}))
+
+vi.mock('../../../utils/agentSwarmsEnabled.js', () => ({
+  isAgentSwarmsEnabled: () => false,
+}))
+
+vi.mock('../../../utils/array.js', () => ({
+  count: (values: readonly unknown[], predicate: (value: unknown) => boolean) =>
+    values.filter(predicate).length,
+}))
+
+vi.mock('../../../utils/config.js', () => ({
+  getGlobalConfig: () => ({}),
+  saveGlobalConfig: vi.fn(),
+}))
+
+vi.mock('../../../utils/cwd.js', () => ({
+  getCwd: () => '/repo',
+}))
+
+vi.mock('../../../utils/debug.js', () => ({
+  logForDebugging: vi.fn(),
+}))
+
+vi.mock('../../../utils/directMemberMessage.js', () => ({
+  parseDirectMemberMessage: () => null,
+  sendDirectMemberMessage: vi.fn(),
+}))
+
+vi.mock('../../../utils/dragDropPaths.js', () => ({
+  extractDraggedFilePaths: (value: string) =>
+    value.startsWith('/dragged/file') ? [value.trim()] : [],
+}))
+
+vi.mock('../../../utils/env.js', () => ({
+  env: {
+    isSSH: () => false,
+    terminal: undefined,
+  },
+}))
+
+vi.mock('../../../utils/errors.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../utils/errors.js')>()
+  return {
+    ...actual,
+    errorMessage: (value: unknown) => String(value),
+  }
+})
+
+vi.mock('../../../utils/extraUsage.js', () => ({
+  isBilledAsExtraUsage: () => false,
+}))
+
+vi.mock('../../../utils/fastMode.js', () => ({
+  FAST_MODE_MODEL_DISPLAY: 'fast-model',
+  clearFastModeCooldown: vi.fn(),
+  getFastModeModel: () => 'fast-model',
+  getFastModeRuntimeState: () => ({ status: 'available' }),
+  getFastModeUnavailableReason: () => null,
+  isFastModeAvailable: () => false,
+  isFastModeCooldown: () => false,
+  isFastModeEnabled: () => false,
+  isFastModeSupportedByModel: () => true,
+}))
+
+vi.mock('../../../utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => false,
+}))
+
+vi.mock('../../../utils/imagePaste.js', () => ({
+  PASTE_THRESHOLD: 20,
+  getImageFromClipboard: vi.fn(async () => null),
+}))
+
+vi.mock('../../../utils/imageStore.js', () => ({
+  cacheImagePath: vi.fn(),
+  storeImage: vi.fn(),
+}))
+
+vi.mock('../../../utils/keyboardShortcuts.js', () => ({
+  MACOS_OPTION_SPECIAL_CHARS: {},
+  isMacosOptionChar: () => false,
+}))
+
+vi.mock('../../../utils/log.js', () => ({
+  logError: vi.fn(),
+}))
+
+vi.mock('../../../utils/model/model.js', () => ({
+  isOpus1mMergeEnabled: () => false,
+  modelDisplayString: (model: string | null) => model ?? 'default',
+}))
+
+vi.mock('../../../utils/permissions/autoModeState.js', () => ({
+  setAutoModeActive: vi.fn(),
+}))
+
+vi.mock('../../../utils/permissions/getNextPermissionMode.js', () => ({
+  cyclePermissionMode: (context: unknown) => ({ context }),
+  getNextPermissionMode: () => 'plan',
+}))
+
+vi.mock('../../../utils/permissions/permissionSetup.js', () => ({
+  transitionPermissionMode: (_from: unknown, _to: unknown, context: unknown) => context,
+}))
+
+vi.mock('../../../utils/platform.js', () => ({
+  getPlatform: () => 'linux',
+}))
+
+vi.mock('../../../utils/promptEditor.js', () => ({
+  editPromptInEditor: vi.fn(async () => ({ content: null, error: null })),
+}))
+
+vi.mock('../../../utils/settings/settings.js', () => ({
+  hasAutoModeOptIn: () => true,
+  updateSettingsForSource: vi.fn(),
+}))
+
+vi.mock('../../../utils/suggestions/commandSuggestions.js', () => ({
+  findSlashCommandPositions: () => [],
+}))
+
+vi.mock('../../../utils/suggestions/slackChannelSuggestions.js', () => ({
+  findSlackChannelPositions: () => [],
+  getKnownChannelsVersion: () => 0,
+  hasSlackMcpServer: () => false,
+  subscribeKnownChannels: () => () => {},
+}))
+
+vi.mock('../../../utils/swarm/backends/registry.js', () => ({
+  isInProcessEnabled: () => false,
+}))
+
+vi.mock('../../../utils/swarm/teamHelpers.js', () => ({
+  syncTeammateMode: vi.fn(),
+}))
+
+vi.mock('../../../utils/teammate.js', () => ({
+  getTeammateColor: () => undefined,
+}))
+
+vi.mock('../../../utils/teammateContext.js', () => ({
+  isInProcessTeammate: () => false,
+}))
+
+vi.mock('../../../utils/teammateMailbox.js', () => ({
+  writeToMailbox: vi.fn(),
+}))
+
+vi.mock('../../../utils/thinking.js', () => ({
+  findThinkingTriggerPositions: () => [],
+  getRainbowColor: () => 'suggestion',
+  isUltrathinkEnabled: () => false,
+}))
+
+vi.mock('../../../conversation/token-budget.js', () => ({
+  findTokenBudgetPositions: () => [],
+}))
+
+vi.mock('../AutoModeOptInDialog.js', () => ({
+  AutoModeOptInDialog: () => null,
+}))
+
+vi.mock('../ConfigurableShortcutHint.js', () => ({
+  ConfigurableShortcutHint: () => null,
+}))
+
+vi.mock('../CoordinatorAgentStatus.js', () => ({
+  getVisibleAgentTasks: () => [],
+  useCoordinatorTaskCount: () => 0,
+}))
+
+vi.mock('../EffortIndicator.js', () => ({
+  getEffortNotificationText: () => undefined,
+}))
+
+vi.mock('../FastIcon.js', () => ({
+  getFastIconString: () => 'FAST',
+}))
+
+vi.mock('../FullscreenLayout.js', () => ({
+  calculateFullscreenLayoutBudget: (rows: number) => ({
+    bottomMaxHeight: Math.max(1, Math.floor(rows / 2)),
+  }),
+}))
+
+vi.mock('../GlobalSearchDialog.js', () => ({
+  GlobalSearchDialog: () => null,
+}))
+
+vi.mock('../../history/HistorySearchDialog.js', () => ({
+  HistorySearchDialog: () => null,
+}))
+
+vi.mock('../ModelPicker.js', () => ({
+  ModelPicker: () => null,
+}))
+
+vi.mock('../QuickOpenDialog.js', () => ({
+  QuickOpenDialog: () => null,
+}))
+
+vi.mock('../ThinkingToggle.js', () => ({
+  ThinkingToggle: () => null,
+}))
+
+vi.mock('../tasks/BackgroundTasksPanel.js', () => ({
+  BackgroundTasksPanel: () => null,
+}))
+
+vi.mock('../tasks/taskStatusUtils.js', () => ({
+  shouldHideTasksFooter: () => false,
+}))
+
+vi.mock('../teams/TeamsDialog.js', () => ({
+  TeamsDialog: () => null,
+}))
+
+vi.mock('../v2/primitives.js', () => ({
+  ModeSwitcher: () => null,
+}))
+
+vi.mock('./ConfiguredPromptTextInput.js', async () => {
+  const ReactModule = await import('react')
+  return {
+    ConfiguredPromptTextInput: ({
+      baseProps,
+    }: {
+      readonly baseProps: Record<string, unknown>
+    }) => {
+      harness.baseProps = baseProps
+      harness.onRender()
+      return ReactModule.createElement(ReactModule.Fragment)
+    },
+  }
+})
+
+vi.mock('./Notifications.js', () => ({
+  FOOTER_TEMPORARY_STATUS_TIMEOUT: 3000,
+  Notifications: () => null,
+}))
+
+vi.mock('./PromptInputFooter.js', () => ({
+  default: () => null,
+}))
+
+vi.mock('./PromptInputModeIndicator.js', () => ({
+  PromptInputModeIndicator: () => null,
+}))
+
+vi.mock('./PromptInputQueuedCommands.js', () => ({
+  PromptInputQueuedCommands: () => null,
+}))
+
+vi.mock('./PromptInputStashNotice.js', () => ({
+  PromptInputStashNotice: () => null,
+}))
+
+vi.mock('./useMaybeTruncateInput.js', () => ({
+  useMaybeTruncateInput: vi.fn(),
+}))
+
+vi.mock('./usePromptInputPlaceholder.js', () => ({
+  usePromptInputPlaceholder: () => 'Type a prompt',
+}))
+
+vi.mock('./useShowFastIconHint.js', () => ({
+  useShowFastIconHint: () => false,
+}))
+
+vi.mock('./useSwarmBanner.js', () => ({
+  useSwarmBanner: () => null,
+}))
+
+vi.mock('./utils.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('./utils.js')>()
+  return {
+    ...actual,
+    isVimModeEnabled: () => false,
+  }
+})
+
+import { createRoot } from '../../ink/root.js'
+import PromptInput from './PromptInput.js'
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function createTestStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+  ;(stdout as unknown as { rows: number }).rows = 30
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function waitForPromptInputProps(): Promise<Record<string, unknown>> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < 1000) {
+    if (harness.baseProps) return harness.baseProps
+    await sleep(10)
+  }
+  throw new Error('PromptInput base props were not captured')
+}
+
+function basePromptInputProps(overrides: Record<string, unknown> = {}) {
+  return {
+    agents: [],
+    apiKeyStatus: 'valid',
+    autoUpdaterResult: null,
+    commands: [],
+    debug: false,
+    getToolUseContext: () => ({}),
+    hasSuppressedDialogs: false,
+    helpOpen: false,
+    ideSelection: undefined,
+    input: '',
+    isLoading: false,
+    isLocalJSXCommandActive: false,
+    isSearchingHistory: false,
+    mcpClients: [],
+    messages: [],
+    mode: 'prompt',
+    onAutoUpdaterResult: vi.fn(),
+    onExit: vi.fn(),
+    onInputChange: vi.fn(),
+    onModeChange: vi.fn(),
+    onShowMessageSelector: vi.fn(),
+    onSubmit: vi.fn(async () => {}),
+    pastedContents: {},
+    setHelpOpen: vi.fn(),
+    setIsSearchingHistory: vi.fn(),
+    setPastedContents: harness.setPastedContents,
+    setShowBashesDialog: vi.fn(),
+    setStashedPrompt: vi.fn(),
+    setToolPermissionContext: vi.fn(),
+    setVimMode: vi.fn(),
+    showBashesDialog: false,
+    stashedPrompt: undefined,
+    submitCount: 0,
+    toolPermissionContext: harness.appState.toolPermissionContext,
+    verbose: false,
+    vimMode: 'INSERT',
+    ...overrides,
+  }
+}
+
+async function renderPromptInput(overrides: Record<string, unknown> = {}) {
+  const { stdin, stdout } = createTestStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  const props = basePromptInputProps(overrides)
+
+  root.render(<PromptInput {...(props as never)} />)
+  await waitForPromptInputProps()
+
+  return {
+    props,
+    root,
+    stdin,
+    stdout,
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep(25)
+    },
+  }
+}
+
+describe('PromptInput render surface', () => {
+  beforeEach(() => {
+    harness.reset()
+  })
+
+  test('wires base text input props for the idle prompt surface', async () => {
+    const rendered = await renderPromptInput({ input: 'hello' })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+
+      expect(baseProps.value).toBe('hello')
+      expect(baseProps.placeholder).toBe('Type a prompt')
+      expect(baseProps.focus).toBe(true)
+      expect(baseProps.showCursor).toBe(true)
+      expect(baseProps.columns).toBe(95)
+      expect(baseProps.multiline).toBe(true)
+      expect(baseProps.disableCursorMovementForUpDownKeys).toBe(false)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('submits normal prompt input through the leader path', async () => {
+    const onSubmit = vi.fn(async () => {})
+    const rendered = await renderPromptInput({ input: 'hello', onSubmit })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+      await (baseProps.onSubmit as (value: string) => Promise<void>)('hello')
+
+      expect(onSubmit).toHaveBeenCalledWith(
+        'hello',
+        expect.objectContaining({
+          clearBuffer: harness.clearBuffer,
+          resetHistory: expect.any(Function),
+          setCursorOffset: expect.any(Function),
+        }),
+        undefined,
+        expect.objectContaining({
+          mode: 'prompt',
+          vimRoutingState: expect.objectContaining({ enabled: false }),
+        }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('updates mode, text, and paste state through captured input handlers', async () => {
+    const onInputChange = vi.fn()
+    const onModeChange = vi.fn()
+    const setHelpOpen = vi.fn()
+    const setPastedContents = vi.fn(
+      (updater: (prev: Record<number, unknown>) => Record<number, unknown>) =>
+        updater({}),
+    )
+    const rendered = await renderPromptInput({
+      input: '',
+      onInputChange,
+      onModeChange,
+      setHelpOpen,
+      setPastedContents,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+
+      ;(baseProps.onChange as (value: string) => void)('?')
+      expect(setHelpOpen).toHaveBeenCalledWith(expect.any(Function))
+
+      ;(baseProps.onChange as (value: string) => void)('!echo hi')
+      expect(onModeChange).toHaveBeenCalledWith('bash')
+      expect(onInputChange).toHaveBeenCalledWith('echo hi')
+
+      ;(baseProps.onPaste as (value: string) => void)('short\tpaste')
+      expect(onInputChange).toHaveBeenCalledWith('short    pasteecho hi')
+
+      ;(baseProps.onPaste as (value: string) => void)('x'.repeat(40))
+      expect(setPastedContents).toHaveBeenCalled()
+      expect(onInputChange).toHaveBeenCalledWith(expect.stringContaining('[Pasted text'))
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -59,6 +59,69 @@ const harness = vi.hoisted(() => {
     pushToBuffer: vi.fn(),
     removeNotification: vi.fn(),
     updateSettingsForSource: vi.fn(),
+    activeAgent: { type: 'leader' } as { type: string; task?: unknown },
+    autoModeOptInProps: undefined as undefined | Record<string, unknown>,
+    backgroundTasksPanelProps: undefined as undefined | Record<string, unknown>,
+    commandQueue: [] as unknown[],
+    coordinatorTaskCount: 0,
+    features: {} as Record<string, boolean>,
+    getGlobalConfigResult: {} as Record<string, unknown>,
+    globalSearchProps: undefined as undefined | Record<string, unknown>,
+    hasAutoModeOptIn: true,
+    history: {
+      dismissSearchHint: vi.fn(),
+      historyFailedMatch: false,
+      historyIndex: 0,
+      historyMatch: null as unknown,
+      historyQuery: '',
+      onHistoryDown: vi.fn(() => false),
+      onHistoryUp: vi.fn(),
+      resetHistory: vi.fn(),
+      setHistoryQuery: vi.fn(),
+    },
+    historySearchProps: undefined as undefined | Record<string, unknown>,
+    ideAtMentionedHandler: undefined as
+      | undefined
+      | ((atMentioned: {
+          filePath: string
+          lineEnd?: number
+          lineStart?: number
+        }) => void),
+    isAgentSwarmsEnabled: false,
+    isBackgroundTask: vi.fn(() => false),
+    isInProcessEnabled: false,
+    isInProcessTeammate: false,
+    isMacosOptionChar: false,
+    isSSH: false,
+    keybindingRegistrations: [] as Array<Record<string, unknown>>,
+    modelPickerProps: undefined as undefined | Record<string, unknown>,
+    nextPermissionMode: 'plan',
+    platform: 'linux',
+    quickOpenProps: undefined as undefined | Record<string, unknown>,
+    runningTeammates: [] as unknown[],
+    saveGlobalConfig: vi.fn(),
+    specialChars: {} as Record<string, string>,
+    swarmBanner: null as null | { bgColor: string; text?: string },
+    teammateColor: undefined as undefined | string,
+    teamsDialogProps: undefined as undefined | Record<string, unknown>,
+    terminal: undefined as undefined | string,
+    thinkingToggleProps: undefined as undefined | Record<string, unknown>,
+    typeahead: {
+      commandArgumentHint: undefined as undefined | string,
+      inlineGhostText: undefined as undefined | string,
+      maxColumnWidth: 0,
+      selectedSuggestion: -1,
+      suggestionType: undefined as undefined | string,
+      suggestions: [] as Array<{ description?: string; label: string }>,
+    },
+    visibleAgentTasks: [] as Array<{ id: string; status?: string }>,
+    viewedTeammate: undefined as
+      | undefined
+      | {
+          id: string
+          identity: { agentName: string; color?: string }
+          permissionMode: string
+        },
     fastMode: {
       available: false,
       cooldown: false,
@@ -94,9 +157,67 @@ const harness = vi.hoisted(() => {
       }
       appState.speculation = { status: 'inactive' }
       appState.speculationSessionTimeSavedMs = 0
+      appState.tasks = {}
+      appState.teamContext = undefined
+      appState.toolPermissionContext = {
+        isAutoModeAvailable: true,
+        isBypassPermissionsModeAvailable: true,
+        mode: 'default',
+      }
       appState.viewingAgentTaskId = null
       appState.viewSelectionMode = null
       harness.updateSettingsForSource.mockClear()
+      harness.activeAgent = { type: 'leader' }
+      harness.autoModeOptInProps = undefined
+      harness.backgroundTasksPanelProps = undefined
+      harness.commandQueue = []
+      harness.coordinatorTaskCount = 0
+      harness.features = {}
+      harness.getGlobalConfigResult = {}
+      harness.globalSearchProps = undefined
+      harness.hasAutoModeOptIn = true
+      harness.history.dismissSearchHint.mockClear()
+      harness.history.historyFailedMatch = false
+      harness.history.historyIndex = 0
+      harness.history.historyMatch = null
+      harness.history.historyQuery = ''
+      harness.history.onHistoryDown.mockReset()
+      harness.history.onHistoryDown.mockReturnValue(false)
+      harness.history.onHistoryUp.mockClear()
+      harness.history.resetHistory.mockClear()
+      harness.history.setHistoryQuery.mockClear()
+      harness.historySearchProps = undefined
+      harness.ideAtMentionedHandler = undefined
+      harness.isAgentSwarmsEnabled = false
+      harness.isBackgroundTask.mockReset()
+      harness.isBackgroundTask.mockReturnValue(false)
+      harness.isInProcessEnabled = false
+      harness.isInProcessTeammate = false
+      harness.isMacosOptionChar = false
+      harness.isSSH = false
+      harness.keybindingRegistrations = []
+      harness.modelPickerProps = undefined
+      harness.nextPermissionMode = 'plan'
+      harness.platform = 'linux'
+      harness.quickOpenProps = undefined
+      harness.runningTeammates = []
+      harness.saveGlobalConfig.mockClear()
+      harness.specialChars = {}
+      harness.swarmBanner = null
+      harness.teammateColor = undefined
+      harness.teamsDialogProps = undefined
+      harness.terminal = undefined
+      harness.thinkingToggleProps = undefined
+      harness.typeahead = {
+        commandArgumentHint: undefined,
+        inlineGhostText: undefined,
+        maxColumnWidth: 0,
+        selectedSuggestion: -1,
+        suggestionType: undefined,
+        suggestions: [],
+      }
+      harness.visibleAgentTasks = []
+      harness.viewedTeammate = undefined
       harness.fastMode = {
         available: false,
         cooldown: false,
@@ -119,7 +240,7 @@ const harness = vi.hoisted(() => {
 })
 
 vi.mock('bun:bundle', () => ({
-  feature: () => false,
+  feature: (name: string) => harness.features[name] === true,
 }))
 
 vi.mock('../../../services/analytics/index.js', () => ({
@@ -160,20 +281,31 @@ vi.mock('../../context/promptOverlayContext.js', () => ({
 }))
 
 vi.mock('../../hooks/useCommandQueue.js', () => ({
-  useCommandQueue: () => [],
+  useCommandQueue: () => harness.commandQueue,
 }))
 
 vi.mock('../../hooks/useIdeAtMentioned.js', () => ({
-  useIdeAtMentioned: vi.fn(),
+  useIdeAtMentioned: vi.fn(
+    (
+      _clients: unknown,
+      handler: (atMentioned: {
+        filePath: string
+        lineEnd?: number
+        lineStart?: number
+      }) => void,
+    ) => {
+      harness.ideAtMentionedHandler = handler
+    },
+  ),
 }))
 
 vi.mock('../../hooks/useArrowKeyHistory.js', () => ({
   useArrowKeyHistory: () => ({
-    dismissSearchHint: vi.fn(),
-    historyIndex: 0,
-    onHistoryDown: vi.fn(() => false),
-    onHistoryUp: vi.fn(),
-    resetHistory: vi.fn(),
+    dismissSearchHint: harness.history.dismissSearchHint,
+    historyIndex: harness.history.historyIndex,
+    onHistoryDown: harness.history.onHistoryDown,
+    onHistoryUp: harness.history.onHistoryUp,
+    resetHistory: harness.history.resetHistory,
   }),
 }))
 
@@ -183,10 +315,10 @@ vi.mock('../../hooks/useDoublePress.js', () => ({
 
 vi.mock('../../hooks/useHistorySearch.js', () => ({
   useHistorySearch: () => ({
-    historyFailedMatch: false,
-    historyMatch: null,
-    historyQuery: '',
-    setHistoryQuery: vi.fn(),
+    historyFailedMatch: harness.history.historyFailedMatch,
+    historyMatch: harness.history.historyMatch,
+    historyQuery: harness.history.historyQuery,
+    setHistoryQuery: harness.history.setHistoryQuery,
   }),
 }))
 
@@ -208,14 +340,7 @@ vi.mock('../../hooks/useTerminalSize.js', () => ({
 }))
 
 vi.mock('../../hooks/useTypeahead.js', () => ({
-  useTypeahead: () => ({
-    commandArgumentHint: undefined,
-    inlineGhostText: undefined,
-    maxColumnWidth: 0,
-    selectedSuggestion: -1,
-    suggestionType: undefined,
-    suggestions: [],
-  }),
+  useTypeahead: () => harness.typeahead,
 }))
 
 vi.mock('../../ink/hooks/use-terminal-focus.js', () => ({
@@ -239,7 +364,15 @@ vi.mock('../../ink.js', async () => {
 })
 
 vi.mock('../../keybindings/KeybindingContext.js', () => ({
-  useOptionalKeybindingContext: () => null,
+  useOptionalKeybindingContext: () => ({
+    registerHandler: (registration: Record<string, unknown>) => {
+      harness.keybindingRegistrations.push(registration)
+      return () => {
+        harness.keybindingRegistrations =
+          harness.keybindingRegistrations.filter(item => item !== registration)
+      }
+    },
+  }),
 }))
 
 vi.mock('../../keybindings/shortcutFormat.js', () => ({
@@ -267,8 +400,8 @@ vi.mock('../../state/AppState.js', () => ({
 }))
 
 vi.mock('../../state/selectors.js', () => ({
-  getActiveAgentForInput: () => ({ type: 'leader' }),
-  getViewedTeammateTask: () => undefined,
+  getActiveAgentForInput: () => harness.activeAgent,
+  getViewedTeammateTask: () => harness.viewedTeammate,
 }))
 
 vi.mock('../../state/teammateViewHelpers.js', () => ({
@@ -282,11 +415,11 @@ vi.mock('../../../commands.js', () => ({
 }))
 
 vi.mock('../../../tasks/InProcessTeammateTask/InProcessTeammateTask.js', () => ({
-  getRunningTeammatesSorted: () => [],
+  getRunningTeammatesSorted: () => harness.runningTeammates,
 }))
 
 vi.mock('../../../tasks/types.js', () => ({
-  isBackgroundTask: () => false,
+  isBackgroundTask: (task: unknown) => harness.isBackgroundTask(task),
 }))
 
 vi.mock('../../../tools/AgentTool/agentColorManager.js', () => ({
@@ -295,7 +428,7 @@ vi.mock('../../../tools/AgentTool/agentColorManager.js', () => ({
 }))
 
 vi.mock('../../../utils/agentSwarmsEnabled.js', () => ({
-  isAgentSwarmsEnabled: () => false,
+  isAgentSwarmsEnabled: () => harness.isAgentSwarmsEnabled,
 }))
 
 vi.mock('../../../utils/array.js', () => ({
@@ -304,8 +437,8 @@ vi.mock('../../../utils/array.js', () => ({
 }))
 
 vi.mock('../../../utils/config.js', () => ({
-  getGlobalConfig: () => ({}),
-  saveGlobalConfig: vi.fn(),
+  getGlobalConfig: () => harness.getGlobalConfigResult,
+  saveGlobalConfig: harness.saveGlobalConfig,
 }))
 
 vi.mock('../../../utils/cwd.js', () => ({
@@ -328,8 +461,10 @@ vi.mock('../../../utils/dragDropPaths.js', () => ({
 
 vi.mock('../../../utils/env.js', () => ({
   env: {
-    isSSH: () => false,
-    terminal: undefined,
+    isSSH: () => harness.isSSH,
+    get terminal() {
+      return harness.terminal
+    },
   },
 }))
 
@@ -372,8 +507,8 @@ vi.mock('../../../utils/imageStore.js', () => ({
 }))
 
 vi.mock('../../../utils/keyboardShortcuts.js', () => ({
-  MACOS_OPTION_SPECIAL_CHARS: {},
-  isMacosOptionChar: () => false,
+  MACOS_OPTION_SPECIAL_CHARS: harness.specialChars,
+  isMacosOptionChar: () => harness.isMacosOptionChar,
 }))
 
 vi.mock('../../../utils/log.js', () => ({
@@ -391,7 +526,7 @@ vi.mock('../../../utils/permissions/autoModeState.js', () => ({
 
 vi.mock('../../../utils/permissions/getNextPermissionMode.js', () => ({
   cyclePermissionMode: (context: unknown) => ({ context }),
-  getNextPermissionMode: () => 'plan',
+  getNextPermissionMode: () => harness.nextPermissionMode,
 }))
 
 vi.mock('../../../utils/permissions/permissionSetup.js', () => ({
@@ -399,7 +534,7 @@ vi.mock('../../../utils/permissions/permissionSetup.js', () => ({
 }))
 
 vi.mock('../../../utils/platform.js', () => ({
-  getPlatform: () => 'linux',
+  getPlatform: () => harness.platform,
 }))
 
 vi.mock('../../../utils/promptEditor.js', () => ({
@@ -411,7 +546,7 @@ vi.mock('../../input/processBashCommand.js', () => ({
 }))
 
 vi.mock('../../../utils/settings/settings.js', () => ({
-  hasAutoModeOptIn: () => true,
+  hasAutoModeOptIn: () => harness.hasAutoModeOptIn,
   updateSettingsForSource: harness.updateSettingsForSource,
 }))
 
@@ -427,7 +562,7 @@ vi.mock('../../../utils/suggestions/slackChannelSuggestions.js', () => ({
 }))
 
 vi.mock('../../../utils/swarm/backends/registry.js', () => ({
-  isInProcessEnabled: () => false,
+  isInProcessEnabled: () => harness.isInProcessEnabled,
 }))
 
 vi.mock('../../../utils/swarm/teamHelpers.js', () => ({
@@ -435,11 +570,11 @@ vi.mock('../../../utils/swarm/teamHelpers.js', () => ({
 }))
 
 vi.mock('../../../utils/teammate.js', () => ({
-  getTeammateColor: () => undefined,
+  getTeammateColor: () => harness.teammateColor,
 }))
 
 vi.mock('../../../utils/teammateContext.js', () => ({
-  isInProcessTeammate: () => false,
+  isInProcessTeammate: () => harness.isInProcessTeammate,
 }))
 
 vi.mock('../../../utils/teammateMailbox.js', () => ({
@@ -457,7 +592,10 @@ vi.mock('../../../conversation/token-budget.js', () => ({
 }))
 
 vi.mock('../AutoModeOptInDialog.js', () => ({
-  AutoModeOptInDialog: () => null,
+  AutoModeOptInDialog: (props: Record<string, unknown>) => {
+    harness.autoModeOptInProps = props
+    return null
+  },
 }))
 
 vi.mock('../ConfigurableShortcutHint.js', () => ({
@@ -465,8 +603,8 @@ vi.mock('../ConfigurableShortcutHint.js', () => ({
 }))
 
 vi.mock('../CoordinatorAgentStatus.js', () => ({
-  getVisibleAgentTasks: () => [],
-  useCoordinatorTaskCount: () => 0,
+  getVisibleAgentTasks: () => harness.visibleAgentTasks,
+  useCoordinatorTaskCount: () => harness.coordinatorTaskCount,
 }))
 
 vi.mock('../EffortIndicator.js', () => ({
@@ -484,27 +622,45 @@ vi.mock('../FullscreenLayout.js', () => ({
 }))
 
 vi.mock('../GlobalSearchDialog.js', () => ({
-  GlobalSearchDialog: () => null,
+  GlobalSearchDialog: (props: Record<string, unknown>) => {
+    harness.globalSearchProps = props
+    return null
+  },
 }))
 
 vi.mock('../../history/HistorySearchDialog.js', () => ({
-  HistorySearchDialog: () => null,
+  HistorySearchDialog: (props: Record<string, unknown>) => {
+    harness.historySearchProps = props
+    return null
+  },
 }))
 
 vi.mock('../ModelPicker.js', () => ({
-  ModelPicker: () => null,
+  ModelPicker: (props: Record<string, unknown>) => {
+    harness.modelPickerProps = props
+    return null
+  },
 }))
 
 vi.mock('../QuickOpenDialog.js', () => ({
-  QuickOpenDialog: () => null,
+  QuickOpenDialog: (props: Record<string, unknown>) => {
+    harness.quickOpenProps = props
+    return null
+  },
 }))
 
 vi.mock('../ThinkingToggle.js', () => ({
-  ThinkingToggle: () => null,
+  ThinkingToggle: (props: Record<string, unknown>) => {
+    harness.thinkingToggleProps = props
+    return null
+  },
 }))
 
 vi.mock('../tasks/BackgroundTasksPanel.js', () => ({
-  BackgroundTasksPanel: () => null,
+  BackgroundTasksPanel: (props: Record<string, unknown>) => {
+    harness.backgroundTasksPanelProps = props
+    return null
+  },
 }))
 
 vi.mock('../tasks/taskStatusUtils.js', () => ({
@@ -512,7 +668,10 @@ vi.mock('../tasks/taskStatusUtils.js', () => ({
 }))
 
 vi.mock('../teams/TeamsDialog.js', () => ({
-  TeamsDialog: () => null,
+  TeamsDialog: (props: Record<string, unknown>) => {
+    harness.teamsDialogProps = props
+    return null
+  },
 }))
 
 vi.mock('../v2/primitives.js', () => ({
@@ -568,7 +727,7 @@ vi.mock('./useShowFastIconHint.js', () => ({
 }))
 
 vi.mock('./useSwarmBanner.js', () => ({
-  useSwarmBanner: () => null,
+  useSwarmBanner: () => harness.swarmBanner,
 }))
 
 vi.mock('./utils.js', async importOriginal => {
@@ -1333,6 +1492,245 @@ describe('PromptInput render surface', () => {
       ])
       expect(onInputChange).toHaveBeenCalledWith('')
       expect(onModeChange).toHaveBeenCalledWith('prompt')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('selects the task footer from history navigation and opens it from footer keys', async () => {
+    harness.isBackgroundTask.mockImplementation(
+      task => (task as { background?: boolean }).background === true,
+    )
+    harness.appState.tasks = {
+      task1: { background: true },
+    }
+    harness.history.onHistoryDown.mockReturnValue(true)
+
+    const historyRendered = await renderPromptInput({ input: 'line' })
+    try {
+      const baseProps = await waitForPromptInputProps()
+
+      ;(baseProps.onHistoryDown as () => void)()
+
+      expect(harness.history.onHistoryDown).toHaveBeenCalled()
+      expect(harness.appState.footerSelection).toBe('tasks')
+      expect(harness.saveGlobalConfig).toHaveBeenCalledWith(expect.any(Function))
+    } finally {
+      await historyRendered.dispose()
+    }
+
+    harness.baseProps = undefined
+    harness.appState.footerSelection = 'tasks'
+    const setShowBashesDialog = vi.fn()
+    const footerRendered = await renderPromptInput({
+      input: 'line',
+      setShowBashesDialog,
+    })
+    try {
+      await waitForPromptInputProps()
+
+      harness.keybindings['footer:down']?.()
+      expect(setShowBashesDialog).toHaveBeenCalledWith(true)
+      expect(harness.appState.footerSelection).toBeNull()
+
+      harness.appState.footerSelection = 'tasks'
+      harness.keybindings['footer:clearSelection']?.()
+      expect(harness.appState.footerSelection).toBeNull()
+    } finally {
+      await footerRendered.dispose()
+    }
+  })
+
+  test('types through selected footer and handles help escape shortcuts', async () => {
+    harness.isBackgroundTask.mockImplementation(
+      task => (task as { background?: boolean }).background === true,
+    )
+    harness.appState.tasks = {
+      task1: { background: true },
+    }
+    harness.appState.footerSelection = 'tasks'
+    const onInputChange = vi.fn()
+    const setHelpOpen = vi.fn()
+    const rendered = await renderPromptInput({
+      helpOpen: true,
+      input: 'hi',
+      onInputChange,
+      setHelpOpen,
+    })
+
+    try {
+      await waitForPromptInputProps()
+
+      latestInputHandler()('x', {
+        ctrl: false,
+        escape: false,
+        meta: false,
+        return: false,
+      })
+      expect(onInputChange).toHaveBeenCalledWith('hix')
+      expect(harness.appState.footerSelection).toBeNull()
+
+      const escapeEvent = { stopImmediatePropagation: vi.fn() }
+      latestInputHandler()('', { escape: true }, escapeEvent)
+      expect(setHelpOpen).toHaveBeenCalledWith(false)
+      expect(escapeEvent.stopImmediatePropagation).toHaveBeenCalled()
+
+      const returnEvent = { stopImmediatePropagation: vi.fn() }
+      latestInputHandler()('', { return: true }, returnEvent)
+      expect(returnEvent.stopImmediatePropagation).toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('drives model and thinking picker callbacks from chat keybindings', async () => {
+    harness.fastMode.enabled = true
+    harness.fastMode.available = true
+    harness.fastMode.supportedByModel = false
+    harness.appState.fastMode = true
+    const setHelpOpen = vi.fn()
+    const rendered = await renderPromptInput({
+      helpOpen: true,
+      setHelpOpen,
+    })
+
+    try {
+      await waitForPromptInputProps()
+
+      harness.keybindings['chat:modelPicker']?.()
+      await sleep(25)
+      expect(setHelpOpen).toHaveBeenCalledWith(false)
+      expect(harness.modelPickerProps).toBeDefined()
+
+      ;(harness.modelPickerProps?.onSelect as (
+        model: string | null,
+        effort: unknown,
+      ) => void)('gpt-slow', undefined)
+      expect(harness.appState.mainLoopModel).toBe('gpt-slow')
+      expect(harness.appState.mainLoopModelForSession).toBeNull()
+      expect(harness.appState.fastMode).toBe(false)
+      expect(harness.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'model-switched' }),
+      )
+
+      harness.keybindings['chat:thinkingToggle']?.()
+      await sleep(25)
+      expect(harness.thinkingToggleProps).toBeDefined()
+
+      ;(harness.thinkingToggleProps?.onSelect as (enabled: boolean) => void)(
+        false,
+      )
+      expect(harness.appState.thinkingEnabled).toBe(false)
+      expect(harness.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'thinking-toggled-hotkey' }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('handles quick-open and history-picker feature dialog callbacks', async () => {
+    harness.features.QUICK_SEARCH = true
+    harness.features.HISTORY_PICKER = true
+    const onInputChange = vi.fn()
+    const onModeChange = vi.fn()
+    const setHelpOpen = vi.fn()
+    const setPastedContents = vi.fn()
+    const rendered = await renderPromptInput({
+      helpOpen: true,
+      input: 'abc',
+      onInputChange,
+      onModeChange,
+      setHelpOpen,
+      setPastedContents,
+    })
+
+    try {
+      await waitForPromptInputProps()
+
+      harness.keybindings['app:quickOpen']?.()
+      await sleep(25)
+      expect(setHelpOpen).toHaveBeenCalledWith(false)
+      expect(harness.quickOpenProps).toBeDefined()
+
+      ;(harness.quickOpenProps?.onInsert as (text: string) => void)('@src/app.ts')
+      expect(onInputChange).toHaveBeenCalledWith('abc @src/app.ts')
+
+      ;(harness.quickOpenProps?.onDone as () => void)()
+      await sleep(25)
+
+      harness.keybindings['history:search']?.()
+      await sleep(25)
+      expect(harness.historySearchProps).toBeDefined()
+
+      ;(harness.historySearchProps?.onSelect as (entry: {
+        display: string
+        pastedContents: Record<number, PastedContent>
+      }) => void)({
+        display: '!npm test',
+        pastedContents: { 9: { id: 9, type: 'text', content: 'saved' } },
+      })
+      expect(onModeChange).toHaveBeenCalledWith('bash')
+      expect(onInputChange).toHaveBeenCalledWith('npm test')
+      expect(setPastedContents).toHaveBeenCalledWith({
+        9: { id: 9, type: 'text', content: 'saved' },
+      })
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('inserts IDE mentions and converts dragged paths into mentions', async () => {
+    const onInputChange = vi.fn()
+    const rendered = await renderPromptInput({
+      input: 'prefix',
+      onInputChange,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+
+      harness.ideAtMentionedHandler?.({
+        filePath: '/repo/src/file.ts',
+        lineEnd: 7,
+        lineStart: 4,
+      })
+      expect(onInputChange).toHaveBeenCalledWith(
+        'prefix @src/file.ts#L4-7 ',
+      )
+
+      ;(baseProps.onPaste as (value: string) => void)('/dragged/file:b')
+      expect(onInputChange).toHaveBeenCalledWith(
+        expect.stringContaining('@"/dragged/file:b" '),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('registered chat submit handler submits the current prompt', async () => {
+    const onSubmit = vi.fn(async () => {})
+    const rendered = await renderPromptInput({
+      input: 'registered submit',
+      onSubmit,
+    })
+
+    try {
+      await waitForPromptInputProps()
+      const registration = harness.keybindingRegistrations.find(
+        item => item.action === 'chat:submit',
+      )
+      expect(registration).toBeDefined()
+
+      ;(registration?.handler as () => void)()
+      await sleep(25)
+
+      expect(onSubmit).toHaveBeenCalledWith(
+        'registered submit',
+        expect.anything(),
+        undefined,
+        expect.objectContaining({ mode: 'prompt' }),
+      )
     } finally {
       await rendered.dispose()
     }

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -51,6 +51,9 @@ const harness = vi.hoisted(() => {
     }>,
     logEvent: vi.fn(),
     promptSuggestionLogEvent: vi.fn(),
+    processBashCommand: vi.fn(async () => ({
+      messages: [],
+    })),
     onRender: vi.fn(),
     pushToBuffer: vi.fn(),
     removeNotification: vi.fn(),
@@ -68,6 +71,10 @@ const harness = vi.hoisted(() => {
       harness.clearBuffer.mockClear()
       harness.logEvent.mockClear()
       harness.promptSuggestionLogEvent.mockClear()
+      harness.processBashCommand.mockReset()
+      harness.processBashCommand.mockResolvedValue({
+        messages: [],
+      })
       harness.onRender.mockClear()
       harness.pushToBuffer.mockClear()
       harness.removeNotification.mockClear()
@@ -396,6 +403,10 @@ vi.mock('../../../utils/platform.js', () => ({
 
 vi.mock('../../../utils/promptEditor.js', () => ({
   editPromptInEditor: vi.fn(async () => harness.editPromptResult),
+}))
+
+vi.mock('../../input/processBashCommand.js', () => ({
+  processBashCommand: harness.processBashCommand,
 }))
 
 vi.mock('../../../utils/settings/settings.js', () => ({
@@ -1034,6 +1045,151 @@ describe('PromptInput render surface', () => {
       )
       expect(harness.appState.promptSuggestion.text).toBe('finish via speculation')
       expect(harness.appState.promptSuggestion.acceptedAt).toBeGreaterThan(0)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('executes bash-mode input locally and emits transcript events', async () => {
+    const emitted: unknown[] = []
+    const setToolJSX = vi.fn()
+    const getToolUseContext = vi.fn(() => ({
+      session: {
+        emit: (event: unknown) => emitted.push(event),
+        nextInternalSubId: vi.fn()
+          .mockReturnValueOnce('bash-input-id')
+          .mockReturnValueOnce('bash-stdout-id')
+          .mockReturnValueOnce('bash-stderr-id'),
+      },
+      setToolJSX,
+    }))
+    harness.processBashCommand.mockResolvedValue({
+      messages: [
+        {
+          message: {
+            content: [
+              { text: '<bash-stdout>ok</bash-stdout>', type: 'text' },
+            ],
+          },
+          type: 'user',
+        },
+        {
+          message: {
+            content: [
+              { text: '<ignored>nope</ignored>', type: 'text' },
+            ],
+          },
+          type: 'user',
+        },
+        {
+          message: {
+            content: [
+              { text: '<bash-stderr>warn</bash-stderr>', type: 'text' },
+            ],
+          },
+          type: 'user',
+        },
+      ],
+    })
+    const onSubmit = vi.fn(async () => {})
+    const onInputChange = vi.fn()
+    const onModeChange = vi.fn()
+    const rendered = await renderPromptInput({
+      getToolUseContext,
+      input: '  pwd  ',
+      mode: 'bash',
+      onInputChange,
+      onModeChange,
+      onSubmit,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+      await (baseProps.onSubmit as (value: string) => Promise<void>)('  pwd  ')
+
+      expect(onSubmit).not.toHaveBeenCalled()
+      expect(getToolUseContext).toHaveBeenCalled()
+      expect(harness.processBashCommand).toHaveBeenCalledWith(
+        'pwd',
+        [],
+        [],
+        expect.objectContaining({ setToolJSX }),
+        setToolJSX,
+      )
+      expect(emitted).toEqual([
+        expect.objectContaining({
+          id: 'bash-input-id',
+          msg: expect.objectContaining({
+            payload: expect.objectContaining({
+              message: '<bash-input>pwd</bash-input>',
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          id: 'bash-stdout-id',
+          msg: expect.objectContaining({
+            payload: expect.objectContaining({
+              message: '<bash-stdout>ok</bash-stdout>',
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          id: 'bash-stderr-id',
+          msg: expect.objectContaining({
+            payload: expect.objectContaining({
+              message: '<bash-stderr>warn</bash-stderr>',
+            }),
+          }),
+        }),
+      ])
+      expect(onInputChange).toHaveBeenCalledWith('')
+      expect(onModeChange).toHaveBeenCalledWith('prompt')
+      expect(harness.clearBuffer).toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('emits bash stderr when local bash execution throws', async () => {
+    const emitted: unknown[] = []
+    const getToolUseContext = vi.fn(() => ({
+      session: {
+        emit: (event: unknown) => emitted.push(event),
+      },
+    }))
+    harness.processBashCommand.mockRejectedValue(new Error('shell failed'))
+    const onInputChange = vi.fn()
+    const onModeChange = vi.fn()
+    const rendered = await renderPromptInput({
+      getToolUseContext,
+      input: 'explode',
+      mode: 'bash',
+      onInputChange,
+      onModeChange,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+      await (baseProps.onSubmit as (value: string) => Promise<void>)('explode')
+
+      expect(emitted).toEqual([
+        expect.objectContaining({
+          msg: expect.objectContaining({
+            payload: expect.objectContaining({
+              message: '<bash-input>explode</bash-input>',
+            }),
+          }),
+        }),
+        expect.objectContaining({
+          msg: expect.objectContaining({
+            payload: expect.objectContaining({
+              message: '<bash-stderr>shell failed</bash-stderr>',
+            }),
+          }),
+        }),
+      ])
+      expect(onInputChange).toHaveBeenCalledWith('')
+      expect(onModeChange).toHaveBeenCalledWith('prompt')
     } finally {
       await rendered.dispose()
     }

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -64,6 +64,8 @@ const harness = vi.hoisted(() => {
     backgroundTasksPanelProps: undefined as undefined | Record<string, unknown>,
     commandQueue: [] as unknown[],
     coordinatorTaskCount: 0,
+    directMessage: null as null | { message: string; recipientName: string },
+    directMessageResult: { success: false } as Record<string, unknown>,
     features: {} as Record<string, boolean>,
     getGlobalConfigResult: {} as Record<string, unknown>,
     globalSearchProps: undefined as undefined | Record<string, unknown>,
@@ -172,6 +174,8 @@ const harness = vi.hoisted(() => {
       harness.backgroundTasksPanelProps = undefined
       harness.commandQueue = []
       harness.coordinatorTaskCount = 0
+      harness.directMessage = null
+      harness.directMessageResult = { success: false }
       harness.features = {}
       harness.getGlobalConfigResult = {}
       harness.globalSearchProps = undefined
@@ -450,8 +454,8 @@ vi.mock('../../../utils/debug.js', () => ({
 }))
 
 vi.mock('../../../utils/directMemberMessage.js', () => ({
-  parseDirectMemberMessage: () => null,
-  sendDirectMemberMessage: vi.fn(),
+  parseDirectMemberMessage: () => harness.directMessage,
+  sendDirectMemberMessage: vi.fn(() => harness.directMessageResult),
 }))
 
 vi.mock('../../../utils/dragDropPaths.js', () => ({
@@ -507,7 +511,12 @@ vi.mock('../../../utils/imageStore.js', () => ({
 }))
 
 vi.mock('../../../utils/keyboardShortcuts.js', () => ({
-  MACOS_OPTION_SPECIAL_CHARS: harness.specialChars,
+  MACOS_OPTION_SPECIAL_CHARS: new Proxy(
+    {},
+    {
+      get: (_target, prop) => harness.specialChars[String(prop)],
+    },
+  ),
   isMacosOptionChar: () => harness.isMacosOptionChar,
 }))
 
@@ -1731,6 +1740,186 @@ describe('PromptInput render surface', () => {
         undefined,
         expect.objectContaining({ mode: 'prompt' }),
       )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('allocates pasted image IDs after prior transcript references', async () => {
+    vi.mocked(getImageFromClipboard).mockResolvedValue({
+      base64: 'png-data',
+      mediaType: 'image/png',
+    })
+    const onInputChange = vi.fn()
+    const pastedContents = createPastedContentsState()
+    const rendered = await renderPromptInput({
+      input: '',
+      messages: [
+        {
+          imagePasteIds: [3],
+          message: {
+            content: [
+              {
+                text: 'old ref [Image #7]',
+                type: 'text',
+              },
+            ],
+          },
+          type: 'user',
+        },
+      ],
+      onInputChange,
+      pastedContents: pastedContents.current,
+      setPastedContents: pastedContents.setPastedContents,
+    })
+
+    try {
+      await waitForPromptInputProps()
+
+      await harness.keybindings['chat:imagePaste']?.()
+      await sleep(25)
+
+      expect(onInputChange).toHaveBeenCalledWith('[Image #8]')
+      expect(pastedContents.current[8]).toEqual(
+        expect.objectContaining({
+          content: 'png-data',
+          id: 8,
+          type: 'image',
+        }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('sends direct member messages without falling through to leader submit', async () => {
+    harness.isAgentSwarmsEnabled = true
+    harness.directMessage = {
+      message: 'take this',
+      recipientName: 'teammate',
+    }
+    harness.directMessageResult = {
+      recipientName: 'teammate',
+      success: true,
+    }
+    const onInputChange = vi.fn()
+    const onSubmit = vi.fn(async () => {})
+    const rendered = await renderPromptInput({
+      input: '@teammate take this',
+      onInputChange,
+      onSubmit,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+      await (baseProps.onSubmit as (value: string) => Promise<void>)(
+        '@teammate take this',
+      )
+
+      expect(onSubmit).not.toHaveBeenCalled()
+      expect(harness.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'direct-message-sent',
+          text: 'Sent to @teammate',
+        }),
+      )
+      expect(onInputChange).toHaveBeenCalledWith('')
+      expect(harness.clearBuffer).toHaveBeenCalled()
+      expect(harness.history.resetHistory).toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('warns for macOS option-key characters with native CSIu terminal guidance', async () => {
+    harness.platform = 'macos'
+    harness.isMacosOptionChar = true
+    harness.specialChars = { å: 'option+a' }
+    harness.terminal = 'ghostty'
+    const rendered = await renderPromptInput()
+
+    try {
+      await waitForPromptInputProps()
+
+      latestInputHandler()('å', {
+        ctrl: false,
+        escape: false,
+        meta: false,
+        return: false,
+      })
+
+      expect(harness.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'option-meta-hint',
+          priority: 'immediate',
+        }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('previews first-time auto mode before applying transition side effects', async () => {
+    vi.useFakeTimers()
+    harness.features.TRANSCRIPT_CLASSIFIER = true
+    harness.hasAutoModeOptIn = false
+    harness.nextPermissionMode = 'auto'
+    const setHelpOpen = vi.fn()
+    const setToolPermissionContext = vi.fn()
+    const rendered = await renderPromptInput({
+      helpOpen: true,
+      setHelpOpen,
+      setToolPermissionContext,
+    })
+
+    try {
+      await waitForPromptInputProps()
+
+      harness.keybindings['chat:cycleMode']?.()
+
+      expect(harness.appState.toolPermissionContext.mode).toBe('auto')
+      expect(setToolPermissionContext).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: 'auto' }),
+      )
+      expect(setHelpOpen).toHaveBeenCalledWith(false)
+
+      vi.advanceTimersByTime(400)
+    } finally {
+      vi.clearAllTimers()
+      vi.useRealTimers()
+      await rendered.dispose()
+    }
+  })
+
+  test('routes footer close through viewed-agent typing and task dismissal paths', async () => {
+    harness.isBackgroundTask.mockImplementation(
+      task => (task as { background?: boolean }).background === true,
+    )
+    harness.appState.tasks = {
+      task1: { background: true },
+    }
+    harness.appState.footerSelection = 'tasks'
+    harness.appState.coordinatorTaskIndex = 1
+    harness.appState.viewSelectionMode = 'viewing-agent'
+    harness.appState.viewingAgentTaskId = 'agent-1'
+    harness.coordinatorTaskCount = 2
+    harness.visibleAgentTasks = [{ id: 'agent-1', status: 'running' }]
+    const onInputChange = vi.fn()
+    const rendered = await renderPromptInput({
+      input: 'route',
+      onInputChange,
+    })
+
+    try {
+      await waitForPromptInputProps()
+
+      harness.keybindings['footer:close']?.()
+      expect(onInputChange).toHaveBeenCalledWith('routex')
+
+      harness.appState.viewSelectionMode = null
+      harness.visibleAgentTasks = [{ id: 'agent-2', status: 'completed' }]
+      harness.keybindings['footer:close']?.()
+      expect(harness.appState.coordinatorTaskIndex).toBe(0)
     } finally {
       await rendered.dispose()
     }

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -45,10 +45,23 @@ const harness = vi.hoisted(() => {
       error: string | null
     },
     keybindings: {} as Record<string, () => unknown>,
+    inputHandlers: [] as Array<{
+      handler: (input: string, key: Record<string, boolean>, event?: unknown) => unknown
+      options?: Record<string, unknown>
+    }>,
     logEvent: vi.fn(),
     onRender: vi.fn(),
     pushToBuffer: vi.fn(),
     removeNotification: vi.fn(),
+    updateSettingsForSource: vi.fn(),
+    fastMode: {
+      available: false,
+      cooldown: false,
+      enabled: false,
+      runtimeState: { status: 'available' },
+      supportedByModel: true,
+      unavailableReason: null as string | null,
+    },
     reset: () => {
       harness.addNotification.mockClear()
       harness.clearBuffer.mockClear()
@@ -59,6 +72,7 @@ const harness = vi.hoisted(() => {
       harness.baseProps = undefined
       harness.editPromptResult = { content: null, error: null }
       harness.keybindings = {}
+      harness.inputHandlers = []
       appState.coordinatorTaskIndex = -1
       appState.footerSelection = null
       appState.promptSuggestion = {
@@ -71,6 +85,15 @@ const harness = vi.hoisted(() => {
       appState.speculation = { status: 'inactive' }
       appState.viewingAgentTaskId = null
       appState.viewSelectionMode = null
+      harness.updateSettingsForSource.mockClear()
+      harness.fastMode = {
+        available: false,
+        cooldown: false,
+        enabled: false,
+        runtimeState: { status: 'available' },
+        supportedByModel: true,
+        unavailableReason: null,
+      }
     },
     setAppState: vi.fn((updater: unknown) => {
       const next =
@@ -195,7 +218,12 @@ vi.mock('../../ink.js', async () => {
       ReactModule.createElement(ReactModule.Fragment, null, children),
     Text: ({ children }: { readonly children?: React.ReactNode }) =>
       ReactModule.createElement(ReactModule.Fragment, null, children),
-    useInput: vi.fn(),
+    useInput: (
+      handler: (input: string, key: Record<string, boolean>, event?: unknown) => unknown,
+      options?: Record<string, unknown>,
+    ) => {
+      harness.inputHandlers.push({ handler, options })
+    },
   }
 })
 
@@ -310,12 +338,12 @@ vi.mock('../../../utils/fastMode.js', () => ({
   FAST_MODE_MODEL_DISPLAY: 'fast-model',
   clearFastModeCooldown: vi.fn(),
   getFastModeModel: () => 'fast-model',
-  getFastModeRuntimeState: () => ({ status: 'available' }),
-  getFastModeUnavailableReason: () => null,
-  isFastModeAvailable: () => false,
-  isFastModeCooldown: () => false,
-  isFastModeEnabled: () => false,
-  isFastModeSupportedByModel: () => true,
+  getFastModeRuntimeState: () => harness.fastMode.runtimeState,
+  getFastModeUnavailableReason: () => harness.fastMode.unavailableReason,
+  isFastModeAvailable: () => harness.fastMode.available,
+  isFastModeCooldown: () => harness.fastMode.cooldown,
+  isFastModeEnabled: () => harness.fastMode.enabled,
+  isFastModeSupportedByModel: () => harness.fastMode.supportedByModel,
 }))
 
 vi.mock('../../../utils/fullscreen.js', () => ({
@@ -369,7 +397,7 @@ vi.mock('../../../utils/promptEditor.js', () => ({
 
 vi.mock('../../../utils/settings/settings.js', () => ({
   hasAutoModeOptIn: () => true,
-  updateSettingsForSource: vi.fn(),
+  updateSettingsForSource: harness.updateSettingsForSource,
 }))
 
 vi.mock('../../../utils/suggestions/commandSuggestions.js', () => ({
@@ -578,6 +606,21 @@ async function waitForPromptInputProps(): Promise<Record<string, unknown>> {
     await sleep(10)
   }
   throw new Error('PromptInput base props were not captured')
+}
+
+async function waitForInputHandlerCount(count: number): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < 1000) {
+    if (harness.inputHandlers.length >= count) return
+    await sleep(10)
+  }
+  throw new Error(`Expected at least ${count} input handlers, got ${harness.inputHandlers.length}`)
+}
+
+function latestInputHandler(): (input: string, key: Record<string, boolean>) => unknown {
+  const latest = harness.inputHandlers.at(-1)
+  if (!latest) throw new Error('No input handler registered')
+  return latest.handler
 }
 
 function basePromptInputProps(overrides: Record<string, unknown> = {}) {
@@ -818,6 +861,72 @@ describe('PromptInput render surface', () => {
         expect.objectContaining({
           key: 'no-image-in-clipboard',
         }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('opens fast mode picker and enables fast mode with model switch when confirmed', async () => {
+    harness.fastMode.enabled = true
+    harness.fastMode.available = true
+    harness.fastMode.supportedByModel = false
+    const setHelpOpen = vi.fn()
+    const rendered = await renderPromptInput({
+      helpOpen: true,
+      setHelpOpen,
+    })
+
+    try {
+      await waitForPromptInputProps()
+      const handlersBeforePicker = harness.inputHandlers.length
+      harness.keybindings['chat:fastMode']?.()
+      await waitForInputHandlerCount(handlersBeforePicker + 1)
+      expect(setHelpOpen).toHaveBeenCalledWith(false)
+
+      latestInputHandler()(' ', { tab: false })
+      await sleep(25)
+      latestInputHandler()('', { return: true })
+      await sleep(25)
+
+      expect(harness.updateSettingsForSource).toHaveBeenCalledWith(
+        'userSettings',
+        { fastMode: true },
+      )
+      expect(harness.appState.fastMode).toBe(true)
+      expect(harness.appState.mainLoopModel).toBe('fast-model')
+      expect(harness.appState.mainLoopModelForSession).toBeNull()
+      expect(harness.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'fast-mode-toggled' }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('cancels unavailable fast mode by disabling an existing fast-mode session', async () => {
+    harness.appState.fastMode = true
+    harness.fastMode.enabled = true
+    harness.fastMode.available = true
+    harness.fastMode.unavailableReason = 'Fast mode unavailable'
+    const rendered = await renderPromptInput()
+
+    try {
+      await waitForPromptInputProps()
+      const handlersBeforePicker = harness.inputHandlers.length
+      harness.keybindings['chat:fastMode']?.()
+      await waitForInputHandlerCount(handlersBeforePicker + 1)
+
+      latestInputHandler()('', { escape: true })
+      await sleep(25)
+
+      expect(harness.updateSettingsForSource).toHaveBeenCalledWith(
+        'userSettings',
+        { fastMode: undefined },
+      )
+      expect(harness.appState.fastMode).toBe(false)
+      expect(harness.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'fast-mode-toggled' }),
       )
     } finally {
       await rendered.dispose()

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -50,6 +50,7 @@ const harness = vi.hoisted(() => {
       options?: Record<string, unknown>
     }>,
     logEvent: vi.fn(),
+    promptSuggestionLogEvent: vi.fn(),
     onRender: vi.fn(),
     pushToBuffer: vi.fn(),
     removeNotification: vi.fn(),
@@ -66,6 +67,7 @@ const harness = vi.hoisted(() => {
       harness.addNotification.mockClear()
       harness.clearBuffer.mockClear()
       harness.logEvent.mockClear()
+      harness.promptSuggestionLogEvent.mockClear()
       harness.onRender.mockClear()
       harness.pushToBuffer.mockClear()
       harness.removeNotification.mockClear()
@@ -83,6 +85,7 @@ const harness = vi.hoisted(() => {
         text: null,
       }
       appState.speculation = { status: 'inactive' }
+      appState.speculationSessionTimeSavedMs = 0
       appState.viewingAgentTaskId = null
       appState.viewSelectionMode = null
       harness.updateSettingsForSource.mockClear()
@@ -125,7 +128,7 @@ vi.mock('../../../services/PromptSuggestion/promptSuggestion.js', () => ({
 }))
 
 vi.mock('../../../services/PromptSuggestion/runtime.js', () => ({
-  logEvent: vi.fn(),
+  logEvent: harness.promptSuggestionLogEvent,
 }))
 
 vi.mock('../../../services/PromptSuggestion/speculation.js', () => ({
@@ -928,6 +931,109 @@ describe('PromptInput render surface', () => {
       expect(harness.addNotification).toHaveBeenCalledWith(
         expect.objectContaining({ key: 'fast-mode-toggled' }),
       )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('accepts a visible prompt suggestion on empty submit', async () => {
+    harness.appState.promptSuggestion = {
+      acceptedAt: 0,
+      generationRequestId: 'generation-1',
+      promptId: 'prompt-1',
+      shownAt: 100,
+      text: 'run the test suite',
+    }
+    const onSubmit = vi.fn(async () => {})
+    const rendered = await renderPromptInput({ input: '', onSubmit })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+      await (baseProps.onSubmit as (value: string) => Promise<void>)('')
+
+      expect(onSubmit).toHaveBeenCalledWith(
+        'run the test suite',
+        expect.objectContaining({
+          clearBuffer: harness.clearBuffer,
+          resetHistory: expect.any(Function),
+          setCursorOffset: expect.any(Function),
+        }),
+        undefined,
+        expect.objectContaining({
+          mode: 'prompt',
+          vimRoutingState: expect.objectContaining({ enabled: false }),
+        }),
+      )
+      expect(harness.promptSuggestionLogEvent).toHaveBeenCalledWith(
+        'agenc_prompt_suggestion',
+        expect.objectContaining({
+          generationRequestId: 'generation-1',
+          outcome: 'accepted',
+          prompt_id: 'prompt-1',
+          source: 'cli',
+        }),
+      )
+      expect(harness.appState.promptSuggestion).toEqual({
+        acceptedAt: 0,
+        generationRequestId: null,
+        promptId: null,
+        shownAt: 0,
+        text: null,
+      })
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('routes accepted prompt suggestions through active speculation state', async () => {
+    harness.appState.promptSuggestion = {
+      acceptedAt: 0,
+      generationRequestId: null,
+      promptId: 'prompt-spec',
+      shownAt: 100,
+      text: 'finish via speculation',
+    }
+    harness.appState.speculation = {
+      status: 'active',
+      taskId: 'spec-task',
+    }
+    harness.appState.speculationSessionTimeSavedMs = 1234
+    const onSubmit = vi.fn(async () => {})
+    const rendered = await renderPromptInput({ input: '', onSubmit })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+      await (baseProps.onSubmit as (value: string) => Promise<void>)('')
+
+      expect(onSubmit).toHaveBeenCalledWith(
+        'finish via speculation',
+        expect.objectContaining({
+          clearBuffer: harness.clearBuffer,
+          resetHistory: expect.any(Function),
+          setCursorOffset: expect.any(Function),
+        }),
+        expect.objectContaining({
+          speculationSessionTimeSavedMs: 1234,
+          state: expect.objectContaining({
+            status: 'active',
+            taskId: 'spec-task',
+          }),
+          setAppState: harness.setAppState,
+        }),
+        expect.objectContaining({
+          vimRoutingState: expect.objectContaining({ enabled: false }),
+        }),
+      )
+      expect(harness.promptSuggestionLogEvent).toHaveBeenCalledWith(
+        'agenc_prompt_suggestion',
+        expect.objectContaining({
+          outcome: 'accepted',
+          prompt_id: 'prompt-spec',
+          source: 'cli',
+        }),
+      )
+      expect(harness.appState.promptSuggestion.text).toBe('finish via speculation')
+      expect(harness.appState.promptSuggestion.acceptedAt).toBeGreaterThan(0)
     } finally {
       await rendered.dispose()
     }

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -40,6 +40,11 @@ const harness = vi.hoisted(() => {
     appState,
     baseProps: undefined as undefined | Record<string, unknown>,
     clearBuffer: vi.fn(),
+    editPromptResult: { content: null, error: null } as {
+      content: string | null
+      error: string | null
+    },
+    keybindings: {} as Record<string, () => unknown>,
     logEvent: vi.fn(),
     onRender: vi.fn(),
     pushToBuffer: vi.fn(),
@@ -52,6 +57,8 @@ const harness = vi.hoisted(() => {
       harness.pushToBuffer.mockClear()
       harness.removeNotification.mockClear()
       harness.baseProps = undefined
+      harness.editPromptResult = { content: null, error: null }
+      harness.keybindings = {}
       appState.coordinatorTaskIndex = -1
       appState.footerSelection = null
       appState.promptSuggestion = {
@@ -201,8 +208,12 @@ vi.mock('../../keybindings/shortcutFormat.js', () => ({
 }))
 
 vi.mock('../../keybindings/useKeybinding.js', () => ({
-  useKeybinding: vi.fn(),
-  useKeybindings: vi.fn(),
+  useKeybinding: (action: string, handler: () => unknown) => {
+    harness.keybindings[action] = handler
+  },
+  useKeybindings: (handlers: Record<string, () => unknown>) => {
+    Object.assign(harness.keybindings, handlers)
+  },
 }))
 
 vi.mock('../../glyphs.js', () => ({
@@ -353,7 +364,7 @@ vi.mock('../../../utils/platform.js', () => ({
 }))
 
 vi.mock('../../../utils/promptEditor.js', () => ({
-  editPromptInEditor: vi.fn(async () => ({ content: null, error: null })),
+  editPromptInEditor: vi.fn(async () => harness.editPromptResult),
 }))
 
 vi.mock('../../../utils/settings/settings.js', () => ({
@@ -612,6 +623,7 @@ function basePromptInputProps(overrides: Record<string, unknown> = {}) {
 }
 
 async function renderPromptInput(overrides: Record<string, unknown> = {}) {
+  harness.baseProps = undefined
   const { stdin, stdout } = createTestStreams()
   const root = await createRoot({
     patchConsole: false,
@@ -718,6 +730,95 @@ describe('PromptInput render surface', () => {
       ;(baseProps.onPaste as (value: string) => void)('x'.repeat(40))
       expect(setPastedContents).toHaveBeenCalled()
       expect(onInputChange).toHaveBeenCalledWith(expect.stringContaining('[Pasted text'))
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('handles stash, newline, and external editor chat actions', async () => {
+    const onInputChange = vi.fn()
+    const setPastedContents = vi.fn()
+    const setStashedPrompt = vi.fn()
+    harness.editPromptResult = { content: 'edited draft', error: null }
+
+    const rendered = await renderPromptInput({
+      input: 'draft',
+      onInputChange,
+      setPastedContents,
+      setStashedPrompt,
+    })
+
+    try {
+      await waitForPromptInputProps()
+
+      harness.keybindings['chat:newline']?.()
+      expect(onInputChange).toHaveBeenCalledWith('draft\n')
+
+      harness.keybindings['chat:stash']?.()
+      expect(setStashedPrompt).toHaveBeenCalledWith({
+        text: 'draft',
+        cursorOffset: 'draft'.length,
+        pastedContents: {},
+      })
+      expect(onInputChange).toHaveBeenCalledWith('')
+      expect(setPastedContents).toHaveBeenCalledWith({})
+
+      await harness.keybindings['chat:externalEditor']?.()
+      expect(onInputChange).toHaveBeenCalledWith('edited draft')
+
+      const unstash = await renderPromptInput({
+        input: '',
+        onInputChange,
+        setPastedContents,
+        setStashedPrompt,
+        stashedPrompt: {
+          text: 'restored',
+          cursorOffset: 4,
+          pastedContents: { 7: { id: 7, type: 'text', content: 'saved' } },
+        },
+      })
+      try {
+        await waitForPromptInputProps()
+        harness.keybindings['chat:stash']?.()
+        expect(onInputChange).toHaveBeenCalledWith('restored')
+        expect(setPastedContents).toHaveBeenCalledWith({
+          7: { id: 7, type: 'text', content: 'saved' },
+        })
+      } finally {
+        await unstash.dispose()
+      }
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('handles mode cycle, image paste miss, and empty prompt submission guards', async () => {
+    const onSubmit = vi.fn(async () => {})
+    const setToolPermissionContext = vi.fn()
+    const rendered = await renderPromptInput({
+      input: '',
+      onSubmit,
+      setToolPermissionContext,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+
+      await (baseProps.onSubmit as (value: string) => Promise<void>)('')
+      expect(onSubmit).not.toHaveBeenCalled()
+
+      harness.keybindings['chat:cycleMode']?.()
+      expect(setToolPermissionContext).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: 'plan' }),
+      )
+
+      await harness.keybindings['chat:imagePaste']?.()
+      await sleep(0)
+      expect(harness.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'no-image-in-clipboard',
+        }),
+      )
     } finally {
       await rendered.dispose()
     }

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -52,6 +52,7 @@ const harness = vi.hoisted(() => {
     }>,
     logEvent: vi.fn(),
     promptSuggestionLogEvent: vi.fn(),
+    promptInputFooterProps: undefined as undefined | Record<string, unknown>,
     processBashCommand: vi.fn(async () => ({
       messages: [],
     })),
@@ -82,6 +83,12 @@ const harness = vi.hoisted(() => {
       setHistoryQuery: vi.fn(),
     },
     historySearchProps: undefined as undefined | Record<string, unknown>,
+    historySearchSelect: undefined as
+      | undefined
+      | ((entry: {
+          display: string
+          pastedContents: Record<number, PastedContent>
+        }) => void),
     ideAtMentionedHandler: undefined as
       | undefined
       | ((atMentioned: {
@@ -137,6 +144,7 @@ const harness = vi.hoisted(() => {
       harness.clearBuffer.mockClear()
       harness.logEvent.mockClear()
       harness.promptSuggestionLogEvent.mockClear()
+      harness.promptInputFooterProps = undefined
       harness.processBashCommand.mockReset()
       harness.processBashCommand.mockResolvedValue({
         messages: [],
@@ -191,6 +199,7 @@ const harness = vi.hoisted(() => {
       harness.history.resetHistory.mockClear()
       harness.history.setHistoryQuery.mockClear()
       harness.historySearchProps = undefined
+      harness.historySearchSelect = undefined
       harness.ideAtMentionedHandler = undefined
       harness.isAgentSwarmsEnabled = false
       harness.isBackgroundTask.mockReset()
@@ -318,12 +327,20 @@ vi.mock('../../hooks/useDoublePress.js', () => ({
 }))
 
 vi.mock('../../hooks/useHistorySearch.js', () => ({
-  useHistorySearch: () => ({
+  useHistorySearch: (
+    onSelect: (entry: {
+      display: string
+      pastedContents: Record<number, PastedContent>
+    }) => void,
+  ) => {
+    harness.historySearchSelect = onSelect
+    return {
     historyFailedMatch: harness.history.historyFailedMatch,
     historyMatch: harness.history.historyMatch,
     historyQuery: harness.history.historyQuery,
     setHistoryQuery: harness.history.setHistoryQuery,
-  }),
+    }
+  },
 }))
 
 vi.mock('../../hooks/useInputBuffer.js', () => ({
@@ -708,7 +725,10 @@ vi.mock('./Notifications.js', () => ({
 }))
 
 vi.mock('./PromptInputFooter.js', () => ({
-  default: () => null,
+  default: (props: Record<string, unknown>) => {
+    harness.promptInputFooterProps = props
+    return null
+  },
 }))
 
 vi.mock('./PromptInputModeIndicator.js', () => ({
@@ -1920,6 +1940,143 @@ describe('PromptInput render surface', () => {
       harness.visibleAgentTasks = [{ id: 'agent-2', status: 'completed' }]
       harness.keybindings['footer:close']?.()
       expect(harness.appState.coordinatorTaskIndex).toBe(0)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('covers history search callback and history arrow guard branches', async () => {
+    const onSubmit = vi.fn(async () => {})
+    const setPastedContents = vi.fn()
+    const rendered = await renderPromptInput({
+      input: 'history',
+      onSubmit,
+      setPastedContents,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+
+      harness.historySearchSelect?.({
+        display: 'submit from history',
+        pastedContents: { 4: { id: 4, type: 'text', content: 'history paste' } },
+      })
+      await sleep(25)
+      expect(setPastedContents).toHaveBeenCalledWith({
+        4: { id: 4, type: 'text', content: 'history paste' },
+      })
+      expect(onSubmit).toHaveBeenCalledWith(
+        'submit from history',
+        expect.anything(),
+        undefined,
+        expect.objectContaining({ mode: 'prompt' }),
+      )
+
+      ;(baseProps.onHistoryUp as () => void)()
+      expect(harness.history.onHistoryUp).toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+
+    harness.typeahead.suggestions = [
+      { label: 'one' },
+      { label: 'two' },
+    ]
+    const guarded = await renderPromptInput({ input: 'guarded' })
+    try {
+      const baseProps = await waitForPromptInputProps()
+      harness.history.onHistoryUp.mockClear()
+      harness.history.onHistoryDown.mockClear()
+
+      ;(baseProps.onHistoryUp as () => void)()
+      ;(baseProps.onHistoryDown as () => void)()
+
+      expect(harness.history.onHistoryUp).not.toHaveBeenCalled()
+      expect(harness.history.onHistoryDown).not.toHaveBeenCalled()
+    } finally {
+      await guarded.dispose()
+    }
+  })
+
+  test('opens team footer dialog and global search dialog callbacks', async () => {
+    harness.isAgentSwarmsEnabled = true
+    harness.features.QUICK_SEARCH = true
+    harness.appState.teamContext = {
+      teamName: 'runtime',
+      teammates: {
+        alice: { color: 'cyan', name: 'alice' },
+        'team-lead': { color: 'purple', name: 'team-lead' },
+      },
+    }
+    harness.appState.footerSelection = 'teams'
+    const onInputChange = vi.fn()
+    const setHelpOpen = vi.fn()
+    const rendered = await renderPromptInput({
+      input: 'abc',
+      onInputChange,
+      setHelpOpen,
+    })
+
+    try {
+      await waitForPromptInputProps()
+
+      harness.keybindings['footer:openSelected']?.()
+      await sleep(25)
+      expect(harness.teamsDialogProps).toEqual(
+        expect.objectContaining({
+          initialTeams: [
+            expect.objectContaining({
+              memberCount: 1,
+              name: 'runtime',
+            }),
+          ],
+        }),
+      )
+
+      ;(harness.teamsDialogProps?.onDone as () => void)()
+      await sleep(25)
+
+      harness.keybindings['app:globalSearch']?.()
+      await sleep(25)
+      expect(setHelpOpen).toHaveBeenCalledWith(false)
+      expect(harness.globalSearchProps).toBeDefined()
+
+      ;(harness.globalSearchProps?.onInsert as (text: string) => void)(
+        '@global-result',
+      )
+      expect(onInputChange).toHaveBeenCalledWith('abc @global-result')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('exercises picker cancel callbacks and help/message action keybindings', async () => {
+    const onMessageActionsEnter = vi.fn()
+    const setHelpOpen = vi.fn()
+    const rendered = await renderPromptInput({
+      helpOpen: true,
+      onMessageActionsEnter,
+      setHelpOpen,
+    })
+
+    try {
+      await waitForPromptInputProps()
+
+      harness.keybindings['help:dismiss']?.()
+      expect(setHelpOpen).toHaveBeenCalledWith(false)
+
+      harness.keybindings['chat:messageActions']?.()
+      expect(onMessageActionsEnter).toHaveBeenCalled()
+
+      harness.keybindings['chat:modelPicker']?.()
+      await sleep(25)
+      expect(harness.modelPickerProps).toBeDefined()
+      ;(harness.modelPickerProps?.onCancel as () => void)()
+
+      harness.keybindings['chat:thinkingToggle']?.()
+      await sleep(25)
+      expect(harness.thinkingToggleProps).toBeDefined()
+      ;(harness.thinkingToggleProps?.onCancel as () => void)()
     } finally {
       await rendered.dispose()
     }

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -2,6 +2,7 @@ import { PassThrough } from 'node:stream'
 
 import React from 'react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { PastedContent } from '../../../utils/config.js'
 
 const harness = vi.hoisted(() => {
   const appState = {
@@ -579,6 +580,8 @@ vi.mock('./utils.js', async importOriginal => {
 })
 
 import { createRoot } from '../../ink/root.js'
+import { getImageFromClipboard } from '../../../utils/imagePaste.js'
+import { cacheImagePath, storeImage } from '../../../utils/imageStore.js'
 import PromptInput from './PromptInput.js'
 
 function sleep(ms: number): Promise<void> {
@@ -679,6 +682,27 @@ function basePromptInputProps(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function createPastedContentsState(
+  initial: Record<number, PastedContent> = {},
+): {
+  readonly current: Record<number, PastedContent>
+  setPastedContents: ReturnType<typeof vi.fn>
+} {
+  let current = initial
+  const setPastedContents = vi.fn(
+    (next: React.SetStateAction<Record<number, PastedContent>>) => {
+      current = typeof next === 'function' ? next(current) : next
+    },
+  )
+
+  return {
+    get current() {
+      return current
+    },
+    setPastedContents,
+  }
+}
+
 async function renderPromptInput(overrides: Record<string, unknown> = {}) {
   harness.baseProps = undefined
   const { stdin, stdout } = createTestStreams()
@@ -709,6 +733,10 @@ async function renderPromptInput(overrides: Record<string, unknown> = {}) {
 describe('PromptInput render surface', () => {
   beforeEach(() => {
     harness.reset()
+    vi.mocked(getImageFromClipboard).mockReset()
+    vi.mocked(getImageFromClipboard).mockResolvedValue(null)
+    vi.mocked(cacheImagePath).mockClear()
+    vi.mocked(storeImage).mockClear()
   })
 
   test('wires base text input props for the idle prompt surface', async () => {
@@ -876,6 +904,121 @@ describe('PromptInput render surface', () => {
           key: 'no-image-in-clipboard',
         }),
       )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('pastes clipboard images as pills and lazy-spaces the next typed word', async () => {
+    vi.mocked(getImageFromClipboard).mockResolvedValue({
+      base64: 'jpeg-data',
+      mediaType: 'image/jpeg',
+      dimensions: { width: 640, height: 480 },
+    })
+    const onInputChange = vi.fn()
+    const onModeChange = vi.fn()
+    const pastedContents = createPastedContentsState()
+    const rendered = await renderPromptInput({
+      input: '',
+      onInputChange,
+      onModeChange,
+      pastedContents: pastedContents.current,
+      setPastedContents: pastedContents.setPastedContents,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+
+      await harness.keybindings['chat:imagePaste']?.()
+      await sleep(25)
+
+      expect(getImageFromClipboard).toHaveBeenCalledTimes(1)
+      expect(onModeChange).toHaveBeenCalledWith('prompt')
+      expect(onInputChange).toHaveBeenCalledWith('[Image #1]')
+      expect(pastedContents.current).toEqual({
+        1: expect.objectContaining({
+          content: 'jpeg-data',
+          dimensions: { width: 640, height: 480 },
+          filename: 'Pasted image',
+          id: 1,
+          mediaType: 'image/jpeg',
+          type: 'image',
+        }),
+      })
+      expect(cacheImagePath).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 1, type: 'image' }),
+      )
+      expect(storeImage).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 1, type: 'image' }),
+      )
+
+      const inputFilter = baseProps.inputFilter as (
+        input: string,
+        key: Record<string, boolean>,
+      ) => string
+      expect(inputFilter('caption', {})).toBe(' caption')
+      expect(inputFilter('again', {})).toBe('again')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('prunes pasted image state when image pills are removed from input', async () => {
+    const referencedImage: PastedContent = {
+      id: 1,
+      type: 'image',
+      content: 'kept-image',
+      mediaType: 'image/png',
+      filename: 'kept.png',
+    }
+    const removedImage: PastedContent = {
+      id: 2,
+      type: 'image',
+      content: 'removed-image',
+      mediaType: 'image/png',
+      filename: 'removed.png',
+    }
+    const textPaste: PastedContent = {
+      id: 3,
+      type: 'text',
+      content: 'kept text',
+    }
+    const pastedContents = createPastedContentsState({
+      1: referencedImage,
+      2: removedImage,
+      3: textPaste,
+    })
+    const rendered = await renderPromptInput({
+      input: '[Image #1] [Image #2]',
+      pastedContents: pastedContents.current,
+      setPastedContents: pastedContents.setPastedContents,
+    })
+
+    try {
+      await sleep(25)
+      expect(pastedContents.current).toEqual({
+        1: referencedImage,
+        2: removedImage,
+        3: textPaste,
+      })
+
+      harness.baseProps = undefined
+      rendered.root.render(
+        <PromptInput
+          {...(basePromptInputProps({
+            input: '[Image #1]',
+            pastedContents: pastedContents.current,
+            setPastedContents: pastedContents.setPastedContents,
+          }) as never)}
+        />,
+      )
+      await waitForPromptInputProps()
+      await sleep(25)
+
+      expect(pastedContents.current).toEqual({
+        1: referencedImage,
+        3: textPaste,
+      })
     } finally {
       await rendered.dispose()
     }

--- a/runtime/tests/tui/components/PromptInput/PromptInput.wave200-001.coverage.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.wave200-001.coverage.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../../utils/config.js', () => ({
+  getGlobalConfig: () => ({}),
+  saveGlobalConfig: () => {},
+}))
+
+vi.mock('../../history/history.js', () => ({
+  formatImageRef: () => '',
+  formatPastedTextRef: () => '',
+  getPastedTextRefNumLines: () => 0,
+  parseReferences: () => [],
+}))
+
+import { calculatePromptMaxVisibleLines } from './PromptInput.js'
+
+describe('PromptInput fullscreen sizing coverage', () => {
+  test('normalizes non-finite terminal rows to the minimum fullscreen input budget', () => {
+    expect(calculatePromptMaxVisibleLines(Number.POSITIVE_INFINITY, true)).toBe(1)
+    expect(calculatePromptMaxVisibleLines(Number.NaN, true)).toBe(1)
+  })
+})

--- a/runtime/tests/tui/components/PromptInput/PromptInputFooter.wave200-085.coverage.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInputFooter.wave200-085.coverage.test.tsx
@@ -1,0 +1,289 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../../utils/staticRender.js'
+
+const harness = vi.hoisted(() => ({
+  appState: {
+    coordinatorTaskIndex: -1,
+  },
+  columns: 100,
+  coordinatorTaskCount: 0,
+  fullscreen: false,
+  modalOverlayActive: false,
+  overlays: [] as unknown[],
+  rows: 30,
+  statusLineEnabled: false,
+  reset() {
+    harness.appState.coordinatorTaskIndex = -1
+    harness.columns = 100
+    harness.coordinatorTaskCount = 0
+    harness.fullscreen = false
+    harness.modalOverlayActive = false
+    harness.overlays = []
+    harness.rows = 30
+    harness.statusLineEnabled = false
+  },
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../context/overlayContext.js', () => ({
+  useIsModalOverlayActive: () => harness.modalOverlayActive,
+}))
+
+vi.mock('../../context/promptOverlayContext.js', () => ({
+  useSetPromptOverlay: (data: unknown) => {
+    harness.overlays.push(data)
+  },
+}))
+
+vi.mock('../../hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    statusLine: harness.statusLineEnabled
+      ? {
+          command: 'status',
+        }
+      : undefined,
+  }),
+}))
+
+vi.mock('../../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({
+    columns: harness.columns,
+    rows: harness.rows,
+  }),
+}))
+
+vi.mock('../../../utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => harness.fullscreen,
+}))
+
+vi.mock('../../state/AppState.js', () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+}))
+
+vi.mock('../CoordinatorAgentStatus.js', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../../ink.js')
+
+  return {
+    CoordinatorTaskPanel: () =>
+      ReactModule.createElement(Text, null, 'CoordinatorTaskPanel'),
+    useCoordinatorTaskCount: () => harness.coordinatorTaskCount,
+  }
+})
+
+vi.mock('../../startup/StatusLine.js', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../../ink.js')
+
+  return {
+    getLastAssistantMessageId: (messages: Array<{ uuid?: string }>) =>
+      messages.at(-1)?.uuid ?? null,
+    StatusLine: ({ lastAssistantMessageId }: { lastAssistantMessageId: string | null }) =>
+      ReactModule.createElement(Text, null, `StatusLine:${lastAssistantMessageId}`),
+    statusLineShouldDisplay: (settings: { statusLine?: unknown }) =>
+      settings.statusLine !== undefined,
+  }
+})
+
+vi.mock('./Notifications.js', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../../ink.js')
+
+  return {
+    Notifications: (props: {
+      readonly isInputWrapped: boolean
+      readonly isNarrow: boolean
+      readonly messages: unknown[]
+    }) =>
+      ReactModule.createElement(
+        Text,
+        null,
+        `Notifications:${String(props.isNarrow)}:${String(props.isInputWrapped)}:${props.messages.length}`,
+      ),
+  }
+})
+
+vi.mock('./PromptInputFooterLeftSide.js', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../../ink.js')
+
+  return {
+    PromptInputFooterLeftSide: (props: {
+      readonly isSearching: boolean
+      readonly suppressHint: boolean
+      readonly tasksSelected: boolean
+      readonly vimMode?: string
+    }) =>
+      ReactModule.createElement(
+        Text,
+        null,
+        `Left:${String(props.tasksSelected)}:${props.vimMode ?? 'none'}:${String(props.suppressHint)}:${String(props.isSearching)}`,
+      ),
+  }
+})
+
+vi.mock('./PromptInputFooterSuggestions.js', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../../ink.js')
+
+  return {
+    PromptInputFooterSuggestions: (props: {
+      readonly selectedSuggestion: number
+      readonly suggestionType: string
+      readonly suggestions: Array<{ displayText: string }>
+    }) =>
+      ReactModule.createElement(
+        Text,
+        null,
+        `Suggestions:${props.selectedSuggestion}:${props.suggestionType}:${props.suggestions.map(suggestion => suggestion.displayText).join(',')}`,
+      ),
+  }
+})
+
+vi.mock('./PromptInputHelpMenu.js', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../../ink.js')
+
+  return {
+    PromptInputHelpMenu: (props: {
+      readonly dimColor: boolean
+      readonly fixedWidth: boolean
+      readonly paddingX: number
+    }) =>
+      ReactModule.createElement(
+        Text,
+        null,
+        `HelpMenu:${String(props.dimColor)}:${String(props.fixedWidth)}:${props.paddingX}`,
+      ),
+  }
+})
+
+import PromptInputFooter from './PromptInputFooter.js'
+
+type FooterProps = React.ComponentProps<typeof PromptInputFooter>
+
+const suggestions = [
+  {
+    id: 'command-help',
+    displayText: '/help',
+    description: 'Show help',
+  },
+]
+
+function props(overrides: Partial<FooterProps> = {}): FooterProps {
+  return {
+    apiKeyStatus: 'valid',
+    autoUpdaterResult: null,
+    debug: false,
+    exitMessage: {
+      show: false,
+    },
+    helpOpen: false,
+    historyFailedMatch: false,
+    historyQuery: '',
+    ideSelection: undefined,
+    isAutoUpdating: false,
+    isLoading: false,
+    isPasting: false,
+    isSearching: false,
+    maxColumnWidth: 42,
+    messages: [],
+    mode: 'prompt',
+    onAutoUpdaterResult: vi.fn(),
+    onChangeIsUpdating: vi.fn(),
+    selectedSuggestion: 0,
+    setHistoryQuery: vi.fn(),
+    suggestionType: 'command',
+    suggestions: [],
+    suppressHint: false,
+    tasksSelected: false,
+    teamsSelected: false,
+    toolPermissionContext: {
+      mode: 'default',
+    } as FooterProps['toolPermissionContext'],
+    verbose: false,
+    vimMode: 'INSERT',
+    ...overrides,
+  }
+}
+
+describe('PromptInputFooter coverage branch render', () => {
+  test('switches between suggestions, fullscreen overlay, help, and footer rows', async () => {
+    harness.reset()
+    const inlineSuggestions = await renderToString(
+      <PromptInputFooter {...props({ suggestions })} />,
+      100,
+    )
+
+    expect(inlineSuggestions).toContain('Suggestions:0:command:/help')
+    expect(inlineSuggestions).not.toContain('Left:')
+    expect(harness.overlays.at(-1)).toBeNull()
+
+    harness.reset()
+    harness.fullscreen = true
+    harness.statusLineEnabled = true
+    const fullscreenOutput = await renderToString(
+      <PromptInputFooter
+        {...props({
+          messages: [{ type: 'assistant', uuid: 'msg-1' } as never],
+          suggestions,
+          tasksSelected: true,
+        })}
+      />,
+      {
+        columns: 120,
+        rows: 30,
+      },
+    )
+
+    expect(fullscreenOutput).toContain('StatusLine:msg-1')
+    expect(fullscreenOutput).toContain('Left:true:none:true:false')
+    expect(fullscreenOutput).toContain('CoordinatorTaskPanel')
+    expect(fullscreenOutput).not.toContain('Notifications:')
+    expect(fullscreenOutput).not.toContain('Suggestions:')
+    expect(harness.overlays.at(-1)).toMatchObject({
+      maxColumnWidth: 42,
+      selectedSuggestion: 0,
+      suggestionType: 'command',
+      suggestions,
+    })
+
+    harness.reset()
+    const helpOutput = await renderToString(
+      <PromptInputFooter {...props({ helpOpen: true })} />,
+      100,
+    )
+
+    expect(helpOutput).toContain('HelpMenu:true:true:2')
+    expect(helpOutput).not.toContain('Left:')
+
+    harness.reset()
+    harness.columns = 60
+    harness.modalOverlayActive = true
+    const footerOutput = await renderToString(
+      <PromptInputFooter
+        {...props({
+          isInputWrapped: true,
+          isSearching: true,
+          suggestions,
+        })}
+      />,
+      {
+        columns: 60,
+        rows: 30,
+      },
+    )
+
+    expect(footerOutput).toContain('Left:false:INSERT:true:true')
+    expect(footerOutput).toContain('Notifications:true:true:0')
+    expect(footerOutput).toContain('CoordinatorTaskPanel')
+    expect(footerOutput).not.toContain('Suggestions:')
+    expect(harness.overlays.at(-1)).toBeNull()
+  })
+})

--- a/runtime/tests/tui/components/PromptInput/PromptInputFooterLeftSide.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInputFooterLeftSide.render.test.tsx
@@ -1,0 +1,482 @@
+import { PassThrough } from "node:stream";
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  appState: {
+    expandedView: "none" as "none" | "tasks" | "teammates",
+    notifications: { current: null as null | { key: string } },
+    remoteSessionUrl: undefined as string | undefined,
+    tasks: {} as Record<string, unknown>,
+    teamContext: undefined as
+      | undefined
+      | { teammates: Record<string, { name: string }> },
+    viewingAgentTaskId: undefined as string | undefined,
+    viewSelectionMode: "none",
+  },
+  columns: 100,
+  config: {
+    copyOnSelect: true as boolean | undefined,
+    editorMode: "normal",
+    prStatusFooterEnabled: true as boolean | undefined,
+  },
+  features: new Set<string>(),
+  fullscreen: false,
+  hasSelection: false,
+  inProcessEnabled: false,
+  isCoordinator: false,
+  isRemoteMode: false,
+  isXterm: false,
+  platform: "linux",
+  prStatus: {
+    number: null as number | null,
+    reviewState: null as string | null,
+    url: null as string | null,
+  },
+  proactiveActive: false,
+  proactiveNextTickAt: null as number | null,
+  selectionState: { lastPressHadAlt: false },
+  swarmsEnabled: false,
+  tasksV2: undefined as undefined | Array<{ id: string; subject: string }>,
+  reset() {
+    harness.appState = {
+      expandedView: "none",
+      notifications: { current: null },
+      remoteSessionUrl: undefined,
+      tasks: {},
+      teamContext: undefined,
+      viewingAgentTaskId: undefined,
+      viewSelectionMode: "none",
+    };
+    harness.columns = 100;
+    harness.config = {
+      copyOnSelect: true,
+      editorMode: "normal",
+      prStatusFooterEnabled: true,
+    };
+    harness.features = new Set();
+    harness.fullscreen = false;
+    harness.hasSelection = false;
+    harness.inProcessEnabled = false;
+    harness.isCoordinator = false;
+    harness.isRemoteMode = false;
+    harness.isXterm = false;
+    harness.platform = "linux";
+    harness.prStatus = {
+      number: null,
+      reviewState: null,
+      url: null,
+    };
+    harness.proactiveActive = false;
+    harness.proactiveNextTickAt = null;
+    harness.selectionState = { lastPressHadAlt: false };
+    harness.swarmsEnabled = false;
+    harness.tasksV2 = undefined;
+  },
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: (name: string) => harness.features.has(name),
+}));
+
+vi.mock("../../../coordinator/coordinatorMode.js", () => ({
+  isCoordinatorMode: () => harness.isCoordinator,
+}));
+
+vi.mock("../../keybindings/useShortcutDisplay.js", () => ({
+  useShortcutDisplay: (command: string) => {
+    if (command === "chat:cycleMode") return "shift+tab";
+    if (command === "chat:cancel") return "esc";
+    if (command === "app:toggleTodos") return "ctrl+t";
+    if (command === "chat:killAgents") return "ctrl+x ctrl+k";
+    return command;
+  },
+}));
+
+vi.mock("../tasks/BackgroundTaskStatus.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../ink.js");
+  return {
+    BackgroundTaskStatus: (props: Record<string, unknown>) =>
+      ReactModule.createElement(
+        Text,
+        null,
+        `Tasks:${String(props.tasksSelected)}:${String(props.isViewingTeammate)}:${String(props.isLeaderIdle)}:${String(props.teammateFooterIndex ?? "none")}`,
+      ),
+  };
+});
+
+vi.mock("../CoordinatorAgentStatus.js", () => ({
+  getVisibleAgentTasks: () => [],
+}));
+
+vi.mock("../teams/TeamStatus.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../ink.js");
+  return {
+    TeamStatus: (props: Record<string, unknown>) =>
+      ReactModule.createElement(
+        Text,
+        null,
+        `Teams:${String(props.teamsSelected)}:${String(props.showHint)}`,
+      ),
+  };
+});
+
+vi.mock("../../../tasks/types.js", () => ({
+  isBackgroundTask: (task: { readonly type?: string; readonly status?: string }) =>
+    task.type === "background" && task.status !== "completed",
+}));
+
+vi.mock("../tasks/taskStatusUtils.js", () => ({
+  shouldHideTasksFooter: () => false,
+}));
+
+vi.mock("../../../utils/agentSwarmsEnabled.js", () => ({
+  isAgentSwarmsEnabled: () => harness.swarmsEnabled,
+}));
+
+vi.mock("../../../utils/swarm/backends/registry.js", () => ({
+  isInProcessEnabled: () => harness.inProcessEnabled,
+}));
+
+vi.mock("../../state/AppState.js", () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+  useAppStateStore: () => ({ getState: () => harness.appState }),
+}));
+
+vi.mock("../../../bootstrap/state.js", () => ({
+  flushInteractionTime: vi.fn(),
+  getIsRemoteMode: () => harness.isRemoteMode,
+}));
+
+vi.mock("./HistorySearchInput.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../ink.js");
+  return {
+    default: (props: Record<string, unknown>) =>
+      ReactModule.createElement(
+        Text,
+        null,
+        `History:${String(props.value)}:${String(props.historyFailedMatch)}`,
+      ),
+  };
+});
+
+vi.mock("../../hooks/usePrStatus.js", () => ({
+  usePrStatus: () => harness.prStatus,
+}));
+
+vi.mock("../design-system/KeyboardShortcutHint.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../ink.js");
+  return {
+    KeyboardShortcutHint: ({
+      action,
+      shortcut,
+    }: {
+      readonly action: string;
+      readonly shortcut: string;
+    }) => ReactModule.createElement(Text, null, `${shortcut} ${action}`),
+  };
+});
+
+vi.mock("../design-system/Byline.js", async () => {
+  const ReactModule = await import("react");
+  return {
+    Byline: ({ children }: { readonly children?: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+  };
+});
+
+vi.mock("../../hooks/useTerminalSize.js", () => ({
+  useTerminalSize: () => ({ columns: harness.columns, rows: 24 }),
+}));
+
+vi.mock("../../hooks/useTasksV2.js", () => ({
+  useTasksV2: () => harness.tasksV2,
+}));
+
+vi.mock("../../../utils/fullscreen.js", () => ({
+  isFullscreenEnvEnabled: () => harness.fullscreen,
+}));
+
+vi.mock("../../ink/terminal.js", async importOriginal => {
+  const actual = await importOriginal<typeof import("../../ink/terminal.js")>();
+  return {
+    ...actual,
+    isXtermJs: () => harness.isXterm,
+  };
+});
+
+vi.mock("../../ink/hooks/use-selection.js", () => ({
+  useHasSelection: () => harness.hasSelection,
+  useSelection: () => ({ getState: () => harness.selectionState }),
+}));
+
+vi.mock("../../../utils/config.js", () => ({
+  getGlobalConfig: () => harness.config,
+}));
+
+vi.mock("../../../utils/platform.js", () => ({
+  getPlatform: () => harness.platform,
+}));
+
+vi.mock("../PrBadge.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../ink.js");
+  return {
+    PrBadge: (props: Record<string, unknown>) =>
+      ReactModule.createElement(
+        Text,
+        null,
+        `PR:${String(props.number)}:${String(props.reviewState)}`,
+      ),
+  };
+});
+
+vi.mock("./proactiveAdapter.js", () => ({
+  getPromptInputProactiveNextTickAt: () => harness.proactiveNextTickAt,
+  isPromptInputProactiveActive: () => harness.proactiveActive,
+  subscribeToPromptInputProactiveChanges: () => () => {},
+}));
+
+import { createRoot } from "../../ink.js";
+import { PromptInputFooterLeftSide } from "./PromptInputFooterLeftSide.js";
+
+function createStreams(): {
+  stdout: PassThrough;
+  stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+} {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.resume();
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function renderFooter(
+  overrides: Partial<React.ComponentProps<typeof PromptInputFooterLeftSide>> = {},
+): Promise<{
+  dispose: () => Promise<void>;
+  output: () => string;
+}> {
+  let output = "";
+  const { stdin, stdout } = createStreams();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+  root.render(
+    <PromptInputFooterLeftSide
+      exitMessage={{ show: false }}
+      historyFailedMatch={false}
+      historyQuery=""
+      isLoading={false}
+      isSearching={false}
+      mode="prompt"
+      setHistoryQuery={vi.fn()}
+      suppressHint={false}
+      tasksSelected={false}
+      teamsSelected={false}
+      toolPermissionContext={{ mode: "default" } as never}
+      vimMode={undefined}
+      {...overrides}
+    />,
+  );
+  await sleep();
+  return {
+    dispose: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    },
+    output: () => stripAnsi(output),
+  };
+}
+
+describe("PromptInputFooterLeftSide render paths", () => {
+  beforeEach(() => {
+    harness.reset();
+  });
+
+  test("renders exit and paste priority messages before mode hints", async () => {
+    const exit = await renderFooter({ exitMessage: { key: "ctrl+c", show: true } });
+    try {
+      expect(exit.output()).toContain("Press the same key again to exit");
+    } finally {
+      await exit.dispose();
+    }
+
+    const paste = await renderFooter({ isPasting: true });
+    try {
+      expect(paste.output()).toContain("Pasting text");
+    } finally {
+      await paste.dispose();
+    }
+  });
+
+  test("renders history search, vim mode, and bash mode states", async () => {
+    const search = await renderFooter({
+      historyFailedMatch: true,
+      historyQuery: "needle",
+      isSearching: true,
+      vimMode: "INSERT",
+    });
+    try {
+      expect(search.output()).toContain("History:needle:true");
+      expect(search.output()).not.toContain("-- INSERT --");
+    } finally {
+      await search.dispose();
+    }
+
+    harness.config.editorMode = "vim";
+    const vim = await renderFooter({ vimMode: "NORMAL" });
+    try {
+      expect(vim.output()).toContain("-- NORMAL --");
+    } finally {
+      await vim.dispose();
+    }
+
+    const bash = await renderFooter({ mode: "bash" });
+    try {
+      expect(bash.output()).toContain("! for bash mode");
+    } finally {
+      await bash.dispose();
+    }
+  });
+
+  test("renders permission, task, team, pr, and shortcut hints", async () => {
+    harness.appState.tasks = {
+      background: { status: "running", type: "background" },
+    };
+    harness.appState.teamContext = {
+      teammates: {
+        fixer: { name: "Fixer" },
+        lead: { name: "team-lead" },
+      },
+    };
+    harness.prStatus = {
+      number: 42,
+      reviewState: "changes_requested",
+      url: "https://example.test/pr/42",
+    };
+    harness.swarmsEnabled = true;
+    harness.tasksV2 = [{ id: "task-1", subject: "do work" }];
+
+    const rendered = await renderFooter({
+      isLoading: true,
+      tasksSelected: true,
+      teamsSelected: true,
+      toolPermissionContext: { mode: "bypassPermissions" } as never,
+    });
+
+    try {
+      const output = rendered.output();
+      expect(output).toContain("YOLO");
+      expect(output).toContain("Tasks:true:false:false:none");
+      expect(output).toContain("Teams:true:false");
+      expect(output).not.toContain("PR:42");
+      expect(output).toContain("esc interrupt");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("renders teammate pill rows and completed-teammate return hint", async () => {
+    harness.appState.tasks = {
+      teammate: {
+        status: "completed",
+        type: "in_process_teammate",
+      },
+    };
+    harness.appState.viewingAgentTaskId = "teammate";
+    harness.appState.viewSelectionMode = "viewing-agent";
+
+    const rendered = await renderFooter({
+      teammateFooterIndex: 2,
+      toolPermissionContext: { mode: "acceptEdits" } as never,
+    });
+
+    try {
+      const output = rendered.output();
+      expect(output).toContain("Tasks:false:true:true:2");
+      expect(output).toContain("esc return to team lead");
+      expect(output).toContain("accept edits on");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("renders proactive countdown and fullscreen selection guidance", async () => {
+    harness.features.add("PROACTIVE");
+    harness.proactiveActive = true;
+    harness.proactiveNextTickAt = Date.now() + 3000;
+
+    const proactive = await renderFooter();
+    try {
+      expect(proactive.output()).toContain("waiting");
+    } finally {
+      await proactive.dispose();
+    }
+
+    harness.features = new Set();
+    harness.fullscreen = true;
+    harness.hasSelection = true;
+    harness.isXterm = true;
+    harness.platform = "macos";
+    harness.selectionState = { lastPressHadAlt: true };
+    const selection = await renderFooter({ suppressHint: true });
+    try {
+      expect(selection.output()).toContain(
+        "set macOptionClickForcesSelection in VS Code settings",
+      );
+    } finally {
+      await selection.dispose();
+    }
+
+    harness.config.copyOnSelect = false;
+    harness.isXterm = false;
+    harness.platform = "linux";
+    const copy = await renderFooter({ suppressHint: true });
+    try {
+      expect(copy.output()).toContain("ctrl+c copy");
+    } finally {
+      await copy.dispose();
+    }
+  });
+
+  test("reserves a fullscreen row when all footer parts are suppressed", async () => {
+    harness.fullscreen = true;
+    const rendered = await renderFooter({ suppressHint: true });
+    try {
+      expect(rendered.output().trim()).toBe("");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+});

--- a/runtime/tests/tui/components/PromptInput/PromptInputFooterLeftSide.wave200-090.coverage.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInputFooterLeftSide.wave200-090.coverage.test.tsx
@@ -1,0 +1,357 @@
+import { PassThrough } from "node:stream";
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  appState: {
+    expandedView: "none" as "none" | "tasks" | "teammates",
+    notifications: { current: null as null | { key: string } },
+    remoteSessionUrl: undefined as string | undefined,
+    tasks: {} as Record<string, { status?: string; type?: string }>,
+    teamContext: undefined as
+      | undefined
+      | { teammates: Record<string, { name: string }> },
+    viewingAgentTaskId: undefined as string | undefined,
+    viewSelectionMode: "none",
+  },
+  columns: 100,
+  config: {
+    copyOnSelect: true as boolean | undefined,
+    prStatusFooterEnabled: true as boolean | undefined,
+  },
+  features: new Set<string>(),
+  fullscreen: false,
+  hasSelection: false,
+  inProcessEnabled: false,
+  isCoordinator: false,
+  isRemoteMode: false,
+  isXterm: false,
+  platform: "linux",
+  prStatus: {
+    number: null as number | null,
+    reviewState: null as string | null,
+    url: null as string | null,
+  },
+  proactiveActive: false,
+  proactiveNextTickAt: null as number | null,
+  selectionState: { lastPressHadAlt: false },
+  swarmsEnabled: false,
+  tasksV2: undefined as undefined | Array<{ id: string; subject: string }>,
+  reset() {
+    harness.appState = {
+      expandedView: "none",
+      notifications: { current: null },
+      remoteSessionUrl: undefined,
+      tasks: {},
+      teamContext: undefined,
+      viewingAgentTaskId: undefined,
+      viewSelectionMode: "none",
+    };
+    harness.columns = 100;
+    harness.config = {
+      copyOnSelect: true,
+      prStatusFooterEnabled: true,
+    };
+    harness.features = new Set();
+    harness.fullscreen = false;
+    harness.hasSelection = false;
+    harness.inProcessEnabled = false;
+    harness.isCoordinator = false;
+    harness.isRemoteMode = false;
+    harness.isXterm = false;
+    harness.platform = "linux";
+    harness.prStatus = {
+      number: null,
+      reviewState: null,
+      url: null,
+    };
+    harness.proactiveActive = false;
+    harness.proactiveNextTickAt = null;
+    harness.selectionState = { lastPressHadAlt: false };
+    harness.swarmsEnabled = false;
+    harness.tasksV2 = undefined;
+  },
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: (name: string) => harness.features.has(name),
+}));
+
+vi.mock("../../../coordinator/coordinatorMode.js", () => ({
+  isCoordinatorMode: () => harness.isCoordinator,
+}));
+
+vi.mock("../../keybindings/useShortcutDisplay.js", () => ({
+  useShortcutDisplay: (command: string) => {
+    if (command === "chat:cancel") return "esc";
+    if (command === "app:toggleTodos") return "ctrl+t";
+    if (command === "chat:killAgents") return "ctrl+x ctrl+k";
+    if (command === "chat:cycleMode") return "shift+tab";
+    return command;
+  },
+}));
+
+vi.mock("../tasks/BackgroundTaskStatus.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../ink.js");
+  return {
+    BackgroundTaskStatus: (props: Record<string, unknown>) =>
+      ReactModule.createElement(
+        Text,
+        null,
+        `task-pill:${String(props.tasksSelected)}:${String(props.isLeaderIdle)}`,
+      ),
+  };
+});
+
+vi.mock("../CoordinatorAgentStatus.js", () => ({
+  getVisibleAgentTasks: () => [],
+}));
+
+vi.mock("../teams/TeamStatus.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../ink.js");
+  return {
+    TeamStatus: () => ReactModule.createElement(Text, null, "team-pill"),
+  };
+});
+
+vi.mock("../../../tasks/types.js", () => ({
+  isBackgroundTask: (task: { readonly status?: string }) =>
+    task.status === "pending" || task.status === "running",
+}));
+
+vi.mock("../tasks/taskStatusUtils.js", () => ({
+  shouldHideTasksFooter: () => false,
+}));
+
+vi.mock("../../../utils/agentSwarmsEnabled.js", () => ({
+  isAgentSwarmsEnabled: () => harness.swarmsEnabled,
+}));
+
+vi.mock("../../../utils/swarm/backends/registry.js", () => ({
+  isInProcessEnabled: () => harness.inProcessEnabled,
+}));
+
+vi.mock("../../state/AppState.js", () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+  useAppStateStore: () => ({ getState: () => harness.appState }),
+}));
+
+vi.mock("../../../bootstrap/state.js", () => ({
+  flushInteractionTime: vi.fn(),
+  getIsRemoteMode: () => harness.isRemoteMode,
+}));
+
+vi.mock("./HistorySearchInput.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../ink.js");
+  return {
+    default: () => ReactModule.createElement(Text, null, "history-search"),
+  };
+});
+
+vi.mock("../../hooks/usePrStatus.js", () => ({
+  usePrStatus: () => harness.prStatus,
+}));
+
+vi.mock("../design-system/KeyboardShortcutHint.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../ink.js");
+  return {
+    KeyboardShortcutHint: ({
+      action,
+      shortcut,
+    }: {
+      readonly action: string;
+      readonly shortcut: string;
+    }) => ReactModule.createElement(Text, null, `${shortcut} ${action}`),
+  };
+});
+
+vi.mock("../design-system/Byline.js", async () => {
+  const ReactModule = await import("react");
+  return {
+    Byline: ({ children }: { readonly children?: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+  };
+});
+
+vi.mock("../../hooks/useTerminalSize.js", () => ({
+  useTerminalSize: () => ({ columns: harness.columns, rows: 24 }),
+}));
+
+vi.mock("../../hooks/useTasksV2.js", () => ({
+  useTasksV2: () => harness.tasksV2,
+}));
+
+vi.mock("../../../utils/fullscreen.js", () => ({
+  isFullscreenEnvEnabled: () => harness.fullscreen,
+}));
+
+vi.mock("../../ink/terminal.js", async importOriginal => {
+  const actual = await importOriginal<typeof import("../../ink/terminal.js")>();
+  return {
+    ...actual,
+    isXtermJs: () => harness.isXterm,
+  };
+});
+
+vi.mock("../../ink/hooks/use-selection.js", () => ({
+  useHasSelection: () => harness.hasSelection,
+  useSelection: () => ({ getState: () => harness.selectionState }),
+}));
+
+vi.mock("../../../utils/config.js", () => ({
+  getGlobalConfig: () => harness.config,
+}));
+
+vi.mock("../../../utils/platform.js", () => ({
+  getPlatform: () => harness.platform,
+}));
+
+vi.mock("../PrBadge.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../ink.js");
+  return {
+    PrBadge: () => ReactModule.createElement(Text, null, "pr-pill"),
+  };
+});
+
+vi.mock("./proactiveAdapter.js", () => ({
+  getPromptInputProactiveNextTickAt: () => harness.proactiveNextTickAt,
+  isPromptInputProactiveActive: () => harness.proactiveActive,
+  subscribeToPromptInputProactiveChanges: () => () => {},
+}));
+
+import { createRoot } from "../../ink.js";
+import { PromptInputFooterLeftSide } from "./PromptInputFooterLeftSide.js";
+
+function createStreams(): {
+  readonly stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  readonly stdout: PassThrough;
+} {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.resume();
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function renderFooter(
+  overrides: Partial<React.ComponentProps<typeof PromptInputFooterLeftSide>> = {},
+): Promise<{
+  readonly dispose: () => Promise<void>;
+  readonly output: () => string;
+}> {
+  let output = "";
+  const { stdin, stdout } = createStreams();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  root.render(
+    <PromptInputFooterLeftSide
+      exitMessage={{ show: false }}
+      historyFailedMatch={false}
+      historyQuery=""
+      isLoading={false}
+      isSearching={false}
+      mode="prompt"
+      setHistoryQuery={vi.fn()}
+      suppressHint={false}
+      tasksSelected={false}
+      teamsSelected={false}
+      toolPermissionContext={{ mode: "default" } as never}
+      vimMode={undefined}
+      {...overrides}
+    />,
+  );
+  await sleep();
+
+  return {
+    dispose: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    },
+    output: () => stripAnsi(output),
+  };
+}
+
+describe("PromptInputFooterLeftSide task hints", () => {
+  beforeEach(() => {
+    harness.reset();
+  });
+
+  test("renders task management and teammate toggle hints from task state", async () => {
+    harness.appState.tasks = {
+      worker: { status: "running", type: "local_agent" },
+    };
+    harness.tasksV2 = [{ id: "todo-1", subject: "follow up" }];
+
+    const unselectedTasks = await renderFooter();
+    try {
+      expect(unselectedTasks.output()).toContain("task-pill:false:true");
+      expect(unselectedTasks.output()).toContain("ctrl+x ctrl+k stop agents");
+      expect(unselectedTasks.output()).toContain("manage");
+    } finally {
+      await unselectedTasks.dispose();
+    }
+
+    const selectedTasks = await renderFooter({ tasksSelected: true });
+    try {
+      expect(selectedTasks.output()).toContain("task-pill:true:true");
+      expect(selectedTasks.output()).toContain("Enter view tasks");
+    } finally {
+      await selectedTasks.dispose();
+    }
+
+    harness.appState.tasks = {
+      teammate: { status: "running", type: "in_process_teammate" },
+    };
+    harness.tasksV2 = undefined;
+
+    for (const [expandedView, expectedAction] of [
+      ["none", "show tasks"],
+      ["tasks", "show teammates"],
+      ["teammates", "hide"],
+    ] as const) {
+      harness.appState.expandedView = expandedView;
+      const rendered = await renderFooter();
+      try {
+        expect(rendered.output()).toContain(`ctrl+t ${expectedAction}`);
+      } finally {
+        await rendered.dispose();
+      }
+    }
+  });
+});

--- a/runtime/tests/tui/components/PromptInput/PromptInputFooterSuggestions.wave200-122.coverage.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInputFooterSuggestions.wave200-122.coverage.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../../utils/staticRender.js'
+import {
+  PromptInputFooterSuggestions,
+  type SuggestionItem,
+} from './PromptInputFooterSuggestions.js'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+describe('PromptInputFooterSuggestions wave200-122 coverage', () => {
+  test('renders an inferred agent overlay window with overflow markers', async () => {
+    const suggestions: SuggestionItem[] = Array.from({ length: 8 }, (_, index) => ({
+      id: index === 1 ? `dm-user-${index}` : `agent-${index}`,
+      displayText: `Agent ${index}`,
+      description: `Handles phase ${index}`,
+    }))
+
+    const output = await renderToString(
+      <PromptInputFooterSuggestions
+        suggestions={suggestions}
+        selectedSuggestion={4}
+        overlay={true}
+      />,
+      { columns: 80, rows: 20 },
+    )
+
+    expect(output).toContain('AGENTS')
+    expect(output).toContain('8 matches')
+    expect(output).toContain('agent')
+    expect(output).toContain('message')
+    expect(output).toContain('↑ 2 more above')
+    expect(output).toContain('↓ 1 more below')
+    expect(output).toContain('* Agent 4 - Handles phase 4')
+    expect(output).not.toContain('Agent 0')
+    expect(output).not.toContain('Agent 7')
+  })
+})

--- a/runtime/tests/tui/components/PromptInput/PromptInputHelpMenu.wave200-042.coverage.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInputHelpMenu.wave200-042.coverage.test.tsx
@@ -1,0 +1,110 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../../ink/root.js'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../keybindings/useShortcutDisplay.js', () => ({
+  useShortcutDisplay: (action: string, _context: string, fallback: string) => {
+    const shortcuts: Record<string, string> = {
+      'app:toggleTranscript': 'ctrl+shift+o',
+      'chat:fastMode': 'alt+shift+o',
+    }
+
+    return shortcuts[action] ?? fallback
+  },
+}))
+
+vi.mock('../../keybindings/loadUserBindings.js', () => ({
+  isKeybindingCustomizationEnabled: () => true,
+}))
+
+vi.mock('../../../services/analytics/growthbook.js', () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: (_key: string, fallback: unknown) =>
+    fallback,
+}))
+
+vi.mock('../../../utils/fastMode.js', () => ({
+  isFastModeAvailable: () => true,
+  isFastModeEnabled: () => true,
+}))
+
+vi.mock('../../../utils/platform.js', () => ({
+  getPlatform: () => 'linux',
+}))
+
+function createStreams(): {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  ;(stdout as unknown as { columns: number; rows: number }).columns = 160
+  ;(stdout as unknown as { columns: number; rows: number }).rows = 40
+
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+describe('PromptInputHelpMenu optional shortcuts coverage', () => {
+  test('renders optional shortcut rows across identical TUI rerenders', async () => {
+    const { PromptInputHelpMenu } = await import('./PromptInputHelpMenu.js')
+    const { stdin, stdout } = createStreams()
+    let output = ''
+
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+    const renderNode = () => (
+      <PromptInputHelpMenu dimColor fixedWidth gap={1} paddingX={1} />
+    )
+
+    try {
+      root.render(renderNode())
+      await sleep()
+      root.render(renderNode())
+      await sleep()
+
+      const text = stripAnsi(output)
+      expect(text).toContain('ctrl + shift + o for verbose output')
+      expect(text).toContain('alt + shift + o to toggle fast mode')
+      expect(text).toContain('/keybindings to customize')
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+})

--- a/runtime/tests/tui/components/PromptInput/PromptInputModeIndicator.wave200-063.coverage.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInputModeIndicator.wave200-063.coverage.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  swarmsEnabled: false,
+  teammateColor: undefined as string | undefined,
+  getTeammateColor: vi.fn((): string | undefined => harness.teammateColor),
+  reset() {
+    harness.swarmsEnabled = false
+    harness.teammateColor = undefined
+    harness.getTeammateColor.mockClear()
+  },
+}))
+
+vi.mock('../../../utils/agentSwarmsEnabled.js', () => ({
+  isAgentSwarmsEnabled: () => harness.swarmsEnabled,
+}))
+
+vi.mock('../../../utils/teammate.js', () => ({
+  getTeammateColor: harness.getTeammateColor,
+}))
+
+import { renderToString } from '../../../utils/staticRender.js'
+import { Box } from '../../ink.js'
+import { PromptInputModeIndicator } from './PromptInputModeIndicator.js'
+
+async function renderIndicator(
+  props: React.ComponentProps<typeof PromptInputModeIndicator>,
+): Promise<string> {
+  return renderToString(<PromptInputModeIndicator {...props} />, 20)
+}
+
+describe('PromptInputModeIndicator coverage', () => {
+  test('renders prompt glyphs across shell, bypass, viewed-agent, and swarm color states', async () => {
+    harness.reset()
+
+    expect(
+      await renderIndicator({
+        mode: 'prompt',
+        isLoading: false,
+      }),
+    ).toContain('❯')
+
+    harness.swarmsEnabled = true
+    harness.teammateColor = undefined
+    expect(
+      await renderIndicator({
+        mode: 'prompt',
+        permissionMode: 'plan',
+        isLoading: false,
+      }),
+    ).toContain('❯')
+
+    harness.teammateColor = 'not-a-theme-color'
+    expect(
+      await renderIndicator({
+        mode: 'prompt',
+        permissionMode: 'default',
+        isLoading: false,
+      }),
+    ).toContain('❯')
+
+    harness.teammateColor = 'red'
+    const output = await renderToString(
+      <Box flexDirection="column">
+        <PromptInputModeIndicator mode="bash" isLoading={true} />
+        <PromptInputModeIndicator
+          mode="prompt"
+          permissionMode="bypassPermissions"
+          isLoading={false}
+        />
+        <PromptInputModeIndicator
+          mode="prompt"
+          permissionMode="plan"
+          isLoading={false}
+          viewingAgentName="worker"
+          viewingAgentColor="cyan"
+        />
+        <PromptInputModeIndicator
+          mode="orphaned-permission"
+          permissionMode="acceptEdits"
+          isLoading={false}
+        />
+      </Box>,
+      20,
+    )
+
+    expect(output).toContain('!')
+    expect(output).toContain('▶')
+    expect(output.match(/❯/g)).toHaveLength(2)
+    expect(harness.getTeammateColor).toHaveBeenCalled()
+  })
+})

--- a/runtime/tests/tui/components/PromptInput/SandboxPromptFooterHint.wave200-069.coverage.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/SandboxPromptFooterHint.wave200-069.coverage.test.tsx
@@ -1,0 +1,170 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => {
+  const subscribers = new Set<() => void>();
+
+  return {
+    enabled: false,
+    subscribers,
+    totalCount: 0,
+    reset() {
+      subscribers.clear();
+      this.enabled = false;
+      this.totalCount = 0;
+    },
+    notify() {
+      for (const subscriber of [...subscribers]) subscriber();
+    },
+    addViolations(count: number) {
+      this.totalCount += count;
+      this.notify();
+    },
+  };
+});
+
+vi.mock("../../keybindings/useShortcutDisplay.js", () => ({
+  useShortcutDisplay: () => "ctrl+shift+o",
+}));
+
+vi.mock("../../../utils/sandbox/sandbox-runtime.js", () => ({
+  SandboxManager: {
+    isSandboxingEnabled: () => harness.enabled,
+    getSandboxViolationStore: () => ({
+      getTotalCount: () => harness.totalCount,
+      subscribe: (subscriber: () => void) => {
+        harness.subscribers.add(subscriber);
+        return () => harness.subscribers.delete(subscriber);
+      },
+    }),
+  },
+}));
+
+import { createRoot } from "../../ink.js";
+import type { DOMElement, DOMNode } from "../../ink/dom.js";
+import instances from "../../ink/instances.js";
+import { SandboxPromptFooterHint } from "./SandboxPromptFooterHint.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+function createStreams(): {
+  stdin: TestStdin;
+  stdout: PassThrough;
+} {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.resume();
+  (stdout as unknown as { columns: number }).columns = 120;
+  return { stdin, stdout };
+}
+
+function collectText(node: DOMNode): string {
+  if (node.nodeName === "#text") return node.nodeValue;
+  return node.childNodes.map(collectText).join("");
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream);
+  if (!instance?.rootNode) throw new Error("Ink root node not found");
+  return instance.rootNode;
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 1_000) {
+    if (predicate()) return;
+    await sleep(10);
+  }
+  throw new Error(message);
+}
+
+async function renderHint(): Promise<{
+  dispose: () => Promise<void>;
+  text: () => string;
+}> {
+  const { stdin, stdout } = createStreams();
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  root.render(<SandboxPromptFooterHint />);
+  await sleep();
+
+  return {
+    dispose: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    },
+    text: () => collectText(getRootNode(stdout)),
+  };
+}
+
+describe("SandboxPromptFooterHint coverage", () => {
+  beforeEach(() => {
+    harness.reset();
+  });
+
+  test("renders only for recent sandbox violations and unsubscribes on unmount", async () => {
+    const disabled = await renderHint();
+    try {
+      expect(disabled.text()).toBe("");
+      expect(harness.subscribers.size).toBe(0);
+    } finally {
+      await disabled.dispose();
+    }
+
+    harness.enabled = true;
+    harness.totalCount = 4;
+    const enabled = await renderHint();
+    try {
+      await waitFor(
+        () => harness.subscribers.size === 1,
+        "sandbox violation subscriber was not registered",
+      );
+      expect(enabled.text()).toBe("");
+
+      harness.notify();
+      await sleep();
+      expect(enabled.text()).toBe("");
+
+      harness.addViolations(1);
+      await waitFor(
+        () => enabled.text().includes("Sandbox blocked 1 operation"),
+        "singular sandbox violation hint was not rendered",
+      );
+      expect(enabled.text()).toContain("ctrl+shift+o for details");
+
+      harness.addViolations(2);
+      await waitFor(
+        () => enabled.text().includes("Sandbox blocked 2 operations"),
+        "plural sandbox violation hint was not rendered",
+      );
+    } finally {
+      await enabled.dispose();
+    }
+
+    expect(harness.subscribers.size).toBe(0);
+  });
+});

--- a/runtime/tests/tui/components/PromptInput/ShimmeredInput.wave200-140.coverage.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/ShimmeredInput.wave200-140.coverage.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { renderToString } from '../../../utils/staticRender.js'
+import { HighlightedInput } from './ShimmeredInput.js'
+
+describe('HighlightedInput coverage', () => {
+  test('renders plain, highlighted, shimmered, and empty input lines', async () => {
+    const output = await renderToString(
+      <HighlightedInput
+        text={'ask\n\nreview now'}
+        highlights={[
+          {
+            start: 0,
+            end: 3,
+            color: 'success',
+            priority: 1,
+          },
+          {
+            start: 5,
+            end: 11,
+            color: 'warning',
+            shimmerColor: 'warningShimmer',
+            priority: 2,
+          },
+        ]}
+      />,
+      40,
+    )
+
+    expect(output).toContain('ask')
+    expect(output).toContain('review now')
+    expect(output.split('\n')).toEqual(['ask', '', 'review now'])
+  })
+})

--- a/runtime/tests/tui/components/PromptInput/usePromptInputPlaceholder.wave200-148.coverage.test.ts
+++ b/runtime/tests/tui/components/PromptInput/usePromptInputPlaceholder.wave200-148.coverage.test.ts
@@ -1,0 +1,238 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const fixture = vi.hoisted(() => {
+  const state = {
+    appState: { promptSuggestionEnabled: true },
+    enabledFeatures: new Set<string>(),
+    exampleCommand: '/status',
+    proactiveActive: false,
+    queuedCommandUpHintCount: 0,
+    queuedCommands: [] as Array<{ editable?: boolean }>,
+  }
+
+  return {
+    state,
+    getExampleCommandFromCache: vi.fn(() => state.exampleCommand),
+    isPromptInputProactiveActive: vi.fn(() => state.proactiveActive),
+    isQueuedCommandEditable: vi.fn(
+      (cmd: { editable?: boolean }) => cmd.editable === true,
+    ),
+    reset() {
+      state.appState = { promptSuggestionEnabled: true }
+      state.enabledFeatures.clear()
+      state.exampleCommand = '/status'
+      state.proactiveActive = false
+      state.queuedCommandUpHintCount = 0
+      state.queuedCommands = []
+      this.getExampleCommandFromCache.mockClear()
+      this.isPromptInputProactiveActive.mockClear()
+      this.isQueuedCommandEditable.mockClear()
+    },
+  }
+})
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => fixture.state.enabledFeatures.has(name),
+}))
+
+vi.mock('../../hooks/useCommandQueue.js', () => ({
+  useCommandQueue: () => fixture.state.queuedCommands,
+}))
+
+vi.mock('../../state/AppState.js', () => ({
+  useAppState: (
+    selector: (state: typeof fixture.state.appState) => unknown,
+  ) => selector(fixture.state.appState),
+}))
+
+vi.mock('../../../utils/config.js', () => ({
+  getGlobalConfig: () => ({
+    queuedCommandUpHintCount: fixture.state.queuedCommandUpHintCount,
+  }),
+}))
+
+vi.mock('../../../utils/exampleCommands.js', () => ({
+  getExampleCommandFromCache: fixture.getExampleCommandFromCache,
+}))
+
+vi.mock('../../../utils/messageQueueManager.js', () => ({
+  isQueuedCommandEditable: fixture.isQueuedCommandEditable,
+}))
+
+vi.mock('./proactiveAdapter.js', () => ({
+  isPromptInputProactiveActive: fixture.isPromptInputProactiveActive,
+}))
+
+import { createRoot } from '../../ink/root.js'
+import { usePromptInputPlaceholder } from './usePromptInputPlaceholder.js'
+
+type PlaceholderProps = Parameters<typeof usePromptInputPlaceholder>[0]
+
+function createStreams(): {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough
+} {
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  const stdout = new PassThrough()
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 100
+
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 0): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderPlaceholder(
+  props: Partial<PlaceholderProps> = {},
+): Promise<string | undefined> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  let didRender = false
+  let placeholder: string | undefined
+
+  function Harness(): null {
+    placeholder = usePromptInputPlaceholder({
+      input: '',
+      submitCount: 0,
+      ...props,
+    })
+    didRender = true
+    return null
+  }
+
+  try {
+    root.render(React.createElement(Harness))
+    await sleep()
+    if (!didRender) throw new Error('placeholder hook did not render')
+    return placeholder
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await sleep()
+  }
+}
+
+async function expectPlaceholder(
+  setup: () => void,
+  expected: string | undefined,
+  props: Partial<PlaceholderProps> = {},
+): Promise<void> {
+  fixture.reset()
+  setup()
+  await expect(renderPlaceholder(props)).resolves.toBe(expected)
+}
+
+describe('usePromptInputPlaceholder coverage', () => {
+  afterEach(() => {
+    fixture.reset()
+  })
+
+  test('prioritizes teammate, queue, suggestion, and proactive placeholder states', async () => {
+    await expectPlaceholder(
+      () => {
+        fixture.state.queuedCommands = [{ editable: true }]
+      },
+      undefined,
+      { input: 'draft', viewingAgentName: 'builder' },
+    )
+
+    await expectPlaceholder(
+      () => {},
+      'Message @builder\u2026',
+      { viewingAgentName: 'builder' },
+    )
+
+    await expectPlaceholder(
+      () => {},
+      'Message @abcdefghijklmnopq...\u2026',
+      { viewingAgentName: 'abcdefghijklmnopqrstu' },
+    )
+
+    await expectPlaceholder(
+      () => {
+        fixture.state.queuedCommands = [{ editable: true }]
+        fixture.state.queuedCommandUpHintCount = 2
+      },
+      'Press up to edit queued messages',
+    )
+
+    await expectPlaceholder(
+      () => {
+        fixture.state.queuedCommands = [{ editable: false }]
+      },
+      '/status',
+    )
+
+    await expectPlaceholder(
+      () => {
+        fixture.state.queuedCommands = [{ editable: true }]
+        fixture.state.queuedCommandUpHintCount = 3
+      },
+      '/status',
+    )
+
+    await expectPlaceholder(
+      () => {
+        fixture.state.appState.promptSuggestionEnabled = false
+      },
+      undefined,
+    )
+
+    await expectPlaceholder(() => {}, undefined, { submitCount: 1 })
+
+    await expectPlaceholder(
+      () => {
+        fixture.state.proactiveActive = true
+      },
+      '/status',
+    )
+
+    await expectPlaceholder(
+      () => {
+        fixture.state.enabledFeatures.add('PROACTIVE')
+      },
+      '/status',
+    )
+
+    await expectPlaceholder(
+      () => {
+        fixture.state.enabledFeatures.add('PROACTIVE')
+        fixture.state.proactiveActive = true
+      },
+      undefined,
+    )
+
+    await expectPlaceholder(
+      () => {
+        fixture.state.enabledFeatures.add('KAIROS')
+        fixture.state.proactiveActive = true
+      },
+      undefined,
+    )
+  })
+})

--- a/runtime/tests/tui/components/PromptInput/useSwarmBanner.wave200-037.coverage.test.ts
+++ b/runtime/tests/tui/components/PromptInput/useSwarmBanner.wave200-037.coverage.test.ts
@@ -1,0 +1,321 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => {
+  function makeState() {
+    return {
+      agent: undefined as string | undefined,
+      agentDefinitions: {
+        activeAgents: [] as Array<{ agentType: string; color?: string }>,
+      },
+      agentNameRegistry: new Map<string, string>(),
+      standaloneAgentContext: undefined as
+        | undefined
+        | { name?: string; color?: string },
+      tasks: {} as Record<string, unknown>,
+      teamContext: undefined as
+        | undefined
+        | {
+            selfAgentColor?: string
+            teamName?: string
+            teammates?: Record<string, unknown>
+          },
+      viewingAgentTaskId: undefined as string | undefined,
+    }
+  }
+
+  const state = {
+    activeAgent: { type: 'leader' } as
+      | { type: 'leader' }
+      | {
+          type: 'named_agent'
+          task: { id: string; description: string; agentType: string }
+        },
+    agentColors: new Map<string, string>(),
+    appState: makeState(),
+    cachedDetection: undefined as undefined | { isNative?: boolean },
+    inProcessEnabled: false,
+    inProcessTeammate: false,
+    insideTmux: null as boolean | null,
+    teammate: {
+      active: false,
+      agentName: undefined as string | undefined,
+      color: undefined as string | undefined,
+      teamName: undefined as string | undefined,
+    },
+    viewedTeammate: undefined as
+      | undefined
+      | { identity: { agentName: string; color?: string } },
+    reset() {
+      state.activeAgent = { type: 'leader' }
+      state.agentColors.clear()
+      state.appState = makeState()
+      state.cachedDetection = undefined
+      state.inProcessEnabled = false
+      state.inProcessTeammate = false
+      state.insideTmux = null
+      state.teammate = {
+        active: false,
+        agentName: undefined,
+        color: undefined,
+        teamName: undefined,
+      }
+      state.viewedTeammate = undefined
+    },
+  }
+
+  return state
+})
+
+vi.mock('../../state/AppState.js', () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+  useAppStateStore: () => ({
+    getState: () => harness.appState,
+  }),
+}))
+
+vi.mock('../../state/selectors.js', () => ({
+  getActiveAgentForInput: () => harness.activeAgent,
+  getViewedTeammateTask: () => harness.viewedTeammate,
+}))
+
+vi.mock('../../../tools/AgentTool/agentColorManager.js', () => ({
+  AGENT_COLOR_TO_THEME_COLOR: {
+    blue: 'blue_FOR_SUBAGENTS_ONLY',
+    cyan: 'cyan_FOR_SUBAGENTS_ONLY',
+    green: 'green_FOR_SUBAGENTS_ONLY',
+    orange: 'orange_FOR_SUBAGENTS_ONLY',
+    pink: 'pink_FOR_SUBAGENTS_ONLY',
+    purple: 'purple_FOR_SUBAGENTS_ONLY',
+    red: 'red_FOR_SUBAGENTS_ONLY',
+    yellow: 'yellow_FOR_SUBAGENTS_ONLY',
+  },
+  AGENT_COLORS: [
+    'red',
+    'blue',
+    'green',
+    'yellow',
+    'purple',
+    'orange',
+    'pink',
+    'cyan',
+  ],
+  getAgentColor: (agentType: string) => harness.agentColors.get(agentType),
+}))
+
+vi.mock('../../../utils/standaloneAgent.js', () => ({
+  getStandaloneAgentName: (state: typeof harness.appState) =>
+    state.standaloneAgentContext?.name,
+}))
+
+vi.mock('../../../utils/swarm/backends/detection.js', () => ({
+  isInsideTmux: () => Promise.resolve(harness.insideTmux),
+}))
+
+vi.mock('../../../utils/swarm/backends/registry.js', () => ({
+  getCachedDetectionResult: () => harness.cachedDetection,
+  isInProcessEnabled: () => harness.inProcessEnabled,
+}))
+
+vi.mock('../../../utils/swarm/constants.js', () => ({
+  getSwarmSocketName: () => 'agenc-swarm-test',
+}))
+
+vi.mock('../../../utils/teammate.js', () => ({
+  getAgentName: () => harness.teammate.agentName,
+  getTeammateColor: () => harness.teammate.color,
+  getTeamName: () => harness.teammate.teamName,
+  isTeammate: () => harness.teammate.active,
+}))
+
+vi.mock('../../../utils/teammateContext.js', () => ({
+  isInProcessTeammate: () => harness.inProcessTeammate,
+}))
+
+import { createRoot } from '../../ink/root.js'
+import { useSwarmBanner } from './useSwarmBanner.js'
+
+type Banner = ReturnType<typeof useSwarmBanner>
+
+function createStreams(): {
+  readonly stdout: PassThrough
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 120
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderBanner(): Promise<Banner> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  let latest: Banner | undefined
+
+  function Harness(): null {
+    latest = useSwarmBanner()
+    return null
+  }
+
+  try {
+    root.render(React.createElement(Harness))
+    await sleep()
+    await sleep()
+    if (latest === undefined) throw new Error('hook did not render')
+    return latest
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await sleep(0)
+  }
+}
+
+async function expectBanner(
+  setup: () => void,
+  expected: Banner,
+): Promise<void> {
+  harness.reset()
+  setup()
+  expect(await renderBanner()).toEqual(expected)
+}
+
+describe('useSwarmBanner coverage', () => {
+  afterEach(() => {
+    harness.reset()
+    vi.clearAllMocks()
+  })
+
+  test('resolves banner identity priority across team and agent contexts', async () => {
+    await expectBanner(() => {
+      harness.teammate = {
+        active: true,
+        agentName: 'builder',
+        color: 'orange',
+        teamName: 'core',
+      }
+      harness.appState.teamContext = { selfAgentColor: 'purple' }
+    }, {
+      bgColor: 'purple_FOR_SUBAGENTS_ONLY',
+      text: '@builder',
+    })
+
+    await expectBanner(() => {
+      harness.insideTmux = false
+      harness.appState.teamContext = {
+        teamName: 'launch',
+        teammates: { analyst: {} },
+      }
+      harness.viewedTeammate = {
+        identity: { agentName: 'analyst', color: 'blue' },
+      }
+    }, {
+      bgColor: 'blue_FOR_SUBAGENTS_ONLY',
+      text: 'View teammates: `tmux -L agenc-swarm-test a`',
+    })
+
+    await expectBanner(() => {
+      harness.insideTmux = false
+      harness.cachedDetection = { isNative: true }
+      harness.appState.teamContext = {
+        teamName: 'launch',
+        teammates: { reviewer: {} },
+      }
+      harness.viewedTeammate = {
+        identity: { agentName: 'reviewer', color: 'green' },
+      }
+    }, {
+      bgColor: 'green_FOR_SUBAGENTS_ONLY',
+      text: '@reviewer',
+    })
+
+    await expectBanner(() => {
+      harness.appState.teamContext = {
+        teamName: 'launch',
+        teammates: { helper: {} },
+      }
+      harness.appState.standaloneAgentContext = {
+        color: 'red',
+        name: 'solo',
+      }
+    }, {
+      bgColor: 'red_FOR_SUBAGENTS_ONLY',
+      text: 'solo',
+    })
+
+    await expectBanner(() => {
+      harness.activeAgent = {
+        type: 'named_agent',
+        task: {
+          agentType: 'scout',
+          description: 'Coordinate rollout',
+          id: 'task-1',
+        },
+      }
+      harness.agentColors.set('scout', 'pink_FOR_SUBAGENTS_ONLY')
+      harness.appState.agentNameRegistry.set('scout-one', 'task-1')
+    }, {
+      bgColor: 'pink_FOR_SUBAGENTS_ONLY',
+      text: '@scout-one',
+    })
+
+    await expectBanner(() => {
+      harness.activeAgent = {
+        type: 'named_agent',
+        task: {
+          agentType: 'general-purpose',
+          description: 'Summarize notes',
+          id: 'task-2',
+        },
+      }
+    }, {
+      bgColor: 'cyan_FOR_SUBAGENTS_ONLY',
+      text: 'Summarize notes',
+    })
+
+    await expectBanner(() => {
+      harness.appState.standaloneAgentContext = { color: 'orange' }
+    }, {
+      bgColor: 'orange_FOR_SUBAGENTS_ONLY',
+      text: '',
+    })
+
+    await expectBanner(() => {
+      harness.appState.agent = 'planner'
+      harness.appState.agentDefinitions.activeAgents = [
+        { agentType: 'planner', color: 'not-a-theme-color' },
+      ]
+    }, {
+      bgColor: 'promptBorder',
+      text: 'planner',
+    })
+
+    await expectBanner(() => {}, null)
+  })
+})

--- a/runtime/tests/tui/components/QuickOpenDialog.render.test.tsx
+++ b/runtime/tests/tui/components/QuickOpenDialog.render.test.tsx
@@ -1,0 +1,475 @@
+import { PassThrough } from 'node:stream'
+import * as path from 'node:path'
+
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type PickerAction = {
+  action: string
+  handler: (item: string) => void
+}
+
+type CapturedPickerProps = {
+  title: string
+  placeholder?: string
+  items: readonly string[]
+  visibleCount: number
+  previewPosition: 'bottom' | 'right'
+  onQueryChange: (query: string) => void
+  onFocus?: (item: string | undefined) => void
+  onSelect: (item: string) => void
+  onTab?: PickerAction
+  onShiftTab?: PickerAction
+  onCancel: () => void
+  emptyMessage?: string | ((query: string) => string)
+  selectAction?: string
+  renderItem: (item: string, isFocused: boolean) => React.ReactNode
+  renderPreview?: (item: string) => React.ReactNode
+}
+
+type Suggestion = {
+  id: string
+  displayText: string
+}
+
+const harness = vi.hoisted(() => ({
+  cwd: '/workspace/project',
+  generateFileSuggestions: vi.fn(),
+  logEvent: vi.fn(),
+  openFileInExternalEditor: vi.fn(),
+  pickerProps: undefined as CapturedPickerProps | undefined,
+  readFileInRange: vi.fn(),
+  registerOverlay: vi.fn(),
+  terminal: {
+    columns: 100,
+    rows: 30,
+  },
+}))
+
+vi.mock('../context/overlayContext', () => ({
+  useRegisterOverlay: harness.registerOverlay,
+}))
+
+vi.mock('../hooks/fileSuggestions', () => ({
+  generateFileSuggestions: harness.generateFileSuggestions,
+}))
+
+vi.mock('../hooks/useTerminalSize', () => ({
+  useTerminalSize: () => harness.terminal,
+}))
+
+vi.mock('../../services/analytics/index', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../../utils/cwd', () => ({
+  getCwd: () => harness.cwd,
+}))
+
+vi.mock('../../utils/editor', () => ({
+  openFileInExternalEditor: harness.openFileInExternalEditor,
+}))
+
+vi.mock('../../utils/readFileInRange', () => ({
+  readFileInRange: harness.readFileInRange,
+}))
+
+vi.mock('./design-system/FuzzyPicker', () => ({
+  FuzzyPicker: (props: CapturedPickerProps) => {
+    harness.pickerProps = props
+    return null
+  },
+}))
+
+import { createRoot } from '../ink/root.js'
+import { renderToString } from '../../utils/staticRender.js'
+import { QuickOpenDialog } from './QuickOpenDialog.js'
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function resetHarness() {
+  harness.terminal.columns = 100
+  harness.terminal.rows = 30
+  harness.pickerProps = undefined
+  harness.registerOverlay.mockClear()
+  harness.generateFileSuggestions.mockReset()
+  harness.generateFileSuggestions.mockResolvedValue([])
+  harness.logEvent.mockClear()
+  harness.openFileInExternalEditor.mockReset()
+  harness.openFileInExternalEditor.mockReturnValue(true)
+  harness.readFileInRange.mockReset()
+  harness.readFileInRange.mockResolvedValue({ content: '' })
+}
+
+function pickerProps(): CapturedPickerProps {
+  const props = harness.pickerProps
+  if (!props) throw new Error('Quick open picker props were not captured')
+  return props
+}
+
+function emptyMessage(props: CapturedPickerProps, query: string): string {
+  const message = props.emptyMessage
+  return typeof message === 'function' ? message(query) : message ?? ''
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await sleep(10)
+  }
+  throw new Error(message)
+}
+
+async function waitForRenderedText(
+  node: () => React.ReactNode,
+  predicate: (output: string) => boolean,
+  message: string,
+): Promise<string> {
+  const startedAt = Date.now()
+  let lastOutput = ''
+  while (Date.now() - startedAt < 1000) {
+    lastOutput = await renderToString(node(), 120)
+    if (predicate(lastOutput)) return lastOutput
+    await sleep(10)
+  }
+  throw new Error(`${message}\nLast output:\n${lastOutput}`)
+}
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = harness.terminal.columns
+  ;(stdout as unknown as { rows: number }).rows = harness.terminal.rows
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function renderDialog() {
+  const onDone = vi.fn()
+  const onInsert = vi.fn()
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  root.render(<QuickOpenDialog onDone={onDone} onInsert={onInsert} />)
+  await waitFor(() => harness.pickerProps !== undefined, 'QuickOpenDialog did not render')
+
+  return {
+    onDone,
+    onInsert,
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep(25)
+    },
+  }
+}
+
+async function searchFor(
+  query: string,
+  suggestions: readonly Suggestion[],
+  expectedItems: readonly string[],
+) {
+  harness.generateFileSuggestions.mockResolvedValueOnce(suggestions)
+
+  pickerProps().onQueryChange(query)
+
+  await waitFor(
+    () => harness.generateFileSuggestions.mock.calls.length > 0,
+    'Quick open did not request file suggestions',
+  )
+  expect(harness.generateFileSuggestions).toHaveBeenLastCalledWith(query, true)
+  await waitFor(
+    () => pickerProps().items.join('\0') === expectedItems.join('\0'),
+    'Quick open results did not render',
+  )
+}
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason?: unknown) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('QuickOpenDialog render and interactions', () => {
+  beforeEach(() => {
+    resetHarness()
+  })
+
+  it('renders the initial picker state, empty-query state, cancel wiring, and bottom preview layout', async () => {
+    const rendered = await renderDialog()
+
+    try {
+      const props = pickerProps()
+
+      expect(harness.registerOverlay).toHaveBeenCalledWith('quick-open')
+      expect(props.title).toBe('Quick Open')
+      expect(props.placeholder).toBe('Type to search files...')
+      expect(props.items).toEqual([])
+      expect(props.visibleCount).toBe(8)
+      expect(props.previewPosition).toBe('bottom')
+      expect(props.selectAction).toBe('open in editor')
+      expect(props.onTab?.action).toBe('mention')
+      expect(props.onShiftTab?.action).toBe('insert path')
+      expect(emptyMessage(props, '')).toBe('Start typing to search...')
+      expect(emptyMessage(props, 'app')).toBe('No matching files')
+
+      props.onQueryChange('   ')
+      await waitFor(
+        () => pickerProps().items.length === 0,
+        'Quick open did not clear results for an empty query',
+      )
+      expect(harness.generateFileSuggestions).not.toHaveBeenCalled()
+
+      props.onCancel()
+      expect(rendered.onDone).toHaveBeenCalledTimes(1)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  it('filters file suggestions, normalizes path separators, and renders focused items', async () => {
+    const rendered = await renderDialog()
+
+    try {
+      const nestedPath = path.join('src', 'nested', 'index.ts')
+      const normalizedNestedPath = nestedPath.split(path.sep).join('/')
+
+      await searchFor(
+        'src',
+        [
+          { id: 'file-src-app', displayText: 'src/app.tsx' },
+          { id: 'command-help', displayText: 'help' },
+          { id: 'file-src-directory', displayText: `src${path.sep}` },
+          { id: 'file-src-nested', displayText: nestedPath },
+        ],
+        ['src/app.tsx', normalizedNestedPath],
+      )
+
+      const props = pickerProps()
+      expect(props.items).toEqual(['src/app.tsx', 'src/nested/index.ts'])
+
+      const itemOutput = await renderToString(props.renderItem('src/app.tsx', true), 120)
+      expect(itemOutput).toContain('src/app.tsx')
+
+      props.onQueryChange('')
+      await waitFor(
+        () => pickerProps().items.length === 0,
+        'Quick open did not clear normalized results for an empty query',
+      )
+      expect(harness.generateFileSuggestions).toHaveBeenCalledTimes(1)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  it('loads preview content and shows the stale preview path while a new focus is loading', async () => {
+    const rendered = await renderDialog()
+
+    try {
+      const secondPreview = deferred<{ content: string }>()
+      harness.readFileInRange
+        .mockResolvedValueOnce({
+          content: 'export const alpha = 1\nneedle alpha',
+        })
+        .mockReturnValueOnce(secondPreview.promise)
+
+      await searchFor(
+        'alpha',
+        [
+          { id: 'file-alpha', displayText: 'src/alpha.ts' },
+          { id: 'file-beta', displayText: 'src/beta.ts' },
+        ],
+        ['src/alpha.ts', 'src/beta.ts'],
+      )
+
+      pickerProps().onFocus?.('src/alpha.ts')
+      const loadingOutput = await renderToString(
+        pickerProps().renderPreview?.('src/alpha.ts'),
+        120,
+      )
+      expect(loadingOutput).toContain('Loading preview...')
+
+      await waitFor(
+        () => harness.readFileInRange.mock.calls.length === 1,
+        'Quick open did not request preview content',
+      )
+      expect(harness.readFileInRange).toHaveBeenCalledWith(
+        '/workspace/project/src/alpha.ts',
+        0,
+        20,
+        undefined,
+        expect.any(AbortSignal),
+      )
+
+      const previewOutput = await waitForRenderedText(
+        () => pickerProps().renderPreview?.('src/alpha.ts'),
+        output => output.includes('needle alpha'),
+        'Quick open preview content did not render',
+      )
+      expect(previewOutput).toContain('src/alpha.ts')
+      expect(previewOutput).toContain('export const alpha = 1')
+
+      pickerProps().onFocus?.('src/beta.ts')
+      await waitFor(
+        () => harness.readFileInRange.mock.calls.length === 2,
+        'Quick open did not request preview content for the new focus',
+      )
+
+      const staleOutput = await renderToString(
+        pickerProps().renderPreview?.('src/beta.ts'),
+        120,
+      )
+      expect(staleOutput).toContain('src/beta.ts - loading...')
+      expect(staleOutput).toContain('needle alpha')
+
+      secondPreview.resolve({ content: 'beta ready' })
+      const refreshedOutput = await waitForRenderedText(
+        () => pickerProps().renderPreview?.('src/beta.ts'),
+        output => output.includes('beta ready'),
+        'Quick open did not replace the stale preview content',
+      )
+      expect(refreshedOutput).toContain('src/beta.ts')
+      expect(refreshedOutput).not.toContain('loading...')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  it('shows preview failures without weakening the selected path display', async () => {
+    const rendered = await renderDialog()
+
+    try {
+      harness.readFileInRange.mockRejectedValueOnce(new Error('cannot preview'))
+
+      await searchFor(
+        'broken',
+        [{ id: 'file-broken', displayText: 'src/broken.ts' }],
+        ['src/broken.ts'],
+      )
+
+      pickerProps().onFocus?.('src/broken.ts')
+      await waitFor(
+        () => harness.readFileInRange.mock.calls.length === 1,
+        'Quick open did not request failing preview content',
+      )
+
+      const previewOutput = await waitForRenderedText(
+        () => pickerProps().renderPreview?.('src/broken.ts'),
+        output => output.includes('(preview unavailable)'),
+        'Quick open did not render preview failure content',
+      )
+      expect(previewOutput).toContain('src/broken.ts')
+      expect(previewOutput).toContain('(preview unavailable)')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  it('opens files, inserts file references, and emits analytics through picker actions', async () => {
+    const rendered = await renderDialog()
+
+    try {
+      await searchFor(
+        'app',
+        [{ id: 'file-app', displayText: 'src/app.tsx' }],
+        ['src/app.tsx'],
+      )
+
+      pickerProps().onSelect('src/app.tsx')
+      expect(harness.openFileInExternalEditor).toHaveBeenCalledWith(
+        '/workspace/project/src/app.tsx',
+      )
+      expect(harness.logEvent).toHaveBeenCalledWith('agenc_quick_open_select', {
+        result_count: 1,
+        opened_editor: true,
+      })
+
+      pickerProps().onTab?.handler('src/app.tsx')
+      expect(rendered.onInsert).toHaveBeenCalledWith('@src/app.tsx ')
+      expect(harness.logEvent).toHaveBeenCalledWith('agenc_quick_open_insert', {
+        result_count: 1,
+        mention: true,
+      })
+
+      pickerProps().onShiftTab?.handler('src/app.tsx')
+      expect(rendered.onInsert).toHaveBeenCalledWith('src/app.tsx ')
+      expect(harness.logEvent).toHaveBeenCalledWith('agenc_quick_open_insert', {
+        result_count: 1,
+        mention: false,
+      })
+      expect(rendered.onDone).toHaveBeenCalledTimes(3)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  it('uses a right-side preview and reduced preview line count on wide terminals', async () => {
+    harness.terminal.columns = 160
+    harness.terminal.rows = 30
+    const rendered = await renderDialog()
+
+    try {
+      expect(pickerProps().previewPosition).toBe('right')
+
+      await searchFor(
+        'wide',
+        [{ id: 'file-wide', displayText: 'src/wide.ts' }],
+        ['src/wide.ts'],
+      )
+
+      pickerProps().onFocus?.('src/wide.ts')
+      await waitFor(
+        () => harness.readFileInRange.mock.calls.length === 1,
+        'Quick open did not request wide-layout preview content',
+      )
+      expect(harness.readFileInRange).toHaveBeenCalledWith(
+        '/workspace/project/src/wide.ts',
+        0,
+        7,
+        undefined,
+        expect.any(AbortSignal),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/components/ScrollKeybindingHandler.coverage2.test.tsx
+++ b/runtime/tests/tui/components/ScrollKeybindingHandler.coverage2.test.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { renderToString } from "../../utils/staticRender.js";
+
+type KeybindingCall = {
+  handlers: Record<string, () => unknown>;
+  options: { context: string; isActive: boolean };
+};
+
+const harness = vi.hoisted(() => {
+  const state = {
+    addNotification: vi.fn(),
+    getClipboardPath: vi.fn(() => "osc52"),
+    keybindingCalls: [] as KeybindingCall[],
+    selection: {
+      clearSelection: vi.fn(),
+      copySelection: vi.fn(() => "terminal copy"),
+      getState: vi.fn(() => null),
+      hasSelection: vi.fn(() => false),
+      moveFocus: vi.fn(),
+      captureScrolledRows: vi.fn(),
+      shiftSelection: vi.fn(),
+      shiftAnchor: vi.fn(),
+      subscribe: vi.fn(() => vi.fn()),
+    },
+  };
+
+  return state;
+});
+
+vi.mock("../context/notifications", () => ({
+  useNotifications: () => ({
+    addNotification: harness.addNotification,
+  }),
+}));
+
+vi.mock("../hooks/useCopyOnSelect", () => ({
+  useCopyOnSelect: vi.fn(),
+  useSelectionBgColor: vi.fn(),
+}));
+
+vi.mock("../ink/hooks/use-selection.js", () => ({
+  useSelection: () => harness.selection,
+}));
+
+vi.mock("../ink/terminal.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../ink/terminal.js")>(
+      "../ink/terminal.js",
+    );
+  return {
+    ...actual,
+    isXtermJs: vi.fn(() => false),
+  };
+});
+
+vi.mock("../ink/termio/osc.js", () => ({
+  getClipboardPath: harness.getClipboardPath,
+}));
+
+vi.mock("src/utils/debug.js", () => ({
+  logForDebugging: vi.fn(),
+}));
+
+vi.mock("../keybindings/useKeybinding.js", () => ({
+  useKeybindings: (
+    handlers: Record<string, () => unknown>,
+    options: { context: string; isActive: boolean },
+  ) => {
+    harness.keybindingCalls.push({ handlers, options });
+  },
+}));
+
+vi.mock("../ink.js", async () => {
+  const actual = await vi.importActual<typeof import("../ink.js")>("../ink.js");
+  return {
+    ...actual,
+    useInput: vi.fn(),
+  };
+});
+
+describe("ScrollKeybindingHandler copy notification coverage", () => {
+  beforeEach(() => {
+    harness.addNotification.mockClear();
+    harness.getClipboardPath.mockClear();
+    harness.getClipboardPath.mockReturnValue("osc52");
+    harness.keybindingCalls.length = 0;
+    harness.selection.copySelection.mockClear();
+    harness.selection.copySelection.mockReturnValue("terminal copy");
+  });
+
+  test("reports OSC 52 clipboard delivery when copying a selection", async () => {
+    const { ScrollKeybindingHandler } = await import("./ScrollKeybindingHandler.js");
+
+    await renderToString(
+      <ScrollKeybindingHandler
+        isActive
+        scrollRef={{ current: null }}
+      />,
+      80,
+    );
+
+    harness.keybindingCalls[0]?.handlers["selection:copy"]?.();
+
+    expect(harness.selection.copySelection).toHaveBeenCalledOnce();
+    expect(harness.addNotification).toHaveBeenCalledWith({
+      key: "selection-copied",
+      text: "sent 13 chars via OSC 52 · check terminal clipboard settings if paste fails",
+      color: "suggestion",
+      priority: "immediate",
+      timeoutMs: 4000,
+    });
+  });
+});

--- a/runtime/tests/tui/components/ScrollKeybindingHandler.logic.test.ts
+++ b/runtime/tests/tui/components/ScrollKeybindingHandler.logic.test.ts
@@ -139,6 +139,42 @@ describe("ScrollKeybindingHandler wheel acceleration", () => {
     expect(state.wheelMode).toBe(false);
   });
 
+  test("drops native wheel mode after an idle gap before resolving a stale flip", () => {
+    const state = initWheelAccel(false, 2);
+
+    expect(computeWheelStep(state, 1, 1_000)).toBe(2);
+    expect(computeWheelStep(state, -1, 1_010)).toBe(0);
+    expect(computeWheelStep(state, 1, 1_020)).toBeGreaterThanOrEqual(5);
+    expect(state.wheelMode).toBe(true);
+
+    expect(computeWheelStep(state, -1, 1_030)).toBe(0);
+    expect(state.pendingFlip).toBe(true);
+
+    expect(computeWheelStep(state, 1, 2_600)).toBe(2);
+    expect(state.pendingFlip).toBe(false);
+    expect(state.wheelMode).toBe(false);
+    expect(state.mult).toBe(2);
+  });
+
+  test("treats sustained native wheel-mode bursts as trackpad device switches", () => {
+    const state = initWheelAccel(false, 1);
+    state.dir = 1;
+    state.time = 1_000;
+    state.mult = 7;
+    state.wheelMode = true;
+
+    expect(computeWheelStep(state, 1, 1_001)).toBe(1);
+    expect(computeWheelStep(state, 1, 1_002)).toBe(1);
+    expect(computeWheelStep(state, 1, 1_003)).toBe(1);
+    expect(computeWheelStep(state, 1, 1_004)).toBe(1);
+    expect(state.wheelMode).toBe(true);
+
+    expect(computeWheelStep(state, 1, 1_005)).toBe(1);
+    expect(state.wheelMode).toBe(false);
+    expect(state.burstCount).toBe(0);
+    expect(state.mult).toBeCloseTo(1.3);
+  });
+
   test("uses xterm.js decay, burst, reversal, and idle behavior", () => {
     const state = initWheelAccel(true, 1);
 
@@ -152,6 +188,19 @@ describe("ScrollKeybindingHandler wheel acceleration", () => {
     expect(state.frac).toBe(0);
 
     expect(computeWheelStep(state, -1, 1_700)).toBe(2);
+  });
+
+  test("carries fractional xterm.js scroll between sparse events", () => {
+    const state = initWheelAccel(true, 1);
+
+    expect(computeWheelStep(state, 1, 1_000)).toBe(2);
+
+    const firstSparse = computeWheelStep(state, 1, 1_400);
+    expect(firstSparse).toBe(1);
+    expect(state.frac).toBeGreaterThan(0.9);
+
+    expect(computeWheelStep(state, 1, 1_800)).toBe(2);
+    expect(state.frac).toBeGreaterThan(0);
   });
 });
 
@@ -200,6 +249,20 @@ describe("ScrollKeybindingHandler drag and jump helpers", () => {
         2,
         8,
         1,
+      ),
+    ).toBe(0);
+    expect(
+      dragScrollDirection(
+        { isDragging: true, focus: { row: 9 } } as never,
+        2,
+        8,
+      ),
+    ).toBe(0);
+    expect(
+      dragScrollDirection(
+        { isDragging: true, anchor: { row: 5 } } as never,
+        2,
+        8,
       ),
     ).toBe(0);
   });
@@ -277,6 +340,18 @@ describe("ScrollKeybindingHandler modal pager", () => {
       false,
     );
     expect(beforeJump).toHaveBeenCalledWith(9);
+
+    const pageUp = makeScrollBox({ scrollTop: 20, viewportHeight: 9 });
+    expect(applyModalPagerAction(pageUp.handle as never, "fullPageUp", beforeJump)).toBe(
+      false,
+    );
+    expect(beforeJump).toHaveBeenCalledWith(-9);
+
+    const halfDown = makeScrollBox({ scrollTop: 20, viewportHeight: 9 });
+    expect(
+      applyModalPagerAction(halfDown.handle as never, "halfPageDown", beforeJump),
+    ).toBe(false);
+    expect(beforeJump).toHaveBeenCalledWith(4);
 
     const top = makeScrollBox({ pendingDelta: 3, scrollTop: 20 });
     expect(applyModalPagerAction(top.handle as never, "top", beforeJump)).toBe(false);

--- a/runtime/tests/tui/components/ScrollKeybindingHandler.render.test.tsx
+++ b/runtime/tests/tui/components/ScrollKeybindingHandler.render.test.tsx
@@ -1,0 +1,423 @@
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { renderToString } from "../../utils/staticRender.js";
+
+type KeybindingCall = {
+  handlers: Record<string, () => unknown>;
+  options: { context: string; isActive: boolean };
+};
+
+type InputEvent = { stopImmediatePropagation: () => void };
+type InputCall = {
+  handler: (
+    input: string,
+    key: Record<string, boolean>,
+    event: InputEvent,
+  ) => void;
+  options: { isActive: boolean };
+};
+
+type SelectionMock = {
+  getState: ReturnType<typeof vi.fn>;
+  clearSelection: ReturnType<typeof vi.fn>;
+  hasSelection: ReturnType<typeof vi.fn>;
+  copySelection: ReturnType<typeof vi.fn>;
+  moveFocus: ReturnType<typeof vi.fn>;
+  captureScrolledRows: ReturnType<typeof vi.fn>;
+  shiftSelection: ReturnType<typeof vi.fn>;
+  shiftAnchor: ReturnType<typeof vi.fn>;
+  subscribe: ReturnType<typeof vi.fn>;
+};
+
+const harness = vi.hoisted(() => {
+  const state = {
+    keybindingCalls: [] as KeybindingCall[],
+    inputCalls: [] as InputCall[],
+    selectionState: null as unknown,
+    unsubscribe: vi.fn(),
+    addNotification: vi.fn(),
+    getClipboardPath: vi.fn(() => "native"),
+    isXtermJs: vi.fn(() => false),
+    logForDebugging: vi.fn(),
+    useCopyOnSelect: vi.fn(),
+    useSelectionBgColor: vi.fn(),
+    selection: undefined as unknown as SelectionMock,
+  };
+
+  state.selection = {
+    getState: vi.fn(() => state.selectionState),
+    clearSelection: vi.fn(),
+    hasSelection: vi.fn(() => false),
+    copySelection: vi.fn(() => ""),
+    moveFocus: vi.fn(),
+    captureScrolledRows: vi.fn(),
+    shiftSelection: vi.fn(),
+    shiftAnchor: vi.fn(),
+    subscribe: vi.fn(() => state.unsubscribe),
+  };
+
+  return state;
+});
+
+vi.mock("../context/notifications", () => ({
+  useNotifications: () => ({
+    addNotification: harness.addNotification,
+  }),
+}));
+
+vi.mock("../hooks/useCopyOnSelect", () => ({
+  useCopyOnSelect: harness.useCopyOnSelect,
+  useSelectionBgColor: harness.useSelectionBgColor,
+}));
+
+vi.mock("../ink/hooks/use-selection.js", () => ({
+  useSelection: () => harness.selection,
+}));
+
+vi.mock("../ink/terminal.js", async () => {
+  const actual = await vi.importActual<typeof import("../ink/terminal.js")>(
+    "../ink/terminal.js",
+  );
+  return {
+    ...actual,
+    isXtermJs: harness.isXtermJs,
+  };
+});
+
+vi.mock("../ink/termio/osc.js", () => ({
+  getClipboardPath: harness.getClipboardPath,
+}));
+
+vi.mock("src/utils/debug.js", () => ({
+  logForDebugging: harness.logForDebugging,
+}));
+
+vi.mock("../keybindings/useKeybinding.js", () => ({
+  useKeybindings: (
+    handlers: Record<string, () => unknown>,
+    options: { context: string; isActive: boolean },
+  ) => {
+    harness.keybindingCalls.push({ handlers, options });
+  },
+}));
+
+vi.mock("../ink.js", async () => {
+  const actual = await vi.importActual<typeof import("../ink.js")>("../ink.js");
+  return {
+    ...actual,
+    useInput: (
+      handler: InputCall["handler"],
+      options: InputCall["options"],
+    ) => {
+      harness.inputCalls.push({ handler, options });
+    },
+  };
+});
+
+function makeScrollBox({
+  pendingDelta = 0,
+  scrollHeight = 100,
+  scrollTop = 10,
+  viewportHeight = 20,
+  viewportTop = 2,
+} = {}) {
+  const calls: Array<[string, number?]> = [];
+  let pending = pendingDelta;
+  let top = scrollTop;
+
+  const handle = {
+    getPendingDelta: () => pending,
+    getScrollHeight: () => scrollHeight,
+    getScrollTop: () => top,
+    getViewportHeight: () => viewportHeight,
+    getViewportTop: () => viewportTop,
+    scrollBy: (amount: number) => {
+      calls.push(["scrollBy", amount]);
+      pending += amount;
+    },
+    scrollTo: (value: number) => {
+      calls.push(["scrollTo", value]);
+      top = value;
+      pending = 0;
+    },
+    scrollToBottom: () => {
+      calls.push(["scrollToBottom"]);
+      top = Math.max(0, scrollHeight - viewportHeight);
+      pending = 0;
+    },
+  };
+
+  return { calls, handle };
+}
+
+function key(overrides: Record<string, boolean> = {}) {
+  return {
+    ctrl: false,
+    downArrow: false,
+    end: false,
+    escape: false,
+    home: false,
+    leftArrow: false,
+    meta: false,
+    shift: false,
+    upArrow: false,
+    ...overrides,
+  };
+}
+
+function event(): InputEvent {
+  return { stopImmediatePropagation: vi.fn() };
+}
+
+async function renderHandler({
+  isActive = true,
+  isModal = false,
+  onScroll = vi.fn(),
+  scrollBox = makeScrollBox(),
+} = {}) {
+  const { ScrollKeybindingHandler } = await import("./ScrollKeybindingHandler.js");
+
+  await renderToString(
+    <ScrollKeybindingHandler
+      scrollRef={{ current: scrollBox.handle as never }}
+      isActive={isActive}
+      isModal={isModal}
+      onScroll={onScroll}
+    />,
+    80,
+  );
+
+  return {
+    customBindings: harness.keybindingCalls[1]?.handlers ?? {},
+    inputCalls: harness.inputCalls,
+    mainBindings: harness.keybindingCalls[0]?.handlers ?? {},
+    onScroll,
+    scrollBox,
+  };
+}
+
+describe("ScrollKeybindingHandler keybinding registration", () => {
+  beforeEach(() => {
+    harness.keybindingCalls.length = 0;
+    harness.inputCalls.length = 0;
+    harness.selectionState = null;
+    harness.unsubscribe.mockClear();
+    harness.addNotification.mockClear();
+    harness.getClipboardPath.mockClear();
+    harness.getClipboardPath.mockReturnValue("native");
+    harness.isXtermJs.mockClear();
+    harness.isXtermJs.mockReturnValue(false);
+    harness.logForDebugging.mockClear();
+    harness.useCopyOnSelect.mockClear();
+    harness.useSelectionBgColor.mockClear();
+
+    harness.selection.getState.mockClear();
+    harness.selection.clearSelection.mockClear();
+    harness.selection.hasSelection.mockClear();
+    harness.selection.hasSelection.mockReturnValue(false);
+    harness.selection.copySelection.mockClear();
+    harness.selection.copySelection.mockReturnValue("");
+    harness.selection.moveFocus.mockClear();
+    harness.selection.captureScrolledRows.mockClear();
+    harness.selection.shiftSelection.mockClear();
+    harness.selection.shiftAnchor.mockClear();
+    harness.selection.subscribe.mockClear();
+    harness.selection.subscribe.mockReturnValue(harness.unsubscribe);
+  });
+
+  test("translates active selections for page-up and page-down keybindings", async () => {
+    harness.selectionState = {
+      anchor: { row: 3 },
+      focus: { row: 5 },
+    };
+    const scrollBox = makeScrollBox({
+      scrollTop: 10,
+      viewportHeight: 10,
+      viewportTop: 2,
+    });
+    const { mainBindings, onScroll } = await renderHandler({ scrollBox });
+
+    mainBindings["scroll:pageDown"]?.();
+
+    expect(harness.selection.captureScrolledRows).toHaveBeenCalledWith(
+      2,
+      6,
+      "above",
+    );
+    expect(harness.selection.shiftSelection).toHaveBeenCalledWith(-5, 2, 11);
+    expect(scrollBox.calls).toEqual([["scrollTo", 15]]);
+    expect(onScroll).toHaveBeenLastCalledWith(false, scrollBox.handle);
+
+    harness.selection.captureScrolledRows.mockClear();
+    harness.selection.shiftSelection.mockClear();
+    scrollBox.calls.length = 0;
+
+    mainBindings["scroll:pageUp"]?.();
+
+    expect(harness.selection.captureScrolledRows).toHaveBeenCalledWith(
+      7,
+      11,
+      "below",
+    );
+    expect(harness.selection.shiftSelection).toHaveBeenCalledWith(5, 2, 11);
+    expect(scrollBox.calls).toEqual([["scrollTo", 10]]);
+    expect(onScroll).toHaveBeenLastCalledWith(false, scrollBox.handle);
+  });
+
+  test("lets wheel keybindings fall through when content fits", async () => {
+    const scrollBox = makeScrollBox({
+      scrollHeight: 10,
+      viewportHeight: 20,
+    });
+    const { mainBindings, onScroll } = await renderHandler({ scrollBox });
+
+    expect(mainBindings["scroll:lineDown"]?.()).toBe(false);
+
+    expect(harness.selection.clearSelection).toHaveBeenCalledOnce();
+    expect(scrollBox.calls).toEqual([]);
+    expect(onScroll).not.toHaveBeenCalled();
+  });
+
+  test("reports sticky bottom from wheel-down and clamps wheel-up at top", async () => {
+    const downBox = makeScrollBox({
+      scrollHeight: 100,
+      scrollTop: 79,
+      viewportHeight: 20,
+    });
+    const first = await renderHandler({ scrollBox: downBox });
+
+    first.mainBindings["scroll:lineDown"]?.();
+
+    expect(downBox.calls).toEqual([["scrollToBottom"]]);
+    expect(first.onScroll).toHaveBeenLastCalledWith(true, downBox.handle);
+    expect(harness.logForDebugging).toHaveBeenCalledWith(
+      expect.stringContaining("wheel accel: window"),
+    );
+
+    harness.keybindingCalls.length = 0;
+    harness.inputCalls.length = 0;
+    harness.selection.clearSelection.mockClear();
+
+    const upBox = makeScrollBox({
+      scrollHeight: 100,
+      scrollTop: 0,
+      viewportHeight: 20,
+    });
+    const second = await renderHandler({ scrollBox: upBox });
+
+    second.mainBindings["scroll:lineUp"]?.();
+
+    expect(harness.selection.clearSelection).toHaveBeenCalledOnce();
+    expect(upBox.calls).toEqual([["scrollTo", 0]]);
+    expect(second.onScroll).toHaveBeenLastCalledWith(false, upBox.handle);
+  });
+
+  test("handles custom half-page and full-page keybinding routes", async () => {
+    const scrollBox = makeScrollBox({
+      scrollTop: 20,
+      viewportHeight: 9,
+    });
+    const { customBindings, onScroll } = await renderHandler({ scrollBox });
+
+    customBindings["scroll:halfPageDown"]?.();
+    expect(scrollBox.calls).toEqual([["scrollTo", 24]]);
+    expect(onScroll).toHaveBeenLastCalledWith(false, scrollBox.handle);
+
+    scrollBox.calls.length = 0;
+
+    customBindings["scroll:fullPageUp"]?.();
+    expect(scrollBox.calls).toEqual([["scrollTo", 15]]);
+    expect(onScroll).toHaveBeenLastCalledWith(false, scrollBox.handle);
+  });
+
+  test("runs absolute scroll and copy keybindings", async () => {
+    const scrollBox = makeScrollBox({
+      pendingDelta: 3,
+      scrollHeight: 100,
+      scrollTop: 20,
+      viewportHeight: 20,
+    });
+    const { mainBindings, onScroll } = await renderHandler({ scrollBox });
+
+    mainBindings["scroll:bottom"]?.();
+    expect(scrollBox.calls).toEqual([["scrollTo", 80], ["scrollToBottom"]]);
+    expect(onScroll).toHaveBeenLastCalledWith(true, scrollBox.handle);
+
+    scrollBox.calls.length = 0;
+
+    mainBindings["scroll:top"]?.();
+    expect(scrollBox.calls).toEqual([["scrollTo", 0]]);
+    expect(onScroll).toHaveBeenLastCalledWith(false, scrollBox.handle);
+
+    harness.selection.copySelection.mockReturnValue("abc");
+    harness.getClipboardPath.mockReturnValue("tmux-buffer");
+
+    mainBindings["selection:copy"]?.();
+
+    expect(harness.addNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "selection-copied",
+        text: expect.stringContaining("tmux buffer"),
+        timeoutMs: 4000,
+      }),
+    );
+  });
+
+  test("consumes modal pager input only when it maps to a scroll action", async () => {
+    const scrollBox = makeScrollBox({ scrollTop: 10 });
+    const { inputCalls, onScroll } = await renderHandler({
+      isModal: true,
+      scrollBox,
+    });
+    const modalInput = inputCalls[0];
+
+    expect(modalInput?.options).toEqual({ isActive: true });
+
+    const consumed = event();
+    modalInput?.handler("j", key(), consumed);
+
+    expect(scrollBox.calls).toEqual([["scrollTo", 11]]);
+    expect(onScroll).toHaveBeenLastCalledWith(false, scrollBox.handle);
+    expect(consumed.stopImmediatePropagation).toHaveBeenCalledOnce();
+
+    const passthrough = event();
+    modalInput?.handler("x", key(), passthrough);
+
+    expect(passthrough.stopImmediatePropagation).not.toHaveBeenCalled();
+  });
+
+  test("handles selection escape, copy, focus extension, and clear input paths", async () => {
+    const { inputCalls } = await renderHandler();
+    const selectionInput = inputCalls[1];
+    harness.selection.hasSelection.mockReturnValue(true);
+
+    const escape = event();
+    selectionInput?.handler("", key({ escape: true }), escape);
+    expect(harness.selection.clearSelection).toHaveBeenCalledOnce();
+    expect(escape.stopImmediatePropagation).toHaveBeenCalledOnce();
+
+    harness.selection.clearSelection.mockClear();
+    harness.selection.copySelection.mockReturnValue("copied");
+
+    const copy = event();
+    selectionInput?.handler("c", key({ ctrl: true }), copy);
+    expect(harness.selection.copySelection).toHaveBeenCalledOnce();
+    expect(harness.addNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "copied 6 chars to clipboard" }),
+    );
+    expect(copy.stopImmediatePropagation).toHaveBeenCalledOnce();
+
+    const extend = event();
+    selectionInput?.handler("", key({ rightArrow: true, shift: true }), extend);
+    expect(harness.selection.moveFocus).toHaveBeenCalledWith("right");
+    expect(extend.stopImmediatePropagation).toHaveBeenCalledOnce();
+
+    harness.selection.clearSelection.mockClear();
+    const ordinary = event();
+    selectionInput?.handler("x", key(), ordinary);
+
+    expect(harness.selection.clearSelection).toHaveBeenCalledOnce();
+    expect(ordinary.stopImmediatePropagation).not.toHaveBeenCalled();
+  });
+});

--- a/runtime/tests/tui/components/ScrollKeybindingHandler.wave200-015.coverage.test.tsx
+++ b/runtime/tests/tui/components/ScrollKeybindingHandler.wave200-015.coverage.test.tsx
@@ -1,0 +1,242 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { describe, expect, test, vi } from "vitest";
+
+import { createRoot } from "../ink/root.js";
+
+type SelectionState = {
+  anchor?: { row: number };
+  focus?: { row: number };
+  isDragging?: boolean;
+  scrolledOffAbove: string[];
+  scrolledOffBelow: string[];
+  scrolledOffAboveSW: boolean[];
+  scrolledOffBelowSW: boolean[];
+};
+
+const harness = vi.hoisted(() => {
+  const state = {
+    addNotification: vi.fn(),
+    keybindingCalls: [] as Array<Record<string, () => unknown>>,
+    onSelectionChange: null as (() => void) | null,
+    selectionState: null as SelectionState | null,
+    unsubscribe: vi.fn(),
+    selection: {
+      clearSelection: vi.fn(),
+      copySelection: vi.fn(() => ""),
+      getState: vi.fn(() => state.selectionState),
+      hasSelection: vi.fn(() => false),
+      moveFocus: vi.fn(),
+      captureScrolledRows: vi.fn(),
+      shiftSelection: vi.fn(),
+      shiftAnchor: vi.fn(),
+      subscribe: vi.fn((callback: () => void) => {
+        state.onSelectionChange = callback;
+        return state.unsubscribe;
+      }),
+    },
+  };
+
+  return state;
+});
+
+vi.mock("bun:bundle", () => ({
+  feature: () => false,
+}));
+
+vi.mock("../context/notifications", () => ({
+  useNotifications: () => ({
+    addNotification: harness.addNotification,
+  }),
+}));
+
+vi.mock("../hooks/useCopyOnSelect", () => ({
+  useCopyOnSelect: vi.fn(),
+  useSelectionBgColor: vi.fn(),
+}));
+
+vi.mock("../ink/hooks/use-selection.js", () => ({
+  useSelection: () => harness.selection,
+}));
+
+vi.mock("../ink/terminal.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../ink/terminal.js")>(
+      "../ink/terminal.js",
+    );
+  return {
+    ...actual,
+    isXtermJs: vi.fn(() => false),
+  };
+});
+
+vi.mock("../ink/termio/osc.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../ink/termio/osc.js")>(
+      "../ink/termio/osc.js",
+    );
+  return {
+    ...actual,
+    getClipboardPath: vi.fn(() => "native"),
+  };
+});
+
+vi.mock("src/utils/debug.js", () => ({
+  logForDebugging: vi.fn(),
+}));
+
+vi.mock("../keybindings/useKeybinding.js", () => ({
+  useKeybindings: (handlers: Record<string, () => unknown>) => {
+    harness.keybindingCalls.push(handlers);
+  },
+}));
+
+vi.mock("../ink.js", async () => {
+  const actual = await vi.importActual<typeof import("../ink.js")>("../ink.js");
+  return {
+    ...actual,
+    useInput: vi.fn(),
+  };
+});
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+function createStreams(): {
+  stdin: TestStdin;
+  stdout: PassThrough;
+} {
+  const stdin = new PassThrough() as TestStdin;
+  const stdout = new PassThrough();
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).columns =
+    80;
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).rows =
+    24;
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).isTTY =
+    true;
+  stdout.resume();
+  return { stdin, stdout };
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForSubscription(): Promise<() => void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (harness.onSelectionChange) return harness.onSelectionChange;
+    await sleep(10);
+  }
+  throw new Error("Timed out waiting for drag-scroll subscription");
+}
+
+function makeScrollHandle() {
+  const calls: Array<[string, number?]> = [];
+  let pendingDelta = 0;
+  let scrollTop = 5;
+
+  return {
+    calls,
+    handle: {
+      getPendingDelta: () => pendingDelta,
+      getScrollHeight: () => 40,
+      getScrollTop: () => scrollTop,
+      getViewportHeight: () => 4,
+      getViewportTop: () => 10,
+      scrollBy: (amount: number) => {
+        calls.push(["scrollBy", amount]);
+        pendingDelta += amount;
+      },
+      scrollTo: (value: number) => {
+        calls.push(["scrollTo", value]);
+        scrollTop = value;
+        pendingDelta = 0;
+      },
+      scrollToBottom: () => {
+        calls.push(["scrollToBottom"]);
+        scrollTop = 36;
+        pendingDelta = 0;
+      },
+    },
+  };
+}
+
+describe("ScrollKeybindingHandler drag-scroll coverage", () => {
+  test("auto-scrolls dragging selections below the viewport and clears opposite-edge captured rows", async () => {
+    harness.addNotification.mockClear();
+    harness.keybindingCalls.length = 0;
+    harness.onSelectionChange = null;
+    harness.selectionState = {
+      anchor: { row: 12 },
+      focus: { row: 15 },
+      isDragging: true,
+      scrolledOffAbove: [],
+      scrolledOffBelow: [],
+      scrolledOffAboveSW: [],
+      scrolledOffBelowSW: [],
+    };
+    harness.selection.captureScrolledRows.mockClear();
+    harness.selection.shiftAnchor.mockClear();
+    harness.selection.subscribe.mockClear();
+    harness.unsubscribe.mockClear();
+
+    const { ScrollKeybindingHandler } = await import("./ScrollKeybindingHandler.js");
+    const scrollBox = makeScrollHandle();
+    const onScroll = vi.fn();
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <ScrollKeybindingHandler
+          isActive
+          onScroll={onScroll}
+          scrollRef={{ current: scrollBox.handle as never }}
+        />,
+      );
+      const notifySelectionChanged = await waitForSubscription();
+
+      notifySelectionChanged();
+
+      expect(harness.selection.captureScrolledRows).toHaveBeenCalledWith(
+        10,
+        11,
+        "above",
+      );
+      expect(harness.selection.shiftAnchor).toHaveBeenCalledWith(-2, 10, 13);
+      expect(scrollBox.calls).toEqual([["scrollBy", 2]]);
+      expect(onScroll).toHaveBeenCalledWith(false, scrollBox.handle);
+
+      harness.selectionState.focus = { row: 8 };
+      harness.selectionState.scrolledOffAbove = ["captured"];
+      harness.selectionState.scrolledOffBelow = [];
+      harness.selectionState.scrolledOffAboveSW = [false];
+      harness.selectionState.scrolledOffBelowSW = [];
+
+      notifySelectionChanged();
+
+      expect(harness.selectionState.scrolledOffAbove).toEqual([]);
+      expect(harness.selectionState.scrolledOffBelow).toEqual([]);
+      expect(harness.selectionState.scrolledOffAboveSW).toEqual([]);
+      expect(harness.selectionState.scrolledOffBelowSW).toEqual([]);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+});

--- a/runtime/tests/tui/components/TaskListV2.render.test.tsx
+++ b/runtime/tests/tui/components/TaskListV2.render.test.tsx
@@ -1,0 +1,301 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  appState: {
+    tasks: {} as Record<string, unknown>,
+    teamContext: undefined as
+      | undefined
+      | {
+          teammates: Record<string, { color?: string; name: string }>;
+        },
+  },
+  columns: 80,
+  rows: 24,
+  swarmsEnabled: false,
+  todoEnabled: true,
+  reset() {
+    harness.appState = {
+      tasks: {},
+      teamContext: undefined,
+    };
+    harness.columns = 80;
+    harness.rows = 24;
+    harness.swarmsEnabled = false;
+    harness.todoEnabled = true;
+  },
+}));
+
+vi.mock("../hooks/useTerminalSize.js", () => ({
+  useTerminalSize: () => ({ columns: harness.columns, rows: harness.rows }),
+}));
+
+vi.mock("../state/AppState.js", () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+}));
+
+vi.mock("../../utils/tasks.js", async importOriginal => {
+  const actual = await importOriginal<typeof import("../../utils/tasks.js")>();
+  return {
+    ...actual,
+    isTodoV2Enabled: () => harness.todoEnabled,
+  };
+});
+
+vi.mock("../../utils/agentSwarmsEnabled.js", () => ({
+  isAgentSwarmsEnabled: () => harness.swarmsEnabled,
+}));
+
+vi.mock("../../tasks/InProcessTeammateTask/types.js", () => ({
+  isInProcessTeammateTask: (task: { readonly type?: string }) =>
+    task.type === "in_process_teammate",
+}));
+
+vi.mock("../../utils/collapseReadSearch.js", () => ({
+  summarizeRecentActivities: (
+    activities: readonly Array<{ readonly activityDescription?: string }>,
+  ) => activities.map(activity => activity.activityDescription).filter(Boolean).join(" + "),
+}));
+
+vi.mock("src/tools/AgentTool/agentColorManager.js", () => ({
+  AGENT_COLOR_TO_THEME_COLOR: {
+    blue: "permission",
+    green: "success",
+  },
+}));
+
+import { createRoot } from "../ink/root.js";
+import { TaskListV2 } from "./TaskListV2.js";
+
+type TestTask = {
+  activeForm?: string;
+  blockedBy: string[];
+  blocks: string[];
+  description: string;
+  id: string;
+  owner?: string;
+  status: "completed" | "in_progress" | "pending";
+  subject: string;
+};
+
+function createStreams(): {
+  stdout: PassThrough & { columns?: number; rows?: number };
+  stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+} {
+  const stdout = new PassThrough() as PassThrough & {
+    columns?: number;
+    rows?: number;
+  };
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.columns = harness.columns;
+  stdout.rows = harness.rows;
+  stdout.resume();
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function task(overrides: Partial<TestTask> & Pick<TestTask, "id" | "subject">): TestTask {
+  return {
+    blockedBy: [],
+    blocks: [],
+    description: `${overrides.subject} description`,
+    status: "pending",
+    ...overrides,
+  };
+}
+
+async function renderTaskList(
+  tasks: TestTask[],
+  isStandalone = false,
+): Promise<{
+  dispose: () => Promise<void>;
+  output: () => string;
+}> {
+  let output = "";
+  const { stdin, stdout } = createStreams();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+  root.render(<TaskListV2 tasks={tasks as never} isStandalone={isStandalone} />);
+  await sleep();
+  return {
+    dispose: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    },
+    output: () => stripAnsi(output),
+  };
+}
+
+describe("TaskListV2 rendering", () => {
+  beforeEach(() => {
+    harness.reset();
+  });
+
+  test("renders nothing when task UI is disabled or empty", async () => {
+    harness.todoEnabled = false;
+    const disabled = await renderTaskList([
+      task({ id: "1", subject: "Hidden task" }),
+    ]);
+    harness.todoEnabled = true;
+    const empty = await renderTaskList([]);
+
+    try {
+      expect(disabled.output().trim()).toBe("");
+      expect(empty.output().trim()).toBe("");
+    } finally {
+      await disabled.dispose();
+      await empty.dispose();
+    }
+  });
+
+  test("renders standalone counts and sorted task rows", async () => {
+    const rendered = await renderTaskList(
+      [
+        task({ id: "2", status: "completed", subject: "Write docs" }),
+        task({ id: "10", subject: "Ship release" }),
+        task({ id: "1", status: "in_progress", subject: "Run tests" }),
+        task({ id: "abc", subject: "Non numeric id" }),
+      ],
+      true,
+    );
+
+    try {
+      const output = rendered.output();
+      expect(output).toContain("4 tasks (1 done, 1 in progress, 2 open)");
+      expect(output.indexOf("Run tests")).toBeLessThan(output.indexOf("Write docs"));
+      expect(output.indexOf("Write docs")).toBeLessThan(output.indexOf("Ship release"));
+      expect(output.indexOf("Ship release")).toBeLessThan(output.indexOf("Non numeric id"));
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("shows blockers and hides blocked activity", async () => {
+    harness.swarmsEnabled = true;
+    harness.appState.tasks = {
+      teammate: {
+        identity: { agentId: "alice@team", agentName: "alice" },
+        progress: {
+          lastActivity: { activityDescription: "Reading files" },
+          recentActivities: [{ activityDescription: "Scanning" }],
+        },
+        status: "running",
+        type: "in_process_teammate",
+      },
+    };
+
+    const rendered = await renderTaskList([
+      task({ id: "1", status: "in_progress", subject: "Active dependency" }),
+      task({
+        blockedBy: ["1"],
+        id: "2",
+        owner: "alice",
+        status: "in_progress",
+        subject: "Blocked teammate work",
+      }),
+    ]);
+
+    try {
+      const output = rendered.output();
+      expect(output).toContain("Blocked teammate work");
+      expect(output).toContain("blocked by #1");
+      expect(output).toContain("@alice");
+      expect(output).not.toContain("Scanning");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("shows active teammate activity and colorized owner when swarms are enabled", async () => {
+    harness.swarmsEnabled = true;
+    harness.appState.teamContext = {
+      teammates: {
+        alice: { color: "blue", name: "alice" },
+      },
+    };
+    harness.appState.tasks = {
+      teammate: {
+        identity: { agentId: "alice@team", agentName: "alice" },
+        progress: {
+          lastActivity: { activityDescription: "Reading files" },
+          recentActivities: [
+            { activityDescription: "Searching" },
+            { activityDescription: "Reading files" },
+          ],
+        },
+        status: "running",
+        type: "in_process_teammate",
+      },
+    };
+
+    const rendered = await renderTaskList([
+      task({
+        id: "1",
+        owner: "alice",
+        status: "in_progress",
+        subject: "Investigate logs",
+      }),
+    ]);
+
+    try {
+      const output = rendered.output();
+      expect(output).toContain("@alice");
+      expect(output).toContain("Searching + Reading files…");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("truncates rows and summarizes hidden task states on short terminals", async () => {
+    harness.rows = 17;
+    const rendered = await renderTaskList([
+      task({ id: "1", status: "completed", subject: "Completed one" }),
+      task({ id: "2", status: "in_progress", subject: "Running two" }),
+      task({ id: "3", subject: "Open three" }),
+      task({ id: "4", status: "completed", subject: "Completed four" }),
+      task({ id: "5", subject: "Open five", blockedBy: ["2"] }),
+    ]);
+
+    try {
+      const output = rendered.output();
+      expect(output).toContain("Running two");
+      expect(output).toContain("Open three");
+      expect(output).toContain("Open five");
+      expect(output).toContain("blocked by #2");
+      expect(output).not.toContain("Completed one");
+      expect(output).not.toContain("Completed four");
+      expect(output).toContain("… +2 completed");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+});

--- a/runtime/tests/tui/components/TaskListV2.wave200-056.coverage.test.tsx
+++ b/runtime/tests/tui/components/TaskListV2.wave200-056.coverage.test.tsx
@@ -1,0 +1,214 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  appState: {
+    tasks: {} as Record<string, unknown>,
+    teamContext: undefined,
+  },
+  columns: 90,
+  rows: 17,
+  todoEnabled: true,
+  reset() {
+    harness.appState = {
+      tasks: {},
+      teamContext: undefined,
+    };
+    harness.columns = 90;
+    harness.rows = 17;
+    harness.todoEnabled = true;
+  },
+}));
+
+vi.mock("../hooks/useTerminalSize.js", () => ({
+  useTerminalSize: () => ({ columns: harness.columns, rows: harness.rows }),
+}));
+
+vi.mock("../state/AppState.js", () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+}));
+
+vi.mock("../../utils/tasks.js", async importOriginal => {
+  const actual = await importOriginal<typeof import("../../utils/tasks.js")>();
+  return {
+    ...actual,
+    isTodoV2Enabled: () => harness.todoEnabled,
+  };
+});
+
+vi.mock("../../utils/agentSwarmsEnabled.js", () => ({
+  isAgentSwarmsEnabled: () => false,
+}));
+
+import { createRoot } from "../ink/root.js";
+import { TaskListV2 } from "./TaskListV2.js";
+
+type TestTask = {
+  activeForm?: string;
+  blockedBy: string[];
+  blocks: string[];
+  description: string;
+  id: string;
+  owner?: string;
+  status: "completed" | "in_progress" | "pending";
+  subject: string;
+};
+
+function createStreams(): {
+  stdout: PassThrough & { columns?: number; rows?: number };
+  stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+} {
+  const stdout = new PassThrough() as PassThrough & {
+    columns?: number;
+    rows?: number;
+  };
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.columns = harness.columns;
+  stdout.rows = harness.rows;
+  stdout.resume();
+  return { stdin, stdout };
+}
+
+async function flushTimers(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(0);
+  await Promise.resolve();
+}
+
+function task(overrides: Partial<TestTask> & Pick<TestTask, "id" | "subject">): TestTask {
+  return {
+    blockedBy: [],
+    blocks: [],
+    description: `${overrides.subject} description`,
+    status: "pending",
+    ...overrides,
+  };
+}
+
+function taskSet(firstTaskStatus: TestTask["status"]): TestTask[] {
+  return [
+    task({
+      id: "1",
+      status: firstTaskStatus,
+      subject: "Freshly completed setup",
+    }),
+    task({
+      id: "2",
+      status: "in_progress",
+      subject: "Active dependency",
+    }),
+    task({
+      blockedBy: ["10", "2"],
+      id: "3",
+      status: "in_progress",
+      subject: "Blocked integration",
+    }),
+    task({
+      id: "4",
+      status: "in_progress",
+      subject: "Hidden running",
+    }),
+    task({
+      id: "5",
+      subject: "Hidden open",
+    }),
+    task({
+      id: "6",
+      status: "completed",
+      subject: "Old finished",
+    }),
+    task({
+      blockedBy: ["2"],
+      id: "10",
+      subject: "Blocked pending dependency",
+    }),
+  ];
+}
+
+async function createTaskListHarness(): Promise<{
+  dispose: () => Promise<void>;
+  output: () => string;
+  render: (tasks: TestTask[]) => Promise<string>;
+}> {
+  let output = "";
+  const { stdin, stdout } = createStreams();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  return {
+    dispose: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await flushTimers();
+    },
+    output: () => stripAnsi(output),
+    render: async tasks => {
+      output = "";
+      root.render(<TaskListV2 tasks={tasks as never} />);
+      await flushTimers();
+      return stripAnsi(output);
+    },
+  };
+}
+
+describe("TaskListV2 recent completion coverage", () => {
+  beforeEach(() => {
+    harness.reset();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("keeps a freshly completed task visible until its recent window expires", async () => {
+    const rendered = await createTaskListHarness();
+
+    try {
+      await rendered.render(taskSet("pending"));
+
+      const recentOutput = await rendered.render(taskSet("completed"));
+      expect(recentOutput).toContain("Freshly completed setup");
+      expect(recentOutput).toContain("Active dependency");
+      expect(recentOutput).toContain("Blocked integration");
+      expect(recentOutput).toContain("blocked by #2, #10");
+      expect(recentOutput).toContain("+1 in progress, 2 pending, 1 completed");
+      expect(recentOutput).not.toContain("Hidden running");
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      await flushTimers();
+
+      const expiredOutput = await rendered.render(taskSet("completed"));
+      expect(expiredOutput).toContain("Hidden running");
+      expect(expiredOutput).toContain("+2 pending, 2 completed");
+      expect(expiredOutput).not.toContain("Freshly completed setup");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+});

--- a/runtime/tests/tui/components/ThinkingToggle.coverage.test.tsx
+++ b/runtime/tests/tui/components/ThinkingToggle.coverage.test.tsx
@@ -1,0 +1,191 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createRoot } from "../ink/root.js";
+import { ThinkingToggle } from "./ThinkingToggle.js";
+
+const harness = vi.hoisted(() => ({
+  keybindings: {} as Record<
+    string,
+    {
+      handler: () => void;
+      options?: { isActive?: boolean };
+    }
+  >,
+  selectProps: undefined as
+    | undefined
+    | {
+        defaultFocusValue?: string;
+        defaultValue?: string;
+        onChange: (value: string) => void;
+        options: Array<{ label: string; value: string }>;
+        visibleOptionCount: number;
+      },
+}));
+
+vi.mock("src/tui/hooks/useExitOnCtrlCDWithKeybindings.js", () => ({
+  useExitOnCtrlCDWithKeybindings: () => ({
+    keyName: "Ctrl+D",
+    pending: false,
+  }),
+}));
+
+vi.mock("../keybindings/useKeybinding.js", () => ({
+  useKeybinding: (
+    action: string,
+    handler: () => void,
+    options?: { isActive?: boolean },
+  ) => {
+    harness.keybindings[action] = { handler, options };
+  },
+}));
+
+vi.mock("./CustomSelect/select.js", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+  const { Text } = await vi.importActual<typeof import("../ink.js")>(
+    "../ink.js",
+  );
+
+  return {
+    Select: (props: typeof harness.selectProps) => {
+      harness.selectProps = props;
+      return ReactActual.createElement(
+        ReactActual.Fragment,
+        null,
+        props?.options.map(option =>
+          ReactActual.createElement(
+            Text,
+            { key: option.value },
+            `${option.label}:${option.value}`,
+          ),
+        ),
+      );
+    },
+  };
+});
+
+const SYNC_START = "\x1B[?2026h";
+const SYNC_END = "\x1B[?2026l";
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  readonly stdout: PassThrough;
+};
+
+function createStreams(): TestStreams {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStreams["stdin"];
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number; rows: number }).columns = 100;
+  (stdout as unknown as { columns: number; rows: number }).rows = 24;
+
+  return { stdin, stdout };
+}
+
+function extractLastFrame(output: string): string {
+  let lastFrame: string | null = null;
+  let cursor = 0;
+
+  while (cursor < output.length) {
+    const start = output.indexOf(SYNC_START, cursor);
+    if (start === -1) break;
+
+    const contentStart = start + SYNC_START.length;
+    const end = output.indexOf(SYNC_END, contentStart);
+    if (end === -1) break;
+
+    const frame = output.slice(contentStart, end);
+    if (frame.trim().length > 0) {
+      lastFrame = frame;
+    }
+    cursor = end + SYNC_END.length;
+  }
+
+  return lastFrame ?? output;
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe("ThinkingToggle", () => {
+  beforeEach(() => {
+    harness.keybindings = {};
+    harness.selectProps = undefined;
+  });
+
+  test("requires confirmation before changing thinking mode mid-conversation", async () => {
+    const onSelect = vi.fn();
+    const onCancel = vi.fn();
+    let output = "";
+    const { stdin, stdout } = createStreams();
+    stdout.on("data", chunk => {
+      output += chunk.toString();
+    });
+
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <ThinkingToggle
+          currentValue={true}
+          isMidConversation={true}
+          onCancel={onCancel}
+          onSelect={onSelect}
+        />,
+      );
+      await sleep();
+
+      expect(harness.selectProps).toMatchObject({
+        defaultFocusValue: "true",
+        defaultValue: "true",
+        visibleOptionCount: 2,
+      });
+      expect(harness.selectProps?.options.map(option => option.value)).toEqual([
+        "true",
+        "false",
+      ]);
+      expect(stripAnsi(extractLastFrame(output))).toContain(
+        "Enable or disable thinking for this session.",
+      );
+
+      harness.selectProps?.onChange("false");
+      await sleep();
+
+      const confirmationOutput = stripAnsi(extractLastFrame(output));
+      expect(onSelect).not.toHaveBeenCalled();
+      expect(confirmationOutput).toContain(
+        "Changing thinking mode mid-conversation will increase latency",
+      );
+      expect(confirmationOutput).toContain("Do you want to proceed?");
+      expect(confirmationOutput).toContain("Esc to cancel");
+      expect(harness.keybindings["confirm:yes"]?.options?.isActive).toBe(true);
+
+      harness.keybindings["confirm:yes"]?.handler();
+
+      expect(onSelect).toHaveBeenCalledExactlyOnceWith(false);
+      expect(onCancel).not.toHaveBeenCalled();
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+});

--- a/runtime/tests/tui/components/VirtualMessageList.coverage.test.tsx
+++ b/runtime/tests/tui/components/VirtualMessageList.coverage.test.tsx
@@ -1,0 +1,264 @@
+import { PassThrough } from "node:stream";
+
+import React, { useContext } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const virtualScroll = vi.hoisted(() => ({
+  bottomSpacer: 0,
+  elements: new Map<number, unknown>(),
+  heights: new Map<number, number | undefined>(),
+  itemTops: new Map<number, number>(),
+  keys: [] as readonly string[],
+  offsets: [] as number[],
+  range: [0, 0] as [number, number],
+  reset() {
+    virtualScroll.bottomSpacer = 0;
+    virtualScroll.elements = new Map();
+    virtualScroll.heights = new Map();
+    virtualScroll.itemTops = new Map();
+    virtualScroll.keys = [];
+    virtualScroll.offsets = [];
+    virtualScroll.range = [0, 0];
+    virtualScroll.topSpacer = 0;
+  },
+  topSpacer: 0,
+}));
+
+vi.mock("../hooks/useVirtualScroll.js", () => ({
+  useVirtualScroll: (_scrollRef: unknown, keys: readonly string[]) => {
+    virtualScroll.keys = keys;
+    return {
+      bottomSpacer: virtualScroll.bottomSpacer,
+      getItemElement: (index: number) =>
+        virtualScroll.elements.get(index) ?? null,
+      getItemHeight: (index: number) => virtualScroll.heights.get(index),
+      getItemTop: (index: number) => virtualScroll.itemTops.get(index) ?? -1,
+      measureRef: (key: string) => (el: unknown) => {
+        const index = virtualScroll.keys.indexOf(key);
+        if (index >= 0 && el) virtualScroll.elements.set(index, el);
+      },
+      offsets: virtualScroll.offsets,
+      range: virtualScroll.range,
+      scrollToIndex: vi.fn(),
+      spacerRef: { current: null },
+      topSpacer: virtualScroll.topSpacer,
+    };
+  },
+}));
+
+import instances from "../ink/instances.js";
+import type { DOMElement, DOMNode } from "../ink/dom.js";
+import { createRoot } from "../ink/root.js";
+import { Text } from "../ink.js";
+import type { ScrollBoxHandle } from "../ink/components/ScrollBox.js";
+import type { RenderableMessage } from "../../types/message.js";
+import { TextHoverColorContext } from "./design-system/ThemedText.js";
+import { VirtualMessageList } from "./VirtualMessageList.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+function userMessage(uuid: string, text: string): RenderableMessage {
+  return {
+    isCompactSummary: false,
+    isMeta: false,
+    isVisibleInTranscriptOnly: false,
+    message: { content: [{ text, type: "text" }] },
+    type: "user",
+    uuid,
+  } as RenderableMessage;
+}
+
+function assistantMessage(uuid: string, text: string): RenderableMessage {
+  return {
+    message: { content: [{ text, type: "text" }] },
+    type: "assistant",
+    uuid,
+  } as RenderableMessage;
+}
+
+function createStreams(): { stdin: TestStdin; stdout: PassThrough } {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.on("data", () => {});
+  (stdout as unknown as { columns: number }).columns = 80;
+  (stdout as unknown as { rows: number }).rows = 24;
+  (stdout as unknown as { isTTY: boolean }).isTTY = true;
+
+  return { stdin, stdout };
+}
+
+function createScrollHandle(): ScrollBoxHandle {
+  return {
+    getPendingDelta: vi.fn(() => 0),
+    getScrollTop: vi.fn(() => 0),
+    getViewportHeight: vi.fn(() => 10),
+    getViewportTop: vi.fn(() => 0),
+    isSticky: vi.fn(() => true),
+    scrollTo: vi.fn(),
+    scrollToBottom: vi.fn(),
+    scrollToElement: vi.fn(),
+    subscribe: vi.fn(() => () => {}),
+  } as unknown as ScrollBoxHandle;
+}
+
+function collectText(node: DOMNode): string {
+  if (node.nodeName === "#text") return node.nodeValue;
+  return node.childNodes.map(collectText).join("");
+}
+
+function findBoxes(
+  node: DOMNode,
+  predicate: (node: DOMElement) => boolean,
+  found: DOMElement[] = [],
+): DOMElement[] {
+  if (node.nodeName === "#text") return found;
+  if (node.nodeName === "ink-box" && predicate(node)) found.push(node);
+  for (const child of node.childNodes) findBoxes(child, predicate, found);
+  return found;
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream);
+  if (!instance?.rootNode) {
+    throw new Error("Ink root node not found");
+  }
+  return instance.rootNode;
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 2_000) {
+    if (predicate()) return;
+    await sleep(10);
+  }
+  throw new Error(message);
+}
+
+describe("VirtualMessageList coverage", () => {
+  beforeEach(() => {
+    virtualScroll.reset();
+  });
+
+  afterEach(() => {
+    virtualScroll.reset();
+  });
+
+  test("dispatches row clicks only from non-blank cells on clickable messages", async () => {
+    const hoverColorByUuid = new Map<string, string>();
+    const messages = [
+      userMessage("u-clickable", "selectable prompt"),
+      assistantMessage("a-static", "non-clickable reply"),
+    ];
+    virtualScroll.range = [0, messages.length];
+    virtualScroll.offsets = [0, 1, 2];
+    messages.forEach((_, index) => {
+      virtualScroll.heights.set(index, 1);
+      virtualScroll.itemTops.set(index, index);
+    });
+
+    function HoverProbe({ uuid }: { uuid: string }): React.ReactNode {
+      const hoverColor = useContext(TextHoverColorContext);
+      hoverColorByUuid.set(uuid, hoverColor ?? "none");
+      return (
+        <Text>
+          {uuid}:{hoverColor ?? "none"}
+        </Text>
+      );
+    }
+
+    const onItemClick = vi.fn();
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <VirtualMessageList
+          columns={80}
+          isItemClickable={message => message.uuid === "u-clickable"}
+          itemKey={message => message.uuid}
+          messages={messages}
+          onItemClick={onItemClick}
+          renderItem={message => <HoverProbe uuid={message.uuid} />}
+          scrollRef={{ current: createScrollHandle() }}
+        />,
+      );
+      await waitForCondition(
+        () => hoverColorByUuid.get("u-clickable") === "none",
+        "initial row render did not complete",
+      );
+
+      const rootNode = getRootNode(stdout);
+      const clickableBox = findBoxes(
+        rootNode,
+        box =>
+          collectText(box).includes("u-clickable") &&
+          typeof box._eventHandlers?.onClick === "function",
+      )[0];
+      const staticBox = findBoxes(rootNode, box =>
+        collectText(box).includes("a-static"),
+      )[0];
+
+      expect(clickableBox).toBeDefined();
+      expect(staticBox).toBeDefined();
+      expect(staticBox?._eventHandlers?.onClick).toBeUndefined();
+      expect(staticBox?._eventHandlers?.onMouseEnter).toBeUndefined();
+
+      (
+        clickableBox?._eventHandlers?.onClick as
+          | ((event: { cellIsBlank: boolean }) => void)
+          | undefined
+      )?.({ cellIsBlank: true });
+      expect(onItemClick).not.toHaveBeenCalled();
+
+      (
+        clickableBox?._eventHandlers?.onClick as
+          | ((event: { cellIsBlank: boolean }) => void)
+          | undefined
+      )?.({ cellIsBlank: false });
+      expect(onItemClick).toHaveBeenCalledTimes(1);
+      expect(onItemClick).toHaveBeenCalledWith(messages[0]);
+
+      (
+        clickableBox?._eventHandlers?.onMouseEnter as (() => void) | undefined
+      )?.();
+      await waitForCondition(
+        () => hoverColorByUuid.get("u-clickable") === "text",
+        "hover color did not apply to clickable row",
+      );
+
+      (
+        clickableBox?._eventHandlers?.onMouseLeave as (() => void) | undefined
+      )?.();
+      await waitForCondition(
+        () => hoverColorByUuid.get("u-clickable") === "none",
+        "hover color did not clear after leaving clickable row",
+      );
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+});

--- a/runtime/tests/tui/components/VirtualMessageList.coverage2.test.tsx
+++ b/runtime/tests/tui/components/VirtualMessageList.coverage2.test.tsx
@@ -1,0 +1,228 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const virtualScroll = vi.hoisted(() => ({
+  elements: new Map<number, unknown>(),
+  heights: new Map<number, number | undefined>(),
+  itemTops: new Map<number, number>(),
+  keys: [] as readonly string[],
+  offsets: [] as number[],
+  range: [0, 0] as [number, number],
+  reset() {
+    virtualScroll.elements = new Map();
+    virtualScroll.heights = new Map();
+    virtualScroll.itemTops = new Map();
+    virtualScroll.keys = [];
+    virtualScroll.offsets = [];
+    virtualScroll.range = [0, 0];
+    virtualScroll.scrollToIndex.mockClear();
+  },
+  scrollToIndex: vi.fn(),
+}));
+
+vi.mock("../hooks/useVirtualScroll.js", () => ({
+  useVirtualScroll: (_scrollRef: unknown, keys: readonly string[]) => {
+    virtualScroll.keys = keys;
+    return {
+      bottomSpacer: 0,
+      getItemElement: (index: number) =>
+        virtualScroll.elements.get(index) ?? null,
+      getItemHeight: (index: number) => virtualScroll.heights.get(index),
+      getItemTop: (index: number) => virtualScroll.itemTops.get(index) ?? -1,
+      measureRef: (key: string) => (el: unknown) => {
+        const index = virtualScroll.keys.indexOf(key);
+        if (index >= 0 && el) virtualScroll.elements.set(index, el);
+      },
+      offsets: virtualScroll.offsets,
+      range: virtualScroll.range,
+      scrollToIndex: virtualScroll.scrollToIndex,
+      spacerRef: { current: null },
+      topSpacer: 0,
+    };
+  },
+}));
+
+import { createRoot } from "../ink/root.js";
+import { Text } from "../ink.js";
+import type { ScrollBoxHandle } from "../ink/components/ScrollBox.js";
+import type { DOMElement } from "../ink/dom.js";
+import type { RenderableMessage } from "../../types/message.js";
+import {
+  type JumpHandle,
+  VirtualMessageList,
+} from "./VirtualMessageList.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+function userMessage(uuid: string, text: string): RenderableMessage {
+  return {
+    isCompactSummary: false,
+    isMeta: false,
+    isVisibleInTranscriptOnly: false,
+    message: { content: [{ text, type: "text" }] },
+    type: "user",
+    uuid,
+  } as RenderableMessage;
+}
+
+function assistantMessage(uuid: string, text: string): RenderableMessage {
+  return {
+    message: { content: [{ text, type: "text" }] },
+    type: "assistant",
+    uuid,
+  } as RenderableMessage;
+}
+
+function fakeElement(height = 2): DOMElement {
+  return {
+    yogaNode: {
+      getComputedHeight: () => height,
+    },
+  } as DOMElement;
+}
+
+function createStreams(): { stdin: TestStdin; stdout: PassThrough } {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.on("data", () => {});
+  stdout.resume();
+
+  return { stdin, stdout };
+}
+
+function createScrollHandle(initialScrollTop = 0): ScrollBoxHandle {
+  let scrollTop = initialScrollTop;
+
+  return {
+    getPendingDelta: vi.fn(() => 0),
+    getScrollTop: vi.fn(() => scrollTop),
+    getViewportHeight: vi.fn(() => 10),
+    getViewportTop: vi.fn(() => 0),
+    isSticky: vi.fn(() => false),
+    scrollTo: vi.fn((value: number) => {
+      scrollTop = value;
+    }),
+    scrollToBottom: vi.fn(),
+    scrollToElement: vi.fn(),
+    subscribe: vi.fn(() => () => {}),
+  } as unknown as ScrollBoxHandle;
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 2_000) {
+    if (predicate()) return;
+    await sleep(10);
+  }
+  throw new Error(message);
+}
+
+describe("VirtualMessageList coverage 2", () => {
+  beforeEach(() => {
+    virtualScroll.reset();
+  });
+
+  afterEach(() => {
+    virtualScroll.reset();
+  });
+
+  test("uses the default transcript search extractor across repeated queries", async () => {
+    const messages = [
+      userMessage("u-needle", "Alpha NEEDLE prompt"),
+      assistantMessage("a-other", "ordinary reply"),
+    ];
+    virtualScroll.range = [0, messages.length];
+    virtualScroll.offsets = [0, 8, 16];
+    messages.forEach((_, index) => {
+      virtualScroll.elements.set(index, fakeElement());
+      virtualScroll.heights.set(index, 2);
+      virtualScroll.itemTops.set(index, index * 8);
+    });
+
+    const jumpRef = React.createRef<JumpHandle | null>();
+    const scrollHandle = createScrollHandle();
+    const onSearchMatchesChange = vi.fn();
+    const setPositions = vi.fn();
+    const scanElement = vi.fn(() => [{ col: 6, row: 0 }]);
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <VirtualMessageList
+          columns={80}
+          itemKey={message => message.uuid}
+          jumpRef={jumpRef}
+          messages={messages}
+          onSearchMatchesChange={onSearchMatchesChange}
+          renderItem={(message, index) => (
+            <Text>
+              {index}:{message.uuid}
+            </Text>
+          )}
+          scanElement={scanElement}
+          scrollRef={{ current: scrollHandle }}
+          setPositions={setPositions}
+        />,
+      );
+      await waitForCondition(
+        () => jumpRef.current !== null,
+        "jump handle was not exposed",
+      );
+
+      jumpRef.current?.setSearchQuery("needle");
+      await waitForCondition(
+        () => scanElement.mock.calls.length === 1,
+        "first default-extractor search did not scan the matched row",
+      );
+
+      expect(scrollHandle.scrollTo).toHaveBeenLastCalledWith(0);
+      expect(scanElement).toHaveBeenLastCalledWith(
+        virtualScroll.elements.get(0),
+      );
+      expect(setPositions).toHaveBeenLastCalledWith({
+        currentIdx: 0,
+        positions: [{ col: 6, row: 0 }],
+        rowOffset: 0,
+      });
+      expect(onSearchMatchesChange).toHaveBeenLastCalledWith(1, 1);
+
+      jumpRef.current?.setSearchQuery("NEEDLE");
+      await waitForCondition(
+        () => scanElement.mock.calls.length === 2,
+        "cached default-extractor search did not rescan the matched row",
+      );
+
+      expect(onSearchMatchesChange).toHaveBeenLastCalledWith(1, 1);
+      expect(virtualScroll.scrollToIndex).not.toHaveBeenCalled();
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+});

--- a/runtime/tests/tui/components/VirtualMessageList.test.tsx
+++ b/runtime/tests/tui/components/VirtualMessageList.test.tsx
@@ -1,0 +1,534 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const virtualScroll = vi.hoisted(() => ({
+  bottomSpacer: 0,
+  elements: new Map<number, unknown>(),
+  heights: new Map<number, number | undefined>(),
+  itemTops: new Map<number, number>(),
+  keys: [] as readonly string[],
+  offsets: [] as number[],
+  range: [0, 0] as [number, number],
+  reset() {
+    virtualScroll.bottomSpacer = 0
+    virtualScroll.elements = new Map()
+    virtualScroll.heights = new Map()
+    virtualScroll.itemTops = new Map()
+    virtualScroll.keys = []
+    virtualScroll.offsets = []
+    virtualScroll.range = [0, 0]
+    virtualScroll.scrollToIndex.mockClear()
+    virtualScroll.topSpacer = 0
+  },
+  scrollToIndex: vi.fn(),
+  topSpacer: 0,
+}))
+
+vi.mock('../hooks/useVirtualScroll.js', () => ({
+  useVirtualScroll: (_scrollRef: unknown, keys: readonly string[]) => {
+    virtualScroll.keys = keys
+    return {
+      bottomSpacer: virtualScroll.bottomSpacer,
+      getItemElement: (index: number) =>
+        virtualScroll.elements.get(index) ?? null,
+      getItemHeight: (index: number) => virtualScroll.heights.get(index),
+      getItemTop: (index: number) => virtualScroll.itemTops.get(index) ?? -1,
+      measureRef: (key: string) => (el: unknown) => {
+        const index = virtualScroll.keys.indexOf(key)
+        if (index >= 0 && el) virtualScroll.elements.set(index, el)
+      },
+      offsets: virtualScroll.offsets,
+      range: virtualScroll.range,
+      scrollToIndex: virtualScroll.scrollToIndex,
+      spacerRef: { current: null },
+      topSpacer: virtualScroll.topSpacer,
+    }
+  },
+}))
+
+vi.mock('../../utils/sleep.js', () => ({
+  sleep: async () => {},
+}))
+
+import { createRoot } from '../ink/root.js'
+import { Text } from '../ink.js'
+import type { ScrollBoxHandle } from '../ink/components/ScrollBox.js'
+import type { DOMElement } from '../ink/dom.js'
+import type { RenderableMessage } from '../../types/message.js'
+import { ScrollChromeContext } from './FullscreenLayout.js'
+import {
+  type JumpHandle,
+  VirtualMessageList,
+} from './VirtualMessageList.js'
+import type {
+  MessageActionsNav,
+  MessageActionsState,
+} from './messageActions.js'
+
+type TestScrollHandle = ScrollBoxHandle & {
+  emit: () => void
+  setPendingDelta: (value: number) => void
+  setSticky: (value: boolean) => void
+}
+
+function userMessage(
+  uuid: string,
+  text: string,
+  overrides: Partial<RenderableMessage> = {},
+): RenderableMessage {
+  return {
+    isCompactSummary: false,
+    isMeta: false,
+    isVisibleInTranscriptOnly: false,
+    message: { content: [{ text, type: 'text' }] },
+    type: 'user',
+    uuid,
+    ...overrides,
+  } as RenderableMessage
+}
+
+function assistantMessage(uuid: string, text: string): RenderableMessage {
+  return {
+    message: { content: [{ text, type: 'text' }] },
+    type: 'assistant',
+    uuid,
+  } as RenderableMessage
+}
+
+function systemMessage(uuid: string, subtype = 'note'): RenderableMessage {
+  return {
+    subtype,
+    type: 'system',
+    uuid,
+  } as RenderableMessage
+}
+
+function queuedCommand(
+  uuid: string,
+  prompt: string | Array<{ type: string; text?: string }>,
+): RenderableMessage {
+  return {
+    attachment: {
+      commandMode: 'prompt',
+      isMeta: false,
+      prompt,
+      type: 'queued_command',
+    },
+    type: 'attachment',
+    uuid,
+  } as RenderableMessage
+}
+
+function fakeElement(height = 2): DOMElement {
+  return {
+    yogaNode: {
+      getComputedHeight: () => height,
+    },
+  } as DOMElement
+}
+
+function createScrollHandle(initialScrollTop = 0): TestScrollHandle {
+  let scrollTop = initialScrollTop
+  let pendingDelta = 0
+  let sticky = false
+  const listeners = new Set<() => void>()
+  return {
+    emit: () => {
+      for (const listener of listeners) listener()
+    },
+    getPendingDelta: vi.fn(() => pendingDelta),
+    getScrollTop: vi.fn(() => scrollTop),
+    getViewportHeight: vi.fn(() => 10),
+    getViewportTop: vi.fn(() => 0),
+    isSticky: vi.fn(() => sticky),
+    scrollTo: vi.fn((value: number) => {
+      scrollTop = value
+    }),
+    scrollToBottom: vi.fn(() => {
+      sticky = true
+    }),
+    scrollToElement: vi.fn(),
+    setPendingDelta: (value: number) => {
+      pendingDelta = value
+    },
+    setSticky: (value: boolean) => {
+      sticky = value
+    },
+    subscribe: vi.fn((listener: () => void) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    }),
+  } as unknown as TestScrollHandle
+}
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderList({
+  cursorNavRef,
+  extractSearchText,
+  isItemClickable,
+  isItemExpanded,
+  itemKey = msg => msg.uuid,
+  jumpRef,
+  messages,
+  onItemClick,
+  onSearchMatchesChange,
+  scanElement,
+  scrollHandle = createScrollHandle(),
+  selectedIndex,
+  setCursor,
+  setPositions,
+  setStickyPrompt,
+  trackStickyPrompt = false,
+}: {
+  cursorNavRef?: React.RefObject<MessageActionsNav | null>
+  extractSearchText?: (msg: RenderableMessage) => string
+  isItemClickable?: (msg: RenderableMessage) => boolean
+  isItemExpanded?: (msg: RenderableMessage) => boolean
+  itemKey?: (msg: RenderableMessage) => string
+  jumpRef?: React.RefObject<JumpHandle | null>
+  messages: RenderableMessage[]
+  onItemClick?: (msg: RenderableMessage) => void
+  onSearchMatchesChange?: (count: number, current: number) => void
+  scanElement?: (el: DOMElement) => Array<{ row: number; col: number }>
+  scrollHandle?: TestScrollHandle
+  selectedIndex?: number
+  setCursor?: (cursor: MessageActionsState | null) => void
+  setPositions?: (
+    state: {
+      positions: Array<{ row: number; col: number }>
+      rowOffset: number
+      currentIdx: number
+    } | null,
+  ) => void
+  setStickyPrompt?: React.ComponentProps<
+    typeof ScrollChromeContext
+  >['value']['setStickyPrompt']
+  trackStickyPrompt?: boolean
+}): Promise<{
+  dispose: () => Promise<void>
+  output: () => string
+  scrollHandle: TestScrollHandle
+}> {
+  let output = ''
+  const { stdin, stdout } = createStreams()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  const scrollRef = {
+    current: scrollHandle,
+  } as React.RefObject<ScrollBoxHandle | null>
+  const node = (
+    <ScrollChromeContext
+      value={{ setStickyPrompt: setStickyPrompt ?? (() => {}) }}
+    >
+      <VirtualMessageList
+        columns={80}
+        cursorNavRef={cursorNavRef}
+        extractSearchText={extractSearchText}
+        isItemClickable={isItemClickable}
+        isItemExpanded={isItemExpanded}
+        itemKey={itemKey}
+        jumpRef={jumpRef}
+        messages={messages}
+        onItemClick={onItemClick}
+        onSearchMatchesChange={onSearchMatchesChange}
+        renderItem={(msg, index) => (
+          <Text>
+            {index}:{msg.uuid}
+          </Text>
+        )}
+        scanElement={scanElement}
+        scrollRef={scrollRef}
+        selectedIndex={selectedIndex}
+        setCursor={setCursor}
+        setPositions={setPositions}
+        trackStickyPrompt={trackStickyPrompt}
+      />
+    </ScrollChromeContext>
+  )
+  root.render(node)
+  await sleep()
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    output: () => stripAnsi(output),
+    scrollHandle,
+  }
+}
+
+describe('VirtualMessageList', () => {
+  beforeEach(() => {
+    virtualScroll.reset()
+  })
+
+  afterEach(() => {
+    virtualScroll.reset()
+  })
+
+  test('renders only the virtualized range with spacers', async () => {
+    const messages = [
+      userMessage('u-1', 'first prompt'),
+      assistantMessage('a-1', 'assistant reply'),
+      queuedCommand('q-1', 'queued prompt'),
+    ]
+    virtualScroll.range = [1, 3]
+    virtualScroll.topSpacer = 2
+    virtualScroll.bottomSpacer = 4
+    virtualScroll.offsets = [0, 2, 4, 6]
+    for (let i = 0; i < messages.length; i++) {
+      virtualScroll.heights.set(i, 1)
+      virtualScroll.itemTops.set(i, i * 2)
+    }
+
+    const rendered = await renderList({
+      isItemClickable: msg => msg.type !== 'attachment',
+      isItemExpanded: msg => msg.uuid === 'a-1',
+      messages,
+      onItemClick: vi.fn(),
+    })
+
+    try {
+      expect(rendered.output()).not.toContain('0:u-1')
+      expect(rendered.output()).toContain('1:a-1')
+      expect(rendered.output()).toContain('2:q-1')
+      expect(virtualScroll.keys).toEqual(['u-1', 'a-1', 'q-1'])
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('exposes cursor navigation over visible navigable messages', async () => {
+    const messages = [
+      userMessage('meta', 'hidden', { isMeta: true } as Partial<RenderableMessage>),
+      userMessage('u-1', 'first prompt'),
+      systemMessage('metrics', 'api_metrics'),
+      assistantMessage('a-1', 'needle reply'),
+      userMessage('xml', '<command-message>synthetic</command-message>'),
+    ]
+    virtualScroll.range = [0, messages.length]
+    virtualScroll.offsets = [0, 2, 4, 6, 8, 10]
+    messages.forEach((_, index) => {
+      virtualScroll.heights.set(index, index === 2 ? 0 : 1)
+      virtualScroll.itemTops.set(index, index * 2)
+      virtualScroll.elements.set(index, fakeElement())
+    })
+    const navRef = React.createRef<MessageActionsNav | null>()
+    const setCursor = vi.fn()
+    const scrollHandle = createScrollHandle()
+
+    const rendered = await renderList({
+      cursorNavRef: navRef,
+      messages,
+      scrollHandle,
+      selectedIndex: 3,
+      setCursor,
+    })
+
+    try {
+      navRef.current?.enterCursor()
+      expect(setCursor).toHaveBeenLastCalledWith({
+        expanded: false,
+        msgType: 'user',
+        toolName: undefined,
+        uuid: 'u-1',
+      })
+
+      navRef.current?.navigatePrev()
+      expect(setCursor).toHaveBeenLastCalledWith({
+        expanded: false,
+        msgType: 'user',
+        toolName: undefined,
+        uuid: 'u-1',
+      })
+
+      navRef.current?.navigateNext()
+      expect(scrollHandle.scrollToBottom).toHaveBeenCalled()
+      expect(setCursor).toHaveBeenLastCalledWith(null)
+
+      navRef.current?.navigateTop()
+      expect(setCursor).toHaveBeenLastCalledWith({
+        expanded: false,
+        msgType: 'user',
+        toolName: undefined,
+        uuid: 'u-1',
+      })
+      expect(navRef.current?.getSelected()).toBe(messages[3])
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('search jump handle scans, highlights, steps, disarms, and warms the search index', async () => {
+    const messages = [
+      userMessage('u-1', 'alpha needle'),
+      assistantMessage('a-1', 'needle and another needle'),
+      queuedCommand('q-1', [
+        { text: 'queued needle', type: 'text' },
+        { type: 'image' },
+      ]),
+    ]
+    virtualScroll.range = [0, messages.length]
+    virtualScroll.offsets = [0, 10, 20, 30]
+    messages.forEach((_, index) => {
+      virtualScroll.heights.set(index, 2)
+      virtualScroll.itemTops.set(index, index * 10)
+      virtualScroll.elements.set(index, fakeElement(2))
+    })
+    const scrollHandle = createScrollHandle(11)
+    const jumpRef = React.createRef<JumpHandle | null>()
+    const setPositions = vi.fn()
+    const onSearchMatchesChange = vi.fn()
+    const scanElement = vi
+      .fn()
+      .mockReturnValueOnce([
+        { col: 2, row: 0 },
+        { col: 8, row: 5 },
+      ])
+      .mockReturnValue([{ col: 1, row: 1 }])
+
+    const rendered = await renderList({
+      extractSearchText: msg => {
+        if (msg.type === 'user') return msg.message.content[0].text.toLowerCase()
+        if (msg.type === 'assistant') {
+          return msg.message.content[0].text.toLowerCase()
+        }
+        return 'queued needle'
+      },
+      jumpRef,
+      messages,
+      onSearchMatchesChange,
+      scanElement,
+      scrollHandle,
+      setPositions,
+    })
+
+    try {
+      jumpRef.current?.setAnchor()
+      jumpRef.current?.setSearchQuery('needle')
+      await sleep()
+
+      expect(scrollHandle.scrollTo).toHaveBeenCalledWith(7)
+      expect(scanElement).toHaveBeenCalled()
+      expect(setPositions).toHaveBeenLastCalledWith({
+        currentIdx: 1,
+        positions: [
+          { col: 2, row: 0 },
+          { col: 8, row: 5 },
+        ],
+        rowOffset: 3,
+      })
+      expect(onSearchMatchesChange).toHaveBeenLastCalledWith(4, 3)
+
+      jumpRef.current?.nextMatch()
+      await sleep()
+      expect(setPositions).toHaveBeenLastCalledWith({
+        currentIdx: 0,
+        positions: [{ col: 1, row: 1 }],
+        rowOffset: 3,
+      })
+
+      jumpRef.current?.disarmSearch()
+      expect(setPositions).toHaveBeenLastCalledWith(null)
+
+      jumpRef.current?.setSearchQuery('missing')
+      expect(scrollHandle.scrollTo).toHaveBeenLastCalledWith(11)
+      expect(onSearchMatchesChange).toHaveBeenLastCalledWith(0, 0)
+
+      await expect(jumpRef.current?.warmSearchIndex()).resolves.toEqual(
+        expect.any(Number),
+      )
+      await expect(jumpRef.current?.warmSearchIndex()).resolves.toBe(0)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('tracks sticky prompts and jump-to-prompt correction paths', async () => {
+    const stickyPrompts: unknown[] = []
+    const messages = [
+      userMessage(
+        'u-1',
+        '<system-reminder>ignore</system-reminder>\n\nsticky prompt\n\nsecond paragraph',
+      ),
+      assistantMessage('a-1', 'visible response'),
+      queuedCommand('q-1', [
+        { text: 'queued visible prompt', type: 'text' },
+        { type: 'image' },
+      ]),
+    ]
+    virtualScroll.range = [1, messages.length]
+    virtualScroll.offsets = [0, 10, 20, 30]
+    messages.forEach((_, index) => {
+      virtualScroll.heights.set(index, 2)
+      virtualScroll.itemTops.set(index, index * 10)
+      if (index !== 0) virtualScroll.elements.set(index, fakeElement(2))
+    })
+    const scrollHandle = createScrollHandle(6)
+
+    const rendered = await renderList({
+      messages,
+      scrollHandle,
+      setStickyPrompt: prompt => stickyPrompts.push(prompt),
+      trackStickyPrompt: true,
+    })
+
+    try {
+      await sleep()
+      const prompt = stickyPrompts.at(-1)
+      expect(prompt).toMatchObject({ text: 'sticky prompt' })
+
+      ;(prompt as { scrollTo: () => void }).scrollTo()
+      expect(stickyPrompts.at(-1)).toBe('clicked')
+      expect(scrollHandle.scrollTo).toHaveBeenCalledWith(0)
+
+      virtualScroll.elements.set(0, fakeElement(2))
+      scrollHandle.emit()
+      await sleep()
+      expect(scrollHandle.scrollToElement).toHaveBeenCalledWith(
+        virtualScroll.elements.get(0),
+        1,
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/components/VirtualMessageList.wave200-016.coverage.test.tsx
+++ b/runtime/tests/tui/components/VirtualMessageList.wave200-016.coverage.test.tsx
@@ -1,0 +1,219 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const virtualScroll = vi.hoisted(() => ({
+  elements: new Map<number, unknown>(),
+  itemTops: new Map<number, number>(),
+  offsets: [] as number[],
+  range: [0, 0] as [number, number],
+  reset() {
+    virtualScroll.elements = new Map();
+    virtualScroll.itemTops = new Map();
+    virtualScroll.offsets = [];
+    virtualScroll.range = [0, 0];
+    virtualScroll.scrollToIndex.mockClear();
+  },
+  scrollToIndex: vi.fn(),
+}));
+
+vi.mock("../hooks/useVirtualScroll.js", () => ({
+  useVirtualScroll: (_scrollRef: unknown, keys: readonly string[]) => ({
+    bottomSpacer: 0,
+    getItemElement: (index: number) =>
+      virtualScroll.elements.get(index) ?? null,
+    getItemHeight: () => 2,
+    getItemTop: (index: number) => virtualScroll.itemTops.get(index) ?? -1,
+    measureRef: (_key: string) => () => {},
+    offsets: virtualScroll.offsets,
+    range: virtualScroll.range,
+    scrollToIndex: virtualScroll.scrollToIndex,
+    spacerRef: { current: null },
+    topSpacer: 0,
+  }),
+}));
+
+import { createRoot } from "../ink/root.js";
+import { Text } from "../ink.js";
+import type { ScrollBoxHandle } from "../ink/components/ScrollBox.js";
+import type { DOMElement } from "../ink/dom.js";
+import type { RenderableMessage } from "../../types/message.js";
+import { ScrollChromeContext } from "./FullscreenLayout.js";
+import {
+  type StickyPrompt,
+  VirtualMessageList,
+} from "./VirtualMessageList.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+function assistantMessage(uuid: string, text: string): RenderableMessage {
+  return {
+    message: { content: [{ text, type: "text" }] },
+    type: "assistant",
+    uuid,
+  } as RenderableMessage;
+}
+
+function queuedCommandMessage(uuid: string): RenderableMessage {
+  return {
+    attachment: {
+      commandMode: "prompt",
+      isMeta: false,
+      prompt: [
+        {
+          text:
+            "<system-reminder>hidden</system-reminder>\n\n" +
+            "queued   command starts here\nwith continuation\n\nignored paragraph",
+          type: "text",
+        },
+        { type: "image" },
+      ],
+      type: "queued_command",
+    },
+    type: "attachment",
+    uuid,
+  } as RenderableMessage;
+}
+
+function fakeElement(height = 2): DOMElement {
+  return {
+    yogaNode: {
+      getComputedHeight: () => height,
+    },
+  } as DOMElement;
+}
+
+function createStreams(): { stdin: TestStdin; stdout: PassThrough } {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.on("data", () => {});
+  stdout.resume();
+
+  return { stdin, stdout };
+}
+
+function createScrollHandle(initialScrollTop = 20): ScrollBoxHandle {
+  const listeners = new Set<() => void>();
+  let scrollTop = initialScrollTop;
+
+  return {
+    getPendingDelta: vi.fn(() => 0),
+    getScrollTop: vi.fn(() => scrollTop),
+    isSticky: vi.fn(() => false),
+    scrollTo: vi.fn((value: number) => {
+      scrollTop = value;
+    }),
+    scrollToElement: vi.fn(),
+    subscribe: vi.fn((listener: () => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    }),
+  } as unknown as ScrollBoxHandle;
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 2_000) {
+    if (predicate()) return;
+    await sleep(10);
+  }
+  throw new Error(message);
+}
+
+describe("VirtualMessageList wave200 coverage", () => {
+  beforeEach(() => {
+    virtualScroll.reset();
+  });
+
+  afterEach(() => {
+    virtualScroll.reset();
+  });
+
+  test("publishes a collapsed queued-command sticky prompt that jumps to its mounted row", async () => {
+    const messages = [
+      assistantMessage("a-before", "earlier output"),
+      queuedCommandMessage("queued-prompt"),
+      assistantMessage("a-after", "visible output"),
+    ];
+    const queuedElement = fakeElement();
+    virtualScroll.range = [0, messages.length];
+    virtualScroll.offsets = [0, 10, 30, 40];
+    virtualScroll.elements.set(1, queuedElement);
+    virtualScroll.itemTops.set(0, 0);
+    virtualScroll.itemTops.set(1, 10);
+    virtualScroll.itemTops.set(2, 30);
+
+    const setStickyPrompt = vi.fn();
+    const scrollHandle = createScrollHandle();
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <ScrollChromeContext value={{ setStickyPrompt }}>
+          <VirtualMessageList
+            columns={80}
+            itemKey={message => message.uuid}
+            messages={messages}
+            renderItem={message => <Text>{message.uuid}</Text>}
+            scrollRef={{ current: scrollHandle }}
+            trackStickyPrompt
+          />
+        </ScrollChromeContext>,
+      );
+
+      await waitForCondition(() => {
+        const prompt = setStickyPrompt.mock.lastCall?.[0] as
+          | StickyPrompt
+          | null
+          | undefined;
+        return typeof prompt === "object" && prompt !== null;
+      }, "sticky prompt was not published");
+
+      const prompt = setStickyPrompt.mock.lastCall?.[0] as Exclude<
+        StickyPrompt,
+        "clicked"
+      >;
+      expect(prompt.text).toBe(
+        "queued command starts here with continuation",
+      );
+
+      prompt.scrollTo();
+
+      expect(setStickyPrompt).toHaveBeenLastCalledWith("clicked");
+      expect(scrollHandle.scrollToElement).toHaveBeenCalledWith(
+        queuedElement,
+        1,
+      );
+      expect(scrollHandle.scrollTo).not.toHaveBeenCalled();
+      expect(virtualScroll.scrollToIndex).not.toHaveBeenCalled();
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+});

--- a/runtime/tests/tui/components/WorktreeExitDialog.test.tsx
+++ b/runtime/tests/tui/components/WorktreeExitDialog.test.tsx
@@ -1,0 +1,737 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
+
+type CapturedDialogProps = {
+  children: React.ReactNode
+  onCancel: () => void
+  subtitle?: React.ReactNode
+  title: React.ReactNode
+}
+
+type CapturedSelectProps = {
+  defaultFocusValue?: string
+  onChange?: (value: string) => void | Promise<void>
+  options: Array<{
+    description?: string
+    label: React.ReactNode
+    value: string
+  }>
+}
+
+type WorktreeSession = {
+  originalCwd: string
+  originalHeadCommit?: string
+  sessionId: string
+  tmuxSessionName?: string
+  worktreeBranch?: string
+  worktreeName: string
+  worktreePath: string
+}
+
+const harness = vi.hoisted(() => ({
+  chdir: vi.fn(),
+  cleanupWorktree: vi.fn(),
+  clearPlansCache: vi.fn(),
+  dialogProps: undefined as CapturedDialogProps | undefined,
+  execFileNoThrow: vi.fn(),
+  keepWorktree: vi.fn(),
+  killTmuxSession: vi.fn(),
+  logEvent: vi.fn(),
+  logForDebugging: vi.fn(),
+  saveWorktreeState: vi.fn(),
+  selectProps: undefined as CapturedSelectProps | undefined,
+  session: null as WorktreeSession | null,
+  setCwd: vi.fn(),
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../services/analytics/index.js', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('src/utils/debug.js', () => ({
+  logForDebugging: harness.logForDebugging,
+}))
+
+vi.mock('../../utils/debug.js', () => ({
+  logForDebugging: harness.logForDebugging,
+}))
+
+vi.mock('../../utils/execFileNoThrow.js', () => ({
+  execFileNoThrow: harness.execFileNoThrow,
+}))
+
+vi.mock('../../utils/plans.js', () => {
+  const getPlansDirectory = () => '/tmp/agenc-plans'
+  ;(
+    getPlansDirectory as typeof getPlansDirectory & {
+      cache: { clear: () => void }
+    }
+  ).cache = { clear: harness.clearPlansCache }
+
+  return { getPlansDirectory }
+})
+
+vi.mock('../../utils/Shell.js', () => ({
+  setCwd: harness.setCwd,
+}))
+
+vi.mock('../../utils/sessionStorage', () => ({
+  saveWorktreeState: harness.saveWorktreeState,
+}))
+
+vi.mock('../../utils/sessionStorage.js', () => ({
+  saveWorktreeState: harness.saveWorktreeState,
+}))
+
+vi.mock('../../utils/worktree.js', () => ({
+  cleanupWorktree: harness.cleanupWorktree,
+  getCurrentWorktreeSession: () => harness.session,
+  keepWorktree: harness.keepWorktree,
+  killTmuxSession: harness.killTmuxSession,
+}))
+
+vi.mock('./spinner/Spinner.js', () => ({
+  Spinner: () => null,
+}))
+
+vi.mock('./design-system/Dialog', async () => {
+  const ReactModule = await vi.importActual<typeof import('react')>('react')
+  const { Box, Text } =
+    await vi.importActual<typeof import('../ink.js')>('../ink.js')
+
+  return {
+    Dialog: (props: CapturedDialogProps) => {
+      harness.dialogProps = props
+      return ReactModule.createElement(
+        Box,
+        { flexDirection: 'column' },
+        ReactModule.createElement(Text, null, props.title),
+        props.subtitle
+          ? ReactModule.createElement(Text, null, props.subtitle)
+          : null,
+        props.children,
+      )
+    },
+  }
+})
+
+vi.mock('./CustomSelect/select', async () => {
+  const ReactModule = await vi.importActual<typeof import('react')>('react')
+  const { Box, Text } =
+    await vi.importActual<typeof import('../ink.js')>('../ink.js')
+
+  return {
+    Select: (props: CapturedSelectProps) => {
+      harness.selectProps = props
+      return ReactModule.createElement(
+        Box,
+        { flexDirection: 'column' },
+        ReactModule.createElement(
+          Text,
+          { key: 'focus' },
+          `focus:${props.defaultFocusValue ?? ''}`,
+        ),
+        ...props.options.map(option =>
+          ReactModule.createElement(
+            Text,
+            { key: option.value },
+            `${option.label} ${option.description ?? ''}`,
+          ),
+        ),
+      )
+    },
+  }
+})
+
+import { createRoot } from '../ink/root.js'
+import { renderToString } from '../../utils/staticRender.js'
+import { WorktreeExitDialog } from './WorktreeExitDialog.js'
+
+function baseSession(
+  overrides: Partial<WorktreeSession> = {},
+): WorktreeSession {
+  return {
+    originalCwd: '/workspace/main',
+    originalHeadCommit: 'abc123',
+    sessionId: 'session-1',
+    worktreeBranch: 'agenc/worktree-test',
+    worktreeName: 'worktree-test',
+    worktreePath: '/workspace/.agenc/worktrees/worktree-test',
+    ...overrides,
+  }
+}
+
+function mockGitState({
+  commitCount,
+  statusLines,
+}: {
+  commitCount: number
+  statusLines: string[]
+}) {
+  harness.execFileNoThrow.mockImplementation(
+    async (file: string, args: string[]) => {
+      expect(file).toBe('git')
+
+      if (args[0] === 'status') {
+        expect(args).toEqual(['status', '--porcelain'])
+        return {
+          code: 0,
+          stderr: '',
+          stdout:
+            statusLines.length > 0 ? `${statusLines.join('\n')}\n` : '',
+        }
+      }
+
+      if (args[0] === 'rev-list') {
+        expect(args).toEqual([
+          'rev-list',
+          '--count',
+          `${harness.session?.originalHeadCommit}..HEAD`,
+        ])
+        return { code: 0, stderr: '', stdout: `${commitCount}\n` }
+      }
+
+      throw new Error(`Unexpected execFileNoThrow call: ${file} ${args.join(' ')}`)
+    },
+  )
+}
+
+function createStreams(): {
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdout: PassThrough
+  output: () => string
+} {
+  let rendered = ''
+  const stdout = new PassThrough()
+  stdout.on('data', chunk => {
+    rendered += chunk.toString()
+  })
+  ;(stdout as unknown as { columns: number; rows: number }).columns = 120
+  ;(stdout as unknown as { columns: number; rows: number }).rows = 30
+  stdout.resume()
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  return {
+    stdin,
+    stdout,
+    output: () => stripAnsi(rendered),
+  }
+}
+
+async function sleep(ms = 0): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await sleep(10)
+  }
+
+  throw new Error(message)
+}
+
+function deferred<T = void>(): {
+  promise: Promise<T>
+  reject: (reason?: unknown) => void
+  resolve: (value: T | PromiseLike<T>) => void
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+
+  return { promise, reject, resolve }
+}
+
+async function mountDialog(props: {
+  onCancel?: () => void
+  onDone?: (result?: string, options?: { display?: string }) => void
+} = {}) {
+  const onDone = props.onDone ?? vi.fn()
+  const { stdin, stdout, output } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  root.render(
+    <WorktreeExitDialog onCancel={props.onCancel} onDone={onDone} />,
+  )
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep(25)
+    },
+    onDone,
+    output,
+  }
+}
+
+async function mountAskingDialog({
+  commitCount,
+  onCancel,
+  statusLines,
+}: {
+  commitCount: number
+  onCancel?: () => void
+  statusLines: string[]
+}) {
+  harness.session = baseSession()
+  mockGitState({ commitCount, statusLines })
+
+  const mounted = await mountDialog({ onCancel })
+  await waitFor(
+    () => harness.selectProps !== undefined,
+    'WorktreeExitDialog did not render choices',
+  )
+
+  return mounted
+}
+
+function selectProps(): CapturedSelectProps {
+  if (!harness.selectProps) {
+    throw new Error('Select props were not captured')
+  }
+
+  return harness.selectProps
+}
+
+function dialogProps(): CapturedDialogProps {
+  if (!harness.dialogProps) {
+    throw new Error('Dialog props were not captured')
+  }
+
+  return harness.dialogProps
+}
+
+describe('WorktreeExitDialog', () => {
+  let chdirSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    harness.chdir.mockClear()
+    harness.cleanupWorktree.mockReset()
+    harness.cleanupWorktree.mockResolvedValue(undefined)
+    harness.clearPlansCache.mockClear()
+    harness.dialogProps = undefined
+    harness.execFileNoThrow.mockReset()
+    harness.keepWorktree.mockReset()
+    harness.keepWorktree.mockResolvedValue(undefined)
+    harness.killTmuxSession.mockReset()
+    harness.killTmuxSession.mockResolvedValue(true)
+    harness.logEvent.mockClear()
+    harness.logForDebugging.mockClear()
+    harness.saveWorktreeState.mockClear()
+    harness.selectProps = undefined
+    harness.session = null
+    harness.setCwd.mockClear()
+
+    chdirSpy = vi.spyOn(process, 'chdir').mockImplementation(directory => {
+      harness.chdir(directory)
+    })
+  })
+
+  afterEach(() => {
+    chdirSpy.mockRestore()
+  })
+
+  it('finishes with a system result when no worktree session is active', async () => {
+    const onDone = vi.fn()
+    harness.execFileNoThrow.mockResolvedValue({
+      code: 0,
+      stderr: '',
+      stdout: '',
+    })
+
+    await renderToString(<WorktreeExitDialog onDone={onDone} />, 100)
+
+    expect(onDone).toHaveBeenCalledWith('No active worktree session found', {
+      display: 'system',
+    })
+  })
+
+  it('auto-removes a clean worktree before finishing', async () => {
+    const cleanup = deferred()
+    harness.session = baseSession()
+    harness.cleanupWorktree.mockReturnValue(cleanup.promise)
+    mockGitState({ commitCount: 0, statusLines: [] })
+
+    const mounted = await mountDialog()
+
+    await waitFor(
+      () => mounted.output().includes('Removing worktree...'),
+      'clean worktree did not render removing state',
+    )
+
+    cleanup.resolve(undefined)
+    await waitFor(
+      () => mounted.onDone.mock.calls.length > 0,
+      'clean worktree did not finish',
+    )
+
+    expect(harness.cleanupWorktree).toHaveBeenCalledOnce()
+    expect(harness.chdir).toHaveBeenCalledWith('/workspace/main')
+    expect(harness.setCwd).toHaveBeenCalledWith('/workspace/main')
+    expect(harness.saveWorktreeState).toHaveBeenCalledWith(null)
+    expect(harness.clearPlansCache).toHaveBeenCalledOnce()
+    expect(mounted.onDone).toHaveBeenCalledWith('Worktree removed (no changes)')
+    expect(harness.selectProps).toBeUndefined()
+
+    await mounted.dispose()
+  })
+
+  it('reports a clean-worktree cleanup failure and exits anyway', async () => {
+    harness.session = baseSession()
+    harness.cleanupWorktree.mockRejectedValue(new Error('remove failed'))
+    mockGitState({ commitCount: 0, statusLines: [] })
+
+    const mounted = await mountDialog()
+
+    await waitFor(
+      () => mounted.onDone.mock.calls.length > 0,
+      'cleanup failure did not finish',
+    )
+
+    expect(harness.logForDebugging).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to clean up worktree: Error: remove failed'),
+      { level: 'error' },
+    )
+    expect(mounted.onDone).toHaveBeenCalledWith(
+      'Worktree cleanup failed, exiting anyway',
+    )
+
+    await mounted.dispose()
+  })
+
+  it.each([
+    {
+      commitCount: 0,
+      expectedSubtitle:
+        'You have 1 uncommitted file. These will be lost if you remove the worktree.',
+      statusLines: [' M runtime/src/tui/index.ts'],
+    },
+    {
+      commitCount: 2,
+      expectedSubtitle:
+        'You have 2 commits on agenc/worktree-test. The branch will be deleted if you remove the worktree.',
+      statusLines: [],
+    },
+    {
+      commitCount: 1,
+      expectedSubtitle:
+        'You have 2 uncommitted files and 1 commit on agenc/worktree-test. All will be lost if you remove.',
+      statusLines: [
+        ' M runtime/src/tui/index.ts',
+        '?? runtime/tests/tui/new.test.ts',
+      ],
+    },
+  ])(
+    'renders the prompt subtitle for $expectedSubtitle',
+    async ({ commitCount, expectedSubtitle, statusLines }) => {
+      const mounted = await mountAskingDialog({ commitCount, statusLines })
+
+      expect(dialogProps().title).toBe('Exiting worktree session')
+      expect(dialogProps().subtitle).toBe(expectedSubtitle)
+      expect(selectProps().defaultFocusValue).toBe('keep')
+      expect(selectProps().options).toEqual([
+        {
+          description: 'Stays at /workspace/.agenc/worktrees/worktree-test',
+          label: 'Keep worktree',
+          value: 'keep',
+        },
+        {
+          description:
+            commitCount > 0 || statusLines.length > 0
+              ? 'All changes and commits will be lost.'
+              : 'Clean up the worktree directory.',
+          label: 'Remove worktree',
+          value: 'remove',
+        },
+      ])
+
+      await mounted.dispose()
+    },
+  )
+
+  it('renders tmux-specific choices with keep-and-reattach focused', async () => {
+    harness.session = baseSession({ tmuxSessionName: 'agenc-worktree-tmux' })
+    mockGitState({ commitCount: 1, statusLines: [' M package.json'] })
+
+    const mounted = await mountDialog()
+    await waitFor(
+      () => harness.selectProps !== undefined,
+      'tmux choices did not render',
+    )
+
+    expect(selectProps().defaultFocusValue).toBe('keep-with-tmux')
+    expect(selectProps().options).toEqual([
+      {
+        description:
+          'Stays at /workspace/.agenc/worktrees/worktree-test. Reattach with: tmux attach -t agenc-worktree-tmux',
+        label: 'Keep worktree and tmux session',
+        value: 'keep-with-tmux',
+      },
+      {
+        description:
+          'Keeps worktree at /workspace/.agenc/worktrees/worktree-test, terminates tmux session.',
+        label: 'Keep worktree, kill tmux session',
+        value: 'keep-kill-tmux',
+      },
+      {
+        description: 'All changes and commits will be lost.',
+        label: 'Remove worktree and tmux session',
+        value: 'remove-with-tmux',
+      },
+    ])
+
+    await mounted.dispose()
+  })
+
+  it('uses the explicit cancel callback when one is provided', async () => {
+    const onCancel = vi.fn()
+    const mounted = await mountAskingDialog({
+      commitCount: 0,
+      onCancel,
+      statusLines: [' M runtime/src/tui/index.ts'],
+    })
+
+    dialogProps().onCancel()
+
+    expect(onCancel).toHaveBeenCalledOnce()
+    expect(harness.keepWorktree).not.toHaveBeenCalled()
+
+    await mounted.dispose()
+  })
+
+  it('keeps the worktree when cancel is pressed without a cancel callback', async () => {
+    const mounted = await mountAskingDialog({
+      commitCount: 1,
+      statusLines: [],
+    })
+
+    dialogProps().onCancel()
+    await waitFor(
+      () => mounted.onDone.mock.calls.length > 0,
+      'fallback keep did not finish',
+    )
+
+    expect(harness.keepWorktree).toHaveBeenCalledOnce()
+    expect(mounted.onDone).toHaveBeenCalledWith(
+      'Worktree kept. Your work is saved at /workspace/.agenc/worktrees/worktree-test on branch agenc/worktree-test',
+    )
+
+    await mounted.dispose()
+  })
+
+  it('keeps a tmux-backed worktree and preserves the reattach instruction', async () => {
+    const keep = deferred()
+    harness.session = baseSession({ tmuxSessionName: 'agenc-worktree-tmux' })
+    harness.keepWorktree.mockReturnValue(keep.promise)
+    mockGitState({ commitCount: 3, statusLines: [' M README.md'] })
+
+    const mounted = await mountDialog()
+    await waitFor(
+      () => harness.selectProps !== undefined,
+      'keep choices did not render',
+    )
+
+    const change = selectProps().onChange?.('keep-with-tmux')
+    await waitFor(
+      () => mounted.output().includes('Keeping worktree...'),
+      'keep action did not render keeping state',
+    )
+
+    keep.resolve(undefined)
+    await change
+    await waitFor(
+      () => mounted.onDone.mock.calls.length > 0,
+      'keep action did not finish',
+    )
+
+    expect(harness.logEvent).toHaveBeenCalledWith('agenc_worktree_kept', {
+      changed_files: 1,
+      commits: 3,
+    })
+    expect(harness.killTmuxSession).not.toHaveBeenCalled()
+    expect(harness.keepWorktree).toHaveBeenCalledOnce()
+    expect(harness.chdir).toHaveBeenCalledWith('/workspace/main')
+    expect(harness.setCwd).toHaveBeenCalledWith('/workspace/main')
+    expect(harness.saveWorktreeState).toHaveBeenCalledWith(null)
+    expect(harness.clearPlansCache).toHaveBeenCalledOnce()
+    expect(mounted.onDone).toHaveBeenCalledWith(
+      'Worktree kept. Your work is saved at /workspace/.agenc/worktrees/worktree-test on branch agenc/worktree-test. Reattach to tmux session with: tmux attach -t agenc-worktree-tmux',
+    )
+
+    await mounted.dispose()
+  })
+
+  it('kills tmux before keeping when requested', async () => {
+    harness.session = baseSession({ tmuxSessionName: 'agenc-worktree-tmux' })
+    mockGitState({ commitCount: 0, statusLines: [' M README.md'] })
+
+    const mounted = await mountDialog()
+    await waitFor(
+      () => harness.selectProps !== undefined,
+      'keep-kill choices did not render',
+    )
+
+    await selectProps().onChange?.('keep-kill-tmux')
+    await waitFor(
+      () => mounted.onDone.mock.calls.length > 0,
+      'keep-kill action did not finish',
+    )
+
+    expect(harness.killTmuxSession).toHaveBeenCalledWith('agenc-worktree-tmux')
+    expect(harness.keepWorktree).toHaveBeenCalledOnce()
+    expect(mounted.onDone).toHaveBeenCalledWith(
+      'Worktree kept at /workspace/.agenc/worktrees/worktree-test on branch agenc/worktree-test. Tmux session terminated.',
+    )
+
+    await mounted.dispose()
+  })
+
+  it('removes a tmux-backed worktree and reports discarded commits plus changes', async () => {
+    const cleanup = deferred()
+    harness.session = baseSession({ tmuxSessionName: 'agenc-worktree-tmux' })
+    harness.cleanupWorktree.mockReturnValue(cleanup.promise)
+    mockGitState({ commitCount: 2, statusLines: [' M package.json'] })
+
+    const mounted = await mountDialog()
+    await waitFor(
+      () => harness.selectProps !== undefined,
+      'remove choices did not render',
+    )
+
+    const change = selectProps().onChange?.('remove-with-tmux')
+    await waitFor(
+      () => mounted.output().includes('Removing worktree...'),
+      'remove action did not render removing state',
+    )
+
+    cleanup.resolve(undefined)
+    await change
+    await waitFor(
+      () => mounted.onDone.mock.calls.length > 0,
+      'remove action did not finish',
+    )
+
+    expect(harness.logEvent).toHaveBeenCalledWith('agenc_worktree_removed', {
+      changed_files: 1,
+      commits: 2,
+    })
+    expect(harness.killTmuxSession).toHaveBeenCalledWith('agenc-worktree-tmux')
+    expect(harness.cleanupWorktree).toHaveBeenCalledOnce()
+    expect(harness.chdir).toHaveBeenCalledWith('/workspace/main')
+    expect(harness.setCwd).toHaveBeenCalledWith('/workspace/main')
+    expect(harness.saveWorktreeState).toHaveBeenCalledWith(null)
+    expect(harness.clearPlansCache).toHaveBeenCalledOnce()
+    expect(mounted.onDone).toHaveBeenCalledWith(
+      'Worktree removed. 2 commits and uncommitted changes were discarded. Tmux session terminated.',
+    )
+
+    await mounted.dispose()
+  })
+
+  it.each([
+    {
+      commitCount: 1,
+      expected:
+        'Worktree removed. 1 commit on agenc/worktree-test was discarded.',
+      statusLines: [],
+    },
+    {
+      commitCount: 0,
+      expected: 'Worktree removed. Uncommitted changes were discarded.',
+      statusLines: [' M README.md'],
+    },
+  ])(
+    'reports the remove result for $expected',
+    async ({ commitCount, expected, statusLines }) => {
+      const mounted = await mountAskingDialog({ commitCount, statusLines })
+
+      await selectProps().onChange?.('remove')
+      await waitFor(
+        () => mounted.onDone.mock.calls.length > 0,
+        'remove action did not finish',
+      )
+
+      expect(mounted.onDone).toHaveBeenCalledWith(expected)
+
+      await mounted.dispose()
+    },
+  )
+
+  it('reports remove cleanup failures without clearing the session locally', async () => {
+    harness.session = baseSession()
+    harness.cleanupWorktree.mockRejectedValue(new Error('cleanup exploded'))
+    mockGitState({ commitCount: 0, statusLines: [' M README.md'] })
+
+    const mounted = await mountDialog()
+    await waitFor(
+      () => harness.selectProps !== undefined,
+      'remove failure choices did not render',
+    )
+
+    await selectProps().onChange?.('remove')
+    await waitFor(
+      () => mounted.onDone.mock.calls.length > 0,
+      'remove failure did not finish',
+    )
+
+    expect(harness.logForDebugging).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Failed to clean up worktree: Error: cleanup exploded',
+      ),
+      { level: 'error' },
+    )
+    expect(harness.chdir).not.toHaveBeenCalled()
+    expect(harness.setCwd).not.toHaveBeenCalled()
+    expect(harness.saveWorktreeState).not.toHaveBeenCalled()
+    expect(mounted.onDone).toHaveBeenCalledWith(
+      'Worktree cleanup failed, exiting anyway',
+    )
+
+    await mounted.dispose()
+  })
+})

--- a/runtime/tests/tui/components/agents/agentFileUtils.wave200-043.coverage.test.ts
+++ b/runtime/tests/tui/components/agents/agentFileUtils.wave200-043.coverage.test.ts
@@ -1,0 +1,171 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+import type { AgentDefinition } from 'src/tools/AgentTool/loadAgentsDir.js'
+import { runWithCwdOverride } from '../../../utils/cwd.js'
+import {
+  deleteAgentFromFile,
+  formatAgentAsMarkdown,
+  getActualAgentFilePath,
+  getActualRelativeAgentFilePath,
+  getNewAgentFilePath,
+  getNewRelativeAgentFilePath,
+  saveAgentToFile,
+  updateAgentFile,
+} from './agentFileUtils.js'
+
+describe('agent file utilities wave 200 coverage', () => {
+  test('formats options and handles custom agent file lifecycle paths', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'agenc-agent-file-utils-'))
+
+    try {
+      await runWithCwdOverride(cwd, async () => {
+        const formatted = formatAgentAsMarkdown(
+          'triage-helper',
+          'Use "quotes"\nwith a backslash \\ marker',
+          ['Read', 'Edit'],
+          'Prefer concise findings.',
+          'green',
+          'agenc-balanced',
+          'project',
+          'high',
+        )
+
+        const descriptionLine = formatted
+          .split('\n')
+          .find((line) => line.startsWith('description: '))
+        expect(descriptionLine).toBe(
+          'description: "Use \\"quotes\\"\\\\nwith a backslash \\\\ marker"',
+        )
+        expect(formatted).toContain('\ntools: Read, Edit')
+        expect(formatted).toContain('\nmodel: agenc-balanced')
+        expect(formatted).toContain('\neffort: high')
+        expect(formatted).toContain('\ncolor: green')
+        expect(formatted).toContain('\nmemory: project')
+
+        const newAgentPath = join(
+          cwd,
+          '.agenc',
+          'agents',
+          'triage-helper.md',
+        )
+        expect(
+          getNewAgentFilePath({
+            source: 'projectSettings',
+            agentType: 'triage-helper',
+          }),
+        ).toBe(newAgentPath)
+        expect(
+          getNewRelativeAgentFilePath({
+            source: 'projectSettings',
+            agentType: 'triage-helper',
+          }),
+        ).toBe(join('.agenc', 'agents', 'triage-helper.md'))
+        expect(
+          getNewRelativeAgentFilePath({
+            source: 'built-in',
+            agentType: 'built-in-helper',
+          }),
+        ).toBe('Built-in')
+        expect(() =>
+          getNewAgentFilePath({
+            source: 'flagSettings',
+            agentType: 'cli-helper',
+          }),
+        ).toThrow('Cannot get directory path for flagSettings agents')
+
+        const agentDir = join(cwd, '.agenc', 'agents')
+        mkdirSync(agentDir, { recursive: true })
+        const storedAgentPath = join(agentDir, 'stored-helper.md')
+        writeFileSync(storedAgentPath, 'old content', 'utf8')
+
+        const customAgent: AgentDefinition = {
+          agentType: 'triage-helper',
+          whenToUse: 'Use for triage.',
+          source: 'projectSettings',
+          filename: 'stored-helper',
+          getSystemPrompt: () => 'old content',
+        }
+        expect(getActualAgentFilePath(customAgent)).toBe(storedAgentPath)
+        expect(getActualRelativeAgentFilePath(customAgent)).toBe(
+          join('.agenc', 'agents', 'stored-helper.md'),
+        )
+
+        const builtInAgent: AgentDefinition = {
+          agentType: 'built-in-helper',
+          whenToUse: 'Use built-in behavior.',
+          source: 'built-in',
+          baseDir: 'built-in',
+          getSystemPrompt: () => 'built-in prompt',
+        }
+        expect(getActualAgentFilePath(builtInAgent)).toBe('Built-in')
+        expect(getActualRelativeAgentFilePath(builtInAgent)).toBe('Built-in')
+
+        const pluginAgent: AgentDefinition = {
+          agentType: 'plugin-helper',
+          whenToUse: 'Use plugin behavior.',
+          source: 'plugin',
+          plugin: '',
+          getSystemPrompt: () => 'plugin prompt',
+        }
+        expect(() => getActualAgentFilePath(pluginAgent)).toThrow(
+          'Cannot get file path for plugin agents',
+        )
+        expect(getActualRelativeAgentFilePath(pluginAgent)).toBe(
+          'Plugin: Unknown',
+        )
+
+        await updateAgentFile(
+          customAgent,
+          'Use after update.',
+          ['Search'],
+          'Updated system prompt.',
+          'blue',
+          'agenc-deep',
+          'local',
+          3,
+        )
+        const updated = readFileSync(storedAgentPath, 'utf8')
+        expect(updated).toContain('name: triage-helper')
+        expect(updated).toContain('tools: Search')
+        expect(updated).toContain('model: agenc-deep')
+        expect(updated).toContain('effort: 3')
+        expect(updated).toContain('memory: local')
+
+        await saveAgentToFile(
+          'projectSettings',
+          'triage-helper',
+          'Use for duplicate checks.',
+          ['*'],
+          'Initial system prompt.',
+          false,
+        )
+        expect(readFileSync(newAgentPath, 'utf8')).not.toContain('\ntools:')
+        await expect(
+          saveAgentToFile(
+            'projectSettings',
+            'triage-helper',
+            'Use for duplicate checks.',
+            ['*'],
+            'Initial system prompt.',
+          ),
+        ).rejects.toThrow(`Agent file already exists: ${newAgentPath}`)
+
+        await deleteAgentFromFile(customAgent)
+        expect(existsSync(storedAgentPath)).toBe(false)
+        await expect(deleteAgentFromFile(customAgent)).resolves.toBeUndefined()
+      })
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+})

--- a/runtime/tests/tui/components/design-system/Divider.wave200-099.coverage.test.tsx
+++ b/runtime/tests/tui/components/design-system/Divider.wave200-099.coverage.test.tsx
@@ -1,0 +1,133 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { describe, expect, test } from "vitest";
+
+import type { DOMElement, DOMNode } from "../../ink/dom.js";
+import instances from "../../ink/instances.js";
+import { createRoot } from "../../ink/root.js";
+import type { TextStyles } from "../../ink/styles.js";
+import { Box } from "../../ink.js";
+import { getTheme } from "../../../utils/theme.js";
+import { Divider } from "./Divider.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+type StyledSegment = {
+  text: string;
+  styles: TextStyles;
+};
+
+function createStreams(columns = 16): {
+  stdin: TestStdin;
+  stdout: PassThrough;
+} {
+  const stdin = new PassThrough() as TestStdin;
+  const stdout = new PassThrough();
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+
+  stdout.resume();
+  (stdout as unknown as { columns: number }).columns = columns;
+  (stdout as unknown as { rows: number }).rows = 24;
+  (stdout as unknown as { isTTY: boolean }).isTTY = true;
+
+  return { stdin, stdout };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream);
+
+  if (!instance?.rootNode) {
+    throw new Error("Ink root node not found");
+  }
+
+  return instance.rootNode;
+}
+
+function collectSegments(
+  node: DOMNode,
+  inheritedStyles: TextStyles = {},
+  segments: StyledSegment[] = [],
+): StyledSegment[] {
+  if (node.nodeName === "#text") {
+    if (node.nodeValue !== "") {
+      segments.push({ text: node.nodeValue, styles: inheritedStyles });
+    }
+    return segments;
+  }
+
+  const nextStyles = node.textStyles
+    ? { ...inheritedStyles, ...node.textStyles }
+    : inheritedStyles;
+
+  for (const child of node.childNodes) {
+    collectSegments(child, nextStyles, segments);
+  }
+
+  return segments;
+}
+
+describe("Divider coverage", () => {
+  test("renders terminal-width, colored, titled, and too-narrow divider variants", async () => {
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <Box flexDirection="column">
+          <Divider padding={14} />
+          <Divider color="permission" char="=" width={5} />
+          <Divider char="." title="Hi" width={10} />
+          <Divider
+            char="-"
+            color="suggestion"
+            title={"\u001b[1mWide\u001b[22m"}
+            width={3}
+          />
+          <Divider char="+" padding={20} />
+        </Box>,
+      );
+      await sleep(30);
+
+      const theme = getTheme("dark");
+      const segments = collectSegments(getRootNode(stdout));
+
+      expect(segments.map(segment => segment.text).join("")).toBe(
+        "──=====... Hi ... Wide ",
+      );
+      expect(segments).toEqual([
+        { text: "──", styles: { color: theme.inactive } },
+        { text: "=====", styles: { color: theme.permission } },
+        { text: "...", styles: { color: theme.inactive } },
+        { text: " ", styles: { color: theme.inactive } },
+        { text: "Hi", styles: { color: theme.inactive } },
+        { text: " ", styles: { color: theme.inactive } },
+        { text: "...", styles: { color: theme.inactive } },
+        { text: " ", styles: { color: theme.suggestion } },
+        { text: "Wide", styles: { color: theme.inactive, bold: true } },
+        { text: " ", styles: { color: theme.suggestion } },
+      ]);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+});

--- a/runtime/tests/tui/components/design-system/FuzzyPicker.test.tsx
+++ b/runtime/tests/tui/components/design-system/FuzzyPicker.test.tsx
@@ -1,0 +1,506 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import instances from "../../ink/instances.js";
+import type { DOMElement, DOMNode } from "../../ink/dom.js";
+import { createRoot } from "../../ink/root.js";
+import { Box, Text } from "../../ink.js";
+import { FuzzyPicker } from "./FuzzyPicker.js";
+
+type PickerItem = {
+  readonly id: string;
+  readonly label: string;
+  readonly preview: string;
+};
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  setRawMode: (mode: boolean) => void;
+  ref: () => void;
+  unref: () => void;
+};
+
+type PickerAction = {
+  action: string;
+  handler: (item: PickerItem) => void;
+};
+
+type PickerProps = {
+  title: string;
+  placeholder?: string;
+  initialQuery?: string;
+  items: readonly PickerItem[];
+  renderItem: (item: PickerItem, isFocused: boolean) => React.ReactNode;
+  renderPreview?: (item: PickerItem) => React.ReactNode;
+  previewPosition?: "bottom" | "right";
+  visibleCount?: number;
+  direction?: "down" | "up";
+  onQueryChange: (query: string) => void;
+  onSelect: (item: PickerItem) => void;
+  onTab?: PickerAction;
+  onShiftTab?: PickerAction;
+  onFocus?: (item: PickerItem | undefined) => void;
+  onCancel: () => void;
+  emptyMessage?: string | ((query: string) => string);
+  matchLabel?: string;
+  selectAction?: string;
+  extraHints?: React.ReactNode;
+};
+
+type PickerRoot = Awaited<ReturnType<typeof createRoot>>;
+
+type PickerHarness = {
+  stdout: PassThrough;
+  stdin: TestStdin;
+  root: PickerRoot;
+  render: (next?: Partial<PickerProps>) => void;
+  text: () => string;
+  segments: () => string[];
+  boxes: (predicate: (node: DOMElement) => boolean) => DOMElement[];
+  send: (sequence: string) => Promise<void>;
+  dispose: () => Promise<void>;
+};
+
+const ITEMS: readonly PickerItem[] = [
+  { id: "alpha", label: "Alpha result", preview: "Alpha preview" },
+  { id: "bravo", label: "Bravo result", preview: "Bravo preview" },
+  { id: "charlie", label: "Charlie result", preview: "Charlie preview" },
+  { id: "delta", label: "Delta result", preview: "Delta preview" },
+  { id: "echo", label: "Echo result", preview: "Echo preview" },
+];
+
+const mountedHarnesses: PickerHarness[] = [];
+
+afterEach(async () => {
+  while (mountedHarnesses.length > 0) {
+    await mountedHarnesses.pop()?.dispose();
+  }
+});
+
+function createTestStreams(columns = 120, rows = 30): {
+  stdout: PassThrough;
+  stderr: PassThrough;
+  stdin: TestStdin;
+} {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+
+  stdout.on("data", () => {});
+  stderr.on("data", () => {});
+
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.ref = () => {};
+  stdin.unref = () => {};
+
+  (stdout as unknown as { columns: number }).columns = columns;
+  (stdout as unknown as { rows: number }).rows = rows;
+  (stdout as unknown as { isTTY: boolean }).isTTY = true;
+
+  return { stdout, stderr, stdin };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await sleep(10);
+  }
+
+  throw new Error(message);
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(
+    stdout as unknown as NodeJS.WriteStream,
+  ) as { rootNode?: DOMElement } | undefined;
+
+  if (!instance?.rootNode) {
+    throw new Error("Ink root node not found");
+  }
+
+  return instance.rootNode;
+}
+
+function collectText(node: DOMNode): string {
+  if (node.nodeName === "#text") return node.nodeValue;
+  return node.childNodes.map(collectText).join("");
+}
+
+function collectTextSegments(node: DOMNode, segments: string[] = []): string[] {
+  if (node.nodeName === "#text") {
+    if (node.nodeValue !== "") segments.push(node.nodeValue);
+    return segments;
+  }
+
+  for (const child of node.childNodes) {
+    collectTextSegments(child, segments);
+  }
+
+  return segments;
+}
+
+function findBoxes(
+  node: DOMNode,
+  predicate: (node: DOMElement) => boolean,
+  results: DOMElement[] = [],
+): DOMElement[] {
+  if (node.nodeName !== "#text") {
+    if (node.nodeName === "ink-box" && predicate(node)) {
+      results.push(node);
+    }
+
+    for (const child of node.childNodes) {
+      findBoxes(child, predicate, results);
+    }
+  }
+
+  return results;
+}
+
+function itemText(item: PickerItem, isFocused: boolean): React.ReactNode {
+  return (
+    <Text>
+      {isFocused ? "focused" : "plain"}:{item.label}
+    </Text>
+  );
+}
+
+async function createPickerHarness(
+  overrides: Partial<PickerProps> = {},
+  viewport: { readonly columns?: number; readonly rows?: number } = {},
+): Promise<PickerHarness> {
+  const { stdout, stderr, stdin } = createTestStreams(
+    viewport.columns ?? 120,
+    viewport.rows ?? 30,
+  );
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  });
+
+  const props: PickerProps = {
+    title: "Pick result",
+    items: ITEMS,
+    renderItem: itemText,
+    onQueryChange: vi.fn(),
+    onSelect: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  } as PickerProps;
+
+  const render = (next: Partial<PickerProps> = {}) => {
+    Object.assign(props, next);
+    root.render(
+      <FuzzyPicker<PickerItem>
+        title={props.title}
+        placeholder={props.placeholder}
+        initialQuery={props.initialQuery}
+        items={props.items}
+        getKey={item => item.id}
+        renderItem={props.renderItem}
+        renderPreview={props.renderPreview}
+        previewPosition={props.previewPosition}
+        visibleCount={props.visibleCount}
+        direction={props.direction}
+        onQueryChange={props.onQueryChange}
+        onSelect={props.onSelect}
+        onTab={props.onTab}
+        onShiftTab={props.onShiftTab}
+        onFocus={props.onFocus}
+        onCancel={props.onCancel}
+        emptyMessage={props.emptyMessage}
+        matchLabel={props.matchLabel}
+        selectAction={props.selectAction}
+        extraHints={props.extraHints}
+      />,
+    );
+  };
+
+  render();
+
+  const harness = {
+    stdout,
+    stdin,
+    root,
+    render,
+    text: () => collectText(getRootNode(stdout)),
+    segments: () => collectTextSegments(getRootNode(stdout)),
+    boxes: (predicate: (node: DOMElement) => boolean) =>
+      findBoxes(getRootNode(stdout), predicate),
+    send: async (sequence: string) => {
+      stdin.write(sequence);
+      await sleep(sequence === "\x1b" ? 90 : 30);
+    },
+    dispose: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      stderr.end();
+      instances.delete(stdout as unknown as NodeJS.WriteStream);
+      await sleep(20);
+    },
+  };
+
+  mountedHarnesses.push(harness);
+
+  await waitForCondition(
+    () => harness.text().includes(props.title),
+    "FuzzyPicker did not mount",
+  );
+
+  return harness;
+}
+
+async function waitForLatestFocus(
+  focusCalls: PickerItem[],
+  id: string,
+): Promise<void> {
+  await waitForCondition(
+    () => focusCalls.at(-1)?.id === id,
+    `Expected focus to move to ${id}`,
+  );
+}
+
+describe("FuzzyPicker", () => {
+  test("updates the query, renders the query-aware empty message, and cancels", async () => {
+    const onQueryChange = vi.fn();
+    const onSelect = vi.fn();
+    const onCancel = vi.fn();
+    const harness = await createPickerHarness({
+      items: [],
+      onQueryChange,
+      onSelect,
+      onCancel,
+      emptyMessage: query => `No picks for ${query || "empty query"}`,
+    });
+
+    await waitForCondition(
+      () => onQueryChange.mock.calls.some(([query]) => query === ""),
+      "Initial query was not reported",
+    );
+    expect(harness.text()).toContain("No picks for empty query");
+
+    await harness.send("ab");
+    await waitForCondition(
+      () => onQueryChange.mock.calls.some(([query]) => query === "ab"),
+      "Typed query was not reported",
+    );
+    expect(harness.text()).toContain("No picks for ab");
+
+    await harness.send("\r");
+    await harness.send("\t");
+    expect(onSelect).not.toHaveBeenCalled();
+
+    await harness.send("\x1b");
+    await waitForCondition(
+      () => onCancel.mock.calls.length === 1,
+      "Escape did not cancel the picker",
+    );
+  });
+
+  test("moves focus through the visible window and clamps at list bounds", async () => {
+    const focusCalls: PickerItem[] = [];
+    const renderItem = vi.fn(itemText);
+    const onSelect = vi.fn();
+    const harness = await createPickerHarness({
+      visibleCount: 3,
+      matchLabel: "5 matches",
+      renderItem,
+      onSelect,
+      onFocus: item => {
+        if (item) focusCalls.push(item);
+      },
+    });
+
+    await waitForLatestFocus(focusCalls, "alpha");
+    expect(harness.text()).toContain("Alpha result");
+    expect(harness.text()).toContain("Bravo result");
+    expect(harness.text()).toContain("Charlie result");
+    expect(harness.text()).not.toContain("Delta result");
+
+    await harness.send("\x1b[B");
+    await waitForLatestFocus(focusCalls, "bravo");
+    await harness.send("\x0e");
+    await waitForLatestFocus(focusCalls, "charlie");
+    await harness.send("\x1b[B");
+    await waitForLatestFocus(focusCalls, "delta");
+    expect(harness.text()).not.toContain("Alpha result");
+    expect(harness.text()).toContain("Bravo result");
+    expect(harness.text()).toContain("Charlie result");
+    expect(harness.text()).toContain("Delta result");
+
+    await harness.send("\x1b[B");
+    await waitForLatestFocus(focusCalls, "echo");
+    await harness.send("\x1b[B");
+    await sleep(30);
+    expect(focusCalls.at(-1)?.id).toBe("echo");
+    expect(harness.text()).not.toContain("Alpha result");
+    expect(harness.text()).not.toContain("Bravo result");
+    expect(harness.text()).toContain("Charlie result");
+    expect(harness.text()).toContain("Delta result");
+    expect(harness.text()).toContain("Echo result");
+
+    await harness.send("\x1b[A");
+    await waitForLatestFocus(focusCalls, "delta");
+    await harness.send("\x10");
+    await waitForLatestFocus(focusCalls, "charlie");
+
+    await harness.send("\r");
+    expect(onSelect).toHaveBeenLastCalledWith(ITEMS[2]);
+    expect(renderItem).toHaveBeenCalledWith(ITEMS[2], true);
+    expect(renderItem).toHaveBeenCalledWith(ITEMS[1], false);
+  });
+
+  test("routes select, tab, shift-tab, and tab fallback actions", async () => {
+    const onSelect = vi.fn();
+    const onTab = { action: "insert", handler: vi.fn() };
+    const onShiftTab = { action: "open", handler: vi.fn() };
+    const harness = await createPickerHarness({
+      onSelect,
+      onTab,
+      onShiftTab,
+      selectAction: "select result",
+    });
+
+    await harness.send("\x1b[B");
+    await harness.send("\r");
+    expect(onSelect).toHaveBeenLastCalledWith(ITEMS[1]);
+
+    await harness.send("\t");
+    expect(onTab.handler).toHaveBeenLastCalledWith(ITEMS[1]);
+
+    await harness.send("\x1b[Z");
+    expect(onShiftTab.handler).toHaveBeenLastCalledWith(ITEMS[1]);
+
+    const fallbackSelect = vi.fn();
+    const fallbackHarness = await createPickerHarness({
+      onSelect: fallbackSelect,
+      onTab: undefined,
+      onShiftTab: undefined,
+    });
+
+    await fallbackHarness.send("\t");
+    expect(fallbackSelect).toHaveBeenLastCalledWith(ITEMS[0]);
+  });
+
+  test("renders bottom and right preview paths and preserves the right preview slot when empty", async () => {
+    const renderPreview = vi.fn((item: PickerItem) => (
+      <Box flexDirection="column">
+        <Text>Preview panel:{item.preview}</Text>
+      </Box>
+    ));
+    const harness = await createPickerHarness({
+      visibleCount: 2,
+      matchLabel: "2 matches",
+      items: ITEMS.slice(0, 2),
+      renderPreview,
+      previewPosition: "bottom",
+    });
+
+    await waitForCondition(
+      () => harness.text().includes("Preview panel:Alpha preview"),
+      "Bottom preview did not render",
+    );
+    const bottomSegments = harness.segments();
+    expect(bottomSegments.indexOf("2 matches")).toBeLessThan(
+      bottomSegments.indexOf("Preview panel:"),
+    );
+    expect(
+      harness.boxes(
+        box =>
+          box.style.flexDirection === "row" &&
+          box.style.gap === 2 &&
+          collectText(box).includes("Preview panel:Alpha preview"),
+      ),
+    ).toHaveLength(0);
+
+    harness.render({ previewPosition: "right" });
+    await waitForCondition(
+      () =>
+        harness.boxes(
+          box =>
+            box.style.flexDirection === "row" &&
+            box.style.gap === 2 &&
+            box.style.height === 3 &&
+            collectText(box).includes("Preview panel:Alpha preview"),
+        ).length === 1,
+      "Right preview row did not render",
+    );
+
+    await harness.send("\x1b[B");
+    await waitForCondition(
+      () => harness.text().includes("Preview panel:Bravo preview"),
+      "Focused preview did not update",
+    );
+    expect(renderPreview).toHaveBeenCalledWith(ITEMS[1]);
+
+    const previewCallsBeforeEmpty = renderPreview.mock.calls.length;
+    harness.render({
+      items: [],
+      emptyMessage: "No previewable items",
+      matchLabel: "0 matches",
+    });
+    await waitForCondition(
+      () => harness.text().includes("No previewable items"),
+      "Empty right-preview state did not render",
+    );
+    expect(renderPreview).toHaveBeenCalledTimes(previewCallsBeforeEmpty);
+    expect(harness.text()).not.toContain("Preview panel:");
+    expect(
+      harness.boxes(
+        box =>
+          box.style.flexDirection === "row" &&
+          box.style.gap === 2 &&
+          box.style.height === 3,
+      ),
+    ).toHaveLength(1);
+  });
+
+  test("renders upward lists with the input below and reversed screen-direction movement", async () => {
+    const focusCalls: PickerItem[] = [];
+    const harness = await createPickerHarness({
+      direction: "up",
+      visibleCount: 2,
+      onFocus: item => {
+        if (item) focusCalls.push(item);
+      },
+    });
+
+    await waitForLatestFocus(focusCalls, "alpha");
+    expect(
+      harness.boxes(
+        box =>
+          box.style.flexDirection === "column-reverse" &&
+          box.style.height === 2 &&
+          collectText(box).includes("Alpha result"),
+      ),
+    ).toHaveLength(1);
+
+    const text = harness.text();
+    expect(text.indexOf("Alpha result")).toBeLessThan(
+      text.indexOf("Type to search"),
+    );
+
+    await harness.send("\x1b[B");
+    await sleep(30);
+    expect(focusCalls.at(-1)?.id).toBe("alpha");
+
+    await harness.send("\x1b[A");
+    await waitForLatestFocus(focusCalls, "bravo");
+  });
+});

--- a/runtime/tests/tui/components/design-system/ProgressBar.wave200-079.coverage.test.tsx
+++ b/runtime/tests/tui/components/design-system/ProgressBar.wave200-079.coverage.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { renderToString } from '../../../utils/staticRender.js'
+import { Box, Text } from '../../ink.js'
+import { ProgressBar } from './ProgressBar.js'
+
+function renderDelimitedBar(node: React.ReactNode): Promise<string> {
+  return renderToString(
+    <Box flexDirection="row">
+      <Text>|</Text>
+      {node}
+      <Text>|</Text>
+    </Box>,
+    20,
+  )
+}
+
+describe('ProgressBar wave200-079 coverage', () => {
+  test('renders clamped and fractional bar states at fixed width', async () => {
+    const empty = await renderDelimitedBar(<ProgressBar ratio={-0.5} width={4} />)
+    const partial = await renderDelimitedBar(
+      <ProgressBar
+        ratio={0.33}
+        width={10}
+        fillColor="success"
+        emptyColor="rate_limit_empty"
+      />,
+    )
+    const nearlyFull = await renderDelimitedBar(
+      <ProgressBar ratio={0.95} width={4} />,
+    )
+    const overFull = await renderDelimitedBar(
+      <ProgressBar ratio={1.5} width={4} />,
+    )
+
+    expect(empty).toBe('|    |')
+    expect(partial).toBe('|███▎      |')
+    expect(nearlyFull).toBe('|███▉|')
+    expect(overFull).toBe('|████|')
+  })
+})

--- a/runtime/tests/tui/components/design-system/Tabs.wave200-143.coverage.test.tsx
+++ b/runtime/tests/tui/components/design-system/Tabs.wave200-143.coverage.test.tsx
@@ -1,0 +1,204 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { describe, expect, test, vi } from "vitest";
+
+import type { DOMElement, DOMNode } from "../../ink/dom.js";
+import instances from "../../ink/instances.js";
+import { createRoot } from "../../ink/root.js";
+import { Text } from "../../ink.js";
+import { Tab, Tabs, useTabHeaderFocus } from "./Tabs.js";
+
+const keybindingMock = vi.hoisted(() => ({
+  registrations: [] as Array<{
+    handlers: Record<string, () => void>;
+    options: { context?: string; isActive?: boolean };
+  }>,
+}));
+
+vi.mock("../../keybindings/useKeybinding.js", () => ({
+  useKeybindings: (
+    handlers: Record<string, () => void>,
+    options: { context?: string; isActive?: boolean },
+  ) => {
+    keybindingMock.registrations.push({ handlers, options });
+  },
+}));
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+function createTestStreams(): {
+  stdin: TestStdin;
+  stdout: PassThrough;
+} {
+  const stdin = new PassThrough() as TestStdin;
+  const stdout = new PassThrough();
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.resume();
+  (stdout as unknown as { columns: number; isTTY: boolean; rows: number }).columns = 80;
+  (stdout as unknown as { columns: number; isTTY: boolean; rows: number }).rows = 24;
+  (stdout as unknown as { columns: number; isTTY: boolean; rows: number }).isTTY = true;
+
+  return { stdin, stdout };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < 2_000) {
+    if (predicate()) return;
+    await sleep(10);
+  }
+
+  throw new Error(message);
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream);
+
+  if (!instance?.rootNode) {
+    throw new Error("Ink root node not found");
+  }
+
+  return instance.rootNode;
+}
+
+function findKeyboardElement(node: DOMNode): DOMElement | undefined {
+  if (node.nodeName !== "#text" && node._eventHandlers?.onKeyDown) {
+    return node;
+  }
+
+  for (const child of node.childNodes) {
+    const found = findKeyboardElement(child);
+    if (found) return found;
+  }
+
+  return undefined;
+}
+
+function latestActiveTabsRegistration(): {
+  handlers: Record<string, () => void>;
+  options: { context?: string; isActive?: boolean };
+} {
+  const registration = keybindingMock.registrations
+    .toReversed()
+    .find(reg => reg.options.context === "Tabs" && reg.options.isActive);
+
+  if (!registration) {
+    throw new Error("Expected an active Tabs keybinding registration");
+  }
+
+  return registration;
+}
+
+function FocusedTab({
+  label,
+  snapshots,
+}: {
+  label: string;
+  snapshots: string[];
+}) {
+  const { headerFocused } = useTabHeaderFocus();
+
+  React.useEffect(() => {
+    snapshots.push(`${label}:${String(headerFocused)}`);
+  }, [headerFocused, label, snapshots]);
+
+  return (
+    <Text>
+      {label}:{String(headerFocused)}
+    </Text>
+  );
+}
+
+describe("Tabs wave200-143 coverage", () => {
+  test("hands focus to opted-in tab content and restores it after content navigation", async () => {
+    keybindingMock.registrations = [];
+    const snapshots: string[] = [];
+    const { stdin, stdout } = createTestStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <Tabs navFromContent>
+          <Tab id="first" title="First">
+            <FocusedTab label="first" snapshots={snapshots} />
+          </Tab>
+          <Tab id="second" title="Second">
+            <FocusedTab label="second" snapshots={snapshots} />
+          </Tab>
+        </Tabs>,
+      );
+
+      await waitFor(
+        () => snapshots.includes("first:true"),
+        "first tab did not render with header focus",
+      );
+      await waitFor(
+        () => keybindingMock.registrations.length >= 4,
+        "tab content did not opt into header-focus handoff",
+      );
+
+      const keyboardElement = findKeyboardElement(getRootNode(stdout));
+      expect(keyboardElement).toBeDefined();
+
+      const preventDefault = vi.fn();
+      keyboardElement?._eventHandlers?.onKeyDown?.({
+        key: "down",
+        preventDefault,
+      } as never);
+
+      await waitFor(
+        () => snapshots.includes("first:false"),
+        "down arrow did not hand focus to tab content",
+      );
+      expect(preventDefault).toHaveBeenCalledOnce();
+
+      latestActiveTabsRegistration().handlers["tabs:next"]();
+      await waitFor(
+        () => snapshots.includes("second:true"),
+        "content navigation did not select next tab and restore header focus",
+      );
+
+      keyboardElement?._eventHandlers?.onKeyDown?.({
+        key: "down",
+        preventDefault: vi.fn(),
+      } as never);
+      await waitFor(
+        () => snapshots.includes("second:false"),
+        "second tab did not hand focus back to content",
+      );
+
+      latestActiveTabsRegistration().handlers["tabs:previous"]();
+      await waitFor(
+        () => snapshots.filter(snapshot => snapshot === "first:true").length >= 2,
+        "content navigation did not select previous tab and restore header focus",
+      );
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep(25);
+    }
+  });
+});

--- a/runtime/tests/tui/components/design-system/ThemeProvider.wave200-068.coverage.test.tsx
+++ b/runtime/tests/tui/components/design-system/ThemeProvider.wave200-068.coverage.test.tsx
@@ -1,0 +1,190 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { describe, expect, test, vi } from "vitest";
+
+import { createRoot } from "../../ink/root.js";
+import { Text } from "../../ink.js";
+import {
+  ThemeProvider,
+  usePreviewTheme,
+  useTheme,
+  useThemeSetting,
+} from "./ThemeProvider.js";
+
+const mocks = vi.hoisted(() => {
+  const feature = vi.fn(() => false);
+  const getGlobalConfig = vi.fn(() => ({ theme: "auto" }));
+  const savedConfigs: unknown[] = [];
+  const saveGlobalConfig = vi.fn((update: (current: unknown) => unknown) => {
+    savedConfigs.push(update({ retained: true, theme: "dark" }));
+  });
+  const getSystemThemeName = vi.fn(() => "light");
+
+  return {
+    feature,
+    getGlobalConfig,
+    getSystemThemeName,
+    savedConfigs,
+    saveGlobalConfig,
+  };
+});
+
+vi.mock("bun:bundle", () => ({
+  feature: mocks.feature,
+}));
+
+vi.mock("../../../utils/config.js", () => ({
+  getGlobalConfig: mocks.getGlobalConfig,
+  saveGlobalConfig: mocks.saveGlobalConfig,
+}));
+
+vi.mock("../../../utils/systemTheme.js", () => ({
+  getSystemThemeName: mocks.getSystemThemeName,
+}));
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  setRawMode: (mode: boolean) => void;
+  ref: () => void;
+  unref: () => void;
+};
+
+type ThemeSnapshot = {
+  setting: "auto" | "dark" | "light";
+  theme: "dark" | "light";
+};
+
+type ProbeControls = {
+  readonly setTheme: (setting: "auto" | "dark" | "light") => void;
+  readonly preview: ReturnType<typeof usePreviewTheme>;
+};
+
+function createTestStreams(): {
+  readonly stderr: PassThrough;
+  readonly stdin: TestStdin;
+  readonly stdout: PassThrough;
+} {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+
+  stdout.on("data", () => {});
+  stderr.on("data", () => {});
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.ref = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number; isTTY: boolean; rows: number }).columns = 80;
+  (stdout as unknown as { columns: number; isTTY: boolean; rows: number }).rows = 24;
+  (stdout as unknown as { columns: number; isTTY: boolean; rows: number }).isTTY = true;
+
+  return { stderr, stdin, stdout };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < 2_000) {
+    if (predicate()) return;
+    await sleep(10);
+  }
+
+  throw new Error(message);
+}
+
+describe("ThemeProvider", () => {
+  test("resolves cached auto themes, previews changes, and persists default saves", async () => {
+    const snapshots: ThemeSnapshot[] = [];
+    let controls: ProbeControls | undefined;
+    const { stderr, stdin, stdout } = createTestStreams();
+    const root = await createRoot({
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      patchConsole: false,
+    });
+
+    function Probe() {
+      const [theme, setTheme] = useTheme();
+      const setting = useThemeSetting();
+      const preview = usePreviewTheme();
+
+      React.useEffect(() => {
+        snapshots.push({ setting, theme });
+        controls = { preview, setTheme };
+      }, [preview, setTheme, setting, theme]);
+
+      return <Text>{`${setting}:${theme}`}</Text>;
+    }
+
+    try {
+      root.render(
+        <ThemeProvider>
+          <Probe />
+        </ThemeProvider>,
+      );
+
+      await waitFor(
+        () => snapshots.some(snapshot => snapshot.setting === "auto" && snapshot.theme === "light"),
+        "auto theme did not resolve from the cached system theme",
+      );
+
+      expect(mocks.getGlobalConfig).toHaveBeenCalledTimes(1);
+      expect(mocks.getSystemThemeName).toHaveBeenCalled();
+      expect(mocks.feature).toHaveBeenCalledWith("AUTO_THEME");
+
+      controls?.preview.savePreview();
+      controls?.preview.cancelPreview();
+      expect(mocks.saveGlobalConfig).not.toHaveBeenCalled();
+
+      controls?.preview.setPreviewTheme("dark");
+      await waitFor(
+        () => snapshots.at(-1)?.setting === "auto" && snapshots.at(-1)?.theme === "dark",
+        "dark preview was not applied",
+      );
+
+      controls?.preview.savePreview();
+      await waitFor(
+        () => snapshots.at(-1)?.setting === "dark" && snapshots.at(-1)?.theme === "dark",
+        "preview was not saved as the persisted theme setting",
+      );
+
+      expect(mocks.saveGlobalConfig).toHaveBeenCalledTimes(1);
+      expect(mocks.savedConfigs).toContainEqual({ retained: true, theme: "dark" });
+
+      controls?.preview.setPreviewTheme("auto");
+      await waitFor(
+        () => snapshots.at(-1)?.setting === "dark" && snapshots.at(-1)?.theme === "light",
+        "auto preview did not resolve from the cached system theme",
+      );
+
+      controls?.preview.cancelPreview();
+      await waitFor(
+        () => snapshots.at(-1)?.setting === "dark" && snapshots.at(-1)?.theme === "dark",
+        "preview cancellation did not restore the saved theme",
+      );
+
+      controls?.setTheme("auto");
+      await waitFor(
+        () => snapshots.at(-1)?.setting === "auto" && snapshots.at(-1)?.theme === "light",
+        "explicit auto setting did not resolve from the cached system theme",
+      );
+
+      expect(mocks.saveGlobalConfig).toHaveBeenCalledTimes(2);
+      expect(mocks.savedConfigs).toContainEqual({ retained: true, theme: "auto" });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      stderr.end();
+    }
+  });
+});

--- a/runtime/tests/tui/components/diff/StructuredDiff.test.tsx
+++ b/runtime/tests/tui/components/diff/StructuredDiff.test.tsx
@@ -1,0 +1,323 @@
+import { PassThrough } from 'node:stream'
+
+import type { StructuredPatchHunk } from 'diff'
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  colorDiffAvailable: true,
+  colorDiffReturnsNull: false,
+  colorLines: ['+ rendered line'],
+  constructorCalls: [] as Array<{
+    fileContent: string | null
+    filePath: string
+    firstLine: string | null
+    patch: StructuredPatchHunk
+  }>,
+  fullscreen: false,
+  renderCalls: [] as Array<{
+    dim: boolean
+    theme: string
+    width: number
+  }>,
+  settings: {
+    syntaxHighlightingDisabled: false,
+  },
+  sliceCalls: [] as Array<{ end?: number; line: string; start: number }>,
+  theme: 'dark-theme',
+}))
+
+vi.mock('../../hooks/useSettings', () => ({
+  useSettings: () => harness.settings,
+}))
+
+vi.mock('../../ink.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../ink.js')>()
+  return {
+    ...actual,
+    RawAnsi: ({
+      lines,
+      width,
+    }: {
+      readonly lines: readonly string[]
+      readonly width: number
+    }) =>
+      React.createElement(
+        actual.Text,
+        null,
+        `RawAnsi:${width}:${lines.join('|')}`,
+      ),
+    useTheme: () => [harness.theme],
+  }
+})
+
+vi.mock('../../../utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => harness.fullscreen,
+}))
+
+vi.mock('../../../utils/sliceAnsi.js', () => ({
+  default: (line: string, start: number, end?: number) => {
+    harness.sliceCalls.push({ end, line, start })
+    return line.slice(start, end)
+  },
+}))
+
+vi.mock('./StructuredDiff/colorDiff', () => ({
+  expectColorDiff: () => {
+    if (!harness.colorDiffAvailable) return null
+    return class FakeColorDiff {
+      constructor(
+        patch: StructuredPatchHunk,
+        firstLine: string | null,
+        filePath: string,
+        fileContent: string | null,
+      ) {
+        harness.constructorCalls.push({
+          fileContent,
+          filePath,
+          firstLine,
+          patch,
+        })
+      }
+
+      render(theme: string, width: number, dim: boolean): string[] | null {
+        harness.renderCalls.push({ dim, theme, width })
+        return harness.colorDiffReturnsNull ? null : harness.colorLines
+      }
+    }
+  },
+}))
+
+vi.mock('./StructuredDiff/Fallback', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../../ink.js')
+  return {
+    StructuredDiffFallback: ({
+      dim,
+      patch,
+      width,
+    }: {
+      readonly dim: boolean
+      readonly patch: StructuredPatchHunk
+      readonly width: number
+    }) =>
+      ReactModule.createElement(
+        Text,
+        null,
+        `Fallback:${patch.oldStart}:${dim ? 'dim' : 'normal'}:${width}`,
+      ),
+  }
+})
+
+import { createRoot } from '../../ink/root.js'
+import { StructuredDiff } from './StructuredDiff.js'
+
+function patch(overrides: Partial<StructuredPatchHunk> = {}): StructuredPatchHunk {
+  return {
+    lines: [' context', '+added'],
+    newLines: 2,
+    newStart: 1,
+    oldLines: 2,
+    oldStart: 1,
+    ...overrides,
+  }
+}
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+  ;(stdout as unknown as { columns: number; rows: number }).columns = 120
+  ;(stdout as unknown as { columns: number; rows: number }).rows = 30
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderDiffToText(
+  props: Partial<React.ComponentProps<typeof StructuredDiff>> & {
+    patch: StructuredPatchHunk
+  },
+): Promise<string> {
+  let output = ''
+  const { stdin, stdout } = createStreams()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  root.render(
+    <StructuredDiff
+      dim={props.dim ?? false}
+      fileContent={props.fileContent}
+      filePath={props.filePath ?? 'src/app.ts'}
+      firstLine={props.firstLine ?? null}
+      patch={props.patch}
+      skipHighlighting={props.skipHighlighting}
+      width={props.width ?? 80}
+    />,
+  )
+  await sleep()
+  root.unmount()
+  stdin.end()
+  stdout.end()
+  await sleep()
+  return stripAnsi(output)
+}
+
+beforeEach(() => {
+  harness.colorDiffAvailable = true
+  harness.colorDiffReturnsNull = false
+  harness.colorLines = ['+ rendered line']
+  harness.constructorCalls = []
+  harness.fullscreen = false
+  harness.renderCalls = []
+  harness.settings = { syntaxHighlightingDisabled: false }
+  harness.sliceCalls = []
+  harness.theme = 'dark-theme'
+})
+
+describe('StructuredDiff', () => {
+  test('falls back when highlighting is unavailable, disabled, skipped, or returns null', async () => {
+    harness.colorDiffAvailable = false
+    await expect(renderDiffToText({ patch: patch({ oldStart: 4 }) })).resolves.toContain(
+      'Fallback:4:normal:80',
+    )
+
+    harness.colorDiffAvailable = true
+    harness.settings.syntaxHighlightingDisabled = true
+    await expect(
+      renderDiffToText({ dim: true, patch: patch({ oldStart: 5 }), width: 44 }),
+    ).resolves.toContain('Fallback:5:dim:44')
+
+    harness.settings.syntaxHighlightingDisabled = false
+    await expect(
+      renderDiffToText({
+        patch: patch({ oldStart: 6 }),
+        skipHighlighting: true,
+        width: 30,
+      }),
+    ).resolves.toContain('Fallback:6:normal:30')
+
+    harness.colorDiffReturnsNull = true
+    await expect(renderDiffToText({ patch: patch({ oldStart: 7 }) })).resolves.toContain(
+      'Fallback:7:normal:80',
+    )
+  })
+
+  test('renders a single RawAnsi column with safe floored widths and nullable file content', async () => {
+    harness.colorLines = ['+ highlighted', ' context']
+    const currentPatch = patch()
+
+    const output = await renderDiffToText({
+      dim: true,
+      filePath: 'bin/run',
+      firstLine: '#!/usr/bin/env node',
+      patch: currentPatch,
+      width: 20.8,
+    })
+
+    expect(output).toContain('RawAnsi:20:+ highlighted| context')
+    expect(harness.constructorCalls).toEqual([
+      {
+        fileContent: null,
+        filePath: 'bin/run',
+        firstLine: '#!/usr/bin/env node',
+        patch: currentPatch,
+      },
+    ])
+    expect(harness.renderCalls).toEqual([
+      { dim: true, theme: 'dark-theme', width: 20 },
+    ])
+    expect(harness.sliceCalls).toEqual([])
+  })
+
+  test('splits gutter and content columns in fullscreen mode', async () => {
+    harness.fullscreen = true
+    harness.colorLines = ['+ 12  added value', '  13  same value']
+    const currentPatch = patch({
+      newLines: 13,
+      newStart: 1,
+      oldLines: 13,
+      oldStart: 1,
+    })
+
+    const output = await renderDiffToText({
+      fileContent: 'const value = 1',
+      patch: currentPatch,
+      width: 24,
+    })
+
+    expect(output).toContain('RawAnsi:5:+ 12 |  13 ')
+    expect(output).toContain('RawAnsi:19: added value| same value')
+    expect(harness.sliceCalls).toEqual([
+      { line: '+ 12  added value', start: 0, end: 5 },
+      { line: '  13  same value', start: 0, end: 5 },
+      { line: '+ 12  added value', start: 5, end: undefined },
+      { line: '  13  same value', start: 5, end: undefined },
+    ])
+  })
+
+  test('keeps single-column output when the computed gutter would consume the width', async () => {
+    harness.fullscreen = true
+    harness.colorLines = ['+ 999  added value']
+
+    const output = await renderDiffToText({
+      patch: patch({ newLines: 999, oldLines: 999 }),
+      width: 3,
+    })
+
+    expect(output).toContain('RawAnsi:3:+ 999  added value')
+    expect(harness.sliceCalls).toEqual([])
+  })
+
+  test('reuses cached renders and evicts old width variants after the cap', async () => {
+    const currentPatch = patch()
+    harness.colorLines = [' cached line']
+
+    await renderDiffToText({ patch: currentPatch, width: 40 })
+    await renderDiffToText({ patch: currentPatch, width: 40 })
+    expect(harness.renderCalls).toHaveLength(1)
+
+    await renderDiffToText({ patch: currentPatch, width: 41 })
+    await renderDiffToText({ patch: currentPatch, width: 42 })
+    await renderDiffToText({ patch: currentPatch, width: 43 })
+    await renderDiffToText({ patch: currentPatch, width: 44 })
+    await renderDiffToText({ patch: currentPatch, width: 40 })
+
+    expect(harness.renderCalls.map(call => call.width)).toEqual([
+      40,
+      41,
+      42,
+      43,
+      44,
+      40,
+    ])
+  })
+})

--- a/runtime/tests/tui/components/diff/StructuredDiff/Fallback.test.tsx
+++ b/runtime/tests/tui/components/diff/StructuredDiff/Fallback.test.tsx
@@ -1,0 +1,200 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { describe, expect, test } from 'vitest'
+
+import { createRoot } from '../../../ink.js'
+import {
+  calculateWordDiffs,
+  numberDiffLines,
+  processAdjacentLines,
+  StructuredDiffFallback,
+  transformLinesToObjects,
+  type LineObject,
+} from './Fallback.js'
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderFallbackToText(props: {
+  readonly dim?: boolean
+  readonly lines: string[]
+  readonly oldStart?: number
+  readonly width?: number
+}): Promise<string> {
+  let output = ''
+  const { stdin, stdout } = createStreams()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  root.render(
+    <StructuredDiffFallback
+      dim={props.dim ?? false}
+      patch={{
+        lines: props.lines,
+        newLines: 0,
+        newStart: props.oldStart ?? 1,
+        oldLines: 0,
+        oldStart: props.oldStart ?? 1,
+      }}
+      width={props.width ?? 80}
+    />,
+  )
+  await sleep()
+  root.unmount()
+  stdin.end()
+  stdout.end()
+  await sleep()
+  return stripAnsi(output)
+}
+
+describe('StructuredDiffFallback helpers', () => {
+  test('transforms patch lines into typed line objects', () => {
+    expect(transformLinesToObjects([' context', '+added', '-removed'])).toEqual([
+      {
+        code: 'context',
+        i: 0,
+        originalCode: 'context',
+        type: 'nochange',
+      },
+      {
+        code: 'added',
+        i: 0,
+        originalCode: 'added',
+        type: 'add',
+      },
+      {
+        code: 'removed',
+        i: 0,
+        originalCode: 'removed',
+        type: 'remove',
+      },
+    ])
+  })
+
+  test('pairs adjacent remove/add lines and keeps unpaired removals', () => {
+    const lines = transformLinesToObjects([
+      '-old name',
+      '-old extra',
+      '+new name',
+      ' context',
+      '-orphan',
+    ])
+
+    const processed = processAdjacentLines(lines)
+
+    expect(processed.map(line => line.type)).toEqual([
+      'remove',
+      'remove',
+      'add',
+      'nochange',
+      'remove',
+    ])
+    expect(processed[0]?.wordDiff).toBe(true)
+    expect(processed[0]?.matchedLine).toBe(processed[2])
+    expect(processed[1]?.wordDiff).toBeUndefined()
+    expect(processed[4]?.wordDiff).toBeUndefined()
+  })
+
+  test('numbers removals without advancing the following added line too far', () => {
+    const diff: LineObject[] = [
+      { code: 'same', i: 0, originalCode: 'same', type: 'nochange' },
+      { code: 'remove one', i: 0, originalCode: 'remove one', type: 'remove' },
+      { code: 'remove two', i: 0, originalCode: 'remove two', type: 'remove' },
+      { code: 'add one', i: 0, originalCode: 'add one', type: 'add' },
+    ]
+
+    expect(numberDiffLines(diff, 10).map(line => [line.type, line.i])).toEqual([
+      ['nochange', 10],
+      ['remove', 11],
+      ['remove', 12],
+      ['add', 11],
+    ])
+  })
+
+  test('preserves whitespace in word-level diffs', () => {
+    const parts = calculateWordDiffs('const value = oldName', 'const value = newName')
+
+    expect(parts.map(part => part.value).join('')).toContain('const value = ')
+    expect(parts.some(part => part.removed && part.value === 'oldName')).toBe(true)
+    expect(parts.some(part => part.added && part.value === 'newName')).toBe(true)
+  })
+})
+
+describe('StructuredDiffFallback rendering', () => {
+  test('renders word-level add and remove pairs with line numbers', async () => {
+    const output = await renderFallbackToText({
+      lines: [
+        ' function read() {',
+        '-  return value.oldName',
+        '+  return value.newName',
+      ],
+      oldStart: 7,
+      width: 60,
+    })
+
+    expect(output).toContain('7  function read()')
+    expect(output).toContain('8 -  return value.oldName')
+    expect(output).toContain('8 +  return value.newName')
+  })
+
+  test('falls back to standard dim rendering and wraps narrow content', async () => {
+    const output = await renderFallbackToText({
+      dim: true,
+      lines: [
+        '-completely different removed line with lots of text',
+        '+tiny',
+        ' unchanged line that is long enough to wrap',
+      ],
+      oldStart: 1,
+      width: 14,
+    })
+
+    expect(output).toContain('1 -complet')
+    expect(output).toContain('different')
+    expect(output).toContain('1 +tiny')
+    expect(output).toContain('2  unchanged')
+  })
+
+  test('clamps invalid widths to a safe minimum', async () => {
+    const output = await renderFallbackToText({
+      lines: ['+x'],
+      oldStart: 3,
+      width: 0,
+    })
+
+    expect(output).toContain('3 +')
+    expect(output).toContain('x')
+  })
+})

--- a/runtime/tests/tui/components/diff/StructuredDiffList.test.tsx
+++ b/runtime/tests/tui/components/diff/StructuredDiffList.test.tsx
@@ -1,0 +1,104 @@
+import type { StructuredPatchHunk } from 'diff'
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('../../ink.js', () => {
+  const Passthrough = ({ children }: { readonly children?: React.ReactNode }) => (
+    <>{children}</>
+  )
+
+  return {
+    Box: Passthrough,
+    NoSelect: Passthrough,
+    Text: Passthrough,
+  }
+})
+
+vi.mock('./StructuredDiff', () => ({
+  StructuredDiff: ({
+    dim,
+    fileContent,
+    filePath,
+    firstLine,
+    patch,
+    width,
+  }: {
+    readonly dim: boolean
+    readonly fileContent?: string
+    readonly filePath: string
+    readonly firstLine: string | null
+    readonly patch: StructuredPatchHunk
+    readonly width: number
+  }) => (
+    <span>
+      {`diff:${patch.newStart}:${dim ? 'dim' : 'normal'}:${width}:${filePath}:${firstLine ?? 'none'}:${fileContent ?? 'empty'}`}
+    </span>
+  ),
+}))
+
+import { StructuredDiffList } from './StructuredDiffList.js'
+
+function collectText(node: React.ReactNode): string {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return ''
+  }
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node)
+  }
+  if (Array.isArray(node)) {
+    return node.map(collectText).join('')
+  }
+  if (React.isValidElement(node)) {
+    const element = node as React.ReactElement<{
+      readonly children?: React.ReactNode
+    }>
+    if (typeof element.type === 'function') {
+      const Component = element.type as (
+        props: typeof element.props,
+      ) => React.ReactNode
+      return collectText(Component(element.props))
+    }
+    return collectText(element.props.children)
+  }
+  return ''
+}
+
+describe('StructuredDiffList', () => {
+  test('renders each hunk with ellipsis separators', () => {
+    const output = collectText(
+      <StructuredDiffList
+        dim
+        fileContent="old file"
+        filePath="src/app.ts"
+        firstLine="import x"
+        hunks={
+          [
+            { newStart: 10 },
+            { newStart: 42 },
+          ] as StructuredPatchHunk[]
+        }
+        width={88}
+      />,
+    )
+
+    expect(output).toBe(
+      'diff:10:dim:88:src/app.ts:import x:old file' +
+        '...' +
+        'diff:42:dim:88:src/app.ts:import x:old file',
+    )
+  })
+
+  test('returns no rendered text for an empty hunk list', () => {
+    expect(
+      collectText(
+        <StructuredDiffList
+          dim={false}
+          filePath="src/app.ts"
+          firstLine={null}
+          hunks={[]}
+          width={80}
+        />,
+      ),
+    ).toBe('')
+  })
+})

--- a/runtime/tests/tui/components/markdown/HighlightedCode.wave200-121.coverage.test.tsx
+++ b/runtime/tests/tui/components/markdown/HighlightedCode.wave200-121.coverage.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../../utils/staticRender.js'
+import { HighlightedCode } from './HighlightedCode.js'
+
+const harness = vi.hoisted(() => ({
+  renderCalls: [] as Array<{
+    readonly theme: unknown
+    readonly width: number
+    readonly dim: boolean
+  }>,
+  reset() {
+    harness.renderCalls = []
+  },
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../../utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => true,
+}))
+
+vi.mock('../../hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    syntaxHighlightingDisabled: false,
+  }),
+}))
+
+vi.mock('../diff/StructuredDiff/colorDiff.js', () => ({
+  expectColorFile: () =>
+    class {
+      render(theme: unknown, width: number, dim: boolean): string[] {
+        harness.renderCalls.push({ theme, width, dim })
+        return [' 1  const first = 1', '12  const twelfth = 12']
+      }
+    },
+}))
+
+describe('HighlightedCode wave200-121 coverage', () => {
+  test('splits fullscreen line gutters from highlighted code output', async () => {
+    harness.reset()
+    const code = Array.from(
+      { length: 12 },
+      (_, index) => `const line${index + 1} = ${index + 1}`,
+    ).join('\n')
+
+    const output = await renderToString(
+      <HighlightedCode code={code} filePath="fixture.ts" width={44} dim />,
+      80,
+    )
+
+    expect(output).toContain(' 1  const first = 1')
+    expect(output).toContain('12  const twelfth = 12')
+    expect(harness.renderCalls).toEqual([
+      expect.objectContaining({ width: 44, dim: true }),
+    ])
+  })
+})

--- a/runtime/tests/tui/components/markdown/HighlightedCodeFallback.coverage.test.tsx
+++ b/runtime/tests/tui/components/markdown/HighlightedCodeFallback.coverage.test.tsx
@@ -1,0 +1,124 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../../ink.js'
+import { HighlightedCodeFallback } from './HighlightedCodeFallback.js'
+
+const highlightMock = vi.hoisted(() => {
+  const highlight = vi.fn(
+    (code: string, options: { readonly language: string }) =>
+      `highlighted:${options.language}:${code}`,
+  )
+  const supportsLanguage = vi.fn((language: string) => language === 'ts')
+  return {
+    getCliHighlightPromise: vi.fn(),
+    highlight,
+    logForDebugging: vi.fn(),
+    supportsLanguage,
+  }
+})
+
+vi.mock('../../../utils/cliHighlight.js', () => ({
+  getCliHighlightPromise: highlightMock.getCliHighlightPromise,
+}))
+
+vi.mock('../../../utils/debug.js', () => ({
+  logForDebugging: highlightMock.logForDebugging,
+}))
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+async function waitForOutput(
+  readOutput: () => string,
+  expected: string,
+): Promise<void> {
+  const deadline = Date.now() + 1000
+  while (Date.now() < deadline) {
+    if (readOutput().includes(expected)) return
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+}
+
+async function renderToText(node: React.ReactNode, expected: string): Promise<string> {
+  let output = ''
+  const { stdin, stdout } = createStreams()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  try {
+    root.render(node)
+    await waitForOutput(() => stripAnsi(output), expected)
+    return stripAnsi(output)
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+  }
+}
+
+describe('HighlightedCodeFallback', () => {
+  beforeEach(() => {
+    const highlighter = {
+      highlight: highlightMock.highlight,
+      supportsLanguage: highlightMock.supportsLanguage,
+    }
+    highlightMock.getCliHighlightPromise.mockReturnValue(
+      Promise.resolve(highlighter),
+    )
+    highlightMock.highlight.mockClear()
+    highlightMock.supportsLanguage.mockClear()
+    highlightMock.logForDebugging.mockClear()
+  })
+
+  test('falls back unsupported extensions to markdown highlighting after normalizing leading tabs', async () => {
+    const expected = 'highlighted:markdown:  const value = 1'
+
+    const output = await renderToText(
+      <HighlightedCodeFallback
+        code={`${String.fromCharCode(9)}const value = 1`}
+        filePath="fixture.unknown"
+      />,
+      expected,
+    )
+
+    expect(output).toContain(expected)
+    expect(highlightMock.supportsLanguage).toHaveBeenCalledWith('unknown')
+    expect(highlightMock.highlight).toHaveBeenCalledWith('  const value = 1', {
+      language: 'markdown',
+    })
+    expect(highlightMock.logForDebugging).toHaveBeenCalledWith(
+      expect.stringContaining('falling back to markdown: unknown'),
+    )
+  })
+})

--- a/runtime/tests/tui/components/markdown/HighlightedCodeFallback.wave200-080.coverage.test.tsx
+++ b/runtime/tests/tui/components/markdown/HighlightedCodeFallback.wave200-080.coverage.test.tsx
@@ -1,0 +1,123 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../../ink.js'
+import { HighlightedCodeFallback } from './HighlightedCodeFallback.js'
+
+const highlightMock = vi.hoisted(() => {
+  const highlight = vi.fn(
+    (code: string, options: { readonly language: string }) =>
+      `highlighted:${options.language}:${code}`,
+  )
+  const supportsLanguage = vi.fn((language: string) => language === 'tsx')
+
+  return {
+    getCliHighlightPromise: vi.fn(),
+    highlight,
+    supportsLanguage,
+  }
+})
+
+vi.mock('../../../utils/cliHighlight.js', () => ({
+  getCliHighlightPromise: highlightMock.getCliHighlightPromise,
+}))
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+async function waitForOutput(
+  readOutput: () => string,
+  expected: string,
+): Promise<void> {
+  const deadline = Date.now() + 1000
+  while (Date.now() < deadline) {
+    if (readOutput().includes(expected)) return
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+  throw new Error(`Timed out waiting for rendered output: ${expected}`)
+}
+
+async function renderToText(
+  node: React.ReactNode,
+  expected: string,
+): Promise<string> {
+  let output = ''
+  const { stdin, stdout } = createStreams()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  try {
+    root.render(node)
+    await waitForOutput(() => stripAnsi(output), expected)
+    return stripAnsi(output)
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+  }
+}
+
+describe('HighlightedCodeFallback wave200-080 coverage', () => {
+  beforeEach(() => {
+    const highlighter = {
+      highlight: highlightMock.highlight,
+      supportsLanguage: highlightMock.supportsLanguage,
+    }
+    highlightMock.getCliHighlightPromise.mockReturnValue(
+      Promise.resolve(highlighter),
+    )
+    highlightMock.getCliHighlightPromise.mockClear()
+    highlightMock.highlight.mockClear()
+    highlightMock.supportsLanguage.mockClear()
+  })
+
+  test('reuses supported-language highlighted output from the module cache after remounting', async () => {
+    const code = 'const wave200080 = true'
+    const expected = `highlighted:tsx:${code}`
+    const node = (
+      <HighlightedCodeFallback code={code} filePath="fixture.tsx" />
+    )
+
+    const first = await renderToText(node, expected)
+    const second = await renderToText(node, expected)
+
+    expect(first).toContain(expected)
+    expect(second).toContain(expected)
+    expect(highlightMock.supportsLanguage).toHaveBeenCalledWith('tsx')
+    expect(highlightMock.highlight).toHaveBeenCalledTimes(1)
+    expect(highlightMock.highlight).toHaveBeenCalledWith(code, {
+      language: 'tsx',
+    })
+  })
+})

--- a/runtime/tests/tui/components/markdown/Markdown.wave200-075.coverage.test.tsx
+++ b/runtime/tests/tui/components/markdown/Markdown.wave200-075.coverage.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../../utils/staticRender.js'
+import { StreamingMarkdown } from './Markdown.js'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    syntaxHighlightingDisabled: true,
+  }),
+}))
+
+describe('StreamingMarkdown coverage', () => {
+  test('renders stable and streaming blocks after stripping prompt XML tags', async () => {
+    const output = await renderToString(
+      <StreamingMarkdown>
+        {[
+          '# Stable heading',
+          '',
+          'Stable paragraph before the final block.',
+          '',
+          '<context>hidden context</context>',
+          '',
+          '- final item still streaming',
+        ].join('\n')}
+      </StreamingMarkdown>,
+      80,
+    )
+
+    expect(output).toContain('Stable heading')
+    expect(output).toContain('Stable paragraph before the final block.')
+    expect(output).toContain('final item still streaming')
+    expect(output).not.toContain('hidden context')
+    expect(output).not.toContain('<context>')
+  })
+})

--- a/runtime/tests/tui/components/markdown/MarkdownTable.wave200-070.coverage.test.tsx
+++ b/runtime/tests/tui/components/markdown/MarkdownTable.wave200-070.coverage.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { marked, type Tokens } from 'marked'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+import { renderToString } from '../../../utils/staticRender.js'
+import { MarkdownTable } from './MarkdownTable.js'
+
+const originalGlyphMode = process.env.AGENC_TUI_GLYPHS
+
+function parseTable(markdown: string): Tokens.Table {
+  const table = marked.lexer(markdown).find(token => token.type === 'table')
+  if (!table || table.type !== 'table') {
+    throw new Error('expected markdown fixture to parse as a table')
+  }
+  return table
+}
+
+describe('MarkdownTable narrow layout', () => {
+  beforeEach(() => {
+    delete process.env.AGENC_TUI_GLYPHS
+  })
+
+  afterEach(() => {
+    if (originalGlyphMode === undefined) {
+      delete process.env.AGENC_TUI_GLYPHS
+    } else {
+      process.env.AGENC_TUI_GLYPHS = originalGlyphMode
+    }
+  })
+
+  test('switches to vertical key-value rows when wrapped cells would be too tall', async () => {
+    const token = parseTable([
+      '| Field | Value |',
+      '| :--- | :--- |',
+      '| Status | First sentence with compact words that should wrap onto continuation lines for the vertical fallback renderer. |',
+      '| Owner | Ada |',
+    ].join('\n'))
+
+    const output = await renderToString(
+      <MarkdownTable token={token} highlight={null} forceWidth={30} />,
+      80,
+    )
+    const lines = output.split('\n').filter(line => line.length > 0)
+
+    expect(output).toContain('Field: Status')
+    expect(output).toContain('Value: First sentence with')
+    expect(output).toContain('  compact words that should')
+    expect(output).toContain('Field: Owner')
+    expect(output).toContain('Value: Ada')
+    expect(lines).toContain('─'.repeat(29))
+    expect(output).not.toContain('┌')
+    expect(output).not.toContain('┬')
+    expect(lines.every(line => line.length <= 30)).toBe(true)
+  })
+})

--- a/runtime/tests/tui/components/memory/MemoryUpdateNotification.test.tsx
+++ b/runtime/tests/tui/components/memory/MemoryUpdateNotification.test.tsx
@@ -1,0 +1,75 @@
+import { homedir } from 'os'
+import { join } from 'path'
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { renderToString } from '../../../utils/staticRender.js'
+import { MemoryUpdateNotification } from './MemoryUpdateNotification.js'
+import { getRelativeMemoryPathForRoots } from './path-format.js'
+
+describe('memory path display formatting', () => {
+  test('formats paths relative to home, cwd, or neither root', () => {
+    expect(
+      getRelativeMemoryPathForRoots(
+        '/home/user',
+        '/home/user',
+        '/workspace/project',
+      ),
+    ).toBe('~')
+    expect(
+      getRelativeMemoryPathForRoots(
+        '/workspace/project',
+        '/home/user',
+        '/workspace/project',
+      ),
+    ).toBe('.')
+    expect(
+      getRelativeMemoryPathForRoots(
+        '/home/user/.agenc/AGENC.md',
+        '/home/user',
+        '/workspace/project',
+      ),
+    ).toBe('~/.agenc/AGENC.md')
+    expect(
+      getRelativeMemoryPathForRoots(
+        '/workspace/project/AGENC.md',
+        '/home/user',
+        '/workspace/project',
+      ),
+    ).toBe('./AGENC.md')
+    expect(
+      getRelativeMemoryPathForRoots(
+        '/home/user/project/AGENC.md',
+        '/home/user',
+        '/home/user/project',
+      ),
+    ).toBe('./AGENC.md')
+    expect(
+      getRelativeMemoryPathForRoots(
+        '/outside/AGENC.md',
+        '/home/user',
+        '/workspace/project',
+      ),
+    ).toBe('/outside/AGENC.md')
+  })
+
+  test('prefers home when home and cwd displays are the same length', () => {
+    expect(
+      getRelativeMemoryPathForRoots('/home/user', '/home/user', '/home/user'),
+    ).toBe('~')
+  })
+})
+
+describe('MemoryUpdateNotification', () => {
+  test('renders the formatted memory path and edit command', async () => {
+    const output = await renderToString(
+      <MemoryUpdateNotification
+        memoryPath={join(homedir(), '.agenc', 'AGENC.md')}
+      />,
+      80,
+    )
+
+    expect(output).toContain('Memory updated in ~/.agenc/AGENC.md')
+    expect(output).toContain('/memory to edit')
+  })
+})

--- a/runtime/tests/tui/components/memory/selector-options.test.ts
+++ b/runtime/tests/tui/components/memory/selector-options.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  buildMemoryFileSelectorOptions,
+  getInitialMemoryPath,
+  OPEN_FOLDER_PREFIX,
+  type AgentMemoryDefinitionForSelector,
+  type MemorySelectorFileInfo,
+} from './selector-options.js'
+
+const userMemoryPath = '/home/user/.agenc/AGENC.md'
+const projectMemoryPath = '/repo/AGENC.md'
+const autoMemoryPath = '/repo/.agenc/auto-memory'
+const teamMemoryPath = '/repo/.agenc/team-memory'
+
+function buildOptions(overrides: {
+  readonly existingMemoryFiles?: readonly MemorySelectorFileInfo[]
+  readonly autoMemoryEnabled?: boolean
+  readonly teamMemoryEnabled?: boolean
+  readonly teamMemoryPath?: string
+  readonly activeAgents?: readonly AgentMemoryDefinitionForSelector[]
+  readonly projectInGitRepo?: boolean
+} = {}) {
+  return buildMemoryFileSelectorOptions({
+    existingMemoryFiles: overrides.existingMemoryFiles ?? [],
+    userMemoryPath,
+    projectMemoryPath,
+    autoMemoryEnabled: overrides.autoMemoryEnabled ?? false,
+    autoMemoryPath,
+    teamMemoryEnabled: overrides.teamMemoryEnabled ?? false,
+    teamMemoryPath: overrides.teamMemoryPath,
+    activeAgents: overrides.activeAgents ?? [],
+    projectInGitRepo: overrides.projectInGitRepo ?? true,
+    displayPathFor: path => path.replace('/repo/', '').replace('/home/user/', '~/'),
+    agentMemoryDirFor: (agentType, scope) => `/agents/${scope}/${agentType}`,
+  })
+}
+
+describe('memory selector options', () => {
+  test('adds absent user and project memory options when files do not exist', () => {
+    expect(buildOptions()).toEqual([
+      {
+        label: 'User memory',
+        value: userMemoryPath,
+        description: 'Saved in ~/.agenc/AGENC.md',
+        kind: 'user',
+        state: 'absent',
+      },
+      {
+        label: 'Project memory',
+        value: projectMemoryPath,
+        description: 'Checked in at ./AGENC.md',
+        kind: 'project',
+        state: 'absent',
+      },
+    ])
+  })
+
+  test('formats present, imported, nested, and dynamic memory files', () => {
+    const options = buildOptions({
+      existingMemoryFiles: [
+        {
+          path: userMemoryPath,
+          type: 'User',
+          content: 'user',
+        },
+        {
+          path: projectMemoryPath,
+          type: 'Project',
+          content: 'project',
+        },
+        {
+          path: '/repo/imported.md',
+          type: 'Project',
+          parent: projectMemoryPath,
+          content: 'imported',
+        },
+        {
+          path: '/repo/imported/deep.md',
+          type: 'Project',
+          parent: '/repo/imported.md',
+          content: 'deep',
+        },
+        {
+          path: '/repo/orphan-import.md',
+          type: 'Project',
+          parent: '/repo/not-yet-listed.md',
+          content: 'orphan',
+        },
+        {
+          path: '/repo/dynamic.md',
+          type: 'Project',
+          isNested: true,
+          content: 'dynamic',
+        },
+        {
+          path: '/repo/pinned.md',
+          type: 'Pinned',
+          content: 'top-level memory',
+        },
+        {
+          path: '/repo/auto.md',
+          type: 'AutoMem',
+          content: 'filtered',
+        },
+        {
+          path: '/repo/team.md',
+          type: 'TeamMem',
+          content: 'filtered',
+        },
+      ],
+      projectInGitRepo: false,
+    })
+
+    expect(options).toEqual([
+      {
+        label: 'User memory',
+        value: userMemoryPath,
+        description: 'Saved in ~/.agenc/AGENC.md',
+        kind: 'user',
+        state: 'present',
+      },
+      {
+        label: 'Project memory',
+        value: projectMemoryPath,
+        description: 'Saved in ./AGENC.md',
+        kind: 'project',
+        state: 'present',
+      },
+      {
+        label: 'L imported.md',
+        value: '/repo/imported.md',
+        description: '@-imported',
+        kind: 'import',
+        state: 'present',
+      },
+      {
+        label: '  L imported/deep.md',
+        value: '/repo/imported/deep.md',
+        description: '@-imported',
+        kind: 'import',
+        state: 'present',
+      },
+      {
+        label: 'L orphan-import.md',
+        value: '/repo/orphan-import.md',
+        description: '@-imported',
+        kind: 'import',
+        state: 'present',
+      },
+      {
+        label: 'dynamic.md',
+        value: '/repo/dynamic.md',
+        description: 'dynamically loaded',
+        kind: 'memory',
+        state: 'present',
+      },
+      {
+        label: 'pinned.md',
+        value: '/repo/pinned.md',
+        description: '',
+        kind: 'memory',
+        state: 'present',
+      },
+    ])
+  })
+
+  test('adds folder and scoped agent entries only when auto-memory is enabled', () => {
+    const disabled = buildOptions({
+      autoMemoryEnabled: false,
+      teamMemoryEnabled: true,
+      teamMemoryPath,
+      activeAgents: [
+        { agentType: 'reviewer', memory: 'project' },
+      ],
+    })
+
+    expect(disabled.map(option => option.kind)).toEqual(['user', 'project'])
+
+    const enabled = buildOptions({
+      autoMemoryEnabled: true,
+      teamMemoryEnabled: true,
+      teamMemoryPath,
+      activeAgents: [
+        { agentType: 'reviewer', memory: 'project' },
+        { agentType: 'localizer', memory: 'local' },
+        { agentType: 'global', memory: 'user' },
+        { agentType: 'disabled', memory: false },
+        { agentType: 'none', memory: null },
+        { agentType: 'missing' },
+      ],
+    })
+
+    expect(enabled.slice(2)).toEqual([
+      {
+        label: 'Open auto-memory folder',
+        value: `${OPEN_FOLDER_PREFIX}${autoMemoryPath}`,
+        description: '',
+        kind: 'folder',
+        state: 'folder',
+      },
+      {
+        label: 'Open team memory folder',
+        value: `${OPEN_FOLDER_PREFIX}${teamMemoryPath}`,
+        description: '',
+        kind: 'folder',
+        state: 'folder',
+      },
+      {
+        label: 'Open reviewer agent memory',
+        value: `${OPEN_FOLDER_PREFIX}/agents/project/reviewer`,
+        description: 'project scope',
+        kind: 'agent',
+        state: 'folder',
+      },
+      {
+        label: 'Open localizer agent memory',
+        value: `${OPEN_FOLDER_PREFIX}/agents/local/localizer`,
+        description: 'local scope',
+        kind: 'agent',
+        state: 'folder',
+      },
+      {
+        label: 'Open global agent memory',
+        value: `${OPEN_FOLDER_PREFIX}/agents/user/global`,
+        description: 'user scope',
+        kind: 'agent',
+        state: 'folder',
+      },
+    ])
+  })
+
+  test('skips team folder without a path and chooses the initial selection', () => {
+    const options = buildOptions({
+      autoMemoryEnabled: true,
+      teamMemoryEnabled: true,
+      teamMemoryPath: undefined,
+    })
+
+    expect(options.map(option => option.label)).toEqual([
+      'User memory',
+      'Project memory',
+      'Open auto-memory folder',
+    ])
+    expect(getInitialMemoryPath(options, projectMemoryPath)).toBe(projectMemoryPath)
+    expect(getInitialMemoryPath(options, '/missing.md')).toBe(userMemoryPath)
+    expect(getInitialMemoryPath([], '/missing.md')).toBe('')
+  })
+})

--- a/runtime/tests/tui/components/messageActions.coverage.test.tsx
+++ b/runtime/tests/tui/components/messageActions.coverage.test.tsx
@@ -1,0 +1,104 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { describe, expect, test } from 'vitest'
+
+import { createRoot } from '../ink/root.js'
+import {
+  MessageActionsBar,
+  type MessageActionsState,
+} from './messageActions.js'
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderBar(cursor: MessageActionsState): Promise<{
+  dispose: () => Promise<void>
+  output: () => string
+}> {
+  let output = ''
+  const { stdin, stdout } = createStreams()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  root.render(<MessageActionsBar cursor={cursor} />)
+  await sleep()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    output: () => stripAnsi(output),
+  }
+}
+
+describe('MessageActionsBar coverage', () => {
+  test('renders grouped tool-use actions with expansion and primary input labels', async () => {
+    const collapsed = await renderBar({
+      expanded: false,
+      msgType: 'grouped_tool_use',
+      toolName: 'Agent',
+      uuid: 'grouped-agent',
+    })
+
+    try {
+      expect(collapsed.output()).toMatch(/enter\s+expand/)
+      expect(collapsed.output()).toMatch(/c\s+copy/)
+      expect(collapsed.output()).toMatch(/p\s+copy prompt/)
+      expect(collapsed.output()).toContain('navigate')
+      expect(collapsed.output()).toMatch(/esc\s+back/)
+    } finally {
+      await collapsed.dispose()
+    }
+
+    const expanded = await renderBar({
+      expanded: true,
+      msgType: 'grouped_tool_use',
+      toolName: 'Agent',
+      uuid: 'grouped-agent',
+    })
+
+    try {
+      expect(expanded.output()).toMatch(/enter\s+collapse/)
+      expect(expanded.output()).toMatch(/p\s+copy prompt/)
+    } finally {
+      await expanded.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/components/messageActions.coverage2.test.tsx
+++ b/runtime/tests/tui/components/messageActions.coverage2.test.tsx
@@ -1,0 +1,267 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const analytics = vi.hoisted(() => ({
+  logEvent: vi.fn(),
+}))
+
+vi.mock('../../services/analytics/index', () => ({
+  logEvent: analytics.logEvent,
+}))
+
+import { createRoot } from '../ink/root.js'
+import {
+  type MessageActionCaps,
+  type MessageActionsNav,
+  type MessageActionsState,
+  type NavigableMessage,
+  useMessageActions,
+} from './messageActions.js'
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function assistantTool(
+  name: string,
+  input: Record<string, unknown>,
+): NavigableMessage {
+  return {
+    type: 'assistant',
+    uuid: `assistant-tool-${name}`,
+    message: { content: [{ type: 'tool_use', name, input }] },
+  } as never
+}
+
+function assistantText(text: string): NavigableMessage {
+  return {
+    type: 'assistant',
+    uuid: `assistant-${text}`,
+    message: { content: [{ type: 'text', text }] },
+  } as never
+}
+
+function userText(text: string): NavigableMessage {
+  return {
+    type: 'user',
+    uuid: `user-${text}`,
+    message: { content: [{ type: 'text', text }] },
+  } as never
+}
+
+async function renderHookHarness(initialCursor: MessageActionsState): Promise<{
+  caps: MessageActionCaps
+  cursor: () => MessageActionsState | null
+  dispose: () => Promise<void>
+  handlers: () => ReturnType<typeof useMessageActions>
+  nav: MessageActionsNav
+  setCursor: (next: MessageActionsState | null) => Promise<void>
+}> {
+  let currentCursor: MessageActionsState | null = initialCursor
+  let latest: ReturnType<typeof useMessageActions> | undefined
+  let setCursorExternal:
+    | React.Dispatch<React.SetStateAction<MessageActionsState | null>>
+    | undefined
+
+  const caps = {
+    copy: vi.fn(),
+    edit: vi.fn(async () => {}),
+  } satisfies MessageActionCaps
+  const nav = {
+    enterCursor: vi.fn(),
+    getSelected: vi.fn(() => null),
+    navigateBottom: vi.fn(),
+    navigateNext: vi.fn(),
+    navigateNextUser: vi.fn(),
+    navigatePrev: vi.fn(),
+    navigatePrevUser: vi.fn(),
+    navigateTop: vi.fn(),
+  } satisfies MessageActionsNav
+  const navRef = { current: nav }
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    const [cursor, setCursor] =
+      React.useState<MessageActionsState | null>(initialCursor)
+    currentCursor = cursor
+    setCursorExternal = setCursor
+    latest = useMessageActions(cursor, setCursor, navRef, caps)
+    return null
+  }
+
+  root.render(<Harness />)
+  await sleep()
+
+  return {
+    caps,
+    cursor: () => currentCursor,
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    handlers: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+    nav,
+    setCursor: async next => {
+      if (setCursorExternal === undefined) {
+        throw new Error('hook setter did not render')
+      }
+      setCursorExternal(next)
+      await sleep()
+    },
+  }
+}
+
+describe('useMessageActions coverage', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('dispatches navigation and message action handlers from the current cursor', async () => {
+    const rendered = await renderHookHarness({
+      expanded: false,
+      msgType: 'grouped_tool_use',
+      toolName: 'Agent',
+      uuid: 'grouped-agent',
+    })
+
+    try {
+      rendered.handlers().enter()
+      expect(analytics.logEvent).toHaveBeenCalledTimes(1)
+      expect(rendered.nav.enterCursor).toHaveBeenCalledTimes(1)
+
+      rendered.handlers().handlers['messageActions:prev']()
+      rendered.handlers().handlers['messageActions:next']()
+      rendered.handlers().handlers['messageActions:prevUser']()
+      rendered.handlers().handlers['messageActions:nextUser']()
+      rendered.handlers().handlers['messageActions:top']()
+      rendered.handlers().handlers['messageActions:bottom']()
+      expect(rendered.nav.navigatePrev).toHaveBeenCalledTimes(1)
+      expect(rendered.nav.navigateNext).toHaveBeenCalledTimes(1)
+      expect(rendered.nav.navigatePrevUser).toHaveBeenCalledTimes(1)
+      expect(rendered.nav.navigateNextUser).toHaveBeenCalledTimes(1)
+      expect(rendered.nav.navigateTop).toHaveBeenCalledTimes(1)
+      expect(rendered.nav.navigateBottom).toHaveBeenCalledTimes(1)
+
+      rendered.handlers().handlers['messageActions:enter']()
+      await sleep()
+      expect(rendered.cursor()).toMatchObject({ expanded: true })
+
+      rendered.handlers().handlers['messageActions:escape']()
+      await sleep()
+      expect(rendered.cursor()).toMatchObject({ expanded: false })
+
+      rendered.handlers().handlers['messageActions:p']()
+      await sleep()
+      expect(rendered.cursor()).toMatchObject({ expanded: false })
+
+      rendered.handlers().handlers['messageActions:escape']()
+      await sleep()
+      expect(rendered.cursor()).toBeNull()
+
+      rendered.handlers().handlers['messageActions:c']()
+      expect(rendered.caps.copy).not.toHaveBeenCalled()
+
+      await rendered.setCursor({
+        expanded: false,
+        msgType: 'assistant',
+        toolName: 'Tmux',
+        uuid: 'assistant-tmux',
+      })
+      rendered.nav.getSelected = vi.fn(() =>
+        assistantTool('Tmux', { args: ['list-sessions', '-F', '#S'] }),
+      )
+      rendered.handlers().handlers['messageActions:p']()
+      await sleep()
+      expect(rendered.caps.copy).toHaveBeenLastCalledWith(
+        'tmux list-sessions -F #S',
+      )
+      expect(rendered.cursor()).toBeNull()
+
+      await rendered.setCursor({
+        expanded: false,
+        msgType: 'assistant',
+        toolName: 'Bash',
+        uuid: 'assistant-without-selection',
+      })
+      rendered.nav.getSelected = vi.fn(() => null)
+      rendered.handlers().handlers['messageActions:p']()
+      await sleep()
+      expect(rendered.cursor()).toMatchObject({
+        uuid: 'assistant-without-selection',
+      })
+
+      await rendered.setCursor({
+        expanded: false,
+        msgType: 'assistant',
+        uuid: 'assistant-copy',
+      })
+      rendered.nav.getSelected = vi.fn(() => assistantText('answer text'))
+      rendered.handlers().handlers['messageActions:c']()
+      await sleep()
+      expect(rendered.caps.copy).toHaveBeenLastCalledWith('answer text')
+      expect(rendered.cursor()).toBeNull()
+
+      await rendered.setCursor({
+        expanded: false,
+        msgType: 'user',
+        uuid: 'user-edit',
+      })
+      rendered.nav.getSelected = vi.fn(() => userText('edit me'))
+      rendered.handlers().handlers['messageActions:enter']()
+      await sleep()
+      expect(rendered.caps.edit).toHaveBeenCalledWith(userText('edit me'))
+      expect(rendered.cursor()).toBeNull()
+
+      await rendered.setCursor({
+        expanded: false,
+        msgType: 'system',
+        uuid: 'system-no-primary',
+      })
+      rendered.handlers().handlers['messageActions:p']()
+      await sleep()
+      expect(rendered.cursor()).toMatchObject({ uuid: 'system-no-primary' })
+
+      rendered.handlers().handlers['messageActions:ctrlc']()
+      await sleep()
+      expect(rendered.cursor()).toBeNull()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/components/messageActions.wave200-089.coverage.test.tsx
+++ b/runtime/tests/tui/components/messageActions.wave200-089.coverage.test.tsx
@@ -1,0 +1,122 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const keybindingMocks = vi.hoisted(() => ({
+  useKeybindings: vi.fn(),
+}))
+
+vi.mock('../keybindings/useKeybinding.js', () => ({
+  useKeybindings: keybindingMocks.useKeybindings,
+}))
+
+import { createRoot, type Root } from '../ink/root.js'
+import { MessageActionsKeybindings } from './messageActions.js'
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function createInkRoot(): Promise<{
+  dispose: () => Promise<void>
+  root: Root
+}> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    root,
+  }
+}
+
+describe('MessageActionsKeybindings coverage', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('registers message-action handlers and memoizes options until activity changes', async () => {
+    const handlers = {
+      'messageActions:next': vi.fn(),
+      'messageActions:prev': vi.fn(),
+    }
+    const rendered = await createInkRoot()
+
+    try {
+      rendered.root.render(
+        <MessageActionsKeybindings handlers={handlers} isActive={true} />,
+      )
+      await sleep()
+
+      expect(keybindingMocks.useKeybindings).toHaveBeenCalledTimes(1)
+      expect(keybindingMocks.useKeybindings).toHaveBeenLastCalledWith(
+        handlers,
+        {
+          context: 'MessageActions',
+          isActive: true,
+        },
+      )
+      const activeOptions = keybindingMocks.useKeybindings.mock.calls[0]?.[1]
+
+      rendered.root.render(
+        <MessageActionsKeybindings handlers={handlers} isActive={true} />,
+      )
+      await sleep()
+
+      expect(keybindingMocks.useKeybindings).toHaveBeenCalledTimes(2)
+      expect(keybindingMocks.useKeybindings.mock.calls[1]?.[1]).toBe(
+        activeOptions,
+      )
+
+      rendered.root.render(
+        <MessageActionsKeybindings handlers={handlers} isActive={false} />,
+      )
+      await sleep()
+
+      expect(keybindingMocks.useKeybindings).toHaveBeenCalledTimes(3)
+      expect(keybindingMocks.useKeybindings.mock.calls[2]?.[1]).toEqual({
+        context: 'MessageActions',
+        isActive: false,
+      })
+      expect(keybindingMocks.useKeybindings.mock.calls[2]?.[1]).not.toBe(
+        activeOptions,
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/components/shell/ShellProgressMessage.coverage.test.tsx
+++ b/runtime/tests/tui/components/shell/ShellProgressMessage.coverage.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { renderToString } from '../../../utils/staticRender.js'
+import { ShellProgressMessage } from './ShellProgressMessage.js'
+
+describe('ShellProgressMessage', () => {
+  test('renders compact shell progress with the latest output and aggregate status', async () => {
+    const output = [
+      '\u001b[31mline 1\u001b[0m',
+      'line 2',
+      'line 3',
+      'line 4',
+      'line 5',
+      'line 6',
+      'line 7',
+    ].join('\n')
+
+    const rendered = await renderToString(
+      <ShellProgressMessage
+        elapsedTimeSeconds={7}
+        fullOutput={`setup\n${output}`}
+        output={output}
+        timeoutMs={120_000}
+        totalBytes={1536}
+        totalLines={9}
+        verbose={false}
+      />,
+      80,
+    )
+
+    expect(rendered).toContain('line 3')
+    expect(rendered).toContain('line 7')
+    expect(rendered).not.toContain('line 1')
+    expect(rendered).not.toContain('line 2')
+    expect(rendered).not.toContain('setup')
+    expect(rendered).toContain('~9 lines')
+    expect(rendered).toContain('(7s · timeout 2m)')
+    expect(rendered).toContain('1.5KB')
+  })
+})

--- a/runtime/tests/tui/components/shell/ShellProgressMessage.wave200-104.coverage.test.tsx
+++ b/runtime/tests/tui/components/shell/ShellProgressMessage.wave200-104.coverage.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { renderToString } from '../../../utils/staticRender.js'
+import { ShellProgressMessage } from './ShellProgressMessage.js'
+
+describe('ShellProgressMessage wave200 coverage', () => {
+  test('renders running, extra-line, and verbose shell output states', async () => {
+    const running = await renderToString(
+      <ShellProgressMessage
+        elapsedTimeSeconds={undefined}
+        fullOutput={'   \n'}
+        output={'   \n\u001b[33m\u001b[0m   '}
+        timeoutMs={90_000}
+        verbose={false}
+      />,
+      80,
+    )
+
+    expect(running).toContain('Running')
+    expect(running).toContain('(timeout 1m 30s)')
+    expect(running).not.toContain('lines')
+
+    const compact = await renderToString(
+      <ShellProgressMessage
+        elapsedTimeSeconds={3}
+        fullOutput={'hidden setup\nalpha\nbeta\ngamma'}
+        output={'alpha\nbeta\ngamma'}
+        totalLines={8}
+        verbose={false}
+      />,
+      80,
+    )
+
+    expect(compact).toContain('alpha')
+    expect(compact).toContain('gamma')
+    expect(compact).toContain('+3 lines')
+    expect(compact).toContain('(3s)')
+    expect(compact).not.toContain('hidden setup')
+
+    const verbose = await renderToString(
+      <ShellProgressMessage
+        elapsedTimeSeconds={12}
+        fullOutput={'\u001b[32mfirst full line\u001b[0m\nsecond full line\nlast full line'}
+        output={'tail only 1\ntail only 2'}
+        totalLines={12}
+        verbose={true}
+      />,
+      80,
+    )
+
+    expect(verbose).toContain('first full line')
+    expect(verbose).toContain('last full line')
+    expect(verbose).toContain('(12s)')
+    expect(verbose).not.toContain('tail only')
+    expect(verbose).not.toContain('+7 lines')
+    expect(verbose).not.toContain('~12 lines')
+  })
+})

--- a/runtime/tests/tui/components/spinner/Spinner.render.test.tsx
+++ b/runtime/tests/tui/components/spinner/Spinner.render.test.tsx
@@ -1,0 +1,422 @@
+import { PassThrough } from "node:stream";
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  activity: {
+    endCLIActivity: vi.fn(),
+    startCLIActivity: vi.fn(),
+  },
+  appState: {
+    effortValue: "medium",
+    expandedView: undefined as undefined | "tasks" | "teammates",
+    isBriefOnly: false,
+    remoteBackgroundTaskCount: 0,
+    remoteConnectionStatus: "connected",
+    selectedIPAgentIndex: 0,
+    tasks: {} as Record<string, unknown>,
+    viewingAgentTaskId: undefined as string | undefined,
+    viewSelectionMode: "idle",
+  },
+  features: new Set<string>(),
+  getKairosActive: false,
+  getUserMsgOptIn: false,
+  growthbookValue: false,
+  localAgents: [] as Array<{ name: string; status?: string }>,
+  settings: {
+    prefersReducedMotion: false,
+    spinnerTipsEnabled: true,
+  } as { prefersReducedMotion?: boolean; spinnerTipsEnabled?: boolean } | undefined,
+  tasksV2: undefined as undefined | Array<{
+    activeForm?: string;
+    blockedBy: string[];
+    id: string;
+    status: string;
+    subject: string;
+  }>,
+  teammateTasks: [] as Array<Record<string, unknown>>,
+  turnOutputTokens: 0,
+  turnTokenBudget: null as number | null,
+  viewedTeammate: undefined as undefined | Record<string, unknown>,
+  reset() {
+    harness.activity.endCLIActivity.mockClear();
+    harness.activity.startCLIActivity.mockClear();
+    harness.appState = {
+      effortValue: "medium",
+      expandedView: undefined,
+      isBriefOnly: false,
+      remoteBackgroundTaskCount: 0,
+      remoteConnectionStatus: "connected",
+      selectedIPAgentIndex: 0,
+      tasks: {},
+      viewingAgentTaskId: undefined,
+      viewSelectionMode: "idle",
+    };
+    harness.features = new Set();
+    harness.getKairosActive = false;
+    harness.getUserMsgOptIn = false;
+    harness.growthbookValue = false;
+    harness.localAgents = [];
+    harness.settings = {
+      prefersReducedMotion: false,
+      spinnerTipsEnabled: true,
+    };
+    harness.tasksV2 = undefined;
+    harness.teammateTasks = [];
+    harness.turnOutputTokens = 0;
+    harness.turnTokenBudget = null;
+    harness.viewedTeammate = undefined;
+  },
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: (name: string) => harness.features.has(name),
+}));
+
+vi.mock("../../../bootstrap/state.js", () => ({
+  flushInteractionTime: vi.fn(),
+  getCurrentTurnTokenBudget: () => harness.turnTokenBudget,
+  getKairosActive: () => harness.getKairosActive,
+  getTurnOutputTokens: () => harness.turnOutputTokens,
+  getUserMsgOptIn: () => harness.getUserMsgOptIn,
+}));
+
+vi.mock("../../../services/analytics/growthbook.js", () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: () => harness.growthbookValue,
+}));
+
+vi.mock("../../../utils/envUtils.js", () => ({
+  isEnvTruthy: (value: string | undefined) => value === "1" || value === "true",
+}));
+
+vi.mock("lodash-es/sample.js", () => ({
+  default: (items: readonly string[]) => items[0],
+}));
+
+vi.mock("../../../utils/activityManager.js", () => ({
+  activityManager: harness.activity,
+}));
+
+vi.mock("../../../constants/spinnerVerbs.js", () => ({
+  getSpinnerVerbs: () => ["Working"],
+}));
+
+vi.mock("../MessageResponse.js", async () => {
+  const ReactModule = await import("react");
+  return {
+    MessageResponse: ({ children }: { readonly children?: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+  };
+});
+
+vi.mock("../TaskListV2.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../ink.js");
+  return {
+    TaskListV2: ({ tasks }: { readonly tasks: readonly { subject: string }[] }) =>
+      ReactModule.createElement(Text, null, `TaskList:${tasks.map(task => task.subject).join(",")}`),
+  };
+});
+
+vi.mock("../../hooks/useTasksV2.js", () => ({
+  useTasksV2: () => harness.tasksV2,
+}));
+
+vi.mock("../../state/AppState.js", () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+}));
+
+vi.mock("../../hooks/useTerminalSize.js", () => ({
+  useTerminalSize: () => ({ columns: 80, rows: 24 }),
+}));
+
+vi.mock("../../hooks/useSettings.js", () => ({
+  useSettings: () => harness.settings,
+}));
+
+vi.mock("../../../tasks/InProcessTeammateTask/types.js", () => ({
+  isInProcessTeammateTask: (task: { readonly type?: string }) =>
+    task.type === "in_process_teammate",
+}));
+
+vi.mock("../../../tasks/types.js", () => ({
+  isBackgroundTask: (task: { readonly type?: string }) => task.type === "background",
+}));
+
+vi.mock("../../../tasks/InProcessTeammateTask/InProcessTeammateTask.js", () => ({
+  getAllInProcessTeammateTasks: () => harness.teammateTasks,
+}));
+
+vi.mock("../../../utils/effort.js", () => ({
+  getEffortSuffix: () => " · effort",
+}));
+
+vi.mock("../../../utils/model/model.js", () => ({
+  getMainLoopModel: () => "grok-4.3",
+}));
+
+vi.mock("../../state/selectors.js", () => ({
+  getViewedTeammateTask: () => harness.viewedTeammate,
+}));
+
+vi.mock("./SpinnerAnimationRow.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../ink.js");
+  return {
+    SpinnerAnimationRow: (props: Record<string, unknown>) =>
+      ReactModule.createElement(
+        Text,
+        null,
+        `Animation:${String(props.message)}:${String(props.mode)}:${String(props.effortSuffix)}`,
+      ),
+  };
+});
+
+vi.mock("./TeammateSpinnerTree.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../ink.js");
+  return {
+    TeammateSpinnerTree: (props: Record<string, unknown>) =>
+      ReactModule.createElement(
+        Text,
+        null,
+        `Tree:${String(props.leaderVerb ?? props.leaderIdleText ?? "none")}:${String(props.allIdle)}`,
+      ),
+  };
+});
+
+vi.mock("./agentActivity.js", () => ({
+  formatRunningAgentSummary: (agents: readonly { readonly name: string }[]) =>
+    agents.map(agent => agent.name).join(", "),
+  getActiveLocalAgentTasks: () => harness.localAgents,
+}));
+
+import { createRoot } from "../../ink/root.js";
+import { BriefIdleStatus, Spinner, SpinnerWithVerb } from "./Spinner.js";
+
+function createStreams(): {
+  stdout: PassThrough;
+  stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+} {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.resume();
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function renderToText(node: React.ReactNode): Promise<{
+  dispose: () => Promise<void>;
+  output: () => string;
+}> {
+  let output = "";
+  const { stdin, stdout } = createStreams();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+  root.render(node);
+  await sleep();
+  return {
+    dispose: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    },
+    output: () => stripAnsi(output),
+  };
+}
+
+function spinnerProps(overrides: Partial<React.ComponentProps<typeof SpinnerWithVerb>> = {}) {
+  return {
+    loadingStartTimeRef: { current: Date.now() - 10_000 },
+    mode: "processing" as const,
+    pauseStartTimeRef: { current: null },
+    responseLengthRef: { current: 4000 },
+    totalPausedMsRef: { current: 0 },
+    verbose: false,
+    ...overrides,
+  };
+}
+
+describe("Spinner render paths", () => {
+  beforeEach(() => {
+    harness.reset();
+  });
+
+  test("renders the compact spinner glyph", async () => {
+    const rendered = await renderToText(<Spinner />);
+
+    try {
+      expect(rendered.output()).toContain("◐");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("uses brief spinner mode with connection warning and background count", async () => {
+    harness.features.add("KAIROS");
+    harness.getKairosActive = true;
+    harness.appState.isBriefOnly = true;
+    harness.appState.remoteConnectionStatus = "reconnecting";
+    harness.appState.remoteBackgroundTaskCount = 2;
+    harness.appState.tasks = {
+      bg: { type: "background" },
+    };
+
+    const rendered = await renderToText(
+      <SpinnerWithVerb {...spinnerProps({ mode: "thinking", overrideMessage: "Brief work" })} />,
+    );
+
+    try {
+      expect(rendered.output()).toContain("Reconnecting");
+      expect(rendered.output()).toContain("3 in background");
+      expect(harness.activity.startCLIActivity).toHaveBeenCalledWith("spinner-thinking");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("renders normal spinner rows with next task, token budget, and expanded task list", async () => {
+    harness.features.add("TOKEN_BUDGET");
+    harness.turnTokenBudget = 1000;
+    harness.turnOutputTokens = 2000;
+    harness.tasksV2 = [
+      {
+        activeForm: "Coding",
+        blockedBy: [],
+        id: "active",
+        status: "running",
+        subject: "Active task",
+      },
+      {
+        blockedBy: [],
+        id: "next",
+        status: "pending",
+        subject: "Next task",
+      },
+    ];
+
+    const rendered = await renderToText(
+      <SpinnerWithVerb {...spinnerProps({ hasActiveTools: true, spinnerSuffix: "suffix" })} />,
+    );
+
+    try {
+      expect(rendered.output()).toContain("Animation:Coding");
+      expect(rendered.output()).toContain("Target: 2.0k used (1.0k min");
+      expect(rendered.output()).toContain("Next: Next task");
+    } finally {
+      await rendered.dispose();
+    }
+
+    harness.appState.expandedView = "tasks";
+    const expanded = await renderToText(<SpinnerWithVerb {...spinnerProps()} />);
+    try {
+      expect(expanded.output()).toContain("TaskList:Active task,Next task");
+    } finally {
+      await expanded.dispose();
+    }
+  });
+
+  test("renders leader idle, teammate tree, and foregrounded idle teammate states", async () => {
+    harness.localAgents = [{ name: "Fixer" }];
+    harness.teammateTasks = [
+      {
+        isIdle: false,
+        progress: { tokenCount: 1234 },
+        status: "running",
+        type: "in_process_teammate",
+      },
+    ];
+    harness.appState.expandedView = "teammates";
+    harness.appState.viewSelectionMode = "selecting-agent";
+
+    const leaderIdle = await renderToText(
+      <SpinnerWithVerb {...spinnerProps({ leaderIsIdle: true })} />,
+    );
+    try {
+      expect(leaderIdle.output()).toContain("Idle · agents running");
+      expect(leaderIdle.output()).toContain("Fixer");
+      expect(leaderIdle.output()).toContain("Tree:Idle:false");
+    } finally {
+      await leaderIdle.dispose();
+    }
+
+    harness.localAgents = [];
+    harness.appState.viewingAgentTaskId = "agent-1";
+    harness.viewedTeammate = {
+      isIdle: true,
+      startTime: Date.now() - 5000,
+    };
+    harness.teammateTasks = [
+      {
+        isIdle: true,
+        status: "running",
+        type: "in_process_teammate",
+      },
+    ];
+
+    const foregroundedIdle = await renderToText(
+      <SpinnerWithVerb {...spinnerProps({ leaderIsIdle: true })} />,
+    );
+    try {
+      expect(foregroundedIdle.output()).toContain("Worked for");
+      expect(foregroundedIdle.output()).toContain("Tree:Idle:true");
+    } finally {
+      await foregroundedIdle.dispose();
+    }
+  });
+
+  test("renders brief idle status for connection and background agent states", async () => {
+    const empty = await renderToText(<BriefIdleStatus />);
+    try {
+      expect(empty.output().trim()).toBe("");
+    } finally {
+      await empty.dispose();
+    }
+
+    harness.appState.remoteConnectionStatus = "disconnected";
+    harness.localAgents = [{ name: "Builder" }];
+    const disconnected = await renderToText(<BriefIdleStatus />);
+    try {
+      expect(disconnected.output()).toContain("Disconnected");
+      expect(disconnected.output()).toContain("1 agent running");
+    } finally {
+      await disconnected.dispose();
+    }
+
+    harness.appState.remoteConnectionStatus = "connected";
+    harness.localAgents = [];
+    harness.appState.remoteBackgroundTaskCount = 4;
+    const background = await renderToText(<BriefIdleStatus />);
+    try {
+      expect(background.output()).toContain("4 in background");
+    } finally {
+      await background.dispose();
+    }
+  });
+});

--- a/runtime/tests/tui/components/spinner/Spinner.wave200-045.coverage.test.tsx
+++ b/runtime/tests/tui/components/spinner/Spinner.wave200-045.coverage.test.tsx
@@ -1,0 +1,329 @@
+import { PassThrough } from 'node:stream'
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  activity: {
+    endCLIActivity: vi.fn(),
+    startCLIActivity: vi.fn(),
+  },
+  appState: {
+    effortValue: 'medium',
+    expandedView: undefined as undefined | 'tasks' | 'teammates',
+    isBriefOnly: false,
+    remoteBackgroundTaskCount: 0,
+    remoteConnectionStatus: 'connected',
+    selectedIPAgentIndex: 0,
+    tasks: {} as Record<string, unknown>,
+    viewingAgentTaskId: undefined as string | undefined,
+    viewSelectionMode: 'idle',
+  },
+  features: new Set<string>(),
+  settings: {
+    prefersReducedMotion: false,
+    spinnerTipsEnabled: true,
+  } as { prefersReducedMotion?: boolean; spinnerTipsEnabled?: boolean } | undefined,
+  tasksV2: undefined as undefined | Array<{
+    activeForm?: string
+    blockedBy: string[]
+    id: string
+    status: string
+    subject: string
+  }>,
+  teammateTasks: [] as Array<Record<string, unknown>>,
+  turnOutputTokens: 0,
+  turnTokenBudget: null as number | null,
+  viewedTeammate: undefined as undefined | Record<string, unknown>,
+  reset() {
+    harness.activity.endCLIActivity.mockClear()
+    harness.activity.startCLIActivity.mockClear()
+    harness.appState = {
+      effortValue: 'medium',
+      expandedView: undefined,
+      isBriefOnly: false,
+      remoteBackgroundTaskCount: 0,
+      remoteConnectionStatus: 'connected',
+      selectedIPAgentIndex: 0,
+      tasks: {},
+      viewingAgentTaskId: undefined,
+      viewSelectionMode: 'idle',
+    }
+    harness.features = new Set()
+    harness.settings = {
+      prefersReducedMotion: false,
+      spinnerTipsEnabled: true,
+    }
+    harness.tasksV2 = undefined
+    harness.teammateTasks = []
+    harness.turnOutputTokens = 0
+    harness.turnTokenBudget = null
+    harness.viewedTeammate = undefined
+  },
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => harness.features.has(name),
+}))
+
+vi.mock('../../../bootstrap/state.js', () => ({
+  flushInteractionTime: vi.fn(),
+  getCurrentTurnTokenBudget: () => harness.turnTokenBudget,
+  getKairosActive: () => false,
+  getTurnOutputTokens: () => harness.turnOutputTokens,
+  getUserMsgOptIn: () => false,
+}))
+
+vi.mock('../../../services/analytics/growthbook.js', () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: () => false,
+}))
+
+vi.mock('../../../utils/envUtils.js', () => ({
+  isEnvTruthy: (value: string | undefined) => value === '1' || value === 'true',
+}))
+
+vi.mock('lodash-es/sample.js', () => ({
+  default: (items: readonly string[]) => items[0],
+}))
+
+vi.mock('../../../utils/activityManager.js', () => ({
+  activityManager: harness.activity,
+}))
+
+vi.mock('../../../constants/spinnerVerbs.js', () => ({
+  getSpinnerVerbs: () => ['Working'],
+}))
+
+vi.mock('../MessageResponse.js', async () => {
+  const ReactModule = await import('react')
+  return {
+    MessageResponse: ({ children }: { readonly children?: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+  }
+})
+
+vi.mock('../TaskListV2.js', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../../ink.js')
+  return {
+    TaskListV2: ({ tasks }: { readonly tasks: readonly { subject: string }[] }) =>
+      ReactModule.createElement(Text, null, `TaskList:${tasks.map(task => task.subject).join(',')}`),
+  }
+})
+
+vi.mock('../../hooks/useTasksV2.js', () => ({
+  useTasksV2: () => harness.tasksV2,
+}))
+
+vi.mock('../../state/AppState.js', () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+}))
+
+vi.mock('../../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: 80, rows: 24 }),
+}))
+
+vi.mock('../../hooks/useSettings.js', () => ({
+  useSettings: () => harness.settings,
+}))
+
+vi.mock('../../../tasks/InProcessTeammateTask/types.js', () => ({
+  isInProcessTeammateTask: (task: { readonly type?: string }) =>
+    task.type === 'in_process_teammate',
+}))
+
+vi.mock('../../../tasks/types.js', () => ({
+  isBackgroundTask: (task: { readonly type?: string }) => task.type === 'background',
+}))
+
+vi.mock('../../../tasks/InProcessTeammateTask/InProcessTeammateTask.js', () => ({
+  getAllInProcessTeammateTasks: () => harness.teammateTasks,
+}))
+
+vi.mock('../../../utils/effort.js', () => ({
+  getEffortSuffix: () => ' - effort',
+}))
+
+vi.mock('../../../utils/model/model.js', () => ({
+  getMainLoopModel: () => 'grok-4.3',
+}))
+
+vi.mock('../../state/selectors.js', () => ({
+  getViewedTeammateTask: () => harness.viewedTeammate,
+}))
+
+vi.mock('./SpinnerAnimationRow.js', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../../ink.js')
+  return {
+    SpinnerAnimationRow: (props: Record<string, unknown>) =>
+      ReactModule.createElement(
+        Text,
+        null,
+        [
+          'Animation',
+          String(props.message),
+          String(props.mode),
+          `thinking=${String(props.thinkingStatus)}`,
+          `teammateTokens=${String(props.teammateTokens)}`,
+          `hasRunningTeammates=${String(props.hasRunningTeammates)}`,
+        ].join('|'),
+      ),
+  }
+})
+
+vi.mock('./TeammateSpinnerTree.js', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../../ink.js')
+  return {
+    TeammateSpinnerTree: (props: Record<string, unknown>) =>
+      ReactModule.createElement(Text, null, `Tree:${String(props.leaderVerb ?? 'none')}`),
+  }
+})
+
+vi.mock('./agentActivity.js', () => ({
+  formatRunningAgentSummary: (agents: readonly { readonly name: string }[]) =>
+    agents.map(agent => agent.name).join(', '),
+  getActiveLocalAgentTasks: () => [],
+}))
+
+import { createRoot } from '../../ink/root.js'
+import { SpinnerWithVerb } from './Spinner.js'
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+async function flushRender(ms = 25): Promise<void> {
+  await vi.advanceTimersByTimeAsync(ms)
+  await Promise.resolve()
+}
+
+async function renderToText(node: React.ReactNode): Promise<{
+  dispose: () => Promise<void>
+  output: () => string
+  rerender: (nextNode: React.ReactNode) => Promise<void>
+}> {
+  let output = ''
+  const { stdin, stdout } = createStreams()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  root.render(node)
+  await flushRender()
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushRender()
+    },
+    output: () => stripAnsi(output),
+    rerender: async (nextNode: React.ReactNode) => {
+      root.render(nextNode)
+      await flushRender()
+    },
+  }
+}
+
+function spinnerProps(overrides: Partial<React.ComponentProps<typeof SpinnerWithVerb>> = {}) {
+  return {
+    loadingStartTimeRef: { current: Date.now() - 10_000 },
+    mode: 'processing' as const,
+    pauseStartTimeRef: { current: null },
+    responseLengthRef: { current: 4000 },
+    totalPausedMsRef: { current: 0 },
+    verbose: false,
+    ...overrides,
+  }
+}
+
+describe('Spinner wave 200 coverage', () => {
+  beforeEach(() => {
+    harness.reset()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-20T00:00:00.000Z'))
+
+    harness.features.add('TOKEN_BUDGET')
+    harness.turnTokenBudget = 4000
+    harness.turnOutputTokens = 2500
+    harness.tasksV2 = [
+      {
+        activeForm: 'Planning',
+        blockedBy: [],
+        id: 'active',
+        status: 'running',
+        subject: 'Active task',
+      },
+    ]
+    harness.appState.tasks = {
+      teammate: {
+        progress: { tokenCount: 777 },
+        status: 'running',
+        type: 'in_process_teammate',
+      },
+    }
+    harness.teammateTasks = [
+      {
+        isIdle: false,
+        status: 'running',
+        type: 'in_process_teammate',
+      },
+    ]
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('carries thinking duration, budget progress, and teammate tokens into the normal spinner row', async () => {
+    const rendered = await renderToText(
+      <SpinnerWithVerb {...spinnerProps({ mode: 'thinking' })} />,
+    )
+
+    try {
+      expect(rendered.output()).toContain('Animation|Planning')
+      expect(rendered.output()).toContain('|thinking|thinking=thinking|')
+
+      await vi.advanceTimersByTimeAsync(2500)
+      await rendered.rerender(<SpinnerWithVerb {...spinnerProps({ mode: 'processing' })} />)
+
+      const output = rendered.output()
+      const compactOutput = output.replace(/\s+/g, '')
+      expect(output).toContain('|processing|thinking=2525|')
+      expect(output).toContain('teammateTokens=777')
+      expect(compactOutput).toContain('hasRunningTeammates=true')
+      expect(output).toContain('Target: 2.5k / 4.0k (63%)')
+      expect(harness.activity.endCLIActivity).toHaveBeenCalledWith('spinner-thinking')
+      expect(harness.activity.startCLIActivity).toHaveBeenCalledWith('spinner-processing')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/components/spinner/SpinnerAnimationRow.wave200-029.coverage.test.tsx
+++ b/runtime/tests/tui/components/spinner/SpinnerAnimationRow.wave200-029.coverage.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../../utils/staticRender.js'
+import {
+  SpinnerAnimationRow,
+  type SpinnerAnimationRowProps,
+} from './SpinnerAnimationRow.js'
+
+const NOW = new Date('2026-05-20T12:00:00.000Z').getTime()
+
+function props(
+  overrides: Partial<SpinnerAnimationRowProps> = {},
+): SpinnerAnimationRowProps {
+  return {
+    columns: 100,
+    effortSuffix: '',
+    foregroundedTeammate: undefined,
+    hasActiveTools: false,
+    hasRunningTeammates: false,
+    leaderIsIdle: false,
+    loadingStartTimeRef: { current: NOW - 31_000 },
+    message: 'Working',
+    messageColor: 'text',
+    mode: 'responding',
+    overrideColor: null,
+    pauseStartTimeRef: { current: null },
+    reducedMotion: false,
+    responseLengthRef: { current: 16_000 },
+    shimmerColor: 'agencShimmer',
+    spinnerSuffix: null,
+    teammateTokens: 0,
+    thinkingStatus: null,
+    totalPausedMsRef: { current: 0 },
+    verbose: false,
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('SpinnerAnimationRow coverage', () => {
+  test('renders metadata, thinking fallbacks, thought summaries, and foregrounded teammate status', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(NOW)
+
+    const activeTools = await renderToString(
+      <SpinnerAnimationRow
+        {...props({
+          effortSuffix: ' deeply',
+          hasActiveTools: true,
+          spinnerSuffix: 'indexing',
+          teammateTokens: 500,
+          thinkingStatus: 'thinking',
+          verbose: true,
+        })}
+      />,
+      120,
+    )
+
+    expect(activeTools).toContain('◐')
+    expect(activeTools).toContain('Working')
+    expect(activeTools).toContain('indexing')
+    expect(activeTools).toContain('31s')
+    expect(activeTools).toContain('4.5k tokens')
+    expect(activeTools).toContain('thinking deeply')
+
+    const compactThinking = await renderToString(
+      <SpinnerAnimationRow
+        {...props({
+          columns: 20,
+          effortSuffix: ' deeply',
+          loadingStartTimeRef: { current: NOW - 2_000 },
+          message: 'Ask',
+          thinkingStatus: 'thinking',
+        })}
+      />,
+      20,
+    )
+
+    expect(compactThinking).toContain('Ask')
+    expect(compactThinking).toContain('(thinking)')
+    expect(compactThinking).not.toContain('deeply')
+    expect(compactThinking).not.toContain('tokens')
+
+    const thoughtSummary = await renderToString(
+      <SpinnerAnimationRow
+        {...props({
+          loadingStartTimeRef: { current: NOW - 61_000 },
+          mode: 'requesting',
+          responseLengthRef: { current: 400 },
+          thinkingStatus: 1_400,
+          verbose: true,
+        })}
+      />,
+      100,
+    )
+
+    expect(thoughtSummary).toContain('↑')
+    expect(thoughtSummary).toContain('1m 1s')
+    expect(thoughtSummary).toContain('100 tokens')
+    expect(thoughtSummary).toContain('thought for 1s')
+
+    const foregroundedTeammate = await renderToString(
+      <SpinnerAnimationRow
+        {...props({
+          foregroundedTeammate: {
+            identity: {
+              agentName: 'Reviewer',
+              color: 'blue',
+            },
+            isIdle: false,
+            progress: { tokenCount: 9_100 },
+          } as SpinnerAnimationRowProps['foregroundedTeammate'],
+          hasRunningTeammates: true,
+          mode: 'tool-use',
+          responseLengthRef: { current: 20_000 },
+          teammateTokens: 3_000,
+          thinkingStatus: 'thinking',
+          verbose: true,
+        })}
+      />,
+      120,
+    )
+
+    expect(foregroundedTeammate).toContain('◐')
+    expect(foregroundedTeammate).toContain('(esc to interrupt Reviewer)')
+    expect(foregroundedTeammate).not.toContain('9.1k tokens')
+    expect(foregroundedTeammate).not.toContain('thinking')
+  })
+})

--- a/runtime/tests/tui/components/spinner/TeammateSpinnerLine.wave200-086.coverage.test.tsx
+++ b/runtime/tests/tui/components/spinner/TeammateSpinnerLine.wave200-086.coverage.test.tsx
@@ -1,0 +1,206 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { InProcessTeammateTaskState } from '../../../tasks/InProcessTeammateTask/types.js'
+import { renderToString } from '../../../utils/staticRender.js'
+import {
+  getMessagePreview,
+  TeammateSpinnerLine,
+} from './TeammateSpinnerLine.js'
+
+const NOW = new Date('2026-05-20T12:00:00.000Z').getTime()
+
+const terminalSizeMock = vi.hoisted(() => ({
+  size: { columns: 120, rows: 24 },
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('lodash-es/sample.js', () => ({
+  default: <T,>(items: readonly T[]) => items[0],
+}))
+
+vi.mock('../../../constants/spinnerVerbs.js', () => ({
+  getSpinnerVerbs: () => ['Reviewing'],
+}))
+
+vi.mock('../../../constants/turnCompletionVerbs.js', () => ({
+  TURN_COMPLETION_VERBS: ['finished'],
+}))
+
+vi.mock('../../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => terminalSizeMock.size,
+}))
+
+function teammate(
+  overrides: Partial<InProcessTeammateTaskState> = {},
+): InProcessTeammateTaskState {
+  return {
+    awaitingPlanApproval: false,
+    description: 'Review teammate work',
+    id: 'tm-coverage',
+    identity: {
+      agentId: 'reviewer@coverage',
+      agentName: 'reviewer',
+      color: 'blue',
+      parentSessionId: 'leader-session',
+      planModeRequired: false,
+      teamName: 'coverage',
+    },
+    isIdle: false,
+    lastReportedTokenCount: 0,
+    lastReportedToolCount: 0,
+    messages: [],
+    outputFile: '/tmp/tm-coverage.out',
+    outputOffset: 0,
+    pendingUserMessages: [],
+    permissionMode: 'default',
+    progress: {
+      lastActivity: {
+        activityDescription: 'Reading source files',
+      },
+      tokenCount: 1500,
+      toolUseCount: 1,
+    },
+    prompt: 'Review this work',
+    shutdownRequested: false,
+    spinnerVerb: 'Reviewing',
+    startTime: NOW - 73_000,
+    status: 'running',
+    totalPausedMs: 0,
+    type: 'in_process_teammate',
+    notified: false,
+    ...overrides,
+  }
+}
+
+async function renderLine(
+  task: InProcessTeammateTaskState,
+  props: Partial<React.ComponentProps<typeof TeammateSpinnerLine>> = {},
+): Promise<string> {
+  return renderToString(
+    <TeammateSpinnerLine
+      teammate={task}
+      isLast={false}
+      {...props}
+    />,
+    terminalSizeMock.size.columns,
+  )
+}
+
+describe('TeammateSpinnerLine wave 086 coverage', () => {
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(NOW)
+    terminalSizeMock.size = { columns: 120, rows: 24 }
+    process.env.AGENC_TUI_GLYPHS = 'ascii'
+  })
+
+  it('renders teammate line statuses, hints, previews, and compact fallbacks', async () => {
+    expect(getMessagePreview([], 80)).toEqual([])
+    expect(
+      getMessagePreview(
+        [
+          {
+            type: 'assistant',
+            message: {
+              content: [
+                null,
+                {
+                  type: 'tool_use',
+                  name: 'Bash',
+                  input: { command: 'npm test\nignored' },
+                },
+                {
+                  type: 'text',
+                  text: 'old note\n\nnewer note\nnewest note',
+                },
+                { type: 'text', text: 'not reached' },
+              ],
+            },
+          },
+          { type: 'system', message: { content: [] } },
+        ] as never,
+        12,
+      ),
+    ).toEqual(['newer note', 'newest note', 'npm test'])
+
+    const activityOutput = await renderLine(
+      teammate({
+        messages: [
+          {
+            type: 'assistant',
+            message: {
+              content: [
+                {
+                  type: 'tool_use',
+                  name: 'Read',
+                  input: { description: 'Inspect source file' },
+                },
+              ],
+            },
+          },
+        ] as never,
+        progress: {
+          recentActivities: [
+            { isRead: true },
+            { isSearch: true },
+          ],
+          tokenCount: 1500,
+          toolUseCount: 1,
+        },
+      }),
+      { isLast: true, showPreview: true },
+    )
+    expect(activityOutput).toContain('@reviewer')
+    expect(activityOutput).toContain('Searching for 1 pattern')
+    expect(activityOutput).toContain('reading 1 file')
+    expect(activityOutput).toContain('1 tool use')
+    expect(activityOutput).toContain('1.5k tokens')
+    expect(activityOutput).toContain('Inspect source file')
+
+    const selectedOutput = await renderLine(teammate(), {
+      isForegrounded: false,
+      isSelected: true,
+    })
+    expect(selectedOutput).toContain('@reviewer')
+    expect(selectedOutput).toContain('shift +')
+    expect(selectedOutput).toContain('enter to view')
+    expect(selectedOutput).not.toContain('Reading source files')
+
+    const stoppingOutput = await renderLine(
+      teammate({ shutdownRequested: true }),
+    )
+    expect(stoppingOutput).toContain('[stopping]')
+
+    const approvalOutput = await renderLine(
+      teammate({ awaitingPlanApproval: true }),
+    )
+    expect(approvalOutput).toContain('[awaiting approval]')
+
+    const idleOutput = await renderLine(teammate({ isIdle: true }))
+    expect(idleOutput).toContain('Idle for 0s')
+
+    const allIdleOutput = await renderLine(
+      teammate({
+        isIdle: true,
+        pastTenseVerb: 'worked',
+        totalPausedMs: 10_000,
+      }),
+      { allIdle: true, isLast: true },
+    )
+    expect(allIdleOutput).toContain('worked for 1m 3s')
+
+    terminalSizeMock.size = { columns: 30, rows: 24 }
+    const compactOutput = await renderLine(
+      teammate({
+        progress: undefined,
+        spinnerVerb: undefined,
+      }),
+    )
+    expect(compactOutput).toContain('Reviewing')
+    expect(compactOutput).not.toContain('@reviewer')
+    expect(compactOutput).not.toContain('tokens')
+  })
+})

--- a/runtime/tests/tui/components/spinner/TeammateSpinnerTree.wave200-067.coverage.test.tsx
+++ b/runtime/tests/tui/components/spinner/TeammateSpinnerTree.wave200-067.coverage.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { renderToString } from "../../../utils/staticRender.js";
+import { TeammateSpinnerTree } from "./TeammateSpinnerTree.js";
+
+const harness = vi.hoisted(() => ({
+  state: {
+    showTeammateMessagePreview: false,
+    tasks: {} as Record<string, unknown>,
+    viewingAgentTaskId: "beta" as string | undefined,
+  },
+}));
+
+vi.mock("../../state/AppState.js", () => ({
+  useAppState: (selector: (state: typeof harness.state) => unknown) =>
+    selector(harness.state),
+}));
+
+function makeTeammateTask(id: string, agentName: string) {
+  return {
+    awaitingPlanApproval: false,
+    id,
+    identity: {
+      agentId: `${agentName}@alpha`,
+      agentName,
+      parentSessionId: "leader-session",
+      planModeRequired: false,
+      teamName: "alpha",
+    },
+    isIdle: false,
+    lastReportedTokenCount: 0,
+    lastReportedToolCount: 0,
+    messages: [
+      {
+        type: "assistant",
+        message: {
+          content: [{ type: "text", text: `recent ${agentName} work` }],
+        },
+      },
+    ],
+    pendingUserMessages: [],
+    permissionMode: "acceptEdits",
+    progress: {
+      lastActivity: {
+        activityDescription: `Working as ${agentName}`,
+      },
+      tokenCount: 1234,
+      toolUseCount: 1,
+    },
+    prompt: "do the work",
+    shutdownRequested: false,
+    spinnerVerb: `Thinking as ${agentName}`,
+    startTime: Date.now() - 5_000,
+    status: "running",
+    totalPausedMs: 0,
+    type: "in_process_teammate",
+  };
+}
+
+describe("TeammateSpinnerTree wave 200 coverage", () => {
+  beforeEach(() => {
+    harness.state = {
+      showTeammateMessagePreview: false,
+      tasks: {
+        alpha: makeTeammateTask("alpha", "Alpha"),
+        beta: makeTeammateTask("beta", "Beta"),
+      },
+      viewingAgentTaskId: "beta",
+    };
+  });
+
+  test("renders a selected background leader while keeping the hide row unselected", async () => {
+    const output = await renderToString(
+      <TeammateSpinnerTree
+        isInSelectionMode={true}
+        leaderTokenCount={0}
+        leaderVerb="coordinating"
+        selectedIndex={-1}
+      />,
+      120,
+    );
+
+    expect(output).toContain("team-lead: coordinating");
+    expect(output).toContain("enter to view");
+    expect(output).toContain("hide");
+    expect(output).not.toContain("enter to collapse");
+    expect(output).not.toContain("0 tokens");
+    expect(output).toContain("@Alpha");
+    expect(output).toContain("Working as Alpha");
+    expect(output).toContain("@Beta");
+    expect(output.indexOf("@Alpha")).toBeLessThan(output.indexOf("@Beta"));
+    expect(output).not.toContain("recent Alpha work");
+  });
+});

--- a/runtime/tests/tui/components/spinner/utils.wave200-128.coverage.test.ts
+++ b/runtime/tests/tui/components/spinner/utils.wave200-128.coverage.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import {
+  computeBriefRightStatusLayout,
+  getDefaultCharacters,
+  hueToRgb,
+  parseRGB,
+  truncateSpinnerText,
+} from './utils.js'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+function withPlatform<T>(platform: NodeJS.Platform, callback: () => T): T {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    enumerable: true,
+    value: platform,
+  })
+  try {
+    return callback()
+  } finally {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+  }
+}
+
+describe('spinner utility coverage edges', () => {
+  test('handles narrow layouts, unicode frame fallbacks, hue sectors, and cached RGB parsing', () => {
+    expect(withPlatform('linux', () => getDefaultCharacters({ TERM: 'xterm-256color' }))).toEqual([
+      '·',
+      '✢',
+      '*',
+      '✶',
+      '✻',
+      '✽',
+    ])
+    expect(withPlatform('darwin', () => getDefaultCharacters({ TERM: 'xterm-256color' }))).toEqual([
+      '·',
+      '✢',
+      '✳',
+      '✶',
+      '✻',
+      '✽',
+    ])
+
+    expect(truncateSpinnerText('waiting', 0, '...')).toBe('')
+    expect(truncateSpinnerText('waiting', 2, '...')).toBe('..')
+
+    expect(computeBriefRightStatusLayout(20, 4, '')).toEqual({
+      pad: 0,
+      rightText: '',
+    })
+    expect(computeBriefRightStatusLayout(10, 5, 'busy')).toEqual({
+      pad: 0,
+      rightText: '',
+    })
+    expect(computeBriefRightStatusLayout(20, 4, '\u200b')).toEqual({
+      pad: 0,
+      rightText: '',
+    })
+
+    expect(hueToRgb(60)).toEqual({ r: 224, g: 224, b: 82 })
+    expect(hueToRgb(180)).toEqual({ r: 82, g: 224, b: 224 })
+    expect(hueToRgb(240)).toEqual({ r: 82, g: 82, b: 224 })
+    expect(hueToRgb(300)).toEqual({ r: 224, g: 82, b: 224 })
+
+    const parsed = parseRGB('rgb(9, 8, 7)')
+    expect(parsed).toEqual({ r: 9, g: 8, b: 7 })
+    expect(parseRGB('rgb(9, 8, 7)')).toBe(parsed)
+  })
+})

--- a/runtime/tests/tui/components/tasks/BackgroundTaskStatus.coverage.test.tsx
+++ b/runtime/tests/tui/components/tasks/BackgroundTaskStatus.coverage.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { renderToString } from '../../../utils/staticRender.js'
+
+const appStateMock = vi.hoisted(() => ({
+  state: {
+    expandedView: undefined as string | undefined,
+    tasks: {} as Record<string, unknown>,
+    viewingAgentTaskId: undefined as string | undefined,
+  },
+  setAppState: vi.fn(),
+}))
+
+const terminalSizeMock = vi.hoisted(() => ({
+  size: { columns: 80, rows: 24 },
+}))
+
+vi.mock('../../state/AppState.js', () => ({
+  useAppState: (selector: (state: typeof appStateMock.state) => unknown) =>
+    selector(appStateMock.state),
+  useSetAppState: () => appStateMock.setAppState,
+}))
+
+vi.mock('../../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => terminalSizeMock.size,
+}))
+
+function teammateTask(id: string, agentName: string, isIdle = false) {
+  return {
+    id,
+    type: 'in_process_teammate',
+    status: 'running',
+    description: agentName,
+    startTime: 10,
+    outputFile: `urn:agenc:task:${id}:output`,
+    outputOffset: 0,
+    notified: false,
+    identity: {
+      agentId: id,
+      agentName,
+      teamName: 'team',
+      color: 'cyan',
+      planModeRequired: false,
+      parentSessionId: 'parent',
+    },
+    prompt: 'help',
+    awaitingPlanApproval: false,
+    permissionMode: 'default',
+    pendingUserMessages: [],
+    isIdle,
+    shutdownRequested: false,
+    lastReportedToolCount: 0,
+    lastReportedTokenCount: 0,
+  }
+}
+
+describe('BackgroundTaskStatus coverage', () => {
+  const originalGlyphMode = process.env.AGENC_TUI_GLYPHS
+
+  beforeEach(() => {
+    process.env.AGENC_TUI_GLYPHS = 'ascii'
+    appStateMock.state = {
+      expandedView: undefined,
+      tasks: {},
+      viewingAgentTaskId: undefined,
+    }
+    appStateMock.setAppState.mockClear()
+    terminalSizeMock.size = { columns: 18, rows: 24 }
+  })
+
+  afterEach(() => {
+    if (originalGlyphMode === undefined) {
+      delete process.env.AGENC_TUI_GLYPHS
+    } else {
+      process.env.AGENC_TUI_GLYPHS = originalGlyphMode
+    }
+  })
+
+  it('keeps the selected teammate visible in a narrow scrollable footer', async () => {
+    appStateMock.state = {
+      ...appStateMock.state,
+      viewingAgentTaskId: 'charlie',
+      tasks: {
+        alpha: teammateTask('alpha', 'alpha-agent'),
+        bravo: teammateTask('bravo', 'bravo-agent'),
+        charlie: teammateTask('charlie', 'charlie-agent'),
+        delta: teammateTask('delta', 'delta-agent', true),
+      },
+    }
+
+    const { BackgroundTaskStatus } = await import('./BackgroundTaskStatus.js')
+    const output = await renderToString(
+      <BackgroundTaskStatus tasksSelected teammateFooterIndex={3} />,
+      18,
+    )
+
+    expect(output).toContain('<')
+    expect(output).toContain('>')
+    expect(output).toContain('@charlie')
+    expect(output).not.toContain('@alpha-agent')
+    expect(output).not.toContain('shift + down to expand')
+  })
+})

--- a/runtime/tests/tui/components/tasks/BackgroundTaskStatus.wave200-023.coverage.test.tsx
+++ b/runtime/tests/tui/components/tasks/BackgroundTaskStatus.wave200-023.coverage.test.tsx
@@ -1,0 +1,358 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { DOMElement, DOMNode } from '../../ink/dom.js'
+import instances from '../../ink/instances.js'
+import { createRoot } from '../../ink/root.js'
+
+const appStateMock = vi.hoisted(() => ({
+  state: {
+    expandedView: undefined as string | undefined,
+    tasks: {} as Record<string, unknown>,
+    viewingAgentTaskId: undefined as string | undefined,
+  },
+  setAppState: vi.fn(),
+}))
+
+const terminalSizeMock = vi.hoisted(() => ({
+  size: { columns: 120, rows: 24 },
+}))
+
+const teammateViewMock = vi.hoisted(() => ({
+  enterTeammateView: vi.fn(),
+  exitTeammateView: vi.fn(),
+}))
+
+vi.mock('../../state/AppState.js', () => ({
+  useAppState: (selector: (state: typeof appStateMock.state) => unknown) =>
+    selector(appStateMock.state),
+  useSetAppState: () => appStateMock.setAppState,
+}))
+
+vi.mock('../../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => terminalSizeMock.size,
+}))
+
+vi.mock('../../state/teammateViewHelpers.js', () => teammateViewMock)
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type StyledText = {
+  text: string
+  styles: Record<string, unknown>
+}
+
+const originalGlyphMode = process.env.AGENC_TUI_GLYPHS
+
+function createStreams(): { stdin: TestStdin; stdout: PassThrough } {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStdin
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.on('data', () => {})
+  ;(stdout as unknown as { columns: number }).columns = 120
+  ;(stdout as unknown as { rows: number }).rows = 24
+  ;(stdout as unknown as { isTTY: boolean }).isTTY = true
+
+  return { stdin, stdout }
+}
+
+function teammateTask(
+  id: string,
+  agentName: string,
+  options: { color?: string; isIdle?: boolean } = {},
+) {
+  return {
+    id,
+    type: 'in_process_teammate',
+    status: 'running',
+    description: agentName,
+    startTime: 10,
+    outputFile: `urn:agenc:task:${id}:output`,
+    outputOffset: 0,
+    notified: false,
+    identity: {
+      agentId: id,
+      agentName,
+      teamName: 'team',
+      color: options.color,
+      planModeRequired: false,
+      parentSessionId: 'parent',
+    },
+    prompt: 'help',
+    awaitingPlanApproval: false,
+    permissionMode: 'default',
+    pendingUserMessages: [],
+    isIdle: options.isIdle ?? false,
+    shutdownRequested: false,
+    lastReportedToolCount: 0,
+    lastReportedTokenCount: 0,
+  }
+}
+
+function shellTask(id: string) {
+  return {
+    id,
+    type: 'local_bash',
+    status: 'running',
+    description: id,
+    startTime: 10,
+    outputFile: `urn:agenc:task:${id}:output`,
+    outputOffset: 0,
+    notified: false,
+    command: 'npm test',
+    kind: 'bash',
+  }
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+  if (!instance?.rootNode) {
+    throw new Error('Ink root node not found')
+  }
+  return instance.rootNode
+}
+
+function collectText(node: DOMNode): string {
+  if (node.nodeName === '#text') return node.nodeValue
+  return node.childNodes.map(collectText).join('')
+}
+
+function collectStyledText(
+  node: DOMNode,
+  inheritedStyles: Record<string, unknown> = {},
+  found: StyledText[] = [],
+): StyledText[] {
+  if (node.nodeName === '#text') {
+    if (node.nodeValue.length > 0) {
+      found.push({ text: node.nodeValue, styles: inheritedStyles })
+    }
+    return found
+  }
+
+  const nextStyles = node.textStyles
+    ? { ...inheritedStyles, ...node.textStyles }
+    : inheritedStyles
+
+  for (const child of node.childNodes) {
+    collectStyledText(child, nextStyles, found)
+  }
+  return found
+}
+
+function textStyles(rootNode: DOMElement, text: string): Record<string, unknown> {
+  const segment = collectStyledText(rootNode).find(item => item.text === text)
+  if (!segment) throw new Error(`Text segment not found: ${text}`)
+  return segment.styles
+}
+
+function findBoxByText(node: DOMNode, text: string): DOMElement | undefined {
+  if (
+    node.nodeName !== '#text' &&
+    node.nodeName === 'ink-box' &&
+    collectText(node).includes(text)
+  ) {
+    return node
+  }
+  if (node.nodeName === '#text') return undefined
+  for (const child of node.childNodes) {
+    const found = findBoxByText(child, text)
+    if (found) return found
+  }
+  return undefined
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < 2_000) {
+    if (predicate()) return
+    await sleep(10)
+  }
+  throw new Error(message)
+}
+
+describe('BackgroundTaskStatus wave 200 coverage', () => {
+  beforeEach(() => {
+    process.env.AGENC_TUI_GLYPHS = 'unicode'
+    appStateMock.state = {
+      expandedView: undefined,
+      tasks: {},
+      viewingAgentTaskId: undefined,
+    }
+    appStateMock.setAppState.mockClear()
+    teammateViewMock.enterTeammateView.mockClear()
+    teammateViewMock.exitTeammateView.mockClear()
+    terminalSizeMock.size = { columns: 120, rows: 24 }
+  })
+
+  afterEach(() => {
+    if (originalGlyphMode === undefined) {
+      delete process.env.AGENC_TUI_GLYPHS
+    } else {
+      process.env.AGENC_TUI_GLYPHS = originalGlyphMode
+    }
+  })
+
+  test('wires hover and click handlers for teammate and summary pills', async () => {
+    const { BackgroundTaskStatus } = await import('./BackgroundTaskStatus.js')
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      appStateMock.state = {
+        expandedView: undefined,
+        viewingAgentTaskId: 'active-red',
+        tasks: {
+          idle: teammateTask('idle', 'aaa-idle', {
+            color: 'ultraviolet',
+            isIdle: true,
+          }),
+          plain: teammateTask('plain', 'mmm-plain'),
+          active: teammateTask('active-red', 'zzz-active', { color: 'red' }),
+        },
+      }
+
+      root.render(
+        <BackgroundTaskStatus tasksSelected={false} isLeaderIdle={true} />,
+      )
+      await waitForCondition(
+        () => collectText(getRootNode(stdout)).includes('@zzz-active'),
+        'teammate footer did not render',
+      )
+
+      let rootNode = getRootNode(stdout)
+      const teammateText = collectText(rootNode)
+      expect(teammateText.indexOf('@zzz-active')).toBeLessThan(
+        teammateText.indexOf('@aaa-idle'),
+      )
+      expect(teammateText).toContain('shift +')
+      expect(teammateText).toContain('to expand')
+      const activeColor = textStyles(rootNode, '@zzz-active').color
+      const activeInitialStyles = { ...textStyles(rootNode, '@zzz-active') }
+      const idleInitialStyles = { ...textStyles(rootNode, '@aaa-idle') }
+      expect(activeColor).toBeTypeOf('string')
+
+      const mainBox = findBoxByText(rootNode, '@main')
+      const activeBox = findBoxByText(rootNode, '@zzz-active')
+      expect(mainBox?._eventHandlers?.onClick).toBeTypeOf('function')
+      expect(activeBox?._eventHandlers?.onClick).toBeTypeOf('function')
+
+      ;(activeBox?._eventHandlers?.onClick as (() => void) | undefined)?.()
+      expect(teammateViewMock.enterTeammateView).toHaveBeenCalledWith(
+        'active-red',
+        appStateMock.setAppState,
+      )
+
+      ;(mainBox?._eventHandlers?.onClick as (() => void) | undefined)?.()
+      expect(teammateViewMock.exitTeammateView).toHaveBeenCalledWith(
+        appStateMock.setAppState,
+      )
+
+      ;(mainBox?._eventHandlers?.onMouseEnter as (() => void) | undefined)?.()
+      await waitForCondition(
+        () => textStyles(getRootNode(stdout), '@main').inverse === true,
+        'main pill hover style did not apply',
+      )
+      const hoveredMainBox = findBoxByText(getRootNode(stdout), '@main')
+      expect(hoveredMainBox?._eventHandlers?.onMouseLeave).toBeTypeOf(
+        'function',
+      )
+      ;(hoveredMainBox?._eventHandlers?.onMouseLeave as
+        | (() => void)
+        | undefined)?.()
+      await waitForCondition(
+        () => textStyles(getRootNode(stdout), '@main').inverse !== true,
+        'main pill hover style did not clear',
+      )
+
+      ;(activeBox?._eventHandlers?.onMouseEnter as (() => void) | undefined)?.()
+      await waitForCondition(
+        () =>
+          textStyles(getRootNode(stdout), '@zzz-active').backgroundColor ===
+          activeColor,
+        'active pill hover style did not apply',
+      )
+      const hoveredActiveBox = findBoxByText(getRootNode(stdout), '@zzz-active')
+      expect(hoveredActiveBox?._eventHandlers?.onMouseLeave).toBeTypeOf(
+        'function',
+      )
+      ;(hoveredActiveBox?._eventHandlers?.onMouseLeave as
+        | (() => void)
+        | undefined)?.()
+      await waitForCondition(
+        () =>
+          textStyles(getRootNode(stdout), '@zzz-active').color ===
+          activeColor,
+        'active pill hover style did not clear',
+      )
+
+      const onOpenDialog = vi.fn()
+      appStateMock.state = {
+        expandedView: undefined,
+        viewingAgentTaskId: undefined,
+        tasks: {
+          shell: shellTask('shell'),
+        },
+      }
+      root.render(
+        <BackgroundTaskStatus
+          tasksSelected={false}
+          onOpenDialog={onOpenDialog}
+        />,
+      )
+      await waitForCondition(
+        () => collectText(getRootNode(stdout)).includes('1 shell'),
+        'summary pill did not render',
+      )
+
+      rootNode = getRootNode(stdout)
+      const summaryBox = findBoxByText(rootNode, '1 shell')
+      expect(summaryBox?._eventHandlers?.onClick).toBeTypeOf('function')
+      ;(summaryBox?._eventHandlers?.onMouseEnter as
+        | (() => void)
+        | undefined)?.()
+      await waitForCondition(
+        () => textStyles(getRootNode(stdout), '1 shell').inverse === true,
+        'summary pill hover style did not apply',
+      )
+      ;(summaryBox?._eventHandlers?.onClick as (() => void) | undefined)?.()
+      expect(onOpenDialog).toHaveBeenCalledTimes(1)
+      ;(summaryBox?._eventHandlers?.onMouseLeave as
+        | (() => void)
+        | undefined)?.()
+      await waitForCondition(
+        () => textStyles(getRootNode(stdout), '1 shell').inverse !== true,
+        'summary pill hover style did not clear',
+      )
+
+      expect(activeInitialStyles).toMatchObject({ bold: true })
+      expect(idleInitialStyles).not.toHaveProperty('bold')
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+})

--- a/runtime/tests/tui/components/tasks/BackgroundTasksPanel.coverage.test.tsx
+++ b/runtime/tests/tui/components/tasks/BackgroundTasksPanel.coverage.test.tsx
@@ -1,0 +1,159 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { renderToString } from '../../../utils/staticRender.js'
+
+const appStateMock = vi.hoisted(() => ({
+  state: { tasks: {} as Record<string, unknown> },
+  setAppState: vi.fn(),
+}))
+
+const inputHandler = vi.hoisted(() => ({
+  current: undefined as
+    | undefined
+    | ((input: string, key: Record<string, boolean>) => void),
+}))
+
+const terminalSizeMock = vi.hoisted(() => ({
+  size: { columns: 120, rows: 32 },
+}))
+
+const killTaskMock = vi.hoisted(() => vi.fn())
+const killAsyncAgentMock = vi.hoisted(() => vi.fn())
+const requestTeammateShutdownMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../state/AppState.js', () => ({
+  useAppState: (selector: (state: typeof appStateMock.state) => unknown) =>
+    selector(appStateMock.state),
+  useSetAppState: () => appStateMock.setAppState,
+}))
+
+vi.mock('../../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => terminalSizeMock.size,
+}))
+
+vi.mock('../../ink.js', async () => {
+  const actual = await vi.importActual<typeof import('../../ink.js')>(
+    '../../ink.js',
+  )
+  return {
+    ...actual,
+    useInput: (
+      handler: (input: string, key: Record<string, boolean>) => void,
+    ) => {
+      inputHandler.current = handler
+    },
+  }
+})
+
+vi.mock('../../../tasks/LocalShellTask/killShellTasks.js', () => ({
+  killTask: killTaskMock,
+}))
+
+vi.mock('../../../tasks/LocalAgentTask/LocalAgentTask.js', () => ({
+  killAsyncAgent: killAsyncAgentMock,
+}))
+
+vi.mock('../../../tasks/InProcessTeammateTask/InProcessTeammateTask.js', () => ({
+  requestTeammateShutdown: requestTeammateShutdownMock,
+}))
+
+function key(overrides: Record<string, boolean> = {}) {
+  return {
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    return: false,
+    escape: false,
+    ...overrides,
+  }
+}
+
+function makeTeammateTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'teammate-1',
+    type: 'in_process_teammate',
+    status: 'running',
+    description: 'Review implementation plan',
+    startTime: Date.now() - 72_000,
+    outputFile: 'urn:agenc:task:teammate-1:output',
+    outputOffset: 0,
+    notified: false,
+    identity: {
+      agentId: 'agent-reviewer',
+      agentName: 'Reviewer',
+      teamName: 'planning',
+      planModeRequired: true,
+      parentSessionId: 'parent-session',
+    },
+    prompt: 'Review the staged changes',
+    model: 'review-model',
+    awaitingPlanApproval: true,
+    permissionMode: 'plan',
+    pendingUserMessages: ['Please check edge cases'],
+    messages: [{ role: 'assistant', content: 'Found one ordering issue' }],
+    progress: {
+      toolUseCount: 3,
+      tokenCount: 1200,
+      lastActivity: {
+        activityDescription: 'reading related tests',
+      },
+      recentActivities: [
+        { toolName: 'read', input: { path: 'runtime/src/tui' } },
+      ],
+    },
+    isIdle: false,
+    shutdownRequested: true,
+    lastReportedToolCount: 3,
+    lastReportedTokenCount: 1200,
+    ...overrides,
+  }
+}
+
+describe('BackgroundTasksPanel coverage', () => {
+  beforeEach(() => {
+    appStateMock.state = { tasks: {} }
+    appStateMock.setAppState.mockClear()
+    terminalSizeMock.size = { columns: 120, rows: 32 }
+    inputHandler.current = undefined
+    killTaskMock.mockClear()
+    killAsyncAgentMock.mockClear()
+    requestTeammateShutdownMock.mockClear()
+  })
+
+  it('renders teammate detail rows and stops the selected teammate task', async () => {
+    appStateMock.state = {
+      tasks: {
+        'teammate-1': makeTeammateTask(),
+      },
+    }
+
+    const { BackgroundTasksPanel } = await import('./BackgroundTasksPanel.js')
+
+    const output = await renderToString(
+      <BackgroundTasksPanel initialDetailTaskId="teammate-1" />,
+      120,
+    )
+
+    expect(output).toContain('TASK DETAIL')
+    expect(output).toContain('identity')
+    expect(output).toContain('Reviewer · agent-reviewer')
+    expect(output).toContain('awaiting plan approval')
+    expect(output).toContain('shutdown requested')
+    expect(output).toContain('reading related tests')
+    expect(output).toContain('Please check edge cases')
+
+    if (!inputHandler.current) {
+      throw new Error('BackgroundTasksPanel did not register input handling')
+    }
+    inputHandler.current('x', key())
+
+    expect(requestTeammateShutdownMock).toHaveBeenCalledWith(
+      'teammate-1',
+      appStateMock.setAppState,
+    )
+    expect(killTaskMock).not.toHaveBeenCalled()
+    expect(killAsyncAgentMock).not.toHaveBeenCalled()
+  })
+})

--- a/runtime/tests/tui/components/tasks/BackgroundTasksPanel.coverage2.test.tsx
+++ b/runtime/tests/tui/components/tasks/BackgroundTasksPanel.coverage2.test.tsx
@@ -1,0 +1,162 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { renderToString } from '../../../utils/staticRender.js'
+
+const appStateMock = vi.hoisted(() => ({
+  state: { tasks: {} as Record<string, unknown> },
+  setAppState: vi.fn(),
+}))
+
+const inputHandler = vi.hoisted(() => ({
+  current: undefined as
+    | undefined
+    | ((input: string, key: Record<string, boolean>) => void),
+}))
+
+const terminalSizeMock = vi.hoisted(() => ({
+  size: { columns: 120, rows: 32 },
+}))
+
+const killTaskMock = vi.hoisted(() => vi.fn())
+const killAsyncAgentMock = vi.hoisted(() => vi.fn())
+const requestTeammateShutdownMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../state/AppState.js', () => ({
+  useAppState: (selector: (state: typeof appStateMock.state) => unknown) =>
+    selector(appStateMock.state),
+  useSetAppState: () => appStateMock.setAppState,
+}))
+
+vi.mock('../../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => terminalSizeMock.size,
+}))
+
+vi.mock('../../ink.js', async () => {
+  const actual = await vi.importActual<typeof import('../../ink.js')>(
+    '../../ink.js',
+  )
+  return {
+    ...actual,
+    useInput: (
+      handler: (input: string, key: Record<string, boolean>) => void,
+    ) => {
+      inputHandler.current = handler
+    },
+  }
+})
+
+vi.mock('../../../tasks/LocalShellTask/killShellTasks.js', () => ({
+  killTask: killTaskMock,
+}))
+
+vi.mock('../../../tasks/LocalAgentTask/LocalAgentTask.js', () => ({
+  killAsyncAgent: killAsyncAgentMock,
+}))
+
+vi.mock('../../../tasks/InProcessTeammateTask/InProcessTeammateTask.js', () => ({
+  requestTeammateShutdown: requestTeammateShutdownMock,
+}))
+
+function key(overrides: Record<string, boolean> = {}) {
+  return {
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    return: false,
+    escape: false,
+    ...overrides,
+  }
+}
+
+function makeLocalAgentTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'local-agent-task',
+    type: 'local_agent',
+    status: 'running',
+    description: 'Local agent background work',
+    startTime: Date.now() - 45_000,
+    outputFile: 'urn:agenc:task:local-agent-task:output',
+    outputOffset: 0,
+    notified: false,
+    agentId: 'local-agent-1',
+    agentType: 'planner',
+    model: 'local-model',
+    prompt: 'Review the task queue',
+    retrieved: false,
+    pendingMessages: ['Follow up once complete'],
+    messages: ['Captured implementation notes'],
+    error: 'retryable tool failure',
+    result: { summary: 'ready' },
+    progress: {
+      toolUseCount: 2,
+      tokenCount: 3456,
+      recentActivities: [
+        {
+          toolName: 'read',
+          input: {
+            path: 'runtime/src/tui/components/tasks/BackgroundTasksPanel.tsx',
+          },
+        },
+      ],
+    },
+    lastReportedToolCount: 2,
+    lastReportedTokenCount: 3456,
+    isBackgrounded: true,
+    retain: false,
+    diskLoaded: false,
+    ...overrides,
+  }
+}
+
+describe('BackgroundTasksPanel local agent coverage', () => {
+  beforeEach(() => {
+    appStateMock.state = { tasks: {} }
+    appStateMock.setAppState.mockClear()
+    terminalSizeMock.size = { columns: 120, rows: 32 }
+    inputHandler.current = undefined
+    killTaskMock.mockClear()
+    killAsyncAgentMock.mockClear()
+    requestTeammateShutdownMock.mockClear()
+  })
+
+  it('renders local agent detail rows and stops the selected local agent task', async () => {
+    appStateMock.state = {
+      tasks: {
+        'local-agent-task': makeLocalAgentTask(),
+      },
+    }
+
+    const { BackgroundTasksPanel } = await import('./BackgroundTasksPanel.js')
+
+    const output = await renderToString(
+      <BackgroundTasksPanel initialDetailTaskId="local-agent-task" />,
+      120,
+    )
+
+    expect(output).toContain('TASK DETAIL')
+    expect(output).toContain('local-agent-1 · planner')
+    expect(output).toContain('local-model')
+    expect(output).toContain('Review the task queue')
+    expect(output).toContain('Follow up once complete')
+    expect(output).toContain('Captured implementation notes')
+    expect(output).toContain('retryable tool failure')
+    expect(output).toContain('"summary":"ready"')
+    expect(output).toContain(
+      'read {"path":"runtime/src/tui/components/tasks/BackgroundTasksPanel.tsx"}',
+    )
+
+    if (!inputHandler.current) {
+      throw new Error('BackgroundTasksPanel did not register input handling')
+    }
+    inputHandler.current('x', key())
+
+    expect(killAsyncAgentMock).toHaveBeenCalledWith(
+      'local-agent-task',
+      appStateMock.setAppState,
+    )
+    expect(killTaskMock).not.toHaveBeenCalled()
+    expect(requestTeammateShutdownMock).not.toHaveBeenCalled()
+  })
+})

--- a/runtime/tests/tui/components/tasks/BackgroundTasksPanel.wave200-017.coverage.test.tsx
+++ b/runtime/tests/tui/components/tasks/BackgroundTasksPanel.wave200-017.coverage.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { renderToString } from '../../../utils/staticRender.js'
+
+const appStateMock = vi.hoisted(() => ({
+  state: { tasks: {} as Record<string, unknown> },
+  setAppState: vi.fn(),
+}))
+
+const inputHandler = vi.hoisted(() => ({
+  current: undefined as
+    | undefined
+    | ((input: string, key: Record<string, boolean>) => void),
+}))
+
+const terminalSizeMock = vi.hoisted(() => ({
+  size: { columns: 80, rows: 24 },
+}))
+
+const killTaskMock = vi.hoisted(() => vi.fn())
+const killAsyncAgentMock = vi.hoisted(() => vi.fn())
+const requestTeammateShutdownMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../state/AppState.js', () => ({
+  useAppState: (selector: (state: typeof appStateMock.state) => unknown) =>
+    selector(appStateMock.state),
+  useSetAppState: () => appStateMock.setAppState,
+}))
+
+vi.mock('../../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => terminalSizeMock.size,
+}))
+
+vi.mock('../../ink.js', async () => {
+  const actual = await vi.importActual<typeof import('../../ink.js')>(
+    '../../ink.js',
+  )
+  return {
+    ...actual,
+    useInput: (
+      handler: (input: string, key: Record<string, boolean>) => void,
+    ) => {
+      inputHandler.current = handler
+    },
+  }
+})
+
+vi.mock('../../../tasks/LocalShellTask/killShellTasks.js', () => ({
+  killTask: killTaskMock,
+}))
+
+vi.mock('../../../tasks/LocalAgentTask/LocalAgentTask.js', () => ({
+  killAsyncAgent: killAsyncAgentMock,
+}))
+
+vi.mock('../../../tasks/InProcessTeammateTask/InProcessTeammateTask.js', () => ({
+  requestTeammateShutdown: requestTeammateShutdownMock,
+}))
+
+function key(overrides: Record<string, boolean> = {}) {
+  return {
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    return: false,
+    escape: false,
+    ...overrides,
+  }
+}
+
+describe('BackgroundTasksPanel empty state coverage', () => {
+  beforeEach(() => {
+    appStateMock.state = { tasks: {} }
+    appStateMock.setAppState.mockClear()
+    terminalSizeMock.size = { columns: 80, rows: 24 }
+    inputHandler.current = undefined
+    killTaskMock.mockClear()
+    killAsyncAgentMock.mockClear()
+    requestTeammateShutdownMock.mockClear()
+  })
+
+  it('renders the empty panel and only dismisses on explicit quit input', async () => {
+    const onDone = vi.fn()
+    const { BackgroundTasksPanel } = await import('./BackgroundTasksPanel.js')
+
+    const output = await renderToString(
+      <BackgroundTasksPanel onDone={onDone} />,
+      80,
+    )
+
+    expect(output).toContain('BACKGROUND TASKS')
+    expect(output).toContain('0 running')
+    expect(output).toContain('0 finished')
+    expect(output).toContain('No background tasks')
+
+    if (!inputHandler.current) {
+      throw new Error('BackgroundTasksPanel did not register input handling')
+    }
+
+    inputHandler.current('', key())
+    expect(onDone).not.toHaveBeenCalled()
+
+    inputHandler.current('q', key())
+    expect(onDone).toHaveBeenCalledTimes(1)
+
+    inputHandler.current('', key({ escape: true }))
+    expect(onDone).toHaveBeenCalledTimes(2)
+    expect(killTaskMock).not.toHaveBeenCalled()
+    expect(killAsyncAgentMock).not.toHaveBeenCalled()
+    expect(requestTeammateShutdownMock).not.toHaveBeenCalled()
+  })
+})

--- a/runtime/tests/tui/components/tasks/taskStatusUtils.wave200-050.coverage.test.tsx
+++ b/runtime/tests/tui/components/tasks/taskStatusUtils.wave200-050.coverage.test.tsx
@@ -1,0 +1,128 @@
+import figures from 'figures'
+import { describe, expect, it } from 'vitest'
+
+import {
+  describeTeammateActivity,
+  getTaskStatusColor,
+  getTaskStatusIcon,
+  isTerminalStatus,
+  shouldHideTasksFooter,
+} from './taskStatusUtils.js'
+
+type TaskStatus = Parameters<typeof isTerminalStatus>[0]
+type TeammateTask = Parameters<typeof describeTeammateActivity>[0]
+
+function teammate(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'teammate-1',
+    type: 'in_process_teammate',
+    status: 'running',
+    description: 'teammate',
+    startTime: 1,
+    outputFile: 'urn:agenc:task:teammate-1:output',
+    outputOffset: 0,
+    notified: false,
+    identity: {
+      agentId: 'teammate-1',
+      agentName: 'worker',
+      teamName: 'coverage',
+      planModeRequired: false,
+      parentSessionId: 'leader',
+    },
+    prompt: 'cover task status utils',
+    awaitingPlanApproval: false,
+    permissionMode: 'default',
+    isIdle: false,
+    shutdownRequested: false,
+    pendingUserMessages: [],
+    lastReportedToolCount: 0,
+    lastReportedTokenCount: 0,
+    ...overrides,
+  } as TeammateTask
+}
+
+describe('taskStatusUtils wave 200 item 050 coverage', () => {
+  it('derives task status presentation, teammate activity, and hidden-footer state', () => {
+    expect(['completed', 'failed', 'killed'].map(status =>
+      isTerminalStatus(status as TaskStatus),
+    )).toEqual([true, true, true])
+    expect(['pending', 'running'].map(status =>
+      isTerminalStatus(status as TaskStatus),
+    )).toEqual([false, false])
+
+    expect(getTaskStatusIcon('running', { hasError: true })).toBe(figures.cross)
+    expect(getTaskStatusIcon('running', { awaitingApproval: true })).toBe(
+      figures.questionMarkPrefix,
+    )
+    expect(getTaskStatusIcon('running', { shutdownRequested: true })).toBe(
+      figures.warning,
+    )
+    expect(getTaskStatusIcon('running', { isIdle: true })).toBe(figures.ellipsis)
+    expect(getTaskStatusIcon('running')).toBe(figures.play)
+    expect(getTaskStatusIcon('completed')).toBe(figures.tick)
+    expect(getTaskStatusIcon('failed')).toBe(figures.cross)
+    expect(getTaskStatusIcon('killed')).toBe(figures.cross)
+    expect(getTaskStatusIcon('pending')).toBe(figures.bullet)
+
+    expect(getTaskStatusColor('running', { hasError: true })).toBe('error')
+    expect(getTaskStatusColor('running', { awaitingApproval: true })).toBe(
+      'warning',
+    )
+    expect(getTaskStatusColor('running', { shutdownRequested: true })).toBe(
+      'warning',
+    )
+    expect(getTaskStatusColor('running', { isIdle: true })).toBe('background')
+    expect(getTaskStatusColor('completed')).toBe('success')
+    expect(getTaskStatusColor('failed')).toBe('error')
+    expect(getTaskStatusColor('killed')).toBe('warning')
+    expect(getTaskStatusColor('pending')).toBe('background')
+
+    expect(describeTeammateActivity(teammate({ shutdownRequested: true }))).toBe(
+      'stopping',
+    )
+    expect(describeTeammateActivity(teammate({ awaitingPlanApproval: true }))).toBe(
+      'awaiting approval',
+    )
+    expect(describeTeammateActivity(teammate({ isIdle: true }))).toBe('idle')
+    expect(describeTeammateActivity(teammate({
+      progress: {
+        recentActivities: [
+          { activityDescription: 'editing src/app.ts' },
+          { isSearch: true },
+          { isRead: true },
+        ],
+      },
+    }))).toMatch(/^Searching for 1 pattern, reading 1 file/)
+    expect(describeTeammateActivity(teammate({
+      progress: {
+        lastActivity: { activityDescription: 'running checks' },
+      },
+    }))).toBe('running checks')
+    expect(describeTeammateActivity(teammate())).toBe('working')
+
+    expect(shouldHideTasksFooter({}, true)).toBe(false)
+    expect(shouldHideTasksFooter({ teammate: teammate() }, false)).toBe(false)
+    expect(shouldHideTasksFooter({ teammate: teammate() }, true)).toBe(true)
+    expect(shouldHideTasksFooter({
+      foreground: teammate({ status: 'completed' }),
+      teammate: teammate(),
+    }, true)).toBe(true)
+    expect(shouldHideTasksFooter({
+      teammate: teammate(),
+      bash: {
+        id: 'bash-1',
+        type: 'local_bash',
+        status: 'running',
+        isBackgrounded: false,
+      },
+    }, true)).toBe(true)
+    expect(shouldHideTasksFooter({
+      teammate: teammate(),
+      bash: {
+        id: 'bash-1',
+        type: 'local_bash',
+        status: 'running',
+      },
+    }, true)).toBe(false)
+  })
+})

--- a/runtime/tests/tui/components/teams/TeamStatus.wave200-061.coverage.test.tsx
+++ b/runtime/tests/tui/components/teams/TeamStatus.wave200-061.coverage.test.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderToString } from "../../../utils/staticRender.js";
+
+type TeamContext = {
+  teamName: string;
+  teamFilePath: string;
+  leadAgentId: string;
+  teammates: Record<
+    string,
+    {
+      name: string;
+      tmuxSessionName: string;
+      tmuxPaneId: string;
+      cwd: string;
+      spawnedAt: number;
+    }
+  >;
+};
+
+const appStateMock = vi.hoisted(() => ({
+  state: {
+    teamContext: undefined as TeamContext | undefined,
+  },
+}));
+
+vi.mock("../../state/AppState.js", () => ({
+  useAppState: (selector: (state: typeof appStateMock.state) => unknown) =>
+    selector(appStateMock.state),
+}));
+
+function teamContext(teammateNames: string[]): TeamContext {
+  return {
+    teamName: "coverage-team",
+    teamFilePath: "/tmp/coverage-team.json",
+    leadAgentId: "lead",
+    teammates: Object.fromEntries(
+      teammateNames.map((name, index) => [
+        `agent-${index}`,
+        {
+          name,
+          tmuxSessionName: "coverage-session",
+          tmuxPaneId: `%${index + 1}`,
+          cwd: "/tmp",
+          spawnedAt: index,
+        },
+      ]),
+    ),
+  };
+}
+
+describe("TeamStatus coverage", () => {
+  beforeEach(() => {
+    appStateMock.state.teamContext = undefined;
+  });
+
+  it("counts visible teammates and only shows the selected hint when requested", async () => {
+    const { TeamStatus } = await import("./TeamStatus.js");
+
+    const noTeam = await renderToString(
+      <TeamStatus teamsSelected={false} showHint={false} />,
+    );
+    expect(noTeam.trim()).toBe("");
+
+    appStateMock.state.teamContext = teamContext(["team-lead"]);
+    const onlyLeader = await renderToString(
+      <TeamStatus teamsSelected={true} showHint={true} />,
+    );
+    expect(onlyLeader.trim()).toBe("");
+
+    appStateMock.state.teamContext = teamContext(["team-lead", "builder"]);
+    const singular = await renderToString(
+      <TeamStatus teamsSelected={false} showHint={true} />,
+    );
+    expect(singular).toContain("1 teammate");
+    expect(singular).not.toContain("Enter to view");
+
+    appStateMock.state.teamContext = teamContext([
+      "team-lead",
+      "builder",
+      "reviewer",
+    ]);
+    const selected = await renderToString(
+      <TeamStatus teamsSelected={true} showHint={true} />,
+    );
+    expect(selected).toContain("2 teammates");
+    expect(selected).toContain("Enter to view");
+  });
+});

--- a/runtime/tests/tui/components/teams/TeamsDialog.coverage2.test.tsx
+++ b/runtime/tests/tui/components/teams/TeamsDialog.coverage2.test.tsx
@@ -1,0 +1,292 @@
+import { PassThrough } from "node:stream";
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type {
+  KeybindingContextName,
+  ParsedKeystroke,
+} from "../../keybindings/types.js";
+
+type MockTeammateStatus = {
+  agentId: string;
+  backendType?: "tmux" | "iterm2";
+  cwd?: string;
+  isHidden: boolean;
+  mode?: string;
+  name: string;
+  status: "idle" | "running";
+  tmuxPaneId: string;
+};
+
+type HandlerRegistration = {
+  action: string;
+  context: KeybindingContextName;
+  handler: () => void;
+};
+
+const teammateStatusMock = vi.hoisted(() => ({
+  statuses: [] as MockTeammateStatus[],
+}));
+
+const backendMock = vi.hoisted(() => ({
+  backend: {
+    hidePane: vi.fn(async () => true),
+    killPane: vi.fn(async () => {}),
+    showPane: vi.fn(async () => true),
+    supportsHideShow: true,
+  },
+  cachedBackend: {
+    supportsHideShow: true,
+  },
+}));
+
+const mailboxMock = vi.hoisted(() => ({
+  sendShutdownRequestToMailbox: vi.fn(async () => {}),
+  writeToMailbox: vi.fn(async () => {}),
+}));
+
+const teamHelpersMock = vi.hoisted(() => ({
+  addHiddenPaneId: vi.fn(() => true),
+  removeHiddenPaneId: vi.fn(() => true),
+  removeMemberFromTeam: vi.fn(() => true),
+  setMemberMode: vi.fn(),
+  setMultipleMemberModes: vi.fn(),
+}));
+
+const execFileNoThrowMock = vi.hoisted(() =>
+  vi.fn(async () => ({ code: 0, stderr: "", error: "" })),
+);
+
+vi.mock("usehooks-ts", async importOriginal => {
+  const actual = await importOriginal<typeof import("usehooks-ts")>();
+  return {
+    ...actual,
+    useInterval: () => {},
+  };
+});
+vi.mock("../../context/overlayContext", () => ({
+  useRegisterOverlay: () => {},
+}));
+vi.mock("../../hooks/useTerminalSize.js", () => ({
+  useTerminalSize: () => ({ columns: 120, rows: 30 }),
+}));
+vi.mock("../../ink.js", async importOriginal => {
+  const actual = await importOriginal<typeof import("../../ink.js")>();
+  return {
+    ...actual,
+    useInput: () => {},
+  };
+});
+vi.mock("../../keybindings/useShortcutDisplay.js", () => ({
+  useShortcutDisplay: () => "shift+tab",
+}));
+vi.mock("../../state/AppState.js", () => ({
+  useAppState: (selector: (state: unknown) => unknown) =>
+    selector({
+      toolPermissionContext: {
+        isBypassPermissionsModeAvailable: true,
+      },
+    }),
+  useSetAppState: () => () => {},
+}));
+vi.mock("../../../utils/teamDiscovery.js", () => ({
+  getTeammateStatuses: () => teammateStatusMock.statuses,
+}));
+vi.mock("../../../utils/swarm/backends/registry.js", () => ({
+  ensureBackendsRegistered: async () => {},
+  getBackendByType: () => backendMock.backend,
+  getCachedBackend: () => backendMock.cachedBackend,
+}));
+vi.mock("../../../utils/tasks.js", async importOriginal => {
+  const actual = await importOriginal<typeof import("../../../utils/tasks.js")>();
+  return {
+    ...actual,
+    listTasks: vi.fn(async () => []),
+    unassignTeammateTasks: vi.fn(async () => ({
+      notificationMessage: "tasks unassigned",
+    })),
+  };
+});
+vi.mock("../../../utils/teammateMailbox.js", () => ({
+  createModeSetRequestMessage: (message: unknown) => message,
+  sendShutdownRequestToMailbox: mailboxMock.sendShutdownRequestToMailbox,
+  writeToMailbox: mailboxMock.writeToMailbox,
+}));
+vi.mock("../../../utils/swarm/teamHelpers.js", () => ({
+  addHiddenPaneId: teamHelpersMock.addHiddenPaneId,
+  removeHiddenPaneId: teamHelpersMock.removeHiddenPaneId,
+  removeMemberFromTeam: teamHelpersMock.removeMemberFromTeam,
+  setMemberMode: teamHelpersMock.setMemberMode,
+  setMultipleMemberModes: teamHelpersMock.setMultipleMemberModes,
+}));
+vi.mock("../../../utils/execFileNoThrow.js", () => ({
+  execFileNoThrow: execFileNoThrowMock,
+}));
+vi.mock("../../../utils/swarm/backends/detection.js", () => ({
+  getLeaderPaneId: () => "%leader",
+  IT2_COMMAND: "it2",
+  isInsideTmuxSync: () => false,
+}));
+
+function defaultTeammateStatuses(): MockTeammateStatus[] {
+  return [
+    {
+      agentId: "agent-fixer",
+      backendType: "tmux",
+      cwd: "/tmp/work",
+      isHidden: false,
+      mode: "acceptEdits",
+      name: "Fixer",
+      status: "running",
+      tmuxPaneId: "%1",
+    },
+    {
+      agentId: "agent-planner",
+      backendType: "tmux",
+      cwd: "/tmp/work",
+      isHidden: false,
+      mode: "plan",
+      name: "Planner",
+      status: "running",
+      tmuxPaneId: "%2",
+    },
+  ];
+}
+
+async function settle(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 30));
+}
+
+async function waitForRegisteredHandler(
+  handlerRegistryRef: React.RefObject<Map<string, Set<HandlerRegistration>>>,
+  action: string,
+): Promise<HandlerRegistration> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const handler = [...(handlerRegistryRef.current?.get(action) ?? [])][0];
+    if (handler) return handler;
+    await settle();
+  }
+
+  throw new Error(`Timed out waiting for keybinding: ${action}`);
+}
+
+async function mountTeamsDialog(node: React.ReactNode): Promise<{
+  unmount: () => void;
+}> {
+  const { createRoot } = await import("../../ink/root.js");
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    setRawMode: (mode: boolean) => void;
+    ref: () => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.ref = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number }).columns = 120;
+
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  });
+
+  root.render(node);
+  await settle();
+
+  return {
+    unmount: () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    },
+  };
+}
+
+beforeEach(() => {
+  teammateStatusMock.statuses = defaultTeammateStatuses();
+  backendMock.backend.hidePane.mockClear();
+  backendMock.backend.killPane.mockClear();
+  backendMock.backend.showPane.mockClear();
+  backendMock.cachedBackend = { supportsHideShow: true };
+  mailboxMock.sendShutdownRequestToMailbox.mockClear();
+  mailboxMock.writeToMailbox.mockClear();
+  teamHelpersMock.addHiddenPaneId.mockClear();
+  teamHelpersMock.removeHiddenPaneId.mockClear();
+  teamHelpersMock.removeMemberFromTeam.mockClear();
+  teamHelpersMock.setMemberMode.mockClear();
+  teamHelpersMock.setMultipleMemberModes.mockClear();
+  execFileNoThrowMock.mockClear();
+});
+
+describe("TeamsDialog mode cycling coverage", () => {
+  test("resets mixed teammate modes to default through the list keybinding", async () => {
+    const { KeybindingProvider } = await import(
+      "../../keybindings/KeybindingContext.js"
+    );
+    const { TeamsDialog } = await import("./TeamsDialog.js");
+    const activeContexts = new Set<KeybindingContextName>(["Confirmation"]);
+    const pendingChordRef = {
+      current: null,
+    } as React.RefObject<ParsedKeystroke[] | null>;
+    const handlerRegistryRef = {
+      current: new Map<string, Set<HandlerRegistration>>(),
+    } as React.RefObject<Map<string, Set<HandlerRegistration>>>;
+    const harness = await mountTeamsDialog(
+      <KeybindingProvider
+        activeContexts={activeContexts}
+        bindings={[]}
+        handlerRegistryRef={handlerRegistryRef}
+        pendingChord={null}
+        pendingChordRef={pendingChordRef}
+        registerActiveContext={context => {
+          activeContexts.add(context);
+        }}
+        setPendingChord={pending => {
+          pendingChordRef.current = pending;
+        }}
+        unregisterActiveContext={context => {
+          activeContexts.delete(context);
+        }}
+      >
+        <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={() => {}} />
+      </KeybindingProvider>,
+    );
+
+    try {
+      const cycleModeHandler = await waitForRegisteredHandler(
+        handlerRegistryRef,
+        "confirm:cycleMode",
+      );
+
+      cycleModeHandler.handler();
+      await settle();
+
+      expect(teamHelpersMock.setMultipleMemberModes).toHaveBeenCalledWith(
+        "alpha",
+        [
+          { memberName: "Fixer", mode: "default" },
+          { memberName: "Planner", mode: "default" },
+        ],
+      );
+      expect(teamHelpersMock.setMemberMode).not.toHaveBeenCalled();
+      expect(mailboxMock.writeToMailbox).toHaveBeenCalledTimes(2);
+      expect(mailboxMock.writeToMailbox.mock.calls.map(call => call[0])).toEqual([
+        "Fixer",
+        "Planner",
+      ]);
+      for (const call of mailboxMock.writeToMailbox.mock.calls) {
+        const message = call[1] as { from: string; text: string };
+        expect(message.from).toBe("team-lead");
+        expect(JSON.parse(message.text)).toEqual({
+          from: "team-lead",
+          mode: "default",
+        });
+        expect(call[2]).toBe("alpha");
+      }
+    } finally {
+      harness.unmount();
+    }
+  });
+});

--- a/runtime/tests/tui/components/teams/TeamsDialog.test.tsx
+++ b/runtime/tests/tui/components/teams/TeamsDialog.test.tsx
@@ -8,6 +8,11 @@ import { sourceUrl } from "../../../helpers/source-path.ts";
 import { createRoot } from "../../ink/root.js";
 import { selectAgenCTuiGlyphs } from "../../glyphs.js";
 import { stringWidth } from "../../ink/stringWidth.js";
+import {
+  getSwarmSocketName,
+  SWARM_SESSION_NAME,
+  SWARM_VIEW_WINDOW_NAME,
+} from "../../../utils/swarm/constants.js";
 import { TeamsDialog } from "./TeamsDialog.js";
 import {
   getTeamListFooterText,
@@ -544,6 +549,203 @@ describe("TeamsDialog rendering", () => {
       expect(onDone).not.toHaveBeenCalled();
     } finally {
       harness.unmount();
+    }
+  });
+
+  test("navigates the list, opens teammate detail, and returns with left arrow", async () => {
+    const harness = await createTeamsDialogHarness(
+      <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={() => {}} />,
+    );
+
+    try {
+      await harness.press("", { downArrow: true });
+      await harness.press("\r", { return: true }, 80);
+      expect(harness.getText()).toContain("@Planner");
+
+      await harness.press("", { leftArrow: true });
+      const output = harness.getText();
+      expect(output).toContain("Team alpha");
+      expect(output).toContain("@Fixer");
+      expect(output).toContain("@Planner");
+
+      await harness.press("", { upArrow: true });
+      await harness.press("\r", { return: true }, 80);
+      expect(harness.getText()).toContain("@Fixer");
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("successful teammate output selection closes the dialog", async () => {
+    const onDone = vi.fn();
+    const harness = await createTeamsDialogHarness(
+      <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={onDone} />,
+    );
+
+    try {
+      await harness.press("\r", { return: true }, 80);
+      await harness.press("\r", { return: true }, 80);
+
+      expect(execFileNoThrowMock).toHaveBeenCalledWith("tmux", [
+        "-L",
+        getSwarmSocketName(),
+        "select-pane",
+        "-t",
+        "%1",
+      ]);
+      expect(onDone).toHaveBeenCalledTimes(1);
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("kill actions update team state and surface failures", async () => {
+    const harness = await createTeamsDialogHarness(
+      <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={() => {}} />,
+    );
+
+    try {
+      await harness.press("k", {}, 80);
+
+      expect(backendMock.backend.killPane).toHaveBeenCalledWith("%1", true);
+      expect(teamHelpersMock.removeMemberFromTeam).toHaveBeenCalledWith(
+        "alpha",
+        "%1",
+      );
+      expect(tasksMock.unassignTeammateTasks).toHaveBeenCalledWith(
+        "alpha",
+        "agent-fixer",
+        "Fixer",
+        "terminated",
+      );
+    } finally {
+      harness.unmount();
+    }
+
+    teammateStatusMock.statuses = [
+      {
+        ...defaultTeammateStatuses()[0],
+        backendType: undefined,
+        name: "Legacy",
+      },
+    ];
+    const failureHarness = await createTeamsDialogHarness(
+      <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={() => {}} />,
+    );
+
+    try {
+      await failureHarness.press("k", {}, 80);
+
+      expect(failureHarness.getText()).toContain(
+        "Cannot kill @Legacy: missing pane backend metadata.",
+      );
+    } finally {
+      failureHarness.unmount();
+    }
+  });
+
+  test("shutdown actions call teammate mailboxes and surface errors", async () => {
+    const harness = await createTeamsDialogHarness(
+      <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={() => {}} />,
+    );
+
+    try {
+      await harness.press("s", {}, 80);
+      expect(mailboxMock.sendShutdownRequestToMailbox).toHaveBeenCalledWith(
+        "Fixer",
+        "alpha",
+        "Graceful shutdown requested by team lead",
+      );
+
+      mailboxMock.sendShutdownRequestToMailbox.mockRejectedValueOnce(
+        new Error("mailbox offline"),
+      );
+      await harness.press("s", {}, 80);
+
+      expect(harness.getText()).toContain(
+        "Cannot request shutdown for @Fixer: mailbox offline",
+      );
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("individual hide and show actions use backend visibility APIs", async () => {
+    const harness = await createTeamsDialogHarness(
+      <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={() => {}} />,
+    );
+
+    try {
+      await harness.press("h", {}, 80);
+      expect(backendMock.backend.hidePane).toHaveBeenCalledWith("%1", true);
+      expect(teamHelpersMock.addHiddenPaneId).toHaveBeenCalledWith("alpha", "%1");
+
+      await harness.press("", { downArrow: true });
+      await harness.press("h", {}, 80);
+      expect(backendMock.backend.showPane).toHaveBeenCalledWith(
+        "%2",
+        `${SWARM_SESSION_NAME}:${SWARM_VIEW_WINDOW_NAME}`,
+        true,
+      );
+      expect(teamHelpersMock.removeHiddenPaneId).toHaveBeenCalledWith(
+        "alpha",
+        "%2",
+      );
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("bulk hide/show and prune operate on teammate groups", async () => {
+    const harness = await createTeamsDialogHarness(
+      <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={() => {}} />,
+    );
+
+    try {
+      await harness.press("H", {}, 80);
+      expect(backendMock.backend.hidePane).toHaveBeenCalledWith("%1", true);
+      expect(backendMock.backend.hidePane).toHaveBeenCalledWith("%2", true);
+    } finally {
+      harness.unmount();
+    }
+
+    teammateStatusMock.statuses = defaultTeammateStatuses().map(teammate => ({
+      ...teammate,
+      isHidden: true,
+    }));
+    backendMock.backend.hidePane.mockClear();
+    const showHarness = await createTeamsDialogHarness(
+      <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={() => {}} />,
+    );
+
+    try {
+      await showHarness.press("H", {}, 80);
+      expect(backendMock.backend.showPane).toHaveBeenCalledWith(
+        "%1",
+        `${SWARM_SESSION_NAME}:${SWARM_VIEW_WINDOW_NAME}`,
+        true,
+      );
+      expect(backendMock.backend.showPane).toHaveBeenCalledWith(
+        "%2",
+        `${SWARM_SESSION_NAME}:${SWARM_VIEW_WINDOW_NAME}`,
+        true,
+      );
+    } finally {
+      showHarness.unmount();
+    }
+
+    backendMock.backend.killPane.mockClear();
+    teammateStatusMock.statuses = defaultTeammateStatuses();
+    const pruneHarness = await createTeamsDialogHarness(
+      <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={() => {}} />,
+    );
+
+    try {
+      await pruneHarness.press("p", {}, 80);
+      expect(backendMock.backend.killPane).toHaveBeenCalledTimes(1);
+      expect(backendMock.backend.killPane).toHaveBeenCalledWith("%2", true);
+    } finally {
+      pruneHarness.unmount();
     }
   });
 });

--- a/runtime/tests/tui/components/teams/TeamsDialog.test.tsx
+++ b/runtime/tests/tui/components/teams/TeamsDialog.test.tsx
@@ -2,7 +2,7 @@ import { PassThrough } from "node:stream";
 import { readFileSync } from "node:fs";
 import React from "react";
 import stripAnsi from "strip-ansi";
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { sourceUrl } from "../../../helpers/source-path.ts";
 
 import { createRoot } from "../../ink/root.js";
@@ -15,8 +15,161 @@ import {
   getTeamsDialogPromptPreview,
 } from "./TeamsDialog.layout.js";
 
+type MockTeammateStatus = {
+  agentId: string;
+  backendType?: "tmux" | "iterm2";
+  color?: string;
+  cwd?: string;
+  isHidden: boolean;
+  mode?: string;
+  model?: string;
+  name: string;
+  prompt?: string;
+  status: "idle" | "running";
+  tmuxPaneId: string;
+  worktreePath?: string;
+};
+
 const teammateStatusMock = vi.hoisted(() => ({
-  statuses: [
+  statuses: [] as MockTeammateStatus[],
+}));
+
+const inputMock = vi.hoisted(() => ({
+  handlers: new Set<(input: string, key: Record<string, boolean>) => void>(),
+}));
+
+const backendMock = vi.hoisted(() => ({
+  backend: {
+    hidePane: vi.fn(async () => true),
+    killPane: vi.fn(async () => {}),
+    showPane: vi.fn(async () => true),
+    supportsHideShow: true,
+  },
+  cachedBackend: {
+    supportsHideShow: true,
+  } as { supportsHideShow: boolean } | null,
+}));
+
+const tasksMock = vi.hoisted(() => ({
+  listTasks: vi.fn(async () => []),
+  unassignTeammateTasks: vi.fn(async () => ({
+    notificationMessage: "tasks unassigned",
+  })),
+}));
+
+const mailboxMock = vi.hoisted(() => ({
+  sendShutdownRequestToMailbox: vi.fn(async () => {}),
+  writeToMailbox: vi.fn(async () => {}),
+}));
+
+const teamHelpersMock = vi.hoisted(() => ({
+  addHiddenPaneId: vi.fn(() => true),
+  removeHiddenPaneId: vi.fn(() => true),
+  removeMemberFromTeam: vi.fn(() => true),
+  setMemberMode: vi.fn(),
+  setMultipleMemberModes: vi.fn(),
+}));
+
+const execFileNoThrowMock = vi.hoisted(() =>
+  vi.fn(async () => ({ code: 0, stderr: "", error: "" })),
+);
+
+vi.mock("usehooks-ts", async importOriginal => {
+  const actual = await importOriginal<typeof import("usehooks-ts")>();
+  return {
+    ...actual,
+    useInterval: () => {},
+  };
+});
+vi.mock("../../context/overlayContext", () => ({
+  useRegisterOverlay: () => {},
+}));
+vi.mock("../../ink.js", async importOriginal => {
+  const actual = await importOriginal<typeof import("../../ink.js")>();
+  const ReactModule = await import("react");
+
+  return {
+    ...actual,
+    useInput: (
+      handler: (input: string, key: Record<string, boolean>) => void,
+    ) => {
+      const handlerRef = ReactModule.useRef(handler);
+      handlerRef.current = handler;
+      ReactModule.useEffect(() => {
+        const currentHandler = (input: string, key: Record<string, boolean>) => {
+          handlerRef.current(input, key);
+        };
+        inputMock.handlers.add(currentHandler);
+        return () => {
+          inputMock.handlers.delete(currentHandler);
+        };
+      }, []);
+    },
+  };
+});
+vi.mock("../../keybindings/useKeybinding.js", () => ({
+  useKeybinding: () => {},
+  useKeybindings: () => {},
+}));
+vi.mock("../../keybindings/useShortcutDisplay.js", () => ({
+  useShortcutDisplay: () => "shift+tab",
+}));
+vi.mock("../../state/AppState.js", () => ({
+  useAppState: (selector: (state: unknown) => unknown) =>
+    selector({
+      toolPermissionContext: {
+        isBypassPermissionsModeAvailable: true,
+      },
+    }),
+  useSetAppState: () => () => {},
+}));
+vi.mock("../../../utils/teamDiscovery.js", () => ({
+  getTeammateStatuses: () => teammateStatusMock.statuses,
+}));
+vi.mock("../../../utils/swarm/backends/registry.js", () => ({
+  ensureBackendsRegistered: async () => {},
+  getBackendByType: () => backendMock.backend,
+  getCachedBackend: () => backendMock.cachedBackend,
+}));
+vi.mock("../../../utils/tasks.js", async importOriginal => {
+  const actual = await importOriginal<typeof import("../../../utils/tasks.js")>();
+  return {
+    ...actual,
+    listTasks: tasksMock.listTasks,
+    unassignTeammateTasks: tasksMock.unassignTeammateTasks,
+  };
+});
+vi.mock("../../../utils/teammateMailbox.js", () => ({
+  createModeSetRequestMessage: (message: unknown) => message,
+  sendShutdownRequestToMailbox: mailboxMock.sendShutdownRequestToMailbox,
+  writeToMailbox: mailboxMock.writeToMailbox,
+}));
+vi.mock("../../../utils/swarm/teamHelpers.js", () => ({
+  addHiddenPaneId: teamHelpersMock.addHiddenPaneId,
+  removeHiddenPaneId: teamHelpersMock.removeHiddenPaneId,
+  removeMemberFromTeam: teamHelpersMock.removeMemberFromTeam,
+  setMemberMode: teamHelpersMock.setMemberMode,
+  setMultipleMemberModes: teamHelpersMock.setMultipleMemberModes,
+}));
+vi.mock("../../../utils/execFileNoThrow.js", () => ({
+  execFileNoThrow: execFileNoThrowMock,
+}));
+vi.mock("../../../utils/swarm/backends/detection.js", () => ({
+  getLeaderPaneId: () => "%leader",
+  IT2_COMMAND: "it2",
+  isInsideTmuxSync: () => false,
+}));
+
+const source = readFileSync(
+  sourceUrl("tui/components/teams/TeamsDialog.tsx"),
+  "utf8",
+);
+
+const SYNC_START = "\x1B[?2026h";
+const SYNC_END = "\x1B[?2026l";
+
+function defaultTeammateStatuses(): MockTeammateStatus[] {
+  return [
     {
       agentId: "agent-fixer",
       backendType: "tmux",
@@ -43,82 +196,54 @@ const teammateStatusMock = vi.hoisted(() => ({
       status: "idle",
       tmuxPaneId: "%2",
     },
-  ],
-}));
+  ];
+}
 
-vi.mock("usehooks-ts", async importOriginal => {
-  const actual = await importOriginal<typeof import("usehooks-ts")>();
+function key(overrides: Record<string, boolean> = {}): Record<string, boolean> {
   return {
-    ...actual,
-    useInterval: () => {},
+    downArrow: false,
+    leftArrow: false,
+    return: false,
+    upArrow: false,
+    ...overrides,
   };
-});
-vi.mock("../../context/overlayContext", () => ({
-  useRegisterOverlay: () => {},
-}));
-vi.mock("../../keybindings/useKeybinding.js", () => ({
-  useKeybinding: () => {},
-  useKeybindings: () => {},
-}));
-vi.mock("../../keybindings/useShortcutDisplay.js", () => ({
-  useShortcutDisplay: () => "shift+tab",
-}));
-vi.mock("../../state/AppState.js", () => ({
-  useAppState: (selector: (state: unknown) => unknown) =>
-    selector({
-      toolPermissionContext: {
-        isBypassPermissionsModeAvailable: true,
-      },
-    }),
-  useSetAppState: () => () => {},
-}));
-vi.mock("../../../utils/teamDiscovery.js", () => ({
-  getTeammateStatuses: () => teammateStatusMock.statuses,
-}));
-vi.mock("../../../utils/swarm/backends/registry.js", () => ({
-  ensureBackendsRegistered: async () => {},
-  getBackendByType: () => ({
-    hidePane: async () => true,
-    killPane: async () => {},
-    showPane: async () => true,
-    supportsHideShow: true,
-  }),
-  getCachedBackend: () => ({
-    supportsHideShow: true,
-  }),
-}));
-vi.mock("../../../utils/tasks.js", async importOriginal => {
-  const actual = await importOriginal<typeof import("../../../utils/tasks.js")>();
-  return {
-    ...actual,
-    listTasks: async () => [],
-    unassignTeammateTasks: async () => ({
-      notificationMessage: "tasks unassigned",
-    }),
-  };
-});
-vi.mock("../../../utils/teammateMailbox.js", () => ({
-  createModeSetRequestMessage: (message: unknown) => message,
-  sendShutdownRequestToMailbox: async () => {},
-  writeToMailbox: async () => {},
-}));
-vi.mock("../../../utils/swarm/teamHelpers.js", () => ({
-  addHiddenPaneId: () => true,
-  removeHiddenPaneId: () => true,
-  removeMemberFromTeam: () => true,
-  setMemberMode: () => {},
-  setMultipleMemberModes: () => {},
-}));
-vi.mock("../../../utils/execFileNoThrow.js", () => ({
-  execFileNoThrow: async () => ({ code: 0, stderr: "", error: "" }),
-}));
+}
 
-const source = readFileSync(
-  sourceUrl("tui/components/teams/TeamsDialog.tsx"),
-  "utf8",
-);
+function extractLastFrame(output: string): string {
+  let lastFrame: string | null = null;
+  let cursor = 0;
 
-async function renderTeamsDialogToText(node: React.ReactNode): Promise<string> {
+  while (cursor < output.length) {
+    const start = output.indexOf(SYNC_START, cursor);
+    if (start === -1) break;
+
+    const contentStart = start + SYNC_START.length;
+    const end = output.indexOf(SYNC_END, contentStart);
+    if (end === -1) break;
+
+    const frame = output.slice(contentStart, end);
+    if (frame.trim().length > 0) {
+      lastFrame = frame;
+    }
+    cursor = end + SYNC_END.length;
+  }
+
+  return lastFrame ?? output;
+}
+
+async function settle(ms = 30): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function createTeamsDialogHarness(node: React.ReactNode): Promise<{
+  getText: () => string;
+  press: (
+    input: string,
+    keyOverrides?: Record<string, boolean>,
+    waitMs?: number,
+  ) => Promise<void>;
+  unmount: () => void;
+}> {
   let output = "";
   const stdout = new PassThrough();
   stdout.on("data", chunk => {
@@ -143,15 +268,62 @@ async function renderTeamsDialogToText(node: React.ReactNode): Promise<string> {
     patchConsole: false,
   });
 
+  root.render(node);
+  await settle();
+
+  return {
+    getText: () => stripAnsi(extractLastFrame(output)),
+    press: async (
+      input: string,
+      keyOverrides: Record<string, boolean> = {},
+      waitMs = 40,
+    ) => {
+      for (const handler of [...inputMock.handlers]) {
+        handler(input, key(keyOverrides));
+      }
+      await settle(waitMs);
+    },
+    unmount: () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    },
+  };
+}
+
+async function renderTeamsDialogToText(node: React.ReactNode): Promise<string> {
+  const harness = await createTeamsDialogHarness(node);
   try {
-    root.render(node);
-    await new Promise(resolve => setTimeout(resolve, 30));
-    return stripAnsi(output);
+    return harness.getText();
   } finally {
-    root.unmount();
-    stdin.end();
+    harness.unmount();
   }
 }
+
+beforeEach(() => {
+  teammateStatusMock.statuses = defaultTeammateStatuses();
+  inputMock.handlers.clear();
+  backendMock.backend.hidePane.mockClear();
+  backendMock.backend.killPane.mockClear();
+  backendMock.backend.showPane.mockClear();
+  backendMock.backend.supportsHideShow = true;
+  backendMock.cachedBackend = { supportsHideShow: true };
+  tasksMock.listTasks.mockReset();
+  tasksMock.listTasks.mockResolvedValue([]);
+  tasksMock.unassignTeammateTasks.mockClear();
+  tasksMock.unassignTeammateTasks.mockResolvedValue({
+    notificationMessage: "tasks unassigned",
+  });
+  mailboxMock.sendShutdownRequestToMailbox.mockClear();
+  mailboxMock.writeToMailbox.mockClear();
+  teamHelpersMock.addHiddenPaneId.mockClear();
+  teamHelpersMock.removeHiddenPaneId.mockClear();
+  teamHelpersMock.removeMemberFromTeam.mockClear();
+  teamHelpersMock.setMemberMode.mockClear();
+  teamHelpersMock.setMultipleMemberModes.mockClear();
+  execFileNoThrowMock.mockReset();
+  execFileNoThrowMock.mockResolvedValue({ code: 0, stderr: "", error: "" });
+});
 
 describe("TeamsDialog pane visibility actions", () => {
   test("hide calls backend before mutating hidden-pane state", () => {
@@ -210,6 +382,169 @@ describe("TeamsDialog rendering", () => {
     expect(output).toContain("[hidden]");
     expect(output).toContain("[idle]");
     expect(output).toContain("shift+tab");
+  });
+
+  test("renders empty team list state", async () => {
+    teammateStatusMock.statuses = [];
+
+    const output = await renderTeamsDialogToText(
+      <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={() => {}} />,
+    );
+
+    expect(output).toContain("Team alpha");
+    expect(output).toContain("0 teammates");
+    expect(output).toContain("No teammates");
+  });
+
+  test("opens teammate detail with loaded task rows, prompt preview, and worktree subtitle", async () => {
+    const longPrompt = "Implement TeamsDialog coverage ".repeat(8);
+    teammateStatusMock.statuses = [
+      {
+        ...defaultTeammateStatuses()[0],
+        prompt: longPrompt,
+        worktreePath: "/tmp/worktrees/fixer",
+      },
+    ];
+    tasksMock.listTasks.mockResolvedValue([
+      {
+        id: "task-done",
+        owner: "agent-fixer",
+        status: "completed",
+        subject: "Ship tests",
+      },
+      {
+        id: "task-active",
+        owner: "Fixer",
+        status: "in_progress",
+        subject: "Cover detail state",
+      },
+      {
+        id: "task-other",
+        owner: "agent-other",
+        status: "pending",
+        subject: "Ignore unrelated task",
+      },
+    ] as never);
+    const harness = await createTeamsDialogHarness(
+      <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={() => {}} />,
+    );
+
+    try {
+      await harness.press("\r", { return: true }, 80);
+      const output = harness.getText();
+
+      expect(output).toContain("@Fixer");
+      expect(output).toContain("grok-4.3");
+      expect(output).toContain("worktree: /tmp/worktrees/fixer");
+      expect(output).toContain("Tasks");
+      expect(output).toContain("done Ship tests");
+      expect(output).toContain("in_progress Cover detail state");
+      expect(output).not.toContain("Ignore unrelated task");
+      expect(output).toContain("Prompt");
+      expect(output).toContain("(p to expand)");
+      expect(output).toContain("Left back");
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("renders task loading and error states in teammate detail", async () => {
+    tasksMock.listTasks.mockReturnValue(new Promise(() => {}) as never);
+    const loadingHarness = await createTeamsDialogHarness(
+      <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={() => {}} />,
+    );
+
+    try {
+      await loadingHarness.press("\r", { return: true });
+      expect(loadingHarness.getText()).toContain("Loading tasks...");
+    } finally {
+      loadingHarness.unmount();
+    }
+
+    tasksMock.listTasks.mockRejectedValue(new Error("task store offline"));
+    const errorHarness = await createTeamsDialogHarness(
+      <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={() => {}} />,
+    );
+
+    try {
+      await errorHarness.press("\r", { return: true }, 80);
+      expect(errorHarness.getText()).toContain(
+        "Unable to load tasks: task store offline",
+      );
+    } finally {
+      errorHarness.unmount();
+    }
+  });
+
+  test("toggles teammate prompt expansion from detail view", async () => {
+    teammateStatusMock.statuses = [
+      {
+        ...defaultTeammateStatuses()[0],
+        prompt: `${"Keep this prompt collapsed ".repeat(8)}EXPANDED-TAIL`,
+      },
+    ];
+    const harness = await createTeamsDialogHarness(
+      <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={() => {}} />,
+    );
+
+    try {
+      await harness.press("\r", { return: true }, 80);
+      expect(harness.getText()).toContain("(p to expand)");
+      expect(harness.getText()).not.toContain("EXPANDED-TAIL");
+
+      await harness.press("p");
+      const output = harness.getText();
+      expect(output).toContain("EXPANDED-TAIL");
+      expect(output).not.toContain("(p to expand)");
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("renders visibility unsupported notices for individual and bulk actions", async () => {
+    backendMock.cachedBackend = { supportsHideShow: false };
+    const harness = await createTeamsDialogHarness(
+      <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={() => {}} />,
+    );
+
+    try {
+      await harness.press("h");
+      expect(harness.getText()).toContain(
+        "Cannot hide or show @Fixer: current backend does not support pane visibility.",
+      );
+
+      await harness.press("H");
+      expect(harness.getText()).toContain(
+        "Cannot hide or show all teammates: current backend does not support pane visibility.",
+      );
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("renders view-output failure notice and keeps dialog open", async () => {
+    const onDone = vi.fn();
+    execFileNoThrowMock.mockResolvedValue({
+      code: 1,
+      error: "",
+      stderr: "pane disappeared",
+    });
+    const harness = await createTeamsDialogHarness(
+      <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={onDone} />,
+    );
+
+    try {
+      await harness.press("\r", { return: true }, 80);
+      await harness.press("\r", { return: true }, 80);
+
+      expect(harness.getText()).toContain(
+        "Cannot view teammate output: pane disappeared",
+      );
+      expect(harness.getText()).toContain("@Fixer");
+      expect(onDone).not.toHaveBeenCalled();
+    } finally {
+      harness.unmount();
+    }
   });
 });
 

--- a/runtime/tests/tui/components/teams/TeamsDialog.wave200-005.coverage.test.tsx
+++ b/runtime/tests/tui/components/teams/TeamsDialog.wave200-005.coverage.test.tsx
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const detectionMock = vi.hoisted(() => ({
+  insideTmux: false,
+  leaderPaneId: "%lead",
+}));
+
+vi.mock("../../../utils/swarm/backends/detection.js", () => ({
+  getLeaderPaneId: () => detectionMock.leaderPaneId,
+  IT2_COMMAND: "it2",
+  isInsideTmuxSync: () => detectionMock.insideTmux,
+}));
+
+describe("resolveTeammateShowTargetPane", () => {
+  beforeEach(() => {
+    detectionMock.insideTmux = false;
+    detectionMock.leaderPaneId = "%lead";
+  });
+
+  test("selects a valid show target and rejects self-targeting", async () => {
+    const { SWARM_SESSION_NAME, SWARM_VIEW_WINDOW_NAME } = await import(
+      "../../../utils/swarm/constants.js"
+    );
+    const { resolveTeammateShowTargetPane } = await import("./TeamsDialog.js");
+
+    detectionMock.insideTmux = true;
+    detectionMock.leaderPaneId = "%lead";
+    expect(resolveTeammateShowTargetPane("%hidden")).toBe("%lead");
+    expect(resolveTeammateShowTargetPane("%lead")).toBeNull();
+
+    detectionMock.insideTmux = false;
+    const swarmViewTarget = `${SWARM_SESSION_NAME}:${SWARM_VIEW_WINDOW_NAME}`;
+    expect(resolveTeammateShowTargetPane("%hidden")).toBe(swarmViewTarget);
+    expect(resolveTeammateShowTargetPane(swarmViewTarget)).toBeNull();
+  });
+});

--- a/runtime/tests/tui/components/v2/messagePrimitives.wave200-109.coverage.test.tsx
+++ b/runtime/tests/tui/components/v2/messagePrimitives.wave200-109.coverage.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../../utils/staticRender.js'
+import { AppStateProvider } from '../../state/AppState.js'
+import {
+  RejectedPlanMessage,
+  RejectedToolUseMessage,
+  UserImageMessage,
+  UserToolCanceledMessage,
+} from './messagePrimitives.js'
+
+const imageHarness = vi.hoisted(() => ({
+  hyperlinks: false,
+  storedPath: null as string | null,
+}))
+
+vi.mock('../../../utils/imageStore.js', () => ({
+  getStoredImagePath: () => imageHarness.storedPath,
+}))
+
+vi.mock('../../ink/supports-hyperlinks.js', () => ({
+  supportsHyperlinks: () => imageHarness.hyperlinks,
+}))
+
+describe('messagePrimitives wave200-109 coverage', () => {
+  test('renders image and rejected control rows through v2 chrome', async () => {
+    imageHarness.hyperlinks = true
+    imageHarness.storedPath = '/tmp/agenc-screenshot.png'
+
+    const linkedImageOutput = await renderToString(
+      <UserImageMessage imageId={42} />,
+      100,
+    )
+
+    expect(linkedImageOutput).toContain('IMAGE')
+    expect(linkedImageOutput).toContain('[ image')
+    expect(linkedImageOutput).toContain('#42')
+
+    imageHarness.hyperlinks = false
+    imageHarness.storedPath = null
+
+    const plainImageOutput = await renderToString(<UserImageMessage />, 100)
+
+    expect(plainImageOutput).toContain('IMAGE')
+    expect(plainImageOutput).toContain('[ image ]')
+
+    const rejectedToolOutput = await renderToString(
+      <RejectedToolUseMessage />,
+      100,
+    )
+    const canceledToolOutput = await renderToString(
+      <UserToolCanceledMessage />,
+      100,
+    )
+    const rejectedPlanOutput = await renderToString(
+      <AppStateProvider>
+        <RejectedPlanMessage plan="1. Inspect the proposed edit" />
+      </AppStateProvider>,
+      100,
+    )
+
+    expect(rejectedToolOutput).toContain('PERMISSION')
+    expect(rejectedToolOutput).toContain('Tool use rejected')
+    expect(canceledToolOutput).toContain('INTERRUPT')
+    expect(canceledToolOutput).toContain('Interrupted by user')
+    expect(rejectedPlanOutput).toContain('PLAN REJECTED')
+    expect(rejectedPlanOutput).toContain("User rejected AgenC's plan:")
+    expect(rejectedPlanOutput).toContain('PLAN TO IMPLEMENT')
+    expect(rejectedPlanOutput).toContain('Inspect the proposed edit')
+  })
+})

--- a/runtime/tests/tui/components/v2/primitives.wave200-100.coverage.test.tsx
+++ b/runtime/tests/tui/components/v2/primitives.wave200-100.coverage.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { renderToString } from '../../../utils/staticRender.js'
+import { DiffInline } from './primitives.js'
+
+describe('v2 primitives coverage', () => {
+  it('renders inline diffs with each row kind and optional line numbers', async () => {
+    const output = await renderToString(
+      <DiffInline
+        file="runtime/src/tui/components/v2/primitives.tsx"
+        stats="+2 -1"
+        lines={[
+          { kind: 'hunk', code: '@@ -12,3 +12,4 @@' },
+          { kind: 'ctx', oldLine: '12', newLine: '12', code: 'const stable = true' },
+          { kind: 'rem', oldLine: '13', code: 'const deleted = true' },
+          { kind: 'add', newLine: '13', code: 'const added = true' },
+        ]}
+      />,
+      100,
+    )
+
+    expect(output).toContain('DIFF')
+    expect(output).toContain('primitives.tsx')
+    expect(output).toContain('+2 -1')
+    expect(output).toContain('@@ -12,3 +12,4 @@')
+    expect(output).toContain('const stable = true')
+    expect(output).toContain('const deleted = true')
+    expect(output).toContain('const added = true')
+  })
+})

--- a/runtime/tests/tui/computer-use-approval/ComputerUseApproval.coverage.test.tsx
+++ b/runtime/tests/tui/computer-use-approval/ComputerUseApproval.coverage.test.tsx
@@ -1,0 +1,137 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type CapturedSelectProps = {
+  options: Array<{ value: string }>
+  onChange: (value: string) => void
+  onCancel: () => void
+}
+
+const harness = vi.hoisted(() => ({
+  execFileNoThrow: vi.fn(),
+  selectProps: undefined as CapturedSelectProps | undefined,
+}))
+
+vi.mock('../components/CustomSelect/select.js', () => ({
+  Select: (props: CapturedSelectProps) => {
+    harness.selectProps = props
+    return null
+  },
+}))
+
+vi.mock('../components/design-system/Dialog.js', async () => {
+  const ReactActual = await vi.importActual<typeof import('react')>('react')
+  return {
+    Dialog: ({ children }: { children: React.ReactNode }) =>
+      ReactActual.createElement(ReactActual.Fragment, null, children),
+  }
+})
+
+vi.mock('../../utils/execFileNoThrow.js', () => ({
+  execFileNoThrow: harness.execFileNoThrow,
+}))
+
+function createTestStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+
+  return { stdout, stdin }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+describe('ComputerUseApproval coverage', () => {
+  beforeEach(() => {
+    harness.execFileNoThrow.mockReset()
+    harness.selectProps = undefined
+  })
+
+  it('offers missing macOS permission actions before retrying the request', async () => {
+    const { createRoot } = await import('../ink.js')
+    const { ComputerUseApproval } = await import('./ComputerUseApproval.js')
+    const onDone = vi.fn()
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    })
+
+    try {
+      root.render(
+        <ComputerUseApproval
+          request={{
+            apps: [],
+            requestedFlags: {},
+            tccState: {
+              accessibility: false,
+              screenRecording: false,
+            },
+          }}
+          onDone={onDone}
+        />,
+      )
+      await sleep(25)
+
+      expect(harness.selectProps?.options.map(option => option.value)).toEqual([
+        'open_accessibility',
+        'open_screen_recording',
+        'retry',
+      ])
+
+      harness.selectProps!.onChange('open_accessibility')
+      expect(harness.execFileNoThrow).toHaveBeenCalledWith(
+        'open',
+        [
+          'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility',
+        ],
+        { useCwd: false },
+      )
+      expect(onDone).not.toHaveBeenCalled()
+
+      harness.selectProps!.onChange('open_screen_recording')
+      expect(harness.execFileNoThrow).toHaveBeenLastCalledWith(
+        'open',
+        [
+          'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture',
+        ],
+        { useCwd: false },
+      )
+      expect(onDone).not.toHaveBeenCalled()
+
+      harness.selectProps!.onChange('retry')
+      expect(onDone).toHaveBeenCalledWith({
+        granted: [],
+        denied: [],
+        flags: {},
+      })
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+  })
+})

--- a/runtime/tests/tui/context/notifications.test.tsx
+++ b/runtime/tests/tui/context/notifications.test.tsx
@@ -1,0 +1,544 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import Text from "../ink/components/Text.js";
+import { createRoot } from "../ink/root.js";
+import {
+  AppStateProvider,
+  getDefaultAppState,
+  useAppState,
+  useAppStateStore,
+  type AppState,
+} from "../state/AppState.js";
+import {
+  getNext,
+  type Notification,
+  useNotifications,
+} from "./notifications.js";
+
+vi.mock("bun:bundle", () => ({
+  feature: () => false,
+}));
+vi.mock("../context/mailbox.js", () => ({
+  MailboxProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("../hooks/useEffectEventCompat.js", () => ({
+  useEffectEventCompat: (callback: unknown) => callback,
+}));
+vi.mock("../hooks/useSettingsChange.js", () => ({
+  useSettingsChange: () => {},
+}));
+vi.mock("../../bootstrap/state.js", () => ({
+  flushInteractionTime: () => {},
+  getActiveTimeCounter: () => ({ activeMs: 0, totalMs: 0 }),
+  getIsNonInteractiveSession: () => false,
+  markScrollActivity: () => {},
+  updateLastInteractionTime: () => {},
+}));
+vi.mock("../../services/analytics/growthbook.js", () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: () => false,
+}));
+vi.mock("../../services/PromptSuggestion/promptSuggestion.js", () => ({
+  shouldEnablePromptSuggestion: () => false,
+}));
+vi.mock("../../tools/Tool.js", () => ({
+  buildTool: (tool: unknown) => tool,
+  getEmptyToolPermissionContext: () => ({
+    mode: "default",
+    additionalDirectories: [],
+    alwaysAllowRules: [],
+    alwaysDenyRules: [],
+    isBypassPermissionsModeAvailable: false,
+  }),
+}));
+vi.mock("../../utils/agentSwarmsEnabled.js", () => ({
+  isAgentSwarmsEnabled: () => false,
+}));
+vi.mock("../../utils/commitAttribution.js", () => ({
+  createEmptyAttributionState: () => ({}),
+}));
+vi.mock("../../utils/debug.js", () => ({
+  logForDebugging: () => {},
+}));
+vi.mock("../../utils/log.js", () => ({
+  logError: () => {},
+}));
+vi.mock("../../utils/permissions/permissionSetup.js", () => ({
+  createDisabledBypassPermissionsContext: (context: unknown) => context,
+  isBypassPermissionsModeDisabled: () => false,
+}));
+vi.mock("../../utils/settings/applySettingsChange.js", () => ({
+  applySettingsChange: () => {},
+}));
+vi.mock("../../utils/settings/settings.js", () => ({
+  getInitialSettings: () => ({}),
+}));
+vi.mock("../../utils/teammate.js", () => ({
+  isPlanModeRequired: () => false,
+  isTeammate: () => false,
+}));
+vi.mock("../../utils/thinking.js", () => ({
+  shouldEnableThinkingByDefault: () => false,
+}));
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+type NotificationApi = ReturnType<typeof useNotifications>;
+
+type NotificationSnapshot = {
+  current: string | null;
+  currentText: string | null;
+  queue: string[];
+  queueTexts: Array<string | null>;
+};
+
+function createTestStreams(): {
+  stdout: PassThrough;
+  stdin: TestStdin;
+} {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number }).columns = 120;
+  (stdout as unknown as { rows: number }).rows = 24;
+  (stdout as unknown as { isTTY: boolean }).isTTY = true;
+  stdout.resume();
+
+  return { stdout, stdin };
+}
+
+function waitForCondition(
+  predicate: () => boolean,
+  timeoutMs = 2_000,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const startedAt = Date.now();
+    const poll = () => {
+      if (predicate()) {
+        resolve();
+        return;
+      }
+      if (Date.now() - startedAt >= timeoutMs) {
+        reject(new Error("Timed out waiting for notifications context state"));
+        return;
+      }
+      setTimeout(poll, 10);
+    };
+    poll();
+  });
+}
+
+function notificationText(
+  notification: Notification | null | undefined,
+): string | null {
+  if (!notification) return null;
+  if ("text" in notification) return notification.text;
+  return "jsx";
+}
+
+function snapshotNotifications(
+  notifications: AppState["notifications"],
+): NotificationSnapshot {
+  return {
+    current: notifications.current?.key ?? null,
+    currentText: notificationText(notifications.current),
+    queue: notifications.queue.map((notification) => notification.key),
+    queueTexts: notifications.queue.map(notificationText),
+  };
+}
+
+function textNotification(
+  key: string,
+  text: string,
+  overrides: Partial<Notification> = {},
+): Notification {
+  return {
+    key,
+    text,
+    priority: "medium",
+    timeoutMs: 1_000,
+    ...overrides,
+  } as Notification;
+}
+
+function appendText(
+  accumulator: Notification,
+  incoming: Notification,
+): Notification {
+  return {
+    ...incoming,
+    text: `${notificationText(accumulator) ?? ""}${notificationText(incoming) ?? ""}`,
+  } as Notification;
+}
+
+function createInitialState(
+  notifications: AppState["notifications"] = { current: null, queue: [] },
+): AppState {
+  return {
+    ...getDefaultAppState(),
+    notifications,
+  };
+}
+
+async function renderNotificationsHarness(
+  initialState = createInitialState(),
+): Promise<{
+  api: () => NotificationApi;
+  dispose: () => Promise<void>;
+  snapshots: NotificationSnapshot[];
+  state: () => AppState["notifications"];
+}> {
+  let api: NotificationApi | undefined;
+  let store: ReturnType<typeof useAppStateStore> | undefined;
+  const snapshots: NotificationSnapshot[] = [];
+  const { stdout, stdin } = createTestStreams();
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  });
+
+  function Probe(): React.ReactNode {
+    api = useNotifications();
+    store = useAppStateStore();
+    const notifications = useAppState((state) => state.notifications);
+
+    React.useEffect(() => {
+      snapshots.push(snapshotNotifications(notifications));
+    }, [notifications]);
+
+    return <Text>notifications</Text>;
+  }
+
+  root.render(
+    <AppStateProvider initialState={initialState}>
+      <Probe />
+    </AppStateProvider>,
+  );
+
+  await waitForCondition(() => api !== undefined && store !== undefined);
+
+  return {
+    api: () => {
+      if (!api) throw new Error("notifications hook did not render");
+      return api;
+    },
+    dispose: async () => {
+      if (api && store) {
+        for (let i = 0; i < 20; i += 1) {
+          const { current, queue } = store.getState().notifications;
+          if (!current && queue.length === 0) break;
+          if (current) {
+            api.removeNotification(current.key);
+          } else {
+            for (const notification of queue) {
+              api.removeNotification(notification.key);
+            }
+          }
+        }
+      }
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await Promise.resolve();
+    },
+    snapshots,
+    state: () => {
+      if (!store) throw new Error("app state store did not render");
+      return store.getState().notifications;
+    },
+  };
+}
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe("notification context", () => {
+  test("starts with provider defaults and ranks queued notifications by priority", async () => {
+    const defaultState = getDefaultAppState();
+    expect(defaultState.notifications).toEqual({
+      current: null,
+      queue: [],
+    });
+    expect(getNext([])).toBeUndefined();
+
+    const low = textNotification("low", "Low", { priority: "low" });
+    const high = textNotification("high", "High", { priority: "high" });
+    const immediate = textNotification("immediate", "Immediate", {
+      priority: "immediate",
+    });
+    const queue = [low, high, immediate];
+
+    expect(getNext(queue)).toBe(immediate);
+    expect(queue).toEqual([low, high, immediate]);
+
+    const harness = await renderNotificationsHarness(defaultState);
+    try {
+      expect(snapshotNotifications(harness.state())).toEqual({
+        current: null,
+        currentText: null,
+        queue: [],
+        queueTexts: [],
+      });
+      expect(harness.snapshots.at(-1)).toEqual({
+        current: null,
+        currentText: null,
+        queue: [],
+        queueTexts: [],
+      });
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  test("adds, folds, deduplicates, invalidates, and removes notifications", async () => {
+    const harness = await renderNotificationsHarness();
+    vi.useFakeTimers();
+
+    try {
+      harness.api().addNotification(textNotification("active", "one"));
+      expect(snapshotNotifications(harness.state())).toEqual({
+        current: "active",
+        currentText: "one",
+        queue: [],
+        queueTexts: [],
+      });
+
+      harness.api().addNotification(
+        textNotification("queued", "queued-one", { priority: "low" }),
+      );
+      harness.api().addNotification(
+        textNotification("urgent", "urgent", { priority: "high" }),
+      );
+      expect(snapshotNotifications(harness.state())).toMatchObject({
+        current: "active",
+        currentText: "one",
+        queue: ["queued", "urgent"],
+        queueTexts: ["queued-one", "urgent"],
+      });
+
+      harness.api().addNotification(
+        textNotification("active", "ignored-active"),
+      );
+      harness.api().addNotification(
+        textNotification("queued", "ignored-queued", { priority: "low" }),
+      );
+      expect(snapshotNotifications(harness.state())).toMatchObject({
+        current: "active",
+        currentText: "one",
+        queue: ["queued", "urgent"],
+        queueTexts: ["queued-one", "urgent"],
+      });
+
+      harness.api().addNotification(
+        textNotification("active", "+folded", { fold: appendText }),
+      );
+      harness.api().addNotification(
+        textNotification("queued", "+folded", {
+          fold: appendText,
+          priority: "low",
+        }),
+      );
+      expect(snapshotNotifications(harness.state())).toMatchObject({
+        current: "active",
+        currentText: "one+folded",
+        queue: ["queued", "urgent"],
+        queueTexts: ["queued-one+folded", "urgent"],
+      });
+
+      harness.api().removeNotification("active");
+      expect(snapshotNotifications(harness.state())).toMatchObject({
+        current: "urgent",
+        currentText: "urgent",
+        queue: ["queued"],
+        queueTexts: ["queued-one+folded"],
+      });
+
+      harness.api().addNotification(
+        textNotification("clear-queued", "clear queued", {
+          invalidates: ["queued"],
+        }),
+      );
+      expect(snapshotNotifications(harness.state())).toMatchObject({
+        current: "urgent",
+        queue: ["clear-queued"],
+      });
+
+      harness.api().addNotification(
+        textNotification("clear-current", "clear current", {
+          invalidates: ["urgent"],
+        }),
+      );
+      expect(snapshotNotifications(harness.state())).toMatchObject({
+        current: "clear-queued",
+        currentText: "clear queued",
+        queue: ["clear-current"],
+        queueTexts: ["clear current"],
+      });
+
+      const beforeMissingRemove = harness.state();
+      harness.api().removeNotification("missing");
+      expect(harness.state()).toBe(beforeMissingRemove);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  test("auto-dismisses with default and per-notification timers", async () => {
+    const harness = await renderNotificationsHarness();
+    vi.useFakeTimers();
+
+    try {
+      harness.api().addNotification(
+        textNotification("default-timeout", "Default", {
+          timeoutMs: undefined,
+        }),
+      );
+      harness.api().addNotification(
+        textNotification("short-timeout", "Short", { timeoutMs: 25 }),
+      );
+
+      await vi.advanceTimersByTimeAsync(7_999);
+      expect(snapshotNotifications(harness.state())).toMatchObject({
+        current: "default-timeout",
+        queue: ["short-timeout"],
+      });
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(snapshotNotifications(harness.state())).toMatchObject({
+        current: "short-timeout",
+        currentText: "Short",
+        queue: [],
+      });
+
+      await vi.advanceTimersByTimeAsync(25);
+      expect(snapshotNotifications(harness.state())).toEqual({
+        current: null,
+        currentText: null,
+        queue: [],
+        queueTexts: [],
+      });
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  test("shows immediate notifications now and resumes queued work after dismissal", async () => {
+    const harness = await renderNotificationsHarness();
+    vi.useFakeTimers();
+
+    try {
+      harness.api().addNotification(
+        textNotification("normal", "Normal", { priority: "medium" }),
+      );
+      harness.api().addNotification(
+        textNotification("queued", "Queued", { priority: "low" }),
+      );
+      harness.api().addNotification(
+        textNotification("immediate", "Immediate", {
+          invalidates: ["queued"],
+          priority: "immediate",
+          timeoutMs: 50,
+        }),
+      );
+
+      expect(snapshotNotifications(harness.state())).toEqual({
+        current: "immediate",
+        currentText: "Immediate",
+        queue: ["normal"],
+        queueTexts: ["Normal"],
+      });
+
+      await vi.advanceTimersByTimeAsync(49);
+      expect(snapshotNotifications(harness.state())).toMatchObject({
+        current: "immediate",
+        queue: ["normal"],
+      });
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(snapshotNotifications(harness.state())).toEqual({
+        current: "normal",
+        currentText: "Normal",
+        queue: [],
+        queueTexts: [],
+      });
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  test("cleans up removed notification timers before an id is reused", async () => {
+    const harness = await renderNotificationsHarness();
+    vi.useFakeTimers();
+
+    try {
+      harness.api().addNotification(
+        textNotification("reused", "old", { timeoutMs: 100 }),
+      );
+      harness.api().removeNotification("reused");
+      harness.api().addNotification(
+        textNotification("reused", "new", { timeoutMs: 1_000 }),
+      );
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(snapshotNotifications(harness.state())).toEqual({
+        current: "reused",
+        currentText: "new",
+        queue: [],
+        queueTexts: [],
+      });
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  test("throws the AppState provider error outside the provider", async () => {
+    const { stdout, stdin } = createTestStreams();
+    const stderr = new PassThrough();
+    let stderrOutput = "";
+    stderr.on("data", (chunk) => {
+      stderrOutput += chunk.toString();
+    });
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      patchConsole: false,
+    });
+
+    function OutsideProviderProbe(): React.ReactNode {
+      useNotifications();
+      return <Text>outside</Text>;
+    }
+
+    try {
+      root.render(<OutsideProviderProbe />);
+      await waitForCondition(() =>
+        stderrOutput.includes(
+          "useAppState/useSetAppState cannot be called outside of an <AppStateProvider />",
+        ),
+      );
+      expect(stderrOutput).toContain(
+        "useAppState/useSetAppState cannot be called outside of an <AppStateProvider />",
+      );
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      stderr.end();
+    }
+  });
+});

--- a/runtime/tests/tui/context/voice.wave200-115.coverage.test.tsx
+++ b/runtime/tests/tui/context/voice.wave200-115.coverage.test.tsx
@@ -1,0 +1,241 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { describe, expect, test, vi } from "vitest";
+
+import Text from "../ink/components/Text.js";
+import { createRoot } from "../ink/root.js";
+import {
+  VoiceProvider,
+  useGetVoiceState,
+  useSetVoiceState,
+  useVoiceState,
+  type VoiceState,
+} from "./voice.js";
+
+vi.mock("../../utils/debug.js", () => ({
+  logForDebugging: () => {},
+}));
+vi.mock("../../bootstrap/state.js", () => ({
+  flushInteractionTime: () => {},
+  markScrollActivity: () => {},
+  updateLastInteractionTime: () => {},
+}));
+vi.mock("../../utils/earlyInput.js", () => ({
+  stopCapturingEarlyInput: () => {},
+}));
+vi.mock("../../utils/envUtils.js", () => ({
+  isEnvTruthy: () => false,
+}));
+vi.mock("../../utils/fullscreen.js", () => ({
+  isMouseClicksDisabled: () => true,
+}));
+vi.mock("../../utils/log.js", () => ({
+  logError: () => {},
+}));
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+type Snapshot = VoiceState & {
+  getterStable: boolean | null;
+  setterStable: boolean | null;
+};
+
+function createTestStreams(): {
+  stdout: PassThrough;
+  stdin: TestStdin;
+} {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number }).columns = 120;
+  (stdout as unknown as { rows: number }).rows = 24;
+  (stdout as unknown as { isTTY: boolean }).isTTY = true;
+
+  return { stdout, stdin };
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("Timed out waiting for voice context state");
+}
+
+const selectVoiceState = (state: VoiceState) => state.voiceState;
+const selectVoiceError = (state: VoiceState) => state.voiceError;
+const selectVoiceInterimTranscript = (state: VoiceState) =>
+  state.voiceInterimTranscript;
+const selectVoiceAudioLevels = (state: VoiceState) => state.voiceAudioLevels;
+const selectVoiceWarmingUp = (state: VoiceState) => state.voiceWarmingUp;
+
+function VoiceProbe({
+  immediateReads,
+  snapshots,
+}: {
+  immediateReads: VoiceState[];
+  snapshots: Snapshot[];
+}): React.ReactNode {
+  const voiceState = useVoiceState(selectVoiceState);
+  const voiceError = useVoiceState(selectVoiceError);
+  const voiceInterimTranscript = useVoiceState(selectVoiceInterimTranscript);
+  const voiceAudioLevels = useVoiceState(selectVoiceAudioLevels);
+  const voiceWarmingUp = useVoiceState(selectVoiceWarmingUp);
+  const setVoiceState = useSetVoiceState();
+  const getVoiceState = useGetVoiceState();
+  const previousSetter = React.useRef<typeof setVoiceState | null>(null);
+  const previousGetter = React.useRef<typeof getVoiceState | null>(null);
+  const didUpdate = React.useRef(false);
+
+  React.useEffect(() => {
+    snapshots.push({
+      voiceState,
+      voiceError,
+      voiceInterimTranscript,
+      voiceAudioLevels,
+      voiceWarmingUp,
+      setterStable:
+        previousSetter.current === null
+          ? null
+          : previousSetter.current === setVoiceState,
+      getterStable:
+        previousGetter.current === null
+          ? null
+          : previousGetter.current === getVoiceState,
+    });
+    previousSetter.current = setVoiceState;
+    previousGetter.current = getVoiceState;
+  }, [
+    getVoiceState,
+    setVoiceState,
+    snapshots,
+    voiceAudioLevels,
+    voiceError,
+    voiceInterimTranscript,
+    voiceState,
+    voiceWarmingUp,
+  ]);
+
+  React.useEffect(() => {
+    if (didUpdate.current) return;
+    didUpdate.current = true;
+    setVoiceState((previous) => ({
+      ...previous,
+      voiceState: "recording",
+      voiceError: "microphone unavailable",
+      voiceInterimTranscript: "hello agenc",
+      voiceAudioLevels: [0.2, 0.5, 0.9],
+      voiceWarmingUp: true,
+    }));
+    immediateReads.push(getVoiceState());
+  }, [getVoiceState, immediateReads, setVoiceState]);
+
+  return <Text>{voiceState}</Text>;
+}
+
+function OutsideProviderProbe(): React.ReactNode {
+  useVoiceState(selectVoiceState);
+  return <Text>outside</Text>;
+}
+
+describe("VoiceProvider", () => {
+  test("publishes default state, supports synchronous updates, and rejects missing provider usage", async () => {
+    const snapshots: Snapshot[] = [];
+    const immediateReads: VoiceState[] = [];
+    const child = (
+      <VoiceProbe immediateReads={immediateReads} snapshots={snapshots} />
+    );
+    const { stdout, stdin } = createTestStreams();
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    });
+
+    try {
+      root.render(<VoiceProvider>{child}</VoiceProvider>);
+      await waitForCondition(() =>
+        snapshots.some((snapshot) => snapshot.voiceState === "recording"),
+      );
+      root.render(<VoiceProvider>{child}</VoiceProvider>);
+      await waitForCondition(() =>
+        snapshots.some((snapshot) => snapshot.setterStable === true),
+      );
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+
+    expect(snapshots[0]).toEqual({
+      voiceState: "idle",
+      voiceError: null,
+      voiceInterimTranscript: "",
+      voiceAudioLevels: [],
+      voiceWarmingUp: false,
+      setterStable: null,
+      getterStable: null,
+    });
+    expect(immediateReads[0]).toEqual({
+      voiceState: "recording",
+      voiceError: "microphone unavailable",
+      voiceInterimTranscript: "hello agenc",
+      voiceAudioLevels: [0.2, 0.5, 0.9],
+      voiceWarmingUp: true,
+    });
+    expect(snapshots).toContainEqual({
+      voiceState: "recording",
+      voiceError: "microphone unavailable",
+      voiceInterimTranscript: "hello agenc",
+      voiceAudioLevels: [0.2, 0.5, 0.9],
+      voiceWarmingUp: true,
+      setterStable: true,
+      getterStable: true,
+    });
+
+    const outside = createTestStreams();
+    const stderr = new PassThrough();
+    let stderrOutput = "";
+    stderr.on("data", (chunk) => {
+      stderrOutput += chunk.toString();
+    });
+    const outsideRoot = await createRoot({
+      stdout: outside.stdout as unknown as NodeJS.WriteStream,
+      stdin: outside.stdin as unknown as NodeJS.ReadStream,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      patchConsole: false,
+    });
+
+    try {
+      outsideRoot.render(<OutsideProviderProbe />);
+      await waitForCondition(() =>
+        stderrOutput.includes(
+          "useVoiceState must be used within a VoiceProvider",
+        ),
+      );
+    } finally {
+      outsideRoot.unmount();
+      outside.stdin.end();
+      outside.stdout.end();
+      stderr.end();
+    }
+
+    expect(stderrOutput).toContain(
+      "useVoiceState must be used within a VoiceProvider",
+    );
+  });
+});

--- a/runtime/tests/tui/cost/MemoryUsageIndicator.coverage.test.tsx
+++ b/runtime/tests/tui/cost/MemoryUsageIndicator.coverage.test.tsx
@@ -1,0 +1,75 @@
+import { PassThrough } from 'node:stream'
+
+import stripAnsi from 'strip-ansi'
+import { describe, expect, test, vi } from 'vitest'
+
+const mockUseMemoryUsage = vi.hoisted(() =>
+  vi.fn(() => ({
+    heapUsed: 3 * 1024 * 1024 * 1024,
+    status: 'critical' as const,
+  })),
+)
+
+vi.mock('../hooks/useMemoryUsage.js', () => ({
+  useMemoryUsage: mockUseMemoryUsage,
+}))
+
+import { createRoot } from '../ink/root.js'
+import { MemoryUsageIndicator } from './MemoryUsageIndicator.js'
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+async function renderToText(): Promise<string> {
+  let output = ''
+  const { stdin, stdout } = createStreams()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  try {
+    root.render(<MemoryUsageIndicator />)
+    await new Promise(resolve => setTimeout(resolve, 30))
+    return stripAnsi(output)
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+  }
+}
+
+describe('MemoryUsageIndicator coverage', () => {
+  test('does not render or subscribe in external builds', async () => {
+    const output = await renderToText()
+
+    expect(mockUseMemoryUsage).not.toHaveBeenCalled()
+    expect(output).toBe('')
+  })
+})

--- a/runtime/tests/tui/cost/TokenWarning.coverage.test.tsx
+++ b/runtime/tests/tui/cost/TokenWarning.coverage.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  autoCompactEnabled: false,
+  percentLeft: 7,
+  suppressWarning: false,
+  upgradeMessage: "/model sonnet[1m]",
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: () => false,
+}));
+
+vi.mock("../../services/analytics/growthbook.js", () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: () => false,
+}));
+
+vi.mock("../../services/compact/autoCompact.js", () => ({
+  calculateTokenWarningState: () => ({
+    isAboveAutoCompactThreshold: false,
+    isAboveErrorThreshold: false,
+    isAboveWarningThreshold: true,
+    isAtBlockingLimit: false,
+    percentLeft: harness.percentLeft,
+  }),
+  getEffectiveContextWindowSize: () => 200_000,
+  isAutoCompactEnabled: () => harness.autoCompactEnabled,
+}));
+
+vi.mock("../../services/compact/compactWarningHook.js", () => ({
+  useCompactWarningSuppression: () => harness.suppressWarning,
+}));
+
+vi.mock("../../services/contextCollapse/index.js", () => ({
+  isContextCollapseEnabled: () => false,
+}));
+
+vi.mock("../../utils/model/contextWindowUpgradeCheck.js", () => ({
+  getUpgradeMessage: () => harness.upgradeMessage,
+}));
+
+import { renderToString } from "../../utils/staticRender.js";
+import { TokenWarning } from "./TokenWarning.js";
+
+describe("TokenWarning coverage", () => {
+  test("renders the manual compact warning with upgrade guidance", async () => {
+    const output = await renderToString(
+      <TokenWarning tokenUsage={193_000} model="sonnet" />,
+      120,
+    );
+
+    expect(output).toContain("Context low (7% remaining)");
+    expect(output).toContain("/model sonnet[1m]");
+    expect(output).not.toContain("Run /compact to compact & continue");
+  });
+});

--- a/runtime/tests/tui/cost/TokenWarning.wave200-131.coverage.test.tsx
+++ b/runtime/tests/tui/cost/TokenWarning.wave200-131.coverage.test.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  autoCompactEnabled: true,
+  collapseEnabled: false,
+  effectiveWindow: 200_000,
+  enabledFeatures: new Set<string>(),
+  growthEnabled: false,
+  percentLeft: 9,
+  upgradeMessage: null as string | null,
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: (flag: string) => harness.enabledFeatures.has(flag),
+}));
+
+vi.mock("../../services/analytics/growthbook.js", () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: () => harness.growthEnabled,
+}));
+
+vi.mock("../../services/compact/autoCompact.js", () => ({
+  calculateTokenWarningState: () => ({
+    isAboveAutoCompactThreshold: true,
+    isAboveErrorThreshold: false,
+    isAboveWarningThreshold: true,
+    isAtBlockingLimit: false,
+    percentLeft: harness.percentLeft,
+  }),
+  getEffectiveContextWindowSize: () => harness.effectiveWindow,
+  isAutoCompactEnabled: () => harness.autoCompactEnabled,
+}));
+
+vi.mock("../../services/compact/compactWarningHook.js", () => ({
+  useCompactWarningSuppression: () => false,
+}));
+
+vi.mock("../../services/contextCollapse/index.js", () => ({
+  isContextCollapseEnabled: () => harness.collapseEnabled,
+}));
+
+vi.mock("../../utils/model/contextWindowUpgradeCheck.js", () => ({
+  getUpgradeMessage: () => harness.upgradeMessage,
+}));
+
+import { renderToString } from "../../utils/staticRender.js";
+import { TokenWarning } from "./TokenWarning.js";
+
+describe("TokenWarning wave 200 worker 131 coverage", () => {
+  test("renders auto-compact labels from reactive and collapse context modes", async () => {
+    harness.enabledFeatures = new Set(["REACTIVE_COMPACT"]);
+    harness.growthEnabled = true;
+    harness.collapseEnabled = false;
+
+    const reactiveOutput = await renderToString(
+      <TokenWarning tokenUsage={190_000} model="sonnet" />,
+      120,
+    );
+
+    expect(reactiveOutput).toContain("95% context used");
+    expect(reactiveOutput).not.toContain("Context low");
+
+    harness.enabledFeatures = new Set(["CONTEXT_COLLAPSE"]);
+    harness.growthEnabled = false;
+    harness.collapseEnabled = true;
+
+    const collapseOutput = await renderToString(
+      <TokenWarning tokenUsage={190_000} model="sonnet" />,
+      120,
+    );
+
+    expect(collapseOutput).toContain("5% until auto-compact");
+    expect(collapseOutput).not.toContain("Run /compact");
+  });
+});

--- a/runtime/tests/tui/daemon-session.wave200-065.coverage.test.ts
+++ b/runtime/tests/tui/daemon-session.wave200-065.coverage.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  createDaemonTuiSession,
+  type AgenCDaemonTuiClient,
+  type AgenCTuiBridgeSession,
+} from "./daemon-session.js";
+import type {
+  AgenCDaemonMethod,
+  AgenCDaemonResultByMethod,
+  JsonObject,
+} from "../app-server/protocol/index.js";
+
+function createBaseSession(): AgenCTuiBridgeSession {
+  return {
+    conversationId: "local_session",
+    services: {},
+  };
+}
+
+function createClient(): AgenCDaemonTuiClient & {
+  emitNotification(event: JsonObject): void;
+} {
+  const notificationListeners = new Set<(event: JsonObject) => void>();
+
+  return {
+    async request<Method extends AgenCDaemonMethod>(): Promise<
+      AgenCDaemonResultByMethod[Method]
+    > {
+      return {} as AgenCDaemonResultByMethod[Method];
+    },
+    subscribeToSessionEvents: () => () => {},
+    subscribeToNotifications: (cb) => {
+      notificationListeners.add(cb);
+      return () => {
+        notificationListeners.delete(cb);
+      };
+    },
+    emitNotification(event) {
+      for (const listener of notificationListeners) {
+        listener(event);
+      }
+    },
+  } as AgenCDaemonTuiClient & {
+    emitNotification(event: JsonObject): void;
+  };
+}
+
+describe("daemon TUI realtime notification coverage", () => {
+  test("ignores unrelated notifications and supplies fallback realtime transcript fields", () => {
+    const client = createClient();
+    const audioPlayer = {
+      enqueue: vi.fn(),
+      close: vi.fn(),
+    };
+    const session = createDaemonTuiSession({
+      baseSession: createBaseSession(),
+      client,
+      sessionId: "session_1",
+      clientId: "tui_1",
+      realtimeThreadId: "agent_1",
+      realtimeAudioPlayer: audioPlayer,
+    });
+    const received: JsonObject[] = [];
+
+    const unsubscribe = session.subscribeToEvents((event) => {
+      received.push(event as JsonObject);
+    });
+
+    client.emitNotification({ params: { threadId: "agent_1" } });
+    client.emitNotification({
+      method: "event.message_chunk",
+      params: { threadId: "agent_1", delta: "ignored" },
+    });
+    client.emitNotification({
+      method: "thread/realtime/started",
+      params: "not-an-object",
+    });
+    client.emitNotification({
+      method: "thread/realtime/unhandled",
+      params: { threadId: "agent_1" },
+    });
+    client.emitNotification({
+      method: "thread/realtime/started",
+      params: { threadId: "agent_1" },
+    });
+    client.emitNotification({
+      method: "thread/realtime/transcript/delta",
+      params: { eventId: "delta_default", threadId: "agent_1" },
+    });
+    client.emitNotification({
+      method: "thread/realtime/transcript/done",
+      params: { eventId: "done_default", threadId: "agent_1" },
+    });
+    client.emitNotification({
+      method: "thread/realtime/itemAdded",
+      params: { eventId: "item_default", threadId: "agent_1" },
+    });
+    client.emitNotification({
+      method: "thread/realtime/sdp",
+      params: { eventId: "sdp_default", threadId: "agent_1" },
+    });
+    client.emitNotification({
+      method: "thread/realtime/error",
+      params: { eventId: "error_default", threadId: "agent_1" },
+    });
+    client.emitNotification({
+      method: "thread/realtime/closed",
+      params: { eventId: "closed_default", threadId: "agent_1" },
+    });
+    unsubscribe();
+
+    expect(received).toEqual([
+      {
+        id: expect.stringMatching(/^realtime:thread\/realtime\/started:agent_1:\d+$/u),
+        type: "realtime_started",
+        payload: {
+          threadId: "agent_1",
+          realtimeSessionId: null,
+        },
+      },
+      {
+        id: "delta_default",
+        type: "realtime_transcript_delta",
+        payload: {
+          threadId: "agent_1",
+          role: "assistant",
+          delta: "",
+        },
+      },
+      {
+        id: "done_default",
+        type: "realtime_transcript_done",
+        payload: {
+          threadId: "agent_1",
+          role: "assistant",
+          text: "",
+        },
+      },
+      {
+        id: "item_default",
+        type: "realtime_item_added",
+        payload: {
+          threadId: "agent_1",
+          item: null,
+        },
+      },
+      {
+        id: "sdp_default",
+        type: "realtime_sdp",
+        payload: {
+          threadId: "agent_1",
+          sdp: "",
+        },
+      },
+      {
+        id: "error_default",
+        type: "realtime_error",
+        payload: {
+          threadId: "agent_1",
+          message: "Realtime error",
+        },
+      },
+      {
+        id: "closed_default",
+        type: "realtime_closed",
+        payload: {
+          threadId: "agent_1",
+          reason: null,
+        },
+      },
+    ]);
+    expect(audioPlayer.enqueue).not.toHaveBeenCalled();
+    expect(audioPlayer.close).toHaveBeenCalledTimes(2);
+  });
+});

--- a/runtime/tests/tui/history/HistorySearchDialog.coverage.test.tsx
+++ b/runtime/tests/tui/history/HistorySearchDialog.coverage.test.tsx
@@ -1,0 +1,339 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type HistoryEntryLike = {
+  display: string
+}
+
+type TimestampedEntryLike = {
+  display: string
+  timestamp: number
+  resolve: () => Promise<HistoryEntryLike>
+}
+
+type PickerItem = {
+  entry: TimestampedEntryLike
+  display: string
+  firstLine: string
+}
+
+type CapturedPickerProps = {
+  title: string
+  placeholder?: string
+  initialQuery?: string
+  items: readonly PickerItem[]
+  getKey: (item: PickerItem) => string
+  onQueryChange: (query: string) => void
+  onSelect: (item: PickerItem) => void
+  onCancel: () => void
+  emptyMessage?: string | ((query: string) => string)
+  selectAction?: string
+  direction?: 'up' | 'down'
+  previewPosition?: 'bottom' | 'right'
+  renderItem: (item: PickerItem, isFocused: boolean) => React.ReactNode
+  renderPreview: (item: PickerItem) => React.ReactNode
+}
+
+type Deferred = {
+  promise: Promise<void>
+  resolve: () => void
+}
+
+const harness = vi.hoisted(() => ({
+  entries: [] as TimestampedEntryLike[],
+  getTimestampedHistory: vi.fn(() => {
+    let index = 0
+    const reader = {
+      next: vi.fn(async (): Promise<IteratorResult<TimestampedEntryLike>> => {
+        await harness.historyGate?.promise
+        if (index >= harness.entries.length) {
+          return { done: true, value: undefined }
+        }
+
+        const value = harness.entries[index]
+        index += 1
+        return { done: false, value: value! }
+      }),
+      return: vi.fn(async (): Promise<IteratorResult<TimestampedEntryLike>> => ({
+        done: true,
+        value: undefined,
+      })),
+      [Symbol.asyncIterator]() {
+        return this
+      },
+    }
+
+    harness.readers.push(reader)
+    return reader
+  }),
+  historyGate: undefined as Deferred | undefined,
+  logEvent: vi.fn(),
+  pickerProps: undefined as CapturedPickerProps | undefined,
+  readers: [] as Array<{
+    next: ReturnType<typeof vi.fn>
+    return: ReturnType<typeof vi.fn>
+  }>,
+  registerOverlay: vi.fn(),
+  terminal: {
+    columns: 120,
+    rows: 30,
+  },
+}))
+
+vi.mock('../context/overlayContext.js', () => ({
+  useRegisterOverlay: harness.registerOverlay,
+}))
+
+vi.mock('./history.js', () => ({
+  getTimestampedHistory: harness.getTimestampedHistory,
+}))
+
+vi.mock('../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => harness.terminal,
+}))
+
+vi.mock('../../services/analytics/index.js', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../components/design-system/FuzzyPicker.js', () => ({
+  FuzzyPicker: (props: CapturedPickerProps) => {
+    harness.pickerProps = props
+    return null
+  },
+}))
+
+import { createRoot } from '../ink/root.js'
+import { renderToString } from '../../utils/staticRender.js'
+import { HistorySearchDialog } from './HistorySearchDialog.js'
+
+function deferred(): Deferred {
+  let resolve!: () => void
+  const promise = new Promise<void>(res => {
+    resolve = res
+  })
+
+  return { promise, resolve }
+}
+
+function resetHarness() {
+  harness.entries = []
+  harness.getTimestampedHistory.mockClear()
+  harness.historyGate = undefined
+  harness.logEvent.mockClear()
+  harness.pickerProps = undefined
+  harness.readers = []
+  harness.registerOverlay.mockClear()
+  harness.terminal.columns = 120
+  harness.terminal.rows = 30
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await sleep(10)
+  }
+
+  throw new Error(message)
+}
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = harness.terminal.columns
+  ;(stdout as unknown as { rows: number }).rows = harness.terminal.rows
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function pickerProps(): CapturedPickerProps {
+  const props = harness.pickerProps
+  if (!props) throw new Error('History search picker props were not captured')
+  return props
+}
+
+function emptyMessage(props: CapturedPickerProps, query: string): string {
+  const message = props.emptyMessage
+  return typeof message === 'function' ? message(query) : message ?? ''
+}
+
+async function renderDialog(initialQuery?: string) {
+  const onCancel = vi.fn()
+  const onSelect = vi.fn()
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  root.render(
+    <HistorySearchDialog
+      initialQuery={initialQuery}
+      onCancel={onCancel}
+      onSelect={onSelect}
+    />,
+  )
+  await waitFor(() => harness.pickerProps !== undefined, 'Dialog did not render')
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep(25)
+    },
+    onCancel,
+    onSelect,
+  }
+}
+
+describe('HistorySearchDialog coverage', () => {
+  beforeEach(() => {
+    resetHarness()
+  })
+
+  it('loads history into the picker, filters exact before fuzzy matches, previews, and selects', async () => {
+    const exactResolvedEntry = { display: 'deploy api route' }
+    const exactResolve = vi.fn(async () => exactResolvedEntry)
+    const fuzzyResolve = vi.fn(async () => ({ display: 'archive project notes' }))
+    const missResolve = vi.fn(async () => ({ display: 'unrelated' }))
+
+    harness.historyGate = deferred()
+    harness.entries = [
+      {
+        display: [
+          'deploy api route',
+          '',
+          'preview detail 1',
+          'preview detail 2',
+          'preview detail 3',
+          'preview detail 4',
+          'preview detail 5',
+          'preview detail 6',
+          'preview detail 7',
+        ].join('\n'),
+        timestamp: 1710000000000,
+        resolve: exactResolve,
+      },
+      {
+        display: 'archive project notes',
+        timestamp: 1700000000000,
+        resolve: fuzzyResolve,
+      },
+      {
+        display: 'zzz unrelated',
+        timestamp: 1690000000000,
+        resolve: missResolve,
+      },
+    ]
+
+    const rendered = await renderDialog('ap')
+
+    try {
+      const loadingProps = pickerProps()
+      expect(harness.registerOverlay).toHaveBeenCalledWith('history-search')
+      expect(loadingProps.title).toBe('Search prompts')
+      expect(loadingProps.placeholder).toMatch(/^Filter history/)
+      expect(loadingProps.initialQuery).toBe('ap')
+      expect(loadingProps.selectAction).toBe('use')
+      expect(loadingProps.direction).toBe('up')
+      expect(loadingProps.previewPosition).toBe('right')
+      expect(loadingProps.items).toEqual([])
+      expect(emptyMessage(loadingProps, '')).toMatch(/^Loading/)
+
+      harness.historyGate.resolve()
+      await waitFor(
+        () => pickerProps().items.map(item => item.firstLine).join('\0') ===
+          'deploy api route\0archive project notes',
+        'History search did not filter exact and fuzzy matches',
+      )
+
+      const filteredProps = pickerProps()
+      expect(filteredProps.items.map(item => item.firstLine)).toEqual([
+        'deploy api route',
+        'archive project notes',
+      ])
+      expect(filteredProps.getKey(filteredProps.items[0]!)).toBe('1710000000000')
+      expect(emptyMessage(filteredProps, 'absent')).toBe('No matching prompts')
+
+      filteredProps.onQueryChange('   ')
+      await waitFor(
+        () => pickerProps().items.length === 3,
+        'History search did not return all items for a blank query',
+      )
+      expect(emptyMessage(pickerProps(), '')).toBe('No history yet')
+
+      pickerProps().onQueryChange('ap')
+      await waitFor(
+        () => pickerProps().items.length === 2,
+        'History search did not restore filtered items',
+      )
+
+      const props = pickerProps()
+      const exactItem = props.items[0]!
+      const fuzzyItem = props.items[1]!
+      const focusedItem = await renderToString(props.renderItem(exactItem, true), 120)
+      const plainItem = await renderToString(props.renderItem(fuzzyItem, false), 120)
+      expect(focusedItem).toContain('deploy api route')
+      expect(plainItem).toContain('archive project notes')
+
+      const overflowingPreview = await renderToString(props.renderPreview(exactItem), 120)
+      expect(overflowingPreview).toContain('deploy api route')
+      expect(overflowingPreview).toContain('preview detail 4')
+      expect(overflowingPreview).toContain('+3 more lines')
+
+      const shortPreview = await renderToString(props.renderPreview(fuzzyItem), 120)
+      expect(shortPreview).toContain('archive project notes')
+      expect(shortPreview).not.toContain('more lines')
+
+      props.onSelect(exactItem)
+      await waitFor(
+        () => rendered.onSelect.mock.calls.length === 1,
+        'History search selection did not resolve',
+      )
+      expect(exactResolve).toHaveBeenCalledTimes(1)
+      expect(rendered.onSelect).toHaveBeenCalledWith(exactResolvedEntry)
+      expect(harness.logEvent).toHaveBeenCalledWith('agenc_history_picker_select', {
+        result_count: 2,
+        query_length: 2,
+      })
+
+      props.onCancel()
+      expect(rendered.onCancel).toHaveBeenCalledTimes(1)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/history/history.io.test.ts
+++ b/runtime/tests/tui/history/history.io.test.ts
@@ -1,0 +1,382 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+type LogEntryLike = {
+  display: string
+  pastedContents?: Record<string, unknown>
+  project: string
+  sessionId?: string
+  timestamp: number
+}
+
+const harness = vi.hoisted(() => ({
+  appendFile: vi.fn(),
+  cleanup: undefined as undefined | (() => Promise<void>),
+  configHome: '/tmp/agenc-home',
+  debug: vi.fn(),
+  hashPastedText: vi.fn((content: string) => `hash:${content.length}`),
+  lines: [] as string[],
+  lock: vi.fn(),
+  lockRelease: vi.fn(),
+  projectRoot: '/workspace/project',
+  readError: null as null | NodeJS.ErrnoException,
+  readPath: undefined as undefined | string,
+  registerCleanup: vi.fn((cleanup: () => Promise<void>) => {
+    harness.cleanup = cleanup
+  }),
+  retrievePastedText: vi.fn(),
+  sessionId: 'session-current',
+  skipHistory: false,
+  sleep: vi.fn(async () => {}),
+  storePastedText: vi.fn(),
+  writeFile: vi.fn(),
+}))
+
+vi.mock('fs/promises', () => ({
+  appendFile: harness.appendFile,
+  writeFile: harness.writeFile,
+}))
+
+vi.mock('../../bootstrap/state.js', () => ({
+  getProjectRoot: () => harness.projectRoot,
+  getSessionId: () => harness.sessionId,
+}))
+
+vi.mock('../../utils/cleanupRegistry.js', () => ({
+  registerCleanup: harness.registerCleanup,
+}))
+
+vi.mock('../../utils/debug.js', () => ({
+  logForDebugging: harness.debug,
+}))
+
+vi.mock('../../utils/envUtils.js', () => ({
+  getAgenCConfigHomeDir: () => harness.configHome,
+  isEnvTruthy: () => harness.skipHistory,
+}))
+
+vi.mock('../../utils/errors.js', () => ({
+  getErrnoCode: (error: NodeJS.ErrnoException) => error.code,
+}))
+
+vi.mock('../../utils/fsOperations.js', () => ({
+  readLinesReverse: async function* (path: string) {
+    harness.readPath = path
+    if (harness.readError) throw harness.readError
+    for (const line of harness.lines) {
+      yield line
+    }
+  },
+}))
+
+vi.mock('../../utils/lockfile.js', () => ({
+  lock: harness.lock,
+}))
+
+vi.mock('../../utils/pasteStore.js', () => ({
+  hashPastedText: harness.hashPastedText,
+  retrievePastedText: harness.retrievePastedText,
+  storePastedText: harness.storePastedText,
+}))
+
+vi.mock('../../utils/sleep.js', () => ({
+  sleep: harness.sleep,
+}))
+
+vi.mock('../../utils/slowOperations.js', () => ({
+  jsonParse: JSON.parse,
+  jsonStringify: JSON.stringify,
+}))
+
+function entry(overrides: Partial<LogEntryLike>): LogEntryLike {
+  return {
+    display: 'prompt',
+    pastedContents: {},
+    project: harness.projectRoot,
+    sessionId: harness.sessionId,
+    timestamp: 1,
+    ...overrides,
+  }
+}
+
+async function loadHistoryModule(): Promise<typeof import('./history.js')> {
+  vi.resetModules()
+  return import('./history.js')
+}
+
+async function waitFor(
+  assertion: () => void,
+  timeoutMs = 1000,
+): Promise<void> {
+  const startedAt = Date.now()
+  let lastError: unknown
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await new Promise(resolve => setTimeout(resolve, 10))
+    }
+  }
+
+  throw lastError
+}
+
+beforeEach(() => {
+  harness.appendFile.mockReset()
+  harness.appendFile.mockResolvedValue(undefined)
+  harness.cleanup = undefined
+  harness.configHome = '/tmp/agenc-home'
+  harness.debug.mockReset()
+  harness.hashPastedText.mockClear()
+  harness.lines = []
+  harness.lock.mockReset()
+  harness.lockRelease.mockReset()
+  harness.lockRelease.mockResolvedValue(undefined)
+  harness.lock.mockResolvedValue(harness.lockRelease)
+  harness.projectRoot = '/workspace/project'
+  harness.readError = null
+  harness.readPath = undefined
+  harness.registerCleanup.mockClear()
+  harness.retrievePastedText.mockReset()
+  harness.retrievePastedText.mockResolvedValue(null)
+  harness.sessionId = 'session-current'
+  harness.skipHistory = false
+  harness.sleep.mockClear()
+  harness.storePastedText.mockReset()
+  harness.storePastedText.mockResolvedValue(undefined)
+  harness.writeFile.mockReset()
+  harness.writeFile.mockResolvedValue(undefined)
+})
+
+describe('history io', () => {
+  test('reads current-session history before other sessions and resolves stored paste content', async () => {
+    harness.retrievePastedText.mockResolvedValue('retrieved large paste')
+    harness.lines = [
+      JSON.stringify(
+        entry({
+          display: 'other newest',
+          sessionId: 'other-session',
+          timestamp: 3,
+        }),
+      ),
+      JSON.stringify(
+        entry({
+          display: 'current older',
+          pastedContents: {
+            1: {
+              id: 1,
+              type: 'text',
+              content: 'inline paste',
+              filename: 'inline.txt',
+            },
+            2: {
+              id: 2,
+              type: 'text',
+              contentHash: 'large-hash',
+              mediaType: 'text/plain',
+            },
+            3: {
+              id: 3,
+              type: 'image',
+              content: 'base64-image',
+              mediaType: 'image/png',
+            },
+          },
+          timestamp: 2,
+        }),
+      ),
+      JSON.stringify(
+        entry({
+          display: 'wrong project',
+          project: '/workspace/other',
+          timestamp: 1,
+        }),
+      ),
+    ]
+    const history = await loadHistoryModule()
+
+    const results = await Array.fromAsync(history.getHistory())
+
+    expect(harness.readPath).toBe('/tmp/agenc-home/history.jsonl')
+    expect(results.map(result => result.display)).toEqual([
+      'current older',
+      'other newest',
+    ])
+    expect(results[0]!.pastedContents).toMatchObject({
+      1: {
+        id: 1,
+        type: 'text',
+        content: 'inline paste',
+        filename: 'inline.txt',
+      },
+      2: {
+        id: 2,
+        type: 'text',
+        content: 'retrieved large paste',
+        mediaType: 'text/plain',
+      },
+      3: {
+        id: 3,
+        type: 'image',
+        content: 'base64-image',
+        mediaType: 'image/png',
+      },
+    })
+    expect(harness.retrievePastedText).toHaveBeenCalledWith('large-hash')
+  })
+
+  test('deduplicates timestamped project history and skips malformed lines', async () => {
+    harness.retrievePastedText.mockResolvedValue('lazy paste')
+    harness.lines = [
+      'not json',
+      JSON.stringify(entry({ display: 'same', timestamp: 4 })),
+      JSON.stringify(entry({ display: 'wrong', project: '/elsewhere', timestamp: 3 })),
+      JSON.stringify(entry({ display: 'same', timestamp: 2 })),
+      JSON.stringify(
+        entry({
+          display: 'unique',
+          pastedContents: {
+            7: { id: 7, type: 'text', contentHash: 'lazy-hash' },
+          },
+          timestamp: 1,
+        }),
+      ),
+    ]
+    const history = await loadHistoryModule()
+
+    const timestamped = await Array.fromAsync(history.getTimestampedHistory())
+
+    expect(harness.debug).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to parse history line:'),
+    )
+    expect(timestamped.map(item => [item.display, item.timestamp])).toEqual([
+      ['same', 4],
+      ['unique', 1],
+    ])
+    await expect(timestamped[1]!.resolve()).resolves.toMatchObject({
+      display: 'unique',
+      pastedContents: {
+        7: { content: 'lazy paste' },
+      },
+    })
+  })
+
+  test('treats missing history files as empty and rethrows other read failures', async () => {
+    const history = await loadHistoryModule()
+    harness.readError = Object.assign(new Error('missing'), { code: 'ENOENT' })
+    await expect(Array.fromAsync(history.makeHistoryReader())).resolves.toEqual(
+      [],
+    )
+
+    harness.readError = Object.assign(new Error('denied'), { code: 'EACCES' })
+    await expect(Array.fromAsync(history.makeHistoryReader())).rejects.toThrow(
+      'denied',
+    )
+  })
+
+  test('writes history entries with inline and externalized text paste content', async () => {
+    const history = await loadHistoryModule()
+    const longPaste = 'x'.repeat(1025)
+
+    history.addToHistory({
+      display: 'run command',
+      pastedContents: {
+        1: {
+          id: 1,
+          type: 'text',
+          content: 'short paste',
+          mediaType: 'text/plain',
+          filename: 'short.txt',
+        },
+        2: {
+          id: 2,
+          type: 'text',
+          content: longPaste,
+          mediaType: 'text/plain',
+        },
+        3: {
+          id: 3,
+          type: 'image',
+          content: 'base64-image',
+          mediaType: 'image/png',
+        },
+      },
+    })
+
+    await waitFor(() => {
+      expect(harness.appendFile).toHaveBeenCalledTimes(1)
+    })
+
+    expect(harness.registerCleanup).toHaveBeenCalledTimes(1)
+    expect(harness.writeFile).toHaveBeenCalledWith(
+      '/tmp/agenc-home/history.jsonl',
+      '',
+      { encoding: 'utf8', mode: 0o600, flag: 'a' },
+    )
+    expect(harness.lock).toHaveBeenCalledWith('/tmp/agenc-home/history.jsonl', {
+      stale: 10000,
+      retries: {
+        retries: 3,
+        minTimeout: 50,
+      },
+    })
+    expect(harness.lockRelease).toHaveBeenCalledTimes(1)
+    expect(harness.storePastedText).toHaveBeenCalledWith(
+      'hash:1025',
+      longPaste,
+    )
+
+    const payload = String(harness.appendFile.mock.calls[0]![1])
+    const written = JSON.parse(payload.trim())
+    expect(written).toMatchObject({
+      display: 'run command',
+      project: '/workspace/project',
+      sessionId: 'session-current',
+    })
+    expect(written.pastedContents).toEqual({
+      1: {
+        id: 1,
+        type: 'text',
+        content: 'short paste',
+        mediaType: 'text/plain',
+        filename: 'short.txt',
+      },
+      2: {
+        id: 2,
+        type: 'text',
+        contentHash: 'hash:1025',
+        mediaType: 'text/plain',
+      },
+    })
+  })
+
+  test('skips disabled prompt history and removes flushed history from readers', async () => {
+    const history = await loadHistoryModule()
+
+    harness.skipHistory = true
+    history.addToHistory('skipped command')
+    await new Promise(resolve => setTimeout(resolve, 20))
+    expect(harness.registerCleanup).not.toHaveBeenCalled()
+    expect(harness.appendFile).not.toHaveBeenCalled()
+
+    harness.skipHistory = false
+    history.addToHistory('temporary command')
+    await waitFor(() => {
+      expect(harness.appendFile).toHaveBeenCalledTimes(1)
+    })
+    const flushedLine = String(harness.appendFile.mock.calls[0]![1]).trim()
+
+    history.removeLastFromHistory()
+    harness.lines = [flushedLine]
+
+    await expect(Array.fromAsync(history.getHistory())).resolves.toEqual([])
+
+    history.clearPendingHistoryEntries()
+    harness.lines = [flushedLine]
+    await expect(Array.fromAsync(history.getHistory())).resolves.toEqual([
+      { display: 'temporary command', pastedContents: {} },
+    ])
+  })
+})

--- a/runtime/tests/tui/history/history.wave200-133.coverage.test.ts
+++ b/runtime/tests/tui/history/history.wave200-133.coverage.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+type Deferred = {
+  promise: Promise<void>
+  resolve: () => void
+}
+
+function deferred(): Deferred {
+  let resolve!: () => void
+  const promise = new Promise<void>(res => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+const harness = vi.hoisted(() => ({
+  appendDeferred: undefined as Deferred | undefined,
+  appendFile: vi.fn(),
+  cleanup: undefined as undefined | (() => Promise<void>),
+  lock: vi.fn(),
+  lockRelease: vi.fn(),
+  registerCleanup: vi.fn((cleanup: () => Promise<void>) => {
+    harness.cleanup = cleanup
+  }),
+  writeFile: vi.fn(),
+}))
+
+vi.mock('fs/promises', () => ({
+  appendFile: harness.appendFile,
+  writeFile: harness.writeFile,
+}))
+
+vi.mock('../../bootstrap/state.js', () => ({
+  getProjectRoot: () => '/workspace/project',
+  getSessionId: () => 'session-current',
+}))
+
+vi.mock('../../utils/cleanupRegistry.js', () => ({
+  registerCleanup: harness.registerCleanup,
+}))
+
+vi.mock('../../utils/envUtils.js', () => ({
+  getAgenCConfigHomeDir: () => '/tmp/agenc-home',
+  isEnvTruthy: () => false,
+}))
+
+vi.mock('../../utils/lockfile.js', () => ({
+  lock: harness.lock,
+}))
+
+vi.mock('../../utils/pasteStore.js', () => ({
+  hashPastedText: (content: string) => `hash:${content.length}`,
+  retrievePastedText: vi.fn(),
+  storePastedText: vi.fn(),
+}))
+
+vi.mock('../../utils/slowOperations.js', () => ({
+  jsonParse: JSON.parse,
+  jsonStringify: JSON.stringify,
+}))
+
+async function loadHistoryModule(): Promise<typeof import('./history.js')> {
+  vi.resetModules()
+  return import('./history.js')
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  const startedAt = Date.now()
+  let lastError: unknown
+
+  while (Date.now() - startedAt < 1000) {
+    try {
+      assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await new Promise(resolve => setTimeout(resolve, 10))
+    }
+  }
+
+  throw lastError
+}
+
+beforeEach(() => {
+  harness.appendDeferred = deferred()
+  harness.appendFile.mockReset()
+  harness.appendFile.mockImplementation(() => harness.appendDeferred!.promise)
+  harness.cleanup = undefined
+  harness.lock.mockReset()
+  harness.lockRelease.mockReset()
+  harness.lockRelease.mockResolvedValue(undefined)
+  harness.lock.mockResolvedValue(harness.lockRelease)
+  harness.registerCleanup.mockClear()
+  harness.writeFile.mockReset()
+  harness.writeFile.mockResolvedValue(undefined)
+})
+
+describe('history prompt cleanup coverage', () => {
+  test('registered cleanup waits for an in-flight prompt history flush', async () => {
+    const history = await loadHistoryModule()
+
+    history.addToHistory('cleanup command')
+
+    await waitFor(() => {
+      expect(harness.appendFile).toHaveBeenCalledTimes(1)
+    })
+    expect(harness.registerCleanup).toHaveBeenCalledTimes(1)
+    expect(harness.cleanup).toBeDefined()
+
+    const onCleanupSettled = vi.fn()
+    const cleanupPromise = harness.cleanup!().then(onCleanupSettled)
+
+    await Promise.resolve()
+    expect(onCleanupSettled).not.toHaveBeenCalled()
+
+    harness.appendDeferred!.resolve()
+    await cleanupPromise
+
+    expect(harness.writeFile).toHaveBeenCalledWith(
+      '/tmp/agenc-home/history.jsonl',
+      '',
+      { encoding: 'utf8', mode: 0o600, flag: 'a' },
+    )
+    expect(harness.lock).toHaveBeenCalledWith('/tmp/agenc-home/history.jsonl', {
+      stale: 10000,
+      retries: {
+        retries: 3,
+        minTimeout: 50,
+      },
+    })
+    expect(harness.lockRelease).toHaveBeenCalledTimes(1)
+
+    const [historyPath, payload, options] = harness.appendFile.mock.calls[0]!
+    expect(historyPath).toBe('/tmp/agenc-home/history.jsonl')
+    expect(options).toEqual({ mode: 0o600 })
+    expect(JSON.parse(String(payload).trim())).toMatchObject({
+      display: 'cleanup command',
+      pastedContents: {},
+      project: '/workspace/project',
+      sessionId: 'session-current',
+    })
+    expect(onCleanupSettled).toHaveBeenCalledTimes(1)
+  })
+})

--- a/runtime/tests/tui/history/transcriptSearch.wave200-106.coverage.test.ts
+++ b/runtime/tests/tui/history/transcriptSearch.wave200-106.coverage.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'vitest'
+
+import { renderableSearchText } from './transcriptSearch.js'
+
+describe('renderableSearchText transcript attachment coverage', () => {
+  test('indexes visible transcript-only attachment text and collapsed memories', () => {
+    expect(renderableSearchText({
+      type: 'attachment',
+      attachment: {
+        type: 'relevant_memories',
+        memories: [
+          { content: 'Memory Alpha' },
+          {
+            content:
+              'Before <system-reminder>hidden reminder</system-reminder> After',
+          },
+        ],
+      },
+    } as never)).toBe('memory alpha\nbefore  after')
+
+    expect(renderableSearchText({
+      type: 'attachment',
+      attachment: {
+        type: 'queued_command',
+        commandMode: 'prompt',
+        isMeta: false,
+        prompt: [
+          { type: 'text', text: 'Queued Followup' },
+          { type: 'image', source: 'ignored-image' },
+          { type: 'text', text: 'Second Line' },
+        ],
+      },
+    } as never)).toBe('queued followup\nsecond line')
+
+    expect(renderableSearchText({
+      type: 'attachment',
+      attachment: {
+        type: 'queued_command',
+        commandMode: 'task-notification',
+        isMeta: false,
+        prompt: 'Hidden task notice',
+      },
+    } as never)).toBe('')
+
+    expect(renderableSearchText({
+      type: 'collapsed_read_search',
+      relevantMemories: [
+        { content: 'Collapsed Memory' },
+        { content: 'Visible Search Hit' },
+      ],
+    } as never)).toBe('collapsed memory\nvisible search hit')
+  })
+})

--- a/runtime/tests/tui/hooks/fileSuggestions.coverage2.test.ts
+++ b/runtime/tests/tui/hooks/fileSuggestions.coverage2.test.ts
@@ -1,0 +1,185 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, sep } from 'node:path'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+let tempRepoRoot = ''
+let tempCwd = ''
+
+const harness = vi.hoisted(() => ({
+  execCalls: [] as { args: string[]; cwd?: string }[],
+  fileIndexLoads: [] as string[][],
+  logError: vi.fn(),
+  logEvent: vi.fn(),
+  reset() {
+    this.execCalls = []
+    this.fileIndexLoads = []
+    this.logError.mockClear()
+    this.logEvent.mockClear()
+  },
+}))
+
+vi.mock('../../utils/cwd.js', () => ({
+  getCwd: () => tempCwd,
+  pwd: () => tempCwd,
+  runWithCwdOverride: <T,>(_cwd: string, fn: () => T) => fn(),
+}))
+
+vi.mock('../../services/analytics/index', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../../utils/settings/settings.js', () => ({
+  getInitialSettings: () => ({}),
+}))
+
+vi.mock('../../utils/config.js', () => ({
+  getGlobalConfig: () => ({}),
+  checkHasTrustDialogAccepted: () => true,
+}))
+
+vi.mock('../../utils/hooks.js', () => ({
+  createBaseHookInput: () => ({ base: true }),
+  executeFileSuggestionCommand: async () => [],
+}))
+
+vi.mock('../../utils/markdownConfigLoader.js', () => ({
+  AGENC_CONFIG_DIRECTORIES: ['commands'],
+  loadMarkdownFilesForSubdir: async () => [
+    { filePath: `.agenc${sep}commands${sep}context.md` },
+  ],
+}))
+
+vi.mock('../../utils/git', () => ({
+  findGitRoot: () => tempRepoRoot,
+  gitExe: () => 'git',
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: harness.logError,
+}))
+
+vi.mock('../../utils/path.js', () => ({
+  expandPath: (value: string) => value,
+}))
+
+vi.mock('../../utils/ripgrep.js', () => ({
+  ripGrep: vi.fn(async () => []),
+}))
+
+vi.mock('../../utils/execFileNoThrow.js', () => ({
+  execFileNoThrowWithCwd: vi.fn(
+    async (_file: string, args: string[], options?: { cwd?: string }) => {
+      harness.execCalls.push({ args, cwd: options?.cwd })
+      if (args.includes('--recurse-submodules')) {
+        return {
+          code: 0,
+          stderr: '',
+          stdout:
+            'workspace/src/tracked.ts\nworkspace/ignored.tmp\nworkspace/nested/deep.ts\n',
+        }
+      }
+      if (args.includes('--others')) {
+        return {
+          code: 0,
+          stderr: '',
+          stdout:
+            'workspace/loose.txt\nworkspace/ignored.tmp\nworkspace/nested/untracked.ts\n',
+        }
+      }
+      return { code: 1, stderr: 'unexpected git args', stdout: '' }
+    },
+  ),
+}))
+
+vi.mock('src/utils/debug.js', () => ({
+  logForDebugging: () => {},
+}))
+
+vi.mock('../ink/native-ts/file-index/index', () => ({
+  CHUNK_MS: 4,
+  FileIndex: class {
+    loadFromFileListAsync(paths: string[]) {
+      harness.fileIndexLoads.push([...paths])
+      return { done: Promise.resolve() }
+    }
+    search() {
+      return []
+    }
+    get readyCount() {
+      return 0
+    }
+  },
+  yieldToEventLoop: vi.fn(async () => {}),
+}))
+
+import {
+  clearFileSuggestionCaches,
+  getPathsForSuggestions,
+} from './fileSuggestions.js'
+
+async function waitForFileIndexLoads(count: number): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    if (harness.fileIndexLoads.length >= count) return
+    await new Promise(resolve => setTimeout(resolve, 0))
+  }
+  throw new Error(`expected ${count} file index loads`)
+}
+
+describe('fileSuggestions git-backed coverage', () => {
+  beforeEach(() => {
+    harness.reset()
+    tempRepoRoot = mkdtempSync(join(tmpdir(), 'agenc-file-suggestions-repo-'))
+    tempCwd = join(tempRepoRoot, 'workspace')
+    mkdirSync(tempCwd, { recursive: true })
+    writeFileSync(join(tempCwd, '.agencignore'), 'ignored.tmp\n')
+    clearFileSuggestionCaches()
+  })
+
+  afterEach(() => {
+    clearFileSuggestionCaches()
+    rmSync(tempRepoRoot, { recursive: true, force: true })
+    tempRepoRoot = ''
+    tempCwd = ''
+  })
+
+  test('loads git-tracked paths relative to cwd and merges untracked paths after ignore filtering', async () => {
+    await getPathsForSuggestions()
+    await waitForFileIndexLoads(2)
+
+    expect(harness.execCalls).toEqual([
+      {
+        args: [
+          '-c',
+          'core.quotepath=false',
+          'ls-files',
+          '--recurse-submodules',
+        ],
+        cwd: tempRepoRoot,
+      },
+      {
+        args: [
+          '-c',
+          'core.quotepath=false',
+          'ls-files',
+          '--others',
+          '--exclude-standard',
+        ],
+        cwd: tempRepoRoot,
+      },
+    ])
+
+    expect(harness.fileIndexLoads.at(-1)).toEqual([
+      `src${sep}tracked.ts`,
+      `nested${sep}deep.ts`,
+      `.agenc${sep}commands${sep}context.md`,
+      'src' + sep,
+      'nested' + sep,
+      `.agenc${sep}commands${sep}`,
+      '.agenc' + sep,
+      'loose.txt',
+      `nested${sep}untracked.ts`,
+      'nested' + sep,
+    ])
+  })
+})

--- a/runtime/tests/tui/hooks/fileSuggestions.test.ts
+++ b/runtime/tests/tui/hooks/fileSuggestions.test.ts
@@ -11,6 +11,35 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 let tempCwd = ''
 
+const harness = vi.hoisted(() => ({
+  commandInputs: [] as unknown[],
+  commandResults: [] as string[],
+  fileIndexLoads: [] as string[][],
+  fileIndexSearchError: null as Error | null,
+  fileIndexSearchQueries: [] as { limit: number; query: string }[],
+  fileIndexSearchResults: [] as { path: string; score?: number }[],
+  gitRoot: null as string | null,
+  logError: vi.fn(),
+  logEvent: vi.fn(),
+  ripGrep: vi.fn(async () => [] as string[]),
+  settings: {} as Record<string, unknown>,
+  yieldToEventLoop: vi.fn(async () => {}),
+  reset() {
+    this.commandInputs = []
+    this.commandResults = []
+    this.fileIndexLoads = []
+    this.fileIndexSearchError = null
+    this.fileIndexSearchQueries = []
+    this.fileIndexSearchResults = []
+    this.gitRoot = null
+    this.settings = {}
+    this.logError.mockClear()
+    this.logEvent.mockClear()
+    this.ripGrep.mockClear()
+    this.yieldToEventLoop.mockClear()
+  },
+}))
+
 vi.mock('../../utils/cwd.js', () => ({
   getCwd: () => tempCwd,
   pwd: () => tempCwd,
@@ -19,13 +48,11 @@ vi.mock('../../utils/cwd.js', () => ({
 
 // Avoid hitting the real analytics path during tests.
 vi.mock('../../services/analytics/index', () => ({
-  logEvent: () => {},
+  logEvent: harness.logEvent,
 }))
 
-// Stable settings: file suggestions use the in-process index path, not the
-// configurable hook command.
 vi.mock('../../utils/settings/settings.js', () => ({
-  getInitialSettings: () => ({}),
+  getInitialSettings: () => harness.settings,
 }))
 
 vi.mock('../../utils/config.js', () => ({
@@ -38,13 +65,37 @@ vi.mock('../../utils/config.js', () => ({
 // paths. Stub the few helpers fileSuggestions.ts imports so the module graph
 // stays small.
 vi.mock('../../utils/hooks.js', () => ({
-  createBaseHookInput: () => ({}),
-  executeFileSuggestionCommand: async () => [],
+  createBaseHookInput: () => ({ base: true }),
+  executeFileSuggestionCommand: async (input: unknown) => {
+    harness.commandInputs.push(input)
+    return harness.commandResults
+  },
 }))
 
 vi.mock('../../utils/markdownConfigLoader.js', () => ({
   AGENC_CONFIG_DIRECTORIES: [],
   loadMarkdownFilesForSubdir: async () => [],
+}))
+
+vi.mock('../../utils/git', () => ({
+  findGitRoot: () => harness.gitRoot,
+  gitExe: () => 'git',
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: harness.logError,
+}))
+
+vi.mock('../../utils/path.js', () => ({
+  expandPath: (value: string) => value.replace(/^~/, '/home/tester'),
+}))
+
+vi.mock('../../utils/ripgrep.js', () => ({
+  ripGrep: harness.ripGrep,
+}))
+
+vi.mock('src/utils/debug.js', () => ({
+  logForDebugging: () => {},
 }))
 
 // FileIndex is a Rust-backed native module the empty-query path does not need
@@ -53,25 +104,133 @@ vi.mock('../../utils/markdownConfigLoader.js', () => ({
 vi.mock('../ink/native-ts/file-index/index', () => ({
   CHUNK_MS: 4,
   FileIndex: class {
-    loadFromFileListAsync() {
+    loadFromFileListAsync(paths: string[]) {
+      harness.fileIndexLoads.push([...paths])
       return { done: Promise.resolve() }
     }
-    search() {
-      return []
+    search(query: string, limit: number) {
+      harness.fileIndexSearchQueries.push({ query, limit })
+      if (harness.fileIndexSearchError) throw harness.fileIndexSearchError
+      return harness.fileIndexSearchResults.slice(0, limit)
     }
     get readyCount() {
       return 0
     }
   },
-  yieldToEventLoop: async () => {},
+  yieldToEventLoop: harness.yieldToEventLoop,
 }))
 
 import {
   annotateBrokenSymlinks,
+  applyFileSuggestion,
   clearFileSuggestionCaches,
+  findLongestCommonPrefix,
   generateFileSuggestions,
+  getDirectoryNames,
+  getDirectoryNamesAsync,
   getHiddenTopLevelMatches,
+  pathListSignature,
 } from './fileSuggestions.js'
+
+beforeEach(() => {
+  harness.reset()
+})
+
+describe('fileSuggestions pure helpers', () => {
+  test('pathListSignature is stable and changes when sampled contents change', () => {
+    const original = ['src/a.ts', 'src/b.ts', 'src/c.ts']
+    const same = ['src/a.ts', 'src/b.ts', 'src/c.ts']
+    const middleChanged = ['src/a.ts', 'src/b-renamed.ts', 'src/c.ts']
+    const tailChanged = ['src/a.ts', 'src/b.ts', 'src/d.ts']
+
+    expect(pathListSignature([])).toBe(pathListSignature([]))
+    expect(pathListSignature(original)).toBe(pathListSignature(same))
+    expect(pathListSignature(original)).not.toBe(
+      pathListSignature(middleChanged),
+    )
+    expect(pathListSignature(original)).not.toBe(pathListSignature(tailChanged))
+  })
+
+  test('getDirectoryNames returns unique parent directories only', () => {
+    const dirs = getDirectoryNames([
+      'README.md',
+      'src/index.ts',
+      'src/utils/file.ts',
+      'src/utils/other.ts',
+    ])
+
+    expect(dirs).toEqual(['src' + sep, join('src', 'utils') + sep])
+    expect(dirs).not.toContain('.' + sep)
+  })
+
+  test('getDirectoryNamesAsync matches sync output and yields during long scans', async () => {
+    const files = Array.from(
+      { length: 257 },
+      (_, index) => join('src', `dir-${index}`, 'file.ts'),
+    )
+    const nowSpy = vi
+      .spyOn(performance, 'now')
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(10)
+      .mockReturnValue(10)
+
+    try {
+      await expect(getDirectoryNamesAsync(files)).resolves.toEqual(
+        getDirectoryNames(files),
+      )
+      expect(harness.yieldToEventLoop).toHaveBeenCalledTimes(1)
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
+  test('findLongestCommonPrefix handles empty, shared, and disjoint suggestions', () => {
+    expect(findLongestCommonPrefix([])).toBe('')
+    expect(
+      findLongestCommonPrefix([
+        { id: 'file-src/index.ts', displayText: 'src/index.ts' },
+        { id: 'file-src/input.ts', displayText: 'src/input.ts' },
+        { id: 'file-src/infra.ts', displayText: 'src/infra.ts' },
+      ]),
+    ).toBe('src/in')
+    expect(
+      findLongestCommonPrefix([
+        { id: 'file-src/index.ts', displayText: 'src/index.ts' },
+        { id: 'file-test/index.ts', displayText: 'test/index.ts' },
+      ]),
+    ).toBe('')
+  })
+
+  test('applyFileSuggestion accepts plain strings and suggestion items', () => {
+    const stringChange = vi.fn()
+    const stringCursor = vi.fn()
+    applyFileSuggestion(
+      'src/index.ts',
+      'open @sr now',
+      'sr',
+      6,
+      stringChange,
+      stringCursor,
+    )
+
+    expect(stringChange).toHaveBeenCalledWith('open @src/index.ts now')
+    expect(stringCursor).toHaveBeenCalledWith(18)
+
+    const itemChange = vi.fn()
+    const itemCursor = vi.fn()
+    applyFileSuggestion(
+      { id: 'file-tests/unit.ts', displayText: 'tests/unit.ts' },
+      'run @te',
+      'te',
+      5,
+      itemChange,
+      itemCursor,
+    )
+
+    expect(itemChange).toHaveBeenCalledWith('run @tests/unit.ts')
+    expect(itemCursor).toHaveBeenCalledWith(18)
+  })
+})
 
 describe('fileSuggestions hidden-file visibility', () => {
   beforeEach(() => {
@@ -136,6 +295,12 @@ describe('fileSuggestions hidden-file visibility', () => {
     expect(matches).toContain('.hideme')
     expect(matches).not.toContain('.hidden-file.txt')
   })
+
+  test('getHiddenTopLevelMatches returns no matches when cwd cannot be read', async () => {
+    rmSync(tempCwd, { recursive: true, force: true })
+
+    await expect(getHiddenTopLevelMatches('.hid')).resolves.toEqual([])
+  })
 })
 
 describe('fileSuggestions broken symlink annotation', () => {
@@ -169,6 +334,21 @@ describe('fileSuggestions broken symlink annotation', () => {
     expect(byName.get('broken-link')).toBe('(broken)')
   })
 
+  test('annotateBrokenSymlinks leaves vanished rows and absolute paths unchanged', () => {
+    writeFileSync(join(tempCwd, 'absolute.txt'), '')
+
+    const vanished = { id: 'file-vanished.txt', displayText: 'vanished.txt' }
+    const absolute = {
+      id: 'file-absolute.txt',
+      displayText: join(tempCwd, 'absolute.txt'),
+    }
+
+    expect(annotateBrokenSymlinks([vanished, absolute])).toEqual([
+      vanished,
+      absolute,
+    ])
+  })
+
   test('empty @ query annotates broken symlinks in the cwd', async () => {
     symlinkSync(
       join(tempCwd, 'missing-target'),
@@ -179,5 +359,91 @@ describe('fileSuggestions broken symlink annotation', () => {
     const dangling = items.find(i => i.displayText === 'dangling')
     expect(dangling).toBeDefined()
     expect(dangling!.description).toBe('(broken)')
+  })
+})
+
+describe('generateFileSuggestions edge branches', () => {
+  beforeEach(() => {
+    tempCwd = mkdtempSync(join(tmpdir(), 'agenc-file-suggestions-'))
+    clearFileSuggestionCaches()
+  })
+
+  afterEach(() => {
+    rmSync(tempCwd, { recursive: true, force: true })
+    tempCwd = ''
+  })
+
+  test('empty query returns nothing when showOnEmpty is disabled', async () => {
+    writeFileSync(join(tempCwd, 'visible.txt'), '')
+
+    await expect(generateFileSuggestions('', false)).resolves.toEqual([])
+    expect(harness.fileIndexSearchQueries).toEqual([])
+    expect(harness.ripGrep).not.toHaveBeenCalled()
+  })
+
+  test('custom command suggestions are query-aware and capped at max suggestions', async () => {
+    harness.settings = { fileSuggestion: { type: 'command' } }
+    harness.commandResults = Array.from(
+      { length: 20 },
+      (_, index) => `result-${index}.ts`,
+    )
+
+    const items = await generateFileSuggestions('src')
+
+    expect(harness.commandInputs).toEqual([{ base: true, query: 'src' }])
+    expect(items).toHaveLength(15)
+    expect(items[0]).toMatchObject({
+      displayText: 'result-0.ts',
+      id: 'file-result-0.ts',
+    })
+    expect(items[0]?.metadata).toBeUndefined()
+    expect(items[1]?.metadata).toBeUndefined()
+    expect(items.at(-1)?.displayText).toBe('result-14.ts')
+  })
+
+  test('non-empty search normalizes current-directory prefixes and backfills hidden matches', async () => {
+    writeFileSync(join(tempCwd, '.hidden-file.txt'), '')
+    writeFileSync(join(tempCwd, '.hideme'), '')
+    harness.fileIndexSearchResults = [{ path: '.hideme', score: 42 }]
+
+    const items = await generateFileSuggestions('./.hid')
+    const names = items.map(item => item.displayText)
+
+    expect(harness.fileIndexSearchQueries[0]).toEqual({
+      limit: 15,
+      query: '.hid',
+    })
+    expect(names.filter(name => name === '.hideme')).toHaveLength(1)
+    expect(names).toContain('.hidden-file.txt')
+    expect(items.find(item => item.displayText === '.hideme')?.metadata).toEqual(
+      { score: 42 },
+    )
+  })
+
+  test('tilde-prefixed search is expanded before querying the index', async () => {
+    await generateFileSuggestions('~/project')
+
+    expect(harness.fileIndexSearchQueries[0]).toEqual({
+      limit: 15,
+      query: '/home/tester/project',
+    })
+  })
+
+  test('parent-directory dotted searches do not backfill top-level dotfiles', async () => {
+    writeFileSync(join(tempCwd, '.hidden-file.txt'), '')
+
+    await expect(generateFileSuggestions('..')).resolves.toEqual([])
+    expect(harness.fileIndexSearchQueries[0]).toEqual({
+      limit: 15,
+      query: '..',
+    })
+  })
+
+  test('search errors are logged and return no suggestions', async () => {
+    const error = new Error('search failed')
+    harness.fileIndexSearchError = error
+
+    await expect(generateFileSuggestions('src')).resolves.toEqual([])
+    expect(harness.logError).toHaveBeenCalledWith(error)
   })
 })

--- a/runtime/tests/tui/hooks/fileSuggestions.wave200-081.coverage.test.ts
+++ b/runtime/tests/tui/hooks/fileSuggestions.wave200-081.coverage.test.ts
@@ -1,0 +1,143 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, sep } from 'node:path'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+let tempCwd = ''
+
+const harness = vi.hoisted(() => ({
+  fileIndexLoads: [] as string[][],
+  logError: vi.fn(),
+  logEvent: vi.fn(),
+  ripGrep: vi.fn(async () => [] as string[]),
+  reset() {
+    this.fileIndexLoads = []
+    this.logError.mockClear()
+    this.logEvent.mockClear()
+    this.ripGrep.mockClear()
+  },
+}))
+
+vi.mock('../../utils/cwd.js', () => ({
+  getCwd: () => tempCwd,
+  pwd: () => tempCwd,
+  runWithCwdOverride: <T,>(_cwd: string, fn: () => T) => fn(),
+}))
+
+vi.mock('../../services/analytics/index', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../../utils/settings/settings.js', () => ({
+  getInitialSettings: () => ({ respectGitignore: false }),
+}))
+
+vi.mock('../../utils/config.js', () => ({
+  getGlobalConfig: () => ({}),
+  checkHasTrustDialogAccepted: () => true,
+}))
+
+vi.mock('../../utils/hooks.js', () => ({
+  createBaseHookInput: () => ({ base: true }),
+  executeFileSuggestionCommand: async () => [],
+}))
+
+vi.mock('../../utils/markdownConfigLoader.js', () => ({
+  AGENC_CONFIG_DIRECTORIES: ['commands'],
+  loadMarkdownFilesForSubdir: async () => [
+    { filePath: `.agenc${sep}commands${sep}context.md` },
+  ],
+}))
+
+vi.mock('../../utils/git', () => ({
+  findGitRoot: () => null,
+  gitExe: () => 'git',
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: harness.logError,
+}))
+
+vi.mock('../../utils/path.js', () => ({
+  expandPath: (value: string) => value,
+}))
+
+vi.mock('../../utils/ripgrep.js', () => ({
+  ripGrep: harness.ripGrep,
+}))
+
+vi.mock('../../utils/execFileNoThrow.js', () => ({
+  execFileNoThrowWithCwd: vi.fn(async () => ({
+    code: 1,
+    stderr: '',
+    stdout: '',
+  })),
+}))
+
+vi.mock('src/utils/debug.js', () => ({
+  logForDebugging: () => {},
+}))
+
+vi.mock('../ink/native-ts/file-index/index', () => ({
+  CHUNK_MS: 4,
+  FileIndex: class {
+    loadFromFileListAsync(paths: string[]) {
+      harness.fileIndexLoads.push([...paths])
+      return { done: Promise.resolve() }
+    }
+    search() {
+      return []
+    }
+    get readyCount() {
+      return 0
+    }
+  },
+  yieldToEventLoop: vi.fn(async () => {}),
+}))
+
+import {
+  clearFileSuggestionCaches,
+  getPathsForSuggestions,
+} from './fileSuggestions.js'
+
+describe('fileSuggestions ripgrep fallback coverage', () => {
+  beforeEach(() => {
+    harness.reset()
+    tempCwd = mkdtempSync(join(tmpdir(), 'agenc-file-suggestions-rg-'))
+    mkdirSync(join(tempCwd, 'src'), { recursive: true })
+    mkdirSync(join(tempCwd, 'ignored-dir'), { recursive: true })
+    writeFileSync(join(tempCwd, '.ignore'), 'ignored.tmp\nignored-dir/\n')
+    clearFileSuggestionCaches()
+  })
+
+  afterEach(() => {
+    clearFileSuggestionCaches()
+    rmSync(tempCwd, { recursive: true, force: true })
+    tempCwd = ''
+  })
+
+  test('falls back to ripgrep with no-ignore-vcs and filters picker ignore patterns', async () => {
+    harness.ripGrep.mockResolvedValueOnce([
+      join(tempCwd, 'src', 'keep.ts'),
+      join(tempCwd, 'ignored.tmp'),
+      join(tempCwd, 'ignored-dir', 'drop.ts'),
+    ])
+
+    await getPathsForSuggestions()
+
+    expect(harness.ripGrep).toHaveBeenCalledTimes(1)
+    const [args, cwdArg] = harness.ripGrep.mock.calls[0]!
+    expect(args).toEqual(expect.arrayContaining(['--files', '--no-ignore-vcs']))
+    expect(cwdArg).toBe('.')
+    expect(harness.fileIndexLoads).toEqual([
+      [
+        'src' + sep,
+        `.agenc${sep}commands` + sep,
+        '.agenc' + sep,
+        `src${sep}keep.ts`,
+        `.agenc${sep}commands${sep}context.md`,
+      ],
+    ])
+    expect(harness.logError).not.toHaveBeenCalled()
+  })
+})

--- a/runtime/tests/tui/hooks/toolPermission/PermissionContext.test.ts
+++ b/runtime/tests/tui/hooks/toolPermission/PermissionContext.test.ts
@@ -1,0 +1,395 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  applyPermissionUpdates: vi.fn(),
+  awaitClassifierAutoApproval: vi.fn(),
+  classifierApprovals: [] as Array<[string, string]>,
+  debug: vi.fn(),
+  features: new Set<string>(),
+  hookResults: [] as Array<{
+    permissionRequestResult?: {
+      behavior: 'allow' | 'deny'
+      interrupt?: boolean
+      message?: string
+      updatedInput?: Record<string, unknown>
+      updatedPermissions?: Array<{ destination: string }>
+    }
+  }>,
+  logEvent: vi.fn(),
+  logPermissionDecision: vi.fn(),
+  persistPermissionUpdates: vi.fn(),
+  sanitizeToolNameForAnalytics: vi.fn((toolName: string) => `safe:${toolName}`),
+  supportsPersistence: vi.fn((destination: string) => destination === 'project'),
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => harness.features.has(name),
+}))
+
+vi.mock('../../../services/analytics/index.js', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../../../services/analytics/metadata.js', () => ({
+  sanitizeToolNameForAnalytics: harness.sanitizeToolNameForAnalytics,
+}))
+
+vi.mock('../../../tools/BashTool/bashPermissions.js', () => ({
+  awaitClassifierAutoApproval: harness.awaitClassifierAutoApproval,
+}))
+
+vi.mock('../../../tools/BashTool/toolName.js', () => ({
+  BASH_TOOL_NAME: 'Bash',
+}))
+
+vi.mock('../../../utils/classifierApprovals.js', () => ({
+  setClassifierApproval: (toolUseID: string, rule: string) => {
+    harness.classifierApprovals.push([toolUseID, rule])
+  },
+}))
+
+vi.mock('src/utils/debug.js', () => ({
+  logForDebugging: harness.debug,
+}))
+
+vi.mock('../../../utils/hooks.js', () => ({
+  executePermissionRequestHooks: async function* () {
+    for (const result of harness.hookResults) {
+      yield result
+    }
+  },
+}))
+
+vi.mock('../../../utils/messages.js', () => ({
+  REJECT_MESSAGE: 'Rejected',
+  REJECT_MESSAGE_WITH_REASON_PREFIX: 'Rejected: ',
+  SUBAGENT_REJECT_MESSAGE: 'Subagent rejected',
+  SUBAGENT_REJECT_MESSAGE_WITH_REASON_PREFIX: 'Subagent rejected: ',
+  withMemoryCorrectionHint: (message: string) => `${message} [memory hint]`,
+}))
+
+vi.mock('../../../utils/permissions/PermissionUpdate.js', () => ({
+  applyPermissionUpdates: harness.applyPermissionUpdates,
+  persistPermissionUpdates: harness.persistPermissionUpdates,
+  supportsPersistence: harness.supportsPersistence,
+}))
+
+vi.mock('./permissionLogging.js', () => ({
+  logPermissionDecision: harness.logPermissionDecision,
+}))
+
+import {
+  createPermissionContext,
+  createPermissionQueueOps,
+  createResolveOnce,
+} from './PermissionContext.js'
+
+type TestTool = {
+  name: string
+  inputsEquivalent?: (
+    previous: Record<string, unknown>,
+    next: Record<string, unknown>,
+  ) => boolean
+}
+
+function tool(overrides: Partial<TestTool> = {}): TestTool {
+  return {
+    name: 'Read',
+    inputsEquivalent: (previous, next) => previous.path === next.path,
+    ...overrides,
+  }
+}
+
+function assistantMessage(id = 'message-1') {
+  return {
+    message: { id },
+  }
+}
+
+function toolUseContext(
+  overrides: Partial<{
+    agentId: string
+    abortController: AbortController
+    isNonInteractiveSession: boolean
+    toolPermissionContext: Record<string, unknown>
+  }> = {},
+) {
+  const abortController = overrides.abortController ?? new AbortController()
+  const toolPermissionContext =
+    overrides.toolPermissionContext ?? ({ mode: 'default' } as const)
+
+  return {
+    abortController,
+    agentId: overrides.agentId,
+    getAppState: () => ({ toolPermissionContext }),
+    options: {
+      isNonInteractiveSession: overrides.isNonInteractiveSession ?? false,
+    },
+  }
+}
+
+function context(
+  overrides: Partial<{
+    input: Record<string, unknown>
+    setToolPermissionContext: ReturnType<typeof vi.fn>
+    tool: TestTool
+    toolUseContext: ReturnType<typeof toolUseContext>
+    toolUseID: string
+  }> = {},
+) {
+  return createPermissionContext(
+    (overrides.tool ?? tool()) as never,
+    overrides.input ?? { path: 'a.ts' },
+    (overrides.toolUseContext ?? toolUseContext()) as never,
+    assistantMessage() as never,
+    overrides.toolUseID ?? 'tool-use-1',
+    overrides.setToolPermissionContext ?? vi.fn(),
+  )
+}
+
+beforeEach(() => {
+  harness.applyPermissionUpdates.mockReset()
+  harness.applyPermissionUpdates.mockImplementation((current, updates) => ({
+    ...current,
+    updates,
+  }))
+  harness.awaitClassifierAutoApproval.mockReset()
+  harness.classifierApprovals = []
+  harness.debug.mockReset()
+  harness.features = new Set()
+  harness.hookResults = []
+  harness.logEvent.mockReset()
+  harness.logPermissionDecision.mockReset()
+  harness.persistPermissionUpdates.mockReset()
+  harness.sanitizeToolNameForAnalytics.mockClear()
+  harness.supportsPersistence.mockClear()
+})
+
+describe('PermissionContext primitives', () => {
+  test('resolve-once resolves or claims at most one winner', () => {
+    const resolve = vi.fn()
+    const once = createResolveOnce(resolve)
+
+    expect(once.isResolved()).toBe(false)
+    expect(once.claim()).toBe(true)
+    expect(once.claim()).toBe(false)
+    expect(once.isResolved()).toBe(true)
+
+    once.resolve('late')
+    once.resolve('later')
+    expect(resolve).toHaveBeenCalledTimes(1)
+    expect(resolve).toHaveBeenCalledWith('late')
+
+    const resolveFirst = vi.fn()
+    const alreadyResolved = createResolveOnce(resolveFirst)
+    alreadyResolved.resolve('first')
+    expect(alreadyResolved.claim()).toBe(false)
+    alreadyResolved.resolve('second')
+    expect(resolveFirst).toHaveBeenCalledTimes(1)
+    expect(resolveFirst).toHaveBeenCalledWith('first')
+  })
+
+  test('queue ops push, remove, and patch matching permission items', () => {
+    let queue: Array<Record<string, unknown>> = []
+    const setQueue = vi.fn(updater => {
+      queue = typeof updater === 'function' ? updater(queue) : updater
+    })
+    const ops = createPermissionQueueOps(setQueue as never)
+
+    ops.push({ toolUseID: 'a', title: 'A' } as never)
+    ops.push({ toolUseID: 'b', title: 'B' } as never)
+    ops.update('a', { title: 'A2' } as never)
+    ops.remove('b')
+
+    expect(queue).toEqual([{ toolUseID: 'a', title: 'A2' }])
+    expect(setQueue).toHaveBeenCalledTimes(4)
+  })
+
+  test('persists permission updates and logs user allows with modified input', async () => {
+    const setToolPermissionContext = vi.fn()
+    const ctx = context({ setToolPermissionContext })
+
+    await expect(ctx.persistPermissions([])).resolves.toBe(false)
+    expect(harness.persistPermissionUpdates).not.toHaveBeenCalled()
+
+    const decision = await ctx.handleUserAllow(
+      { path: 'b.ts' },
+      [{ destination: 'project' }],
+      '  looks good  ',
+      123,
+      [{ type: 'text', text: 'extra block' }] as never,
+      { type: 'user' } as never,
+    )
+
+    expect(harness.persistPermissionUpdates).toHaveBeenCalledWith([
+      { destination: 'project' },
+    ])
+    expect(setToolPermissionContext).toHaveBeenCalledWith({
+      mode: 'default',
+      updates: [{ destination: 'project' }],
+    })
+    expect(harness.logPermissionDecision).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 'message-1', toolUseID: 'tool-use-1' }),
+      { decision: 'accept', source: { type: 'user', permanent: true } },
+      123,
+    )
+    expect(decision).toMatchObject({
+      behavior: 'allow',
+      updatedInput: { path: 'b.ts' },
+      userModified: true,
+      acceptFeedback: 'looks good',
+      contentBlocks: [{ type: 'text', text: 'extra block' }],
+      decisionReason: { type: 'user' },
+    })
+  })
+
+  test('cancels main-agent and subagent requests with the expected rejection messages', () => {
+    const mainContext = toolUseContext()
+    const main = context({ toolUseContext: mainContext })
+
+    expect(main.cancelAndAbort()).toEqual({
+      behavior: 'ask',
+      message: 'Rejected [memory hint]',
+      contentBlocks: undefined,
+    })
+    expect(mainContext.abortController.signal.aborted).toBe(true)
+    expect(harness.debug).toHaveBeenCalledWith(
+      expect.stringContaining('Aborting: tool=Read'),
+    )
+
+    const subagentContext = toolUseContext({ agentId: 'agent-1' })
+    const subagent = context({ toolUseContext: subagentContext })
+    expect(subagent.cancelAndAbort('needs changes')).toEqual({
+      behavior: 'ask',
+      message: 'Subagent rejected: needs changes',
+      contentBlocks: undefined,
+    })
+    expect(subagentContext.abortController.signal.aborted).toBe(false)
+  })
+
+  test('resolves aborted requests by logging cancellation and abort decision', () => {
+    const abortController = new AbortController()
+    abortController.abort()
+    const ctx = context({ toolUseContext: toolUseContext({ abortController }) })
+    const resolve = vi.fn()
+
+    expect(ctx.resolveIfAborted(resolve)).toBe(true)
+
+    expect(harness.logEvent).toHaveBeenCalledWith('tengu_tool_use_cancelled', {
+      messageID: 'message-1',
+      toolName: 'safe:Read',
+    })
+    expect(resolve).toHaveBeenCalledWith(
+      expect.objectContaining({
+        behavior: 'ask',
+        message: 'Rejected [memory hint]',
+      }),
+    )
+
+    const active = context()
+    expect(active.resolveIfAborted(vi.fn())).toBe(false)
+  })
+
+  test('runs permission hooks for allow, deny, interrupt, and empty results', async () => {
+    const allow = context()
+    harness.hookResults = [
+      {
+        permissionRequestResult: {
+          behavior: 'allow',
+          updatedInput: { path: 'hook.ts' },
+          updatedPermissions: [{ destination: 'session' }],
+        },
+      },
+    ]
+
+    await expect(
+      allow.runHooks('default', [{ destination: 'suggestion' }], undefined, 50),
+    ).resolves.toMatchObject({
+      behavior: 'allow',
+      decisionReason: { type: 'hook', hookName: 'PermissionRequest' },
+      updatedInput: { path: 'hook.ts' },
+      userModified: false,
+    })
+    expect(harness.logPermissionDecision).toHaveBeenCalledWith(
+      expect.anything(),
+      { decision: 'accept', source: { type: 'hook', permanent: false } },
+      50,
+    )
+
+    const abortController = new AbortController()
+    const deny = context({ toolUseContext: toolUseContext({ abortController }) })
+    harness.hookResults = [
+      {
+        permissionRequestResult: {
+          behavior: 'deny',
+          interrupt: true,
+          message: 'blocked by hook',
+        },
+      },
+    ]
+
+    await expect(deny.runHooks('default', undefined)).resolves.toEqual({
+      behavior: 'deny',
+      message: 'blocked by hook',
+      decisionReason: {
+        type: 'hook',
+        hookName: 'PermissionRequest',
+        reason: 'blocked by hook',
+      },
+    })
+    expect(abortController.signal.aborted).toBe(true)
+    expect(harness.debug).toHaveBeenCalledWith(
+      expect.stringContaining('Hook interrupt: tool=Read'),
+    )
+
+    harness.hookResults = [{}]
+    await expect(context().runHooks(undefined, undefined)).resolves.toBeNull()
+  })
+
+  test('auto-approves bash commands through classifier decisions', async () => {
+    harness.features.add('BASH_CLASSIFIER')
+    harness.features.add('TRANSCRIPT_CLASSIFIER')
+    harness.awaitClassifierAutoApproval.mockResolvedValue({
+      type: 'classifier',
+      reason: 'Allowed by prompt rule: "npm test"',
+    })
+    const ctx = context({
+      tool: tool({ name: 'Bash' }),
+      input: { command: 'npm test' },
+      toolUseContext: toolUseContext({ isNonInteractiveSession: true }),
+      toolUseID: 'tool-use-classifier',
+    })
+
+    await expect(
+      ctx.tryClassifier?.({ id: 'pending' } as never, { command: 'npm test -- --run' }),
+    ).resolves.toEqual({
+      behavior: 'allow',
+      updatedInput: { command: 'npm test -- --run' },
+      userModified: false,
+      decisionReason: {
+        type: 'classifier',
+        reason: 'Allowed by prompt rule: "npm test"',
+      },
+    })
+    expect(harness.awaitClassifierAutoApproval).toHaveBeenCalledWith(
+      { id: 'pending' },
+      expect.any(AbortSignal),
+      true,
+    )
+    expect(harness.classifierApprovals).toEqual([
+      ['tool-use-classifier', 'npm test'],
+    ])
+    expect(harness.logPermissionDecision).toHaveBeenCalledWith(
+      expect.objectContaining({ toolUseID: 'tool-use-classifier' }),
+      { decision: 'accept', source: { type: 'classifier' } },
+      undefined,
+    )
+
+    await expect(
+      context({ tool: tool({ name: 'Read' }) }).tryClassifier?.(
+        { id: 'pending' } as never,
+        undefined,
+      ),
+    ).resolves.toBeNull()
+  })
+})

--- a/runtime/tests/tui/hooks/toolPermission/permissionLogging.wave200-028.coverage.test.ts
+++ b/runtime/tests/tui/hooks/toolPermission/permissionLogging.wave200-028.coverage.test.ts
@@ -1,0 +1,325 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  counter: {
+    add: vi.fn(),
+  },
+  features: new Set<string>(),
+  getCodeEditToolDecisionCounter: vi.fn(),
+  getLanguageName: vi.fn(),
+  logEvent: vi.fn(),
+  logOTelEvent: vi.fn(),
+  sandboxEnabled: true,
+  sanitizeToolNameForAnalytics: vi.fn((toolName: string) => `safe:${toolName}`),
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => harness.features.has(name),
+}))
+
+vi.mock('../../../services/analytics/index.js', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../../../services/analytics/metadata.js', () => ({
+  sanitizeToolNameForAnalytics: harness.sanitizeToolNameForAnalytics,
+}))
+
+vi.mock('../../../bootstrap/state.js', () => ({
+  getCodeEditToolDecisionCounter: harness.getCodeEditToolDecisionCounter,
+}))
+
+vi.mock('../../../utils/cliHighlight.js', () => ({
+  getLanguageName: harness.getLanguageName,
+}))
+
+vi.mock('../../../utils/sandbox/sandbox-runtime.js', () => ({
+  SandboxManager: {
+    isSandboxingEnabled: () => harness.sandboxEnabled,
+  },
+}))
+
+vi.mock('../../../utils/telemetry/events.js', () => ({
+  logOTelEvent: harness.logOTelEvent,
+}))
+
+import {
+  buildCodeEditToolAttributes,
+  isCodeEditingTool,
+  logPermissionDecision,
+} from './permissionLogging.js'
+
+type ParseResult =
+  | { success: true; data: Record<string, unknown> }
+  | { success: false }
+
+function tool(
+  name: string,
+  parseResult: ParseResult = {
+    success: true,
+    data: { file_path: 'src/sample.ts' },
+  },
+  filePath: string | undefined = 'src/sample.ts',
+) {
+  return {
+    name,
+    inputSchema: {
+      safeParse: vi.fn(() => parseResult),
+    },
+    getPath:
+      filePath === undefined ? undefined : vi.fn(() => filePath),
+  }
+}
+
+function context(
+  overrides: Partial<{
+    existingDecisions: Map<string, unknown>
+    input: Record<string, unknown>
+    messageId: string
+    tool: ReturnType<typeof tool>
+    toolUseID: string
+  }> = {},
+) {
+  const toolUseContext: { toolDecisions?: Map<string, unknown> } = {}
+  if (overrides.existingDecisions) {
+    toolUseContext.toolDecisions = overrides.existingDecisions
+  }
+  return {
+    ctx: {
+      tool: overrides.tool ?? tool('Read', { success: false }),
+      input: overrides.input ?? { file_path: 'src/sample.ts' },
+      toolUseContext,
+      messageId: overrides.messageId ?? 'message-1',
+      toolUseID: overrides.toolUseID ?? 'tool-use-1',
+    },
+    toolUseContext,
+  }
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('permissionLogging coverage', () => {
+  beforeEach(() => {
+    harness.counter.add.mockClear()
+    harness.features = new Set()
+    harness.getCodeEditToolDecisionCounter.mockReset()
+    harness.getCodeEditToolDecisionCounter.mockReturnValue(harness.counter)
+    harness.getLanguageName.mockReset()
+    harness.getLanguageName.mockResolvedValue('TypeScript')
+    harness.logEvent.mockClear()
+    harness.logOTelEvent.mockClear()
+    harness.sandboxEnabled = true
+    harness.sanitizeToolNameForAnalytics.mockClear()
+    vi.spyOn(Date, 'now').mockReturnValue(2_000)
+  })
+
+  test('logs decision sources to analytics, OTel, code-edit counters, and context state', async () => {
+    expect(isCodeEditingTool('Edit')).toBe(true)
+    expect(isCodeEditingTool('Write')).toBe(true)
+    expect(isCodeEditingTool('NotebookEdit')).toBe(true)
+    expect(isCodeEditingTool('Read')).toBe(false)
+
+    const editTool = tool('Edit')
+    await expect(
+      buildCodeEditToolAttributes(
+        editTool as never,
+        { file_path: 'src/sample.ts' },
+        'accept',
+        'user_permanent',
+      ),
+    ).resolves.toEqual({
+      decision: 'accept',
+      language: 'TypeScript',
+      source: 'user_permanent',
+      tool_name: 'Edit',
+    })
+    expect(editTool.inputSchema.safeParse).toHaveBeenCalledWith({
+      file_path: 'src/sample.ts',
+    })
+    expect(editTool.getPath).toHaveBeenCalledWith({ file_path: 'src/sample.ts' })
+
+    const invalidInputTool = tool('Edit', { success: false })
+    await expect(
+      buildCodeEditToolAttributes(
+        invalidInputTool as never,
+        { file_path: 'bad.ts' },
+        'reject',
+        'hook',
+      ),
+    ).resolves.toEqual({
+      decision: 'reject',
+      source: 'hook',
+      tool_name: 'Edit',
+    })
+    expect(invalidInputTool.getPath).not.toHaveBeenCalled()
+
+    const editDecision = context({ tool: editTool, toolUseID: 'edit-1' })
+    logPermissionDecision(
+      editDecision.ctx as never,
+      { decision: 'accept', source: { type: 'user', permanent: true } },
+      1_250,
+    )
+    await flushMicrotasks()
+
+    expect(harness.counter.add).toHaveBeenCalledWith(1, {
+      decision: 'accept',
+      language: 'TypeScript',
+      source: 'user_permanent',
+      tool_name: 'Edit',
+    })
+    expect(editDecision.toolUseContext.toolDecisions?.get('edit-1')).toEqual({
+      decision: 'accept',
+      source: 'user_permanent',
+      timestamp: 2_000,
+    })
+
+    const existingDecisions = new Map<string, unknown>()
+    logPermissionDecision(
+      context({
+        existingDecisions,
+        toolUseID: 'config-allow',
+      }).ctx as never,
+      { decision: 'accept', source: 'config' },
+      1_000,
+    )
+
+    harness.features.add('BASH_CLASSIFIER')
+    logPermissionDecision(
+      context({ toolUseID: 'classifier-allow' }).ctx as never,
+      { decision: 'accept', source: { type: 'classifier' } },
+      1_500,
+    )
+    logPermissionDecision(
+      context({ toolUseID: 'temporary-allow' }).ctx as never,
+      { decision: 'accept', source: { type: 'user', permanent: false } },
+      1_500,
+    )
+    logPermissionDecision(
+      context({ toolUseID: 'hook-allow' }).ctx as never,
+      { decision: 'accept', source: { type: 'hook' } },
+      1_500,
+    )
+    logPermissionDecision(
+      context({ toolUseID: 'config-reject' }).ctx as never,
+      { decision: 'reject', source: 'config' },
+      1_000,
+    )
+    logPermissionDecision(
+      context({ toolUseID: 'hook-reject' }).ctx as never,
+      { decision: 'reject', source: { type: 'hook' } },
+      1_500,
+    )
+    logPermissionDecision(
+      context({ toolUseID: 'feedback-reject' }).ctx as never,
+      { decision: 'reject', source: { type: 'user_reject', hasFeedback: true } },
+      1_500,
+    )
+    logPermissionDecision(
+      context({ toolUseID: 'abort-reject' }).ctx as never,
+      { decision: 'reject', source: { type: 'user_abort' } },
+      1_500,
+    )
+
+    expect(existingDecisions.get('config-allow')).toEqual({
+      decision: 'accept',
+      source: 'config',
+      timestamp: 2_000,
+    })
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'agenc_tool_use_granted_in_prompt_permanent',
+      {
+        messageID: 'message-1',
+        sandboxEnabled: true,
+        toolName: 'safe:Edit',
+        waiting_for_user_permission_ms: 750,
+      },
+    )
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'agenc_tool_use_granted_in_config',
+      {
+        messageID: 'message-1',
+        sandboxEnabled: true,
+        toolName: 'safe:Read',
+      },
+    )
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'agenc_tool_use_granted_by_classifier',
+      {
+        messageID: 'message-1',
+        sandboxEnabled: true,
+        toolName: 'safe:Read',
+        waiting_for_user_permission_ms: 500,
+      },
+    )
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'agenc_tool_use_granted_in_prompt_temporary',
+      {
+        messageID: 'message-1',
+        sandboxEnabled: true,
+        toolName: 'safe:Read',
+        waiting_for_user_permission_ms: 500,
+      },
+    )
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'agenc_tool_use_granted_by_permission_hook',
+      {
+        messageID: 'message-1',
+        permanent: false,
+        sandboxEnabled: true,
+        toolName: 'safe:Read',
+        waiting_for_user_permission_ms: 500,
+      },
+    )
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'agenc_tool_use_denied_in_config',
+      {
+        messageID: 'message-1',
+        sandboxEnabled: true,
+        toolName: 'safe:Read',
+      },
+    )
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'agenc_tool_use_rejected_in_prompt',
+      {
+        isHook: true,
+        messageID: 'message-1',
+        sandboxEnabled: true,
+        toolName: 'safe:Read',
+        waiting_for_user_permission_ms: 500,
+      },
+    )
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'agenc_tool_use_rejected_in_prompt',
+      {
+        hasFeedback: true,
+        messageID: 'message-1',
+        sandboxEnabled: true,
+        toolName: 'safe:Read',
+        waiting_for_user_permission_ms: 500,
+      },
+    )
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'agenc_tool_use_rejected_in_prompt',
+      {
+        hasFeedback: false,
+        messageID: 'message-1',
+        sandboxEnabled: true,
+        toolName: 'safe:Read',
+        waiting_for_user_permission_ms: 500,
+      },
+    )
+    expect(harness.logOTelEvent).toHaveBeenCalledWith('tool_decision', {
+      decision: 'accept',
+      source: 'classifier',
+      tool_name: 'safe:Read',
+    })
+    expect(harness.logOTelEvent).toHaveBeenCalledWith('tool_decision', {
+      decision: 'reject',
+      source: 'user_abort',
+      tool_name: 'safe:Read',
+    })
+  })
+})

--- a/runtime/tests/tui/hooks/unifiedSuggestions.wave200-057.coverage.test.ts
+++ b/runtime/tests/tui/hooks/unifiedSuggestions.wave200-057.coverage.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  generateFileSuggestions: vi.fn(),
+  getAgentColor: vi.fn((agentType: string) =>
+    agentType === 'planner' ? 'cyan' : undefined,
+  ),
+  logError: vi.fn(),
+  reset() {
+    this.generateFileSuggestions.mockReset()
+    this.getAgentColor.mockReset()
+    this.getAgentColor.mockImplementation((agentType: string) =>
+      agentType === 'planner' ? 'cyan' : undefined,
+    )
+    this.logError.mockClear()
+  },
+}))
+
+vi.mock('./fileSuggestions.js', () => ({
+  generateFileSuggestions: harness.generateFileSuggestions,
+}))
+
+vi.mock('src/tools/AgentTool/agentColorManager.js', () => ({
+  getAgentColor: harness.getAgentColor,
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: harness.logError,
+}))
+
+import { generateUnifiedSuggestions } from './unifiedSuggestions.js'
+
+beforeEach(() => {
+  harness.reset()
+})
+
+describe('generateUnifiedSuggestions coverage', () => {
+  test('returns no suggestions for an empty query until the empty-state list is requested', async () => {
+    await expect(generateUnifiedSuggestions('', {}, [])).resolves.toEqual([])
+    expect(harness.generateFileSuggestions).not.toHaveBeenCalled()
+  })
+
+  test('merges empty-state file, MCP resource, and agent rows with normalized descriptions', async () => {
+    harness.generateFileSuggestions.mockResolvedValue([
+      {
+        id: 'source-file',
+        displayText: 'src/index.ts',
+        description: 'local file',
+      },
+    ])
+
+    const suggestions = await generateUnifiedSuggestions(
+      '',
+      {
+        docs: [
+          {
+            server: 'docs',
+            uri: 'file:///docs/start',
+            name: 'Start Guide',
+            description: '  multi\nline   resource  ',
+          },
+        ],
+      },
+      [
+        {
+          agentType: 'planner',
+          whenToUse: '  writes\nplans   quickly  ',
+        },
+      ],
+      true,
+    )
+
+    expect(harness.generateFileSuggestions).toHaveBeenCalledWith('', true)
+    expect(suggestions).toEqual([
+      {
+        id: 'file-src/index.ts',
+        displayText: 'src/index.ts',
+        description: 'local file',
+      },
+      {
+        id: 'mcp-resource-docs__file:///docs/start',
+        displayText: 'docs:file:///docs/start',
+        description: 'multi line resource',
+      },
+      {
+        id: 'agent-planner',
+        displayText: 'planner (agent)',
+        description: 'writes plans quickly',
+        color: 'cyan',
+      },
+    ])
+  })
+
+  test('ranks query results by file metadata, default file score, and Fuse matches', async () => {
+    harness.generateFileSuggestions.mockResolvedValue([
+      {
+        id: 'source-high',
+        displayText: 'src/high.ts',
+        metadata: { score: 0.7 },
+      },
+      {
+        id: 'source-low',
+        displayText: 'src/low.ts',
+        metadata: { score: 0.1 },
+      },
+      {
+        id: 'source-default',
+        displayText: 'src/default.ts',
+      },
+    ])
+
+    const suggestions = await generateUnifiedSuggestions(
+      'deploy',
+      {
+        ops: [
+          {
+            server: 'ops',
+            uri: 'deploy://playbook',
+            name: 'Deploy Playbook',
+            description: '',
+          },
+        ],
+      },
+      [
+        {
+          agentType: 'deploy',
+          whenToUse: 'deploys releases safely',
+        },
+      ],
+    )
+
+    expect(harness.generateFileSuggestions).toHaveBeenCalledWith(
+      'deploy',
+      false,
+    )
+    expect(suggestions.map(item => item.id)).toEqual(
+      expect.arrayContaining([
+        'agent-deploy',
+        'mcp-resource-ops__deploy://playbook',
+      ]),
+    )
+    expect(
+      suggestions
+        .filter(item => item.id.startsWith('file-'))
+        .map(item => item.id),
+    ).toEqual(['file-src/low.ts', 'file-src/default.ts', 'file-src/high.ts'])
+  })
+
+  test('logs and omits agent suggestions when agent suggestion creation fails', async () => {
+    const error = new Error('agent color failed')
+    harness.getAgentColor.mockImplementation(() => {
+      throw error
+    })
+    harness.generateFileSuggestions.mockResolvedValue([])
+
+    await expect(
+      generateUnifiedSuggestions(
+        '',
+        {},
+        [{ agentType: 'broken', whenToUse: 'x' }],
+        true,
+      ),
+    ).resolves.toEqual([])
+
+    expect(harness.logError).toHaveBeenCalledWith(error)
+  })
+})

--- a/runtime/tests/tui/hooks/useApiKeyVerification.wave200-066.coverage.test.tsx
+++ b/runtime/tests/tui/hooks/useApiKeyVerification.wave200-066.coverage.test.tsx
@@ -1,0 +1,172 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const authHarness = vi.hoisted(() => {
+  const state = {
+    authEnabled: true,
+    key: undefined as string | undefined,
+    nonInteractive: false,
+    source: undefined as string | undefined,
+    subscriber: false,
+  }
+
+  return {
+    state,
+    getApiKeyFromApiKeyHelper: vi.fn(async () => undefined),
+    getAnthropicApiKeyWithSource: vi.fn(
+      (_options?: { skipRetrievingKeyFromApiKeyHelper?: boolean }) => ({
+        key: state.key,
+        source: state.source,
+      }),
+    ),
+    reset() {
+      state.authEnabled = true
+      state.key = undefined
+      state.nonInteractive = false
+      state.source = undefined
+      state.subscriber = false
+      this.getApiKeyFromApiKeyHelper.mockClear()
+      this.getAnthropicApiKeyWithSource.mockClear()
+      this.verifyApiKey.mockClear()
+    },
+    verifyApiKey: vi.fn(async () => true),
+  }
+})
+
+vi.mock('../../bootstrap/state', async importOriginal => ({
+  ...(await importOriginal()),
+  getIsNonInteractiveSession: () => authHarness.state.nonInteractive,
+}))
+
+vi.mock('../../services/api/anthropic', () => ({
+  verifyApiKey: authHarness.verifyApiKey,
+}))
+
+vi.mock('../../utils/auth.js', () => ({
+  getAnthropicApiKeyWithSource: authHarness.getAnthropicApiKeyWithSource,
+  getApiKeyFromApiKeyHelper: authHarness.getApiKeyFromApiKeyHelper,
+  isAgenCAISubscriber: () => authHarness.state.subscriber,
+  isAnthropicAuthEnabled: () => authHarness.state.authEnabled,
+}))
+
+import { createRoot } from '../ink/root.js'
+import { useApiKeyVerification } from './useApiKeyVerification.js'
+
+type HookResult = ReturnType<typeof useApiKeyVerification>
+type Snapshot = {
+  errorMessage: string | null
+  status: HookResult['status']
+}
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough
+}
+
+function createStreams(): TestStreams {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStreams['stdin']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 100
+
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 10): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await sleep()
+  }
+  throw new Error(message)
+}
+
+describe('useApiKeyVerification api key helper coverage', () => {
+  beforeEach(() => {
+    authHarness.reset()
+  })
+
+  test('reports a configured helper that warms but does not return a key', async () => {
+    authHarness.state.nonInteractive = true
+    authHarness.state.source = 'apiKeyHelper'
+    const snapshots: Snapshot[] = []
+    let latest: HookResult | null = null
+
+    function Harness(): null {
+      const result = useApiKeyVerification()
+      latest = result
+
+      React.useEffect(() => {
+        snapshots.push({
+          errorMessage: result.error?.message ?? null,
+          status: result.status,
+        })
+      }, [result.error, result.status])
+
+      return null
+    }
+
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      root.render(React.createElement(Harness))
+
+      await waitForCondition(
+        () => latest?.status === 'loading',
+        'Timed out waiting for initial loading status',
+      )
+
+      expect(authHarness.getAnthropicApiKeyWithSource).toHaveBeenCalledWith({
+        skipRetrievingKeyFromApiKeyHelper: true,
+      })
+
+      await latest?.reverify()
+
+      await waitForCondition(
+        () =>
+          latest?.status === 'error' &&
+          latest.error?.message ===
+            'API key helper did not return a valid key',
+        'Timed out waiting for helper error status',
+      )
+
+      expect(authHarness.getApiKeyFromApiKeyHelper).toHaveBeenCalledWith(true)
+      expect(authHarness.getAnthropicApiKeyWithSource).toHaveBeenLastCalledWith()
+      expect(authHarness.verifyApiKey).not.toHaveBeenCalled()
+      expect(snapshots).toContainEqual({
+        errorMessage: 'API key helper did not return a valid key',
+        status: 'error',
+      })
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+})

--- a/runtime/tests/tui/hooks/useArrowKeyHistory.test.tsx
+++ b/runtime/tests/tui/hooks/useArrowKeyHistory.test.tsx
@@ -1,0 +1,342 @@
+import { PassThrough } from 'node:stream'
+
+import React, { useState } from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  entries: [] as HistoryEntryLike[],
+  historyReadCount: 0,
+  removeNotification: vi.fn(),
+  reset() {
+    this.addNotification.mockClear()
+    this.entries = []
+    this.historyReadCount = 0
+    this.removeNotification.mockClear()
+  },
+}))
+
+type HistoryEntryLike = {
+  display: string
+  pastedContents?: Record<number, PastedContentLike>
+}
+
+type PastedContentLike = {
+  content: string
+  id: number
+  type: 'text'
+}
+
+vi.mock('../context/notifications.js', () => ({
+  useNotifications: () => ({
+    addNotification: harness.addNotification,
+    removeNotification: harness.removeNotification,
+  }),
+}))
+
+vi.mock('../history/history.js', () => ({
+  getHistory: async function* () {
+    harness.historyReadCount += 1
+    for (const entry of harness.entries) {
+      yield entry
+    }
+  },
+}))
+
+import { createRoot } from '../ink/root.js'
+import {
+  type HistoryMode,
+  useArrowKeyHistory,
+} from './useArrowKeyHistory.js'
+
+type HookResult = ReturnType<typeof useArrowKeyHistory>
+
+function createStreams(): {
+  readonly stdout: PassThrough
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  let lastError: unknown
+  for (let i = 0; i < 20; i++) {
+    try {
+      assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await sleep()
+    }
+  }
+  throw lastError
+}
+
+function pastedText(id: number, content: string): PastedContentLike {
+  return { content, id, type: 'text' }
+}
+
+async function renderHookHarness(
+  initial: {
+    currentInput?: string
+    currentMode?: HistoryMode
+    currentPastedContents?: Record<number, PastedContentLike>
+  } = {},
+): Promise<{
+  readonly currentInput: () => string
+  readonly currentMode: () => HistoryMode
+  readonly currentPastedContents: () => Record<number, PastedContentLike>
+  readonly dispose: () => Promise<void>
+  readonly latest: () => HookResult
+  readonly onSetInput: ReturnType<typeof vi.fn>
+  readonly setCursorOffset: ReturnType<typeof vi.fn>
+}> {
+  let latest: HookResult | undefined
+  let latestInput = initial.currentInput ?? ''
+  let latestMode = initial.currentMode ?? 'prompt'
+  let latestPastedContents = initial.currentPastedContents ?? {}
+  const onSetInput = vi.fn()
+  const setCursorOffset = vi.fn()
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    const [input, setInput] = useState(latestInput)
+    const [mode, setMode] = useState<HistoryMode>(latestMode)
+    const [pastedContents, setPastedContents] = useState(latestPastedContents)
+    latestInput = input
+    latestMode = mode
+    latestPastedContents = pastedContents
+    latest = useArrowKeyHistory(
+      (value, nextMode, nextPastedContents) => {
+        onSetInput(value, nextMode, nextPastedContents)
+        setInput(value)
+        setMode(nextMode)
+        setPastedContents(nextPastedContents)
+      },
+      input,
+      pastedContents,
+      setCursorOffset,
+      mode,
+    )
+    return null
+  }
+
+  root.render(<Harness />)
+  await sleep()
+
+  return {
+    currentInput: () => latestInput,
+    currentMode: () => latestMode,
+    currentPastedContents: () => latestPastedContents,
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+    onSetInput,
+    setCursorOffset,
+  }
+}
+
+describe('useArrowKeyHistory', () => {
+  beforeEach(() => {
+    harness.reset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('traverses up and down, preserves the edit buffer, and moves cursors appropriately', async () => {
+    const recentMultiline = 'recent line one\nrecent line two'
+    const draftPastedContents = { 7: pastedText(7, 'draft paste') }
+    const recentPastedContents = { 2: pastedText(2, 'recent paste') }
+    harness.entries = [
+      { display: recentMultiline, pastedContents: recentPastedContents },
+      { display: 'older command', pastedContents: {} },
+    ]
+    const rendered = await renderHookHarness({
+      currentInput: 'draft input',
+      currentPastedContents: draftPastedContents,
+    })
+
+    try {
+      rendered.latest().onHistoryUp()
+      await waitFor(() => expect(rendered.currentInput()).toBe(recentMultiline))
+      expect(rendered.currentMode()).toBe('prompt')
+      expect(rendered.currentPastedContents()).toEqual(recentPastedContents)
+      expect(rendered.latest().historyIndex).toBe(1)
+      expect(rendered.setCursorOffset).toHaveBeenLastCalledWith(0)
+
+      rendered.latest().onHistoryUp()
+      await waitFor(() => expect(rendered.currentInput()).toBe('older command'))
+      expect(rendered.latest().historyIndex).toBe(2)
+      expect(rendered.setCursorOffset).toHaveBeenLastCalledWith(0)
+      expect(harness.addNotification).toHaveBeenCalledTimes(1)
+      expect(harness.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'search-history-hint',
+          priority: 'immediate',
+        }),
+      )
+
+      expect(rendered.latest().onHistoryDown()).toBe(false)
+      await waitFor(() => expect(rendered.currentInput()).toBe(recentMultiline))
+      expect(rendered.latest().historyIndex).toBe(1)
+      expect(rendered.setCursorOffset).toHaveBeenLastCalledWith(
+        recentMultiline.length,
+      )
+
+      expect(rendered.latest().onHistoryDown()).toBe(false)
+      await waitFor(() => expect(rendered.currentInput()).toBe('draft input'))
+      expect(rendered.latest().historyIndex).toBe(0)
+      expect(rendered.currentMode()).toBe('prompt')
+      expect(rendered.currentPastedContents()).toEqual(draftPastedContents)
+      expect(rendered.setCursorOffset).toHaveBeenLastCalledWith(
+        'draft input'.length,
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('leaves input unchanged for empty history and reports down as unhandled at the draft', async () => {
+    harness.entries = []
+    const rendered = await renderHookHarness({
+      currentInput: 'draft input',
+      currentPastedContents: { 1: pastedText(1, 'draft paste') },
+    })
+
+    try {
+      rendered.latest().onHistoryUp()
+      await sleep(50)
+
+      expect(harness.historyReadCount).toBe(1)
+      expect(rendered.latest().historyIndex).toBe(0)
+      expect(rendered.currentInput()).toBe('draft input')
+      expect(rendered.onSetInput).not.toHaveBeenCalled()
+      expect(rendered.setCursorOffset).not.toHaveBeenCalled()
+
+      expect(rendered.latest().onHistoryDown()).toBe(true)
+      await sleep()
+      expect(rendered.currentInput()).toBe('draft input')
+      expect(rendered.onSetInput).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('stays on the oldest item when up traversal reaches the history boundary', async () => {
+    harness.entries = [{ display: 'only command', pastedContents: {} }]
+    const rendered = await renderHookHarness({ currentInput: 'draft input' })
+
+    try {
+      rendered.latest().onHistoryUp()
+      await waitFor(() => expect(rendered.currentInput()).toBe('only command'))
+      expect(rendered.latest().historyIndex).toBe(1)
+      expect(rendered.onSetInput).toHaveBeenCalledTimes(1)
+
+      rendered.latest().onHistoryUp()
+      await sleep(50)
+      expect(rendered.currentInput()).toBe('only command')
+      expect(rendered.latest().historyIndex).toBe(1)
+      expect(rendered.onSetInput).toHaveBeenCalledTimes(1)
+      expect(harness.addNotification).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('reset clears navigation state, notifications, and cached history', async () => {
+    harness.entries = [{ display: 'before reset', pastedContents: {} }]
+    const rendered = await renderHookHarness({ currentInput: 'draft input' })
+
+    try {
+      rendered.latest().onHistoryUp()
+      await waitFor(() => expect(rendered.currentInput()).toBe('before reset'))
+      expect(rendered.latest().historyIndex).toBe(1)
+      expect(harness.historyReadCount).toBe(1)
+
+      rendered.latest().resetHistory()
+      await waitFor(() => expect(rendered.latest().historyIndex).toBe(0))
+      expect(harness.removeNotification).toHaveBeenCalledWith(
+        'search-history-hint',
+      )
+
+      expect(rendered.latest().onHistoryDown()).toBe(true)
+      await sleep()
+      expect(rendered.currentInput()).toBe('before reset')
+
+      harness.entries = [{ display: 'after reset', pastedContents: {} }]
+      rendered.latest().onHistoryUp()
+      await waitFor(() => expect(rendered.currentInput()).toBe('after reset'))
+      expect(rendered.latest().historyIndex).toBe(1)
+      expect(harness.historyReadCount).toBe(2)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('filters bash history and restores a bash draft with its mode and pasted contents', async () => {
+    const draftPastedContents = { 9: pastedText(9, 'shell draft paste') }
+    harness.entries = [
+      { display: 'prompt command', pastedContents: {} },
+      { display: '!npm test', pastedContents: {} },
+      { display: '!git status', pastedContents: {} },
+    ]
+    const rendered = await renderHookHarness({
+      currentInput: 'draft shell',
+      currentMode: 'bash',
+      currentPastedContents: draftPastedContents,
+    })
+
+    try {
+      rendered.latest().onHistoryUp()
+      await waitFor(() => expect(rendered.currentInput()).toBe('npm test'))
+      expect(rendered.currentMode()).toBe('bash')
+      expect(rendered.latest().historyIndex).toBe(1)
+      expect(rendered.setCursorOffset).toHaveBeenLastCalledWith(0)
+
+      expect(rendered.latest().onHistoryDown()).toBe(false)
+      await waitFor(() => expect(rendered.currentInput()).toBe('draft shell'))
+      expect(rendered.currentMode()).toBe('bash')
+      expect(rendered.currentPastedContents()).toEqual(draftPastedContents)
+      expect(rendered.setCursorOffset).toHaveBeenLastCalledWith(
+        'draft shell'.length,
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/hooks/useCancelRequest.wave200-149.coverage.test.tsx
+++ b/runtime/tests/tui/hooks/useCancelRequest.wave200-149.coverage.test.tsx
@@ -1,0 +1,224 @@
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+
+type AppState = {
+  tasks: Record<string, any>
+  viewSelectionMode: string
+}
+
+type CapturedKeybinding = {
+  handler: () => void
+  isActive?: boolean
+}
+
+const fixture = vi.hoisted(() => ({
+  state: {
+    tasks: {} as Record<string, any>,
+    viewSelectionMode: 'none',
+  } as AppState,
+  queuedCommandsLength: 0,
+  hasCommandsInQueue: false,
+  overlayActive: false,
+  keybindings: new Map<string, CapturedKeybinding>(),
+  addNotification: vi.fn(),
+  removeNotification: vi.fn(),
+  killAllRunningAgentTasks: vi.fn(),
+  markAgentsNotified: vi.fn(),
+  enqueuePendingNotification: vi.fn(),
+  emitTaskTerminatedSdk: vi.fn(),
+  exitTeammateView: vi.fn(),
+  logEvent: vi.fn(),
+  onAgentsKilled: vi.fn(),
+  onCancel: vi.fn(),
+  setToolUseConfirmQueue: vi.fn(),
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../services/analytics/index.js', () => ({
+  logEvent: fixture.logEvent,
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppState: (selector: (state: AppState) => unknown) =>
+    selector(fixture.state),
+  useAppStateStore: () => ({
+    getState: () => fixture.state,
+  }),
+  useSetAppState: () => (updater: AppState | ((prev: AppState) => AppState)) => {
+    fixture.state =
+      typeof updater === 'function' ? updater(fixture.state) : updater
+  },
+}))
+
+vi.mock('../components/PromptInput/utils.js', () => ({
+  isVimModeEnabled: () => false,
+}))
+
+vi.mock('../context/notifications', () => ({
+  useNotifications: () => ({
+    addNotification: fixture.addNotification,
+    removeNotification: fixture.removeNotification,
+  }),
+}))
+
+vi.mock('../context/overlayContext', () => ({
+  useIsOverlayActive: () => fixture.overlayActive,
+}))
+
+vi.mock('./useCommandQueue', () => ({
+  useCommandQueue: () => ({ length: fixture.queuedCommandsLength }),
+}))
+
+vi.mock('../keybindings/shortcutFormat.js', () => ({
+  getShortcutDisplay: () => 'ctrl+x ctrl+k',
+}))
+
+vi.mock('../keybindings/useKeybinding.js', () => ({
+  useKeybinding: (
+    action: string,
+    handler: () => void,
+    options?: { isActive?: boolean },
+  ) => {
+    fixture.keybindings.set(action, {
+      handler,
+      isActive: options?.isActive,
+    })
+  },
+}))
+
+vi.mock('../state/teammateViewHelpers', () => ({
+  exitTeammateView: (...args: unknown[]) => fixture.exitTeammateView(...args),
+}))
+
+vi.mock('../../tasks/LocalAgentTask/LocalAgentTask', () => ({
+  killAllRunningAgentTasks: (...args: unknown[]) =>
+    fixture.killAllRunningAgentTasks(...args),
+  markAgentsNotified: (...args: unknown[]) =>
+    fixture.markAgentsNotified(...args),
+}))
+
+vi.mock('../../utils/messageQueueManager.js', () => ({
+  clearCommandQueue: vi.fn(),
+  enqueuePendingNotification: (...args: unknown[]) =>
+    fixture.enqueuePendingNotification(...args),
+  hasCommandsInQueue: () => fixture.hasCommandsInQueue,
+}))
+
+vi.mock('../../utils/sdkEventQueue.js', () => ({
+  emitTaskTerminatedSdk: (...args: unknown[]) =>
+    fixture.emitTaskTerminatedSdk(...args),
+}))
+
+function runningAgent(
+  id: string,
+  description: string,
+  toolUseId: string,
+): Record<string, unknown> {
+  return {
+    id,
+    type: 'local_agent',
+    status: 'running',
+    description,
+    toolUseId,
+  }
+}
+
+function getKeybinding(action: string): CapturedKeybinding {
+  const keybinding = fixture.keybindings.get(action)
+  if (keybinding === undefined) {
+    throw new Error(`Missing keybinding: ${action}`)
+  }
+  return keybinding
+}
+
+describe('CancelRequestHandler teammate-view interrupt coverage', () => {
+  beforeEach(() => {
+    fixture.state = {
+      tasks: {
+        agent_1: runningAgent('agent_1', 'inspect status bar', 'tool_1'),
+        agent_2: runningAgent('agent_2', 'write summary', 'tool_2'),
+      },
+      viewSelectionMode: 'viewing-agent',
+    }
+    fixture.queuedCommandsLength = 0
+    fixture.hasCommandsInQueue = false
+    fixture.overlayActive = false
+    fixture.keybindings.clear()
+    vi.clearAllMocks()
+  })
+
+  test('Ctrl+C from teammate view stops all agents, returns to main, and cancels the active turn', async () => {
+    const abortController = new AbortController()
+    const { CancelRequestHandler } = await import('./useCancelRequest.js')
+
+    await renderToString(
+      <CancelRequestHandler
+        setToolUseConfirmQueue={fixture.setToolUseConfirmQueue}
+        onCancel={fixture.onCancel}
+        onAgentsKilled={fixture.onAgentsKilled}
+        isMessageSelectorVisible={false}
+        screen="prompt"
+        abortSignal={abortController.signal}
+      />,
+      100,
+    )
+
+    const interrupt = getKeybinding('app:interrupt')
+    expect(interrupt.isActive).toBe(true)
+    expect(getKeybinding('chat:cancel').isActive).toBe(false)
+
+    interrupt.handler()
+
+    expect(fixture.killAllRunningAgentTasks).toHaveBeenCalledWith(
+      fixture.state.tasks,
+      expect.any(Function),
+    )
+    expect(fixture.markAgentsNotified).toHaveBeenCalledWith(
+      'agent_1',
+      expect.any(Function),
+    )
+    expect(fixture.markAgentsNotified).toHaveBeenCalledWith(
+      'agent_2',
+      expect.any(Function),
+    )
+    expect(fixture.emitTaskTerminatedSdk).toHaveBeenCalledWith(
+      'agent_1',
+      'stopped',
+      {
+        toolUseId: 'tool_1',
+        summary: 'inspect status bar',
+      },
+    )
+    expect(fixture.emitTaskTerminatedSdk).toHaveBeenCalledWith(
+      'agent_2',
+      'stopped',
+      {
+        toolUseId: 'tool_2',
+        summary: 'write summary',
+      },
+    )
+    expect(fixture.enqueuePendingNotification).toHaveBeenCalledWith({
+      value:
+        '2 background agents were stopped by the user: "inspect status bar", "write summary".',
+      mode: 'task-notification',
+    })
+    expect(fixture.onAgentsKilled).toHaveBeenCalledWith([
+      { taskId: 'agent_1', description: 'inspect status bar' },
+      { taskId: 'agent_2', description: 'write summary' },
+    ])
+    expect(fixture.exitTeammateView).toHaveBeenCalledWith(expect.any(Function))
+    expect(fixture.setToolUseConfirmQueue).toHaveBeenCalledWith(
+      expect.any(Function),
+    )
+    expect(fixture.onCancel).toHaveBeenCalledTimes(1)
+    expect(fixture.logEvent).toHaveBeenCalledWith('agenc_cancel', {
+      source: 'escape',
+      streamMode: undefined,
+    })
+  })
+})

--- a/runtime/tests/tui/hooks/useClipboardImageHint.wave200-126.coverage.test.ts
+++ b/runtime/tests/tui/hooks/useClipboardImageHint.wave200-126.coverage.test.ts
@@ -1,0 +1,172 @@
+import { PassThrough } from 'node:stream'
+
+import React, { act } from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  hasImageInClipboard: vi.fn(),
+}))
+
+vi.mock('../context/notifications.js', () => ({
+  useNotifications: () => ({
+    addNotification: harness.addNotification,
+  }),
+}))
+
+vi.mock('../keybindings/shortcutFormat.js', () => ({
+  getShortcutDisplay: () => 'Ctrl+V',
+}))
+
+vi.mock('../../utils/imagePaste.js', () => ({
+  hasImageInClipboard: harness.hasImageInClipboard,
+}))
+
+import { createRoot } from '../ink/root.js'
+import { useClipboardImageHint } from './useClipboardImageHint.js'
+
+type HookProps = {
+  enabled: boolean
+  isFocused: boolean
+}
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough
+}
+
+function createStreams(): TestStreams {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStreams['stdin']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 100
+
+  return { stdin, stdout }
+}
+
+async function flushEffects(ms = 0): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms)
+    await Promise.resolve()
+  })
+}
+
+async function renderHookHarness(
+  initialProps: HookProps,
+): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly render: (next: Partial<HookProps>) => Promise<void>
+}> {
+  let props = initialProps
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    useClipboardImageHint(props.isFocused, props.enabled)
+    return null
+  }
+
+  async function render(next: Partial<HookProps> = {}): Promise<void> {
+    props = { ...props, ...next }
+    await act(async () => {
+      root.render(React.createElement(Harness))
+    })
+    await flushEffects()
+  }
+
+  await render()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushEffects()
+    },
+    render,
+  }
+}
+
+describe('useClipboardImageHint coverage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(60_000)
+    harness.addNotification.mockClear()
+    harness.hasImageInClipboard.mockReset()
+    harness.hasImageInClipboard.mockResolvedValue(false)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  test('debounces focus-regain checks, skips disabled and missed images, notifies once per cooldown window', async () => {
+    const rendered = await renderHookHarness({
+      enabled: true,
+      isFocused: true,
+    })
+
+    try {
+      await flushEffects(1_000)
+      expect(harness.hasImageInClipboard).not.toHaveBeenCalled()
+
+      await rendered.render({ enabled: true, isFocused: false })
+      await rendered.render({ enabled: false, isFocused: true })
+      await flushEffects(1_000)
+      expect(harness.hasImageInClipboard).not.toHaveBeenCalled()
+
+      await rendered.render({ enabled: true, isFocused: false })
+      await rendered.render({ isFocused: true })
+      await rendered.render({ isFocused: false })
+      await flushEffects(1_000)
+      expect(harness.hasImageInClipboard).not.toHaveBeenCalled()
+
+      await rendered.render({ isFocused: true })
+      await flushEffects(1_000)
+      expect(harness.hasImageInClipboard).toHaveBeenCalledTimes(1)
+      expect(harness.addNotification).not.toHaveBeenCalled()
+
+      harness.hasImageInClipboard.mockResolvedValue(true)
+      await rendered.render({ isFocused: false })
+      await rendered.render({ isFocused: true })
+      await flushEffects(1_000)
+      expect(harness.hasImageInClipboard).toHaveBeenCalledTimes(2)
+      expect(harness.addNotification).toHaveBeenCalledWith({
+        key: 'clipboard-image-hint',
+        text: 'Image in clipboard · Ctrl+V to paste',
+        priority: 'immediate',
+        timeoutMs: 8000,
+      })
+
+      await rendered.render({ isFocused: false })
+      await rendered.render({ isFocused: true })
+      await flushEffects(1_000)
+      expect(harness.hasImageInClipboard).toHaveBeenCalledTimes(2)
+      expect(harness.addNotification).toHaveBeenCalledTimes(1)
+
+      await rendered.render({ isFocused: false })
+      await flushEffects(30_000)
+      await rendered.render({ isFocused: true })
+      await flushEffects(1_000)
+      expect(harness.hasImageInClipboard).toHaveBeenCalledTimes(3)
+      expect(harness.addNotification).toHaveBeenCalledTimes(2)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/hooks/useCopyOnSelect.wave200-135.coverage.test.tsx
+++ b/runtime/tests/tui/hooks/useCopyOnSelect.wave200-135.coverage.test.tsx
@@ -1,0 +1,190 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  config: {} as { copyOnSelect?: boolean },
+  copySelectionNoClear: vi.fn(() => 'selected text'),
+  getState: vi.fn(() => null as { isDragging?: boolean } | null),
+  hasSelection: vi.fn(() => false),
+  latestSubscriber: null as (() => void) | null,
+  selectionBgColors: [] as string[],
+  themeName: 'dark',
+  unsubscribe: vi.fn(),
+  reset() {
+    this.config = {}
+    this.copySelectionNoClear.mockReset()
+    this.copySelectionNoClear.mockReturnValue('selected text')
+    this.getState.mockReset()
+    this.getState.mockReturnValue(null)
+    this.hasSelection.mockReset()
+    this.hasSelection.mockReturnValue(false)
+    this.latestSubscriber = null
+    this.selectionBgColors = []
+    this.themeName = 'dark'
+    this.unsubscribe.mockReset()
+  },
+}))
+
+vi.mock('../components/design-system/ThemeProvider', () => ({
+  useTheme: () => [harness.themeName, vi.fn()],
+}))
+
+vi.mock('../../utils/config.js', () => ({
+  getGlobalConfig: () => harness.config,
+}))
+
+vi.mock('../../utils/theme.js', () => ({
+  getTheme: (name: string) => ({ selectionBg: `${name}-selection` }),
+}))
+
+import { createRoot } from '../ink/root.js'
+import { useCopyOnSelect, useSelectionBgColor } from './useCopyOnSelect.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+function createStreams(): {
+  readonly stdin: TestStdin
+  readonly stdout: PassThrough
+} {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough()
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function notifySelectionChanged(): void {
+  if (harness.latestSubscriber === null) {
+    throw new Error('selection subscriber was not registered')
+  }
+  harness.latestSubscriber()
+}
+
+function createSelection() {
+  return {
+    copySelectionNoClear: harness.copySelectionNoClear,
+    getState: harness.getState,
+    hasSelection: harness.hasSelection,
+    setSelectionBgColor: (color: string) => {
+      harness.selectionBgColors.push(color)
+    },
+    subscribe: vi.fn((subscriber: () => void) => {
+      harness.latestSubscriber = subscriber
+      return harness.unsubscribe
+    }),
+  }
+}
+
+describe('useCopyOnSelect wave200 coverage', () => {
+  beforeEach(() => {
+    harness.reset()
+  })
+
+  test('copies settled selections once, respects disabled and blank selections, and refreshes theme color', async () => {
+    const selection = createSelection()
+    const firstCopied = vi.fn()
+    const secondCopied = vi.fn()
+    let isActive = false
+    let onCopied: ((text: string) => void) | undefined = firstCopied
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    function Harness(): null {
+      useCopyOnSelect(selection as never, isActive, onCopied)
+      useSelectionBgColor(selection as never)
+      return null
+    }
+
+    async function render(): Promise<void> {
+      root.render(<Harness />)
+      await sleep()
+    }
+
+    try {
+      await render()
+
+      expect(selection.subscribe).not.toHaveBeenCalled()
+      expect(harness.selectionBgColors).toEqual(['dark-selection'])
+
+      isActive = true
+      harness.themeName = 'light'
+      await render()
+
+      expect(selection.subscribe).toHaveBeenCalledTimes(1)
+      expect(harness.selectionBgColors).toEqual([
+        'dark-selection',
+        'light-selection',
+      ])
+
+      harness.getState.mockReturnValue({ isDragging: true })
+      harness.hasSelection.mockReturnValue(true)
+      notifySelectionChanged()
+      expect(harness.copySelectionNoClear).not.toHaveBeenCalled()
+
+      harness.getState.mockReturnValue({ isDragging: false })
+      notifySelectionChanged()
+      expect(harness.copySelectionNoClear).toHaveBeenCalledTimes(1)
+      expect(firstCopied).toHaveBeenCalledWith('selected text')
+
+      notifySelectionChanged()
+      expect(harness.copySelectionNoClear).toHaveBeenCalledTimes(1)
+
+      harness.hasSelection.mockReturnValue(false)
+      notifySelectionChanged()
+
+      harness.config = { copyOnSelect: false }
+      harness.hasSelection.mockReturnValue(true)
+      harness.copySelectionNoClear.mockClear()
+      notifySelectionChanged()
+      expect(harness.copySelectionNoClear).not.toHaveBeenCalled()
+
+      harness.config = { copyOnSelect: true }
+      onCopied = secondCopied
+      await render()
+
+      notifySelectionChanged()
+      expect(harness.copySelectionNoClear).toHaveBeenCalledTimes(1)
+      expect(secondCopied).toHaveBeenCalledWith('selected text')
+      expect(firstCopied).toHaveBeenCalledTimes(1)
+
+      harness.hasSelection.mockReturnValue(false)
+      notifySelectionChanged()
+      harness.hasSelection.mockReturnValue(true)
+      harness.copySelectionNoClear.mockReturnValue('   ')
+      notifySelectionChanged()
+
+      expect(secondCopied).toHaveBeenCalledTimes(1)
+
+      harness.copySelectionNoClear.mockReturnValue('retry should be blocked')
+      notifySelectionChanged()
+      expect(secondCopied).toHaveBeenCalledTimes(1)
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+
+    expect(harness.unsubscribe).toHaveBeenCalledTimes(1)
+  })
+})

--- a/runtime/tests/tui/hooks/useGlobalKeybindings.coverage.test.tsx
+++ b/runtime/tests/tui/hooks/useGlobalKeybindings.coverage.test.tsx
@@ -1,0 +1,167 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+type CapturedKeybinding = {
+  handler: () => void;
+  options?: {
+    context?: string;
+    isActive?: boolean;
+  };
+};
+
+const harness = vi.hoisted(() => ({
+  appState: {
+    expandedView: "none",
+    isBriefOnly: false,
+  },
+  features: new Set<string>(),
+  growthbookCalls: [] as Array<{ fallback: boolean; key: string }>,
+  keybindings: new Map<string, CapturedKeybinding>(),
+  logEvent: vi.fn(),
+  setAppState: vi.fn(),
+  terminalAllowed: false,
+  terminalToggle: vi.fn(),
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: (name: string) => harness.features.has(name),
+}));
+
+vi.mock("../keybindings/useKeybinding.js", () => ({
+  useKeybinding: (
+    action: string,
+    handler: () => void,
+    options?: CapturedKeybinding["options"],
+  ) => {
+    harness.keybindings.set(action, { handler, options });
+  },
+}));
+
+vi.mock("../state/AppState.js", () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+  useSetAppState: () => harness.setAppState,
+}));
+
+vi.mock("../../services/analytics/index.js", () => ({
+  logEvent: harness.logEvent,
+}));
+
+vi.mock("../../services/analytics/growthbook.js", () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: (key: string, fallback: boolean) => {
+    harness.growthbookCalls.push({ fallback, key });
+    return key === "agenc_terminal_panel" ? harness.terminalAllowed : fallback;
+  },
+}));
+
+vi.mock("../../utils/terminalPanel.js", () => ({
+  getTerminalPanel: () => ({
+    toggle: harness.terminalToggle,
+  }),
+}));
+
+import { createRoot } from "../ink/root.js";
+import { GlobalKeybindingHandlers } from "./useGlobalKeybindings.js";
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  readonly stdout: PassThrough;
+};
+
+function createStreams(): TestStreams {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStreams["stdin"];
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.resume();
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe("GlobalKeybindingHandlers", () => {
+  beforeEach(() => {
+    harness.features = new Set(["TERMINAL_PANEL"]);
+    harness.growthbookCalls = [];
+    harness.keybindings = new Map();
+    harness.terminalAllowed = false;
+    vi.clearAllMocks();
+  });
+
+  test("gates transcript bindings and terminal panel toggle on their active states", async () => {
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <GlobalKeybindingHandlers
+          screen="transcript"
+          setScreen={
+            vi.fn() as React.Dispatch<
+              React.SetStateAction<"prompt" | "transcript">
+            >
+          }
+          showAllInTranscript={false}
+          setShowAllInTranscript={
+            vi.fn() as React.Dispatch<React.SetStateAction<boolean>>
+          }
+          messageCount={3}
+          virtualScrollActive={true}
+          searchBarOpen={true}
+        />,
+      );
+      await sleep();
+
+      expect(harness.keybindings.get("transcript:toggleShowAll")?.options).toEqual(
+        {
+          context: "Transcript",
+          isActive: false,
+        },
+      );
+      expect(harness.keybindings.get("transcript:exit")?.options).toEqual({
+        context: "Transcript",
+        isActive: false,
+      });
+
+      const toggleTerminal = harness.keybindings.get("app:toggleTerminal")
+        ?.handler;
+      expect(toggleTerminal).toBeDefined();
+
+      toggleTerminal?.();
+      expect(harness.growthbookCalls).toEqual([
+        { fallback: false, key: "agenc_terminal_panel" },
+      ]);
+      expect(harness.terminalToggle).not.toHaveBeenCalled();
+
+      harness.terminalAllowed = true;
+      toggleTerminal?.();
+      expect(harness.growthbookCalls).toEqual([
+        { fallback: false, key: "agenc_terminal_panel" },
+        { fallback: false, key: "agenc_terminal_panel" },
+      ]);
+      expect(harness.terminalToggle).toHaveBeenCalledTimes(1);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+});

--- a/runtime/tests/tui/hooks/useGlobalKeybindings.wave200-030.coverage.test.tsx
+++ b/runtime/tests/tui/hooks/useGlobalKeybindings.wave200-030.coverage.test.tsx
@@ -1,0 +1,311 @@
+import { PassThrough } from "node:stream";
+import { createRequire } from "node:module";
+
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { Screen } from "../types/screen.js";
+
+type ExpandedView = "none" | "tasks" | "teammates";
+
+type AppState = {
+  expandedView: ExpandedView;
+  isBriefOnly: boolean;
+  showTeammateMessagePreview?: boolean;
+  tasks: Record<string, { status?: string; type?: string }>;
+};
+
+type CapturedKeybinding = {
+  handler: () => void;
+  options?: {
+    context?: string;
+    isActive?: boolean;
+  };
+};
+
+const harness = vi.hoisted(() => ({
+  appState: {
+    expandedView: "none",
+    isBriefOnly: false,
+    showTeammateMessagePreview: false,
+    tasks: {},
+  } as AppState,
+  briefEnabled: false,
+  features: new Set<string>(),
+  keybindings: new Map<string, CapturedKeybinding>(),
+  logEvent: vi.fn(),
+  setAppState: vi.fn(),
+  terminalToggle: vi.fn(),
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: (name: string) => harness.features.has(name),
+}));
+
+vi.mock("../keybindings/useKeybinding.js", () => ({
+  useKeybinding: (
+    action: string,
+    handler: () => void,
+    options?: CapturedKeybinding["options"],
+  ) => {
+    harness.keybindings.set(action, { handler, options });
+  },
+}));
+
+vi.mock("../state/AppState.js", () => ({
+  useAppState: (selector: (state: AppState) => unknown) =>
+    selector(harness.appState),
+  useSetAppState: () => harness.setAppState,
+}));
+
+vi.mock("../../services/analytics/index.js", () => ({
+  logEvent: harness.logEvent,
+}));
+
+vi.mock("../../services/analytics/growthbook.js", () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: () => true,
+}));
+
+vi.mock("../../utils/terminalPanel.js", () => ({
+  getTerminalPanel: () => ({
+    toggle: harness.terminalToggle,
+  }),
+}));
+
+import instances from "../ink/instances.js";
+import { createRoot } from "../ink/root.js";
+import { GlobalKeybindingHandlers } from "./useGlobalKeybindings.js";
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  readonly stdout: PassThrough;
+};
+
+function createStreams(): TestStreams {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStreams["stdin"];
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.resume();
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function keybinding(action: string): CapturedKeybinding {
+  const binding = harness.keybindings.get(action);
+  if (!binding) throw new Error(`missing keybinding: ${action}`);
+  return binding;
+}
+
+const requireForTest = createRequire(import.meta.url);
+const moduleLoader = requireForTest("node:module") as {
+  _load: (request: string, parent: unknown, isMain: boolean) => unknown;
+};
+
+function installLazyRequireMocks(): () => void {
+  const originalLoad = moduleLoader._load;
+
+  moduleLoader._load = ((request: string, parent: unknown, isMain: boolean) => {
+    if (
+      request === "../../tasks/InProcessTeammateTask/InProcessTeammateTask"
+    ) {
+      return {
+        getAllInProcessTeammateTasks: (
+          tasks: Record<string, { status?: string; type?: string }>,
+        ) =>
+          Object.values(tasks).filter(
+            task => task.type === "in_process_teammate",
+          ),
+      };
+    }
+
+    if (request === "../../tools/BriefTool/BriefTool") {
+      return {
+        isBriefEnabled: () => harness.briefEnabled,
+      };
+    }
+
+    return Reflect.apply(originalLoad, moduleLoader, [request, parent, isMain]);
+  }) as typeof originalLoad;
+
+  return () => {
+    moduleLoader._load = originalLoad;
+  };
+}
+
+describe("GlobalKeybindingHandlers wave200 coverage", () => {
+  beforeEach(() => {
+    harness.appState = {
+      expandedView: "none",
+      isBriefOnly: false,
+      showTeammateMessagePreview: false,
+      tasks: {},
+    };
+    harness.briefEnabled = false;
+    harness.features = new Set(["KAIROS_BRIEF", "TERMINAL_PANEL"]);
+    harness.keybindings = new Map();
+    vi.clearAllMocks();
+    harness.setAppState.mockImplementation(
+      (update: AppState | ((prev: AppState) => AppState)) => {
+        harness.appState =
+          typeof update === "function" ? update(harness.appState) : update;
+      },
+    );
+  });
+
+  test("runs registered global and transcript callbacks against app state", async () => {
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+    const restoreLazyRequireMocks = installLazyRequireMocks();
+    const previousStdoutInstance = instances.get(process.stdout);
+    const forceRedraw = vi.fn();
+
+    let screen: Screen = "prompt";
+    let showAllInTranscript = true;
+    const onEnterTranscript = vi.fn();
+    const onExitTranscript = vi.fn();
+    const setScreen = vi.fn((next: React.SetStateAction<Screen>) => {
+      screen = typeof next === "function" ? next(screen) : next;
+    });
+    const setShowAllInTranscript = vi.fn(
+      (next: React.SetStateAction<boolean>) => {
+        showAllInTranscript =
+          typeof next === "function" ? next(showAllInTranscript) : next;
+      },
+    );
+
+    const renderHandlers = async () => {
+      root.render(
+        <GlobalKeybindingHandlers
+          screen={screen}
+          setScreen={setScreen}
+          showAllInTranscript={showAllInTranscript}
+          setShowAllInTranscript={setShowAllInTranscript}
+          messageCount={5}
+          onEnterTranscript={onEnterTranscript}
+          onExitTranscript={onExitTranscript}
+        />,
+      );
+      await sleep();
+    };
+
+    try {
+      instances.set(process.stdout, { forceRedraw } as never);
+      harness.appState.tasks = {
+        teammate: {
+          status: "running",
+          type: "in_process_teammate",
+        },
+      };
+
+      await renderHandlers();
+      keybinding("app:toggleTodos").handler();
+      expect(harness.appState.expandedView).toBe("tasks");
+
+      await renderHandlers();
+      keybinding("app:toggleTodos").handler();
+      expect(harness.appState.expandedView).toBe("teammates");
+
+      await renderHandlers();
+      keybinding("app:toggleTodos").handler();
+      expect(harness.appState.expandedView).toBe("none");
+
+      harness.appState.tasks = {};
+      harness.appState.expandedView = "tasks";
+      await renderHandlers();
+      keybinding("app:toggleTodos").handler();
+      expect(harness.appState.expandedView).toBe("none");
+
+      await renderHandlers();
+      keybinding("app:toggleTodos").handler();
+      expect(harness.appState.expandedView).toBe("tasks");
+
+      harness.appState.isBriefOnly = true;
+      harness.briefEnabled = false;
+      screen = "prompt";
+      showAllInTranscript = true;
+      setScreen.mockClear();
+      setShowAllInTranscript.mockClear();
+      await renderHandlers();
+      keybinding("app:toggleTranscript").handler();
+      expect(harness.appState.isBriefOnly).toBe(false);
+      expect(setScreen).not.toHaveBeenCalled();
+      expect(setShowAllInTranscript).not.toHaveBeenCalled();
+
+      await renderHandlers();
+      keybinding("app:toggleTranscript").handler();
+      expect(screen).toBe("transcript");
+      expect(showAllInTranscript).toBe(false);
+      expect(onEnterTranscript).toHaveBeenCalledTimes(1);
+
+      showAllInTranscript = false;
+      await renderHandlers();
+      expect(keybinding("transcript:toggleShowAll").options).toEqual({
+        context: "Transcript",
+        isActive: true,
+      });
+      expect(keybinding("transcript:exit").options).toEqual({
+        context: "Transcript",
+        isActive: true,
+      });
+      keybinding("transcript:toggleShowAll").handler();
+      expect(showAllInTranscript).toBe(true);
+
+      keybinding("transcript:exit").handler();
+      expect(screen).toBe("prompt");
+      expect(showAllInTranscript).toBe(false);
+      expect(onExitTranscript).toHaveBeenCalledTimes(1);
+
+      harness.appState.isBriefOnly = false;
+      harness.briefEnabled = false;
+      await renderHandlers();
+      keybinding("app:toggleBrief").handler();
+      expect(harness.appState.isBriefOnly).toBe(false);
+
+      harness.briefEnabled = true;
+      await renderHandlers();
+      keybinding("app:toggleBrief").handler();
+      expect(harness.appState.isBriefOnly).toBe(true);
+      expect(harness.logEvent).toHaveBeenCalledWith(
+        "agenc_brief_mode_toggled",
+        {
+          enabled: true,
+          gated: false,
+          source: "keybinding",
+        },
+      );
+
+      keybinding("app:toggleTeammatePreview").handler();
+      expect(harness.appState.showTeammateMessagePreview).toBe(true);
+
+      keybinding("app:redraw").handler();
+      expect(forceRedraw).toHaveBeenCalledTimes(1);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      if (previousStdoutInstance) {
+        instances.set(process.stdout, previousStdoutInstance);
+      } else {
+        instances.delete(process.stdout);
+      }
+      restoreLazyRequireMocks();
+      await sleep();
+    }
+  });
+});

--- a/runtime/tests/tui/hooks/useHistorySearch.test.tsx
+++ b/runtime/tests/tui/hooks/useHistorySearch.test.tsx
@@ -1,0 +1,389 @@
+import { PassThrough } from "node:stream";
+
+import React, { useState } from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  entries: [] as HistoryEntryLike[],
+  features: new Set<string>(),
+  inputSubscription: undefined as
+    | undefined
+    | { handler: (input: string, key: unknown, event: { keypress: string }) => void; isActive: boolean },
+  keybinding: new Map<
+    string,
+    { handler: () => void; isActive: boolean; context: string }
+  >(),
+  keybindings: new Map<
+    string,
+    { handler: () => void; isActive: boolean; context: string }
+  >(),
+  readers: [] as Array<{
+    next: ReturnType<typeof vi.fn>;
+    return: ReturnType<typeof vi.fn>;
+  }>,
+  reset() {
+    harness.entries = [];
+    harness.features = new Set();
+    harness.inputSubscription = undefined;
+    harness.keybinding = new Map();
+    harness.keybindings = new Map();
+    harness.readers = [];
+  },
+}));
+
+type HistoryEntryLike = {
+  display: string;
+  pastedContents?: Record<string, unknown>;
+};
+
+vi.mock("bun:bundle", () => ({
+  feature: (name: string) => harness.features.has(name),
+}));
+
+vi.mock("../history/history.js", () => ({
+  makeHistoryReader: () => {
+    let index = 0;
+    const reader = {
+      next: vi.fn(async () => {
+        if (index >= harness.entries.length) {
+          return { done: true, value: undefined };
+        }
+        const value = harness.entries[index++];
+        return { done: false, value };
+      }),
+      return: vi.fn(async () => ({ done: true, value: undefined })),
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+    harness.readers.push(reader);
+    return reader;
+  },
+}));
+
+vi.mock("../keybindings/useKeybinding.js", () => ({
+  useKeybinding: (
+    command: string,
+    handler: () => void,
+    options: { context: string; isActive: boolean },
+  ) => {
+    harness.keybinding.set(command, {
+      context: options.context,
+      handler,
+      isActive: options.isActive,
+    });
+  },
+  useKeybindings: (
+    handlers: Record<string, () => void>,
+    options: { context: string; isActive: boolean },
+  ) => {
+    for (const [command, handler] of Object.entries(handlers)) {
+      harness.keybindings.set(command, {
+        context: options.context,
+        handler,
+        isActive: options.isActive,
+      });
+    }
+  },
+}));
+
+vi.mock("../ink.js", () => ({
+  useInput: (
+    handler: (input: string, key: unknown, event: { keypress: string }) => void,
+    options: { isActive: boolean },
+  ) => {
+    harness.inputSubscription = {
+      handler,
+      isActive: options.isActive,
+    };
+  },
+}));
+
+import { createRoot } from "../ink/root.js";
+import { useHistorySearch } from "./useHistorySearch.js";
+
+type HookResult = ReturnType<typeof useHistorySearch>;
+
+function createStreams(): {
+  stdout: PassThrough;
+  stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+} {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.resume();
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  let lastError: unknown;
+  for (let i = 0; i < 20; i++) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await sleep(25);
+    }
+  }
+  throw lastError;
+}
+
+async function renderHistoryHarness(
+  initial: {
+    currentCursorOffset?: number;
+    currentInput?: string;
+    currentMode?: "bash" | "prompt";
+    currentPastedContents?: Record<string, unknown>;
+  } = {},
+): Promise<{
+  callbacks: {
+    onAcceptHistory: ReturnType<typeof vi.fn>;
+    onCursorChange: ReturnType<typeof vi.fn>;
+    onInputChange: ReturnType<typeof vi.fn>;
+    onModeChange: ReturnType<typeof vi.fn>;
+    setPastedContents: ReturnType<typeof vi.fn>;
+  };
+  dispose: () => Promise<void>;
+  isSearching: () => boolean;
+  result: () => HookResult;
+}> {
+  let latest: HookResult | undefined;
+  let latestIsSearching = false;
+  const callbacks = {
+    onAcceptHistory: vi.fn(),
+    onCursorChange: vi.fn(),
+    onInputChange: vi.fn(),
+    onModeChange: vi.fn(),
+    setPastedContents: vi.fn(),
+  };
+  const { stdin, stdout } = createStreams();
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+  function Harness(): null {
+    const [isSearching, setIsSearching] = useState(false);
+    latestIsSearching = isSearching;
+    latest = useHistorySearch(
+      callbacks.onAcceptHistory,
+      initial.currentInput ?? "original input",
+      callbacks.onInputChange,
+      callbacks.onCursorChange,
+      initial.currentCursorOffset ?? 9,
+      callbacks.onModeChange,
+      initial.currentMode ?? "prompt",
+      isSearching,
+      setIsSearching,
+      callbacks.setPastedContents,
+      initial.currentPastedContents ?? { original: true },
+    );
+    return null;
+  }
+  root.render(<Harness />);
+  await sleep();
+  return {
+    callbacks,
+    dispose: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    },
+    isSearching: () => latestIsSearching,
+    result: () => {
+      if (!latest) throw new Error("hook did not render");
+      return latest;
+    },
+  };
+}
+
+describe("useHistorySearch", () => {
+  beforeEach(() => {
+    harness.reset();
+  });
+
+  test("starts search through the global history keybinding unless the picker owns it", async () => {
+    const rendered = await renderHistoryHarness();
+
+    try {
+      expect(harness.keybinding.get("history:search")).toMatchObject({
+        context: "Global",
+        isActive: true,
+      });
+      harness.keybinding.get("history:search")?.handler();
+      await waitFor(() => expect(rendered.isSearching()).toBe(true));
+      expect(harness.inputSubscription?.isActive).toBe(true);
+      expect(harness.keybindings.get("historySearch:accept")).toMatchObject({
+        context: "HistorySearch",
+        isActive: true,
+      });
+      expect(harness.readers).toHaveLength(1);
+    } finally {
+      await rendered.dispose();
+    }
+
+    harness.reset();
+    harness.features.add("HISTORY_PICKER");
+    const gated = await renderHistoryHarness();
+    try {
+      expect(harness.keybinding.get("history:search")).toMatchObject({
+        isActive: false,
+      });
+    } finally {
+      await gated.dispose();
+    }
+  });
+
+  test("searches history, deduplicates matches, and resumes to the next result", async () => {
+    harness.entries = [
+      { display: "first miss" },
+      { display: "!echo hello", pastedContents: { one: true } },
+      { display: "!echo hello", pastedContents: { duplicate: true } },
+      { display: "say hello again", pastedContents: { two: true } },
+    ];
+    const rendered = await renderHistoryHarness();
+
+    try {
+      harness.keybinding.get("history:search")?.handler();
+      await waitFor(() => expect(rendered.isSearching()).toBe(true));
+      rendered.result().setHistoryQuery("hello");
+      await waitFor(() =>
+        expect(rendered.callbacks.onInputChange).toHaveBeenLastCalledWith("!echo hello"),
+      );
+
+      expect(rendered.result().historyFailedMatch).toBe(false);
+      expect(rendered.result().historyMatch).toMatchObject({
+        display: "!echo hello",
+      });
+      expect(rendered.callbacks.onModeChange).toHaveBeenLastCalledWith("bash");
+      expect(rendered.callbacks.setPastedContents).toHaveBeenLastCalledWith({
+        one: true,
+      });
+      expect(rendered.callbacks.onCursorChange).toHaveBeenLastCalledWith(5);
+
+      harness.keybindings.get("historySearch:next")?.handler();
+      await waitFor(() =>
+        expect(rendered.callbacks.onInputChange).toHaveBeenLastCalledWith("say hello again"),
+      );
+      expect(rendered.result().historyMatch).toMatchObject({
+        display: "say hello again",
+      });
+      expect(rendered.callbacks.setPastedContents).toHaveBeenLastCalledWith({
+        two: true,
+      });
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("marks failed matches and restores the original input when the query is cleared", async () => {
+    harness.entries = [{ display: "nothing relevant" }];
+    const rendered = await renderHistoryHarness({
+      currentCursorOffset: 4,
+      currentInput: "keep me",
+      currentMode: "bash",
+      currentPastedContents: { keep: true },
+    });
+
+    try {
+      harness.keybinding.get("history:search")?.handler();
+      await waitFor(() => expect(rendered.isSearching()).toBe(true));
+      rendered.result().setHistoryQuery("missing");
+      await waitFor(() => expect(rendered.result().historyFailedMatch).toBe(true));
+
+      rendered.result().setHistoryQuery("");
+      await waitFor(() =>
+        expect(rendered.callbacks.onInputChange).toHaveBeenLastCalledWith("keep me"),
+      );
+      expect(rendered.result().historyMatch).toBeUndefined();
+      expect(rendered.result().historyFailedMatch).toBe(false);
+      expect(rendered.callbacks.onCursorChange).toHaveBeenLastCalledWith(4);
+      expect(rendered.callbacks.onModeChange).toHaveBeenLastCalledWith("bash");
+      expect(rendered.callbacks.setPastedContents).toHaveBeenLastCalledWith({
+        keep: true,
+      });
+      expect(harness.readers.at(-1)?.return).toHaveBeenCalled();
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("accepts, executes, and cancels history search state", async () => {
+    harness.entries = [{ display: "!run accepted", pastedContents: { ok: true } }];
+    const rendered = await renderHistoryHarness({
+      currentInput: "original command",
+      currentPastedContents: { original: true },
+    });
+
+    try {
+      harness.keybinding.get("history:search")?.handler();
+      await waitFor(() => expect(rendered.isSearching()).toBe(true));
+      rendered.result().setHistoryQuery("accepted");
+      await waitFor(() =>
+        expect(rendered.callbacks.onInputChange).toHaveBeenLastCalledWith("!run accepted"),
+      );
+
+      harness.keybindings.get("historySearch:accept")?.handler();
+      await waitFor(() => expect(rendered.isSearching()).toBe(false));
+      expect(rendered.callbacks.onInputChange).toHaveBeenLastCalledWith("run accepted");
+      expect(rendered.callbacks.onModeChange).toHaveBeenLastCalledWith("bash");
+      expect(rendered.callbacks.setPastedContents).toHaveBeenLastCalledWith({
+        ok: true,
+      });
+
+      harness.keybinding.get("history:search")?.handler();
+      await waitFor(() => expect(rendered.isSearching()).toBe(true));
+      harness.keybindings.get("historySearch:execute")?.handler();
+      await waitFor(() => expect(rendered.isSearching()).toBe(false));
+      expect(rendered.callbacks.onAcceptHistory).toHaveBeenLastCalledWith({
+        display: "original command",
+        pastedContents: { original: true },
+      });
+
+      harness.keybinding.get("history:search")?.handler();
+      await waitFor(() => expect(rendered.isSearching()).toBe(true));
+      rendered.result().setHistoryQuery("");
+      const event = { key: "backspace", preventDefault: vi.fn() };
+      rendered.result().handleKeyDown(event as never);
+      await waitFor(() => expect(rendered.isSearching()).toBe(false));
+      expect(event.preventDefault).toHaveBeenCalled();
+      expect(rendered.callbacks.onInputChange).toHaveBeenLastCalledWith("original command");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("ignores keydown and input bridge events while inactive", async () => {
+    const rendered = await renderHistoryHarness();
+
+    try {
+      const event = { key: "backspace", preventDefault: vi.fn() };
+      rendered.result().handleKeyDown(event as never);
+      expect(event.preventDefault).not.toHaveBeenCalled();
+      expect(harness.inputSubscription?.isActive).toBe(false);
+      harness.inputSubscription?.handler("", {}, { keypress: "backspace" });
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    } finally {
+      await rendered.dispose();
+    }
+  });
+});

--- a/runtime/tests/tui/hooks/useIdeSelection.wave200-087.coverage.test.tsx
+++ b/runtime/tests/tui/hooks/useIdeSelection.wave200-087.coverage.test.tsx
@@ -1,0 +1,174 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../ink/root.js'
+import {
+  type IDESelection,
+  useIdeSelection,
+} from './useIdeSelection.js'
+
+type SelectionPoint = {
+  readonly line: number
+  readonly character: number
+}
+
+type SelectionNotificationParams = {
+  readonly selection?: {
+    readonly start: SelectionPoint
+    readonly end: SelectionPoint
+  } | null
+  readonly text?: string
+  readonly filePath?: string
+}
+
+type NotificationHandler = (notification: {
+  readonly params: SelectionNotificationParams
+}) => void
+
+type TestIdeClient = {
+  readonly client: {
+    readonly setNotificationHandler: ReturnType<typeof vi.fn>
+  }
+  readonly emit: (params: SelectionNotificationParams) => void
+}
+
+const fixture = vi.hoisted(() => ({
+  ideClient: undefined as TestIdeClient | undefined,
+  logError: vi.fn(),
+}))
+
+vi.mock('../../utils/ide', () => ({
+  getConnectedIdeClient: () => fixture.ideClient,
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: fixture.logError,
+}))
+
+function createIdeClient(): TestIdeClient {
+  let handler: NotificationHandler | undefined
+
+  return {
+    client: {
+      setNotificationHandler: vi.fn(
+        (_schema: unknown, next: NotificationHandler) => {
+          handler = next
+        },
+      ),
+    },
+    emit: (params: SelectionNotificationParams) => {
+      if (handler === undefined) {
+        throw new Error('selection handler was not registered')
+      }
+      handler({ params })
+    },
+  }
+}
+
+function createStreams(): {
+  readonly stdout: PassThrough
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function Harness({
+  mcpClients,
+  onSelect,
+}: {
+  readonly mcpClients: unknown[]
+  readonly onSelect: (selection: IDESelection) => void
+}): null {
+  useIdeSelection(mcpClients as never, onSelect)
+  return null
+}
+
+describe('useIdeSelection wave200 coverage', () => {
+  beforeEach(() => {
+    fixture.ideClient = undefined
+    fixture.logError.mockClear()
+  })
+
+  test('publishes IDE selections and clears stale selected text when the IDE reports an empty selection', async () => {
+    const ideClient = createIdeClient()
+    fixture.ideClient = ideClient
+    const onSelect = vi.fn()
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      root.render(<Harness mcpClients={[{}]} onSelect={onSelect} />)
+      await sleep()
+
+      expect(ideClient.client.setNotificationHandler).toHaveBeenCalledTimes(1)
+      expect(onSelect).toHaveBeenLastCalledWith({
+        lineCount: 0,
+        lineStart: undefined,
+        text: undefined,
+        filePath: undefined,
+      })
+
+      ideClient.emit({
+        selection: {
+          start: { line: 4, character: 3 },
+          end: { line: 6, character: 0 },
+        },
+        text: 'alpha\nbeta',
+        filePath: '/workspace/src/app.ts',
+      })
+
+      expect(onSelect).toHaveBeenLastCalledWith({
+        lineCount: 2,
+        lineStart: 4,
+        text: 'alpha\nbeta',
+        filePath: '/workspace/src/app.ts',
+      })
+
+      ideClient.emit({
+        selection: null,
+        text: '',
+        filePath: '/workspace/src/app.ts',
+      })
+
+      expect(onSelect).toHaveBeenLastCalledWith({
+        lineCount: 0,
+        lineStart: undefined,
+        text: '',
+        filePath: '/workspace/src/app.ts',
+      })
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+})

--- a/runtime/tests/tui/hooks/useInputBuffer.wave200-058.coverage.test.tsx
+++ b/runtime/tests/tui/hooks/useInputBuffer.wave200-058.coverage.test.tsx
@@ -1,0 +1,156 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { createRoot } from '../ink/root.js'
+import {
+  type UseInputBufferResult,
+  useInputBuffer,
+} from './useInputBuffer.js'
+
+type HarnessOptions = {
+  debounceMs: number
+  maxBufferSize: number
+}
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough
+}
+
+function createStreams(): TestStreams {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStreams['stdin']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderHookHarness(
+  options: HarnessOptions,
+): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly latest: () => UseInputBufferResult
+}> {
+  let latest: UseInputBufferResult | undefined
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    latest = useInputBuffer(options)
+    return null
+  }
+
+  root.render(React.createElement(Harness))
+  await sleep()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+  }
+}
+
+async function push(
+  rendered: { readonly latest: () => UseInputBufferResult },
+  text: string,
+  cursorOffset = text.length,
+): Promise<void> {
+  rendered.latest().pushToBuffer(text, cursorOffset)
+  await sleep()
+}
+
+describe('useInputBuffer coverage', () => {
+  test('keeps undo history coherent across capped entries, branch edits, debounced clears, and duplicate pushes', async () => {
+    const capped = await renderHookHarness({
+      debounceMs: 0,
+      maxBufferSize: 2,
+    })
+
+    try {
+      await push(capped, 'one')
+      await push(capped, 'two')
+      await push(capped, 'three')
+
+      expect(capped.latest().undo()).toEqual(
+        expect.objectContaining({
+          cursorOffset: 3,
+          pastedContents: {},
+          text: 'two',
+        }),
+      )
+      await sleep()
+
+      await push(capped, 'branch')
+      expect(capped.latest().undo()).toEqual(
+        expect.objectContaining({
+          text: 'two',
+        }),
+      )
+    } finally {
+      await capped.dispose()
+    }
+
+    const debounced = await renderHookHarness({
+      debounceMs: 50,
+      maxBufferSize: 10,
+    })
+
+    try {
+      debounced.latest().pushToBuffer('settled', 7)
+      debounced.latest().pushToBuffer('pending', 7)
+      debounced.latest().clearBuffer()
+      await sleep(80)
+
+      expect(debounced.latest().canUndo).toBe(false)
+      expect(debounced.latest().undo()).toBeUndefined()
+    } finally {
+      await debounced.dispose()
+    }
+
+    const duplicates = await renderHookHarness({
+      debounceMs: 0,
+      maxBufferSize: 10,
+    })
+
+    try {
+      await push(duplicates, 'alpha')
+      await push(duplicates, 'beta')
+      await push(duplicates, 'beta')
+
+      expect(duplicates.latest().undo()).toEqual(
+        expect.objectContaining({
+          text: 'alpha',
+        }),
+      )
+    } finally {
+      await duplicates.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/hooks/usePasteHandler.test.ts
+++ b/runtime/tests/tui/hooks/usePasteHandler.test.ts
@@ -1,64 +1,472 @@
-import { expect, test } from 'bun:test'
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const imagePasteMocks = vi.hoisted(() => ({
+  getImageFromClipboard: vi.fn(),
+  isImageFilePath: vi.fn(),
+  tryReadImageFromPath: vi.fn(),
+}))
+
+const logMocks = vi.hoisted(() => ({
+  logError: vi.fn(),
+}))
+
+const platformMock = vi.hoisted(() => ({
+  current: 'linux' as 'linux' | 'macos' | 'unknown' | 'windows' | 'wsl',
+}))
+
+vi.mock('../../utils/imagePaste.js', () => ({
+  PASTE_THRESHOLD: 800,
+  getImageFromClipboard: imagePasteMocks.getImageFromClipboard,
+  isImageFilePath: imagePasteMocks.isImageFilePath,
+  tryReadImageFromPath: imagePasteMocks.tryReadImageFromPath,
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: logMocks.logError,
+}))
+
+vi.mock('../../utils/platform.js', () => ({
+  getPlatform: () => platformMock.current,
+}))
+
+import { recordInputBurst, resetBurstDetector } from '../input/burst-detector.js'
+import { createRoot } from '../ink/root.js'
+import type { InputEvent, Key } from '../ink.js'
+import type { ImageDimensions } from '../../utils/imageResizer.js'
 import {
   shouldHandleInputAsPaste,
   supportsClipboardImageFallback,
-} from './usePasteHandler'
+  usePasteHandler,
+} from './usePasteHandler.js'
 
-test('supports clipboard image fallback on Windows', () => {
-  expect(supportsClipboardImageFallback('windows')).toBe(true)
+type PasteHandlerProps = Parameters<typeof usePasteHandler>[0]
+type PasteHandlerState = ReturnType<typeof usePasteHandler>
+
+const BASE_KEY: Key = {
+  backspace: false,
+  ctrl: false,
+  delete: false,
+  downArrow: false,
+  end: false,
+  escape: false,
+  fn: false,
+  home: false,
+  leftArrow: false,
+  meta: false,
+  pageDown: false,
+  pageUp: false,
+  return: false,
+  rightArrow: false,
+  shift: false,
+  super: false,
+  tab: false,
+  upArrow: false,
+  wheelDown: false,
+  wheelUp: false,
+}
+
+function createStreams(): {
+  readonly stdout: PassThrough
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 80
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  return { stdin, stdout }
+}
+
+function defaultIsImageFilePath(text: string): boolean {
+  return /\.(png|jpe?g|gif|webp)$/i.test(
+    text.trim().replace(/^['"]|['"]$/g, ''),
+  )
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>
+  readonly reject: (error: unknown) => void
+  readonly resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    resolve = innerResolve
+    reject = innerReject
+  })
+  return { promise, reject, resolve }
+}
+
+function inputEvent(isPasted: boolean): InputEvent {
+  return {
+    keypress: {
+      isPasted,
+    },
+  } as InputEvent
+}
+
+function key(overrides: Partial<Key> = {}): Key {
+  return { ...BASE_KEY, ...overrides }
+}
+
+async function sleep(ms = 0): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForPasteFlush(): Promise<void> {
+  await sleep(140)
+  await sleep()
+}
+
+async function renderPasteHandler(
+  initialProps: PasteHandlerProps,
+): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly latest: () => PasteHandlerState
+  readonly render: (next?: Partial<PasteHandlerProps>) => Promise<void>
+}> {
+  let props = initialProps
+  let latest: PasteHandlerState | undefined
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    latest = usePasteHandler(props)
+    return null
+  }
+
+  async function render(next: Partial<PasteHandlerProps> = {}): Promise<void> {
+    props = { ...props, ...next }
+    root.render(React.createElement(Harness))
+    await sleep()
+  }
+
+  await render()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+    render,
+  }
+}
+
+beforeEach(() => {
+  platformMock.current = 'linux'
+  imagePasteMocks.getImageFromClipboard.mockReset()
+  imagePasteMocks.getImageFromClipboard.mockResolvedValue(null)
+  imagePasteMocks.isImageFilePath.mockReset()
+  imagePasteMocks.isImageFilePath.mockImplementation(defaultIsImageFilePath)
+  imagePasteMocks.tryReadImageFromPath.mockReset()
+  imagePasteMocks.tryReadImageFromPath.mockResolvedValue(null)
+  logMocks.logError.mockReset()
+  resetBurstDetector()
 })
 
-test('supports clipboard image fallback on macOS', () => {
-  expect(supportsClipboardImageFallback('macos')).toBe(true)
+afterEach(() => {
+  resetBurstDetector()
 })
 
-test('supports clipboard image fallback on Linux', () => {
-  expect(supportsClipboardImageFallback('linux')).toBe(true)
+describe('supportsClipboardImageFallback', () => {
+  test('supports clipboard image fallback on Windows', () => {
+    expect(supportsClipboardImageFallback('windows')).toBe(true)
+  })
+
+  test('supports clipboard image fallback on macOS', () => {
+    expect(supportsClipboardImageFallback('macos')).toBe(true)
+  })
+
+  test('supports clipboard image fallback on Linux', () => {
+    expect(supportsClipboardImageFallback('linux')).toBe(true)
+  })
+
+  test('does not support clipboard image fallback on WSL', () => {
+    expect(supportsClipboardImageFallback('wsl')).toBe(false)
+  })
+
+  test('does not support clipboard image fallback on unknown platforms', () => {
+    expect(supportsClipboardImageFallback('unknown')).toBe(false)
+  })
 })
 
-test('does not support clipboard image fallback on WSL', () => {
-  expect(supportsClipboardImageFallback('wsl')).toBe(false)
+describe('shouldHandleInputAsPaste', () => {
+  test('does not treat a bracketed paste as pending when no paste handlers are provided', () => {
+    expect(
+      shouldHandleInputAsPaste({
+        hasTextPasteHandler: false,
+        hasImagePasteHandler: false,
+        inputLength: 'kimi-k2.5'.length,
+        pastePending: false,
+        hasImageFilePath: false,
+        isFromPaste: true,
+      }),
+    ).toBe(false)
+  })
+
+  test('treats bracketed text paste as pending when a text paste handler exists', () => {
+    expect(
+      shouldHandleInputAsPaste({
+        hasTextPasteHandler: true,
+        hasImagePasteHandler: false,
+        inputLength: 'kimi-k2.5'.length,
+        pastePending: false,
+        hasImageFilePath: false,
+        isFromPaste: true,
+      }),
+    ).toBe(true)
+  })
+
+  test('treats image path paste as pending when only an image handler exists', () => {
+    expect(
+      shouldHandleInputAsPaste({
+        hasTextPasteHandler: false,
+        hasImagePasteHandler: true,
+        inputLength: 'C:\\Users\\jat\\image.png'.length,
+        pastePending: false,
+        hasImageFilePath: true,
+        isFromPaste: false,
+      }),
+    ).toBe(true)
+  })
 })
 
-test('does not support clipboard image fallback on unknown platforms', () => {
-  expect(supportsClipboardImageFallback('unknown')).toBe(false)
-})
+describe('usePasteHandler', () => {
+  test('routes a large plain paste through onPaste without calling onInput', async () => {
+    const pastedText = 'p'.repeat(801)
+    const onInput = vi.fn()
+    const onPaste = vi.fn()
+    const rendered = await renderPasteHandler({ onInput, onPaste })
 
-test('does not treat a bracketed paste as pending when no paste handlers are provided', () => {
-  expect(
-    shouldHandleInputAsPaste({
-      hasTextPasteHandler: false,
-      hasImagePasteHandler: false,
-      inputLength: 'kimi-k2.5'.length,
-      pastePending: false,
-      hasImageFilePath: false,
-      isFromPaste: true,
-    }),
-  ).toBe(false)
-})
+    try {
+      rendered.latest().wrappedOnInput(pastedText, key(), inputEvent(false))
 
-test('treats bracketed text paste as pending when a text paste handler exists', () => {
-  expect(
-    shouldHandleInputAsPaste({
-      hasTextPasteHandler: true,
-      hasImagePasteHandler: false,
-      inputLength: 'kimi-k2.5'.length,
-      pastePending: false,
-      hasImageFilePath: false,
-      isFromPaste: true,
-    }),
-  ).toBe(true)
-})
+      expect(onInput).not.toHaveBeenCalled()
+      expect(onPaste).not.toHaveBeenCalled()
 
-test('treats image path paste as pending when only an image handler exists', () => {
-  expect(
-    shouldHandleInputAsPaste({
-      hasTextPasteHandler: false,
-      hasImagePasteHandler: true,
-      inputLength: 'C:\\Users\\jat\\image.png'.length,
-      pastePending: false,
-      hasImageFilePath: true,
-      isFromPaste: false,
-    }),
-  ).toBe(true)
+      await waitForPasteFlush()
+
+      expect(onPaste).toHaveBeenCalledTimes(1)
+      expect(onPaste).toHaveBeenCalledWith(pastedText)
+      expect(onInput).not.toHaveBeenCalled()
+      expect(rendered.latest().isPasting).toBe(false)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('routes short bracketed paste content through onPaste', async () => {
+    const onInput = vi.fn()
+    const onPaste = vi.fn()
+    const rendered = await renderPasteHandler({ onInput, onPaste })
+
+    try {
+      rendered.latest().wrappedOnInput('short', key(), inputEvent(true))
+
+      await waitForPasteFlush()
+
+      expect(onPaste).toHaveBeenCalledTimes(1)
+      expect(onPaste).toHaveBeenCalledWith('short')
+      expect(onInput).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('preserves callback ordering while a paste continuation is pending', async () => {
+    const calls: string[] = []
+    const onInput = vi.fn(input => calls.push(`input:${input}`))
+    const onPaste = vi.fn(input => calls.push(`paste:${input}`))
+    const rendered = await renderPasteHandler({ onInput, onPaste })
+
+    try {
+      rendered.latest().wrappedOnInput('first', key(), inputEvent(true))
+      rendered.latest().wrappedOnInput('\nsecond', key(), inputEvent(false))
+
+      await waitForPasteFlush()
+
+      expect(onInput).not.toHaveBeenCalled()
+      expect(onPaste).toHaveBeenCalledTimes(1)
+      expect(onPaste).toHaveBeenCalledWith('first\nsecond')
+      expect(calls).toEqual(['paste:first\nsecond'])
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('preserves image paste metadata from pasted file paths', async () => {
+    const imagePath = '/tmp/agenc-screenshot.png'
+    const dimensions: ImageDimensions = {
+      displayHeight: 360,
+      displayWidth: 640,
+      originalHeight: 720,
+      originalWidth: 1280,
+    }
+    imagePasteMocks.tryReadImageFromPath.mockResolvedValue({
+      base64: 'image-data',
+      dimensions,
+      mediaType: 'image/png',
+      path: imagePath,
+    })
+    const onImagePaste = vi.fn()
+    const onInput = vi.fn()
+    const onPaste = vi.fn()
+    const rendered = await renderPasteHandler({
+      onImagePaste,
+      onInput,
+      onPaste,
+    })
+
+    try {
+      rendered.latest().wrappedOnInput(imagePath, key(), inputEvent(false))
+
+      await waitForPasteFlush()
+
+      expect(imagePasteMocks.tryReadImageFromPath).toHaveBeenCalledWith(imagePath)
+      expect(onImagePaste).toHaveBeenCalledTimes(1)
+      expect(onImagePaste).toHaveBeenCalledWith(
+        'image-data',
+        'image/png',
+        'agenc-screenshot.png',
+        dimensions,
+        imagePath,
+      )
+      expect(onPaste).not.toHaveBeenCalled()
+      expect(onInput).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('ignores empty bracketed paste when clipboard image lookup misses', async () => {
+    platformMock.current = 'macos'
+    imagePasteMocks.getImageFromClipboard.mockResolvedValue(null)
+    const onImagePaste = vi.fn()
+    const onInput = vi.fn()
+    const onPaste = vi.fn()
+    const rendered = await renderPasteHandler({
+      onImagePaste,
+      onInput,
+      onPaste,
+    })
+
+    try {
+      rendered.latest().wrappedOnInput('', key(), inputEvent(true))
+
+      await sleep(90)
+
+      expect(imagePasteMocks.getImageFromClipboard).toHaveBeenCalledTimes(1)
+      expect(onImagePaste).not.toHaveBeenCalled()
+      expect(onPaste).not.toHaveBeenCalled()
+      expect(onInput).not.toHaveBeenCalled()
+      expect(rendered.latest().isPasting).toBe(false)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('logs rejected clipboard image lookup without routing paste callbacks', async () => {
+    platformMock.current = 'macos'
+    const error = new Error('clipboard unavailable')
+    imagePasteMocks.getImageFromClipboard.mockRejectedValue(error)
+    const onImagePaste = vi.fn()
+    const onInput = vi.fn()
+    const onPaste = vi.fn()
+    const rendered = await renderPasteHandler({
+      onImagePaste,
+      onInput,
+      onPaste,
+    })
+
+    try {
+      rendered.latest().wrappedOnInput('', key(), inputEvent(true))
+
+      await sleep(90)
+
+      expect(logMocks.logError).toHaveBeenCalledWith(error)
+      expect(onImagePaste).not.toHaveBeenCalled()
+      expect(onPaste).not.toHaveBeenCalled()
+      expect(onInput).not.toHaveBeenCalled()
+      expect(rendered.latest().isPasting).toBe(false)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('does not call image paste after clipboard lookup resolves post-cleanup', async () => {
+    platformMock.current = 'macos'
+    const pendingClipboard = deferred<{
+      base64: string
+      dimensions: ImageDimensions
+      mediaType: string
+    } | null>()
+    imagePasteMocks.getImageFromClipboard.mockReturnValue(pendingClipboard.promise)
+    const onImagePaste = vi.fn()
+    const rendered = await renderPasteHandler({
+      onImagePaste,
+      onInput: vi.fn(),
+    })
+
+    rendered.latest().wrappedOnInput('', key(), inputEvent(true))
+    await vi.waitFor(() => {
+      expect(imagePasteMocks.getImageFromClipboard).toHaveBeenCalledTimes(1)
+    })
+
+    await rendered.dispose()
+    pendingClipboard.resolve({
+      base64: 'late-image',
+      dimensions: { displayHeight: 2, displayWidth: 1 },
+      mediaType: 'image/png',
+    })
+    await sleep()
+
+    expect(onImagePaste).not.toHaveBeenCalled()
+  })
+
+  test('exposes suspected raw paste as a one-shot confirmation flag', async () => {
+    const rendered = await renderPasteHandler({ onInput: vi.fn() })
+
+    try {
+      expect(rendered.latest().isSuspectedPaste()).toBe(false)
+
+      recordInputBurst(60, false)
+
+      expect(rendered.latest().isSuspectedPaste()).toBe(true)
+      expect(rendered.latest().consumeSuspectedPaste()).toBe(true)
+      expect(rendered.latest().isSuspectedPaste()).toBe(false)
+      expect(rendered.latest().consumeSuspectedPaste()).toBe(false)
+
+      recordInputBurst(60, true)
+
+      expect(rendered.latest().isSuspectedPaste()).toBe(false)
+    } finally {
+      await rendered.dispose()
+    }
+  })
 })

--- a/runtime/tests/tui/hooks/usePrStatus.wave200-052.coverage.test.tsx
+++ b/runtime/tests/tui/hooks/usePrStatus.wave200-052.coverage.test.tsx
@@ -1,0 +1,178 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import Text from '../ink/components/Text.js'
+import { createRoot } from '../ink/root.js'
+import { usePrStatus, type PrStatusState } from './usePrStatus.js'
+
+const harness = vi.hoisted(() => ({
+  fetchPrStatus: vi.fn(),
+  interactionTime: 1,
+}))
+const realSetImmediate = setImmediate
+
+vi.mock('../../bootstrap/state.js', () => ({
+  flushInteractionTime: vi.fn(),
+  getActiveTimeCounter: () => 0,
+  getLastInteractionTime: () => harness.interactionTime,
+  markScrollActivity: vi.fn(),
+  updateLastInteractionTime: vi.fn(),
+}))
+
+vi.mock('../../utils/ghPrStatus', () => ({
+  fetchPrStatus: harness.fetchPrStatus,
+}))
+
+type TestStreams = {
+  stdout: PassThrough & {
+    columns: number
+    isTTY: boolean
+    rows: number
+    write: ReturnType<typeof vi.fn>
+  }
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+}
+
+function createTestStreams(): TestStreams {
+  const stdout = new PassThrough() as TestStreams['stdout']
+  const stdin = new PassThrough() as TestStreams['stdin']
+
+  stdout.columns = 120
+  stdout.rows = 30
+  stdout.isTTY = false
+  stdout.write = vi.fn(() => true)
+  stdout.resume()
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  return { stdout, stdin }
+}
+
+async function flushEffects(): Promise<void> {
+  await Promise.resolve()
+  await vi.advanceTimersByTimeAsync(16)
+  await new Promise(resolve => realSetImmediate(resolve))
+  await Promise.resolve()
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  label: string,
+): Promise<void> {
+  for (let attempts = 0; attempts < 20; attempts += 1) {
+    await flushEffects()
+    if (predicate()) return
+  }
+
+  throw new Error(`Timed out waiting for ${label}`)
+}
+
+function Harness({
+  enabled,
+  isLoading,
+  snapshots,
+}: {
+  enabled: boolean
+  isLoading: boolean
+  snapshots: PrStatusState[]
+}): React.ReactNode {
+  const prStatus = usePrStatus(isLoading, enabled)
+
+  React.useEffect(() => {
+    snapshots.push(prStatus)
+  }, [prStatus, snapshots])
+
+  return <Text>{prStatus.reviewState ?? 'none'}</Text>
+}
+
+describe('usePrStatus coverage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(120_000)
+    harness.fetchPrStatus.mockReset()
+    harness.interactionTime = 1
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  test('reschedules from the last fetch time and disables future polling after a slow unchanged result', async () => {
+    const pr = {
+      number: 52,
+      reviewState: 'pending',
+      url: 'https://example.test/pull/52',
+    }
+    const snapshots: PrStatusState[] = []
+    const streams = createTestStreams()
+    const root = await createRoot({
+      stdin: streams.stdin as unknown as NodeJS.ReadStream,
+      stdout: streams.stdout as unknown as NodeJS.WriteStream,
+      patchConsole: false,
+    })
+
+    harness.fetchPrStatus.mockImplementation(async () => {
+      if (harness.fetchPrStatus.mock.calls.length === 2) {
+        vi.setSystemTime(Date.now() + 4_001)
+      }
+
+      return pr
+    })
+
+    try {
+      root.render(
+        <Harness enabled={true} isLoading={false} snapshots={snapshots} />,
+      )
+
+      await waitForCondition(
+        () => snapshots.some(snapshot => snapshot.number === 52),
+        'initial PR status',
+      )
+
+      expect(harness.fetchPrStatus).toHaveBeenCalledTimes(1)
+      const firstUpdated = snapshots.find(
+        snapshot => snapshot.number === 52,
+      )?.lastUpdated
+      expect(firstUpdated).toBeGreaterThanOrEqual(120_000)
+
+      root.render(
+        <Harness enabled={true} isLoading={true} snapshots={snapshots} />,
+      )
+      await flushEffects()
+      await vi.advanceTimersByTimeAsync(59_000)
+      expect(harness.fetchPrStatus).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(1_000)
+      await waitForCondition(
+        () => harness.fetchPrStatus.mock.calls.length === 2,
+        'second PR status poll',
+      )
+
+      expect(snapshots.at(-1)?.lastUpdated).toBe(firstUpdated)
+
+      root.render(
+        <Harness enabled={true} isLoading={false} snapshots={snapshots} />,
+      )
+      await flushEffects()
+      await vi.advanceTimersByTimeAsync(60_000)
+      await flushEffects()
+
+      expect(harness.fetchPrStatus).toHaveBeenCalledTimes(2)
+    } finally {
+      root.unmount()
+      streams.stdin.end()
+      streams.stdout.end()
+    }
+  })
+})

--- a/runtime/tests/tui/hooks/useSearchInput.coverage2.test.ts
+++ b/runtime/tests/tui/hooks/useSearchInput.coverage2.test.ts
@@ -1,0 +1,193 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import Text from '../ink/components/Text.js'
+import { createRoot } from '../ink/root.js'
+import { clearKillRing } from '../../utils/TextCursor.js'
+import type { KeyboardEvent } from './events/keyboard-event.js'
+import { useSearchInput } from './useSearchInput.js'
+
+vi.mock('../../utils/debug.js', () => ({
+  logForDebugging: () => {},
+}))
+vi.mock('../../bootstrap/state.js', () => ({
+  flushInteractionTime: () => {},
+  getActiveTimeCounter: () => 0,
+  markScrollActivity: () => {},
+  updateLastInteractionTime: () => {},
+}))
+vi.mock('../../utils/earlyInput.js', () => ({
+  stopCapturingEarlyInput: () => {},
+}))
+vi.mock('../../utils/envUtils.js', () => ({
+  isEnvTruthy: () => false,
+}))
+vi.mock('../../utils/fullscreen.js', () => ({
+  isMouseClicksDisabled: () => true,
+}))
+vi.mock('../../utils/log.js', () => ({
+  logError: () => {},
+}))
+
+type SearchInputState = ReturnType<typeof useSearchInput>
+
+type Snapshot = {
+  query: string
+  cursorOffset: number
+}
+
+type TestStreams = {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+}
+
+function createTestStreams(): TestStreams {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStreams['stdin']
+
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+
+  return { stdout, stdin }
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+  throw new Error('Timed out waiting for search input state')
+}
+
+function expectSnapshot(
+  snapshots: Snapshot[],
+  expected: Partial<Snapshot>,
+): Promise<void> {
+  return waitForCondition(() =>
+    snapshots.some(snapshot =>
+      Object.entries(expected).every(
+        ([key, value]) => snapshot[key as keyof Snapshot] === value,
+      ),
+    ),
+  )
+}
+
+function keyboard(
+  key: string,
+  modifiers: Partial<Pick<KeyboardEvent, 'ctrl' | 'meta' | 'fn'>> = {},
+): KeyboardEvent & { preventDefault: ReturnType<typeof vi.fn> } {
+  return {
+    key,
+    ctrl: modifiers.ctrl ?? false,
+    meta: modifiers.meta ?? false,
+    fn: modifiers.fn ?? false,
+    preventDefault: vi.fn(),
+  } as never
+}
+
+function Harness({
+  controlsRef,
+  snapshots,
+  initialQuery,
+}: {
+  controlsRef: { current: SearchInputState | null }
+  snapshots: Snapshot[]
+  initialQuery: string
+}): React.ReactNode {
+  const state = useSearchInput({
+    isActive: true,
+    onExit: () => {},
+    initialQuery,
+    columns: 80,
+  })
+
+  controlsRef.current = state
+
+  React.useEffect(() => {
+    snapshots.push({
+      query: state.query,
+      cursorOffset: state.cursorOffset,
+    })
+  }, [snapshots, state])
+
+  return React.createElement(Text, null, state.query)
+}
+
+describe('useSearchInput coverage', () => {
+  beforeEach(() => {
+    clearKillRing()
+  })
+
+  afterEach(() => {
+    clearKillRing()
+  })
+
+  test('yank-pop replaces the latest yanked kill-ring entry with the previous one', async () => {
+    const snapshots: Snapshot[] = []
+    const controlsRef = { current: null as SearchInputState | null }
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    })
+
+    try {
+      root.render(
+        React.createElement(Harness, {
+          controlsRef,
+          snapshots,
+          initialQuery: 'alpha beta gamma',
+        }),
+      )
+      await expectSnapshot(snapshots, {
+        query: 'alpha beta gamma',
+        cursorOffset: 'alpha beta gamma'.length,
+      })
+
+      controlsRef.current?.handleKeyDown(keyboard('u', { ctrl: true }))
+      await expectSnapshot(snapshots, { query: '', cursorOffset: 0 })
+
+      controlsRef.current?.handleKeyDown(keyboard('delta epsilon'))
+      await expectSnapshot(snapshots, {
+        query: 'delta epsilon',
+        cursorOffset: 'delta epsilon'.length,
+      })
+
+      controlsRef.current?.handleKeyDown(keyboard('backspace', { meta: true }))
+      await expectSnapshot(snapshots, {
+        query: 'delta ',
+        cursorOffset: 'delta '.length,
+      })
+
+      controlsRef.current?.handleKeyDown(keyboard('y', { ctrl: true }))
+      await expectSnapshot(snapshots, {
+        query: 'delta epsilon',
+        cursorOffset: 'delta epsilon'.length,
+      })
+
+      controlsRef.current?.handleKeyDown(keyboard('y', { meta: true }))
+      await expectSnapshot(snapshots, {
+        query: 'delta alpha beta gamma',
+        cursorOffset: 'delta alpha beta gamma'.length,
+      })
+    } finally {
+      root.unmount()
+      stdin.end()
+    }
+  })
+})

--- a/runtime/tests/tui/hooks/useSearchInput.wave200-048.coverage.test.tsx
+++ b/runtime/tests/tui/hooks/useSearchInput.wave200-048.coverage.test.tsx
@@ -1,0 +1,275 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import Text from '../ink/components/Text.js'
+import { createRoot } from '../ink/root.js'
+import { clearKillRing } from '../../utils/TextCursor.js'
+import { useSearchInput } from './useSearchInput.js'
+
+vi.mock('../../utils/debug.js', () => ({
+  logForDebugging: () => {},
+}))
+vi.mock('../../bootstrap/state.js', () => ({
+  flushInteractionTime: () => {},
+  getActiveTimeCounter: () => 0,
+  markScrollActivity: () => {},
+  updateLastInteractionTime: () => {},
+}))
+vi.mock('../../utils/earlyInput.js', () => ({
+  stopCapturingEarlyInput: () => {},
+}))
+vi.mock('../../utils/envUtils.js', () => ({
+  isEnvTruthy: () => false,
+}))
+vi.mock('../../utils/fullscreen.js', () => ({
+  isMouseClicksDisabled: () => true,
+}))
+vi.mock('../../utils/log.js', () => ({
+  logError: () => {},
+}))
+
+type SearchInputState = ReturnType<typeof useSearchInput>
+type SearchInputKey = Parameters<SearchInputState['handleKeyDown']>[0]
+
+type Snapshot = {
+  query: string
+  cursorOffset: number
+}
+
+type TestStreams = {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+}
+
+function createTestStreams(): TestStreams {
+  const stdout = new PassThrough()
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 120
+
+  const stdin = new PassThrough() as TestStreams['stdin']
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  return { stdin, stdout }
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+  throw new Error('Timed out waiting for search input state')
+}
+
+function expectSnapshot(
+  snapshots: Snapshot[],
+  expected: Partial<Snapshot>,
+): Promise<void> {
+  return waitForCondition(() =>
+    Object.entries(expected).every(
+      ([key, value]) => latestSnapshot(snapshots)[key as keyof Snapshot] === value,
+    ),
+  )
+}
+
+function latestSnapshot(snapshots: Snapshot[]): Snapshot {
+  const snapshot = snapshots.at(-1)
+  if (snapshot === undefined) throw new Error('No search input snapshot')
+  return snapshot
+}
+
+function keyboard(
+  key: string,
+  modifiers: Partial<Pick<SearchInputKey, 'ctrl' | 'meta' | 'fn'>> = {},
+): SearchInputKey & { preventDefault: ReturnType<typeof vi.fn> } {
+  return {
+    key,
+    ctrl: modifiers.ctrl ?? false,
+    meta: modifiers.meta ?? false,
+    fn: modifiers.fn ?? false,
+    preventDefault: vi.fn(),
+  } as SearchInputKey & { preventDefault: ReturnType<typeof vi.fn> }
+}
+
+function Harness({
+  backspaceExitsOnEmpty = true,
+  controlsRef,
+  initialQuery = '',
+  onCancel,
+  onExit,
+  snapshots,
+}: {
+  backspaceExitsOnEmpty?: boolean
+  controlsRef: { current: SearchInputState | null }
+  initialQuery?: string
+  onCancel?: () => void
+  onExit: () => void
+  snapshots: Snapshot[]
+}): React.ReactNode {
+  const state = useSearchInput({
+    backspaceExitsOnEmpty,
+    columns: 80,
+    initialQuery,
+    isActive: true,
+    onCancel,
+    onExit,
+  })
+
+  controlsRef.current = state
+
+  React.useEffect(() => {
+    snapshots.push({
+      cursorOffset: state.cursorOffset,
+      query: state.query,
+    })
+  }, [snapshots, state])
+
+  return <Text>{state.query}</Text>
+}
+
+describe('useSearchInput wave200 coverage', () => {
+  beforeEach(() => {
+    clearKillRing()
+  })
+
+  afterEach(() => {
+    clearKillRing()
+  })
+
+  test('handles shortcut edge cases without inserting ignored keys', async () => {
+    const snapshots: Snapshot[] = []
+    const controlsRef = { current: null as SearchInputState | null }
+    const onCancel = vi.fn()
+    const onExit = vi.fn()
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    })
+
+    try {
+      root.render(
+        <Harness
+          controlsRef={controlsRef}
+          initialQuery="alpha beta"
+          onCancel={onCancel}
+          onExit={onExit}
+          snapshots={snapshots}
+        />,
+      )
+      await expectSnapshot(snapshots, {
+        cursorOffset: 'alpha beta'.length,
+        query: 'alpha beta',
+      })
+
+      controlsRef.current?.setQuery('left right')
+      await expectSnapshot(snapshots, {
+        cursorOffset: 'left right'.length,
+        query: 'left right',
+      })
+
+      controlsRef.current?.handleKeyDown(keyboard('left', { ctrl: true }))
+      await expectSnapshot(snapshots, { cursorOffset: 'left '.length })
+
+      controlsRef.current?.handleKeyDown(keyboard('right', { fn: true }))
+      await expectSnapshot(snapshots, { cursorOffset: 'left right'.length })
+
+      controlsRef.current?.handleKeyDown(keyboard('left'))
+      await expectSnapshot(snapshots, { cursorOffset: 'left righ'.length })
+
+      controlsRef.current?.handleKeyDown(keyboard('d', { ctrl: true }))
+      await expectSnapshot(snapshots, {
+        cursorOffset: 'left righ'.length,
+        query: 'left righ',
+      })
+
+      controlsRef.current?.handleKeyDown(keyboard('h', { ctrl: true }))
+      await expectSnapshot(snapshots, {
+        cursorOffset: 'left rig'.length,
+        query: 'left rig',
+      })
+
+      controlsRef.current?.handleKeyDown(keyboard('e', { ctrl: true }))
+      await expectSnapshot(snapshots, { cursorOffset: 'left rig'.length })
+
+      controlsRef.current?.handleKeyDown(keyboard('b', { ctrl: true }))
+      await expectSnapshot(snapshots, { cursorOffset: 'left ri'.length })
+
+      controlsRef.current?.handleKeyDown(keyboard('f', { ctrl: true }))
+      await expectSnapshot(snapshots, { cursorOffset: 'left rig'.length })
+
+      controlsRef.current?.handleKeyDown(keyboard('b', { meta: true }))
+      await expectSnapshot(snapshots, { cursorOffset: 'left '.length })
+
+      controlsRef.current?.handleKeyDown(keyboard('k', { ctrl: true }))
+      await expectSnapshot(snapshots, {
+        cursorOffset: 'left '.length,
+        query: 'left ',
+      })
+
+      controlsRef.current?.handleKeyDown(keyboard('y', { ctrl: true }))
+      await expectSnapshot(snapshots, {
+        cursorOffset: 'left rig'.length,
+        query: 'left rig',
+      })
+
+      controlsRef.current?.handleKeyDown(keyboard('g', { ctrl: true }))
+      expect(onCancel).toHaveBeenCalledTimes(1)
+
+      const unknownMeta = keyboard('z', { meta: true })
+      controlsRef.current?.handleKeyDown(unknownMeta)
+      expect(unknownMeta.preventDefault).toHaveBeenCalledTimes(1)
+
+      const tab = keyboard('tab')
+      controlsRef.current?.handleKeyDown(tab)
+      expect(tab.preventDefault).not.toHaveBeenCalled()
+
+      const pageUp = keyboard('pageup')
+      controlsRef.current?.handleKeyDown(pageUp)
+      expect(pageUp.preventDefault).not.toHaveBeenCalled()
+      expect(latestSnapshot(snapshots)).toMatchObject({
+        cursorOffset: 'left rig'.length,
+        query: 'left rig',
+      })
+
+      controlsRef.current?.setQuery('')
+      await expectSnapshot(snapshots, { cursorOffset: 0, query: '' })
+
+      controlsRef.current?.handleKeyDown(keyboard('d', { ctrl: true }))
+      expect(onCancel).toHaveBeenCalledTimes(2)
+
+      root.render(
+        <Harness
+          backspaceExitsOnEmpty={false}
+          controlsRef={controlsRef}
+          onCancel={onCancel}
+          onExit={onExit}
+          snapshots={snapshots}
+        />,
+      )
+      await expectSnapshot(snapshots, { cursorOffset: 0, query: '' })
+
+      controlsRef.current?.handleKeyDown(keyboard('backspace'))
+      expect(onCancel).toHaveBeenCalledTimes(2)
+      expect(onExit).not.toHaveBeenCalled()
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+  })
+})

--- a/runtime/tests/tui/hooks/useSwarmPermissionPoller.wave200-076.coverage.test.ts
+++ b/runtime/tests/tui/hooks/useSwarmPermissionPoller.wave200-076.coverage.test.ts
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  logForDebugging: vi.fn(),
+}))
+
+vi.mock('src/utils/debug.js', () => ({
+  logForDebugging: harness.logForDebugging,
+}))
+
+import {
+  clearAllPendingCallbacks,
+  hasPermissionCallback,
+  hasSandboxPermissionCallback,
+  processMailboxPermissionResponse,
+  processSandboxPermissionResponse,
+  registerPermissionCallback,
+  registerSandboxPermissionCallback,
+  unregisterPermissionCallback,
+} from './useSwarmPermissionPoller.js'
+
+describe('useSwarmPermissionPoller callback registries', () => {
+  beforeEach(() => {
+    clearAllPendingCallbacks()
+    harness.logForDebugging.mockClear()
+  })
+
+  test('routes mailbox and sandbox responses through registered callbacks', () => {
+    const validPermissionUpdate = {
+      type: 'addDirectories',
+      directories: ['/repo/src'],
+      destination: 'session',
+    }
+    const malformedPermissionUpdate = {
+      type: 'addDirectories',
+      directories: [42],
+      destination: 'session',
+    }
+
+    expect(
+      processMailboxPermissionResponse({
+        requestId: 'missing',
+        decision: 'approved',
+      }),
+    ).toBe(false)
+    expect(harness.logForDebugging).toHaveBeenCalledWith(
+      '[SwarmPermissionPoller] No callback registered for mailbox response missing',
+    )
+
+    const onAllow = vi.fn()
+    const onReject = vi.fn()
+    registerPermissionCallback({
+      requestId: 'approve-request',
+      toolUseId: 'tool-use-1',
+      onAllow,
+      onReject,
+    })
+
+    expect(hasPermissionCallback('approve-request')).toBe(true)
+    expect(
+      processMailboxPermissionResponse({
+        requestId: 'approve-request',
+        decision: 'approved',
+        updatedInput: { command: 'npm test' },
+        permissionUpdates: [
+          validPermissionUpdate,
+          malformedPermissionUpdate,
+        ],
+      }),
+    ).toBe(true)
+    expect(hasPermissionCallback('approve-request')).toBe(false)
+    expect(onAllow).toHaveBeenCalledWith(
+      { command: 'npm test' },
+      [validPermissionUpdate],
+    )
+    expect(onReject).not.toHaveBeenCalled()
+    expect(harness.logForDebugging).toHaveBeenCalledWith(
+      expect.stringContaining('Dropping malformed permissionUpdate entry:'),
+      { level: 'warn' },
+    )
+    expect(
+      processMailboxPermissionResponse({
+        requestId: 'approve-request',
+        decision: 'approved',
+      }),
+    ).toBe(false)
+
+    const unregisteredAllow = vi.fn()
+    registerPermissionCallback({
+      requestId: 'unregistered-request',
+      toolUseId: 'tool-use-2',
+      onAllow: unregisteredAllow,
+      onReject: vi.fn(),
+    })
+    unregisterPermissionCallback('unregistered-request')
+    expect(hasPermissionCallback('unregistered-request')).toBe(false)
+    expect(
+      processMailboxPermissionResponse({
+        requestId: 'unregistered-request',
+        decision: 'approved',
+      }),
+    ).toBe(false)
+    expect(unregisteredAllow).not.toHaveBeenCalled()
+
+    const rejectedAllow = vi.fn()
+    const rejectedReject = vi.fn()
+    registerPermissionCallback({
+      requestId: 'reject-request',
+      toolUseId: 'tool-use-3',
+      onAllow: rejectedAllow,
+      onReject: rejectedReject,
+    })
+
+    expect(
+      processMailboxPermissionResponse({
+        requestId: 'reject-request',
+        decision: 'rejected',
+        feedback: 'needs narrower access',
+      }),
+    ).toBe(true)
+    expect(rejectedAllow).not.toHaveBeenCalled()
+    expect(rejectedReject).toHaveBeenCalledWith('needs narrower access')
+    expect(hasPermissionCallback('reject-request')).toBe(false)
+
+    const emptyUpdatesAllow = vi.fn()
+    registerPermissionCallback({
+      requestId: 'empty-updates-request',
+      toolUseId: 'tool-use-4',
+      onAllow: emptyUpdatesAllow,
+      onReject: vi.fn(),
+    })
+    expect(
+      processMailboxPermissionResponse({
+        requestId: 'empty-updates-request',
+        decision: 'approved',
+        permissionUpdates: 'not-an-array',
+      }),
+    ).toBe(true)
+    expect(emptyUpdatesAllow).toHaveBeenCalledWith(undefined, [])
+
+    expect(
+      processSandboxPermissionResponse({
+        requestId: 'missing-sandbox',
+        host: 'example.test',
+        allow: true,
+      }),
+    ).toBe(false)
+
+    const resolveSandbox = vi.fn()
+    registerSandboxPermissionCallback({
+      requestId: 'sandbox-request',
+      host: 'example.test',
+      resolve: resolveSandbox,
+    })
+    expect(hasSandboxPermissionCallback('sandbox-request')).toBe(true)
+    expect(
+      processSandboxPermissionResponse({
+        requestId: 'sandbox-request',
+        host: 'example.test',
+        allow: false,
+      }),
+    ).toBe(true)
+    expect(resolveSandbox).toHaveBeenCalledWith(false)
+    expect(hasSandboxPermissionCallback('sandbox-request')).toBe(false)
+    expect(
+      processSandboxPermissionResponse({
+        requestId: 'sandbox-request',
+        host: 'example.test',
+        allow: true,
+      }),
+    ).toBe(false)
+
+    registerPermissionCallback({
+      requestId: 'clear-permission',
+      toolUseId: 'tool-use-5',
+      onAllow: vi.fn(),
+      onReject: vi.fn(),
+    })
+    registerSandboxPermissionCallback({
+      requestId: 'clear-sandbox',
+      host: 'example.test',
+      resolve: vi.fn(),
+    })
+    clearAllPendingCallbacks()
+    expect(hasPermissionCallback('clear-permission')).toBe(false)
+    expect(hasSandboxPermissionCallback('clear-sandbox')).toBe(false)
+  })
+})

--- a/runtime/tests/tui/hooks/useTasksV2.test.tsx
+++ b/runtime/tests/tui/hooks/useTasksV2.test.tsx
@@ -1,0 +1,469 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { Task } from '../../utils/tasks.js'
+
+type AppStateFixture = {
+  expandedView: 'none' | 'tasks' | 'teammates'
+  teamContext?: { leadAgentId: string; teamName: string }
+}
+
+type ManualTimer = {
+  active: boolean
+  callback: () => void
+  delay: number
+  unref: ReturnType<typeof vi.fn>
+}
+
+type SubscriptionRecord = {
+  getSnapshot: () => unknown
+  snapshots: unknown[]
+  unsubscribe: () => void
+}
+
+type WatcherRecord = {
+  close: ReturnType<typeof vi.fn>
+  dir: string
+  listener: () => void
+  unref: ReturnType<typeof vi.fn>
+}
+
+const fixture = vi.hoisted(() => {
+  const state = {
+    appState: {
+      expandedView: 'none',
+      teamContext: undefined,
+    } as AppStateFixture,
+    enabled: true,
+    isLead: true,
+    subscriptions: [] as SubscriptionRecord[],
+    taskListId: 'list-a',
+    taskListeners: new Set<() => void>(),
+    tasksByList: new Map<string, Task[]>(),
+    watchThrows: false,
+    watchers: [] as WatcherRecord[],
+  }
+
+  const listTasks = vi.fn(async (taskListId: string) => {
+    return state.tasksByList.get(taskListId) ?? []
+  })
+
+  const onTasksUpdated = vi.fn((listener: () => void) => {
+    state.taskListeners.add(listener)
+    return vi.fn(() => {
+      state.taskListeners.delete(listener)
+    })
+  })
+
+  const resetTaskList = vi.fn(async (taskListId: string) => {
+    state.tasksByList.set(taskListId, [])
+  })
+
+  const setAppState = vi.fn(
+    (
+      updater:
+        | AppStateFixture
+        | ((previous: AppStateFixture) => AppStateFixture),
+    ) => {
+      state.appState =
+        typeof updater === 'function' ? updater(state.appState) : updater
+    },
+  )
+
+  const useSyncExternalStore = vi.fn(
+    (subscribe: (listener: () => void) => () => void, getSnapshot: () => unknown) => {
+      const record: SubscriptionRecord = {
+        getSnapshot,
+        snapshots: [],
+        unsubscribe: () => {},
+      }
+      record.unsubscribe = subscribe(() => {
+        record.snapshots.push(getSnapshot())
+      })
+      record.snapshots.push(getSnapshot())
+      state.subscriptions.push(record)
+      return record.snapshots.at(-1)
+    },
+  )
+
+  const watch = vi.fn((dir: string, listener: () => void) => {
+    if (state.watchThrows) {
+      throw new Error('watch unavailable')
+    }
+    const watcher: WatcherRecord = {
+      close: vi.fn(),
+      dir,
+      listener,
+      unref: vi.fn(),
+    }
+    state.watchers.push(watcher)
+    return watcher
+  })
+
+  function reset(): void {
+    state.appState = {
+      expandedView: 'none',
+      teamContext: undefined,
+    }
+    state.enabled = true
+    state.isLead = true
+    state.subscriptions = []
+    state.taskListId = 'list-a'
+    state.taskListeners.clear()
+    state.tasksByList = new Map([['list-a', []]])
+    state.watchThrows = false
+    state.watchers = []
+
+    listTasks.mockClear()
+    onTasksUpdated.mockClear()
+    resetTaskList.mockClear()
+    setAppState.mockClear()
+    useSyncExternalStore.mockClear()
+    watch.mockClear()
+  }
+
+  return {
+    listTasks,
+    onTasksUpdated,
+    reset,
+    resetTaskList,
+    setAppState,
+    state,
+    useSyncExternalStore,
+    watch,
+  }
+})
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react')
+  return {
+    ...actual,
+    useEffect: (effect: () => void | (() => void)) => effect(),
+    useSyncExternalStore: fixture.useSyncExternalStore,
+  }
+})
+
+vi.mock('fs', () => ({
+  watch: fixture.watch,
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppState: (selector: (state: AppStateFixture) => unknown) =>
+    selector(fixture.state.appState),
+  useSetAppState: () => fixture.setAppState,
+}))
+
+vi.mock('../../utils/tasks.js', () => ({
+  getTaskListId: () => fixture.state.taskListId,
+  getTasksDir: (taskListId: string) => `/tasks/${taskListId}`,
+  isTodoV2Enabled: () => fixture.state.enabled,
+  listTasks: fixture.listTasks,
+  onTasksUpdated: fixture.onTasksUpdated,
+  resetTaskList: fixture.resetTaskList,
+}))
+
+vi.mock('../../utils/teammate.js', () => ({
+  isTeamLead: () => fixture.state.isLead,
+}))
+
+let timers: ManualTimer[] = []
+
+function installTimerMocks(): void {
+  vi.spyOn(globalThis, 'setTimeout').mockImplementation(
+    (handler: TimerHandler, delay?: number, ...args: unknown[]) => {
+      const timer: ManualTimer = {
+        active: true,
+        callback: () => {
+          if (typeof handler !== 'function') {
+            throw new TypeError('string timers are not supported in this test')
+          }
+          handler(...args)
+        },
+        delay: delay ?? 0,
+        unref: vi.fn(),
+      }
+      timers.push(timer)
+      return timer as unknown as ReturnType<typeof setTimeout>
+    },
+  )
+  vi.spyOn(globalThis, 'clearTimeout').mockImplementation(
+    (timer: Parameters<typeof clearTimeout>[0]) => {
+      if (timer && typeof timer === 'object' && 'active' in timer) {
+        ;(timer as unknown as ManualTimer).active = false
+      }
+    },
+  )
+}
+
+function task(
+  id: string,
+  status: Task['status'],
+  overrides: Partial<Task> = {},
+): Task {
+  return {
+    activeForm: `${status} ${id}`,
+    blockedBy: [],
+    blocks: [],
+    description: `Task ${id}`,
+    id,
+    subject: `Task ${id}`,
+    status,
+    ...overrides,
+  }
+}
+
+function activeTimers(delay?: number): ManualTimer[] {
+  return timers.filter(
+    timer => timer.active && (delay === undefined || timer.delay === delay),
+  )
+}
+
+async function flushPromises(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve()
+  }
+}
+
+async function fireNextTimer(delay?: number): Promise<ManualTimer> {
+  const timer = activeTimers(delay)[0]
+  expect(timer).toBeDefined()
+  timer.active = false
+  timer.callback()
+  await flushPromises()
+  return timer
+}
+
+async function emitTasksUpdated(): Promise<void> {
+  for (const listener of [...fixture.state.taskListeners]) {
+    listener()
+  }
+  await fireNextTimer(50)
+}
+
+function latestTasks(record: SubscriptionRecord): Task[] | undefined {
+  return record.snapshots.at(-1) as Task[] | undefined
+}
+
+async function mountUseTasksV2(): Promise<{
+  dispose: () => void
+  initial: Task[] | undefined
+  record: SubscriptionRecord
+}> {
+  const { useTasksV2 } = await import('./useTasksV2.js')
+  const initial = useTasksV2()
+  const record = fixture.state.subscriptions.at(-1)
+  if (!record) {
+    throw new Error('useTasksV2 did not subscribe')
+  }
+  return {
+    dispose: record.unsubscribe,
+    initial,
+    record,
+  }
+}
+
+describe('useTasksV2', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    fixture.reset()
+    timers = []
+    installTimerMocks()
+  })
+
+  afterEach(() => {
+    for (const subscription of fixture.state.subscriptions) {
+      subscription.unsubscribe()
+    }
+    vi.restoreAllMocks()
+  })
+
+  test('returns hidden initial state without starting the store when disabled', async () => {
+    fixture.state.enabled = false
+    fixture.state.tasksByList.set('list-a', [task('1', 'pending')])
+
+    const mounted = await mountUseTasksV2()
+    await flushPromises()
+
+    expect(mounted.initial).toBeUndefined()
+    expect(latestTasks(mounted.record)).toBeUndefined()
+    expect(fixture.listTasks).not.toHaveBeenCalled()
+    expect(fixture.onTasksUpdated).not.toHaveBeenCalled()
+    expect(fixture.watch).not.toHaveBeenCalled()
+  })
+
+  test('does not subscribe for non-lead team members', async () => {
+    fixture.state.appState.teamContext = {
+      leadAgentId: 'lead-agent',
+      teamName: 'alpha',
+    }
+    fixture.state.isLead = false
+    fixture.state.tasksByList.set('list-a', [task('1', 'pending')])
+
+    const mounted = await mountUseTasksV2()
+    await flushPromises()
+
+    expect(mounted.initial).toBeUndefined()
+    expect(fixture.listTasks).not.toHaveBeenCalled()
+    expect(fixture.onTasksUpdated).not.toHaveBeenCalled()
+  })
+
+  test('hides an empty initial list and continues when fs.watch setup fails', async () => {
+    fixture.state.watchThrows = true
+
+    const mounted = await mountUseTasksV2()
+    await flushPromises()
+
+    expect(fixture.watch).toHaveBeenCalledWith('/tasks/list-a', expect.any(Function))
+    expect(fixture.listTasks).toHaveBeenCalledWith('list-a')
+    expect(latestTasks(mounted.record)).toBeUndefined()
+    expect(activeTimers()).toHaveLength(0)
+  })
+
+  test('filters internal tasks and preserves source ordering across add, update, and remove events', async () => {
+    fixture.state.tasksByList.set('list-a', [
+      task('2', 'pending'),
+      task('internal', 'pending', { metadata: { _internal: true } }),
+      task('10', 'completed'),
+    ])
+    const mounted = await mountUseTasksV2()
+    await flushPromises()
+
+    expect(latestTasks(mounted.record)?.map(t => t.id)).toEqual(['2', '10'])
+
+    fixture.state.tasksByList.set('list-a', [
+      task('2', 'in_progress'),
+      task('1', 'pending'),
+      task('10', 'completed'),
+    ])
+    await emitTasksUpdated()
+
+    expect(latestTasks(mounted.record)?.map(t => [t.id, t.status])).toEqual([
+      ['2', 'in_progress'],
+      ['1', 'pending'],
+      ['10', 'completed'],
+    ])
+
+    fixture.state.tasksByList.set('list-a', [
+      task('2', 'completed'),
+      task('1', 'pending'),
+    ])
+    await emitTasksUpdated()
+
+    expect(latestTasks(mounted.record)?.map(t => [t.id, t.status])).toEqual([
+      ['2', 'completed'],
+      ['1', 'pending'],
+    ])
+  })
+
+  test('shares one store across subscribers and tears down watchers, listeners, and timers after the last unsubscribe', async () => {
+    fixture.state.tasksByList.set('list-a', [task('1', 'pending')])
+
+    const first = await mountUseTasksV2()
+    const second = await mountUseTasksV2()
+    await flushPromises()
+
+    expect(fixture.onTasksUpdated).toHaveBeenCalledTimes(1)
+    expect(fixture.listTasks).toHaveBeenCalledTimes(1)
+    expect(fixture.watch).toHaveBeenCalledTimes(1)
+    expect(activeTimers(5000)).toHaveLength(1)
+
+    first.dispose()
+    expect(fixture.state.watchers[0]?.close).not.toHaveBeenCalled()
+
+    second.dispose()
+    expect(fixture.state.watchers[0]?.close).toHaveBeenCalledTimes(1)
+    expect(fixture.state.taskListeners).toHaveLength(0)
+    expect(activeTimers()).toHaveLength(0)
+  })
+
+  test('debounces watcher events and clears stale debounce work on unmount', async () => {
+    fixture.state.tasksByList.set('list-a', [task('1', 'pending')])
+    const mounted = await mountUseTasksV2()
+    await flushPromises()
+
+    fixture.state.tasksByList.set('list-a', [task('1', 'in_progress')])
+    fixture.state.watchers[0]?.listener()
+    fixture.state.tasksByList.set('list-a', [task('1', 'completed')])
+    fixture.state.watchers[0]?.listener()
+
+    expect(activeTimers(50)).toHaveLength(1)
+
+    mounted.dispose()
+    await fireNextTimer(50).catch(() => undefined)
+
+    expect(fixture.listTasks).toHaveBeenCalledTimes(1)
+    expect(fixture.state.watchers[0]?.close).toHaveBeenCalledTimes(1)
+  })
+
+  test('resets and hides completed tasks after the completion delay, then shows new work', async () => {
+    fixture.state.tasksByList.set('list-a', [task('1', 'completed')])
+    const mounted = await mountUseTasksV2()
+    await flushPromises()
+
+    expect(latestTasks(mounted.record)?.map(t => t.id)).toEqual(['1'])
+    expect(activeTimers(5000)).toHaveLength(1)
+
+    await fireNextTimer(5000)
+
+    expect(fixture.resetTaskList).toHaveBeenCalledWith('list-a')
+    expect(latestTasks(mounted.record)).toBeUndefined()
+
+    fixture.state.tasksByList.set('list-a', [task('2', 'pending')])
+    await emitTasksUpdated()
+
+    expect(latestTasks(mounted.record)?.map(t => t.id)).toEqual(['2'])
+  })
+
+  test('cancels completed-task hiding when incomplete work appears before the delay', async () => {
+    fixture.state.tasksByList.set('list-a', [task('1', 'completed')])
+    const mounted = await mountUseTasksV2()
+    await flushPromises()
+    const hideTimer = activeTimers(5000)[0]
+    expect(hideTimer).toBeDefined()
+
+    fixture.state.tasksByList.set('list-a', [
+      task('1', 'completed'),
+      task('2', 'pending'),
+    ])
+    await emitTasksUpdated()
+
+    expect(hideTimer.active).toBe(false)
+    expect(fixture.resetTaskList).not.toHaveBeenCalled()
+    expect(latestTasks(mounted.record)?.map(t => t.id)).toEqual(['1', '2'])
+  })
+
+  test('does not reset a stale completed list after the task-list id changes', async () => {
+    fixture.state.tasksByList.set('list-a', [task('1', 'completed')])
+    const mounted = await mountUseTasksV2()
+    await flushPromises()
+
+    fixture.state.taskListId = 'list-b'
+    fixture.state.tasksByList.set('list-b', [task('2', 'pending')])
+    await fireNextTimer(5000)
+
+    expect(fixture.resetTaskList).not.toHaveBeenCalled()
+    expect(latestTasks(mounted.record)?.map(t => t.id)).toEqual(['1'])
+
+    await emitTasksUpdated()
+
+    expect(fixture.state.watchers.map(watcher => watcher.dir)).toEqual([
+      '/tasks/list-a',
+      '/tasks/list-b',
+    ])
+    expect(fixture.state.watchers[0]?.close).toHaveBeenCalledTimes(1)
+    expect(latestTasks(mounted.record)?.map(t => t.id)).toEqual(['2'])
+  })
+
+  test('collapses expanded task view when the hook is hidden', async () => {
+    fixture.state.enabled = false
+    fixture.state.appState = {
+      expandedView: 'tasks',
+    }
+    const { useTasksV2WithCollapseEffect } = await import('./useTasksV2.js')
+
+    const tasks = useTasksV2WithCollapseEffect()
+
+    expect(tasks).toBeUndefined()
+    expect(fixture.setAppState).toHaveBeenCalledTimes(1)
+    expect(fixture.state.appState.expandedView).toBe('none')
+  })
+})

--- a/runtime/tests/tui/hooks/useTextInput.test.tsx
+++ b/runtime/tests/tui/hooks/useTextInput.test.tsx
@@ -1,0 +1,438 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  addToHistory: vi.fn(),
+  fullscreen: false,
+  markBackslashReturnUsed: vi.fn(),
+  modifiers: {
+    shift: false,
+  } as Record<string, boolean>,
+  prewarmModifiers: vi.fn(),
+  removeNotification: vi.fn(),
+  reset() {
+    this.addNotification.mockClear()
+    this.addToHistory.mockClear()
+    this.fullscreen = false
+    this.markBackslashReturnUsed.mockClear()
+    this.modifiers = { shift: false }
+    this.prewarmModifiers.mockClear()
+    this.removeNotification.mockClear()
+  },
+}))
+
+vi.mock('../context/notifications.js', () => ({
+  useNotifications: () => ({
+    addNotification: harness.addNotification,
+    removeNotification: harness.removeNotification,
+  }),
+}))
+
+vi.mock('../../commands/terminalSetup/terminalSetup.js', () => ({
+  markBackslashReturnUsed: harness.markBackslashReturnUsed,
+}))
+
+vi.mock('../history/history.js', () => ({
+  addToHistory: harness.addToHistory,
+}))
+
+vi.mock('../../utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => harness.fullscreen,
+}))
+
+vi.mock('../../utils/modifiers.js', () => ({
+  isModifierPressed: (modifier: string) => harness.modifiers[modifier] === true,
+  prewarmModifiers: harness.prewarmModifiers,
+}))
+
+import { createRoot } from '../ink/root.js'
+import type { Key } from '../ink.js'
+import { env } from '../../utils/env.js'
+import { useTextInput, type UseTextInputProps } from './useTextInput.js'
+
+type HookState = ReturnType<typeof useTextInput>
+
+const BASE_KEY: Key = {
+  backspace: false,
+  ctrl: false,
+  delete: false,
+  downArrow: false,
+  end: false,
+  escape: false,
+  fn: false,
+  home: false,
+  leftArrow: false,
+  meta: false,
+  pageDown: false,
+  pageUp: false,
+  return: false,
+  rightArrow: false,
+  shift: false,
+  super: false,
+  tab: false,
+  upArrow: false,
+  wheelDown: false,
+  wheelUp: false,
+}
+
+function key(overrides: Partial<Key> = {}): Key {
+  return { ...BASE_KEY, ...overrides }
+}
+
+function createStreams(): {
+  readonly stdout: PassThrough
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 80
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderHookHarness(
+  overrides: Partial<UseTextInputProps> = {},
+): Promise<{
+  readonly latest: () => HookState
+  readonly onChange: ReturnType<typeof vi.fn>
+  readonly onOffsetChange: ReturnType<typeof vi.fn>
+  readonly render: (next?: Partial<UseTextInputProps>) => Promise<void>
+  readonly dispose: () => Promise<void>
+}> {
+  const onChange = vi.fn()
+  const onOffsetChange = vi.fn()
+  let props: UseTextInputProps = {
+    columns: 20,
+    cursorChar: '|',
+    externalOffset: overrides.value?.length ?? 0,
+    invert: text => text,
+    onChange,
+    onOffsetChange,
+    themeText: text => text,
+    value: '',
+    ...overrides,
+  }
+  let latest: HookState | undefined
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    latest = useTextInput(props)
+    return null
+  }
+
+  async function render(next: Partial<UseTextInputProps> = {}): Promise<void> {
+    props = { ...props, ...next }
+    root.render(<Harness />)
+    await sleep()
+  }
+
+  await render()
+
+  return {
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+    onChange,
+    onOffsetChange,
+    render,
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+  }
+}
+
+describe('useTextInput', () => {
+  const originalTerminal = env.terminal
+
+  beforeEach(() => {
+    harness.reset()
+    env.terminal = originalTerminal
+  })
+
+  afterEach(() => {
+    env.terminal = originalTerminal
+    vi.restoreAllMocks()
+  })
+
+  test('handles filtered input, mode characters, DEL bytes, and prop resync', async () => {
+    const inputFilter = vi.fn((input: string) =>
+      input === 'blocked' ? '' : input,
+    )
+    const rendered = await renderHookHarness({
+      externalOffset: 0,
+      inputFilter,
+      value: '',
+    })
+
+    try {
+      rendered.latest().onInput('blocked', key())
+      await sleep()
+      expect(rendered.latest().value).toBe('')
+      expect(rendered.onChange).not.toHaveBeenCalled()
+
+      rendered.latest().onInput('!', key())
+      await sleep()
+      expect(rendered.latest().value).toBe('!')
+      expect(rendered.latest().offset).toBe(0)
+
+      rendered.latest().onInput('abc', key())
+      await sleep()
+      expect(rendered.latest().value).toBe('abc!')
+
+      rendered.latest().onInput('\x7f\x7f', key())
+      await sleep()
+      expect(rendered.latest().value).toBe('a!')
+
+      rendered.latest().setOffset(2)
+      await sleep()
+      expect(rendered.latest().offset).toBe(2)
+      rendered.latest().setOffset(2)
+      await sleep()
+      expect(rendered.onOffsetChange).toHaveBeenCalledTimes(3)
+
+      await rendered.render({ externalOffset: 1, value: 'parent' })
+      expect(rendered.latest().value).toBe('parent')
+      expect(rendered.latest().offset).toBe(1)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('handles cursor movement, kill ring, yank, and yank-pop editing', async () => {
+    const rendered = await renderHookHarness({
+      columns: 80,
+      externalOffset: 'alpha beta gamma'.length,
+      value: 'alpha beta gamma',
+    })
+
+    try {
+      rendered.latest().onInput('a', key({ ctrl: true }))
+      await sleep()
+      expect(rendered.latest().offset).toBe(0)
+
+      rendered.latest().onInput('e', key({ ctrl: true }))
+      await sleep()
+      expect(rendered.latest().offset).toBe('alpha beta gamma'.length)
+
+      rendered.latest().onInput('b', key({ meta: true }))
+      await sleep()
+      expect(rendered.latest().offset).toBe('alpha beta '.length)
+
+      rendered.latest().onInput('d', key({ meta: true }))
+      await sleep()
+      expect(rendered.latest().value).toBe('alpha beta ')
+
+      await rendered.render({
+        externalOffset: 'alpha '.length,
+        value: 'alpha beta gamma',
+      })
+      rendered.latest().onInput('k', key({ ctrl: true }))
+      await sleep()
+      expect(rendered.latest().value).toBe('alpha ')
+
+      rendered.latest().onInput('y', key({ ctrl: true }))
+      await sleep()
+      expect(rendered.latest().value).toBe('alpha beta gamma')
+
+      rendered.latest().onInput('w', key({ ctrl: true }))
+      await sleep()
+      expect(rendered.latest().value).toBe('alpha beta ')
+
+      rendered.latest().onInput('u', key({ ctrl: true }))
+      await sleep()
+      expect(rendered.latest().value).toBe('')
+
+      rendered.latest().onInput('y', key({ ctrl: true }))
+      await sleep()
+      const firstYank = rendered.latest().value
+      expect(firstYank.length).toBeGreaterThan(0)
+
+      rendered.latest().onInput('y', key({ meta: true }))
+      await sleep()
+      expect(rendered.latest().value).not.toBe(firstYank)
+
+      rendered.latest().onInput('h', key({ ctrl: true }))
+      await sleep()
+      expect(rendered.latest().value.length).toBeLessThan(firstYank.length)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('handles enter variants and terminal control sequences', async () => {
+    const onSubmit = vi.fn()
+    const rendered = await renderHookHarness({
+      externalOffset: 4,
+      multiline: true,
+      onSubmit,
+      value: 'run\\',
+    })
+
+    try {
+      rendered.latest().onInput('\r', key({ return: true }))
+      await sleep()
+      expect(harness.markBackslashReturnUsed).toHaveBeenCalledTimes(1)
+      expect(rendered.latest().value).toBe('run\n')
+
+      rendered.latest().onInput('\r', key({ meta: true, return: true }))
+      await sleep()
+      expect(rendered.latest().value).toBe('run\n\n')
+
+      env.terminal = 'Apple_Terminal'
+      harness.modifiers.shift = true
+      await rendered.render({
+        externalOffset: 4,
+        value: 'line',
+      })
+      expect(harness.prewarmModifiers).toHaveBeenCalled()
+      rendered.latest().onInput('\r', key({ return: true }))
+      await sleep()
+      expect(rendered.latest().value).toBe('line\n')
+
+      env.terminal = originalTerminal
+      harness.modifiers.shift = false
+      await rendered.render({
+        externalOffset: 'submit'.length,
+        value: 'submit',
+      })
+      rendered.latest().onInput('\r', key({ return: true }))
+      await sleep()
+      expect(onSubmit).toHaveBeenLastCalledWith('submit')
+
+      rendered.latest().onInput('x\r', key())
+      await sleep()
+      expect(onSubmit).toHaveBeenLastCalledWith('submitx')
+
+      rendered.latest().onInput('\\\r', key())
+      await sleep()
+      expect(rendered.latest().value).toContain('\\\n')
+
+      rendered.latest().onInput('\x1b[H', key())
+      await sleep()
+      expect(rendered.latest().offset).toBe(0)
+      rendered.latest().onInput('\x1b[F', key())
+      await sleep()
+      expect(rendered.latest().offset).toBeGreaterThan(0)
+
+      harness.fullscreen = true
+      const beforePageKeys = {
+        offset: rendered.latest().offset,
+        value: rendered.latest().value,
+      }
+      rendered.latest().onInput('', key({ pageUp: true }))
+      rendered.latest().onInput('', key({ pageDown: true }))
+      rendered.latest().onInput('', key({ wheelUp: true }))
+      rendered.latest().onInput('', key({ wheelDown: true }))
+      rendered.latest().onInput('', key({ tab: true }))
+      await sleep()
+      expect(rendered.latest().value).toBe(beforePageKeys.value)
+      expect(rendered.latest().offset).toBe(beforePageKeys.offset)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('handles escape, ctrl-c, ctrl-d, and history callbacks', async () => {
+    const onClearInput = vi.fn()
+    const onExit = vi.fn()
+    const onExitMessage = vi.fn()
+    const onHistoryDown = vi.fn()
+    const onHistoryReset = vi.fn()
+    const onHistoryUp = vi.fn()
+    const rendered = await renderHookHarness({
+      disableCursorMovementForUpDownKeys: true,
+      externalOffset: 'clear me'.length,
+      onClearInput,
+      onExit,
+      onExitMessage,
+      onHistoryDown,
+      onHistoryReset,
+      onHistoryUp,
+      value: 'clear me',
+    })
+
+    try {
+      rendered.latest().onInput('', key({ escape: true }))
+      await sleep()
+      expect(harness.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'escape-again-to-clear' }),
+      )
+
+      rendered.latest().onInput('', key({ escape: true }))
+      await sleep()
+      expect(harness.removeNotification).toHaveBeenCalledWith(
+        'escape-again-to-clear',
+      )
+      expect(onClearInput).toHaveBeenCalledTimes(1)
+      expect(harness.addToHistory).toHaveBeenCalledWith('clear me')
+      expect(rendered.latest().value).toBe('')
+      expect(onHistoryReset).toHaveBeenCalled()
+
+      await rendered.render({
+        externalOffset: 'interrupt'.length,
+        value: 'interrupt',
+      })
+      rendered.latest().onInput('c', key({ ctrl: true }))
+      await sleep()
+      expect(rendered.latest().value).toBe('')
+      expect(onExitMessage).toHaveBeenCalledWith(true, 'Ctrl-C')
+      rendered.latest().onInput('c', key({ ctrl: true }))
+      await sleep()
+      expect(onExitMessage).toHaveBeenCalledWith(false, 'Ctrl-C')
+      expect(onExit).toHaveBeenCalledTimes(1)
+
+      rendered.latest().onInput('p', key({ ctrl: true }))
+      rendered.latest().onInput('n', key({ ctrl: true }))
+      await sleep()
+      expect(onHistoryUp).toHaveBeenCalled()
+      expect(onHistoryDown).toHaveBeenCalled()
+
+      rendered.latest().onInput('d', key({ ctrl: true }))
+      await sleep()
+      expect(onExitMessage).toHaveBeenCalledWith(true, 'Ctrl-D')
+      rendered.latest().onInput('d', key({ ctrl: true }))
+      await sleep()
+      expect(onExit).toHaveBeenCalledTimes(2)
+
+      await rendered.render({
+        externalOffset: 1,
+        value: 'xy',
+      })
+      rendered.latest().onInput('d', key({ ctrl: true }))
+      await sleep()
+      expect(rendered.latest().value).toBe('x')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/hooks/useTextInput.wave200-026.coverage.test.tsx
+++ b/runtime/tests/tui/hooks/useTextInput.wave200-026.coverage.test.tsx
@@ -1,0 +1,276 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  addToHistory: vi.fn(),
+  fullscreen: false,
+  markBackslashReturnUsed: vi.fn(),
+  modifiers: {} as Record<string, boolean>,
+  prewarmModifiers: vi.fn(),
+  removeNotification: vi.fn(),
+  reset() {
+    this.addNotification.mockClear()
+    this.addToHistory.mockClear()
+    this.fullscreen = false
+    this.markBackslashReturnUsed.mockClear()
+    this.modifiers = {}
+    this.prewarmModifiers.mockClear()
+    this.removeNotification.mockClear()
+  },
+}))
+
+vi.mock('../context/notifications.js', () => ({
+  useNotifications: () => ({
+    addNotification: harness.addNotification,
+    removeNotification: harness.removeNotification,
+  }),
+}))
+
+vi.mock('../../commands/terminalSetup/terminalSetup.js', () => ({
+  markBackslashReturnUsed: harness.markBackslashReturnUsed,
+}))
+
+vi.mock('../history/history.js', () => ({
+  addToHistory: harness.addToHistory,
+}))
+
+vi.mock('../../utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => harness.fullscreen,
+}))
+
+vi.mock('../../utils/modifiers.js', () => ({
+  isModifierPressed: (modifier: string) => harness.modifiers[modifier] === true,
+  prewarmModifiers: harness.prewarmModifiers,
+}))
+
+import { createRoot } from '../ink/root.js'
+import type { Key } from '../ink.js'
+import { clearKillRing } from '../../utils/TextCursor.js'
+import { env } from '../../utils/env.js'
+import { useTextInput, type UseTextInputProps } from './useTextInput.js'
+
+type HookState = ReturnType<typeof useTextInput>
+
+const BASE_KEY: Key = {
+  backspace: false,
+  ctrl: false,
+  delete: false,
+  downArrow: false,
+  end: false,
+  escape: false,
+  fn: false,
+  home: false,
+  leftArrow: false,
+  meta: false,
+  pageDown: false,
+  pageUp: false,
+  return: false,
+  rightArrow: false,
+  shift: false,
+  super: false,
+  tab: false,
+  upArrow: false,
+  wheelDown: false,
+  wheelUp: false,
+}
+
+function key(overrides: Partial<Key> = {}): Key {
+  return { ...BASE_KEY, ...overrides }
+}
+
+function createStreams(): {
+  readonly stdout: PassThrough
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 100
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderHookHarness(
+  overrides: Partial<UseTextInputProps> = {},
+): Promise<{
+  readonly latest: () => HookState
+  readonly onChange: ReturnType<typeof vi.fn>
+  readonly render: (next?: Partial<UseTextInputProps>) => Promise<void>
+  readonly dispose: () => Promise<void>
+}> {
+  const onChange = vi.fn()
+  const onOffsetChange = vi.fn()
+  let props: UseTextInputProps = {
+    columns: 80,
+    cursorChar: '|',
+    externalOffset: overrides.value?.length ?? 0,
+    invert: text => text,
+    onChange,
+    onOffsetChange,
+    themeText: text => text,
+    value: '',
+    ...overrides,
+  }
+  let latest: HookState | undefined
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    latest = useTextInput(props)
+    return null
+  }
+
+  async function render(next: Partial<UseTextInputProps> = {}): Promise<void> {
+    props = { ...props, ...next }
+    root.render(<Harness />)
+    await sleep()
+  }
+
+  await render()
+
+  return {
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+    onChange,
+    render,
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+  }
+}
+
+describe('useTextInput wave200 coverage', () => {
+  const originalTerminal = env.terminal
+
+  beforeEach(() => {
+    harness.reset()
+    clearKillRing()
+    env.terminal = originalTerminal
+  })
+
+  afterEach(() => {
+    clearKillRing()
+    env.terminal = originalTerminal
+    vi.restoreAllMocks()
+  })
+
+  test('maps uncovered editing and navigation key branches through onInput', async () => {
+    const rendered = await renderHookHarness({
+      disableEscapeDoublePress: true,
+      externalOffset: 'alpha beta gamma'.length,
+      value: 'alpha beta gamma',
+    })
+
+    try {
+      rendered.latest().onInput('', key({ escape: true }))
+      rendered.latest().onInput('y', key({ ctrl: true }))
+      rendered.latest().onInput('y', key({ meta: true }))
+      await sleep()
+      expect(harness.addNotification).not.toHaveBeenCalled()
+      expect(rendered.latest().value).toBe('alpha beta gamma')
+
+      rendered.latest().onInput('', key({ leftArrow: true, ctrl: true }))
+      await sleep()
+      expect(rendered.latest().offset).toBe('alpha beta '.length)
+
+      rendered.latest().onInput('', key({ rightArrow: true, meta: true }))
+      await sleep()
+      expect(rendered.latest().offset).toBe('alpha beta gamma'.length)
+
+      rendered.latest().onInput('b', key({ ctrl: true }))
+      await sleep()
+      expect(rendered.latest().offset).toBe('alpha beta gamm'.length)
+
+      rendered.latest().onInput('f', key({ ctrl: true }))
+      await sleep()
+      expect(rendered.latest().offset).toBe('alpha beta gamma'.length)
+
+      rendered.latest().onInput('', key({ home: true }))
+      await sleep()
+      expect(rendered.latest().offset).toBe(0)
+
+      rendered.latest().onInput('', key({ end: true }))
+      await sleep()
+      expect(rendered.latest().offset).toBe('alpha beta gamma'.length)
+
+      rendered.latest().onInput('', key({ pageUp: true }))
+      await sleep()
+      expect(rendered.latest().offset).toBe(0)
+
+      rendered.latest().onInput('', key({ pageDown: true }))
+      await sleep()
+      expect(rendered.latest().offset).toBe('alpha beta gamma'.length)
+
+      rendered.latest().onInput('', key({ leftArrow: true }))
+      await sleep()
+      expect(rendered.latest().offset).toBe('alpha beta gamm'.length)
+
+      rendered.latest().onInput('', key({ rightArrow: true }))
+      await sleep()
+      expect(rendered.latest().offset).toBe('alpha beta gamma'.length)
+
+      rendered.latest().onInput('', key({ backspace: true }))
+      await sleep()
+      expect(rendered.latest().value).toBe('alpha beta gamm')
+
+      rendered.latest().onInput('', key({ backspace: true, meta: true }))
+      await sleep()
+      expect(rendered.latest().value).toBe('alpha beta ')
+
+      await rendered.render({
+        externalOffset: 'alpha '.length,
+        value: 'alpha beta gamma',
+      })
+      rendered.latest().onInput('f', key({ meta: true }))
+      await sleep()
+      expect(rendered.latest().offset).toBe('alpha beta '.length)
+
+      await rendered.render({
+        externalOffset: 'alpha '.length,
+        value: 'alpha beta',
+      })
+      rendered.latest().onInput('', key({ delete: true }))
+      await sleep()
+      expect(rendered.latest().value).toBe('alpha eta')
+
+      await rendered.render({
+        externalOffset: 'alpha '.length,
+        value: 'alpha beta',
+      })
+      rendered.latest().onInput('', key({ delete: true, meta: true }))
+      await sleep()
+      expect(rendered.latest().value).toBe('alpha ')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/hooks/useTypeahead.coverage2.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.coverage2.test.tsx
@@ -1,0 +1,333 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  appState: {
+    agentNameRegistry: new Map<string, string>(),
+    mcp: {
+      clients: [] as unknown[],
+      resources: [] as unknown[],
+    },
+    promptSuggestion: {
+      acceptedAt: 0,
+      generationRequestId: null,
+      promptId: null,
+      shownAt: 0,
+      text: null as string | null,
+    },
+    tasks: {} as Record<string, { status?: string }>,
+    teamContext: undefined as unknown,
+    viewingAgentTaskId: null as string | null,
+  },
+  keybindings: {} as Record<string, () => unknown>,
+  reset() {
+    harness.addNotification.mockClear()
+    harness.appState.agentNameRegistry = new Map()
+    harness.appState.mcp = { clients: [], resources: [] }
+    harness.appState.promptSuggestion = {
+      acceptedAt: 0,
+      generationRequestId: null,
+      promptId: null,
+      shownAt: 0,
+      text: null,
+    }
+    harness.appState.tasks = {}
+    harness.appState.teamContext = undefined
+    harness.appState.viewingAgentTaskId = null
+    harness.keybindings = {}
+  },
+}))
+
+vi.mock('usehooks-ts', async () => {
+  const ReactModule = await import('react')
+  return {
+    useDebounceCallback: (callback: (...args: unknown[]) => unknown) => {
+      const callbackRef = ReactModule.useRef(callback)
+      callbackRef.current = callback
+      return ReactModule.useMemo(() => {
+        const debounced = (...args: unknown[]) => callbackRef.current(...args)
+        debounced.cancel = vi.fn()
+        return debounced
+      }, [])
+    },
+  }
+})
+
+vi.mock('../context/notifications.js', () => ({
+  useNotifications: () => ({ addNotification: harness.addNotification }),
+}))
+
+vi.mock('../../services/analytics/index.js', () => ({
+  logEvent: vi.fn(),
+}))
+
+vi.mock('../context/overlayContext', () => ({
+  useIsModalOverlayActive: () => false,
+  useRegisterOverlay: vi.fn(),
+}))
+
+vi.mock('../ink.js', async () => {
+  const ReactModule = await import('react')
+  return {
+    Text: ({ children }: { readonly children?: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+    useInput: vi.fn(),
+  }
+})
+
+vi.mock('../keybindings/KeybindingContext.js', () => ({
+  useOptionalKeybindingContext: () => ({ pendingChord: null }),
+  useRegisterKeybindingContext: vi.fn(),
+}))
+
+vi.mock('../keybindings/useKeybinding.js', () => ({
+  useKeybindings: (handlers: Record<string, () => unknown>) => {
+    Object.assign(harness.keybindings, handlers)
+  },
+}))
+
+vi.mock('../keybindings/useShortcutDisplay.js', () => ({
+  useShortcutDisplay: () => 'alt+t',
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+  useAppStateStore: () => ({ getState: () => harness.appState }),
+}))
+
+vi.mock('../../utils/agentSwarmsEnabled', () => ({
+  isAgentSwarmsEnabled: () => Boolean(harness.appState.teamContext),
+}))
+
+vi.mock('../../utils/bash/shellCompletion.js', () => ({
+  getShellCompletions: vi.fn(async () => []),
+}))
+
+vi.mock('../../utils/sessionStorage.js', () => ({
+  getSessionIdFromLog: (log: { readonly sessionId?: string }) =>
+    log.sessionId ?? 'session-1',
+  searchSessionsByCustomTitle: vi.fn(async () => []),
+}))
+
+vi.mock('../../utils/suggestions/directoryCompletion.js', () => ({
+  getDirectoryCompletions: vi.fn(async () => []),
+  getPathCompletions: vi.fn(async () => []),
+  isPathLikeToken: (token: string) =>
+    token.startsWith('/') || token.startsWith('./') || token.startsWith('~/'),
+}))
+
+vi.mock('../../utils/suggestions/shellHistoryCompletion.js', () => ({
+  getShellHistoryCompletion: vi.fn(async () => null),
+}))
+
+vi.mock('../../utils/suggestions/slackChannelSuggestions.js', () => ({
+  getSlackChannelSuggestions: vi.fn(async () => []),
+  hasSlackMcpServer: () => false,
+}))
+
+vi.mock('../../utils/swarm/constants.js', () => ({
+  TEAM_LEAD_NAME: 'team-lead',
+}))
+
+vi.mock('./fileSuggestions', () => ({
+  applyFileSuggestion: (
+    replacementValue: string,
+    input: string,
+    token: string,
+    startPos: number,
+    onInputChange: (value: string) => void,
+    setCursorOffset: (offset: number) => void,
+  ) => {
+    const next =
+      input.slice(0, startPos) +
+      replacementValue +
+      input.slice(startPos + token.length)
+    onInputChange(next)
+    setCursorOffset(startPos + replacementValue.length)
+  },
+  findLongestCommonPrefix: (items: readonly { readonly displayText: string }[]) =>
+    items[0]?.displayText ?? '',
+  onIndexBuildComplete: () => () => {},
+  startBackgroundCacheRefresh: vi.fn(),
+}))
+
+vi.mock('./unifiedSuggestions', () => ({
+  generateUnifiedSuggestions: vi.fn(async () => []),
+}))
+
+import { createRoot } from '../ink/root.js'
+import type { SuggestionItem } from '../components/PromptInput/PromptInputFooterSuggestions.js'
+import { useTypeahead } from './useTypeahead.js'
+
+type SuggestionsState = {
+  commandArgumentHint?: string
+  selectedSuggestion: number
+  suggestions: SuggestionItem[]
+}
+
+type HookSnapshot = ReturnType<typeof useTypeahead> & {
+  suggestionsState: SuggestionsState
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function createTestStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+function TypeaheadHarness(props: {
+  readonly commands: readonly unknown[]
+  readonly input: string
+  readonly onInputChange: (value: string) => void
+  readonly onSubmit: (value: string, isSubmittingSlashCommand?: boolean) => void
+  readonly setCursorOffset: (offset: number) => void
+  readonly snapshot: (value: HookSnapshot) => void
+}): React.ReactNode {
+  const [suggestionsState, setSuggestionsState] = React.useState<SuggestionsState>({
+    commandArgumentHint: undefined,
+    selectedSuggestion: -1,
+    suggestions: [],
+  })
+  const result = useTypeahead({
+    agents: [],
+    commands: props.commands as never[],
+    cursorOffset: props.input.length,
+    input: props.input,
+    markAccepted: vi.fn(),
+    mode: 'prompt',
+    onInputChange: props.onInputChange,
+    onSubmit: props.onSubmit,
+    setCursorOffset: props.setCursorOffset,
+    setSuggestionsState,
+    suggestionsState,
+  })
+
+  React.useEffect(() => {
+    props.snapshot({ ...result, suggestionsState })
+  })
+  return null
+}
+
+async function renderHookHarness(props: {
+  readonly commands: readonly unknown[]
+  readonly input: string
+  readonly onInputChange: (value: string) => void
+  readonly onSubmit: (value: string, isSubmittingSlashCommand?: boolean) => void
+  readonly setCursorOffset: (offset: number) => void
+}): Promise<{
+  dispose: () => Promise<void>
+  getSnapshot: () => HookSnapshot
+}> {
+  const { stdin, stdout } = createTestStreams()
+  let snapshot: HookSnapshot | undefined
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  root.render(
+    <TypeaheadHarness
+      {...props}
+      snapshot={value => {
+        snapshot = value
+      }}
+    />,
+  )
+  await waitFor(() => snapshot !== undefined, 'hook snapshot')
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep(25)
+    },
+    getSnapshot: () => {
+      if (!snapshot) throw new Error('Hook snapshot missing')
+      return snapshot
+    },
+  }
+}
+
+async function waitFor(predicate: () => boolean, label: string): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < 1000) {
+    if (predicate()) return
+    await sleep(10)
+  }
+  throw new Error(`Timed out waiting for ${label}`)
+}
+
+const command = (name: string) => ({
+  aliases: [],
+  description: `${name} command`,
+  isHidden: false,
+  name,
+  type: 'prompt',
+})
+
+describe('useTypeahead coverage gaps', () => {
+  beforeEach(() => {
+    harness.reset()
+  })
+
+  test('accepts mid-input slash command ghost text with autocomplete accept', async () => {
+    const onInputChange = vi.fn()
+    const onSubmit = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      commands: [command('help')],
+      input: 'ask /he',
+      onInputChange,
+      onSubmit,
+      setCursorOffset,
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().inlineGhostText?.fullCommand === 'help',
+        'mid-input slash ghost text',
+      )
+      expect(rendered.getSnapshot().inlineGhostText).toEqual(
+        expect.objectContaining({
+          fullCommand: 'help',
+          insertPosition: 'ask /he'.length,
+          text: 'lp',
+        }),
+      )
+
+      harness.keybindings['autocomplete:accept']?.()
+
+      expect(onInputChange).toHaveBeenCalledWith('ask /help ')
+      expect(setCursorOffset).toHaveBeenCalledWith('ask /help '.length)
+      expect(onSubmit).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
@@ -859,4 +859,234 @@ describe('useTypeahead hook paths', () => {
       await rendered.dispose()
     }
   })
+
+  test('tab accepts command and custom title suggestions without submitting them', async () => {
+    const onInputChange = vi.fn()
+    const onSubmit = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      commands: [command('help'), command('resume')],
+      input: '/h',
+      onInputChange,
+      onSubmit,
+      setCursorOffset,
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'command',
+        'command suggestions',
+      )
+
+      harness.keybindings['autocomplete:accept']?.()
+      expect(onInputChange).toHaveBeenCalledWith('/help ')
+      expect(setCursorOffset).toHaveBeenCalledWith('/help '.length)
+      expect(onSubmit).not.toHaveBeenCalled()
+
+      onInputChange.mockClear()
+      setCursorOffset.mockClear()
+      harness.sessionTitleMatches = [
+        {
+          customTitle: 'Sprint planning',
+          messageCount: 12,
+          modified: new Date('2026-05-20T00:00:00.000Z'),
+          sessionId: 'session-42',
+        },
+      ]
+      rendered.rerender({ input: '/resume Sprint', cursorOffset: '/resume Sprint'.length })
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'custom-title',
+        'custom title suggestions',
+      )
+
+      harness.keybindings['autocomplete:accept']?.()
+      expect(onInputChange).toHaveBeenCalledWith('/resume session-42')
+      expect(setCursorOffset).toHaveBeenCalledWith('/resume session-42'.length)
+      expect(onSubmit).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('tab accepts shell, teammate, and Slack suggestions', async () => {
+    harness.shellCompletions = [
+      {
+        displayText: 'grep',
+        id: 'grep',
+        metadata: { completionType: 'command', inputSnapshot: 'g' },
+      },
+      {
+        displayText: 'git',
+        id: 'git',
+        metadata: { completionType: 'command', inputSnapshot: 'g' },
+      },
+    ]
+    const onInputChange = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      input: 'g',
+      mode: 'bash',
+      onInputChange,
+      setCursorOffset,
+    })
+
+    try {
+      harness.keybindings['autocomplete:accept']?.()
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'shell',
+        'shell suggestions',
+      )
+
+      harness.keybindings['autocomplete:accept']?.()
+      expect(onInputChange).toHaveBeenCalledWith('grep ')
+      expect(setCursorOffset).toHaveBeenCalledWith('grep '.length)
+
+      onInputChange.mockClear()
+      setCursorOffset.mockClear()
+      harness.appState.teamContext = {
+        teammates: {
+          lead: { name: 'team-lead' },
+        },
+      }
+      harness.appState.agentNameRegistry.set('Planner', 'agent-planner')
+      harness.appState.tasks = {
+        'agent-planner': { status: 'idle' },
+      }
+      rendered.rerender({ input: '@Pl', mode: 'prompt', cursorOffset: 3 })
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'agent',
+        'agent suggestions',
+      )
+
+      harness.keybindings['autocomplete:accept']?.()
+      expect(onInputChange).toHaveBeenCalledWith('@Planner ')
+      expect(setCursorOffset).toHaveBeenCalledWith('@Planner '.length)
+
+      onInputChange.mockClear()
+      setCursorOffset.mockClear()
+      harness.appState.teamContext = undefined
+      harness.appState.agentNameRegistry = new Map()
+      harness.appState.mcp = {
+        clients: [{ name: 'slack' }],
+        resources: [],
+      }
+      harness.slackSuggestions = [
+        { displayText: '#general', id: 'slack-general', description: 'channel' },
+      ]
+      rendered.rerender({ input: '#gen', cursorOffset: 4 })
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'slack-channel',
+        'slack channel suggestions',
+      )
+
+      harness.keybindings['autocomplete:accept']?.()
+      expect(onInputChange).toHaveBeenCalledWith('#general ')
+      expect(setCursorOffset).toHaveBeenCalledWith('#general '.length)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('tab applies file suggestions as common prefixes and exact selections', async () => {
+    harness.unifiedSuggestions = [
+      {
+        id: 'src/app.ts',
+        displayText: 'src/app.ts',
+        description: 'file',
+      },
+    ]
+    const onInputChange = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      input: '@sr',
+      onInputChange,
+      setCursorOffset,
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'file',
+        'file suggestions',
+      )
+
+      harness.keybindings['autocomplete:accept']?.()
+      expect(onInputChange).toHaveBeenCalledWith('@src/app.ts')
+      expect(setCursorOffset).toHaveBeenCalledWith('@src/app.ts'.length)
+
+      onInputChange.mockClear()
+      setCursorOffset.mockClear()
+      rendered.rerender({ input: '@src/app.ts', cursorOffset: '@src/app.ts'.length })
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'file',
+        'exact file suggestion',
+      )
+
+      harness.keybindings['autocomplete:accept']?.()
+      expect(onInputChange).toHaveBeenCalledWith('@src/app.ts ')
+      expect(setCursorOffset).toHaveBeenCalledWith('@src/app.ts '.length)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('tab handles directory suggestions in command and general path contexts', async () => {
+    harness.directorySuggestions = [
+      {
+        displayText: 'README.md',
+        id: 'README.md',
+        metadata: { type: 'file' },
+      },
+    ]
+    const onInputChange = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      input: '/add-dir R',
+      onInputChange,
+      setCursorOffset,
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'directory',
+        'command file suggestion',
+      )
+
+      harness.keybindings['autocomplete:accept']?.()
+      expect(onInputChange).toHaveBeenCalledWith('/add-dir README.md ')
+      expect(setCursorOffset).toHaveBeenCalledWith('/add-dir README.md '.length)
+
+      onInputChange.mockClear()
+      setCursorOffset.mockClear()
+      harness.directorySuggestions = [
+        {
+          displayText: '/tmp/project',
+          id: '/tmp/project',
+          metadata: { type: 'directory' },
+        },
+      ]
+      rendered.rerender({ input: '@/tm', cursorOffset: '@/tm'.length })
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'directory',
+        'general path directory suggestion',
+      )
+
+      harness.keybindings['autocomplete:accept']?.()
+      expect(onInputChange).toHaveBeenCalledWith('@/tmp/project/')
+      expect(setCursorOffset).toHaveBeenCalledWith('@/tmp/project/'.length)
+
+      onInputChange.mockClear()
+      setCursorOffset.mockClear()
+      rendered.rerender({ input: '/add-dir /tmp', cursorOffset: '/add-dir /tmp'.length })
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'directory',
+        'enter clears command directory suggestion',
+      )
+
+      rendered.getSnapshot().handleKeyDown(createKey('return'))
+      expect(onInputChange).not.toHaveBeenCalled()
+      expect(setCursorOffset).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
 })

--- a/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
@@ -1,0 +1,448 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  appState: {
+    agentNameRegistry: new Map<string, string>(),
+    mcp: {
+      clients: [],
+      resources: [],
+    },
+    promptSuggestion: {
+      acceptedAt: 0,
+      generationRequestId: null,
+      promptId: null,
+      shownAt: 0,
+      text: null as string | null,
+    },
+    tasks: {},
+    teamContext: undefined,
+    viewingAgentTaskId: null as string | null,
+  },
+  directorySuggestions: [] as unknown[],
+  keybindings: {} as Record<string, () => unknown>,
+  shellHistoryCompletion: null as null | {
+    fullCommand: string
+    suffix: string
+  },
+  unifiedSuggestions: [] as unknown[],
+  reset() {
+    harness.addNotification.mockClear()
+    harness.appState.agentNameRegistry = new Map()
+    harness.appState.mcp = { clients: [], resources: [] }
+    harness.appState.promptSuggestion = {
+      acceptedAt: 0,
+      generationRequestId: null,
+      promptId: null,
+      shownAt: 0,
+      text: null,
+    }
+    harness.appState.tasks = {}
+    harness.appState.teamContext = undefined
+    harness.appState.viewingAgentTaskId = null
+    harness.directorySuggestions = []
+    harness.keybindings = {}
+    harness.shellHistoryCompletion = null
+    harness.unifiedSuggestions = []
+  },
+  slackSuggestions: [] as unknown[],
+}))
+
+vi.mock('usehooks-ts', async () => {
+  const ReactModule = await import('react')
+  return {
+    useDebounceCallback: (callback: (...args: unknown[]) => unknown) => {
+      const callbackRef = ReactModule.useRef(callback)
+      callbackRef.current = callback
+      return ReactModule.useMemo(() => {
+        const debounced = (...args: unknown[]) => callbackRef.current(...args)
+        debounced.cancel = vi.fn()
+        return debounced
+      }, [])
+    },
+  }
+})
+
+vi.mock('../context/notifications.js', () => ({
+  useNotifications: () => ({ addNotification: harness.addNotification }),
+}))
+
+vi.mock('../../services/analytics/index.js', () => ({
+  logEvent: vi.fn(),
+}))
+
+vi.mock('../context/overlayContext', () => ({
+  useIsModalOverlayActive: () => false,
+  useRegisterOverlay: vi.fn(),
+}))
+
+vi.mock('../ink.js', async () => {
+  const ReactModule = await import('react')
+  return {
+    Text: ({ children }: { readonly children?: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+    useInput: vi.fn(),
+  }
+})
+
+vi.mock('../keybindings/KeybindingContext.js', () => ({
+  useOptionalKeybindingContext: () => ({ pendingChord: null }),
+  useRegisterKeybindingContext: vi.fn(),
+}))
+
+vi.mock('../keybindings/useKeybinding.js', () => ({
+  useKeybindings: (handlers: Record<string, () => unknown>) => {
+    Object.assign(harness.keybindings, handlers)
+  },
+}))
+
+vi.mock('../keybindings/useShortcutDisplay.js', () => ({
+  useShortcutDisplay: () => 'alt+t',
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+  useAppStateStore: () => ({ getState: () => harness.appState }),
+}))
+
+vi.mock('../../utils/agentSwarmsEnabled', () => ({
+  isAgentSwarmsEnabled: () => Boolean(harness.appState.teamContext),
+}))
+
+vi.mock('../../utils/bash/shellCompletion.js', () => ({
+  getShellCompletions: vi.fn(async () => []),
+}))
+
+vi.mock('../../utils/sessionStorage.js', () => ({
+  getSessionIdFromLog: (log: { readonly sessionId?: string }) =>
+    log.sessionId ?? 'session-1',
+  searchSessionsByCustomTitle: vi.fn(async () => []),
+}))
+
+vi.mock('../../utils/suggestions/directoryCompletion.js', () => ({
+  getDirectoryCompletions: vi.fn(async () => harness.directorySuggestions),
+  getPathCompletions: vi.fn(async () => harness.directorySuggestions),
+  isPathLikeToken: (token: string) =>
+    token.startsWith('/') || token.startsWith('./') || token.startsWith('~/'),
+}))
+
+vi.mock('../../utils/suggestions/shellHistoryCompletion.js', () => ({
+  getShellHistoryCompletion: vi.fn(async () => harness.shellHistoryCompletion),
+}))
+
+vi.mock('../../utils/suggestions/slackChannelSuggestions.js', () => ({
+  getSlackChannelSuggestions: vi.fn(async () => harness.slackSuggestions),
+  hasSlackMcpServer: () => harness.appState.mcp.clients.length > 0,
+}))
+
+vi.mock('../../utils/swarm/constants.js', () => ({
+  TEAM_LEAD_NAME: 'team-lead',
+}))
+
+vi.mock('./fileSuggestions', () => ({
+  applyFileSuggestion: (
+    replacementValue: string,
+    input: string,
+    token: string,
+    startPos: number,
+    onInputChange: (value: string) => void,
+    setCursorOffset: (offset: number) => void,
+  ) => {
+    const next =
+      input.slice(0, startPos) +
+      replacementValue +
+      input.slice(startPos + token.length)
+    onInputChange(next)
+    setCursorOffset(startPos + replacementValue.length)
+  },
+  findLongestCommonPrefix: (items: readonly { readonly displayText: string }[]) => {
+    if (items.length === 0) return ''
+    let prefix = items[0]?.displayText ?? ''
+    for (const item of items.slice(1)) {
+      while (!item.displayText.startsWith(prefix)) prefix = prefix.slice(0, -1)
+    }
+    return prefix
+  },
+  onIndexBuildComplete: () => () => {},
+  startBackgroundCacheRefresh: vi.fn(),
+}))
+
+vi.mock('./unifiedSuggestions', () => ({
+  generateUnifiedSuggestions: vi.fn(async () => harness.unifiedSuggestions),
+}))
+
+import { createRoot } from '../ink/root.js'
+import { KeyboardEvent } from '../ink/events/keyboard-event.js'
+import type { SuggestionItem } from '../components/PromptInput/PromptInputFooterSuggestions.js'
+import type { PromptInputMode } from '../../types/textInputTypes.js'
+import { useTypeahead } from './useTypeahead.js'
+
+type SuggestionsState = {
+  commandArgumentHint?: string
+  selectedSuggestion: number
+  suggestions: SuggestionItem[]
+}
+
+type HookSnapshot = ReturnType<typeof useTypeahead> & {
+  suggestionsState: SuggestionsState
+}
+
+const EMPTY_AGENTS: readonly never[] = []
+const EMPTY_COMMANDS: readonly never[] = []
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function createKey(
+  name: string,
+  options: { ctrl?: boolean; shift?: boolean } = {},
+): KeyboardEvent {
+  return new KeyboardEvent({
+    ctrl: options.ctrl ?? false,
+    fn: false,
+    isPasted: false,
+    kind: 'key',
+    meta: false,
+    name,
+    option: false,
+    raw: name,
+    sequence: name.length === 1 ? name : '',
+    shift: options.shift ?? false,
+    super: false,
+  })
+}
+
+function createTestStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+function TypeaheadHarness(props: {
+  readonly commands?: readonly unknown[]
+  readonly cursorOffset?: number
+  readonly input: string
+  readonly mode?: PromptInputMode
+  readonly onInputChange: (value: string) => void
+  readonly onModeChange?: (mode: PromptInputMode) => void
+  readonly onSubmit?: (value: string, isSubmittingSlashCommand?: boolean) => void
+  readonly setCursorOffset: (offset: number) => void
+  readonly snapshot: (value: HookSnapshot) => void
+}): React.ReactNode {
+  const [suggestionsState, setSuggestionsState] = React.useState<SuggestionsState>({
+    commandArgumentHint: undefined,
+    selectedSuggestion: -1,
+    suggestions: [],
+  })
+  const result = useTypeahead({
+    agents: EMPTY_AGENTS as never,
+    commands: (props.commands ?? EMPTY_COMMANDS) as never,
+    cursorOffset: props.cursorOffset ?? props.input.length,
+    input: props.input,
+    markAccepted: vi.fn(),
+    mode: props.mode ?? 'prompt',
+    onInputChange: props.onInputChange,
+    onModeChange: props.onModeChange,
+    onSubmit: props.onSubmit ?? vi.fn(),
+    setCursorOffset: props.setCursorOffset,
+    setSuggestionsState,
+    suggestionsState,
+  })
+
+  React.useEffect(() => {
+    props.snapshot({ ...result, suggestionsState })
+  })
+  return null
+}
+
+async function renderHookHarness(props: {
+  readonly commands?: readonly unknown[]
+  readonly input: string
+  readonly mode?: PromptInputMode
+  readonly onInputChange?: (value: string) => void
+  readonly onModeChange?: (mode: PromptInputMode) => void
+  readonly onSubmit?: (value: string, isSubmittingSlashCommand?: boolean) => void
+  readonly setCursorOffset?: (offset: number) => void
+}): Promise<{
+  dispose: () => Promise<void>
+  getSnapshot: () => HookSnapshot
+  rerender: (next: Partial<typeof props>) => void
+}> {
+  const { stdin, stdout } = createTestStreams()
+  let currentProps = props
+  let snapshot: HookSnapshot | undefined
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  const render = () => {
+    root.render(
+      <TypeaheadHarness
+        {...currentProps}
+        onInputChange={currentProps.onInputChange ?? vi.fn()}
+        setCursorOffset={currentProps.setCursorOffset ?? vi.fn()}
+        snapshot={value => {
+          snapshot = value
+        }}
+      />,
+    )
+  }
+  render()
+  await waitFor(() => snapshot !== undefined, 'hook snapshot')
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep(25)
+    },
+    getSnapshot: () => {
+      if (!snapshot) throw new Error('Hook snapshot missing')
+      return snapshot
+    },
+    rerender: next => {
+      currentProps = { ...currentProps, ...next }
+      render()
+    },
+  }
+}
+
+async function waitFor(predicate: () => boolean, label: string): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < 1000) {
+    if (predicate()) return
+    await sleep(10)
+  }
+  throw new Error(`Timed out waiting for ${label}`)
+}
+
+const command = (name: string, aliases: readonly string[] = []) => ({
+  aliases,
+  description: `${name} command`,
+  isHidden: false,
+  name,
+  type: 'prompt',
+})
+
+describe('useTypeahead hook paths', () => {
+  beforeEach(() => {
+    harness.reset()
+  })
+
+  test('generates slash command suggestions and navigates them with autocomplete keybindings', async () => {
+    const rendered = await renderHookHarness({
+      commands: [command('help'), command('history'), command('logout')],
+      input: '/h',
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'command',
+        'command suggestions',
+      )
+      expect(rendered.getSnapshot().suggestions.map(item => item.displayText)).toContain(
+        '/help',
+      )
+
+      harness.keybindings['autocomplete:next']?.()
+      await waitFor(
+        () => rendered.getSnapshot().suggestionsState.selectedSuggestion === 1,
+        'next suggestion',
+      )
+
+      harness.keybindings['autocomplete:previous']?.()
+      await waitFor(
+        () => rendered.getSnapshot().suggestionsState.selectedSuggestion === 0,
+        'previous suggestion',
+      )
+
+      harness.keybindings['autocomplete:dismiss']?.()
+      await waitFor(
+        () => rendered.getSnapshot().suggestions.length === 0,
+        'dismissed suggestions',
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('accepts prompt suggestion ghost text with right arrow and mode detection', async () => {
+    harness.appState.promptSuggestion = {
+      acceptedAt: 0,
+      generationRequestId: null,
+      promptId: 'prompt-1',
+      shownAt: Date.now(),
+      text: '!echo accepted',
+    }
+    const onInputChange = vi.fn()
+    const onModeChange = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      input: '',
+      onInputChange,
+      onModeChange,
+      setCursorOffset,
+    })
+
+    try {
+      rendered.getSnapshot().handleKeyDown(createKey('right'))
+
+      expect(onModeChange).toHaveBeenCalledWith('bash')
+      expect(onInputChange).toHaveBeenCalledWith('echo accepted')
+      expect(setCursorOffset).toHaveBeenCalledWith('echo accepted'.length)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('uses tab to show thinking hint on empty input and to fetch file suggestions for @ tokens', async () => {
+    harness.unifiedSuggestions = [
+      { id: 'src/app.ts', displayText: 'src/app.ts', description: 'file' },
+    ]
+    const rendered = await renderHookHarness({ input: '' })
+
+    try {
+      const emptyTab = createKey('tab')
+      rendered.getSnapshot().handleKeyDown(emptyTab)
+      expect(emptyTab.defaultPrevented).toBe(true)
+      expect(harness.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'thinking-toggle-hint' }),
+      )
+
+      rendered.rerender({ input: '@sr', cursorOffset: 3 })
+      await waitFor(() => rendered.getSnapshot().handleKeyDown !== undefined, 'rerender')
+      const tokenTab = createKey('tab')
+      rendered.getSnapshot().handleKeyDown(tokenTab)
+      await waitFor(
+        () => rendered.getSnapshot().suggestions.some(item => item.id === 'src/app.ts'),
+        'file suggestions',
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
@@ -8,8 +8,8 @@ const harness = vi.hoisted(() => ({
   appState: {
     agentNameRegistry: new Map<string, string>(),
     mcp: {
-      clients: [],
-      resources: [],
+      clients: [] as unknown[],
+      resources: [] as unknown[],
     },
     promptSuggestion: {
       acceptedAt: 0,
@@ -18,12 +18,14 @@ const harness = vi.hoisted(() => ({
       shownAt: 0,
       text: null as string | null,
     },
-    tasks: {},
-    teamContext: undefined,
+    tasks: {} as Record<string, { status?: string }>,
+    teamContext: undefined as unknown,
     viewingAgentTaskId: null as string | null,
   },
   directorySuggestions: [] as unknown[],
   keybindings: {} as Record<string, () => unknown>,
+  sessionTitleMatches: [] as unknown[],
+  shellCompletions: [] as unknown[],
   shellHistoryCompletion: null as null | {
     fullCommand: string
     suffix: string
@@ -45,6 +47,8 @@ const harness = vi.hoisted(() => ({
     harness.appState.viewingAgentTaskId = null
     harness.directorySuggestions = []
     harness.keybindings = {}
+    harness.sessionTitleMatches = []
+    harness.shellCompletions = []
     harness.shellHistoryCompletion = null
     harness.unifiedSuggestions = []
   },
@@ -114,13 +118,13 @@ vi.mock('../../utils/agentSwarmsEnabled', () => ({
 }))
 
 vi.mock('../../utils/bash/shellCompletion.js', () => ({
-  getShellCompletions: vi.fn(async () => []),
+  getShellCompletions: vi.fn(async () => harness.shellCompletions),
 }))
 
 vi.mock('../../utils/sessionStorage.js', () => ({
   getSessionIdFromLog: (log: { readonly sessionId?: string }) =>
     log.sessionId ?? 'session-1',
-  searchSessionsByCustomTitle: vi.fn(async () => []),
+  searchSessionsByCustomTitle: vi.fn(async () => harness.sessionTitleMatches),
 }))
 
 vi.mock('../../utils/suggestions/directoryCompletion.js', () => ({
@@ -441,6 +445,165 @@ describe('useTypeahead hook paths', () => {
         () => rendered.getSnapshot().suggestions.some(item => item.id === 'src/app.ts'),
         'file suggestions',
       )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('accepts bash history ghost text and single shell completion through autocomplete accept', async () => {
+    harness.shellHistoryCompletion = {
+      fullCommand: 'git status --short',
+      suffix: 'atus --short',
+    }
+    const onInputChange = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      input: 'git st',
+      mode: 'bash',
+      onInputChange,
+      setCursorOffset,
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().inlineGhostText?.fullCommand === 'git status --short',
+        'bash history ghost text',
+      )
+
+      harness.keybindings['autocomplete:accept']?.()
+      expect(onInputChange).toHaveBeenCalledWith('git status --short')
+      expect(setCursorOffset).toHaveBeenCalledWith('git status --short'.length)
+
+      harness.shellHistoryCompletion = null
+      harness.shellCompletions = [
+        {
+          displayText: 'grep',
+          id: 'grep',
+          metadata: { completionType: 'command' },
+        },
+      ]
+      rendered.rerender({ input: 'gr', mode: 'bash' })
+      await waitFor(
+        () => rendered.getSnapshot().inlineGhostText === undefined,
+        'cleared bash ghost text',
+      )
+
+      harness.keybindings['autocomplete:accept']?.()
+      await waitFor(
+        () => onInputChange.mock.calls.some(call => call[0] === 'grep '),
+        'single shell completion applied',
+      )
+      expect(setCursorOffset).toHaveBeenCalledWith('grep '.length)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('applies teammate and slack trigger suggestions with enter', async () => {
+    harness.appState.teamContext = {
+      teammates: {
+        fixer: { name: 'Fixer' },
+        lead: { name: 'team-lead' },
+      },
+    }
+    harness.appState.agentNameRegistry.set('Planner', 'agent-planner')
+    harness.appState.tasks = {
+      'agent-planner': { status: 'running' },
+    }
+    const onInputChange = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      input: '@Pl',
+      onInputChange,
+      setCursorOffset,
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'agent',
+        'agent suggestions',
+      )
+      expect(rendered.getSnapshot().suggestions.map(item => item.displayText)).toEqual([
+        '@Planner',
+      ])
+
+      rendered.getSnapshot().handleKeyDown(createKey('return'))
+      expect(onInputChange).toHaveBeenCalledWith('@Planner ')
+      expect(setCursorOffset).toHaveBeenCalledWith('@Planner '.length)
+
+      harness.appState.teamContext = undefined
+      harness.appState.agentNameRegistry = new Map()
+      harness.appState.mcp = {
+        clients: [{ name: 'slack' }],
+        resources: [],
+      }
+      harness.slackSuggestions = [
+        { displayText: '#general', id: 'slack-general', description: 'channel' },
+      ]
+      rendered.rerender({ input: '#gen', cursorOffset: 4 })
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'slack-channel',
+        'slack channel suggestions',
+      )
+
+      rendered.getSnapshot().handleKeyDown(createKey('return'))
+      expect(onInputChange).toHaveBeenCalledWith('#general ')
+      expect(setCursorOffset).toHaveBeenCalledWith('#general '.length)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('handles directory command completion and resume title execution', async () => {
+    harness.directorySuggestions = [
+      {
+        displayText: 'src',
+        id: 'src',
+        metadata: { type: 'directory' },
+      },
+    ]
+    const onInputChange = vi.fn()
+    const onSubmit = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      input: '/add-dir s',
+      onInputChange,
+      onSubmit,
+      setCursorOffset,
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'directory',
+        'directory suggestions',
+      )
+
+      harness.keybindings['autocomplete:accept']?.()
+      await waitFor(
+        () => onInputChange.mock.calls.some(call => call[0] === '/add-dir src/'),
+        'directory suggestion applied',
+      )
+      expect(setCursorOffset).toHaveBeenCalledWith('/add-dir src/'.length)
+
+      harness.directorySuggestions = []
+      harness.sessionTitleMatches = [
+        {
+          customTitle: 'Sprint planning',
+          messageCount: 12,
+          modified: new Date('2026-05-20T00:00:00.000Z'),
+          sessionId: 'session-42',
+        },
+      ]
+      rendered.rerender({ input: '/resume Sprint', cursorOffset: '/resume Sprint'.length })
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'custom-title',
+        'custom title suggestions',
+      )
+
+      rendered.getSnapshot().handleKeyDown(createKey('return'))
+      expect(onInputChange).toHaveBeenCalledWith('/resume session-42')
+      expect(setCursorOffset).toHaveBeenCalledWith('/resume session-42'.length)
+      expect(onSubmit).toHaveBeenCalledWith('/resume session-42', true)
     } finally {
       await rendered.dispose()
     }

--- a/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
@@ -50,6 +50,7 @@ const harness = vi.hoisted(() => ({
     harness.sessionTitleMatches = []
     harness.shellCompletions = []
     harness.shellHistoryCompletion = null
+    harness.slackSuggestions = []
     harness.unifiedSuggestions = []
   },
   slackSuggestions: [] as unknown[],
@@ -184,6 +185,7 @@ import { KeyboardEvent } from '../ink/events/keyboard-event.js'
 import type { SuggestionItem } from '../components/PromptInput/PromptInputFooterSuggestions.js'
 import type { PromptInputMode } from '../../types/textInputTypes.js'
 import { useTypeahead } from './useTypeahead.js'
+import { generateUnifiedSuggestions } from './unifiedSuggestions'
 
 type SuggestionsState = {
   commandArgumentHint?: string
@@ -201,6 +203,8 @@ const EMPTY_COMMANDS: readonly never[] = []
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
+
+const generateUnifiedSuggestionsMock = vi.mocked(generateUnifiedSuggestions)
 
 function createKey(
   name: string,
@@ -249,6 +253,7 @@ function TypeaheadHarness(props: {
   readonly commands?: readonly unknown[]
   readonly cursorOffset?: number
   readonly input: string
+  readonly markAccepted?: () => void
   readonly mode?: PromptInputMode
   readonly onInputChange: (value: string) => void
   readonly onModeChange?: (mode: PromptInputMode) => void
@@ -266,7 +271,7 @@ function TypeaheadHarness(props: {
     commands: (props.commands ?? EMPTY_COMMANDS) as never,
     cursorOffset: props.cursorOffset ?? props.input.length,
     input: props.input,
-    markAccepted: vi.fn(),
+    markAccepted: props.markAccepted ?? vi.fn(),
     mode: props.mode ?? 'prompt',
     onInputChange: props.onInputChange,
     onModeChange: props.onModeChange,
@@ -285,6 +290,7 @@ function TypeaheadHarness(props: {
 async function renderHookHarness(props: {
   readonly commands?: readonly unknown[]
   readonly input: string
+  readonly markAccepted?: () => void
   readonly mode?: PromptInputMode
   readonly onInputChange?: (value: string) => void
   readonly onModeChange?: (mode: PromptInputMode) => void
@@ -355,6 +361,7 @@ const command = (name: string, aliases: readonly string[] = []) => ({
 describe('useTypeahead hook paths', () => {
   beforeEach(() => {
     harness.reset()
+    generateUnifiedSuggestionsMock.mockClear()
   })
 
   test('generates slash command suggestions and navigates them with autocomplete keybindings', async () => {
@@ -604,6 +611,250 @@ describe('useTypeahead hook paths', () => {
       expect(onInputChange).toHaveBeenCalledWith('/resume session-42')
       expect(setCursorOffset).toHaveBeenCalledWith('/resume session-42'.length)
       expect(onSubmit).toHaveBeenCalledWith('/resume session-42', true)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('enters partial slash commands without executing until the command text is exact', async () => {
+    const onInputChange = vi.fn()
+    const onSubmit = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      commands: [command('help')],
+      input: '/h',
+      onInputChange,
+      onSubmit,
+      setCursorOffset,
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'command',
+        'partial command suggestions',
+      )
+
+      rendered.getSnapshot().handleKeyDown(createKey('return'))
+      expect(onInputChange).toHaveBeenCalledWith('/help ')
+      expect(setCursorOffset).toHaveBeenCalledWith('/help '.length)
+      expect(onSubmit).not.toHaveBeenCalled()
+
+      onInputChange.mockClear()
+      setCursorOffset.mockClear()
+      rendered.rerender({ input: '/help', cursorOffset: '/help'.length })
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'command',
+        'exact command suggestions',
+      )
+
+      rendered.getSnapshot().handleKeyDown(createKey('return'))
+      expect(onInputChange).toHaveBeenCalledWith('/help ')
+      expect(setCursorOffset).toHaveBeenCalledWith('/help '.length)
+      expect(onSubmit).toHaveBeenCalledWith('/help ', true)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('shows command argument hints on a trailing space and clears them once args start', async () => {
+    const rendered = await renderHookHarness({
+      commands: [{ ...command('review'), argumentHint: '<target>' }],
+      input: '/review ',
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().commandArgumentHint === '<target>',
+        'command argument hint',
+      )
+      expect(rendered.getSnapshot().suggestions).toEqual([])
+
+      rendered.rerender({
+        input: '/review src',
+        cursorOffset: '/review src'.length,
+      })
+      await waitFor(
+        () => rendered.getSnapshot().commandArgumentHint === undefined,
+        'cleared command argument hint',
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('does not accept prompt suggestion text while viewing a teammate', async () => {
+    harness.appState.promptSuggestion = {
+      acceptedAt: 0,
+      generationRequestId: null,
+      promptId: 'prompt-1',
+      shownAt: Date.now(),
+      text: '!echo hidden',
+    }
+    harness.appState.viewingAgentTaskId = 'task-1'
+    const markAccepted = vi.fn()
+    const onInputChange = vi.fn()
+    const onModeChange = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      input: '',
+      markAccepted,
+      onInputChange,
+      onModeChange,
+      setCursorOffset,
+    })
+
+    try {
+      rendered.getSnapshot().handleKeyDown(createKey('right'))
+      expect(markAccepted).not.toHaveBeenCalled()
+      expect(onModeChange).not.toHaveBeenCalled()
+      expect(onInputChange).not.toHaveBeenCalled()
+      expect(setCursorOffset).not.toHaveBeenCalled()
+
+      const tab = createKey('tab')
+      rendered.getSnapshot().handleKeyDown(tab)
+      expect(tab.defaultPrevented).toBe(true)
+      expect(markAccepted).not.toHaveBeenCalled()
+      expect(onInputChange).not.toHaveBeenCalled()
+      expect(harness.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'thinking-toggle-hint' }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('dismiss remembers the current input and does not immediately refetch it', async () => {
+    harness.unifiedSuggestions = [
+      { id: 'src/app.ts', displayText: 'src/app.ts', description: 'file' },
+    ]
+    const rendered = await renderHookHarness({ input: '@sr', cursorOffset: 3 })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'file',
+        'initial file suggestions',
+      )
+
+      harness.keybindings['autocomplete:dismiss']?.()
+      await waitFor(
+        () => rendered.getSnapshot().suggestions.length === 0,
+        'dismissed suggestions',
+      )
+
+      generateUnifiedSuggestionsMock.mockClear()
+      rendered.rerender({ input: '@sr', cursorOffset: 3 })
+      await sleep(25)
+      expect(generateUnifiedSuggestionsMock).not.toHaveBeenCalled()
+
+      rendered.rerender({ input: '@src', cursorOffset: 4 })
+      await waitFor(
+        () => generateUnifiedSuggestionsMock.mock.calls.length > 0,
+        'refetch after input changes',
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('tab cycles active @ file suggestions instead of accepting one', async () => {
+    harness.unifiedSuggestions = [
+      { id: 'src/app.ts', displayText: 'src/app.ts', description: 'file' },
+      { id: 'src/api.ts', displayText: 'src/api.ts', description: 'file' },
+    ]
+    const onInputChange = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      input: '@sr',
+      onInputChange,
+      setCursorOffset,
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'file',
+        'file suggestions',
+      )
+      expect(rendered.getSnapshot().suggestionsState.selectedSuggestion).toBe(0)
+
+      harness.keybindings['autocomplete:accept']?.()
+      await waitFor(
+        () => rendered.getSnapshot().suggestionsState.selectedSuggestion === 1,
+        'cycled file suggestion',
+      )
+      expect(onInputChange).not.toHaveBeenCalled()
+      expect(setCursorOffset).not.toHaveBeenCalled()
+
+      harness.keybindings['autocomplete:accept']?.()
+      await waitFor(
+        () => rendered.getSnapshot().suggestionsState.selectedSuggestion === 0,
+        'wrapped file suggestion cycle',
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('enter applies quoted file suggestions from an @ token', async () => {
+    harness.unifiedSuggestions = [
+      {
+        id: 'docs/release notes.md',
+        displayText: 'docs/release notes.md',
+        description: 'file',
+      },
+    ]
+    const onInputChange = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      input: '@docs',
+      onInputChange,
+      setCursorOffset,
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'file',
+        'file suggestion',
+      )
+
+      rendered.getSnapshot().handleKeyDown(createKey('return'))
+      expect(onInputChange).toHaveBeenCalledWith('@"docs/release notes.md" ')
+      expect(setCursorOffset).toHaveBeenCalledWith(
+        '@"docs/release notes.md" '.length,
+      )
+      await waitFor(
+        () => rendered.getSnapshot().suggestions.length === 0,
+        'cleared file suggestion',
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('enter applies general path directory suggestions outside slash commands', async () => {
+    harness.directorySuggestions = [
+      {
+        displayText: '/tmp/project',
+        id: '/tmp/project',
+        metadata: { type: 'directory' },
+      },
+    ]
+    const onInputChange = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      input: '@/tm',
+      onInputChange,
+      setCursorOffset,
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'directory',
+        'path directory suggestions',
+      )
+
+      rendered.getSnapshot().handleKeyDown(createKey('return'))
+      expect(onInputChange).toHaveBeenCalledWith('@/tmp/project/')
+      expect(setCursorOffset).toHaveBeenCalledWith('@/tmp/project/'.length)
     } finally {
       await rendered.dispose()
     }

--- a/runtime/tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx
@@ -1,0 +1,264 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+type ParsedKeyForTest = {
+  ctrl: boolean
+  fn: boolean
+  meta: boolean
+  name: string
+  option: boolean
+  sequence: string
+  shift: boolean
+  super: boolean
+}
+
+type UseInputCallback = (
+  input: string,
+  key: unknown,
+  event: {
+    keypress: ParsedKeyForTest
+    stopImmediatePropagation: () => void
+  },
+) => void
+
+const harness = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  appState: {
+    agentNameRegistry: new Map<string, string>(),
+    mcp: {
+      clients: [] as unknown[],
+      resources: [] as unknown[],
+    },
+    promptSuggestion: {
+      acceptedAt: 0,
+      generationRequestId: null,
+      promptId: null,
+      shownAt: 0,
+      text: null as string | null,
+    },
+    tasks: {} as Record<string, { status?: string }>,
+    teamContext: undefined as unknown,
+    viewingAgentTaskId: null as string | null,
+  },
+  useInputHandler: null as UseInputCallback | null,
+}))
+
+vi.mock('usehooks-ts', async () => {
+  const ReactModule = await import('react')
+  return {
+    useDebounceCallback: (callback: (...args: unknown[]) => unknown) => {
+      const callbackRef = ReactModule.useRef(callback)
+      callbackRef.current = callback
+      return ReactModule.useMemo(() => {
+        const debounced = (...args: unknown[]) => callbackRef.current(...args)
+        debounced.cancel = vi.fn()
+        return debounced
+      }, [])
+    },
+  }
+})
+
+vi.mock('../context/notifications.js', () => ({
+  useNotifications: () => ({ addNotification: harness.addNotification }),
+}))
+
+vi.mock('../../services/analytics/index.js', () => ({
+  logEvent: vi.fn(),
+}))
+
+vi.mock('../context/overlayContext', () => ({
+  useIsModalOverlayActive: () => false,
+  useRegisterOverlay: vi.fn(),
+}))
+
+vi.mock('../ink.js', async () => {
+  const ReactModule = await import('react')
+  return {
+    Text: ({ children }: { readonly children?: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+    useInput: vi.fn((handler: UseInputCallback) => {
+      harness.useInputHandler = handler
+    }),
+  }
+})
+
+vi.mock('../keybindings/KeybindingContext.js', () => ({
+  useOptionalKeybindingContext: () => ({ pendingChord: null }),
+  useRegisterKeybindingContext: vi.fn(),
+}))
+
+vi.mock('../keybindings/useKeybinding.js', () => ({
+  useKeybindings: vi.fn(),
+}))
+
+vi.mock('../keybindings/useShortcutDisplay.js', () => ({
+  useShortcutDisplay: () => 'alt+t',
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+  useAppStateStore: () => ({ getState: () => harness.appState }),
+}))
+
+vi.mock('../../utils/agentSwarmsEnabled', () => ({
+  isAgentSwarmsEnabled: () => false,
+}))
+
+vi.mock('../../utils/bash/shellCompletion.js', () => ({
+  getShellCompletions: vi.fn(async () => []),
+}))
+
+vi.mock('../../utils/sessionStorage.js', () => ({
+  getSessionIdFromLog: () => 'session-1',
+  searchSessionsByCustomTitle: vi.fn(async () => []),
+}))
+
+vi.mock('../../utils/suggestions/directoryCompletion.js', () => ({
+  getDirectoryCompletions: vi.fn(async () => []),
+  getPathCompletions: vi.fn(async () => []),
+  isPathLikeToken: (token: string) =>
+    token.startsWith('/') || token.startsWith('./') || token.startsWith('~/'),
+}))
+
+vi.mock('../../utils/suggestions/shellHistoryCompletion.js', () => ({
+  getShellHistoryCompletion: vi.fn(async () => null),
+}))
+
+vi.mock('../../utils/suggestions/slackChannelSuggestions.js', () => ({
+  getSlackChannelSuggestions: vi.fn(async () => []),
+  hasSlackMcpServer: () => false,
+}))
+
+vi.mock('../../utils/swarm/constants.js', () => ({
+  TEAM_LEAD_NAME: 'team-lead',
+}))
+
+vi.mock('./fileSuggestions', () => ({
+  applyFileSuggestion: vi.fn(),
+  findLongestCommonPrefix: vi.fn(() => ''),
+  onIndexBuildComplete: () => () => {},
+  startBackgroundCacheRefresh: vi.fn(),
+}))
+
+vi.mock('./unifiedSuggestions', () => ({
+  generateUnifiedSuggestions: vi.fn(async () => []),
+}))
+
+import { createRoot } from '../ink/root.js'
+import type { SuggestionItem } from '../components/PromptInput/PromptInputFooterSuggestions.js'
+import { useTypeahead } from './useTypeahead.js'
+
+type SuggestionsState = {
+  commandArgumentHint?: string
+  selectedSuggestion: number
+  suggestions: SuggestionItem[]
+}
+
+function createTestStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+function TypeaheadHarness(): React.ReactNode {
+  const [suggestionsState, setSuggestionsState] = React.useState<SuggestionsState>({
+    commandArgumentHint: undefined,
+    selectedSuggestion: -1,
+    suggestions: [],
+  })
+
+  useTypeahead({
+    agents: [],
+    commands: [],
+    cursorOffset: 0,
+    input: '',
+    markAccepted: vi.fn(),
+    mode: 'prompt',
+    onInputChange: vi.fn(),
+    onSubmit: vi.fn(),
+    setCursorOffset: vi.fn(),
+    setSuggestionsState,
+    suggestionsState,
+  })
+
+  return null
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForUseInputHandler(): Promise<UseInputCallback> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < 1000) {
+    if (harness.useInputHandler) return harness.useInputHandler
+    await sleep(10)
+  }
+  throw new Error('Timed out waiting for useInput registration')
+}
+
+function tabKeypress(): ParsedKeyForTest {
+  return {
+    ctrl: false,
+    fn: false,
+    meta: false,
+    name: 'tab',
+    option: false,
+    sequence: '\t',
+    shift: false,
+    super: false,
+  }
+}
+
+describe('useTypeahead useInput bridge', () => {
+  test('stops the original Ink input event when the adapted keyboard event is consumed', async () => {
+    const { stdin, stdout } = createTestStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      root.render(<TypeaheadHarness />)
+      const useInputHandler = await waitForUseInputHandler()
+      const stopImmediatePropagation = vi.fn()
+
+      useInputHandler('', {}, {
+        keypress: tabKeypress(),
+        stopImmediatePropagation,
+      })
+
+      expect(stopImmediatePropagation).toHaveBeenCalledTimes(1)
+      expect(harness.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ key: 'thinking-toggle-hint' }),
+      )
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep(25)
+    }
+  })
+})

--- a/runtime/tests/tui/hooks/useVimInput.coverage.test.ts
+++ b/runtime/tests/tui/hooks/useVimInput.coverage.test.ts
@@ -1,0 +1,227 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const hookHarness = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  addToHistory: vi.fn(),
+  fullscreen: false,
+  markBackslashReturnUsed: vi.fn(),
+  modifiers: {
+    shift: false,
+  } as Record<string, boolean>,
+  prewarmModifiers: vi.fn(),
+  removeNotification: vi.fn(),
+  reset() {
+    this.addNotification.mockClear()
+    this.addToHistory.mockClear()
+    this.fullscreen = false
+    this.markBackslashReturnUsed.mockClear()
+    this.modifiers = { shift: false }
+    this.prewarmModifiers.mockClear()
+    this.removeNotification.mockClear()
+  },
+}))
+
+vi.mock('../context/notifications.js', () => ({
+  useNotifications: () => ({
+    addNotification: hookHarness.addNotification,
+    removeNotification: hookHarness.removeNotification,
+  }),
+}))
+
+vi.mock('../../commands/terminalSetup/terminalSetup.js', () => ({
+  markBackslashReturnUsed: hookHarness.markBackslashReturnUsed,
+}))
+
+vi.mock('../history/history.js', () => ({
+  addToHistory: hookHarness.addToHistory,
+}))
+
+vi.mock('../../utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => hookHarness.fullscreen,
+}))
+
+vi.mock('../../utils/modifiers.js', () => ({
+  isModifierPressed: (modifier: string) =>
+    hookHarness.modifiers[modifier] === true,
+  prewarmModifiers: hookHarness.prewarmModifiers,
+}))
+
+import { createRoot } from '../ink/root.js'
+import type { Key } from '../ink.js'
+import { useVimInput } from './useVimInput.js'
+
+type VimHookProps = Parameters<typeof useVimInput>[0]
+type VimHookState = ReturnType<typeof useVimInput>
+
+const BASE_KEY: Key = {
+  backspace: false,
+  ctrl: false,
+  delete: false,
+  downArrow: false,
+  end: false,
+  escape: false,
+  fn: false,
+  home: false,
+  leftArrow: false,
+  meta: false,
+  pageDown: false,
+  pageUp: false,
+  return: false,
+  rightArrow: false,
+  shift: false,
+  super: false,
+  tab: false,
+  upArrow: false,
+  wheelDown: false,
+  wheelUp: false,
+}
+
+function key(overrides: Partial<Key> = {}): Key {
+  return { ...BASE_KEY, ...overrides }
+}
+
+function createStreams(): {
+  readonly stdout: PassThrough
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 80
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderHookHarness(
+  overrides: Partial<VimHookProps> = {},
+): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly latest: () => VimHookState
+  readonly onChange: ReturnType<typeof vi.fn>
+  readonly onModeChange: ReturnType<typeof vi.fn>
+  readonly onOffsetChange: ReturnType<typeof vi.fn>
+  readonly render: (next?: Partial<VimHookProps>) => Promise<void>
+  readonly send: (input: string, inputKey?: Partial<Key>) => Promise<void>
+}> {
+  const onChange = vi.fn()
+  const onModeChange = vi.fn()
+  const onOffsetChange = vi.fn()
+  let props: VimHookProps = {
+    columns: 20,
+    cursorChar: '|',
+    externalOffset: overrides.value?.length ?? 0,
+    invert: text => text,
+    onChange,
+    onModeChange,
+    onOffsetChange,
+    themeText: text => text,
+    value: '',
+    ...overrides,
+  }
+  let latest: VimHookState | undefined
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    latest = useVimInput(props)
+    return null
+  }
+
+  async function render(next: Partial<VimHookProps> = {}): Promise<void> {
+    props = { ...props, ...next }
+    root.render(React.createElement(Harness))
+    await sleep()
+  }
+
+  await render()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+    onChange,
+    onModeChange,
+    onOffsetChange,
+    render,
+    send: async (input: string, inputKey: Partial<Key> = {}) => {
+      if (latest === undefined) throw new Error('hook did not render')
+      latest.onInput(input, key(inputKey))
+      await sleep()
+    },
+  }
+}
+
+describe('useVimInput coverage', () => {
+  beforeEach(() => {
+    hookHarness.reset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('runs the filter in every mode while routing NORMAL commands with raw input', async () => {
+    const inputFilter = vi.fn((input: string) =>
+      input === 'x' ? 'l' : input.toUpperCase(),
+    )
+    const rendered = await renderHookHarness({ inputFilter })
+
+    try {
+      await rendered.send('a')
+      await rendered.send('b')
+      expect(rendered.latest().value).toBe('AB')
+
+      await rendered.send('', { escape: true })
+      expect(rendered.latest().mode).toBe('NORMAL')
+      expect(rendered.latest().offset).toBe(1)
+      expect(rendered.onModeChange).toHaveBeenLastCalledWith('NORMAL')
+
+      await rendered.send('.')
+      expect(rendered.latest().value).toBe('AABB')
+      expect(rendered.latest().mode).toBe('NORMAL')
+
+      await rendered.send('r')
+      await rendered.send('', { escape: true })
+      await rendered.send('x')
+      expect(rendered.latest().value).toBe('AAB')
+
+      await rendered.send('.')
+      expect(rendered.latest().value).toBe('AA')
+
+      expect(inputFilter).toHaveBeenCalledWith('x', expect.any(Object))
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/hooks/useVimInput.wave200-062.coverage.test.ts
+++ b/runtime/tests/tui/hooks/useVimInput.wave200-062.coverage.test.ts
@@ -1,0 +1,235 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  addToHistory: vi.fn(),
+  fullscreen: false,
+  markBackslashReturnUsed: vi.fn(),
+  modifiers: {
+    shift: false,
+  } as Record<string, boolean>,
+  prewarmModifiers: vi.fn(),
+  removeNotification: vi.fn(),
+  reset() {
+    this.addNotification.mockClear()
+    this.addToHistory.mockClear()
+    this.fullscreen = false
+    this.markBackslashReturnUsed.mockClear()
+    this.modifiers = { shift: false }
+    this.prewarmModifiers.mockClear()
+    this.removeNotification.mockClear()
+  },
+}))
+
+vi.mock('../context/notifications.js', () => ({
+  useNotifications: () => ({
+    addNotification: harness.addNotification,
+    removeNotification: harness.removeNotification,
+  }),
+}))
+
+vi.mock('../../commands/terminalSetup/terminalSetup.js', () => ({
+  markBackslashReturnUsed: harness.markBackslashReturnUsed,
+}))
+
+vi.mock('../history/history.js', () => ({
+  addToHistory: harness.addToHistory,
+}))
+
+vi.mock('../../utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => harness.fullscreen,
+}))
+
+vi.mock('../../utils/modifiers.js', () => ({
+  isModifierPressed: (modifier: string) =>
+    harness.modifiers[modifier] === true,
+  prewarmModifiers: harness.prewarmModifiers,
+}))
+
+import { createRoot } from '../ink/root.js'
+import type { Key } from '../ink.js'
+import { useVimInput } from './useVimInput.js'
+
+type VimHookProps = Parameters<typeof useVimInput>[0]
+type VimHookState = ReturnType<typeof useVimInput>
+
+const BASE_KEY: Key = {
+  backspace: false,
+  ctrl: false,
+  delete: false,
+  downArrow: false,
+  end: false,
+  escape: false,
+  fn: false,
+  home: false,
+  leftArrow: false,
+  meta: false,
+  pageDown: false,
+  pageUp: false,
+  return: false,
+  rightArrow: false,
+  shift: false,
+  super: false,
+  tab: false,
+  upArrow: false,
+  wheelDown: false,
+  wheelUp: false,
+}
+
+function key(overrides: Partial<Key> = {}): Key {
+  return { ...BASE_KEY, ...overrides }
+}
+
+function createStreams(): {
+  readonly stdout: PassThrough
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 80
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderHookHarness(
+  overrides: Partial<VimHookProps> = {},
+): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly latest: () => VimHookState
+  readonly onChange: ReturnType<typeof vi.fn>
+  readonly onModeChange: ReturnType<typeof vi.fn>
+  readonly onOffsetChange: ReturnType<typeof vi.fn>
+  readonly render: (next?: Partial<VimHookProps>) => Promise<void>
+  readonly send: (input: string, inputKey?: Partial<Key>) => Promise<void>
+}> {
+  const onChange = vi.fn()
+  const onModeChange = vi.fn()
+  const onOffsetChange = vi.fn()
+  let props: VimHookProps = {
+    columns: 20,
+    cursorChar: '|',
+    externalOffset: overrides.value?.length ?? 0,
+    invert: text => text,
+    onChange,
+    onModeChange,
+    onOffsetChange,
+    themeText: text => text,
+    value: '',
+    ...overrides,
+  }
+  let latest: VimHookState | undefined
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    latest = useVimInput(props)
+    return null
+  }
+
+  async function render(next: Partial<VimHookProps> = {}): Promise<void> {
+    props = { ...props, ...next }
+    root.render(React.createElement(Harness))
+    await sleep()
+  }
+
+  await render()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+    onChange,
+    onModeChange,
+    onOffsetChange,
+    render,
+    send: async (input: string, inputKey: Partial<Key> = {}) => {
+      if (latest === undefined) throw new Error('hook did not render')
+      latest.onInput(input, key(inputKey))
+      await sleep()
+    },
+  }
+}
+
+describe('useVimInput wave200 coverage', () => {
+  beforeEach(() => {
+    harness.reset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('replays normal-mode edits after dot repeat and preserves mode transitions', async () => {
+    const rendered = await renderHookHarness({
+      externalOffset: 0,
+      value: 'abc def ghi',
+    })
+
+    try {
+      rendered.latest().setMode('NORMAL')
+      await sleep()
+
+      await rendered.send('.')
+      expect(rendered.latest().value).toBe('abc def ghi')
+
+      await rendered.send('f')
+      await rendered.send('d')
+      expect(rendered.latest().offset).toBe(4)
+
+      await rendered.send(';')
+      expect(rendered.latest().offset).toBe(4)
+
+      await rendered.send('d')
+      await rendered.send('w')
+      expect(rendered.latest().value).toBe('abc ghi')
+
+      await rendered.send('.')
+      expect(rendered.latest().value).toBe('abc ')
+
+      rendered.latest().setMode('INSERT')
+      await sleep()
+      expect(rendered.latest().mode).toBe('INSERT')
+      expect(rendered.onModeChange).toHaveBeenLastCalledWith('INSERT')
+
+      rendered.latest().setMode('NORMAL')
+      await sleep()
+      await rendered.send('A')
+      expect(rendered.latest().mode).toBe('INSERT')
+      expect(rendered.latest().offset).toBe(4)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/hooks/useVirtualScroll.test.tsx
+++ b/runtime/tests/tui/hooks/useVirtualScroll.test.tsx
@@ -1,0 +1,307 @@
+import { PassThrough } from "node:stream";
+
+import React, { useLayoutEffect } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createRoot } from "../ink/root.js";
+import type { ScrollBoxHandle } from "../ink/components/ScrollBox.js";
+import type { DOMElement } from "../ink/dom.js";
+import {
+  type VirtualScrollResult,
+  useVirtualScroll,
+} from "./useVirtualScroll.js";
+
+type FakeScrollHandle = ScrollBoxHandle & {
+  emit: () => void;
+  lastClamp: [number | undefined, number | undefined] | undefined;
+  scrollToCalls: number[];
+  setPendingDelta: (value: number) => void;
+  setScrollTop: (value: number) => void;
+  setSticky: (value: boolean) => void;
+  setViewportHeight: (value: number) => void;
+};
+
+function createScrollHandle(
+  overrides: {
+    pendingDelta?: number;
+    scrollTop?: number;
+    sticky?: boolean;
+    viewportHeight?: number;
+  } = {},
+): FakeScrollHandle {
+  let scrollTop = overrides.scrollTop ?? 0;
+  let pendingDelta = overrides.pendingDelta ?? 0;
+  let sticky = overrides.sticky ?? false;
+  let viewportHeight = overrides.viewportHeight ?? 20;
+  const listeners = new Set<() => void>();
+  const handle = {
+    emit: () => {
+      for (const listener of listeners) listener();
+    },
+    getPendingDelta: () => pendingDelta,
+    getScrollTop: () => scrollTop,
+    getViewportHeight: () => viewportHeight,
+    isSticky: () => sticky,
+    lastClamp: undefined as [number | undefined, number | undefined] | undefined,
+    scrollTo: vi.fn((value: number) => {
+      handle.scrollToCalls.push(value);
+      scrollTop = value;
+    }),
+    scrollToCalls: [] as number[],
+    setClampBounds: vi.fn((min?: number, max?: number) => {
+      handle.lastClamp = [min, max];
+    }),
+    setPendingDelta: (value: number) => {
+      pendingDelta = value;
+    },
+    setScrollTop: (value: number) => {
+      scrollTop = value;
+    },
+    setSticky: (value: boolean) => {
+      sticky = value;
+    },
+    setViewportHeight: (value: number) => {
+      viewportHeight = value;
+    },
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  } as FakeScrollHandle;
+  return handle;
+}
+
+function createStreams(): {
+  stdout: PassThrough;
+  stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+} {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.resume();
+  return { stdin, stdout };
+}
+
+function fakeElement(
+  height: number,
+  top: number,
+  width = 10,
+): DOMElement {
+  return {
+    yogaNode: {
+      getComputedHeight: () => height,
+      getComputedTop: () => top,
+      getComputedWidth: () => width,
+    },
+  } as DOMElement;
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function renderHookHarness(
+  initial: {
+    columns?: number;
+    itemKeys: readonly string[];
+    scrollRef: React.RefObject<ScrollBoxHandle | null>;
+  },
+): Promise<{
+  dispose: () => Promise<void>;
+  latest: () => VirtualScrollResult;
+  render: (next?: Partial<typeof initial>) => Promise<void>;
+}> {
+  let props = {
+    columns: 80,
+    ...initial,
+  };
+  let latest: VirtualScrollResult | undefined;
+  const { stdin, stdout } = createStreams();
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  function Harness(): null {
+    latest = useVirtualScroll(props.scrollRef, props.itemKeys, props.columns);
+    useLayoutEffect(() => {
+      latest = latest;
+    });
+    return null;
+  }
+
+  async function render(next: Partial<typeof initial> = {}): Promise<void> {
+    props = {
+      ...props,
+      ...next,
+    };
+    root.render(<Harness />);
+    await sleep();
+  }
+
+  await render();
+  return {
+    dispose: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    },
+    latest: () => {
+      if (!latest) throw new Error("hook did not render");
+      return latest;
+    },
+    render,
+  };
+}
+
+describe("useVirtualScroll", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("renders a tail range before the scrollbox is attached", async () => {
+    const harness = await renderHookHarness({
+      itemKeys: Array.from({ length: 40 }, (_, index) => `item-${index}`),
+      scrollRef: { current: null },
+    });
+
+    try {
+      expect(harness.latest().range).toEqual([10, 40]);
+      expect(harness.latest().topSpacer).toBe(30);
+      expect(harness.latest().bottomSpacer).toBe(0);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  test("uses sticky mode to mount the tail and clears clamp bounds", async () => {
+    const scroll = createScrollHandle({ sticky: true, viewportHeight: 20 });
+    const harness = await renderHookHarness({
+      itemKeys: Array.from({ length: 400 }, (_, index) => `item-${index}`),
+      scrollRef: { current: scroll },
+    });
+
+    try {
+      const result = harness.latest();
+      expect(result.range[1]).toBe(400);
+      expect(result.range[1] - result.range[0]).toBeLessThanOrEqual(300);
+      expect(result.topSpacer).toBeGreaterThan(0);
+      expect(scroll.setClampBounds).toHaveBeenLastCalledWith(undefined, undefined);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  test("computes a non-sticky range from committed and pending scroll", async () => {
+    const scroll = createScrollHandle({
+      pendingDelta: 240,
+      scrollTop: 600,
+      sticky: false,
+      viewportHeight: 20,
+    });
+    const harness = await renderHookHarness({
+      itemKeys: Array.from({ length: 500 }, (_, index) => `item-${index}`),
+      scrollRef: { current: scroll },
+    });
+
+    try {
+      const result = harness.latest();
+      expect(result.range[0]).toBeGreaterThan(0);
+      expect(result.range[1]).toBeGreaterThan(result.range[0]);
+      expect(result.range[1] - result.range[0]).toBeLessThanOrEqual(300);
+      expect(result.topSpacer).toBe(result.offsets[result.range[0]]);
+      expect(scroll.lastClamp?.[0]).toBe(result.topSpacer);
+      expect(scroll.lastClamp?.[1]).toBeGreaterThan(result.topSpacer);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  test("stores measured heights and scrolls to cached item offsets", async () => {
+    const scroll = createScrollHandle({
+      scrollTop: 0,
+      sticky: false,
+      viewportHeight: 20,
+    });
+    const harness = await renderHookHarness({
+      itemKeys: ["a", "b", "c"],
+      scrollRef: { current: scroll },
+    });
+
+    try {
+      harness.latest().measureRef("a")(fakeElement(5, 11));
+      harness.latest().measureRef("b")(fakeElement(7, 16));
+      harness.latest().spacerRef.current = fakeElement(0, 4);
+      await harness.render();
+      await harness.render();
+
+      const result = harness.latest();
+      expect(result.getItemTop(0)).toBe(11);
+      expect(result.getItemElement(1)).not.toBeNull();
+      expect(result.getItemHeight(0)).toBe(5);
+      expect(result.getItemHeight(1)).toBe(7);
+      expect(Array.from(result.offsets).slice(0, 4)).toEqual([0, 5, 12, 15]);
+
+      result.scrollToIndex(2);
+      expect(scroll.scrollToCalls).toEqual([16]);
+
+      result.measureRef("b")(null);
+      expect(result.getItemElement(1)).toBeNull();
+      expect(result.getItemHeight(1)).toBe(7);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
+  test("scales cached heights and freezes range across column changes", async () => {
+    const scroll = createScrollHandle({
+      scrollTop: 0,
+      sticky: false,
+      viewportHeight: 20,
+    });
+    const harness = await renderHookHarness({
+      columns: 100,
+      itemKeys: ["a", "b", "c", "d"],
+      scrollRef: { current: scroll },
+    });
+
+    try {
+      harness.latest().measureRef("a")(fakeElement(10, 0));
+      harness.latest().measureRef("b")(fakeElement(20, 10));
+      await harness.render();
+      await harness.render();
+      const beforeResize = harness.latest().range;
+      harness.latest().measureRef("a")(fakeElement(3, 0));
+
+      await harness.render({ columns: 50 });
+      const firstResize = harness.latest();
+      expect(firstResize.range).toEqual(beforeResize);
+      expect(firstResize.getItemHeight(0)).toBe(20);
+      expect(firstResize.getItemHeight(1)).toBe(40);
+
+      await harness.render();
+      expect(harness.latest().getItemHeight(0)).toBe(3);
+    } finally {
+      await harness.dispose();
+    }
+  });
+});

--- a/runtime/tests/tui/hooks/useVirtualScroll.wave200-095.coverage.test.tsx
+++ b/runtime/tests/tui/hooks/useVirtualScroll.wave200-095.coverage.test.tsx
@@ -1,0 +1,207 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../ink/root.js'
+import type { ScrollBoxHandle } from '../ink/components/ScrollBox.js'
+import type { DOMElement } from '../ink/dom.js'
+import {
+  type VirtualScrollResult,
+  useVirtualScroll,
+} from './useVirtualScroll.js'
+
+type FakeScrollHandle = ScrollBoxHandle & {
+  lastClamp: [number | undefined, number | undefined] | undefined
+  scrollToCalls: number[]
+  setScrollTop: (value: number) => void
+}
+
+function createScrollHandle(): FakeScrollHandle {
+  let scrollTop = 0
+  const listeners = new Set<() => void>()
+  const handle = {
+    getPendingDelta: () => 0,
+    getScrollTop: () => scrollTop,
+    getViewportHeight: () => 20,
+    isSticky: () => false,
+    lastClamp: undefined as [number | undefined, number | undefined] | undefined,
+    scrollTo: vi.fn((value: number) => {
+      handle.scrollToCalls.push(value)
+      scrollTop = value
+    }),
+    scrollToCalls: [] as number[],
+    setClampBounds: vi.fn((min?: number, max?: number) => {
+      handle.lastClamp = [min, max]
+    }),
+    setScrollTop: (value: number) => {
+      scrollTop = value
+    },
+    subscribe: (listener: () => void) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+  } as FakeScrollHandle
+  return handle
+}
+
+function createStreams(): {
+  readonly stdout: PassThrough
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+function fakeElement(height: number, top: number, width = 10): DOMElement {
+  return {
+    yogaNode: {
+      getComputedHeight: () => height,
+      getComputedTop: () => top,
+      getComputedWidth: () => width,
+    },
+  } as DOMElement
+}
+
+function unmeasuredElement(): DOMElement {
+  return {} as DOMElement
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderHookHarness(initial: {
+  itemKeys: readonly string[]
+  scrollRef: React.RefObject<ScrollBoxHandle | null>
+}): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly latest: () => VirtualScrollResult
+  readonly render: (next?: Partial<typeof initial>) => Promise<void>
+}> {
+  let props = initial
+  let latest: VirtualScrollResult | undefined
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    latest = useVirtualScroll(props.scrollRef, props.itemKeys, 80)
+    return null
+  }
+
+  async function render(next: Partial<typeof initial> = {}): Promise<void> {
+    props = { ...props, ...next }
+    root.render(<Harness />)
+    await sleep()
+  }
+
+  await render()
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+    render,
+  }
+}
+
+describe('useVirtualScroll wave200-095 coverage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('keeps unsafe mounted rows while sliding fast-scroll ranges and clearing stale refs', async () => {
+    const itemKeys = [
+      'stale',
+      'blocker',
+      'zero',
+      'final',
+      ...Array.from({ length: 796 }, (_, index) => `item-${index}`),
+    ]
+    const scroll = createScrollHandle()
+    const harness = await renderHookHarness({
+      itemKeys,
+      scrollRef: { current: scroll },
+    })
+
+    try {
+      const initial = harness.latest()
+      expect(initial.range[0]).toBe(0)
+
+      const staleRef = initial.measureRef('stale')
+      const blockerRef = initial.measureRef('blocker')
+      const finalRef = initial.measureRef('final')
+      staleRef(fakeElement(12, 0))
+      blockerRef(unmeasuredElement())
+      initial.measureRef('zero')(fakeElement(0, 12))
+      finalRef(fakeElement(9, 12))
+      finalRef(null)
+      expect(initial.getItemHeight(3)).toBe(9)
+
+      await harness.render()
+      expect(harness.latest().getItemHeight(0)).toBe(12)
+      expect(harness.latest().getItemHeight(1)).toBeUndefined()
+      expect(harness.latest().getItemHeight(2)).toBe(0)
+      expect(harness.latest().getItemTop(1)).toBe(-1)
+
+      scroll.setScrollTop(600)
+      await harness.render()
+      const blocked = harness.latest()
+      expect(blocked.range[0]).toBe(1)
+
+      const scrollToCallCount = scroll.scrollToCalls.length
+      blocked.scrollToIndex(-1)
+      blocked.scrollToIndex(itemKeys.length)
+      expect(scroll.scrollToCalls).toHaveLength(scrollToCallCount)
+
+      staleRef(null)
+      await harness.render({ itemKeys: itemKeys.slice(1) })
+      expect(harness.latest().measureRef('stale')).not.toBe(staleRef)
+
+      blockerRef(null)
+      scroll.setScrollTop(2400)
+      await harness.render()
+      const fastDown = harness.latest().range
+      expect(fastDown[0]).toBeGreaterThan(blocked.range[0])
+      expect(fastDown[1] - fastDown[0]).toBeLessThanOrEqual(300)
+
+      scroll.setScrollTop(0)
+      await harness.render()
+      const fastUp = harness.latest().range
+      expect(fastUp[0]).toBeLessThan(fastDown[0])
+      expect(fastUp[1] - fastUp[0]).toBeLessThanOrEqual(300)
+    } finally {
+      await harness.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/ink/Ansi.coverage.test.tsx
+++ b/runtime/tests/tui/ink/Ansi.coverage.test.tsx
@@ -1,0 +1,115 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { Ansi } from './Ansi.js'
+import type { DOMElement } from './dom.ts'
+import instances from './instances.ts'
+import { createRoot } from './root.ts'
+import { squashTextNodesToSegments } from './squash-text-nodes.js'
+
+vi.mock('../../utils/fullscreen.js', () => ({
+  isMouseClicksDisabled: () => false,
+}))
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  setRawMode: (mode: boolean) => void
+  ref: () => void
+  unref: () => void
+}
+
+function createTestStreams(): {
+  stdout: PassThrough
+  stdin: TestStdin
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStdin
+
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 80
+  ;(stdout as unknown as { rows: number }).rows = 24
+  ;(stdout as unknown as { isTTY: boolean }).isTTY = true
+
+  return { stdout, stdin }
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+  if (!instance?.rootNode) throw new Error('Ink root node not found')
+  return instance.rootNode
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+describe('Ansi coverage', () => {
+  test('renders ANSI styles, resets, and OSC 8 links as structured text segments', async () => {
+    const previousForceHyperlink = process.env.FORCE_HYPERLINK
+    process.env.FORCE_HYPERLINK = '1'
+
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    })
+
+    try {
+      root.render(
+        <Ansi>
+          {
+            'plain ' +
+            '\x1b[1;31mbold-red\x1b[22;39m ' +
+            '\x1b[3;4;9;7;38;5;202;48;2;10;20;30mstyled\x1b[0m ' +
+            '\x1b]8;;https://example.test/docs\x07linked\x1b]8;;\x07'
+          }
+        </Ansi>,
+      )
+      await sleep(25)
+
+      const segments = squashTextNodesToSegments(getRootNode(stdout))
+
+      expect(segments.map(segment => segment.text).join('')).toBe(
+        'plain bold-red styled linked',
+      )
+      expect(segments).toEqual([
+        { text: 'plain ', styles: {} },
+        { text: 'bold-red', styles: { bold: true, color: 'ansi:red' } },
+        { text: ' ', styles: {} },
+        {
+          text: 'styled',
+          styles: {
+            backgroundColor: 'rgb(10,20,30)',
+            color: 'ansi256(202)',
+            inverse: true,
+            italic: true,
+            strikethrough: true,
+            underline: true,
+          },
+        },
+        { text: ' ', styles: {} },
+        {
+          hyperlink: 'https://example.test/docs',
+          text: 'linked',
+          styles: {},
+        },
+      ])
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      if (previousForceHyperlink === undefined) {
+        delete process.env.FORCE_HYPERLINK
+      } else {
+        process.env.FORCE_HYPERLINK = previousForceHyperlink
+      }
+      await sleep(25)
+    }
+  })
+})

--- a/runtime/tests/tui/ink/Ansi.wave200-088.coverage.test.tsx
+++ b/runtime/tests/tui/ink/Ansi.wave200-088.coverage.test.tsx
@@ -1,0 +1,122 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { Ansi } from './Ansi.js'
+import type { DOMElement } from './dom.ts'
+import instances from './instances.ts'
+import { createRoot } from './root.ts'
+import { squashTextNodesToSegments } from './squash-text-nodes.js'
+
+vi.mock('../../utils/fullscreen.js', () => ({
+  isMouseClicksDisabled: () => false,
+}))
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  setRawMode: (mode: boolean) => void
+  ref: () => void
+  unref: () => void
+}
+
+function createTestStreams(): {
+  stdout: PassThrough
+  stdin: TestStdin
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStdin
+
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 80
+  ;(stdout as unknown as { rows: number }).rows = 24
+  ;(stdout as unknown as { isTTY: boolean }).isTTY = true
+
+  return { stdout, stdin }
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+  if (!instance?.rootNode) throw new Error('Ink root node not found')
+  return instance.rootNode
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+describe('Ansi wave200 coverage', () => {
+  test('renders coercion, empty parses, dim plain text, and dim styled links', async () => {
+    const previousForceHyperlink = process.env.FORCE_HYPERLINK
+    process.env.FORCE_HYPERLINK = '1'
+
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    })
+
+    const render = async (node: React.ReactNode) => {
+      root.render(node)
+      await sleep(25)
+      return squashTextNodesToSegments(getRootNode(stdout))
+    }
+
+    try {
+      await expect(
+        render(
+          React.createElement(
+            Ansi as unknown as React.ComponentType<{
+              children: unknown
+              dimColor?: boolean
+            }>,
+            { dimColor: true },
+            42,
+          ),
+        ),
+      ).resolves.toEqual([{ text: '42', styles: { dim: true } }])
+
+      await expect(render(<Ansi>{''}</Ansi>)).resolves.toEqual([])
+      await expect(render(<Ansi>{'\x1b[31m'}</Ansi>)).resolves.toEqual([])
+
+      await expect(render(<Ansi dimColor={true}>plain</Ansi>)).resolves.toEqual(
+        [{ text: 'plain', styles: { dim: true } }],
+      )
+
+      await expect(
+        render(
+          <Ansi dimColor={true}>
+            {
+              '\x1b]8;;https://example.test/ansi\x07' +
+              '\x1b[1;31mlink\x1b[22;39m' +
+              '\x1b]8;;\x07'
+            }
+          </Ansi>,
+        ),
+      ).resolves.toEqual([
+        {
+          hyperlink: 'https://example.test/ansi',
+          text: 'link',
+          styles: {
+            color: 'ansi:red',
+            dim: true,
+          },
+        },
+      ])
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      if (previousForceHyperlink === undefined) {
+        delete process.env.FORCE_HYPERLINK
+      } else {
+        process.env.FORCE_HYPERLINK = previousForceHyperlink
+      }
+      await sleep(25)
+    }
+  })
+})

--- a/runtime/tests/tui/ink/bidi.wave200-078.coverage.test.ts
+++ b/runtime/tests/tui/ink/bidi.wave200-078.coverage.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const originalEnv = { ...process.env }
+const originalPlatform = process.platform
+
+type TestClusteredChar = {
+  value: string
+  width: number
+  styleId: number
+  hyperlink: string | undefined
+}
+
+function char(value: string, styleId: number): TestClusteredChar {
+  return {
+    value,
+    width: 1,
+    styleId,
+    hyperlink: styleId % 2 === 0 ? `https://agenc.test/${styleId}` : undefined,
+  }
+}
+
+async function importFreshBidiModule() {
+  vi.resetModules()
+  return import('./bidi.ts')
+}
+
+describe('bidi wave200-078 coverage', () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    delete process.env['WT_SESSION']
+    process.env['TERM_PROGRAM'] = 'vscode'
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'linux',
+    })
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: originalPlatform,
+    })
+    vi.resetModules()
+  })
+
+  test('reorders RTL clusters only when software bidi is needed', async () => {
+    const { reorderBidi } = await importFreshBidiModule()
+
+    const empty: TestClusteredChar[] = []
+    expect(reorderBidi(empty)).toBe(empty)
+
+    const ltr = [char('a', 1), char('b', 2), char('c', 3)]
+    expect(reorderBidi(ltr)).toBe(ltr)
+
+    const mixed = [
+      char('a', 1),
+      char(' ', 2),
+      char('א', 3),
+      char('ב', 4),
+      char('ג', 5),
+      char(' ', 6),
+      char('b', 7),
+    ]
+
+    const reordered = reorderBidi(mixed)
+
+    expect(reordered).not.toBe(mixed)
+    expect(reordered.map(c => c.value).join('')).toBe('a גבא b')
+    expect(reordered.map(c => c.styleId)).toEqual([1, 2, 5, 4, 3, 6, 7])
+    expect(reordered.map(c => c.hyperlink)).toEqual([
+      undefined,
+      'https://agenc.test/2',
+      undefined,
+      'https://agenc.test/4',
+      undefined,
+      'https://agenc.test/6',
+      undefined,
+    ])
+
+    expect(
+      reorderBidi([char('x', 8), char('ش', 9), char('س', 10)]).map(
+        c => c.value,
+      ),
+    ).toEqual(['x', 'س', 'ش'])
+  })
+})

--- a/runtime/tests/tui/ink/clearTerminal.wave200-141.coverage.test.ts
+++ b/runtime/tests/tui/ink/clearTerminal.wave200-141.coverage.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+type ClearTerminalModule = typeof import('./clearTerminal.js')
+
+const CLEAR_MODERN = '\x1B[2J\x1B[3J\x1B[H'
+const CLEAR_WINDOWS_CLASSIC = '\x1B[2J\x1B[0f'
+
+const ENV_KEYS = [
+  'MSYSTEM',
+  'TERM_PROGRAM',
+  'TERM_PROGRAM_VERSION',
+  'WT_SESSION',
+] as const
+
+type EnvKey = (typeof ENV_KEYS)[number]
+type EnvOverrides = Partial<Record<EnvKey, string>>
+
+const originalEnv = new Map(ENV_KEYS.map(key => [key, process.env[key]]))
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+function restoreEnv(): void {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv.get(key)
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+function setEnv(overrides: EnvOverrides = {}): void {
+  for (const key of ENV_KEYS) {
+    delete process.env[key]
+  }
+
+  for (const [key, value] of Object.entries(overrides)) {
+    process.env[key as EnvKey] = value
+  }
+}
+
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    enumerable: true,
+    value,
+  })
+}
+
+async function loadClearTerminal(
+  platform: NodeJS.Platform,
+  env: EnvOverrides = {},
+): Promise<ClearTerminalModule> {
+  vi.resetModules()
+  setPlatform(platform)
+  setEnv(env)
+  return await import('./clearTerminal.js')
+}
+
+afterEach(() => {
+  restoreEnv()
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  }
+  vi.resetModules()
+})
+
+describe('clear terminal sequence detection', () => {
+  test('selects scrollback clearing only for terminals that support it', async () => {
+    const linux = await loadClearTerminal('linux')
+    expect(linux.getClearTerminalSequence()).toBe(CLEAR_MODERN)
+    expect(linux.clearTerminal).toBe(CLEAR_MODERN)
+
+    const classicWindows = await loadClearTerminal('win32')
+    expect(classicWindows.getClearTerminalSequence()).toBe(
+      CLEAR_WINDOWS_CLASSIC,
+    )
+    expect(classicWindows.clearTerminal).toBe(CLEAR_WINDOWS_CLASSIC)
+
+    const windowsTerminal = await loadClearTerminal('win32', {
+      WT_SESSION: 'session',
+    })
+    expect(windowsTerminal.getClearTerminalSequence()).toBe(CLEAR_MODERN)
+    expect(windowsTerminal.clearTerminal).toBe(CLEAR_MODERN)
+
+    const vscodeConpty = await loadClearTerminal('win32', {
+      TERM_PROGRAM: 'vscode',
+      TERM_PROGRAM_VERSION: '1.90.0',
+    })
+    expect(vscodeConpty.getClearTerminalSequence()).toBe(CLEAR_MODERN)
+
+    const vscodeWithoutVersion = await loadClearTerminal('win32', {
+      TERM_PROGRAM: 'vscode',
+    })
+    expect(vscodeWithoutVersion.getClearTerminalSequence()).toBe(
+      CLEAR_WINDOWS_CLASSIC,
+    )
+
+    const minttyByProgram = await loadClearTerminal('win32', {
+      TERM_PROGRAM: 'mintty',
+    })
+    expect(minttyByProgram.getClearTerminalSequence()).toBe(CLEAR_MODERN)
+
+    const minttyByMsystem = await loadClearTerminal('win32', {
+      MSYSTEM: 'MINGW64',
+    })
+    expect(minttyByMsystem.getClearTerminalSequence()).toBe(CLEAR_MODERN)
+  })
+})

--- a/runtime/tests/tui/ink/colorize.wave200-077.coverage.test.ts
+++ b/runtime/tests/tui/ink/colorize.wave200-077.coverage.test.ts
@@ -1,0 +1,162 @@
+import chalk from 'chalk'
+import stripAnsi from 'strip-ansi'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+type ColorizeModule = typeof import('./colorize.js')
+
+const ORIGINAL_ENV = {
+  AGENC_TMUX_TRUECOLOR: process.env.AGENC_TMUX_TRUECOLOR,
+  TERM_PROGRAM: process.env.TERM_PROGRAM,
+  TMUX: process.env.TMUX,
+}
+const ORIGINAL_CHALK_LEVEL = chalk.level
+
+function restoreEnv(name: keyof typeof ORIGINAL_ENV): void {
+  const value = ORIGINAL_ENV[name]
+  if (value === undefined) {
+    delete process.env[name]
+  } else {
+    process.env[name] = value
+  }
+}
+
+async function loadColorize(): Promise<ColorizeModule> {
+  vi.resetModules()
+  return await import('./colorize.js')
+}
+
+describe('colorize coverage', () => {
+  afterEach(() => {
+    restoreEnv('AGENC_TMUX_TRUECOLOR')
+    restoreEnv('TERM_PROGRAM')
+    restoreEnv('TMUX')
+    chalk.level = ORIGINAL_CHALK_LEVEL
+    vi.resetModules()
+  })
+
+  test('applies every supported raw color format for foreground and background output', async () => {
+    delete process.env.AGENC_TMUX_TRUECOLOR
+    delete process.env.TERM_PROGRAM
+    delete process.env.TMUX
+    chalk.level = 3
+
+    const { applyColor, applyTextStyles, colorize } = await loadColorize()
+
+    expect(colorize('sample', undefined, 'foreground')).toBe('sample')
+    expect(colorize('sample', 'ansi:not-a-real-color', 'foreground')).toBe(
+      'sample',
+    )
+    expect(colorize('sample', 'ansi256(nope)', 'foreground')).toBe('sample')
+    expect(colorize('sample', 'rgb(1,2)', 'background')).toBe('sample')
+    expect(colorize('sample', 'named-color', 'foreground')).toBe('sample')
+
+    const ansiColors: Array<{
+      readonly name: string
+      readonly foreground: number
+      readonly background: number
+    }> = [
+      { name: 'black', foreground: 30, background: 40 },
+      { name: 'red', foreground: 31, background: 41 },
+      { name: 'green', foreground: 32, background: 42 },
+      { name: 'yellow', foreground: 33, background: 43 },
+      { name: 'blue', foreground: 34, background: 44 },
+      { name: 'magenta', foreground: 35, background: 45 },
+      { name: 'cyan', foreground: 36, background: 46 },
+      { name: 'white', foreground: 37, background: 47 },
+      { name: 'blackBright', foreground: 90, background: 100 },
+      { name: 'redBright', foreground: 91, background: 101 },
+      { name: 'greenBright', foreground: 92, background: 102 },
+      { name: 'yellowBright', foreground: 93, background: 103 },
+      { name: 'blueBright', foreground: 94, background: 104 },
+      { name: 'magentaBright', foreground: 95, background: 105 },
+      { name: 'cyanBright', foreground: 96, background: 106 },
+      { name: 'whiteBright', foreground: 97, background: 107 },
+    ]
+
+    for (const { name, foreground, background } of ansiColors) {
+      expect(colorize('x', `ansi:${name}`, 'foreground')).toBe(
+        `\x1B[${foreground}mx\x1B[39m`,
+      )
+      expect(colorize('x', `ansi:${name}`, 'background')).toBe(
+        `\x1B[${background}mx\x1B[49m`,
+      )
+    }
+
+    expect(colorize('x', '#010203', 'foreground')).toBe(
+      '\x1B[38;2;1;2;3mx\x1B[39m',
+    )
+    expect(colorize('x', '#010203', 'background')).toBe(
+      '\x1B[48;2;1;2;3mx\x1B[49m',
+    )
+    expect(colorize('x', 'ansi256(202)', 'foreground')).toBe(
+      '\x1B[38;5;202mx\x1B[39m',
+    )
+    expect(colorize('x', 'ansi256(202)', 'background')).toBe(
+      '\x1B[48;5;202mx\x1B[49m',
+    )
+    expect(colorize('x', 'rgb(4, 5, 6)', 'foreground')).toBe(
+      '\x1B[38;2;4;5;6mx\x1B[39m',
+    )
+    expect(colorize('x', 'rgb(4, 5, 6)', 'background')).toBe(
+      '\x1B[48;2;4;5;6mx\x1B[49m',
+    )
+
+    expect(applyColor('plain', undefined)).toBe('plain')
+
+    const styled = applyTextStyles('decorated', {
+      backgroundColor: 'ansi256(45)',
+      bold: true,
+      color: 'rgb(7,8,9)',
+      dim: true,
+      inverse: true,
+      italic: true,
+      strikethrough: true,
+      underline: true,
+    })
+
+    expect(stripAnsi(styled)).toBe('decorated')
+    expect(styled).toContain('\x1B[48;5;45m')
+    expect(styled).toContain('\x1B[38;2;7;8;9m')
+    expect(styled).toContain('\x1B[1m')
+    expect(styled).toContain('\x1B[2m')
+    expect(styled).toContain('\x1B[3m')
+    expect(styled).toContain('\x1B[4m')
+    expect(styled).toContain('\x1B[7m')
+    expect(styled).toContain('\x1B[9m')
+  })
+
+  test('adjusts chalk color level for xterm.js and tmux module-load environments', async () => {
+    delete process.env.AGENC_TMUX_TRUECOLOR
+    process.env.TERM_PROGRAM = 'vscode'
+    delete process.env.TMUX
+    chalk.level = 2
+
+    const xtermJs = await loadColorize()
+
+    expect(xtermJs.CHALK_BOOSTED_FOR_XTERMJS).toBe(true)
+    expect(xtermJs.CHALK_CLAMPED_FOR_TMUX).toBe(false)
+    expect(chalk.level).toBe(3)
+
+    delete process.env.AGENC_TMUX_TRUECOLOR
+    process.env.TERM_PROGRAM = 'vscode'
+    process.env.TMUX = '/tmp/tmux-1000/default,1,0'
+    chalk.level = 2
+
+    const tmuxInsideXtermJs = await loadColorize()
+
+    expect(tmuxInsideXtermJs.CHALK_BOOSTED_FOR_XTERMJS).toBe(true)
+    expect(tmuxInsideXtermJs.CHALK_CLAMPED_FOR_TMUX).toBe(true)
+    expect(chalk.level).toBe(2)
+
+    process.env.AGENC_TMUX_TRUECOLOR = '1'
+    delete process.env.TERM_PROGRAM
+    process.env.TMUX = '/tmp/tmux-1000/default,1,0'
+    chalk.level = 3
+
+    const truecolorTmux = await loadColorize()
+
+    expect(truecolorTmux.CHALK_BOOSTED_FOR_XTERMJS).toBe(false)
+    expect(truecolorTmux.CHALK_CLAMPED_FOR_TMUX).toBe(false)
+    expect(chalk.level).toBe(3)
+  })
+})

--- a/runtime/tests/tui/ink/components/AlternateScreen.wave200-098.coverage.test.tsx
+++ b/runtime/tests/tui/ink/components/AlternateScreen.wave200-098.coverage.test.tsx
@@ -1,0 +1,164 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { AlternateScreen } from './AlternateScreen.js'
+import Text from './Text.js'
+import { TerminalSizeContext } from './TerminalSizeContext.js'
+import type { DOMElement } from '../dom.ts'
+import {
+  deleteInkInstance,
+  getInkInstance,
+  setInkInstance,
+} from '../instances.js'
+import { createRoot } from '../root.js'
+import {
+  DISABLE_MOUSE_TRACKING,
+  ENABLE_MOUSE_TRACKING,
+  ENTER_ALT_SCREEN,
+  EXIT_ALT_SCREEN,
+} from '../termio/dec.js'
+import { TerminalWriteProvider } from '../useTerminalNotification.js'
+
+type TestStdout = PassThrough & {
+  columns: number
+  rows: number
+  isTTY: boolean
+}
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+}
+
+function createTestStreams(): {
+  stdout: TestStdout
+  stdin: TestStdin
+} {
+  const stdout = new PassThrough() as TestStdout
+  const stdin = new PassThrough() as TestStdin
+
+  stdout.columns = 80
+  stdout.rows = 24
+  stdout.isTTY = false
+  stdout.resume()
+  stdin.isTTY = false
+
+  return { stdout, stdin }
+}
+
+function findAltScreenBox(node: DOMElement): DOMElement | undefined {
+  if (
+    node.nodeName === 'ink-box' &&
+    node.style.flexDirection === 'column' &&
+    node.style.height === 7 &&
+    node.style.width === '100%'
+  ) {
+    return node
+  }
+
+  for (const child of node.childNodes) {
+    if (child.nodeName === '#text') continue
+    const found = findAltScreenBox(child)
+    if (found) return found
+  }
+
+  return undefined
+}
+
+function getRootNode(stdout: TestStdout): DOMElement {
+  const instance = getInkInstance(stdout as unknown as NodeJS.WriteStream)
+  if (!instance?.rootNode) throw new Error('Ink root node not found')
+  return instance.rootNode
+}
+
+function renderHarness(mouseTracking: boolean | undefined, writeRaw: (data: string) => void) {
+  return (
+    <TerminalWriteProvider value={writeRaw}>
+      <TerminalSizeContext.Provider value={{ columns: 80, rows: 7 }}>
+        <AlternateScreen mouseTracking={mouseTracking}>
+          <Text>fullscreen body</Text>
+        </AlternateScreen>
+      </TerminalSizeContext.Provider>
+    </TerminalWriteProvider>
+  )
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+describe('AlternateScreen coverage', () => {
+  test('enters, updates, and exits the alternate screen with viewport-bounded layout', async () => {
+    const previousProcessStdoutInk = getInkInstance(process.stdout)
+    const fakeInk = {
+      clearTextSelection: vi.fn(),
+      setAltScreenActive: vi.fn(),
+    }
+    const writeRaw = vi.fn()
+    const { stdout, stdin } = createTestStreams()
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    })
+    let mounted = true
+
+    setInkInstance(process.stdout, fakeInk as never)
+
+    try {
+      root.render(renderHarness(undefined, writeRaw))
+
+      expect(writeRaw).toHaveBeenCalledWith(
+        `${ENTER_ALT_SCREEN}\x1B[2J\x1B[H${ENABLE_MOUSE_TRACKING}`,
+      )
+      expect(fakeInk.setAltScreenActive).toHaveBeenCalledWith(true, true)
+      expect(findAltScreenBox(getRootNode(stdout))?.style).toMatchObject({
+        flexDirection: 'column',
+        flexShrink: 0,
+        height: 7,
+        width: '100%',
+      })
+
+      root.render(renderHarness(false, writeRaw))
+
+      expect(writeRaw.mock.calls.map(([value]) => value)).toEqual([
+        `${ENTER_ALT_SCREEN}\x1B[2J\x1B[H${ENABLE_MOUSE_TRACKING}`,
+        `${DISABLE_MOUSE_TRACKING}${EXIT_ALT_SCREEN}`,
+        `${ENTER_ALT_SCREEN}\x1B[2J\x1B[H`,
+      ])
+      expect(fakeInk.setAltScreenActive.mock.calls).toEqual([
+        [true, true],
+        [false],
+        [true, false],
+      ])
+      expect(fakeInk.clearTextSelection).toHaveBeenCalledTimes(1)
+
+      root.unmount()
+      mounted = false
+
+      expect(writeRaw.mock.calls.map(([value]) => value)).toEqual([
+        `${ENTER_ALT_SCREEN}\x1B[2J\x1B[H${ENABLE_MOUSE_TRACKING}`,
+        `${DISABLE_MOUSE_TRACKING}${EXIT_ALT_SCREEN}`,
+        `${ENTER_ALT_SCREEN}\x1B[2J\x1B[H`,
+        EXIT_ALT_SCREEN,
+      ])
+      expect(fakeInk.setAltScreenActive.mock.calls).toEqual([
+        [true, true],
+        [false],
+        [true, false],
+        [false],
+      ])
+      expect(fakeInk.clearTextSelection).toHaveBeenCalledTimes(2)
+    } finally {
+      if (mounted) root.unmount()
+      stdin.end()
+      stdout.end()
+      deleteInkInstance(process.stdout)
+      if (previousProcessStdoutInk) {
+        setInkInstance(process.stdout, previousProcessStdoutInk)
+      }
+      await sleep(25)
+    }
+  })
+})

--- a/runtime/tests/tui/ink/components/App.coverage2.test.tsx
+++ b/runtime/tests/tui/ink/components/App.coverage2.test.tsx
@@ -1,0 +1,83 @@
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import App, { handleMouseEvent } from "./App.js";
+import type { ParsedMouse } from "../parse-keypress.js";
+import { createSelectionState } from "../selection.js";
+
+function stream() {
+  const s = new PassThrough() as NodeJS.WriteStream & NodeJS.ReadStream;
+  s.isTTY = false;
+  s.write = vi.fn(() => true) as never;
+  return s;
+}
+
+function mouse(action: ParsedMouse["action"], button: number): ParsedMouse {
+  return {
+    action,
+    button,
+    col: 5,
+    kind: "mouse",
+    row: 7,
+    sequence: `mouse:${action}:${button}`,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllEnvs();
+});
+
+describe("Ink App mouse coverage", () => {
+  test("cancels a pending hyperlink open when a second nearby press becomes a multi-click", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    vi.stubEnv("TERM_PROGRAM", "");
+
+    const selection = createSelectionState();
+    const onSelectionChange = vi.fn();
+    const onOpenHyperlink = vi.fn();
+    const onMultiClick = vi.fn();
+    const onClickAt = vi.fn(() => false);
+    const getHyperlinkAt = vi.fn(() => "https://agenc.test/item");
+    const app = new App({
+      children: null,
+      stdin: stream(),
+      stdout: stream(),
+      stderr: stream(),
+      exitOnCtrlC: true,
+      onExit: () => {},
+      terminalColumns: 80,
+      terminalRows: 24,
+      selection,
+      onSelectionChange,
+      onClickAt,
+      onHoverAt: () => {},
+      getHyperlinkAt,
+      onOpenHyperlink,
+      onMultiClick,
+      onSelectionDrag: () => {},
+      dispatchKeyboardEvent: () => {},
+    });
+
+    handleMouseEvent(app, mouse("press", 0));
+    handleMouseEvent(app, mouse("release", 0));
+
+    expect(onClickAt).toHaveBeenCalledWith(4, 6);
+    expect(getHyperlinkAt).toHaveBeenCalledWith(4, 6);
+    expect(onOpenHyperlink).not.toHaveBeenCalled();
+    expect(app.pendingHyperlinkTimer).not.toBeNull();
+
+    vi.advanceTimersByTime(499);
+    vi.setSystemTime(1_499);
+
+    handleMouseEvent(app, mouse("press", 0));
+
+    expect(app.pendingHyperlinkTimer).toBeNull();
+    expect(onMultiClick).toHaveBeenCalledWith(4, 6, 2);
+
+    vi.advanceTimersByTime(1);
+    expect(onOpenHyperlink).not.toHaveBeenCalled();
+    expect(onSelectionChange).toHaveBeenCalledTimes(2);
+  });
+});

--- a/runtime/tests/tui/ink/components/App.wave200-011.coverage.test.tsx
+++ b/runtime/tests/tui/ink/components/App.wave200-011.coverage.test.tsx
@@ -1,0 +1,71 @@
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import App from "./App.js";
+import { createSelectionState } from "../selection.js";
+
+type TestStream = NodeJS.ReadStream & NodeJS.WriteStream;
+
+function stream(): TestStream {
+  const s = new PassThrough() as TestStream;
+  s.isTTY = false;
+  s.write = vi.fn(() => true) as never;
+  return s;
+}
+
+function appProps(overrides: Partial<ConstructorParameters<typeof App>[0]> = {}): ConstructorParameters<typeof App>[0] {
+  return {
+    children: null,
+    stdin: stream(),
+    stdout: stream(),
+    stderr: stream(),
+    exitOnCtrlC: true,
+    onExit: () => {},
+    terminalColumns: 80,
+    terminalRows: 24,
+    selection: createSelectionState(),
+    onSelectionChange: () => {},
+    onClickAt: () => false,
+    onHoverAt: () => {},
+    getHyperlinkAt: () => undefined,
+    onOpenHyperlink: () => {},
+    onMultiClick: () => {},
+    onSelectionDrag: () => {},
+    dispatchKeyboardEvent: () => {},
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("Ink App stdin recovery coverage", () => {
+  test("reattaches the data listener when processing a resumed stdin chunk throws", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(6_001);
+    vi.stubEnv("DISABLE_ERROR_REPORTING", "1");
+
+    const stdin = stream();
+    const onStdinResume = vi.fn();
+    const app = new App(appProps({ stdin, onStdinResume }));
+    const error = new Error("parser failed");
+
+    app.rawModeEnabledCount = 1;
+    app.lastStdinTime = 1_000;
+    vi.spyOn(app, "processInput").mockImplementation(() => {
+      throw error;
+    });
+
+    expect(stdin.listeners("data")).not.toContain(app.handleDataChunk);
+
+    app.handleDataChunk("input");
+
+    expect(onStdinResume).toHaveBeenCalledOnce();
+    expect(app.lastStdinTime).toBe(6_001);
+    expect(app.processInput).toHaveBeenCalledWith("input");
+    expect(stdin.listeners("data")).toContain(app.handleDataChunk);
+  });
+});

--- a/runtime/tests/tui/ink/components/ClockContext.wave200-110.coverage.test.tsx
+++ b/runtime/tests/tui/ink/components/ClockContext.wave200-110.coverage.test.tsx
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { createClock } from './ClockContext.js'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('ClockContext clock coverage', () => {
+  test('ticks only while keep-alive subscribers are present and returns live time when paused', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+
+    const clock = createClock(20)
+    const passiveTicks: number[] = []
+    const activeTicks: number[] = []
+
+    const unsubscribePassive = clock.subscribe(() => {
+      passiveTicks.push(clock.now())
+    }, false)
+
+    expect(clock.now()).toBe(0)
+
+    vi.advanceTimersByTime(40)
+
+    expect(passiveTicks).toEqual([])
+    expect(clock.now()).toBe(40)
+
+    const unsubscribeActive = clock.subscribe(() => {
+      activeTicks.push(clock.now())
+    }, true)
+
+    vi.advanceTimersByTime(20)
+
+    expect(passiveTicks).toEqual([60])
+    expect(activeTicks).toEqual([60])
+    expect(clock.now()).toBe(60)
+
+    clock.setTickInterval(20)
+    vi.advanceTimersByTime(20)
+
+    expect(passiveTicks).toEqual([60, 80])
+    expect(activeTicks).toEqual([60, 80])
+
+    clock.setTickInterval(5)
+    vi.advanceTimersByTime(4)
+
+    expect(activeTicks).toEqual([60, 80])
+
+    vi.advanceTimersByTime(1)
+
+    expect(passiveTicks).toEqual([60, 80, 85])
+    expect(activeTicks).toEqual([60, 80, 85])
+
+    unsubscribeActive()
+    vi.advanceTimersByTime(10)
+
+    expect(passiveTicks).toEqual([60, 80, 85])
+    expect(activeTicks).toEqual([60, 80, 85])
+    expect(clock.now()).toBe(95)
+
+    unsubscribePassive()
+    vi.advanceTimersByTime(5)
+
+    expect(clock.now()).toBe(100)
+  })
+})

--- a/runtime/tests/tui/ink/components/ScrollBox.coverage.test.tsx
+++ b/runtime/tests/tui/ink/components/ScrollBox.coverage.test.tsx
@@ -1,0 +1,215 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { describe, expect, test, vi } from "vitest";
+
+import type { DOMElement } from "../dom.js";
+import instances from "../instances.js";
+import { createRoot } from "../root.js";
+import ScrollBox, { type ScrollBoxHandle } from "./ScrollBox.js";
+import Text from "./Text.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+function createTestStreams(): {
+  stdin: TestStdin;
+  stdout: PassThrough;
+} {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.resume();
+  (stdout as unknown as { columns: number }).columns = 80;
+  (stdout as unknown as { rows: number }).rows = 24;
+  (stdout as unknown as { isTTY: boolean }).isTTY = true;
+
+  return { stdin, stdout };
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream);
+  if (!instance?.rootNode) throw new Error("Ink root node not found");
+  return instance.rootNode;
+}
+
+function findScrollBox(node: DOMElement): DOMElement | null {
+  if (
+    node.nodeName === "ink-box" &&
+    node.style.overflowX === "scroll" &&
+    node.style.overflowY === "scroll"
+  ) {
+    return node;
+  }
+
+  for (const child of node.childNodes) {
+    if (child.nodeName === "#text") continue;
+    const found = findScrollBox(child);
+    if (found) return found;
+  }
+
+  return null;
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await new Promise<void>(resolve => queueMicrotask(resolve));
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await sleep(10);
+  }
+
+  throw new Error(message);
+}
+
+describe("ScrollBox imperative handle", () => {
+  test("mutates DOM scroll state, notifies subscribers, and exposes viewport getters", async () => {
+    const ref = React.createRef<ScrollBoxHandle>();
+    const { stdin, stdout } = createTestStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+    let mounted = true;
+
+    try {
+      root.render(
+        <ScrollBox ref={ref} height={4}>
+          <Text>scrollable content</Text>
+        </ScrollBox>,
+      );
+
+      await waitForCondition(
+        () => ref.current !== null && findScrollBox(getRootNode(stdout)) !== null,
+        "ScrollBox did not mount",
+      );
+
+      const handle = ref.current;
+      if (!handle) throw new Error("ScrollBox handle not attached");
+
+      const scrollBox = findScrollBox(getRootNode(stdout));
+      if (!scrollBox) throw new Error("ScrollBox DOM node not found");
+
+      const render = vi.fn();
+      getRootNode(stdout).onRender = render;
+
+      expect(scrollBox.scrollTop).toBe(0);
+      expect(scrollBox.style.flexDirection).toBe("row");
+      expect(scrollBox.style.flexGrow).toBe(0);
+      expect(scrollBox.style.flexShrink).toBe(1);
+      expect(handle.isSticky()).toBe(false);
+
+      scrollBox.scrollHeight = 31;
+      scrollBox.scrollViewportHeight = 4;
+      scrollBox.scrollViewportTop = 9;
+
+      const content = scrollBox.childNodes[0] as DOMElement | undefined;
+      if (!content) throw new Error("ScrollBox content wrapper not found");
+      content.yogaNode = {
+        getComputedHeight: () => 37,
+      } as DOMElement["yogaNode"];
+
+      expect(handle.getScrollHeight()).toBe(31);
+      expect(handle.getFreshScrollHeight()).toBe(37);
+      content.yogaNode = undefined;
+      expect(handle.getFreshScrollHeight()).toBe(31);
+      expect(handle.getViewportHeight()).toBe(4);
+      expect(handle.getViewportTop()).toBe(9);
+
+      const notifications: string[] = [];
+      const unsubscribe = handle.subscribe(() => notifications.push("scroll"));
+
+      scrollBox.attributes.stickyScroll = true;
+      expect(handle.isSticky()).toBe(true);
+
+      handle.scrollTo(6.9);
+      expect(scrollBox.stickyScroll).toBe(false);
+      expect(scrollBox.scrollTop).toBe(6);
+      expect(scrollBox.pendingScrollDelta).toBeUndefined();
+      expect(scrollBox.scrollAnchor).toBeUndefined();
+      expect(handle.isSticky()).toBe(false);
+      expect(notifications).toHaveLength(1);
+      await flushMicrotasks();
+      expect(render).toHaveBeenCalledTimes(1);
+
+      handle.scrollBy(2.8);
+      handle.scrollBy(1.2);
+      expect(scrollBox.pendingScrollDelta).toBe(3);
+      expect(notifications).toHaveLength(3);
+      await flushMicrotasks();
+      expect(render).toHaveBeenCalledTimes(2);
+
+      const anchor = {
+        yogaNode: {
+          getComputedTop: () => 18,
+        },
+      } as DOMElement;
+      handle.scrollToElement(anchor);
+      expect(scrollBox.stickyScroll).toBe(false);
+      expect(scrollBox.pendingScrollDelta).toBeUndefined();
+      expect(scrollBox.scrollAnchor).toEqual({ el: anchor, offset: 0 });
+      expect(notifications).toHaveLength(4);
+      await flushMicrotasks();
+      expect(render).toHaveBeenCalledTimes(3);
+
+      handle.scrollToBottom();
+      expect(scrollBox.pendingScrollDelta).toBeUndefined();
+      expect(scrollBox.stickyScroll).toBe(true);
+      expect(handle.isSticky()).toBe(true);
+      expect(notifications).toHaveLength(5);
+
+      handle.setClampBounds(4, 12);
+      expect(scrollBox.scrollClampMin).toBe(4);
+      expect(scrollBox.scrollClampMax).toBe(12);
+
+      unsubscribe();
+      handle.scrollBy(5);
+      expect(notifications).toHaveLength(5);
+      await flushMicrotasks();
+      expect(render).toHaveBeenCalledTimes(4);
+
+      root.unmount();
+      mounted = false;
+      await sleep();
+
+      expect(handle.getScrollTop()).toBe(0);
+      expect(handle.getPendingDelta()).toBe(0);
+      expect(handle.getScrollHeight()).toBe(0);
+      expect(handle.getFreshScrollHeight()).toBe(0);
+      expect(handle.getViewportHeight()).toBe(0);
+      expect(handle.getViewportTop()).toBe(0);
+      expect(handle.isSticky()).toBe(false);
+      expect(() => handle.scrollTo(1)).not.toThrow();
+      expect(() => handle.scrollBy(1)).not.toThrow();
+      expect(() => handle.scrollToElement(anchor)).not.toThrow();
+      expect(() => handle.scrollToBottom()).not.toThrow();
+      expect(() => handle.setClampBounds(undefined, undefined)).not.toThrow();
+    } finally {
+      if (mounted) root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+});

--- a/runtime/tests/tui/ink/components/context-hooks.test.tsx
+++ b/runtime/tests/tui/ink/components/context-hooks.test.tsx
@@ -1,0 +1,86 @@
+import React, { useContext } from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { renderToString } from '../../../utils/staticRender.js'
+import AppContext, { useApp, type Props as AppContextProps } from './AppContext.js'
+import CursorDeclarationContext, {
+  type CursorDeclarationSetter,
+} from './CursorDeclarationContext.js'
+import StdinContext, {
+  useStdin,
+  type Props as StdinContextProps,
+} from './StdinContext.js'
+import Text from './Text.js'
+
+function getDefaultContextValue<T>(context: unknown): T {
+  const value = context as { _currentValue?: T; _currentValue2?: T }
+  const current = value._currentValue ?? value._currentValue2
+  if (current === undefined) throw new Error('missing context default value')
+  return current
+}
+
+describe('Ink context hooks', () => {
+  test('returns and exercises the default app context', async () => {
+    let captured: AppContextProps | undefined
+    const defaultValue = getDefaultContextValue<AppContextProps>(AppContext)
+
+    function Probe() {
+      captured = useApp()
+      return <Text>app</Text>
+    }
+
+    const output = await renderToString(<Probe />, 20)
+
+    expect(output).toContain('app')
+    expect(AppContext.displayName).toBe('InternalAppContext')
+    expect(captured).toBeDefined()
+    expect(() => captured?.exit()).not.toThrow()
+    expect(() => defaultValue.exit(new Error('ignored'))).not.toThrow()
+  })
+
+  test('returns and exercises the default stdin context', async () => {
+    let captured: StdinContextProps | undefined
+    const defaultValue = getDefaultContextValue<StdinContextProps>(StdinContext)
+
+    function Probe() {
+      captured = useStdin()
+      return <Text>stdin</Text>
+    }
+
+    const output = await renderToString(<Probe />, 20)
+
+    expect(output).toContain('stdin')
+    expect(StdinContext.displayName).toBe('InternalStdinContext')
+    expect(captured).toBeDefined()
+    expect(defaultValue.stdin).toBe(process.stdin)
+    expect(defaultValue.isRawModeSupported).toBe(false)
+    expect(defaultValue.internal_exitOnCtrlC).toBe(true)
+    expect(defaultValue.internal_querier).toBeNull()
+    expect(defaultValue.internal_eventEmitter).toBeDefined()
+    expect(() => defaultValue.setRawMode(true)).not.toThrow()
+  })
+
+  test('uses the default cursor declaration setter as a no-op', async () => {
+    let setCursorDeclaration: CursorDeclarationSetter | undefined
+    const defaultValue =
+      getDefaultContextValue<CursorDeclarationSetter>(CursorDeclarationContext)
+
+    function Probe() {
+      setCursorDeclaration = useContext(CursorDeclarationContext)
+      return <Text>cursor</Text>
+    }
+
+    const output = await renderToString(<Probe />, 20)
+
+    expect(output).toContain('cursor')
+    expect(setCursorDeclaration).toBeDefined()
+    expect(() => setCursorDeclaration?.(null)).not.toThrow()
+    expect(() =>
+      defaultValue({
+        node: {} as never,
+        relativeX: 1,
+        relativeY: 2,
+      }),
+    ).not.toThrow()
+  })
+})

--- a/runtime/tests/tui/ink/dom.wave200-091.coverage.test.ts
+++ b/runtime/tests/tui/ink/dom.wave200-091.coverage.test.ts
@@ -1,0 +1,159 @@
+import { expect, test, vi } from 'vitest'
+
+import {
+  appendChildNode,
+  createNode,
+  createTextNode,
+  findOwnerChainAtRow,
+  insertBeforeNode,
+  removeChildNode,
+  scheduleRenderFrom,
+  setAttribute,
+  setStyle,
+  setTextNodeValue,
+  setTextStyles,
+  type DOMElement,
+  type TextNode,
+} from './dom.ts'
+import {
+  consumeAbsoluteRemovedFlag,
+  nodeCache,
+  pendingClears,
+} from './node-cache.ts'
+import applyStyles, { type Styles } from './styles.ts'
+
+function applyNodeStyle(node: DOMElement, style: Styles): void {
+  setStyle(node, style)
+  if (node.yogaNode) applyStyles(node.yogaNode, style, node.style)
+}
+
+function appendTextNode(parent: DOMElement, text: string): TextNode {
+  const textNode = createTextNode(text)
+  appendChildNode(parent, textNode as unknown as DOMElement)
+  return textNode
+}
+
+test('keeps DOM layout bookkeeping consistent across mutations', () => {
+  consumeAbsoluteRemovedFlag()
+
+  const root = createNode('ink-root')
+  applyNodeStyle(root, {
+    alignItems: 'flex-start',
+    flexDirection: 'column',
+    height: 8,
+    width: 20,
+  })
+
+  const firstParent = createNode('ink-box')
+  applyNodeStyle(firstParent, { height: 1, width: 5 })
+  const secondParent = createNode('ink-box')
+  applyNodeStyle(secondParent, { height: 1, width: 5 })
+  const reparented = createNode('ink-box')
+  applyNodeStyle(reparented, { height: 1, width: 5 })
+
+  appendChildNode(firstParent, reparented)
+  appendChildNode(secondParent, reparented)
+
+  expect(firstParent.childNodes).toEqual([])
+  expect(secondParent.childNodes).toEqual([reparented])
+  expect(reparented.parentNode).toBe(secondParent)
+
+  const detachedParent = createNode('ink-box')
+  const moved = createNode('ink-box')
+  appendChildNode(detachedParent, moved)
+  insertBeforeNode(secondParent, moved, createNode('ink-box'))
+
+  expect(detachedParent.childNodes).toEqual([])
+  expect(secondParent.childNodes.at(-1)).toBe(moved)
+  expect(moved.parentNode).toBe(secondParent)
+
+  const raw = createNode('ink-raw-ansi')
+  setAttribute(raw, 'rawWidth', 7)
+  setAttribute(raw, 'rawHeight', 2)
+  appendChildNode(root, secondParent)
+  appendChildNode(root, raw)
+  root.yogaNode?.calculateLayout(20, 8)
+
+  expect(raw.yogaNode?.getComputedWidth()).toBe(7)
+  expect(raw.yogaNode?.getComputedHeight()).toBe(2)
+
+  raw.dirty = false
+  setAttribute(raw, 'children', 'ignored')
+  expect(raw.attributes.children).toBeUndefined()
+  expect(raw.dirty).toBe(false)
+
+  setAttribute(raw, 'rawWidth', 7)
+  expect(raw.dirty).toBe(false)
+
+  setStyle(raw, raw.style)
+  expect(raw.dirty).toBe(false)
+
+  setTextStyles(raw, { color: 'ansi:red' })
+  expect(raw.dirty).toBe(true)
+  raw.dirty = false
+  setTextStyles(raw, { color: 'ansi:red' })
+  expect(raw.dirty).toBe(false)
+
+  const onRender = vi.fn()
+  root.onRender = onRender
+  const textNode = appendTextNode(root, 'same')
+  scheduleRenderFrom(textNode)
+  scheduleRenderFrom(createTextNode('orphan'))
+  expect(onRender).toHaveBeenCalledTimes(1)
+
+  setTextNodeValue(textNode, 42 as unknown as string)
+  expect(textNode.nodeValue).toBe('42')
+
+  const overlay = createNode('ink-box')
+  applyNodeStyle(overlay, {
+    height: 1,
+    position: 'absolute',
+    width: 3,
+  })
+  const overlayChild = createNode('ink-box')
+  appendChildNode(overlay, overlayChild)
+  appendChildNode(root, overlay)
+
+  nodeCache.set(overlay, { height: 1, width: 3, x: 1, y: 2 })
+  nodeCache.set(overlayChild, { height: 1, width: 1, x: 1, y: 2 })
+  removeChildNode(root, overlay)
+
+  expect(nodeCache.has(overlay)).toBe(false)
+  expect(nodeCache.has(overlayChild)).toBe(false)
+  expect(pendingClears.get(root)).toEqual([
+    { height: 1, width: 3, x: 1, y: 2 },
+    { height: 1, width: 1, x: 1, y: 2 },
+  ])
+  expect(consumeAbsoluteRemovedFlag()).toBe(true)
+  expect(consumeAbsoluteRemovedFlag()).toBe(false)
+
+  const ownerRoot = createNode('ink-root')
+  applyNodeStyle(ownerRoot, { flexDirection: 'column', height: 5, width: 10 })
+
+  const hidden = createNode('ink-box')
+  hidden.debugOwnerChain = ['hidden']
+  applyNodeStyle(hidden, { display: 'none', height: 2, width: 10 })
+
+  const first = createNode('ink-box')
+  first.debugOwnerChain = ['first']
+  applyNodeStyle(first, { height: 1, width: 10 })
+
+  const nestedParent = createNode('ink-box')
+  nestedParent.debugOwnerChain = ['parent']
+  applyNodeStyle(nestedParent, { height: 2, width: 10 })
+
+  const nested = createNode('ink-box')
+  nested.debugOwnerChain = ['child']
+  applyNodeStyle(nested, { height: 1, width: 10 })
+
+  appendTextNode(nestedParent, 'ignored')
+  appendChildNode(nestedParent, nested)
+  appendChildNode(ownerRoot, hidden)
+  appendChildNode(ownerRoot, first)
+  appendChildNode(ownerRoot, nestedParent)
+  ownerRoot.yogaNode?.calculateLayout(10, 5)
+
+  expect(findOwnerChainAtRow(ownerRoot, 0)).toEqual(['first'])
+  expect(findOwnerChainAtRow(ownerRoot, 1)).toEqual(['child'])
+  expect(findOwnerChainAtRow(ownerRoot, 4)).toEqual([])
+})

--- a/runtime/tests/tui/ink/events.test.ts
+++ b/runtime/tests/tui/ink/events.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest'
+
+import { ClickEvent } from './events/click-event.ts'
+import { Event } from './events/event.ts'
+import { TerminalFocusEvent } from './events/terminal-focus-event.ts'
+
+describe('Ink event classes', () => {
+  test('tracks immediate propagation state on the base event', () => {
+    const event = new Event()
+
+    expect(event.didStopImmediatePropagation()).toBe(false)
+
+    event.stopImmediatePropagation()
+
+    expect(event.didStopImmediatePropagation()).toBe(true)
+  })
+
+  test('stores click coordinates, blank-cell state, and local coordinates', () => {
+    const event = new ClickEvent(12, 4, true)
+
+    expect(event.col).toBe(12)
+    expect(event.row).toBe(4)
+    expect(event.cellIsBlank).toBe(true)
+    expect(event.localCol).toBe(0)
+    expect(event.localRow).toBe(0)
+
+    event.localCol = 3
+    event.localRow = 2
+    expect(event.localCol).toBe(3)
+    expect(event.localRow).toBe(2)
+
+    event.stopImmediatePropagation()
+    expect(event.didStopImmediatePropagation()).toBe(true)
+  })
+
+  test('stores terminal focus and blur event types', () => {
+    const focus = new TerminalFocusEvent('terminalfocus')
+    const blur = new TerminalFocusEvent('terminalblur')
+
+    expect(focus.type).toBe('terminalfocus')
+    expect(blur.type).toBe('terminalblur')
+
+    blur.stopImmediatePropagation()
+    expect(blur.didStopImmediatePropagation()).toBe(true)
+  })
+})

--- a/runtime/tests/tui/ink/events/dispatcher.wave200-136.coverage.test.ts
+++ b/runtime/tests/tui/ink/events/dispatcher.wave200-136.coverage.test.ts
@@ -1,0 +1,170 @@
+import {
+  ContinuousEventPriority,
+  DefaultEventPriority,
+  DiscreteEventPriority,
+} from 'react-reconciler/constants.js'
+import { expect, test } from 'vitest'
+
+import { Dispatcher } from './dispatcher.ts'
+import { TerminalEvent, type EventTarget } from './terminal-event.ts'
+
+type TestTarget = EventTarget & {
+  name: string
+  _eventHandlers?: Record<string, (event: TerminalEvent) => void>
+}
+
+class RecordingEvent extends TerminalEvent {
+  readonly preparedTargets: string[] = []
+
+  override _prepareForTarget(target: EventTarget): void {
+    this.preparedTargets.push(
+      `${(target as TestTarget).name}:${this.eventPhase}`,
+    )
+  }
+}
+
+function node(
+  name: string,
+  parentNode?: TestTarget,
+  _eventHandlers?: TestTarget['_eventHandlers'],
+): TestTarget {
+  return { name, parentNode, _eventHandlers }
+}
+
+test('dispatches terminal events through phases, propagation stops, and priority wrappers', () => {
+  const dispatcher = new Dispatcher()
+  const calls: string[] = []
+  const priorities: number[] = []
+
+  const root = node('root', undefined, {
+    onKeyDownCapture: event => {
+      calls.push(
+        `${(event.currentTarget as TestTarget).name}:${event.eventPhase}`,
+      )
+      priorities.push(dispatcher.resolveEventPriority())
+    },
+    onKeyDown: event => {
+      calls.push(
+        `${(event.currentTarget as TestTarget).name}:${event.eventPhase}`,
+      )
+    },
+  })
+  const parent = node('parent', root, {
+    onKeyDownCapture: event => {
+      calls.push(
+        `${(event.currentTarget as TestTarget).name}:${event.eventPhase}`,
+      )
+    },
+    onKeyDown: event => {
+      calls.push(
+        `${(event.currentTarget as TestTarget).name}:${event.eventPhase}`,
+      )
+    },
+  })
+  const child = node('child', parent, {
+    onKeyDownCapture: event => {
+      calls.push(
+        `${(event.currentTarget as TestTarget).name}:${event.eventPhase}`,
+      )
+      event.stopPropagation()
+    },
+    onKeyDown: event => {
+      calls.push(
+        `${(event.currentTarget as TestTarget).name}:${event.eventPhase}`,
+      )
+      event.preventDefault()
+    },
+  })
+
+  const previousEvent = new TerminalEvent('previous')
+  const event = new RecordingEvent('keydown')
+  dispatcher.currentEvent = previousEvent
+
+  expect(dispatcher.dispatch(child, event)).toBe(false)
+  expect(dispatcher.currentEvent).toBe(previousEvent)
+  expect(event.target).toBe(child)
+  expect(event.currentTarget).toBeNull()
+  expect(event.eventPhase).toBe('none')
+  expect(calls).toEqual([
+    'root:capturing',
+    'parent:capturing',
+    'child:at_target',
+    'child:at_target',
+  ])
+  expect(event.preparedTargets).toEqual([
+    'root:capturing',
+    'parent:capturing',
+    'child:at_target',
+    'child:at_target',
+  ])
+  expect(priorities).toEqual([DiscreteEventPriority])
+
+  const nonBubblingCalls: string[] = []
+  const nonBubblingParent = node('non-bubbling-parent', undefined, {
+    onKeyDown: () => nonBubblingCalls.push('parent'),
+  })
+  const nonBubblingChild = node('non-bubbling-child', nonBubblingParent, {
+    onKeyDown: () => nonBubblingCalls.push('child'),
+  })
+  expect(
+    dispatcher.dispatch(
+      nonBubblingChild,
+      new TerminalEvent('keydown', { bubbles: false }),
+    ),
+  ).toBe(true)
+  expect(nonBubblingCalls).toEqual(['child'])
+
+  const immediateCalls: string[] = []
+  const immediateTarget = node('immediate', undefined, {
+    onKeyDownCapture: event => {
+      immediateCalls.push('capture')
+      event.stopImmediatePropagation()
+    },
+    onKeyDown: () => immediateCalls.push('bubble'),
+  })
+  expect(dispatcher.dispatch(immediateTarget, new TerminalEvent('keydown'))).toBe(
+    true,
+  )
+  expect(immediateCalls).toEqual(['capture'])
+
+  expect(dispatcher.dispatch(child, new TerminalEvent('unknown'))).toBe(true)
+  const clickTarget = node('clickable', undefined, { onClick: () => {} })
+  expect(
+    dispatcher.dispatch(clickTarget, new TerminalEvent('click')),
+  ).toBe(true)
+
+  for (const type of ['keydown', 'keyup', 'click', 'focus', 'blur', 'paste']) {
+    dispatcher.currentEvent = new TerminalEvent(type)
+    expect(dispatcher.resolveEventPriority()).toBe(DiscreteEventPriority)
+  }
+  for (const type of ['resize', 'scroll', 'mousemove']) {
+    dispatcher.currentEvent = new TerminalEvent(type)
+    expect(dispatcher.resolveEventPriority()).toBe(ContinuousEventPriority)
+  }
+  dispatcher.currentEvent = new TerminalEvent('custom')
+  expect(dispatcher.resolveEventPriority()).toBe(DefaultEventPriority)
+  dispatcher.currentEvent = null
+  expect(dispatcher.resolveEventPriority()).toBe(DefaultEventPriority)
+
+  const continuousPriorityTarget = node('continuous-priority', undefined, {
+    onKeyDown: () => {
+      priorities.push(dispatcher.resolveEventPriority())
+    },
+  })
+  expect(
+    dispatcher.dispatchContinuous(
+      continuousPriorityTarget,
+      new TerminalEvent('keydown'),
+    ),
+  ).toBe(true)
+  expect(dispatcher.currentUpdatePriority).toBe(0)
+  expect(priorities.at(-1)).toBe(ContinuousEventPriority)
+
+  const fallbackDispatcher = new Dispatcher()
+  expect(
+    fallbackDispatcher.dispatchDiscrete(
+      node('discrete-fallback'),
+      new TerminalEvent('keydown'),
+    ),
+  ).toBe(true)
+})

--- a/runtime/tests/tui/ink/focus.wave200-107.coverage.test.ts
+++ b/runtime/tests/tui/ink/focus.wave200-107.coverage.test.ts
@@ -1,0 +1,185 @@
+import { expect, test } from 'vitest'
+
+import type { DOMElement, DOMNode } from './dom.ts'
+import type { FocusEvent } from './events/focus-event.ts'
+import { FocusManager, getFocusManager, getRootNode } from './focus.ts'
+
+type EventRecord = {
+  target: string
+  type: string
+  relatedTarget: string | null
+  bubbles: boolean
+  cancelable: boolean
+}
+
+function makeElement(id: string, tabIndex?: number): DOMElement {
+  return {
+    nodeName: 'ink-box',
+    attributes:
+      tabIndex === undefined
+        ? { id }
+        : {
+            id,
+            tabIndex,
+          },
+    childNodes: [],
+    parentNode: undefined,
+    style: {},
+    dirty: false,
+  }
+}
+
+function makeTextNode(parentNode: DOMElement): DOMNode {
+  return {
+    nodeName: '#text',
+    nodeValue: 'ignored',
+    parentNode,
+    style: {},
+  } as DOMNode
+}
+
+function append(parent: DOMElement, child: DOMElement): DOMElement {
+  child.parentNode = parent
+  parent.childNodes.push(child)
+  return child
+}
+
+function detach(parent: DOMElement, child: DOMElement): void {
+  parent.childNodes = parent.childNodes.filter(node => node !== child)
+  child.parentNode = undefined
+}
+
+function nodeId(node: DOMElement): string {
+  return String(node.attributes.id)
+}
+
+test('manages focus traversal, guarded focus, subtree removal, and root lookup', () => {
+  const events: EventRecord[] = []
+  const manager = new FocusManager((target, event: FocusEvent) => {
+    events.push({
+      target: nodeId(target),
+      type: event.type,
+      relatedTarget: event.relatedTarget
+        ? nodeId(event.relatedTarget as DOMElement)
+        : null,
+      bubbles: event.bubbles,
+      cancelable: event.cancelable,
+    })
+    return true
+  })
+
+  const root = makeElement('root')
+  root.focusManager = manager
+  const noTabIndex = append(root, makeElement('no-tab-index'))
+  const clickOnly = append(root, makeElement('click-only', -1))
+  root.childNodes.push(makeTextNode(root))
+
+  const tabbable = Array.from({ length: 35 }, (_, index) =>
+    append(root, makeElement(`tab-${index}`, 0)),
+  )
+  const removedPanel = append(root, makeElement('removed-panel'))
+  const removedLeaf = append(removedPanel, makeElement('removed-leaf', 0))
+
+  expect(getRootNode(removedLeaf)).toBe(root)
+  expect(getFocusManager(removedLeaf)).toBe(manager)
+  expect(() => getRootNode(makeElement('orphan'))).toThrow(
+    'Node is not in a tree with a FocusManager',
+  )
+
+  manager.blur()
+  manager.disable()
+  manager.handleAutoFocus(tabbable[0]!)
+  manager.focusNext(root)
+  expect(manager.activeElement).toBeNull()
+  expect(events).toEqual([])
+
+  manager.enable()
+  manager.focusNext(makeElement('empty-root'))
+  manager.handleClickFocus(noTabIndex)
+  expect(manager.activeElement).toBeNull()
+
+  manager.handleClickFocus(clickOnly)
+  expect(manager.activeElement).toBe(clickOnly)
+  expect(events).toEqual([
+    {
+      target: 'click-only',
+      type: 'focus',
+      relatedTarget: null,
+      bubbles: true,
+      cancelable: false,
+    },
+  ])
+
+  manager.focus(clickOnly)
+  manager.disable()
+  manager.focus(tabbable[0]!)
+  expect(manager.activeElement).toBe(clickOnly)
+  expect(events).toHaveLength(1)
+
+  manager.enable()
+  manager.focusNext(root)
+  expect(manager.activeElement).toBe(tabbable[0])
+
+  manager.blur()
+  manager.focusPrevious(root)
+  expect(manager.activeElement).toBe(removedLeaf)
+
+  manager.focusNext(root)
+  expect(manager.activeElement).toBe(tabbable[0])
+
+  manager.focusPrevious(root)
+  expect(manager.activeElement).toBe(removedLeaf)
+
+  manager.blur()
+  events.length = 0
+
+  for (const node of tabbable) {
+    manager.focus(node)
+  }
+  manager.focus(removedLeaf)
+  detach(root, removedPanel)
+
+  manager.handleNodeRemoved(removedPanel, root)
+
+  expect(manager.activeElement).toBe(tabbable.at(-1))
+  expect(events.slice(-4)).toEqual([
+    {
+      target: 'tab-34',
+      type: 'blur',
+      relatedTarget: 'removed-leaf',
+      bubbles: true,
+      cancelable: false,
+    },
+    {
+      target: 'removed-leaf',
+      type: 'focus',
+      relatedTarget: 'tab-34',
+      bubbles: true,
+      cancelable: false,
+    },
+    {
+      target: 'removed-leaf',
+      type: 'blur',
+      relatedTarget: null,
+      bubbles: true,
+      cancelable: false,
+    },
+    {
+      target: 'tab-34',
+      type: 'focus',
+      relatedTarget: 'removed-leaf',
+      bubbles: true,
+      cancelable: false,
+    },
+  ])
+
+  const eventCountAfterRestore = events.length
+  manager.handleNodeRemoved(noTabIndex, root)
+  expect(manager.activeElement).toBe(tabbable.at(-1))
+  expect(events).toHaveLength(eventCountAfterRestore)
+
+  manager.blur()
+  events.length = 0
+  manager.handleNodeRemoved(tabbable[0]!, root)
+  expect(events).toEqual([])
+})

--- a/runtime/tests/tui/ink/hooks/use-interval.wave200-123.coverage.test.ts
+++ b/runtime/tests/tui/ink/hooks/use-interval.wave200-123.coverage.test.ts
@@ -1,0 +1,232 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { ClockContext, type Clock } from '../components/ClockContext.js'
+import { createRoot, type Root } from '../root.js'
+import { useAnimationTimer, useInterval } from './use-interval.js'
+
+type ManualSubscription = {
+  active: boolean
+  readonly keepAlive: boolean
+  readonly onChange: () => void
+}
+
+type HookProbeProps = {
+  readonly animationIntervalMs: number
+  readonly clock: Clock | null
+  readonly intervalMs: number | null
+  readonly onInterval: () => void
+}
+
+function createManualClock(): {
+  readonly activeSubscriptions: () => ManualSubscription[]
+  readonly advance: (ms: number) => void
+  readonly clock: Clock
+} {
+  let now = 0
+  const subscriptions: ManualSubscription[] = []
+
+  return {
+    activeSubscriptions: () =>
+      subscriptions.filter(subscription => subscription.active),
+    advance: ms => {
+      now += ms
+
+      for (const subscription of subscriptions.filter(
+        candidate => candidate.active,
+      )) {
+        subscription.onChange()
+      }
+    },
+    clock: {
+      now: () => now,
+      setTickInterval: () => {},
+      subscribe: (onChange, keepAlive) => {
+        const subscription: ManualSubscription = {
+          active: true,
+          keepAlive,
+          onChange,
+        }
+        subscriptions.push(subscription)
+
+        return () => {
+          subscription.active = false
+        }
+      },
+    },
+  }
+}
+
+function createStreams(): {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough
+} {
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  const stdout = new PassThrough()
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function flushEffects(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 5))
+}
+
+async function renderHookHarness(): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly latestTime: () => number
+  readonly render: (props: HookProbeProps) => Promise<void>
+}> {
+  let latestTime: number | undefined
+  const { stdin, stdout } = createStreams()
+  const root: Root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function HookProbe(props: HookProbeProps): null {
+    latestTime = useAnimationTimer(props.animationIntervalMs)
+    useInterval(props.onInterval, props.intervalMs)
+    return null
+  }
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushEffects()
+    },
+    latestTime: () => {
+      if (latestTime === undefined) throw new Error('hook did not render')
+      return latestTime
+    },
+    render: async props => {
+      root.render(
+        React.createElement(
+          ClockContext.Provider,
+          { value: props.clock },
+          React.createElement(HookProbe, props),
+        ),
+      )
+      await flushEffects()
+    },
+  }
+}
+
+describe('use-interval hook coverage', () => {
+  test('uses the shared clock for animation time and interval callbacks', async () => {
+    const manualClock = createManualClock()
+    const firstCallbackCalls: number[] = []
+    const secondCallbackCalls: number[] = []
+    const rendered = await renderHookHarness()
+
+    try {
+      await rendered.render({
+        animationIntervalMs: 50,
+        clock: null,
+        intervalMs: 40,
+        onInterval: () => firstCallbackCalls.push(manualClock.clock.now()),
+      })
+
+      expect(rendered.latestTime()).toBe(0)
+      expect(manualClock.activeSubscriptions()).toEqual([])
+
+      await rendered.render({
+        animationIntervalMs: 50,
+        clock: manualClock.clock,
+        intervalMs: null,
+        onInterval: () => firstCallbackCalls.push(manualClock.clock.now()),
+      })
+
+      expect(
+        manualClock.activeSubscriptions().map(subscription => subscription.keepAlive),
+      ).toEqual([false])
+
+      manualClock.advance(49)
+      await flushEffects()
+
+      expect(rendered.latestTime()).toBe(0)
+
+      manualClock.advance(1)
+      await flushEffects()
+
+      expect(rendered.latestTime()).toBe(50)
+      expect(firstCallbackCalls).toEqual([])
+
+      await rendered.render({
+        animationIntervalMs: 50,
+        clock: manualClock.clock,
+        intervalMs: 40,
+        onInterval: () => firstCallbackCalls.push(manualClock.clock.now()),
+      })
+
+      expect(
+        manualClock.activeSubscriptions().map(subscription => subscription.keepAlive),
+      ).toEqual([false, false])
+
+      manualClock.advance(39)
+      await flushEffects()
+
+      expect(firstCallbackCalls).toEqual([])
+
+      manualClock.advance(1)
+      await flushEffects()
+
+      expect(firstCallbackCalls).toEqual([90])
+
+      await rendered.render({
+        animationIntervalMs: 50,
+        clock: manualClock.clock,
+        intervalMs: 40,
+        onInterval: () => secondCallbackCalls.push(manualClock.clock.now()),
+      })
+
+      expect(manualClock.activeSubscriptions()).toHaveLength(2)
+
+      manualClock.advance(40)
+      await flushEffects()
+
+      expect(firstCallbackCalls).toEqual([90])
+      expect(secondCallbackCalls).toEqual([130])
+      expect(rendered.latestTime()).toBe(130)
+
+      await rendered.render({
+        animationIntervalMs: 50,
+        clock: manualClock.clock,
+        intervalMs: null,
+        onInterval: () => secondCallbackCalls.push(manualClock.clock.now()),
+      })
+
+      expect(manualClock.activeSubscriptions()).toHaveLength(1)
+
+      manualClock.advance(80)
+      await flushEffects()
+
+      expect(secondCallbackCalls).toEqual([130])
+      expect(rendered.latestTime()).toBe(210)
+    } finally {
+      await rendered.dispose()
+    }
+
+    expect(manualClock.activeSubscriptions()).toEqual([])
+  })
+})

--- a/runtime/tests/tui/ink/hooks/use-selection.wave200-113.coverage.test.ts
+++ b/runtime/tests/tui/ink/hooks/use-selection.wave200-113.coverage.test.ts
@@ -1,0 +1,203 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../root.js'
+import {
+  deleteInkInstance,
+  getInkInstance,
+  setInkInstance,
+} from '../instances.js'
+import { createSelectionState } from '../selection.js'
+import { useHasSelection, useSelection } from './use-selection.js'
+
+type SelectionControls = ReturnType<typeof useSelection>
+
+type HarnessState = {
+  has: boolean
+  selection: SelectionControls
+}
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough
+}
+
+const originalInk = getInkInstance(process.stdout)
+
+function createStreams(): TestStreams {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStreams['stdin']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  ;(stdout as unknown as { columns: number; rows: number }).columns = 80
+  ;(stdout as unknown as { rows: number }).rows = 24
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderSelectionHarness(): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly latest: () => HarnessState
+}> {
+  let latest: HarnessState | undefined
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    latest = {
+      has: useHasSelection(),
+      selection: useSelection(),
+    }
+    return null
+  }
+
+  root.render(React.createElement(Harness))
+  await sleep()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+  }
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 1000,
+): Promise<void> {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return
+    await sleep(10)
+  }
+  throw new Error('timed out waiting for hook update')
+}
+
+afterEach(() => {
+  deleteInkInstance(process.stdout)
+  if (originalInk !== undefined) {
+    setInkInstance(process.stdout, originalInk)
+  }
+})
+
+describe('useSelection wave200 coverage', () => {
+  test('returns safe fallbacks and delegates selection operations to the active ink instance', async () => {
+    deleteInkInstance(process.stdout)
+
+    const fallback = await renderSelectionHarness()
+    try {
+      const selection = fallback.latest().selection
+
+      expect(fallback.latest().has).toBe(false)
+      expect(selection.copySelection()).toBe('')
+      expect(selection.copySelectionNoClear()).toBe('')
+      expect(selection.hasSelection()).toBe(false)
+      expect(selection.getState()).toBeNull()
+      expect(selection.subscribe(() => {})).toEqual(expect.any(Function))
+      expect(() => {
+        selection.clearSelection()
+        selection.shiftAnchor(1, 0, 2)
+        selection.shiftSelection(1, 0, 2)
+        selection.moveFocus('right')
+        selection.captureScrolledRows(0, 1, 'above')
+        selection.setSelectionBgColor('#123456')
+      }).not.toThrow()
+    } finally {
+      await fallback.dispose()
+    }
+
+    let selected = false
+    const listeners = new Set<() => void>()
+    const state = createSelectionState()
+    state.anchor = { col: 2, row: 1 }
+    state.focus = { col: 5, row: 1 }
+
+    const fakeInk = {
+      captureScrolledRows: vi.fn(),
+      clearTextSelection: vi.fn(),
+      copySelection: vi.fn(() => 'copied-and-cleared'),
+      copySelectionNoClear: vi.fn(() => 'copied'),
+      hasTextSelection: vi.fn(() => selected),
+      moveSelectionFocus: vi.fn(),
+      selection: state,
+      setSelectionBgColor: vi.fn(),
+      shiftSelectionForScroll: vi.fn(),
+      subscribeToSelectionChange: vi.fn((cb: () => void) => {
+        listeners.add(cb)
+        return () => listeners.delete(cb)
+      }),
+    }
+
+    setInkInstance(
+      process.stdout,
+      fakeInk as unknown as Parameters<typeof setInkInstance>[1],
+    )
+
+    const active = await renderSelectionHarness()
+    try {
+      const selection = active.latest().selection
+      expect(active.latest().has).toBe(false)
+      expect(selection.getState()).toBe(state)
+      expect(selection.copySelection()).toBe('copied-and-cleared')
+      expect(selection.copySelectionNoClear()).toBe('copied')
+      expect(selection.hasSelection()).toBe(false)
+
+      selection.clearSelection()
+      selection.shiftAnchor(3, 0, 2)
+      selection.shiftSelection(-2, 0, 4)
+      selection.moveFocus('home')
+      selection.captureScrolledRows(4, 6, 'below')
+      selection.setSelectionBgColor('#abcdef')
+
+      expect(fakeInk.clearTextSelection).toHaveBeenCalledOnce()
+      expect(state.anchor).toEqual({ col: 2, row: 2 })
+      expect(state.virtualAnchorRow).toBe(4)
+      expect(fakeInk.shiftSelectionForScroll).toHaveBeenCalledWith(-2, 0, 4)
+      expect(fakeInk.moveSelectionFocus).toHaveBeenCalledWith('home')
+      expect(fakeInk.captureScrolledRows).toHaveBeenCalledWith(4, 6, 'below')
+      expect(fakeInk.setSelectionBgColor).toHaveBeenCalledWith('#abcdef')
+
+      let unsubscribed = false
+      const unsubscribe = selection.subscribe(() => {
+        unsubscribed = true
+      })
+      expect(fakeInk.subscribeToSelectionChange).toHaveBeenCalled()
+      unsubscribe()
+      expect(unsubscribed).toBe(false)
+
+      selected = true
+      for (const listener of listeners) listener()
+      await waitFor(() => active.latest().has)
+
+      expect(active.latest().has).toBe(true)
+    } finally {
+      await active.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/ink/ink.coverage2.test.tsx
+++ b/runtime/tests/tui/ink/ink.coverage2.test.tsx
@@ -1,0 +1,153 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import type Ink from './ink.tsx'
+import type { Frame } from './frame.ts'
+import instances from './instances.ts'
+import { createRoot, type Root } from './root.ts'
+import { CURSOR_HOME, ERASE_SCREEN, cursorPosition } from './termio/csi.ts'
+import { ENABLE_MOUSE_TRACKING } from './termio/dec.ts'
+
+type TestStdout = PassThrough & {
+  columns: number
+  rows: number
+  isTTY: boolean
+}
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  isRaw?: boolean
+  setRawMode: (mode: boolean) => void
+  ref: () => void
+  unref: () => void
+}
+
+type InkInternals = Ink & {
+  frontFrame: Frame
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function textNode(children: React.ReactNode): React.ReactElement {
+  return React.createElement(
+    'ink-text',
+    {
+      style: {
+        flexDirection: 'row',
+        flexGrow: 0,
+        flexShrink: 1,
+        textWrap: 'wrap',
+      },
+    },
+    children,
+  )
+}
+
+function createTestStreams(): {
+  stdout: TestStdout
+  stdin: TestStdin
+  stderr: PassThrough
+  stdoutWrites: string[]
+} {
+  const stdout = new PassThrough() as TestStdout
+  const stdin = new PassThrough() as TestStdin
+  const stderr = new PassThrough()
+  const stdoutWrites: string[] = []
+
+  stdout.columns = 18
+  stdout.rows = 5
+  stdout.isTTY = true
+  stdout.on('data', chunk => {
+    stdoutWrites.push(Buffer.from(chunk).toString('utf8'))
+  })
+
+  stdin.isTTY = true
+  stdin.isRaw = false
+  stdin.setRawMode = mode => {
+    stdin.isRaw = mode
+  }
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+
+  return { stdout, stdin, stderr, stdoutWrites }
+}
+
+function getInkInstance(stdout: PassThrough): InkInternals {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+  if (!instance) throw new Error('Ink instance not found')
+  return instance as InkInternals
+}
+
+async function createHarness(): Promise<{
+  root: Root
+  instance: InkInternals
+  stdout: TestStdout
+  stdin: TestStdin
+  stderr: PassThrough
+  stdoutWrites: string[]
+  dispose: () => Promise<void>
+}> {
+  const { stdout, stdin, stderr, stdoutWrites } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    patchConsole: false,
+  })
+  const instance = getInkInstance(stdout)
+
+  return {
+    root,
+    instance,
+    stdout,
+    stdin,
+    stderr,
+    stdoutWrites,
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      stderr.end()
+      await sleep(25)
+    },
+  }
+}
+
+describe('Ink resize coverage', () => {
+  test('resizes alt-screen frames atomically and skips same-size resize events', async () => {
+    const harness = await createHarness()
+
+    try {
+      harness.root.render(textNode('resize me'))
+      await sleep(30)
+      harness.instance.setAltScreenActive(true, true)
+      await sleep(30)
+
+      harness.stdoutWrites.length = 0
+      harness.stdout.emit('resize')
+      await sleep(30)
+      expect(harness.stdoutWrites).toEqual([])
+      expect(harness.instance.frontFrame.screen.width).toBe(18)
+      expect(harness.instance.frontFrame.screen.height).toBe(5)
+
+      harness.stdout.columns = 24
+      harness.stdout.rows = 7
+      harness.stdout.emit('resize')
+      await sleep(30)
+
+      const writes = harness.stdoutWrites.join('')
+      expect(writes).toContain(ENABLE_MOUSE_TRACKING)
+      expect(writes).toContain(ERASE_SCREEN + CURSOR_HOME)
+      expect(writes).toContain(cursorPosition(7, 1))
+      expect(harness.instance.frontFrame.screen.width).toBe(24)
+      expect(harness.instance.frontFrame.screen.height).toBe(7)
+      expect(harness.instance.frontFrame.viewport.height).toBe(8)
+    } finally {
+      await harness.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/ink/ink.render.test.tsx
+++ b/runtime/tests/tui/ink/ink.render.test.tsx
@@ -1,0 +1,423 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import type Ink from './ink.tsx'
+import { drainStdin } from './ink.tsx'
+import type { DOMElement, ElementNames } from './dom.ts'
+import type { Frame } from './frame.ts'
+import instances from './instances.ts'
+import { createRoot, type Root } from './root.ts'
+import { CellWidth, cellAt } from './screen.ts'
+import { CURSOR_HOME, ERASE_SCREEN } from './termio/csi.ts'
+import { ENABLE_MOUSE_TRACKING, ENTER_ALT_SCREEN } from './termio/dec.ts'
+
+const clipboardMock = vi.hoisted(() => ({
+  setClipboard: vi.fn(async (_text: string) => ''),
+  supportsTabStatus: vi.fn(() => false),
+}))
+
+vi.mock('./termio/osc.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('./termio/osc.ts')>()
+  return {
+    ...actual,
+    setClipboard: clipboardMock.setClipboard,
+    supportsTabStatus: clipboardMock.supportsTabStatus,
+  }
+})
+
+vi.mock('../../utils/fullscreen.js', () => ({
+  isMouseClicksDisabled: () => false,
+}))
+
+type TestStdout = PassThrough & {
+  columns: number
+  rows: number
+  isTTY: boolean
+}
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  isRaw?: boolean
+  setRawMode: (mode: boolean) => void
+  ref: () => void
+  unref: () => void
+}
+
+type InkInternals = Ink & {
+  frontFrame: Frame
+  prevFrameContaminated: boolean
+  rootNode: DOMElement
+  selection: Ink['selection']
+}
+
+const RAW_TEXT_STYLE = {
+  flexDirection: 'row',
+  flexGrow: 0,
+  flexShrink: 1,
+  textWrap: 'wrap',
+} as const
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function textNode(children: React.ReactNode): React.ReactElement {
+  return React.createElement(
+    'ink-text',
+    {
+      style: RAW_TEXT_STYLE,
+    },
+    children,
+  )
+}
+
+function createTestStreams(options: {
+  columns?: number
+  rows?: number
+  stdoutIsTTY?: boolean
+  stdinIsTTY?: boolean
+  stdinIsRaw?: boolean
+} = {}): {
+  stdout: TestStdout
+  stdin: TestStdin
+  stderr: PassThrough
+  stdoutWrites: string[]
+  rawModes: boolean[]
+} {
+  const stdout = new PassThrough() as TestStdout
+  const stdin = new PassThrough() as TestStdin
+  const stderr = new PassThrough()
+  const stdoutWrites: string[] = []
+  const rawModes: boolean[] = []
+
+  stdout.columns = options.columns ?? 40
+  stdout.rows = options.rows ?? 8
+  stdout.isTTY = options.stdoutIsTTY ?? true
+  stdout.on('data', chunk => {
+    stdoutWrites.push(Buffer.from(chunk).toString('utf8'))
+  })
+
+  stdin.isTTY = options.stdinIsTTY ?? true
+  stdin.isRaw = options.stdinIsRaw ?? false
+  stdin.setRawMode = (mode: boolean) => {
+    rawModes.push(mode)
+    stdin.isRaw = mode
+  }
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+
+  return { stdout, stdin, stderr, stdoutWrites, rawModes }
+}
+
+function getInkInstance(stdout: PassThrough): InkInternals {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+  if (!instance) throw new Error('Ink instance not found')
+  return instance as InkInternals
+}
+
+function findElement(
+  node: DOMElement,
+  nodeName: ElementNames,
+): DOMElement | undefined {
+  if (node.nodeName === nodeName) return node
+
+  for (const child of node.childNodes) {
+    if (child.nodeName === '#text') continue
+    const found = findElement(child, nodeName)
+    if (found) return found
+  }
+
+  return undefined
+}
+
+function requireElement(stdout: PassThrough, nodeName: ElementNames): DOMElement {
+  const { rootNode } = getInkInstance(stdout)
+  const found = findElement(rootNode, nodeName)
+  if (!found) throw new Error(`Element ${nodeName} not found`)
+  return found
+}
+
+async function createHarness(options: {
+  columns?: number
+  rows?: number
+  stdoutIsTTY?: boolean
+  stdinIsTTY?: boolean
+  stdinIsRaw?: boolean
+} = {}): Promise<{
+  root: Root
+  instance: InkInternals
+  stdout: TestStdout
+  stdin: TestStdin
+  stderr: PassThrough
+  stdoutWrites: string[]
+  rawModes: boolean[]
+  dispose: () => Promise<void>
+}> {
+  const { stdout, stdin, stderr, stdoutWrites, rawModes } = createTestStreams(
+    options,
+  )
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    patchConsole: false,
+  })
+  const instance = getInkInstance(stdout)
+
+  return {
+    root,
+    instance,
+    stdout,
+    stdin,
+    stderr,
+    stdoutWrites,
+    rawModes,
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      stderr.end()
+      await sleep(25)
+    },
+  }
+}
+
+describe('Ink instance rendering paths', () => {
+  test('tracks alt-screen state and reasserts terminal modes with a full repaint', async () => {
+    const harness = await createHarness({ columns: 20, rows: 5 })
+
+    try {
+      harness.root.render(textNode('ready'))
+      await sleep(10)
+
+      harness.stdoutWrites.length = 0
+      harness.instance.setAltScreenActive(true, true)
+
+      expect(harness.instance.isAltScreenActive).toBe(true)
+      expect(harness.instance.frontFrame.screen.width).toBe(20)
+      expect(harness.instance.frontFrame.screen.height).toBe(5)
+      expect(harness.instance.frontFrame.viewport.height).toBe(6)
+      expect(harness.instance.prevFrameContaminated).toBe(true)
+
+      harness.instance.reassertTerminalModes(false)
+      expect(harness.stdoutWrites.join('')).toContain(ENABLE_MOUSE_TRACKING)
+      expect(harness.stdoutWrites.join('')).not.toContain(ENTER_ALT_SCREEN)
+
+      harness.stdoutWrites.length = 0
+      harness.instance.reassertTerminalModes(true)
+
+      const reasserted = harness.stdoutWrites.join('')
+      expect(reasserted).toContain(ENTER_ALT_SCREEN + ERASE_SCREEN + CURSOR_HOME)
+      expect(reasserted).toContain(ENABLE_MOUSE_TRACKING)
+
+      harness.stdoutWrites.length = 0
+      harness.instance.forceRedraw()
+      expect(harness.stdoutWrites.join('')).toContain(ERASE_SCREEN + CURSOR_HOME)
+
+      harness.instance.setAltScreenActive(false)
+      expect(harness.instance.isAltScreenActive).toBe(false)
+      expect(harness.instance.frontFrame.screen.height).toBe(0)
+    } finally {
+      await harness.dispose()
+    }
+  })
+
+  test('suspends and resumes stdin listeners and raw mode around external TUI handoff', async () => {
+    const harness = await createHarness({ stdinIsRaw: true })
+    const readableListener = vi.fn()
+
+    try {
+      harness.stdin.on('readable', readableListener)
+      expect(harness.stdin.listenerCount('readable')).toBe(1)
+
+      harness.instance.suspendStdin()
+      expect(harness.stdin.listenerCount('readable')).toBe(0)
+      expect(harness.rawModes).toEqual([false])
+
+      harness.instance.resumeStdin()
+      expect(harness.stdin.listeners('readable')).toContain(readableListener)
+      expect(harness.rawModes).toEqual([false, true])
+    } finally {
+      await harness.dispose()
+    }
+  })
+
+  test('copies, clears, and extends alt-screen text selection without native clipboard access', async () => {
+    const harness = await createHarness({ columns: 40, rows: 6 })
+    const selectionChanges: string[] = []
+
+    try {
+      harness.instance.setAltScreenActive(true)
+      harness.root.render(textNode('alpha beta'))
+      await sleep(10)
+
+      expect(harness.instance.copySelectionNoClear()).toBe('')
+      harness.instance.handleMultiClick(1, 0, 2)
+      expect(harness.instance.hasTextSelection()).toBe(true)
+      expect(harness.instance.copySelectionNoClear()).toBe('alpha')
+      expect(harness.instance.hasTextSelection()).toBe(true)
+      expect(clipboardMock.setClipboard).toHaveBeenCalledWith('alpha')
+
+      const unsubscribe = harness.instance.subscribeToSelectionChange(() => {
+        selectionChanges.push('changed')
+      })
+
+      harness.instance.moveSelectionFocus('right')
+      expect(harness.instance.selection.focus).toEqual({ col: 5, row: 0 })
+
+      harness.instance.handleSelectionDrag(9, 0)
+      expect(harness.instance.copySelection()).toBe('alpha beta')
+      expect(harness.instance.hasTextSelection()).toBe(false)
+      expect(selectionChanges.length).toBeGreaterThan(0)
+
+      const afterCopyChanges = selectionChanges.length
+      harness.instance.clearTextSelection()
+      expect(selectionChanges).toHaveLength(afterCopyChanges)
+
+      unsubscribe()
+    } finally {
+      await harness.dispose()
+    }
+  })
+
+  test('looks up rendered hyperlinks, dispatches hit-tested mouse events, and opens mutable hyperlink handlers', async () => {
+    const harness = await createHarness({ columns: 40, rows: 6 })
+    const clicks: Array<{ localCol?: number; localRow?: number }> = []
+    const hoverEvents: string[] = []
+    const opened: string[] = []
+
+    try {
+      expect(harness.instance.dispatchClick(0, 0)).toBe(false)
+      expect(harness.instance.getHyperlinkAt(0, 0)).toBeUndefined()
+
+      harness.instance.setAltScreenActive(true)
+      harness.root.render(
+        React.createElement(
+          'ink-box',
+          {
+            onClick: (event: { localCol?: number; localRow?: number }) => {
+              clicks.push({
+                localCol: event.localCol,
+                localRow: event.localRow,
+              })
+            },
+            onMouseEnter: () => hoverEvents.push('enter'),
+            onMouseLeave: () => hoverEvents.push('leave'),
+            style: { height: 1, width: 12 },
+            tabIndex: 0,
+          },
+          textNode('hit'),
+        ),
+      )
+      await sleep(10)
+
+      expect(harness.instance.dispatchClick(1, 0)).toBe(true)
+      expect(clicks).toEqual([{ localCol: 1, localRow: 0 }])
+
+      harness.instance.dispatchHover(1, 0)
+      harness.instance.dispatchHover(30, 5)
+      expect(hoverEvents).toEqual(['enter', 'leave'])
+
+      harness.root.render(
+        textNode(
+          React.createElement(
+            'ink-link',
+            { href: 'https://wide.test' },
+            '\u597d',
+          ),
+        ),
+      )
+      await sleep(10)
+      expect(cellAt(harness.instance.frontFrame.screen, 1, 0)?.width).toBe(
+        CellWidth.SpacerTail,
+      )
+      expect(harness.instance.getHyperlinkAt(1, 0)).toBe('https://wide.test')
+
+      harness.root.render(textNode('see https://plain.test/path).'))
+      await sleep(10)
+      expect(harness.instance.getHyperlinkAt(12, 0)).toBe(
+        'https://plain.test/path',
+      )
+
+      harness.instance.openHyperlink('https://ignored.test')
+      harness.instance.onHyperlinkClick = url => opened.push(url)
+      harness.instance.openHyperlink('https://opened.test')
+      expect(opened).toEqual(['https://opened.test'])
+    } finally {
+      await harness.dispose()
+    }
+  })
+
+  test('scans rendered subtrees and schedules search highlight overlays', async () => {
+    const harness = await createHarness({ columns: 40, rows: 6 })
+
+    try {
+      harness.instance.setAltScreenActive(true)
+      harness.root.render(textNode('alpha beta beta'))
+      await sleep(10)
+
+      const textElement = requireElement(harness.stdout, 'ink-text')
+      expect(harness.instance.scanElementSubtree(textElement)).toEqual([])
+
+      harness.instance.setSearchHighlight('beta')
+      harness.instance.setSearchHighlight('beta')
+      await sleep(10)
+
+      const positions = harness.instance.scanElementSubtree(textElement)
+      expect(positions).toEqual([
+        { col: 6, len: 4, row: 0 },
+        { col: 11, len: 4, row: 0 },
+      ])
+
+      harness.instance.setSearchPositions({
+        currentIdx: 1,
+        positions,
+        rowOffset: 0,
+      })
+      await sleep(10)
+
+      harness.instance.setSearchPositions(null)
+      harness.instance.setSearchHighlight('')
+    } finally {
+      await harness.dispose()
+    }
+  })
+})
+
+describe('drainStdin', () => {
+  test('returns early for non-TTY streams', () => {
+    const stdin = new PassThrough() as TestStdin
+    const rawModes: boolean[] = []
+    stdin.isTTY = false
+    stdin.setRawMode = (mode: boolean) => {
+      rawModes.push(mode)
+    }
+    stdin.ref = () => {}
+    stdin.unref = () => {}
+
+    drainStdin(stdin as unknown as NodeJS.ReadStream)
+
+    expect(rawModes).toEqual([])
+  })
+
+  test('drains buffered bytes and restores cooked mode for TTY streams', () => {
+    const stdin = new PassThrough() as TestStdin
+    const rawModes: boolean[] = []
+    stdin.isTTY = true
+    stdin.isRaw = false
+    stdin.setRawMode = (mode: boolean) => {
+      rawModes.push(mode)
+      stdin.isRaw = mode
+    }
+    stdin.ref = () => {}
+    stdin.unref = () => {}
+    stdin.write('pending')
+
+    drainStdin(stdin as unknown as NodeJS.ReadStream)
+
+    expect(rawModes).toEqual(process.platform === 'win32' ? [] : [true, false])
+    expect(stdin.read()).toBeNull()
+  })
+})

--- a/runtime/tests/tui/ink/ink.wave200-004.coverage.test.tsx
+++ b/runtime/tests/tui/ink/ink.wave200-004.coverage.test.tsx
@@ -1,0 +1,107 @@
+import { PassThrough } from 'node:stream'
+
+import { describe, expect, test, vi } from 'vitest'
+
+import type Ink from './ink.tsx'
+import instances from './instances.ts'
+import { createRoot, type Root } from './root.ts'
+
+type TestStdout = PassThrough & {
+  columns: number
+  rows: number
+  isTTY: boolean
+}
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  isRaw?: boolean
+  setRawMode: (mode: boolean) => void
+  ref: () => void
+  unref: () => void
+}
+
+type InkInternals = Ink & {
+  prevFrameContaminated: boolean
+}
+
+function createStreams(): {
+  stdout: TestStdout
+  stdin: TestStdin
+  stderr: PassThrough
+} {
+  const stdout = new PassThrough() as TestStdout
+  const stdin = new PassThrough() as TestStdin
+  const stderr = new PassThrough()
+
+  stdout.columns = 24
+  stdout.rows = 6
+  stdout.isTTY = false
+
+  stdin.isTTY = true
+  stdin.isRaw = false
+  stdin.setRawMode = mode => {
+    stdin.isRaw = mode
+  }
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+
+  return { stdout, stdin, stderr }
+}
+
+function getInkInstance(stdout: PassThrough): InkInternals {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+  if (!instance) throw new Error('Ink instance not found')
+  return instance as InkInternals
+}
+
+describe('Ink console patch coverage', () => {
+  test('restores patched console and stderr while repainting after alt-screen stderr writes', async () => {
+    const originalConsoleLog = console.log
+    const originalConsoleWarn = console.warn
+    const originalConsoleAssert = console.assert
+    const originalStderrWrite = process.stderr.write
+    const { stdout, stdin, stderr } = createStreams()
+    let root: Root | undefined
+
+    try {
+      root = await createRoot({
+        stdout: stdout as unknown as NodeJS.WriteStream,
+        stdin: stdin as unknown as NodeJS.ReadStream,
+        stderr: stderr as unknown as NodeJS.WriteStream,
+        patchConsole: true,
+      })
+      const instance = getInkInstance(stdout)
+
+      expect(console.log).not.toBe(originalConsoleLog)
+      expect(console.warn).not.toBe(originalConsoleWarn)
+      expect(console.assert).not.toBe(originalConsoleAssert)
+      expect(process.stderr.write).not.toBe(originalStderrWrite)
+
+      console.log('debug %s', 'message')
+      console.assert(true, 'assert %s', 'message')
+
+      instance.setAltScreenActive(true)
+      instance.prevFrameContaminated = false
+      const callback = vi.fn()
+
+      const result = process.stderr.write('direct stderr\n', callback)
+
+      expect(result).toBe(true)
+      expect(callback).toHaveBeenCalledOnce()
+      expect(instance.prevFrameContaminated).toBe(true)
+
+      root.unmount()
+      root = undefined
+
+      expect(console.log).toBe(originalConsoleLog)
+      expect(console.warn).toBe(originalConsoleWarn)
+      expect(console.assert).toBe(originalConsoleAssert)
+      expect(process.stderr.write).toBe(originalStderrWrite)
+    } finally {
+      root?.unmount()
+      stdin.end()
+      stdout.end()
+      stderr.end()
+    }
+  })
+})

--- a/runtime/tests/tui/ink/log-update.wave200-032.coverage.test.ts
+++ b/runtime/tests/tui/ink/log-update.wave200-032.coverage.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from 'vitest'
+
+import type { Frame } from './frame.ts'
+import { LogUpdate } from './log-update.ts'
+import {
+  CellWidth,
+  CharPool,
+  createScreen,
+  HyperlinkPool,
+  setCellAt,
+  StylePool,
+} from './screen.ts'
+
+function stdoutText(diff: ReturnType<LogUpdate['render']>): string {
+  return diff
+    .filter(
+      (patch): patch is Extract<(typeof diff)[number], { type: 'stdout' }> =>
+        patch.type === 'stdout',
+    )
+    .map(patch => patch.content)
+    .join('')
+}
+
+function frameFromRows(
+  stylePool: StylePool,
+  charPool: CharPool,
+  hyperlinkPool: HyperlinkPool,
+  rows: string[],
+  scrollHint?: Frame['scrollHint'],
+): Frame {
+  const width = rows.reduce((max, row) => Math.max(max, row.length), 0)
+  const screen = createScreen(width, rows.length, stylePool, charPool, hyperlinkPool)
+
+  for (const [y, row] of rows.entries()) {
+    for (const [x, char] of [...row].entries()) {
+      setCellAt(screen, x, y, {
+        char,
+        styleId: stylePool.none,
+        width: CellWidth.Narrow,
+      })
+    }
+  }
+
+  return {
+    cursor: { x: 0, y: 0, visible: false },
+    screen,
+    scrollHint,
+    viewport: { width, height: rows.length },
+  }
+}
+
+test('alt-screen scroll hints use DECSTBM and repaint only the newly exposed row', () => {
+  const stylePool = new StylePool()
+  const charPool = new CharPool()
+  const hyperlinkPool = new HyperlinkPool()
+  const log = new LogUpdate({ isTTY: true, stylePool })
+
+  const prev = frameFromRows(stylePool, charPool, hyperlinkPool, [
+    'TOP0',
+    'OLD1',
+    'OLD2',
+    'KEEP',
+  ])
+  const next = frameFromRows(
+    stylePool,
+    charPool,
+    hyperlinkPool,
+    ['TOP0', 'OLD2', 'NEW2', 'KEEP'],
+    { top: 1, bottom: 2, delta: 1 },
+  )
+
+  const diff = log.render(prev, next, true)
+  const stdout = stdoutText(diff)
+
+  expect(diff[0]).toEqual({
+    type: 'stdout',
+    content: '\x1b[2;3r\x1b[1S\x1b[r\x1b[H',
+  })
+  expect(stdout).toContain('NEW2')
+  expect(stdout).not.toContain('OLD2')
+  expect(diff.some(patch => patch.type === 'clearTerminal')).toBe(false)
+})

--- a/runtime/tests/tui/ink/native-ts/color-diff/index.wave200-036.coverage.test.ts
+++ b/runtime/tests/tui/ink/native-ts/color-diff/index.wave200-036.coverage.test.ts
@@ -1,0 +1,96 @@
+import stripAnsi from 'strip-ansi'
+import { describe, expect, test } from 'vitest'
+
+import { __test, ColorDiff, ColorFile, getNativeModule } from './index.js'
+
+describe('color-diff wave200-036 coverage', () => {
+  test('renders daltonized narrow diffs and terminal detection edge cases', () => {
+    const originalColorTerm = process.env.COLORTERM
+    const rocket = '\u{1f680}'
+
+    try {
+      process.env.COLORTERM = '24bit'
+
+      expect(__test.detectColorMode('plain')).toBe('truecolor')
+      expect(__test.ansi256FromRgb(128, 128, 128)).toBe(244)
+      expect(__test.colorToEscape({ r: 200, g: 0, b: 0, a: 0 }, true, 'ansi')).toBe(
+        '\x1b[38;5;200m',
+      )
+      expect(
+        __test.colorToEscape(
+          { r: 128, g: 128, b: 128, a: 255 },
+          false,
+          'color256',
+        ),
+      ).toBe('\x1b[48;5;244m')
+      expect(__test.detectLanguage('CMakeLists.txt', null)).toBe('cmake')
+      expect(__test.detectLanguage('tool', '\ufeff#!/usr/bin/env node')).toBe(
+        'javascript',
+      )
+      expect(__test.detectLanguage('tool', '#!/usr/bin/perl')).toBe('perl')
+      expect(__test.detectLanguage('template', '<?php echo 1')).toBe('php')
+      expect(__test.detectLanguage('feed', '<?xml version="1.0"')).toBe('xml')
+      expect(getNativeModule()).toBe(getNativeModule())
+
+      const darkLines = new ColorDiff(
+        {
+          oldStart: 7,
+          oldLines: 0,
+          newStart: 7,
+          newLines: 1,
+          lines: [`+a${rocket}`],
+        },
+        null,
+        'note.txt',
+        'prefix is accepted for API parity',
+      ).render('dark-daltonized', 5, false)
+
+      expect(darkLines).not.toBeNull()
+      expect(darkLines!.join('')).toContain('\x1b[48;2;0;27;41m')
+      expect(darkLines!.length).toBeGreaterThan(1)
+      expect(darkLines!.map(line => stripAnsi(line)).join('\n')).toContain(
+        `+${rocket}`,
+      )
+
+      const lightLines = new ColorDiff(
+        {
+          oldStart: 3,
+          oldLines: 2,
+          newStart: 3,
+          newLines: 2,
+          lines: ['-alpha beta', '+alpha zeta', ' context'],
+        },
+        null,
+        'patch.txt',
+      ).render('light-daltonized', 24, false)
+
+      expect(lightLines).not.toBeNull()
+      expect(lightLines!.join('')).toContain('\x1b[48;2;219;237;255m')
+      expect(lightLines!.join('')).toContain('\x1b[48;2;179;217;255m')
+
+      const lightPlain = lightLines!.map(line => stripAnsi(line)).join('\n')
+      expect(lightPlain).toContain('-alpha beta')
+      expect(lightPlain).toContain('+alpha zeta')
+      expect(lightPlain).toContain('context')
+
+      const fileLines = new ColorFile(
+        '#!/usr/bin/env node\nconst value = 1\nconsole.log(value)',
+        'script',
+      ).render('light-daltonized', 7, true)
+
+      expect(fileLines).not.toBeNull()
+      expect(fileLines!.join('')).toContain('\x1b[0m\x1b[2m')
+
+      const filePlain = fileLines!.map(line => stripAnsi(line)).join('\n')
+      const compactFilePlain = filePlain.replace(/\s+/g, '')
+      expect(filePlain).toContain('1 #!')
+      expect(compactFilePlain).toContain('2constvalue=1')
+    } finally {
+      if (originalColorTerm === undefined) {
+        delete process.env.COLORTERM
+      } else {
+        process.env.COLORTERM = originalColorTerm
+      }
+    }
+  })
+})

--- a/runtime/tests/tui/ink/native-ts/file-index/index.wave200-114.coverage.test.ts
+++ b/runtime/tests/tui/ink/native-ts/file-index/index.wave200-114.coverage.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { FileIndex } from "./index.js";
+
+describe("FileIndex wave200-114 coverage", () => {
+  test("keeps async indexing queryable while preserving top-k and top-level search semantics", async () => {
+    expect(new FileIndex().search("", 3)).toEqual([]);
+
+    const asyncIndex = new FileIndex();
+    const paths = Array.from({ length: 300 }, (_, index) => {
+      return `src/generated/path-${String(index).padStart(3, "0")}.ts`;
+    });
+    paths[5] = "src/early-target.ts";
+    paths[299] = "src/late-target.ts";
+
+    let now = 0;
+    const nowSpy = vi.spyOn(performance, "now").mockImplementation(() => {
+      now += 10;
+      return now;
+    });
+
+    try {
+      const { done, queryable } = asyncIndex.loadFromFileListAsync(paths);
+
+      await queryable;
+
+      expect(asyncIndex.search("early", 5).map(result => result.path)).toContain(
+        "src/early-target.ts",
+      );
+      expect(asyncIndex.search("late", 5)).toEqual([]);
+
+      await done;
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    expect(asyncIndex.search("late", 5).map(result => result.path)).toContain(
+      "src/late-target.ts",
+    );
+
+    const orderedIndex = new FileIndex();
+    orderedIndex.loadFromFileList([
+      `a${"x".repeat(80)}b.ts`,
+      "ab.ts",
+      "axb.ts",
+      `a${"x".repeat(200)}b.ts`,
+      "ba.ts",
+    ]);
+
+    expect(orderedIndex.search("ab", 2).map(result => result.path)).toEqual([
+      "ab.ts",
+      "axb.ts",
+    ]);
+
+    const boundedIndex = new FileIndex();
+    boundedIndex.loadFromFileList([
+      "abc.ts",
+      `a${"x".repeat(200)}b${"x".repeat(200)}c.ts`,
+      "cba.ts",
+    ]);
+
+    expect(boundedIndex.search("abc", 1)).toEqual([
+      { path: "abc.ts", score: 0 },
+    ]);
+
+    const topLevelIndex = new FileIndex();
+    topLevelIndex.loadFromFileList([
+      "zz00/file.ts",
+      "aa00/file.ts",
+      ...Array.from({ length: 100 }, (_, index) => {
+        return `r${String(index).padStart(3, "0")}/file.ts`;
+      }),
+    ]);
+
+    const topLevel = topLevelIndex.search("", 200).map(result => result.path);
+    expect(topLevel).toHaveLength(100);
+    expect(topLevel[0]).toBe("aa00");
+    expect(topLevel).toContain("zz00");
+    expect(topLevel).toContain("r097");
+    expect(topLevel).not.toContain("r098");
+  });
+});

--- a/runtime/tests/tui/ink/native-ts/yoga-layout/index.coverage2.test.ts
+++ b/runtime/tests/tui/ink/native-ts/yoga-layout/index.coverage2.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "vitest";
+
+import YogaDefault, { Align, Edge, FlexDirection } from "./index.js";
+
+describe("yoga-layout TypeScript shim baseline coverage", () => {
+  test("aligns row children to a nested reference baseline", () => {
+    const config = YogaDefault.Config.create();
+    config.setPointScaleFactor(0);
+
+    const root = YogaDefault.Node.createWithConfig(config);
+    const tall = YogaDefault.Node.createWithConfig(config);
+    const container = YogaDefault.Node.createWithConfig(config);
+    const label = YogaDefault.Node.createWithConfig(config);
+    const flexStart = YogaDefault.Node.createWithConfig(config);
+
+    try {
+      root.setFlexDirection(FlexDirection.Row);
+      root.setAlignItems(Align.Baseline);
+      root.setWidth(20);
+      root.setHeight(20);
+
+      tall.setWidth(4);
+      tall.setHeight(7);
+
+      container.setWidth(6);
+      container.setHeight(8);
+
+      label.setWidth(6);
+      label.setHeight(3);
+      label.setMargin(Edge.Top, 2);
+      label.setIsReferenceBaseline(true);
+      container.insertChild(label, 0);
+
+      flexStart.setWidth(2);
+      flexStart.setHeight(1);
+      flexStart.setAlignSelf(Align.FlexStart);
+
+      root.insertChild(tall, 0);
+      root.insertChild(container, 1);
+      root.insertChild(flexStart, 2);
+
+      root.calculateLayout(undefined, undefined);
+
+      expect(root.getAlignItems()).toBe(Align.Baseline);
+      expect(label.isReferenceBaseline()).toBe(true);
+      expect(flexStart.getAlignSelf()).toBe(Align.FlexStart);
+      expect(tall.getComputedLayout()).toMatchObject({
+        left: 0,
+        top: 0,
+        width: 4,
+        height: 7,
+      });
+      expect(container.getComputedLayout()).toMatchObject({
+        left: 4,
+        top: 2,
+        width: 6,
+        height: 8,
+      });
+      expect(label.getComputedLayout()).toMatchObject({
+        left: 0,
+        top: 2,
+        width: 6,
+        height: 3,
+      });
+      expect(flexStart.getComputedLayout()).toMatchObject({
+        left: 10,
+        top: 0,
+        width: 2,
+        height: 1,
+      });
+    } finally {
+      root.freeRecursive();
+      config.free();
+    }
+  });
+});

--- a/runtime/tests/tui/ink/native-ts/yoga-layout/index.test.ts
+++ b/runtime/tests/tui/ink/native-ts/yoga-layout/index.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, test } from "vitest";
+
+import YogaDefault, {
+  Align,
+  Display,
+  Edge,
+  Errata,
+  ExperimentalFeature,
+  FlexDirection,
+  Gutter,
+  Justify,
+  MeasureMode,
+  Node,
+  Overflow,
+  PositionType,
+  Unit,
+  Wrap,
+  getYogaCounters,
+  loadYoga,
+} from "./index.js";
+
+describe("yoga-layout TypeScript shim", () => {
+  test("exports the load API, node factories, and mutable config object", async () => {
+    const Yoga = await loadYoga();
+    expect(Yoga).toBe(YogaDefault);
+
+    const config = Yoga.Config.create();
+    config.setPointScaleFactor(2);
+    config.setErrata(Errata.Classic);
+    config.setUseWebDefaults(true);
+    config.setExperimentalFeatureEnabled(ExperimentalFeature.WebFlexBasis, true);
+
+    expect(config.pointScaleFactor).toBe(2);
+    expect(config.getErrata()).toBe(Errata.Classic);
+    expect(config.useWebDefaults).toBe(true);
+    expect(config.isExperimentalFeatureEnabled(ExperimentalFeature.WebFlexBasis)).toBe(
+      false,
+    );
+
+    const beforeLive = getYogaCounters().live;
+    const defaultNode = Yoga.Node.createDefault();
+    const createdNode = Yoga.Node.create();
+    const configuredNode = Yoga.Node.createWithConfig(config);
+
+    try {
+      expect(defaultNode).toBeInstanceOf(Node);
+      expect(createdNode).toBeInstanceOf(Node);
+      expect(configuredNode.config).toBe(config);
+      expect(() => Yoga.Node.destroy(createdNode)).not.toThrow();
+    } finally {
+      defaultNode.free();
+      createdNode.free();
+      configuredNode.free();
+      Yoga.Config.destroy(config);
+      config.free();
+    }
+
+    expect(getYogaCounters().live).toBe(beforeLive);
+  });
+
+  test("normalizes dimension setters and flex shorthand through public getters", () => {
+    const node = YogaDefault.Node.createDefault();
+
+    try {
+      node.setWidthPercent(50);
+      node.setHeight("25%");
+      node.setMinWidth(Number.POSITIVE_INFINITY);
+      node.setMaxHeight("bad-value");
+      node.setFlex(2);
+
+      expect(node.getWidth()).toEqual({ unit: Unit.Percent, value: 50 });
+      expect(node.getHeight()).toEqual({ unit: Unit.Percent, value: 25 });
+      expect(node.style.minWidth.unit).toBe(Unit.Undefined);
+      expect(node.style.maxHeight.unit).toBe(Unit.Undefined);
+      expect(node.getFlexGrow()).toBe(2);
+      expect(node.getFlexShrink()).toBe(1);
+      expect(node.getFlexBasis()).toEqual({ unit: Unit.Point, value: 0 });
+
+      node.setFlex(-3);
+      expect(node.getFlexGrow()).toBe(0);
+      expect(node.getFlexShrink()).toBe(3);
+
+      node.setFlex(Number.NaN);
+      expect(node.getFlexGrow()).toBe(0);
+      expect(node.getFlexShrink()).toBe(0);
+
+      node.setFlexBasisAuto();
+      expect(node.getFlexBasis().unit).toBe(Unit.Auto);
+      node.setFlexBasisPercent(30);
+      expect(node.getFlexBasis()).toEqual({ unit: Unit.Percent, value: 30 });
+    } finally {
+      node.free();
+    }
+  });
+
+  test("resolves physical edge fallbacks and percentages for computed spacing", () => {
+    const root = YogaDefault.Node.createDefault();
+    const child = YogaDefault.Node.createDefault();
+
+    try {
+      root.setWidth(200);
+      root.setHeight(100);
+      root.setPadding(Edge.All, 2);
+      root.setPaddingPercent(Edge.Horizontal, 10);
+      root.setBorder(Edge.Vertical, 3);
+      root.setBorder(Edge.Left, 4);
+
+      child.setWidth(20);
+      child.setHeight(10);
+      child.setMargin(Edge.All, 1);
+      child.setMargin(Edge.Horizontal, "10%");
+      child.setMargin(Edge.Start, 7);
+      child.setMargin(Edge.End, 9);
+      child.setMargin(Edge.Left, 3);
+
+      root.insertChild(child, 0);
+      root.calculateLayout(200, 100);
+
+      expect(root.getComputedPadding(Edge.Left)).toBe(20);
+      expect(root.getComputedPadding(Edge.End)).toBe(20);
+      expect(root.getComputedPadding(Edge.Top)).toBe(2);
+      expect(root.getComputedBorder(Edge.Left)).toBe(4);
+      expect(root.getComputedBorder(Edge.Bottom)).toBe(3);
+      expect(child.getComputedMargin(Edge.Left)).toBe(3);
+      expect(child.getComputedMargin(Edge.End)).toBe(20);
+      expect(child.getComputedMargin(99 as Edge)).toBe(3);
+    } finally {
+      root.freeRecursive();
+    }
+  });
+
+  test("measures leaf nodes, reports counters, and cache-hits unchanged layouts", () => {
+    const root = YogaDefault.Node.createDefault();
+    const measured = YogaDefault.Node.createDefault();
+    const calls: Array<{
+      width: number;
+      widthMode: MeasureMode;
+      heightMode: MeasureMode;
+    }> = [];
+
+    try {
+      root.setFlexDirection(FlexDirection.Row);
+      root.setWidth(10);
+      root.setHeight(4);
+      measured.setMeasureFunc((width, widthMode, _height, heightMode) => {
+        calls.push({ width, widthMode, heightMode });
+        return { width: Math.min(width, 6), height: 1 };
+      });
+      root.insertChild(measured, 0);
+
+      root.calculateLayout(undefined, undefined);
+      expect(calls).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            width: 10,
+            widthMode: MeasureMode.AtMost,
+            heightMode: MeasureMode.Exactly,
+          }),
+        ]),
+      );
+      expect(measured.getComputedWidth()).toBe(6);
+      expect(measured.getComputedHeight()).toBe(4);
+      expect(getYogaCounters().measured).toBeGreaterThan(0);
+
+      root.calculateLayout(undefined, undefined);
+      expect(getYogaCounters().cacheHits).toBeGreaterThan(0);
+    } finally {
+      root.freeRecursive();
+    }
+  });
+
+  test("zeros display:none subtrees and lays out display:contents children directly", () => {
+    const root = YogaDefault.Node.createDefault();
+    const hidden = YogaDefault.Node.createDefault();
+    const hiddenChild = YogaDefault.Node.createDefault();
+    const contents = YogaDefault.Node.createDefault();
+    const lifted = YogaDefault.Node.createDefault();
+
+    try {
+      root.setFlexDirection(FlexDirection.Row);
+      root.setWidth(30);
+      root.setHeight(8);
+
+      hidden.setDisplay(Display.None);
+      hidden.setWidth(5);
+      hidden.setHeight(4);
+      hiddenChild.setWidth(2);
+      hiddenChild.setHeight(2);
+      hidden.insertChild(hiddenChild, 0);
+
+      contents.setDisplay(Display.Contents);
+      contents.setWidth(20);
+      contents.setHeight(20);
+      lifted.setWidth(7);
+      lifted.setHeight(3);
+      contents.insertChild(lifted, 0);
+
+      root.insertChild(hidden, 0);
+      root.insertChild(contents, 1);
+      root.calculateLayout(undefined, undefined);
+
+      expect(hidden.getComputedLayout()).toMatchObject({
+        left: 0,
+        top: 0,
+        width: 0,
+        height: 0,
+      });
+      expect(hiddenChild.getComputedLayout()).toMatchObject({
+        left: 0,
+        top: 0,
+        width: 0,
+        height: 0,
+      });
+      expect(contents.getComputedLayout()).toMatchObject({
+        left: 0,
+        top: 0,
+        width: 0,
+        height: 0,
+      });
+      expect(lifted.getComputedLayout()).toMatchObject({
+        left: 0,
+        top: 0,
+        width: 7,
+        height: 3,
+      });
+
+      hidden.setDisplay(Display.Flex);
+      root.calculateLayout(undefined, undefined);
+
+      expect(hidden.getComputedLayout()).toMatchObject({
+        left: 0,
+        top: 0,
+        width: 5,
+        height: 4,
+      });
+      expect(hiddenChild.getComputedLayout()).toMatchObject({
+        left: 0,
+        top: 0,
+        width: 2,
+        height: 2,
+      });
+      expect(lifted.getComputedLeft()).toBe(5);
+    } finally {
+      root.freeRecursive();
+    }
+  });
+
+  test("positions flow children with auto margins, relative offsets, and gap", () => {
+    const config = YogaDefault.Config.create();
+    config.setPointScaleFactor(0);
+    const root = YogaDefault.Node.createWithConfig(config);
+    const child = YogaDefault.Node.createWithConfig(config);
+
+    try {
+      root.setFlexDirection(FlexDirection.Row);
+      root.setWidth(30);
+      root.setHeight(10);
+      root.setGap(Gutter.Column, 2);
+
+      child.setWidth(6);
+      child.setHeight(2);
+      child.setMarginAuto(Edge.Left);
+      child.setMarginAuto(Edge.Right);
+      child.setMarginAuto(Edge.Top);
+      child.setMarginAuto(Edge.Bottom);
+      child.setPosition(Edge.Top, 1);
+      child.setPositionPercent(Edge.Left, 10);
+
+      root.insertChild(child, 0);
+      root.calculateLayout(undefined, undefined);
+
+      expect(child.getComputedLayout()).toMatchObject({
+        left: 15,
+        top: 5,
+        width: 6,
+        height: 2,
+      });
+    } finally {
+      root.freeRecursive();
+      config.free();
+    }
+  });
+
+  test("derives absolute child sizes from opposing insets and padding box", () => {
+    const root = YogaDefault.Node.createDefault();
+    const child = YogaDefault.Node.createDefault();
+
+    try {
+      root.setWidth(100);
+      root.setHeight(40);
+      root.setPadding(Edge.All, 5);
+      root.setBorder(Edge.All, 1);
+
+      child.setPositionType(PositionType.Absolute);
+      child.setPositionPercent(Edge.Left, 10);
+      child.setPosition(Edge.Right, 20);
+      child.setPosition(Edge.Bottom, 4);
+      child.setHeight(6);
+
+      root.insertChild(child, 0);
+      root.calculateLayout(undefined, undefined);
+
+      expect(child.getComputedLayout()).toMatchObject({
+        left: 11,
+        top: 29,
+        width: 68,
+        height: 6,
+      });
+      expect(root.getComputedRight()).toBe(0);
+      expect(root.getComputedBottom()).toBe(0);
+    } finally {
+      root.freeRecursive();
+    }
+  });
+
+  test("wraps lines, distributes align-content space, and flips wrap-reverse", () => {
+    const root = YogaDefault.Node.createDefault();
+    const first = YogaDefault.Node.createDefault();
+    const second = YogaDefault.Node.createDefault();
+    const third = YogaDefault.Node.createDefault();
+
+    try {
+      root.setFlexDirection(FlexDirection.Row);
+      root.setFlexWrap(Wrap.WrapReverse);
+      root.setAlignContent(Align.SpaceBetween);
+      root.setJustifyContent(Justify.FlexStart);
+      root.setOverflow(Overflow.Visible);
+      root.setWidth(10);
+      root.setHeight(20);
+
+      for (const child of [first, second, third]) {
+        child.setWidth(6);
+        child.setHeight(2);
+        root.insertChild(child, root.getChildCount());
+      }
+
+      root.calculateLayout(undefined, undefined);
+
+      expect(first.getComputedTop()).toBe(18);
+      expect(second.getComputedTop()).toBe(9);
+      expect(third.getComputedTop()).toBe(0);
+      expect(root.getFlexWrap()).toBe(Wrap.WrapReverse);
+      expect(root.getAlignContent()).toBe(Align.SpaceBetween);
+      expect(root.getJustifyContent()).toBe(Justify.FlexStart);
+      expect(root.getOverflow()).toBe(Overflow.Visible);
+    } finally {
+      root.freeRecursive();
+    }
+  });
+});

--- a/runtime/tests/tui/ink/native-ts/yoga-layout/index.wave200-008.coverage.test.ts
+++ b/runtime/tests/tui/ink/native-ts/yoga-layout/index.wave200-008.coverage.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "vitest";
+
+import YogaDefault, {
+  Align,
+  FlexDirection,
+  Justify,
+  PositionType,
+  Wrap,
+} from "./index.js";
+
+describe("yoga-layout absolute fallback placement", () => {
+  test("positions inset-free absolute children from parent flex alignment", () => {
+    const config = YogaDefault.Config.create();
+    config.setPointScaleFactor(0);
+
+    const createRoot = () => {
+      const root = YogaDefault.Node.createWithConfig(config);
+      root.setWidth(100);
+      root.setHeight(40);
+      return root;
+    };
+
+    const createAbsoluteChild = () => {
+      const child = YogaDefault.Node.createWithConfig(config);
+      child.setPositionType(PositionType.Absolute);
+      child.setWidth(10);
+      child.setHeight(6);
+      return child;
+    };
+
+    const rowFlexEnd = createRoot();
+    const rowFlexEndChild = createAbsoluteChild();
+    rowFlexEnd.setFlexDirection(FlexDirection.Row);
+    rowFlexEnd.setJustifyContent(Justify.FlexEnd);
+    rowFlexEnd.setAlignItems(Align.Center);
+    rowFlexEnd.insertChild(rowFlexEndChild, 0);
+
+    const rowWrapReverse = createRoot();
+    const rowWrapReverseChild = createAbsoluteChild();
+    rowWrapReverse.setFlexDirection(FlexDirection.Row);
+    rowWrapReverse.setJustifyContent(Justify.Center);
+    rowWrapReverse.setAlignItems(Align.FlexEnd);
+    rowWrapReverse.setFlexWrap(Wrap.WrapReverse);
+    rowWrapReverse.insertChild(rowWrapReverseChild, 0);
+
+    const columnCenter = createRoot();
+    const columnCenterChild = createAbsoluteChild();
+    columnCenter.setFlexDirection(FlexDirection.Column);
+    columnCenter.setJustifyContent(Justify.Center);
+    columnCenter.setAlignItems(Align.FlexEnd);
+    columnCenter.insertChild(columnCenterChild, 0);
+
+    try {
+      rowFlexEnd.calculateLayout(undefined, undefined);
+      rowWrapReverse.calculateLayout(undefined, undefined);
+      columnCenter.calculateLayout(undefined, undefined);
+
+      expect(rowFlexEndChild.getComputedLayout()).toMatchObject({
+        left: 90,
+        top: 17,
+        width: 10,
+        height: 6,
+      });
+      expect(rowWrapReverseChild.getComputedLayout()).toMatchObject({
+        left: 45,
+        top: 0,
+        width: 10,
+        height: 6,
+      });
+      expect(columnCenterChild.getComputedLayout()).toMatchObject({
+        left: 90,
+        top: 17,
+        width: 10,
+        height: 6,
+      });
+    } finally {
+      rowFlexEnd.freeRecursive();
+      rowWrapReverse.freeRecursive();
+      columnCenter.freeRecursive();
+      config.free();
+    }
+  });
+});

--- a/runtime/tests/tui/ink/output.coverage.test.ts
+++ b/runtime/tests/tui/ink/output.coverage.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from 'vitest'
+
+import Output from './output.ts'
+import {
+  CellWidth,
+  CharPool,
+  HyperlinkPool,
+  StylePool,
+  charInCellAt,
+  createScreen,
+  setCellAt,
+} from './screen.ts'
+
+test('absolute clears prevent clean blits from restoring stale overlay rows', () => {
+  const stylePool = new StylePool()
+  const charPool = new CharPool()
+  const hyperlinkPool = new HyperlinkPool()
+  const source = createScreen(6, 3, stylePool, charPool, hyperlinkPool)
+  const target = createScreen(6, 3, stylePool, charPool, hyperlinkPool)
+
+  const rows = ['GHOST!', 'NORMAL', 'TAIL!!']
+  for (const [y, row] of rows.entries()) {
+    for (const [x, char] of [...row].entries()) {
+      setCellAt(source, x, y, {
+        char,
+        hyperlink: undefined,
+        styleId: stylePool.none,
+        width: CellWidth.Narrow,
+      })
+    }
+  }
+
+  const output = new Output({
+    height: 3,
+    screen: target,
+    stylePool,
+    width: 6,
+  })
+
+  output.clear({ height: 1, width: 6, x: 0, y: 0 }, true)
+  output.blit(source, 0, 0, 6, 3)
+
+  const screen = output.get()
+
+  expect(charInCellAt(screen, 0, 0)).toBe(' ')
+  expect(charInCellAt(screen, 5, 0)).toBe(' ')
+  expect(charInCellAt(screen, 0, 1)).toBe('N')
+  expect(charInCellAt(screen, 5, 1)).toBe('L')
+  expect(charInCellAt(screen, 0, 2)).toBe('T')
+  expect(charInCellAt(screen, 5, 2)).toBe('!')
+})

--- a/runtime/tests/tui/ink/output.wave200-033.coverage.test.ts
+++ b/runtime/tests/tui/ink/output.wave200-033.coverage.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from 'vitest'
+
+import Output from './output.ts'
+import {
+  CellWidth,
+  CharPool,
+  HyperlinkPool,
+  StylePool,
+  cellAt,
+  charInCellAt,
+  createScreen,
+} from './screen.ts'
+
+test('write skips terminal controls while preserving terminal cell positions', () => {
+  const stylePool = new StylePool()
+  const screen = createScreen(
+    16,
+    2,
+    stylePool,
+    new CharPool(),
+    new HyperlinkPool(),
+  )
+  const output = new Output({
+    height: 2,
+    screen,
+    stylePool,
+    width: 16,
+  })
+
+  output.write(
+    1,
+    0,
+    'A\tB\x1b[2JC\x1b(BD\x1b7E\x1b]0;title\x07F\x1bPpayload\x1b\\G\x07H',
+  )
+  output.write(0, 1, '\u200bZ')
+  output.write(15, 1, '\u597d')
+
+  const rendered = output.get()
+
+  expect(charInCellAt(rendered, 1, 0)).toBe('A')
+  expect(charInCellAt(rendered, 8, 0)).toBe('B')
+  expect(charInCellAt(rendered, 9, 0)).toBe('C')
+  expect(charInCellAt(rendered, 10, 0)).toBe('D')
+  expect(charInCellAt(rendered, 11, 0)).toBe('E')
+  expect(charInCellAt(rendered, 12, 0)).toBe('F')
+  expect(charInCellAt(rendered, 13, 0)).toBe('G')
+  expect(charInCellAt(rendered, 14, 0)).toBe('H')
+  expect(charInCellAt(rendered, 0, 1)).toBe('Z')
+  expect(cellAt(rendered, 15, 1)).toEqual(
+    expect.objectContaining({
+      char: ' ',
+      width: CellWidth.SpacerHead,
+    }),
+  )
+})

--- a/runtime/tests/tui/ink/parse-keypress.wave200-084.coverage.test.ts
+++ b/runtime/tests/tui/ink/parse-keypress.wave200-084.coverage.test.ts
@@ -1,0 +1,93 @@
+import { Buffer } from 'buffer'
+import { expect, test } from 'vitest'
+
+import {
+  INITIAL_STATE,
+  parseMultipleKeypresses,
+  type ParsedInput,
+  type ParsedKey,
+  type ParsedResponse,
+} from './parse-keypress.ts'
+
+function parseOne(input: Buffer | string): ParsedInput {
+  const [items] = parseMultipleKeypresses(INITIAL_STATE, input)
+
+  expect(items).toHaveLength(1)
+
+  return items[0]!
+}
+
+function parseKey(input: Buffer | string): ParsedKey {
+  const item = parseOne(input)
+
+  expect(item.kind).toBe('key')
+
+  return item as ParsedKey
+}
+
+function parseResponse(input: string): ParsedResponse {
+  const item = parseOne(input)
+
+  expect(item.kind).toBe('response')
+
+  return item as ParsedResponse
+}
+
+test('parses compatibility key encodings through the public parser', () => {
+  expect(parseResponse('\x1b[?c').response).toEqual({
+    params: [],
+    type: 'da1',
+  })
+
+  expect(parseMultipleKeypresses(INITIAL_STATE)).toEqual([
+    [],
+    expect.objectContaining({ incomplete: '', mode: 'NORMAL' }),
+  ])
+  expect(parseKey(Buffer.from('q'))).toEqual(
+    expect.objectContaining({ name: 'q', sequence: 'q' }),
+  )
+  expect(parseKey(Buffer.from([0xe1]))).toEqual(
+    expect.objectContaining({ meta: true, sequence: '\x1ba' }),
+  )
+  expect(parseKey(new String('7') as unknown as string)).toEqual(
+    expect.objectContaining({ name: 'number', sequence: '7' }),
+  )
+
+  const csiUKeyNames = new Map<number, string | undefined>([
+    [9, 'tab'],
+    [32, 'space'],
+    [57400, '1'],
+    [57401, '2'],
+    [57402, '3'],
+    [57403, '4'],
+    [57404, '5'],
+    [57405, '6'],
+    [57406, '7'],
+    [57407, '8'],
+    [57408, '9'],
+    [57409, '.'],
+    [57410, '/'],
+    [57411, '*'],
+    [57412, '-'],
+    [57413, '+'],
+    [57415, '='],
+    [0xf0000, undefined],
+    [0x100000, undefined],
+  ])
+
+  for (const [codepoint, name] of csiUKeyNames) {
+    expect(parseKey(`\x1b[${codepoint}u`)).toEqual(
+      expect.objectContaining({ name }),
+    )
+  }
+
+  expect(parseKey('\x1b[1~')).toEqual(
+    expect.objectContaining({ ctrl: false, name: 'home' }),
+  )
+  expect(parseKey('\x1b[4~')).toEqual(
+    expect.objectContaining({ ctrl: false, name: 'end' }),
+  )
+  expect(parseKey('\x1b[1;5D')).toEqual(
+    expect.objectContaining({ ctrl: true, name: 'left' }),
+  )
+})

--- a/runtime/tests/tui/ink/reconciler.coverage2.test.ts
+++ b/runtime/tests/tui/ink/reconciler.coverage2.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from 'vitest'
+
+import { getOwnerChain } from './reconciler.ts'
+
+type ComponentFn = (() => null) & {
+  displayName?: string
+}
+
+type TestFiber = {
+  elementType?: ComponentFn | string | { displayName?: string; name?: string } | null
+  _debugOwner?: TestFiber | null
+  return?: TestFiber | null
+}
+
+function FunctionNameOwner(): null {
+  return null
+}
+
+test('walks reconciler owner fibers while skipping hosts, repeats, and cycles', () => {
+  const DisplayNameOwner = (() => null) as ComponentFn
+  DisplayNameOwner.displayName = 'DisplayNameOwner'
+
+  const ignoredHostReturn: TestFiber = {
+    elementType: { displayName: 'IgnoredHostReturn' },
+  }
+  const objectNameOwner: TestFiber = {
+    elementType: { name: 'ObjectNameOwner' },
+  }
+  const debugOwner: TestFiber = {
+    elementType: DisplayNameOwner,
+    return: objectNameOwner,
+  }
+  const hostFiber: TestFiber = {
+    elementType: 'ink-box',
+    _debugOwner: debugOwner,
+    return: ignoredHostReturn,
+  }
+  const leafFiber: TestFiber = {
+    elementType: FunctionNameOwner,
+    _debugOwner: hostFiber,
+  }
+
+  expect(getOwnerChain(leafFiber)).toEqual([
+    'FunctionNameOwner',
+    'DisplayNameOwner',
+    'ObjectNameOwner',
+  ])
+
+  const repeatedParent: TestFiber = {
+    elementType: { name: 'RepeatedOwner' },
+  }
+  const repeatedChild: TestFiber = {
+    elementType: { displayName: 'RepeatedOwner' },
+    return: repeatedParent,
+  }
+
+  expect(getOwnerChain(repeatedChild)).toEqual(['RepeatedOwner'])
+
+  const cyclicOwner: TestFiber = {
+    elementType: { displayName: 'CyclicOwner' },
+  }
+  cyclicOwner.return = cyclicOwner
+
+  expect(getOwnerChain(cyclicOwner)).toEqual(['CyclicOwner'])
+  expect(getOwnerChain(null)).toEqual([])
+})

--- a/runtime/tests/tui/ink/reconciler.wave200-031.coverage.test.ts
+++ b/runtime/tests/tui/ink/reconciler.wave200-031.coverage.test.ts
@@ -1,0 +1,189 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { expect, test, vi } from 'vitest'
+
+import type { DOMElement, ElementNames } from './dom.ts'
+import { LayoutDisplay } from './layout/node.ts'
+import { createRoot, type Root } from './root.ts'
+import instances from './instances.ts'
+
+vi.mock('../../utils/fullscreen.js', () => ({
+  isMouseClicksDisabled: () => false,
+}))
+
+type TestStdout = PassThrough & {
+  columns: number
+  rows: number
+  isTTY: boolean
+}
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  setRawMode: (mode: boolean) => void
+  ref: () => void
+  unref: () => void
+}
+
+const RAW_TEXT_STYLE = {
+  flexDirection: 'row',
+  flexGrow: 0,
+  flexShrink: 1,
+  textWrap: 'wrap',
+} as const
+
+const Activity = React.Activity as React.ElementType<{
+  mode: 'visible' | 'hidden'
+  children: React.ReactNode
+}>
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function createTestStreams(): {
+  stdout: TestStdout
+  stdin: TestStdin
+} {
+  const stdout = new PassThrough() as TestStdout
+  const stdin = new PassThrough() as TestStdin
+
+  stdout.columns = 80
+  stdout.rows = 24
+  stdout.isTTY = true
+
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+
+  return { stdout, stdin }
+}
+
+function getRootNode(stdout: TestStdout): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream) as
+    | { rootNode?: DOMElement }
+    | undefined
+
+  if (!instance?.rootNode) {
+    throw new Error('Ink root node not found')
+  }
+
+  return instance.rootNode
+}
+
+function findElement(
+  node: DOMElement,
+  nodeName: ElementNames,
+): DOMElement | undefined {
+  if (node.nodeName === nodeName) {
+    return node
+  }
+
+  for (const child of node.childNodes) {
+    if (child.nodeName === '#text') {
+      continue
+    }
+
+    const found = findElement(child, nodeName)
+    if (found) {
+      return found
+    }
+  }
+
+  return undefined
+}
+
+function requireElement(
+  stdout: TestStdout,
+  nodeName: ElementNames,
+): DOMElement {
+  const found = findElement(getRootNode(stdout), nodeName)
+
+  if (!found) {
+    throw new Error(`Expected to find ${nodeName}`)
+  }
+
+  return found
+}
+
+async function createHarness(): Promise<{
+  root: Root
+  stdout: TestStdout
+  stdin: TestStdin
+  dispose: () => Promise<void>
+}> {
+  const { stdout, stdin } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  return {
+    root,
+    stdout,
+    stdin,
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep(25)
+    },
+  }
+}
+
+function renderNestedText(mode: 'visible' | 'hidden'): React.ReactElement {
+  return React.createElement(
+    Activity,
+    { mode },
+    React.createElement(
+      'ink-text',
+      {
+        style: RAW_TEXT_STYLE,
+      },
+      'outer ',
+      React.createElement(
+        'ink-text',
+        {
+          style: RAW_TEXT_STYLE,
+        },
+        'inner',
+      ),
+    ),
+  )
+}
+
+test('reconciler virtualizes nested text and toggles Activity visibility in place', async () => {
+  const harness = await createHarness()
+
+  try {
+    harness.root.render(renderNestedText('visible'))
+    await sleep(25)
+
+    const hostText = requireElement(harness.stdout, 'ink-text')
+    const virtualText = requireElement(harness.stdout, 'ink-virtual-text')
+
+    expect(virtualText.parentNode).toBe(hostText)
+    expect(hostText.isHidden).toBeUndefined()
+    expect(hostText.yogaNode?.getDisplay()).toBe(LayoutDisplay.Flex)
+
+    harness.root.render(renderNestedText('hidden'))
+    await sleep(25)
+
+    const hiddenHostText = requireElement(harness.stdout, 'ink-text')
+    expect(hiddenHostText).toBe(hostText)
+    expect(hiddenHostText.isHidden).toBe(true)
+    expect(hiddenHostText.yogaNode?.getDisplay()).toBe(LayoutDisplay.None)
+
+    harness.root.render(renderNestedText('visible'))
+    await sleep(25)
+
+    const visibleHostText = requireElement(harness.stdout, 'ink-text')
+    expect(visibleHostText).toBe(hostText)
+    expect(visibleHostText.isHidden).toBe(false)
+    expect(visibleHostText.yogaNode?.getDisplay()).toBe(LayoutDisplay.Flex)
+  } finally {
+    await harness.dispose()
+  }
+})

--- a/runtime/tests/tui/ink/render-node-to-output.coverage.test.ts
+++ b/runtime/tests/tui/ink/render-node-to-output.coverage.test.ts
@@ -1,10 +1,30 @@
 import { describe, expect, test } from 'vitest'
 
 import {
+  appendChildNode,
+  createNode,
+  createTextNode,
+  type DOMElement,
+} from './dom.ts'
+import Output from './output.ts'
+import {
   applyStylesToWrappedText,
   buildCharToSegmentMap,
+  consumeFollowScroll,
+  getScrollDrainNode,
+  getScrollHint,
+  resetScrollDrainNode,
+  resetScrollHint,
 } from './render-node-to-output.ts'
+import renderNodeToOutput from './render-node-to-output.ts'
+import {
+  CharPool,
+  createScreen,
+  HyperlinkPool,
+  StylePool,
+} from './screen.ts'
 import type { StyledSegment } from './squash-text-nodes.ts'
+import applyStyles, { type Styles } from './styles.ts'
 
 const OSC = '\u001B]'
 const BEL = '\u0007'
@@ -15,6 +35,68 @@ function link(text: string, url: string): string {
 
 function mapFor(segments: StyledSegment[]): number[] {
   return buildCharToSegmentMap(segments)
+}
+
+function applyNodeStyle(node: DOMElement, style: Styles): void {
+  node.style = { ...node.style, ...style }
+  if (node.yogaNode) applyStyles(node.yogaNode, style, style)
+}
+
+function appendText(parent: DOMElement, text: string): void {
+  appendChildNode(parent, createTextNode(text) as unknown as DOMElement)
+}
+
+function createOutput(width: number, height: number): Output {
+  const stylePool = new StylePool()
+  return new Output({
+    height,
+    screen: createScreen(width, height, stylePool, new CharPool(), new HyperlinkPool()),
+    stylePool,
+    width,
+  })
+}
+
+function createScrollableTree(options: {
+  pendingScrollDelta?: number
+  scrollTop?: number
+  stickyScroll?: boolean
+}): { root: DOMElement; scrollBox: DOMElement } {
+  const root = createNode('ink-root')
+  applyNodeStyle(root, {
+    flexDirection: 'column',
+    height: 4,
+    width: 10,
+  })
+
+  const scrollBox = createNode('ink-box')
+  applyNodeStyle(scrollBox, {
+    flexDirection: 'column',
+    height: 3,
+    overflowY: 'scroll',
+    width: 10,
+  })
+  scrollBox.scrollTop = options.scrollTop
+  scrollBox.pendingScrollDelta = options.pendingScrollDelta
+  scrollBox.stickyScroll = options.stickyScroll
+
+  const content = createNode('ink-box')
+  applyNodeStyle(content, {
+    flexDirection: 'column',
+    flexShrink: 0,
+    width: 10,
+  })
+
+  for (let i = 0; i < 12; i += 1) {
+    const line = createNode('ink-text')
+    appendText(line, `line-${i}`)
+    appendChildNode(content, line)
+  }
+
+  appendChildNode(scrollBox, content)
+  appendChildNode(root, scrollBox)
+  root.yogaNode?.calculateLayout(10, 4)
+
+  return { root, scrollBox }
 }
 
 describe('render-node-to-output coverage', () => {
@@ -71,5 +153,79 @@ describe('render-node-to-output coverage', () => {
         true,
       ),
     ).toBe(link('AB', 'https://example.test/leading'))
+  })
+
+  test('xterm scroll drain snaps excess and leaves a drain node for the next frame', () => {
+    const previousTermProgram = process.env.TERM_PROGRAM
+    process.env.TERM_PROGRAM = 'vscode'
+    resetScrollHint()
+    resetScrollDrainNode()
+
+    try {
+      const { root, scrollBox } = createScrollableTree({
+        pendingScrollDelta: 40,
+        scrollTop: 0,
+      })
+
+      renderNodeToOutput(root, createOutput(10, 4), { prevScreen: undefined })
+
+      expect(scrollBox.scrollTop).toBe(2)
+      expect(scrollBox.pendingScrollDelta).toBe(38)
+      expect(getScrollDrainNode()).toBe(scrollBox)
+      expect(getScrollHint()).toBeNull()
+    } finally {
+      if (previousTermProgram === undefined) {
+        delete process.env.TERM_PROGRAM
+      } else {
+        process.env.TERM_PROGRAM = previousTermProgram
+      }
+      resetScrollHint()
+      resetScrollDrainNode()
+    }
+  })
+
+  test('small scroll drain clears completed deltas and records follow-scroll movement', () => {
+    const previousTermProgram = process.env.TERM_PROGRAM
+    delete process.env.TERM_PROGRAM
+    resetScrollHint()
+    resetScrollDrainNode()
+
+    try {
+      const { root, scrollBox } = createScrollableTree({
+        pendingScrollDelta: 2,
+        scrollTop: 0,
+      })
+
+      renderNodeToOutput(root, createOutput(10, 4), { prevScreen: undefined })
+
+      expect(scrollBox.scrollTop).toBe(2)
+      expect(scrollBox.pendingScrollDelta).toBeUndefined()
+      expect(getScrollDrainNode()).toBeNull()
+      expect(consumeFollowScroll()).toBeNull()
+
+      const followTree = createScrollableTree({
+        scrollTop: 0,
+        stickyScroll: true,
+      })
+      renderNodeToOutput(followTree.root, createOutput(10, 4), {
+        prevScreen: undefined,
+      })
+
+      expect(followTree.scrollBox.scrollTop).toBe(9)
+      expect(consumeFollowScroll()).toEqual({
+        delta: 9,
+        viewportBottom: 2,
+        viewportTop: 0,
+      })
+    } finally {
+      if (previousTermProgram === undefined) {
+        delete process.env.TERM_PROGRAM
+      } else {
+        process.env.TERM_PROGRAM = previousTermProgram
+      }
+      resetScrollHint()
+      resetScrollDrainNode()
+      consumeFollowScroll()
+    }
   })
 })

--- a/runtime/tests/tui/ink/render-node-to-output.coverage.test.ts
+++ b/runtime/tests/tui/ink/render-node-to-output.coverage.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  applyStylesToWrappedText,
+  buildCharToSegmentMap,
+} from './render-node-to-output.ts'
+import type { StyledSegment } from './squash-text-nodes.ts'
+
+const OSC = '\u001B]'
+const BEL = '\u0007'
+
+function link(text: string, url: string): string {
+  return `${OSC}8;;${url}${BEL}${text}${OSC}8;;${BEL}`
+}
+
+function mapFor(segments: StyledSegment[]): number[] {
+  return buildCharToSegmentMap(segments)
+}
+
+describe('render-node-to-output coverage', () => {
+  test('maps trim-wrapped text back to linked segments after skipped whitespace', () => {
+    const softWrappedSegments: StyledSegment[] = [
+      {
+        hyperlink: 'https://example.test/first',
+        styles: {},
+        text: 'AB   ',
+      },
+      {
+        hyperlink: 'https://example.test/second',
+        styles: {},
+        text: '\tD\n ',
+      },
+      {
+        hyperlink: 'https://example.test/third',
+        styles: {},
+        text: 'EF',
+      },
+    ]
+
+    expect(
+      applyStylesToWrappedText(
+        'AB\n\tD\nEF',
+        softWrappedSegments,
+        mapFor(softWrappedSegments),
+        softWrappedSegments.map(segment => segment.text).join(''),
+        true,
+      ),
+    ).toBe(
+      [
+        link('AB', 'https://example.test/first'),
+        link('\tD', 'https://example.test/second'),
+        link('EF', 'https://example.test/third'),
+      ].join('\n'),
+    )
+
+    const leadingTrimSegments: StyledSegment[] = [
+      { styles: {}, text: '  ' },
+      {
+        hyperlink: 'https://example.test/leading',
+        styles: {},
+        text: 'AB',
+      },
+    ]
+
+    expect(
+      applyStylesToWrappedText(
+        'AB',
+        leadingTrimSegments,
+        mapFor(leadingTrimSegments),
+        leadingTrimSegments.map(segment => segment.text).join(''),
+        true,
+      ),
+    ).toBe(link('AB', 'https://example.test/leading'))
+  })
+})

--- a/runtime/tests/tui/ink/render-node-to-output.wave200-009.coverage.test.ts
+++ b/runtime/tests/tui/ink/render-node-to-output.wave200-009.coverage.test.ts
@@ -1,0 +1,101 @@
+import { expect, test } from 'vitest'
+
+import {
+  appendChildNode,
+  createNode,
+  createTextNode,
+  setAttribute,
+  setStyle,
+  type DOMElement,
+} from './dom.ts'
+import Output from './output.ts'
+import renderNodeToOutput from './render-node-to-output.ts'
+import {
+  CharPool,
+  HyperlinkPool,
+  StylePool,
+  charInCellAt,
+  createScreen,
+} from './screen.ts'
+import applyStyles, { type Styles } from './styles.ts'
+
+function applyNodeStyle(node: DOMElement, style: Styles): void {
+  setStyle(node, style)
+  if (node.yogaNode) applyStyles(node.yogaNode, style, style)
+}
+
+function appendText(parent: DOMElement, text: string): void {
+  appendChildNode(parent, createTextNode(text) as unknown as DOMElement)
+}
+
+test('renders a top-clamped absolute overlay without selecting its gutter row', () => {
+  const root = createNode('ink-root')
+  applyNodeStyle(root, {
+    flexDirection: 'column',
+    height: 3,
+    width: 8,
+  })
+
+  const gutter = createNode('ink-box')
+  applyNodeStyle(gutter, {
+    height: 1,
+    marginLeft: 2,
+    noSelect: 'from-left-edge',
+    width: 4,
+  })
+
+  const gutterText = createNode('ink-text')
+  appendText(gutterText, 'SIDE')
+  appendChildNode(gutter, gutterText)
+
+  const raw = createNode('ink-raw-ansi')
+  setAttribute(raw, 'rawText', '\u001B[31mRAW\u001B[0m')
+  setAttribute(raw, 'rawWidth', 3)
+  setAttribute(raw, 'rawHeight', 1)
+
+  const overlay = createNode('ink-box')
+  applyNodeStyle(overlay, {
+    height: 1,
+    left: 1,
+    opaque: true,
+    position: 'absolute',
+    top: -1,
+    width: 5,
+  })
+
+  const overlayText = createNode('ink-text')
+  appendText(overlayText, 'TOP')
+  appendChildNode(overlay, overlayText)
+
+  appendChildNode(root, gutter)
+  appendChildNode(root, raw)
+  appendChildNode(root, overlay)
+  root.yogaNode?.calculateLayout(8, 3)
+
+  const stylePool = new StylePool()
+  const screen = createScreen(
+    8,
+    3,
+    stylePool,
+    new CharPool(),
+    new HyperlinkPool(),
+  )
+  const output = new Output({
+    height: 3,
+    screen,
+    stylePool,
+    width: 8,
+  })
+
+  renderNodeToOutput(root, output, { prevScreen: undefined })
+  const rendered = output.get()
+
+  expect(charInCellAt(rendered, 1, 0)).toBe('T')
+  expect(charInCellAt(rendered, 2, 0)).toBe('O')
+  expect(charInCellAt(rendered, 3, 0)).toBe('P')
+  expect(charInCellAt(rendered, 4, 0)).toBe(' ')
+  expect(charInCellAt(rendered, 0, 1)).toBe('R')
+  expect(charInCellAt(rendered, 1, 1)).toBe('A')
+  expect(charInCellAt(rendered, 2, 1)).toBe('W')
+  expect([...rendered.noSelect.slice(0, 8)]).toEqual([1, 1, 1, 1, 1, 1, 0, 0])
+})

--- a/runtime/tests/tui/ink/render-to-screen.wave200-096.coverage.test.tsx
+++ b/runtime/tests/tui/ink/render-to-screen.wave200-096.coverage.test.tsx
@@ -1,0 +1,100 @@
+import { expect, test } from 'vitest'
+
+import Box from './components/Box.tsx'
+import Text from './components/Text.tsx'
+import {
+  applyPositionedHighlight,
+  renderToScreen,
+  scanPositions,
+} from './render-to-screen.ts'
+import {
+  CellWidth,
+  CharPool,
+  HyperlinkPool,
+  StylePool,
+  cellAt,
+  charInCellAt,
+  createScreen,
+  setCellAt,
+  type Screen,
+} from './screen.ts'
+
+function makeScreen(width: number, height: number): {
+  screen: Screen
+  styles: StylePool
+} {
+  const styles = new StylePool()
+  return {
+    screen: createScreen(width, height, styles, new CharPool(), new HyperlinkPool()),
+    styles,
+  }
+}
+
+function writeCell(
+  screen: Screen,
+  styles: StylePool,
+  x: number,
+  y: number,
+  char: string,
+  width = CellWidth.Narrow,
+): void {
+  setCellAt(screen, x, y, {
+    char,
+    hyperlink: undefined,
+    styleId: styles.none,
+    width,
+  })
+}
+
+function rowText(screen: Screen, row: number): string {
+  return Array.from({ length: screen.width }, (_, col) =>
+    charInCellAt(screen, col, row),
+  ).join('')
+}
+
+test('renders reusable search screens and clips positioned highlights', () => {
+  const element = (
+    <Box flexDirection="column" width={12}>
+      <Text>Alpha</Text>
+      <Text>Beta</Text>
+    </Box>
+  )
+  let rendered = renderToScreen(element, 12)
+  for (let index = 1; index < 20; index++) {
+    rendered = renderToScreen(element, 12)
+  }
+
+  expect(rendered.height).toBeGreaterThanOrEqual(2)
+  expect(rowText(rendered.screen, 0)).toContain('Alpha')
+  expect(rowText(rendered.screen, 1)).toContain('Beta')
+  expect(scanPositions(rendered.screen, 'ta')).toContainEqual({
+    col: 2,
+    len: 2,
+    row: 1,
+  })
+
+  const { screen, styles } = makeScreen(7, 2)
+  writeCell(screen, styles, 0, 0, 'A')
+  writeCell(screen, styles, 1, 0, '好', CellWidth.Wide)
+  writeCell(screen, styles, 3, 0, 'B')
+  writeCell(screen, styles, 4, 0, 'x')
+  writeCell(screen, styles, 5, 0, 'A')
+  writeCell(screen, styles, 6, 0, 'B')
+  screen.noSelect[4] = 1
+
+  expect(scanPositions(screen, '')).toEqual([])
+  expect(scanPositions(screen, 'BA')).toEqual([{ col: 3, len: 3, row: 0 }])
+
+  expect(applyPositionedHighlight(screen, styles, [], 0, 0)).toBe(false)
+  expect(
+    applyPositionedHighlight(screen, styles, [{ col: 0, len: 1, row: 0 }], -1, 0),
+  ).toBe(false)
+  expect(
+    applyPositionedHighlight(screen, styles, [{ col: -1, len: 9, row: 1 }], 0, 0),
+  ).toBe(true)
+
+  const currentMatch = styles.withCurrentMatch(styles.none)
+  for (let col = 0; col < screen.width; col++) {
+    expect(cellAt(screen, col, 1)?.styleId).toBe(currentMatch)
+  }
+})

--- a/runtime/tests/tui/ink/screen.wave200-040.coverage.test.ts
+++ b/runtime/tests/tui/ink/screen.wave200-040.coverage.test.ts
@@ -1,0 +1,175 @@
+import { expect, test } from 'vitest'
+
+import {
+  CellWidth,
+  CharPool,
+  HyperlinkPool,
+  StylePool,
+  blitRegion,
+  cellAt,
+  charInCellAt,
+  clearRegion,
+  createScreen,
+  diffEach,
+  isEmptyCellAt,
+  resetScreen,
+  setCellAt,
+  setCellStyleId,
+  shiftRows,
+  visibleCellAtIndex,
+  type Screen,
+} from './screen.ts'
+
+function makePools(): {
+  chars: CharPool
+  links: HyperlinkPool
+  styles: StylePool
+} {
+  return {
+    chars: new CharPool(),
+    links: new HyperlinkPool(),
+    styles: new StylePool(),
+  }
+}
+
+function makeScreen(width: number, height: number): {
+  screen: Screen
+  styles: StylePool
+} {
+  const { chars, links, styles } = makePools()
+  return {
+    screen: createScreen(width, height, styles, chars, links),
+    styles,
+  }
+}
+
+function writeCell(
+  screen: Screen,
+  styles: StylePool,
+  x: number,
+  y: number,
+  char: string,
+  width = CellWidth.Narrow,
+): void {
+  setCellAt(screen, x, y, {
+    char,
+    hyperlink: undefined,
+    styleId: styles.none,
+    width,
+  })
+}
+
+test('preserves packed screen invariants across wide-cell edges and clipped diffs', () => {
+  const pools = makePools()
+  const normalized = createScreen(3.9, -2, pools.styles, pools.chars, pools.links)
+  expect(normalized).toMatchObject({ height: 0, width: 3 })
+  expect(isEmptyCellAt(normalized, -1, 0)).toBe(true)
+
+  resetScreen(normalized, 4.8, 2.2)
+  expect(normalized).toMatchObject({ height: 2, width: 4 })
+
+  const charPool = new CharPool()
+  expect(charPool.get(999)).toBe(' ')
+  const nonAscii = charPool.intern('é')
+  expect(charPool.intern('é')).toBe(nonAscii)
+  expect(new HyperlinkPool().get(0)).toBeUndefined()
+
+  const inverseBoldUnderline = pools.styles.intern([
+    { code: '\x1b[7m', endCode: '\x1b[27m', type: 'ansi' },
+    { code: '\x1b[1m', endCode: '\x1b[22m', type: 'ansi' },
+    { code: '\x1b[4m', endCode: '\x1b[24m', type: 'ansi' },
+    { code: '\x1b[31m', endCode: '\x1b[39m', type: 'ansi' },
+    { code: '\x1b[48;2;2;3;4m', endCode: '\x1b[49m', type: 'ansi' },
+  ])
+  const currentMatch = pools.styles.withCurrentMatch(inverseBoldUnderline)
+  expect(
+    pools.styles.get(currentMatch).map(style => style.endCode),
+  ).not.toContain('\x1b[49m')
+
+  const selectionBg = {
+    code: '\x1b[48;2;9;8;7m',
+    endCode: '\x1b[49m',
+    type: 'ansi' as const,
+  }
+  pools.styles.setSelectionBg(selectionBg)
+  const selected = pools.styles.withSelectionBg(inverseBoldUnderline)
+  pools.styles.setSelectionBg(selectionBg)
+  expect(pools.styles.withSelectionBg(inverseBoldUnderline)).toBe(selected)
+
+  const { screen: wide, styles } = makeScreen(5, 1)
+  writeCell(wide, styles, 1, 0, '好', CellWidth.Wide)
+  expect(visibleCellAtIndex(wide.cells, wide.charPool, wide.hyperlinkPool, 2, -1))
+    .toBeUndefined()
+
+  writeCell(wide, styles, 1, 0, 'x')
+  expect(cellAt(wide, 2, 0)).toMatchObject({
+    char: ' ',
+    width: CellWidth.Narrow,
+  })
+
+  writeCell(wide, styles, 1, 0, '好', CellWidth.Wide)
+  writeCell(wide, styles, 0, 0, '本', CellWidth.Wide)
+  expect(cellAt(wide, 1, 0)?.width).toBe(CellWidth.SpacerTail)
+  expect(cellAt(wide, 2, 0)).toMatchObject({
+    char: ' ',
+    width: CellWidth.Narrow,
+  })
+
+  const tailStyle = styles.intern([
+    { code: '\x1b[32m', endCode: '\x1b[39m', type: 'ansi' },
+  ])
+  setCellStyleId(wide, 1, 0, tailStyle)
+  expect(cellAt(wide, 1, 0)?.styleId).toBe(styles.none)
+
+  const { screen: src, styles: srcStyles } = makeScreen(4, 1)
+  writeCell(src, srcStyles, 1, 0, '界', CellWidth.Wide)
+  const dst = createScreen(4, 1, srcStyles, src.charPool, src.hyperlinkPool)
+  blitRegion(dst, src, 0, 0, 2, 1)
+  expect(cellAt(dst, 2, 0)?.width).toBe(CellWidth.SpacerTail)
+  expect(dst.damage).toEqual({ height: 1, width: 3, x: 0, y: 0 })
+  blitRegion(dst, src, 3, 0, 2, 1)
+  expect(dst.damage).toEqual({ height: 1, width: 3, x: 0, y: 0 })
+
+  const { screen: clearFull, styles: clearStyles } = makeScreen(3, 2)
+  writeCell(clearFull, clearStyles, 0, 0, 'a')
+  writeCell(clearFull, clearStyles, 1, 1, 'b')
+  clearFull.damage = undefined
+  clearRegion(clearFull, 0, 0, 3, 2)
+  expect(clearFull.damage).toEqual({ height: 2, width: 3, x: 0, y: 0 })
+  expect(charInCellAt(clearFull, 1, 1)).toBe(' ')
+
+  const { screen: clearRight, styles: clearRightStyles } = makeScreen(4, 1)
+  writeCell(clearRight, clearRightStyles, 2, 0, '語', CellWidth.Wide)
+  clearRight.damage = undefined
+  clearRegion(clearRight, 1, 0, 2, 1)
+  expect(cellAt(clearRight, 3, 0)).toMatchObject({
+    char: ' ',
+    width: CellWidth.Narrow,
+  })
+  expect(clearRight.damage).toEqual({ height: 1, width: 3, x: 1, y: 0 })
+
+  writeCell(normalized, pools.styles, 0, 0, 'n')
+  shiftRows(normalized, -1, 1, 1)
+  expect(charInCellAt(normalized, 0, 0)).toBe('n')
+
+  const { screen: prev, styles: diffStyles } = makeScreen(3, 2)
+  const next = createScreen(3, 1, diffStyles, prev.charPool, prev.hyperlinkPool)
+  writeCell(prev, diffStyles, 0, 1, 'r')
+  let removed: string | undefined
+  const stoppedOnRemoval = diffEach(prev, next, (_x, _y, oldCell) => {
+    removed = oldCell?.char
+    return true
+  })
+  expect(stoppedOnRemoval).toBe(true)
+  expect(removed).toBe('r')
+
+  const wider = createScreen(4, 1, diffStyles, prev.charPool, prev.hyperlinkPool)
+  writeCell(wider, diffStyles, 3, 0, 'z')
+  let added: string | undefined
+  const stoppedOnAddition = diffEach(next, wider, (_x, _y, _oldCell, newCell) => {
+    added = newCell?.char
+    return true
+  })
+  expect(stoppedOnAddition).toBe(true)
+  expect(added).toBe('z')
+})

--- a/runtime/tests/tui/ink/selection.wave200-046.coverage.test.ts
+++ b/runtime/tests/tui/ink/selection.wave200-046.coverage.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'vitest'
+
+import { createSelectionState, shiftSelection } from './selection.ts'
+
+describe('selection shift coverage', () => {
+  test('prunes stale scroll accumulators and clamps anchor spans', () => {
+    const staleAbove = createSelectionState()
+    staleAbove.anchor = { col: 1, row: 0 }
+    staleAbove.focus = { col: 2, row: 1 }
+    staleAbove.anchorSpan = {
+      hi: { col: 2, row: 1 },
+      kind: 'word',
+      lo: { col: 1, row: 0 },
+    }
+    staleAbove.scrolledOffAbove = ['old-above']
+    staleAbove.scrolledOffAboveSW = [true]
+
+    shiftSelection(staleAbove, 0, 0, 2, 5)
+
+    expect(staleAbove.scrolledOffAbove).toEqual([])
+    expect(staleAbove.scrolledOffAboveSW).toEqual([])
+    expect(staleAbove.anchorSpan).toEqual({
+      hi: { col: 2, row: 1 },
+      kind: 'word',
+      lo: { col: 1, row: 0 },
+    })
+
+    const staleBelow = createSelectionState()
+    staleBelow.anchor = { col: 1, row: 0 }
+    staleBelow.focus = { col: 2, row: 1 }
+    staleBelow.scrolledOffBelow = ['old-below']
+    staleBelow.scrolledOffBelowSW = [false]
+
+    shiftSelection(staleBelow, 0, 0, 2, 5)
+
+    expect(staleBelow.scrolledOffBelow).toEqual([])
+    expect(staleBelow.scrolledOffBelowSW).toEqual([])
+
+    const restoringBelowDebt = createSelectionState()
+    restoringBelowDebt.anchor = { col: 1, row: 0 }
+    restoringBelowDebt.focus = { col: 2, row: 2 }
+    restoringBelowDebt.virtualFocusRow = 4
+    restoringBelowDebt.scrolledOffBelow = ['near', 'far']
+    restoringBelowDebt.scrolledOffBelowSW = [true, false]
+
+    shiftSelection(restoringBelowDebt, -1, 0, 2, 5)
+
+    expect(restoringBelowDebt.focus).toEqual({ col: 4, row: 2 })
+    expect(restoringBelowDebt.virtualFocusRow).toBe(3)
+    expect(restoringBelowDebt.scrolledOffBelow).toEqual(['far'])
+    expect(restoringBelowDebt.scrolledOffBelowSW).toEqual([false])
+
+    const topClampedSpan = createSelectionState()
+    topClampedSpan.anchor = { col: 1, row: 1 }
+    topClampedSpan.focus = { col: 2, row: 1 }
+    topClampedSpan.anchorSpan = {
+      hi: { col: 3, row: 1 },
+      kind: 'line',
+      lo: { col: 1, row: 0 },
+    }
+
+    shiftSelection(topClampedSpan, -1, 0, 2, 5)
+
+    expect(topClampedSpan.anchorSpan).toEqual({
+      hi: { col: 3, row: 0 },
+      kind: 'line',
+      lo: { col: 0, row: 0 },
+    })
+
+    const bottomClampedSpan = createSelectionState()
+    bottomClampedSpan.anchor = { col: 1, row: 1 }
+    bottomClampedSpan.focus = { col: 2, row: 1 }
+    bottomClampedSpan.anchorSpan = {
+      hi: { col: 3, row: 2 },
+      kind: 'line',
+      lo: { col: 1, row: 1 },
+    }
+
+    shiftSelection(bottomClampedSpan, 1, 0, 2, 5)
+
+    expect(bottomClampedSpan.anchorSpan).toEqual({
+      hi: { col: 4, row: 2 },
+      kind: 'line',
+      lo: { col: 1, row: 2 },
+    })
+  })
+})

--- a/runtime/tests/tui/ink/stringWidth.wave200-111.coverage.test.ts
+++ b/runtime/tests/tui/ink/stringWidth.wave200-111.coverage.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, expect, test, vi } from 'vitest'
+
+type StringWidthModule = typeof import('./stringWidth.js')
+
+async function loadStringWidth(): Promise<StringWidthModule> {
+  vi.resetModules()
+  return import('./stringWidth.js')
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.resetModules()
+})
+
+test('measures terminal cell widths through fallback and Bun module branches', async () => {
+  vi.stubGlobal('Bun', undefined)
+
+  const fallback = await loadStringWidth()
+  const singleRegionalIndicator = String.fromCodePoint(0x1f1fa)
+  const pairedRegionalIndicators = String.fromCodePoint(0x1f1fa, 0x1f1f8)
+  const emojiPresentation = String.fromCodePoint(0x1f600)
+  const tagCharacter = String.fromCodePoint(0xe0000)
+  const variationSelectorSupplement = String.fromCodePoint(0xe0100)
+
+  const fallbackCases: Array<readonly [input: string, width: number]> = [
+    ['abc\t', 3],
+    ['\x1b[31m\x1b[39m', 0],
+    ['\x1b[32mgreen\x1b[39m', 5],
+    [emojiPresentation, 2],
+    [singleRegionalIndicator, 1],
+    [pairedRegionalIndicators, 2],
+    ['1\ufe0f', 1],
+    ['#\ufe0f', 1],
+    ['*\ufe0f', 1],
+    ['1\ufe0f\u20e3', 2],
+    ['a\x85', 1],
+    ['\u00ad', 0],
+    ['\u200b\ufeff\u2060', 0],
+    ['\ufe0e' + variationSelectorSupplement, 0],
+    ['e\u0301\u1ab0\u1dc0\u20d0\ufe20', 1],
+    ['\u0900\u093e\u0951\u0962', 0],
+    ['\u0e31\u0e34\u0e47\u0eb1\u0eb4\u0ec8', 0],
+    ['\u0600\u06dd\u070f\u08e2', 0],
+    ['\ud800' + tagCharacter, 0],
+  ]
+
+  for (const [input, width] of fallbackCases) {
+    expect(fallback.stringWidth(input)).toBe(width)
+  }
+
+  const bunStringWidth = vi.fn(
+    (
+      input: string,
+      options?: { readonly ambiguousIsNarrow?: boolean },
+    ): number => (options?.ambiguousIsNarrow ? input.length : 0),
+  )
+
+  vi.stubGlobal('Bun', { stringWidth: bunStringWidth })
+
+  const bunBacked = await loadStringWidth()
+
+  expect(bunBacked.stringWidth('wide?')).toBe(5)
+  expect(bunStringWidth).toHaveBeenCalledWith('wide?', {
+    ambiguousIsNarrow: true,
+  })
+})

--- a/runtime/tests/tui/ink/styles.wave200-051.coverage.test.ts
+++ b/runtime/tests/tui/ink/styles.wave200-051.coverage.test.ts
@@ -1,0 +1,208 @@
+import { expect, test, vi } from 'vitest'
+
+import {
+  LayoutAlign,
+  LayoutDisplay,
+  LayoutEdge,
+  LayoutFlexDirection,
+  LayoutGutter,
+  LayoutJustify,
+  LayoutOverflow,
+  LayoutPositionType,
+  LayoutWrap,
+  type LayoutNode,
+} from './layout/node.ts'
+import applyStyles, { type Styles } from './styles.ts'
+
+function createLayoutNode(): LayoutNode {
+  return {
+    setPositionType: vi.fn(),
+    setPosition: vi.fn(),
+    setPositionPercent: vi.fn(),
+    setOverflow: vi.fn(),
+    setMargin: vi.fn(),
+    setPadding: vi.fn(),
+    setFlexGrow: vi.fn(),
+    setFlexShrink: vi.fn(),
+    setFlexWrap: vi.fn(),
+    setFlexDirection: vi.fn(),
+    setFlexBasis: vi.fn(),
+    setFlexBasisPercent: vi.fn(),
+    setAlignItems: vi.fn(),
+    setAlignSelf: vi.fn(),
+    setJustifyContent: vi.fn(),
+    setWidth: vi.fn(),
+    setWidthPercent: vi.fn(),
+    setWidthAuto: vi.fn(),
+    setHeight: vi.fn(),
+    setHeightPercent: vi.fn(),
+    setHeightAuto: vi.fn(),
+    setMinWidth: vi.fn(),
+    setMinWidthPercent: vi.fn(),
+    setMinHeight: vi.fn(),
+    setMinHeightPercent: vi.fn(),
+    setMaxWidth: vi.fn(),
+    setMaxWidthPercent: vi.fn(),
+    setMaxHeight: vi.fn(),
+    setMaxHeightPercent: vi.fn(),
+    setDisplay: vi.fn(),
+    setBorder: vi.fn(),
+    setGap: vi.fn(),
+  } as unknown as LayoutNode
+}
+
+function expectPositionCall(
+  node: LayoutNode,
+  edge: (typeof LayoutEdge)[keyof typeof LayoutEdge],
+  value: number,
+): void {
+  expect(
+    vi
+      .mocked(node.setPosition)
+      .mock.calls.some(([actualEdge, actualValue]) => {
+        return actualEdge === edge && Object.is(actualValue, value)
+      }),
+  ).toBe(true)
+}
+
+test('maps less common style branches to layout node setters', () => {
+  const node = createLayoutNode()
+
+  applyStyles(
+    node,
+    {
+      position: 'absolute',
+      top: '25%',
+      bottom: undefined,
+      left: 3,
+      right: undefined,
+      overflowX: 'hidden',
+      overflowY: 'visible',
+      margin: undefined,
+      marginX: 0,
+      marginY: 2,
+      marginLeft: 0,
+      marginRight: 0,
+      marginTop: 4,
+      marginBottom: 0,
+      padding: undefined,
+      paddingX: 1,
+      paddingY: 0,
+      paddingLeft: 0,
+      paddingRight: 5,
+      paddingTop: 0,
+      paddingBottom: 6,
+      flexGrow: undefined,
+      flexShrink: undefined,
+      flexWrap: 'wrap-reverse',
+      flexDirection: 'row-reverse',
+      flexBasis: '45%',
+      alignItems: undefined,
+      alignSelf: 'center',
+      justifyContent: 'space-evenly',
+      width: undefined,
+      height: '40%',
+      minWidth: '25%',
+      minHeight: '30%',
+      maxWidth: undefined,
+      maxHeight: '80%',
+      display: 'flex',
+      borderStyle: 'single',
+      borderTop: false,
+      borderBottom: true,
+      borderLeft: false,
+      borderRight: true,
+      gap: undefined,
+      columnGap: undefined,
+      rowGap: 4,
+    } as Styles,
+    {
+      borderStyle: 'single',
+      borderTop: false,
+      borderBottom: true,
+      borderLeft: false,
+      borderRight: true,
+    } as Styles,
+  )
+
+  applyStyles(node, {
+    flexWrap: 'nowrap',
+    flexDirection: 'column-reverse',
+    flexBasis: undefined,
+    alignSelf: 'auto',
+    justifyContent: 'space-around',
+    height: undefined,
+    maxWidth: '70%',
+    display: 'none',
+    borderRight: false,
+    columnGap: 0,
+  } as Styles)
+
+  applyStyles(node, {
+    overflow: 'scroll',
+    flexWrap: 'wrap',
+    flexDirection: 'column',
+    alignSelf: 'flex-start',
+    justifyContent: 'flex-start',
+    maxHeight: undefined,
+    rowGap: undefined,
+  } as Styles)
+
+  expect(node.setPositionType).toHaveBeenCalledWith(LayoutPositionType.Absolute)
+  expect(node.setPositionPercent).toHaveBeenCalledWith(LayoutEdge.Top, 25)
+  expectPositionCall(node, LayoutEdge.Bottom, Number.NaN)
+  expect(node.setPosition).toHaveBeenCalledWith(LayoutEdge.Left, 3)
+  expectPositionCall(node, LayoutEdge.Right, Number.NaN)
+  expect(node.setOverflow).toHaveBeenCalledWith(LayoutOverflow.Hidden)
+  expect(node.setOverflow).toHaveBeenCalledWith(LayoutOverflow.Scroll)
+
+  expect(node.setMargin).toHaveBeenCalledWith(LayoutEdge.All, 0)
+  expect(node.setMargin).toHaveBeenCalledWith(LayoutEdge.Horizontal, 0)
+  expect(node.setMargin).toHaveBeenCalledWith(LayoutEdge.End, 0)
+  expect(node.setPadding).toHaveBeenCalledWith(LayoutEdge.All, 0)
+  expect(node.setPadding).toHaveBeenCalledWith(LayoutEdge.Left, 0)
+
+  expect(node.setFlexGrow).toHaveBeenCalledWith(0)
+  expect(node.setFlexShrink).toHaveBeenCalledWith(1)
+  expect(node.setFlexWrap).toHaveBeenCalledWith(LayoutWrap.WrapReverse)
+  expect(node.setFlexWrap).toHaveBeenCalledWith(LayoutWrap.NoWrap)
+  expect(node.setFlexWrap).toHaveBeenCalledWith(LayoutWrap.Wrap)
+  expect(node.setFlexDirection).toHaveBeenCalledWith(
+    LayoutFlexDirection.RowReverse,
+  )
+  expect(node.setFlexDirection).toHaveBeenCalledWith(
+    LayoutFlexDirection.ColumnReverse,
+  )
+  expect(node.setFlexDirection).toHaveBeenCalledWith(LayoutFlexDirection.Column)
+  expect(node.setFlexBasisPercent).toHaveBeenCalledWith(45)
+  expect(node.setFlexBasis).toHaveBeenCalledWith(Number.NaN)
+  expect(node.setAlignItems).toHaveBeenCalledWith(LayoutAlign.Stretch)
+  expect(node.setAlignSelf).toHaveBeenCalledWith(LayoutAlign.Center)
+  expect(node.setAlignSelf).toHaveBeenCalledWith(LayoutAlign.Auto)
+  expect(node.setAlignSelf).toHaveBeenCalledWith(LayoutAlign.FlexStart)
+  expect(node.setJustifyContent).toHaveBeenCalledWith(LayoutJustify.SpaceEvenly)
+  expect(node.setJustifyContent).toHaveBeenCalledWith(LayoutJustify.SpaceAround)
+  expect(node.setJustifyContent).toHaveBeenCalledWith(LayoutJustify.FlexStart)
+
+  expect(node.setWidthAuto).toHaveBeenCalled()
+  expect(node.setHeightPercent).toHaveBeenCalledWith(40)
+  expect(node.setHeightAuto).toHaveBeenCalled()
+  expect(node.setMinWidthPercent).toHaveBeenCalledWith(25)
+  expect(node.setMinHeightPercent).toHaveBeenCalledWith(30)
+  expect(node.setMaxWidth).toHaveBeenCalledWith(0)
+  expect(node.setMaxWidthPercent).toHaveBeenCalledWith(70)
+  expect(node.setMaxHeightPercent).toHaveBeenCalledWith(80)
+  expect(node.setMaxHeight).toHaveBeenCalledWith(0)
+  expect(node.setDisplay).toHaveBeenCalledWith(LayoutDisplay.Flex)
+  expect(node.setDisplay).toHaveBeenCalledWith(LayoutDisplay.None)
+
+  expect(node.setBorder).toHaveBeenCalledWith(LayoutEdge.Top, 0)
+  expect(node.setBorder).toHaveBeenCalledWith(LayoutEdge.Bottom, 1)
+  expect(node.setBorder).toHaveBeenCalledWith(LayoutEdge.Left, 0)
+  expect(node.setBorder).toHaveBeenCalledWith(LayoutEdge.Right, 1)
+  expect(node.setBorder).toHaveBeenCalledWith(LayoutEdge.Right, 0)
+  expect(node.setGap).toHaveBeenCalledWith(LayoutGutter.All, 0)
+  expect(node.setGap).toHaveBeenCalledWith(LayoutGutter.Column, 0)
+  expect(node.setGap).toHaveBeenCalledWith(LayoutGutter.Row, 4)
+  expect(node.setGap).toHaveBeenCalledWith(LayoutGutter.Row, 0)
+})

--- a/runtime/tests/tui/ink/terminal.wave200-041.coverage.test.ts
+++ b/runtime/tests/tui/ink/terminal.wave200-041.coverage.test.ts
@@ -1,0 +1,313 @@
+import type { Writable } from 'stream'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import type { Diff } from './frame.ts'
+import type { Terminal } from './terminal.ts'
+
+type EnvOverrides = Record<string, string | undefined>
+
+const TERMINAL_ENV_KEYS = [
+  'AGENC_ENABLE_EXTENDED_KEYS',
+  'ALACRITTY_LOG',
+  'ConEmuANSI',
+  'ConEmuPID',
+  'ConEmuTask',
+  'CURSOR_TRACE_ID',
+  'GNOME_TERMINAL_SERVICE',
+  'KITTY_WINDOW_ID',
+  'KONSOLE_VERSION',
+  'MSYSTEM',
+  'NODE_ENV',
+  'SESSIONNAME',
+  'SSH_CLIENT',
+  'SSH_CONNECTION',
+  'SSH_TTY',
+  'STY',
+  'TERM',
+  'TERMINAL_EMULATOR',
+  'TERM_PROGRAM',
+  'TERM_PROGRAM_VERSION',
+  'TERMINATOR_UUID',
+  'TILIX_ID',
+  'TMUX',
+  'VSCODE_GIT_ASKPASS_MAIN',
+  'VTE_VERSION',
+  'VisualStudioVersion',
+  'WSL_DISTRO_NAME',
+  'WT_SESSION',
+  'XTERM_VERSION',
+  'ZED_TERM',
+  '__CFBundleIdentifier',
+] as const
+
+const originalEnv = new Map(
+  TERMINAL_ENV_KEYS.map(key => [key, process.env[key]]),
+)
+const originalStdoutIsTTY = Object.getOwnPropertyDescriptor(
+  process.stdout,
+  'isTTY',
+)
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+function resetTerminalEnv(overrides: EnvOverrides = {}): void {
+  for (const key of TERMINAL_ENV_KEYS) {
+    delete process.env[key]
+  }
+  process.env.NODE_ENV = 'test'
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+function restoreTerminalEnv(): void {
+  for (const key of TERMINAL_ENV_KEYS) {
+    const value = originalEnv.get(key)
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+function setStdoutIsTTY(value: boolean): void {
+  Object.defineProperty(process.stdout, 'isTTY', {
+    configurable: true,
+    value,
+    writable: true,
+  })
+}
+
+function restoreStdoutIsTTY(): void {
+  if (originalStdoutIsTTY) {
+    Object.defineProperty(process.stdout, 'isTTY', originalStdoutIsTTY)
+  } else {
+    delete (process.stdout as { isTTY?: boolean }).isTTY
+  }
+}
+
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    enumerable: true,
+    value,
+  })
+}
+
+async function importTerminal(overrides: EnvOverrides = {}) {
+  vi.resetModules()
+  resetTerminalEnv(overrides)
+  return import('./terminal.ts')
+}
+
+function makeTerminal(writes: string[]): Terminal {
+  const stdout = {
+    write: (chunk: string | Uint8Array): boolean => {
+      writes.push(
+        typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'),
+      )
+      return true
+    },
+  } as unknown as Writable
+
+  return {
+    stderr: stdout,
+    stdout,
+  }
+}
+
+afterEach(() => {
+  restoreTerminalEnv()
+  restoreStdoutIsTTY()
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  }
+  vi.restoreAllMocks()
+  vi.resetModules()
+})
+
+describe('terminal capability detection', () => {
+  test('detects progress reporting support from TTY state and terminal env', async () => {
+    const terminal = await importTerminal()
+
+    setStdoutIsTTY(false)
+    expect(terminal.isProgressReportingAvailable()).toBe(false)
+
+    setStdoutIsTTY(true)
+    resetTerminalEnv({ WT_SESSION: '1' })
+    expect(terminal.isProgressReportingAvailable()).toBe(false)
+
+    resetTerminalEnv({ ConEmuPID: '100' })
+    expect(terminal.isProgressReportingAvailable()).toBe(true)
+
+    resetTerminalEnv({ TERM_PROGRAM_VERSION: 'not-a-version' })
+    expect(terminal.isProgressReportingAvailable()).toBe(false)
+
+    resetTerminalEnv({
+      TERM_PROGRAM: 'ghostty',
+      TERM_PROGRAM_VERSION: '1.1.9',
+    })
+    expect(terminal.isProgressReportingAvailable()).toBe(false)
+
+    resetTerminalEnv({
+      TERM_PROGRAM: 'ghostty',
+      TERM_PROGRAM_VERSION: '1.2.0',
+    })
+    expect(terminal.isProgressReportingAvailable()).toBe(true)
+
+    resetTerminalEnv({
+      TERM_PROGRAM: 'iTerm.app',
+      TERM_PROGRAM_VERSION: '3.6.5',
+    })
+    expect(terminal.isProgressReportingAvailable()).toBe(false)
+
+    resetTerminalEnv({
+      TERM_PROGRAM: 'iTerm.app',
+      TERM_PROGRAM_VERSION: '3.6.6',
+    })
+    expect(terminal.isProgressReportingAvailable()).toBe(true)
+
+    resetTerminalEnv({
+      TERM_PROGRAM: 'WezTerm',
+      TERM_PROGRAM_VERSION: '20240203',
+    })
+    expect(terminal.isProgressReportingAvailable()).toBe(false)
+  })
+
+  test('detects synchronized output support from known terminals', async () => {
+    const terminal = await importTerminal()
+
+    const supportedCases: EnvOverrides[] = [
+      { TERM_PROGRAM: 'WezTerm' },
+      { TERM: 'xterm-kitty' },
+      { KITTY_WINDOW_ID: '42' },
+      { TERM: 'xterm-ghostty' },
+      { TERM: 'foot-extra' },
+      { TERM: 'xterm-alacritty' },
+      { ZED_TERM: '1' },
+      { WT_SESSION: 'session' },
+      { VTE_VERSION: '6800' },
+    ]
+
+    for (const env of supportedCases) {
+      resetTerminalEnv(env)
+      expect(terminal.isSynchronizedOutputSupported()).toBe(true)
+    }
+
+    resetTerminalEnv({ TERM_PROGRAM: 'WezTerm', TMUX: '1' })
+    expect(terminal.isSynchronizedOutputSupported()).toBe(false)
+
+    resetTerminalEnv({ TERM_PROGRAM: 'Apple_Terminal', VTE_VERSION: '6799' })
+    expect(terminal.isSynchronizedOutputSupported()).toBe(false)
+  })
+
+  test('freezes synchronized output and extended key support at import time', async () => {
+    const synced = await importTerminal({ TERM_PROGRAM: 'WezTerm' })
+    expect(synced.SYNC_OUTPUT_SUPPORTED).toBe(true)
+    expect(synced.supportsExtendedKeys()).toBe(false)
+
+    const extendedKeys = await importTerminal({
+      AGENC_ENABLE_EXTENDED_KEYS: '1',
+      TERM_PROGRAM: 'WezTerm',
+    })
+    expect(extendedKeys.SYNC_OUTPUT_SUPPORTED).toBe(true)
+    expect(extendedKeys.supportsExtendedKeys()).toBe(true)
+
+    const xtermJs = await importTerminal({
+      AGENC_ENABLE_EXTENDED_KEYS: '1',
+      TERM_PROGRAM: 'vscode',
+    })
+    expect(xtermJs.supportsExtendedKeys()).toBe(false)
+
+    const tmux = await importTerminal({
+      AGENC_ENABLE_EXTENDED_KEYS: '1',
+      TMUX: '1',
+    })
+    expect(tmux.SYNC_OUTPUT_SUPPORTED).toBe(false)
+    expect(tmux.supportsExtendedKeys()).toBe(true)
+  })
+
+  test('uses XTVERSION once for terminal identity probes', async () => {
+    const testMode = await importTerminal({ TERM_PROGRAM: 'ghostty' })
+    expect(testMode.isGhosttyTerminal()).toBe(false)
+
+    const ghostty = await importTerminal({ NODE_ENV: 'development' })
+    expect(ghostty.isGhosttyTerminal()).toBe(false)
+
+    ghostty.setXtversionName('Ghostty 1.2.0')
+    expect(ghostty.isGhosttyTerminal()).toBe(true)
+    expect(ghostty.shouldSkipMainScreenSyncMarkers()).toBe(true)
+    expect(ghostty.shouldUseMainScreenRewrite()).toBe(true)
+
+    ghostty.setXtversionName('xterm.js 5.3.0')
+    expect(ghostty.isGhosttyTerminal()).toBe(true)
+    expect(ghostty.isXtermJs()).toBe(false)
+
+    const xterm = await importTerminal()
+    xterm.setXtversionName('xterm.js 5.3.0')
+    expect(xterm.isXtermJs()).toBe(true)
+
+    resetTerminalEnv({ TERM_PROGRAM: 'vscode' })
+    expect(xterm.isXtermJs()).toBe(true)
+  })
+
+  test('detects cursor-up viewport yank risk on Windows-style terminals', async () => {
+    const terminal = await importTerminal()
+
+    setPlatform('linux')
+    resetTerminalEnv()
+    expect(terminal.hasCursorUpViewportYankBug()).toBe(false)
+
+    resetTerminalEnv({ WT_SESSION: 'session' })
+    expect(terminal.hasCursorUpViewportYankBug()).toBe(true)
+
+    setPlatform('win32')
+    resetTerminalEnv()
+    expect(terminal.hasCursorUpViewportYankBug()).toBe(true)
+  })
+})
+
+describe('writeDiffToTerminal', () => {
+  test('serializes every patch type and skips empty diffs', async () => {
+    const terminal = await importTerminal()
+    const writes: string[] = []
+    const output = makeTerminal(writes)
+
+    terminal.writeDiffToTerminal(output, [], true)
+    expect(writes).toEqual([])
+
+    const diff: Diff = [
+      { type: 'stdout', content: 'hi' },
+      { type: 'clear', count: 2 },
+      { type: 'clearTerminal', reason: 'clear' },
+      { type: 'cursorHide' },
+      { type: 'cursorShow' },
+      { type: 'cursorMove', x: -2, y: 3 },
+      { type: 'cursorTo', col: 5 },
+      { type: 'carriageReturn' },
+      { type: 'hyperlink', uri: '' },
+      { type: 'styleStr', str: '\x1b[31m' },
+    ]
+
+    terminal.writeDiffToTerminal(output, diff, true)
+    expect(writes).toEqual([
+      'hi' +
+        '\x1b[2K\x1b[1A\x1b[2K\x1b[G' +
+        '\x1b[2J\x1b[3J\x1b[H' +
+        '\x1b[?25l' +
+        '\x1b[?25h' +
+        '\x1b[2D\x1b[3B' +
+        '\x1b[5G' +
+        '\r' +
+        '\x1b]8;;\x07' +
+        '\x1b[31m',
+    ])
+
+    terminal.writeDiffToTerminal(output, [{ type: 'stdout', content: 'sync' }])
+    expect(writes[1]).toBe('\x1b[?2026hsync\x1b[?2026l')
+  })
+})

--- a/runtime/tests/tui/ink/termio/osc.wave200-025.coverage.test.ts
+++ b/runtime/tests/tui/ink/termio/osc.wave200-025.coverage.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const originalEnv = { ...process.env }
+const originalPlatform = process.platform
+
+const envMock = { terminal: 'xterm' as string | null }
+const execFileNoThrowMock = vi.fn(
+  async () => ({ code: 0, stdout: '', stderr: '' }),
+)
+
+function installOscMocks(): void {
+  vi.doMock('../../../utils/env.js', () => ({
+    env: envMock,
+  }))
+
+  vi.doMock('../../../utils/execFileNoThrow.js', () => ({
+    execFileNoThrow: execFileNoThrowMock,
+    execFileNoThrowWithCwd: execFileNoThrowMock,
+  }))
+}
+
+async function importFreshOscModule() {
+  return import('./osc.ts')
+}
+
+async function flushClipboardCopy(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+async function waitForExecCall(
+  command: string,
+): Promise<(typeof execFileNoThrowMock.mock.calls)[number] | undefined> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const call = execFileNoThrowMock.mock.calls.find(([cmd]) => cmd === command)
+    if (call) return call
+    await flushClipboardCopy()
+  }
+
+  return undefined
+}
+
+describe('OSC wave200-025 coverage', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    installOscMocks()
+    envMock.terminal = 'kitty'
+    execFileNoThrowMock.mockReset()
+    execFileNoThrowMock.mockResolvedValue({ code: 0, stdout: '', stderr: '' })
+    process.env = { ...originalEnv }
+    delete process.env['LC_TERMINAL']
+    delete process.env['SSH_CONNECTION']
+    delete process.env['STY']
+    delete process.env['TMUX']
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+    Object.defineProperty(process, 'platform', { value: originalPlatform })
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  test('formats tab status, wraps multiplexer sequences, and uses clipboard fallbacks', async () => {
+    const {
+      OSC,
+      _resetLinuxCopyCache,
+      parseOSC,
+      setClipboard,
+      tabStatus,
+      wrapForMultiplexer,
+    } = await importFreshOscModule()
+
+    expect(
+      tabStatus({
+        indicator: { type: 'rgb', r: 1, g: 2, b: 3 },
+        status: 'build;ok\\done',
+        statusColor: { type: 'rgb', r: 255, g: 0, b: 16 },
+      }),
+    ).toBe(
+      `\x1b]${OSC.TAB_STATUS};indicator=#010203;status=build\\;ok\\\\done;status-color=#ff0010\x1b\\`,
+    )
+    expect(
+      tabStatus({ indicator: null, status: null, statusColor: null }),
+    ).toBe(`\x1b]${OSC.TAB_STATUS};indicator=;status=;status-color=\x1b\\`)
+
+    expect(
+      parseOSC(
+        `${OSC.TAB_STATUS};indicator=rgb:f/80/0;status=left\\;right\\\\done;status-color=#0a0b0c;unused=value`,
+      ),
+    ).toEqual({
+      type: 'tabStatus',
+      action: {
+        indicator: { type: 'rgb', r: 255, g: 128, b: 0 },
+        status: 'left;right\\done',
+        statusColor: { type: 'rgb', r: 10, g: 11, b: 12 },
+      },
+    })
+    expect(parseOSC(`${OSC.TAB_STATUS};indicator=;status=;status-color=`)).toEqual(
+      {
+        type: 'tabStatus',
+        action: { indicator: null, status: null, statusColor: null },
+      },
+    )
+
+    process.env['TMUX'] = '/tmp/tmux-1000/default,123,0'
+    expect(wrapForMultiplexer('\x1b]0;title\x07')).toBe(
+      '\x1bPtmux;\x1b\x1b]0;title\x07\x1b\\',
+    )
+    delete process.env['TMUX']
+    process.env['STY'] = 'screen-session'
+    expect(wrapForMultiplexer('plain')).toBe('\x1bPplain\x1b\\')
+    delete process.env['STY']
+
+    process.env['TMUX'] = '/tmp/tmux-1000/default,123,0'
+    process.env['SSH_CONNECTION'] = 'client server'
+    process.env['LC_TERMINAL'] = 'iTerm2'
+    execFileNoThrowMock.mockClear()
+
+    const tmuxText = 'tmux copy'
+    const tmuxSequence = await setClipboard(tmuxText)
+    const tmuxB64 = Buffer.from(tmuxText, 'utf8').toString('base64')
+
+    expect(tmuxSequence).toBe(
+      `\x1bPtmux;\x1b\x1b]52;c;${tmuxB64}\x07\x1b\\`,
+    )
+    expect(execFileNoThrowMock).toHaveBeenCalledWith(
+      'tmux',
+      ['load-buffer', '-'],
+      {
+        input: tmuxText,
+        timeout: 2000,
+        useCwd: false,
+      },
+    )
+
+    delete process.env['TMUX']
+    delete process.env['SSH_CONNECTION']
+    delete process.env['LC_TERMINAL']
+    _resetLinuxCopyCache()
+    execFileNoThrowMock.mockReset()
+    execFileNoThrowMock
+      .mockResolvedValueOnce({ code: 1, stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ code: 0, stdout: '', stderr: '' })
+      .mockResolvedValue({ code: 0, stdout: '', stderr: '' })
+
+    const linuxText = 'local linux'
+    const linuxSequence = await setClipboard(linuxText)
+    const linuxB64 = Buffer.from(linuxText, 'utf8').toString('base64')
+    const xclipProbe = await waitForExecCall('xclip')
+
+    expect(linuxSequence).toBe(`\x1b]52;c;${linuxB64}\x1b\\`)
+    expect(execFileNoThrowMock.mock.calls[0]).toEqual([
+      'wl-copy',
+      [],
+      { input: linuxText, timeout: 2000, useCwd: false },
+    ])
+    expect(xclipProbe).toEqual([
+      'xclip',
+      ['-selection', 'clipboard'],
+      { input: linuxText, timeout: 2000, useCwd: false },
+    ])
+
+    execFileNoThrowMock.mockClear()
+    await setClipboard('cached linux')
+    const cachedXclip = await waitForExecCall('xclip')
+
+    expect(cachedXclip).toEqual([
+      'xclip',
+      ['-selection', 'clipboard'],
+      { input: 'cached linux', timeout: 2000, useCwd: false },
+    ])
+  })
+})

--- a/runtime/tests/tui/ink/useTerminalNotification.wave200-132.coverage.test.tsx
+++ b/runtime/tests/tui/ink/useTerminalNotification.wave200-132.coverage.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import {
+  type TerminalNotification,
+  TerminalWriteProvider,
+  useTerminalNotification,
+} from './useTerminalNotification.js'
+
+const terminalHarness = vi.hoisted(() => ({
+  progressAvailable: false,
+}))
+
+vi.mock('../../../utils/env.js', () => ({
+  env: { terminal: 'xterm' },
+}))
+
+vi.mock('./terminal.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('./terminal.js')>()
+  return {
+    ...actual,
+    isProgressReportingAvailable: () => terminalHarness.progressAvailable,
+  }
+})
+
+const originalTmux = process.env['TMUX']
+const originalSty = process.env['STY']
+
+afterEach(() => {
+  terminalHarness.progressAvailable = false
+
+  if (originalTmux === undefined) {
+    delete process.env['TMUX']
+  } else {
+    process.env['TMUX'] = originalTmux
+  }
+
+  if (originalSty === undefined) {
+    delete process.env['STY']
+  } else {
+    process.env['STY'] = originalSty
+  }
+})
+
+function osc(...parts: (number | string)[]): string {
+  return `\x1b]${parts.join(';')}\x07`
+}
+
+function CaptureNotification({
+  onCapture,
+}: {
+  readonly onCapture: (notification: TerminalNotification) => void
+}): null {
+  onCapture(useTerminalNotification())
+  return null
+}
+
+async function renderNotificationHarness(
+  writes: string[],
+): Promise<TerminalNotification> {
+  let captured: TerminalNotification | undefined
+
+  delete process.env['TMUX']
+  delete process.env['STY']
+
+  await renderToString(
+    <TerminalWriteProvider value={data => writes.push(data)}>
+      <CaptureNotification onCapture={notification => (captured = notification)} />
+    </TerminalWriteProvider>,
+    20,
+  )
+
+  if (captured === undefined) {
+    throw new Error('terminal notification hook did not render')
+  }
+
+  return captured
+}
+
+describe('useTerminalNotification wave200 coverage', () => {
+  test('writes terminal notifications and gates progress OSC sequences', async () => {
+    const writes: string[] = []
+    const notification = await renderNotificationHarness(writes)
+
+    notification.progress('running', 42)
+    expect(writes).toEqual([])
+
+    notification.notifyITerm2({ message: 'build passed', title: 'AgenC' })
+    notification.notifyITerm2({ message: 'plain notice' })
+    notification.notifyKitty({ id: 7, message: 'job complete', title: 'Worker' })
+    notification.notifyGhostty({ message: 'ready', title: 'Session' })
+    notification.notifyBell()
+
+    terminalHarness.progressAvailable = true
+    notification.progress(null)
+    notification.progress('completed')
+    notification.progress('error', -4.5)
+    notification.progress('indeterminate')
+    notification.progress('running', 100.5)
+    notification.progress('running')
+
+    expect(writes).toEqual([
+      osc(9, '\n\nAgenC:\nbuild passed'),
+      osc(9, '\n\nplain notice'),
+      osc(99, 'i=7:d=0:p=title', 'Worker'),
+      osc(99, 'i=7:p=body', 'job complete'),
+      osc(99, 'i=7:d=1:a=focus', ''),
+      osc(777, 'notify', 'Session', 'ready'),
+      '\x07',
+      osc(9, 4, 0, ''),
+      osc(9, 4, 0, ''),
+      osc(9, 4, 2, 0),
+      osc(9, 4, 3, ''),
+      osc(9, 4, 1, 100),
+      osc(9, 4, 1, 0),
+    ])
+  })
+})

--- a/runtime/tests/tui/input/processPromptInput.coverage.test.ts
+++ b/runtime/tests/tui/input/processPromptInput.coverage.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { processPromptInput } from './processPromptInput.js'
+
+function bridgeContext(commands: any[]) {
+  return {
+    options: { commands },
+    getAppState: () => ({
+      toolPermissionContext: { mode: 'default' },
+    }),
+    setAppState: () => {},
+    requestPrompt: async () => '',
+  } as any
+}
+
+describe('processPromptInput coverage', () => {
+  test('executes bridge-safe slash commands even when slash commands are skipped', async () => {
+    const call = vi.fn(async (args: string) => ({
+      type: 'text',
+      value: `bridge result: ${args}`,
+    }))
+    const load = vi.fn(async () => ({ call }))
+
+    const result = await processPromptInput({
+      input: '/help remote status',
+      mode: 'prompt' as any,
+      setToolJSX: () => {},
+      context: bridgeContext([
+        {
+          type: 'local',
+          name: 'help',
+          description: 'Show help',
+          load,
+        },
+      ]),
+      skipSlashCommands: true,
+      bridgeOrigin: true,
+      skipAttachments: true,
+    })
+
+    expect(load).toHaveBeenCalledTimes(1)
+    expect(call).toHaveBeenCalledWith('remote status', expect.any(Object))
+    expect(result.shouldQuery).toBe(false)
+    expect(result.resultText).toBe('bridge result: remote status')
+    expect(JSON.stringify(result.messages)).toContain(
+      '<local-command-stdout>bridge result: remote status</local-command-stdout>',
+    )
+  })
+})

--- a/runtime/tests/tui/input/processPromptInput.coverage2.test.ts
+++ b/runtime/tests/tui/input/processPromptInput.coverage2.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'vitest'
+
+import { processPromptInput } from './processPromptInput.js'
+
+function contextWithBlockingHook() {
+  return {
+    options: { commands: [] },
+    services: {
+      hooks: {
+        userPromptSubmitHooks: [
+          () => ({
+            additionalContexts: ['x'.repeat(10001)],
+            blockingError: {
+              blockingError: 'blocked by local policy',
+            },
+          }),
+        ],
+      },
+    },
+    getAppState: () => ({
+      toolPermissionContext: { mode: 'default' },
+    }),
+    setAppState: () => {},
+    requestPrompt: async () => '',
+  } as any
+}
+
+describe('processPromptInput coverage hooks', () => {
+  test('returns hook context and warning when a prompt-submit hook blocks', async () => {
+    const result = await processPromptInput({
+      input: 'summarize the deployment plan',
+      mode: 'prompt' as any,
+      setToolJSX: () => {},
+      context: contextWithBlockingHook(),
+      skipAttachments: true,
+    })
+
+    expect(result.shouldQuery).toBe(false)
+    expect(result.messages).toHaveLength(2)
+
+    const contextMessage = result.messages[0] as any
+    expect(contextMessage.type).toBe('attachment')
+    expect(contextMessage.attachment.type).toBe('hook_additional_context')
+    expect(contextMessage.attachment.content[0]).toContain(
+      '[output truncated - exceeded 10000 characters]',
+    )
+
+    const warningMessage = result.messages[1] as any
+    expect(warningMessage.type).toBe('system')
+    expect(warningMessage.level).toBe('warning')
+    expect(warningMessage.content).toBe(
+      'UserPromptSubmit operation blocked by hook:\n' +
+        'blocked by local policy\n\n' +
+        'Original prompt: summarize the deployment plan',
+    )
+  })
+})

--- a/runtime/tests/tui/input/processPromptInput.wave200-014.coverage.test.ts
+++ b/runtime/tests/tui/input/processPromptInput.wave200-014.coverage.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'vitest'
+
+import { processPromptInput } from './processPromptInput.js'
+
+function contextWithPromptHooks(hooks: any[]) {
+  const emitted: unknown[] = []
+
+  return {
+    context: {
+      options: { commands: [] },
+      services: {
+        hooks: {
+          userPromptSubmitHooks: hooks,
+        },
+      },
+      session: {
+        emit: (event: unknown) => emitted.push(event),
+        nextInternalSubId: () => `hook-warning-${emitted.length + 1}`,
+      },
+      getAppState: () => ({
+        toolPermissionContext: { mode: 'default' },
+      }),
+      setAppState: () => {},
+      requestPrompt: async () => '',
+    } as any,
+    emitted,
+  }
+}
+
+describe('processPromptInput prompt-submit hook coverage', () => {
+  test('emits hook warnings and appends only non-progress hook messages', async () => {
+    const { context, emitted } = contextWithPromptHooks([
+      () => {
+        throw new Error('lint hook exploded')
+      },
+      () => ({
+        message: {
+          type: 'progress',
+          attachment: { type: 'hook_progress' },
+        },
+      }),
+      () => ({
+        additionalContexts: [],
+        message: {
+          type: 'attachment',
+          attachment: {
+            type: 'hook_success',
+            content: 'approved context',
+          },
+        },
+      }),
+      () => ({
+        message: {
+          type: 'attachment',
+          attachment: {
+            type: 'hook_stderr',
+            content: 'nonblocking note',
+          },
+        },
+      }),
+    ])
+
+    const result = await processPromptInput({
+      input: 'prepare release notes',
+      mode: 'prompt' as any,
+      setToolJSX: () => {},
+      context,
+      skipAttachments: true,
+    })
+
+    expect(result.shouldQuery).toBe(true)
+    expect(result.messages).toHaveLength(3)
+    expect((result.messages[1] as any).attachment).toEqual({
+      type: 'hook_success',
+      content: 'approved context',
+    })
+    expect((result.messages[2] as any).attachment).toEqual({
+      type: 'hook_stderr',
+      content: 'nonblocking note',
+    })
+    expect(JSON.stringify(result.messages)).not.toContain('hook_progress')
+    expect(emitted).toEqual([
+      {
+        id: 'hook-warning-1',
+        msg: {
+          type: 'warning',
+          payload: {
+            cause: 'user_prompt_submit_hook_threw',
+            message: 'UserPromptSubmit hook 0 failed: lint hook exploded',
+          },
+        },
+      },
+    ])
+  })
+})

--- a/runtime/tests/tui/input/processTextPrompt.wave200-130.coverage.test.ts
+++ b/runtime/tests/tui/input/processTextPrompt.wave200-130.coverage.test.ts
@@ -1,0 +1,113 @@
+import type { ContentBlockParam } from '@anthropic-ai/sdk/resources'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { processTextPrompt } from './processTextPrompt.js'
+
+const mocks = vi.hoisted(() => ({
+  createUserMessage: vi.fn((input: { content: unknown }) => ({
+    type: 'user',
+    message: { role: 'user', content: input.content },
+    ...input,
+  })),
+  logEvent: vi.fn(),
+  logOTelEvent: vi.fn(),
+  redactIfDisabled: vi.fn((value: string) => `redacted:${value}`),
+  setPromptId: vi.fn(),
+  startInteractionSpan: vi.fn(),
+}))
+
+vi.mock('../../bootstrap/state.js', () => ({
+  flushInteractionTime: vi.fn(),
+  setPromptId: mocks.setPromptId,
+  updateLastInteractionTime: vi.fn(),
+}))
+
+vi.mock('../../services/analytics/index.js', () => ({
+  logEvent: mocks.logEvent,
+}))
+
+vi.mock('../../utils/messages.js', () => ({
+  createUserMessage: mocks.createUserMessage,
+}))
+
+vi.mock('../../utils/telemetry/events.js', () => ({
+  logOTelEvent: mocks.logOTelEvent,
+  redactIfDisabled: mocks.redactIfDisabled,
+}))
+
+vi.mock('../../utils/telemetry/sessionTracing.js', () => ({
+  startInteractionSpan: mocks.startInteractionSpan,
+}))
+
+describe('processTextPrompt array image prompt coverage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('uses first text for interaction span and last text for prompt telemetry', () => {
+    const contextBlock = {
+      type: 'text',
+      text: '<selection>status panel</selection>',
+    } satisfies ContentBlockParam
+    const promptBlock = {
+      type: 'text',
+      text: 'summarize the selected status',
+    } satisfies ContentBlockParam
+    const imageBlock = {
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: 'image/png',
+        data: 'iVBORw0KGgo=',
+      },
+    } satisfies ContentBlockParam
+    const attachmentMessage = {
+      type: 'attachment',
+      attachment: {
+        type: 'hook_success',
+        content: 'extra diagnostic context',
+      },
+    }
+
+    const result = processTextPrompt(
+      [contextBlock, promptBlock],
+      [imageBlock],
+      [17],
+      [attachmentMessage],
+      'prompt-uuid',
+      'plan',
+      true,
+    )
+    const promptId = mocks.setPromptId.mock.calls[0]?.[0]
+
+    expect(result.shouldQuery).toBe(true)
+    expect(mocks.startInteractionSpan).toHaveBeenCalledWith(contextBlock.text)
+    expect(mocks.redactIfDisabled).toHaveBeenCalledWith(promptBlock.text)
+    expect(mocks.logOTelEvent).toHaveBeenCalledWith('user_prompt', {
+      prompt_length: String(promptBlock.text.length),
+      prompt: `redacted:${promptBlock.text}`,
+      'prompt.id': promptId,
+    })
+    expect(mocks.logEvent).toHaveBeenCalledWith('agenc_input_prompt', {
+      is_negative: false,
+      is_keep_going: false,
+    })
+    expect(mocks.createUserMessage).toHaveBeenCalledWith({
+      content: [contextBlock, promptBlock, imageBlock],
+      uuid: 'prompt-uuid',
+      imagePasteIds: [17],
+      permissionMode: 'plan',
+      isMeta: true,
+    })
+    expect(result.messages).toEqual([
+      expect.objectContaining({
+        content: [contextBlock, promptBlock, imageBlock],
+        uuid: 'prompt-uuid',
+        imagePasteIds: [17],
+        permissionMode: 'plan',
+        isMeta: true,
+      }),
+      attachmentMessage,
+    ])
+  })
+})

--- a/runtime/tests/tui/keybindings/KeybindingProviderSetup.coverage.test.tsx
+++ b/runtime/tests/tui/keybindings/KeybindingProviderSetup.coverage.test.tsx
@@ -1,0 +1,226 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import Text from "../ink/components/Text.js";
+import { createRoot } from "../ink/root.js";
+import { useKeybindingContext } from "./KeybindingContext.js";
+import { KeybindingSetup } from "./KeybindingProviderSetup.js";
+import { parseBindings } from "./parser.js";
+
+const inputHandlers = vi.hoisted(() => [] as unknown[]);
+const addNotification = vi.hoisted(() => vi.fn());
+const removeNotification = vi.hoisted(() => vi.fn());
+const initializeKeybindingWatcher = vi.hoisted(() =>
+  vi.fn(async () => undefined),
+);
+const loadKeybindingsSyncWithWarnings = vi.hoisted(() => vi.fn());
+const reloadListeners = vi.hoisted(
+  () => [] as Array<(result: unknown) => void>,
+);
+const unsubscribe = vi.hoisted(() => vi.fn());
+const subscribeToKeybindingChanges = vi.hoisted(() =>
+  vi.fn((listener: (result: unknown) => void) => {
+    reloadListeners.push(listener);
+    return unsubscribe;
+  }),
+);
+
+vi.mock("../ink.js", () => ({
+  useInput: (handler: unknown) => {
+    inputHandlers.push(handler);
+  },
+}));
+
+vi.mock("../context/notifications.js", () => ({
+  useNotifications: () => ({
+    addNotification,
+    removeNotification,
+  }),
+}));
+
+vi.mock("../../utils/debug.js", () => ({
+  logForDebugging: () => {},
+}));
+
+vi.mock("./loadUserBindings.js", () => ({
+  initializeKeybindingWatcher,
+  loadKeybindingsSyncWithWarnings,
+  subscribeToKeybindingChanges,
+}));
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+function createTestStreams(): {
+  stdout: PassThrough;
+  stdin: TestStdin;
+} {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number }).columns = 80;
+  (stdout as unknown as { rows: number }).rows = 24;
+  (stdout as unknown as { isTTY: boolean }).isTTY = true;
+  stdout.resume();
+
+  return { stdout, stdin };
+}
+
+function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const startedAt = Date.now();
+    const poll = () => {
+      if (predicate()) {
+        resolve();
+        return;
+      }
+      if (Date.now() - startedAt >= timeoutMs) {
+        reject(new Error(message));
+        return;
+      }
+      setTimeout(poll, 10);
+    };
+    poll();
+  });
+}
+
+function Probe({ displays }: { displays: string[] }): React.ReactNode {
+  const keybindings = useKeybindingContext();
+
+  React.useEffect(() => {
+    displays.push(keybindings.getDisplayText("chat:submit", "Chat") ?? "missing");
+  }, [displays, keybindings]);
+
+  return <Text>keybinding setup</Text>;
+}
+
+describe("KeybindingProviderSetup coverage", () => {
+  const originalGlyphMode = process.env.AGENC_TUI_GLYPHS;
+
+  beforeEach(() => {
+    process.env.AGENC_TUI_GLYPHS = "ascii";
+    inputHandlers.length = 0;
+    reloadListeners.length = 0;
+    addNotification.mockClear();
+    removeNotification.mockClear();
+    initializeKeybindingWatcher.mockClear();
+    loadKeybindingsSyncWithWarnings.mockReset();
+    subscribeToKeybindingChanges.mockClear();
+    unsubscribe.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalGlyphMode === undefined) {
+      delete process.env.AGENC_TUI_GLYPHS;
+    } else {
+      process.env.AGENC_TUI_GLYPHS = originalGlyphMode;
+    }
+  });
+
+  test("shows and clears the keybinding warning notification after watched reloads", async () => {
+    const initialBindings = parseBindings([
+      {
+        context: "Chat",
+        bindings: {
+          enter: "chat:submit",
+        },
+      },
+    ]);
+    const displays: string[] = [];
+    const { stdout, stdin } = createTestStreams();
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    });
+
+    loadKeybindingsSyncWithWarnings.mockReturnValue({
+      bindings: initialBindings,
+      warnings: [],
+    });
+
+    try {
+      root.render(
+        <KeybindingSetup>
+          <Probe displays={displays} />
+        </KeybindingSetup>,
+      );
+
+      await waitForCondition(
+        () =>
+          subscribeToKeybindingChanges.mock.calls.length === 1 &&
+          removeNotification.mock.calls.length === 1,
+        "KeybindingSetup did not initialize watcher effects",
+      );
+
+      expect(loadKeybindingsSyncWithWarnings).toHaveBeenCalledTimes(1);
+      expect(initializeKeybindingWatcher).toHaveBeenCalledTimes(1);
+      expect(inputHandlers).toHaveLength(1);
+      expect(displays).toContain("Enter");
+      expect(removeNotification).toHaveBeenCalledWith(
+        "keybinding-config-warning",
+      );
+
+      reloadListeners[0]?.({
+        bindings: initialBindings,
+        warnings: [
+          {
+            message: "reserved",
+            severity: "warning",
+            type: "reserved",
+          },
+        ],
+      });
+
+      await waitForCondition(
+        () => addNotification.mock.calls.length === 1,
+        "keybinding warning notification was not added",
+      );
+
+      expect(addNotification).toHaveBeenCalledWith({
+        key: "keybinding-config-warning",
+        text: "Found 1 keybinding warning - /doctor for details",
+        color: "warning",
+        priority: "high",
+        timeoutMs: 60000,
+      });
+
+      reloadListeners[0]?.({
+        bindings: initialBindings,
+        warnings: [],
+      });
+
+      await waitForCondition(
+        () => removeNotification.mock.calls.length === 2,
+        "keybinding warning notification was not cleared",
+      );
+
+      expect(removeNotification).toHaveBeenLastCalledWith(
+        "keybinding-config-warning",
+      );
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+
+    await waitForCondition(
+      () => unsubscribe.mock.calls.length === 1,
+      "KeybindingSetup did not unsubscribe on unmount",
+    );
+  });
+});

--- a/runtime/tests/tui/keybindings/KeybindingProviderSetup.wave200-118.coverage.test.tsx
+++ b/runtime/tests/tui/keybindings/KeybindingProviderSetup.wave200-118.coverage.test.tsx
@@ -1,0 +1,111 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("../ink.js", () => ({
+  useInput: () => {},
+}));
+
+vi.mock("../context/notifications.js", () => ({
+  useNotifications: () => ({
+    addNotification: () => {},
+    removeNotification: () => {},
+  }),
+}));
+
+vi.mock("../../utils/debug.js", () => ({
+  logForDebugging: () => {},
+}));
+
+import type { Key } from "../ink.js";
+import { createChordInputHandler } from "./KeybindingProviderSetup.js";
+import { parseBindings } from "./parser.js";
+import type { ParsedKeystroke } from "./types.js";
+
+function key(overrides: Partial<Key> = {}): Key {
+  return {
+    ctrl: false,
+    shift: false,
+    fn: false,
+    meta: false,
+    super: false,
+    escape: false,
+    return: false,
+    tab: false,
+    backspace: false,
+    delete: false,
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    pageUp: false,
+    pageDown: false,
+    wheelUp: false,
+    wheelDown: false,
+    home: false,
+    end: false,
+    ...overrides,
+  } as Key;
+}
+
+function inputEvent(): { stopped: boolean; stopImmediatePropagation: () => void } {
+  return {
+    stopped: false,
+    stopImmediatePropagation() {
+      this.stopped = true;
+    },
+  };
+}
+
+describe("KeybindingProviderSetup wave200-118 coverage", () => {
+  test("keeps propagation stable for ignored, unbound, and cancelled chord inputs", () => {
+    const bindings = parseBindings([
+      {
+        context: "Chat",
+        bindings: {
+          "ctrl+x ctrl+k": null,
+          "ctrl+x ctrl+u": "chat:killAgents",
+        },
+      },
+    ]);
+    const pendingChordRef = { current: null as ParsedKeystroke[] | null };
+    const pendingStates: Array<ParsedKeystroke[] | null> = [];
+    const setPendingChord = (pending: ParsedKeystroke[] | null): void => {
+      pendingStates.push(pending);
+      pendingChordRef.current = pending;
+    };
+    const handler = createChordInputHandler({
+      bindings,
+      pendingChordRef,
+      setPendingChord,
+      activeContexts: new Set(["Chat"]),
+      handlerRegistryRef: { current: null } as Parameters<
+        typeof createChordInputHandler
+      >[0]["handlerRegistryRef"],
+    });
+
+    const ignoredWheelEvent = inputEvent();
+    handler("", key({ wheelUp: true }), ignoredWheelEvent);
+    expect(ignoredWheelEvent.stopped).toBe(false);
+    expect(pendingStates).toEqual([]);
+
+    const unboundPrefixEvent = inputEvent();
+    handler("x", key({ ctrl: true }), unboundPrefixEvent);
+    expect(unboundPrefixEvent.stopped).toBe(true);
+    expect(pendingChordRef.current?.[0]?.key).toBe("x");
+
+    const unboundCompletionEvent = inputEvent();
+    handler("k", key({ ctrl: true }), unboundCompletionEvent);
+    expect(unboundCompletionEvent.stopped).toBe(true);
+    expect(pendingChordRef.current).toBeNull();
+
+    const cancelledPrefixEvent = inputEvent();
+    handler("x", key({ ctrl: true }), cancelledPrefixEvent);
+    expect(cancelledPrefixEvent.stopped).toBe(true);
+    expect(pendingChordRef.current?.[0]?.key).toBe("x");
+
+    const cancelledEvent = inputEvent();
+    handler("", key({ escape: true }), cancelledEvent);
+    expect(cancelledEvent.stopped).toBe(true);
+    expect(pendingChordRef.current).toBeNull();
+    expect(pendingStates.at(-1)).toBeNull();
+  });
+});

--- a/runtime/tests/tui/keybindings/loadUserBindings.wave200-137.coverage.test.ts
+++ b/runtime/tests/tui/keybindings/loadUserBindings.wave200-137.coverage.test.ts
@@ -1,0 +1,145 @@
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => {
+  const state = {
+    cleanup: undefined as undefined | (() => Promise<void>),
+    closeWatcher: vi.fn(async () => undefined),
+    debug: vi.fn(),
+    handlers: new Map<string, (path: string) => void | Promise<void>>(),
+    registerCleanup: undefined as unknown as ReturnType<typeof vi.fn>,
+    watch: undefined as unknown as ReturnType<typeof vi.fn>,
+  }
+
+  state.registerCleanup = vi.fn((cleanup: () => Promise<void>) => {
+    state.cleanup = cleanup
+    return () => {
+      if (state.cleanup === cleanup) {
+        state.cleanup = undefined
+      }
+    }
+  })
+
+  state.watch = vi.fn(() => ({
+    close: state.closeWatcher,
+    on(event: string, handler: (path: string) => void | Promise<void>) {
+      state.handlers.set(event, handler)
+      return this
+    },
+  }))
+
+  return state
+})
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('chokidar', () => ({
+  default: { watch: harness.watch },
+  watch: harness.watch,
+}))
+
+vi.mock('../../utils/cleanupRegistry.js', () => ({
+  registerCleanup: harness.registerCleanup,
+}))
+
+vi.mock('../../utils/debug.js', () => ({
+  logForDebugging: harness.debug,
+}))
+
+import {
+  disposeKeybindingWatcher,
+  getKeybindingsPath,
+  initializeKeybindingWatcher,
+  resetKeybindingLoaderForTesting,
+} from './loadUserBindings.ts'
+
+const originalConfigDir = process.env.AGENC_CONFIG_DIR
+const tempDirs: string[] = []
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'agenc-keybindings-wave137-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+beforeEach(() => {
+  harness.cleanup = undefined
+  harness.closeWatcher.mockClear()
+  harness.debug.mockClear()
+  harness.handlers.clear()
+  harness.registerCleanup.mockClear()
+  harness.watch.mockClear()
+  process.env.AGENC_CONFIG_DIR = originalConfigDir
+  resetKeybindingLoaderForTesting()
+})
+
+afterEach(async () => {
+  disposeKeybindingWatcher()
+  resetKeybindingLoaderForTesting()
+  if (originalConfigDir === undefined) {
+    delete process.env.AGENC_CONFIG_DIR
+  } else {
+    process.env.AGENC_CONFIG_DIR = originalConfigDir
+  }
+  await Promise.all(
+    tempDirs.splice(0).map(dir => rm(dir, { force: true, recursive: true })),
+  )
+})
+
+describe('loadUserBindings watcher lifecycle', () => {
+  test('handles duplicate initialization, registered cleanup, reset, and non-directory config parents', async () => {
+    const dir = await createTempDir()
+    process.env.AGENC_CONFIG_DIR = dir
+
+    await initializeKeybindingWatcher()
+
+    expect(harness.watch).toHaveBeenCalledTimes(1)
+    expect(harness.watch).toHaveBeenCalledWith(
+      getKeybindingsPath(),
+      expect.objectContaining({
+        awaitWriteFinish: {
+          pollInterval: 200,
+          stabilityThreshold: 500,
+        },
+        ignoreInitial: true,
+        ignorePermissionErrors: true,
+      }),
+    )
+    expect(harness.handlers.has('add')).toBe(true)
+    expect(harness.handlers.has('change')).toBe(true)
+    expect(harness.handlers.has('unlink')).toBe(true)
+    expect(harness.registerCleanup).toHaveBeenCalledTimes(1)
+
+    await initializeKeybindingWatcher()
+    expect(harness.watch).toHaveBeenCalledTimes(1)
+
+    resetKeybindingLoaderForTesting()
+    expect(harness.closeWatcher).toHaveBeenCalledTimes(1)
+
+    await initializeKeybindingWatcher()
+    expect(harness.watch).toHaveBeenCalledTimes(2)
+    expect(harness.registerCleanup).toHaveBeenCalledTimes(2)
+
+    await harness.cleanup?.()
+    expect(harness.closeWatcher).toHaveBeenCalledTimes(2)
+
+    await initializeKeybindingWatcher()
+    expect(harness.watch).toHaveBeenCalledTimes(2)
+
+    resetKeybindingLoaderForTesting()
+    const configParentFile = join(dir, 'config-parent-file')
+    await writeFile(configParentFile, '')
+    process.env.AGENC_CONFIG_DIR = configParentFile
+
+    await initializeKeybindingWatcher()
+
+    expect(harness.watch).toHaveBeenCalledTimes(2)
+    expect(harness.debug).toHaveBeenCalledWith(
+      expect.stringContaining('is not a directory'),
+    )
+  })
+})

--- a/runtime/tests/tui/keybindings/match.wave200-083.coverage.test.ts
+++ b/runtime/tests/tui/keybindings/match.wave200-083.coverage.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "vitest";
+
+import type { Key } from "../ink.js";
+import { getKeyName, matchesBinding, matchesKeystroke } from "./match.js";
+import type { ParsedBinding, ParsedKeystroke } from "./types.js";
+
+const baseKey: Key = {
+  upArrow: false,
+  downArrow: false,
+  leftArrow: false,
+  rightArrow: false,
+  pageDown: false,
+  pageUp: false,
+  wheelUp: false,
+  wheelDown: false,
+  home: false,
+  end: false,
+  return: false,
+  escape: false,
+  ctrl: false,
+  shift: false,
+  fn: false,
+  tab: false,
+  backspace: false,
+  delete: false,
+  meta: false,
+  super: false,
+};
+
+function key(overrides: Partial<Key> = {}): Key {
+  return { ...baseKey, ...overrides };
+}
+
+function stroke(
+  keyName: string,
+  overrides: Partial<ParsedKeystroke> = {},
+): ParsedKeystroke {
+  return {
+    key: keyName,
+    ctrl: false,
+    alt: false,
+    shift: false,
+    meta: false,
+    super: false,
+    ...overrides,
+  };
+}
+
+describe("keybinding input matching", () => {
+  test("normalizes terminal keys and matches only exact modifier combinations", () => {
+    const namedKeyCases: Array<[Partial<Key>, string, string | null]> = [
+      [{ escape: true }, "", "escape"],
+      [{ return: true }, "", "enter"],
+      [{ tab: true }, "", "tab"],
+      [{ backspace: true }, "", "backspace"],
+      [{ delete: true }, "", "delete"],
+      [{ upArrow: true }, "", "up"],
+      [{ downArrow: true }, "", "down"],
+      [{ leftArrow: true }, "", "left"],
+      [{ rightArrow: true }, "", "right"],
+      [{ pageUp: true }, "", "pageup"],
+      [{ pageDown: true }, "", "pagedown"],
+      [{ wheelUp: true }, "", "wheelup"],
+      [{ wheelDown: true }, "", "wheeldown"],
+      [{ home: true }, "", "home"],
+      [{ end: true }, "", "end"],
+      [{}, "A", "a"],
+      [{}, "ab", null],
+    ];
+
+    for (const [overrides, input, expected] of namedKeyCases) {
+      expect(getKeyName(input, key(overrides))).toBe(expected);
+    }
+
+    expect(matchesKeystroke("x", key(), stroke("x"))).toBe(true);
+    expect(matchesKeystroke("x", key(), stroke("y"))).toBe(false);
+
+    expect(
+      matchesKeystroke("x", key({ ctrl: true }), stroke("x", { ctrl: true })),
+    ).toBe(true);
+    expect(matchesKeystroke("x", key({ ctrl: true }), stroke("x"))).toBe(false);
+
+    expect(
+      matchesKeystroke("x", key({ shift: true }), stroke("x", { shift: true })),
+    ).toBe(true);
+    expect(matchesKeystroke("x", key({ shift: true }), stroke("x"))).toBe(false);
+
+    expect(
+      matchesKeystroke("x", key({ meta: true }), stroke("x", { alt: true })),
+    ).toBe(true);
+    expect(
+      matchesKeystroke("x", key({ meta: true }), stroke("x", { meta: true })),
+    ).toBe(true);
+    expect(matchesKeystroke("x", key(), stroke("x", { alt: true }))).toBe(false);
+
+    expect(
+      matchesKeystroke("x", key({ super: true }), stroke("x", { super: true })),
+    ).toBe(true);
+    expect(matchesKeystroke("x", key({ super: true }), stroke("x"))).toBe(false);
+
+    expect(
+      matchesKeystroke("", key({ escape: true, meta: true }), stroke("escape")),
+    ).toBe(true);
+    expect(
+      matchesKeystroke(
+        "",
+        key({ escape: true, meta: true }),
+        stroke("escape", { meta: true }),
+      ),
+    ).toBe(false);
+
+    const enterBinding: ParsedBinding = {
+      action: "chat:submit",
+      chord: [stroke("enter")],
+      context: "Chat",
+    };
+
+    expect(matchesBinding("", key({ return: true }), enterBinding)).toBe(true);
+    expect(
+      matchesBinding("", key({ return: true }), {
+        ...enterBinding,
+        chord: [stroke("enter"), stroke("x")],
+      }),
+    ).toBe(false);
+    expect(
+      matchesBinding("", key({ return: true }), {
+        ...enterBinding,
+        chord: new Array(1) as ParsedKeystroke[],
+      }),
+    ).toBe(false);
+  });
+});

--- a/runtime/tests/tui/keybindings/parser.wave200-112.coverage.test.ts
+++ b/runtime/tests/tui/keybindings/parser.wave200-112.coverage.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  chordToDisplayString,
+  chordToString,
+  keystrokeToDisplayString,
+  keystrokeToString,
+  parseChord,
+  parseKeystroke,
+} from './parser.js'
+import type { ParsedKeystroke } from './types.js'
+
+function stroke(
+  key: string,
+  overrides: Partial<ParsedKeystroke> = {},
+): ParsedKeystroke {
+  return {
+    key,
+    ctrl: false,
+    alt: false,
+    shift: false,
+    meta: false,
+    super: false,
+    ...overrides,
+  }
+}
+
+describe('keybinding parser display coverage', () => {
+  test('normalizes aliases and formats named keys across display modes', () => {
+    expect(parseKeystroke('alt+opt+option+esc')).toEqual(
+      stroke('escape', { alt: true }),
+    )
+    expect(parseKeystroke('return')).toEqual(stroke('enter'))
+    expect(parseKeystroke('\u2193')).toEqual(stroke('down'))
+    expect(parseChord(' ')).toEqual([stroke(' ')])
+
+    expect(
+      keystrokeToString(
+        stroke('escape', {
+          alt: true,
+          shift: true,
+          meta: true,
+          super: true,
+        }),
+      ),
+    ).toBe('alt+shift+meta+cmd+Esc')
+
+    expect(
+      chordToString([
+        stroke(' '),
+        stroke('backspace'),
+        stroke('delete'),
+        stroke('pageup'),
+        stroke('pagedown'),
+        stroke('home'),
+        stroke('end'),
+      ]),
+    ).toBe('Space Backspace Delete PageUp PageDown Home End')
+
+    expect(
+      keystrokeToDisplayString(
+        stroke('down', { alt: true, super: true }),
+        'macos',
+        {},
+      ),
+    ).toBe('opt+cmd+\u2193')
+
+    expect(
+      keystrokeToDisplayString(
+        stroke('down', { meta: true, super: true }),
+        'linux',
+        { AGENC_TUI_GLYPHS: 'ascii' },
+      ),
+    ).toBe('alt+super+down')
+
+    expect(
+      chordToDisplayString([stroke('left'), stroke('right')], 'linux', {}),
+    ).toBe('\u2190 \u2192')
+  })
+})

--- a/runtime/tests/tui/keybindings/resolver.wave200-119.coverage.test.ts
+++ b/runtime/tests/tui/keybindings/resolver.wave200-119.coverage.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from "vitest";
+
+import type { Key } from "../ink.js";
+import { parseBindings } from "./parser.js";
+import {
+  getBindingDisplayText,
+  resolveKey,
+  resolveKeyWithChordState,
+} from "./resolver.js";
+import type { ParsedBinding, ParsedKeystroke } from "./types.js";
+
+const baseKey: Key = {
+  upArrow: false,
+  downArrow: false,
+  leftArrow: false,
+  rightArrow: false,
+  pageDown: false,
+  pageUp: false,
+  wheelUp: false,
+  wheelDown: false,
+  home: false,
+  end: false,
+  return: false,
+  escape: false,
+  ctrl: false,
+  shift: false,
+  fn: false,
+  tab: false,
+  backspace: false,
+  delete: false,
+  meta: false,
+  super: false,
+};
+
+function key(overrides: Partial<Key> = {}): Key {
+  return { ...baseKey, ...overrides };
+}
+
+function stroke(
+  keyName: string,
+  overrides: Partial<ParsedKeystroke> = {},
+): ParsedKeystroke {
+  return {
+    key: keyName,
+    ctrl: false,
+    alt: false,
+    shift: false,
+    meta: false,
+    super: false,
+    ...overrides,
+  };
+}
+
+describe("keybinding resolver edge coverage", () => {
+  test("keeps direct, shadowed chord, cancellation, and malformed binding outcomes distinct", () => {
+    const bindings = parseBindings([
+      {
+        context: "Global",
+        bindings: {
+          "ctrl+x": "app:toggleTodos",
+        },
+      },
+      {
+        context: "Chat",
+        bindings: {
+          "ctrl+x ctrl+k": "chat:killAgents",
+          "ctrl+x": "chat:undo",
+          "ctrl+z": null,
+          escape: "chat:cancel",
+        },
+      },
+      {
+        context: "Chat",
+        bindings: {
+          "ctrl+x": "chat:stash",
+          "ctrl+x ctrl+k": null,
+        },
+      },
+    ]);
+
+    expect(resolveKey("n", key(), ["Chat"], bindings)).toEqual({
+      type: "none",
+    });
+    expect(resolveKey("z", key({ ctrl: true }), ["Chat"], bindings)).toEqual({
+      type: "unbound",
+    });
+    expect(resolveKey("x", key({ ctrl: true }), ["Chat"], bindings)).toEqual({
+      type: "match",
+      action: "chat:stash",
+    });
+    expect(getBindingDisplayText("chat:stash", "Chat", bindings)).toBe(
+      "ctrl+x",
+    );
+    expect(
+      getBindingDisplayText("chat:submit", "Chat", bindings),
+    ).toBeUndefined();
+
+    expect(
+      resolveKeyWithChordState(
+        "x",
+        key({ ctrl: true }),
+        ["Chat"],
+        bindings,
+        null,
+      ),
+    ).toEqual({ type: "match", action: "chat:stash" });
+    expect(
+      resolveKeyWithChordState(
+        "z",
+        key({ ctrl: true }),
+        ["Chat"],
+        bindings,
+        null,
+      ),
+    ).toEqual({ type: "unbound" });
+    expect(
+      resolveKeyWithChordState(
+        "",
+        key({ escape: true, meta: true }),
+        ["Chat"],
+        bindings,
+        null,
+      ),
+    ).toEqual({ type: "match", action: "chat:cancel" });
+
+    const pending = [stroke("x", { ctrl: true })];
+    expect(
+      resolveKeyWithChordState(
+        "",
+        key({ escape: true }),
+        ["Chat"],
+        bindings,
+        pending,
+      ),
+    ).toEqual({ type: "chord_cancelled" });
+    expect(
+      resolveKeyWithChordState("", key(), ["Chat"], bindings, null),
+    ).toEqual({ type: "none" });
+    expect(
+      resolveKeyWithChordState("", key(), ["Chat"], bindings, pending),
+    ).toEqual({ type: "chord_cancelled" });
+
+    const chordBindings = parseBindings([
+      {
+        context: "Chat",
+        bindings: {
+          "ctrl+x ctrl+k": "chat:killAgents",
+        },
+      },
+    ]);
+    const started = resolveKeyWithChordState(
+      "x",
+      key({ ctrl: true }),
+      ["Chat"],
+      chordBindings,
+      null,
+    );
+    expect(started.type).toBe("chord_started");
+    if (started.type !== "chord_started") {
+      throw new Error("expected chord to start");
+    }
+    expect(
+      resolveKeyWithChordState(
+        "q",
+        key({ ctrl: true }),
+        ["Chat"],
+        chordBindings,
+        started.pending,
+      ),
+    ).toEqual({ type: "chord_cancelled" });
+
+    const malformedPrefix: ParsedBinding = {
+      context: "Chat",
+      action: "chat:killAgents",
+      chord: new Array(2) as ParsedKeystroke[],
+    };
+    const malformedExact: ParsedBinding = {
+      context: "Chat",
+      action: "chat:undo",
+      chord: new Array(1) as ParsedKeystroke[],
+    };
+    expect(
+      resolveKeyWithChordState(
+        "x",
+        key({ ctrl: true }),
+        ["Chat"],
+        [malformedPrefix],
+        null,
+      ),
+    ).toEqual({ type: "none" });
+    expect(
+      resolveKeyWithChordState(
+        "x",
+        key({ ctrl: true }),
+        ["Chat"],
+        [malformedExact],
+        null,
+      ),
+    ).toEqual({ type: "none" });
+  });
+});

--- a/runtime/tests/tui/keybindings/shortcutFormat.test.ts
+++ b/runtime/tests/tui/keybindings/shortcutFormat.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => {
+  const state = {
+    bindings: [{ bindings: [], context: 'Global' }],
+    getBindingDisplayText: vi.fn(),
+    loadKeybindingsSync: vi.fn(),
+  }
+
+  state.loadKeybindingsSync.mockImplementation(() => state.bindings)
+
+  return state
+})
+
+vi.mock('./loadUserBindings.js', () => ({
+  loadKeybindingsSync: mocks.loadKeybindingsSync,
+}))
+
+vi.mock('./resolver.js', () => ({
+  getBindingDisplayText: mocks.getBindingDisplayText,
+}))
+
+import { getShortcutDisplay } from './shortcutFormat.js'
+
+describe('getShortcutDisplay', () => {
+  beforeEach(() => {
+    mocks.getBindingDisplayText.mockReset()
+    mocks.loadKeybindingsSync.mockClear()
+  })
+
+  test('returns the configured shortcut display text when available', () => {
+    mocks.getBindingDisplayText.mockReturnValue('shift+tab')
+
+    expect(getShortcutDisplay('chat:cycleMode', 'Chat', 'tab')).toBe(
+      'shift+tab',
+    )
+    expect(mocks.loadKeybindingsSync).toHaveBeenCalledOnce()
+    expect(mocks.getBindingDisplayText).toHaveBeenCalledWith(
+      'chat:cycleMode',
+      'Chat',
+      mocks.bindings,
+    )
+  })
+
+  test('returns the fallback display text when no binding resolves', () => {
+    mocks.getBindingDisplayText.mockReturnValue(undefined)
+
+    expect(getShortcutDisplay('app:toggleTranscript', 'Global', 'ctrl+o')).toBe(
+      'ctrl+o',
+    )
+    expect(mocks.loadKeybindingsSync).toHaveBeenCalledOnce()
+    expect(mocks.getBindingDisplayText).toHaveBeenCalledWith(
+      'app:toggleTranscript',
+      'Global',
+      mocks.bindings,
+    )
+  })
+})

--- a/runtime/tests/tui/keybindings/useKeybinding.wave200-074.coverage.test.ts
+++ b/runtime/tests/tui/keybindings/useKeybinding.wave200-074.coverage.test.ts
@@ -1,0 +1,370 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  context: undefined as undefined | {
+    activeContexts: Set<string>
+    registerHandler: ReturnType<typeof vi.fn>
+    resolve: ReturnType<typeof vi.fn>
+    setPendingChord: ReturnType<typeof vi.fn>
+  },
+  inputHandlers: [] as Array<{
+    handler: (input: string, key: unknown, event: unknown) => void
+    options: unknown
+  }>,
+  unregisters: [] as Array<ReturnType<typeof vi.fn>>,
+}))
+
+vi.mock('../ink.js', () => ({
+  useInput: (handler: unknown, options: unknown) => {
+    harness.inputHandlers.push({
+      handler: handler as (input: string, key: unknown, event: unknown) => void,
+      options,
+    })
+  },
+}))
+
+vi.mock('./KeybindingContext.js', () => ({
+  useOptionalKeybindingContext: () => harness.context,
+}))
+
+import { createRoot } from '../ink/root.js'
+import type { Key } from '../ink.js'
+import type { InputEvent } from '../ink/events/input-event.js'
+import { useKeybinding, useKeybindings } from './useKeybinding.js'
+
+const BASE_KEY: Key = {
+  backspace: false,
+  ctrl: false,
+  delete: false,
+  downArrow: false,
+  end: false,
+  escape: false,
+  fn: false,
+  home: false,
+  leftArrow: false,
+  meta: false,
+  pageDown: false,
+  pageUp: false,
+  return: false,
+  rightArrow: false,
+  shift: false,
+  super: false,
+  tab: false,
+  upArrow: false,
+  wheelDown: false,
+  wheelUp: false,
+}
+
+function key(overrides: Partial<Key> = {}): Key {
+  return { ...BASE_KEY, ...overrides }
+}
+
+function event(): InputEvent & {
+  stopImmediatePropagation: ReturnType<typeof vi.fn>
+} {
+  return {
+    preventDefault: vi.fn(),
+    stopImmediatePropagation: vi.fn(),
+  } as unknown as InputEvent & {
+    stopImmediatePropagation: ReturnType<typeof vi.fn>
+  }
+}
+
+function createStreams(): {
+  readonly stdout: PassThrough
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function makeContext() {
+  harness.unregisters = []
+  const context = {
+    activeContexts: new Set(['Autocomplete', 'Chat']),
+    registerHandler: vi.fn(() => {
+      const unregister = vi.fn()
+      harness.unregisters.push(unregister)
+      return unregister
+    }),
+    resolve: vi.fn(),
+    setPendingChord: vi.fn(),
+  }
+  harness.context = context
+  return context
+}
+
+async function renderNode(node: React.ReactNode): Promise<{
+  dispose: () => Promise<void>
+}> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  root.render(node)
+  await sleep()
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+  }
+}
+
+function SingularProbe({
+  handler,
+  isActive = true,
+}: {
+  handler: () => void | false
+  isActive?: boolean
+}): null {
+  useKeybinding('chat:submit', handler, { context: 'Chat', isActive })
+  return null
+}
+
+function AggregateProbe({
+  handlers,
+}: {
+  handlers: Record<string, (() => void | false) | undefined>
+}): null {
+  useKeybindings(handlers as Record<string, () => void | false>, {
+    context: 'Chat',
+  })
+  return null
+}
+
+describe('useKeybinding wave200 coverage', () => {
+  beforeEach(() => {
+    harness.context = undefined
+    harness.inputHandlers = []
+    harness.unregisters = []
+  })
+
+  test('drives singular and aggregate resolver outcomes through captured input handlers', async () => {
+    const inactive = await renderNode(
+      React.createElement(SingularProbe, {
+        handler: vi.fn(),
+        isActive: false,
+      }),
+    )
+    try {
+      expect(harness.inputHandlers.at(-1)?.options).toEqual({
+        isActive: false,
+      })
+      harness.inputHandlers.at(-1)?.handler('x', key(), event())
+    } finally {
+      await inactive.dispose()
+    }
+
+    harness.inputHandlers = []
+    const singularContext = makeContext()
+    const singularHandler = vi.fn()
+    const singular = await renderNode(
+      React.createElement(SingularProbe, { handler: singularHandler }),
+    )
+    const singularInput = harness.inputHandlers.at(-1)?.handler
+    if (!singularInput) throw new Error('singular input handler was not captured')
+
+    try {
+      expect(singularContext.registerHandler).toHaveBeenCalledWith({
+        action: 'chat:submit',
+        context: 'Chat',
+        handler: singularHandler,
+      })
+
+      singularContext.resolve.mockReturnValueOnce({
+        type: 'match',
+        action: 'chat:submit',
+      })
+      const matched = event()
+      singularInput('s', key({ ctrl: true }), matched)
+      expect(singularContext.resolve).toHaveBeenLastCalledWith(
+        's',
+        key({ ctrl: true }),
+        ['Autocomplete', 'Chat', 'Global'],
+      )
+      expect(singularContext.setPendingChord).toHaveBeenLastCalledWith(null)
+      expect(singularHandler).toHaveBeenCalledTimes(1)
+      expect(matched.stopImmediatePropagation).toHaveBeenCalledTimes(1)
+
+      singularHandler.mockReturnValueOnce(false)
+      singularContext.resolve.mockReturnValueOnce({
+        type: 'match',
+        action: 'chat:submit',
+      })
+      const fallThrough = event()
+      singularInput('s', key(), fallThrough)
+      expect(singularHandler).toHaveBeenCalledTimes(2)
+      expect(fallThrough.stopImmediatePropagation).not.toHaveBeenCalled()
+
+      singularContext.resolve.mockReturnValueOnce({
+        type: 'match',
+        action: 'chat:cancel',
+      })
+      const otherAction = event()
+      singularInput('c', key(), otherAction)
+      expect(singularHandler).toHaveBeenCalledTimes(2)
+      expect(otherAction.stopImmediatePropagation).not.toHaveBeenCalled()
+
+      const pendingChord = [{ key: 'x', ctrl: true }]
+      singularContext.resolve.mockReturnValueOnce({
+        type: 'chord_started',
+        pending: pendingChord,
+      })
+      const chordStarted = event()
+      singularInput('x', key({ ctrl: true }), chordStarted)
+      expect(singularContext.setPendingChord).toHaveBeenLastCalledWith(
+        pendingChord,
+      )
+      expect(chordStarted.stopImmediatePropagation).toHaveBeenCalledTimes(1)
+
+      singularContext.resolve.mockReturnValueOnce({ type: 'chord_cancelled' })
+      const chordCancelled = event()
+      singularInput('', key({ escape: true }), chordCancelled)
+      expect(singularContext.setPendingChord).toHaveBeenLastCalledWith(null)
+      expect(chordCancelled.stopImmediatePropagation).not.toHaveBeenCalled()
+
+      singularContext.resolve.mockReturnValueOnce({ type: 'unbound' })
+      const unbound = event()
+      singularInput('u', key(), unbound)
+      expect(singularContext.setPendingChord).toHaveBeenLastCalledWith(null)
+      expect(unbound.stopImmediatePropagation).toHaveBeenCalledTimes(1)
+
+      singularContext.resolve.mockReturnValueOnce({ type: 'none' })
+      const none = event()
+      singularInput('z', key(), none)
+      expect(none.stopImmediatePropagation).not.toHaveBeenCalled()
+    } finally {
+      await singular.dispose()
+    }
+    expect(harness.unregisters).toHaveLength(1)
+    expect(harness.unregisters[0]).toHaveBeenCalledTimes(1)
+
+    harness.inputHandlers = []
+    const aggregateContext = makeContext()
+    const submitHandler = vi.fn()
+    const cancelHandler = vi.fn()
+    const aggregate = await renderNode(
+      React.createElement(AggregateProbe, {
+        handlers: {
+          'chat:cancel': cancelHandler,
+          'chat:maybe': undefined,
+          'chat:submit': submitHandler,
+        },
+      }),
+    )
+    const aggregateInput = harness.inputHandlers.at(-1)?.handler
+    if (!aggregateInput) {
+      throw new Error('aggregate input handler was not captured')
+    }
+
+    try {
+      expect(aggregateContext.registerHandler).toHaveBeenCalledTimes(3)
+
+      aggregateContext.resolve.mockReturnValueOnce({
+        type: 'match',
+        action: 'chat:submit',
+      })
+      const aggregateMatched = event()
+      aggregateInput('s', key(), aggregateMatched)
+      expect(aggregateContext.resolve).toHaveBeenLastCalledWith(
+        's',
+        key(),
+        ['Autocomplete', 'Chat', 'Global'],
+      )
+      expect(submitHandler).toHaveBeenCalledTimes(1)
+      expect(aggregateMatched.stopImmediatePropagation).toHaveBeenCalledTimes(1)
+
+      submitHandler.mockReturnValueOnce(false)
+      aggregateContext.resolve.mockReturnValueOnce({
+        type: 'match',
+        action: 'chat:submit',
+      })
+      const aggregateFallThrough = event()
+      aggregateInput('s', key(), aggregateFallThrough)
+      expect(submitHandler).toHaveBeenCalledTimes(2)
+      expect(aggregateFallThrough.stopImmediatePropagation).not.toHaveBeenCalled()
+
+      aggregateContext.resolve.mockReturnValueOnce({
+        type: 'match',
+        action: 'chat:missing',
+      })
+      const missingAction = event()
+      aggregateInput('m', key(), missingAction)
+      expect(missingAction.stopImmediatePropagation).not.toHaveBeenCalled()
+
+      aggregateContext.resolve.mockReturnValueOnce({
+        type: 'match',
+        action: 'chat:maybe',
+      })
+      const undefinedHandler = event()
+      aggregateInput('u', key(), undefinedHandler)
+      expect(undefinedHandler.stopImmediatePropagation).not.toHaveBeenCalled()
+
+      aggregateContext.resolve.mockReturnValueOnce({
+        type: 'chord_started',
+        pending: [{ key: 'k', ctrl: true }],
+      })
+      const aggregateChord = event()
+      aggregateInput('k', key({ ctrl: true }), aggregateChord)
+      expect(aggregateContext.setPendingChord).toHaveBeenLastCalledWith([
+        { key: 'k', ctrl: true },
+      ])
+      expect(aggregateChord.stopImmediatePropagation).toHaveBeenCalledTimes(1)
+
+      aggregateContext.resolve.mockReturnValueOnce({
+        type: 'chord_cancelled',
+      })
+      const aggregateCancelled = event()
+      aggregateInput('', key({ escape: true }), aggregateCancelled)
+      expect(aggregateContext.setPendingChord).toHaveBeenLastCalledWith(null)
+      expect(aggregateCancelled.stopImmediatePropagation).not.toHaveBeenCalled()
+
+      aggregateContext.resolve.mockReturnValueOnce({ type: 'unbound' })
+      const aggregateUnbound = event()
+      aggregateInput('u', key(), aggregateUnbound)
+      expect(aggregateContext.setPendingChord).toHaveBeenLastCalledWith(null)
+      expect(aggregateUnbound.stopImmediatePropagation).toHaveBeenCalledTimes(1)
+
+      aggregateContext.resolve.mockReturnValueOnce({ type: 'none' })
+      const aggregateNone = event()
+      aggregateInput('n', key(), aggregateNone)
+      expect(aggregateNone.stopImmediatePropagation).not.toHaveBeenCalled()
+      expect(cancelHandler).not.toHaveBeenCalled()
+    } finally {
+      await aggregate.dispose()
+    }
+
+    expect(harness.unregisters).toHaveLength(3)
+    expect(harness.unregisters.every(unregister => unregister.mock.calls.length === 1)).toBe(
+      true,
+    )
+  })
+})

--- a/runtime/tests/tui/main.coverage.test.ts
+++ b/runtime/tests/tui/main.coverage.test.ts
@@ -1,0 +1,171 @@
+import { EventEmitter } from "node:events";
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => {
+  const state = {
+    exitCallback: undefined as (() => void) | undefined,
+    app: vi.fn(() => null),
+    onExitUnsubscribe: vi.fn(),
+    renderInk: vi.fn(),
+    recordTuiBackpressure: vi.fn(),
+    onExit: undefined as unknown as (callback: () => void) => () => void,
+  };
+  state.onExit = vi.fn((callback: () => void) => {
+    state.exitCallback = callback;
+    return state.onExitUnsubscribe;
+  });
+  return state;
+});
+
+vi.mock("signal-exit", () => ({
+  onExit: harness.onExit,
+}));
+
+vi.mock("./ink.js", () => ({
+  render: harness.renderInk,
+}));
+
+vi.mock("./components/App.js", () => ({
+  AgenCTuiApp: harness.app,
+}));
+
+vi.mock("./backpressure.js", () => ({
+  recordTuiBackpressure: harness.recordTuiBackpressure,
+}));
+
+import {
+  DISABLE_KITTY_KEYBOARD,
+  DISABLE_MODIFY_OTHER_KEYS,
+} from "./ink/termio/csi.js";
+import {
+  DISABLE_MOUSE_TRACKING,
+  EXIT_ALT_SCREEN,
+  SHOW_CURSOR,
+} from "./ink/termio/dec.js";
+import {
+  bootTUI,
+  RENDER_BACKPRESSURE_THRESHOLD_MS,
+} from "./main.js";
+import { AgenCTuiApp } from "./components/App.js";
+
+class TestReadStream extends EventEmitter {
+  isTTY = true;
+  setRawMode = vi.fn();
+}
+
+class TestWriteStream extends EventEmitter {
+  isTTY = true;
+  readonly writes: string[] = [];
+  write = vi.fn((chunk: string | Uint8Array) => {
+    this.writes.push(String(chunk));
+    return true;
+  });
+}
+
+type RenderedTuiElement = {
+  readonly type: unknown;
+  readonly props: {
+    readonly session: unknown;
+    readonly configStore: unknown;
+    readonly isInteractive: boolean;
+    readonly model?: unknown;
+    readonly initialPrompt?: string;
+    readonly initialComposerText?: string;
+    readonly getFpsMetrics: () => unknown;
+  };
+};
+
+type RenderOptions = {
+  readonly stdin: unknown;
+  readonly stdout: unknown;
+  readonly stderr: unknown;
+  readonly patchConsole: boolean;
+  readonly exitOnCtrlC: boolean;
+  readonly onFrame: (event: { readonly durationMs: number }) => void;
+};
+
+describe("TUI main coverage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    harness.exitCallback = undefined;
+  });
+
+  test("bootTUI wires Ink startup, render backpressure, and terminal restoration", async () => {
+    const stdin = new TestReadStream();
+    const stdout = new TestWriteStream();
+    const stderr = new TestWriteStream();
+    const session = { id: "session-1" };
+    const configStore = { source: "test" };
+    const unmount = vi.fn();
+    const waitUntilExit = vi.fn(async () => undefined);
+
+    harness.renderInk.mockResolvedValue({ unmount, waitUntilExit });
+
+    const handle = await bootTUI({
+      session: session as never,
+      configStore: configStore as never,
+      stdin: stdin as never,
+      stdout: stdout as never,
+      stderr: stderr as never,
+      model: "model-for-test" as never,
+      initialPrompt: "start here",
+      initialComposerText: "draft prompt",
+    });
+
+    expect(stdin.setRawMode).toHaveBeenCalledWith(true);
+    expect(harness.onExit).toHaveBeenCalledTimes(1);
+    expect(stdin.listenerCount("close")).toBe(1);
+    expect(stdin.listenerCount("end")).toBe(1);
+    expect(stdin.listenerCount("error")).toBe(1);
+
+    expect(harness.renderInk).toHaveBeenCalledTimes(1);
+    const [element, renderOptions] = harness.renderInk.mock
+      .calls[0] as [RenderedTuiElement, RenderOptions];
+    expect(element.type).toBe(AgenCTuiApp);
+    expect(element.props.session).toBe(session);
+    expect(element.props.configStore).toBe(configStore);
+    expect(element.props.isInteractive).toBe(true);
+    expect(element.props.model).toBe("model-for-test");
+    expect(element.props.initialPrompt).toBe("start here");
+    expect(element.props.initialComposerText).toBe("draft prompt");
+    expect(element.props.getFpsMetrics()).toBeUndefined();
+
+    expect(renderOptions).toMatchObject({
+      stdin,
+      stdout,
+      stderr,
+      patchConsole: true,
+      exitOnCtrlC: false,
+    });
+
+    renderOptions.onFrame({
+      durationMs: RENDER_BACKPRESSURE_THRESHOLD_MS - 1,
+    });
+    expect(harness.recordTuiBackpressure).not.toHaveBeenCalled();
+
+    renderOptions.onFrame({
+      durationMs: RENDER_BACKPRESSURE_THRESHOLD_MS,
+    });
+    expect(harness.recordTuiBackpressure).toHaveBeenCalledWith({
+      source: "render",
+      durationMs: RENDER_BACKPRESSURE_THRESHOLD_MS,
+    });
+    expect(element.props.getFpsMetrics()).toMatchObject({
+      sampleCount: 2,
+    });
+
+    await expect(handle.waitUntilExit()).resolves.toBeUndefined();
+    expect(waitUntilExit).toHaveBeenCalledTimes(1);
+
+    handle.unmount();
+    expect(unmount).toHaveBeenCalledTimes(1);
+
+    harness.exitCallback?.();
+    expect(stdout.write).toHaveBeenNthCalledWith(1, EXIT_ALT_SCREEN);
+    expect(stdout.write).toHaveBeenNthCalledWith(2, DISABLE_MOUSE_TRACKING);
+    expect(stdout.write).toHaveBeenNthCalledWith(3, DISABLE_KITTY_KEYBOARD);
+    expect(stdout.write).toHaveBeenNthCalledWith(4, DISABLE_MODIFY_OTHER_KEYS);
+    expect(stdout.write).toHaveBeenNthCalledWith(5, SHOW_CURSOR);
+  });
+});

--- a/runtime/tests/tui/main.wave200-064.coverage.test.ts
+++ b/runtime/tests/tui/main.wave200-064.coverage.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("./ink.js", () => ({
+  render: vi.fn(),
+}));
+
+vi.mock("./components/App.js", () => ({
+  AgenCTuiApp: vi.fn(() => null),
+}));
+
+import {
+  handleStdinLoss,
+  STDIN_LOSS_FLUSH_HARD_CAP_MS,
+  type StdinLossSession,
+} from "./main.js";
+
+describe("TUI main stdin loss coverage", () => {
+  test("flushes session state, emits a structured warning, unmounts, and exits", async () => {
+    const timeoutHandle = { unref: vi.fn() };
+    const setTimeoutMock = vi.fn(
+      (_callback: () => void, _durationMs: number) =>
+        timeoutHandle as unknown as NodeJS.Timeout,
+    );
+    const exit = vi.fn((code: number): never => {
+      throw new Error(`exit:${code}`);
+    });
+    let resolveFlush!: () => void;
+    const flushPromise = new Promise<void>((resolve) => {
+      resolveFlush = resolve;
+    });
+    const session = {
+      abortTerminal: vi.fn(),
+      flushEventLog: vi.fn(() => flushPromise),
+      emit: vi.fn(),
+      nextInternalSubId: vi.fn(() => "internal-warning-1"),
+    };
+    const unmountInk = vi.fn(() => {
+      throw new Error("already unmounted");
+    });
+
+    const result = handleStdinLoss(
+      session as unknown as StdinLossSession,
+      unmountInk,
+      {
+        exit,
+        setTimeoutFn: setTimeoutMock as unknown as typeof setTimeout,
+      },
+    );
+
+    await Promise.resolve();
+
+    expect(session.abortTerminal).toHaveBeenCalledWith("stdin_lost");
+    expect(session.flushEventLog).toHaveBeenCalledTimes(1);
+    expect(setTimeoutMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      STDIN_LOSS_FLUSH_HARD_CAP_MS,
+    );
+    expect(timeoutHandle.unref).toHaveBeenCalledTimes(1);
+
+    resolveFlush();
+    await expect(result).rejects.toThrow("exit:130");
+
+    expect(session.nextInternalSubId).toHaveBeenCalledTimes(1);
+    expect(session.emit).toHaveBeenCalledWith({
+      id: "internal-warning-1",
+      msg: {
+        type: "warning",
+        payload: {
+          cause: "stdin_lost",
+          message:
+            "stdin was lost while the TUI was active; aborting the session",
+          timestamp: expect.any(Number),
+        },
+      },
+    });
+    expect(unmountInk).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(130);
+  });
+});

--- a/runtime/tests/tui/message-renderers/AdvisorMessage.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/AdvisorMessage.coverage.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import type { AdvisorBlock } from '../../utils/advisor.js'
+import { renderToString } from '../../utils/staticRender.js'
+import { AdvisorMessage } from './AdvisorMessage.js'
+
+function normalize(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
+function renderAdvisorMessage(
+  block: AdvisorBlock,
+  options: {
+    readonly advisorModel?: string
+    readonly erroredToolUseIDs?: readonly string[]
+    readonly resolvedToolUseIDs?: readonly string[]
+    readonly verbose?: boolean
+  } = {},
+): Promise<string> {
+  return renderToString(
+    <AdvisorMessage
+      addMargin={false}
+      advisorModel={options.advisorModel}
+      block={block}
+      erroredToolUseIDs={new Set(options.erroredToolUseIDs ?? [])}
+      resolvedToolUseIDs={new Set(options.resolvedToolUseIDs ?? [])}
+      shouldAnimate={false}
+      verbose={options.verbose ?? false}
+    />,
+    120,
+  )
+}
+
+describe('AdvisorMessage coverage', () => {
+  test('renders advisor progress and each result outcome', async () => {
+    const progress = normalize(
+      await renderAdvisorMessage(
+        {
+          type: 'server_tool_use',
+          id: 'advisor-tool-1',
+          name: 'advisor',
+          input: { scope: 'rendering' },
+        },
+        {
+          advisorModel: 'advisor-model',
+          erroredToolUseIDs: ['advisor-tool-1'],
+          resolvedToolUseIDs: ['advisor-tool-1'],
+        },
+      ),
+    )
+    expect(progress).toContain('Advising using advisor-model')
+    expect(progress).toContain('{"scope":"rendering"}')
+
+    const compactResult = normalize(
+      await renderAdvisorMessage({
+        type: 'advisor_tool_result',
+        tool_use_id: 'advisor-tool-1',
+        content: {
+          type: 'advisor_result',
+          text: 'Tighten the assertions around the status line.',
+        },
+      }),
+    )
+    expect(compactResult).toContain(
+      'Advisor has reviewed the conversation and will apply the feedback',
+    )
+    expect(compactResult).toContain('ctrl+o')
+    expect(compactResult).not.toContain('Tighten the assertions')
+
+    const verboseResult = normalize(
+      await renderAdvisorMessage(
+        {
+          type: 'advisor_tool_result',
+          tool_use_id: 'advisor-tool-1',
+          content: {
+            type: 'advisor_result',
+            text: 'Tighten the assertions around the status line.',
+          },
+        },
+        { verbose: true },
+      ),
+    )
+    expect(verboseResult).toContain(
+      'Tighten the assertions around the status line.',
+    )
+
+    const redactedResult = normalize(
+      await renderAdvisorMessage({
+        type: 'advisor_tool_result',
+        tool_use_id: 'advisor-tool-1',
+        content: {
+          type: 'advisor_redacted_result',
+          encrypted_content: 'encrypted-feedback',
+        },
+      }),
+    )
+    expect(redactedResult).toContain(
+      'Advisor has reviewed the conversation and will apply the feedback',
+    )
+    expect(redactedResult).not.toContain('encrypted-feedback')
+
+    const errorResult = normalize(
+      await renderAdvisorMessage({
+        type: 'advisor_tool_result',
+        tool_use_id: 'advisor-tool-1',
+        content: {
+          type: 'advisor_tool_result_error',
+          error_code: 'rate_limited',
+        },
+      }),
+    )
+    expect(errorResult).toContain('Advisor unavailable (rate_limited)')
+  })
+})

--- a/runtime/tests/tui/message-renderers/AssistantTextMessage.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/AssistantTextMessage.coverage.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import { MessageActionsSelectedContext } from '../components/messageActions.js'
+import { AssistantTextMessage } from './AssistantTextMessage.js'
+
+vi.mock('../hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    syntaxHighlightingDisabled: true,
+  }),
+}))
+
+describe('AssistantTextMessage ordinary text coverage', () => {
+  test('renders ordinary assistant text through the AgenC message chrome when selected', async () => {
+    const output = await renderToString(
+      <MessageActionsSelectedContext.Provider value={true}>
+        <AssistantTextMessage
+          param={{ type: 'text', text: '**Ready** to proceed' }}
+          addMargin={true}
+          shouldShowDot={false}
+          verbose={false}
+        />
+      </MessageActionsSelectedContext.Provider>,
+      100,
+    )
+
+    expect(output).toContain('AGENC')
+    expect(output).toContain('Ready to proceed')
+  })
+})

--- a/runtime/tests/tui/message-renderers/AssistantTextMessage.wave200-124.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/AssistantTextMessage.wave200-124.coverage.test.tsx
@@ -1,0 +1,93 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { API_TIMEOUT_ERROR_MESSAGE } from '../../services/api/errors.js'
+import { createRoot } from '../ink/root.js'
+import { AssistantTextMessage } from './AssistantTextMessage.js'
+
+const originalApiTimeoutMs = process.env.API_TIMEOUT_MS
+
+function createStreams(): {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  ;(stdout as unknown as { columns: number; rows: number }).columns = 100
+  ;(stdout as unknown as { columns: number; rows: number }).rows = 24
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+afterEach(() => {
+  if (originalApiTimeoutMs === undefined) {
+    delete process.env.API_TIMEOUT_MS
+  } else {
+    process.env.API_TIMEOUT_MS = originalApiTimeoutMs
+  }
+})
+
+describe('AssistantTextMessage wave200-124 coverage', () => {
+  test('renders the configured API timeout hint across identical TUI rerenders', async () => {
+    process.env.API_TIMEOUT_MS = '4321'
+    const { stdin, stdout } = createStreams()
+    let output = ''
+
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+    const renderNode = () => (
+      <AssistantTextMessage
+        addMargin={false}
+        param={{ type: 'text', text: API_TIMEOUT_ERROR_MESSAGE }}
+        shouldShowDot={false}
+        verbose={false}
+      />
+    )
+
+    try {
+      root.render(renderNode())
+      await sleep()
+      root.render(renderNode())
+      await sleep()
+
+      const text = stripAnsi(output)
+      expect(text).toContain(API_TIMEOUT_ERROR_MESSAGE)
+      expect(text).toContain('(API_TIMEOUT_MS=4321ms, try increasing it)')
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+})

--- a/runtime/tests/tui/message-renderers/AssistantToolUseMessage.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/AssistantToolUseMessage.coverage.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { Tool } from '../../tools/Tool.js'
+import type { AgenCToolUseBlockParam } from '../../types/message.js'
+import { renderToString } from '../../utils/staticRender.js'
+import { AssistantToolUseMessage } from './AssistantToolUseMessage.js'
+
+const appStateMock = vi.hoisted(() => ({
+  pendingWorkerRequest: undefined as undefined | { toolUseId: string },
+  toolPermissionContext: {
+    mode: 'default',
+    strippedDangerousRules: undefined as undefined | Record<string, unknown>,
+  },
+}))
+
+vi.mock('../../utils/classifierApprovalsHook.js', () => ({
+  useIsClassifierChecking: () => false,
+}))
+
+vi.mock('../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: 80, rows: 24 }),
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppStateMaybeOutsideOfProvider: (
+    selector: (state: typeof appStateMock) => unknown,
+  ) => selector(appStateMock),
+}))
+
+vi.mock('../ink.js', async () => {
+  const actual = await vi.importActual<typeof import('../ink.js')>(
+    '../ink.js',
+  )
+  return {
+    ...actual,
+    useTheme: () => ['dark'],
+  }
+})
+
+describe('AssistantToolUseMessage queued rendering coverage', () => {
+  it('renders queued detail while summarizing empty tool-use text from input', async () => {
+    const param: AgenCToolUseBlockParam = {
+      type: 'tool_use',
+      id: 'toolu_queued_search',
+      name: 'Search',
+      input: { query: 'queued lookup', ignored: 'not shown' },
+    }
+    const tool = {
+      name: 'Search',
+      inputSchema: {
+        safeParse: (input: unknown) => ({ success: true, data: input }),
+      },
+      userFacingName: () => 'Search',
+      renderToolUseMessage: () => '',
+      renderToolUseQueuedMessage: () => 'Queued behind active tool work',
+    } as unknown as Tool
+    const output = await renderToString(
+      <AssistantToolUseMessage
+        param={param}
+        addMargin={false}
+        tools={[tool]}
+        commands={[]}
+        verbose={false}
+        inProgressToolUseIDs={new Set()}
+        progressMessagesForMessage={[]}
+        shouldAnimate={false}
+        shouldShowDot={false}
+        lookups={{
+          resolvedToolUseIDs: new Set<string>(),
+          erroredToolUseIDs: new Set<string>(),
+        } as never}
+      />,
+      80,
+    )
+
+    expect(output).toContain('Search')
+    expect(output).toContain('queued lookup')
+    expect(output).toContain('Queued behind active tool work')
+    expect(output).not.toContain('not shown')
+    expect(output).not.toContain('Running')
+  })
+})

--- a/runtime/tests/tui/message-renderers/AssistantToolUseMessage.coverage2.test.tsx
+++ b/runtime/tests/tui/message-renderers/AssistantToolUseMessage.coverage2.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { Tool } from '../../tools/Tool.js'
+import type {
+  AgenCToolUseBlockParam,
+  ProgressMessage,
+} from '../../types/message.js'
+import { renderToString } from '../../utils/staticRender.js'
+import { Text } from '../ink.js'
+import { AssistantToolUseMessage } from './AssistantToolUseMessage.js'
+
+const appStateMock = vi.hoisted(() => ({
+  pendingWorkerRequest: undefined as undefined | { toolUseId: string },
+  toolPermissionContext: {
+    mode: 'default',
+    strippedDangerousRules: undefined as undefined | Record<string, unknown>,
+  },
+}))
+
+vi.mock('../../utils/classifierApprovalsHook.js', () => ({
+  useIsClassifierChecking: () => false,
+}))
+
+vi.mock('../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: 80, rows: 24 }),
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppStateMaybeOutsideOfProvider: (
+    selector: (state: typeof appStateMock) => unknown,
+  ) => selector(appStateMock),
+}))
+
+vi.mock('../ink.js', async () => {
+  const actual = await vi.importActual<typeof import('../ink.js')>(
+    '../ink.js',
+  )
+  return {
+    ...actual,
+    useTheme: () => ['dark'],
+  }
+})
+
+describe('AssistantToolUseMessage transparent wrapper coverage', () => {
+  it('renders active transparent wrappers from progress without wrapper chrome', async () => {
+    const param: AgenCToolUseBlockParam = {
+      type: 'tool_use',
+      id: 'toolu_transparent_wrapper',
+      name: 'Delegate',
+      input: { prompt: 'outer task should stay hidden' },
+    }
+    const toolProgress = {
+      data: { type: 'tool_progress', text: 'child task running' },
+    }
+    const hookProgress = {
+      data: { type: 'hook_progress', hookEvent: 'PreToolUse' },
+    }
+    const progressMessagesForMessage = [
+      hookProgress,
+      toolProgress,
+    ] as ProgressMessage[]
+    let receivedProgressMessages: ProgressMessage[] = []
+    let receivedProgressOptions:
+      | {
+          readonly verbose: boolean
+          readonly terminalSize?: { readonly columns: number; readonly rows: number }
+          readonly inProgressToolCallCount?: number
+          readonly isTranscriptMode?: boolean
+        }
+      | undefined
+
+    const tool = {
+      name: 'Delegate',
+      inputSchema: {
+        safeParse: (input: unknown) => ({ success: true, data: input }),
+      },
+      userFacingName: () => 'Delegate',
+      isTransparentWrapper: () => true,
+      renderToolUseMessage: vi.fn(() => 'outer chrome'),
+      renderToolUseProgressMessage: vi.fn((messages, options) => {
+        receivedProgressMessages = messages
+        receivedProgressOptions = options
+        return <Text>{messages[0]?.data.text}</Text>
+      }),
+    } as unknown as Tool
+
+    const output = await renderToString(
+      <AssistantToolUseMessage
+        param={param}
+        addMargin={false}
+        tools={[tool]}
+        commands={[]}
+        verbose={true}
+        inProgressToolUseIDs={new Set([param.id])}
+        progressMessagesForMessage={progressMessagesForMessage}
+        shouldAnimate={false}
+        shouldShowDot={false}
+        inProgressToolCallCount={3}
+        isTranscriptMode={true}
+        lookups={{
+          resolvedToolUseIDs: new Set<string>(),
+          erroredToolUseIDs: new Set<string>(),
+          inProgressHookCounts: new Map([
+            [param.id, new Map([['PreToolUse', 1]])],
+          ]),
+          resolvedHookCounts: new Map<string, Map<string, number>>(),
+        } as never}
+      />,
+      80,
+    )
+
+    expect(output).toContain('child task running')
+    expect(output).toContain('PreToolUse')
+    expect(output).toContain('hook running')
+    expect(output).not.toContain('Delegate')
+    expect(output).not.toContain('outer task should stay hidden')
+    expect(output).not.toContain('outer chrome')
+    expect(tool.renderToolUseMessage).not.toHaveBeenCalled()
+    expect(tool.renderToolUseProgressMessage).toHaveBeenCalledTimes(1)
+    expect(receivedProgressMessages).toEqual([toolProgress])
+    expect(receivedProgressOptions).toMatchObject({
+      verbose: true,
+      terminalSize: { columns: 80, rows: 24 },
+      inProgressToolCallCount: 3,
+      isTranscriptMode: true,
+    })
+  })
+})

--- a/runtime/tests/tui/message-renderers/AssistantToolUseMessage.wave200-047.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/AssistantToolUseMessage.wave200-047.coverage.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Tool } from '../../tools/Tool.js'
+import type { AgenCToolUseBlockParam } from '../../types/message.js'
+import { renderToString } from '../../utils/staticRender.js'
+import { AssistantToolUseMessage } from './AssistantToolUseMessage.js'
+
+const appStateMock = vi.hoisted(() => ({
+  pendingWorkerRequest: undefined as undefined | { toolUseId: string },
+  toolPermissionContext: {
+    mode: 'default',
+    strippedDangerousRules: undefined as undefined | Record<string, unknown>,
+  },
+}))
+
+const logMock = vi.hoisted(() => ({
+  errors: [] as Error[],
+}))
+
+vi.mock('../../utils/classifierApprovalsHook.js', () => ({
+  useIsClassifierChecking: () => false,
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: (error: Error) => {
+    logMock.errors.push(error)
+  },
+}))
+
+vi.mock('../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: 80, rows: 24 }),
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppStateMaybeOutsideOfProvider: (
+    selector: (state: typeof appStateMock) => unknown,
+  ) => selector(appStateMock),
+}))
+
+vi.mock('../ink.js', async () => {
+  const actual = await vi.importActual<typeof import('../ink.js')>(
+    '../ink.js',
+  )
+  return {
+    ...actual,
+    useTheme: () => ['dark'],
+  }
+})
+
+function lookups() {
+  return {
+    resolvedToolUseIDs: new Set<string>(),
+    erroredToolUseIDs: new Set<string>(),
+  } as never
+}
+
+describe('AssistantToolUseMessage hook fallback coverage', () => {
+  beforeEach(() => {
+    logMock.errors.length = 0
+    appStateMock.pendingWorkerRequest = undefined
+    appStateMock.toolPermissionContext.mode = 'default'
+    appStateMock.toolPermissionContext.strippedDangerousRules = undefined
+  })
+
+  it('keeps tool rows visible when optional display hooks throw', async () => {
+    const circularInput: Record<string, unknown> = { ignored: true }
+    circularInput.self = circularInput
+    const runningParam: AgenCToolUseBlockParam = {
+      type: 'tool_use',
+      id: 'toolu_throwing_running',
+      name: 'Reader',
+      input: circularInput,
+    }
+    const runningTool = {
+      name: 'Reader',
+      inputSchema: {
+        safeParse: (input: unknown) => ({ success: true, data: input }),
+      },
+      userFacingName: () => 'Reader',
+      renderToolUseMessage: vi.fn(() => {
+        throw new Error('message render failed')
+      }),
+      renderToolUseProgressMessage: vi.fn(() => {
+        throw new Error('progress render failed')
+      }),
+    } as unknown as Tool
+
+    const runningOutput = await renderToString(
+      <AssistantToolUseMessage
+        param={runningParam}
+        addMargin={false}
+        tools={[runningTool]}
+        commands={[]}
+        verbose={false}
+        inProgressToolUseIDs={new Set([runningParam.id])}
+        progressMessagesForMessage={[]}
+        shouldAnimate={false}
+        shouldShowDot={false}
+        lookups={lookups()}
+      />,
+      80,
+    )
+
+    expect(runningOutput).toContain('Reader')
+    expect(runningOutput).toContain('[object Object]')
+    expect(runningOutput).not.toContain('message render failed')
+    expect(runningOutput).not.toContain('progress render failed')
+    expect(runningTool.renderToolUseMessage).toHaveBeenCalledTimes(1)
+    expect(runningTool.renderToolUseProgressMessage).toHaveBeenCalledTimes(1)
+
+    const queuedParam: AgenCToolUseBlockParam = {
+      type: 'tool_use',
+      id: 'toolu_throwing_queued',
+      name: 'QueueTool',
+      input: { command: 'queued command' },
+    }
+    const queuedTool = {
+      name: 'QueueTool',
+      inputSchema: {
+        safeParse: (input: unknown) => ({ success: true, data: input }),
+      },
+      userFacingName: () => 'QueueTool',
+      renderToolUseMessage: () => 'queued command',
+      renderToolUseQueuedMessage: vi.fn(() => {
+        throw new Error('queued render failed')
+      }),
+    } as unknown as Tool
+
+    const queuedOutput = await renderToString(
+      <AssistantToolUseMessage
+        param={queuedParam}
+        addMargin={false}
+        tools={[queuedTool]}
+        commands={[]}
+        verbose={false}
+        inProgressToolUseIDs={new Set()}
+        progressMessagesForMessage={[]}
+        shouldAnimate={false}
+        shouldShowDot={false}
+        lookups={lookups()}
+      />,
+      80,
+    )
+
+    expect(queuedOutput).toContain('QueueTool')
+    expect(queuedOutput).toContain('queued command')
+    expect(queuedOutput).not.toContain('queued render failed')
+    expect(queuedTool.renderToolUseQueuedMessage).toHaveBeenCalledTimes(1)
+    expect(logMock.errors.map(error => error.message)).toEqual([
+      expect.stringContaining('Error rendering tool use message for Reader'),
+      expect.stringContaining('Error rendering tool use progress message for Reader'),
+      expect.stringContaining('Error rendering tool use queued message for QueueTool'),
+    ])
+  })
+})

--- a/runtime/tests/tui/message-renderers/AttachmentMessage.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/AttachmentMessage.coverage.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { describe, expect, test, vi } from "vitest";
+
+import { renderToString } from "../../utils/staticRender.js";
+import { AttachmentMessage } from "./AttachmentMessage.js";
+
+const featureMock = vi.hoisted(() => ({
+  experimentalSkillSearch: false,
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: (flag: string) =>
+    flag === "EXPERIMENTAL_SKILL_SEARCH" &&
+    featureMock.experimentalSkillSearch,
+}));
+
+vi.mock("../../utils/agentSwarmsEnabled.js", () => ({
+  isAgentSwarmsEnabled: () => false,
+}));
+
+async function renderAttachment(attachment: unknown): Promise<string> {
+  return renderToString(
+    <AttachmentMessage
+      addMargin={false}
+      attachment={attachment as never}
+      verbose={false}
+    />,
+    { columns: 120 },
+  );
+}
+
+describe("AttachmentMessage coverage", () => {
+  test("renders feature-gated skill discovery summaries and hides empty results", async () => {
+    featureMock.experimentalSkillSearch = true;
+
+    await expect(
+      renderAttachment({
+        signal: "project_context",
+        skills: [
+          {
+            description: "Creates compact implementation plans",
+            name: "Plan Builder",
+            shortId: "pb1",
+          },
+          {
+            description: "Reviews focused diffs",
+            name: "Diff Reviewer",
+          },
+        ],
+        source: "native",
+        type: "skill_discovery",
+      }),
+    ).resolves.toContain(
+      "2 relevant skills: Plan Builder [pb1], Diff Reviewer",
+    );
+
+    const emptyOutput = await renderAttachment({
+      signal: "project_context",
+      skills: [],
+      source: "native",
+      type: "skill_discovery",
+    });
+    expect(emptyOutput.trim()).toBe("");
+  });
+});

--- a/runtime/tests/tui/message-renderers/AttachmentMessage.wave200-071.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/AttachmentMessage.wave200-071.coverage.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import { AttachmentMessage } from './AttachmentMessage.js'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../utils/agentSwarmsEnabled.js', () => ({
+  isAgentSwarmsEnabled: () => true,
+}))
+
+vi.mock('../../utils/teammateMailbox.js', () => ({
+  isShutdownApproved: (text: string) => text === 'shutdown-approved',
+}))
+
+vi.mock('../components/messageActions', () => ({
+  useSelectedMessageBg: () => undefined,
+}))
+
+vi.mock('./PlanApprovalMessage', async () => {
+  const ReactActual = await vi.importActual<typeof import('react')>('react')
+
+  return {
+    formatTeammateMessageContent: (text: string) =>
+      text === 'plain-fallback' ? undefined : `formatted ${text}`,
+    tryRenderPlanApprovalMessage: (text: string, from: string) =>
+      text === 'plan-approval'
+        ? ReactActual.createElement(
+            'ink-text',
+            null,
+            `plan approval from ${from}`,
+          )
+        : null,
+  }
+})
+
+vi.mock('./UserTeammateMessage', async () => {
+  const ReactActual = await vi.importActual<typeof import('react')>('react')
+
+  return {
+    TeammateMessageContent: ({
+      content,
+      displayName,
+    }: {
+      content: string
+      displayName: string
+    }) => ReactActual.createElement('ink-text', null, `${displayName}: ${content}`),
+  }
+})
+
+function renderAttachment(attachment: unknown): Promise<string> {
+  return renderToString(
+    <AttachmentMessage
+      addMargin={false}
+      attachment={attachment as never}
+      verbose={false}
+    />,
+    { columns: 120 },
+  )
+}
+
+describe('AttachmentMessage wave200-071 coverage', () => {
+  test('handles teammate mailbox filtering and fallback render paths', async () => {
+    const hiddenOutput = await renderAttachment({
+      messages: [
+        { from: 'system', text: 'shutdown-approved' },
+        { from: 'system', text: '{"type":"idle_notification"}' },
+        { from: 'system', text: '{"type":"teammate_terminated"}' },
+      ],
+      type: 'teammate_mailbox',
+    })
+
+    expect(hiddenOutput.trim()).toBe('')
+
+    const output = await renderAttachment({
+      messages: [
+        {
+          from: 'Dispatcher',
+          text: JSON.stringify({
+            subject: 'Audit rendering',
+            taskId: 'TUI-71',
+            type: 'task_assignment',
+          }),
+        },
+        { from: 'Planner', text: 'plan-approval' },
+        { from: 'Writer', text: 'plain-fallback' },
+      ],
+      type: 'teammate_mailbox',
+    })
+
+    expect(output).toContain('Task assigned: #TUI-71 - Audit rendering')
+    expect(output).toContain('(from Dispatcher)')
+    expect(output).toContain('plan approval from Planner')
+    expect(output).toContain('Writer: plain-fallback')
+  })
+})

--- a/runtime/tests/tui/message-renderers/CollapsedReadSearchContent.test.tsx
+++ b/runtime/tests/tui/message-renderers/CollapsedReadSearchContent.test.tsx
@@ -1,0 +1,317 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../hooks/useMinDisplayTime.js', () => ({
+  useMinDisplayTime: (value: string | undefined) => value,
+}))
+
+vi.mock('../glyphs.js', () => ({
+  selectAgenCTuiGlyphs: () => ({
+    ellipsis: '...',
+    responseGutter: '>',
+    separator: '*',
+  }),
+}))
+
+vi.mock('../../tools/Tool.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../tools/Tool.js')>()
+  return {
+    ...actual,
+    findToolByName: (tools: Array<{ name: string }> | undefined, name: string) =>
+      tools?.find(tool => tool.name === name),
+  }
+})
+
+vi.mock('../../tools/REPLTool/primitiveTools.js', () => ({
+  getReplPrimitiveTools: () => [],
+}))
+
+vi.mock('../../utils/collapseReadSearch.js', () => ({
+  getToolUseIdsFromCollapsedGroup: (message: { toolUseIDs?: string[] }) =>
+    message.toolUseIDs ?? [],
+}))
+
+vi.mock('../../utils/file.js', () => ({
+  getDisplayPath: (path: string) => `display:${path}`,
+}))
+
+vi.mock('../../utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => true,
+}))
+
+vi.mock('../components/CtrlOToExpand.js', () => ({
+  CtrlOToExpand: () => <>expand</>,
+}))
+
+vi.mock('../components/messageActions.js', () => ({
+  useSelectedMessageBg: () => undefined,
+}))
+
+vi.mock('../components/PrBadge.js', () => ({
+  PrBadge: ({ number }: { readonly number: number }) => (
+    <>{`PR #${number}`}</>
+  ),
+}))
+
+vi.mock('../components/ToolUseLoader.js', () => ({
+  ToolUseLoader: ({
+    isError,
+    isUnresolved,
+  }: {
+    readonly isError?: boolean
+    readonly isUnresolved?: boolean
+  }) => (
+    <>{`loader:${isUnresolved ? 'unresolved' : 'resolved'}:${isError ? 'error' : 'ok'}`}</>
+  ),
+}))
+
+vi.mock('../ink.js', async () => {
+  const actual = await vi.importActual<typeof import('../ink.js')>('../ink.js')
+  return {
+    ...actual,
+    useTheme: () => ['dark'],
+  }
+})
+
+import { CollapsedReadSearchContent } from './CollapsedReadSearchContent.js'
+
+function baseLookups(overrides: Record<string, unknown> = {}) {
+  return {
+    erroredToolUseIDs: new Set<string>(),
+    progressMessagesByToolUseID: new Map(),
+    resolvedToolUseIDs: new Set<string>(),
+    toolResultByToolUseID: new Map(),
+    ...overrides,
+  } as never
+}
+
+function baseMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    bashCount: 0,
+    gitOpBashCount: 0,
+    listCount: 0,
+    mcpCallCount: 0,
+    memoryReadCount: 0,
+    memorySearchCount: 0,
+    memoryWriteCount: 0,
+    messages: [],
+    readCount: 0,
+    replCount: 0,
+    searchCount: 0,
+    toolUseIDs: [],
+    ...overrides,
+  } as never
+}
+
+function renderCollapsed(
+  message: ReturnType<typeof baseMessage>,
+  options: {
+    readonly inProgressToolUseIDs?: Set<string>
+    readonly isActiveGroup?: boolean
+    readonly lookups?: ReturnType<typeof baseLookups>
+    readonly tools?: unknown[]
+    readonly verbose?: boolean
+  } = {},
+): Promise<string> {
+  return renderToString(
+    <CollapsedReadSearchContent
+      inProgressToolUseIDs={options.inProgressToolUseIDs ?? new Set()}
+      isActiveGroup={options.isActiveGroup}
+      lookups={options.lookups ?? baseLookups()}
+      message={message}
+      shouldAnimate={false}
+      tools={(options.tools ?? []) as never}
+      verbose={options.verbose ?? false}
+    />,
+    120,
+  )
+}
+
+describe('CollapsedReadSearchContent', () => {
+  test('renders nothing for an empty collapsed group', async () => {
+    const output = await renderCollapsed(baseMessage())
+
+    expect(output.trim()).toBe('')
+  })
+
+  test('renders active non-verbose operation summaries, hint, progress, and hook totals', async () => {
+    const progressMessagesByToolUseID = new Map([
+      [
+        'bash-1',
+        [
+          {
+            data: {
+              elapsedTimeSeconds: 3,
+              totalLines: 1,
+              type: 'bash_progress',
+            },
+          },
+        ],
+      ],
+    ])
+    const output = await renderCollapsed(
+      baseMessage({
+        bashCount: 3,
+        branches: [{ action: 'rebased', ref: 'main' }],
+        commits: [{ kind: 'committed', sha: 'abc123' }],
+        gitOpBashCount: 1,
+        hookCount: 2,
+        hookTotalMs: 1200,
+        isActiveGroup: true,
+        latestDisplayHint: 'npm test',
+        listCount: 1,
+        mcpCallCount: 2,
+        mcpServerNames: ['agenc.ai docs'],
+        memoryReadCount: 1,
+        memorySearchCount: 1,
+        memoryWriteCount: 2,
+        prs: [{ action: 'created', number: 7, url: 'https://example.test/pr/7' }],
+        pushes: [{ branch: 'feature/tui' }],
+        readCount: 1,
+        replCount: 2,
+        searchCount: 2,
+        toolUseIDs: ['bash-1'],
+      }),
+      {
+        inProgressToolUseIDs: new Set(['bash-1']),
+        isActiveGroup: true,
+        lookups: baseLookups({ progressMessagesByToolUseID }),
+      },
+    )
+
+    const flatOutput = output.replace(/\s+/g, ' ')
+    expect(output).toContain('Committed abc123')
+    expect(output).toContain('pushed to feature/tui')
+    expect(output).toContain('rebased onto main')
+    expect(output).toContain('created PR #7')
+    expect(output).toContain('searching for 2 patterns')
+    expect(output).toContain('reading 1 file')
+    expect(output).toContain('listing 1 directory')
+    expect(output).toContain("REPL'ing 2 times")
+    expect(output).toContain('querying docs 2 times')
+    expect(output).toContain('running 2 bash commands')
+    expect(output).toContain('recalling 1 memory')
+    expect(flatOutput).toContain('searching memories')
+    expect(output).toContain('writing 2 memories')
+    expect(output).toContain('...')
+    expect(output).toContain('expand')
+    expect(output).toContain('npm test')
+    expect(output).toContain('1 line')
+    expect(output).toContain('Ran 2 PreToolUse hooks')
+  })
+
+  test('renders finalized summaries and falls back from read/search history to display hints', async () => {
+    const output = await renderCollapsed(
+      baseMessage({
+        hookCount: 1,
+        hookTotalMs: 250,
+        listCount: 2,
+        readCount: 2,
+        readFilePaths: ['/tmp/last-read.ts'],
+        searchArgs: ['needle'],
+        searchCount: 1,
+      }),
+    )
+
+    expect(output).toContain('Searched for 1 pattern')
+    expect(output).toContain('read 2 files')
+    expect(output).toContain('listed 2 directories')
+    expect(output).toContain('Ran 1 PreToolUse hook')
+    expect(output).not.toContain('display:/tmp/last-read.ts')
+  })
+
+  test('renders verbose tool uses, hooks, results, and recalled memories', async () => {
+    const renderToolResultMessage = vi.fn((result: { value: string }) => (
+      <>{`result:${result.value}`}</>
+    ))
+    const renderToolUseTag = vi.fn(() => <>tag</>)
+    const tool = {
+      inputSchema: {
+        safeParse: (input: unknown) => ({ data: input, success: true }),
+      },
+      name: 'DemoTool',
+      outputSchema: {
+        safeParse: (output: unknown) => ({ data: output, success: true }),
+      },
+      renderToolResultMessage,
+      renderToolUseMessage: (input: { value: string }) => `input:${input.value}`,
+      renderToolUseTag,
+      userFacingName: () => 'Demo tool',
+    }
+    const lookups = baseLookups({
+      resolvedToolUseIDs: new Set(['tool-1']),
+      toolResultByToolUseID: new Map([
+        ['tool-1', { toolUseResult: { value: 'done' }, type: 'user' }],
+      ]),
+    })
+
+    const output = await renderCollapsed(
+      baseMessage({
+        hookCount: 1,
+        hookInfos: [{ command: 'preflight', durationMs: 400 }],
+        hookTotalMs: 400,
+        messages: [
+          {
+            message: {
+              content: [
+                {
+                  id: 'tool-1',
+                  input: { value: 'ok' },
+                  name: 'DemoTool',
+                  type: 'tool_use',
+                },
+              ],
+            },
+            type: 'assistant',
+          },
+          {
+            message: {
+              content: [{ text: 'not a tool', type: 'text' }],
+            },
+            type: 'assistant',
+          },
+          {
+            messages: [
+              {
+                message: {
+                  content: [
+                    {
+                      id: 'missing-tool',
+                      input: {},
+                      name: 'MissingTool',
+                      type: 'tool_use',
+                    },
+                  ],
+                },
+                type: 'assistant',
+              },
+            ],
+            type: 'grouped_tool_use',
+          },
+        ],
+        relevantMemories: [{ content: 'Remember this', path: '/tmp/team.md' }],
+      }),
+      { lookups, tools: [tool], verbose: true },
+    )
+
+    expect(output).toContain('Demo tool')
+    expect(output).toContain('input:ok')
+    expect(renderToolUseTag).toHaveBeenCalledOnce()
+    expect(renderToolResultMessage).toHaveBeenCalledWith(
+      { value: 'done' },
+      [],
+      expect.objectContaining({ verbose: true }),
+    )
+    expect(output).toContain('Ran 1 PreToolUse hook')
+    expect(output).toContain('preflight')
+    expect(output).toContain('Recalled team.md')
+    expect(output).toContain('Remember this')
+    expect(output).not.toContain('MissingTool')
+  })
+})

--- a/runtime/tests/tui/message-renderers/CollapsedReadSearchContent.wave200-059.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/CollapsedReadSearchContent.wave200-059.coverage.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../hooks/useMinDisplayTime.js', () => ({
+  useMinDisplayTime: (value: string | undefined) => value,
+}))
+
+vi.mock('../glyphs.js', () => ({
+  selectAgenCTuiGlyphs: () => ({
+    ellipsis: '...',
+    responseGutter: '>',
+    separator: '|',
+  }),
+}))
+
+vi.mock('../../utils/collapseReadSearch.js', () => ({
+  getToolUseIdsFromCollapsedGroup: (message: { toolUseIDs?: string[] }) =>
+    message.toolUseIDs ?? [],
+}))
+
+vi.mock('../../utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => true,
+}))
+
+vi.mock('../components/CtrlOToExpand.js', () => ({
+  CtrlOToExpand: () => <>expand</>,
+}))
+
+vi.mock('../components/messageActions.js', () => ({
+  useSelectedMessageBg: () => undefined,
+}))
+
+vi.mock('../components/ToolUseLoader.js', () => ({
+  ToolUseLoader: () => <>loader</>,
+}))
+
+vi.mock('../ink.js', async () => {
+  const actual = await vi.importActual<typeof import('../ink.js')>('../ink.js')
+  return {
+    ...actual,
+    useTheme: () => ['dark'],
+  }
+})
+
+import { CollapsedReadSearchContent } from './CollapsedReadSearchContent.js'
+
+function lookupsWithReplProgress() {
+  return {
+    erroredToolUseIDs: new Set<string>(),
+    progressMessagesByToolUseID: new Map([
+      [
+        'repl-tool',
+        [
+          {
+            data: {
+              phase: 'start',
+              toolInput: {
+                command: 'cat fallback-command.ts',
+                file_path: '/workspace/src/live-repl-target.ts',
+                pattern: 'fallback-pattern',
+              },
+              toolName: 'Read',
+              type: 'repl_tool_call',
+            },
+          },
+        ],
+      ],
+    ]),
+    resolvedToolUseIDs: new Set<string>(),
+    toolResultByToolUseID: new Map(),
+  } as never
+}
+
+describe('CollapsedReadSearchContent wave200-059 coverage', () => {
+  test('shows the active REPL inner tool file path as the live hint', async () => {
+    const output = await renderToString(
+      <CollapsedReadSearchContent
+        inProgressToolUseIDs={new Set(['repl-tool'])}
+        isActiveGroup={true}
+        lookups={lookupsWithReplProgress()}
+        message={
+          {
+            bashCount: 0,
+            gitOpBashCount: 0,
+            listCount: 0,
+            mcpCallCount: 0,
+            memoryReadCount: 0,
+            memorySearchCount: 0,
+            memoryWriteCount: 0,
+            messages: [],
+            readCount: 0,
+            readFilePaths: ['/workspace/src/stale-read-fallback.ts'],
+            replCount: 1,
+            searchArgs: ['stale-search-fallback'],
+            searchCount: 0,
+            toolUseIDs: ['repl-tool'],
+          } as never
+        }
+        shouldAnimate={false}
+        tools={[]}
+        verbose={false}
+      />,
+      120,
+    )
+
+    expect(output).toContain("REPL'ing 1 time")
+    expect(output).toContain('/workspace/src/live-repl-target.ts')
+    expect(output).not.toContain('stale-read-fallback')
+    expect(output).not.toContain('stale-search-fallback')
+    expect(output).not.toContain('fallback-command')
+    expect(output).not.toContain('fallback-pattern')
+  })
+})

--- a/runtime/tests/tui/message-renderers/GroupedToolUseContent.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/GroupedToolUseContent.coverage.test.tsx
@@ -1,0 +1,128 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import type { Tool } from '../../tools/Tool.js'
+import { GroupedToolUseContent } from './GroupedToolUseContent.js'
+
+describe('GroupedToolUseContent', () => {
+  test('forwards grouped tool use state, filtered progress, results, and animation intent', () => {
+    const renderGroupedToolUse = vi.fn(() => 'grouped node')
+    const tool = {
+      name: 'Agent',
+      renderGroupedToolUse,
+    } as unknown as Tool
+    const tools = [tool]
+    const completedToolUse = {
+      id: 'tool-complete',
+      input: { prompt: 'summarize the change' },
+      name: 'Agent',
+      type: 'tool_use',
+    }
+    const failedToolUse = {
+      id: 'tool-failed',
+      input: { prompt: 'review the change' },
+      name: 'Agent',
+      type: 'tool_use',
+    }
+    const runningToolUse = {
+      id: 'tool-running',
+      input: { prompt: 'run focused tests' },
+      name: 'Agent',
+      type: 'tool_use',
+    }
+    const completedResultParam = {
+      content: 'summary ready',
+      tool_use_id: 'tool-complete',
+      type: 'tool_result',
+    }
+    const failedResultParam = {
+      content: 'review failed',
+      is_error: true,
+      tool_use_id: 'tool-failed',
+      type: 'tool_result',
+    }
+    const visibleProgress = {
+      data: { message: 'running tests', type: 'task_output' },
+      parentToolUseID: 'tool-running',
+      type: 'progress',
+    }
+    const hookProgress = {
+      data: { hookEvent: 'PreToolUse', type: 'hook_progress' },
+      parentToolUseID: 'tool-running',
+      type: 'progress',
+    }
+    const node = GroupedToolUseContent({
+      inProgressToolUseIDs: new Set(['tool-running']),
+      lookups: {
+        erroredToolUseIDs: new Set(['tool-failed']),
+        progressMessagesByToolUseID: new Map([
+          ['tool-running', [hookProgress, visibleProgress]],
+        ]),
+        resolvedToolUseIDs: new Set(['tool-complete', 'tool-failed']),
+      } as never,
+      message: {
+        messages: [
+          { message: { content: [completedToolUse] }, type: 'assistant' },
+          { message: { content: [failedToolUse] }, type: 'assistant' },
+          { message: { content: [runningToolUse] }, type: 'assistant' },
+        ],
+        results: [
+          {
+            message: { content: [completedResultParam] },
+            toolUseResult: { text: 'done' },
+            type: 'user',
+          },
+          {
+            message: { content: [failedResultParam] },
+            toolUseResult: { text: 'boom' },
+            type: 'user',
+          },
+        ],
+        toolName: 'Agent',
+        type: 'grouped_tool_use',
+      } as never,
+      shouldAnimate: true,
+      tools,
+    })
+
+    expect(node).toBe('grouped node')
+    expect(renderGroupedToolUse).toHaveBeenCalledTimes(1)
+    expect(renderGroupedToolUse).toHaveBeenCalledWith(
+      [
+        {
+          isError: false,
+          isInProgress: false,
+          isResolved: true,
+          param: completedToolUse,
+          progressMessages: [],
+          result: {
+            output: { text: 'done' },
+            param: completedResultParam,
+          },
+        },
+        {
+          isError: true,
+          isInProgress: false,
+          isResolved: true,
+          param: failedToolUse,
+          progressMessages: [],
+          result: {
+            output: { text: 'boom' },
+            param: failedResultParam,
+          },
+        },
+        {
+          isError: false,
+          isInProgress: true,
+          isResolved: false,
+          param: runningToolUse,
+          progressMessages: [visibleProgress],
+          result: undefined,
+        },
+      ],
+      {
+        shouldAnimate: true,
+        tools,
+      },
+    )
+  })
+})

--- a/runtime/tests/tui/message-renderers/HighlightedThinkingText.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/HighlightedThinkingText.coverage.test.tsx
@@ -1,0 +1,70 @@
+import figures from 'figures'
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import { MessageActionsSelectedContext } from '../components/messageActions.js'
+import { QueuedMessageProvider } from '../context/QueuedMessageContext.js'
+import { HighlightedThinkingText } from './HighlightedThinkingText.js'
+
+const thinkingMock = vi.hoisted(() => ({
+  findThinkingTriggerPositions: vi.fn((text: string) => {
+    const start = text.toLowerCase().indexOf('ultrathink')
+    if (start === -1) return []
+    return [{ word: text.slice(start, start + 10), start, end: start + 10 }]
+  }),
+  getRainbowColor: vi.fn(() => 'suggestion'),
+  isUltrathinkEnabled: vi.fn(() => true),
+}))
+
+const timestampMock = vi.hoisted(() => ({
+  formatBriefTimestamp: vi.fn(() => '12:34 PM'),
+}))
+
+vi.mock('../../utils/thinking.js', () => thinkingMock)
+vi.mock('../../utils/formatBriefTimestamp.js', () => timestampMock)
+
+describe('HighlightedThinkingText coverage', () => {
+  test('renders pointer, thinking highlight pieces, and brief queued layout', async () => {
+    const highlighted = await renderToString(
+      <MessageActionsSelectedContext.Provider value={true}>
+        <HighlightedThinkingText text="please ultrathink now" />
+      </MessageActionsSelectedContext.Provider>,
+      80,
+    )
+
+    expect(highlighted).toContain(`${figures.pointer} please ultrathink now`)
+    expect(thinkingMock.findThinkingTriggerPositions).toHaveBeenCalledWith(
+      'please ultrathink now',
+    )
+    expect(thinkingMock.getRainbowColor).toHaveBeenCalledTimes(10)
+    expect(thinkingMock.getRainbowColor.mock.calls.map(([index]) => index)).toEqual([
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+    ])
+
+    const plainWithoutPointer = await renderToString(
+      <HighlightedThinkingText text="plain prompt" showPointer={false} />,
+      80,
+    )
+
+    expect(plainWithoutPointer.trim()).toBe('plain prompt')
+
+    const brief = await renderToString(
+      <QueuedMessageProvider isFirst={true} useBriefLayout={true}>
+        <HighlightedThinkingText
+          text="queued prompt"
+          timestamp="2026-05-20T18:34:00.000Z"
+          useBriefLayout={true}
+        />
+      </QueuedMessageProvider>,
+      80,
+    )
+
+    expect(brief).toContain('You 12:34 PM')
+    expect(brief).toContain('queued prompt')
+    expect(brief).not.toContain(figures.pointer)
+    expect(timestampMock.formatBriefTimestamp).toHaveBeenCalledWith(
+      '2026-05-20T18:34:00.000Z',
+    )
+  })
+})

--- a/runtime/tests/tui/message-renderers/HookProgressMessage.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/HookProgressMessage.coverage.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import type { MessageLookups } from '../../utils/messages.js'
+import { renderToString } from '../../utils/staticRender.js'
+import { HookProgressMessage } from './HookProgressMessage.js'
+
+type HookCounts = ReadonlyArray<readonly [string, Readonly<Record<string, number>>]>
+
+function createLookups(options: {
+  readonly inProgress?: HookCounts
+  readonly resolved?: HookCounts
+}): MessageLookups {
+  const createCountMap = (counts: HookCounts = []) =>
+    new Map(
+      counts.map(([toolUseID, byEvent]) => [
+        toolUseID,
+        new Map(Object.entries(byEvent)),
+      ]),
+    )
+
+  return {
+    siblingToolUseIDs: new Map(),
+    progressMessagesByToolUseID: new Map(),
+    inProgressHookCounts: createCountMap(options.inProgress),
+    resolvedHookCounts: createCountMap(options.resolved),
+    toolResultByToolUseID: new Map(),
+    toolUseByToolUseID: new Map(),
+    normalizedMessageCount: 0,
+    resolvedToolUseIDs: new Set(),
+    erroredToolUseIDs: new Set(),
+  } as MessageLookups
+}
+
+function renderHookProgress(
+  props: Omit<React.ComponentProps<typeof HookProgressMessage>, 'verbose'>,
+): Promise<string> {
+  return renderToString(
+    <HookProgressMessage
+      {...props}
+      verbose={false}
+    />,
+    { columns: 100, rows: 10 },
+  )
+}
+
+describe('HookProgressMessage coverage', () => {
+  test('renders active hook progress and omits absent or fully resolved hook events', async () => {
+    const previousGlyphMode = process.env.AGENC_TUI_GLYPHS
+    process.env.AGENC_TUI_GLYPHS = 'ascii'
+
+    try {
+      const preToolUse = await renderHookProgress({
+        hookEvent: 'PreToolUse',
+        toolUseID: 'toolu-active',
+        lookups: createLookups({
+          inProgress: [['toolu-active', { PreToolUse: 1 }]],
+        }),
+      })
+
+      expect(preToolUse).toContain('Running PreToolUse hook...')
+
+      const transcriptPostToolUse = await renderHookProgress({
+        hookEvent: 'PostToolUse',
+        toolUseID: 'toolu-active',
+        isTranscriptMode: true,
+        lookups: createLookups({
+          inProgress: [['toolu-active', { PostToolUse: 2 }]],
+        }),
+      })
+
+      expect(transcriptPostToolUse).toContain('2 PostToolUse hooks running')
+      expect(transcriptPostToolUse).not.toContain('Running PostToolUse')
+
+      const notification = await renderHookProgress({
+        hookEvent: 'Notification',
+        toolUseID: 'toolu-active',
+        lookups: createLookups({
+          inProgress: [['toolu-active', { Notification: 2 }]],
+          resolved: [['toolu-active', { Notification: 1 }]],
+        }),
+      })
+
+      expect(notification).toContain('Running Notification hooks...')
+
+      const missing = await renderHookProgress({
+        hookEvent: 'PreToolUse',
+        toolUseID: 'toolu-missing',
+        lookups: createLookups({}),
+      })
+
+      expect(missing).toBe('\n')
+
+      const fullyResolved = await renderHookProgress({
+        hookEvent: 'Notification',
+        toolUseID: 'toolu-done',
+        lookups: createLookups({
+          inProgress: [['toolu-done', { Notification: 2 }]],
+          resolved: [['toolu-done', { Notification: 2 }]],
+        }),
+      })
+
+      expect(fullyResolved).toBe('\n')
+    } finally {
+      if (previousGlyphMode === undefined) {
+        delete process.env.AGENC_TUI_GLYPHS
+      } else {
+        process.env.AGENC_TUI_GLYPHS = previousGlyphMode
+      }
+    }
+  })
+})

--- a/runtime/tests/tui/message-renderers/PlanApprovalMessage.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/PlanApprovalMessage.coverage.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import { tryRenderPlanApprovalMessage } from './PlanApprovalMessage.js'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    syntaxHighlightingDisabled: true,
+  }),
+}))
+
+function renderPlanApprovalMessage(content: string): Promise<string> {
+  const node = tryRenderPlanApprovalMessage(content, 'lead')
+  if (!React.isValidElement(node)) {
+    throw new Error('expected structured plan approval content to render')
+  }
+  return renderToString(node, { columns: 100, rows: 24 })
+}
+
+describe('PlanApprovalMessage coverage', () => {
+  test('renders request, approval, and rejection states from structured teammate payloads', async () => {
+    const previousGlyphMode = process.env.AGENC_TUI_GLYPHS
+    process.env.AGENC_TUI_GLYPHS = 'ascii'
+
+    try {
+      const requestOutput = await renderPlanApprovalMessage(
+        JSON.stringify({
+          type: 'plan_approval_request',
+          from: 'planner',
+          timestamp: '2026-05-20T00:00:00.000Z',
+          planFilePath: '/tmp/plan.md',
+          planContent: '# Implementation Plan\n\n- Add focused TUI coverage',
+          requestId: 'req-1',
+        }),
+      )
+
+      expect(requestOutput).toContain('Plan Approval Request from planner')
+      expect(requestOutput).toContain('Implementation Plan')
+      expect(requestOutput).toContain('Add focused TUI coverage')
+      expect(requestOutput).toContain('Plan file: /tmp/plan.md')
+
+      const approvedOutput = await renderPlanApprovalMessage(
+        JSON.stringify({
+          type: 'plan_approval_response',
+          requestId: 'req-1',
+          approved: true,
+          timestamp: '2026-05-20T00:00:01.000Z',
+        }),
+      )
+
+      expect(approvedOutput).toContain('OK Plan Approved by lead')
+      expect(approvedOutput).toContain(
+        'You can now proceed with implementation. Your plan mode restrictions have been lifted.',
+      )
+
+      const rejectedOutput = await renderPlanApprovalMessage(
+        JSON.stringify({
+          type: 'plan_approval_response',
+          requestId: 'req-1',
+          approved: false,
+          feedback: 'Add rollback coverage before proceeding.',
+          timestamp: '2026-05-20T00:00:02.000Z',
+        }),
+      )
+
+      expect(rejectedOutput).toContain('ERR Plan Rejected by lead')
+      expect(rejectedOutput).toContain(
+        'Feedback: Add rollback coverage before proceeding.',
+      )
+      expect(rejectedOutput).toContain(
+        'Please revise your plan based on the feedback and call ExitPlanMode again.',
+      )
+    } finally {
+      if (previousGlyphMode === undefined) {
+        delete process.env.AGENC_TUI_GLYPHS
+      } else {
+        process.env.AGENC_TUI_GLYPHS = previousGlyphMode
+      }
+    }
+  })
+})

--- a/runtime/tests/tui/message-renderers/ShutdownMessage.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/ShutdownMessage.coverage.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import {
+  getShutdownMessageSummary,
+  tryRenderShutdownMessage,
+} from './ShutdownMessage.js'
+
+function shutdownPayload(payload: Record<string, unknown>): string {
+  return JSON.stringify({
+    requestId: 'shutdown-worker-one',
+    timestamp: '2026-05-20T00:00:00.000Z',
+    ...payload,
+  })
+}
+
+describe('ShutdownMessage coverage', () => {
+  test('renders request and rejection payloads while summarizing shutdown lifecycle messages', async () => {
+    const request = shutdownPayload({
+      type: 'shutdown_request',
+      from: 'lead',
+      reason: 'Rotate credentials',
+    })
+    const rejected = shutdownPayload({
+      type: 'shutdown_rejected',
+      from: 'worker-one',
+      reason: 'Need to finish current edit',
+    })
+    const approved = shutdownPayload({
+      type: 'shutdown_approved',
+      from: 'worker-one',
+    })
+
+    const requestNode = tryRenderShutdownMessage(request)
+    expect(React.isValidElement(requestNode)).toBe(true)
+    const requestOutput = await renderToString(requestNode, { columns: 100 })
+    expect(requestOutput).toContain('Shutdown request from lead')
+    expect(requestOutput).toContain('Reason: Rotate credentials')
+
+    const rejectedNode = tryRenderShutdownMessage(rejected)
+    expect(React.isValidElement(rejectedNode)).toBe(true)
+    const rejectedOutput = await renderToString(rejectedNode, { columns: 100 })
+    expect(rejectedOutput).toContain('Shutdown rejected by worker-one')
+    expect(rejectedOutput).toContain('Reason: Need to finish current edit')
+    expect(rejectedOutput).toContain(
+      'Teammate is continuing to work. You may request shutdown again later.',
+    )
+
+    expect(tryRenderShutdownMessage(approved)).toBeNull()
+    expect(tryRenderShutdownMessage('plain message')).toBeNull()
+    expect(getShutdownMessageSummary(request)).toBe(
+      '[Shutdown Request from lead] Rotate credentials',
+    )
+    expect(getShutdownMessageSummary(approved)).toBe(
+      '[Shutdown Approved] worker-one is now exiting',
+    )
+    expect(getShutdownMessageSummary(rejected)).toBe(
+      '[Shutdown Rejected] worker-one: Need to finish current edit',
+    )
+    expect(getShutdownMessageSummary('plain message')).toBeNull()
+  })
+})

--- a/runtime/tests/tui/message-renderers/SystemTextMessage.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/SystemTextMessage.coverage.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import { SystemTextMessage } from './SystemTextMessage.js'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../utils/config.js', () => ({
+  getGlobalConfig: () => ({ showTurnDuration: false }),
+}))
+
+vi.mock('../../utils/browser.js', () => ({
+  openPath: () => {},
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppStateStore: () => ({
+    getState: () => ({ tasks: {} }),
+  }),
+}))
+
+function renderSystemMessage(message: Record<string, unknown>): Promise<string> {
+  return renderToString(
+    <SystemTextMessage
+      message={{ type: 'system', ...message } as never}
+      addMargin={false}
+      verbose={false}
+    />,
+    { columns: 100, rows: 24 },
+  )
+}
+
+describe('SystemTextMessage coverage', () => {
+  test('keeps budget usage visible when turn-duration text is disabled', async () => {
+    const budgetOnly = await renderSystemMessage({
+      subtype: 'turn_duration',
+      durationMs: 2400,
+      budgetTokens: 4000,
+      budgetLimit: 8000,
+      budgetNudges: 0,
+    })
+
+    expect(budgetOnly).toContain('4.0k / 8.0k (50%)')
+    expect(budgetOnly).not.toContain('for 2s')
+
+    await expect(
+      renderSystemMessage({
+        subtype: 'turn_duration',
+        durationMs: 2400,
+        budgetNudges: 0,
+      }),
+    ).resolves.toBe('\n')
+  })
+})

--- a/runtime/tests/tui/message-renderers/SystemTextMessage.coverage2.test.tsx
+++ b/runtime/tests/tui/message-renderers/SystemTextMessage.coverage2.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import { SystemTextMessage } from './SystemTextMessage.js'
+
+const appState = vi.hoisted(() => ({
+  tasks: {
+    shell: {
+      id: 'shell',
+      type: 'local_bash',
+      status: 'running',
+      description: 'npm test',
+      command: 'npm test',
+      startTime: 0,
+      outputFile: 'urn:agenc:task:shell:output',
+      outputOffset: 0,
+      notified: false,
+      isBackgrounded: true,
+    },
+  },
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../utils/config.js', () => ({
+  getGlobalConfig: () => ({ showTurnDuration: true }),
+}))
+
+vi.mock('../../utils/browser.js', () => ({
+  openPath: () => {},
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppStateStore: () => ({
+    getState: () => appState,
+  }),
+}))
+
+function renderSystemMessage(message: Record<string, unknown>): Promise<string> {
+  return renderToString(
+    <SystemTextMessage
+      message={{ type: 'system', ...message } as never}
+      addMargin={false}
+      verbose={false}
+    />,
+    { columns: 100, rows: 24 },
+  )
+}
+
+describe('SystemTextMessage additional coverage', () => {
+  test('renders over-budget turn duration with plural nudges and running task summary', async () => {
+    const output = await renderSystemMessage({
+      subtype: 'turn_duration',
+      durationMs: 3100,
+      budgetTokens: 1200,
+      budgetLimit: 1000,
+      budgetNudges: 2,
+    })
+
+    expect(output).toContain('for 3s')
+    expect(output).toContain('1.2k used (1.0k min')
+    expect(output).toContain('2 nudges')
+    expect(output).toContain('1 shell still running')
+  })
+})

--- a/runtime/tests/tui/message-renderers/SystemTextMessage.wave200-010.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/SystemTextMessage.wave200-010.coverage.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import { SystemTextMessage } from './SystemTextMessage.js'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../utils/config.js', () => ({
+  getGlobalConfig: () => ({ showTurnDuration: true }),
+}))
+
+vi.mock('../../utils/browser.js', () => ({
+  openPath: () => {},
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppStateStore: () => ({
+    getState: () => ({ tasks: {} }),
+  }),
+}))
+
+function renderSystemMessage(message: Record<string, unknown>): Promise<string> {
+  return renderToString(
+    <SystemTextMessage
+      message={{ type: 'system', ...message } as never}
+      addMargin={true}
+      verbose={false}
+    />,
+    { columns: 80, rows: 24 },
+  )
+}
+
+describe('SystemTextMessage wave200-010 coverage', () => {
+  test('defaults malformed protocol events and keeps only string facts', async () => {
+    const output = await renderSystemMessage({
+      subtype: 'protocol_event',
+      protocolKind: 'unknown',
+      facts: [
+        null,
+        'ignored',
+        { label: 'kept', value: 'visible fact' },
+        { label: 'missing value' },
+        { label: 42, value: 'wrong label' },
+      ],
+    })
+
+    expect(output).toContain('protocol')
+    expect(output).toContain('KEPT')
+    expect(output).toContain('visible fact')
+    expect(output).not.toContain('missing value')
+    expect(output).not.toContain('wrong label')
+  })
+})

--- a/runtime/tests/tui/message-renderers/TaskAssignmentMessage.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/TaskAssignmentMessage.coverage.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import {
+  getTaskAssignmentSummary,
+  tryRenderTaskAssignmentMessage,
+} from './TaskAssignmentMessage.js'
+
+describe('TaskAssignmentMessage coverage', () => {
+  test('renders parsed task assignment details and ignores non-assignment content', async () => {
+    const content = JSON.stringify({
+      type: 'task_assignment',
+      taskId: '42',
+      subject: 'Inspect renderer branch coverage',
+      description: 'Confirm the assignment card includes the body text.',
+      assignedBy: 'lead',
+      timestamp: '2026-05-20T12:00:00.000Z',
+    })
+
+    const output = await renderToString(
+      <>{tryRenderTaskAssignmentMessage(content)}</>,
+      { columns: 100 },
+    )
+
+    expect(output).toContain('Task #42 assigned by lead')
+    expect(output).toContain('Inspect renderer branch coverage')
+    expect(output).toContain('Confirm the assignment card includes the body text.')
+    expect(getTaskAssignmentSummary(content)).toBe(
+      '[Task Assigned] #42 - Inspect renderer branch coverage',
+    )
+
+    const nonAssignment = JSON.stringify({ type: 'teammate_message' })
+    expect(tryRenderTaskAssignmentMessage(nonAssignment)).toBeNull()
+    expect(getTaskAssignmentSummary(nonAssignment)).toBeNull()
+  })
+})

--- a/runtime/tests/tui/message-renderers/UserBashOutputMessage.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/UserBashOutputMessage.coverage.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import { UserBashOutputMessage } from './UserBashOutputMessage.js'
+
+describe('UserBashOutputMessage', () => {
+  it('renders persisted stdout preview and stderr from tagged bash output', async () => {
+    const output = await renderToString(
+      <UserBashOutputMessage
+        content={
+          '<bash-stdout>raw file output <persisted-output>preview line 1\npreview line 2</persisted-output></bash-stdout>' +
+          '<bash-stderr>warning line</bash-stderr>'
+        }
+        verbose={true}
+      />,
+      100,
+    )
+
+    expect(output).toContain('preview line 1')
+    expect(output).toContain('preview line 2')
+    expect(output).toContain('warning line')
+    expect(output).not.toContain('raw file output')
+    expect(output).not.toContain('<persisted-output>')
+    expect(output).not.toContain('(No output)')
+  })
+})

--- a/runtime/tests/tui/message-renderers/UserLocalCommandOutputMessage.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/UserLocalCommandOutputMessage.coverage.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { DIAMOND_OPEN } from '../../constants/figures.js'
+import { renderToString } from '../../utils/staticRender.js'
+import { UserLocalCommandOutputMessage } from './UserLocalCommandOutputMessage.js'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    syntaxHighlightingDisabled: true,
+  }),
+}))
+
+describe('UserLocalCommandOutputMessage coverage', () => {
+  it('renders launch-style stdout and ordinary stderr output', async () => {
+    const output = await renderToString(
+      <UserLocalCommandOutputMessage
+        content={[
+          '<local-command-stdout>',
+          `  ${DIAMOND_OPEN} sync local job \u00b7 running`,
+          '    started worker   ',
+          '</local-command-stdout>',
+          '<local-command-stderr>',
+          '  warning: stderr is preserved  ',
+          '</local-command-stderr>',
+        ].join('\n')}
+      />,
+      { columns: 120, rows: 10 },
+    )
+
+    expect(output).toContain(`${DIAMOND_OPEN} sync local job \u00b7 running`)
+    expect(output).toMatch(/\u23bf\s+started worker/)
+    expect(output).toMatch(/\u23bf\s+warning: stderr is preserved/)
+  })
+})

--- a/runtime/tests/tui/message-renderers/UserLocalCommandOutputMessage.wave200-125.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/UserLocalCommandOutputMessage.wave200-125.coverage.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { NO_CONTENT_MESSAGE } from '../../constants/messages.js'
+import { renderToString } from '../../utils/staticRender.js'
+import { UserLocalCommandOutputMessage } from './UserLocalCommandOutputMessage.js'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    syntaxHighlightingDisabled: true,
+  }),
+}))
+
+describe('UserLocalCommandOutputMessage wave200-125 coverage', () => {
+  test('renders the no-content fallback when local command output tags are absent', async () => {
+    const output = await renderToString(
+      <UserLocalCommandOutputMessage content="plain command transcript" />,
+      { columns: 80, rows: 6 },
+    )
+
+    expect(output).toContain(NO_CONTENT_MESSAGE)
+    expect(output).not.toContain('plain command transcript')
+    expect(output).not.toContain('local-command-stdout')
+    expect(output).not.toContain('local-command-stderr')
+  })
+})

--- a/runtime/tests/tui/message-renderers/UserPromptMessage.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/UserPromptMessage.coverage.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import { UserPromptMessage } from './UserPromptMessage.js'
+
+describe('UserPromptMessage coverage', () => {
+  test('renders long prompts with head-tail truncation in the user message layout', async () => {
+    const head = `HEAD_START ${'h'.repeat(2_489)}`
+    const hidden = Array.from(
+      { length: 900 },
+      (_, index) => `MIDDLE_SENTINEL_${index}`,
+    ).join('\n')
+    const tail = `${'t'.repeat(2_491)} TAIL_END`
+
+    const output = await renderToString(
+      <UserPromptMessage
+        addMargin={false}
+        param={{ type: 'text', text: `${head}\n${hidden}\n${tail}` }}
+        timestamp="12:34"
+      />,
+      { columns: 6_000, rows: 24 },
+    )
+
+    expect(output).toContain('YOU')
+    expect(output).toContain('12:34')
+    expect(output).toContain('HEAD_START')
+    expect(output).toContain('TAIL_END')
+    expect(output).toMatch(/… \+\d+ lines …/)
+    expect(output).not.toContain('MIDDLE_SENTINEL')
+  })
+})

--- a/runtime/tests/tui/message-renderers/UserTeammateMessage.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/UserTeammateMessage.coverage.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { TEAMMATE_MESSAGE_TAG } from '../../constants/xml.js'
+import { renderToString } from '../../utils/staticRender.js'
+import { UserTeammateMessage } from './UserTeammateMessage.js'
+
+function teammateMessage({
+  teammateId,
+  color,
+  summary,
+  content,
+}: {
+  teammateId: string
+  color?: string
+  summary?: string
+  content: string
+}): string {
+  const colorAttribute = color ? ` color="${color}"` : ''
+  const summaryAttribute = summary ? ` summary="${summary}"` : ''
+
+  return `<${TEAMMATE_MESSAGE_TAG} teammate_id="${teammateId}"${colorAttribute}${summaryAttribute}>
+${content}
+</${TEAMMATE_MESSAGE_TAG}>`
+}
+
+describe('UserTeammateMessage coverage', () => {
+  test('renders visible teammate updates and hides lifecycle noise', async () => {
+    const output = await renderToString(
+      <UserTeammateMessage
+        addMargin={false}
+        isTranscriptMode={true}
+        param={{
+          type: 'text',
+          text: [
+            teammateMessage({
+              teammateId: 'builder',
+              color: 'green',
+              summary: 'ready for review',
+              content: 'Investigated renderer output\nCaptured the terminal text',
+            }),
+            teammateMessage({
+              teammateId: 'leader',
+              color: 'yellow',
+              content: JSON.stringify({
+                type: 'task_completed',
+                from: 'leader',
+                taskId: 'TUI-17',
+                taskSubject: 'write renderer coverage',
+              }),
+            }),
+            teammateMessage({
+              teammateId: 'builder',
+              content: JSON.stringify({
+                type: 'idle_notification',
+                from: 'builder',
+                timestamp: '2026-05-20T00:00:00.000Z',
+              }),
+            }),
+            teammateMessage({
+              teammateId: 'builder',
+              content: JSON.stringify({
+                type: 'teammate_terminated',
+                message: 'terminated message should stay hidden',
+              }),
+            }),
+            teammateMessage({
+              teammateId: 'builder',
+              content: JSON.stringify({
+                type: 'shutdown_approved',
+                requestId: 'shutdown-builder',
+                from: 'builder',
+                timestamp: '2026-05-20T00:00:01.000Z',
+              }),
+            }),
+          ].join('\n'),
+        }}
+      />,
+      { columns: 120 },
+    )
+
+    expect(output).toContain('@builder')
+    expect(output).toContain('ready for review')
+    expect(output).toContain('Investigated renderer output')
+    expect(output).toContain('Captured the terminal text')
+    expect(output).toContain('@leader')
+    expect(output).toContain('Completed task #TUI-17')
+    expect(output).toContain('(write renderer coverage)')
+    expect(output).not.toContain('idle_notification')
+    expect(output).not.toContain('terminated message should stay hidden')
+    expect(output).not.toContain('shutdown_approved')
+  })
+})

--- a/runtime/tests/tui/message-renderers/UserTextMessage.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/UserTextMessage.coverage.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+const features = vi.hoisted(() => new Set<string>())
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => features.has(name),
+}))
+
+vi.mock('../hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    syntaxHighlightingDisabled: true,
+  }),
+}))
+
+import { renderToString } from '../../utils/staticRender.js'
+import { UserTextMessage } from './UserTextMessage.js'
+
+function renderUserText(text: string): Promise<string> {
+  return renderToString(
+    <UserTextMessage
+      addMargin={false}
+      param={{ type: 'text', text }}
+      verbose={false}
+    />,
+    { columns: 100, rows: 24 },
+  )
+}
+
+describe('UserTextMessage coverage', () => {
+  test('renders feature-gated channel messages with source, user, and body text', async () => {
+    features.add('KAIROS_CHANNELS')
+
+    const output = await renderUserText(
+      [
+        '<channel source="mcp:notifications" user="deploy-bot">',
+        'Deploy finished for staging',
+        '</channel>',
+      ].join('\n'),
+    )
+
+    expect(output).toContain('notifications · deploy-bot')
+    expect(output).toContain('Deploy finished for staging')
+    expect(output).not.toContain('<channel')
+  })
+})

--- a/runtime/tests/tui/message-renderers/UserTextMessage.coverage2.test.tsx
+++ b/runtime/tests/tui/message-renderers/UserTextMessage.coverage2.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    syntaxHighlightingDisabled: true,
+  }),
+}))
+
+import { renderToString } from '../../utils/staticRender.js'
+import { UserTextMessage } from './UserTextMessage.js'
+
+describe('UserTextMessage coverage2', () => {
+  test('routes MCP polling updates through the resource update renderer', async () => {
+    const output = await renderToString(
+      <UserTextMessage
+        addMargin={false}
+        param={{
+          type: 'text',
+          text: [
+            '<mcp-polling-update type="tool" server="linear" tool="listIssues">',
+            '<reason>sync requested</reason>',
+            '</mcp-polling-update>',
+          ].join(''),
+        }}
+        verbose={false}
+      />,
+      { columns: 100, rows: 24 },
+    )
+
+    expect(output).toContain('MCP')
+    expect(output).toContain('linear')
+    expect(output).toContain('listIssues')
+    expect(output).toContain('sync requested')
+    expect(output).not.toContain('mcp-polling-update')
+  })
+})

--- a/runtime/tests/tui/message-renderers/UserTextMessage.wave200-024.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/UserTextMessage.wave200-024.coverage.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    syntaxHighlightingDisabled: true,
+  }),
+}))
+
+import { TEAMMATE_MESSAGE_TAG } from '../../constants/xml.js'
+import { renderToString } from '../../utils/staticRender.js'
+import { UserTextMessage } from './UserTextMessage.js'
+
+const originalUserType = process.env.USER_TYPE
+
+afterEach(() => {
+  if (originalUserType === undefined) {
+    delete process.env.USER_TYPE
+  } else {
+    process.env.USER_TYPE = originalUserType
+  }
+})
+
+describe('UserTextMessage wave200-024 coverage', () => {
+  test('routes teammate messages when agent swarms are enabled', async () => {
+    process.env.USER_TYPE = 'ant'
+
+    const output = await renderToString(
+      <UserTextMessage
+        addMargin={false}
+        isTranscriptMode={true}
+        param={{
+          type: 'text',
+          text: `<${TEAMMATE_MESSAGE_TAG} teammate_id="reviewer" color="cyan" summary="coverage route">
+Renderer selected the teammate branch.
+</${TEAMMATE_MESSAGE_TAG}>`,
+        }}
+        verbose={false}
+      />,
+      { columns: 100 },
+    )
+
+    expect(output).toContain('@reviewer')
+    expect(output).toContain('coverage route')
+    expect(output).toContain('Renderer selected the teammate branch.')
+    expect(output).not.toContain(`<${TEAMMATE_MESSAGE_TAG}`)
+  })
+})

--- a/runtime/tests/tui/message-renderers/UserToolResultMessage/UserToolErrorMessage.wave200-049.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/UserToolResultMessage/UserToolErrorMessage.wave200-049.coverage.test.tsx
@@ -1,0 +1,151 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+const featureFlags = vi.hoisted(() => new Set<string>())
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => featureFlags.has(name),
+}))
+
+vi.mock('../../hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    syntaxHighlightingDisabled: true,
+  }),
+}))
+
+import type { Tool, Tools } from '../../../tools/Tool.js'
+import type {
+  AgenCToolResultBlockParam,
+  ProgressMessage,
+} from '../../../types/message.js'
+import { renderToString } from '../../../utils/staticRender.js'
+import {
+  INTERRUPT_MESSAGE_FOR_TOOL_USE,
+  PLAN_REJECTION_PREFIX,
+  REJECT_MESSAGE_WITH_REASON_PREFIX,
+} from '../../../utils/messages.js'
+import { Text } from '../../ink.js'
+import { UserToolErrorMessage } from './UserToolErrorMessage.js'
+
+function toolResult(content: AgenCToolResultBlockParam['content']): AgenCToolResultBlockParam {
+  return {
+    type: 'tool_result',
+    tool_use_id: 'toolu_error',
+    is_error: true,
+    content,
+  }
+}
+
+describe('UserToolErrorMessage wave200-049 coverage', () => {
+  test('routes denial, interruption, rejection, classifier, delegated, and fallback errors', async () => {
+    featureFlags.clear()
+    featureFlags.add('TRANSCRIPT_CLASSIFIER')
+
+    const toolProgress = {
+      uuid: 'progress-tool',
+      data: { type: 'tool_progress', text: 'kept progress' },
+    }
+    const hookProgress = {
+      uuid: 'progress-hook',
+      data: { type: 'hook_progress', hookEvent: 'PreToolUse' },
+    }
+    const progressMessages = [
+      hookProgress,
+      toolProgress,
+    ] as ProgressMessage[]
+    let receivedOptions:
+      | {
+          readonly progressMessagesForMessage: ProgressMessage[]
+          readonly tools: Tools
+          readonly verbose: boolean
+          readonly isTranscriptMode?: boolean
+        }
+      | undefined
+    const delegatedTool = {
+      name: 'Delegate',
+      renderToolUseErrorMessage: vi.fn((content: unknown, options) => {
+        receivedOptions = options
+        return <Text>delegated {String(content)} transcript</Text>
+      }),
+    } as unknown as Tool
+    const tools = [delegatedTool] as Tools
+
+    const output = await renderToString(
+      <>
+        <UserToolErrorMessage
+          progressMessagesForMessage={[]}
+          tool={delegatedTool}
+          tools={tools}
+          param={toolResult({ error: 'rejected by user' } as never)}
+          verbose={false}
+        />
+        <UserToolErrorMessage
+          progressMessagesForMessage={[]}
+          tools={[]}
+          param={toolResult(`before ${INTERRUPT_MESSAGE_FOR_TOOL_USE}`)}
+          verbose={false}
+        />
+        <UserToolErrorMessage
+          progressMessagesForMessage={[]}
+          tools={[]}
+          param={toolResult(
+            `${PLAN_REJECTION_PREFIX}Keep this plan visible.`,
+          )}
+          verbose={false}
+        />
+        <UserToolErrorMessage
+          progressMessagesForMessage={[]}
+          tools={[]}
+          param={toolResult(
+            `${REJECT_MESSAGE_WITH_REASON_PREFIX}Use a safer path.`,
+          )}
+          verbose={false}
+        />
+        <UserToolErrorMessage
+          progressMessagesForMessage={[]}
+          tools={[]}
+          param={toolResult(
+            'Permission for this action has been denied. Reason: command looked destructive',
+          )}
+          verbose={false}
+        />
+        <UserToolErrorMessage
+          progressMessagesForMessage={progressMessages}
+          tool={delegatedTool}
+          tools={tools}
+          param={toolResult('custom failure')}
+          verbose={true}
+          isTranscriptMode={true}
+        />
+        <UserToolErrorMessage
+          progressMessagesForMessage={[]}
+          tools={[]}
+          param={toolResult(
+            '<tool_use_error><error>InputValidationError: missing path</error></tool_use_error>',
+          )}
+          verbose={false}
+        />
+      </>,
+      { columns: 120, rows: 24 },
+    )
+
+    expect(output).toContain('Permission request denied by user.')
+    expect(output).toContain('Interrupted')
+    expect(output).toContain('What should AgenC do instead?')
+    expect(output).toContain("User rejected AgenC's plan:")
+    expect(output).toContain('Keep this plan visible.')
+    expect(output).toContain('Tool use rejected')
+    expect(output).toContain('Denied by auto mode classifier')
+    expect(output).toContain('/feedback if incorrect')
+    expect(output).toContain('delegated custom failure transcript')
+    expect(output).toContain('Invalid tool parameters')
+    expect(output).not.toContain('InputValidationError')
+    expect(delegatedTool.renderToolUseErrorMessage).toHaveBeenCalledTimes(1)
+    expect(receivedOptions).toMatchObject({
+      tools,
+      verbose: true,
+      isTranscriptMode: true,
+    })
+    expect(receivedOptions?.progressMessagesForMessage).toEqual([toolProgress])
+  })
+})

--- a/runtime/tests/tui/message-renderers/UserToolResultMessage/UserToolRejectMessage.wave200-072.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/UserToolResultMessage/UserToolRejectMessage.wave200-072.coverage.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import type { Tool, Tools } from '../../../tools/Tool.js'
+import type { ProgressMessage } from '../../../types/message.js'
+import { renderToString } from '../../../utils/staticRender.js'
+import { Text } from '../../ink.js'
+import { UserToolRejectMessage } from './UserToolRejectMessage.js'
+
+const previousGlyphMode = process.env.AGENC_TUI_GLYPHS
+
+afterEach(() => {
+  if (previousGlyphMode === undefined) {
+    delete process.env.AGENC_TUI_GLYPHS
+  } else {
+    process.env.AGENC_TUI_GLYPHS = previousGlyphMode
+  }
+})
+
+describe('UserToolRejectMessage wave200-072 coverage', () => {
+  test('falls back for unavailable rejected renderers and delegates validated rejected input', async () => {
+    process.env.AGENC_TUI_GLYPHS = 'ascii'
+
+    const tools = [] as unknown as Tools
+    const toolProgress = {
+      uuid: 'tool-progress',
+      data: { type: 'tool_progress', text: 'kept' },
+    } as ProgressMessage
+    const hookProgress = {
+      uuid: 'hook-progress',
+      data: { type: 'hook_progress', hookEvent: 'PreToolUse' },
+    } as ProgressMessage
+    const progressMessagesForMessage = [hookProgress, toolProgress]
+    const noRendererSafeParse = vi.fn()
+    const invalidRenderer = vi.fn()
+    const nullRenderer = vi.fn(() => null)
+    const delegatedRenderer = vi.fn((input, options) => (
+      <Text>
+        delegated {input.path} columns {options.columns} progress{' '}
+        {options.progressMessagesForMessage.length} style {options.style} theme{' '}
+        {options.theme} transcript {String(options.isTranscriptMode)} verbose{' '}
+        {String(options.verbose)}
+      </Text>
+    ))
+    const noRendererTool = {
+      name: 'NoRejectedRenderer',
+      inputSchema: { safeParse: noRendererSafeParse },
+    } as unknown as Tool
+    const invalidTool = {
+      name: 'InvalidRejectedInput',
+      inputSchema: {
+        safeParse: () => ({ success: false }),
+      },
+      renderToolUseRejectedMessage: invalidRenderer,
+    } as unknown as Tool
+    const nullTool = {
+      name: 'NullRejectedRenderer',
+      inputSchema: {
+        safeParse: () => ({ success: true, data: { path: 'null-render' } }),
+      },
+      renderToolUseRejectedMessage: nullRenderer,
+    } as unknown as Tool
+    const delegatedTool = {
+      name: 'DelegatedRejectedRenderer',
+      inputSchema: {
+        safeParse: (input: { path: string }) => ({
+          success: true,
+          data: { path: `${input.path}:parsed` },
+        }),
+      },
+      renderToolUseRejectedMessage: delegatedRenderer,
+    } as unknown as Tool
+
+    const sharedProps = {
+      input: { path: 'runtime/src/example.ts' },
+      progressMessagesForMessage,
+      tools,
+      lookups: {} as never,
+    }
+
+    const output = await renderToString(
+      <>
+        <UserToolRejectMessage
+          {...sharedProps}
+          tool={undefined}
+          verbose={false}
+        />
+        <UserToolRejectMessage
+          {...sharedProps}
+          tool={noRendererTool}
+          verbose={false}
+        />
+        <UserToolRejectMessage
+          {...sharedProps}
+          tool={invalidTool}
+          verbose={false}
+        />
+        <UserToolRejectMessage
+          {...sharedProps}
+          tool={nullTool}
+          verbose={false}
+        />
+        <UserToolRejectMessage
+          {...sharedProps}
+          tool={delegatedTool}
+          style="condensed"
+          verbose={true}
+          isTranscriptMode={true}
+        />
+      </>,
+      { columns: 96, rows: 24 },
+    )
+
+    expect(output).toContain('Interrupted')
+    expect(output).toContain('What should AgenC do instead?')
+    const normalizedOutput = output.replace(/\s+/g, ' ')
+    expect(normalizedOutput).toContain(
+      'delegated runtime/src/example.ts:parsed columns 96 progress 1 style condensed theme dark transcript true verbose true',
+    )
+    expect(noRendererSafeParse).not.toHaveBeenCalled()
+    expect(invalidRenderer).not.toHaveBeenCalled()
+    expect(nullRenderer).toHaveBeenCalledTimes(1)
+    expect(delegatedRenderer).toHaveBeenCalledTimes(1)
+    expect(delegatedRenderer.mock.calls[0]?.[1]).toMatchObject({
+      columns: 96,
+      messages: [],
+      tools,
+      verbose: true,
+      progressMessagesForMessage: [toolProgress],
+      style: 'condensed',
+      theme: 'dark',
+      isTranscriptMode: true,
+    })
+  })
+})

--- a/runtime/tests/tui/message-renderers/UserToolResultMessage/UserToolResultMessage.coverage2.test.tsx
+++ b/runtime/tests/tui/message-renderers/UserToolResultMessage/UserToolResultMessage.coverage2.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { describe, expect, test } from "vitest";
+
+import { renderToString } from "../../../utils/staticRender.js";
+import { UserToolResultMessage } from "./UserToolResultMessage.js";
+
+describe("UserToolResultMessage additional coverage", () => {
+  test("renders recovered orphan tool results with mixed content blocks", async () => {
+    const output = await renderToString(
+      <UserToolResultMessage
+        param={{
+          type: "tool_result",
+          tool_use_id: "toolu_missing",
+          content: [
+            "plain output",
+            { type: "text", text: "text block output" },
+            { type: "image", source: { type: "base64", data: "abc" } },
+          ],
+        }}
+        message={{ type: "user", message: { role: "user", content: [] } }}
+        lookups={{ toolUseByToolUseID: new Map() }}
+        progressMessagesForMessage={[]}
+        tools={[]}
+        verbose={false}
+        width={80}
+      />,
+      { columns: 100, rows: 24 },
+    );
+
+    expect(output).toContain(
+      "Tool result recovered without matching tool call:",
+    );
+    expect(output).toContain("plain output");
+    expect(output).toContain("text block output");
+    expect(output).toContain(
+      '{"type":"image","source":{"type":"base64","data":"abc"}}',
+    );
+  });
+});

--- a/runtime/tests/tui/message-renderers/UserToolResultMessage/UserToolResultMessage.wave200-035.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/UserToolResultMessage/UserToolResultMessage.wave200-035.coverage.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import type { Tool } from '../../../tools/Tool.js'
+import {
+  CANCEL_MESSAGE,
+  INTERRUPT_MESSAGE_FOR_TOOL_USE,
+} from '../../../utils/messages.js'
+import { renderToString } from '../../../utils/staticRender.js'
+import { Text } from '../../ink.js'
+import { UserToolResultMessage } from './UserToolResultMessage.js'
+
+describe('UserToolResultMessage wave200-035 coverage', () => {
+  test('routes matched tool results through cancellation, rejection, error, and success renderers', async () => {
+    const toolUse = {
+      type: 'tool_use',
+      id: 'toolu_wave200_035',
+      name: 'WaveCoverageTool',
+      input: { path: 'runtime/src/example.ts' },
+    }
+    const lookups = {
+      toolUseByToolUseID: new Map([[toolUse.id, toolUse]]),
+      inProgressHookCounts: new Map(),
+      resolvedHookCounts: new Map(),
+    }
+    const progressMessagesForMessage = [
+      { data: { type: 'hook_progress', hookEvent: 'PreToolUse' } },
+      { data: { type: 'tool_progress', text: 'working' } },
+    ]
+    const message = {
+      type: 'user',
+      toolUseResult: { value: 'saved' },
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: toolUse.id,
+            content: 'persisted fallback',
+          },
+        ],
+      },
+    }
+    const tool = {
+      name: 'WaveCoverageTool',
+      inputSchema: {
+        safeParse: (input: unknown) => ({ success: true, data: input }),
+      },
+      outputSchema: {
+        safeParse: (output: unknown) => ({ success: true, data: output }),
+      },
+      userFacingName: () => 'WaveCoverageTool',
+      renderToolUseRejectedMessage: vi.fn((input, options) => (
+        <Text>
+          rejected {input.path} {options.progressMessagesForMessage.length}{' '}
+          {String(options.isTranscriptMode)}
+        </Text>
+      )),
+      renderToolUseErrorMessage: vi.fn((content, options) => (
+        <Text>
+          errored {String(content)} {options.progressMessagesForMessage.length}{' '}
+          {String(options.isTranscriptMode)}
+        </Text>
+      )),
+      renderToolResultMessage: vi.fn((result, progress, options) => (
+        <Text>
+          succeeded {result.value} {progress.length} {options.input.path}{' '}
+          {String(options.isTranscriptMode)}
+        </Text>
+      )),
+    } as unknown as Tool
+
+    const render = (content: string, isError = false) =>
+      renderToString(
+        <UserToolResultMessage
+          param={{
+            type: 'tool_result',
+            tool_use_id: toolUse.id,
+            content,
+            is_error: isError,
+          }}
+          message={message}
+          lookups={lookups as never}
+          progressMessagesForMessage={progressMessagesForMessage as never}
+          tools={[tool]}
+          verbose={true}
+          width={70}
+          isTranscriptMode={true}
+        />,
+        { columns: 90, rows: 24 },
+      )
+
+    await expect(render(`${CANCEL_MESSAGE} Later.`)).resolves.toContain(
+      'Interrupted by user',
+    )
+    await expect(render(INTERRUPT_MESSAGE_FOR_TOOL_USE)).resolves.toContain(
+      'rejected runtime/src/example.ts 1 true',
+    )
+    await expect(render('tool failed', true)).resolves.toContain(
+      'errored tool failed 1 true',
+    )
+    await expect(render('tool succeeded')).resolves.toContain(
+      'succeeded saved 1 runtime/src/example.ts true',
+    )
+
+    expect(tool.renderToolUseRejectedMessage).toHaveBeenCalledTimes(1)
+    expect(tool.renderToolUseErrorMessage).toHaveBeenCalledTimes(1)
+    expect(tool.renderToolResultMessage).toHaveBeenCalledTimes(1)
+  })
+})

--- a/runtime/tests/tui/message-renderers/UserToolResultMessage/UserToolSuccessMessage.wave200-060.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/UserToolResultMessage/UserToolSuccessMessage.wave200-060.coverage.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('bun:bundle', () => ({
+  feature: (flag: string) => flag === 'BASH_CLASSIFIER',
+}))
+
+import type { Tool, Tools } from '../../../tools/Tool.js'
+import { clearClassifierApprovals, setClassifierApproval } from '../../../utils/classifierApprovals.js'
+import { renderToString } from '../../../utils/staticRender.js'
+import { Text } from '../../ink.js'
+import { UserToolSuccessMessage } from './UserToolSuccessMessage.js'
+
+afterEach(() => {
+  clearClassifierApprovals()
+})
+
+function createLookups(toolUseID: string) {
+  return {
+    inProgressHookCounts: new Map([
+      [toolUseID, new Map([['PostToolUse', 1]])],
+    ]),
+    resolvedHookCounts: new Map(),
+    toolUseByToolUseID: new Map([
+      [toolUseID, { input: { path: 'src/recovered.ts' } }],
+    ]),
+  } as never
+}
+
+describe('UserToolSuccessMessage wave200-060 coverage', () => {
+  test('renders parsed successful output with filtered progress, input, approval, and hook status', async () => {
+    const toolUseID = 'toolu_success_wave200_060'
+    setClassifierApproval(toolUseID, 'Bash(ls:*)')
+
+    const renderToolResultMessage = vi.fn(
+      (
+        result: { summary: string },
+        progressMessages: ReadonlyArray<{ data: { type: string } }>,
+        options: { input?: unknown; isBriefOnly?: boolean },
+      ) => (
+        <Text>
+          {[
+            result.summary,
+            `progress:${progressMessages.length}`,
+            `input:${(options.input as { path: string }).path}`,
+            `brief:${String(options.isBriefOnly)}`,
+          ].join(' ')}
+        </Text>
+      ),
+    )
+
+    const tool = {
+      outputSchema: {
+        safeParse: () => ({
+          success: true,
+          data: { summary: 'parsed tool result' },
+        }),
+      },
+      renderToolResultMessage,
+      userFacingName: () => 'Coverage tool',
+    } as unknown as Tool
+    const tools = [tool] as Tools
+
+    const output = await renderToString(
+      <UserToolSuccessMessage
+        message={{
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: toolUseID,
+                content: '<persisted-output>fallback should stay hidden</persisted-output>',
+              },
+            ],
+          },
+          toolUseResult: { raw: 'serialized result' },
+        } as never}
+        lookups={createLookups(toolUseID)}
+        toolUseID={toolUseID}
+        progressMessagesForMessage={[
+          {
+            toolUseID,
+            data: { type: 'hook_progress', hookEvent: 'PostToolUse' },
+          },
+          {
+            toolUseID,
+            data: { type: 'bash_progress', totalLines: 3 },
+          },
+        ] as never}
+        style="condensed"
+        tool={tool}
+        tools={tools}
+        verbose={true}
+        width={72}
+      />,
+      { columns: 100, rows: 12 },
+    )
+
+    expect(renderToolResultMessage).toHaveBeenCalledTimes(1)
+    expect(renderToolResultMessage.mock.calls[0]?.[0]).toEqual({
+      summary: 'parsed tool result',
+    })
+    expect(renderToolResultMessage.mock.calls[0]?.[1]).toHaveLength(1)
+    expect(renderToolResultMessage.mock.calls[0]?.[1]?.[0]?.data.type).toBe(
+      'bash_progress',
+    )
+    expect(renderToolResultMessage.mock.calls[0]?.[2]).toMatchObject({
+      style: 'condensed',
+      tools,
+      verbose: true,
+      isBriefOnly: false,
+      input: { path: 'src/recovered.ts' },
+    })
+    expect(output).toContain('parsed tool result')
+    expect(output).toContain('progress:1')
+    expect(output).toContain('input:src/recovered.ts')
+    expect(output).toContain('brief:false')
+    expect(output).toContain('Auto-approved')
+    expect(output).toContain('"Bash(ls:*)"')
+    expect(output).toContain('Running PostToolUse hook')
+    expect(output).not.toContain('fallback should stay hidden')
+  })
+})

--- a/runtime/tests/tui/message-renderers/teamMemCollapsed.test.tsx
+++ b/runtime/tests/tui/message-renderers/teamMemCollapsed.test.tsx
@@ -1,0 +1,245 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import type { DOMElement, DOMNode } from '../ink/dom.ts'
+import instances from '../ink/instances.js'
+import { createRoot } from '../ink/root.js'
+import { Text } from '../ink.js'
+import {
+  TeamMemCountParts,
+  checkHasTeamMemOps,
+} from './teamMemCollapsed.js'
+
+type TeamMemRenderOptions = {
+  readonly hasPrecedingParts?: boolean
+  readonly isActiveGroup?: boolean
+  readonly teamMemoryReadCount?: number
+  readonly teamMemorySearchCount?: number
+  readonly teamMemoryWriteCount?: number
+}
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function createTestStreams(): {
+  stdin: TestStdin
+  stdout: PassThrough
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStdin
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+  ;(stdout as unknown as { rows: number }).rows = 24
+  ;(stdout as unknown as { isTTY: boolean }).isTTY = true
+
+  return { stdin, stdout }
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+  if (!instance?.rootNode) {
+    throw new Error('Ink instance root node not found')
+  }
+  return instance.rootNode
+}
+
+function renderTeamMemParts(options: {
+  readonly hasPrecedingParts?: boolean
+  readonly isActiveGroup?: boolean
+  readonly teamMemoryReadCount?: number
+  readonly teamMemorySearchCount?: number
+  readonly teamMemoryWriteCount?: number
+}): Promise<string> {
+  return renderToString(
+    <Text>
+      <TeamMemCountParts
+        hasPrecedingParts={options.hasPrecedingParts ?? false}
+        isActiveGroup={options.isActiveGroup ?? false}
+        message={{
+          teamMemoryReadCount: options.teamMemoryReadCount,
+          teamMemorySearchCount: options.teamMemorySearchCount,
+          teamMemoryWriteCount: options.teamMemoryWriteCount,
+        }}
+      />
+    </Text>,
+    120,
+  )
+}
+
+function teamMemNode(options: TeamMemRenderOptions): React.ReactNode {
+  return (
+    <Text>
+      <TeamMemCountParts
+        hasPrecedingParts={options.hasPrecedingParts ?? false}
+        isActiveGroup={options.isActiveGroup ?? false}
+        message={{
+          teamMemoryReadCount: options.teamMemoryReadCount,
+          teamMemorySearchCount: options.teamMemorySearchCount,
+          teamMemoryWriteCount: options.teamMemoryWriteCount,
+        }}
+      />
+    </Text>
+  )
+}
+
+function collectInkText(node: DOMNode): string {
+  if (node.nodeName === '#text') {
+    return node.nodeValue
+  }
+  return node.childNodes.map(collectInkText).join('')
+}
+
+async function renderTeamMemSequence(
+  states: readonly TeamMemRenderOptions[],
+): Promise<readonly string[]> {
+  const snapshots: string[] = []
+  const { stdin, stdout } = createTestStreams()
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  try {
+    for (const state of states) {
+      root.render(teamMemNode(state))
+      await sleep(20)
+      snapshots.push(collectInkText(getRootNode(stdout)).replace(/\s+/g, ' '))
+    }
+    return snapshots
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await sleep(25)
+  }
+}
+
+describe('checkHasTeamMemOps', () => {
+  test('detects read, search, and write team memory operations', () => {
+    expect(checkHasTeamMemOps({})).toBe(false)
+    expect(checkHasTeamMemOps({ teamMemoryReadCount: 1 })).toBe(true)
+    expect(checkHasTeamMemOps({ teamMemorySearchCount: 1 })).toBe(true)
+    expect(checkHasTeamMemOps({ teamMemoryWriteCount: 1 })).toBe(true)
+  })
+})
+
+describe('TeamMemCountParts', () => {
+  test('renders nothing when there are no team memory operations', async () => {
+    await expect(renderTeamMemParts({})).resolves.toBe('\n')
+  })
+
+  test('renders active team-memory operations without preceding parts', async () => {
+    const output = await renderTeamMemParts({
+      isActiveGroup: true,
+      teamMemoryReadCount: 1,
+      teamMemorySearchCount: 1,
+      teamMemoryWriteCount: 2,
+    })
+    const flatOutput = output.replace(/\s+/g, ' ')
+
+    expect(flatOutput).toContain(
+      'Recalling 1 team memory, searching team memories, writing 2 team memories',
+    )
+  })
+
+  test('renders finalized team-memory operations after preceding parts', async () => {
+    const output = await renderTeamMemParts({
+      hasPrecedingParts: true,
+      teamMemoryReadCount: 2,
+      teamMemorySearchCount: 1,
+      teamMemoryWriteCount: 1,
+    })
+    const flatOutput = output.replace(/\s+/g, ' ')
+
+    expect(flatOutput).toContain(
+      ', recalled 2 team memories, searched team memories, wrote 1 team memory',
+    )
+  })
+
+  test('renders standalone finalized verbs for each operation type', async () => {
+    await expect(renderTeamMemParts({ teamMemoryReadCount: 1 })).resolves.toContain(
+      'Recalled 1 team memory',
+    )
+    await expect(
+      renderTeamMemParts({ teamMemorySearchCount: 1 }),
+    ).resolves.toContain('Searched team memories')
+    await expect(
+      renderTeamMemParts({ teamMemoryWriteCount: 1 }),
+    ).resolves.toContain('Wrote 1 team memory')
+  })
+
+  test('renders standalone active verbs for search and write operations', async () => {
+    await expect(
+      renderTeamMemParts({
+        isActiveGroup: true,
+        teamMemorySearchCount: 1,
+      }),
+    ).resolves.toContain('Searching team memories')
+    await expect(
+      renderTeamMemParts({
+        isActiveGroup: true,
+        teamMemoryWriteCount: 1,
+      }),
+    ).resolves.toContain('Writing 1 team memory')
+  })
+
+  test('renders active read operations after preceding parts', async () => {
+    await expect(
+      renderTeamMemParts({
+        hasPrecedingParts: true,
+        isActiveGroup: true,
+        teamMemoryReadCount: 1,
+      }),
+    ).resolves.toContain(', recalling 1 team memory')
+  })
+
+  test('reuses memoized nodes while rerendering changed counts', async () => {
+    const snapshots = await renderTeamMemSequence([
+      {
+        hasPrecedingParts: true,
+        teamMemoryReadCount: 1,
+        teamMemorySearchCount: 1,
+        teamMemoryWriteCount: 1,
+      },
+      {
+        hasPrecedingParts: true,
+        teamMemoryReadCount: 1,
+        teamMemorySearchCount: 1,
+        teamMemoryWriteCount: 2,
+      },
+      {
+        hasPrecedingParts: true,
+        teamMemoryReadCount: 2,
+        teamMemorySearchCount: 1,
+        teamMemoryWriteCount: 2,
+      },
+      {
+        hasPrecedingParts: true,
+        teamMemoryReadCount: 2,
+        teamMemorySearchCount: 1,
+        teamMemoryWriteCount: 2,
+      },
+    ])
+
+    expect(snapshots.at(-1)).toContain(
+      ', recalled 2 team memories, searched team memories, wrote 2 team memories',
+    )
+  })
+})

--- a/runtime/tests/tui/message-renderers/teamMemSaved.test.ts
+++ b/runtime/tests/tui/message-renderers/teamMemSaved.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest'
+
+import { teamMemSavedPart } from './teamMemSaved.js'
+
+describe('teamMemSavedPart', () => {
+  test('returns null when no team memory count is present', () => {
+    expect(teamMemSavedPart({})).toBeNull()
+    expect(teamMemSavedPart({ teamCount: 0 })).toBeNull()
+  })
+
+  test('formats singular team memory count', () => {
+    expect(teamMemSavedPart({ teamCount: 1 })).toEqual({
+      count: 1,
+      segment: '1 team memory',
+    })
+  })
+
+  test('formats plural team memory count', () => {
+    expect(teamMemSavedPart({ teamCount: 3 })).toEqual({
+      count: 3,
+      segment: '3 team memories',
+    })
+  })
+})

--- a/runtime/tests/tui/message-visibility.test.ts
+++ b/runtime/tests/tui/message-visibility.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest'
+
+import { isNullRenderingAttachment } from './message-visibility.js'
+
+describe('isNullRenderingAttachment', () => {
+  test('recognizes attachment types that do not render a TUI row', () => {
+    expect(
+      isNullRenderingAttachment({
+        attachment: { type: 'hook_success' },
+        type: 'attachment',
+      }),
+    ).toBe(true)
+  })
+
+  test('rejects visible attachment types', () => {
+    expect(
+      isNullRenderingAttachment({
+        attachment: { type: 'image' },
+        type: 'attachment',
+      }),
+    ).toBe(false)
+  })
+
+  test('rejects non-attachment messages without reading attachment data', () => {
+    expect(isNullRenderingAttachment({ type: 'assistant' })).toBe(false)
+  })
+})

--- a/runtime/tests/tui/permission-requests.coverage.test.tsx
+++ b/runtime/tests/tui/permission-requests.coverage.test.tsx
@@ -1,0 +1,156 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { describe, expect, test, vi } from "vitest";
+
+import type { ReviewDecision } from "../permissions/review-decision.js";
+import { APPROVED } from "../permissions/review-decision.js";
+import type { ApprovalCtx } from "../tools/orchestrator.js";
+import { createRoot } from "./ink.js";
+import type { PendingRequest } from "./permission-requests.js";
+import { AgenCPermissionOverlay } from "./permission-requests.js";
+
+const SYNC_START = "\x1B[?2026h";
+const SYNC_END = "\x1B[?2026l";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+function createStreams(): {
+  readonly stdin: TestStdin;
+  readonly stdout: PassThrough;
+  readonly output: () => string;
+} {
+  let output = "";
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).columns = 120;
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).rows = 24;
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).isTTY = true;
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  return {
+    stdin,
+    stdout,
+    output: () => output,
+  };
+}
+
+function extractLastFrame(output: string): string {
+  let lastFrame: string | null = null;
+  let cursor = 0;
+
+  while (cursor < output.length) {
+    const start = output.indexOf(SYNC_START, cursor);
+    if (start === -1) break;
+    const contentStart = start + SYNC_START.length;
+    const end = output.indexOf(SYNC_END, contentStart);
+    if (end === -1) break;
+    const frame = output.slice(contentStart, end);
+    if (frame.trim().length > 0) {
+      lastFrame = frame;
+    }
+    cursor = end + SYNC_END.length;
+  }
+
+  return lastFrame ?? output;
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function createPendingRequest(
+  resolve: (decision: ReviewDecision) => void,
+): PendingRequest {
+  return {
+    id: "request-mainnet-stake",
+    ctx: {
+      callId: "call-mainnet-stake",
+      toolName: "Bash",
+      turnId: "turn-1",
+      invocation: {
+        payload: {
+          kind: "function",
+          arguments: "{\"command\":\"agenc stake --mainnet --validator 42\"}",
+        },
+      },
+    } as unknown as ApprovalCtx,
+    input: {
+      command: "agenc stake --mainnet --validator 42",
+    },
+    description: "Stake on mainnet",
+    resolve,
+  };
+}
+
+describe("permission request overlay coverage", () => {
+  test("requires the typed high-risk confirmation word before approving", async () => {
+    const resolved: ReviewDecision[] = [];
+    const request = createPendingRequest(decision => {
+      resolved.push(decision);
+    });
+    const tools = [
+      {
+        name: "Bash",
+        userFacingName: vi.fn(() => "Protocol staking"),
+      },
+    ];
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(<AgenCPermissionOverlay request={request} tools={tools} />);
+      await sleep();
+
+      const initialFrame = stripAnsi(extractLastFrame(output()));
+      const compactInitialFrame = initialFrame.replace(/\s+/gu, "");
+      expect(compactInitialFrame).toContain("high-riskapproval");
+      expect(compactInitialFrame).toContain("Protocolstaking");
+      expect(compactInitialFrame).toContain("agencstake--mainnet--validator42");
+      expect(compactInitialFrame).toContain("type'stake'toapprove");
+
+      stdin.write("s");
+      await sleep();
+      stdin.write("x");
+      await sleep();
+      stdin.write("\x7F");
+      await sleep();
+      for (const character of "take") {
+        stdin.write(character);
+        await sleep();
+      }
+
+      const typedFrame = stripAnsi(extractLastFrame(output()));
+      expect(typedFrame).toContain("stake");
+      expect(resolved).toEqual([]);
+
+      stdin.write("\r");
+      await sleep();
+
+      expect(tools[0]?.userFacingName).toHaveBeenCalledWith(request.input);
+      expect(resolved).toEqual([APPROVED]);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+});

--- a/runtime/tests/tui/permission-requests.wave200-038.coverage.test.tsx
+++ b/runtime/tests/tui/permission-requests.wave200-038.coverage.test.tsx
@@ -1,0 +1,313 @@
+import { PassThrough } from "node:stream";
+
+import React, { useEffect } from "react";
+import { describe, expect, test, vi } from "vitest";
+
+import type { AppState } from "./state/AppState.js";
+import { ABORT, APPROVED, APPROVED_FOR_SESSION, DENIED } from "../permissions/review-decision.js";
+import type { ReviewDecision } from "../permissions/review-decision.js";
+import {
+  ASK_USER_QUESTION_TOOL_NAME,
+  clearAskUserQuestionResponsesForTest,
+  createAskUserQuestionTool,
+} from "../tools/ask-user-question/tool.js";
+import type { ApprovalCtx, ApprovalResolver } from "../tools/orchestrator.js";
+import { createRoot, Text } from "./ink.js";
+import type { PendingRequest } from "./permission-requests.js";
+import {
+  buildToolUseConfirmQueue,
+  usePermissionRequests,
+} from "./permission-requests.js";
+import type { AgenCBridgeSession } from "./session-types.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+type ProjectedConfirm = {
+  readonly input: unknown;
+  readonly toolUseID: string;
+  onAbort(): void;
+  onAllow(updatedInput: unknown, permissionUpdates?: readonly unknown[]): void;
+  onReject(feedback?: string): void;
+  onUserInteraction(): void;
+  recheckPermission(): Promise<void>;
+};
+
+function createStreams(): {
+  readonly stdin: TestStdin;
+  readonly stdout: PassThrough;
+} {
+  const stdin = new PassThrough() as TestStdin;
+  const stdout = new PassThrough();
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  Object.assign(stdout, {
+    columns: 120,
+    rows: 24,
+    isTTY: true,
+  });
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 10): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  const started = Date.now();
+  let lastError: unknown;
+
+  while (Date.now() - started < 1_000) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await sleep();
+    }
+  }
+
+  throw lastError;
+}
+
+function createCtx(
+  callId: string,
+  toolName: string,
+  payload: unknown,
+  retryReason?: string,
+): ApprovalCtx {
+  return {
+    callId,
+    toolName,
+    turnId: "turn-038",
+    retryReason,
+    invocation: {
+      callId,
+      payload,
+      toolName: { name: toolName },
+    },
+  } as ApprovalCtx;
+}
+
+function createSession(
+  previousResolver: ApprovalResolver,
+  previousBridge: NonNullable<AgenCBridgeSession["appStateBridge"]>,
+): AgenCBridgeSession {
+  return {
+    conversationId: "conversation-038",
+    services: {
+      approvalResolver: previousResolver,
+      permissionModeRegistry: {
+        current: () => ({ mode: "default" }),
+      },
+    },
+    appStateBridge: previousBridge,
+  } as AgenCBridgeSession;
+}
+
+describe("permission request bridge coverage", () => {
+  test("derives queued inputs and settles approval decisions", async () => {
+    clearAskUserQuestionResponsesForTest();
+
+    const askInput = {
+      questions: [
+        {
+          question: "Continue planning?",
+          header: "Planning",
+          options: [
+            { label: "Plan now", description: "Use existing context" },
+            { label: "Discuss first", description: "Clarify before planning" },
+          ],
+        },
+      ],
+    };
+    const previousResolver: ApprovalResolver = {
+      request: vi.fn(async () => DENIED),
+    };
+    const previousBridge: NonNullable<AgenCBridgeSession["appStateBridge"]> = {
+      setModel: vi.fn(),
+    };
+    const session = createSession(previousResolver, previousBridge);
+    const setModel = vi.fn<(next: string) => void>();
+    const setExpandedView = vi.fn<(next: "none" | "tasks") => void>();
+    const setAppState = vi.fn<(updater: (prev: AppState) => AppState) => void>();
+    let latestRequests: readonly PendingRequest[] = [];
+
+    function Harness() {
+      const requests = usePermissionRequests(
+        session,
+        setModel,
+        setExpandedView,
+        setAppState,
+      );
+
+      useEffect(() => {
+        latestRequests = requests;
+      }, [requests]);
+
+      return <Text>{String(requests.length)}</Text>;
+    }
+
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(<Harness />);
+      await waitFor(() => {
+        expect(session.services.approvalResolver).not.toBe(previousResolver);
+        expect(session.appStateBridge).not.toBe(previousBridge);
+      });
+
+      session.appStateBridge?.setModel?.("model-next");
+      session.appStateBridge?.setExpandedView?.("tasks");
+      session.appStateBridge?.setAppState?.(state => state);
+
+      expect(setModel).toHaveBeenCalledWith("model-next");
+      expect(setExpandedView).toHaveBeenCalledWith("tasks");
+      expect(setAppState).toHaveBeenCalledTimes(1);
+
+      const resolver = session.services.approvalResolver;
+      expect(resolver).toBeDefined();
+
+      const functionDecision = resolver!.request(
+        createCtx(
+          "function-bad-json",
+          "Shell",
+          { kind: "function", arguments: "{not json" },
+          "Retry shell command?",
+        ),
+      );
+      const mcpDecision = resolver!.request(
+        createCtx("mcp-read", "Read", {
+          kind: "mcp",
+          rawArguments: "{\"path\":\"src/app.ts\"}",
+        }),
+      );
+      const customDecision = resolver!.request(
+        createCtx("custom-empty", "CustomTool", {
+          kind: "custom",
+          input: 42,
+        }),
+      );
+      const shellDecision = resolver!.request(
+        createCtx("local-shell", "Shell", {
+          kind: "local_shell",
+          params: { command: ["pwd"], cwd: "/tmp/agenc" },
+        }),
+      );
+      const askDecision = resolver!.request(
+        createCtx("ask-skip", ASK_USER_QUESTION_TOOL_NAME, {
+          kind: "function",
+          arguments: JSON.stringify(askInput),
+        }),
+      );
+
+      await waitFor(() => {
+        expect(latestRequests).toHaveLength(5);
+      });
+      expect(
+        latestRequests.map(request => ({
+          id: request.id,
+          input: request.input,
+          description: request.description,
+        })),
+      ).toEqual([
+        {
+          id: "function-bad-json",
+          input: { input: "{not json" },
+          description: "Retry shell command?",
+        },
+        {
+          id: "mcp-read",
+          input: { path: "src/app.ts" },
+          description: "Permission required to use Read",
+        },
+        {
+          id: "custom-empty",
+          input: { input: "" },
+          description: "Permission required to use CustomTool",
+        },
+        {
+          id: "local-shell",
+          input: { command: ["pwd"], cwd: "/tmp/agenc" },
+          description: "Permission required to use Shell",
+        },
+        {
+          id: "ask-skip",
+          input: askInput,
+          description: `Permission required to use ${ASK_USER_QUESTION_TOOL_NAME}`,
+        },
+      ]);
+
+      const confirmQueue = buildToolUseConfirmQueue(latestRequests, [
+        { name: "Shell" },
+        { name: "Read" },
+        { name: ASK_USER_QUESTION_TOOL_NAME },
+      ]) as readonly ProjectedConfirm[];
+      const confirms = new Map(
+        confirmQueue.map(confirm => [confirm.toolUseID, confirm]),
+      );
+
+      expect(confirms.has("custom-empty")).toBe(false);
+      await expect(customDecision).resolves.toEqual(DENIED);
+
+      const functionConfirm = confirms.get("function-bad-json");
+      expect(functionConfirm).toBeDefined();
+      functionConfirm!.onUserInteraction();
+      await functionConfirm!.recheckPermission();
+      functionConfirm!.onAllow(functionConfirm!.input, []);
+      await expect(functionDecision).resolves.toEqual(APPROVED);
+
+      const shellConfirm = confirms.get("local-shell");
+      expect(shellConfirm).toBeDefined();
+      shellConfirm!.onAllow(shellConfirm!.input, [{ scope: "session" }]);
+      await expect(shellDecision).resolves.toEqual(APPROVED_FOR_SESSION);
+
+      const mcpConfirm = confirms.get("mcp-read");
+      expect(mcpConfirm).toBeDefined();
+      mcpConfirm!.onAbort();
+      await expect(mcpDecision).resolves.toEqual(ABORT);
+
+      const askConfirm = confirms.get("ask-skip");
+      expect(askConfirm).toBeDefined();
+      askConfirm!.onReject("The user provided enough answers for the plan interview");
+      await expect(askDecision).resolves.toEqual(APPROVED);
+
+      const askTool = createAskUserQuestionTool();
+      const askResult = await askTool.execute({
+        __callId: "ask-skip",
+        ...askInput,
+      });
+      expect(askResult).toMatchObject({
+        codeModeResult: {
+          planInterviewAction: "skip_plan_interview",
+        },
+      });
+
+      await waitFor(() => {
+        expect(latestRequests).toHaveLength(0);
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      clearAskUserQuestionResponsesForTest();
+      await sleep();
+    }
+
+    expect(session.services.approvalResolver).toBe(previousResolver);
+    expect(session.appStateBridge).toBe(previousBridge);
+  });
+});

--- a/runtime/tests/tui/realtime/audio.wave200-102.coverage.test.ts
+++ b/runtime/tests/tui/realtime/audio.wave200-102.coverage.test.ts
@@ -1,0 +1,137 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import type { ChildProcess } from "node:child_process";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+type RecordingAvailability = {
+  readonly available: boolean;
+  readonly reason?: string;
+};
+
+type StartRecording = (
+  onChunk: (chunk: Buffer) => void,
+  onClosed: () => void,
+  options: { readonly silenceDetection: boolean },
+) => Promise<boolean>;
+
+const voice = vi.hoisted(() => ({
+  checkRecordingAvailability: vi.fn<() => Promise<RecordingAvailability>>(),
+  startRecording: vi.fn<StartRecording>(),
+  stopRecording: vi.fn<() => void>(),
+}));
+
+vi.mock("../../services/voice.js", () => voice);
+
+import {
+  createProcessRealtimeAudioPlayer,
+  startDefaultRealtimeAudioCapture,
+  type RealtimeAudioCaptureCallbacks,
+  type RealtimeAudioPlayerSpawn,
+} from "./audio.js";
+
+function callbacks(): RealtimeAudioCaptureCallbacks {
+  return {
+    onAudio: vi.fn(),
+    onLevel: vi.fn(),
+    onError: vi.fn(),
+    onClosed: vi.fn(),
+  };
+}
+
+function outputAudio(chunk: Buffer): {
+  readonly data: string;
+  readonly sampleRate: number;
+  readonly numChannels: number;
+} {
+  return {
+    data: chunk.toString("base64"),
+    sampleRate: 24_000,
+    numChannels: 1,
+  };
+}
+
+function createChild(
+  writeChunk: (chunk: Buffer) => boolean,
+): ChildProcess & { stdin: PassThrough } {
+  const child = new EventEmitter() as ChildProcess & { stdin: PassThrough };
+  const stdin = new PassThrough();
+  stdin.write = vi.fn((chunk: Buffer) => writeChunk(Buffer.from(chunk))) as never;
+  child.stdin = stdin;
+  child.kill = vi.fn(() => true) as never;
+  return child;
+}
+
+describe("AgenC realtime audio coverage", () => {
+  beforeEach(() => {
+    voice.checkRecordingAvailability.mockReset();
+    voice.startRecording.mockReset();
+    voice.stopRecording.mockReset();
+  });
+
+  test("starts default capture, maps PCM frames, stops recording, and reports startup failures", async () => {
+    const capturedChunk = Buffer.from([0x00, 0x80, 0x34, 0x12, 0xff]);
+    const captureCallbacks = callbacks();
+    voice.checkRecordingAvailability.mockResolvedValue({ available: true });
+    voice.startRecording.mockImplementation(async (onChunk, onClosed) => {
+      onChunk(capturedChunk);
+      onClosed();
+      return true;
+    });
+
+    const session = await startDefaultRealtimeAudioCapture(captureCallbacks);
+
+    expect(voice.startRecording).toHaveBeenCalledWith(
+      expect.any(Function),
+      captureCallbacks.onClosed,
+      { silenceDetection: false },
+    );
+    expect(captureCallbacks.onAudio).toHaveBeenCalledWith({
+      data: capturedChunk.toString("base64"),
+      sampleRate: 16_000,
+      numChannels: 1,
+      samplesPerChannel: 2,
+    });
+    expect(captureCallbacks.onLevel).toHaveBeenCalledWith(65_535);
+
+    session.stop();
+
+    expect(voice.stopRecording).toHaveBeenCalledTimes(1);
+
+    voice.checkRecordingAvailability.mockResolvedValue({
+      available: false,
+      reason: "microphone denied",
+    });
+    await expect(startDefaultRealtimeAudioCapture(callbacks())).rejects.toThrow(
+      "microphone denied",
+    );
+
+    voice.checkRecordingAvailability.mockResolvedValue({ available: false });
+    await expect(startDefaultRealtimeAudioCapture(callbacks())).rejects.toThrow(
+      "Audio recording is not available",
+    );
+
+    voice.checkRecordingAvailability.mockResolvedValue({ available: true });
+    voice.startRecording.mockResolvedValue(false);
+    await expect(startDefaultRealtimeAudioCapture(callbacks())).rejects.toThrow(
+      "Failed to start audio capture",
+    );
+  });
+
+  test("does not replay accepted stream chunks after stdin backpressure drains", () => {
+    let isDrained = false;
+    const writes: Buffer[] = [];
+    const child = createChild((chunk) => {
+      writes.push(chunk);
+      return isDrained;
+    });
+    const spawnProcess = vi.fn<RealtimeAudioPlayerSpawn>(() => child);
+    const player = createProcessRealtimeAudioPlayer(spawnProcess);
+    const chunk = Buffer.from([1, 2, 3, 4]);
+
+    player.enqueue(outputAudio(chunk));
+    isDrained = true;
+    child.stdin.emit("drain");
+
+    expect(writes).toEqual([chunk]);
+  });
+});

--- a/runtime/tests/tui/realtime/controller.wave200-105.coverage.test.ts
+++ b/runtime/tests/tui/realtime/controller.wave200-105.coverage.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type {
+  AgenCDaemonMethod,
+  AgenCDaemonResultByMethod,
+  JsonObject,
+} from "../../app-server/protocol/index.js";
+import type { RealtimeAudioPlayer } from "./audio.js";
+import { createRealtimeTuiControls } from "./controller.js";
+
+function createClient(): {
+  readonly requests: Array<{
+    readonly method: AgenCDaemonMethod;
+    readonly params?: JsonObject;
+  }>;
+  request<Method extends AgenCDaemonMethod>(
+    method: Method,
+    params?: JsonObject,
+  ): Promise<AgenCDaemonResultByMethod[Method]>;
+} {
+  const requests: Array<{
+    readonly method: AgenCDaemonMethod;
+    readonly params?: JsonObject;
+  }> = [];
+  return {
+    requests,
+    async request(method, params) {
+      requests.push({ method, params });
+      return {} as AgenCDaemonResultByMethod[typeof method];
+    },
+  };
+}
+
+describe("AgenC realtime TUI controller coverage", () => {
+  test("sanitizes transcript notifications while best-effort cleaning up remote errors", async () => {
+    const client = createClient();
+    const emitted: JsonObject[] = [];
+    const stopCapture = vi.fn(async () => {
+      throw new Error("capture stop is best effort");
+    });
+    const audioPlayer: RealtimeAudioPlayer = {
+      enqueue: vi.fn(),
+      close: vi.fn(),
+    };
+    const controls = createRealtimeTuiControls({
+      threadId: "thread-105",
+      client,
+      emitEvent: (event) => emitted.push(event),
+      startAudioCapture: async () => ({ stop: stopCapture }),
+      audioPlayer,
+    });
+    const snapshots: string[] = [];
+    const unsubscribe = controls.subscribe((state) => {
+      snapshots.push(
+        [
+          state.phase,
+          state.localAudioLevel,
+          state.lastItemSummary ?? "",
+          state.errorBanner ?? "",
+        ].join("|"),
+      );
+    });
+
+    controls.handleTranscriptEvent(null);
+    controls.handleTranscriptEvent({ type: 105, payload: { peak: 65_535 } });
+    controls.handleTranscriptEvent({
+      type: "realtime_output_audio_delta",
+      payload: { audio: { data: "AAAA", sampleRate: 24_000 } },
+    });
+    controls.handleTranscriptEvent({
+      type: "realtime_item_added",
+      payload: "not an object",
+    });
+    controls.handleTranscriptEvent({
+      type: "realtime_local_audio_level",
+      payload: { peak: 321.6 },
+    });
+
+    expect(audioPlayer.enqueue).not.toHaveBeenCalled();
+    expect(controls.getState()).toMatchObject({
+      lastItemSummary: "null",
+      localAudioLevel: 322,
+    });
+
+    await controls.start({ transport: "websocket" });
+    controls.handleTranscriptEvent({
+      type: "realtime_error",
+      payload: "not an object",
+    });
+    await Promise.resolve();
+    unsubscribe();
+
+    expect(stopCapture).toHaveBeenCalledTimes(1);
+    expect(audioPlayer.close).toHaveBeenCalledTimes(1);
+    expect(controls.getState()).toMatchObject({
+      phase: "inactive",
+      errorBanner: "Realtime error",
+    });
+    expect(emitted).toEqual([]);
+    expect(snapshots).toContain("inactive|322|null|");
+    expect(client.requests.map((request) => request.method)).toEqual([
+      "thread/realtime/start",
+    ]);
+  });
+});

--- a/runtime/tests/tui/session-transcript.coverage2.test.ts
+++ b/runtime/tests/tui/session-transcript.coverage2.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+
+import { adaptTranscriptEvents } from "./session-transcript.js";
+
+describe("session transcript startup message coverage", () => {
+  test("projects startup content arrays, images, JSON fallback, and empty content into user rows", () => {
+    const transcript = adaptTranscriptEvents([], [
+      {
+        role: "user",
+        content: [
+          "literal",
+          { type: "text", text: "block text" },
+          { type: "image" },
+          { type: "metadata", value: 7 },
+        ],
+      },
+      { role: "user", content: null },
+      { role: "user", content: 42 },
+    ] as any);
+
+    expect(
+      transcript.messages.map((message) => message.message.content),
+    ).toEqual([
+      'literal\nblock text\n[Image]\n{"type":"metadata","value":7}',
+      "(empty)",
+      "42",
+    ]);
+  });
+});

--- a/runtime/tests/tui/session-transcript.wave200-003.coverage.test.ts
+++ b/runtime/tests/tui/session-transcript.wave200-003.coverage.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "vitest";
+
+import { adaptTranscriptEvents } from "./session-transcript.js";
+
+describe("session transcript collab resume coverage", () => {
+  test("renders resume and close rows with fallback status summaries", () => {
+    const transcript = adaptTranscriptEvents([
+      {
+        id: "resume-begin",
+        msg: {
+          type: "collab_resume_begin",
+          payload: {
+            callId: "resume-1",
+            receiverThreadId: "thread-abcdef123456",
+            receiverAgentRoleDisplayName: "planner",
+          },
+        },
+      },
+      {
+        id: "resume-end",
+        msg: {
+          type: "collab_resume_end",
+          payload: {
+            callId: "resume-1",
+            receiverThreadId: "thread-abcdef123456",
+            receiverAgentRoleDisplayName: "planner",
+            status: { status: "paused", error: "snapshot expired" },
+          },
+        },
+      },
+      {
+        id: "close-begin",
+        msg: {
+          type: "collab_close_begin",
+          payload: {
+            callId: "close-1",
+            receiverThreadId: "thread-abcdef123456",
+            receiverAgentNickname: "planner",
+          },
+        },
+      },
+      {
+        id: "close-end",
+        msg: {
+          type: "collab_close_end",
+          payload: {
+            callId: "close-1",
+            receiverThreadId: "thread-abcdef123456",
+            receiverAgentNickname: "planner",
+            status: { status: "not_found" },
+          },
+        },
+      },
+    ]);
+
+    expect(transcript.inProgressToolUseIDs.size).toBe(0);
+    expect(transcript.messages).toMatchObject([
+      {
+        type: "system",
+        subtype: "collab_agent",
+        title: "Resuming planner",
+        details: [],
+        state: "running",
+      },
+      {
+        type: "system",
+        subtype: "collab_agent",
+        title: "Resumed planner",
+        details: ["status: paused: snapshot expired"],
+        state: "info",
+      },
+      {
+        type: "system",
+        subtype: "collab_agent",
+        title: "Closing planner",
+        details: [],
+        state: "running",
+      },
+      {
+        type: "system",
+        subtype: "collab_agent",
+        title: "Closed planner",
+        details: ["previous status: Not found"],
+        state: "error",
+      },
+    ]);
+  });
+});

--- a/runtime/tests/tui/startup/StatusLine.wave200-093.coverage.test.tsx
+++ b/runtime/tests/tui/startup/StatusLine.wave200-093.coverage.test.tsx
@@ -1,0 +1,368 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../ink/root.js'
+import { StatusLine, statusLineShouldDisplay } from './StatusLine.js'
+
+const mocks = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  appState: {
+    toolPermissionContext: {
+      mode: 'acceptEdits',
+      additionalWorkingDirectories: new Map([
+        ['/workspace/packages/runtime', true],
+        ['/tmp/shared-tools', true],
+      ]),
+    },
+    statusLineText: '\u001b[32mseed-status\u001b[0m',
+  } as Record<string, unknown>,
+  checkHasProjectTrustAcceptedSync: vi.fn(() => false),
+  doesMostRecentAssistantMessageExceed200k: vi.fn(() => true),
+  executeStatusLineCommand: vi.fn(async () => 'updated-status'),
+  feature: vi.fn(() => false),
+  getContextWindowForModel: vi.fn(() => 200000),
+  getCurrentUsage: vi.fn(() => 4096),
+  getKairosActive: vi.fn(() => false),
+  getRuntimeMainLoopModel: vi.fn(() => 'runtime-gpt-5'),
+  logEvent: vi.fn(),
+  logForDebugging: vi.fn(),
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: mocks.feature,
+}))
+
+vi.mock('../../services/analytics/index.js', () => ({
+  logEvent: mocks.logEvent,
+}))
+
+vi.mock('../../constants/outputStyles.js', () => ({
+  DEFAULT_OUTPUT_STYLE_NAME: 'default-style',
+}))
+
+vi.mock('../rate-limits/agenc-ai-limits.js', () => ({
+  getRawUtilization: () => ({
+    five_hour: {
+      utilization: 0.42,
+      resets_at: 1710000000,
+    },
+    seven_day: {
+      utilization: 0.7,
+      resets_at: 1710500000,
+    },
+  }),
+}))
+
+vi.mock('../../bootstrap/state.js', () => ({
+  flushInteractionTime: () => {},
+  getActiveTimeCounter: () => 0,
+  getIsRemoteMode: () => true,
+  getKairosActive: mocks.getKairosActive,
+  getMainThreadAgentType: () => 'reviewer',
+  getOriginalCwd: () => '/workspace',
+  getSdkBetas: () => ['context-window-beta'],
+  getSessionId: () => 'session-wave-093',
+  updateLastInteractionTime: () => {},
+}))
+
+vi.mock('../../cost/tracker.js', () => ({
+  getTotalAPIDuration: () => 2345,
+  getTotalCost: () => 1.25,
+  getTotalDuration: () => 3456,
+  getTotalInputTokens: () => 111,
+  getTotalLinesAdded: () => 12,
+  getTotalLinesRemoved: () => 5,
+  getTotalOutputTokens: () => 222,
+}))
+
+vi.mock('../hooks/useMainLoopModel.js', () => ({
+  useMainLoopModel: () => 'gpt-5',
+}))
+
+vi.mock('../hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    disableAllHooks: true,
+    outputStyle: 'compact',
+    statusLine: { command: 'statusline --json', padding: 2 },
+  }),
+}))
+
+vi.mock('../context/notifications.js', () => ({
+  useNotifications: () => ({
+    addNotification: mocks.addNotification,
+  }),
+}))
+
+vi.mock('../../permissions/trust/project-trust.js', () => ({
+  checkHasProjectTrustAcceptedSync: mocks.checkHasProjectTrustAcceptedSync,
+}))
+
+vi.mock('../../utils/config.js', () => ({
+  getGlobalConfig: () => ({ tui: { vimMode: true } }),
+}))
+
+vi.mock('../../utils/context.js', () => ({
+  calculateContextPercentages: () => ({ used: 2, remaining: 98 }),
+  getContextWindowForModel: mocks.getContextWindowForModel,
+}))
+
+vi.mock('../../utils/cwd.js', () => ({
+  getCwd: () => '/workspace/app',
+}))
+
+vi.mock('../../utils/debug.js', () => ({
+  logForDebugging: mocks.logForDebugging,
+}))
+
+vi.mock('../../utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => false,
+}))
+
+vi.mock('../../utils/hooks.js', () => ({
+  createBaseHookInput: () => ({
+    transcript_path: '/workspace/transcript.jsonl',
+  }),
+  executeStatusLineCommand: mocks.executeStatusLineCommand,
+}))
+
+vi.mock('../../utils/messages.js', () => ({
+  getLastAssistantMessage: (messages: Array<{ uuid?: string }>) =>
+    messages.at(-1),
+}))
+
+vi.mock('../../utils/model/model.js', () => ({
+  getRuntimeMainLoopModel: mocks.getRuntimeMainLoopModel,
+  renderModelName: (model: string) => `Rendered ${model}`,
+}))
+
+vi.mock('../../utils/sessionStorage.js', () => ({
+  getCurrentSessionTitle: () => 'Wave 093 session',
+}))
+
+vi.mock('../../utils/tokens.js', () => ({
+  doesMostRecentAssistantMessageExceed200k:
+    mocks.doesMostRecentAssistantMessageExceed200k,
+  getCurrentUsage: mocks.getCurrentUsage,
+}))
+
+vi.mock('../../utils/worktree.js', () => ({
+  getCurrentWorktreeSession: () => ({
+    worktreeName: 'coverage-worker',
+    worktreePath: '/workspace/worktrees/coverage-worker',
+    worktreeBranch: 'coverage/statusline',
+    originalCwd: '/workspace',
+    originalBranch: 'main',
+  }),
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppState: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector(mocks.appState),
+  useSetAppState: () => (next: unknown) => {
+    mocks.appState =
+      typeof next === 'function'
+        ? (next as (state: Record<string, unknown>) => Record<string, unknown>)(
+            mocks.appState,
+          )
+        : (next as Record<string, unknown>)
+  },
+}))
+
+function createStreams(): {
+  readonly stdout: PassThrough
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  readonly output: () => string
+} {
+  let rendered = ''
+  const stdout = new PassThrough()
+  stdout.on('data', chunk => {
+    rendered += chunk.toString()
+  })
+  ;(stdout as unknown as { columns: number }).columns = 120
+  stdout.resume()
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+
+  return { stdout, stdin, output: () => rendered }
+}
+
+async function waitForCommand(): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (mocks.executeStatusLineCommand.mock.calls.length > 0) return
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+}
+
+describe('StatusLine wave200-093 coverage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('MACRO', { VERSION: '99.0.0-test' })
+    mocks.addNotification.mockClear()
+    mocks.appState = {
+      toolPermissionContext: {
+        mode: 'acceptEdits',
+        additionalWorkingDirectories: new Map([
+          ['/workspace/packages/runtime', true],
+          ['/tmp/shared-tools', true],
+        ]),
+      },
+      statusLineText: '\u001b[32mseed-status\u001b[0m',
+    }
+    mocks.checkHasProjectTrustAcceptedSync.mockClear()
+    mocks.doesMostRecentAssistantMessageExceed200k.mockClear()
+    mocks.executeStatusLineCommand.mockClear()
+    mocks.feature.mockReset()
+    mocks.feature.mockReturnValue(false)
+    mocks.getContextWindowForModel.mockClear()
+    mocks.getCurrentUsage.mockClear()
+    mocks.getKairosActive.mockReset()
+    mocks.getKairosActive.mockReturnValue(false)
+    mocks.getRuntimeMainLoopModel.mockClear()
+    mocks.logEvent.mockClear()
+    mocks.logForDebugging.mockClear()
+  })
+
+  test('builds the rich command input and mount notices from current TUI state', async () => {
+    expect(
+      statusLineShouldDisplay({ statusLine: { command: 'statusline' } } as any),
+    ).toBe(true)
+    expect(statusLineShouldDisplay({} as any)).toBe(false)
+
+    mocks.feature.mockReturnValue(true)
+    mocks.getKairosActive.mockReturnValue(true)
+    expect(
+      statusLineShouldDisplay({ statusLine: { command: 'statusline' } } as any),
+    ).toBe(false)
+    mocks.feature.mockReturnValue(false)
+    mocks.getKairosActive.mockReturnValue(false)
+
+    const { stdin, stdout, output } = createStreams()
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    })
+
+    try {
+      root.render(
+        <StatusLine
+          messagesRef={{ current: [{ uuid: 'assistant-093' }] as any[] }}
+          lastAssistantMessageId="assistant-093"
+          vimMode="NORMAL"
+        />,
+      )
+      await waitForCommand()
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+
+    expect(output()).toContain('-- NORMAL --')
+    expect(output()).toContain('seed-status')
+    expect(mocks.logEvent).toHaveBeenCalledWith('agenc_status_line_mount', {
+      command_length: 'statusline --json'.length,
+      padding: 2,
+    })
+    expect(mocks.logForDebugging).toHaveBeenCalledWith(
+      'Status line is configured but disableAllHooks is true',
+      { level: 'warn' },
+    )
+    expect(mocks.addNotification).toHaveBeenCalledWith({
+      key: 'statusline-trust-blocked',
+      text: 'statusline skipped until project trust is accepted',
+      color: 'warning',
+      priority: 'low',
+    })
+
+    expect(mocks.executeStatusLineCommand).toHaveBeenCalledTimes(1)
+    const [input, signal, timeout, logResult] =
+      mocks.executeStatusLineCommand.mock.calls[0]!
+    expect(signal.aborted).toBe(true)
+    expect(timeout).toBeUndefined()
+    expect(logResult).toBe(true)
+    expect(input).toMatchObject({
+      transcript_path: '/workspace/transcript.jsonl',
+      session_name: 'Wave 093 session',
+      model: {
+        id: 'runtime-gpt-5',
+        display_name: 'Rendered runtime-gpt-5',
+      },
+      workspace: {
+        current_dir: '/workspace/app',
+        project_dir: '/workspace',
+        added_dirs: ['/workspace/packages/runtime', '/tmp/shared-tools'],
+      },
+      output_style: {
+        name: 'compact',
+      },
+      cost: {
+        total_cost_usd: 1.25,
+        total_duration_ms: 3456,
+        total_api_duration_ms: 2345,
+        total_lines_added: 12,
+        total_lines_removed: 5,
+      },
+      context_window: {
+        total_input_tokens: 111,
+        total_output_tokens: 222,
+        context_window_size: 200000,
+        current_usage: 4096,
+        used_percentage: 2,
+        remaining_percentage: 98,
+      },
+      exceeds_200k_tokens: true,
+      rate_limits: {
+        five_hour: {
+          used_percentage: 42,
+          resets_at: 1710000000,
+        },
+        seven_day: {
+          used_percentage: 70,
+          resets_at: 1710500000,
+        },
+      },
+      vim: {
+        mode: 'NORMAL',
+      },
+      agent: {
+        name: 'reviewer',
+      },
+      remote: {
+        session_id: 'session-wave-093',
+      },
+      worktree: {
+        name: 'coverage-worker',
+        path: '/workspace/worktrees/coverage-worker',
+        branch: 'coverage/statusline',
+        original_cwd: '/workspace',
+        original_branch: 'main',
+      },
+    })
+    expect(mocks.getRuntimeMainLoopModel).toHaveBeenCalledWith({
+      permissionMode: 'acceptEdits',
+      mainLoopModel: 'gpt-5',
+      exceeds200kTokens: true,
+    })
+    expect(mocks.getContextWindowForModel).toHaveBeenCalledWith(
+      'runtime-gpt-5',
+      ['context-window-beta'],
+    )
+    expect(mocks.appState.statusLineText).toBe('updated-status')
+  })
+})

--- a/runtime/tests/tui/startup/StatusNotices.wave200-073.coverage.test.tsx
+++ b/runtime/tests/tui/startup/StatusNotices.wave200-073.coverage.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderToString } from "../../utils/staticRender.js";
+
+const mocks = vi.hoisted(() => ({
+  apiKeyConfigured: false,
+  apiKeySource: "none" as "ANTHROPIC_API_KEY" | "apiKeyHelper" | "none",
+  authTokenSource: {
+    source: "none",
+    hasToken: false,
+  } as {
+    source:
+      | "ANTHROPIC_AUTH_TOKEN"
+      | "AGENC_OAUTH_TOKEN"
+      | "AGENC_OAUTH_TOKEN_FILE_DESCRIPTOR"
+      | "CCR_OAUTH_TOKEN_FILE"
+      | "apiKeyHelper"
+      | "none";
+    hasToken: boolean;
+  },
+  buildMemoryDiagnostics: vi.fn(async () => [
+    "Large AGENC.md will impact startup",
+  ]),
+  subscriber: false,
+}));
+
+const previousDaemonAutostart = process.env.AGENC_DAEMON_AUTOSTART;
+
+vi.mock("../../utils/auth.js", () => ({
+  getApiKeyFromConfigOrMacOSKeychain: () =>
+    mocks.apiKeyConfigured ? "configured-key" : null,
+  getAuthTokenSource: () => mocks.authTokenSource,
+  getproviderApiKeyWithSource: () => ({ source: mocks.apiKeySource }),
+  isAgenCAISubscriber: () => mocks.subscriber,
+}));
+
+vi.mock("../../utils/config.js", () => ({
+  getGlobalConfig: () => ({ autoInstallIdeExtension: true }),
+}));
+
+vi.mock("../../utils/format.js", () => ({
+  formatNumber: (value: number) => String(value),
+}));
+
+vi.mock("../../utils/ide.js", () => ({
+  getTerminalIdeType: () => null,
+  isSupportedJetBrainsTerminal: () => false,
+  toIDEDisplayName: (ideType: string | null) => ideType ?? "JetBrains IDE",
+}));
+
+vi.mock("../../utils/jetbrains.js", () => ({
+  isJetBrainsPluginInstalledCachedSync: () => true,
+}));
+
+vi.mock("../../utils/status.js", () => ({
+  buildMemoryDiagnostics: mocks.buildMemoryDiagnostics,
+}));
+
+vi.mock("../../utils/statusNoticeHelpers.js", () => ({
+  AGENT_DESCRIPTIONS_THRESHOLD: 100,
+  getAgentDescriptionsTotalTokens: () => 0,
+}));
+
+describe("StatusNotices coverage", () => {
+  beforeEach(() => {
+    mocks.apiKeyConfigured = false;
+    mocks.apiKeySource = "none";
+    mocks.authTokenSource = { source: "none", hasToken: false };
+    mocks.buildMemoryDiagnostics.mockClear();
+    mocks.subscriber = false;
+  });
+
+  afterEach(() => {
+    if (previousDaemonAutostart === undefined) {
+      delete process.env.AGENC_DAEMON_AUTOSTART;
+    } else {
+      process.env.AGENC_DAEMON_AUTOSTART = previousDaemonAutostart;
+    }
+  });
+
+  it("renders daemon startup guidance and then reuses loaded memory diagnostics", async () => {
+    process.env.AGENC_DAEMON_AUTOSTART = "off";
+    const { StatusNotices } = await import("./StatusNotices.js");
+
+    const daemonOutput = await renderToString(<StatusNotices />, 100);
+    expect(daemonOutput).toContain("AgenC daemon autostart is disabled");
+    expect(daemonOutput).toContain("agenc daemon start");
+
+    await vi.waitFor(() => {
+      expect(mocks.buildMemoryDiagnostics).toHaveBeenCalledTimes(1);
+    });
+
+    process.env.AGENC_DAEMON_AUTOSTART = "true";
+    const memoryOutput = await renderToString(<StatusNotices />, 100);
+
+    expect(mocks.buildMemoryDiagnostics).toHaveBeenCalledTimes(1);
+    expect(memoryOutput).toContain("Large AGENC.md will impact startup");
+    expect(memoryOutput).toContain("/memory to edit");
+    expect(memoryOutput).not.toContain("AgenC daemon autostart is disabled");
+  });
+});

--- a/runtime/tests/tui/startup/statusNoticeDefinitions.wave200-142.coverage.test.tsx
+++ b/runtime/tests/tui/startup/statusNoticeDefinitions.wave200-142.coverage.test.tsx
@@ -1,0 +1,251 @@
+import * as React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type {
+  StatusNoticeContext,
+  StatusNoticeDefinition,
+} from './statusNoticeDefinitions.js'
+
+type AuthSource =
+  | 'ANTHROPIC_AUTH_TOKEN'
+  | 'AGENC_OAUTH_TOKEN'
+  | 'AGENC_OAUTH_TOKEN_FILE_DESCRIPTOR'
+  | 'CCR_OAUTH_TOKEN_FILE'
+  | 'apiKeyHelper'
+  | 'managedOAuth'
+  | 'none'
+type ApiKeySource =
+  | 'ANTHROPIC_API_KEY'
+  | '/login managed key'
+  | 'apiKeyHelper'
+  | 'none'
+
+const mocks = vi.hoisted(() => ({
+  agentTokens: 0,
+  apiKeyConfigured: false,
+  apiKeySource: 'none' as ApiKeySource,
+  authTokenSource: {
+    hasToken: false,
+    source: 'none' as AuthSource,
+  },
+  pluginInstalled: true,
+  subscriber: false,
+  supportedIde: false,
+  terminalIdeType: null as string | null,
+}))
+
+vi.mock('../ink.js', async () => {
+  const React = await import('react')
+  return {
+    Box: ({ children }: { readonly children?: React.ReactNode }) =>
+      React.createElement('ink-box', null, children),
+    Text: ({ children }: { readonly children?: React.ReactNode }) =>
+      React.createElement('ink-text', null, children),
+  }
+})
+
+vi.mock('../../utils/auth.js', () => ({
+  getApiKeyFromConfigOrMacOSKeychain: () =>
+    mocks.apiKeyConfigured ? 'configured-key' : null,
+  getAuthTokenSource: () => mocks.authTokenSource,
+  getproviderApiKeyWithSource: () => ({ source: mocks.apiKeySource }),
+  isAgenCAISubscriber: () => mocks.subscriber,
+}))
+
+vi.mock('../../utils/format.js', () => ({
+  formatNumber: (value: number) => String(value),
+}))
+
+vi.mock('../../utils/ide.js', () => ({
+  getTerminalIdeType: () => mocks.terminalIdeType,
+  isSupportedJetBrainsTerminal: () => mocks.supportedIde,
+  toIDEDisplayName: (ideType: string | null) => ideType ?? 'JetBrains IDE',
+}))
+
+vi.mock('../../utils/jetbrains.js', () => ({
+  isJetBrainsPluginInstalledCachedSync: () => mocks.pluginInstalled,
+}))
+
+vi.mock('../../utils/statusNoticeHelpers.js', () => ({
+  AGENT_DESCRIPTIONS_THRESHOLD: 100,
+  getAgentDescriptionsTotalTokens: () => mocks.agentTokens,
+}))
+
+function baseContext(
+  overrides: Partial<StatusNoticeContext> = {},
+): StatusNoticeContext {
+  return {
+    config: {
+      autoInstallIdeExtension: true,
+    } as StatusNoticeContext['config'],
+    daemonStatus: {
+      autostartDisabled: false,
+    },
+    memoryDiagnostics: [],
+    ...overrides,
+  }
+}
+
+function collectText(node: React.ReactNode): string {
+  if (node === null || node === undefined || typeof node === 'boolean') return ''
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(collectText).join('')
+  if (React.isValidElement(node)) {
+    return collectText((node.props as { children?: React.ReactNode }).children)
+  }
+  return ''
+}
+
+function noticeById(
+  notices: readonly StatusNoticeDefinition[],
+  id: string,
+): StatusNoticeDefinition {
+  const notice = notices.find(candidate => candidate.id === id)
+  expect(notice).toBeDefined()
+  return notice as StatusNoticeDefinition
+}
+
+describe('statusNoticeDefinitions wave200-142 coverage', () => {
+  beforeEach(() => {
+    mocks.agentTokens = 0
+    mocks.apiKeyConfigured = false
+    mocks.apiKeySource = 'none'
+    mocks.authTokenSource = { hasToken: false, source: 'none' }
+    mocks.pluginInstalled = true
+    mocks.subscriber = false
+    mocks.supportedIde = false
+    mocks.terminalIdeType = null
+  })
+
+  test('renders fallback notice guidance for diagnostics, auth, and IDE setup', async () => {
+    const { getActiveNotices, statusNoticeDefinitions } = await import(
+      './statusNoticeDefinitions.js'
+    )
+
+    mocks.agentTokens = 101
+    const diagnosticsContext = baseContext({
+      memoryDiagnostics: ['Large AGENC.md will slow startup'],
+    })
+    const diagnosticIds = getActiveNotices(diagnosticsContext).map(
+      notice => notice.id,
+    )
+
+    expect(diagnosticIds).toContain('large-memory-files')
+    expect(diagnosticIds).toContain('large-agent-descriptions')
+    expect(
+      collectText(
+        noticeById(statusNoticeDefinitions, 'large-memory-files').render(
+          diagnosticsContext,
+        ),
+      ),
+    ).toContain('Large AGENC.md will slow startup')
+    expect(
+      collectText(
+        noticeById(statusNoticeDefinitions, 'large-agent-descriptions').render(
+          diagnosticsContext,
+        ),
+      ),
+    ).toContain('101 tokens > 100')
+
+    mocks.subscriber = true
+    mocks.authTokenSource = { hasToken: true, source: 'apiKeyHelper' }
+    expect(getActiveNotices(baseContext()).map(notice => notice.id)).toContain(
+      'agenc-account-external-token',
+    )
+    expect(
+      collectText(
+        noticeById(
+          statusNoticeDefinitions,
+          'agenc-account-external-token',
+        ).render(baseContext()),
+      ),
+    ).toContain('Using apiKeyHelper instead of AgenC account')
+
+    mocks.apiKeyConfigured = true
+    mocks.apiKeySource = 'apiKeyHelper'
+    expect(getActiveNotices(baseContext()).map(notice => notice.id)).toContain(
+      'api-key-conflict',
+    )
+    expect(
+      collectText(
+        noticeById(statusNoticeDefinitions, 'api-key-conflict').render(
+          baseContext(),
+        ),
+      ),
+    ).toContain('Using apiKeyHelper instead of provider Console key')
+    expect(getActiveNotices(baseContext()).map(notice => notice.id)).not.toContain(
+      'both-auth-methods',
+    )
+
+    const bothAuthNotice = noticeById(statusNoticeDefinitions, 'both-auth-methods')
+    const cleanupCases: Array<{
+      readonly apiKeySource: ApiKeySource
+      readonly expected: string
+      readonly source: AuthSource
+    }> = [
+      {
+        apiKeySource: '/login managed key',
+        expected: 'Unset the ANTHROPIC_AUTH_TOKEN environment variable',
+        source: 'ANTHROPIC_AUTH_TOKEN',
+      },
+      {
+        apiKeySource: '/login managed key',
+        expected: 'Restart without the inherited OAuth token',
+        source: 'AGENC_OAUTH_TOKEN_FILE_DESCRIPTOR',
+      },
+      {
+        apiKeySource: '/login managed key',
+        expected: 'Remove the managed OAuth token file',
+        source: 'CCR_OAUTH_TOKEN_FILE',
+      },
+      {
+        apiKeySource: 'apiKeyHelper',
+        expected: 'Unset the apiKeyHelper setting',
+        source: 'apiKeyHelper',
+      },
+      {
+        apiKeySource: '/login managed key',
+        expected: 'No token source is active',
+        source: 'none',
+      },
+      {
+        apiKeySource: '/login managed key',
+        expected: 'sign out of the AgenC account',
+        source: 'managedOAuth',
+      },
+    ]
+
+    for (const cleanupCase of cleanupCases) {
+      mocks.apiKeySource = cleanupCase.apiKeySource
+      mocks.authTokenSource = {
+        hasToken: cleanupCase.source !== 'none',
+        source: cleanupCase.source,
+      }
+
+      expect(collectText(bothAuthNotice.render(baseContext()))).toContain(
+        cleanupCase.expected,
+      )
+    }
+
+    mocks.supportedIde = true
+    mocks.terminalIdeType = 'IntelliJ IDEA'
+    mocks.pluginInstalled = false
+
+    expect(
+      getActiveNotices(
+        baseContext({
+          config: {} as StatusNoticeContext['config'],
+        }),
+      ).map(notice => notice.id),
+    ).toContain('jetbrains-plugin-install')
+    expect(
+      getActiveNotices(
+        baseContext({
+          config: {
+            autoInstallIdeExtension: false,
+          } as StatusNoticeContext['config'],
+        }),
+      ).map(notice => notice.id),
+    ).not.toContain('jetbrains-plugin-install')
+  })
+})

--- a/runtime/tests/tui/state/collabAgentTaskSync.wave200-116.coverage.test.ts
+++ b/runtime/tests/tui/state/collabAgentTaskSync.wave200-116.coverage.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { syncCollabAgentEventToAppState } from "./collabAgentTaskSync.js";
+import type { AppState } from "./AppStateStore.js";
+
+function applyEvent(state: AppState, event: unknown, now = 5000): AppState {
+  let next = state;
+  syncCollabAgentEventToAppState(
+    event,
+    (updater) => {
+      next = updater(next as never) as AppState;
+    },
+    now,
+  );
+  return next;
+}
+
+function applyEventToUnknown(state: unknown, event: unknown): unknown {
+  let next = state;
+  syncCollabAgentEventToAppState(
+    event,
+    (updater) => {
+      next = updater(next as never);
+    },
+    5000,
+  );
+  return next;
+}
+
+function baseState(): AppState {
+  return {
+    tasks: {},
+  } as AppState;
+}
+
+describe("syncCollabAgentEventToAppState coverage edges", () => {
+  test("normalizes fallback statuses and ignores malformed task events", () => {
+    const cleanup = vi.fn();
+    const abortController = new AbortController();
+    const spawned = applyEvent(baseState(), {
+      type: "collab_agent_spawn_end",
+      payload: {
+        newThreadId: "agent/canceled 1",
+        status: "canceled",
+      },
+    });
+
+    expect(spawned.tasks["agent/canceled 1"]).toMatchObject({
+      id: "agent/canceled 1",
+      status: "killed",
+      description: "agent/canceled 1",
+      outputFile: "urn:agenc:task:agent%2Fcanceled%201:output",
+      endTime: 5000,
+      evictAfter: 35000,
+      notified: true,
+      selectedAgent: { name: "agent/canceled 1" },
+    });
+
+    const seeded = applyEvent(spawned, {
+      type: "collab_agent_spawn_end",
+      payload: {
+        newThreadId: "agent_existing",
+        newAgentPath: "  /tmp/fallback-agent  ",
+        prompt: "  review the fallback path  ",
+        status: 7,
+      },
+    });
+    const withExisting = {
+      ...seeded,
+      tasks: {
+        ...seeded.tasks,
+        agent_existing: {
+          ...seeded.tasks.agent_existing!,
+          abortController,
+          diskLoaded: true,
+          lastReportedTokenCount: 13,
+          lastReportedToolCount: 2,
+          messages: [{ role: "assistant", content: "hello" }],
+          pendingMessages: ["queued"],
+          progress: { toolUseCount: 2, tokenCount: 13 },
+          result: { ok: true },
+          retrieved: true,
+          unregisterCleanup: cleanup,
+        },
+      },
+    } as AppState;
+
+    const failedFromFlatStatus = applyEvent(withExisting, {
+      type: "collab_agent_status",
+      payload: {
+        threadId: "agent_existing",
+        status: "failed",
+        error: "flat status error",
+      },
+    });
+
+    expect(failedFromFlatStatus.tasks.agent_existing).toMatchObject({
+      status: "failed",
+      description: "/tmp/fallback-agent",
+      prompt: "review the fallback path",
+      error: "flat status error",
+      abortController,
+      diskLoaded: true,
+      lastReportedTokenCount: 13,
+      lastReportedToolCount: 2,
+      messages: [{ role: "assistant", content: "hello" }],
+      pendingMessages: ["queued"],
+      progress: { toolUseCount: 2, tokenCount: 13 },
+      result: { ok: true },
+      retrieved: true,
+      unregisterCleanup: cleanup,
+    });
+
+    const daemonFailed = applyEvent(failedFromFlatStatus, {
+      type: "background_agent_status",
+      payload: {
+        agentId: "agent_existing",
+        runStatus: "errored",
+        message: "daemon failed",
+      },
+    });
+    const daemonStopped = applyEvent(daemonFailed, {
+      type: "background_agent_status",
+      payload: {
+        agentId: "agent_existing",
+        status: "stopped",
+      },
+    });
+    const daemonIdle = applyEvent(daemonStopped, {
+      type: "background_agent_status",
+      payload: {
+        agentId: "agent_existing",
+        status: "idle",
+      },
+    });
+
+    expect(daemonFailed.tasks.agent_existing).toMatchObject({
+      status: "failed",
+      error: "daemon failed",
+    });
+    expect(daemonStopped.tasks.agent_existing).toMatchObject({
+      status: "killed",
+    });
+    expect(daemonIdle.tasks.agent_existing).toMatchObject({
+      status: "completed",
+    });
+
+    const missingTasks = applyEvent({} as AppState, {
+      type: "background_agent_status",
+      payload: {
+        agentId: "unknown",
+        runStatus: "pending",
+      },
+    });
+    expect(missingTasks).toEqual({});
+
+    const malformedEvents = [
+      null,
+      { type: 7, payload: {} },
+      { type: "collab_agent_spawn_end", payload: {} },
+      { type: "collab_agent_status", payload: {} },
+      { type: "collab_agent_interaction_begin", payload: {} },
+      { type: "background_agent_status", payload: {} },
+      { type: "collab_waiting_end", payload: { agentStatuses: "nope" } },
+      {
+        type: "collab_waiting_end",
+        payload: { agentStatuses: [null, {}, { threadId: " " }] },
+      },
+    ];
+
+    for (const event of malformedEvents) {
+      expect(applyEvent(daemonIdle, event)).toBe(daemonIdle);
+    }
+
+    expect(
+      applyEventToUnknown(null, {
+        type: "collab_agent_spawn_end",
+        payload: { newThreadId: "agent_null", status: "running" },
+      }),
+    ).toBeNull();
+  });
+});

--- a/runtime/tests/tui/state/onChangeAppState.wave200-054.coverage.test.ts
+++ b/runtime/tests/tui/state/onChangeAppState.wave200-054.coverage.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  externalMetadataToAppState,
+  onChangeAppState,
+} from "./onChangeAppState.js";
+import type { AppState } from "./AppStateStore.js";
+
+type TestGlobalConfig = {
+  showExpandedTodos?: boolean;
+  showSpinnerTree?: boolean;
+  tungstenPanelVisible?: boolean;
+  verbose?: boolean;
+};
+
+const harness = vi.hoisted(() => ({
+  applyConfigEnvironmentVariables: vi.fn(),
+  clearApiKeyHelperCache: vi.fn(),
+  clearAwsCredentialsCache: vi.fn(),
+  clearGcpCredentialsCache: vi.fn(),
+  globalConfig: {} as TestGlobalConfig,
+  isAntEmployee: vi.fn(() => true),
+  logError: vi.fn(),
+  notifyPermissionModeChanged: vi.fn(),
+  notifySessionMetadataChanged: vi.fn(),
+  persistActiveProviderProfileModel: vi.fn(),
+  saveGlobalConfig: vi.fn(),
+  setMainLoopModelOverride: vi.fn(),
+  updateSettingsForSource: vi.fn(),
+}));
+
+vi.mock("../../bootstrap/state.js", () => ({
+  setMainLoopModelOverride: harness.setMainLoopModelOverride,
+}));
+
+vi.mock("../../utils/auth.js", () => ({
+  clearApiKeyHelperCache: harness.clearApiKeyHelperCache,
+  clearAwsCredentialsCache: harness.clearAwsCredentialsCache,
+  clearGcpCredentialsCache: harness.clearGcpCredentialsCache,
+}));
+
+vi.mock("../../utils/buildConfig.js", () => ({
+  isAntEmployee: harness.isAntEmployee,
+}));
+
+vi.mock("../../utils/config.js", () => ({
+  getGlobalConfig: () => harness.globalConfig,
+  saveGlobalConfig: (updater: (current: TestGlobalConfig) => TestGlobalConfig) => {
+    harness.saveGlobalConfig(updater);
+    harness.globalConfig = updater(harness.globalConfig);
+  },
+}));
+
+vi.mock("../../utils/errors.js", () => ({
+  toError: (error: unknown) =>
+    error instanceof Error ? error : new Error(String(error)),
+}));
+
+vi.mock("../../utils/log.js", () => ({
+  logError: harness.logError,
+}));
+
+vi.mock("../../utils/managedEnv.js", () => ({
+  applyConfigEnvironmentVariables: harness.applyConfigEnvironmentVariables,
+}));
+
+vi.mock("../../utils/permissions/PermissionMode.js", () => ({
+  permissionModeFromString: (mode: string) =>
+    mode === "plan" || mode === "acceptEdits" ? mode : "default",
+  toExternalPermissionMode: (mode: string) =>
+    mode === "bubble" || mode === "auto" ? "default" : mode,
+}));
+
+vi.mock("../../utils/providerProfiles.js", () => ({
+  persistActiveProviderProfileModel: harness.persistActiveProviderProfileModel,
+}));
+
+vi.mock("../../utils/sessionState.js", () => ({
+  notifyPermissionModeChanged: harness.notifyPermissionModeChanged,
+  notifySessionMetadataChanged: harness.notifySessionMetadataChanged,
+}));
+
+vi.mock("../../utils/settings/settings.js", () => ({
+  updateSettingsForSource: harness.updateSettingsForSource,
+}));
+
+function makeState(overrides: Partial<AppState> = {}): AppState {
+  return {
+    expandedView: "none",
+    mainLoopModel: null,
+    settings: { env: { OLD_VALUE: "1" } },
+    toolPermissionContext: { mode: "default" },
+    tungstenPanelVisible: false,
+    verbose: false,
+    ...overrides,
+  } as AppState;
+}
+
+describe("onChangeAppState coverage", () => {
+  beforeEach(() => {
+    delete process.env.AGENC_PROVIDER_PROFILE_ENV_APPLIED;
+    harness.applyConfigEnvironmentVariables.mockReset();
+    harness.clearApiKeyHelperCache.mockReset();
+    harness.clearAwsCredentialsCache.mockReset();
+    harness.clearGcpCredentialsCache.mockReset();
+    harness.globalConfig = {
+      showExpandedTodos: false,
+      showSpinnerTree: true,
+      tungstenPanelVisible: false,
+      verbose: false,
+    };
+    harness.isAntEmployee.mockReset();
+    harness.isAntEmployee.mockReturnValue(true);
+    harness.logError.mockReset();
+    harness.notifyPermissionModeChanged.mockReset();
+    harness.notifySessionMetadataChanged.mockReset();
+    harness.persistActiveProviderProfileModel.mockReset();
+    harness.saveGlobalConfig.mockReset();
+    harness.setMainLoopModelOverride.mockReset();
+    harness.updateSettingsForSource.mockReset();
+  });
+
+  test("hydrates permission mode from external metadata", () => {
+    const previous = makeState({
+      toolPermissionContext: {
+        additionalDirectories: ["/tmp/project"],
+        mode: "default",
+      },
+    });
+
+    const updated = externalMetadataToAppState({ permission_mode: "plan" })(
+      previous,
+    );
+    const unchanged = externalMetadataToAppState({ permission_mode: null })(
+      previous,
+    );
+
+    expect(updated.toolPermissionContext).toMatchObject({
+      additionalDirectories: ["/tmp/project"],
+      mode: "plan",
+    });
+    expect(unchanged.toolPermissionContext).toBe(previous.toolPermissionContext);
+  });
+
+  test("syncs changed app state to session listeners, settings, config, and auth caches", () => {
+    process.env.AGENC_PROVIDER_PROFILE_ENV_APPLIED = "1";
+    const oldState = makeState();
+    const newState = makeState({
+      expandedView: "tasks",
+      mainLoopModel: "gpt-5.4",
+      settings: { env: { NEW_VALUE: "1" } },
+      toolPermissionContext: { mode: "plan" },
+      tungstenPanelVisible: true,
+      verbose: true,
+    });
+
+    onChangeAppState({ newState, oldState });
+
+    expect(harness.notifySessionMetadataChanged).toHaveBeenCalledWith({
+      permission_mode: "plan",
+    });
+    expect(harness.notifyPermissionModeChanged).toHaveBeenCalledWith("plan");
+    expect(harness.updateSettingsForSource).toHaveBeenCalledWith(
+      "userSettings",
+      { model: "gpt-5.4" },
+    );
+    expect(harness.setMainLoopModelOverride).toHaveBeenCalledWith("gpt-5.4");
+    expect(harness.persistActiveProviderProfileModel).toHaveBeenCalledWith(
+      "gpt-5.4",
+    );
+    expect(harness.globalConfig).toMatchObject({
+      showExpandedTodos: true,
+      showSpinnerTree: false,
+      tungstenPanelVisible: true,
+      verbose: true,
+    });
+    expect(harness.saveGlobalConfig).toHaveBeenCalledTimes(3);
+    expect(harness.clearApiKeyHelperCache).toHaveBeenCalledTimes(1);
+    expect(harness.clearAwsCredentialsCache).toHaveBeenCalledTimes(1);
+    expect(harness.clearGcpCredentialsCache).toHaveBeenCalledTimes(1);
+    expect(harness.applyConfigEnvironmentVariables).toHaveBeenCalledTimes(1);
+  });
+
+  test("clears the model preference without reporting unchanged external permission metadata", () => {
+    const oldState = makeState({
+      mainLoopModel: "gpt-5.4",
+      toolPermissionContext: { mode: "default" },
+    });
+    const newState = makeState({
+      mainLoopModel: null,
+      toolPermissionContext: { mode: "bubble" },
+    });
+
+    onChangeAppState({ newState, oldState });
+
+    expect(harness.notifySessionMetadataChanged).not.toHaveBeenCalled();
+    expect(harness.notifyPermissionModeChanged).toHaveBeenCalledWith("bubble");
+    expect(harness.updateSettingsForSource).toHaveBeenCalledWith(
+      "userSettings",
+      { model: undefined },
+    );
+    expect(harness.setMainLoopModelOverride).toHaveBeenCalledWith(null);
+    expect(harness.persistActiveProviderProfileModel).not.toHaveBeenCalled();
+  });
+
+  test("logs auth cache clearing failures without throwing", () => {
+    const error = new Error("cache unavailable");
+    harness.clearAwsCredentialsCache.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    expect(() =>
+      onChangeAppState({
+        oldState: makeState(),
+        newState: makeState({ settings: { env: { NEW_VALUE: "1" } } }),
+      }),
+    ).not.toThrow();
+
+    expect(harness.logError).toHaveBeenCalledWith(error);
+    expect(harness.applyConfigEnvironmentVariables).not.toHaveBeenCalled();
+  });
+});

--- a/runtime/tests/tui/state/selectors.wave200-150.coverage.test.ts
+++ b/runtime/tests/tui/state/selectors.wave200-150.coverage.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+
+import type { AppState } from "./AppStateStore.js";
+import {
+  getActiveAgentForInput,
+  getViewedTeammateTask,
+} from "./selectors.js";
+
+function makeState(
+  viewingAgentTaskId: string | undefined,
+  tasks: AppState["tasks"] = {},
+): AppState {
+  return {
+    viewingAgentTaskId,
+    tasks,
+  } as AppState;
+}
+
+function makeTask(id: string, type: string): AppState["tasks"][string] {
+  return {
+    id,
+    type,
+    status: "running",
+    description: id,
+    startTime: 1,
+    outputFile: `urn:agenc:task:${id}:output`,
+    outputOffset: 0,
+    notified: false,
+  } as AppState["tasks"][string];
+}
+
+describe("state selectors coverage", () => {
+  test("routes input to the viewed teammate, named local agent, or leader fallback", () => {
+    const teammateTask = makeTask("teammate-1", "in_process_teammate");
+    const localAgentTask = makeTask("agent-1", "local_agent");
+    const shellTask = makeTask("shell-1", "local_bash");
+
+    expect(getViewedTeammateTask(makeState(undefined))).toBeUndefined();
+    expect(getViewedTeammateTask(makeState("missing"))).toBeUndefined();
+    expect(
+      getViewedTeammateTask(makeState("agent-1", { "agent-1": localAgentTask })),
+    ).toBeUndefined();
+    expect(
+      getViewedTeammateTask(
+        makeState("teammate-1", { "teammate-1": teammateTask }),
+      ),
+    ).toBe(teammateTask);
+
+    expect(
+      getActiveAgentForInput(
+        makeState("teammate-1", { "teammate-1": teammateTask }),
+      ),
+    ).toEqual({ type: "viewed", task: teammateTask });
+    expect(
+      getActiveAgentForInput(makeState("agent-1", { "agent-1": localAgentTask })),
+    ).toEqual({ type: "named_agent", task: localAgentTask });
+    expect(
+      getActiveAgentForInput(makeState("shell-1", { "shell-1": shellTask })),
+    ).toEqual({ type: "leader" });
+    expect(getActiveAgentForInput(makeState(undefined))).toEqual({
+      type: "leader",
+    });
+  });
+});

--- a/runtime/tests/tui/tool-rendering.coverage.test.tsx
+++ b/runtime/tests/tui/tool-rendering.coverage.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("./ink.js", () => {
+  function Box(_props: { readonly children?: unknown }) {
+    return null;
+  }
+  function Text(_props: { readonly children?: unknown }) {
+    return null;
+  }
+  return { Box, Text };
+});
+
+import { createTuiTool, ToolErrorView } from "./tool-rendering.js";
+
+describe("TUI dynamic tool fallback coverage", () => {
+  test("dynamic tools expose the baseline TUI tool contract", async () => {
+    const input = { path: "src/example.ts" };
+    const tool = createTuiTool("DynamicCoverageTool");
+
+    expect(tool.name).toBe("DynamicCoverageTool");
+    expect(tool.aliases).toEqual([]);
+    expect(tool.maxResultSizeChars).toBe(Infinity);
+    expect(tool.inputSchema.safeParse("raw input")).toEqual({
+      success: true,
+      data: { value: "raw input" },
+    });
+    await expect(tool.call(input)).resolves.toEqual({ result: undefined });
+    await expect(tool.description()).resolves.toBe("DynamicCoverageTool");
+    await expect(tool.prompt()).resolves.toBe(
+      "DynamicCoverageTool is provided by the AgenC runtime.",
+    );
+    await expect(tool.checkPermissions(input)).resolves.toEqual({
+      behavior: "ask",
+      message: "Permission required to use DynamicCoverageTool",
+    });
+
+    expect(tool.isConcurrencySafe(input)).toBe(false);
+    expect(tool.isEnabled()).toBe(true);
+    expect(tool.isReadOnly(input)).toBe(false);
+    expect(tool.isDestructive(input)).toBe(false);
+    expect(tool.toAutoClassifierInput(input)).toBe(input);
+    expect(tool.userFacingName(input)).toBe("DynamicCoverageTool");
+    expect(tool.getActivityDescription(input)).toBe(
+      "DynamicCoverageTool {\"path\":\"src/example.ts\"}",
+    );
+    expect(tool.renderToolUseMessage(input)).toBe(
+      "{\"path\":\"src/example.ts\"}",
+    );
+
+    const resultBlock = tool.mapToolResultToToolResultBlockParam(
+      { content: "result text" },
+      "tool-1",
+    );
+    expect(resultBlock).toEqual({
+      type: "tool_result",
+      tool_use_id: "tool-1",
+      content: "result text",
+    });
+
+    const errorNode = tool.renderToolUseErrorMessage(new Error("failed"));
+    expect((errorNode as { readonly type: unknown }).type).toBe(ToolErrorView);
+    expect(
+      (errorNode as { readonly props: { readonly content: string } }).props
+        .content,
+    ).toContain("<tool-error>failed</tool-error>");
+  });
+});

--- a/runtime/tests/tui/tool-rendering.coverage2.test.tsx
+++ b/runtime/tests/tui/tool-rendering.coverage2.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("./ink.js", () => {
+  function Box(_props: { readonly children?: unknown }) {
+    return null;
+  }
+  function Text(_props: { readonly children?: unknown }) {
+    return null;
+  }
+  return { Box, Text };
+});
+
+import { createTuiTool } from "./tool-rendering.js";
+
+describe("TUI Skill tool rendering coverage", () => {
+  test("Skill tool cards parse nested JSON input and omit null args from the preview", () => {
+    const tool = createTuiTool("Skill");
+    const longPrompt = "x".repeat(100);
+    const input = {
+      skill: JSON.stringify({
+        skill: "//$$review-helper",
+        args: JSON.stringify({
+          file: "runtime/src/tui/tool-rendering.tsx",
+          mode: null,
+          prompt: longPrompt,
+        }),
+      }),
+    };
+
+    const expectedPreviewPrefix =
+      `file runtime/src/tui/tool-rendering.tsx, prompt ${"x".repeat(71)}`;
+    const preview = tool.renderToolUseMessage(input);
+    const activity = tool.getActivityDescription(input);
+
+    expect(tool.userFacingName(input)).toBe("$review-helper");
+    expect(preview.startsWith(expectedPreviewPrefix)).toBe(true);
+    expect(preview).toHaveLength(expectedPreviewPrefix.length + 1);
+    expect(preview.codePointAt(preview.length - 1)).toBe(0x2026);
+    expect(activity).toBe(`Load $review-helper: ${preview}`);
+    expect(preview).not.toContain("mode");
+    expect(preview).not.toContain(longPrompt);
+  });
+});

--- a/runtime/tests/tui/tool-rendering.test.tsx
+++ b/runtime/tests/tui/tool-rendering.test.tsx
@@ -1,0 +1,241 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("./ink.js", () => {
+  function Box(_props: { readonly children?: unknown }) {
+    return null;
+  }
+  function Text(_props: { readonly children?: unknown }) {
+    return null;
+  }
+  return { Box, Text };
+});
+
+import {
+  BashOutputView,
+  createTuiTool,
+  createTuiTools,
+  EditDiffView,
+  FileReadView,
+  FileWriteView,
+  GlobPathsView,
+  GrepMatchesView,
+  ToolErrorView,
+} from "./tool-rendering.js";
+
+interface ChildProps {
+  readonly bold?: boolean;
+  readonly children?: unknown;
+  readonly color?: string;
+  readonly dimColor?: boolean;
+}
+
+interface ChildElement {
+  readonly props: ChildProps;
+}
+
+function flatten(node: unknown): ChildElement[] {
+  if (!node || typeof node !== "object") return [];
+  const children = (node as { props?: { children?: unknown } }).props?.children;
+  const arr = Array.isArray(children) ? children : [children];
+  return arr
+    .flat(Infinity)
+    .filter(
+      (child): child is ChildElement =>
+        typeof child === "object" && child !== null,
+    );
+}
+
+describe("TUI tool rendering helpers", () => {
+  test("createTuiTools merges canonical tools with nonblank dynamic names, dedupes, and sorts", () => {
+    const tools = createTuiTools([
+      "Bash",
+      "mcp.audit-ping.ping",
+      "",
+      "  ",
+      "ZedTool",
+    ]);
+    const names = tools.map((tool: { readonly name: string }) => tool.name);
+
+    expect(names).toEqual([...names].sort());
+    expect(names).toContain("Bash");
+    expect(names).toContain("FileRead");
+    expect(names).toContain("mcp.audit-ping.ping");
+    expect(names).toContain("ZedTool");
+    expect(names).not.toContain("");
+    expect(names.filter((name) => name === "Bash")).toHaveLength(1);
+  });
+
+  test("Write summaries cover path-only, content-only, and empty inputs", () => {
+    const tool = createTuiTool("Write");
+
+    expect(tool.renderToolUseMessage({ file_path: "notes.md" })).toBe(
+      "notes.md",
+    );
+    expect(tool.renderToolUseMessage({ content: "x" })).toBe(
+      "file content (1 char)",
+    );
+    expect(tool.renderToolUseMessage({})).toBe("file");
+  });
+
+  test("Edit summaries include size changes with and without a path", () => {
+    const tool = createTuiTool("Edit");
+
+    expect(
+      tool.renderToolUseMessage({
+        file_path: "src/a.ts",
+        old_string: "x",
+        new_string: "yz",
+      }),
+    ).toBe("src/a.ts (1 char -> 2 chars)");
+    expect(
+      tool.renderToolUseMessage({ old_string: "old", new_string: "newer" }),
+    ).toBe("edit (3 chars -> 5 chars)");
+  });
+
+  test("search and MCP tool summaries cover multi-select and populated dynamic inputs", () => {
+    const search = createTuiTool("system.searchTools");
+    const mcp = createTuiTool("mcp.audit-ping.ping");
+
+    expect(search.renderToolUseMessage({ select: ["Read", "Write"] })).toBe(
+      "Select tools: Read, Write",
+    );
+    expect(search.renderToolUseMessage({})).toBe("Search tools");
+    expect(mcp.renderToolUseMessage({ path: "src/a.ts", limit: 2 })).toBe(
+      "path: src/a.ts, limit: 2",
+    );
+    expect(mcp.getActivityDescription({ path: "src/a.ts" })).toBe(
+      "mcp.audit-ping.ping path: src/a.ts",
+    );
+  });
+
+  test("generic tool summaries hide bulky string fields while preserving useful context", () => {
+    const tool = createTuiTool("CustomTool");
+    const summary = tool.renderToolUseMessage({
+      content: "secret",
+      old_string: "abc",
+      new_string: "defg",
+      reason: "needs\nspacing",
+      count: 2,
+    });
+
+    expect(summary).toContain('"content":"[6 chars]"');
+    expect(summary).toContain('"old_string":"[3 chars]"');
+    expect(summary).toContain('"new_string":"[4 chars]"');
+    expect(summary).toContain('"reason":"needs spacing"');
+    expect(summary).toContain('"count":2');
+    expect(summary).not.toContain("secret");
+    expect(tool.renderToolUseMessage("raw")).toBe('{"value":"raw"}');
+  });
+
+  test("EditDiffView renders an unheaded diff when the file tag is absent", () => {
+    const children = flatten(
+      EditDiffView({
+        content: "<edit-diff>@@ -1 +1 @@\n-old\n+new</edit-diff>",
+      }),
+    );
+
+    expect(children.find((child) => child.props.bold === true)).toBeUndefined();
+    expect(children.find((child) => child.props.color === "cyan")).toBeDefined();
+    expect(children.find((child) => child.props.color === "red")).toBeDefined();
+    expect(children.find((child) => child.props.color === "green")).toBeDefined();
+  });
+
+  test("BashOutputView dims duration-only metadata and still marks silent output", () => {
+    const children = flatten(
+      BashOutputView({
+        content: "<bash-stdout></bash-stdout>[duration_ms=42]",
+      }),
+    );
+
+    expect(
+      children.find(
+        (child) =>
+          child.props.children === "(No output)" &&
+          child.props.dimColor === true,
+      ),
+    ).toBeDefined();
+    expect(
+      children.find(
+        (child) =>
+          child.props.children === "[duration_ms=42]" &&
+          child.props.dimColor === true &&
+          child.props.color === undefined,
+      ),
+    ).toBeDefined();
+  });
+
+  test("ToolErrorView falls back to raw content when no error envelope exists", () => {
+    const children = flatten(ToolErrorView({ content: "raw failure" }));
+
+    expect(
+      children.find(
+        (child) =>
+          child.props.children === "Tool error" &&
+          child.props.bold === true &&
+          child.props.color === "red",
+      ),
+    ).toBeDefined();
+    expect(
+      children.find((child) => child.props.children === "raw failure"),
+    ).toBeDefined();
+  });
+
+  test("file, grep, and glob views keep visible fallbacks for missing content", () => {
+    const readChildren = flatten(
+      FileReadView({
+        content: "<read-file>x.ts</read-file><read-content>unterminated",
+      }),
+    );
+    expect(
+      readChildren.find(
+        (child) =>
+          child.props.children === "(empty file)" &&
+          child.props.dimColor === true,
+      ),
+    ).toBeDefined();
+
+    const writeChildren = flatten(FileWriteView({ content: "" }));
+    expect(
+      writeChildren.find(
+        (child) =>
+          child.props.children === "Wrote file" &&
+          child.props.color === "green",
+      ),
+    ).toBeDefined();
+
+    const grepChildren = flatten(
+      GrepMatchesView({ content: "<grep-matches></grep-matches>" }),
+    );
+    expect(grepChildren.find((child) => child.props.bold === true)).toBeUndefined();
+    expect(
+      grepChildren.find(
+        (child) =>
+          child.props.children === "(no matches)" &&
+          child.props.dimColor === true,
+      ),
+    ).toBeDefined();
+
+    const globChildren = flatten(
+      GlobPathsView({
+        content:
+          "<glob-paths></glob-paths><glob-truncated>true</glob-truncated>",
+      }),
+    );
+    expect(globChildren.find((child) => child.props.bold === true)).toBeUndefined();
+    expect(
+      globChildren.find(
+        (child) =>
+          child.props.children === "(no paths)" &&
+          child.props.dimColor === true,
+      ),
+    ).toBeDefined();
+    expect(
+      globChildren.find(
+        (child) =>
+          child.props.children ===
+            "(Results are truncated. Consider using a more specific path or pattern.)" &&
+          child.props.dimColor === true,
+      ),
+    ).toBeDefined();
+  });
+});

--- a/runtime/tests/tui/tool-rendering.wave200-019.coverage.test.tsx
+++ b/runtime/tests/tui/tool-rendering.wave200-019.coverage.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("./ink.js", () => {
+  function Box(_props: { readonly children?: unknown }) {
+    return null;
+  }
+  function Text(_props: { readonly children?: unknown }) {
+    return null;
+  }
+  return { Box, Text };
+});
+
+import {
+  BashOutputView,
+  createTuiTool,
+  EditDiffView,
+  FileReadView,
+  FileWriteView,
+  GlobPathsView,
+  GrepMatchesView,
+  ToolErrorView,
+} from "./tool-rendering.js";
+
+describe("TUI tool result rendering dispatch", () => {
+  test("routes structured result envelopes to their focused view components", () => {
+    const cases = [
+      {
+        name: "AnyTool",
+        content: "<tool-error-name>AnyTool</tool-error-name><tool-error>boom</tool-error>",
+        expected: ToolErrorView,
+      },
+      {
+        name: "Bash",
+        content: "<bash-stdout>ok</bash-stdout>",
+        expected: BashOutputView,
+      },
+      {
+        name: "Edit",
+        content: "<edit-diff>@@ -1 +1 @@\n-old\n+new</edit-diff>",
+        expected: EditDiffView,
+      },
+      {
+        name: "FileRead",
+        content: "<read-content>body</read-content>",
+        expected: FileReadView,
+      },
+      {
+        name: "Write",
+        content: "<write-summary>Wrote 4 bytes</write-summary>",
+        expected: FileWriteView,
+      },
+      {
+        name: "Grep",
+        content: "<grep-matches>src/a.ts:1:hit</grep-matches>",
+        expected: GrepMatchesView,
+      },
+      {
+        name: "Glob",
+        content: "<glob-paths>src/a.ts</glob-paths>",
+        expected: GlobPathsView,
+      },
+    ];
+
+    for (const { name, content, expected } of cases) {
+      const node = createTuiTool(name).renderToolResultMessage(content, []);
+      expect((node as { readonly type: unknown }).type).toBe(expected);
+      expect((node as { readonly props: { readonly content: string } }).props.content)
+        .toBe(content);
+    }
+
+    const generic = createTuiTool("OtherTool").renderToolResultMessage(
+      "plain output",
+      [],
+    );
+    expect((generic as { readonly type: { readonly name?: string } }).type.name).toBe(
+      "Box",
+    );
+    expect(
+      (generic as { readonly props: { readonly children: { readonly props: { readonly children: string } } } })
+        .props.children.props.children,
+    ).toBe("plain output");
+  });
+});

--- a/runtime/tests/tui/vim/operators.coverage2.test.ts
+++ b/runtime/tests/tui/vim/operators.coverage2.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'vitest'
+
+import { TextCursor } from '../../utils/TextCursor.js'
+import { executeToggleCase, type OperatorContext } from './operators.js'
+import type { FindType, RecordedChange } from './types.js'
+
+function makeContext(initialText: string, initialOffset = 0): {
+  ctx: OperatorContext
+  state: {
+    text: string
+    offset: number
+    register: string
+    linewise: boolean
+    lastFind: { type: FindType; char: string } | null
+    changes: RecordedChange[]
+    enteredInsertAt: number | null
+  }
+} {
+  const state = {
+    text: initialText,
+    offset: initialOffset,
+    register: '',
+    linewise: false,
+    lastFind: null as { type: FindType; char: string } | null,
+    changes: [] as RecordedChange[],
+    enteredInsertAt: null as number | null,
+  }
+  const ctx: OperatorContext = {
+    get cursor() {
+      return TextCursor.fromText(state.text, 80, state.offset)
+    },
+    get text() {
+      return state.text
+    },
+    setText: text => {
+      state.text = text
+    },
+    setOffset: offset => {
+      state.offset = offset
+    },
+    enterInsert: offset => {
+      state.enteredInsertAt = offset
+      state.offset = offset
+    },
+    getRegister: () => state.register,
+    setRegister: (content, linewise) => {
+      state.register = content
+      state.linewise = linewise
+    },
+    getLastFind: () => state.lastFind,
+    setLastFind: (type, char) => {
+      state.lastFind = { type, char }
+    },
+    recordChange: change => {
+      state.changes.push(change)
+    },
+  }
+  return { ctx, state }
+}
+
+describe('vim operator toggle case coverage', () => {
+  test('toggles mixed case characters and ignores cursors past the buffer', () => {
+    const toggled = makeContext('aBcd')
+
+    executeToggleCase(3, toggled.ctx)
+
+    expect(toggled.state.text).toBe('AbCd')
+    expect(toggled.state.offset).toBe(3)
+    expect(toggled.state.changes).toEqual([{ type: 'toggleCase', count: 3 }])
+
+    const atEnd = makeContext('abc', 3)
+
+    executeToggleCase(1, atEnd.ctx)
+
+    expect(atEnd.state.text).toBe('abc')
+    expect(atEnd.state.offset).toBe(3)
+    expect(atEnd.state.changes).toEqual([])
+  })
+})

--- a/runtime/tests/tui/vim/operators.wave200-044.coverage.test.ts
+++ b/runtime/tests/tui/vim/operators.wave200-044.coverage.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'vitest'
+
+import { TextCursor } from '../../utils/TextCursor.js'
+import { executeOpenLine, type OperatorContext } from './operators.js'
+import type { FindType, RecordedChange } from './types.js'
+
+function makeContext(initialText: string, initialOffset = 0): {
+  ctx: OperatorContext
+  state: {
+    text: string
+    offset: number
+    register: string
+    linewise: boolean
+    lastFind: { type: FindType; char: string } | null
+    changes: RecordedChange[]
+    enteredInsertAt: number | null
+  }
+} {
+  const state = {
+    text: initialText,
+    offset: initialOffset,
+    register: '',
+    linewise: false,
+    lastFind: null as { type: FindType; char: string } | null,
+    changes: [] as RecordedChange[],
+    enteredInsertAt: null as number | null,
+  }
+  const ctx: OperatorContext = {
+    get cursor() {
+      return TextCursor.fromText(state.text, 80, state.offset)
+    },
+    get text() {
+      return state.text
+    },
+    setText: text => {
+      state.text = text
+    },
+    setOffset: offset => {
+      state.offset = offset
+    },
+    enterInsert: offset => {
+      state.enteredInsertAt = offset
+      state.offset = offset
+    },
+    getRegister: () => state.register,
+    setRegister: (content, linewise) => {
+      state.register = content
+      state.linewise = linewise
+    },
+    getLastFind: () => state.lastFind,
+    setLastFind: (type, char) => {
+      state.lastFind = { type, char }
+    },
+    recordChange: change => {
+      state.changes.push(change)
+    },
+  }
+  return { ctx, state }
+}
+
+describe('vim open line operator coverage', () => {
+  test('opens blank lines above and below the current logical line', () => {
+    const below = makeContext('one\ntwo\nthree', 'one\ntwo'.length)
+
+    executeOpenLine('below', below.ctx)
+
+    expect(below.state.text).toBe('one\ntwo\n\nthree')
+    expect(below.state.enteredInsertAt).toBe('one\ntwo\n'.length)
+    expect(below.state.offset).toBe(below.state.enteredInsertAt)
+    expect(below.state.changes).toEqual([
+      { type: 'openLine', direction: 'below' },
+    ])
+
+    const above = makeContext('one\ntwo\nthree', 'one\n'.length)
+
+    executeOpenLine('above', above.ctx)
+
+    expect(above.state.text).toBe('one\n\ntwo\nthree')
+    expect(above.state.enteredInsertAt).toBe('one\n'.length)
+    expect(above.state.offset).toBe(above.state.enteredInsertAt)
+    expect(above.state.changes).toEqual([
+      { type: 'openLine', direction: 'above' },
+    ])
+  })
+})

--- a/runtime/tests/tui/vim/text-objects.wave200-101.coverage.test.ts
+++ b/runtime/tests/tui/vim/text-objects.wave200-101.coverage.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest'
+
+import { findTextObject } from './text-objects.js'
+
+function sliceAt(
+  text: string,
+  offset: number,
+  objectType: string,
+  isInner: boolean,
+): string | null {
+  const range = findTextObject(text, offset, objectType, isInner)
+  return range ? text.slice(range.start, range.end) : null
+}
+
+describe('vim text objects wave200-101 coverage', () => {
+  test('covers edge paths for words, delimiters, paragraphs, and tags', () => {
+    expect(findTextObject('alpha', 0, 'x', true)).toBeNull()
+
+    const punctuation = 'alpha,; beta'
+    expect(sliceAt(punctuation, punctuation.indexOf(','), 'w', true)).toBe(',;')
+    expect(sliceAt('alpha beta', 'alpha beta'.indexOf('beta'), 'w', false))
+      .toBe(' beta')
+
+    const quotedLine = 'first "one"\nsecond "two"'
+    expect(sliceAt(quotedLine, quotedLine.indexOf('one'), '"', true)).toBe('one')
+    expect(sliceAt(quotedLine, quotedLine.indexOf('two'), '"', false)).toBe(
+      '"two"',
+    )
+
+    const nestedCall = 'fn(a(b)c)'
+    expect(sliceAt(nestedCall, nestedCall.indexOf('c'), '(', true)).toBe(
+      'a(b)c',
+    )
+    expect(findTextObject('alpha)', 2, '(', true)).toBeNull()
+
+    expect(findTextObject('', 0, 'p', true)).toBeNull()
+    expect(sliceAt('single paragraph', 3, 'p', true)).toBe('single paragraph')
+    expect(sliceAt('first\n \t\nsecond', 1, 'p', false)).toBe('first\n \t\n')
+    expect(sliceAt('first\n\nsecond', 'first\n\nsecond'.indexOf('second'), 'p', false))
+      .toBe('\n\nsecond')
+
+    const mismatchedTag = '<div></span><p>ok</p></div>'
+    expect(sliceAt(mismatchedTag, mismatchedTag.indexOf('ok'), 't', true))
+      .toBe('ok')
+  })
+})

--- a/runtime/tests/tui/vim/transitions.wave200-027.coverage.test.ts
+++ b/runtime/tests/tui/vim/transitions.wave200-027.coverage.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { TextCursor } from '../../utils/TextCursor.js'
+import { transition, type TransitionContext } from './transitions.js'
+import type { CommandState, FindType, RecordedChange } from './types.js'
+
+function makeContext(initialText: string, initialOffset = 0): {
+  ctx: TransitionContext
+  state: {
+    text: string
+    offset: number
+    register: string
+    linewise: boolean
+    lastFind: { type: FindType; char: string } | null
+    changes: RecordedChange[]
+    enteredInsertAt: number | null
+    onUndo: ReturnType<typeof vi.fn>
+    onDotRepeat: ReturnType<typeof vi.fn>
+  }
+} {
+  const state = {
+    text: initialText,
+    offset: initialOffset,
+    register: '',
+    linewise: false,
+    lastFind: null as { type: FindType; char: string } | null,
+    changes: [] as RecordedChange[],
+    enteredInsertAt: null as number | null,
+    onUndo: vi.fn(),
+    onDotRepeat: vi.fn(),
+  }
+  const ctx: TransitionContext = {
+    get cursor() {
+      return TextCursor.fromText(state.text, 80, state.offset)
+    },
+    get text() {
+      return state.text
+    },
+    setText: text => {
+      state.text = text
+    },
+    setOffset: offset => {
+      state.offset = offset
+    },
+    enterInsert: offset => {
+      state.enteredInsertAt = offset
+      state.offset = offset
+    },
+    getRegister: () => state.register,
+    setRegister: (content, linewise) => {
+      state.register = content
+      state.linewise = linewise
+    },
+    getLastFind: () => state.lastFind,
+    setLastFind: (type, char) => {
+      state.lastFind = { type, char }
+    },
+    recordChange: change => {
+      state.changes.push(change)
+    },
+    onUndo: state.onUndo,
+    onDotRepeat: state.onDotRepeat,
+  }
+  return { ctx, state }
+}
+
+function input(
+  command: CommandState,
+  key: string,
+  ctx: TransitionContext,
+): CommandState {
+  const result = transition(command, key, ctx)
+  result.execute?.()
+  return result.next ?? { type: 'idle' }
+}
+
+describe('vim transitions wave200 coverage', () => {
+  test('dispatches edit commands and cancels pending transition states', () => {
+    const toggle = makeContext('aB')
+    expect(input({ type: 'idle' }, '~', toggle.ctx)).toEqual({ type: 'idle' })
+    expect(toggle.state.text).toBe('AB')
+    expect(toggle.state.changes).toEqual([{ type: 'toggleCase', count: 1 }])
+
+    const join = makeContext('one\n  two\nthree')
+    input({ type: 'idle' }, 'J', join.ctx)
+    expect(join.state.text).toBe('one two\nthree')
+    expect(join.state.changes).toEqual([{ type: 'join', count: 1 }])
+
+    const pasteAfter = makeContext('ac')
+    pasteAfter.state.register = 'b'
+    input({ type: 'idle' }, 'p', pasteAfter.ctx)
+    expect(pasteAfter.state.text).toBe('abc')
+    expect(pasteAfter.state.offset).toBe(1)
+
+    const pasteBefore = makeContext('ac', 1)
+    pasteBefore.state.register = 'b'
+    input({ type: 'idle' }, 'P', pasteBefore.ctx)
+    expect(pasteBefore.state.text).toBe('abc')
+    expect(pasteBefore.state.offset).toBe(1)
+
+    const deleteToEnd = makeContext('one two', 4)
+    input({ type: 'idle' }, 'D', deleteToEnd.ctx)
+    expect(deleteToEnd.state.text).toBe('one ')
+    expect(deleteToEnd.state.register).toBe('two')
+
+    const changeToEnd = makeContext('one two', 4)
+    input({ type: 'idle' }, 'C', changeToEnd.ctx)
+    expect(changeToEnd.state.text).toBe('one ')
+    expect(changeToEnd.state.register).toBe('two')
+    expect(changeToEnd.state.enteredInsertAt).toBe(4)
+
+    const yankLine = makeContext('one\ntwo', 4)
+    input({ type: 'idle' }, 'Y', yankLine.ctx)
+    expect(yankLine.state.register).toBe('two\n')
+    expect(yankLine.state.linewise).toBe(true)
+
+    const insert = makeContext('abc', 1)
+    input({ type: 'idle' }, 'i', insert.ctx)
+    expect(insert.state.enteredInsertAt).toBe(1)
+
+    const insertAtText = makeContext('  abc', 4)
+    input({ type: 'idle' }, 'I', insertAtText.ctx)
+    expect(insertAtText.state.enteredInsertAt).toBe(2)
+
+    const appendMiddle = makeContext('abc', 1)
+    input({ type: 'idle' }, 'a', appendMiddle.ctx)
+    expect(appendMiddle.state.enteredInsertAt).toBe(2)
+
+    const appendEnd = makeContext('abc', 3)
+    input({ type: 'idle' }, 'a', appendEnd.ctx)
+    expect(appendEnd.state.enteredInsertAt).toBe(3)
+
+    const appendLine = makeContext('abc')
+    input({ type: 'idle' }, 'A', appendLine.ctx)
+    expect(appendLine.state.enteredInsertAt).toBe(3)
+
+    const openBelow = makeContext('one\ntwo')
+    input({ type: 'idle' }, 'o', openBelow.ctx)
+    expect(openBelow.state.text).toBe('one\n\ntwo')
+    expect(openBelow.state.enteredInsertAt).toBe(4)
+
+    const openAbove = makeContext('one\ntwo', 4)
+    input({ type: 'idle' }, 'O', openAbove.ctx)
+    expect(openAbove.state.text).toBe('one\n\ntwo')
+    expect(openAbove.state.enteredInsertAt).toBe(4)
+
+    const undo = makeContext('abc')
+    input({ type: 'idle' }, 'u', undo.ctx)
+    expect(undo.state.onUndo).toHaveBeenCalledTimes(1)
+
+    const dotRepeat = makeContext('abc')
+    input({ type: 'idle' }, '.', dotRepeat.ctx)
+    expect(dotRepeat.state.onDotRepeat).toHaveBeenCalledTimes(1)
+
+    const operatorFind = makeContext('abc-def')
+    let command = input({ type: 'idle' }, 'd', operatorFind.ctx)
+    command = input(command, 'f', operatorFind.ctx)
+    expect(command).toEqual({
+      type: 'operatorFind',
+      op: 'delete',
+      count: 1,
+      find: 'f',
+    })
+    command = input(command, '-', operatorFind.ctx)
+    expect(command).toEqual({ type: 'idle' })
+    expect(operatorFind.state.text).toBe('def')
+    expect(operatorFind.state.register).toBe('abc-')
+    expect(operatorFind.state.lastFind).toEqual({ type: 'f', char: '-' })
+
+    const lineOp = makeContext('one\ntwo')
+    input({ type: 'operator', op: 'yank', count: 1 }, 'y', lineOp.ctx)
+    expect(lineOp.state.register).toBe('one\n')
+    expect(lineOp.state.linewise).toBe(true)
+
+    const invalid = makeContext('abc')
+    expect(transition({ type: 'idle' }, '?', invalid.ctx)).toEqual({})
+    expect(input({ type: 'count', digits: '2' }, '?', invalid.ctx)).toEqual({
+      type: 'idle',
+    })
+    expect(
+      input({ type: 'operator', op: 'delete', count: 1 }, '?', invalid.ctx),
+    ).toEqual({ type: 'idle' })
+    expect(
+      input(
+        { type: 'operatorCount', op: 'delete', count: 2, digits: '3' },
+        '?',
+        invalid.ctx,
+      ),
+    ).toEqual({ type: 'idle' })
+    expect(
+      input(
+        { type: 'operatorTextObj', op: 'delete', count: 1, scope: 'inner' },
+        '?',
+        invalid.ctx,
+      ),
+    ).toEqual({ type: 'idle' })
+    expect(input({ type: 'g', count: 1 }, '?', invalid.ctx)).toEqual({
+      type: 'idle',
+    })
+    expect(
+      input({ type: 'operatorG', op: 'delete', count: 1 }, '?', invalid.ctx),
+    ).toEqual({ type: 'idle' })
+    expect(input({ type: 'indent', dir: '>', count: 1 }, '<', invalid.ctx))
+      .toEqual({ type: 'idle' })
+  })
+})


### PR DESCRIPTION
## Summary
- Expand runtime TUI coverage across components, hooks, renderers, and ink paths.
- Add regression coverage for runtime compact behavior.
- Fix mid-turn context-limit compaction so provider-reported over-limit prompts force compaction instead of being vetoed by local token estimation.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/services/compact/autoCompact.test.ts
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/session/run-turn.compact-contract.test.ts
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/session/run-turn.test.ts tests/session/run-turn.compact-contract.test.ts tests/services/compact/autoCompact.test.ts
- npm --workspace=@tetsuo-ai/runtime run typecheck -- --pretty false
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui