### PR TITLE
test(runtime): expand TUI coverage swarm

### DIFF
--- a/AGENC-TUI-SURFACE.md
+++ b/AGENC-TUI-SURFACE.md
@@ -1,0 +1,853 @@
+# AGENC-TUI-SURFACE.md
+
+## Top-level TUI screens & layouts
+
+### App Shell
+- Main app provider - `runtime/src/tui/components/App.tsx:2394`; wraps `PromptOverlayProvider`, `KeybindingSetup`, and `AgenCTuiShell`; can open permission, elicitation, exit, cost, message selector, slash-command, and prompt-overlay surfaces.
+- TUI shell - `runtime/src/tui/components/App.tsx:1362`; owns session state, app state, command state, background task state, approval state, overlays, transcript, and prompt dispatch.
+- Fullscreen shell - `runtime/src/tui/components/FullscreenLayout.tsx:326`; frames top chrome, scrollback, prompt, modal layer, suggestion layer, new-message pill, and bottom chrome.
+- Non-fullscreen fallback - `runtime/src/tui/components/FullscreenLayout.tsx:489`; renders body/content/modal/footer without design chrome.
+- Top chrome - `runtime/src/tui/components/FullscreenLayout.tsx:522`; shows brand, cwd, permission mode, active task PDA, and live/warn tab state.
+- Bottom chrome - `runtime/src/tui/components/FullscreenLayout.tsx:547`; shows mode, cwd, MCP count, message count, and agent/task status.
+- Prompt overlay slot - `runtime/src/tui/components/FullscreenLayout.tsx:726`; hosts dialog-style prompt overlays above the composer.
+- Suggestion overlay slot - `runtime/src/tui/components/FullscreenLayout.tsx:703`; hosts prompt suggestions and slash-command palette above the composer.
+
+### Startup And Welcome
+- Startup status line - `runtime/src/tui/startup/StatusLine.tsx:328`; optional command-backed status line before and during the session.
+- Startup notices - `runtime/src/tui/startup/StatusNotices.tsx:38`; shows memory, daemon, auth, and IDE/plugin warnings from `runtime/src/tui/startup/statusNoticeDefinitions.tsx:237`.
+- Standalone onboarding screen - `runtime/src/tui/components/App.tsx:2273`; first-run flow with `/exit`, `/quit`, `/next`, `/skip`, `/done`, and `/test` prompt commands.
+- Empty transcript welcome - `runtime/src/tui/components/Messages.tsx:588`; shows logo/header content when no renderable messages exist.
+- V2 cold welcome panel - `runtime/src/tui/components/v2/primitives.tsx:692`; design-system welcome with network, version, cwd, git, token, wallet, stake, rep, slashed, help, and claim hints.
+- Auto-updater banner/status - `runtime/src/tui/components/AutoUpdater.tsx:24`; checks updates and shows updating, success, or failure states.
+
+### Main Session
+- Transcript screen - `runtime/src/tui/components/Messages.tsx:523`; scrollback renderer for user, assistant, system, tool, attachment, plan, protocol, and agent messages.
+- Message row shell - `runtime/src/tui/components/MessageRow.tsx:93`; applies streaming state, collapse rules, transcript metadata, and row chrome.
+- Prompt composer - `runtime/src/tui/components/PromptInput/PromptInput.tsx:559`; user input, slash-command entry, file/image paste, history, IDE mentions, queued commands, fast-mode picker, and footer controls.
+- Prompt mode indicator - `runtime/src/tui/components/PromptInput/PromptInputModeIndicator.tsx:71`; shows normal prompt pointer or bash-mode `!` state.
+- Prompt footer - `runtime/src/tui/components/PromptInput/PromptInputFooter.tsx:62`; shows mode, model/status hints, IDE status, footer actions, and selected footer items.
+- Queued commands strip - `runtime/src/tui/components/PromptInput/PromptInputQueuedCommands.tsx:132`; lists queued prompt commands before execution.
+- Sticky prompt header - `runtime/src/tui/components/FullscreenLayout.tsx:655`; appears when content scrolls behind the prompt area.
+- New messages pill - `runtime/src/tui/components/FullscreenLayout.tsx:595`; jumps to bottom or reports `N new messages`.
+
+### Plan And Review
+- Plan mode banner - `runtime/src/tui/components/FullscreenLayout.tsx:509`; announces plan mode inside the fullscreen scrollback.
+- V2 plan banner - `runtime/src/tui/components/v2/primitives.tsx:503`; compact `plan mode` row with reviewer-style hinting.
+- Plan approval message - `runtime/src/tui/message-renderers/PlanApprovalMessage.tsx:18`; transcript card for requested plan review.
+- Plan approval response - `runtime/src/tui/message-renderers/PlanApprovalMessage.tsx:78`; transcript card for approved or rejected plan result.
+- Plan list - `runtime/src/tui/components/v2/primitives.tsx:928`; renders plan items with `✓`, `▮`, `·`, and `✕`.
+- Review-mode system rows - `runtime/src/tui/session-transcript.ts:2349`; transcript handling for `plan_started`, `plan_item_completed`, `entered_review_mode`, and `exit_review_mode`.
+
+### Slash Registry Screens
+- Help screen - `runtime/src/tui/components/HelpV2/HelpV2.tsx:22`; opened by `/help`; can show general help or commands via `runtime/src/tui/components/HelpV2/Commands.tsx:17`.
+- Status dashboard - `runtime/src/commands/status-menu.tsx:172`; opened by `/status`; can inspect model, mode, git, session, and app state.
+- Model menu - `runtime/src/commands/model-menu.tsx:310`; opened by `/model`; can switch provider/model rows.
+- Provider menu - `runtime/src/commands/provider-menu.tsx:586`; opened by `/provider`; can inspect configured providers and auth state.
+- Permissions menu - `runtime/src/commands/permissions.ts:625`; opened by `/permissions`; can inspect and change permission mode/rules.
+- Plan menu - `runtime/src/commands/plan.ts:206`; opened by `/plan`; enters or exits plan mode and can show plan actions.
+- Agents menu - `runtime/src/commands/agents-menu.tsx:591`; opened by `/agents`; can list, create, edit, and delete agent definitions.
+- Background tasks screen - `runtime/src/tui/components/tasks/BackgroundTasksPanel.tsx:412`; opened by `/tasks`; can inspect, follow, stop, or view background work.
+- Config menu - `runtime/src/commands/config-menu.tsx:268`; opened by `/config`; shows config files, tools, providers, agents, MCP, permissions, hooks, and status rows.
+- Hooks menu - `runtime/src/commands/hooks-menu.tsx:427`; opened by `/hooks`; can inspect hooks, test edits, and show runtime-unavailable state.
+- Skills menu - `runtime/src/commands/skills-menu.tsx:99`; opened by `/skills`; can browse available skill roots and invoked skills.
+- MCP menu - `runtime/src/commands/mcp-menu.tsx:295`; opened by `/mcp`; can list servers, tools, tool details, and add server config.
+- Plugins menu - `runtime/src/commands/plugins.tsx:104`; opened by `/plugins`; shows loaded plugins and marketplace/plugin state.
+- Memory menu - `runtime/src/commands/memory/memory.tsx:195`; opened by `/memory`; can open user, project, auto, or agent memory files/folders.
+- Resume menu - `runtime/src/commands/resume-menu.tsx:23`; opened by `/resume`; can select a previous session.
+- Context usage modal - `runtime/src/tui/components/v2/ContextUsageModal.tsx:269`; opened by `/context`; shows token and context-window usage.
+- Diff menu - `runtime/src/commands/diff-menu.tsx:244`; opened by `/diff`; shows git status, staged/unstaged/untracked summaries, and diff actions.
+
+### Background And Multi-agent
+- Coordinator task panel - `runtime/src/tui/components/CoordinatorAgentStatus.tsx:75`; visible when coordinator/sub-agent/task state exists.
+- Agent progress line - `runtime/src/tui/components/AgentProgressLine.tsx:24`; inline background-agent progress row.
+- Background task status strip - `runtime/src/tui/components/tasks/BackgroundTaskStatus.tsx:25`; compact active-task pills and shortcut hint.
+- Task detail modal - `runtime/src/tui/components/tasks/BackgroundTasksPanel.tsx:621`; detailed background task view from the tasks screen.
+- Teams dialog - `runtime/src/tui/components/teams/TeamsDialog.tsx:92`; team/agent assignment surface with list and detail panes.
+
+### Exit And Interrupt
+- Exit flow - `runtime/src/tui/components/ExitFlow.tsx:17`; handles quit and worktree cleanup routing.
+- Worktree exit dialog - `runtime/src/tui/components/WorktreeExitDialog.tsx:35`; asks whether to keep or remove a worktree on exit.
+- Interrupt keybinding - `runtime/src/tui/keybindings/defaultBindings.ts:37`; global `ctrl+c` triggers `app:interrupt`.
+- Exit keybinding - `runtime/src/tui/keybindings/defaultBindings.ts:42`; global `ctrl+d` triggers `app:exit`.
+
+### IDE, Voice, And Updaters
+- IDE onboarding dialog - `runtime/src/tui/components/IdeOnboardingDialog.tsx:25`; guides terminal IDE integration setup.
+- IDE status indicator - `runtime/src/tui/components/IdeStatusIndicator.tsx:14`; shows selected lines or current IDE file.
+- Realtime voice panel - `runtime/src/tui/realtime/RealtimePanel.tsx:68`; shows voice transport, mic/PTT state, meter, transcript, and errors.
+- Fast-mode picker - `runtime/src/tui/components/PromptInput/PromptInput.tsx:177`; inline ON/OFF selector for fast mode.
+- Fast icon - `runtime/src/tui/components/FastIcon.tsx:13`; lightning indicator for fast mode and cooldown.
+- Diagnostics display - `runtime/src/tui/components/DiagnosticsDisplay.tsx:17`; shows IDE diagnostics summaries and verbose details.
+- Token warning - `runtime/src/tui/cost/TokenWarning.tsx:16`; warns when remaining context is low.
+- Rate-limit panel - `runtime/src/tui/components/dialogs/RateLimitMessage.tsx:75`; shows rate-limit details and upgrade/reset messaging.
+
+## Every modal / popup / overlay
+
+### Global Overlay Stack
+- Permission overlay - `runtime/src/tui/permission-requests.tsx:257`; triggered by tool permission requests; shows tool name, risk, scope, command/input, facts, and approve/deny controls; keys from `runtime/src/tui/permission-requests.tsx:344` and typed gate from `runtime/src/tui/permission-requests.tsx:356`.
+- AgenC approval overlay - `runtime/src/tui/permission-requests.tsx:324`; triggered for TUI-branded approval cards; low risk uses `confirm:yes`, `confirm:no`, `app:interrupt`; high risk requires typing `settle`, `stake`, `transfer`, or `yes`.
+- Elicitation overlay - `runtime/src/tui/components/App.tsx:843`; triggered by `request_user_input`, MCP form, or MCP URL pending state; shows title, message, detail, text/form placeholder, and submit/cancel affordance.
+- Modal overlay slot - `runtime/src/tui/components/FullscreenLayout.tsx:472`; triggered by modal tool JSX; floats over scrollback with a divider.
+- Prompt dialog overlay - `runtime/src/tui/components/FullscreenLayout.tsx:726`; triggered by prompt overlay provider; hosts dialogs such as auto-mode opt-in.
+- Suggestions overlay - `runtime/src/tui/components/FullscreenLayout.tsx:703`; triggered by prompt suggestions or slash palette; navigated by autocomplete/select keys.
+
+### Core Dialogs And Pickers
+- Dialog shell - `runtime/src/tui/components/design-system/Dialog.tsx:43`; shared frame for title, subtitle, footer, and optional input guide.
+- Fuzzy picker - `runtime/src/tui/components/design-system/FuzzyPicker.tsx:86`; shared list picker; keys include `up`/`ctrl+p`, `down`/`ctrl+n`, `return`, `tab`, `shift+tab`, and `escape` from `runtime/src/tui/components/design-system/FuzzyPicker.tsx:144`.
+- Global search dialog - `runtime/src/tui/components/GlobalSearchDialog.tsx:70`; triggered by global search key; shows fuzzy search over transcript/items; uses `FuzzyPicker`.
+- Quick open dialog - `runtime/src/tui/components/QuickOpenDialog.tsx:46`; triggered by quick-open key; shows fuzzy command/file/open targets; uses `FuzzyPicker`.
+- History search dialog - `runtime/src/tui/history/HistorySearchDialog.tsx:29`; triggered by `history:search`; shows prompt history in `FuzzyPicker`.
+- Message selector - `runtime/src/tui/components/MessageSelector.tsx:92`; triggered by transcript selection; shows message list, diff stats, preview, and restore/select actions; keys from `runtime/src/tui/components/MessageSelector.tsx:319`.
+- Model picker - `runtime/src/tui/components/ModelPicker.tsx:41`; triggered by model selection; shows model list, effort selector, provider/model metadata; left/right adjust effort from `runtime/src/tui/components/ModelPicker.tsx:208`.
+- Context usage modal - `runtime/src/tui/components/v2/ContextUsageModal.tsx:269`; triggered by `/context`; shows parsed token rows, progress bars, and raw fallback; closes with modal/select cancel keys.
+- MCP desktop import dialog - `runtime/src/tui/components/MCPServerDesktopImportDialog.tsx:19`; triggered when importing desktop MCP servers; shows multi-select server list via `SelectMulti` at `runtime/src/tui/components/MCPServerDesktopImportDialog.tsx:166`.
+- IDE onboarding dialog - `runtime/src/tui/components/IdeOnboardingDialog.tsx:25`; triggered during IDE setup; shows onboarding copy and confirmation controls from `runtime/src/tui/components/IdeOnboardingDialog.tsx:41`.
+- Auto-mode opt-in dialog - `runtime/src/tui/components/AutoModeOptInDialog.tsx:17`; triggered before enabling auto mode; shows allow/deny options with `Select` and title at `runtime/src/tui/components/AutoModeOptInDialog.tsx:130`.
+- Paste confirm dialog - `runtime/src/tui/components/PasteConfirmDialog.tsx:27`; triggered for pasted bash/multiline text; keys `Esc`, `n/N`, `y/Y`, and `Enter` from `runtime/src/tui/components/PasteConfirmDialog.tsx:29`.
+- Cost threshold dialog - `runtime/src/tui/components/dialogs/CostThresholdDialog.tsx:39`; triggered by cost threshold; shows continue/cancel choices via `Select`.
+- Worktree exit dialog - `runtime/src/tui/components/WorktreeExitDialog.tsx:35`; triggered on exit from worktree; shows keep/remove/cancel actions and loading state.
+- Teams dialog - `runtime/src/tui/components/teams/TeamsDialog.tsx:92`; triggered by teams/agents UI; keys for arrows, return, delete, mode cycling, and cancel from `runtime/src/tui/components/teams/TeamsDialog.tsx:159`.
+
+### Command Menus
+- Help modal - `runtime/src/tui/components/HelpV2/HelpV2.tsx:22`; triggered by `/help` or help key; shows general help or slash-command help.
+- Status dashboard modal - `runtime/src/commands/status-menu.tsx:172`; triggered by `/status`; shows status rows and color/glyph states.
+- Config menu modal - `runtime/src/commands/config-menu.tsx:268`; triggered by `/config`; shows settings/config rows and file locations.
+- Diff menu modal - `runtime/src/commands/diff-menu.tsx:244`; triggered by `/diff`; shows working-tree diff summary and actions.
+- Resume menu modal - `runtime/src/commands/resume-menu.tsx:23`; triggered by `/resume`; shows saved sessions.
+- Agents menu modal - `runtime/src/commands/agents-menu.tsx:591`; triggered by `/agents`; list/detail/create/edit/delete modes.
+- Hooks detail modal - `runtime/src/commands/hooks-menu.tsx:301`; triggered from `/hooks`; shows hook event, matcher, command, timeout, source, and status.
+- Hooks edit modal - `runtime/src/commands/hooks-menu.tsx:366`; triggered from `/hooks`; test-edits hook fields.
+- Hooks unavailable modal - `runtime/src/commands/hooks-menu.tsx:848`; triggered when hooks runtime is unavailable.
+- MCP form modal - `runtime/src/commands/mcp-menu.tsx:226`; triggered by `/mcp new` or add action; shows server name and command fields.
+- MCP menu modal - `runtime/src/commands/mcp-menu.tsx:295`; triggered by `/mcp`; list/tools/tool/form modes.
+- Skills menu modal - `runtime/src/commands/skills-menu.tsx:99`; triggered by `/skills`; shows skill roots and selected skill detail.
+- Memory command modal - `runtime/src/commands/memory/memory.tsx:195`; triggered by `/memory`; shows memory file/folder actions.
+- Provider menu modal - `runtime/src/commands/provider-menu.tsx:586`; triggered by `/provider`; list/detail/auth modes.
+- Model menu modal - `runtime/src/commands/model-menu.tsx:310`; triggered by `/model`; provider/model rows.
+- Plugins menu modal - `runtime/src/commands/plugins.tsx:104`; triggered by `/plugins`; loaded plugin rows.
+- Background tasks modal - `runtime/src/tui/components/tasks/BackgroundTasksPanel.tsx:412`; triggered by `/tasks`; list/detail panes and stop/follow actions.
+
+### V2 Primitive Overlays
+- Menu modal primitive - `runtime/src/tui/components/v2/primitives.tsx:1129`; generic bordered modal with active-row highlight, `esc dismiss`, and scroll status.
+- Slash palette - `runtime/src/tui/components/v2/primitives.tsx:1288`; triggered by slash input; shows `slash commands · N`, active row, source-like description glyphs, hidden count, and `↑↓ navigate · ⏎ run · esc dismiss`.
+- Approval card - `runtime/src/tui/components/v2/primitives.tsx:1059`; embedded in permission overlay; high risk uses `errorWash`, low risk uses `workerWash`, command block, facts, and typed confirmation hint.
+
+## Slash commands
+
+### Registry
+- Unified registry - `runtime/src/commands/registry.ts:127`; source of built-in ordering and command inclusion.
+- Static command loader - `runtime/src/commands.ts:292`; loads registry built-ins.
+- Dynamic command loader - `runtime/src/commands.ts:403`; adds local, bundled, plugin skill, and plugin commands.
+- Protocol command source - `runtime/src/commands/protocol.ts:49`; declares protocol commands with `source: "plugin"` and `kind: "protocol"`.
+
+### Builtin Commands
+- `/help` - source `builtin`; short help and command reference; opens modal; renders `HelpV2` at `runtime/src/tui/components/HelpV2/HelpV2.tsx:22`; command at `runtime/src/commands/help.ts:260`.
+- `/status` - source `builtin`; runtime and session status dashboard; opens modal; renders `StatusDashboardView` at `runtime/src/commands/status-menu.tsx:172`; command at `runtime/src/commands/status.ts:287`.
+- `/model` - source `builtin`; model/provider switcher; opens modal; renders `ModelMenuView` at `runtime/src/commands/model-menu.tsx:310`; command at `runtime/src/commands/model.ts:294`.
+- `/provider` - source `builtin`; provider configuration/auth status; opens modal; renders `ProviderMenuView` at `runtime/src/commands/provider-menu.tsx:586`; command at `runtime/src/commands/provider.ts:189`.
+- `/permissions` - source `builtin`; permission mode/rules table; opens modal; renders permissions menu from `runtime/src/commands/permissions.ts:625`; aliases `approvals`, `allowed-tools`; command at `runtime/src/commands/permissions.ts:608`.
+- `/plan` - source `builtin`; enters/exits plan mode or shows plan options; runs inline plus optional modal; renders plan banner `runtime/src/tui/components/FullscreenLayout.tsx:509`; command at `runtime/src/commands/plan.ts:163`.
+- `/agents` - source `builtin`; agent definition manager; opens modal; renders `AgentsMenuModal` at `runtime/src/commands/agents-menu.tsx:591`; command at `runtime/src/commands/agent-management.tsx:19`.
+- `/tasks` - source `builtin`; background task list; opens modal; renders `BackgroundTasksPanel` at `runtime/src/tui/components/tasks/BackgroundTasksPanel.tsx:412`; aliases `jobs`, `bashes`; command at `runtime/src/commands/tasks.ts:213`.
+- `/config` - source `builtin`; configuration dashboard; opens modal; renders `ConfigMenuView` at `runtime/src/commands/config-menu.tsx:268`; alias `settings`; command at `runtime/src/commands/config.ts:275`.
+- `/hooks` - source `builtin`; hook browser/test editor; opens modal; renders `HooksMenuView` at `runtime/src/commands/hooks-menu.tsx:427`; command at `runtime/src/commands/hooks.ts:296`.
+- `/skills` - source `builtin`; skill roots and skill launcher info; opens modal; renders `SkillsMenuView` at `runtime/src/commands/skills-menu.tsx:99`; command at `runtime/src/commands/skills.ts:375`.
+- `/mcp` - source `builtin`; MCP server/tools/status/reconnect/enable/disable/add; opens modal or runs inline subcommand; renders `McpMenuView` at `runtime/src/commands/mcp-menu.tsx:295`; command at `runtime/src/commands/mcp.ts:700`.
+- `/plugins` - source `builtin`; plugin and marketplace browser; opens modal; renders `PluginsMenuView` at `runtime/src/commands/plugins.tsx:104`; aliases `plugin`, `marketplace`; command at `runtime/src/commands/plugins.tsx:200`.
+- `/memory` - source `builtin`; memory file/folder opener; opens modal; renders `MemoryCommand` at `runtime/src/commands/memory/memory.tsx:195`; command at `runtime/src/commands/memory/slash.ts:18`.
+- `/resume` - source `builtin`; session picker/resume; opens modal unless direct session args are supplied; renders `ResumeMenuView` at `runtime/src/commands/resume-menu.tsx:23`; alias `sessions`; command at `runtime/src/commands/resume.ts:285`.
+- `/clear` - source `builtin`; clears current session; runs inline; message text `Session cleared.`; command at `runtime/src/commands/clear.ts:161`.
+- `/compact` - source `builtin`; compacts context/session history; runs inline with compact status path; command at `runtime/src/commands/session-compact.ts:83`.
+- `/context` - source `builtin`; context usage display; opens modal; renders `ContextUsageModal` at `runtime/src/tui/components/v2/ContextUsageModal.tsx:269`; alias `ctx`; command at `runtime/src/commands/session-compact.ts:120`.
+- `/diff` - source `builtin`; git diff/status summary; opens modal; renders `DiffMenuView` at `runtime/src/commands/diff-menu.tsx:244`; command at `runtime/src/commands/diff.ts:148`.
+- `/exit` - source `builtin`; exits current session; runs inline and may open `ExitFlow` at `runtime/src/tui/components/ExitFlow.tsx:17`; alias `quit`; command at `runtime/src/commands/exit.ts:21`.
+
+### Protocol Commands
+- `/claim` - source `plugin`; protocol claim flow; runs inline; no modal; command source at `runtime/src/commands/protocol.ts:66`.
+- `/delegate` - source `plugin`; protocol delegate flow; runs inline; no modal; command source at `runtime/src/commands/protocol.ts:67`.
+- `/proof` - source `plugin`; protocol proof flow; runs inline; no modal; command source at `runtime/src/commands/protocol.ts:68`.
+- `/settle` - source `plugin`; protocol settle flow; runs inline; no modal; command source at `runtime/src/commands/protocol.ts:70`.
+- `/stake` - source `plugin`; protocol stake flow; runs inline; no modal; command source at `runtime/src/commands/protocol.ts:72`.
+
+### Dynamic Commands
+- Skill commands - source `plugin`; loaded from local/bundled/plugin skills; can run inline or return tool JSX; dynamic loader at `runtime/src/commands.ts:403`.
+- Plugin commands - source `plugin`; loaded from plugin command providers; can run inline or open plugin-owned tool JSX; dynamic loader at `runtime/src/commands.ts:435`.
+
+## Tools
+
+### Transcript Rendering Defaults
+- Tool-use row shell - `runtime/src/tui/message-renderers/AssistantToolUseMessage.tsx:48`; renders pending/running/done/failed tool rows and v2 `Tool` cards.
+- Tool success result row - `runtime/src/tui/message-renderers/UserToolSuccessMessage.tsx:58`; renders approved tool results and expanded custom result views.
+- Tool rejection row - `runtime/src/tui/message-renderers/UserToolRejectMessage.tsx:21`; renders denied/canceled tool results.
+- Orphan tool result row - `runtime/src/tui/message-renderers/UserToolResultMessage.tsx:43`; handles unmatched tool-result messages.
+- Tool result routing - `runtime/src/tui/tool-result-routing.ts:59`; dispatches custom result tags to expanded views.
+- TUI tool renderer registry - `runtime/src/tui/tool-rendering.tsx:537`; defines summaries, user-facing names, activity text, and result renderers.
+
+### File Tools
+- `FileRead` - reads files; transcript uses `AssistantToolUseMessage` at `runtime/src/tui/message-renderers/AssistantToolUseMessage.tsx:48`; custom expanded view `FileReadView` at `runtime/src/tui/tool-rendering.tsx:121`.
+- `Read` - model-facing alias for `FileRead`; transcript and expanded view same as `FileRead`; alias declared at `runtime/src/tools/canonicalToolSurface.ts:548`.
+- `Edit` - edits one file; transcript uses tool rows; custom expanded view `EditDiffView` at `runtime/src/tui/tool-rendering.tsx:73`.
+- `FileEdit` - alias for `Edit`; transcript and diff view same as `Edit`; alias declared at `runtime/src/tools/canonicalToolSurface.ts:563`.
+- `MultiEdit` - applies multiple file edits; transcript uses generic tool row plus edit diff result when tagged; tool declared at `runtime/src/tools/system/file-edit.ts:964`.
+- `Write` - writes file content; transcript uses tool row; custom expanded view `FileWriteView` at `runtime/src/tui/tool-rendering.tsx:148`.
+- `FileWrite` - alias for `Write`; transcript and write summary same as `Write`; alias declared at `runtime/src/tools/canonicalToolSurface.ts:582`.
+- `Glob` - finds paths by glob; transcript uses tool row; custom expanded view `GlobPathsView` at `runtime/src/tui/tool-rendering.tsx:211`.
+- `Grep` - searches text; transcript uses tool row; custom expanded view `GrepMatchesView` at `runtime/src/tui/tool-rendering.tsx:168`.
+- `system.grep` - canonical alias for `Grep`; transcript and expanded view same as `Grep`; alias declared at `runtime/src/tools/canonicalToolSurface.ts:600`.
+- `system.glob` - canonical alias for `Glob`; transcript and expanded view same as `Glob`; alias declared at `runtime/src/tools/canonicalToolSurface.ts:614`.
+- `NotebookEdit` - edits notebook cells; transcript uses generic tool row unless result is routed as file/edit content; tool declared at `runtime/src/tools/system/notebook-edit.ts:97`.
+- `NotebookRead` - reads notebooks; transcript uses generic tool row; model-facing tool declared at `runtime/src/bin/model-facing-tools.ts:1892`.
+- `system.listDir` - lists directory entries; transcript uses generic tool row; tool declared at `runtime/src/tools/system/filesystem.ts:843`.
+- `system.stat` - stats paths; transcript uses generic tool row; tool declared at `runtime/src/tools/system/filesystem.ts:934`.
+- `system.mkdir` - creates directories; transcript uses generic tool row; tool declared at `runtime/src/tools/system/filesystem.ts:982`.
+- `system.delete` - deletes files/directories; transcript uses generic tool row; tool declared at `runtime/src/tools/system/filesystem.ts:1022`.
+- `system.move` - moves/renames files/directories; transcript uses generic tool row; tool declared at `runtime/src/tools/system/filesystem.ts:1092`.
+- `apply_patch` - applies patch hunks; transcript uses generic tool row plus edit-like output if routed; approval required from `runtime/src/tools/apply-patch/tool.ts:158`; tool declared at `runtime/src/tools/apply-patch/tool.ts:143`.
+
+### Shell And Process Tools
+- `exec_command` - runs PTY/plain shell commands; transcript uses tool row; custom expanded view through `BashOutputView` when routed; tool declared at `runtime/src/tools/system/exec-command.ts:236`.
+- `write_stdin` - writes to running exec session; transcript uses generic tool row; tool declared at `runtime/src/tools/system/write-stdin.ts:52`.
+- `system.bash` - shell command tool; transcript uses tool row; custom expanded view `BashOutputView` at `runtime/src/tui/tool-rendering.tsx:276`; tool declared at `runtime/src/tools/system/bash.ts:882`.
+- `Bash` - canonical/model-facing shell alias; transcript and output view same as `system.bash`; alias declared at `runtime/src/tools/canonicalToolSurface.ts:521`.
+- `PowerShell` - model-facing PowerShell tool; transcript uses generic shell-like tool row; declared at `runtime/src/bin/model-facing-tools.ts:2406`.
+- `Sleep` - waits for a duration; transcript uses generic tool row; tool declared at `runtime/src/tools/system/sleep.ts:50`.
+- `Monitor` - monitors running process/output; transcript uses generic tool row; tool declared at `runtime/src/tools/system/monitor.ts:58`.
+- `EnterWorktree` - enters a worktree; transcript uses generic tool row; tool declared at `runtime/src/tools/system/worktree.ts:308`.
+- `ExitWorktree` - exits/removes worktree; transcript uses generic tool row and may trigger `WorktreeExitDialog` at `runtime/src/tui/components/WorktreeExitDialog.tsx:35`; tool declared at `runtime/src/tools/system/worktree.ts:441`.
+
+### Repo, Symbol, And Planning Tools
+- `system.repoInventory` - repo inventory summary; transcript uses generic tool row; tool declared at `runtime/src/tools/system/git-tools.ts:28`.
+- `system.gitStatus` - git status; transcript uses generic tool row; tool declared at `runtime/src/tools/system/git-tools.ts:105`.
+- `system.gitDiff` - git diff; transcript uses generic tool row; tool declared at `runtime/src/tools/system/git-tools.ts:139`.
+- `system.gitShow` - git show; transcript uses generic tool row; tool declared at `runtime/src/tools/system/git-tools.ts:190`.
+- `system.gitBranchInfo` - branch info; transcript uses generic tool row; tool declared at `runtime/src/tools/system/git-tools.ts:230`.
+- `system.gitChangeSummary` - change summary; transcript uses generic tool row; tool declared at `runtime/src/tools/system/git-tools.ts:266`.
+- `system.gitWorktreeList` - worktree list; transcript uses generic tool row; tool declared at `runtime/src/tools/system/git-tools.ts:300`.
+- `system.gitWorktreeCreate` - create worktree; transcript uses generic tool row; tool declared at `runtime/src/tools/system/git-tools.ts:343`.
+- `system.gitWorktreeRemove` - remove worktree; transcript uses generic tool row; tool declared at `runtime/src/tools/system/git-tools.ts:403`.
+- `system.gitWorktreeStatus` - worktree status; transcript uses generic tool row; tool declared at `runtime/src/tools/system/git-tools.ts:470`.
+- `system.symbolSearch` - symbol search; transcript uses generic tool row; tool declared at `runtime/src/tools/system/symbol-tools.ts:27`.
+- `system.symbolDefinition` - symbol definition lookup; transcript uses generic tool row; tool declared at `runtime/src/tools/system/symbol-tools.ts:67`.
+- `system.symbolReferences` - symbol references lookup; transcript uses generic tool row; tool declared at `runtime/src/tools/system/symbol-tools.ts:110`.
+- `TodoWrite` - plan/todo update; transcript uses plan-list rendering and generic tool row as needed; tool declared at `runtime/src/tools/system/planning.ts:260`.
+- `EnterPlanMode` - enters plan mode; transcript shows plan banner and mode chrome; approval at `runtime/src/tools/system/planning.ts:318`; tool declared at `runtime/src/tools/system/planning.ts:313`.
+- `ExitPlanMode` - exits plan mode; transcript shows plan approval/exit events; approval at `runtime/src/tools/system/planning.ts:352`; tool declared at `runtime/src/tools/system/planning.ts:348`.
+- `VerifyPlanExecution` - model-facing plan verification; transcript uses generic tool row; tool declared at `runtime/src/bin/model-facing-tools.ts:2199`.
+- `system.searchTools` - tool search; transcript uses generic tool row; tool declared at `runtime/src/tools/system/tool-search.ts:136`.
+
+### Web Tools
+- `WebFetch` - fetches URL content; transcript uses generic tool row; model-facing declaration at `runtime/src/bin/model-facing-tools.ts:130`.
+- `WebSearch` - web search; transcript uses generic tool row; model-facing declaration at `runtime/src/bin/model-facing-tools.ts:1805`.
+- `RemoteTrigger` - remote trigger/webhook-style model-facing operation; transcript uses generic tool row; tool declared at `runtime/src/bin/model-facing-tools.ts:2449`.
+
+### Agent-control Tools
+- `spawn_agent` - spawns sub-agent; transcript suppresses generic row and emits collab-agent system rows; tool declared at `runtime/src/agents/v2/spawn.ts:499`; spawn end row from `runtime/src/agents/v2/spawn.ts:468`.
+- `wait_agent` - waits for agent completion; transcript emits waiting begin/end rows; tool declared at `runtime/src/agents/v2/wait.ts:287`.
+- `close_agent` - closes an agent; transcript emits close begin/end rows; tool declared at `runtime/src/agents/v2/close-agent.ts:83`.
+- `followup_task` - sends follow-up task; transcript uses collab interaction rows; tool declared at `runtime/src/agents/v2/followup-task.ts:7`.
+- `send_message` - sends message to agent; transcript uses collab interaction rows; tool declared at `runtime/src/agents/v2/send-message.ts:7`.
+- `list_agents` - lists active agents; transcript uses generic/collab rows; tool declared at `runtime/src/agents/v2/list-agents.ts:52`.
+- `TaskCreate` - creates background task; transcript uses task/agent rows; tool declared at `runtime/src/tools/tasks/task-board.ts:197`.
+- `TaskGet` - reads task; transcript uses generic task row; tool declared at `runtime/src/tools/tasks/task-board.ts:253`.
+- `TaskUpdate` - updates task; transcript uses generic task row; tool declared at `runtime/src/tools/tasks/task-board.ts:291`.
+- `TaskList` - lists tasks; transcript uses generic task row; tool declared at `runtime/src/tools/tasks/task-board.ts:446`.
+- `TaskOutput` - reads background task output; transcript uses background task rows; tool declared at `runtime/src/tools/tasks/background.ts:77`.
+- `TaskStop` - stops background task; transcript uses background task rows; tool declared at `runtime/src/tools/tasks/background.ts:168`.
+- `spawn_agents_on_csv` - model-facing bulk agent job spawner; transcript uses generic/collab rows; declared at `runtime/src/bin/model-facing-tools.ts:1152`.
+- `report_agent_job_result` - model-facing bulk agent result reporter; transcript uses generic row; declared at `runtime/src/bin/model-facing-tools.ts:1199`.
+
+### Protocol, MCP, And Custom Tools
+- `AskUserQuestion` - asks user for input; transcript uses dedicated TUI tool from `runtime/src/tui/tool-rendering.tsx:537`; approval required from `runtime/src/tools/ask-user-question/tool.ts:342`; tool declared at `runtime/src/tools/ask-user-question/tool.ts:327`.
+- `request_user_input` - model-facing elicitation/request input tool; transcript opens `ElicitationOverlay` at `runtime/src/tui/components/App.tsx:843`; tool declared at `runtime/src/elicitation/request-user-input.ts:268`.
+- `mcp__<server>__<tool>` - dynamic MCP tool namespace; transcript uses generic dynamic TUI tool unless a result tag routes custom view; dynamic MCP names added at `runtime/src/tui/tool-rendering.tsx:680`.
+- `Skill` - invokes a skill; transcript uses generic tool row plus skill attachment rows; tool declared at `runtime/src/bin/model-facing-tools.ts:1308`.
+- `CronCreate` - creates scheduled task; transcript uses generic row; tool declared at `runtime/src/bin/model-facing-tools.ts:2249`.
+- `CronDelete` - deletes scheduled task; transcript uses generic row; tool declared at `runtime/src/bin/model-facing-tools.ts:2295`.
+- `CronList` - lists scheduled tasks; transcript uses generic row; tool declared at `runtime/src/bin/model-facing-tools.ts:2319`.
+- `WorkflowTool` - model-facing workflow operation; transcript uses generic row; tool declared at `runtime/src/bin/model-facing-tools.ts:2335`.
+- Structured-output tool - model-facing structured output helper; transcript uses generic row; tool declared at `runtime/src/bin/structured-output-tool.ts:60`.
+- Plugin/custom runtime tools - loaded through model-facing tool wiring and plugin registry; transcript uses generic dynamic tool rows unless the plugin emits known TUI result tags; registry note at `runtime/src/tool-registry.ts:452`.
+
+## Permission modes & approval flows
+
+### Permission Modes
+- `default` - `runtime/src/permissions/types.ts:40`; normal mode; title `Default`, short `Default`, symbol `""`, color `text` from `runtime/src/permissions/mode-display.ts:32`; v2 pill label `default` from `runtime/src/tui/components/v2/primitives.tsx:42`.
+- `acceptEdits` - `runtime/src/permissions/types.ts:41`; auto-accepts edit-class actions while asking for riskier operations; title `Accept edits`, symbol `⏵⏵`/`>>`, color `autoAccept` from `runtime/src/permissions/mode-display.ts:44`; v2 pill uses `agenc`/`agencWash` from `runtime/src/tui/components/v2/primitives.tsx:43`.
+- `plan` - `runtime/src/permissions/types.ts:42`; planning mode with execution gated; title `Plan Mode`, symbol `⏸`/`||`, color `planMode` from `runtime/src/permissions/mode-display.ts:38`; v2 pill uses `planMode`/`planModeWash` from `runtime/src/tui/components/v2/primitives.tsx:44`.
+- `bypassPermissions` - `runtime/src/permissions/types.ts:43`; bypass mode for dangerous operations; title `Bypass Permissions`, symbol `⏵⏵`/`>>`, color `error` from `runtime/src/permissions/mode-display.ts:50`; v2 pill label `bypass perms` and `errorWash` from `runtime/src/tui/components/v2/primitives.tsx:46`.
+- `dontAsk` - `runtime/src/permissions/types.ts:44`; non-interactive no-prompt mode; title `Don't Ask`, short `DontAsk`, color `error` from `runtime/src/permissions/mode-display.ts:56`; v2 pill muted at `runtime/src/tui/components/v2/primitives.tsx:47`.
+- `auto` - `runtime/src/permissions/types.ts:45`; auto mode; title `Auto mode`, color `warning` from `runtime/src/permissions/mode-display.ts:62`; v2 pill uses `success`/`successWash` at `runtime/src/tui/components/v2/primitives.tsx:45`.
+- `unattended` - `runtime/src/permissions/types.ts:46`; internal unattended mode; title `Unattended`, symbol `⏵`/`>`, color `warning` from `runtime/src/permissions/mode-display.ts:68`; not user-addressable from `runtime/src/permissions/types.ts:54`.
+- `bubble` - `runtime/src/permissions/types.ts:47`; internal bubble mode; title `Bubble`, symbol `""`, color `text` from `runtime/src/permissions/mode-display.ts:74`; not user-addressable from `runtime/src/permissions/types.ts:54`.
+
+### Mode Chrome
+- User-facing mode switcher order - `runtime/src/tui/components/v2/primitives.tsx:193`; `[1] default`, `[2] acceptEdits`, `[3] plan`, `[4] auto`, `[5] bypassPermissions`.
+- Mode switcher hint - `runtime/src/tui/components/v2/primitives.tsx:222`; shows `shift+tab cycles forward · /permissions for full rule table`.
+- Header mode pill - `runtime/src/tui/components/v2/primitives.tsx:172`; displays mode label/color in top chrome.
+- Prompt glyph - `runtime/src/tui/components/PromptInput/permissionModeChrome.ts:14`; bypass mode uses `glyphs.promptBypass`, all others use `glyphs.pointer`.
+- Footer mode label - `runtime/src/tui/components/PromptInput/permissionModeChrome.ts:22`; bypass shows `YOLO` and symbol `!`, others show `<mode> on`.
+- Plan mode banner - `runtime/src/tui/components/FullscreenLayout.tsx:509`; visible when plan mode is active.
+- Status bar mode variant - `runtime/src/tui/components/FullscreenLayout.tsx:547`; uses mode-derived variant for bottom chrome tint.
+
+### Approval Surfaces
+- Low-risk file write/edit approval - `runtime/src/tui/permission-requests.tsx:344`; `ApprovalCard` at `runtime/src/tui/components/v2/primitives.tsx:1059` shows tool, input block, facts, approve/deny hints, and low-risk `workerWash`.
+- High-risk bash approval - `runtime/src/tui/permission-requests.tsx:302`; command/input matching `mainnet`, `settle`, `stake`, `transfer`, `slash`, `escrow`, or `solana transfer` gets high-risk styling and typed confirmation.
+- High-risk protocol write approval - `runtime/src/tui/permission-requests.tsx:389`; facts show `scope: mainnet / protocol`; card uses `errorWash` and an explicit typed word.
+- Typed-confirmation gate - `runtime/src/tui/permission-requests.tsx:312`; required word is `settle`, `stake`, `transfer`, or `yes`; Enter accepts only when typed text matches.
+- Fail-closed unknown tool approval - `runtime/src/tui/permission-requests.tsx:99`; unknown tool names receive a denial-style confirmation surface.
+- `AskUserQuestion` approval special case - `runtime/src/tui/permission-requests.tsx:147`; rejection resolves the pending user-question flow instead of generic denial.
+- Permission context data - `runtime/src/permissions/types.ts:350`; UI decisions use mode, additional directories, allow/deny/ask rule maps, bypass availability, stripped dangerous rules, pre-plan mode, and auto-mode availability.
+
+## Agents
+
+### Agent Roles And Registry
+- Runtime role registry - `runtime/src/agents/role.ts:290`; registers built-in and Markdown-defined roles.
+- Built-in default role - `runtime/src/agents/role.ts:254`; `default` role with public presentation `netrunner`.
+- Built-in explorer role - `runtime/src/agents/role.ts:261`; read-oriented `explorer` role with public presentation `scanner`.
+- Built-in worker role - `runtime/src/agents/role.ts:269`; execution-oriented `worker` role with public presentation `runner`.
+- Public role labels - `runtime/src/agents/role-presentation.ts:18`; `default` -> `Netrunner`, `explorer` -> `Scanner`, `worker` -> `Runner`.
+- Additional public role labels - `runtime/src/agents/role-presentation.ts:37`; `docs` -> `Scribe`, `operator` -> `Fixer`, `marketplace` -> `Broker`, `browser` -> `Ghost`, `remote` -> `Trace`.
+- Agent registry root paths - `runtime/src/agents/registry.ts:35`; root agent path `/root`, memory agent path `/morpheus`.
+- Markdown role directories - `runtime/src/agents/role.ts:695`; loads user, project, and managed agent-role files.
+
+### Spawn Surfaces
+- V2 agent tool group - `runtime/src/agents/v2/index.ts:10`; creates `spawn_agent`, `wait_agent`, `close_agent`, `followup_task`, `send_message`, and `list_agents`.
+- Spawn-agent tool - `runtime/src/agents/v2/spawn.ts:499`; starts sub-agents and emits collab-agent events.
+- Wait-agent tool - `runtime/src/agents/v2/wait.ts:287`; waits for agent completion and emits waiting events.
+- Close-agent tool - `runtime/src/agents/v2/close-agent.ts:83`; shuts down agents and emits close events.
+- Follow-up task tool - `runtime/src/agents/v2/followup-task.ts:7`; sends new task to an existing agent.
+- Send-message tool - `runtime/src/agents/v2/send-message.ts:7`; sends a message to an existing agent.
+- List-agents tool - `runtime/src/agents/v2/list-agents.ts:52`; lists active/known agents.
+- General-purpose agent - `runtime/src/tools/AgentTool/built-in/generalPurposeAgent.ts:25`; broad `general-purpose` sub-agent.
+- Explore agent - `runtime/src/tools/AgentTool/built-in/exploreAgent.ts:64`; read-only exploration agent.
+- Plan agent - `runtime/src/tools/AgentTool/built-in/planAgent.ts:73`; read-only planning agent.
+- Verification agent - `runtime/src/tools/AgentTool/built-in/verificationAgent.ts:134`; background verification agent that returns a verdict.
+- AgenC guide agent - `runtime/src/tools/AgentTool/built-in/agencGuideAgent.ts:100`; guided support agent with `dontAsk` permission mode.
+- Statusline setup agent - `runtime/src/tools/AgentTool/built-in/statuslineSetup.ts:138`; setup agent for status-line configuration.
+
+### TUI Presentation
+- Coordinator task panel - `runtime/src/tui/components/CoordinatorAgentStatus.tsx:75`; shows orchestrator, active count, selected/viewed agent glyphs, and agent tree rows.
+- Agent line - `runtime/src/tui/components/CoordinatorAgentStatus.tsx:205`; shows elapsed time, status text, tools/tokens, selected state, and tree indentation.
+- Agent progress line - `runtime/src/tui/components/AgentProgressLine.tsx:24`; shows tree branch glyph, status text, tool/tokens, response gutter, and background/running/done labels.
+- Background tasks panel - `runtime/src/tui/components/tasks/BackgroundTasksPanel.tsx:412`; groups background agents, shell commands, approvals, and other tasks.
+- Background task status strip - `runtime/src/tui/components/tasks/BackgroundTaskStatus.tsx:25`; compact active-task pills, arrow hint, and summary.
+- Agents menu - `runtime/src/commands/agents-menu.tsx:591`; persistent agent-definition editor for list/detail/create/edit/delete.
+
+### Lifecycle States
+- `pending_init` - `runtime/src/agents/status.ts:22`; initializing; shown as initializing/pending rows in agent progress/status components.
+- `running` - `runtime/src/agents/status.ts:25`; active; shown with running icon, elapsed time, and active count.
+- `completed` - `runtime/src/agents/status.ts:29`; final done state; shown with success/tick styling.
+- `errored` - `runtime/src/agents/status.ts:33`; final error state; shown with error/cross styling.
+- `shutdown` - `runtime/src/agents/status.ts:38`; final killed/closed state; shown as shutdown/killed background task.
+- `not_found` - `runtime/src/agents/status.ts:43`; final missing-agent state; shown as error/not-found result.
+- `interrupted` - `runtime/src/agents/status.ts:47`; interrupted/paused result; shown as interrupted state.
+- Background `running` - `runtime/src/tui/components/tasks/taskStatusUtils.tsx:76`; display text `working`.
+- Background `idle` - `runtime/src/tui/components/tasks/taskStatusUtils.tsx:78`; display text `idle`.
+- Background `awaiting approval` - `runtime/src/tui/components/tasks/taskStatusUtils.tsx:77`; display text `awaiting approval`.
+- Background `stopping` - `runtime/src/tui/components/tasks/taskStatusUtils.tsx:79`; display text `stopping`.
+- Background terminal states - `runtime/src/tui/components/tasks/taskStatusUtils.tsx:15`; `completed`, `failed`, and `killed` are terminal.
+
+## Event types
+
+### Canonical EventMsg Variants
+- `session_meta` - `runtime/src/session/event-log.ts:533`; durable session metadata; transcript-affecting only when converted to session state.
+- `session_configured` - `runtime/src/session/event-log.ts:540`; session configuration; mostly state/status-bar input.
+- `turn_started` - `runtime/src/session/event-log.ts:546`; transient turn state; transcript handler at `runtime/src/tui/session-transcript.ts:1583`.
+- `turn_context` - `runtime/src/session/event-log.ts:552`; context state; transcript token/context rows from `runtime/src/tui/session-transcript.ts:2031`.
+- `agent_message` - `runtime/src/session/event-log.ts:558`; assistant text; transcript renderer through `AssistantTextMessage` at `runtime/src/tui/message-renderers/AssistantTextMessage.tsx:48`.
+- `agent_message_delta` - `runtime/src/session/event-log.ts:566`; streaming assistant text; transient until accumulated in transcript.
+- `agent_thinking` - `runtime/src/session/event-log.ts:573`; thinking content; rendered or hidden through `SystemTextMessage` at `runtime/src/tui/message-renderers/SystemTextMessage.tsx:150`.
+- `assistant_thinking_block_start` - `runtime/src/session/event-log.ts:579`; transient thinking block boundary.
+- `assistant_thinking_delta` - `runtime/src/session/event-log.ts:584`; transient thinking text.
+- `assistant_thinking_block_stop` - `runtime/src/session/event-log.ts:590`; transient thinking block boundary.
+- `user_message` - `runtime/src/session/event-log.ts:595`; durable user turn content; transcript handler at `runtime/src/tui/session-transcript.ts:1663`.
+- `token_count` - `runtime/src/session/event-log.ts:602`; token/status data; transcript context rows from `runtime/src/tui/session-transcript.ts:2031`.
+- `mcp_tool_call_begin` - `runtime/src/session/event-log.ts:609`; MCP tool start; transcript tool row from `runtime/src/tui/session-transcript.ts:1845`.
+- `mcp_tool_call_end` - `runtime/src/session/event-log.ts:617`; MCP tool end; transcript result row from `runtime/src/tui/session-transcript.ts:1968`.
+- `exec_command_begin` - `runtime/src/session/event-log.ts:624`; shell command start; transcript tool row.
+- `exec_command_end` - `runtime/src/session/event-log.ts:631`; shell command end; transcript result row.
+- `exec_approval_request` - `runtime/src/session/event-log.ts:638`; approval request; permission overlay/status input.
+- `tool_call_started` - `runtime/src/session/event-log.ts:645`; generic tool start; transcript tool row.
+- `tool_input_block_start` - `runtime/src/session/event-log.ts:652`; streaming tool input boundary.
+- `tool_input_delta` - `runtime/src/session/event-log.ts:659`; streaming tool input; transient until finalized.
+- `tool_call_completed` - `runtime/src/session/event-log.ts:666`; generic tool completion; transcript result row.
+- `tool_progress` - `runtime/src/session/event-log.ts:672`; transient progress; can update tool row/status.
+- `request_permissions` - `runtime/src/session/event-log.ts:679`; approval request; permission overlay.
+- `request_user_input` - `runtime/src/session/event-log.ts:685`; elicitation request; opens `ElicitationOverlay` at `runtime/src/tui/components/App.tsx:843`.
+- `mcp_elicitation_request` - `runtime/src/session/event-log.ts:692`; MCP elicitation; opens `ElicitationOverlay`.
+- `mcp_elicitation_complete` - `runtime/src/session/event-log.ts:699`; closes/settles MCP elicitation; transient UI state.
+- `context_compacted` - `runtime/src/session/event-log.ts:705`; durable; transcript compacted marker.
+- `turn_complete` - `runtime/src/session/event-log.ts:712`; durable; transcript/status updates.
+- `turn_aborted` - `runtime/src/session/event-log.ts:718`; durable; transcript/status/error updates.
+- `thread_rolled_back` - `runtime/src/session/event-log.ts:724`; transcript history mutation.
+- `error` - `runtime/src/session/event-log.ts:730`; durable; system error row.
+- `stream_error` - `runtime/src/session/event-log.ts:736`; transient/error row; transcript handler at `runtime/src/tui/session-transcript.ts:2074`.
+- `warning` - `runtime/src/session/event-log.ts:742`; warning row/status notice.
+- `guardian_assessment` - `runtime/src/session/event-log.ts:748`; policy/safety-style assessment row.
+- `review_delegate_started` - `runtime/src/session/event-log.ts:754`; review/agent status event.
+- `review_delegate_completed` - `runtime/src/session/event-log.ts:761`; review/agent status event.
+- `plan_approval_requested` - `runtime/src/session/event-log.ts:768`; transcript plan approval request.
+- `plan_approval_completed` - `runtime/src/session/event-log.ts:774`; transcript plan approval result.
+
+### Protocol Event Variants
+- `protocol_claim` - `runtime/src/session/event-log.ts:781`; durable; renders protocol claim card via `ProtocolEvent` at `runtime/src/tui/components/v2/primitives.tsx:1382`.
+- `protocol_settle` - `runtime/src/session/event-log.ts:787`; durable; renders settle success/failure card.
+- `protocol_slash` - `runtime/src/session/event-log.ts:793`; durable; renders slash/error-style card.
+- `protocol_stake` - `runtime/src/session/event-log.ts:799`; durable; renders stake card.
+
+### Collaboration And Agent Event Variants
+- `collab_agent_spawn_begin` - `runtime/src/session/event-log.ts:805`; transient; agent spawn status.
+- `collab_agent_spawn_end` - `runtime/src/session/event-log.ts:811`; transcript agent-spawn system row.
+- `collab_agent_status` - `runtime/src/session/event-log.ts:817`; status/transcript row for agent lifecycle.
+- `collab_agent_interaction_begin` - `runtime/src/session/event-log.ts:823`; transient interaction row.
+- `collab_agent_interaction_end` - `runtime/src/session/event-log.ts:829`; transcript interaction completion.
+- `collab_waiting_begin` - `runtime/src/session/event-log.ts:835`; waiting status row.
+- `collab_waiting_end` - `runtime/src/session/event-log.ts:841`; waiting completion row.
+- `collab_close_begin` - `runtime/src/session/event-log.ts:847`; closing status row.
+- `collab_close_end` - `runtime/src/session/event-log.ts:853`; close completion row.
+- `collab_resume_begin` - `runtime/src/session/event-log.ts:859`; resume status row.
+- `collab_resume_end` - `runtime/src/session/event-log.ts:865`; resume completion row.
+
+### Plan Mode Event Variants
+- `entered_review_mode` - `runtime/src/session/event-log.ts:871`; status/transcript state for review mode.
+- `deprecation_notice` - `runtime/src/session/event-log.ts:877`; transcript warning/info row.
+- `plan_started` - `runtime/src/session/event-log.ts:883`; transcript plan-start row.
+- `plan_delta` - `runtime/src/session/event-log.ts:889`; transient plan update.
+- `plan_item_completed` - `runtime/src/session/event-log.ts:895`; transcript plan item completion.
+- `plan_exited` - `runtime/src/session/event-log.ts:901`; status/transcript plan exit.
+- `exit_review_mode` - `runtime/src/session/event-log.ts:907`; status/transcript review exit.
+
+### Durable Vs Transient
+- Durable set - `runtime/src/session/event-log.ts:922`; `turn_complete`, `turn_aborted`, `error`, `context_compacted`, `protocol_claim`, `protocol_settle`, `protocol_slash`, and `protocol_stake`.
+- Transcript-rendered core events - `runtime/src/tui/session-transcript.ts:1538`; history, turn, user, assistant, tool, context, token, protocol, error, slash, collab, and plan events.
+- Status-only or state-only events - `session_configured`, `turn_started`, `tool_progress`, `exec_approval_request`, and `request_permissions` primarily drive app state, overlays, status bars, or row updates.
+- Renderer-only legacy events - `runtime/src/tui/session-transcript.ts:2078`; `slash_result` is handled in transcript code but is not in canonical `EventMsg`.
+
+## Status bar & top chrome
+
+### Top Chrome Order
+- Brand bleed - `runtime/src/tui/components/FullscreenLayout.tsx:514`; colored background strip behind top chrome.
+- Header component - `runtime/src/tui/components/v2/primitives.tsx:298`; ordered as brand bar, optional tab status, tab label, mode pill, optional task segment.
+- Brand/cwd segment - `runtime/src/tui/components/v2/primitives.tsx:298`; literal `agenc · <cwd>`.
+- Tab status segment - `runtime/src/tui/components/FullscreenLayout.tsx:523`; `live` or `warn` based on app status.
+- Tab label segment - `runtime/src/tui/components/FullscreenLayout.tsx:528`; literal `agenc · orchestrator`.
+- Mode pill segment - `runtime/src/tui/components/v2/primitives.tsx:172`; color and label from `modeChrome`.
+- Active task segment - `runtime/src/tui/components/FullscreenLayout.tsx:530`; shows `task <taskPda>` when active task data exists.
+
+### Bottom Status Bar Order
+- Bottom chrome component - `runtime/src/tui/components/FullscreenLayout.tsx:547`; renders `mode`, `cwd`, `mcp`, `messages`, and `agents` labels.
+- Status bar primitive - `runtime/src/tui/components/v2/primitives.tsx:385`; draws variant wash, top border, left segments, and right segments.
+- Segment primitive - `runtime/src/tui/components/v2/primitives.tsx:358`; displays label/value with optional accent.
+- Right-hand segments - `runtime/src/tui/components/FullscreenLayout.tsx:535`; include cwd, MCP server count, transcript message count, and active agent/task summary.
+- Context bar - `runtime/src/tui/components/v2/primitives.tsx:435`; separate compact progress bar for context usage when used by callers.
+
+### Mode-pill Color Logic
+- `default` - `runtime/src/tui/components/v2/primitives.tsx:42`; fg `subtle`, label `default`, no wash.
+- `acceptEdits` - `runtime/src/tui/components/v2/primitives.tsx:43`; fg `agenc`, bg `agencWash`, label `accept edits`.
+- `plan` - `runtime/src/tui/components/v2/primitives.tsx:44`; fg `planMode`, bg `planModeWash`, label `plan`.
+- `auto` - `runtime/src/tui/components/v2/primitives.tsx:45`; fg `success`, bg `successWash`, label `auto`.
+- `bypassPermissions` - `runtime/src/tui/components/v2/primitives.tsx:46`; fg `error`, bg `errorWash`, label `bypass perms`.
+- `dontAsk`, `unattended`, `bubble` - `runtime/src/tui/components/v2/primitives.tsx:47`; fg `inactive`, muted internal labels.
+
+## Glyphs & icons
+
+### Glyph Table
+- `"arrowUp"` - unicode `figures.arrowUp`, ascii `^`; up navigation, scroll, and picker hints; source `runtime/src/tui/glyphs.ts:5`.
+- `"arrowDown"` - unicode `figures.arrowDown`, ascii `v`; down navigation and new-message pill; source `runtime/src/tui/glyphs.ts:6`.
+- `"arrowLeft"` - unicode `figures.arrowLeft`, ascii `<`; left navigation and picker panes; source `runtime/src/tui/glyphs.ts:7`.
+- `"arrowRight"` - unicode `figures.arrowRight`, ascii `>`; right navigation and picker panes; source `runtime/src/tui/glyphs.ts:8`.
+- `"enter"` - unicode `↵`, ascii `Enter`; submit/select key hint; source `runtime/src/tui/glyphs.ts:9`.
+- `"ellipsis"` - unicode `…`, ascii `...`; truncated/continuation text; source `runtime/src/tui/glyphs.ts:10`.
+- `"horizontal"` - unicode `─`, ascii `-`; horizontal rules and separators; source `runtime/src/tui/glyphs.ts:11`.
+- `"modalDivider"` - unicode `▔`, ascii `-`; modal divider line; source `runtime/src/tui/glyphs.ts:12`.
+- `"mcpResource"` - unicode `◇`, ascii `*`; MCP resource attachment/icon marker; source `runtime/src/tui/glyphs.ts:13`.
+- `"pointer"` - unicode `figures.pointer`, ascii `>`; prompt pointer, selection pointer, and active row marker; source `runtime/src/tui/glyphs.ts:14`.
+- `"promptBypass"` - unicode `▶`, ascii `>`; bypass-permissions prompt glyph; source `runtime/src/tui/glyphs.ts:15`.
+- `"responseGutter"` - unicode `⎿`, ascii `|_`; assistant/tool result gutter and expanded-result prefix; source `runtime/src/tui/glyphs.ts:16`.
+- `"redactedThinkingPrefix"` - unicode `✻`, ascii `*`; redacted thinking prefix; source `runtime/src/tui/glyphs.ts:17`.
+- `"separator"` - unicode `·`, ascii `-`; inline separator in compact labels; source `runtime/src/tui/glyphs.ts:18`.
+- `"statusError"` - unicode `✗`, ascii `ERR`; error/failure status; source `runtime/src/tui/glyphs.ts:19`.
+- `"statusSuccess"` - unicode `✓`, ascii `OK`; success/done status; source `runtime/src/tui/glyphs.ts:20`.
+- `"spinnerFrames"` - unicode `["·", "✢", "✳", "✶", "✻", "✽"]`, ascii `["-", "\\", "|", "/"]`; animated spinner; source `runtime/src/tui/glyphs.ts:21`.
+- `"spinnerReducedMotionDot"` - unicode `●`, ascii `*`; reduced-motion spinner; source `runtime/src/tui/glyphs.ts:22`.
+- `"statusDot"` - unicode `●`, ascii `*`; live/status dot; source `runtime/src/tui/glyphs.ts:23`.
+- `"thinkingEllipsis"` - unicode `…`, ascii `...`; thinking continuation; source `runtime/src/tui/glyphs.ts:24`.
+- `"thinkingPrefix"` - unicode `∴`, ascii empty string; visible thinking prefix; source `runtime/src/tui/glyphs.ts:25`.
+- `"titleAnimationFrames"` - unicode `["⠂", "⠐"]`, ascii `["*", "+"]`; title/header animation; source `runtime/src/tui/glyphs.ts:26`.
+- `"titleStaticPrefix"` - unicode `✳`, ascii `*`; static title prefix; source `runtime/src/tui/glyphs.ts:27`.
+- `"treeBranch"` - unicode `├─`, ascii `|-`; non-final tree branch; source `runtime/src/tui/glyphs.ts:28`.
+- `"treeContinuation"` - unicode `│`, ascii `|`; tree continuation gutter; source `runtime/src/tui/glyphs.ts:29`.
+- `"treeLast"` - unicode `└─`, ascii `` `-``; final tree branch; source `runtime/src/tui/glyphs.ts:30`.
+- `"treeRoot"` - unicode `┌─`, ascii `.-`; root tree branch; source `runtime/src/tui/glyphs.ts:31`.
+- `"treeSelectedBranch"` - unicode `╞═`, ascii `|>`; selected non-final tree branch; source `runtime/src/tui/glyphs.ts:32`.
+- `"treeSelectedLast"` - unicode `╘═`, ascii `` `>``; selected final tree branch; source `runtime/src/tui/glyphs.ts:33`.
+- `"treeSelectedRoot"` - unicode `╒═`, ascii `.>`; selected root tree branch; source `runtime/src/tui/glyphs.ts:34`.
+- `"voiceCursorBars"` - unicode `" ▁▂▃▄▅▆▇█"`, ascii `" .:-=+*#@"`; voice/audio meter cursor bars; source `runtime/src/tui/glyphs.ts:35`.
+
+### Glyph Mode
+- ASCII mode selector - `runtime/src/tui/glyphs.ts:107`; `AGENC_TUI_GLYPHS=ascii` selects ASCII glyphs, otherwise unicode glyphs.
+- Permission-mode symbol selector - `runtime/src/permissions/mode-display.ts:94`; also respects `AGENC_TUI_GLYPHS=ascii` for mode symbols.
+
+## Theme tokens
+
+### Core Tokens
+- `"autoAccept"` - accept-edits mode and auto-accept affordances; source `runtime/src/utils/theme.ts:5`.
+- `"bashBorder"` - bash-mode prompt border and shell accents; source `runtime/src/utils/theme.ts:6`.
+- `"agenc"` - primary AgenC accent for assistant/chrome; source `runtime/src/utils/theme.ts:7`.
+- `"agencShimmer"` - animated/shimmer primary accent; source `runtime/src/utils/theme.ts:8`.
+- `"agencBlue_FOR_SYSTEM_SPINNER"` - system spinner blue; source `runtime/src/utils/theme.ts:9`.
+- `"agencBlueShimmer_FOR_SYSTEM_SPINNER"` - shimmer variant of system spinner blue; source `runtime/src/utils/theme.ts:10`.
+- `"permission"` - permission prompt accent; source `runtime/src/utils/theme.ts:11`.
+- `"permissionShimmer"` - shimmer permission accent; source `runtime/src/utils/theme.ts:12`.
+- `"planMode"` - plan-mode text/border; source `runtime/src/utils/theme.ts:13`.
+- `"ide"` - IDE integration indicator; source `runtime/src/utils/theme.ts:14`.
+- `"promptBorder"` - normal prompt border; source `runtime/src/utils/theme.ts:15`.
+- `"promptBorderShimmer"` - animated prompt border; source `runtime/src/utils/theme.ts:16`.
+- `"text"` - primary foreground text; source `runtime/src/utils/theme.ts:17`.
+- `"inverseText"` - inverted foreground text; source `runtime/src/utils/theme.ts:18`.
+- `"inactive"` - disabled/muted foreground; source `runtime/src/utils/theme.ts:19`.
+- `"inactiveShimmer"` - animated muted foreground; source `runtime/src/utils/theme.ts:20`.
+- `"subtle"` - secondary foreground; source `runtime/src/utils/theme.ts:21`.
+- `"suggestion"` - suggestions/autocomplete text; source `runtime/src/utils/theme.ts:22`.
+- `"remember"` - memory/remember accent; source `runtime/src/utils/theme.ts:23`.
+- `"background"` - base terminal background; source `runtime/src/utils/theme.ts:24`.
+- `"success"` - success/done foreground; source `runtime/src/utils/theme.ts:25`.
+- `"error"` - error/destructive foreground; source `runtime/src/utils/theme.ts:26`.
+- `"warning"` - warning foreground; source `runtime/src/utils/theme.ts:27`.
+- `"merged"` - merged/diff status foreground; source `runtime/src/utils/theme.ts:28`.
+- `"warningShimmer"` - animated warning foreground; source `runtime/src/utils/theme.ts:29`.
+- `"diffAdded"` - added diff line; source `runtime/src/utils/theme.ts:30`.
+- `"diffRemoved"` - removed diff line; source `runtime/src/utils/theme.ts:31`.
+- `"diffAddedDimmed"` - dim added diff line; source `runtime/src/utils/theme.ts:32`.
+- `"diffRemovedDimmed"` - dim removed diff line; source `runtime/src/utils/theme.ts:33`.
+- `"diffAddedWord"` - added diff word highlight; source `runtime/src/utils/theme.ts:34`.
+- `"diffRemovedWord"` - removed diff word highlight; source `runtime/src/utils/theme.ts:35`.
+- `"red_FOR_SUBAGENTS_ONLY"` - sub-agent red color; source `runtime/src/utils/theme.ts:36`.
+- `"blue_FOR_SUBAGENTS_ONLY"` - sub-agent blue color; source `runtime/src/utils/theme.ts:37`.
+- `"green_FOR_SUBAGENTS_ONLY"` - sub-agent green color; source `runtime/src/utils/theme.ts:38`.
+- `"yellow_FOR_SUBAGENTS_ONLY"` - sub-agent yellow color; source `runtime/src/utils/theme.ts:39`.
+- `"purple_FOR_SUBAGENTS_ONLY"` - sub-agent purple color; source `runtime/src/utils/theme.ts:40`.
+- `"orange_FOR_SUBAGENTS_ONLY"` - sub-agent orange color; source `runtime/src/utils/theme.ts:41`.
+- `"pink_FOR_SUBAGENTS_ONLY"` - sub-agent pink color; source `runtime/src/utils/theme.ts:42`.
+- `"cyan_FOR_SUBAGENTS_ONLY"` - sub-agent cyan color; source `runtime/src/utils/theme.ts:43`.
+- `"professionalBlue"` - professional blue accent; source `runtime/src/utils/theme.ts:47`.
+- `"chromeYellow"` - chrome/yellow accent; source `runtime/src/utils/theme.ts:48`.
+
+### V2 And Surface Tokens
+- `"clawd_body"` - inherited body text token; source `runtime/src/utils/theme.ts:52`.
+- `"clawd_background"` - inherited background token; source `runtime/src/utils/theme.ts:53`.
+- `"surfaceBackground"` - V2 panel/surface background; source `runtime/src/utils/theme.ts:56`.
+- `"userMessageBackground"` - V2 user-message background; source `runtime/src/utils/theme.ts:57`.
+- `"userMessageBackgroundHover"` - V2 user-message hover background; source `runtime/src/utils/theme.ts:58`.
+- `"messageActionsBackground"` - V2 message-actions background; source `runtime/src/utils/theme.ts:59`.
+- `"selectionBg"` - V2 selected row background; source `runtime/src/utils/theme.ts:60`.
+- `"bashMessageBackgroundColor"` - V2 bash-message background; source `runtime/src/utils/theme.ts:61`.
+- `"agencWash"` - V2 primary accent wash; source `runtime/src/utils/theme.ts:62`.
+- `"worker"` - V2 worker/secondary accent; source `runtime/src/utils/theme.ts:63`.
+- `"workerWash"` - V2 worker wash; source `runtime/src/utils/theme.ts:64`.
+- `"successWash"` - V2 success wash; source `runtime/src/utils/theme.ts:65`.
+- `"errorWash"` - V2 error/destructive wash; source `runtime/src/utils/theme.ts:66`.
+- `"text2"` - V2 secondary text; source `runtime/src/utils/theme.ts:67`.
+- `"muted3"` - V2 tertiary muted text; source `runtime/src/utils/theme.ts:68`.
+- `"line"` - V2 hard divider line; source `runtime/src/utils/theme.ts:69`.
+- `"lineSoft"` - V2 soft divider line; source `runtime/src/utils/theme.ts:70`.
+- `"briefLabelWorker"` - V2 worker brief label; source `runtime/src/utils/theme.ts:71`.
+- `"planModeWash"` - V2 plan-mode wash; source `runtime/src/utils/theme.ts:72`.
+
+### Specialized Tokens
+- `"memoryBackgroundColor"` - memory row/background; source `runtime/src/utils/theme.ts:78`.
+- `"rate_limit_fill"` - rate-limit progress fill; source `runtime/src/utils/theme.ts:79`.
+- `"rate_limit_empty"` - rate-limit progress empty track; source `runtime/src/utils/theme.ts:80`.
+- `"fastMode"` - fast-mode accent; source `runtime/src/utils/theme.ts:82`.
+- `"fastModeShimmer"` - fast-mode shimmer accent; source `runtime/src/utils/theme.ts:83`.
+- `"briefLabelYou"` - brief-mode user label; source `runtime/src/utils/theme.ts:85`.
+- `"briefLabelAgenC"` - brief-mode assistant label; source `runtime/src/utils/theme.ts:86`.
+- `"rainbow_red"` - rainbow accent red; source `runtime/src/utils/theme.ts:88`.
+- `"rainbow_orange"` - rainbow accent orange; source `runtime/src/utils/theme.ts:89`.
+- `"rainbow_yellow"` - rainbow accent yellow; source `runtime/src/utils/theme.ts:90`.
+- `"rainbow_green"` - rainbow accent green; source `runtime/src/utils/theme.ts:91`.
+- `"rainbow_blue"` - rainbow accent blue; source `runtime/src/utils/theme.ts:92`.
+- `"rainbow_indigo"` - rainbow accent indigo; source `runtime/src/utils/theme.ts:93`.
+- `"rainbow_violet"` - rainbow accent violet; source `runtime/src/utils/theme.ts:94`.
+- `"rainbow_red_shimmer"` - rainbow shimmer red; source `runtime/src/utils/theme.ts:95`.
+- `"rainbow_orange_shimmer"` - rainbow shimmer orange; source `runtime/src/utils/theme.ts:96`.
+- `"rainbow_yellow_shimmer"` - rainbow shimmer yellow; source `runtime/src/utils/theme.ts:97`.
+- `"rainbow_green_shimmer"` - rainbow shimmer green; source `runtime/src/utils/theme.ts:98`.
+- `"rainbow_blue_shimmer"` - rainbow shimmer blue; source `runtime/src/utils/theme.ts:99`.
+- `"rainbow_indigo_shimmer"` - rainbow shimmer indigo; source `runtime/src/utils/theme.ts:100`.
+- `"rainbow_violet_shimmer"` - rainbow shimmer violet; source `runtime/src/utils/theme.ts:101`.
+
+## Keybindings
+
+### Global
+- `"ctrl+c"` -> `"app:interrupt"`; source `runtime/src/tui/keybindings/defaultBindings.ts:37`.
+- `"ctrl+d"` -> `"app:exit"`; source `runtime/src/tui/keybindings/defaultBindings.ts:42`.
+- `"ctrl+l"` -> `"app:redraw"`; source `runtime/src/tui/keybindings/defaultBindings.ts:47`.
+- `"ctrl+t"` -> `"app:toggleTodos"`; source `runtime/src/tui/keybindings/defaultBindings.ts:52`.
+- `"ctrl+o"` -> `"app:toggleTranscript"`; source `runtime/src/tui/keybindings/defaultBindings.ts:57`.
+- `"ctrl+shift+b"` -> `"app:toggleBrief"` when available; source `runtime/src/tui/keybindings/defaultBindings.ts:64`.
+- `"ctrl+shift+o"` -> `"app:toggleTeammatePreview"` when available; source `runtime/src/tui/keybindings/defaultBindings.ts:64`.
+- `"ctrl+r"` -> `"history:search"`; source `runtime/src/tui/keybindings/defaultBindings.ts:64`.
+- `"ctrl+shift+f"`/`"cmd+shift+f"` -> `"app:globalSearch"` when available; source `runtime/src/tui/keybindings/defaultBindings.ts:64`.
+- `"ctrl+shift+p"`/`"cmd+shift+p"` -> `"app:quickOpen"` when available; source `runtime/src/tui/keybindings/defaultBindings.ts:64`.
+- `"meta+j"` -> `"app:toggleTerminal"` when available; source `runtime/src/tui/keybindings/defaultBindings.ts:64`.
+
+### Composer
+- `"escape"` -> `"composer:escape"`; source `runtime/src/tui/keybindings/defaultBindings.ts:67`.
+- `"ctrl+x ctrl+k"` -> `"composer:clear"`; source `runtime/src/tui/keybindings/defaultBindings.ts:72`.
+- `"shift+tab"` or terminal-specific mode cycle key -> `"composer:cycleMode"`; source `runtime/src/tui/keybindings/defaultBindings.ts:77`.
+- `"meta+p"` -> `"composer:insertPath"`; source `runtime/src/tui/keybindings/defaultBindings.ts:82`.
+- `"meta+o"` -> `"composer:toggleOpen"`; source `runtime/src/tui/keybindings/defaultBindings.ts:87`.
+- `"meta+t"` -> `"composer:toggleTerminal"`; source `runtime/src/tui/keybindings/defaultBindings.ts:92`.
+- `"enter"` -> `"composer:submit"`; source `runtime/src/tui/keybindings/defaultBindings.ts:94`.
+- `"up"` -> `"composer:historyPrev"`; source `runtime/src/tui/keybindings/defaultBindings.ts:94`.
+- `"down"` -> `"composer:historyNext"`; source `runtime/src/tui/keybindings/defaultBindings.ts:94`.
+- `"ctrl+_"`/`"ctrl+shift+-"` -> `"composer:undo"`; source `runtime/src/tui/keybindings/defaultBindings.ts:94`.
+- `"ctrl+x ctrl+e"` -> `"composer:externalEditor"`; source `runtime/src/tui/keybindings/defaultBindings.ts:94`.
+- `"ctrl+g"` -> `"composer:openPlanFile"`; source `runtime/src/tui/keybindings/defaultBindings.ts:94`.
+- `"ctrl+s"` -> `"composer:save"`; source `runtime/src/tui/keybindings/defaultBindings.ts:94`.
+- `"ctrl+v"` or `"alt+v"` -> `"composer:pasteImage"`; source `runtime/src/tui/keybindings/defaultBindings.ts:94`.
+- `"shift+up"` -> `"composer:multilineUp"` when available; source `runtime/src/tui/keybindings/defaultBindings.ts:94`.
+
+### Autocomplete And Select
+- `"tab"` -> `"autocomplete:accept"`; source `runtime/src/tui/keybindings/defaultBindings.ts:97`.
+- `"escape"` -> `"autocomplete:cancel"`; source `runtime/src/tui/keybindings/defaultBindings.ts:102`.
+- `"up"` -> `"autocomplete:previous"`; source `runtime/src/tui/keybindings/defaultBindings.ts:103`.
+- `"down"` -> `"autocomplete:next"`; source `runtime/src/tui/keybindings/defaultBindings.ts:103`.
+- `"up"`/`"ctrl+p"` -> `"select:previous"`; source `runtime/src/tui/keybindings/defaultBindings.ts:317`.
+- `"down"`/`"ctrl+n"` -> `"select:next"`; source `runtime/src/tui/keybindings/defaultBindings.ts:322`.
+- `"return"` -> `"select:confirm"`; source `runtime/src/tui/keybindings/defaultBindings.ts:327`.
+
+### Confirmation
+- `"y"` -> `"confirm:yes"`; source `runtime/src/tui/keybindings/defaultBindings.ts:128`.
+- `"n"` -> `"confirm:no"`; source `runtime/src/tui/keybindings/defaultBindings.ts:133`.
+- `"a"` -> `"confirm:always"`; source `runtime/src/tui/keybindings/defaultBindings.ts:138`.
+- `"escape"` -> `"confirm:cancel"`; source `runtime/src/tui/keybindings/defaultBindings.ts:143`.
+- `"return"` -> `"confirm:submit"`; source `runtime/src/tui/keybindings/defaultBindings.ts:145`.
+
+### Tabs, Transcript, And Scroll
+- `"tab"` -> `"tabs:next"`; source `runtime/src/tui/keybindings/defaultBindings.ts:148`.
+- `"shift+tab"` -> `"tabs:previous"`; source `runtime/src/tui/keybindings/defaultBindings.ts:153`.
+- `"ctrl+o"` -> `"transcript:toggle"`; source `runtime/src/tui/keybindings/defaultBindings.ts:158`.
+- `"ctrl+f"` -> `"transcript:search"`; source `runtime/src/tui/keybindings/defaultBindings.ts:163`.
+- `"pageup"` -> `"scroll:pageUp"`; source `runtime/src/tui/keybindings/defaultBindings.ts:193`.
+- `"pagedown"` -> `"scroll:pageDown"`; source `runtime/src/tui/keybindings/defaultBindings.ts:198`.
+- `"home"` -> `"scroll:top"`; source `runtime/src/tui/keybindings/defaultBindings.ts:203`.
+- `"end"` -> `"scroll:bottom"`; source `runtime/src/tui/keybindings/defaultBindings.ts:208`.
+
+### Modal Contexts
+- History search `"escape"` -> `"history:cancel"`; source `runtime/src/tui/keybindings/defaultBindings.ts:169`.
+- History search `"return"` -> `"history:select"`; source `runtime/src/tui/keybindings/defaultBindings.ts:174`.
+- Task `"ctrl+b"` -> `"task:background"`; source `runtime/src/tui/keybindings/defaultBindings.ts:179`.
+- Theme picker `"escape"` -> `"theme:cancel"`; source `runtime/src/tui/keybindings/defaultBindings.ts:187`.
+- Help `"escape"` -> `"help:close"`; source `runtime/src/tui/keybindings/defaultBindings.ts:212`.
+- Attachments `"delete"` -> `"attachment:remove"`; source `runtime/src/tui/keybindings/defaultBindings.ts:219`.
+- Attachments `"return"` -> `"attachment:open"`; source `runtime/src/tui/keybindings/defaultBindings.ts:224`.
+- Footer `"left"` -> `"footer:previous"`; source `runtime/src/tui/keybindings/defaultBindings.ts:231`.
+- Footer `"right"` -> `"footer:next"`; source `runtime/src/tui/keybindings/defaultBindings.ts:236`.
+- Footer `"return"` -> `"footer:activate"`; source `runtime/src/tui/keybindings/defaultBindings.ts:241`.
+
+### Message Selector, Diff, Model, Plugin
+- Message selector `"j"`/`"down"` -> `"messageSelector:next"`; source `runtime/src/tui/keybindings/defaultBindings.ts:246`.
+- Message selector `"k"`/`"up"` -> `"messageSelector:previous"`; source `runtime/src/tui/keybindings/defaultBindings.ts:251`.
+- Message selector `"return"` -> `"messageSelector:select"`; source `runtime/src/tui/keybindings/defaultBindings.ts:256`.
+- Message selector `"escape"` -> `"messageSelector:cancel"`; source `runtime/src/tui/keybindings/defaultBindings.ts:261`.
+- Diff dialog `"escape"` -> `"diff:close"`; source `runtime/src/tui/keybindings/defaultBindings.ts:296`.
+- Diff dialog `"return"` -> `"diff:confirm"`; source `runtime/src/tui/keybindings/defaultBindings.ts:301`.
+- Model picker `"left"` -> `"model:effortDown"`; source `runtime/src/tui/keybindings/defaultBindings.ts:309`.
+- Model picker `"right"` -> `"model:effortUp"`; source `runtime/src/tui/keybindings/defaultBindings.ts:313`.
+- Plugin `"return"` -> `"plugin:open"`; source `runtime/src/tui/keybindings/defaultBindings.ts:332`.
+- Plugin `"escape"` -> `"plugin:close"`; source `runtime/src/tui/keybindings/defaultBindings.ts:336`.
+
+### Reserved
+- Non-rebindable `"ctrl+c"`, `"ctrl+d"`, `"ctrl+m"` - source `runtime/src/tui/keybindings/reservedShortcuts.ts:16`.
+- Terminal-reserved `"ctrl+z"` and `"ctrl+\\"` - source `runtime/src/tui/keybindings/reservedShortcuts.ts:43`.
+- macOS-reserved `"cmd+c"`, `"cmd+v"`, `"cmd+x"`, `"cmd+q"`, `"cmd+w"`, `"cmd+tab"`, `"cmd+space"` - source `runtime/src/tui/keybindings/reservedShortcuts.ts:59`.
+
+## Message kinds & renderers
+
+### Transcript Containers
+- Messages list - `runtime/src/tui/components/Messages.tsx:523`; routes rows, unseen divider, search/filter state, and static vs dynamic rendering.
+- Message row - `runtime/src/tui/components/MessageRow.tsx:93`; applies row padding, streaming state, grouping, and transcript metadata.
+- Static-render switch - `runtime/src/tui/components/Messages.tsx:688`; statically renders attachments, user/assistant/system text, grouped tool use, and collapsed read/search content.
+
+### User Messages
+- User prompt - `runtime/src/tui/message-renderers/UserPromptMessage.tsx:53`; v2 `Msg role="user"`, user background, truncation, and hover/action background.
+- User text - `runtime/src/tui/message-renderers/UserTextMessage.tsx:1`; plain user text renderer.
+- User local command output - `runtime/src/tui/message-renderers/UserLocalCommandOutputMessage.tsx:1`; local command output row.
+- User bash output - `runtime/src/tui/message-renderers/UserBashOutputMessage.tsx:1`; user-originated shell output row.
+- User cross-session row - `runtime/src/tui/message-renderers/UserCrossSessionMessage.tsx:1`; cross-session user context.
+- User teammate row - `runtime/src/tui/message-renderers/UserTeammateMessage.tsx:1`; teammate-originated message row.
+- User fork boilerplate - `runtime/src/tui/message-renderers/UserForkBoilerplateMessage.tsx:1`; fork/session boilerplate row.
+- User GitHub webhook - `runtime/src/tui/message-renderers/UserGitHubWebhookMessage.tsx:1`; GitHub webhook-originated user context.
+
+### Assistant And System Messages
+- Assistant text - `runtime/src/tui/message-renderers/AssistantTextMessage.tsx:48`; v2 `Msg role="agenc"`, special API/error text handling, assistant chrome.
+- Highlighted thinking text - `runtime/src/tui/message-renderers/HighlightedThinkingText.tsx:1`; thinking block highlighting.
+- Assistant tool use - `runtime/src/tui/message-renderers/AssistantToolUseMessage.tsx:48`; tool call label, pending/running/done state, progress, permission, and expanded result slot.
+- System text - `runtime/src/tui/message-renderers/SystemTextMessage.tsx:67`; dispatches protocol, duration, memory, away summary, agent kill, bridge status, scheduled task, permission retry, API error, hook summary, and generic info/warn/error.
+- Protocol system message - `runtime/src/tui/message-renderers/SystemTextMessage.tsx:534`; wraps v2 `ProtocolEvent`.
+- Collab agent system message - `runtime/src/tui/message-renderers/SystemTextMessage.tsx:571`; dot state colors, title/detail, and `⎿` gutter.
+- Shutdown message - `runtime/src/tui/message-renderers/ShutdownMessage.tsx:1`; shutdown summary row.
+- Advisor message - `runtime/src/tui/message-renderers/AdvisorMessage.tsx:20`; server/advisor result, error, redacted, and result rows.
+- Hook progress message - `runtime/src/tui/message-renderers/HookProgressMessage.tsx:1`; hook execution progress.
+
+### Tool And Attachment Messages
+- Tool success result - `runtime/src/tui/message-renderers/UserToolResultMessage/UserToolSuccessMessage.tsx:58`; success tick, rendered result content, and empty-name plain assistant fallback.
+- Tool reject result - `runtime/src/tui/message-renderers/UserToolResultMessage/UserToolRejectMessage.tsx:21`; rejected/canceled tool output.
+- Tool result root - `runtime/src/tui/message-renderers/UserToolResultMessage/UserToolResultMessage.tsx:43`; dispatches tool result variants.
+- Grouped tool use - `runtime/src/tui/message-renderers/GroupedToolUseContent.tsx:1`; groups related tool rows.
+- Collapsed read/search content - `runtime/src/tui/message-renderers/CollapsedReadSearchContent.tsx:142`; compact rows for read/search output.
+- Attachment message - `runtime/src/tui/message-renderers/AttachmentMessage.tsx:41`; renders files, directories, notebooks, IDE lines, memory, skills, agents, queued commands, plan files, diagnostics, MCP resources, permissions, hooks, task status, and teammate shutdown batches.
+- Diagnostics attachment - `runtime/src/tui/components/DiagnosticsDisplay.tsx:17`; verbose or compact diagnostics from attachment renderer.
+- Snip boundary - `runtime/src/tui/message-renderers/SnipBoundaryMessage.tsx:1`; compaction/snip visual boundary.
+- Task assignment message - `runtime/src/tui/message-renderers/TaskAssignmentMessage.tsx:1`; task assignment row.
+
+### Special Chrome Rules
+- V2 role colors - `runtime/src/tui/components/v2/primitives.tsx:838`; `user`, `agenc`, `worker`, and `system` roles use distinct color/glyph choices.
+- V2 tool card - `runtime/src/tui/components/v2/primitives.tsx:871`; uses `⎿` gutter, status glyphs, expanded border, and result area.
+- Tool glyph states - `runtime/src/tui/components/v2/primitives.tsx:85`; `queued` `○`, `running` `◐`, `done` `●`, `failed` `✕`.
+- Attachment diagnostics toggle hint - `runtime/src/tui/components/DiagnosticsDisplay.tsx:73`; compact diagnostics mention `Ctrl+O` for details.
+
+## Special inline states
+
+### Prompt And Composer States
+- Bash mode - `runtime/src/tui/components/PromptInput/PromptInputModeIndicator.tsx:71`; triggered by shell-mode input; shows `!`, `bashBorder`, shell progress, and bash output.
+- Bash progress - `runtime/src/tui/components/BashModeProgress.tsx:15`; triggered while shell command is running; shows command and progress text.
+- Paste confirmation - `runtime/src/tui/components/PasteConfirmDialog.tsx:27`; triggered by risky paste into bash/composer; shows yes/no/enter/esc controls.
+- Plan mode banner - `runtime/src/tui/components/FullscreenLayout.tsx:509`; triggered by permission mode `plan`; shows plan-mode notice and changes mode tint.
+- Auto mode opt-in - `runtime/src/tui/components/AutoModeOptInDialog.tsx:17`; triggered before enabling auto; asks to confirm auto behavior.
+- Fast mode - `runtime/src/tui/components/PromptInput/PromptInput.tsx:151`; triggered by fast-mode toggle; shows `FastModePicker` and `FastIcon`.
+- Voice mode - `runtime/src/tui/realtime/RealtimePanel.tsx:68`; triggered by realtime session; shows mic/PTT/meter/transcript/errors.
+- IDE indicator - `runtime/src/tui/components/IdeStatusIndicator.tsx:14`; triggered by IDE connection, selected lines, or active file.
+
+### Pickers And Search
+- File/quick picker - `runtime/src/tui/components/QuickOpenDialog.tsx:46`; triggered by quick-open key; shows fuzzy targets.
+- Global search - `runtime/src/tui/components/GlobalSearchDialog.tsx:70`; triggered by search key; shows fuzzy global results.
+- History search - `runtime/src/tui/history/HistorySearchDialog.tsx:29`; triggered by `ctrl+r`; shows prompt history.
+- Model picker - `runtime/src/tui/components/ModelPicker.tsx:41`; triggered by model selection; shows model list and effort adjustment.
+- Message selector - `runtime/src/tui/components/MessageSelector.tsx:92`; triggered by transcript selection; shows message restore/select UI.
+- Slash palette - `runtime/src/tui/components/v2/primitives.tsx:1288`; triggered by slash input; shows command list and navigation hints.
+
+### Runtime States
+- Background tasks strip - `runtime/src/tui/components/tasks/BackgroundTaskStatus.tsx:25`; triggered by active background tasks; shows task pills and arrow hint.
+- Completion pipeline rows - `runtime/src/tui/components/App.tsx:2312`; triggered during completion pipeline activity; renders progress rows in scroll content.
+- Render health warning - `runtime/src/tui/components/App.tsx:908`; triggered by render/FPS health state; shows concise warning row.
+- Backpressure warning - `runtime/src/tui/components/App.tsx:2357`; triggered by input/output backpressure; appears above prompt.
+- Cost threshold - `runtime/src/tui/components/dialogs/CostThresholdDialog.tsx:39`; triggered by cost guard; shows continue/cancel.
+- Rate limit - `runtime/src/tui/components/dialogs/RateLimitMessage.tsx:75`; triggered by rate-limit errors; shows reset/upsell info.
+
+## Configuration surfaces
+
+### `/model`
+- Command - `runtime/src/commands/model.ts:294`; opens model switcher unless direct args are handled inline.
+- UI - `runtime/src/commands/model-menu.tsx:310`; rows show provider/model status, configured state, and selection state.
+- Data - `runtime/src/commands/model-menu.tsx:55`; reads config, session selection, app state model, and settings source.
+- Editable fields - provider/model selection and effort through `ModelPicker` at `runtime/src/tui/components/ModelPicker.tsx:41`.
+
+### `/hooks`
+- Command - `runtime/src/commands/hooks.ts:296`; opens hooks menu or unavailable state.
+- UI - `runtime/src/commands/hooks-menu.tsx:427`; list/detail/edit-test surfaces with hook state.
+- Data - `runtime/src/commands/hooks-menu.tsx:896`; reads `config.hooks`.
+- Fields - event, matcher, enabled, type, timeout, source, command from `runtime/src/commands/hooks-menu.tsx:312`; edit-test fields from `runtime/src/commands/hooks-menu.tsx:217`.
+
+### `/skills`
+- Command - `runtime/src/commands/skills.ts:375`; opens skill browser or handles skill creation paths.
+- UI - `runtime/src/commands/skills-menu.tsx:99`; list of skills/roots and detail panel.
+- Data - `runtime/src/commands/skills-menu.tsx:139`; roots and skill metadata from skill discovery.
+- Fields - mostly browse/open; new-skill creation template path starts at `runtime/src/commands/skills.ts:202`.
+
+### `/mcp`
+- Command - `runtime/src/commands/mcp.ts:700`; supports `status`, `tools [server]`, `reconnect`, `enable`, `disable`, `new`, and `add`.
+- UI - `runtime/src/commands/mcp-menu.tsx:295`; list/tools/tool/form modes.
+- Data - `runtime/src/commands/mcp-menu.tsx:32`; form fields include `serverName` and `commandLine`; tool detail includes `serverName`, `toolName`, and `description`.
+- Editable fields - add-server form at `runtime/src/commands/mcp-menu.tsx:226`; save/create path at `runtime/src/commands/mcp-menu.tsx:361`.
+
+### `/permissions`
+- Command - `runtime/src/commands/permissions.ts:608`; aliases `approvals`, `allowed-tools`.
+- UI - `runtime/src/commands/permissions.ts:625`; permission mode and rule table.
+- Data - `runtime/src/permissions/types.ts:350`; mode, directories, allow/deny/ask rules, bypass availability, stripped dangerous rules, and auto-mode availability.
+- Editable fields - user-facing permission modes from `runtime/src/permissions/types.ts:54`; allow/deny/ask rule maps from `runtime/src/permissions/types.ts:350`.
+
+### `/memory`
+- Command - `runtime/src/commands/memory/slash.ts:18`; opens memory picker/editor launcher.
+- UI - `runtime/src/commands/memory/memory.tsx:195`; modal with memory targets and open/create actions.
+- Data - user memory path from `runtime/src/commands/memory/memory.tsx:206`; project memory path from `runtime/src/commands/memory/memory.tsx:207`; auto memory from `runtime/src/commands/memory/memory.tsx:217`; agent memory directory from `runtime/src/commands/memory/memory.tsx:222`.
+- Editable fields - underlying Markdown files/folders opened externally by actions from `runtime/src/commands/memory/memory.tsx:86`.
+
+### `/plugins`
+- Command - `runtime/src/commands/plugins.tsx:200`; aliases `plugin`, `marketplace`.
+- UI - `runtime/src/commands/plugins.tsx:104`; loaded plugin/marketplace menu.
+- Data - plugin registry/state supplied to `openPluginsMenu` at `runtime/src/commands/plugins.tsx:181`.
+- Editable fields - no static in-TUI config editor pinned; plugin-specific commands can expose their own dynamic surfaces.
+
+### `/agents`
+- Command - `runtime/src/commands/agent-management.tsx:19`; opens agent management modal.
+- UI - `runtime/src/commands/agents-menu.tsx:591`; list/detail/create/edit/delete modes.
+- Data - agent file frontmatter fields from `runtime/src/tui/components/agents/agentFileUtils.ts:20`; storage roots from `runtime/src/tui/components/agents/agentFileUtils.ts:60`.
+- Editable fields - source, agent type, when-to-use, tools, model, system prompt, and save action from `runtime/src/commands/agents-menu.tsx:260`.
+- Persistence - create/update/delete agent files through `runtime/src/tui/components/agents/agentFileUtils.ts:166`.
+
+### Other Config-visible Surfaces
+- `/config` - `runtime/src/commands/config.ts:275`; config dashboard at `runtime/src/commands/config-menu.tsx:268`; shows agenc home, config files, tools, providers, agents, MCP, permissions, hooks, and environment-derived status.
+- `/provider` - `runtime/src/commands/provider.ts:189`; provider auth/config menu at `runtime/src/commands/provider-menu.tsx:586`; shows provider, model, auth, base URL, configured state, websocket, and model count.
+- `/status` - `runtime/src/commands/status.ts:287`; read-only status dashboard at `runtime/src/commands/status-menu.tsx:172`.
+
+## On-chain protocol surface
+
+### Slash Commands
+- Protocol command factory - `runtime/src/commands/protocol.ts:49`; marks protocol commands as `source: "plugin"` and `kind: "protocol"`.
+- `/claim` - `runtime/src/commands/protocol.ts:66`; inline protocol command; currently agnostic to visible chain-state screen.
+- `/delegate` - `runtime/src/commands/protocol.ts:67`; inline protocol command; currently agnostic to visible chain-state screen.
+- `/proof` - `runtime/src/commands/protocol.ts:68`; inline protocol command; currently agnostic to visible chain-state screen.
+- `/settle` - `runtime/src/commands/protocol.ts:70`; inline protocol command; high-risk typed gate can apply if routed through permissioned tool text.
+- `/stake` - `runtime/src/commands/protocol.ts:72`; inline protocol command; high-risk typed gate can apply if routed through permissioned tool text.
+
+### Protocol Events
+- Claim payload - `runtime/src/session/event-log.ts:297`; includes task/claim fields for `protocol_claim`.
+- Settle payload - `runtime/src/session/event-log.ts:309`; includes task/settle fields for `protocol_settle`.
+- Slash payload - `runtime/src/session/event-log.ts:322`; includes task/slash fields for `protocol_slash`.
+- Stake payload - `runtime/src/session/event-log.ts:335`; includes stake fields for `protocol_stake`.
+- Transcript conversion - `runtime/src/tui/session-transcript.ts:422`; turns protocol events into system messages.
+- Protocol formatter - `runtime/src/tui/session-transcript.ts:688`; formats claim, settle, slash, and stake text/details.
+- Protocol card - `runtime/src/tui/components/v2/primitives.tsx:1382`; renders `claim`, `settle`, `slash`, and `stake` cards with success/error/worker variants.
+
+### Approval And Chain-risk Gate
+- High-risk detector - `runtime/src/tui/permission-requests.tsx:302`; matches `mainnet`, `settle`, `stake`, `transfer`, `slash`, `escrow`, and `solana transfer`.
+- Typed word selector - `runtime/src/tui/permission-requests.tsx:312`; uses `settle`, `stake`, `transfer`, or `yes`.
+- Protocol approval facts - `runtime/src/tui/permission-requests.tsx:389`; high-risk cards show `scope: mainnet / protocol`.
+- Approval card visuals - `runtime/src/tui/components/v2/primitives.tsx:1059`; high-risk protocol approvals use `errorWash`, command block, facts, and typed confirmation hint.
+
+### Chain-state Chrome
+- Welcome wallet/stake/rep/slashed fields - `runtime/src/tui/components/v2/primitives.tsx:680`; V2 welcome panel defaults include wallet, stake, rep, and slashed counts.
+- Welcome chain rows - `runtime/src/tui/components/v2/primitives.tsx:723`; visible network/wallet/stake/rep/slashed rows.
+- Task in-flight card - `runtime/src/tui/components/v2/primitives.tsx:785`; shows task PDA, escrow, deadline, and approval shortcuts.
+- Header active task PDA - `runtime/src/tui/components/FullscreenLayout.tsx:530`; displays active task PDA in top chrome.
+- Chain gating status - protocol event cards are gated by emitted protocol events; typed-confirmation gate is gated by high-risk text/tool content; welcome/task panels are design/state display surfaces and not themselves command gates.
+
+## Anything I missed
+
+### Miscellaneous And Notable
+- Auto-updater - `runtime/src/tui/components/AutoUpdater.tsx:24`; update check interval, updating state, success, failure, and install messaging.
+- IDE onboarding - `runtime/src/tui/components/IdeOnboardingDialog.tsx:25`; separate onboarding flow from the main welcome screen.
+- Exit confirmation/worktree cleanup - `runtime/src/tui/components/ExitFlow.tsx:17`; can route to `WorktreeExitDialog` at `runtime/src/tui/components/WorktreeExitDialog.tsx:35`.
+- Diagnostics display - `runtime/src/tui/components/DiagnosticsDisplay.tsx:17`; compact and verbose diagnostics visible through attachments.
+- Rate-limit display - `runtime/src/tui/components/dialogs/RateLimitMessage.tsx:75`; error/upsell/reset panel for API limits.
+- Token warning - `runtime/src/tui/cost/TokenWarning.tsx:16`; context usage warning before hard failure.
+- Render/FPS health warning - `runtime/src/tui/components/App.tsx:908`; shows when render health degrades.
+- Backpressure warning - `runtime/src/tui/components/App.tsx:2357`; visible above prompt when app backpressure exists.
+- Bridge status system row - `runtime/src/tui/message-renderers/SystemTextMessage.tsx:153`; visible bridge status in transcript.
+- Scheduled task fire row - `runtime/src/tui/message-renderers/SystemTextMessage.tsx:165`; visible scheduled-task event.
+- Permission retry row - `runtime/src/tui/message-renderers/SystemTextMessage.tsx:187`; visible retry/challenge state after permission issues.
+- Stop hook summary row - `runtime/src/tui/message-renderers/SystemTextMessage.tsx:248`; visible hook summary.
+- MCP resource attachment - `runtime/src/tui/message-renderers/AttachmentMessage.tsx:252`; shows MCP resource references with `mcpResource` glyph.
+- Command permissions attachment - `runtime/src/tui/message-renderers/AttachmentMessage.tsx:257`; shows command permission context in transcript.
+- Team memory collapsed/saved rows - `runtime/src/tui/message-renderers/teamMemCollapsed.tsx:1`; visible team memory summaries.
+
+## Coverage Notes
+- I searched the TUI entry points, `runtime/src/tui/components/App.tsx`, `runtime/src/tui/components/FullscreenLayout.tsx`, `runtime/src/tui/components/v2/`, `runtime/src/tui/message-renderers/`, slash-command registry, command files, tool registry, permission types, event log, glyphs, theme tokens, and keybindings.
+- Local project instruction files `GOAL_DISCIPLINE.md`, `PORT_CHECKLIST.md`, and `.agenc/AGENC.md` were not present in this checkout when checked; this report is based on source code.
+- Dynamic plugin slash commands are runtime-discovered in `runtime/src/commands.ts:403`; only the static built-ins and protocol commands can be fully enumerated from source.
+- Dynamic MCP tools use `mcp__<server>__<tool>` names from connected servers; static source only pins the namespace and rendering behavior.
+- Model/provider catalogs depend on runtime config and environment; the report maps the menus and fields, not every possible model value.
+- `runtime/src/tui/session-transcript.ts:2078` handles renderer-only event names such as `slash_result` that are not listed in canonical `EventMsg` in `runtime/src/session/event-log.ts:533`.
+- Some design-system V2 chain panels display wallet/task/escrow fields, but command gating in inspected code is event/approval driven rather than a separate chain-state screen gate.

--- a/runtime/src/services/mcp/agencai.ts
+++ b/runtime/src/services/mcp/agencai.ts
@@ -1,0 +1,16 @@
+import { getGlobalConfig, saveGlobalConfig } from '../../utils/config.js'
+
+export function hasAgenCAiMcpEverConnected(name: string): boolean {
+  return getGlobalConfig().agencAiMcpEverConnected?.includes(name) ?? false
+}
+
+export function markAgenCAiMcpConnected(name: string): void {
+  saveGlobalConfig(current => {
+    const connected = current.agencAiMcpEverConnected ?? []
+    if (connected.includes(name)) return current
+    return {
+      ...current,
+      agencAiMcpEverConnected: [...connected, name],
+    }
+  })
+}

--- a/runtime/src/services/mcp/client.ts
+++ b/runtime/src/services/mcp/client.ts
@@ -123,10 +123,7 @@ import {
   hasMcpDiscoveryButNoToken,
   wrapFetchWithStepUpDetection,
 } from './auth.js'
-// Donor remote-MCP connection tracking removed in the upstream-backend
-// purge. Stub keeps the call sites compiling without reaching a service
-// that doesn't exist.
-const markAgenCAiMcpConnected = (_name: string): void => {}
+import { markAgenCAiMcpConnected } from './agencai.js'
 import { getAllMcpConfigs, isMcpServerDisabled } from './config.js'
 import { getMcpServerHeaders } from './headersHelper.js'
 import { SdkControlClientTransport } from './SdkControlTransport.js'

--- a/runtime/src/tui/components/InterruptedByUser.tsx
+++ b/runtime/src/tui/components/InterruptedByUser.tsx
@@ -4,7 +4,7 @@ export function InterruptedByUser() {
   const $ = _c(1);
   let t0;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = <><Text dimColor={true}>Interrupted </Text>{false ? <Text dimColor={true}>· [internal] /issue to report a model issue</Text> : <Text dimColor={true}>· What should AgenC do instead?</Text>}</>;
+    t0 = <><Text dimColor={true}>Interrupted </Text><Text dimColor={true}>· What should AgenC do instead?</Text></>;
     $[0] = t0;
   } else {
     t0 = $[0];

--- a/runtime/src/tui/components/design-system/ThemeProvider.tsx
+++ b/runtime/src/tui/components/design-system/ThemeProvider.tsx
@@ -68,7 +68,7 @@ export function ThemeProvider({
       if (activeSetting !== 'auto' || !internal_querier) return;
       let cleanup: (() => void) | undefined;
       let cancelled = false;
-      void import('../../../utils/systemThemeWatcher').then(({
+      void import('../../../utils/systemThemeWatcher.js').then(({
         watchSystemTheme
       }) => {
         if (cancelled) return;

--- a/runtime/src/tui/components/tasks/BackgroundTaskStatus.layout.ts
+++ b/runtime/src/tui/components/tasks/BackgroundTaskStatus.layout.ts
@@ -40,7 +40,7 @@ export function getTeammateFooterLayout(
 
   const clampedSelected = Math.max(0, Math.min(selectedIndex, totalItems - 1));
   const window = calculateHorizontalScrollWindow(
-    pillWidths.map(width => Math.max(1, width)),
+    pillWidths.map((width, index) => Math.max(1, width) + (index > 0 ? 1 : 0)),
     pillColumns,
     TEAMMATE_FOOTER_SCROLL_ARROW_COLUMNS,
     clampedSelected,

--- a/runtime/src/tui/components/v2/messagePrimitives.tsx
+++ b/runtime/src/tui/components/v2/messagePrimitives.tsx
@@ -151,26 +151,37 @@ type ParsedResourceUpdate = {
 
 function parseResourceUpdates(text: string): ParsedResourceUpdate[] {
   const updates: ParsedResourceUpdate[] = []
+  const attr = (attributes: string, name: string): string | undefined =>
+    new RegExp(`${name}="([^"]*)"`, 'u').exec(attributes)?.[1]
+  const reasonFromBody = (body: string): string | undefined =>
+    /<reason>([^<]+)<\/reason>/u.exec(body)?.[1]
+
   const resourceRegex =
-    /<mcp-resource-update\s+server="([^"]+)"\s+uri="([^"]+)"[^>]*>(?:[\s\S]*?<reason>([^<]+)<\/reason>)?/g
+    /<mcp-resource-update\b([^>]*)>([\s\S]*?)<\/mcp-resource-update>/g
   let match: RegExpExecArray | null
   while ((match = resourceRegex.exec(text)) !== null) {
+    const server = attr(match[1] ?? '', 'server')
+    const target = attr(match[1] ?? '', 'uri')
+    if (!server || !target) continue
     updates.push({
       kind: 'resource',
-      server: match[1] ?? '',
-      target: match[2] ?? '',
-      reason: match[3],
+      server,
+      target,
+      reason: reasonFromBody(match[2] ?? ''),
     })
   }
 
   const pollingRegex =
-    /<mcp-polling-update\s+type="([^"]+)"\s+server="([^"]+)"\s+tool="([^"]+)"[^>]*>(?:[\s\S]*?<reason>([^<]+)<\/reason>)?/g
+    /<mcp-polling-update\b([^>]*)>([\s\S]*?)<\/mcp-polling-update>/g
   while ((match = pollingRegex.exec(text)) !== null) {
+    const server = attr(match[1] ?? '', 'server')
+    const target = attr(match[1] ?? '', 'tool')
+    if (!server || !target) continue
     updates.push({
       kind: 'polling',
-      server: match[2] ?? '',
-      target: match[3] ?? '',
-      reason: match[4],
+      server,
+      target,
+      reason: reasonFromBody(match[2] ?? ''),
     })
   }
   return updates

--- a/runtime/src/tui/components/v2/primitives.tsx
+++ b/runtime/src/tui/components/v2/primitives.tsx
@@ -1368,7 +1368,7 @@ export function SlashPalette({
       })}
       {hidden > 0 ? (
         <ThemedBox flexDirection="row" borderTop borderTopColor="lineSoft" paddingX={2}>
-          <ThemedText color="inactive">{`+ ${hidden}more · ↓ to scroll`}</ThemedText>
+          <ThemedText color="inactive">{`+ ${hidden} more · ↓ to scroll`}</ThemedText>
           <Box flexGrow={1} />
           <ThemedText color="worker">◆</ThemedText>
           <ThemedText color="inactive"> agenc ·  core</ThemedText>

--- a/runtime/src/tui/hooks/notifs/useMcpConnectivityStatus.tsx
+++ b/runtime/src/tui/hooks/notifs/useMcpConnectivityStatus.tsx
@@ -7,14 +7,7 @@ import { useNotifications } from '../../context/notifications.js';
 import { getIsRemoteMode } from '../../../bootstrap/state';
 import { Text } from '../../ink.js';
 import type { MCPServerConnection } from '../../../services/mcp/types';
-
-// ---- donor-purge stubs ----
-// These symbols used to come from modules deleted in the api.anthropic.com
-// purge. They are stubbed here as no-ops so the surrounding moved-source
-// code paths degrade silently. Real implementations land when AgenC ships
-// the equivalent backend.
-const hasAgenCAiMcpEverConnected = (): boolean => false;
-// ---- end donor-purge stubs ----
+import { hasAgenCAiMcpEverConnected } from '../../../services/mcp/agencai.js';
 type Props = {
   mcpClients?: MCPServerConnection[];
 };
@@ -52,7 +45,7 @@ export function useMcpConnectivityStatus(t0) {
         }
         if (failedAgenCAiClients.length > 0) {
           addNotification({
-            key: "mcp-claudeai-failed",
+            key: "mcp-agencai-failed",
             jsx: <><Text color="error">{failedAgenCAiClients.length} agenc.tech{" "}{failedAgenCAiClients.length === 1 ? "connector" : "connectors"}{" "}unavailable</Text><Text dimColor={true}> · /mcp</Text></>,
             priority: "medium"
           });
@@ -66,7 +59,7 @@ export function useMcpConnectivityStatus(t0) {
         }
         if (needsAuthAgenCAiServers.length > 0) {
           addNotification({
-            key: "mcp-claudeai-needs-auth",
+            key: "mcp-agencai-needs-auth",
             jsx: <><Text color="warning">{needsAuthAgenCAiServers.length} agenc.tech{" "}{needsAuthAgenCAiServers.length === 1 ? "connector needs" : "connectors need"}{" "}auth</Text><Text dimColor={true}> · /mcp</Text></>,
             priority: "medium"
           });
@@ -87,14 +80,14 @@ export function useMcpConnectivityStatus(t0) {
   useEffect(t2, t3);
 }
 function _temp4(client_2) {
-  return client_2.type === "needs-auth" && client_2.config.type === "claudeai-proxy" && hasAgenCAiMcpEverConnected(client_2.name);
+  return client_2.type === "needs-auth" && client_2.config.type === "agencai-proxy" && hasAgenCAiMcpEverConnected(client_2.name);
 }
 function _temp3(client_1) {
-  return client_1.type === "needs-auth" && client_1.config.type !== "claudeai-proxy";
+  return client_1.type === "needs-auth" && client_1.config.type !== "agencai-proxy";
 }
 function _temp2(client_0) {
-  return client_0.type === "failed" && client_0.config.type === "claudeai-proxy" && hasAgenCAiMcpEverConnected(client_0.name);
+  return client_0.type === "failed" && client_0.config.type === "agencai-proxy" && hasAgenCAiMcpEverConnected(client_0.name);
 }
 function _temp(client) {
-  return client.type === "failed" && client.config.type !== "sse-ide" && client.config.type !== "ws-ide" && client.config.type !== "claudeai-proxy";
+  return client.type === "failed" && client.config.type !== "sse-ide" && client.config.type !== "ws-ide" && client.config.type !== "agencai-proxy";
 }

--- a/runtime/src/tui/hooks/useIdeSelection.ts
+++ b/runtime/src/tui/hooks/useIdeSelection.ts
@@ -64,6 +64,11 @@ export function useIdeSelection(
 ): void {
   const handlersRegistered = useRef(false)
   const currentIDERef = useRef<ConnectedMCPServer | null>(null)
+  const onSelectRef = useRef(onSelect)
+
+  useEffect(() => {
+    onSelectRef.current = onSelect
+  }, [onSelect])
 
   useEffect(() => {
     // Find the IDE client from the MCP clients list
@@ -76,7 +81,7 @@ export function useIdeSelection(
       handlersRegistered.current = false
       currentIDERef.current = ideClient || null
       // Reset the selection when the IDE client changes.
-      onSelect({
+      onSelectRef.current({
         lineCount: 0,
         lineStart: undefined,
         text: undefined,
@@ -92,7 +97,7 @@ export function useIdeSelection(
     // Handler function for selection changes
     const selectionChangeHandler = (data: SelectionData) => {
       if (!data.selection?.start || !data.selection?.end) {
-        onSelect({
+        onSelectRef.current({
           lineCount: 0,
           lineStart: undefined,
           text: data.text,
@@ -115,7 +120,7 @@ export function useIdeSelection(
         filePath: data.filePath,
       }
 
-      onSelect(selection)
+      onSelectRef.current(selection)
     }
 
     // Register notification handler for selection_changed events

--- a/runtime/src/tui/ink/dom.ts
+++ b/runtime/src/tui/ink/dom.ts
@@ -344,16 +344,14 @@ const measureTextNode = function (
   // Actual tab expansion happens in output.ts based on screen position.
   const text = expandTabs(rawText)
 
+  if (width > 0 && width < 1) {
+    return measureText(text, Number.POSITIVE_INFINITY)
+  }
+
   const dimensions = measureText(text, width)
 
   // Text fits into container, no need to wrap
   if (dimensions.width <= width) {
-    return dimensions
-  }
-
-  // This is happening when <Box> is shrinking child nodes and layout asks
-  // if we can fit this text node in a <1px space, so we just say "no"
-  if (dimensions.width >= 1 && width > 0 && width < 1) {
     return dimensions
   }
 

--- a/runtime/src/tui/ink/layout/yoga.ts
+++ b/runtime/src/tui/ink/layout/yoga.ts
@@ -79,8 +79,8 @@ export class YogaLayoutNode implements LayoutNode {
 
   // Layout
 
-  calculateLayout(width?: number, _height?: number): void {
-    this.yoga.calculateLayout(width, undefined, Direction.LTR)
+  calculateLayout(width?: number, height?: number): void {
+    this.yoga.calculateLayout(width, height, Direction.LTR)
   }
 
   setMeasureFunc(fn: LayoutMeasureFunc): void {

--- a/runtime/src/tui/ink/render-to-screen.ts
+++ b/runtime/src/tui/ink/render-to-screen.ts
@@ -88,14 +88,16 @@ export function renderToScreen(
   // Yoga layout. Root might not have a yogaNode if the tree is empty.
   root.yogaNode?.setWidth(width)
   root.yogaNode?.calculateLayout(width)
-  const height = Math.ceil(root.yogaNode?.getComputedHeight() ?? 0)
+  const naturalHeight = Math.ceil(root.yogaNode?.getComputedHeight() ?? 0)
+  const height = Math.max(1, naturalHeight)
   const t2 = performance.now()
 
-  // Paint to a fresh Screen. Width = given, height = yoga's natural.
+  // Paint to a fresh Screen. Width = given, height = yoga's natural height,
+  // with an empty-render floor so Output and Screen agree on dimensions.
   // No alt-screen, no prevScreen (every call is fresh).
   const screen = createScreen(
     width,
-    Math.max(1, height), // avoid 0-height Screen (createScreen may choke)
+    height,
     stylePool!,
     charPool!,
     hyperlinkPool!,

--- a/runtime/src/tui/ink/stringWidth.ts
+++ b/runtime/src/tui/ink/stringWidth.ts
@@ -111,6 +111,10 @@ function getEmojiWidth(grapheme: string): number {
     return count === 1 ? 1 : 2
   }
 
+  if (isTextPresentationSymbol(grapheme)) {
+    return 1
+  }
+
   // Incomplete keycap: digit/symbol + VS16 without U+20E3
   if (grapheme.length === 2) {
     const second = grapheme.codePointAt(1)
@@ -123,6 +127,18 @@ function getEmojiWidth(grapheme: string): number {
   }
 
   return 2
+}
+
+function isTextPresentationSymbol(grapheme: string): boolean {
+  const first = grapheme.codePointAt(0)!
+  if (first < 0x2600 || first > 0x27bf) return false
+  for (const char of grapheme) {
+    const codePoint = char.codePointAt(0)!
+    if (codePoint === 0xfe0f || codePoint === 0x200d || codePoint === 0x20e3) {
+      return false
+    }
+  }
+  return true
 }
 
 function isZeroWidth(codePoint: number): boolean {
@@ -224,5 +240,15 @@ const bunStringWidth =
 const BUN_STRING_WIDTH_OPTS = { ambiguousIsNarrow: true } as const
 
 export const stringWidth: (str: string) => number = bunStringWidth
-  ? str => bunStringWidth(str, BUN_STRING_WIDTH_OPTS)
+  ? str =>
+      typeof str === 'string' && containsTextPresentationSymbol(str)
+        ? stringWidthJavaScript(str)
+        : bunStringWidth(str, BUN_STRING_WIDTH_OPTS)
   : stringWidthJavaScript
+
+function containsTextPresentationSymbol(str: string): boolean {
+  for (const { segment } of getGraphemeSegmenter().segment(str)) {
+    if (isTextPresentationSymbol(segment)) return true
+  }
+  return false
+}

--- a/runtime/src/tui/ink/supports-hyperlinks.ts
+++ b/runtime/src/tui/ink/supports-hyperlinks.ts
@@ -33,13 +33,16 @@ type SupportsHyperlinksOptions = {
 export function supportsHyperlinks(
   options?: SupportsHyperlinksOptions,
 ): boolean {
+  const env = options?.env ?? process.env
+  if (env.FORCE_HYPERLINK === '0') return false
+  if (env.FORCE_HYPERLINK === '1') return true
+  if (env.NO_COLOR) return false
+
   const stdoutSupported =
-    options?.stdoutSupported ?? defaultStdoutSupportsHyperlinks(options?.env ?? process.env)
+    options?.stdoutSupported ?? defaultStdoutSupportsHyperlinks(env)
   if (stdoutSupported) {
     return true
   }
-
-  const env = options?.env ?? process.env
 
   // Check for additional terminals not detected by supports-hyperlinks
   const termProgram = env['TERM_PROGRAM']

--- a/runtime/src/tui/ink/useTerminalNotification.ts
+++ b/runtime/src/tui/ink/useTerminalNotification.ts
@@ -111,9 +111,6 @@ export function useTerminalNotification(): TerminalNotification {
             ),
           )
           break
-        case null:
-          // Handled by the if guard above
-          break
       }
     },
     [writeRaw],

--- a/runtime/src/tui/message-renderers/AttachmentMessage.tsx
+++ b/runtime/src/tui/message-renderers/AttachmentMessage.tsx
@@ -23,7 +23,7 @@ import { isAgentSwarmsEnabled } from '../../utils/agentSwarmsEnabled.js';
 import { tryRenderPlanApprovalMessage, formatTeammateMessageContent } from './PlanApprovalMessage';
 import { BLACK_CIRCLE } from '../../constants/figures.js';
 import { TeammateMessageContent } from './UserTeammateMessage';
-import { isShutdownApproved } from '../../utils/teammateMailbox.js';
+import { isShutdownApproved, isTaskAssignment } from '../../utils/teammateMailbox.js';
 import { CtrlOToExpand } from '../components/CtrlOToExpand';
 import FullWidthRow from '../components/design-system/FullWidthRow';
 import { FilePathLink } from '../components/FilePathLink';
@@ -69,19 +69,8 @@ export function AttachmentMessage({
     }
     return <Box flexDirection="column">
         {visibleMessages.map((msg_0, idx) => {
-        // Try to parse as JSON for task_assignment messages
-        let parsedMsg: {
-          type?: string;
-          taskId?: string;
-          subject?: string;
-          assignedBy?: string;
-        } | null = null;
-        try {
-          parsedMsg = jsonParse(msg_0.text);
-        } catch {
-          // Not JSON, treat as plain text
-        }
-        if (parsedMsg?.type === 'task_assignment') {
+        const parsedMsg = isTaskAssignment(msg_0.text);
+        if (parsedMsg) {
           return <Box key={idx} paddingLeft={2}>
                 <Text>{BLACK_CIRCLE} </Text>
                 <Text>Task assigned: </Text>

--- a/runtime/src/tui/message-renderers/UserCrossSessionMessage.js
+++ b/runtime/src/tui/message-renderers/UserCrossSessionMessage.js
@@ -1,0 +1,31 @@
+import React from 'react'
+
+const CROSS_SESSION_MESSAGE_TAG = 'cross-session-message'
+
+export function UserCrossSessionMessage({ addMargin, param }) {
+  const text = param?.text
+  const body = normalizeText(extractTag(text, CROSS_SESSION_MESSAGE_TAG))
+  if (!body) return null
+
+  const from = attr(text, 'from') ?? 'peer'
+  return React.createElement(
+    React.Fragment,
+    null,
+    addMargin ? React.createElement('ink-text', null, '\n') : null,
+    React.createElement('ink-text', null, `message from ${from}: `),
+    React.createElement('ink-text', null, body),
+  )
+}
+
+function attr(text, name) {
+  return new RegExp(`${name}="([^"]*)"`, 'u').exec(String(text ?? ''))?.[1]
+}
+
+function normalizeText(value) {
+  return (value ?? '').replace(/\s+/g, ' ').trim()
+}
+
+function extractTag(text, tagName) {
+  return new RegExp(`<${tagName}(?:\\s+[^>]*)?>([\\s\\S]*?)<\\/${tagName}>`, 'iu')
+    .exec(String(text ?? ''))?.[1] ?? null
+}

--- a/runtime/src/tui/message-renderers/UserForkBoilerplateMessage.js
+++ b/runtime/src/tui/message-renderers/UserForkBoilerplateMessage.js
@@ -1,0 +1,31 @@
+import React from 'react'
+
+const FORK_BOILERPLATE_TAG = 'fork-boilerplate'
+const FORK_DIRECTIVE_PREFIX = 'Your directive: '
+
+export function UserForkBoilerplateMessage({ addMargin, param }) {
+  const body = extractTag(param?.text, FORK_BOILERPLATE_TAG)
+  const directive = normalizeText(
+    body?.startsWith(FORK_DIRECTIVE_PREFIX)
+      ? body.slice(FORK_DIRECTIVE_PREFIX.length)
+      : body,
+  )
+  if (!directive) return null
+
+  return React.createElement(
+    React.Fragment,
+    null,
+    addMargin ? React.createElement('ink-text', null, '\n') : null,
+    React.createElement('ink-text', null, 'fork directive: '),
+    React.createElement('ink-text', null, directive),
+  )
+}
+
+function normalizeText(value) {
+  return (value ?? '').replace(/\s+/g, ' ').trim()
+}
+
+function extractTag(text, tagName) {
+  return new RegExp(`<${tagName}(?:\\s+[^>]*)?>([\\s\\S]*?)<\\/${tagName}>`, 'iu')
+    .exec(String(text ?? ''))?.[1] ?? null
+}

--- a/runtime/src/tui/message-renderers/UserGitHubWebhookMessage.js
+++ b/runtime/src/tui/message-renderers/UserGitHubWebhookMessage.js
@@ -1,0 +1,20 @@
+import React from 'react'
+
+export function UserGitHubWebhookMessage({ addMargin, param }) {
+  const body = normalizeWebhookBody(param?.text)
+  return React.createElement(
+    React.Fragment,
+    null,
+    addMargin ? React.createElement('ink-text', null, '\n') : null,
+    React.createElement('ink-text', null, 'GitHub webhook: '),
+    React.createElement('ink-text', null, body || 'activity received'),
+  )
+}
+
+function normalizeWebhookBody(text) {
+  return String(text ?? '')
+    .replace(/<\/?github-webhook-activity[^>]*>/giu, ' ')
+    .replace(/<[^>]+>/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}

--- a/runtime/src/tui/vim/text-objects.ts
+++ b/runtime/src/tui/vim/text-objects.ts
@@ -276,7 +276,6 @@ function findTagObject(
     if (openIndex === -1) continue
 
     const [open] = stack.splice(openIndex, 1)
-    if (!open) continue
     pairs.push({
       name,
       start: open.start,

--- a/runtime/src/utils/systemThemeWatcher.ts
+++ b/runtime/src/utils/systemThemeWatcher.ts
@@ -1,0 +1,44 @@
+import { oscColor, type TerminalQuerier } from '../tui/ink/terminal-querier.js'
+import {
+  setCachedSystemTheme,
+  themeFromOscColor,
+  type SystemTheme,
+} from './systemTheme.js'
+
+const OSC_BACKGROUND_COLOR = 11
+const POLL_INTERVAL_MS = 2_000
+
+export function watchSystemTheme(
+  querier: TerminalQuerier,
+  onThemeChange: (theme: SystemTheme) => void,
+): () => void {
+  let cancelled = false
+  let inFlight = false
+
+  const poll = async (): Promise<void> => {
+    if (cancelled || inFlight) return
+    inFlight = true
+    try {
+      const responsePromise = querier.send(oscColor(OSC_BACKGROUND_COLOR))
+      await querier.flush()
+      const response = await responsePromise
+      if (cancelled || !response) return
+      const theme = themeFromOscColor(response.data)
+      if (!theme) return
+      setCachedSystemTheme(theme)
+      onThemeChange(theme)
+    } finally {
+      inFlight = false
+    }
+  }
+
+  void poll()
+  const timer = setInterval(() => {
+    void poll()
+  }, POLL_INTERVAL_MS)
+
+  return () => {
+    cancelled = true
+    clearInterval(timer)
+  }
+}

--- a/runtime/src/utils/teammateMailbox.ts
+++ b/runtime/src/utils/teammateMailbox.ts
@@ -959,6 +959,17 @@ export type TaskAssignmentMessage = {
   timestamp: string
 }
 
+const TaskAssignmentMessageSchema = lazySchema(() =>
+  z.object({
+    type: z.literal('task_assignment'),
+    taskId: z.string().min(1),
+    subject: z.string().min(1),
+    description: z.string().default(''),
+    assignedBy: z.string().default(''),
+    timestamp: z.string().default(''),
+  }),
+)
+
 /**
  * Checks if a message text contains a task assignment
  */
@@ -966,10 +977,8 @@ export function isTaskAssignment(
   messageText: string,
 ): TaskAssignmentMessage | null {
   try {
-    const parsed = jsonParse(messageText)
-    if (parsed && parsed.type === 'task_assignment') {
-      return parsed as TaskAssignmentMessage
-    }
+    const result = TaskAssignmentMessageSchema().safeParse(jsonParse(messageText))
+    if (result.success) return result.data
   } catch {
     // Not JSON or not a valid task assignment
   }

--- a/runtime/tests/tui/coverage-swarm/swarm-001-components-PromptInput-PromptInput.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-001-components-PromptInput-PromptInput.test.tsx
@@ -1,0 +1,1296 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import type { PastedContent } from '../../utils/config.js'
+
+const harness = vi.hoisted(() => {
+  const appState = {
+    coordinatorTaskIndex: -1,
+    effortValue: undefined,
+    expandedView: 'transcript',
+    fastMode: false,
+    footerSelection: null as null | 'tasks' | 'teams',
+    isBriefOnly: false,
+    mainLoopModel: 'gpt-5.4',
+    mainLoopModelForSession: null,
+    mcp: { clients: [] },
+    promptSuggestion: {
+      acceptedAt: 0,
+      generationRequestId: null,
+      promptId: null,
+      shownAt: 0,
+      text: null,
+    },
+    speculation: { status: 'inactive' },
+    speculationSessionTimeSavedMs: 0,
+    tasks: {} as Record<string, Record<string, unknown>>,
+    teamContext: undefined as
+      | undefined
+      | {
+          teamName: string
+          teammates: Record<string, { color?: string; name: string }>
+        },
+    thinkingEnabled: true,
+    toolPermissionContext: {
+      isAutoModeAvailable: true,
+      isBypassPermissionsModeAvailable: true,
+      mode: 'default',
+    },
+    viewingAgentTaskId: null as null | string,
+    viewSelectionMode: null as null | string,
+  }
+
+  return {
+    activeAgent: { type: 'leader' } as { task?: unknown; type: string },
+    addNotification: vi.fn(),
+    appState,
+    autoModeOptInProps: undefined as undefined | Record<string, unknown>,
+    backgroundTasksPanelProps: undefined as undefined | Record<string, unknown>,
+    baseProps: undefined as undefined | Record<string, unknown>,
+    clearBuffer: vi.fn(),
+    commandQueue: [] as unknown[],
+    coordinatorTaskCount: 0,
+    directMessage: null as null | { message: string; recipientName: string },
+    directMessageResult: { success: false } as Record<string, unknown>,
+    editPromptError: null as null | Error,
+    editPromptResult: { content: null, error: null } as {
+      content: string | null
+      error: string | null
+    },
+    enterTeammateView: vi.fn(),
+    exitTeammateView: vi.fn(),
+    features: {} as Record<string, boolean>,
+    fullscreen: false,
+    getGlobalConfigResult: {} as Record<string, unknown>,
+    globalSearchProps: undefined as undefined | Record<string, unknown>,
+    hasAutoModeOptIn: true,
+    history: {
+      dismissSearchHint: vi.fn(),
+      historyFailedMatch: false,
+      historyIndex: 0,
+      historyMatch: null as unknown,
+      historyQuery: '',
+      onHistoryDown: vi.fn(() => false),
+      onHistoryUp: vi.fn(),
+      resetHistory: vi.fn(),
+      setHistoryQuery: vi.fn(),
+    },
+    historySearchProps: undefined as undefined | Record<string, unknown>,
+    ideAtMentionedHandler: undefined as
+      | undefined
+      | ((atMentioned: {
+          filePath: string
+          lineEnd?: number
+          lineStart?: number
+        }) => void),
+    inputHandlers: [] as Array<{
+      handler: (
+        input: string,
+        key: Record<string, boolean>,
+        event?: { stopImmediatePropagation: () => void },
+      ) => unknown
+      options?: Record<string, unknown>
+    }>,
+    isAgentSwarmsEnabled: false,
+    isBackgroundTask: vi.fn(() => false),
+    isInProcessEnabled: false,
+    isInProcessTeammate: false,
+    isMacosOptionChar: false,
+    isSSH: false,
+    keybindingRegistrations: [] as Array<Record<string, unknown>>,
+    keybindings: {} as Record<string, () => unknown>,
+    logEvent: vi.fn(),
+    modelPickerProps: undefined as undefined | Record<string, unknown>,
+    nextPermissionMode: 'plan',
+    onRender: vi.fn(),
+    platform: 'linux',
+    promptInputFooterProps: undefined as undefined | Record<string, unknown>,
+    promptOverlayDialog: undefined as unknown,
+    promptSuggestionLogEvent: vi.fn(),
+    pushToBuffer: vi.fn(),
+    quickOpenProps: undefined as undefined | Record<string, unknown>,
+    removeNotification: vi.fn(),
+    runningTeammates: [] as Array<{ id: string }>,
+    saveGlobalConfig: vi.fn(),
+    setAutoModeActive: vi.fn(),
+    specialChars: {} as Record<string, string>,
+    stopOrDismissAgent: vi.fn(),
+    swarmBanner: null as null | { bgColor: string; text?: string },
+    syncTeammateMode: vi.fn(),
+    teammateColor: undefined as undefined | string,
+    teamsDialogProps: undefined as undefined | Record<string, unknown>,
+    terminal: undefined as undefined | string,
+    thinking: {
+      positions: [] as Array<{ end: number; start: number }>,
+      ultrathinkEnabled: false,
+    },
+    thinkingToggleProps: undefined as undefined | Record<string, unknown>,
+    transitionPermissionMode: vi.fn(
+      (_from: unknown, _to: unknown, context: Record<string, unknown>) => ({
+        ...context,
+        transitioned: true,
+      }),
+    ),
+    typeahead: {
+      commandArgumentHint: undefined as undefined | string,
+      inlineGhostText: undefined as undefined | string,
+      maxColumnWidth: 0,
+      selectedSuggestion: -1,
+      suggestionType: undefined as undefined | string,
+      suggestions: [] as Array<{ description?: string; label: string }>,
+    },
+    updateSettingsForSource: vi.fn(),
+    visibleAgentTasks: [] as Array<{ id: string; status?: string }>,
+    viewedTeammate: undefined as
+      | undefined
+      | {
+          id: string
+          identity: { agentName: string; color?: string }
+          permissionMode: string
+        },
+    fastMode: {
+      available: false,
+      cooldown: false,
+      enabled: false,
+      runtimeState: { status: 'available' },
+      supportedByModel: true,
+      unavailableReason: null as string | null,
+    },
+    reset: () => {
+      harness.activeAgent = { type: 'leader' }
+      harness.addNotification.mockClear()
+      harness.autoModeOptInProps = undefined
+      harness.backgroundTasksPanelProps = undefined
+      harness.baseProps = undefined
+      harness.clearBuffer.mockClear()
+      harness.commandQueue = []
+      harness.coordinatorTaskCount = 0
+      harness.directMessage = null
+      harness.directMessageResult = { success: false }
+      harness.editPromptError = null
+      harness.editPromptResult = { content: null, error: null }
+      harness.enterTeammateView.mockClear()
+      harness.exitTeammateView.mockClear()
+      harness.features = {}
+      harness.fullscreen = false
+      harness.getGlobalConfigResult = {}
+      harness.globalSearchProps = undefined
+      harness.hasAutoModeOptIn = true
+      harness.history.dismissSearchHint.mockClear()
+      harness.history.historyFailedMatch = false
+      harness.history.historyIndex = 0
+      harness.history.historyMatch = null
+      harness.history.historyQuery = ''
+      harness.history.onHistoryDown.mockReset()
+      harness.history.onHistoryDown.mockReturnValue(false)
+      harness.history.onHistoryUp.mockClear()
+      harness.history.resetHistory.mockClear()
+      harness.history.setHistoryQuery.mockClear()
+      harness.historySearchProps = undefined
+      harness.ideAtMentionedHandler = undefined
+      harness.inputHandlers = []
+      harness.isAgentSwarmsEnabled = false
+      harness.isBackgroundTask.mockReset()
+      harness.isBackgroundTask.mockReturnValue(false)
+      harness.isInProcessEnabled = false
+      harness.isInProcessTeammate = false
+      harness.isMacosOptionChar = false
+      harness.isSSH = false
+      harness.keybindingRegistrations = []
+      harness.keybindings = {}
+      harness.logEvent.mockClear()
+      harness.modelPickerProps = undefined
+      harness.nextPermissionMode = 'plan'
+      harness.onRender.mockClear()
+      harness.platform = 'linux'
+      harness.promptInputFooterProps = undefined
+      harness.promptOverlayDialog = undefined
+      harness.promptSuggestionLogEvent.mockClear()
+      harness.pushToBuffer.mockClear()
+      harness.quickOpenProps = undefined
+      harness.removeNotification.mockClear()
+      harness.runningTeammates = []
+      harness.saveGlobalConfig.mockClear()
+      harness.setAppState.mockClear()
+      harness.setAutoModeActive.mockClear()
+      harness.setPastedContents.mockClear()
+      harness.specialChars = {}
+      harness.stopOrDismissAgent.mockClear()
+      harness.swarmBanner = null
+      harness.syncTeammateMode.mockClear()
+      harness.teammateColor = undefined
+      harness.teamsDialogProps = undefined
+      harness.terminal = undefined
+      harness.thinking = {
+        positions: [],
+        ultrathinkEnabled: false,
+      }
+      harness.thinkingToggleProps = undefined
+      harness.transitionPermissionMode.mockClear()
+      harness.typeahead = {
+        commandArgumentHint: undefined,
+        inlineGhostText: undefined,
+        maxColumnWidth: 0,
+        selectedSuggestion: -1,
+        suggestionType: undefined,
+        suggestions: [],
+      }
+      harness.updateSettingsForSource.mockClear()
+      harness.visibleAgentTasks = []
+      harness.viewedTeammate = undefined
+      harness.fastMode = {
+        available: false,
+        cooldown: false,
+        enabled: false,
+        runtimeState: { status: 'available' },
+        supportedByModel: true,
+        unavailableReason: null,
+      }
+      appState.coordinatorTaskIndex = -1
+      appState.effortValue = undefined
+      appState.expandedView = 'transcript'
+      appState.fastMode = false
+      appState.footerSelection = null
+      appState.isBriefOnly = false
+      appState.mainLoopModel = 'gpt-5.4'
+      appState.mainLoopModelForSession = null
+      appState.mcp = { clients: [] }
+      appState.promptSuggestion = {
+        acceptedAt: 0,
+        generationRequestId: null,
+        promptId: null,
+        shownAt: 0,
+        text: null,
+      }
+      appState.speculation = { status: 'inactive' }
+      appState.speculationSessionTimeSavedMs = 0
+      appState.tasks = {}
+      appState.teamContext = undefined
+      appState.thinkingEnabled = true
+      appState.toolPermissionContext = {
+        isAutoModeAvailable: true,
+        isBypassPermissionsModeAvailable: true,
+        mode: 'default',
+      }
+      appState.viewingAgentTaskId = null
+      appState.viewSelectionMode = null
+    },
+    setAppState: vi.fn((updater: unknown) => {
+      const next =
+        typeof updater === 'function'
+          ? (updater as (prev: typeof appState) => typeof appState)(appState)
+          : updater
+      Object.assign(appState, next)
+    }),
+    setPastedContents: vi.fn(),
+    undo: vi.fn(),
+  }
+})
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => harness.features[name] === true,
+}))
+
+vi.mock('../../services/analytics/index.js', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../../services/analytics/growthbook.js', () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: () => null,
+}))
+
+vi.mock('../../services/PromptSuggestion/promptSuggestion.js', () => ({
+  abortPromptSuggestion: vi.fn(),
+  logSuggestionSuppressed: vi.fn(),
+}))
+
+vi.mock('../../services/PromptSuggestion/runtime.js', () => ({
+  logEvent: harness.promptSuggestionLogEvent,
+}))
+
+vi.mock('../../services/PromptSuggestion/speculation.js', () => ({
+  abortSpeculation: vi.fn(),
+}))
+
+vi.mock('../context/notifications.js', () => ({
+  useNotifications: () => ({
+    addNotification: harness.addNotification,
+    removeNotification: harness.removeNotification,
+  }),
+}))
+
+vi.mock('../context/overlayContext.js', () => ({
+  useIsModalOverlayActive: () => false,
+  useRegisterOverlay: vi.fn(),
+}))
+
+vi.mock('../context/promptOverlayContext.js', () => ({
+  useSetPromptOverlayDialog: () => (dialog: unknown) => {
+    harness.promptOverlayDialog = dialog
+  },
+}))
+
+vi.mock('../hooks/useCommandQueue.js', () => ({
+  useCommandQueue: () => harness.commandQueue,
+}))
+
+vi.mock('../hooks/useIdeAtMentioned.js', () => ({
+  useIdeAtMentioned: vi.fn(
+    (
+      _clients: unknown,
+      handler: (atMentioned: {
+        filePath: string
+        lineEnd?: number
+        lineStart?: number
+      }) => void,
+    ) => {
+      harness.ideAtMentionedHandler = handler
+    },
+  ),
+}))
+
+vi.mock('../hooks/useArrowKeyHistory.js', () => ({
+  useArrowKeyHistory: () => ({
+    dismissSearchHint: harness.history.dismissSearchHint,
+    historyIndex: harness.history.historyIndex,
+    onHistoryDown: harness.history.onHistoryDown,
+    onHistoryUp: harness.history.onHistoryUp,
+    resetHistory: harness.history.resetHistory,
+  }),
+}))
+
+vi.mock('../hooks/useDoublePress.js', () => ({
+  useDoublePress: (_single: () => void, doublePress: () => void) => doublePress,
+}))
+
+vi.mock('../hooks/useHistorySearch.js', () => ({
+  useHistorySearch: () => ({
+    historyFailedMatch: harness.history.historyFailedMatch,
+    historyMatch: harness.history.historyMatch,
+    historyQuery: harness.history.historyQuery,
+    setHistoryQuery: harness.history.setHistoryQuery,
+  }),
+}))
+
+vi.mock('../hooks/useInputBuffer.js', () => ({
+  useInputBuffer: () => ({
+    canUndo: false,
+    clearBuffer: harness.clearBuffer,
+    pushToBuffer: harness.pushToBuffer,
+    undo: harness.undo,
+  }),
+}))
+
+vi.mock('../hooks/useMainLoopModel.js', () => ({
+  useMainLoopModel: () => 'gpt-5.4',
+}))
+
+vi.mock('../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: 100, rows: 30 }),
+}))
+
+vi.mock('../hooks/useTypeahead.js', () => ({
+  useTypeahead: () => harness.typeahead,
+}))
+
+vi.mock('../ink/hooks/use-terminal-focus.js', () => ({
+  useTerminalFocus: () => true,
+}))
+
+vi.mock('../ink.js', async () => {
+  const ReactModule = await import('react')
+  return {
+    Box: ({ children }: { readonly children?: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+    Text: ({ children }: { readonly children?: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+    useInput: (
+      handler: (
+        input: string,
+        key: Record<string, boolean>,
+        event?: { stopImmediatePropagation: () => void },
+      ) => unknown,
+      options?: Record<string, unknown>,
+    ) => {
+      harness.inputHandlers.push({ handler, options })
+    },
+  }
+})
+
+vi.mock('../keybindings/KeybindingContext.js', () => ({
+  useOptionalKeybindingContext: () => ({
+    registerHandler: (registration: Record<string, unknown>) => {
+      harness.keybindingRegistrations.push(registration)
+      return () => {
+        harness.keybindingRegistrations =
+          harness.keybindingRegistrations.filter(item => item !== registration)
+      }
+    },
+  }),
+}))
+
+vi.mock('../keybindings/shortcutFormat.js', () => ({
+  getShortcutDisplay: () => 'ctrl+v',
+}))
+
+vi.mock('../keybindings/useKeybinding.js', () => ({
+  useKeybinding: (action: string, handler: () => unknown) => {
+    harness.keybindings[action] = handler
+  },
+  useKeybindings: (handlers: Record<string, () => unknown>) => {
+    Object.assign(harness.keybindings, handlers)
+  },
+}))
+
+vi.mock('../glyphs.js', () => ({
+  selectAgenCTuiGlyphs: () => ({ horizontal: '-' }),
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+  useAppStateStore: () => ({ getState: () => harness.appState }),
+  useSetAppState: () => harness.setAppState,
+}))
+
+vi.mock('../state/selectors.js', () => ({
+  getActiveAgentForInput: () => harness.activeAgent,
+  getViewedTeammateTask: () => harness.viewedTeammate,
+}))
+
+vi.mock('../state/teammateViewHelpers.js', () => ({
+  enterTeammateView: harness.enterTeammateView,
+  exitTeammateView: harness.exitTeammateView,
+  stopOrDismissAgent: harness.stopOrDismissAgent,
+}))
+
+vi.mock('../../commands.js', () => ({
+  hasCommand: () => false,
+}))
+
+vi.mock('../../tasks/InProcessTeammateTask/InProcessTeammateTask.js', () => ({
+  getRunningTeammatesSorted: () => harness.runningTeammates,
+}))
+
+vi.mock('../../tasks/types.js', () => ({
+  isBackgroundTask: (task: unknown) => harness.isBackgroundTask(task),
+}))
+
+vi.mock('../../tools/AgentTool/agentColorManager.js', () => ({
+  AGENT_COLORS: ['cyan', 'purple'],
+  AGENT_COLOR_TO_THEME_COLOR: { cyan: 'accent', purple: 'secondary' },
+}))
+
+vi.mock('../../utils/agentSwarmsEnabled.js', () => ({
+  isAgentSwarmsEnabled: () => harness.isAgentSwarmsEnabled,
+}))
+
+vi.mock('../../utils/array.js', () => ({
+  count: (values: readonly unknown[], predicate: (value: unknown) => boolean) =>
+    values.filter(predicate).length,
+}))
+
+vi.mock('../../utils/config.js', () => ({
+  getGlobalConfig: () => harness.getGlobalConfigResult,
+  saveGlobalConfig: harness.saveGlobalConfig,
+}))
+
+vi.mock('../../utils/cwd.js', () => ({
+  getCwd: () => '/repo',
+}))
+
+vi.mock('../../utils/debug.js', () => ({
+  logForDebugging: vi.fn(),
+}))
+
+vi.mock('../../utils/directMemberMessage.js', () => ({
+  parseDirectMemberMessage: () => harness.directMessage,
+  sendDirectMemberMessage: vi.fn(() => harness.directMessageResult),
+}))
+
+vi.mock('../../utils/dragDropPaths.js', () => ({
+  extractDraggedFilePaths: (value: string) =>
+    value.startsWith('/dragged/file') ? [value.trim()] : [],
+}))
+
+vi.mock('../../utils/env.js', () => ({
+  env: {
+    isSSH: () => harness.isSSH,
+    get terminal() {
+      return harness.terminal
+    },
+  },
+}))
+
+vi.mock('../../utils/errors.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../utils/errors.js')>()
+  return {
+    ...actual,
+    errorMessage: (value: unknown) => String(value),
+  }
+})
+
+vi.mock('../../utils/extraUsage.js', () => ({
+  isBilledAsExtraUsage: () => false,
+}))
+
+vi.mock('../../utils/fastMode.js', () => ({
+  FAST_MODE_MODEL_DISPLAY: 'fast-model',
+  clearFastModeCooldown: vi.fn(),
+  getFastModeModel: () => 'fast-model',
+  getFastModeRuntimeState: () => harness.fastMode.runtimeState,
+  getFastModeUnavailableReason: () => harness.fastMode.unavailableReason,
+  isFastModeAvailable: () => harness.fastMode.available,
+  isFastModeCooldown: () => harness.fastMode.cooldown,
+  isFastModeEnabled: () => harness.fastMode.enabled,
+  isFastModeSupportedByModel: () => harness.fastMode.supportedByModel,
+}))
+
+vi.mock('../../utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => harness.fullscreen,
+}))
+
+vi.mock('../../utils/imagePaste.js', () => ({
+  PASTE_THRESHOLD: 20,
+  getImageFromClipboard: vi.fn(async () => null),
+}))
+
+vi.mock('../../utils/imageStore.js', () => ({
+  cacheImagePath: vi.fn(),
+  storeImage: vi.fn(),
+}))
+
+vi.mock('../../utils/keyboardShortcuts.js', () => ({
+  MACOS_OPTION_SPECIAL_CHARS: new Proxy(
+    {},
+    {
+      get: (_target, prop) => harness.specialChars[String(prop)],
+    },
+  ),
+  isMacosOptionChar: () => harness.isMacosOptionChar,
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: vi.fn(),
+}))
+
+vi.mock('../../utils/model/model.js', () => ({
+  isOpus1mMergeEnabled: () => false,
+  modelDisplayString: (model: string | null) => model ?? 'default',
+}))
+
+vi.mock('../../utils/permissions/autoModeState.js', () => ({
+  setAutoModeActive: harness.setAutoModeActive,
+}))
+
+vi.mock('../../utils/permissions/getNextPermissionMode.js', () => ({
+  cyclePermissionMode: (context: unknown) => ({ context }),
+  getNextPermissionMode: () => harness.nextPermissionMode,
+}))
+
+vi.mock('../../utils/permissions/permissionSetup.js', () => ({
+  transitionPermissionMode: harness.transitionPermissionMode,
+}))
+
+vi.mock('../../utils/platform.js', () => ({
+  getPlatform: () => harness.platform,
+}))
+
+vi.mock('../../utils/promptEditor.js', () => ({
+  editPromptInEditor: vi.fn(async () => {
+    if (harness.editPromptError) throw harness.editPromptError
+    return harness.editPromptResult
+  }),
+}))
+
+vi.mock('../input/processBashCommand.js', () => ({
+  processBashCommand: vi.fn(async () => ({ messages: [] })),
+}))
+
+vi.mock('../../utils/settings/settings.js', () => ({
+  hasAutoModeOptIn: () => harness.hasAutoModeOptIn,
+  updateSettingsForSource: harness.updateSettingsForSource,
+}))
+
+vi.mock('../../utils/suggestions/commandSuggestions.js', () => ({
+  findSlashCommandPositions: () => [],
+}))
+
+vi.mock('../../utils/suggestions/slackChannelSuggestions.js', () => ({
+  findSlackChannelPositions: () => [],
+  getKnownChannelsVersion: () => 0,
+  hasSlackMcpServer: () => false,
+  subscribeKnownChannels: () => () => {},
+}))
+
+vi.mock('../../utils/swarm/backends/registry.js', () => ({
+  isInProcessEnabled: () => harness.isInProcessEnabled,
+}))
+
+vi.mock('../../utils/swarm/teamHelpers.js', () => ({
+  syncTeammateMode: harness.syncTeammateMode,
+}))
+
+vi.mock('../../utils/teammate.js', () => ({
+  getTeammateColor: () => harness.teammateColor,
+}))
+
+vi.mock('../../utils/teammateContext.js', () => ({
+  isInProcessTeammate: () => harness.isInProcessTeammate,
+}))
+
+vi.mock('../../utils/teammateMailbox.js', () => ({
+  writeToMailbox: vi.fn(),
+}))
+
+vi.mock('../../utils/thinking.js', () => ({
+  findThinkingTriggerPositions: () => harness.thinking.positions,
+  getRainbowColor: () => 'suggestion',
+  isUltrathinkEnabled: () => harness.thinking.ultrathinkEnabled,
+}))
+
+vi.mock('../../conversation/token-budget.js', () => ({
+  findTokenBudgetPositions: () => [],
+}))
+
+vi.mock('../components/AutoModeOptInDialog.js', () => ({
+  AutoModeOptInDialog: (props: Record<string, unknown>) => {
+    harness.autoModeOptInProps = props
+    return null
+  },
+}))
+
+vi.mock('../components/ConfigurableShortcutHint.js', () => ({
+  ConfigurableShortcutHint: () => null,
+}))
+
+vi.mock('../components/CoordinatorAgentStatus.js', () => ({
+  getVisibleAgentTasks: () => harness.visibleAgentTasks,
+  useCoordinatorTaskCount: () => harness.coordinatorTaskCount,
+}))
+
+vi.mock('../components/EffortIndicator.js', () => ({
+  getEffortNotificationText: () => undefined,
+}))
+
+vi.mock('../components/FastIcon.js', () => ({
+  getFastIconString: () => 'FAST',
+}))
+
+vi.mock('../components/FullscreenLayout.js', () => ({
+  calculateFullscreenLayoutBudget: (rows: number) => ({
+    bottomMaxHeight: Math.max(1, Math.floor(rows / 2)),
+  }),
+}))
+
+vi.mock('../components/GlobalSearchDialog.js', () => ({
+  GlobalSearchDialog: (props: Record<string, unknown>) => {
+    harness.globalSearchProps = props
+    return null
+  },
+}))
+
+vi.mock('../history/HistorySearchDialog.js', () => ({
+  HistorySearchDialog: (props: Record<string, unknown>) => {
+    harness.historySearchProps = props
+    return null
+  },
+}))
+
+vi.mock('../components/ModelPicker.js', () => ({
+  ModelPicker: (props: Record<string, unknown>) => {
+    harness.modelPickerProps = props
+    return null
+  },
+}))
+
+vi.mock('../components/QuickOpenDialog.js', () => ({
+  QuickOpenDialog: (props: Record<string, unknown>) => {
+    harness.quickOpenProps = props
+    return null
+  },
+}))
+
+vi.mock('../components/ThinkingToggle.js', () => ({
+  ThinkingToggle: (props: Record<string, unknown>) => {
+    harness.thinkingToggleProps = props
+    return null
+  },
+}))
+
+vi.mock('../components/tasks/BackgroundTasksPanel.js', () => ({
+  BackgroundTasksPanel: (props: Record<string, unknown>) => {
+    harness.backgroundTasksPanelProps = props
+    return null
+  },
+}))
+
+vi.mock('../components/tasks/taskStatusUtils.js', () => ({
+  shouldHideTasksFooter: () => false,
+}))
+
+vi.mock('../components/teams/TeamsDialog.js', () => ({
+  TeamsDialog: (props: Record<string, unknown>) => {
+    harness.teamsDialogProps = props
+    return null
+  },
+}))
+
+vi.mock('../components/v2/primitives.js', () => ({
+  ModeSwitcher: () => null,
+}))
+
+vi.mock('../components/PromptInput/ConfiguredPromptTextInput.js', async () => {
+  const ReactModule = await import('react')
+  return {
+    ConfiguredPromptTextInput: ({
+      baseProps,
+    }: {
+      readonly baseProps: Record<string, unknown>
+    }) => {
+      harness.baseProps = baseProps
+      harness.onRender()
+      return ReactModule.createElement(ReactModule.Fragment)
+    },
+  }
+})
+
+vi.mock('../components/PromptInput/Notifications.js', () => ({
+  FOOTER_TEMPORARY_STATUS_TIMEOUT: 3000,
+  Notifications: () => null,
+}))
+
+vi.mock('../components/PromptInput/PromptInputFooter.js', () => ({
+  default: (props: Record<string, unknown>) => {
+    harness.promptInputFooterProps = props
+    return null
+  },
+}))
+
+vi.mock('../components/PromptInput/PromptInputModeIndicator.js', () => ({
+  PromptInputModeIndicator: () => null,
+}))
+
+vi.mock('../components/PromptInput/PromptInputQueuedCommands.js', () => ({
+  PromptInputQueuedCommands: () => null,
+}))
+
+vi.mock('../components/PromptInput/PromptInputStashNotice.js', () => ({
+  PromptInputStashNotice: () => null,
+}))
+
+vi.mock('../components/PromptInput/useMaybeTruncateInput.js', () => ({
+  useMaybeTruncateInput: vi.fn(),
+}))
+
+vi.mock('../components/PromptInput/usePromptInputPlaceholder.js', () => ({
+  usePromptInputPlaceholder: () => 'Type a prompt',
+}))
+
+vi.mock('../components/PromptInput/useShowFastIconHint.js', () => ({
+  useShowFastIconHint: () => false,
+}))
+
+vi.mock('../components/PromptInput/useSwarmBanner.js', () => ({
+  useSwarmBanner: () => harness.swarmBanner,
+}))
+
+vi.mock('../components/PromptInput/utils.js', async importOriginal => {
+  const actual = await importOriginal<
+    typeof import('../components/PromptInput/utils.js')
+  >()
+  return {
+    ...actual,
+    isVimModeEnabled: () => false,
+  }
+})
+
+import { createRoot } from '../ink/root.js'
+import PromptInput from '../components/PromptInput/PromptInput.js'
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function createTestStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+  ;(stdout as unknown as { rows: number }).rows = 30
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function waitForPromptInputProps(): Promise<Record<string, unknown>> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < 1000) {
+    if (harness.baseProps) return harness.baseProps
+    await sleep(10)
+  }
+  throw new Error('PromptInput base props were not captured')
+}
+
+async function waitFor(condition: () => boolean, message: string): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < 1000) {
+    if (condition()) return
+    await sleep(10)
+  }
+  throw new Error(message)
+}
+
+function basePromptInputProps(overrides: Record<string, unknown> = {}) {
+  return {
+    agents: [],
+    apiKeyStatus: 'valid',
+    autoUpdaterResult: null,
+    commands: [],
+    debug: false,
+    getToolUseContext: () => ({}),
+    hasSuppressedDialogs: false,
+    helpOpen: false,
+    ideSelection: undefined,
+    input: '',
+    isLoading: false,
+    isLocalJSXCommandActive: false,
+    isSearchingHistory: false,
+    mcpClients: [],
+    messages: [],
+    mode: 'prompt',
+    onAutoUpdaterResult: vi.fn(),
+    onExit: vi.fn(),
+    onInputChange: vi.fn(),
+    onModeChange: vi.fn(),
+    onShowMessageSelector: vi.fn(),
+    onSubmit: vi.fn(async () => {}),
+    pastedContents: {},
+    setHelpOpen: vi.fn(),
+    setIsSearchingHistory: vi.fn(),
+    setPastedContents: harness.setPastedContents,
+    setShowBashesDialog: vi.fn(),
+    setStashedPrompt: vi.fn(),
+    setToolPermissionContext: vi.fn(),
+    setVimMode: vi.fn(),
+    showBashesDialog: false,
+    stashedPrompt: undefined,
+    submitCount: 0,
+    toolPermissionContext: harness.appState.toolPermissionContext,
+    verbose: false,
+    vimMode: 'INSERT',
+    ...overrides,
+  }
+}
+
+async function renderPromptInput(overrides: Record<string, unknown> = {}) {
+  harness.baseProps = undefined
+  const { stdin, stdout } = createTestStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  const props = basePromptInputProps(overrides)
+
+  root.render(<PromptInput {...(props as never)} />)
+  await waitForPromptInputProps()
+
+  return {
+    props,
+    root,
+    stdin,
+    stdout,
+    rerender: async (next: Record<string, unknown>) => {
+      harness.baseProps = undefined
+      root.render(<PromptInput {...(basePromptInputProps(next) as never)} />)
+      await waitForPromptInputProps()
+    },
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep(25)
+    },
+  }
+}
+
+describe('PromptInput coverage swarm row 001', () => {
+  beforeEach(() => {
+    harness.reset()
+  })
+
+  test('adds teammate mention and image chip highlights', async () => {
+    harness.isAgentSwarmsEnabled = true
+    harness.appState.teamContext = {
+      teamName: 'runtime',
+      teammates: {
+        alice: { color: 'cyan', name: 'alice' },
+        bob: { color: 'missing-theme', name: 'bob' },
+      },
+    }
+    const input = 'ask @alice and @bob [Image #2]'
+    const imageStart = input.indexOf('[Image')
+    const rendered = await renderPromptInput({ input })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+      const highlights = baseProps.highlights as Array<Record<string, unknown>>
+
+      expect(highlights).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            color: 'accent',
+            end: 'ask @alice'.length,
+            priority: 5,
+            start: 'ask '.length,
+          }),
+        ]),
+      )
+      expect(highlights).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            start: input.indexOf('@bob'),
+            color: undefined,
+          }),
+        ]),
+      )
+
+      ;(baseProps.onChangeCursorOffset as (offset: number) => void)(
+        imageStart + 2,
+      )
+      await waitFor(
+        () => (harness.baseProps?.cursorOffset as number | undefined) === imageStart,
+        'cursor did not snap to the image chip start',
+      )
+
+      const snappedHighlights = harness.baseProps?.highlights as Array<
+        Record<string, unknown>
+      >
+      expect(snappedHighlights).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            inverse: true,
+            start: imageStart,
+          }),
+        ]),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('shows the stash hint only after gradual clearing of substantial input', async () => {
+    harness.getGlobalConfigResult = { hasUsedStash: false }
+    const rendered = await renderPromptInput({
+      input: 'this is a substantial draft prompt',
+    })
+
+    try {
+      await rendered.rerender({ input: 'short draft' })
+      await rendered.rerender({ input: 'tiny' })
+
+      expect(harness.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'stash-hint',
+          priority: 'immediate',
+        }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('detects pasted composer modes and dragged-path spacing', async () => {
+    const onInputChange = vi.fn()
+    const onModeChange = vi.fn()
+    const rendered = await renderPromptInput({
+      input: '',
+      onInputChange,
+      onModeChange,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+
+      ;(baseProps.onPaste as (value: string) => void)('!npm test')
+      expect(onModeChange).toHaveBeenCalledWith('bash')
+      expect(onInputChange).toHaveBeenCalledWith('npm test')
+
+      await rendered.rerender({
+        input: 'prefix',
+        onInputChange,
+        onModeChange,
+      })
+      ;(harness.baseProps?.onPaste as (value: string) => void)(
+        '/dragged/file x',
+      )
+      expect(onInputChange).toHaveBeenCalledWith(
+        expect.stringContaining(' @"/dragged/file x" '),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('reports external editor returned errors and thrown failures', async () => {
+    harness.editPromptResult = { content: null, error: 'editor exited' }
+    const rendered = await renderPromptInput({ input: 'draft' })
+
+    try {
+      await harness.keybindings['chat:externalEditor']?.()
+      expect(harness.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'external-editor-error',
+          text: 'editor exited',
+        }),
+      )
+
+      harness.addNotification.mockClear()
+      harness.editPromptError = new Error('spawn failed')
+      await harness.keybindings['chat:externalEditor']?.()
+      expect(harness.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'external-editor-error',
+          text: 'External editor failed: Error: spawn failed',
+        }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('falls through direct message misses and routes active teammate input', async () => {
+    harness.isAgentSwarmsEnabled = true
+    harness.directMessage = { message: 'hello', recipientName: 'unknown' }
+    harness.directMessageResult = {
+      error: 'no_team_context',
+      success: false,
+    }
+    const onSubmit = vi.fn(async () => {})
+    const rendered = await renderPromptInput({
+      input: '@unknown hello',
+      onSubmit,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+      await (baseProps.onSubmit as (value: string) => Promise<void>)(
+        '@unknown hello',
+      )
+      expect(onSubmit).toHaveBeenCalledWith(
+        '@unknown hello',
+        expect.anything(),
+        undefined,
+        expect.objectContaining({ mode: 'prompt' }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+
+    harness.reset()
+    harness.activeAgent = { task: { id: 'agent-task' }, type: 'worker' }
+    const onAgentSubmit = vi.fn(async () => {})
+    const leaderSubmit = vi.fn(async () => {})
+    const teammateRendered = await renderPromptInput({
+      input: 'status',
+      onAgentSubmit,
+      onSubmit: leaderSubmit,
+    })
+
+    try {
+      const baseProps = await waitForPromptInputProps()
+      await (baseProps.onSubmit as (value: string) => Promise<void>)('status')
+
+      expect(leaderSubmit).not.toHaveBeenCalled()
+      expect(onAgentSubmit).toHaveBeenCalledWith(
+        'status',
+        { id: 'agent-task' },
+        expect.objectContaining({
+          clearBuffer: harness.clearBuffer,
+          resetHistory: expect.any(Function),
+        }),
+      )
+    } finally {
+      await teammateRendered.dispose()
+    }
+  })
+
+  test('accepts and declines the first-time auto-mode dialog', async () => {
+    harness.features.TRANSCRIPT_CLASSIFIER = true
+    harness.hasAutoModeOptIn = false
+    harness.nextPermissionMode = 'auto'
+    const setToolPermissionContext = vi.fn()
+    const rendered = await renderPromptInput({ setToolPermissionContext })
+
+    try {
+      await waitForPromptInputProps()
+      harness.keybindings['chat:cycleMode']?.()
+      await waitFor(
+        () => harness.autoModeOptInProps !== undefined,
+        'auto mode dialog did not render',
+      )
+
+      ;(harness.autoModeOptInProps?.onAccept as () => void)()
+      expect(harness.transitionPermissionMode).toHaveBeenCalledWith(
+        'default',
+        'auto',
+        expect.objectContaining({ mode: 'default' }),
+      )
+      expect(setToolPermissionContext).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          mode: 'auto',
+          transitioned: true,
+        }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+
+    harness.reset()
+    harness.features.TRANSCRIPT_CLASSIFIER = true
+    harness.hasAutoModeOptIn = false
+    harness.nextPermissionMode = 'auto'
+    const declineSetToolPermissionContext = vi.fn()
+    const declineRendered = await renderPromptInput({
+      setToolPermissionContext: declineSetToolPermissionContext,
+    })
+
+    try {
+      await waitForPromptInputProps()
+      harness.keybindings['chat:cycleMode']?.()
+      await waitFor(
+        () => harness.autoModeOptInProps !== undefined,
+        'auto mode dialog did not render for decline',
+      )
+
+      ;(harness.autoModeOptInProps?.onDecline as () => void)()
+      expect(harness.setAutoModeActive).toHaveBeenCalledWith(false)
+      expect(declineSetToolPermissionContext).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          isAutoModeAvailable: false,
+          mode: 'default',
+        }),
+      )
+    } finally {
+      await declineRendered.dispose()
+    }
+  })
+
+  test('cycles viewed teammate permission mode without touching the leader mode', async () => {
+    harness.isAgentSwarmsEnabled = true
+    harness.nextPermissionMode = 'plan'
+    harness.appState.viewingAgentTaskId = 'worker-1'
+    harness.viewedTeammate = {
+      id: 'worker-1',
+      identity: { agentName: 'worker', color: 'cyan' },
+      permissionMode: 'default',
+    }
+    harness.appState.tasks = {
+      'worker-1': {
+        id: 'worker-1',
+        permissionMode: 'default',
+        type: 'in_process_teammate',
+      },
+    }
+    const setToolPermissionContext = vi.fn()
+    const rendered = await renderPromptInput({ setToolPermissionContext })
+
+    try {
+      await waitForPromptInputProps()
+
+      harness.keybindings['chat:cycleMode']?.()
+
+      expect(harness.appState.tasks['worker-1']).toEqual(
+        expect.objectContaining({
+          permissionMode: 'plan',
+        }),
+      )
+      expect(setToolPermissionContext).not.toHaveBeenCalled()
+      expect(harness.appState.toolPermissionContext.mode).toBe('default')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('covers footer coordinator and teammate navigation branches', async () => {
+    harness.isBackgroundTask.mockImplementation(
+      task => (task as { background?: boolean }).background === true,
+    )
+    harness.appState.tasks = {
+      task1: { background: true },
+    }
+    harness.appState.footerSelection = 'tasks'
+    harness.appState.coordinatorTaskIndex = -1
+    harness.coordinatorTaskCount = 2
+    harness.visibleAgentTasks = [{ id: 'agent-1', status: 'running' }]
+    const rendered = await renderPromptInput({ input: 'footer' })
+
+    try {
+      await waitForPromptInputProps()
+
+      harness.keybindings['footer:down']?.()
+      expect(harness.appState.coordinatorTaskIndex).toBe(0)
+      await rendered.rerender({ input: 'footer' })
+
+      harness.keybindings['footer:down']?.()
+      expect(harness.appState.coordinatorTaskIndex).toBe(1)
+      await rendered.rerender({ input: 'footer' })
+
+      harness.keybindings['footer:openSelected']?.()
+      expect(harness.enterTeammateView).toHaveBeenCalledWith(
+        'agent-1',
+        harness.setAppState,
+      )
+
+      harness.keybindings['footer:up']?.()
+      expect(harness.appState.coordinatorTaskIndex).toBe(0)
+    } finally {
+      await rendered.dispose()
+    }
+
+    harness.reset()
+    harness.isBackgroundTask.mockImplementation(
+      task => (task as { background?: boolean }).background === true,
+    )
+    harness.appState.tasks = {
+      task1: { background: true },
+    }
+    harness.appState.footerSelection = 'tasks'
+    harness.runningTeammates = [{ id: 'teammate-1' }]
+    const teammateRendered = await renderPromptInput({ input: 'team footer' })
+
+    try {
+      await waitForPromptInputProps()
+
+      harness.keybindings['footer:next']?.()
+      await sleep(0)
+      harness.keybindings['footer:openSelected']?.()
+
+      expect(harness.enterTeammateView).toHaveBeenCalledWith(
+        'teammate-1',
+        harness.setAppState,
+      )
+    } finally {
+      await teammateRendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-002-components-App.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-002-components-App.test.tsx
@@ -1,0 +1,360 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type {
+  McpElicitationRequestEvent,
+  McpPrimitiveSchemaDefinition,
+  RequestUserInputEvent,
+} from "../../elicitation/types.js";
+import { getCommandQueue, resetCommandQueue } from "../../utils/messageQueueManager.js";
+import {
+  createElicitationQueue,
+  enqueueSlashPromptResult,
+  installElicitationResolvers,
+  parseMcpField,
+  settlePendingOnSubmit,
+  type McpFormPending,
+  type McpUrlPending,
+  type UserPending,
+} from "../components/App.js";
+
+function userRequest(questions: RequestUserInputEvent["questions"]): RequestUserInputEvent {
+  return {
+    callId: "call-1",
+    questions,
+  };
+}
+
+function mcpUrlRequest(requestId = "url-1"): McpElicitationRequestEvent {
+  return {
+    turnId: "turn-1",
+    serverName: "auth",
+    requestId,
+    request: {
+      mode: "url",
+      message: "Authorize access",
+      elicitationId: requestId,
+      url: "https://auth.example.test/start",
+    },
+  };
+}
+
+function mcpFormRequest(
+  properties: Record<string, McpPrimitiveSchemaDefinition>,
+  required: string[] = [],
+): McpElicitationRequestEvent {
+  return {
+    turnId: "turn-1",
+    serverName: "forms",
+    requestId: "form-1",
+    request: {
+      mode: "form",
+      message: "Provide values",
+      requestedSchema: {
+        type: "object",
+        required,
+        properties,
+      },
+    },
+  };
+}
+
+function formPending(
+  properties: Record<string, McpPrimitiveSchemaDefinition>,
+  resolve = vi.fn(),
+  required: string[] = [],
+): McpFormPending {
+  return {
+    kind: "mcp-form",
+    request: mcpFormRequest(properties, required),
+    resolve,
+    fields: Object.keys(properties),
+    content: {},
+    index: 0,
+  };
+}
+
+describe("App coverage swarm row 002", () => {
+  test("parses string and collection MCP schema edges", () => {
+    expect(
+      parseMcpField("green", {
+        type: "string",
+        anyOf: [
+          { const: "red", title: "Red" },
+          { const: "blue", title: "Blue" },
+        ],
+      }),
+    ).toEqual({
+      ok: false,
+      message: "must be one of: red, blue",
+    });
+    expect(parseMcpField("ab", { type: "string", minLength: 3 })).toEqual({
+      ok: false,
+      message: "must be at least 3 characters",
+    });
+    expect(parseMcpField("abcd", { type: "string", maxLength: 3 })).toEqual({
+      ok: false,
+      message: "must be at most 3 characters",
+    });
+    expect(
+      parseMcpField("read, write", {
+        type: "array",
+        items: { type: "string", enum: ["read", "write"] },
+      }),
+    ).toEqual({
+      ok: true,
+      value: ["read", "write"],
+    });
+  });
+
+  test("settles user prompts with default, missing, and later questions", () => {
+    const firstResolve = vi.fn();
+    const firstPending: UserPending = {
+      kind: "user",
+      request: userRequest([
+        {
+          id: "choice",
+          header: "Choice",
+          question: "Pick one",
+          options: [
+            { label: "Alpha", description: "First" },
+            { label: "Beta", description: "Second" },
+          ],
+        },
+        {
+          id: "note",
+          header: "Note",
+          question: "Add note",
+          options: [],
+        },
+      ]),
+      resolve: firstResolve,
+      answers: {},
+      index: 0,
+    };
+
+    const next = settlePendingOnSubmit(firstPending, "");
+
+    expect(firstResolve).not.toHaveBeenCalled();
+    expect(next).toMatchObject({
+      kind: "user",
+      answers: { choice: { answers: ["Alpha"] } },
+      index: 1,
+    });
+
+    expect(settlePendingOnSubmit(next as UserPending, "details")).toBeNull();
+    expect(firstResolve).toHaveBeenCalledWith({
+      answers: {
+        choice: { answers: ["Alpha"] },
+        note: { answers: ["details"] },
+      },
+    });
+
+    const missingResolve = vi.fn();
+    const missingQuestion: UserPending = {
+      kind: "user",
+      request: userRequest([]),
+      resolve: missingResolve,
+      answers: { previous: { answers: ["kept"] } },
+      index: 0,
+    };
+
+    expect(settlePendingOnSubmit(missingQuestion, "ignored")).toBeNull();
+    expect(missingResolve).toHaveBeenCalledWith({
+      answers: { previous: { answers: ["kept"] } },
+    });
+  });
+
+  test("settles MCP forms with no fields and skipped optional fields", () => {
+    const emptyResolve = vi.fn();
+    const emptyPending: McpFormPending = {
+      kind: "mcp-form",
+      request: mcpFormRequest({}),
+      resolve: emptyResolve,
+      fields: [],
+      content: { existing: "value" },
+      index: 0,
+    };
+
+    expect(settlePendingOnSubmit(emptyPending, "")).toBeNull();
+    expect(emptyResolve).toHaveBeenCalledWith({
+      action: "accept",
+      content: { existing: "value" },
+    });
+
+    const resolve = vi.fn();
+    const pending = formPending(
+      {
+        optional: { type: "string" },
+        required: { type: "integer" },
+      },
+      resolve,
+      ["required"],
+    );
+
+    const next = settlePendingOnSubmit(pending, "");
+    expect(resolve).not.toHaveBeenCalled();
+    expect(next).toMatchObject({
+      kind: "mcp-form",
+      content: {},
+      index: 1,
+      error: undefined,
+    });
+
+    expect(settlePendingOnSubmit(next as McpFormPending, "7")).toBeNull();
+    expect(resolve).toHaveBeenCalledWith({
+      action: "accept",
+      content: { required: 7 },
+    });
+  });
+
+  test("manages elicitation queue cancellation and URL completion branches", () => {
+    const queue = createElicitationQueue();
+    const firstResolve = vi.fn();
+    const secondResolve = vi.fn();
+    const unrelatedResolve = vi.fn();
+    const first: McpUrlPending = {
+      kind: "mcp-url",
+      request: mcpUrlRequest("url-1"),
+      resolve: firstResolve,
+    };
+    const second: McpUrlPending = {
+      kind: "mcp-url",
+      request: mcpUrlRequest("url-2"),
+      resolve: secondResolve,
+    };
+    const unrelated: McpUrlPending = {
+      kind: "mcp-url",
+      request: mcpUrlRequest("missing"),
+      resolve: unrelatedResolve,
+    };
+
+    expect(queue.enqueue(first)).toBe(first);
+    expect(queue.enqueue(second)).toBe(first);
+    expect(queue.cancel(unrelated)).toEqual({
+      handled: false,
+      current: first,
+    });
+
+    expect(queue.cancel(second)).toEqual({
+      handled: true,
+      current: first,
+    });
+    expect(secondResolve).not.toHaveBeenCalled();
+
+    expect(queue.completeMcpUrl("auth", "url-1", { action: "decline" })).toEqual({
+      handled: true,
+      current: null,
+    });
+    expect(firstResolve).toHaveBeenCalledWith({ action: "decline" });
+    expect(queue.completeMcpUrl("auth", "url-2")).toEqual({
+      handled: false,
+      current: null,
+    });
+    expect(queue.clear()).toEqual([]);
+  });
+
+  test("resolvers handle pre-aborted signals, event-log completions, and cleanup", async () => {
+    const previousUser = { request: vi.fn() };
+    const previousMcp = { request: vi.fn() };
+    const unsubscribe = vi.fn();
+    let eventListener:
+      | ((event: {
+          msg: {
+            type?: unknown;
+            payload: { serverName: string; elicitationId: string };
+          };
+        }) => void)
+      | undefined;
+    const session = {
+      services: {
+        requestUserInputResolver: previousUser,
+        mcpElicitationResolver: previousMcp,
+      },
+      eventLog: {
+        subscribe: vi.fn((listener: NonNullable<typeof eventListener>) => {
+          eventListener = listener;
+          return unsubscribe;
+        }),
+      },
+    };
+    const prompted: unknown[] = [];
+    const controller = installElicitationResolvers(session, pending => {
+      prompted.push(pending);
+    });
+
+    const preAborted = new AbortController();
+    preAborted.abort();
+    const abortedRequest = session.services.requestUserInputResolver.request(
+      userRequest([
+        {
+          id: "choice",
+          header: "Choice",
+          question: "Pick one",
+          options: [],
+        },
+      ]),
+      preAborted.signal,
+    );
+
+    await expect(abortedRequest).resolves.toBeNull();
+    expect(prompted.at(-1)).toBeNull();
+
+    const pendingUrl = session.services.mcpElicitationResolver.request(
+      mcpUrlRequest("url-3"),
+    );
+    expect(prompted.at(-1)).toMatchObject({ kind: "mcp-url" });
+
+    eventListener?.({
+      msg: {
+        type: "other",
+        payload: { serverName: "auth", elicitationId: "url-3" },
+      },
+    });
+    let resolved = false;
+    void pendingUrl.then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    eventListener?.({
+      msg: {
+        type: "mcp_elicitation_complete",
+        payload: { serverName: "auth", elicitationId: "url-3" },
+      },
+    });
+
+    await expect(pendingUrl).resolves.toEqual({ action: "accept" });
+    expect(prompted.at(-1)).toBeNull();
+
+    controller.cleanup();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(session.services.requestUserInputResolver).toBe(previousUser);
+    expect(session.services.mcpElicitationResolver).toBe(previousMcp);
+  });
+
+  test("enqueueSlashPromptResult ignores blank content and queues trimmed work", () => {
+    const scheduleQueueDrain = vi.fn();
+    resetCommandQueue();
+
+    try {
+      expect(enqueueSlashPromptResult("   ", scheduleQueueDrain)).toBe(false);
+      expect(getCommandQueue()).toEqual([]);
+      expect(scheduleQueueDrain).not.toHaveBeenCalled();
+
+      expect(enqueueSlashPromptResult("  queued content  ", scheduleQueueDrain)).toBe(
+        true,
+      );
+      expect(getCommandQueue()).toMatchObject([
+        {
+          value: "  queued content  ",
+          preExpansionValue: "  queued content  ",
+          mode: "prompt",
+        },
+      ]);
+      expect(scheduleQueueDrain).toHaveBeenCalledTimes(1);
+    } finally {
+      resetCommandQueue();
+    }
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-003-session-transcript.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-003-session-transcript.test.ts
@@ -1,0 +1,619 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { describe, expect, test } from "vitest";
+
+import { createRoot, type Root } from "../ink/root.js";
+import {
+  adaptTranscriptEvents,
+  formatStructuredToolResult,
+  useSessionTranscript,
+  type AdaptedTranscript,
+  type SessionTranscriptEvent,
+} from "../session-transcript.js";
+
+function evt(
+  id: string,
+  type: string,
+  payload: Record<string, unknown> = {},
+): SessionTranscriptEvent {
+  return { id, msg: { type, payload } } as SessionTranscriptEvent;
+}
+
+function systemContents(transcript: AdaptedTranscript): string[] {
+  return transcript.messages
+    .filter((message) => message.type === "system")
+    .map((message) => String(message.content));
+}
+
+function createStreams(): {
+  readonly stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  readonly stdout: PassThrough;
+} {
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  const stdout = new PassThrough();
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  Object.assign(stdout, { columns: 120, rows: 24, isTTY: true });
+  stdout.resume();
+
+  return { stdin, stdout };
+}
+
+function flushEffects(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 5));
+}
+
+async function renderTranscriptHookHarness(): Promise<{
+  readonly dispose: () => Promise<void>;
+  readonly latest: () => AdaptedTranscript;
+  readonly render: (session: Record<string, unknown>) => Promise<void>;
+}> {
+  const { stdin, stdout } = createStreams();
+  const root: Root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+  let latestTranscript: AdaptedTranscript | undefined;
+
+  function Probe({ session }: { readonly session: Record<string, unknown> }): null {
+    latestTranscript = useSessionTranscript(session as never, [
+      { role: "user", content: "startup prompt" },
+    ]);
+    return null;
+  }
+
+  return {
+    dispose: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await flushEffects();
+    },
+    latest: () => {
+      if (latestTranscript === undefined) {
+        throw new Error("transcript hook did not render");
+      }
+      return latestTranscript;
+    },
+    render: async (session) => {
+      root.render(React.createElement(Probe, { session }));
+      await flushEffects();
+    },
+  };
+}
+
+describe("session transcript coverage swarm row 003", () => {
+  test("covers legacy tool JSON fallbacks and orphan structured result recovery rows", () => {
+    const transcript = adaptTranscriptEvents([
+      {
+        id: "legacy-empty-args",
+        type: "tool_call",
+        toolCall: { name: "EmptyArgs", arguments: "" },
+      } as SessionTranscriptEvent,
+      {
+        id: "legacy-bad-args",
+        type: "tool_call",
+        toolCall: { id: "legacy-bad", name: "BadArgs", arguments: "{bad" },
+      } as SessionTranscriptEvent,
+      evt("orphan-structured-ok", "tool_call_completed", {
+        callId: "orphan-ok",
+        result: [{ type: "text", text: "ok" }],
+        isError: false,
+      }),
+      evt("orphan-structured-error", "tool_call_completed", {
+        callId: "orphan-error",
+        result: [{ type: "text", text: "failed" }],
+        isError: true,
+      }),
+      evt("orphan-empty-array", "tool_call_completed", {
+        callId: "orphan-empty-array",
+        result: [],
+        isError: false,
+      }),
+    ]);
+
+    const toolUseBlocks = transcript.messages
+      .filter((message) => message.type === "assistant")
+      .map((message) => message.message.content[0]);
+
+    expect(toolUseBlocks).toEqual([
+      expect.objectContaining({ name: "EmptyArgs", input: {} }),
+      expect.objectContaining({
+        id: "legacy-bad",
+        name: "BadArgs",
+        input: { input: "{bad" },
+      }),
+    ]);
+    expect(systemContents(transcript)).toEqual([
+      "Tool completed before its start event was received (orphan-ok).",
+      "Tool failed before its start event was received (orphan-error).",
+      "Recovered tool result without matching start (orphan-empty-array): ",
+    ]);
+  });
+
+  test("formats structured tool result edge cases for MCP, Glob, and circular fallback data", () => {
+    const mcp = formatStructuredToolResult("MCP", "mcp_tool_call_end", {
+      result: { content: "mcp text" },
+    });
+    const globNoFiles = formatStructuredToolResult("Glob", "tool_call_completed", {
+      result: "No files found",
+      metadata: { pattern: "*.missing" },
+    });
+    const globBlankAndTruncated = formatStructuredToolResult(
+      "Glob",
+      "tool_call_completed",
+      {
+        result:
+          "\na.ts\n\n(Results are truncated. Consider using a more specific path or pattern.)",
+        metadata: { pattern: "*.ts" },
+      },
+    );
+    const globObjectTruncated = formatStructuredToolResult(
+      "Glob",
+      "tool_call_completed",
+      {
+        result: { paths: ["a.ts", 7], pattern: "*.ts" },
+        metadata: { truncated: true },
+      },
+    );
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const fallback = formatStructuredToolResult("Other", "tool_call_completed", {
+      result: circular,
+    });
+
+    expect(mcp).toEqual([{ type: "text", text: "mcp text" }]);
+    expect(globNoFiles).toEqual([
+      { type: "text", text: "<glob-pattern>*.missing</glob-pattern>" },
+      { type: "text", text: "<glob-paths></glob-paths>" },
+    ]);
+    expect(globBlankAndTruncated).toContainEqual({
+      type: "text",
+      text: "<glob-paths>a.ts</glob-paths>",
+    });
+    expect(globBlankAndTruncated).toContainEqual({
+      type: "text",
+      text: "<glob-truncated>true</glob-truncated>",
+    });
+    expect(globObjectTruncated).toContainEqual({
+      type: "text",
+      text: "<glob-paths>a.ts</glob-paths>",
+    });
+    expect(globObjectTruncated).toContainEqual({
+      type: "text",
+      text: "<glob-truncated>true</glob-truncated>",
+    });
+    expect(fallback).toEqual([{ type: "text", text: "[object Object]" }]);
+  });
+
+  test("filters protocol payload facts while preserving valid derived facts", () => {
+    const transcript = adaptTranscriptEvents([
+      evt("claim", "protocol_claim", {
+        message: "claim accepted",
+        escrowLamports: 20_000_000_000,
+        stakeLamports: Number.POSITIVE_INFINITY,
+        facts: [
+          null,
+          { label: "", value: "missing label" },
+          { label: "ok", value: true },
+          { label: "bad", value: { nested: true } },
+        ],
+      }),
+    ]);
+
+    expect(transcript.messages).toHaveLength(1);
+    expect(transcript.messages[0]).toMatchObject({
+      type: "system",
+      subtype: "protocol_event",
+      protocolKind: "claim",
+      content: "claim accepted",
+      badgeVariant: "worker",
+      state: "info",
+    });
+    expect(transcript.messages[0]?.facts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "escrow", value: expect.stringMatching(/^20/) }),
+        { label: "ok", value: "true" },
+      ]),
+    );
+    expect(
+      transcript.messages[0]?.facts.map(
+        (fact: { readonly label: string }) => fact.label,
+      ),
+    ).not.toContain("bad");
+  });
+
+  test("normalizes sparse token counts and background-agent status variants", () => {
+    const longMessage = Array.from({ length: 80 }, (_, index) => `word${index}`).join(
+      "   ",
+    );
+    const transcript = adaptTranscriptEvents([
+      evt("tokens", "token_count", {
+        promptTokens: -4.8,
+        completionTokens: 2.9,
+        totalTokens: 0,
+        cachedInputTokens: "not numeric",
+        model: " ",
+        provider: " ",
+      }),
+      evt("running", "background_agent_status", {
+        status: "running",
+        message: longMessage,
+      }),
+      evt("complete", "background_agent_status", {
+        status: "COMPLETE",
+      }),
+      evt("cancelled", "background_agent_status", {
+        status: "killed",
+      }),
+      evt("custom", "background_agent_status", {
+        status: "custom_status",
+      }),
+      evt("idle-non-string", "background_agent_status", {
+        status: null,
+        message: "should not render",
+      }),
+    ]);
+
+    const contents = systemContents(transcript);
+
+    expect(contents[0]).toContain("0 in");
+    expect(contents[0]).toContain("2 out");
+    expect(contents[0]).toContain("2 total");
+    expect(contents[0]).toContain("est.");
+    expect(contents[0]).not.toContain("unknown");
+    expect(contents[1]).toContain("Background agent running: word0 word1");
+    expect(contents[1]!.length).toBeLessThan(210);
+    expect(contents).toContain("Background agent completed");
+    expect(contents).toContain("Background agent cancelled");
+    expect(contents).toContain("Background agent custom-status");
+    expect(contents.join("\n")).not.toContain("should not render");
+  });
+
+  test("handles realtime defaults and event-key fallback paths", () => {
+    const circularEvent = {
+      type: "error",
+      payload: {},
+    } as SessionTranscriptEvent & { payload: { message?: unknown } };
+    circularEvent.payload.message = circularEvent;
+
+    const transcript = adaptTranscriptEvents([
+      { type: "context_compacted" } as SessionTranscriptEvent,
+      { type: "realtime_started", payload: {} } as SessionTranscriptEvent,
+      {
+        type: "realtime_transcript_delta",
+        payload: { role: "assistant", delta: "voice preview" },
+      } as SessionTranscriptEvent,
+      {
+        type: "realtime_transcript_delta",
+        payload: { role: "user", delta: "ignored" },
+      } as SessionTranscriptEvent,
+      { type: "realtime_error", payload: {} } as SessionTranscriptEvent,
+      {
+        type: "realtime_closed",
+        payload: { reason: "   " },
+      } as SessionTranscriptEvent,
+      circularEvent,
+    ]);
+
+    expect(systemContents(transcript)).toEqual([
+      "Context compacted",
+      "Realtime voice started",
+      "Realtime error",
+      "Realtime closed",
+      "[object Object]",
+    ]);
+    expect(transcript.streamingText).toBeNull();
+  });
+
+  test("maps slash result variants without leaking silent control results", () => {
+    const transcript = adaptTranscriptEvents([
+      {
+        id: "slash-text",
+        type: "slash_result",
+        result: { kind: "text", text: "plain text" },
+      } as SessionTranscriptEvent,
+      {
+        id: "slash-compact",
+        type: "slash_result",
+        result: { kind: "compact", text: "compact text" },
+      } as SessionTranscriptEvent,
+      {
+        id: "slash-empty-error",
+        type: "slash_result",
+        result: { kind: "error", message: "" },
+      } as SessionTranscriptEvent,
+      {
+        id: "slash-content-error",
+        type: "slash_result",
+        payload: { kind: "error", message: { content: "content error" } },
+      } as SessionTranscriptEvent,
+      {
+        id: "slash-text-non-string",
+        type: "slash_result",
+        result: { kind: "text", text: 7 },
+      } as SessionTranscriptEvent,
+      {
+        id: "slash-skip",
+        type: "slash_result",
+        result: { kind: "skip" },
+      } as SessionTranscriptEvent,
+      {
+        id: "slash-exit",
+        type: "slash_result",
+        result: { kind: "exit" },
+      } as SessionTranscriptEvent,
+      {
+        id: "slash-prompt",
+        type: "slash_result",
+        result: { kind: "prompt" },
+      } as SessionTranscriptEvent,
+      {
+        id: "slash-weird",
+        type: "slash_result",
+        payload: { kind: "weird", value: 9 },
+      } as SessionTranscriptEvent,
+    ]);
+
+    expect(systemContents(transcript)).toEqual([
+      "plain text",
+      "compact text",
+      "Error: slash command failed",
+      "Error: content error",
+      '{\n  "kind": "weird",\n  "value": 9\n}',
+    ]);
+  });
+
+  test("parses subagent notifications across status encodings and falls back to assistant text", () => {
+    const transcript = adaptTranscriptEvents([
+      evt("subagent-running", "agent_message", {
+        message:
+          '<subagent_notification>{"agent_path":"worker-thread-123456","status":"running"}</subagent_notification>',
+      }),
+      evt("subagent-completed", "agent_message", {
+        message:
+          '<subagent_notification>{"agent_path":"worker-thread-2","status":{"completed":"done"}} </subagent_notification>',
+      }),
+      evt("subagent-errored", "agent_message", {
+        message:
+          '<subagent_notification>{"agent_path":"worker-thread-3","status":{"errored":""}}</subagent_notification>',
+      }),
+      evt("subagent-unknown", "agent_message", {
+        message:
+          '<subagent_notification>{"agent_path":"worker-thread-4","status":{}}</subagent_notification>',
+      }),
+      evt("subagent-invalid", "agent_message", {
+        message: "<subagent_notification>{not json}</subagent_notification>",
+      }),
+    ]);
+
+    const collabRows = transcript.messages.filter(
+      (message) => message.subtype === "collab_agent",
+    );
+    const assistantRows = transcript.messages.filter(
+      (message) => message.type === "assistant",
+    );
+
+    expect(collabRows).toMatchObject([
+      { state: "running", details: ["status: Running"] },
+      { state: "success", details: ["done"] },
+      { state: "error", details: ["error"] },
+    ]);
+    expect(assistantRows).toHaveLength(2);
+    expect(JSON.stringify(assistantRows)).toContain("worker-thread-4");
+    expect(JSON.stringify(assistantRows)).toContain("{not json}");
+  });
+
+  test("synthesizes streamed tool input on completion and ignores malformed stream events", () => {
+    const transcript = adaptTranscriptEvents([
+      evt("block-no-call", "tool_input_block_start", { index: 0 }),
+      evt("block-no-index", "tool_input_block_start", { callId: "missing-index" }),
+      evt("delta-no-index", "tool_input_delta", { partialJson: "{}" }),
+      evt("delta-non-string", "tool_input_delta", {
+        index: 1,
+        partialJson: 7,
+      }),
+      evt("stream-start", "tool_input_block_start", {
+        callId: "stream-1",
+        index: 1,
+        contentBlock: {
+          type: "tool_use",
+          id: "stream-1",
+          name: "FileRead",
+          input: { path: "src/a.ts" },
+        },
+      }),
+      evt("stream-start-duplicate", "tool_input_block_start", {
+        callId: "stream-1",
+        index: 1,
+        contentBlock: {
+          type: "tool_use",
+          id: "stream-1",
+          name: "FileRead",
+          input: { path: "src/a.ts" },
+        },
+      }),
+      evt("stream-complete", "tool_call_completed", {
+        callId: "stream-1",
+        result: { content: "done" },
+      }),
+    ]);
+
+    expect(transcript.streamingToolUses).toEqual([]);
+    expect(transcript.inProgressToolUseIDs.size).toBe(0);
+    expect(transcript.toolNames.has("FileRead")).toBe(true);
+    expect(transcript.messages).toHaveLength(2);
+    expect(transcript.messages[0]?.message.content[0]).toMatchObject({
+      type: "tool_use",
+      id: "stream-1",
+      name: "FileRead",
+      input: { path: "src/a.ts" },
+    });
+    expect(transcript.messages[1]?.message.content[0]).toMatchObject({
+      type: "tool_result",
+      tool_use_id: "stream-1",
+    });
+  });
+
+  test("renders collab lifecycle edge states and fallback status details", () => {
+    const transcript = adaptTranscriptEvents([
+      evt("settled-spawn-begin", "collab_agent_spawn_begin", {
+        callId: "settled-spawn",
+        prompt: "this begin row is stale",
+      }),
+      evt("settled-spawn-end", "collab_agent_spawn_end", {
+        callId: "settled-spawn",
+        newThreadId: "thread-settled",
+        newAgentRole: "reviewer",
+        prompt: "review the changes",
+        newAgentPath: "/tmp/reviewer",
+        status: { status: "interrupted", reason: "operator paused the worker" },
+      }),
+      evt("spawn-running", "collab_agent_spawn_begin", {
+        callId: "spawn-running",
+        prompt: "draft a plan",
+        taskName: "plan-draft",
+        model: "local-model",
+        reasoningEffort: "high",
+      }),
+      evt("interaction-begin", "collab_agent_interaction_begin", {
+        callId: "interaction-1",
+        receiverThreadId: "shortid",
+        prompt: "send status",
+      }),
+      evt("interaction-end", "collab_agent_interaction_end", {
+        callId: "interaction-1",
+        receiverThreadId: "shortid",
+        status: null,
+      }),
+      evt("wait-begin-empty", "collab_waiting_begin", {
+        callId: "wait-empty",
+      }),
+      evt("wait-end-statuses", "collab_waiting_end", {
+        callId: "wait-empty",
+        statuses: {
+          "agent-a": { status: "errored", error: "failed check" },
+          "agent-b": { status: "shutdown" },
+        },
+      }),
+    ]);
+
+    expect(transcript.inProgressToolUseIDs).toEqual(new Set(["spawn-running"]));
+    expect(transcript.messages).toMatchObject([
+      {
+        subtype: "collab_agent",
+        title: "Spawned reviewer",
+        state: "running",
+        details: expect.arrayContaining([
+          "review the changes",
+          "status: Interrupted - operator paused the worker",
+          "manage: wait_agent, send_message, or close_agent /tmp/reviewer",
+        ]),
+      },
+      {
+        subtype: "collab_agent",
+        title: "Spawning agent",
+        state: "running",
+        details: ["draft a plan", "task plan-draft", "model local-model, effort high"],
+      },
+      {
+        subtype: "collab_agent",
+        title: "Sending input to shortid",
+        state: "running",
+        details: ["send status"],
+      },
+      {
+        subtype: "collab_agent",
+        title: "Sent input to shortid",
+        state: "info",
+        details: ["status: unavailable"],
+      },
+      {
+        subtype: "collab_agent",
+        title: "Waiting for agents",
+        state: "running",
+        details: [],
+      },
+      {
+        subtype: "collab_agent",
+        title: "Finished waiting",
+        state: "error",
+        details: ["agent-a: Error - failed check", "agent-b: Shutdown"],
+      },
+    ]);
+  });
+
+  test("useSessionTranscript consumes initial events, subscriptions, phase events, and cleanup", async () => {
+    let eventLogCallback: ((event: SessionTranscriptEvent) => void) | undefined;
+    let phaseCallback: ((event: unknown) => void) | undefined;
+    let unsubscribedLog = false;
+    let unsubscribedPhase = false;
+    const getterSession = {
+      initialTranscriptEvents: [
+        evt("ignored-property", "user_message", { message: "ignored property" }),
+      ],
+      getInitialTranscriptEvents: () => [
+        evt("getter-initial", "user_message", { message: "from getter" }),
+      ],
+      eventLog: {
+        subscribe: (callback: (event: SessionTranscriptEvent) => void) => {
+          eventLogCallback = callback;
+          return () => {
+            unsubscribedLog = true;
+          };
+        },
+      },
+      subscribeToEvents: (callback: (event: unknown) => void) => {
+        phaseCallback = callback;
+        return () => {
+          unsubscribedPhase = true;
+        };
+      },
+    };
+    const propertySession = {
+      initialTranscriptEvents: [
+        evt("property-initial", "user_message", { message: "from property" }),
+      ],
+    };
+    const harness = await renderTranscriptHookHarness();
+
+    try {
+      await harness.render(getterSession);
+      expect(JSON.stringify(harness.latest().messages)).toContain("startup prompt");
+      expect(JSON.stringify(harness.latest().messages)).toContain("from getter");
+      expect(JSON.stringify(harness.latest().messages)).not.toContain("ignored property");
+
+      eventLogCallback?.(evt("log-event", "user_message", { message: "from log" }));
+      phaseCallback?.({ type: "context_compacted" });
+      phaseCallback?.(null);
+      await flushEffects();
+
+      expect(JSON.stringify(harness.latest().messages)).toContain("from log");
+      expect(JSON.stringify(harness.latest().messages)).toContain("Context compacted");
+
+      await harness.render(propertySession);
+
+      expect(unsubscribedLog).toBe(true);
+      expect(unsubscribedPhase).toBe(true);
+      expect(JSON.stringify(harness.latest().messages)).toContain("from property");
+      expect(JSON.stringify(harness.latest().messages)).not.toContain("from getter");
+    } finally {
+      await harness.dispose();
+    }
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-004-ink-ink.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-004-ink-ink.test.tsx
@@ -1,0 +1,310 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import type Ink from '../ink/ink.tsx'
+import type { Frame } from '../ink/frame.ts'
+import instances from '../ink/instances.ts'
+import { createRoot, type Root } from '../ink/root.ts'
+import { CURSOR_HOME, DISABLE_KITTY_KEYBOARD, DISABLE_MODIFY_OTHER_KEYS, ERASE_SCREEN } from '../ink/termio/csi.ts'
+import { DISABLE_MOUSE_TRACKING, ENABLE_MOUSE_TRACKING, ENTER_ALT_SCREEN, EXIT_ALT_SCREEN } from '../ink/termio/dec.ts'
+
+type TestStdout = PassThrough & {
+  columns: number
+  rows: number
+  isTTY: boolean
+}
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  isRaw?: boolean
+  setRawMode: (mode: boolean) => void
+  ref: () => void
+  unref: () => void
+}
+
+type InkInternals = Ink & {
+  frontFrame: Frame
+  handleResume: () => void
+}
+
+const RAW_TEXT_STYLE = {
+  flexDirection: 'row',
+  flexGrow: 0,
+  flexShrink: 1,
+  textWrap: 'wrap',
+} as const
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function textNode(children: React.ReactNode): React.ReactElement {
+  return React.createElement(
+    'ink-text',
+    {
+      style: RAW_TEXT_STYLE,
+    },
+    children,
+  )
+}
+
+function columnNode(...rows: string[]): React.ReactElement {
+  return React.createElement(
+    'ink-box',
+    {
+      style: {
+        flexDirection: 'column',
+        flexGrow: 0,
+        flexShrink: 1,
+      },
+    },
+    rows.map((row, index) =>
+      React.createElement(
+        'ink-text',
+        {
+          key: index,
+          style: RAW_TEXT_STYLE,
+        },
+        row,
+      ),
+    ),
+  )
+}
+
+function createTestStreams(options: {
+  columns?: number
+  rows?: number
+  stdoutIsTTY?: boolean
+  stdinIsTTY?: boolean
+  stdinIsRaw?: boolean
+} = {}): {
+  stdout: TestStdout
+  stdin: TestStdin
+  stderr: PassThrough
+  stdoutWrites: string[]
+  rawModes: boolean[]
+} {
+  const stdout = new PassThrough() as TestStdout
+  const stdin = new PassThrough() as TestStdin
+  const stderr = new PassThrough()
+  const stdoutWrites: string[] = []
+  const rawModes: boolean[] = []
+
+  stdout.columns = options.columns ?? 24
+  stdout.rows = options.rows ?? 6
+  stdout.isTTY = options.stdoutIsTTY ?? true
+  stdout.on('data', chunk => {
+    stdoutWrites.push(Buffer.from(chunk).toString('utf8'))
+  })
+
+  stdin.isTTY = options.stdinIsTTY ?? true
+  stdin.isRaw = options.stdinIsRaw ?? false
+  stdin.setRawMode = (mode: boolean) => {
+    rawModes.push(mode)
+    stdin.isRaw = mode
+  }
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+
+  return { stdout, stdin, stderr, stdoutWrites, rawModes }
+}
+
+function getInkInstance(stdout: PassThrough): InkInternals {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+  if (!instance) throw new Error('Ink instance not found')
+  return instance as unknown as InkInternals
+}
+
+async function createHarness(options: {
+  columns?: number
+  rows?: number
+  stdoutIsTTY?: boolean
+  stdinIsTTY?: boolean
+  stdinIsRaw?: boolean
+} = {}): Promise<{
+  root: Root
+  instance: InkInternals
+  stdout: TestStdout
+  stdin: TestStdin
+  stderr: PassThrough
+  stdoutWrites: string[]
+  rawModes: boolean[]
+  dispose: () => Promise<void>
+}> {
+  const { stdout, stdin, stderr, stdoutWrites, rawModes } =
+    createTestStreams(options)
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    patchConsole: false,
+  })
+  const instance = getInkInstance(stdout)
+
+  return {
+    root,
+    instance,
+    stdout,
+    stdin,
+    stderr,
+    stdoutWrites,
+    rawModes,
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      stderr.end()
+      await sleep(25)
+    },
+  }
+}
+
+describe('Ink coverage swarm row 004', () => {
+  test('handles resume paths for main-screen and alt-screen buffers', async () => {
+    const harness = await createHarness({ columns: 22, rows: 5 })
+
+    try {
+      harness.root.render(textNode('resume'))
+      await sleep(10)
+
+      harness.stdoutWrites.length = 0
+      harness.instance.handleResume()
+
+      expect(harness.stdoutWrites.join('')).toBe('')
+      expect(harness.instance.frontFrame.screen.width).toBe(0)
+      expect(harness.instance.frontFrame.screen.height).toBe(0)
+
+      harness.instance.setAltScreenActive(true, true)
+      harness.stdoutWrites.length = 0
+
+      harness.instance.handleResume()
+
+      const writes = harness.stdoutWrites.join('')
+      expect(writes).toContain(ENTER_ALT_SCREEN + ERASE_SCREEN + CURSOR_HOME)
+      expect(writes).toContain(ENABLE_MOUSE_TRACKING)
+      expect(harness.instance.frontFrame.screen.width).toBe(22)
+      expect(harness.instance.frontFrame.screen.height).toBe(5)
+    } finally {
+      await harness.dispose()
+    }
+  })
+
+  test('hands off and restores external alternate-screen terminal sessions', async () => {
+    const harness = await createHarness({ stdinIsRaw: true })
+    const readableListener = vi.fn()
+
+    try {
+      harness.root.render(textNode('handoff'))
+      await sleep(10)
+      harness.stdin.on('readable', readableListener)
+
+      harness.stdoutWrites.length = 0
+      harness.instance.enterAlternateScreen()
+
+      let writes = harness.stdoutWrites.join('')
+      expect(harness.stdin.listenerCount('readable')).toBe(0)
+      expect(harness.rawModes.at(-1)).toBe(false)
+      expect(writes).toContain(
+        DISABLE_KITTY_KEYBOARD + DISABLE_MODIFY_OTHER_KEYS,
+      )
+      expect(writes).toContain(ENTER_ALT_SCREEN)
+
+      harness.stdoutWrites.length = 0
+      harness.instance.exitAlternateScreen()
+
+      writes = harness.stdoutWrites.join('')
+      expect(harness.stdin.listeners('readable')).toContain(readableListener)
+      expect(harness.rawModes.at(-1)).toBe(true)
+      expect(writes).toContain(EXIT_ALT_SCREEN)
+
+      harness.instance.setAltScreenActive(true, true)
+      harness.stdoutWrites.length = 0
+      harness.instance.enterAlternateScreen()
+
+      writes = harness.stdoutWrites.join('')
+      expect(writes).toContain(DISABLE_MOUSE_TRACKING)
+      expect(writes).not.toContain(ENTER_ALT_SCREEN)
+
+      harness.stdoutWrites.length = 0
+      harness.instance.exitAlternateScreen()
+
+      writes = harness.stdoutWrites.join('')
+      expect(writes).toContain(ENTER_ALT_SCREEN + ERASE_SCREEN + CURSOR_HOME)
+      expect(writes).toContain(ENABLE_MOUSE_TRACKING)
+      expect(writes).not.toContain(EXIT_ALT_SCREEN)
+    } finally {
+      await harness.dispose()
+    }
+  })
+
+  test('covers selection helpers and keyboard extension edge cases', async () => {
+    const harness = await createHarness({ columns: 12, rows: 5 })
+    const selectionChanges = vi.fn()
+
+    try {
+      harness.instance.setAltScreenActive(true)
+      harness.root.render(columnNode('alpha', 'beta', 'gamma'))
+      await sleep(10)
+
+      harness.instance.setSelectionBgColor('not-a-real-color')
+      harness.instance.setSelectionBgColor('#102030')
+
+      const unsubscribe =
+        harness.instance.subscribeToSelectionChange(selectionChanges)
+      const selection = harness.instance.selection
+      selection.anchor = { col: 0, row: 1 }
+      selection.focus = { col: 0, row: 1 }
+      selection.isDragging = false
+
+      harness.instance.moveSelectionFocus('left')
+      expect(selection.focus).toEqual({
+        col: harness.instance.frontFrame.screen.width - 1,
+        row: 0,
+      })
+
+      harness.instance.moveSelectionFocus('right')
+      expect(selection.focus).toEqual({ col: 0, row: 1 })
+
+      harness.instance.moveSelectionFocus('down')
+      expect(selection.focus).toEqual({ col: 0, row: 2 })
+
+      harness.instance.moveSelectionFocus('up')
+      expect(selection.focus).toEqual({ col: 0, row: 1 })
+
+      harness.instance.moveSelectionFocus('lineEnd')
+      expect(selection.focus).toEqual({
+        col: harness.instance.frontFrame.screen.width - 1,
+        row: 1,
+      })
+
+      harness.instance.moveSelectionFocus('lineStart')
+      expect(selection.focus).toEqual({ col: 0, row: 1 })
+
+      selection.anchor = { col: 0, row: 0 }
+      selection.focus = { col: 2, row: 0 }
+      harness.instance.captureScrolledRows(0, 0, 'above')
+      expect(selection.scrolledOffAbove).toEqual(['alp'])
+
+      harness.instance.setAltScreenActive(false)
+      harness.instance.moveSelectionFocus('right')
+      expect(selection.focus).toEqual({ col: 2, row: 0 })
+
+      harness.instance.setAltScreenActive(true)
+      selection.focus = null
+      harness.instance.moveSelectionFocus('right')
+      expect(selection.focus).toBeNull()
+
+      selection.anchor = { col: 0, row: 0 }
+      selection.focus = { col: 1, row: 0 }
+      harness.instance.shiftSelectionForScroll(-5, 0, 1)
+
+      expect(harness.instance.hasTextSelection()).toBe(false)
+      expect(selectionChanges).toHaveBeenCalled()
+      unsubscribe()
+    } finally {
+      await harness.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-005-components-Messages.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-005-components-Messages.test.tsx
@@ -1,0 +1,543 @@
+import { PassThrough } from 'node:stream'
+import type { ReactNode } from 'react'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  rows: [] as Array<{
+    canAnimate: boolean
+    hasContentAfter: boolean
+    isUserContinuation: boolean
+    lastThinkingBlockId: string | null
+    latestBashOutputUUID: string | null
+    type: string
+    uuid: string
+    verbose: boolean
+  }>,
+  dividers: [] as string[],
+  features: new Set<string>(),
+  hasContentAfterIndexResult: false,
+  progress: vi.fn(),
+  streamingMarkdown: [] as string[],
+  thinkingMessages: [] as string[],
+  virtualCalls: [] as Array<{
+    extractSearchText: (message: unknown) => string
+    isItemClickable: (message: unknown) => boolean
+    isItemExpanded: (message: unknown) => boolean
+    messages: unknown[]
+    onItemClick: (message: unknown) => void
+    selectedIndex: number | undefined
+  }>,
+  reset() {
+    harness.rows = []
+    harness.dividers = []
+    harness.features = new Set()
+    harness.hasContentAfterIndexResult = false
+    harness.progress.mockClear()
+    harness.streamingMarkdown = []
+    harness.thinkingMessages = []
+    harness.virtualCalls = []
+  },
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => harness.features.has(name),
+}))
+
+vi.mock('../../../src/bootstrap/state.js', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    flushInteractionTime: () => {},
+    getActiveTimeCounter: () => null,
+    getAllowedSettingSources: () => [],
+    getFlagSettingsInline: () => null,
+    getFlagSettingsPath: () => undefined,
+    getIsRemoteMode: () => false,
+  }
+})
+
+vi.mock('../../../src/tui/hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: 48, rows: 24 }),
+}))
+
+vi.mock('../../../src/tui/keybindings/useShortcutDisplay.js', () => ({
+  useShortcutDisplay: () => 'Ctrl+E',
+}))
+
+vi.mock('../../../src/tui/ink/useTerminalNotification.js', async () => {
+  const ReactModule = await import('react')
+  const TerminalWriteContext = ReactModule.createContext<((data: string) => void) | null>(null)
+  return {
+    TerminalWriteContext,
+    TerminalWriteProvider: TerminalWriteContext.Provider,
+    useTerminalNotification: () => ({ progress: harness.progress }),
+  }
+})
+
+vi.mock('../../../src/utils/config.js', () => ({
+  getGlobalConfig: () => ({ terminalProgressBarEnabled: true }),
+}))
+
+vi.mock('../../../src/utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => false,
+}))
+
+vi.mock('../../../src/tui/startup/StatusNotices.js', () => ({
+  StatusNotices: () => null,
+}))
+
+vi.mock('../../../src/tui/components/OffscreenFreeze.js', () => ({
+  OffscreenFreeze: ({ children }: { readonly children?: ReactNode }) =>
+    React.createElement(React.Fragment, null, children),
+}))
+
+vi.mock('../../../src/tui/components/v2/primitives.js', async () => {
+  const { Text } = await import('../../../src/tui/ink.js')
+  return {
+    WelcomeColdPanel: () => React.createElement(Text, null, 'welcome'),
+  }
+})
+
+vi.mock('../../../src/tui/components/design-system/Divider.js', async () => {
+  const { Text } = await import('../../../src/tui/ink.js')
+  return {
+    Divider: ({ title }: { readonly title: string }) => {
+      harness.dividers.push(title)
+      return React.createElement(Text, null, `divider:${title}`)
+    },
+  }
+})
+
+vi.mock('../../../src/tui/components/markdown/Markdown.js', async () => {
+  const { Text } = await import('../../../src/tui/ink.js')
+  return {
+    StreamingMarkdown: ({ children }: { readonly children?: ReactNode }) => {
+      harness.streamingMarkdown.push(String(children ?? ''))
+      return React.createElement(Text, null, children)
+    },
+  }
+})
+
+vi.mock('../../../src/tui/components/v2/messagePrimitives.js', async () => {
+  const { Text } = await import('../../../src/tui/ink.js')
+  return {
+    ThinkingMessage: ({
+      param,
+    }: {
+      readonly param: { readonly thinking: string }
+    }) => {
+      harness.thinkingMessages.push(param.thinking)
+      return React.createElement(Text, null, `thinking:${param.thinking}`)
+    },
+  }
+})
+
+vi.mock('../../../src/tui/components/MessageRow.js', async () => {
+  const { Text } = await import('../../../src/tui/ink.js')
+  return {
+    hasContentAfterIndex: vi.fn(() => harness.hasContentAfterIndexResult),
+    MessageRow: (props: {
+      readonly canAnimate: boolean
+      readonly hasContentAfter: boolean
+      readonly isUserContinuation: boolean
+      readonly lastThinkingBlockId?: string | null
+      readonly latestBashOutputUUID?: string | null
+      readonly message: { readonly type: string; readonly uuid: string }
+      readonly verbose: boolean
+    }) => {
+      harness.rows.push({
+        canAnimate: props.canAnimate,
+        hasContentAfter: props.hasContentAfter,
+        isUserContinuation: props.isUserContinuation,
+        lastThinkingBlockId: props.lastThinkingBlockId ?? null,
+        latestBashOutputUUID: props.latestBashOutputUUID ?? null,
+        type: props.message.type,
+        uuid: props.message.uuid,
+        verbose: props.verbose,
+      })
+      return React.createElement(Text, null, `row:${props.message.uuid}`)
+    },
+  }
+})
+
+vi.mock('../../../src/tui/components/VirtualMessageList.js', async () => {
+  const { Text } = await import('../../../src/tui/ink.js')
+  return {
+    VirtualMessageList: (props: {
+      readonly extractSearchText: (message: unknown) => string
+      readonly isItemClickable: (message: unknown) => boolean
+      readonly isItemExpanded: (message: unknown) => boolean
+      readonly messages: unknown[]
+      readonly onItemClick: (message: unknown) => void
+      readonly renderItem: (message: unknown, index: number) => ReactNode
+      readonly selectedIndex?: number
+    }) => {
+      harness.virtualCalls.push({
+        extractSearchText: props.extractSearchText,
+        isItemClickable: props.isItemClickable,
+        isItemExpanded: props.isItemExpanded,
+        messages: props.messages,
+        onItemClick: props.onItemClick,
+        selectedIndex: props.selectedIndex,
+      })
+      const children = props.messages.flatMap((message, index) => {
+        const rendered = props.renderItem(message, index)
+        return Array.isArray(rendered) ? rendered : [rendered]
+      })
+      return React.createElement(
+        React.Fragment,
+        null,
+        ...children,
+        React.createElement(Text, null, `virtual:${props.messages.length}`),
+      )
+    },
+  }
+})
+
+import { createRoot } from '../../../src/tui/ink/root.js'
+import type { Tools } from '../../../src/tools/Tool.js'
+import { Messages } from '../../../src/tui/components/Messages.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+function createStreams(): {
+  stdin: TestStdin
+  stdout: PassThrough
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStdin
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function render(node: ReactNode): Promise<{
+  dispose: () => Promise<void>
+  rerender: (next: ReactNode) => Promise<void>
+}> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  root.render(node)
+  await sleep()
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    rerender: async next => {
+      root.render(next)
+      await sleep()
+    },
+  }
+}
+
+const commands = []
+const emptyQueue = []
+const emptyTools = [] as unknown as Tools
+
+const baseProps = {
+  commands,
+  conversationId: 'swarm-005',
+  inProgressToolUseIDs: new Set<string>(),
+  isLoading: false,
+  isMessageSelectorVisible: false,
+  messages: [],
+  screen: 'main' as const,
+  streamingToolUses: [],
+  toolJSX: null,
+  toolUseConfirmQueue: emptyQueue,
+  tools: emptyTools,
+  verbose: false,
+}
+
+function user(uuid: string, text: string) {
+  return {
+    message: { content: [{ text, type: 'text' }] },
+    type: 'user',
+    uuid,
+  }
+}
+
+function assistantToolUse(uuid: string, id: string, name = 'Read') {
+  return {
+    message: {
+      content: [{ id, input: { file_path: 'src/example.ts' }, name, type: 'tool_use' }],
+    },
+    type: 'assistant',
+    uuid,
+  }
+}
+
+function userToolResult(uuid: string, toolUseID: string, toolUseResult: unknown) {
+  return {
+    message: {
+      content: [{ content: 'done', tool_use_id: toolUseID, type: 'tool_result' }],
+    },
+    toolUseResult,
+    type: 'user',
+    uuid,
+  }
+}
+
+function latestVirtualCall() {
+  const call = harness.virtualCalls.at(-1)
+  expect(call).toBeDefined()
+  return call!
+}
+
+describe('Messages coverage swarm row 005', () => {
+  beforeEach(() => {
+    harness.reset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('renders virtual rows with selection, dividers, streaming output, and derived row props', async () => {
+    const messages = [
+      user('bash-output', '<bash-stdout>ok'),
+      user('next-user', 'next prompt'),
+      assistantToolUse('tool-use-row', 'tool-read'),
+      userToolResult('tool-result-row', 'tool-read', { text: 'done' }),
+    ]
+    const rendered = await render(
+      <Messages
+        {...baseProps}
+        cursor={{ expanded: true, uuid: 'next-user' }}
+        hidePastThinking={true}
+        messages={messages}
+        scrollRef={{ current: null }}
+        streamingText="streaming answer"
+        streamingThinking={{
+          isStreaming: true,
+          streamingEndedAt: 100,
+          thinking: 'still thinking',
+        }}
+        toolJSX={{ jsx: null, shouldHidePromptInput: false }}
+        unseenDivider={{ count: 1, firstUnseenUuid: 'next-user' }}
+      />,
+    )
+
+    try {
+      expect(harness.rows.map(row => row.uuid)).toContain('next-user')
+      const nextUserRow = harness.rows.find(row => row.uuid === 'next-user')
+      expect(nextUserRow).toMatchObject({
+        canAnimate: false,
+        isUserContinuation: true,
+        lastThinkingBlockId: 'streaming',
+        latestBashOutputUUID: 'bash-output',
+        verbose: true,
+      })
+      expect(latestVirtualCall().selectedIndex).toBe(1)
+      expect(harness.dividers).toContain('1 new message')
+      expect(harness.streamingMarkdown).toContain('streaming answer')
+      expect(harness.thinkingMessages).toContain('still thinking')
+      expect(harness.progress).toHaveBeenCalledWith('completed')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('classifies virtual-list click targets and caches tool-owned search text', async () => {
+    const extractSearchText = vi.fn(() => 'Needle From Tool')
+    const isResultTruncated = vi.fn(() => true)
+    const tools = [
+      {
+        extractSearchText,
+        isResultTruncated,
+        name: 'Read',
+      },
+    ] as unknown as Tools
+    const rendered = await render(
+      <Messages
+        {...baseProps}
+        messages={[
+          assistantToolUse('tool-use-row', 'tool-read'),
+          userToolResult('tool-result-row', 'tool-read', { lines: 200 }),
+        ]}
+        scrollRef={{ current: null }}
+        tools={tools}
+      />,
+    )
+
+    try {
+      const virtual = latestVirtualCall()
+      const toolResultMessage = {
+        message: {
+          content: [{ tool_use_id: 'tool-read', type: 'tool_result' }],
+        },
+        toolUseResult: { lines: 200 },
+        type: 'user',
+        uuid: 'manual-tool-result',
+      }
+
+      expect(
+        virtual.isItemClickable({ messages: [], type: 'collapsed_read_search', uuid: 'collapsed' }),
+      ).toBe(true)
+      expect(
+        virtual.isItemClickable({
+          message: {
+            content: [
+              {
+                content: { text: 'ok', type: 'advisor_result' },
+                tool_use_id: 'advisor-1',
+                type: 'advisor_tool_result',
+              },
+            ],
+          },
+          type: 'assistant',
+          uuid: 'advisor-result',
+        }),
+      ).toBe(true)
+      expect(
+        virtual.isItemClickable({
+          message: {
+            content: [
+              {
+                content: { encrypted_content: 'hidden', type: 'advisor_redacted_result' },
+                tool_use_id: 'advisor-1',
+                type: 'advisor_tool_result',
+              },
+            ],
+          },
+          type: 'assistant',
+          uuid: 'advisor-redacted-result',
+        }),
+      ).toBe(false)
+      expect(
+        virtual.isItemClickable({
+          message: { content: [{ text: 'plain', type: 'text' }] },
+          type: 'assistant',
+          uuid: 'assistant-text',
+        }),
+      ).toBe(false)
+      expect(
+        virtual.isItemClickable({
+          message: {
+            content: [{ is_error: true, tool_use_id: 'tool-read', type: 'tool_result' }],
+          },
+          toolUseResult: { lines: 200 },
+          type: 'user',
+          uuid: 'errored-result',
+        }),
+      ).toBe(false)
+      expect(virtual.isItemClickable(toolResultMessage)).toBe(true)
+      expect(isResultTruncated).toHaveBeenCalledWith({ lines: 200 })
+
+      expect(virtual.extractSearchText(toolResultMessage)).toBe('needle from tool')
+      expect(virtual.extractSearchText(toolResultMessage)).toBe('needle from tool')
+      expect(extractSearchText).toHaveBeenCalledTimes(1)
+
+      const expandableMessage = virtual.messages[0]!
+      expect(virtual.isItemExpanded(expandableMessage)).toBe(false)
+      virtual.onItemClick(expandableMessage)
+      await sleep()
+      expect(latestVirtualCall().isItemExpanded(expandableMessage)).toBe(true)
+      latestVirtualCall().onItemClick(expandableMessage)
+      await sleep()
+      expect(latestVirtualCall().isItemExpanded(expandableMessage)).toBe(false)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('renders transcript indicators for truncated and expanded histories', async () => {
+    const manyMessages = Array.from({ length: 35 }, (_, index) =>
+      user(`message-${index}`, `message ${index}`),
+    )
+    const truncated = await render(
+      <Messages
+        {...baseProps}
+        messages={manyMessages}
+        screen="transcript"
+      />,
+    )
+
+    try {
+      expect(harness.dividers.some(title => title.includes('to show 5 previous messages'))).toBe(true)
+    } finally {
+      await truncated.dispose()
+    }
+
+    harness.rows = []
+    harness.dividers = []
+    const expanded = await render(
+      <Messages
+        {...baseProps}
+        messages={manyMessages}
+        screen="transcript"
+        showAllInTranscript={true}
+      />,
+    )
+
+    try {
+      expect(harness.dividers.some(title => title.includes('to hide 5 previous messages'))).toBe(true)
+      expect(harness.rows).toHaveLength(35)
+    } finally {
+      await expanded.dispose()
+    }
+  })
+
+  test('memoizes semantically equal collection props but rerenders changed streaming thinking', async () => {
+    const contentBlock = {
+      id: 'stream-tool',
+      input: { command: 'pwd' },
+      name: 'Read',
+      type: 'tool_use',
+    }
+    const messages = [user('stable-user', 'hello')]
+    const makeProps = () => ({
+      ...baseProps,
+      inProgressToolUseIDs: new Set(['stream-tool']),
+      messages,
+      onOpenRateLimitOptions: vi.fn(),
+      streamingThinking: null,
+      streamingToolUses: [{ contentBlock }],
+      tools: [{ name: 'Read' }] as unknown as Tools,
+      unseenDivider: { count: 2, firstUnseenUuid: 'missing' },
+    })
+
+    const rendered = await render(<Messages {...makeProps()} />)
+
+    try {
+      const rowCount = harness.rows.length
+      await rendered.rerender(<Messages {...makeProps()} />)
+      expect(harness.rows).toHaveLength(rowCount)
+
+      await rendered.rerender(
+        <Messages
+          {...makeProps()}
+          streamingThinking={{
+            isStreaming: true,
+            streamingEndedAt: 200,
+            thinking: 'new thought',
+          }}
+        />,
+      )
+      expect(harness.rows.length).toBeGreaterThan(rowCount)
+      expect(harness.thinkingMessages).toContain('new thought')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-006-ink-native-ts-yoga-layout-index.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-006-ink-native-ts-yoga-layout-index.test.ts
@@ -1,0 +1,480 @@
+import { describe, expect, test } from "vitest";
+
+import YogaDefault, {
+  Align,
+  BoxSizing,
+  Direction,
+  Edge,
+  FlexDirection,
+  Gutter,
+  Justify,
+  PositionType,
+  Unit,
+  Wrap,
+} from "../../../src/tui/ink/native-ts/yoga-layout/index.js";
+
+function unscaledConfig() {
+  const config = YogaDefault.Config.create();
+  config.setPointScaleFactor(0);
+  return config;
+}
+
+function expectClose(value: number, expected: number) {
+  expect(value).toBeCloseTo(expected, 5);
+}
+
+describe("coverage swarm row 006 yoga-layout shim", () => {
+  test("covers tree, lifecycle, dirty, and parity stub helpers", () => {
+    const root = YogaDefault.Node.createDefault();
+    const child = YogaDefault.Node.createDefault();
+    const stray = YogaDefault.Node.createDefault();
+
+    try {
+      root.removeChild(stray);
+      expect(root.getChildCount()).toBe(0);
+
+      root.setWidth(10);
+      root.setHeight(10);
+      child.setWidth(2);
+      root.insertChild(child, 0);
+
+      expect(root.getChild(0)).toBe(child);
+      expect(child.getParent()).toBe(root);
+
+      root.calculateLayout(undefined, undefined);
+      expect(root.isDirty()).toBe(false);
+
+      child.setHeight(3);
+      expect(child.isDirty()).toBe(true);
+      expect(root.isDirty()).toBe(true);
+      expect(child.hasNewLayout()).toBe(true);
+      child.markLayoutSeen();
+
+      root.removeChild(child);
+      expect(child.getParent()).toBeNull();
+
+      child.setMeasureFunc(() => ({ width: 1, height: 1 }));
+      child.unsetMeasureFunc();
+      expect(child.measureFunc).toBeNull();
+
+      child.copyStyle(root);
+      child.setDirtiedFunc(() => {});
+      child.unsetDirtiedFunc();
+      child.setAspectRatio(1);
+      child.setAlwaysFormsContainingBlock(true);
+      child.setBoxSizing(BoxSizing.ContentBox);
+      expect(Number.isNaN(child.getAspectRatio())).toBe(true);
+
+      child.reset();
+      expect(child.getChildCount()).toBe(0);
+      expect(child.getParent()).toBeNull();
+      expect(child.isDirty()).toBe(true);
+      expect(child.getWidth()).toMatchObject({ unit: Unit.Auto });
+    } finally {
+      root.free();
+      child.free();
+      stray.free();
+    }
+  });
+
+  test("normalizes additional style setters and getters", () => {
+    const node = YogaDefault.Node.createDefault();
+
+    try {
+      node.setWidth(undefined);
+      expect(node.getWidth().unit).toBe(Unit.Undefined);
+
+      node.setHeightAuto();
+      expect(node.getHeight().unit).toBe(Unit.Auto);
+      node.setHeightPercent(40);
+      expect(node.getHeight()).toEqual({ unit: Unit.Percent, value: 40 });
+
+      node.setMinWidthPercent(25);
+      node.setMinHeightPercent(30);
+      node.setMaxWidth("80");
+      expect(node.style.maxWidth).toEqual({ unit: Unit.Point, value: 80 });
+      node.setMaxWidthPercent(75);
+      node.setMaxHeightPercent(50);
+      expect(node.style.minWidth).toEqual({ unit: Unit.Percent, value: 25 });
+      expect(node.style.minHeight).toEqual({ unit: Unit.Percent, value: 30 });
+      expect(node.style.maxWidth).toEqual({ unit: Unit.Percent, value: 75 });
+      expect(node.style.maxHeight).toEqual({ unit: Unit.Percent, value: 50 });
+
+      node.setFlexGrow(undefined);
+      node.setFlexShrink(undefined);
+      node.setFlex(0);
+      expect(node.getFlexGrow()).toBe(0);
+      expect(node.getFlexShrink()).toBe(0);
+
+      node.setFlexBasis("auto");
+      expect(node.getFlexBasis().unit).toBe(Unit.Auto);
+      node.setFlexBasis("12");
+      expect(node.getFlexBasis()).toEqual({ unit: Unit.Point, value: 12 });
+
+      node.setFlexDirection(FlexDirection.RowReverse);
+      node.setPositionType(PositionType.Static);
+      node.setPositionAuto(Edge.Right);
+      node.setDirection(Direction.RTL);
+      expect(node.getFlexDirection()).toBe(FlexDirection.RowReverse);
+      expect(node.getPositionType()).toBe(PositionType.Static);
+      expect(node.getDirection()).toBe(Direction.RTL);
+      expect(node.style.position[Edge.Right]).toMatchObject({
+        unit: Unit.Auto,
+      });
+
+      node.setMargin(Edge.Right, "auto");
+      node.setMargin(Edge.Right, undefined);
+      node.setMarginPercent(Edge.Left, 25);
+      node.setGapPercent(Gutter.Row, 10);
+      expect(node.style.margin[Edge.Left]).toEqual({
+        unit: Unit.Percent,
+        value: 25,
+      });
+      expect(node.style.gap[Gutter.Row]).toEqual({
+        unit: Unit.Percent,
+        value: 10,
+      });
+    } finally {
+      node.free();
+    }
+  });
+
+  test("lays out reversed axes and percent min/max bounds", () => {
+    const config = unscaledConfig();
+    const rowReverse = YogaDefault.Node.createWithConfig(config);
+    const first = YogaDefault.Node.createWithConfig(config);
+    const second = YogaDefault.Node.createWithConfig(config);
+    const columnReverse = YogaDefault.Node.createWithConfig(config);
+    const top = YogaDefault.Node.createWithConfig(config);
+    const bottom = YogaDefault.Node.createWithConfig(config);
+    const bounded = YogaDefault.Node.createWithConfig(config);
+    const maxed = YogaDefault.Node.createWithConfig(config);
+    const mined = YogaDefault.Node.createWithConfig(config);
+
+    try {
+      rowReverse.setFlexDirection(FlexDirection.RowReverse);
+      rowReverse.setWidth(20);
+      rowReverse.setHeight(5);
+      first.setWidth(3);
+      first.setHeight(1);
+      second.setWidth(4);
+      second.setHeight(1);
+      rowReverse.insertChild(first, 0);
+      rowReverse.insertChild(second, 1);
+      rowReverse.calculateLayout(undefined, undefined);
+
+      expect(first.getComputedLeft()).toBe(17);
+      expect(second.getComputedLeft()).toBe(13);
+
+      columnReverse.setFlexDirection(FlexDirection.ColumnReverse);
+      columnReverse.setWidth(5);
+      columnReverse.setHeight(10);
+      top.setWidth(1);
+      top.setHeight(2);
+      bottom.setWidth(1);
+      bottom.setHeight(3);
+      columnReverse.insertChild(top, 0);
+      columnReverse.insertChild(bottom, 1);
+      columnReverse.calculateLayout(undefined, undefined);
+
+      expect(top.getComputedTop()).toBe(8);
+      expect(bottom.getComputedTop()).toBe(5);
+
+      bounded.setFlexDirection(FlexDirection.Row);
+      bounded.setWidth(100);
+      bounded.setHeight(5);
+      maxed.setWidth(80);
+      maxed.setMaxWidthPercent(50);
+      mined.setWidth(10);
+      mined.setMinWidthPercent(30);
+      bounded.insertChild(maxed, 0);
+      bounded.insertChild(mined, 1);
+      bounded.calculateLayout(undefined, undefined);
+
+      expect(maxed.getComputedWidth()).toBe(50);
+      expect(mined.getComputedWidth()).toBe(30);
+    } finally {
+      rowReverse.freeRecursive();
+      columnReverse.freeRecursive();
+      bounded.freeRecursive();
+      config.free();
+    }
+  });
+
+  test("distributes wrapped lines for align-content variants", () => {
+    const cases: Array<[Align, number[]]> = [
+      [Align.Center, [7, 9, 11]],
+      [Align.FlexEnd, [14, 16, 18]],
+      [Align.Stretch, [0, 20 / 3, 40 / 3]],
+      [Align.SpaceAround, [7 / 3, 9, 47 / 3]],
+      [Align.SpaceEvenly, [3.5, 9, 14.5]],
+      [Align.Baseline, [0, 2, 4]],
+    ];
+
+    for (const [alignContent, expectedTops] of cases) {
+      const config = unscaledConfig();
+      const root = YogaDefault.Node.createWithConfig(config);
+      const children = [
+        YogaDefault.Node.createWithConfig(config),
+        YogaDefault.Node.createWithConfig(config),
+        YogaDefault.Node.createWithConfig(config),
+      ];
+
+      try {
+        root.setFlexDirection(FlexDirection.Row);
+        root.setFlexWrap(Wrap.Wrap);
+        root.setAlignItems(Align.FlexStart);
+        root.setAlignContent(alignContent);
+        root.setWidth(10);
+        root.setHeight(20);
+
+        for (const child of children) {
+          child.setWidth(6);
+          child.setHeight(2);
+          root.insertChild(child, root.getChildCount());
+        }
+
+        root.calculateLayout(undefined, undefined);
+
+        children.forEach((child, index) => {
+          expectClose(child.getComputedTop(), expectedTops[index]!);
+          expect(child.getComputedHeight()).toBe(2);
+        });
+      } finally {
+        root.freeRecursive();
+        config.free();
+      }
+    }
+  });
+
+  test("positions flow children with space-around, space-evenly, and one-sided auto margins", () => {
+    const config = unscaledConfig();
+    const around = YogaDefault.Node.createWithConfig(config);
+    const aroundA = YogaDefault.Node.createWithConfig(config);
+    const aroundB = YogaDefault.Node.createWithConfig(config);
+    const evenly = YogaDefault.Node.createWithConfig(config);
+    const evenlyA = YogaDefault.Node.createWithConfig(config);
+    const evenlyB = YogaDefault.Node.createWithConfig(config);
+    const empty = YogaDefault.Node.createWithConfig(config);
+    const autoRoot = YogaDefault.Node.createWithConfig(config);
+    const autoLead = YogaDefault.Node.createWithConfig(config);
+    const autoTrail = YogaDefault.Node.createWithConfig(config);
+    const relative = YogaDefault.Node.createWithConfig(config);
+
+    try {
+      for (const root of [around, evenly]) {
+        root.setFlexDirection(FlexDirection.Row);
+        root.setAlignItems(Align.FlexStart);
+        root.setWidth(20);
+        root.setHeight(4);
+      }
+
+      for (const child of [aroundA, aroundB, evenlyA, evenlyB]) {
+        child.setWidth(2);
+        child.setHeight(1);
+      }
+
+      around.setJustifyContent(Justify.SpaceAround);
+      around.insertChild(aroundA, 0);
+      around.insertChild(aroundB, 1);
+      around.calculateLayout(undefined, undefined);
+      expectClose(aroundA.getComputedLeft(), 4);
+      expectClose(aroundB.getComputedLeft(), 14);
+
+      evenly.setJustifyContent(Justify.SpaceEvenly);
+      evenly.insertChild(evenlyA, 0);
+      evenly.insertChild(evenlyB, 1);
+      evenly.calculateLayout(undefined, undefined);
+      expectClose(evenlyA.getComputedLeft(), 16 / 3);
+      expectClose(evenlyB.getComputedLeft(), 38 / 3);
+
+      empty.setFlexDirection(FlexDirection.Row);
+      empty.setJustifyContent(Justify.SpaceAround);
+      empty.setWidth(10);
+      empty.setHeight(2);
+      empty.calculateLayout(undefined, undefined);
+      expect(empty.getChildCount()).toBe(0);
+
+      autoRoot.setFlexDirection(FlexDirection.Row);
+      autoRoot.setAlignItems(Align.FlexStart);
+      autoRoot.setWidth(30);
+      autoRoot.setHeight(10);
+      autoLead.setWidth(2);
+      autoLead.setHeight(2);
+      autoLead.setMarginAuto(Edge.Top);
+      autoTrail.setWidth(2);
+      autoTrail.setHeight(2);
+      autoTrail.setMarginAuto(Edge.Bottom);
+      relative.setWidth(2);
+      relative.setHeight(2);
+      relative.setPosition(Edge.Right, 1);
+      relative.setPosition(Edge.Bottom, 2);
+      autoRoot.insertChild(autoLead, 0);
+      autoRoot.insertChild(autoTrail, 1);
+      autoRoot.insertChild(relative, 2);
+      autoRoot.calculateLayout(undefined, undefined);
+
+      expect(autoLead.getComputedTop()).toBe(8);
+      expect(autoTrail.getComputedTop()).toBe(0);
+      expect(relative.getComputedLeft()).toBe(3);
+      expect(relative.getComputedTop()).toBe(-2);
+    } finally {
+      around.freeRecursive();
+      evenly.freeRecursive();
+      empty.freeRecursive();
+      autoRoot.freeRecursive();
+      config.free();
+    }
+  });
+
+  test("covers absolute child derived sizes and fallback alignment", () => {
+    const config = unscaledConfig();
+    const derived = YogaDefault.Node.createWithConfig(config);
+    const derivedChild = YogaDefault.Node.createWithConfig(config);
+    const wrapReverse = YogaDefault.Node.createWithConfig(config);
+    const wrapReverseChild = YogaDefault.Node.createWithConfig(config);
+    const columnReverse = YogaDefault.Node.createWithConfig(config);
+    const columnReverseChild = YogaDefault.Node.createWithConfig(config);
+
+    try {
+      derived.setWidth(50);
+      derived.setHeight(30);
+      derivedChild.setPositionType(PositionType.Absolute);
+      derivedChild.setPosition(Edge.Left, 5);
+      derivedChild.setPosition(Edge.Top, 3);
+      derivedChild.setPosition(Edge.Bottom, 5);
+      derivedChild.setWidth(10);
+      derived.insertChild(derivedChild, 0);
+      derived.calculateLayout(undefined, undefined);
+
+      expect(derivedChild.getComputedLayout()).toMatchObject({
+        left: 5,
+        top: 3,
+        width: 10,
+        height: 22,
+      });
+
+      wrapReverse.setFlexDirection(FlexDirection.Column);
+      wrapReverse.setFlexWrap(Wrap.WrapReverse);
+      wrapReverse.setWidth(20);
+      wrapReverse.setHeight(20);
+      wrapReverseChild.setPositionType(PositionType.Absolute);
+      wrapReverseChild.setWidth(4);
+      wrapReverseChild.setHeight(5);
+      wrapReverse.insertChild(wrapReverseChild, 0);
+      wrapReverse.calculateLayout(undefined, undefined);
+
+      expect(wrapReverseChild.getComputedLayout()).toMatchObject({
+        left: 16,
+        top: 0,
+        width: 4,
+        height: 5,
+      });
+
+      columnReverse.setFlexDirection(FlexDirection.ColumnReverse);
+      columnReverse.setAlignItems(Align.FlexStart);
+      columnReverse.setWidth(20);
+      columnReverse.setHeight(20);
+      columnReverseChild.setPositionType(PositionType.Absolute);
+      columnReverseChild.setWidth(4);
+      columnReverseChild.setHeight(5);
+      columnReverse.insertChild(columnReverseChild, 0);
+      columnReverse.calculateLayout(undefined, undefined);
+
+      expect(columnReverseChild.getComputedLayout()).toMatchObject({
+        left: 0,
+        top: 15,
+        width: 4,
+        height: 5,
+      });
+    } finally {
+      derived.freeRecursive();
+      wrapReverse.freeRecursive();
+      columnReverse.freeRecursive();
+      config.free();
+    }
+  });
+
+  test("exercises explicit flex-basis and partial flex grow and shrink distribution", () => {
+    const config = unscaledConfig();
+    const basisRoot = YogaDefault.Node.createWithConfig(config);
+    const basisChild = YogaDefault.Node.createWithConfig(config);
+    const growRoot = YogaDefault.Node.createWithConfig(config);
+    const growA = YogaDefault.Node.createWithConfig(config);
+    const growB = YogaDefault.Node.createWithConfig(config);
+    const shrinkRoot = YogaDefault.Node.createWithConfig(config);
+    const shrinkA = YogaDefault.Node.createWithConfig(config);
+    const shrinkB = YogaDefault.Node.createWithConfig(config);
+
+    try {
+      basisRoot.setFlexDirection(FlexDirection.Row);
+      basisRoot.setWidth(20);
+      basisRoot.setHeight(4);
+      basisChild.setFlexBasis("25%");
+      basisRoot.insertChild(basisChild, 0);
+      basisRoot.calculateLayout(undefined, undefined);
+      expect(basisChild.getComputedWidth()).toBe(5);
+
+      growRoot.setFlexDirection(FlexDirection.Row);
+      growRoot.setWidth(100);
+      growRoot.setHeight(4);
+      for (const child of [growA, growB]) {
+        child.setWidth(10);
+        child.setHeight(1);
+        child.setFlexGrow(0.25);
+        growRoot.insertChild(child, growRoot.getChildCount());
+      }
+      growRoot.calculateLayout(undefined, undefined);
+      expectClose(growA.getComputedWidth(), 30);
+      expectClose(growB.getComputedWidth(), 30);
+
+      shrinkRoot.setFlexDirection(FlexDirection.Row);
+      shrinkRoot.setWidth(10);
+      shrinkRoot.setHeight(4);
+      for (const child of [shrinkA, shrinkB]) {
+        child.setWidth(10);
+        child.setHeight(1);
+        child.setFlexShrink(0.25);
+        shrinkRoot.insertChild(child, shrinkRoot.getChildCount());
+      }
+      shrinkRoot.calculateLayout(undefined, undefined);
+      expectClose(shrinkA.getComputedWidth(), 7.5);
+      expectClose(shrinkB.getComputedWidth(), 7.5);
+    } finally {
+      basisRoot.freeRecursive();
+      growRoot.freeRecursive();
+      shrinkRoot.freeRecursive();
+      config.free();
+    }
+  });
+
+  test("applies root position offsets and percent gap fallback", () => {
+    const config = unscaledConfig();
+    const root = YogaDefault.Node.createWithConfig(config);
+    const first = YogaDefault.Node.createWithConfig(config);
+    const second = YogaDefault.Node.createWithConfig(config);
+
+    try {
+      root.setFlexDirection(FlexDirection.Row);
+      root.setWidth(40);
+      root.setHeight(4);
+      root.setPositionPercent(Edge.Left, 10);
+      root.setPosition(Edge.Top, "2");
+      root.setGap(Gutter.All, "10%");
+      first.setWidth(2);
+      first.setHeight(1);
+      second.setWidth(2);
+      second.setHeight(1);
+      root.insertChild(first, 0);
+      root.insertChild(second, 1);
+      root.calculateLayout(40, 4);
+
+      expect(root.getComputedLeft()).toBe(4);
+      expect(root.getComputedTop()).toBe(2);
+      expect(second.getComputedLeft()).toBe(6);
+    } finally {
+      root.freeRecursive();
+      config.free();
+    }
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-007-message-renderers-SystemTextMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-007-message-renderers-SystemTextMessage.test.tsx
@@ -1,0 +1,136 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../../../src/tui/ink.js'
+import { SystemTextMessage } from '../../../src/tui/message-renderers/SystemTextMessage.js'
+
+const appState = vi.hoisted(() => {
+  const state = {
+    tasks: {
+      shell: {
+        id: 'shell',
+        type: 'local_bash',
+        status: 'running',
+        description: 'npm test',
+        command: 'npm test',
+        startTime: 0,
+        outputFile: 'urn:agenc:task:shell:output',
+        outputOffset: 0,
+        notified: false,
+        isBackgrounded: true,
+      },
+    },
+  }
+
+  return {
+    store: {
+      getState: () => state,
+    },
+  }
+})
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../../src/utils/config.js', () => ({
+  getGlobalConfig: () => ({ showTurnDuration: true }),
+}))
+
+vi.mock('../../../src/utils/browser.js', () => ({
+  openPath: () => {},
+}))
+
+vi.mock('../../../src/tui/state/AppState.js', () => ({
+  useAppStateStore: () => appState.store,
+}))
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestStdout = PassThrough & {
+  columns: number
+  rows: number
+  isTTY: boolean
+}
+
+function createStreams(): {
+  readonly stdin: TestStdin
+  readonly stdout: TestStdout
+} {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough() as TestStdout
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 100
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function renderNode(): React.ReactElement {
+  return (
+    <SystemTextMessage
+      message={{
+        type: 'system',
+        subtype: 'turn_duration',
+        durationMs: 2400,
+        budgetTokens: 400,
+        budgetLimit: 800,
+        budgetNudges: 0,
+      } as never}
+      addMargin={false}
+      verbose={false}
+    />
+  )
+}
+
+describe('SystemTextMessage coverage swarm 007', () => {
+  test('reuses the turn-duration app-state selector across identical rerenders', async () => {
+    const { stdin, stdout } = createStreams()
+    let output = ''
+
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      root.render(renderNode())
+      await sleep()
+      root.render(renderNode())
+      await sleep()
+
+      const text = stripAnsi(output).replace(/\s+/g, '')
+      expect(text).toContain('400/800(50%)')
+      expect(text).toContain('1shellstillrunning')
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-008-ink-render-node-to-output.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-008-ink-render-node-to-output.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  appendChildNode,
+  createNode,
+  createTextNode,
+  setAttribute,
+  setStyle,
+  type DOMElement,
+} from '../../../src/tui/ink/dom.ts'
+import Output from '../../../src/tui/ink/output.ts'
+import renderNodeToOutput, {
+  didLayoutShift,
+  resetLayoutShifted,
+} from '../../../src/tui/ink/render-node-to-output.ts'
+import {
+  cellAt,
+  CharPool,
+  charInCellAt,
+  createScreen,
+  HyperlinkPool,
+  StylePool,
+} from '../../../src/tui/ink/screen.ts'
+import applyStyles, { type Styles } from '../../../src/tui/ink/styles.ts'
+
+function applyNodeStyle(node: DOMElement, style: Styles): void {
+  const nextStyle = { ...node.style, ...style }
+  setStyle(node, nextStyle)
+  if (node.yogaNode) applyStyles(node.yogaNode, style, nextStyle)
+}
+
+function appendText(parent: DOMElement, text: string): void {
+  appendChildNode(parent, createTextNode(text) as unknown as DOMElement)
+}
+
+function createOutput(width: number, height: number): Output {
+  const stylePool = new StylePool()
+  return new Output({
+    height,
+    screen: createScreen(width, height, stylePool, new CharPool(), new HyperlinkPool()),
+    stylePool,
+    width,
+  })
+}
+
+function render(
+  root: DOMElement,
+  width: number,
+  height: number,
+  prevScreen?: ReturnType<Output['get']>,
+): ReturnType<Output['get']> {
+  root.yogaNode?.calculateLayout(width, height)
+  const output = createOutput(width, height)
+  renderNodeToOutput(root, output, { prevScreen })
+  return output.get()
+}
+
+function createTextRoot(width: number, height: number): DOMElement {
+  const root = createNode('ink-root')
+  applyNodeStyle(root, {
+    flexDirection: 'column',
+    height,
+    width,
+  })
+  return root
+}
+
+function createScrollableTree(): {
+  anchor: DOMElement
+  root: DOMElement
+  scrollBox: DOMElement
+} {
+  const root = createTextRoot(8, 3)
+
+  const scrollBox = createNode('ink-box')
+  applyNodeStyle(scrollBox, {
+    flexDirection: 'column',
+    height: 3,
+    overflowY: 'scroll',
+    width: 8,
+  })
+
+  const content = createNode('ink-box')
+  applyNodeStyle(content, {
+    flexDirection: 'column',
+    flexShrink: 0,
+    width: 8,
+  })
+
+  let anchor = content
+  for (let i = 0; i < 6; i += 1) {
+    const line = createNode('ink-text')
+    appendText(line, `row-${i}`)
+    appendChildNode(content, line)
+    if (i === 4) anchor = line
+  }
+
+  appendChildNode(scrollBox, content)
+  appendChildNode(root, scrollBox)
+
+  return { anchor, root, scrollBox }
+}
+
+describe('renderNodeToOutput coverage swarm row 008', () => {
+  test('clears a cached subtree when its layout display becomes none', () => {
+    resetLayoutShifted()
+
+    const root = createTextRoot(6, 2)
+    const text = createNode('ink-text')
+    appendText(text, 'hide')
+    appendChildNode(root, text)
+
+    const firstScreen = render(root, 6, 2)
+    expect(charInCellAt(firstScreen, 0, 0)).toBe('h')
+
+    applyNodeStyle(text, {
+      display: 'none',
+    })
+
+    const hiddenScreen = render(root, 6, 2, firstScreen)
+
+    expect(charInCellAt(hiddenScreen, 0, 0)).toBe(' ')
+    expect(charInCellAt(hiddenScreen, 1, 0)).toBe(' ')
+    expect(didLayoutShift()).toBe(true)
+  })
+
+  test('keeps hyperlink and soft-wrap metadata across wrapped text segments', () => {
+    const root = createTextRoot(2, 2)
+    const text = createNode('ink-text')
+    applyNodeStyle(text, {
+      width: 2,
+    })
+
+    const link = createNode('ink-link')
+    setAttribute(link, 'href', 'https://agenc.test/row-008')
+    appendText(link, 'AB')
+
+    appendChildNode(text, link)
+    appendText(text, 'CD')
+    appendChildNode(root, text)
+
+    const screen = render(root, 2, 2)
+
+    expect(charInCellAt(screen, 0, 0)).toBe('A')
+    expect(charInCellAt(screen, 1, 0)).toBe('B')
+    expect(charInCellAt(screen, 0, 1)).toBe('C')
+    expect(charInCellAt(screen, 1, 1)).toBe('D')
+    expect(cellAt(screen, 0, 0)?.hyperlink).toBe('https://agenc.test/row-008')
+    expect(cellAt(screen, 1, 0)?.hyperlink).toBe('https://agenc.test/row-008')
+    expect(cellAt(screen, 0, 1)?.hyperlink).toBeUndefined()
+    expect(screen.softWrap[1]).toBe(2)
+  })
+
+  test('applies scroll anchors and clears zero pending scroll deltas', () => {
+    const { anchor, root, scrollBox } = createScrollableTree()
+    scrollBox.scrollTop = 1
+    scrollBox.pendingScrollDelta = 0
+    scrollBox.scrollAnchor = {
+      el: anchor,
+      offset: -1,
+    }
+
+    const screen = render(root, 8, 3)
+
+    expect(scrollBox.scrollTop).toBe(3)
+    expect(scrollBox.pendingScrollDelta).toBeUndefined()
+    expect(scrollBox.scrollAnchor).toBeUndefined()
+    expect(scrollBox.scrollHeight).toBe(6)
+    expect(scrollBox.scrollViewportHeight).toBe(3)
+    expect(charInCellAt(screen, 0, 0)).toBe('r')
+    expect(charInCellAt(screen, 4, 0)).toBe('3')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx
@@ -1,0 +1,717 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  appState: {
+    agentNameRegistry: new Map<string, string>(),
+    mcp: {
+      clients: [] as unknown[],
+      resources: [] as unknown[],
+    },
+    promptSuggestion: {
+      acceptedAt: 0,
+      generationRequestId: null,
+      promptId: null,
+      shownAt: 0,
+      text: null as string | null,
+    },
+    tasks: {} as Record<string, { status?: string }>,
+    teamContext: undefined as unknown,
+    viewingAgentTaskId: null as string | null,
+  },
+  directorySuggestions: [] as unknown[],
+  keybindings: {} as Record<string, () => unknown>,
+  logEvent: vi.fn(),
+  pendingChord: null as null | string,
+  sessionTitleMatches: [] as unknown[],
+  shellCompletions: [] as unknown[],
+  shellCompletionRejects: false,
+  shellHistoryCompletion: null as null | {
+    fullCommand: string
+    suffix: string
+  },
+  slackSuggestions: [] as unknown[],
+  unifiedSuggestions: [] as unknown[],
+  reset() {
+    harness.addNotification.mockClear()
+    harness.appState.agentNameRegistry = new Map()
+    harness.appState.mcp = { clients: [], resources: [] }
+    harness.appState.promptSuggestion = {
+      acceptedAt: 0,
+      generationRequestId: null,
+      promptId: null,
+      shownAt: 0,
+      text: null,
+    }
+    harness.appState.tasks = {}
+    harness.appState.teamContext = undefined
+    harness.appState.viewingAgentTaskId = null
+    harness.directorySuggestions = []
+    harness.keybindings = {}
+    harness.logEvent.mockClear()
+    harness.pendingChord = null
+    harness.sessionTitleMatches = []
+    harness.shellCompletions = []
+    harness.shellCompletionRejects = false
+    harness.shellHistoryCompletion = null
+    harness.slackSuggestions = []
+    harness.unifiedSuggestions = []
+  },
+}))
+
+vi.mock('usehooks-ts', async () => {
+  const ReactModule = await import('react')
+  return {
+    useDebounceCallback: (callback: (...args: unknown[]) => unknown) => {
+      const callbackRef = ReactModule.useRef(callback)
+      callbackRef.current = callback
+      return ReactModule.useMemo(() => {
+        const debounced = (...args: unknown[]) => callbackRef.current(...args)
+        debounced.cancel = vi.fn()
+        return debounced
+      }, [])
+    },
+  }
+})
+
+vi.mock('src/tui/context/notifications.js', () => ({
+  useNotifications: () => ({ addNotification: harness.addNotification }),
+}))
+
+vi.mock('src/services/analytics/index.js', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('src/tui/context/overlayContext', () => ({
+  useIsModalOverlayActive: () => false,
+  useRegisterOverlay: vi.fn(),
+}))
+
+vi.mock('src/tui/ink.js', async () => {
+  const ReactModule = await import('react')
+  return {
+    Text: ({ children }: { readonly children?: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+    useInput: vi.fn(),
+  }
+})
+
+vi.mock('src/tui/keybindings/KeybindingContext.js', () => ({
+  useOptionalKeybindingContext: () => ({ pendingChord: harness.pendingChord }),
+  useRegisterKeybindingContext: vi.fn(),
+}))
+
+vi.mock('src/tui/keybindings/useKeybinding.js', () => ({
+  useKeybindings: (handlers: Record<string, () => unknown>) => {
+    Object.assign(harness.keybindings, handlers)
+  },
+}))
+
+vi.mock('src/tui/keybindings/useShortcutDisplay.js', () => ({
+  useShortcutDisplay: () => 'alt+t',
+}))
+
+vi.mock('src/tui/state/AppState.js', () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+  useAppStateStore: () => ({ getState: () => harness.appState }),
+}))
+
+vi.mock('src/utils/agentSwarmsEnabled', () => ({
+  isAgentSwarmsEnabled: () => Boolean(harness.appState.teamContext),
+}))
+
+vi.mock('src/utils/bash/shellCompletion.js', () => ({
+  getShellCompletions: vi.fn(async () => {
+    if (harness.shellCompletionRejects) {
+      throw new Error('completion failed')
+    }
+    return harness.shellCompletions
+  }),
+}))
+
+vi.mock('src/utils/sessionStorage.js', () => ({
+  getSessionIdFromLog: (log: { readonly sessionId?: string }) =>
+    log.sessionId ?? 'session-1',
+  searchSessionsByCustomTitle: vi.fn(async () => harness.sessionTitleMatches),
+}))
+
+vi.mock('src/utils/suggestions/directoryCompletion.js', () => ({
+  getDirectoryCompletions: vi.fn(async () => harness.directorySuggestions),
+  getPathCompletions: vi.fn(async () => harness.directorySuggestions),
+  isPathLikeToken: (token: string) =>
+    token.startsWith('/') || token.startsWith('./') || token.startsWith('~/'),
+}))
+
+vi.mock('src/utils/suggestions/shellHistoryCompletion.js', () => ({
+  getShellHistoryCompletion: vi.fn(async () => harness.shellHistoryCompletion),
+}))
+
+vi.mock('src/utils/suggestions/slackChannelSuggestions.js', () => ({
+  getSlackChannelSuggestions: vi.fn(async () => harness.slackSuggestions),
+  hasSlackMcpServer: () => harness.appState.mcp.clients.length > 0,
+}))
+
+vi.mock('src/utils/swarm/constants.js', () => ({
+  TEAM_LEAD_NAME: 'team-lead',
+}))
+
+vi.mock('src/tui/hooks/fileSuggestions', () => ({
+  applyFileSuggestion: (
+    replacementValue: string,
+    input: string,
+    token: string,
+    startPos: number,
+    onInputChange: (value: string) => void,
+    setCursorOffset: (offset: number) => void,
+  ) => {
+    const next =
+      input.slice(0, startPos) +
+      replacementValue +
+      input.slice(startPos + token.length)
+    onInputChange(next)
+    setCursorOffset(startPos + replacementValue.length)
+  },
+  findLongestCommonPrefix: (items: readonly { readonly displayText: string }[]) => {
+    if (items.length === 0) return ''
+    let prefix = items[0]?.displayText ?? ''
+    for (const item of items.slice(1)) {
+      while (!item.displayText.startsWith(prefix)) prefix = prefix.slice(0, -1)
+    }
+    return prefix
+  },
+  onIndexBuildComplete: () => () => {},
+  startBackgroundCacheRefresh: vi.fn(),
+}))
+
+vi.mock('src/tui/hooks/unifiedSuggestions', () => ({
+  generateUnifiedSuggestions: vi.fn(async () => harness.unifiedSuggestions),
+}))
+
+import { createRoot } from 'src/tui/ink/root.js'
+import { KeyboardEvent } from 'src/tui/ink/events/keyboard-event.js'
+import type { SuggestionItem } from 'src/tui/components/PromptInput/PromptInputFooterSuggestions.js'
+import type { PromptInputMode } from 'src/types/textInputTypes.js'
+import {
+  applyDirectorySuggestion,
+  applyShellSuggestion,
+  formatReplacementValue,
+  useTypeahead,
+} from 'src/tui/hooks/useTypeahead.js'
+
+type SuggestionsState = {
+  commandArgumentHint?: string
+  selectedSuggestion: number
+  suggestions: SuggestionItem[]
+}
+
+type HookSnapshot = ReturnType<typeof useTypeahead> & {
+  suggestionsState: SuggestionsState
+}
+
+const EMPTY_AGENTS: readonly never[] = []
+const EMPTY_COMMANDS: readonly never[] = []
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function createKey(
+  name: string,
+  options: { ctrl?: boolean; meta?: boolean; shift?: boolean } = {},
+): KeyboardEvent {
+  return new KeyboardEvent({
+    ctrl: options.ctrl ?? false,
+    fn: false,
+    isPasted: false,
+    kind: 'key',
+    meta: options.meta ?? false,
+    name,
+    option: false,
+    raw: name,
+    sequence: name.length === 1 ? name : '',
+    shift: options.shift ?? false,
+    super: false,
+  })
+}
+
+function createTestStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+function TypeaheadHarness(props: {
+  readonly commands?: readonly unknown[]
+  readonly cursorOffset?: number
+  readonly initialSuggestionsState?: SuggestionsState
+  readonly input: string
+  readonly markAccepted?: () => void
+  readonly mode?: PromptInputMode
+  readonly onInputChange: (value: string) => void
+  readonly onModeChange?: (mode: PromptInputMode) => void
+  readonly onSubmit?: (value: string, isSubmittingSlashCommand?: boolean) => void
+  readonly setCursorOffset: (offset: number) => void
+  readonly snapshot: (value: HookSnapshot) => void
+  readonly suppressSuggestions?: boolean
+}): React.ReactNode {
+  const [suggestionsState, setSuggestionsState] = React.useState<SuggestionsState>(
+    props.initialSuggestionsState ?? {
+      commandArgumentHint: undefined,
+      selectedSuggestion: -1,
+      suggestions: [],
+    },
+  )
+  const result = useTypeahead({
+    agents: EMPTY_AGENTS as never,
+    commands: (props.commands ?? EMPTY_COMMANDS) as never,
+    cursorOffset: props.cursorOffset ?? props.input.length,
+    input: props.input,
+    markAccepted: props.markAccepted ?? vi.fn(),
+    mode: props.mode ?? 'prompt',
+    onInputChange: props.onInputChange,
+    onModeChange: props.onModeChange,
+    onSubmit: props.onSubmit ?? vi.fn(),
+    setCursorOffset: props.setCursorOffset,
+    setSuggestionsState,
+    suggestionsState,
+    suppressSuggestions: props.suppressSuggestions,
+  })
+
+  React.useEffect(() => {
+    props.snapshot({ ...result, suggestionsState })
+  })
+  return null
+}
+
+async function renderHookHarness(props: {
+  readonly commands?: readonly unknown[]
+  readonly cursorOffset?: number
+  readonly initialSuggestionsState?: SuggestionsState
+  readonly input: string
+  readonly markAccepted?: () => void
+  readonly mode?: PromptInputMode
+  readonly onInputChange?: (value: string) => void
+  readonly onModeChange?: (mode: PromptInputMode) => void
+  readonly onSubmit?: (value: string, isSubmittingSlashCommand?: boolean) => void
+  readonly setCursorOffset?: (offset: number) => void
+  readonly suppressSuggestions?: boolean
+}): Promise<{
+  dispose: () => Promise<void>
+  getSnapshot: () => HookSnapshot
+  rerender: (next: Partial<typeof props>) => void
+}> {
+  const { stdin, stdout } = createTestStreams()
+  let currentProps = props
+  let snapshot: HookSnapshot | undefined
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  const render = () => {
+    root.render(
+      <TypeaheadHarness
+        {...currentProps}
+        onInputChange={currentProps.onInputChange ?? vi.fn()}
+        setCursorOffset={currentProps.setCursorOffset ?? vi.fn()}
+        snapshot={value => {
+          snapshot = value
+        }}
+      />,
+    )
+  }
+  render()
+  await waitFor(() => snapshot !== undefined, 'hook snapshot')
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep(25)
+    },
+    getSnapshot: () => {
+      if (!snapshot) throw new Error('Hook snapshot missing')
+      return snapshot
+    },
+    rerender: next => {
+      currentProps = { ...currentProps, ...next }
+      render()
+    },
+  }
+}
+
+async function waitFor(predicate: () => boolean, label: string): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < 1000) {
+    if (predicate()) return
+    await sleep(10)
+  }
+  throw new Error(`Timed out waiting for ${label}`)
+}
+
+const command = (
+  name: string,
+  options: {
+    aliases?: readonly string[]
+    argNames?: readonly string[]
+    argumentHint?: string
+    isHidden?: boolean
+  } = {},
+) => ({
+  aliases: options.aliases ?? [],
+  argNames: options.argNames,
+  argumentHint: options.argumentHint,
+  description: `${name} command`,
+  isHidden: options.isHidden ?? false,
+  name,
+  type: 'prompt',
+})
+
+describe('useTypeahead coverage swarm row 009', () => {
+  beforeEach(() => {
+    harness.reset()
+  })
+
+  test('formats and applies exported completion helpers', () => {
+    expect(
+      formatReplacementValue({
+        displayText: 'docs/read me.md',
+        hasAtPrefix: false,
+        isComplete: true,
+        mode: 'prompt',
+        needsQuotes: true,
+      }),
+    ).toBe('@"docs/read me.md" ')
+    expect(
+      formatReplacementValue({
+        displayText: 'HOME',
+        hasAtPrefix: true,
+        isComplete: true,
+        mode: 'bash',
+        needsQuotes: false,
+      }),
+    ).toBe('HOME ')
+    expect(
+      formatReplacementValue({
+        displayText: 'plain',
+        hasAtPrefix: false,
+        isComplete: false,
+        mode: 'prompt',
+        needsQuotes: false,
+      }),
+    ).toBe('plain')
+
+    const onInputChange = vi.fn()
+    const setCursorOffset = vi.fn()
+    applyShellSuggestion(
+      { displayText: 'PATH', id: 'path' } as SuggestionItem,
+      'echo $PA && done',
+      'echo $PA'.length,
+      onInputChange,
+      setCursorOffset,
+      'variable',
+    )
+    expect(onInputChange).toHaveBeenCalledWith('echo $PATH  && done')
+    expect(setCursorOffset).toHaveBeenCalledWith('echo $PATH '.length)
+
+    onInputChange.mockClear()
+    setCursorOffset.mockClear()
+    applyShellSuggestion(
+      { displayText: 'grep', id: 'grep' } as SuggestionItem,
+      'gr file.txt',
+      2,
+      onInputChange,
+      setCursorOffset,
+      'command',
+    )
+    expect(onInputChange).toHaveBeenCalledWith('grep  file.txt')
+    expect(setCursorOffset).toHaveBeenCalledWith('grep '.length)
+
+    expect(applyDirectorySuggestion('open @/tm now', '/tmp', 5, 4, true)).toEqual({
+      cursorPos: 'open @/tmp/'.length,
+      newInput: 'open @/tmp/ now',
+    })
+    expect(applyDirectorySuggestion('@read', 'README.md', 0, 5, false)).toEqual({
+      cursorPos: '@README.md '.length,
+      newInput: '@README.md ',
+    })
+  })
+
+  test('suppresses and clears an existing autocomplete state', async () => {
+    const rendered = await renderHookHarness({
+      initialSuggestionsState: {
+        commandArgumentHint: '<old>',
+        selectedSuggestion: 1,
+        suggestions: [
+          { displayText: 'old', id: 'old' },
+        ] as SuggestionItem[],
+      },
+      input: '@old',
+      suppressSuggestions: true,
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionsState.suggestions.length === 0,
+        'suppressed suggestions cleared',
+      )
+      expect(rendered.getSnapshot().suggestionsState).toEqual({
+        commandArgumentHint: undefined,
+        selectedSuggestion: -1,
+        suggestions: [],
+      })
+      expect(rendered.getSnapshot().suggestionType).toBe('none')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('shows progressive command argument hints and clears stale hints once arguments start', async () => {
+    const rendered = await renderHookHarness({
+      commands: [command('launch', { argNames: ['target', 'mode'] })],
+      input: '/launch ',
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().commandArgumentHint === '[target] [mode]',
+        'progressive command argument hint',
+      )
+      expect(rendered.getSnapshot().suggestions).toEqual([])
+
+      rendered.rerender({
+        cursorOffset: '/launch target'.length - 2,
+        input: '/launch target',
+      })
+      await waitFor(
+        () => rendered.getSnapshot().commandArgumentHint === undefined,
+        'stale command argument hint cleared',
+      )
+      expect(rendered.getSnapshot().suggestions).toEqual([])
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('clears stale command, title, Slack, file, and shell suggestions', async () => {
+    harness.unifiedSuggestions = [
+      { displayText: 'src/app.ts', id: 'src/app.ts' },
+    ]
+    const rendered = await renderHookHarness({
+      commands: [command('help'), command('resume')],
+      input: '/h',
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'command',
+        'command suggestions',
+      )
+      rendered.rerender({ cursorOffset: 'plain text'.length, input: 'plain text' })
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'none',
+        'stale command suggestions cleared',
+      )
+
+      rendered.rerender({
+        cursorOffset: '/resume missing'.length,
+        input: '/resume missing',
+      })
+      await sleep(25)
+      expect(rendered.getSnapshot().suggestionType).toBe('none')
+      expect(rendered.getSnapshot().suggestions).toEqual([])
+
+      harness.sessionTitleMatches = [
+        {
+          customTitle: 'Planning notes',
+          messageCount: 4,
+          modified: new Date('2026-05-20T00:00:00.000Z'),
+          sessionId: 'session-9',
+        },
+      ]
+      rendered.rerender({
+        cursorOffset: '/resume plan'.length,
+        input: '/resume plan',
+      })
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'custom-title',
+        'custom title suggestions',
+      )
+      harness.sessionTitleMatches = []
+      rendered.rerender({ cursorOffset: 'not resume'.length, input: 'not resume' })
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'none',
+        'stale custom title suggestions cleared',
+      )
+
+      harness.appState.mcp = { clients: [{ name: 'slack' }], resources: [] }
+      harness.slackSuggestions = [
+        { displayText: '#general', id: 'slack-general' },
+      ]
+      rendered.rerender({ cursorOffset: '#gen'.length, input: '#gen' })
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'slack-channel',
+        'Slack channel suggestions',
+      )
+      rendered.rerender({ cursorOffset: 'plain'.length, input: 'plain' })
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'none',
+        'stale Slack suggestions cleared',
+      )
+
+      harness.appState.mcp = { clients: [], resources: [] }
+      rendered.rerender({ cursorOffset: '@sr'.length, input: '@sr' })
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'file',
+        'file suggestions',
+      )
+      rendered.rerender({ cursorOffset: 'plain '.length, input: 'plain ' })
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'none',
+        'stale file suggestions cleared',
+      )
+
+      harness.shellCompletions = [
+        {
+          displayText: 'grep',
+          id: 'grep',
+          metadata: { completionType: 'command', inputSnapshot: 'g' },
+        },
+        {
+          displayText: 'git',
+          id: 'git',
+          metadata: { completionType: 'command', inputSnapshot: 'g' },
+        },
+      ]
+      rendered.rerender({ cursorOffset: 'g'.length, input: 'g', mode: 'bash' })
+      harness.keybindings['autocomplete:accept']?.()
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'shell',
+        'shell suggestions',
+      )
+      rendered.rerender({ cursorOffset: 'go'.length, input: 'go', mode: 'bash' })
+      await waitFor(
+        () => rendered.getSnapshot().suggestionType === 'none',
+        'stale shell suggestions cleared',
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('handles keyboard navigation branches and prompt suggestion tab acceptance', async () => {
+    harness.unifiedSuggestions = [
+      { displayText: 'src/app.ts', id: 'src/app.ts' },
+      { displayText: 'src/api.ts', id: 'src/api.ts' },
+    ]
+    const markAccepted = vi.fn()
+    const onInputChange = vi.fn()
+    const setCursorOffset = vi.fn()
+    const rendered = await renderHookHarness({
+      input: '@sr',
+      markAccepted,
+      onInputChange,
+      setCursorOffset,
+    })
+
+    try {
+      await waitFor(
+        () => rendered.getSnapshot().suggestions.length === 2,
+        'file suggestions for key navigation',
+      )
+
+      const ctrlN = createKey('n', { ctrl: true })
+      rendered.getSnapshot().handleKeyDown(ctrlN)
+      expect(ctrlN.defaultPrevented).toBe(true)
+      await waitFor(
+        () => rendered.getSnapshot().suggestionsState.selectedSuggestion === 1,
+        'ctrl-n selected next item',
+      )
+
+      const ctrlP = createKey('p', { ctrl: true })
+      rendered.getSnapshot().handleKeyDown(ctrlP)
+      expect(ctrlP.defaultPrevented).toBe(true)
+      await waitFor(
+        () => rendered.getSnapshot().suggestionsState.selectedSuggestion === 0,
+        'ctrl-p selected previous item',
+      )
+
+      harness.pendingChord = 'ctrl+x'
+      rendered.rerender({ input: '@sr', cursorOffset: '@sr'.length })
+      const blockedCtrlN = createKey('n', { ctrl: true })
+      rendered.getSnapshot().handleKeyDown(blockedCtrlN)
+      expect(blockedCtrlN.defaultPrevented).toBe(false)
+
+      harness.pendingChord = null
+      harness.appState.promptSuggestion = {
+        acceptedAt: 0,
+        generationRequestId: null,
+        promptId: 'prompt-1',
+        shownAt: Date.now(),
+        text: 'accepted text',
+      }
+      rendered.rerender({ input: '', cursorOffset: 0 })
+      await waitFor(
+        () => rendered.getSnapshot().suggestions.length === 0,
+        'suggestions cleared before prompt suggestion tab',
+      )
+      const tab = createKey('tab')
+      rendered.getSnapshot().handleKeyDown(tab)
+      expect(tab.defaultPrevented).toBe(true)
+      expect(markAccepted).toHaveBeenCalled()
+      expect(onInputChange).toHaveBeenCalledWith('accepted text')
+      expect(setCursorOffset).toHaveBeenCalledWith('accepted text'.length)
+
+      const shiftTab = createKey('tab', { shift: true })
+      rendered.getSnapshot().handleKeyDown(shiftTab)
+      expect(shiftTab.defaultPrevented).toBe(false)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('logs and suppresses bash completion failures', async () => {
+    harness.shellCompletionRejects = true
+    const rendered = await renderHookHarness({
+      input: 'g',
+      mode: 'bash',
+    })
+
+    try {
+      harness.keybindings['autocomplete:accept']?.()
+      await waitFor(
+        () => harness.logEvent.mock.calls.length === 1,
+        'shell completion failure log',
+      )
+      expect(harness.logEvent).toHaveBeenCalledWith(
+        'agenc_shell_completion_failed',
+        {},
+      )
+      expect(rendered.getSnapshot().suggestions).toEqual([])
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-010-ink-components-App.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-010-ink-components-App.test.tsx
@@ -1,0 +1,263 @@
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import App, { handleMouseEvent } from "../../../src/tui/ink/components/App.js";
+import type { ParsedMouse } from "../../../src/tui/ink/parse-keypress.js";
+import { createSelectionState } from "../../../src/tui/ink/selection.js";
+import { FOCUS_IN, FOCUS_OUT } from "../../../src/tui/ink/termio/csi.js";
+import {
+  getTerminalFocused,
+  resetTerminalFocusState,
+} from "../../../src/tui/ink/terminal-focus-state.js";
+
+type TestStream = NodeJS.ReadStream & NodeJS.WriteStream;
+type AppProps = ConstructorParameters<typeof App>[0];
+
+function stream(): TestStream {
+  const s = new PassThrough() as TestStream;
+  s.isTTY = false;
+  s.write = vi.fn(() => true) as never;
+  return s;
+}
+
+function mouse(
+  action: ParsedMouse["action"],
+  button: number,
+  col = 5,
+  row = 7,
+): ParsedMouse {
+  return {
+    action,
+    button,
+    col,
+    kind: "mouse",
+    row,
+    sequence: `mouse:${action}:${button}:${col}:${row}`,
+  };
+}
+
+function appProps(overrides: Partial<AppProps> = {}): AppProps {
+  return {
+    children: null,
+    stdin: stream(),
+    stdout: stream(),
+    stderr: stream(),
+    exitOnCtrlC: true,
+    onExit: () => {},
+    terminalColumns: 80,
+    terminalRows: 24,
+    selection: createSelectionState(),
+    onSelectionChange: () => {},
+    onClickAt: () => false,
+    onHoverAt: () => {},
+    getHyperlinkAt: () => undefined,
+    onOpenHyperlink: () => {},
+    onMultiClick: () => {},
+    onSelectionDrag: () => {},
+    dispatchKeyboardEvent: () => {},
+    ...overrides,
+  };
+}
+
+function createApp(overrides: Partial<AppProps> = {}): App {
+  return new App(appProps(overrides));
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  resetTerminalFocusState();
+});
+
+describe("Ink App coverage swarm row 010", () => {
+  test("ignores mouse handling when click handling is disabled", () => {
+    vi.stubEnv("AGENC_DISABLE_MOUSE_CLICKS", "1");
+
+    const selection = createSelectionState();
+    const onSelectionChange = vi.fn();
+    const onClickAt = vi.fn(() => false);
+    const app = createApp({
+      selection,
+      onClickAt,
+      onSelectionChange,
+    });
+
+    handleMouseEvent(app, mouse("press", 0));
+
+    expect(selection.anchor).toBeNull();
+    expect(onClickAt).not.toHaveBeenCalled();
+    expect(onSelectionChange).not.toHaveBeenCalled();
+  });
+
+  test("finishes a stale drag on no-button motion and deduplicates hover", () => {
+    const selection = createSelectionState();
+    selection.isDragging = true;
+    const onHoverAt = vi.fn();
+    const onSelectionChange = vi.fn();
+    const app = createApp({
+      selection,
+      onHoverAt,
+      onSelectionChange,
+    });
+
+    handleMouseEvent(app, mouse("press", 0x20 | 0x03, 3, 4));
+    handleMouseEvent(app, mouse("press", 0x20 | 0x03, 3, 4));
+
+    expect(selection.isDragging).toBe(false);
+    expect(onSelectionChange).toHaveBeenCalledOnce();
+    expect(onHoverAt).toHaveBeenCalledOnce();
+    expect(onHoverAt).toHaveBeenCalledWith(2, 3);
+  });
+
+  test("routes drag motion and non-left button edge cases", () => {
+    const selection = createSelectionState();
+    const onSelectionDrag = vi.fn();
+    const onSelectionChange = vi.fn();
+    const app = createApp({
+      selection,
+      onSelectionDrag,
+      onSelectionChange,
+    });
+
+    handleMouseEvent(app, mouse("press", 0x20, 9, 11));
+    expect(onSelectionDrag).toHaveBeenCalledWith(8, 10);
+    expect(onSelectionChange).not.toHaveBeenCalled();
+
+    app.clickCount = 2;
+    handleMouseEvent(app, mouse("press", 1));
+    expect(app.clickCount).toBe(0);
+
+    handleMouseEvent(app, mouse("release", 1));
+    expect(onSelectionChange).not.toHaveBeenCalled();
+
+    selection.isDragging = true;
+    handleMouseEvent(app, mouse("release", 1));
+    expect(selection.isDragging).toBe(false);
+    expect(onSelectionChange).toHaveBeenCalledOnce();
+  });
+
+  test("caps repeated nearby presses at triple-click line selection", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2_000);
+
+    const selection = createSelectionState();
+    const onMultiClick = vi.fn();
+    const onOpenHyperlink = vi.fn();
+    const app = createApp({
+      selection,
+      onMultiClick,
+      onOpenHyperlink,
+    });
+    app.clickCount = 2;
+    app.lastClickTime = 1_750;
+    app.lastClickCol = 4;
+    app.lastClickRow = 6;
+    app.pendingHyperlinkTimer = setTimeout(onOpenHyperlink, 1_000);
+
+    handleMouseEvent(app, mouse("press", 0, 5, 7));
+
+    expect(app.clickCount).toBe(3);
+    expect(app.pendingHyperlinkTimer).toBeNull();
+    expect(onMultiClick).toHaveBeenCalledWith(4, 6, 3);
+    expect(selection.anchor).toBeNull();
+
+    vi.advanceTimersByTime(1_000);
+    expect(onOpenHyperlink).not.toHaveBeenCalled();
+  });
+
+  test("supersedes a pending hyperlink open with the latest clicked link", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    vi.stubEnv("TERM_PROGRAM", "");
+
+    const onOpenHyperlink = vi.fn();
+    const getHyperlinkAt = vi
+      .fn<() => string>()
+      .mockReturnValueOnce("https://agenc.test/first")
+      .mockReturnValueOnce("https://agenc.test/second");
+    const app = createApp({
+      getHyperlinkAt,
+      onOpenHyperlink,
+    });
+
+    handleMouseEvent(app, mouse("press", 0, 5, 7));
+    handleMouseEvent(app, mouse("release", 0, 5, 7));
+    expect(app.pendingHyperlinkTimer).not.toBeNull();
+
+    vi.advanceTimersByTime(250);
+
+    handleMouseEvent(app, mouse("press", 0, 20, 7));
+    handleMouseEvent(app, mouse("release", 0, 20, 7));
+
+    vi.advanceTimersByTime(500);
+
+    expect(getHyperlinkAt).toHaveBeenCalledTimes(2);
+    expect(onOpenHyperlink).toHaveBeenCalledOnce();
+    expect(onOpenHyperlink).toHaveBeenCalledWith("https://agenc.test/second");
+  });
+
+  test("skips App hyperlink opening in VS Code terminals", () => {
+    vi.useFakeTimers();
+    vi.stubEnv("TERM_PROGRAM", "vscode");
+
+    const getHyperlinkAt = vi.fn(() => "https://agenc.test/item");
+    const onOpenHyperlink = vi.fn();
+    const app = createApp({
+      getHyperlinkAt,
+      onOpenHyperlink,
+    });
+
+    handleMouseEvent(app, mouse("press", 0));
+    handleMouseEvent(app, mouse("release", 0));
+    vi.advanceTimersByTime(500);
+
+    expect(getHyperlinkAt).toHaveBeenCalledWith(4, 6);
+    expect(app.pendingHyperlinkTimer).toBeNull();
+    expect(onOpenHyperlink).not.toHaveBeenCalled();
+  });
+
+  test("processes terminal focus transitions and restores focus on key input", () => {
+    const selection = createSelectionState();
+    selection.anchor = { col: 1, row: 1 };
+    selection.focus = { col: 2, row: 2 };
+    selection.isDragging = true;
+    const onSelectionChange = vi.fn();
+    const dispatchKeyboardEvent = vi.fn();
+    const app = createApp({
+      selection,
+      onSelectionChange,
+      dispatchKeyboardEvent,
+    });
+    const onFocus = vi.fn();
+    const onBlur = vi.fn();
+    const onInput = vi.fn();
+    app.internal_eventEmitter.on("terminalfocus", onFocus);
+    app.internal_eventEmitter.on("terminalblur", onBlur);
+    app.internal_eventEmitter.on("input", onInput);
+
+    app.processInput(FOCUS_OUT);
+
+    expect(getTerminalFocused()).toBe(false);
+    expect(selection.isDragging).toBe(false);
+    expect(onSelectionChange).toHaveBeenCalledOnce();
+    expect(onBlur.mock.calls[0]?.[0]).toMatchObject({ type: "terminalblur" });
+    expect(dispatchKeyboardEvent).not.toHaveBeenCalled();
+
+    app.processInput(FOCUS_IN);
+    expect(getTerminalFocused()).toBe(true);
+    expect(onFocus.mock.calls[0]?.[0]).toMatchObject({ type: "terminalfocus" });
+
+    app.handleTerminalFocus(false);
+    app.processInput("a");
+
+    expect(getTerminalFocused()).toBe(true);
+    expect(onInput).toHaveBeenCalledOnce();
+    expect(dispatchKeyboardEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "key",
+        sequence: "a",
+      }),
+    );
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-011-components-CustomSelect-select.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-011-components-CustomSelect-select.test.tsx
@@ -1,0 +1,384 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../../../src/tui/ink/root.js'
+import { Text } from '../../../src/tui/ink.js'
+import {
+  Select,
+  type OptionWithDescription,
+} from '../../../src/tui/components/CustomSelect/select.js'
+import type { UseSelectProps } from '../../../src/tui/components/CustomSelect/use-select-input.js'
+
+type CapturedSelectOptionProps = {
+  children: React.ReactNode
+  isFocused: boolean
+  isSelected: boolean
+  shouldShowDownArrow?: boolean
+  shouldShowUpArrow?: boolean
+}
+
+type CapturedInputOptionProps = {
+  imagesSelected?: boolean
+  inputValue: string
+  isFocused: boolean
+  isSelected: boolean
+  layout: 'compact' | 'expanded'
+  maxIndexWidth: number
+  onInputChange: (value: string) => void
+  onSubmit: (value: string) => void
+  option: Extract<OptionWithDescription<string>, { type: 'input' }> & {
+    index: number
+  }
+  selectedImageIndex?: number
+  shouldShowDownArrow: boolean
+  shouldShowUpArrow: boolean
+  showLabel?: boolean
+}
+
+const harness = vi.hoisted(() => ({
+  inputOptionProps: [] as CapturedInputOptionProps[],
+  selectInputProps: undefined as UseSelectProps<string> | undefined,
+  selectOptionProps: [] as CapturedSelectOptionProps[],
+}))
+
+vi.mock('../../../src/tui/components/CustomSelect/select-option.js', async () => {
+  const ReactActual = await vi.importActual<typeof import('react')>('react')
+
+  return {
+    SelectOption: (props: CapturedSelectOptionProps) => {
+      harness.selectOptionProps.push(props)
+
+      return ReactActual.createElement(
+        'ink-text',
+        null,
+        [
+          'option',
+          props.isFocused ? 'focused' : 'blurred',
+          props.isSelected ? 'selected' : 'unselected',
+          props.shouldShowUpArrow ? 'up' : 'no-up',
+          props.shouldShowDownArrow ? 'down' : 'no-down',
+        ].join(':'),
+      )
+    },
+  }
+})
+
+vi.mock(
+  '../../../src/tui/components/CustomSelect/select-input-option.js',
+  async () => {
+    const ReactActual = await vi.importActual<typeof import('react')>('react')
+
+    return {
+      SelectInputOption: (props: CapturedInputOptionProps) => {
+        harness.inputOptionProps.push(props)
+
+        return ReactActual.createElement(
+          'ink-text',
+          null,
+          [
+            'input',
+            props.option.value,
+            props.layout,
+            props.inputValue,
+            props.showLabel ? 'label' : 'placeholder',
+            props.shouldShowUpArrow ? 'up' : 'no-up',
+            props.shouldShowDownArrow ? 'down' : 'no-down',
+            props.imagesSelected ? `image-${props.selectedImageIndex}` : 'no-image',
+          ].join(':'),
+        )
+      },
+    }
+  },
+)
+
+vi.mock('../../../src/tui/components/CustomSelect/use-select-input.js', () => ({
+  useSelectInput: (props: UseSelectProps<string>) => {
+    harness.selectInputProps = props
+  },
+}))
+
+vi.mock('../../../src/utils/debug.js', () => ({
+  logForDebugging: () => {},
+}))
+vi.mock('../../../src/bootstrap/state.js', () => ({
+  flushInteractionTime: () => {},
+  getActiveTimeCounter: () => 0,
+  markScrollActivity: () => {},
+  updateLastInteractionTime: () => {},
+}))
+vi.mock('../../../src/utils/earlyInput.js', () => ({
+  stopCapturingEarlyInput: () => {},
+}))
+vi.mock('../../../src/utils/envUtils.js', () => ({
+  isEnvTruthy: () => false,
+}))
+vi.mock('../../../src/utils/fullscreen.js', () => ({
+  isMouseClicksDisabled: () => true,
+}))
+vi.mock('../../../src/utils/log.js', () => ({
+  logError: () => {},
+}))
+
+type RenderedSelect = {
+  dispose: () => Promise<void>
+  output: () => string
+  rerender: (node: React.ReactNode) => Promise<void>
+}
+
+async function sleep(ms = 30): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderSelect(node: React.ReactNode): Promise<RenderedSelect> {
+  let output = ''
+  const stdout = new PassThrough()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  root.render(node)
+  await sleep()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep(5)
+    },
+    output: () => stripAnsi(output),
+    rerender: async nextNode => {
+      root.render(nextNode)
+      await sleep()
+    },
+  }
+}
+
+function latestInputOption(): CapturedInputOptionProps {
+  const props = harness.inputOptionProps.at(-1)
+  expect(props).toBeDefined()
+  return props!
+}
+
+describe('Select coverage swarm row 011', () => {
+  beforeEach(() => {
+    harness.inputOptionProps = []
+    harness.selectInputProps = undefined
+    harness.selectOptionProps = []
+  })
+
+  test('renders expanded text options with selected state, descriptions, and upward scroll affordance', async () => {
+    const options: OptionWithDescription<string>[] = [
+      {
+        value: 'alpha',
+        label: 'Alpha choice',
+        description: 'Hidden above the viewport',
+      },
+      {
+        value: 'beta',
+        label: 'Beta choice',
+        description: 'Selected expanded description',
+      },
+      {
+        value: 'gamma',
+        label: 'Gamma choice',
+        description: 'Focused expanded description',
+        dimDescription: false,
+      },
+    ]
+
+    const rendered = await renderSelect(
+      <Select
+        options={options}
+        defaultFocusValue="gamma"
+        defaultValue="beta"
+        highlightText="Beta"
+        layout="expanded"
+        visibleOptionCount={2}
+      />,
+    )
+
+    try {
+      expect(rendered.output()).toContain('Selected expanded description')
+      expect(rendered.output()).toContain('Focused expanded description')
+      expect(rendered.output()).not.toContain('Hidden above the viewport')
+      expect(harness.selectOptionProps).toMatchObject([
+        {
+          isFocused: false,
+          isSelected: true,
+          shouldShowUpArrow: true,
+          shouldShowDownArrow: false,
+        },
+        {
+          isFocused: true,
+          isSelected: false,
+          shouldShowUpArrow: false,
+          shouldShowDownArrow: false,
+        },
+      ])
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('wires compact-vertical input rows through value changes and empty submit', async () => {
+    const onCancel = vi.fn()
+    const onChange = vi.fn()
+    const options: OptionWithDescription<string>[] = [
+      {
+        value: 'alpha',
+        label: 'Alpha choice',
+        description: 'Visible text description',
+      },
+      {
+        type: 'input',
+        value: 'prompt',
+        label: 'Prompt',
+        initialValue: 'draft',
+        allowEmptySubmitToCancel: true,
+        onChange: () => {},
+      },
+      {
+        value: 'omega',
+        label: 'Omega choice',
+      },
+    ]
+
+    const rendered = await renderSelect(
+      <Select
+        options={options}
+        defaultFocusValue="prompt"
+        inlineDescriptions={true}
+        layout="compact-vertical"
+        onCancel={onCancel}
+        onChange={onChange}
+        visibleOptionCount={2}
+      />,
+    )
+
+    try {
+      expect(rendered.output()).toContain('Visible text description')
+      expect(latestInputOption()).toMatchObject({
+        inputValue: 'draft',
+        isFocused: true,
+        isSelected: false,
+        layout: 'compact',
+        maxIndexWidth: 1,
+        shouldShowDownArrow: true,
+        shouldShowUpArrow: false,
+        showLabel: true,
+      })
+
+      latestInputOption().onInputChange('edited')
+      await sleep()
+      expect(latestInputOption().inputValue).toBe('edited')
+
+      latestInputOption().onSubmit('')
+      expect(onChange).toHaveBeenCalledWith('prompt')
+      expect(onCancel).not.toHaveBeenCalled()
+      expect(harness.selectInputProps).toMatchObject({
+        disableSelection: false,
+        isDisabled: false,
+        isMultiSelect: false,
+      })
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('renders compact two-column descriptions with nested labels and hidden indexes', async () => {
+    const options: OptionWithDescription<string>[] = [
+      {
+        value: 'node-label',
+        label: (
+          <>
+            Node <Text>label</Text>
+          </>
+        ),
+        description: 'Description beside nested label',
+      },
+      {
+        value: 'plain',
+        label: 'Plain option',
+        description: 'Selected description beside plain label',
+        disabled: true,
+      },
+    ]
+
+    const rendered = await renderSelect(
+      <Select
+        options={options}
+        defaultFocusValue="node-label"
+        defaultValue="plain"
+        hideIndexes={true}
+      />,
+    )
+
+    try {
+      const output = rendered.output()
+      expect(output).toContain('Node label')
+      expect(output).toContain('Description beside nested label')
+      expect(output).toContain('Plain option')
+      expect(output).toContain('Selected description beside plain label')
+      expect(output).not.toContain('1.')
+      expect(output).not.toContain('2.')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('enters image selection mode from compact input rows with pasted images', async () => {
+    const options: OptionWithDescription<string>[] = [
+      {
+        type: 'input',
+        value: 'prompt',
+        label: 'Prompt',
+        onChange: () => {},
+      },
+    ]
+
+    const rendered = await renderSelect(
+      <Select
+        options={options}
+        defaultFocusValue="prompt"
+        pastedContents={{
+          1: { id: 1, type: 'image', content: 'first' },
+          2: { id: 2, type: 'text', content: 'ignored' },
+          3: { id: 3, type: 'image', content: 'second' },
+        }}
+      />,
+    )
+
+    try {
+      expect(harness.selectInputProps?.onEnterImageSelection?.()).toBe(true)
+      await sleep()
+      expect(latestInputOption()).toMatchObject({
+        imagesSelected: true,
+        selectedImageIndex: 1,
+      })
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-012-components-MessageSelector.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-012-components-MessageSelector.test.tsx
@@ -1,0 +1,589 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+type CapturedSelectProps = {
+  defaultFocusValue?: string
+  isDisabled?: boolean
+  onCancel: () => void
+  onChange: (value: string) => void | Promise<void>
+  onFocus: (value: string) => void
+  options: Array<{
+    label: string
+    onChange?: (value: string) => void
+    value: string
+  }>
+}
+
+const harness = vi.hoisted(() => ({
+  appState: { fileHistory: { entries: [] } },
+  canRestore: true,
+  columns: 80,
+  diffStats: {
+    deletions: 1,
+    filesChanged: ['/tmp/alpha.ts', '/tmp/beta.ts'],
+    insertions: 2,
+  },
+  exitPending: false,
+  fileHistoryEnabled: true,
+  keybindings: {} as Record<string, () => unknown>,
+  logError: vi.fn(),
+  logEvent: vi.fn(),
+  selectProps: null as CapturedSelectProps | null,
+  reset() {
+    harness.canRestore = true
+    harness.columns = 80
+    harness.diffStats = {
+      deletions: 1,
+      filesChanged: ['/tmp/alpha.ts', '/tmp/beta.ts'],
+      insertions: 2,
+    }
+    harness.exitPending = false
+    harness.fileHistoryEnabled = true
+    harness.keybindings = {}
+    harness.logError.mockClear()
+    harness.logEvent.mockClear()
+    harness.selectProps = null
+  },
+}))
+
+vi.mock('../../services/analytics/index.js', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppState: (selector: (state: unknown) => unknown) =>
+    selector(harness.appState),
+}))
+
+vi.mock('../../utils/fileHistory.js', () => ({
+  fileHistoryCanRestore: () => harness.canRestore,
+  fileHistoryEnabled: () => harness.fileHistoryEnabled,
+  fileHistoryGetDiffStats: vi.fn(async () => harness.diffStats),
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: harness.logError,
+}))
+
+vi.mock('src/tui/hooks/useExitOnCtrlCDWithKeybindings.js', () => ({
+  useExitOnCtrlCDWithKeybindings: () => ({
+    keyName: 'ctrl+c',
+    pending: harness.exitPending,
+  }),
+}))
+
+vi.mock('../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: harness.columns, rows: 24 }),
+}))
+
+vi.mock('../keybindings/useKeybinding.js', () => ({
+  useKeybinding: (name: string, handler: () => unknown) => {
+    harness.keybindings[name] = handler
+  },
+  useKeybindings: (handlers: Record<string, () => unknown>) => {
+    Object.assign(harness.keybindings, handlers)
+  },
+}))
+
+vi.mock('../components/spinner/Spinner.js', async () => {
+  const { Text } = await import('../ink.js')
+
+  return {
+    Spinner: () => React.createElement(Text, null, 'spin'),
+  }
+})
+
+vi.mock('../components/CustomSelect/select', async () => {
+  const { Text } = await import('../ink.js')
+
+  return {
+    Select: (props: CapturedSelectProps) => {
+      harness.selectProps = props
+
+      return React.createElement(
+        React.Fragment,
+        null,
+        props.options.map(option =>
+          React.createElement(Text, { key: option.value }, option.label),
+        ),
+      )
+    },
+  }
+})
+
+import { createRoot } from '../ink/root.js'
+import type { Message, UserMessage } from '../../types/message.js'
+import {
+  buildMessageSelectorFileHistoryMetadata,
+  computeMessageOptionTextWidth,
+  MessageSelector,
+  messagesAfterAreOnlySynthetic,
+} from '../components/MessageSelector.js'
+
+function userMessage(
+  uuid: string,
+  text: string,
+  overrides: Partial<UserMessage> = {},
+): UserMessage {
+  return {
+    message: { content: [{ text, type: 'text' }] },
+    timestamp: '2026-05-20T00:00:00.000Z',
+    type: 'user',
+    uuid,
+    ...overrides,
+  } as UserMessage
+}
+
+function userStringMessage(uuid: string, content: string): UserMessage {
+  return userMessage(uuid, '', {
+    message: { content },
+  } as Partial<UserMessage>)
+}
+
+function assistantMessage(uuid: string, text: string): Message {
+  return {
+    message: { content: [{ text, type: 'text' }] },
+    type: 'assistant',
+    uuid,
+  } as Message
+}
+
+function toolResultMessage(uuid: string, toolUseResult?: unknown): Message {
+  return {
+    message: {
+      content: [{ content: 'done', tool_use_id: uuid, type: 'tool_result' }],
+    },
+    toolUseResult,
+    type: 'user',
+    uuid,
+  } as Message
+}
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForOutput(
+  output: () => string,
+  expected: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    if (output().includes(expected)) return
+    await sleep(10)
+  }
+
+  throw new Error(`Timed out waiting for output: ${expected}`)
+}
+
+async function waitForSelectOption(value: string): Promise<void> {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    if (harness.selectProps?.options.some(option => option.value === value)) {
+      return
+    }
+    await sleep(10)
+  }
+
+  throw new Error(`Timed out waiting for option: ${value}`)
+}
+
+async function renderSelector(props: {
+  messages: Message[]
+  onClose?: () => void
+  onPreRestore?: () => void
+  onRestoreCode?: (message: UserMessage) => Promise<void>
+  onRestoreMessage?: (message: UserMessage) => Promise<void>
+  onSummarize?: (
+    message: UserMessage,
+    feedback?: string,
+    direction?: 'from' | 'up_to',
+  ) => Promise<void>
+  preselectedMessage?: UserMessage
+}): Promise<{
+  dispose: () => Promise<void>
+  output: () => string
+}> {
+  let output = ''
+  const { stdin, stdout } = createStreams()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  root.render(
+    <MessageSelector
+      messages={props.messages}
+      onClose={props.onClose ?? vi.fn()}
+      onPreRestore={props.onPreRestore ?? vi.fn()}
+      onRestoreCode={props.onRestoreCode ?? vi.fn(async () => {})}
+      onRestoreMessage={props.onRestoreMessage ?? vi.fn(async () => {})}
+      onSummarize={props.onSummarize ?? vi.fn(async () => {})}
+      preselectedMessage={props.preselectedMessage}
+    />,
+  )
+  await sleep()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    output: () => stripAnsi(output),
+  }
+}
+
+describe('MessageSelector coverage-swarm row 012', () => {
+  beforeEach(() => {
+    harness.reset()
+  })
+
+  test('covers metadata edge cases and synthetic tail fallthroughs', () => {
+    expect(computeMessageOptionTextWidth(12, -4)).toBe(12)
+
+    const first = userMessage('user-1', 'restore from here')
+    const current = userMessage('current-message', '')
+    const metadata = buildMessageSelectorFileHistoryMetadata({
+      canRestoreMessage: () => true,
+      currentUUID: current.uuid as never,
+      fileHistory: {} as never,
+      isFileHistoryEnabled: true,
+      messageOptions: [first, current],
+      messages: [
+        first,
+        toolResultMessage('edit-1', {
+          filePath: '/tmp/reused.ts',
+          structuredPatch: [{ lines: ['+one', '-old'] }],
+        }),
+        toolResultMessage('edit-2', {
+          filePath: '/tmp/reused.ts',
+          structuredPatch: [{ lines: ['+two'] }],
+        }),
+        toolResultMessage('bad-edit', {
+          filePath: '/tmp/bad.ts',
+          structuredPatch: [{}],
+        }),
+      ],
+    })
+
+    expect(metadata[first.uuid]).toEqual({
+      deletions: 1,
+      filesChanged: ['/tmp/reused.ts', '/tmp/bad.ts'],
+      insertions: 2,
+    })
+    expect(
+      messagesAfterAreOnlySynthetic(
+        [
+          first,
+          undefined,
+          {
+            message: { content: [] },
+            type: 'tombstone',
+            uuid: 'tombstone-message',
+          },
+        ] as never,
+        0,
+      ),
+    ).toBe(true)
+  })
+
+  test('selecting the virtual current prompt closes without restore', async () => {
+    const onClose = vi.fn()
+    const rendered = await renderSelector({
+      messages: [userMessage('user-1', 'previous prompt')],
+      onClose,
+    })
+
+    try {
+      harness.keybindings['messageSelector:select']?.()
+      await sleep()
+
+      expect(onClose).toHaveBeenCalledTimes(1)
+      expect(harness.logEvent).toHaveBeenCalledWith(
+        'agenc_message_selector_selected',
+        expect.objectContaining({ index_from_end: 1 }),
+      )
+      expect(rendered.output()).toContain('(current)')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('shows direct conversation restore failures when file history is disabled', async () => {
+    harness.fileHistoryEnabled = false
+    const selected = userMessage('user-1', 'restore this conversation')
+    const onClose = vi.fn()
+    const onPreRestore = vi.fn()
+    const onRestoreMessage = vi.fn(async () => {
+      throw new Error('conversation exploded')
+    })
+    const rendered = await renderSelector({
+      messages: [selected, assistantMessage('assistant-1', 'reply')],
+      onClose,
+      onPreRestore,
+      onRestoreMessage,
+    })
+
+    try {
+      harness.keybindings['messageSelector:up']?.()
+      await sleep()
+      harness.keybindings['messageSelector:select']?.()
+      await waitForOutput(rendered.output, 'Failed to restore the conversation:')
+
+      expect(onPreRestore).toHaveBeenCalledTimes(1)
+      expect(onRestoreMessage).toHaveBeenCalledWith(selected)
+      expect(onClose).not.toHaveBeenCalled()
+      expect(harness.logError).toHaveBeenCalledWith(expect.any(Error))
+      expect(rendered.output()).toContain('conversation exploded')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('backs out of non-preselected confirmation via escape and nevermind', async () => {
+    harness.diffStats = {
+      deletions: 0,
+      filesChanged: [],
+      insertions: 0,
+    }
+    const selected = userMessage('user-1', 'restore candidate')
+    const onClose = vi.fn()
+    const rendered = await renderSelector({
+      messages: [selected, assistantMessage('assistant-1', 'reply')],
+      onClose,
+    })
+
+    try {
+      harness.keybindings['messageSelector:up']?.()
+      await sleep()
+      harness.keybindings['messageSelector:select']?.()
+      await waitForSelectOption('nevermind')
+
+      harness.keybindings['confirm:no']?.()
+      await sleep()
+      expect(onClose).not.toHaveBeenCalled()
+      expect(rendered.output()).toContain('Restore the code and/or conversation')
+
+      harness.keybindings['messageSelector:select']?.()
+      await waitForSelectOption('nevermind')
+      await harness.selectProps?.onChange('nevermind')
+      await sleep()
+
+      expect(onClose).not.toHaveBeenCalled()
+      expect(harness.logEvent).toHaveBeenCalledWith(
+        'agenc_message_selector_restore_option_selected',
+        { option: 'nevermind' },
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('submits summarize-from without feedback while the spinner is visible', async () => {
+    const selected = userMessage('user-1', 'summarize from here')
+    const onClose = vi.fn()
+    const onPreRestore = vi.fn()
+    let finishSummarize: (() => void) | undefined
+    const onSummarize = vi.fn(
+      () =>
+        new Promise<void>(resolve => {
+          finishSummarize = resolve
+        }),
+    )
+    const rendered = await renderSelector({
+      messages: [selected, assistantMessage('assistant-1', 'reply')],
+      onClose,
+      onPreRestore,
+      onSummarize,
+      preselectedMessage: selected,
+    })
+
+    try {
+      await waitForSelectOption('summarize')
+      const summarize = harness.selectProps?.options.find(
+        option => option.value === 'summarize',
+      )
+      summarize?.onChange?.('   ')
+
+      const pendingChange = harness.selectProps?.onChange('summarize')
+      await waitForOutput(rendered.output, 'Summarizing')
+
+      expect(onPreRestore).toHaveBeenCalledTimes(1)
+      expect(onSummarize).toHaveBeenCalledWith(selected, undefined, 'from')
+
+      finishSummarize?.()
+      await pendingChange
+      await sleep()
+
+      expect(onClose).toHaveBeenCalledTimes(1)
+    } finally {
+      finishSummarize?.()
+      await rendered.dispose()
+    }
+  })
+
+  test('reports combined code and conversation restore failures', async () => {
+    const selected = userMessage('user-1', 'restore both')
+    const onClose = vi.fn()
+    const onRestoreCode = vi.fn(async () => {
+      throw new Error('code failed')
+    })
+    const onRestoreMessage = vi.fn(async () => {
+      throw new Error('conversation failed')
+    })
+    const rendered = await renderSelector({
+      messages: [selected, assistantMessage('assistant-1', 'reply')],
+      onClose,
+      onRestoreCode,
+      onRestoreMessage,
+      preselectedMessage: selected,
+    })
+
+    try {
+      await waitForSelectOption('both')
+      await harness.selectProps?.onChange('both')
+      await waitForOutput(
+        rendered.output,
+        'Failed to restore the conversation and code:',
+      )
+
+      expect(onRestoreCode).toHaveBeenCalledWith(selected)
+      expect(onRestoreMessage).toHaveBeenCalledWith(selected)
+      expect(onClose).not.toHaveBeenCalled()
+      expect(harness.logError).toHaveBeenCalledTimes(2)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('renders pick-list file metadata, no-change metadata, and pending exit copy', async () => {
+    harness.exitPending = true
+    const first = userMessage('user-1', 'first prompt')
+    const second = userMessage('user-2', 'second prompt')
+    const rendered = await renderSelector({
+      messages: [
+        first,
+        toolResultMessage('edit-1', {
+          filePath: '/tmp/one.ts',
+          structuredPatch: [{ lines: ['+new', '-old'] }],
+        }),
+        second,
+      ],
+    })
+
+    try {
+      await waitForOutput(rendered.output, 'No code changes')
+
+      expect(rendered.output()).toContain('one.ts')
+      expect(rendered.output()).toContain('+1')
+      expect(rendered.output()).toContain('-1')
+      expect(rendered.output()).toContain('No code changes')
+      expect(rendered.output()).toContain('Press ctrl+c again to exit')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('renders command message variants and empty preselected prompts', async () => {
+    harness.fileHistoryEnabled = false
+    const slashCommand = userMessage(
+      'user-1',
+      '<command-message>deploy</command-message><command-args>prod</command-args>',
+    )
+    const skillCommand = userMessage(
+      'user-2',
+      '<command-message>review</command-message><skill-format>true</skill-format>',
+    )
+    const commands = await renderSelector({
+      messages: [slashCommand, skillCommand],
+    })
+
+    try {
+      expect(commands.output()).toContain('/deploy prod')
+      expect(commands.output()).toContain('$review')
+    } finally {
+      await commands.dispose()
+    }
+
+    const empty = userStringMessage('empty-message', '    ')
+    const emptyRendered = await renderSelector({
+      messages: [userMessage('user-3', 'valid prompt')],
+      preselectedMessage: empty,
+    })
+
+    try {
+      await waitForOutput(emptyRendered.output, '((empty message))')
+      expect(emptyRendered.output()).toContain('((empty message))')
+    } finally {
+      await emptyRendered.dispose()
+    }
+  })
+
+  test('renders no-file and many-file restore descriptions', async () => {
+    const selected = userMessage('user-1', 'restore code')
+    harness.diffStats = {
+      deletions: 0,
+      filesChanged: [''],
+      insertions: 0,
+    }
+    const noFile = await renderSelector({
+      messages: [selected, assistantMessage('assistant-1', 'reply')],
+      preselectedMessage: selected,
+    })
+
+    try {
+      await waitForOutput(noFile.output, 'nothing will be restored')
+      expect(noFile.output()).toContain('The code has not changed')
+    } finally {
+      await noFile.dispose()
+    }
+
+    harness.diffStats = {
+      deletions: 3,
+      filesChanged: ['/tmp/first.ts', '/tmp/second.ts', '/tmp/third.ts'],
+      insertions: 7,
+    }
+    const manyFiles = await renderSelector({
+      messages: [selected, assistantMessage('assistant-1', 'reply')],
+      preselectedMessage: selected,
+    })
+
+    try {
+      await waitForOutput(manyFiles.output, 'first.ts and 2 other files')
+      expect(manyFiles.output()).toContain('first.ts and 2 other files')
+    } finally {
+      await manyFiles.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-013-components-tasks-BackgroundTasksPanel.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-013-components-tasks-BackgroundTasksPanel.test.tsx
@@ -1,0 +1,407 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+
+const appStateMock = vi.hoisted(() => ({
+  state: { tasks: {} as Record<string, unknown> },
+  setAppState: vi.fn(),
+}))
+
+const inputHandler = vi.hoisted(() => ({
+  current: undefined as
+    | undefined
+    | ((input: string, key: Record<string, boolean>) => void),
+}))
+
+const terminalSizeMock = vi.hoisted(() => ({
+  size: { columns: 132, rows: 36 },
+}))
+
+const killTaskMock = vi.hoisted(() => vi.fn())
+const killAsyncAgentMock = vi.hoisted(() => vi.fn())
+const requestTeammateShutdownMock = vi.hoisted(() => vi.fn())
+const tailFileMock = vi.hoisted(() => vi.fn())
+const getTaskOutputPathMock = vi.hoisted(() =>
+  vi.fn((taskId: string) => `/tmp/${taskId}.log`),
+)
+
+vi.mock('../state/AppState.js', () => ({
+  useAppState: (selector: (state: typeof appStateMock.state) => unknown) =>
+    selector(appStateMock.state),
+  useSetAppState: () => appStateMock.setAppState,
+}))
+
+vi.mock('../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => terminalSizeMock.size,
+}))
+
+vi.mock('../ink.js', async () => {
+  const actual = await vi.importActual<typeof import('../ink.js')>('../ink.js')
+  return {
+    ...actual,
+    useInput: (
+      handler: (input: string, key: Record<string, boolean>) => void,
+    ) => {
+      inputHandler.current = handler
+    },
+  }
+})
+
+vi.mock('../../tasks/LocalShellTask/killShellTasks.js', () => ({
+  killTask: killTaskMock,
+}))
+
+vi.mock('../../tasks/LocalAgentTask/LocalAgentTask.js', () => ({
+  killAsyncAgent: killAsyncAgentMock,
+}))
+
+vi.mock('../../tasks/InProcessTeammateTask/InProcessTeammateTask.js', () => ({
+  requestTeammateShutdown: requestTeammateShutdownMock,
+}))
+
+vi.mock('../../utils/fsOperations.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../utils/fsOperations.js')>()
+  return {
+    ...actual,
+    tailFile: tailFileMock,
+  }
+})
+
+vi.mock('../../utils/task/diskOutput.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../utils/task/diskOutput.js')>()
+  return {
+    ...actual,
+    getTaskOutputPath: getTaskOutputPathMock,
+  }
+})
+
+function key(overrides: Record<string, boolean> = {}) {
+  return {
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    return: false,
+    escape: false,
+    ...overrides,
+  }
+}
+
+function makeShellTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'shell-task',
+    type: 'local_bash',
+    status: 'running',
+    description: 'Run shell task',
+    startTime: Date.now() - 2_000,
+    outputFile: 'urn:agenc:task:shell-task:output',
+    outputOffset: 0,
+    notified: false,
+    command: 'npm run test:unit',
+    kind: 'bash',
+    isBackgrounded: true,
+    ...overrides,
+  }
+}
+
+function makeRemoteTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'remote-task',
+    type: 'remote_agent',
+    status: 'running',
+    description: 'Remote task description',
+    startTime: Date.now() - 1_000,
+    outputFile: 'urn:agenc:task:remote-task:output',
+    outputOffset: 0,
+    notified: false,
+    remoteTaskType: 'ultrareview',
+    sessionId: 'session-remote',
+    command: 'review the change',
+    title: 'Remote review',
+    todoList: [],
+    log: [],
+    pollStartedAt: Date.now() - 1_000,
+    ...overrides,
+  }
+}
+
+function makeLocalAgentTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'local-agent-task',
+    type: 'local_agent',
+    status: 'completed',
+    description: 'Local agent description',
+    startTime: Date.now() - 5_000,
+    outputFile: 'urn:agenc:task:local-agent-task:output',
+    outputOffset: 0,
+    notified: false,
+    agentId: 'agent-local',
+    agentType: 'planner',
+    prompt: 'Use this prompt as the title',
+    retrieved: false,
+    pendingMessages: [],
+    messages: [],
+    lastReportedToolCount: 0,
+    lastReportedTokenCount: 0,
+    retain: false,
+    diskLoaded: false,
+    ...overrides,
+  }
+}
+
+function makeTeammateTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'teammate-task',
+    type: 'in_process_teammate',
+    status: 'completed',
+    description: 'Teammate task description',
+    startTime: Date.now() - 4_000,
+    outputFile: 'urn:agenc:task:teammate-task:output',
+    outputOffset: 0,
+    notified: false,
+    identity: {
+      agentId: 'agent-teammate',
+      agentName: 'Reviewer',
+      teamName: 'runtime',
+      planModeRequired: false,
+      parentSessionId: 'parent-session',
+    },
+    prompt: 'Check the task panel',
+    model: 'teammate-model',
+    awaitingPlanApproval: false,
+    permissionMode: 'default',
+    pendingUserMessages: [],
+    messages: [],
+    isIdle: true,
+    shutdownRequested: false,
+    lastReportedToolCount: 0,
+    lastReportedTokenCount: 0,
+    ...overrides,
+  }
+}
+
+describe('BackgroundTasksPanel swarm row 013', () => {
+  beforeEach(() => {
+    appStateMock.state = { tasks: {} }
+    appStateMock.setAppState.mockClear()
+    inputHandler.current = undefined
+    terminalSizeMock.size = { columns: 132, rows: 36 }
+    killTaskMock.mockClear()
+    killAsyncAgentMock.mockClear()
+    requestTeammateShutdownMock.mockClear()
+    tailFileMock.mockReset()
+    getTaskOutputPathMock.mockClear()
+  })
+
+  it('filters dialog tasks, renders terminal task rows, and leaves remote stop unavailable', async () => {
+    appStateMock.state = {
+      tasks: {
+        invalidPrimitive: null,
+        invalidType: {
+          id: 'invalid-type',
+          type: 'generic',
+          status: 'completed',
+          description: 'should stay hidden',
+        },
+        foregroundFinished: makeShellTask({
+          id: 'foreground-finished',
+          status: 'completed',
+          command: 'should not be listed',
+          isBackgrounded: false,
+        }),
+        remoteRunning: makeRemoteTask({
+          id: 'remote-running',
+          title: 'Remote selected task',
+          startTime: Date.now() - 1_000,
+        }),
+        pendingShell: makeShellTask({
+          id: 'pending-shell',
+          status: 'pending',
+          command: 'pnpm build',
+          startTime: Date.now() - 2_000,
+        }),
+        completedRemote: makeRemoteTask({
+          id: 'remote-finished',
+          status: 'completed',
+          title: 'Finished remote task',
+          startTime: Date.now() - 3_000,
+        }),
+        completedTeammate: makeTeammateTask({
+          id: 'teammate-finished',
+          status: 'completed',
+          startTime: Date.now() - 4_000,
+        }),
+        completedLocal: makeLocalAgentTask({
+          id: 'local-finished',
+          status: 'completed',
+          startTime: Date.now() - 5_000,
+        }),
+        completedShell: makeShellTask({
+          id: 'shell-finished',
+          status: 'completed',
+          command: 'npm run done',
+          isBackgrounded: undefined,
+          startTime: Date.now() - 6_000,
+        }),
+      },
+    }
+
+    const { BackgroundTasksPanel } = await import(
+      '../components/tasks/BackgroundTasksPanel.js'
+    )
+
+    const output = await renderToString(<BackgroundTasksPanel />, 132)
+
+    expect(output).toContain('2 running')
+    expect(output).toContain('4 finished')
+    expect(output).toContain('remote-running')
+    expect(output).toContain('Remote selected task')
+    expect(output).toContain('Remote task stop is not available')
+    expect(output).toContain('pnpm build')
+    expect(output).toContain('queued')
+    expect(output).toContain('Finished remote')
+    expect(output).toContain('Check the task')
+    expect(output).toContain('Use this prompt')
+    expect(output).toContain('npm run done')
+    expect(output).not.toContain('foreground-finished')
+    expect(output).not.toContain('invalid-type')
+    expect(output).not.toContain('should stay hidden')
+
+    if (!inputHandler.current) {
+      throw new Error('BackgroundTasksPanel did not register input handling')
+    }
+    inputHandler.current('x', key())
+
+    expect(killTaskMock).not.toHaveBeenCalled()
+    expect(killAsyncAgentMock).not.toHaveBeenCalled()
+    expect(requestTeammateShutdownMock).not.toHaveBeenCalled()
+  })
+
+  it('renders shell result details and requests the output tail for running tasks', async () => {
+    tailFileMock.mockResolvedValue({
+      content: 'tail line from shell',
+      bytesTotal: 1536,
+    })
+    appStateMock.state = {
+      tasks: {
+        shell: makeShellTask({
+          id: 'shell-with-result',
+          command: 'node scripts/check.js',
+          kind: 'monitor',
+          result: { code: 7, interrupted: true },
+        }),
+      },
+    }
+
+    const { BackgroundTasksPanel } = await import(
+      '../components/tasks/BackgroundTasksPanel.js'
+    )
+
+    const output = await renderToString(
+      <BackgroundTasksPanel initialDetailTaskId="shell-with-result" />,
+      132,
+    )
+
+    expect(output).toContain('TASK DETAIL')
+    expect(output).toContain('node scripts/check.js')
+    expect(output).toContain('monitor')
+    expect(output).toContain('code 7')
+    expect(output).toContain('interrupted')
+    expect(output).toContain('yes')
+    expect(output).toContain('loading output tail')
+    expect(getTaskOutputPathMock).toHaveBeenCalledWith('shell-with-result')
+    expect(tailFileMock).toHaveBeenCalledWith('/tmp/shell-with-result.log', 8192)
+  })
+
+  it('renders remote review progress and ignores stop input for finished tasks', async () => {
+    appStateMock.state = {
+      tasks: {
+        review: makeRemoteTask({
+          id: 'remote-review',
+          status: 'completed',
+          title: '',
+          command: '',
+          description: 'Remote description fallback',
+          reviewProgress: {
+            bugsFound: 4,
+            bugsVerified: 2,
+            bugsRefuted: 1,
+          },
+          log: undefined,
+        }),
+      },
+    }
+
+    const { BackgroundTasksPanel } = await import(
+      '../components/tasks/BackgroundTasksPanel.js'
+    )
+
+    const output = await renderToString(
+      <BackgroundTasksPanel initialDetailTaskId="remote-review" />,
+      132,
+    )
+
+    expect(output).toContain('TASK DETAIL')
+    expect(output).toContain('Remote description fallback')
+    expect(output).toContain('review')
+    expect(output).toContain('4 found')
+    expect(output).toContain('2 verified')
+    expect(output).toContain('1 refuted')
+
+    if (!inputHandler.current) {
+      throw new Error('BackgroundTasksPanel did not register input handling')
+    }
+    inputHandler.current('x', key())
+
+    expect(killTaskMock).not.toHaveBeenCalled()
+    expect(killAsyncAgentMock).not.toHaveBeenCalled()
+    expect(requestTeammateShutdownMock).not.toHaveBeenCalled()
+  })
+
+  it('stringifies sparse local agent detail values and activity fallbacks', async () => {
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+    appStateMock.state = {
+      tasks: {
+        local: makeLocalAgentTask({
+          id: 'local-agent-detail',
+          status: 'failed',
+          model: undefined,
+          error: new Error('agent exploded'),
+          result: 12n,
+          messages: [null, true, circular],
+          progress: {
+            recentActivities: [
+              {
+                toolName: 'write',
+                input: 'notes.txt',
+              },
+            ],
+          },
+        }),
+      },
+    }
+
+    const { BackgroundTasksPanel } = await import(
+      '../components/tasks/BackgroundTasksPanel.js'
+    )
+
+    const output = await renderToString(
+      <BackgroundTasksPanel initialDetailTaskId="local-agent-detail" />,
+      132,
+    )
+
+    expect(output).toContain('TASK DETAIL')
+    expect(output).toContain('failed')
+    expect(output).toContain('Use this prompt as the title')
+    expect(output).toContain('agent exploded')
+    expect(output).toContain('12')
+    expect(output).toContain('null')
+    expect(output).toContain('true')
+    expect(output).toContain('[object Object]')
+    expect(output).toContain('write notes.txt')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-014-components-VirtualMessageList.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-014-components-VirtualMessageList.test.tsx
@@ -1,0 +1,568 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const virtualScroll = vi.hoisted(() => ({
+  bottomSpacer: 0,
+  elements: new Map<number, unknown>(),
+  heights: new Map<number, number | undefined>(),
+  itemTops: new Map<number, number>(),
+  keys: [] as readonly string[],
+  offsets: [] as number[],
+  range: [0, 0] as [number, number],
+  reset() {
+    virtualScroll.bottomSpacer = 0;
+    virtualScroll.elements = new Map();
+    virtualScroll.heights = new Map();
+    virtualScroll.itemTops = new Map();
+    virtualScroll.keys = [];
+    virtualScroll.offsets = [];
+    virtualScroll.range = [0, 0];
+    virtualScroll.scrollToIndex.mockClear();
+    virtualScroll.topSpacer = 0;
+  },
+  scrollToIndex: vi.fn(),
+  topSpacer: 0,
+}));
+
+vi.mock("../hooks/useVirtualScroll.js", () => ({
+  useVirtualScroll: (_scrollRef: unknown, keys: readonly string[]) => {
+    virtualScroll.keys = keys;
+    return {
+      bottomSpacer: virtualScroll.bottomSpacer,
+      getItemElement: (index: number) =>
+        virtualScroll.elements.get(index) ?? null,
+      getItemHeight: (index: number) => virtualScroll.heights.get(index),
+      getItemTop: (index: number) => virtualScroll.itemTops.get(index) ?? -1,
+      measureRef: (key: string) => (el: unknown) => {
+        const index = virtualScroll.keys.indexOf(key);
+        if (index >= 0 && el) virtualScroll.elements.set(index, el);
+      },
+      offsets: virtualScroll.offsets,
+      range: virtualScroll.range,
+      scrollToIndex: virtualScroll.scrollToIndex,
+      spacerRef: { current: null },
+      topSpacer: virtualScroll.topSpacer,
+    };
+  },
+}));
+
+vi.mock("../../utils/sleep.js", () => ({
+  sleep: async () => {},
+}));
+
+import { createRoot } from "../ink/root.js";
+import { Text } from "../ink.js";
+import type { ScrollBoxHandle } from "../ink/components/ScrollBox.js";
+import type { DOMElement } from "../ink/dom.js";
+import type { RenderableMessage } from "../../types/message.js";
+import { ScrollChromeContext } from "../components/FullscreenLayout.js";
+import {
+  type JumpHandle,
+  type StickyPrompt,
+  VirtualMessageList,
+} from "../components/VirtualMessageList.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+type TestScrollHandle = ScrollBoxHandle & {
+  emit: () => void;
+  setPendingDelta: (value: number) => void;
+  setSticky: (value: boolean) => void;
+};
+
+function userMessage(
+  uuid: string,
+  text: string,
+  overrides: Partial<RenderableMessage> = {},
+): RenderableMessage {
+  return {
+    isCompactSummary: false,
+    isMeta: false,
+    isVisibleInTranscriptOnly: false,
+    message: { content: [{ text, type: "text" }] },
+    type: "user",
+    uuid,
+    ...overrides,
+  } as RenderableMessage;
+}
+
+function nonTextUserMessage(uuid: string): RenderableMessage {
+  return {
+    isCompactSummary: false,
+    isMeta: false,
+    isVisibleInTranscriptOnly: false,
+    message: { content: [{ source: "inline", type: "image" }] },
+    type: "user",
+    uuid,
+  } as unknown as RenderableMessage;
+}
+
+function assistantMessage(uuid: string, text: string): RenderableMessage {
+  return {
+    message: { content: [{ text, type: "text" }] },
+    type: "assistant",
+    uuid,
+  } as RenderableMessage;
+}
+
+function queuedTaskNotification(uuid: string): RenderableMessage {
+  return {
+    attachment: {
+      commandMode: "task-notification",
+      isMeta: false,
+      prompt: "task status should not stick",
+      type: "queued_command",
+    },
+    type: "attachment",
+    uuid,
+  } as RenderableMessage;
+}
+
+function fakeElement(height = 2): DOMElement {
+  return {
+    yogaNode: {
+      getComputedHeight: () => height,
+    },
+  } as DOMElement;
+}
+
+function createStreams(): { stdin: TestStdin; stdout: PassThrough } {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.on("data", () => {});
+  stdout.resume();
+
+  return { stdin, stdout };
+}
+
+function createScrollHandle(initialScrollTop = 0): TestScrollHandle {
+  let pendingDelta = 0;
+  let scrollTop = initialScrollTop;
+  let sticky = false;
+  const listeners = new Set<() => void>();
+
+  return {
+    emit: () => {
+      for (const listener of listeners) listener();
+    },
+    getPendingDelta: vi.fn(() => pendingDelta),
+    getScrollTop: vi.fn(() => scrollTop),
+    getViewportHeight: vi.fn(() => 5),
+    getViewportTop: vi.fn(() => 0),
+    isSticky: vi.fn(() => sticky),
+    scrollTo: vi.fn((value: number) => {
+      scrollTop = value;
+    }),
+    scrollToBottom: vi.fn(() => {
+      sticky = true;
+    }),
+    scrollToElement: vi.fn(),
+    setPendingDelta: (value: number) => {
+      pendingDelta = value;
+    },
+    setSticky: (value: boolean) => {
+      sticky = value;
+    },
+    subscribe: vi.fn((listener: () => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    }),
+  } as unknown as TestScrollHandle;
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 2_000) {
+    if (predicate()) return;
+    await sleep(10);
+  }
+  throw new Error(message);
+}
+
+function renderNode({
+  jumpRef,
+  messages,
+  onSearchMatchesChange,
+  scanElement,
+  scrollHandle,
+  selectedIndex,
+  setPositions,
+  setStickyPrompt,
+  trackStickyPrompt = false,
+}: {
+  jumpRef?: React.RefObject<JumpHandle | null>;
+  messages: RenderableMessage[];
+  onSearchMatchesChange?: (count: number, current: number) => void;
+  scanElement?: (el: DOMElement) => Array<{ row: number; col: number }>;
+  scrollHandle: ScrollBoxHandle | null;
+  selectedIndex?: number;
+  setPositions?: (
+    state: {
+      positions: Array<{ row: number; col: number }>;
+      rowOffset: number;
+      currentIdx: number;
+    } | null,
+  ) => void;
+  setStickyPrompt?: (prompt: StickyPrompt | null) => void;
+  trackStickyPrompt?: boolean;
+}): React.ReactNode {
+  return (
+    <ScrollChromeContext value={{ setStickyPrompt: setStickyPrompt ?? (() => {}) }}>
+      <VirtualMessageList
+        columns={80}
+        itemKey={message => message.uuid}
+        jumpRef={jumpRef}
+        messages={messages}
+        onSearchMatchesChange={onSearchMatchesChange}
+        renderItem={(message, index) => (
+          <Text>
+            {index}:{message.uuid}
+          </Text>
+        )}
+        scanElement={scanElement}
+        scrollRef={{ current: scrollHandle }}
+        selectedIndex={selectedIndex}
+        setPositions={setPositions}
+        trackStickyPrompt={trackStickyPrompt}
+      />
+    </ScrollChromeContext>
+  );
+}
+
+describe("VirtualMessageList swarm 014 coverage", () => {
+  beforeEach(() => {
+    virtualScroll.reset();
+  });
+
+  afterEach(() => {
+    virtualScroll.reset();
+  });
+
+  test("rebuilds cached keys after compaction and pins an unmounted selected row", async () => {
+    const messages = [
+      userMessage("u-one", "first prompt"),
+      assistantMessage("a-one", "reply"),
+      userMessage("u-two", "second prompt"),
+    ];
+    virtualScroll.range = [0, 2];
+    virtualScroll.offsets = [0, 2, 4, 6];
+    messages.forEach((_, index) => {
+      virtualScroll.heights.set(index, 1);
+      virtualScroll.itemTops.set(index, index * 2);
+    });
+
+    const scrollHandle = createScrollHandle();
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        renderNode({
+          messages,
+          scrollHandle,
+          selectedIndex: 2,
+        }),
+      );
+      await waitForCondition(
+        () => virtualScroll.scrollToIndex.mock.calls.length > 0,
+        "selected row fallback did not request virtual scrolling",
+      );
+
+      expect(virtualScroll.keys).toEqual(["u-one", "a-one", "u-two"]);
+      expect(virtualScroll.scrollToIndex).toHaveBeenCalledWith(2);
+
+      const compacted = [assistantMessage("a-new", "compacted reply")];
+      virtualScroll.range = [0, compacted.length];
+      virtualScroll.offsets = [0, 1];
+      virtualScroll.scrollToIndex.mockClear();
+
+      root.render(
+        renderNode({
+          messages: compacted,
+          scrollHandle,
+        }),
+      );
+      await waitForCondition(
+        () => virtualScroll.keys.length === 1,
+        "compacted key cache did not rebuild",
+      );
+
+      expect(virtualScroll.keys).toEqual(["a-new"]);
+      expect(virtualScroll.scrollToIndex).not.toHaveBeenCalled();
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+
+  test("queues next-match during seek and scrolls offscreen highlights into view", async () => {
+    const messages = [
+      userMessage("u-needle", "needle needle"),
+      assistantMessage("a-needle", "needle"),
+    ];
+    virtualScroll.range = [0, messages.length];
+    virtualScroll.offsets = [0, 10, 20];
+    virtualScroll.elements.set(0, fakeElement());
+    virtualScroll.elements.set(1, fakeElement());
+    messages.forEach((_, index) => {
+      virtualScroll.heights.set(index, 2);
+      virtualScroll.itemTops.set(index, index * 10);
+    });
+
+    const jumpRef = React.createRef<JumpHandle | null>();
+    const onSearchMatchesChange = vi.fn();
+    const scrollHandle = createScrollHandle();
+    const setPositions = vi.fn();
+    const scanElement = vi
+      .fn<(_: DOMElement) => Array<{ row: number; col: number }>>()
+      .mockReturnValueOnce([
+        { col: 1, row: 0 },
+        { col: 8, row: 14 },
+      ])
+      .mockReturnValue([{ col: 2, row: 1 }]);
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        renderNode({
+          jumpRef,
+          messages,
+          onSearchMatchesChange,
+          scanElement,
+          scrollHandle,
+          setPositions,
+        }),
+      );
+      await waitForCondition(
+        () => jumpRef.current !== null,
+        "jump handle was not exposed",
+      );
+
+      jumpRef.current?.setSearchQuery("needle");
+      jumpRef.current?.nextMatch();
+
+      await waitForCondition(
+        () => scanElement.mock.calls.length >= 2,
+        "queued next-match did not scan the next matched row",
+      );
+
+      expect(scrollHandle.scrollTo).toHaveBeenCalledWith(11);
+      expect(scrollHandle.scrollTo).toHaveBeenLastCalledWith(7);
+      expect(setPositions).toHaveBeenLastCalledWith({
+        currentIdx: 0,
+        positions: [{ col: 2, row: 1 }],
+        rowOffset: 3,
+      });
+      expect(onSearchMatchesChange).toHaveBeenLastCalledWith(3, 3);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+
+  test("clears phantom search matches when no rendered positions are found", async () => {
+    const messages = [userMessage("u-phantom", "needle")];
+    virtualScroll.range = [0, messages.length];
+    virtualScroll.offsets = [0, 5];
+    virtualScroll.elements.set(0, fakeElement());
+    virtualScroll.heights.set(0, 2);
+    virtualScroll.itemTops.set(0, 5);
+
+    const jumpRef = React.createRef<JumpHandle | null>();
+    const scrollHandle = createScrollHandle();
+    const setPositions = vi.fn();
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        renderNode({
+          jumpRef,
+          messages,
+          scrollHandle,
+          setPositions,
+        }),
+      );
+      await waitForCondition(
+        () => jumpRef.current !== null,
+        "jump handle was not exposed",
+      );
+
+      jumpRef.current?.setSearchQuery("needle");
+
+      await waitForCondition(
+        () => setPositions.mock.calls.length >= 2,
+        "phantom match did not clear search positions",
+      );
+
+      expect(scrollHandle.scrollTo).toHaveBeenCalledWith(2);
+      expect(setPositions).toHaveBeenLastCalledWith(null);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+
+  test("filters non-real sticky prompt candidates before publishing an older prompt", async () => {
+    const messages = [
+      userMessage("u-old", "old prompt\n\nhidden details"),
+      userMessage("u-meta", "meta prompt", { isMeta: true } as Partial<RenderableMessage>),
+      nonTextUserMessage("u-image"),
+      userMessage("u-xml", "<command-message>synthetic</command-message>"),
+      queuedTaskNotification("q-task"),
+      userMessage("u-edge", "visible prompt at viewport top"),
+      assistantMessage("a-visible", "visible reply"),
+    ];
+    virtualScroll.range = [6, messages.length];
+    virtualScroll.offsets = [0, 8, 16, 24, 30, 34, 50, 60];
+    messages.forEach((_, index) => {
+      virtualScroll.heights.set(index, 2);
+      virtualScroll.itemTops.set(index, virtualScroll.offsets[index]!);
+    });
+
+    const setStickyPrompt = vi.fn();
+    const scrollHandle = createScrollHandle(35);
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        renderNode({
+          messages,
+          scrollHandle,
+          setStickyPrompt,
+          trackStickyPrompt: true,
+        }),
+      );
+
+      await waitForCondition(() => {
+        const prompt = setStickyPrompt.mock.lastCall?.[0] as StickyPrompt | null;
+        return typeof prompt === "object" && prompt !== null;
+      }, "sticky prompt was not published");
+
+      const prompt = setStickyPrompt.mock.lastCall?.[0] as Exclude<
+        StickyPrompt,
+        "clicked"
+      >;
+      expect(prompt.text).toBe("old prompt");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+
+  test("clears sticky prompt when the previous candidate disappears", async () => {
+    const messages = [
+      userMessage("u-sticky", "temporary sticky prompt"),
+      assistantMessage("a-visible", "visible reply"),
+    ];
+    virtualScroll.range = [1, messages.length];
+    virtualScroll.offsets = [0, 10, 20];
+    messages.forEach((_, index) => {
+      virtualScroll.heights.set(index, 2);
+      virtualScroll.itemTops.set(index, index * 10);
+    });
+
+    const setStickyPrompt = vi.fn();
+    const scrollHandle = createScrollHandle(12);
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        renderNode({
+          messages,
+          scrollHandle,
+          setStickyPrompt,
+          trackStickyPrompt: true,
+        }),
+      );
+
+      await waitForCondition(
+        () => {
+          const prompt = setStickyPrompt.mock.lastCall?.[0] as
+            | StickyPrompt
+            | null
+            | undefined;
+          return typeof prompt === "object" && prompt !== null;
+        },
+        "initial sticky prompt was not published",
+      );
+
+      const clearedMessages = [assistantMessage("a-only", "only reply")];
+      virtualScroll.range = [0, clearedMessages.length];
+      virtualScroll.offsets = [0, 10];
+      virtualScroll.heights = new Map([[0, 2]]);
+      virtualScroll.itemTops = new Map([[0, 0]]);
+
+      root.render(
+        renderNode({
+          messages: clearedMessages,
+          scrollHandle,
+          setStickyPrompt,
+          trackStickyPrompt: true,
+        }),
+      );
+
+      await waitForCondition(
+        () => setStickyPrompt.mock.lastCall?.[0] === null,
+        "stale sticky prompt was not cleared",
+      );
+
+      expect(setStickyPrompt).toHaveBeenLastCalledWith(null);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-015-input-processPromptInput.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-015-input-processPromptInput.test.ts
@@ -1,0 +1,384 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const imageMocks = vi.hoisted(() => ({
+  createImageMetadataText: vi.fn(),
+  maybeResizeAndDownsampleImageBlock: vi.fn(),
+  storeImages: vi.fn(),
+}))
+
+vi.mock('src/utils/imageResizer.js', () => ({
+  createImageMetadataText: imageMocks.createImageMetadataText,
+  maybeResizeAndDownsampleImageBlock:
+    imageMocks.maybeResizeAndDownsampleImageBlock,
+}))
+
+vi.mock('src/utils/imageStore.js', () => ({
+  storeImages: imageMocks.storeImages,
+}))
+
+import { processPromptInput } from 'src/tui/input/processPromptInput.js'
+import {
+  createImageMetadataText,
+  maybeResizeAndDownsampleImageBlock,
+} from 'src/utils/imageResizer.js'
+import { storeImages } from 'src/utils/imageStore.js'
+
+function baseContext(commands: any[] = [], extra: Record<string, unknown> = {}) {
+  return {
+    options: { commands },
+    getAppState: () => ({
+      toolPermissionContext: { mode: 'default' },
+    }),
+    setAppState: () => {},
+    requestPrompt: async () => '',
+    ...extra,
+  } as any
+}
+
+async function routePrompt(
+  input: Parameters<typeof processPromptInput>[0]['input'],
+  options: Partial<Parameters<typeof processPromptInput>[0]> = {},
+) {
+  return processPromptInput({
+    input,
+    mode: 'prompt' as any,
+    setToolJSX: () => {},
+    context: baseContext(),
+    skipAttachments: true,
+    ...options,
+  })
+}
+
+function localCommand(
+  name: string,
+  result: unknown,
+  overrides: Record<string, unknown> = {},
+) {
+  const call = vi.fn(async () => result)
+  const load = vi.fn(async () => ({ call }))
+
+  return {
+    command: {
+      type: 'local',
+      name,
+      description: `/${name}`,
+      load,
+      ...overrides,
+    },
+    call,
+    load,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(maybeResizeAndDownsampleImageBlock).mockImplementation(
+    async block => ({
+      block,
+      dimensions: undefined,
+    }),
+  )
+  vi.mocked(createImageMetadataText).mockImplementation(
+    (dimensions: any, sourcePath?: string) =>
+      sourcePath
+        ? `[image ${dimensions.width}x${dimensions.height} ${sourcePath}]`
+        : `[image ${dimensions.width}x${dimensions.height}]`,
+  )
+  vi.mocked(storeImages).mockResolvedValue(new Map())
+})
+
+describe('processPromptInput coverage swarm row 015', () => {
+  test('rejects bridge slash commands that are not bridge safe', async () => {
+    const { command, load } = localCommand('config', {
+      type: 'text',
+      value: 'should not run',
+    })
+
+    const result = await routePrompt('/config', {
+      context: baseContext([command]),
+      bridgeOrigin: true,
+      skipSlashCommands: true,
+    })
+
+    expect(load).not.toHaveBeenCalled()
+    expect(result.shouldQuery).toBe(false)
+    expect(result.resultText).toBe(
+      "/config isn't available over Remote Control.",
+    )
+    expect(JSON.stringify(result.messages)).toContain(
+      "<local-command-stdout>/config isn't available over Remote Control.</local-command-stdout>",
+    )
+  })
+
+  test('formats invalid, unknown, unavailable, skip, and compact slash results', async () => {
+    const invalid = await routePrompt('/', {
+      context: baseContext([]),
+    })
+    expect(invalid.shouldQuery).toBe(false)
+    expect(invalid.resultText).toBe('Commands are in the form `/command [args]`')
+
+    const unknown = await routePrompt('/missing args', {
+      context: baseContext([]),
+    })
+    expect(unknown.shouldQuery).toBe(false)
+    expect(unknown.resultText).toBe('Unknown command: /missing')
+
+    const unavailable = localCommand('disabled', {
+      type: 'text',
+      value: 'should not run',
+    }, {
+      isEnabled: () => false,
+    })
+    const unavailableResult = await routePrompt('/disabled', {
+      context: baseContext([unavailable.command]),
+    })
+    expect(unavailable.load).not.toHaveBeenCalled()
+    expect(unavailableResult.resultText).toBe('/disabled is not available')
+
+    const hidden = localCommand('hidden', {
+      type: 'text',
+      value: 'should not run',
+    }, {
+      userInvocable: false,
+    })
+    const hiddenResult = await routePrompt('/hidden', {
+      context: baseContext([hidden.command]),
+    })
+    expect(hidden.load).not.toHaveBeenCalled()
+    expect(hiddenResult.resultText).toBe('/hidden is not available')
+
+    const skipped = localCommand('noop', { type: 'skip' })
+    const skippedResult = await routePrompt('/noop', {
+      context: baseContext([skipped.command]),
+    })
+    expect(skippedResult).toEqual({ messages: [], shouldQuery: false })
+
+    const emptyCompact = localCommand('compact-empty', {
+      type: 'compact',
+    })
+    const emptyCompactResult = await routePrompt('/compact-empty', {
+      context: baseContext([emptyCompact.command]),
+    })
+    expect(emptyCompactResult).toEqual({ messages: [], shouldQuery: false })
+
+    const compact = localCommand('compact', {
+      type: 'compact',
+      displayText: 'summary ready',
+    })
+    const compactResult = await routePrompt('/compact now', {
+      context: baseContext([compact.command]),
+      uuid: 'slash-uuid',
+    })
+    expect(compact.call).toHaveBeenCalledWith('now', expect.any(Object))
+    expect(compactResult.shouldQuery).toBe(false)
+    expect(compactResult.resultText).toBe('summary ready')
+    expect(JSON.stringify(compactResult.messages)).toContain(
+      '<local-command-stdout>summary ready</local-command-stdout>',
+    )
+    expect(JSON.stringify(compactResult.messages)).toContain('slash-uuid')
+  })
+
+  test('keeps skipped slash input as regular prompt text', async () => {
+    const result = await routePrompt('/help from remote text', {
+      skipSlashCommands: true,
+    })
+
+    expect(result.shouldQuery).toBe(true)
+    expect((result.messages[0] as any).message.content).toBe(
+      '/help from remote text',
+    )
+  })
+
+  test('stops after nonblocking hook context when continuation is prevented', async () => {
+    const context = baseContext([], {
+      services: {
+        hooks: {
+          userPromptSubmitHooks: [
+            () => ({
+              additionalContexts: ['review note'],
+              preventContinuation: true,
+              stopReason: 'needs approval',
+            }),
+          ],
+        },
+      },
+    })
+
+    const result = await routePrompt('deploy now', { context })
+
+    expect(result.shouldQuery).toBe(false)
+    expect(result.messages).toHaveLength(3)
+    expect((result.messages[1] as any).attachment).toMatchObject({
+      type: 'hook_additional_context',
+      content: ['review note'],
+      hookName: 'UserPromptSubmit',
+      hookEvent: 'UserPromptSubmit',
+    })
+    expect((result.messages[2] as any).message.content).toBe(
+      'Operation stopped by hook: needs approval',
+    )
+  })
+
+  test('routes invisible meta prompts without showing processing input', async () => {
+    const setUserInputOnProcessing = vi.fn()
+
+    const result = await routePrompt('quiet system prompt', {
+      isMeta: true,
+      setUserInputOnProcessing,
+    })
+
+    expect(setUserInputOnProcessing).not.toHaveBeenCalled()
+    expect(result.shouldQuery).toBe(true)
+    expect((result.messages[0] as any).isMeta).toBe(true)
+  })
+
+  test('finalizes vim insert keys before showing and submitting prompt text', async () => {
+    const setUserInputOnProcessing = vi.fn()
+
+    const result = await routePrompt('abc', {
+      setUserInputOnProcessing,
+      vimRoutingState: {
+        enabled: true,
+        mode: 'INSERT',
+        keys: ['!'],
+        cursorOffset: 3,
+      },
+    })
+
+    expect(setUserInputOnProcessing).toHaveBeenCalledWith('abc!')
+    expect((result.messages[0] as any).message.content).toBe('abc!')
+  })
+
+  test('normalizes content-block image input and appends resized metadata', async () => {
+    vi.mocked(maybeResizeAndDownsampleImageBlock).mockResolvedValueOnce({
+      block: {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: 'image/png',
+          data: 'resized-array-image',
+        },
+      },
+      dimensions: { width: 12, height: 34 },
+    } as any)
+
+    const result = await routePrompt([
+      {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: 'image/png',
+          data: 'array-image',
+        },
+      },
+      { type: 'text', text: 'describe this' },
+    ] as any)
+
+    expect(maybeResizeAndDownsampleImageBlock).toHaveBeenCalledTimes(1)
+    expect(createImageMetadataText).toHaveBeenCalledWith({
+      width: 12,
+      height: 34,
+    })
+    expect((result.messages[0] as any).message.content).toEqual([
+      {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: 'image/png',
+          data: 'resized-array-image',
+        },
+      },
+      { type: 'text', text: 'describe this' },
+    ])
+    expect((result.messages[1] as any).isMeta).toBe(true)
+    expect((result.messages[1] as any).message.content).toEqual([
+      { type: 'text', text: '[image 12x34]' },
+    ])
+  })
+
+  test('adds pasted image blocks and falls back to original dimensions for metadata', async () => {
+    vi.mocked(storeImages).mockResolvedValueOnce(
+      new Map([[7, '/tmp/pasted-image.png']]),
+    )
+    vi.mocked(maybeResizeAndDownsampleImageBlock).mockResolvedValueOnce({
+      block: {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: 'image/jpeg',
+          data: 'resized-pasted-image',
+        },
+      },
+      dimensions: undefined,
+    } as any)
+
+    const result = await routePrompt('use this image', {
+      pastedContents: {
+        7: {
+          id: 7,
+          type: 'image',
+          content: 'pasted-image',
+          mediaType: 'image/jpeg',
+          dimensions: { width: 80, height: 60 },
+        },
+      },
+    })
+
+    expect(storeImages).toHaveBeenCalledWith({
+      7: {
+        id: 7,
+        type: 'image',
+        content: 'pasted-image',
+        mediaType: 'image/jpeg',
+        dimensions: { width: 80, height: 60 },
+      },
+    })
+    expect(maybeResizeAndDownsampleImageBlock).toHaveBeenCalledWith({
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: 'image/jpeg',
+        data: 'pasted-image',
+      },
+    })
+    expect(createImageMetadataText).toHaveBeenCalledWith(
+      { width: 80, height: 60 },
+      '/tmp/pasted-image.png',
+    )
+    expect((result.messages[0] as any).imagePasteIds).toEqual([7])
+    expect((result.messages[0] as any).message.content).toEqual([
+      { type: 'text', text: 'use this image' },
+      {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: 'image/jpeg',
+          data: 'resized-pasted-image',
+        },
+      },
+    ])
+    expect((result.messages[1] as any).message.content).toEqual([
+      { type: 'text', text: '[image 80x60 /tmp/pasted-image.png]' },
+    ])
+  })
+
+  test('throws when non-prompt modes receive content blocks without text', async () => {
+    await expect(
+      processPromptInput({
+        input: [
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: 'image/png',
+              data: 'image-only',
+            },
+          },
+        ] as any,
+        mode: 'bash' as any,
+        setToolJSX: () => {},
+        context: baseContext(),
+      }),
+    ).rejects.toThrow('Mode: bash requires a string input.')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-016-components-teams-TeamsDialog.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-016-components-teams-TeamsDialog.test.tsx
@@ -1,0 +1,649 @@
+import { PassThrough } from "node:stream";
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+type MockTeammateStatus = {
+  agentId: string;
+  backendType?: "tmux" | "iterm2";
+  color?: string;
+  cwd?: string;
+  isHidden: boolean;
+  mode?: string;
+  model?: string;
+  name: string;
+  prompt?: string;
+  status: "idle" | "running";
+  tmuxPaneId: string;
+  worktreePath?: string;
+};
+
+const teammateStatusMock = vi.hoisted(() => ({
+  statuses: [] as MockTeammateStatus[],
+}));
+
+const inputMock = vi.hoisted(() => ({
+  handlers: new Set<(input: string, key: Record<string, boolean>) => void>(),
+}));
+
+const keybindingMock = vi.hoisted(() => ({
+  handlers: new Map<string, () => void>(),
+}));
+
+const backendMock = vi.hoisted(() => ({
+  backend: {
+    hidePane: vi.fn(async () => true),
+    killPane: vi.fn(async () => {}),
+    showPane: vi.fn(async () => true),
+    supportsHideShow: true,
+  },
+  cachedBackend: {
+    supportsHideShow: true,
+  } as { supportsHideShow: boolean } | null,
+}));
+
+const tasksMock = vi.hoisted(() => ({
+  listTasks: vi.fn(async () => []),
+  unassignTeammateTasks: vi.fn(async () => ({
+    notificationMessage: "tasks unassigned",
+  })),
+}));
+
+const mailboxMock = vi.hoisted(() => ({
+  sendShutdownRequestToMailbox: vi.fn(async () => {}),
+  writeToMailbox: vi.fn(async () => {}),
+}));
+
+const teamHelpersMock = vi.hoisted(() => ({
+  addHiddenPaneId: vi.fn(() => true),
+  removeHiddenPaneId: vi.fn(() => true),
+  removeMemberFromTeam: vi.fn(() => true),
+  setMemberMode: vi.fn(),
+  setMultipleMemberModes: vi.fn(),
+}));
+
+const execFileNoThrowMock = vi.hoisted(() =>
+  vi.fn(async () => ({ code: 0, stderr: "", error: "" })),
+);
+
+const detectionMock = vi.hoisted(() => ({
+  insideTmux: false,
+  leaderPaneId: "%leader" as string | null,
+}));
+
+const appStateMock = vi.hoisted(() => ({
+  state: {
+    teamContext: {
+      teammates: {
+        "agent-fixer": {},
+        "agent-planner": {},
+      } as Record<string, unknown>,
+    },
+    inbox: {
+      messages: [] as Array<{ text: string }>,
+    },
+  },
+}));
+
+vi.mock("usehooks-ts", async importOriginal => {
+  const actual = await importOriginal<typeof import("usehooks-ts")>();
+  return {
+    ...actual,
+    useInterval: () => {},
+  };
+});
+vi.mock("../../../src/tui/context/overlayContext.js", () => ({
+  useRegisterOverlay: () => {},
+}));
+vi.mock("../../../src/tui/hooks/useTerminalSize.js", () => ({
+  useTerminalSize: () => ({ columns: 120, rows: 30 }),
+}));
+vi.mock("../../../src/tui/ink.js", async importOriginal => {
+  const actual = await importOriginal<typeof import("../../../src/tui/ink.js")>();
+  const ReactModule = await import("react");
+
+  return {
+    ...actual,
+    useInput: (
+      handler: (input: string, key: Record<string, boolean>) => void,
+    ) => {
+      const handlerRef = ReactModule.useRef(handler);
+      handlerRef.current = handler;
+      ReactModule.useEffect(() => {
+        const currentHandler = (input: string, key: Record<string, boolean>) => {
+          handlerRef.current(input, key);
+        };
+        inputMock.handlers.add(currentHandler);
+        return () => {
+          inputMock.handlers.delete(currentHandler);
+        };
+      }, []);
+    },
+  };
+});
+vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
+  useKeybinding: () => {},
+  useKeybindings: (handlers: Record<string, () => void>) => {
+    for (const [action, handler] of Object.entries(handlers)) {
+      keybindingMock.handlers.set(action, handler);
+    }
+  },
+}));
+vi.mock("../../../src/tui/keybindings/useShortcutDisplay.js", () => ({
+  useShortcutDisplay: () => "shift+tab",
+}));
+vi.mock("../../../src/tui/state/AppState.js", () => ({
+  useAppState: (selector: (state: unknown) => unknown) =>
+    selector({
+      toolPermissionContext: {
+        isBypassPermissionsModeAvailable: true,
+      },
+    }),
+  useSetAppState: () => (updater: (prev: typeof appStateMock.state) => typeof appStateMock.state) => {
+    appStateMock.state = updater(appStateMock.state);
+  },
+}));
+vi.mock("../../../src/utils/teamDiscovery.js", () => ({
+  getTeammateStatuses: () => teammateStatusMock.statuses,
+}));
+vi.mock("../../../src/utils/swarm/backends/registry.js", () => ({
+  ensureBackendsRegistered: async () => {},
+  getBackendByType: () => backendMock.backend,
+  getCachedBackend: () => backendMock.cachedBackend,
+}));
+vi.mock("../../../src/utils/tasks.js", async importOriginal => {
+  const actual = await importOriginal<typeof import("../../../src/utils/tasks.js")>();
+  return {
+    ...actual,
+    listTasks: tasksMock.listTasks,
+    unassignTeammateTasks: tasksMock.unassignTeammateTasks,
+  };
+});
+vi.mock("../../../src/utils/teammateMailbox.js", () => ({
+  createModeSetRequestMessage: (message: unknown) => message,
+  sendShutdownRequestToMailbox: mailboxMock.sendShutdownRequestToMailbox,
+  writeToMailbox: mailboxMock.writeToMailbox,
+}));
+vi.mock("../../../src/utils/swarm/teamHelpers.js", () => ({
+  addHiddenPaneId: teamHelpersMock.addHiddenPaneId,
+  removeHiddenPaneId: teamHelpersMock.removeHiddenPaneId,
+  removeMemberFromTeam: teamHelpersMock.removeMemberFromTeam,
+  setMemberMode: teamHelpersMock.setMemberMode,
+  setMultipleMemberModes: teamHelpersMock.setMultipleMemberModes,
+}));
+vi.mock("../../../src/utils/execFileNoThrow.js", () => ({
+  execFileNoThrow: execFileNoThrowMock,
+}));
+vi.mock("../../../src/utils/swarm/backends/detection.js", () => ({
+  getLeaderPaneId: () => detectionMock.leaderPaneId,
+  IT2_COMMAND: "it2",
+  isInsideTmuxSync: () => detectionMock.insideTmux,
+}));
+
+const SYNC_START = "\x1B[?2026h";
+const SYNC_END = "\x1B[?2026l";
+
+function defaultTeammateStatuses(): MockTeammateStatus[] {
+  return [
+    {
+      agentId: "agent-fixer",
+      backendType: "tmux",
+      color: "purple",
+      cwd: "/tmp/work",
+      isHidden: false,
+      mode: "acceptEdits",
+      model: "gpt-5.4",
+      name: "Fixer",
+      prompt: "Fix the failing tests",
+      status: "running",
+      tmuxPaneId: "%1",
+    },
+    {
+      agentId: "agent-planner",
+      backendType: "tmux",
+      cwd: "/tmp/work",
+      isHidden: true,
+      mode: "plan",
+      model: "grok-4.3",
+      name: "Planner",
+      prompt: "Plan the next task",
+      status: "idle",
+      tmuxPaneId: "%2",
+    },
+  ];
+}
+
+function key(overrides: Record<string, boolean> = {}): Record<string, boolean> {
+  return {
+    downArrow: false,
+    leftArrow: false,
+    return: false,
+    upArrow: false,
+    ...overrides,
+  };
+}
+
+function extractLastFrame(output: string): string {
+  let lastFrame: string | null = null;
+  let cursor = 0;
+
+  while (cursor < output.length) {
+    const start = output.indexOf(SYNC_START, cursor);
+    if (start === -1) break;
+
+    const contentStart = start + SYNC_START.length;
+    const end = output.indexOf(SYNC_END, contentStart);
+    if (end === -1) break;
+
+    const frame = output.slice(contentStart, end);
+    if (frame.trim().length > 0) {
+      lastFrame = frame;
+    }
+    cursor = end + SYNC_END.length;
+  }
+
+  return lastFrame ?? output;
+}
+
+async function settle(ms = 30): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function createTeamsDialogHarness(): Promise<{
+  getText: () => string;
+  press: (
+    input: string,
+    keyOverrides?: Record<string, boolean>,
+    waitMs?: number,
+  ) => Promise<void>;
+  unmount: () => void;
+}> {
+  const { createRoot } = await import("../../../src/tui/ink/root.js");
+  const { TeamsDialog } = await import(
+    "../../../src/tui/components/teams/TeamsDialog.js"
+  );
+  let output = "";
+  const stdout = new PassThrough();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    setRawMode: (mode: boolean) => void;
+    ref: () => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.ref = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number }).columns = 120;
+
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  });
+
+  root.render(
+    <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={() => {}} />,
+  );
+  await settle();
+
+  return {
+    getText: () => stripAnsi(extractLastFrame(output)),
+    press: async (
+      input: string,
+      keyOverrides: Record<string, boolean> = {},
+      waitMs = 40,
+    ) => {
+      for (const handler of [...inputMock.handlers]) {
+        handler(input, key(keyOverrides));
+      }
+      await settle(waitMs);
+    },
+    unmount: () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    },
+  };
+}
+
+beforeEach(() => {
+  teammateStatusMock.statuses = defaultTeammateStatuses();
+  inputMock.handlers.clear();
+  keybindingMock.handlers.clear();
+  backendMock.backend.hidePane.mockReset();
+  backendMock.backend.hidePane.mockResolvedValue(true);
+  backendMock.backend.killPane.mockReset();
+  backendMock.backend.killPane.mockResolvedValue(undefined);
+  backendMock.backend.showPane.mockReset();
+  backendMock.backend.showPane.mockResolvedValue(true);
+  backendMock.backend.supportsHideShow = true;
+  backendMock.cachedBackend = { supportsHideShow: true };
+  tasksMock.listTasks.mockReset();
+  tasksMock.listTasks.mockResolvedValue([]);
+  tasksMock.unassignTeammateTasks.mockReset();
+  tasksMock.unassignTeammateTasks.mockResolvedValue({
+    notificationMessage: "tasks unassigned",
+  });
+  mailboxMock.sendShutdownRequestToMailbox.mockReset();
+  mailboxMock.sendShutdownRequestToMailbox.mockResolvedValue(undefined);
+  mailboxMock.writeToMailbox.mockReset();
+  mailboxMock.writeToMailbox.mockResolvedValue(undefined);
+  teamHelpersMock.addHiddenPaneId.mockReset();
+  teamHelpersMock.addHiddenPaneId.mockReturnValue(true);
+  teamHelpersMock.removeHiddenPaneId.mockReset();
+  teamHelpersMock.removeHiddenPaneId.mockReturnValue(true);
+  teamHelpersMock.removeMemberFromTeam.mockReset();
+  teamHelpersMock.removeMemberFromTeam.mockReturnValue(true);
+  teamHelpersMock.setMemberMode.mockReset();
+  teamHelpersMock.setMultipleMemberModes.mockReset();
+  execFileNoThrowMock.mockReset();
+  execFileNoThrowMock.mockResolvedValue({ code: 0, stderr: "", error: "" });
+  detectionMock.insideTmux = false;
+  detectionMock.leaderPaneId = "%leader";
+  appStateMock.state = {
+    teamContext: {
+      teammates: {
+        "agent-fixer": {},
+        "agent-planner": {},
+      },
+    },
+    inbox: {
+      messages: [],
+    },
+  };
+});
+
+describe("TeamsDialog coverage-swarm detail actions", () => {
+  test("cycles a teammate mode from detail view", async () => {
+    const harness = await createTeamsDialogHarness();
+
+    try {
+      await harness.press("\r", { return: true });
+      keybindingMock.handlers.get("confirm:cycleMode")?.();
+      await settle();
+
+      expect(teamHelpersMock.setMemberMode).toHaveBeenCalledWith(
+        "alpha",
+        "Fixer",
+        "plan",
+      );
+      expect(mailboxMock.writeToMailbox).toHaveBeenCalledWith(
+        "Fixer",
+        expect.objectContaining({
+          from: "team-lead",
+          text: JSON.stringify({ mode: "plan", from: "team-lead" }),
+        }),
+        "alpha",
+      );
+      expect(teamHelpersMock.setMultipleMemberModes).not.toHaveBeenCalled();
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("shutdown from detail view requests shutdown and returns to list", async () => {
+    const harness = await createTeamsDialogHarness();
+
+    try {
+      await harness.press("\r", { return: true });
+      await harness.press("s", {}, 80);
+
+      expect(mailboxMock.sendShutdownRequestToMailbox).toHaveBeenCalledWith(
+        "Fixer",
+        "alpha",
+        "Graceful shutdown requested by team lead",
+      );
+      expect(harness.getText()).toContain("Team alpha");
+      expect(harness.getText()).toContain("2 teammates");
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("kill from detail view updates team context and inbox", async () => {
+    const harness = await createTeamsDialogHarness();
+
+    try {
+      await harness.press("\r", { return: true });
+      await harness.press("k", {}, 80);
+
+      expect(backendMock.backend.killPane).toHaveBeenCalledWith("%1", true);
+      expect(teamHelpersMock.removeMemberFromTeam).toHaveBeenCalledWith(
+        "alpha",
+        "%1",
+      );
+      expect(appStateMock.state.teamContext.teammates).not.toHaveProperty(
+        "agent-fixer",
+      );
+      expect(JSON.parse(appStateMock.state.inbox.messages[0]?.text ?? "{}")).toEqual({
+        type: "teammate_terminated",
+        message: "tasks unassigned",
+      });
+      expect(harness.getText()).toContain("Team alpha");
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("kill from detail view surfaces task cleanup failures", async () => {
+    tasksMock.unassignTeammateTasks.mockRejectedValueOnce(
+      new Error("task store offline"),
+    );
+    const harness = await createTeamsDialogHarness();
+
+    try {
+      await harness.press("\r", { return: true });
+      await harness.press("k", {}, 80);
+
+      expect(harness.getText()).toContain(
+        "Killed @Fixer, but task cleanup failed: task store offline",
+      );
+    } finally {
+      harness.unmount();
+    }
+  });
+});
+
+describe("TeamsDialog coverage-swarm pane and backend branches", () => {
+  test("uses iterm2 focus when viewing an iterm teammate output", async () => {
+    teammateStatusMock.statuses = [
+      {
+        ...defaultTeammateStatuses()[0],
+        backendType: "iterm2",
+        tmuxPaneId: "session-1",
+      },
+    ];
+    const harness = await createTeamsDialogHarness();
+
+    try {
+      await harness.press("\r", { return: true });
+      await harness.press("\r", { return: true }, 80);
+
+      expect(execFileNoThrowMock).toHaveBeenCalledWith("it2", [
+        "session",
+        "focus",
+        "-s",
+        "session-1",
+      ]);
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("uses the current tmux server when already inside tmux", async () => {
+    detectionMock.insideTmux = true;
+    const harness = await createTeamsDialogHarness();
+
+    try {
+      await harness.press("\r", { return: true });
+      await harness.press("\r", { return: true }, 80);
+
+      expect(execFileNoThrowMock).toHaveBeenCalledWith("tmux", [
+        "select-pane",
+        "-t",
+        "%1",
+      ]);
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("falls back to exit code when view-output returns no error text", async () => {
+    execFileNoThrowMock.mockResolvedValueOnce({
+      code: 7,
+      error: "",
+      stderr: "",
+    });
+    const harness = await createTeamsDialogHarness();
+
+    try {
+      await harness.press("\r", { return: true });
+      await harness.press("\r", { return: true }, 80);
+
+      expect(harness.getText()).toContain(
+        "Cannot view teammate output: exit code 7",
+      );
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("surfaces individual hide metadata and backend failures", async () => {
+    teammateStatusMock.statuses = [
+      {
+        ...defaultTeammateStatuses()[0],
+        tmuxPaneId: "",
+      },
+    ];
+    const missingMetadataHarness = await createTeamsDialogHarness();
+    try {
+      await missingMetadataHarness.press("h", {}, 80);
+      expect(missingMetadataHarness.getText()).toContain(
+        "Cannot hide @Fixer: missing pane metadata.",
+      );
+    } finally {
+      missingMetadataHarness.unmount();
+    }
+
+    backendMock.backend.supportsHideShow = false;
+    teammateStatusMock.statuses = defaultTeammateStatuses();
+    const unsupportedHarness = await createTeamsDialogHarness();
+    try {
+      await unsupportedHarness.press("h", {}, 80);
+      expect(unsupportedHarness.getText()).toContain(
+        "Cannot hide @Fixer: backend does not support pane visibility.",
+      );
+    } finally {
+      unsupportedHarness.unmount();
+    }
+
+    backendMock.backend.supportsHideShow = true;
+    teammateStatusMock.statuses = defaultTeammateStatuses();
+    backendMock.backend.hidePane.mockResolvedValueOnce(false);
+    const refusedHarness = await createTeamsDialogHarness();
+    try {
+      await refusedHarness.press("h", {}, 80);
+      expect(refusedHarness.getText()).toContain(
+        "Cannot hide @Fixer: backend refused the hide request.",
+      );
+    } finally {
+      refusedHarness.unmount();
+    }
+  });
+
+  test("surfaces hidden-state write failures for hide and show", async () => {
+    teamHelpersMock.addHiddenPaneId.mockReturnValueOnce(false);
+    const hideHarness = await createTeamsDialogHarness();
+    try {
+      await hideHarness.press("h", {}, 80);
+      expect(hideHarness.getText()).toContain(
+        "Hidden @Fixer, but could not record hidden state for team alpha.",
+      );
+    } finally {
+      hideHarness.unmount();
+    }
+
+    teammateStatusMock.statuses = [
+      {
+        ...defaultTeammateStatuses()[0],
+        isHidden: true,
+      },
+    ];
+    teamHelpersMock.removeHiddenPaneId.mockReturnValueOnce(false);
+    const showHarness = await createTeamsDialogHarness();
+    try {
+      await showHarness.press("h", {}, 80);
+      expect(showHarness.getText()).toContain(
+        "Shown @Fixer, but could not update hidden state for team alpha.",
+      );
+    } finally {
+      showHarness.unmount();
+    }
+  });
+
+  test("surfaces show target and backend refusal failures", async () => {
+    teammateStatusMock.statuses = [
+      {
+        ...defaultTeammateStatuses()[0],
+        isHidden: true,
+      },
+    ];
+    detectionMock.insideTmux = true;
+    detectionMock.leaderPaneId = "%1";
+    const noTargetHarness = await createTeamsDialogHarness();
+    try {
+      await noTargetHarness.press("h", {}, 80);
+      expect(noTargetHarness.getText()).toContain(
+        "Cannot show @Fixer: no valid target pane is available.",
+      );
+    } finally {
+      noTargetHarness.unmount();
+    }
+
+    detectionMock.insideTmux = false;
+    backendMock.backend.showPane.mockResolvedValueOnce(false);
+    const refusedHarness = await createTeamsDialogHarness();
+    try {
+      await refusedHarness.press("h", {}, 80);
+      expect(refusedHarness.getText()).toContain(
+        "Cannot show @Fixer: backend refused the show request.",
+      );
+    } finally {
+      refusedHarness.unmount();
+    }
+  });
+
+  test("surfaces bulk visibility and prune failures", async () => {
+    backendMock.backend.hidePane.mockResolvedValueOnce(false);
+    const bulkHarness = await createTeamsDialogHarness();
+    try {
+      await bulkHarness.press("H", {}, 80);
+      expect(bulkHarness.getText()).toContain(
+        "Cannot hide @Fixer: backend refused the hide request.",
+      );
+    } finally {
+      bulkHarness.unmount();
+    }
+
+    teammateStatusMock.statuses = [
+      {
+        ...defaultTeammateStatuses()[1],
+        backendType: undefined,
+      },
+    ];
+    const pruneHarness = await createTeamsDialogHarness();
+    try {
+      await pruneHarness.press("p", {}, 80);
+      expect(pruneHarness.getText()).toContain(
+        "Cannot kill @Planner: missing pane backend metadata.",
+      );
+    } finally {
+      pruneHarness.unmount();
+    }
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-017-tool-rendering.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-017-tool-rendering.test.tsx
@@ -1,0 +1,340 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("../ink.js", () => {
+  function Box(_props: { readonly children?: unknown }) {
+    return null;
+  }
+  function Text(_props: { readonly children?: unknown }) {
+    return null;
+  }
+  return { Box, Text };
+});
+
+import {
+  BashOutputView,
+  createTuiTool,
+  EditDiffView,
+  FileReadView,
+  GlobPathsView,
+  GrepMatchesView,
+  ToolErrorView,
+} from "../tool-rendering.js";
+
+interface ChildProps {
+  readonly bold?: boolean;
+  readonly children?: unknown;
+  readonly color?: string;
+  readonly dimColor?: boolean;
+}
+
+interface ChildElement {
+  readonly props: ChildProps;
+}
+
+function flatten(node: unknown): ChildElement[] {
+  if (!node || typeof node !== "object") return [];
+  const children = (node as { props?: { children?: unknown } }).props?.children;
+  const arr = Array.isArray(children) ? children : [children];
+  return arr
+    .flat(Infinity)
+    .filter(
+      (child): child is ChildElement =>
+        typeof child === "object" && child !== null,
+    );
+}
+
+function textOf(child: ChildElement): string {
+  return String(child.props.children ?? "");
+}
+
+describe("coverage swarm row 017 tool-rendering branches", () => {
+  test("EditDiffView renders no-change headers and truncates long diff output", () => {
+    const emptyChildren = flatten(
+      EditDiffView({
+        content: "<edit-file>src/a.ts</edit-file><edit-diff></edit-diff>",
+      }),
+    );
+
+    expect(
+      emptyChildren.find(
+        (child) => child.props.bold === true && child.props.children === "src/a.ts",
+      ),
+    ).toBeDefined();
+    expect(
+      emptyChildren.find(
+        (child) =>
+          child.props.dimColor === true &&
+          child.props.children === "(No changes)",
+      ),
+    ).toBeDefined();
+
+    const longDiff = [
+      "--- a/src/a.ts",
+      "+++ b/src/a.ts",
+      " unchanged context",
+      "x".repeat(9000),
+    ].join("\n");
+    const diffChildren = flatten(
+      EditDiffView({
+        content: `<edit-file>src/a.ts</edit-file><edit-diff>${longDiff}</edit-diff>`,
+      }),
+    );
+
+    expect(
+      diffChildren.find(
+        (child) => child.props.dimColor === true && textOf(child).startsWith("---"),
+      ),
+    ).toBeDefined();
+    expect(
+      diffChildren.find(
+        (child) => child.props.dimColor === true && textOf(child).startsWith("+++"),
+      ),
+    ).toBeDefined();
+    expect(diffChildren.some((child) => textOf(child).includes("chars truncated")))
+      .toBe(true);
+  });
+
+  test("FileReadView renders ranged content and omits an empty header", () => {
+    const rangedChildren = flatten(
+      FileReadView({
+        content:
+          "<read-file>src/a.ts</read-file><read-lines>10-12</read-lines><read-content>body</read-content>",
+      }),
+    );
+
+    expect(
+      rangedChildren.find(
+        (child) =>
+          child.props.bold === true &&
+          child.props.children === "src/a.ts [10-12]",
+      ),
+    ).toBeDefined();
+    expect(rangedChildren.find((child) => child.props.children === "body"))
+      .toBeDefined();
+
+    const bodyOnlyChildren = flatten(
+      FileReadView({ content: "<read-content>body only</read-content>" }),
+    );
+    expect(bodyOnlyChildren.find((child) => child.props.bold === true))
+      .toBeUndefined();
+    expect(bodyOnlyChildren.find((child) => child.props.children === "body only"))
+      .toBeDefined();
+  });
+
+  test("GrepMatchesView renders singular, plural, and truncated match lists", () => {
+    const singleChildren = flatten(
+      GrepMatchesView({
+        content:
+          "<grep-pattern>needle</grep-pattern><grep-matches>src/a.ts:1:needle</grep-matches>",
+      }),
+    );
+
+    expect(
+      singleChildren.find(
+        (child) =>
+          child.props.bold === true &&
+          child.props.children === "Grep: needle (1 match)",
+      ),
+    ).toBeDefined();
+    expect(
+      singleChildren.find((child) => child.props.children === "src/a.ts:1:needle"),
+    ).toBeDefined();
+
+    const matches = Array.from(
+      { length: 202 },
+      (_, index) => `src/${index}.ts:${index}:hit`,
+    ).join("\n");
+    const manyChildren = flatten(
+      GrepMatchesView({
+        content: `<grep-pattern>hit</grep-pattern><grep-matches>${matches}</grep-matches>`,
+      }),
+    );
+
+    expect(
+      manyChildren.find(
+        (child) =>
+          child.props.bold === true &&
+          child.props.children === "Grep: hit (202 matches)",
+      ),
+    ).toBeDefined();
+    expect(
+      manyChildren.find(
+        (child) =>
+          child.props.dimColor === true &&
+          textOf(child).includes("2 more matches truncated"),
+      ),
+    ).toBeDefined();
+  });
+
+  test("GlobPathsView renders singular headers, headerless lists, and truncation", () => {
+    const singleChildren = flatten(
+      GlobPathsView({
+        content: "<glob-pattern>*.ts</glob-pattern><glob-paths>src/a.ts</glob-paths>",
+      }),
+    );
+
+    expect(
+      singleChildren.find(
+        (child) =>
+          child.props.bold === true &&
+          child.props.children === "Glob: *.ts (1 path)",
+      ),
+    ).toBeDefined();
+    expect(singleChildren.find((child) => child.props.children === "src/a.ts"))
+      .toBeDefined();
+    expect(singleChildren.some((child) => textOf(child).includes("truncated")))
+      .toBe(false);
+
+    const paths = Array.from(
+      { length: 201 },
+      (_, index) => `src/${index}.ts`,
+    ).join("\n");
+    const manyChildren = flatten(
+      GlobPathsView({
+        content: `<glob-paths>${paths}</glob-paths><glob-truncated>true</glob-truncated>`,
+      }),
+    );
+
+    expect(manyChildren.find((child) => child.props.bold === true))
+      .toBeUndefined();
+    expect(
+      manyChildren.find(
+        (child) =>
+          child.props.dimColor === true &&
+          textOf(child).includes("1 more paths truncated"),
+      ),
+    ).toBeDefined();
+    expect(
+      manyChildren.find(
+        (child) =>
+          child.props.dimColor === true &&
+          textOf(child).startsWith("(Results are truncated."),
+      ),
+    ).toBeDefined();
+  });
+
+  test("BashOutputView colors stderr and failed metadata while omitting silent state", () => {
+    const failedChildren = flatten(
+      BashOutputView({
+        content:
+          "<bash-stdout>ok</bash-stdout><bash-stderr>err</bash-stderr>[exit_code=2 duration_ms=3]",
+      }),
+    );
+
+    expect(failedChildren.find((child) => child.props.children === "ok"))
+      .toBeDefined();
+    expect(
+      failedChildren.find(
+        (child) => child.props.color === "red" && child.props.children === "err",
+      ),
+    ).toBeDefined();
+    expect(
+      failedChildren.find(
+        (child) =>
+          child.props.color === "red" &&
+          child.props.dimColor === false &&
+          child.props.children === "[exit_code=2 duration_ms=3]",
+      ),
+    ).toBeDefined();
+    expect(failedChildren.some((child) => child.props.children === "(No output)"))
+      .toBe(false);
+
+    const plainChildren = flatten(
+      BashOutputView({ content: "<bash-stdout>ok</bash-stdout>" }),
+    );
+    expect(plainChildren.find((child) => child.props.children === "ok"))
+      .toBeDefined();
+    expect(plainChildren.some((child) => textOf(child).startsWith("[exit_code=")))
+      .toBe(false);
+  });
+
+  test("ToolErrorView uses named error envelopes", () => {
+    const children = flatten(
+      ToolErrorView({
+        content:
+          "<tool-error-name>CustomTool</tool-error-name><tool-error>bad input</tool-error>",
+      }),
+    );
+
+    expect(
+      children.find(
+        (child) =>
+          child.props.bold === true &&
+          child.props.color === "red" &&
+          child.props.children === "CustomTool error",
+      ),
+    ).toBeDefined();
+    expect(children.find((child) => child.props.children === "bad input"))
+      .toBeDefined();
+  });
+
+  test("createTuiTool covers read, command, search, MCP, Skill, and Bash summaries", () => {
+    const read = createTuiTool("FileRead");
+    expect(read.getPath({ path: "src/from-path.ts" })).toBe("src/from-path.ts");
+    expect(read.getActivityDescription({ file_path: "src/read.ts" })).toBe(
+      "Reading src/read.ts",
+    );
+    expect(read.getActivityDescription({})).toBe("Reading file");
+    expect(read.isReadOnly()).toBe(true);
+    expect(read.renderToolUseMessage({ file_path: "src/read.ts" })).toBe(
+      "src/read.ts",
+    );
+    expect(read.renderToolUseMessage({})).toBe("file");
+    expect(read.userFacingName()).toBe("Read");
+
+    const command = createTuiTool("exec_command");
+    expect(command.userFacingName({})).toBe("Run");
+    expect(command.renderToolUseMessage({ cmd: "  npm   test  " })).toBe(
+      "npm test",
+    );
+    expect(command.renderToolUseMessage({})).toBe("command");
+    expect(command.getActivityDescription({ command: "pnpm build" })).toBe(
+      "Run: pnpm build",
+    );
+
+    const search = createTuiTool("system.searchTools");
+    expect(search.userFacingName({})).toBe("Tool search");
+    expect(search.renderToolUseMessage({ select: "Read" })).toBe(
+      "Select tool: Read",
+    );
+    expect(search.renderToolUseMessage({ query: "file tools" })).toBe(
+      "Search tools: file tools",
+    );
+    expect(search.getActivityDescription({ query: "grep" })).toBe(
+      "Search tools: grep",
+    );
+
+    const mcp = createTuiTool("mcp.server.tool");
+    expect(mcp.renderToolUseMessage({})).toBe("");
+    expect(mcp.getActivityDescription({})).toBe("mcp.server.tool");
+
+    const skill = createTuiTool("Skill");
+    expect(skill.userFacingName({ name: "deploy", args: "target\nprod" })).toBe(
+      "$deploy",
+    );
+    expect(skill.renderToolUseMessage({ name: "deploy", args: "target\nprod" }))
+      .toBe("target prod");
+    expect(skill.renderToolUseMessage({ skill: "" })).toBe("");
+    expect(skill.getActivityDescription({ skill: "" })).toBe("Load $skill");
+
+    const bash = createTuiTool("Bash");
+    expect(bash.renderToolUseMessage({ command: "echo\nhello" })).toBe(
+      "echo hello",
+    );
+  });
+
+  test("renderToolUseErrorMessage supports string and non-message errors", () => {
+    const tool = createTuiTool("DynamicTool");
+    const stringError = tool.renderToolUseErrorMessage("plain failure");
+    expect(
+      (stringError as { readonly props: { readonly content: string } }).props
+        .content,
+    ).toContain("<tool-error>plain failure</tool-error>");
+
+    const objectError = tool.renderToolUseErrorMessage({ code: 500 });
+    expect(
+      (objectError as { readonly props: { readonly content: string } }).props
+        .content,
+    ).toContain("<tool-error>{\"code\":500}</tool-error>");
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-018-message-renderers-UserTextMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-018-message-renderers-UserTextMessage.test.tsx
@@ -1,0 +1,348 @@
+import React from 'react'
+import Module from 'node:module'
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest'
+
+const state = vi.hoisted(() => {
+  const sentinel = Symbol.for('react.memo_cache_sentinel')
+  const cache: unknown[] = []
+  const features = new Set<string>()
+  const stub = (name: string) =>
+    Object.assign(function StubComponent() {
+      return null
+    }, { displayName: name })
+
+  return {
+    sentinel,
+    cache,
+    features,
+    renderers: {
+      InterruptedByUser: stub('InterruptedByUser'),
+      MessageResponse: stub('MessageResponse'),
+      UserAgentNotificationMessage: stub('UserAgentNotificationMessage'),
+      UserBashInputMessage: stub('UserBashInputMessage'),
+      UserBashOutputMessage: stub('UserBashOutputMessage'),
+      UserChannelMessage: stub('UserChannelMessage'),
+      UserCommandMessage: stub('UserCommandMessage'),
+      UserLocalCommandOutputMessage: stub('UserLocalCommandOutputMessage'),
+      UserMemoryInputMessage: stub('UserMemoryInputMessage'),
+      UserPlanMessage: stub('UserPlanMessage'),
+      UserPromptMessage: stub('UserPromptMessage'),
+      UserResourceUpdateMessage: stub('UserResourceUpdateMessage'),
+      UserTeammateMessage: stub('UserTeammateMessage'),
+    },
+    dynamicRenderers: {
+      UserCrossSessionMessage: stub('UserCrossSessionMessage'),
+      UserForkBoilerplateMessage: stub('UserForkBoilerplateMessage'),
+      UserGitHubWebhookMessage: stub('UserGitHubWebhookMessage'),
+    },
+  }
+})
+
+vi.mock('react-compiler-runtime', () => ({
+  c: (size: number) => {
+    if (state.cache.length !== size) {
+      state.cache.length = 0
+      for (let index = 0; index < size; index += 1) {
+        state.cache.push(state.sentinel)
+      }
+    }
+    return state.cache
+  },
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => state.features.has(name),
+}))
+
+vi.mock('../message-renderers/UserTextMessage.renderers.js', () => ({
+  ...state.renderers,
+}))
+
+import { NO_CONTENT_MESSAGE } from '../../constants/messages.js'
+import {
+  COMMAND_MESSAGE_TAG,
+  LOCAL_COMMAND_CAVEAT_TAG,
+  TASK_NOTIFICATION_TAG,
+  TEAMMATE_MESSAGE_TAG,
+  TICK_TAG,
+} from '../../constants/xml.js'
+import { INTERRUPT_MESSAGE } from '../../utils/messages.js'
+import { UserTextMessage } from '../message-renderers/UserTextMessage.js'
+
+type UserTextMessageProps = Parameters<typeof UserTextMessage>[0]
+type ReactElementWithProps = React.ReactElement<Record<string, unknown>>
+type ModuleWithLoad = typeof Module & {
+  _load: (
+    request: string,
+    parent: unknown,
+    isMain: boolean,
+  ) => unknown
+}
+
+const moduleWithLoad = Module as ModuleWithLoad
+const originalModuleLoad = moduleWithLoad._load
+const originalUserType = process.env.USER_TYPE
+
+function resetUserType(): void {
+  if (originalUserType === undefined) {
+    delete process.env.USER_TYPE
+  } else {
+    process.env.USER_TYPE = originalUserType
+  }
+}
+
+function makeProps(
+  text: string,
+  overrides: Partial<Omit<UserTextMessageProps, 'param'>> = {},
+): UserTextMessageProps {
+  return {
+    addMargin: false,
+    param: { type: 'text', text },
+    verbose: false,
+    ...overrides,
+  }
+}
+
+function asElement(node: React.ReactNode): ReactElementWithProps {
+  expect(React.isValidElement(node)).toBe(true)
+  return node as ReactElementWithProps
+}
+
+function expectCachedElement(
+  props: UserTextMessageProps,
+  expectedType: React.ElementType,
+): ReactElementWithProps {
+  const first = asElement(UserTextMessage(props))
+  const second = asElement(UserTextMessage(props))
+
+  expect(second).toBe(first)
+  expect(first.type).toBe(expectedType)
+
+  return first
+}
+
+beforeEach(() => {
+  state.cache.length = 0
+  state.features.clear()
+  resetUserType()
+
+  moduleWithLoad._load = function loadDynamicRenderer(
+    request: string,
+    parent: unknown,
+    isMain: boolean,
+  ) {
+    switch (request) {
+      case './UserCrossSessionMessage.js':
+        return {
+          UserCrossSessionMessage:
+            state.dynamicRenderers.UserCrossSessionMessage,
+        }
+      case './UserForkBoilerplateMessage.js':
+        return {
+          UserForkBoilerplateMessage:
+            state.dynamicRenderers.UserForkBoilerplateMessage,
+        }
+      case './UserGitHubWebhookMessage.js':
+        return {
+          UserGitHubWebhookMessage:
+            state.dynamicRenderers.UserGitHubWebhookMessage,
+        }
+      default:
+        return originalModuleLoad.call(this, request, parent, isMain)
+    }
+  }
+})
+
+afterAll(() => {
+  moduleWithLoad._load = originalModuleLoad
+  resetUserType()
+})
+
+describe('UserTextMessage swarm 018 coverage', () => {
+  test('returns null for hidden synthetic messages', () => {
+    expect(UserTextMessage(makeProps(`  ${NO_CONTENT_MESSAGE}  `))).toBeNull()
+    expect(
+      UserTextMessage(makeProps(`<${TICK_TAG}>heartbeat</${TICK_TAG}>`)),
+    ).toBeNull()
+    expect(
+      UserTextMessage(
+        makeProps(
+          `<${LOCAL_COMMAND_CAVEAT_TAG}>hidden</${LOCAL_COMMAND_CAVEAT_TAG}>`,
+        ),
+      ),
+    ).toBeNull()
+  })
+
+  test('reuses cached elements for standard user-message routes', () => {
+    const plan = expectCachedElement(
+      makeProps('ignored once plan content exists', {
+        addMargin: true,
+        planContent: '1. inspect route\n2. assert cache',
+      }),
+      state.renderers.UserPlanMessage,
+    )
+    expect(plan.props.addMargin).toBe(true)
+    expect(plan.props.planContent).toContain('assert cache')
+
+    const bashOutput = expectCachedElement(
+      makeProps('<bash-stderr>stderr branch</bash-stderr>', { verbose: true }),
+      state.renderers.UserBashOutputMessage,
+    )
+    expect(bashOutput.props.content).toContain('stderr branch')
+    expect(bashOutput.props.verbose).toBe(true)
+
+    const localOutput = expectCachedElement(
+      makeProps(
+        '<local-command-stderr>local stderr</local-command-stderr>',
+      ),
+      state.renderers.UserLocalCommandOutputMessage,
+    )
+    expect(localOutput.props.content).toContain('local stderr')
+
+    const interrupted = expectCachedElement(
+      makeProps(INTERRUPT_MESSAGE),
+      state.renderers.MessageResponse,
+    )
+    const interruptedChild = asElement(interrupted.props.children)
+    expect(interrupted.props.height).toBe(1)
+    expect(interruptedChild.type).toBe(state.renderers.InterruptedByUser)
+
+    const bashInput = expectCachedElement(
+      makeProps('<bash-input>npm test</bash-input>'),
+      state.renderers.UserBashInputMessage,
+    )
+    expect(bashInput.props.param).toMatchObject({
+      text: '<bash-input>npm test</bash-input>',
+    })
+
+    const command = expectCachedElement(
+      makeProps(`<${COMMAND_MESSAGE_TAG}>/status</${COMMAND_MESSAGE_TAG}>`),
+      state.renderers.UserCommandMessage,
+    )
+    expect(command.props.param).toMatchObject({
+      text: `<${COMMAND_MESSAGE_TAG}>/status</${COMMAND_MESSAGE_TAG}>`,
+    })
+
+    const memory = expectCachedElement(
+      makeProps('<user-memory-input>remember this</user-memory-input>'),
+      state.renderers.UserMemoryInputMessage,
+    )
+    expect(memory.props.text).toContain('remember this')
+
+    process.env.USER_TYPE = 'ant'
+    const teammate = expectCachedElement(
+      makeProps(
+        `<${TEAMMATE_MESSAGE_TAG} teammate_id="qa">hello</${TEAMMATE_MESSAGE_TAG}>`,
+        { isTranscriptMode: true },
+      ),
+      state.renderers.UserTeammateMessage,
+    )
+    expect(teammate.props.isTranscriptMode).toBe(true)
+
+    const task = expectCachedElement(
+      makeProps(`<${TASK_NOTIFICATION_TAG}>done</${TASK_NOTIFICATION_TAG}>`),
+      state.renderers.UserAgentNotificationMessage,
+    )
+    expect(task.props.param).toMatchObject({
+      text: `<${TASK_NOTIFICATION_TAG}>done</${TASK_NOTIFICATION_TAG}>`,
+    })
+
+    const resource = expectCachedElement(
+      makeProps('<mcp-resource-update>changed</mcp-resource-update>'),
+      state.renderers.UserResourceUpdateMessage,
+    )
+    expect(resource.props.param).toMatchObject({
+      text: '<mcp-resource-update>changed</mcp-resource-update>',
+    })
+
+    const prompt = expectCachedElement(
+      makeProps('ordinary prompt', {
+        addMargin: true,
+        isTranscriptMode: true,
+        timestamp: '12:34',
+      }),
+      state.renderers.UserPromptMessage,
+    )
+    expect(prompt.props).toMatchObject({
+      addMargin: true,
+      isTranscriptMode: true,
+      timestamp: '12:34',
+    })
+  })
+
+  test('routes enabled dynamic feature messages and reuses their cached modules', () => {
+    state.features.add('KAIROS_GITHUB_WEBHOOKS')
+    const webhook = expectCachedElement(
+      makeProps(
+        '<github-webhook-activity><event>push</event></github-webhook-activity>',
+        { addMargin: true },
+      ),
+      state.dynamicRenderers.UserGitHubWebhookMessage,
+    )
+    expect(webhook.props.addMargin).toBe(true)
+
+    state.cache.length = 0
+    state.features.clear()
+    state.features.add('FORK_SUBAGENT')
+    const fork = expectCachedElement(
+      makeProps('<fork-boilerplate>Your directive: test</fork-boilerplate>'),
+      state.dynamicRenderers.UserForkBoilerplateMessage,
+    )
+    expect(fork.props.param).toMatchObject({
+      text: '<fork-boilerplate>Your directive: test</fork-boilerplate>',
+    })
+
+    state.cache.length = 0
+    state.features.clear()
+    state.features.add('UDS_INBOX')
+    const crossSession = expectCachedElement(
+      makeProps('<cross-session-message from="peer">hello</cross-session-message>'),
+      state.dynamicRenderers.UserCrossSessionMessage,
+    )
+    expect(crossSession.props.param).toMatchObject({
+      text: '<cross-session-message from="peer">hello</cross-session-message>',
+    })
+  })
+
+  test('falls through enabled feature gates without matching tags and routes channel flags', () => {
+    state.features.add('KAIROS_GITHUB_WEBHOOKS')
+    state.features.add('FORK_SUBAGENT')
+    state.features.add('UDS_INBOX')
+    state.features.add('KAIROS')
+
+    const prompt = expectCachedElement(
+      makeProps('feature flags enabled without special tags'),
+      state.renderers.UserPromptMessage,
+    )
+    expect(prompt.props.param).toMatchObject({
+      text: 'feature flags enabled without special tags',
+    })
+
+    state.cache.length = 0
+    const kairosChannel = expectCachedElement(
+      makeProps('<channel source="inbox">body</channel>'),
+      state.renderers.UserChannelMessage,
+    )
+    expect(kairosChannel.props.param).toMatchObject({
+      text: '<channel source="inbox">body</channel>',
+    })
+
+    state.cache.length = 0
+    state.features.clear()
+    state.features.add('KAIROS_CHANNELS')
+    const channelsFlag = expectCachedElement(
+      makeProps('<channel source="updates">body</channel>'),
+      state.renderers.UserChannelMessage,
+    )
+    expect(channelsFlag.props.param).toMatchObject({
+      text: '<channel source="updates">body</channel>',
+    })
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-019-components-FullscreenLayout.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-019-components-FullscreenLayout.test.tsx
@@ -1,0 +1,404 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { describe, expect, test, vi } from 'vitest'
+
+const browser = vi.hoisted(() => ({
+  openBrowser: vi.fn(),
+  openPath: vi.fn(),
+}))
+
+vi.mock('../../../src/utils/browser.js', () => browser)
+
+import { createRoot, Text } from '../../../src/tui/ink.js'
+import {
+  AppStateProvider,
+  getDefaultAppState,
+} from '../../../src/tui/state/AppState.js'
+import {
+  DesignTopChrome,
+  FullscreenLayout,
+  useUnseenDivider,
+} from '../../../src/tui/components/FullscreenLayout.js'
+import {
+  useSetPromptOverlay,
+  useSetPromptOverlayDialog,
+} from '../../../src/tui/context/promptOverlayContext.js'
+import {
+  deleteInkInstance,
+  setInkInstance,
+} from '../../../src/tui/ink/instances.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+import type { ScrollBoxHandle } from '../../../src/tui/ink/components/ScrollBox.js'
+
+const SYNC_START = '\x1B[?2026h'
+const SYNC_END = '\x1B[?2026l'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestStdout = PassThrough & {
+  columns: number
+  rows: number
+  isTTY: boolean
+}
+
+type Viewport = {
+  readonly columns: number
+  readonly rows: number
+}
+
+type TestScrollHandle = ScrollBoxHandle & {
+  setPendingDelta: (value: number) => void
+  setScrollHeight: (value: number) => void
+  setScrollTop: (value: number) => void
+  setViewportHeight: (value: number) => void
+}
+
+function restoreEnv(name: string, previous: string | undefined): void {
+  if (previous === undefined) {
+    delete process.env[name]
+  } else {
+    process.env[name] = previous
+  }
+}
+
+async function withFullscreenEnv<T>(fn: () => Promise<T>): Promise<T> {
+  const previous = process.env.AGENC_NO_FLICKER
+  process.env.AGENC_NO_FLICKER = '1'
+  try {
+    return await fn()
+  } finally {
+    restoreEnv('AGENC_NO_FLICKER', previous)
+  }
+}
+
+function extractLastFrame(output: string): string {
+  let lastFrame: string | null = null
+  let cursor = 0
+
+  while (cursor < output.length) {
+    const start = output.indexOf(SYNC_START, cursor)
+    if (start === -1) break
+
+    const contentStart = start + SYNC_START.length
+    const end = output.indexOf(SYNC_END, contentStart)
+    if (end === -1) break
+
+    const frame = output.slice(contentStart, end)
+    if (frame.trim().length > 0) {
+      lastFrame = frame
+    }
+    cursor = end + SYNC_END.length
+  }
+
+  return lastFrame ?? output
+}
+
+function createStreams(viewport: Viewport): {
+  readonly stdin: TestStdin
+  readonly stdout: TestStdout
+  readonly getOutput: () => string
+} {
+  let output = ''
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough() as TestStdout
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = viewport.columns
+  stdout.rows = viewport.rows
+  stdout.isTTY = true
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  return {
+    stdin,
+    stdout,
+    getOutput: () => output,
+  }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderLatestFrame(
+  node: React.ReactNode,
+  viewport: Viewport = { columns: 100, rows: 14 },
+): Promise<string> {
+  return withFullscreenEnv(async () => {
+    const { stdin, stdout, getOutput } = createStreams(viewport)
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      root.render(node)
+      await sleep()
+      return stripAnsi(extractLastFrame(getOutput()))
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+}
+
+function createScrollHandle(): TestScrollHandle {
+  let pendingDelta = -1
+  let scrollHeight = 30
+  let scrollTop = 20
+  let viewportHeight = 10
+
+  return {
+    getPendingDelta: vi.fn(() => pendingDelta),
+    getScrollHeight: vi.fn(() => scrollHeight),
+    getScrollTop: vi.fn(() => scrollTop),
+    getViewportHeight: vi.fn(() => viewportHeight),
+    scrollToBottom: vi.fn(),
+    setPendingDelta: (value: number) => {
+      pendingDelta = value
+    },
+    setScrollHeight: (value: number) => {
+      scrollHeight = value
+    },
+    setScrollTop: (value: number) => {
+      scrollTop = value
+    },
+    setViewportHeight: (value: number) => {
+      viewportHeight = value
+    },
+  } as unknown as TestScrollHandle
+}
+
+function task(id: string, status: string): never {
+  return {
+    id,
+    type: 'local_bash',
+    status,
+    description: id,
+    command: id,
+    startTime: 0,
+    outputFile: `urn:agenc:task:${id}:output`,
+    outputOffset: 0,
+    notified: false,
+  } as never
+}
+
+function SuggestionsWriter(): React.ReactNode {
+  useSetPromptOverlay({
+    suggestions: [
+      {
+        id: 'command-help',
+        displayText: '/help',
+        description: 'show commands',
+      },
+      {
+        id: 'command-status',
+        displayText: '/status',
+        description: 'show status',
+      },
+    ],
+    selectedSuggestion: 1,
+    maxColumnWidth: 16,
+    suggestionType: 'command',
+  })
+
+  return <Text>prompt suggestions writer</Text>
+}
+
+function DialogWriter(): React.ReactNode {
+  useSetPromptOverlayDialog(<Text>floating dialog marker</Text>)
+  return <Text>prompt dialog writer</Text>
+}
+
+describe('FullscreenLayout coverage swarm 019', () => {
+  test('repins the unseen divider after a pending-delta scroll-away snapshot', async () => {
+    let messageCount = 4
+    let latest: ReturnType<typeof useUnseenDivider> | undefined
+    const { stdin, stdout } = createStreams({ columns: 80, rows: 12 })
+    stdout.resume()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    function Harness(): null {
+      latest = useUnseenDivider(messageCount)
+      return null
+    }
+
+    async function render(
+      nextCount = messageCount,
+    ): Promise<ReturnType<typeof useUnseenDivider>> {
+      messageCount = nextCount
+      root.render(<Harness />)
+      await sleep()
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    }
+
+    try {
+      const handle = createScrollHandle()
+      let state = await render()
+
+      state.onScrollAway(handle)
+      await sleep()
+      state = await render()
+      expect(state.dividerIndex).toBe(4)
+      expect(state.dividerYRef.current).toBe(30)
+
+      state.onRepin()
+      expect(state.dividerYRef.current).toBe(30)
+
+      await sleep()
+      state = await render()
+      expect(state.dividerIndex).toBeNull()
+      expect(state.dividerYRef.current).toBeNull()
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+
+  test('selects active tasks for top chrome and truncates long task ids', async () => {
+    const state = getDefaultAppState()
+    const output = await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...state,
+          tasks: {
+            done: task('done-task', 'completed'),
+            active: task('run-task-1234567890abcdefghij', 'running'),
+          },
+        }}
+      >
+        <DesignTopChrome columns={120} noColor={true} />
+      </AppStateProvider>,
+      120,
+    )
+
+    expect(output).toContain('run-task')
+    expect(output).not.toContain('run-task-1234567890abcdefghij')
+    expect(output).not.toContain('done-task')
+  })
+
+  test('renders expanded bottom chrome task counts for active tasks', async () => {
+    const state = getDefaultAppState()
+    const output = await withFullscreenEnv(() =>
+      renderToString(
+        <AppStateProvider
+          initialState={{
+            ...state,
+            tasks: {
+              running: task('running-task', 'running'),
+              queued: task('queued-task', 'queued'),
+              completed: task('completed-task', 'completed'),
+            },
+            toolPermissionContext: {
+              ...state.toolPermissionContext,
+              mode: 'auto',
+            },
+          }}
+        >
+          <FullscreenLayout
+            scrollable={<Text>scroll body</Text>}
+            bottom={<Text>prompt body</Text>}
+          />
+        </AppStateProvider>,
+        { columns: 100, rows: 12 },
+      ),
+    )
+
+    expect(output).toContain('TASKS')
+    expect(output).toContain('2')
+    expect(output).toContain('MODE')
+  })
+
+  test('portals prompt suggestions above the clipped bottom slot', async () => {
+    const output = await renderLatestFrame(
+      <FullscreenLayout
+        scrollable={<Text>scroll body</Text>}
+        bottom={<SuggestionsWriter />}
+      />,
+    )
+    const compactOutput = output.replace(/\s+/gu, '')
+
+    expect(compactOutput).toContain('SLASHCOMMANDS')
+    expect(compactOutput).toContain('/statusshowstatus')
+  })
+
+  test('portals prompt dialogs over the fullscreen scroll region', async () => {
+    const output = await renderLatestFrame(
+      <FullscreenLayout
+        scrollable={<Text>scroll body</Text>}
+        bottom={<DialogWriter />}
+      />,
+    )
+
+    expect(output.replace(/\s+/gu, '')).toContain('dialogmarker')
+  })
+
+  test('routes fullscreen hyperlink clicks to file and browser openers', async () => {
+    browser.openBrowser.mockClear()
+    browser.openPath.mockClear()
+    const fakeInk = {} as { onHyperlinkClick?: (url: string) => void }
+    setInkInstance(process.stdout, fakeInk as never)
+
+    const { stdin, stdout } = createStreams({ columns: 90, rows: 12 })
+    stdout.resume()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      await withFullscreenEnv(async () => {
+        root.render(
+          <FullscreenLayout
+            scrollable={<Text>link body</Text>}
+            bottom={<Text>prompt body</Text>}
+          />,
+        )
+        await sleep()
+
+        expect(fakeInk.onHyperlinkClick).toEqual(expect.any(Function))
+
+        fakeInk.onHyperlinkClick?.('file:///tmp/agenc-layout-marker.txt')
+        fakeInk.onHyperlinkClick?.('https://example.test/docs')
+        fakeInk.onHyperlinkClick?.('file://%zz')
+
+        expect(browser.openPath).toHaveBeenCalledTimes(1)
+        expect(browser.openPath).toHaveBeenCalledWith(
+          '/tmp/agenc-layout-marker.txt',
+        )
+        expect(browser.openBrowser).toHaveBeenCalledWith(
+          'https://example.test/docs',
+        )
+      })
+    } finally {
+      root.unmount()
+      deleteInkInstance(process.stdout)
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-020-ink-reconciler.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-020-ink-reconciler.test.ts
@@ -1,0 +1,351 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { expect, test, vi } from 'vitest'
+
+import type { DOMElement, ElementNames } from '../ink/dom.ts'
+import type { Root } from '../ink/root.ts'
+
+vi.mock('../../utils/fullscreen.js', () => ({
+  isMouseClicksDisabled: () => false,
+}))
+
+type TestStdout = PassThrough & {
+  columns: number
+  rows: number
+  isTTY: boolean
+}
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  setRawMode: (mode: boolean) => void
+  ref: () => void
+  unref: () => void
+}
+
+type InstancesMap = {
+  get: (stdout: NodeJS.WriteStream) => { rootNode?: DOMElement } | undefined
+}
+
+const RAW_TEXT_STYLE = {
+  flexDirection: 'row',
+  flexGrow: 0,
+  flexShrink: 1,
+  textWrap: 'wrap',
+} as const
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function createTestStreams(): {
+  stdout: TestStdout
+  stdin: TestStdin
+  stderr: PassThrough
+  stderrWrites: string[]
+} {
+  const stdout = new PassThrough() as TestStdout
+  const stdin = new PassThrough() as TestStdin
+  const stderr = new PassThrough()
+  const stderrWrites: string[] = []
+
+  stderr.on('data', chunk => {
+    stderrWrites.push(Buffer.from(chunk).toString('utf8'))
+  })
+
+  stdout.columns = 80
+  stdout.rows = 24
+  stdout.isTTY = true
+
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+
+  return { stdout, stdin, stderr, stderrWrites }
+}
+
+async function createHarness(): Promise<{
+  root: Root
+  stdout: TestStdout
+  stdin: TestStdin
+  stderr: PassThrough
+  stderrWrites: string[]
+  instances: InstancesMap
+  dispose: () => Promise<void>
+}> {
+  const [{ createRoot }, { default: instances }] = await Promise.all([
+    import('../ink/root.ts'),
+    import('../ink/instances.ts'),
+  ])
+  const { stdout, stdin, stderr, stderrWrites } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    patchConsole: false,
+  })
+
+  return {
+    root,
+    stdout,
+    stdin,
+    stderr,
+    stderrWrites,
+    instances: instances as InstancesMap,
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      stderr.end()
+      await sleep(25)
+    },
+  }
+}
+
+function getRootNode(stdout: TestStdout, instances: InstancesMap): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+
+  if (!instance?.rootNode) {
+    throw new Error('Ink root node not found')
+  }
+
+  return instance.rootNode
+}
+
+function collectElements(
+  node: DOMElement,
+  nodeName: ElementNames,
+  found: DOMElement[] = [],
+): DOMElement[] {
+  if (node.nodeName === nodeName) {
+    found.push(node)
+  }
+
+  for (const child of node.childNodes) {
+    if (child.nodeName !== '#text') {
+      collectElements(child, nodeName, found)
+    }
+  }
+
+  return found
+}
+
+function requireElement(
+  stdout: TestStdout,
+  instances: InstancesMap,
+  nodeName: ElementNames,
+): DOMElement {
+  const found = collectElements(getRootNode(stdout, instances), nodeName)[0]
+
+  if (!found) {
+    throw new Error(`Expected to find ${nodeName}`)
+  }
+
+  return found
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  errorMessage: string,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < 1000) {
+    if (predicate()) {
+      return
+    }
+
+    await sleep(10)
+  }
+
+  throw new Error(errorMessage)
+}
+
+test('debug repaint flag is parsed lazily and cached', async () => {
+  const previous = process.env.AGENC_DEBUG_REPAINTS
+
+  try {
+    vi.resetModules()
+    process.env.AGENC_DEBUG_REPAINTS = '1'
+    const enabledModule = await import('../ink/reconciler.ts')
+
+    expect(enabledModule.isDebugRepaintsEnabled()).toBe(true)
+    process.env.AGENC_DEBUG_REPAINTS = '0'
+    expect(enabledModule.isDebugRepaintsEnabled()).toBe(true)
+
+    vi.resetModules()
+    process.env.AGENC_DEBUG_REPAINTS = '0'
+    const disabledModule = await import('../ink/reconciler.ts')
+
+    expect(disabledModule.isDebugRepaintsEnabled()).toBe(false)
+  } finally {
+    if (previous === undefined) {
+      delete process.env.AGENC_DEBUG_REPAINTS
+    } else {
+      process.env.AGENC_DEBUG_REPAINTS = previous
+    }
+    vi.resetModules()
+  }
+})
+
+test('owner chain walk stops at the reconciler fiber limit', async () => {
+  const { getOwnerChain } = await import('../ink/reconciler.ts')
+  let fiber: { elementType: { name: string }; return?: unknown } | undefined
+
+  for (let index = 59; index >= 0; index--) {
+    fiber = {
+      elementType: { name: `Owner${index}` },
+      return: fiber,
+    }
+  }
+
+  expect(getOwnerChain(fiber)).toHaveLength(50)
+  expect(getOwnerChain(fiber)[0]).toBe('Owner0')
+  expect(getOwnerChain(fiber).at(-1)).toBe('Owner49')
+})
+
+test('profile counters expose last yoga time and reset cleanly', async () => {
+  const {
+    getLastCommitMs,
+    getLastYogaMs,
+    markCommitStart,
+    recordYogaMs,
+    resetProfileCounters,
+  } = await import('../ink/reconciler.ts')
+
+  recordYogaMs(12.5)
+  markCommitStart()
+
+  expect(getLastYogaMs()).toBe(12.5)
+
+  resetProfileCounters()
+
+  expect(getLastYogaMs()).toBe(0)
+  expect(getLastCommitMs()).toBe(0)
+})
+
+test('test-mode commits call immediate render for content and skip empty unmounts', async () => {
+  const harness = await createHarness()
+
+  try {
+    const rootNode = getRootNode(harness.stdout, harness.instances)
+    const originalImmediateRender = rootNode.onImmediateRender
+    const immediateRender = vi.fn(() => originalImmediateRender?.())
+    rootNode.onImmediateRender = immediateRender
+
+    harness.root.render(React.createElement('ink-box', null, 'content'))
+
+    await waitForCondition(
+      () => immediateRender.mock.calls.length > 0,
+      'Timed out waiting for initial immediate render',
+    )
+
+    const callsAfterContent = immediateRender.mock.calls.length
+    expect(rootNode.hasRenderedContent).toBe(true)
+
+    harness.root.unmount()
+    await sleep(50)
+
+    expect(immediateRender).toHaveBeenCalledTimes(callsAfterContent)
+  } finally {
+    await harness.dispose()
+  }
+})
+
+test('deleted host props reset attributes and style on rerender', async () => {
+  const harness = await createHarness()
+
+  try {
+    harness.root.render(
+      React.createElement(
+        'ink-box',
+        {
+          role: 'button',
+          style: { flexDirection: 'column', paddingLeft: 2 },
+        },
+        'first',
+      ),
+    )
+    await sleep(25)
+
+    const box = requireElement(harness.stdout, harness.instances, 'ink-box')
+    expect(box.attributes.role).toBe('button')
+    expect(box.style).toMatchObject({
+      flexDirection: 'column',
+      paddingLeft: 2,
+    })
+
+    harness.root.render(React.createElement('ink-box', null, 'second'))
+    await sleep(25)
+
+    const sameBox = requireElement(harness.stdout, harness.instances, 'ink-box')
+    expect(sameBox).toBe(box)
+    expect(sameBox.attributes.role).toBeUndefined()
+    expect(sameBox.style).toEqual({})
+  } finally {
+    await harness.dispose()
+  }
+})
+
+test('removed host child is detached and has layout references cleared', async () => {
+  const harness = await createHarness()
+
+  try {
+    harness.root.render(
+      React.createElement(
+        'ink-box',
+        null,
+        React.createElement('ink-box', { id: 'removed-child' }, 'child'),
+      ),
+    )
+    await sleep(25)
+
+    const rootNode = getRootNode(harness.stdout, harness.instances)
+    const removedChild = collectElements(rootNode, 'ink-box').find(
+      node => node.attributes.id === 'removed-child',
+    )
+
+    if (!removedChild) {
+      throw new Error('Expected nested child before removal')
+    }
+
+    expect(removedChild.parentNode).toBeDefined()
+    expect(removedChild.yogaNode).toBeDefined()
+
+    harness.root.render(React.createElement('ink-box', null, 'replacement'))
+
+    await waitForCondition(
+      () => removedChild.parentNode === undefined,
+      'Timed out waiting for removed child to detach',
+    )
+
+    expect(removedChild.yogaNode).toBeUndefined()
+  } finally {
+    await harness.dispose()
+  }
+})
+
+test('reconciler rejects boxes nested inside text hosts', async () => {
+  const harness = await createHarness()
+
+  try {
+    harness.root.render(
+      React.createElement(
+        'ink-text',
+        { style: RAW_TEXT_STYLE },
+        React.createElement('ink-box', null, 'invalid'),
+      ),
+    )
+
+    await waitForCondition(
+      () =>
+        harness.stderrWrites
+          .join('')
+          .includes("<Box> can't be nested inside <Text> component"),
+      'Timed out waiting for nested box render error',
+    )
+  } finally {
+    await harness.dispose()
+  }
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-021-ink-log-update.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-021-ink-log-update.test.ts
@@ -1,0 +1,454 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import type { Diff, Frame } from '../ink/frame.ts'
+import { LogUpdate } from '../ink/log-update.ts'
+import {
+  CellWidth,
+  CharPool,
+  createScreen,
+  HyperlinkPool,
+  setCellAt,
+  StylePool,
+} from '../ink/screen.ts'
+import { LINK_END } from '../ink/termio/osc.ts'
+
+type Pools = {
+  stylePool: StylePool
+  charPool: CharPool
+  hyperlinkPool: HyperlinkPool
+}
+
+type CellSpec =
+  | null
+  | string
+  | {
+      char: string
+      hyperlink?: string
+      styleId?: number
+      width?: CellWidth
+    }
+
+type RowSpec = string | CellSpec[]
+
+function createPools(): Pools {
+  return {
+    stylePool: new StylePool(),
+    charPool: new CharPool(),
+    hyperlinkPool: new HyperlinkPool(),
+  }
+}
+
+function rowWidth(row: RowSpec): number {
+  return typeof row === 'string' ? Array.from(row).length : row.length
+}
+
+function frameFromRows(
+  pools: Pools,
+  rows: RowSpec[],
+  options: {
+    cursor?: Frame['cursor']
+    scrollHint?: Frame['scrollHint']
+    softWrap?: Record<number, number>
+    viewportHeight?: number
+    viewportWidth?: number
+    width?: number
+  } = {},
+): Frame {
+  const width =
+    options.width ?? rows.reduce((max, row) => Math.max(max, rowWidth(row)), 0)
+  const screen = createScreen(
+    width,
+    rows.length,
+    pools.stylePool,
+    pools.charPool,
+    pools.hyperlinkPool,
+  )
+
+  rows.forEach((row, y) => {
+    const cells: CellSpec[] =
+      typeof row === 'string' ? Array.from(row) : row
+    cells.forEach((spec, x) => {
+      if (spec === null) return
+      const cell =
+        typeof spec === 'string'
+          ? { char: spec }
+          : spec
+      setCellAt(screen, x, y, {
+        char: cell.char,
+        hyperlink: cell.hyperlink,
+        styleId: cell.styleId ?? pools.stylePool.none,
+        width: cell.width ?? CellWidth.Narrow,
+      })
+    })
+  })
+
+  for (const [y, value] of Object.entries(options.softWrap ?? {})) {
+    screen.softWrap[Number(y)] = value
+  }
+
+  return {
+    cursor: options.cursor ?? { x: 0, y: rows.length, visible: true },
+    screen,
+    scrollHint: options.scrollHint,
+    viewport: {
+      height: options.viewportHeight ?? 10,
+      width: options.viewportWidth ?? Math.max(width, 1),
+    },
+  }
+}
+
+function stdoutText(diff: Diff): string {
+  return diff
+    .filter((patch): patch is Extract<Diff[number], { type: 'stdout' }> => {
+      return patch.type === 'stdout'
+    })
+    .map(patch => patch.content)
+    .join('')
+}
+
+function redStyle(stylePool: StylePool): number {
+  return stylePool.intern([
+    { code: '\x1b[31m', endCode: '\x1b[39m', type: 'ansi' },
+  ])
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('coverage swarm row 021: LogUpdate', () => {
+  test('non-TTY rendering closes trailing hyperlinks and resets styles', () => {
+    const pools = createPools()
+    const styleId = redStyle(pools.stylePool)
+    const log = new LogUpdate({ isTTY: false, stylePool: pools.stylePool })
+    const prev = frameFromRows(pools, [], { width: 1 })
+    const next = frameFromRows(
+      pools,
+      [
+        [
+          {
+            char: 'R',
+            hyperlink: 'https://example.test/item',
+            styleId,
+          },
+        ],
+      ],
+      { width: 1 },
+    )
+
+    const diff = log.render(prev, next)
+    const stdout = stdoutText(diff)
+
+    expect(diff).toHaveLength(1)
+    expect(stdout).toContain('https://example.test/item')
+    expect(stdout).toContain('\x1b[31m')
+    expect(stdout).toContain('\x1b[39m')
+    expect(stdout).toContain(LINK_END)
+  })
+
+  test('preservePreviousOutput emits newline for pipes and cursor show for hidden TTY cursors', () => {
+    const pools = createPools()
+    const frame = frameFromRows(pools, ['done'], {
+      cursor: { x: 0, y: 1, visible: false },
+    })
+
+    expect(
+      new LogUpdate({
+        isTTY: false,
+        stylePool: pools.stylePool,
+      }).preservePreviousOutput(frame),
+    ).toEqual([{ type: 'stdout', content: '\n' }])
+    expect(
+      new LogUpdate({
+        isTTY: true,
+        stylePool: pools.stylePool,
+      }).preservePreviousOutput(frame),
+    ).toEqual([{ type: 'cursorShow' }])
+  })
+
+  test('scrollback changes trigger a full reset with source line debug context', () => {
+    const pools = createPools()
+    const log = new LogUpdate({ isTTY: true, stylePool: pools.stylePool })
+    const prev = frameFromRows(pools, ['old', 'same', 'tail'], {
+      cursor: { x: 0, y: 3, visible: true },
+      viewportHeight: 2,
+      viewportWidth: 4,
+    })
+    const next = frameFromRows(pools, ['new', 'same', 'tail'], {
+      cursor: { x: 0, y: 3, visible: true },
+      viewportHeight: 2,
+      viewportWidth: 4,
+    })
+
+    expect(log.render(prev, next)[0]).toEqual({
+      debug: { nextLine: 'new', prevLine: 'old', triggerY: 0 },
+      reason: 'offscreen',
+      type: 'clearTerminal',
+    })
+  })
+
+  test('growing output still resets when changed rows are above the viewport', () => {
+    const pools = createPools()
+    const log = new LogUpdate({ isTTY: true, stylePool: pools.stylePool })
+    const prev = frameFromRows(pools, ['old', 'same', 'tail'], {
+      cursor: { x: 0, y: 3, visible: true },
+      viewportHeight: 2,
+      viewportWidth: 4,
+    })
+    const next = frameFromRows(pools, ['new', 'same', 'tail', 'more'], {
+      cursor: { x: 0, y: 4, visible: true },
+      viewportHeight: 2,
+      viewportWidth: 4,
+    })
+
+    expect(log.render(prev, next)[0]).toEqual({
+      debug: { nextLine: 'new', prevLine: 'old', triggerY: 0 },
+      reason: 'offscreen',
+      type: 'clearTerminal',
+    })
+  })
+
+  test('shrinking by more lines than the viewport can erase falls back to a full reset', () => {
+    const pools = createPools()
+    const log = new LogUpdate({ isTTY: true, stylePool: pools.stylePool })
+    const prev = frameFromRows(pools, ['a', 'b', 'c', 'd', 'e'], {
+      cursor: { x: 0, y: 0, visible: true },
+      viewportHeight: 2,
+      viewportWidth: 1,
+    })
+    const next = frameFromRows(pools, ['a'], {
+      cursor: { x: 0, y: 1, visible: true },
+      viewportHeight: 2,
+      viewportWidth: 1,
+    })
+
+    expect(log.render(prev, next)[0]).toMatchObject({
+      reason: 'offscreen',
+      type: 'clearTerminal',
+    })
+  })
+
+  test('alt-screen negative scroll hints use DECSTBM scroll-down patches', () => {
+    const pools = createPools()
+    const log = new LogUpdate({ isTTY: true, stylePool: pools.stylePool })
+    const prev = frameFromRows(pools, ['TOP', 'NEW', 'OLD', 'END'], {
+      cursor: { x: 0, y: 0, visible: false },
+      viewportHeight: 4,
+      viewportWidth: 3,
+    })
+    const next = frameFromRows(pools, ['TOP', 'NEW', 'MID', 'END'], {
+      cursor: { x: 0, y: 0, visible: false },
+      scrollHint: { bottom: 2, delta: -1, top: 1 },
+      viewportHeight: 4,
+      viewportWidth: 3,
+    })
+
+    const diff = log.render(prev, next, true)
+
+    expect(diff[0]).toEqual({
+      content: '\x1b[2;3r\x1b[1T\x1b[r\x1b[H',
+      type: 'stdout',
+    })
+    expect(stdoutText(diff)).toContain('MID')
+  })
+
+  test('wide spacer cells are skipped when added or removed', () => {
+    const pools = createPools()
+    const log = new LogUpdate({ isTTY: true, stylePool: pools.stylePool })
+    const wide = '\u4e00'
+    const empty = frameFromRows(pools, [[null, null]], {
+      cursor: { x: 0, y: 0, visible: true },
+      viewportWidth: 2,
+      width: 2,
+    })
+    const wideRow = frameFromRows(
+      pools,
+      [[{ char: wide, width: CellWidth.Wide }, null]],
+      {
+        cursor: { x: 0, y: 0, visible: true },
+        viewportWidth: 2,
+        width: 2,
+      },
+    )
+
+    expect(stdoutText(log.render(empty, wideRow))).toContain(wide)
+
+    const cleared = frameFromRows(pools, [], {
+      cursor: { x: 0, y: 0, visible: true },
+      viewportWidth: 2,
+      width: 2,
+    })
+    const removedStdout = stdoutText(log.render(wideRow, cleared))
+
+    expect(removedStdout.match(/ /g)).toHaveLength(1)
+  })
+
+  test('wide cells at the viewport edge are not written across the boundary', () => {
+    const pools = createPools()
+    const log = new LogUpdate({ isTTY: true, stylePool: pools.stylePool })
+    const wide = '\u4e00'
+    const prev = frameFromRows(pools, [[null]], {
+      cursor: { x: 0, y: 0, visible: true },
+      viewportWidth: 1,
+      width: 1,
+    })
+    const next = frameFromRows(
+      pools,
+      [[{ char: wide, width: CellWidth.Wide }]],
+      {
+        cursor: { x: 0, y: 1, visible: true },
+        viewportWidth: 1,
+        width: 1,
+      },
+    )
+
+    expect(stdoutText(log.render(prev, next))).not.toContain(wide)
+  })
+
+  test('compensates newer wide emoji and variation-selector emoji widths', () => {
+    const pools = createPools()
+    const log = new LogUpdate({ isTTY: true, stylePool: pools.stylePool })
+    const prev = frameFromRows(pools, [[null, null, null, null]], {
+      cursor: { x: 0, y: 0, visible: true },
+      viewportWidth: 4,
+      width: 4,
+    })
+
+    for (const char of ['\u{1fae0}', '\u{1fb00}', '\u2764\ufe0f']) {
+      const next = frameFromRows(
+        pools,
+        [[null, { char, width: CellWidth.Wide }, null, null]],
+        {
+          cursor: { x: 0, y: 0, visible: true },
+          viewportWidth: 4,
+          width: 4,
+        },
+      )
+      const diff = log.render(prev, next)
+
+      expect(diff).toContainEqual({ col: 3, type: 'cursorTo' })
+      expect(diff).toContainEqual({ col: 2, type: 'cursorTo' })
+      expect(diff).toContainEqual({ col: 4, type: 'cursorTo' })
+      expect(stdoutText(diff)).toContain(char)
+    }
+  })
+
+  test('empty wide cells avoid width compensation and produce empty writes', () => {
+    const pools = createPools()
+    const log = new LogUpdate({ isTTY: true, stylePool: pools.stylePool })
+    const prev = frameFromRows(pools, [[null, null, null]], {
+      cursor: { x: 0, y: 0, visible: true },
+      viewportWidth: 3,
+      width: 3,
+    })
+    const next = frameFromRows(
+      pools,
+      [[{ char: '', width: CellWidth.Wide }, null, null]],
+      {
+        cursor: { x: 0, y: 0, visible: true },
+        viewportWidth: 3,
+        width: 3,
+      },
+    )
+
+    expect(log.render(prev, next)).toContainEqual({
+      content: '',
+      type: 'stdout',
+    })
+  })
+
+  test('cells beyond the viewport advance the virtual cursor to the next row', () => {
+    const pools = createPools()
+    const log = new LogUpdate({ isTTY: true, stylePool: pools.stylePool })
+    const prev = frameFromRows(pools, [[null, null]], {
+      cursor: { x: 0, y: 0, visible: true },
+      viewportWidth: 1,
+      width: 2,
+    })
+    const next = frameFromRows(pools, [[null, 'Z']], {
+      cursor: { x: 0, y: 0, visible: true },
+      viewportWidth: 1,
+      width: 2,
+    })
+
+    expect(stdoutText(log.render(prev, next))).toContain('Z')
+  })
+
+  test('main-screen rewrite handles growth without clearing existing rows', () => {
+    const pools = createPools()
+    const log = new LogUpdate({ isTTY: true, stylePool: pools.stylePool })
+    const prev = frameFromRows(pools, ['top'], {
+      cursor: { x: 0, y: 1, visible: true },
+      viewportWidth: 4,
+      width: 4,
+    })
+    const next = frameFromRows(pools, ['top', 'next'], {
+      cursor: { x: 0, y: 2, visible: true },
+      viewportWidth: 4,
+      width: 4,
+    })
+
+    const diff = log.render(prev, next, false, true, true)
+
+    expect(diff.some(patch => patch.type === 'clear')).toBe(false)
+    expect(stdoutText(diff)).toContain('next')
+  })
+
+  test('main-screen rewrite ignores identical frames and honors width or wrap changes', () => {
+    const pools = createPools()
+    const log = new LogUpdate({ isTTY: true, stylePool: pools.stylePool })
+    const samePrev = frameFromRows(pools, ['same'], {
+      cursor: { x: 0, y: 0, visible: true },
+      viewportWidth: 5,
+    })
+    const sameNext = frameFromRows(pools, ['same'], {
+      cursor: { x: 1, y: 0, visible: true },
+      viewportWidth: 5,
+    })
+
+    expect(log.render(samePrev, sameNext, false, true, true)).toContainEqual({
+      type: 'cursorMove',
+      x: 1,
+      y: 0,
+    })
+
+    const narrow = frameFromRows(pools, ['abc'], {
+      cursor: { x: 0, y: 1, visible: true },
+      viewportWidth: 5,
+    })
+    const wide = frameFromRows(pools, ['abcd'], {
+      cursor: { x: 0, y: 1, visible: true },
+      viewportWidth: 5,
+    })
+    expect(log.render(narrow, wide, false, true, true)).toContainEqual({
+      count: 1,
+      type: 'clear',
+    })
+
+    const wrapped = frameFromRows(pools, ['abc'], {
+      cursor: { x: 0, y: 1, visible: true },
+      softWrap: { 0: 1 },
+      viewportWidth: 5,
+    })
+    expect(log.render(wrapped, narrow, false, true, true)).toContainEqual({
+      count: 1,
+      type: 'clear',
+    })
+  })
+
+  test('slow incremental renders collect damage details for debug logging', () => {
+    const pools = createPools()
+    const log = new LogUpdate({ isTTY: true, stylePool: pools.stylePool })
+    const prev = frameFromRows(pools, ['a'], {
+      cursor: { x: 0, y: 0, visible: true },
+      viewportWidth: 1,
+    })
+    const next = frameFromRows(pools, ['b'], {
+      cursor: { x: 0, y: 0, visible: true },
+      viewportWidth: 1,
+    })
+    vi.spyOn(performance, 'now').mockReturnValueOnce(0).mockReturnValueOnce(75)
+
+    expect(stdoutText(log.render(prev, next))).toContain('b')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-022-components-Message.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-022-components-Message.test.tsx
@@ -1,0 +1,414 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  calls: [] as Array<{ name: string; props: Record<string, unknown> }>,
+  columns: 12,
+  features: new Set<string>(),
+  fullscreen: false,
+  logError: vi.fn(),
+  reset() {
+    harness.calls = []
+    harness.columns = 12
+    harness.features = new Set()
+    harness.fullscreen = false
+    harness.logError.mockClear()
+  },
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => harness.features.has(name),
+}))
+
+vi.mock('../../utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => harness.fullscreen,
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: harness.logError,
+}))
+
+vi.mock('../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: harness.columns, rows: 24 }),
+}))
+
+vi.mock('../../services/compact/snipProjection.js', () => ({
+  isSnipBoundaryMessage: (message: { readonly subtype?: string }) =>
+    message.subtype === 'snip_boundary',
+}))
+
+vi.mock('../../services/compact/snipCompact.js', () => ({
+  isSnipMarkerMessage: (message: { readonly subtype?: string }) =>
+    message.subtype === 'snip_marker',
+}))
+
+vi.mock('../message-renderers/SnipBoundaryMessage.js', () => ({
+  SnipBoundaryMessage: (props: Record<string, unknown>) => {
+    harness.calls.push({ name: 'SnipBoundaryMessage', props })
+    return null
+  },
+}))
+
+vi.mock('../components/Message.renderers.js', async () => {
+  const ReactModule = await import('react')
+  const renderer = (name: string) => (props: Record<string, unknown>) => {
+    harness.calls.push({ name, props })
+    return null
+  }
+
+  return {
+    AdvisorMessage: renderer('AdvisorMessage'),
+    AssistantRedactedThinkingMessage: renderer('AssistantRedactedThinkingMessage'),
+    AssistantTextMessage: renderer('AssistantTextMessage'),
+    AssistantThinkingMessage: renderer('AssistantThinkingMessage'),
+    AssistantToolUseMessage: renderer('AssistantToolUseMessage'),
+    AttachmentMessage: renderer('AttachmentMessage'),
+    CollapsedReadSearchContent: renderer('CollapsedReadSearchContent'),
+    CompactBoundaryMessage: renderer('CompactBoundaryMessage'),
+    CompactSummary: renderer('CompactSummary'),
+    ExpandShellOutputProvider: ({
+      children,
+    }: {
+      readonly children?: React.ReactNode
+    }) => {
+      harness.calls.push({ name: 'ExpandShellOutputProvider', props: {} })
+      return ReactModule.createElement(ReactModule.Fragment, null, children)
+    },
+    GroupedToolUseContent: renderer('GroupedToolUseContent'),
+    OffscreenFreeze: ({ children }: { readonly children?: React.ReactNode }) => {
+      harness.calls.push({ name: 'OffscreenFreeze', props: {} })
+      return ReactModule.createElement(ReactModule.Fragment, null, children)
+    },
+    SystemTextMessage: renderer('SystemTextMessage'),
+    UserImageMessage: renderer('UserImageMessage'),
+    UserTextMessage: renderer('UserTextMessage'),
+    UserToolResultMessage: renderer('UserToolResultMessage'),
+  }
+})
+
+import { Box } from '../ink.js'
+import { createRoot } from '../ink/root.js'
+import type { Props } from '../components/Message.js'
+import {
+  getToolResultMessageWidth,
+  Message,
+} from '../components/Message.js'
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function baseProps(message: Props['message']): Props {
+  return {
+    addMargin: true,
+    commands: [],
+    inProgressToolUseIDs: new Set(['tool-live']),
+    isStatic: false,
+    isTranscriptMode: false,
+    lookups: {
+      erroredToolUseIDs: new Set(['tool-error']),
+      resolvedToolUseIDs: new Set(['tool-ok']),
+    },
+    message,
+    progressMessagesForMessage: [],
+    shouldAnimate: true,
+    shouldShowDot: true,
+    tools: [] as never,
+    verbose: true,
+  } as Props
+}
+
+async function createMessageRoot(
+  messages: Array<Props['message']>,
+  overrides: Partial<Props> = {},
+): Promise<{
+  render: () => void
+  dispose: () => Promise<void>
+}> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  const messageProps = messages.map(message => ({
+    ...baseProps(message),
+    ...overrides,
+    message,
+  }))
+
+  const render = () => {
+    root.render(
+      <Box flexDirection="column">
+        {messageProps.map(props => (
+          <Message
+            key={props.message.uuid}
+            {...props}
+          />
+        ))}
+      </Box>,
+    )
+  }
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    render,
+  }
+}
+
+async function renderMessages(
+  messages: Array<Props['message']>,
+  overrides: Partial<Props> = {},
+): Promise<{ dispose: () => Promise<void> }> {
+  const mounted = await createMessageRoot(messages, overrides)
+  mounted.render()
+  await sleep()
+  return { dispose: mounted.dispose }
+}
+
+describe('Message coverage swarm row 022', () => {
+  beforeEach(() => {
+    harness.reset()
+  })
+
+  test('routes user continuation, transcript summary, fallback image ids, and narrow tool result widths', async () => {
+    harness.columns = 3
+
+    const messages = [
+      {
+        isCompactSummary: true,
+        message: { content: [{ text: 'summary', type: 'text' }] },
+        type: 'user',
+        uuid: 'compact-summary',
+      },
+      {
+        message: {
+          content: [
+            {
+              source: { data: 'abc', media_type: 'image/png', type: 'base64' },
+              type: 'image',
+            },
+            { content: 'done', tool_use_id: 'tool-1', type: 'tool_result' },
+            { type: 'unknown_user_block' },
+          ],
+        },
+        type: 'user',
+        uuid: 'user-continuation',
+      },
+    ] as Array<Props['message']>
+
+    const rendered = await renderMessages(messages, {
+      isTranscriptMode: true,
+      isUserContinuation: true,
+      latestBashOutputUUID: 'other-user',
+    })
+
+    try {
+      expect(getToolResultMessageWidth(0)).toBe(1)
+      expect(harness.calls.find(call => call.name === 'CompactSummary')?.props).toMatchObject({
+        screen: 'transcript',
+      })
+      expect(harness.calls.find(call => call.name === 'UserImageMessage')?.props).toMatchObject({
+        addMargin: false,
+        imageId: 1,
+      })
+      expect(
+        harness.calls.find(call => call.name === 'UserToolResultMessage')?.props,
+      ).toMatchObject({ width: 1 })
+      expect(harness.calls.some(call => call.name === 'ExpandShellOutputProvider')).toBe(
+        false,
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('reuses cached system renderers for stable compact, snip, local command, and text messages', async () => {
+    harness.features.add('HISTORY_SNIP')
+
+    const messages = [
+      { subtype: 'compact_boundary', type: 'system', uuid: 'compact-boundary' },
+      { subtype: 'snip_boundary', type: 'system', uuid: 'snip-boundary' },
+      { subtype: 'snip_marker', type: 'system', uuid: 'snip-marker' },
+      {
+        content: 'local command',
+        subtype: 'local_command',
+        type: 'system',
+        uuid: 'local-command',
+      },
+      { content: 'system text', subtype: 'notice', type: 'system', uuid: 'system-text' },
+    ] as Array<Props['message']>
+
+    const mounted = await createMessageRoot(messages)
+
+    try {
+      mounted.render()
+      await sleep()
+
+      expect(harness.calls.map(call => call.name)).toEqual(
+        expect.arrayContaining([
+          'CompactBoundaryMessage',
+          'SnipBoundaryMessage',
+          'UserTextMessage',
+          'SystemTextMessage',
+        ]),
+      )
+      expect(harness.calls.some(call => call.props.message === messages[2])).toBe(false)
+
+      const callCountAfterFirstRender = harness.calls.length
+      mounted.render()
+      await sleep()
+
+      expect(harness.calls).toHaveLength(callCountAfterFirstRender)
+    } finally {
+      await mounted.dispose()
+    }
+  })
+
+  test('routes connector fallback, assistant cache reuse, and non-advisor server tool errors', async () => {
+    harness.features.add('CONNECTOR_TEXT')
+
+    const assistant = {
+      advisorModel: 'reviewer-model',
+      message: {
+        content: [
+          { connector_text: 'from connector', type: 'connector_text' },
+          { text: 'regular text', type: 'text' },
+          { id: 'tool-live', input: { command: 'pwd' }, name: 'Bash', type: 'tool_use' },
+          { data: 'hidden', type: 'redacted_thinking' },
+          { thinking: 'visible thinking', type: 'thinking' },
+          { id: 'advisor-1', input: {}, name: 'advisor', type: 'server_tool_use' },
+          { id: 'external-1', input: {}, name: 'web_search', type: 'server_tool_use' },
+          { type: 'unknown_assistant_block' },
+        ],
+      },
+      type: 'assistant',
+      uuid: 'assistant-assorted',
+    } as Props['message']
+
+    const mounted = await createMessageRoot([assistant], {
+      isTranscriptMode: true,
+      lastThinkingBlockId: 'assistant-assorted:4',
+      verbose: false,
+    })
+
+    try {
+      mounted.render()
+      await sleep()
+
+      expect(harness.calls.map(call => call.name)).toEqual(
+        expect.arrayContaining([
+          'AssistantTextMessage',
+          'AssistantToolUseMessage',
+          'AssistantRedactedThinkingMessage',
+          'AssistantThinkingMessage',
+          'AdvisorMessage',
+        ]),
+      )
+      expect(
+        harness.calls.find(
+          call =>
+            call.name === 'AssistantTextMessage' &&
+            (call.props.param as { text?: string }).text === 'from connector',
+        )?.props,
+      ).toMatchObject({ param: { text: 'from connector', type: 'text' } })
+      expect(
+        harness.calls.find(call => call.name === 'AssistantThinkingMessage')?.props,
+      ).toMatchObject({ hideInTranscript: false })
+      expect(harness.calls.find(call => call.name === 'AdvisorMessage')?.props).toMatchObject({
+        advisorModel: 'reviewer-model',
+        verbose: true,
+      })
+      expect(
+        harness.logError.mock.calls.map(([error]) => (error as Error).message),
+      ).toEqual(
+        expect.arrayContaining([
+          'Unable to render server tool block: server_tool_use',
+          'Unable to render message type: unknown_assistant_block',
+        ]),
+      )
+
+      const callCountAfterFirstRender = harness.calls.length
+      mounted.render()
+      await sleep()
+
+      expect(harness.calls).toHaveLength(callCountAfterFirstRender)
+    } finally {
+      await mounted.dispose()
+    }
+  })
+
+  test('derives collapsed read search verbosity from transcript mode when verbose is false', async () => {
+    const collapsed = {
+      messages: [],
+      type: 'collapsed_read_search',
+      uuid: 'collapsed-search',
+    } as Props['message']
+
+    const transcriptRender = await renderMessages([collapsed], {
+      isActiveCollapsedGroup: true,
+      isTranscriptMode: true,
+      verbose: false,
+    })
+
+    try {
+      expect(
+        harness.calls.find(call => call.name === 'CollapsedReadSearchContent')?.props,
+      ).toMatchObject({
+        isActiveGroup: true,
+        verbose: true,
+      })
+    } finally {
+      await transcriptRender.dispose()
+    }
+
+    harness.reset()
+
+    const promptRender = await renderMessages([collapsed], {
+      isTranscriptMode: false,
+      verbose: false,
+    })
+
+    try {
+      expect(
+        harness.calls.find(call => call.name === 'CollapsedReadSearchContent')?.props,
+      ).toMatchObject({
+        isActiveGroup: undefined,
+        verbose: false,
+      })
+    } finally {
+      await promptRender.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-023-components-ScrollKeybindingHandler.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-023-components-ScrollKeybindingHandler.test.tsx
@@ -1,0 +1,334 @@
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { renderToString } from "../../utils/staticRender.js";
+
+type KeybindingCall = {
+  handlers: Record<string, () => unknown>;
+  options: { context: string; isActive: boolean };
+};
+
+type InputEvent = { stopImmediatePropagation: () => void };
+type InputCall = {
+  handler: (
+    input: string,
+    key: Record<string, boolean>,
+    event: InputEvent,
+  ) => void;
+  options: { isActive: boolean };
+};
+
+type ScrollBoxMock = {
+  calls: Array<[string, number?]>;
+  handle: {
+    getPendingDelta: () => number;
+    getScrollHeight: () => number;
+    getScrollTop: () => number;
+    getViewportHeight: () => number;
+    getViewportTop: () => number;
+    scrollBy: (amount: number) => void;
+    scrollTo: (value: number) => void;
+    scrollToBottom: () => void;
+  };
+};
+
+const harness = vi.hoisted(() => {
+  const state = {
+    addNotification: vi.fn(),
+    getClipboardPath: vi.fn(() => "native"),
+    inputCalls: [] as InputCall[],
+    isXtermJs: vi.fn(() => false),
+    keybindingCalls: [] as KeybindingCall[],
+    logForDebugging: vi.fn(),
+    selectionState: null as unknown,
+    useCopyOnSelect: vi.fn(),
+    useSelectionBgColor: vi.fn(),
+    selection: {
+      clearSelection: vi.fn(),
+      copySelection: vi.fn(() => ""),
+      getState: vi.fn(() => state.selectionState),
+      hasSelection: vi.fn(() => false),
+      moveFocus: vi.fn(),
+      captureScrolledRows: vi.fn(),
+      shiftSelection: vi.fn(),
+      shiftAnchor: vi.fn(),
+      subscribe: vi.fn(() => vi.fn()),
+    },
+  };
+
+  return state;
+});
+
+vi.mock("bun:bundle", () => ({
+  feature: () => false,
+}));
+
+vi.mock("../context/notifications", () => ({
+  useNotifications: () => ({
+    addNotification: harness.addNotification,
+  }),
+}));
+
+vi.mock("../hooks/useCopyOnSelect", () => ({
+  useCopyOnSelect: harness.useCopyOnSelect,
+  useSelectionBgColor: harness.useSelectionBgColor,
+}));
+
+vi.mock("../ink/hooks/use-selection.js", () => ({
+  useSelection: () => harness.selection,
+}));
+
+vi.mock("../ink/terminal.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../ink/terminal.js")>(
+      "../ink/terminal.js",
+    );
+  return {
+    ...actual,
+    isXtermJs: harness.isXtermJs,
+  };
+});
+
+vi.mock("../ink/termio/osc.js", () => ({
+  getClipboardPath: harness.getClipboardPath,
+}));
+
+vi.mock("src/utils/debug.js", () => ({
+  logForDebugging: harness.logForDebugging,
+}));
+
+vi.mock("../keybindings/useKeybinding.js", () => ({
+  useKeybindings: (
+    handlers: Record<string, () => unknown>,
+    options: { context: string; isActive: boolean },
+  ) => {
+    harness.keybindingCalls.push({ handlers, options });
+  },
+}));
+
+vi.mock("../ink.js", async () => {
+  const actual = await vi.importActual<typeof import("../ink.js")>("../ink.js");
+  return {
+    ...actual,
+    useInput: (
+      handler: InputCall["handler"],
+      options: InputCall["options"],
+    ) => {
+      harness.inputCalls.push({ handler, options });
+    },
+  };
+});
+
+function makeScrollBox({
+  pendingDelta = 0,
+  scrollHeight = 100,
+  scrollTop = 10,
+  viewportHeight = 20,
+  viewportTop = 2,
+} = {}): ScrollBoxMock {
+  const calls: Array<[string, number?]> = [];
+  let pending = pendingDelta;
+  let top = scrollTop;
+
+  const handle = {
+    getPendingDelta: () => pending,
+    getScrollHeight: () => scrollHeight,
+    getScrollTop: () => top,
+    getViewportHeight: () => viewportHeight,
+    getViewportTop: () => viewportTop,
+    scrollBy: (amount: number) => {
+      calls.push(["scrollBy", amount]);
+      pending += amount;
+    },
+    scrollTo: (value: number) => {
+      calls.push(["scrollTo", value]);
+      top = value;
+      pending = 0;
+    },
+    scrollToBottom: () => {
+      calls.push(["scrollToBottom"]);
+      top = Math.max(0, scrollHeight - viewportHeight);
+      pending = 0;
+    },
+  };
+
+  return { calls, handle };
+}
+
+function key(overrides: Record<string, boolean> = {}) {
+  return {
+    ctrl: false,
+    downArrow: false,
+    end: false,
+    escape: false,
+    home: false,
+    leftArrow: false,
+    meta: false,
+    rightArrow: false,
+    shift: false,
+    upArrow: false,
+    ...overrides,
+  };
+}
+
+function event(): InputEvent {
+  return { stopImmediatePropagation: vi.fn() };
+}
+
+async function renderHandler({
+  isActive = true,
+  isModal = false,
+  onScroll = vi.fn(),
+  scrollBox = makeScrollBox(),
+  scrollRefCurrent = scrollBox.handle as ScrollBoxMock["handle"] | null,
+} = {}) {
+  const { ScrollKeybindingHandler } = await import(
+    "../components/ScrollKeybindingHandler.js"
+  );
+
+  await renderToString(
+    <ScrollKeybindingHandler
+      scrollRef={{ current: scrollRefCurrent as never }}
+      isActive={isActive}
+      isModal={isModal}
+      onScroll={onScroll}
+    />,
+    80,
+  );
+
+  return {
+    customBindings: harness.keybindingCalls[1]?.handlers ?? {},
+    inputCalls: harness.inputCalls,
+    mainBindings: harness.keybindingCalls[0]?.handlers ?? {},
+    onScroll,
+    scrollBox,
+  };
+}
+
+describe("ScrollKeybindingHandler coverage swarm row 023", () => {
+  beforeEach(() => {
+    harness.addNotification.mockClear();
+    harness.getClipboardPath.mockClear();
+    harness.getClipboardPath.mockReturnValue("native");
+    harness.inputCalls.length = 0;
+    harness.isXtermJs.mockClear();
+    harness.isXtermJs.mockReturnValue(false);
+    harness.keybindingCalls.length = 0;
+    harness.logForDebugging.mockClear();
+    harness.selectionState = null;
+    harness.useCopyOnSelect.mockClear();
+    harness.useSelectionBgColor.mockClear();
+
+    harness.selection.clearSelection.mockClear();
+    harness.selection.copySelection.mockClear();
+    harness.selection.copySelection.mockReturnValue("");
+    harness.selection.getState.mockClear();
+    harness.selection.hasSelection.mockClear();
+    harness.selection.hasSelection.mockReturnValue(false);
+    harness.selection.moveFocus.mockClear();
+    harness.selection.captureScrolledRows.mockClear();
+    harness.selection.shiftSelection.mockClear();
+    harness.selection.shiftAnchor.mockClear();
+    harness.selection.subscribe.mockClear();
+    harness.selection.subscribe.mockReturnValue(vi.fn());
+  });
+
+  test("no-ops scroll actions that require a missing scroll ref", async () => {
+    const { customBindings, mainBindings, onScroll } = await renderHandler({
+      scrollRefCurrent: null,
+    });
+
+    mainBindings["scroll:pageUp"]?.();
+    mainBindings["scroll:pageDown"]?.();
+    mainBindings["scroll:top"]?.();
+    mainBindings["scroll:bottom"]?.();
+    customBindings["scroll:halfPageUp"]?.();
+    customBindings["scroll:halfPageDown"]?.();
+    customBindings["scroll:fullPageUp"]?.();
+    customBindings["scroll:fullPageDown"]?.();
+
+    expect(onScroll).not.toHaveBeenCalled();
+    expect(harness.selection.captureScrolledRows).not.toHaveBeenCalled();
+    expect(harness.selection.shiftSelection).not.toHaveBeenCalled();
+  });
+
+  test("scrolls wheel-down within content and reports non-sticky state", async () => {
+    const scrollBox = makeScrollBox({
+      scrollHeight: 100,
+      scrollTop: 20,
+      viewportHeight: 20,
+    });
+    const { mainBindings, onScroll } = await renderHandler({ scrollBox });
+
+    mainBindings["scroll:lineDown"]?.();
+
+    expect(harness.selection.clearSelection).toHaveBeenCalledOnce();
+    expect(scrollBox.calls).toEqual([["scrollBy", 1]]);
+    expect(onScroll).toHaveBeenLastCalledWith(false, scrollBox.handle);
+    expect(harness.logForDebugging).toHaveBeenCalledWith(
+      expect.stringContaining("wheel accel: window"),
+    );
+  });
+
+  test("does not translate selections outside the scroll viewport", async () => {
+    const scrollBox = makeScrollBox({
+      scrollTop: 10,
+      viewportHeight: 10,
+      viewportTop: 5,
+    });
+    const { mainBindings } = await renderHandler({ scrollBox });
+
+    harness.selectionState = {
+      anchor: { row: 4 },
+      focus: { row: 7 },
+    };
+    mainBindings["scroll:pageDown"]?.();
+
+    harness.selectionState = {
+      anchor: { row: 7 },
+      focus: { row: 20 },
+    };
+    mainBindings["scroll:pageDown"]?.();
+
+    expect(harness.selection.captureScrolledRows).not.toHaveBeenCalled();
+    expect(harness.selection.shiftSelection).not.toHaveBeenCalled();
+    expect(scrollBox.calls).toEqual([["scrollTo", 15], ["scrollTo", 20]]);
+  });
+
+  test("selection input passes through when absent and preserves meta navigation", async () => {
+    const { inputCalls } = await renderHandler();
+    const selectionInput = inputCalls[1];
+
+    const absent = event();
+    selectionInput?.handler("x", key(), absent);
+
+    expect(harness.selection.clearSelection).not.toHaveBeenCalled();
+    expect(absent.stopImmediatePropagation).not.toHaveBeenCalled();
+
+    harness.selection.hasSelection.mockReturnValue(true);
+
+    const metaNav = event();
+    selectionInput?.handler("", key({ meta: true, rightArrow: true }), metaNav);
+
+    expect(harness.selection.moveFocus).not.toHaveBeenCalled();
+    expect(harness.selection.clearSelection).not.toHaveBeenCalled();
+    expect(metaNav.stopImmediatePropagation).not.toHaveBeenCalled();
+  });
+
+  test("copy-on-select callback uses the same clipboard notification path", async () => {
+    await renderHandler();
+
+    const copiedCallback = harness.useCopyOnSelect.mock.calls[0]?.[2] as
+      | ((text: string) => void)
+      | undefined;
+    copiedCallback?.("copied from drag");
+
+    expect(harness.addNotification).toHaveBeenCalledWith({
+      key: "selection-copied",
+      text: "copied 16 chars to clipboard",
+      color: "suggestion",
+      priority: "immediate",
+      timeoutMs: 2000,
+    });
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-024-components-spinner-TeammateSpinnerTree.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-024-components-spinner-TeammateSpinnerTree.test.tsx
@@ -1,0 +1,166 @@
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { TeammateSpinnerTree } from "../../../src/tui/components/spinner/TeammateSpinnerTree.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+type AppStateSlice = {
+  showTeammateMessagePreview: boolean;
+  tasks: Record<string, unknown>;
+  viewingAgentTaskId?: string;
+};
+
+const harness = vi.hoisted(() => ({
+  state: {
+    showTeammateMessagePreview: false,
+    tasks: {},
+    viewingAgentTaskId: undefined,
+  } as AppStateSlice,
+}));
+
+vi.mock("../../../src/tui/state/AppState.js", () => ({
+  useAppState: (selector: (state: AppStateSlice) => unknown) =>
+    selector(harness.state),
+}));
+
+function makeTeammateTask({
+  agentName,
+  id,
+  ...overrides
+}: {
+  agentName: string;
+  id: string;
+  [key: string]: unknown;
+}) {
+  return {
+    awaitingPlanApproval: false,
+    description: `${agentName} teammate`,
+    id,
+    identity: {
+      agentId: `${agentName}@alpha`,
+      agentName,
+      parentSessionId: "leader-session",
+      planModeRequired: false,
+      teamName: "alpha",
+    },
+    isIdle: false,
+    lastReportedTokenCount: 0,
+    lastReportedToolCount: 0,
+    messages: [
+      {
+        message: {
+          content: [
+            {
+              text: `recent ${agentName} update`,
+              type: "text",
+            },
+          ],
+        },
+        type: "assistant",
+      },
+    ],
+    notified: false,
+    outputFile: `/tmp/${id}.log`,
+    outputOffset: 0,
+    pendingUserMessages: [],
+    permissionMode: "acceptEdits",
+    progress: {
+      lastActivity: {
+        activityDescription: `Working as ${agentName}`,
+      },
+      tokenCount: 2400,
+      toolUseCount: 2,
+    },
+    prompt: "do the work",
+    shutdownRequested: false,
+    spinnerVerb: `Thinking as ${agentName}`,
+    startTime: Date.now() - 5000,
+    status: "running",
+    totalPausedMs: 0,
+    type: "in_process_teammate",
+    ...overrides,
+  };
+}
+
+describe("TeammateSpinnerTree coverage swarm row 024", () => {
+  beforeEach(() => {
+    harness.state = {
+      showTeammateMessagePreview: false,
+      tasks: {
+        worker: makeTeammateTask({ agentName: "Worker", id: "worker" }),
+      },
+      viewingAgentTaskId: "worker",
+    };
+  });
+
+  test("renders a backgrounded leader action without selection controls", async () => {
+    const output = await renderToString(
+      <TeammateSpinnerTree leaderTokenCount={1500} leaderVerb="coordinating" />,
+      120,
+    );
+
+    expect(output).toContain("team-lead: coordinating");
+    expect(output).toContain("1.5k tokens");
+    expect(output).toContain("@Worker");
+    expect(output).not.toContain("hide");
+    expect(output).not.toContain("enter to collapse");
+  });
+
+  test("renders backgrounded leader idle text and omits nonpositive token counts", async () => {
+    const output = await renderToString(
+      <TeammateSpinnerTree leaderIdleText="Idle for 9s" leaderTokenCount={0} />,
+      120,
+    );
+
+    expect(output).toContain("team-lead: Idle for 9s");
+    expect(output).not.toContain("0 tokens");
+    expect(output).not.toContain("hide");
+  });
+
+  test("renders the selected hide row when selection moves past teammates", async () => {
+    const output = await renderToString(
+      <TeammateSpinnerTree isInSelectionMode selectedIndex={1} />,
+      120,
+    );
+
+    expect(output).toContain("team-lead");
+    expect(output).toContain("hide");
+    expect(output).toContain("enter to collapse");
+    expect(output).not.toContain("enter to view");
+  });
+
+  test("renders the selected background leader while hide stays unselected", async () => {
+    const output = await renderToString(
+      <TeammateSpinnerTree
+        isInSelectionMode
+        leaderVerb="reviewing"
+        selectedIndex={-1}
+      />,
+      120,
+    );
+
+    expect(output).toContain("team-lead: reviewing");
+    expect(output).toContain("enter to view");
+    expect(output).toContain("hide");
+    expect(output).not.toContain("enter to collapse");
+  });
+
+  test("renders nothing when teammate records are not running", async () => {
+    harness.state.tasks = {
+      completed: makeTeammateTask({
+        agentName: "Completed",
+        id: "completed",
+        status: "completed",
+      }),
+      killed: makeTeammateTask({
+        agentName: "Killed",
+        id: "killed",
+        status: "killed",
+      }),
+    };
+
+    const output = await renderToString(<TeammateSpinnerTree />, 120);
+
+    expect(output.trim()).toBe("");
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-025-message-renderers-AttachmentMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-025-message-renderers-AttachmentMessage.test.tsx
@@ -1,0 +1,201 @@
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { renderToString } from "../../utils/staticRender.js";
+import { AttachmentMessage } from "../message-renderers/AttachmentMessage.js";
+
+const swarmsMock = vi.hoisted(() => ({
+  enabled: false,
+}));
+
+const appStateMock = vi.hoisted(() => ({
+  tasks: {} as Record<string, unknown>,
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: () => false,
+}));
+
+vi.mock("../../utils/agentSwarmsEnabled.js", () => ({
+  isAgentSwarmsEnabled: () => swarmsMock.enabled,
+}));
+
+vi.mock("../state/AppState.js", () => ({
+  useAppState: (selector: (state: typeof appStateMock) => unknown) =>
+    selector(appStateMock),
+}));
+
+vi.mock("../components/messageActions", () => ({
+  useSelectedMessageBg: () => undefined,
+}));
+
+vi.mock("../components/CtrlOToExpand", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+  return {
+    CtrlOToExpand: () =>
+      ReactActual.createElement("ink-text", null, "ctrl-o"),
+  };
+});
+
+vi.mock("../components/MessageResponse", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+  return {
+    MessageResponse: ({ children }: { children: React.ReactNode }) =>
+      ReactActual.createElement(ReactActual.Fragment, null, children),
+  };
+});
+
+vi.mock("../components/design-system/FullWidthRow", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+  return {
+    default: ({ children }: { children: React.ReactNode }) =>
+      ReactActual.createElement(ReactActual.Fragment, null, children),
+  };
+});
+
+vi.mock("../message-renderers/UserTextMessage", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+  return {
+    UserTextMessage: ({ param }: { param: { text: string } }) =>
+      ReactActual.createElement("ink-text", null, `queued: ${param.text}`),
+  };
+});
+
+vi.mock("../components/v2/messagePrimitives.js", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+  return {
+    UserImageMessage: ({ imageId }: { imageId: number }) =>
+      ReactActual.createElement("ink-text", null, `image ${imageId}`),
+  };
+});
+
+async function renderAttachment(
+  attachment: unknown,
+  options: {
+    isTranscriptMode?: boolean;
+    verbose?: boolean;
+  } = {},
+): Promise<string> {
+  return renderToString(
+    <AttachmentMessage
+      addMargin={false}
+      attachment={attachment as never}
+      isTranscriptMode={options.isTranscriptMode}
+      verbose={options.verbose ?? false}
+    />,
+    { columns: 120 },
+  );
+}
+
+describe("AttachmentMessage coverage swarm 025", () => {
+  beforeEach(() => {
+    swarmsMock.enabled = false;
+    appStateMock.tasks = {};
+  });
+
+  test("renders lesser-used visible attachment summaries", async () => {
+    await expect(
+      renderAttachment({
+        content: {
+          file: { originalSize: 1536 },
+          type: "binary",
+        },
+        displayPath: "assets/logo.bin",
+        type: "file",
+      }),
+    ).resolves.toContain("Read assets/logo.bin (1.5KB)");
+
+    const memories = await renderAttachment({
+      memories: [{ content: "hidden unless verbose", path: "/repo/NOTES.md" }],
+      type: "relevant_memories",
+    });
+    expect(memories).toContain("Recalled 1 memory");
+    expect(memories).not.toContain("hidden unless verbose");
+
+    await expect(
+      renderAttachment({
+        prompt: [
+          { text: "first line", type: "text" },
+          { source: { media_type: "image/png", type: "base64" }, type: "image" },
+          { text: "second line", type: "text" },
+        ],
+        type: "queued_command",
+      }),
+    ).resolves.toContain("queued: first line\nsecond line");
+
+    await expect(
+      renderAttachment(
+        {
+          hookEvent: "PostToolUse",
+          type: "async_hook_response",
+        },
+        { isTranscriptMode: true },
+      ),
+    ).resolves.toContain("Async hook PostToolUse completed");
+
+    await expect(
+      renderAttachment({
+        decision: "allow",
+        hookEvent: "PreToolUse",
+        type: "hook_permission_decision",
+      }),
+    ).resolves.toContain("Allowed by PreToolUse hook");
+  });
+
+  test("keeps hidden hook branches silent and falls back to generic tasks", async () => {
+    const hiddenCases = [
+      { hookEvent: "PostToolUse", type: "async_hook_response" },
+      {
+        blockingError: { blockingError: "will be summarized elsewhere" },
+        hookEvent: "SubagentStop",
+        hookName: "cleanup",
+        type: "hook_blocking_error",
+      },
+      {
+        hookEvent: "SubagentStop",
+        hookName: "cleanup",
+        type: "hook_non_blocking_error",
+      },
+    ];
+
+    for (const attachment of hiddenCases) {
+      const output = await renderAttachment(attachment);
+      expect(output.trim()).toBe("");
+    }
+
+    await expect(
+      renderAttachment({
+        blockingError: { blockingError: "   " },
+        hookEvent: "PreToolUse",
+        hookName: "lint",
+        type: "hook_blocking_error",
+      }),
+    ).resolves.toContain("lint hook returned blocking error");
+
+    swarmsMock.enabled = true;
+    appStateMock.tasks = {
+      other: {
+        type: "local_agent",
+      },
+    };
+
+    await expect(
+      renderAttachment({
+        description: "cleanup",
+        status: "killed",
+        taskId: "other",
+        taskType: "in_process_teammate",
+        type: "task_status",
+      }),
+    ).resolves.toContain('Task "cleanup" stopped');
+
+    await expect(
+      renderAttachment({
+        description: "checkpoint",
+        status: "paused",
+        taskType: "local_agent",
+        type: "task_status",
+      }),
+    ).resolves.toContain('Task "checkpoint" paused');
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-026-ink-selection.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-026-ink-selection.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  createSelectionState,
+  findPlainTextUrlAt,
+  getSelectedText,
+  hasSelection,
+  selectLineAt,
+  shiftSelectionForFollow,
+} from '../ink/selection.ts'
+import {
+  CellWidth,
+  CharPool,
+  HyperlinkPool,
+  StylePool,
+  createScreen,
+  setCellAt,
+  type Screen,
+} from '../ink/screen.ts'
+
+function makeScreen(width: number, height: number): {
+  screen: Screen
+  styles: StylePool
+} {
+  const styles = new StylePool()
+  return {
+    screen: createScreen(
+      width,
+      height,
+      styles,
+      new CharPool(),
+      new HyperlinkPool(),
+    ),
+    styles,
+  }
+}
+
+function writeText(
+  screen: Screen,
+  styles: StylePool,
+  row: number,
+  text: string,
+): void {
+  for (let col = 0; col < text.length; col++) {
+    setCellAt(screen, col, row, {
+      char: text[col]!,
+      hyperlink: undefined,
+      styleId: styles.none,
+      width: CellWidth.Narrow,
+    })
+  }
+}
+
+describe('selection coverage swarm row 026', () => {
+  test('splits a plain-text URL run at the next scheme after the clicked URL', () => {
+    const row = 'urls https://first.test/ahttps://second.test/b'
+    const { screen, styles } = makeScreen(row.length, 1)
+    writeText(screen, styles, 0, row)
+
+    expect(findPlainTextUrlAt(screen, row.indexOf('first'), 0)).toBe(
+      'https://first.test/a',
+    )
+    expect(findPlainTextUrlAt(screen, row.indexOf('second'), 0)).toBe(
+      'https://second.test/b',
+    )
+  })
+
+  test('stops URL expansion at wide cells and still trims unbalanced closers', () => {
+    const prefix = 'https://first.test/path)'
+    const { screen, styles } = makeScreen(prefix.length + 2, 1)
+    writeText(screen, styles, 0, prefix)
+    setCellAt(screen, prefix.length, 0, {
+      char: '好',
+      hyperlink: undefined,
+      styleId: styles.none,
+      width: CellWidth.Wide,
+    })
+
+    expect(findPlainTextUrlAt(screen, prefix.indexOf('first'), 0)).toBe(
+      'https://first.test/path',
+    )
+  })
+
+  test('extracts selections across captured rows and skips wide-cell spacers', () => {
+    const { screen, styles } = makeScreen(5, 1)
+    writeText(screen, styles, 0, 'A   ')
+    setCellAt(screen, 1, 0, {
+      char: '好',
+      hyperlink: undefined,
+      styleId: styles.none,
+      width: CellWidth.Wide,
+    })
+    setCellAt(screen, 3, 0, {
+      char: 'B',
+      hyperlink: undefined,
+      styleId: styles.none,
+      width: CellWidth.Narrow,
+    })
+
+    const selection = createSelectionState()
+    selection.anchor = { col: 0, row: 0 }
+    selection.focus = { col: 4, row: 0 }
+    selection.scrolledOffAbove = ['top ', 'wrap']
+    selection.scrolledOffAboveSW = [false, true]
+    selection.scrolledOffBelow = [' tail', 'bottom']
+    selection.scrolledOffBelowSW = [true, false]
+
+    expect(getSelectedText(selection, screen)).toBe(
+      'top wrap\nA好B tail\nbottom',
+    )
+  })
+
+  test('line selection ignores out-of-bounds rows without disturbing state', () => {
+    const { screen } = makeScreen(4, 2)
+    const selection = createSelectionState()
+
+    selectLineAt(selection, screen, -1)
+    selectLineAt(selection, screen, 2)
+
+    expect(hasSelection(selection)).toBe(false)
+    expect(selection.isDragging).toBe(false)
+    expect(selection.anchorSpan).toBeNull()
+  })
+
+  test('follow scrolling tracks anchor-only selections through bottom clamps', () => {
+    const selection = createSelectionState()
+    selection.anchor = { col: 2, row: 2 }
+
+    expect(shiftSelectionForFollow(selection, 4, 0, 3)).toBe(false)
+
+    expect(selection.anchor).toEqual({ col: 2, row: 3 })
+    expect(selection.focus).toBeNull()
+    expect(selection.virtualAnchorRow).toBe(6)
+    expect(selection.virtualFocusRow).toBeUndefined()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-027-daemon-session.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-027-daemon-session.test.ts
@@ -1,0 +1,636 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createMcpUrlCompletionResponse } from "../../elicitation/url-completion.js";
+import type {
+  AgenCDaemonMethod,
+  AgenCDaemonResultByMethod,
+  JsonObject,
+} from "../../app-server/protocol/index.js";
+import {
+  attachDaemonAgentTuiSession,
+  createDaemonTuiSession,
+  type AgenCDaemonConnectionState,
+  type AgenCDaemonTuiClient,
+  type AgenCTuiBridgeSession,
+} from "../daemon-session.js";
+
+interface RecordedRequest {
+  readonly method: string;
+  readonly params?: JsonObject;
+  readonly signal?: AbortSignal;
+}
+
+interface TestClient extends AgenCDaemonTuiClient {
+  readonly requests: RecordedRequest[];
+  connectionState: AgenCDaemonConnectionState | null;
+  sessionSubscribeCount: number;
+  sessionUnsubscribeCount: number;
+  notificationSubscribeCount: number;
+  notificationUnsubscribeCount: number;
+  connectionSubscribeCount: number;
+  connectionUnsubscribeCount: number;
+  emit(sessionId: string, event: JsonObject): void;
+  emitNotification(event: JsonObject): void;
+  emitConnection(state: AgenCDaemonConnectionState): void;
+}
+
+function createBaseSession(
+  overrides: Partial<AgenCTuiBridgeSession> = {},
+): AgenCTuiBridgeSession {
+  const { services, ...rest } = overrides;
+  return {
+    conversationId: "local_session",
+    ...rest,
+    services: {
+      ...services,
+    },
+  };
+}
+
+function createClient(
+  requestImpl?: (
+    method: string,
+    params: JsonObject | undefined,
+    options: { readonly signal?: AbortSignal } | undefined,
+    requests: RecordedRequest[],
+  ) => Promise<unknown>,
+): TestClient {
+  const sessionListeners = new Map<string, Set<(event: JsonObject) => void>>();
+  const notificationListeners = new Set<(event: JsonObject) => void>();
+  const connectionListeners = new Set<
+    (state: AgenCDaemonConnectionState) => void
+  >();
+  const client = {
+    requests: [],
+    connectionState: null,
+    sessionSubscribeCount: 0,
+    sessionUnsubscribeCount: 0,
+    notificationSubscribeCount: 0,
+    notificationUnsubscribeCount: 0,
+    connectionSubscribeCount: 0,
+    connectionUnsubscribeCount: 0,
+    async request<Method extends AgenCDaemonMethod>(
+      method: Method,
+      params?: JsonObject,
+      options?: { readonly signal?: AbortSignal },
+    ): Promise<AgenCDaemonResultByMethod[Method]> {
+      const record: RecordedRequest = {
+        method,
+        ...(params !== undefined ? { params } : {}),
+        ...(options?.signal !== undefined ? { signal: options.signal } : {}),
+      };
+      this.requests.push(record);
+      if (requestImpl !== undefined) {
+        return await requestImpl(method, params, options, this.requests) as
+          AgenCDaemonResultByMethod[Method];
+      }
+      if (method === "agent.attach") {
+        return {
+          agentId: "agent_1",
+          attachmentId: "attach_1",
+          sessionIds: ["session_1"],
+          runtimeSessionId: "runtime_1",
+        } as AgenCDaemonResultByMethod[Method];
+      }
+      if (method === "session.snapshot") {
+        return {
+          sessionId: params?.sessionId,
+          events: [{ id: "event_1", type: "message" }],
+        } as AgenCDaemonResultByMethod[Method];
+      }
+      if (method === "session.mcp.addServer") {
+        const config = params?.config;
+        const name =
+          typeof config === "object" &&
+          config !== null &&
+          "name" in config &&
+          typeof config.name === "string"
+            ? config.name
+            : "server";
+        return {
+          serverName: name,
+          success: name !== "remote-failure",
+          toolCount: name === "remote-failure" ? 0 : 2,
+          ...(name === "remote-failure" ? { error: "remote rejected" } : {}),
+        } as AgenCDaemonResultByMethod[Method];
+      }
+      return {} as AgenCDaemonResultByMethod[Method];
+    },
+    subscribeToSessionEvents(sessionId: string, cb: (event: JsonObject) => void) {
+      this.sessionSubscribeCount += 1;
+      const listeners = sessionListeners.get(sessionId) ?? new Set();
+      listeners.add(cb);
+      sessionListeners.set(sessionId, listeners);
+      return () => {
+        this.sessionUnsubscribeCount += 1;
+        listeners.delete(cb);
+      };
+    },
+    subscribeToNotifications(cb: (event: JsonObject) => void) {
+      this.notificationSubscribeCount += 1;
+      notificationListeners.add(cb);
+      return () => {
+        this.notificationUnsubscribeCount += 1;
+        notificationListeners.delete(cb);
+      };
+    },
+    getConnectionState() {
+      return this.connectionState;
+    },
+    subscribeToConnectionState(cb: (state: AgenCDaemonConnectionState) => void) {
+      this.connectionSubscribeCount += 1;
+      connectionListeners.add(cb);
+      return () => {
+        this.connectionUnsubscribeCount += 1;
+        connectionListeners.delete(cb);
+      };
+    },
+    emit(sessionId: string, event: JsonObject) {
+      for (const listener of sessionListeners.get(sessionId) ?? []) {
+        listener(event);
+      }
+    },
+    emitNotification(event: JsonObject) {
+      for (const listener of notificationListeners) {
+        listener(event);
+      }
+    },
+    emitConnection(state: AgenCDaemonConnectionState) {
+      this.connectionState = state;
+      for (const listener of connectionListeners) {
+        listener(state);
+      }
+    },
+  } satisfies TestClient;
+  return client;
+}
+
+const flush = (): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
+describe("coverage swarm daemon session adapter", () => {
+  it("throws when an agent attachment has no daemon session and exposes snapshots", async () => {
+    const client = createClient(async (method) => {
+      if (method === "agent.attach") {
+        return {
+          agentId: "agent_empty",
+          attachmentId: "attach_empty",
+          sessionIds: [],
+        };
+      }
+      return {};
+    });
+
+    await expect(
+      attachDaemonAgentTuiSession({
+        baseSession: createBaseSession(),
+        client,
+        agentId: "agent_empty",
+        clientId: "tui_1",
+      }),
+    ).rejects.toThrow("daemon agent has no attached session: agent_empty");
+
+    const attached = createDaemonTuiSession({
+      baseSession: createBaseSession(),
+      client: createClient(),
+      sessionId: "session_1",
+      clientId: "tui_1",
+    });
+    await expect(attached.getDaemonSessionSnapshot?.()).resolves.toEqual({
+      sessionId: "session_1",
+      events: [{ id: "event_1", type: "message" }],
+    });
+  });
+
+  it("filters queued idle input and clears active turns when streaming fails", async () => {
+    const failedStream = new Error("stream failed");
+    const client = createClient(async (method) => {
+      if (method === "message.stream") throw failedStream;
+      return {};
+    });
+    const baseSession = createBaseSession({
+      activeTurn: {
+        unsafePeek: () => ({ turnId: "base_turn" }),
+      },
+    });
+    const session = createDaemonTuiSession({
+      baseSession,
+      client,
+      sessionId: "session_1",
+      clientId: "tui_1",
+    });
+
+    await session.submit("");
+    expect(client.requests).toEqual([]);
+    expect(session.enqueueIdleInput(42)).toBe(0);
+    expect(session.enqueueIdleInput({ content: { text: "not an array" } })).toBe(0);
+    expect(
+      session.enqueueIdleInput({
+        content: [
+          null,
+          { type: "text", text: 123 },
+          { type: "image_url", image_url: { path: "/tmp/no-url.png" } },
+          { type: "image_url", image_url: { url: "file:///tmp/ok.png" } },
+          { type: "text", text: "queued text" },
+        ],
+      }),
+    ).toBe(1);
+    expect(session.enqueueIdleInput("raw string")).toBe(2);
+
+    await expect(session.submit("typed text")).rejects.toBe(failedStream);
+    expect(session.activeTurn?.unsafePeek()).toEqual({ turnId: "base_turn" });
+    expect(client.requests).toEqual([
+      {
+        method: "message.stream",
+        params: {
+          sessionId: "session_1",
+          content: [
+            { type: "image_url", image_url: { url: "file:///tmp/ok.png" } },
+            { type: "text", text: "queued text" },
+            { type: "text", text: "raw string" },
+            { type: "text", text: "typed text" },
+          ],
+          streamId: expect.stringMatching(/^tui_1:/u),
+        },
+      },
+    ]);
+  });
+
+  it("returns daemon MCP addServer results across local mirror edge cases", async () => {
+    const nullManagerSession = createDaemonTuiSession({
+      baseSession: createBaseSession({
+        services: { mcpManager: null },
+      }),
+      client: createClient(),
+      sessionId: "session_1",
+      clientId: "tui_1",
+    });
+    expect(nullManagerSession.services.mcpManager).toBeNull();
+
+    const remoteOnlySession = createDaemonTuiSession({
+      baseSession: createBaseSession({
+        services: { mcpManager: { listServers: () => [] } },
+      }),
+      client: createClient(),
+      sessionId: "session_1",
+      clientId: "tui_1",
+    });
+    await expect(
+      (
+        remoteOnlySession.services.mcpManager as {
+          addServer(config: { readonly name: string }): Promise<unknown>;
+        }
+      ).addServer({ name: "remote-failure" }),
+    ).resolves.toEqual({
+      serverName: "remote-failure",
+      success: false,
+      toolCount: 0,
+      error: "remote rejected",
+    });
+
+    const alreadyConfiguredAddServer = vi.fn(async () => ({
+      serverName: "already-configured",
+      success: false,
+      toolCount: 0,
+      error: "Server already configured",
+    }));
+    const alreadyConfiguredSession = createDaemonTuiSession({
+      baseSession: createBaseSession({
+        services: { mcpManager: { addServer: alreadyConfiguredAddServer } },
+      }),
+      client: createClient(),
+      sessionId: "session_1",
+      clientId: "tui_1",
+    });
+    await expect(
+      (
+        alreadyConfiguredSession.services.mcpManager as {
+          addServer(config: { readonly name: string }): Promise<unknown>;
+        }
+      ).addServer({ name: "already-configured" }),
+    ).resolves.toEqual({
+      serverName: "already-configured",
+      success: true,
+      toolCount: 2,
+    });
+
+    const fatalLocalAddServer = vi.fn(async () => ({
+      serverName: "fatal-local",
+      success: false,
+      toolCount: 0,
+      error: "local validation failed",
+    }));
+    const fatalLocalSession = createDaemonTuiSession({
+      baseSession: createBaseSession({
+        services: { mcpManager: { addServer: fatalLocalAddServer } },
+      }),
+      client: createClient(),
+      sessionId: "session_1",
+      clientId: "tui_1",
+    });
+    await expect(
+      (
+        fatalLocalSession.services.mcpManager as {
+          addServer(config: { readonly name: string }): Promise<unknown>;
+        }
+      ).addServer({ name: "fatal-local" }),
+    ).resolves.toEqual({
+      serverName: "fatal-local",
+      success: false,
+      toolCount: 0,
+      error: "local validation failed",
+    });
+  });
+
+  it("bridges resolver fallbacks for permissions and elicitations", async () => {
+    const client = createClient();
+    const approvalResolver = vi.fn(async (ctx) => {
+      expect(ctx.toolName).toBe("tool");
+      expect(ctx.turnId).toBe("call_session");
+      expect(ctx.retryReason).toBe("needs confirmation");
+      expect(ctx.invocation.payload.arguments).toBe(JSON.stringify({ ok: true }));
+      return { kind: "approved_for_session" as const };
+    });
+    const requestUserInputResolver = vi.fn(async (event) => {
+      expect(event.requestId).toBe("call_input");
+      expect(event.questions).toEqual([{ id: "choice" }]);
+      return { answers: { choice: { answers: ["Yes"] } } };
+    });
+    const mcpElicitationResolver = vi
+      .fn()
+      .mockResolvedValueOnce(createMcpUrlCompletionResponse())
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(new Error("resolver failed"));
+    const session = createDaemonTuiSession({
+      baseSession: createBaseSession({
+        services: {
+          approvalResolver: { request: approvalResolver },
+          requestUserInputResolver: { request: requestUserInputResolver },
+          mcpElicitationResolver: { request: mcpElicitationResolver },
+        },
+      }),
+      client,
+      sessionId: "session_1",
+      clientId: "tui_1",
+    });
+
+    const unsubscribe = session.subscribeToEvents(() => {});
+    client.emit("session_1", {
+      msg: {
+        type: "request_permissions",
+        payload: {
+          callId: "call_session",
+          input: { ok: true },
+          reason: "needs confirmation",
+        },
+      },
+    });
+    client.emit("session_1", {
+      msg: {
+        type: "request_user_input",
+        payload: {
+          callId: "call_input",
+          turnId: "turn_1",
+          questions: [{ id: "choice" }, "bad"],
+        },
+      },
+    });
+    client.emit("session_1", {
+      msg: {
+        type: "mcp_elicitation_request",
+        payload: {
+          serverName: "srv",
+          requestId: 7,
+          turnId: "turn_1",
+          request: { mode: "url" },
+        },
+      },
+    });
+    client.emit("session_1", {
+      msg: {
+        type: "mcp_elicitation_request",
+        payload: {
+          serverName: "srv",
+          requestId: "mcp_null",
+          turnId: "turn_1",
+          request: { mode: "form" },
+        },
+      },
+    });
+    client.emit("session_1", {
+      msg: {
+        type: "mcp_elicitation_request",
+        payload: {
+          serverName: "srv",
+          requestId: "mcp_throw",
+          turnId: "turn_1",
+          request: { mode: "form" },
+        },
+      },
+    });
+    await flush();
+    unsubscribe();
+
+    expect(client.requests).toHaveLength(4);
+    expect(client.requests).toEqual(expect.arrayContaining([
+      {
+        method: "tool.approve",
+        params: {
+          sessionId: "session_1",
+          requestId: "call_session",
+          scope: "session",
+        },
+      },
+      {
+        method: "elicitation.respond",
+        params: {
+          sessionId: "session_1",
+          requestId: "call_input",
+          kind: "request_user_input",
+          response: { answers: { choice: { answers: ["Yes"] } } },
+        },
+      },
+      {
+        method: "elicitation.respond",
+        params: {
+          sessionId: "session_1",
+          requestId: "mcp_null",
+          kind: "mcp",
+          serverName: "srv",
+          response: { action: "cancel" },
+        },
+      },
+      {
+        method: "elicitation.respond",
+        params: {
+          sessionId: "session_1",
+          requestId: "mcp_throw",
+          kind: "mcp",
+          serverName: "srv",
+          response: { action: "cancel" },
+        },
+      },
+    ]));
+  });
+
+  it("denies permission requests when the approval resolver throws", async () => {
+    const client = createClient();
+    const session = createDaemonTuiSession({
+      baseSession: createBaseSession({
+        services: {
+          approvalResolver: {
+            request: async () => {
+              throw new Error("approval failed");
+            },
+          },
+        },
+      }),
+      client,
+      sessionId: "session_1",
+      clientId: "tui_1",
+    });
+
+    session.subscribeToEvents(() => {});
+    client.emit("session_1", {
+      msg: {
+        type: "request_permissions",
+        payload: { callId: "call_denied" },
+      },
+    });
+    await flush();
+
+    expect(client.requests).toEqual([
+      {
+        method: "tool.deny",
+        params: {
+          sessionId: "session_1",
+          requestId: "call_denied",
+          reason: "denied",
+        },
+      },
+    ]);
+  });
+
+  it("subscribes once, tears down after the last listener, and maps notices", () => {
+    const client = createClient();
+    client.connectionState = {
+      status: "reconnecting",
+      id: "custom-reconnect",
+      message: "custom reconnecting",
+    };
+    const session = createDaemonTuiSession({
+      baseSession: createBaseSession({
+        initialTranscriptEvents: [{ id: "unused", type: "initial" }],
+        getInitialTranscriptEvents: () => [{ id: "method", type: "initial" }],
+      }),
+      client,
+      sessionId: "session_1",
+      clientId: "tui_1",
+    });
+    const firstEvents: JsonObject[] = [];
+    const secondEvents: JsonObject[] = [];
+
+    expect(session.getInitialTranscriptEvents()).toEqual([
+      { id: "method", type: "initial" },
+      {
+        id: "custom-reconnect",
+        type: "warning",
+        payload: {
+          message: "custom reconnecting",
+          cause: "daemon_connection_state",
+          status: "reconnecting",
+        },
+      },
+    ]);
+
+    const unsubscribeFirst = session.subscribeToEvents((event) => {
+      firstEvents.push(event as JsonObject);
+    });
+    const unsubscribeSecond = session.subscribeToEvents((event) => {
+      secondEvents.push(event as JsonObject);
+    });
+    expect(client.sessionSubscribeCount).toBe(1);
+    expect(client.notificationSubscribeCount).toBe(1);
+    expect(client.connectionSubscribeCount).toBe(1);
+
+    client.emitConnection({ status: "connected" });
+    client.emit("session_1", { method: 123, params: { ok: true } });
+    client.emit("session_1", {
+      method: "event.permission_request",
+      params: {
+        requestId: "call_1",
+        permissions: ["tool.use", 5, "tool.admin"],
+      },
+    });
+    client.emit("session_1", {
+      msg: {
+        type: "background_agent_status",
+        payload: {
+          eventId: "",
+          status: "running",
+        },
+      },
+    });
+    expect(session.activeTurn?.unsafePeek()).toEqual({ turnId: "daemon-turn" });
+
+    client.emit("session_1", {
+      method: "event.agent_status",
+      params: {
+        eventId: "",
+        status: "running",
+      },
+    });
+
+    unsubscribeFirst();
+    expect(client.sessionUnsubscribeCount).toBe(0);
+    client.emit("session_1", {
+      method: "event.agent_status",
+      params: {
+        turnId: "turn_done",
+        status: "completed",
+      },
+    });
+    expect(session.activeTurn?.unsafePeek()).toBeNull();
+    unsubscribeSecond();
+
+    expect(client.sessionUnsubscribeCount).toBe(1);
+    expect(client.notificationUnsubscribeCount).toBe(1);
+    expect(client.connectionUnsubscribeCount).toBe(1);
+    expect(firstEvents).toEqual([
+      { method: 123, params: { ok: true } },
+      {
+        id: "permission-request:call_1",
+        type: "request_permissions",
+        payload: {
+          callId: "call_1",
+          permissions: ["tool.use", "tool.admin"],
+        },
+      },
+      {
+        type: "background_agent_status",
+        payload: {
+          eventId: "",
+          status: "running",
+        },
+      },
+      {
+        id: "status",
+        type: "background_agent_status",
+        payload: {
+          turnId: "status",
+          status: "running",
+        },
+      },
+    ]);
+    expect(secondEvents.at(-1)).toEqual({
+      id: "turn_done",
+      type: "background_agent_status",
+      payload: {
+        turnId: "turn_done",
+        status: "completed",
+      },
+    });
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-028-components-tasks-BackgroundTaskStatus.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-028-components-tasks-BackgroundTaskStatus.test.tsx
@@ -1,0 +1,353 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import type { DOMElement, DOMNode } from '../ink/dom.js'
+import instances from '../ink/instances.js'
+import { createRoot } from '../ink/root.js'
+
+const appStateMock = vi.hoisted(() => ({
+  state: {
+    expandedView: undefined as string | undefined,
+    tasks: {} as Record<string, unknown>,
+    viewingAgentTaskId: undefined as string | undefined,
+  },
+  setAppState: vi.fn(),
+}))
+
+const terminalSizeMock = vi.hoisted(() => ({
+  size: { columns: 80, rows: 24 },
+}))
+
+const teammateViewMock = vi.hoisted(() => ({
+  enterTeammateView: vi.fn(),
+  exitTeammateView: vi.fn(),
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppState: (selector: (state: typeof appStateMock.state) => unknown) =>
+    selector(appStateMock.state),
+  useSetAppState: () => appStateMock.setAppState,
+}))
+
+vi.mock('../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => terminalSizeMock.size,
+}))
+
+vi.mock('../state/teammateViewHelpers.js', () => teammateViewMock)
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+const originalGlyphMode = process.env.AGENC_TUI_GLYPHS
+
+function shellTask(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    type: 'local_bash',
+    status: 'running',
+    description: id,
+    startTime: 10,
+    outputFile: `urn:agenc:task:${id}:output`,
+    outputOffset: 0,
+    notified: false,
+    command: `npm run ${id}`,
+    kind: 'bash',
+    ...overrides,
+  }
+}
+
+function teammateTask(
+  id: string,
+  agentName: string,
+  options: { color?: string; isIdle?: boolean } = {},
+) {
+  return {
+    id,
+    type: 'in_process_teammate',
+    status: 'running',
+    description: agentName,
+    startTime: 10,
+    outputFile: `urn:agenc:task:${id}:output`,
+    outputOffset: 0,
+    notified: false,
+    identity: {
+      agentId: id,
+      agentName,
+      teamName: 'team',
+      color: options.color,
+      planModeRequired: false,
+      parentSessionId: 'parent',
+    },
+    prompt: 'help',
+    awaitingPlanApproval: false,
+    permissionMode: 'default',
+    pendingUserMessages: [],
+    isIdle: options.isIdle ?? false,
+    shutdownRequested: false,
+    lastReportedToolCount: 0,
+    lastReportedTokenCount: 0,
+  }
+}
+
+function createStreams(): { stdin: TestStdin; stdout: PassThrough } {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough()
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.on('data', () => {})
+  ;(stdout as unknown as { columns: number }).columns = 120
+  ;(stdout as unknown as { rows: number }).rows = 24
+  ;(stdout as unknown as { isTTY: boolean }).isTTY = true
+
+  return { stdin, stdout }
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+  if (!instance?.rootNode) {
+    throw new Error('Ink root node not found')
+  }
+  return instance.rootNode
+}
+
+function collectText(node: DOMNode): string {
+  if (node.nodeName === '#text') return node.nodeValue
+  return node.childNodes.map(collectText).join('')
+}
+
+function findBoxByText(node: DOMNode, text: string): DOMElement | undefined {
+  if (
+    node.nodeName !== '#text' &&
+    node.nodeName === 'ink-box' &&
+    collectText(node).includes(text)
+  ) {
+    return node
+  }
+  if (node.nodeName === '#text') return undefined
+  for (const child of node.childNodes) {
+    const found = findBoxByText(child, text)
+    if (found) return found
+  }
+  return undefined
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForText(stdout: PassThrough, text: string): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < 2_000) {
+    if (collectText(getRootNode(stdout)).includes(text)) return
+    await sleep(10)
+  }
+  throw new Error(`Timed out waiting for ${text}`)
+}
+
+describe('BackgroundTaskStatus coverage swarm row 028', () => {
+  beforeEach(() => {
+    process.env.AGENC_TUI_GLYPHS = 'ascii'
+    appStateMock.state = {
+      expandedView: undefined,
+      tasks: {},
+      viewingAgentTaskId: undefined,
+    }
+    appStateMock.setAppState.mockClear()
+    teammateViewMock.enterTeammateView.mockClear()
+    teammateViewMock.exitTeammateView.mockClear()
+    terminalSizeMock.size = { columns: 80, rows: 24 }
+  })
+
+  afterEach(() => {
+    if (originalGlyphMode === undefined) {
+      delete process.env.AGENC_TUI_GLYPHS
+    } else {
+      process.env.AGENC_TUI_GLYPHS = originalGlyphMode
+    }
+  })
+
+  test('renders nothing when no visible footer task remains', async () => {
+    const { BackgroundTaskStatus } = await import(
+      '../components/tasks/BackgroundTaskStatus.js'
+    )
+
+    expect(
+      (
+        await renderToString(
+          <BackgroundTaskStatus tasksSelected={false} />,
+          80,
+        )
+      ).trim(),
+    ).toBe('')
+
+    appStateMock.state = {
+      expandedView: 'teammates',
+      viewingAgentTaskId: undefined,
+      tasks: {
+        alpha: teammateTask('alpha', 'alpha'),
+      },
+    }
+
+    expect(
+      (
+        await renderToString(
+          <BackgroundTaskStatus tasksSelected={false} />,
+          80,
+        )
+      ).trim(),
+    ).toBe('')
+  })
+
+  test('uses the compact summary when spinner tree has mixed task types', async () => {
+    appStateMock.state = {
+      expandedView: 'teammates',
+      viewingAgentTaskId: undefined,
+      tasks: {
+        shell: shellTask('shell'),
+        alpha: teammateTask('alpha', 'alpha'),
+      },
+    }
+
+    const { BackgroundTaskStatus } = await import(
+      '../components/tasks/BackgroundTaskStatus.js'
+    )
+    const output = await renderToString(
+      <BackgroundTaskStatus tasksSelected={true} />,
+      80,
+    )
+
+    expect(output).toContain('2 background tasks')
+    expect(output).not.toContain('@alpha')
+    expect(output).not.toContain('to view')
+  })
+
+  test('renders teammate pill states and routes teammate clicks', async () => {
+    process.env.AGENC_TUI_GLYPHS = 'unicode'
+    terminalSizeMock.size = { columns: 120, rows: 24 }
+    appStateMock.state = {
+      expandedView: undefined,
+      viewingAgentTaskId: 'viewed',
+      tasks: {
+        idle: teammateTask('idle', 'aaa-idle', { isIdle: true }),
+        viewed: teammateTask('viewed', 'bbb-viewed', { color: 'red' }),
+        plain: teammateTask('plain', 'ccc-plain'),
+        colored: teammateTask('colored', 'ddd-colored', { color: 'cyan' }),
+        selected: teammateTask('selected', 'zzz-selected', {
+          color: 'not-a-theme-color',
+        }),
+      },
+    }
+
+    const { BackgroundTaskStatus } = await import(
+      '../components/tasks/BackgroundTaskStatus.js'
+    )
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      root.render(
+        <BackgroundTaskStatus tasksSelected={true} teammateFooterIndex={5} />,
+      )
+      await waitForText(stdout, '@zzz-selected')
+
+      const rootNode = getRootNode(stdout)
+      const text = collectText(rootNode)
+      expect(text).toContain('@main')
+      expect(text).toContain('@aaa-idle')
+      expect(text).toContain('@bbb-viewed')
+      expect(text).toContain('@ccc-plain')
+      expect(text).toContain('@ddd-colored')
+      expect(text).toContain('@zzz-selected')
+      expect(text).toContain('to expand')
+
+      const mainBox = findBoxByText(rootNode, '@main')
+      const selectedBox = findBoxByText(rootNode, '@zzz-selected')
+      expect(mainBox?._eventHandlers?.onClick).toBeTypeOf('function')
+      expect(selectedBox?._eventHandlers?.onClick).toBeTypeOf('function')
+
+      ;(selectedBox?._eventHandlers?.onMouseEnter as
+        | (() => void)
+        | undefined)?.()
+      await sleep()
+      ;(selectedBox?._eventHandlers?.onMouseLeave as
+        | (() => void)
+        | undefined)?.()
+      ;(selectedBox?._eventHandlers?.onClick as (() => void) | undefined)?.()
+      expect(teammateViewMock.enterTeammateView).toHaveBeenCalledWith(
+        'selected',
+        appStateMock.setAppState,
+      )
+
+      ;(mainBox?._eventHandlers?.onClick as (() => void) | undefined)?.()
+      expect(teammateViewMock.exitTeammateView).toHaveBeenCalledWith(
+        appStateMock.setAppState,
+      )
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+
+  test('wires compact summary pill hover and click handlers', async () => {
+    appStateMock.state = {
+      expandedView: undefined,
+      viewingAgentTaskId: undefined,
+      tasks: {
+        shell: shellTask('shell'),
+      },
+    }
+    const onOpenDialog = vi.fn()
+    const { BackgroundTaskStatus } = await import(
+      '../components/tasks/BackgroundTaskStatus.js'
+    )
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      root.render(
+        <BackgroundTaskStatus
+          tasksSelected={false}
+          onOpenDialog={onOpenDialog}
+        />,
+      )
+      await waitForText(stdout, '1 shell')
+
+      const summaryBox = findBoxByText(getRootNode(stdout), '1 shell')
+      expect(summaryBox?._eventHandlers?.onClick).toBeTypeOf('function')
+      ;(summaryBox?._eventHandlers?.onMouseEnter as
+        | (() => void)
+        | undefined)?.()
+      await sleep()
+      ;(summaryBox?._eventHandlers?.onMouseLeave as
+        | (() => void)
+        | undefined)?.()
+      ;(summaryBox?._eventHandlers?.onClick as (() => void) | undefined)?.()
+      expect(onOpenDialog).toHaveBeenCalledTimes(1)
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-029-message-renderers-CollapsedReadSearchContent.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-029-message-renderers-CollapsedReadSearchContent.test.tsx
@@ -1,0 +1,495 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from 'src/utils/staticRender.js'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('src/tui/hooks/useMinDisplayTime.js', () => ({
+  useMinDisplayTime: (value: string | undefined) => value,
+}))
+
+vi.mock('src/tui/glyphs.js', () => ({
+  selectAgenCTuiGlyphs: () => ({
+    ellipsis: '...',
+    responseGutter: '>',
+    separator: '*',
+  }),
+}))
+
+vi.mock('src/tools/Tool.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('src/tools/Tool.js')>()
+  return {
+    ...actual,
+    findToolByName: (tools: Array<{ name: string }> | undefined, name: string) =>
+      tools?.find(tool => tool.name === name),
+  }
+})
+
+vi.mock('src/tools/REPLTool/primitiveTools.js', () => ({
+  getReplPrimitiveTools: () => [],
+}))
+
+vi.mock('src/utils/collapseReadSearch.js', () => ({
+  getToolUseIdsFromCollapsedGroup: (message: { toolUseIDs?: string[] }) =>
+    message.toolUseIDs ?? [],
+}))
+
+vi.mock('src/utils/file.js', () => ({
+  getDisplayPath: (path: string) => `display:${path}`,
+}))
+
+vi.mock('src/utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => true,
+}))
+
+vi.mock('src/tui/components/CtrlOToExpand.js', () => ({
+  CtrlOToExpand: () => <>expand</>,
+}))
+
+vi.mock('src/tui/components/messageActions.js', () => ({
+  useSelectedMessageBg: () => undefined,
+}))
+
+vi.mock('src/tui/components/PrBadge.js', () => ({
+  PrBadge: ({ number }: { readonly number: number }) => (
+    <>{`PR #${number}`}</>
+  ),
+}))
+
+vi.mock('src/tui/components/ToolUseLoader.js', () => ({
+  ToolUseLoader: ({
+    isError,
+    isUnresolved,
+    shouldAnimate,
+  }: {
+    readonly isError?: boolean
+    readonly isUnresolved?: boolean
+    readonly shouldAnimate?: boolean
+  }) => (
+    <>
+      {`loader:${isUnresolved ? 'unresolved' : 'resolved'}:${
+        isError ? 'error' : 'ok'
+      }:${shouldAnimate ? 'animated' : 'still'}`}
+    </>
+  ),
+}))
+
+vi.mock('src/tui/ink.js', async () => {
+  const actual = await vi.importActual<typeof import('src/tui/ink.js')>(
+    'src/tui/ink.js',
+  )
+  return {
+    ...actual,
+    useTheme: () => ['dark'],
+  }
+})
+
+import { CollapsedReadSearchContent } from 'src/tui/message-renderers/CollapsedReadSearchContent.js'
+
+function baseLookups(overrides: Record<string, unknown> = {}) {
+  return {
+    erroredToolUseIDs: new Set<string>(),
+    progressMessagesByToolUseID: new Map(),
+    resolvedToolUseIDs: new Set<string>(),
+    toolResultByToolUseID: new Map(),
+    ...overrides,
+  } as never
+}
+
+function baseMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    bashCount: 0,
+    gitOpBashCount: 0,
+    listCount: 0,
+    mcpCallCount: 0,
+    memoryReadCount: 0,
+    memorySearchCount: 0,
+    memoryWriteCount: 0,
+    messages: [],
+    readCount: 0,
+    replCount: 0,
+    searchCount: 0,
+    toolUseIDs: [],
+    ...overrides,
+  } as never
+}
+
+async function renderCollapsed(
+  message: ReturnType<typeof baseMessage>,
+  options: {
+    readonly inProgressToolUseIDs?: Set<string>
+    readonly isActiveGroup?: boolean
+    readonly lookups?: ReturnType<typeof baseLookups>
+    readonly shouldAnimate?: boolean
+    readonly tools?: unknown[]
+    readonly verbose?: boolean
+  } = {},
+): Promise<string> {
+  return renderToString(
+    <CollapsedReadSearchContent
+      inProgressToolUseIDs={options.inProgressToolUseIDs ?? new Set()}
+      isActiveGroup={options.isActiveGroup}
+      lookups={options.lookups ?? baseLookups()}
+      message={message}
+      shouldAnimate={options.shouldAnimate ?? false}
+      tools={(options.tools ?? []) as never}
+      verbose={options.verbose ?? false}
+    />,
+    120,
+  )
+}
+
+describe('CollapsedReadSearchContent swarm row 029 coverage', () => {
+  test('uses active REPL fallback hints and the slowest shell progress details', async () => {
+    const progressMessagesByToolUseID = new Map([
+      [
+        'skipped',
+        [
+          {
+            data: {
+              elapsedTimeSeconds: 10,
+              totalLines: 99,
+              type: 'bash_progress',
+            },
+          },
+        ],
+      ],
+      [
+        'pattern',
+        [
+          {
+            data: {
+              phase: 'start',
+              toolInput: { pattern: 'live-pattern' },
+              toolName: 'Search',
+              type: 'repl_tool_call',
+            },
+          },
+        ],
+      ],
+      [
+        'command',
+        [
+          {
+            data: {
+              phase: 'start',
+              toolInput: { command: 'node fallback.js' },
+              toolName: 'Bash',
+              type: 'repl_tool_call',
+            },
+          },
+        ],
+      ],
+      [
+        'tool-name',
+        [
+          {
+            data: {
+              phase: 'start',
+              toolInput: {},
+              toolName: 'FallbackTool',
+              type: 'repl_tool_call',
+            },
+          },
+        ],
+      ],
+      [
+        'ignored',
+        [
+          {
+            data: {
+              type: 'other_progress',
+            },
+          },
+        ],
+      ],
+      [
+        'slow',
+        [
+          {
+            data: {
+              elapsedTimeSeconds: 2,
+              totalLines: 1,
+              type: 'bash_progress',
+            },
+          },
+        ],
+      ],
+      [
+        'faster',
+        [
+          {
+            data: {
+              elapsedTimeSeconds: 4,
+              totalLines: 3,
+              type: 'powershell_progress',
+            },
+          },
+        ],
+      ],
+    ])
+
+    const output = await renderCollapsed(
+      baseMessage({
+        bashCount: 1,
+        searchCount: 1,
+        toolUseIDs: [
+          'skipped',
+          'pattern',
+          'command',
+          'tool-name',
+          'ignored',
+          'slow',
+          'faster',
+        ],
+      }),
+      {
+        inProgressToolUseIDs: new Set([
+          'pattern',
+          'command',
+          'tool-name',
+          'ignored',
+          'slow',
+          'faster',
+        ]),
+        isActiveGroup: true,
+        lookups: baseLookups({
+          erroredToolUseIDs: new Set(['faster']),
+          progressMessagesByToolUseID,
+        }),
+      },
+    )
+
+    expect(output).toContain('Searching for 1 pattern')
+    expect(output).toContain('running 1 bash command')
+    expect(output).toContain('FallbackTool')
+    expect(output).toContain('4s')
+    expect(output).toContain('3 lines')
+    expect(output).not.toContain('99 lines')
+  })
+
+  test('renders finalized git, PR, MCP, list, read, and REPL variants', async () => {
+    const output = await renderCollapsed(
+      baseMessage({
+        bashCount: undefined,
+        commits: [
+          { kind: 'amended', sha: 'def456' },
+          { kind: 'cherry-picked', sha: 'fedcba' },
+        ],
+        gitOpBashCount: undefined,
+        listCount: 1,
+        mcpCallCount: 1,
+        mcpServerNames: undefined,
+        prs: [{ action: 'ready', number: 12 }],
+        readCount: 1,
+        replCount: 1,
+      }),
+    )
+
+    expect(output).toContain('Amended commit def456')
+    expect(output).toContain('cherry-picked fedcba')
+    expect(output).toContain('marked ready PR #12')
+    expect(output).toContain('read 1 file')
+    expect(output).toContain('listed 1 directory')
+    expect(output).toContain("REPL'd 1 time")
+    expect(output).toContain('queried MCP')
+  })
+
+  test('renders memory-only summaries with first and following verbs', async () => {
+    const finalized = await renderCollapsed(
+      baseMessage({
+        bashCount: undefined,
+        gitOpBashCount: undefined,
+        mcpCallCount: undefined,
+        memoryReadCount: 2,
+        memorySearchCount: 1,
+        memoryWriteCount: 1,
+      }),
+    )
+    const activeSearch = await renderCollapsed(
+      baseMessage({
+        memorySearchCount: 1,
+      }),
+      { isActiveGroup: true },
+    )
+    const activeWrite = await renderCollapsed(
+      baseMessage({
+        memoryWriteCount: 2,
+      }),
+      { isActiveGroup: true },
+    )
+
+    expect(finalized).toContain('Recalled 2 memories')
+    expect(finalized).toContain('searched memories')
+    expect(finalized).toContain('wrote 1 memory')
+    expect(activeSearch).toContain('Searching memories')
+    expect(activeWrite).toContain('Writing 2 memories')
+  })
+
+  test('renders multiline active hints and shell timing without line counts', async () => {
+    const output = await renderCollapsed(
+      baseMessage({
+        bashCount: 1,
+        latestDisplayHint: 'first line\nsecond line',
+        toolUseIDs: ['bash'],
+      }),
+      {
+        inProgressToolUseIDs: new Set(['bash']),
+        isActiveGroup: true,
+        lookups: baseLookups({
+          progressMessagesByToolUseID: new Map([
+            [
+              'bash',
+              [
+                {
+                  data: {
+                    elapsedTimeSeconds: 2,
+                    totalLines: 0,
+                    type: 'bash_progress',
+                  },
+                },
+              ],
+            ],
+          ]),
+        }),
+      },
+    )
+
+    expect(output).toContain('Running 1 bash command')
+    expect(output).toContain('first line')
+    expect(output).toContain('second line')
+    expect(output).toContain('2s')
+  })
+
+  test('uses search arguments as the active hint when no read path is present', async () => {
+    const output = await renderCollapsed(
+      baseMessage({
+        searchArgs: ['needle'],
+        searchCount: 1,
+      }),
+      { isActiveGroup: true },
+    )
+
+    expect(output).toContain('Searching for 1 pattern')
+    expect(output).toContain('"needle"')
+  })
+
+  test('renders verbose tool uses with missing tools and parser failures', async () => {
+    const invalidInputMessage = vi.fn(() => 'should not render')
+    const parsedFailResult = vi.fn(() => <>result should not render</>)
+    const tools = [
+      {
+        inputSchema: {
+          safeParse: () => ({ success: false }),
+        },
+        name: 'InvalidInputTool',
+        renderToolUseMessage: invalidInputMessage,
+        userFacingName: (input: unknown) =>
+          input === undefined ? 'Invalid input tool' : 'Unexpected input',
+      },
+      {
+        inputSchema: {
+          safeParse: (input: unknown) => ({ data: input, success: true }),
+        },
+        name: 'ParsedFailTool',
+        outputSchema: {
+          safeParse: () => ({ success: false }),
+        },
+        renderToolResultMessage: parsedFailResult,
+        renderToolUseMessage: (input: { value: string }) => `input:${input.value}`,
+        userFacingName: () => 'Parsed fail tool',
+      },
+      {
+        inputSchema: {
+          safeParse: (input: unknown) => ({ data: input, success: true }),
+        },
+        name: 'ErroredTool',
+        renderToolUseMessage: () => 'running',
+        userFacingName: () => 'Errored tool',
+      },
+    ]
+
+    const output = await renderCollapsed(
+      baseMessage({
+        messages: [
+          {
+            message: {
+              content: [
+                {
+                  id: 'missing',
+                  input: {},
+                  name: 'MissingTool',
+                  type: 'tool_use',
+                },
+              ],
+            },
+            type: 'assistant',
+          },
+          {
+            message: {
+              content: [
+                {
+                  id: 'invalid-input',
+                  input: { value: 'bad' },
+                  name: 'InvalidInputTool',
+                  type: 'tool_use',
+                },
+              ],
+            },
+            type: 'assistant',
+          },
+          {
+            message: {
+              content: [
+                {
+                  id: 'parsed-fail',
+                  input: { value: 'ok' },
+                  name: 'ParsedFailTool',
+                  type: 'tool_use',
+                },
+              ],
+            },
+            type: 'assistant',
+          },
+          {
+            message: {
+              content: [
+                {
+                  id: 'errored',
+                  input: { value: 'boom' },
+                  name: 'ErroredTool',
+                  type: 'tool_use',
+                },
+              ],
+            },
+            type: 'assistant',
+          },
+        ],
+      }),
+      {
+        inProgressToolUseIDs: new Set(['errored']),
+        lookups: baseLookups({
+          erroredToolUseIDs: new Set(['errored']),
+          resolvedToolUseIDs: new Set(['parsed-fail']),
+          toolResultByToolUseID: new Map([
+            ['parsed-fail', { toolUseResult: { value: 'ignored' }, type: 'user' }],
+          ]),
+        }),
+        shouldAnimate: true,
+        tools,
+        verbose: true,
+      },
+    )
+
+    expect(output).not.toContain('MissingTool')
+    expect(output).toContain('Invalid input tool')
+    expect(output).toContain('Parsed fail tool')
+    expect(output).toContain('input:ok')
+    expect(output).toContain('Errored tool')
+    expect(invalidInputMessage).not.toHaveBeenCalled()
+    expect(parsedFailResult).not.toHaveBeenCalled()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-030-vim-operators.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-030-vim-operators.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, test } from 'vitest'
+
+import { TextCursor } from 'src/utils/TextCursor.js'
+import {
+  executeIndent,
+  executeJoin,
+  executeLineOp,
+  executeOperatorFind,
+  executeOperatorMotion,
+  executeOperatorTextObj,
+  executePaste,
+  executeX,
+  type OperatorContext,
+} from 'src/tui/vim/operators.js'
+import type { FindType, RecordedChange } from 'src/tui/vim/types.js'
+
+function makeContext(initialText: string, initialOffset = 0): {
+  ctx: OperatorContext
+  state: {
+    text: string
+    offset: number
+    register: string
+    linewise: boolean
+    lastFind: { type: FindType; char: string } | null
+    changes: RecordedChange[]
+    enteredInsertAt: number | null
+  }
+} {
+  const state = {
+    text: initialText,
+    offset: initialOffset,
+    register: '',
+    linewise: false,
+    lastFind: null as { type: FindType; char: string } | null,
+    changes: [] as RecordedChange[],
+    enteredInsertAt: null as number | null,
+  }
+
+  const ctx: OperatorContext = {
+    get cursor() {
+      return TextCursor.fromText(state.text, 80, state.offset)
+    },
+    get text() {
+      return state.text
+    },
+    setText: text => {
+      state.text = text
+    },
+    setOffset: offset => {
+      state.offset = offset
+    },
+    enterInsert: offset => {
+      state.enteredInsertAt = offset
+      state.offset = offset
+    },
+    getRegister: () => state.register,
+    setRegister: (content, linewise) => {
+      state.register = content
+      state.linewise = linewise
+    },
+    getLastFind: () => state.lastFind,
+    setLastFind: (type, char) => {
+      state.lastFind = { type, char }
+    },
+    recordChange: change => {
+      state.changes.push(change)
+    },
+  }
+
+  return { ctx, state }
+}
+
+describe('vim operator coverage swarm row 030', () => {
+  test('leaves state untouched when operator targets are missing', () => {
+    const sameCursorMotion = makeContext('abc')
+    const stableCursor = TextCursor.fromText(
+      sameCursorMotion.state.text,
+      80,
+      sameCursorMotion.state.offset,
+    )
+
+    executeOperatorMotion('delete', 'unknown-motion', 1, {
+      ...sameCursorMotion.ctx,
+      cursor: stableCursor,
+    })
+
+    expect(sameCursorMotion.state.text).toBe('abc')
+    expect(sameCursorMotion.state.register).toBe('')
+    expect(sameCursorMotion.state.changes).toEqual([])
+
+    const missingFind = makeContext('abc')
+    executeOperatorFind('delete', 'f', 'z', 1, missingFind.ctx)
+
+    expect(missingFind.state.text).toBe('abc')
+    expect(missingFind.state.lastFind).toBeNull()
+    expect(missingFind.state.changes).toEqual([])
+
+    const missingTextObject = makeContext('plain text')
+    executeOperatorTextObj('delete', 'inner', '"', 1, missingTextObject.ctx)
+
+    expect(missingTextObject.state.text).toBe('plain text')
+    expect(missingTextObject.state.register).toBe('')
+    expect(missingTextObject.state.changes).toEqual([])
+  })
+
+  test('handles counted text objects when the requested count exceeds matches', () => {
+    const counted = makeContext('one two', 1)
+
+    executeOperatorTextObj('yank', 'around', 'w', 4, counted.ctx)
+
+    expect(counted.state.text).toBe('one two')
+    expect(counted.state.register).toBe('one two')
+    expect(counted.state.linewise).toBe(false)
+    expect(counted.state.offset).toBe(0)
+    expect(counted.state.changes).toEqual([
+      {
+        type: 'operatorTextObj',
+        op: 'yank',
+        objType: 'w',
+        scope: 'around',
+        count: 4,
+      },
+    ])
+  })
+
+  test('covers linewise delete and change boundaries', () => {
+    const deleteLastLine = makeContext('one\ntwo', 'one\n'.length)
+
+    executeLineOp('delete', 1, deleteLastLine.ctx)
+
+    expect(deleteLastLine.state.text).toBe('one')
+    expect(deleteLastLine.state.register).toBe('two\n')
+    expect(deleteLastLine.state.linewise).toBe(true)
+    expect(deleteLastLine.state.offset).toBe(2)
+
+    const changeSingle = makeContext('only')
+
+    executeLineOp('change', 1, changeSingle.ctx)
+
+    expect(changeSingle.state.text).toBe('')
+    expect(changeSingle.state.register).toBe('only\n')
+    expect(changeSingle.state.enteredInsertAt).toBe(0)
+
+    const changeMiddle = makeContext('one\ntwo\nthree\nfour', 'one\n'.length)
+
+    executeLineOp('change', 2, changeMiddle.ctx)
+
+    expect(changeMiddle.state.text).toBe('one\n\nfour')
+    expect(changeMiddle.state.register).toBe('two\nthree\n')
+    expect(changeMiddle.state.enteredInsertAt).toBe('one\n'.length)
+  })
+
+  test('covers no-op delete character and join cases', () => {
+    const atEnd = makeContext('abc', 3)
+
+    executeX(1, atEnd.ctx)
+
+    expect(atEnd.state.text).toBe('abc')
+    expect(atEnd.state.register).toBe('')
+    expect(atEnd.state.changes).toEqual([])
+
+    const lastLine = makeContext('one\ntwo', 'one\ntwo'.length)
+
+    executeJoin(1, lastLine.ctx)
+
+    expect(lastLine.state.text).toBe('one\ntwo')
+    expect(lastLine.state.changes).toEqual([])
+
+    const withBlankLine = makeContext('one\n\nthree')
+
+    executeJoin(2, withBlankLine.ctx)
+
+    expect(withBlankLine.state.text).toBe('one three')
+    expect(withBlankLine.state.offset).toBe('one'.length)
+    expect(withBlankLine.state.changes).toEqual([{ type: 'join', count: 2 }])
+  })
+
+  test('covers paste without a register and before-cursor paste variants', () => {
+    const emptyRegister = makeContext('abc')
+
+    executePaste(true, 1, emptyRegister.ctx)
+
+    expect(emptyRegister.state.text).toBe('abc')
+    expect(emptyRegister.state.offset).toBe(0)
+
+    const linewiseBefore = makeContext('one\ntwo', 'one\n'.length)
+    linewiseBefore.state.register = 'alpha\n'
+
+    executePaste(false, 2, linewiseBefore.ctx)
+
+    expect(linewiseBefore.state.text).toBe('one\nalpha\nalpha\ntwo')
+    expect(linewiseBefore.state.offset).toBe('one\n'.length)
+
+    const characterBefore = makeContext('ac', 1)
+    characterBefore.state.register = 'b'
+
+    executePaste(false, 3, characterBefore.ctx)
+
+    expect(characterBefore.state.text).toBe('abbbc')
+    expect(characterBefore.state.offset).toBe(3)
+  })
+
+  test('outdents tabs, partial whitespace, and nonblank lines', () => {
+    const indented = makeContext('\tone\n one\none')
+
+    executeIndent('<', 3, indented.ctx)
+
+    expect(indented.state.text).toBe('one\none\none')
+    expect(indented.state.offset).toBe(0)
+    expect(indented.state.changes).toEqual([
+      { type: 'indent', dir: '<', count: 3 },
+    ])
+  })
+
+  test('changes counted big-WORD motion through the last selected word', () => {
+    const changed = makeContext('one two three four')
+
+    executeOperatorMotion('change', 'W', 2, changed.ctx)
+
+    expect(changed.state.text).toBe(' three four')
+    expect(changed.state.register).toBe('one two')
+    expect(changed.state.enteredInsertAt).toBe(0)
+    expect(changed.state.changes).toEqual([
+      { type: 'operator', op: 'change', motion: 'W', count: 2 },
+    ])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-031-components-markdown-HighlightedCodeFallback.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-031-components-markdown-HighlightedCodeFallback.test.tsx
@@ -1,0 +1,236 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../../../src/tui/ink.js'
+import { HighlightedCodeFallback } from '../../../src/tui/components/markdown/HighlightedCodeFallback.js'
+
+const highlightMock = vi.hoisted(() => {
+  const highlight = vi.fn(
+    (code: string, options: { readonly language: string }) =>
+      `highlighted:${options.language}:${code}`,
+  )
+  const supportsLanguage = vi.fn((language: string) =>
+    ['js', 'rs', 'markdown'].includes(language),
+  )
+
+  return {
+    getCliHighlightPromise: vi.fn(),
+    highlight,
+    logForDebugging: vi.fn(),
+    supportsLanguage,
+  }
+})
+
+vi.mock('../../../src/utils/cliHighlight.js', () => ({
+  getCliHighlightPromise: highlightMock.getCliHighlightPromise,
+}))
+
+vi.mock('../../../src/utils/debug.js', () => ({
+  logForDebugging: highlightMock.logForDebugging,
+}))
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+async function waitForOutput(
+  readOutput: () => string,
+  expected: string,
+): Promise<void> {
+  const deadline = Date.now() + 1000
+  while (Date.now() < deadline) {
+    if (readOutput().includes(expected)) return
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+  throw new Error(`Timed out waiting for rendered output: ${expected}`)
+}
+
+async function waitForCondition(
+  isReady: () => boolean,
+  description: string,
+): Promise<void> {
+  const deadline = Date.now() + 1000
+  while (Date.now() < deadline) {
+    if (isReady()) return
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+  throw new Error(`Timed out waiting for ${description}`)
+}
+
+async function renderToText(
+  node: React.ReactNode,
+  expected: string,
+  options: {
+    readonly afterExpected?: () => boolean
+  } = {},
+): Promise<string> {
+  let output = ''
+  const { stdin, stdout } = createStreams()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  try {
+    root.render(node)
+    await waitForOutput(() => stripAnsi(output), expected)
+    if (options.afterExpected) {
+      await waitForCondition(options.afterExpected, 'post-render condition')
+    }
+    return stripAnsi(output)
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+  }
+}
+
+function fulfilledPromise<T>(value: T): Promise<T> {
+  const promise = Promise.resolve(value) as Promise<T> & {
+    status: 'fulfilled'
+    value: T
+  }
+  promise.status = 'fulfilled'
+  promise.value = value
+  return promise
+}
+
+describe('HighlightedCodeFallback coverage swarm row 031', () => {
+  beforeEach(() => {
+    const highlighter = {
+      highlight: highlightMock.highlight,
+      supportsLanguage: highlightMock.supportsLanguage,
+    }
+    highlightMock.getCliHighlightPromise.mockReset()
+    highlightMock.highlight.mockReset()
+    highlightMock.logForDebugging.mockReset()
+    highlightMock.supportsLanguage.mockReset()
+    highlightMock.highlight.mockImplementation(
+      (code: string, options: { readonly language: string }) =>
+        `highlighted:${options.language}:${code}`,
+    )
+    highlightMock.supportsLanguage.mockImplementation((language: string) =>
+      ['js', 'rs', 'markdown'].includes(language),
+    )
+    highlightMock.getCliHighlightPromise.mockReturnValue(
+      fulfilledPromise(highlighter),
+    )
+  })
+
+  test('renders normalized plain ANSI text without loading a highlighter when coloring is skipped', async () => {
+    const expected = '  const row031Skip = true'
+
+    const output = await renderToText(
+      <HighlightedCodeFallback
+        code={`${String.fromCharCode(9)}const row031Skip = true`}
+        dim={true}
+        filePath="fixture.js"
+        skipColoring={true}
+      />,
+      expected,
+    )
+
+    expect(output).toContain(expected)
+    expect(highlightMock.getCliHighlightPromise).not.toHaveBeenCalled()
+    expect(highlightMock.supportsLanguage).not.toHaveBeenCalled()
+    expect(highlightMock.highlight).not.toHaveBeenCalled()
+  })
+
+  test('falls back to plain code when the highlighter promise resolves without a highlighter', async () => {
+    highlightMock.getCliHighlightPromise.mockReturnValue(fulfilledPromise(null))
+    const code = 'const row031NoHighlighter = true'
+
+    const output = await renderToText(
+      <HighlightedCodeFallback code={code} filePath="fixture.js" />,
+      code,
+    )
+
+    expect(output).toContain(code)
+    expect(highlightMock.getCliHighlightPromise).toHaveBeenCalled()
+    expect(highlightMock.supportsLanguage).not.toHaveBeenCalled()
+    expect(highlightMock.highlight).not.toHaveBeenCalled()
+  })
+
+  test('retries markdown highlighting when the supported language throws an unknown-language error', async () => {
+    const code = 'let row031_retry = true;'
+    const expected = `highlighted:markdown:${code}`
+    highlightMock.highlight.mockImplementation(
+      (receivedCode: string, options: { readonly language: string }) => {
+        if (options.language === 'rs') {
+          throw new Error('Unknown language: rs')
+        }
+        return `highlighted:${options.language}:${receivedCode}`
+      },
+    )
+
+    const output = await renderToText(
+      <HighlightedCodeFallback code={code} filePath="fixture.rs" />,
+      expected,
+    )
+
+    expect(output).toContain(expected)
+    expect(highlightMock.supportsLanguage).toHaveBeenCalledWith('rs')
+    expect(highlightMock.highlight).toHaveBeenCalledTimes(2)
+    expect(highlightMock.highlight).toHaveBeenNthCalledWith(1, code, {
+      language: 'rs',
+    })
+    expect(highlightMock.highlight).toHaveBeenNthCalledWith(2, code, {
+      language: 'markdown',
+    })
+    expect(highlightMock.logForDebugging).toHaveBeenCalledWith(
+      expect.stringContaining('falling back to markdown: Error: Unknown language: rs'),
+    )
+  })
+
+  test('falls back to unhighlighted code when highlighting fails for a non-language reason', async () => {
+    const code = 'const row031GenericError = true'
+    highlightMock.highlight.mockImplementation(() => {
+      throw new Error('theme failed')
+    })
+
+    const output = await renderToText(
+      <HighlightedCodeFallback code={code} filePath="fixture.js" />,
+      code,
+      { afterExpected: () => highlightMock.highlight.mock.calls.length > 0 },
+    )
+
+    expect(output).toContain(code)
+    expect(highlightMock.supportsLanguage).toHaveBeenCalledWith('js')
+    expect(highlightMock.highlight).toHaveBeenCalledWith(code, {
+      language: 'js',
+    })
+    expect(
+      highlightMock.logForDebugging.mock.calls.some(([message]) =>
+        String(message).includes('falling back to markdown'),
+      ),
+    ).toBe(false)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-032-message-renderers-AssistantToolUseMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-032-message-renderers-AssistantToolUseMessage.test.tsx
@@ -1,0 +1,280 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { Tool } from '../../tools/Tool.js'
+import type { AgenCToolUseBlockParam } from '../../types/message.js'
+import { renderToString } from '../../utils/staticRender.js'
+import { Text } from '../ink.js'
+import {
+  AssistantToolUseMessage,
+  getAssistantToolUsePendingText,
+} from '../message-renderers/AssistantToolUseMessage.js'
+
+const appStateMock = vi.hoisted(() => ({
+  pendingWorkerRequest: undefined as undefined | { toolUseId: string },
+  toolPermissionContext: {
+    mode: 'default',
+    strippedDangerousRules: undefined as undefined | Record<string, unknown>,
+  },
+}))
+
+vi.mock('../../utils/classifierApprovalsHook.js', () => ({
+  useIsClassifierChecking: () => false,
+}))
+
+vi.mock('../hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: 96, rows: 32 }),
+}))
+
+vi.mock('../state/AppState.js', () => ({
+  useAppStateMaybeOutsideOfProvider: (
+    selector: (state: typeof appStateMock) => unknown,
+  ) => selector(appStateMock),
+}))
+
+vi.mock('../ink.js', async () => {
+  const actual = await vi.importActual<typeof import('../ink.js')>(
+    '../ink.js',
+  )
+  return {
+    ...actual,
+    useTheme: () => ['dark'],
+  }
+})
+
+function lookups(options: {
+  readonly resolved?: readonly string[]
+  readonly errored?: readonly string[]
+} = {}) {
+  return {
+    resolvedToolUseIDs: new Set(options.resolved ?? []),
+    erroredToolUseIDs: new Set(options.errored ?? []),
+    inProgressHookCounts: new Map<string, Map<string, number>>(),
+    resolvedHookCounts: new Map<string, Map<string, number>>(),
+  } as never
+}
+
+function toolUseParam(
+  id: string,
+  name: string,
+  input: Record<string, unknown>,
+): AgenCToolUseBlockParam {
+  return {
+    type: 'tool_use',
+    id,
+    name,
+    input,
+  }
+}
+
+function makeTool(options: {
+  readonly name: string
+  readonly label?: string
+  readonly renderToolUseMessage?: Tool['renderToolUseMessage']
+  readonly renderToolUseQueuedMessage?: Tool['renderToolUseQueuedMessage']
+  readonly renderToolUseTag?: Tool['renderToolUseTag']
+  readonly isTransparentWrapper?: () => boolean
+  readonly inputSchema?: Tool['inputSchema']
+}): Tool {
+  return {
+    name: options.name,
+    inputSchema: options.inputSchema ?? {
+      safeParse: (input: unknown) => ({ success: true, data: input }),
+    },
+    userFacingName: () => options.label ?? options.name,
+    renderToolUseMessage: options.renderToolUseMessage ?? (() => ''),
+    ...(options.renderToolUseQueuedMessage
+      ? { renderToolUseQueuedMessage: options.renderToolUseQueuedMessage }
+      : {}),
+    ...(options.renderToolUseTag
+      ? { renderToolUseTag: options.renderToolUseTag }
+      : {}),
+    ...(options.isTransparentWrapper
+      ? { isTransparentWrapper: options.isTransparentWrapper }
+      : {}),
+  } as unknown as Tool
+}
+
+async function renderToolUse(options: {
+  readonly param: AgenCToolUseBlockParam
+  readonly tool: Tool
+  readonly inProgress?: boolean
+  readonly resolved?: boolean
+  readonly errored?: boolean
+}): Promise<string> {
+  return renderToString(
+    <AssistantToolUseMessage
+      param={options.param}
+      addMargin={false}
+      tools={[options.tool]}
+      commands={[]}
+      verbose={false}
+      inProgressToolUseIDs={
+        options.inProgress === false ? new Set() : new Set([options.param.id])
+      }
+      progressMessagesForMessage={[]}
+      shouldAnimate={false}
+      shouldShowDot={false}
+      lookups={lookups({
+        resolved: options.resolved ? [options.param.id] : [],
+        errored: options.errored ? [options.param.id] : [],
+      })}
+    />,
+    96,
+  )
+}
+
+describe('AssistantToolUseMessage swarm 032 coverage', () => {
+  beforeEach(() => {
+    appStateMock.pendingWorkerRequest = undefined
+    appStateMock.toolPermissionContext.mode = 'default'
+    appStateMock.toolPermissionContext.strippedDangerousRules = undefined
+  })
+
+  it('formats pending text for each classifier state with selectable glyphs', () => {
+    expect(
+      getAssistantToolUsePendingText('permission', {
+        AGENC_TUI_GLYPHS: 'ascii',
+      }),
+    ).toBe('Waiting for permission...')
+    expect(
+      getAssistantToolUsePendingText('auto-classifier', {
+        AGENC_TUI_GLYPHS: 'unicode',
+      }),
+    ).toBe('Auto classifier checking…')
+    expect(
+      getAssistantToolUsePendingText('bash-classifier', {
+        AGENC_TUI_GLYPHS: 'ascii',
+      }),
+    ).toBe('Bash classifier checking...')
+  })
+
+  it('renders every tool-kind classifier path while summarizing fallback args', async () => {
+    const cases = [
+      ['PowerShell', 'Shell Runner', { command: 'Write-Host hi' }, 'Write-Host hi'],
+      ['Glob', 'Glob Search', { pattern: '**/*.ts' }, '**/*.ts'],
+      ['PatchWriter', 'File Edit', { file_path: 'src/file.ts' }, 'src/file.ts'],
+      ['Task', 'Delegate Agent', { description: 'delegate work' }, 'delegate work'],
+      ['ProofCheck', 'Proof Verify', { prompt: 'prove it' }, 'prove it'],
+      ['ClaimSubmit', 'Claim Submit', { path: 'claim.json' }, 'claim.json'],
+      ['SettleTrade', 'Settle Market', { query: 'market-1' }, 'market-1'],
+      ['StakeVote', 'Stake Lock', { path: 'stake.toml' }, 'stake.toml'],
+      ['PlainRead', 'Plain Read', { value: 42 }, '{"value":42}'],
+    ] as const
+
+    for (const [name, label, input, expectedArg] of cases) {
+      const param = toolUseParam(`toolu_${name}`, name, input)
+      const output = await renderToolUse({
+        param,
+        tool: makeTool({ name, label }),
+        resolved: true,
+      })
+
+      expect(output).toContain(label)
+      expect(output).toContain(expectedArg)
+      expect(output).toContain('●')
+    }
+  })
+
+  it('omits tools with an intentionally empty user-facing name', async () => {
+    const renderToolUseMessage = vi.fn(() => 'hidden details')
+    const param = toolUseParam('toolu_hidden', 'HiddenTool', { command: 'hide' })
+    const output = await renderToolUse({
+      param,
+      tool: makeTool({
+        name: 'HiddenTool',
+        label: '',
+        renderToolUseMessage,
+      }),
+    })
+
+    expect(output.trim()).toBe('')
+    expect(renderToolUseMessage).not.toHaveBeenCalled()
+  })
+
+  it('keeps failed JSX detail expanded with tags and summarized args', async () => {
+    const param = toolUseParam('toolu_failed_detail', 'ClaimTool', {
+      prompt: 'claim payload',
+    })
+    const output = await renderToolUse({
+      param,
+      tool: makeTool({
+        name: 'ClaimTool',
+        label: 'Claim Submit',
+        renderToolUseMessage: () => <Text>expanded claim detail</Text>,
+        renderToolUseTag: () => <Text>tag detail</Text>,
+      }),
+      resolved: true,
+      errored: true,
+    })
+
+    expect(output).toContain('✕')
+    expect(output).toContain('Claim Submit')
+    expect(output).toContain('claim payload')
+    expect(output).toContain('expanded claim detail')
+    expect(output).toContain('tag detail')
+  })
+
+  it('uses input summaries and React queued detail when the display reparse fails', async () => {
+    let parseCount = 0
+    const renderToolUseMessage = vi.fn(() => 'should not render')
+    const param = toolUseParam('toolu_queued_node', 'SearchTool', {
+      path: 'queued/path.ts',
+    })
+    const output = await renderToolUse({
+      param,
+      tool: makeTool({
+        name: 'SearchTool',
+        label: 'Search Tool',
+        inputSchema: {
+          safeParse: (input: unknown) => {
+            parseCount += 1
+            return parseCount === 1
+              ? { success: true, data: input }
+              : { success: false, error: new Error('second parse failed') }
+          },
+        } as unknown as Tool['inputSchema'],
+        renderToolUseMessage,
+        renderToolUseQueuedMessage: () => <Text>queued as node</Text>,
+      }),
+      inProgress: false,
+    })
+
+    expect(parseCount).toBe(2)
+    expect(renderToolUseMessage).not.toHaveBeenCalled()
+    expect(output).toContain('Search Tool')
+    expect(output).toContain('queued/path.ts')
+    expect(output).toContain('queued as node')
+    expect(output).toContain('○')
+  })
+
+  it('suppresses queued and resolved transparent wrappers', async () => {
+    const param = toolUseParam('toolu_transparent', 'Delegate', {
+      prompt: 'outer task',
+    })
+    const renderToolUseProgressMessage = vi.fn(() => <Text>progress detail</Text>)
+    const tool = {
+      ...makeTool({
+        name: 'Delegate',
+        label: 'Delegate',
+        isTransparentWrapper: () => true,
+      }),
+      renderToolUseProgressMessage,
+    } as unknown as Tool
+
+    const queuedOutput = await renderToolUse({
+      param,
+      tool,
+      inProgress: false,
+    })
+    const resolvedOutput = await renderToolUse({
+      param,
+      tool,
+      resolved: true,
+    })
+
+    expect(queuedOutput.trim()).toBe('')
+    expect(resolvedOutput.trim()).toBe('')
+    expect(renderToolUseProgressMessage).not.toHaveBeenCalled()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-033-hooks-useVimInput.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-033-hooks-useVimInput.test.ts
@@ -1,0 +1,377 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  addToHistory: vi.fn(),
+  fullscreen: false,
+  markBackslashReturnUsed: vi.fn(),
+  modifiers: {
+    shift: false,
+  } as Record<string, boolean>,
+  prewarmModifiers: vi.fn(),
+  removeNotification: vi.fn(),
+  reset() {
+    this.addNotification.mockClear()
+    this.addToHistory.mockClear()
+    this.fullscreen = false
+    this.markBackslashReturnUsed.mockClear()
+    this.modifiers = { shift: false }
+    this.prewarmModifiers.mockClear()
+    this.removeNotification.mockClear()
+  },
+}))
+
+vi.mock('src/tui/context/notifications.js', () => ({
+  useNotifications: () => ({
+    addNotification: harness.addNotification,
+    removeNotification: harness.removeNotification,
+  }),
+}))
+
+vi.mock('src/commands/terminalSetup/terminalSetup.js', () => ({
+  markBackslashReturnUsed: harness.markBackslashReturnUsed,
+}))
+
+vi.mock('src/tui/history/history.js', () => ({
+  addToHistory: harness.addToHistory,
+}))
+
+vi.mock('src/utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => harness.fullscreen,
+}))
+
+vi.mock('src/utils/modifiers.js', () => ({
+  isModifierPressed: (modifier: string) =>
+    harness.modifiers[modifier] === true,
+  prewarmModifiers: harness.prewarmModifiers,
+}))
+
+import { createRoot } from 'src/tui/ink/root.js'
+import type { Key } from 'src/tui/ink.js'
+import { useVimInput } from 'src/tui/hooks/useVimInput.js'
+
+type VimHookProps = Parameters<typeof useVimInput>[0]
+type VimHookState = ReturnType<typeof useVimInput>
+
+const BASE_KEY: Key = {
+  backspace: false,
+  ctrl: false,
+  delete: false,
+  downArrow: false,
+  end: false,
+  escape: false,
+  fn: false,
+  home: false,
+  leftArrow: false,
+  meta: false,
+  pageDown: false,
+  pageUp: false,
+  return: false,
+  rightArrow: false,
+  shift: false,
+  super: false,
+  tab: false,
+  upArrow: false,
+  wheelDown: false,
+  wheelUp: false,
+}
+
+function key(overrides: Partial<Key> = {}): Key {
+  return { ...BASE_KEY, ...overrides }
+}
+
+function createStreams(): {
+  readonly stdout: PassThrough
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 80
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderHookHarness(
+  overrides: Partial<VimHookProps> = {},
+): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly latest: () => VimHookState
+  readonly onChange: ReturnType<typeof vi.fn>
+  readonly onModeChange: ReturnType<typeof vi.fn>
+  readonly onOffsetChange: ReturnType<typeof vi.fn>
+  readonly onSubmit: ReturnType<typeof vi.fn>
+  readonly send: (input: string, inputKey?: Partial<Key>) => Promise<void>
+}> {
+  const onChange = vi.fn()
+  const onModeChange = vi.fn()
+  const onOffsetChange = vi.fn()
+  const onSubmit = vi.fn()
+  let props: VimHookProps = {
+    columns: 20,
+    cursorChar: '|',
+    externalOffset: overrides.value?.length ?? 0,
+    invert: text => text,
+    onChange,
+    onModeChange,
+    onOffsetChange,
+    onSubmit,
+    themeText: text => text,
+    value: '',
+    ...overrides,
+  }
+  let latest: VimHookState | undefined
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    latest = useVimInput(props)
+    return null
+  }
+
+  root.render(React.createElement(Harness))
+  await sleep()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+    onChange,
+    onModeChange,
+    onOffsetChange,
+    onSubmit,
+    send: async (input: string, inputKey: Partial<Key> = {}) => {
+      if (latest === undefined) throw new Error('hook did not render')
+      latest.onInput(input, key(inputKey))
+      await sleep()
+    },
+  }
+}
+
+async function switchToNormal(rendered: {
+  readonly latest: () => VimHookState
+}): Promise<void> {
+  rendered.latest().setMode('NORMAL')
+  await sleep()
+}
+
+describe('useVimInput swarm coverage', () => {
+  beforeEach(() => {
+    harness.reset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('replays character edits through dot repeat', async () => {
+    const rendered = await renderHookHarness({
+      externalOffset: 0,
+      value: 'abc',
+    })
+
+    try {
+      await switchToNormal(rendered)
+
+      await rendered.send('x')
+      expect(rendered.latest().value).toBe('bc')
+
+      await rendered.send('.')
+      expect(rendered.latest().value).toBe('c')
+    } finally {
+      await rendered.dispose()
+    }
+
+    const toggleRendered = await renderHookHarness({
+      externalOffset: 0,
+      value: 'aBc',
+    })
+
+    try {
+      await switchToNormal(toggleRendered)
+
+      await toggleRendered.send('~')
+      expect(toggleRendered.latest().value).toBe('ABc')
+
+      await toggleRendered.send('.')
+      expect(toggleRendered.latest().value).toBe('Abc')
+    } finally {
+      await toggleRendered.dispose()
+    }
+  })
+
+  test('replays line edits through dot repeat', async () => {
+    const indentRendered = await renderHookHarness({
+      externalOffset: 0,
+      value: 'one\ntwo',
+    })
+
+    try {
+      await switchToNormal(indentRendered)
+
+      await indentRendered.send('>')
+      await indentRendered.send('>')
+      expect(indentRendered.latest().value).toBe('  one\ntwo')
+
+      await indentRendered.send('.')
+      expect(indentRendered.latest().value).toBe('    one\ntwo')
+    } finally {
+      await indentRendered.dispose()
+    }
+
+    const joinRendered = await renderHookHarness({
+      externalOffset: 0,
+      value: 'one\ntwo\nthree',
+    })
+
+    try {
+      await switchToNormal(joinRendered)
+
+      await joinRendered.send('J')
+      expect(joinRendered.latest().value).toBe('one two\nthree')
+
+      await joinRendered.send('.')
+      expect(joinRendered.latest().value).toBe('one two three')
+    } finally {
+      await joinRendered.dispose()
+    }
+
+    const openLineRendered = await renderHookHarness({
+      externalOffset: 0,
+      value: 'one\ntwo',
+    })
+
+    try {
+      await switchToNormal(openLineRendered)
+
+      await openLineRendered.send('o')
+      expect(openLineRendered.latest().value).toBe('one\n\ntwo')
+      expect(openLineRendered.latest().mode).toBe('INSERT')
+
+      await openLineRendered.send('', { escape: true })
+      expect(openLineRendered.latest().mode).toBe('NORMAL')
+
+      await openLineRendered.send('.')
+      expect(openLineRendered.latest().value).toBe('one\n\n\ntwo')
+      expect(openLineRendered.latest().mode).toBe('INSERT')
+    } finally {
+      await openLineRendered.dispose()
+    }
+  })
+
+  test('replays find and text object operators through dot repeat', async () => {
+    const findRendered = await renderHookHarness({
+      externalOffset: 0,
+      value: 'abc def ghi',
+    })
+
+    try {
+      await switchToNormal(findRendered)
+
+      await findRendered.send('d')
+      await findRendered.send('f')
+      await findRendered.send(' ')
+      expect(findRendered.latest().value).toBe('def ghi')
+
+      await findRendered.send('.')
+      expect(findRendered.latest().value).toBe('ghi')
+    } finally {
+      await findRendered.dispose()
+    }
+
+    const textObjectRendered = await renderHookHarness({
+      externalOffset: 1,
+      value: '"one" "two"',
+    })
+
+    try {
+      await switchToNormal(textObjectRendered)
+
+      await textObjectRendered.send('d')
+      await textObjectRendered.send('i')
+      await textObjectRendered.send('"')
+      expect(textObjectRendered.latest().value).toBe('"" "two"')
+
+      await textObjectRendered.send('f')
+      await textObjectRendered.send('"')
+      await textObjectRendered.send('.')
+      expect(textObjectRendered.latest().value).toBe('"" ""')
+    } finally {
+      await textObjectRendered.dispose()
+    }
+  })
+
+  test('handles normal mode cancellation and passthrough branches', async () => {
+    const rendered = await renderHookHarness({
+      externalOffset: 1,
+      value: 'abc',
+    })
+
+    try {
+      await switchToNormal(rendered)
+
+      await rendered.send('r')
+      await rendered.send('', { escape: true })
+      await rendered.send('z')
+      expect(rendered.latest().value).toBe('abc')
+
+      await rendered.send('', { backspace: true })
+      expect(rendered.latest().offset).toBe(0)
+
+      await rendered.send('2')
+      await rendered.send('', { delete: true })
+      await rendered.send('x')
+      expect(rendered.latest().value).toBe('bc')
+
+      await rendered.send('', { return: true })
+      expect(rendered.onSubmit).toHaveBeenCalledWith('bc')
+    } finally {
+      await rendered.dispose()
+    }
+
+    const searchRendered = await renderHookHarness({
+      externalOffset: 0,
+      value: '',
+    })
+
+    try {
+      await switchToNormal(searchRendered)
+
+      await searchRendered.send('?')
+      expect(searchRendered.onChange).toHaveBeenCalledWith('?')
+    } finally {
+      await searchRendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-034-hooks-fileSuggestions.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-034-hooks-fileSuggestions.test.ts
@@ -1,0 +1,286 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, sep } from 'node:path'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+type ExecResult = {
+  code: number
+  stdout: string
+  stderr: string
+}
+
+let tempRoot = ''
+let tempCwd = ''
+
+const harness = vi.hoisted(() => ({
+  execCalls: [] as Array<{
+    args: string[]
+    options: { cwd?: string; timeout?: number }
+  }>,
+  execResults: [] as Array<ExecResult | Error>,
+  fileIndexLoads: [] as string[][],
+  gitRoot: null as string | null,
+  globalConfig: {} as Record<string, unknown>,
+  logError: vi.fn(),
+  logEvent: vi.fn(),
+  markdownFiles: [] as string[],
+  projectSettings: {} as Record<string, unknown>,
+  ripGrep: vi.fn(async () => [] as string[]),
+  yieldToEventLoop: vi.fn(async () => {}),
+  reset() {
+    this.execCalls = []
+    this.execResults = []
+    this.fileIndexLoads = []
+    this.gitRoot = null
+    this.globalConfig = {}
+    this.markdownFiles = []
+    this.projectSettings = {}
+    this.logError.mockClear()
+    this.logEvent.mockClear()
+    this.ripGrep.mockReset()
+    this.ripGrep.mockResolvedValue([])
+    this.yieldToEventLoop.mockClear()
+  },
+}))
+
+vi.mock('../../utils/cwd.js', () => ({
+  getCwd: () => tempCwd,
+  pwd: () => tempCwd,
+  runWithCwdOverride: <T,>(_cwd: string, fn: () => T) => fn(),
+}))
+
+vi.mock('../../services/analytics/index', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../../utils/settings/settings.js', () => ({
+  getInitialSettings: () => harness.projectSettings,
+}))
+
+vi.mock('../../utils/config.js', () => ({
+  checkHasTrustDialogAccepted: () => true,
+  getGlobalConfig: () => harness.globalConfig,
+}))
+
+vi.mock('../../utils/hooks.js', () => ({
+  createBaseHookInput: () => ({ cwd: tempCwd }),
+  executeFileSuggestionCommand: async () => [],
+}))
+
+vi.mock('../../utils/markdownConfigLoader.js', () => ({
+  AGENC_CONFIG_DIRECTORIES: ['agents'],
+  loadMarkdownFilesForSubdir: async () =>
+    harness.markdownFiles.map(filePath => ({ filePath })),
+}))
+
+vi.mock('../../utils/git', () => ({
+  findGitRoot: () => harness.gitRoot,
+  gitExe: () => 'git',
+}))
+
+vi.mock('../../utils/execFileNoThrow.js', () => ({
+  execFileNoThrowWithCwd: async (
+    _command: string,
+    args: string[],
+    options: { cwd?: string; timeout?: number },
+  ) => {
+    harness.execCalls.push({ args, options })
+    const result = harness.execResults.shift()
+    if (result instanceof Error) throw result
+    return result ?? { code: 0, stdout: '', stderr: '' }
+  },
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: harness.logError,
+}))
+
+vi.mock('../../utils/ripgrep.js', () => ({
+  ripGrep: harness.ripGrep,
+}))
+
+vi.mock('src/utils/debug.js', () => ({
+  logForDebugging: () => {},
+}))
+
+vi.mock('../ink/native-ts/file-index/index', () => ({
+  CHUNK_MS: 4,
+  FileIndex: class {
+    loadFromFileListAsync(paths: string[]) {
+      harness.fileIndexLoads.push([...paths])
+      return { done: Promise.resolve() }
+    }
+
+    search() {
+      return []
+    }
+  },
+  yieldToEventLoop: harness.yieldToEventLoop,
+}))
+
+import {
+  clearFileSuggestionCaches,
+  getPathsForSuggestions,
+  onIndexBuildComplete,
+  startBackgroundCacheRefresh,
+} from '../hooks/fileSuggestions.js'
+
+async function waitFor(assertion: () => void): Promise<void> {
+  let lastError: unknown
+  for (let attempt = 0; attempt < 25; attempt++) {
+    try {
+      assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await new Promise(resolve => setTimeout(resolve, 0))
+    }
+  }
+  throw lastError
+}
+
+beforeEach(() => {
+  harness.reset()
+  tempRoot = mkdtempSync(join(tmpdir(), 'agenc-file-suggestions-swarm-'))
+  tempCwd = tempRoot
+  clearFileSuggestionCaches()
+})
+
+afterEach(() => {
+  clearFileSuggestionCaches()
+  rmSync(tempRoot, { recursive: true, force: true })
+  tempRoot = ''
+  tempCwd = ''
+})
+
+describe('fileSuggestions project file loading', () => {
+  test('normalizes git paths from repo root to cwd and merges untracked files', async () => {
+    tempCwd = join(tempRoot, 'packages', 'app')
+    mkdirSync(tempCwd, { recursive: true })
+    writeFileSync(
+      join(tempCwd, '.agencignore'),
+      'ignored.ts\nignored-untracked.ts\n',
+    )
+
+    harness.gitRoot = tempRoot
+    harness.markdownFiles = ['.agenc/agents/build.md']
+    harness.execResults = [
+      {
+        code: 0,
+        stdout: 'packages/app/src/index.ts\npackages/app/ignored.ts\n',
+        stderr: '',
+      },
+      {
+        code: 0,
+        stdout:
+          'packages/app/new-file.ts\npackages/app/ignored-untracked.ts\n',
+        stderr: '',
+      },
+    ]
+
+    await getPathsForSuggestions()
+    await waitFor(() => expect(harness.fileIndexLoads).toHaveLength(2))
+
+    expect(harness.execCalls[0]?.args).toEqual([
+      '-c',
+      'core.quotepath=false',
+      'ls-files',
+      '--recurse-submodules',
+    ])
+    expect(harness.execCalls[0]?.options.cwd).toBe(tempRoot)
+    expect(harness.execCalls[1]?.args).toEqual([
+      '-c',
+      'core.quotepath=false',
+      'ls-files',
+      '--others',
+      '--exclude-standard',
+    ])
+
+    const trackedLoad = harness.fileIndexLoads[0]!
+    expect(trackedLoad).toEqual(
+      expect.arrayContaining([
+        'src' + sep,
+        '.agenc' + sep,
+        join('.agenc', 'agents') + sep,
+        'src/index.ts',
+        join('.agenc', 'agents', 'build.md'),
+      ]),
+    )
+    expect(trackedLoad).not.toContain('ignored.ts')
+
+    const mergedLoad = harness.fileIndexLoads[1]!
+    expect(mergedLoad).toEqual(
+      expect.arrayContaining([
+        'src/index.ts',
+        join('.agenc', 'agents', 'build.md'),
+        'new-file.ts',
+      ]),
+    )
+    expect(mergedLoad).not.toContain('ignored-untracked.ts')
+  })
+
+  test('falls back to ripgrep and disables ignore-vcs when configured', async () => {
+    harness.gitRoot = null
+    harness.projectSettings = { respectGitignore: false }
+    harness.ripGrep.mockResolvedValue([
+      join(tempCwd, 'src', 'index.ts'),
+      join(tempCwd, 'src', 'utils', 'tool.ts'),
+    ])
+
+    await getPathsForSuggestions()
+
+    expect(harness.execCalls).toEqual([])
+    expect(harness.ripGrep).toHaveBeenCalledWith(
+      expect.arrayContaining(['--no-ignore-vcs']),
+      '.',
+      expect.any(AbortSignal),
+    )
+    expect(harness.fileIndexLoads[0]).toEqual(
+      expect.arrayContaining([
+        'src' + sep,
+        join('src', 'utils') + sep,
+        join('src', 'index.ts'),
+        join('src', 'utils', 'tool.ts'),
+      ]),
+    )
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'tengu_file_suggestions_ripgrep',
+      expect.objectContaining({ file_count: 2 }),
+    )
+  })
+
+  test('logs scanner failures and still returns the reusable file index', async () => {
+    const scanError = new Error('scan failed')
+    harness.gitRoot = null
+    harness.ripGrep.mockRejectedValue(scanError)
+
+    await expect(getPathsForSuggestions()).resolves.toBeDefined()
+
+    expect(harness.logError).toHaveBeenCalledWith(scanError)
+    expect(harness.fileIndexLoads).toEqual([])
+  })
+
+  test('background refresh coalesces in-flight work and throttles repeats', async () => {
+    const listener = vi.fn()
+    const unsubscribe = onIndexBuildComplete(listener)
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+    harness.gitRoot = null
+    harness.ripGrep.mockResolvedValue([join(tempCwd, 'src', 'index.ts')])
+
+    try {
+      startBackgroundCacheRefresh()
+      startBackgroundCacheRefresh()
+
+      await waitFor(() => expect(listener).toHaveBeenCalledTimes(1))
+      expect(harness.ripGrep).toHaveBeenCalledTimes(1)
+
+      startBackgroundCacheRefresh()
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(harness.ripGrep).toHaveBeenCalledTimes(1)
+    } finally {
+      unsubscribe()
+      nowSpy.mockRestore()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-035-permission-requests.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-035-permission-requests.test.tsx
@@ -1,0 +1,369 @@
+import { PassThrough } from "node:stream";
+
+import React, { useEffect } from "react";
+import { describe, expect, test, vi } from "vitest";
+
+import { ABORT, APPROVED, DENIED } from "src/permissions/review-decision.js";
+import type { ReviewDecision } from "src/permissions/review-decision.js";
+import type { AppState } from "src/tui/state/AppState.js";
+import {
+  ASK_USER_QUESTION_TOOL_NAME,
+  clearAskUserQuestionResponsesForTest,
+  createAskUserQuestionTool,
+} from "src/tools/ask-user-question/tool.js";
+import type { ApprovalCtx, ApprovalResolver } from "src/tools/orchestrator.js";
+import { createRoot, Text } from "src/tui/ink.js";
+import type { PendingRequest } from "src/tui/permission-requests.js";
+import {
+  buildToolUseConfirm,
+  buildToolUseConfirmQueue,
+  usePermissionRequests,
+} from "src/tui/permission-requests.js";
+import type { AgenCBridgeSession } from "src/tui/session-types.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+type ProjectedConfirm = {
+  readonly input: unknown;
+  readonly toolUseID: string;
+  onAbort(): void;
+  onAllow(updatedInput: unknown, permissionUpdates?: readonly unknown[]): void;
+  onReject(feedback?: string): void;
+  recheckPermission(): Promise<void>;
+};
+
+function createStreams(): {
+  readonly stdin: TestStdin;
+  readonly stdout: PassThrough;
+} {
+  const stdin = new PassThrough() as TestStdin;
+  const stdout = new PassThrough();
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  Object.assign(stdout, {
+    columns: 120,
+    rows: 24,
+    isTTY: true,
+  });
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 10): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  const started = Date.now();
+  let lastError: unknown;
+
+  while (Date.now() - started < 1_000) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await sleep();
+    }
+  }
+
+  throw lastError;
+}
+
+function createCtx(
+  callId: string,
+  toolName: string,
+  payload: unknown,
+  options: {
+    readonly retryReason?: string;
+    readonly signal?: AbortSignal;
+  } = {},
+): ApprovalCtx {
+  return {
+    callId,
+    toolName,
+    turnId: "turn-035",
+    retryReason: options.retryReason,
+    signal: options.signal,
+    invocation: {
+      callId,
+      payload,
+      toolName: { name: toolName },
+    },
+  } as ApprovalCtx;
+}
+
+function createSession(
+  previousResolver: ApprovalResolver,
+  previousBridge: NonNullable<AgenCBridgeSession["appStateBridge"]>,
+): AgenCBridgeSession {
+  return {
+    conversationId: "conversation-035",
+    services: {
+      approvalResolver: previousResolver,
+      permissionModeRegistry: {
+        current: () => ({ mode: "default" }),
+      },
+    },
+    appStateBridge: previousBridge,
+  } as AgenCBridgeSession;
+}
+
+function createPendingRequest(
+  toolName: string,
+  input: Record<string, unknown>,
+  resolve: (decision: ReviewDecision) => void,
+): PendingRequest {
+  return {
+    id: `request-${toolName}`,
+    ctx: createCtx(`call-${toolName}`, toolName, {
+      kind: "function",
+      arguments: JSON.stringify(input),
+    }),
+    input,
+    description: `Permission required to use ${toolName}`,
+    resolve,
+  };
+}
+
+const askInput = {
+  questions: [
+    {
+      question: "Which path should planning take?",
+      header: "Plan",
+      options: [
+        { label: "Clarify", description: "Discuss the decision first" },
+        { label: "Continue", description: "Proceed with the current plan" },
+      ],
+    },
+  ],
+};
+
+describe("permission request swarm coverage", () => {
+  test("derives edge-case approval inputs and restores the session bridge", async () => {
+    const previousResolver: ApprovalResolver = {
+      request: vi.fn(async () => DENIED),
+    };
+    const previousBridge: NonNullable<AgenCBridgeSession["appStateBridge"]> = {
+      setModel: vi.fn(),
+    };
+    const session = createSession(previousResolver, previousBridge);
+    const setModel = vi.fn<(next: string) => void>();
+    const setExpandedView = vi.fn<(next: "none" | "tasks") => void>();
+    const setAppState = vi.fn<(updater: (prev: AppState) => AppState) => void>();
+    let latestRequests: readonly PendingRequest[] = [];
+
+    function Harness() {
+      const requests = usePermissionRequests(
+        session,
+        setModel,
+        setExpandedView,
+        setAppState,
+      );
+
+      useEffect(() => {
+        latestRequests = requests;
+      }, [requests]);
+
+      return <Text>{String(requests.length)}</Text>;
+    }
+
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(<Harness />);
+      await waitFor(() => {
+        expect(session.services.approvalResolver).not.toBe(previousResolver);
+        expect(session.appStateBridge).not.toBe(previousBridge);
+      });
+
+      session.appStateBridge?.setModel?.("next-model");
+      session.appStateBridge?.setExpandedView?.("tasks");
+      session.appStateBridge?.setAppState?.(state => state);
+      expect(setModel).toHaveBeenCalledWith("next-model");
+      expect(setExpandedView).toHaveBeenCalledWith("tasks");
+      expect(setAppState).toHaveBeenCalledTimes(1);
+
+      const resolver = session.services.approvalResolver;
+      expect(resolver).toBeDefined();
+
+      const abortController = new AbortController();
+      const missingPayloadDecision = resolver!.request(
+        createCtx("missing-payload", "Read", undefined),
+      );
+      const arrayPayloadDecision = resolver!.request(
+        createCtx("array-json", "Write", {
+          kind: "function",
+          arguments: "[\"not\", \"an\", \"object\"]",
+        }),
+      );
+      const blankMcpDecision = resolver!.request(
+        createCtx("blank-mcp", "McpTool", {
+          kind: "mcp",
+          rawArguments: "  ",
+        }),
+      );
+      const customTextDecision = resolver!.request(
+        createCtx("custom-text", "CustomTool", {
+          kind: "custom",
+          input: "freeform request",
+        }),
+      );
+      const badShellDecision = resolver!.request(
+        createCtx(
+          "bad-shell",
+          "Shell",
+          {
+            kind: "local_shell",
+            params: ["pwd"],
+          },
+          { signal: abortController.signal },
+        ),
+      );
+
+      await waitFor(() => {
+        expect(latestRequests).toHaveLength(5);
+      });
+      expect(
+        latestRequests.map(request => ({
+          id: request.id,
+          input: request.input,
+          description: request.description,
+        })),
+      ).toEqual([
+        {
+          id: "missing-payload",
+          input: {},
+          description: "Permission required to use Read",
+        },
+        {
+          id: "array-json",
+          input: {},
+          description: "Permission required to use Write",
+        },
+        {
+          id: "blank-mcp",
+          input: {},
+          description: "Permission required to use McpTool",
+        },
+        {
+          id: "custom-text",
+          input: { input: "freeform request" },
+          description: "Permission required to use CustomTool",
+        },
+        {
+          id: "bad-shell",
+          input: {},
+          description: "Permission required to use Shell",
+        },
+      ]);
+
+      abortController.abort();
+      await expect(badShellDecision).resolves.toEqual(ABORT);
+      await waitFor(() => {
+        expect(latestRequests.map(request => request.id)).not.toContain("bad-shell");
+      });
+
+      const confirmQueue = buildToolUseConfirmQueue(latestRequests, [
+        { name: "Read" },
+        { name: "Write" },
+        { name: "McpTool" },
+        { name: "CustomTool" },
+      ]) as readonly ProjectedConfirm[];
+      const confirms = new Map(
+        confirmQueue.map(confirm => [confirm.toolUseID, confirm]),
+      );
+
+      confirms.get("missing-payload")!.onAllow({}, []);
+      confirms.get("array-json")!.onReject("No thanks");
+      confirms.get("blank-mcp")!.onAbort();
+      confirms.get("custom-text")!.onAllow(confirms.get("custom-text")!.input, []);
+
+      await expect(missingPayloadDecision).resolves.toEqual(APPROVED);
+      await expect(arrayPayloadDecision).resolves.toEqual(DENIED);
+      await expect(blankMcpDecision).resolves.toEqual(ABORT);
+      await expect(customTextDecision).resolves.toEqual(APPROVED);
+      await waitFor(() => {
+        expect(latestRequests).toHaveLength(0);
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+
+    expect(session.services.approvalResolver).toBe(previousResolver);
+    expect(session.appStateBridge).toBe(previousBridge);
+  });
+
+  test("denies missing tools and records ask-user-question chat feedback", async () => {
+    clearAskUserQuestionResponsesForTest();
+
+    const deniedDecisions: ReviewDecision[] = [];
+    const missingToolRequest = createPendingRequest("MissingTool", {}, decision => {
+      deniedDecisions.push(decision);
+    });
+
+    expect(buildToolUseConfirm(missingToolRequest, [{ name: "OtherTool" }])).toBeNull();
+    expect(deniedDecisions).toEqual([DENIED]);
+
+    const invalidAskDecisions: ReviewDecision[] = [];
+    const invalidAskRequest = createPendingRequest(
+      ASK_USER_QUESTION_TOOL_NAME,
+      {},
+      decision => {
+        invalidAskDecisions.push(decision);
+      },
+    );
+    const invalidAskConfirm = buildToolUseConfirm(invalidAskRequest, [
+      { name: ASK_USER_QUESTION_TOOL_NAME },
+    ]) as ProjectedConfirm;
+
+    invalidAskConfirm.onReject("The user wants to clarify these questions");
+    expect(invalidAskDecisions).toEqual([DENIED]);
+
+    const askDecisions: ReviewDecision[] = [];
+    const askRequest = createPendingRequest(
+      ASK_USER_QUESTION_TOOL_NAME,
+      askInput,
+      decision => {
+        askDecisions.push(decision);
+      },
+    );
+    const askConfirm = buildToolUseConfirm(askRequest, [
+      { name: ASK_USER_QUESTION_TOOL_NAME },
+    ]) as ProjectedConfirm;
+
+    await askConfirm.recheckPermission();
+    askConfirm.onReject("The user wants to clarify these questions before answering");
+    expect(askDecisions).toEqual([APPROVED]);
+
+    const askTool = createAskUserQuestionTool();
+    const askResult = await askTool.execute({
+      __callId: askRequest.ctx.callId,
+      ...askInput,
+    });
+
+    expect(askResult).toMatchObject({
+      codeModeResult: {
+        planInterviewAction: "chat_about_this",
+      },
+    });
+
+    clearAskUserQuestionResponsesForTest();
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-036-components-CustomSelect-use-select-input.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-036-components-CustomSelect-use-select-input.test.ts
@@ -1,0 +1,552 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { OptionWithDescription } from '../../../src/tui/components/CustomSelect/select.js'
+import { useSelectInput } from '../../../src/tui/components/CustomSelect/use-select-input.js'
+import type {
+  SelectState,
+} from '../../../src/tui/components/CustomSelect/use-select-state.js'
+import { createRoot } from '../../../src/tui/ink/root.js'
+
+type InputKey = Partial<{
+  ctrl: boolean
+  downArrow: boolean
+  pageDown: boolean
+  pageUp: boolean
+  tab: boolean
+  upArrow: boolean
+}>
+
+type InputEventStub = {
+  stopImmediatePropagation: () => void
+}
+
+type CapturedInput = {
+  handler: (input: string, key: InputKey, event: InputEventStub) => void
+  options: { isActive?: boolean }
+}
+
+type CapturedKeybindings = {
+  handlers: Record<string, () => void>
+  options: { context?: string; isActive?: boolean }
+}
+
+const inputMock = vi.hoisted(() => ({
+  current: undefined as CapturedInput | undefined,
+}))
+
+const keybindingMock = vi.hoisted(() => ({
+  current: undefined as CapturedKeybindings | undefined,
+}))
+
+const overlayMock = vi.hoisted(() => ({
+  useRegisterOverlay: vi.fn(),
+}))
+
+vi.mock('../../../src/tui/context/overlayContext.js', () => ({
+  useRegisterOverlay: overlayMock.useRegisterOverlay,
+}))
+
+vi.mock('../../../src/tui/ink.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../src/tui/ink.js')>()
+  return {
+    ...actual,
+    useInput: (
+      handler: CapturedInput['handler'],
+      options: CapturedInput['options'],
+    ) => {
+      inputMock.current = { handler, options }
+    },
+  }
+})
+
+vi.mock('../../../src/tui/keybindings/useKeybinding.js', () => ({
+  useKeybindings: (
+    handlers: Record<string, () => void>,
+    options: { context?: string; isActive?: boolean },
+  ) => {
+    keybindingMock.current = { handlers, options }
+  },
+}))
+
+function createSelectState(
+  options: OptionWithDescription<string>[],
+  overrides: Partial<SelectState<string>> = {},
+): SelectState<string> {
+  return {
+    focusedValue: options[0]?.value,
+    focusedIndex: 1,
+    visibleFromIndex: 0,
+    visibleToIndex: options.length - 1,
+    value: undefined,
+    options,
+    visibleOptions: options.map((option, index) => ({ ...option, index })),
+    isInInput: false,
+    focusNextOption: vi.fn(),
+    focusPreviousOption: vi.fn(),
+    focusNextPage: vi.fn(),
+    focusPreviousPage: vi.fn(),
+    focusOption: vi.fn(),
+    selectFocusedOption: vi.fn(),
+    onChange: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  }
+}
+
+function Harness({
+  disableSelection,
+  imagesSelected,
+  inputValues,
+  isDisabled,
+  isMultiSelect,
+  onDownFromLastItem,
+  onEnterImageSelection,
+  onInputModeToggle,
+  onUpFromFirstItem,
+  options,
+  state,
+}: {
+  disableSelection?: boolean | 'numeric'
+  imagesSelected?: boolean
+  inputValues?: Map<string, string>
+  isDisabled?: boolean
+  isMultiSelect?: boolean
+  onDownFromLastItem?: () => void
+  onEnterImageSelection?: () => boolean
+  onInputModeToggle?: (value: string) => void
+  onUpFromFirstItem?: () => void
+  options: OptionWithDescription<string>[]
+  state: SelectState<string>
+}): null {
+  useSelectInput({
+    disableSelection,
+    imagesSelected,
+    inputValues,
+    isDisabled,
+    isMultiSelect,
+    onDownFromLastItem,
+    onEnterImageSelection,
+    onInputModeToggle,
+    onUpFromFirstItem,
+    options,
+    state,
+  })
+  return null
+}
+
+async function renderHarness(
+  props: React.ComponentProps<typeof Harness>,
+): Promise<() => void> {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  root.render(React.createElement(Harness, props))
+  await new Promise(resolve => setTimeout(resolve, 30))
+
+  return () => {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+  }
+}
+
+function pressInput(input: string, key: InputKey = {}): InputEventStub {
+  const event = {
+    stopImmediatePropagation: vi.fn(),
+  }
+
+  expect(inputMock.current).toBeDefined()
+  inputMock.current!.handler(input, key, event)
+  return event
+}
+
+function keybinding(name: string): () => void {
+  const handler = keybindingMock.current?.handlers[name]
+  expect(handler).toBeDefined()
+  return handler!
+}
+
+describe('useSelectInput coverage swarm row 036', () => {
+  beforeEach(() => {
+    inputMock.current = undefined
+    keybindingMock.current = undefined
+    overlayMock.useRegisterOverlay.mockClear()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('registers inactive input and keybinding handlers without cancel or navigation handlers', async () => {
+    const options: OptionWithDescription<string>[] = [
+      { value: 'alpha', label: 'Alpha' },
+      { type: 'input', value: 'prompt', label: 'Prompt', onChange: vi.fn() },
+    ]
+    const state = createSelectState(options, {
+      focusedValue: 'prompt',
+      onCancel: undefined,
+    })
+    const unmount = await renderHarness({
+      isDisabled: true,
+      options,
+      state,
+    })
+
+    try {
+      expect(overlayMock.useRegisterOverlay).toHaveBeenCalledWith(
+        'select',
+        false,
+      )
+      expect(keybindingMock.current).toEqual({
+        handlers: {},
+        options: { context: 'Select', isActive: false },
+      })
+      expect(inputMock.current?.options).toEqual({ isActive: false })
+    } finally {
+      unmount()
+    }
+  })
+
+  test('drives keybinding navigation, boundary callbacks, accept guards, and cancel', async () => {
+    const options: OptionWithDescription<string>[] = [
+      { value: 'alpha', label: 'Alpha' },
+      { value: 'disabled', label: 'Disabled', disabled: true },
+      { value: 'omega', label: 'Omega' },
+    ]
+    const state = createSelectState(options, {
+      focusedValue: 'alpha',
+    })
+    const onDownFromLastItem = vi.fn()
+    const onUpFromFirstItem = vi.fn()
+    const unmount = await renderHarness({
+      onDownFromLastItem,
+      onUpFromFirstItem,
+      options,
+      state,
+    })
+
+    try {
+      keybinding('select:next')()
+      expect(state.focusNextOption).toHaveBeenCalledTimes(1)
+
+      state.focusedValue = 'omega'
+      keybinding('select:next')()
+      expect(onDownFromLastItem).toHaveBeenCalledTimes(1)
+      expect(state.focusNextOption).toHaveBeenCalledTimes(1)
+
+      state.visibleFromIndex = 1
+      keybinding('select:previous')()
+      expect(state.focusPreviousOption).toHaveBeenCalledTimes(1)
+
+      state.visibleFromIndex = 0
+      state.focusedValue = 'alpha'
+      keybinding('select:previous')()
+      expect(onUpFromFirstItem).toHaveBeenCalledTimes(1)
+      expect(state.focusPreviousOption).toHaveBeenCalledTimes(1)
+
+      state.focusedValue = 'disabled'
+      keybinding('select:accept')()
+      expect(state.selectFocusedOption).not.toHaveBeenCalled()
+      expect(state.onChange).not.toHaveBeenCalled()
+
+      state.focusedValue = undefined
+      keybinding('select:accept')()
+      expect(state.selectFocusedOption).not.toHaveBeenCalled()
+      expect(state.onChange).not.toHaveBeenCalled()
+
+      state.focusedValue = 'alpha'
+      keybinding('select:accept')()
+      expect(state.selectFocusedOption).toHaveBeenCalledTimes(1)
+      expect(state.onChange).toHaveBeenCalledWith('alpha')
+
+      keybinding('select:cancel')()
+      expect(state.onCancel).toHaveBeenCalledTimes(1)
+    } finally {
+      unmount()
+    }
+  })
+
+  test('does not accept from keybindings when selection is fully disabled', async () => {
+    const options: OptionWithDescription<string>[] = [
+      { value: 'alpha', label: 'Alpha' },
+    ]
+    const state = createSelectState(options)
+    const unmount = await renderHarness({
+      disableSelection: true,
+      options,
+      state,
+    })
+
+    try {
+      keybinding('select:accept')()
+      expect(state.selectFocusedOption).not.toHaveBeenCalled()
+      expect(state.onChange).not.toHaveBeenCalled()
+    } finally {
+      unmount()
+    }
+  })
+
+  test('handles input-mode tab, image handoff, arrow navigation, and edge callbacks', async () => {
+    const options: OptionWithDescription<string>[] = [
+      {
+        type: 'input',
+        value: 'first',
+        label: 'First',
+        onChange: vi.fn(),
+      },
+      {
+        type: 'input',
+        value: 'prompt',
+        label: 'Prompt',
+        onChange: vi.fn(),
+      },
+      {
+        type: 'input',
+        value: 'last',
+        label: 'Last',
+        onChange: vi.fn(),
+      },
+    ]
+    const state = createSelectState(options, {
+      focusedValue: 'prompt',
+      isInInput: true,
+    })
+    const onDownFromLastItem = vi.fn()
+    const onEnterImageSelection = vi.fn()
+      .mockReturnValueOnce(true)
+      .mockReturnValue(false)
+    const onInputModeToggle = vi.fn()
+    const onUpFromFirstItem = vi.fn()
+    const unmount = await renderHarness({
+      onDownFromLastItem,
+      onEnterImageSelection,
+      onInputModeToggle,
+      onUpFromFirstItem,
+      options,
+      state,
+    })
+
+    try {
+      pressInput('', { tab: true })
+      expect(onInputModeToggle).toHaveBeenCalledWith('prompt')
+
+      const imageEvent = pressInput('', { downArrow: true })
+      expect(onEnterImageSelection).toHaveBeenCalledTimes(1)
+      expect(imageEvent.stopImmediatePropagation).toHaveBeenCalledTimes(1)
+      expect(state.focusNextOption).not.toHaveBeenCalled()
+
+      const downEvent = pressInput('', { downArrow: true })
+      expect(state.focusNextOption).toHaveBeenCalledTimes(1)
+      expect(downEvent.stopImmediatePropagation).toHaveBeenCalledTimes(1)
+
+      const ctrlNEvent = pressInput('n', { ctrl: true })
+      expect(state.focusNextOption).toHaveBeenCalledTimes(2)
+      expect(ctrlNEvent.stopImmediatePropagation).toHaveBeenCalledTimes(1)
+
+      state.focusedValue = 'last'
+      const lastEvent = pressInput('', { downArrow: true })
+      expect(onDownFromLastItem).toHaveBeenCalledTimes(1)
+      expect(lastEvent.stopImmediatePropagation).toHaveBeenCalledTimes(1)
+      expect(state.focusNextOption).toHaveBeenCalledTimes(2)
+
+      state.focusedValue = 'prompt'
+      const ctrlPEvent = pressInput('p', { ctrl: true })
+      expect(state.focusPreviousOption).toHaveBeenCalledTimes(1)
+      expect(ctrlPEvent.stopImmediatePropagation).toHaveBeenCalledTimes(1)
+
+      state.focusedValue = 'first'
+      const firstEvent = pressInput('', { upArrow: true })
+      expect(onUpFromFirstItem).toHaveBeenCalledTimes(1)
+      expect(firstEvent.stopImmediatePropagation).toHaveBeenCalledTimes(1)
+      expect(state.focusPreviousOption).toHaveBeenCalledTimes(1)
+
+      const digitEvent = pressInput('7')
+      expect(digitEvent.stopImmediatePropagation).not.toHaveBeenCalled()
+      expect(state.onChange).not.toHaveBeenCalled()
+    } finally {
+      unmount()
+    }
+  })
+
+  test('suppresses input handling while image selection is active', async () => {
+    const options: OptionWithDescription<string>[] = [
+      { type: 'input', value: 'prompt', label: 'Prompt', onChange: vi.fn() },
+    ]
+    const state = createSelectState(options, {
+      focusedValue: 'prompt',
+      isInInput: true,
+    })
+    const onEnterImageSelection = vi.fn()
+    const unmount = await renderHarness({
+      imagesSelected: true,
+      onEnterImageSelection,
+      options,
+      state,
+    })
+
+    try {
+      const event = pressInput('', { downArrow: true })
+      expect(onEnterImageSelection).not.toHaveBeenCalled()
+      expect(state.focusNextOption).not.toHaveBeenCalled()
+      expect(event.stopImmediatePropagation).not.toHaveBeenCalled()
+    } finally {
+      unmount()
+    }
+  })
+
+  test('handles non-input paging, multi-select spaces, and numeric shortcut targets', async () => {
+    const options: OptionWithDescription<string>[] = [
+      { value: 'alpha', label: 'Alpha' },
+      { value: 'disabled', label: 'Disabled', disabled: true },
+      {
+        type: 'input',
+        value: 'ready',
+        label: 'Ready',
+        onChange: vi.fn(),
+      },
+      {
+        type: 'input',
+        value: 'cancel',
+        label: 'Cancel',
+        onChange: vi.fn(),
+        allowEmptySubmitToCancel: true,
+      },
+      {
+        type: 'input',
+        value: 'empty',
+        label: 'Empty',
+        onChange: vi.fn(),
+      },
+      { value: 'omega', label: 'Omega' },
+    ]
+    const state = createSelectState(options, {
+      focusedValue: 'alpha',
+    })
+    const inputValues = new Map<string, string>([
+      ['ready', ' submit '],
+      ['cancel', ''],
+      ['empty', '   '],
+    ])
+    const unmount = await renderHarness({
+      inputValues,
+      isMultiSelect: true,
+      options,
+      state,
+    })
+
+    try {
+      pressInput('', { pageDown: true })
+      expect(state.focusNextPage).toHaveBeenCalledTimes(1)
+
+      pressInput('', { pageUp: true })
+      expect(state.focusPreviousPage).toHaveBeenCalledTimes(1)
+
+      pressInput('\u3000')
+      expect(state.selectFocusedOption).toHaveBeenCalledTimes(1)
+      expect(state.onChange).toHaveBeenCalledWith('alpha')
+
+      state.focusedValue = 'disabled'
+      pressInput(' ')
+      expect(state.selectFocusedOption).toHaveBeenCalledTimes(1)
+      expect(state.onChange).toHaveBeenCalledTimes(1)
+
+      state.focusedValue = undefined
+      pressInput(' ')
+      expect(state.selectFocusedOption).toHaveBeenCalledTimes(1)
+      expect(state.onChange).toHaveBeenCalledTimes(1)
+
+      pressInput('0')
+      pressInput('9')
+      expect(state.onChange).toHaveBeenCalledTimes(1)
+
+      pressInput('2')
+      expect(state.onChange).toHaveBeenCalledTimes(1)
+
+      pressInput('3')
+      expect(state.onChange).toHaveBeenNthCalledWith(2, 'ready')
+
+      pressInput('4')
+      expect(state.onChange).toHaveBeenNthCalledWith(3, 'cancel')
+
+      pressInput('5')
+      expect(state.focusOption).toHaveBeenCalledWith('empty')
+      expect(state.onChange).toHaveBeenCalledTimes(3)
+
+      pressInput('\uff16')
+      expect(state.onChange).toHaveBeenNthCalledWith(4, 'omega')
+    } finally {
+      unmount()
+    }
+  })
+
+  test('keeps page navigation but suppresses selection input when selection is disabled', async () => {
+    const options: OptionWithDescription<string>[] = [
+      { value: 'alpha', label: 'Alpha' },
+      { value: 'omega', label: 'Omega' },
+    ]
+    const state = createSelectState(options)
+    const unmount = await renderHarness({
+      disableSelection: true,
+      isMultiSelect: true,
+      options,
+      state,
+    })
+
+    try {
+      pressInput('', { pageDown: true })
+      expect(state.focusNextPage).toHaveBeenCalledTimes(1)
+
+      pressInput(' ')
+      pressInput('1')
+      expect(state.selectFocusedOption).not.toHaveBeenCalled()
+      expect(state.onChange).not.toHaveBeenCalled()
+    } finally {
+      unmount()
+    }
+  })
+
+  test('allows multi-select spaces but suppresses numeric shortcuts in numeric-only disabled mode', async () => {
+    const options: OptionWithDescription<string>[] = [
+      { value: 'alpha', label: 'Alpha' },
+      { value: 'omega', label: 'Omega' },
+    ]
+    const state = createSelectState(options)
+    const unmount = await renderHarness({
+      disableSelection: 'numeric',
+      isMultiSelect: true,
+      options,
+      state,
+    })
+
+    try {
+      pressInput('1')
+      expect(state.onChange).not.toHaveBeenCalled()
+
+      pressInput(' ')
+      expect(state.selectFocusedOption).toHaveBeenCalledTimes(1)
+      expect(state.onChange).toHaveBeenCalledWith('alpha')
+    } finally {
+      unmount()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-037-hooks-useTextInput.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-037-hooks-useTextInput.test.ts
@@ -1,0 +1,300 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  addToHistory: vi.fn(),
+  fullscreen: false,
+  markBackslashReturnUsed: vi.fn(),
+  modifiers: {} as Record<string, boolean>,
+  prewarmModifiers: vi.fn(),
+  removeNotification: vi.fn(),
+  reset() {
+    this.addNotification.mockClear()
+    this.addToHistory.mockClear()
+    this.fullscreen = false
+    this.markBackslashReturnUsed.mockClear()
+    this.modifiers = {}
+    this.prewarmModifiers.mockClear()
+    this.removeNotification.mockClear()
+  },
+}))
+
+vi.mock('src/tui/context/notifications.js', () => ({
+  useNotifications: () => ({
+    addNotification: harness.addNotification,
+    removeNotification: harness.removeNotification,
+  }),
+}))
+
+vi.mock('src/commands/terminalSetup/terminalSetup.js', () => ({
+  markBackslashReturnUsed: harness.markBackslashReturnUsed,
+}))
+
+vi.mock('src/tui/history/history.js', () => ({
+  addToHistory: harness.addToHistory,
+}))
+
+vi.mock('src/utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => harness.fullscreen,
+}))
+
+vi.mock('src/utils/modifiers.js', () => ({
+  isModifierPressed: (modifier: string) => harness.modifiers[modifier] === true,
+  prewarmModifiers: harness.prewarmModifiers,
+}))
+
+import { createRoot } from 'src/tui/ink/root.js'
+import type { Key } from 'src/tui/ink.js'
+import { clearKillRing } from 'src/utils/TextCursor.js'
+import { useTextInput, type UseTextInputProps } from 'src/tui/hooks/useTextInput.js'
+
+type HookState = ReturnType<typeof useTextInput>
+
+const BASE_KEY: Key = {
+  backspace: false,
+  ctrl: false,
+  delete: false,
+  downArrow: false,
+  end: false,
+  escape: false,
+  fn: false,
+  home: false,
+  leftArrow: false,
+  meta: false,
+  pageDown: false,
+  pageUp: false,
+  return: false,
+  rightArrow: false,
+  shift: false,
+  super: false,
+  tab: false,
+  upArrow: false,
+  wheelDown: false,
+  wheelUp: false,
+}
+
+function key(overrides: Partial<Key> = {}): Key {
+  return { ...BASE_KEY, ...overrides }
+}
+
+function createStreams(): {
+  readonly stdout: PassThrough
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 80
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderHookHarness(
+  overrides: Partial<UseTextInputProps> = {},
+): Promise<{
+  readonly latest: () => HookState
+  readonly onChange: ReturnType<typeof vi.fn>
+  readonly onExitMessage: ReturnType<typeof vi.fn>
+  readonly onHistoryDown: ReturnType<typeof vi.fn>
+  readonly onHistoryUp: ReturnType<typeof vi.fn>
+  readonly onOffsetChange: ReturnType<typeof vi.fn>
+  readonly render: (next?: Partial<UseTextInputProps>) => Promise<void>
+  readonly dispose: () => Promise<void>
+}> {
+  const onChange = vi.fn()
+  const onExitMessage = vi.fn()
+  const onHistoryDown = vi.fn()
+  const onHistoryUp = vi.fn()
+  const onOffsetChange = vi.fn()
+  let props: UseTextInputProps = {
+    columns: 20,
+    cursorChar: '|',
+    externalOffset: overrides.value?.length ?? 0,
+    invert: text => `<${text}>`,
+    onChange,
+    onExitMessage,
+    onHistoryDown,
+    onHistoryUp,
+    onOffsetChange,
+    themeText: text => text,
+    value: '',
+    ...overrides,
+  }
+  let latest: HookState | undefined
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    latest = useTextInput(props)
+    return null
+  }
+
+  async function render(next: Partial<UseTextInputProps> = {}): Promise<void> {
+    props = { ...props, ...next }
+    root.render(React.createElement(Harness))
+    await sleep()
+  }
+
+  await render()
+
+  return {
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+    onChange,
+    onExitMessage,
+    onHistoryDown,
+    onHistoryUp,
+    onOffsetChange,
+    render,
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+  }
+}
+
+describe('useTextInput coverage swarm row 037', () => {
+  beforeEach(() => {
+    harness.reset()
+    clearKillRing()
+  })
+
+  afterEach(() => {
+    clearKillRing()
+    vi.restoreAllMocks()
+  })
+
+  test('routes plain up and down arrows through wrapped cursor movement', async () => {
+    const input = 'alpha beta gamma delta'
+    const rendered = await renderHookHarness({
+      columns: 8,
+      externalOffset: input.length,
+      value: input,
+    })
+
+    try {
+      const endOffset = rendered.latest().offset
+
+      rendered.latest().onInput('', key({ upArrow: true }))
+      await sleep()
+      const offsetAfterUp = rendered.latest().offset
+
+      expect(offsetAfterUp).toBeLessThan(endOffset)
+      expect(rendered.onHistoryUp).not.toHaveBeenCalled()
+
+      rendered.latest().onInput('', key({ downArrow: true }))
+      await sleep()
+      expect(rendered.latest().offset).toBe(endOffset)
+      expect(rendered.onHistoryDown).not.toHaveBeenCalled()
+
+      rendered.latest().onInput('', key({ upArrow: true, shift: true }))
+      await sleep()
+      expect(rendered.latest().offset).toBe(endOffset)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('falls back to history callbacks for multiline boundary arrows', async () => {
+    const rendered = await renderHookHarness({
+      externalOffset: 0,
+      multiline: true,
+      value: 'solo',
+    })
+
+    try {
+      rendered.latest().onInput('', key({ upArrow: true }))
+      await sleep()
+      expect(rendered.onHistoryUp).toHaveBeenCalledTimes(1)
+      expect(rendered.latest().offset).toBe(0)
+
+      await rendered.render({ externalOffset: 'solo'.length, value: 'solo' })
+      rendered.latest().onInput('', key({ downArrow: true }))
+      await sleep()
+      expect(rendered.onHistoryDown).toHaveBeenCalledTimes(1)
+      expect(rendered.latest().offset).toBe('solo'.length)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('renders inline ghost text only when insert position matches the cursor', async () => {
+    const rendered = await renderHookHarness({
+      dim: text => `[${text}]`,
+      externalOffset: 3,
+      inlineGhostText: { insertPosition: 3, text: ' there' },
+      value: 'say',
+    })
+
+    try {
+      expect(rendered.latest().renderedValue).toContain('< >[there]')
+
+      await rendered.render({
+        inlineGhostText: { insertPosition: 1, text: ' ignored' },
+      })
+      expect(rendered.latest().renderedValue).not.toContain('[ignored]')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('ignores stale empty-input Ctrl-D timeout after local value changes', async () => {
+    const rendered = await renderHookHarness({
+      externalOffset: 0,
+      value: '',
+    })
+
+    try {
+      rendered.latest().onInput('x\x7f', key())
+      await sleep()
+      expect(rendered.latest().value).toBe('')
+      expect(rendered.onChange).not.toHaveBeenCalled()
+
+      rendered.latest().onInput('', key({ ctrl: true }))
+      await sleep()
+      expect(rendered.onExitMessage).not.toHaveBeenCalled()
+
+      rendered.latest().onInput('d', key({ ctrl: true }))
+      await sleep()
+      expect(rendered.onExitMessage).toHaveBeenCalledWith(true, 'Ctrl-D')
+
+      rendered.latest().setValue('busy', 4)
+      await sleep()
+      expect(rendered.latest().value).toBe('busy')
+
+      rendered.latest().setValue('busy', 4)
+      await sleep(850)
+      expect(rendered.onExitMessage).not.toHaveBeenCalledWith(false, 'Ctrl-D')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-038-components-markdown-HighlightedCode.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-038-components-markdown-HighlightedCode.test.tsx
@@ -1,0 +1,191 @@
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../../src/utils/staticRender.js'
+import { HighlightedCode } from '../../../src/tui/components/markdown/HighlightedCode.js'
+
+const harness = vi.hoisted(() => ({
+  syntaxHighlightingDisabled: false,
+  fullscreen: false,
+  colorFileAvailable: true,
+  highlightedLines: [] as string[],
+  expectColorFileCalls: 0,
+  colorFileConstructors: [] as Array<{
+    readonly code: string
+    readonly filePath: string
+  }>,
+  renderCalls: [] as Array<{
+    readonly width: number
+    readonly dim: boolean
+  }>,
+  fallbackCalls: [] as Array<{
+    readonly code: string
+    readonly filePath: string
+    readonly dim: boolean | undefined
+    readonly skipColoring: boolean | undefined
+  }>,
+  measureCalls: 0,
+  measureWidth: 0,
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../../src/tui/hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    syntaxHighlightingDisabled: harness.syntaxHighlightingDisabled,
+  }),
+}))
+
+vi.mock('../../../src/utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => harness.fullscreen,
+}))
+
+vi.mock('../../../src/tui/ink.js', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    measureElement: () => {
+      harness.measureCalls += 1
+      return { width: harness.measureWidth, height: 1 }
+    },
+  }
+})
+
+vi.mock(
+  '../../../src/tui/components/markdown/HighlightedCodeFallback.js',
+  async () => {
+    return {
+      HighlightedCodeFallback: (props: {
+        readonly code: string
+        readonly filePath: string
+        readonly dim?: boolean
+        readonly skipColoring?: boolean
+      }) => {
+        harness.fallbackCalls.push({
+          code: props.code,
+          filePath: props.filePath,
+          dim: props.dim,
+          skipColoring: props.skipColoring,
+        })
+
+        return null
+      },
+    }
+  },
+)
+
+vi.mock('../../../src/tui/components/diff/StructuredDiff/colorDiff.js', () => ({
+  expectColorFile: () => {
+    harness.expectColorFileCalls += 1
+    if (!harness.colorFileAvailable) return null
+
+    return class MockColorFile {
+      constructor(
+        readonly code: string,
+        readonly filePath: string,
+      ) {
+        harness.colorFileConstructors.push({ code, filePath })
+      }
+
+      render(_theme: unknown, width: number, dim: boolean): string[] {
+        harness.renderCalls.push({ width, dim })
+        return harness.highlightedLines
+      }
+    }
+  },
+}))
+
+describe('HighlightedCode coverage swarm 038', () => {
+  beforeEach(() => {
+    harness.syntaxHighlightingDisabled = false
+    harness.fullscreen = false
+    harness.colorFileAvailable = true
+    harness.highlightedLines = ['highlighted line']
+    harness.expectColorFileCalls = 0
+    harness.colorFileConstructors = []
+    harness.renderCalls = []
+    harness.fallbackCalls = []
+    harness.measureCalls = 0
+    harness.measureWidth = 0
+  })
+
+  test('uses the plain fallback without loading color helpers when highlighting is disabled', async () => {
+    harness.syntaxHighlightingDisabled = true
+
+    await renderToString(
+      <HighlightedCode
+        code="const disabled = 1"
+        filePath="disabled.ts"
+        width={60}
+        dim
+      />,
+      80,
+    )
+
+    expect(harness.expectColorFileCalls).toBe(0)
+    expect(harness.colorFileConstructors).toEqual([])
+    expect(harness.fallbackCalls).toEqual([
+      {
+        code: 'const disabled = 1',
+        filePath: 'disabled.ts',
+        dim: true,
+        skipColoring: true,
+      },
+    ])
+  })
+
+  test('uses the color-capable fallback when color helpers are unavailable', async () => {
+    harness.colorFileAvailable = false
+
+    await renderToString(
+      <HighlightedCode
+        code="let unavailable = 2"
+        filePath="unavailable.ts"
+        width={52}
+      />,
+      80,
+    )
+
+    expect(harness.expectColorFileCalls).toBe(1)
+    expect(harness.colorFileConstructors).toEqual([])
+    expect(harness.fallbackCalls).toEqual([
+      {
+        code: 'let unavailable = 2',
+        filePath: 'unavailable.ts',
+        dim: false,
+        skipColoring: false,
+      },
+    ])
+  })
+
+  test('renders highlighted output without fullscreen gutters', async () => {
+    harness.highlightedLines = [
+      ' 1  const first = 1',
+      '12  const twelfth = 12',
+    ]
+
+    const output = await renderToString(
+      <HighlightedCode code="const first = 1" filePath="plain.ts" width={37} />,
+      80,
+    )
+
+    expect(output).toContain(' 1  const first = 1')
+    expect(output).toContain('12  const twelfth = 12')
+    expect(harness.fallbackCalls).toEqual([])
+    expect(harness.renderCalls).toEqual([{ width: 37, dim: false }])
+  })
+
+  test('uses the default render width when the width prop is omitted', async () => {
+    harness.measureWidth = 62
+    harness.highlightedLines = ['measured width line']
+
+    await renderToString(
+      <HighlightedCode code="const measured = 3" filePath="measured.ts" />,
+      90,
+    )
+
+    expect(harness.renderCalls[0]).toEqual({ width: 80, dim: false })
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-039-message-renderers-AssistantTextMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-039-message-renderers-AssistantTextMessage.test.tsx
@@ -1,0 +1,197 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('../hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    syntaxHighlightingDisabled: true,
+  }),
+}))
+
+vi.mock('../../utils/model/contextWindowUpgradeCheck.js', () => ({
+  getUpgradeMessage: () => 'switch to a larger context model',
+}))
+
+vi.mock('../../utils/secureStorage/macOsKeychainStorage.js', () => ({
+  isMacOsKeychainLocked: () => true,
+}))
+
+import { ERROR_MESSAGE_USER_ABORT } from '../../services/compact/compact.js'
+import {
+  API_ERROR_MESSAGE_PREFIX,
+  CREDIT_BALANCE_TOO_LOW_ERROR_MESSAGE,
+  CUSTOM_OFF_SWITCH_MESSAGE,
+  INVALID_API_KEY_ERROR_MESSAGE,
+  INVALID_API_KEY_ERROR_MESSAGE_EXTERNAL,
+  ORG_DISABLED_ERROR_MESSAGE_ENV_KEY_WITH_OAUTH,
+  PROMPT_TOO_LONG_ERROR_MESSAGE,
+  TOKEN_REVOKED_ERROR_MESSAGE,
+} from '../../services/api/errors.js'
+import { createRoot } from '../ink/root.js'
+import { AssistantTextMessage } from '../message-renderers/AssistantTextMessage.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type RenderOptions = {
+  readonly addMargin?: boolean
+  readonly onOpenRateLimitOptions?: () => void
+  readonly verbose?: boolean
+}
+
+function createStreams(): {
+  readonly stdin: TestStdin
+  readonly stdout: PassThrough
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStdin
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  ;(stdout as unknown as { columns: number; rows: number }).columns = 120
+  ;(stdout as unknown as { columns: number; rows: number }).rows = 30
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function normalizeOutput(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
+function renderAssistantText(text: string, options: RenderOptions = {}): React.ReactNode {
+  return (
+    <AssistantTextMessage
+      addMargin={options.addMargin ?? false}
+      onOpenRateLimitOptions={options.onOpenRateLimitOptions}
+      param={{ type: 'text', text }}
+      shouldShowDot={false}
+      verbose={options.verbose ?? false}
+    />
+  )
+}
+
+async function renderSequence(
+  steps: ReadonlyArray<{
+    readonly text: string
+    readonly options?: RenderOptions
+  }>,
+): Promise<string> {
+  const { stdin, stdout } = createStreams()
+  let output = ''
+
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  try {
+    for (const step of steps) {
+      root.render(renderAssistantText(step.text, step.options))
+      await sleep()
+    }
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await sleep()
+  }
+
+  return stripAnsi(output)
+}
+
+describe('AssistantTextMessage swarm 039 coverage', () => {
+  test('rerenders memoized built-in messages with their action text intact', async () => {
+    const output = await renderSequence([
+      { text: PROMPT_TOO_LONG_ERROR_MESSAGE },
+      { text: PROMPT_TOO_LONG_ERROR_MESSAGE },
+      { text: CREDIT_BALANCE_TOO_LOW_ERROR_MESSAGE },
+      { text: CREDIT_BALANCE_TOO_LOW_ERROR_MESSAGE },
+      { text: INVALID_API_KEY_ERROR_MESSAGE },
+      { text: INVALID_API_KEY_ERROR_MESSAGE },
+      { text: INVALID_API_KEY_ERROR_MESSAGE_EXTERNAL },
+      { text: INVALID_API_KEY_ERROR_MESSAGE_EXTERNAL },
+      { text: ORG_DISABLED_ERROR_MESSAGE_ENV_KEY_WITH_OAUTH },
+      { text: ORG_DISABLED_ERROR_MESSAGE_ENV_KEY_WITH_OAUTH },
+      { text: TOKEN_REVOKED_ERROR_MESSAGE },
+      { text: TOKEN_REVOKED_ERROR_MESSAGE },
+      { text: CUSTOM_OFF_SWITCH_MESSAGE },
+      { text: CUSTOM_OFF_SWITCH_MESSAGE },
+      { text: ERROR_MESSAGE_USER_ABORT },
+      { text: ERROR_MESSAGE_USER_ABORT },
+    ])
+
+    expect(output).toContain('switch to a larger context model')
+    expect(output).toContain('Credit balance too low')
+    expect(output).toContain('security unlock-keychain')
+    expect(output).toContain(INVALID_API_KEY_ERROR_MESSAGE_EXTERNAL)
+    expect(normalizeOutput(output)).toContain(
+      normalizeOutput(ORG_DISABLED_ERROR_MESSAGE_ENV_KEY_WITH_OAUTH),
+    )
+    expect(output).toContain(TOKEN_REVOKED_ERROR_MESSAGE)
+    expect(output).toContain('use /model')
+    expect(output).toContain('Interrupted')
+  })
+
+  test('rerenders rate-limit and API-prefixed messages through cached branches', async () => {
+    const onOpenRateLimitOptions = vi.fn()
+    const longApiError = `${API_ERROR_MESSAGE_PREFIX}: ${'x'.repeat(1200)}`
+    const output = await renderSequence([
+      {
+        text: "You've hit your session limit",
+        options: { onOpenRateLimitOptions },
+      },
+      {
+        text: "You've hit your session limit",
+        options: { onOpenRateLimitOptions },
+      },
+      {
+        text: "You've used 90% of your weekly limit",
+        options: { onOpenRateLimitOptions },
+      },
+      {
+        text: "You've used 90% of your weekly limit",
+        options: { onOpenRateLimitOptions },
+      },
+      { text: API_ERROR_MESSAGE_PREFIX },
+      { text: API_ERROR_MESSAGE_PREFIX },
+      { text: `${API_ERROR_MESSAGE_PREFIX}: short failure` },
+      { text: `${API_ERROR_MESSAGE_PREFIX}: short failure` },
+      { text: longApiError },
+      { text: longApiError },
+    ])
+
+    expect(output).toContain("You've hit your session limit")
+    expect(output).toContain("You've used 90% of your weekly limit")
+    expect(output).toContain('Please wait a moment and try again.')
+    expect(output).toContain('short failure')
+    expect(output).toContain('ctrl+o')
+  })
+
+  test('rerenders ordinary assistant text without margin or selected background', async () => {
+    const output = await renderSequence([
+      { text: '**Ready** to proceed' },
+      { text: '**Ready** to proceed' },
+    ])
+
+    expect(output).toContain('AGENC')
+    expect(output).toContain('Ready to proceed')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-040-components-messageActions.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-040-components-messageActions.test.tsx
@@ -1,0 +1,512 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const probes = vi.hoisted(() => ({
+  keybindingCalls: [] as Array<{
+    handlers: Record<string, () => void>
+    options: { context: string; isActive: boolean }
+  }>,
+  logEvent: vi.fn(),
+}))
+
+vi.mock('../keybindings/useKeybinding.js', () => ({
+  useKeybindings: (
+    handlers: Record<string, () => void>,
+    options: { context: string; isActive: boolean },
+  ) => {
+    probes.keybindingCalls.push({ handlers, options })
+  },
+}))
+
+vi.mock('../../services/analytics/index', () => ({
+  logEvent: probes.logEvent,
+}))
+
+import { Text } from '../ink.js'
+import { createRoot, type Root } from '../ink/root.js'
+import {
+  MessageActionsBar,
+  MessageActionsKeybindings,
+  MessageActionsSelectedContext,
+  type MessageActionCaps,
+  type MessageActionsNav,
+  type MessageActionsState,
+  type NavigableMessage,
+  copyTextOf,
+  isNavigableMessage,
+  stripSystemReminders,
+  toolCallOf,
+  useMessageActions,
+  useSelectedMessageBg,
+} from '../components/messageActions.js'
+
+function createStreams(): {
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdout: PassThrough
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as ReturnType<typeof createStreams>['stdin']
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 120
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function createInkRoot(): Promise<{
+  dispose: () => Promise<void>
+  output: () => string
+  root: Root
+}> {
+  let output = ''
+  const { stdin, stdout } = createStreams()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    output: () => stripAnsi(output),
+    root,
+  }
+}
+
+function userText(text: string, extra: Record<string, unknown> = {}): NavigableMessage {
+  return {
+    type: 'user',
+    uuid: `user-${text}`,
+    message: { content: [{ type: 'text', text }] },
+    ...extra,
+  } as never
+}
+
+function assistantText(text: string): NavigableMessage {
+  return {
+    type: 'assistant',
+    uuid: `assistant-${text}`,
+    message: { content: [{ type: 'text', text }] },
+  } as never
+}
+
+function assistantTool(
+  name: string,
+  input: Record<string, unknown>,
+): NavigableMessage {
+  return {
+    type: 'assistant',
+    uuid: `assistant-tool-${name}`,
+    message: { content: [{ type: 'tool_use', name, input }] },
+  } as never
+}
+
+function toolResult(content: unknown): NavigableMessage {
+  return {
+    type: 'user',
+    uuid: 'tool-result',
+    message: {
+      content: [{ type: 'tool_result', tool_use_id: 'tool-1', content }],
+    },
+  } as never
+}
+
+function navWithSelected(selected: NavigableMessage | null): MessageActionsNav {
+  return {
+    enterCursor: vi.fn(),
+    getSelected: vi.fn(() => selected),
+    navigateBottom: vi.fn(),
+    navigateNext: vi.fn(),
+    navigateNextUser: vi.fn(),
+    navigatePrev: vi.fn(),
+    navigatePrevUser: vi.fn(),
+    navigateTop: vi.fn(),
+  }
+}
+
+type CapturedActions = ReturnType<typeof useMessageActions> & {
+  cursor: MessageActionsState | null
+  setCursor: React.Dispatch<React.SetStateAction<MessageActionsState | null>>
+}
+
+async function renderActionsHarness({
+  caps,
+  capture,
+  initialCursor,
+  nav,
+}: {
+  caps: MessageActionCaps
+  capture: { current: CapturedActions | null }
+  initialCursor: MessageActionsState | null
+  nav: { current: MessageActionsNav | null }
+}): Promise<{
+  dispose: () => Promise<void>
+}> {
+  const rendered = await createInkRoot()
+
+  function Harness(): React.ReactNode {
+    const [cursor, setCursor] =
+      React.useState<MessageActionsState | null>(initialCursor)
+    const actions = useMessageActions(cursor, setCursor, nav, caps)
+    capture.current = { ...actions, cursor, setCursor }
+    return <Text>{cursor ? `${cursor.uuid}:${cursor.expanded}` : 'none'}</Text>
+  }
+
+  rendered.root.render(<Harness />)
+  await sleep()
+
+  return {
+    dispose: rendered.dispose,
+  }
+}
+
+describe('swarm 040 message action helpers', () => {
+  afterEach(() => {
+    probes.keybindingCalls = []
+    vi.clearAllMocks()
+  })
+
+  test('classifies less common actionable and filtered message shapes', () => {
+    expect(isNavigableMessage(assistantText('No response requested.'))).toBe(false)
+    expect(isNavigableMessage(assistantTool('Read', { file_path: 123 }))).toBe(true)
+    expect(isNavigableMessage(assistantTool('Unknown', { file_path: 'x' }))).toBe(false)
+
+    expect(isNavigableMessage(userText('No response requested.'))).toBe(false)
+    expect(
+      isNavigableMessage(
+        userText(
+          '<system-reminder>hidden</system-reminder>\n<local-command-stdout>generated</local-command-stdout>',
+        ),
+      ),
+    ).toBe(false)
+    expect(isNavigableMessage(userText('kept prompt'))).toBe(true)
+
+    expect(isNavigableMessage({ type: 'system', subtype: undefined } as never)).toBe(true)
+    expect(
+      isNavigableMessage({
+        type: 'attachment',
+        attachment: { type: 'hook_blocking_error' },
+      } as never),
+    ).toBe(true)
+    expect(
+      isNavigableMessage({
+        type: 'attachment',
+        attachment: { type: 'image' },
+      } as never),
+    ).toBe(false)
+  })
+
+  test('extracts tool calls and copy text for sparse payload variants', () => {
+    expect(stripSystemReminders('  visible')).toBe('visible')
+    expect(stripSystemReminders('<system-reminder>open')).toBe('<system-reminder>open')
+
+    expect(toolCallOf(assistantText('plain'))).toBeUndefined()
+    expect(
+      toolCallOf({
+        type: 'grouped_tool_use',
+        toolName: 'Task',
+        messages: [
+          {
+            type: 'assistant',
+            message: { content: [{ type: 'text', text: 'not a tool' }] },
+          },
+        ],
+      } as never),
+    ).toBeUndefined()
+    expect(
+      toolCallOf({
+        type: 'grouped_tool_use',
+        toolName: 'Task',
+        messages: [
+          {
+            type: 'assistant',
+            message: { content: [{ type: 'tool_use', input: { prompt: 'delegate' } }] },
+          },
+        ],
+      } as never),
+    ).toEqual({ name: 'Task', input: { prompt: 'delegate' } })
+
+    expect(copyTextOf({ type: 'user', message: { content: [{ type: 'image' }] } } as never)).toBe('')
+    expect(copyTextOf(assistantTool('Edit', { file_path: 'edited.ts' }))).toBe('edited.ts')
+    expect(copyTextOf(assistantTool('Write', { file_path: 'written.ts' }))).toBe('written.ts')
+    expect(copyTextOf(assistantTool('Task', { prompt: 'summarize' }))).toBe('summarize')
+    expect(copyTextOf(assistantTool('Read', { file_path: 99 }))).toBe('')
+
+    expect(
+      copyTextOf({
+        type: 'grouped_tool_use',
+        results: [
+          toolResult(undefined),
+          { type: 'user', message: { content: [{ type: 'text', text: 'ignored' }] } },
+          toolResult([{ type: 'image' }, { type: 'text', text: 'visible block' }]),
+        ],
+      } as never),
+    ).toBe('visible block')
+
+    expect(
+      copyTextOf({
+        type: 'collapsed_read_search',
+        messages: [
+          toolResult('direct result'),
+          { type: 'assistant', message: { content: [{ type: 'text', text: 'ignored' }] } },
+          {
+            type: 'grouped_tool_use',
+            results: [toolResult(null), toolResult([{ type: 'text', text: 'nested result' }])],
+          },
+        ],
+      } as never),
+    ).toBe('direct result\n\nnested result')
+
+    expect(
+      copyTextOf({
+        type: 'attachment',
+        attachment: {
+          type: 'queued_command',
+          prompt: [{ type: 'image' }, { type: 'text', text: 'typed command' }],
+        },
+      } as never),
+    ).toBe('typed command')
+    expect(copyTextOf({ type: 'attachment', attachment: { type: 'hook_error_during_execution' } } as never)).toBe(
+      '[hook_error_during_execution]',
+    )
+  })
+})
+
+describe('swarm 040 message action rendering', () => {
+  test('renders action bars across memoized and changed cursors', async () => {
+    const rendered = await createInkRoot()
+    const cursor: MessageActionsState = {
+      expanded: false,
+      msgType: 'system',
+      uuid: 'system-message',
+    }
+
+    try {
+      rendered.root.render(<MessageActionsBar cursor={cursor} />)
+      await sleep()
+      rendered.root.render(<MessageActionsBar cursor={cursor} />)
+      await sleep()
+      rendered.root.render(
+        <MessageActionsBar
+          cursor={{
+            expanded: true,
+            msgType: 'attachment',
+            uuid: 'attachment-message',
+          }}
+        />,
+      )
+      await sleep()
+
+      const output = rendered.output()
+      expect(output).toContain('enter expand')
+      expect(output).toContain('enter collapse')
+      expect(output).toContain('c copy')
+      expect(output).toContain('navigate')
+      expect(output).toContain('esc back')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('memoizes keybinding options until active state changes', async () => {
+    const rendered = await createInkRoot()
+    const handlers = { 'messageActions:next': vi.fn() }
+
+    try {
+      rendered.root.render(
+        <MessageActionsKeybindings handlers={handlers} isActive={true} />,
+      )
+      await sleep()
+      rendered.root.render(
+        <MessageActionsKeybindings handlers={handlers} isActive={true} />,
+      )
+      await sleep()
+      rendered.root.render(
+        <MessageActionsKeybindings handlers={handlers} isActive={false} />,
+      )
+      await sleep()
+
+      expect(probes.keybindingCalls).toHaveLength(3)
+      expect(probes.keybindingCalls[0]?.options).toEqual({
+        context: 'MessageActions',
+        isActive: true,
+      })
+      expect(probes.keybindingCalls[1]?.options).toBe(
+        probes.keybindingCalls[0]?.options,
+      )
+      expect(probes.keybindingCalls[2]?.options).toEqual({
+        context: 'MessageActions',
+        isActive: false,
+      })
+      expect(probes.keybindingCalls[2]?.options).not.toBe(
+        probes.keybindingCalls[0]?.options,
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('reads selected background only from its context', async () => {
+    function BgProbe(): React.ReactNode {
+      return <Text>{useSelectedMessageBg() ?? 'none'}</Text>
+    }
+
+    const rendered = await createInkRoot()
+
+    try {
+      rendered.root.render(<BgProbe />)
+      await sleep()
+      rendered.root.render(
+        <MessageActionsSelectedContext.Provider value={true}>
+          <BgProbe />
+        </MessageActionsSelectedContext.Provider>,
+      )
+      await sleep()
+
+      expect(rendered.output()).toContain('none')
+      expect(rendered.output()).toContain('messageActionsBackground')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})
+
+describe('swarm 040 useMessageActions', () => {
+  test('keeps handlers stable while dispatching current cursor, nav, and caps', async () => {
+    const capture = { current: null as CapturedActions | null }
+    const nav = { current: null as MessageActionsNav | null }
+    const caps: MessageActionCaps = {
+      copy: vi.fn(),
+      edit: vi.fn(async () => {}),
+    }
+    const rendered = await renderActionsHarness({
+      caps,
+      capture,
+      initialCursor: null,
+      nav,
+    })
+
+    try {
+      const handlers = capture.current?.handlers
+      expect(handlers).toBeDefined()
+
+      capture.current?.enter()
+      expect(probes.logEvent).toHaveBeenCalledWith(
+        'tengu_message_actions_enter',
+        {},
+      )
+
+      expect(() => {
+        handlers?.['messageActions:prev']()
+        handlers?.['messageActions:next']()
+        handlers?.['messageActions:top']()
+        handlers?.['messageActions:bottom']()
+        handlers?.['messageActions:c']()
+      }).not.toThrow()
+      expect(caps.copy).not.toHaveBeenCalled()
+
+      capture.current?.setCursor({
+        expanded: false,
+        msgType: 'system',
+        uuid: 'sticky-system',
+      })
+      await sleep()
+      handlers?.['messageActions:enter']()
+      await sleep()
+      expect(capture.current?.cursor).toMatchObject({ expanded: true })
+
+      handlers?.['messageActions:escape']()
+      await sleep()
+      expect(capture.current?.cursor).toMatchObject({ expanded: false })
+
+      capture.current?.setCursor({
+        expanded: false,
+        msgType: 'assistant',
+        toolName: 'Unknown',
+        uuid: 'unknown-tool',
+      })
+      await sleep()
+      handlers?.['messageActions:p']()
+      await sleep()
+      expect(capture.current?.cursor).toMatchObject({ uuid: 'unknown-tool' })
+
+      nav.current = navWithSelected(null)
+      capture.current?.setCursor({
+        expanded: false,
+        msgType: 'user',
+        uuid: 'missing-selected',
+      })
+      await sleep()
+      handlers?.['messageActions:enter']()
+      await sleep()
+      expect(capture.current?.cursor).toMatchObject({ uuid: 'missing-selected' })
+
+      nav.current = navWithSelected(assistantText('not a tool'))
+      capture.current?.setCursor({
+        expanded: false,
+        msgType: 'assistant',
+        toolName: 'Bash',
+        uuid: 'primary-without-tool-call',
+      })
+      await sleep()
+      handlers?.['messageActions:p']()
+      await sleep()
+      expect(caps.copy).not.toHaveBeenCalled()
+      expect(capture.current?.cursor).toBeNull()
+
+      nav.current = navWithSelected(assistantTool('Read', { file_path: 42 }))
+      capture.current?.setCursor({
+        expanded: false,
+        msgType: 'assistant',
+        toolName: 'Read',
+        uuid: 'primary-empty-value',
+      })
+      await sleep()
+      handlers?.['messageActions:p']()
+      await sleep()
+      expect(caps.copy).not.toHaveBeenCalled()
+      expect(capture.current?.cursor).toBeNull()
+
+      nav.current = navWithSelected(assistantText('copy from selected'))
+      capture.current?.setCursor({
+        expanded: false,
+        msgType: 'assistant',
+        uuid: 'copy-selected',
+      })
+      await sleep()
+      handlers?.['messageActions:c']()
+      await sleep()
+      expect(caps.copy).toHaveBeenCalledWith('copy from selected')
+      expect(capture.current?.cursor).toBeNull()
+
+      handlers?.['messageActions:ctrlc']()
+      await sleep()
+      expect(capture.current?.cursor).toBeNull()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-041-components-ModelPicker.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-041-components-ModelPicker.test.tsx
@@ -1,0 +1,245 @@
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { ModelPicker } from "../../../src/tui/components/ModelPicker.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+type AppState = {
+  effortValue?: string;
+  fastMode: boolean;
+};
+
+type ModelOption = {
+  description: string;
+  label: string;
+  value: string | null;
+};
+
+type SelectProps = {
+  defaultFocusValue: string | undefined;
+  defaultValue: string;
+  onCancel: () => void;
+  onChange: (value: string) => void;
+  onFocus: (value: string | undefined) => void;
+  options: Array<{ label: string; value: string }>;
+  visibleOptionCount: number;
+};
+
+const harness = vi.hoisted(() => ({
+  appState: {
+    effortValue: undefined as string | undefined,
+    fastMode: false,
+  },
+  defaultEfforts: new Map<string, string | undefined>(),
+  defaultModel: "default-model",
+  exitState: {
+    keyName: "Ctrl+Q",
+    pending: false,
+  },
+  fastMode: {
+    available: true,
+    cooldown: false,
+    enabled: false,
+  },
+  keybindings: undefined as Record<string, () => void> | undefined,
+  logEvent: vi.fn(),
+  maxModels: new Set<string>(),
+  options: [] as ModelOption[],
+  persistEfforts: true,
+  selectProps: undefined as SelectProps | undefined,
+  setAppState: vi.fn(),
+  settingsEffort: undefined as string | undefined,
+  unsupportedModels: new Set<string>(),
+  updateSettingsForSource: vi.fn(),
+}));
+
+vi.mock("src/tui/hooks/useExitOnCtrlCDWithKeybindings.js", () => ({
+  useExitOnCtrlCDWithKeybindings: () => harness.exitState,
+}));
+
+vi.mock("../keybindings/useKeybinding.js", () => ({
+  useKeybindings: (bindings: Record<string, () => void>) => {
+    harness.keybindings = bindings;
+  },
+}));
+
+vi.mock("../state/AppState.js", () => ({
+  useAppState: (selector: (state: AppState) => unknown) =>
+    selector(harness.appState),
+  useSetAppState: () => (updater: (state: AppState) => AppState) => {
+    harness.setAppState(updater);
+    harness.appState = updater(harness.appState);
+  },
+}));
+
+vi.mock("../../services/analytics/index.js", () => ({
+  logEvent: harness.logEvent,
+}));
+
+vi.mock("../../utils/fastMode.js", () => ({
+  FAST_MODE_MODEL_DISPLAY: "fast-model",
+  isFastModeAvailable: () => harness.fastMode.available,
+  isFastModeCooldown: () => harness.fastMode.cooldown,
+  isFastModeEnabled: () => harness.fastMode.enabled,
+}));
+
+vi.mock("../../utils/effort.js", () => ({
+  convertEffortValueToLevel: (value: string | undefined) => value,
+  getDefaultEffortForModel: (model: string) => harness.defaultEfforts.get(model),
+  modelSupportsEffort: (model: string) =>
+    !harness.unsupportedModels.has(model),
+  modelSupportsMaxEffort: (model: string) => harness.maxModels.has(model),
+  resolvePickerEffortPersistence: (
+    effort: string | undefined,
+    defaultEffort: string,
+    persistedEffort: string | undefined,
+    hasToggledEffort: boolean,
+  ) => (hasToggledEffort ? effort : effort ?? persistedEffort ?? defaultEffort),
+  toPersistableEffort: (effort: string | undefined) =>
+    harness.persistEfforts ? effort : undefined,
+}));
+
+vi.mock("../../utils/model/model.js", () => ({
+  getDefaultMainLoopModel: () => harness.defaultModel,
+  modelDisplayString: (model: string) => `Display ${model}`,
+  parseUserSpecifiedModel: (model: string) => model,
+}));
+
+vi.mock("../../utils/model/modelOptions.js", () => ({
+  getModelOptions: () => harness.options,
+}));
+
+vi.mock("../../utils/settings/settings.js", () => ({
+  getSettingsForSource: () => ({ effortLevel: harness.settingsEffort }),
+  updateSettingsForSource: harness.updateSettingsForSource,
+}));
+
+vi.mock("../components/CustomSelect/select.js", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    Select: (props: SelectProps) => {
+      harness.selectProps = props;
+      return ReactActual.createElement(
+        "ink-text",
+        null,
+        props.options
+          .slice(0, props.visibleOptionCount)
+          .map(option => option.label)
+          .join("\n"),
+      );
+    },
+  };
+});
+
+describe("ModelPicker coverage swarm 041", () => {
+  beforeEach(() => {
+    harness.appState = {
+      effortValue: undefined,
+      fastMode: false,
+    };
+    harness.defaultEfforts = new Map<string, string | undefined>([
+      ["default-model", "medium"],
+    ]);
+    harness.defaultModel = "default-model";
+    harness.exitState = {
+      keyName: "Ctrl+Q",
+      pending: false,
+    };
+    harness.fastMode = {
+      available: true,
+      cooldown: false,
+      enabled: false,
+    };
+    harness.keybindings = undefined;
+    harness.logEvent.mockReset();
+    harness.maxModels = new Set<string>();
+    harness.options = [
+      {
+        description: "Use default",
+        label: "Default Model",
+        value: "default-model",
+      },
+    ];
+    harness.persistEfforts = true;
+    harness.selectProps = undefined;
+    harness.setAppState.mockReset();
+    harness.settingsEffort = undefined;
+    harness.unsupportedModels = new Set<string>();
+    harness.updateSettingsForSource.mockReset();
+  });
+
+  test("handles an empty option list and non-persistable default effort", async () => {
+    harness.defaultEfforts = new Map<string, string | undefined>([
+      ["default-basic", undefined],
+    ]);
+    harness.defaultModel = "default-basic";
+    harness.options = [];
+    harness.persistEfforts = false;
+    harness.unsupportedModels = new Set(["default-basic"]);
+
+    const onSelect = vi.fn();
+    const output = await renderToString(
+      <ModelPicker initial={null} onSelect={onSelect} />,
+      { columns: 120 },
+    );
+
+    expect(output).toContain("Effort not supported");
+    expect(harness.selectProps).toMatchObject({
+      defaultFocusValue: undefined,
+      defaultValue: "__NO_PREFERENCE__",
+      options: [],
+      visibleOptionCount: 0,
+    });
+
+    harness.selectProps?.onChange("__NO_PREFERENCE__");
+
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      "tengu_model_command_menu_effort",
+      { effort: undefined },
+    );
+    expect(onSelect).toHaveBeenCalledWith(null, undefined);
+    expect(harness.updateSettingsForSource).not.toHaveBeenCalled();
+    expect(harness.setAppState).toHaveBeenCalledTimes(1);
+    expect(harness.appState.effortValue).toBe("high");
+  });
+
+  test("suppresses the fast-mode prompt when fast mode cannot be enabled", async () => {
+    harness.fastMode = {
+      available: false,
+      cooldown: false,
+      enabled: true,
+    };
+    harness.exitState = {
+      keyName: "Ctrl+Q",
+      pending: true,
+    };
+
+    const unavailableOutput = await renderToString(
+      <ModelPicker initial="default-model" isStandaloneCommand onSelect={() => {}} />,
+      { columns: 120 },
+    );
+
+    expect(unavailableOutput).toContain("Press Ctrl+Q again to exit");
+    expect(unavailableOutput).not.toContain("Use /fast");
+    expect(unavailableOutput).not.toContain("Fast mode is ON");
+
+    harness.fastMode = {
+      available: true,
+      cooldown: true,
+      enabled: true,
+    };
+    harness.exitState = {
+      keyName: "Ctrl+Q",
+      pending: false,
+    };
+
+    const cooldownOutput = await renderToString(
+      <ModelPicker initial="default-model" onSelect={() => {}} />,
+      { columns: 120 },
+    );
+
+    expect(cooldownOutput).not.toContain("Use /fast");
+    expect(cooldownOutput).not.toContain("Fast mode is ON");
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-042-main.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-042-main.test.tsx
@@ -1,0 +1,279 @@
+import { EventEmitter } from "node:events";
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => {
+  const state = {
+    exitCallback: undefined as (() => void) | undefined,
+    app: vi.fn(() => null),
+    onExitUnsubscribe: vi.fn(),
+    renderInk: vi.fn(),
+    recordTuiBackpressure: vi.fn(),
+    onExit: undefined as unknown as (callback: () => void) => () => void,
+  };
+  state.onExit = vi.fn((callback: () => void) => {
+    state.exitCallback = callback;
+    return state.onExitUnsubscribe;
+  });
+  return state;
+});
+
+vi.mock("signal-exit", () => ({
+  onExit: harness.onExit,
+}));
+
+vi.mock("../ink.js", () => ({
+  render: harness.renderInk,
+}));
+
+vi.mock("../components/App.js", () => ({
+  AgenCTuiApp: harness.app,
+}));
+
+vi.mock("../backpressure.js", () => ({
+  recordTuiBackpressure: harness.recordTuiBackpressure,
+}));
+
+import {
+  bootTUI,
+  handleStdinLoss,
+  STDIN_LOSS_FLUSH_FALLBACK_MS,
+  type StdinLossSession,
+} from "../main.js";
+
+type MockStdin = EventEmitter & {
+  isTTY: boolean;
+  setRawMode?: ReturnType<typeof vi.fn>;
+};
+
+type MockWriteStream = EventEmitter & {
+  isTTY: boolean;
+  writes: string[];
+  write: ReturnType<typeof vi.fn>;
+};
+
+type RenderedTuiElement = {
+  readonly props: {
+    readonly isInteractive: boolean;
+    readonly initialUserMessages?: readonly unknown[];
+  };
+};
+
+function createStdin(options: {
+  readonly isTTY?: boolean;
+  readonly setRawMode?: ReturnType<typeof vi.fn>;
+} = {}): MockStdin {
+  const stream = new EventEmitter() as MockStdin;
+  stream.isTTY = options.isTTY ?? true;
+  if (options.setRawMode !== undefined) {
+    stream.setRawMode = options.setRawMode;
+  }
+  return stream;
+}
+
+function createWriteStream(
+  writeImpl?: (chunk: string | Uint8Array) => boolean,
+): MockWriteStream {
+  const stream = new EventEmitter() as MockWriteStream;
+  stream.isTTY = true;
+  stream.writes = [];
+  stream.write = vi.fn((chunk: string | Uint8Array) => {
+    stream.writes.push(String(chunk));
+    return writeImpl?.(chunk) ?? true;
+  });
+  return stream;
+}
+
+function exitWithError(code: number): never {
+  throw new Error(`exit:${code}`);
+}
+
+describe("TUI main swarm coverage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    harness.exitCallback = undefined;
+  });
+
+  test("cleans up listeners, raw mode, and exit hooks when Ink render rejects", async () => {
+    const setRawMode = vi.fn();
+    const stdin = createStdin({ setRawMode });
+    const stdout = createWriteStream();
+    const stderr = createWriteStream();
+    const renderError = new Error("render failed");
+    harness.renderInk.mockRejectedValue(renderError);
+
+    await expect(
+      bootTUI({
+        session: {} as never,
+        configStore: {} as never,
+        stdin: stdin as never,
+        stdout: stdout as never,
+        stderr: stderr as never,
+      }),
+    ).rejects.toBe(renderError);
+
+    expect(setRawMode).toHaveBeenNthCalledWith(1, true);
+    expect(setRawMode).toHaveBeenNthCalledWith(2, false);
+    expect(stdin.listenerCount("close")).toBe(0);
+    expect(stdin.listenerCount("end")).toBe(0);
+    expect(stdin.listenerCount("error")).toBe(0);
+    expect(harness.onExitUnsubscribe).toHaveBeenCalledTimes(1);
+    expect(stdout.write).toHaveBeenCalledTimes(5);
+  });
+
+  test("continues render cleanup when raw-mode release and terminal restore throw", async () => {
+    const setRawMode = vi.fn((enabled: boolean) => {
+      if (!enabled) throw new Error("raw release failed");
+    });
+    const stdin = createStdin({ setRawMode });
+    const stdout = createWriteStream(() => {
+      throw new Error("restore failed");
+    });
+    const renderError = new Error("render failed after raw claim");
+    harness.renderInk.mockRejectedValue(renderError);
+
+    await expect(
+      bootTUI({
+        session: {} as never,
+        configStore: {} as never,
+        stdin: stdin as never,
+        stdout: stdout as never,
+        stderr: createWriteStream() as never,
+      }),
+    ).rejects.toBe(renderError);
+
+    expect(setRawMode).toHaveBeenNthCalledWith(1, true);
+    expect(setRawMode).toHaveBeenNthCalledWith(2, false);
+    expect(stdout.write).toHaveBeenCalledTimes(1);
+    expect(harness.onExitUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  test("skips startup raw mode for non-TTY input and marks the app noninteractive", async () => {
+    const stdin = createStdin({ isTTY: false });
+    const initialUserMessages = [{ role: "user", content: "hello" }];
+    harness.renderInk.mockResolvedValue({
+      unmount: vi.fn(),
+      waitUntilExit: vi.fn(async () => undefined),
+    });
+
+    await bootTUI({
+      session: {} as never,
+      configStore: {} as never,
+      stdin: stdin as never,
+      stdout: createWriteStream() as never,
+      stderr: createWriteStream() as never,
+      initialUserMessages: initialUserMessages as never,
+    });
+
+    expect(stdin.setRawMode).toBeUndefined();
+    const [element] = harness.renderInk.mock.calls[0] as [RenderedTuiElement];
+    expect(element.props.isInteractive).toBe(false);
+    expect(element.props.initialUserMessages).toBe(initialUserMessages);
+  });
+
+  test("uses fallback stdin-loss delay and unstructured warnings without internal ids", async () => {
+    const setTimeoutMock = vi.fn(
+      (callback: () => void, _durationMs: number) => {
+        callback();
+        return {} as NodeJS.Timeout;
+      },
+    );
+    const session = {
+      abortTerminal: vi.fn(() => {
+        throw new Error("abort failed");
+      }),
+      emit: vi.fn(),
+    };
+    const unmountInk = vi.fn();
+
+    await expect(
+      handleStdinLoss(
+        session as unknown as StdinLossSession,
+        unmountInk,
+        {
+          exit: exitWithError,
+          setTimeoutFn: setTimeoutMock as unknown as typeof setTimeout,
+        },
+      ),
+    ).rejects.toThrow("exit:130");
+
+    expect(setTimeoutMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      STDIN_LOSS_FLUSH_FALLBACK_MS,
+    );
+    expect(session.emit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "warning:stdin_lost",
+        cause: "stdin_lost",
+        message:
+          "stdin was lost while the TUI was active; aborting the session",
+      }),
+    );
+    expect(unmountInk).toHaveBeenCalledTimes(1);
+  });
+
+  test("continues stdin-loss shutdown when flush, emit, and unmount handlers fail", async () => {
+    const session = {
+      abortTerminal: vi.fn(),
+      flushEventLog: vi.fn(() => {
+        throw new Error("flush failed");
+      }),
+      emit: vi.fn(() => {
+        throw new Error("emit failed");
+      }),
+    };
+    const unmountInk = vi.fn(() => {
+      throw new Error("unmount failed");
+    });
+
+    await expect(
+      handleStdinLoss(
+        session as unknown as StdinLossSession,
+        unmountInk,
+        { exit: exitWithError },
+      ),
+    ).rejects.toThrow("exit:130");
+
+    expect(session.flushEventLog).toHaveBeenCalledTimes(1);
+    expect(session.emit).toHaveBeenCalledTimes(1);
+    expect(unmountInk).toHaveBeenCalledTimes(1);
+  });
+
+  test("accepts synchronous flush results and emits structured stdin-loss warnings", async () => {
+    const timeoutHandle = { unref: vi.fn() };
+    const setTimeoutMock = vi.fn(
+      (_callback: () => void, _durationMs: number) =>
+        timeoutHandle as unknown as NodeJS.Timeout,
+    );
+    const session = {
+      flushEventLog: vi.fn(() => undefined),
+      emit: vi.fn(),
+      nextInternalSubId: vi.fn(() => "warning-1"),
+    };
+
+    await expect(
+      handleStdinLoss(
+        session as unknown as StdinLossSession,
+        vi.fn(),
+        {
+          exit: exitWithError,
+          setTimeoutFn: setTimeoutMock as unknown as typeof setTimeout,
+        },
+      ),
+    ).rejects.toThrow("exit:130");
+
+    expect(timeoutHandle.unref).toHaveBeenCalledTimes(1);
+    expect(session.emit).toHaveBeenCalledWith({
+      id: "warning-1",
+      msg: {
+        type: "warning",
+        payload: {
+          cause: "stdin_lost",
+          message:
+            "stdin was lost while the TUI was active; aborting the session",
+          timestamp: expect.any(Number),
+        },
+      },
+    });
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-043-components-NativeAutoUpdater.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-043-components-NativeAutoUpdater.test.tsx
@@ -1,0 +1,494 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+type AutoUpdaterResult = {
+  status: "success" | "install_failed";
+  version: string | null;
+};
+
+const harness = vi.hoisted(() => ({
+  installLatest: vi.fn(),
+  intervalDelay: undefined as number | null | undefined,
+  isAutoUpdaterDisabled: vi.fn(() => false),
+  logError: vi.fn(),
+  logEvent: vi.fn(),
+  logForDebugging: vi.fn(),
+  settings: { autoUpdatesChannel: "beta" } as
+    | { autoUpdatesChannel?: string }
+    | null,
+  updateResults: [] as AutoUpdaterResult[],
+  updatingStates: [] as boolean[],
+}));
+
+vi.mock("usehooks-ts", () => ({
+  useInterval: (_callback: () => void, delay: number | null) => {
+    harness.intervalDelay = delay;
+  },
+}));
+
+vi.mock("../hooks/useUpdateNotification.js", () => ({
+  useUpdateNotification: (version: string | null | undefined) =>
+    version ? "available" : null,
+}));
+
+vi.mock("../../services/analytics/index.js", () => ({
+  logEvent: harness.logEvent,
+}));
+
+vi.mock("src/utils/debug.js", () => ({
+  logForDebugging: harness.logForDebugging,
+}));
+
+vi.mock("../../utils/log.js", () => ({
+  logError: harness.logError,
+}));
+
+vi.mock("../../utils/config.js", () => ({
+  getGlobalConfig: () => ({ theme: "dark" }),
+  isAutoUpdaterDisabled: harness.isAutoUpdaterDisabled,
+  saveGlobalConfig: vi.fn(),
+}));
+
+vi.mock("../../utils/nativeInstaller/installer.js", () => ({
+  installLatest: harness.installLatest,
+}));
+
+vi.mock("../../utils/settings/settings.js", () => ({
+  getInitialSettings: () => harness.settings,
+}));
+
+import { createRoot } from "../ink/root.js";
+import { renderToString } from "../../utils/staticRender.js";
+import { NativeAutoUpdater } from "../components/NativeAutoUpdater.js";
+
+const originalGlyphMode = process.env.AGENC_TUI_GLYPHS;
+const originalMacro = (globalThis as Record<string, unknown>).MACRO;
+const originalNodeEnv = process.env.NODE_ENV;
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  readonly stdout: PassThrough;
+};
+
+function createStreams(): TestStreams {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStreams["stdin"];
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number; rows: number }).columns = 160;
+  (stdout as unknown as { columns: number; rows: number }).rows = 24;
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  description: string,
+): Promise<void> {
+  const deadline = Date.now() + 1000;
+
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await sleep(10);
+  }
+
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+function StatefulNativeAutoUpdater(): React.ReactNode {
+  const [isUpdating, setIsUpdating] = React.useState(false);
+  const [autoUpdaterResult, setAutoUpdaterResult] =
+    React.useState<AutoUpdaterResult | null>(null);
+  const onAutoUpdaterResult = React.useCallback((result: AutoUpdaterResult) => {
+    harness.updateResults.push(result);
+    setAutoUpdaterResult(result);
+  }, []);
+  const onChangeIsUpdating = React.useCallback((nextIsUpdating: boolean) => {
+    harness.updatingStates.push(nextIsUpdating);
+    setIsUpdating(nextIsUpdating);
+  }, []);
+
+  return (
+    <NativeAutoUpdater
+      autoUpdaterResult={autoUpdaterResult}
+      isUpdating={isUpdating}
+      onAutoUpdaterResult={onAutoUpdaterResult}
+      onChangeIsUpdating={onChangeIsUpdating}
+      showSuccessMessage={true}
+      verbose={true}
+    />
+  );
+}
+
+async function renderStatefulUpdater(): Promise<{
+  cleanup: () => void;
+  readOutput: () => string;
+}> {
+  let output = "";
+  const { stdin, stdout } = createStreams();
+  stdout.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  root.render(<StatefulNativeAutoUpdater />);
+
+  return {
+    cleanup: () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    },
+    readOutput: () => stripAnsi(output),
+  };
+}
+
+function resetHarness(): void {
+  harness.installLatest.mockReset();
+  harness.isAutoUpdaterDisabled.mockReset();
+  harness.isAutoUpdaterDisabled.mockReturnValue(false);
+  harness.logError.mockClear();
+  harness.logEvent.mockClear();
+  harness.logForDebugging.mockClear();
+  harness.intervalDelay = undefined;
+  harness.settings = { autoUpdatesChannel: "beta" };
+  harness.updateResults = [];
+  harness.updatingStates = [];
+}
+
+describe("NativeAutoUpdater coverage swarm row 043", () => {
+  beforeEach(() => {
+    resetHarness();
+    process.env.AGENC_TUI_GLYPHS = "ascii";
+    process.env.NODE_ENV = "production";
+    (globalThis as Record<string, unknown>).MACRO = {
+      VERSION: "1.0.0",
+    };
+  });
+
+  afterEach(() => {
+    if (originalGlyphMode === undefined) {
+      delete process.env.AGENC_TUI_GLYPHS;
+    } else {
+      process.env.AGENC_TUI_GLYPHS = originalGlyphMode;
+    }
+
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+
+    if (originalMacro === undefined) {
+      delete (globalThis as Record<string, unknown>).MACRO;
+    } else {
+      (globalThis as Record<string, unknown>).MACRO = originalMacro;
+    }
+  });
+
+  test.each(["test", "development"])(
+    "skips installer checks in %s mode",
+    async (nodeEnv) => {
+      process.env.NODE_ENV = nodeEnv;
+
+      const rendered = await renderToString(
+        <NativeAutoUpdater
+          autoUpdaterResult={null}
+          isUpdating={false}
+          onAutoUpdaterResult={(result) => {
+            harness.updateResults.push(result);
+          }}
+          onChangeIsUpdating={(nextIsUpdating) => {
+            harness.updatingStates.push(nextIsUpdating);
+          }}
+          showSuccessMessage={true}
+          verbose={false}
+        />,
+        100,
+      );
+
+      expect(rendered.trim()).toBe("");
+      expect(harness.intervalDelay).toBe(1_800_000);
+      expect(harness.installLatest).not.toHaveBeenCalled();
+      expect(harness.isAutoUpdaterDisabled).not.toHaveBeenCalled();
+      expect(harness.logForDebugging).toHaveBeenCalledWith(
+        "NativeAutoUpdater: Skipping update check in test/dev environment",
+      );
+      expect(harness.updateResults).toEqual([]);
+      expect(harness.updatingStates).toEqual([]);
+    },
+  );
+
+  test("returns before checking when an update is already active", async () => {
+    const rendered = await renderToString(
+      <NativeAutoUpdater
+        autoUpdaterResult={null}
+        isUpdating={true}
+        onAutoUpdaterResult={(result) => {
+          harness.updateResults.push(result);
+        }}
+        onChangeIsUpdating={(nextIsUpdating) => {
+          harness.updatingStates.push(nextIsUpdating);
+        }}
+        showSuccessMessage={true}
+        verbose={true}
+      />,
+      100,
+    );
+
+    expect(rendered.trim()).toBe("");
+    expect(harness.intervalDelay).toBe(1_800_000);
+    expect(harness.installLatest).not.toHaveBeenCalled();
+    expect(harness.isAutoUpdaterDisabled).not.toHaveBeenCalled();
+    expect(harness.logForDebugging).not.toHaveBeenCalledWith(
+      "NativeAutoUpdater: Skipping update check in test/dev environment",
+    );
+    expect(harness.updateResults).toEqual([]);
+    expect(harness.updatingStates).toEqual([]);
+  });
+
+  test("does not start the installer when auto updates are disabled", async () => {
+    harness.isAutoUpdaterDisabled.mockReturnValue(true);
+
+    const rendered = await renderStatefulUpdater();
+    try {
+      await sleep(25);
+
+      expect(harness.intervalDelay).toBe(1_800_000);
+      expect(harness.isAutoUpdaterDisabled).toHaveBeenCalledOnce();
+      expect(harness.installLatest).not.toHaveBeenCalled();
+      expect(harness.logEvent).not.toHaveBeenCalled();
+      expect(harness.updateResults).toEqual([]);
+      expect(harness.updatingStates).toEqual([]);
+      expect(rendered.readOutput()).not.toContain("Checking for updates");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  test("renders successful installer output with fallback channel metadata", async () => {
+    harness.settings = null;
+    harness.installLatest.mockResolvedValueOnce({
+      latestVersion: "2.0.0",
+      lockFailed: false,
+      wasUpdated: true,
+    });
+
+    const rendered = await renderStatefulUpdater();
+    try {
+      await waitFor(
+        () => rendered.readOutput().includes("Update installed"),
+        "successful update output",
+      );
+
+      expect(rendered.readOutput()).toContain("current: 1.0.0 - latest: 2.0.0");
+      expect(rendered.readOutput()).toContain(
+        "OK Update installed - Restart to update",
+      );
+      expect(harness.installLatest).toHaveBeenCalledWith("latest");
+      expect(harness.logEvent).toHaveBeenCalledWith(
+        "tengu_native_auto_updater_start",
+        {},
+      );
+      expect(harness.logEvent).toHaveBeenCalledWith(
+        "tengu_native_auto_updater_success",
+        expect.objectContaining({ latency_ms: expect.any(Number) }),
+      );
+      expect(harness.updateResults).toEqual([
+        { status: "success", version: "2.0.0" },
+      ]);
+      expect(harness.updatingStates).toEqual([true, false]);
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  test("logs lock contention without reporting an updater result", async () => {
+    harness.installLatest.mockResolvedValueOnce({
+      latestVersion: "2.0.0",
+      lockFailed: true,
+      wasUpdated: false,
+    });
+
+    const rendered = await renderStatefulUpdater();
+    try {
+      await waitFor(
+        () => harness.updatingStates.includes(false),
+        "lock contention completion",
+      );
+
+      expect(harness.installLatest).toHaveBeenCalledWith("beta");
+      expect(harness.logEvent).toHaveBeenCalledWith(
+        "tengu_native_auto_updater_lock_contention",
+        expect.objectContaining({ latency_ms: expect.any(Number) }),
+      );
+      expect(harness.logError).not.toHaveBeenCalled();
+      expect(harness.updateResults).toEqual([]);
+      expect(harness.updatingStates).toEqual([true, false]);
+      expect(rendered.readOutput()).not.toContain("Update installed");
+      expect(rendered.readOutput()).not.toContain("Auto-update failed");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  test("logs the up-to-date installer result without showing a status row", async () => {
+    harness.installLatest.mockResolvedValueOnce({
+      latestVersion: "1.0.0",
+      lockFailed: false,
+      wasUpdated: false,
+    });
+
+    const rendered = await renderStatefulUpdater();
+    try {
+      await waitFor(
+        () =>
+          harness.logEvent.mock.calls.some(
+            ([eventName]) => eventName === "tengu_native_auto_updater_up_to_date",
+          ),
+        "up-to-date analytics event",
+      );
+
+      expect(harness.installLatest).toHaveBeenCalledWith("beta");
+      expect(harness.updateResults).toEqual([]);
+      expect(harness.updatingStates).toEqual([true, false]);
+      expect(rendered.readOutput()).not.toContain("Update installed");
+      expect(rendered.readOutput()).not.toContain("Auto-update failed");
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  test.each([
+    [
+      "timeout waiting for package",
+      {
+        error_timeout: true,
+      },
+    ],
+    [
+      "Checksum mismatch for downloaded archive",
+      {
+        error_checksum: true,
+      },
+    ],
+    [
+      "ENOENT executable not found",
+      {
+        error_not_found: true,
+      },
+    ],
+    [
+      "EACCES permission denied",
+      {
+        error_permission: true,
+      },
+    ],
+    [
+      "ENOSPC writing package",
+      {
+        error_disk_full: true,
+      },
+    ],
+    [
+      "npm failed with exit 1",
+      {
+        error_npm: true,
+      },
+    ],
+    [
+      "unexpected archive format",
+      {
+        error_timeout: false,
+        error_checksum: false,
+        error_not_found: false,
+        error_permission: false,
+        error_disk_full: false,
+        error_npm: false,
+        error_network: false,
+      },
+    ],
+  ])("classifies installer failures for %s", async (message, expectedFlags) => {
+    const installError = new Error(message);
+    harness.installLatest.mockRejectedValueOnce(installError);
+
+    const rendered = await renderStatefulUpdater();
+    try {
+      await waitFor(
+        () => harness.updateResults.length === 1,
+        "failed update result",
+      );
+      await waitFor(
+        () => rendered.readOutput().includes("Auto-update failed"),
+        "failed update output",
+      );
+
+      const failCall = harness.logEvent.mock.calls.find(
+        ([eventName]) => eventName === "tengu_native_auto_updater_fail",
+      );
+
+      expect(harness.logError).toHaveBeenCalledWith(installError);
+      expect(failCall?.[1]).toEqual(
+        expect.objectContaining({
+          error_checksum: false,
+          error_disk_full: false,
+          error_network: false,
+          error_not_found: false,
+          error_npm: false,
+          error_permission: false,
+          error_timeout: false,
+          ...expectedFlags,
+        }),
+      );
+      expect(harness.updateResults).toEqual([
+        { status: "install_failed", version: null },
+      ]);
+      expect(harness.updatingStates).toEqual([true, false]);
+      expect(rendered.readOutput()).toContain(
+        "ERR Auto-update failed - Try /status",
+      );
+    } finally {
+      rendered.cleanup();
+    }
+  });
+
+  test("hides the success message when the caller suppresses it", async () => {
+    process.env.NODE_ENV = "test";
+
+    const rendered = await renderToString(
+      <NativeAutoUpdater
+        autoUpdaterResult={{ status: "success", version: "2.0.0" }}
+        isUpdating={false}
+        onAutoUpdaterResult={() => {}}
+        onChangeIsUpdating={() => {}}
+        showSuccessMessage={false}
+        verbose={false}
+      />,
+      100,
+    );
+
+    expect(rendered).not.toContain("Update installed");
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-044-message-renderers-UserToolResultMessage-UserToolSuccessMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-044-message-renderers-UserToolResultMessage-UserToolSuccessMessage.test.tsx
@@ -1,0 +1,231 @@
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const featureFlags = vi.hoisted(() => new Set<string>())
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => featureFlags.has(name),
+}))
+
+import type { Tool, Tools } from '../../../src/tools/Tool.js'
+import {
+  clearClassifierApprovals,
+  setYoloClassifierApproval,
+} from '../../../src/utils/classifierApprovals.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+import { Text } from '../../../src/tui/ink.js'
+import {
+  getToolResultFallbackContent,
+  UserToolSuccessMessage,
+} from '../../../src/tui/message-renderers/UserToolResultMessage/UserToolSuccessMessage.js'
+
+afterEach(() => {
+  featureFlags.clear()
+  clearClassifierApprovals()
+})
+
+function createLookups(toolUseID: string, input?: unknown) {
+  return {
+    inProgressHookCounts: new Map([
+      [toolUseID, new Map([['PostToolUse', 1]])],
+    ]),
+    resolvedHookCounts: new Map(),
+    toolUseByToolUseID: new Map(input === undefined ? [] : [[toolUseID, { input }]]),
+  } as never
+}
+
+function messageWithToolResult(
+  toolUseID: string,
+  content: unknown,
+  toolUseResult?: unknown,
+) {
+  return {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: toolUseID,
+          content,
+        },
+      ],
+    },
+    toolUseResult,
+  } as never
+}
+
+describe('UserToolSuccessMessage swarm-044 coverage', () => {
+  test('formats fallback content from mixed recovered block shapes', () => {
+    expect(getToolResultFallbackContent('not an array')).toBeNull()
+    expect(getToolResultFallbackContent([{ type: 'text', text: 'ignored' }])).toBeNull()
+    expect(getToolResultFallbackContent([{ type: 'tool_result' }])).toBeNull()
+    expect(
+      getToolResultFallbackContent([
+        {
+          type: 'tool_result',
+          content: [
+            'plain output',
+            { type: 'text', text: 'text output' },
+            { type: 'image', source: { type: 'base64', data: 'abc' } },
+          ],
+        },
+      ]),
+    ).toBe(
+      'plain output\ntext output\n{"type":"image","source":{"type":"base64","data":"abc"}}',
+    )
+  })
+
+  test('renders recovered fallback output for a missing tool result and transcript classifier approval', async () => {
+    featureFlags.add('TRANSCRIPT_CLASSIFIER')
+    const toolUseID = 'toolu_swarm_044_missing'
+    setYoloClassifierApproval(toolUseID, 'allowed by rule')
+
+    const output = await renderToString(
+      <UserToolSuccessMessage
+        message={messageWithToolResult(
+          toolUseID,
+          '<persisted-output>resumed fallback output</persisted-output>',
+        )}
+        lookups={createLookups(toolUseID)}
+        toolUseID={toolUseID}
+        progressMessagesForMessage={[]}
+        tools={[]}
+        verbose={false}
+        width={60}
+        isTranscriptMode={true}
+      />,
+      { columns: 90, rows: 12 },
+    )
+
+    expect(output).toContain('resumed fallback output')
+    expect(output).toContain('Allowed by auto mode classifier')
+    expect(output).toContain('1 PostToolUse hook running')
+  })
+
+  test('falls back instead of delegating when output schema validation fails', async () => {
+    const toolUseID = 'toolu_swarm_044_invalid_schema'
+    const renderToolResultMessage = vi.fn(() => <Text>delegated result</Text>)
+    const tool = {
+      outputSchema: {
+        safeParse: () => ({ success: false, error: new Error('bad output') }),
+      },
+      renderToolResultMessage,
+      userFacingName: () => 'Schema tool',
+    } as unknown as Tool
+
+    const output = await renderToString(
+      <UserToolSuccessMessage
+        message={messageWithToolResult(
+          toolUseID,
+          [{ type: 'text', text: 'schema fallback output' }],
+          { unexpected: true },
+        )}
+        lookups={createLookups(toolUseID)}
+        toolUseID={toolUseID}
+        progressMessagesForMessage={[]}
+        tool={tool}
+        tools={[tool] as Tools}
+        verbose={true}
+        width={60}
+      />,
+      { columns: 90, rows: 12 },
+    )
+
+    expect(output).toContain('schema fallback output')
+    expect(output).toContain('Running PostToolUse hook')
+    expect(renderToolResultMessage).not.toHaveBeenCalled()
+  })
+
+  test('uses the raw result without a schema and allows assistant-text chrome opt out', async () => {
+    const toolUseID = 'toolu_swarm_044_raw_result'
+    const renderToolResultMessage = vi.fn(
+      (
+        result: { value: string },
+        progressMessages: ReadonlyArray<{ data: { type: string } }>,
+        options: { input?: { path: string }; isTranscriptMode?: boolean },
+      ) => (
+        <Text>
+          {result.value} progress:{progressMessages.length} input:
+          {options.input?.path} transcript:{String(options.isTranscriptMode)}
+        </Text>
+      ),
+    )
+    const tool = {
+      renderToolResultMessage,
+      userFacingName: vi.fn(() => ''),
+    } as unknown as Tool
+    const tools = [tool] as Tools
+
+    const output = await renderToString(
+      <UserToolSuccessMessage
+        message={messageWithToolResult(
+          toolUseID,
+          'hidden fallback',
+          { value: 'raw output' },
+        )}
+        lookups={createLookups(toolUseID, { path: 'src/raw.ts' })}
+        toolUseID={toolUseID}
+        progressMessagesForMessage={[
+          { data: { type: 'hook_progress', hookEvent: 'PostToolUse' } },
+          { data: { type: 'tool_progress', text: 'visible' } },
+        ] as never}
+        tool={tool}
+        tools={tools}
+        verbose={false}
+        width={40}
+        isTranscriptMode={true}
+      />,
+      { columns: 90, rows: 12 },
+    )
+
+    expect(output).toContain('raw output progress:1 input:src/raw.ts transcript:true')
+    expect(output).not.toContain('hidden fallback')
+    expect(renderToolResultMessage).toHaveBeenCalledTimes(1)
+    expect(tool.userFacingName).toHaveBeenCalledWith(undefined)
+  })
+
+  test('renders nothing when neither fallback nor delegated content is available', async () => {
+    const toolUseID = 'toolu_swarm_044_empty'
+    const nullRenderingTool = {
+      renderToolResultMessage: vi.fn(() => null),
+      userFacingName: vi.fn(() => 'Null renderer'),
+    } as unknown as Tool
+
+    const missingWithoutFallback = await renderToString(
+      <UserToolSuccessMessage
+        message={{
+          type: 'user',
+          message: { role: 'user', content: [] },
+          toolUseResult: null,
+        } as never}
+        lookups={createLookups(toolUseID)}
+        toolUseID={toolUseID}
+        progressMessagesForMessage={[]}
+        tools={[]}
+        verbose={false}
+        width={50}
+      />,
+      { columns: 80, rows: 8 },
+    )
+
+    const delegatedNull = await renderToString(
+      <UserToolSuccessMessage
+        message={messageWithToolResult(toolUseID, 'hidden', { value: 'ignored' })}
+        lookups={createLookups(toolUseID)}
+        toolUseID={toolUseID}
+        progressMessagesForMessage={[]}
+        tool={nullRenderingTool}
+        tools={[nullRenderingTool] as Tools}
+        verbose={false}
+        width={50}
+      />,
+      { columns: 80, rows: 8 },
+    )
+
+    expect(missingWithoutFallback.trim()).toBe('')
+    expect(delegatedNull.trim()).toBe('')
+    expect(nullRenderingTool.renderToolResultMessage).toHaveBeenCalledTimes(1)
+    expect(nullRenderingTool.userFacingName).not.toHaveBeenCalled()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-045-components-markdown-Markdown.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-045-components-markdown-Markdown.test.tsx
@@ -1,0 +1,329 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createRoot, type Root } from '../../../src/tui/ink.js'
+import {
+  Markdown,
+  StreamingMarkdown,
+} from '../../../src/tui/components/markdown/Markdown.js'
+
+type MockToken = {
+  align?: Array<'center' | 'left' | 'right' | null>
+  header?: MockToken[]
+  lang?: string
+  raw: string
+  rows?: MockToken[][]
+  text?: string
+  tokens?: MockToken[]
+  type: string
+}
+
+const settingsMock = vi.hoisted(() => ({
+  syntaxHighlightingDisabled: true,
+}))
+
+const highlightMock = vi.hoisted(() => {
+  const highlighter = {
+    highlight: vi.fn(
+      (code: string, options: { readonly language: string }) =>
+        `highlighted:${options.language}:${code}`,
+    ),
+    supportsLanguage: vi.fn((language: string) => language === 'ts'),
+  }
+
+  return {
+    getCliHighlightPromise: vi.fn(),
+    highlighter,
+  }
+})
+
+const markedMock = vi.hoisted(() => ({
+  lexer: vi.fn<(content: string) => MockToken[]>(),
+  use: vi.fn(),
+}))
+
+const tableMock = vi.hoisted(() => ({
+  render: vi.fn((props: { readonly token: MockToken }) => {
+    return `TABLE:${props.token.raw}`
+  }),
+}))
+
+vi.mock('marked', () => ({
+  marked: {
+    lexer: markedMock.lexer,
+    use: markedMock.use,
+  },
+}))
+
+vi.mock('../../../src/tui/hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    syntaxHighlightingDisabled: settingsMock.syntaxHighlightingDisabled,
+  }),
+}))
+
+vi.mock('../../../src/utils/cliHighlight.js', () => ({
+  getCliHighlightPromise: highlightMock.getCliHighlightPromise,
+}))
+
+vi.mock('../../../src/utils/messages.js', () => ({
+  stripPromptXMLTags: (input: string) =>
+    input.replace(/<context>[\s\S]*?<\/context>/g, ''),
+}))
+
+vi.mock('../../../src/tui/components/markdown/MarkdownTable.js', () => ({
+  MarkdownTable: (props: { readonly token: MockToken }) =>
+    tableMock.render(props),
+}))
+
+function textToken(text: string, raw = text): MockToken {
+  return {
+    raw,
+    text,
+    tokens: [
+      {
+        raw: text,
+        text,
+        type: 'text',
+      },
+    ],
+    type: 'paragraph',
+  }
+}
+
+function codeToken(code: string, raw: string): MockToken {
+  return {
+    lang: 'ts',
+    raw,
+    text: code,
+    type: 'code',
+  }
+}
+
+function lexBlocks(content: string): MockToken[] {
+  if (content.length === 0) return []
+  const tokens: MockToken[] = []
+  let offset = 0
+
+  while (offset < content.length) {
+    const boundary = content.indexOf('\n\n', offset)
+    if (boundary === -1) {
+      const tail = content.slice(offset)
+      if (tail.trim() === '') {
+        tokens.push({ raw: tail, type: 'space' })
+      } else {
+        tokens.push(textToken(tail))
+      }
+      break
+    }
+
+    const text = content.slice(offset, boundary)
+    const raw = content.slice(offset, boundary + 2)
+    if (text.trim() === '') {
+      tokens.push({ raw, type: 'space' })
+    } else {
+      tokens.push(textToken(text, raw))
+    }
+    offset = boundary + 2
+  }
+
+  return tokens
+}
+
+function defaultLexer(content: string): MockToken[] {
+  if (content.includes('ROW045_CODE')) {
+    return [codeToken('const row045Highlight = true', content)]
+  }
+
+  if (content.includes('ROW045_TABLE')) {
+    return [
+      textToken('before row045 table', 'before row045 table\n\n'),
+      {
+        align: ['left'],
+        header: [textToken('Column')],
+        raw: 'ROW045_TABLE',
+        rows: [[textToken('cell')]],
+        type: 'table',
+      },
+      textToken('after row045 table', '\n\nafter row045 table'),
+    ]
+  }
+
+  return lexBlocks(content)
+}
+
+function createStreams(): {
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdout: PassThrough
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  return { stdin, stdout }
+}
+
+async function waitForOutput(
+  readOutput: () => string,
+  expected: string,
+): Promise<void> {
+  const deadline = Date.now() + 1000
+  while (Date.now() < deadline) {
+    if (readOutput().includes(expected)) return
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+  throw new Error(`Timed out waiting for rendered output: ${expected}`)
+}
+
+async function createRenderHarness(): Promise<{
+  cleanup: () => void
+  readOutput: () => string
+  root: Root
+}> {
+  let output = ''
+  const { stdin, stdout } = createStreams()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  return {
+    cleanup: () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    },
+    readOutput: () => stripAnsi(output),
+    root,
+  }
+}
+
+async function renderToText(
+  node: React.ReactNode,
+  expected: string,
+): Promise<string> {
+  const harness = await createRenderHarness()
+  try {
+    harness.root.render(node)
+    await waitForOutput(harness.readOutput, expected)
+    return harness.readOutput()
+  } finally {
+    harness.cleanup()
+  }
+}
+
+describe('Markdown coverage swarm row 045', () => {
+  beforeEach(() => {
+    settingsMock.syntaxHighlightingDisabled = true
+    highlightMock.getCliHighlightPromise.mockReset()
+    highlightMock.getCliHighlightPromise.mockReturnValue(
+      Promise.resolve(highlightMock.highlighter),
+    )
+    highlightMock.highlighter.highlight.mockClear()
+    highlightMock.highlighter.supportsLanguage.mockClear()
+    markedMock.lexer.mockClear()
+    markedMock.lexer.mockImplementation(defaultLexer)
+    markedMock.use.mockClear()
+    tableMock.render.mockClear()
+  })
+
+  test('uses the plain-text fast path for long content whose markdown marker is outside the syntax sample', async () => {
+    const content = `${'a'.repeat(510)} # row045 marker after sample`
+
+    const output = await renderToText(
+      <Markdown>{content}</Markdown>,
+      'row045 marker after sample',
+    )
+
+    expect(output).toContain('row045 marker after sample')
+    expect(markedMock.lexer).not.toHaveBeenCalled()
+  })
+
+  test('reuses cached markdown tokens across remounts for the same content', async () => {
+    const content = '# row045 cached branch\n\nstill cached'
+
+    await renderToText(<Markdown>{content}</Markdown>, 'row045 cached branch')
+    await renderToText(<Markdown>{content}</Markdown>, 'row045 cached branch')
+
+    expect(markedMock.lexer).toHaveBeenCalledTimes(1)
+    expect(markedMock.lexer).toHaveBeenCalledWith(content)
+  })
+
+  test('flushes text around table tokens and passes the table token through', async () => {
+    const output = await renderToText(
+      <Markdown>{'ROW045_TABLE'}</Markdown>,
+      'after row045 table',
+    )
+
+    expect(output).toContain('before row045 table')
+    expect(output).toContain('after row045 table')
+    expect(tableMock.render).toHaveBeenCalledTimes(1)
+    expect(tableMock.render).toHaveBeenCalledWith(
+      expect.objectContaining({
+        highlight: null,
+        token: expect.objectContaining({ raw: 'ROW045_TABLE' }),
+      }),
+    )
+  })
+
+  test('loads a highlighter when syntax highlighting is enabled', async () => {
+    settingsMock.syntaxHighlightingDisabled = false
+
+    const output = await renderToText(
+      <Markdown>{'```ts\nROW045_CODE\n```'}</Markdown>,
+      'highlighted:ts:const row045Highlight = true',
+    )
+
+    expect(output).toContain('highlighted:ts:const row045Highlight = true')
+    expect(highlightMock.getCliHighlightPromise).toHaveBeenCalled()
+    expect(highlightMock.highlighter.supportsLanguage).toHaveBeenCalledWith(
+      'ts',
+    )
+    expect(highlightMock.highlighter.highlight).toHaveBeenCalledWith(
+      'const row045Highlight = true',
+      { language: 'ts' },
+    )
+  })
+
+  test('resets the streaming stable prefix when the streamed text is replaced', async () => {
+    const harness = await createRenderHarness()
+    try {
+      harness.root.render(
+        <StreamingMarkdown>
+          {'row045 stable block\n\nrow045 growing block'}
+        </StreamingMarkdown>,
+      )
+      await waitForOutput(harness.readOutput, 'row045 growing block')
+
+      markedMock.lexer.mockClear()
+      harness.root.render(
+        <StreamingMarkdown>{'row045 replacement text'}</StreamingMarkdown>,
+      )
+      await waitForOutput(harness.readOutput, 'row045 replacement text')
+
+      expect(markedMock.lexer).toHaveBeenCalledWith('row045 replacement text')
+    } finally {
+      harness.cleanup()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-046-ink-native-ts-color-diff-index.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-046-ink-native-ts-color-diff-index.test.ts
@@ -1,0 +1,164 @@
+import Module from 'node:module'
+import stripAnsi from 'strip-ansi'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+type ColorDiffModule = typeof import('../ink/native-ts/color-diff/index.js')
+
+const originalColorTerm = process.env.COLORTERM
+const moduleWithLoad = Module as typeof Module & {
+  _load: (request: string, parent: unknown, isMain: boolean) => unknown
+}
+const originalModuleLoad = moduleWithLoad._load
+
+function restoreColorTerm(): void {
+  if (originalColorTerm === undefined) {
+    delete process.env.COLORTERM
+  } else {
+    process.env.COLORTERM = originalColorTerm
+  }
+}
+
+async function loadColorDiff(): Promise<ColorDiffModule> {
+  return await import('../ink/native-ts/color-diff/index.js')
+}
+
+function mockHighlightJs(api: {
+  getLanguage: ReturnType<typeof vi.fn>
+  highlight: ReturnType<typeof vi.fn>
+}): void {
+  moduleWithLoad._load = (request, parent, isMain) => {
+    if (request === 'highlight.js') {
+      return { default: api }
+    }
+    return originalModuleLoad(request, parent, isMain)
+  }
+}
+
+describe('color-diff row 046 coverage', () => {
+  afterEach(() => {
+    restoreColorTerm()
+    moduleWithLoad._load = originalModuleLoad
+    vi.doUnmock('../../utils/log.js')
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  test('renders plain files and unrecognized diff markers with the light theme fallback', async () => {
+    delete process.env.COLORTERM
+
+    const { ColorDiff, ColorFile, getSyntaxTheme } = await loadColorDiff()
+
+    expect(getSyntaxTheme('plain')).toEqual({ theme: 'GitHub', source: null })
+
+    const fileLines = new ColorFile(
+      'plain text\nsecond line',
+      'notes.unknown',
+    ).render('light', 18, false)
+
+    expect(fileLines).not.toBeNull()
+    expect(fileLines!.map(line => stripAnsi(line))).toEqual([
+      ' 1 plain text',
+      ' 2 second line',
+    ])
+
+    const diffLines = new ColorDiff(
+      {
+        oldStart: 2,
+        oldLines: 1,
+        newStart: 2,
+        newLines: 1,
+        lines: ['?untagged value'],
+      },
+      null,
+      'notes.unknown',
+    ).render('light', 18, false)
+
+    expect(diffLines).not.toBeNull()
+    expect(stripAnsi(diffLines![0]!)).toBe(' 2  untagged value')
+  })
+
+  test('falls back to plain output when a detected highlighter throws', async () => {
+    vi.resetModules()
+
+    const getLanguage = vi.fn(() => ({}))
+    const highlight = vi.fn(() => {
+      throw new Error('highlight failed')
+    })
+    mockHighlightJs({ getLanguage, highlight })
+
+    const { ColorFile } = await loadColorDiff()
+
+    const lines = new ColorFile('throwing line', 'sample.fake').render(
+      'light',
+      40,
+      false,
+    )
+
+    expect(lines).not.toBeNull()
+    expect(getLanguage).toHaveBeenCalledWith('fake')
+    expect(highlight).toHaveBeenCalledWith('throwing line\n', {
+      language: 'fake',
+      ignoreIllegals: true,
+    })
+    expect(stripAnsi(lines![0]!)).toBe(' 1 throwing line')
+  })
+
+  test('logs malformed highlighter emitters only once before using plain output', async () => {
+    vi.resetModules()
+
+    const logError = vi.fn()
+    vi.doMock('../../utils/log.js', () => ({ logError }))
+
+    const getLanguage = vi.fn(() => ({}))
+    const highlight = vi.fn(() => ({ emitter: { children: [] } }))
+    mockHighlightJs({ getLanguage, highlight })
+
+    const { ColorFile } = await loadColorDiff()
+
+    const lines = new ColorFile('bad emitter\nagain', 'sample.fake').render(
+      'dark',
+      80,
+      false,
+    )
+
+    expect(lines).not.toBeNull()
+    expect(lines!.map(line => stripAnsi(line))).toEqual([
+      ' 1 bad emitter',
+      ' 2 again',
+    ])
+    expect(logError).toHaveBeenCalledTimes(1)
+    expect(logError.mock.calls[0]![0]).toEqual(expect.any(Error))
+    expect((logError.mock.calls[0]![0] as Error).message).toContain(
+      'children',
+    )
+  })
+
+  test('flattens mocked highlighter scope and kind nodes in rendered output', async () => {
+    vi.resetModules()
+
+    const getLanguage = vi.fn(() => ({}))
+    const highlight = vi.fn(() => ({
+      emitter: {
+        rootNode: {
+          children: [
+            { kind: 'keyword', children: ['const'] },
+            ' value = ',
+            { scope: 'title.function', children: ['run'] },
+          ],
+        },
+      },
+    }))
+    mockHighlightJs({ getLanguage, highlight })
+
+    const { ColorFile } = await loadColorDiff()
+
+    const lines = new ColorFile('ignored', 'sample.fake').render(
+      'dark',
+      80,
+      false,
+    )
+
+    expect(lines).not.toBeNull()
+    expect(stripAnsi(lines![0]!)).toBe(' 1 const value = run')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-047-components-PromptInput-PromptInputFooterLeftSide.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-047-components-PromptInput-PromptInputFooterLeftSide.test.tsx
@@ -1,0 +1,293 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { describe, expect, test, vi } from "vitest";
+
+const footerState = vi.hoisted(() => ({
+  appState: {
+    expandedView: "none" as "none" | "tasks" | "teammates",
+    notifications: { current: null as null | { key: string } },
+    remoteSessionUrl: undefined as string | undefined,
+    tasks: {} as Record<string, unknown>,
+    teamContext: undefined as
+      | undefined
+      | { teammates: Record<string, { name: string }> },
+    viewingAgentTaskId: undefined as string | undefined,
+    viewSelectionMode: "normal",
+  },
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: () => false,
+}));
+
+vi.mock("../../../src/coordinator/coordinatorMode.js", () => ({
+  isCoordinatorMode: () => false,
+}));
+
+vi.mock("../../../src/tui/keybindings/useShortcutDisplay.js", () => ({
+  useShortcutDisplay: (_id: string, _scope: string, fallback: string) => fallback,
+}));
+
+vi.mock("../../../src/utils/config.js", () => ({
+  getGlobalConfig: () => ({
+    copyOnSelect: true,
+    editorMode: "normal",
+    prStatusFooterEnabled: true,
+    tui: { vimMode: false },
+  }),
+}));
+
+vi.mock("../../../src/utils/permissions/PermissionMode.js", () => ({
+  getModeColor: () => "mode",
+  isDefaultMode: (mode: string | undefined) =>
+    mode === undefined || mode === "default",
+}));
+
+vi.mock("../../../src/tui/components/tasks/BackgroundTaskStatus.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../../src/tui/ink.js");
+
+  return {
+    BackgroundTaskStatus: () => ReactModule.createElement(Text, null, "tasks"),
+  };
+});
+
+vi.mock("../../../src/tasks/types.js", () => ({
+  isBackgroundTask: () => false,
+}));
+
+vi.mock("../../../src/tui/components/CoordinatorAgentStatus.js", () => ({
+  getVisibleAgentTasks: () => [],
+}));
+
+vi.mock("../../../src/tui/components/tasks/taskStatusUtils.js", () => ({
+  shouldHideTasksFooter: () => false,
+}));
+
+vi.mock("../../../src/utils/agentSwarmsEnabled.js", () => ({
+  isAgentSwarmsEnabled: () => false,
+}));
+
+vi.mock("../../../src/tui/components/teams/TeamStatus.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../../src/tui/ink.js");
+
+  return {
+    TeamStatus: () => ReactModule.createElement(Text, null, "team"),
+  };
+});
+
+vi.mock("../../../src/utils/swarm/backends/registry.js", () => ({
+  isInProcessEnabled: () => false,
+}));
+
+vi.mock("../../../src/tui/state/AppState.js", () => ({
+  useAppState: (selector: (state: typeof footerState.appState) => unknown) =>
+    selector(footerState.appState),
+  useAppStateStore: () => ({
+    getState: () => footerState.appState,
+  }),
+}));
+
+vi.mock("../../../src/bootstrap/state.js", () => ({
+  flushInteractionTime: () => {},
+  getIsRemoteMode: () => false,
+}));
+
+vi.mock("../../../src/tui/components/PromptInput/HistorySearchInput.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../../src/tui/ink.js");
+
+  return {
+    default: () => ReactModule.createElement(Text, null, "history-search"),
+  };
+});
+
+vi.mock("../../../src/tui/hooks/usePrStatus.js", () => ({
+  usePrStatus: () => ({
+    number: null,
+    reviewState: null,
+    url: null,
+  }),
+}));
+
+vi.mock("../../../src/tui/components/design-system/KeyboardShortcutHint.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../../src/tui/ink.js");
+
+  return {
+    KeyboardShortcutHint: ({
+      action,
+      shortcut,
+    }: {
+      readonly action: string;
+      readonly shortcut: string;
+    }) => ReactModule.createElement(Text, null, `${shortcut} to ${action}`),
+  };
+});
+
+vi.mock("../../../src/tui/components/design-system/Byline.js", async () => {
+  const ReactModule = await import("react");
+
+  return {
+    Byline: ({ children }: { readonly children?: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+  };
+});
+
+vi.mock("../../../src/tui/hooks/useTerminalSize.js", () => ({
+  useTerminalSize: () => ({ columns: 100, rows: 24 }),
+}));
+
+vi.mock("../../../src/tui/hooks/useTasksV2.js", () => ({
+  useTasksV2: () => undefined,
+}));
+
+vi.mock("../../../src/utils/fullscreen.js", () => ({
+  isFullscreenEnvEnabled: () => false,
+}));
+
+vi.mock("../../../src/tui/ink/terminal.js", async importOriginal => {
+  const actual =
+    await importOriginal<typeof import("../../../src/tui/ink/terminal.js")>();
+
+  return {
+    ...actual,
+    SYNC_OUTPUT_SUPPORTED: false,
+    isXtermJs: () => false,
+    shouldSkipMainScreenSyncMarkers: () => true,
+    shouldUseMainScreenRewrite: () => false,
+    supportsExtendedKeys: () => false,
+    writeDiffToTerminal: (
+      terminal: { stdout: { write: (chunk: string) => void } },
+      diff: Array<{ content?: string; str?: string; type: string }>,
+    ) => {
+      terminal.stdout.write(
+        diff
+          .map(patch =>
+            patch.type === "stdout"
+              ? patch.content ?? ""
+              : patch.type === "styleStr"
+                ? patch.str ?? ""
+                : "",
+          )
+          .join(""),
+      );
+    },
+  };
+});
+
+vi.mock("../../../src/tui/ink/hooks/use-selection.js", () => ({
+  useHasSelection: () => false,
+  useSelection: () => ({
+    getState: () => ({ lastPressHadAlt: false }),
+  }),
+}));
+
+vi.mock("../../../src/utils/platform.js", () => ({
+  getPlatform: () => "linux",
+}));
+
+vi.mock("../../../src/tui/components/PrBadge.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await import("../../../src/tui/ink.js");
+
+  return {
+    PrBadge: () => ReactModule.createElement(Text, null, "pr"),
+  };
+});
+
+vi.mock("../../../src/tui/components/PromptInput/proactiveAdapter.js", () => ({
+  getPromptInputProactiveNextTickAt: () => null,
+  isPromptInputProactiveActive: () => false,
+  subscribeToPromptInputProactiveChanges: () => () => {},
+}));
+
+import { createRoot } from "../../../src/tui/ink.js";
+import { PromptInputFooterLeftSide } from "../../../src/tui/components/PromptInput/PromptInputFooterLeftSide.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+type TestStdout = PassThrough & {
+  columns: number;
+  isTTY: boolean;
+  rows: number;
+};
+
+function createStreams(): {
+  readonly stdin: TestStdin;
+  readonly stdout: TestStdout;
+} {
+  const stdin = new PassThrough() as TestStdin;
+  const stdout = new PassThrough() as TestStdout;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.columns = 100;
+  stdout.rows = 24;
+  stdout.isTTY = true;
+  stdout.resume();
+
+  return { stdin, stdout };
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe("PromptInputFooterLeftSide coverage swarm 047", () => {
+  test("reuses memoized footer fragments across identical rerenders", async () => {
+    const { stdin, stdout } = createStreams();
+    let output = "";
+
+    stdout.on("data", chunk => {
+      output += chunk.toString();
+    });
+
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    const setHistoryQuery = vi.fn();
+    const toolPermissionContext = { mode: "default" } as never;
+    const props: React.ComponentProps<typeof PromptInputFooterLeftSide> = {
+      exitMessage: { show: false },
+      historyFailedMatch: false,
+      historyQuery: "",
+      isLoading: false,
+      isSearching: false,
+      mode: "prompt",
+      setHistoryQuery,
+      suppressHint: false,
+      tasksSelected: false,
+      teamsSelected: false,
+      toolPermissionContext,
+      vimMode: undefined,
+    };
+
+    try {
+      root.render(<PromptInputFooterLeftSide {...props} />);
+      await sleep();
+      root.render(<PromptInputFooterLeftSide {...props} />);
+      await sleep();
+
+      expect(stripAnsi(output)).toContain("?forshortcuts");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-048-components-CustomSelect-select-input-option.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-048-components-CustomSelect-select-input-option.test.tsx
@@ -1,0 +1,376 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createRoot } from "../../../src/tui/ink/root.js";
+import {
+  computeSelectInputColumns,
+  SelectInputOption,
+} from "../../../src/tui/components/CustomSelect/select-input-option.js";
+
+const keybindingMock = vi.hoisted(() => ({
+  single: new Map<
+    string,
+    Array<{
+      handler: () => void | Promise<void>;
+      options: { context?: string; isActive?: boolean };
+    }>
+  >(),
+  multi: undefined as
+    | undefined
+    | {
+        handlers: Record<string, () => void>;
+        options: { context?: string; isActive?: boolean };
+      },
+}));
+
+const inputMock = vi.hoisted(() => ({
+  current: undefined as
+    | undefined
+    | {
+        handler: (_input: string, key: { upArrow?: boolean }) => void;
+        options: { isActive?: boolean };
+      },
+}));
+
+const textInputMock = vi.hoisted(() => ({
+  current: undefined as
+    | undefined
+    | {
+        columns: number;
+        cursorOffset: number;
+        focus: boolean;
+        onChange: (value: string) => void;
+        onChangeCursorOffset: (offset: number) => void;
+        onExit?: () => void;
+        onImagePaste?: (base64: string) => void;
+        onPaste: (value: string) => void;
+        onSubmit: (value: string) => void;
+        placeholder?: string;
+        value: string;
+      },
+}));
+
+const imagePasteMock = vi.hoisted(() => {
+  const state = {
+    result: undefined as
+      | undefined
+      | {
+          base64: string;
+          dimensions?: { height: number; width: number };
+          mediaType?: string;
+        },
+    getImageFromClipboard: vi.fn(async () => state.result),
+  };
+
+  return state;
+});
+
+vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
+  useKeybinding: (
+    action: string,
+    handler: () => void | Promise<void>,
+    options: { context?: string; isActive?: boolean },
+  ) => {
+    const bindings = keybindingMock.single.get(action) ?? [];
+    bindings.push({ handler, options });
+    keybindingMock.single.set(action, bindings);
+  },
+  useKeybindings: (
+    handlers: Record<string, () => void>,
+    options: { context?: string; isActive?: boolean },
+  ) => {
+    keybindingMock.multi = { handlers, options };
+  },
+}));
+
+vi.mock("../../../src/tui/ink.js", async importOriginal => {
+  const actual = await importOriginal<typeof import("../../../src/tui/ink.js")>();
+
+  return {
+    ...actual,
+    useInput: (
+      handler: (_input: string, key: { upArrow?: boolean }) => void,
+      options: { isActive?: boolean },
+    ) => {
+      inputMock.current = { handler, options };
+    },
+  };
+});
+
+vi.mock("../../../src/tui/components/TextInput.js", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    default: (props: typeof textInputMock.current) => {
+      textInputMock.current = props;
+
+      return ReactActual.createElement(
+        "ink-text",
+        null,
+        props?.value || props?.placeholder || "",
+      );
+    },
+  };
+});
+
+vi.mock("../../../src/tui/components/ClickableImageRef.js", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    ClickableImageRef: ({
+      imageId,
+      isSelected,
+    }: {
+      imageId: number;
+      isSelected?: boolean;
+    }) =>
+      ReactActual.createElement(
+        "ink-text",
+        null,
+        isSelected ? `[image ${imageId} selected]` : `[image ${imageId}]`,
+      ),
+  };
+});
+
+vi.mock("../../../src/tui/components/ConfigurableShortcutHint.js", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    ConfigurableShortcutHint: ({
+      description,
+      fallback,
+    }: {
+      description: string;
+      fallback: string;
+    }) => ReactActual.createElement("ink-text", null, `${fallback} ${description}`),
+  };
+});
+
+vi.mock("../../../src/utils/imagePaste.js", () => ({
+  getImageFromClipboard: imagePasteMock.getImageFromClipboard,
+}));
+
+type TestRoot = Awaited<ReturnType<typeof createRoot>>;
+
+const mountedRoots: Array<{ root: TestRoot; stdin: PassThrough }> = [];
+
+function inputOption(overrides = {}) {
+  return {
+    description: "Prompt details",
+    dimDescription: true,
+    label: "Prompt",
+    labelValueSeparator: ": ",
+    onChange: vi.fn(),
+    placeholder: "Write prompt",
+    showLabelWithValue: true,
+    type: "input",
+    ...overrides,
+  } as const;
+}
+
+async function waitForRender(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 30));
+}
+
+async function renderOption(node: React.ReactNode): Promise<() => string> {
+  let output = "";
+  const stdout = new PassThrough();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.ref = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number }).columns = 80;
+
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  });
+  mountedRoots.push({ root, stdin });
+
+  root.render(node);
+  await waitForRender();
+
+  return () => stripAnsi(output);
+}
+
+describe("computeSelectInputColumns coverage", () => {
+  test("floors fractional terminal measurements before reserving input chrome", () => {
+    expect(computeSelectInputColumns(40.9, 2.9, true, "Prompt", ": ")).toBe(26);
+  });
+
+  test("clamps non-positive terminal measurements to one usable column", () => {
+    expect(computeSelectInputColumns(0, -4, true, "Prompt")).toBe(1);
+  });
+});
+
+describe("SelectInputOption coverage", () => {
+  beforeEach(() => {
+    keybindingMock.single.clear();
+    keybindingMock.multi = undefined;
+    inputMock.current = undefined;
+    textInputMock.current = undefined;
+    imagePasteMock.result = undefined;
+    imagePasteMock.getImageFromClipboard.mockClear();
+  });
+
+  afterEach(() => {
+    for (const { root, stdin } of mountedRoots.splice(0)) {
+      root.unmount();
+      stdin.end();
+    }
+  });
+
+  test("renders an unfocused labeled value and filters pasted content to images", async () => {
+    const text = await renderOption(
+      <SelectInputOption
+        option={inputOption()}
+        isFocused={false}
+        isSelected={false}
+        shouldShowDownArrow={false}
+        shouldShowUpArrow={false}
+        maxIndexWidth={2}
+        index={7}
+        inputValue="saved prompt"
+        onInputChange={() => {}}
+        onSubmit={() => {}}
+        layout="expanded"
+        pastedContents={{
+          1: { id: 1, type: "text", text: "ignored paste" },
+          2: { id: 2, type: "image" },
+        } as never}
+      />,
+    );
+
+    expect(text()).toContain("7.");
+    expect(text()).toContain("Prompt");
+    expect(text()).toContain(": saved prompt");
+    expect(text()).toContain("Prompt details");
+    expect(text()).toContain("[image 2]");
+    expect(text()).not.toContain("ignored paste");
+
+    await keybindingMock.single.get("chat:imagePaste")?.at(-1)?.handler();
+    expect(imagePasteMock.getImageFromClipboard).not.toHaveBeenCalled();
+    expect(
+      keybindingMock.single.get("chat:externalEditor")?.at(-1)?.options.isActive,
+    ).toBe(false);
+  });
+
+  test("leaves image paste callback untouched when the clipboard has no image", async () => {
+    const onImagePaste = vi.fn();
+
+    await renderOption(
+      <SelectInputOption
+        option={inputOption({ showLabelWithValue: false })}
+        isFocused
+        isSelected={false}
+        shouldShowDownArrow={false}
+        shouldShowUpArrow={false}
+        maxIndexWidth={1}
+        index={1}
+        inputValue=""
+        onInputChange={() => {}}
+        onSubmit={() => {}}
+        layout="compact"
+        onImagePaste={onImagePaste}
+      />,
+    );
+
+    await keybindingMock.single.get("chat:imagePaste")?.at(-1)?.handler();
+
+    expect(imagePasteMock.getImageFromClipboard).toHaveBeenCalledTimes(1);
+    expect(onImagePaste).not.toHaveBeenCalled();
+  });
+
+  test("uses single-image attachment controls without cycling selection", async () => {
+    const onImagesSelectedChange = vi.fn();
+    const onRemoveImage = vi.fn();
+    const onSelectedImageIndexChange = vi.fn();
+
+    const text = await renderOption(
+      <SelectInputOption
+        option={inputOption()}
+        isFocused
+        isSelected
+        shouldShowDownArrow={false}
+        shouldShowUpArrow={false}
+        maxIndexWidth={1}
+        index={2}
+        inputValue=""
+        onInputChange={() => {}}
+        onSubmit={() => {}}
+        layout="compact"
+        pastedContents={{ 5: { id: 5, type: "image" } } as never}
+        imagesSelected
+        selectedImageIndex={0}
+        onImagesSelectedChange={onImagesSelectedChange}
+        onRemoveImage={onRemoveImage}
+        onSelectedImageIndexChange={onSelectedImageIndexChange}
+      />,
+    );
+
+    expect(text()).toContain("[image 5 selected]");
+    expect(text()).toContain("backspace remove");
+    expect(text()).toContain("esc cancel");
+    expect(text()).not.toContain("right next");
+
+    keybindingMock.multi?.handlers["attachments:next"]();
+    keybindingMock.multi?.handlers["attachments:previous"]();
+    expect(onSelectedImageIndexChange).not.toHaveBeenCalled();
+
+    keybindingMock.multi?.handlers["attachments:remove"]();
+    expect(onRemoveImage).toHaveBeenCalledWith(5);
+    expect(onImagesSelectedChange).toHaveBeenCalledWith(false);
+
+    inputMock.current?.handler("", {});
+    expect(onImagesSelectedChange).toHaveBeenCalledTimes(1);
+
+    inputMock.current?.handler("", { upArrow: true });
+    expect(onImagesSelectedChange).toHaveBeenCalledTimes(2);
+    expect(onImagesSelectedChange).toHaveBeenLastCalledWith(false);
+  });
+
+  test("does not remove an attachment when selected image index is out of range", async () => {
+    const onImagesSelectedChange = vi.fn();
+    const onRemoveImage = vi.fn();
+
+    await renderOption(
+      <SelectInputOption
+        option={inputOption()}
+        isFocused
+        isSelected={false}
+        shouldShowDownArrow={false}
+        shouldShowUpArrow={false}
+        maxIndexWidth={1}
+        index={3}
+        inputValue=""
+        onInputChange={() => {}}
+        onSubmit={() => {}}
+        layout="compact"
+        pastedContents={{ 8: { id: 8, type: "image" } } as never}
+        imagesSelected
+        selectedImageIndex={3}
+        onImagesSelectedChange={onImagesSelectedChange}
+        onRemoveImage={onRemoveImage}
+      />,
+    );
+
+    keybindingMock.multi?.handlers["attachments:remove"]();
+
+    expect(onRemoveImage).not.toHaveBeenCalled();
+    expect(onImagesSelectedChange).not.toHaveBeenCalled();
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-049-keybindings-KeybindingProviderSetup.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-049-keybindings-KeybindingProviderSetup.test.tsx
@@ -1,0 +1,242 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("../ink.js", () => ({
+  useInput: () => {},
+}));
+
+vi.mock("../context/notifications.js", () => ({
+  useNotifications: () => ({
+    addNotification: () => {},
+    removeNotification: () => {},
+  }),
+}));
+
+vi.mock("../../utils/debug.js", () => ({
+  logForDebugging: () => {},
+}));
+
+import type { Key } from "../ink.js";
+import {
+  createChordInputHandler,
+  formatKeybindingWarningNotification,
+  formatKeybindingWarningSummary,
+} from "../keybindings/KeybindingProviderSetup.js";
+import { parseBindings } from "../keybindings/parser.js";
+import type {
+  KeybindingContextName,
+  ParsedKeystroke,
+} from "../keybindings/types.js";
+
+type HandlerRegistration = {
+  action: string;
+  context: KeybindingContextName;
+  handler: () => void;
+};
+
+function key(overrides: Partial<Key> = {}): Key {
+  return {
+    ctrl: false,
+    shift: false,
+    fn: false,
+    meta: false,
+    super: false,
+    escape: false,
+    return: false,
+    tab: false,
+    backspace: false,
+    delete: false,
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    pageUp: false,
+    pageDown: false,
+    wheelUp: false,
+    wheelDown: false,
+    home: false,
+    end: false,
+    ...overrides,
+  } as Key;
+}
+
+function inputEvent(): {
+  stopped: boolean;
+  stopImmediatePropagation: () => void;
+} {
+  return {
+    stopped: false,
+    stopImmediatePropagation() {
+      this.stopped = true;
+    },
+  };
+}
+
+describe("KeybindingProviderSetup coverage swarm 049", () => {
+  test("formats empty, plural, and unicode warning messages", () => {
+    expect(formatKeybindingWarningSummary([])).toBeNull();
+    expect(
+      formatKeybindingWarningSummary([
+        { type: "parse_error", severity: "error", message: "bad one" },
+        { type: "parse_error", severity: "error", message: "bad two" },
+      ]),
+    ).toBe("Found 2 keybinding errors");
+    expect(
+      formatKeybindingWarningSummary([
+        { type: "reserved", severity: "warning", message: "reserved one" },
+        { type: "reserved", severity: "warning", message: "reserved two" },
+      ]),
+    ).toBe("Found 2 keybinding warnings");
+    expect(
+      formatKeybindingWarningSummary([
+        { type: "parse_error", severity: "error", message: "bad" },
+        { type: "reserved", severity: "warning", message: "reserved one" },
+        { type: "reserved", severity: "warning", message: "reserved two" },
+      ]),
+    ).toBe("Found 1 keybinding error and 2 warnings");
+    expect(
+      formatKeybindingWarningNotification("Found 2 keybinding warnings", {
+        AGENC_TUI_GLYPHS: "unicode",
+      }),
+    ).toBe("Found 2 keybinding warnings · /doctor for details");
+  });
+
+  test("leaves non-chord matches and misses available for child input handlers", () => {
+    const bindings = parseBindings([
+      {
+        context: "Chat",
+        bindings: {
+          enter: "chat:submit",
+        },
+      },
+    ]);
+    const pendingChordRef = { current: null as ParsedKeystroke[] | null };
+    const pendingStates: Array<ParsedKeystroke[] | null> = [];
+    const handler = createChordInputHandler({
+      bindings,
+      pendingChordRef,
+      setPendingChord: pending => {
+        pendingStates.push(pending);
+        pendingChordRef.current = pending;
+      },
+      activeContexts: new Set(["Chat"]),
+      handlerRegistryRef: { current: new Map() },
+    });
+
+    const missEvent = inputEvent();
+    handler("z", key(), missEvent);
+    expect(missEvent.stopped).toBe(false);
+    expect(pendingStates).toEqual([]);
+
+    const matchEvent = inputEvent();
+    handler("", key({ return: true }), matchEvent);
+    expect(matchEvent.stopped).toBe(false);
+    expect(pendingStates).toEqual([null]);
+    expect(pendingChordRef.current).toBeNull();
+  });
+
+  test("uses registered handler contexts to resolve inactive chord bindings", () => {
+    const bindings = parseBindings([
+      {
+        context: "Chat",
+        bindings: {
+          "ctrl+x ctrl+k": "chat:killAgents",
+        },
+      },
+    ]);
+    const pendingChordRef = { current: null as ParsedKeystroke[] | null };
+    const setPendingChord = (pending: ParsedKeystroke[] | null): void => {
+      pendingChordRef.current = pending;
+    };
+    const invoked = vi.fn();
+    const registry = new Map<string, Set<HandlerRegistration>>([
+      [
+        "chat:killAgents",
+        new Set([
+          {
+            action: "chat:killAgents",
+            context: "Chat",
+            handler: invoked,
+          },
+        ]),
+      ],
+    ]);
+    const handler = createChordInputHandler({
+      bindings,
+      pendingChordRef,
+      setPendingChord,
+      activeContexts: new Set(),
+      handlerRegistryRef: { current: registry },
+    });
+
+    const prefixEvent = inputEvent();
+    handler("x", key({ ctrl: true }), prefixEvent);
+    expect(prefixEvent.stopped).toBe(true);
+    expect(pendingChordRef.current?.[0]?.key).toBe("x");
+
+    const completionEvent = inputEvent();
+    handler("k", key({ ctrl: true }), completionEvent);
+    expect(completionEvent.stopped).toBe(true);
+    expect(pendingChordRef.current).toBeNull();
+    expect(invoked).toHaveBeenCalledTimes(1);
+  });
+
+  test("clears chord state without stopping when a completed chord has no handler", () => {
+    const bindings = parseBindings([
+      {
+        context: "Chat",
+        bindings: {
+          "ctrl+x ctrl+k": "chat:killAgents",
+        },
+      },
+    ]);
+    const pendingChordRef = { current: null as ParsedKeystroke[] | null };
+    const handler = createChordInputHandler({
+      bindings,
+      pendingChordRef,
+      setPendingChord: pending => {
+        pendingChordRef.current = pending;
+      },
+      activeContexts: new Set(["Chat"]),
+      handlerRegistryRef: {
+        current: new Map<string, Set<HandlerRegistration>>([
+          ["chat:other", new Set()],
+        ]),
+      },
+    });
+
+    handler("x", key({ ctrl: true }), inputEvent());
+    const completionEvent = inputEvent();
+    handler("k", key({ ctrl: true }), completionEvent);
+
+    expect(completionEvent.stopped).toBe(false);
+    expect(pendingChordRef.current).toBeNull();
+  });
+
+  test("intercepts wheel input while a chord is pending", () => {
+    const bindings = parseBindings([
+      {
+        context: "Chat",
+        bindings: {
+          "ctrl+x ctrl+k": "chat:killAgents",
+        },
+      },
+    ]);
+    const pendingChordRef = { current: null as ParsedKeystroke[] | null };
+    const handler = createChordInputHandler({
+      bindings,
+      pendingChordRef,
+      setPendingChord: pending => {
+        pendingChordRef.current = pending;
+      },
+      activeContexts: new Set(["Chat"]),
+      handlerRegistryRef: { current: new Map() },
+    });
+
+    handler("x", key({ ctrl: true }), inputEvent());
+    const wheelEvent = inputEvent();
+    handler("", key({ wheelDown: true }), wheelEvent);
+
+    expect(wheelEvent.stopped).toBe(true);
+    expect(pendingChordRef.current).toBeNull();
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-050-components-AutoUpdater.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-050-components-AutoUpdater.test.tsx
@@ -1,0 +1,510 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { AutoUpdaterResult } from "../../../src/utils/autoUpdater.js";
+
+const harness = vi.hoisted(() => ({
+  getCurrentInstallationType: vi.fn(),
+  getGlobalConfig: vi.fn(),
+  getInitialSettings: vi.fn(),
+  getLatestVersion: vi.fn(),
+  getMaxVersion: vi.fn(),
+  installGlobalPackage: vi.fn(),
+  installOrUpdateAgenCPackage: vi.fn(),
+  intervalDelay: undefined as number | null | undefined,
+  isAutoUpdaterDisabled: vi.fn(),
+  localInstallationExists: vi.fn(),
+  logEvent: vi.fn(),
+  logForDebugging: vi.fn(),
+  removeInstalledSymlink: vi.fn(),
+  shouldSkipVersion: vi.fn(),
+  updateNotificationValue: true,
+}));
+
+vi.mock("usehooks-ts", () => ({
+  useInterval: (_callback: () => void, delay: number | null) => {
+    harness.intervalDelay = delay;
+  },
+}));
+
+vi.mock("../../../src/services/analytics/index.js", () => ({
+  logEvent: harness.logEvent,
+}));
+
+vi.mock("../../../src/tui/hooks/useUpdateNotification.js", () => ({
+  useUpdateNotification: () => harness.updateNotificationValue,
+}));
+
+vi.mock("../../../src/utils/autoUpdater.js", () => ({
+  getLatestVersion: harness.getLatestVersion,
+  getMaxVersion: harness.getMaxVersion,
+  installGlobalPackage: harness.installGlobalPackage,
+  shouldSkipVersion: harness.shouldSkipVersion,
+}));
+
+vi.mock("../../../src/utils/config.js", () => ({
+  getGlobalConfig: harness.getGlobalConfig,
+  isAutoUpdaterDisabled: harness.isAutoUpdaterDisabled,
+  saveGlobalConfig: vi.fn(),
+}));
+
+vi.mock("../../../src/utils/debug.js", () => ({
+  logForDebugging: harness.logForDebugging,
+}));
+
+vi.mock("../../../src/utils/doctorDiagnostic.js", () => ({
+  getCurrentInstallationType: harness.getCurrentInstallationType,
+}));
+
+vi.mock("../../../src/utils/localInstaller.js", () => ({
+  installOrUpdateAgenCPackage: harness.installOrUpdateAgenCPackage,
+  localInstallationExists: harness.localInstallationExists,
+}));
+
+vi.mock("../../../src/utils/nativeInstaller/installer.js", () => ({
+  removeInstalledSymlink: harness.removeInstalledSymlink,
+}));
+
+vi.mock("../../../src/utils/semver.js", () => {
+  const compareVersions = (left: string, right: string): number => {
+    const leftParts = left.split(".").map(Number);
+    const rightParts = right.split(".").map(Number);
+
+    for (let index = 0; index < 3; index += 1) {
+      const delta = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+      if (delta !== 0) {
+        return delta;
+      }
+    }
+
+    return 0;
+  };
+
+  return {
+    gt: (left: string, right: string) => compareVersions(left, right) > 0,
+    gte: (left: string, right: string) => compareVersions(left, right) >= 0,
+  };
+});
+
+vi.mock("../../../src/utils/settings/settings.js", () => ({
+  getInitialSettings: harness.getInitialSettings,
+}));
+
+import { AutoUpdater } from "../../../src/tui/components/AutoUpdater.js";
+import { createRoot } from "../../../src/tui/ink/root.js";
+
+const originalGlyphMode = process.env.AGENC_TUI_GLYPHS;
+const originalMacro = (globalThis as Record<string, unknown>).MACRO;
+const originalNodeEnv = process.env.NODE_ENV;
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  readonly stdout: PassThrough;
+};
+
+type RenderedRoot = {
+  readonly cleanup: () => Promise<void>;
+  readonly readOutput: () => string;
+};
+
+function resetHarness(): void {
+  harness.getCurrentInstallationType.mockReset().mockResolvedValue("npm-global");
+  harness.getGlobalConfig
+    .mockReset()
+    .mockReturnValue({ installMethod: "global", theme: "dark" });
+  harness.getInitialSettings
+    .mockReset()
+    .mockReturnValue({ autoUpdatesChannel: "stable" });
+  harness.getLatestVersion.mockReset().mockResolvedValue("2.0.0");
+  harness.getMaxVersion.mockReset().mockResolvedValue(null);
+  harness.installGlobalPackage.mockReset().mockResolvedValue("success");
+  harness.installOrUpdateAgenCPackage.mockReset().mockResolvedValue("success");
+  harness.isAutoUpdaterDisabled.mockReset().mockReturnValue(false);
+  harness.localInstallationExists.mockReset().mockResolvedValue(false);
+  harness.logEvent.mockReset();
+  harness.logForDebugging.mockReset();
+  harness.removeInstalledSymlink.mockReset().mockResolvedValue(undefined);
+  harness.shouldSkipVersion.mockReset().mockReturnValue(false);
+  harness.intervalDelay = undefined;
+  harness.updateNotificationValue = true;
+}
+
+function setMacro(version = "1.0.0"): void {
+  (globalThis as Record<string, unknown>).MACRO = {
+    PACKAGE_URL: "@tetsuo-ai/agenc",
+    VERSION: version,
+  };
+}
+
+function createStreams(): TestStreams {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStreams["stdin"];
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number; rows: number }).columns = 240;
+  (stdout as unknown as { columns: number; rows: number }).rows = 24;
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function renderInRoot(node: React.ReactNode): Promise<RenderedRoot> {
+  let output = "";
+  const { stdin, stdout } = createStreams();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  root.render(node);
+
+  return {
+    readOutput: () => stripAnsi(output),
+    cleanup: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep(0);
+    },
+  };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  label: string,
+): Promise<void> {
+  const deadline = Date.now() + 1000;
+
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await sleep(10);
+  }
+
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+async function waitForOutput(
+  rendered: RenderedRoot,
+  expectedText: string,
+): Promise<string> {
+  await waitFor(
+    () => rendered.readOutput().includes(expectedText),
+    `output containing ${expectedText}`,
+  );
+  return rendered.readOutput();
+}
+
+function StatefulAutoUpdater(): React.ReactNode {
+  const [isUpdating, setIsUpdating] = React.useState(false);
+  const [autoUpdaterResult, setAutoUpdaterResult] =
+    React.useState<AutoUpdaterResult | null>(null);
+
+  return (
+    <AutoUpdater
+      autoUpdaterResult={autoUpdaterResult}
+      isUpdating={isUpdating}
+      onAutoUpdaterResult={setAutoUpdaterResult}
+      onChangeIsUpdating={setIsUpdating}
+      showSuccessMessage={true}
+      verbose={true}
+    />
+  );
+}
+
+function StaticAutoUpdater({
+  autoUpdaterResult = null,
+  isUpdating = false,
+}: {
+  readonly autoUpdaterResult?: AutoUpdaterResult | null;
+  readonly isUpdating?: boolean;
+}): React.ReactNode {
+  return (
+    <AutoUpdater
+      autoUpdaterResult={autoUpdaterResult}
+      isUpdating={isUpdating}
+      onAutoUpdaterResult={() => {}}
+      onChangeIsUpdating={() => {}}
+      showSuccessMessage={true}
+      verbose={true}
+    />
+  );
+}
+
+describe("AutoUpdater coverage swarm row 050", () => {
+  beforeEach(() => {
+    resetHarness();
+    process.env.AGENC_TUI_GLYPHS = "ascii";
+    process.env.NODE_ENV = "production";
+    setMacro();
+  });
+
+  afterEach(() => {
+    if (originalGlyphMode === undefined) {
+      delete process.env.AGENC_TUI_GLYPHS;
+    } else {
+      process.env.AGENC_TUI_GLYPHS = originalGlyphMode;
+    }
+
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+
+    if (originalMacro === undefined) {
+      delete (globalThis as Record<string, unknown>).MACRO;
+    } else {
+      (globalThis as Record<string, unknown>).MACRO = originalMacro;
+    }
+  });
+
+  test("skips checks in development and while another update is active", async () => {
+    process.env.NODE_ENV = "development";
+    let rendered = await renderInRoot(<StaticAutoUpdater />);
+
+    try {
+      await waitFor(
+        () =>
+          harness.logForDebugging.mock.calls.some(
+            ([message]) =>
+              message ===
+              "AutoUpdater: Skipping update check in test/dev environment",
+          ),
+        "development update-check skip",
+      );
+      expect(harness.getLatestVersion).not.toHaveBeenCalled();
+    } finally {
+      await rendered.cleanup();
+    }
+
+    resetHarness();
+    process.env.NODE_ENV = "production";
+    rendered = await renderInRoot(
+      <StaticAutoUpdater
+        autoUpdaterResult={{ status: "success", version: "2.0.0" }}
+        isUpdating={true}
+      />,
+    );
+
+    try {
+      const output = await waitForOutput(rendered, "Auto-updating...");
+      expect(output).toContain("globalVersion:");
+      await sleep(20);
+      expect(harness.getLatestVersion).not.toHaveBeenCalled();
+      expect(
+        harness.logForDebugging.mock.calls.some(([message]) =>
+          String(message).startsWith("AutoUpdater:"),
+        ),
+      ).toBe(false);
+    } finally {
+      await rendered.cleanup();
+    }
+  });
+
+  test("caps to maxVersion and returns when current version already meets it", async () => {
+    setMacro("2.0.0");
+    harness.getLatestVersion.mockResolvedValue("9.0.0");
+    harness.getMaxVersion.mockResolvedValue("2.0.0");
+    const onChangeIsUpdating = vi.fn();
+    const rendered = await renderInRoot(
+      <AutoUpdater
+        autoUpdaterResult={null}
+        isUpdating={false}
+        onAutoUpdaterResult={() => {}}
+        onChangeIsUpdating={onChangeIsUpdating}
+        showSuccessMessage={true}
+        verbose={true}
+      />,
+    );
+
+    try {
+      await waitFor(
+        () =>
+          harness.logForDebugging.mock.calls.some(
+            ([message]) =>
+              message ===
+              "AutoUpdater: current version 2.0.0 is already at or above maxVersion 2.0.0, skipping update",
+          ),
+        "max-version current-version skip",
+      );
+
+      expect(harness.logForDebugging).toHaveBeenCalledWith(
+        "AutoUpdater: maxVersion 2.0.0 is set, capping update from 9.0.0 to 2.0.0",
+      );
+      expect(harness.shouldSkipVersion).not.toHaveBeenCalled();
+      expect(harness.installGlobalPackage).not.toHaveBeenCalled();
+      expect(harness.installOrUpdateAgenCPackage).not.toHaveBeenCalled();
+      expect(harness.removeInstalledSymlink).not.toHaveBeenCalled();
+      expect(onChangeIsUpdating).not.toHaveBeenCalled();
+    } finally {
+      await rendered.cleanup();
+    }
+  });
+
+  test("installs with the npm-global path and keeps native symlinks untouched", async () => {
+    harness.getGlobalConfig.mockReturnValue({
+      installMethod: "native",
+      theme: "dark",
+    });
+    harness.getCurrentInstallationType.mockResolvedValue("npm-global");
+    const rendered = await renderInRoot(<StatefulAutoUpdater />);
+
+    try {
+      const output = await waitForOutput(rendered, "Update installed");
+
+      expect(output).toContain("globalVersion: 1.0.0 - latestVersion: 2.0.0");
+      expect(output).toContain("OK Update installed - Restart to apply");
+      expect(harness.intervalDelay).toBe(1_800_000);
+      expect(harness.getLatestVersion).toHaveBeenCalledWith("stable");
+      expect(harness.removeInstalledSymlink).not.toHaveBeenCalled();
+      expect(harness.getCurrentInstallationType).toHaveBeenCalledOnce();
+      expect(harness.installGlobalPackage).toHaveBeenCalledOnce();
+      expect(harness.installOrUpdateAgenCPackage).not.toHaveBeenCalled();
+      expect(harness.logForDebugging).toHaveBeenCalledWith(
+        "AutoUpdater: Detected installation type: npm-global",
+      );
+      expect(harness.logForDebugging).toHaveBeenCalledWith(
+        "AutoUpdater: Using global update method",
+      );
+      expect(harness.logEvent).toHaveBeenCalledWith(
+        "tengu_auto_updater_success",
+        expect.objectContaining({
+          fromVersion: "1.0.0",
+          installationType: "npm-global",
+          toVersion: "2.0.0",
+          wasMigrated: false,
+        }),
+      );
+    } finally {
+      await rendered.cleanup();
+    }
+  });
+
+  test("installs with the npm-local path and records migrated success", async () => {
+    harness.getCurrentInstallationType.mockResolvedValue("npm-local");
+    const rendered = await renderInRoot(<StatefulAutoUpdater />);
+
+    try {
+      await waitForOutput(rendered, "Update installed");
+
+      expect(harness.removeInstalledSymlink).toHaveBeenCalledOnce();
+      expect(harness.installOrUpdateAgenCPackage).toHaveBeenCalledWith("stable");
+      expect(harness.installGlobalPackage).not.toHaveBeenCalled();
+      expect(harness.logForDebugging).toHaveBeenCalledWith(
+        "AutoUpdater: Using local update method",
+      );
+      expect(harness.logEvent).toHaveBeenCalledWith(
+        "tengu_auto_updater_success",
+        expect.objectContaining({
+          installationType: "npm-local",
+          toVersion: "2.0.0",
+          wasMigrated: true,
+        }),
+      );
+    } finally {
+      await rendered.cleanup();
+    }
+  });
+
+  test("does not install when disabled, already current, or user-skipped", async () => {
+    const cases = [
+      {
+        label: "disabled",
+        arrange: () => {
+          harness.isAutoUpdaterDisabled.mockReturnValue(true);
+        },
+        wait: () => harness.getMaxVersion.mock.calls.length > 0,
+        shouldSkipCalls: 0,
+      },
+      {
+        label: "already current",
+        arrange: () => {
+          harness.getLatestVersion.mockResolvedValue("1.0.0");
+        },
+        wait: () => harness.getMaxVersion.mock.calls.length > 0,
+        shouldSkipCalls: 0,
+      },
+      {
+        label: "user skipped",
+        arrange: () => {
+          harness.shouldSkipVersion.mockReturnValue(true);
+        },
+        wait: () => harness.shouldSkipVersion.mock.calls.length > 0,
+        shouldSkipCalls: 1,
+      },
+    ];
+
+    for (const testCase of cases) {
+      resetHarness();
+      testCase.arrange();
+      const rendered = await renderInRoot(<StaticAutoUpdater />);
+
+      try {
+        await waitFor(testCase.wait, `${testCase.label} skip`);
+        await sleep(10);
+        expect(harness.installGlobalPackage, testCase.label).not.toHaveBeenCalled();
+        expect(
+          harness.installOrUpdateAgenCPackage,
+          testCase.label,
+        ).not.toHaveBeenCalled();
+        expect(harness.removeInstalledSymlink, testCase.label).not.toHaveBeenCalled();
+        expect(harness.shouldSkipVersion, testCase.label).toHaveBeenCalledTimes(
+          testCase.shouldSkipCalls,
+        );
+      } finally {
+        await rendered.cleanup();
+      }
+    }
+  });
+
+  test("renders the global repair command for fallback no-permissions failures", async () => {
+    harness.getCurrentInstallationType.mockResolvedValue("unknown");
+    harness.installGlobalPackage.mockResolvedValue("no_permissions");
+    const rendered = await renderInRoot(<StatefulAutoUpdater />);
+
+    try {
+      const output = await waitForOutput(rendered, "Auto-update failed");
+
+      expect(output).toContain("ERR Auto-update failed - Try agenc doctor");
+      expect(output).toContain("npm i -g @tetsuo-ai/agenc");
+      expect(harness.localInstallationExists).toHaveBeenCalledOnce();
+      expect(harness.installGlobalPackage).toHaveBeenCalledOnce();
+      expect(harness.installOrUpdateAgenCPackage).not.toHaveBeenCalled();
+      expect(harness.logForDebugging).toHaveBeenCalledWith(
+        "AutoUpdater: Unknown installation type, falling back to config",
+      );
+      expect(harness.logEvent).toHaveBeenCalledWith(
+        "tengu_auto_updater_fail",
+        expect.objectContaining({
+          attemptedVersion: "2.0.0",
+          installationType: "unknown",
+          status: "no_permissions",
+          wasMigrated: false,
+        }),
+      );
+    } finally {
+      await rendered.cleanup();
+    }
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-051-message-renderers-UserLocalCommandOutputMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-051-message-renderers-UserLocalCommandOutputMessage.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { DIAMOND_FILLED } from '../../../src/constants/figures.js'
+import { NO_CONTENT_MESSAGE } from '../../../src/constants/messages.js'
+import { UserLocalCommandOutputMessage } from '../../../src/tui/message-renderers/UserLocalCommandOutputMessage.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../../src/tui/hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    syntaxHighlightingDisabled: true,
+  }),
+}))
+
+describe('UserLocalCommandOutputMessage coverage swarm 051', () => {
+  test('renders stderr-only filled launch output without suffix or rest content', async () => {
+    const output = await renderToString(
+      <UserLocalCommandOutputMessage
+        content={[
+          '<local-command-stderr>',
+          `${DIAMOND_FILLED} finished local setup`,
+          '</local-command-stderr>',
+        ].join('\n')}
+      />,
+      { columns: 100, rows: 8 },
+    )
+
+    expect(output).toContain(`${DIAMOND_FILLED} finished local setup`)
+    expect(output).not.toContain('\u00b7')
+    expect(output).not.toContain('\u23bf')
+  })
+
+  test('renders stdout-only ordinary output without requiring stderr', async () => {
+    const output = await renderToString(
+      <UserLocalCommandOutputMessage
+        content={[
+          '<local-command-stdout>',
+          'setup completed',
+          '</local-command-stdout>',
+        ].join('\n')}
+      />,
+      { columns: 100, rows: 8 },
+    )
+
+    expect(output).toMatch(/\u23bf\s+setup completed/)
+  })
+
+  test('ignores whitespace-only output tags without using the fallback', async () => {
+    const output = await renderToString(
+      <UserLocalCommandOutputMessage
+        content={[
+          '<local-command-stdout>',
+          '   ',
+          '</local-command-stdout>',
+          '<local-command-stderr>',
+          '\t',
+          '</local-command-stderr>',
+        ].join('\n')}
+      />,
+      { columns: 100, rows: 8 },
+    )
+
+    expect(output.trim()).toBe('')
+    expect(output).not.toContain(NO_CONTENT_MESSAGE)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-052-components-TextInput.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-052-components-TextInput.test.tsx
@@ -1,0 +1,432 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  accessibilityEnabled: false,
+  baseTextInputCalls: [] as Array<Record<string, unknown>>,
+  clipboardImageHint: vi.fn(),
+  dim: vi.fn((text: string) => `dim(${text})`),
+  feature: vi.fn((flag: string) => flag === 'VOICE_MODE' && harness.voiceMode),
+  inverse: vi.fn((text: string) => `inverse(${text})`),
+  rgb: vi.fn((r: number, g: number, b: number) => (text: string) => `rgb(${r},${g},${b})(${text})`),
+  settings: null as null | { prefersReducedMotion?: boolean },
+  terminalFocused: true,
+  textInputCalls: [] as Array<Record<string, unknown>>,
+  voice: {
+    voiceAudioLevels: [] as Array<number | undefined>,
+    voiceState: 'idle',
+  },
+  voiceMode: false,
+  voiceStateCalls: [] as string[],
+  reset() {
+    this.accessibilityEnabled = false
+    this.baseTextInputCalls = []
+    this.clipboardImageHint.mockClear()
+    this.dim.mockClear()
+    this.feature.mockClear()
+    this.inverse.mockClear()
+    this.rgb.mockClear()
+    this.settings = null
+    this.terminalFocused = true
+    this.textInputCalls = []
+    this.voice = {
+      voiceAudioLevels: [],
+      voiceState: 'idle',
+    }
+    this.voiceMode = false
+    this.voiceStateCalls = []
+  },
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: harness.feature,
+}))
+
+vi.mock('chalk', () => ({
+  default: {
+    dim: harness.dim,
+    inverse: harness.inverse,
+    rgb: harness.rgb,
+  },
+}))
+
+vi.mock('../hooks/useClipboardImageHint.js', () => ({
+  useClipboardImageHint: harness.clipboardImageHint,
+}))
+
+vi.mock('../hooks/useSettings.js', () => ({
+  useSettings: () => harness.settings,
+}))
+
+vi.mock('../context/voice.js', () => ({
+  useVoiceState: (selector: (state: typeof harness.voice) => unknown) => {
+    const selected = selector(harness.voice)
+    harness.voiceStateCalls.push(
+      selected === harness.voice.voiceAudioLevels ? 'voiceAudioLevels' : String(selected),
+    )
+    return selected
+  },
+}))
+
+vi.mock('../../utils/envUtils.js', () => ({
+  isEnvTruthy: () => harness.accessibilityEnabled,
+}))
+
+vi.mock('../ink.js', async () => {
+  const ReactModule = await import('react')
+
+  return {
+    Box: ({ children }: { children?: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+    color: (name: string, theme: string) => (text: string) =>
+      `color(${name}:${theme}:${text})`,
+    useTerminalFocus: () => harness.terminalFocused,
+    useTheme: () => ['dark', () => {}] as const,
+  }
+})
+
+vi.mock('../hooks/useTextInput.js', () => ({
+  useTextInput: (props: Record<string, unknown>) => {
+    harness.textInputCalls.push(props)
+    return {
+      cursorColumn: 0,
+      cursorLine: 0,
+      offset: props.externalOffset ?? 0,
+      onInput: vi.fn(),
+      renderedValue: String(props.value ?? ''),
+      setOffset: vi.fn(),
+      setValue: vi.fn(),
+      value: String(props.value ?? ''),
+      viewportCharEnd: String(props.value ?? '').length,
+      viewportCharOffset: 0,
+    }
+  },
+}))
+
+vi.mock('../components/BaseTextInput.js', async () => {
+  const ReactModule = await import('react')
+
+  return {
+    BaseTextInput: (props: Record<string, unknown>) => {
+      harness.baseTextInputCalls.push(props)
+      return ReactModule.createElement(ReactModule.Fragment)
+    },
+  }
+})
+
+import { createRoot } from '../ink/root.js'
+import TextInput from '../components/TextInput.js'
+
+type TextInputProps = React.ComponentProps<typeof TextInput>
+
+const originalGlyphMode = process.env.AGENC_TUI_GLYPHS
+
+function createStreams(): {
+  readonly stdout: PassThrough
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 100
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function baseProps(overrides: Partial<TextInputProps> = {}): TextInputProps {
+  return {
+    columns: 80,
+    cursorOffset: 0,
+    focus: true,
+    onChange: vi.fn(),
+    onChangeCursorOffset: vi.fn(),
+    showCursor: true,
+    value: 'draft',
+    ...overrides,
+  }
+}
+
+async function renderTextInput(
+  overrides: Partial<TextInputProps> = {},
+): Promise<void> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  try {
+    root.render(<TextInput {...baseProps(overrides)} />)
+    await sleep()
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await sleep()
+  }
+}
+
+function latestTextInputProps(): Record<string, unknown> {
+  const props = harness.textInputCalls.at(-1)
+  if (!props) throw new Error('useTextInput was not called')
+  return props
+}
+
+function latestBaseTextInputProps(): Record<string, unknown> {
+  const props = harness.baseTextInputCalls.at(-1)
+  if (!props) throw new Error('BaseTextInput was not called')
+  return props
+}
+
+describe('TextInput coverage swarm row 052', () => {
+  beforeEach(() => {
+    harness.reset()
+    process.env.AGENC_TUI_GLYPHS = 'ascii'
+  })
+
+  afterEach(() => {
+    harness.reset()
+    if (originalGlyphMode === undefined) {
+      delete process.env.AGENC_TUI_GLYPHS
+    } else {
+      process.env.AGENC_TUI_GLYPHS = originalGlyphMode
+    }
+  })
+
+  test('uses the standard cursor and forwards input/base props when voice mode is disabled', async () => {
+    const onChange = vi.fn()
+    const onSubmit = vi.fn()
+    const onExit = vi.fn()
+    const onExitMessage = vi.fn()
+    const onHistoryReset = vi.fn()
+    const onHistoryUp = vi.fn()
+    const onHistoryDown = vi.fn()
+    const onClearInput = vi.fn()
+    const onImagePaste = vi.fn()
+    const onChangeCursorOffset = vi.fn()
+    const inputFilter = vi.fn((input: string) => input.toUpperCase())
+    const inlineGhostText = {
+      fullCommand: 'review',
+      insertPosition: 2,
+      text: 'view',
+    }
+    const highlights = [{ color: 'success', end: 2, priority: 1, start: 0 }]
+
+    await renderTextInput({
+      columns: 42,
+      cursorOffset: 3,
+      disableCursorMovementForUpDownKeys: true,
+      disableEscapeDoublePress: true,
+      focus: true,
+      highlightPastedText: true,
+      highlights,
+      inlineGhostText,
+      inputFilter,
+      mask: '*',
+      maxVisibleLines: 5,
+      multiline: true,
+      onChange,
+      onClearInput,
+      onExit,
+      onExitMessage,
+      onHistoryDown,
+      onHistoryReset,
+      onHistoryUp,
+      onImagePaste,
+      onSubmit,
+      showCursor: true,
+      value: 'ask',
+    })
+
+    const textInputProps = latestTextInputProps()
+    const baseInputProps = latestBaseTextInputProps()
+    const invert = textInputProps.invert as (text: string) => string
+    const dim = textInputProps.dim as (text: string) => string
+    const themeText = textInputProps.themeText as (text: string) => string
+
+    expect(harness.voiceStateCalls).toEqual([])
+    expect(harness.clipboardImageHint).toHaveBeenCalledWith(true, true)
+    expect(invert('x')).toBe('inverse(x)')
+    expect(dim('x')).toBe('dim(x)')
+    expect(themeText('x')).toBe('color(text:dark:x)')
+    expect(textInputProps).toMatchObject({
+      columns: 42,
+      cursorChar: ' ',
+      disableCursorMovementForUpDownKeys: true,
+      disableEscapeDoublePress: true,
+      externalOffset: 3,
+      focus: true,
+      highlightPastedText: true,
+      inlineGhostText,
+      inputFilter,
+      mask: '*',
+      maxVisibleLines: 5,
+      multiline: true,
+      onChange,
+      onClearInput,
+      onExit,
+      onExitMessage,
+      onHistoryDown,
+      onHistoryReset,
+      onHistoryUp,
+      onImagePaste,
+      onSubmit,
+      value: 'ask',
+    })
+    expect(textInputProps.onOffsetChange).toBeTypeOf('function')
+    expect(baseInputProps).toMatchObject({
+      highlights,
+      hidePlaceholderText: false,
+      terminalFocus: true,
+      value: 'ask',
+    })
+    expect(baseInputProps.invert).toBe(textInputProps.invert)
+    expect(baseInputProps.inputState).toMatchObject({
+      renderedValue: 'ask',
+      value: 'ask',
+    })
+  })
+
+  test('uses identity cursor inversion when terminal focus or accessibility disables the cursor', async () => {
+    harness.terminalFocused = false
+    await renderTextInput({
+      onImagePaste: undefined,
+      showCursor: false,
+      value: 'unfocused',
+    })
+
+    let textInputProps = latestTextInputProps()
+    let invert = textInputProps.invert as (text: string) => string
+    expect(harness.clipboardImageHint).toHaveBeenLastCalledWith(false, false)
+    expect(textInputProps.cursorChar).toBe('')
+    expect(invert('cursor')).toBe('cursor')
+    expect(harness.inverse).not.toHaveBeenCalled()
+
+    harness.textInputCalls = []
+    harness.baseTextInputCalls = []
+    harness.terminalFocused = true
+    harness.accessibilityEnabled = true
+    await renderTextInput({
+      onImagePaste: vi.fn(),
+      showCursor: true,
+      value: 'accessible',
+    })
+
+    textInputProps = latestTextInputProps()
+    invert = textInputProps.invert as (text: string) => string
+    expect(harness.clipboardImageHint).toHaveBeenLastCalledWith(true, true)
+    expect(textInputProps.cursorChar).toBe(' ')
+    expect(invert('cursor')).toBe('cursor')
+    expect(harness.inverse).not.toHaveBeenCalled()
+  })
+
+  test('hides placeholder text and renders silent voice cursor levels while recording', async () => {
+    harness.voiceMode = true
+    harness.voice = {
+      voiceAudioLevels: [],
+      voiceState: 'recording',
+    }
+    harness.settings = { prefersReducedMotion: false }
+
+    await renderTextInput({ value: '' })
+
+    let textInputProps = latestTextInputProps()
+    let baseInputProps = latestBaseTextInputProps()
+    let invert = textInputProps.invert as (text: string) => string
+
+    expect(harness.voiceStateCalls).toEqual(['recording', 'voiceAudioLevels'])
+    expect(baseInputProps.hidePlaceholderText).toBe(true)
+    expect(invert('ignored')).toBe('rgb(128,128,128)(.)')
+
+    harness.textInputCalls = []
+    harness.baseTextInputCalls = []
+    harness.voice = {
+      voiceAudioLevels: [undefined],
+      voiceState: 'recording',
+    }
+
+    await renderTextInput({ value: '' })
+
+    textInputProps = latestTextInputProps()
+    baseInputProps = latestBaseTextInputProps()
+    invert = textInputProps.invert as (text: string) => string
+
+    expect(baseInputProps.hidePlaceholderText).toBe(true)
+    expect(invert('ignored')).toBe('rgb(128,128,128)(.)')
+  })
+
+  test('uses colored voice cursor for active audio and falls back to standard inverse for reduced motion', async () => {
+    harness.voiceMode = true
+    harness.voice = {
+      voiceAudioLevels: [0.8],
+      voiceState: 'recording',
+    }
+    harness.settings = { prefersReducedMotion: false }
+
+    await renderTextInput({ value: 'speaking' })
+
+    let textInputProps = latestTextInputProps()
+    let baseInputProps = latestBaseTextInputProps()
+    let invert = textInputProps.invert as (text: string) => string
+
+    expect(baseInputProps.hidePlaceholderText).toBe(true)
+    expect(invert('ignored')).toBe('rgb(82,224,82)(:)')
+
+    harness.textInputCalls = []
+    harness.baseTextInputCalls = []
+    harness.voice = {
+      voiceAudioLevels: [0.8],
+      voiceState: 'recording',
+    }
+    harness.settings = { prefersReducedMotion: true }
+
+    await renderTextInput({ value: 'still speaking' })
+
+    textInputProps = latestTextInputProps()
+    baseInputProps = latestBaseTextInputProps()
+    invert = textInputProps.invert as (text: string) => string
+
+    expect(baseInputProps.hidePlaceholderText).toBe(true)
+    expect(invert('cursor')).toBe('inverse(cursor)')
+  })
+
+  test('keeps placeholder visible when voice mode is enabled but not recording', async () => {
+    harness.voiceMode = true
+    harness.voice = {
+      voiceAudioLevels: [0.4],
+      voiceState: 'processing',
+    }
+    harness.settings = { prefersReducedMotion: false }
+
+    await renderTextInput({ value: 'processing' })
+
+    const textInputProps = latestTextInputProps()
+    const baseInputProps = latestBaseTextInputProps()
+    const invert = textInputProps.invert as (text: string) => string
+
+    expect(baseInputProps.hidePlaceholderText).toBe(false)
+    expect(invert('cursor')).toBe('inverse(cursor)')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-053-components-v2-messagePrimitives.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-053-components-v2-messagePrimitives.test.tsx
@@ -1,0 +1,285 @@
+import React from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import { AppStateProvider } from '../state/AppState.js'
+import {
+  PlanMessage,
+  ShellInputMessage,
+  ThinkingMessage,
+  UserAgentNotificationMessage,
+  UserChannelMessage,
+  UserCommandMessage,
+  UserImageMessage,
+  UserMemoryInputMessage,
+  UserResourceUpdateMessage,
+} from '../components/v2/messagePrimitives.js'
+
+const originalGlyphMode = process.env.AGENC_TUI_GLYPHS
+
+afterEach(() => {
+  if (originalGlyphMode === undefined) {
+    delete process.env.AGENC_TUI_GLYPHS
+  } else {
+    process.env.AGENC_TUI_GLYPHS = originalGlyphMode
+  }
+})
+
+function textParam(text: string): { readonly type: 'text'; readonly text: string } {
+  return { type: 'text', text }
+}
+
+function renderWithAppState(
+  node: React.ReactNode,
+  width = 100,
+): Promise<string> {
+  return renderToString(<AppStateProvider>{node}</AppStateProvider>, width)
+}
+
+describe('messagePrimitives coverage swarm 053', () => {
+  it('returns null for text markers and thinking content that are absent', () => {
+    expect(
+      ShellInputMessage({
+        addMargin: false,
+        param: textParam('plain text'),
+      }),
+    ).toBeNull()
+    expect(
+      UserCommandMessage({
+        addMargin: false,
+        param: textParam('<command-args>ignored</command-args>'),
+      }),
+    ).toBeNull()
+    expect(
+      UserAgentNotificationMessage({
+        addMargin: false,
+        param: textParam('<status>completed</status>'),
+      }),
+    ).toBeNull()
+    expect(
+      UserResourceUpdateMessage({
+        addMargin: false,
+        param: textParam('<mcp-resource-update />'),
+      }),
+    ).toBeNull()
+    expect(
+      UserMemoryInputMessage({
+        addMargin: false,
+        text: '<memory>missing user-memory marker</memory>',
+      }),
+    ).toBeNull()
+    expect(
+      UserChannelMessage({
+        addMargin: false,
+        param: textParam('<channel>missing source</channel>'),
+      }),
+    ).toBeNull()
+    expect(
+      ThinkingMessage({
+        param: { type: 'thinking', thinking: '' },
+        addMargin: false,
+        isTranscriptMode: false,
+        verbose: false,
+      }),
+    ).toBeNull()
+    expect(
+      ThinkingMessage({
+        param: { type: 'thinking', thinking: 'hidden by transcript option' },
+        addMargin: false,
+        isTranscriptMode: true,
+        verbose: true,
+        hideInTranscript: true,
+      }),
+    ).toBeNull()
+  })
+
+  it('renders command, shell, image, and notification variants', async () => {
+    const output = await renderToString(
+      <>
+        <ShellInputMessage
+          addMargin={true}
+          param={textParam('<bash-input>npm test -- --runInBand</bash-input>')}
+        />
+        <UserCommandMessage
+          addMargin={true}
+          param={textParam(
+            '<command-message>lint</command-message><skill-format>true</skill-format>',
+          )}
+        />
+        <UserCommandMessage
+          addMargin={false}
+          param={textParam('<command-message>status</command-message>')}
+        />
+        <UserImageMessage imageId={53} addMargin={true} />
+        <UserAgentNotificationMessage
+          addMargin={true}
+          param={textParam(
+            '<status>failed</status><summary>worker failed checks</summary>',
+          )}
+        />
+        <UserAgentNotificationMessage
+          addMargin={false}
+          param={textParam(
+            '<status>killed</status><summary>worker was stopped</summary>',
+          )}
+        />
+        <UserAgentNotificationMessage
+          addMargin={false}
+          param={textParam('<status>running</status><summary>worker queued</summary>')}
+        />
+      </>,
+      120,
+    )
+
+    expect(output).toContain('SHELL')
+    expect(output).toContain('! npm test -- --runInBand')
+    expect(output).toContain('SKILL')
+    expect(output).toContain('$lint')
+    expect(output).toContain('/status')
+    expect(output).toContain('IMAGE')
+    expect(output).toContain('#53')
+    expect(output).toContain('worker failed checks')
+    expect(output).toContain('worker was stopped')
+    expect(output).toContain('worker queued')
+  })
+
+  it('renders resource and polling updates with target formatting branches', async () => {
+    const longTarget = `https://example.test/${'segment-'.repeat(8)}tail`
+    const fileOutput = await renderToString(
+      <UserResourceUpdateMessage
+        addMargin={true}
+        param={textParam(
+          '<mcp-resource-update server="files" uri="file:///tmp/"></mcp-resource-update>',
+        )}
+      />,
+      140,
+    )
+    const shortOutput = await renderToString(
+      <UserResourceUpdateMessage
+        addMargin={false}
+        param={textParam(
+          '<mcp-resource-update server="cache" uri="urn:short"></mcp-resource-update>',
+        )}
+      />,
+      140,
+    )
+    const longOutput = await renderToString(
+      <UserResourceUpdateMessage
+        addMargin={false}
+        param={textParam(
+          `<mcp-resource-update server="remote" uri="${longTarget}"><reason>refreshed</reason></mcp-resource-update>`,
+        )}
+      />,
+      140,
+    )
+    const pollingOutput = await renderToString(
+      <UserResourceUpdateMessage
+        addMargin={false}
+        param={textParam(
+          '<mcp-polling-update type="tools" server="github" tool="list_issues"><reason>polling now</reason></mcp-polling-update>',
+        )}
+      />,
+      140,
+    )
+    const adjacentOutput = await renderToString(
+      <UserResourceUpdateMessage
+        addMargin={false}
+        param={textParam(
+          '<mcp-resource-update server="one" uri="urn:one"><reason>first</reason></mcp-resource-update><mcp-resource-update server="two" uri="urn:two"><reason>second</reason></mcp-resource-update>',
+        )}
+      />,
+      140,
+    )
+    const output = [
+      fileOutput,
+      shortOutput,
+      longOutput,
+      pollingOutput,
+      adjacentOutput,
+    ].join('\n')
+
+    expect(output).toContain('MCP')
+    expect(output).toContain('files:')
+    expect(output).toContain('/tmp/')
+    expect(output).toContain('cache:')
+    expect(output).toContain('urn:short')
+    expect(output).toContain('remote:')
+    expect(output).toContain(longTarget.slice(0, 39))
+    expect(output).not.toContain(longTarget)
+    expect(output).toContain('refreshed')
+    expect(output).toContain('github:')
+    expect(output).toContain('list_issues')
+    expect(output).toContain('polling now')
+    expect(output).toContain('one:')
+    expect(output).toContain('urn:one')
+    expect(output).toContain('first')
+    expect(output).toContain('two:')
+    expect(output).toContain('urn:two')
+    expect(output).toContain('second')
+  })
+
+  it('renders memory, channel, and standalone plan formatting branches', async () => {
+    const output = await renderWithAppState(
+      <>
+        <UserMemoryInputMessage
+          addMargin={true}
+          text="<user-memory-input>keep the API token local</user-memory-input>"
+        />
+        <UserChannelMessage
+          addMargin={true}
+          param={textParam(
+            '<channel source="irc">one\n   two   three</channel>',
+          )}
+        />
+        <UserChannelMessage
+          addMargin={false}
+          param={textParam(
+            `<channel source="plugin:chat:ops" user="sam">${'abcdef'.repeat(
+              12,
+            )}</channel>`,
+          )}
+        />
+        <PlanMessage addMargin={true} planContent="1. Keep the test scoped" />
+      </>,
+      120,
+    )
+
+    expect(output).toContain('MEMORY')
+    expect(output).toContain('keep the API token local')
+    expect(output).toContain('Noted.')
+    expect(output).toContain('CHANNEL')
+    expect(output).toContain('irc:')
+    expect(output).toContain('one two three')
+    expect(output).toContain('ops · sam')
+    expect(output).not.toContain('abcdef'.repeat(12))
+    expect(output).toContain('PLAN TO IMPLEMENT')
+    expect(output).toContain('Keep the test scoped')
+  })
+
+  it('renders collapsed and verbose thinking branches', async () => {
+    process.env.AGENC_TUI_GLYPHS = 'ascii'
+
+    const collapsed = await renderWithAppState(
+      <ThinkingMessage
+        param={{ type: 'thinking', thinking: 'private chain of thought' }}
+        addMargin={true}
+        isTranscriptMode={false}
+        verbose={false}
+      />,
+    )
+    const verbose = await renderWithAppState(
+      <ThinkingMessage
+        param={{ type: 'thinking', thinking: 'visible reasoning summary' }}
+        addMargin={false}
+        isTranscriptMode={false}
+        verbose={true}
+      />,
+    )
+
+    expect(collapsed).toContain('Thinking')
+    expect(collapsed).toContain('ctrl+o')
+    expect(collapsed).not.toContain('private chain of thought')
+    expect(verbose).toContain('Thinking...')
+    expect(verbose).toContain('visible reasoning summary')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-054-context-overlayContext.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-054-context-overlayContext.test.tsx
@@ -1,0 +1,294 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../utils/staticRender.js'
+import { createRoot, Text } from '../../../src/tui/ink.js'
+import {
+  useIsModalOverlayActive,
+  useIsOverlayActive,
+  useRegisterOverlay,
+} from '../../../src/tui/context/overlayContext.js'
+import { AppStoreContext } from '../../../src/tui/state/AppState.js'
+
+type OverlayState = {
+  activeOverlays: ReadonlySet<string>
+}
+
+type OverlayStore = {
+  getState: () => OverlayState
+  setState: (updater: (prev: OverlayState) => OverlayState) => void
+  subscribe: (listener: () => void) => () => void
+}
+
+const appStateHarness = vi.hoisted(() => ({
+  state: {
+    activeOverlays: new Set<string>(),
+  },
+}))
+
+const inkInstanceHarness = vi.hoisted(() => ({
+  invalidatePrevFrame: vi.fn(),
+  get: vi.fn(() => ({
+    invalidatePrevFrame: inkInstanceHarness.invalidatePrevFrame,
+  })),
+}))
+
+vi.mock('../../../src/tui/state/AppState.js', async () => {
+  const ReactActual = await vi.importActual<typeof import('react')>('react')
+
+  return {
+    AppStoreContext: ReactActual.createContext<OverlayStore | null>(null),
+    useAppState: (
+      selector: (state: { activeOverlays: ReadonlySet<string> }) => unknown,
+    ) => selector(appStateHarness.state),
+  }
+})
+
+vi.mock('../../../src/tui/ink/instances.js', () => ({
+  default: {
+    get: inkInstanceHarness.get,
+  },
+  deleteInkInstance: vi.fn(() => true),
+  getInkInstance: vi.fn(() => undefined),
+  setInkInstance: vi.fn(),
+}))
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestStdout = PassThrough & {
+  columns: number
+  rows: number
+  isTTY: boolean
+}
+
+function createStreams(): {
+  readonly stdin: TestStdin
+  readonly stdout: TestStdout
+} {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough() as TestStdout
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 100
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < 1_000) {
+    if (predicate()) return
+    await sleep(10)
+  }
+
+  throw new Error(message)
+}
+
+function createOverlayStore(initialIds: readonly string[] = []): {
+  readonly store: OverlayStore
+  readonly writes: Array<{ readonly ids: string[]; readonly same: boolean }>
+  readonly ids: () => string[]
+} {
+  let state: OverlayState = {
+    activeOverlays: new Set(initialIds),
+  }
+  const listeners = new Set<() => void>()
+  const writes: Array<{ ids: string[]; same: boolean }> = []
+
+  const store: OverlayStore = {
+    getState: () => state,
+    setState: updater => {
+      const prev = state
+      const next = updater(prev)
+
+      writes.push({
+        ids: [...next.activeOverlays].sort(),
+        same: Object.is(prev, next),
+      })
+
+      if (Object.is(prev, next)) return
+
+      state = next
+      for (const listener of listeners) listener()
+    },
+    subscribe: listener => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+  }
+
+  return {
+    store,
+    writes,
+    ids: () => [...state.activeOverlays].sort(),
+  }
+}
+
+async function renderRegisterHarness(
+  node: React.ReactNode,
+): Promise<{
+  readonly root: Awaited<ReturnType<typeof createRoot>>
+  readonly stdin: TestStdin
+  readonly stdout: TestStdout
+}> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  root.render(node)
+
+  return { root, stdin, stdout }
+}
+
+function cleanupHarness({
+  stdin,
+  stdout,
+}: {
+  readonly stdin: TestStdin
+  readonly stdout: TestStdout
+}) {
+  stdin.end()
+  stdout.end()
+}
+
+function RegisterOverlay({
+  enabled,
+  id,
+}: {
+  readonly enabled?: boolean
+  readonly id: string
+}) {
+  useRegisterOverlay(id, enabled)
+  return null
+}
+
+function OverlayStatus() {
+  const isActive = useIsOverlayActive()
+  const isModalActive = useIsModalOverlayActive()
+
+  return (
+    <Text>
+      {isActive ? 'active' : 'idle'}:{isModalActive ? 'modal' : 'nonmodal'}
+    </Text>
+  )
+}
+
+describe('overlayContext coverage swarm 054', () => {
+  test('registers duplicate overlays once and unregisters idempotently', async () => {
+    const overlayStore = createOverlayStore()
+    const harness = await renderRegisterHarness(
+      <AppStoreContext.Provider value={overlayStore.store as never}>
+        <RegisterOverlay id="select" />
+        <RegisterOverlay id="select" />
+      </AppStoreContext.Provider>,
+    )
+
+    try {
+      await waitForCondition(
+        () =>
+          overlayStore.ids().join(',') === 'select' &&
+          overlayStore.writes.length >= 2,
+        'timed out waiting for overlay registration',
+      )
+
+      expect(overlayStore.ids()).toEqual(['select'])
+      expect(overlayStore.writes).toContainEqual({
+        ids: ['select'],
+        same: true,
+      })
+
+      harness.root.unmount()
+
+      await waitForCondition(
+        () => overlayStore.ids().length === 0,
+        'timed out waiting for overlay cleanup',
+      )
+
+      expect(overlayStore.writes).toContainEqual({
+        ids: [],
+        same: true,
+      })
+      expect(inkInstanceHarness.invalidatePrevFrame).toHaveBeenCalled()
+    } finally {
+      harness.root.unmount()
+      cleanupHarness(harness)
+    }
+  })
+
+  test('skips registration when disabled or outside the app store provider', async () => {
+    const overlayStore = createOverlayStore()
+    const disabledHarness = await renderRegisterHarness(
+      <AppStoreContext.Provider value={overlayStore.store as never}>
+        <RegisterOverlay enabled={false} id="select" />
+      </AppStoreContext.Provider>,
+    )
+
+    try {
+      await sleep()
+      expect(overlayStore.ids()).toEqual([])
+      expect(overlayStore.writes).toEqual([])
+    } finally {
+      disabledHarness.root.unmount()
+      cleanupHarness(disabledHarness)
+    }
+
+    const missingProviderHarness = await renderRegisterHarness(
+      <RegisterOverlay id="select" />,
+    )
+
+    try {
+      await sleep()
+    } finally {
+      missingProviderHarness.root.unmount()
+      cleanupHarness(missingProviderHarness)
+    }
+  })
+
+  test('distinguishes any overlay from modal overlays', async () => {
+    appStateHarness.state = {
+      activeOverlays: new Set(),
+    }
+    await expect(renderToString(<OverlayStatus />, 40)).resolves.toContain(
+      'idle:nonmodal',
+    )
+
+    appStateHarness.state = {
+      activeOverlays: new Set(['autocomplete']),
+    }
+    await expect(renderToString(<OverlayStatus />, 40)).resolves.toContain(
+      'active:nonmodal',
+    )
+
+    appStateHarness.state = {
+      activeOverlays: new Set(['autocomplete', 'select']),
+    }
+    await expect(renderToString(<OverlayStatus />, 40)).resolves.toContain(
+      'active:modal',
+    )
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-055-ink-terminal-querier.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-055-ink-terminal-querier.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from 'vitest'
+
+import type { TerminalResponse } from '../../../src/tui/ink/parse-keypress.js'
+import {
+  TerminalQuerier,
+  cursorPosition,
+  da1,
+  da2,
+  decrqm,
+  kittyKeyboard,
+  oscColor,
+  xtversion,
+  type QuerierStdin,
+} from '../../../src/tui/ink/terminal-querier.js'
+
+type TestQuery = {
+  readonly request: string
+  readonly match: (response: TerminalResponse) => boolean
+}
+
+function makeStdout(): {
+  readonly stdout: NodeJS.WriteStream
+  readonly writes: string[]
+} {
+  const writes: string[] = []
+  const stdout = {
+    write: (chunk: string | Uint8Array): boolean => {
+      writes.push(
+        typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'),
+      )
+      return true
+    },
+  } as unknown as NodeJS.WriteStream
+
+  return { stdout, writes }
+}
+
+function tick(): Promise<void> {
+  return new Promise(resolve => setImmediate(resolve))
+}
+
+describe('TerminalQuerier coverage swarm row 055', () => {
+  test('matches terminal query builder responses and rejects near misses', () => {
+    const queryCases: readonly {
+      readonly query: TestQuery
+      readonly request: string | RegExp
+      readonly matching: TerminalResponse
+      readonly misses: readonly TerminalResponse[]
+    }[] = [
+      {
+        query: decrqm(2026),
+        request: '\x1b[?2026$p',
+        matching: { type: 'decrpm', mode: 2026, status: 1 },
+        misses: [
+          { type: 'decrpm', mode: 2027, status: 1 },
+          { type: 'da1', params: [] },
+        ],
+      },
+      {
+        query: da1(),
+        request: '\x1b[c',
+        matching: { type: 'da1', params: [1, 2] },
+        misses: [{ type: 'da2', params: [1, 2] }],
+      },
+      {
+        query: da2(),
+        request: '\x1b[>c',
+        matching: { type: 'da2', params: [0, 1, 2] },
+        misses: [{ type: 'da1', params: [0, 1, 2] }],
+      },
+      {
+        query: kittyKeyboard(),
+        request: '\x1b[?u',
+        matching: { type: 'kittyKeyboard', flags: 7 },
+        misses: [{ type: 'cursorPosition', row: 4, col: 9 }],
+      },
+      {
+        query: cursorPosition(),
+        request: '\x1b[?6n',
+        matching: { type: 'cursorPosition', row: 12, col: 34 },
+        misses: [{ type: 'kittyKeyboard', flags: 7 }],
+      },
+      {
+        query: oscColor(11),
+        request: /^\x1b\]11;\?(?:\x07|\x1b\\)$/u,
+        matching: { type: 'osc', code: 11, data: 'rgb:0000/1111/2222' },
+        misses: [
+          { type: 'osc', code: 10, data: 'rgb:0000/1111/2222' },
+          { type: 'xtversion', name: 'test-term(1.0)' },
+        ],
+      },
+      {
+        query: xtversion(),
+        request: '\x1b[>0q',
+        matching: { type: 'xtversion', name: 'test-term(1.0)' },
+        misses: [{ type: 'osc', code: 11, data: 'rgb:0000/1111/2222' }],
+      },
+    ]
+
+    for (const { matching, misses, query, request } of queryCases) {
+      if (typeof request === 'string') expect(query.request).toBe(request)
+      else expect(query.request).toMatch(request)
+
+      expect(query.match(matching)).toBe(true)
+      for (const miss of misses) expect(query.match(miss)).toBe(false)
+    }
+  })
+
+  test('non-TTY flush drains queries queued before suppression', async () => {
+    const { stdout, writes } = makeStdout()
+    const stdin: QuerierStdin = { isTTY: true, isRaw: true }
+    const querier = new TerminalQuerier(stdout, stdin)
+
+    const pending = querier.send(xtversion())
+    expect(writes).toEqual(['\x1b[>0q'])
+
+    stdin.isTTY = false
+    await expect(querier.flush()).resolves.toBeUndefined()
+    await expect(pending).resolves.toBeUndefined()
+  })
+
+  test('non-TTY flush resolves queued sentinels from earlier flush calls', async () => {
+    const { stdout, writes } = makeStdout()
+    const stdin: QuerierStdin = { isTTY: true, isRaw: true }
+    const querier = new TerminalQuerier(stdout, stdin)
+
+    const firstFlush = querier.flush()
+    expect(writes).toEqual(['\x1b[c'])
+
+    stdin.isTTY = false
+    await expect(querier.flush()).resolves.toBeUndefined()
+    await expect(firstFlush).resolves.toBeUndefined()
+  })
+
+  test('DA1 without a sentinel is ignored until a matching response arrives', async () => {
+    const { stdout } = makeStdout()
+    const querier = new TerminalQuerier(stdout, { isTTY: true, isRaw: true })
+
+    const pending = querier.send(xtversion())
+    let settled = false
+    pending.then(() => {
+      settled = true
+    })
+
+    querier.onResponse({ type: 'da1', params: [] })
+    await tick()
+    expect(settled).toBe(false)
+
+    querier.onResponse({ type: 'xtversion', name: 'late-term(2.0)' })
+    await expect(pending).resolves.toEqual({
+      type: 'xtversion',
+      name: 'late-term(2.0)',
+    })
+  })
+
+  test('unsolicited non-DA1 responses leave pending queries for the flush barrier', async () => {
+    const { stdout } = makeStdout()
+    const querier = new TerminalQuerier(stdout, { isTTY: true, isRaw: true })
+
+    const pending = querier.send(decrqm(2026))
+    querier.onResponse({ type: 'osc', code: 11, data: 'ignored' })
+
+    const flushed = querier.flush()
+    querier.onResponse({ type: 'da1', params: [] })
+
+    await expect(flushed).resolves.toBeUndefined()
+    await expect(pending).resolves.toBeUndefined()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-056-message-renderers-AdvisorMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-056-message-renderers-AdvisorMessage.test.tsx
@@ -1,0 +1,167 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import type { AdvisorBlock } from '../../utils/advisor.js'
+import { renderToString } from '../../utils/staticRender.js'
+import { AdvisorMessage } from '../message-renderers/AdvisorMessage.js'
+
+function normalize(text: string): string {
+  return text.replace(/\s+/g, ' ').trim()
+}
+
+function renderAdvisorMessage(
+  block: AdvisorBlock,
+  options: {
+    readonly addMargin?: boolean
+    readonly advisorModel?: string
+    readonly erroredToolUseIDs?: readonly string[]
+    readonly resolvedToolUseIDs?: readonly string[]
+    readonly shouldAnimate?: boolean
+    readonly verbose?: boolean
+  } = {},
+): Promise<string> {
+  return renderToString(
+    <AdvisorMessage
+      addMargin={options.addMargin ?? false}
+      advisorModel={options.advisorModel}
+      block={block}
+      erroredToolUseIDs={new Set(options.erroredToolUseIDs ?? [])}
+      resolvedToolUseIDs={new Set(options.resolvedToolUseIDs ?? [])}
+      shouldAnimate={options.shouldAnimate ?? false}
+      verbose={options.verbose ?? false}
+    />,
+    120,
+  )
+}
+
+describe('AdvisorMessage coverage swarm row 056', () => {
+  test('renders unresolved advisor progress without optional model or input text', async () => {
+    const output = normalize(
+      await renderAdvisorMessage(
+        {
+          type: 'server_tool_use',
+          id: 'advisor-empty-input',
+          name: 'advisor',
+          input: {},
+        },
+        {
+          addMargin: true,
+          shouldAnimate: true,
+        },
+      ),
+    )
+
+    expect(output).toContain('Advising')
+    expect(output).toContain('◐')
+    expect(output).not.toContain('using')
+    expect(output).not.toContain('{}')
+  })
+
+  test('renders completed and failed advisor progress with model and serialized input', async () => {
+    const completed = normalize(
+      await renderAdvisorMessage(
+        {
+          type: 'server_tool_use',
+          id: 'advisor-complete',
+          name: 'advisor',
+          input: { files: ['src/tui/message-renderers/AdvisorMessage.tsx'] },
+        },
+        {
+          advisorModel: 'advisor-model',
+          resolvedToolUseIDs: ['advisor-complete'],
+        },
+      ),
+    )
+
+    expect(completed).toContain('●')
+    expect(completed).toContain('Advising using advisor-model')
+    expect(completed).toContain(
+      '{"files":["src/tui/message-renderers/AdvisorMessage.tsx"]}',
+    )
+
+    const failed = normalize(
+      await renderAdvisorMessage(
+        {
+          type: 'server_tool_use',
+          id: 'advisor-failed',
+          name: 'advisor',
+          input: { reason: 'rate-limit' },
+        },
+        {
+          erroredToolUseIDs: ['advisor-failed'],
+          resolvedToolUseIDs: ['advisor-failed'],
+        },
+      ),
+    )
+
+    expect(failed).toContain('✕')
+    expect(failed).toContain('{"reason":"rate-limit"}')
+  })
+
+  test('renders compact, verbose, redacted, and error advisor results', async () => {
+    const compact = normalize(
+      await renderAdvisorMessage({
+        type: 'advisor_tool_result',
+        tool_use_id: 'advisor-complete',
+        content: {
+          type: 'advisor_result',
+          text: 'Apply the review feedback.',
+        },
+      }),
+    )
+
+    expect(compact).toContain(
+      'Advisor has reviewed the conversation and will apply the feedback',
+    )
+    expect(compact).toContain('ctrl+o')
+    expect(compact).not.toContain('Apply the review feedback.')
+
+    const verbose = normalize(
+      await renderAdvisorMessage(
+        {
+          type: 'advisor_tool_result',
+          tool_use_id: 'advisor-complete',
+          content: {
+            type: 'advisor_result',
+            text: 'Apply the review feedback.',
+          },
+        },
+        { verbose: true },
+      ),
+    )
+
+    expect(verbose).toContain('Apply the review feedback.')
+    expect(verbose).not.toContain('ctrl+o')
+
+    const redacted = normalize(
+      await renderAdvisorMessage({
+        type: 'advisor_tool_result',
+        tool_use_id: 'advisor-redacted',
+        content: {
+          type: 'advisor_redacted_result',
+          encrypted_content: 'hidden-feedback',
+        },
+      }),
+    )
+
+    expect(redacted).toContain(
+      'Advisor has reviewed the conversation and will apply the feedback',
+    )
+    expect(redacted).not.toContain('hidden-feedback')
+
+    const unavailable = normalize(
+      await renderAdvisorMessage({
+        type: 'advisor_tool_result',
+        tool_use_id: 'advisor-error',
+        content: {
+          type: 'advisor_tool_result_error',
+          error_code: 'temporarily_unavailable',
+        },
+      }),
+    )
+
+    expect(unavailable).toContain(
+      'Advisor unavailable (temporarily_unavailable)',
+    )
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-057-state-teammateViewHelpers.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-057-state-teammateViewHelpers.test.ts
@@ -1,0 +1,300 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { AppState } from "src/tui/state/AppState.js";
+import {
+  enterTeammateView,
+  exitTeammateView,
+  stopOrDismissAgent,
+} from "src/tui/state/teammateViewHelpers.js";
+import { logEvent } from "src/services/analytics/index.js";
+
+vi.mock("src/services/analytics/index.js", () => ({
+  logEvent: vi.fn(),
+}));
+
+function makeState(overrides: Partial<AppState> = {}): AppState {
+  return {
+    tasks: {},
+    viewSelectionMode: "none",
+    viewingAgentTaskId: undefined,
+    ...overrides,
+  } as AppState;
+}
+
+function makeAgentTask(
+  id: string,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    id,
+    type: "local_agent",
+    status: "running",
+    description: id,
+    startTime: 1,
+    outputFile: `urn:agenc:task:${id}:output`,
+    outputOffset: 0,
+    notified: false,
+    agentId: id,
+    prompt: "inspect",
+    agentType: "worker",
+    retrieved: false,
+    messages: undefined,
+    lastReportedToolCount: 0,
+    lastReportedTokenCount: 0,
+    pendingMessages: [],
+    retain: false,
+    diskLoaded: false,
+    ...overrides,
+  };
+}
+
+function makeShellTask(id: string): Record<string, unknown> {
+  return {
+    id,
+    type: "local_bash",
+    status: "completed",
+    description: id,
+    startTime: 1,
+    outputFile: `urn:agenc:task:${id}:output`,
+    outputOffset: 0,
+    notified: false,
+    command: "true",
+  };
+}
+
+function applyUpdate(
+  initial: AppState,
+  action: (setAppState: (updater: (prev: AppState) => AppState) => void) => void,
+): AppState {
+  let state = initial;
+  action((updater) => {
+    state = updater(state);
+  });
+  return state;
+}
+
+describe("teammateViewHelpers coverage edges", () => {
+  beforeEach(() => {
+    vi.spyOn(Date, "now").mockReturnValue(1_000);
+    vi.mocked(logEvent).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("enterTeammateView keeps state identity when the retained agent is already selected", () => {
+    const state = makeState({
+      viewSelectionMode: "viewing-agent",
+      viewingAgentTaskId: "agent_1",
+      tasks: {
+        agent_1: makeAgentTask("agent_1", {
+          retain: true,
+          evictAfter: undefined,
+        }),
+      },
+    });
+
+    const next = applyUpdate(state, (setAppState) => {
+      enterTeammateView("agent_1", setAppState);
+    });
+
+    expect(next).toBe(state);
+    expect(logEvent).toHaveBeenCalledWith("tengu_transcript_view_enter", {});
+  });
+
+  test("enterTeammateView releases the previous retained agent and clears the selected agent eviction deadline", () => {
+    const previousMessages = [{ type: "assistant", uuid: "msg_1" }];
+    const state = makeState({
+      viewSelectionMode: "viewing-agent",
+      viewingAgentTaskId: "agent_old",
+      tasks: {
+        agent_old: makeAgentTask("agent_old", {
+          status: "completed",
+          retain: true,
+          diskLoaded: true,
+          messages: previousMessages,
+        }),
+        agent_new: makeAgentTask("agent_new", {
+          retain: true,
+          evictAfter: 10_000,
+        }),
+      },
+    });
+
+    const next = applyUpdate(state, (setAppState) => {
+      enterTeammateView("agent_new", setAppState);
+    });
+
+    expect(next.viewSelectionMode).toBe("viewing-agent");
+    expect(next.viewingAgentTaskId).toBe("agent_new");
+    expect(next.tasks).not.toBe(state.tasks);
+    expect(next.tasks.agent_old).toMatchObject({
+      retain: false,
+      diskLoaded: false,
+      messages: undefined,
+      evictAfter: 31_000,
+    });
+    expect(next.tasks.agent_new).toMatchObject({
+      retain: true,
+      evictAfter: undefined,
+    });
+  });
+
+  test("enterTeammateView can select a missing or non-local task without cloning tasks", () => {
+    const state = makeState({
+      tasks: {
+        shell_1: makeShellTask("shell_1"),
+      },
+    });
+
+    const missing = applyUpdate(state, (setAppState) => {
+      enterTeammateView("missing_agent", setAppState);
+    });
+    const shell = applyUpdate(state, (setAppState) => {
+      enterTeammateView("shell_1", setAppState);
+    });
+
+    expect(missing.tasks).toBe(state.tasks);
+    expect(missing.viewSelectionMode).toBe("viewing-agent");
+    expect(missing.viewingAgentTaskId).toBe("missing_agent");
+    expect(shell.tasks).toBe(state.tasks);
+    expect(shell.viewingAgentTaskId).toBe("shell_1");
+  });
+
+  test("exitTeammateView preserves an idle state and clears a stale selection mode", () => {
+    const idle = makeState();
+    const stale = makeState({ viewSelectionMode: "viewing-agent" });
+
+    const stillIdle = applyUpdate(idle, (setAppState) => {
+      exitTeammateView(setAppState);
+    });
+    const cleared = applyUpdate(stale, (setAppState) => {
+      exitTeammateView(setAppState);
+    });
+
+    expect(stillIdle).toBe(idle);
+    expect(cleared).toMatchObject({
+      viewSelectionMode: "none",
+      viewingAgentTaskId: undefined,
+    });
+    expect(logEvent).toHaveBeenCalledWith("tengu_transcript_view_exit", {});
+  });
+
+  test("exitTeammateView clears view without releasing non-local or non-retained tasks", () => {
+    const nonLocal = makeState({
+      viewSelectionMode: "viewing-agent",
+      viewingAgentTaskId: "shell_1",
+      tasks: {
+        shell_1: makeShellTask("shell_1"),
+      },
+    });
+    const notRetained = makeState({
+      viewSelectionMode: "viewing-agent",
+      viewingAgentTaskId: "agent_1",
+      tasks: {
+        agent_1: makeAgentTask("agent_1", {
+          retain: false,
+          messages: [{ type: "assistant", uuid: "msg_1" }],
+        }),
+      },
+    });
+
+    const clearedNonLocal = applyUpdate(nonLocal, (setAppState) => {
+      exitTeammateView(setAppState);
+    });
+    const clearedNotRetained = applyUpdate(notRetained, (setAppState) => {
+      exitTeammateView(setAppState);
+    });
+
+    expect(clearedNonLocal.tasks).toBe(nonLocal.tasks);
+    expect(clearedNonLocal.viewSelectionMode).toBe("none");
+    expect(clearedNotRetained.tasks).toBe(notRetained.tasks);
+    expect(clearedNotRetained.tasks.agent_1).toMatchObject({
+      retain: false,
+      messages: [{ type: "assistant", uuid: "msg_1" }],
+    });
+  });
+
+  test("exitTeammateView releases a retained running task without scheduling eviction", () => {
+    const state = makeState({
+      viewSelectionMode: "viewing-agent",
+      viewingAgentTaskId: "agent_1",
+      tasks: {
+        agent_1: makeAgentTask("agent_1", {
+          retain: true,
+          diskLoaded: true,
+          messages: [{ type: "assistant", uuid: "msg_1" }],
+        }),
+      },
+    });
+
+    const next = applyUpdate(state, (setAppState) => {
+      exitTeammateView(setAppState);
+    });
+
+    expect(next.viewSelectionMode).toBe("none");
+    expect(next.viewingAgentTaskId).toBeUndefined();
+    expect(next.tasks.agent_1).toMatchObject({
+      retain: false,
+      diskLoaded: false,
+      messages: undefined,
+      evictAfter: undefined,
+    });
+  });
+
+  test("stopOrDismissAgent ignores non-local and already dismissed tasks", () => {
+    const nonLocal = makeState({
+      tasks: {
+        shell_1: makeShellTask("shell_1"),
+      },
+    });
+    const dismissed = makeState({
+      tasks: {
+        agent_1: makeAgentTask("agent_1", {
+          status: "completed",
+          evictAfter: 0,
+        }),
+      },
+    });
+
+    const nonLocalNext = applyUpdate(nonLocal, (setAppState) => {
+      stopOrDismissAgent("shell_1", setAppState);
+    });
+    const dismissedNext = applyUpdate(dismissed, (setAppState) => {
+      stopOrDismissAgent("agent_1", setAppState);
+    });
+
+    expect(nonLocalNext).toBe(nonLocal);
+    expect(dismissedNext).toBe(dismissed);
+  });
+
+  test("stopOrDismissAgent dismisses an unviewed terminal agent without clearing the current view", () => {
+    const state = makeState({
+      viewSelectionMode: "viewing-agent",
+      viewingAgentTaskId: "agent_current",
+      tasks: {
+        agent_current: makeAgentTask("agent_current", { retain: true }),
+        agent_done: makeAgentTask("agent_done", {
+          status: "failed",
+          retain: true,
+          diskLoaded: true,
+          messages: [{ type: "assistant", uuid: "msg_1" }],
+        }),
+      },
+    });
+
+    const next = applyUpdate(state, (setAppState) => {
+      stopOrDismissAgent("agent_done", setAppState);
+    });
+
+    expect(next.viewSelectionMode).toBe("viewing-agent");
+    expect(next.viewingAgentTaskId).toBe("agent_current");
+    expect(next.tasks.agent_done).toMatchObject({
+      retain: false,
+      diskLoaded: false,
+      messages: undefined,
+      evictAfter: 0,
+    });
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-058-components-FileEditToolUseRejectedMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-058-components-FileEditToolUseRejectedMessage.test.tsx
@@ -1,0 +1,238 @@
+import { PassThrough } from 'node:stream'
+
+import type { StructuredPatchHunk } from 'diff'
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const childMocks = vi.hoisted(() => ({
+  diffs: [] as Array<Record<string, unknown>>,
+  highlighted: [] as Array<Record<string, unknown>>,
+}))
+
+vi.mock('../../../src/tui/hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({ columns: 100, rows: 24 }),
+}))
+
+vi.mock('../../../src/utils/cwd.js', () => ({
+  getCwd: () => '/workspace',
+}))
+
+vi.mock('../../../src/tui/components/markdown/HighlightedCode.js', async () => {
+  const ReactModule = await import('react')
+  const { default: Text } = await import('../../../src/tui/ink/components/Text.js')
+
+  return {
+    HighlightedCode: (props: Record<string, unknown>) => {
+      childMocks.highlighted.push(props)
+      return ReactModule.createElement(
+        Text,
+        null,
+        `code:${props.filePath}:${props.width}:${props.code}`,
+      )
+    },
+  }
+})
+
+vi.mock('../../../src/tui/components/diff/StructuredDiffList.js', async () => {
+  const ReactModule = await import('react')
+  const { default: Text } = await import('../../../src/tui/ink/components/Text.js')
+
+  return {
+    StructuredDiffList: (props: Record<string, unknown>) => {
+      childMocks.diffs.push(props)
+      return ReactModule.createElement(
+        Text,
+        null,
+        `diff:${props.filePath}:${props.firstLine ?? 'null'}:${props.width}`,
+      )
+    },
+  }
+})
+
+import { renderToString } from '../../../src/utils/staticRender.js'
+import { createRoot, Text } from '../../../src/tui/ink.js'
+import { FileEditToolUseRejectedMessage } from '../../../src/tui/components/FileEditToolUseRejectedMessage.js'
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 100
+
+  return { stdin, stdout }
+}
+
+async function waitForOutput(
+  readOutput: () => string,
+  expected: string,
+): Promise<void> {
+  const deadline = Date.now() + 1000
+  while (Date.now() < deadline) {
+    if (readOutput().includes(expected)) return
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+  throw new Error(`Timed out waiting for rendered output: ${expected}`)
+}
+
+type Scenario = 'write' | 'missingPatch' | 'diff' | 'condensed'
+
+function MemoHarness({
+  patch,
+  scenario,
+  tick,
+}: {
+  patch: StructuredPatchHunk[]
+  scenario: Scenario
+  tick: number
+}): React.ReactElement {
+  const shared = {
+    file_path: '/workspace/src/row058.ts',
+    firstLine: null,
+    verbose: false,
+  } as const
+
+  let message: React.ReactElement
+  if (scenario === 'write') {
+    message = (
+      <FileEditToolUseRejectedMessage
+        {...shared}
+        content="alpha"
+        operation="write"
+      />
+    )
+  } else if (scenario === 'missingPatch') {
+    message = (
+      <FileEditToolUseRejectedMessage
+        {...shared}
+        operation="update"
+      />
+    )
+  } else if (scenario === 'diff') {
+    message = (
+      <FileEditToolUseRejectedMessage
+        {...shared}
+        fileContent="before"
+        operation="update"
+        patch={patch}
+      />
+    )
+  } else {
+    message = (
+      <FileEditToolUseRejectedMessage
+        {...shared}
+        operation="update"
+        style="condensed"
+      />
+    )
+  }
+
+  return (
+    <>
+      <Text>{`tick:${tick}`}</Text>
+      {message}
+    </>
+  )
+}
+
+describe('FileEditToolUseRejectedMessage coverage swarm row 058', () => {
+  beforeEach(() => {
+    childMocks.diffs = []
+    childMocks.highlighted = []
+  })
+
+  test('reuses memoized write, missing-patch, and diff render branches', async () => {
+    const patch: StructuredPatchHunk[] = [
+      {
+        oldStart: 1,
+        oldLines: 1,
+        newStart: 1,
+        newLines: 1,
+        lines: ['-before', '+after'],
+      },
+    ]
+    const { stdin, stdout } = createStreams()
+    let output = ''
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+    const readOutput = () => stripAnsi(output)
+
+    try {
+      const renderScenario = async (scenario: Scenario, tick: number) => {
+        root.render(<MemoHarness patch={patch} scenario={scenario} tick={tick} />)
+        await waitForOutput(readOutput, `tick:${tick}`)
+      }
+
+      await renderScenario('write', 1)
+      await renderScenario('write', 2)
+      await renderScenario('missingPatch', 3)
+      await renderScenario('missingPatch', 4)
+      await renderScenario('diff', 5)
+      await renderScenario('diff', 6)
+      await renderScenario('condensed', 7)
+      await renderScenario('condensed', 8)
+
+      expect(readOutput()).toContain('User rejected write to')
+      expect(readOutput()).toContain('User rejected update to')
+      expect(readOutput()).toContain('src/row058.ts')
+      expect(readOutput()).toContain('code:/workspace/src/row058.ts:88:alpha')
+      expect(readOutput()).toContain('diff:/workspace/src/row058.ts:null:88')
+      expect(childMocks.highlighted).toHaveLength(1)
+      expect(childMocks.diffs).toHaveLength(1)
+      expect(childMocks.diffs[0]).toMatchObject({
+        dim: true,
+        fileContent: 'before',
+        filePath: '/workspace/src/row058.ts',
+        firstLine: null,
+        hunks: patch,
+        width: 88,
+      })
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+  })
+
+  test('treats condensed verbose output as a normal verbose rejection', async () => {
+    const output = await renderToString(
+      <FileEditToolUseRejectedMessage
+        file_path="/workspace/src/verbose.ts"
+        firstLine={null}
+        operation="update"
+        patch={[]}
+        style="condensed"
+        verbose={true}
+      />,
+      100,
+    )
+
+    expect(output).toContain('User rejected update to')
+    expect(output).toContain('/workspace/src/verbose.ts')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-059-components-diff-StructuredDiff-Fallback.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-059-components-diff-StructuredDiff-Fallback.test.tsx
@@ -1,0 +1,106 @@
+import type { StructuredPatchHunk } from 'diff'
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { renderToString } from '../../../src/utils/staticRender.js'
+import {
+  processAdjacentLines,
+  StructuredDiffFallback,
+  type LineObject,
+} from '../../../src/tui/components/diff/StructuredDiff/Fallback.js'
+
+function hunk(lines: string[], oldStart = 1): StructuredPatchHunk {
+  return {
+    lines,
+    newLines: 0,
+    newStart: oldStart,
+    oldLines: 0,
+    oldStart,
+  } as StructuredPatchHunk
+}
+
+function renderFallback(options: {
+  readonly dim?: boolean
+  readonly lines: string[]
+  readonly oldStart?: number
+  readonly width?: number
+}): Promise<string> {
+  return renderToString(
+    <StructuredDiffFallback
+      dim={options.dim ?? false}
+      patch={hunk(options.lines, options.oldStart)}
+      width={options.width ?? 80}
+    />,
+    { columns: options.width ?? 80 },
+  )
+}
+
+describe('StructuredDiffFallback coverage swarm 059', () => {
+  test('skips sparse rows while pairing later remove and add candidates', () => {
+    const sparse = [] as LineObject[]
+    sparse.length = 3
+    sparse[1] = {
+      code: 'const label = oldName',
+      i: 0,
+      originalCode: 'const label = oldName',
+      type: 'remove',
+    }
+    sparse[2] = {
+      code: 'const label = newName',
+      i: 0,
+      originalCode: 'const label = newName',
+      type: 'add',
+    }
+
+    const processed = processAdjacentLines(sparse)
+
+    expect(processed).toHaveLength(2)
+    expect(processed[0]?.wordDiff).toBe(true)
+    expect(processed[0]?.matchedLine).toBe(processed[1])
+    expect(processed[1]?.matchedLine).toBe(processed[0])
+  })
+
+  test('renders an empty hunk without emitting placeholder rows', async () => {
+    const output = await renderFallback({ lines: [], width: 30 })
+
+    expect(output.trim()).toBe('')
+  })
+
+  test('wraps word-level diff parts when the content column is narrow', async () => {
+    const output = await renderFallback({
+      lines: [
+        '-prefixAlphaBetaGammaDelta old tail',
+        '+prefixAlphaBetaGammaDelta new tail',
+      ],
+      oldStart: 12,
+      width: 18,
+    })
+
+    expect(output).toContain('12 -prefixAlpha')
+    expect(output).toContain('taGammaDelta')
+    expect(output).toContain('old')
+    expect(output).toContain('12 +prefixAlpha')
+    expect(output).toContain('new')
+  })
+
+  test('uses standard rendering for dimmed minor changes and major changes', async () => {
+    const dimOutput = await renderFallback({
+      dim: true,
+      lines: ['-prefix old tail', '+prefix new tail'],
+      oldStart: 4,
+      width: 50,
+    })
+
+    expect(dimOutput).toContain('4 -prefix old tail')
+    expect(dimOutput).toContain('4 +prefix new tail')
+
+    const majorChangeOutput = await renderFallback({
+      lines: ['-short', '+a completely different replacement'],
+      oldStart: 9,
+      width: 40,
+    })
+
+    expect(majorChangeOutput).toContain('9 -short')
+    expect(majorChangeOutput).toContain('9 +a completely different replacement')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-060-ink-Ansi.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-060-ink-Ansi.test.tsx
@@ -1,0 +1,158 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { Ansi } from '../../../src/tui/ink/Ansi.js'
+import type { DOMElement } from '../../../src/tui/ink/dom.js'
+import instances from '../../../src/tui/ink/instances.js'
+import { createRoot } from '../../../src/tui/ink/root.js'
+import {
+  squashTextNodesToSegments,
+  type StyledSegment,
+} from '../../../src/tui/ink/squash-text-nodes.js'
+
+vi.mock('../../../src/utils/fullscreen.js', () => ({
+  isMouseClicksDisabled: () => false,
+}))
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestStdout = PassThrough & {
+  columns: number
+  isTTY: boolean
+  rows: number
+}
+
+type AnsiWithRevisionProps = {
+  children?: unknown
+  dimColor?: boolean
+  revision: number
+}
+
+const AnsiWithRevision =
+  Ansi as unknown as React.ComponentType<AnsiWithRevisionProps>
+
+function createTestStreams(): {
+  stdin: TestStdin
+  stdout: TestStdout
+} {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough() as TestStdout
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 100
+  stdout.isTTY = true
+  stdout.rows = 24
+
+  return { stdin, stdout }
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+  if (!instance?.rootNode) throw new Error('Ink root node not found')
+  return instance.rootNode
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function withAnsiSegments(
+  run: (
+    render: (node: React.ReactNode) => Promise<StyledSegment[]>,
+  ) => Promise<void>,
+): Promise<void> {
+  const { stdin, stdout } = createTestStreams()
+  const root = await createRoot({
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    patchConsole: false,
+  })
+
+  const render = async (node: React.ReactNode): Promise<StyledSegment[]> => {
+    root.render(node)
+    await sleep(25)
+    return squashTextNodesToSegments(getRootNode(stdout))
+  }
+
+  try {
+    await run(render)
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await sleep(25)
+  }
+}
+
+describe('Ansi coverage swarm row 060', () => {
+  test('merges adjacent text actions when ignored control actions split them', async () => {
+    await withAnsiSegments(async render => {
+      await expect(render(<Ansi>{'left\x07right'}</Ansi>)).resolves.toEqual([
+        {
+          styles: {},
+          text: 'leftright',
+        },
+      ])
+    })
+  })
+
+  test('renders single-span OSC 8 hyperlinks without adding text styles', async () => {
+    const previousForceHyperlink = process.env.FORCE_HYPERLINK
+    process.env.FORCE_HYPERLINK = '1'
+
+    try {
+      await withAnsiSegments(async render => {
+        await expect(
+          render(
+            <Ansi>
+              {'\x1b]8;;https://agenc.test/row-060\x07linked\x1b]8;;\x07'}
+            </Ansi>,
+          ),
+        ).resolves.toEqual([
+          {
+            hyperlink: 'https://agenc.test/row-060',
+            styles: {},
+            text: 'linked',
+          },
+        ])
+      })
+    } finally {
+      if (previousForceHyperlink === undefined) {
+        delete process.env.FORCE_HYPERLINK
+      } else {
+        process.env.FORCE_HYPERLINK = previousForceHyperlink
+      }
+    }
+  })
+
+  test('reuses cached plain string and non-string children across unrelated prop changes', async () => {
+    await withAnsiSegments(async render => {
+      await expect(
+        render(<AnsiWithRevision revision={0}>plain</AnsiWithRevision>),
+      ).resolves.toEqual([{ styles: {}, text: 'plain' }])
+
+      await expect(
+        render(<AnsiWithRevision revision={1}>plain</AnsiWithRevision>),
+      ).resolves.toEqual([{ styles: {}, text: 'plain' }])
+
+      await expect(
+        render(<AnsiWithRevision revision={2}>{42}</AnsiWithRevision>),
+      ).resolves.toEqual([{ styles: {}, text: '42' }])
+
+      await expect(
+        render(<AnsiWithRevision revision={3}>{42}</AnsiWithRevision>),
+      ).resolves.toEqual([{ styles: {}, text: '42' }])
+    })
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-061-ink-tabstops.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-061-ink-tabstops.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest'
+
+import { expandTabs } from '../../../src/tui/ink/tabstops.js'
+
+describe('tabstops coverage swarm row 061', () => {
+  test('returns text without tabs unchanged', () => {
+    expect(expandTabs('plain text\nwith ansi \x1b[31mred\x1b[39m')).toBe(
+      'plain text\nwith ansi \x1b[31mred\x1b[39m',
+    )
+  })
+
+  test('expands tabs to the next default eight-column stop', () => {
+    expect(expandTabs('\tstart')).toBe('        start')
+    expect(expandTabs('abc\tdef')).toBe('abc     def')
+    expect(expandTabs('abcdefgh\tz')).toBe('abcdefgh        z')
+    expect(expandTabs('a\tb\tc')).toBe('a       b       c')
+  })
+
+  test('resets the column after newlines', () => {
+    expect(expandTabs('abcd\tX\nab\tY\n\tZ')).toBe(
+      'abcd    X\nab      Y\n        Z',
+    )
+  })
+
+  test('uses the provided tab interval', () => {
+    expect(expandTabs('ab\tc', 4)).toBe('ab  c')
+    expect(expandTabs('abcd\tc', 4)).toBe('abcd    c')
+    expect(expandTabs('a\tb\nabc\tz', 3)).toBe('a  b\nabc   z')
+  })
+
+  test('preserves terminal sequences without advancing the column', () => {
+    expect(expandTabs('ab\x1b[31m\tc\x1b[39m')).toBe(
+      'ab\x1b[31m      c\x1b[39m',
+    )
+    expect(expandTabs('ab\x1b[31mcd\tz\x1b[39m')).toBe(
+      'ab\x1b[31mcd    z\x1b[39m',
+    )
+  })
+
+  test('counts wide characters by terminal display width', () => {
+    expect(expandTabs('界\tz')).toBe('界      z')
+    expect(expandTabs('a界\tz', 4)).toBe('a界 z')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-062-ink-layout-geometry.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-062-ink-layout-geometry.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  ZERO_EDGES,
+  addEdges,
+  clamp,
+  clampRect,
+  edges,
+  resolveEdges,
+  unionRect,
+  withinBounds,
+} from '../../../src/tui/ink/layout/geometry.js'
+
+describe('ink layout geometry coverage swarm row 062', () => {
+  test('creates and combines edge values across overloads', () => {
+    expect(edges(3)).toEqual({ top: 3, right: 3, bottom: 3, left: 3 })
+    expect(edges(2, 5)).toEqual({ top: 2, right: 5, bottom: 2, left: 5 })
+    expect(edges(1, 2, 3, 4)).toEqual({
+      top: 1,
+      right: 2,
+      bottom: 3,
+      left: 4,
+    })
+
+    expect(addEdges(edges(1, 2, 3, 4), edges(4, 3, 2, 1))).toEqual({
+      top: 5,
+      right: 5,
+      bottom: 5,
+      left: 5,
+    })
+  })
+
+  test('resolves missing edge values to zero while preserving provided values', () => {
+    expect(ZERO_EDGES).toEqual({ top: 0, right: 0, bottom: 0, left: 0 })
+    expect(resolveEdges()).toEqual(ZERO_EDGES)
+    expect(resolveEdges({ top: 1, bottom: 0 })).toEqual({
+      top: 1,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    })
+    expect(resolveEdges({ right: -2, left: 4 })).toEqual({
+      top: 0,
+      right: -2,
+      bottom: 0,
+      left: 4,
+    })
+  })
+
+  test('unions rectangles using the outermost occupied coordinates', () => {
+    expect(
+      unionRect(
+        { x: 3, y: 4, width: 5, height: 2 },
+        { x: -1, y: 6, width: 2, height: 3 },
+      ),
+    ).toEqual({ x: -1, y: 4, width: 9, height: 5 })
+
+    expect(
+      unionRect(
+        { x: 0, y: 0, width: 2, height: 2 },
+        { x: 1, y: 1, width: 1, height: 1 },
+      ),
+    ).toEqual({ x: 0, y: 0, width: 2, height: 2 })
+  })
+
+  test('clamps rectangles to the available size including empty intersections', () => {
+    expect(
+      clampRect({ x: -2, y: -1, width: 5, height: 4 }, { width: 4, height: 3 }),
+    ).toEqual({ x: 0, y: 0, width: 3, height: 3 })
+
+    expect(
+      clampRect({ x: 1, y: 1, width: 2, height: 2 }, { width: 5, height: 5 }),
+    ).toEqual({ x: 1, y: 1, width: 2, height: 2 })
+
+    expect(
+      clampRect({ x: 7, y: 2, width: 3, height: 3 }, { width: 5, height: 5 }),
+    ).toEqual({ x: 7, y: 2, width: 0, height: 3 })
+
+    expect(
+      clampRect({ x: 2, y: 8, width: 3, height: 3 }, { width: 5, height: 5 }),
+    ).toEqual({ x: 2, y: 8, width: 3, height: 0 })
+  })
+
+  test('checks points against inclusive lower and exclusive upper bounds', () => {
+    const size = { width: 3, height: 2 }
+
+    expect(withinBounds(size, { x: 0, y: 0 })).toBe(true)
+    expect(withinBounds(size, { x: 2, y: 1 })).toBe(true)
+    expect(withinBounds(size, { x: -1, y: 0 })).toBe(false)
+    expect(withinBounds(size, { x: 0, y: -1 })).toBe(false)
+    expect(withinBounds(size, { x: 3, y: 1 })).toBe(false)
+    expect(withinBounds(size, { x: 1, y: 2 })).toBe(false)
+  })
+
+  test('clamps numbers only when bounds are provided and exceeded', () => {
+    expect(clamp(5)).toBe(5)
+    expect(clamp(-2, 0)).toBe(0)
+    expect(clamp(3, 0)).toBe(3)
+    expect(clamp(9, undefined, 4)).toBe(4)
+    expect(clamp(2, undefined, 4)).toBe(2)
+    expect(clamp(7, 0, 10)).toBe(7)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-063-ink-termio-osc.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-063-ink-termio-osc.test.ts
@@ -1,0 +1,314 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const originalEnv = { ...process.env }
+const originalPlatform = process.platform
+
+const envMock = { terminal: 'xterm' as string | null }
+const execFileNoThrowMock = vi.fn(
+  async () => ({ code: 0, stdout: '', stderr: '' }),
+)
+
+function installOscMocks(): void {
+  vi.doMock('../../../src/utils/env.js', () => ({
+    env: envMock,
+  }))
+
+  vi.doMock('../../../src/utils/execFileNoThrow.js', () => ({
+    execFileNoThrow: execFileNoThrowMock,
+    execFileNoThrowWithCwd: execFileNoThrowMock,
+  }))
+}
+
+async function importFreshOscModule() {
+  return import('../../../src/tui/ink/termio/osc.js')
+}
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform })
+}
+
+function successfulExecResult(): {
+  readonly code: number
+  readonly stdout: string
+  readonly stderr: string
+} {
+  return { code: 0, stdout: '', stderr: '' }
+}
+
+function failedExecResult(): {
+  readonly code: number
+  readonly stdout: string
+  readonly stderr: string
+} {
+  return { code: 1, stdout: '', stderr: '' }
+}
+
+async function flushClipboardCopy(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+async function waitForExecCall(
+  command: string,
+): Promise<(typeof execFileNoThrowMock.mock.calls)[number] | undefined> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const call = execFileNoThrowMock.mock.calls.find(([cmd]) => cmd === command)
+    if (call) return call
+    await flushClipboardCopy()
+  }
+
+  return undefined
+}
+
+async function settleClipboardProbe(): Promise<void> {
+  for (let attempt = 0; attempt < 4; attempt++) await flushClipboardCopy()
+}
+
+function oscContent(sequence: string): string {
+  const withoutPrefix = sequence.startsWith('\x1b]')
+    ? sequence.slice(2)
+    : sequence
+
+  if (withoutPrefix.endsWith('\x1b\\')) return withoutPrefix.slice(0, -2)
+  if (withoutPrefix.endsWith('\x07')) return withoutPrefix.slice(0, -1)
+  return withoutPrefix
+}
+
+describe('osc coverage swarm row 063', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    installOscMocks()
+    envMock.terminal = 'xterm'
+    execFileNoThrowMock.mockReset()
+    execFileNoThrowMock.mockResolvedValue(successfulExecResult())
+    process.env = { ...originalEnv }
+    delete process.env['LC_TERMINAL']
+    delete process.env['SSH_CONNECTION']
+    delete process.env['STY']
+    delete process.env['TMUX']
+    setPlatform('linux')
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+    setPlatform(originalPlatform)
+    vi.doUnmock('../../../src/utils/env.js')
+    vi.doUnmock('../../../src/utils/execFileNoThrow.js')
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  test('formats OSC terminators and parses title and hyperlink branches', async () => {
+    const { OSC, osc, parseOSC } = await importFreshOscModule()
+
+    expect(osc(OSC.SET_TITLE, 'plain')).toBe(`\x1b]${OSC.SET_TITLE};plain\x07`)
+
+    envMock.terminal = 'kitty'
+    expect(osc(OSC.SET_TITLE, 'kitty')).toBe(
+      `\x1b]${OSC.SET_TITLE};kitty\x1b\\`,
+    )
+
+    expect(parseOSC(`${OSC.SET_TITLE_AND_ICON};both`)).toEqual({
+      type: 'title',
+      action: { type: 'both', title: 'both' },
+    })
+    expect(parseOSC(`${OSC.SET_ICON};icon`)).toEqual({
+      type: 'title',
+      action: { type: 'iconName', name: 'icon' },
+    })
+    expect(parseOSC(`${OSC.SET_TITLE};window`)).toEqual({
+      type: 'title',
+      action: { type: 'windowTitle', title: 'window' },
+    })
+    expect(parseOSC(`${OSC.HYPERLINK};;https://example.test/a;b`)).toEqual({
+      type: 'link',
+      action: {
+        type: 'start',
+        url: 'https://example.test/a;b',
+        params: undefined,
+      },
+    })
+    expect(
+      parseOSC(`${OSC.HYPERLINK};id=abc:ignored:rel=help;https://example.test`),
+    ).toEqual({
+      type: 'link',
+      action: {
+        type: 'start',
+        url: 'https://example.test',
+        params: { id: 'abc', rel: 'help' },
+      },
+    })
+    expect(parseOSC(`${OSC.HYPERLINK};;`)).toEqual({
+      type: 'link',
+      action: { type: 'end' },
+    })
+    expect(parseOSC('not-a-command')).toEqual({
+      type: 'unknown',
+      sequence: '\x1b]not-a-command',
+    })
+  })
+
+  test('parses tab-status colors and generates status and link outputs', async () => {
+    const {
+      LINK_END,
+      OSC,
+      link,
+      parseOSC,
+      parseOscColor,
+      supportsTabStatus,
+      tabStatus,
+    } = await importFreshOscModule()
+
+    expect(parseOscColor('#Aa10ff')).toEqual({
+      type: 'rgb',
+      r: 170,
+      g: 16,
+      b: 255,
+    })
+    expect(parseOscColor('rgb:0000/8000/ffff')).toEqual({
+      type: 'rgb',
+      r: 0,
+      g: 128,
+      b: 255,
+    })
+    expect(parseOscColor('rgb:ffff/zz/0')).toBeNull()
+    expect(
+      parseOSC(
+        `${OSC.TAB_STATUS};status;indicator=bogus;status-color=rgb:zz/0/0`,
+      ),
+    ).toEqual({
+      type: 'tabStatus',
+      action: {
+        status: null,
+        indicator: null,
+        statusColor: null,
+      },
+    })
+
+    expect(tabStatus({})).toBe(`\x1b]${OSC.TAB_STATUS};\x07`)
+    expect(
+      tabStatus({
+        indicator: { type: 'default' },
+        statusColor: { type: 'indexed', index: 4 },
+      }),
+    ).toBe(`\x1b]${OSC.TAB_STATUS};indicator=;status-color=\x07`)
+    expect(link('')).toBe(LINK_END)
+    expect(link('https://agenc.test/docs', { id: 'manual', title: 'Docs' })).toBe(
+      '\x1b]8;id=manual:title=Docs;https://agenc.test/docs\x07',
+    )
+    expect(parseOSC(oscContent(link('https://agenc.test/auto')))).toEqual({
+      type: 'link',
+      action: {
+        type: 'start',
+        url: 'https://agenc.test/auto',
+        params: { id: expect.any(String) },
+      },
+    })
+    expect(supportsTabStatus()).toBe(false)
+  })
+
+  test('selects clipboard paths and falls back when tmux buffer loading fails', async () => {
+    const {
+      OSC,
+      getClipboardPath,
+      setClipboard,
+      tmuxLoadBuffer,
+      wrapForMultiplexer,
+    } = await importFreshOscModule()
+
+    expect(getClipboardPath()).toBe('osc52')
+    expect(wrapForMultiplexer('raw')).toBe('raw')
+    expect(await tmuxLoadBuffer('outside')).toBe(false)
+    expect(execFileNoThrowMock).not.toHaveBeenCalled()
+
+    process.env['TMUX'] = '/tmp/tmux-1000/default,123,0'
+    execFileNoThrowMock.mockResolvedValueOnce(failedExecResult())
+
+    expect(await tmuxLoadBuffer('inside')).toBe(false)
+    expect(execFileNoThrowMock).toHaveBeenLastCalledWith(
+      'tmux',
+      ['load-buffer', '-w', '-'],
+      {
+        input: 'inside',
+        timeout: 2000,
+        useCwd: false,
+      },
+    )
+
+    process.env['SSH_CONNECTION'] = 'client server'
+    execFileNoThrowMock.mockReset()
+    execFileNoThrowMock.mockResolvedValueOnce(failedExecResult())
+
+    const text = 'tmux fallback'
+    const sequence = await setClipboard(text)
+
+    expect(sequence).toBe(
+      `\x1b]${OSC.CLIPBOARD};c;${Buffer.from(text, 'utf8').toString('base64')}\x07`,
+    )
+    expect(execFileNoThrowMock).toHaveBeenCalledTimes(1)
+  })
+
+  test('caches linux clipboard probes for wl-copy, xsel, and missing tools', async () => {
+    const { _resetLinuxCopyCache, setClipboard } = await importFreshOscModule()
+
+    _resetLinuxCopyCache()
+    await setClipboard('wayland')
+    expect(await waitForExecCall('wl-copy')).toEqual([
+      'wl-copy',
+      [],
+      { input: 'wayland', timeout: 2000, useCwd: false },
+    ])
+    await settleClipboardProbe()
+
+    execFileNoThrowMock.mockClear()
+    await setClipboard('cached wayland')
+    expect(execFileNoThrowMock.mock.calls).toEqual([
+      [
+        'wl-copy',
+        [],
+        { input: 'cached wayland', timeout: 2000, useCwd: false },
+      ],
+    ])
+
+    _resetLinuxCopyCache()
+    execFileNoThrowMock.mockReset()
+    execFileNoThrowMock
+      .mockResolvedValueOnce(failedExecResult())
+      .mockResolvedValueOnce(failedExecResult())
+      .mockResolvedValueOnce(successfulExecResult())
+      .mockResolvedValue(successfulExecResult())
+
+    await setClipboard('xsel probe')
+    expect(await waitForExecCall('xsel')).toEqual([
+      'xsel',
+      ['--clipboard', '--input'],
+      { input: 'xsel probe', timeout: 2000, useCwd: false },
+    ])
+    await settleClipboardProbe()
+
+    execFileNoThrowMock.mockClear()
+    await setClipboard('cached xsel')
+    expect(execFileNoThrowMock.mock.calls).toEqual([
+      [
+        'xsel',
+        ['--clipboard', '--input'],
+        { input: 'cached xsel', timeout: 2000, useCwd: false },
+      ],
+    ])
+
+    _resetLinuxCopyCache()
+    execFileNoThrowMock.mockReset()
+    execFileNoThrowMock.mockResolvedValue(failedExecResult())
+
+    await setClipboard('missing tools')
+    expect(await waitForExecCall('xsel')).toEqual([
+      'xsel',
+      ['--clipboard', '--input'],
+      { input: 'missing tools', timeout: 2000, useCwd: false },
+    ])
+    await settleClipboardProbe()
+
+    execFileNoThrowMock.mockClear()
+    await setClipboard('still missing')
+    expect(execFileNoThrowMock).not.toHaveBeenCalled()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-064-realtime-controller.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-064-realtime-controller.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type {
+  AgenCDaemonMethod,
+  AgenCDaemonResultByMethod,
+  JsonObject,
+  ThreadRealtimeAudioChunk,
+} from "../../../src/app-server/protocol/index.js";
+import {
+  createRealtimeWebrtcEventChannel,
+  RealtimeWebrtcSessionHandle,
+  type StartedRealtimeWebrtcSession,
+} from "../../../src/conversation/realtime/webrtc/lib.js";
+import type {
+  RealtimeAudioCaptureCallbacks,
+  RealtimeAudioPlayer,
+} from "../../../src/tui/realtime/audio.js";
+import { createRealtimeTuiControls } from "../../../src/tui/realtime/controller.js";
+
+type RequestRecord = {
+  readonly method: AgenCDaemonMethod;
+  readonly params?: JsonObject;
+};
+
+function createClient(
+  onRequest?: (
+    method: AgenCDaemonMethod,
+    params?: JsonObject,
+  ) => Promise<unknown> | unknown,
+): {
+  readonly requests: RequestRecord[];
+  request<Method extends AgenCDaemonMethod>(
+    method: Method,
+    params?: JsonObject,
+  ): Promise<AgenCDaemonResultByMethod[Method]>;
+} {
+  const requests: RequestRecord[] = [];
+  return {
+    requests,
+    async request(method, params) {
+      requests.push({ method, params });
+      const result =
+        onRequest === undefined ? {} : await onRequest(method, params);
+      return (result ?? {}) as AgenCDaemonResultByMethod[typeof method];
+    },
+  };
+}
+
+function createNoopAudioCapture() {
+  return async () => ({ stop: vi.fn() });
+}
+
+function createAudioPlayer(closeImpl: () => void = () => {}) {
+  const enqueued: ThreadRealtimeAudioChunk[] = [];
+  return {
+    enqueued,
+    enqueue: vi.fn((audio: ThreadRealtimeAudioChunk) => {
+      enqueued.push(audio);
+    }),
+    close: vi.fn(closeImpl),
+  } satisfies RealtimeAudioPlayer & {
+    readonly enqueued: ThreadRealtimeAudioChunk[];
+  };
+}
+
+function deferred(): { readonly promise: Promise<void>; resolve(): void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (Date.now() <= deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(`timed out waiting for ${message}`);
+}
+
+describe("AgenC realtime TUI controller coverage swarm row 064", () => {
+  test("passes explicit websocket start options and ignores lifecycle no-ops", async () => {
+    const startGate = deferred();
+    const client = createClient(async (method) => {
+      if (method === "thread/realtime/start") await startGate.promise;
+    });
+    const controls = createRealtimeTuiControls({
+      threadId: "thread-064",
+      client,
+      emitEvent: () => {},
+      startAudioCapture: createNoopAudioCapture(),
+      audioPlayer: createAudioPlayer(),
+    });
+
+    await controls.stop();
+    expect(client.requests).toHaveLength(0);
+
+    const firstStart = controls.start({
+      transport: "websocket",
+      realtimeSessionId: "rt-resume",
+      prompt: "Keep replies terse",
+      outputModality: "text",
+      voice: "cedar",
+    });
+    const duplicateWhileStarting = controls.start({ transport: "websocket" });
+
+    await waitFor(
+      () => client.requests.length === 1,
+      "pending websocket start request",
+    );
+    expect(controls.getState()).toMatchObject({
+      phase: "starting",
+      transport: "websocket",
+    });
+
+    startGate.resolve();
+    await Promise.all([firstStart, duplicateWhileStarting]);
+
+    expect(client.requests).toEqual([
+      {
+        method: "thread/realtime/start",
+        params: {
+          threadId: "thread-064",
+          transport: { type: "websocket" },
+          realtimeSessionId: "rt-resume",
+          prompt: "Keep replies terse",
+          outputModality: "text",
+          voice: "cedar",
+        },
+      },
+    ]);
+
+    controls.handleTranscriptEvent({
+      type: "realtime_started",
+      payload: {},
+    });
+    expect(controls.getState()).toMatchObject({
+      phase: "active",
+      realtimeSessionId: null,
+    });
+
+    await controls.start({ transport: "websocket" });
+    expect(client.requests).toHaveLength(1);
+  });
+
+  test("surfaces fallback cleanup errors when audio player close throws non-errors", async () => {
+    const client = createClient();
+    const emitted: JsonObject[] = [];
+    const audioPlayer = createAudioPlayer(() => {
+      throw "";
+    });
+    const controls = createRealtimeTuiControls({
+      threadId: "thread-064",
+      client,
+      emitEvent: (event) => emitted.push(event),
+      startAudioCapture: createNoopAudioCapture(),
+      audioPlayer,
+    });
+
+    await controls.start({ transport: "websocket" });
+    await expect(controls.stop()).rejects.toThrow("Realtime cleanup failed");
+
+    expect(client.requests.map((request) => request.method)).toEqual([
+      "thread/realtime/start",
+      "thread/realtime/stop",
+    ]);
+    expect(audioPlayer.close).toHaveBeenCalledOnce();
+    expect(controls.getState()).toMatchObject({
+      phase: "inactive",
+      errorBanner: "Realtime cleanup failed",
+    });
+    expect(emitted.at(-1)).toMatchObject({
+      type: "realtime_error",
+      payload: {
+        threadId: "thread-064",
+        message: "Realtime cleanup failed",
+      },
+    });
+  });
+
+  test("closes a started WebRTC transport when daemon start rejects with a non-error", async () => {
+    const client = createClient((method) => {
+      if (method === "thread/realtime/start") throw "daemon rejected";
+    });
+    const channel = createRealtimeWebrtcEventChannel();
+    const close = vi.fn();
+    const started: StartedRealtimeWebrtcSession = {
+      offerSdp: "offer-sdp-064",
+      handle: new RealtimeWebrtcSessionHandle({
+        applyAnswerSdp: vi.fn(),
+        close,
+      }),
+      events: channel.receiver,
+    };
+    const emitted: JsonObject[] = [];
+    const controls = createRealtimeTuiControls({
+      threadId: "thread-064",
+      client,
+      emitEvent: (event) => emitted.push(event),
+      startWebrtcSession: async () => started,
+      audioPlayer: createAudioPlayer(),
+    });
+
+    await expect(controls.start({ transport: "webrtc" })).rejects.toBe(
+      "daemon rejected",
+    );
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(client.requests).toEqual([
+      {
+        method: "thread/realtime/start",
+        params: {
+          threadId: "thread-064",
+          transport: { type: "webrtc", sdp: "offer-sdp-064" },
+          realtimeSessionId: null,
+          prompt: null,
+          outputModality: "audio",
+          voice: null,
+        },
+      },
+    ]);
+    expect(controls.getState()).toMatchObject({
+      phase: "inactive",
+      errorBanner: "daemon rejected",
+    });
+    expect(emitted.at(-1)).toMatchObject({
+      type: "realtime_error",
+      payload: { threadId: "thread-064", message: "daemon rejected" },
+    });
+  });
+
+  test("filters transcript payloads and preserves complete output audio metadata", () => {
+    const client = createClient();
+    const audioPlayer = createAudioPlayer();
+    const controls = createRealtimeTuiControls({
+      threadId: "thread-064",
+      client,
+      emitEvent: () => {},
+      audioPlayer,
+    });
+
+    controls.handleTranscriptEvent({
+      type: "realtime_sdp",
+      payload: { sdp: "ignored-without-webrtc" },
+    });
+    controls.handleTranscriptEvent({
+      type: "realtime_output_audio_delta",
+      payload: { audio: "not an object" },
+    });
+    controls.handleTranscriptEvent({
+      type: "realtime_output_audio_delta",
+      payload: {
+        audio: {
+          data: "AAAA",
+          sampleRate: 24_000,
+          numChannels: 1,
+          samplesPerChannel: 12,
+          itemId: "item-064",
+        },
+      },
+    });
+
+    expect(audioPlayer.enqueued).toEqual([
+      {
+        data: "AAAA",
+        sampleRate: 24_000,
+        numChannels: 1,
+        samplesPerChannel: 12,
+        itemId: "item-064",
+      },
+    ]);
+
+    controls.handleTranscriptEvent({
+      type: "realtime_transcript_delta",
+      payload: { role: "assistant", delta: "hel" },
+    });
+    controls.handleTranscriptEvent({
+      type: "realtime_transcript_delta",
+      payload: { role: "assistant", delta: "lo" },
+    });
+    controls.handleTranscriptEvent({
+      type: "realtime_transcript_delta",
+      payload: { role: "assistant", delta: 64 },
+    });
+    controls.handleTranscriptEvent({
+      type: "realtime_transcript_done",
+      payload: { role: "user", text: "done" },
+    });
+    controls.handleTranscriptEvent({
+      type: "realtime_transcript_done",
+      payload: { role: "user", text: null },
+    });
+    controls.handleTranscriptEvent({
+      type: "realtime_item_added",
+      payload: { item: { type: "message", id: "msg-064" } },
+    });
+    controls.handleTranscriptEvent({
+      type: "realtime_local_audio_level",
+      payload: { peak: "loud" },
+    });
+    controls.handleTranscriptEvent({ type: "unhandled_realtime_event" });
+
+    expect(controls.getState()).toMatchObject({
+      lastTranscript: { role: "user", text: "done" },
+      lastItemSummary: "message msg-064",
+      localAudioLevel: 0,
+    });
+  });
+
+  test("ignores late websocket capture terminal callbacks after requested stop", async () => {
+    const client = createClient();
+    let callbacks: RealtimeAudioCaptureCallbacks | null = null;
+    const controls = createRealtimeTuiControls({
+      threadId: "thread-064",
+      client,
+      emitEvent: () => {},
+      startAudioCapture: async (nextCallbacks) => {
+        callbacks = nextCallbacks;
+        return { stop: vi.fn() };
+      },
+      audioPlayer: createAudioPlayer(),
+    });
+
+    await controls.start({ transport: "websocket" });
+    await controls.stop();
+    const stopCount = client.requests.filter(
+      (request) => request.method === "thread/realtime/stop",
+    ).length;
+
+    callbacks?.onError("late capture failure");
+    callbacks?.onClosed();
+    await Promise.resolve();
+
+    expect(
+      client.requests.filter(
+        (request) => request.method === "thread/realtime/stop",
+      ),
+    ).toHaveLength(stopCount);
+    expect(controls.getState()).toMatchObject({
+      phase: "inactive",
+      errorBanner: null,
+      closedBanner: "Realtime closed: requested",
+    });
+  });
+
+  test("keeps capture terminal daemon-stop cleanup best effort", async () => {
+    const client = createClient((method) => {
+      if (method === "thread/realtime/stop") {
+        throw new Error("ignored stop failure");
+      }
+    });
+    const emitted: JsonObject[] = [];
+    let callbacks: RealtimeAudioCaptureCallbacks | null = null;
+    const stopCapture = vi.fn();
+    const audioPlayer = createAudioPlayer();
+    const controls = createRealtimeTuiControls({
+      threadId: "thread-064",
+      client,
+      emitEvent: (event) => emitted.push(event),
+      startAudioCapture: async (nextCallbacks) => {
+        callbacks = nextCallbacks;
+        return { stop: stopCapture };
+      },
+      audioPlayer,
+    });
+
+    await controls.start({ transport: "websocket" });
+    callbacks?.onError("capture failed");
+
+    await waitFor(
+      () =>
+        controls.getState().errorBanner === "capture failed" &&
+        client.requests.some(
+          (request) => request.method === "thread/realtime/stop",
+        ),
+      "capture terminal cleanup with failing daemon stop",
+    );
+
+    expect(stopCapture).toHaveBeenCalledOnce();
+    expect(audioPlayer.close).toHaveBeenCalledOnce();
+    expect(emitted.at(-1)).toMatchObject({
+      type: "realtime_error",
+      payload: { threadId: "thread-064", message: "capture failed" },
+    });
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-065-components-v2-primitives.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-065-components-v2-primitives.test.tsx
@@ -1,0 +1,327 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import type { PermissionMode } from '../../../src/permissions/types.js'
+import { Box, Text } from '../../../src/tui/ink.js'
+import {
+  ApprovalCard,
+  BrandCells,
+  ChatBody,
+  MenuModal,
+  ModePill,
+  ModeSwitcher,
+  Msg,
+  PlanList,
+  PlanModeBanner,
+  PromptChrome,
+  ProtocolEvent,
+  SlashPalette,
+  StatusSegment,
+  TaskInFlightCard,
+  TerminalFrame,
+  Tool,
+  WelcomeColdPanel,
+} from '../../../src/tui/components/v2/primitives.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+
+describe('v2 primitives coverage swarm row 065', () => {
+  test('renders narrow and wide terminal frame chrome branches', async () => {
+    const narrow = await renderToString(
+      <TerminalFrame
+        title="agenc ~ compact"
+        tabLabel="hidden-tab"
+        tabStatus="warn"
+        permissionMode={'bubble' as PermissionMode}
+        taskPda="hidden-task"
+        promptPlaceholder="say something"
+        statusLeft={[<StatusSegment key="stake" label="stake" value="18" separator={false} />]}
+        columns={54}
+        minHeight={8}
+      >
+        <ChatBody>
+          <Text>narrow body</Text>
+        </ChatBody>
+      </TerminalFrame>,
+      { columns: 54, rows: 12 },
+    )
+
+    expect(narrow).toContain('~/compact')
+    expect(narrow).toContain('mode · bubble')
+    expect(narrow).toContain('narrow body')
+    expect(narrow).toContain('say something')
+    expect(narrow).not.toContain('hidden-tab')
+    expect(narrow).not.toContain('hidden-task')
+
+    const wide = await renderToString(
+      <TerminalFrame
+        title="session"
+        tabLabel="pending-tab"
+        tabStatus="pending"
+        permissionMode="bypassPermissions"
+        taskPda="6qTask"
+        bodyOverlay={<StatusSegment label="cost" value="0.20" />}
+        bodyOverlayX={4}
+        promptOverlay={<PlanModeBanner title="hold" body="read only until approved" />}
+        contextLeft="ctx-left"
+        contextRight={<Text>ctx-right</Text>}
+        promptText="cargo test"
+        promptHint="hint right"
+        shellMode={true}
+        paused={true}
+        statusVariant="neutral"
+        statusLeft={[
+          'raw-left',
+          <StatusSegment key="stake" label="stake" value="18" gapAfter={0} />,
+          <StatusSegment key="cost" label="cost" value="0.1" />,
+        ]}
+        statusRight={[<StatusSegment key="net" label="net" value="localnet" />]}
+        columns={148}
+        minHeight={14}
+      >
+        <ChatBody centered={true} maxWidth={60}>
+          <Text>wide body</Text>
+        </ChatBody>
+      </TerminalFrame>,
+      { columns: 148, rows: 18 },
+    )
+
+    expect(wide).toContain('pending-tab')
+    expect(wide).toContain('6qTask')
+    expect(wide).toContain('wide body')
+    expect(wide).toContain('COST 0.20')
+    expect(wide).toContain('HOLD')
+    expect(wide).toContain('ctx-left')
+    expect(wide).toContain('ctx-right')
+    expect(wide).toContain('$')
+    expect(wide).toContain('cargo test')
+    expect(wide).toContain('hint right')
+    expect(wide).toContain('localnet')
+  })
+
+  test('renders cards, lists, tools, and approval variants', async () => {
+    const output = await renderToString(
+      <Box flexDirection="column">
+        <BrandCells columns={1} rows={1} />
+        <ModePill mode={'unknown-mode' as PermissionMode} />
+        <ModeSwitcher currentMode="acceptEdits" spacious={true} />
+        <WelcomeColdPanel
+          version="9.9.9"
+          build="row065"
+          network="devnet"
+          cwd="/tmp/agenc"
+          gitBranch="coverage"
+          gitState="dirty"
+          stats={[
+            { label: 'CUSTOM', value: '42' },
+            { label: 'LAST', value: 'fallback color' },
+          ]}
+        />
+        <TaskInFlightCard
+          taskId="#65"
+          title="cover v2 primitives"
+          taskPda="row065-pda"
+          escrow="0.65"
+          deadline="deadline now"
+          planItems={[
+            { state: 'done', text: 'read source' },
+            { state: 'active', text: 'write focused tests' },
+            { state: 'pending', text: 'run target' },
+            { state: 'failed', text: 'report source issue' },
+          ]}
+        />
+        <Msg role="system" label="notice">{['array ', 65]}</Msg>
+        <Msg role="user" label="operator" time="12:34">{6500}</Msg>
+        <Tool kind="edit" state="queued" args="file.ts" />
+        <Tool kind="grep" state="running" args="pattern: row065" time="1s" />
+        <Tool
+          kind="bash"
+          state="failed"
+          args="npm test"
+          result="exit 1"
+          expanded={true}
+          detail={<Text>stderr detail</Text>}
+        />
+        <Tool kind="stake" args="stake account" result="ok" />
+        <PlanList
+          title="mixed plan"
+          gapAfterActive={true}
+          items={[
+            { state: 'done', text: 'completed row' },
+            { state: 'active', text: 'active row' },
+            { state: 'pending', text: 'pending row' },
+            { state: 'failed', text: 'failed row' },
+          ]}
+        />
+        <PromptChrome paused={true} placeholder="paused placeholder" hint="paused hint" />
+        <ApprovalCard
+          risk="low"
+          title="local approval"
+          command="npm run lint"
+          facts={[
+            { label: 'network', value: 'localnet' },
+            { label: 'cost', value: '0.01' },
+          ]}
+          note="safe local command"
+          confirmLabel="approve"
+        />
+        <ApprovalCard
+          risk="high"
+          title="settle approval"
+          command="settle_task --mainnet"
+          facts={[
+            { label: 'net', value: 'mainnet-beta' },
+            { label: 'risk', value: 'high' },
+          ]}
+          confirmLabel="type yes"
+          requireTypedConfirmation={true}
+        />
+      </Box>,
+      { columns: 132, rows: 40 },
+    )
+
+    expect(output).toContain('mode · default')
+    expect(output).toContain('current · acceptEdits')
+    expect(output).toContain('9.9.9')
+    expect(output).toContain('row065')
+    expect(output).toContain('CUSTOM')
+    expect(output).toContain('#65')
+    expect(output).toContain('CHECKPOINTED PLAN')
+    expect(output).toContain('NOTICE')
+    expect(output).toContain('array 65')
+    expect(output).toContain('OPERATOR')
+    expect(output).toContain('6500')
+    expect(output).toContain('Edit')
+    expect(output).toContain('Grep')
+    expect(output).toContain('exit 1')
+    expect(output).toContain('stderr detail')
+    expect(output).toContain('MIXED PLAN')
+    expect(output).toContain('paused placeholder')
+    expect(output).toContain('req 0x47a3')
+    expect(output).toContain('note · safe local command')
+    expect(output).toContain('edit command')
+    expect(output).toContain('req 0x9c14')
+    expect(output).toContain('confirmation required')
+  })
+
+  test('windows menu rows with previews and clamps empty menu state', async () => {
+    const rows = [
+      { status: 'new', name: 'alpha' },
+      { status: 'run', name: 'beta' },
+      { status: 'done', name: 'gamma' },
+    ]
+
+    const previewOutput = await renderToString(
+      <MenuModal
+        title="preview"
+        summary="summary text"
+        headerRight="right hint"
+        columns={[8, 10]}
+        headers={['status', 'name']}
+        items={rows}
+        activeIndex={99}
+        preview={<Text>preview side</Text>}
+        previewWidth="35%"
+        footer={[{ keyName: 'j', label: 'down' }]}
+        hint="footer hint"
+        omitTopBorder={true}
+        paddingX={0}
+        columnGap={0}
+        modalMinHeight={20}
+        rowMinHeight={2}
+        renderRow={(row, index, active) => [
+          <Text key="status">{active ? `>${row.status}` : row.status}</Text>,
+          <Text key="name">{`${index}:${row.name}`}</Text>,
+        ]}
+      />,
+      { columns: 80, rows: 8 },
+    )
+
+    expect(previewOutput).toContain('summary text')
+    expect(previewOutput).toContain('right hint')
+    expect(previewOutput).toContain('>done')
+    expect(previewOutput).toContain('2:gamma')
+    expect(previewOutput).toContain('preview side')
+    expect(previewOutput).toContain('scroll 2-3/3')
+    expect(previewOutput).toContain('footer hint')
+    expect(previewOutput).not.toContain('0:alpha')
+
+    const emptyOutput = await renderToString(
+      <MenuModal
+        title="empty"
+        columns={[6]}
+        headers={['name']}
+        items={[]}
+        activeIndex={-5}
+        footer={[]}
+        renderRow={() => [<Text key="unused">unused</Text>]}
+      />,
+      { columns: 80 },
+    )
+
+    expect(emptyOutput).toContain('EMPTY')
+    expect(emptyOutput).toContain('name')
+    expect(emptyOutput).toContain('[esc] dismiss')
+    expect(emptyOutput).not.toContain('unused')
+    expect(emptyOutput).not.toContain('scroll')
+  })
+
+  test('renders slash palette overflow and protocol event variants', async () => {
+    const output = await renderToString(
+      <Box flexDirection="column">
+        <SlashPalette
+          activeCommand="/delegate"
+          totalCount={5}
+          maxVisible={3}
+          headerRightInset={0}
+          items={[
+            { command: '/delegate', args: '<agent>', description: 'agenc · delegate work' },
+            { command: '/claim', args: '<task>', description: 'claim marketplace work' },
+            { command: '/settle', args: '<task>', description: 'settle escrow' },
+            { command: '/stake', args: '<amount>', description: 'stake identity' },
+          ]}
+        />
+        <SlashPalette
+          activeCommand="/offset"
+          totalCount={1}
+          maxVisible={1}
+          offsetTop={2}
+          headerRightInset={0}
+          items={[
+            { command: '/offset', args: '', description: 'offset branch' },
+          ]}
+        />
+        <ProtocolEvent
+          kind="settle"
+          title="settled task"
+          body="settled body"
+          facts={[{ label: 'proof', value: 'hash-065' }]}
+        />
+        <ProtocolEvent kind="slash" title="slash event" body={<Text>slash body</Text>} />
+        <ProtocolEvent kind="stake" title="stake event" body={['stake ', 'body']} />
+        <ProtocolEvent
+          kind="claim"
+          title="claim event"
+          body="claim body"
+          facts={[{ label: 'task', value: '#65' }]}
+        />
+      </Box>,
+      { columns: 100, rows: 24 },
+    )
+
+    expect(output).toContain('slash commands · 5')
+    expect(output).toContain('/delegate')
+    expect(output).toContain('delegate work')
+    expect(output).not.toContain('agenc · delegate work')
+    expect(output).toContain('+ 2')
+    expect(output).toContain('more ·')
+    expect(output).toContain('settled task')
+    expect(output).toContain('PROOF')
+    expect(output).toContain('hash-065')
+    expect(output).toContain('slash event')
+    expect(output).toContain('slash body')
+    expect(output).toContain('stake event')
+    expect(output).toContain('stake body')
+    expect(output).toContain('claim event')
+    expect(output).toContain('#65')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-066-hooks-useIdeAtMentioned.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-066-hooks-useIdeAtMentioned.test.ts
@@ -1,0 +1,273 @@
+import { PassThrough } from 'node:stream'
+
+import React, { act } from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const fixture = vi.hoisted(() => ({
+  ideClient: undefined as TestIdeClient | undefined,
+  getConnectedIdeClient: vi.fn(),
+  logError: vi.fn(),
+}))
+
+vi.mock('../../../src/utils/ide.js', () => ({
+  getConnectedIdeClient: fixture.getConnectedIdeClient,
+}))
+
+vi.mock('../../../src/utils/log.js', () => ({
+  logError: fixture.logError,
+}))
+
+import { createRoot } from '../../../src/tui/ink.js'
+import {
+  type IDEAtMentioned,
+  useIdeAtMentioned,
+} from '../../../src/tui/hooks/useIdeAtMentioned.js'
+
+type AtMentionedNotificationParams = {
+  readonly filePath: string
+  readonly lineStart?: number
+  readonly lineEnd?: number
+}
+
+type NotificationHandler = (notification: {
+  readonly params: AtMentionedNotificationParams
+}) => void
+
+type TestIdeClient = {
+  readonly client: {
+    readonly setNotificationHandler: ReturnType<typeof vi.fn>
+  }
+  readonly emit: (params: AtMentionedNotificationParams) => void
+}
+
+type HookProps = {
+  readonly mcpClients: unknown[]
+  readonly onAtMentioned: (atMentioned: IDEAtMentioned) => void
+}
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough & {
+    columns: number
+    rows: number
+    isTTY: boolean
+  }
+}
+
+function createIdeClient(): TestIdeClient {
+  let handler: NotificationHandler | undefined
+
+  return {
+    client: {
+      setNotificationHandler: vi.fn(
+        (_schema: unknown, next: NotificationHandler) => {
+          handler = next
+        },
+      ),
+    },
+    emit: (params: AtMentionedNotificationParams) => {
+      if (handler === undefined) {
+        throw new Error('at-mentioned handler was not registered')
+      }
+      handler({ params })
+    },
+  }
+}
+
+function createStreams(): TestStreams {
+  const stdin = new PassThrough() as TestStreams['stdin']
+  const stdout = new PassThrough() as TestStreams['stdout']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 100
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+async function renderHookHarness(
+  initialProps: HookProps,
+): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly render: (next: Partial<HookProps>) => Promise<void>
+}> {
+  let props = initialProps
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    useIdeAtMentioned(props.mcpClients as never, props.onAtMentioned)
+    return null
+  }
+
+  async function render(next: Partial<HookProps> = {}): Promise<void> {
+    props = { ...props, ...next }
+    await act(async () => {
+      root.render(React.createElement(Harness))
+    })
+    await flushEffects()
+  }
+
+  await render()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushEffects()
+    },
+    render,
+  }
+}
+
+describe('useIdeAtMentioned coverage swarm 066', () => {
+  beforeEach(() => {
+    fixture.ideClient = undefined
+    fixture.getConnectedIdeClient.mockReset()
+    fixture.getConnectedIdeClient.mockImplementation(() => fixture.ideClient)
+    fixture.logError.mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('registers only when an IDE client is available and converts line numbers to one-based positions', async () => {
+    const onAtMentioned = vi.fn()
+    const firstClients = [{ name: 'not-ide' }]
+    const rendered = await renderHookHarness({
+      mcpClients: firstClients,
+      onAtMentioned,
+    })
+
+    try {
+      expect(fixture.getConnectedIdeClient).toHaveBeenLastCalledWith(
+        firstClients,
+      )
+
+      const ideClient = createIdeClient()
+      fixture.ideClient = ideClient
+      const secondClients = [{ name: 'ide' }]
+      await rendered.render({ mcpClients: secondClients })
+
+      expect(fixture.getConnectedIdeClient).toHaveBeenLastCalledWith(
+        secondClients,
+      )
+      expect(ideClient.client.setNotificationHandler).toHaveBeenCalledTimes(1)
+
+      ideClient.emit({
+        filePath: '/workspace/src/app.ts',
+        lineStart: 0,
+        lineEnd: 4,
+      })
+
+      expect(onAtMentioned).toHaveBeenLastCalledWith({
+        filePath: '/workspace/src/app.ts',
+        lineStart: 1,
+        lineEnd: 5,
+      })
+
+      ideClient.emit({
+        filePath: '/workspace/src/untitled.ts',
+      })
+
+      expect(onAtMentioned).toHaveBeenLastCalledWith({
+        filePath: '/workspace/src/untitled.ts',
+        lineStart: undefined,
+        lineEnd: undefined,
+      })
+      expect(fixture.logError).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('ignores stale handlers after the connected IDE client changes', async () => {
+    const firstIdeClient = createIdeClient()
+    fixture.ideClient = firstIdeClient
+    const onAtMentioned = vi.fn()
+    const rendered = await renderHookHarness({
+      mcpClients: [{ id: 'first' }],
+      onAtMentioned,
+    })
+
+    try {
+      expect(firstIdeClient.client.setNotificationHandler).toHaveBeenCalledTimes(
+        1,
+      )
+
+      const secondIdeClient = createIdeClient()
+      fixture.ideClient = secondIdeClient
+      await rendered.render({ mcpClients: [{ id: 'second' }] })
+
+      firstIdeClient.emit({
+        filePath: '/workspace/src/stale.ts',
+        lineStart: 2,
+      })
+
+      expect(onAtMentioned).not.toHaveBeenCalled()
+
+      secondIdeClient.emit({
+        filePath: '/workspace/src/current.ts',
+        lineEnd: 8,
+      })
+
+      expect(onAtMentioned).toHaveBeenCalledTimes(1)
+      expect(onAtMentioned).toHaveBeenLastCalledWith({
+        filePath: '/workspace/src/current.ts',
+        lineStart: undefined,
+        lineEnd: 9,
+      })
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('logs notification handler errors instead of surfacing callback failures', async () => {
+    const ideClient = createIdeClient()
+    fixture.ideClient = ideClient
+    const callbackError = new Error('callback failed')
+    const rendered = await renderHookHarness({
+      mcpClients: [{ name: 'ide' }],
+      onAtMentioned: () => {
+        throw callbackError
+      },
+    })
+
+    try {
+      expect(() => {
+        ideClient.emit({
+          filePath: '/workspace/src/failing.ts',
+          lineStart: 6,
+          lineEnd: 6,
+        })
+      }).not.toThrow()
+
+      expect(fixture.logError).toHaveBeenCalledWith(callbackError)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-067-message-renderers-PlanApprovalMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-067-message-renderers-PlanApprovalMessage.test.tsx
@@ -1,0 +1,241 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../../src/tui/hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    syntaxHighlightingDisabled: true,
+  }),
+}))
+
+import { renderToString } from '../../../src/utils/staticRender.js'
+import {
+  formatTeammateMessageContent,
+  getPlanApprovalResponseTitle,
+  tryRenderPlanApprovalMessage,
+} from '../../../src/tui/message-renderers/PlanApprovalMessage.js'
+
+function payload(value: Record<string, unknown>): string {
+  return JSON.stringify(value)
+}
+
+function planResponse(approved: boolean, feedback?: string): string {
+  return payload({
+    type: 'plan_approval_response',
+    requestId: 'row-067',
+    approved,
+    feedback,
+    timestamp: '2026-05-20T00:00:01.000Z',
+  })
+}
+
+async function renderPlanMessage(content: string): Promise<string> {
+  const node = tryRenderPlanApprovalMessage(content, 'lead')
+  if (!React.isValidElement(node)) {
+    throw new Error('expected a rendered plan approval message')
+  }
+  return renderToString(<>{node}</>, { columns: 100, rows: 24 })
+}
+
+describe('PlanApprovalMessage coverage swarm 067', () => {
+  test('renders request and response payload states with ascii status titles', async () => {
+    const previousGlyphMode = process.env.AGENC_TUI_GLYPHS
+    process.env.AGENC_TUI_GLYPHS = 'ascii'
+
+    try {
+      expect(getPlanApprovalResponseTitle(true, 'lead')).toBe(
+        'OK Plan Approved by lead',
+      )
+      expect(getPlanApprovalResponseTitle(false, 'lead')).toBe(
+        'ERR Plan Rejected by lead',
+      )
+
+      const requestOutput = await renderPlanMessage(
+        payload({
+          type: 'plan_approval_request',
+          from: 'planner',
+          timestamp: '2026-05-20T00:00:00.000Z',
+          planFilePath: '/tmp/row-067-plan.md',
+          planContent: '# Row 067 plan\n\n- Cover renderer branches',
+          requestId: 'row-067',
+        }),
+      )
+
+      expect(requestOutput).toContain('Plan Approval Request from planner')
+      expect(requestOutput).toContain('Row 067 plan')
+      expect(requestOutput).toContain('Cover renderer branches')
+      expect(requestOutput).toContain('Plan file: /tmp/row-067-plan.md')
+
+      const approvedOutput = await renderPlanMessage(planResponse(true))
+      expect(approvedOutput).toContain('OK Plan Approved by lead')
+      expect(approvedOutput).toContain(
+        'You can now proceed with implementation. Your plan mode restrictions have been lifted.',
+      )
+
+      const rejectedOutput = await renderPlanMessage(
+        planResponse(false, 'Add rollback coverage.'),
+      )
+      expect(rejectedOutput).toContain('ERR Plan Rejected by lead')
+      expect(rejectedOutput).toContain('Feedback: Add rollback coverage.')
+      expect(rejectedOutput).toContain(
+        'Please revise your plan based on the feedback and call ExitPlanMode again.',
+      )
+
+      const rejectedWithoutFeedbackOutput = await renderPlanMessage(
+        planResponse(false),
+      )
+      expect(rejectedWithoutFeedbackOutput).toContain(
+        'ERR Plan Rejected by lead',
+      )
+      expect(rejectedWithoutFeedbackOutput).not.toContain('Feedback:')
+      expect(rejectedWithoutFeedbackOutput).toContain(
+        'Please revise your plan based on the feedback and call ExitPlanMode again.',
+      )
+    } finally {
+      if (previousGlyphMode === undefined) {
+        delete process.env.AGENC_TUI_GLYPHS
+      } else {
+        process.env.AGENC_TUI_GLYPHS = previousGlyphMode
+      }
+    }
+  })
+
+  test('returns null for malformed plan payloads and summarizes plan fallback text', () => {
+    expect(
+      tryRenderPlanApprovalMessage(
+        payload({
+          type: 'plan_approval_request',
+          from: 'planner',
+          timestamp: '2026-05-20T00:00:00.000Z',
+          requestId: 'missing-required-fields',
+        }),
+        'lead',
+      ),
+    ).toBeNull()
+
+    expect(formatTeammateMessageContent(planResponse(false))).toBe(
+      '[Plan Rejected] Please revise your plan',
+    )
+  })
+
+  test('summarizes teammate lifecycle messages before falling back to raw content', () => {
+    expect(
+      formatTeammateMessageContent(
+        payload({
+          type: 'idle_notification',
+          from: 'worker',
+          timestamp: '2026-05-20T00:00:00.000Z',
+        }),
+      ),
+    ).toBe('Agent idle')
+
+    expect(
+      formatTeammateMessageContent(
+        payload({
+          type: 'idle_notification',
+          from: 'worker',
+          timestamp: '2026-05-20T00:00:00.000Z',
+          completedTaskId: '067',
+        }),
+      ),
+    ).toBe('Agent idle · Task 067 completed')
+
+    expect(
+      formatTeammateMessageContent(
+        payload({
+          type: 'idle_notification',
+          from: 'worker',
+          timestamp: '2026-05-20T00:00:00.000Z',
+          completedTaskId: '067',
+          completedStatus: 'blocked',
+          summary: 'waiting for approval',
+        }),
+      ),
+    ).toBe('Agent idle · Task 067 blocked · Last DM: waiting for approval')
+
+    expect(
+      formatTeammateMessageContent(
+        payload({
+          type: 'shutdown_request',
+          requestId: 'shutdown-1',
+          from: 'lead',
+          timestamp: '2026-05-20T00:00:00.000Z',
+        }),
+      ),
+    ).toBe('[Shutdown Request from lead]')
+
+    expect(
+      formatTeammateMessageContent(
+        payload({
+          type: 'shutdown_request',
+          requestId: 'shutdown-2',
+          from: 'lead',
+          reason: 'handoff complete',
+          timestamp: '2026-05-20T00:00:00.000Z',
+        }),
+      ),
+    ).toBe('[Shutdown Request from lead] handoff complete')
+
+    expect(
+      formatTeammateMessageContent(
+        payload({
+          type: 'shutdown_approved',
+          requestId: 'shutdown-3',
+          from: 'worker',
+          timestamp: '2026-05-20T00:00:00.000Z',
+        }),
+      ),
+    ).toBe('[Shutdown Approved] worker is now exiting')
+
+    expect(
+      formatTeammateMessageContent(
+        payload({
+          type: 'shutdown_rejected',
+          requestId: 'shutdown-4',
+          from: 'worker',
+          reason: 'tests still running',
+          timestamp: '2026-05-20T00:00:00.000Z',
+        }),
+      ),
+    ).toBe('[Shutdown Rejected] worker: tests still running')
+
+    expect(
+      formatTeammateMessageContent(
+        payload({
+          type: 'task_assignment',
+          taskId: '067',
+          subject: 'Cover PlanApprovalMessage',
+          description: 'Add focused branch coverage.',
+          assignedBy: 'lead',
+          timestamp: '2026-05-20T00:00:00.000Z',
+        }),
+      ),
+    ).toBe('[Task Assigned] #067 - Cover PlanApprovalMessage')
+
+    expect(
+      formatTeammateMessageContent(
+        payload({
+          type: 'teammate_terminated',
+          message: 'worker stopped',
+        }),
+      ),
+    ).toBe('worker stopped')
+
+    const terminatedWithoutMessage = payload({ type: 'teammate_terminated' })
+    const unrelatedStructured = payload({
+      type: 'unrelated',
+      message: 'leave this alone',
+    })
+
+    expect(formatTeammateMessageContent(terminatedWithoutMessage)).toBe(
+      terminatedWithoutMessage,
+    )
+    expect(formatTeammateMessageContent(unrelatedStructured)).toBe(
+      unrelatedStructured,
+    )
+    expect(formatTeammateMessageContent('{not json')).toBe('{not json')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-068-components-AgentProgressLine.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-068-components-AgentProgressLine.test.tsx
@@ -1,0 +1,125 @@
+import React, { useLayoutEffect, useState } from "react";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { renderToString } from "../../utils/staticRender.js";
+import { AgentProgressLine } from "../components/AgentProgressLine.js";
+
+type AgentProgressLineProps = React.ComponentProps<typeof AgentProgressLine>;
+
+const originalGlyphMode = process.env.AGENC_TUI_GLYPHS;
+
+afterEach(() => {
+  if (originalGlyphMode === undefined) {
+    delete process.env.AGENC_TUI_GLYPHS;
+  } else {
+    process.env.AGENC_TUI_GLYPHS = originalGlyphMode;
+  }
+});
+
+function props(
+  overrides: Partial<AgentProgressLineProps> = {},
+): AgentProgressLineProps {
+  return {
+    agentType: "worker",
+    isError: false,
+    isLast: false,
+    isResolved: false,
+    shouldAnimate: false,
+    tokens: null,
+    toolUseCount: 0,
+    ...overrides,
+  };
+}
+
+function RerenderSameLine() {
+  const [tick, setTick] = useState(0);
+
+  useLayoutEffect(() => {
+    if (tick === 0) setTick(1);
+  }, [tick]);
+
+  return (
+    <AgentProgressLine
+      {...props({
+        agentType: "cache",
+        description: "stable",
+        isLast: true,
+        lastToolInfo: "Still working",
+        toolUseCount: 1,
+        tokens: 2000,
+      })}
+    />
+  );
+}
+
+async function renderLine(
+  overrides: Partial<AgentProgressLineProps>,
+): Promise<string> {
+  return renderToString(<AgentProgressLine {...props(overrides)} />, {
+    columns: 120,
+  });
+}
+
+describe("AgentProgressLine coverage swarm 068", () => {
+  test("renders active fallback status with colored labels and plural usage", async () => {
+    process.env.AGENC_TUI_GLYPHS = "ascii";
+
+    const output = await renderLine({
+      agentType: "planner",
+      color: "worker",
+      description: "queued",
+      descriptionColor: "success",
+      toolUseCount: 0,
+    });
+
+    expect(output).toContain("|- planner (queued) · 0 tool uses");
+    expect(output).toContain("|  |_  Initializing...");
+  });
+
+  test("uses hide-type fallback labels when name is absent", async () => {
+    process.env.AGENC_TUI_GLYPHS = "ascii";
+
+    const descriptionOnly = await renderLine({
+      description: "indexing",
+      hideType: true,
+      isResolved: true,
+    });
+    expect(descriptionOnly).toContain("|- indexing · 0 tool uses");
+    expect(descriptionOnly).toContain("|  |_  Done");
+
+    const agentOnly = await renderLine({
+      agentType: "fallback",
+      hideType: true,
+      isResolved: true,
+    });
+    expect(agentOnly).toContain("|- fallback · 0 tool uses");
+    expect(agentOnly).toContain("|  |_  Done");
+  });
+
+  test("keeps backgrounded resolved work compact without a task description", async () => {
+    process.env.AGENC_TUI_GLYPHS = "ascii";
+
+    const output = await renderLine({
+      isAsync: true,
+      isLast: true,
+      isResolved: true,
+      taskDescription: undefined,
+      tokens: 9000,
+      toolUseCount: 3,
+    });
+
+    expect(output).toContain("`- worker");
+    expect(output).not.toContain("Running in the background");
+    expect(output).not.toContain("3 tool uses");
+    expect(output).not.toContain("9.0k tokens");
+  });
+
+  test("rerenders identical props through memoized render branches", async () => {
+    process.env.AGENC_TUI_GLYPHS = "ascii";
+
+    const output = await renderToString(<RerenderSameLine />, { columns: 120 });
+
+    expect(output).toContain("`- cache (stable) · 1 tool use · 2.0k tokens");
+    expect(output).toContain("   |_  Still working");
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-069-components-v2-ContextUsageModal.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-069-components-v2-ContextUsageModal.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { renderToString } from '../../../src/utils/staticRender.js'
+import { ContextUsageModal } from '../../../src/tui/components/v2/ContextUsageModal.js'
+
+const inputMock = vi.hoisted(() => ({
+  handler: undefined as
+    | undefined
+    | ((input: string, key: Record<string, boolean>) => void),
+  options: undefined as undefined | { readonly isActive?: boolean },
+}))
+
+vi.mock('../../../src/tui/ink.js', async () => {
+  const actual = await vi.importActual<typeof import('../../../src/tui/ink.js')>(
+    '../../../src/tui/ink.js',
+  )
+  return {
+    ...actual,
+    useInput: (
+      handler: (input: string, key: Record<string, boolean>) => void,
+      options: { readonly isActive?: boolean } = {},
+    ) => {
+      inputMock.handler = handler
+      inputMock.options = options
+    },
+  }
+})
+
+function key(overrides: Record<string, boolean> = {}): Record<string, boolean> {
+  return {
+    escape: false,
+    ...overrides,
+  }
+}
+
+describe('ContextUsageModal swarm row 069 coverage', () => {
+  beforeEach(() => {
+    inputMock.handler = undefined
+    inputMock.options = undefined
+  })
+
+  it('renders derived structured rows for file, system, plan, and auto-compact details', async () => {
+    const output = await renderToString(
+      <ContextUsageModal
+        text={[
+          'Context: 180,000 / 200,000 tokens (90% of hard limit)',
+          'system: 10,000 tokens',
+          'plan: 5,000 tokens',
+          'files: 8,402 tokens',
+          'tool catalog: 2,000 tokens',
+          'auto-compact: disabled (hard limit applies; 20,000 tokens free)',
+        ].join('\n')}
+        onDone={() => {}}
+        active={false}
+      />,
+      140,
+    )
+
+    expect(output).toContain('180,000 / 200,000 tokens')
+    expect(output).toContain('auto-compact at 92%')
+    expect(output).toContain('SYSTEM')
+    expect(output).toContain('10,000')
+    expect(output).toContain('PLAN')
+    expect(output).toContain('5,000')
+    expect(output).toContain('FILES (3)')
+    expect(output).toContain('8,402')
+    expect(output).toContain('lib.rs')
+    expect(output).toContain('3,841')
+    expect(output).toContain('pool.rs')
+    expect(output).toContain('2,118')
+    expect(output).toContain('math.rs')
+    expect(output).toContain('2,443')
+    expect(output).toContain('HISTORY')
+    expect(output).toContain('154,598')
+    expect(output).toContain('AUTO COMPACT')
+    expect(output).toContain('disabled (hard limit applies; 20,000 tokens free)')
+  })
+
+  it('clamps over-limit usage and renders compact-at rows without optional detail', async () => {
+    const output = await renderToString(
+      <ContextUsageModal
+        text={[
+          'Context: 250,000 / 200,000 tokens (125% of hard limit)',
+          'messages: 249,900 tokens',
+          'tool catalog: 100 tokens',
+          'compaction threshold: 190,000 tokens',
+        ].join('\n')}
+        onDone={() => {}}
+        active={false}
+      />,
+      120,
+    )
+
+    expect(output).toContain('250,000 / 200,000 tokens')
+    expect(output).toContain('125% used')
+    expect(output).toContain('headroom 0k')
+    expect(output).toContain('auto-compact at 95%')
+    expect(output).toContain('COMPACT AT')
+    expect(output).toContain('190,000')
+    expect(output).not.toContain('AUTO COMPACT')
+    expect(output).not.toContain('PROMPT CACHE')
+  })
+
+  it('falls back to numbered raw rows for malformed structured headers and blank rows', async () => {
+    const output = await renderToString(
+      <ContextUsageModal
+        text={'Context: 10 / 20 tokens (1.2.3% of hard limit)\n\ntrailing  '}
+        onDone={() => {}}
+        active={false}
+      />,
+      100,
+    )
+
+    expect(output).toContain('CONTEXT')
+    expect(output).toContain('001')
+    expect(output).toContain('Context: 10 / 20 tokens')
+    expect(output).toContain('002')
+    expect(output).toContain('003')
+    expect(output).toContain('trailing')
+    expect(output).toContain('close')
+    expect(output).toContain('dismiss')
+  })
+
+  it('wires default active input handling for close keys only', async () => {
+    const onDone = vi.fn()
+
+    await renderToString(
+      <ContextUsageModal text="unstructured context text" onDone={onDone} />,
+      100,
+    )
+
+    expect(inputMock.options).toEqual({ isActive: true })
+    if (!inputMock.handler) {
+      throw new Error('ContextUsageModal did not register input handling')
+    }
+
+    inputMock.handler('x', key())
+    expect(onDone).not.toHaveBeenCalled()
+
+    inputMock.handler('q', key())
+    inputMock.handler('', key({ escape: true }))
+
+    expect(onDone).toHaveBeenCalledTimes(2)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-070-ink-render-border.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-070-ink-render-border.test.ts
@@ -1,0 +1,189 @@
+import stripAnsi from 'strip-ansi'
+import { describe, expect, test, vi } from 'vitest'
+
+import type { DOMNode } from '../../../src/tui/ink/dom.ts'
+import type Output from '../../../src/tui/ink/output.ts'
+import renderBorder, {
+  type BorderStyle,
+} from '../../../src/tui/ink/render-border.ts'
+import type { Styles } from '../../../src/tui/ink/styles.ts'
+
+function createNode(
+  style: Styles,
+  width: number,
+  height: number,
+): DOMNode {
+  return {
+    attributes: {},
+    childNodes: [],
+    dirty: false,
+    nodeName: 'ink-box',
+    parentNode: undefined,
+    style,
+    yogaNode: {
+      getComputedHeight: () => height,
+      getComputedWidth: () => width,
+    },
+  } as unknown as DOMNode
+}
+
+function createOutput(): {
+  output: Output
+  write: ReturnType<typeof vi.fn>
+} {
+  const write = vi.fn()
+  return {
+    output: { write } as unknown as Output,
+    write,
+  }
+}
+
+function plainWriteCalls(
+  write: ReturnType<typeof vi.fn>,
+): Array<[number, number, string]> {
+  return write.mock.calls.map(([x, y, text]) => [
+    x as number,
+    y as number,
+    stripAnsi(text as string),
+  ])
+}
+
+describe('renderBorder coverage swarm row 070', () => {
+  test('does not write when the node has no border style', () => {
+    const { output, write } = createOutput()
+
+    renderBorder(2, 3, createNode({}, 8, 4), output)
+
+    expect(write).not.toHaveBeenCalled()
+  })
+
+  test('renders custom object borders with centered top text and vertical sides', () => {
+    const { output, write } = createOutput()
+    const borderStyle: BorderStyle = {
+      bottom: '_',
+      bottomLeft: '{',
+      bottomRight: '}',
+      left: '|',
+      right: '!',
+      top: '=',
+      topLeft: '[',
+      topRight: ']',
+    }
+
+    renderBorder(
+      1,
+      2,
+      createNode(
+        {
+          borderBottomDimColor: true,
+          borderColor: 'ansi:white',
+          borderLeftColor: 'ansi:yellow',
+          borderLeftDimColor: true,
+          borderRightColor: 'ansi:green',
+          borderRightDimColor: true,
+          borderStyle,
+          borderText: {
+            align: 'center',
+            content: 'Hi',
+            position: 'top',
+          },
+          borderTopColor: 'ansi:red',
+          borderTopDimColor: true,
+        },
+        8,
+        4,
+      ),
+      output,
+    )
+
+    expect(plainWriteCalls(write)).toEqual([
+      [1, 2, '[==Hi==]'],
+      [1, 3, '|\n|\n'],
+      [8, 3, '!\n!\n'],
+      [1, 5, '{______}'],
+    ])
+  })
+
+  test('renders dashed bottom text with hidden top and left borders', () => {
+    const { output, write } = createOutput()
+
+    renderBorder(
+      0,
+      0,
+      createNode(
+        {
+          borderLeft: false,
+          borderStyle: 'dashed',
+          borderText: {
+            align: 'end',
+            content: 'Z',
+            offset: 2,
+            position: 'bottom',
+          },
+          borderTop: false,
+        },
+        7,
+        3,
+      ),
+      output,
+    )
+
+    expect(plainWriteCalls(write)).toEqual([
+      [6, 0, '╎\n╎\n'],
+      [0, 2, '╌╌╌Z╌╌ '],
+    ])
+  })
+
+  test('clamps start-aligned text and truncates overlong border text', () => {
+    const startAligned = createOutput()
+
+    renderBorder(
+      0,
+      0,
+      createNode(
+        {
+          borderBottom: false,
+          borderLeft: false,
+          borderRight: false,
+          borderStyle: 'single',
+          borderText: {
+            align: 'start',
+            content: 'A',
+            offset: 50,
+            position: 'top',
+          },
+        },
+        6,
+        1,
+      ),
+      startAligned.output,
+    )
+
+    expect(plainWriteCalls(startAligned.write)).toEqual([[0, 0, '────A─']])
+
+    const truncated = createOutput()
+
+    renderBorder(
+      4,
+      5,
+      createNode(
+        {
+          borderLeft: false,
+          borderRight: false,
+          borderStyle: 'single',
+          borderText: {
+            align: 'center',
+            content: 'LONGTEXT',
+            position: 'bottom',
+          },
+          borderTop: false,
+        },
+        5,
+        1,
+      ),
+      truncated.output,
+    )
+
+    expect(plainWriteCalls(truncated.write)).toEqual([[4, 5, 'LONGT']])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-071-ink-hooks-use-animation-frame.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-071-ink-hooks-use-animation-frame.test.ts
@@ -1,0 +1,268 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { ClockContext, type Clock } from '../../../src/tui/ink/components/ClockContext.js'
+import type { DOMElement } from '../../../src/tui/ink/dom.js'
+import { createRoot, type Root } from '../../../src/tui/ink/root.js'
+import { useAnimationFrame } from '../../../src/tui/ink/hooks/use-animation-frame.js'
+
+const viewportMock = vi.hoisted(() => {
+  const state = { isVisible: true }
+  const ref = vi.fn()
+
+  return {
+    ref,
+    state,
+    useTerminalViewport: vi.fn(
+      () => [ref, { isVisible: state.isVisible }] as const,
+    ),
+  }
+})
+
+vi.mock('../../../src/tui/ink/hooks/use-terminal-viewport.js', () => ({
+  useTerminalViewport: viewportMock.useTerminalViewport,
+}))
+
+type ManualSubscription = {
+  active: boolean
+  readonly keepAlive: boolean
+  readonly onChange: () => void
+}
+
+type HookProbeProps = {
+  readonly intervalMs?: number | null
+}
+
+type HookState = {
+  ref?: (element: DOMElement | null) => void
+  time?: number
+}
+
+function createManualClock(): {
+  readonly activeSubscriptions: () => ManualSubscription[]
+  readonly advance: (ms: number) => void
+  readonly clock: Clock
+} {
+  let now = 0
+  const subscriptions: ManualSubscription[] = []
+
+  return {
+    activeSubscriptions: () =>
+      subscriptions.filter(subscription => subscription.active),
+    advance: ms => {
+      now += ms
+
+      for (const subscription of subscriptions.filter(
+        candidate => candidate.active,
+      )) {
+        subscription.onChange()
+      }
+    },
+    clock: {
+      now: () => now,
+      setTickInterval: () => {},
+      subscribe: (onChange, keepAlive) => {
+        const subscription: ManualSubscription = {
+          active: true,
+          keepAlive,
+          onChange,
+        }
+        subscriptions.push(subscription)
+
+        return () => {
+          subscription.active = false
+        }
+      },
+    },
+  }
+}
+
+function createStreams(): {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough
+} {
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  const stdout = new PassThrough()
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function flushEffects(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 5))
+}
+
+async function renderHookHarness(): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly latestRef: () => (element: DOMElement | null) => void
+  readonly latestTime: () => number
+  readonly render: (
+    props: HookProbeProps & { readonly clock: Clock | null },
+  ) => Promise<void>
+}> {
+  const latest: HookState = {}
+  const { stdin, stdout } = createStreams()
+  const root: Root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function HookProbe(props: HookProbeProps): null {
+    const [ref, time] = useAnimationFrame(props.intervalMs)
+    latest.ref = ref
+    latest.time = time
+    return null
+  }
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushEffects()
+    },
+    latestRef: () => {
+      if (latest.ref === undefined) throw new Error('hook did not render ref')
+      return latest.ref
+    },
+    latestTime: () => {
+      if (latest.time === undefined) throw new Error('hook did not render time')
+      return latest.time
+    },
+    render: async props => {
+      root.render(
+        React.createElement(
+          ClockContext.Provider,
+          { value: props.clock },
+          React.createElement(HookProbe, { intervalMs: props.intervalMs }),
+        ),
+      )
+      await flushEffects()
+    },
+  }
+}
+
+beforeEach(() => {
+  viewportMock.state.isVisible = true
+  viewportMock.ref.mockClear()
+  viewportMock.useTerminalViewport.mockClear()
+})
+
+describe('useAnimationFrame coverage swarm row 071', () => {
+  test('subscribes visible animations to the shared clock and respects the interval threshold', async () => {
+    const manualClock = createManualClock()
+    const rendered = await renderHookHarness()
+
+    try {
+      await rendered.render({ clock: null, intervalMs: 25 })
+
+      expect(rendered.latestRef()).toBe(viewportMock.ref)
+      expect(rendered.latestTime()).toBe(0)
+      expect(manualClock.activeSubscriptions()).toEqual([])
+
+      await rendered.render({ clock: manualClock.clock, intervalMs: 25 })
+
+      expect(
+        manualClock.activeSubscriptions().map(subscription => subscription.keepAlive),
+      ).toEqual([true])
+
+      manualClock.advance(24)
+      await flushEffects()
+
+      expect(rendered.latestTime()).toBe(0)
+
+      manualClock.advance(1)
+      await flushEffects()
+
+      expect(rendered.latestTime()).toBe(25)
+
+      manualClock.advance(25)
+      await flushEffects()
+
+      expect(rendered.latestTime()).toBe(50)
+    } finally {
+      await rendered.dispose()
+    }
+
+    expect(manualClock.activeSubscriptions()).toEqual([])
+  })
+
+  test('uses the default frame interval and pauses while invisible or explicitly disabled', async () => {
+    const manualClock = createManualClock()
+    const rendered = await renderHookHarness()
+
+    try {
+      await rendered.render({ clock: manualClock.clock })
+
+      expect(
+        manualClock.activeSubscriptions().map(subscription => subscription.keepAlive),
+      ).toEqual([true])
+
+      manualClock.advance(15)
+      await flushEffects()
+
+      expect(rendered.latestTime()).toBe(0)
+
+      manualClock.advance(1)
+      await flushEffects()
+
+      expect(rendered.latestTime()).toBe(16)
+
+      viewportMock.state.isVisible = false
+      await rendered.render({ clock: manualClock.clock })
+
+      expect(manualClock.activeSubscriptions()).toEqual([])
+
+      manualClock.advance(50)
+      await flushEffects()
+
+      expect(rendered.latestTime()).toBe(16)
+
+      viewportMock.state.isVisible = true
+      await rendered.render({ clock: manualClock.clock, intervalMs: null })
+
+      expect(manualClock.activeSubscriptions()).toEqual([])
+
+      manualClock.advance(50)
+      await flushEffects()
+
+      expect(rendered.latestTime()).toBe(16)
+
+      await rendered.render({ clock: manualClock.clock, intervalMs: 20 })
+
+      expect(manualClock.activeSubscriptions()).toHaveLength(1)
+
+      manualClock.advance(19)
+      await flushEffects()
+
+      expect(rendered.latestTime()).toBe(16)
+
+      manualClock.advance(1)
+      await flushEffects()
+
+      expect(rendered.latestTime()).toBe(136)
+    } finally {
+      await rendered.dispose()
+    }
+
+    expect(manualClock.activeSubscriptions()).toEqual([])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-072-ink-termio-parser.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-072-ink-termio-parser.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'vitest'
+
+import { Parser } from '../../../src/tui/ink/termio/parser.ts'
+
+const ESC = '\x1b'
+
+describe('termio Parser coverage swarm row 072', () => {
+  test('handles empty/default CSI params, colon params, and fallback lookups', () => {
+    const parser = new Parser()
+
+    expect(
+      parser.feed(
+        [
+          `${ESC}[;5H`,
+          `${ESC}[2:3f`,
+          `${ESC}[J`,
+          `${ESC}[99J`,
+          `${ESC}[K`,
+          `${ESC}[99K`,
+          `${ESC}[X`,
+          `${ESC}[r`,
+          `${ESC}[ q`,
+          `${ESC}[99 q`,
+        ].join(''),
+      ),
+    ).toEqual([
+      { action: { col: 5, row: 0, type: 'position' }, type: 'cursor' },
+      { action: { col: 3, row: 2, type: 'position' }, type: 'cursor' },
+      { action: { region: 'toEnd', type: 'display' }, type: 'erase' },
+      { action: { region: 'toEnd', type: 'display' }, type: 'erase' },
+      { action: { region: 'toEnd', type: 'line' }, type: 'erase' },
+      { action: { region: 'toEnd', type: 'line' }, type: 'erase' },
+      { action: { count: 1, type: 'chars' }, type: 'erase' },
+      { action: { bottom: 1, top: 1, type: 'setRegion' }, type: 'scroll' },
+      {
+        action: { blinking: true, style: 'block', type: 'style' },
+        type: 'cursor',
+      },
+      {
+        action: { blinking: true, style: 'block', type: 'style' },
+        type: 'cursor',
+      },
+    ])
+  })
+
+  test('resets empty SGR style and treats combined graphemes as double width', () => {
+    const parser = new Parser()
+
+    expect(parser.feed(`${ESC}[1;31m${ESC}[me\u0301`)).toEqual([
+      {
+        graphemes: [{ value: 'e\u0301', width: 2 }],
+        style: expect.objectContaining({
+          bold: false,
+          fg: { type: 'default' },
+        }),
+        type: 'text',
+      },
+    ])
+  })
+
+  test('parses alternate-screen variants and private mode resets', () => {
+    const parser = new Parser()
+
+    expect(
+      parser.feed(
+        [
+          `${ESC}[?47h`,
+          `${ESC}[?47l`,
+          `${ESC}[?2004l`,
+          `${ESC}[?1000l`,
+          `${ESC}[?1002l`,
+          `${ESC}[?1003l`,
+        ].join(''),
+      ),
+    ).toEqual([
+      { action: { enabled: true, type: 'alternateScreen' }, type: 'mode' },
+      { action: { enabled: false, type: 'alternateScreen' }, type: 'mode' },
+      { action: { enabled: false, type: 'bracketedPaste' }, type: 'mode' },
+      { action: { mode: 'off', type: 'mouseTracking' }, type: 'mode' },
+      { action: { mode: 'off', type: 'mouseTracking' }, type: 'mode' },
+      { action: { mode: 'off', type: 'mouseTracking' }, type: 'mode' },
+    ])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-073-components-ThinkingToggle.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-073-components-ThinkingToggle.test.tsx
@@ -1,0 +1,306 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createRoot } from "../../../src/tui/ink.js";
+import { ThinkingToggle } from "../../../src/tui/components/ThinkingToggle.js";
+
+type KeybindingRecord = {
+  handler: () => void;
+  options?: {
+    context?: string;
+    isActive?: boolean;
+  };
+};
+
+type SelectProps = {
+  defaultFocusValue?: string;
+  defaultValue?: string;
+  onCancel?: () => void;
+  onChange: (value: string) => void;
+  options: Array<{
+    description?: string;
+    label: string;
+    value: string;
+  }>;
+  visibleOptionCount: number;
+};
+
+const harness = vi.hoisted(() => ({
+  exitState: {
+    keyName: "Ctrl+D",
+    pending: false,
+  },
+  keybindings: {} as Record<string, KeybindingRecord>,
+  selectProps: undefined as SelectProps | undefined,
+}));
+
+vi.mock("src/tui/hooks/useExitOnCtrlCDWithKeybindings.js", () => ({
+  useExitOnCtrlCDWithKeybindings: () => harness.exitState,
+}));
+
+vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
+  useKeybinding: (
+    action: string,
+    handler: () => void,
+    options?: KeybindingRecord["options"],
+  ) => {
+    harness.keybindings[action] = { handler, options };
+  },
+}));
+
+vi.mock("../../../src/tui/components/CustomSelect/select.js", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+  const { default: Text } = await vi.importActual<
+    typeof import("../../../src/tui/ink/components/Text.js")
+  >("../../../src/tui/ink/components/Text.js");
+
+  return {
+    Select: (props: SelectProps) => {
+      harness.selectProps = props;
+
+      return ReactActual.createElement(
+        ReactActual.Fragment,
+        null,
+        props.options.map(option =>
+          ReactActual.createElement(
+            Text,
+            { key: option.value },
+            `${option.label}:${option.value}:${option.description ?? ""}`,
+          ),
+        ),
+      );
+    },
+  };
+});
+
+const SYNC_START = "\x1B[?2026h";
+const SYNC_END = "\x1B[?2026l";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+type TestStdout = PassThrough & {
+  columns: number;
+  isTTY: boolean;
+  rows: number;
+};
+
+function createStreams(): {
+  readonly stdin: TestStdin;
+  readonly stdout: TestStdout;
+} {
+  const stdin = new PassThrough() as TestStdin;
+  const stdout = new PassThrough() as TestStdout;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+
+  stdout.columns = 100;
+  stdout.rows = 24;
+  stdout.isTTY = true;
+  stdout.resume();
+
+  return { stdin, stdout };
+}
+
+function extractLastFrame(output: string): string {
+  let lastFrame: string | null = null;
+  let cursor = 0;
+
+  while (cursor < output.length) {
+    const start = output.indexOf(SYNC_START, cursor);
+    if (start === -1) break;
+
+    const contentStart = start + SYNC_START.length;
+    const end = output.indexOf(SYNC_END, contentStart);
+    if (end === -1) break;
+
+    const frame = output.slice(contentStart, end);
+    if (frame.trim().length > 0) {
+      lastFrame = frame;
+    }
+    cursor = end + SYNC_END.length;
+  }
+
+  return lastFrame ?? output;
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function compactText(text: string): string {
+  return text.replace(/\s+/g, "");
+}
+
+async function renderToggle(props: {
+  currentValue: boolean;
+  isMidConversation?: boolean;
+  onCancel?: () => void;
+  onSelect: (enabled: boolean) => void;
+}): Promise<{
+  readonly getText: () => string;
+  readonly stdin: TestStdin;
+  readonly stdout: TestStdout;
+  readonly unmount: () => Promise<void>;
+}> {
+  const { stdin, stdout } = createStreams();
+  let output = "";
+
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  root.render(<ThinkingToggle {...props} />);
+  await sleep();
+
+  return {
+    getText: () => stripAnsi(extractLastFrame(output)),
+    stdin,
+    stdout,
+    unmount: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    },
+  };
+}
+
+describe("ThinkingToggle coverage swarm row 073", () => {
+  beforeEach(() => {
+    harness.exitState = {
+      keyName: "Ctrl+D",
+      pending: false,
+    };
+    harness.keybindings = {};
+    harness.selectProps = undefined;
+  });
+
+  test("selects immediately outside a mid-conversation change", async () => {
+    const onSelect = vi.fn();
+    const rendered = await renderToggle({
+      currentValue: false,
+      onSelect,
+    });
+
+    try {
+      expect(harness.selectProps).toMatchObject({
+        defaultFocusValue: "false",
+        defaultValue: "false",
+        visibleOptionCount: 2,
+      });
+      expect(harness.selectProps?.options).toEqual([
+        {
+          description: "AgenC will think before responding",
+          label: "Enabled",
+          value: "true",
+        },
+        {
+          description: "AgenC will respond without extended thinking",
+          label: "Disabled",
+          value: "false",
+        },
+      ]);
+
+      const text = compactText(rendered.getText());
+      expect(text).toContain("Enableordisablethinkingforthissession.");
+      expect(text).toContain("Esctoexit");
+      expect(harness.keybindings["confirm:yes"]?.options).toEqual({
+        context: "Confirmation",
+        isActive: false,
+      });
+
+      harness.selectProps?.onChange("true");
+      harness.keybindings["confirm:yes"]?.handler();
+      harness.selectProps?.onCancel?.();
+
+      expect(onSelect).toHaveBeenCalledExactlyOnceWith(true);
+    } finally {
+      await rendered.unmount();
+    }
+  });
+
+  test("uses no to clear pending confirmation before canceling", async () => {
+    const onCancel = vi.fn();
+    const onSelect = vi.fn();
+    const rendered = await renderToggle({
+      currentValue: false,
+      isMidConversation: true,
+      onCancel,
+      onSelect,
+    });
+
+    try {
+      harness.selectProps?.onChange("true");
+      await sleep();
+
+      expect(onSelect).not.toHaveBeenCalled();
+      expect(rendered.getText()).toContain("Do you want to proceed?");
+      expect(compactText(rendered.getText())).toContain("Esctocancel");
+      expect(harness.keybindings["confirm:yes"]?.options?.isActive).toBe(true);
+
+      harness.keybindings["confirm:no"]?.handler();
+      await sleep();
+
+      expect(onCancel).not.toHaveBeenCalled();
+      expect(onSelect).not.toHaveBeenCalled();
+      expect(harness.selectProps?.defaultValue).toBe("false");
+
+      harness.keybindings["confirm:yes"]?.handler();
+      harness.keybindings["confirm:no"]?.handler();
+
+      expect(onSelect).not.toHaveBeenCalled();
+      expect(onCancel).toHaveBeenCalledOnce();
+    } finally {
+      await rendered.unmount();
+    }
+  });
+
+  test("shows exit-pending footer and accepts unchanged mid-conversation value", async () => {
+    harness.exitState = {
+      keyName: "Ctrl+C",
+      pending: true,
+    };
+    const onCancel = vi.fn();
+    const onSelect = vi.fn();
+    const rendered = await renderToggle({
+      currentValue: true,
+      isMidConversation: true,
+      onCancel,
+      onSelect,
+    });
+
+    try {
+      expect(compactText(rendered.getText())).toContain(
+        "PressCtrl+Cagaintoexit",
+      );
+      expect(compactText(rendered.getText())).not.toContain("Esctoexit");
+
+      harness.selectProps?.onChange("true");
+
+      expect(onSelect).toHaveBeenCalledExactlyOnceWith(true);
+      expect(onCancel).not.toHaveBeenCalled();
+      expect(compactText(rendered.getText())).not.toContain(
+        "Doyouwanttoproceed?",
+      );
+    } finally {
+      await rendered.unmount();
+    }
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-074-components-shell-ShellProgressMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-074-components-shell-ShellProgressMessage.test.tsx
@@ -1,0 +1,138 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { describe, expect, test } from 'vitest'
+
+import { ShellProgressMessage } from '../../../src/tui/components/shell/ShellProgressMessage.js'
+import { createRoot } from '../../../src/tui/ink.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestStdout = PassThrough & {
+  columns: number
+  rows: number
+  isTTY: boolean
+}
+
+function createStreams(): {
+  readonly stdin: TestStdin
+  readonly stdout: TestStdout
+} {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough() as TestStdout
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 100
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function normalize(output: string): string {
+  return stripAnsi(output).replace(/\s+/g, ' ')
+}
+
+describe('ShellProgressMessage coverage swarm row 074', () => {
+  test('reuses cached compact output on identical rerenders', async () => {
+    const { stdin, stdout } = createStreams()
+    let output = ''
+
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+    const renderNode = () => (
+      <ShellProgressMessage
+        elapsedTimeSeconds={5}
+        fullOutput={'first\nsecond\nthird'}
+        output={'first\nsecond\nthird'}
+        timeoutMs={undefined}
+        totalBytes={2048}
+        totalLines={undefined}
+        verbose={false}
+      />
+    )
+
+    try {
+      root.render(renderNode())
+      await sleep()
+      root.render(renderNode())
+      await sleep()
+
+      const text = normalize(output)
+      expect(text).toContain('first')
+      expect(text).toContain('second')
+      expect(text).toContain('third')
+      expect(text).toContain('(5s)')
+      expect(text).toContain('2KB')
+      expect(text).not.toContain('lines')
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+
+  test('reuses cached running output on identical rerenders', async () => {
+    const { stdin, stdout } = createStreams()
+    let output = ''
+
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+    const renderNode = () => (
+      <ShellProgressMessage
+        elapsedTimeSeconds={undefined}
+        fullOutput={'\u001b[31m\u001b[0m   '}
+        output={'   '}
+        timeoutMs={undefined}
+        verbose={false}
+      />
+    )
+
+    try {
+      root.render(renderNode())
+      await sleep()
+      root.render(renderNode())
+      await sleep()
+
+      const text = normalize(output)
+      expect(text).toContain('Running')
+      expect(text).not.toContain('timeout')
+      expect(text).not.toContain('lines')
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-075-ink-components-Box.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-075-ink-components-Box.test.tsx
@@ -1,0 +1,209 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { describe, expect, test, vi } from "vitest";
+
+import Box from "../../../src/tui/ink/components/Box.js";
+import Text from "../../../src/tui/ink/components/Text.js";
+import type { DOMElement } from "../../../src/tui/ink/dom.js";
+import { createRoot } from "../../../src/tui/ink/root.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+type TestRoot = Awaited<ReturnType<typeof createRoot>>;
+
+function createTestStreams(): {
+  stdin: TestStdin;
+  stdout: PassThrough;
+} {
+  const stdout = new PassThrough();
+  stdout.resume();
+  (stdout as unknown as { columns: number }).columns = 80;
+  (stdout as unknown as { rows: number }).rows = 24;
+  (stdout as unknown as { isTTY: boolean }).isTTY = true;
+
+  const stdin = new PassThrough() as TestStdin;
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await sleep(10);
+  }
+
+  throw new Error(message);
+}
+
+async function withRoot(
+  run: (root: TestRoot) => Promise<void> | void,
+): Promise<void> {
+  const { stdin, stdout } = createTestStreams();
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  try {
+    await run(root);
+  } finally {
+    root.unmount();
+    stdin.end();
+    stdout.end();
+    await sleep();
+  }
+}
+
+async function requireRef(
+  ref: React.RefObject<DOMElement | null>,
+): Promise<DOMElement> {
+  await waitForCondition(() => ref.current !== null, "Box did not mount");
+  if (!ref.current) throw new Error("Box ref was not attached");
+  return ref.current;
+}
+
+describe("Box coverage swarm row 075", () => {
+  test("forwards defaults, event handlers, attributes, and children to ink-box", async () => {
+    await withRoot(async root => {
+      const boxRef = React.createRef<DOMElement>();
+      const handlers = {
+        onBlur: vi.fn(),
+        onBlurCapture: vi.fn(),
+        onClick: vi.fn(),
+        onFocus: vi.fn(),
+        onFocusCapture: vi.fn(),
+        onKeyDown: vi.fn(),
+        onKeyDownCapture: vi.fn(),
+        onMouseEnter: vi.fn(),
+        onMouseLeave: vi.fn(),
+      };
+
+      root.render(
+        <Box ref={boxRef} autoFocus tabIndex={3} {...handlers}>
+          <Text>content</Text>
+        </Box>,
+      );
+
+      const box = await requireRef(boxRef);
+
+      expect(box.nodeName).toBe("ink-box");
+      expect(box.attributes).toMatchObject({
+        autoFocus: true,
+        tabIndex: 3,
+      });
+      expect(box.style).toMatchObject({
+        flexDirection: "row",
+        flexGrow: 0,
+        flexShrink: 1,
+        flexWrap: "nowrap",
+        overflowX: "visible",
+        overflowY: "visible",
+      });
+      expect(box._eventHandlers).toMatchObject(handlers);
+      expect(box.childNodes.some(child => child.nodeName === "ink-text")).toBe(true);
+    });
+  });
+
+  test("normalizes explicit flex props and overflow fallback precedence", async () => {
+    await withRoot(async root => {
+      const commonOverflowRef = React.createRef<DOMElement>();
+      const axisOverflowRef = React.createRef<DOMElement>();
+
+      root.render(
+        <>
+          <Box
+            ref={commonOverflowRef}
+            flexDirection="column"
+            flexGrow={2}
+            flexShrink={0}
+            flexWrap="wrap"
+            overflow="hidden"
+          >
+            <Text>common</Text>
+          </Box>
+          <Box
+            ref={axisOverflowRef}
+            columnGap={2}
+            gap={1}
+            margin={1}
+            marginBottom={2}
+            marginLeft={3}
+            marginRight={4}
+            marginTop={5}
+            marginX={6}
+            marginY={7}
+            overflow="hidden"
+            overflowX="scroll"
+            overflowY="visible"
+            padding={1}
+            paddingBottom={2}
+            paddingLeft={3}
+            paddingRight={4}
+            paddingTop={5}
+            paddingX={6}
+            paddingY={7}
+            rowGap={3}
+          >
+            <Text>axis</Text>
+          </Box>
+        </>,
+      );
+
+      const commonOverflowBox = await requireRef(commonOverflowRef);
+      const axisOverflowBox = await requireRef(axisOverflowRef);
+
+      expect(commonOverflowBox.style).toMatchObject({
+        flexDirection: "column",
+        flexGrow: 2,
+        flexShrink: 0,
+        flexWrap: "wrap",
+        overflow: "hidden",
+        overflowX: "hidden",
+        overflowY: "hidden",
+      });
+      expect(axisOverflowBox.style).toMatchObject({
+        columnGap: 2,
+        gap: 1,
+        margin: 1,
+        marginBottom: 2,
+        marginLeft: 3,
+        marginRight: 4,
+        marginTop: 5,
+        marginX: 6,
+        marginY: 7,
+        overflow: "hidden",
+        overflowX: "scroll",
+        overflowY: "visible",
+        padding: 1,
+        paddingBottom: 2,
+        paddingLeft: 3,
+        paddingRight: 4,
+        paddingTop: 5,
+        paddingX: 6,
+        paddingY: 7,
+        rowGap: 3,
+      });
+    });
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-076-components-spinner-Spinner.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-076-components-spinner-Spinner.test.tsx
@@ -1,0 +1,403 @@
+import { PassThrough } from "node:stream";
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  activity: {
+    ended: [] as string[],
+    started: [] as string[],
+  },
+  appState: {
+    effortValue: "medium",
+    expandedView: undefined as "tasks" | "teammates" | undefined,
+    isBriefOnly: false,
+    remoteBackgroundTaskCount: 0,
+    remoteConnectionStatus: "connected",
+    selectedIPAgentIndex: 0,
+    tasks: {} as Record<string, any>,
+    viewingAgentTaskId: undefined as string | undefined,
+    viewSelectionMode: "normal",
+  },
+  currentTurnTokenBudget: null as number | null,
+  featureFlags: new Set<string>(),
+  getKairosActive: false,
+  getUserMsgOptIn: false,
+  growthbookBrief: false,
+  localAgents: [] as Array<{ id: string; summary: string }>,
+  outputTokens: 0,
+  settings: {
+    prefersReducedMotion: false,
+    spinnerTipsEnabled: true,
+  } as { prefersReducedMotion?: boolean; spinnerTipsEnabled?: boolean } | undefined,
+  spinnerVerbs: ["Working"] as string[],
+  tasksV2: undefined as any[] | undefined,
+  terminalColumns: 80,
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: (name: string) => harness.featureFlags.has(name),
+}));
+
+vi.mock("../../../src/bootstrap/state.js", () => ({
+  flushInteractionTime: () => {},
+  getCurrentTurnTokenBudget: () => harness.currentTurnTokenBudget,
+  getKairosActive: () => harness.getKairosActive,
+  getTurnOutputTokens: () => harness.outputTokens,
+  getUserMsgOptIn: () => harness.getUserMsgOptIn,
+}));
+
+vi.mock("../../../src/services/analytics/growthbook.js", () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: () => harness.growthbookBrief,
+}));
+
+vi.mock("../../../src/utils/envUtils.js", () => ({
+  isEnvTruthy: (value: string | undefined) => value === "1" || value === "true",
+}));
+
+vi.mock("lodash-es/sample.js", () => ({
+  default: (items: readonly string[]) => items[0],
+}));
+
+vi.mock("../../../src/utils/activityManager.js", () => ({
+  activityManager: {
+    endCLIActivity: (id: string) => {
+      harness.activity.ended.push(id);
+    },
+    startCLIActivity: (id: string) => {
+      harness.activity.started.push(id);
+    },
+  },
+}));
+
+vi.mock("../../../src/constants/spinnerVerbs.js", () => ({
+  getSpinnerVerbs: () => harness.spinnerVerbs,
+}));
+
+vi.mock("../../../src/tui/components/MessageResponse.js", async () => {
+  const ReactModule = await import("react");
+  return {
+    MessageResponse: ({ children }: { children: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+  };
+});
+
+vi.mock("../../../src/tui/components/TaskListV2.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await vi.importActual<typeof import("../../../src/tui/ink.js")>(
+    "../../../src/tui/ink.js",
+  );
+  return {
+    TaskListV2: ({ tasks }: { tasks: Array<{ subject: string }> }) =>
+      ReactModule.createElement(
+        Text,
+        null,
+        `TASKS:${tasks.map(task => task.subject).join(",")}`,
+      ),
+  };
+});
+
+vi.mock("../../../src/tui/hooks/useTasksV2.js", () => ({
+  useTasksV2: () => harness.tasksV2,
+}));
+
+vi.mock("../../../src/tui/state/AppState.js", () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+}));
+
+vi.mock("../../../src/tui/hooks/useTerminalSize.js", () => ({
+  useTerminalSize: () => ({ columns: harness.terminalColumns, rows: 24 }),
+}));
+
+vi.mock("../../../src/tui/hooks/useSettings.js", () => ({
+  useSettings: () => harness.settings,
+}));
+
+vi.mock("../../../src/tasks/InProcessTeammateTask/types.js", () => ({
+  isInProcessTeammateTask: (task: any) => task?.type === "in_process_teammate",
+}));
+
+vi.mock("../../../src/tasks/types.js", () => ({
+  isBackgroundTask: (task: any) => task?.type === "background_task",
+}));
+
+vi.mock("../../../src/tasks/InProcessTeammateTask/InProcessTeammateTask.js", () => ({
+  getAllInProcessTeammateTasks: (tasks: Record<string, any>) =>
+    Object.values(tasks ?? {}).filter(task => task?.type === "in_process_teammate"),
+}));
+
+vi.mock("../../../src/utils/effort.js", () => ({
+  getEffortSuffix: (_model: string, effort: string) => `:${effort}`,
+}));
+
+vi.mock("../../../src/utils/model/model.js", () => ({
+  getMainLoopModel: () => "grok-4.3",
+}));
+
+vi.mock("../../../src/tui/state/selectors.js", () => ({
+  getViewedTeammateTask: ({ viewingAgentTaskId, tasks }: any) =>
+    viewingAgentTaskId ? tasks?.[viewingAgentTaskId] : undefined,
+}));
+
+vi.mock("../../../src/tui/components/spinner/SpinnerAnimationRow.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await vi.importActual<typeof import("../../../src/tui/ink.js")>(
+    "../../../src/tui/ink.js",
+  );
+  return {
+    SpinnerAnimationRow: (props: Record<string, unknown>) =>
+      ReactModule.createElement(
+        Text,
+        null,
+        [
+          "ROW",
+          String(props.mode),
+          String(props.message),
+          `tokens:${String(props.teammateTokens)}`,
+          `teammates:${String(props.hasRunningTeammates)}`,
+          `thinking:${String(props.thinkingStatus)}`,
+          String(props.effortSuffix),
+        ].join("|"),
+      ),
+  };
+});
+
+vi.mock("../../../src/tui/components/spinner/TeammateSpinnerTree.js", async () => {
+  const ReactModule = await import("react");
+  const { Text } = await vi.importActual<typeof import("../../../src/tui/ink.js")>(
+    "../../../src/tui/ink.js",
+  );
+  return {
+    TeammateSpinnerTree: (props: Record<string, unknown>) =>
+      ReactModule.createElement(
+        Text,
+        null,
+        `TREE:${String(props.leaderVerb ?? props.leaderIdleText ?? "")}:${String(props.allIdle)}`,
+      ),
+  };
+});
+
+vi.mock("../../../src/tui/components/spinner/agentActivity.js", () => ({
+  formatRunningAgentSummary: (agents: Array<{ summary: string }>) =>
+    agents.map(agent => agent.summary).join(", "),
+  getActiveLocalAgentTasks: () => harness.localAgents,
+}));
+
+import { createRoot } from "../../../src/tui/ink/root.js";
+import {
+  BriefIdleStatus,
+  SpinnerWithVerb,
+} from "../../../src/tui/components/spinner/Spinner.js";
+
+function makeRef<T>(current: T): React.RefObject<T> {
+  return { current };
+}
+
+function spinnerProps(
+  overrides: Partial<React.ComponentProps<typeof SpinnerWithVerb>> = {},
+): React.ComponentProps<typeof SpinnerWithVerb> {
+  return {
+    loadingStartTimeRef: makeRef(Date.now() - 10_000),
+    mode: "responding",
+    pauseStartTimeRef: makeRef(null),
+    responseLengthRef: makeRef(2048),
+    totalPausedMsRef: makeRef(0),
+    verbose: false,
+    ...overrides,
+  };
+}
+
+function teammate(overrides: Record<string, any> = {}) {
+  return {
+    id: "teammate-1",
+    isIdle: false,
+    startTime: Date.now() - 5_000,
+    status: "running",
+    type: "in_process_teammate",
+    ...overrides,
+  };
+}
+
+async function renderToText(node: React.ReactNode): Promise<string> {
+  let output = "";
+  const stdout = new PassThrough();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number }).columns = harness.terminalColumns;
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  try {
+    root.render(node);
+    await new Promise(resolve => setTimeout(resolve, 30));
+    return stripAnsi(output);
+  } finally {
+    root.unmount();
+    stdin.end();
+    stdout.end();
+  }
+}
+
+beforeEach(() => {
+  harness.activity.ended = [];
+  harness.activity.started = [];
+  harness.appState.effortValue = "medium";
+  harness.appState.expandedView = undefined;
+  harness.appState.isBriefOnly = false;
+  harness.appState.remoteBackgroundTaskCount = 0;
+  harness.appState.remoteConnectionStatus = "connected";
+  harness.appState.selectedIPAgentIndex = 0;
+  harness.appState.tasks = {};
+  harness.appState.viewingAgentTaskId = undefined;
+  harness.appState.viewSelectionMode = "normal";
+  harness.currentTurnTokenBudget = null;
+  harness.featureFlags.clear();
+  harness.getKairosActive = false;
+  harness.getUserMsgOptIn = false;
+  harness.growthbookBrief = false;
+  harness.localAgents = [];
+  harness.outputTokens = 0;
+  harness.settings = {
+    prefersReducedMotion: false,
+    spinnerTipsEnabled: true,
+  };
+  harness.spinnerVerbs = ["Working"];
+  harness.tasksV2 = undefined;
+  harness.terminalColumns = 80;
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("Spinner coverage swarm row 076", () => {
+  test("keeps the full spinner while viewing a teammate in brief-only mode", async () => {
+    harness.featureFlags.add("KAIROS_BRIEF");
+    harness.getKairosActive = true;
+    harness.appState.isBriefOnly = true;
+    harness.appState.viewingAgentTaskId = "teammate-1";
+    harness.appState.tasks = {
+      "teammate-1": teammate(),
+    };
+
+    const output = await renderToText(
+      <SpinnerWithVerb {...spinnerProps({ overrideMessage: "Leader work" })} />,
+    );
+
+    expect(output).toContain("ROW|responding|Working");
+    expect(output).toContain("tokens:0");
+    expect(output).toContain("teammates:true");
+    expect(output).not.toContain("Leader work");
+  });
+
+  test("uses env-enabled brief mode with reconnecting status", async () => {
+    vi.stubEnv("AGENC_BRIEF", "true");
+    harness.featureFlags.add("KAIROS_BRIEF");
+    harness.getUserMsgOptIn = true;
+    harness.appState.isBriefOnly = true;
+    harness.appState.remoteConnectionStatus = "reconnecting";
+    harness.appState.remoteBackgroundTaskCount = 2;
+    harness.spinnerVerbs = [];
+
+    const output = await renderToText(<SpinnerWithVerb {...spinnerProps()} />);
+
+    expect(output).toContain("Reconnecting");
+    expect(output).toContain("2 in background");
+    expect(harness.activity.started).toContain("spinner-responding");
+  });
+
+  test("renders active local agents without replacing the normal spinner row", async () => {
+    harness.localAgents = [
+      { id: "agent-1", summary: "Indexing" },
+      { id: "agent-2", summary: "Testing" },
+    ];
+    harness.settings = {
+      prefersReducedMotion: false,
+      spinnerTipsEnabled: false,
+    };
+
+    const output = await renderToText(
+      <SpinnerWithVerb
+        {...spinnerProps({
+          loadingStartTimeRef: makeRef(Date.now() - 1_900_000),
+        })}
+      />,
+    );
+
+    expect(output).toContain("ROW|responding|Working");
+    expect(output).toContain("Indexing, Testing");
+    expect(output).not.toContain("Tip: Use /clear");
+  });
+
+  test("falls back to the first pending task when every pending task is blocked", async () => {
+    harness.featureFlags.add("TOKEN_BUDGET");
+    harness.currentTurnTokenBudget = 4_000;
+    harness.outputTokens = 3_000;
+    harness.tasksV2 = [
+      {
+        blockedBy: [],
+        id: "current",
+        status: "running",
+        subject: "Reviewing plan",
+      },
+      {
+        blockedBy: ["current"],
+        id: "first-pending",
+        status: "pending",
+        subject: "first blocked",
+      },
+      {
+        blockedBy: ["first-pending"],
+        id: "second-pending",
+        status: "pending",
+        subject: "second blocked",
+      },
+    ];
+
+    const output = await renderToText(
+      <SpinnerWithVerb
+        {...spinnerProps({
+          loadingStartTimeRef: makeRef(Date.now() - 20_000),
+          pauseStartTimeRef: makeRef(Date.now() - 4_000),
+          totalPausedMsRef: makeRef(1_000),
+        })}
+      />,
+    );
+
+    expect(output).toContain("ROW|responding|Reviewing plan");
+    expect(output).toContain("Next: first blocked");
+    expect(output).toContain("Target: 3.0k / 4.0k (75%)");
+  });
+
+  test("prefers plural local agent idle text over background counts", async () => {
+    harness.appState.remoteConnectionStatus = "disconnected";
+    harness.appState.remoteBackgroundTaskCount = 5;
+    harness.localAgents = [
+      { id: "agent-1", summary: "Indexing" },
+      { id: "agent-2", summary: "Testing" },
+    ];
+
+    const output = await renderToText(<BriefIdleStatus />);
+
+    expect(output).toContain("Disconnected");
+    expect(output).toContain("2 agents running");
+    expect(output).not.toContain("5 in background");
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-077-history-history.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-077-history-history.test.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+type Deferred<T = void> = {
+  promise: Promise<T>
+  reject: (error: unknown) => void
+  resolve: (value: T) => void
+}
+
+function deferred<T = void>(): Deferred<T> {
+  let reject!: (error: unknown) => void
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, reject, resolve }
+}
+
+type LogLineInput = {
+  display: string
+  pastedContents?: Record<string, unknown>
+  project?: string
+  sessionId?: string
+  timestamp?: number
+}
+
+const harness = vi.hoisted(() => ({
+  appendFile: vi.fn(async () => {}),
+  configHome: '/tmp/agenc-row-077',
+  debug: vi.fn(),
+  lock: vi.fn(),
+  lockRelease: vi.fn(async () => {}),
+  projectRoot: '/workspace/project',
+  readLines: [] as string[],
+  registerCleanup: vi.fn(),
+  retrievePastedText: vi.fn(async () => null as string | null),
+  sessionId: 'session-current',
+  skipHistory: false,
+  sleep: vi.fn(async () => {}),
+  storePastedText: vi.fn(async () => {}),
+  writeFile: vi.fn(async () => {}),
+}))
+
+vi.mock('fs/promises', () => ({
+  appendFile: harness.appendFile,
+  writeFile: harness.writeFile,
+}))
+
+vi.mock('../../../src/bootstrap/state.js', () => ({
+  getProjectRoot: () => harness.projectRoot,
+  getSessionId: () => harness.sessionId,
+}))
+
+vi.mock('../../../src/utils/cleanupRegistry.js', () => ({
+  registerCleanup: harness.registerCleanup,
+}))
+
+vi.mock('../../../src/utils/debug.js', () => ({
+  logForDebugging: harness.debug,
+}))
+
+vi.mock('../../../src/utils/envUtils.js', () => ({
+  getAgenCConfigHomeDir: () => harness.configHome,
+  isEnvTruthy: () => harness.skipHistory,
+}))
+
+vi.mock('../../../src/utils/errors.js', () => ({
+  getErrnoCode: (error: unknown) =>
+    typeof error === 'object' && error !== null && 'code' in error
+      ? (error as { code?: string }).code
+      : undefined,
+}))
+
+vi.mock('../../../src/utils/fsOperations.js', () => ({
+  readLinesReverse: async function* () {
+    for (const line of harness.readLines) {
+      yield line
+    }
+  },
+}))
+
+vi.mock('../../../src/utils/lockfile.js', () => ({
+  lock: harness.lock,
+}))
+
+vi.mock('../../../src/utils/pasteStore.js', () => ({
+  hashPastedText: (content: string) => `hash:${content.length}`,
+  retrievePastedText: harness.retrievePastedText,
+  storePastedText: harness.storePastedText,
+}))
+
+vi.mock('../../../src/utils/sleep.js', () => ({
+  sleep: harness.sleep,
+}))
+
+vi.mock('../../../src/utils/slowOperations.js', () => ({
+  jsonParse: JSON.parse,
+  jsonStringify: JSON.stringify,
+}))
+
+async function loadHistory(): Promise<
+  typeof import('../../../src/tui/history/history.js')
+> {
+  vi.resetModules()
+  return import('../../../src/tui/history/history.js')
+}
+
+async function collect<T>(iterable: AsyncGenerator<T>): Promise<T[]> {
+  const items: T[] = []
+  for await (const item of iterable) {
+    items.push(item)
+  }
+  return items
+}
+
+function logLine(input: LogLineInput): string {
+  return JSON.stringify({
+    pastedContents: {},
+    project: harness.projectRoot,
+    sessionId: harness.sessionId,
+    timestamp: 1,
+    ...input,
+  })
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  const startedAt = Date.now()
+  let lastError: unknown
+
+  while (Date.now() - startedAt < 1000) {
+    try {
+      assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await new Promise(resolve => setTimeout(resolve, 5))
+    }
+  }
+
+  throw lastError
+}
+
+beforeEach(() => {
+  harness.appendFile.mockReset()
+  harness.appendFile.mockResolvedValue(undefined)
+  harness.configHome = '/tmp/agenc-row-077'
+  harness.debug.mockClear()
+  harness.lock.mockReset()
+  harness.lockRelease.mockReset()
+  harness.lockRelease.mockResolvedValue(undefined)
+  harness.lock.mockResolvedValue(harness.lockRelease)
+  harness.projectRoot = '/workspace/project'
+  harness.readLines = []
+  harness.registerCleanup.mockClear()
+  harness.retrievePastedText.mockClear()
+  harness.retrievePastedText.mockResolvedValue(null)
+  harness.sessionId = 'session-current'
+  harness.skipHistory = false
+  harness.sleep.mockReset()
+  harness.sleep.mockResolvedValue(undefined)
+  harness.storePastedText.mockClear()
+  harness.writeFile.mockReset()
+  harness.writeFile.mockResolvedValue(undefined)
+})
+
+describe('coverage swarm row 077 history module', () => {
+  test('reads pending entries newest first and removes the most recent pending entry', async () => {
+    const writeStarted = deferred<void>()
+    harness.writeFile.mockImplementationOnce(() => writeStarted.promise)
+    const history = await loadHistory()
+
+    history.addToHistory('first pending')
+    history.addToHistory('second pending')
+
+    await Promise.resolve()
+    await expect(collect(history.getHistory())).resolves.toMatchObject([
+      { display: 'second pending', pastedContents: {} },
+      { display: 'first pending', pastedContents: {} },
+    ])
+
+    history.removeLastFromHistory()
+
+    await expect(collect(history.getHistory())).resolves.toMatchObject([
+      { display: 'first pending', pastedContents: {} },
+    ])
+
+    writeStarted.resolve()
+    await waitFor(() => {
+      expect(harness.appendFile).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  test('caps timestamped project history at one hundred unique displays', async () => {
+    harness.readLines = Array.from({ length: 101 }, (_, index) =>
+      logLine({
+        display: `prompt ${index}`,
+        timestamp: 200 - index,
+      }),
+    )
+    const history = await loadHistory()
+
+    const timestamped = await collect(history.getTimestampedHistory())
+
+    expect(timestamped).toHaveLength(100)
+    expect(timestamped[0]).toMatchObject({
+      display: 'prompt 0',
+      timestamp: 200,
+    })
+    expect(timestamped[99]).toMatchObject({
+      display: 'prompt 99',
+      timestamp: 101,
+    })
+  })
+
+  test('drops unresolved stored paste references while preserving empty history entries', async () => {
+    harness.readLines = [
+      logLine({
+        display: 'missing paste content',
+        pastedContents: {
+          1: {
+            contentHash: 'missing-hash',
+            id: 1,
+            type: 'text',
+          },
+          2: {
+            id: 2,
+            type: 'text',
+          },
+        },
+      }),
+    ]
+    const history = await loadHistory()
+
+    await expect(collect(history.makeHistoryReader())).resolves.toEqual([
+      {
+        display: 'missing paste content',
+        pastedContents: {},
+      },
+    ])
+    expect(harness.retrievePastedText).toHaveBeenCalledWith('missing-hash')
+  })
+
+  test('logs write failures and stops retrying after the retry budget', async () => {
+    harness.writeFile.mockRejectedValue(new Error('disk unavailable'))
+    const history = await loadHistory()
+
+    history.addToHistory('retry prompt')
+
+    await waitFor(() => {
+      expect(harness.writeFile).toHaveBeenCalledTimes(6)
+      expect(harness.sleep).toHaveBeenCalledTimes(6)
+    })
+
+    expect(harness.appendFile).not.toHaveBeenCalled()
+    expect(harness.lock).not.toHaveBeenCalled()
+    expect(harness.debug).toHaveBeenCalledTimes(6)
+    expect(harness.debug).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to write prompt history:'),
+    )
+
+    history.clearPendingHistoryEntries()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-078-hooks-usePasteHandler.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-078-hooks-usePasteHandler.test.ts
@@ -1,0 +1,353 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const imagePasteMocks = vi.hoisted(() => ({
+  getImageFromClipboard: vi.fn(),
+  isImageFilePath: vi.fn(),
+  tryReadImageFromPath: vi.fn(),
+}))
+
+const platformMock = vi.hoisted(() => ({
+  current: 'linux' as 'linux' | 'macos' | 'unknown' | 'windows' | 'wsl',
+}))
+
+vi.mock('../../../src/utils/imagePaste.js', () => ({
+  PASTE_THRESHOLD: 800,
+  getImageFromClipboard: imagePasteMocks.getImageFromClipboard,
+  isImageFilePath: imagePasteMocks.isImageFilePath,
+  tryReadImageFromPath: imagePasteMocks.tryReadImageFromPath,
+}))
+
+vi.mock('../../../src/utils/log.js', () => ({
+  logError: vi.fn(),
+}))
+
+vi.mock('../../../src/utils/platform.js', () => ({
+  getPlatform: () => platformMock.current,
+}))
+
+import { createRoot } from '../../../src/tui/ink/root.js'
+import type { InputEvent, Key } from '../../../src/tui/ink.js'
+import type { ImageDimensions } from '../../../src/utils/imageResizer.js'
+import {
+  shouldHandleInputAsPaste,
+  usePasteHandler,
+} from '../../../src/tui/hooks/usePasteHandler.js'
+
+type PasteHandlerProps = Parameters<typeof usePasteHandler>[0]
+type PasteHandlerState = ReturnType<typeof usePasteHandler>
+
+const BASE_KEY: Key = {
+  backspace: false,
+  ctrl: false,
+  delete: false,
+  downArrow: false,
+  end: false,
+  escape: false,
+  fn: false,
+  home: false,
+  leftArrow: false,
+  meta: false,
+  pageDown: false,
+  pageUp: false,
+  return: false,
+  rightArrow: false,
+  shift: false,
+  super: false,
+  tab: false,
+  upArrow: false,
+  wheelDown: false,
+  wheelUp: false,
+}
+
+function createStreams(): {
+  readonly stdout: PassThrough
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 80
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  return { stdin, stdout }
+}
+
+function defaultIsImageFilePath(text: string): boolean {
+  return /\.(png|jpe?g|gif|webp)$/i.test(
+    text.trim().replace(/^['"]|['"]$/g, ''),
+  )
+}
+
+function inputEvent(isPasted: boolean): InputEvent {
+  return {
+    keypress: {
+      isPasted,
+    },
+  } as InputEvent
+}
+
+function key(overrides: Partial<Key> = {}): Key {
+  return { ...BASE_KEY, ...overrides }
+}
+
+async function sleep(ms = 0): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForPasteFlush(): Promise<void> {
+  await sleep(180)
+  await sleep()
+}
+
+async function renderPasteHandler(
+  initialProps: PasteHandlerProps,
+): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly latest: () => PasteHandlerState
+}> {
+  let latest: PasteHandlerState | undefined
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    latest = usePasteHandler(initialProps)
+    return null
+  }
+
+  root.render(React.createElement(Harness))
+  await sleep()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+  }
+}
+
+beforeEach(() => {
+  platformMock.current = 'linux'
+  imagePasteMocks.getImageFromClipboard.mockReset()
+  imagePasteMocks.getImageFromClipboard.mockResolvedValue(null)
+  imagePasteMocks.isImageFilePath.mockReset()
+  imagePasteMocks.isImageFilePath.mockImplementation(defaultIsImageFilePath)
+  imagePasteMocks.tryReadImageFromPath.mockReset()
+  imagePasteMocks.tryReadImageFromPath.mockResolvedValue(null)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('shouldHandleInputAsPaste coverage swarm 078', () => {
+  test('requires a matching handler before treating short non-pasted input as paste', () => {
+    expect(
+      shouldHandleInputAsPaste({
+        hasTextPasteHandler: false,
+        hasImagePasteHandler: false,
+        inputLength: 4,
+        pastePending: true,
+        hasImageFilePath: true,
+        isFromPaste: true,
+      }),
+    ).toBe(false)
+
+    expect(
+      shouldHandleInputAsPaste({
+        hasTextPasteHandler: true,
+        hasImagePasteHandler: false,
+        inputLength: 4,
+        pastePending: true,
+        hasImageFilePath: false,
+        isFromPaste: false,
+      }),
+    ).toBe(true)
+  })
+})
+
+describe('usePasteHandler coverage swarm 078', () => {
+  test('passes ordinary input through without entering paste handling', async () => {
+    const onInput = vi.fn()
+    const onPaste = vi.fn()
+    const rendered = await renderPasteHandler({ onInput, onPaste })
+
+    try {
+      rendered.latest().wrappedOnInput('a', key({ ctrl: true }), inputEvent(false))
+
+      expect(onInput).toHaveBeenCalledTimes(1)
+      expect(onInput).toHaveBeenCalledWith('a', key({ ctrl: true }))
+      expect(onPaste).not.toHaveBeenCalled()
+      expect(rendered.latest().isPasting).toBe(false)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('strips orphaned terminal focus suffixes from pasted text', async () => {
+    const onInput = vi.fn()
+    const onPaste = vi.fn()
+    const rendered = await renderPasteHandler({ onInput, onPaste })
+
+    try {
+      rendered.latest().wrappedOnInput('alpha[I', key(), inputEvent(true))
+      await waitForPasteFlush()
+
+      expect(onPaste).toHaveBeenCalledWith('alpha')
+      expect(onInput).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('routes unreadable image paths back through text paste', async () => {
+    const imagePath = '/tmp/agenc-missing.png'
+    const onImagePaste = vi.fn()
+    const onInput = vi.fn()
+    const onPaste = vi.fn()
+    const rendered = await renderPasteHandler({
+      onImagePaste,
+      onInput,
+      onPaste,
+    })
+
+    try {
+      rendered.latest().wrappedOnInput(imagePath, key(), inputEvent(false))
+      await waitForPasteFlush()
+
+      expect(imagePasteMocks.tryReadImageFromPath).toHaveBeenCalledWith(imagePath)
+      expect(onImagePaste).not.toHaveBeenCalled()
+      expect(onPaste).toHaveBeenCalledTimes(1)
+      expect(onPaste).toHaveBeenCalledWith(imagePath)
+      expect(onInput).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('pastes readable dragged images and preserves non-image text lines', async () => {
+    const dimensions: ImageDimensions = {
+      displayHeight: 12,
+      displayWidth: 20,
+    }
+    imagePasteMocks.tryReadImageFromPath.mockImplementation(
+      async (path: string) => ({
+        base64: `data:${path}`,
+        dimensions,
+        mediaType: 'image/png',
+        path,
+      }),
+    )
+    const onImagePaste = vi.fn()
+    const onInput = vi.fn()
+    const onPaste = vi.fn()
+    const rendered = await renderPasteHandler({
+      onImagePaste,
+      onInput,
+      onPaste,
+    })
+
+    try {
+      rendered
+        .latest()
+        .wrappedOnInput(
+          '/tmp/agenc-one.png\nnote for upload /tmp/agenc-two.jpg',
+          key(),
+          inputEvent(false),
+        )
+      await waitForPasteFlush()
+
+      expect(onImagePaste).toHaveBeenCalledTimes(2)
+      expect(onImagePaste).toHaveBeenNthCalledWith(
+        1,
+        'data:/tmp/agenc-one.png',
+        'image/png',
+        'agenc-one.png',
+        dimensions,
+        '/tmp/agenc-one.png',
+      )
+      expect(onImagePaste).toHaveBeenNthCalledWith(
+        2,
+        'data:/tmp/agenc-two.jpg',
+        'image/png',
+        'agenc-two.jpg',
+        dimensions,
+        '/tmp/agenc-two.jpg',
+      )
+      expect(onPaste).toHaveBeenCalledWith('note for upload')
+      expect(onInput).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('falls back to clipboard image data for expired macOS screenshots', async () => {
+    platformMock.current = 'macos'
+    const dimensions: ImageDimensions = {
+      displayHeight: 32,
+      displayWidth: 40,
+    }
+    imagePasteMocks.getImageFromClipboard.mockResolvedValue({
+      base64: 'clipboard-image',
+      dimensions,
+      mediaType: 'image/png',
+    })
+    const onImagePaste = vi.fn()
+    const onInput = vi.fn()
+    const onPaste = vi.fn()
+    const rendered = await renderPasteHandler({
+      onImagePaste,
+      onInput,
+      onPaste,
+    })
+
+    try {
+      rendered
+        .latest()
+        .wrappedOnInput(
+          '/private/var/folders/x/T/TemporaryItems/com.apple.screencaptureui/session/Screenshot 2026-05-20 at 1.00.00 PM.png',
+          key(),
+          inputEvent(false),
+        )
+      await waitForPasteFlush()
+
+      expect(imagePasteMocks.getImageFromClipboard).toHaveBeenCalledTimes(1)
+      expect(onImagePaste).toHaveBeenCalledWith(
+        'clipboard-image',
+        'image/png',
+        undefined,
+        dimensions,
+      )
+      expect(onPaste).not.toHaveBeenCalled()
+      expect(onInput).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-079-ink-events-input-event.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-079-ink-events-input-event.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from 'vitest'
+
+import { InputEvent } from '../../../src/tui/ink/events/input-event.ts'
+import type { ParsedKey } from '../../../src/tui/ink/parse-keypress.ts'
+
+function keypress(overrides: Partial<ParsedKey> = {}): ParsedKey {
+  return {
+    kind: 'key',
+    name: '',
+    fn: false,
+    ctrl: false,
+    meta: false,
+    shift: false,
+    option: false,
+    super: false,
+    sequence: '',
+    raw: '',
+    isPasted: false,
+    ...overrides,
+  }
+}
+
+describe('InputEvent coverage swarm row 079', () => {
+  test('maps parsed key names and modifiers onto the public key shape', () => {
+    const namedKeys: Array<[ParsedKey['name'], keyof InputEvent['key']]> = [
+      ['up', 'upArrow'],
+      ['down', 'downArrow'],
+      ['left', 'leftArrow'],
+      ['right', 'rightArrow'],
+      ['pagedown', 'pageDown'],
+      ['pageup', 'pageUp'],
+      ['wheelup', 'wheelUp'],
+      ['wheeldown', 'wheelDown'],
+      ['home', 'home'],
+      ['end', 'end'],
+      ['return', 'return'],
+      ['escape', 'escape'],
+      ['tab', 'tab'],
+      ['backspace', 'backspace'],
+      ['delete', 'delete'],
+    ]
+
+    for (const [name, property] of namedKeys) {
+      const event = new InputEvent(keypress({ name, sequence: `\x1b-${name}` }))
+
+      expect(event.key[property], name).toBe(true)
+      expect(event.input, name).toBe('')
+    }
+
+    const modified = new InputEvent(
+      keypress({
+        ctrl: true,
+        fn: true,
+        meta: true,
+        name: 'x',
+        shift: true,
+        super: true,
+      }),
+    )
+
+    expect(modified.key).toEqual(
+      expect.objectContaining({
+        ctrl: true,
+        fn: true,
+        meta: true,
+        shift: true,
+        super: true,
+      }),
+    )
+    expect(modified.input).toBe('x')
+  })
+
+  test('normalizes missing, control, uppercase, option, and escape input', () => {
+    expect(new InputEvent(keypress({ sequence: undefined })).input).toBe('')
+    expect(
+      new InputEvent(keypress({ ctrl: true, name: 'space', sequence: 'ignored' }))
+        .input,
+    ).toBe(' ')
+    expect(new InputEvent(keypress({ ctrl: true, name: 'c' })).input).toBe('c')
+
+    const uppercase = new InputEvent(
+      keypress({ name: 'a', sequence: 'A', shift: false }),
+    )
+    expect(uppercase.input).toBe('A')
+    expect(uppercase.key.shift).toBe(true)
+
+    expect(
+      new InputEvent(
+        keypress({ name: 'up', option: true, sequence: '\x1b\x1b[A' }),
+      ).key.meta,
+    ).toBe(true)
+    expect(new InputEvent(keypress({ name: 'escape' })).key.meta).toBe(true)
+  })
+
+  test('suppresses malformed function-key and orphaned mouse fragments', () => {
+    expect(
+      new InputEvent(
+        keypress({ code: '[25~', name: undefined, sequence: '\x1b[25~' }),
+      ).input,
+    ).toBe('')
+
+    expect(
+      new InputEvent(keypress({ name: '', sequence: '[<64;74;16M' })).input,
+    ).toBe('')
+    expect(
+      new InputEvent(keypress({ name: '', sequence: '[<65;10;5m' })).input,
+    ).toBe('')
+  })
+
+  test('converts CSI-u and modifyOtherKeys payloads to text input safely', () => {
+    const csiCases: Array<[string | undefined, string, string]> = [
+      ['b', '\x1b[98;3u', 'b'],
+      ['space', '\x1b[32;5u', ' '],
+      ['escape', '\x1b[27;5u', ''],
+      [undefined, '\x1b[57358u', ''],
+      ['return', '\x1b[13;2u', 'return'],
+    ]
+
+    for (const [name, sequence, expected] of csiCases) {
+      expect(new InputEvent(keypress({ name, sequence })).input).toBe(expected)
+    }
+
+    const modifyOtherKeysCases: Array<[string | undefined, string, string]> = [
+      ['b', '\x1b[27;3;98~', 'b'],
+      ['space', '\x1b[27;5;32~', ' '],
+      ['escape', '\x1b[27;5;27~', ''],
+      [undefined, '\x1b[27;5;0~', ''],
+    ]
+
+    for (const [name, sequence, expected] of modifyOtherKeysCases) {
+      expect(new InputEvent(keypress({ name, sequence })).input).toBe(expected)
+    }
+  })
+
+  test('preserves application keypad printable input instead of clearing it', () => {
+    expect(new InputEvent(keypress({ name: '0', sequence: '\x1bOp' })).input).toBe(
+      '0',
+    )
+    expect(new InputEvent(keypress({ name: '+', sequence: '\x1bOk' })).input).toBe(
+      '+',
+    )
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-080-components-PromptInput-PromptInputFooterSuggestions.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-080-components-PromptInput-PromptInputFooterSuggestions.test.tsx
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from 'src/utils/staticRender.js'
+import {
+  PromptInputFooterSuggestions,
+  type SuggestionItem,
+  type SuggestionType,
+} from 'src/tui/components/PromptInput/PromptInputFooterSuggestions.js'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+beforeEach(() => {
+  vi.stubEnv('AGENC_TUI_GLYPHS', 'ascii')
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+function renderSuggestions(
+  suggestions: SuggestionItem[],
+  options: {
+    columns?: number
+    overlay?: boolean
+    rows?: number
+    selectedSuggestion?: number
+    suggestionType?: SuggestionType
+  } = {},
+): Promise<string> {
+  return renderToString(
+    <PromptInputFooterSuggestions
+      suggestions={suggestions}
+      selectedSuggestion={options.selectedSuggestion ?? 0}
+      overlay={options.overlay}
+      suggestionType={options.suggestionType}
+    />,
+    {
+      columns: options.columns ?? 80,
+      rows: options.rows ?? 20,
+    },
+  )
+}
+
+describe('PromptInputFooterSuggestions coverage swarm row 080', () => {
+  test('renders nothing for empty suggestions', async () => {
+    await expect(renderSuggestions([]).then(output => output.trim())).resolves.toBe('')
+  })
+
+  test.each([
+    ['shell', 'SHELL COMPLETIONS', 'shell', 'complete'],
+    ['custom-title', 'SESSION TITLES', 'session', 'resume'],
+    ['slack-channel', 'SLACK CHANNELS', 'channel', 'mention'],
+    ['none', 'SUGGESTIONS', 'suggestion', 'select'],
+  ] as const)(
+    'renders explicit %s copy in the header and keyboard hint',
+    async (suggestionType, title, label, acceptVerb) => {
+      const output = await renderSuggestions(
+        [
+          {
+            id: `${suggestionType}-first`,
+            displayText: 'candidate',
+            description: 'Primary candidate',
+          },
+        ],
+        { suggestionType },
+      )
+
+      expect(output).toContain(title)
+      expect(output).toContain('1 match')
+      expect(output).toContain(label)
+      expect(output).toContain(`navigate ^v - ${acceptVerb} Enter`)
+    },
+  )
+
+  test('infers directory suggestions and uses terminal height for inline overflow', async () => {
+    const suggestions: SuggestionItem[] = Array.from(
+      { length: 4 },
+      (_, index) => ({
+        id: `directory-${index}`,
+        displayText: `dir-${index}`,
+        description: `Directory   number ${index}`,
+      }),
+    )
+
+    const output = await renderSuggestions(suggestions, {
+      columns: 64,
+      rows: 4,
+      selectedSuggestion: 2,
+    })
+
+    expect(output).toContain('DIRECTORIES')
+    expect(output).toContain('4 matches')
+    expect(output).toContain('directory')
+    expect(output).toContain('navigate ^v - insert Enter')
+    expect(output).toContain('^ 2 more above')
+    expect(output).toContain('v 1 more below')
+    expect(output).toContain('> dir-2')
+    expect(output).toContain('Directory number 2')
+    expect(output).not.toContain('dir-0')
+    expect(output).not.toContain('dir-3')
+  })
+
+  test('truncates long file paths and keeps unified rows single-line', async () => {
+    const longPath =
+      '/repo/packages/deep/nested/src/components/VeryLongComponentFileName.tsx'
+    const output = await renderSuggestions(
+      [
+        {
+          id: 'file-long',
+          displayText: longPath,
+          description: 'Detailed   TypeScript   component file',
+        },
+        {
+          id: 'file-readme',
+          displayText: 'README.md',
+        },
+      ],
+      {
+        columns: 80,
+        selectedSuggestion: 0,
+      },
+    )
+
+    expect(output).toContain('FILES & RESOURCES')
+    expect(output).toContain('> + ')
+    expect(output).toContain(' - Detailed TypeScript')
+    expect(output).toContain('  + README.md')
+    expect(output).not.toContain(longPath)
+  })
+
+  test('keeps fallback suggestions usable with an out-of-range selection', async () => {
+    const output = await renderSuggestions(
+      [
+        {
+          id: 'custom-alpha',
+          displayText: 'alpha',
+          tag: 'hot',
+          description: 'Alpha   branch   details',
+          color: 'success',
+        },
+        {
+          id: 'custom-beta',
+          displayText: 'beta',
+          description: 'Beta branch details',
+        },
+      ],
+      {
+        selectedSuggestion: 99,
+      },
+    )
+
+    expect(output).toContain('SUGGESTIONS')
+    expect(output).toContain('2 matches')
+    expect(output).toContain('navigate ^v - select Enter')
+    expect(output).toContain('[hot] Alpha branch details')
+    expect(output).toContain('beta')
+    expect(output).not.toContain('> alpha')
+    expect(output).not.toContain('> beta')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-081-keybindings-loadUserBindings.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-081-keybindings-loadUserBindings.test.ts
@@ -1,0 +1,208 @@
+import { mkdtemp, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => {
+  const state = {
+    cleanup: undefined as undefined | (() => Promise<void>),
+    closeWatcher: vi.fn(async () => undefined),
+    debug: vi.fn(),
+    handlers: new Map<string, (path: string) => void | Promise<void>>(),
+    readFile: vi.fn(),
+    registerCleanup: undefined as unknown as ReturnType<typeof vi.fn>,
+    watch: undefined as unknown as ReturnType<typeof vi.fn>,
+  }
+
+  state.registerCleanup = vi.fn((cleanup: () => Promise<void>) => {
+    state.cleanup = cleanup
+    return () => {
+      if (state.cleanup === cleanup) {
+        state.cleanup = undefined
+      }
+    }
+  })
+
+  state.watch = vi.fn(() => ({
+    close: state.closeWatcher,
+    on(event: string, handler: (path: string) => void | Promise<void>) {
+      state.handlers.set(event, handler)
+      return this
+    },
+  }))
+
+  return state
+})
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('fs/promises', async () => {
+  const actual = await vi.importActual<typeof import('fs/promises')>(
+    'fs/promises',
+  )
+
+  harness.readFile.mockImplementation((...args: unknown[]) =>
+    actual.readFile(...(args as Parameters<typeof actual.readFile>)),
+  )
+
+  return {
+    ...actual,
+    readFile: harness.readFile,
+  }
+})
+
+vi.mock('chokidar', () => ({
+  default: { watch: harness.watch },
+  watch: harness.watch,
+}))
+
+vi.mock('../../../src/utils/cleanupRegistry.js', () => ({
+  registerCleanup: harness.registerCleanup,
+}))
+
+vi.mock('../../../src/utils/debug.js', () => ({
+  logForDebugging: harness.debug,
+}))
+
+import {
+  disposeKeybindingWatcher,
+  getCachedKeybindingWarnings,
+  getKeybindingsPath,
+  initializeKeybindingWatcher,
+  loadKeybindings,
+  loadKeybindingsSyncWithWarnings,
+  resetKeybindingLoaderForTesting,
+  subscribeToKeybindingChanges,
+} from '../../../src/tui/keybindings/loadUserBindings.ts'
+
+const originalConfigDir = process.env.AGENC_CONFIG_DIR
+const tempDirs: string[] = []
+
+async function createConfigDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'agenc-keybindings-row081-'))
+  tempDirs.push(dir)
+  process.env.AGENC_CONFIG_DIR = dir
+  resetKeybindingLoaderForTesting()
+  return dir
+}
+
+async function writeKeybindings(content: string): Promise<void> {
+  await writeFile(getKeybindingsPath(), content)
+}
+
+beforeEach(() => {
+  harness.cleanup = undefined
+  harness.closeWatcher.mockClear()
+  harness.debug.mockClear()
+  harness.handlers.clear()
+  harness.readFile.mockClear()
+  harness.registerCleanup.mockClear()
+  harness.watch.mockClear()
+  process.env.AGENC_CONFIG_DIR = originalConfigDir
+  resetKeybindingLoaderForTesting()
+})
+
+afterEach(async () => {
+  disposeKeybindingWatcher()
+  resetKeybindingLoaderForTesting()
+  if (originalConfigDir === undefined) {
+    delete process.env.AGENC_CONFIG_DIR
+  } else {
+    process.env.AGENC_CONFIG_DIR = originalConfigDir
+  }
+  await Promise.all(
+    tempDirs.splice(0).map(dir => rm(dir, { force: true, recursive: true })),
+  )
+})
+
+describe('loadUserBindings coverage swarm row 081', () => {
+  test('reports sync shape errors for non-array and malformed block variants', async () => {
+    await createConfigDir()
+
+    await writeKeybindings('{"bindings":{}}')
+    let result = loadKeybindingsSyncWithWarnings()
+
+    expect(result.bindings.length).toBeGreaterThan(0)
+    expect(result.warnings).toEqual([
+      expect.objectContaining({
+        message: '"bindings" must be an array',
+        severity: 'error',
+        suggestion: 'Set "bindings" to an array of keybinding blocks',
+        type: 'parse_error',
+      }),
+    ])
+    expect(getCachedKeybindingWarnings()).toBe(result.warnings)
+
+    resetKeybindingLoaderForTesting()
+    await writeKeybindings('{"bindings":[{"context":"Chat","bindings":null}]}')
+    result = loadKeybindingsSyncWithWarnings()
+
+    expect(result.warnings).toEqual([
+      expect.objectContaining({
+        message: 'keybindings.json contains invalid block structure',
+        suggestion: 'Each block must have "context" (string) and "bindings" (object)',
+        type: 'parse_error',
+      }),
+    ])
+    expect(getCachedKeybindingWarnings()).toBe(result.warnings)
+  })
+
+  test('formats non-Error async read failures as parse warnings', async () => {
+    await createConfigDir()
+    harness.readFile.mockRejectedValueOnce('permission denied as string')
+
+    const result = await loadKeybindings()
+
+    expect(result.bindings.length).toBeGreaterThan(0)
+    expect(result.warnings).toEqual([
+      expect.objectContaining({
+        message:
+          'Failed to parse keybindings.json: permission denied as string',
+        severity: 'error',
+        type: 'parse_error',
+      }),
+    ])
+    expect(harness.debug).toHaveBeenCalledWith(
+      expect.stringContaining('permission denied as string'),
+    )
+  })
+
+  test('does not start a watcher after disposal before initialization', async () => {
+    await createConfigDir()
+    disposeKeybindingWatcher()
+
+    await initializeKeybindingWatcher()
+
+    expect(harness.watch).not.toHaveBeenCalled()
+    expect(harness.registerCleanup).not.toHaveBeenCalled()
+  })
+
+  test('logs reload failures from keybinding change subscribers', async () => {
+    await createConfigDir()
+    await initializeKeybindingWatcher()
+    await writeKeybindings(`{
+      "bindings": [
+        {
+          "context": "Chat",
+          "bindings": {
+            "ctrl+y": "chat:newline"
+          }
+        }
+      ]
+    }`)
+
+    subscribeToKeybindingChanges(() => {
+      throw new Error('subscriber failed')
+    })
+
+    await expect(
+      harness.handlers.get('add')?.(getKeybindingsPath()),
+    ).resolves.toBeUndefined()
+
+    expect(harness.debug).toHaveBeenCalledWith(
+      expect.stringContaining('[keybindings] Error reloading: subscriber failed'),
+    )
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-082-hooks-notifs-useMcpConnectivityStatus.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-082-hooks-notifs-useMcpConnectivityStatus.test.tsx
@@ -1,0 +1,228 @@
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { MCPServerConnection } from '../../../src/services/mcp/types.js'
+
+const harness = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  agencAiConnected: false,
+  logError: vi.fn(),
+  remoteMode: false,
+}))
+
+vi.mock('react-compiler-runtime', () => ({
+  c: (size: number) => new Array(size),
+}))
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react')
+  return {
+    ...actual,
+    useEffect: (effect: () => void | (() => void)) => {
+      effect()
+    },
+  }
+})
+
+vi.mock('../../../src/tui/context/notifications.js', () => ({
+  useNotifications: () => ({
+    addNotification: harness.addNotification,
+  }),
+}))
+
+vi.mock('../../../src/bootstrap/state.js', () => ({
+  getIsRemoteMode: () => harness.remoteMode,
+}))
+
+vi.mock('../../../src/services/mcp/agencai.js', () => ({
+  hasAgenCAiMcpEverConnected: () => harness.agencAiConnected,
+}))
+
+vi.mock('../../../src/tui/ink.js', async () => {
+  const ReactModule = await vi.importActual<typeof import('react')>('react')
+  return {
+    Text: ({ children }: { readonly children?: ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+  }
+})
+
+vi.mock('../../../src/utils/log.js', () => ({
+  logError: harness.logError,
+}))
+
+import { useMcpConnectivityStatus } from '../../../src/tui/hooks/notifs/useMcpConnectivityStatus.js'
+
+function scopedConfig(type: string): MCPServerConnection['config'] {
+  if (type === 'stdio') {
+    return {
+      type: 'stdio',
+      command: 'node',
+      args: [],
+      scope: 'user',
+    }
+  }
+
+  return {
+    type,
+    url: `https://${type}.example.test`,
+    scope: 'user',
+  } as MCPServerConnection['config']
+}
+
+function failedClient(
+  name: string,
+  configType: string = 'stdio',
+): MCPServerConnection {
+  return {
+    type: 'failed',
+    name,
+    config: scopedConfig(configType),
+    error: 'connection failed',
+  }
+}
+
+function needsAuthClient(
+  name: string,
+  configType: string = 'http',
+): MCPServerConnection {
+  return {
+    type: 'needs-auth',
+    name,
+    config: scopedConfig(configType),
+  }
+}
+
+function connectedClient(name: string): MCPServerConnection {
+  return {
+    type: 'connected',
+    name,
+    config: scopedConfig('stdio'),
+    capabilities: {},
+    client: {} as MCPServerConnection['client'],
+    cleanup: vi.fn(),
+  } as MCPServerConnection
+}
+
+function runHook(mcpClients?: readonly MCPServerConnection[]): void {
+  useMcpConnectivityStatus({
+    mcpClients: mcpClients as MCPServerConnection[] | undefined,
+  })
+}
+
+describe('useMcpConnectivityStatus swarm coverage 082', () => {
+  beforeEach(() => {
+    harness.addNotification.mockReset()
+    harness.agencAiConnected = false
+    harness.logError.mockReset()
+    harness.remoteMode = false
+  })
+
+  test('does not notify for default, remote, or non-actionable client lists', () => {
+    runHook()
+    expect(harness.addNotification).not.toHaveBeenCalled()
+
+    harness.remoteMode = true
+    runHook([failedClient('files')])
+    expect(harness.addNotification).not.toHaveBeenCalled()
+
+    harness.remoteMode = false
+    runHook([
+      connectedClient('connected'),
+      {
+        type: 'pending',
+        name: 'pending',
+        config: scopedConfig('stdio'),
+      },
+      {
+        type: 'disabled',
+        name: 'disabled',
+        config: scopedConfig('stdio'),
+      },
+      failedClient('ide-sse', 'sse-ide'),
+      failedClient('ide-ws', 'ws-ide'),
+    ])
+
+    expect(harness.addNotification).not.toHaveBeenCalled()
+    expect(harness.logError).not.toHaveBeenCalled()
+  })
+
+  test('adds separate local failure and local auth notifications', () => {
+    runHook([failedClient('files'), needsAuthClient('calendar')])
+
+    expect(harness.addNotification).toHaveBeenCalledTimes(2)
+    expect(harness.addNotification).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        key: 'mcp-failed',
+        priority: 'medium',
+      }),
+    )
+    expect(harness.addNotification).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        key: 'mcp-needs-auth',
+        priority: 'medium',
+      }),
+    )
+    expect(harness.logError).not.toHaveBeenCalled()
+  })
+
+  test('adds agenc.tech connector notifications only after a connector has connected before', () => {
+    runHook([failedClient('remote-files', 'agencai-proxy')])
+    expect(harness.addNotification).not.toHaveBeenCalled()
+
+    harness.agencAiConnected = true
+    runHook([
+      failedClient('remote-files', 'agencai-proxy'),
+      needsAuthClient('remote-calendar', 'agencai-proxy'),
+    ])
+
+    expect(harness.addNotification).toHaveBeenCalledTimes(2)
+    expect(harness.addNotification).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        key: 'mcp-agencai-failed',
+      }),
+    )
+    expect(harness.addNotification).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        key: 'mcp-agencai-needs-auth',
+      }),
+    )
+  })
+
+  test('uses plural notification branches for multiple local failures and auth prompts', () => {
+    runHook([
+      failedClient('files'),
+      failedClient('search'),
+      needsAuthClient('calendar'),
+      needsAuthClient('docs'),
+    ])
+
+    expect(harness.addNotification).toHaveBeenCalledTimes(2)
+    expect(harness.addNotification).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        key: 'mcp-failed',
+      }),
+    )
+    expect(harness.addNotification).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        key: 'mcp-needs-auth',
+      }),
+    )
+  })
+
+  test('logs notification errors thrown during status processing', () => {
+    const error = new Error('notification failed')
+    harness.addNotification.mockImplementationOnce(() => {
+      throw error
+    })
+
+    runHook([failedClient('files')])
+
+    expect(harness.logError).toHaveBeenCalledWith(error)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-083-message-renderers-UserToolResultMessage-UserToolResultMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-083-message-renderers-UserToolResultMessage-UserToolResultMessage.test.tsx
@@ -1,0 +1,178 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+import type { Tool, Tools } from '../../../src/tools/Tool.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+import { REJECT_MESSAGE } from '../../../src/utils/messages.js'
+import { Text } from '../../../src/tui/ink.js'
+import {
+  formatOrphanToolResultContent,
+  UserToolResultMessage,
+} from '../../../src/tui/message-renderers/UserToolResultMessage/UserToolResultMessage.js'
+
+function createMessage(toolUseID: string) {
+  return {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: toolUseID,
+          content: 'persisted result',
+        },
+      ],
+    },
+    toolUseResult: { summary: 'persisted summary' },
+  } as never
+}
+
+function createLookups(toolUse?: {
+  readonly id: string
+  readonly name: string
+  readonly input: Record<string, unknown>
+}) {
+  return {
+    inProgressHookCounts: new Map(),
+    resolvedHookCounts: new Map(),
+    toolUseByToolUseID: new Map(
+      toolUse === undefined ? [] : [[toolUse.id, toolUse]],
+    ),
+  } as never
+}
+
+describe('UserToolResultMessage swarm-083 coverage', () => {
+  test('formats orphan tool result content from denials, arrays, nullish, and scalar values', () => {
+    expect(formatOrphanToolResultContent({ error: 'rejected by user' })).toBe(
+      'Permission request denied by user.',
+    )
+    expect(formatOrphanToolResultContent('plain recovered output')).toBe(
+      'plain recovered output',
+    )
+    expect(
+      formatOrphanToolResultContent([
+        'first line',
+        { type: 'text', text: 'second line' },
+        { type: 'image', source: { media_type: 'image/png', data: 'abc' } },
+        { text: 123 },
+      ]),
+    ).toBe(
+      'first line\nsecond line\n{"type":"image","source":{"media_type":"image/png","data":"abc"}}\n{"text":123}',
+    )
+    expect(formatOrphanToolResultContent(null)).toBe('')
+    expect(formatOrphanToolResultContent(42 as never)).toBe('42')
+  })
+
+  test('renders recovered orphan results without a matching tool call', async () => {
+    const output = await renderToString(
+      <UserToolResultMessage
+        param={{
+          type: 'tool_result',
+          tool_use_id: 'toolu_swarm_083_orphan',
+          content: [
+            { type: 'text', text: 'restored text' },
+            { type: 'json', value: 7 },
+          ],
+        }}
+        message={createMessage('toolu_swarm_083_orphan')}
+        lookups={createLookups()}
+        progressMessagesForMessage={[]}
+        tools={[]}
+        verbose={false}
+        width={60}
+      />,
+      { columns: 100, rows: 10 },
+    )
+
+    expect(output).toContain('Tool result recovered without matching tool call:')
+    expect(output).toContain('restored text')
+    expect(output).toContain('{"type":"json","value":7}')
+  })
+
+  test('routes orphan error results through the fallback error renderer', async () => {
+    const output = await renderToString(
+      <UserToolResultMessage
+        param={{
+          type: 'tool_result',
+          tool_use_id: 'toolu_swarm_083_orphan_error',
+          content: 'orphan failure',
+          is_error: true,
+        }}
+        message={createMessage('toolu_swarm_083_orphan_error')}
+        lookups={createLookups()}
+        progressMessagesForMessage={[]}
+        tools={[]}
+        verbose={true}
+        width={60}
+      />,
+      { columns: 100, rows: 10 },
+    )
+
+    expect(output).toContain('Error: orphan failure')
+  })
+
+  test('routes matched rejected tool results by reject-message prefix', async () => {
+    const toolUse = {
+      id: 'toolu_swarm_083_reject',
+      name: 'SwarmRejectTool',
+      input: { path: 'runtime/src/rejected.ts' },
+    }
+    const renderToolUseRejectedMessage = vi.fn(
+      (
+        input: { path: string },
+        options: {
+          readonly progressMessagesForMessage: ReadonlyArray<unknown>
+          readonly style?: string
+          readonly verbose?: boolean
+          readonly isTranscriptMode?: boolean
+        },
+      ) => (
+        <Text>
+          rejected {input.path} progress:
+          {options.progressMessagesForMessage.length} style:{options.style}{' '}
+          verbose:{String(options.verbose)} transcript:
+          {String(options.isTranscriptMode)}
+        </Text>
+      ),
+    )
+    const tool = {
+      name: 'SwarmRejectTool',
+      inputSchema: {
+        safeParse: (input: unknown) => ({ success: true, data: input }),
+      },
+      renderToolUseRejectedMessage,
+    } as unknown as Tool
+    const tools = [tool] as Tools
+
+    const output = await renderToString(
+      <UserToolResultMessage
+        param={{
+          type: 'tool_result',
+          tool_use_id: toolUse.id,
+          content: `${REJECT_MESSAGE} extra context`,
+        }}
+        message={createMessage(toolUse.id)}
+        lookups={createLookups(toolUse)}
+        progressMessagesForMessage={[
+          { data: { type: 'hook_progress', hookEvent: 'PreToolUse' } },
+          { data: { type: 'tool_progress', text: 'visible progress' } },
+        ] as never}
+        style="condensed"
+        tools={tools}
+        verbose={true}
+        width={72}
+        isTranscriptMode={true}
+      />,
+      { columns: 120, rows: 10 },
+    )
+
+    expect(output).toContain(
+      'rejected runtime/src/rejected.ts progress:1 style:condensed verbose:true transcript:true',
+    )
+    expect(renderToolUseRejectedMessage).toHaveBeenCalledTimes(1)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-084-context-stats.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-084-context-stats.test.tsx
@@ -1,0 +1,263 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { saveCurrentProjectConfig } from "src/utils/config.js";
+import { createRoot, Text } from "src/tui/ink.js";
+import {
+  createStatsStore,
+  StatsProvider,
+  useCounter,
+  useGauge,
+  useSet,
+  useStats,
+  useTimer,
+  type StatsStore,
+} from "src/tui/context/stats.js";
+
+vi.mock("src/utils/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("src/utils/config.js")>();
+  return {
+    ...actual,
+    saveCurrentProjectConfig: vi.fn(),
+  };
+});
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+function createStreams(): {
+  readonly stdin: TestStdin;
+  readonly stdout: PassThrough;
+} {
+  const stdin = new PassThrough() as TestStdin;
+  const stdout = new PassThrough();
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  Object.assign(stdout, {
+    columns: 120,
+    isTTY: true,
+    rows: 24,
+  });
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 10): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  const started = Date.now();
+  let lastError: unknown;
+
+  while (Date.now() - started < 1_000) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await sleep();
+    }
+  }
+
+  throw lastError;
+}
+
+function OutsideStatsProbe(): React.ReactNode {
+  useStats();
+  return <Text>outside</Text>;
+}
+
+type HookSnapshot = {
+  readonly stable: boolean | null;
+  readonly tick: number;
+};
+
+function HookProbe({
+  snapshots,
+}: {
+  readonly snapshots: HookSnapshot[];
+}): React.ReactNode {
+  const [tick, setTick] = React.useState(0);
+  const count = useCounter("counter.metric");
+  const gauge = useGauge("gauge.metric");
+  const timer = useTimer("timer.metric");
+  const addToSet = useSet("set.metric");
+  const previous = React.useRef<{
+    readonly addToSet: typeof addToSet;
+    readonly count: typeof count;
+    readonly gauge: typeof gauge;
+    readonly timer: typeof timer;
+  } | null>(null);
+
+  React.useEffect(() => {
+    snapshots.push({
+      stable:
+        previous.current === null
+          ? null
+          : previous.current.count === count &&
+            previous.current.gauge === gauge &&
+            previous.current.timer === timer &&
+            previous.current.addToSet === addToSet,
+      tick,
+    });
+    previous.current = { addToSet, count, gauge, timer };
+    if (tick === 0) {
+      setTick(1);
+    }
+  }, [addToSet, count, gauge, snapshots, tick, timer]);
+
+  React.useEffect(() => {
+    if (tick !== 1) return;
+    count(2);
+    gauge(7);
+    timer(13);
+    addToSet("agent");
+  }, [addToSet, count, gauge, tick, timer]);
+
+  return <Text>{String(tick)}</Text>;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.mocked(saveCurrentProjectConfig).mockClear();
+});
+
+describe("stats context coverage swarm row 084", () => {
+  test("keeps an unsampled overflow observation out of reservoir percentiles", () => {
+    const random = vi.spyOn(Math, "random").mockReturnValue(0.999_999);
+    const store = createStatsStore();
+
+    for (let i = 0; i < 1_024; i += 1) {
+      store.observe("latency", 100);
+    }
+    store.observe("latency", 1);
+
+    expect(store.getAll()).toMatchObject({
+      latency_avg: (1_024 * 100 + 1) / 1_025,
+      latency_count: 1_025,
+      latency_max: 100,
+      latency_min: 1,
+      latency_p50: 100,
+      latency_p95: 100,
+      latency_p99: 100,
+    });
+    expect(random).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses an internal store, skips empty exit flushes, and removes the listener", async () => {
+    const before = new Set(process.listeners("exit"));
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    let exitListener: NodeJS.ExitListener | undefined;
+    try {
+      root.render(
+        <StatsProvider>
+          <Text>empty</Text>
+        </StatsProvider>,
+      );
+
+      await waitFor(() => {
+        exitListener = process
+          .listeners("exit")
+          .find((listener) => !before.has(listener)) as
+          | NodeJS.ExitListener
+          | undefined;
+        expect(exitListener).toBeDefined();
+      });
+
+      exitListener?.(0);
+      expect(saveCurrentProjectConfig).not.toHaveBeenCalled();
+
+      root.unmount();
+      await waitFor(() => {
+        expect(process.listeners("exit")).not.toContain(exitListener);
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  test("memoizes metric hook callbacks across rerenders and delegates updates", async () => {
+    const store: StatsStore = {
+      add: vi.fn(),
+      getAll: vi.fn(() => ({})),
+      increment: vi.fn(),
+      observe: vi.fn(),
+      set: vi.fn(),
+    };
+    const snapshots: HookSnapshot[] = [];
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <StatsProvider store={store}>
+          <HookProbe snapshots={snapshots} />
+        </StatsProvider>,
+      );
+
+      await waitFor(() => {
+        expect(snapshots).toContainEqual({ stable: true, tick: 1 });
+      });
+
+      expect(store.increment).toHaveBeenCalledWith("counter.metric", 2);
+      expect(store.set).toHaveBeenCalledWith("gauge.metric", 7);
+      expect(store.observe).toHaveBeenCalledWith("timer.metric", 13);
+      expect(store.add).toHaveBeenCalledWith("set.metric", "agent");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  test("reports missing provider usage through the renderer error path", async () => {
+    const { stdin, stdout } = createStreams();
+    const stderr = new PassThrough();
+    let stderrOutput = "";
+    stderr.on("data", (chunk) => {
+      stderrOutput += chunk.toString();
+    });
+    const root = await createRoot({
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(<OutsideStatsProbe />);
+      await waitFor(() => {
+        expect(stderrOutput).toContain(
+          "useStats must be used within a StatsProvider",
+        );
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      stderr.end();
+    }
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-085-ink-output.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-085-ink-output.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, test } from 'vitest'
+
+import Output from '../../../src/tui/ink/output.js'
+import {
+  cellAt,
+  CellWidth,
+  CharPool,
+  charInCellAt,
+  createScreen,
+  HyperlinkPool,
+  setCellAt,
+  StylePool,
+  type Screen,
+} from '../../../src/tui/ink/screen.js'
+
+function makeScreen(
+  width: number,
+  height: number,
+  stylePool = new StylePool(),
+  charPool = new CharPool(),
+  hyperlinkPool = new HyperlinkPool(),
+): Screen {
+  return createScreen(width, height, stylePool, charPool, hyperlinkPool)
+}
+
+function makeOutput(width: number, height: number): {
+  output: Output
+  screen: Screen
+  stylePool: StylePool
+} {
+  const stylePool = new StylePool()
+  const screen = makeScreen(width, height, stylePool)
+
+  return {
+    output: new Output({ height, screen, stylePool, width }),
+    screen,
+    stylePool,
+  }
+}
+
+function writePlain(
+  screen: Screen,
+  stylePool: StylePool,
+  y: number,
+  text: string,
+): void {
+  for (let x = 0; x < text.length; x += 1) {
+    setCellAt(screen, x, y, {
+      char: text[x]!,
+      hyperlink: undefined,
+      styleId: stylePool.none,
+      width: CellWidth.Narrow,
+    })
+  }
+}
+
+function rowText(screen: Screen, y: number): string {
+  let text = ''
+  for (let x = 0; x < screen.width; x += 1) {
+    text += charInCellAt(screen, x, y) ?? ''
+  }
+  return text
+}
+
+describe('Output coverage swarm row 085', () => {
+  test('reset clears queued operations and caps the line cache', () => {
+    const { output, stylePool } = makeOutput(5, 1)
+    output.write(0, 0, 'stale')
+
+    const cache = (output as unknown as {
+      charCache: Map<string, unknown>
+    }).charCache
+    for (let i = 0; i < 16385; i += 1) {
+      cache.set(`line-${i}`, [])
+    }
+
+    const nextScreen = makeScreen(3, 1, stylePool)
+    output.reset(3, 1, nextScreen)
+
+    expect(output.width).toBe(3)
+    expect(output.height).toBe(1)
+    expect(cache.size).toBe(0)
+    expect(charInCellAt(output.get(), 0, 0)).toBe(' ')
+  })
+
+  test('intersects nested clips and preserves soft-wrap provenance after vertical clipping', () => {
+    const { output } = makeOutput(6, 4)
+
+    output.clip({ x1: 1, x2: 5, y1: 1, y2: 4 })
+    output.clip({ x1: undefined, x2: 4, y1: undefined, y2: 3 })
+    output.write(0, 0, 'abcd\nEFGH\nIJKL', [false, true, true])
+    output.write(5, 1, 'NO')
+    output.write(1, 3, 'NO')
+    output.unclip()
+    output.write(0, 3, 'tail')
+
+    const screen = output.get()
+
+    expect(rowText(screen, 0)).toBe('      ')
+    expect(rowText(screen, 1)).toBe(' FGH  ')
+    expect(rowText(screen, 2)).toBe(' JKL  ')
+    expect(rowText(screen, 3)).toBe(' ail  ')
+    expect(screen.softWrap[1]).toBe(4)
+    expect(screen.softWrap[2]).toBe(4)
+  })
+
+  test('absolute clears suppress fully covered blit rows and no-select marks win last', () => {
+    const { output, screen: destination, stylePool } = makeOutput(4, 3)
+    const source = makeScreen(
+      4,
+      3,
+      stylePool,
+      destination.charPool,
+      destination.hyperlinkPool,
+    )
+    writePlain(source, stylePool, 0, 'ABCD')
+    writePlain(source, stylePool, 1, 'WXYZ')
+    writePlain(source, stylePool, 2, 'EFGH')
+
+    output.clear({ x: -3, y: -3, width: 1, height: 1 })
+    output.clear({ x: 0, y: 1, width: 4, height: 1 }, true)
+    output.blit(source, 0, 0, 4, 3)
+    output.noSelect({ x: 1, y: 0, width: 2, height: 3 })
+
+    const screen = output.get()
+
+    expect(rowText(screen, 0)).toBe('ABCD')
+    expect(rowText(screen, 1)).toBe('    ')
+    expect(rowText(screen, 2)).toBe('EFGH')
+    expect(screen.noSelect[1]).toBe(1)
+    expect(screen.noSelect[5]).toBe(1)
+    expect(screen.noSelect[9]).toBe(1)
+  })
+
+  test('shift moves blitted rows upward and clears the exposed row', () => {
+    const { output, screen: destination, stylePool } = makeOutput(3, 3)
+    const source = makeScreen(
+      3,
+      3,
+      stylePool,
+      destination.charPool,
+      destination.hyperlinkPool,
+    )
+    writePlain(source, stylePool, 0, 'one')
+    writePlain(source, stylePool, 1, 'two')
+    writePlain(source, stylePool, 2, 'tre')
+
+    output.blit(source, 0, 0, 3, 3)
+    output.shift(0, 2, 1)
+
+    const screen = output.get()
+
+    expect(rowText(screen, 0)).toBe('two')
+    expect(rowText(screen, 1)).toBe('tre')
+    expect(rowText(screen, 2)).toBe('   ')
+  })
+
+  test('writes tabs, escape controls, zero-width characters, and wide-cell edges', () => {
+    const { output } = makeOutput(10, 4)
+
+    output.write(0, 0, 'A\tB')
+    output.write(
+      0,
+      1,
+      'C\x1b[2JD\x1b(0E\x1b]2;title\x07F\x1bPpayload\x1b\\G\x1b7H\x08I',
+    )
+    output.write(0, 2, 'a\u200Bb')
+    output.write(0, 3, '界Z')
+    output.write(9, 3, '界')
+
+    const screen = output.get()
+
+    expect(charInCellAt(screen, 0, 0)).toBe('A')
+    expect(charInCellAt(screen, 1, 0)).toBe(' ')
+    expect(charInCellAt(screen, 7, 0)).toBe(' ')
+    expect(charInCellAt(screen, 8, 0)).toBe('B')
+    expect(rowText(screen, 1)).toBe('CDEFGHI   ')
+    expect(charInCellAt(screen, 0, 2)).toBe('a')
+    expect(charInCellAt(screen, 1, 2)).toBe('b')
+    expect(cellAt(screen, 0, 3)).toMatchObject({
+      char: '界',
+      width: CellWidth.Wide,
+    })
+    expect(cellAt(screen, 1, 3)).toMatchObject({
+      char: '',
+      width: CellWidth.SpacerTail,
+    })
+    expect(charInCellAt(screen, 2, 3)).toBe('Z')
+    expect(cellAt(screen, 9, 3)).toMatchObject({
+      char: ' ',
+      width: CellWidth.SpacerHead,
+    })
+  })
+
+  test('extracts OSC 8 hyperlinks without leaking close codes into styles', () => {
+    const { output } = makeOutput(4, 1)
+
+    output.write(0, 0, '\x1b]8;;https://agenc.test/row-085\x07A\x1b]8;;\x07B')
+
+    const screen = output.get()
+
+    expect(cellAt(screen, 0, 0)).toMatchObject({
+      char: 'A',
+      hyperlink: 'https://agenc.test/row-085',
+    })
+    expect(cellAt(screen, 1, 0)).toMatchObject({
+      char: 'B',
+      hyperlink: undefined,
+      styleId: 0,
+    })
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-086-components-compact-CompactSummary.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-086-components-compact-CompactSummary.test.tsx
@@ -1,0 +1,161 @@
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { CompactSummary } from '../../../src/tui/components/compact/CompactSummary.js'
+
+const harness = vi.hoisted(() => ({
+  cache: [] as unknown[],
+  getUserMessageText: vi.fn(),
+}))
+
+const memoSentinel = Symbol.for('react.memo_cache_sentinel')
+
+vi.mock('react-compiler-runtime', () => ({
+  c: (size: number) => {
+    if (harness.cache.length !== size) {
+      harness.cache = Array.from({ length: size }, () => memoSentinel)
+    }
+    return harness.cache
+  },
+}))
+
+vi.mock('../../../src/tui/ink.js', async () => {
+  const ReactModule = await vi.importActual<typeof import('react')>('react')
+  const Passthrough = ({ children }: { children?: React.ReactNode }) =>
+    ReactModule.createElement(ReactModule.Fragment, null, children)
+
+  return {
+    Box: Passthrough,
+    Text: Passthrough,
+  }
+})
+
+vi.mock('../../../src/tui/components/ConfigurableShortcutHint', () => ({
+  ConfigurableShortcutHint: ({ description }: { description: string }) => (
+    <>{description}</>
+  ),
+}))
+
+vi.mock('../../../src/tui/components/MessageResponse', () => ({
+  MessageResponse: ({ children }: { children?: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}))
+
+vi.mock('../../../src/utils/messages.js', () => ({
+  getUserMessageText: harness.getUserMessageText,
+}))
+
+describe('CompactSummary coverage swarm', () => {
+  beforeEach(() => {
+    harness.cache = Array.from({ length: 24 }, () => memoSentinel)
+    harness.getUserMessageText.mockReset()
+  })
+
+  test('reuses cached metadata slots and recomputes transcript-only content when the screen changes', () => {
+    const message = compactMessage({
+      summarizeMetadata: {
+        direction: 'up_to',
+        messagesSummarized: 8,
+        userContext: 'preserve API notes',
+      },
+    })
+    harness.getUserMessageText.mockReturnValue('full cached summary')
+
+    const promptOutput = renderSummary(message, 'prompt')
+    const cachedPromptOutput = renderSummary(message, 'prompt')
+    const transcriptOutput = renderSummary(message, 'transcript')
+
+    expect(promptOutput).toContain('Summarized conversation')
+    expect(promptOutput).toContain('Summarized 8 messages up to this point')
+    expect(promptOutput).toContain('preserve API notes')
+    expect(promptOutput).toContain('expand history')
+    expect(promptOutput).not.toContain('full cached summary')
+    expect(cachedPromptOutput).toBe(promptOutput)
+
+    expect(transcriptOutput).toContain('Summarized conversation')
+    expect(transcriptOutput).toContain('full cached summary')
+    expect(transcriptOutput).not.toContain('expand history')
+    expect(harness.getUserMessageText).toHaveBeenCalledTimes(1)
+  })
+
+  test('reuses cached fallback summary slots and hides the expansion hint in transcript mode', () => {
+    const message = compactMessage()
+    harness.getUserMessageText.mockReturnValue('fallback compact details')
+
+    const promptOutput = renderSummary(message, 'prompt')
+    const cachedPromptOutput = renderSummary(message, 'prompt')
+    const transcriptOutput = renderSummary(message, 'transcript')
+
+    expect(promptOutput).toContain('Compact summary')
+    expect(promptOutput).toContain('expand')
+    expect(promptOutput).not.toContain('fallback compact details')
+    expect(cachedPromptOutput).toBe(promptOutput)
+
+    expect(transcriptOutput).toContain('Compact summary')
+    expect(transcriptOutput).toContain('fallback compact details')
+    expect(transcriptOutput).not.toContain('expand')
+    expect(harness.getUserMessageText).toHaveBeenCalledTimes(1)
+  })
+
+  test('normalizes missing user-message text to an empty transcript response', () => {
+    const message = compactMessage()
+    harness.getUserMessageText.mockReturnValue(null)
+
+    const output = renderSummary(message, 'transcript')
+
+    expect(output).toContain('Compact summary')
+    expect(output).not.toContain('null')
+    expect(output).not.toContain('undefined')
+    expect(output).not.toContain('expand')
+  })
+})
+
+function compactMessage(input: {
+  readonly summarizeMetadata?: {
+    readonly direction: 'up_to' | 'from'
+    readonly messagesSummarized: number
+    readonly userContext?: string
+  }
+} = {}) {
+  return {
+    type: 'user',
+    isCompactSummary: true,
+    summarizeMetadata: input.summarizeMetadata,
+    message: {
+      content: [{ type: 'text', text: 'ignored by mocked extractor' }],
+    },
+  } as never
+}
+
+function renderSummary(
+  message: React.ComponentProps<typeof CompactSummary>['message'],
+  screen: React.ComponentProps<typeof CompactSummary>['screen'],
+): string {
+  return renderPlain(<CompactSummary message={message} screen={screen} />)
+}
+
+function renderPlain(node: React.ReactNode): string {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return ''
+  }
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node)
+  }
+  if (Array.isArray(node)) {
+    return node.map(renderPlain).join('')
+  }
+  if (React.isValidElement(node)) {
+    if (typeof node.type === 'function') {
+      const Component = node.type as (
+        props: typeof node.props,
+      ) => React.ReactNode
+      return renderPlain(Component(node.props))
+    }
+    const element = node as React.ReactElement<{
+      children?: React.ReactNode
+    }>
+    return renderPlain(element.props.children)
+  }
+  return ''
+}

--- a/runtime/tests/tui/coverage-swarm/swarm-087-context-notifications.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-087-context-notifications.test.tsx
@@ -1,0 +1,313 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import type { Notification } from "src/tui/context/notifications.js";
+
+type RuntimeState = {
+  notifications: {
+    current: Notification | null;
+    queue: Notification[];
+  };
+};
+
+const harness = vi.hoisted(() => {
+  type MutableRuntimeState = {
+    notifications: {
+      current: unknown | null;
+      queue: unknown[];
+    };
+  };
+
+  const state = (notifications: MutableRuntimeState["notifications"]) => ({
+    notifications,
+  });
+
+  const h = {
+    logError: vi.fn(),
+    setAppState: undefined as unknown as ReturnType<typeof vi.fn>,
+    state: state({ current: null, queue: [] }),
+    store: undefined as unknown as { getState: ReturnType<typeof vi.fn> },
+    reset(notifications: MutableRuntimeState["notifications"] = {
+      current: null,
+      queue: [],
+    }) {
+      h.state = state(notifications);
+      h.logError.mockClear();
+      h.setAppState.mockClear();
+      h.store.getState.mockClear();
+    },
+  };
+
+  h.setAppState = vi.fn(
+    (updater: (prev: MutableRuntimeState) => MutableRuntimeState) => {
+      const previous = h.state;
+      const next = updater(previous);
+      if (!Object.is(next, previous)) {
+        h.state = next;
+      }
+    },
+  );
+  h.store = {
+    getState: vi.fn(() => h.state),
+  };
+
+  return h;
+});
+
+vi.mock("src/tui/state/AppState.js", () => ({
+  useAppStateStore: () => harness.store,
+  useSetAppState: () => harness.setAppState,
+}));
+
+vi.mock("src/utils/log.js", () => ({
+  logError: harness.logError,
+}));
+
+import { createRoot } from "src/tui/ink/root.js";
+import { getNext, useNotifications } from "src/tui/context/notifications.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+type NotificationApi = ReturnType<typeof useNotifications>;
+
+function createStreams(): {
+  stdin: TestStdin;
+  stdout: PassThrough;
+} {
+  const stdin = new PassThrough() as TestStdin;
+  const stdout = new PassThrough();
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  Object.assign(stdout, {
+    columns: 120,
+    rows: 24,
+    isTTY: true,
+  });
+  stdout.resume();
+
+  return { stdin, stdout };
+}
+
+function notification(
+  key: string,
+  text: string,
+  overrides: Partial<Notification> = {},
+): Notification {
+  return {
+    key,
+    text,
+    priority: "medium",
+    timeoutMs: 1_000,
+    ...overrides,
+  } as Notification;
+}
+
+function snapshot() {
+  return {
+    current: harness.state.notifications.current?.key ?? null,
+    queue: harness.state.notifications.queue.map(
+      notification => notification.key,
+    ),
+  };
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  const startedAt = Date.now();
+  let lastError: unknown;
+
+  while (Date.now() - startedAt < 1_000) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+  }
+
+  throw lastError;
+}
+
+async function renderNotificationsHarness(
+  notifications: RuntimeState["notifications"] = { current: null, queue: [] },
+): Promise<{
+  api: () => NotificationApi;
+  dispose: () => Promise<void>;
+}> {
+  harness.reset(notifications);
+
+  let api: NotificationApi | undefined;
+  const { stdin, stdout } = createStreams();
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  function Probe(): React.ReactNode {
+    api = useNotifications();
+    return null;
+  }
+
+  root.render(<Probe />);
+  await waitFor(() => {
+    expect(api).toBeDefined();
+  });
+
+  return {
+    api: () => {
+      if (!api) throw new Error("notifications hook did not render");
+      return api;
+    },
+    dispose: async () => {
+      if (api) {
+        for (let i = 0; i < 20; i += 1) {
+          const { current, queue } = harness.state.notifications;
+          if (!current && queue.length === 0) break;
+          if (current) {
+            api.removeNotification(current.key);
+            continue;
+          }
+          for (const queued of queue) {
+            api.removeNotification(queued.key);
+          }
+        }
+      }
+
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await Promise.resolve();
+    },
+  };
+}
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  harness.reset();
+});
+
+describe("notification context coverage swarm row 087", () => {
+  test("processes an initial queue on mount and preserves equal-priority order", async () => {
+    const medium = notification("medium", "Medium");
+    const high = notification("high", "High", { priority: "high" });
+    const peer = notification("peer", "Peer");
+
+    expect(getNext([medium, peer])).toBe(medium);
+
+    const rendered = await renderNotificationsHarness({
+      current: null,
+      queue: [medium, high, peer],
+    });
+
+    try {
+      await waitFor(() => {
+        expect(snapshot()).toEqual({
+          current: "high",
+          queue: ["medium", "peer"],
+        });
+      });
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("ignores stale normal-notification timeout callbacks", async () => {
+    const rendered = await renderNotificationsHarness();
+    vi.useFakeTimers();
+
+    try {
+      rendered
+        .api()
+        .addNotification(notification("stale", "Stale", { timeoutMs: 25 }));
+      expect(snapshot()).toEqual({ current: "stale", queue: [] });
+
+      harness.state = {
+        notifications: {
+          current: notification("newer", "Newer"),
+          queue: [],
+        },
+      };
+
+      await vi.advanceTimersByTimeAsync(25);
+      expect(snapshot()).toEqual({ current: "newer", queue: [] });
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("drops superseded immediate notifications and ignores stale immediate timers", async () => {
+    const rendered = await renderNotificationsHarness({
+      current: notification("old-immediate", "Old", {
+        priority: "immediate",
+      }),
+      queue: [
+        notification("drop", "Drop"),
+        notification("keep", "Keep", { priority: "low" }),
+      ],
+    });
+    vi.useFakeTimers();
+
+    try {
+      rendered.api().addNotification(
+        notification("now", "Now", {
+          invalidates: ["drop"],
+          priority: "immediate",
+          timeoutMs: 25,
+        }),
+      );
+
+      expect(snapshot()).toEqual({ current: "now", queue: ["keep"] });
+
+      harness.state = {
+        notifications: {
+          current: notification("manual", "Manual"),
+          queue: harness.state.notifications.queue,
+        },
+      };
+
+      await vi.advanceTimersByTimeAsync(25);
+      expect(snapshot()).toEqual({ current: "manual", queue: ["keep"] });
+
+      rendered.api().removeNotification("keep");
+      expect(snapshot()).toEqual({ current: "manual", queue: [] });
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("logs fold failures and leaves the active notification intact", async () => {
+    const rendered = await renderNotificationsHarness();
+
+    try {
+      rendered.api().addNotification(notification("fold", "First"));
+      const before = harness.state;
+      const foldError = new Error("fold failed");
+
+      rendered.api().addNotification(
+        notification("fold", "Second", {
+          fold: () => {
+            throw foldError;
+          },
+        }),
+      );
+
+      expect(harness.logError).toHaveBeenCalledWith(foldError);
+      expect(harness.state).toBe(before);
+      expect(snapshot()).toEqual({ current: "fold", queue: [] });
+    } finally {
+      await rendered.dispose();
+    }
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-088-input-processTextPrompt.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-088-input-processTextPrompt.test.ts
@@ -1,0 +1,152 @@
+import type { ContentBlockParam } from '@anthropic-ai/sdk/resources'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  finalizeVimInputForRouting,
+  processTextPrompt,
+} from '../../../src/tui/input/processTextPrompt.js'
+
+const mocks = vi.hoisted(() => ({
+  createUserMessage: vi.fn((input: { content: unknown }) => ({
+    type: 'user',
+    message: { role: 'user', content: input.content },
+    ...input,
+  })),
+  logEvent: vi.fn(),
+  logOTelEvent: vi.fn(),
+  redactIfDisabled: vi.fn((value: string) => `redacted:${value}`),
+  setPromptId: vi.fn(),
+  startInteractionSpan: vi.fn(),
+}))
+
+vi.mock('../../../src/bootstrap/state.js', () => ({
+  flushInteractionTime: vi.fn(),
+  setPromptId: mocks.setPromptId,
+  updateLastInteractionTime: vi.fn(),
+}))
+
+vi.mock('../../../src/services/analytics/index.js', () => ({
+  logEvent: mocks.logEvent,
+}))
+
+vi.mock('../../../src/utils/messages.js', () => ({
+  createUserMessage: mocks.createUserMessage,
+}))
+
+vi.mock('../../../src/utils/telemetry/events.js', () => ({
+  logOTelEvent: mocks.logOTelEvent,
+  redactIfDisabled: mocks.redactIfDisabled,
+}))
+
+vi.mock('../../../src/utils/telemetry/sessionTracing.js', () => ({
+  startInteractionSpan: mocks.startInteractionSpan,
+}))
+
+function imageBlock(data = 'iVBORw0KGgo='): ContentBlockParam {
+  return {
+    type: 'image',
+    source: {
+      type: 'base64',
+      media_type: 'image/png',
+      data,
+    },
+  }
+}
+
+describe('processTextPrompt coverage swarm row 088', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('finalizes insert-mode vim routing with clamped offsets and escape back to normal mode', () => {
+    expect(finalizeVimInputForRouting('alpha', undefined)).toBe('alpha')
+    expect(
+      finalizeVimInputForRouting('alpha', {
+        enabled: false,
+        mode: 'INSERT',
+        keys: ['!'],
+      }),
+    ).toBe('alpha')
+
+    expect(
+      finalizeVimInputForRouting('abc', {
+        enabled: true,
+        mode: 'INSERT',
+        cursorOffset: -20,
+        columns: 12,
+        keys: ['X', 'Y', '\x1b', 'x'],
+      }),
+    ).toBe('XYbc')
+  })
+
+  test('omits whitespace-only text and empty paste ids when creating image prompts', () => {
+    const pastedImage = imageBlock()
+    const result = processTextPrompt(
+      '   ',
+      [pastedImage],
+      [],
+      [],
+      'prompt-uuid',
+      'acceptEdits',
+      false,
+    )
+    const promptId = mocks.setPromptId.mock.calls[0]?.[0]
+
+    expect(result.shouldQuery).toBe(true)
+    expect(mocks.startInteractionSpan).toHaveBeenCalledWith('   ')
+    expect(mocks.redactIfDisabled).toHaveBeenCalledWith('   ')
+    expect(mocks.logOTelEvent).toHaveBeenCalledWith('user_prompt', {
+      prompt_length: '3',
+      prompt: 'redacted:   ',
+      'prompt.id': promptId,
+    })
+    expect(mocks.createUserMessage).toHaveBeenCalledWith({
+      content: [pastedImage],
+      uuid: 'prompt-uuid',
+      imagePasteIds: undefined,
+      permissionMode: 'acceptEdits',
+      isMeta: undefined,
+    })
+    expect(result.messages).toEqual([
+      expect.objectContaining({
+        content: [pastedImage],
+        imagePasteIds: undefined,
+        isMeta: undefined,
+      }),
+    ])
+  })
+
+  test('skips prompt telemetry when array input has no text blocks', () => {
+    const inlineImage = imageBlock('inline-image')
+    const result = processTextPrompt([inlineImage], [], [], [])
+
+    expect(result.shouldQuery).toBe(true)
+    expect(mocks.startInteractionSpan).toHaveBeenCalledWith('')
+    expect(mocks.logOTelEvent).not.toHaveBeenCalled()
+    expect(mocks.logEvent).toHaveBeenCalledWith('agenc_input_prompt', {
+      is_negative: false,
+      is_keep_going: false,
+    })
+    expect(mocks.createUserMessage).toHaveBeenCalledWith({
+      content: [inlineImage],
+      uuid: undefined,
+      permissionMode: undefined,
+      isMeta: undefined,
+    })
+  })
+
+  test('records negative and keep-going prompt classifications together', () => {
+    processTextPrompt('This sucks, keep going', [], [], [])
+
+    expect(mocks.logEvent).toHaveBeenCalledWith('agenc_input_prompt', {
+      is_negative: true,
+      is_keep_going: true,
+    })
+    expect(mocks.createUserMessage).toHaveBeenCalledWith({
+      content: 'This sucks, keep going',
+      uuid: undefined,
+      permissionMode: undefined,
+      isMeta: undefined,
+    })
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-089-hooks-useApiKeyVerification.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-089-hooks-useApiKeyVerification.test.ts
@@ -1,0 +1,307 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const authHarness = vi.hoisted(() => {
+  const state = {
+    authEnabled: true,
+    key: undefined as string | undefined,
+    nonInteractive: false,
+    source: undefined as string | undefined,
+    subscriber: false,
+  }
+
+  return {
+    state,
+    getApiKeyFromApiKeyHelper: vi.fn(async () => undefined),
+    getAnthropicApiKeyWithSource: vi.fn(
+      (_options?: { skipRetrievingKeyFromApiKeyHelper?: boolean }) => ({
+        key: state.key,
+        source: state.source,
+      }),
+    ),
+    reset() {
+      state.authEnabled = true
+      state.key = undefined
+      state.nonInteractive = false
+      state.source = undefined
+      state.subscriber = false
+      this.getApiKeyFromApiKeyHelper.mockClear()
+      this.getAnthropicApiKeyWithSource.mockClear()
+      this.verifyApiKey.mockReset()
+      this.verifyApiKey.mockResolvedValue(true)
+    },
+    verifyApiKey: vi.fn(async () => true),
+  }
+})
+
+vi.mock('../../../src/bootstrap/state', async importOriginal => ({
+  ...(await importOriginal()),
+  getIsNonInteractiveSession: () => authHarness.state.nonInteractive,
+}))
+
+vi.mock('../../../src/services/api/anthropic', () => ({
+  verifyApiKey: authHarness.verifyApiKey,
+}))
+
+vi.mock('../../../src/utils/auth.js', () => ({
+  getAnthropicApiKeyWithSource: authHarness.getAnthropicApiKeyWithSource,
+  getApiKeyFromApiKeyHelper: authHarness.getApiKeyFromApiKeyHelper,
+  isAgenCAISubscriber: () => authHarness.state.subscriber,
+  isAnthropicAuthEnabled: () => authHarness.state.authEnabled,
+}))
+
+import { createRoot } from '../../../src/tui/ink/root.js'
+import { useApiKeyVerification } from '../../../src/tui/hooks/useApiKeyVerification.js'
+
+type HookResult = ReturnType<typeof useApiKeyVerification>
+type Snapshot = {
+  readonly errorMessage: string | null
+  readonly status: HookResult['status']
+}
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough & {
+    columns: number
+    isTTY: boolean
+    rows: number
+  }
+}
+
+function createStreams(): TestStreams {
+  const stdout = new PassThrough() as TestStreams['stdout']
+  const stdin = new PassThrough() as TestStreams['stdin']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.columns = 100
+  stdout.isTTY = true
+  stdout.rows = 30
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 10): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await sleep()
+  }
+  throw new Error(message)
+}
+
+async function renderVerificationHook(): Promise<{
+  readonly cleanup: () => Promise<void>
+  readonly getLatest: () => HookResult
+  readonly rerender: () => void
+  readonly snapshots: Snapshot[]
+}> {
+  let latest: HookResult | null = null
+  const snapshots: Snapshot[] = []
+
+  function Harness(): null {
+    const result = useApiKeyVerification()
+    latest = result
+
+    React.useEffect(() => {
+      snapshots.push({
+        errorMessage: result.error?.message ?? null,
+        status: result.status,
+      })
+    }, [result.error, result.status])
+
+    return null
+  }
+
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  const render = () => root.render(React.createElement(Harness))
+  render()
+
+  return {
+    async cleanup() {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep(0)
+    },
+    getLatest() {
+      if (latest === null) {
+        throw new Error('useApiKeyVerification did not render')
+      }
+      return latest
+    },
+    rerender: render,
+    snapshots,
+  }
+}
+
+describe('useApiKeyVerification coverage swarm row 089', () => {
+  beforeEach(() => {
+    authHarness.reset()
+  })
+
+  test.each([
+    {
+      name: 'disabled auth',
+      patch: { authEnabled: false },
+    },
+    {
+      name: 'subscriber auth',
+      patch: { subscriber: true },
+    },
+  ])('treats $name as already valid', async ({ patch }) => {
+    Object.assign(authHarness.state, patch)
+    const rendered = await renderVerificationHook()
+
+    try {
+      await waitForCondition(
+        () => rendered.getLatest().status === 'valid',
+        'Timed out waiting for valid initial status',
+      )
+
+      await rendered.getLatest().reverify()
+
+      expect(rendered.getLatest().status).toBe('valid')
+      expect(authHarness.getApiKeyFromApiKeyHelper).not.toHaveBeenCalled()
+      expect(authHarness.getAnthropicApiKeyWithSource).not.toHaveBeenCalled()
+      expect(authHarness.verifyApiKey).not.toHaveBeenCalled()
+    } finally {
+      await rendered.cleanup()
+    }
+  })
+
+  test.each([
+    { expectedStatus: 'valid' as const, verifierResult: true },
+    { expectedStatus: 'invalid' as const, verifierResult: false },
+  ])(
+    'sets $expectedStatus after rechecking an existing key',
+    async ({ expectedStatus, verifierResult }) => {
+      authHarness.state.key = 'sk-ant-test'
+      authHarness.state.nonInteractive = true
+      authHarness.state.source = 'environment'
+      authHarness.verifyApiKey.mockResolvedValueOnce(verifierResult)
+      const rendered = await renderVerificationHook()
+
+      try {
+        await waitForCondition(
+          () => rendered.getLatest().status === 'loading',
+          'Timed out waiting for loading initial status',
+        )
+
+        expect(
+          authHarness.getAnthropicApiKeyWithSource,
+        ).toHaveBeenCalledWith({
+          skipRetrievingKeyFromApiKeyHelper: true,
+        })
+
+        await rendered.getLatest().reverify()
+
+        await waitForCondition(
+          () => rendered.getLatest().status === expectedStatus,
+          `Timed out waiting for ${expectedStatus} status`,
+        )
+
+        expect(authHarness.getApiKeyFromApiKeyHelper).toHaveBeenCalledWith(
+          true,
+        )
+        expect(authHarness.getAnthropicApiKeyWithSource).toHaveBeenLastCalledWith()
+        expect(authHarness.verifyApiKey).toHaveBeenCalledWith(
+          'sk-ant-test',
+          false,
+        )
+        expect(rendered.getLatest().error).toBeNull()
+      } finally {
+        await rendered.cleanup()
+      }
+    },
+  )
+
+  test('keeps missing status when no key source can provide a key', async () => {
+    const rendered = await renderVerificationHook()
+
+    try {
+      await waitForCondition(
+        () => rendered.getLatest().status === 'missing',
+        'Timed out waiting for missing initial status',
+      )
+
+      await rendered.getLatest().reverify()
+
+      await waitForCondition(
+        () => rendered.getLatest().status === 'missing',
+        'Timed out waiting for missing reverify status',
+      )
+
+      expect(authHarness.getApiKeyFromApiKeyHelper).toHaveBeenCalledWith(false)
+      expect(authHarness.getAnthropicApiKeyWithSource).toHaveBeenLastCalledWith()
+      expect(authHarness.verifyApiKey).not.toHaveBeenCalled()
+      expect(rendered.getLatest().error).toBeNull()
+    } finally {
+      await rendered.cleanup()
+    }
+  })
+
+  test('records verifier errors and clears them when auth becomes disabled', async () => {
+    authHarness.state.key = 'sk-ant-test'
+    authHarness.state.source = 'environment'
+    authHarness.verifyApiKey.mockRejectedValueOnce(new Error('network failed'))
+    const rendered = await renderVerificationHook()
+
+    try {
+      await waitForCondition(
+        () => rendered.getLatest().status === 'loading',
+        'Timed out waiting for loading initial status',
+      )
+
+      await rendered.getLatest().reverify()
+
+      await waitForCondition(
+        () =>
+          rendered.getLatest().status === 'error' &&
+          rendered.getLatest().error?.message === 'network failed',
+        'Timed out waiting for verifier error status',
+      )
+
+      expect(rendered.snapshots).toContainEqual({
+        errorMessage: 'network failed',
+        status: 'error',
+      })
+
+      authHarness.state.authEnabled = false
+      rendered.rerender()
+
+      await waitForCondition(
+        () =>
+          rendered.getLatest().status === 'valid' &&
+          rendered.getLatest().error === null,
+        'Timed out waiting for disabled auth to clear verifier error',
+      )
+    } finally {
+      await rendered.cleanup()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-090-ink-termio-types.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-090-ink-termio-types.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  colorsEqual,
+  defaultStyle,
+  stylesEqual,
+  type Color,
+  type TextStyle,
+} from '../../../src/tui/ink/termio/types.js'
+
+function changedStyle(change: Partial<TextStyle>): TextStyle {
+  return { ...defaultStyle(), ...change }
+}
+
+describe('termio semantic type helpers coverage swarm row 090', () => {
+  test('creates an independent default text style with reset colors', () => {
+    const first = defaultStyle()
+    const second = defaultStyle()
+
+    expect(first).toEqual({
+      bg: { type: 'default' },
+      blink: false,
+      bold: false,
+      dim: false,
+      fg: { type: 'default' },
+      hidden: false,
+      inverse: false,
+      italic: false,
+      overline: false,
+      strikethrough: false,
+      underline: 'none',
+      underlineColor: { type: 'default' },
+    })
+    expect(first).not.toBe(second)
+    expect(first.fg).not.toBe(second.fg)
+    expect(first.bg).not.toBe(second.bg)
+    expect(first.underlineColor).not.toBe(second.underlineColor)
+  })
+
+  test('compares named, indexed, RGB, and default colors', () => {
+    const cases: Array<[Color, Color, boolean]> = [
+      [
+        { type: 'named', name: 'red' },
+        { type: 'named', name: 'red' },
+        true,
+      ],
+      [
+        { type: 'named', name: 'red' },
+        { type: 'named', name: 'blue' },
+        false,
+      ],
+      [
+        { type: 'indexed', index: 12 },
+        { type: 'indexed', index: 12 },
+        true,
+      ],
+      [
+        { type: 'indexed', index: 12 },
+        { type: 'indexed', index: 13 },
+        false,
+      ],
+      [
+        { type: 'rgb', r: 1, g: 2, b: 3 },
+        { type: 'rgb', r: 1, g: 2, b: 3 },
+        true,
+      ],
+      [
+        { type: 'rgb', r: 1, g: 2, b: 3 },
+        { type: 'rgb', r: 9, g: 2, b: 3 },
+        false,
+      ],
+      [
+        { type: 'rgb', r: 1, g: 2, b: 3 },
+        { type: 'rgb', r: 1, g: 9, b: 3 },
+        false,
+      ],
+      [
+        { type: 'rgb', r: 1, g: 2, b: 3 },
+        { type: 'rgb', r: 1, g: 2, b: 9 },
+        false,
+      ],
+      [{ type: 'default' }, { type: 'default' }, true],
+      [{ type: 'default' }, { type: 'named', name: 'white' }, false],
+    ]
+
+    for (const [left, right, expected] of cases) {
+      expect(colorsEqual(left, right)).toBe(expected)
+    }
+  })
+
+  test('compares every text style field and nested color', () => {
+    const base = defaultStyle()
+
+    expect(stylesEqual(base, defaultStyle())).toBe(true)
+
+    for (const change of [
+      { bold: true },
+      { dim: true },
+      { italic: true },
+      { underline: 'single' as const },
+      { blink: true },
+      { inverse: true },
+      { hidden: true },
+      { strikethrough: true },
+      { overline: true },
+      { fg: { type: 'named' as const, name: 'green' as const } },
+      { bg: { type: 'indexed' as const, index: 7 } },
+      { underlineColor: { type: 'rgb' as const, r: 4, g: 5, b: 6 } },
+    ]) {
+      expect(stylesEqual(base, changedStyle(change))).toBe(false)
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-091-components-design-system-ThemeProvider.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-091-components-design-system-ThemeProvider.test.tsx
@@ -1,0 +1,269 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  feature: vi.fn(() => false),
+  getGlobalConfig: vi.fn(() => ({ theme: 'auto' })),
+  getSystemThemeName: vi.fn(() => 'dark'),
+  saveGlobalConfig: vi.fn(),
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: mocks.feature,
+}))
+
+vi.mock('../../../src/utils/config.js', () => ({
+  getGlobalConfig: mocks.getGlobalConfig,
+  saveGlobalConfig: mocks.saveGlobalConfig,
+}))
+
+vi.mock('../../../src/utils/systemTheme.js', () => ({
+  getSystemThemeName: mocks.getSystemThemeName,
+}))
+
+import { createRoot, type Root } from '../../../src/tui/ink/root.js'
+import Text from '../../../src/tui/ink/components/Text.js'
+import {
+  ThemeProvider,
+  usePreviewTheme,
+  useTheme,
+  useThemeSetting,
+} from '../../../src/tui/components/design-system/ThemeProvider.js'
+
+type ThemeSetting = 'auto' | 'dark' | 'light'
+type ThemeName = 'dark' | 'light'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type Rendered = {
+  dispose: () => Promise<void>
+  root: Root
+}
+
+function createStreams(): {
+  stderr: PassThrough
+  stdin: TestStdin
+  stdout: PassThrough
+} {
+  const stderr = new PassThrough()
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStdin
+
+  stderr.resume()
+  stdout.resume()
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number; isTTY: boolean; rows: number }).columns = 80
+  ;(stdout as unknown as { columns: number; isTTY: boolean; rows: number }).rows = 24
+  ;(stdout as unknown as { columns: number; isTTY: boolean; rows: number }).isTTY = true
+
+  return { stderr, stdin, stdout }
+}
+
+function sleep(ms = 20): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function createInkRoot(): Promise<Rendered> {
+  const { stderr, stdin, stdout } = createStreams()
+  const root = await createRoot({
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    patchConsole: false,
+  })
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      stderr.end()
+      await sleep()
+    },
+    root,
+  }
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  let lastError: unknown
+
+  for (let i = 0; i < 50; i += 1) {
+    try {
+      assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await sleep(10)
+    }
+  }
+
+  throw lastError
+}
+
+describe('ThemeProvider coverage swarm row 091', () => {
+  beforeEach(() => {
+    mocks.feature.mockReturnValue(false)
+    mocks.getGlobalConfig.mockReturnValue({ theme: 'auto' })
+    mocks.getSystemThemeName.mockReturnValue('dark')
+    mocks.saveGlobalConfig.mockImplementation(
+      (update: (current: unknown) => unknown) => {
+        update({ retained: true, theme: 'light' })
+      },
+    )
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('returns stable no-op defaults when hooks are used without a provider', async () => {
+    const rendered = await createInkRoot()
+    let captured:
+      | {
+          preview: ReturnType<typeof usePreviewTheme>
+          setTheme: (setting: ThemeSetting) => void
+          setting: ThemeSetting
+          theme: ThemeName
+        }
+      | undefined
+
+    function Probe() {
+      const [theme, setTheme] = useTheme()
+      const setting = useThemeSetting()
+      const preview = usePreviewTheme()
+
+      React.useEffect(() => {
+        captured = { preview, setTheme, setting, theme }
+      }, [preview, setTheme, setting, theme])
+
+      return <Text>{`${setting}:${theme}`}</Text>
+    }
+
+    try {
+      rendered.root.render(<Probe />)
+
+      await waitFor(() => {
+        expect(captured).toMatchObject({ setting: 'dark', theme: 'dark' })
+      })
+
+      expect(() => captured?.setTheme('light')).not.toThrow()
+      expect(() => captured?.preview.setPreviewTheme('light')).not.toThrow()
+      expect(() => captured?.preview.savePreview()).not.toThrow()
+      expect(() => captured?.preview.cancelPreview()).not.toThrow()
+      expect(mocks.getGlobalConfig).not.toHaveBeenCalled()
+      expect(mocks.saveGlobalConfig).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('uses explicit initial state and delegates direct saves to the supplied callback', async () => {
+    const rendered = await createInkRoot()
+    const onThemeSave = vi.fn()
+    const snapshots: Array<{ setting: ThemeSetting; theme: ThemeName }> = []
+    let setTheme: ((setting: ThemeSetting) => void) | undefined
+    let preview: ReturnType<typeof usePreviewTheme> | undefined
+
+    function Probe() {
+      const [theme, setThemeSetting] = useTheme()
+      const setting = useThemeSetting()
+      const previewControls = usePreviewTheme()
+
+      React.useEffect(() => {
+        snapshots.push({ setting, theme })
+        setTheme = setThemeSetting
+        preview = previewControls
+      }, [previewControls, setThemeSetting, setting, theme])
+
+      return <Text>{`${setting}:${theme}`}</Text>
+    }
+
+    try {
+      rendered.root.render(
+        <ThemeProvider initialState="light" onThemeSave={onThemeSave}>
+          <Probe />
+        </ThemeProvider>,
+      )
+
+      await waitFor(() => {
+        expect(snapshots.at(-1)).toEqual({ setting: 'light', theme: 'light' })
+      })
+      expect(mocks.getGlobalConfig).not.toHaveBeenCalled()
+      expect(mocks.getSystemThemeName).not.toHaveBeenCalled()
+
+      preview?.setPreviewTheme('dark')
+      await waitFor(() => {
+        expect(snapshots.at(-1)).toEqual({ setting: 'light', theme: 'dark' })
+      })
+
+      setTheme?.('light')
+      await waitFor(() => {
+        expect(snapshots.at(-1)).toEqual({ setting: 'light', theme: 'light' })
+      })
+      expect(onThemeSave).toHaveBeenCalledWith('light')
+
+      setTheme?.('auto')
+      await waitFor(() => {
+        expect(snapshots.at(-1)).toEqual({ setting: 'auto', theme: 'dark' })
+      })
+
+      expect(onThemeSave).toHaveBeenCalledWith('auto')
+      expect(mocks.getSystemThemeName).toHaveBeenCalledTimes(1)
+      expect(mocks.saveGlobalConfig).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('feature-enabled effect returns early for concrete active themes', async () => {
+    mocks.feature.mockReturnValue(true)
+    const rendered = await createInkRoot()
+    const snapshots: Array<{ setting: ThemeSetting; theme: ThemeName }> = []
+    let preview: ReturnType<typeof usePreviewTheme> | undefined
+
+    function Probe() {
+      const [theme] = useTheme()
+      const setting = useThemeSetting()
+      const previewControls = usePreviewTheme()
+
+      React.useEffect(() => {
+        snapshots.push({ setting, theme })
+        preview = previewControls
+      }, [previewControls, setting, theme])
+
+      return <Text>{`${setting}:${theme}`}</Text>
+    }
+
+    try {
+      rendered.root.render(
+        <ThemeProvider initialState="dark" onThemeSave={vi.fn()}>
+          <Probe />
+        </ThemeProvider>,
+      )
+
+      await waitFor(() => {
+        expect(snapshots.at(-1)).toEqual({ setting: 'dark', theme: 'dark' })
+      })
+
+      preview?.setPreviewTheme('light')
+      await waitFor(() => {
+        expect(snapshots.at(-1)).toEqual({ setting: 'dark', theme: 'light' })
+      })
+
+      expect(mocks.feature).toHaveBeenCalledWith('AUTO_THEME')
+      expect(mocks.getSystemThemeName).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-092-components-design-system-FuzzyPicker.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-092-components-design-system-FuzzyPicker.test.tsx
@@ -1,0 +1,316 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  computeFuzzyPickerVisibleCount,
+  FuzzyPicker,
+  getFuzzyPickerDefaultPlaceholder,
+  getFuzzyPickerNavigationShortcut,
+} from '../../../src/tui/components/design-system/FuzzyPicker.tsx'
+import type { DOMElement, DOMNode } from '../../../src/tui/ink/dom.ts'
+import instances from '../../../src/tui/ink/instances.ts'
+import { createRoot, Text } from '../../../src/tui/ink.ts'
+
+type PickerItem = {
+  readonly id: string
+  readonly label: string
+}
+
+type PickerAction = {
+  readonly action: string
+  readonly handler: (item: PickerItem) => void
+}
+
+type PickerProps = {
+  title: string
+  placeholder?: string
+  initialQuery?: string
+  items: readonly PickerItem[]
+  renderItem: (item: PickerItem, isFocused: boolean) => React.ReactNode
+  visibleCount?: number
+  direction?: 'down' | 'up'
+  onQueryChange: (query: string) => void
+  onSelect: (item: PickerItem) => void
+  onTab?: PickerAction
+  onShiftTab?: PickerAction
+  onFocus?: (item: PickerItem | undefined) => void
+  onCancel: () => void
+  emptyMessage?: string | ((query: string) => string)
+  matchLabel?: string
+  selectAction?: string
+  extraHints?: React.ReactNode
+}
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  setRawMode: (mode: boolean) => void
+  ref: () => void
+  unref: () => void
+}
+
+type TestStdout = PassThrough & {
+  columns: number
+  rows: number
+  isTTY: boolean
+}
+
+type PickerHarness = {
+  readonly stdin: TestStdin
+  readonly stdout: TestStdout
+  readonly render: (next?: Partial<PickerProps>) => void
+  readonly text: () => string
+  readonly send: (sequence: string) => Promise<void>
+  readonly dispose: () => Promise<void>
+}
+
+const ITEMS: readonly PickerItem[] = [
+  { id: 'alpha', label: 'Alpha result' },
+  { id: 'bravo', label: 'Bravo result' },
+  { id: 'charlie', label: 'Charlie result' },
+]
+
+const mountedHarnesses: PickerHarness[] = []
+
+afterEach(async () => {
+  while (mountedHarnesses.length > 0) {
+    await mountedHarnesses.pop()?.dispose()
+  }
+})
+
+function createStreams(columns = 120, rows = 30): {
+  readonly stdin: TestStdin
+  readonly stdout: TestStdout
+  readonly stderr: PassThrough
+} {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough() as TestStdout
+  const stderr = new PassThrough()
+
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = columns
+  stdout.rows = rows
+  stdout.isTTY = true
+  stdout.on('data', () => {})
+  stderr.on('data', () => {})
+
+  return { stdin, stdout, stderr }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < 2_000) {
+    if (predicate()) return
+    await sleep(10)
+  }
+
+  throw new Error(message)
+}
+
+function rootNode(stdout: TestStdout): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream) as
+    | { rootNode?: DOMElement }
+    | undefined
+
+  if (!instance?.rootNode) {
+    throw new Error('Ink root node not found')
+  }
+
+  return instance.rootNode
+}
+
+function collectText(node: DOMNode): string {
+  if (node.nodeName === '#text') return node.nodeValue
+  return node.childNodes.map(collectText).join('')
+}
+
+function renderItem(item: PickerItem, isFocused: boolean): React.ReactNode {
+  return (
+    <Text>
+      {isFocused ? 'focused' : 'plain'}:{item.label}
+    </Text>
+  )
+}
+
+async function createPickerHarness(
+  overrides: Partial<PickerProps> = {},
+  viewport: { readonly columns?: number; readonly rows?: number } = {},
+): Promise<PickerHarness> {
+  const { stdin, stdout, stderr } = createStreams(
+    viewport.columns ?? 120,
+    viewport.rows ?? 30,
+  )
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+  })
+
+  const props: PickerProps = {
+    title: 'Pick result',
+    items: ITEMS,
+    renderItem,
+    onQueryChange: vi.fn(),
+    onSelect: vi.fn(),
+    onCancel: vi.fn(),
+    ...overrides,
+  }
+
+  const render = (next: Partial<PickerProps> = {}) => {
+    Object.assign(props, next)
+    root.render(
+      <FuzzyPicker<PickerItem>
+        title={props.title}
+        placeholder={props.placeholder}
+        initialQuery={props.initialQuery}
+        items={props.items}
+        getKey={item => item.id}
+        renderItem={props.renderItem}
+        visibleCount={props.visibleCount}
+        direction={props.direction}
+        onQueryChange={props.onQueryChange}
+        onSelect={props.onSelect}
+        onTab={props.onTab}
+        onShiftTab={props.onShiftTab}
+        onFocus={props.onFocus}
+        onCancel={props.onCancel}
+        emptyMessage={props.emptyMessage}
+        matchLabel={props.matchLabel}
+        selectAction={props.selectAction}
+        extraHints={props.extraHints}
+      />,
+    )
+  }
+
+  render()
+
+  const harness: PickerHarness = {
+    stdin,
+    stdout,
+    render,
+    text: () => collectText(rootNode(stdout)),
+    send: async (sequence: string) => {
+      stdin.write(sequence)
+      await sleep(sequence === '\x1b' ? 90 : 30)
+    },
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      stderr.end()
+      instances.delete(stdout as unknown as NodeJS.WriteStream)
+      await sleep(20)
+    },
+  }
+
+  mountedHarnesses.push(harness)
+
+  await waitForCondition(
+    () => harness.text().includes(props.title),
+    'FuzzyPicker did not mount',
+  )
+
+  return harness
+}
+
+describe('FuzzyPicker coverage swarm row 092', () => {
+  test('normalizes fallback layout inputs and default glyph helpers', () => {
+    expect(computeFuzzyPickerVisibleCount(0, 0)).toBe(1)
+    expect(computeFuzzyPickerVisibleCount(2.8, 99)).toBe(2)
+    expect(computeFuzzyPickerVisibleCount(6, 13, true)).toBe(2)
+
+    expect(getFuzzyPickerDefaultPlaceholder()).toMatch(/^Type to search/)
+    expect(getFuzzyPickerNavigationShortcut()).toContain('/')
+  })
+
+  test('renders compact hints with explicit placeholder and extra byline content', async () => {
+    const onTab = { action: 'insert item', handler: vi.fn() }
+    const onShiftTab = { action: 'open details', handler: vi.fn() }
+    const harness = await createPickerHarness(
+      {
+        placeholder: 'Search custom picks',
+        onTab,
+        onShiftTab,
+        selectAction: 'open selected',
+        extraHints: <Text>Ctrl+K to filter</Text>,
+      },
+      { columns: 80 },
+    )
+
+    await waitForCondition(
+      () => harness.text().includes('Search custom picks'),
+      'Explicit placeholder did not render',
+    )
+    expect(harness.text()).toContain('to nav')
+    expect(harness.text()).not.toContain('to navigate')
+    expect(harness.text()).toContain('Enter to open')
+    expect(harness.text()).not.toContain('Enter to open selected')
+    expect(harness.text()).toContain('Tab to insert item')
+    expect(harness.text()).not.toContain('shift+tab')
+    expect(harness.text()).toContain('Ctrl+K to filter')
+
+    harness.render({ selectAction: 'choose' })
+    await waitForCondition(
+      () => harness.text().includes('Enter to choose'),
+      'Compact single-word select action did not render',
+    )
+  })
+
+  test('reports initial query and routes shift-tab to the tab fallback handler', async () => {
+    const onQueryChange = vi.fn()
+    const onTab = { action: 'insert', handler: vi.fn() }
+    const harness = await createPickerHarness({
+      initialQuery: 'bra',
+      onQueryChange,
+      onTab,
+    })
+
+    await waitForCondition(
+      () => onQueryChange.mock.calls.some(([query]) => query === 'bra'),
+      'Initial query was not reported',
+    )
+    expect(harness.text()).toContain('bra')
+
+    await harness.send('\x1b[Z')
+    expect(onTab.handler).toHaveBeenLastCalledWith(ITEMS[0])
+  })
+
+  test('clamps focus to undefined when the item list is cleared', async () => {
+    const onFocus = vi.fn()
+    const harness = await createPickerHarness({
+      items: ITEMS.slice(0, 2),
+      onFocus,
+      visibleCount: 2,
+    })
+
+    await waitForCondition(
+      () => onFocus.mock.calls.some(([item]) => item?.id === 'alpha'),
+      'Initial focus was not reported',
+    )
+
+    harness.render({
+      items: [],
+      emptyMessage: 'Nothing available',
+    })
+
+    await waitForCondition(
+      () => onFocus.mock.calls.some(([item]) => item === undefined),
+      'Empty focus state was not reported',
+    )
+    expect(harness.text()).toContain('Nothing available')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-093-ink-hooks-use-tab-status.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-093-ink-hooks-use-tab-status.test.ts
@@ -1,0 +1,248 @@
+import { PassThrough } from 'node:stream'
+
+import React, { act } from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const oscHarness = vi.hoisted(() => {
+  const state = { supported: true }
+
+  return {
+    state,
+    supportsTabStatus: vi.fn(() => state.supported),
+    tabStatus: vi.fn((fields: { readonly status?: string | null }) => {
+      return `tab-status:${fields.status ?? 'clear'}`
+    }),
+    wrapForMultiplexer: vi.fn((sequence: string) => `wrapped:${sequence}`),
+  }
+})
+
+vi.mock('../../../src/tui/ink/termio/osc.js', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('../../../src/tui/ink/termio/osc.js')>()
+
+  return {
+    ...actual,
+    supportsTabStatus: oscHarness.supportsTabStatus,
+    tabStatus: oscHarness.tabStatus,
+    wrapForMultiplexer: oscHarness.wrapForMultiplexer,
+  }
+})
+
+import { createRoot } from '../../../src/tui/ink.js'
+import {
+  type TabStatusKind,
+  useTabStatus,
+} from '../../../src/tui/ink/hooks/use-tab-status.js'
+import { CLEAR_TAB_STATUS } from '../../../src/tui/ink/termio/osc.js'
+import { TerminalWriteProvider } from '../../../src/tui/ink/useTerminalNotification.js'
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough & {
+    columns: number
+    isTTY: boolean
+    rows: number
+  }
+}
+
+type WriteRaw = ((data: string) => void) | null
+
+const realSetImmediate = setImmediate
+
+function createStreams(): TestStreams {
+  const stdin = new PassThrough() as TestStreams['stdin']
+  const stdout = new PassThrough() as TestStreams['stdout']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 100
+  stdout.rows = 24
+  stdout.isTTY = false
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+  })
+  await new Promise(resolve => realSetImmediate(resolve))
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+function TabStatusProbe({
+  kind,
+}: {
+  readonly kind: TabStatusKind | null
+}): null {
+  useTabStatus(kind)
+  return null
+}
+
+async function renderHookHarness(
+  initialKind: TabStatusKind | null,
+  initialWriteRaw: WriteRaw,
+): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly render: (
+    nextKind: TabStatusKind | null,
+    nextWriteRaw?: WriteRaw,
+  ) => Promise<void>
+}> {
+  let kind = initialKind
+  let writeRaw = initialWriteRaw
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  async function render(
+    nextKind: TabStatusKind | null,
+    nextWriteRaw: WriteRaw = writeRaw,
+  ): Promise<void> {
+    kind = nextKind
+    writeRaw = nextWriteRaw
+
+    await act(async () => {
+      root.render(
+        React.createElement(
+          TerminalWriteProvider,
+          { value: writeRaw },
+          React.createElement(TabStatusProbe, { kind }),
+        ),
+      )
+    })
+    await flushEffects()
+  }
+
+  await render(kind)
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushEffects()
+    },
+    render,
+  }
+}
+
+describe('useTabStatus coverage swarm row 093', () => {
+  beforeEach(() => {
+    oscHarness.state.supported = true
+    oscHarness.supportsTabStatus.mockClear()
+    oscHarness.tabStatus.mockClear()
+    oscHarness.wrapForMultiplexer.mockClear()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('emits wrapped preset status sequences for each tab-status kind', async () => {
+    const writeRaw = vi.fn()
+    const rendered = await renderHookHarness('idle', writeRaw)
+
+    try {
+      await rendered.render('busy')
+      await rendered.render('waiting')
+
+      expect(oscHarness.tabStatus.mock.calls.map(([fields]) => fields)).toEqual([
+        {
+          indicator: { type: 'rgb', r: 0, g: 215, b: 95 },
+          status: 'Idle',
+          statusColor: { type: 'rgb', r: 136, g: 136, b: 136 },
+        },
+        {
+          indicator: { type: 'rgb', r: 255, g: 149, b: 0 },
+          status: 'Working…',
+          statusColor: { type: 'rgb', r: 255, g: 149, b: 0 },
+        },
+        {
+          indicator: { type: 'rgb', r: 95, g: 135, b: 255 },
+          status: 'Waiting',
+          statusColor: { type: 'rgb', r: 95, g: 135, b: 255 },
+        },
+      ])
+      expect(oscHarness.wrapForMultiplexer.mock.calls).toEqual([
+        ['tab-status:Idle'],
+        ['tab-status:Working…'],
+        ['tab-status:Waiting'],
+      ])
+      expect(writeRaw.mock.calls.map(([sequence]) => sequence)).toEqual([
+        'wrapped:tab-status:Idle',
+        'wrapped:tab-status:Working…',
+        'wrapped:tab-status:Waiting',
+      ])
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('skips initial null status and short-circuits when no terminal writer exists', async () => {
+    const nullRendered = await renderHookHarness(null, vi.fn())
+
+    try {
+      expect(oscHarness.supportsTabStatus).not.toHaveBeenCalled()
+      expect(oscHarness.tabStatus).not.toHaveBeenCalled()
+    } finally {
+      await nullRendered.dispose()
+    }
+
+    const noWriterRendered = await renderHookHarness('busy', null)
+
+    try {
+      await noWriterRendered.render(null)
+
+      expect(oscHarness.supportsTabStatus).not.toHaveBeenCalled()
+      expect(oscHarness.tabStatus).not.toHaveBeenCalled()
+      expect(oscHarness.wrapForMultiplexer).not.toHaveBeenCalled()
+    } finally {
+      await noWriterRendered.dispose()
+    }
+  })
+
+  test('gates unsupported terminals and clears stale status after support is available', async () => {
+    const writeRaw = vi.fn()
+    oscHarness.state.supported = false
+    const rendered = await renderHookHarness('waiting', writeRaw)
+
+    try {
+      await rendered.render(null)
+
+      expect(oscHarness.supportsTabStatus).toHaveBeenCalledTimes(2)
+      expect(oscHarness.tabStatus).not.toHaveBeenCalled()
+      expect(writeRaw).not.toHaveBeenCalled()
+
+      oscHarness.state.supported = true
+      await rendered.render('idle')
+      await rendered.render(null)
+
+      expect(oscHarness.tabStatus).toHaveBeenCalledTimes(1)
+      expect(oscHarness.wrapForMultiplexer.mock.calls.slice(-2)).toEqual([
+        ['tab-status:Idle'],
+        [CLEAR_TAB_STATUS],
+      ])
+      expect(writeRaw.mock.calls.map(([sequence]) => sequence)).toEqual([
+        'wrapped:tab-status:Idle',
+        `wrapped:${CLEAR_TAB_STATUS}`,
+      ])
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-094-input-processBashCommand.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-094-input-processBashCommand.test.tsx
@@ -1,0 +1,458 @@
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => {
+  class MockShellError extends Error {
+    stdout: string;
+    stderr: string;
+    code: number;
+    interrupted: boolean;
+
+    constructor(
+      stdout: string,
+      stderr: string,
+      code: number,
+      interrupted: boolean,
+    ) {
+      super("Shell command failed");
+      this.name = "ShellError";
+      this.stdout = stdout;
+      this.stderr = stderr;
+      this.code = code;
+      this.interrupted = interrupted;
+    }
+  }
+
+  return {
+    CanonicalBashTool: {
+      name: "Bash",
+      call: vi.fn(),
+    },
+    PowerShellTool: {
+      name: "PowerShell",
+      call: vi.fn(),
+    },
+    ShellError: MockShellError,
+    consumeSuspectedPaste: vi.fn(() => false),
+    isPowerShellToolEnabled: vi.fn(() => false),
+    logEvent: vi.fn(),
+    processToolResultBlock: vi.fn(async () => ({ content: "mapped output" })),
+    resolveDefaultShell: vi.fn(() => "bash"),
+  };
+});
+
+vi.mock("../../../src/tui/components/BashModeProgress.js", () => ({
+  BashModeProgress: ({
+    input,
+    progress,
+    verbose,
+  }: {
+    input: string;
+    progress: unknown;
+    verbose: boolean;
+  }) => React.createElement("bash-progress", { input, progress, verbose }),
+}));
+
+vi.mock("../../../src/tui/components/PasteConfirmDialog.js", () => ({
+  PasteConfirmDialog: ({
+    command,
+    onDecide,
+  }: {
+    command: string;
+    onDecide: (allow: boolean) => void;
+  }) => React.createElement("paste-confirm", { command, onDecide }),
+}));
+
+vi.mock("../../../src/tools/canonicalToolSurface.js", () => ({
+  CanonicalBashTool: harness.CanonicalBashTool,
+}));
+
+vi.mock("../../../src/tools/PowerShellTool/PowerShellTool.js", () => ({
+  PowerShellTool: harness.PowerShellTool,
+}));
+
+vi.mock("../../../src/services/analytics/index.js", () => ({
+  logEvent: harness.logEvent,
+}));
+
+vi.mock("../../../src/utils/errors.js", () => ({
+  ShellError: harness.ShellError,
+  errorMessage: (error: unknown) =>
+    error instanceof Error ? error.message : String(error),
+}));
+
+vi.mock("../../../src/utils/messages.js", () => ({
+  createSyntheticUserCaveatMessage: () => ({
+    content: "<caveat />",
+    role: "user",
+    type: "synthetic_caveat",
+  }),
+  createUserInterruptionMessage: (input: unknown) => ({
+    content: `<interrupted>${JSON.stringify(input)}</interrupted>`,
+    role: "user",
+    type: "interruption",
+  }),
+  createUserMessage: ({ content }: { content: string }) => ({
+    content,
+    role: "user",
+    type: "user",
+  }),
+  prepareUserContent: ({
+    inputString,
+    precedingInputBlocks,
+  }: {
+    inputString: string;
+    precedingInputBlocks: readonly unknown[];
+  }) => `${inputString}|preceding:${precedingInputBlocks.length}`,
+}));
+
+vi.mock("../../../src/utils/shell/resolveDefaultShell.js", () => ({
+  resolveDefaultShell: harness.resolveDefaultShell,
+}));
+
+vi.mock("../../../src/utils/shell/shellToolUtils.js", () => ({
+  isPowerShellToolEnabled: harness.isPowerShellToolEnabled,
+}));
+
+vi.mock("../../../src/utils/toolResultStorage.js", () => ({
+  processToolResultBlock: harness.processToolResultBlock,
+}));
+
+vi.mock("../../../src/utils/xml.js", () => ({
+  escapeXml: (value: string) =>
+    value
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;"),
+}));
+
+vi.mock("../../../src/tui/input/burst-detector.js", () => ({
+  consumeSuspectedPaste: harness.consumeSuspectedPaste,
+}));
+
+import { processBashCommand } from "../../../src/tui/input/processBashCommand.js";
+
+function makeContext(verbose = false) {
+  return {
+    options: {
+      verbose,
+    },
+  };
+}
+
+function makeAttachment(content = "attachment") {
+  return {
+    content,
+    type: "attachment",
+  };
+}
+
+function contentMessages(result: Awaited<ReturnType<typeof processBashCommand>>) {
+  return result.messages.map((message) => message.content);
+}
+
+function latestPasteDialog(
+  setToolJSX: ReturnType<typeof vi.fn>,
+): React.ReactElement<{
+  command: string;
+  onDecide: (allow: boolean) => void;
+}> {
+  const dialogCall = setToolJSX.mock.calls.find(
+    ([value]) => value && value.shouldHidePromptInput === true,
+  );
+  expect(dialogCall).toBeDefined();
+  return dialogCall![0].jsx;
+}
+
+describe("processBashCommand coverage swarm 094", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    harness.CanonicalBashTool.call.mockResolvedValue({
+      data: {
+        content: "fallback content",
+        metadata: {
+          stderr: "warn <err>",
+          stdout: "raw stdout",
+        },
+      },
+    });
+    harness.PowerShellTool.call.mockResolvedValue({
+      data: {
+        stderr: "ps err",
+        stdout: "ps out",
+      },
+    });
+    harness.consumeSuspectedPaste.mockReturnValue(false);
+    harness.isPowerShellToolEnabled.mockReturnValue(false);
+    harness.processToolResultBlock.mockResolvedValue({
+      content: "mapped <persisted-output>ok</persisted-output>",
+    });
+    harness.resolveDefaultShell.mockReturnValue("bash");
+  });
+
+  test("runs canonical bash, surfaces progress, and preserves mapped stdout", async () => {
+    const setToolJSX = vi.fn();
+    harness.CanonicalBashTool.call.mockImplementation(
+      async (_input, _context, _a, _b, onProgress) => {
+        onProgress({
+          data: {
+            elapsedTimeSeconds: 1,
+            fullOutput: "line one",
+            output: "line one",
+            totalLines: 1,
+          },
+        });
+        return {
+          data: {
+            content: "content fallback",
+            metadata: {
+              stderr: "warn <err>",
+              stdout: "raw stdout",
+            },
+          },
+        };
+      },
+    );
+
+    const result = await processBashCommand(
+      "echo ok",
+      [{ text: "before", type: "text" }],
+      [makeAttachment("attached")],
+      makeContext(true) as never,
+      setToolJSX,
+    );
+
+    expect(harness.logEvent).toHaveBeenCalledWith("agenc_input_bash", {
+      powershell: false,
+    });
+    expect(harness.CanonicalBashTool.call).toHaveBeenCalledWith(
+      { command: "echo ok" },
+      expect.objectContaining({ options: { verbose: true } }),
+      undefined,
+      undefined,
+      expect.any(Function),
+    );
+    expect(harness.PowerShellTool.call).not.toHaveBeenCalled();
+    expect(harness.processToolResultBlock).toHaveBeenCalledWith(
+      harness.CanonicalBashTool,
+      expect.objectContaining({ content: "content fallback" }),
+      expect.any(String),
+    );
+    expect(result.shouldQuery).toBe(false);
+    expect(contentMessages(result)).toEqual([
+      "<caveat />",
+      "<bash-input>echo ok</bash-input>|preceding:1",
+      "attached",
+      "<bash-stdout>mapped <persisted-output>ok</persisted-output></bash-stdout><bash-stderr>warn &lt;err&gt;</bash-stderr>",
+    ]);
+    expect(setToolJSX).toHaveBeenCalledWith(
+      expect.objectContaining({ shouldHidePromptInput: false }),
+    );
+    expect(setToolJSX).toHaveBeenCalledWith(
+      expect.objectContaining({ showSpinner: false }),
+    );
+    expect(setToolJSX).toHaveBeenLastCalledWith(null);
+  });
+
+  test("falls back to escaped canonical stdout when mapper content is not text", async () => {
+    const setToolJSX = vi.fn();
+    harness.CanonicalBashTool.call.mockResolvedValue({
+      data: {
+        content: "raw & <content>",
+      },
+    });
+    harness.processToolResultBlock.mockResolvedValue({
+      content: [{ type: "text", text: "structured result" }],
+    });
+
+    const result = await processBashCommand(
+      "cat file",
+      [],
+      [],
+      makeContext() as never,
+      setToolJSX,
+    );
+
+    expect(contentMessages(result).at(-1)).toBe(
+      "<bash-stdout>raw &amp; &lt;content&gt;</bash-stdout><bash-stderr></bash-stderr>",
+    );
+    expect(setToolJSX).toHaveBeenLastCalledWith(null);
+  });
+
+  test("uses string result data as canonical stdout fallback", async () => {
+    const setToolJSX = vi.fn();
+    harness.CanonicalBashTool.call.mockResolvedValue({
+      data: "plain & <stdout>",
+    });
+    harness.processToolResultBlock.mockResolvedValue({
+      content: null,
+    });
+
+    const result = await processBashCommand(
+      "printf plain",
+      [],
+      [],
+      makeContext() as never,
+      setToolJSX,
+    );
+
+    expect(harness.processToolResultBlock).toHaveBeenCalledWith(
+      harness.CanonicalBashTool,
+      "plain & <stdout>",
+      expect.any(String),
+    );
+    expect(contentMessages(result).at(-1)).toBe(
+      "<bash-stdout>plain &amp; &lt;stdout&gt;</bash-stdout><bash-stderr></bash-stderr>",
+    );
+  });
+
+  test("aborts suspected pasted input when the confirmation dialog rejects it", async () => {
+    const setToolJSX = vi.fn();
+    harness.consumeSuspectedPaste.mockReturnValue(true);
+
+    const pending = processBashCommand(
+      "rm -rf tmp",
+      [],
+      [],
+      makeContext() as never,
+      setToolJSX,
+    );
+    const dialog = latestPasteDialog(setToolJSX);
+
+    expect(dialog.props.command).toBe("rm -rf tmp");
+    dialog.props.onDecide(false);
+
+    const result = await pending;
+
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      "agenc_input_bash_paste_gate",
+      { powershell: false },
+    );
+    expect(harness.CanonicalBashTool.call).not.toHaveBeenCalled();
+    expect(contentMessages(result).at(-1)).toBe(
+      "<bash-stderr>Bash submission aborted: input looked like a paste and was not confirmed.</bash-stderr>",
+    );
+    expect(setToolJSX).toHaveBeenLastCalledWith(null);
+  });
+
+  test("runs confirmed pasted input through the PowerShell backend", async () => {
+    const setToolJSX = vi.fn();
+    harness.consumeSuspectedPaste.mockReturnValue(true);
+    harness.isPowerShellToolEnabled.mockReturnValue(true);
+    harness.resolveDefaultShell.mockReturnValue("powershell");
+    harness.processToolResultBlock.mockResolvedValue({
+      content: "mapped powershell",
+    });
+
+    const pending = processBashCommand(
+      "Get-ChildItem",
+      [],
+      [],
+      makeContext() as never,
+      setToolJSX,
+    );
+    latestPasteDialog(setToolJSX).props.onDecide(true);
+
+    const result = await pending;
+
+    expect(harness.logEvent).toHaveBeenCalledWith("agenc_input_bash", {
+      powershell: true,
+    });
+    expect(harness.PowerShellTool.call).toHaveBeenCalledWith(
+      {
+        _dangerouslyDisableSandboxApproved: true,
+        command: "Get-ChildItem",
+        dangerouslyDisableSandbox: true,
+      },
+      expect.any(Object),
+      undefined,
+      undefined,
+      expect.any(Function),
+    );
+    expect(harness.CanonicalBashTool.call).not.toHaveBeenCalled();
+    expect(harness.processToolResultBlock).toHaveBeenCalledWith(
+      harness.PowerShellTool,
+      { stderr: "", stdout: "ps out" },
+      expect.any(String),
+    );
+    expect(contentMessages(result).at(-1)).toBe(
+      "<bash-stdout>mapped powershell</bash-stdout><bash-stderr>ps err</bash-stderr>",
+    );
+  });
+
+  test("formats ShellError output and interruption branches", async () => {
+    const setToolJSX = vi.fn();
+    harness.CanonicalBashTool.call.mockRejectedValueOnce(
+      new harness.ShellError("partial <out>", "bad & err", 2, false),
+    );
+
+    const failed = await processBashCommand(
+      "false",
+      [],
+      [makeAttachment("kept")],
+      makeContext() as never,
+      setToolJSX,
+    );
+
+    expect(contentMessages(failed)).toEqual([
+      "<caveat />",
+      "<bash-input>false</bash-input>|preceding:0",
+      "kept",
+      "<bash-stdout>partial &lt;out&gt;</bash-stdout><bash-stderr>bad &amp; err</bash-stderr>",
+    ]);
+
+    harness.CanonicalBashTool.call.mockRejectedValueOnce(
+      new harness.ShellError("ignored", "interrupted", 130, true),
+    );
+
+    const interrupted = await processBashCommand(
+      "sleep 10",
+      [],
+      [makeAttachment("after interrupt")],
+      makeContext() as never,
+      setToolJSX,
+    );
+
+    expect(contentMessages(interrupted)).toEqual([
+      "<caveat />",
+      "<bash-input>sleep 10</bash-input>|preceding:0",
+      '<interrupted>{"toolUse":false}</interrupted>',
+      "after interrupt",
+    ]);
+  });
+
+  test("formats missing and thrown non-shell results as command failures", async () => {
+    const setToolJSX = vi.fn();
+    harness.CanonicalBashTool.call.mockResolvedValueOnce({
+      data: null,
+    });
+
+    const missing = await processBashCommand(
+      "missing result",
+      [],
+      [],
+      makeContext() as never,
+      setToolJSX,
+    );
+
+    expect(contentMessages(missing).at(-1)).toBe(
+      "<bash-stderr>Command failed: No result received from shell command</bash-stderr>",
+    );
+
+    harness.CanonicalBashTool.call.mockRejectedValueOnce(
+      new Error("boom <unsafe>"),
+    );
+
+    const thrown = await processBashCommand(
+      "throw",
+      [],
+      [],
+      makeContext() as never,
+      setToolJSX,
+    );
+
+    expect(contentMessages(thrown).at(-1)).toBe(
+      "<bash-stderr>Command failed: boom &lt;unsafe&gt;</bash-stderr>",
+    );
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-095-components-design-system-ListItem.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-095-components-design-system-ListItem.test.tsx
@@ -1,0 +1,232 @@
+import { PassThrough } from 'node:stream'
+
+import figures from 'figures'
+import React from 'react'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { ListItem } from '../../../src/tui/components/design-system/ListItem.js'
+import type { DOMElement, DOMNode } from '../../../src/tui/ink/dom.js'
+import instances from '../../../src/tui/ink/instances.js'
+import { createRoot } from '../../../src/tui/ink/root.js'
+import type { TextStyles } from '../../../src/tui/ink/styles.js'
+import { Box, Text } from '../../../src/tui/ink.js'
+import { getTheme } from '../../../src/utils/theme.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestRoot = Awaited<ReturnType<typeof createRoot>>
+
+type StyledSegment = {
+  text: string
+  styles: TextStyles
+}
+
+type CursorDeclaration = {
+  relativeX: number
+  relativeY: number
+  node: DOMElement
+}
+
+const mountedRoots: Array<{ root: TestRoot; stdin: TestStdin; stdout: PassThrough }> = []
+
+function createStreams(): { stdin: TestStdin; stdout: PassThrough } {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough()
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 80
+  ;(stdout as unknown as { rows: number }).rows = 24
+  ;(stdout as unknown as { isTTY: boolean }).isTTY = true
+
+  return { stdin, stdout }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+
+  if (!instance?.rootNode) {
+    throw new Error('Ink root node not found')
+  }
+
+  return instance.rootNode
+}
+
+function getCursorDeclaration(stdout: PassThrough): CursorDeclaration | null {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream) as
+    | { cursorDeclaration?: CursorDeclaration | null }
+    | undefined
+
+  return instance?.cursorDeclaration ?? null
+}
+
+function collectSegments(
+  node: DOMNode,
+  inheritedStyles: TextStyles = {},
+  segments: StyledSegment[] = [],
+): StyledSegment[] {
+  if (node.nodeName === '#text') {
+    if (node.nodeValue !== '') {
+      segments.push({ text: node.nodeValue, styles: inheritedStyles })
+    }
+    return segments
+  }
+
+  const nextStyles = node.textStyles
+    ? { ...inheritedStyles, ...node.textStyles }
+    : inheritedStyles
+
+  for (const child of node.childNodes) {
+    collectSegments(child, nextStyles, segments)
+  }
+
+  return segments
+}
+
+function findSegment(segments: StyledSegment[], text: string): StyledSegment {
+  const segment = segments.find(entry => entry.text === text)
+  expect(segment).toBeDefined()
+  return segment!
+}
+
+async function renderListItem(node: React.ReactNode): Promise<{
+  cursor: () => CursorDeclaration | null
+  segments: () => StyledSegment[]
+  text: () => string
+}> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  mountedRoots.push({ root, stdin, stdout })
+
+  root.render(node)
+  await sleep(30)
+
+  return {
+    cursor: () => getCursorDeclaration(stdout),
+    segments: () => collectSegments(getRootNode(stdout)),
+    text: () =>
+      collectSegments(getRootNode(stdout))
+        .map(segment => segment.text)
+        .join(''),
+  }
+}
+
+afterEach(() => {
+  for (const { root, stdin, stdout } of mountedRoots.splice(0)) {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+  }
+})
+
+describe('ListItem coverage swarm row 095', () => {
+  test('renders focused selected content with description and active cursor declaration', async () => {
+    const theme = getTheme('dark')
+    const rendered = await renderListItem(
+      <ListItem isFocused={true} isSelected={true} description="Extra details">
+        Selected item
+      </ListItem>,
+    )
+    const segments = rendered.segments()
+
+    expect(segments.map(segment => segment.text)).toEqual([
+      figures.pointer,
+      'Selected item',
+      figures.tick,
+      'Extra details',
+    ])
+    expect(findSegment(segments, figures.pointer).styles).toMatchObject({
+      color: theme.suggestion,
+    })
+    expect(findSegment(segments, 'Selected item').styles).toMatchObject({
+      color: theme.success,
+    })
+    expect(findSegment(segments, figures.tick).styles).toMatchObject({
+      color: theme.success,
+    })
+    expect(findSegment(segments, 'Extra details').styles).toMatchObject({
+      color: theme.inactive,
+    })
+    expect(rendered.cursor()).toMatchObject({ relativeX: 0, relativeY: 0 })
+  })
+
+  test('suppresses indicators and cursor declaration for disabled selected items', async () => {
+    const theme = getTheme('dark')
+    const rendered = await renderListItem(
+      <ListItem
+        disabled={true}
+        isFocused={true}
+        isSelected={true}
+        description="Disabled details"
+      >
+        Disabled choice
+      </ListItem>,
+    )
+    const segments = rendered.segments()
+
+    expect(rendered.text()).toContain('Disabled choice')
+    expect(rendered.text()).toContain('Disabled details')
+    expect(rendered.text()).not.toContain(figures.pointer)
+    expect(rendered.text()).not.toContain(figures.tick)
+    expect(findSegment(segments, 'Disabled choice').styles).toMatchObject({
+      color: theme.inactive,
+    })
+    expect(findSegment(segments, 'Disabled details').styles).toMatchObject({
+      color: theme.inactive,
+    })
+    expect(rendered.cursor()).toBeNull()
+  })
+
+  test('renders scroll affordances, default text, focused text, and unstyled children', async () => {
+    const theme = getTheme('dark')
+    const rendered = await renderListItem(
+      <Box flexDirection="column">
+        <ListItem isFocused={false} showScrollDown={true}>
+          Down item
+        </ListItem>
+        <ListItem isFocused={false} showScrollUp={true}>
+          Up item
+        </ListItem>
+        <ListItem isFocused={false}>Plain item</ListItem>
+        <ListItem isFocused={true} declareCursor={false}>
+          Focused item
+        </ListItem>
+        <ListItem isFocused={false} styled={false}>
+          <Text color="warning">Custom child</Text>
+        </ListItem>
+      </Box>,
+    )
+    const segments = rendered.segments()
+
+    expect(findSegment(segments, figures.arrowDown).styles).toMatchObject({
+      color: theme.inactive,
+    })
+    expect(findSegment(segments, figures.arrowUp).styles).toMatchObject({
+      color: theme.inactive,
+    })
+    expect(findSegment(segments, 'Plain item').styles.color).toBeUndefined()
+    expect(findSegment(segments, 'Focused item').styles).toMatchObject({
+      color: theme.suggestion,
+    })
+    expect(findSegment(segments, 'Custom child').styles).toMatchObject({
+      color: theme.warning,
+    })
+    expect(rendered.cursor()).toBeNull()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-096-components-shell-OutputLine.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-096-components-shell-OutputLine.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { renderToString } from '../../../src/utils/staticRender.js'
+import { InVirtualListContext } from '../../../src/tui/components/messageActions.js'
+import {
+  ExpandShellOutputProvider,
+} from '../../../src/tui/components/shell/ExpandShellOutputContext.js'
+import {
+  OutputLine,
+  linkifyUrlsInText,
+  stripUnderlineAnsi,
+  tryFormatJson,
+  tryJsonFormatContent,
+} from '../../../src/tui/components/shell/OutputLine.js'
+
+const previousForceHyperlink = process.env.FORCE_HYPERLINK
+
+afterEach(() => {
+  if (previousForceHyperlink === undefined) {
+    delete process.env.FORCE_HYPERLINK
+  } else {
+    process.env.FORCE_HYPERLINK = previousForceHyperlink
+  }
+})
+
+describe('OutputLine coverage swarm 096', () => {
+  test('formats valid JSON while preserving invalid or lossy JSON text', () => {
+    expect(tryFormatJson('{"status":"ok","count":2}')).toBe(
+      ['{', '  "status": "ok",', '  "count": 2', '}'].join('\n'),
+    )
+
+    expect(tryFormatJson('{not valid json')).toBe('{not valid json')
+
+    const largeIntegerJson = '{"id":9007199254740993}'
+    expect(tryFormatJson(largeIntegerJson)).toBe(largeIntegerJson)
+
+    expect(tryJsonFormatContent('{"ok":true}\nplain line')).toBe(
+      ['{', '  "ok": true', '}', 'plain line'].join('\n'),
+    )
+
+    const oversized = `{"payload":"${'x'.repeat(10_100)}"}`
+    expect(tryJsonFormatContent(oversized)).toBe(oversized)
+  })
+
+  test('linkifies JSON URLs and strips only underline ANSI sequences', () => {
+    process.env.FORCE_HYPERLINK = '1'
+
+    const linked = linkifyUrlsInText(
+      '{"url":"https://example.test/path?query=1"}',
+    )
+
+    expect(linked).toContain(
+      '\u001b]8;;https://example.test/path?query=1\u0007',
+    )
+    expect(linked).toContain('\u001b]8;;\u0007')
+
+    expect(
+      stripUnderlineAnsi(
+        'a\u001b[4mb\u001b[1;4;31mc\u001b[4;31md',
+      ),
+    ).toBe('abcd')
+    expect(stripUnderlineAnsi('\u001b[31mred\u001b[0m')).toBe(
+      '\u001b[31mred\u001b[0m',
+    )
+  })
+
+  test('truncates ordinary output and suppresses expand hints inside virtual lists', async () => {
+    const content = Array.from(
+      { length: 7 },
+      (_, index) => `line ${index + 1}`,
+    ).join('\n')
+
+    const output = await renderToString(
+      <InVirtualListContext.Provider value={true}>
+        <OutputLine content={content} isWarning={true} linkifyUrls={false} />
+      </InVirtualListContext.Provider>,
+      { columns: 80, rows: 12 },
+    )
+
+    expect(output).toContain('line 1')
+    expect(output).toContain('line 3')
+    expect(output).toContain('+4 lines')
+    expect(output).not.toContain('line 7')
+    expect(output).not.toContain('to expand')
+  })
+
+  test('shows full formatted output when verbose or expand context is active', async () => {
+    process.env.FORCE_HYPERLINK = '1'
+
+    const verboseOutput = await renderToString(
+      <OutputLine
+        content={
+          '{"url":"https://example.test/log","status":"ok"}\n' +
+          'plain \u001b[4munderlined'
+        }
+        isError={true}
+        linkifyUrls={true}
+        verbose={true}
+      />,
+      { columns: 40, rows: 12, color: true },
+    )
+
+    expect(verboseOutput).toContain('"url": "https://example.test/log"')
+    expect(verboseOutput).toContain('"status": "ok"')
+    expect(verboseOutput).toContain('plain underlined')
+    expect(verboseOutput).not.toContain('to expand')
+
+    const expandedContent = Array.from(
+      { length: 6 },
+      (_, index) => `expanded ${index + 1}`,
+    ).join('\n')
+    const expandedOutput = await renderToString(
+      <ExpandShellOutputProvider>
+        <OutputLine content={expandedContent} linkifyUrls={false} />
+      </ExpandShellOutputProvider>,
+      { columns: 40, rows: 12 },
+    )
+
+    expect(expandedOutput).toContain('expanded 1')
+    expect(expandedOutput).toContain('expanded 6')
+    expect(expandedOutput).not.toContain('+3 lines')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-097-computer-use-approval-ComputerUseApproval.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-097-computer-use-approval-ComputerUseApproval.test.tsx
@@ -1,0 +1,395 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { ComputerUsePermissionRequest } from '../../utils/computerUse/approvalTypes.js'
+import { createRoot } from '../ink.js'
+import {
+  ComputerUseApproval,
+  getInitialComputerUseSelectedAppIds,
+} from '../computer-use-approval/ComputerUseApproval.js'
+
+type CapturedSelectProps = {
+  options: Array<{
+    description?: string
+    label?: React.ReactNode
+    value: string
+  }>
+  onCancel: () => void
+  onChange: (value: string) => void
+  visibleOptionCount?: number
+}
+
+type CapturedDialogProps = {
+  onCancel: () => void
+  title: string
+}
+
+type SentinelCategory = 'shell' | 'filesystem' | 'system_settings'
+
+const harness = vi.hoisted(() => {
+  const sentinels: Record<string, SentinelCategory | undefined> = {}
+
+  return {
+    dialogProps: undefined as CapturedDialogProps | undefined,
+    execFileNoThrow: vi.fn(),
+    getComputerUseSentinelCategory: vi.fn(
+      (bundleId: string) => sentinels[bundleId],
+    ),
+    selectProps: undefined as CapturedSelectProps | undefined,
+    sentinels,
+  }
+})
+
+vi.mock('../components/CustomSelect/select.js', () => ({
+  Select: (props: CapturedSelectProps) => {
+    harness.selectProps = props
+    return null
+  },
+}))
+
+vi.mock('../components/design-system/Dialog.js', async () => {
+  const ReactActual = await vi.importActual<typeof import('react')>('react')
+
+  return {
+    Dialog: ({
+      children,
+      onCancel,
+      title,
+    }: CapturedDialogProps & { children: React.ReactNode }) => {
+      harness.dialogProps = { onCancel, title }
+      return ReactActual.createElement(ReactActual.Fragment, null, children)
+    },
+  }
+})
+
+vi.mock('../../utils/execFileNoThrow.js', () => ({
+  execFileNoThrow: harness.execFileNoThrow,
+}))
+
+vi.mock('../../utils/computerUse/approvalTypes.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../utils/computerUse/approvalTypes.js')>(
+      '../../utils/computerUse/approvalTypes.js',
+    )
+
+  return {
+    ...actual,
+    getComputerUseSentinelCategory: harness.getComputerUseSentinelCategory,
+  }
+})
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+const previousGlyphMode = process.env.AGENC_TUI_GLYPHS
+
+function createStreams(): {
+  stdin: TestStdin
+  stdout: PassThrough
+} {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough()
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+  ;(stdout as unknown as { rows: number }).rows = 24
+  ;(stdout as unknown as { isTTY: boolean }).isTTY = true
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function compactText(text: string): string {
+  return text.replace(/\s+/g, '')
+}
+
+async function renderApproval(
+  request: ComputerUsePermissionRequest,
+  onDone = vi.fn(),
+): Promise<{
+  dispose: () => Promise<void>
+  onDone: typeof onDone
+  output: () => string
+}> {
+  let output = ''
+  const { stdin, stdout } = createStreams()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  root.render(<ComputerUseApproval request={request} onDone={onDone} />)
+  await sleep()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep(5)
+    },
+    onDone,
+    output: () => stripAnsi(output),
+  }
+}
+
+beforeEach(() => {
+  process.env.AGENC_TUI_GLYPHS = 'ascii'
+  harness.dialogProps = undefined
+  harness.execFileNoThrow.mockReset()
+  harness.getComputerUseSentinelCategory.mockClear()
+  harness.selectProps = undefined
+
+  for (const key of Object.keys(harness.sentinels)) {
+    delete harness.sentinels[key]
+  }
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+
+  if (previousGlyphMode === undefined) {
+    delete process.env.AGENC_TUI_GLYPHS
+  } else {
+    process.env.AGENC_TUI_GLYPHS = previousGlyphMode
+  }
+})
+
+describe('ComputerUseApproval coverage swarm row 097', () => {
+  test('selects only resolved apps that still need approval by default', () => {
+    expect(
+      getInitialComputerUseSelectedAppIds([
+        {
+          requestedName: 'Selectable',
+          resolved: {
+            bundleId: 'com.example.selectable',
+            displayName: 'Selectable',
+          },
+        },
+        {
+          requestedName: 'Already Allowed',
+          alreadyGranted: true,
+          resolved: {
+            bundleId: 'com.example.already',
+            displayName: 'Already Allowed',
+          },
+        },
+        {
+          requestedName: 'Missing App',
+        },
+      ]),
+    ).toEqual(['com.example.selectable'])
+  })
+
+  test('renders partial TCC state and cancels with a deny-all response', async () => {
+    const rendered = await renderApproval({
+      apps: [],
+      requestedFlags: { clipboardRead: true },
+      tccState: {
+        accessibility: true,
+        screenRecording: false,
+      },
+    })
+
+    try {
+      expect(harness.dialogProps?.title).toBe(
+        'Computer Use needs macOS permissions',
+      )
+      expect(harness.selectProps?.options.map(option => option.value)).toEqual([
+        'open_screen_recording',
+        'retry',
+      ])
+      const output = compactText(rendered.output())
+      expect(output).toContain('Accessibility:')
+      expect(output).toContain('granted')
+      expect(output).toContain('ScreenRecording:')
+      expect(output).toContain('notgranted')
+
+      harness.dialogProps!.onCancel()
+
+      expect(rendered.onDone).toHaveBeenCalledWith({
+        denied: [],
+        flags: {},
+        granted: [],
+      })
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('returns granted, denied, and requested flag details after app toggles', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
+    harness.sentinels['com.example.shell'] = 'shell'
+    harness.sentinels['com.example.files'] = 'filesystem'
+    harness.sentinels['com.example.settings'] = 'system_settings'
+
+    const rendered = await renderApproval({
+      apps: [
+        {
+          requestedName: 'Terminal',
+          resolved: {
+            bundleId: 'com.example.shell',
+            displayName: 'Terminal',
+          },
+        },
+        {
+          requestedName: 'File Manager',
+          resolved: {
+            bundleId: 'com.example.files',
+            displayName: 'File Manager',
+          },
+        },
+        {
+          requestedName: 'System Settings',
+          resolved: {
+            bundleId: 'com.example.settings',
+            displayName: 'System Settings',
+          },
+        },
+        {
+          requestedName: 'Missing App',
+        },
+        {
+          requestedName: 'Already Allowed',
+          alreadyGranted: true,
+          resolved: {
+            bundleId: 'com.example.already',
+            displayName: 'Already Allowed',
+          },
+        },
+      ],
+      reason: 'Automated browser setup needs temporary app control.',
+      requestedFlags: {
+        clipboardRead: true,
+        clipboardWrite: true,
+        systemKeyCombos: true,
+      },
+      willHide: [{}, {}],
+    })
+
+    try {
+      expect(harness.selectProps?.options.map(option => option.value)).toEqual([
+        'app:com.example.shell',
+        'app:com.example.files',
+        'app:com.example.settings',
+        'allow_selected',
+        'deny',
+      ])
+      expect(harness.selectProps?.visibleOptionCount).toBe(5)
+      expect(harness.selectProps?.options.map(option => option.description)).toEqual([
+        '! equivalent to shell access',
+        '! can read/write any file',
+        '! can change system settings',
+        undefined,
+        undefined,
+      ])
+
+      const output = compactText(rendered.output())
+      expect(output).toContain('Automatedbrowsersetupneedstemporaryappcontrol.')
+      expect(output).toContain('MissingApp')
+      expect(output).toContain('(notinstalled)')
+      expect(output).toContain('AlreadyAllowed')
+      expect(output).toContain('(alreadygranted)')
+      expect(output).toContain('Alsorequested:')
+      expect(output).toContain('clipboardRead')
+      expect(output).toContain('clipboardWrite')
+      expect(output).toContain('systemKeyCombos')
+      expect(output).toContain('2otherappswillbehiddenwhileAgenCworks.')
+
+      harness.selectProps!.onChange('app:com.example.shell')
+      await sleep()
+      harness.selectProps!.onChange('allow_selected')
+
+      expect(rendered.onDone).toHaveBeenCalledWith({
+        denied: [
+          {
+            bundleId: 'com.example.shell',
+            reason: 'user_denied',
+          },
+          {
+            bundleId: 'Missing App',
+            reason: 'not_installed',
+          },
+        ],
+        flags: {
+          clipboardRead: true,
+          clipboardWrite: true,
+          systemKeyCombos: true,
+        },
+        granted: [
+          {
+            bundleId: 'com.example.files',
+            displayName: 'File Manager',
+            grantedAt: 1_700_000_000_000,
+          },
+          {
+            bundleId: 'com.example.settings',
+            displayName: 'System Settings',
+            grantedAt: 1_700_000_000_000,
+          },
+        ],
+      })
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('denies app approval requests from both the option and dialog cancel', async () => {
+    const request: ComputerUsePermissionRequest = {
+      apps: [
+        {
+          requestedName: 'Terminal',
+          resolved: {
+            bundleId: 'com.example.terminal',
+            displayName: 'Terminal',
+          },
+        },
+      ],
+      requestedFlags: {
+        systemKeyCombos: true,
+      },
+    }
+
+    const deniedFromOption = await renderApproval(request)
+    try {
+      harness.selectProps!.onChange('deny')
+      expect(deniedFromOption.onDone).toHaveBeenCalledWith({
+        denied: [],
+        flags: {},
+        granted: [],
+      })
+    } finally {
+      await deniedFromOption.dispose()
+    }
+
+    const deniedFromDialog = await renderApproval(request)
+    try {
+      harness.dialogProps!.onCancel()
+      expect(deniedFromDialog.onDone).toHaveBeenCalledWith({
+        denied: [],
+        flags: {},
+        granted: [],
+      })
+    } finally {
+      await deniedFromDialog.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-098-ink-screen.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-098-ink-screen.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  CellWidth,
+  CharPool,
+  HyperlinkPool,
+  StylePool,
+  cellAt,
+  charInCellAt,
+  createScreen,
+  diffEach,
+  extractHyperlinkFromStyles,
+  filterOutHyperlinkStyles,
+  resetScreen,
+  setCellAt,
+  visibleCellAtIndex,
+  type Screen,
+} from '../../../src/tui/ink/screen.ts'
+
+function makeScreen(width: number, height: number): {
+  screen: Screen
+  styles: StylePool
+} {
+  const styles = new StylePool()
+  return {
+    screen: createScreen(
+      width,
+      height,
+      styles,
+      new CharPool(),
+      new HyperlinkPool(),
+    ),
+    styles,
+  }
+}
+
+function writeCell(
+  screen: Screen,
+  styles: StylePool,
+  x: number,
+  y: number,
+  char: string,
+  styleId = styles.none,
+): void {
+  setCellAt(screen, x, y, {
+    char,
+    hyperlink: undefined,
+    styleId,
+    width: CellWidth.Narrow,
+  })
+}
+
+describe('screen coverage swarm row 098', () => {
+  test('reset reuses larger buffers while clearing active cells and markers', () => {
+    const { screen, styles } = makeScreen(4, 2)
+    const cells = screen.cells
+    const cells64 = screen.cells64
+    const noSelect = screen.noSelect
+    const softWrap = screen.softWrap
+
+    writeCell(screen, styles, 0, 0, 'x')
+    screen.noSelect[0] = 1
+    screen.softWrap[0] = 2
+
+    resetScreen(screen, 2, 1)
+
+    expect(screen.cells).toBe(cells)
+    expect(screen.cells64).toBe(cells64)
+    expect(screen.noSelect).toBe(noSelect)
+    expect(screen.softWrap).toBe(softWrap)
+    expect(screen).toMatchObject({ height: 1, width: 2 })
+    expect(charInCellAt(screen, 0, 0)).toBe(' ')
+    expect(screen.noSelect[0]).toBe(0)
+    expect(screen.softWrap[0]).toBe(0)
+    expect(screen.damage).toBeUndefined()
+  })
+
+  test('foreground-only styled spaces are visible only when style changes', () => {
+    const { screen, styles } = makeScreen(3, 1)
+    const foreground = styles.intern([
+      { code: '\x1b[31m', endCode: '\x1b[39m', type: 'ansi' },
+    ])
+    const background = styles.intern([
+      { code: '\x1b[48;2;1;2;3m', endCode: '\x1b[49m', type: 'ansi' },
+    ])
+
+    writeCell(screen, styles, 0, 0, ' ', foreground)
+    writeCell(screen, styles, 1, 0, ' ', background)
+
+    expect(
+      visibleCellAtIndex(
+        screen.cells,
+        screen.charPool,
+        screen.hyperlinkPool,
+        0,
+        foreground,
+      ),
+    ).toBeUndefined()
+    expect(
+      visibleCellAtIndex(
+        screen.cells,
+        screen.charPool,
+        screen.hyperlinkPool,
+        0,
+        styles.none,
+      ),
+    ).toMatchObject({ char: ' ', styleId: foreground })
+    expect(
+      visibleCellAtIndex(
+        screen.cells,
+        screen.charPool,
+        screen.hyperlinkPool,
+        1,
+        background,
+      ),
+    ).toMatchObject({ char: ' ', styleId: background })
+  })
+
+  test('diffs same-width height growth while skipping empty additions', () => {
+    const { screen: prev, styles } = makeScreen(3, 1)
+    const next = createScreen(3, 3, styles, prev.charPool, prev.hyperlinkPool)
+    writeCell(next, styles, 1, 2, 'z')
+    next.damage = { x: 0, y: 1, width: 3, height: 2 }
+
+    const changes: Array<{
+      added: string | undefined
+      removed: string | undefined
+      x: number
+      y: number
+    }> = []
+    const stopped = diffEach(prev, next, (x, y, removed, added) => {
+      changes.push({ added: added?.char, removed: removed?.char, x, y })
+    })
+
+    expect(stopped).toBe(false)
+    expect(changes).toEqual([
+      { added: 'z', removed: undefined, x: 1, y: 2 },
+    ])
+  })
+
+  test('empty OSC 8 hyperlinks parse as null and are filtered from styles', () => {
+    const emptyOsc8 = {
+      code: '\x1b]8;;\x07',
+      endCode: '\x1b]8;;\x07',
+      type: 'ansi' as const,
+    }
+    const textStyle = {
+      code: '\x1b[1m',
+      endCode: '\x1b[22m',
+      type: 'ansi' as const,
+    }
+
+    expect(extractHyperlinkFromStyles([textStyle, emptyOsc8])).toBeNull()
+    expect(filterOutHyperlinkStyles([textStyle, emptyOsc8])).toEqual([
+      textStyle,
+    ])
+  })
+
+  test('style overlays preserve already inverse styles without duplicate codes', () => {
+    const { styles } = makeScreen(1, 1)
+    const inverse = styles.intern([
+      { code: '\x1b[7m', endCode: '\x1b[27m', type: 'ansi' },
+    ])
+
+    expect(styles.withInverse(inverse)).toBe(inverse)
+    expect(styles.get(9999)).toEqual([])
+  })
+
+  test('cell views tolerate stale packed hyperlink ids', () => {
+    const { screen, styles } = makeScreen(1, 1)
+
+    writeCell(screen, styles, 0, 0, 'a')
+    screen.cells[1] = 7 << 2
+
+    expect(cellAt(screen, 0, 0)).toMatchObject({
+      char: 'a',
+      hyperlink: undefined,
+    })
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-099-ink-layout-yoga.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-099-ink-layout-yoga.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import {
+  LayoutAlign,
+  LayoutDisplay,
+  LayoutEdge,
+  LayoutFlexDirection,
+  LayoutGutter,
+  LayoutJustify,
+  LayoutMeasureMode,
+  LayoutOverflow,
+  LayoutPositionType,
+  LayoutWrap,
+} from '../../../src/tui/ink/layout/node.js'
+import {
+  YogaLayoutNode,
+  createYogaLayoutNode,
+} from '../../../src/tui/ink/layout/yoga.js'
+import {
+  Align,
+  Display,
+  Direction,
+  Edge,
+  FlexDirection,
+  Gutter,
+  Justify,
+  Overflow,
+  PositionType,
+  Unit,
+  Wrap,
+} from '../../../src/tui/ink/native-ts/yoga-layout/index.js'
+
+function node(): YogaLayoutNode {
+  return createYogaLayoutNode() as YogaLayoutNode
+}
+
+describe('ink layout yoga coverage swarm row 099', () => {
+  test('wraps yoga tree operations and parent lookup', () => {
+    const root = node()
+    const child = node()
+
+    try {
+      expect(root.getParent()).toBeNull()
+      expect(root.getChildCount()).toBe(0)
+
+      root.insertChild(child, 0)
+
+      expect(root.getChildCount()).toBe(1)
+      expect((child.getParent() as YogaLayoutNode).yoga).toBe(root.yoga)
+
+      root.removeChild(child)
+
+      expect(root.getChildCount()).toBe(0)
+      expect(child.getParent()).toBeNull()
+    } finally {
+      child.free()
+      root.free()
+    }
+  })
+
+  test('translates yoga measure modes before calling layout measure functions', () => {
+    const unconstrained = node()
+    const row = node()
+    const measured = node()
+    const modes: LayoutMeasureMode[] = []
+
+    try {
+      unconstrained.setMeasureFunc((width, mode) => {
+        modes.push(mode)
+        expect(Number.isNaN(width)).toBe(true)
+        return { width: 4, height: 1 }
+      })
+      unconstrained.calculateLayout()
+
+      row.setFlexDirection(LayoutFlexDirection.Row)
+      row.setWidth(20)
+      row.setHeight(4)
+      measured.setMeasureFunc((width, mode) => {
+        modes.push(mode)
+        if (mode === LayoutMeasureMode.AtMost) {
+          expect(width).toBe(20)
+        }
+        return { width: Math.min(width, 6), height: 1 }
+      })
+      row.insertChild(measured, 0)
+      row.calculateLayout(20)
+
+      measured.setWidth(7)
+      measured.markDirty()
+      row.calculateLayout(20)
+
+      expect(modes).toContain(LayoutMeasureMode.Undefined)
+      expect(modes).toContain(LayoutMeasureMode.AtMost)
+      expect(modes).toContain(LayoutMeasureMode.Exactly)
+
+      measured.unsetMeasureFunc()
+      expect(measured.yoga.measureFunc).toBeNull()
+    } finally {
+      row.freeRecursive()
+      unconstrained.free()
+    }
+  })
+
+  test('passes explicit height through to native yoga layout', () => {
+    const root = node()
+    const calculateLayout = vi.spyOn(root.yoga, 'calculateLayout')
+
+    try {
+      root.calculateLayout(12, 5)
+
+      expect(calculateLayout).toHaveBeenCalledWith(12, 5, Direction.LTR)
+    } finally {
+      root.free()
+    }
+  })
+
+  test('maps adapter style values to yoga enums and dimensions', () => {
+    const subject = node()
+
+    try {
+      subject.setWidth(10)
+      expect(subject.yoga.getWidth()).toEqual({ unit: Unit.Point, value: 10 })
+      subject.setWidthPercent(50)
+      expect(subject.yoga.getWidth()).toEqual({
+        unit: Unit.Percent,
+        value: 50,
+      })
+      subject.setWidthAuto()
+      expect(subject.yoga.getWidth().unit).toBe(Unit.Auto)
+
+      subject.setHeight(8)
+      expect(subject.yoga.getHeight()).toEqual({ unit: Unit.Point, value: 8 })
+      subject.setHeightPercent(40)
+      expect(subject.yoga.getHeight()).toEqual({
+        unit: Unit.Percent,
+        value: 40,
+      })
+      subject.setHeightAuto()
+      expect(subject.yoga.getHeight().unit).toBe(Unit.Auto)
+
+      subject.setMinWidth(2)
+      subject.setMinWidthPercent(25)
+      subject.setMinHeight(3)
+      subject.setMinHeightPercent(30)
+      subject.setMaxWidth(12)
+      subject.setMaxWidthPercent(75)
+      subject.setMaxHeight(9)
+      subject.setMaxHeightPercent(60)
+
+      expect(subject.yoga.style.minWidth).toEqual({
+        unit: Unit.Percent,
+        value: 25,
+      })
+      expect(subject.yoga.style.minHeight).toEqual({
+        unit: Unit.Percent,
+        value: 30,
+      })
+      expect(subject.yoga.style.maxWidth).toEqual({
+        unit: Unit.Percent,
+        value: 75,
+      })
+      expect(subject.yoga.style.maxHeight).toEqual({
+        unit: Unit.Percent,
+        value: 60,
+      })
+
+      subject.setFlexDirection(LayoutFlexDirection.Row)
+      expect(subject.yoga.getFlexDirection()).toBe(FlexDirection.Row)
+      subject.setFlexDirection(LayoutFlexDirection.RowReverse)
+      expect(subject.yoga.getFlexDirection()).toBe(FlexDirection.RowReverse)
+      subject.setFlexDirection(LayoutFlexDirection.Column)
+      expect(subject.yoga.getFlexDirection()).toBe(FlexDirection.Column)
+      subject.setFlexDirection(LayoutFlexDirection.ColumnReverse)
+      expect(subject.yoga.getFlexDirection()).toBe(FlexDirection.ColumnReverse)
+
+      subject.setFlexGrow(2)
+      subject.setFlexShrink(3)
+      subject.setFlexBasis(5)
+      expect(subject.yoga.getFlexGrow()).toBe(2)
+      expect(subject.yoga.getFlexShrink()).toBe(3)
+      expect(subject.yoga.getFlexBasis()).toEqual({
+        unit: Unit.Point,
+        value: 5,
+      })
+      subject.setFlexBasisPercent(15)
+      expect(subject.yoga.getFlexBasis()).toEqual({
+        unit: Unit.Percent,
+        value: 15,
+      })
+
+      subject.setFlexWrap(LayoutWrap.NoWrap)
+      expect(subject.yoga.getFlexWrap()).toBe(Wrap.NoWrap)
+      subject.setFlexWrap(LayoutWrap.Wrap)
+      expect(subject.yoga.getFlexWrap()).toBe(Wrap.Wrap)
+      subject.setFlexWrap(LayoutWrap.WrapReverse)
+      expect(subject.yoga.getFlexWrap()).toBe(Wrap.WrapReverse)
+
+      subject.setAlignItems(LayoutAlign.Auto)
+      expect(subject.yoga.getAlignItems()).toBe(Align.Auto)
+      subject.setAlignItems(LayoutAlign.Stretch)
+      expect(subject.yoga.getAlignItems()).toBe(Align.Stretch)
+      subject.setAlignItems(LayoutAlign.FlexStart)
+      expect(subject.yoga.getAlignItems()).toBe(Align.FlexStart)
+      subject.setAlignItems(LayoutAlign.Center)
+      expect(subject.yoga.getAlignItems()).toBe(Align.Center)
+      subject.setAlignItems(LayoutAlign.FlexEnd)
+      expect(subject.yoga.getAlignItems()).toBe(Align.FlexEnd)
+
+      subject.setAlignSelf(LayoutAlign.Auto)
+      expect(subject.yoga.getAlignSelf()).toBe(Align.Auto)
+      subject.setAlignSelf(LayoutAlign.Stretch)
+      expect(subject.yoga.getAlignSelf()).toBe(Align.Stretch)
+      subject.setAlignSelf(LayoutAlign.FlexStart)
+      expect(subject.yoga.getAlignSelf()).toBe(Align.FlexStart)
+      subject.setAlignSelf(LayoutAlign.Center)
+      expect(subject.yoga.getAlignSelf()).toBe(Align.Center)
+      subject.setAlignSelf(LayoutAlign.FlexEnd)
+      expect(subject.yoga.getAlignSelf()).toBe(Align.FlexEnd)
+
+      subject.setJustifyContent(LayoutJustify.FlexStart)
+      expect(subject.yoga.getJustifyContent()).toBe(Justify.FlexStart)
+      subject.setJustifyContent(LayoutJustify.Center)
+      expect(subject.yoga.getJustifyContent()).toBe(Justify.Center)
+      subject.setJustifyContent(LayoutJustify.FlexEnd)
+      expect(subject.yoga.getJustifyContent()).toBe(Justify.FlexEnd)
+      subject.setJustifyContent(LayoutJustify.SpaceBetween)
+      expect(subject.yoga.getJustifyContent()).toBe(Justify.SpaceBetween)
+      subject.setJustifyContent(LayoutJustify.SpaceAround)
+      expect(subject.yoga.getJustifyContent()).toBe(Justify.SpaceAround)
+      subject.setJustifyContent(LayoutJustify.SpaceEvenly)
+      expect(subject.yoga.getJustifyContent()).toBe(Justify.SpaceEvenly)
+
+      subject.setDisplay(LayoutDisplay.None)
+      expect(subject.getDisplay()).toBe(LayoutDisplay.None)
+      expect(subject.yoga.getDisplay()).toBe(Display.None)
+      subject.setDisplay(LayoutDisplay.Flex)
+      expect(subject.getDisplay()).toBe(LayoutDisplay.Flex)
+      expect(subject.yoga.getDisplay()).toBe(Display.Flex)
+
+      subject.setPositionType(LayoutPositionType.Absolute)
+      expect(subject.yoga.getPositionType()).toBe(PositionType.Absolute)
+      subject.setPositionType(LayoutPositionType.Relative)
+      expect(subject.yoga.getPositionType()).toBe(PositionType.Relative)
+
+      subject.setOverflow(LayoutOverflow.Visible)
+      expect(subject.yoga.getOverflow()).toBe(Overflow.Visible)
+      subject.setOverflow(LayoutOverflow.Hidden)
+      expect(subject.yoga.getOverflow()).toBe(Overflow.Hidden)
+      subject.setOverflow(LayoutOverflow.Scroll)
+      expect(subject.yoga.getOverflow()).toBe(Overflow.Scroll)
+    } finally {
+      subject.free()
+    }
+  })
+
+  test('maps layout edges and gutters for spacing, position, and computed reads', () => {
+    const root = node()
+    const child = node()
+    const edgeCases = [
+      [LayoutEdge.All, Edge.All],
+      [LayoutEdge.Horizontal, Edge.Horizontal],
+      [LayoutEdge.Vertical, Edge.Vertical],
+      [LayoutEdge.Left, Edge.Left],
+      [LayoutEdge.Right, Edge.Right],
+      [LayoutEdge.Top, Edge.Top],
+      [LayoutEdge.Bottom, Edge.Bottom],
+      [LayoutEdge.Start, Edge.Start],
+      [LayoutEdge.End, Edge.End],
+    ] as const
+
+    try {
+      root.setWidth(100)
+      root.setHeight(40)
+      root.setFlexDirection(LayoutFlexDirection.Row)
+
+      for (const [index, [layoutEdge, yogaEdge]] of edgeCases.entries()) {
+        child.setMargin(layoutEdge, index + 1)
+        child.setPadding(layoutEdge, index + 2)
+        child.setBorder(layoutEdge, index + 3)
+        child.setPosition(layoutEdge, index + 4)
+        child.setPositionPercent(layoutEdge, index + 5)
+
+        expect(child.yoga.style.margin[yogaEdge]).toEqual({
+          unit: Unit.Point,
+          value: index + 1,
+        })
+        expect(child.yoga.style.padding[yogaEdge]).toEqual({
+          unit: Unit.Point,
+          value: index + 2,
+        })
+        expect(child.yoga.style.border[yogaEdge]).toEqual({
+          unit: Unit.Point,
+          value: index + 3,
+        })
+        expect(child.yoga.style.position[yogaEdge]).toEqual({
+          unit: Unit.Percent,
+          value: index + 5,
+        })
+      }
+
+      child.setGap(LayoutGutter.All, 1)
+      child.setGap(LayoutGutter.Column, 2)
+      child.setGap(LayoutGutter.Row, 3)
+      expect(child.yoga.style.gap[Gutter.All]).toEqual({
+        unit: Unit.Point,
+        value: 1,
+      })
+      expect(child.yoga.style.gap[Gutter.Column]).toEqual({
+        unit: Unit.Point,
+        value: 2,
+      })
+      expect(child.yoga.style.gap[Gutter.Row]).toEqual({
+        unit: Unit.Point,
+        value: 3,
+      })
+
+      child.setWidth(10)
+      child.setHeight(5)
+      root.insertChild(child, 0)
+      root.calculateLayout(100)
+
+      expect(child.getComputedLeft()).toBeGreaterThanOrEqual(0)
+      expect(child.getComputedTop()).toBeGreaterThanOrEqual(0)
+      expect(child.getComputedWidth()).toBeGreaterThan(0)
+      expect(child.getComputedHeight()).toBeGreaterThan(0)
+      expect(child.getComputedBorder(LayoutEdge.Left)).toBe(
+        child.yoga.getComputedBorder(Edge.Left),
+      )
+      expect(child.getComputedPadding(LayoutEdge.Left)).toBe(
+        child.yoga.getComputedPadding(Edge.Left),
+      )
+    } finally {
+      root.freeRecursive()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-100-state-AppState.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-100-state-AppState.test.tsx
@@ -1,0 +1,341 @@
+import React from "react";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { renderToString } from "../../../src/utils/staticRender.js";
+import { createRoot, Text } from "../../../src/tui/ink.js";
+import {
+  AppStateProvider,
+  useAppState,
+  useAppStateMaybeOutsideOfProvider,
+  useAppStateStore,
+  useSetAppState,
+  type AppState,
+  type AppStateStore,
+} from "../../../src/tui/state/AppState.js";
+
+const harness = vi.hoisted(() => ({
+  bypassDisabled: false,
+  settingsChange: undefined as ((source: unknown) => void) | undefined,
+}));
+
+const mockFns = vi.hoisted(() => ({
+  applySettingsChange: vi.fn(),
+  createDisabledBypassPermissionsContext: vi.fn(
+    (context: Record<string, unknown>) => ({
+      ...context,
+      disabledByRemoteSettings: true,
+      isBypassPermissionsModeAvailable: false,
+    }),
+  ),
+  logForDebugging: vi.fn(),
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: () => false,
+}));
+
+vi.mock("../../../src/tui/context/mailbox.js", () => ({
+  MailboxProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock("../../../src/tui/hooks/useEffectEventCompat.js", () => ({
+  useEffectEventCompat: (callback: unknown) => callback,
+}));
+
+vi.mock("../../../src/tui/hooks/useSettingsChange.js", () => ({
+  useSettingsChange: (callback: (source: unknown) => void) => {
+    harness.settingsChange = callback;
+  },
+}));
+
+vi.mock("../../../src/utils/debug.js", () => ({
+  logForDebugging: mockFns.logForDebugging,
+}));
+
+vi.mock("../../../src/utils/permissions/permissionSetup.js", () => ({
+  createDisabledBypassPermissionsContext:
+    mockFns.createDisabledBypassPermissionsContext,
+  isBypassPermissionsModeDisabled: () => harness.bypassDisabled,
+}));
+
+vi.mock("../../../src/utils/settings/applySettingsChange.js", () => ({
+  applySettingsChange: mockFns.applySettingsChange,
+}));
+
+vi.mock("../../../src/services/PromptSuggestion/promptSuggestion.js", () => ({
+  shouldEnablePromptSuggestion: () => false,
+}));
+
+vi.mock("../../../src/tools/Tool.js", () => ({
+  buildTool: (tool: unknown) => tool,
+  getEmptyToolPermissionContext: () => ({
+    additionalDirectories: [],
+    alwaysAllowRules: [],
+    alwaysDenyRules: [],
+    isBypassPermissionsModeAvailable: false,
+    mode: "default",
+  }),
+}));
+
+vi.mock("../../../src/utils/commitAttribution.js", () => ({
+  createEmptyAttributionState: () => ({}),
+}));
+
+vi.mock("../../../src/utils/settings/settings.js", () => ({
+  getInitialSettings: () => ({}),
+}));
+
+vi.mock("../../../src/utils/teammate.js", () => ({
+  isPlanModeRequired: () => false,
+  isTeammate: () => false,
+}));
+
+vi.mock("../../../src/utils/thinking.js", () => ({
+  shouldEnableThinkingByDefault: () => false,
+}));
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: () => void;
+  unref: () => void;
+};
+
+type TestStdout = PassThrough & {
+  columns: number;
+  isTTY: boolean;
+  rows: number;
+};
+
+function makeState(overrides: Partial<AppState> = {}): AppState {
+  return {
+    statusLineText: "ready",
+    toolPermissionContext: {
+      additionalDirectories: [],
+      alwaysAllowRules: [],
+      alwaysDenyRules: [],
+      isBypassPermissionsModeAvailable: false,
+      mode: "default",
+    },
+    ...overrides,
+  } as AppState;
+}
+
+function createStreams(): {
+  readonly stderr: PassThrough;
+  readonly stdin: TestStdin;
+  readonly stdout: TestStdout;
+} {
+  const stderr = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+  const stdout = new PassThrough() as TestStdout;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+
+  stdout.columns = 100;
+  stdout.rows = 24;
+  stdout.isTTY = true;
+  stdout.resume();
+
+  return { stderr, stdin, stdout };
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < 1_000) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  throw new Error(message);
+}
+
+function MaybeOutsideProbe(): React.ReactNode {
+  const value = useAppStateMaybeOutsideOfProvider(
+    (state) => state.statusLineText,
+  );
+
+  return <Text>{value ?? "outside-missing"}</Text>;
+}
+
+describe("AppState coverage swarm row 100", () => {
+  beforeEach(() => {
+    harness.bypassDisabled = false;
+    harness.settingsChange = undefined;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns undefined from the optional selector outside AppStateProvider", async () => {
+    const output = await renderToString(<MaybeOutsideProbe />, 80);
+
+    expect(output).toContain("outside-missing");
+  });
+
+  test("wires store access, setState, mount permission updates, and settings changes", async () => {
+    harness.bypassDisabled = true;
+    const initialState = makeState({
+      statusLineText: "before",
+      toolPermissionContext: {
+        additionalDirectories: [],
+        alwaysAllowRules: [],
+        alwaysDenyRules: [],
+        isBypassPermissionsModeAvailable: true,
+        mode: "bypassPermissions",
+      },
+    });
+    const onChangeAppState = vi.fn();
+    let capturedStore: AppStateStore | undefined;
+    let capturedSetAppState:
+      | ((updater: (prev: AppState) => AppState) => void)
+      | undefined;
+
+    function StoreProbe(): React.ReactNode {
+      capturedStore = useAppStateStore();
+      capturedSetAppState = useSetAppState();
+      const value = useAppStateMaybeOutsideOfProvider(
+        (state) => state.statusLineText,
+      );
+
+      return <Text>{value}</Text>;
+    }
+
+    const { stderr, stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={initialState}
+          onChangeAppState={onChangeAppState}
+        >
+          <StoreProbe />
+        </AppStateProvider>,
+      );
+
+      await waitForCondition(
+        () =>
+          capturedStore?.getState().toolPermissionContext
+            .isBypassPermissionsModeAvailable === false,
+        "Timed out waiting for bypass permission mode to be disabled",
+      );
+
+      expect(mockFns.logForDebugging).toHaveBeenCalledWith(
+        "Disabling bypass permissions mode on mount (remote settings loaded before mount)",
+      );
+      expect(
+        mockFns.createDisabledBypassPermissionsContext,
+      ).toHaveBeenCalledWith(initialState.toolPermissionContext);
+      expect(onChangeAppState).toHaveBeenCalledTimes(1);
+
+      capturedSetAppState?.((prev) => ({
+        ...prev,
+        statusLineText: "after-set",
+      }));
+
+      expect(capturedStore?.getState().statusLineText).toBe("after-set");
+      expect(onChangeAppState).toHaveBeenCalledTimes(2);
+
+      harness.settingsChange?.("workspace");
+
+      expect(mockFns.applySettingsChange).toHaveBeenCalledWith(
+        "workspace",
+        capturedStore?.setState,
+      );
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      stderr.end();
+    }
+  });
+
+  test("throws the strict hook error outside AppStateProvider", async () => {
+    function OutsideProviderProbe(): React.ReactNode {
+      useAppState((state) => state.statusLineText);
+      return <Text>outside</Text>;
+    }
+
+    const { stderr, stdin, stdout } = createStreams();
+    let stderrOutput = "";
+    stderr.on("data", (chunk) => {
+      stderrOutput += chunk.toString();
+    });
+    const root = await createRoot({
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(<OutsideProviderProbe />);
+
+      await waitForCondition(
+        () =>
+          stderrOutput.includes(
+            "useAppState/useSetAppState cannot be called outside of an <AppStateProvider />",
+          ),
+        "Timed out waiting for the strict AppState hook error",
+      );
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      stderr.end();
+    }
+  });
+
+  test("rejects nested AppStateProvider trees", async () => {
+    const initialState = makeState();
+    const { stderr, stdin, stdout } = createStreams();
+    let stderrOutput = "";
+    stderr.on("data", (chunk) => {
+      stderrOutput += chunk.toString();
+    });
+    const root = await createRoot({
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider initialState={initialState}>
+          <AppStateProvider initialState={initialState}>
+            <Text>nested</Text>
+          </AppStateProvider>
+        </AppStateProvider>,
+      );
+
+      await waitForCondition(
+        () =>
+          stderrOutput.includes(
+            "AppStateProvider can not be nested within another AppStateProvider",
+          ),
+        "Timed out waiting for nested AppStateProvider error",
+      );
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      stderr.end();
+    }
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-101-components-CustomSelect-use-select-navigation.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-101-components-CustomSelect-use-select-navigation.test.ts
@@ -1,0 +1,314 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import type { OptionWithDescription } from '../../../src/tui/components/CustomSelect/select.js'
+import {
+  optionsNavigateEqual,
+  type SelectNavigation,
+  useSelectNavigation,
+} from '../../../src/tui/components/CustomSelect/use-select-navigation.js'
+import { createRoot } from '../../../src/tui/ink/root.js'
+
+type TestStreams = {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+}
+
+type Snapshot = {
+  focusedIndex: number
+  focusedValue: string | undefined
+  isInInput: boolean
+  visibleFromIndex: number
+  visibleToIndex: number
+  visibleValues: string[]
+}
+
+function createTestStreams(): TestStreams {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStreams['stdin']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 120
+
+  return { stdout, stdin }
+}
+
+function options(
+  values: string[],
+  overrides: Record<string, Partial<OptionWithDescription<string>>> = {},
+): OptionWithDescription<string>[] {
+  return values.map(value => ({
+    value,
+    label: value,
+    ...overrides[value],
+  }))
+}
+
+function snapshotOf(navigation: SelectNavigation<string>): Snapshot {
+  return {
+    focusedIndex: navigation.focusedIndex,
+    focusedValue: navigation.focusedValue,
+    isInInput: navigation.isInInput,
+    visibleFromIndex: navigation.visibleFromIndex,
+    visibleToIndex: navigation.visibleToIndex,
+    visibleValues: navigation.visibleOptions.map(option => option.value),
+  }
+}
+
+async function waitForNavigation(
+  controlsRef: { current: SelectNavigation<string> | null },
+  expected: Partial<Snapshot>,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < 2_000) {
+    const current = controlsRef.current
+    if (current) {
+      const snapshot = snapshotOf(current)
+      const matches = Object.entries(expected).every(([key, value]) => {
+        const actual = snapshot[key as keyof Snapshot]
+        return Array.isArray(value)
+          ? JSON.stringify(actual) === JSON.stringify(value)
+          : actual === value
+      })
+
+      if (matches) {
+        return
+      }
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+
+  const latest = controlsRef.current ? snapshotOf(controlsRef.current) : null
+  throw new Error(
+    `Timed out waiting for select navigation ${JSON.stringify({
+      expected,
+      latest,
+    })}`,
+  )
+}
+
+function Harness({
+  controlsRef,
+  focusValue,
+  initialFocusValue,
+  onFocus,
+  optionItems,
+  visibleOptionCount,
+}: {
+  controlsRef: { current: SelectNavigation<string> | null }
+  focusValue?: string
+  initialFocusValue?: string
+  onFocus?: (value: string) => void
+  optionItems: OptionWithDescription<string>[]
+  visibleOptionCount?: number
+}): null {
+  controlsRef.current = useSelectNavigation({
+    focusValue,
+    initialFocusValue,
+    onFocus,
+    options: optionItems,
+    visibleOptionCount,
+  })
+
+  return null
+}
+
+async function renderNavigation(
+  props: Omit<React.ComponentProps<typeof Harness>, 'controlsRef'>,
+): Promise<{
+  controlsRef: { current: SelectNavigation<string> | null }
+  dispose: () => void
+  rerender: (
+    nextProps: Omit<React.ComponentProps<typeof Harness>, 'controlsRef'>,
+  ) => void
+}> {
+  const controlsRef = { current: null as SelectNavigation<string> | null }
+  const { stdout, stdin } = createTestStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  const render = (
+    nextProps: Omit<React.ComponentProps<typeof Harness>, 'controlsRef'>,
+  ) => {
+    root.render(React.createElement(Harness, { ...nextProps, controlsRef }))
+  }
+
+  render(props)
+
+  return {
+    controlsRef,
+    dispose: () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    },
+    rerender: render,
+  }
+}
+
+describe('useSelectNavigation coverage swarm row 101', () => {
+  test('compares option arrays using only navigation fields', () => {
+    expect(
+      optionsNavigateEqual(
+        [{ value: 'same', label: 'Original' }],
+        [{ value: 'same', label: React.createElement('span', null, 'New') }],
+      ),
+    ).toBe(true)
+
+    expect(
+      optionsNavigateEqual(
+        [{ value: 'one', label: 'One' }],
+        [
+          { value: 'one', label: 'One' },
+          { value: 'two', label: 'Two' },
+        ],
+      ),
+    ).toBe(false)
+
+    expect(
+      optionsNavigateEqual(
+        [{ value: 'one', label: 'One' }],
+        [{ value: 'two', label: 'One' }],
+      ),
+    ).toBe(false)
+
+    expect(
+      optionsNavigateEqual(
+        [{ value: 'one', label: 'One' }],
+        [{ value: 'one', label: 'One', disabled: true }],
+      ),
+    ).toBe(false)
+
+    expect(
+      optionsNavigateEqual(
+        [{ type: 'input', value: 'one', label: 'One', onChange: vi.fn() }],
+        [{ value: 'one', label: 'One' }],
+      ),
+    ).toBe(false)
+  })
+
+  test('uses the default page size when initial focus starts below the viewport', async () => {
+    const rendered = await renderNavigation({
+      initialFocusValue: 'seven',
+      optionItems: options([
+        'one',
+        'two',
+        'three',
+        'four',
+        'five',
+        'six',
+        'seven',
+      ]),
+    })
+
+    try {
+      await waitForNavigation(rendered.controlsRef, {
+        focusedIndex: 7,
+        focusedValue: 'seven',
+        isInInput: false,
+        visibleFromIndex: 2,
+        visibleToIndex: 7,
+        visibleValues: ['three', 'four', 'five', 'six', 'seven'],
+      })
+
+      rendered.controlsRef.current?.focusPreviousOption()
+      await waitForNavigation(rendered.controlsRef, {
+        focusedIndex: 6,
+        focusedValue: 'six',
+        visibleFromIndex: 2,
+        visibleToIndex: 7,
+        visibleValues: ['three', 'four', 'five', 'six', 'seven'],
+      })
+    } finally {
+      rendered.dispose()
+    }
+  })
+
+  test('preserves the current viewport when option metadata changes without moving focus', async () => {
+    const onFocus = vi.fn()
+    const rendered = await renderNavigation({
+      initialFocusValue: 'two',
+      onFocus,
+      optionItems: options(['one', 'two', 'three', 'four']),
+      visibleOptionCount: 2,
+    })
+
+    try {
+      await waitForNavigation(rendered.controlsRef, {
+        focusedValue: 'two',
+        visibleFromIndex: 0,
+        visibleToIndex: 2,
+        visibleValues: ['one', 'two'],
+      })
+
+      rendered.rerender({
+        initialFocusValue: 'two',
+        onFocus,
+        optionItems: options(['one', 'two', 'three', 'four'], {
+          one: { disabled: true },
+        }),
+        visibleOptionCount: 2,
+      })
+
+      await waitForNavigation(rendered.controlsRef, {
+        focusedIndex: 2,
+        focusedValue: 'two',
+        visibleFromIndex: 0,
+        visibleToIndex: 2,
+        visibleValues: ['one', 'two'],
+      })
+      expect(onFocus).toHaveBeenLastCalledWith('two')
+    } finally {
+      rendered.dispose()
+    }
+  })
+
+  test('reports empty navigation as unfocused and non-input', async () => {
+    const rendered = await renderNavigation({
+      optionItems: [],
+      visibleOptionCount: 3,
+    })
+
+    try {
+      await waitForNavigation(rendered.controlsRef, {
+        focusedIndex: 0,
+        focusedValue: undefined,
+        isInInput: false,
+        visibleFromIndex: 0,
+        visibleToIndex: 0,
+        visibleValues: [],
+      })
+
+      rendered.controlsRef.current?.focusNextOption()
+      rendered.controlsRef.current?.focusPreviousOption()
+      rendered.controlsRef.current?.focusNextPage()
+      rendered.controlsRef.current?.focusPreviousPage()
+      rendered.controlsRef.current?.focusOption(undefined)
+
+      await waitForNavigation(rendered.controlsRef, {
+        focusedIndex: 0,
+        focusedValue: undefined,
+        visibleFromIndex: 0,
+        visibleToIndex: 0,
+        visibleValues: [],
+      })
+    } finally {
+      rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-102-components-diff-StructuredDiff.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-102-components-diff-StructuredDiff.test.tsx
@@ -1,0 +1,323 @@
+import { PassThrough } from 'node:stream'
+
+import type { StructuredPatchHunk } from 'diff'
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  colorLines: ['+ highlighted line'],
+  constructorCalls: [] as Array<{
+    readonly fileContent: string | null
+    readonly filePath: string
+    readonly firstLine: string | null
+    readonly patch: StructuredPatchHunk
+  }>,
+  fallbackCalls: [] as Array<{
+    readonly dim: boolean
+    readonly patch: StructuredPatchHunk
+    readonly width: unknown
+  }>,
+  fullscreen: false,
+  rawAnsiCalls: [] as Array<{
+    readonly lines: readonly string[]
+    readonly width: number
+  }>,
+  renderCalls: [] as Array<{
+    readonly dim: boolean
+    readonly theme: string
+    readonly width: number
+  }>,
+  settings: {
+    syntaxHighlightingDisabled: false,
+  },
+  sliceCalls: [] as Array<{ readonly end?: number; readonly line: string; readonly start: number }>,
+  theme: 'dark-theme',
+}))
+
+vi.mock('../../../src/tui/hooks/useSettings.js', () => ({
+  useSettings: () => harness.settings,
+}))
+
+vi.mock('../../../src/tui/ink.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../src/tui/ink.js')>()
+  return {
+    ...actual,
+    RawAnsi: ({
+      lines,
+      width,
+    }: {
+      readonly lines: readonly string[]
+      readonly width: number
+    }) => {
+      harness.rawAnsiCalls.push({ lines, width })
+      return React.createElement(
+        actual.Text,
+        null,
+        `RawAnsi:${width}:${lines.join('|')}`,
+      )
+    },
+    useTheme: () => [harness.theme],
+  }
+})
+
+vi.mock('../../../src/utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => harness.fullscreen,
+}))
+
+vi.mock('../../../src/utils/sliceAnsi.js', () => ({
+  default: (line: string, start: number, end?: number) => {
+    harness.sliceCalls.push({ end, line, start })
+    return line.slice(start, end)
+  },
+}))
+
+vi.mock('../../../src/tui/components/diff/StructuredDiff/colorDiff.js', () => ({
+  expectColorDiff: () =>
+    class FakeColorDiff {
+      constructor(
+        patch: StructuredPatchHunk,
+        firstLine: string | null,
+        filePath: string,
+        fileContent: string | null,
+      ) {
+        harness.constructorCalls.push({
+          fileContent,
+          filePath,
+          firstLine,
+          patch,
+        })
+      }
+
+      render(theme: string, width: number, dim: boolean): string[] {
+        harness.renderCalls.push({ dim, theme, width })
+        return harness.colorLines
+      }
+    },
+}))
+
+vi.mock('../../../src/tui/components/diff/StructuredDiff/Fallback.js', async () => {
+  const ReactModule = await import('react')
+  const { Text } = await import('../../../src/tui/ink.js')
+  return {
+    StructuredDiffFallback: ({
+      dim,
+      patch,
+      width,
+    }: {
+      readonly dim: boolean
+      readonly patch: StructuredPatchHunk
+      readonly width: unknown
+    }) => {
+      harness.fallbackCalls.push({ dim, patch, width })
+      return ReactModule.createElement(
+        Text,
+        null,
+        `Fallback:${patch.oldStart}:${dim ? 'dim' : 'normal'}:${String(width)}`,
+      )
+    },
+  }
+})
+
+import { createRoot } from '../../../src/tui/ink/root.js'
+import { StructuredDiff } from '../../../src/tui/components/diff/StructuredDiff.js'
+
+function patch(overrides: Partial<StructuredPatchHunk> = {}): StructuredPatchHunk {
+  return {
+    lines: [' context', '-old value', '+new value'],
+    newLines: 3,
+    newStart: 1,
+    oldLines: 3,
+    oldStart: 1,
+    ...overrides,
+  }
+}
+
+function widthObject(value: number): number {
+  return new Number(value) as unknown as number
+}
+
+async function sleep(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 25))
+}
+
+async function createTestRoot(): Promise<{
+  readonly cleanup: () => Promise<void>
+  readonly output: () => string
+  readonly render: (
+    props: Partial<React.ComponentProps<typeof StructuredDiff>> & {
+      readonly patch: StructuredPatchHunk
+      readonly width: number
+    },
+  ) => Promise<void>
+}> {
+  let output = ''
+  const stdout = new PassThrough()
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+  ;(stdout as unknown as { columns: number; rows: number }).columns = 120
+  ;(stdout as unknown as { columns: number; rows: number }).rows = 30
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  return {
+    cleanup: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    output: () => stripAnsi(output),
+    render: async props => {
+      root.render(
+        <StructuredDiff
+          dim={props.dim ?? false}
+          fileContent={props.fileContent}
+          filePath={props.filePath ?? 'src/example.ts'}
+          firstLine={props.firstLine ?? null}
+          patch={props.patch}
+          skipHighlighting={props.skipHighlighting}
+          width={props.width}
+        />,
+      )
+      await sleep()
+    },
+  }
+}
+
+beforeEach(() => {
+  harness.colorLines = ['+ highlighted line']
+  harness.constructorCalls = []
+  harness.fallbackCalls = []
+  harness.fullscreen = false
+  harness.rawAnsiCalls = []
+  harness.renderCalls = []
+  harness.settings = { syntaxHighlightingDisabled: false }
+  harness.sliceCalls = []
+  harness.theme = 'dark-theme'
+})
+
+describe('StructuredDiff coverage swarm 102', () => {
+  test('reuses the single-column highlighted element when only raw width identity changes', async () => {
+    harness.colorLines = ['+ tiny terminal line']
+    const currentPatch = patch({ oldStart: 8 })
+    const root = await createTestRoot()
+
+    try {
+      await root.render({
+        fileContent: undefined,
+        filePath: 'bin/run',
+        firstLine: '#!/usr/bin/env node',
+        patch: currentPatch,
+        width: widthObject(0.2),
+      })
+      await root.render({
+        fileContent: undefined,
+        filePath: 'bin/run',
+        firstLine: '#!/usr/bin/env node',
+        patch: currentPatch,
+        width: widthObject(0.8),
+      })
+
+      expect(root.output()).toContain('RawAnsi:1:+ tiny terminal line')
+      expect(harness.constructorCalls).toEqual([
+        {
+          fileContent: null,
+          filePath: 'bin/run',
+          firstLine: '#!/usr/bin/env node',
+          patch: currentPatch,
+        },
+      ])
+      expect(harness.renderCalls).toEqual([
+        { dim: false, theme: 'dark-theme', width: 1 },
+      ])
+      expect(harness.rawAnsiCalls).toHaveLength(1)
+      expect(harness.sliceCalls).toEqual([])
+    } finally {
+      await root.cleanup()
+    }
+  })
+
+  test('reuses pre-split gutter columns on same-safe-width rerenders', async () => {
+    harness.fullscreen = true
+    harness.colorLines = ['+ 1001 added value', '  1002 same value']
+    const currentPatch = patch({
+      newLines: 2,
+      newStart: 1000,
+      oldLines: 3,
+      oldStart: 998,
+    })
+    const root = await createTestRoot()
+
+    try {
+      await root.render({ patch: currentPatch, width: widthObject(30.1) })
+      await root.render({ patch: currentPatch, width: widthObject(30.9) })
+
+      expect(root.output()).toContain('RawAnsi:7:+ 1001 |  1002 ')
+      expect(root.output()).toContain('RawAnsi:23:added value|same value')
+      expect(harness.renderCalls).toEqual([
+        { dim: false, theme: 'dark-theme', width: 30 },
+      ])
+      expect(harness.rawAnsiCalls).toHaveLength(2)
+      expect(harness.sliceCalls).toEqual([
+        { end: 7, line: '+ 1001 added value', start: 0 },
+        { end: 7, line: '  1002 same value', start: 0 },
+        { end: undefined, line: '+ 1001 added value', start: 7 },
+        { end: undefined, line: '  1002 same value', start: 7 },
+      ])
+    } finally {
+      await root.cleanup()
+    }
+  })
+
+  test('reuses the fallback element when skipped highlighting rerenders with a new file path', async () => {
+    const currentPatch = patch({ oldStart: 21 })
+    const root = await createTestRoot()
+
+    try {
+      await root.render({
+        dim: true,
+        filePath: 'src/first.ts',
+        patch: currentPatch,
+        skipHighlighting: true,
+        width: 44,
+      })
+      await root.render({
+        dim: true,
+        filePath: 'src/second.ts',
+        patch: currentPatch,
+        skipHighlighting: true,
+        width: 44,
+      })
+
+      expect(root.output()).toContain('Fallback:21:dim:44')
+      expect(harness.renderCalls).toEqual([])
+      expect(harness.rawAnsiCalls).toEqual([])
+      expect(harness.fallbackCalls).toEqual([
+        {
+          dim: true,
+          patch: currentPatch,
+          width: 44,
+        },
+      ])
+    } finally {
+      await root.cleanup()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-103-ink-optimizer.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-103-ink-optimizer.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest'
+
+import type { Diff } from '../../../src/tui/ink/frame.js'
+import { optimize } from '../../../src/tui/ink/optimizer.js'
+
+describe('optimizer coverage swarm row 103', () => {
+  test('returns empty and single-patch diffs unchanged', () => {
+    const empty: Diff = []
+    const single: Diff = [{ type: 'stdout', content: 'ready' }]
+
+    expect(optimize(empty)).toBe(empty)
+    expect(optimize(single)).toBe(single)
+  })
+
+  test('filters no-op stdout, cursorMove, and clear patches', () => {
+    const diff: Diff = [
+      { type: 'stdout', content: '' },
+      { type: 'cursorMove', x: 0, y: 0 },
+      { type: 'clear', count: 0 },
+      { type: 'stdout', content: 'visible' },
+      { type: 'clear', count: 2 },
+    ]
+
+    expect(optimize(diff)).toEqual([
+      { type: 'stdout', content: 'visible' },
+      { type: 'clear', count: 2 },
+    ])
+  })
+
+  test('merges cursor moves and collapses consecutive cursorTo patches', () => {
+    const diff: Diff = [
+      { type: 'cursorMove', x: 2, y: -1 },
+      { type: 'cursorMove', x: -3, y: 4 },
+      { type: 'stdout', content: 'x' },
+      { type: 'cursorTo', col: 4 },
+      { type: 'cursorTo', col: 9 },
+    ]
+
+    expect(optimize(diff)).toEqual([
+      { type: 'cursorMove', x: -1, y: 3 },
+      { type: 'stdout', content: 'x' },
+      { type: 'cursorTo', col: 9 },
+    ])
+  })
+
+  test('concatenates adjacent styles and dedupes only repeated hyperlink URIs', () => {
+    const diff: Diff = [
+      { type: 'styleStr', str: '\u001B[49m' },
+      { type: 'styleStr', str: '\u001B[2m' },
+      { type: 'hyperlink', uri: 'https://agenc.test/a' },
+      { type: 'hyperlink', uri: 'https://agenc.test/a' },
+      { type: 'hyperlink', uri: 'https://agenc.test/b' },
+    ]
+
+    expect(optimize(diff)).toEqual([
+      { type: 'styleStr', str: '\u001B[49m\u001B[2m' },
+      { type: 'hyperlink', uri: 'https://agenc.test/a' },
+      { type: 'hyperlink', uri: 'https://agenc.test/b' },
+    ])
+  })
+
+  test('cancels adjacent cursor visibility pairs in both orders', () => {
+    const diff: Diff = [
+      { type: 'cursorHide' },
+      { type: 'cursorShow' },
+      { type: 'stdout', content: 'after-first-pair' },
+      { type: 'cursorShow' },
+      { type: 'cursorHide' },
+      { type: 'stdout', content: 'after-second-pair' },
+    ]
+
+    expect(optimize(diff)).toEqual([
+      { type: 'stdout', content: 'after-first-pair' },
+      { type: 'stdout', content: 'after-second-pair' },
+    ])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-104-ink-termio-csi.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-104-ink-termio-csi.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  CSI_PREFIX,
+  CURSOR_HOME,
+  CURSOR_LEFT,
+  CURSOR_RESTORE,
+  CURSOR_SAVE,
+  CURSOR_STYLES,
+  DISABLE_KITTY_KEYBOARD,
+  DISABLE_MODIFY_OTHER_KEYS,
+  ENABLE_KITTY_KEYBOARD,
+  ENABLE_MODIFY_OTHER_KEYS,
+  ERASE_LINE,
+  ERASE_SCREEN,
+  ERASE_SCROLLBACK,
+  FOCUS_IN,
+  FOCUS_OUT,
+  PASTE_END,
+  PASTE_START,
+  RESET_SCROLL_REGION,
+  csi,
+  cursorBack,
+  cursorDown,
+  cursorForward,
+  cursorMove,
+  cursorPosition,
+  cursorTo,
+  cursorUp,
+  eraseLine,
+  eraseLines,
+  eraseScreen,
+  eraseToEndOfLine,
+  eraseToEndOfScreen,
+  eraseToStartOfLine,
+  eraseToStartOfScreen,
+  isCSIFinal,
+  isCSIIntermediate,
+  isCSIParam,
+  scrollDown,
+  scrollUp,
+  setScrollRegion,
+} from '../../../src/tui/ink/termio/csi.js'
+
+const CSI = '\x1b['
+
+describe('termio CSI helpers coverage swarm row 104', () => {
+  test('classifies CSI byte ranges by inclusive boundaries', () => {
+    expect(CSI_PREFIX).toBe(CSI)
+
+    expect(isCSIParam(0x2f)).toBe(false)
+    expect(isCSIParam(0x30)).toBe(true)
+    expect(isCSIParam(0x3f)).toBe(true)
+    expect(isCSIParam(0x40)).toBe(false)
+
+    expect(isCSIIntermediate(0x1f)).toBe(false)
+    expect(isCSIIntermediate(0x20)).toBe(true)
+    expect(isCSIIntermediate(0x2f)).toBe(true)
+    expect(isCSIIntermediate(0x30)).toBe(false)
+
+    expect(isCSIFinal(0x3f)).toBe(false)
+    expect(isCSIFinal(0x40)).toBe(true)
+    expect(isCSIFinal(0x7e)).toBe(true)
+    expect(isCSIFinal(0x7f)).toBe(false)
+  })
+
+  test('formats CSI sequences from raw bodies and joined parameters', () => {
+    expect(csi()).toBe(CSI)
+    expect(csi('H')).toBe(`${CSI}H`)
+    expect(csi('>4;2m')).toBe(`${CSI}>4;2m`)
+    expect(csi(4, 20, 'r')).toBe(`${CSI}4;20r`)
+    expect(csi('?25', 'l')).toBe(`${CSI}?25l`)
+  })
+
+  test('generates cursor movement and save/restore sequences', () => {
+    expect(cursorUp()).toBe(`${CSI}1A`)
+    expect(cursorUp(0)).toBe('')
+    expect(cursorDown(2)).toBe(`${CSI}2B`)
+    expect(cursorDown(0)).toBe('')
+    expect(cursorForward(3)).toBe(`${CSI}3C`)
+    expect(cursorForward(0)).toBe('')
+    expect(cursorBack(4)).toBe(`${CSI}4D`)
+    expect(cursorBack(0)).toBe('')
+
+    expect(cursorTo(7)).toBe(`${CSI}7G`)
+    expect(CURSOR_LEFT).toBe(`${CSI}G`)
+    expect(cursorPosition(8, 9)).toBe(`${CSI}8;9H`)
+    expect(CURSOR_HOME).toBe(`${CSI}H`)
+    expect(CURSOR_SAVE).toBe(`${CSI}s`)
+    expect(CURSOR_RESTORE).toBe(`${CSI}u`)
+  })
+
+  test('combines relative cursor movement in horizontal then vertical order', () => {
+    expect(cursorMove(0, 0)).toBe('')
+    expect(cursorMove(3, 2)).toBe(`${CSI}3C${CSI}2B`)
+    expect(cursorMove(-4, -5)).toBe(`${CSI}4D${CSI}5A`)
+    expect(cursorMove(6, -7)).toBe(`${CSI}6C${CSI}7A`)
+    expect(cursorMove(-8, 9)).toBe(`${CSI}8D${CSI}9B`)
+  })
+
+  test('generates erase sequences and repeated line clearing', () => {
+    expect(eraseToEndOfLine()).toBe(`${CSI}K`)
+    expect(eraseToStartOfLine()).toBe(`${CSI}1K`)
+    expect(eraseLine()).toBe(`${CSI}2K`)
+    expect(ERASE_LINE).toBe(`${CSI}2K`)
+
+    expect(eraseToEndOfScreen()).toBe(`${CSI}J`)
+    expect(eraseToStartOfScreen()).toBe(`${CSI}1J`)
+    expect(eraseScreen()).toBe(`${CSI}2J`)
+    expect(ERASE_SCREEN).toBe(`${CSI}2J`)
+    expect(ERASE_SCROLLBACK).toBe(`${CSI}3J`)
+
+    expect(eraseLines(0)).toBe('')
+    expect(eraseLines(-1)).toBe('')
+    expect(eraseLines(1)).toBe(`${CSI}2K${CSI}G`)
+    expect(eraseLines(3)).toBe(`${CSI}2K${CSI}1A${CSI}2K${CSI}1A${CSI}2K${CSI}G`)
+  })
+
+  test('generates scroll, paste, focus, keyboard, and mode sequences', () => {
+    expect(scrollUp()).toBe(`${CSI}1S`)
+    expect(scrollUp(0)).toBe('')
+    expect(scrollDown(2)).toBe(`${CSI}2T`)
+    expect(scrollDown(0)).toBe('')
+    expect(setScrollRegion(4, 20)).toBe(`${CSI}4;20r`)
+    expect(RESET_SCROLL_REGION).toBe(`${CSI}r`)
+
+    expect(PASTE_START).toBe(`${CSI}200~`)
+    expect(PASTE_END).toBe(`${CSI}201~`)
+    expect(FOCUS_IN).toBe(`${CSI}I`)
+    expect(FOCUS_OUT).toBe(`${CSI}O`)
+    expect(ENABLE_KITTY_KEYBOARD).toBe(`${CSI}>1u`)
+    expect(DISABLE_KITTY_KEYBOARD).toBe(`${CSI}<u`)
+    expect(ENABLE_MODIFY_OTHER_KEYS).toBe(`${CSI}>4;2m`)
+    expect(DISABLE_MODIFY_OTHER_KEYS).toBe(`${CSI}>4m`)
+  })
+
+  test('exports cursor style lookup values by protocol index', () => {
+    expect(CURSOR_STYLES).toEqual([
+      { blinking: true, style: 'block' },
+      { blinking: true, style: 'block' },
+      { blinking: false, style: 'block' },
+      { blinking: true, style: 'underline' },
+      { blinking: false, style: 'underline' },
+      { blinking: true, style: 'bar' },
+      { blinking: false, style: 'bar' },
+    ])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-105-message-renderers-UserTeammateMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-105-message-renderers-UserTeammateMessage.test.tsx
@@ -1,0 +1,205 @@
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../../src/tui/hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    syntaxHighlightingDisabled: true,
+  }),
+}))
+
+import { TEAMMATE_MESSAGE_TAG } from '../../../src/constants/xml.js'
+import { UserTeammateMessage } from '../../../src/tui/message-renderers/UserTeammateMessage.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+
+function teammateMessage({
+  teammateId,
+  color,
+  summary,
+  content,
+}: {
+  readonly teammateId: string
+  readonly color?: string
+  readonly summary?: string
+  readonly content: string
+}): string {
+  const colorAttribute = color ? ` color="${color}"` : ''
+  const summaryAttribute = summary ? ` summary="${summary}"` : ''
+
+  return `<${TEAMMATE_MESSAGE_TAG} teammate_id="${teammateId}"${colorAttribute}${summaryAttribute}>
+${content}
+</${TEAMMATE_MESSAGE_TAG}>`
+}
+
+function payload(value: Record<string, unknown>): string {
+  return JSON.stringify(value)
+}
+
+async function renderUserTeammateMessage(
+  text: string,
+  options: {
+    readonly addMargin?: boolean
+    readonly isTranscriptMode?: boolean
+  } = {},
+): Promise<string> {
+  return renderToString(
+    <UserTeammateMessage
+      addMargin={options.addMargin ?? false}
+      isTranscriptMode={options.isTranscriptMode}
+      param={{ type: 'text', text }}
+    />,
+    { columns: 120, rows: 30 },
+  )
+}
+
+describe('UserTeammateMessage coverage swarm 105', () => {
+  test('renders nothing for unmatched input, empty teammate content, and lifecycle-only messages', async () => {
+    expect((await renderUserTeammateMessage('plain text')).trim()).toBe('')
+    expect(
+      (
+        await renderUserTeammateMessage(
+          `<${TEAMMATE_MESSAGE_TAG} teammate_id="empty"></${TEAMMATE_MESSAGE_TAG}>`,
+        )
+      ).trim(),
+    ).toBe('')
+    expect(
+      (
+        await renderUserTeammateMessage(
+          teammateMessage({
+            teammateId: 'worker',
+            content: payload({
+              type: 'shutdown_approved',
+              requestId: 'shutdown-105',
+              from: 'worker',
+              timestamp: '2026-05-20T00:00:00.000Z',
+            }),
+          }),
+        )
+      ).trim(),
+    ).toBe('')
+  })
+
+  test('renders plan approval request and response payloads from teammate messages', async () => {
+    const output = await renderUserTeammateMessage(
+      [
+        teammateMessage({
+          teammateId: 'planner',
+          color: 'cyan',
+          content: payload({
+            type: 'plan_approval_request',
+            from: 'planner',
+            timestamp: '2026-05-20T00:00:00.000Z',
+            planFilePath: '/tmp/row-105-plan.md',
+            planContent: '# Row 105\n\n- Add teammate renderer coverage',
+            requestId: 'plan-105',
+          }),
+        }),
+        teammateMessage({
+          teammateId: 'leader',
+          color: 'green',
+          content: payload({
+            type: 'plan_approval_response',
+            requestId: 'plan-105',
+            approved: false,
+            feedback: 'Tighten the branch assertions.',
+            timestamp: '2026-05-20T00:00:01.000Z',
+          }),
+        }),
+      ].join('\n'),
+    )
+
+    expect(output).toContain('Plan Approval Request from planner')
+    expect(output).toContain('Row 105')
+    expect(output).toContain('Plan file: /tmp/row-105-plan.md')
+    expect(output).toContain('Plan Rejected by leader')
+    expect(output).toContain('Feedback: Tighten the branch assertions.')
+  })
+
+  test('renders shutdown request, shutdown rejection, and task assignment payloads', async () => {
+    const output = await renderUserTeammateMessage(
+      [
+        teammateMessage({
+          teammateId: 'leader',
+          content: payload({
+            type: 'shutdown_request',
+            requestId: 'shutdown-105',
+            from: 'leader',
+            reason: 'coverage pass complete',
+            timestamp: '2026-05-20T00:00:00.000Z',
+          }),
+        }),
+        teammateMessage({
+          teammateId: 'worker',
+          content: payload({
+            type: 'shutdown_rejected',
+            requestId: 'shutdown-105',
+            from: 'worker',
+            reason: 'target test still running',
+            timestamp: '2026-05-20T00:00:01.000Z',
+          }),
+        }),
+        teammateMessage({
+          teammateId: 'leader',
+          content: payload({
+            type: 'task_assignment',
+            taskId: '105',
+            subject: 'Cover UserTeammateMessage',
+            description: 'Exercise structured payload branches.',
+            assignedBy: 'leader',
+            timestamp: '2026-05-20T00:00:02.000Z',
+          }),
+        }),
+      ].join('\n'),
+    )
+
+    expect(output).toContain('Shutdown request from leader')
+    expect(output).toContain('Reason: coverage pass complete')
+    expect(output).toContain('Shutdown rejected by worker')
+    expect(output).toContain('Reason: target test still running')
+    expect(output).toContain('Task #105 assigned by leader')
+    expect(output).toContain('Cover UserTeammateMessage')
+    expect(output).toContain('Exercise structured payload branches.')
+  })
+
+  test('renders completed tasks without a subject and plain transcript content with summaries', async () => {
+    const transcript = await renderUserTeammateMessage(
+      [
+        teammateMessage({
+          teammateId: 'worker',
+          color: 'magenta',
+          summary: 'shared raw notes',
+          content: '{not json',
+        }),
+        teammateMessage({
+          teammateId: 'worker',
+          content: payload({
+            type: 'task_completed',
+            from: 'worker',
+            taskId: '105',
+          }),
+        }),
+      ].join('\n'),
+      { addMargin: true, isTranscriptMode: true },
+    )
+
+    expect(transcript).toContain('@worker')
+    expect(transcript).toContain('shared raw notes')
+    expect(transcript).toContain('{not json')
+    expect(transcript).toContain('Completed task #105')
+    expect(transcript).not.toContain('(undefined)')
+
+    const compact = await renderUserTeammateMessage(
+      teammateMessage({
+        teammateId: 'worker',
+        content: 'hidden outside transcript mode',
+      }),
+      { isTranscriptMode: false },
+    )
+
+    expect(compact).toContain('@worker')
+    expect(compact).not.toContain('hidden outside transcript mode')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-106-realtime-audio.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-106-realtime-audio.test.ts
@@ -1,0 +1,161 @@
+import { type ChildProcess } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+
+import { describe, expect, test, vi } from 'vitest'
+
+import type { ThreadRealtimeAudioChunk } from '../../../src/app-server/protocol/index.ts'
+import {
+  createProcessRealtimeAudioPlayer,
+  pcmBufferToRealtimeAudioChunk,
+  pcmPeakLevel,
+  type RealtimeAudioPlayerSpawn,
+} from '../../../src/tui/realtime/audio.ts'
+
+type TestChild = ChildProcess & {
+  readonly stdin: PassThrough
+}
+
+function outputAudio(
+  chunk: Buffer,
+  sampleRate = 24_000,
+  numChannels = 1,
+): ThreadRealtimeAudioChunk {
+  return {
+    data: chunk.toString('base64'),
+    sampleRate,
+    numChannels,
+  }
+}
+
+function createChild(
+  writeChunk: (chunk: Buffer) => boolean = () => true,
+): TestChild {
+  const child = new EventEmitter() as TestChild
+  const stdin = new PassThrough()
+  const destroy = stdin.destroy.bind(stdin)
+
+  stdin.write = vi.fn((chunk: Buffer | Uint8Array | string) => {
+    const buffer = Buffer.isBuffer(chunk)
+      ? Buffer.from(chunk)
+      : Buffer.from(chunk)
+    return writeChunk(buffer)
+  }) as never
+  stdin.destroy = vi.fn(() => destroy()) as never
+  child.stdin = stdin
+  child.kill = vi.fn(() => true) as never
+
+  return child
+}
+
+describe('realtime audio coverage swarm row 106', () => {
+  test('encodes capture PCM and ignores odd trailing peak bytes', () => {
+    const pcm = Buffer.from([0x00, 0x20, 0xff])
+
+    expect(pcmBufferToRealtimeAudioChunk(pcm)).toEqual({
+      data: pcm.toString('base64'),
+      sampleRate: 16_000,
+      numChannels: 1,
+      samplesPerChannel: 1,
+    })
+    expect(pcmPeakLevel(pcm)).toBe(16_384)
+  })
+
+  test('restarts playback when the output format changes and closes the active process', () => {
+    const children = [createChild(), createChild()]
+    const spawnProcess = vi.fn<RealtimeAudioPlayerSpawn>(() => {
+      const child = children.shift()
+      if (child === undefined) throw new Error('missing child')
+      return child
+    })
+    const player = createProcessRealtimeAudioPlayer(spawnProcess)
+
+    player.enqueue(outputAudio(Buffer.from([1, 2]), 24_000, 1))
+    player.enqueue(outputAudio(Buffer.from([3, 4]), 384_000, 8))
+
+    expect(spawnProcess).toHaveBeenNthCalledWith(
+      1,
+      'play',
+      [
+        '-q',
+        '-t',
+        'raw',
+        '-r',
+        '24000',
+        '-e',
+        'signed',
+        '-b',
+        '16',
+        '-c',
+        '1',
+        '-',
+      ],
+      { stdio: ['pipe', 'ignore', 'ignore'] },
+    )
+    expect(spawnProcess).toHaveBeenNthCalledWith(
+      2,
+      'play',
+      [
+        '-q',
+        '-t',
+        'raw',
+        '-r',
+        '384000',
+        '-e',
+        'signed',
+        '-b',
+        '16',
+        '-c',
+        '8',
+        '-',
+      ],
+      { stdio: ['pipe', 'ignore', 'ignore'] },
+    )
+    expect(children).toHaveLength(0)
+
+    const first = spawnProcess.mock.results[0]?.value as TestChild
+    const second = spawnProcess.mock.results[1]?.value as TestChild
+    expect(first.stdin.write).toHaveBeenCalledWith(Buffer.from([1, 2]))
+    expect(first.stdin.destroy).toHaveBeenCalledTimes(1)
+    expect(first.kill).toHaveBeenCalledWith('SIGTERM')
+    expect(second.stdin.write).toHaveBeenCalledWith(Buffer.from([3, 4]))
+
+    player.close()
+
+    expect(second.stdin.destroy).toHaveBeenCalledTimes(1)
+    expect(second.kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
+  test('resets after synchronous stdin write failures and respawns on the next chunk', () => {
+    const first = createChild(() => {
+      throw new Error('broken pipe')
+    })
+    const second = createChild()
+    const spawnProcess = vi.fn<RealtimeAudioPlayerSpawn>()
+      .mockReturnValueOnce(first)
+      .mockReturnValueOnce(second)
+    const player = createProcessRealtimeAudioPlayer(spawnProcess)
+    const chunk = outputAudio(Buffer.from([5, 6]))
+
+    expect(() => player.enqueue(chunk)).not.toThrow()
+    player.enqueue(chunk)
+
+    expect(spawnProcess).toHaveBeenCalledTimes(2)
+    expect(first.stdin.write).toHaveBeenCalledTimes(1)
+    expect(second.stdin.write).toHaveBeenCalledWith(Buffer.from([5, 6]))
+  })
+
+  test('drops output whose decoded payload exceeds the process queue limit', () => {
+    const spawnProcess = vi.fn<RealtimeAudioPlayerSpawn>(() => createChild())
+    const player = createProcessRealtimeAudioPlayer(spawnProcess)
+    const encodedLimit = Math.ceil((512 * 1024) / 3) * 4
+
+    player.enqueue({
+      data: 'A'.repeat(encodedLimit),
+      sampleRate: 24_000,
+      numChannels: 1,
+    })
+
+    expect(spawnProcess).not.toHaveBeenCalled()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-107-components-AutoModeOptInDialog.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-107-components-AutoModeOptInDialog.test.tsx
@@ -1,0 +1,207 @@
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { AutoModeOptInDialog } from "../../../src/tui/components/AutoModeOptInDialog.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+type SelectOption = {
+  label: string;
+  value: "accept" | "accept-default" | "decline";
+};
+
+type SelectProps = {
+  onCancel: () => void;
+  onChange: (value: string) => void;
+  options: SelectOption[];
+};
+
+type DialogProps = {
+  children: React.ReactNode;
+  color?: string;
+  onCancel: () => void;
+  title: React.ReactNode;
+};
+
+const harness = vi.hoisted(() => ({
+  dialogProps: [] as DialogProps[],
+  logEvent: vi.fn(),
+  selectProps: [] as SelectProps[],
+  updateSettingsForSource: vi.fn(),
+}));
+
+vi.mock("../../../src/services/analytics/index.js", () => ({
+  logEvent: harness.logEvent,
+}));
+
+vi.mock("../../../src/utils/settings/settings.js", () => ({
+  updateSettingsForSource: harness.updateSettingsForSource,
+}));
+
+vi.mock("../../../src/tui/components/CustomSelect/select.js", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    Select: (props: SelectProps) => {
+      harness.selectProps.push(props);
+
+      return ReactActual.createElement(
+        "ink-text",
+        null,
+        props.options.map(option => option.label).join("\n"),
+      );
+    },
+  };
+});
+
+vi.mock("../../../src/tui/components/design-system/Dialog.js", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    Dialog: (props: DialogProps) => {
+      harness.dialogProps.push(props);
+
+      return ReactActual.createElement(
+        "ink-box",
+        null,
+        ReactActual.createElement(
+          "ink-text",
+          null,
+          `Dialog:${String(props.title)}:${props.color ?? "none"}`,
+        ),
+        props.children,
+      );
+    },
+  };
+});
+
+async function renderDialog(
+  props: Partial<React.ComponentProps<typeof AutoModeOptInDialog>> = {},
+): Promise<string> {
+  return renderToString(
+    <AutoModeOptInDialog
+      onAccept={vi.fn()}
+      onDecline={vi.fn()}
+      {...props}
+    />,
+    { columns: 120, rows: 24 },
+  );
+}
+
+function latestSelectProps(): SelectProps {
+  const props = harness.selectProps.at(-1);
+  expect(props).toBeDefined();
+  return props!;
+}
+
+describe("AutoModeOptInDialog coverage swarm row 107", () => {
+  beforeEach(() => {
+    harness.dialogProps = [];
+    harness.selectProps = [];
+    harness.logEvent.mockReset();
+    harness.updateSettingsForSource.mockReset();
+  });
+
+  test("renders the warning dialog with the default decline label", async () => {
+    const onDecline = vi.fn();
+    const output = await renderDialog({ onDecline });
+
+    expect(output).toContain("Dialog:Enable auto mode?:warning");
+    expect(output).toContain(
+      "Auto mode lets AgenC handle permission prompts automatically",
+    );
+    expect(latestSelectProps().options).toEqual([
+      {
+        label: "Yes, and make it my default mode",
+        value: "accept-default",
+      },
+      {
+        label: "Yes, enable auto mode",
+        value: "accept",
+      },
+      {
+        label: "No, go back",
+        value: "decline",
+      },
+    ]);
+    expect(harness.dialogProps.at(-1)).toMatchObject({
+      color: "warning",
+      onCancel: onDecline,
+      title: "Enable auto mode?",
+    });
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      "agenc_auto_mode_opt_in_dialog_shown",
+      {},
+    );
+  });
+
+  test("uses the exit decline label for startup gating", async () => {
+    await renderDialog({ declineExits: true });
+
+    expect(latestSelectProps().options.at(-1)).toEqual({
+      label: "No, exit",
+      value: "decline",
+    });
+  });
+
+  test("accept stores the skip-prompt setting and accepts the dialog", async () => {
+    const onAccept = vi.fn();
+    const onDecline = vi.fn();
+    await renderDialog({ onAccept, onDecline });
+
+    harness.logEvent.mockClear();
+    latestSelectProps().onChange("accept");
+
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      "agenc_auto_mode_opt_in_dialog_accept",
+      {},
+    );
+    expect(harness.updateSettingsForSource).toHaveBeenCalledWith(
+      "userSettings",
+      {
+        skipAutoPermissionPrompt: true,
+      },
+    );
+    expect(onAccept).toHaveBeenCalledOnce();
+    expect(onDecline).not.toHaveBeenCalled();
+  });
+
+  test("accept-default also stores auto as the default permission mode", async () => {
+    const onAccept = vi.fn();
+    await renderDialog({ onAccept });
+
+    harness.logEvent.mockClear();
+    latestSelectProps().onChange("accept-default");
+
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      "agenc_auto_mode_opt_in_dialog_accept_default",
+      {},
+    );
+    expect(harness.updateSettingsForSource).toHaveBeenCalledWith(
+      "userSettings",
+      {
+        permissions: {
+          defaultMode: "auto",
+        },
+        skipAutoPermissionPrompt: true,
+      },
+    );
+    expect(onAccept).toHaveBeenCalledOnce();
+  });
+
+  test("decline logs the choice without changing settings", async () => {
+    const onAccept = vi.fn();
+    const onDecline = vi.fn();
+    await renderDialog({ onAccept, onDecline });
+
+    harness.logEvent.mockClear();
+    latestSelectProps().onChange("decline");
+
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      "agenc_auto_mode_opt_in_dialog_decline",
+      {},
+    );
+    expect(harness.updateSettingsForSource).not.toHaveBeenCalled();
+    expect(onAccept).not.toHaveBeenCalled();
+    expect(onDecline).toHaveBeenCalledOnce();
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-108-components-agents-agentFileUtils.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-108-components-agents-agentFileUtils.test.ts
@@ -1,0 +1,201 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import type { AgentDefinition } from '../../../src/tools/AgentTool/loadAgentsDir.js'
+import { runWithCwdOverride } from '../../../src/utils/cwd.js'
+import {
+  deleteAgentFromFile,
+  getActualAgentFilePath,
+  getActualRelativeAgentFilePath,
+  getNewAgentFilePath,
+  getNewRelativeAgentFilePath,
+  saveAgentToFile,
+  updateAgentFile,
+} from '../../../src/tui/components/agents/agentFileUtils.js'
+
+function customAgent(
+  agentType: string,
+  source: 'userSettings' | 'projectSettings' | 'policySettings' | 'flagSettings',
+  filename?: string,
+): AgentDefinition {
+  return {
+    agentType,
+    whenToUse: 'Use for focused coverage.',
+    source,
+    filename,
+    getSystemPrompt: () => 'Follow the instructions.',
+  }
+}
+
+describe('agentFileUtils coverage swarm row 108', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  test('resolves user, policy, local, and flag agent paths', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'agenc-agent-paths-'))
+    const configHome = join(cwd, 'config-home')
+    const managedHome = join(cwd, 'managed-home')
+
+    vi.stubEnv('AGENC_CONFIG_DIR', configHome)
+    vi.stubEnv('USER_TYPE', 'ant')
+    vi.stubEnv('AGENC_MANAGED_SETTINGS_PATH', managedHome)
+
+    try {
+      await runWithCwdOverride(cwd, async () => {
+        expect(
+          getNewAgentFilePath({
+            source: 'userSettings',
+            agentType: 'user-helper',
+          }),
+        ).toBe(join(configHome, 'agents', 'user-helper.md'))
+        expect(
+          getNewRelativeAgentFilePath({
+            source: 'userSettings',
+            agentType: 'user-helper',
+          }),
+        ).toBe(join(configHome, 'agents', 'user-helper.md'))
+
+        expect(
+          getNewAgentFilePath({
+            source: 'policySettings',
+            agentType: 'managed-helper',
+          }),
+        ).toBe(join(managedHome, '.agenc', 'agents', 'managed-helper.md'))
+        expect(
+          getNewRelativeAgentFilePath({
+            source: 'policySettings',
+            agentType: 'managed-helper',
+          }),
+        ).toBe(join(managedHome, '.agenc', 'agents', 'managed-helper.md'))
+
+        expect(
+          getNewAgentFilePath({
+            source: 'localSettings',
+            agentType: 'local-helper',
+          }),
+        ).toBe(join(cwd, '.agenc', 'agents', 'local-helper.md'))
+        expect(
+          getNewRelativeAgentFilePath({
+            source: 'localSettings',
+            agentType: 'local-helper',
+          }),
+        ).toBe(join(cwd, '.agenc', 'agents', 'local-helper.md'))
+
+        expect(getActualAgentFilePath(customAgent('user-helper', 'userSettings'))).toBe(
+          join(configHome, 'agents', 'user-helper.md'),
+        )
+        expect(
+          getActualRelativeAgentFilePath(
+            customAgent('renamed-helper', 'projectSettings', 'stored-helper'),
+          ),
+        ).toBe(join('.agenc', 'agents', 'stored-helper.md'))
+        expect(
+          getActualRelativeAgentFilePath(customAgent('cli-helper', 'flagSettings')),
+        ).toBe('CLI argument')
+        expect(
+          getActualRelativeAgentFilePath({
+            agentType: 'plugin-helper',
+            whenToUse: 'Use plugin behavior.',
+            source: 'plugin',
+            plugin: 'quality-plugin',
+            getSystemPrompt: () => 'Plugin prompt.',
+          }),
+        ).toBe('Plugin: quality-plugin')
+      })
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('saves user agents and preserves non-existence write errors', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'agenc-agent-save-'))
+    const configHome = join(cwd, 'config-home')
+
+    vi.stubEnv('AGENC_CONFIG_DIR', configHome)
+
+    try {
+      await saveAgentToFile(
+        'userSettings',
+        'user-helper',
+        'Use this helper for user-wide work.',
+        ['Read'],
+        'Stay focused.',
+      )
+
+      const userFile = join(configHome, 'agents', 'user-helper.md')
+      expect(readFileSync(userFile, 'utf8')).toContain('tools: Read')
+
+      await runWithCwdOverride(cwd, async () => {
+        await expect(
+          saveAgentToFile(
+            'projectSettings',
+            'missing-dir/nested-helper',
+            'Use this helper when a nested path is requested.',
+            ['Read'],
+            'This write should fail before content is created.',
+          ),
+        ).rejects.toMatchObject({ code: 'ENOENT' })
+      })
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects built-in mutations and rethrows delete failures', async () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'agenc-agent-errors-'))
+    const builtInAgent: AgentDefinition = {
+      agentType: 'built-in-helper',
+      whenToUse: 'Use built-in behavior.',
+      source: 'built-in',
+      baseDir: 'built-in',
+      getSystemPrompt: () => 'Built-in prompt.',
+    }
+
+    try {
+      await expect(
+        saveAgentToFile(
+          'built-in',
+          'built-in-helper',
+          'Use built-in behavior.',
+          undefined,
+          'Built-in prompt.',
+        ),
+      ).rejects.toThrow('Cannot save built-in agents')
+      await expect(
+        updateAgentFile(
+          builtInAgent,
+          'Use built-in behavior.',
+          undefined,
+          'Built-in prompt.',
+        ),
+      ).rejects.toThrow('Cannot update built-in agents')
+      await expect(deleteAgentFromFile(builtInAgent)).rejects.toThrow(
+        'Cannot delete built-in agents',
+      )
+
+      await runWithCwdOverride(cwd, async () => {
+        const agentDir = join(cwd, '.agenc', 'agents')
+        mkdirSync(join(agentDir, 'blocked-helper.md'), { recursive: true })
+
+        await expect(
+          deleteAgentFromFile(
+            customAgent('blocked-helper', 'projectSettings'),
+          ),
+        ).rejects.toMatchObject({ code: 'EISDIR' })
+        expect(existsSync(join(agentDir, 'blocked-helper.md'))).toBe(true)
+      })
+    } finally {
+      rmSync(cwd, { recursive: true, force: true })
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-109-hooks-useCancelRequest.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-109-hooks-useCancelRequest.test.ts
@@ -1,0 +1,324 @@
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from 'src/utils/staticRender.js'
+
+type AppState = {
+  tasks: Record<string, any>
+  viewSelectionMode: string
+}
+
+type CapturedKeybinding = {
+  handler: () => void
+  isActive?: boolean
+}
+
+const fixture = vi.hoisted(() => ({
+  state: {
+    tasks: {} as Record<string, any>,
+    viewSelectionMode: 'none',
+  } as AppState,
+  queuedCommandsLength: 0,
+  hasCommandsInQueue: false,
+  overlayActive: false,
+  vimEnabled: false,
+  keybindings: new Map<string, CapturedKeybinding>(),
+  addNotification: vi.fn(),
+  removeNotification: vi.fn(),
+  clearCommandQueue: vi.fn(),
+  enqueuePendingNotification: vi.fn(),
+  emitTaskTerminatedSdk: vi.fn(),
+  exitTeammateView: vi.fn(),
+  killAllRunningAgentTasks: vi.fn(),
+  markAgentsNotified: vi.fn(),
+  logEvent: vi.fn(),
+  onAgentsKilled: vi.fn(),
+  onCancel: vi.fn(),
+  popCommandFromQueue: vi.fn(),
+  setToolUseConfirmQueue: vi.fn(),
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('src/services/analytics/index.js', () => ({
+  logEvent: fixture.logEvent,
+}))
+
+vi.mock('src/tui/state/AppState.js', () => ({
+  useAppState: (selector: (state: AppState) => unknown) =>
+    selector(fixture.state),
+  useAppStateStore: () => ({
+    getState: () => fixture.state,
+  }),
+  useSetAppState: () => (updater: AppState | ((prev: AppState) => AppState)) => {
+    fixture.state =
+      typeof updater === 'function' ? updater(fixture.state) : updater
+  },
+}))
+
+vi.mock('src/tui/components/PromptInput/utils.js', () => ({
+  isVimModeEnabled: () => fixture.vimEnabled,
+}))
+
+vi.mock('src/tui/context/notifications', () => ({
+  useNotifications: () => ({
+    addNotification: fixture.addNotification,
+    removeNotification: fixture.removeNotification,
+  }),
+}))
+
+vi.mock('src/tui/context/overlayContext', () => ({
+  useIsOverlayActive: () => fixture.overlayActive,
+}))
+
+vi.mock('src/tui/hooks/useCommandQueue', () => ({
+  useCommandQueue: () => ({ length: fixture.queuedCommandsLength }),
+}))
+
+vi.mock('src/tui/keybindings/shortcutFormat.js', () => ({
+  getShortcutDisplay: () => 'ctrl+x ctrl+k',
+}))
+
+vi.mock('src/tui/keybindings/useKeybinding.js', () => ({
+  useKeybinding: (
+    action: string,
+    handler: () => void,
+    options?: { readonly isActive?: boolean },
+  ) => {
+    fixture.keybindings.set(action, {
+      handler,
+      isActive: options?.isActive,
+    })
+  },
+}))
+
+vi.mock('src/tui/state/teammateViewHelpers', () => ({
+  exitTeammateView: (...args: unknown[]) => fixture.exitTeammateView(...args),
+}))
+
+vi.mock('src/tasks/LocalAgentTask/LocalAgentTask', () => ({
+  killAllRunningAgentTasks: (...args: unknown[]) =>
+    fixture.killAllRunningAgentTasks(...args),
+  markAgentsNotified: (...args: unknown[]) =>
+    fixture.markAgentsNotified(...args),
+}))
+
+vi.mock('src/utils/messageQueueManager.js', () => ({
+  clearCommandQueue: (...args: unknown[]) => fixture.clearCommandQueue(...args),
+  enqueuePendingNotification: (...args: unknown[]) =>
+    fixture.enqueuePendingNotification(...args),
+  hasCommandsInQueue: () => fixture.hasCommandsInQueue,
+}))
+
+vi.mock('src/utils/sdkEventQueue.js', () => ({
+  emitTaskTerminatedSdk: (...args: unknown[]) =>
+    fixture.emitTaskTerminatedSdk(...args),
+}))
+
+function runningAgent(
+  id: string,
+  description: string,
+  toolUseId: string,
+): Record<string, unknown> {
+  return {
+    id,
+    type: 'local_agent',
+    status: 'running',
+    description,
+    toolUseId,
+  }
+}
+
+function getKeybinding(action: string): CapturedKeybinding {
+  const keybinding = fixture.keybindings.get(action)
+  if (keybinding === undefined) {
+    throw new Error(`Missing keybinding: ${action}`)
+  }
+  return keybinding
+}
+
+async function renderHandler(
+  overrides: {
+    readonly abortSignal?: AbortSignal
+    readonly inputMode?: 'bash' | 'prompt' | 'orphaned-permission'
+    readonly inputValue?: string
+    readonly isHelpOpen?: boolean
+    readonly isLocalJSXCommand?: boolean
+    readonly isMessageSelectorVisible?: boolean
+    readonly isSearchingHistory?: boolean
+    readonly popCommandFromQueue?: () => void
+    readonly screen?: 'prompt' | 'transcript'
+    readonly vimMode?: 'INSERT' | 'NORMAL'
+  } = {},
+): Promise<void> {
+  const { CancelRequestHandler } = await import(
+    'src/tui/hooks/useCancelRequest.js'
+  )
+
+  await renderToString(
+    React.createElement(CancelRequestHandler, {
+      setToolUseConfirmQueue: fixture.setToolUseConfirmQueue,
+      onCancel: fixture.onCancel,
+      onAgentsKilled: fixture.onAgentsKilled,
+      isMessageSelectorVisible: false,
+      screen: 'prompt',
+      popCommandFromQueue: fixture.popCommandFromQueue,
+      ...overrides,
+    }),
+    100,
+  )
+}
+
+describe('CancelRequestHandler coverage swarm 109', () => {
+  beforeEach(() => {
+    fixture.state = {
+      tasks: {},
+      viewSelectionMode: 'none',
+    }
+    fixture.queuedCommandsLength = 0
+    fixture.hasCommandsInQueue = false
+    fixture.overlayActive = false
+    fixture.vimEnabled = false
+    fixture.keybindings.clear()
+    vi.clearAllMocks()
+  })
+
+  test('Escape pops a queued command while idle instead of cancelling the turn', async () => {
+    fixture.queuedCommandsLength = 1
+    fixture.hasCommandsInQueue = true
+
+    await renderHandler()
+
+    const cancel = getKeybinding('chat:cancel')
+    expect(cancel.isActive).toBe(true)
+
+    cancel.handler()
+
+    expect(fixture.popCommandFromQueue).toHaveBeenCalledTimes(1)
+    expect(fixture.onCancel).not.toHaveBeenCalled()
+    expect(fixture.setToolUseConfirmQueue).not.toHaveBeenCalled()
+    expect(fixture.logEvent).not.toHaveBeenCalled()
+  })
+
+  test('queued-command fallback cancels when no pop handler was supplied', async () => {
+    fixture.queuedCommandsLength = 1
+    fixture.hasCommandsInQueue = true
+
+    await renderHandler({ popCommandFromQueue: undefined })
+
+    const cancel = getKeybinding('chat:cancel')
+    expect(cancel.isActive).toBe(true)
+
+    cancel.handler()
+
+    expect(fixture.popCommandFromQueue).not.toHaveBeenCalled()
+    expect(fixture.setToolUseConfirmQueue).toHaveBeenCalledWith(
+      expect.any(Function),
+    )
+    expect(fixture.onCancel).toHaveBeenCalledTimes(1)
+    expect(fixture.logEvent).toHaveBeenCalledWith('agenc_cancel', {
+      source: 'escape',
+      streamMode: undefined,
+    })
+  })
+
+  test('context guards deactivate Escape while keeping Ctrl+C available for an active turn', async () => {
+    const abortController = new AbortController()
+
+    await renderHandler({
+      abortSignal: abortController.signal,
+      inputMode: 'bash',
+      inputValue: '',
+    })
+
+    expect(getKeybinding('chat:cancel').isActive).toBe(false)
+    expect(getKeybinding('app:interrupt').isActive).toBe(true)
+
+    getKeybinding('app:interrupt').handler()
+
+    expect(fixture.onCancel).toHaveBeenCalledTimes(1)
+    expect(fixture.setToolUseConfirmQueue).toHaveBeenCalledWith(
+      expect.any(Function),
+    )
+  })
+
+  test.each([
+    ['transcript screen', { screen: 'transcript' as const }],
+    ['history search', { isSearchingHistory: true }],
+    ['message selector', { isMessageSelectorVisible: true }],
+    ['local JSX command', { isLocalJSXCommand: true }],
+    ['help dialog', { isHelpOpen: true }],
+    ['overlay', {}, true],
+    ['vim insert mode', { vimMode: 'INSERT' as const }, false, true],
+  ])(
+    'deactivates cancel keybindings while %s handles Escape',
+    async (_name, overrides, overlayActive = false, vimEnabled = false) => {
+      fixture.overlayActive = overlayActive
+      fixture.vimEnabled = vimEnabled
+      const abortController = new AbortController()
+
+      await renderHandler({
+        abortSignal: abortController.signal,
+        ...overrides,
+      })
+
+      expect(getKeybinding('chat:cancel').isActive).toBe(false)
+      expect(getKeybinding('app:interrupt').isActive).toBe(false)
+    },
+  )
+
+  test('kill-agents chord reports when there are no stoppable background agents', async () => {
+    fixture.state.tasks = {
+      finished: {
+        id: 'finished',
+        type: 'local_agent',
+        status: 'completed',
+        description: 'finished task',
+      },
+    }
+
+    await renderHandler()
+
+    getKeybinding('chat:killAgents').handler()
+
+    expect(fixture.addNotification).toHaveBeenCalledWith({
+      key: 'kill-agents-none',
+      text: 'No background agents to stop',
+      priority: 'immediate',
+      timeoutMs: 2000,
+    })
+    expect(fixture.killAllRunningAgentTasks).not.toHaveBeenCalled()
+    expect(fixture.clearCommandQueue).not.toHaveBeenCalled()
+  })
+
+  test('kill-agents confirmation expires before stopping agents', async () => {
+    fixture.state.tasks = {
+      agent_1: runningAgent('agent_1', 'inspect status bar', 'tool_1'),
+    }
+    const nowSpy = vi.spyOn(Date, 'now')
+    nowSpy.mockReturnValueOnce(1_000).mockReturnValueOnce(4_500)
+
+    try {
+      await renderHandler()
+
+      const killAgents = getKeybinding('chat:killAgents')
+      killAgents.handler()
+      killAgents.handler()
+
+      expect(fixture.addNotification).toHaveBeenCalledTimes(2)
+      expect(fixture.addNotification).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          key: 'kill-agents-confirm',
+        }),
+      )
+      expect(fixture.removeNotification).not.toHaveBeenCalled()
+      expect(fixture.clearCommandQueue).not.toHaveBeenCalled()
+      expect(fixture.killAllRunningAgentTasks).not.toHaveBeenCalled()
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-110-message-renderers-HookProgressMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-110-message-renderers-HookProgressMessage.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { renderToString } from '../../../src/utils/staticRender.js'
+import {
+  getHookProgressRunningLabel,
+  getHookProgressTranscriptRunningLabel,
+  HookProgressMessage,
+} from '../../../src/tui/message-renderers/HookProgressMessage.js'
+
+type HookCounts = ReadonlyArray<readonly [string, Readonly<Record<string, number>>]>
+type HookProgressProps = React.ComponentProps<typeof HookProgressMessage>
+
+const originalGlyphMode = process.env.AGENC_TUI_GLYPHS
+
+afterEach(() => {
+  if (originalGlyphMode === undefined) {
+    delete process.env.AGENC_TUI_GLYPHS
+  } else {
+    process.env.AGENC_TUI_GLYPHS = originalGlyphMode
+  }
+})
+
+function createLookups(options: {
+  readonly inProgress?: HookCounts
+  readonly resolved?: HookCounts
+}): HookProgressProps['lookups'] {
+  const createCountMap = (counts: HookCounts = []) =>
+    new Map(
+      counts.map(([toolUseID, byEvent]) => [
+        toolUseID,
+        new Map(Object.entries(byEvent)),
+      ]),
+    )
+
+  return {
+    inProgressHookCounts: createCountMap(options.inProgress),
+    resolvedHookCounts: createCountMap(options.resolved),
+  } as HookProgressProps['lookups']
+}
+
+function normalize(output: string): string {
+  return output.replace(/\s+/g, ' ').trim()
+}
+
+async function renderHookProgress(
+  props: Omit<HookProgressProps, 'verbose'>,
+): Promise<string> {
+  return renderToString(
+    <HookProgressMessage
+      {...props}
+      verbose={false}
+    />,
+    { columns: 100, rows: 8 },
+  )
+}
+
+describe('HookProgressMessage swarm-110 coverage', () => {
+  test('formats running labels for glyph mode and hook count variants', () => {
+    expect(
+      getHookProgressRunningLabel(1, { AGENC_TUI_GLYPHS: 'unicode' }),
+    ).toBe(' hook…')
+    expect(
+      getHookProgressRunningLabel(3, { AGENC_TUI_GLYPHS: 'ascii' }),
+    ).toBe(' hooks...')
+    expect(getHookProgressTranscriptRunningLabel(1)).toBe(' hook running')
+    expect(getHookProgressTranscriptRunningLabel(3)).toBe(' hooks running')
+  })
+
+  test('renders tool hook progress before the non-tool resolved-count gate', async () => {
+    process.env.AGENC_TUI_GLYPHS = 'ascii'
+
+    const output = normalize(
+      await renderHookProgress({
+        hookEvent: 'PreToolUse',
+        toolUseID: 'toolu-resolved-pre-hook',
+        lookups: createLookups({
+          inProgress: [['toolu-resolved-pre-hook', { PreToolUse: 2 }]],
+          resolved: [['toolu-resolved-pre-hook', { PreToolUse: 2 }]],
+        }),
+      }),
+    )
+
+    expect(output).toContain('Running PreToolUse hooks...')
+  })
+
+  test('renders singular transcript wording for post-tool hooks', async () => {
+    const output = normalize(
+      await renderHookProgress({
+        hookEvent: 'PostToolUse',
+        toolUseID: 'toolu-transcript-post-hook',
+        isTranscriptMode: true,
+        lookups: createLookups({
+          inProgress: [['toolu-transcript-post-hook', { PostToolUse: 1 }]],
+        }),
+      }),
+    )
+
+    expect(output).toContain('1 PostToolUse hook running')
+    expect(output).not.toContain('Running PostToolUse')
+  })
+
+  test('renders active non-tool hooks and omits missing event entries', async () => {
+    process.env.AGENC_TUI_GLYPHS = 'ascii'
+
+    const missingEvent = await renderHookProgress({
+      hookEvent: 'Notification',
+      toolUseID: 'toolu-other-hook-only',
+      lookups: createLookups({
+        inProgress: [['toolu-other-hook-only', { Stop: 1 }]],
+      }),
+    })
+
+    expect(missingEvent).toBe('\n')
+
+    const activeNonToolHook = normalize(
+      await renderHookProgress({
+        hookEvent: 'Notification',
+        toolUseID: 'toolu-active-notification',
+        lookups: createLookups({
+          inProgress: [['toolu-active-notification', { Notification: 1 }]],
+        }),
+      }),
+    )
+
+    expect(activeNonToolHook).toContain('Running Notification hook...')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-111-history-transcriptSearch.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-111-history-transcriptSearch.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import {
+  renderableSearchText,
+  toolResultSearchText,
+  toolUseSearchText,
+} from '../../../src/tui/history/transcriptSearch.js'
+
+vi.mock('../../../src/utils/messages.js', () => ({
+  INTERRUPT_MESSAGE: '[Request interrupted by user]',
+  INTERRUPT_MESSAGE_FOR_TOOL_USE: '[Request interrupted by user for tool use]',
+}))
+
+const INTERRUPT_FOR_TOOL_USE = '[Request interrupted by user for tool use]'
+
+describe('transcriptSearch coverage swarm row 111', () => {
+  test('returns cached lowercase text for the same renderable message object', () => {
+    const message = {
+      type: 'user',
+      message: {
+        content: 'Original Search Text',
+      },
+    } as never
+
+    expect(renderableSearchText(message)).toBe('original search text')
+
+    ;(message as { message: { content: string } }).message.content =
+      'Mutated Search Text'
+
+    expect(renderableSearchText(message)).toBe('original search text')
+  })
+
+  test('filters user content blocks and strips only closed system reminders', () => {
+    expect(
+      renderableSearchText({
+        type: 'user',
+        message: {
+          content: [
+            { type: 'text', text: 'Visible User Text' },
+            { type: 'text', text: INTERRUPT_FOR_TOOL_USE },
+            { type: 'tool_result', content: 'model-facing hidden text' },
+            { type: 'image', source: 'ignored-image' },
+          ],
+        },
+        toolUseResult: {
+          file: {
+            content:
+              'File Body <system-reminder>hidden context</system-reminder> Tail',
+          },
+        },
+      } as never),
+    ).toBe('visible user text\nfile body  tail')
+
+    expect(
+      renderableSearchText({
+        type: 'user',
+        message: {
+          content: 'Keep <system-reminder>unfinished reminder',
+        },
+      } as never),
+    ).toBe('keep <system-reminder>unfinished reminder')
+  })
+
+  test('indexes only visible queued command prompt attachments', () => {
+    expect(
+      renderableSearchText({
+        type: 'attachment',
+        attachment: {
+          type: 'queued_command',
+          commandMode: 'prompt',
+          isMeta: false,
+          prompt: 'Queued Prompt Text',
+        },
+      } as never),
+    ).toBe('queued prompt text')
+
+    expect(
+      renderableSearchText({
+        type: 'attachment',
+        attachment: {
+          type: 'queued_command',
+          commandMode: 'prompt',
+          isMeta: true,
+          prompt: 'Meta Prompt Text',
+        },
+      } as never),
+    ).toBe('')
+
+    expect(
+      renderableSearchText({
+        type: 'attachment',
+        attachment: {
+          type: 'other_attachment',
+          prompt: 'Invisible Attachment Text',
+        },
+      } as never),
+    ).toBe('')
+
+    expect(
+      renderableSearchText({
+        type: 'collapsed_read_search',
+      } as never),
+    ).toBe('')
+  })
+
+  test('extracts tool use text from rendered fields and ignores malformed values', () => {
+    expect(toolUseSearchText(null)).toBe('')
+    expect(toolUseSearchText('command text')).toBe('')
+
+    expect(
+      toolUseSearchText({
+        command: 'npm test',
+        path: 'src/file.ts',
+        description: 'short description',
+        query: 123,
+        args: ['--run', 'suite'],
+        files: ['visible.txt', 2],
+      }),
+    ).toBe('npm test\nsrc/file.ts\nshort description\n--run suite')
+  })
+
+  test('extracts tool result text from known rendered shapes only', () => {
+    expect(toolResultSearchText('plain result')).toBe('plain result')
+    expect(toolResultSearchText(undefined)).toBe('')
+    expect(toolResultSearchText({ stdout: 'only stdout' })).toBe('only stdout')
+
+    expect(
+      toolResultSearchText({
+        file: { content: 'read file body' },
+        output: 'ignored fallback',
+      }),
+    ).toBe('read file body')
+
+    expect(
+      toolResultSearchText({
+        file: { path: 'missing-content.txt' },
+        output: 'fallback output',
+      }),
+    ).toBe('fallback output')
+
+    expect(
+      toolResultSearchText({
+        content: 'content field',
+        output: 'output field',
+        result: 'result field',
+        text: 'text field',
+        message: 'message field',
+        filenames: ['a.ts', 'b.ts'],
+        lines: ['line one'],
+        results: ['match one'],
+        mixed: ['ignored', 4],
+        rawOutputPath: 'hidden metadata',
+      }),
+    ).toBe(
+      'content field\noutput field\nresult field\ntext field\nmessage field\na.ts\nb.ts\nline one\nmatch one',
+    )
+
+    expect(toolResultSearchText({ durationMs: 'hidden metadata' })).toBe('')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-112-keybindings-KeybindingContext.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-112-keybindings-KeybindingContext.test.tsx
@@ -1,0 +1,394 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { describe, expect, test, vi } from "vitest";
+
+import Text from "../ink/components/Text.js";
+import { createRoot } from "../ink/root.js";
+import type { Key } from "../ink.js";
+import {
+  KeybindingProvider,
+  useKeybindingContext,
+  useRegisterKeybindingContext,
+} from "../keybindings/KeybindingContext.js";
+import { parseBindings } from "../keybindings/parser.js";
+import type {
+  KeybindingContextName,
+  ParsedKeystroke,
+} from "../keybindings/types.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+type HandlerRegistration = {
+  action: string;
+  context: KeybindingContextName;
+  handler: () => void;
+};
+
+function createTestStreams(): {
+  stdout: PassThrough;
+  stdin: TestStdin;
+} {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number }).columns = 80;
+  (stdout as unknown as { rows: number }).rows = 24;
+  (stdout as unknown as { isTTY: boolean }).isTTY = true;
+  stdout.resume();
+
+  return { stdout, stdin };
+}
+
+function key(overrides: Partial<Key> = {}): Key {
+  return {
+    backspace: false,
+    ctrl: false,
+    delete: false,
+    downArrow: false,
+    end: false,
+    escape: false,
+    fn: false,
+    home: false,
+    leftArrow: false,
+    meta: false,
+    pageDown: false,
+    pageUp: false,
+    return: false,
+    rightArrow: false,
+    shift: false,
+    super: false,
+    tab: false,
+    upArrow: false,
+    wheelDown: false,
+    wheelUp: false,
+    ...overrides,
+  } as Key;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await sleep(10);
+  }
+  throw new Error(message);
+}
+
+type ProviderHarnessProps = {
+  activeContexts?: Set<KeybindingContextName>;
+  children: React.ReactNode;
+  handlerRegistryRef?: React.RefObject<Map<string, Set<HandlerRegistration>> | null>;
+  registeredContexts?: KeybindingContextName[];
+  unregisteredContexts?: KeybindingContextName[];
+};
+
+function ProviderHarness({
+  activeContexts = new Set<KeybindingContextName>(),
+  children,
+  handlerRegistryRef = {
+    current: new Map<string, Set<HandlerRegistration>>(),
+  },
+  registeredContexts = [],
+  unregisteredContexts = [],
+}: ProviderHarnessProps): React.ReactNode {
+  const pendingChordRef = React.useRef<ParsedKeystroke[] | null>(null);
+  const [pendingChord, setPendingChordState] = React.useState<
+    ParsedKeystroke[] | null
+  >(null);
+  const bindings = React.useMemo(
+    () =>
+      parseBindings([
+        {
+          context: "Chat",
+          bindings: {
+            enter: "chat:submit",
+            "ctrl+x ctrl+k": "chat:killAgents",
+          },
+        },
+      ]),
+    [],
+  );
+  const setPendingChord = React.useCallback(
+    (pending: ParsedKeystroke[] | null) => {
+      pendingChordRef.current = pending;
+      setPendingChordState(pending);
+    },
+    [],
+  );
+
+  return (
+    <KeybindingProvider
+      activeContexts={activeContexts}
+      bindings={bindings}
+      handlerRegistryRef={
+        handlerRegistryRef as React.RefObject<
+          Map<string, Set<HandlerRegistration>>
+        >
+      }
+      pendingChord={pendingChord}
+      pendingChordRef={pendingChordRef}
+      registerActiveContext={context => {
+        registeredContexts.push(context);
+        activeContexts.add(context);
+      }}
+      setPendingChord={setPendingChord}
+      unregisterActiveContext={context => {
+        unregisteredContexts.push(context);
+        activeContexts.delete(context);
+      }}
+    >
+      {children}
+    </KeybindingProvider>
+  );
+}
+
+class HookErrorBoundary extends React.Component<
+  { errors: string[]; children: React.ReactNode },
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError(): { hasError: boolean } {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error): void {
+    this.props.errors.push(error.message);
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError) return <Text>caught</Text>;
+    return this.props.children;
+  }
+}
+
+function RequiredContextProbe(): React.ReactNode {
+  useKeybindingContext();
+  return <Text>required</Text>;
+}
+
+function NullRegistryProbe({ events }: { events: string[] }): React.ReactNode {
+  const ctx = useKeybindingContext();
+
+  React.useEffect(() => {
+    const cleanup = ctx.registerHandler({
+      action: "chat:submit",
+      context: "Chat",
+      handler: () => events.push("unexpected-handler"),
+    });
+
+    events.push(`invoke:${ctx.invokeAction("chat:submit")}`);
+    cleanup();
+    events.push("cleanup-ok");
+
+    const resolved = ctx.resolve("x", key({ ctrl: true }), ["Chat"]);
+    events.push(`resolve:${resolved.type}`);
+    if (resolved.type === "chord_started") {
+      ctx.setPendingChord(resolved.pending);
+    }
+  }, [ctx, events]);
+
+  return <Text>null registry</Text>;
+}
+
+function RegistryProbe({
+  events,
+  registry,
+}: {
+  events: string[];
+  registry: Map<string, Set<HandlerRegistration>>;
+}): React.ReactNode {
+  const ctx = useKeybindingContext();
+
+  React.useEffect(() => {
+    const cleanupActive = ctx.registerHandler({
+      action: "chat:submit",
+      context: "Chat",
+      handler: () => events.push("active-handler"),
+    });
+
+    events.push(`empty:${ctx.invokeAction("chat:killAgents")}`);
+    events.push(`active:${ctx.invokeAction("chat:submit")}`);
+    cleanupActive();
+    events.push(`left:${registry.get("chat:submit")?.size ?? 0}`);
+    events.push(`inactive:${ctx.invokeAction("chat:submit")}`);
+  }, [ctx, events, registry]);
+
+  return <Text>registry</Text>;
+}
+
+function RegisterContextProbe({
+  isActive,
+}: {
+  isActive?: boolean;
+}): React.ReactNode {
+  useRegisterKeybindingContext("Chat", isActive);
+  return <Text>registration</Text>;
+}
+
+async function withRoot(
+  render: (root: Awaited<ReturnType<typeof createRoot>>) => void | Promise<void>,
+): Promise<void> {
+  const { stdout, stdin } = createTestStreams();
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  });
+
+  try {
+    await render(root);
+  } finally {
+    root.unmount();
+    stdin.end();
+    stdout.end();
+    await sleep(25);
+  }
+}
+
+describe("KeybindingContext coverage swarm 112", () => {
+  test("reports the required hook error outside a provider", async () => {
+    const errors: string[] = [];
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const stderrWrite = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    const stdoutWrite = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    try {
+      await withRoot(root => {
+        root.render(
+          <HookErrorBoundary errors={errors}>
+            <RequiredContextProbe />
+          </HookErrorBoundary>,
+        );
+
+        return waitForCondition(
+          () =>
+            errors.includes(
+              "useKeybindingContext must be used within KeybindingProvider",
+            ),
+          "required hook error was not captured",
+        );
+      });
+    } finally {
+      consoleError.mockRestore();
+      stderrWrite.mockRestore();
+      stdoutWrite.mockRestore();
+    }
+  });
+
+  test("keeps null handler registry paths as safe no-ops", async () => {
+    const events: string[] = [];
+
+    await withRoot(root => {
+      root.render(
+        <ProviderHarness handlerRegistryRef={{ current: null }}>
+          <NullRegistryProbe events={events} />
+        </ProviderHarness>,
+      );
+
+      return waitForCondition(
+        () => events.includes("cleanup-ok"),
+        "null registry probe did not run",
+      );
+    });
+
+    expect(events).toEqual([
+      "invoke:false",
+      "cleanup-ok",
+      "resolve:chord_started",
+    ]);
+  });
+
+  test("keeps inactive registered handlers while removing only the active handler", async () => {
+    const events: string[] = [];
+    const inactiveHandler = vi.fn();
+    const registry = new Map<string, Set<HandlerRegistration>>([
+      ["chat:killAgents", new Set()],
+      [
+        "chat:submit",
+        new Set([
+          {
+            action: "chat:submit",
+            context: "Confirmation",
+            handler: inactiveHandler,
+          },
+        ]),
+      ],
+    ]);
+
+    await withRoot(root => {
+      root.render(
+        <ProviderHarness
+          activeContexts={new Set(["Chat"])}
+          handlerRegistryRef={{ current: registry }}
+        >
+          <RegistryProbe events={events} registry={registry} />
+        </ProviderHarness>,
+      );
+
+      return waitForCondition(
+        () => events.includes("inactive:false"),
+        "registry probe did not finish",
+      );
+    });
+
+    expect(events).toEqual([
+      "empty:false",
+      "active-handler",
+      "active:true",
+      "left:1",
+      "inactive:false",
+    ]);
+    expect(inactiveHandler).not.toHaveBeenCalled();
+    expect(registry.get("chat:submit")).toHaveLength(1);
+  });
+
+  test("skips context registration when inactive or outside a provider", async () => {
+    const registeredContexts: KeybindingContextName[] = [];
+    const unregisteredContexts: KeybindingContextName[] = [];
+
+    await withRoot(async root => {
+      root.render(<RegisterContextProbe />);
+      await sleep(25);
+    });
+
+    await withRoot(async root => {
+      root.render(
+        <ProviderHarness
+          registeredContexts={registeredContexts}
+          unregisteredContexts={unregisteredContexts}
+        >
+          <RegisterContextProbe isActive={false} />
+        </ProviderHarness>,
+      );
+      await sleep(25);
+    });
+
+    expect(registeredContexts).toEqual([]);
+    expect(unregisteredContexts).toEqual([]);
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-113-context-promptOverlayContext.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-113-context-promptOverlayContext.test.tsx
@@ -1,0 +1,262 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import { createRoot, Text } from '../../../src/tui/ink.js'
+import {
+  PromptOverlayProvider,
+  type PromptOverlayData,
+  usePromptOverlay,
+  usePromptOverlayDialog,
+  useSetPromptOverlay,
+  useSetPromptOverlayDialog,
+} from '../../../src/tui/context/promptOverlayContext.js'
+
+vi.mock('../../../src/utils/debug.js', () => ({
+  logForDebugging: () => {},
+}))
+
+vi.mock('../../../src/bootstrap/state.js', () => ({
+  flushInteractionTime: () => {},
+  getActiveTimeCounter: () => 0,
+  markScrollActivity: () => {},
+  updateLastInteractionTime: () => {},
+}))
+
+vi.mock('../../../src/utils/earlyInput.js', () => ({
+  stopCapturingEarlyInput: () => {},
+}))
+
+vi.mock('../../../src/utils/envUtils.js', () => ({
+  isEnvTruthy: () => false,
+}))
+
+vi.mock('../../../src/utils/fullscreen.js', () => ({
+  isMouseClicksDisabled: () => true,
+}))
+
+vi.mock('../../../src/utils/log.js', () => ({
+  logError: () => {},
+}))
+
+type Snapshot = {
+  readonly dialog: string | null
+  readonly overlay: string | null
+}
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestStdout = PassThrough & {
+  columns: number
+  isTTY: boolean
+}
+
+const overlayData: PromptOverlayData = {
+  suggestions: [
+    {
+      id: 'command-status',
+      displayText: '/status',
+      description: 'show status',
+    },
+  ],
+  selectedSuggestion: 0,
+  maxColumnWidth: 24,
+  suggestionType: 'command',
+}
+
+const dialogNode = <Text>stable dialog</Text>
+
+function createStreams(): {
+  readonly stdin: TestStdin
+  readonly stdout: TestStdout
+} {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough() as TestStdout
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 120
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await sleep(10)
+  }
+  throw new Error('Timed out waiting for prompt overlay coverage state')
+}
+
+function dialogLabel(node: React.ReactNode): string | null {
+  if (node === null || node === undefined) return null
+  if (!React.isValidElement(node)) return 'node'
+
+  const props = node.props as { readonly children?: React.ReactNode }
+  return typeof props.children === 'string' ? props.children : 'node'
+}
+
+function Observer({
+  snapshots,
+}: {
+  readonly snapshots: Snapshot[]
+}): React.ReactNode {
+  const overlay = usePromptOverlay()
+  const dialog = usePromptOverlayDialog()
+
+  React.useEffect(() => {
+    snapshots.push({
+      dialog: dialogLabel(dialog),
+      overlay: overlay?.suggestions[0]?.displayText ?? null,
+    })
+  }, [dialog, overlay, snapshots])
+
+  return <Text>observer</Text>
+}
+
+function UnscopedWriter({
+  snapshots,
+}: {
+  readonly snapshots: Snapshot[]
+}): React.ReactNode {
+  useSetPromptOverlay(overlayData)
+  useSetPromptOverlayDialog(dialogNode)
+
+  return <Observer snapshots={snapshots} />
+}
+
+function StableWriter({
+  renders,
+  revision,
+}: {
+  readonly renders: { count: number }
+  readonly revision: number
+}): React.ReactNode {
+  renders.count += 1
+
+  useSetPromptOverlay(overlayData)
+  useSetPromptOverlayDialog(dialogNode)
+
+  return <Text>{`writer-${revision}`}</Text>
+}
+
+function ProviderHarness({
+  renders,
+  revision,
+  snapshots,
+}: {
+  readonly renders: { count: number }
+  readonly revision: number
+  readonly snapshots: Snapshot[]
+}): React.ReactNode {
+  return (
+    <PromptOverlayProvider>
+      <StableWriter renders={renders} revision={revision} />
+      <Observer snapshots={snapshots} />
+    </PromptOverlayProvider>
+  )
+}
+
+describe('prompt overlay context coverage swarm 113', () => {
+  test('setter hooks are no-ops outside the provider and keep default readers null', async () => {
+    const snapshots: Snapshot[] = []
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      root.render(<UnscopedWriter snapshots={snapshots} />)
+      await waitForCondition(() =>
+        snapshots.some(
+          snapshot => snapshot.overlay === null && snapshot.dialog === null,
+        ),
+      )
+
+      const beforeRerender = snapshots.length
+      root.render(<UnscopedWriter snapshots={snapshots} />)
+      await sleep()
+
+      expect(snapshots.slice(beforeRerender)).toEqual([])
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+
+    expect(snapshots).toEqual([{ overlay: null, dialog: null }])
+  })
+
+  test('stable setter inputs survive rerenders without changing overlay state', async () => {
+    const renders = { count: 0 }
+    const snapshots: Snapshot[] = []
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      root.render(
+        <ProviderHarness
+          renders={renders}
+          revision={1}
+          snapshots={snapshots}
+        />,
+      )
+      await waitForCondition(() =>
+        snapshots.some(
+          snapshot =>
+            snapshot.overlay === '/status' &&
+            snapshot.dialog === 'stable dialog',
+        ),
+      )
+
+      const beforeRerender = snapshots.length
+      root.render(
+        <ProviderHarness
+          renders={renders}
+          revision={2}
+          snapshots={snapshots}
+        />,
+      )
+      await sleep()
+
+      expect(renders.count).toBeGreaterThanOrEqual(2)
+      expect(snapshots.slice(beforeRerender)).toEqual([])
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+
+    expect(snapshots).toContainEqual({
+      dialog: 'stable dialog',
+      overlay: '/status',
+    })
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-114-message-renderers-UserPromptMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-114-message-renderers-UserPromptMessage.test.tsx
@@ -1,0 +1,239 @@
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const state = vi.hoisted(() => ({
+  featureFlags: new Set<string>(),
+  getKairosActive: vi.fn(() => false),
+  getUserMsgOptIn: vi.fn(() => false),
+  growthbookValue: false,
+  isBriefOnly: false,
+  logError: vi.fn(),
+  viewingAgentTaskId: null as string | null,
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => state.featureFlags.has(name),
+}))
+
+vi.mock('../../../src/bootstrap/state', async importOriginal => ({
+  ...(await importOriginal<typeof import('../../../src/bootstrap/state')>()),
+  getKairosActive: () => state.getKairosActive(),
+  getUserMsgOptIn: () => state.getUserMsgOptIn(),
+}))
+
+vi.mock('../../../src/services/analytics/growthbook', () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: () => state.growthbookValue,
+}))
+
+vi.mock('../../../src/tui/state/AppState.js', () => ({
+  useAppState: <T,>(selector: (appState: {
+    readonly isBriefOnly: boolean
+    readonly viewingAgentTaskId: string | null
+  }) => T): T =>
+    selector({
+      isBriefOnly: state.isBriefOnly,
+      viewingAgentTaskId: state.viewingAgentTaskId,
+    }),
+}))
+
+vi.mock('../../../src/utils/log.js', () => ({
+  logError: (error: Error) => state.logError(error),
+}))
+
+vi.mock('../../../src/tui/message-renderers/HighlightedThinkingText', async () => {
+  const { default: Text } = await import(
+    '../../../src/tui/ink/components/Text.js'
+  )
+
+  return {
+    HighlightedThinkingText: ({
+      showPointer,
+      text,
+      timestamp,
+      useBriefLayout,
+    }: {
+      readonly showPointer?: boolean
+      readonly text: string
+      readonly timestamp?: string
+      readonly useBriefLayout?: boolean
+    }) => (
+      <Text>
+        {`highlight brief:${String(useBriefLayout)} pointer:${String(
+          showPointer,
+        )} time:${timestamp ?? 'none'} text:${text}`}
+      </Text>
+    ),
+  }
+})
+
+vi.mock('../../../src/tui/components/v2/primitives.js', async () => {
+  const { default: Text } = await import(
+    '../../../src/tui/ink/components/Text.js'
+  )
+
+  return {
+    Msg: ({
+      children,
+      label,
+      role,
+      time,
+    }: {
+      readonly children: React.ReactNode
+      readonly label: string
+      readonly role: string
+      readonly time?: string
+    }) => (
+      <Text>
+        {`msg role:${role} label:${label} time:${time ?? 'none'} `}
+        {children}
+      </Text>
+    ),
+  }
+})
+
+import { renderToString } from '../../../src/utils/staticRender.js'
+import { MessageActionsSelectedContext } from '../../../src/tui/components/messageActions.js'
+import {
+  getUserPromptTruncationNotice,
+  truncateUserPromptDisplayText,
+  UserPromptMessage,
+} from '../../../src/tui/message-renderers/UserPromptMessage.js'
+
+const originalBriefEnv = process.env.AGENC_BRIEF
+
+function resetState(): void {
+  state.featureFlags.clear()
+  state.getKairosActive.mockReturnValue(false)
+  state.getUserMsgOptIn.mockReturnValue(false)
+  state.growthbookValue = false
+  state.isBriefOnly = false
+  state.logError.mockClear()
+  state.viewingAgentTaskId = null
+
+  if (originalBriefEnv === undefined) {
+    delete process.env.AGENC_BRIEF
+  } else {
+    process.env.AGENC_BRIEF = originalBriefEnv
+  }
+}
+
+afterEach(() => {
+  resetState()
+})
+
+function renderPrompt({
+  addMargin = false,
+  isSelected = false,
+  isTranscriptMode,
+  text = 'hello from user',
+  timestamp = '10:15',
+}: {
+  readonly addMargin?: boolean
+  readonly isSelected?: boolean
+  readonly isTranscriptMode?: boolean
+  readonly text?: string
+  readonly timestamp?: string
+} = {}): Promise<string> {
+  return renderToString(
+    <MessageActionsSelectedContext.Provider value={isSelected}>
+      <UserPromptMessage
+        addMargin={addMargin}
+        isTranscriptMode={isTranscriptMode}
+        param={{ type: 'text', text }}
+        timestamp={timestamp}
+      />
+    </MessageActionsSelectedContext.Provider>,
+    { columns: 100, rows: 12 },
+  )
+}
+
+describe('UserPromptMessage swarm 114 coverage', () => {
+  test('formats truncation notices and preserves short prompts', () => {
+    expect(getUserPromptTruncationNotice(7, { AGENC_TUI_GLYPHS: 'ascii' })).toBe(
+      '... +7 lines ...',
+    )
+
+    expect(truncateUserPromptDisplayText('short prompt')).toBe('short prompt')
+
+    const longPrompt = `${'head\n'.repeat(650)}${'middle\n'.repeat(
+      1200,
+    )}${'tail\n'.repeat(650)}`
+    const truncated = truncateUserPromptDisplayText(longPrompt, {
+      AGENC_TUI_GLYPHS: 'ascii',
+    })
+
+    expect(truncated.length).toBeLessThan(longPrompt.length)
+    expect(truncated).toContain('... +')
+    expect(truncated).toContain(' lines ...')
+    expect(truncated.startsWith(longPrompt.slice(0, 2500))).toBe(true)
+    expect(truncated.endsWith(longPrompt.slice(-2500))).toBe(true)
+  })
+
+  test('logs and renders nothing for empty prompt text', async () => {
+    const output = await renderPrompt({ text: '' })
+
+    expect(output.trim()).toBe('')
+    expect(state.logError).toHaveBeenCalledTimes(1)
+    expect(state.logError.mock.calls[0]?.[0]).toMatchObject({
+      message: 'No content found in user prompt message',
+    })
+  })
+
+  test('renders normal selected prompt through message chrome', async () => {
+    const output = await renderPrompt({
+      addMargin: true,
+      isSelected: true,
+      text: 'normal selected prompt',
+      timestamp: '11:45',
+    })
+
+    expect(output).toContain('msg role:user label:you time:11:45')
+    expect(output).toContain(
+      'highlight brief:undefined pointer:false time:none text:normal',
+    )
+    expect(output).toContain('selected prompt')
+  })
+
+  test('uses brief layout only when feature, state, opt-in, and view gates allow it', async () => {
+    state.featureFlags.add('KAIROS_BRIEF')
+    state.getUserMsgOptIn.mockReturnValue(true)
+    state.growthbookValue = true
+    state.isBriefOnly = true
+
+    await expect(
+      renderPrompt({ text: 'brief prompt', timestamp: '12:00' }),
+    ).resolves.toContain(
+      'highlight brief:true pointer:undefined time:12:00 text:brief prompt',
+    )
+
+    await expect(
+      renderPrompt({
+        isTranscriptMode: true,
+        text: 'transcript prompt',
+        timestamp: '12:01',
+      }),
+    ).resolves.toContain('msg role:user label:you time:12:01')
+
+    state.viewingAgentTaskId = 'task-114'
+
+    await expect(
+      renderPrompt({ text: 'viewing task prompt', timestamp: '12:02' }),
+    ).resolves.toContain('msg role:user label:you time:12:02')
+  })
+
+  test('allows active Kairos with env opt-in to drive brief layout', async () => {
+    state.featureFlags.add('KAIROS')
+    state.getKairosActive.mockReturnValue(true)
+    state.isBriefOnly = true
+    process.env.AGENC_BRIEF = '1'
+
+    const output = await renderPrompt({
+      text: `${'visible\n'.repeat(1400)}final question`,
+      timestamp: '12:03',
+    })
+
+    expect(output).toContain('highlight brief:true')
+    expect(output).toContain('… +')
+    expect(output).toContain('final question')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-115-components-PackageManagerAutoUpdater.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-115-components-PackageManagerAutoUpdater.test.tsx
@@ -1,0 +1,315 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  getLatestVersionFromGcs: vi.fn(),
+  getMaxVersion: vi.fn(),
+  getPackageManager: vi.fn(),
+  intervalDelay: undefined as number | null | undefined,
+  isAutoUpdaterDisabled: vi.fn(),
+  logForDebugging: vi.fn(),
+  settings: undefined as { autoUpdatesChannel?: string } | null | undefined,
+  shouldSkipVersion: vi.fn(),
+}));
+
+vi.mock("usehooks-ts", () => ({
+  useInterval: (_callback: () => void, delay: number | null) => {
+    harness.intervalDelay = delay;
+  },
+}));
+
+vi.mock("../../../src/utils/autoUpdater.js", () => ({
+  getLatestVersionFromGcs: harness.getLatestVersionFromGcs,
+  getMaxVersion: harness.getMaxVersion,
+  shouldSkipVersion: harness.shouldSkipVersion,
+}));
+
+vi.mock("../../../src/utils/config.js", () => ({
+  isAutoUpdaterDisabled: harness.isAutoUpdaterDisabled,
+}));
+
+vi.mock("../../../src/utils/debug.js", () => ({
+  logForDebugging: harness.logForDebugging,
+}));
+
+vi.mock("../../../src/utils/nativeInstaller/packageManagers.js", () => ({
+  getPackageManager: harness.getPackageManager,
+}));
+
+vi.mock("../../../src/utils/semver.js", () => {
+  const compareVersions = (left: string, right: string): number => {
+    const leftParts = left.split(".").map(Number);
+    const rightParts = right.split(".").map(Number);
+
+    for (let index = 0; index < 3; index += 1) {
+      const delta = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+      if (delta !== 0) {
+        return delta;
+      }
+    }
+
+    return 0;
+  };
+
+  return {
+    gt: (left: string, right: string) => compareVersions(left, right) > 0,
+    gte: (left: string, right: string) => compareVersions(left, right) >= 0,
+  };
+});
+
+vi.mock("../../../src/utils/settings/settings.js", () => ({
+  getInitialSettings: () => harness.settings,
+}));
+
+import { PackageManagerAutoUpdater } from "../../../src/tui/components/PackageManagerAutoUpdater.js";
+import { createRoot } from "../../../src/tui/ink/root.js";
+
+const originalMacro = (globalThis as Record<string, unknown>).MACRO;
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  readonly stdout: PassThrough;
+};
+
+type RenderedUpdater = {
+  readonly cleanup: () => Promise<void>;
+  readonly readOutput: () => string;
+};
+
+function resetHarness(): void {
+  harness.getLatestVersionFromGcs.mockReset().mockResolvedValue("2.0.0");
+  harness.getMaxVersion.mockReset().mockResolvedValue(undefined);
+  harness.getPackageManager.mockReset().mockResolvedValue("homebrew");
+  harness.intervalDelay = undefined;
+  harness.isAutoUpdaterDisabled.mockReset().mockReturnValue(false);
+  harness.logForDebugging.mockReset();
+  harness.settings = { autoUpdatesChannel: "stable" };
+  harness.shouldSkipVersion.mockReset().mockReturnValue(false);
+}
+
+function setMacro(version = "1.0.0"): void {
+  (globalThis as Record<string, unknown>).MACRO = {
+    VERSION: version,
+  };
+}
+
+function createStreams(): TestStreams {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStreams["stdin"];
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number; rows: number }).columns = 160;
+  (stdout as unknown as { columns: number; rows: number }).rows = 24;
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function renderUpdater({
+  verbose = false,
+}: {
+  readonly verbose?: boolean;
+} = {}): Promise<RenderedUpdater> {
+  let output = "";
+  const { stdin, stdout } = createStreams();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  root.render(
+    <PackageManagerAutoUpdater
+      autoUpdaterResult={null}
+      isUpdating={false}
+      onAutoUpdaterResult={() => {}}
+      onChangeIsUpdating={() => {}}
+      showSuccessMessage={false}
+      verbose={verbose}
+    />,
+  );
+
+  return {
+    cleanup: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep(0);
+    },
+    readOutput: () => stripAnsi(output),
+  };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  label: string,
+): Promise<void> {
+  const deadline = Date.now() + 1000;
+
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await sleep(10);
+  }
+
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+async function waitForOutput(
+  rendered: RenderedUpdater,
+  expectedText: string,
+): Promise<string> {
+  await waitFor(
+    () => rendered.readOutput().includes(expectedText),
+    `output containing ${expectedText}`,
+  );
+  return rendered.readOutput();
+}
+
+describe("PackageManagerAutoUpdater coverage swarm row 115", () => {
+  beforeEach(() => {
+    resetHarness();
+    setMacro();
+  });
+
+  afterEach(() => {
+    if (originalMacro === undefined) {
+      delete (globalThis as Record<string, unknown>).MACRO;
+    } else {
+      (globalThis as Record<string, unknown>).MACRO = originalMacro;
+    }
+  });
+
+  test("returns before package checks when auto updates are disabled", async () => {
+    harness.isAutoUpdaterDisabled.mockReturnValue(true);
+
+    const rendered = await renderUpdater({ verbose: true });
+    try {
+      await waitFor(
+        () => harness.isAutoUpdaterDisabled.mock.calls.length > 0,
+        "disabled auto-update check",
+      );
+      await sleep(20);
+
+      expect(harness.intervalDelay).toBe(1_800_000);
+      expect(harness.getPackageManager).not.toHaveBeenCalled();
+      expect(harness.getLatestVersionFromGcs).not.toHaveBeenCalled();
+      expect(harness.getMaxVersion).not.toHaveBeenCalled();
+      expect(harness.shouldSkipVersion).not.toHaveBeenCalled();
+      expect(rendered.readOutput()).not.toContain("Update available");
+    } finally {
+      await rendered.cleanup();
+    }
+  });
+
+  test("caps to maxVersion and returns when the current version already meets it", async () => {
+    setMacro("2.0.0");
+    harness.getLatestVersionFromGcs.mockResolvedValue("9.0.0");
+    harness.getMaxVersion.mockResolvedValue("2.0.0");
+
+    const rendered = await renderUpdater({ verbose: true });
+    try {
+      await waitFor(
+        () =>
+          harness.logForDebugging.mock.calls.some(
+            ([message]) =>
+              message ===
+              "PackageManagerAutoUpdater: current version 2.0.0 is already at or above maxVersion 2.0.0, skipping update",
+          ),
+        "max-version current-version skip",
+      );
+
+      expect(harness.logForDebugging).toHaveBeenCalledWith(
+        "PackageManagerAutoUpdater: maxVersion 2.0.0 is set, capping update from 9.0.0 to 2.0.0",
+      );
+      expect(harness.shouldSkipVersion).not.toHaveBeenCalled();
+      expect(rendered.readOutput()).not.toContain("Update available");
+    } finally {
+      await rendered.cleanup();
+    }
+  });
+
+  test.each([
+    ["winget", "winget upgrade AgenC.AgenCCode"],
+    ["apk", "apk upgrade agenc-code"],
+    ["unknown", "your package manager update command"],
+  ])("renders the %s package-manager command", async (packageManager, command) => {
+    harness.getPackageManager.mockResolvedValue(packageManager);
+    harness.settings = null;
+
+    const rendered = await renderUpdater({ verbose: false });
+    try {
+      const output = await waitForOutput(rendered, command);
+
+      expect(output).toContain("Update available! Run:");
+      expect(output).not.toContain("currentVersion:");
+      expect(harness.getLatestVersionFromGcs).toHaveBeenCalledWith("latest");
+      expect(harness.shouldSkipVersion).toHaveBeenCalledWith("2.0.0");
+      expect(harness.logForDebugging).toHaveBeenCalledWith(
+        "PackageManagerAutoUpdater: Update available 1.0.0 -> 2.0.0",
+      );
+    } finally {
+      await rendered.cleanup();
+    }
+  });
+
+  test.each([
+    {
+      label: "missing latest version",
+      latest: undefined,
+      shouldSkip: false,
+      shouldSkipCalls: 0,
+    },
+    {
+      label: "already current version",
+      latest: "1.0.0",
+      shouldSkip: false,
+      shouldSkipCalls: 0,
+    },
+    {
+      label: "user skipped target version",
+      latest: "2.0.0",
+      shouldSkip: true,
+      shouldSkipCalls: 1,
+    },
+  ])(
+    "suppresses the update prompt for $label",
+    async ({ latest, shouldSkip, shouldSkipCalls }) => {
+      harness.getLatestVersionFromGcs.mockResolvedValue(latest);
+      harness.shouldSkipVersion.mockReturnValue(shouldSkip);
+
+      const rendered = await renderUpdater({ verbose: true });
+      try {
+        await waitFor(
+          () => harness.getMaxVersion.mock.calls.length > 0,
+          "version check completion",
+        );
+        await sleep(20);
+
+        expect(harness.shouldSkipVersion).toHaveBeenCalledTimes(shouldSkipCalls);
+        expect(rendered.readOutput()).not.toContain("Update available");
+      } finally {
+        await rendered.cleanup();
+      }
+    },
+  );
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-116-hooks-useMemoryUsage.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-116-hooks-useMemoryUsage.test.ts
@@ -1,0 +1,159 @@
+import { PassThrough } from 'node:stream'
+
+import React, { act } from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const fixture = vi.hoisted(() => ({
+  intervalCallback: undefined as (() => void) | undefined,
+  intervalDelay: undefined as number | null | undefined,
+}))
+
+vi.mock('usehooks-ts', () => ({
+  useInterval: (callback: () => void, delay: number | null) => {
+    fixture.intervalCallback = callback
+    fixture.intervalDelay = delay
+  },
+}))
+
+import { createRoot } from '../../../src/tui/ink.js'
+import {
+  type MemoryUsageInfo,
+  useMemoryUsage,
+} from '../../../src/tui/hooks/useMemoryUsage.js'
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough & {
+    columns: number
+    isTTY: boolean
+    rows: number
+  }
+}
+
+const HIGH_MEMORY_THRESHOLD = 1.5 * 1024 * 1024 * 1024
+const CRITICAL_MEMORY_THRESHOLD = 2.5 * 1024 * 1024 * 1024
+
+function createStreams(): TestStreams {
+  const stdin = new PassThrough() as TestStreams['stdin']
+  const stdout = new PassThrough() as TestStreams['stdout']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 100
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+async function renderHookHarness(): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly latest: () => MemoryUsageInfo | null
+}> {
+  let latest: MemoryUsageInfo | null | undefined
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    latest = useMemoryUsage()
+    return null
+  }
+
+  await act(async () => {
+    root.render(React.createElement(Harness))
+  })
+  await flushEffects()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushEffects()
+    },
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+  }
+}
+
+describe('useMemoryUsage coverage swarm 116', () => {
+  let heapUsed = 0
+  let memoryUsageSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fixture.intervalCallback = undefined
+    fixture.intervalDelay = undefined
+    heapUsed = 0
+    const baseMemoryUsage = process.memoryUsage()
+    memoryUsageSpy = vi
+      .spyOn(process, 'memoryUsage')
+      .mockImplementation(() => ({ ...baseMemoryUsage, heapUsed }))
+  })
+
+  afterEach(() => {
+    memoryUsageSpy.mockRestore()
+  })
+
+  test('reports high and critical heap usage while suppressing normal usage', async () => {
+    const rendered = await renderHookHarness()
+
+    async function poll(nextHeapUsed: number): Promise<void> {
+      heapUsed = nextHeapUsed
+      const callback = fixture.intervalCallback
+      if (callback === undefined) {
+        throw new Error('memory usage interval was not registered')
+      }
+
+      await act(async () => {
+        callback()
+      })
+      await flushEffects()
+    }
+
+    try {
+      expect(fixture.intervalDelay).toBe(10_000)
+      expect(rendered.latest()).toBeNull()
+
+      await poll(HIGH_MEMORY_THRESHOLD - 1)
+      expect(rendered.latest()).toBeNull()
+
+      await poll(HIGH_MEMORY_THRESHOLD)
+      expect(rendered.latest()).toEqual({
+        heapUsed: HIGH_MEMORY_THRESHOLD,
+        status: 'high',
+      })
+
+      await poll(CRITICAL_MEMORY_THRESHOLD)
+      expect(rendered.latest()).toEqual({
+        heapUsed: CRITICAL_MEMORY_THRESHOLD,
+        status: 'critical',
+      })
+
+      await poll(0)
+      expect(rendered.latest()).toBeNull()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-117-components-CoordinatorAgentStatus.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-117-components-CoordinatorAgentStatus.test.tsx
@@ -1,0 +1,278 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  appState: {
+    agentNameRegistry: new Map<string, string>(),
+    coordinatorTaskIndex: 0,
+    footerSelection: "chat" as "chat" | "tasks",
+    tasks: {} as Record<string, unknown>,
+    viewingAgentTaskId: undefined as string | undefined,
+  },
+  entered: [] as string[],
+  evicted: [] as string[],
+  exited: 0,
+  setAppState: vi.fn(),
+  terminalColumns: 80,
+}));
+
+vi.mock("../../../src/tui/hooks/useTerminalSize.js", () => ({
+  useTerminalSize: () => ({ columns: harness.terminalColumns, rows: 24 }),
+}));
+
+vi.mock("../../../src/tui/state/AppState.js", () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+  useSetAppState: () => harness.setAppState,
+}));
+
+vi.mock("../../../src/tui/state/teammateViewHelpers.js", () => ({
+  enterTeammateView: (taskId: string) => {
+    harness.entered.push(taskId);
+  },
+  exitTeammateView: () => {
+    harness.exited++;
+  },
+}));
+
+vi.mock("../../../src/utils/task/framework.js", () => ({
+  evictTerminalTask: (taskId: string) => {
+    harness.evicted.push(taskId);
+  },
+}));
+
+import { createRoot } from "../../../src/tui/ink/root.js";
+import {
+  getCoordinatorTaskCount,
+  getCoordinatorTaskPanelVisibilityKey,
+  getVisibleAgentTasks,
+  shouldShowCoordinatorTaskPanel,
+  CoordinatorTaskPanel,
+} from "../../../src/tui/components/CoordinatorAgentStatus.js";
+
+type AgentTask = {
+  agentId: string;
+  agentType: string;
+  description: string;
+  diskLoaded: boolean;
+  endTime?: number;
+  evictAfter?: number;
+  id: string;
+  isBackgrounded: boolean;
+  lastReportedTokenCount: number;
+  lastReportedToolCount: number;
+  pendingMessages: string[];
+  progress?: {
+    lastActivity?: Record<string, unknown>;
+    summary?: string;
+    tokenCount?: number;
+  };
+  prompt: string;
+  retain: boolean;
+  retrieved: boolean;
+  startTime: number;
+  status: "completed" | "failed" | "killed" | "pending" | "running";
+  totalPausedMs?: number;
+  type: "local_agent";
+};
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+type TestStdout = PassThrough & {
+  columns: number;
+  isTTY: boolean;
+  rows: number;
+};
+
+function task(id: string, overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    agentId: id,
+    agentType: "worker",
+    description: `${id} task description`,
+    diskLoaded: false,
+    id,
+    isBackgrounded: true,
+    lastReportedTokenCount: 0,
+    lastReportedToolCount: 0,
+    pendingMessages: [],
+    prompt: `${id} prompt`,
+    retain: false,
+    retrieved: false,
+    startTime: 1_000,
+    status: "running",
+    type: "local_agent",
+    ...overrides,
+  };
+}
+
+function createStreams(): { stdin: TestStdin; stdout: TestStdout } {
+  const stdin = new PassThrough() as TestStdin;
+  const stdout = new PassThrough() as TestStdout;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+
+  stdout.columns = harness.terminalColumns;
+  stdout.rows = 24;
+  stdout.isTTY = true;
+  stdout.resume();
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function renderPanel(): Promise<{
+  dispose: () => Promise<void>;
+  output: () => string;
+}> {
+  let output = "";
+  const { stdin, stdout } = createStreams();
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  root.render(<CoordinatorTaskPanel />);
+  await sleep();
+
+  return {
+    dispose: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    },
+    output: () => stripAnsi(output),
+  };
+}
+
+function compact(text: string): string {
+  return text.replace(/\s+/g, "");
+}
+
+describe("CoordinatorAgentStatus coverage swarm row 117", () => {
+  beforeEach(() => {
+    harness.appState = {
+      agentNameRegistry: new Map(),
+      coordinatorTaskIndex: 0,
+      footerSelection: "chat",
+      tasks: {},
+      viewingAgentTaskId: undefined,
+    };
+    harness.entered = [];
+    harness.evicted = [];
+    harness.exited = 0;
+    harness.setAppState.mockClear();
+    harness.terminalColumns = 80;
+    vi.spyOn(Date, "now").mockReturnValue(10_000);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("filters visible panel agents and encodes visibility keys for running and ended tasks", () => {
+    const visible = getVisibleAgentTasks({
+      dismissed: task("dismissed", { evictAfter: 0, startTime: 1 }),
+      main: task("main", { agentType: "main-session", startTime: 2 }),
+      plain: { id: "plain", startTime: 3, status: "running", type: "other" },
+      later: task("later", { endTime: 10, startTime: 30, status: "completed" }),
+      earlier: task("earlier", { startTime: 20, status: "pending" }),
+    });
+
+    expect(visible.map(agent => agent.id)).toEqual(["earlier", "later"]);
+    expect(getCoordinatorTaskCount({})).toBe(0);
+    expect(getCoordinatorTaskPanelVisibilityKey(visible)).toBe(
+      "earlier:pending:20:|later:completed:30:10",
+    );
+  });
+
+  test("keeps the panel hidden for empty or unrelated viewed task states", () => {
+    const visibleTasks = [task("active")];
+
+    expect(
+      shouldShowCoordinatorTaskPanel({
+        footerSelection: "tasks",
+        now: 10_000,
+        transientVisibleUntil: 20_000,
+        viewingAgentTaskId: undefined,
+        visibleTasks: [],
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldShowCoordinatorTaskPanel({
+        footerSelection: "chat",
+        now: 10_000,
+        transientVisibleUntil: 10_000,
+        viewingAgentTaskId: "missing",
+        visibleTasks,
+      }),
+    ).toBe(false);
+  });
+
+  test("renders transient agents without task-footer selection or action hints", async () => {
+    harness.appState.footerSelection = "chat";
+    harness.appState.tasks = {
+      active: task("active", {
+        description: "Audit the status panel",
+        progress: { tokenCount: 12 },
+      }),
+    };
+
+    const rendered = await renderPanel();
+
+    try {
+      const output = rendered.output();
+      const compactOutput = compact(output);
+      expect(output).toContain("AGENTS");
+      expect(compactOutput).toContain("1active");
+      expect(output).toContain("orchestrator");
+      expect(compactOutput).toContain("Auditthestatuspanel");
+      expect(compactOutput).toContain("12tokens");
+      expect(compactOutput).not.toContain("xtostop");
+      expect(output).not.toContain("active:");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("marks the orchestrator row selected while leaving unselected agents without hints", async () => {
+    harness.appState.footerSelection = "tasks";
+    harness.appState.coordinatorTaskIndex = 0;
+    harness.appState.tasks = {
+      active: task("active", { description: "Keep watching worker output" }),
+    };
+
+    const rendered = await renderPanel();
+
+    try {
+      const output = rendered.output();
+      const compactOutput = compact(output);
+      expect(output).toContain("orchestrator");
+      expect(compactOutput).toContain("Keepwatchingworkeroutput");
+      expect(compactOutput).not.toContain("xtostop");
+      expect(compactOutput).not.toContain("xtoclear");
+    } finally {
+      await rendered.dispose();
+    }
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-118-components-PrBadge.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-118-components-PrBadge.test.tsx
@@ -1,0 +1,221 @@
+import { PassThrough } from "node:stream";
+
+import React, { useLayoutEffect, useState } from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { PrBadge } from "../../../src/tui/components/PrBadge.js";
+import type { DOMElement } from "../../../src/tui/ink/dom.js";
+import instances from "../../../src/tui/ink/instances.js";
+import { createRoot } from "../../../src/tui/ink/root.js";
+import { squashTextNodesToSegments } from "../../../src/tui/ink/squash-text-nodes.js";
+import type { PrReviewState } from "../../../src/utils/ghPrStatus.js";
+import { getTheme } from "../../../src/utils/theme.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+type TestStdout = PassThrough & {
+  columns: number;
+  isTTY: boolean;
+  rows: number;
+};
+
+const previousForceHyperlink = process.env.FORCE_HYPERLINK;
+
+afterEach(() => {
+  if (previousForceHyperlink === undefined) {
+    delete process.env.FORCE_HYPERLINK;
+  } else {
+    process.env.FORCE_HYPERLINK = previousForceHyperlink;
+  }
+});
+
+function createStreams(): {
+  readonly stdin: TestStdin;
+  readonly stdout: TestStdout;
+} {
+  const stdin = new PassThrough() as TestStdin;
+  const stdout = new PassThrough() as TestStdout;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+
+  stdout.columns = 120;
+  stdout.rows = 24;
+  stdout.isTTY = true;
+  stdout.resume();
+
+  return { stdin, stdout };
+}
+
+function getRootNode(stdout: TestStdout): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream);
+  if (!instance?.rootNode) {
+    throw new Error("Ink root node not found");
+  }
+  return instance.rootNode;
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function renderSegments(
+  node: React.ReactNode,
+): Promise<
+  Array<{
+    readonly hyperlink?: string;
+    readonly styles: Record<string, unknown>;
+    readonly text: string;
+  }>
+> {
+  const { stdin, stdout } = createStreams();
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  try {
+    root.render(node);
+    await sleep();
+    return squashTextNodesToSegments(getRootNode(stdout));
+  } finally {
+    root.unmount();
+    stdin.end();
+    stdout.end();
+    await sleep();
+  }
+}
+
+function RerenderStableBadge({
+  onRender,
+}: {
+  readonly onRender: (count: number) => void;
+}) {
+  const [count, setCount] = useState(0);
+
+  useLayoutEffect(() => {
+    onRender(count);
+    if (count === 0) setCount(1);
+  }, [count, onRender]);
+
+  return (
+    <PrBadge
+      number={118}
+      reviewState="approved"
+      url="https://example.test/pull/118"
+    />
+  );
+}
+
+describe("PrBadge coverage swarm 118", () => {
+  test("maps review states onto colored linked PR labels", async () => {
+    process.env.FORCE_HYPERLINK = "1";
+    const theme = getTheme("dark");
+    const cases: Array<{
+      readonly color: "error" | "merged" | "success" | "warning" | undefined;
+      readonly number: number;
+      readonly state?: PrReviewState;
+    }> = [
+      { color: "success", number: 118, state: "approved" },
+      { color: "error", number: 119, state: "changes_requested" },
+      { color: "warning", number: 120, state: "pending" },
+      { color: "merged", number: 121, state: "merged" },
+      { color: undefined, number: 122 },
+    ];
+
+    const segments = await renderSegments(
+      <>
+        {cases.map(({ number, state }) => (
+          <PrBadge
+            key={number}
+            number={number}
+            reviewState={state}
+            url={`https://example.test/pull/${number}`}
+          />
+        ))}
+      </>,
+    );
+
+    expect(segments.map(segment => segment.text).join("")).toContain(
+      "PR #118PR #119PR #120PR #121PR #122",
+    );
+
+    for (const { color, number } of cases) {
+      const url = `https://example.test/pull/${number}`;
+      const numberSegments = segments.filter(
+        segment => segment.hyperlink === url,
+      );
+
+      expect(numberSegments.map(segment => segment.text).join("")).toBe(
+        `#${number}`,
+      );
+      expect(numberSegments[0]?.styles).toMatchObject({
+        underline: true,
+      });
+      expect(numberSegments[1]?.styles).toMatchObject(
+        numberSegments[0]?.styles ?? {},
+      );
+
+      if (color === undefined) {
+        expect(numberSegments[0]?.styles.color).toBe(theme.inactive);
+      } else {
+        expect(numberSegments[0]?.styles.color).toBe(theme[color]);
+      }
+    }
+
+    expect(
+      segments.filter(segment => segment.text === "PR").map(segment => ({
+        color: segment.styles.color,
+      })),
+    ).toEqual(cases.map(() => ({ color: theme.inactive })));
+  });
+
+  test("keeps bold fallback styling and reuses cached render branches", async () => {
+    process.env.FORCE_HYPERLINK = "1";
+    const onRender = vi.fn();
+
+    const segments = await renderSegments(
+      <>
+        <RerenderStableBadge onRender={onRender} />
+        <PrBadge
+          bold={true}
+          number={123}
+          url="https://example.test/pull/123"
+        />
+      </>,
+    );
+
+    expect(onRender).toHaveBeenCalledWith(0);
+    expect(onRender).toHaveBeenCalledWith(1);
+
+    const rerendered = segments.filter(
+      segment => segment.hyperlink === "https://example.test/pull/118",
+    );
+    expect(rerendered.map(segment => segment.text).join("")).toBe("#118");
+    expect(rerendered[0]?.styles).toMatchObject({
+      color: getTheme("dark").success,
+      underline: true,
+    });
+
+    const boldFallback = segments.filter(
+      segment => segment.hyperlink === "https://example.test/pull/123",
+    );
+    expect(boldFallback.map(segment => segment.text).join("")).toBe("#123");
+    expect(boldFallback[0]?.styles).toMatchObject({
+      bold: true,
+      underline: true,
+    });
+    expect(boldFallback[0]?.styles.color).toBeUndefined();
+
+    const labels = segments.filter(segment => segment.text === "PR");
+    expect(labels.at(-1)?.styles.color).toBeUndefined();
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-119-components-dialogs-CostThresholdDialog.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-119-components-dialogs-CostThresholdDialog.test.tsx
@@ -1,0 +1,123 @@
+import type { ReactNode } from 'react'
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { CostThresholdDialog } from '../../../src/tui/components/dialogs/CostThresholdDialog.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+
+type DialogProps = {
+  readonly children: ReactNode
+  readonly onCancel: () => void
+  readonly title: ReactNode
+}
+
+type SelectProps = {
+  readonly onChange: (value: string) => void
+  readonly options: Array<{
+    readonly label: string
+    readonly value: string
+  }>
+}
+
+const harness = vi.hoisted(() => ({
+  dialogProps: undefined as DialogProps | undefined,
+  provider: 'firstParty',
+  selectProps: undefined as SelectProps | undefined,
+}))
+
+vi.mock('../../../src/utils/model/providers.js', () => ({
+  getAPIProvider: () => harness.provider,
+}))
+
+vi.mock('../../../src/tui/components/CustomSelect/select.js', async () => {
+  const ReactActual = await vi.importActual<typeof import('react')>('react')
+
+  return {
+    Select: (props: SelectProps) => {
+      harness.selectProps = props
+
+      return ReactActual.createElement(
+        'ink-text',
+        null,
+        props.options.map(option => option.label).join('\n'),
+      )
+    },
+  }
+})
+
+vi.mock('../../../src/tui/components/design-system/Dialog.js', async () => {
+  const ReactActual = await vi.importActual<typeof import('react')>('react')
+
+  return {
+    Dialog: (props: DialogProps) => {
+      harness.dialogProps = props
+
+      return ReactActual.createElement(
+        'ink-box',
+        { flexDirection: 'column' },
+        ReactActual.createElement('ink-text', null, props.title),
+        props.children,
+      )
+    },
+  }
+})
+
+describe('CostThresholdDialog coverage swarm row 119', () => {
+  beforeEach(() => {
+    harness.dialogProps = undefined
+    harness.provider = 'firstParty'
+    harness.selectProps = undefined
+  })
+
+  test.each([
+    ['firstParty', 'provider API'],
+    ['openai', 'provider-compatible API'],
+    ['gemini', 'Gemini API'],
+    ['github', 'GitHub Copilot API'],
+    ['mistral', 'Mistral API'],
+    ['nvidia-nim', 'NVIDIA NIM API'],
+    ['minimax', 'MiniMax API'],
+    ['agenc', 'AgenC API'],
+    ['xai', 'xAI API'],
+    ['unexpected-provider', 'API'],
+  ])('renders the %s provider cost threshold copy', async (provider, label) => {
+    harness.provider = provider
+
+    const output = await renderToString(
+      <CostThresholdDialog onDone={() => {}} />,
+      { columns: 120 },
+    )
+
+    expect(harness.dialogProps?.title).toBe(
+      `You've spent $5 on the ${label} this session.`,
+    )
+    expect(output).toContain(
+      `You've spent $5 on the ${label} this session.`,
+    )
+    expect(output).toContain('Learn more about how to monitor your spending:')
+    expect(output).toContain('https://agenc.tech/docs/costs')
+    expect(output).toContain('Got it, thanks!')
+  })
+
+  test('forwards dismiss actions through onDone', async () => {
+    const onDone = vi.fn()
+
+    await renderToString(<CostThresholdDialog onDone={onDone} />, {
+      columns: 120,
+    })
+
+    expect(harness.dialogProps?.onCancel).toBe(onDone)
+    expect(harness.selectProps?.options).toEqual([
+      {
+        label: 'Got it, thanks!',
+        value: 'ok',
+      },
+    ])
+    expect(harness.selectProps?.onChange).toBe(onDone)
+
+    harness.dialogProps?.onCancel()
+    harness.selectProps?.onChange('ok')
+
+    expect(onDone).toHaveBeenCalledTimes(2)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-120-cost-TokenWarning.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-120-cost-TokenWarning.test.tsx
@@ -1,0 +1,122 @@
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  autoCompactEnabled: false,
+  collapseEnabled: false,
+  effectiveWindow: 200_000,
+  enabledFeatures: new Set<string>(),
+  errorThreshold: false,
+  growthEnabled: false,
+  percentLeft: 8,
+  suppressWarning: false,
+  upgradeMessage: null as string | null,
+  warningThreshold: true,
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: (flag: string) => state.enabledFeatures.has(flag),
+}));
+
+vi.mock("../../services/analytics/growthbook.js", () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: () => state.growthEnabled,
+}));
+
+vi.mock("../../services/compact/autoCompact.js", () => ({
+  calculateTokenWarningState: () => ({
+    isAboveAutoCompactThreshold: state.autoCompactEnabled,
+    isAboveErrorThreshold: state.errorThreshold,
+    isAboveWarningThreshold: state.warningThreshold,
+    isAtBlockingLimit: false,
+    percentLeft: state.percentLeft,
+  }),
+  getEffectiveContextWindowSize: () => state.effectiveWindow,
+  isAutoCompactEnabled: () => state.autoCompactEnabled,
+}));
+
+vi.mock("../../services/compact/compactWarningHook.js", () => ({
+  useCompactWarningSuppression: () => state.suppressWarning,
+}));
+
+vi.mock("../../services/contextCollapse/index.js", () => ({
+  isContextCollapseEnabled: () => state.collapseEnabled,
+}));
+
+vi.mock("../../utils/model/contextWindowUpgradeCheck.js", () => ({
+  getUpgradeMessage: () => state.upgradeMessage,
+}));
+
+import { renderToString } from "../../utils/staticRender.js";
+import { TokenWarning } from "../cost/TokenWarning.js";
+
+async function renderWarning(tokenUsage = 192_000): Promise<string> {
+  return renderToString(
+    <TokenWarning tokenUsage={tokenUsage} model="sonnet" />,
+    { columns: 120 },
+  );
+}
+
+describe("TokenWarning coverage swarm row 120", () => {
+  beforeEach(() => {
+    state.autoCompactEnabled = false;
+    state.collapseEnabled = false;
+    state.effectiveWindow = 200_000;
+    state.enabledFeatures = new Set();
+    state.errorThreshold = false;
+    state.growthEnabled = false;
+    state.percentLeft = 8;
+    state.suppressWarning = false;
+    state.upgradeMessage = null;
+    state.warningThreshold = true;
+  });
+
+  test("renders nothing below the warning threshold or while suppressed", async () => {
+    state.warningThreshold = false;
+    expect((await renderWarning()).trim()).toBe("");
+
+    state.warningThreshold = true;
+    state.suppressWarning = true;
+    expect((await renderWarning()).trim()).toBe("");
+  });
+
+  test("renders the manual compact fallback without upgrade guidance", async () => {
+    state.errorThreshold = true;
+    state.percentLeft = 3;
+
+    const output = await renderWarning();
+
+    expect(output).toContain("Context low (3% remaining)");
+    expect(output).toContain("Run /compact to compact & continue");
+  });
+
+  test("renders auto-compact guidance with upgrade text", async () => {
+    state.autoCompactEnabled = true;
+    state.percentLeft = 11;
+    state.upgradeMessage = "/model larger";
+
+    const output = await renderWarning();
+
+    expect(output).toContain("11% until auto-compact");
+    expect(output).toContain("/model larger");
+    expect(output).not.toContain("Context low");
+  });
+
+  test("uses effective context percentages for reactive and collapse modes", async () => {
+    state.autoCompactEnabled = true;
+    state.effectiveWindow = 100;
+    state.enabledFeatures = new Set(["REACTIVE_COMPACT"]);
+    state.growthEnabled = true;
+
+    const reactiveOutput = await renderWarning(125);
+
+    expect(reactiveOutput).toContain("100% context used");
+
+    state.enabledFeatures = new Set(["CONTEXT_COLLAPSE"]);
+    state.growthEnabled = false;
+    state.collapseEnabled = true;
+
+    const collapseOutput = await renderWarning(75);
+
+    expect(collapseOutput).toContain("25% until auto-compact");
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-121-components-MessageRow.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-121-components-MessageRow.test.tsx
@@ -1,0 +1,380 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  calls: [] as Array<{ name: string; props: Record<string, unknown> }>,
+  collapsibleTools: new Set<string>(),
+  staticMessages: new Set<string>(),
+  reset() {
+    harness.calls = [];
+    harness.collapsibleTools = new Set();
+    harness.staticMessages = new Set();
+  },
+}));
+
+vi.mock("../../../src/utils/collapseReadSearch.js", () => ({
+  getDisplayMessageFromCollapsed: (message: { displayMessage?: unknown }) =>
+    message.displayMessage,
+  getToolSearchOrReadInfo: (name: string) => ({
+    isCollapsible: harness.collapsibleTools.has(name),
+  }),
+  getToolUseIdsFromCollapsedGroup: (message: { toolUseIds?: string[] }) =>
+    message.toolUseIds ?? [],
+  hasAnyToolInProgress: (
+    message: { toolUseIds?: string[] },
+    inProgressToolUseIDs: Set<string>,
+  ) => (message.toolUseIds ?? []).some(id => inProgressToolUseIDs.has(id)),
+}));
+
+vi.mock("../../../src/utils/messages.js", () => ({
+  EMPTY_STRING_SET: new Set<string>(),
+  getProgressMessagesFromLookup: (
+    message: { uuid: string },
+    lookups: { progress?: Record<string, string[]> },
+  ) => lookups.progress?.[message.uuid] ?? [],
+  getSiblingToolUseIDsFromLookup: (
+    message: { uuid: string },
+    lookups: { siblings?: Record<string, string[]> },
+  ) => new Set(lookups.siblings?.[message.uuid] ?? []),
+  getToolUseID: (message: {
+    message?: { content?: Array<{ id?: string }> };
+    toolUseID?: string;
+  }) => message.toolUseID ?? message.message?.content?.[0]?.id,
+}));
+
+vi.mock("../../../src/tui/components/Message.js", async () => {
+  const ReactModule = await import("react");
+  const { default: Text } = await vi.importActual<
+    typeof import("../../../src/tui/ink/components/Text.js")
+  >("../../../src/tui/ink/components/Text.js");
+
+  return {
+    hasThinkingContent: (message: {
+      message?: { content?: Array<{ type?: string }> };
+    }) =>
+      Boolean(
+        message.message?.content?.some(
+          content =>
+            content.type === "thinking" ||
+            content.type === "redacted_thinking",
+        ),
+      ),
+    Message: (props: Record<string, unknown>) => {
+      const message = props.message as { type: string; uuid: string };
+      harness.calls.push({ name: "Message", props });
+
+      return ReactModule.createElement(
+        Text,
+        null,
+        [
+          "row",
+          message.uuid,
+          message.type,
+          String(props.shouldAnimate),
+          String(props.isActiveCollapsedGroup),
+          String(props.containerWidth ?? "none"),
+          String(props.addMargin),
+        ].join(":"),
+      );
+    },
+  };
+});
+
+vi.mock("../../../src/tui/components/Messages.js", () => ({
+  shouldRenderStatically: (message: { uuid: string }) =>
+    harness.staticMessages.has(message.uuid),
+}));
+
+vi.mock("../../../src/tui/components/MessageModel.js", async () => {
+  const ReactModule = await import("react");
+  const { default: Text } = await vi.importActual<
+    typeof import("../../../src/tui/ink/components/Text.js")
+  >("../../../src/tui/ink/components/Text.js");
+
+  return {
+    MessageModel: ({ message }: { readonly message: { uuid: string } }) =>
+      ReactModule.createElement(Text, null, `model:${message.uuid}`),
+  };
+});
+
+vi.mock("../../../src/tui/components/MessageTimestamp.js", async () => {
+  const ReactModule = await import("react");
+  const { default: Text } = await vi.importActual<
+    typeof import("../../../src/tui/ink/components/Text.js")
+  >("../../../src/tui/ink/components/Text.js");
+
+  return {
+    MessageTimestamp: ({ message }: { readonly message: { uuid: string } }) =>
+      ReactModule.createElement(Text, null, `time:${message.uuid}`),
+  };
+});
+
+vi.mock("../../../src/tui/components/OffscreenFreeze.js", async () => {
+  const ReactModule = await import("react");
+
+  return {
+    OffscreenFreeze: ({ children }: { readonly children?: React.ReactNode }) => {
+      harness.calls.push({ name: "OffscreenFreeze", props: {} });
+      return ReactModule.createElement(ReactModule.Fragment, null, children);
+    },
+  };
+});
+
+import { MessageRow, type Props } from "../../../src/tui/components/MessageRow.js";
+import { createRoot } from "../../../src/tui/ink/root.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+function createStreams(): {
+  readonly stdin: TestStdin;
+  readonly stdout: PassThrough;
+} {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  stdout.resume();
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function assistant(
+  uuid: string,
+  content: Array<Record<string, unknown>>,
+  overrides: Record<string, unknown> = {},
+): Props["message"] {
+  return {
+    message: {
+      content,
+      model: overrides.model,
+    },
+    type: "assistant",
+    uuid,
+    ...overrides,
+  } as Props["message"];
+}
+
+function textBlock(text = "hello"): Record<string, unknown> {
+  return { text, type: "text" };
+}
+
+function toolUseBlock(id: string, name = "Agent"): Record<string, unknown> {
+  return { id, input: {}, name, type: "tool_use" };
+}
+
+function groupedMessage(
+  uuid: string,
+  ids: string[],
+  toolName = "Agent",
+): Props["message"] {
+  return {
+    displayMessage: assistant(`${uuid}-display`, [textBlock("grouped")]),
+    messages: ids.map(id => assistant(`${uuid}-${id}`, [toolUseBlock(id, toolName)])),
+    toolName,
+    type: "grouped_tool_use",
+    uuid,
+  } as Props["message"];
+}
+
+function collapsedMessage(
+  uuid: string,
+  ids: string[],
+  displayMessage = assistant(`${uuid}-display`, [textBlock("collapsed")]),
+): Props["message"] {
+  return {
+    displayMessage,
+    messages: [],
+    toolUseIds: ids,
+    type: "collapsed_read_search",
+    uuid,
+  } as Props["message"];
+}
+
+function baseLookups(overrides: Record<string, unknown> = {}): Props["lookups"] {
+  return {
+    erroredToolUseIDs: new Set<string>(),
+    resolvedToolUseIDs: new Set<string>(),
+    ...overrides,
+  } as Props["lookups"];
+}
+
+function baseProps(message: Props["message"], overrides: Partial<Props> = {}): Props {
+  return {
+    canAnimate: true,
+    columns: 38,
+    commands: [],
+    hasContentAfter: false,
+    inProgressToolUseIDs: new Set<string>(),
+    isLoading: false,
+    isUserContinuation: false,
+    lastThinkingBlockId: null,
+    latestBashOutputUUID: null,
+    lookups: baseLookups(),
+    message,
+    screen: "prompt",
+    streamingToolUseIDs: new Set<string>(),
+    tools: [] as never,
+    verbose: false,
+    ...overrides,
+  };
+}
+
+async function renderRow(props: Props): Promise<{
+  readonly output: () => string;
+  readonly unmount: () => Promise<void>;
+}> {
+  let output = "";
+  const { stdin, stdout } = createStreams();
+
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  root.render(<MessageRow {...props} />);
+  await sleep();
+
+  return {
+    output: () => stripAnsi(output),
+    unmount: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    },
+  };
+}
+
+describe("MessageRow coverage swarm row 121", () => {
+  beforeEach(() => {
+    harness.reset();
+  });
+
+  test("passes false animation state for disabled and inactive tool rows", async () => {
+    const staticText = assistant("static-text", [textBlock()]);
+    harness.staticMessages.add(staticText.uuid);
+
+    const disabledAnimation = await renderRow(
+      baseProps(staticText, {
+        canAnimate: false,
+        lookups: baseLookups({ progress: { [staticText.uuid]: ["queued"] } }),
+      }),
+    );
+    const inactiveTool = await renderRow(
+      baseProps(assistant("inactive-tool", [toolUseBlock("tool-id")]), {
+        inProgressToolUseIDs: new Set(["other-tool"]),
+      }),
+    );
+
+    try {
+      expect(disabledAnimation.output()).toContain(
+        "row:static-text:assistant:false:false:38:true",
+      );
+      expect(inactiveTool.output()).toContain(
+        "row:inactive-tool:assistant:false:false:38:true",
+      );
+      expect(
+        harness.calls.find(
+          call =>
+            call.name === "Message" &&
+            (call.props.message as { uuid: string }).uuid === "static-text",
+        )?.props,
+      ).toMatchObject({
+        isStatic: true,
+        progressMessagesForMessage: ["queued"],
+        shouldAnimate: false,
+      });
+    } finally {
+      await disabledAnimation.unmount();
+      await inactiveTool.unmount();
+    }
+  });
+
+  test("distinguishes grouped and collapsed inactive states from loading-only collapsed activity", async () => {
+    const grouped = await renderRow(baseProps(groupedMessage("grouped-idle", ["group-tool"])));
+    const collapsedLoading = await renderRow(
+      baseProps(collapsedMessage("collapsed-loading", ["read-tool"]), {
+        isLoading: true,
+      }),
+    );
+    const collapsedAfterContent = await renderRow(
+      baseProps(collapsedMessage("collapsed-after", ["read-tool"]), {
+        hasContentAfter: true,
+        isLoading: true,
+      }),
+    );
+
+    try {
+      expect(grouped.output()).toContain(
+        "row:grouped-idle:grouped_tool_use:false:false:38:true",
+      );
+      expect(collapsedLoading.output()).toContain(
+        "row:collapsed-loading:collapsed_read_search:false:true:38:true",
+      );
+      expect(collapsedAfterContent.output()).toContain(
+        "row:collapsed-after:collapsed_read_search:false:false:38:true",
+      );
+      expect(
+        harness.calls
+          .filter(call => call.name === "Message")
+          .map(call => call.props.progressMessagesForMessage),
+      ).toEqual([[], [], []]);
+    } finally {
+      await grouped.unmount();
+      await collapsedLoading.unmount();
+      await collapsedAfterContent.unmount();
+    }
+  });
+
+  test("uses normal row layout for transcript assistant rows without text metadata", async () => {
+    const displayMessage = assistant(
+      "non-text-display",
+      [{ id: "server-id", name: "search", type: "server_tool_use" }],
+      { model: "gpt-test", timestamp: "2026-05-20T00:00:00.000Z" },
+    );
+    const rendered = await renderRow(
+      baseProps(collapsedMessage("collapsed-transcript", ["read-tool"], displayMessage), {
+        columns: 62,
+        screen: "transcript",
+      }),
+    );
+
+    try {
+      const output = rendered.output();
+      expect(output).toContain(
+        "row:collapsed-transcript:collapsed_read_search:false:false:62:true",
+      );
+      expect(output).not.toContain("time:non-text-display");
+      expect(output).not.toContain("model:non-text-display");
+      expect(
+        harness.calls.find(call => call.name === "Message")?.props,
+      ).toMatchObject({
+        addMargin: true,
+        containerWidth: 62,
+        isTranscriptMode: true,
+      });
+    } finally {
+      await rendered.unmount();
+    }
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-122-components-markdown-MarkdownTable.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-122-components-markdown-MarkdownTable.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react'
+import { marked, type Tokens } from 'marked'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+import { MarkdownTable } from '../../../src/tui/components/markdown/MarkdownTable.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+
+const originalGlyphMode = process.env.AGENC_TUI_GLYPHS
+
+function parseTable(markdown: string): Tokens.Table {
+  const table = marked.lexer(markdown).find(token => token.type === 'table')
+  if (!table || table.type !== 'table') {
+    throw new Error('expected markdown fixture to parse as a table')
+  }
+  return table
+}
+
+async function renderTable(markdown: string, forceWidth: number): Promise<string> {
+  const token = parseTable(markdown)
+  return renderToString(
+    <MarkdownTable token={token} highlight={null} forceWidth={forceWidth} />,
+    100,
+  )
+}
+
+function nonEmptyLines(output: string): string[] {
+  return output.split('\n').filter(line => line.length > 0)
+}
+
+describe('MarkdownTable coverage swarm row 122', () => {
+  beforeEach(() => {
+    delete process.env.AGENC_TUI_GLYPHS
+  })
+
+  afterEach(() => {
+    if (originalGlyphMode === undefined) {
+      delete process.env.AGENC_TUI_GLYPHS
+    } else {
+      process.env.AGENC_TUI_GLYPHS = originalGlyphMode
+    }
+  })
+
+  test('renders a compact table with centered headers and aligned data cells', async () => {
+    const output = await renderTable(
+      [
+        '| Agent | Status | Score |',
+        '| :--- | :---: | ---: |',
+        '| Alpha | ready | 7 |',
+        '| Empty |  | 1024 |',
+      ].join('\n'),
+      80,
+    )
+
+    expect(output).toContain('┌')
+    expect(output).toContain('┘')
+    expect(output).toMatch(/│ Agent\s+│\s+Status\s+│ Score │/)
+    expect(output).toMatch(/│ Alpha\s+│\s+ready\s+│\s+7 │/)
+    expect(output).toMatch(/│ Empty\s+│\s+│\s+1024 │/)
+  })
+
+  test('shrinks ideal column widths and wraps multiline rows without switching layouts', async () => {
+    const output = await renderTable(
+      [
+        '| Item | Count |',
+        '| :--- | ---: |',
+        '| Alpha wraps over several compact words | 7 |',
+        '| Beta | 42 |',
+      ].join('\n'),
+      34,
+    )
+    const lines = nonEmptyLines(output)
+
+    expect(output).toContain('┌')
+    expect(output).toContain('Alpha wraps')
+    expect(output).toContain('several compact')
+    expect(output).toMatch(/│\s+7 │/)
+    expect(output).toMatch(/│\s+42 │/)
+    expect(lines.every(line => line.length <= 34)).toBe(true)
+  })
+
+  test('hard-wraps long words in horizontal layout when minimum widths exceed the terminal', async () => {
+    const output = await renderTable(
+      [
+        '| Key | Value |',
+        '| :--- | :--- |',
+        '| abcdef | uvwxyz |',
+      ].join('\n'),
+      17,
+    )
+    const lines = nonEmptyLines(output)
+
+    expect(output).toContain('┌')
+    expect(output).toContain('abc')
+    expect(output).toContain('def')
+    expect(output).toContain('uvw')
+    expect(output).toContain('xyz')
+    expect(lines.every(line => line.length <= 17)).toBe(true)
+    expect(output).not.toContain('Key:')
+  })
+
+  test('uses ascii borders when ascii glyph mode is requested', async () => {
+    process.env.AGENC_TUI_GLYPHS = 'ascii'
+
+    const output = await renderTable(
+      [
+        '| Item | Count |',
+        '| :--- | ---: |',
+        '| Alpha | 7 |',
+      ].join('\n'),
+      40,
+    )
+
+    expect(output).toContain('+')
+    expect(output).toContain('|')
+    expect(output).toContain('-')
+    expect(output).not.toContain('┌')
+    expect(output).not.toContain('│')
+  })
+
+  test('falls back to vertical rows when the horizontal table would hit the safety margin', async () => {
+    const output = await renderTable(
+      [
+        '| Name | Value |',
+        '| :--- | :--- |',
+        '| Alpha | ok |',
+        '| Beta | done |',
+      ].join('\n'),
+      10,
+    )
+    const lines = nonEmptyLines(output)
+
+    expect(output).toContain('Name: Alpha')
+    expect(output).toContain('Value: ok')
+    expect(output).toContain('Name: Beta')
+    expect(output).toContain('Value: done')
+    expect(lines).toContain('─'.repeat(9))
+    expect(output).not.toContain('┌')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-123-components-spinner-TeammateSpinnerLine.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-123-components-spinner-TeammateSpinnerLine.test.tsx
@@ -1,0 +1,232 @@
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { InProcessTeammateTaskState } from '../../../src/tasks/InProcessTeammateTask/types.js'
+import {
+  computeTeammateActivityMaxWidth,
+  computeTeammatePreviewTextWidth,
+  getMessagePreview,
+  TeammateSpinnerLine,
+} from '../../../src/tui/components/spinner/TeammateSpinnerLine.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+
+const NOW = new Date('2026-05-20T12:00:00.000Z').getTime()
+const originalGlyphMode = process.env.AGENC_TUI_GLYPHS
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('lodash-es/sample.js', () => ({
+  default: <T,>(items: readonly T[]) => items[0],
+}))
+
+vi.mock('../../../src/constants/spinnerVerbs.js', () => ({
+  getSpinnerVerbs: () => ['Coordinating'],
+}))
+
+vi.mock('../../../src/constants/turnCompletionVerbs.js', () => ({
+  TURN_COMPLETION_VERBS: ['finished'],
+}))
+
+function teammate(
+  overrides: Partial<InProcessTeammateTaskState> = {},
+): InProcessTeammateTaskState {
+  return {
+    awaitingPlanApproval: false,
+    description: 'Review teammate progress',
+    id: 'tm-row-123',
+    identity: {
+      agentId: 'reviewer@coverage',
+      agentName: 'reviewer',
+      color: 'green',
+      parentSessionId: 'leader-session',
+      planModeRequired: false,
+      teamName: 'coverage',
+    },
+    isIdle: false,
+    lastReportedTokenCount: 0,
+    lastReportedToolCount: 0,
+    messages: [],
+    notified: false,
+    outputFile: '/tmp/tm-row-123.log',
+    outputOffset: 0,
+    pendingUserMessages: [],
+    permissionMode: 'default',
+    progress: {
+      lastActivity: {
+        activityDescription: 'Reading project notes',
+      },
+      tokenCount: 2500,
+      toolUseCount: 2,
+    },
+    prompt: 'Review the current work',
+    shutdownRequested: false,
+    spinnerVerb: 'Reviewing',
+    startTime: NOW - 75_000,
+    status: 'running',
+    totalPausedMs: 0,
+    type: 'in_process_teammate',
+    ...overrides,
+  }
+}
+
+async function renderLine(
+  task: InProcessTeammateTaskState,
+  props: Partial<React.ComponentProps<typeof TeammateSpinnerLine>> = {},
+  columns = 120,
+): Promise<string> {
+  return renderToString(
+    <TeammateSpinnerLine teammate={task} isLast={false} {...props} />,
+    columns,
+  )
+}
+
+describe('TeammateSpinnerLine coverage swarm row 123', () => {
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(NOW)
+    process.env.AGENC_TUI_GLYPHS = 'ascii'
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    if (originalGlyphMode === undefined) {
+      delete process.env.AGENC_TUI_GLYPHS
+    } else {
+      process.env.AGENC_TUI_GLYPHS = originalGlyphMode
+    }
+  })
+
+  test('clamps layout helpers and extracts previews from recent message content', () => {
+    expect(computeTeammateActivityMaxWidth(40.9, 8, 10, 5)).toBe(16)
+    expect(computeTeammateActivityMaxWidth(12, 8, 10, 5)).toBe(0)
+    expect(computeTeammatePreviewTextWidth(12.9)).toBe(4)
+    expect(computeTeammatePreviewTextWidth(7)).toBe(0)
+    expect(getMessagePreview(undefined, 80)).toEqual([])
+
+    expect(
+      getMessagePreview(
+        [
+          {
+            type: 'assistant',
+            message: {
+              content: [{ type: 'text', text: 'older line' }],
+            },
+          },
+          {
+            type: 'user',
+            message: {
+              content: [
+                null,
+                { type: 'tool_use', name: 'Grep', input: { pattern: 'needle' } },
+                { type: 'text', text: 'first latest\n\nsecond latest' },
+              ],
+            },
+          },
+        ] as never,
+        80,
+      ),
+    ).toEqual(['first latest', 'second latest', 'needle'])
+
+    expect(
+      getMessagePreview(
+        [
+          {
+            type: 'assistant',
+            message: {
+              content: [{ type: 'tool_use', name: 'Notebook' }],
+            },
+          },
+        ] as never,
+        80,
+      ),
+    ).toEqual(['Using Notebook...'])
+  })
+
+  test('renders selected, foregrounded, and compact active teammate rows', async () => {
+    const selected = await renderLine(teammate(), {
+      isForegrounded: false,
+      isSelected: true,
+    })
+
+    expect(selected).toContain('@reviewer')
+    expect(selected).toContain('2 tool uses')
+    expect(selected).toContain('2.5k tokens')
+    expect(selected).toContain('shift +')
+    expect(selected).toContain('enter to view')
+    expect(selected).not.toContain('Reading project notes')
+
+    const foregrounded = await renderLine(teammate(), {
+      isForegrounded: true,
+      isSelected: false,
+    })
+
+    expect(foregrounded).toContain('@reviewer')
+    expect(foregrounded).toContain('shift +')
+    expect(foregrounded).not.toContain('enter to view')
+    expect(foregrounded).not.toContain('Reading project notes')
+
+    const compact = await renderLine(
+      teammate({ progress: undefined, spinnerVerb: undefined }),
+      {},
+      30,
+    )
+
+    expect(compact).toContain('Coordinating')
+    expect(compact).not.toContain('@reviewer')
+    expect(compact).not.toContain('tokens')
+  })
+
+  test('renders status precedence, idle durations, and preview continuation rows', async () => {
+    const stopping = await renderLine(
+      teammate({
+        awaitingPlanApproval: true,
+        isIdle: true,
+        shutdownRequested: true,
+      }),
+    )
+
+    expect(stopping).toContain('[stopping]')
+    expect(stopping).not.toContain('[awaiting approval]')
+    expect(stopping).not.toContain('Idle for')
+
+    const awaitingApproval = await renderLine(
+      teammate({ awaitingPlanApproval: true }),
+    )
+    expect(awaitingApproval).toContain('[awaiting approval]')
+
+    const idle = await renderLine(teammate({ isIdle: true }))
+    expect(idle).toContain('Idle for 0s')
+
+    const allIdle = await renderLine(
+      teammate({
+        isIdle: true,
+        pastTenseVerb: 'finished',
+        startTime: NOW - 74_000,
+        totalPausedMs: 10_000,
+      }),
+      { allIdle: true, isLast: true },
+    )
+    expect(allIdle).toContain('finished for 1m 4s')
+
+    const preview = await renderLine(
+      teammate({
+        messages: [
+          {
+            type: 'assistant',
+            message: {
+              content: [
+                { type: 'text', text: 'opened file\nchecked branch' },
+              ],
+            },
+          },
+        ] as never,
+      }),
+      { showPreview: true },
+    )
+
+    expect(preview).toContain('Reading project notes')
+    expect(preview).toContain('|   opened file')
+    expect(preview).toContain('|   checked branch')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-124-hooks-useArrowKeyHistory.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-124-hooks-useArrowKeyHistory.test.tsx
@@ -1,0 +1,269 @@
+import { PassThrough } from 'node:stream'
+
+import React, { useState } from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+type PastedContentLike = {
+  content: string
+  id: number
+  type: 'text'
+}
+
+type HistoryEntryLike = {
+  display: string
+  pastedContents?: Record<number, PastedContentLike>
+}
+
+const harness = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  entries: [] as HistoryEntryLike[],
+  historyReadCount: 0,
+  removeNotification: vi.fn(),
+  reset() {
+    this.addNotification.mockClear()
+    this.entries = []
+    this.historyReadCount = 0
+    this.removeNotification.mockClear()
+  },
+}))
+
+vi.mock('../../../src/tui/context/notifications.js', () => ({
+  useNotifications: () => ({
+    addNotification: harness.addNotification,
+    removeNotification: harness.removeNotification,
+  }),
+}))
+
+vi.mock('../../../src/tui/history/history.js', () => ({
+  getHistory: async function* () {
+    harness.historyReadCount += 1
+    for (const entry of harness.entries) {
+      yield entry
+    }
+  },
+}))
+
+import { createRoot } from '../../../src/tui/ink/root.js'
+import {
+  type HistoryMode,
+  useArrowKeyHistory,
+} from '../../../src/tui/hooks/useArrowKeyHistory.js'
+
+type HookResult = ReturnType<typeof useArrowKeyHistory>
+
+function createStreams(): {
+  readonly stdout: PassThrough
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  let lastError: unknown
+  for (let i = 0; i < 30; i++) {
+    try {
+      assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await sleep()
+    }
+  }
+  throw lastError
+}
+
+async function renderHookHarness(
+  initial: {
+    currentInput?: string
+    currentMode?: HistoryMode
+    includeCursorSetter?: boolean
+  } = {},
+): Promise<{
+  readonly currentInput: () => string
+  readonly currentMode: () => HistoryMode | undefined
+  readonly dispose: () => Promise<void>
+  readonly latest: () => HookResult
+  readonly onSetInput: ReturnType<typeof vi.fn>
+  readonly setCursorOffset: ReturnType<typeof vi.fn>
+}> {
+  let latest: HookResult | undefined
+  let latestInput = initial.currentInput ?? ''
+  let latestMode = initial.currentMode
+  let latestPastedContents: Record<number, PastedContentLike> = {}
+  const onSetInput = vi.fn()
+  const setCursorOffset = vi.fn()
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    const [input, setInput] = useState(latestInput)
+    const [mode, setMode] = useState<HistoryMode | undefined>(latestMode)
+    const [pastedContents, setPastedContents] = useState(latestPastedContents)
+
+    latestInput = input
+    latestMode = mode
+    latestPastedContents = pastedContents
+    latest = useArrowKeyHistory(
+      (value, nextMode, nextPastedContents) => {
+        onSetInput(value, nextMode, nextPastedContents)
+        setInput(value)
+        setMode(nextMode)
+        setPastedContents(nextPastedContents)
+      },
+      input,
+      pastedContents,
+      initial.includeCursorSetter === false ? undefined : setCursorOffset,
+      mode,
+    )
+
+    return null
+  }
+
+  root.render(<Harness />)
+  await sleep()
+
+  return {
+    currentInput: () => latestInput,
+    currentMode: () => latestMode,
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+    onSetInput,
+    setCursorOffset,
+  }
+}
+
+describe('useArrowKeyHistory coverage swarm 124', () => {
+  beforeEach(() => {
+    harness.reset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('batches rapid upward traversal and expands the pending history load by chunks', async () => {
+    harness.entries = Array.from({ length: 12 }, (_, index) => ({
+      display: `history entry ${index}`,
+      pastedContents: {},
+    }))
+    const rendered = await renderHookHarness({ currentInput: 'draft' })
+
+    try {
+      for (let i = 0; i < 11; i++) {
+        rendered.latest().onHistoryUp()
+      }
+
+      await waitFor(() =>
+        expect(rendered.currentInput()).toBe('history entry 10'),
+      )
+
+      expect(rendered.latest().historyIndex).toBe(11)
+      expect(harness.historyReadCount).toBe(2)
+      expect(harness.addNotification).toHaveBeenCalledTimes(1)
+      expect(rendered.setCursorOffset).toHaveBeenLastCalledWith(0)
+
+      expect(rendered.latest().onHistoryDown()).toBe(false)
+      await waitFor(() =>
+        expect(rendered.currentInput()).toBe('history entry 9'),
+      )
+      expect(rendered.latest().historyIndex).toBe(10)
+      expect(rendered.setCursorOffset).toHaveBeenLastCalledWith(
+        'history entry 9'.length,
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('clears an empty bash draft back to bash mode and exposes explicit hint dismissal', async () => {
+    harness.entries = [
+      { display: 'plain prompt command', pastedContents: {} },
+      { display: '!npm run dev', pastedContents: {} },
+    ]
+    const rendered = await renderHookHarness({
+      currentInput: '   ',
+      currentMode: 'bash',
+    })
+
+    try {
+      rendered.latest().onHistoryUp()
+      await waitFor(() => expect(rendered.currentInput()).toBe('npm run dev'))
+      expect(rendered.currentMode()).toBe('bash')
+
+      expect(rendered.latest().onHistoryDown()).toBe(false)
+      await waitFor(() => expect(rendered.currentInput()).toBe(''))
+      expect(rendered.currentMode()).toBe('bash')
+      expect(rendered.onSetInput).toHaveBeenLastCalledWith('', 'bash', {})
+
+      rendered.latest().dismissSearchHint()
+      expect(harness.removeNotification).toHaveBeenCalledWith(
+        'search-history-hint',
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('ignores blank history entries and derives the draft mode when no current mode was supplied', async () => {
+    harness.entries = [{ display: '', pastedContents: {} }]
+    const rendered = await renderHookHarness({
+      currentInput: '!draft command',
+      includeCursorSetter: false,
+    })
+
+    try {
+      rendered.latest().onHistoryUp()
+      await waitFor(() => expect(rendered.latest().historyIndex).toBe(1))
+      expect(rendered.currentInput()).toBe('!draft command')
+      expect(rendered.onSetInput).not.toHaveBeenCalled()
+      expect(rendered.setCursorOffset).not.toHaveBeenCalled()
+
+      expect(rendered.latest().onHistoryDown()).toBe(false)
+      await waitFor(() => expect(rendered.currentInput()).toBe('draft command'))
+      expect(rendered.currentMode()).toBe('bash')
+      expect(rendered.onSetInput).toHaveBeenLastCalledWith(
+        'draft command',
+        'bash',
+        {},
+      )
+      expect(rendered.setCursorOffset).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-125-ink-terminal-focus-state.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-125-ink-terminal-focus-state.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  getTerminalFocused,
+  getTerminalFocusState,
+  resetTerminalFocusState,
+  setTerminalFocused,
+  subscribeTerminalFocus,
+} from '../../../src/tui/ink/terminal-focus-state.js'
+
+afterEach(() => {
+  resetTerminalFocusState()
+  vi.restoreAllMocks()
+})
+
+describe('terminal-focus-state coverage swarm row 125', () => {
+  test('treats the default unknown state as focused', () => {
+    expect(getTerminalFocusState()).toBe('unknown')
+    expect(getTerminalFocused()).toBe(true)
+  })
+
+  test('tracks focused and blurred states', () => {
+    setTerminalFocused(false)
+
+    expect(getTerminalFocusState()).toBe('blurred')
+    expect(getTerminalFocused()).toBe(false)
+
+    setTerminalFocused(true)
+
+    expect(getTerminalFocusState()).toBe('focused')
+    expect(getTerminalFocused()).toBe(true)
+  })
+
+  test('notifies subscribers synchronously and stops after unsubscribe', () => {
+    const seen: Array<{
+      focused: boolean
+      state: ReturnType<typeof getTerminalFocusState>
+    }> = []
+    const subscriber = vi.fn(() => {
+      seen.push({
+        focused: getTerminalFocused(),
+        state: getTerminalFocusState(),
+      })
+    })
+    const unsubscribe = subscribeTerminalFocus(subscriber)
+
+    setTerminalFocused(false)
+
+    expect(subscriber).toHaveBeenCalledOnce()
+    expect(seen).toEqual([{ focused: false, state: 'blurred' }])
+
+    unsubscribe()
+    setTerminalFocused(true)
+
+    expect(subscriber).toHaveBeenCalledOnce()
+    expect(getTerminalFocusState()).toBe('focused')
+  })
+
+  test('notifies every current subscriber in insertion order', () => {
+    const calls: string[] = []
+    const unsubscribeFirst = subscribeTerminalFocus(() => {
+      calls.push(`first:${getTerminalFocusState()}`)
+    })
+    const unsubscribeSecond = subscribeTerminalFocus(() => {
+      calls.push(`second:${getTerminalFocusState()}`)
+    })
+
+    setTerminalFocused(false)
+    unsubscribeFirst()
+    setTerminalFocused(true)
+    unsubscribeSecond()
+
+    expect(calls).toEqual(['first:blurred', 'second:blurred', 'second:focused'])
+  })
+
+  test('reset restores unknown focus and notifies active subscribers', () => {
+    setTerminalFocused(false)
+    const subscriber = vi.fn()
+    const unsubscribe = subscribeTerminalFocus(subscriber)
+
+    resetTerminalFocusState()
+
+    expect(getTerminalFocusState()).toBe('unknown')
+    expect(getTerminalFocused()).toBe(true)
+    expect(subscriber).toHaveBeenCalledOnce()
+
+    unsubscribe()
+  })
+
+  test('unsubscribe is idempotent', () => {
+    const subscriber = vi.fn()
+    const unsubscribe = subscribeTerminalFocus(subscriber)
+
+    unsubscribe()
+    unsubscribe()
+    setTerminalFocused(false)
+
+    expect(subscriber).not.toHaveBeenCalled()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-126-keybindings-validate.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-126-keybindings-validate.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../../src/tui/keybindings/parser.js', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('../../../src/tui/keybindings/parser.js')>()
+
+  return {
+    ...actual,
+    parseKeystroke: (input: string) => {
+      if (input === 'mock-empty') {
+        return {
+          alt: false,
+          ctrl: false,
+          key: '',
+          meta: false,
+          shift: false,
+          super: false,
+        }
+      }
+
+      return actual.parseKeystroke(input)
+    },
+  }
+})
+
+import type {
+  KeybindingBlock,
+  ParsedBinding,
+} from '../../../src/tui/keybindings/types.js'
+import {
+  checkDuplicateKeysInJson,
+  checkDuplicates,
+  checkReservedShortcuts,
+  formatWarnings,
+  validateBindings,
+  validateUserConfig,
+} from '../../../src/tui/keybindings/validate.js'
+
+describe('keybinding validate coverage swarm row 126', () => {
+  test('reports parser failures when a keystroke produces no key or modifiers', () => {
+    const warnings = validateUserConfig([
+      {
+        context: 'Chat',
+        bindings: {
+          'mock-empty': 'chat:submit',
+        },
+      },
+    ])
+
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        context: 'Chat',
+        key: 'mock-empty',
+        message: 'Could not parse keystroke "mock-empty"',
+        severity: 'error',
+        type: 'parse_error',
+      }),
+    ])
+  })
+
+  test('accepts null unbinds and valid chat command bindings', () => {
+    expect(
+      validateUserConfig([
+        {
+          context: 'Chat',
+          bindings: {
+            'ctrl+y': null,
+            'meta+r': 'command:run_task-1',
+          },
+        },
+      ]),
+    ).toEqual([])
+  })
+
+  test('handles empty duplicate-json blocks and missing context names', () => {
+    const warnings = checkDuplicateKeysInJson(`[
+      {
+        "bindings": {}
+      },
+      {
+        "bindings": {
+          "ctrl+x": "chat:cancel",
+          "ctrl+x": "chat:submit",
+          "ctrl+x": "chat:newline"
+        }
+      },
+      {
+        "context": "Chat",
+        "bindings": {
+          "enter": "chat:submit"
+        }
+      },
+      {
+        "context": "Chat",
+        "bindings": {
+          "enter": "chat:newline"
+        }
+      }
+    ]`)
+
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        context: 'unknown',
+        key: 'ctrl+x',
+        message: 'Duplicate key "ctrl+x" in unknown bindings',
+        severity: 'warning',
+        type: 'duplicate',
+      }),
+    ])
+  })
+
+  test('describes null unbinds when normalized duplicates conflict', () => {
+    const blocks: KeybindingBlock[] = [
+      {
+        context: 'Chat',
+        bindings: {
+          'ctrl+z': 'chat:cancel',
+          'control+z': null,
+        },
+      },
+    ]
+
+    expect(checkDuplicates(blocks)).toEqual([
+      expect.objectContaining({
+        action: 'null (unbind)',
+        context: 'Chat',
+        key: 'control+z',
+        suggestion:
+          'Previously bound to "chat:cancel". Only the last binding will be used.',
+        type: 'duplicate',
+      }),
+    ])
+  })
+
+  test('preserves null action metadata on reserved shortcut warnings', () => {
+    const warnings = checkReservedShortcuts([
+      {
+        action: null,
+        chord: [
+          {
+            alt: false,
+            ctrl: true,
+            key: 'm',
+            meta: false,
+            shift: false,
+            super: false,
+          },
+        ],
+        context: 'Chat',
+      },
+    ] as ParsedBinding[])
+
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        action: undefined,
+        context: 'Chat',
+        key: 'ctrl+m',
+        severity: 'error',
+        type: 'reserved',
+      }),
+    ])
+  })
+
+  test('skips duplicate and reserved checks for structurally invalid config', () => {
+    const warnings = validateBindings(
+      [
+        {
+          context: 'Chat',
+          bindings: null,
+        },
+      ],
+      [],
+    )
+
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        message: 'Keybinding block 1 missing "bindings" field',
+        type: 'parse_error',
+      }),
+    ])
+  })
+
+  test('pluralizes all-error and all-warning batches', () => {
+    expect(
+      formatWarnings([
+        {
+          message: 'Bad key one',
+          severity: 'error',
+          type: 'parse_error',
+        },
+        {
+          message: 'Bad key two',
+          severity: 'error',
+          type: 'invalid_context',
+        },
+      ]),
+    ).toBe(
+      [
+        'Found 2 keybinding errors:',
+        '✗ Keybinding error: Bad key one',
+        '✗ Keybinding error: Bad key two',
+      ].join('\n'),
+    )
+
+    expect(
+      formatWarnings([
+        {
+          message: 'Risky key one',
+          severity: 'warning',
+          type: 'reserved',
+        },
+        {
+          message: 'Risky key two',
+          severity: 'warning',
+          type: 'duplicate',
+        },
+      ]),
+    ).toBe(
+      [
+        'Found 2 keybinding warnings:',
+        '! Keybinding warning: Risky key one',
+        '! Keybinding warning: Risky key two',
+      ].join('\n'),
+    )
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-127-components-GlobalSearchDialog.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-127-components-GlobalSearchDialog.test.tsx
@@ -1,0 +1,300 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+type SearchMatch = {
+  file: string
+  line: number
+  text: string
+}
+
+type PickerAction = {
+  action: string
+  handler: (item: SearchMatch) => void
+}
+
+type CapturedPickerProps = {
+  items: readonly SearchMatch[]
+  visibleCount: number
+  previewPosition: 'bottom' | 'right'
+  onQueryChange: (query: string) => void
+  onFocus?: (item: SearchMatch | undefined) => void
+  onSelect: (item: SearchMatch) => void
+  onTab?: PickerAction
+  onShiftTab?: PickerAction
+  onCancel: () => void
+  emptyMessage?: string | ((query: string) => string)
+  matchLabel?: string
+  renderItem: (item: SearchMatch, isFocused: boolean) => React.ReactNode
+  renderPreview?: (item: SearchMatch) => React.ReactNode
+}
+
+const harness = vi.hoisted(() => ({
+  cwd: '/workspace/project',
+  logEvent: vi.fn(),
+  openFileInExternalEditor: vi.fn(),
+  pickerProps: undefined as CapturedPickerProps | undefined,
+  readFileInRange: vi.fn(),
+  registerOverlay: vi.fn(),
+  ripGrepStream: vi.fn(),
+  terminal: {
+    columns: 4,
+    rows: 5,
+  },
+}))
+
+vi.mock('src/tui/context/overlayContext.js', () => ({
+  useRegisterOverlay: harness.registerOverlay,
+}))
+
+vi.mock('src/tui/hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => harness.terminal,
+}))
+
+vi.mock('src/services/analytics/index.js', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('src/utils/cwd.js', () => ({
+  getCwd: () => harness.cwd,
+}))
+
+vi.mock('src/utils/editor.js', () => ({
+  openFileInExternalEditor: harness.openFileInExternalEditor,
+}))
+
+vi.mock('src/utils/readFileInRange.js', () => ({
+  readFileInRange: harness.readFileInRange,
+}))
+
+vi.mock('src/utils/ripgrep.js', () => ({
+  ripGrepStream: harness.ripGrepStream,
+}))
+
+vi.mock('src/tui/components/design-system/FuzzyPicker.js', () => ({
+  FuzzyPicker: (props: CapturedPickerProps) => {
+    harness.pickerProps = props
+    return null
+  },
+}))
+
+import { createRoot } from 'src/tui/ink/root.js'
+import { renderToString } from 'src/utils/staticRender.js'
+import {
+  GlobalSearchDialog,
+  computeGlobalSearchLayout,
+  parseRipgrepLine,
+} from 'src/tui/components/GlobalSearchDialog.js'
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function resetHarness() {
+  harness.terminal.columns = 4
+  harness.terminal.rows = 5
+  harness.pickerProps = undefined
+  harness.registerOverlay.mockClear()
+  harness.logEvent.mockClear()
+  harness.openFileInExternalEditor.mockReset()
+  harness.openFileInExternalEditor.mockReturnValue(false)
+  harness.readFileInRange.mockReset()
+  harness.readFileInRange.mockResolvedValue({ content: '' })
+  harness.ripGrepStream.mockReset()
+  harness.ripGrepStream.mockResolvedValue(undefined)
+}
+
+function pickerProps(): CapturedPickerProps {
+  const props = harness.pickerProps
+  if (!props) throw new Error('Global search picker props were not captured')
+  return props
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await sleep(10)
+  }
+  throw new Error(message)
+}
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = harness.terminal.columns
+  ;(stdout as unknown as { rows: number }).rows = harness.terminal.rows
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function renderDialog() {
+  const onDone = vi.fn()
+  const onInsert = vi.fn()
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  root.render(<GlobalSearchDialog onDone={onDone} onInsert={onInsert} />)
+  await waitFor(() => harness.pickerProps !== undefined, 'GlobalSearchDialog did not render')
+
+  return {
+    onDone,
+    onInsert,
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep(25)
+    },
+  }
+}
+
+describe('GlobalSearchDialog coverage swarm row 127', () => {
+  beforeEach(() => {
+    resetHarness()
+  })
+
+  test('handles parser and layout edge cases', () => {
+    expect(
+      parseRipgrepLine('C:\\repo\\src\\app.ts:7:needle: with colon'),
+    ).toEqual({
+      file: 'C:\\repo\\src\\app.ts',
+      line: 7,
+      text: 'needle: with colon',
+    })
+    expect(parseRipgrepLine(':12:missing file')).toBeNull()
+    expect(parseRipgrepLine(`src/app.ts:${'9'.repeat(400)}:overflow`)).toBeNull()
+    expect(parseRipgrepLine('src/app.ts:not-a-line:needle')).toBeNull()
+
+    expect(
+      computeGlobalSearchLayout(
+        undefined as unknown as number,
+        undefined as unknown as number,
+      ),
+    ).toMatchObject({
+      listWidth: 1,
+      maxPathWidth: 1,
+      maxTextWidth: 1,
+      previewOnRight: false,
+      previewWidth: 1,
+      visibleResults: 4,
+    })
+  })
+
+  test('filters stale matches, suppresses duplicate stream results, and records failed editor opens', async () => {
+    const rendered = await renderDialog()
+    const searchSignals: AbortSignal[] = []
+
+    try {
+      harness.ripGrepStream.mockImplementation(
+        async (
+          args: string[],
+          cwd: string,
+          signal: AbortSignal,
+          onLines: (chunk: readonly string[]) => void,
+        ) => {
+          searchSignals.push(signal)
+          expect(args.slice(0, 8)).toEqual([
+            '-n',
+            '--no-heading',
+            '-i',
+            '-m',
+            '10',
+            '-F',
+            '-e',
+            args[7],
+          ])
+          expect(cwd).toBe(harness.cwd)
+
+          if (args[7] === 'needle') {
+            onLines([
+              '/workspace/project/src/alpha.ts:2:Needle alpha',
+              '/workspace/project/src/beta.ts:3:Needle beta',
+            ])
+            return
+          }
+
+          onLines(['/workspace/project/src/alpha.ts:2:Needle alpha'])
+        },
+      )
+
+      expect(pickerProps().visibleCount).toBe(4)
+      expect(pickerProps().previewPosition).toBe('bottom')
+
+      pickerProps().onQueryChange('needle')
+      await waitFor(
+        () => pickerProps().items.length === 2,
+        'Initial global search results did not render',
+      )
+
+      const narrowOutput = await renderToString(
+        pickerProps().renderItem(pickerProps().items[0], false),
+        10,
+      )
+      expect(narrowOutput).not.toContain('Needle alpha')
+
+      pickerProps().onQueryChange('alpha')
+      await waitFor(
+        () =>
+          pickerProps().items.length === 1 &&
+          pickerProps().items[0]?.file === 'src/alpha.ts',
+        'Global search did not filter stale results while the next search was pending',
+      )
+      expect(searchSignals[0]?.aborted).toBe(true)
+
+      await waitFor(
+        () => harness.ripGrepStream.mock.calls.length === 2,
+        'Global search did not run the second query',
+      )
+      await sleep(25)
+      expect(pickerProps().items).toEqual([
+        {
+          file: 'src/alpha.ts',
+          line: 2,
+          text: 'Needle alpha',
+        },
+      ])
+
+      pickerProps().onSelect(pickerProps().items[0])
+      expect(harness.openFileInExternalEditor).toHaveBeenCalledWith(
+        '/workspace/project/src/alpha.ts',
+        2,
+      )
+      expect(harness.logEvent).toHaveBeenCalledWith('agenc_global_search_select', {
+        opened_editor: false,
+        result_count: 1,
+      })
+      expect(rendered.onDone).toHaveBeenCalledTimes(1)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-128-cost-MemoryUsageIndicator.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-128-cost-MemoryUsageIndicator.test.tsx
@@ -1,0 +1,173 @@
+import { readFileSync } from 'node:fs'
+import vm from 'node:vm'
+
+import { transformSync } from 'esbuild'
+import React from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+const sourcePath = new URL(
+  '../../../src/tui/cost/MemoryUsageIndicator.tsx',
+  import.meta.url,
+)
+
+const mockUseMemoryUsage = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../src/tui/hooks/useMemoryUsage.js', () => ({
+  useMemoryUsage: mockUseMemoryUsage,
+}))
+
+import { MemoryUsageIndicator } from '../../../src/tui/cost/MemoryUsageIndicator.js'
+
+type MemoryUsageInfo = {
+  heapUsed: number
+  status: 'critical' | 'high' | 'normal'
+}
+
+type MemoryUsageComponent = () => React.ReactNode
+
+type TextElementProps = {
+  children?: React.ReactNode
+  color?: string
+  wrap?: string
+}
+
+function Box({ children }: { children?: React.ReactNode }): React.ReactElement {
+  return React.createElement('box', null, children)
+}
+
+function Text(props: TextElementProps): React.ReactElement {
+  return React.createElement('text', props, props.children)
+}
+
+function loadInternalBuildComponent({
+  formatFileSize,
+  useMemoryUsage,
+}: {
+  formatFileSize: (bytes: number) => string
+  useMemoryUsage: () => MemoryUsageInfo | null
+}): MemoryUsageComponent {
+  const externalSource = readFileSync(sourcePath, 'utf8')
+  const internalSource = externalSource.replace(
+    `if ("external" !== 'ant') {`,
+    `if ("ant" !== 'ant') {`,
+  )
+
+  if (internalSource === externalSource) {
+    throw new Error('MemoryUsageIndicator build-time guard was not found')
+  }
+
+  const transformed = transformSync(internalSource, {
+    format: 'cjs',
+    jsx: 'transform',
+    jsxFactory: 'React.createElement',
+    jsxFragment: 'React.Fragment',
+    loader: 'tsx',
+    sourcefile: sourcePath.pathname,
+    sourcemap: 'inline',
+  })
+
+  const module = { exports: {} as Record<string, unknown> }
+  const context = {
+    exports: module.exports,
+    module,
+    require: (specifier: string): unknown => {
+      switch (specifier) {
+        case 'react':
+          return React
+        case '../hooks/useMemoryUsage.js':
+          return { useMemoryUsage }
+        case '../ink.js':
+          return { Box, Text }
+        case '../../utils/format.js':
+          return { formatFileSize }
+        default:
+          throw new Error(`Unexpected import from transformed source: ${specifier}`)
+      }
+    },
+  }
+
+  vm.runInNewContext(transformed.code, context, {
+    filename: sourcePath.pathname,
+  })
+
+  return module.exports.MemoryUsageIndicator as MemoryUsageComponent
+}
+
+function getTextElement(node: React.ReactNode): React.ReactElement<TextElementProps> {
+  if (!React.isValidElement(node)) {
+    throw new Error('expected MemoryUsageIndicator to return an element')
+  }
+
+  const child = React.Children.only(node.props.children)
+  if (!React.isValidElement<TextElementProps>(child)) {
+    throw new Error('expected MemoryUsageIndicator to render text')
+  }
+  return child
+}
+
+function textContent(node: React.ReactNode): string {
+  return React.Children.toArray(node).join('')
+}
+
+describe('MemoryUsageIndicator coverage swarm 128', () => {
+  test('returns null before subscribing in external builds', () => {
+    mockUseMemoryUsage.mockReturnValue({
+      heapUsed: 3 * 1024 * 1024 * 1024,
+      status: 'critical',
+    })
+
+    expect(MemoryUsageIndicator()).toBeNull()
+    expect(mockUseMemoryUsage).not.toHaveBeenCalled()
+  })
+
+  test('suppresses empty and normal memory usage in the internal build path', () => {
+    const formatFileSize = vi.fn((bytes: number) => `${bytes} bytes`)
+    const useMemoryUsage = vi.fn<() => MemoryUsageInfo | null>(() => null)
+    const Component = loadInternalBuildComponent({ formatFileSize, useMemoryUsage })
+
+    expect(Component()).toBeNull()
+    expect(useMemoryUsage).toHaveBeenCalledOnce()
+    expect(formatFileSize).not.toHaveBeenCalled()
+
+    useMemoryUsage.mockReturnValue({
+      heapUsed: 1024,
+      status: 'normal',
+    })
+
+    expect(Component()).toBeNull()
+    expect(useMemoryUsage).toHaveBeenCalledTimes(2)
+    expect(formatFileSize).not.toHaveBeenCalled()
+  })
+
+  test('renders high and critical memory warnings in the internal build path', () => {
+    const formatFileSize = vi.fn((bytes: number) => `${bytes / 1024}KB`)
+    const useMemoryUsage = vi.fn<() => MemoryUsageInfo | null>()
+    const Component = loadInternalBuildComponent({ formatFileSize, useMemoryUsage })
+
+    useMemoryUsage.mockReturnValue({
+      heapUsed: 1536,
+      status: 'high',
+    })
+
+    const highText = getTextElement(Component())
+    expect(highText.props.color).toBe('warning')
+    expect(highText.props.wrap).toBe('truncate')
+    expect(textContent(highText.props.children)).toBe(
+      'High memory usage (1.5KB) · /heapdump',
+    )
+    expect(formatFileSize).toHaveBeenLastCalledWith(1536)
+
+    useMemoryUsage.mockReturnValue({
+      heapUsed: 3072,
+      status: 'critical',
+    })
+
+    const criticalText = getTextElement(Component())
+    expect(criticalText.props.color).toBe('error')
+    expect(criticalText.props.wrap).toBe('truncate')
+    expect(textContent(criticalText.props.children)).toBe(
+      'High memory usage (3KB) · /heapdump',
+    )
+    expect(formatFileSize).toHaveBeenLastCalledWith(3072)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-129-hooks-toolPermission-PermissionContext.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-129-hooks-toolPermission-PermissionContext.test.ts
@@ -1,0 +1,321 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  applyPermissionUpdates: vi.fn(),
+  awaitClassifierAutoApproval: vi.fn(),
+  classifierApprovals: [] as Array<[string, string]>,
+  debug: vi.fn(),
+  features: new Set<string>(),
+  hookResults: [] as Array<{
+    permissionRequestResult?: {
+      behavior: 'allow' | 'deny'
+      interrupt?: boolean
+      message?: string
+      updatedInput?: Record<string, unknown>
+      updatedPermissions?: Array<{ destination: string }>
+    }
+  }>,
+  logEvent: vi.fn(),
+  logPermissionDecision: vi.fn(),
+  persistPermissionUpdates: vi.fn(),
+  sanitizeToolNameForAnalytics: vi.fn((toolName: string) => `safe:${toolName}`),
+  supportsPersistence: vi.fn((destination: string) => destination === 'project'),
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => harness.features.has(name),
+}))
+
+vi.mock('../../../src/services/analytics/index.js', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../../../src/services/analytics/metadata.js', () => ({
+  sanitizeToolNameForAnalytics: harness.sanitizeToolNameForAnalytics,
+}))
+
+vi.mock('../../../src/tools/BashTool/bashPermissions.js', () => ({
+  awaitClassifierAutoApproval: harness.awaitClassifierAutoApproval,
+}))
+
+vi.mock('../../../src/tools/BashTool/toolName.js', () => ({
+  BASH_TOOL_NAME: 'Bash',
+}))
+
+vi.mock('../../../src/utils/classifierApprovals.js', () => ({
+  setClassifierApproval: (toolUseID: string, rule: string) => {
+    harness.classifierApprovals.push([toolUseID, rule])
+  },
+}))
+
+vi.mock('src/utils/debug.js', () => ({
+  logForDebugging: harness.debug,
+}))
+
+vi.mock('../../../src/utils/hooks.js', () => ({
+  executePermissionRequestHooks: async function* () {
+    for (const result of harness.hookResults) {
+      yield result
+    }
+  },
+}))
+
+vi.mock('../../../src/utils/messages.js', () => ({
+  REJECT_MESSAGE: 'Rejected',
+  REJECT_MESSAGE_WITH_REASON_PREFIX: 'Rejected: ',
+  SUBAGENT_REJECT_MESSAGE: 'Subagent rejected',
+  SUBAGENT_REJECT_MESSAGE_WITH_REASON_PREFIX: 'Subagent rejected: ',
+  withMemoryCorrectionHint: (message: string) => `${message} [memory hint]`,
+}))
+
+vi.mock('../../../src/utils/permissions/PermissionUpdate.js', () => ({
+  applyPermissionUpdates: harness.applyPermissionUpdates,
+  persistPermissionUpdates: harness.persistPermissionUpdates,
+  supportsPersistence: harness.supportsPersistence,
+}))
+
+vi.mock('../../../src/tui/hooks/toolPermission/permissionLogging.js', () => ({
+  logPermissionDecision: harness.logPermissionDecision,
+}))
+
+import {
+  createPermissionContext,
+  createPermissionQueueOps,
+} from '../../../src/tui/hooks/toolPermission/PermissionContext.js'
+
+type TestTool = {
+  name: string
+  inputsEquivalent?: (
+    previous: Record<string, unknown>,
+    next: Record<string, unknown>,
+  ) => boolean
+}
+
+function tool(overrides: Partial<TestTool> = {}): TestTool {
+  return {
+    name: 'Read',
+    inputsEquivalent: (previous, next) => previous.path === next.path,
+    ...overrides,
+  }
+}
+
+function toolUseContext(
+  overrides: Partial<{
+    abortController: AbortController
+    agentId: string
+    isNonInteractiveSession: boolean
+    toolPermissionContext: Record<string, unknown>
+  }> = {},
+) {
+  const abortController = overrides.abortController ?? new AbortController()
+  const toolPermissionContext =
+    overrides.toolPermissionContext ?? ({ mode: 'default' } as const)
+
+  return {
+    abortController,
+    agentId: overrides.agentId,
+    getAppState: () => ({ toolPermissionContext }),
+    options: {
+      isNonInteractiveSession: overrides.isNonInteractiveSession ?? false,
+    },
+  }
+}
+
+function context(
+  overrides: Partial<{
+    input: Record<string, unknown>
+    setToolPermissionContext: ReturnType<typeof vi.fn>
+    tool: TestTool
+    toolUseContext: ReturnType<typeof toolUseContext>
+    toolUseID: string
+  }> = {},
+) {
+  return createPermissionContext(
+    (overrides.tool ?? tool()) as never,
+    overrides.input ?? { path: 'a.ts' },
+    (overrides.toolUseContext ?? toolUseContext()) as never,
+    { message: { id: 'message-1' } } as never,
+    overrides.toolUseID ?? 'tool-use-1',
+    overrides.setToolPermissionContext ?? vi.fn(),
+  )
+}
+
+beforeEach(() => {
+  harness.applyPermissionUpdates.mockReset()
+  harness.applyPermissionUpdates.mockImplementation((current, updates) => ({
+    ...current,
+    updates,
+  }))
+  harness.awaitClassifierAutoApproval.mockReset()
+  harness.classifierApprovals = []
+  harness.debug.mockReset()
+  harness.features = new Set()
+  harness.hookResults = []
+  harness.logEvent.mockReset()
+  harness.logPermissionDecision.mockReset()
+  harness.persistPermissionUpdates.mockReset()
+  harness.sanitizeToolNameForAnalytics.mockClear()
+  harness.supportsPersistence.mockClear()
+})
+
+describe('PermissionContext coverage swarm row 129', () => {
+  test('omits optional allow fields when feedback and content blocks are empty', async () => {
+    const setToolPermissionContext = vi.fn()
+    const ctx = context({
+      setToolPermissionContext,
+      tool: { name: 'Write' },
+    })
+
+    await expect(
+      ctx.handleUserAllow({ path: 'a.ts' }, [], '   ', 25, []),
+    ).resolves.toEqual({
+      behavior: 'allow',
+      updatedInput: { path: 'a.ts' },
+      userModified: false,
+    })
+
+    expect(harness.persistPermissionUpdates).not.toHaveBeenCalled()
+    expect(setToolPermissionContext).not.toHaveBeenCalled()
+    expect(harness.logPermissionDecision).toHaveBeenCalledWith(
+      expect.objectContaining({ toolUseID: 'tool-use-1' }),
+      { decision: 'accept', source: { type: 'user', permanent: false } },
+      25,
+    )
+  })
+
+  test('keeps rejection paths non-aborting unless the abort flag is explicit', () => {
+    const activeContext = toolUseContext()
+    const active = context({ toolUseContext: activeContext })
+    const block = [{ type: 'text', text: 'diagnostic block' }]
+
+    expect(active.cancelAndAbort('needs review')).toEqual({
+      behavior: 'ask',
+      message: 'Rejected: needs review [memory hint]',
+      contentBlocks: undefined,
+    })
+    expect(activeContext.abortController.signal.aborted).toBe(false)
+
+    expect(active.cancelAndAbort(undefined, false, block as never)).toEqual({
+      behavior: 'ask',
+      message: 'Rejected [memory hint]',
+      contentBlocks: block,
+    })
+    expect(activeContext.abortController.signal.aborted).toBe(false)
+
+    const forcedContext = toolUseContext()
+    const forced = context({ toolUseContext: forcedContext })
+
+    expect(forced.cancelAndAbort('stop now', true)).toEqual({
+      behavior: 'ask',
+      message: 'Rejected: stop now [memory hint]',
+      contentBlocks: undefined,
+    })
+    expect(forcedContext.abortController.signal.aborted).toBe(true)
+    expect(harness.debug).toHaveBeenCalledWith(
+      expect.stringContaining('isAbort=true'),
+    )
+  })
+
+  test('uses hook allow and deny fallback values', async () => {
+    const setToolPermissionContext = vi.fn()
+    harness.hookResults = [
+      {
+        permissionRequestResult: {
+          behavior: 'allow',
+          updatedPermissions: [{ destination: 'project' }],
+        },
+      },
+    ]
+
+    await expect(
+      context({ setToolPermissionContext }).runHooks(
+        'plan',
+        undefined,
+        { path: 'suggested.ts' },
+        100,
+      ),
+    ).resolves.toEqual({
+      behavior: 'allow',
+      updatedInput: { path: 'suggested.ts' },
+      userModified: false,
+      decisionReason: { type: 'hook', hookName: 'PermissionRequest' },
+    })
+    expect(setToolPermissionContext).toHaveBeenCalledWith({
+      mode: 'default',
+      updates: [{ destination: 'project' }],
+    })
+    expect(harness.logPermissionDecision).toHaveBeenCalledWith(
+      expect.anything(),
+      { decision: 'accept', source: { type: 'hook', permanent: true } },
+      100,
+    )
+
+    harness.hookResults = [
+      {
+        permissionRequestResult: {
+          behavior: 'deny',
+        },
+      },
+    ]
+
+    await expect(context().runHooks(undefined, undefined)).resolves.toEqual({
+      behavior: 'deny',
+      message: 'Permission denied by hook',
+      decisionReason: {
+        type: 'hook',
+        hookName: 'PermissionRequest',
+        reason: undefined,
+      },
+    })
+    expect(harness.debug).not.toHaveBeenCalledWith(
+      expect.stringContaining('Hook interrupt'),
+    )
+  })
+
+  test('covers classifier fallback outcomes and queue misses', async () => {
+    harness.features.add('BASH_CLASSIFIER')
+    const classifier = context({
+      input: { command: 'npm test' },
+      tool: tool({ name: 'Bash' }),
+      toolUseContext: toolUseContext({ isNonInteractiveSession: true }),
+    })
+
+    await expect(classifier.tryClassifier?.(undefined, undefined)).resolves.toBeNull()
+    expect(harness.awaitClassifierAutoApproval).not.toHaveBeenCalled()
+
+    harness.awaitClassifierAutoApproval.mockResolvedValueOnce(null)
+    await expect(
+      classifier.tryClassifier?.({ id: 'pending' } as never, undefined),
+    ).resolves.toBeNull()
+
+    harness.features.add('TRANSCRIPT_CLASSIFIER')
+    harness.awaitClassifierAutoApproval.mockResolvedValueOnce({
+      type: 'classifier',
+      reason: 'Allowed without stored prompt rule',
+    })
+    await expect(
+      classifier.tryClassifier?.({ id: 'pending-2' } as never, undefined),
+    ).resolves.toEqual({
+      behavior: 'allow',
+      updatedInput: { command: 'npm test' },
+      userModified: false,
+      decisionReason: {
+        type: 'classifier',
+        reason: 'Allowed without stored prompt rule',
+      },
+    })
+    expect(harness.classifierApprovals).toEqual([])
+
+    let queue: Array<Record<string, unknown>> = [{ toolUseID: 'kept', title: 'Kept' }]
+    const setQueue = vi.fn(updater => {
+      queue = typeof updater === 'function' ? updater(queue) : updater
+    })
+    const ops = createPermissionQueueOps(setQueue as never)
+
+    ops.update('missing', { title: 'Ignored' } as never)
+    ops.remove('missing')
+
+    expect(queue).toEqual([{ toolUseID: 'kept', title: 'Kept' }])
+    expect(setQueue).toHaveBeenCalledTimes(2)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-130-ink-frame.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-130-ink-frame.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  emptyFrame,
+  shouldClearScreen,
+  type Frame,
+} from '../../../src/tui/ink/frame.js'
+import {
+  CharPool,
+  createScreen,
+  HyperlinkPool,
+  isEmptyCellAt,
+  StylePool,
+} from '../../../src/tui/ink/screen.js'
+
+function makePools(): {
+  stylePool: StylePool
+  charPool: CharPool
+  hyperlinkPool: HyperlinkPool
+} {
+  return {
+    charPool: new CharPool(),
+    hyperlinkPool: new HyperlinkPool(),
+    stylePool: new StylePool(),
+  }
+}
+
+function makeFrame({
+  screenHeight,
+  viewportHeight,
+  viewportWidth = 12,
+}: {
+  screenHeight: number
+  viewportHeight: number
+  viewportWidth?: number
+}): Frame {
+  const pools = makePools()
+
+  return {
+    cursor: { visible: true, x: 0, y: 0 },
+    screen: createScreen(
+      4,
+      screenHeight,
+      pools.stylePool,
+      pools.charPool,
+      pools.hyperlinkPool,
+    ),
+    viewport: { height: viewportHeight, width: viewportWidth },
+  }
+}
+
+describe('frame coverage swarm row 130', () => {
+  test('emptyFrame builds a zero-sized screen while preserving viewport and cursor defaults', () => {
+    const pools = makePools()
+    const frame = emptyFrame(
+      24,
+      80,
+      pools.stylePool,
+      pools.charPool,
+      pools.hyperlinkPool,
+    )
+
+    expect(frame.viewport).toEqual({ height: 24, width: 80 })
+    expect(frame.cursor).toEqual({ visible: true, x: 0, y: 0 })
+    expect(frame.screen.width).toBe(0)
+    expect(frame.screen.height).toBe(0)
+    expect(frame.screen.charPool).toBe(pools.charPool)
+    expect(frame.screen.hyperlinkPool).toBe(pools.hyperlinkPool)
+    expect(frame.screen.emptyStyleId).toBe(pools.stylePool.none)
+    expect(isEmptyCellAt(frame.screen, 0, 0)).toBe(true)
+    expect(frame.scrollHint).toBeUndefined()
+    expect(frame.scrollDrainPending).toBeUndefined()
+  })
+
+  test('shouldClearScreen returns undefined when viewport is unchanged and frames fit', () => {
+    const prev = makeFrame({ screenHeight: 2, viewportHeight: 4 })
+    const next = makeFrame({ screenHeight: 3, viewportHeight: 4 })
+
+    expect(shouldClearScreen(prev, next)).toBeUndefined()
+  })
+
+  test('shouldClearScreen reports resize for viewport height changes before overflow checks', () => {
+    const prev = makeFrame({ screenHeight: 6, viewportHeight: 6 })
+    const next = makeFrame({ screenHeight: 7, viewportHeight: 8 })
+
+    expect(shouldClearScreen(prev, next)).toBe('resize')
+  })
+
+  test('shouldClearScreen reports resize for viewport width changes', () => {
+    const prev = makeFrame({
+      screenHeight: 1,
+      viewportHeight: 4,
+      viewportWidth: 12,
+    })
+    const next = makeFrame({
+      screenHeight: 1,
+      viewportHeight: 4,
+      viewportWidth: 10,
+    })
+
+    expect(shouldClearScreen(prev, next)).toBe('resize')
+  })
+
+  test('shouldClearScreen reports offscreen when the current screen reaches the viewport height', () => {
+    const prev = makeFrame({ screenHeight: 2, viewportHeight: 4 })
+    const next = makeFrame({ screenHeight: 4, viewportHeight: 4 })
+
+    expect(shouldClearScreen(prev, next)).toBe('offscreen')
+  })
+
+  test('shouldClearScreen keeps clearing while the previous frame was offscreen', () => {
+    const prev = makeFrame({ screenHeight: 4, viewportHeight: 4 })
+    const next = makeFrame({ screenHeight: 2, viewportHeight: 4 })
+
+    expect(shouldClearScreen(prev, next)).toBe('offscreen')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-131-components-DiagnosticsDisplay.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-131-components-DiagnosticsDisplay.test.tsx
@@ -1,0 +1,240 @@
+import { PassThrough } from "node:stream";
+
+import figures from "figures";
+import React, { useLayoutEffect, useState } from "react";
+import stripAnsi from "strip-ansi";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("../../../src/utils/cwd.js", () => ({
+  getCwd: () => "/workspace",
+}));
+
+import { DiagnosticsDisplay } from "../../../src/tui/components/DiagnosticsDisplay.js";
+import { createRoot } from "../../../src/tui/ink/root.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+const previousGlyphMode = process.env.AGENC_TUI_GLYPHS;
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+type TestStdout = PassThrough & {
+  columns: number;
+  isTTY: boolean;
+  rows: number;
+};
+
+function createStreams(): {
+  readonly stdin: TestStdin;
+  readonly stdout: TestStdout;
+} {
+  const stdin = new PassThrough() as TestStdin;
+  const stdout = new PassThrough() as TestStdout;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+
+  stdout.columns = 120;
+  stdout.rows = 24;
+  stdout.isTTY = true;
+  stdout.resume();
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function renderWithRoot(node: React.ReactNode): Promise<string> {
+  const { stdin, stdout } = createStreams();
+  let output = "";
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  try {
+    root.render(node);
+    await sleep();
+    return stripAnsi(output);
+  } finally {
+    root.unmount();
+    stdin.end();
+    stdout.end();
+    await sleep();
+  }
+}
+
+const compactAttachment = {
+  type: "diagnostics",
+  isNew: true,
+  files: [
+    {
+      uri: "file:///workspace/src/compact.ts",
+      diagnostics: [
+        {
+          severity: "Error",
+          range: {
+            start: { line: 1, character: 2 },
+            end: { line: 1, character: 9 },
+          },
+          message: "Invalid compact path",
+        },
+      ],
+    },
+  ],
+} as const;
+
+function RerenderStableCompact({
+  onRender,
+}: {
+  readonly onRender: (count: number) => void;
+}) {
+  const [count, setCount] = useState(0);
+
+  useLayoutEffect(() => {
+    onRender(count);
+    if (count === 0) setCount(1);
+  }, [count, onRender]);
+
+  return (
+    <DiagnosticsDisplay attachment={compactAttachment} verbose={false} />
+  );
+}
+
+describe("DiagnosticsDisplay coverage swarm 131", () => {
+  afterEach(() => {
+    if (previousGlyphMode === undefined) {
+      delete process.env.AGENC_TUI_GLYPHS;
+    } else {
+      process.env.AGENC_TUI_GLYPHS = previousGlyphMode;
+    }
+  });
+
+  test("renders verbose file and AgenC right-file diagnostics with optional metadata", async () => {
+    process.env.AGENC_TUI_GLYPHS = "ascii";
+
+    const output = await renderToString(
+      <DiagnosticsDisplay
+        attachment={{
+          type: "diagnostics",
+          isNew: true,
+          files: [
+            {
+              uri: "file:///workspace/src/problem.ts",
+              diagnostics: [
+                {
+                  severity: "Warning",
+                  range: {
+                    start: { line: 0, character: 1 },
+                    end: { line: 0, character: 6 },
+                  },
+                  message: "Missing semicolon",
+                },
+              ],
+            },
+            {
+              uri: "_agenc_fs_right:/workspace/src/generated.ts",
+              diagnostics: [
+                {
+                  severity: "Hint",
+                  range: {
+                    start: { line: 4, character: 0 },
+                    end: { line: 4, character: 5 },
+                  },
+                  message: "Prefer const",
+                  code: "hint-1",
+                },
+                {
+                  severity: "Info",
+                  range: {
+                    start: { line: 7, character: 3 },
+                    end: { line: 7, character: 9 },
+                  },
+                  message: "Inferred any",
+                  source: "typescript",
+                },
+              ],
+            },
+          ],
+        }}
+        verbose={true}
+      />,
+      120,
+    );
+
+    expect(output).toContain("|_ src/problem.ts (file://):");
+    expect(output).toContain(
+      `${figures.warning} [Line 1:2] Missing semicolon`,
+    );
+    expect(output).toContain("|_ src/generated.ts (agenc_fs_right):");
+    expect(output).toContain(`${figures.star} [Line 5:1] Prefer const [hint-1]`);
+    expect(output).toContain(
+      `${figures.info} [Line 8:4] Inferred any (typescript)`,
+    );
+    expect(output).not.toContain("_agenc_fs_right:");
+  });
+
+  test("renders compact empty and plural summaries", async () => {
+    const empty = await renderToString(
+      <DiagnosticsDisplay
+        attachment={{ type: "diagnostics", isNew: true, files: [] }}
+        verbose={false}
+      />,
+      120,
+    );
+    const plural = await renderToString(
+      <DiagnosticsDisplay
+        attachment={{
+          type: "diagnostics",
+          isNew: true,
+          files: [
+            {
+              uri: "file:///workspace/src/first.ts",
+              diagnostics: compactAttachment.files[0].diagnostics,
+            },
+            {
+              uri: "file:///workspace/src/second.ts",
+              diagnostics: [
+                compactAttachment.files[0].diagnostics[0],
+                compactAttachment.files[0].diagnostics[0],
+              ],
+            },
+          ],
+        }}
+        verbose={false}
+      />,
+      120,
+    );
+
+    expect(empty.trim()).toBe("");
+    expect(plural).toContain("Found 3 new diagnostic issues in 2 files");
+    expect(plural).toContain("(ctrl+o to expand)");
+  });
+
+  test("reuses compact render branches when stable props rerender", async () => {
+    const onRender = vi.fn();
+
+    const output = await renderWithRoot(
+      <RerenderStableCompact onRender={onRender} />,
+    );
+
+    expect(onRender).toHaveBeenCalledWith(0);
+    expect(onRender).toHaveBeenCalledWith(1);
+    expect(output.replace(/\s+/g, "")).toContain(
+      "Found1newdiagnosticissuein1file",
+    );
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-132-message-renderers-ShutdownMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-132-message-renderers-ShutdownMessage.test.tsx
@@ -1,0 +1,156 @@
+import React, { useLayoutEffect, useState } from 'react'
+import { describe, expect, test } from 'vitest'
+
+import {
+  getShutdownMessageSummary,
+  ShutdownRejectedDisplay,
+  ShutdownRequestDisplay,
+  tryRenderShutdownMessage,
+} from '../../../src/tui/message-renderers/ShutdownMessage.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+
+function shutdownPayload(overrides: Record<string, unknown>): string {
+  return JSON.stringify({
+    requestId: 'shutdown-row-132',
+    timestamp: '2026-05-20T00:00:00.000Z',
+    ...overrides,
+  })
+}
+
+function requestPayload(reason?: string): string {
+  return shutdownPayload({
+    type: 'shutdown_request',
+    from: 'lead',
+    ...(reason === undefined ? {} : { reason }),
+  })
+}
+
+function rejectedPayload(reason = 'still flushing logs'): string {
+  return shutdownPayload({
+    type: 'shutdown_rejected',
+    from: 'worker-132',
+    reason,
+  })
+}
+
+function approvedPayload(): string {
+  return shutdownPayload({
+    type: 'shutdown_approved',
+    from: 'worker-132',
+  })
+}
+
+function RerenderShutdownRequest() {
+  const [count, setCount] = useState(0)
+
+  useLayoutEffect(() => {
+    if (count === 0) setCount(1)
+  }, [count])
+
+  return (
+    <ShutdownRequestDisplay
+      request={{
+        type: 'shutdown_request',
+        requestId: 'shutdown-rerender-request',
+        from: 'lead',
+        reason: 'same reason',
+        timestamp: '2026-05-20T00:00:00.000Z',
+      }}
+    />
+  )
+}
+
+function RerenderShutdownRejected() {
+  const [count, setCount] = useState(0)
+
+  useLayoutEffect(() => {
+    if (count === 0) setCount(1)
+  }, [count])
+
+  return (
+    <ShutdownRejectedDisplay
+      response={{
+        type: 'shutdown_rejected',
+        requestId: 'shutdown-rerender-rejected',
+        from: 'worker-132',
+        reason: 'same rejection',
+        timestamp: '2026-05-20T00:00:00.000Z',
+      }}
+    />
+  )
+}
+
+async function renderShutdownContent(content: string): Promise<string> {
+  const node = tryRenderShutdownMessage(content)
+  if (!React.isValidElement(node)) {
+    throw new Error('expected a rendered shutdown message')
+  }
+  return renderToString(<>{node}</>, { columns: 100, rows: 12 })
+}
+
+describe('ShutdownMessage coverage swarm 132', () => {
+  test('renders shutdown requests with and without optional reasons', async () => {
+    const withReason = await renderShutdownContent(requestPayload('handoff done'))
+    expect(withReason).toContain('Shutdown request from lead')
+    expect(withReason).toContain('Reason: handoff done')
+
+    const withoutReason = await renderShutdownContent(requestPayload())
+    expect(withoutReason).toContain('Shutdown request from lead')
+    expect(withoutReason).not.toContain('Reason:')
+  })
+
+  test('renders shutdown rejection details and continuation guidance', async () => {
+    const output = await renderShutdownContent(rejectedPayload())
+
+    expect(output).toContain('Shutdown rejected by worker-132')
+    expect(output).toContain('Reason: still flushing logs')
+    expect(output).toContain(
+      'Teammate is continuing to work. You may request shutdown again later.',
+    )
+  })
+
+  test('suppresses approved and invalid shutdown payloads', () => {
+    expect(tryRenderShutdownMessage(approvedPayload())).toBeNull()
+    expect(tryRenderShutdownMessage('not json')).toBeNull()
+    expect(
+      tryRenderShutdownMessage(
+        JSON.stringify({
+          type: 'shutdown_request',
+          from: 'lead',
+        }),
+      ),
+    ).toBeNull()
+  })
+
+  test('summarizes every shutdown lifecycle variant', () => {
+    expect(getShutdownMessageSummary(requestPayload())).toBe(
+      '[Shutdown Request from lead]',
+    )
+    expect(getShutdownMessageSummary(requestPayload('handoff done'))).toBe(
+      '[Shutdown Request from lead] handoff done',
+    )
+    expect(getShutdownMessageSummary(approvedPayload())).toBe(
+      '[Shutdown Approved] worker-132 is now exiting',
+    )
+    expect(getShutdownMessageSummary(rejectedPayload('tests still running'))).toBe(
+      '[Shutdown Rejected] worker-132: tests still running',
+    )
+    expect(getShutdownMessageSummary('not json')).toBeNull()
+  })
+
+  test('keeps memoized renderer output stable across rerenders', async () => {
+    const requestOutput = await renderToString(<RerenderShutdownRequest />, {
+      columns: 100,
+      rows: 12,
+    })
+    expect(requestOutput).toContain('Shutdown request from lead')
+    expect(requestOutput).toContain('Reason: same reason')
+
+    const rejectedOutput = await renderToString(<RerenderShutdownRejected />, {
+      columns: 100,
+      rows: 12,
+    })
+    expect(rejectedOutput).toContain('Shutdown rejected by worker-132')
+    expect(rejectedOutput).toContain('Reason: same rejection')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-133-startup-StatusLine.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-133-startup-StatusLine.test.tsx
@@ -1,0 +1,474 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../ink/root.js'
+
+const harness = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  appState: {
+    toolPermissionContext: {
+      mode: 'default',
+      additionalWorkingDirectories: new Map<string, boolean>(),
+    },
+    statusLineText: '',
+  } as Record<string, unknown>,
+  checkHasProjectTrustAcceptedSync: vi.fn(() => true),
+  contextPercentages: { used: 13, remaining: 87 },
+  currentUsage: 130,
+  doesMostRecentAssistantMessageExceed200k: vi.fn(() => false),
+  executeStatusLineCommand: vi.fn(async () => 'next-status'),
+  feature: vi.fn(() => false),
+  fullscreenEnabled: false,
+  getCwd: vi.fn(() => '/workspace/fallback'),
+  getKairosActive: vi.fn(() => false),
+  getMainThreadAgentType: vi.fn(() => undefined as string | undefined),
+  getOriginalCwd: vi.fn(() => '/workspace/project'),
+  getSessionId: vi.fn(() => 'session-133'),
+  isRemoteMode: false,
+  logEvent: vi.fn(),
+  logForDebugging: vi.fn(),
+  mainLoopModel: 'gpt-5',
+  rawUtilization: {} as Record<string, unknown>,
+  runtimeModel: 'runtime-gpt-5',
+  sessionTitle: undefined as string | undefined,
+  settings: {
+    statusLine: { command: 'statusline', padding: 0 },
+  } as Record<string, unknown>,
+  setAppState: vi.fn(),
+  vimEnabled: false,
+  worktreeSession: undefined as
+    | undefined
+    | {
+        worktreeName: string
+        worktreePath: string
+        worktreeBranch: string
+        originalCwd: string
+        originalBranch: string
+      },
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: harness.feature,
+}))
+
+vi.mock('../../../src/services/analytics/index.js', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../../../src/tui/rate-limits/agenc-ai-limits.js', () => ({
+  getRawUtilization: () => harness.rawUtilization,
+}))
+
+vi.mock('../../../src/bootstrap/state.js', () => ({
+  flushInteractionTime: () => {},
+  getActiveTimeCounter: () => 0,
+  getIsRemoteMode: () => harness.isRemoteMode,
+  getKairosActive: harness.getKairosActive,
+  getMainThreadAgentType: harness.getMainThreadAgentType,
+  getOriginalCwd: harness.getOriginalCwd,
+  getSdkBetas: () => ['beta-133'],
+  getSessionId: harness.getSessionId,
+  updateLastInteractionTime: () => {},
+}))
+
+vi.mock('../../../src/constants/outputStyles.js', () => ({
+  DEFAULT_OUTPUT_STYLE_NAME: 'default-style',
+}))
+
+vi.mock('../../../src/tui/context/notifications.js', () => ({
+  useNotifications: () => ({
+    addNotification: harness.addNotification,
+  }),
+}))
+
+vi.mock('../../../src/cost/tracker.js', () => ({
+  getTotalAPIDuration: () => 3,
+  getTotalCost: () => 1.33,
+  getTotalDuration: () => 5,
+  getTotalInputTokens: () => 8,
+  getTotalLinesAdded: () => 2,
+  getTotalLinesRemoved: () => 1,
+  getTotalOutputTokens: () => 13,
+}))
+
+vi.mock('../../../src/tui/hooks/useMainLoopModel.js', () => ({
+  useMainLoopModel: () => harness.mainLoopModel,
+}))
+
+vi.mock('../../../src/tui/hooks/useSettings.js', () => ({
+  useSettings: () => harness.settings,
+}))
+
+vi.mock('../../../src/permissions/trust/project-trust.js', () => ({
+  checkHasProjectTrustAcceptedSync: harness.checkHasProjectTrustAcceptedSync,
+}))
+
+vi.mock('../../../src/utils/context.js', () => ({
+  calculateContextPercentages: () => harness.contextPercentages,
+  getContextWindowForModel: () => 1000,
+}))
+
+vi.mock('../../../src/utils/cwd.js', () => ({
+  getCwd: harness.getCwd,
+}))
+
+vi.mock('../../../src/utils/debug.js', () => ({
+  logForDebugging: harness.logForDebugging,
+}))
+
+vi.mock('../../../src/utils/fullscreen.js', () => ({
+  isFullscreenEnvEnabled: () => harness.fullscreenEnabled,
+}))
+
+vi.mock('../../../src/utils/hooks.js', () => ({
+  createBaseHookInput: () => ({
+    transcript_path: '/workspace/transcript.jsonl',
+  }),
+  executeStatusLineCommand: harness.executeStatusLineCommand,
+}))
+
+vi.mock('../../../src/utils/messages.js', () => ({
+  getLastAssistantMessage: (messages: Array<{ uuid?: string }>) =>
+    messages.at(-1),
+}))
+
+vi.mock('../../../src/utils/model/model.js', () => ({
+  getRuntimeMainLoopModel: () => harness.runtimeModel,
+  renderModelName: (model: string) => `Rendered ${model}`,
+}))
+
+vi.mock('../../../src/utils/sessionStorage.js', () => ({
+  getCurrentSessionTitle: () => harness.sessionTitle,
+}))
+
+vi.mock('../../../src/utils/tokens.js', () => ({
+  doesMostRecentAssistantMessageExceed200k:
+    harness.doesMostRecentAssistantMessageExceed200k,
+  getCurrentUsage: () => harness.currentUsage,
+}))
+
+vi.mock('../../../src/utils/worktree.js', () => ({
+  getCurrentWorktreeSession: () => harness.worktreeSession,
+}))
+
+vi.mock('../../../src/tui/components/PromptInput/utils.js', () => ({
+  formatVimModeIndicator: (mode?: string) => `-- ${mode ?? 'INSERT'} --`,
+  isVimModeEnabled: () => harness.vimEnabled,
+}))
+
+vi.mock('../../../src/tui/state/AppState.js', () => ({
+  useAppState: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector(harness.appState),
+  useSetAppState: () => (next: unknown) => {
+    harness.setAppState(next)
+    harness.appState =
+      typeof next === 'function'
+        ? (next as (state: Record<string, unknown>) => Record<string, unknown>)(
+            harness.appState,
+          )
+        : (next as Record<string, unknown>)
+  },
+}))
+
+import {
+  StatusLine,
+  statusLineShouldDisplay,
+} from '../../../src/tui/startup/StatusLine.js'
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  output: () => string
+} {
+  let rendered = ''
+  const stdout = new PassThrough()
+  stdout.on('data', chunk => {
+    rendered += chunk.toString()
+  })
+  ;(stdout as unknown as { columns: number }).columns = 120
+  stdout.resume()
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+
+  return { stdout, stdin, output: () => rendered }
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    if (predicate()) return
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+  throw new Error('timed out waiting for StatusLine update')
+}
+
+function resetHarness(): void {
+  harness.addNotification.mockClear()
+  harness.appState = {
+    toolPermissionContext: {
+      mode: 'default',
+      additionalWorkingDirectories: new Map<string, boolean>(),
+    },
+    statusLineText: '',
+  }
+  harness.checkHasProjectTrustAcceptedSync.mockReset()
+  harness.checkHasProjectTrustAcceptedSync.mockReturnValue(true)
+  harness.contextPercentages = { used: 13, remaining: 87 }
+  harness.currentUsage = 130
+  harness.doesMostRecentAssistantMessageExceed200k.mockReset()
+  harness.doesMostRecentAssistantMessageExceed200k.mockReturnValue(false)
+  harness.executeStatusLineCommand.mockReset()
+  harness.executeStatusLineCommand.mockResolvedValue('next-status')
+  harness.feature.mockReset()
+  harness.feature.mockReturnValue(false)
+  harness.fullscreenEnabled = false
+  harness.getCwd.mockReset()
+  harness.getCwd.mockReturnValue('/workspace/fallback')
+  harness.getKairosActive.mockReset()
+  harness.getKairosActive.mockReturnValue(false)
+  harness.getMainThreadAgentType.mockReset()
+  harness.getMainThreadAgentType.mockReturnValue(undefined)
+  harness.getOriginalCwd.mockReset()
+  harness.getOriginalCwd.mockReturnValue('/workspace/project')
+  harness.getSessionId.mockReset()
+  harness.getSessionId.mockReturnValue('session-133')
+  harness.isRemoteMode = false
+  harness.logEvent.mockClear()
+  harness.logForDebugging.mockClear()
+  harness.mainLoopModel = 'gpt-5'
+  harness.rawUtilization = {}
+  harness.runtimeModel = 'runtime-gpt-5'
+  harness.sessionTitle = undefined
+  harness.settings = {
+    statusLine: { command: 'statusline', padding: 0 },
+  }
+  harness.setAppState.mockClear()
+  harness.vimEnabled = false
+  harness.worktreeSession = undefined
+}
+
+describe('StatusLine coverage swarm row 133', () => {
+  beforeEach(() => {
+    vi.stubGlobal('MACRO', { VERSION: '133-test' })
+    resetHarness()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  test('display guard allows configured status lines unless Kairos is active', () => {
+    expect(statusLineShouldDisplay({} as never)).toBe(false)
+    expect(
+      statusLineShouldDisplay({
+        statusLine: { command: 'statusline' },
+      } as never),
+    ).toBe(true)
+
+    harness.feature.mockReturnValue(true)
+    harness.getKairosActive.mockReturnValue(false)
+    expect(
+      statusLineShouldDisplay({
+        statusLine: { command: 'statusline' },
+      } as never),
+    ).toBe(true)
+
+    harness.getKairosActive.mockReturnValue(true)
+    expect(
+      statusLineShouldDisplay({
+        statusLine: { command: 'statusline' },
+      } as never),
+    ).toBe(false)
+  })
+
+  test('builds sparse command input and keeps identical status text stable', async () => {
+    const stateBefore = {
+      toolPermissionContext: {
+        mode: 'plan',
+        additionalWorkingDirectories: new Map<string, boolean>(),
+      },
+      statusLineText: 'same-status',
+    }
+    harness.appState = stateBefore
+    harness.executeStatusLineCommand.mockResolvedValue('same-status')
+    harness.getOriginalCwd.mockReturnValue('')
+
+    const { stdin, stdout, output } = createStreams()
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    })
+
+    try {
+      root.render(
+        <StatusLine messagesRef={{ current: [] }} lastAssistantMessageId={null} />,
+      )
+      await waitFor(() => harness.setAppState.mock.calls.length === 1)
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+
+    expect(output()).toContain('same-status')
+    expect(harness.appState).toBe(stateBefore)
+    expect(harness.checkHasProjectTrustAcceptedSync).toHaveBeenCalledWith({
+      cwd: '/workspace/fallback',
+    })
+
+    const [input, signal, timeout, logResult] =
+      harness.executeStatusLineCommand.mock.calls[0]!
+    expect(signal.aborted).toBe(true)
+    expect(timeout).toBeUndefined()
+    expect(logResult).toBe(true)
+    expect(input).toMatchObject({
+      transcript_path: '/workspace/transcript.jsonl',
+      model: {
+        id: 'runtime-gpt-5',
+        display_name: 'Rendered runtime-gpt-5',
+      },
+      workspace: {
+        current_dir: '/workspace/fallback',
+        project_dir: '',
+        added_dirs: [],
+      },
+      version: '133-test',
+      output_style: {
+        name: 'default-style',
+      },
+      cost: {
+        total_cost_usd: 1.33,
+        total_duration_ms: 5,
+        total_api_duration_ms: 3,
+        total_lines_added: 2,
+        total_lines_removed: 1,
+      },
+      context_window: {
+        total_input_tokens: 8,
+        total_output_tokens: 13,
+        context_window_size: 1000,
+        current_usage: 130,
+        used_percentage: 13,
+        remaining_percentage: 87,
+      },
+      exceeds_200k_tokens: false,
+    })
+    expect(input).not.toHaveProperty('session_name')
+    expect(input).not.toHaveProperty('rate_limits')
+    expect(input).not.toHaveProperty('vim')
+    expect(input).not.toHaveProperty('agent')
+    expect(input).not.toHaveProperty('remote')
+    expect(input).not.toHaveProperty('worktree')
+  })
+
+  test('reruns with result logging when the status line command changes', async () => {
+    const messages = [{ uuid: 'assistant-133' }]
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    })
+
+    try {
+      root.render(
+        <StatusLine
+          messagesRef={{ current: messages }}
+          lastAssistantMessageId={null}
+        />,
+      )
+      await waitFor(() => harness.executeStatusLineCommand.mock.calls.length === 1)
+
+      harness.settings = {
+        statusLine: { command: 'statusline --changed', padding: 1 },
+      }
+      root.render(
+        <StatusLine
+          messagesRef={{ current: messages }}
+          lastAssistantMessageId={null}
+        />,
+      )
+      await waitFor(() => harness.executeStatusLineCommand.mock.calls.length === 2)
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+
+    expect(harness.doesMostRecentAssistantMessageExceed200k).toHaveBeenCalledOnce()
+    expect(harness.executeStatusLineCommand.mock.calls[0]![3]).toBe(true)
+    expect(harness.executeStatusLineCommand.mock.calls[1]![3]).toBe(true)
+    expect(harness.logEvent).toHaveBeenCalledWith('agenc_status_line_mount', {
+      command_length: 'statusline'.length,
+      padding: 0,
+    })
+  })
+
+  test('reports trust-blocked status lines and swallows command failures', async () => {
+    harness.appState = {
+      toolPermissionContext: {
+        mode: 'default',
+        additionalWorkingDirectories: new Map<string, boolean>(),
+      },
+      statusLineText: 'before-error',
+    }
+    harness.checkHasProjectTrustAcceptedSync.mockReturnValue(false)
+    harness.executeStatusLineCommand.mockRejectedValue(new Error('status failed'))
+    harness.settings = {
+      disableAllHooks: true,
+      statusLine: { command: 'statusline --failing', padding: 4 },
+    }
+
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    })
+
+    try {
+      root.render(
+        <StatusLine messagesRef={{ current: [] }} lastAssistantMessageId={null} />,
+      )
+      await waitFor(() => harness.executeStatusLineCommand.mock.calls.length === 1)
+      await new Promise(resolve => setTimeout(resolve, 0))
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+
+    expect(harness.appState.statusLineText).toBe('before-error')
+    expect(harness.setAppState).not.toHaveBeenCalled()
+    expect(harness.addNotification).toHaveBeenCalledWith({
+      key: 'statusline-trust-blocked',
+      text: 'statusline skipped until project trust is accepted',
+      color: 'warning',
+      priority: 'low',
+    })
+    expect(harness.logForDebugging).toHaveBeenCalledWith(
+      'Status line is configured but disableAllHooks is true',
+      { level: 'warn' },
+    )
+    expect(harness.logForDebugging).toHaveBeenCalledWith(
+      'Status line command skipped: workspace trust not accepted',
+      { level: 'warn' },
+    )
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-134-components-CustomSelect-SelectMulti.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-134-components-CustomSelect-SelectMulti.test.tsx
@@ -1,0 +1,328 @@
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../../src/utils/staticRender.js'
+import { SelectMulti } from '../../../src/tui/components/CustomSelect/SelectMulti.js'
+import type {
+  MultiSelectState,
+  UseMultiSelectStateProps,
+} from '../../../src/tui/components/CustomSelect/use-multi-select-state.js'
+import type { OptionWithDescription } from '../../../src/tui/components/CustomSelect/select.js'
+
+type TextOption = OptionWithDescription<string>
+type InputOption = Extract<OptionWithDescription<string>, { type: 'input' }>
+
+type SelectOptionProps = {
+  children: React.ReactNode
+  description?: string
+  isFocused: boolean
+  isSelected: boolean
+  shouldShowDownArrow?: boolean
+  shouldShowUpArrow?: boolean
+}
+
+type InputOptionProps = {
+  children: React.ReactNode
+  index: number
+  inputValue: string
+  isFocused: boolean
+  isSelected: boolean
+  layout: 'compact' | 'expanded'
+  maxIndexWidth: number
+  onExit?: () => void
+  onImagePaste?: (
+    base64Image: string,
+    mediaType?: string,
+    filename?: string,
+    dimensions?: { width: number; height: number },
+    sourcePath?: string,
+  ) => void
+  onInputChange: (value: string) => void
+  onOpenEditor?: (
+    currentValue: string,
+    setValue: (value: string) => void,
+  ) => void
+  onRemoveImage?: (id: number) => void
+  option: InputOption
+  pastedContents?: Record<number, { id: number; content: string; mediaType: string }>
+  shouldShowDownArrow: boolean
+  shouldShowUpArrow: boolean
+}
+
+const harness = vi.hoisted(() => ({
+  hookProps: [] as UseMultiSelectStateProps<string>[],
+  inputOptionProps: [] as InputOptionProps[],
+  selectOptionProps: [] as SelectOptionProps[],
+  state: undefined as MultiSelectState<string> | undefined,
+}))
+
+vi.mock(
+  '../../../src/tui/components/CustomSelect/use-multi-select-state.js',
+  () => ({
+    useMultiSelectState: (props: UseMultiSelectStateProps<string>) => {
+      harness.hookProps.push(props)
+      if (!harness.state) {
+        throw new Error('missing SelectMulti state test double')
+      }
+      return harness.state
+    },
+  }),
+)
+
+vi.mock(
+  '../../../src/tui/components/CustomSelect/select-option.js',
+  () => ({
+    SelectOption: (props: SelectOptionProps) => {
+      harness.selectOptionProps.push(props)
+      return <>{props.children}</>
+    },
+  }),
+)
+
+vi.mock(
+  '../../../src/tui/components/CustomSelect/select-input-option.js',
+  () => ({
+    SelectInputOption: (props: InputOptionProps) => {
+      harness.inputOptionProps.push(props)
+      return (
+        <>
+          {props.children}
+          <ink-text>{`input:${props.option.value}:${props.inputValue}`}</ink-text>
+        </>
+      )
+    },
+  }),
+)
+
+function textOption(value: string, index?: number): TextOption & { index?: number } {
+  return {
+    label: `Option ${value}`,
+    value,
+    description: `Description ${value}`,
+    ...(index === undefined ? {} : { index }),
+  }
+}
+
+function inputOption(value: string, index?: number): InputOption & { index?: number } {
+  return {
+    type: 'input',
+    label: `Input ${value}`,
+    value,
+    onChange: vi.fn(),
+    ...(index === undefined ? {} : { index }),
+  }
+}
+
+function options(count: number): TextOption[] {
+  return Array.from({ length: count }, (_, index) =>
+    textOption(String(index + 1)),
+  )
+}
+
+function state(
+  overrides: Partial<MultiSelectState<string>> = {},
+): MultiSelectState<string> {
+  const baseOptions = options(3)
+  return {
+    focusedValue: '1',
+    inputValues: new Map(),
+    isInInput: false,
+    isSubmitFocused: false,
+    onCancel: vi.fn(),
+    options: baseOptions,
+    selectedValues: [],
+    updateInputValue: vi.fn(),
+    visibleFromIndex: 0,
+    visibleOptions: [
+      { ...baseOptions[0]!, index: 0 },
+      { ...baseOptions[1]!, index: 1 },
+    ],
+    visibleToIndex: 2,
+    ...overrides,
+  }
+}
+
+describe('SelectMulti coverage swarm row 134', () => {
+  beforeEach(() => {
+    harness.hookProps = []
+    harness.inputOptionProps = []
+    harness.selectOptionProps = []
+    harness.state = state()
+  })
+
+  test('passes uncommon configuration through to the state hook', async () => {
+    const onCancel = vi.fn()
+    const onChange = vi.fn()
+    const onDownFromLastItem = vi.fn()
+    const onFocus = vi.fn()
+    const onSubmit = vi.fn()
+    const onUpFromFirstItem = vi.fn()
+    const selectOptions = options(2)
+
+    await renderToString(
+      <SelectMulti
+        defaultValue={['2']}
+        focusValue="2"
+        hideIndexes={true}
+        initialFocusLast={true}
+        isDisabled={true}
+        onCancel={onCancel}
+        onChange={onChange}
+        onDownFromLastItem={onDownFromLastItem}
+        onFocus={onFocus}
+        onSubmit={onSubmit}
+        onUpFromFirstItem={onUpFromFirstItem}
+        options={selectOptions}
+        submitButtonText="Apply"
+        visibleOptionCount={7}
+      />,
+      120,
+    )
+
+    expect(harness.hookProps.at(-1)).toMatchObject({
+      defaultValue: ['2'],
+      focusValue: '2',
+      hideIndexes: true,
+      initialFocusLast: true,
+      isDisabled: true,
+      onCancel,
+      onChange,
+      onDownFromLastItem,
+      onFocus,
+      onSubmit,
+      onUpFromFirstItem,
+      options: selectOptions,
+      submitButtonText: 'Apply',
+      visibleOptionCount: 7,
+    })
+  })
+
+  test('renders high-index text rows and keeps option focus off while submit is focused', async () => {
+    const allOptions = options(12)
+    harness.state = state({
+      focusedValue: '10',
+      isSubmitFocused: true,
+      selectedValues: ['9'],
+      visibleFromIndex: 8,
+      visibleOptions: [
+        { ...textOption('9'), index: 8 },
+        { ...textOption('10'), index: 9 },
+      ],
+      visibleToIndex: 10,
+    })
+
+    const output = await renderToString(
+      <SelectMulti
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+        options={allOptions}
+        submitButtonText="Apply"
+        visibleOptionCount={2}
+      />,
+      120,
+    )
+
+    expect(output).toContain('9.')
+    expect(output).toContain('10.')
+    expect(output).toContain('Option 9')
+    expect(output).toContain('Option 10')
+    expect(output).toContain('Apply')
+    expect(harness.selectOptionProps).toMatchObject([
+      {
+        isFocused: false,
+        isSelected: false,
+        shouldShowDownArrow: false,
+        shouldShowUpArrow: true,
+      },
+      {
+        isFocused: false,
+        isSelected: false,
+        shouldShowDownArrow: true,
+        shouldShowUpArrow: false,
+      },
+    ])
+  })
+
+  test('renders input rows with empty fallback values and forwards helper callbacks', async () => {
+    const updateInputValue = vi.fn()
+    const onCancel = vi.fn()
+    const onImagePaste = vi.fn()
+    const onOpenEditor = vi.fn()
+    const onRemoveImage = vi.fn()
+    const typedOption = inputOption('typed', 9)
+    const pastedContents = {
+      4: { id: 4, content: 'image-data', mediaType: 'image/png' },
+    }
+
+    harness.state = state({
+      focusedValue: 'typed',
+      inputValues: new Map(),
+      selectedValues: ['typed'],
+      updateInputValue,
+      visibleFromIndex: 9,
+      visibleOptions: [typedOption],
+      visibleToIndex: 10,
+    })
+
+    const output = await renderToString(
+      <SelectMulti
+        onCancel={onCancel}
+        onImagePaste={onImagePaste}
+        onOpenEditor={onOpenEditor}
+        onRemoveImage={onRemoveImage}
+        options={[...options(9), typedOption, ...options(2)]}
+        pastedContents={pastedContents}
+      />,
+      120,
+    )
+
+    expect(output).toContain('input:typed:')
+    expect(harness.inputOptionProps).toHaveLength(1)
+    expect(harness.inputOptionProps[0]).toMatchObject({
+      index: 10,
+      inputValue: '',
+      isFocused: true,
+      isSelected: false,
+      layout: 'compact',
+      maxIndexWidth: 2,
+      onImagePaste,
+      onOpenEditor,
+      onRemoveImage,
+      option: typedOption,
+      pastedContents,
+      shouldShowDownArrow: true,
+      shouldShowUpArrow: true,
+    })
+
+    harness.inputOptionProps[0]!.onInputChange('new value')
+    expect(updateInputValue).toHaveBeenCalledWith('typed', 'new value')
+
+    harness.inputOptionProps[0]!.onExit?.()
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+
+  test('does not render a submit button unless both label and handler are present', async () => {
+    harness.state = state()
+    const withTextOnly = await renderToString(
+      <SelectMulti
+        onCancel={vi.fn()}
+        options={options(1)}
+        submitButtonText="Apply"
+      />,
+      120,
+    )
+
+    harness.state = state()
+    const withHandlerOnly = await renderToString(
+      <SelectMulti
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+        options={options(1)}
+      />,
+      120,
+    )
+
+    expect(withTextOnly).not.toContain('Apply')
+    expect(withHandlerOnly).not.toContain('Apply')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-135-components-design-system-ThemedBox.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-135-components-design-system-ThemedBox.test.tsx
@@ -1,0 +1,206 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+import { ThemeProvider } from '../../../src/tui/components/design-system/ThemeProvider.js'
+import ThemedBox from '../../../src/tui/components/design-system/ThemedBox.js'
+import type { DOMElement } from '../../../src/tui/ink/dom.js'
+import instances from '../../../src/tui/ink/instances.js'
+import { createRoot } from '../../../src/tui/ink/root.js'
+import { getTheme } from '../../../src/utils/theme.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestStdout = PassThrough & {
+  columns: number
+  isTTY: boolean
+  rows: number
+}
+
+type MountedRoot = {
+  root: Awaited<ReturnType<typeof createRoot>>
+  stdin: TestStdin
+  stdout: TestStdout
+}
+
+const mountedRoots: MountedRoot[] = []
+
+function createStreams(): {
+  stderr: PassThrough
+  stdin: TestStdin
+  stdout: TestStdout
+} {
+  const stderr = new PassThrough()
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough() as TestStdout
+
+  stderr.resume()
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.columns = 80
+  stdout.isTTY = true
+  stdout.rows = 24
+  stdout.resume()
+
+  return { stderr, stdin, stdout }
+}
+
+function sleep(ms = 20): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  let lastError: unknown
+
+  for (let i = 0; i < 50; i += 1) {
+    try {
+      assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await sleep(10)
+    }
+  }
+
+  throw lastError
+}
+
+async function renderNode(node: React.ReactNode): Promise<void> {
+  const { stderr, stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  mountedRoots.push({ root, stdin, stdout })
+  root.render(node)
+}
+
+afterEach(async () => {
+  while (mountedRoots.length > 0) {
+    const mounted = mountedRoots.pop()!
+    mounted.root.unmount()
+    mounted.stdin.end()
+    mounted.stdout.end()
+    instances.delete(mounted.stdout as unknown as NodeJS.WriteStream)
+  }
+
+  await sleep()
+})
+
+describe('ThemedBox coverage swarm row 135', () => {
+  test('resolves every theme color prop against the active theme', async () => {
+    const ref = React.createRef<DOMElement>()
+    const theme = getTheme('light')
+
+    await renderNode(
+      <ThemeProvider initialState="light" onThemeSave={vi.fn()}>
+        <ThemedBox
+          ref={ref}
+          backgroundColor="surfaceBackground"
+          borderBottomColor="success"
+          borderColor="lineSoft"
+          borderLeftColor="warning"
+          borderRightColor="error"
+          borderStyle="single"
+          borderTopColor="agenc"
+          paddingX={2}
+          width={12}
+        >
+          themed
+        </ThemedBox>
+      </ThemeProvider>,
+    )
+
+    await waitFor(() => {
+      expect(ref.current).not.toBeNull()
+    })
+
+    expect(ref.current?.style).toMatchObject({
+      backgroundColor: theme.surfaceBackground,
+      borderBottomColor: theme.success,
+      borderColor: theme.lineSoft,
+      borderLeftColor: theme.warning,
+      borderRightColor: theme.error,
+      borderStyle: 'single',
+      borderTopColor: theme.agenc,
+      paddingX: 2,
+      width: 12,
+    })
+  })
+
+  test('passes raw colors through without theme lookup', async () => {
+    const ref = React.createRef<DOMElement>()
+
+    await renderNode(
+      <ThemedBox
+        ref={ref}
+        backgroundColor="#101010"
+        borderBottomColor="ansi256(42)"
+        borderColor="#abcdef"
+        borderLeftColor="ansi:cyan"
+        borderRightColor="remember"
+        borderTopColor="rgb(1,2,3)"
+      >
+        raw
+      </ThemedBox>,
+    )
+
+    await waitFor(() => {
+      expect(ref.current).not.toBeNull()
+    })
+
+    const darkTheme = getTheme('dark')
+    expect(ref.current?.style).toMatchObject({
+      backgroundColor: '#101010',
+      borderBottomColor: 'ansi256(42)',
+      borderColor: '#abcdef',
+      borderLeftColor: 'ansi:cyan',
+      borderRightColor: darkTheme.remember,
+      borderTopColor: 'rgb(1,2,3)',
+    })
+  })
+
+  test('leaves omitted color props undefined while forwarding layout props', async () => {
+    const ref = React.createRef<DOMElement>()
+
+    await renderNode(
+      <ThemedBox ref={ref} flexDirection="column" gap={1} margin={2}>
+        plain
+      </ThemedBox>,
+    )
+
+    await waitFor(() => {
+      expect(ref.current).not.toBeNull()
+    })
+
+    expect(ref.current?.style).toMatchObject({
+      flexDirection: 'column',
+      flexGrow: 0,
+      flexShrink: 1,
+      flexWrap: 'nowrap',
+      gap: 1,
+      margin: 2,
+    })
+    expect(ref.current?.style.backgroundColor).toBeUndefined()
+    expect(ref.current?.style.borderBottomColor).toBeUndefined()
+    expect(ref.current?.style.borderColor).toBeUndefined()
+    expect(ref.current?.style.borderLeftColor).toBeUndefined()
+    expect(ref.current?.style.borderRightColor).toBeUndefined()
+    expect(ref.current?.style.borderTopColor).toBeUndefined()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-136-components-spinner-agentActivity.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-136-components-spinner-agentActivity.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  formatLocalAgentName,
+  formatRunningAgentSummary,
+  getActiveLocalAgentTasks,
+  isActiveLocalAgentStatus,
+  isStoppableLocalAgentStatus,
+  normalizeLocalAgentStatus,
+  type ActiveLocalAgentTask,
+} from "../../../src/tui/components/spinner/agentActivity.js";
+
+describe("agentActivity coverage swarm row 136", () => {
+  test("normalizes blank, aliased, and unknown local agent statuses", () => {
+    expect(
+      [
+        undefined,
+        "",
+        "   ",
+        "Awaiting-User",
+        "WAITING_ON_USER",
+        "awaiting_permission",
+        "blocked",
+        "errored",
+        "complete",
+        "canceled",
+        "custom_state",
+      ].map(normalizeLocalAgentStatus),
+    ).toEqual([
+      "idle",
+      "idle",
+      "idle",
+      "waiting on user",
+      "waiting on user",
+      "waiting on user",
+      "waiting on user",
+      "failed",
+      "completed",
+      "cancelled",
+      "custom-state",
+    ]);
+  });
+
+  test("keeps active and stoppable status checks aligned with normalized values", () => {
+    expect(isActiveLocalAgentStatus("Awaiting-User")).toBe(true);
+    expect(isActiveLocalAgentStatus("custom_state")).toBe(false);
+    expect(isActiveLocalAgentStatus(null)).toBe(false);
+
+    expect(isStoppableLocalAgentStatus("STARTING")).toBe(true);
+    expect(isStoppableLocalAgentStatus("running")).toBe(true);
+    expect(isStoppableLocalAgentStatus("failing")).toBe(false);
+    expect(isStoppableLocalAgentStatus("pending_review")).toBe(false);
+  });
+
+  test("filters only foreground active local agents and sorts by fallback display name", () => {
+    const tasks: Record<string, unknown> = {
+      missing: undefined,
+      primitive: "running",
+      nullish: null,
+      otherType: {
+        type: "background_task",
+        status: "running",
+        isBackgrounded: false,
+      },
+      backgrounded: {
+        id: "backgrounded",
+        type: "local_agent",
+        status: "running",
+        description: "Backgrounded",
+        isBackgrounded: true,
+      },
+      implicitBackground: {
+        id: "implicit",
+        type: "local_agent",
+        status: "running",
+        description: "Implicit",
+      },
+      idle: {
+        id: "idle",
+        type: "local_agent",
+        status: "idle",
+        description: "Idle",
+        isBackgrounded: false,
+      },
+      beta: {
+        id: "task-beta",
+        type: "local_agent",
+        status: "blocked",
+        description: "Beta",
+        isBackgrounded: false,
+      },
+      alpha: {
+        id: "task-alpha",
+        type: "local_agent",
+        status: "running",
+        description: "Alpha",
+        isBackgrounded: false,
+      },
+    };
+
+    expect(getActiveLocalAgentTasks(undefined)).toEqual([]);
+    expect(getActiveLocalAgentTasks(tasks).map(formatLocalAgentName)).toEqual([
+      "Alpha",
+      "Beta",
+    ]);
+  });
+
+  test("formats names from descriptions, agent types, agent ids, task ids, then a default", () => {
+    expect(
+      formatLocalAgentName({
+        description: "  Ship patch  ",
+      }),
+    ).toBe("Ship patch");
+
+    expect(
+      formatLocalAgentName({
+        agentType: "reviewer",
+        description: "line one\nline two",
+      }),
+    ).toBe("reviewer");
+
+    expect(
+      formatLocalAgentName({
+        agentId: "agent-abcdef123456",
+        agentType: "agent",
+      }),
+    ).toBe("agent-ab");
+
+    expect(
+      formatLocalAgentName({
+        agentId: "   ",
+        id: "task-123456789",
+      }),
+    ).toBe("task-123");
+
+    expect(formatLocalAgentName({ id: 42 })).toBe("agent");
+  });
+
+  test("summarizes one agent without token suffix when tokens are not positive finite numbers", () => {
+    const agents: ActiveLocalAgentTask[] = [
+      {
+        description: "Solo",
+        progress: { tokenCount: Number.POSITIVE_INFINITY },
+        status: "starting",
+      },
+    ];
+
+    expect(formatRunningAgentSummary(agents)).toBe("1 agent: Solo starting");
+  });
+
+  test("summarizes the first three agents, counts the rest, and adds finite tokens", () => {
+    const agents: ActiveLocalAgentTask[] = [
+      {
+        description: "Alpha",
+        progress: { tokenCount: 500 },
+        status: "running",
+      },
+      {
+        description: "Beta",
+        progress: { tokenCount: "700" },
+        status: "awaiting-user",
+      },
+      {
+        description: "Gamma",
+        progress: { tokenCount: 1_000 },
+        status: "completing",
+      },
+      {
+        description: "Delta",
+        progress: { tokenCount: 0 },
+        status: "failing",
+      },
+    ];
+
+    expect(formatRunningAgentSummary(agents)).toBe(
+      "4 agents: Alpha running, Beta waiting on user, Gamma completing +1 · 1.5k tokens",
+    );
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-137-ink-termio-tokenize.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-137-ink-termio-tokenize.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'vitest'
+
+import { createTokenizer } from '../../../src/tui/ink/termio/tokenize.ts'
+
+const ESC = '\x1b'
+const BEL = '\x07'
+const ST = `${ESC}\\`
+
+describe('termio tokenizer coverage swarm row 137', () => {
+  test('buffers incomplete CSI input, flushes it, and reset discards it', () => {
+    const tokenizer = createTokenizer()
+
+    expect(tokenizer.feed(`hello${ESC}[`)).toEqual([
+      { type: 'text', value: 'hello' },
+    ])
+    expect(tokenizer.buffer()).toBe(`${ESC}[`)
+
+    expect(tokenizer.feed('31m!')).toEqual([
+      { type: 'sequence', value: `${ESC}[31m` },
+      { type: 'text', value: '!' },
+    ])
+    expect(tokenizer.buffer()).toBe('')
+
+    expect(tokenizer.feed(`${ESC}]0;partial`)).toEqual([])
+    expect(tokenizer.flush()).toEqual([
+      { type: 'sequence', value: `${ESC}]0;partial` },
+    ])
+    expect(tokenizer.buffer()).toBe('')
+
+    expect(tokenizer.feed(`${ESC}[?`)).toEqual([])
+    tokenizer.reset()
+    expect(tokenizer.feed('after reset')).toEqual([
+      { type: 'text', value: 'after reset' },
+    ])
+  })
+
+  test('classifies escape, intermediate, SS3, OSC, DCS, and APC sequences', () => {
+    const tokenizer = createTokenizer()
+
+    expect(
+      tokenizer.feed(
+        [
+          `${ESC}c`,
+          `${ESC}(B`,
+          `${ESC}%G`,
+          `${ESC}OP`,
+          `${ESC}]0;title${BEL}`,
+          `${ESC}]8;;url${ST}`,
+          `${ESC}Ppayload${BEL}`,
+          `${ESC}_app${ST}`,
+          'tail',
+        ].join(''),
+      ),
+    ).toEqual([
+      { type: 'sequence', value: `${ESC}c` },
+      { type: 'sequence', value: `${ESC}(B` },
+      { type: 'sequence', value: `${ESC}%G` },
+      { type: 'sequence', value: `${ESC}OP` },
+      { type: 'sequence', value: `${ESC}]0;title${BEL}` },
+      { type: 'sequence', value: `${ESC}]8;;url${ST}` },
+      { type: 'sequence', value: `${ESC}Ppayload${BEL}` },
+      { type: 'sequence', value: `${ESC}_app${ST}` },
+      { type: 'text', value: 'tail' },
+    ])
+  })
+
+  test('recovers invalid escape forms as text and resumes at nested escapes', () => {
+    const tokenizer = createTokenizer()
+
+    expect(tokenizer.feed(`${ESC}\x00x`)).toEqual([
+      { type: 'text', value: `${ESC}\x00x` },
+    ])
+    expect(tokenizer.feed(`${ESC}(\x1fz`)).toEqual([
+      { type: 'text', value: `${ESC}(\x1fz` },
+    ])
+    expect(tokenizer.feed(`${ESC}O\x1fq`)).toEqual([
+      { type: 'text', value: `${ESC}O\x1fq` },
+    ])
+    expect(tokenizer.feed(`${ESC}[${ESC}[A`)).toEqual([
+      { type: 'text', value: `${ESC}[` },
+      { type: 'sequence', value: `${ESC}[A` },
+    ])
+    expect(tokenizer.feed(`${ESC}${ESC}c`)).toEqual([
+      { type: 'sequence', value: ESC },
+      { type: 'sequence', value: `${ESC}c` },
+    ])
+  })
+
+  test('gates X10 mouse payload consumption behind the option', () => {
+    const defaultTokenizer = createTokenizer()
+
+    expect(defaultTokenizer.feed(`${ESC}[Mabc`)).toEqual([
+      { type: 'sequence', value: `${ESC}[M` },
+      { type: 'text', value: 'abc' },
+    ])
+
+    const mouseTokenizer = createTokenizer({ x10Mouse: true })
+    expect(mouseTokenizer.feed(`${ESC}[Ma`)).toEqual([])
+    expect(mouseTokenizer.buffer()).toBe(`${ESC}[Ma`)
+    expect(mouseTokenizer.feed('bc')).toEqual([
+      { type: 'sequence', value: `${ESC}[Mabc` },
+    ])
+
+    expect(mouseTokenizer.feed(`${ESC}[M${ESC}[A`)).toEqual([
+      { type: 'sequence', value: `${ESC}[M` },
+      { type: 'sequence', value: `${ESC}[A` },
+    ])
+    expect(mouseTokenizer.feed(`${ESC}[<0;1;2Mrest`)).toEqual([
+      { type: 'sequence', value: `${ESC}[<0;1;2M` },
+      { type: 'text', value: 'rest' },
+    ])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-138-message-renderers-UserToolResultMessage-UserToolErrorMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-138-message-renderers-UserToolResultMessage-UserToolErrorMessage.test.tsx
@@ -1,0 +1,199 @@
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const featureFlags = vi.hoisted(() => new Set<string>())
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => featureFlags.has(name),
+}))
+
+vi.mock('../../../src/tui/hooks/useSettings.js', () => ({
+  useSettings: () => ({
+    syntaxHighlightingDisabled: true,
+  }),
+}))
+
+import type { Tool, Tools } from '../../../src/tools/Tool.js'
+import type {
+  AgenCToolResultBlockParam,
+  ProgressMessage,
+} from '../../../src/types/message.js'
+import { Text } from '../../../src/tui/ink.js'
+import { UserToolErrorMessage } from '../../../src/tui/message-renderers/UserToolResultMessage/UserToolErrorMessage.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+import {
+  INTERRUPT_MESSAGE_FOR_TOOL_USE,
+  PLAN_REJECTION_PREFIX,
+  REJECT_MESSAGE_WITH_REASON_PREFIX,
+} from '../../../src/utils/messages.js'
+
+afterEach(() => {
+  featureFlags.clear()
+})
+
+function toolResult(
+  content: AgenCToolResultBlockParam['content'],
+): AgenCToolResultBlockParam {
+  return {
+    type: 'tool_result',
+    tool_use_id: 'toolu_swarm_138',
+    is_error: true,
+    content,
+  }
+}
+
+describe('UserToolErrorMessage swarm-138 coverage', () => {
+  test('renders permission denial, interruption, plan rejection, and explicit rejection rows', async () => {
+    const output = await renderToString(
+      <>
+        <UserToolErrorMessage
+          progressMessagesForMessage={[]}
+          tools={[]}
+          param={toolResult(JSON.stringify({ error: 'rejected by user' }))}
+          verbose={false}
+        />
+        <UserToolErrorMessage
+          progressMessagesForMessage={[]}
+          tools={[]}
+          param={toolResult(`before ${INTERRUPT_MESSAGE_FOR_TOOL_USE}`)}
+          verbose={false}
+        />
+        <UserToolErrorMessage
+          progressMessagesForMessage={[]}
+          tools={[]}
+          param={toolResult(`${PLAN_REJECTION_PREFIX}Inspect before editing.`)}
+          verbose={false}
+        />
+        <UserToolErrorMessage
+          progressMessagesForMessage={[]}
+          tools={[]}
+          param={toolResult(
+            `${REJECT_MESSAGE_WITH_REASON_PREFIX}Pick a narrower path.`,
+          )}
+          verbose={false}
+        />
+      </>,
+      { columns: 120, rows: 18 },
+    )
+
+    expect(output).toContain('Permission request denied by user.')
+    expect(output).toContain('Interrupted')
+    expect(output).toContain('PLAN REJECTED')
+    expect(output).toContain('Inspect before editing.')
+    expect(output).toContain('Tool use rejected')
+  })
+
+  test('uses the compact classifier denial only when the transcript classifier feature is enabled', async () => {
+    const deniedContent =
+      'Permission for this action has been denied. Reason: command looked unsafe'
+
+    const featureOffOutput = await renderToString(
+      <UserToolErrorMessage
+        progressMessagesForMessage={[]}
+        tools={[]}
+        param={toolResult(deniedContent)}
+        verbose={false}
+      />,
+      { columns: 100, rows: 8 },
+    )
+
+    featureFlags.add('TRANSCRIPT_CLASSIFIER')
+
+    const featureOnOutput = await renderToString(
+      <UserToolErrorMessage
+        progressMessagesForMessage={[]}
+        tools={[]}
+        param={toolResult(deniedContent)}
+        verbose={false}
+      />,
+      { columns: 100, rows: 8 },
+    )
+
+    expect(featureOffOutput).toContain(`Error: ${deniedContent}`)
+    expect(featureOffOutput).not.toContain('Denied by auto mode classifier')
+    expect(featureOnOutput).toContain('Denied by auto mode classifier')
+    expect(featureOnOutput).toContain('/feedback if incorrect')
+    expect(featureOnOutput).not.toContain('command looked unsafe')
+  })
+
+  test('delegates tool errors with filtered progress and transcript options', async () => {
+    const toolProgress = {
+      uuid: 'tool-progress',
+      data: { type: 'tool_progress', text: 'visible progress' },
+    } as ProgressMessage
+    const hookProgress = {
+      uuid: 'hook-progress',
+      data: { type: 'hook_progress', hookEvent: 'PreToolUse' },
+    } as ProgressMessage
+    let receivedOptions:
+      | {
+          readonly progressMessagesForMessage: ProgressMessage[]
+          readonly tools: Tools
+          readonly verbose: boolean
+          readonly isTranscriptMode?: boolean
+        }
+      | undefined
+    const delegatedTool = {
+      name: 'SwarmErrorDelegate',
+      renderToolUseErrorMessage: vi.fn((content: unknown, options) => {
+        receivedOptions = options
+        return (
+          <Text>
+            delegated {String(content)} progress:
+            {options.progressMessagesForMessage.length} verbose:
+            {String(options.verbose)} transcript:
+            {String(options.isTranscriptMode)}
+          </Text>
+        )
+      }),
+    } as unknown as Tool
+    const tools = [delegatedTool] as Tools
+
+    const output = await renderToString(
+      <UserToolErrorMessage
+        progressMessagesForMessage={[hookProgress, toolProgress]}
+        tool={delegatedTool}
+        tools={tools}
+        param={toolResult('custom failure')}
+        verbose={true}
+        isTranscriptMode={true}
+      />,
+      { columns: 120, rows: 8 },
+    )
+
+    expect(output).toContain(
+      'delegated custom failure progress:1 verbose:true transcript:true',
+    )
+    expect(delegatedTool.renderToolUseErrorMessage).toHaveBeenCalledTimes(1)
+    expect(receivedOptions).toMatchObject({
+      tools,
+      verbose: true,
+      isTranscriptMode: true,
+    })
+    expect(receivedOptions?.progressMessagesForMessage).toEqual([toolProgress])
+  })
+
+  test('falls back when the delegated error renderer returns null', async () => {
+    const nullRenderingTool = {
+      name: 'SwarmNullErrorRenderer',
+      renderToolUseErrorMessage: vi.fn(() => null),
+    } as unknown as Tool
+
+    const output = await renderToString(
+      <UserToolErrorMessage
+        progressMessagesForMessage={[]}
+        tool={nullRenderingTool}
+        tools={[nullRenderingTool] as Tools}
+        param={toolResult(
+          '<tool_use_error><error>InputValidationError: missing path</error></tool_use_error>',
+        )}
+        verbose={false}
+      />,
+      { columns: 100, rows: 8 },
+    )
+
+    expect(output).toContain('Invalid tool parameters')
+    expect(output).not.toContain('InputValidationError')
+    expect(nullRenderingTool.renderToolUseErrorMessage).toHaveBeenCalledTimes(1)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-139-components-design-system-Tabs.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-139-components-design-system-Tabs.test.tsx
@@ -1,0 +1,360 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const keybindingMock = vi.hoisted(() => ({
+  registrations: [] as Array<{
+    handlers: Record<string, () => void>
+    options: { context?: string; isActive?: boolean }
+  }>,
+}))
+
+vi.mock('../../../src/tui/keybindings/useKeybinding.js', () => ({
+  useKeybindings: (
+    handlers: Record<string, () => void>,
+    options: { context?: string; isActive?: boolean },
+  ) => {
+    keybindingMock.registrations.push({ handlers, options })
+  },
+}))
+
+import {
+  Tab,
+  Tabs,
+  useTabHeaderFocus,
+  useTabsWidth,
+} from '../../../src/tui/components/design-system/Tabs.js'
+import { ModalContext } from '../../../src/tui/context/modalContext.js'
+import type { DOMElement, DOMNode } from '../../../src/tui/ink/dom.js'
+import instances from '../../../src/tui/ink/instances.js'
+import { createRoot } from '../../../src/tui/ink/root.js'
+import { Text } from '../../../src/tui/ink.js'
+import type { ScrollBoxHandle } from '../../../src/tui/ink/components/ScrollBox.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestStdout = PassThrough & {
+  columns: number
+  isTTY: boolean
+  rows: number
+}
+
+type MountedRoot = {
+  root: Awaited<ReturnType<typeof createRoot>>
+  stdin: TestStdin
+  stdout: TestStdout
+}
+
+const mountedRoots: MountedRoot[] = []
+
+function createStreams(): { stdin: TestStdin; stdout: TestStdout } {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough() as TestStdout
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 42
+  stdout.rows = 12
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < 2_000) {
+    if (predicate()) return
+    await sleep(10)
+  }
+
+  throw new Error(message)
+}
+
+function getRootNode(stdout: TestStdout): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+
+  if (!instance?.rootNode) {
+    throw new Error('Ink root node not found')
+  }
+
+  return instance.rootNode
+}
+
+function collectText(node: DOMNode): string {
+  if (node.nodeName === '#text') return node.nodeValue
+
+  return node.childNodes.map(collectText).join('')
+}
+
+function findKeyboardElement(node: DOMNode): DOMElement | undefined {
+  if (node.nodeName !== '#text' && node._eventHandlers?.onKeyDown) {
+    return node
+  }
+
+  for (const child of node.childNodes) {
+    const found = findKeyboardElement(child)
+    if (found) return found
+  }
+
+  return undefined
+}
+
+function findScrollBox(node: DOMNode): DOMElement | undefined {
+  if (
+    node.nodeName !== '#text' &&
+    node.nodeName === 'ink-box' &&
+    node.style.overflowX === 'scroll' &&
+    node.style.overflowY === 'scroll'
+  ) {
+    return node
+  }
+
+  if (node.nodeName === '#text') return undefined
+
+  for (const child of node.childNodes) {
+    const found = findScrollBox(child)
+    if (found) return found
+  }
+
+  return undefined
+}
+
+function latestActiveTabsRegistration(): {
+  handlers: Record<string, () => void>
+  options: { context?: string; isActive?: boolean }
+} {
+  const registration = keybindingMock.registrations
+    .toReversed()
+    .find(reg => reg.options.context === 'Tabs' && reg.options.isActive)
+
+  if (!registration) {
+    throw new Error('Expected active Tabs keybindings')
+  }
+
+  return registration
+}
+
+async function renderNode(node: React.ReactNode): Promise<MountedRoot> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  const mounted = { root, stdin, stdout }
+  mountedRoots.push(mounted)
+  root.render(node)
+
+  await waitFor(
+    () => getRootNode(stdout).childNodes.length > 0,
+    'Tabs test tree did not mount',
+  )
+
+  return mounted
+}
+
+function HeaderFocusProbe({ snapshots }: { snapshots: boolean[] }) {
+  const { headerFocused } = useTabHeaderFocus()
+
+  React.useEffect(() => {
+    snapshots.push(headerFocused)
+  }, [headerFocused, snapshots])
+
+  return <Text>{`focus:${String(headerFocused)}`}</Text>
+}
+
+describe('Tabs coverage swarm row 139', () => {
+  beforeEach(() => {
+    keybindingMock.registrations = []
+  })
+
+  afterEach(() => {
+    for (const { root, stdin, stdout } of mountedRoots.splice(0)) {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      instances.delete(stdout as unknown as NodeJS.WriteStream)
+    }
+  })
+
+  test('falls back from unknown tab ids and keeps controlled navigation external', async () => {
+    const rendered = await renderNode(
+      <Tabs defaultTab="missing">
+        <Tab title="Alpha">
+          <Text>alpha content</Text>
+        </Tab>
+        <Tab id="beta" title="Beta">
+          <Text>beta content</Text>
+        </Tab>
+      </Tabs>,
+    )
+
+    expect(collectText(getRootNode(rendered.stdout))).toContain('alpha content')
+    expect(collectText(getRootNode(rendered.stdout))).not.toContain(
+      'beta content',
+    )
+
+    latestActiveTabsRegistration().handlers['tabs:next']()
+    await waitFor(
+      () => collectText(getRootNode(rendered.stdout)).includes('beta content'),
+      'uncontrolled next navigation did not select the second tab',
+    )
+
+    const onTabChange = vi.fn()
+    keybindingMock.registrations = []
+    rendered.root.render(
+      <Tabs selectedTab="missing" onTabChange={onTabChange}>
+        <Tab id="first" title="First">
+          <Text>controlled first</Text>
+        </Tab>
+        <Tab id="second" title="Second">
+          <Text>controlled second</Text>
+        </Tab>
+      </Tabs>,
+    )
+
+    await waitFor(
+      () => collectText(getRootNode(rendered.stdout)).includes('controlled first'),
+      'controlled fallback did not render the first tab',
+    )
+
+    latestActiveTabsRegistration().handlers['tabs:previous']()
+    expect(onTabChange).toHaveBeenCalledWith('second')
+    expect(collectText(getRootNode(rendered.stdout))).not.toContain(
+      'controlled second',
+    )
+  })
+
+  test('ignores non-down header key events and blurs only opted-in content on down', async () => {
+    const snapshots: boolean[] = []
+    const rendered = await renderNode(
+      <Tabs color="permission">
+        <Tab id="first" title="First">
+          <HeaderFocusProbe snapshots={snapshots} />
+        </Tab>
+        <Tab id="second" title="Second">
+          <Text>second content</Text>
+        </Tab>
+      </Tabs>,
+    )
+
+    await waitFor(
+      () => snapshots.includes(true),
+      'header focus probe did not report initial focus',
+    )
+
+    const keyboardElement = findKeyboardElement(getRootNode(rendered.stdout))
+    expect(keyboardElement).toBeDefined()
+
+    const nonDownPreventDefault = vi.fn()
+    keyboardElement?._eventHandlers?.onKeyDown?.({
+      key: 'up',
+      preventDefault: nonDownPreventDefault,
+    } as never)
+    await sleep(20)
+
+    expect(nonDownPreventDefault).not.toHaveBeenCalled()
+    expect(snapshots.at(-1)).toBe(true)
+
+    const downPreventDefault = vi.fn()
+    keyboardElement?._eventHandlers?.onKeyDown?.({
+      key: 'down',
+      preventDefault: downPreventDefault,
+    } as never)
+
+    await waitFor(
+      () => snapshots.includes(false),
+      'down key did not hand focus to opted-in tab content',
+    )
+    expect(downPreventDefault).toHaveBeenCalledTimes(1)
+  })
+
+  test('provides stable hook defaults outside a Tabs provider', async () => {
+    let captured:
+      | {
+          blurHeader: () => void
+          focusHeader: () => void
+          headerFocused: boolean
+          width: number | undefined
+        }
+      | undefined
+
+    function OutsideProbe() {
+      const focus = useTabHeaderFocus()
+      const width = useTabsWidth()
+
+      React.useEffect(() => {
+        captured = { ...focus, width }
+      }, [focus, width])
+
+      return <Text>{`outside:${String(focus.headerFocused)}:${String(width)}`}</Text>
+    }
+
+    const rendered = await renderNode(<OutsideProbe />)
+
+    await waitFor(
+      () => captured !== undefined,
+      'outside Tabs hook defaults were not captured',
+    )
+
+    expect(collectText(getRootNode(rendered.stdout))).toContain(
+      'outside:false:undefined',
+    )
+    expect(captured?.headerFocused).toBe(false)
+    expect(captured?.width).toBeUndefined()
+    expect(() => captured?.blurHeader()).not.toThrow()
+    expect(() => captured?.focusHeader()).not.toThrow()
+  })
+
+  test('uses the modal scroll ref path and modal tab content layout', async () => {
+    const scrollRef = React.createRef<ScrollBoxHandle>()
+    const rendered = await renderNode(
+      <ModalContext.Provider
+        value={{ columns: 30, rows: 8, scrollRef }}
+      >
+        <Tabs hidden useFullWidth defaultTab="modal">
+          <Tab id="modal" title="Modal">
+            <Text>modal content</Text>
+          </Tab>
+          <Tab id="other" title="Other">
+            <Text>other content</Text>
+          </Tab>
+        </Tabs>
+      </ModalContext.Provider>,
+    )
+
+    await waitFor(
+      () => scrollRef.current !== null,
+      'Tabs did not attach the modal scroll ref',
+    )
+
+    const rootNode = getRootNode(rendered.stdout)
+    const scrollBox = findScrollBox(rootNode)
+
+    expect(collectText(rootNode)).toContain('modal content')
+    expect(collectText(rootNode)).not.toContain('other content')
+    expect(collectText(rootNode)).not.toContain('Modal')
+    expect(scrollBox).toBeDefined()
+    expect(scrollBox?.style.flexShrink).toBe(0)
+    expect(scrollRef.current?.getScrollTop()).toBe(0)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-140-state-collabAgentTaskSync.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-140-state-collabAgentTaskSync.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, test } from "vitest";
+
+import { syncCollabAgentEventToAppState } from "src/tui/state/collabAgentTaskSync.js";
+
+type TestTask = Record<string, unknown>;
+type TestState = {
+  readonly marker?: string;
+  readonly tasks?: Record<string, TestTask>;
+};
+
+function applyEvent<T extends TestState>(
+  state: T,
+  event: unknown,
+  now = 10_000,
+): T {
+  let next: TestState = state;
+  syncCollabAgentEventToAppState(
+    event,
+    (updater) => {
+      next = updater(next as never) as TestState;
+    },
+    now,
+  );
+  return next as T;
+}
+
+function localAgentTask(
+  id: string,
+  overrides: Record<string, unknown> = {},
+): TestTask {
+  return {
+    id,
+    type: "local_agent",
+    status: "running",
+    description: id,
+    startTime: 100,
+    outputFile: `urn:agenc:task:${encodeURIComponent(id)}:output`,
+    outputOffset: 0,
+    notified: false,
+    agentId: id,
+    prompt: "inspect",
+    agentType: "worker",
+    retrieved: false,
+    lastReportedToolCount: 0,
+    lastReportedTokenCount: 0,
+    isBackgrounded: true,
+    pendingMessages: [],
+    retain: false,
+    diskLoaded: false,
+    selectedAgent: { name: id },
+    ...overrides,
+  };
+}
+
+function shellTask(id: string): TestTask {
+  return {
+    id,
+    type: "local_bash",
+    status: "running",
+    description: id,
+    startTime: 100,
+    outputFile: `urn:agenc:task:${encodeURIComponent(id)}:output`,
+    outputOffset: 0,
+    notified: false,
+    command: "true",
+  };
+}
+
+describe("collabAgentTaskSync coverage swarm row 140", () => {
+  test("creates spawned tasks with trimmed fallback metadata and pending aliases", () => {
+    const next = applyEvent(
+      { marker: "keep", tasks: {} },
+      {
+        type: "collab_agent_spawn_end",
+        payload: {
+          newThreadId: "  agent 140/alpha  ",
+          taskName: "  Fallback task title  ",
+          prompt: "  summarize the logs  ",
+          newAgentRole: "  reviewer  ",
+          status: "STARTING",
+        },
+      },
+    );
+
+    expect(next.marker).toBe("keep");
+    expect(next.tasks?.["agent 140/alpha"]).toMatchObject({
+      id: "agent 140/alpha",
+      type: "local_agent",
+      status: "pending",
+      description: "Fallback task title",
+      prompt: "summarize the logs",
+      agentType: "reviewer",
+      outputFile: "urn:agenc:task:agent%20140%2Falpha:output",
+      notified: false,
+      selectedAgent: { name: "Fallback task title" },
+    });
+  });
+
+  test("updates existing live status with path, role, model, and failed aliases", () => {
+    const state: TestState = {
+      tasks: {
+        "agent-140": localAgentTask("agent-140", {
+          description: "original",
+          prompt: "original prompt",
+          agentType: "worker",
+        }),
+      },
+    };
+
+    const next = applyEvent(state, {
+      type: "collab_agent_status",
+      payload: {
+        threadId: "agent-140",
+        agentPath: "  /tmp/agent-140  ",
+        prompt: "  check failing case  ",
+        agentRole: "  fixer  ",
+        model: "  model-140  ",
+        status: "not_found",
+        error: "  missing worker  ",
+      },
+    });
+
+    expect(next.tasks?.["agent-140"]).toMatchObject({
+      status: "failed",
+      description: "/tmp/agent-140",
+      prompt: "check failing case",
+      agentType: "fixer",
+      model: "model-140",
+      error: "missing worker",
+      notified: true,
+      endTime: 10_000,
+      evictAfter: 40_000,
+    });
+  });
+
+  test("starts interaction tasks even when the receiver did not already exist", () => {
+    const next = applyEvent(
+      { tasks: {} },
+      {
+        type: "collab_agent_interaction_begin",
+        payload: {
+          receiverThreadId: "fresh-agent",
+          receiverAgentRole: "  helper  ",
+          prompt: "  continue work  ",
+          status: { status: "running" },
+        },
+      },
+    );
+
+    expect(next.tasks?.["fresh-agent"]).toMatchObject({
+      id: "fresh-agent",
+      status: "running",
+      description: "fresh-agent",
+      prompt: "continue work",
+      agentType: "helper",
+      notified: false,
+    });
+    expect(next.tasks?.["fresh-agent"]).not.toHaveProperty("error");
+  });
+
+  test("normalizes daemon status variants without updating non-agent tasks", () => {
+    const shellOnly: TestState = {
+      tasks: {
+        "shell-140": shellTask("shell-140"),
+      },
+    };
+
+    expect(
+      applyEvent(shellOnly, {
+        type: "background_agent_status",
+        payload: {
+          agentId: "shell-140",
+          runStatus: "pending",
+        },
+      }),
+    ).toBe(shellOnly);
+
+    const runStatusCases = [
+      ["pending", "pending"],
+      ["working", "running"],
+      ["paused", "running"],
+      ["blocked", "running"],
+      ["suspended", "running"],
+      ["stopped", "killed"],
+    ] as const;
+
+    for (const [runStatus, expected] of runStatusCases) {
+      const next = applyEvent(
+        { tasks: { worker: localAgentTask("worker") } },
+        {
+          type: "background_agent_status",
+          payload: {
+            agentId: "worker",
+            runStatus,
+          },
+        },
+      );
+      expect(next.tasks?.worker).toMatchObject({ status: expected });
+    }
+
+    const statusCases = [
+      ["running", "running"],
+      ["error", "failed"],
+      ["stopping", "killed"],
+      ["unknown", "running"],
+    ] as const;
+
+    for (const [status, expected] of statusCases) {
+      const next = applyEvent(
+        { tasks: { worker: localAgentTask("worker") } },
+        {
+          type: "background_agent_status",
+          payload: {
+            agentId: "worker",
+            status,
+            message: "daemon message",
+          },
+        },
+      );
+      expect(next.tasks?.worker).toMatchObject({ status: expected });
+    }
+  });
+
+  test("maps additional collab status aliases through wait summaries", () => {
+    const state: TestState = {
+      tasks: {
+        complete: localAgentTask("complete"),
+        interrupted: localAgentTask("interrupted"),
+        shutdown: localAgentTask("shutdown"),
+      },
+    };
+
+    const next = applyEvent(state, {
+      type: "collab_waiting_end",
+      payload: {
+        agentStatuses: [
+          { threadId: "complete", status: "complete" },
+          { threadId: "interrupted", status: "interrupted" },
+          { threadId: "shutdown", status: "shutdown" },
+        ],
+      },
+    });
+
+    expect(next.tasks?.complete).toMatchObject({
+      status: "completed",
+      notified: true,
+      endTime: 10_000,
+    });
+    expect(next.tasks?.interrupted).toMatchObject({
+      status: "running",
+      notified: false,
+    });
+    expect(next.tasks?.shutdown).toMatchObject({
+      status: "killed",
+      notified: true,
+      endTime: 10_000,
+    });
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-141-ink-components-Link.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-141-ink-components-Link.test.tsx
@@ -1,0 +1,291 @@
+import { PassThrough } from 'node:stream'
+
+import React, { useLayoutEffect, useState } from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import Link from '../../../src/tui/ink/components/Link.js'
+import type { DOMElement } from '../../../src/tui/ink/dom.js'
+import instances from '../../../src/tui/ink/instances.js'
+import { createRoot } from '../../../src/tui/ink/root.js'
+import { squashTextNodesToSegments } from '../../../src/tui/ink/squash-text-nodes.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestStdout = PassThrough & {
+  columns: number
+  isTTY: boolean
+  rows: number
+}
+
+const envKeys = [
+  'FORCE_HYPERLINK',
+  'LC_TERMINAL',
+  'NO_COLOR',
+  'TERM',
+  'TERM_PROGRAM',
+] as const
+
+const previousEnv = Object.fromEntries(
+  envKeys.map(key => [key, process.env[key]]),
+) as Record<(typeof envKeys)[number], string | undefined>
+
+afterEach(() => {
+  for (const key of envKeys) {
+    const previous = previousEnv[key]
+
+    if (previous === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = previous
+    }
+  }
+})
+
+function createStreams(): {
+  readonly stdin: TestStdin
+  readonly stdout: TestStdout
+} {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough() as TestStdout
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 120
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function getRootNode(stdout: TestStdout): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+
+  if (!instance?.rootNode) {
+    throw new Error('Ink root node not found')
+  }
+
+  return instance.rootNode
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await sleep(10)
+  }
+
+  throw new Error(message)
+}
+
+async function renderSegments(
+  node: React.ReactNode,
+  waitForRender: () => Promise<void> = () => sleep(),
+): Promise<
+  Array<{
+    readonly hyperlink?: string
+    readonly styles: Record<string, unknown>
+    readonly text: string
+  }>
+> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  try {
+    root.render(node)
+    await waitForRender()
+    return squashTextNodesToSegments(getRootNode(stdout))
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await sleep()
+  }
+}
+
+function setHyperlinksSupported(supported: boolean): void {
+  if (supported) {
+    process.env.FORCE_HYPERLINK = '1'
+    return
+  }
+
+  process.env.FORCE_HYPERLINK = '0'
+  process.env.TERM = 'xterm-256color'
+  delete process.env.LC_TERMINAL
+  delete process.env.TERM_PROGRAM
+}
+
+function HyperlinkRerenderHarness({
+  onStage,
+}: {
+  readonly onStage: (stage: number) => void
+}) {
+  const [stage, setStage] = useState(0)
+
+  useLayoutEffect(() => {
+    onStage(stage)
+
+    if (stage < 3) {
+      setStage(stage + 1)
+    }
+  }, [onStage, stage])
+
+  const stableProps = stage < 2
+  const url = stableProps
+    ? 'https://row-141.example/cached'
+    : 'https://row-141.example/final'
+  const label = stableProps ? 'cached label' : 'final label'
+
+  return <Link url={url}>{label}</Link>
+}
+
+function FallbackRerenderHarness({
+  onStage,
+}: {
+  readonly onStage: (stage: number) => void
+}) {
+  const [stage, setStage] = useState(0)
+
+  useLayoutEffect(() => {
+    onStage(stage)
+
+    if (stage < 3) {
+      setStage(stage + 1)
+    }
+  }, [onStage, stage])
+
+  const fallback = stage < 2 ? 'cached fallback' : 'final fallback'
+
+  return (
+    <Link fallback={fallback} url="https://row-141.example/no-link">
+      ignored label
+    </Link>
+  )
+}
+
+describe('Link coverage swarm row 141', () => {
+  test('renders hyperlinks with url fallback content and falsey children', async () => {
+    setHyperlinksSupported(true)
+    const defaultUrl = 'https://row-141.example/default'
+    const zeroChildUrl = 'https://row-141.example/zero'
+
+    const segments = await renderSegments(
+      <>
+        <Link url={defaultUrl} />
+        <Link url={zeroChildUrl}>{0}</Link>
+      </>,
+    )
+
+    expect(segments).toEqual([
+      {
+        hyperlink: defaultUrl,
+        styles: {},
+        text: defaultUrl,
+      },
+      {
+        hyperlink: zeroChildUrl,
+        styles: {},
+        text: '0',
+      },
+    ])
+  })
+
+  test('renders fallback text when hyperlinks are not supported', async () => {
+    setHyperlinksSupported(false)
+
+    const segments = await renderSegments(
+      <>
+        <Link fallback="plain fallback" url="https://row-141.example/hidden">
+          visible label
+        </Link>
+        <Link fallback={null} url="https://row-141.example/content">
+          content label
+        </Link>
+        <Link url="https://row-141.example/url-only" />
+      </>,
+    )
+
+    expect(segments).toEqual([
+      {
+        styles: {},
+        text: 'plain fallback',
+      },
+      {
+        styles: {},
+        text: 'content label',
+      },
+      {
+        styles: {},
+        text: 'https://row-141.example/url-only',
+      },
+    ])
+    expect(segments.every(segment => segment.hyperlink === undefined)).toBe(true)
+  })
+
+  test('rerenders stable and changed hyperlink props through cached branches', async () => {
+    setHyperlinksSupported(true)
+    const onStage = vi.fn()
+
+    const segments = await renderSegments(
+      <HyperlinkRerenderHarness onStage={onStage} />,
+      () =>
+        waitForCondition(
+          () => onStage.mock.calls.some(([stage]) => stage === 3),
+          'hyperlink rerender stages did not complete',
+        ),
+    )
+
+    expect(onStage.mock.calls.map(([stage]) => stage)).toEqual([0, 1, 2, 3])
+    expect(segments).toEqual([
+      {
+        hyperlink: 'https://row-141.example/final',
+        styles: {},
+        text: 'final label',
+      },
+    ])
+  })
+
+  test('rerenders stable and changed fallback props through cached branches', async () => {
+    setHyperlinksSupported(false)
+    const onStage = vi.fn()
+
+    const segments = await renderSegments(
+      <FallbackRerenderHarness onStage={onStage} />,
+      () =>
+        waitForCondition(
+          () => onStage.mock.calls.some(([stage]) => stage === 3),
+          'fallback rerender stages did not complete',
+        ),
+    )
+
+    expect(onStage.mock.calls.map(([stage]) => stage)).toEqual([0, 1, 2, 3])
+    expect(segments).toEqual([
+      {
+        styles: {},
+        text: 'final fallback',
+      },
+    ])
+    expect(segments[0]?.hyperlink).toBeUndefined()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-142-components-BaseTextInput.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-142-components-BaseTextInput.test.tsx
@@ -1,0 +1,276 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { BaseInputState } from '../../types/textInputTypes.js'
+import type { TextHighlight } from '../../utils/textHighlighting.js'
+import { createRoot, Text } from '../ink.js'
+import { BaseTextInput } from '../components/BaseTextInput.js'
+
+const highlightedInputMock = vi.hoisted(() => ({
+  calls: [] as Array<{
+    highlights: TextHighlight[]
+    text: string
+  }>,
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('../../utils/config.js', () => ({
+  getGlobalConfig: () => ({ theme: 'dark' }),
+  saveGlobalConfig: vi.fn(),
+}))
+
+vi.mock('../../utils/systemTheme.js', () => ({
+  getSystemThemeName: () => 'dark',
+  resolveThemeSetting: () => 'dark',
+}))
+
+vi.mock('../components/PromptInput/ShimmeredInput.js', async () => {
+  const ReactModule = await import('react')
+  const { Text: InkText } = await import('../ink.js')
+
+  return {
+    HighlightedInput: ({
+      highlights,
+      text,
+    }: {
+      highlights: TextHighlight[]
+      text: string
+    }) => {
+      highlightedInputMock.calls.push({ highlights, text })
+      return ReactModule.createElement(InkText, null, `highlighted:${text}`)
+    },
+  }
+})
+
+const SYNC_START = '\x1B[?2026h'
+const SYNC_END = '\x1B[?2026l'
+
+function extractLastFrame(output: string): string {
+  let lastFrame: string | null = null
+  let cursor = 0
+
+  while (cursor < output.length) {
+    const start = output.indexOf(SYNC_START, cursor)
+    if (start === -1) break
+
+    const contentStart = start + SYNC_START.length
+    const end = output.indexOf(SYNC_END, contentStart)
+    if (end === -1) break
+
+    const frame = output.slice(contentStart, end)
+    if (frame.trim().length > 0) lastFrame = frame
+    cursor = end + SYNC_END.length
+  }
+
+  return lastFrame ?? output
+}
+
+function createStreams(): {
+  getOutput: () => string
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdout: PassThrough
+} {
+  let output = ''
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 80
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  return { getOutput: () => output, stdin, stdout }
+}
+
+function createInputState(
+  overrides: Partial<BaseInputState> = {},
+): BaseInputState {
+  return {
+    cursorColumn: 0,
+    cursorLine: 0,
+    offset: 0,
+    onInput: vi.fn(),
+    renderedValue: '',
+    setOffset: vi.fn(),
+    setValue: vi.fn(),
+    value: '',
+    viewportCharEnd: 0,
+    viewportCharOffset: 0,
+    ...overrides,
+  }
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+describe('BaseTextInput coverage swarm row 142', () => {
+  beforeEach(() => {
+    highlightedInputMock.calls = []
+  })
+
+  test('renders the generated placeholder when no placeholder element is supplied', async () => {
+    const inputState = createInputState()
+    const { getOutput, stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      root.render(
+        <BaseTextInput
+          columns={80}
+          cursorOffset={0}
+          focus={true}
+          inputState={inputState}
+          onChange={vi.fn()}
+          onChangeCursorOffset={vi.fn()}
+          placeholder="type here"
+          showCursor={true}
+          terminalFocus={false}
+          value=""
+        >
+          <Text> suffix</Text>
+        </BaseTextInput>,
+      )
+      await sleep()
+
+      const output = stripAnsi(extractLastFrame(getOutput()))
+      expect(output).toContain('type here suffix')
+      expect(output).not.toContain('custom placeholder')
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+
+  test('passes highlights through unchanged when the cursor is hidden and viewport starts at zero', async () => {
+    const highlights: TextHighlight[] = [
+      { color: 'success', end: 5, priority: 1, start: 0 },
+      { color: 'error', end: 12, priority: 2, start: 6 },
+    ]
+    const inputState = createInputState({
+      cursorColumn: 2,
+      offset: 2,
+      renderedValue: '/ship target',
+      value: '/ship target',
+      viewportCharEnd: 12,
+      viewportCharOffset: 0,
+    })
+    const { getOutput, stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      root.render(
+        <BaseTextInput
+          argumentHint="<path>"
+          columns={80}
+          cursorOffset={2}
+          focus={true}
+          highlights={highlights}
+          inputState={inputState}
+          onChange={vi.fn()}
+          onChangeCursorOffset={vi.fn()}
+          showCursor={false}
+          terminalFocus={true}
+          value="/ship target"
+        >
+          <Text> tail</Text>
+        </BaseTextInput>,
+      )
+      await sleep()
+
+      const output = stripAnsi(extractLastFrame(getOutput()))
+      expect(output).toContain('highlighted:/ship target tail')
+      expect(output).not.toContain('<path>')
+      expect(highlightedInputMock.calls).toEqual([
+        {
+          highlights,
+          text: '/ship target',
+        },
+      ])
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+
+  test('treats an empty highlight list as the plain text render path', async () => {
+    const inputState = createInputState({
+      cursorColumn: 4,
+      offset: 4,
+      renderedValue: 'note',
+      value: 'note',
+      viewportCharEnd: 4,
+    })
+    const { getOutput, stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      root.render(
+        <BaseTextInput
+          argumentHint="<ignored>"
+          columns={80}
+          cursorOffset={4}
+          focus={false}
+          highlights={[]}
+          inputState={inputState}
+          onChange={vi.fn()}
+          onChangeCursorOffset={vi.fn()}
+          placeholder="fallback"
+          showCursor={false}
+          terminalFocus={true}
+          value="note"
+        >
+          <Text> tail</Text>
+        </BaseTextInput>,
+      )
+      await sleep()
+
+      const output = stripAnsi(extractLastFrame(getOutput()))
+      expect(output).toContain('note tail')
+      expect(output).not.toContain('<ignored>')
+      expect(output).not.toContain('fallback')
+      expect(highlightedInputMock.calls).toEqual([])
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-143-ink-termio-sgr.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-143-ink-termio-sgr.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'vitest'
+
+import { applySGR } from '../../../src/tui/ink/termio/sgr.js'
+import { defaultStyle } from '../../../src/tui/ink/termio/types.js'
+
+describe('termio SGR parser coverage swarm row 143', () => {
+  test('applies blink alias, underline none, and colon color variants', () => {
+    const style = applySGR(
+      '6;4:0;38:2::10:20:30;48:5:201;58:5:44',
+      defaultStyle(),
+    )
+
+    expect(style).toEqual(
+      expect.objectContaining({
+        blink: true,
+        underline: 'none',
+        fg: { type: 'rgb', r: 10, g: 20, b: 30 },
+        bg: { type: 'indexed', index: 201 },
+        underlineColor: { type: 'indexed', index: 44 },
+      }),
+    )
+  })
+
+  test('leaves extended colors unchanged when colon parameters are incomplete', () => {
+    const base = applySGR('31;48;5;22;58;2;1;2;3', defaultStyle())
+
+    expect(applySGR('38:5', base)).toEqual(base)
+    expect(applySGR('38:2:1:2', base)).toEqual(base)
+    expect(applySGR('38:7:1', base)).toEqual(base)
+  })
+
+  test('handles semicolon RGB foregrounds and later ordinary SGR codes', () => {
+    const rgb = applySGR('38;2;9;8;7;48;7;58;8', defaultStyle())
+
+    expect(rgb).toEqual(
+      expect.objectContaining({
+        fg: { type: 'rgb', r: 9, g: 8, b: 7 },
+        bg: { type: 'default' },
+        underlineColor: { type: 'default' },
+        inverse: true,
+        hidden: true,
+      }),
+    )
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-144-components-teams-TeamStatus.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-144-components-teams-TeamStatus.test.tsx
@@ -1,0 +1,139 @@
+import React, { useLayoutEffect, useState } from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { TeamStatus } from "../../../src/tui/components/teams/TeamStatus.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+type Teammate = {
+  cwd: string;
+  name: string;
+  spawnedAt: number;
+  tmuxPaneId: string;
+  tmuxSessionName: string;
+};
+
+type TeamContext = {
+  leadAgentId: string;
+  teamFilePath: string;
+  teamName: string;
+  teammates: Record<string, Teammate>;
+};
+
+const appStateMock = vi.hoisted(() => ({
+  state: {
+    teamContext: undefined as TeamContext | undefined,
+  },
+}));
+
+vi.mock("../../../src/tui/state/AppState.js", () => ({
+  useAppState: (selector: (state: typeof appStateMock.state) => unknown) =>
+    selector(appStateMock.state),
+}));
+
+function teamContext(names: string[]): TeamContext {
+  return {
+    leadAgentId: "lead",
+    teamFilePath: "/tmp/team.json",
+    teamName: "coverage-team",
+    teammates: Object.fromEntries(
+      names.map((name, index) => [
+        `agent-${index}`,
+        {
+          cwd: "/tmp",
+          name,
+          spawnedAt: index,
+          tmuxPaneId: `%${index + 1}`,
+          tmuxSessionName: "coverage-team",
+        },
+      ]),
+    ),
+  };
+}
+
+function RerenderTeamStatus(props: {
+  showHint: boolean;
+  teamsSelected: boolean;
+}) {
+  const [renderCount, setRenderCount] = useState(0);
+
+  useLayoutEffect(() => {
+    if (renderCount === 0) setRenderCount(1);
+  }, [renderCount]);
+
+  return <TeamStatus {...props} />;
+}
+
+describe("TeamStatus coverage swarm row 144", () => {
+  beforeEach(() => {
+    appStateMock.state.teamContext = undefined;
+  });
+
+  test("renders nothing when the team context has no visible teammate", async () => {
+    expect(
+      (
+        await renderToString(
+          <TeamStatus teamsSelected={false} showHint={false} />,
+          80,
+        )
+      ).trim(),
+    ).toBe("");
+
+    appStateMock.state.teamContext = teamContext(["team-lead"]);
+
+    expect(
+      (
+        await renderToString(
+          <TeamStatus teamsSelected={true} showHint={true} />,
+          80,
+        )
+      ).trim(),
+    ).toBe("");
+  });
+
+  test("counts non-lead teammates and only shows the selected hint when enabled", async () => {
+    appStateMock.state.teamContext = teamContext(["team-lead", "builder"]);
+
+    const unselected = await renderToString(
+      <TeamStatus teamsSelected={false} showHint={true} />,
+      80,
+    );
+    expect(unselected).toContain("1 teammate");
+    expect(unselected).not.toContain("Enter to view");
+
+    const selectedWithoutHint = await renderToString(
+      <TeamStatus teamsSelected={true} showHint={false} />,
+      80,
+    );
+    expect(selectedWithoutHint).toContain("1 teammate");
+    expect(selectedWithoutHint).not.toContain("Enter to view");
+
+    appStateMock.state.teamContext = teamContext([
+      "team-lead",
+      "builder",
+      "reviewer",
+    ]);
+
+    const selectedWithHint = await renderToString(
+      <TeamStatus teamsSelected={true} showHint={true} />,
+      80,
+    );
+    expect(selectedWithHint).toContain("2 teammates");
+    expect(selectedWithHint).toContain("Enter to view");
+  });
+
+  test("keeps the selected footer stable across a rerender with the same team context", async () => {
+    appStateMock.state.teamContext = teamContext([
+      "team-lead",
+      "builder",
+      "reviewer",
+    ]);
+
+    const output = await renderToString(
+      <RerenderTeamStatus teamsSelected={true} showHint={true} />,
+      80,
+    );
+
+    expect(output).toContain("2 teammates");
+    expect(output).toContain("Enter to view");
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-145-message-renderers-UserToolResultMessage-UserToolRejectMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-145-message-renderers-UserToolResultMessage-UserToolRejectMessage.test.tsx
@@ -1,0 +1,244 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import type { Tool, Tools } from '../../../src/tools/Tool.js'
+import type { ProgressMessage } from '../../../src/types/message.js'
+import { Text, createRoot, type Root } from '../../../src/tui/ink.js'
+import { UserToolRejectMessage } from '../../../src/tui/message-renderers/UserToolResultMessage/UserToolRejectMessage.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+
+const previousGlyphMode = process.env.AGENC_TUI_GLYPHS
+
+afterEach(() => {
+  if (previousGlyphMode === undefined) {
+    delete process.env.AGENC_TUI_GLYPHS
+  } else {
+    process.env.AGENC_TUI_GLYPHS = previousGlyphMode
+  }
+})
+
+function createProgressMessages(): ProgressMessage[] {
+  return [
+    {
+      uuid: 'swarm-145-hook-progress',
+      data: { type: 'hook_progress', hookEvent: 'PreToolUse' },
+    } as ProgressMessage,
+    {
+      uuid: 'swarm-145-tool-progress',
+      data: { type: 'tool_progress', text: 'visible tool progress' },
+    } as ProgressMessage,
+  ]
+}
+
+function createStreams(): {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough & { columns: number; rows: number }
+} {
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  const stdout = new PassThrough() as PassThrough & {
+    columns: number
+    rows: number
+  }
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.columns = 104
+  stdout.rows = 12
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function flushRender(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 5))
+}
+
+describe('UserToolRejectMessage swarm-145 coverage', () => {
+  test('renders the fallback without validating when the rejected renderer is unavailable', async () => {
+    process.env.AGENC_TUI_GLYPHS = 'ascii'
+
+    const noRendererSafeParse = vi.fn()
+    const output = await renderToString(
+      <UserToolRejectMessage
+        input={{ path: 'runtime/src/unrendered.ts' }}
+        progressMessagesForMessage={[]}
+        tool={
+          {
+            inputSchema: { safeParse: noRendererSafeParse },
+            name: 'NoRejectedRenderer',
+          } as unknown as Tool
+        }
+        tools={[] as unknown as Tools}
+        lookups={{} as never}
+        verbose={false}
+      />,
+      { columns: 88, rows: 10 },
+    )
+
+    expect(output).toContain('Interrupted')
+    expect(output).toContain('What should AgenC do instead?')
+    expect(noRendererSafeParse).not.toHaveBeenCalled()
+  })
+
+  test('falls back when rejected input fails the tool schema', async () => {
+    process.env.AGENC_TUI_GLYPHS = 'ascii'
+
+    const renderToolUseRejectedMessage = vi.fn(() => <Text>delegated</Text>)
+    const output = await renderToString(
+      <UserToolRejectMessage
+        input={{ path: 'runtime/src/invalid.ts' }}
+        progressMessagesForMessage={createProgressMessages()}
+        tool={
+          {
+            inputSchema: {
+              safeParse: vi.fn(() => ({ success: false })),
+            },
+            name: 'InvalidRejectedInput',
+            renderToolUseRejectedMessage,
+          } as unknown as Tool
+        }
+        tools={[] as unknown as Tools}
+        lookups={{} as never}
+        verbose={true}
+      />,
+      { columns: 92, rows: 10 },
+    )
+
+    expect(output).toContain('Interrupted')
+    expect(renderToolUseRejectedMessage).not.toHaveBeenCalled()
+  })
+
+  test('delegates parsed rejected input with terminal, theme, and filtered progress options', async () => {
+    const tools = [] as unknown as Tools
+    const progressMessagesForMessage = createProgressMessages()
+    const renderToolUseRejectedMessage = vi.fn(
+      (
+        input: { path: string; parsed: boolean },
+        options: {
+          readonly columns: number
+          readonly isTranscriptMode?: boolean
+          readonly progressMessagesForMessage: readonly ProgressMessage[]
+          readonly style?: string
+          readonly theme: string
+          readonly tools: Tools
+          readonly verbose: boolean
+        },
+      ) => (
+        <Text>
+          rejected {input.path} parsed:{String(input.parsed)} columns:
+          {options.columns} progress:
+          {options.progressMessagesForMessage.length} style:{options.style}{' '}
+          theme:{options.theme} transcript:
+          {String(options.isTranscriptMode)} verbose:{String(options.verbose)}
+        </Text>
+      ),
+    )
+    const tool = {
+      inputSchema: {
+        safeParse: (input: { path: string }) => ({
+          success: true,
+          data: { path: input.path, parsed: true },
+        }),
+      },
+      name: 'DelegatedRejectedInput',
+      renderToolUseRejectedMessage,
+    } as unknown as Tool
+
+    const output = await renderToString(
+      <UserToolRejectMessage
+        input={{ path: 'runtime/src/delegated.ts' }}
+        progressMessagesForMessage={progressMessagesForMessage}
+        style="condensed"
+        tool={tool}
+        tools={tools}
+        lookups={{} as never}
+        verbose={true}
+        isTranscriptMode={true}
+      />,
+      { columns: 117, rows: 10 },
+    )
+
+    expect(output.replace(/\s+/g, ' ')).toContain(
+      'rejected runtime/src/delegated.ts parsed:true columns:117 progress:1 style:condensed theme:dark transcript:true verbose:true',
+    )
+    expect(renderToolUseRejectedMessage).toHaveBeenCalledTimes(1)
+    expect(renderToolUseRejectedMessage.mock.calls[0]?.[1]).toMatchObject({
+      columns: 117,
+      messages: [],
+      progressMessagesForMessage: [progressMessagesForMessage[1]],
+      style: 'condensed',
+      theme: 'dark',
+      tools,
+      verbose: true,
+      isTranscriptMode: true,
+    })
+  })
+
+  test('reuses the delegated render result while rejection props stay referentially stable', async () => {
+    const progressMessagesForMessage = createProgressMessages()
+    const tools = [] as unknown as Tools
+    const stableInput = { path: 'runtime/src/stable.ts' }
+    const renderToolUseRejectedMessage = vi.fn((input: { path: string }) => (
+      <Text>delegated {input.path}</Text>
+    ))
+    const tool = {
+      inputSchema: {
+        safeParse: (input: { path: string }) => ({ success: true, data: input }),
+      },
+      name: 'MemoizedRejectedInput',
+      renderToolUseRejectedMessage,
+    } as unknown as Tool
+    const { stdin, stdout } = createStreams()
+    const root: Root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    function render(input: { path: string }): void {
+      root.render(
+        <UserToolRejectMessage
+          input={input}
+          progressMessagesForMessage={progressMessagesForMessage}
+          tool={tool}
+          tools={tools}
+          lookups={{} as never}
+          verbose={false}
+        />,
+      )
+    }
+
+    try {
+      render(stableInput)
+      await flushRender()
+      render(stableInput)
+      await flushRender()
+
+      expect(renderToolUseRejectedMessage).toHaveBeenCalledTimes(1)
+
+      render({ path: 'runtime/src/changed.ts' })
+      await flushRender()
+
+      expect(renderToolUseRejectedMessage).toHaveBeenCalledTimes(2)
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushRender()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-146-backpressure.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-146-backpressure.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  formatTuiBackpressureWarning,
+  getTuiBackpressureSnapshot,
+  recordTuiBackpressure,
+  resetTuiBackpressureForTesting,
+  subscribeTuiBackpressure,
+} from '../../../src/tui/backpressure.js'
+
+const subscriptions: Array<() => void> = []
+
+function subscribe(listener: () => void): () => void {
+  const unsubscribe = subscribeTuiBackpressure(listener)
+  subscriptions.push(unsubscribe)
+  return unsubscribe
+}
+
+afterEach(() => {
+  while (subscriptions.length > 0) {
+    subscriptions.pop()?.()
+  }
+  resetTuiBackpressureForTesting()
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+describe('TUI backpressure coverage swarm row 146', () => {
+  test('ignores non-positive and non-finite durations without notifying listeners', () => {
+    const listener = vi.fn()
+    subscribe(listener)
+
+    recordTuiBackpressure({ source: 'input', durationMs: 0, nowMs: 10 })
+    recordTuiBackpressure({ source: 'render', durationMs: -1, nowMs: 10 })
+    recordTuiBackpressure({ source: 'input', durationMs: Number.POSITIVE_INFINITY, nowMs: 10 })
+    recordTuiBackpressure({ source: 'render', durationMs: Number.NaN, nowMs: 10 })
+
+    expect(listener).not.toHaveBeenCalled()
+    expect(getTuiBackpressureSnapshot()).toEqual({
+      active: false,
+      durationMs: 0,
+      expiresAtMs: 0,
+      source: null,
+      startedAtMs: 0,
+    })
+  })
+
+  test('uses current time and the default visible window when optional timing is omitted', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(12_345)
+
+    recordTuiBackpressure({ source: 'input', durationMs: 49.4 })
+
+    expect(getTuiBackpressureSnapshot()).toEqual({
+      active: true,
+      durationMs: 49.4,
+      expiresAtMs: 16_345,
+      source: 'input',
+      startedAtMs: 12_345,
+    })
+    expect(formatTuiBackpressureWarning(getTuiBackpressureSnapshot())).toBe(
+      'Input is catching up after 49ms of blocked key processing',
+    )
+  })
+
+  test('clears expired snapshots synchronously when read after the visible window', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+
+    recordTuiBackpressure({
+      source: 'render',
+      durationMs: 1_250,
+      visibleMs: 25,
+    })
+    vi.setSystemTime(1_026)
+
+    expect(getTuiBackpressureSnapshot()).toEqual({
+      active: false,
+      durationMs: 0,
+      expiresAtMs: 0,
+      source: null,
+      startedAtMs: 0,
+    })
+  })
+
+  test('replaces the pending clear timer and emits only for the current snapshot', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(2_000)
+    const listener = vi.fn()
+    subscribe(listener)
+
+    recordTuiBackpressure({
+      source: 'input',
+      durationMs: 100,
+      visibleMs: 100,
+    })
+    vi.advanceTimersByTime(50)
+    recordTuiBackpressure({
+      source: 'render',
+      durationMs: 1_500,
+      visibleMs: 1_000,
+    })
+    vi.advanceTimersByTime(100)
+
+    expect(listener).toHaveBeenCalledTimes(2)
+    expect(getTuiBackpressureSnapshot()).toMatchObject({
+      active: true,
+      durationMs: 1_500,
+      source: 'render',
+    })
+
+    vi.advanceTimersByTime(900)
+
+    expect(listener).toHaveBeenCalledTimes(3)
+    expect(getTuiBackpressureSnapshot().active).toBe(false)
+  })
+
+  test('does not format inactive or source-less snapshots', () => {
+    expect(
+      formatTuiBackpressureWarning({
+        active: false,
+        durationMs: 900,
+        expiresAtMs: 20,
+        source: 'render',
+        startedAtMs: 10,
+      }),
+    ).toBeNull()
+    expect(
+      formatTuiBackpressureWarning({
+        active: true,
+        durationMs: 900,
+        expiresAtMs: 20,
+        source: null,
+        startedAtMs: 10,
+      }),
+    ).toBeNull()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-147-completion-pipeline.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-147-completion-pipeline.test.ts
@@ -1,0 +1,147 @@
+import { resolve } from "node:path";
+
+import { describe, expect, test } from "vitest";
+
+import {
+  COMPLETION_PIPELINE_EVENT_LOG_ENV,
+  COMPLETION_PIPELINE_EVENT_LOG_PATH,
+  completionPipelineOwnsPrompt,
+  formatCompletionPipelineRows,
+  gateIndexFor,
+  normalizeCompletionPipelineEvent,
+  readCompletionPipelineEvents,
+  reduceCompletionPipelineEvents,
+  resolveCompletionPipelineEventLogPath,
+  safeGateLabel,
+  type CompletionPipelineEvent,
+} from "../completion-pipeline.js";
+
+function event(
+  sequence: number,
+  gateId: string,
+  status: CompletionPipelineEvent["status"],
+  overrides: Partial<CompletionPipelineEvent> = {},
+): CompletionPipelineEvent {
+  return {
+    pipelineId: "row-147",
+    sequence,
+    gateId,
+    gateIndex: gateIndexFor(gateId),
+    status,
+    timestamp: new Date(sequence * 1000).toISOString(),
+    ...overrides,
+  };
+}
+
+describe("completion pipeline coverage swarm row 147", () => {
+  test("resolves default log paths and normalizes optional text fields", () => {
+    expect(resolveCompletionPipelineEventLogPath({}, "/tmp/agenc")).toBe(
+      resolve("/tmp/agenc", COMPLETION_PIPELINE_EVENT_LOG_PATH),
+    );
+    expect(
+      resolveCompletionPipelineEventLogPath(
+        { [COMPLETION_PIPELINE_EVENT_LOG_ENV]: "   " },
+        "/tmp/agenc",
+      ),
+    ).toBe(resolve("/tmp/agenc", COMPLETION_PIPELINE_EVENT_LOG_PATH));
+
+    const normalized = normalizeCompletionPipelineEvent({
+      pipelineId: "row-147",
+      sequence: 4,
+      gateId: "branch_shape",
+      status: "succeeded",
+      message: "  ",
+      detail: 42,
+      timestamp: "2026-05-20T12:00:00.000Z",
+    });
+
+    expect(normalized).toEqual({
+      pipelineId: "row-147",
+      sequence: 4,
+      gateId: "branch_shape",
+      gateIndex: 1,
+      status: "succeeded",
+      timestamp: "2026-05-20T12:00:00.000Z",
+    });
+  });
+
+  test("returns no events for a missing default log and parses only valid lines", () => {
+    expect(
+      readCompletionPipelineEvents({
+        env: {},
+        cwd: "/tmp/agenc-row-147-missing-log-root",
+      }),
+    ).toEqual([]);
+
+    const valid = event(1, "prep", "started");
+    expect(
+      readCompletionPipelineEvents({
+        readFile: () =>
+          [
+            "",
+            "not json",
+            JSON.stringify({ pipelineId: "row-147", gateId: "prep" }),
+            JSON.stringify(valid),
+          ].join("\r\n"),
+      }),
+    ).toEqual([valid]);
+  });
+
+  test("keeps a later active gate when an earlier gate succeeds", () => {
+    const state = reduceCompletionPipelineEvents([
+      event(1, "prep", "started"),
+      event(2, "typecheck", "started"),
+      event(3, "prep", "succeeded"),
+    ]);
+
+    expect(state.gates.find((gate) => gate.gateId === "prep")).toMatchObject({
+      status: "succeeded",
+      started: true,
+    });
+    expect(state.activeGate).toMatchObject({ gateId: "typecheck" });
+    expect(completionPipelineOwnsPrompt(state)).toBe(true);
+    expect(formatCompletionPipelineRows(state)).toContain(
+      "Completion 6/9: Typecheck running",
+    );
+  });
+
+  test("flushes multiple held terminal events after their matching start", () => {
+    const state = reduceCompletionPipelineEvents([
+      event(1, "typecheck", "succeeded"),
+      event(2, "typecheck", "failed", { message: "compiler failed" }),
+      event(3, "typecheck", "started"),
+    ]);
+
+    expect(state.gates).toHaveLength(1);
+    expect(state.gates[0]).toMatchObject({
+      gateId: "typecheck",
+      status: "failed",
+      message: "compiler failed",
+      started: true,
+    });
+    expect(state.activeGate).toBeNull();
+    expect(formatCompletionPipelineRows(state)).toEqual([
+      "Completion 6/9: Typecheck failed",
+      "Completion pipeline failed at Typecheck: compiler failed",
+    ]);
+  });
+
+  test("sorts same-index custom gates by sequence and formats cancellation details", () => {
+    const state = reduceCompletionPipelineEvents([
+      event(2, "zeta_gate", "started", { gateIndex: 99 }),
+      event(1, "alpha-gate", "started", { gateIndex: 99 }),
+      event(3, "zeta_gate", "cancelled", {
+        gateIndex: 99,
+        detail: "operator stopped it",
+      }),
+    ]);
+
+    expect(safeGateLabel("alpha-gate")).toBe("alpha gate");
+    expect(formatCompletionPipelineRows(state)).toEqual([
+      "Completion ?/9: alpha gate running",
+      "Completion ?/9: zeta gate cancelled: operator stopped it",
+      "Completion pipeline cancelled: operator stopped it",
+    ]);
+    expect(completionPipelineOwnsPrompt(state)).toBe(false);
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-148-components-design-system-Byline.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-148-components-design-system-Byline.test.tsx
@@ -1,0 +1,204 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+import { Byline } from '../../../src/tui/components/design-system/Byline.js'
+import type { DOMElement, DOMNode } from '../../../src/tui/ink/dom.js'
+import instances from '../../../src/tui/ink/instances.js'
+import { createRoot } from '../../../src/tui/ink/root.js'
+import type { TextStyles } from '../../../src/tui/ink/styles.js'
+import { Text } from '../../../src/tui/ink.js'
+import { selectAgenCTuiGlyphs } from '../../../src/tui/glyphs.js'
+import { getTheme } from '../../../src/utils/theme.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestStdout = PassThrough & {
+  columns: number
+  isTTY: boolean
+  rows: number
+}
+
+type TestRoot = Awaited<ReturnType<typeof createRoot>>
+
+type StyledSegment = {
+  text: string
+  styles: TextStyles
+}
+
+const mountedRoots: Array<{
+  root: TestRoot
+  stdin: TestStdin
+  stdout: TestStdout
+}> = []
+
+let originalGlyphMode: string | undefined
+
+function createStreams(): { stdin: TestStdin; stdout: TestStdout } {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough() as TestStdout
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 80
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 30): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function getRootNode(stdout: TestStdout): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+
+  if (!instance?.rootNode) {
+    throw new Error('Ink root node not found')
+  }
+
+  return instance.rootNode
+}
+
+function collectSegments(
+  node: DOMNode,
+  inheritedStyles: TextStyles = {},
+  segments: StyledSegment[] = [],
+): StyledSegment[] {
+  if (node.nodeName === '#text') {
+    if (node.nodeValue !== '') {
+      segments.push({ text: node.nodeValue, styles: inheritedStyles })
+    }
+
+    return segments
+  }
+
+  const nextStyles = node.textStyles
+    ? { ...inheritedStyles, ...node.textStyles }
+    : inheritedStyles
+
+  for (const child of node.childNodes) {
+    collectSegments(child, nextStyles, segments)
+  }
+
+  return segments
+}
+
+async function renderByline(node: React.ReactNode): Promise<{
+  segments: () => StyledSegment[]
+  text: () => string
+}> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  mountedRoots.push({ root, stdin, stdout })
+  root.render(node)
+  await sleep()
+
+  return {
+    segments: () => collectSegments(getRootNode(stdout)),
+    text: () =>
+      collectSegments(getRootNode(stdout))
+        .map(segment => segment.text)
+        .join(''),
+  }
+}
+
+beforeEach(() => {
+  originalGlyphMode = process.env.AGENC_TUI_GLYPHS
+  delete process.env.AGENC_TUI_GLYPHS
+})
+
+afterEach(() => {
+  for (const { root, stdin, stdout } of mountedRoots.splice(0)) {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    instances.delete(stdout as unknown as NodeJS.WriteStream)
+  }
+
+  if (originalGlyphMode === undefined) {
+    delete process.env.AGENC_TUI_GLYPHS
+  } else {
+    process.env.AGENC_TUI_GLYPHS = originalGlyphMode
+  }
+})
+
+describe('Byline coverage swarm row 148', () => {
+  test('renders nothing when every child is filtered out by React children traversal', async () => {
+    const rendered = await renderByline(
+      <Byline>
+        {null}
+        {false}
+        {undefined}
+      </Byline>,
+    )
+
+    expect(rendered.text()).toBe('')
+    expect(rendered.segments()).toEqual([])
+  })
+
+  test('joins element children with a dim unicode separator', async () => {
+    const separator = selectAgenCTuiGlyphs({
+      AGENC_TUI_GLYPHS: 'unicode',
+    }).separator
+    const separatorStyles = { color: getTheme('dark').inactive }
+    const rendered = await renderByline(
+      <Byline>
+        <Text>Alpha</Text>
+        <Text>Beta</Text>
+        <Text>Gamma</Text>
+      </Byline>,
+    )
+
+    expect(rendered.text()).toBe(
+      `Alpha ${separator} Beta ${separator} Gamma`,
+    )
+    expect(rendered.segments()).toEqual([
+      { text: 'Alpha', styles: {} },
+      { text: ` ${separator} `, styles: separatorStyles },
+      { text: 'Beta', styles: {} },
+      { text: ` ${separator} `, styles: separatorStyles },
+      { text: 'Gamma', styles: {} },
+    ])
+  })
+
+  test('uses the ascii separator and supports primitive children', async () => {
+    process.env.AGENC_TUI_GLYPHS = 'ascii'
+
+    const separator = selectAgenCTuiGlyphs({
+      AGENC_TUI_GLYPHS: 'ascii',
+    }).separator
+    const separatorStyles = { color: getTheme('dark').inactive }
+    const rendered = await renderByline(
+      <Byline>
+        <Text>Element child</Text>
+        primitive child
+      </Byline>,
+    )
+
+    expect(rendered.text()).toBe(
+      `Element child ${separator} primitive child`,
+    )
+    expect(rendered.segments()).toEqual([
+      { text: 'Element child', styles: {} },
+      { text: ` ${separator} `, styles: separatorStyles },
+      { text: 'primitive child', styles: {} },
+    ])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-149-components-design-system-Divider.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-149-components-design-system-Divider.test.tsx
@@ -1,0 +1,179 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { Divider } from '../../../src/tui/components/design-system/Divider.js'
+import type { DOMElement, DOMNode } from '../../../src/tui/ink/dom.js'
+import instances from '../../../src/tui/ink/instances.js'
+import { createRoot } from '../../../src/tui/ink/root.js'
+import type { TextStyles } from '../../../src/tui/ink/styles.js'
+import { getTheme } from '../../../src/utils/theme.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestRoot = Awaited<ReturnType<typeof createRoot>>
+
+type StyledSegment = {
+  text: string
+  styles: TextStyles
+}
+
+const mountedRoots: Array<{
+  root: TestRoot
+  stdin: TestStdin
+  stdout: PassThrough
+}> = []
+
+function createStreams(columns = 12): { stdin: TestStdin; stdout: PassThrough } {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough()
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = columns
+  ;(stdout as unknown as { rows: number }).rows = 24
+  ;(stdout as unknown as { isTTY: boolean }).isTTY = true
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 30): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+
+  if (!instance?.rootNode) {
+    throw new Error('Ink root node not found')
+  }
+
+  return instance.rootNode
+}
+
+function collectSegments(
+  node: DOMNode,
+  inheritedStyles: TextStyles = {},
+  segments: StyledSegment[] = [],
+): StyledSegment[] {
+  if (node.nodeName === '#text') {
+    if (node.nodeValue !== '') {
+      segments.push({ text: node.nodeValue, styles: inheritedStyles })
+    }
+    return segments
+  }
+
+  const nextStyles = node.textStyles
+    ? { ...inheritedStyles, ...node.textStyles }
+    : inheritedStyles
+
+  for (const child of node.childNodes) {
+    collectSegments(child, nextStyles, segments)
+  }
+
+  return segments
+}
+
+async function renderDivider(
+  node: React.ReactNode,
+  columns?: number,
+): Promise<{
+  rerender: (next: React.ReactNode) => Promise<void>
+  segments: () => StyledSegment[]
+  text: () => string
+}> {
+  const { stdin, stdout } = createStreams(columns)
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  mountedRoots.push({ root, stdin, stdout })
+
+  const rerender = async (next: React.ReactNode) => {
+    root.render(next)
+    await sleep()
+  }
+
+  await rerender(node)
+
+  return {
+    rerender,
+    segments: () => collectSegments(getRootNode(stdout)),
+    text: () =>
+      collectSegments(getRootNode(stdout))
+        .map(segment => segment.text)
+        .join(''),
+  }
+}
+
+afterEach(() => {
+  for (const { root, stdin, stdout } of mountedRoots.splice(0)) {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    instances.delete(stdout as unknown as NodeJS.WriteStream)
+  }
+})
+
+describe('Divider coverage swarm row 149', () => {
+  test('rerenders the terminal-width divider through the cached untitled branch', async () => {
+    const theme = getTheme('dark')
+    const divider = <Divider char="*" padding={2} />
+    const rendered = await renderDivider(divider, 8)
+
+    expect(rendered.text()).toBe('******')
+    expect(rendered.segments()).toEqual([
+      { text: '******', styles: { color: theme.inactive } },
+    ])
+
+    await rendered.rerender(divider)
+
+    expect(rendered.text()).toBe('******')
+    expect(rendered.segments()).toEqual([
+      { text: '******', styles: { color: theme.inactive } },
+    ])
+  })
+
+  test('rerenders a colored titled divider through cached side and title branches', async () => {
+    const theme = getTheme('dark')
+    const divider = (
+      <Divider
+        char="-"
+        color="suggestion"
+        title={'\u001b[1mGo\u001b[22m'}
+        width={8}
+      />
+    )
+    const rendered = await renderDivider(divider)
+
+    expect(rendered.text()).toBe('-- Go --')
+    expect(rendered.segments()).toEqual([
+      { text: '--', styles: { color: theme.suggestion } },
+      { text: ' ', styles: { color: theme.suggestion } },
+      { text: 'Go', styles: { color: theme.inactive, bold: true } },
+      { text: ' ', styles: { color: theme.suggestion } },
+      { text: '--', styles: { color: theme.suggestion } },
+    ])
+
+    await rendered.rerender(divider)
+
+    expect(rendered.text()).toBe('-- Go --')
+    expect(rendered.segments()).toEqual([
+      { text: '--', styles: { color: theme.suggestion } },
+      { text: ' ', styles: { color: theme.suggestion } },
+      { text: 'Go', styles: { color: theme.inactive, bold: true } },
+      { text: ' ', styles: { color: theme.suggestion } },
+      { text: '--', styles: { color: theme.suggestion } },
+    ])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-150-components-design-system-LoadingState.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-150-components-design-system-LoadingState.test.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const compilerRuntime = vi.hoisted(() => {
+  const sentinel = Symbol.for("react.memo_cache_sentinel");
+  let cache: unknown[] = [];
+
+  function reset(size = 10): void {
+    cache = Array.from({ length: size }, () => sentinel);
+  }
+
+  reset();
+
+  return {
+    c: vi.fn((size: number) => {
+      if (cache.length !== size) reset(size);
+      return cache;
+    }),
+    reset,
+  };
+});
+
+const spinnerFixture = vi.hoisted(() => ({
+  Spinner: function MockSpinner() {
+    return null;
+  },
+}));
+
+vi.mock("react-compiler-runtime", () => ({
+  c: compilerRuntime.c,
+}));
+
+vi.mock("../../../src/tui/components/spinner/Spinner.js", () => ({
+  Spinner: spinnerFixture.Spinner,
+}));
+
+import { LoadingState } from "../../../src/tui/components/design-system/LoadingState.js";
+
+type LoadingStateElement = React.ReactElement<{
+  children?: React.ReactNode;
+  flexDirection?: string;
+}>;
+
+type TextElement = React.ReactElement<{
+  bold?: boolean;
+  children?: React.ReactNode;
+  dimColor?: boolean;
+}>;
+
+function requireElement(node: React.ReactNode, label: string): LoadingStateElement {
+  expect(React.isValidElement(node), label).toBe(true);
+  return node as LoadingStateElement;
+}
+
+function childrenOf(element: LoadingStateElement): React.ReactNode[] {
+  return React.Children.toArray(element.props.children);
+}
+
+function renderLoadingState(
+  props: React.ComponentProps<typeof LoadingState>,
+): LoadingStateElement {
+  return requireElement(LoadingState(props), "LoadingState root");
+}
+
+describe("LoadingState coverage swarm row 150", () => {
+  beforeEach(() => {
+    compilerRuntime.reset();
+    compilerRuntime.c.mockClear();
+  });
+
+  test("renders the default loading row without a subtitle and reuses memoized output", () => {
+    const first = renderLoadingState({ message: "Loading sessions" });
+    const rootChildren = childrenOf(first);
+    const row = requireElement(rootChildren[0], "loading row");
+    const rowChildren = childrenOf(row);
+    const message = requireElement(rowChildren[1], "message text") as TextElement;
+
+    expect(compilerRuntime.c).toHaveBeenCalledWith(10);
+    expect(first.props.flexDirection).toBe("column");
+    expect(rootChildren).toHaveLength(1);
+    expect(row.props.flexDirection).toBe("row");
+    expect(requireElement(rowChildren[0], "spinner").type).toBe(
+      spinnerFixture.Spinner,
+    );
+    expect(message.props).toMatchObject({
+      bold: false,
+      dimColor: false,
+    });
+    expect(message.props.children).toEqual([" ", "Loading sessions"]);
+
+    const second = renderLoadingState({ message: "Loading sessions" });
+
+    expect(second).toBe(first);
+  });
+
+  test("applies explicit emphasis props and adds a dim subtitle", () => {
+    const withoutSubtitle = renderLoadingState({ message: "Loading" });
+
+    const withSubtitle = renderLoadingState({
+      bold: true,
+      dimColor: true,
+      message: "Loading teams",
+      subtitle: "Fetching project state",
+    });
+    const rootChildren = childrenOf(withSubtitle);
+    const row = requireElement(rootChildren[0], "loading row");
+    const rowChildren = childrenOf(row);
+    const message = requireElement(rowChildren[1], "message text") as TextElement;
+    const subtitle = requireElement(rootChildren[1], "subtitle") as TextElement;
+
+    expect(withSubtitle).not.toBe(withoutSubtitle);
+    expect(requireElement(rowChildren[0], "spinner").type).toBe(
+      spinnerFixture.Spinner,
+    );
+    expect(message.props).toMatchObject({
+      bold: true,
+      dimColor: true,
+    });
+    expect(message.props.children).toEqual([" ", "Loading teams"]);
+    expect(subtitle.props).toMatchObject({ dimColor: true });
+    expect(subtitle.props.children).toBe("Fetching project state");
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-151-components-shell-ShellTimeDisplay.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-151-components-shell-ShellTimeDisplay.test.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { describe, expect, test } from "vitest";
+
+import { ShellTimeDisplay } from "../../../src/tui/components/shell/ShellTimeDisplay.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+describe("ShellTimeDisplay coverage swarm row 151", () => {
+  test("renders nothing when neither elapsed time nor timeout is available", async () => {
+    const output = await renderToString(<ShellTimeDisplay />);
+
+    expect(output.trim()).toBe("");
+  });
+
+  test("renders timeout-only state with trailing zero units hidden", async () => {
+    const output = await renderToString(
+      <ShellTimeDisplay timeoutMs={120_000} />,
+    );
+
+    expect(output).toBe("(timeout 2m)");
+  });
+
+  test("renders elapsed time without timeout metadata", async () => {
+    const output = await renderToString(
+      <ShellTimeDisplay elapsedTimeSeconds={65} timeoutMs={undefined} />,
+    );
+
+    expect(output).toBe("(1m 5s)");
+  });
+
+  test("renders elapsed time and timeout metadata together", async () => {
+    const output = await renderToString(
+      <ShellTimeDisplay elapsedTimeSeconds={65} timeoutMs={120_000} />,
+    );
+
+    expect(output).toContain("(1m 5s");
+    expect(output).toContain("timeout 2m)");
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-152-hooks-usePrStatus.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-152-hooks-usePrStatus.test.ts
@@ -1,0 +1,248 @@
+import { PassThrough } from 'node:stream'
+
+import React, { act } from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const fixture = vi.hoisted(() => ({
+  fetchPrStatus: vi.fn(),
+  interactionTime: 1,
+}))
+
+vi.mock('../../../src/tui/bootstrap/state.js', () => ({
+  getLastInteractionTime: () => fixture.interactionTime,
+}))
+
+vi.mock('../../../src/utils/ghPrStatus.js', () => ({
+  fetchPrStatus: fixture.fetchPrStatus,
+}))
+
+import { createRoot } from '../../../src/tui/ink.js'
+import {
+  type PrStatusState,
+  usePrStatus,
+} from '../../../src/tui/hooks/usePrStatus.js'
+
+type HookProps = {
+  readonly enabled: boolean
+  readonly isLoading: boolean
+}
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough & {
+    columns: number
+    isTTY: boolean
+    rows: number
+  }
+}
+
+const POLL_INTERVAL_MS = 60_000
+const IDLE_STOP_MS = 60 * 60_000
+const realSetImmediate = setImmediate
+
+function createStreams(): TestStreams {
+  const stdin = new PassThrough() as TestStreams['stdin']
+  const stdout = new PassThrough() as TestStreams['stdout']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 100
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function flushEffects(ms = 0): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms)
+    await Promise.resolve()
+  })
+  await new Promise<void>(resolve => realSetImmediate(resolve))
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  let lastError: unknown
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await flushEffects()
+    }
+  }
+  throw lastError
+}
+
+async function renderHookHarness(
+  initialProps: HookProps,
+): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly latest: () => PrStatusState
+  readonly render: (next: Partial<HookProps>) => Promise<void>
+}> {
+  let latest: PrStatusState | undefined
+  let props = initialProps
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    latest = usePrStatus(props.isLoading, props.enabled)
+    return null
+  }
+
+  async function render(next: Partial<HookProps> = {}): Promise<void> {
+    props = { ...props, ...next }
+    await act(async () => {
+      root.render(React.createElement(Harness))
+    })
+    await flushEffects()
+  }
+
+  await render()
+
+  return {
+    dispose: async () => {
+      await act(async () => {
+        root.unmount()
+      })
+      stdin.end()
+      stdout.end()
+      await flushEffects()
+    },
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+    render,
+  }
+}
+
+describe('usePrStatus coverage swarm row 152', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(120_000)
+    fixture.fetchPrStatus.mockReset()
+    fixture.interactionTime = 1
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  test('does not fetch or schedule polling when disabled', async () => {
+    fixture.fetchPrStatus.mockResolvedValue({
+      number: 152,
+      reviewState: 'approved',
+      url: 'https://example.test/pull/152',
+    })
+    const rendered = await renderHookHarness({
+      enabled: false,
+      isLoading: false,
+    })
+
+    try {
+      expect(rendered.latest()).toEqual({
+        number: null,
+        reviewState: null,
+        url: null,
+        lastUpdated: 0,
+      })
+
+      await flushEffects(POLL_INTERVAL_MS * 2)
+      await rendered.render({ isLoading: true })
+      await flushEffects(POLL_INTERVAL_MS * 2)
+
+      expect(fixture.fetchPrStatus).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('clears the previous PR status when a later poll finds no PR', async () => {
+    fixture.fetchPrStatus
+      .mockResolvedValueOnce({
+        number: 152,
+        reviewState: 'changes_requested',
+        url: 'https://example.test/pull/152',
+      })
+      .mockResolvedValueOnce(null)
+    const rendered = await renderHookHarness({
+      enabled: true,
+      isLoading: false,
+    })
+
+    try {
+      await waitFor(() => {
+        expect(rendered.latest()).toMatchObject({
+          number: 152,
+          reviewState: 'changes_requested',
+          url: 'https://example.test/pull/152',
+        })
+      })
+      const firstUpdated = rendered.latest().lastUpdated
+
+      await flushEffects(POLL_INTERVAL_MS)
+      await waitFor(() => {
+        expect(fixture.fetchPrStatus).toHaveBeenCalledTimes(2)
+      })
+
+      expect(rendered.latest()).toEqual({
+        number: null,
+        reviewState: null,
+        url: null,
+        lastUpdated: expect.any(Number),
+      })
+      expect(rendered.latest().lastUpdated).toBeGreaterThan(firstUpdated)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('stops polling once the session has been idle for an hour', async () => {
+    fixture.fetchPrStatus.mockResolvedValue({
+      number: 152,
+      reviewState: 'pending',
+      url: 'https://example.test/pull/152',
+    })
+    const rendered = await renderHookHarness({
+      enabled: true,
+      isLoading: false,
+    })
+
+    try {
+      await waitFor(() => {
+        expect(fixture.fetchPrStatus).toHaveBeenCalledTimes(1)
+      })
+
+      vi.setSystemTime(Date.now() + IDLE_STOP_MS)
+      await flushEffects(POLL_INTERVAL_MS)
+
+      expect(fixture.fetchPrStatus).toHaveBeenCalledTimes(1)
+
+      await flushEffects(POLL_INTERVAL_MS)
+
+      expect(fixture.fetchPrStatus).toHaveBeenCalledTimes(1)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-153-hooks-useSearchInput.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-153-hooks-useSearchInput.test.ts
@@ -1,0 +1,292 @@
+import { PassThrough } from 'node:stream'
+
+import React, { act } from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const terminalSizeFixture = vi.hoisted(() => {
+  const state = { columns: 7 }
+
+  return {
+    state,
+    useTerminalSize: vi.fn(() => ({ columns: state.columns, rows: 24 })),
+  }
+})
+
+vi.mock('../../../src/tui/hooks/useTerminalSize.js', () => ({
+  useTerminalSize: terminalSizeFixture.useTerminalSize,
+}))
+
+vi.mock('../../../src/utils/debug.js', () => ({
+  logForDebugging: () => {},
+}))
+
+vi.mock('../../../src/bootstrap/state.js', () => ({
+  flushInteractionTime: () => {},
+  getActiveTimeCounter: () => 0,
+  markScrollActivity: () => {},
+  updateLastInteractionTime: () => {},
+}))
+
+vi.mock('../../../src/utils/earlyInput.js', () => ({
+  stopCapturingEarlyInput: () => {},
+}))
+
+vi.mock('../../../src/utils/envUtils.js', () => ({
+  isEnvTruthy: () => false,
+}))
+
+vi.mock('../../../src/utils/fullscreen.js', () => ({
+  isMouseClicksDisabled: () => true,
+}))
+
+vi.mock('../../../src/utils/log.js', () => ({
+  logError: () => {},
+}))
+
+import { createRoot } from '../../../src/tui/ink/root.js'
+import { clearKillRing } from '../../../src/utils/TextCursor.js'
+import { useSearchInput } from '../../../src/tui/hooks/useSearchInput.js'
+
+type SearchInputState = ReturnType<typeof useSearchInput>
+type SearchInputKey = Parameters<SearchInputState['handleKeyDown']>[0]
+
+type HookProps = {
+  readonly backspaceExitsOnEmpty?: boolean
+  readonly columns?: number
+  readonly initialQuery?: string
+  readonly isActive?: boolean
+  readonly onCancel?: () => void
+  readonly onExit: () => void
+  readonly onExitUp?: () => void
+  readonly passthroughCtrlKeys?: string[]
+}
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough & {
+    columns: number
+    isTTY: boolean
+    rows: number
+  }
+}
+
+function createStreams(): TestStreams {
+  const stdin = new PassThrough() as TestStreams['stdin']
+  const stdout = new PassThrough() as TestStreams['stdout']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 120
+  stdout.rows = 30
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function key(
+  keyName: string,
+  modifiers: Partial<Pick<SearchInputKey, 'ctrl' | 'fn' | 'meta'>> = {},
+): SearchInputKey & { preventDefault: ReturnType<typeof vi.fn> } {
+  return {
+    ctrl: modifiers.ctrl ?? false,
+    fn: modifiers.fn ?? false,
+    key: keyName,
+    meta: modifiers.meta ?? false,
+    preventDefault: vi.fn(),
+  } as SearchInputKey & { preventDefault: ReturnType<typeof vi.fn> }
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 0))
+  })
+}
+
+async function renderSearchInput(
+  initialProps: HookProps,
+): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly latest: () => SearchInputState
+  readonly press: (
+    event: SearchInputKey & { preventDefault: ReturnType<typeof vi.fn> },
+  ) => Promise<void>
+  readonly render: (next?: Partial<HookProps>) => Promise<void>
+}> {
+  let latest: SearchInputState | undefined
+  let props: HookProps = initialProps
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    latest = useSearchInput({
+      backspaceExitsOnEmpty: props.backspaceExitsOnEmpty,
+      columns: props.columns,
+      initialQuery: props.initialQuery,
+      isActive: props.isActive ?? true,
+      onCancel: props.onCancel,
+      onExit: props.onExit,
+      onExitUp: props.onExitUp,
+      passthroughCtrlKeys: props.passthroughCtrlKeys,
+    })
+    return null
+  }
+
+  async function render(next: Partial<HookProps> = {}): Promise<void> {
+    props = { ...props, ...next }
+    await act(async () => {
+      root.render(React.createElement(Harness))
+    })
+    await flushEffects()
+  }
+
+  await render()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushEffects()
+    },
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+    press: async event => {
+      await act(async () => {
+        latest?.handleKeyDown(event)
+      })
+      await flushEffects()
+    },
+    render,
+  }
+}
+
+describe('useSearchInput coverage swarm row 153', () => {
+  beforeEach(() => {
+    clearKillRing()
+    terminalSizeFixture.state.columns = 7
+    terminalSizeFixture.useTerminalSize.mockClear()
+  })
+
+  afterEach(() => {
+    clearKillRing()
+    vi.restoreAllMocks()
+  })
+
+  test('uses terminal columns by default and handles exit keys without optional callbacks', async () => {
+    const onExit = vi.fn()
+    const rendered = await renderSearchInput({
+      initialQuery: 'query',
+      onExit,
+    })
+
+    try {
+      expect(rendered.latest()).toMatchObject({
+        cursorOffset: 'query'.length,
+        query: 'query',
+      })
+      expect(terminalSizeFixture.useTerminalSize).toHaveBeenCalled()
+
+      const up = key('up')
+      await rendered.press(up)
+      expect(up.preventDefault).toHaveBeenCalledTimes(1)
+      expect(onExit).not.toHaveBeenCalled()
+
+      const down = key('down')
+      await rendered.press(down)
+      expect(down.preventDefault).toHaveBeenCalledTimes(1)
+      expect(onExit).toHaveBeenCalledTimes(1)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('routes empty-query destructive shortcuts through configured fallback exits', async () => {
+    const onCancel = vi.fn()
+    const onExit = vi.fn()
+    const rendered = await renderSearchInput({ onExit })
+
+    try {
+      await rendered.press(key('backspace'))
+      expect(onExit).toHaveBeenCalledTimes(1)
+
+      await rendered.press(key('d', { ctrl: true }))
+      expect(onExit).toHaveBeenCalledTimes(2)
+
+      await rendered.render({ onCancel })
+      await rendered.press(key('h', { ctrl: true }))
+      expect(onCancel).toHaveBeenCalledTimes(1)
+
+      await rendered.render({ backspaceExitsOnEmpty: false })
+      await rendered.press(key('h', { ctrl: true }))
+      expect(onCancel).toHaveBeenCalledTimes(1)
+      expect(onExit).toHaveBeenCalledTimes(2)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('leaves passthrough and no-op yank inputs untouched', async () => {
+    const onExit = vi.fn()
+    const rendered = await renderSearchInput({
+      initialQuery: 'seed',
+      onExit,
+      passthroughCtrlKeys: ['n'],
+    })
+
+    try {
+      const passthrough = key('N', { ctrl: true })
+      await rendered.press(passthrough)
+      expect(passthrough.preventDefault).not.toHaveBeenCalled()
+      expect(rendered.latest()).toMatchObject({
+        cursorOffset: 'seed'.length,
+        query: 'seed',
+      })
+
+      const emptyYank = key('y', { ctrl: true })
+      await rendered.press(emptyYank)
+      expect(emptyYank.preventDefault).toHaveBeenCalledTimes(1)
+      expect(rendered.latest()).toMatchObject({
+        cursorOffset: 'seed'.length,
+        query: 'seed',
+      })
+
+      const emptyYankPop = key('y', { meta: true })
+      await rendered.press(emptyYankPop)
+      expect(emptyYankPop.preventDefault).toHaveBeenCalledTimes(1)
+      expect(rendered.latest()).toMatchObject({
+        cursorOffset: 'seed'.length,
+        query: 'seed',
+      })
+
+      const cancelWithoutHandler = key('c', { ctrl: true })
+      await rendered.press(cancelWithoutHandler)
+      expect(cancelWithoutHandler.preventDefault).toHaveBeenCalledTimes(1)
+      expect(onExit).not.toHaveBeenCalled()
+
+      const emptyInput = key('')
+      await rendered.press(emptyInput)
+      expect(emptyInput.preventDefault).not.toHaveBeenCalled()
+      expect(rendered.latest()).toMatchObject({
+        cursorOffset: 'seed'.length,
+        query: 'seed',
+      })
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-154-ink-renderer.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-154-ink-renderer.test.ts
@@ -1,0 +1,247 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { DOMElement } from '../../../src/tui/ink/dom.js'
+import type { Frame } from '../../../src/tui/ink/frame.js'
+import { addPendingClear } from '../../../src/tui/ink/node-cache.js'
+import createRenderer, {
+  type RenderOptions,
+} from '../../../src/tui/ink/renderer.js'
+import {
+  charInCellAt,
+  CharPool,
+  createScreen,
+  HyperlinkPool,
+  StylePool,
+} from '../../../src/tui/ink/screen.js'
+
+const mocks = vi.hoisted(() => ({
+  getScrollDrainNode: vi.fn(),
+  getScrollHint: vi.fn(),
+  logForDebugging: vi.fn(),
+  renderNodeToOutput: vi.fn(),
+  resetLayoutShifted: vi.fn(),
+  resetScrollDrainNode: vi.fn(),
+  resetScrollHint: vi.fn(),
+}))
+
+vi.mock('../../../src/utils/debug.js', () => ({
+  logForDebugging: mocks.logForDebugging,
+}))
+
+vi.mock('../../../src/tui/ink/render-node-to-output.js', () => ({
+  default: mocks.renderNodeToOutput,
+  getScrollDrainNode: mocks.getScrollDrainNode,
+  getScrollHint: mocks.getScrollHint,
+  resetLayoutShifted: mocks.resetLayoutShifted,
+  resetScrollDrainNode: mocks.resetScrollDrainNode,
+  resetScrollHint: mocks.resetScrollHint,
+}))
+
+type Pools = {
+  charPool: CharPool
+  hyperlinkPool: HyperlinkPool
+  stylePool: StylePool
+}
+
+function makePools(): Pools {
+  return {
+    charPool: new CharPool(),
+    hyperlinkPool: new HyperlinkPool(),
+    stylePool: new StylePool(),
+  }
+}
+
+function makeFrame(
+  width: number,
+  height: number,
+  pools: Pools = makePools(),
+): Frame {
+  return {
+    cursor: { visible: true, x: 0, y: 0 },
+    screen: createScreen(
+      width,
+      height,
+      pools.stylePool,
+      pools.charPool,
+      pools.hyperlinkPool,
+    ),
+    viewport: { height, width },
+  }
+}
+
+function makeOptions(
+  pools: Pools,
+  overrides: Partial<RenderOptions> = {},
+): RenderOptions {
+  return {
+    altScreen: false,
+    backFrame: makeFrame(8, 4, pools),
+    frontFrame: makeFrame(8, 4, pools),
+    isTTY: true,
+    prevFrameContaminated: false,
+    terminalRows: 4,
+    terminalWidth: 8,
+    ...overrides,
+  }
+}
+
+function makeNode(width: number, height: number): DOMElement {
+  return {
+    attributes: {},
+    childNodes: [],
+    dirty: false,
+    nodeName: 'ink-root',
+    parentNode: undefined,
+    style: {},
+    yogaNode: {
+      getComputedHeight: vi.fn(() => height),
+      getComputedWidth: vi.fn(() => width),
+    } as unknown as DOMElement['yogaNode'],
+  }
+}
+
+function makeNodeWithoutYoga(): DOMElement {
+  return {
+    attributes: {},
+    childNodes: [],
+    dirty: false,
+    nodeName: 'ink-root',
+    parentNode: undefined,
+    style: {},
+  }
+}
+
+describe('createRenderer coverage swarm row 154', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getScrollDrainNode.mockReturnValue(null)
+    mocks.getScrollHint.mockReturnValue(null)
+    mocks.renderNodeToOutput.mockImplementation((_node, output) => {
+      output.write(0, 0, 'A')
+    })
+  })
+
+  test('returns an empty frame for missing or invalid yoga dimensions', () => {
+    const pools = makePools()
+    const missingYogaRenderer = createRenderer(
+      makeNodeWithoutYoga(),
+      pools.stylePool,
+    )
+
+    const missingYogaFrame = missingYogaRenderer(makeOptions(pools))
+
+    expect(missingYogaFrame.screen.width).toBe(8)
+    expect(missingYogaFrame.screen.height).toBe(0)
+    expect(missingYogaFrame.viewport).toEqual({ width: 8, height: 4 })
+    expect(missingYogaFrame.cursor).toEqual({ x: 0, y: 0, visible: true })
+    expect(mocks.renderNodeToOutput).not.toHaveBeenCalled()
+    expect(mocks.logForDebugging).not.toHaveBeenCalled()
+
+    const invalidRenderer = createRenderer(
+      makeNode(Number.POSITIVE_INFINITY, -1),
+      pools.stylePool,
+    )
+
+    const invalidFrame = invalidRenderer(makeOptions(pools))
+
+    expect(invalidFrame.screen.width).toBe(8)
+    expect(invalidFrame.screen.height).toBe(0)
+    expect(mocks.renderNodeToOutput).not.toHaveBeenCalled()
+    expect(mocks.logForDebugging).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid yoga dimensions'),
+    )
+  })
+
+  test('renders a scrollback frame and reuses the output on the next frame', () => {
+    const pools = makePools()
+    const node = makeNode(5, 2)
+    const renderer = createRenderer(node, pools.stylePool)
+    const options = makeOptions(pools, {
+      isTTY: false,
+      terminalRows: 10,
+      terminalWidth: 12,
+    })
+
+    const firstFrame = renderer(options)
+    expect(firstFrame.screen.width).toBe(5)
+    expect(firstFrame.screen.height).toBe(2)
+    expect(charInCellAt(firstFrame.screen, 0, 0)).toBe('A')
+    expect(firstFrame.viewport).toEqual({ width: 12, height: 10 })
+    expect(firstFrame.cursor).toEqual({ x: 0, y: 2, visible: true })
+    expect(firstFrame.scrollHint).toBeNull()
+    expect(firstFrame.scrollDrainPending).toBe(false)
+
+    mocks.renderNodeToOutput.mockImplementationOnce((_node, output) => {
+      output.write(0, 0, 'B')
+    })
+    const secondFrame = renderer(options)
+
+    expect(secondFrame.screen.width).toBe(5)
+    expect(secondFrame.screen.height).toBe(2)
+    expect(charInCellAt(secondFrame.screen, 0, 0)).toBe('B')
+    expect(mocks.renderNodeToOutput).toHaveBeenCalledTimes(2)
+    expect(mocks.renderNodeToOutput).toHaveBeenNthCalledWith(
+      1,
+      node,
+      expect.anything(),
+      { prevScreen: options.frontFrame.screen },
+    )
+    expect(mocks.resetLayoutShifted).toHaveBeenCalledTimes(2)
+    expect(mocks.resetScrollHint).toHaveBeenCalledTimes(2)
+    expect(mocks.resetScrollDrainNode).toHaveBeenCalledTimes(2)
+  })
+
+  test('disables previous-screen blits after contamination or absolute removals', () => {
+    const pools = makePools()
+    const node = makeNode(5, 2)
+    const renderer = createRenderer(node, pools.stylePool)
+
+    renderer(makeOptions(pools, { prevFrameContaminated: true }))
+
+    expect(mocks.renderNodeToOutput).toHaveBeenLastCalledWith(
+      node,
+      expect.anything(),
+      { prevScreen: undefined },
+    )
+
+    addPendingClear(node, { height: 1, width: 1, x: 0, y: 0 }, true)
+    renderer(makeOptions(pools, { prevFrameContaminated: false }))
+
+    expect(mocks.renderNodeToOutput).toHaveBeenLastCalledWith(
+      node,
+      expect.anything(),
+      { prevScreen: undefined },
+    )
+  })
+
+  test('clips oversized alt-screen output and marks scroll drains dirty', () => {
+    const pools = makePools()
+    const node = makeNode(6, 5)
+    const drainNode = makeNode(1, 1)
+    const scrollHint = { bottom: 3, top: 1 }
+    const renderer = createRenderer(node, pools.stylePool)
+
+    mocks.getScrollDrainNode.mockReturnValue(drainNode)
+    mocks.getScrollHint.mockReturnValue(scrollHint)
+
+    const frame = renderer(
+      makeOptions(pools, {
+        altScreen: true,
+        terminalRows: 3,
+        terminalWidth: 10,
+      }),
+    )
+
+    expect(frame.screen.width).toBe(6)
+    expect(frame.screen.height).toBe(3)
+    expect(frame.viewport).toEqual({ width: 10, height: 4 })
+    expect(frame.cursor).toEqual({ x: 0, y: 2, visible: false })
+    expect(frame.scrollHint).toBe(scrollHint)
+    expect(frame.scrollDrainPending).toBe(true)
+    expect(drainNode.dirty).toBe(true)
+    expect(mocks.logForDebugging).toHaveBeenCalledWith(
+      expect.stringContaining('alt-screen: yoga height 5 > terminalRows 3'),
+      { level: 'warn' },
+    )
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-155-realtime-state.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-155-realtime-state.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  effectiveRealtimeMicrophoneMuted,
+  formatRealtimeItemSummary,
+  initialRealtimeTuiState,
+  normalizeRealtimePeak,
+  realtimeLevelBar,
+  reduceRealtimeTuiState,
+} from '../../../src/tui/realtime/state.js'
+
+describe('realtime state coverage swarm row 155', () => {
+  test('guards lifecycle transitions that should not advance active state', () => {
+    const inactive = initialRealtimeTuiState()
+    expect(reduceRealtimeTuiState(inactive, { type: 'stop_requested' })).toBe(
+      inactive,
+    )
+    expect(
+      reduceRealtimeTuiState(inactive, {
+        type: 'started',
+        realtimeSessionId: 'rt_ignored',
+      }),
+    ).toBe(inactive)
+
+    const starting = reduceRealtimeTuiState(inactive, {
+      type: 'start_requested',
+      transport: 'websocket',
+    })
+    const started = reduceRealtimeTuiState(starting, {
+      type: 'started',
+      realtimeSessionId: undefined,
+      transport: 'webrtc',
+    })
+    expect(started).toMatchObject({
+      phase: 'active',
+      transport: 'webrtc',
+      realtimeSessionId: null,
+    })
+
+    const failed = reduceRealtimeTuiState(started, {
+      type: 'start_failed',
+      message: 'token rejected',
+    })
+    expect(failed).toMatchObject({
+      phase: 'inactive',
+      requestedClose: false,
+      transport: null,
+      realtimeSessionId: null,
+      errorBanner: 'token rejected',
+    })
+  })
+
+  test('normalizes close banners and transcript replacement cases', () => {
+    let state = reduceRealtimeTuiState(initialRealtimeTuiState(), {
+      type: 'transcript_delta',
+      role: 'assistant',
+      delta: 'hello',
+    })
+    state = reduceRealtimeTuiState(state, {
+      type: 'transcript_delta',
+      role: 'user',
+      delta: 'new speaker',
+    })
+    expect(state.lastTranscript).toEqual({
+      role: 'user',
+      text: 'new speaker',
+    })
+
+    state = reduceRealtimeTuiState(state, {
+      type: 'transcript_done',
+      role: 'assistant',
+      text: 'final answer',
+    })
+    expect(state.lastTranscript).toEqual({
+      role: 'assistant',
+      text: 'final answer',
+    })
+
+    expect(
+      reduceRealtimeTuiState(state, { type: 'closed', reason: '   ' }),
+    ).toMatchObject({
+      phase: 'inactive',
+      closedBanner: 'Realtime closed',
+      errorBanner: null,
+    })
+    expect(
+      reduceRealtimeTuiState(state, { type: 'closed', reason: null }),
+    ).toMatchObject({
+      closedBanner: 'Realtime closed',
+    })
+  })
+
+  test('handles push-to-talk release and peak meter edge cases', () => {
+    let state = reduceRealtimeTuiState(initialRealtimeTuiState(), {
+      type: 'push_to_talk_held_changed',
+      held: true,
+    })
+    expect(state.pushToTalkHeld).toBe(false)
+
+    state = reduceRealtimeTuiState(state, {
+      type: 'push_to_talk_changed',
+      enabled: true,
+    })
+    state = reduceRealtimeTuiState(state, {
+      type: 'push_to_talk_held_changed',
+      held: true,
+    })
+    expect(effectiveRealtimeMicrophoneMuted(state)).toBe(false)
+
+    state = reduceRealtimeTuiState(state, {
+      type: 'push_to_talk_changed',
+      enabled: false,
+    })
+    expect(state.pushToTalkHeld).toBe(false)
+    expect(effectiveRealtimeMicrophoneMuted(state)).toBe(false)
+
+    expect(normalizeRealtimePeak(Number.NaN)).toBe(0)
+    expect(normalizeRealtimePeak(Number.POSITIVE_INFINITY)).toBe(0)
+    expect(normalizeRealtimePeak(-1)).toBe(0)
+    expect(normalizeRealtimePeak(65_535.6)).toBe(65_535)
+    expect(normalizeRealtimePeak(12.6)).toBe(13)
+    expect(realtimeLevelBar(-5, 0)).toBe('-')
+    expect(realtimeLevelBar(65_535, 2.9)).toBe('##')
+  })
+
+  test('summarizes realtime items across primitive, typed, and truncated objects', () => {
+    expect(formatRealtimeItemSummary(null)).toBe('null')
+    expect(formatRealtimeItemSummary(true)).toBe('true')
+    expect(formatRealtimeItemSummary(42)).toBe('42')
+    expect(formatRealtimeItemSummary(['a', 'b', 'c'])).toBe('array(3)')
+    expect(
+      formatRealtimeItemSummary({ type: 'response', itemId: 'item_1' }),
+    ).toBe('response item_1')
+    expect(formatRealtimeItemSummary({ type: 'response' })).toBe('response')
+    expect(formatRealtimeItemSummary({ type: 7, text: 'plain' })).toBe(
+      '{"type":7,"text":"plain"}',
+    )
+
+    const longSummary = formatRealtimeItemSummary({
+      payload: 'x'.repeat(120),
+    })
+    expect(longSummary).toHaveLength(96)
+    expect(longSummary.endsWith('...')).toBe(true)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-156-components-ClickableImageRef.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-156-components-ClickableImageRef.test.tsx
@@ -1,0 +1,244 @@
+import { PassThrough } from 'node:stream'
+import { pathToFileURL } from 'node:url'
+
+import React, { useLayoutEffect, useState } from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const componentMocks = vi.hoisted(() => ({
+  imagePathById: new Map<number, string>(),
+  supportsHyperlinks: vi.fn(() => true),
+}))
+
+vi.mock('../../../src/utils/imageStore.js', () => ({
+  getStoredImagePath: (imageId: number) =>
+    componentMocks.imagePathById.get(imageId) ?? null,
+}))
+
+vi.mock('../../../src/tui/ink/supports-hyperlinks.js', () => ({
+  supportsHyperlinks: componentMocks.supportsHyperlinks,
+}))
+
+import { ClickableImageRef } from '../../../src/tui/components/ClickableImageRef.js'
+import type { DOMElement } from '../../../src/tui/ink/dom.js'
+import instances from '../../../src/tui/ink/instances.js'
+import { createRoot } from '../../../src/tui/ink/root.js'
+import { squashTextNodesToSegments } from '../../../src/tui/ink/squash-text-nodes.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestStdout = PassThrough & {
+  columns: number
+  isTTY: boolean
+  rows: number
+}
+
+function createStreams(): {
+  readonly stdin: TestStdin
+  readonly stdout: TestStdout
+} {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough() as TestStdout
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 100
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function getRootNode(stdout: TestStdout): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+  if (!instance?.rootNode) {
+    throw new Error('Ink root node not found')
+  }
+
+  return instance.rootNode
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await sleep(10)
+  }
+
+  throw new Error(message)
+}
+
+async function renderSegments(
+  node: React.ReactNode,
+  waitForRender: () => Promise<void> = () => sleep(),
+): Promise<
+  Array<{
+    readonly hyperlink?: string
+    readonly styles: Record<string, unknown>
+    readonly text: string
+  }>
+> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  try {
+    root.render(node)
+    await waitForRender()
+    return squashTextNodesToSegments(getRootNode(stdout))
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await sleep()
+  }
+}
+
+afterEach(() => {
+  componentMocks.imagePathById.clear()
+  componentMocks.supportsHyperlinks.mockReset()
+  componentMocks.supportsHyperlinks.mockReturnValue(true)
+})
+
+function LinkedRerenderProbe({
+  onStage,
+}: {
+  readonly onStage: (stage: number) => void
+}): React.ReactElement {
+  const [stage, setStage] = useState(0)
+
+  useLayoutEffect(() => {
+    onStage(stage)
+    if (stage < 2) {
+      setStage(stage + 1)
+    }
+  }, [onStage, stage])
+
+  return (
+    <ClickableImageRef
+      backgroundColor={stage === 2 ? 'warning' : undefined}
+      imageId={12}
+      isSelected={stage === 2}
+    />
+  )
+}
+
+function PlainRerenderProbe({
+  onStage,
+}: {
+  readonly onStage: (stage: number) => void
+}): React.ReactElement {
+  const [stage, setStage] = useState(0)
+
+  useLayoutEffect(() => {
+    onStage(stage)
+    if (stage < 2) {
+      setStage(stage + 1)
+    }
+  }, [onStage, stage])
+
+  return (
+    <ClickableImageRef
+      backgroundColor={stage === 2 ? 'error' : undefined}
+      imageId={stage === 2 ? 22 : 21}
+      isSelected={stage === 2}
+    />
+  )
+}
+
+describe('ClickableImageRef coverage swarm row 156', () => {
+  test('renders selected cached images as styled file hyperlinks across rerenders', async () => {
+    const imagePath = '/tmp/agenc coverage/row 156 selected image.png'
+    componentMocks.imagePathById.set(12, imagePath)
+    componentMocks.supportsHyperlinks.mockReturnValue(true)
+    const onStage = vi.fn()
+
+    const segments = await renderSegments(
+      <LinkedRerenderProbe onStage={onStage} />,
+      () =>
+        waitForCondition(
+          () => onStage.mock.calls.some(([stage]) => stage === 2),
+          'ClickableImageRef linked rerenders did not complete',
+        ),
+    )
+
+    expect(onStage.mock.calls.map(([stage]) => stage)).toEqual([0, 1, 2])
+    expect(segments).toEqual([
+      {
+        hyperlink: pathToFileURL(imagePath).href,
+        styles: {
+          backgroundColor: expect.any(String),
+          bold: true,
+          inverse: true,
+        },
+        text: '[Image #12]',
+      },
+    ])
+    expect(componentMocks.supportsHyperlinks).toHaveBeenCalled()
+  })
+
+  test('falls back to styled text when hyperlinks are unsupported or the image is missing', async () => {
+    componentMocks.imagePathById.set(
+      21,
+      '/tmp/agenc coverage/row 156 unsupported image.png',
+    )
+    componentMocks.supportsHyperlinks.mockReturnValue(false)
+    const onStage = vi.fn()
+
+    const unsupportedSegments = await renderSegments(
+      <PlainRerenderProbe onStage={onStage} />,
+      () =>
+        waitForCondition(
+          () => onStage.mock.calls.some(([stage]) => stage === 2),
+          'ClickableImageRef fallback rerenders did not complete',
+        ),
+    )
+
+    expect(onStage.mock.calls.map(([stage]) => stage)).toEqual([0, 1, 2])
+    expect(unsupportedSegments).toEqual([
+      {
+        hyperlink: undefined,
+        styles: {
+          backgroundColor: expect.any(String),
+          inverse: true,
+        },
+        text: '[Image #22]',
+      },
+    ])
+
+    componentMocks.supportsHyperlinks.mockClear()
+    componentMocks.supportsHyperlinks.mockReturnValue(true)
+    const missingSegments = await renderSegments(
+      <ClickableImageRef imageId={99} />,
+    )
+
+    expect(missingSegments).toEqual([
+      {
+        hyperlink: undefined,
+        styles: {},
+        text: '[Image #99]',
+      },
+    ])
+    expect(componentMocks.supportsHyperlinks).not.toHaveBeenCalled()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-157-components-design-system-Dialog.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-157-components-design-system-Dialog.test.tsx
@@ -1,0 +1,157 @@
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../../src/utils/staticRender.js'
+import {
+  Dialog,
+  getDialogBodyMaxHeight,
+} from '../../../src/tui/components/design-system/Dialog.js'
+import { Text } from '../../../src/tui/ink.js'
+
+type ExitState = {
+  keyName: 'Ctrl-C' | 'Ctrl-D' | null
+  pending: boolean
+}
+
+type KeybindingRecord = {
+  action: string
+  handler: () => void
+  options?: {
+    context?: string
+    isActive?: boolean
+  }
+}
+
+const harness = vi.hoisted(() => ({
+  exitHookActiveStates: [] as Array<boolean | undefined>,
+  exitState: {
+    keyName: null,
+    pending: false,
+  } as ExitState,
+  keybindings: [] as KeybindingRecord[],
+}))
+
+vi.mock('src/tui/hooks/useExitOnCtrlCDWithKeybindings.js', () => ({
+  useExitOnCtrlCDWithKeybindings: (
+    _onExit: unknown,
+    _onInterrupt: unknown,
+    isActive?: boolean,
+  ) => {
+    harness.exitHookActiveStates.push(isActive)
+    return harness.exitState
+  },
+}))
+
+vi.mock('../../../src/tui/keybindings/useKeybinding.js', () => ({
+  useKeybinding: (
+    action: string,
+    handler: () => void,
+    options?: KeybindingRecord['options'],
+  ) => {
+    harness.keybindings.push({ action, handler, options })
+  },
+}))
+
+async function renderDialog(
+  props: Partial<React.ComponentProps<typeof Dialog>> = {},
+): Promise<string> {
+  return renderToString(
+    <Dialog title="Confirm action" onCancel={() => {}} {...props}>
+      <Text>Dialog body</Text>
+    </Dialog>,
+    { columns: 80, rows: 24 },
+  )
+}
+
+describe('Dialog coverage swarm row 157', () => {
+  beforeEach(() => {
+    harness.exitHookActiveStates = []
+    harness.exitState = {
+      keyName: null,
+      pending: false,
+    }
+    harness.keybindings = []
+  })
+
+  test('computes body height with guide chrome, truncation, and unsafe row values', () => {
+    expect(getDialogBodyMaxHeight(24, true)).toBe(18)
+    expect(getDialogBodyMaxHeight(24, false)).toBe(20)
+    expect(getDialogBodyMaxHeight(7.9, true)).toBe(1)
+    expect(getDialogBodyMaxHeight(8.9, false)).toBe(4)
+    expect(getDialogBodyMaxHeight(Number.POSITIVE_INFINITY, true)).toBe(1)
+    expect(getDialogBodyMaxHeight(-4, false)).toBe(1)
+  })
+
+  test('renders the default subtitle and input guide and wires cancel keybinding', async () => {
+    const onCancel = vi.fn()
+    const output = await renderDialog({
+      onCancel,
+      subtitle: 'Review before continuing',
+    })
+
+    expect(output).toContain('Confirm action')
+    expect(output).toContain('Review before continuing')
+    expect(output).toContain('Dialog body')
+    expect(output).toContain('Enter to confirm')
+    expect(output).toContain('Esc to cancel')
+    expect(harness.exitHookActiveStates).toEqual([true])
+    expect(harness.keybindings).toHaveLength(1)
+    expect(harness.keybindings[0]).toMatchObject({
+      action: 'confirm:no',
+      options: {
+        context: 'Confirmation',
+        isActive: true,
+      },
+    })
+
+    harness.keybindings[0]?.handler()
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  test('renders the pending exit prompt when the exit hook reports a first press', async () => {
+    harness.exitState = {
+      keyName: 'Ctrl-D',
+      pending: true,
+    }
+
+    const output = await renderDialog()
+
+    expect(output).toContain('Press Ctrl-D again to exit')
+    expect(output).not.toContain('Enter to confirm')
+  })
+
+  test('honors custom guides, hidden guides, hidden borders, and inactive cancel bindings', async () => {
+    harness.exitState = {
+      keyName: 'Ctrl-C',
+      pending: true,
+    }
+    const inputGuide = vi.fn((exitState: ExitState) => (
+      <Text>{`Custom guide ${exitState.keyName} ${exitState.pending}`}</Text>
+    ))
+
+    const customGuideOutput = await renderDialog({ inputGuide })
+
+    expect(customGuideOutput).toContain('Custom guide Ctrl-C true')
+    expect(inputGuide).toHaveBeenCalledWith(harness.exitState)
+
+    const hiddenOutput = await renderDialog({
+      hideBorder: true,
+      hideInputGuide: true,
+      isCancelActive: false,
+      title: 'Borderless dialog',
+    })
+
+    expect(hiddenOutput).toContain('Borderless dialog')
+    expect(hiddenOutput).toContain('Dialog body')
+    expect(hiddenOutput).not.toContain('Custom guide')
+    expect(hiddenOutput).not.toContain('Press Ctrl-C again to exit')
+    expect(harness.exitHookActiveStates.at(-1)).toBe(false)
+    expect(harness.keybindings.at(-1)).toMatchObject({
+      action: 'confirm:no',
+      options: {
+        context: 'Confirmation',
+        isActive: false,
+      },
+    })
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-158-components-design-system-ProgressBar.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-158-components-design-system-ProgressBar.test.tsx
@@ -1,0 +1,190 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { ProgressBar } from '../../../src/tui/components/design-system/ProgressBar.js'
+import type { DOMElement, DOMNode } from '../../../src/tui/ink/dom.js'
+import instances from '../../../src/tui/ink/instances.js'
+import { createRoot } from '../../../src/tui/ink/root.js'
+import type { TextStyles } from '../../../src/tui/ink/styles.js'
+import { getTheme } from '../../../src/utils/theme.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestStdout = PassThrough & {
+  columns: number
+  isTTY: boolean
+  rows: number
+}
+
+type MountedRoot = {
+  root: Awaited<ReturnType<typeof createRoot>>
+  stdin: TestStdin
+  stdout: TestStdout
+}
+
+type StyledSegment = {
+  text: string
+  styles: TextStyles
+}
+
+const mountedRoots: MountedRoot[] = []
+
+function createStreams(): { stdin: TestStdin; stdout: TestStdout } {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough() as TestStdout
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 80
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 30): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function getRootNode(stdout: TestStdout): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+
+  if (!instance?.rootNode) {
+    throw new Error('Ink root node not found')
+  }
+
+  return instance.rootNode
+}
+
+function collectSegments(
+  node: DOMNode,
+  inheritedStyles: TextStyles = {},
+  segments: StyledSegment[] = [],
+): StyledSegment[] {
+  if (node.nodeName === '#text') {
+    if (node.nodeValue !== '') {
+      segments.push({ text: node.nodeValue, styles: inheritedStyles })
+    }
+    return segments
+  }
+
+  const nextStyles = node.textStyles
+    ? { ...inheritedStyles, ...node.textStyles }
+    : inheritedStyles
+
+  for (const child of node.childNodes) {
+    collectSegments(child, nextStyles, segments)
+  }
+
+  return segments
+}
+
+async function renderProgressBar(node: React.ReactNode): Promise<{
+  rerender: (next: React.ReactNode) => Promise<void>
+  segment: () => StyledSegment
+}> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  mountedRoots.push({ root, stdin, stdout })
+
+  const rerender = async (next: React.ReactNode) => {
+    root.render(next)
+    await sleep()
+  }
+
+  await rerender(node)
+
+  return {
+    rerender,
+    segment: () => {
+      const segments = collectSegments(getRootNode(stdout))
+      expect(segments).toHaveLength(1)
+      return segments[0]!
+    },
+  }
+}
+
+afterEach(() => {
+  for (const { root, stdin, stdout } of mountedRoots.splice(0)) {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    instances.delete(stdout as unknown as NodeJS.WriteStream)
+  }
+})
+
+describe('ProgressBar coverage swarm row 158', () => {
+  test('clamps ratios and renders fractional blocks for narrow widths', async () => {
+    const empty = await renderProgressBar(<ProgressBar ratio={-0.25} width={4} />)
+    expect(empty.segment()).toEqual({ text: '    ', styles: {} })
+
+    const partial = await renderProgressBar(
+      <ProgressBar ratio={0.2} width={1} />,
+    )
+    expect(partial.segment()).toEqual({ text: '▏', styles: {} })
+
+    const full = await renderProgressBar(<ProgressBar ratio={1.5} width={4} />)
+    expect(full.segment()).toEqual({ text: '████', styles: {} })
+  })
+
+  test('passes fill and empty colors through while preserving rerendered segments', async () => {
+    const theme = getTheme('dark')
+    const rendered = await renderProgressBar(
+      <ProgressBar
+        ratio={0.5}
+        width={6}
+        fillColor="success"
+        emptyColor="rate_limit_empty"
+      />,
+    )
+
+    expect(rendered.segment()).toEqual({
+      text: '███   ',
+      styles: {
+        backgroundColor: theme.rate_limit_empty,
+        color: theme.success,
+      },
+    })
+
+    await rendered.rerender(
+      <ProgressBar
+        ratio={0.5}
+        width={6}
+        fillColor="success"
+        emptyColor="rate_limit_empty"
+      />,
+    )
+    expect(rendered.segment()).toEqual({
+      text: '███   ',
+      styles: {
+        backgroundColor: theme.rate_limit_empty,
+        color: theme.success,
+      },
+    })
+
+    await rendered.rerender(
+      <ProgressBar ratio={0.58} width={6} fillColor="warning" />,
+    )
+    expect(rendered.segment()).toEqual({
+      text: '███▌  ',
+      styles: {
+        color: theme.warning,
+      },
+    })
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-159-context-mailbox.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-159-context-mailbox.test.tsx
@@ -1,0 +1,198 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { describe, expect, test } from "vitest";
+
+import { MailboxProvider, useMailbox } from "src/tui/context/mailbox.js";
+import { createRoot, Text } from "src/tui/ink.js";
+import type { Mailbox } from "src/utils/mailbox.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+type TestStdout = PassThrough & {
+  columns: number;
+  isTTY: boolean;
+  rows: number;
+};
+
+type MailboxSnapshot = {
+  readonly label: string;
+  readonly length: number;
+  readonly mailbox: Mailbox;
+  readonly revision: number;
+};
+
+function createStreams(): {
+  readonly stdin: TestStdin;
+  readonly stdout: TestStdout;
+} {
+  const stdin = new PassThrough() as TestStdin;
+  const stdout = new PassThrough() as TestStdout;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+
+  stdout.columns = 100;
+  stdout.rows = 24;
+  stdout.isTTY = true;
+  stdout.resume();
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 10): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  const startedAt = Date.now();
+  let lastError: unknown;
+
+  while (Date.now() - startedAt < 1_000) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await sleep();
+    }
+  }
+
+  throw lastError;
+}
+
+async function withRoot(
+  run: (root: Awaited<ReturnType<typeof createRoot>>) => Promise<void>,
+): Promise<void> {
+  const { stdin, stdout } = createStreams();
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  try {
+    await run(root);
+  } finally {
+    root.unmount();
+    stdin.end();
+    stdout.end();
+    await sleep();
+  }
+}
+
+function MailboxProbe({
+  label,
+  snapshots,
+}: {
+  readonly label: string;
+  readonly snapshots: MailboxSnapshot[];
+}): React.ReactNode {
+  const mailbox = useMailbox();
+
+  React.useEffect(() => {
+    snapshots.push({
+      label,
+      length: mailbox.length,
+      mailbox,
+      revision: mailbox.revision,
+    });
+  }, [label, mailbox, snapshots]);
+
+  return <Text>{label}</Text>;
+}
+
+function OutsideMailboxProbe(): React.ReactNode {
+  useMailbox();
+  return <Text>outside</Text>;
+}
+
+describe("MailboxProvider coverage swarm row 159", () => {
+  test("provides one reusable mailbox across cached and changed children", async () => {
+    const snapshots: MailboxSnapshot[] = [];
+    const stableChild = (
+      <MailboxProbe label="first" snapshots={snapshots} />
+    );
+
+    await withRoot(async (root) => {
+      root.render(<MailboxProvider>{stableChild}</MailboxProvider>);
+      await waitFor(() => {
+        expect(snapshots).toHaveLength(1);
+      });
+
+      const mailbox = snapshots[0]!.mailbox;
+      mailbox.send({
+        content: "queued for the next render",
+        id: "message-159",
+        source: "user",
+        timestamp: "2026-05-20T00:00:00.000Z",
+      });
+
+      root.render(<MailboxProvider>{stableChild}</MailboxProvider>);
+      await sleep();
+
+      root.render(
+        <MailboxProvider>
+          <MailboxProbe label="second" snapshots={snapshots} />
+        </MailboxProvider>,
+      );
+      await waitFor(() => {
+        expect(snapshots).toHaveLength(2);
+      });
+    });
+
+    expect(snapshots[0]).toMatchObject({
+      label: "first",
+      length: 0,
+      revision: 0,
+    });
+    expect(snapshots[1]).toMatchObject({
+      label: "second",
+      length: 1,
+      revision: 1,
+    });
+    expect(snapshots[1]!.mailbox).toBe(snapshots[0]!.mailbox);
+    expect(snapshots[1]!.mailbox.poll()).toMatchObject({
+      content: "queued for the next render",
+      id: "message-159",
+      source: "user",
+    });
+  });
+
+  test("reports missing provider usage through the renderer error path", async () => {
+    const { stdin, stdout } = createStreams();
+    const stderr = new PassThrough();
+    let stderrOutput = "";
+    stderr.on("data", (chunk) => {
+      stderrOutput += chunk.toString();
+    });
+    const root = await createRoot({
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(<OutsideMailboxProbe />);
+      await waitFor(() => {
+        expect(stderrOutput).toContain(
+          "useMailbox must be used within a MailboxProvider",
+        );
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      stderr.end();
+      await sleep();
+    }
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-160-hooks-useExitOnCtrlCDWithKeybindings.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-160-hooks-useExitOnCtrlCDWithKeybindings.test.ts
@@ -1,0 +1,223 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { ExitState } from '../../../src/tui/hooks/useExitOnCtrlCDWithKeybindings.js'
+
+type CapturedKeybindings = {
+  handlers: Record<string, () => void>
+  options: {
+    context?: string
+    isActive?: boolean
+  }
+}
+
+const fixture = vi.hoisted(() => ({
+  appExit: vi.fn(),
+  keybindings: [] as CapturedKeybindings[],
+  reset() {
+    this.appExit.mockClear()
+    this.keybindings = []
+  },
+}))
+
+vi.mock(
+  '../../../src/tui/ink/components/AppContext.js',
+  async importOriginal => {
+    const actual =
+      await importOriginal<
+        typeof import('../../../src/tui/ink/components/AppContext.js')
+      >()
+
+    return {
+      ...actual,
+      useApp: () => ({
+        exit: fixture.appExit,
+      }),
+    }
+  },
+)
+
+vi.mock('../../../src/tui/keybindings/useKeybinding.js', () => ({
+  useKeybindings: (
+    handlers: Record<string, () => void>,
+    options: CapturedKeybindings['options'],
+  ) => {
+    fixture.keybindings.push({ handlers, options })
+  },
+}))
+
+import { createRoot } from '../../../src/tui/ink/root.js'
+import { useExitOnCtrlCDWithKeybindings } from '../../../src/tui/hooks/useExitOnCtrlCDWithKeybindings.js'
+
+type HookProps = {
+  isActive?: boolean
+  onExit?: () => void
+  onInterrupt?: () => boolean
+}
+
+type TestStreams = {
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdout: PassThrough & {
+    columns: number
+    isTTY: boolean
+    rows: number
+  }
+}
+
+function createStreams(): TestStreams {
+  const stdin = new PassThrough() as TestStreams['stdin']
+  const stdout = new PassThrough() as TestStreams['stdout']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 100
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function flushEffects(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+function latestKeybindings(): CapturedKeybindings {
+  const keybindings = fixture.keybindings.at(-1)
+  if (keybindings === undefined) {
+    throw new Error('keybindings were not registered')
+  }
+  return keybindings
+}
+
+async function renderHookHarness(props: HookProps = {}): Promise<{
+  dispose: () => Promise<void>
+  latest: () => ExitState
+  press: (action: 'app:exit' | 'app:interrupt') => Promise<void>
+}> {
+  let latest: ExitState | undefined
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    latest = useExitOnCtrlCDWithKeybindings(
+      props.onExit,
+      props.onInterrupt,
+      props.isActive,
+    )
+    return null
+  }
+
+  root.render(React.createElement(Harness))
+  await flushEffects()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushEffects()
+    },
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+    press: async action => {
+      const handler = latestKeybindings().handlers[action]
+      if (handler === undefined) {
+        throw new Error(`missing handler for ${action}`)
+      }
+
+      handler()
+      await flushEffects()
+    },
+  }
+}
+
+describe('useExitOnCtrlCDWithKeybindings coverage swarm 160', () => {
+  beforeEach(() => {
+    fixture.reset()
+  })
+
+  test('registers global bindings as active by default and exits on Ctrl-D double press', async () => {
+    const rendered = await renderHookHarness()
+
+    try {
+      expect(rendered.latest()).toEqual({ pending: false, keyName: null })
+      expect(latestKeybindings().options).toEqual({
+        context: 'Global',
+        isActive: true,
+      })
+
+      await rendered.press('app:exit')
+      expect(rendered.latest()).toEqual({ pending: true, keyName: 'Ctrl-D' })
+      expect(fixture.appExit).not.toHaveBeenCalled()
+
+      await rendered.press('app:exit')
+      expect(rendered.latest()).toEqual({ pending: false, keyName: 'Ctrl-D' })
+      expect(fixture.appExit).toHaveBeenCalledTimes(1)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('lets onInterrupt consume Ctrl-C before the double-press exit path', async () => {
+    const onExit = vi.fn()
+    const onInterrupt = vi.fn(() => true)
+    const rendered = await renderHookHarness({
+      isActive: false,
+      onExit,
+      onInterrupt,
+    })
+
+    try {
+      expect(latestKeybindings().options).toEqual({
+        context: 'Global',
+        isActive: false,
+      })
+
+      await rendered.press('app:interrupt')
+      expect(onInterrupt).toHaveBeenCalledTimes(1)
+      expect(rendered.latest()).toEqual({ pending: false, keyName: null })
+      expect(onExit).not.toHaveBeenCalled()
+      expect(fixture.appExit).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('falls through to Ctrl-C double press when onInterrupt declines to handle it', async () => {
+    const onExit = vi.fn()
+    const onInterrupt = vi.fn(() => false)
+    const rendered = await renderHookHarness({ onExit, onInterrupt })
+
+    try {
+      await rendered.press('app:interrupt')
+      expect(onInterrupt).toHaveBeenCalledTimes(1)
+      expect(rendered.latest()).toEqual({ pending: true, keyName: 'Ctrl-C' })
+      expect(onExit).not.toHaveBeenCalled()
+
+      await rendered.press('app:interrupt')
+      expect(onInterrupt).toHaveBeenCalledTimes(2)
+      expect(rendered.latest()).toEqual({ pending: false, keyName: 'Ctrl-C' })
+      expect(onExit).toHaveBeenCalledTimes(1)
+      expect(fixture.appExit).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-161-components-TaskListV2.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-161-components-TaskListV2.test.tsx
@@ -1,0 +1,227 @@
+import React from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const harness = vi.hoisted(() => ({
+  appState: {
+    tasks: {} as Record<string, unknown>,
+    teamContext: undefined as
+      | undefined
+      | {
+          teammates: Record<string, { color?: string; name: string }>;
+        },
+  },
+  columns: 80,
+  rows: 24,
+  swarmsEnabled: false,
+  todoEnabled: true,
+  reset() {
+    harness.appState = {
+      tasks: {},
+      teamContext: undefined,
+    };
+    harness.columns = 80;
+    harness.rows = 24;
+    harness.swarmsEnabled = false;
+    harness.todoEnabled = true;
+  },
+}));
+
+vi.mock("../../../src/tui/hooks/useTerminalSize.js", () => ({
+  useTerminalSize: () => ({ columns: harness.columns, rows: harness.rows }),
+}));
+
+vi.mock("../../../src/tui/state/AppState.js", () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+}));
+
+vi.mock("../../../src/utils/tasks.js", async importOriginal => {
+  const actual = await importOriginal<typeof import("../../../src/utils/tasks.js")>();
+  return {
+    ...actual,
+    isTodoV2Enabled: () => harness.todoEnabled,
+  };
+});
+
+vi.mock("../../../src/utils/agentSwarmsEnabled.js", () => ({
+  isAgentSwarmsEnabled: () => harness.swarmsEnabled,
+}));
+
+vi.mock("../../../src/tasks/InProcessTeammateTask/types.js", () => ({
+  isInProcessTeammateTask: (task: { readonly type?: string }) =>
+    task.type === "in_process_teammate",
+}));
+
+vi.mock("../../../src/utils/collapseReadSearch.js", () => ({
+  summarizeRecentActivities: (
+    activities: readonly Array<{ readonly activityDescription?: string }>,
+  ) => activities.map(activity => activity.activityDescription).filter(Boolean).join(" + "),
+}));
+
+vi.mock("src/tools/AgentTool/agentColorManager.js", () => ({
+  AGENT_COLOR_TO_THEME_COLOR: {
+    green: "success",
+  },
+}));
+
+import { renderToString } from "../../utils/staticRender.js";
+import {
+  getTaskListTextWidth,
+  TaskListV2,
+} from "../../../src/tui/components/TaskListV2.js";
+
+type TestTask = {
+  activeForm?: string;
+  blockedBy: string[];
+  blocks: string[];
+  description: string;
+  id: string;
+  owner?: string;
+  status: "completed" | "in_progress" | "pending";
+  subject: string;
+};
+
+const originalGlyphMode = process.env.AGENC_TUI_GLYPHS;
+
+function task(overrides: Partial<TestTask> & Pick<TestTask, "id" | "subject">): TestTask {
+  return {
+    blockedBy: [],
+    blocks: [],
+    description: `${overrides.subject} description`,
+    status: "pending",
+    ...overrides,
+  };
+}
+
+async function renderTaskList(tasks: TestTask[]): Promise<string> {
+  return renderToString(<TaskListV2 tasks={tasks as never} />, {
+    columns: harness.columns,
+    rows: harness.rows,
+  });
+}
+
+describe("TaskListV2 coverage swarm row 161", () => {
+  beforeEach(() => {
+    harness.reset();
+    process.env.AGENC_TUI_GLYPHS = "ascii";
+  });
+
+  afterEach(() => {
+    if (originalGlyphMode === undefined) {
+      delete process.env.AGENC_TUI_GLYPHS;
+    } else {
+      process.env.AGENC_TUI_GLYPHS = originalGlyphMode;
+    }
+  });
+
+  test("normalizes fractional and non-finite row text widths", () => {
+    expect(getTaskListTextWidth(81.9, 10.9)).toBe(56);
+    expect(getTaskListTextWidth(-20, -3)).toBe(1);
+    expect(getTaskListTextWidth(Infinity, 4)).toBe(1);
+    expect(getTaskListTextWidth(80, Infinity)).toBe(65);
+  });
+
+  test("renders no rows or hidden summary when the terminal is too short", async () => {
+    harness.rows = 10;
+
+    const output = await renderTaskList([
+      task({ id: "1", status: "in_progress", subject: "Running task" }),
+      task({ id: "2", subject: "Queued task" }),
+      task({ id: "3", status: "completed", subject: "Finished task" }),
+    ]);
+
+    expect(output.trim()).toBe("");
+    expect(output).not.toContain("Running task");
+    expect(output).not.toContain("+");
+  });
+
+  test("uses agent-id activity fallback while hiding owners on narrow terminals", async () => {
+    harness.columns = 58;
+    harness.swarmsEnabled = true;
+    harness.appState.tasks = {
+      activeAgent: {
+        identity: { agentId: "alice@team", agentName: "alice" },
+        progress: {
+          lastActivity: { activityDescription: "Reading fallback activity" },
+        },
+        status: "running",
+        type: "in_process_teammate",
+      },
+      stoppedAgent: {
+        identity: { agentId: "bob@team", agentName: "bob" },
+        progress: {
+          lastActivity: { activityDescription: "Stopped activity" },
+        },
+        status: "completed",
+        type: "in_process_teammate",
+      },
+    };
+
+    const output = await renderTaskList([
+      task({
+        id: "1",
+        owner: "alice@team",
+        status: "in_progress",
+        subject: "Agent id owned task",
+      }),
+    ]);
+
+    expect(output).toContain("Agent id owned task");
+    expect(output).toContain("Reading fallback activity...");
+    expect(output).not.toContain("@alice@team");
+    expect(output).not.toContain("Stopped activity");
+  });
+
+  test("renders active owners when teammate colors are missing or unmapped", async () => {
+    harness.swarmsEnabled = true;
+    harness.appState.teamContext = {
+      teammates: {
+        badColor: { color: "purple", name: "badColor" },
+        goodColor: { color: "green", name: "goodColor" },
+        noColor: { name: "noColor" },
+      },
+    };
+    harness.appState.tasks = {
+      badColor: {
+        identity: { agentId: "badColor@team", agentName: "badColor" },
+        status: "running",
+        type: "in_process_teammate",
+      },
+      goodColor: {
+        identity: { agentId: "goodColor@team", agentName: "goodColor" },
+        status: "running",
+        type: "in_process_teammate",
+      },
+      noColor: {
+        identity: { agentId: "noColor@team", agentName: "noColor" },
+        status: "running",
+        type: "in_process_teammate",
+      },
+    };
+
+    const output = await renderTaskList([
+      task({
+        id: "1",
+        owner: "badColor",
+        status: "in_progress",
+        subject: "Unmapped color task",
+      }),
+      task({
+        id: "2",
+        owner: "goodColor",
+        status: "in_progress",
+        subject: "Mapped color task",
+      }),
+      task({
+        id: "3",
+        owner: "noColor",
+        status: "in_progress",
+        subject: "No color task",
+      }),
+    ]);
+
+    expect(output).toContain("@badColor");
+    expect(output).toContain("@goodColor");
+    expect(output).toContain("@noColor");
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-162-components-PromptInput-PromptInputModeIndicator.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-162-components-PromptInput-PromptInputModeIndicator.test.tsx
@@ -1,0 +1,195 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  swarmsEnabled: false,
+  teammateColor: undefined as string | undefined,
+  getTeammateColor: vi.fn((): string | undefined => harness.teammateColor),
+  isAgentSwarmsEnabled: vi.fn((): boolean => harness.swarmsEnabled),
+  reset() {
+    harness.swarmsEnabled = false
+    harness.teammateColor = undefined
+    harness.getTeammateColor.mockClear()
+    harness.isAgentSwarmsEnabled.mockClear()
+  },
+}))
+
+vi.mock('../../../src/utils/agentSwarmsEnabled.js', () => ({
+  isAgentSwarmsEnabled: harness.isAgentSwarmsEnabled,
+}))
+
+vi.mock('../../../src/utils/teammate.js', () => ({
+  getTeammateColor: harness.getTeammateColor,
+}))
+
+import { PromptInputModeIndicator } from '../../../src/tui/components/PromptInput/PromptInputModeIndicator.js'
+import { Box, createRoot } from '../../../src/tui/ink.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestStdout = PassThrough & {
+  columns: number
+  rows: number
+  isTTY: boolean
+}
+
+function createStreams(): {
+  readonly stdin: TestStdin
+  readonly stdout: TestStdout
+} {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough() as TestStdout
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 24
+  stdout.rows = 8
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderIndicator(
+  props: React.ComponentProps<typeof PromptInputModeIndicator>,
+): Promise<string> {
+  return renderToString(<PromptInputModeIndicator {...props} />, 24)
+}
+
+describe('PromptInputModeIndicator coverage swarm 162', () => {
+  test('renders the bash indicator without consulting teammate color when swarms are off', async () => {
+    harness.reset()
+
+    const output = await renderIndicator({
+      mode: 'bash',
+      permissionMode: 'bypassPermissions',
+      isLoading: true,
+    })
+
+    expect(output).toContain('!')
+    expect(output).not.toContain('❯')
+    expect(output).not.toContain('▶')
+    expect(harness.isAgentSwarmsEnabled).toHaveBeenCalled()
+    expect(harness.getTeammateColor).not.toHaveBeenCalled()
+  })
+
+  test('handles teammate color lookup fallbacks for prompt-like modes', async () => {
+    harness.reset()
+    harness.swarmsEnabled = true
+
+    harness.teammateColor = undefined
+    await expect(
+      renderIndicator({
+        mode: 'prompt',
+        isLoading: false,
+      }),
+    ).resolves.toContain('❯')
+
+    harness.teammateColor = 'ultraviolet'
+    await expect(
+      renderIndicator({
+        mode: 'orphaned-permission',
+        permissionMode: 'default',
+        isLoading: false,
+      }),
+    ).resolves.toContain('❯')
+
+    harness.teammateColor = 'cyan'
+    await expect(
+      renderIndicator({
+        mode: 'task-notification',
+        permissionMode: 'acceptEdits',
+        isLoading: true,
+      }),
+    ).resolves.toContain('❯')
+
+    expect(harness.getTeammateColor).toHaveBeenCalledTimes(3)
+  })
+
+  test('prefers the viewed-agent branch and maps optional viewed colors', async () => {
+    harness.reset()
+    harness.swarmsEnabled = true
+    harness.teammateColor = 'red'
+
+    const output = await renderToString(
+      <Box flexDirection="column">
+        <PromptInputModeIndicator
+          mode="prompt"
+          permissionMode="bypassPermissions"
+          isLoading={false}
+          viewingAgentName="planner"
+        />
+        <PromptInputModeIndicator
+          mode="prompt"
+          permissionMode="bypassPermissions"
+          isLoading={false}
+          viewingAgentName="runner"
+          viewingAgentColor="purple"
+        />
+      </Box>,
+      24,
+    )
+
+    expect(output.match(/▶/g)).toHaveLength(2)
+    expect(output).not.toContain('!')
+    expect(harness.getTeammateColor).toHaveBeenCalled()
+  })
+
+  test('keeps the same prompt output across an identical rerender', async () => {
+    harness.reset()
+    harness.swarmsEnabled = true
+    harness.teammateColor = 'pink'
+
+    const { stdin, stdout } = createStreams()
+    let output = ''
+
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      const renderNode = () => (
+        <PromptInputModeIndicator
+          mode="prompt"
+          permissionMode="bypassPermissions"
+          isLoading={false}
+        />
+      )
+
+      root.render(renderNode())
+      await sleep()
+      root.render(renderNode())
+      await sleep()
+
+      expect(stripAnsi(output)).toContain('▶')
+      expect(harness.getTeammateColor).toHaveBeenCalledTimes(1)
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-163-hooks-useDoublePress.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-163-hooks-useDoublePress.test.ts
@@ -1,0 +1,346 @@
+import { PassThrough } from 'node:stream'
+
+import React, { act } from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../../../src/tui/ink.js'
+import {
+  DOUBLE_PRESS_TIMEOUT_MS,
+  useDoublePress,
+} from '../../../src/tui/hooks/useDoublePress.js'
+
+type HookProps = {
+  readonly onDoublePress: () => void
+  readonly onFirstPress?: () => void
+  readonly setPending: (pending: boolean) => void
+  readonly sharedKey?: string
+}
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough & {
+    columns: number
+    isTTY: boolean
+    rows: number
+  }
+}
+
+function createStreams(): TestStreams {
+  const stdin = new PassThrough() as TestStreams['stdin']
+  const stdout = new PassThrough() as TestStreams['stdout']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 100
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+async function renderHookHarness(
+  initialProps: HookProps,
+): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly press: () => Promise<void>
+  readonly render: (next: Partial<HookProps>) => Promise<void>
+}> {
+  let props = initialProps
+  let press: (() => void) | undefined
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    press = useDoublePress(
+      props.setPending,
+      props.onDoublePress,
+      props.onFirstPress,
+      props.sharedKey,
+    )
+    return null
+  }
+
+  async function render(next: Partial<HookProps> = {}): Promise<void> {
+    props = { ...props, ...next }
+    await act(async () => {
+      root.render(React.createElement(Harness))
+    })
+    await flushEffects()
+  }
+
+  await render()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushEffects()
+    },
+    press: async () => {
+      const currentPress = press
+      if (currentPress === undefined) throw new Error('hook did not render')
+      await act(async () => {
+        currentPress()
+      })
+      await flushEffects()
+    },
+    render,
+  }
+}
+
+async function renderSharedHookHarness(
+  left: HookProps,
+  right: HookProps,
+): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly pressLeft: () => Promise<void>
+  readonly pressRight: () => Promise<void>
+}> {
+  let leftPress: (() => void) | undefined
+  let rightPress: (() => void) | undefined
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    leftPress = useDoublePress(
+      left.setPending,
+      left.onDoublePress,
+      left.onFirstPress,
+      left.sharedKey,
+    )
+    rightPress = useDoublePress(
+      right.setPending,
+      right.onDoublePress,
+      right.onFirstPress,
+      right.sharedKey,
+    )
+    return null
+  }
+
+  await act(async () => {
+    root.render(React.createElement(Harness))
+  })
+  await flushEffects()
+
+  async function runPress(currentPress: (() => void) | undefined): Promise<void> {
+    if (currentPress === undefined) throw new Error('hook did not render')
+    await act(async () => {
+      currentPress()
+    })
+    await flushEffects()
+  }
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushEffects()
+    },
+    pressLeft: () => runPress(leftPress),
+    pressRight: () => runPress(rightPress),
+  }
+}
+
+describe('useDoublePress coverage swarm 163', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  test('runs first-press and double-press callbacks on the local pending window', async () => {
+    const setPending = vi.fn()
+    const onDoublePress = vi.fn()
+    const onFirstPress = vi.fn()
+    const rendered = await renderHookHarness({
+      onDoublePress,
+      onFirstPress,
+      setPending,
+    })
+
+    try {
+      await rendered.press()
+
+      expect(onFirstPress).toHaveBeenCalledTimes(1)
+      expect(setPending).toHaveBeenLastCalledWith(true)
+      expect(onDoublePress).not.toHaveBeenCalled()
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(DOUBLE_PRESS_TIMEOUT_MS - 1)
+      })
+      await rendered.press()
+
+      expect(onFirstPress).toHaveBeenCalledTimes(1)
+      expect(setPending).toHaveBeenLastCalledWith(false)
+      expect(onDoublePress).toHaveBeenCalledTimes(1)
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(DOUBLE_PRESS_TIMEOUT_MS)
+      })
+      expect(setPending).toHaveBeenCalledTimes(2)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('expires pending state and treats the next local press as a new first press', async () => {
+    const setPending = vi.fn()
+    const onDoublePress = vi.fn()
+    const onFirstPress = vi.fn()
+    const rendered = await renderHookHarness({
+      onDoublePress,
+      onFirstPress,
+      setPending,
+    })
+
+    try {
+      await rendered.press()
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(DOUBLE_PRESS_TIMEOUT_MS)
+      })
+
+      expect(setPending).toHaveBeenNthCalledWith(1, true)
+      expect(setPending).toHaveBeenNthCalledWith(2, false)
+      expect(onDoublePress).not.toHaveBeenCalled()
+
+      await rendered.press()
+
+      expect(onFirstPress).toHaveBeenCalledTimes(2)
+      expect(setPending).toHaveBeenNthCalledWith(3, true)
+      expect(onDoublePress).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('clears pending timeout on unmount', async () => {
+    const setPending = vi.fn()
+    const rendered = await renderHookHarness({
+      onDoublePress: vi.fn(),
+      setPending,
+    })
+
+    await rendered.press()
+    await rendered.dispose()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DOUBLE_PRESS_TIMEOUT_MS)
+    })
+
+    expect(setPending).toHaveBeenCalledTimes(1)
+    expect(setPending).toHaveBeenLastCalledWith(true)
+  })
+
+  test('shares a double-press window between hook instances with the same key', async () => {
+    const leftSetPending = vi.fn()
+    const leftDoublePress = vi.fn()
+    const leftFirstPress = vi.fn()
+    const rightSetPending = vi.fn()
+    const rightDoublePress = vi.fn()
+    const rightFirstPress = vi.fn()
+    const rendered = await renderSharedHookHarness(
+      {
+        onDoublePress: leftDoublePress,
+        onFirstPress: leftFirstPress,
+        setPending: leftSetPending,
+        sharedKey: 'shared-confirm',
+      },
+      {
+        onDoublePress: rightDoublePress,
+        onFirstPress: rightFirstPress,
+        setPending: rightSetPending,
+        sharedKey: 'shared-confirm',
+      },
+    )
+
+    try {
+      await rendered.pressLeft()
+
+      expect(leftFirstPress).toHaveBeenCalledTimes(1)
+      expect(leftSetPending).toHaveBeenLastCalledWith(true)
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1)
+      })
+      await rendered.pressRight()
+
+      expect(rightFirstPress).not.toHaveBeenCalled()
+      expect(rightSetPending).toHaveBeenLastCalledWith(false)
+      expect(rightDoublePress).toHaveBeenCalledTimes(1)
+      expect(leftDoublePress).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('keeps newer shared-key presses when an older shared timeout resolves', async () => {
+    const leftSetPending = vi.fn()
+    const leftFirstPress = vi.fn()
+    const rightSetPending = vi.fn()
+    const rightDoublePress = vi.fn()
+    const rightFirstPress = vi.fn()
+    const rendered = await renderSharedHookHarness(
+      {
+        onDoublePress: vi.fn(),
+        onFirstPress: leftFirstPress,
+        setPending: leftSetPending,
+        sharedKey: 'stale-shared-token',
+      },
+      {
+        onDoublePress: rightDoublePress,
+        onFirstPress: rightFirstPress,
+        setPending: rightSetPending,
+        sharedKey: 'stale-shared-token',
+      },
+    )
+
+    try {
+      await rendered.pressLeft()
+
+      vi.setSystemTime(1_000_000 + DOUBLE_PRESS_TIMEOUT_MS + 1)
+      await rendered.pressRight()
+
+      expect(leftFirstPress).toHaveBeenCalledTimes(1)
+      expect(rightFirstPress).toHaveBeenCalledTimes(1)
+      expect(rightDoublePress).not.toHaveBeenCalled()
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(DOUBLE_PRESS_TIMEOUT_MS)
+      })
+
+      expect(leftSetPending).toHaveBeenLastCalledWith(false)
+      expect(rightSetPending).toHaveBeenLastCalledWith(false)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-164-components-MessageTimestamp.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-164-components-MessageTimestamp.test.tsx
@@ -1,0 +1,108 @@
+import React, { useLayoutEffect, useState } from "react";
+import { describe, expect, test } from "vitest";
+
+import { MessageTimestamp } from "../../../src/tui/components/MessageTimestamp.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+const TIMESTAMP = "2026-05-20T18:07:00.000Z";
+
+function expectedTimestamp(timestamp = TIMESTAMP): string {
+  return new Date(timestamp).toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    hour12: true,
+    minute: "2-digit",
+  });
+}
+
+function assistantMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    message: {
+      content: [
+        { id: "tool-1", input: {}, name: "Read", type: "tool_use" },
+        { text: "visible response", type: "text" },
+      ],
+    },
+    timestamp: TIMESTAMP,
+    type: "assistant",
+    uuid: "assistant-1",
+    ...overrides,
+  };
+}
+
+async function renderTimestamp(
+  message: Record<string, unknown>,
+  isTranscriptMode = true,
+): Promise<string> {
+  return renderToString(
+    <MessageTimestamp
+      isTranscriptMode={isTranscriptMode}
+      message={message as never}
+    />,
+    { columns: 80 },
+  );
+}
+
+function RerenderSameTimestamp() {
+  const [count, setCount] = useState(0);
+
+  useLayoutEffect(() => {
+    if (count === 0) setCount(1);
+  }, [count]);
+
+  return (
+    <MessageTimestamp
+      isTranscriptMode={true}
+      message={assistantMessage({ uuid: `assistant-${count}` }) as never}
+    />
+  );
+}
+
+describe("MessageTimestamp coverage swarm 164", () => {
+  test("renders formatted assistant timestamps only in transcript mode with text content", async () => {
+    const output = await renderTimestamp(assistantMessage());
+
+    expect(output).toContain(expectedTimestamp());
+  });
+
+  test("hides timestamps outside every required visibility condition", async () => {
+    const cases = [
+      {
+        isTranscriptMode: false,
+        message: assistantMessage(),
+      },
+      {
+        isTranscriptMode: true,
+        message: assistantMessage({ timestamp: undefined }),
+      },
+      {
+        isTranscriptMode: true,
+        message: assistantMessage({ type: "user" }),
+      },
+      {
+        isTranscriptMode: true,
+        message: assistantMessage({
+          message: {
+            content: [
+              { id: "tool-1", input: {}, name: "Read", type: "tool_use" },
+              { thinking: "private", type: "thinking" },
+            ],
+          },
+        }),
+      },
+    ];
+
+    for (const { isTranscriptMode, message } of cases) {
+      const output = await renderTimestamp(message, isTranscriptMode);
+
+      expect(output.trim()).toBe("");
+    }
+  });
+
+  test("keeps cached timestamp output stable across same-timestamp rerenders", async () => {
+    const output = await renderToString(<RerenderSameTimestamp />, {
+      columns: 80,
+    });
+
+    expect(output).toContain(expectedTimestamp());
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-165-components-QuickOpenDialog.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-165-components-QuickOpenDialog.test.tsx
@@ -1,0 +1,404 @@
+import { PassThrough } from "node:stream";
+import * as path from "node:path";
+
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+type PickerAction = {
+  action: string;
+  handler: (item: string) => void;
+};
+
+type CapturedPickerProps = {
+  title: string;
+  placeholder?: string;
+  items: readonly string[];
+  visibleCount: number;
+  previewPosition: "bottom" | "right";
+  onQueryChange: (query: string) => void;
+  onFocus?: (item: string | undefined) => void;
+  onSelect: (item: string) => void;
+  onTab?: PickerAction;
+  onShiftTab?: PickerAction;
+  onCancel: () => void;
+  emptyMessage?: string | ((query: string) => string);
+  selectAction?: string;
+  renderPreview?: (item: string) => React.ReactNode;
+};
+
+type Suggestion = {
+  id: string;
+  displayText: string;
+};
+
+const harness = vi.hoisted(() => ({
+  cwd: "/workspace/project",
+  generateFileSuggestions: vi.fn(),
+  logEvent: vi.fn(),
+  openFileInExternalEditor: vi.fn(),
+  pickerProps: undefined as CapturedPickerProps | undefined,
+  readFileInRange: vi.fn(),
+  registerOverlay: vi.fn(),
+  terminal: {
+    columns: 120,
+    rows: 10,
+  },
+}));
+
+vi.mock("src/tui/context/overlayContext.js", () => ({
+  useRegisterOverlay: harness.registerOverlay,
+}));
+
+vi.mock("src/tui/hooks/fileSuggestions.js", () => ({
+  generateFileSuggestions: harness.generateFileSuggestions,
+}));
+
+vi.mock("src/tui/hooks/useTerminalSize.js", () => ({
+  useTerminalSize: () => harness.terminal,
+}));
+
+vi.mock("src/services/analytics/index.js", () => ({
+  logEvent: harness.logEvent,
+}));
+
+vi.mock("src/utils/cwd.js", () => ({
+  getCwd: () => harness.cwd,
+}));
+
+vi.mock("src/utils/editor.js", () => ({
+  openFileInExternalEditor: harness.openFileInExternalEditor,
+}));
+
+vi.mock("src/utils/readFileInRange.js", () => ({
+  readFileInRange: harness.readFileInRange,
+}));
+
+vi.mock("src/tui/components/design-system/FuzzyPicker.js", () => ({
+  FuzzyPicker: (props: CapturedPickerProps) => {
+    harness.pickerProps = props;
+    return null;
+  },
+}));
+
+import { createRoot } from "src/tui/ink/root.js";
+import { renderToString } from "src/utils/staticRender.js";
+import {
+  computeQuickOpenLayout,
+  QuickOpenDialog,
+} from "src/tui/components/QuickOpenDialog.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+type TestStdout = PassThrough & {
+  columns: number;
+  isTTY: boolean;
+  rows: number;
+};
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function resetHarness() {
+  harness.terminal.columns = 120;
+  harness.terminal.rows = 10;
+  harness.pickerProps = undefined;
+  harness.registerOverlay.mockClear();
+  harness.generateFileSuggestions.mockReset();
+  harness.generateFileSuggestions.mockResolvedValue([]);
+  harness.logEvent.mockClear();
+  harness.openFileInExternalEditor.mockReset();
+  harness.openFileInExternalEditor.mockReturnValue(false);
+  harness.readFileInRange.mockReset();
+  harness.readFileInRange.mockResolvedValue({ content: "" });
+}
+
+function pickerProps(): CapturedPickerProps {
+  const props = harness.pickerProps;
+  if (!props) throw new Error("QuickOpenDialog picker props were not captured");
+  return props;
+}
+
+function createStreams(): {
+  stdin: TestStdin;
+  stdout: TestStdout;
+} {
+  const stdin = new PassThrough() as TestStdin;
+  const stdout = new PassThrough() as TestStdout;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+
+  stdout.columns = harness.terminal.columns;
+  stdout.rows = harness.terminal.rows;
+  stdout.isTTY = true;
+  stdout.resume();
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await sleep(10);
+  }
+
+  throw new Error(message);
+}
+
+async function renderDialog(): Promise<{
+  onDone: ReturnType<typeof vi.fn>;
+  onInsert: ReturnType<typeof vi.fn>;
+  dispose: () => Promise<void>;
+}> {
+  const onDone = vi.fn();
+  const onInsert = vi.fn();
+  const { stdin, stdout } = createStreams();
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  root.render(<QuickOpenDialog onDone={onDone} onInsert={onInsert} />);
+  await waitFor(
+    () => harness.pickerProps !== undefined,
+    "QuickOpenDialog did not render",
+  );
+
+  return {
+    onDone,
+    onInsert,
+    dispose: async () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    },
+  };
+}
+
+async function renderedPreview(item: string): Promise<string> {
+  return renderToString(pickerProps().renderPreview?.(item), 120);
+}
+
+describe("QuickOpenDialog coverage swarm row 165", () => {
+  beforeEach(() => {
+    resetHarness();
+  });
+
+  test("keeps layout dimensions bounded at terminal breakpoints", () => {
+    expect(
+      computeQuickOpenLayout(
+        undefined as unknown as number,
+        undefined as unknown as number,
+      ),
+    ).toMatchObject({
+      effectivePreviewLines: 20,
+      maxPathWidth: 1,
+      previewOnRight: false,
+      previewWidth: 1,
+      visibleResults: 1,
+    });
+
+    expect(computeQuickOpenLayout(119, 14)).toMatchObject({
+      effectivePreviewLines: 20,
+      previewOnRight: false,
+      visibleResults: 1,
+    });
+
+    expect(computeQuickOpenLayout(120, 14)).toMatchObject({
+      effectivePreviewLines: 1,
+      maxPathWidth: 44,
+      previewOnRight: true,
+      previewWidth: 62,
+      visibleResults: 1,
+    });
+  });
+
+  test("ignores stale searches while normalizing only file suggestions", async () => {
+    const rendered = await renderDialog();
+    const firstSearch = deferred<Suggestion[]>();
+    const secondSearch = deferred<Suggestion[]>();
+
+    try {
+      harness.generateFileSuggestions
+        .mockReturnValueOnce(firstSearch.promise)
+        .mockReturnValueOnce(secondSearch.promise);
+
+      expect(pickerProps().title).toBe("Quick Open");
+      expect(pickerProps().previewPosition).toBe("right");
+      expect(pickerProps().visibleCount).toBe(1);
+      expect(harness.registerOverlay).toHaveBeenCalledWith("quick-open");
+
+      pickerProps().onQueryChange("old");
+      await waitFor(
+        () => harness.generateFileSuggestions.mock.calls.length === 1,
+        "Quick open did not start the first search",
+      );
+
+      pickerProps().onQueryChange("new");
+      await waitFor(
+        () => harness.generateFileSuggestions.mock.calls.length === 2,
+        "Quick open did not start the second search",
+      );
+
+      secondSearch.resolve([
+        { id: "command-help", displayText: "help" },
+        { id: "file-directory", displayText: `src${path.sep}` },
+        { id: "file-new", displayText: path.join("src", "new.ts") },
+      ]);
+      await waitFor(
+        () => pickerProps().items.join("\0") === "src/new.ts",
+        "Quick open did not render filtered second-search results",
+      );
+
+      firstSearch.resolve([{ id: "file-old", displayText: "src/old.ts" }]);
+      await sleep();
+      expect(pickerProps().items).toEqual(["src/new.ts"]);
+
+      pickerProps().onSelect("src/new.ts");
+      expect(harness.openFileInExternalEditor).toHaveBeenCalledWith(
+        "/workspace/project/src/new.ts",
+      );
+      expect(harness.logEvent).toHaveBeenCalledWith("agenc_quick_open_select", {
+        opened_editor: false,
+        result_count: 1,
+      });
+      expect(rendered.onDone).toHaveBeenCalledTimes(1);
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("aborts stale preview reads and resets the preview when focus clears", async () => {
+    const rendered = await renderDialog();
+    const slowPreview = deferred<{ content: string }>();
+    const fastPreview = deferred<{ content: string }>();
+    const previewSignals: AbortSignal[] = [];
+
+    try {
+      harness.readFileInRange.mockImplementation(
+        (
+          _file: string,
+          _start: number,
+          _lines: number,
+          _encoding: undefined,
+          signal: AbortSignal,
+        ) => {
+          previewSignals.push(signal);
+          return previewSignals.length === 1
+            ? slowPreview.promise
+            : fastPreview.promise;
+        },
+      );
+
+      pickerProps().onFocus?.("src/slow.ts");
+      await waitFor(
+        () => previewSignals.length === 1,
+        "Quick open did not request the first preview",
+      );
+
+      pickerProps().onFocus?.("src/fast.ts");
+      await waitFor(
+        () => previewSignals.length === 2,
+        "Quick open did not request the second preview",
+      );
+      expect(previewSignals[0]?.aborted).toBe(true);
+      expect(harness.readFileInRange).toHaveBeenLastCalledWith(
+        "/workspace/project/src/fast.ts",
+        0,
+        1,
+        undefined,
+        expect.any(AbortSignal),
+      );
+
+      slowPreview.resolve({ content: "stale preview" });
+      fastPreview.resolve({ content: "fresh preview" });
+      await waitFor(
+        async () => (await renderedPreview("src/fast.ts")).includes("fresh preview"),
+        "Quick open did not render the fresh preview",
+      );
+      expect(await renderedPreview("src/fast.ts")).not.toContain("stale preview");
+
+      pickerProps().onFocus?.(undefined);
+      await waitFor(
+        async () =>
+          (await renderedPreview("src/fast.ts")).includes("Loading preview..."),
+        "Quick open did not clear the preview when focus cleared",
+      );
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("reports preview failures and inserts paths through alternate picker actions", async () => {
+    const rendered = await renderDialog();
+
+    try {
+      harness.generateFileSuggestions.mockResolvedValueOnce([
+        { id: "file-broken", displayText: "src/broken.ts" },
+      ]);
+      harness.readFileInRange.mockRejectedValueOnce(new Error("cannot preview"));
+
+      pickerProps().onQueryChange("broken");
+      await waitFor(
+        () => pickerProps().items.length === 1,
+        "Quick open did not render the broken file result",
+      );
+
+      pickerProps().onFocus?.("src/broken.ts");
+      await waitFor(
+        async () =>
+          (await renderedPreview("src/broken.ts")).includes(
+            "(preview unavailable)",
+          ),
+        "Quick open did not render preview failure content",
+      );
+
+      pickerProps().onTab?.handler("src/broken.ts");
+      expect(rendered.onInsert).toHaveBeenCalledWith("@src/broken.ts ");
+      expect(harness.logEvent).toHaveBeenCalledWith("agenc_quick_open_insert", {
+        mention: true,
+        result_count: 1,
+      });
+
+      pickerProps().onShiftTab?.handler("src/broken.ts");
+      expect(rendered.onInsert).toHaveBeenCalledWith("src/broken.ts ");
+      expect(harness.logEvent).toHaveBeenCalledWith("agenc_quick_open_insert", {
+        mention: false,
+        result_count: 1,
+      });
+      expect(rendered.onDone).toHaveBeenCalledTimes(2);
+    } finally {
+      await rendered.dispose();
+    }
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-166-ink-dom.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-166-ink-dom.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  appendChildNode,
+  clearYogaNodeReferences,
+  createNode,
+  createTextNode,
+  findOwnerChainAtRow,
+  insertBeforeNode,
+  removeChildNode,
+  setStyle,
+  setTextStyles,
+  type DOMElement,
+  type DOMNode,
+} from '../../../src/tui/ink/dom.ts'
+import applyStyles, { type Styles } from '../../../src/tui/ink/styles.ts'
+
+function applyNodeStyle(node: DOMElement, style: Styles): void {
+  setStyle(node, style)
+  if (node.yogaNode) applyStyles(node.yogaNode, style, node.style)
+}
+
+function appendText(parent: DOMElement, text: string): void {
+  appendChildNode(parent, createTextNode(text) as unknown as DOMElement)
+}
+
+describe('ink DOM coverage swarm row 166', () => {
+  test('inserts layout children before a layout sibling after non-layout nodes', () => {
+    const parent = createNode('ink-box')
+    applyNodeStyle(parent, {
+      flexDirection: 'row',
+      height: 1,
+      width: 20,
+    })
+
+    const virtualText = createNode('ink-virtual-text')
+    const link = createNode('ink-link')
+    const progress = createNode('ink-progress')
+    const firstLayout = createNode('ink-box')
+    const insertedLayout = createNode('ink-box')
+
+    applyNodeStyle(firstLayout, { height: 1, width: 4 })
+    applyNodeStyle(insertedLayout, { height: 1, width: 3 })
+
+    expect(virtualText.yogaNode).toBeUndefined()
+    expect(link.yogaNode).toBeUndefined()
+    expect(progress.yogaNode).toBeUndefined()
+
+    appendChildNode(parent, virtualText)
+    appendChildNode(parent, link)
+    appendChildNode(parent, progress)
+    appendChildNode(parent, firstLayout)
+    insertBeforeNode(parent, insertedLayout, firstLayout)
+
+    expect(parent.childNodes).toEqual([
+      virtualText,
+      link,
+      progress,
+      insertedLayout,
+      firstLayout,
+    ])
+    expect(parent.yogaNode?.getChildCount()).toBe(2)
+
+    parent.yogaNode?.calculateLayout(20, 1)
+
+    expect(insertedLayout.yogaNode?.getComputedLeft()).toBe(0)
+    expect(firstLayout.yogaNode?.getComputedLeft()).toBe(3)
+  })
+
+  test('measures text in intrinsic, constrained, and sub-column layouts', () => {
+    const intrinsicText = createNode('ink-text')
+    appendText(intrinsicText, 'abcdef\nx')
+
+    intrinsicText.yogaNode?.calculateLayout()
+
+    expect(intrinsicText.yogaNode?.getComputedWidth()).toBe(6)
+    expect(intrinsicText.yogaNode?.getComputedHeight()).toBe(2)
+
+    const wrappedText = createNode('ink-text')
+    appendText(wrappedText, 'abcdef')
+
+    wrappedText.yogaNode?.calculateLayout(3)
+
+    expect(wrappedText.yogaNode?.getComputedWidth()).toBe(3)
+    expect(wrappedText.yogaNode?.getComputedHeight()).toBe(2)
+
+    const tooNarrowText = createNode('ink-text')
+    appendText(tooNarrowText, 'abcd')
+
+    tooNarrowText.yogaNode?.calculateLayout(0.5)
+
+    expect(tooNarrowText.yogaNode?.getComputedWidth()).toBe(1)
+    expect(tooNarrowText.yogaNode?.getComputedHeight()).toBe(1)
+  })
+
+  test('keeps style dirty flags stable for shallow-equal updates', () => {
+    const node = createNode('ink-box')
+
+    setStyle(node, undefined)
+    expect(node.dirty).toBe(false)
+
+    setStyle(node, { height: 1, width: 2 })
+    expect(node.dirty).toBe(true)
+
+    node.dirty = false
+    setStyle(node, { height: 1, width: 2 })
+    expect(node.dirty).toBe(false)
+
+    setStyle(node, { height: 1 })
+    expect(node.dirty).toBe(true)
+
+    node.dirty = false
+    setTextStyles(node, { bold: true })
+    expect(node.dirty).toBe(true)
+
+    node.dirty = false
+    setTextStyles(node, { bold: false })
+    expect(node.dirty).toBe(true)
+  })
+
+  test('handles orphan removals and non-element owner lookups', () => {
+    const parent = createNode('ink-box')
+    const child = createNode('ink-box')
+    const text = createTextNode('loose')
+
+    removeChildNode(parent, child)
+    removeChildNode(parent, text as DOMNode)
+
+    expect(parent.childNodes).toEqual([])
+    expect(child.parentNode).toBeUndefined()
+    expect(text.parentNode).toBeUndefined()
+    expect(parent.dirty).toBe(true)
+    expect(findOwnerChainAtRow(createNode('ink-link'), 0)).toEqual([])
+  })
+
+  test('clears yoga references across element and text descendants', () => {
+    const root = createNode('ink-root')
+    const box = createNode('ink-box')
+    const text = createTextNode('text')
+
+    appendChildNode(box, text as unknown as DOMElement)
+    appendChildNode(root, box)
+
+    expect(root.yogaNode).toBeDefined()
+    expect(box.yogaNode).toBeDefined()
+
+    clearYogaNodeReferences(root)
+
+    expect(root.yogaNode).toBeUndefined()
+    expect(box.yogaNode).toBeUndefined()
+    expect(text.yogaNode).toBeUndefined()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-167-ink-components-Button.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-167-ink-components-Button.test.tsx
@@ -1,0 +1,218 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { describe, expect, test, vi } from "vitest";
+
+import Button from "../../../src/tui/ink/components/Button.js";
+import type { ButtonState } from "../../../src/tui/ink/components/Button.js";
+import Text from "../../../src/tui/ink/components/Text.js";
+import type { DOMElement } from "../../../src/tui/ink/dom.js";
+import { createRoot } from "../../../src/tui/ink/root.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+type TestRoot = Awaited<ReturnType<typeof createRoot>>;
+type HandlerMap = NonNullable<DOMElement["_eventHandlers"]>;
+
+function createTestStreams(): {
+  stdin: TestStdin;
+  stdout: PassThrough;
+} {
+  const stdout = new PassThrough();
+  stdout.resume();
+  (stdout as unknown as { columns: number }).columns = 80;
+  (stdout as unknown as { rows: number }).rows = 24;
+  (stdout as unknown as { isTTY: boolean }).isTTY = true;
+
+  const stdin = new PassThrough() as TestStdin;
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await sleep(10);
+  }
+
+  throw new Error(message);
+}
+
+async function withRoot(
+  run: (root: TestRoot) => Promise<void> | void,
+): Promise<void> {
+  const { stdin, stdout } = createTestStreams();
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  try {
+    await run(root);
+  } finally {
+    root.unmount();
+    stdin.end();
+    stdout.end();
+    await sleep();
+  }
+}
+
+async function requireRef(
+  ref: React.RefObject<DOMElement | null>,
+): Promise<DOMElement> {
+  await waitForCondition(() => ref.current !== null, "Button box did not mount");
+  if (!ref.current) throw new Error("Button ref was not attached");
+  return ref.current;
+}
+
+function handlersFor(box: DOMElement): HandlerMap {
+  if (!box._eventHandlers) throw new Error("Button handlers were not attached");
+  return box._eventHandlers;
+}
+
+describe("Button coverage swarm row 167", () => {
+  test("forwards default tabIndex, style props, static children, and click activation", async () => {
+    await withRoot(async root => {
+      const buttonRef = React.createRef<DOMElement>();
+      const onAction = vi.fn();
+
+      root.render(
+        <Button
+          ref={buttonRef}
+          borderColor="green"
+          borderStyle="round"
+          marginX={1}
+          onAction={onAction}
+          paddingX={2}
+        >
+          <Text>static child</Text>
+        </Button>,
+      );
+
+      const box = await requireRef(buttonRef);
+      const handlers = handlersFor(box);
+
+      expect(box.nodeName).toBe("ink-box");
+      expect(box.attributes).toMatchObject({
+        tabIndex: 0,
+      });
+      expect(box.style).toMatchObject({
+        borderColor: "green",
+        borderStyle: "round",
+        marginX: 1,
+        paddingX: 2,
+      });
+      expect(box.childNodes.some(child => child.nodeName === "ink-text")).toBe(true);
+
+      (handlers.onClick as (event: unknown) => void)({});
+
+      expect(onAction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("updates render-prop state for focus, hover, keyboard activation, and reset", async () => {
+    await withRoot(async root => {
+      const buttonRef = React.createRef<DOMElement>();
+      const onAction = vi.fn();
+      const states: ButtonState[] = [];
+
+      root.render(
+        <Button ref={buttonRef} autoFocus onAction={onAction} tabIndex={5}>
+          {state => {
+            states.push({ ...state });
+            return (
+              <Text>
+                {state.focused ? "focused" : "blurred"}-
+                {state.hovered ? "hovered" : "plain"}-
+                {state.active ? "active" : "idle"}
+              </Text>
+            );
+          }}
+        </Button>,
+      );
+
+      const box = await requireRef(buttonRef);
+      const handlers = handlersFor(box);
+
+      expect(box.attributes).toMatchObject({
+        autoFocus: true,
+        tabIndex: 5,
+      });
+
+      (handlers.onMouseEnter as () => void)();
+      await waitForCondition(
+        () => states.some(state => state.hovered),
+        "Button hover state did not render",
+      );
+
+      (handlers.onFocus as (event: unknown) => void)({});
+      await waitForCondition(
+        () => states.some(state => state.focused),
+        "Button focus state did not render",
+      );
+
+      const ignoredPreventDefault = vi.fn();
+      (handlers.onKeyDown as (event: { key: string; preventDefault: () => void }) => void)({
+        key: "escape",
+        preventDefault: ignoredPreventDefault,
+      });
+
+      expect(ignoredPreventDefault).not.toHaveBeenCalled();
+      expect(onAction).not.toHaveBeenCalled();
+
+      const returnPreventDefault = vi.fn();
+      (handlers.onKeyDown as (event: { key: string; preventDefault: () => void }) => void)({
+        key: "return",
+        preventDefault: returnPreventDefault,
+      });
+
+      expect(returnPreventDefault).toHaveBeenCalledTimes(1);
+      expect(onAction).toHaveBeenCalledTimes(1);
+      await waitForCondition(
+        () => states.some(state => state.active),
+        "Button active state did not render",
+      );
+      await waitForCondition(
+        () => states.at(-1)?.active === false,
+        "Button active state did not reset",
+      );
+
+      const spacePreventDefault = vi.fn();
+      (handlers.onKeyDown as (event: { key: string; preventDefault: () => void }) => void)({
+        key: " ",
+        preventDefault: spacePreventDefault,
+      });
+
+      expect(spacePreventDefault).toHaveBeenCalledTimes(1);
+      expect(onAction).toHaveBeenCalledTimes(2);
+
+      (handlers.onBlur as (event: unknown) => void)({});
+      (handlers.onMouseLeave as () => void)();
+
+      await waitForCondition(
+        () => states.at(-1)?.focused === false && states.at(-1)?.hovered === false,
+        "Button blur and mouse leave state did not render",
+      );
+    });
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-168-message-renderers-TaskAssignmentMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-168-message-renderers-TaskAssignmentMessage.test.tsx
@@ -1,0 +1,197 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { describe, expect, test } from 'vitest'
+
+import { createRoot } from '../../../src/tui/ink.js'
+import {
+  getTaskAssignmentSummary,
+  TaskAssignmentDisplay,
+  tryRenderTaskAssignmentMessage,
+} from '../../../src/tui/message-renderers/TaskAssignmentMessage.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+import type { TaskAssignmentMessage } from '../../../src/utils/teammateMailbox.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestStdout = PassThrough & {
+  columns: number
+  rows: number
+  isTTY: boolean
+}
+
+function createStreams(): {
+  readonly stdin: TestStdin
+  readonly stdout: TestStdout
+} {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough() as TestStdout
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 100
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function normalize(output: string): string {
+  return output.replace(/\s+/g, ' ').trim()
+}
+
+function compact(output: string): string {
+  return output.replace(/\s+/g, '')
+}
+
+function payload(value: Record<string, unknown>): string {
+  return JSON.stringify(value)
+}
+
+function assignment(overrides: Partial<TaskAssignmentMessage> = {}): TaskAssignmentMessage {
+  return {
+    type: 'task_assignment',
+    taskId: '168',
+    subject: 'Cover TaskAssignmentMessage',
+    description: 'Exercise the assignment body branch.',
+    assignedBy: 'lead',
+    timestamp: '2026-05-20T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function renderAssignment(
+  value: TaskAssignmentMessage,
+): React.ReactElement {
+  return <TaskAssignmentDisplay assignment={value} />
+}
+
+async function renderAssignmentSequence(
+  values: readonly TaskAssignmentMessage[],
+): Promise<string> {
+  const { stdin, stdout } = createStreams()
+  let output = ''
+
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  try {
+    for (const value of values) {
+      root.render(renderAssignment(value))
+      await sleep()
+    }
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await sleep()
+  }
+
+  return normalize(stripAnsi(output))
+}
+
+describe('TaskAssignmentMessage coverage swarm 168', () => {
+  test('renders assignment details across cached rerenders and optional descriptions', async () => {
+    const full = assignment()
+    const withoutDescription = assignment({
+      description: '',
+      subject: 'Cover optional description branch',
+    })
+
+    const output = await renderAssignmentSequence([
+      full,
+      full,
+      withoutDescription,
+      withoutDescription,
+      assignment({
+        taskId: '168-next',
+        subject: 'Cover changed assignment title',
+        description: 'Exercise updated assignment details.',
+      }),
+    ])
+
+    const compactOutput = compact(output)
+    expect(compactOutput).toContain('Task#168assignedbylead')
+    expect(compactOutput).toContain('CoverTaskAssignmentMessage')
+    expect(compactOutput).toContain('Exercisetheassignmentbodybranch.')
+
+    const emptyDescriptionOutput = normalize(
+      await renderToString(renderAssignment(withoutDescription), {
+        columns: 100,
+        rows: 12,
+      }),
+    )
+
+    expect(emptyDescriptionOutput).toContain('Task #168 assigned by lead')
+    expect(emptyDescriptionOutput).toContain('Cover optional description branch')
+    expect(emptyDescriptionOutput).not.toContain('undefined')
+
+    const changedOutput = normalize(
+      await renderToString(
+        renderAssignment(
+          assignment({
+            taskId: '168-next',
+            subject: 'Cover changed assignment title',
+            description: 'Exercise updated assignment details.',
+          }),
+        ),
+        { columns: 100, rows: 12 },
+      ),
+    )
+
+    expect(changedOutput).toContain('Task #168-next assigned by lead')
+    expect(changedOutput).toContain('Cover changed assignment title')
+    expect(changedOutput).toContain('Exercise updated assignment details.')
+  })
+
+  test('parses valid assignment payloads and ignores non-assignment content', async () => {
+    const content = payload(assignment({
+      taskId: '168-json',
+      subject: 'Parse task assignment payload',
+      description: '',
+      assignedBy: 'coordinator',
+    }))
+
+    const node = tryRenderTaskAssignmentMessage(content)
+    expect(React.isValidElement(node)).toBe(true)
+
+    const output = normalize(
+      await renderToString(<>{node}</>, { columns: 100, rows: 12 }),
+    )
+
+    expect(output).toContain('Task #168-json assigned by coordinator')
+    expect(output).toContain('Parse task assignment payload')
+    expect(output).not.toContain('undefined')
+    expect(getTaskAssignmentSummary(content)).toBe(
+      '[Task Assigned] #168-json - Parse task assignment payload',
+    )
+
+    expect(
+      tryRenderTaskAssignmentMessage(payload({ type: 'teammate_message' })),
+    ).toBeNull()
+    expect(tryRenderTaskAssignmentMessage('{not json')).toBeNull()
+    expect(getTaskAssignmentSummary(payload({ type: 'teammate_message' }))).toBeNull()
+    expect(getTaskAssignmentSummary('{not json')).toBeNull()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-169-message-renderers-UserBashOutputMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-169-message-renderers-UserBashOutputMessage.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { UserBashOutputMessage } from '../../../src/tui/message-renderers/UserBashOutputMessage.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+
+describe('UserBashOutputMessage coverage swarm row 169', () => {
+  test('renders raw stdout and stderr when stdout has no persisted-output tag', async () => {
+    const output = await renderToString(
+      <UserBashOutputMessage
+        content={[
+          '<bash-stdout>',
+          'plain stdout',
+          '</bash-stdout>',
+          '<bash-stderr>',
+          'plain stderr',
+          '</bash-stderr>',
+        ].join('\n')}
+        verbose={true}
+      />,
+      { columns: 100, rows: 8 },
+    )
+
+    expect(output).toContain('plain stdout')
+    expect(output).toContain('plain stderr')
+    expect(output).not.toContain('(No output)')
+  })
+
+  test('uses the persisted stdout preview instead of the raw output envelope', async () => {
+    const output = await renderToString(
+      <UserBashOutputMessage
+        content={[
+          '<bash-stdout>',
+          'raw output that should be hidden',
+          '<persisted-output>',
+          'persisted preview',
+          '</persisted-output>',
+          '</bash-stdout>',
+        ].join('\n')}
+        verbose={true}
+      />,
+      { columns: 100, rows: 8 },
+    )
+
+    expect(output).toContain('persisted preview')
+    expect(output).not.toContain('raw output that should be hidden')
+    expect(output).not.toContain('<persisted-output>')
+  })
+
+  test('shows the empty-output fallback when bash output tags are absent', async () => {
+    const output = await renderToString(
+      <UserBashOutputMessage content="legacy untagged shell text" />,
+      { columns: 100, rows: 8 },
+    )
+
+    expect(output).toContain('(No output)')
+    expect(output).not.toContain('legacy untagged shell text')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-170-vim-transitions.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-170-vim-transitions.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import { TextCursor } from 'src/utils/TextCursor.js'
+import { transition, type TransitionContext } from 'src/tui/vim/transitions.js'
+import type { CommandState, FindType, RecordedChange } from 'src/tui/vim/types.js'
+
+function makeContext(
+  initialText: string,
+  initialOffset = 0,
+  includeCallbacks = true,
+): {
+  ctx: TransitionContext
+  state: {
+    text: string
+    offset: number
+    register: string
+    linewise: boolean
+    lastFind: { type: FindType; char: string } | null
+    changes: RecordedChange[]
+    enteredInsertAt: number | null
+    onUndo: ReturnType<typeof vi.fn>
+    onDotRepeat: ReturnType<typeof vi.fn>
+  }
+} {
+  const state = {
+    text: initialText,
+    offset: initialOffset,
+    register: '',
+    linewise: false,
+    lastFind: null as { type: FindType; char: string } | null,
+    changes: [] as RecordedChange[],
+    enteredInsertAt: null as number | null,
+    onUndo: vi.fn(),
+    onDotRepeat: vi.fn(),
+  }
+  const callbacks = includeCallbacks
+    ? { onUndo: state.onUndo, onDotRepeat: state.onDotRepeat }
+    : {}
+  const ctx: TransitionContext = {
+    get cursor() {
+      return TextCursor.fromText(state.text, 80, state.offset)
+    },
+    get text() {
+      return state.text
+    },
+    setText: text => {
+      state.text = text
+    },
+    setOffset: offset => {
+      state.offset = offset
+    },
+    enterInsert: offset => {
+      state.enteredInsertAt = offset
+      state.offset = offset
+    },
+    getRegister: () => state.register,
+    setRegister: (content, linewise) => {
+      state.register = content
+      state.linewise = linewise
+    },
+    getLastFind: () => state.lastFind,
+    setLastFind: (type, char) => {
+      state.lastFind = { type, char }
+    },
+    recordChange: change => {
+      state.changes.push(change)
+    },
+    ...callbacks,
+  }
+  return { ctx, state }
+}
+
+function input(
+  command: CommandState,
+  key: string,
+  ctx: TransitionContext,
+): CommandState {
+  const result = transition(command, key, ctx)
+  result.execute?.()
+  return result.next ?? { type: 'idle' }
+}
+
+describe('vim transitions coverage swarm row 170', () => {
+  test('covers counted normal motions, missing find targets, and omitted callbacks', () => {
+    const moved = makeContext('one two three')
+    let command = input({ type: 'idle' }, '2', moved.ctx)
+    command = input(command, 'w', moved.ctx)
+
+    expect(command).toEqual({ type: 'idle' })
+    expect(moved.state.offset).toBe('one two '.length)
+
+    const missingFind = makeContext('abc')
+    command = input({ type: 'idle' }, 'f', missingFind.ctx)
+    expect(command).toEqual({ type: 'find', find: 'f', count: 1 })
+    command = input(command, 'z', missingFind.ctx)
+
+    expect(command).toEqual({ type: 'idle' })
+    expect(missingFind.state.offset).toBe(0)
+    expect(missingFind.state.lastFind).toBeNull()
+
+    const noCallbacks = makeContext('abc', 0, false)
+    expect(() => input({ type: 'idle' }, 'u', noCallbacks.ctx)).not.toThrow()
+    expect(() => input({ type: 'idle' }, '.', noCallbacks.ctx)).not.toThrow()
+    expect(noCallbacks.state.onUndo).not.toHaveBeenCalled()
+    expect(noCallbacks.state.onDotRepeat).not.toHaveBeenCalled()
+  })
+
+  test('routes operator-count commands through motion, find, and text-object states', () => {
+    const clamped = makeContext('alpha beta')
+    expect(
+      transition(
+        { type: 'operatorCount', op: 'delete', count: 1, digits: '9999' },
+        '9',
+        clamped.ctx,
+      ).next,
+    ).toEqual({
+      type: 'operatorCount',
+      op: 'delete',
+      count: 1,
+      digits: '10000',
+    })
+
+    const motion = makeContext('one two three four')
+    let command = input({ type: 'idle' }, 'd', motion.ctx)
+    command = input(command, '2', motion.ctx)
+    command = input(command, 'w', motion.ctx)
+
+    expect(command).toEqual({ type: 'idle' })
+    expect(motion.state.text).toBe('three four')
+    expect(motion.state.register).toBe('one two ')
+    expect(motion.state.changes).toEqual([
+      { type: 'operator', op: 'delete', motion: 'w', count: 2 },
+    ])
+
+    const find = makeContext('a-b-c-d')
+    command = input({ type: 'idle' }, 'd', find.ctx)
+    command = input(command, '2', find.ctx)
+    command = input(command, 'f', find.ctx)
+    expect(command).toEqual({
+      type: 'operatorFind',
+      op: 'delete',
+      count: 2,
+      find: 'f',
+    })
+    command = input(command, '-', find.ctx)
+
+    expect(command).toEqual({ type: 'idle' })
+    expect(find.state.text).toBe('c-d')
+    expect(find.state.register).toBe('a-b-')
+
+    const textObject = makeContext('say "hello"', 6)
+    command = input({ type: 'idle' }, 'y', textObject.ctx)
+    command = input(command, '1', textObject.ctx)
+    command = input(command, 'i', textObject.ctx)
+    expect(command).toEqual({
+      type: 'operatorTextObj',
+      op: 'yank',
+      count: 1,
+      scope: 'inner',
+    })
+    command = input(command, '"', textObject.ctx)
+
+    expect(command).toEqual({ type: 'idle' })
+    expect(textObject.state.text).toBe('say "hello"')
+    expect(textObject.state.register).toBe('hello')
+  })
+
+  test('covers g-prefixed operator branches and repeat-find reversal variants', () => {
+    const oversizedGg = makeContext('one\ntwo\nthree')
+    let command = input({ type: 'idle' }, '9', oversizedGg.ctx)
+    command = input(command, 'g', oversizedGg.ctx)
+    command = input(command, 'g', oversizedGg.ctx)
+
+    expect(command).toEqual({ type: 'idle' })
+    expect(oversizedGg.state.offset).toBe('one\ntwo\n'.length)
+
+    const previousBigWordEnd = makeContext(
+      'one two three',
+      'one two three'.indexOf('three'),
+    )
+    command = input({ type: 'idle' }, 'g', previousBigWordEnd.ctx)
+    command = input(command, 'E', previousBigWordEnd.ctx)
+
+    expect(command).toEqual({ type: 'idle' })
+    expect(previousBigWordEnd.state.offset).toBe('one two'.length - 1)
+
+    const yankVisualDown = makeContext('a\nb')
+    command = input(
+      { type: 'operatorG', op: 'yank', count: 1 },
+      'j',
+      yankVisualDown.ctx,
+    )
+
+    expect(command).toEqual({ type: 'idle' })
+    expect(yankVisualDown.state.changes).toEqual([
+      { type: 'operator', op: 'yank', motion: 'gj', count: 1 },
+    ])
+
+    const yankVisualUp = makeContext('a\nb', 2)
+    command = input(
+      { type: 'operatorG', op: 'yank', count: 1 },
+      'k',
+      yankVisualUp.ctx,
+    )
+
+    expect(command).toEqual({ type: 'idle' })
+    expect(yankVisualUp.state.changes).toEqual([
+      { type: 'operator', op: 'yank', motion: 'gk', count: 1 },
+    ])
+
+    const deleteToFirst = makeContext('one\ntwo\nthree', 5)
+    command = input({ type: 'idle' }, 'd', deleteToFirst.ctx)
+    command = input(command, 'g', deleteToFirst.ctx)
+    command = input(command, 'g', deleteToFirst.ctx)
+
+    expect(command).toEqual({ type: 'idle' })
+    expect(deleteToFirst.state.text).toBe('three')
+    expect(deleteToFirst.state.register).toBe('one\ntwo\n')
+    expect(deleteToFirst.state.linewise).toBe(true)
+
+    const reverseTill = makeContext('ab-cd-ef', 7)
+    reverseTill.state.lastFind = { type: 't', char: '-' }
+    input({ type: 'idle' }, 'N', reverseTill.ctx)
+    expect(reverseTill.state.offset).toBe(6)
+
+    const forwardTill = makeContext('ab-cd-ef')
+    forwardTill.state.lastFind = { type: 'T', char: '-' }
+    input({ type: 'idle' }, 'N', forwardTill.ctx)
+    expect(forwardTill.state.offset).toBe(1)
+
+    const noOperatorFindMemory = makeContext('abc')
+    command = input({ type: 'idle' }, 'd', noOperatorFindMemory.ctx)
+    command = input(command, ';', noOperatorFindMemory.ctx)
+
+    expect(command).toEqual({ type: 'idle' })
+    expect(noOperatorFindMemory.state.text).toBe('abc')
+    expect(noOperatorFindMemory.state.changes).toEqual([])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-171-components-HelpV2-HelpV2.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-171-components-HelpV2-HelpV2.test.tsx
@@ -1,0 +1,420 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { Command } from "../../../src/commands.js";
+
+type KeybindingRecord = {
+  action: string;
+  handler: () => void;
+  options: {
+    context?: string;
+    isActive?: boolean;
+  };
+};
+
+type CommandPanelRecord = {
+  columns: number;
+  emptyMessage?: string;
+  maxHeight: number;
+  names: string[];
+  title: string;
+};
+
+const harness = vi.hoisted(() => ({
+  commandPanels: [] as CommandPanelRecord[],
+  exitHandler: undefined as (() => void) | undefined,
+  exitState: {
+    keyName: "ctrl+c",
+    pending: false,
+  },
+  insideModal: false,
+  keybindings: [] as KeybindingRecord[],
+  modalSize: undefined as { columns: number; rows: number } | undefined,
+  panes: [] as Array<{ color?: string }>,
+  shortcut: "esc",
+  tabs: [] as Array<{
+    color?: string;
+    defaultTab?: string;
+    title?: string;
+  }>,
+  terminalSize: {
+    columns: 100,
+    rows: 24,
+  },
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: () => false,
+}));
+
+vi.mock("src/tui/hooks/useExitOnCtrlCDWithKeybindings.js", () => ({
+  useExitOnCtrlCDWithKeybindings: (handler: () => void) => {
+    harness.exitHandler = handler;
+    return harness.exitState;
+  },
+}));
+
+vi.mock("../../../src/commands.js", () => ({
+  builtInCommandNames: () => new Set(["help", "status"]),
+}));
+
+vi.mock("../../../src/tui/context/modalContext.js", () => ({
+  useIsInsideModal: () => harness.insideModal,
+  useModalOrTerminalSize: (fallback: { columns: number; rows: number }) =>
+    harness.modalSize ?? fallback,
+}));
+
+vi.mock("../../../src/tui/hooks/useTerminalSize.js", () => ({
+  useTerminalSize: () => harness.terminalSize,
+}));
+
+vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
+  useKeybinding: (
+    action: string,
+    handler: () => void,
+    options: KeybindingRecord["options"] = {},
+  ) => {
+    harness.keybindings.push({ action, handler, options });
+  },
+}));
+
+vi.mock("../../../src/tui/keybindings/useShortcutDisplay.js", () => ({
+  useShortcutDisplay: () => harness.shortcut,
+}));
+
+vi.mock("../../../src/tui/components/design-system/Pane.js", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+  const { default: Box } = await vi.importActual<
+    typeof import("../../../src/tui/ink/components/Box.js")
+  >("../../../src/tui/ink/components/Box.js");
+
+  return {
+    Pane: (props: { children?: React.ReactNode; color?: string }) => {
+      harness.panes.push({ color: props.color });
+      return ReactActual.createElement(
+        Box,
+        { flexDirection: "column" },
+        props.children,
+      );
+    },
+  };
+});
+
+vi.mock("../../../src/tui/components/design-system/Tabs.js", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+  const { default: Box } = await vi.importActual<
+    typeof import("../../../src/tui/ink/components/Box.js")
+  >("../../../src/tui/ink/components/Box.js");
+  const { default: Text } = await vi.importActual<
+    typeof import("../../../src/tui/ink/components/Text.js")
+  >("../../../src/tui/ink/components/Text.js");
+
+  return {
+    Tab: (props: { children?: React.ReactNode; title: string }) =>
+      ReactActual.createElement(
+        Box,
+        { flexDirection: "column" },
+        ReactActual.createElement(Text, null, `tab:${props.title}`),
+        props.children,
+      ),
+    Tabs: (props: {
+      children?: React.ReactNode;
+      color?: string;
+      defaultTab?: string;
+      title?: string;
+    }) => {
+      harness.tabs.push({
+        color: props.color,
+        defaultTab: props.defaultTab,
+        title: props.title,
+      });
+
+      return ReactActual.createElement(
+        Box,
+        { flexDirection: "column" },
+        ReactActual.createElement(
+          Text,
+          null,
+          `tabs:${props.title}:${props.color}:${props.defaultTab}`,
+        ),
+        props.children,
+      );
+    },
+  };
+});
+
+vi.mock("../../../src/tui/components/HelpV2/Commands.js", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+  const { default: Text } = await vi.importActual<
+    typeof import("../../../src/tui/ink/components/Text.js")
+  >("../../../src/tui/ink/components/Text.js");
+
+  return {
+    Commands: (props: {
+      columns: number;
+      commands: Array<{ name: string }>;
+      emptyMessage?: string;
+      maxHeight: number;
+      title: string;
+    }) => {
+      const names = props.commands.map(command => command.name);
+      harness.commandPanels.push({
+        columns: props.columns,
+        emptyMessage: props.emptyMessage,
+        maxHeight: props.maxHeight,
+        names,
+        title: props.title,
+      });
+
+      return ReactActual.createElement(
+        Text,
+        null,
+        `commands:${props.title}:${names.join(",")}:${
+          props.emptyMessage ?? ""
+        }`,
+      );
+    },
+  };
+});
+
+vi.mock("../../../src/tui/components/HelpV2/General.js", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+  const { default: Text } = await vi.importActual<
+    typeof import("../../../src/tui/ink/components/Text.js")
+  >("../../../src/tui/ink/components/Text.js");
+
+  return {
+    General: () => ReactActual.createElement(Text, null, "general-help"),
+  };
+});
+
+import { HelpV2 } from "../../../src/tui/components/HelpV2/HelpV2.js";
+import { createRoot, type Root } from "../../../src/tui/ink.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+type TestStdout = PassThrough & {
+  columns: number;
+  isTTY: boolean;
+  rows: number;
+};
+
+function makeCommand(
+  name: string,
+  overrides: Partial<Command> = {},
+): Command {
+  return {
+    contentLength: name.length,
+    description: `${name} description`,
+    name,
+    progressMessage: "running",
+    type: "prompt",
+    ...overrides,
+  } as Command;
+}
+
+function createStreams(): {
+  output: () => string;
+  stdin: TestStdin;
+  stdout: TestStdout;
+} {
+  const stdin = new PassThrough() as TestStdin;
+  const stdout = new PassThrough() as TestStdout;
+  let rendered = "";
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+
+  stdout.columns = 120;
+  stdout.rows = 30;
+  stdout.isTTY = true;
+  stdout.on("data", chunk => {
+    rendered += chunk.toString();
+  });
+  stdout.resume();
+
+  return {
+    output: () => stripAnsi(rendered),
+    stdin,
+    stdout,
+  };
+}
+
+function sleep(ms = 30): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function compactText(text: string): string {
+  return text.replace(/\s+/g, "");
+}
+
+async function renderHelp(props: {
+  commands: Command[];
+  onClose: (result?: string, options?: { display?: string }) => void;
+  query?: string;
+}): Promise<{
+  output: () => string;
+  render: (nextProps: typeof props) => Promise<void>;
+  root: Root;
+  unmount: () => void;
+}> {
+  const { output, stdin, stdout } = createStreams();
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  const render = async (nextProps: typeof props): Promise<void> => {
+    root.render(<HelpV2 {...nextProps} />);
+    await sleep();
+  };
+
+  await render(props);
+
+  return {
+    output,
+    render,
+    root,
+    unmount: () => {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    },
+  };
+}
+
+function latestPanel(title: string): CommandPanelRecord {
+  const panel = [...harness.commandPanels]
+    .reverse()
+    .find(candidate => candidate.title === title);
+
+  if (!panel) {
+    throw new Error(`No command panel found for ${title}`);
+  }
+
+  return panel;
+}
+
+describe("HelpV2 coverage swarm row 171", () => {
+  beforeEach(() => {
+    harness.commandPanels = [];
+    harness.exitHandler = undefined;
+    harness.exitState = {
+      keyName: "ctrl+c",
+      pending: false,
+    };
+    harness.insideModal = false;
+    harness.keybindings = [];
+    harness.modalSize = undefined;
+    harness.panes = [];
+    harness.shortcut = "esc";
+    harness.tabs = [];
+    harness.terminalSize = {
+      columns: 100,
+      rows: 24,
+    };
+  });
+
+  test("filters commands, registers dismissal, and refreshes cached footer state", async () => {
+    const onClose = vi.fn();
+    const commands = [
+      makeCommand("help"),
+      makeCommand("status", { isHidden: true }),
+      makeCommand("deploy-project", { source: "plugin" }),
+      makeCommand("secret-project", { isHidden: true, source: "plugin" }),
+    ];
+    const props = { commands, onClose, query: "deploy" };
+    const rendered = await renderHelp(props);
+
+    try {
+      expect(harness.tabs.at(-1)).toEqual({
+        color: "professionalBlue",
+        defaultTab: "general",
+        title: "AgenC Help",
+      });
+      expect(harness.panes.at(-1)).toEqual({ color: "professionalBlue" });
+      expect(harness.keybindings.at(-1)).toMatchObject({
+        action: "help:dismiss",
+        options: { context: "Help" },
+      });
+
+      expect(latestPanel("Default commands matching deploy:")).toMatchObject({
+        columns: 100,
+        names: ["help"],
+      });
+      expect(latestPanel("Custom commands matching deploy:")).toMatchObject({
+        columns: 100,
+        emptyMessage: "No matching custom commands",
+        names: ["deploy-project"],
+      });
+      expect(compactText(rendered.output())).toContain("esctocancel");
+
+      harness.keybindings.at(-1)?.handler();
+      expect(onClose).toHaveBeenCalledWith("Help dialog dismissed", {
+        display: "system",
+      });
+
+      harness.exitHandler?.();
+      expect(onClose).toHaveBeenCalledTimes(2);
+
+      await rendered.render(props);
+      harness.exitState = {
+        keyName: "ctrl+d",
+        pending: true,
+      };
+      await rendered.render(props);
+
+      expect(compactText(rendered.output())).toContain("Pressctrl+dagaintoexit");
+    } finally {
+      rendered.unmount();
+    }
+  });
+
+  test("uses modal dimensions and no-query labels when rendered inside a modal", async () => {
+    const onClose = vi.fn();
+    const initialCommands = [makeCommand("help")];
+    const rendered = await renderHelp({
+      commands: initialCommands,
+      onClose,
+      query: "initial",
+    });
+
+    try {
+      harness.insideModal = true;
+      harness.modalSize = {
+        columns: 42,
+        rows: 10,
+      };
+
+      await rendered.render({
+        commands: [makeCommand("help")],
+        onClose,
+      });
+
+      expect(latestPanel("Browse default commands:")).toMatchObject({
+        columns: 42,
+        maxHeight: 5,
+        names: ["help"],
+      });
+      expect(latestPanel("Browse custom commands:")).toMatchObject({
+        columns: 42,
+        emptyMessage: "No custom commands found",
+        maxHeight: 5,
+        names: [],
+      });
+    } finally {
+      rendered.unmount();
+    }
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-172-hooks-useGlobalKeybindings.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-172-hooks-useGlobalKeybindings.test.tsx
@@ -1,0 +1,243 @@
+import { createRequire } from 'node:module'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from 'src/utils/staticRender.js'
+import type { Screen } from 'src/tui/types/screen.js'
+
+type ExpandedView = 'none' | 'tasks' | 'teammates'
+
+type AppState = {
+  expandedView: ExpandedView
+  isBriefOnly: boolean
+  showTeammateMessagePreview: boolean
+  tasks: Record<string, unknown>
+}
+
+type CapturedKeybinding = {
+  handler: () => void
+  options?: {
+    context?: string
+    isActive?: boolean
+  }
+}
+
+const fixture = vi.hoisted(() => ({
+  appState: {
+    expandedView: 'none',
+    isBriefOnly: false,
+    showTeammateMessagePreview: false,
+    tasks: {},
+  } as AppState,
+  briefEnabled: false,
+  features: new Set<string>(),
+  growthbookCalls: [] as Array<{ fallback: boolean; key: string }>,
+  keybindings: new Map<string, CapturedKeybinding>(),
+  logEvent: vi.fn(),
+  terminalAllowed: false,
+  terminalToggle: vi.fn(),
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => fixture.features.has(name),
+}))
+
+vi.mock('src/tui/keybindings/useKeybinding.js', () => ({
+  useKeybinding: (
+    action: string,
+    handler: () => void,
+    options?: CapturedKeybinding['options'],
+  ) => {
+    fixture.keybindings.set(action, { handler, options })
+  },
+}))
+
+vi.mock('src/tui/state/AppState.js', () => ({
+  useAppState: (selector: (state: AppState) => unknown) =>
+    selector(fixture.appState),
+  useSetAppState: () => (
+    update: AppState | ((prev: AppState) => AppState),
+  ) => {
+    fixture.appState =
+      typeof update === 'function' ? update(fixture.appState) : update
+  },
+}))
+
+vi.mock('src/services/analytics/index.js', () => ({
+  logEvent: fixture.logEvent,
+}))
+
+vi.mock('src/services/analytics/growthbook.js', () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: (key: string, fallback: boolean) => {
+    fixture.growthbookCalls.push({ fallback, key })
+    return key === 'agenc_terminal_panel' ? fixture.terminalAllowed : fallback
+  },
+}))
+
+vi.mock('src/utils/terminalPanel.js', () => ({
+  getTerminalPanel: () => ({
+    toggle: fixture.terminalToggle,
+  }),
+}))
+
+import { GlobalKeybindingHandlers } from 'src/tui/hooks/useGlobalKeybindings.js'
+
+const requireForTest = createRequire(import.meta.url)
+const moduleLoader = requireForTest('node:module') as {
+  _load: (request: string, parent: unknown, isMain: boolean) => unknown
+}
+
+function installLazyRequireMocks(): () => void {
+  const originalLoad = moduleLoader._load
+
+  moduleLoader._load = ((request: string, parent: unknown, isMain: boolean) => {
+    if (request === '../../tools/BriefTool/BriefTool') {
+      return {
+        isBriefEnabled: () => fixture.briefEnabled,
+      }
+    }
+
+    return Reflect.apply(originalLoad, moduleLoader, [request, parent, isMain])
+  }) as typeof originalLoad
+
+  return () => {
+    moduleLoader._load = originalLoad
+  }
+}
+
+function keybinding(action: string): CapturedKeybinding {
+  const binding = fixture.keybindings.get(action)
+  if (binding === undefined) {
+    throw new Error(`Missing keybinding: ${action}`)
+  }
+  return binding
+}
+
+async function renderHandlers(
+  overrides: Partial<React.ComponentProps<typeof GlobalKeybindingHandlers>> = {},
+): Promise<{
+  getScreen: () => Screen
+  getShowAllInTranscript: () => boolean
+  onEnterTranscript: ReturnType<typeof vi.fn>
+  onExitTranscript: ReturnType<typeof vi.fn>
+  setScreen: ReturnType<typeof vi.fn>
+  setShowAllInTranscript: ReturnType<typeof vi.fn>
+}> {
+  let screen = overrides.screen ?? 'prompt'
+  let showAllInTranscript = overrides.showAllInTranscript ?? true
+  const onEnterTranscript = vi.fn()
+  const onExitTranscript = vi.fn()
+  const setScreen = vi.fn((next: React.SetStateAction<Screen>) => {
+    screen = typeof next === 'function' ? next(screen) : next
+  })
+  const setShowAllInTranscript = vi.fn(
+    (next: React.SetStateAction<boolean>) => {
+      showAllInTranscript =
+        typeof next === 'function' ? next(showAllInTranscript) : next
+    },
+  )
+
+  await renderToString(
+    <GlobalKeybindingHandlers
+      screen={screen}
+      setScreen={setScreen}
+      showAllInTranscript={showAllInTranscript}
+      setShowAllInTranscript={setShowAllInTranscript}
+      messageCount={7}
+      onEnterTranscript={onEnterTranscript}
+      onExitTranscript={onExitTranscript}
+      {...overrides}
+    />,
+    100,
+  )
+
+  return {
+    getScreen: () => screen,
+    getShowAllInTranscript: () => showAllInTranscript,
+    onEnterTranscript,
+    onExitTranscript,
+    setScreen,
+    setShowAllInTranscript,
+  }
+}
+
+describe('GlobalKeybindingHandlers coverage swarm 172', () => {
+  beforeEach(() => {
+    fixture.appState = {
+      expandedView: 'none',
+      isBriefOnly: false,
+      showTeammateMessagePreview: false,
+      tasks: {},
+    }
+    fixture.briefEnabled = false
+    fixture.features = new Set()
+    fixture.growthbookCalls = []
+    fixture.keybindings = new Map()
+    fixture.terminalAllowed = false
+    vi.clearAllMocks()
+  })
+
+  test('toggles transcript back to prompt and leaves prompt-only transcript bindings inactive', async () => {
+    const rendered = await renderHandlers({ screen: 'transcript' })
+
+    keybinding('app:toggleTranscript').handler()
+
+    expect(rendered.getScreen()).toBe('prompt')
+    expect(rendered.getShowAllInTranscript()).toBe(false)
+    expect(rendered.onEnterTranscript).not.toHaveBeenCalled()
+    expect(rendered.onExitTranscript).toHaveBeenCalledTimes(1)
+    expect(fixture.logEvent).toHaveBeenCalledWith('agenc_toggle_transcript', {
+      is_entering: false,
+      message_count: 7,
+      show_all: true,
+    })
+
+    fixture.keybindings = new Map()
+    await renderHandlers({ screen: 'prompt' })
+
+    expect(keybinding('transcript:toggleShowAll').options).toEqual({
+      context: 'Transcript',
+      isActive: false,
+    })
+    expect(keybinding('transcript:exit').options).toEqual({
+      context: 'Transcript',
+      isActive: false,
+    })
+  })
+
+  test('does not query terminal-panel gates when the feature is disabled and redraw tolerates a missing stdout instance', async () => {
+    await renderHandlers()
+
+    keybinding('app:toggleTerminal').handler()
+    expect(fixture.growthbookCalls).toEqual([])
+    expect(fixture.terminalToggle).not.toHaveBeenCalled()
+
+    expect(() => keybinding('app:redraw').handler()).not.toThrow()
+  })
+
+  test('keeps stale brief-mode updates idempotent when the requested state is already applied', async () => {
+    fixture.features = new Set(['KAIROS_BRIEF'])
+    fixture.briefEnabled = true
+    const restoreLazyRequireMocks = installLazyRequireMocks()
+
+    try {
+      await renderHandlers()
+
+      fixture.appState.isBriefOnly = true
+      keybinding('app:toggleBrief').handler()
+
+      expect(fixture.appState.isBriefOnly).toBe(true)
+      expect(fixture.logEvent).toHaveBeenCalledWith(
+        'agenc_brief_mode_toggled',
+        {
+          enabled: true,
+          gated: false,
+          source: 'keybinding',
+        },
+      )
+    } finally {
+      restoreLazyRequireMocks()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-173-ink-components-AlternateScreen.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-173-ink-components-AlternateScreen.test.tsx
@@ -1,0 +1,204 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { describe, expect, test, vi } from "vitest";
+
+import { AlternateScreen } from "../../../src/tui/ink/components/AlternateScreen.js";
+import { TerminalSizeContext } from "../../../src/tui/ink/components/TerminalSizeContext.js";
+import Text from "../../../src/tui/ink/components/Text.js";
+import type { DOMElement } from "../../../src/tui/ink/dom.js";
+import {
+  deleteInkInstance,
+  getInkInstance,
+  setInkInstance,
+} from "../../../src/tui/ink/instances.js";
+import { createRoot } from "../../../src/tui/ink/root.js";
+import {
+  DISABLE_MOUSE_TRACKING,
+  ENABLE_MOUSE_TRACKING,
+  ENTER_ALT_SCREEN,
+  EXIT_ALT_SCREEN,
+} from "../../../src/tui/ink/termio/dec.js";
+import { TerminalWriteProvider } from "../../../src/tui/ink/useTerminalNotification.js";
+
+type TestStdout = PassThrough & {
+  columns: number;
+  isTTY: boolean;
+  rows: number;
+};
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+};
+
+type TestRoot = Awaited<ReturnType<typeof createRoot>>;
+
+function createTestStreams(): {
+  stdin: TestStdin;
+  stdout: TestStdout;
+} {
+  const stdout = new PassThrough() as TestStdout;
+  stdout.columns = 80;
+  stdout.rows = 24;
+  stdout.isTTY = false;
+  stdout.resume();
+
+  const stdin = new PassThrough() as TestStdin;
+  stdin.isTTY = false;
+
+  return { stdin, stdout };
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function withRoot(
+  run: (root: TestRoot, stdout: TestStdout) => Promise<void> | void,
+): Promise<void> {
+  const { stdin, stdout } = createTestStreams();
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  });
+
+  try {
+    await run(root, stdout);
+  } finally {
+    root.unmount();
+    stdin.end();
+    stdout.end();
+    await sleep();
+  }
+}
+
+function withProcessInk<T>(
+  run: (ink: {
+    clearTextSelection: ReturnType<typeof vi.fn>;
+    setAltScreenActive: ReturnType<typeof vi.fn>;
+  }) => T,
+): T {
+  const previousInk = getInkInstance(process.stdout);
+  const ink = {
+    clearTextSelection: vi.fn(),
+    setAltScreenActive: vi.fn(),
+  };
+
+  setInkInstance(process.stdout, ink as never);
+  try {
+    return run(ink);
+  } finally {
+    deleteInkInstance(process.stdout);
+    if (previousInk) {
+      setInkInstance(process.stdout, previousInk);
+    }
+  }
+}
+
+function getRootNode(stdout: TestStdout): DOMElement {
+  const instance = getInkInstance(stdout as unknown as NodeJS.WriteStream);
+  if (!instance?.rootNode) {
+    throw new Error("Ink root node not found");
+  }
+  return instance.rootNode;
+}
+
+function findAltScreenBox(node: DOMElement, height: number): DOMElement | undefined {
+  if (
+    node.nodeName === "ink-box" &&
+    node.style.flexDirection === "column" &&
+    node.style.flexShrink === 0 &&
+    node.style.height === height &&
+    node.style.width === "100%"
+  ) {
+    return node;
+  }
+
+  for (const child of node.childNodes) {
+    if (child.nodeName === "#text") continue;
+    const found = findAltScreenBox(child, height);
+    if (found) return found;
+  }
+
+  return undefined;
+}
+
+describe("AlternateScreen coverage swarm row 173", () => {
+  test("enters with default mouse tracking, constrains layout, and avoids stable rerender churn", async () => {
+    const writeRaw = vi.fn();
+    const child = <Text>stable child</Text>;
+
+    await withRoot(async (root, stdout) => {
+      withProcessInk(ink => {
+        const element = (
+          <TerminalWriteProvider value={writeRaw}>
+            <TerminalSizeContext.Provider value={{ columns: 80, rows: 9 }}>
+              <AlternateScreen>{child}</AlternateScreen>
+            </TerminalSizeContext.Provider>
+          </TerminalWriteProvider>
+        );
+
+        root.render(element);
+        root.render(element);
+
+        expect(writeRaw).toHaveBeenCalledTimes(1);
+        expect(writeRaw).toHaveBeenCalledWith(
+          `${ENTER_ALT_SCREEN}\x1B[2J\x1B[H${ENABLE_MOUSE_TRACKING}`,
+        );
+        expect(ink.setAltScreenActive).toHaveBeenCalledOnce();
+        expect(ink.setAltScreenActive).toHaveBeenCalledWith(true, true);
+        expect(findAltScreenBox(getRootNode(stdout), 9)).toBeDefined();
+      });
+    });
+
+    expect(writeRaw.mock.calls.map(([value]) => value)).toEqual([
+      `${ENTER_ALT_SCREEN}\x1B[2J\x1B[H${ENABLE_MOUSE_TRACKING}`,
+      `${DISABLE_MOUSE_TRACKING}${EXIT_ALT_SCREEN}`,
+    ]);
+  });
+
+  test("omits mouse tracking sequences when disabled and restores selection on cleanup", async () => {
+    const writeRaw = vi.fn();
+
+    await withRoot(async root => {
+      withProcessInk(ink => {
+        root.render(
+          <TerminalWriteProvider value={writeRaw}>
+            <TerminalSizeContext.Provider value={{ columns: 100, rows: 5 }}>
+              <AlternateScreen mouseTracking={false}>
+                <Text>mouse disabled</Text>
+              </AlternateScreen>
+            </TerminalSizeContext.Provider>
+          </TerminalWriteProvider>,
+        );
+
+        expect(writeRaw).toHaveBeenCalledWith(`${ENTER_ALT_SCREEN}\x1B[2J\x1B[H`);
+        expect(ink.setAltScreenActive).toHaveBeenCalledWith(true, false);
+      });
+    });
+
+    expect(writeRaw.mock.calls.map(([value]) => value)).toEqual([
+      `${ENTER_ALT_SCREEN}\x1B[2J\x1B[H`,
+      EXIT_ALT_SCREEN,
+    ]);
+  });
+
+  test("skips terminal side effects with a null write context and uses default row height", async () => {
+    await withRoot(async (root, stdout) => {
+      withProcessInk(ink => {
+        root.render(
+          <TerminalWriteProvider value={null}>
+            <AlternateScreen>
+              <Text>no writer</Text>
+            </AlternateScreen>
+          </TerminalWriteProvider>,
+        );
+
+        expect(ink.setAltScreenActive).not.toHaveBeenCalled();
+        expect(ink.clearTextSelection).not.toHaveBeenCalled();
+        expect(findAltScreenBox(getRootNode(stdout), 24)).toBeDefined();
+      });
+    });
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-174-message-renderers-UserToolResultMessage-utils.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-174-message-renderers-UserToolResultMessage-utils.test.tsx
@@ -1,0 +1,176 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import type { Tool, Tools } from '../../../src/tools/Tool.js'
+import { createRoot, type Root } from '../../../src/tui/ink/root.js'
+import { useGetToolFromMessages } from '../../../src/tui/message-renderers/UserToolResultMessage/utils.js'
+
+type ToolUseLike = {
+  readonly id: string
+  readonly input: Record<string, unknown>
+  readonly name: string
+  readonly type: 'tool_use'
+}
+
+type HookProps = {
+  readonly lookups: Parameters<typeof useGetToolFromMessages>[2]
+  readonly toolUseID: string
+  readonly tools: Tools
+}
+
+type HookValue = ReturnType<typeof useGetToolFromMessages>
+
+function createStreams(): {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough
+} {
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  const stdout = new PassThrough()
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function flushRender(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 5))
+}
+
+function makeTool(name: string, aliases: string[] = []): Tool {
+  return { aliases, name } as unknown as Tool
+}
+
+function makeToolUse(
+  id: string,
+  name: string,
+  input: Record<string, unknown> = {},
+): ToolUseLike {
+  return { id, input, name, type: 'tool_use' }
+}
+
+function makeLookups(
+  toolUses: readonly ToolUseLike[],
+): Parameters<typeof useGetToolFromMessages>[2] {
+  return {
+    toolUseByToolUseID: new Map(toolUses.map(toolUse => [toolUse.id, toolUse])),
+  } as Parameters<typeof useGetToolFromMessages>[2]
+}
+
+async function renderHookHarness(
+  initialProps: HookProps,
+): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly latest: () => HookValue
+  readonly render: (next: Partial<HookProps>) => Promise<void>
+}> {
+  let latest: HookValue | undefined
+  let props = initialProps
+  const { stdin, stdout } = createStreams()
+  const root: Root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function HookProbe(): null {
+    latest = useGetToolFromMessages(props.toolUseID, props.tools, props.lookups)
+    return null
+  }
+
+  async function render(next: Partial<HookProps> = {}): Promise<void> {
+    props = { ...props, ...next }
+    root.render(<HookProbe />)
+    await flushRender()
+  }
+
+  await render()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushRender()
+    },
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+    render,
+  }
+}
+
+describe('UserToolResultMessage utils coverage swarm row 174', () => {
+  test('returns null when the tool use is missing or the referenced tool is unavailable', async () => {
+    const rendered = await renderHookHarness({
+      lookups: makeLookups([]),
+      toolUseID: 'missing-tool-use',
+      tools: [makeTool('Read')],
+    })
+
+    try {
+      expect(rendered.latest()).toBeNull()
+
+      await rendered.render({
+        lookups: makeLookups([makeToolUse('write-1', 'Write')]),
+        toolUseID: 'write-1',
+      })
+
+      expect(rendered.latest()).toBeNull()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('resolves aliases and reuses the memoized result for equivalent lookups', async () => {
+    const readTool = makeTool('Read', ['View'])
+    const toolUse = makeToolUse('read-1', 'View', { file_path: 'notes.txt' })
+    const rendered = await renderHookHarness({
+      lookups: makeLookups([toolUse]),
+      toolUseID: 'read-1',
+      tools: [readTool],
+    })
+
+    try {
+      const firstResult = rendered.latest()
+
+      expect(firstResult).toEqual({ tool: readTool, toolUse })
+
+      await rendered.render({})
+      expect(rendered.latest()).toBe(firstResult)
+
+      await rendered.render({
+        lookups: makeLookups([toolUse]),
+      })
+      expect(rendered.latest()).toBe(firstResult)
+
+      const nextToolUse = makeToolUse('read-1', 'View', {
+        file_path: 'updated.txt',
+      })
+      await rendered.render({
+        lookups: makeLookups([nextToolUse]),
+      })
+
+      expect(rendered.latest()).toEqual({ tool: readTool, toolUse: nextToolUse })
+      expect(rendered.latest()).not.toBe(firstResult)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-175-hooks-useIdeSelection.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-175-hooks-useIdeSelection.test.ts
@@ -1,0 +1,381 @@
+import { PassThrough } from 'node:stream'
+
+import React, { act } from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const fixture = vi.hoisted(() => ({
+  ideClient: undefined as TestIdeClient | undefined,
+  getConnectedIdeClient: vi.fn(),
+  logError: vi.fn(),
+}))
+
+vi.mock('../../../src/utils/ide.js', () => ({
+  getConnectedIdeClient: fixture.getConnectedIdeClient,
+}))
+
+vi.mock('../../../src/utils/log.js', () => ({
+  logError: fixture.logError,
+}))
+
+import { createRoot } from '../../../src/tui/ink.js'
+import {
+  type IDESelection,
+  useIdeSelection,
+} from '../../../src/tui/hooks/useIdeSelection.js'
+
+type SelectionPoint = {
+  readonly line: number
+  readonly character: number
+}
+
+type SelectionNotificationParams = {
+  readonly selection?: {
+    readonly start?: SelectionPoint
+    readonly end?: SelectionPoint
+  } | null
+  readonly text?: string
+  readonly filePath?: string
+}
+
+type NotificationHandler = (notification: {
+  readonly params: SelectionNotificationParams
+}) => void
+
+type TestIdeClient = {
+  readonly client: {
+    readonly setNotificationHandler: ReturnType<typeof vi.fn>
+  }
+  readonly emit: (params: SelectionNotificationParams) => void
+}
+
+type HookProps = {
+  readonly mcpClients: unknown[]
+  readonly onSelect: (selection: IDESelection) => void
+}
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough & {
+    columns: number
+    rows: number
+    isTTY: boolean
+  }
+}
+
+function createIdeClient(): TestIdeClient {
+  let handler: NotificationHandler | undefined
+
+  return {
+    client: {
+      setNotificationHandler: vi.fn(
+        (_schema: unknown, next: NotificationHandler) => {
+          handler = next
+        },
+      ),
+    },
+    emit: (params: SelectionNotificationParams) => {
+      if (handler === undefined) {
+        throw new Error('selection handler was not registered')
+      }
+      handler({ params })
+    },
+  }
+}
+
+function createStreams(): TestStreams {
+  const stdin = new PassThrough() as TestStreams['stdin']
+  const stdout = new PassThrough() as TestStreams['stdout']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 100
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+async function renderHookHarness(
+  initialProps: HookProps,
+): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly render: (next?: Partial<HookProps>) => Promise<void>
+}> {
+  let props = initialProps
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    useIdeSelection(props.mcpClients as never, props.onSelect)
+    return null
+  }
+
+  async function render(next: Partial<HookProps> = {}): Promise<void> {
+    props = { ...props, ...next }
+    await act(async () => {
+      root.render(React.createElement(Harness))
+    })
+    await flushEffects()
+  }
+
+  await render()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushEffects()
+    },
+    render,
+  }
+}
+
+describe('useIdeSelection coverage swarm 175', () => {
+  beforeEach(() => {
+    fixture.ideClient = undefined
+    fixture.getConnectedIdeClient.mockReset()
+    fixture.getConnectedIdeClient.mockImplementation(() => fixture.ideClient)
+    fixture.logError.mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('waits for an IDE client and registers once for the same connected IDE', async () => {
+    const onSelect = vi.fn()
+    const initialClients = [{ name: 'not-ide' }]
+    const rendered = await renderHookHarness({
+      mcpClients: initialClients,
+      onSelect,
+    })
+
+    try {
+      expect(fixture.getConnectedIdeClient).toHaveBeenLastCalledWith(
+        initialClients,
+      )
+      expect(onSelect).not.toHaveBeenCalled()
+
+      const ideClient = createIdeClient()
+      fixture.ideClient = ideClient
+      const connectedClients = [{ name: 'ide' }]
+      await rendered.render({ mcpClients: connectedClients })
+
+      expect(fixture.getConnectedIdeClient).toHaveBeenLastCalledWith(
+        connectedClients,
+      )
+      expect(onSelect).toHaveBeenCalledTimes(1)
+      expect(onSelect).toHaveBeenLastCalledWith({
+        lineCount: 0,
+        lineStart: undefined,
+        text: undefined,
+        filePath: undefined,
+      })
+      expect(ideClient.client.setNotificationHandler).toHaveBeenCalledTimes(1)
+
+      await rendered.render({ mcpClients: [{ name: 'same-ide' }] })
+
+      expect(onSelect).toHaveBeenCalledTimes(1)
+      expect(ideClient.client.setNotificationHandler).toHaveBeenCalledTimes(1)
+
+      ideClient.emit({
+        selection: {
+          start: { line: 2, character: 4 },
+          end: { line: 4, character: 9 },
+        },
+        text: 'selected text',
+        filePath: '/workspace/src/current.ts',
+      })
+
+      expect(onSelect).toHaveBeenLastCalledWith({
+        lineCount: 3,
+        lineStart: 2,
+        text: 'selected text',
+        filePath: '/workspace/src/current.ts',
+      })
+      expect(fixture.logError).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('ignores stale handlers after the connected IDE client changes', async () => {
+    const firstIdeClient = createIdeClient()
+    fixture.ideClient = firstIdeClient
+    const onSelect = vi.fn()
+    const rendered = await renderHookHarness({
+      mcpClients: [{ id: 'first' }],
+      onSelect,
+    })
+
+    try {
+      expect(firstIdeClient.client.setNotificationHandler).toHaveBeenCalledTimes(
+        1,
+      )
+      expect(onSelect).toHaveBeenCalledTimes(1)
+
+      const secondIdeClient = createIdeClient()
+      fixture.ideClient = secondIdeClient
+      await rendered.render({ mcpClients: [{ id: 'second' }] })
+
+      expect(onSelect).toHaveBeenCalledTimes(2)
+      expect(onSelect).toHaveBeenLastCalledWith({
+        lineCount: 0,
+        lineStart: undefined,
+        text: undefined,
+        filePath: undefined,
+      })
+      expect(secondIdeClient.client.setNotificationHandler).toHaveBeenCalledTimes(
+        1,
+      )
+
+      firstIdeClient.emit({
+        selection: {
+          start: { line: 8, character: 1 },
+          end: { line: 8, character: 2 },
+        },
+        text: 'stale',
+        filePath: '/workspace/src/stale.ts',
+      })
+
+      expect(onSelect).toHaveBeenCalledTimes(2)
+
+      secondIdeClient.emit({
+        selection: {
+          start: { line: 9, character: 1 },
+          end: { line: 10, character: 0 },
+        },
+        text: 'current',
+        filePath: '/workspace/src/current.ts',
+      })
+
+      expect(onSelect).toHaveBeenCalledTimes(3)
+      expect(onSelect).toHaveBeenLastCalledWith({
+        lineCount: 1,
+        lineStart: 9,
+        text: 'current',
+        filePath: '/workspace/src/current.ts',
+      })
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('ignores selection payloads that lack both a complete range and text', async () => {
+    const ideClient = createIdeClient()
+    fixture.ideClient = ideClient
+    const onSelect = vi.fn()
+    const rendered = await renderHookHarness({
+      mcpClients: [{ name: 'ide' }],
+      onSelect,
+    })
+
+    try {
+      onSelect.mockClear()
+
+      ideClient.emit({
+        selection: {
+          start: { line: 3, character: 0 },
+        },
+        filePath: '/workspace/src/incomplete.ts',
+      })
+
+      expect(onSelect).not.toHaveBeenCalled()
+      expect(fixture.logError).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('uses the latest callback for the same registered IDE handler', async () => {
+    const ideClient = createIdeClient()
+    fixture.ideClient = ideClient
+    const firstOnSelect = vi.fn()
+    const secondOnSelect = vi.fn()
+    const rendered = await renderHookHarness({
+      mcpClients: [{ name: 'ide' }],
+      onSelect: firstOnSelect,
+    })
+
+    try {
+      firstOnSelect.mockClear()
+      await rendered.render({ onSelect: secondOnSelect })
+
+      ideClient.emit({
+        selection: {
+          start: { line: 7, character: 1 },
+          end: { line: 8, character: 4 },
+        },
+        text: 'fresh callback',
+        filePath: '/workspace/src/fresh.ts',
+      })
+
+      expect(firstOnSelect).not.toHaveBeenCalled()
+      expect(secondOnSelect).toHaveBeenCalledWith({
+        lineCount: 2,
+        lineStart: 7,
+        text: 'fresh callback',
+        filePath: '/workspace/src/fresh.ts',
+      })
+      expect(ideClient.client.setNotificationHandler).toHaveBeenCalledTimes(1)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('logs notification handler errors instead of surfacing callback failures', async () => {
+    const ideClient = createIdeClient()
+    fixture.ideClient = ideClient
+    const callbackError = new Error('callback failed')
+    let shouldThrow = false
+    const onSelect = vi.fn(() => {
+      if (shouldThrow) {
+        throw callbackError
+      }
+    })
+    const rendered = await renderHookHarness({
+      mcpClients: [{ name: 'ide' }],
+      onSelect,
+    })
+
+    try {
+      fixture.logError.mockClear()
+      shouldThrow = true
+
+      expect(() => {
+        ideClient.emit({
+          selection: {
+            start: { line: 5, character: 1 },
+            end: { line: 5, character: 3 },
+          },
+          text: 'broken',
+          filePath: '/workspace/src/failing.ts',
+        })
+      }).not.toThrow()
+
+      expect(fixture.logError).toHaveBeenCalledWith(callbackError)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-176-ink-hit-test.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-176-ink-hit-test.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test, vi } from 'vitest'
+
+import type { ClickEvent } from '../../../src/tui/ink/events/click-event.js'
+import type { DOMElement, DOMNode } from '../../../src/tui/ink/dom.js'
+import {
+  dispatchClick,
+  dispatchHover,
+  hitTest,
+} from '../../../src/tui/ink/hit-test.js'
+import { nodeCache } from '../../../src/tui/ink/node-cache.js'
+
+function element(nodeName: DOMElement['nodeName'] = 'ink-box'): DOMElement {
+  return {
+    attributes: {},
+    childNodes: [],
+    dirty: false,
+    nodeName,
+    parentNode: undefined,
+    style: {},
+  }
+}
+
+function textNode(value = 'text'): DOMNode {
+  return {
+    nodeName: '#text',
+    nodeValue: value,
+    parentNode: undefined,
+    style: {},
+  } as DOMNode
+}
+
+function append(parent: DOMElement, child: DOMNode): void {
+  child.parentNode = parent
+  parent.childNodes.push(child)
+}
+
+function cache(
+  node: DOMElement,
+  rect: { height: number; width: number; x: number; y: number },
+): void {
+  nodeCache.set(node, rect)
+}
+
+describe('hit-test coverage swarm row 176', () => {
+  test('rejects uncached nodes and treats right and bottom bounds as exclusive', () => {
+    const root = element('ink-root')
+
+    expect(hitTest(root, 0, 0)).toBeNull()
+
+    cache(root, { height: 2, width: 4, x: 2, y: 3 })
+
+    expect(hitTest(root, 1, 3)).toBeNull()
+    expect(hitTest(root, 6, 3)).toBeNull()
+    expect(hitTest(root, 2, 2)).toBeNull()
+    expect(hitTest(root, 2, 5)).toBeNull()
+    expect(hitTest(root, 5, 4)).toBe(root)
+  })
+
+  test('prefers later siblings, skips text children, and ignores uncached subtrees', () => {
+    const root = element('ink-root')
+    const back = element()
+    const top = element()
+    const uncached = element()
+    const grandchild = element()
+
+    append(root, back)
+    append(root, textNode())
+    append(root, top)
+    append(root, uncached)
+    append(uncached, grandchild)
+
+    cache(root, { height: 4, width: 10, x: 0, y: 0 })
+    cache(back, { height: 2, width: 4, x: 1, y: 1 })
+    cache(top, { height: 2, width: 4, x: 2, y: 1 })
+    cache(grandchild, { height: 1, width: 1, x: 3, y: 1 })
+
+    expect(hitTest(root, 3, 1)).toBe(top)
+    expect(hitTest(root, 1, 1)).toBe(back)
+    expect(hitTest(root, 8, 1)).toBe(root)
+  })
+
+  test('click dispatch focuses the nearest tabIndex ancestor and bubbles local coordinates', () => {
+    const root = element('ink-root')
+    const parent = element()
+    const leaf = element()
+    const focusManager = { handleClickFocus: vi.fn() }
+    const clicks: Array<{
+      blank: boolean
+      col: number
+      localCol: number
+      localRow: number
+      name: string
+      row: number
+    }> = []
+
+    root.focusManager = focusManager as unknown as DOMElement['focusManager']
+    parent.attributes.tabIndex = 0
+    leaf._eventHandlers = {
+      onClick: (event: ClickEvent) => {
+        clicks.push({
+          blank: event.cellIsBlank,
+          col: event.col,
+          localCol: event.localCol,
+          localRow: event.localRow,
+          name: 'leaf',
+          row: event.row,
+        })
+      },
+    }
+    parent._eventHandlers = {
+      onClick: (event: ClickEvent) => {
+        clicks.push({
+          blank: event.cellIsBlank,
+          col: event.col,
+          localCol: event.localCol,
+          localRow: event.localRow,
+          name: 'parent',
+          row: event.row,
+        })
+      },
+    }
+
+    append(root, parent)
+    append(parent, leaf)
+    cache(root, { height: 10, width: 20, x: 0, y: 0 })
+    cache(parent, { height: 4, width: 5, x: 4, y: 3 })
+    cache(leaf, { height: 1, width: 2, x: 6, y: 5 })
+
+    expect(dispatchClick(root, 7, 5, true)).toBe(true)
+
+    expect(focusManager.handleClickFocus).toHaveBeenCalledWith(parent)
+    expect(clicks).toEqual([
+      {
+        blank: true,
+        col: 7,
+        localCol: 1,
+        localRow: 0,
+        name: 'leaf',
+        row: 5,
+      },
+      {
+        blank: true,
+        col: 7,
+        localCol: 3,
+        localRow: 2,
+        name: 'parent',
+        row: 5,
+      },
+    ])
+  })
+
+  test('click dispatch reports misses, unhandled hits, and immediate propagation stops', () => {
+    const root = element('ink-root')
+    const child = element()
+    const rootClick = vi.fn()
+    const childClick = vi.fn((event: ClickEvent) => {
+      event.stopImmediatePropagation()
+    })
+
+    append(root, child)
+    cache(root, { height: 4, width: 4, x: 0, y: 0 })
+    cache(child, { height: 2, width: 2, x: 1, y: 1 })
+
+    expect(dispatchClick(root, 9, 9)).toBe(false)
+    expect(dispatchClick(root, 1, 1)).toBe(false)
+
+    root._eventHandlers = { onClick: rootClick }
+    child._eventHandlers = { onClick: childClick }
+
+    expect(dispatchClick(root, 1, 1)).toBe(true)
+    expect(childClick).toHaveBeenCalledTimes(1)
+    expect(rootClick).not.toHaveBeenCalled()
+  })
+
+  test('hover dispatch diffs handled ancestors and skips leave on detached nodes', () => {
+    const root = element('ink-root')
+    const child = element()
+    const leaf = element()
+    const detached = element()
+    const hovered = new Set<DOMElement>([detached])
+    const events: string[] = []
+
+    root._eventHandlers = {
+      onMouseEnter: () => events.push('root-enter'),
+      onMouseLeave: () => events.push('root-leave'),
+    }
+    child._eventHandlers = {
+      onMouseEnter: () => events.push('child-enter'),
+      onMouseLeave: () => events.push('child-leave'),
+    }
+    detached._eventHandlers = {
+      onMouseLeave: () => events.push('detached-leave'),
+    }
+
+    append(root, child)
+    append(child, leaf)
+    cache(root, { height: 2, width: 5, x: 0, y: 0 })
+    cache(child, { height: 1, width: 2, x: 1, y: 0 })
+    cache(leaf, { height: 1, width: 1, x: 1, y: 0 })
+
+    dispatchHover(root, 1, 0, hovered)
+    dispatchHover(root, 1, 0, hovered)
+    dispatchHover(root, 4, 0, hovered)
+    dispatchHover(root, 9, 0, hovered)
+
+    expect(events).toEqual(['child-enter', 'root-enter', 'child-leave'])
+    expect(hovered.size).toBe(0)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-177-ink-root.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-177-ink-root.test.ts
@@ -1,0 +1,187 @@
+import { PassThrough } from "node:stream";
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const inkMock = vi.hoisted(() => ({
+  constructorOptions: [] as Array<Record<string, unknown>>,
+  instances: [] as Array<{
+    render: ReturnType<typeof vi.fn>;
+    unmount: ReturnType<typeof vi.fn>;
+    waitUntilExit: ReturnType<typeof vi.fn>;
+  }>,
+}));
+
+const registryMock = vi.hoisted(() => ({
+  map: new Map<NodeJS.WriteStream, unknown>(),
+}));
+
+const debugMock = vi.hoisted(() => ({
+  logForDebugging: vi.fn(),
+}));
+
+vi.mock("../../../src/tui/ink/ink.js", () => {
+  class MockInk {
+    render = vi.fn();
+    unmount = vi.fn();
+    waitUntilExit = vi.fn(async () => undefined);
+
+    constructor(options: Record<string, unknown>) {
+      inkMock.constructorOptions.push(options);
+      inkMock.instances.push(this);
+    }
+  }
+
+  return {
+    default: MockInk,
+  };
+});
+
+vi.mock("../../../src/tui/ink/instances.js", () => ({
+  deleteInkInstance: vi.fn((stdout: NodeJS.WriteStream) =>
+    registryMock.map.delete(stdout),
+  ),
+  getInkInstance: vi.fn((stdout: NodeJS.WriteStream = process.stdout) =>
+    registryMock.map.get(stdout),
+  ),
+  setInkInstance: vi.fn((stdout: NodeJS.WriteStream, instance: unknown) => {
+    registryMock.map.set(stdout, instance);
+  }),
+}));
+
+vi.mock("../../../src/utils/debug.js", () => ({
+  logForDebugging: debugMock.logForDebugging,
+}));
+
+import wrappedRender, {
+  createRoot,
+  renderSync,
+} from "../../../src/tui/ink/root.js";
+
+function createStdout(): NodeJS.WriteStream {
+  return new PassThrough() as unknown as NodeJS.WriteStream;
+}
+
+function createStdin(): NodeJS.ReadStream {
+  return new PassThrough() as unknown as NodeJS.ReadStream;
+}
+
+afterEach(() => {
+  inkMock.constructorOptions.length = 0;
+  inkMock.instances.length = 0;
+  registryMock.map.clear();
+  vi.clearAllMocks();
+});
+
+describe("Ink root coverage swarm row 177", () => {
+  test("renderSync accepts a stdout stream option, reuses the registered instance, and can clean it up", () => {
+    const stdout = createStdout();
+
+    const first = renderSync("first render", stdout);
+    const second = renderSync("second render", { stdout });
+
+    expect(inkMock.constructorOptions).toHaveLength(1);
+    expect(inkMock.constructorOptions[0]).toMatchObject({
+      stdout,
+      stdin: process.stdin,
+      stderr: process.stderr,
+      exitOnCtrlC: true,
+      patchConsole: true,
+    });
+    expect(inkMock.instances[0]?.render).toHaveBeenNthCalledWith(
+      1,
+      "first render",
+    );
+    expect(inkMock.instances[0]?.render).toHaveBeenNthCalledWith(
+      2,
+      "second render",
+    );
+
+    second.rerender("third render");
+    second.unmount();
+    expect(first.waitUntilExit).toBe(inkMock.instances[0]?.waitUntilExit);
+    expect(inkMock.instances[0]?.render).toHaveBeenNthCalledWith(
+      3,
+      "third render",
+    );
+    expect(inkMock.instances[0]?.unmount).toHaveBeenCalledTimes(1);
+
+    expect(registryMock.map.has(stdout)).toBe(true);
+    expect(first.cleanup()).toBe(true);
+    expect(registryMock.map.has(stdout)).toBe(false);
+  });
+
+  test("renderSync passes explicit render options through when creating a fresh instance", () => {
+    const stdout = createStdout();
+    const stdin = createStdin();
+    const stderr = createStdout();
+    const onFrame = vi.fn();
+
+    renderSync("custom options", {
+      stdout,
+      stdin,
+      stderr,
+      exitOnCtrlC: false,
+      patchConsole: false,
+      onFrame,
+    });
+
+    expect(inkMock.constructorOptions).toEqual([
+      {
+        stdout,
+        stdin,
+        stderr,
+        exitOnCtrlC: false,
+        patchConsole: false,
+        onFrame,
+      },
+    ]);
+    expect(inkMock.instances[0]?.render).toHaveBeenCalledWith(
+      "custom options",
+    );
+  });
+
+  test("wrapped render preserves the async boundary and logs after rendering", async () => {
+    const stdout = createStdout();
+
+    const pendingRender = wrappedRender("wrapped render", { stdout });
+
+    expect(inkMock.instances).toHaveLength(0);
+
+    const instance = await pendingRender;
+
+    expect(instance).toMatchObject({
+      rerender: inkMock.instances[0]?.render,
+      waitUntilExit: inkMock.instances[0]?.waitUntilExit,
+    });
+    expect(inkMock.instances[0]?.render).toHaveBeenCalledWith(
+      "wrapped render",
+    );
+    expect(debugMock.logForDebugging).toHaveBeenCalledWith(
+      expect.stringContaining("[render] first ink render:"),
+    );
+  });
+
+  test("createRoot applies defaults, registers the instance, and delegates root methods", async () => {
+    const root = await createRoot();
+
+    expect(inkMock.constructorOptions).toEqual([
+      {
+        stdout: process.stdout,
+        stdin: process.stdin,
+        stderr: process.stderr,
+        exitOnCtrlC: true,
+        patchConsole: true,
+        onFrame: undefined,
+      },
+    ]);
+    expect(registryMock.map.get(process.stdout)).toBe(inkMock.instances[0]);
+
+    root.render("root node");
+    root.unmount();
+    await root.waitUntilExit();
+
+    expect(inkMock.instances[0]?.render).toHaveBeenCalledWith("root node");
+    expect(inkMock.instances[0]?.unmount).toHaveBeenCalledTimes(1);
+    expect(inkMock.instances[0]?.waitUntilExit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-178-ink-components-NoSelect.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-178-ink-components-NoSelect.test.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const compilerRuntime = vi.hoisted(() => {
+  const sentinel = Symbol("memo-cache-sentinel");
+  let cache: unknown[] = [];
+
+  function reset(size = 8): void {
+    cache = Array.from({ length: size }, () => sentinel);
+  }
+
+  reset();
+
+  return {
+    c: vi.fn((size: number) => {
+      if (cache.length !== size) reset(size);
+      return cache;
+    }),
+    reset,
+  };
+});
+
+vi.mock("react-compiler-runtime", () => ({
+  c: compilerRuntime.c,
+}));
+
+import { NoSelect } from "../../../src/tui/ink/components/NoSelect.js";
+
+type NoSelectElement = React.ReactElement<{
+  children?: React.ReactNode;
+  flexDirection?: string;
+  fromLeftEdge?: boolean;
+  marginLeft?: number;
+  noSelect?: boolean | "from-left-edge";
+  paddingX?: number;
+  width?: number;
+}>;
+
+function renderNoSelect(props: Parameters<typeof NoSelect>[0]): NoSelectElement {
+  const element = NoSelect(props);
+
+  expect(React.isValidElement(element)).toBe(true);
+  return element as NoSelectElement;
+}
+
+describe("NoSelect coverage swarm row 178", () => {
+  beforeEach(() => {
+    compilerRuntime.reset();
+    compilerRuntime.c.mockClear();
+  });
+
+  test("wraps children in a selectable-exclusion Box by default", () => {
+    const element = renderNoSelect({
+      children: "plain text",
+      flexDirection: "column",
+      marginLeft: 2,
+    });
+
+    expect(element.props.noSelect).toBe(true);
+    expect(element.props.children).toBe("plain text");
+    expect(element.props.flexDirection).toBe("column");
+    expect(element.props.marginLeft).toBe(2);
+    expect(element.props.fromLeftEdge).toBeUndefined();
+  });
+
+  test("extends the exclusion region from the left edge when requested", () => {
+    const child = <ink-text>gutter</ink-text>;
+    const element = renderNoSelect({
+      children: child,
+      fromLeftEdge: true,
+      width: 6,
+    });
+
+    expect(element.props.noSelect).toBe("from-left-edge");
+    expect(element.props.children).toBe(child);
+    expect(element.props.width).toBe(6);
+    expect(element.props.fromLeftEdge).toBeUndefined();
+  });
+
+  test("reuses the memoized Box element for identical props", () => {
+    const props = {
+      children: "stable",
+      paddingX: 1,
+    };
+
+    const first = renderNoSelect(props);
+    const second = renderNoSelect(props);
+
+    expect(second).toBe(first);
+    expect(compilerRuntime.c).toHaveBeenCalledTimes(2);
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-179-slash-argument-substitution.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-179-slash-argument-substitution.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  generateProgressiveArgumentHint,
+  parseArgumentNames,
+  parseArguments,
+  substituteArguments,
+} from 'src/tui/slash/argument-substitution.js'
+
+describe('argument substitution coverage edges', () => {
+  test('parses blank input and filters non-string shell tokens', () => {
+    expect(parseArguments('')).toEqual([])
+    expect(parseArguments('   \t  ')).toEqual([])
+    expect(parseArguments('build && test # trailing')).toEqual([
+      'build',
+      'test',
+    ])
+  })
+
+  test('drops invalid argument-name shapes from frontmatter values', () => {
+    expect(parseArgumentNames(undefined)).toEqual([])
+    expect(parseArgumentNames(42 as never)).toEqual([])
+    expect(parseArgumentNames('  topic   123 focus  ')).toEqual([
+      'topic',
+      'focus',
+    ])
+    expect(parseArgumentNames(['alpha', '', '007', 42 as never, 'omega']))
+      .toEqual(['alpha', 'omega'])
+  })
+
+  test('renders all progressive hint names before any args are typed', () => {
+    expect(generateProgressiveArgumentHint(['topic', 'focus'], [])).toBe(
+      '[topic] [focus]',
+    )
+  })
+
+  test('leaves content unchanged for null args and when append is disabled', () => {
+    expect(
+      substituteArguments(
+        'Use $ARGUMENTS later',
+        null as unknown as string | undefined,
+      ),
+    ).toBe('Use $ARGUMENTS later')
+
+    expect(substituteArguments('Plain body', 'alpha beta', false)).toBe(
+      'Plain body',
+    )
+    expect(substituteArguments('Plain body', '')).toBe('Plain body')
+  })
+
+  test('replaces placeholders with empty values for an explicit empty arg string', () => {
+    expect(
+      substituteArguments(
+        'all=$ARGUMENTS first=$0 named=$topic',
+        '',
+        true,
+        ['topic'],
+      ),
+    ).toBe('all= first= named=')
+  })
+
+  test('respects named and indexed placeholder boundaries', () => {
+    expect(
+      substituteArguments(
+        '$topic $topic[0] $topicExtra one=$1 sticky=$1x missing=$ARGUMENTS[9]',
+        'alpha beta',
+        true,
+        ['topic'],
+      ),
+    ).toBe('alpha $topic[0] $topicExtra one=beta sticky=$1x missing=')
+  })
+
+  test('skips empty argument-name entries while replacing later names', () => {
+    expect(
+      substituteArguments('$first/$second/$third', 'one two three', true, [
+        'first',
+        '',
+        'third',
+      ]),
+    ).toBe('one/$second/three')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-180-components-PromptInput-PromptInputQueuedCommands.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-180-components-PromptInput-PromptInputQueuedCommands.test.tsx
@@ -1,0 +1,198 @@
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { Text } from '../../../src/tui/ink.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+
+type QueuedCommandFixture = {
+  value: unknown
+  mode: string
+  isMeta?: boolean
+}
+
+const fixture = vi.hoisted(() => ({
+  appState: {
+    isBriefOnly: false,
+    viewingAgentTaskId: undefined as string | undefined,
+  },
+  commands: [] as QueuedCommandFixture[],
+  features: {} as Record<string, boolean>,
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => fixture.features[name] === true,
+}))
+
+vi.mock('src/tui/hooks/useCommandQueue.js', () => ({
+  useCommandQueue: () => fixture.commands,
+}))
+
+vi.mock('src/tui/state/AppState.js', () => ({
+  useAppState: (
+    selector: (state: typeof fixture.appState) => unknown,
+  ) => selector(fixture.appState),
+}))
+
+vi.mock('src/tui/context/QueuedMessageContext.js', () => ({
+  QueuedMessageProvider: ({
+    children,
+    isFirst,
+    useBriefLayout,
+  }: {
+    children: React.ReactNode
+    isFirst: boolean
+    useBriefLayout: boolean
+  }) => (
+    <>
+      <Text>
+        {isFirst ? '[first]' : '[later]'}
+        {useBriefLayout ? '[brief]' : '[full]'}
+      </Text>
+      {children}
+    </>
+  ),
+}))
+
+vi.mock('src/tui/components/Message.js', () => ({
+  Message: ({ message }: { message: { message?: { content?: unknown } } }) => {
+    const content = message.message?.content
+
+    if (Array.isArray(content)) {
+      return (
+        <Text>
+          {content
+            .map((block) =>
+              typeof block === 'object' && block !== null && 'text' in block
+                ? String(block.text)
+                : JSON.stringify(block),
+            )
+            .join('|')}
+        </Text>
+      )
+    }
+
+    return <Text>{typeof content === 'string' ? content : ''}</Text>
+  },
+}))
+
+vi.mock('src/utils/messages.js', () => ({
+  EMPTY_LOOKUPS: {},
+  createUserMessage: ({ content }: { content: unknown }) => ({
+    message: { content },
+    type: 'user',
+  }),
+  normalizeMessages: (messages: unknown[]) => messages,
+}))
+
+vi.mock('src/utils/messageQueueManager.js', () => ({
+  isQueuedCommandEditable: (command: QueuedCommandFixture) =>
+    !command.isMeta &&
+    (command.mode === 'prompt' || command.mode === 'bash'),
+  isQueuedCommandVisible: (command: QueuedCommandFixture) =>
+    command.isMeta !== true,
+}))
+
+async function renderQueuedCommands(): Promise<string> {
+  const { PromptInputQueuedCommands } = await import(
+    '../../../src/tui/components/PromptInput/PromptInputQueuedCommands.js'
+  )
+
+  return renderToString(<PromptInputQueuedCommands />, { columns: 120 })
+}
+
+describe('PromptInputQueuedCommands coverage swarm 180', () => {
+  beforeEach(() => {
+    fixture.appState = {
+      isBriefOnly: false,
+      viewingAgentTaskId: undefined,
+    }
+    fixture.commands = []
+    fixture.features = {}
+  })
+
+  test('renders nothing for empty queues, all-hidden queues, and teammate transcript views', async () => {
+    expect((await renderQueuedCommands()).trim()).toBe('')
+
+    fixture.commands = [
+      {
+        isMeta: true,
+        mode: 'prompt',
+        value: 'hidden queued text',
+      },
+    ]
+    expect((await renderQueuedCommands()).trim()).toBe('')
+
+    fixture.appState.viewingAgentTaskId = 'agent-task-1'
+    fixture.commands = [
+      {
+        mode: 'prompt',
+        value: 'leader text hidden while viewing teammate',
+      },
+    ]
+    expect((await renderQueuedCommands()).trim()).toBe('')
+  })
+
+  test('counts editable prompt and bash entries while preserving non-string bash content', async () => {
+    fixture.commands = [
+      {
+        mode: 'prompt',
+        value: 'first queued prompt',
+      },
+      {
+        mode: 'bash',
+        value: [{ text: 'array backed bash command', type: 'text' }],
+      },
+    ]
+
+    const output = await renderQueuedCommands()
+
+    expect(output).toContain('2 inputs queued for next turn')
+    expect(output).toContain('first queued prompt')
+    expect(output).toContain('array backed bash command')
+    expect(output).not.toContain('<bash-input>[object Object]</bash-input>')
+  })
+
+  test('passes brief layout through the queued message provider when brief features are enabled', async () => {
+    fixture.features.KAIROS_BRIEF = true
+    fixture.appState.isBriefOnly = true
+    fixture.commands = [
+      {
+        mode: 'prompt',
+        value: 'brief queued prompt',
+      },
+      {
+        mode: 'prompt',
+        value: 'second queued prompt',
+      },
+    ]
+
+    const output = await renderQueuedCommands()
+
+    expect(output).toContain('[first][brief]')
+    expect(output).toContain('[later][brief]')
+    expect(output).toContain('brief queued prompt')
+    expect(output).toContain('second queued prompt')
+  })
+
+  test('filters idle notifications and caps visible task notification overflow', async () => {
+    fixture.commands = [
+      {
+        mode: 'task-notification',
+        value: JSON.stringify({ type: 'idle_notification' }),
+      },
+      ...[1, 2, 3, 4].map((index) => ({
+        mode: 'task-notification',
+        value: `<task-notification><summary>task ${index}</summary><status>completed</status></task-notification>`,
+      })),
+    ]
+
+    const output = await renderQueuedCommands()
+
+    expect(output).not.toContain('idle_notification')
+    expect(output).toContain('task 1')
+    expect(output).toContain('task 2')
+    expect(output).toContain('+2 more tasks completed')
+    expect(output).not.toContain('task 4')
+    expect(output).not.toContain('inputs queued for next turn')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-181-context-QueuedMessageContext.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-181-context-QueuedMessageContext.test.tsx
@@ -1,0 +1,187 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import {
+  QueuedMessageProvider,
+  useQueuedMessage,
+} from '../../../src/tui/context/QueuedMessageContext.js'
+import { createRoot, Text } from '../../../src/tui/ink.js'
+
+type QueueSnapshot =
+  | {
+      readonly isFirst: boolean
+      readonly isQueued: boolean
+      readonly paddingWidth: number
+    }
+  | undefined
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestStdout = PassThrough & {
+  columns: number
+  isTTY: boolean
+}
+
+type TestRoot = Awaited<ReturnType<typeof createRoot>>
+
+function createStreams(): {
+  readonly stdin: TestStdin
+  readonly stdout: TestStdout
+} {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough() as TestStdout
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 80
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await sleep(10)
+  }
+
+  throw new Error(message)
+}
+
+async function withRoot(
+  run: (root: TestRoot) => Promise<void> | void,
+): Promise<void> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  try {
+    await run(root)
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await sleep()
+  }
+}
+
+function CaptureQueuedMessage({
+  label,
+  snapshots,
+}: {
+  readonly label: string
+  readonly snapshots: QueueSnapshot[]
+}): React.ReactNode {
+  const queuedMessage = useQueuedMessage()
+
+  React.useEffect(() => {
+    snapshots.push(
+      queuedMessage === undefined
+        ? undefined
+        : {
+            isFirst: queuedMessage.isFirst,
+            isQueued: queuedMessage.isQueued,
+            paddingWidth: queuedMessage.paddingWidth,
+          },
+    )
+  }, [queuedMessage, snapshots])
+
+  return <Text>{label}</Text>
+}
+
+describe('QueuedMessageContext coverage swarm row 181', () => {
+  test('returns undefined when the hook is used outside a provider', async () => {
+    const snapshots: QueueSnapshot[] = []
+
+    await withRoot(async root => {
+      root.render(
+        <CaptureQueuedMessage label="outside" snapshots={snapshots} />,
+      )
+
+      await waitForCondition(
+        () => snapshots.length === 1,
+        'Queued message default context was not captured',
+      )
+    })
+
+    expect(snapshots).toEqual([undefined])
+  })
+
+  test('provides normal and brief queued metadata and reuses stable provider output', async () => {
+    const normalSnapshots: QueueSnapshot[] = []
+    const briefSnapshots: QueueSnapshot[] = []
+    const stableChild = (
+      <CaptureQueuedMessage label="normal" snapshots={normalSnapshots} />
+    )
+
+    await withRoot(async root => {
+      root.render(
+        <QueuedMessageProvider isFirst={false}>
+          {stableChild}
+        </QueuedMessageProvider>,
+      )
+
+      await waitForCondition(
+        () => normalSnapshots.length === 1,
+        'Normal queued message context was not captured',
+      )
+
+      root.render(
+        <QueuedMessageProvider isFirst={false}>
+          {stableChild}
+        </QueuedMessageProvider>,
+      )
+      await sleep()
+
+      root.render(
+        <QueuedMessageProvider isFirst={true} useBriefLayout={true}>
+          <CaptureQueuedMessage label="brief" snapshots={briefSnapshots} />
+        </QueuedMessageProvider>,
+      )
+
+      await waitForCondition(
+        () => briefSnapshots.length === 1,
+        'Brief queued message context was not captured',
+      )
+    })
+
+    expect(normalSnapshots).toEqual([
+      {
+        isFirst: false,
+        isQueued: true,
+        paddingWidth: 4,
+      },
+    ])
+    expect(briefSnapshots).toEqual([
+      {
+        isFirst: true,
+        isQueued: true,
+        paddingWidth: 0,
+      },
+    ])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-182-hooks-useVirtualScroll.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-182-hooks-useVirtualScroll.test.ts
@@ -1,0 +1,298 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import type { ScrollBoxHandle } from '../../../src/tui/ink/components/ScrollBox.js'
+import type { DOMElement } from '../../../src/tui/ink/dom.js'
+import { createRoot } from '../../../src/tui/ink/root.js'
+import {
+  type VirtualScrollResult,
+  useVirtualScroll,
+} from '../../../src/tui/hooks/useVirtualScroll.js'
+
+type ClampCall = readonly [number | undefined, number | undefined]
+
+class FakeScrollBox implements ScrollBoxHandle {
+  readonly clampCalls: ClampCall[] = []
+  readonly listeners = new Set<() => void>()
+  readonly scrollToCalls: number[] = []
+  pendingDelta = 0
+  scrollTop = 0
+  sticky = false
+  viewportHeight = 20
+
+  scrollTo(y: number): void {
+    this.scrollToCalls.push(y)
+    this.scrollTop = Math.max(0, Math.floor(y))
+    this.pendingDelta = 0
+    this.sticky = false
+    this.emit()
+  }
+
+  scrollBy(dy: number): void {
+    this.pendingDelta += Math.floor(dy)
+    this.sticky = false
+    this.emit()
+  }
+
+  scrollToElement(): void {
+    this.sticky = false
+    this.emit()
+  }
+
+  scrollToBottom(): void {
+    this.pendingDelta = 0
+    this.sticky = true
+    this.emit()
+  }
+
+  getScrollTop(): number {
+    return this.scrollTop
+  }
+
+  getPendingDelta(): number {
+    return this.pendingDelta
+  }
+
+  getScrollHeight(): number {
+    return 0
+  }
+
+  getFreshScrollHeight(): number {
+    return 0
+  }
+
+  getViewportHeight(): number {
+    return this.viewportHeight
+  }
+
+  getViewportTop(): number {
+    return 0
+  }
+
+  isSticky(): boolean {
+    return this.sticky
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  setClampBounds(min: number | undefined, max: number | undefined): void {
+    this.clampCalls.push([min, max])
+  }
+
+  emit(): void {
+    for (const listener of this.listeners) listener()
+  }
+}
+
+function createStreams(): {
+  readonly stdout: PassThrough
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  return { stdin, stdout }
+}
+
+function fakeElement(height: number, top: number, width = 10): DOMElement {
+  return {
+    yogaNode: {
+      getComputedHeight: () => height,
+      getComputedTop: () => top,
+      getComputedWidth: () => width,
+    },
+  } as DOMElement
+}
+
+function makeKeys(count: number): string[] {
+  return Array.from({ length: count }, (_, index) => `item-${index}`)
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  let lastError: unknown
+  for (let i = 0; i < 30; i++) {
+    try {
+      assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await sleep()
+    }
+  }
+  throw lastError
+}
+
+async function renderHookHarness(initial: {
+  columns?: number
+  itemKeys: readonly string[]
+  scrollRef: React.RefObject<ScrollBoxHandle | null>
+}): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly latest: () => VirtualScrollResult
+  readonly render: (next?: Partial<typeof initial>) => Promise<void>
+}> {
+  let props = {
+    columns: 80,
+    ...initial,
+  }
+  let latest: VirtualScrollResult | undefined
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    latest = useVirtualScroll(props.scrollRef, props.itemKeys, props.columns)
+    return null
+  }
+
+  async function render(next: Partial<typeof initial> = {}): Promise<void> {
+    props = { ...props, ...next }
+    root.render(React.createElement(Harness))
+    await sleep()
+  }
+
+  await render()
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+    render,
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useVirtualScroll coverage swarm 182', () => {
+  test('uses pending target notifications when sticky scrolling breaks', async () => {
+    const scroll = new FakeScrollBox()
+    scroll.sticky = true
+    const rendered = await renderHookHarness({
+      itemKeys: makeKeys(200),
+      scrollRef: { current: scroll },
+    })
+
+    try {
+      expect(rendered.latest().range[1]).toBe(200)
+      expect(scroll.clampCalls.at(-1)).toEqual([undefined, undefined])
+
+      scroll.sticky = false
+      scroll.pendingDelta = 160
+      scroll.emit()
+
+      await waitFor(() => {
+        expect(rendered.latest().range[1]).toBeLessThan(200)
+      })
+      expect(rendered.latest().range[0]).toBeGreaterThanOrEqual(0)
+      expect(scroll.clampCalls.at(-1)?.[0]).toBeGreaterThanOrEqual(0)
+      expect(scroll.clampCalls.at(-1)?.[1]).toBeGreaterThan(0)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('clamps a frozen resize range when the item list shrinks', async () => {
+    const scroll = new FakeScrollBox()
+    scroll.scrollTop = 900
+    const keys = makeKeys(500)
+    const rendered = await renderHookHarness({
+      itemKeys: keys,
+      scrollRef: { current: scroll },
+    })
+
+    try {
+      expect(rendered.latest().range[0]).toBeGreaterThan(3)
+
+      await rendered.render({ columns: 40, itemKeys: keys.slice(0, 3) })
+      expect(rendered.latest().range).toEqual([3, 3])
+      expect(rendered.latest().bottomSpacer).toBe(0)
+      expect(scroll.clampCalls.at(-1)).toEqual([9, Infinity])
+
+      await rendered.render()
+      expect(rendered.latest().range).toEqual([0, 3])
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('skips zero-height measurements until Yoga has a real width', async () => {
+    const scroll = new FakeScrollBox()
+    scroll.sticky = true
+    const rendered = await renderHookHarness({
+      itemKeys: ['zero-width', 'empty', 'missing-yoga'],
+      scrollRef: { current: scroll },
+    })
+
+    try {
+      rendered.latest().measureRef('zero-width')(fakeElement(0, 5, 0))
+      rendered.latest().measureRef('empty')(fakeElement(0, 6))
+      rendered.latest().measureRef('missing-yoga')({} as DOMElement)
+
+      await rendered.render()
+
+      expect(rendered.latest().getItemHeight(0)).toBeUndefined()
+      expect(rendered.latest().getItemTop(0)).toBe(-1)
+      expect(rendered.latest().getItemHeight(1)).toBe(0)
+      expect(rendered.latest().getItemTop(2)).toBe(-1)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('leaves tail clamp unbounded and uses list origin for index seeks', async () => {
+    const scroll = new FakeScrollBox()
+    const rendered = await renderHookHarness({
+      itemKeys: makeKeys(10),
+      scrollRef: { current: scroll },
+    })
+
+    try {
+      rendered.latest().spacerRef.current = fakeElement(0, 7)
+      await rendered.render()
+
+      expect(rendered.latest().range).toEqual([0, 10])
+      expect(scroll.clampCalls.at(-1)).toEqual([0, Infinity])
+
+      rendered.latest().scrollToIndex(2)
+      expect(scroll.scrollToCalls).toEqual([13])
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-183-ink-styles.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-183-ink-styles.test.ts
@@ -1,0 +1,145 @@
+import { expect, test, vi } from 'vitest'
+
+import {
+  LayoutAlign,
+  LayoutDisplay,
+  LayoutEdge,
+  LayoutFlexDirection,
+  LayoutGutter,
+  LayoutJustify,
+  LayoutOverflow,
+  LayoutPositionType,
+  type LayoutNode,
+} from '../../../src/tui/ink/layout/node.ts'
+import applyStyles, { type Styles } from '../../../src/tui/ink/styles.ts'
+
+function createLayoutNode(): LayoutNode {
+  return {
+    setAlignItems: vi.fn(),
+    setAlignSelf: vi.fn(),
+    setBorder: vi.fn(),
+    setDisplay: vi.fn(),
+    setFlexBasis: vi.fn(),
+    setFlexBasisPercent: vi.fn(),
+    setFlexDirection: vi.fn(),
+    setFlexGrow: vi.fn(),
+    setFlexShrink: vi.fn(),
+    setFlexWrap: vi.fn(),
+    setGap: vi.fn(),
+    setHeight: vi.fn(),
+    setHeightAuto: vi.fn(),
+    setHeightPercent: vi.fn(),
+    setJustifyContent: vi.fn(),
+    setMargin: vi.fn(),
+    setMaxHeight: vi.fn(),
+    setMaxHeightPercent: vi.fn(),
+    setMaxWidth: vi.fn(),
+    setMaxWidthPercent: vi.fn(),
+    setMinHeight: vi.fn(),
+    setMinHeightPercent: vi.fn(),
+    setMinWidth: vi.fn(),
+    setMinWidthPercent: vi.fn(),
+    setOverflow: vi.fn(),
+    setPadding: vi.fn(),
+    setPosition: vi.fn(),
+    setPositionPercent: vi.fn(),
+    setPositionType: vi.fn(),
+    setWidth: vi.fn(),
+    setWidthAuto: vi.fn(),
+    setWidthPercent: vi.fn(),
+  } as unknown as LayoutNode
+}
+
+test('maps concrete style values to layout node setters', () => {
+  const node = createLayoutNode()
+
+  applyStyles(node, {
+    alignItems: 'flex-start',
+    alignSelf: 'flex-end',
+    columnGap: 3,
+    display: 'flex',
+    flexBasis: 7,
+    flexDirection: 'row',
+    flexGrow: 2,
+    flexShrink: 3,
+    gap: 2,
+    height: 5,
+    justifyContent: 'center',
+    marginBottom: 8,
+    marginLeft: 4,
+    marginRight: 6,
+    marginTop: 7,
+    maxHeight: 11,
+    maxWidth: 10,
+    minHeight: 9,
+    minWidth: 8,
+    overflow: 'visible',
+    paddingBottom: 12,
+    paddingLeft: 9,
+    paddingRight: 10,
+    paddingTop: 11,
+    position: 'relative',
+    rowGap: 4,
+    width: 12,
+  })
+
+  expect(node.setPositionType).toHaveBeenCalledWith(
+    LayoutPositionType.Relative,
+  )
+  expect(node.setOverflow).toHaveBeenCalledWith(LayoutOverflow.Visible)
+  expect(node.setMargin).toHaveBeenCalledWith(LayoutEdge.Start, 4)
+  expect(node.setMargin).toHaveBeenCalledWith(LayoutEdge.End, 6)
+  expect(node.setMargin).toHaveBeenCalledWith(LayoutEdge.Top, 7)
+  expect(node.setMargin).toHaveBeenCalledWith(LayoutEdge.Bottom, 8)
+  expect(node.setPadding).toHaveBeenCalledWith(LayoutEdge.Left, 9)
+  expect(node.setPadding).toHaveBeenCalledWith(LayoutEdge.Right, 10)
+  expect(node.setPadding).toHaveBeenCalledWith(LayoutEdge.Top, 11)
+  expect(node.setPadding).toHaveBeenCalledWith(LayoutEdge.Bottom, 12)
+  expect(node.setFlexGrow).toHaveBeenCalledWith(2)
+  expect(node.setFlexShrink).toHaveBeenCalledWith(3)
+  expect(node.setFlexDirection).toHaveBeenCalledWith(LayoutFlexDirection.Row)
+  expect(node.setFlexBasis).toHaveBeenCalledWith(7)
+  expect(node.setAlignItems).toHaveBeenCalledWith(LayoutAlign.FlexStart)
+  expect(node.setAlignSelf).toHaveBeenCalledWith(LayoutAlign.FlexEnd)
+  expect(node.setJustifyContent).toHaveBeenCalledWith(LayoutJustify.Center)
+  expect(node.setWidth).toHaveBeenCalledWith(12)
+  expect(node.setHeight).toHaveBeenCalledWith(5)
+  expect(node.setMinWidth).toHaveBeenCalledWith(8)
+  expect(node.setMinHeight).toHaveBeenCalledWith(9)
+  expect(node.setMaxWidth).toHaveBeenCalledWith(10)
+  expect(node.setMaxHeight).toHaveBeenCalledWith(11)
+  expect(node.setDisplay).toHaveBeenCalledWith(LayoutDisplay.Flex)
+  expect(node.setGap).toHaveBeenCalledWith(LayoutGutter.All, 2)
+  expect(node.setGap).toHaveBeenCalledWith(LayoutGutter.Column, 3)
+  expect(node.setGap).toHaveBeenCalledWith(LayoutGutter.Row, 4)
+})
+
+test('maps remaining alignment and individual border branches', () => {
+  const node = createLayoutNode()
+
+  applyStyles(node, {
+    alignItems: 'center',
+    borderBottom: false,
+    borderLeft: undefined,
+    borderRight: true,
+    borderTop: true,
+    justifyContent: 'flex-end',
+  } as Styles)
+
+  applyStyles(node, {
+    alignItems: 'flex-end',
+    justifyContent: 'space-between',
+  })
+
+  expect(node.setAlignItems).toHaveBeenCalledWith(LayoutAlign.Center)
+  expect(node.setAlignItems).toHaveBeenCalledWith(LayoutAlign.FlexEnd)
+  expect(node.setJustifyContent).toHaveBeenCalledWith(LayoutJustify.FlexEnd)
+  expect(node.setJustifyContent).toHaveBeenCalledWith(
+    LayoutJustify.SpaceBetween,
+  )
+  expect(node.setBorder).toHaveBeenCalledWith(LayoutEdge.Top, 1)
+  expect(node.setBorder).toHaveBeenCalledWith(LayoutEdge.Bottom, 0)
+  expect(node.setBorder).toHaveBeenCalledWith(LayoutEdge.Right, 1)
+  expect(node.setBorder).not.toHaveBeenCalledWith(LayoutEdge.Left, 0)
+  expect(node.setBorder).not.toHaveBeenCalledWith(LayoutEdge.Left, 1)
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-184-rate-limits-agenc-ai-limits.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-184-rate-limits-agenc-ai-limits.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+type LimitsSnapshot = {
+  readonly status: 'allowed' | 'allowed_warning' | 'rejected'
+  readonly unifiedRateLimitFallbackAvailable: boolean
+  readonly isUsingOverage?: boolean
+  readonly rateLimitType?: 'five_hour' | 'seven_day' | 'overage'
+  readonly resetsAt?: number
+  readonly utilization?: number
+}
+
+type RawWindowUtilization = {
+  readonly utilization: number
+  readonly resets_at: number
+}
+
+type RawUtilization = {
+  readonly five_hour?: RawWindowUtilization
+  readonly seven_day?: RawWindowUtilization
+}
+
+type LimitsListener = (limits: LimitsSnapshot) => void
+
+const harness = vi.hoisted(() => ({
+  cleanup: undefined as (() => void) | undefined,
+  currentLimits: {
+    status: 'allowed',
+    unifiedRateLimitFallbackAvailable: false,
+    isUsingOverage: false,
+  } as LimitsSnapshot,
+  currentState: undefined as LimitsSnapshot | undefined,
+  effectDeps: undefined as readonly unknown[] | undefined,
+  getRawUtilization: vi.fn<() => RawUtilization>(() => ({})),
+  stateUpdates: [] as LimitsSnapshot[],
+  statusListeners: new Set<LimitsListener>(),
+  useEffect: vi.fn(
+    (effect: () => void | (() => void), deps?: readonly unknown[]) => {
+      harness.effectDeps = deps
+      harness.cleanup = effect() ?? undefined
+    },
+  ),
+  useState: vi.fn((initial: LimitsSnapshot) => {
+    harness.currentState = initial
+    return [
+      harness.currentState,
+      (next: LimitsSnapshot) => {
+        harness.currentState = next
+        harness.stateUpdates.push(next)
+      },
+    ] as const
+  }),
+}))
+
+vi.mock('react', () => ({
+  useEffect: harness.useEffect,
+  useState: harness.useState,
+}))
+
+vi.mock('../../../src/services/agencAiLimits.js', () => ({
+  get currentLimits() {
+    return harness.currentLimits
+  },
+  getRawUtilization: harness.getRawUtilization,
+  statusListeners: harness.statusListeners,
+}))
+
+import {
+  getRawUtilization,
+  useAgenCAiLimits,
+} from '../../../src/tui/rate-limits/agenc-ai-limits.js'
+
+describe('agenc-ai-limits coverage swarm row 184', () => {
+  beforeEach(() => {
+    harness.cleanup = undefined
+    harness.currentLimits = {
+      status: 'allowed',
+      unifiedRateLimitFallbackAvailable: false,
+      isUsingOverage: false,
+    }
+    harness.currentState = undefined
+    harness.effectDeps = undefined
+    harness.getRawUtilization.mockReset()
+    harness.getRawUtilization.mockReturnValue({})
+    harness.stateUpdates = []
+    harness.statusListeners.clear()
+    harness.useEffect.mockClear()
+    harness.useState.mockClear()
+  })
+
+  test('subscribes to limit changes with cloned initial and listener snapshots', () => {
+    const initialLimits: LimitsSnapshot = {
+      status: 'allowed_warning',
+      unifiedRateLimitFallbackAvailable: true,
+      isUsingOverage: false,
+      rateLimitType: 'five_hour',
+      resetsAt: 1_800,
+      utilization: 0.91,
+    }
+    harness.currentLimits = initialLimits
+
+    const rendered = useAgenCAiLimits()
+
+    expect(rendered).toEqual(initialLimits)
+    expect(rendered).not.toBe(initialLimits)
+    expect(harness.useState).toHaveBeenCalledTimes(1)
+    expect(harness.useEffect).toHaveBeenCalledTimes(1)
+    expect(harness.effectDeps).toEqual([])
+    expect(harness.statusListeners.size).toBe(1)
+
+    const [listener] = harness.statusListeners
+    const nextLimits: LimitsSnapshot = {
+      status: 'rejected',
+      unifiedRateLimitFallbackAvailable: false,
+      isUsingOverage: true,
+      rateLimitType: 'overage',
+      resetsAt: 3_600,
+      utilization: 1,
+    }
+
+    listener(nextLimits)
+
+    expect(harness.stateUpdates).toHaveLength(1)
+    expect(harness.stateUpdates[0]).toEqual(nextLimits)
+    expect(harness.stateUpdates[0]).not.toBe(nextLimits)
+
+    expect(harness.cleanup).toBeTypeOf('function')
+    harness.cleanup?.()
+    expect(harness.statusListeners.size).toBe(0)
+  })
+
+  test('returns independent raw utilization windows when present', () => {
+    const raw: RawUtilization = {
+      five_hour: { utilization: 0.25, resets_at: 10 },
+      seven_day: { utilization: 0.75, resets_at: 20 },
+    }
+    harness.getRawUtilization.mockReturnValue(raw)
+
+    const result = getRawUtilization()
+
+    expect(result).toEqual(raw)
+    expect(result).not.toBe(raw)
+    expect(result.five_hour).not.toBe(raw.five_hour)
+    expect(result.seven_day).not.toBe(raw.seven_day)
+  })
+
+  test('omits raw utilization windows that are not reported', () => {
+    harness.getRawUtilization.mockReturnValue({})
+
+    expect(getRawUtilization()).toEqual({})
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-185-tool-result-routing.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-185-tool-result-routing.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  pickToolResultDispatch,
+  resultTextForTuiTool,
+} from "../tool-result-routing.js";
+
+describe("pickToolResultDispatch coverage swarm row 185", () => {
+  test("exact routed tool names without their own envelope fall through to generic", () => {
+    expect(pickToolResultDispatch("Write", "<read-content>x</read-content>")).toBe(
+      "generic",
+    );
+    expect(
+      pickToolResultDispatch("Grep", "<write-summary>x</write-summary>"),
+    ).toBe("generic");
+    expect(pickToolResultDispatch("Glob", "<grep-matches>x</grep-matches>")).toBe(
+      "generic",
+    );
+  });
+
+  test("tool-error envelope wins before later exact tool routes", () => {
+    expect(
+      pickToolResultDispatch(
+        "Glob",
+        "<glob-paths>src/index.ts</glob-paths>\n<tool-error>denied</tool-error>",
+      ),
+    ).toBe("tool-error-view");
+  });
+});
+
+describe("resultTextForTuiTool coverage swarm row 185", () => {
+  test("flattens empty arrays and object content text block arrays", () => {
+    expect(resultTextForTuiTool([])).toBe("");
+    expect(
+      resultTextForTuiTool({
+        content: [
+          { type: "text", text: "<read-content>first</read-content>" },
+          { type: "text", text: "second" },
+        ],
+      }),
+    ).toBe("<read-content>first</read-content>\nsecond");
+  });
+
+  test("falls back to JSON for malformed block arrays and non-string content", () => {
+    const nonTextBlock = { type: "image", text: "not flattened" };
+    const nonStringTextBlock = { type: "text", text: 123 };
+
+    expect(resultTextForTuiTool([nonTextBlock])).toBe(
+      JSON.stringify(nonTextBlock),
+    );
+    expect(resultTextForTuiTool({ content: [nonStringTextBlock] })).toBe(
+      JSON.stringify({ content: [nonStringTextBlock] }),
+    );
+    expect(resultTextForTuiTool({ content: 42 })).toBe('{"content":42}');
+  });
+
+  test("truncates long JSON fallback values to the short preview", () => {
+    const value = { payload: "x".repeat(200) };
+    const rendered = resultTextForTuiTool(value);
+
+    expect(rendered).toBe(`${JSON.stringify(value).slice(0, 137)}...`);
+    expect(rendered).toHaveLength(140);
+  });
+
+  test("stringifies primitive values when JSON.stringify does not return text", () => {
+    expect(resultTextForTuiTool(Symbol("row-185"))).toBe("Symbol(row-185)");
+    expect(resultTextForTuiTool(() => "ignored")).toContain("=>");
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-186-components-IdeStatusIndicator.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-186-components-IdeStatusIndicator.test.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { describe, expect, test } from "vitest";
+
+import type { MCPServerConnection } from "../../../src/services/mcp/types.js";
+import { IdeStatusIndicator } from "../../../src/tui/components/IdeStatusIndicator.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+function ideClient(type: MCPServerConnection["type"]): MCPServerConnection {
+  return {
+    name: "ide",
+    type,
+    config: {
+      ideName: "VS Code",
+      scope: "local",
+      type: "ws-ide",
+      url: "ws://localhost:1234",
+    },
+  } as unknown as MCPServerConnection;
+}
+
+async function renderIndicator(
+  ideSelection: React.ComponentProps<typeof IdeStatusIndicator>["ideSelection"],
+  mcpClients: MCPServerConnection[] = [ideClient("connected")],
+): Promise<string> {
+  return renderToString(
+    <IdeStatusIndicator ideSelection={ideSelection} mcpClients={mcpClients} />,
+    80,
+  );
+}
+
+async function renderTrimmedIndicator(
+  ideSelection: React.ComponentProps<typeof IdeStatusIndicator>["ideSelection"],
+  mcpClients?: MCPServerConnection[],
+): Promise<string> {
+  return (await renderIndicator(ideSelection, mcpClients)).trim();
+}
+
+describe("IdeStatusIndicator coverage swarm row 186", () => {
+  test("suppresses empty selections even when the IDE client is connected", async () => {
+    await expect(
+      renderTrimmedIndicator({ text: "", lineCount: 3 }),
+    ).resolves.toHaveLength(0);
+
+    await expect(
+      renderTrimmedIndicator({ text: "selected", lineCount: 0 }),
+    ).resolves.toHaveLength(0);
+
+    await expect(
+      renderTrimmedIndicator({ filePath: "", lineCount: 0 }),
+    ).resolves.toHaveLength(0);
+  });
+
+  test("prefers selected text counts over the file path context", async () => {
+    await expect(
+      renderIndicator({
+        filePath: "/workspace/src/fallback.ts",
+        lineCount: 2,
+        text: "one\ntwo",
+      }),
+    ).resolves.toContain("2 lines selected");
+
+    await expect(
+      renderIndicator({
+        filePath: "/workspace/src/fallback.ts",
+        lineCount: 2,
+        text: "one\ntwo",
+      }),
+    ).resolves.not.toContain("In fallback.ts");
+  });
+
+  test("renders file context for connected clients without selected text", async () => {
+    await expect(
+      renderIndicator({ filePath: "/workspace/src/current.ts", lineCount: 0 }),
+    ).resolves.toContain("In current.ts");
+  });
+
+  test("does not render file or selection context for disconnected clients", async () => {
+    await expect(
+      renderTrimmedIndicator(
+        { filePath: "/workspace/src/current.ts", lineCount: 0 },
+        [ideClient("failed")],
+      ),
+    ).resolves.toHaveLength(0);
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-187-components-WorktreeExitDialog.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-187-components-WorktreeExitDialog.test.tsx
@@ -1,0 +1,227 @@
+import type { ReactElement, ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+type CommandResultOptions = {
+  readonly display?: string
+}
+
+type WorktreeSession = {
+  readonly originalCwd: string
+  readonly originalHeadCommit: string
+  readonly sessionId: string
+  readonly tmuxSessionName?: string
+  readonly worktreeBranch: string
+  readonly worktreeName: string
+  readonly worktreePath: string
+}
+
+type SelectProps = {
+  readonly defaultFocusValue?: string
+  readonly onChange: (value: string) => void | Promise<void>
+  readonly options: Array<{
+    readonly description?: string
+    readonly label: string
+    readonly value: string
+  }>
+}
+
+type DialogElementProps = {
+  readonly children: ReactElement<SelectProps>
+  readonly onCancel: () => void
+  readonly subtitle?: ReactNode
+  readonly title: ReactNode
+}
+
+const harness = vi.hoisted(() => ({
+  cleanupWorktree: vi.fn(),
+  clearPlansCache: vi.fn(),
+  execFileNoThrow: vi.fn(),
+  keepWorktree: vi.fn(),
+  killTmuxSession: vi.fn(),
+  logEvent: vi.fn(),
+  logForDebugging: vi.fn(),
+  saveWorktreeState: vi.fn(),
+  session: {
+    originalCwd: '/workspace/main',
+    originalHeadCommit: 'abc123',
+    sessionId: 'session-1',
+    worktreeBranch: 'feature/clean-worktree',
+    worktreeName: 'clean-worktree',
+    worktreePath: '/workspace/.agenc/worktrees/clean-worktree',
+  } as WorktreeSession | null,
+  setChanges: vi.fn(),
+  setCommitCount: vi.fn(),
+  setCwd: vi.fn(),
+  setResultMessage: vi.fn(),
+  setStatus: vi.fn(),
+  useEffect: vi.fn(),
+  useState: vi.fn(),
+}))
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react')
+
+  return {
+    ...actual,
+    useEffect: harness.useEffect,
+    useState: harness.useState,
+  }
+})
+
+vi.mock('bun:bundle', () => ({
+  feature: () => false,
+}))
+
+vi.mock('src/services/analytics/index.js', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('src/utils/debug.js', () => ({
+  logForDebugging: harness.logForDebugging,
+}))
+
+vi.mock('src/utils/execFileNoThrow.js', () => ({
+  execFileNoThrow: harness.execFileNoThrow,
+}))
+
+vi.mock('src/utils/plans.js', () => {
+  const getPlansDirectory = () => '/workspace/.agenc/plans'
+  ;(
+    getPlansDirectory as typeof getPlansDirectory & {
+      cache: { clear: () => void }
+    }
+  ).cache = { clear: harness.clearPlansCache }
+
+  return { getPlansDirectory }
+})
+
+vi.mock('src/utils/Shell.js', () => ({
+  setCwd: harness.setCwd,
+}))
+
+vi.mock('src/utils/sessionStorage.js', () => ({
+  saveWorktreeState: harness.saveWorktreeState,
+}))
+
+vi.mock('src/utils/worktree.js', () => ({
+  cleanupWorktree: harness.cleanupWorktree,
+  getCurrentWorktreeSession: () => harness.session,
+  keepWorktree: harness.keepWorktree,
+  killTmuxSession: harness.killTmuxSession,
+}))
+
+vi.mock('../../../src/tui/components/CustomSelect/select.js', () => ({
+  Select: () => null,
+}))
+
+vi.mock('../../../src/tui/components/design-system/Dialog.js', () => ({
+  Dialog: () => null,
+}))
+
+vi.mock('../../../src/tui/components/spinner/Spinner.js', () => ({
+  Spinner: () => null,
+}))
+
+function seedDialogState(): void {
+  const states: Array<readonly [unknown, (value: unknown) => void]> = [
+    ['asking', harness.setStatus],
+    [[], harness.setChanges],
+    [0, harness.setCommitCount],
+    [undefined, harness.setResultMessage],
+  ]
+  let index = 0
+
+  harness.useState.mockImplementation(() => {
+    const state = states[index]
+    index += 1
+    if (!state) throw new Error('Unexpected WorktreeExitDialog state slot')
+    return state
+  })
+}
+
+async function callDialog(): Promise<ReactElement<DialogElementProps>> {
+  const { WorktreeExitDialog } = await import(
+    '../../../src/tui/components/WorktreeExitDialog.js'
+  )
+
+  return WorktreeExitDialog({
+    onDone: (_result?: string, _options?: CommandResultOptions) => {},
+  }) as ReactElement<DialogElementProps>
+}
+
+describe('WorktreeExitDialog coverage swarm row 187', () => {
+  let chdirSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    harness.cleanupWorktree.mockReset().mockResolvedValue(undefined)
+    harness.clearPlansCache.mockClear()
+    harness.execFileNoThrow.mockReset()
+    harness.keepWorktree.mockReset().mockResolvedValue(undefined)
+    harness.killTmuxSession.mockReset().mockResolvedValue(undefined)
+    harness.logEvent.mockClear()
+    harness.logForDebugging.mockClear()
+    harness.saveWorktreeState.mockClear()
+    harness.setChanges.mockClear()
+    harness.setCommitCount.mockClear()
+    harness.setCwd.mockClear()
+    harness.setResultMessage.mockClear()
+    harness.setStatus.mockClear()
+    harness.session = {
+      originalCwd: '/workspace/main',
+      originalHeadCommit: 'abc123',
+      sessionId: 'session-1',
+      worktreeBranch: 'feature/clean-worktree',
+      worktreeName: 'clean-worktree',
+      worktreePath: '/workspace/.agenc/worktrees/clean-worktree',
+    }
+    harness.useEffect.mockReset()
+    harness.useState.mockReset()
+    seedDialogState()
+    chdirSpy = vi.spyOn(process, 'chdir').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    chdirSpy.mockRestore()
+    vi.resetModules()
+  })
+
+  test('renders the clean asking branch and reports clean manual removal', async () => {
+    const dialog = await callDialog()
+
+    expect(dialog.props.title).toBe('Exiting worktree session')
+    expect(dialog.props.subtitle).toBe(
+      'You are working in a worktree. Keep it to continue working there, or remove it to clean up.',
+    )
+    expect(dialog.props.children.props).toMatchObject({
+      defaultFocusValue: 'keep',
+      options: [
+        {
+          description:
+            'Stays at /workspace/.agenc/worktrees/clean-worktree',
+          label: 'Keep worktree',
+          value: 'keep',
+        },
+        {
+          description: 'Clean up the worktree directory.',
+          label: 'Remove worktree',
+          value: 'remove',
+        },
+      ],
+    })
+
+    await dialog.props.children.props.onChange('remove')
+
+    expect(harness.logEvent).toHaveBeenCalledWith('agenc_worktree_removed', {
+      changed_files: 0,
+      commits: 0,
+    })
+    expect(harness.killTmuxSession).not.toHaveBeenCalled()
+    expect(harness.cleanupWorktree).toHaveBeenCalledOnce()
+    expect(chdirSpy).toHaveBeenCalledWith('/workspace/main')
+    expect(harness.setCwd).toHaveBeenCalledWith('/workspace/main')
+    expect(harness.saveWorktreeState).toHaveBeenCalledWith(null)
+    expect(harness.clearPlansCache).toHaveBeenCalledOnce()
+    expect(harness.setResultMessage).toHaveBeenCalledWith('Worktree removed.')
+    expect(harness.setStatus).toHaveBeenLastCalledWith('done')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-188-ink-parse-keypress.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-188-ink-parse-keypress.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  INITIAL_STATE,
+  parseMultipleKeypresses,
+  type ParsedInput,
+  type ParsedKey,
+} from '../../../src/tui/ink/parse-keypress.js'
+
+function parseOne(sequence: string): ParsedInput {
+  const [items] = parseMultipleKeypresses(INITIAL_STATE, sequence)
+
+  expect(items).toHaveLength(1)
+
+  return items[0]!
+}
+
+function parseKey(sequence: string): ParsedKey {
+  const item = parseOne(sequence)
+
+  expect(item.kind).toBe('key')
+
+  return item as ParsedKey
+}
+
+function parseKeyAfterOptionalFlush(sequence: string): ParsedKey {
+  const [items, state] = parseMultipleKeypresses(INITIAL_STATE, sequence)
+
+  if (items.length === 1) {
+    expect(items[0]?.kind).toBe('key')
+
+    return items[0] as ParsedKey
+  }
+
+  const [flushed] = parseMultipleKeypresses(state, null)
+  expect(flushed).toHaveLength(1)
+  expect(flushed[0]?.kind).toBe('key')
+
+  return flushed[0] as ParsedKey
+}
+
+describe('parse-keypress coverage swarm row 188', () => {
+  test('parses exact page navigation overrides', () => {
+    expect(parseKey('\x1b[5~')).toEqual(
+      expect.objectContaining({
+        ctrl: false,
+        meta: false,
+        name: 'pageup',
+        shift: false,
+      }),
+    )
+    expect(parseKey('\x1b[6~')).toEqual(
+      expect.objectContaining({
+        ctrl: false,
+        meta: false,
+        name: 'pagedown',
+        shift: false,
+      }),
+    )
+  })
+
+  test('marks rxvt shift and control aliases from function-key sequences', () => {
+    expect(parseKeyAfterOptionalFlush('\x1b[2$')).toEqual(
+      expect.objectContaining({
+        code: '[2$',
+        ctrl: false,
+        name: 'insert',
+        shift: true,
+      }),
+    )
+    expect(parseKeyAfterOptionalFlush('\x1b[3^')).toEqual(
+      expect.objectContaining({
+        code: '[3^',
+        ctrl: true,
+        name: 'delete',
+        shift: false,
+      }),
+    )
+    expect(parseKey('\x1bOa')).toEqual(
+      expect.objectContaining({
+        code: 'Oa',
+        ctrl: true,
+        name: 'up',
+      }),
+    )
+  })
+
+  test('falls back malformed terminal responses to key events', () => {
+    expect(parseKey('\x1b]not-a-response\x07')).toEqual(
+      expect.objectContaining({
+        name: '',
+        raw: '\x1b]not-a-response\x07',
+        sequence: '\x1b]not-a-response\x07',
+      }),
+    )
+    expect(parseKey('\x1bPnot-a-version\x1b\\')).toEqual(
+      expect.objectContaining({
+        name: '',
+        raw: '\x1bPnot-a-version\x1b\\',
+        sequence: '\x1bPnot-a-version\x1b\\',
+      }),
+    )
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-189-components-spinner-SpinnerAnimationRow.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-189-components-spinner-SpinnerAnimationRow.test.tsx
@@ -1,0 +1,165 @@
+import React from "react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import {
+  SpinnerAnimationRow,
+  type SpinnerAnimationRowProps,
+} from "../../../src/tui/components/spinner/SpinnerAnimationRow.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+const NOW = new Date("2026-05-20T12:00:00.000Z").getTime();
+
+function makeRef<T>(current: T): React.RefObject<T> {
+  return { current };
+}
+
+function props(
+  overrides: Partial<SpinnerAnimationRowProps> = {},
+): SpinnerAnimationRowProps {
+  return {
+    columns: 100,
+    effortSuffix: "",
+    foregroundedTeammate: undefined,
+    hasActiveTools: false,
+    hasRunningTeammates: false,
+    leaderIsIdle: false,
+    loadingStartTimeRef: makeRef(NOW - 31_000),
+    message: "Working",
+    messageColor: "text",
+    mode: "responding",
+    overrideColor: null,
+    pauseStartTimeRef: makeRef(null),
+    reducedMotion: false,
+    responseLengthRef: makeRef(800),
+    shimmerColor: "agencShimmer",
+    spinnerSuffix: null,
+    teammateTokens: 0,
+    thinkingStatus: null,
+    totalPausedMsRef: makeRef(0),
+    verbose: false,
+    ...overrides,
+  };
+}
+
+async function renderRow(
+  overrides: Partial<SpinnerAnimationRowProps> = {},
+): Promise<string> {
+  const rowProps = props(overrides);
+
+  return renderToString(<SpinnerAnimationRow {...rowProps} />, rowProps.columns);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("SpinnerAnimationRow coverage swarm row 189", () => {
+  test("uses paused elapsed time and renders the responding token glyph", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    const output = await renderRow({
+      loadingStartTimeRef: makeRef(NOW - 60_000),
+      pauseStartTimeRef: makeRef(NOW - 15_000),
+      totalPausedMsRef: makeRef(5_000),
+      verbose: true,
+    });
+
+    expect(output).toContain("Working");
+    expect(output).toContain("40s");
+    expect(output).toContain("200 tokens");
+    expect(output.match(/↓/g)?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+
+  test("shows aggregate teammate tokens without adding a token glyph", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    const output = await renderRow({
+      hasRunningTeammates: true,
+      loadingStartTimeRef: makeRef(NOW - 10_000),
+      responseLengthRef: makeRef(4_000),
+      teammateTokens: 2_500,
+    });
+
+    expect(output).toContain("10s");
+    expect(output).toContain("3.5k tokens");
+    expect(output.match(/↓/g)?.length ?? 0).toBe(1);
+  });
+
+  test("covers tool-input status while suppressing zero token metadata", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    const withTokens = await renderRow({
+      mode: "tool-input",
+      responseLengthRef: makeRef(1_200),
+      verbose: true,
+    });
+
+    expect(withTokens).toContain("◐");
+    expect(withTokens).toContain("300 tokens");
+
+    const withoutTokens = await renderRow({
+      mode: "thinking",
+      responseLengthRef: makeRef(0),
+      verbose: true,
+    });
+
+    expect(withoutTokens).toContain("31s");
+    expect(withoutTokens).not.toContain("0 tokens");
+  });
+
+  test("omits thinking text when compact columns cannot fit even the bare label", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    const output = await renderRow({
+      columns: 14,
+      effortSuffix: " deeply",
+      loadingStartTimeRef: makeRef(NOW - 2_000),
+      message: "Go",
+      thinkingStatus: "thinking",
+    });
+
+    expect(output).toContain("Go");
+    expect(output).not.toContain("thinking");
+    expect(output).not.toContain("deeply");
+  });
+
+  test("renders foregrounded teammate status when progress is absent and hides idle teammate metadata", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(NOW);
+
+    const foregrounded = await renderRow({
+      foregroundedTeammate: {
+        identity: {
+          agentName: "Scout",
+          color: "yellow",
+        },
+        isIdle: false,
+      } as SpinnerAnimationRowProps["foregroundedTeammate"],
+      hasRunningTeammates: true,
+      responseLengthRef: makeRef(4_000),
+      teammateTokens: 2_000,
+      thinkingStatus: "thinking",
+      verbose: true,
+    });
+
+    expect(foregrounded).toContain("(esc to interrupt Scout)");
+    expect(foregrounded).not.toContain("tokens");
+    expect(foregrounded).not.toContain("thinking");
+
+    const idle = await renderRow({
+      foregroundedTeammate: {
+        identity: {
+          agentName: "IdleScout",
+          color: "yellow",
+        },
+        isIdle: true,
+      } as SpinnerAnimationRowProps["foregroundedTeammate"],
+      thinkingStatus: "thinking",
+      verbose: true,
+    });
+
+    expect(idle).toContain("Working");
+    expect(idle).not.toContain("IdleScout");
+    expect(idle).not.toContain("tokens");
+    expect(idle).not.toContain("thinking");
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-190-history-HistorySearchDialog.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-190-history-HistorySearchDialog.test.tsx
@@ -1,0 +1,339 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+type HistoryEntryLike = {
+  display: string
+}
+
+type TimestampedEntryLike = {
+  display: string
+  timestamp: number
+  resolve: () => Promise<HistoryEntryLike>
+}
+
+type PickerItem = {
+  age: string
+  display: string
+  entry: TimestampedEntryLike
+  firstLine: string
+}
+
+type CapturedPickerProps = {
+  direction?: 'down' | 'up'
+  emptyMessage?: string | ((query: string) => string)
+  getKey: (item: PickerItem) => string
+  initialQuery?: string
+  items: readonly PickerItem[]
+  onCancel: () => void
+  onQueryChange: (query: string) => void
+  onSelect: (item: PickerItem) => void
+  placeholder?: string
+  previewPosition?: 'bottom' | 'right'
+  renderItem: (item: PickerItem, isFocused: boolean) => React.ReactNode
+  renderPreview: (item: PickerItem) => React.ReactNode
+  selectAction?: string
+  title: string
+}
+
+type HistoryReader = AsyncIterator<TimestampedEntryLike> &
+  AsyncIterable<TimestampedEntryLike> & {
+    next: ReturnType<typeof vi.fn>
+    return: ReturnType<typeof vi.fn>
+  }
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+}
+
+const harness = vi.hoisted(() => ({
+  entries: [] as TimestampedEntryLike[],
+  getTimestampedHistory: vi.fn(() => {
+    if (harness.readerFactory) return harness.readerFactory()
+
+    let index = 0
+    const reader = {
+      next: vi.fn(async (): Promise<IteratorResult<TimestampedEntryLike>> => {
+        if (index >= harness.entries.length) {
+          return { done: true, value: undefined }
+        }
+
+        const value = harness.entries[index]
+        index += 1
+        return { done: false, value: value! }
+      }),
+      return: vi.fn(async (): Promise<IteratorResult<TimestampedEntryLike>> => ({
+        done: true,
+        value: undefined,
+      })),
+      [Symbol.asyncIterator]() {
+        return this
+      },
+    } satisfies HistoryReader
+
+    harness.readers.push(reader)
+    return reader
+  }),
+  logEvent: vi.fn(),
+  pickerProps: undefined as CapturedPickerProps | undefined,
+  readerFactory: undefined as (() => HistoryReader) | undefined,
+  readers: [] as HistoryReader[],
+  registerOverlay: vi.fn(),
+  terminal: {
+    columns: 120,
+    rows: 30,
+  },
+}))
+
+vi.mock('../../../src/tui/context/overlayContext.js', () => ({
+  useRegisterOverlay: harness.registerOverlay,
+}))
+
+vi.mock('../../../src/tui/history/history.js', () => ({
+  getTimestampedHistory: harness.getTimestampedHistory,
+}))
+
+vi.mock('../../../src/tui/hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => harness.terminal,
+}))
+
+vi.mock('../../../src/services/analytics/index.js', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../../../src/tui/components/design-system/FuzzyPicker.js', () => ({
+  FuzzyPicker: (props: CapturedPickerProps) => {
+    harness.pickerProps = props
+    return null
+  },
+}))
+
+import { createRoot } from '../../../src/tui/ink/root.js'
+import { HistorySearchDialog } from '../../../src/tui/history/HistorySearchDialog.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(res => {
+    resolve = res
+  })
+
+  return { promise, resolve }
+}
+
+function resetHarness() {
+  harness.entries = []
+  harness.getTimestampedHistory.mockClear()
+  harness.logEvent.mockClear()
+  harness.pickerProps = undefined
+  harness.readerFactory = undefined
+  harness.readers = []
+  harness.registerOverlay.mockClear()
+  harness.terminal.columns = 120
+  harness.terminal.rows = 30
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await sleep(10)
+  }
+
+  throw new Error(message)
+}
+
+function createStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = harness.terminal.columns
+  ;(stdout as unknown as { rows: number }).rows = harness.terminal.rows
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function pickerProps(): CapturedPickerProps {
+  const props = harness.pickerProps
+  if (!props) throw new Error('History search picker props were not captured')
+  return props
+}
+
+function emptyMessage(props: CapturedPickerProps, query: string): string {
+  const message = props.emptyMessage
+  return typeof message === 'function' ? message(query) : message ?? ''
+}
+
+async function renderDialog(initialQuery?: string) {
+  const onCancel = vi.fn()
+  const onSelect = vi.fn()
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  root.render(
+    <HistorySearchDialog
+      initialQuery={initialQuery}
+      onCancel={onCancel}
+      onSelect={onSelect}
+    />,
+  )
+  await waitFor(() => harness.pickerProps !== undefined, 'Dialog did not render')
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await sleep(25)
+    },
+    onCancel,
+    onSelect,
+  }
+}
+
+describe('HistorySearchDialog coverage swarm row 190', () => {
+  beforeEach(() => {
+    resetHarness()
+  })
+
+  test('uses bottom preview layout on narrow terminals and handles empty filtered results', async () => {
+    harness.terminal.columns = 28
+    harness.entries = [
+      {
+        display: [
+          'first line that is deliberately long for the row',
+          '',
+          'second preview line',
+        ].join('\n'),
+        timestamp: Date.now(),
+        resolve: vi.fn(async () => ({ display: 'resolved prompt' })),
+      },
+    ]
+
+    const rendered = await renderDialog()
+
+    try {
+      await waitFor(
+        () => pickerProps().items.length === 1,
+        'History search did not load the narrow-layout item',
+      )
+
+      const loadedProps = pickerProps()
+      const item = loadedProps.items[0]!
+
+      expect(harness.registerOverlay).toHaveBeenCalledWith('history-search')
+      expect(loadedProps.initialQuery).toBeUndefined()
+      expect(loadedProps.previewPosition).toBe('bottom')
+      expect(loadedProps.getKey(item)).toBe(String(item.entry.timestamp))
+      expect(item.firstLine).toBe(
+        'first line that is deliberately long for the row',
+      )
+
+      const row = await renderToString(loadedProps.renderItem(item, false), 80)
+      expect(row).toContain('first line')
+      expect(row).not.toContain('second preview line')
+
+      const preview = await renderToString(loadedProps.renderPreview(item), 80)
+      expect(preview).toContain('first line')
+      expect(preview).toContain('second preview line')
+
+      loadedProps.onQueryChange('missing')
+      await waitFor(
+        () => pickerProps().items.length === 0,
+        'History search did not apply an empty filter result',
+      )
+      expect(emptyMessage(pickerProps(), 'missing')).toBe('No matching prompts')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('returns the history reader when unmounted while streaming entries', async () => {
+    const secondEntry = deferred<TimestampedEntryLike>()
+    let nextCount = 0
+    const reader = {
+      next: vi.fn(async (): Promise<IteratorResult<TimestampedEntryLike>> => {
+        nextCount += 1
+        if (nextCount === 1) {
+          return {
+            done: false,
+            value: {
+              display: 'already yielded',
+              timestamp: 1,
+              resolve: vi.fn(async () => ({ display: 'already yielded' })),
+            },
+          }
+        }
+
+        if (nextCount === 2) {
+          return { done: false, value: await secondEntry.promise }
+        }
+
+        return { done: true, value: undefined }
+      }),
+      return: vi.fn(async (): Promise<IteratorResult<TimestampedEntryLike>> => ({
+        done: true,
+        value: undefined,
+      })),
+      [Symbol.asyncIterator]() {
+        return this
+      },
+    } satisfies HistoryReader
+    harness.readerFactory = () => {
+      harness.readers.push(reader)
+      return reader
+    }
+
+    const rendered = await renderDialog('pending')
+    await waitFor(
+      () => reader.next.mock.calls.length === 2,
+      'History reader did not start waiting for the second entry',
+    )
+
+    await rendered.dispose()
+    secondEntry.resolve({
+      display: 'cancelled entry',
+      timestamp: 2,
+      resolve: vi.fn(async () => ({ display: 'cancelled entry' })),
+    })
+
+    await waitFor(
+      () => reader.return.mock.calls.length > 0,
+      'History reader was not returned after cancellation',
+    )
+    expect(reader.return).toHaveBeenCalledWith(undefined)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-191-hooks-typeaheadTokens.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-191-hooks-typeaheadTokens.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  HASH_CHANNEL_RE,
+  HAS_AT_SYMBOL_RE,
+  extractCompletionToken,
+  extractSearchToken,
+} from '../hooks/typeaheadTokens.js'
+
+describe('typeaheadTokens coverage swarm row 191', () => {
+  test('returns null for empty input and cursor-only whitespace', () => {
+    expect(extractCompletionToken('', 0, true)).toBeNull()
+    expect(extractCompletionToken('   ', 3, false)).toBeNull()
+  })
+
+  test('extends quoted @ tokens across the cursor through the closing quote', () => {
+    const text = 'attach @"folder name/file.md" after'
+    const cursor = 'attach @"folder'.length
+
+    expect(extractCompletionToken(text, cursor, true)).toEqual({
+      token: '@"folder name/file.md"',
+      startPos: 'attach '.length,
+      isQuoted: true,
+    })
+  })
+
+  test('keeps unterminated quoted @ tokens searchable without a trailing quote', () => {
+    const token = extractCompletionToken('open @"folder name', 'open @"folder name'.length, true)
+
+    expect(token).toEqual({
+      token: '@"folder name',
+      startPos: 'open '.length,
+      isQuoted: true,
+    })
+    expect(extractSearchToken(token!)).toBe('folder name')
+  })
+
+  test('falls back to the plain suffix when an @ token contains an invalid path char', () => {
+    const text = 'open @bad?tail'
+
+    expect(extractCompletionToken(text, text.length, true)).toEqual({
+      token: 'tail',
+      startPos: 'open @bad?'.length,
+      isQuoted: false,
+    })
+  })
+
+  test('uses plain-token extraction when @ matching is enabled but no @ is present', () => {
+    const text = 'open src/components/Button.tsx'
+    const cursor = 'open src/components'.length
+
+    expect(extractCompletionToken(text, cursor, true)).toEqual({
+      token: 'src/components/Button.tsx',
+      startPos: 'open '.length,
+      isQuoted: false,
+    })
+  })
+
+  test('does not extend @ token suffixes across punctuation after the cursor', () => {
+    const text = 'see @src, then continue'
+    const cursor = 'see @src'.length
+
+    expect(extractCompletionToken(text, cursor, true)).toEqual({
+      token: '@src',
+      startPos: 'see '.length,
+      isQuoted: false,
+    })
+  })
+
+  test('extracts search text from at-prefixed and plain tokens', () => {
+    expect(extractSearchToken({ token: '@/tmp/file.ts' })).toBe('/tmp/file.ts')
+    expect(extractSearchToken({ token: 'src/hooks' })).toBe('src/hooks')
+    expect(extractSearchToken({ token: '@"src/with space"', isQuoted: true })).toBe(
+      'src/with space',
+    )
+  })
+
+  test('matches trailing @ mentions and hash channels only at supported boundaries', () => {
+    expect('send @src/hooks'.match(HAS_AT_SYMBOL_RE)?.[2]).toBe('src/hooks')
+    expect('send @"src/with space"'.match(HAS_AT_SYMBOL_RE)?.[2]).toBe(
+      '"src/with space"',
+    )
+    expect('send #team_updates'.match(HASH_CHANNEL_RE)?.[2]).toBe('team_updates')
+    expect('send #Team'.match(HASH_CHANNEL_RE)).toBeNull()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-192-hooks-useHistorySearch.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-192-hooks-useHistorySearch.test.ts
@@ -1,0 +1,467 @@
+import { PassThrough } from 'node:stream'
+
+import React, { act, useState } from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+type PastedContentLike = {
+  content: string
+  type: 'text'
+}
+
+type HistoryEntryLike = {
+  display: string
+  pastedContents?: Record<number, PastedContentLike>
+}
+
+type ParsedKeyLike = {
+  ctrl: boolean
+  fn: boolean
+  meta: boolean
+  name: string
+  option: boolean
+  sequence?: string
+  shift: boolean
+  super: boolean
+}
+
+const fixture = vi.hoisted(() => ({
+  entries: [] as HistoryEntryLike[],
+  featureFlags: new Set<string>(),
+  inputSubscriptions: [] as Array<{
+    handler: (
+      input: string,
+      key: unknown,
+      event: { keypress: ParsedKeyLike },
+    ) => void
+    options: { isActive?: boolean }
+  }>,
+  keybindingCalls: [] as Array<{
+    action: string
+    handler: () => void
+    options: { context: string; isActive?: boolean }
+  }>,
+  keybindingsCalls: [] as Array<{
+    handlers: Record<string, () => void>
+    options: { context: string; isActive?: boolean }
+  }>,
+  readers: [] as Array<{
+    next: ReturnType<typeof vi.fn>
+    return: ReturnType<typeof vi.fn>
+  }>,
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => fixture.featureFlags.has(name),
+}))
+
+vi.mock('../../../src/tui/history/history.js', () => ({
+  makeHistoryReader: () => {
+    let index = 0
+    const reader = {
+      next: vi.fn(async () => {
+        const value = fixture.entries[index++]
+        if (value === undefined) return { done: true, value: undefined }
+        return { done: false, value }
+      }),
+      return: vi.fn(async (value: undefined) => ({ done: true, value })),
+      [Symbol.asyncIterator]() {
+        return this
+      },
+    }
+    fixture.readers.push(reader)
+    return reader
+  },
+}))
+
+vi.mock('../../../src/tui/keybindings/useKeybinding.js', () => ({
+  useKeybinding: (
+    action: string,
+    handler: () => void,
+    options: { context: string; isActive?: boolean },
+  ) => {
+    fixture.keybindingCalls.push({ action, handler, options })
+  },
+  useKeybindings: (
+    handlers: Record<string, () => void>,
+    options: { context: string; isActive?: boolean },
+  ) => {
+    fixture.keybindingsCalls.push({ handlers, options })
+  },
+}))
+
+vi.mock('../../../src/tui/ink.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../src/tui/ink.js')>()
+
+  return {
+    ...actual,
+    useInput: (
+      handler: (
+        input: string,
+        key: unknown,
+        event: { keypress: ParsedKeyLike },
+      ) => void,
+      options: { isActive?: boolean },
+    ) => {
+      fixture.inputSubscriptions.push({ handler, options })
+    },
+  }
+})
+
+import { createRoot } from '../../../src/tui/ink/root.js'
+import { useHistorySearch } from '../../../src/tui/hooks/useHistorySearch.js'
+
+type HookResult = ReturnType<typeof useHistorySearch>
+
+type CapturedHistory = HookResult & {
+  accepted: HistoryEntryLike[]
+  cursor: number
+  input: string
+  isSearching: boolean
+  mode: 'prompt' | 'bash'
+  pastedContents: Record<number, PastedContentLike>
+}
+
+type TestStreams = {
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdout: PassThrough & {
+    columns: number
+    isTTY: boolean
+    rows: number
+  }
+}
+
+function createStreams(): TestStreams {
+  const stdin = new PassThrough() as TestStreams['stdin']
+  const stdout = new PassThrough() as TestStreams['stdout']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 120
+  stdout.rows = 30
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function sleep(ms = 10): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  let lastError: unknown
+
+  for (let i = 0; i < 50; i++) {
+    try {
+      assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await sleep()
+    }
+  }
+
+  throw lastError
+}
+
+function parsedKey(name: string, sequence = ''): ParsedKeyLike {
+  return {
+    ctrl: false,
+    fn: false,
+    meta: false,
+    name,
+    option: false,
+    sequence,
+    shift: false,
+    super: false,
+  }
+}
+
+function latestStartSearchHandler(): (() => void) | undefined {
+  return fixture.keybindingCalls
+    .filter(call => call.action === 'history:search')
+    .at(-1)?.handler
+}
+
+function latestHistoryHandlers(): Record<string, () => void> {
+  return fixture.keybindingsCalls.at(-1)?.handlers ?? {}
+}
+
+function latestInputSubscription():
+  | (typeof fixture.inputSubscriptions)[number]
+  | undefined {
+  return fixture.inputSubscriptions.at(-1)
+}
+
+async function renderHookHarness(
+  initial: {
+    currentCursorOffset?: number
+    currentInput?: string
+    currentMode?: 'prompt' | 'bash'
+    currentPastedContents?: Record<number, PastedContentLike>
+  } = {},
+): Promise<{
+  capture: { current: CapturedHistory | null }
+  dispose: () => Promise<void>
+}> {
+  const capture = { current: null as CapturedHistory | null }
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    const [accepted, setAccepted] = useState<HistoryEntryLike[]>([])
+    const [input, setInput] = useState(initial.currentInput ?? 'draft prompt')
+    const [cursor, setCursor] = useState(initial.currentCursorOffset ?? 5)
+    const [mode, setMode] = useState<'prompt' | 'bash'>(
+      initial.currentMode ?? 'prompt',
+    )
+    const [isSearching, setIsSearching] = useState(false)
+    const [pastedContents, setPastedContents] = useState<
+      Record<number, PastedContentLike>
+    >(initial.currentPastedContents ?? {})
+    const history = useHistorySearch(
+      entry => setAccepted(items => [...items, entry as HistoryEntryLike]),
+      input,
+      setInput,
+      setCursor,
+      cursor,
+      setMode,
+      mode,
+      isSearching,
+      setIsSearching,
+      setPastedContents,
+      pastedContents,
+    )
+
+    capture.current = {
+      ...history,
+      accepted,
+      cursor,
+      input,
+      isSearching,
+      mode,
+      pastedContents,
+    }
+    return null
+  }
+
+  await act(async () => {
+    root.render(React.createElement(Harness))
+    await Promise.resolve()
+  })
+
+  return {
+    capture,
+    dispose: async () => {
+      await act(async () => {
+        root.unmount()
+        await Promise.resolve()
+      })
+      stdin.end()
+      stdout.end()
+      await sleep()
+    },
+  }
+}
+
+async function startSearch(capture: { current: CapturedHistory | null }) {
+  await act(async () => {
+    latestStartSearchHandler()?.()
+    await Promise.resolve()
+  })
+  await waitFor(() => expect(capture.current?.isSearching).toBe(true))
+}
+
+beforeEach(() => {
+  fixture.entries = []
+  fixture.featureFlags.clear()
+  fixture.inputSubscriptions = []
+  fixture.keybindingCalls = []
+  fixture.keybindingsCalls = []
+  fixture.readers = []
+})
+
+describe('useHistorySearch coverage swarm 192', () => {
+  test('uses the display match offset when the stripped command lacks the query', async () => {
+    fixture.entries = [
+      {
+        display: '!npm run build',
+        pastedContents: { 1: { content: 'build log', type: 'text' } },
+      },
+    ]
+    const rendered = await renderHookHarness()
+
+    try {
+      await startSearch(rendered.capture)
+
+      await act(async () => {
+        rendered.capture.current?.setHistoryQuery('!')
+        await Promise.resolve()
+      })
+
+      await waitFor(() =>
+        expect(rendered.capture.current?.input).toBe('!npm run build'),
+      )
+      expect(rendered.capture.current?.cursor).toBe(0)
+      expect(rendered.capture.current?.mode).toBe('bash')
+      expect(rendered.capture.current?.pastedContents).toEqual({
+        1: { content: 'build log', type: 'text' },
+      })
+      expect(rendered.capture.current?.historyFailedMatch).toBe(false)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('executes a non-empty query without accepting when no history match exists', async () => {
+    fixture.entries = [{ display: 'unrelated entry', pastedContents: {} }]
+    const rendered = await renderHookHarness({
+      currentInput: 'original input',
+      currentPastedContents: { 2: { content: 'original', type: 'text' } },
+    })
+
+    try {
+      await startSearch(rendered.capture)
+
+      await act(async () => {
+        rendered.capture.current?.setHistoryQuery('missing')
+        await Promise.resolve()
+      })
+
+      await waitFor(() =>
+        expect(rendered.capture.current?.historyFailedMatch).toBe(true),
+      )
+
+      await act(async () => {
+        latestHistoryHandlers()['historySearch:execute']?.()
+        await Promise.resolve()
+      })
+
+      await waitFor(() =>
+        expect(rendered.capture.current?.isSearching).toBe(false),
+      )
+      expect(rendered.capture.current?.accepted).toEqual([])
+      expect(rendered.capture.current?.input).toBe('original input')
+      expect(rendered.capture.current?.historyQuery).toBe('')
+      expect(rendered.capture.current?.pastedContents).toEqual({
+        2: { content: 'original', type: 'text' },
+      })
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('ignores non-cancel keydowns and cancels through the active input bridge', async () => {
+    const rendered = await renderHookHarness({
+      currentCursorOffset: 3,
+      currentInput: 'keep',
+    })
+
+    try {
+      await startSearch(rendered.capture)
+
+      await act(async () => {
+        rendered.capture.current?.setHistoryQuery('no-match')
+        await Promise.resolve()
+      })
+      await waitFor(() =>
+        expect(rendered.capture.current?.historyFailedMatch).toBe(true),
+      )
+
+      const backspaceWithQuery = {
+        key: 'backspace',
+        preventDefault: vi.fn(),
+      }
+      rendered.capture.current?.handleKeyDown(backspaceWithQuery as never)
+      expect(backspaceWithQuery.preventDefault).not.toHaveBeenCalled()
+      expect(rendered.capture.current?.isSearching).toBe(true)
+
+      const returnKey = { key: 'return', preventDefault: vi.fn() }
+      rendered.capture.current?.handleKeyDown(returnKey as never)
+      expect(returnKey.preventDefault).not.toHaveBeenCalled()
+      expect(rendered.capture.current?.isSearching).toBe(true)
+
+      await act(async () => {
+        rendered.capture.current?.setHistoryQuery('')
+        await Promise.resolve()
+      })
+      await waitFor(() =>
+        expect(rendered.capture.current?.historyQuery).toBe(''),
+      )
+
+      const activeInput = latestInputSubscription()
+      expect(activeInput?.options).toMatchObject({ isActive: true })
+
+      await act(async () => {
+        activeInput?.handler('', {}, { keypress: parsedKey('backspace', '\x7f') })
+        await Promise.resolve()
+      })
+
+      await waitFor(() =>
+        expect(rendered.capture.current?.isSearching).toBe(false),
+      )
+      expect(rendered.capture.current?.input).toBe('keep')
+      expect(rendered.capture.current?.cursor).toBe(3)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('treats a stale next-match handler as a no-op after cancel closes the reader', async () => {
+    fixture.entries = [
+      { display: 'first match', pastedContents: {} },
+      { display: 'second match', pastedContents: {} },
+    ]
+    const rendered = await renderHookHarness({ currentInput: 'restore me' })
+
+    try {
+      await startSearch(rendered.capture)
+
+      await act(async () => {
+        rendered.capture.current?.setHistoryQuery('match')
+        await Promise.resolve()
+      })
+      await waitFor(() =>
+        expect(rendered.capture.current?.input).toBe('first match'),
+      )
+
+      const staleNextMatch = latestHistoryHandlers()['historySearch:next']
+      const activeReader = fixture.readers.at(-1)
+      const nextCallsBeforeCancel = activeReader?.next.mock.calls.length
+
+      await act(async () => {
+        latestHistoryHandlers()['historySearch:cancel']?.()
+        await Promise.resolve()
+      })
+      await waitFor(() =>
+        expect(rendered.capture.current?.isSearching).toBe(false),
+      )
+
+      await act(async () => {
+        staleNextMatch?.()
+        await Promise.resolve()
+      })
+
+      await sleep()
+      expect(rendered.capture.current?.input).toBe('restore me')
+      expect(activeReader?.return).toHaveBeenCalledTimes(1)
+      expect(activeReader?.next).toHaveBeenCalledTimes(
+        nextCallsBeforeCancel ?? 0,
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-193-ink-squash-text-nodes.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-193-ink-squash-text-nodes.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  createNode,
+  createTextNode,
+  type DOMElement,
+  type DOMNode,
+} from '../../../src/tui/ink/dom.js'
+import squashTextNodes, {
+  squashTextNodesToSegments,
+} from '../../../src/tui/ink/squash-text-nodes.js'
+import type { TextStyles } from '../../../src/tui/ink/styles.js'
+
+function append(
+  parent: DOMElement,
+  ...children: Array<DOMNode | undefined>
+): DOMElement {
+  for (const child of children) {
+    if (child !== undefined) {
+      child.parentNode = parent
+    }
+    parent.childNodes.push(child as DOMNode)
+  }
+
+  return parent
+}
+
+function element(
+  nodeName: DOMElement['nodeName'],
+  children: Array<DOMNode | undefined> = [],
+  textStyles?: TextStyles,
+): DOMElement {
+  const node = createNode(nodeName)
+  node.textStyles = textStyles
+  append(node, ...children)
+
+  return node
+}
+
+function text(value: string): DOMNode {
+  return createTextNode(value)
+}
+
+describe('squash-text-nodes coverage swarm row 193', () => {
+  test('squashes plain text through supported text containers only', () => {
+    const ignoredBox = element('ink-box', [text('hidden')])
+    const root = element('ink-root', [
+      undefined,
+      text('alpha'),
+      text(''),
+      element('ink-text', [
+        text('-'),
+        element('ink-virtual-text', [text('beta')]),
+      ]),
+      element('ink-link', [text('-gamma')]),
+      ignoredBox,
+    ])
+
+    expect(squashTextNodes(root)).toBe('alpha-beta-gamma')
+  })
+
+  test('emits styled segments while preserving caller output array', () => {
+    const inheritedStyles = { dim: true, underline: true } satisfies TextStyles
+    const root = element(
+      'ink-root',
+      [
+        text('base'),
+        text(''),
+        element('ink-text', [text('-bold')], { bold: true, dim: false }),
+        element('ink-virtual-text', [text('-virtual')], {
+          backgroundColor: '#101010',
+        }),
+      ],
+      { color: 'ansi:green' },
+    )
+    const out = [
+      { text: 'seed', styles: { italic: true } satisfies TextStyles },
+    ]
+
+    expect(squashTextNodesToSegments(root, inheritedStyles, undefined, out)).toBe(
+      out,
+    )
+    expect(out).toEqual([
+      {
+        styles: { italic: true },
+        text: 'seed',
+      },
+      {
+        hyperlink: undefined,
+        styles: { color: 'ansi:green', dim: true, underline: true },
+        text: 'base',
+      },
+      {
+        hyperlink: undefined,
+        styles: {
+          bold: true,
+          color: 'ansi:green',
+          dim: false,
+          underline: true,
+        },
+        text: '-bold',
+      },
+      {
+        hyperlink: undefined,
+        styles: {
+          backgroundColor: '#101010',
+          color: 'ansi:green',
+          dim: true,
+          underline: true,
+        },
+        text: '-virtual',
+      },
+    ])
+  })
+
+  test('uses link hrefs and falls back to inherited hyperlinks for empty hrefs', () => {
+    const explicit = element('ink-link', [text('explicit')])
+    explicit.attributes.href = 'https://agenc.test/explicit'
+
+    const inherited = element('ink-link', [text('-inherited')])
+    inherited.attributes.href = ''
+
+    const nested = element('ink-text', [explicit, inherited])
+    const root = element('ink-root', [nested])
+
+    expect(
+      squashTextNodesToSegments(root, {}, 'https://agenc.test/fallback'),
+    ).toEqual([
+      {
+        hyperlink: 'https://agenc.test/explicit',
+        styles: {},
+        text: 'explicit',
+      },
+      {
+        hyperlink: 'https://agenc.test/fallback',
+        styles: {},
+        text: '-inherited',
+      },
+    ])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-194-ink-supports-hyperlinks.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-194-ink-supports-hyperlinks.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  ADDITIONAL_HYPERLINK_TERMINALS,
+  supportsHyperlinks,
+} from '../../../src/tui/ink/supports-hyperlinks.js'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('supportsHyperlinks coverage swarm row 194', () => {
+  test('treats disabling env values as hard opt-outs before stdout support', () => {
+    expect(
+      supportsHyperlinks({
+        env: {
+          NO_COLOR: '1',
+          TERM: 'dumb',
+        },
+        stdoutSupported: true,
+      }),
+    ).toBe(false)
+    expect(
+      supportsHyperlinks({
+        env: {
+          FORCE_HYPERLINK: '0',
+        },
+        stdoutSupported: true,
+      }),
+    ).toBe(false)
+  })
+
+  test('uses FORCE_HYPERLINK and disabling env values in default stdout detection', () => {
+    expect(supportsHyperlinks({ env: { FORCE_HYPERLINK: '1' } })).toBe(true)
+    expect(supportsHyperlinks({ env: { FORCE_HYPERLINK: '0' } })).toBe(false)
+    expect(supportsHyperlinks({ env: { NO_COLOR: '1' } })).toBe(false)
+  })
+
+  test('detects extra terminal allowlist entries from TERM_PROGRAM and LC_TERMINAL', () => {
+    expect(ADDITIONAL_HYPERLINK_TERMINALS).toContain('ghostty')
+
+    expect(
+      supportsHyperlinks({
+        env: {
+          TERM_PROGRAM: 'ghostty',
+        },
+      }),
+    ).toBe(true)
+
+    expect(
+      supportsHyperlinks({
+        env: {
+          LC_TERMINAL: 'iTerm2',
+          TERM_PROGRAM: 'tmux',
+        },
+      }),
+    ).toBe(true)
+  })
+
+  test('detects kitty from TERM and rejects unrelated terminal env', () => {
+    expect(
+      supportsHyperlinks({
+        env: {
+          TERM: 'xterm-kitty',
+        },
+      }),
+    ).toBe(true)
+
+    expect(
+      supportsHyperlinks({
+        env: {
+          LC_TERMINAL: 'screen',
+          TERM: 'xterm-256color',
+          TERM_PROGRAM: 'tmux',
+        },
+      }),
+    ).toBe(false)
+  })
+
+  test('falls back to process env when no options are supplied', () => {
+    vi.stubEnv('NO_COLOR', '')
+    vi.stubEnv('FORCE_HYPERLINK', '1')
+
+    expect(supportsHyperlinks()).toBe(true)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-195-ink-hooks-use-terminal-viewport.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-195-ink-hooks-use-terminal-viewport.test.ts
@@ -1,0 +1,262 @@
+import { PassThrough } from 'node:stream'
+
+import React, { act } from 'react'
+import { describe, expect, test } from 'vitest'
+
+import {
+  TerminalSizeContext,
+  type TerminalSize,
+} from '../../../src/tui/ink/components/TerminalSizeContext.js'
+import type { DOMElement } from '../../../src/tui/ink/dom.js'
+import { useTerminalViewport } from '../../../src/tui/ink/hooks/use-terminal-viewport.js'
+import { createRoot, type Root } from '../../../src/tui/ink/root.js'
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough & {
+    columns: number
+    isTTY: boolean
+    rows: number
+  }
+}
+
+type LayoutNodeStub = {
+  readonly getComputedHeight: () => number
+  readonly getComputedTop: () => number
+}
+
+type ElementOptions = {
+  readonly height: number
+  readonly parentNode?: DOMElement
+  readonly scrollTop?: number
+  readonly top: number
+  readonly withYoga?: boolean
+}
+
+type HookSnapshot = {
+  readonly entry: { readonly isVisible: boolean }
+  readonly ref: (element: DOMElement | null) => void
+}
+
+function createStreams(): TestStreams {
+  const stdin = new PassThrough() as TestStreams['stdin']
+  const stdout = new PassThrough() as TestStreams['stdout']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 80
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function createElement({
+  height,
+  parentNode,
+  scrollTop,
+  top,
+  withYoga = true,
+}: ElementOptions): DOMElement {
+  const yogaNode: LayoutNodeStub | undefined = withYoga
+    ? {
+        getComputedHeight: () => height,
+        getComputedTop: () => top,
+      }
+    : undefined
+
+  return {
+    attributes: {},
+    childNodes: [],
+    dirty: false,
+    nodeName: 'ink-box',
+    parentNode,
+    scrollTop,
+    style: {},
+    yogaNode,
+  } as unknown as DOMElement
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+async function renderHookHarness(): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly latest: () => HookSnapshot
+  readonly render: (props: {
+    readonly element: DOMElement | null
+    readonly terminalSize: TerminalSize | null
+  }) => Promise<void>
+  readonly renderSettled: (props: {
+    readonly element: DOMElement | null
+    readonly terminalSize: TerminalSize | null
+  }) => Promise<HookSnapshot>
+}> {
+  let latest: HookSnapshot | undefined
+  const { stdin, stdout } = createStreams()
+  const root: Root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function ViewportProbe({
+    element,
+  }: {
+    readonly element: DOMElement | null
+  }): null {
+    const [ref, entry] = useTerminalViewport()
+    ref(element)
+    latest = { entry, ref }
+    return null
+  }
+
+  async function render(props: {
+    readonly element: DOMElement | null
+    readonly terminalSize: TerminalSize | null
+  }): Promise<void> {
+    await act(async () => {
+      root.render(
+        React.createElement(
+          TerminalSizeContext.Provider,
+          { value: props.terminalSize },
+          React.createElement(ViewportProbe, { element: props.element }),
+        ),
+      )
+    })
+    await flushEffects()
+  }
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushEffects()
+    },
+    latest: () => {
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+    render,
+    renderSettled: async props => {
+      await render(props)
+      await render(props)
+      if (latest === undefined) throw new Error('hook did not render')
+      return latest
+    },
+  }
+}
+
+describe('useTerminalViewport coverage swarm row 195', () => {
+  test('keeps the default visible entry when layout data is unavailable', async () => {
+    const rendered = await renderHookHarness()
+    const missingYoga = createElement({
+      height: 1,
+      top: 100,
+      withYoga: false,
+    })
+
+    try {
+      expect(
+        (
+          await rendered.renderSettled({
+            element: null,
+            terminalSize: { columns: 80, rows: 5 },
+          })
+        ).entry.isVisible,
+      ).toBe(true)
+
+      expect(
+        (
+          await rendered.renderSettled({
+            element: missingYoga,
+            terminalSize: { columns: 80, rows: 5 },
+          })
+        ).entry.isVisible,
+      ).toBe(true)
+
+      expect(
+        (
+          await rendered.renderSettled({
+            element: createElement({ height: 1, top: 100 }),
+            terminalSize: null,
+          })
+        ).entry.isVisible,
+      ).toBe(true)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('matches the cursor-restore viewport boundary when content overflows rows', async () => {
+    const rendered = await renderHookHarness()
+    const root = createElement({ height: 30, top: 0 })
+    const boundaryElement = createElement({
+      height: 1,
+      parentNode: root,
+      top: 20,
+    })
+
+    try {
+      expect(
+        (
+          await rendered.renderSettled({
+            element: boundaryElement,
+            terminalSize: { columns: 80, rows: 10 },
+          })
+        ).entry.isVisible,
+      ).toBe(false)
+
+      expect(
+        (
+          await rendered.renderSettled({
+            element: boundaryElement,
+            terminalSize: { columns: 80, rows: 11 },
+          })
+        ).entry.isVisible,
+      ).toBe(true)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('subtracts ancestor scroll offsets when deciding visibility', async () => {
+    const rendered = await renderHookHarness()
+    const scrollContainer = createElement({
+      height: 30,
+      scrollTop: 10,
+      top: 0,
+    })
+    const scrolledIntoView = createElement({
+      height: 1,
+      parentNode: scrollContainer,
+      top: 35,
+    })
+
+    try {
+      expect(
+        (
+          await rendered.renderSettled({
+            element: scrolledIntoView,
+            terminalSize: { columns: 80, rows: 10 },
+          })
+        ).entry.isVisible,
+      ).toBe(true)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-196-keybindings-defaultBindings.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-196-keybindings-defaultBindings.test.ts
@@ -1,0 +1,208 @@
+import { afterAll, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { KeybindingBlock } from '../../../src/tui/keybindings/types.js'
+
+const harness = vi.hoisted(() => ({
+  features: new Set<string>(),
+  platform: 'linux',
+  runningWithBun: false,
+  satisfiesCalls: [] as Array<{ range: string; version: string }>,
+  satisfiesResult: false,
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => harness.features.has(name),
+}))
+
+vi.mock('../../../src/utils/platform.js', () => ({
+  getPlatform: () => harness.platform,
+}))
+
+vi.mock('../../../src/utils/bundledMode.js', () => ({
+  isRunningWithBun: () => harness.runningWithBun,
+}))
+
+vi.mock('../../../src/utils/semver.js', () => ({
+  satisfies: (version: string, range: string) => {
+    harness.satisfiesCalls.push({ range, version })
+    return harness.satisfiesResult
+  },
+}))
+
+const originalBunDescriptor = Object.getOwnPropertyDescriptor(
+  process.versions,
+  'bun',
+)
+
+function setBunVersion(version: string | undefined): void {
+  Object.defineProperty(process.versions, 'bun', {
+    configurable: true,
+    value: version,
+  })
+}
+
+function restoreBunVersion(): void {
+  if (originalBunDescriptor) {
+    Object.defineProperty(process.versions, 'bun', originalBunDescriptor)
+    return
+  }
+
+  delete (process.versions as Record<string, string | undefined>).bun
+}
+
+async function loadDefaultBindings(): Promise<KeybindingBlock[]> {
+  vi.resetModules()
+  const module = await import(
+    '../../../src/tui/keybindings/defaultBindings.js'
+  )
+  return module.DEFAULT_BINDINGS
+}
+
+function bindingsFor(
+  blocks: KeybindingBlock[],
+  context: KeybindingBlock['context'],
+): Record<string, string | null> {
+  const block = blocks.find(entry => entry.context === context)
+  if (!block) throw new Error(`Missing ${context} default bindings`)
+  return block.bindings
+}
+
+function hasContext(
+  blocks: KeybindingBlock[],
+  context: KeybindingBlock['context'],
+): boolean {
+  return blocks.some(entry => entry.context === context)
+}
+
+describe('default keybindings coverage swarm row 196', () => {
+  beforeEach(() => {
+    harness.features = new Set()
+    harness.platform = 'linux'
+    harness.runningWithBun = false
+    harness.satisfiesCalls = []
+    harness.satisfiesResult = false
+    setBunVersion(undefined)
+  })
+
+  afterAll(() => {
+    restoreBunVersion()
+  })
+
+  test('uses portable defaults without feature-gated bindings off Windows', async () => {
+    const blocks = await loadDefaultBindings()
+    const global = bindingsFor(blocks, 'Global')
+    const chat = bindingsFor(blocks, 'Chat')
+
+    expect(chat).toMatchObject({
+      'ctrl+v': 'chat:imagePaste',
+      'shift+tab': 'chat:cycleMode',
+    })
+    expect(chat).not.toHaveProperty('alt+v')
+    expect(chat).not.toHaveProperty('meta+m')
+    expect(chat).not.toHaveProperty('shift+up')
+    expect(global).not.toHaveProperty('ctrl+shift+b')
+    expect(global).not.toHaveProperty('ctrl+shift+f')
+    expect(global).not.toHaveProperty('meta+j')
+    expect(hasContext(blocks, 'MessageActions')).toBe(false)
+    expect(harness.satisfiesCalls).toEqual([])
+  })
+
+  test('uses Windows fallbacks when Node terminal VT mode is unavailable', async () => {
+    harness.platform = 'windows'
+    harness.satisfiesResult = false
+
+    const blocks = await loadDefaultBindings()
+    const chat = bindingsFor(blocks, 'Chat')
+
+    expect(chat).toMatchObject({
+      'alt+v': 'chat:imagePaste',
+      'meta+m': 'chat:cycleMode',
+    })
+    expect(chat).not.toHaveProperty('ctrl+v')
+    expect(chat).not.toHaveProperty('shift+tab')
+    expect(harness.satisfiesCalls).toEqual([
+      {
+        range: '>=22.17.0 <23.0.0 || >=24.2.0',
+        version: process.versions.node,
+      },
+    ])
+  })
+
+  test('keeps shift tab on Windows when Node terminal VT mode is available', async () => {
+    harness.platform = 'windows'
+    harness.satisfiesResult = true
+
+    const blocks = await loadDefaultBindings()
+    const chat = bindingsFor(blocks, 'Chat')
+
+    expect(chat).toMatchObject({
+      'alt+v': 'chat:imagePaste',
+      'shift+tab': 'chat:cycleMode',
+    })
+    expect(chat).not.toHaveProperty('meta+m')
+  })
+
+  test('checks Bun terminal VT support using fallback and explicit versions', async () => {
+    harness.platform = 'windows'
+    harness.runningWithBun = true
+    harness.satisfiesResult = false
+
+    const fallbackBlocks = await loadDefaultBindings()
+    expect(bindingsFor(fallbackBlocks, 'Chat')).toMatchObject({
+      'meta+m': 'chat:cycleMode',
+    })
+    expect(harness.satisfiesCalls).toEqual([
+      { range: '>=1.2.23', version: '0.0.0' },
+    ])
+
+    harness.satisfiesCalls = []
+    harness.satisfiesResult = true
+    setBunVersion('1.2.23')
+
+    const supportedBlocks = await loadDefaultBindings()
+    expect(bindingsFor(supportedBlocks, 'Chat')).toMatchObject({
+      'shift+tab': 'chat:cycleMode',
+    })
+    expect(harness.satisfiesCalls).toEqual([
+      { range: '>=1.2.23', version: '1.2.23' },
+    ])
+  })
+
+  test('adds global, chat, and modal bindings when feature flags are enabled', async () => {
+    harness.features = new Set([
+      'KAIROS',
+      'QUICK_SEARCH',
+      'TERMINAL_PANEL',
+      'MESSAGE_ACTIONS',
+    ])
+
+    const allFlagBlocks = await loadDefaultBindings()
+    expect(bindingsFor(allFlagBlocks, 'Global')).toMatchObject({
+      'ctrl+shift+b': 'app:toggleBrief',
+      'ctrl+shift+f': 'app:globalSearch',
+      'cmd+shift+f': 'app:globalSearch',
+      'ctrl+shift+p': 'app:quickOpen',
+      'cmd+shift+p': 'app:quickOpen',
+      'meta+j': 'app:toggleTerminal',
+    })
+    expect(bindingsFor(allFlagBlocks, 'Chat')).toMatchObject({
+      'shift+up': 'chat:messageActions',
+    })
+    expect(bindingsFor(allFlagBlocks, 'MessageActions')).toMatchObject({
+      up: 'messageActions:prev',
+      down: 'messageActions:next',
+      'meta+up': 'messageActions:top',
+      'super+down': 'messageActions:bottom',
+      enter: 'messageActions:enter',
+      c: 'messageActions:c',
+      p: 'messageActions:p',
+    })
+
+    harness.features = new Set(['KAIROS_BRIEF'])
+    const briefFlagBlocks = await loadDefaultBindings()
+    expect(bindingsFor(briefFlagBlocks, 'Global')).toMatchObject({
+      'ctrl+shift+b': 'app:toggleBrief',
+    })
+    expect(hasContext(briefFlagBlocks, 'MessageActions')).toBe(false)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-197-startup-StatusNotices.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-197-startup-StatusNotices.test.tsx
@@ -1,0 +1,180 @@
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../../src/utils/staticRender.js'
+
+type CapturedContext = {
+  readonly agentDefinitions?: unknown
+  readonly config: unknown
+  readonly daemonStatus: {
+    readonly autostartDisabled: boolean
+  }
+  readonly memoryDiagnostics: readonly string[]
+}
+
+type Notice = {
+  readonly id: string
+  readonly render: (context: CapturedContext) => React.ReactNode
+  readonly type: 'info' | 'warning'
+}
+
+const harness = vi.hoisted(() => ({
+  buildMemoryDiagnostics: vi.fn<() => Promise<unknown[]>>(async () => []),
+  contexts: [] as CapturedContext[],
+  getActiveNotices: vi.fn((context: CapturedContext): Notice[] => {
+    harness.contexts.push(context)
+    return [
+      {
+        id: 'probe',
+        render: renderedContext =>
+          React.createElement(
+            'ink-text',
+            null,
+            [
+              `disabled:${renderedContext.daemonStatus.autostartDisabled}`,
+              `memory:${renderedContext.memoryDiagnostics.join('|')}`,
+            ].join(' '),
+          ),
+        type: 'info',
+      },
+    ]
+  }),
+  globalConfig: {
+    autoInstallIdeExtension: true,
+    source: 'swarm-197',
+  },
+}))
+
+vi.mock('../../../src/utils/config.js', () => ({
+  getGlobalConfig: () => harness.globalConfig,
+}))
+
+vi.mock('../../../src/utils/status.js', () => ({
+  buildMemoryDiagnostics: harness.buildMemoryDiagnostics,
+}))
+
+vi.mock('../../../src/tui/startup/statusNoticeDefinitions.js', () => ({
+  getActiveNotices: harness.getActiveNotices,
+}))
+
+const previousDaemonAutostart = process.env.AGENC_DAEMON_AUTOSTART
+
+function restoreDaemonAutostart(): void {
+  if (previousDaemonAutostart === undefined) {
+    delete process.env.AGENC_DAEMON_AUTOSTART
+  } else {
+    process.env.AGENC_DAEMON_AUTOSTART = previousDaemonAutostart
+  }
+}
+
+async function renderStatusNotices(
+  props: Record<string, unknown> = {},
+): Promise<string> {
+  const { StatusNotices } = await import(
+    '../../../src/tui/startup/StatusNotices.js'
+  )
+
+  return renderToString(
+    React.createElement(StatusNotices, props),
+    { columns: 120 },
+  )
+}
+
+describe('StatusNotices coverage swarm row 197', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    harness.buildMemoryDiagnostics.mockReset()
+    harness.buildMemoryDiagnostics.mockResolvedValue([])
+    harness.contexts = []
+    harness.getActiveNotices.mockClear()
+    harness.getActiveNotices.mockImplementation((context: CapturedContext) => {
+      harness.contexts.push(context)
+      return [
+        {
+          id: 'probe',
+          render: renderedContext =>
+            React.createElement(
+              'ink-text',
+              null,
+              [
+                `disabled:${renderedContext.daemonStatus.autostartDisabled}`,
+                `memory:${renderedContext.memoryDiagnostics.join('|')}`,
+              ].join(' '),
+            ),
+          type: 'info',
+        },
+      ]
+    })
+    restoreDaemonAutostart()
+  })
+
+  afterEach(() => {
+    restoreDaemonAutostart()
+  })
+
+  test.each([
+    ['0'],
+    [' false '],
+    ['OFF'],
+  ])('marks daemon autostart disabled for %s', async value => {
+    process.env.AGENC_DAEMON_AUTOSTART = value
+
+    const output = await renderStatusNotices()
+
+    expect(output).toContain('disabled:true')
+    expect(harness.contexts.at(-1)?.daemonStatus.autostartDisabled).toBe(true)
+  })
+
+  test('returns no rendered output when no notices are active', async () => {
+    harness.getActiveNotices.mockImplementation((context: CapturedContext) => {
+      harness.contexts.push(context)
+      return []
+    })
+
+    const output = await renderStatusNotices({
+      agentDefinitions: { agents: ['reviewer'] },
+    })
+
+    expect(output.trim()).toBe('')
+    expect(harness.contexts.at(-1)).toMatchObject({
+      agentDefinitions: { agents: ['reviewer'] },
+      config: harness.globalConfig,
+      daemonStatus: { autostartDisabled: false },
+      memoryDiagnostics: [],
+    })
+  })
+
+  test('shares a pending memory diagnostics request and reuses the cached result', async () => {
+    let resolveDiagnostics: (value: unknown[]) => void = () => {}
+    harness.buildMemoryDiagnostics.mockImplementation(
+      () =>
+        new Promise(resolve => {
+          resolveDiagnostics = resolve
+        }),
+    )
+
+    const { StatusNotices } = await import(
+      '../../../src/tui/startup/StatusNotices.js'
+    )
+
+    await renderToString(
+      <>
+        <StatusNotices />
+        <StatusNotices />
+      </>,
+      { columns: 120 },
+    )
+
+    await vi.waitFor(() => {
+      expect(harness.buildMemoryDiagnostics).toHaveBeenCalledTimes(1)
+    })
+
+    resolveDiagnostics([404, 'Large memory file'])
+    await Promise.resolve()
+
+    const cachedOutput = await renderStatusNotices()
+
+    expect(harness.buildMemoryDiagnostics).toHaveBeenCalledTimes(1)
+    expect(cachedOutput).toContain('memory:404|Large memory file')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-198-vim-text-objects.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-198-vim-text-objects.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'vitest'
+
+import { findTextObject } from 'src/tui/vim/text-objects.js'
+
+function sliceAt(
+  text: string,
+  offset: number,
+  objectType: string,
+  isInner: boolean,
+): string | null {
+  const range = findTextObject(text, offset, objectType, isInner)
+  return range ? text.slice(range.start, range.end) : null
+}
+
+describe('vim text objects coverage swarm row 198', () => {
+  test('covers word object classification and around-whitespace branches', () => {
+    expect(sliceAt('alpha   beta', 'alpha   beta'.indexOf(' '), 'w', false))
+      .toBe('   ')
+    expect(sliceAt('alpha,; beta', 'alpha,; beta'.indexOf(','), 'w', false))
+      .toBe(',; ')
+    expect(findTextObject('alpha', 1, 'w', false)).toEqual({
+      start: 0,
+      end: 5,
+    })
+  })
+
+  test('returns null when quote pairs exist but the cursor is outside them', () => {
+    const text = '"one" middle "two"'
+
+    expect(findTextObject(text, text.indexOf('middle'), '"', true)).toBeNull()
+  })
+
+  test('extends around paragraphs across trailing and leading blank lines', () => {
+    expect(sliceAt('first\n\n', 1, 'p', false)).toBe('first\n\n')
+    expect(
+      sliceAt(
+        'first\n \t\nsecond',
+        'first\n \t\nsecond'.indexOf('second'),
+        'p',
+        false,
+      ),
+    ).toBe('\nsecond')
+  })
+
+  test('clamps tag offsets and selects the smallest containing tag', () => {
+    const singleTag = '<x>ok</x>'
+    expect(sliceAt(singleTag, Number.POSITIVE_INFINITY, 't', true)).toBe('ok')
+    expect(sliceAt(singleTag, Number.NEGATIVE_INFINITY, 't', false)).toBe(
+      singleTag,
+    )
+
+    const nested = '<outer><inner>value</inner></outer>'
+    expect(sliceAt(nested, nested.indexOf('value'), 't', false)).toBe(
+      '<inner>value</inner>',
+    )
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-199-components-messagesBriefFiltering.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-199-components-messagesBriefFiltering.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  dropTextInBriefTurns,
+  filterForBriefTool,
+} from '../../../src/tui/components/messagesBriefFiltering.js'
+
+const BRIEF_TOOL = 'SendUserMessage'
+const OTHER_TOOL = 'SendUserFile'
+
+type TestContent = {
+  id?: string
+  name?: string
+  text?: string
+  tool_use_id?: string
+  type: string
+}
+
+type TestMessage = {
+  attachment?: {
+    commandMode?: string
+    isMeta?: boolean
+    origin?: unknown
+    type: string
+  }
+  id: string
+  isApiErrorMessage?: boolean
+  isMeta?: boolean
+  message?: {
+    content: TestContent[]
+  }
+  subtype?: string
+  type: string
+}
+
+function assistantText(id: string): TestMessage {
+  return {
+    id,
+    message: { content: [{ text: id, type: 'text' }] },
+    type: 'assistant',
+  }
+}
+
+function assistantToolUse(
+  id: string,
+  name: string,
+  includeToolUseID = true,
+): TestMessage {
+  const block: TestContent = { name, type: 'tool_use' }
+  if (includeToolUseID) block.id = id
+  return {
+    id,
+    message: { content: [block] },
+    type: 'assistant',
+  }
+}
+
+function userPrompt(id: string): TestMessage {
+  return {
+    id,
+    isMeta: false,
+    message: { content: [{ text: id, type: 'text' }] },
+    type: 'user',
+  }
+}
+
+function toolResult(id: string, toolUseID: string): TestMessage {
+  return {
+    id,
+    message: { content: [{ tool_use_id: toolUseID, type: 'tool_result' }] },
+    type: 'user',
+  }
+}
+
+function ids(messages: TestMessage[]): string[] {
+  return messages.map(message => message.id)
+}
+
+describe('messages brief filtering coverage swarm row 199', () => {
+  test('keeps api errors and allowed brief calls while requiring known tool ids for results', () => {
+    const messages: TestMessage[] = [
+      toolResult('result-before-tool-use', 'brief-tool-use'),
+      {
+        id: 'api-error',
+        isApiErrorMessage: true,
+        message: { content: [{ text: 'rate limited', type: 'text' }] },
+        type: 'assistant',
+      },
+      assistantToolUse('brief-no-id', BRIEF_TOOL, false),
+      toolResult('result-for-missing-id', 'brief-no-id'),
+      assistantToolUse('other-tool-use', OTHER_TOOL),
+      assistantToolUse('brief-tool-use', BRIEF_TOOL),
+      toolResult('matching-result', 'brief-tool-use'),
+      {
+        id: 'user-with-empty-content',
+        isMeta: false,
+        message: { content: [] },
+        type: 'user',
+      },
+      { id: 'unknown-message', type: 'unknown' },
+    ]
+
+    expect(ids(filterForBriefTool(messages, [BRIEF_TOOL]))).toEqual([
+      'api-error',
+      'brief-no-id',
+      'brief-tool-use',
+      'matching-result',
+      'user-with-empty-content',
+    ])
+  })
+
+  test('only keeps plain queued prompt attachments in brief mode', () => {
+    const messages: TestMessage[] = [
+      {
+        attachment: { commandMode: 'prompt', type: 'queued_command' },
+        id: 'queued-prompt',
+        type: 'attachment',
+      },
+      {
+        attachment: {
+          commandMode: 'prompt',
+          isMeta: true,
+          type: 'queued_command',
+        },
+        id: 'meta-queued-prompt',
+        type: 'attachment',
+      },
+      {
+        attachment: {
+          commandMode: 'prompt',
+          origin: 'hook',
+          type: 'queued_command',
+        },
+        id: 'origin-queued-prompt',
+        type: 'attachment',
+      },
+      {
+        attachment: { commandMode: 'prompt', type: 'file' },
+        id: 'file-attachment',
+        type: 'attachment',
+      },
+      {
+        attachment: { commandMode: 'task-notification', type: 'queued_command' },
+        id: 'task-queued-command',
+        type: 'attachment',
+      },
+    ]
+
+    expect(ids(filterForBriefTool(messages, [BRIEF_TOOL]))).toEqual([
+      'queued-prompt',
+    ])
+  })
+
+  test('returns the original transcript when no brief tool is used', () => {
+    const messages = [
+      userPrompt('user'),
+      assistantText('assistant-text'),
+      assistantToolUse('other-tool-use', OTHER_TOOL),
+      toolResult('other-tool-result', 'other-tool-use'),
+    ]
+
+    const filtered = dropTextInBriefTurns(messages, [BRIEF_TOOL])
+
+    expect(filtered).toBe(messages)
+    expect(ids(filtered)).toEqual([
+      'user',
+      'assistant-text',
+      'other-tool-use',
+      'other-tool-result',
+    ])
+  })
+
+  test('does not advance turns for meta users or tool results when dropping brief text', () => {
+    const messages: TestMessage[] = [
+      assistantText('preface-text'),
+      assistantToolUse('preface-brief', BRIEF_TOOL),
+      userPrompt('real-user'),
+      {
+        id: 'meta-user',
+        isMeta: true,
+        message: { content: [{ text: 'internal', type: 'text' }] },
+        type: 'user',
+      },
+      toolResult('tool-result-user', 'preface-brief'),
+      assistantText('same-turn-text'),
+      assistantToolUse('same-turn-brief', BRIEF_TOOL),
+      userPrompt('next-user'),
+      assistantText('next-turn-text'),
+    ]
+
+    expect(ids(dropTextInBriefTurns(messages, [BRIEF_TOOL]))).toEqual([
+      'preface-brief',
+      'real-user',
+      'meta-user',
+      'tool-result-user',
+      'same-turn-brief',
+      'next-user',
+      'next-turn-text',
+    ])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-200-components-CustomSelect-select-option.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-200-components-CustomSelect-select-option.test.tsx
@@ -1,0 +1,237 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createRoot, type Root } from "../../../src/tui/ink/root.js";
+import { SelectOption } from "../../../src/tui/components/CustomSelect/select-option.js";
+
+const listItemMock = vi.hoisted(() => ({
+  calls: [] as Array<{
+    children?: React.ReactNode;
+    declareCursor?: boolean;
+    description?: string;
+    isFocused: boolean;
+    isSelected?: boolean;
+    showScrollDown?: boolean;
+    showScrollUp?: boolean;
+    styled?: boolean;
+  }>,
+}));
+
+vi.mock("../../../src/tui/components/design-system/ListItem.js", async () => {
+  const ReactActual = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    ListItem: (props: (typeof listItemMock.calls)[number]) => {
+      listItemMock.calls.push(props);
+
+      return ReactActual.createElement("ink-text", null, props.children);
+    },
+  };
+});
+
+const mountedRoots: Root[] = [];
+
+async function makeRoot(): Promise<Root> {
+  const stdout = new PassThrough() as PassThrough & { columns: number };
+  stdout.columns = 80;
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    ref: () => void;
+    setRawMode: (mode: boolean) => void;
+    unref: () => void;
+  };
+  stdin.isTTY = true;
+  stdin.setRawMode = () => {};
+  stdin.ref = () => {};
+  stdin.unref = () => {};
+
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  });
+  mountedRoots.push(root);
+
+  return root;
+}
+
+async function renderAndWait(root: Root, node: React.ReactNode): Promise<void> {
+  root.render(node);
+  await new Promise(resolve => setTimeout(resolve, 30));
+}
+
+describe("SelectOption coverage swarm row 200", () => {
+  beforeEach(() => {
+    listItemMock.calls = [];
+  });
+
+  afterEach(() => {
+    for (const root of mountedRoots.splice(0)) {
+      root.unmount();
+    }
+  });
+
+  test("forwards option state, scroll hints, description, and cursor control", async () => {
+    const root = await makeRoot();
+
+    await renderAndWait(
+      root,
+      <SelectOption
+        isFocused={true}
+        isSelected={true}
+        description="Secondary details"
+        shouldShowDownArrow={true}
+        shouldShowUpArrow={true}
+        declareCursor={false}
+      >
+        Primary option
+      </SelectOption>,
+    );
+
+    expect(listItemMock.calls).toHaveLength(1);
+    expect(listItemMock.calls[0]).toMatchObject({
+      declareCursor: false,
+      description: "Secondary details",
+      isFocused: true,
+      isSelected: true,
+      showScrollDown: true,
+      showScrollUp: true,
+      styled: false,
+    });
+    expect(listItemMock.calls[0]?.children).toBe("Primary option");
+  });
+
+  test("keeps optional ListItem props unset when no option adornments are requested", async () => {
+    const root = await makeRoot();
+
+    await renderAndWait(
+      root,
+      <SelectOption isFocused={false} isSelected={false}>
+        Plain option
+      </SelectOption>,
+    );
+
+    expect(listItemMock.calls[0]).toMatchObject({
+      isFocused: false,
+      isSelected: false,
+      styled: false,
+    });
+    expect(listItemMock.calls[0]?.declareCursor).toBeUndefined();
+    expect(listItemMock.calls[0]?.description).toBeUndefined();
+    expect(listItemMock.calls[0]?.showScrollDown).toBeUndefined();
+    expect(listItemMock.calls[0]?.showScrollUp).toBeUndefined();
+  });
+
+  test("reuses the cached ListItem element until a forwarded prop changes", async () => {
+    const root = await makeRoot();
+    const label = "Cached option";
+
+    await renderAndWait(
+      root,
+      <SelectOption isFocused={false} isSelected={false}>
+        {label}
+      </SelectOption>,
+    );
+    expect(listItemMock.calls).toHaveLength(1);
+
+    await renderAndWait(
+      root,
+      <SelectOption isFocused={false} isSelected={false}>
+        {label}
+      </SelectOption>,
+    );
+    expect(listItemMock.calls).toHaveLength(1);
+
+    await renderAndWait(
+      root,
+      <SelectOption
+        isFocused={false}
+        isSelected={false}
+        declareCursor={false}
+      >
+        {label}
+      </SelectOption>,
+    );
+    expect(listItemMock.calls).toHaveLength(2);
+
+    await renderAndWait(
+      root,
+      <SelectOption
+        isFocused={false}
+        isSelected={false}
+        declareCursor={false}
+        description="Updated detail"
+      >
+        {label}
+      </SelectOption>,
+    );
+    expect(listItemMock.calls).toHaveLength(3);
+
+    await renderAndWait(
+      root,
+      <SelectOption
+        isFocused={true}
+        isSelected={false}
+        declareCursor={false}
+        description="Updated detail"
+      >
+        {label}
+      </SelectOption>,
+    );
+    expect(listItemMock.calls).toHaveLength(4);
+
+    await renderAndWait(
+      root,
+      <SelectOption
+        isFocused={true}
+        isSelected={true}
+        declareCursor={false}
+        description="Updated detail"
+      >
+        {label}
+      </SelectOption>,
+    );
+    expect(listItemMock.calls).toHaveLength(5);
+
+    await renderAndWait(
+      root,
+      <SelectOption
+        isFocused={true}
+        isSelected={true}
+        declareCursor={false}
+        description="Updated detail"
+        shouldShowDownArrow={true}
+      >
+        {label}
+      </SelectOption>,
+    );
+    expect(listItemMock.calls).toHaveLength(6);
+
+    await renderAndWait(
+      root,
+      <SelectOption
+        isFocused={true}
+        isSelected={true}
+        declareCursor={false}
+        description="Updated detail"
+        shouldShowDownArrow={true}
+        shouldShowUpArrow={true}
+      >
+        {label}
+      </SelectOption>,
+    );
+    expect(listItemMock.calls).toHaveLength(7);
+    expect(listItemMock.calls.at(-1)).toMatchObject({
+      declareCursor: false,
+      description: "Updated detail",
+      isFocused: true,
+      isSelected: true,
+      showScrollDown: true,
+      showScrollUp: true,
+      styled: false,
+    });
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-201-components-teams-TeamsDialog-layout.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-201-components-teams-TeamsDialog-layout.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "vitest";
+
+import { stringWidth } from "../../../src/tui/ink/stringWidth.js";
+import type { AgenCTuiGlyphs } from "../../../src/tui/glyphs.js";
+import {
+  fitTeamsDialogFooter,
+  getTeamListFooterText,
+  getTeammateDetailFooterText,
+  getTeamsDialogContentColumns,
+  getTeamsDialogPromptPreview,
+} from "../../../src/tui/components/teams/TeamsDialog.layout.js";
+
+const glyphs: AgenCTuiGlyphs = {
+  arrowUp: "^",
+  arrowDown: "v",
+  check: "*",
+  cross: "x",
+  ellipsis: "...",
+  horizontal: "-",
+  pointer: ">",
+  separator: "|",
+  vertical: "|",
+};
+
+describe("TeamsDialog.layout coverage swarm row 201", () => {
+  test("normalizes unusable content widths to one column", () => {
+    expect(getTeamsDialogContentColumns(Number.NaN)).toBe(1);
+    expect(getTeamsDialogContentColumns(Number.POSITIVE_INFINITY)).toBe(1);
+    expect(getTeamsDialogContentColumns(-12)).toBe(1);
+    expect(getTeamsDialogContentColumns(7.9)).toBe(3);
+  });
+
+  test("truncates footers for non-finite and tiny terminal widths", () => {
+    expect(fitTeamsDialogFooter("abcdef", Number.NaN, "...")).toBe(".");
+    expect(fitTeamsDialogFooter("abcdef", 3, "...")).toBe("..");
+    expect(fitTeamsDialogFooter("abcdef", 4, "...")).toBe("...");
+    expect(fitTeamsDialogFooter("abc", 12, "...")).toBe("abc");
+  });
+
+  test("omits hide and show actions when terminal support is disabled", () => {
+    const listFooter = getTeamListFooterText({
+      glyphs,
+      supportsHideShow: false,
+      cycleModeShortcut: "tab",
+      columns: 500,
+    });
+    const detailFooter = getTeammateDetailFooterText({
+      glyphs,
+      supportsHideShow: false,
+      cycleModeShortcut: "tab",
+      columns: 500,
+    });
+
+    expect(listFooter).toContain("^/v select");
+    expect(listFooter).toContain("tab sync cycle modes for all");
+    expect(listFooter).not.toContain("hide/show");
+    expect(detailFooter).toContain("Left back");
+    expect(detailFooter).toContain("tab cycle mode");
+    expect(detailFooter).not.toContain("hide/show");
+  });
+
+  test("returns empty and short prompt previews without expansion hints", () => {
+    expect(getTeamsDialogPromptPreview(undefined, 20, false, "...")).toEqual({
+      text: "",
+      showExpandHint: false,
+    });
+    expect(getTeamsDialogPromptPreview("short prompt", 40, false, "...")).toEqual(
+      {
+        text: "short prompt",
+        showExpandHint: false,
+      },
+    );
+  });
+
+  test("truncates narrow prompt previews without reserving expand hint space", () => {
+    expect(getTeamsDialogPromptPreview("abcdef", 7, false, "...")).toEqual({
+      text: "...",
+      showExpandHint: false,
+    });
+    expect(getTeamsDialogPromptPreview("abcdef", 5, false, "...")).toEqual({
+      text: ".",
+      showExpandHint: false,
+    });
+  });
+
+  test("truncates prompt previews on grapheme boundaries before adding ellipsis", () => {
+    const preview = getTeamsDialogPromptPreview("ab👍cdef", 11, false, "...");
+
+    expect(preview).toEqual({
+      text: "ab👍...",
+      showExpandHint: false,
+    });
+    expect(stringWidth(preview.text)).toBe(7);
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-202-hooks-useInputBuffer.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-202-hooks-useInputBuffer.test.ts
@@ -1,0 +1,214 @@
+import { PassThrough } from 'node:stream'
+
+import React, { act } from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { createRoot } from '../../../src/tui/ink/root.js'
+import {
+  type BufferEntry,
+  type UseInputBufferResult,
+  useInputBuffer,
+} from '../../../src/tui/hooks/useInputBuffer.js'
+
+type HarnessOptions = {
+  debounceMs: number
+  maxBufferSize: number
+}
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough & {
+    columns: number
+    isTTY: boolean
+    rows: number
+  }
+}
+
+type PastedContents = NonNullable<
+  Parameters<UseInputBufferResult['pushToBuffer']>[2]
+>
+
+function createStreams(): TestStreams {
+  const stdin = new PassThrough() as TestStreams['stdin']
+  const stdout = new PassThrough() as TestStreams['stdout']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 100
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+async function advanceTimers(ms: number): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms)
+  })
+  await flushEffects()
+}
+
+async function renderHookHarness(
+  options: HarnessOptions,
+): Promise<{
+  readonly clear: () => Promise<void>
+  readonly dispose: () => Promise<void>
+  readonly latest: () => UseInputBufferResult
+  readonly push: (
+    text: string,
+    cursorOffset?: number,
+    pastedContents?: PastedContents,
+  ) => Promise<void>
+  readonly undo: () => Promise<BufferEntry | undefined>
+}> {
+  let latest: UseInputBufferResult | undefined
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    latest = useInputBuffer(options)
+    return null
+  }
+
+  await act(async () => {
+    root.render(React.createElement(Harness))
+  })
+  await flushEffects()
+
+  function readLatest(): UseInputBufferResult {
+    if (latest === undefined) throw new Error('hook did not render')
+    return latest
+  }
+
+  return {
+    clear: async () => {
+      await act(async () => {
+        readLatest().clearBuffer()
+      })
+      await flushEffects()
+    },
+    dispose: async () => {
+      await act(async () => {
+        root.unmount()
+      })
+      stdin.end()
+      stdout.end()
+      await flushEffects()
+    },
+    latest: readLatest,
+    push: async (
+      text: string,
+      cursorOffset = text.length,
+      pastedContents?: PastedContents,
+    ) => {
+      await act(async () => {
+        readLatest().pushToBuffer(text, cursorOffset, pastedContents)
+      })
+      await flushEffects()
+    },
+    undo: async () => {
+      let entry: BufferEntry | undefined
+      await act(async () => {
+        entry = readLatest().undo()
+      })
+      await flushEffects()
+      return entry
+    },
+  }
+}
+
+describe('useInputBuffer coverage swarm 202', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000_000)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  test('flushes only the latest debounced push and preserves pasted contents', async () => {
+    const pastedContents = {
+      7: {
+        content: 'clipboard text',
+        id: 7,
+        type: 'text',
+      },
+    } satisfies PastedContents
+    const rendered = await renderHookHarness({
+      debounceMs: 50,
+      maxBufferSize: 10,
+    })
+
+    try {
+      await rendered.push('alpha')
+      await act(async () => {
+        rendered.latest().pushToBuffer('beta', 4)
+        rendered.latest().pushToBuffer('gamma', 5, pastedContents)
+      })
+      await flushEffects()
+
+      expect(rendered.latest().canUndo).toBe(false)
+
+      await advanceTimers(50)
+      expect(rendered.latest().canUndo).toBe(true)
+
+      await advanceTimers(50)
+      await rendered.push('delta')
+
+      await expect(rendered.undo()).resolves.toEqual(
+        expect.objectContaining({
+          cursorOffset: 5,
+          pastedContents,
+          text: 'gamma',
+        }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('clearBuffer without a pending timeout drops history and resets debounce timing', async () => {
+    const rendered = await renderHookHarness({
+      debounceMs: 1_000,
+      maxBufferSize: 5,
+    })
+
+    try {
+      await rendered.push('before-clear')
+      await rendered.clear()
+      await rendered.push('after-clear')
+
+      expect(rendered.latest().canUndo).toBe(false)
+      await expect(rendered.undo()).resolves.toEqual(
+        expect.objectContaining({
+          cursorOffset: 'after-clear'.length,
+          pastedContents: {},
+          text: 'after-clear',
+        }),
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-203-hooks-toolPermission-permissionLogging.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-203-hooks-toolPermission-permissionLogging.test.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  counter: {
+    add: vi.fn(),
+  },
+  features: new Set<string>(),
+  getCodeEditToolDecisionCounter: vi.fn(),
+  getLanguageName: vi.fn(),
+  logEvent: vi.fn(),
+  logOTelEvent: vi.fn(),
+  sandboxEnabled: false,
+  sanitizeToolNameForAnalytics: vi.fn((toolName: string) => `safe:${toolName}`),
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: (name: string) => harness.features.has(name),
+}))
+
+vi.mock('../../../src/services/analytics/index.js', () => ({
+  logEvent: harness.logEvent,
+}))
+
+vi.mock('../../../src/services/analytics/metadata.js', () => ({
+  sanitizeToolNameForAnalytics: harness.sanitizeToolNameForAnalytics,
+}))
+
+vi.mock('../../../src/bootstrap/state.js', () => ({
+  getCodeEditToolDecisionCounter: harness.getCodeEditToolDecisionCounter,
+}))
+
+vi.mock('../../../src/utils/cliHighlight.js', () => ({
+  getLanguageName: harness.getLanguageName,
+}))
+
+vi.mock('../../../src/utils/sandbox/sandbox-runtime.js', () => ({
+  SandboxManager: {
+    isSandboxingEnabled: () => harness.sandboxEnabled,
+  },
+}))
+
+vi.mock('../../../src/utils/telemetry/events.js', () => ({
+  logOTelEvent: harness.logOTelEvent,
+}))
+
+import {
+  buildCodeEditToolAttributes,
+  logPermissionDecision,
+} from '../../../src/tui/hooks/toolPermission/permissionLogging.js'
+
+type ParseResult =
+  | { success: true; data: Record<string, unknown> }
+  | { success: false }
+
+function tool(
+  overrides: Partial<{
+    filePath: string | undefined
+    name: string
+    parseResult: ParseResult
+    withGetPath: boolean
+  }> = {},
+) {
+  const withGetPath = overrides.withGetPath ?? true
+  const filePath =
+    Object.hasOwn(overrides, 'filePath') ? overrides.filePath : 'src/demo.ts'
+
+  return {
+    name: overrides.name ?? 'Read',
+    inputSchema: {
+      safeParse: vi.fn(
+        () =>
+          overrides.parseResult ?? {
+            success: true,
+            data: { file_path: 'src/demo.ts' },
+          },
+      ),
+    },
+    ...(withGetPath
+      ? {
+          getPath: vi.fn(() => filePath),
+        }
+      : {}),
+  }
+}
+
+function context(
+  overrides: Partial<{
+    input: Record<string, unknown> | undefined
+    messageId: string
+    tool: ReturnType<typeof tool>
+    toolUseID: string
+  }> = {},
+) {
+  const toolUseContext: { toolDecisions?: Map<string, unknown> } = {}
+
+  return {
+    ctx: {
+      tool: overrides.tool ?? tool(),
+      input: Object.hasOwn(overrides, 'input')
+        ? overrides.input
+        : { file_path: 'src/demo.ts' },
+      toolUseContext,
+      messageId: overrides.messageId ?? 'message-1',
+      toolUseID: overrides.toolUseID ?? 'tool-use-1',
+    },
+    toolUseContext,
+  }
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('permissionLogging coverage swarm row 203', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    harness.counter.add.mockClear()
+    harness.features = new Set()
+    harness.getCodeEditToolDecisionCounter.mockReset()
+    harness.getCodeEditToolDecisionCounter.mockReturnValue(harness.counter)
+    harness.getLanguageName.mockReset()
+    harness.getLanguageName.mockResolvedValue('TypeScript')
+    harness.logEvent.mockClear()
+    harness.logOTelEvent.mockClear()
+    harness.sandboxEnabled = false
+    harness.sanitizeToolNameForAnalytics.mockClear()
+    vi.spyOn(Date, 'now').mockReturnValue(4_000)
+  })
+
+  test('omits language attributes when path extraction is unavailable', async () => {
+    const noPathTool = tool({ name: 'Edit', withGetPath: false })
+
+    await expect(
+      buildCodeEditToolAttributes(
+        noPathTool as never,
+        { file_path: 'src/demo.ts' },
+        'accept',
+        'hook',
+      ),
+    ).resolves.toEqual({
+      decision: 'accept',
+      source: 'hook',
+      tool_name: 'Edit',
+    })
+    expect(noPathTool.inputSchema.safeParse).not.toHaveBeenCalled()
+
+    const noInputTool = tool({ name: 'Write' })
+    await expect(
+      buildCodeEditToolAttributes(
+        noInputTool as never,
+        undefined,
+        'reject',
+        'config',
+      ),
+    ).resolves.toEqual({
+      decision: 'reject',
+      source: 'config',
+      tool_name: 'Write',
+    })
+    expect(noInputTool.inputSchema.safeParse).not.toHaveBeenCalled()
+
+    const noFilePathTool = tool({ filePath: undefined, name: 'NotebookEdit' })
+    await expect(
+      buildCodeEditToolAttributes(
+        noFilePathTool as never,
+        { file_path: 'src/demo.ts' },
+        'accept',
+        'user_temporary',
+      ),
+    ).resolves.toEqual({
+      decision: 'accept',
+      source: 'user_temporary',
+      tool_name: 'NotebookEdit',
+    })
+    expect(noFilePathTool.inputSchema.safeParse).toHaveBeenCalledWith({
+      file_path: 'src/demo.ts',
+    })
+    expect(harness.getLanguageName).not.toHaveBeenCalled()
+  })
+
+  test('logs permanent hook approval without prompt wait metadata', () => {
+    const hookContext = context({ tool: tool({ name: 'Read' }) })
+
+    logPermissionDecision(
+      hookContext.ctx as never,
+      { decision: 'accept', source: { type: 'hook', permanent: true } },
+    )
+
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'agenc_tool_use_granted_by_permission_hook',
+      {
+        messageID: 'message-1',
+        permanent: true,
+        sandboxEnabled: false,
+        toolName: 'safe:Read',
+      },
+    )
+    expect(hookContext.toolUseContext.toolDecisions?.get('tool-use-1')).toEqual({
+      decision: 'accept',
+      source: 'hook',
+      timestamp: 4_000,
+    })
+    expect(harness.logOTelEvent).toHaveBeenCalledWith('tool_decision', {
+      decision: 'accept',
+      source: 'hook',
+      tool_name: 'safe:Read',
+    })
+  })
+
+  test('keeps classifier approval unknown when classifier features are disabled', () => {
+    const classifierContext = context({
+      tool: tool({ name: 'Read' }),
+      toolUseID: 'classifier-off',
+    })
+
+    logPermissionDecision(
+      classifierContext.ctx as never,
+      { decision: 'accept', source: { type: 'classifier' } },
+      3_900,
+    )
+
+    expect(harness.logEvent).not.toHaveBeenCalled()
+    expect(
+      classifierContext.toolUseContext.toolDecisions?.get('classifier-off'),
+    ).toEqual({
+      decision: 'accept',
+      source: 'unknown',
+      timestamp: 4_000,
+    })
+    expect(harness.logOTelEvent).toHaveBeenCalledWith('tool_decision', {
+      decision: 'accept',
+      source: 'unknown',
+      tool_name: 'safe:Read',
+    })
+  })
+
+  test('uses transcript classifier feature and tolerates a missing code edit counter', async () => {
+    harness.features.add('TRANSCRIPT_CLASSIFIER')
+    harness.getCodeEditToolDecisionCounter.mockReturnValue(undefined)
+
+    const editTool = tool({ name: 'Edit' })
+    const classifierContext = context({
+      tool: editTool,
+      toolUseID: 'classifier-edit',
+    })
+
+    logPermissionDecision(
+      classifierContext.ctx as never,
+      { decision: 'accept', source: { type: 'classifier' } },
+      3_750,
+    )
+    await flushMicrotasks()
+
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'agenc_tool_use_granted_by_classifier',
+      {
+        messageID: 'message-1',
+        sandboxEnabled: false,
+        toolName: 'safe:Edit',
+        waiting_for_user_permission_ms: 250,
+      },
+    )
+    expect(harness.getLanguageName).toHaveBeenCalledWith('src/demo.ts')
+    expect(harness.getCodeEditToolDecisionCounter).toHaveBeenCalled()
+    expect(harness.counter.add).not.toHaveBeenCalled()
+    expect(
+      classifierContext.toolUseContext.toolDecisions?.get('classifier-edit'),
+    ).toEqual({
+      decision: 'accept',
+      source: 'classifier',
+      timestamp: 4_000,
+    })
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-204-realtime-RealtimePanel.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-204-realtime-RealtimePanel.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { stringWidth } from '../../../src/tui/ink/stringWidth.js'
+import {
+  getRealtimeStatusRenderParts,
+  RealtimePanel,
+} from '../../../src/tui/realtime/RealtimePanel.js'
+import {
+  initialRealtimeTuiState,
+  type RealtimeTuiState,
+} from '../../../src/tui/realtime/state.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+
+function activeState(overrides: Partial<RealtimeTuiState> = {}): RealtimeTuiState {
+  return {
+    ...initialRealtimeTuiState(),
+    phase: 'active',
+    transport: 'websocket',
+    realtimeSessionId: 'rt_1',
+    ...overrides,
+  }
+}
+
+describe('RealtimePanel coverage swarm row 204', () => {
+  test('returns empty status parts for unusable terminal widths', () => {
+    const state = activeState()
+
+    expect(getRealtimeStatusRenderParts(state, 0)).toEqual({
+      statusText: '',
+      meterText: null,
+    })
+    expect(getRealtimeStatusRenderParts(state, -5)).toEqual({
+      statusText: '',
+      meterText: null,
+    })
+    expect(getRealtimeStatusRenderParts(state, Number.NaN)).toEqual({
+      statusText: '',
+      meterText: null,
+    })
+    expect(getRealtimeStatusRenderParts(state, Number.POSITIVE_INFINITY)).toEqual(
+      {
+        statusText: '',
+        meterText: null,
+      },
+    )
+  })
+
+  test('reports push-to-talk armed and held microphone status', () => {
+    const armed = getRealtimeStatusRenderParts(
+      activeState({ pushToTalk: true, pushToTalkHeld: false }),
+      100,
+    )
+    expect(armed.statusText).toContain('mic muted')
+    expect(armed.statusText).toContain('ptt armed')
+
+    const held = getRealtimeStatusRenderParts(
+      activeState({ pushToTalk: true, pushToTalkHeld: true }),
+      100,
+    )
+    expect(held.statusText).toContain('mic live')
+    expect(held.statusText).toContain('ptt held')
+  })
+
+  test('truncates status while preserving meter until the meter no longer fits', () => {
+    const state = activeState({
+      localAudioLevel: 65_535,
+      realtimeSessionId:
+        'rt_session_with_a_long_identifier_that_should_be_truncated',
+    })
+
+    const withMeter = getRealtimeStatusRenderParts(state, 24)
+    expect(withMeter.meterText).toBe(' [############]')
+    expect(withMeter.statusText).not.toContain('rt_session_with_a_long')
+    expect(stringWidth(`${withMeter.statusText}${withMeter.meterText}`)).toBeLessThanOrEqual(
+      24,
+    )
+
+    const withoutMeter = getRealtimeStatusRenderParts(state, 8)
+    expect(withoutMeter.meterText).toBeNull()
+    expect(withoutMeter.statusText).not.toContain('[')
+    expect(stringWidth(withoutMeter.statusText)).toBeLessThanOrEqual(8)
+  })
+
+  test('renders nothing for a clean inactive state and gives errors banner priority', async () => {
+    const inactive = await renderToString(
+      <RealtimePanel state={initialRealtimeTuiState()} />,
+      { columns: 100, rows: 4 },
+    )
+    expect(inactive.trim()).toBe('')
+
+    const output = await renderToString(
+      <RealtimePanel
+        state={activeState({
+          errorBanner: 'microphone failed',
+          closedBanner: 'Realtime closed: remote hangup',
+          lastTranscript: { role: 'user', text: 'hello from mic' },
+          lastItemSummary: 'response out_1',
+        })}
+      />,
+      { columns: 100, rows: 8 },
+    )
+
+    expect(output).toContain('microphone failed')
+    expect(output).not.toContain('remote hangup')
+    expect(output).toContain('user: hello from mic')
+    expect(output).toContain('item: response out_1')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-205-components-SearchBox.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-205-components-SearchBox.test.tsx
@@ -1,0 +1,118 @@
+import React, { useLayoutEffect, useState } from "react";
+import { describe, expect, test } from "vitest";
+
+import { SearchBox } from "../../../src/tui/components/SearchBox.js";
+import {
+  renderToAnsiString,
+  renderToString,
+} from "../../../src/utils/staticRender.js";
+
+async function renderSearchBox(
+  props: React.ComponentProps<typeof SearchBox>,
+): Promise<string> {
+  return renderToString(<SearchBox {...props} />, { columns: 40 });
+}
+
+function RerenderSameSearchBox() {
+  const [rerendered, setRerendered] = useState(false);
+
+  useLayoutEffect(() => {
+    if (!rerendered) setRerendered(true);
+  }, [rerendered]);
+
+  return (
+    <SearchBox
+      query="cached"
+      prefix=">"
+      placeholder="Find"
+      isFocused={true}
+      isTerminalFocused={true}
+      cursorOffset={2}
+      width={18}
+    />
+  );
+}
+
+describe("SearchBox coverage swarm row 205", () => {
+  test("renders terminal cursor branches inside a query and at the query end", async () => {
+    const middleCursor = await renderToAnsiString(
+      <SearchBox
+        query="abc"
+        prefix=">"
+        placeholder="Find"
+        isFocused={true}
+        isTerminalFocused={true}
+        cursorOffset={1}
+        borderless={true}
+      />,
+      { columns: 40, color: true },
+    );
+    const endCursor = await renderSearchBox({
+      query: "go",
+      prefix: ">",
+      placeholder: "Find",
+      isFocused: true,
+      isTerminalFocused: true,
+      cursorOffset: 2,
+      borderless: true,
+    });
+
+    expect(middleCursor).toContain("a");
+    expect(middleCursor).toContain("b");
+    expect(middleCursor).toContain("c");
+    expect(middleCursor).toContain("\x1B[7m");
+    expect(endCursor).toContain("> go");
+  });
+
+  test("renders focused and unfocused text without terminal cursor styling", async () => {
+    await expect(
+      renderSearchBox({
+        query: "plain",
+        prefix: ">",
+        placeholder: "Find",
+        isFocused: true,
+        isTerminalFocused: false,
+        borderless: true,
+      }),
+    ).resolves.toContain("> plain");
+
+    await expect(
+      renderSearchBox({
+        query: "match",
+        prefix: ">",
+        placeholder: "Find",
+        isFocused: false,
+        isTerminalFocused: false,
+        borderless: true,
+      }),
+    ).resolves.toContain("> match");
+
+    await expect(
+      renderSearchBox({
+        query: "",
+        prefix: ">",
+        placeholder: "Find",
+        isFocused: false,
+        isTerminalFocused: true,
+        borderless: true,
+      }),
+    ).resolves.toContain("> Find");
+  });
+
+  test("renders focused terminal placeholders and survives same-props rerenders", async () => {
+    await expect(
+      renderSearchBox({
+        query: "",
+        prefix: ">",
+        placeholder: "Find",
+        isFocused: true,
+        isTerminalFocused: true,
+        borderless: true,
+      }),
+    ).resolves.toContain("> Find");
+
+    await expect(
+      renderToString(<RerenderSameSearchBox />, { columns: 40 }),
+    ).resolves.toContain("> cached");
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-206-components-VimTextInput.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-206-components-VimTextInput.test.tsx
@@ -1,0 +1,309 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({
+  baseTextInputCalls: [] as Array<Record<string, unknown>>,
+  clipboardImageHint: vi.fn(),
+  inverse: vi.fn((text: string) => `inverse(${text})`),
+  setMode: vi.fn(),
+  terminalFocused: true,
+  theme: 'dark',
+  vimInputCalls: [] as Array<Record<string, unknown>>,
+  vimMode: 'INSERT' as 'INSERT' | 'NORMAL',
+  reset() {
+    this.baseTextInputCalls = []
+    this.clipboardImageHint.mockClear()
+    this.inverse.mockClear()
+    this.setMode.mockClear()
+    this.terminalFocused = true
+    this.theme = 'dark'
+    this.vimInputCalls = []
+    this.vimMode = 'INSERT'
+  },
+}))
+
+vi.mock('chalk', () => ({
+  default: {
+    inverse: harness.inverse,
+  },
+}))
+
+vi.mock('../hooks/useClipboardImageHint.js', () => ({
+  useClipboardImageHint: harness.clipboardImageHint,
+}))
+
+vi.mock('../ink.js', async () => {
+  const ReactModule = await import('react')
+
+  return {
+    Box: ({ children }: { children?: React.ReactNode }) =>
+      ReactModule.createElement(ReactModule.Fragment, null, children),
+    color: (name: string, theme: string) => (text: string) =>
+      `color(${name}:${theme}:${text})`,
+    useTerminalFocus: () => harness.terminalFocused,
+    useTheme: () => [harness.theme, () => {}] as const,
+  }
+})
+
+vi.mock('../hooks/useVimInput.js', () => ({
+  useVimInput: (props: Record<string, unknown>) => {
+    harness.vimInputCalls.push(props)
+    return {
+      cursorColumn: 0,
+      cursorLine: 0,
+      mode: harness.vimMode,
+      offset: props.externalOffset ?? 0,
+      onInput: vi.fn(),
+      renderedValue: String(props.value ?? ''),
+      setMode: harness.setMode,
+      setOffset: vi.fn(),
+      setValue: vi.fn(),
+      value: String(props.value ?? ''),
+      viewportCharEnd: String(props.value ?? '').length,
+      viewportCharOffset: 0,
+    }
+  },
+}))
+
+vi.mock('../components/BaseTextInput.js', async () => {
+  const ReactModule = await import('react')
+
+  return {
+    BaseTextInput: (props: Record<string, unknown>) => {
+      harness.baseTextInputCalls.push(props)
+      return ReactModule.createElement(ReactModule.Fragment)
+    },
+  }
+})
+
+import { createRoot } from '../ink/root.js'
+import VimTextInput from '../components/VimTextInput.js'
+
+type VimTextInputProps = React.ComponentProps<typeof VimTextInput>
+
+function createStreams(): {
+  readonly stdout: PassThrough
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 100
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function baseProps(
+  overrides: Partial<VimTextInputProps> = {},
+): VimTextInputProps {
+  return {
+    columns: 80,
+    cursorOffset: 0,
+    focus: true,
+    onChange: vi.fn(),
+    onChangeCursorOffset: vi.fn(),
+    showCursor: true,
+    value: 'draft',
+    ...overrides,
+  }
+}
+
+async function renderVimTextInput(
+  overrides: Partial<VimTextInputProps> = {},
+): Promise<void> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  try {
+    root.render(<VimTextInput {...baseProps(overrides)} />)
+    await sleep()
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await sleep()
+  }
+}
+
+function latestVimInputProps(): Record<string, unknown> {
+  const props = harness.vimInputCalls.at(-1)
+  if (!props) throw new Error('useVimInput was not called')
+  return props
+}
+
+function latestBaseTextInputProps(): Record<string, unknown> {
+  const props = harness.baseTextInputCalls.at(-1)
+  if (!props) throw new Error('BaseTextInput was not called')
+  return props
+}
+
+describe('VimTextInput coverage swarm row 206', () => {
+  beforeEach(() => {
+    harness.reset()
+  })
+
+  afterEach(() => {
+    harness.reset()
+  })
+
+  test('forwards vim hook props and focused terminal rendering props', async () => {
+    const onChange = vi.fn()
+    const onSubmit = vi.fn()
+    const onExit = vi.fn()
+    const onExitMessage = vi.fn()
+    const onHistoryReset = vi.fn()
+    const onHistoryUp = vi.fn()
+    const onHistoryDown = vi.fn()
+    const onClearInput = vi.fn()
+    const onImagePaste = vi.fn()
+    const onChangeCursorOffset = vi.fn()
+    const onModeChange = vi.fn()
+    const onUndo = vi.fn()
+    const inputFilter = vi.fn((input: string) => input.trimStart())
+    const highlights = [{ color: 'success', end: 5, priority: 1, start: 0 }]
+
+    await renderVimTextInput({
+      columns: 42,
+      cursorOffset: 4,
+      disableCursorMovementForUpDownKeys: true,
+      disableEscapeDoublePress: true,
+      focus: true,
+      highlightPastedText: true,
+      highlights,
+      inputFilter,
+      mask: '*',
+      maxVisibleLines: 3,
+      multiline: true,
+      onChange,
+      onChangeCursorOffset,
+      onClearInput,
+      onExit,
+      onExitMessage,
+      onHistoryDown,
+      onHistoryReset,
+      onHistoryUp,
+      onImagePaste,
+      onModeChange,
+      onSubmit,
+      onUndo,
+      showCursor: true,
+      value: 'draft',
+    })
+
+    const vimInputProps = latestVimInputProps()
+    const baseTextInputProps = latestBaseTextInputProps()
+    const invert = vimInputProps.invert as (text: string) => string
+    const themeText = vimInputProps.themeText as (text: string) => string
+
+    expect(harness.clipboardImageHint).toHaveBeenCalledWith(true, true)
+    expect(invert('cursor')).toBe('inverse(cursor)')
+    expect(themeText('body')).toBe('color(text:dark:body)')
+    expect(vimInputProps).toMatchObject({
+      columns: 42,
+      cursorChar: ' ',
+      disableCursorMovementForUpDownKeys: true,
+      disableEscapeDoublePress: true,
+      externalOffset: 4,
+      focus: true,
+      highlightPastedText: true,
+      inputFilter,
+      mask: '*',
+      maxVisibleLines: 3,
+      multiline: true,
+      onChange,
+      onClearInput,
+      onExit,
+      onExitMessage,
+      onHistoryDown,
+      onHistoryReset,
+      onHistoryUp,
+      onImagePaste,
+      onModeChange,
+      onOffsetChange: onChangeCursorOffset,
+      onSubmit,
+      onUndo,
+      value: 'draft',
+    })
+    expect(baseTextInputProps).toMatchObject({
+      highlights,
+      terminalFocus: true,
+      value: 'draft',
+    })
+    expect(baseTextInputProps.inputState).toMatchObject({
+      mode: 'INSERT',
+      renderedValue: 'draft',
+      value: 'draft',
+    })
+  })
+
+  test('uses identity cursor inversion when the terminal is unfocused and cursor is hidden', async () => {
+    harness.terminalFocused = false
+    harness.theme = 'light'
+
+    await renderVimTextInput({
+      onImagePaste: undefined,
+      showCursor: false,
+      value: 'unfocused',
+    })
+
+    const vimInputProps = latestVimInputProps()
+    const baseTextInputProps = latestBaseTextInputProps()
+    const invert = vimInputProps.invert as (text: string) => string
+    const themeText = vimInputProps.themeText as (text: string) => string
+
+    expect(harness.clipboardImageHint).toHaveBeenCalledWith(false, false)
+    expect(vimInputProps.cursorChar).toBe('')
+    expect(invert('cursor')).toBe('cursor')
+    expect(themeText('body')).toBe('color(text:light:body)')
+    expect(harness.inverse).not.toHaveBeenCalled()
+    expect(baseTextInputProps.terminalFocus).toBe(false)
+  })
+
+  test('applies initial vim mode only when it differs from the current hook mode', async () => {
+    harness.vimMode = 'INSERT'
+
+    await renderVimTextInput({
+      initialMode: 'NORMAL',
+      value: 'modal',
+    })
+
+    expect(harness.setMode).toHaveBeenCalledWith('NORMAL')
+
+    harness.setMode.mockClear()
+    harness.vimInputCalls = []
+    harness.baseTextInputCalls = []
+    harness.vimMode = 'NORMAL'
+
+    await renderVimTextInput({
+      initialMode: 'NORMAL',
+      value: 'already normal',
+    })
+
+    expect(harness.setMode).not.toHaveBeenCalled()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-207-hooks-unifiedSuggestions.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-207-hooks-unifiedSuggestions.test.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { ServerResource } from '../../../src/services/mcp/types.js'
+import type { AgentDefinition } from '../../../src/tools/AgentTool/loadAgentsDir.js'
+
+const harness = vi.hoisted(() => ({
+  fileSuggestions: [] as Array<{
+    id: string
+    displayText: string
+    description?: string
+    metadata?: unknown
+  }>,
+  fileSuggestionCalls: [] as Array<{
+    query: string
+    showOnEmpty: boolean
+  }>,
+  getAgentColor: vi.fn((agentType: string) =>
+    agentType === 'builder' ? 'green' : 'blue',
+  ),
+  logError: vi.fn(),
+}))
+
+vi.mock('../../../src/tui/hooks/fileSuggestions.js', () => ({
+  generateFileSuggestions: vi.fn((query: string, showOnEmpty: boolean) => {
+    harness.fileSuggestionCalls.push({ query, showOnEmpty })
+    return Promise.resolve(harness.fileSuggestions)
+  }),
+}))
+
+vi.mock('src/tools/AgentTool/agentColorManager.js', () => ({
+  getAgentColor: harness.getAgentColor,
+}))
+
+vi.mock('../../../src/utils/log.js', () => ({
+  logError: harness.logError,
+}))
+
+import { generateUnifiedSuggestions } from '../../../src/tui/hooks/unifiedSuggestions.js'
+
+function resource(
+  server: string,
+  uri: string,
+  overrides: Partial<ServerResource> = {},
+): ServerResource {
+  return {
+    server,
+    uri,
+    ...overrides,
+  } as ServerResource
+}
+
+function agent(agentType: string, whenToUse: string): AgentDefinition {
+  return {
+    agentType,
+    whenToUse,
+    source: 'projectSettings',
+    getSystemPrompt: () => '',
+  } as AgentDefinition
+}
+
+describe('unifiedSuggestions coverage swarm row 207', () => {
+  beforeEach(() => {
+    harness.fileSuggestions = []
+    harness.fileSuggestionCalls = []
+    harness.getAgentColor.mockReset()
+    harness.getAgentColor.mockImplementation((agentType: string) =>
+      agentType === 'builder' ? 'green' : 'blue',
+    )
+    harness.logError.mockClear()
+  })
+
+  test('does not query sources for an empty query unless empty suggestions are requested', async () => {
+    const result = await generateUnifiedSuggestions(
+      '',
+      {
+        docs: [resource('docs', 'doc://readme')],
+      },
+      [agent('builder', 'Use for build work')],
+    )
+
+    expect(result).toEqual([])
+    expect(harness.fileSuggestionCalls).toEqual([])
+    expect(harness.getAgentColor).not.toHaveBeenCalled()
+  })
+
+  test('returns file, MCP resource, and agent suggestions for empty-trigger suggestions', async () => {
+    harness.fileSuggestions = [
+      {
+        id: 'file-one',
+        displayText: 'src/index.ts',
+        description: 'entry point',
+      },
+      {
+        id: 'file-two',
+        displayText: 'docs/readme.md',
+      },
+    ]
+
+    const result = await generateUnifiedSuggestions(
+      '',
+      {
+        docs: [
+          resource('docs', 'doc://schema', {
+            name: 'schema',
+            description: '  schema\nresource\ttext  ',
+          }),
+          resource('docs', 'doc://fallback-name', {
+            name: 'Fallback Name',
+          }),
+          resource('docs', 'doc://fallback-uri'),
+        ],
+      },
+      [
+        agent('builder', '  Builds\nfeatures\tquickly  '),
+        agent('reviewer', 'Reviews code'),
+      ],
+      true,
+    )
+
+    expect(harness.fileSuggestionCalls).toEqual([
+      { query: '', showOnEmpty: true },
+    ])
+    expect(result).toEqual([
+      {
+        id: 'file-src/index.ts',
+        displayText: 'src/index.ts',
+        description: 'entry point',
+      },
+      {
+        id: 'file-docs/readme.md',
+        displayText: 'docs/readme.md',
+        description: undefined,
+      },
+      {
+        id: 'mcp-resource-docs__doc://schema',
+        displayText: 'docs:doc://schema',
+        description: 'schema resource text',
+      },
+      {
+        id: 'mcp-resource-docs__doc://fallback-name',
+        displayText: 'docs:doc://fallback-name',
+        description: 'Fallback Name',
+      },
+      {
+        id: 'mcp-resource-docs__doc://fallback-uri',
+        displayText: 'docs:doc://fallback-uri',
+        description: 'doc://fallback-uri',
+      },
+      {
+        id: 'agent-builder',
+        displayText: 'builder (agent)',
+        description: 'Builds features quickly',
+        color: 'green',
+      },
+      {
+        id: 'agent-reviewer',
+        displayText: 'reviewer (agent)',
+        description: 'Reviews code',
+        color: 'blue',
+      },
+    ])
+  })
+
+  test('sorts file suggestions by nucleo score and uses the default score when absent', async () => {
+    harness.fileSuggestions = [
+      {
+        id: 'slow',
+        displayText: 'src/slow.ts',
+        metadata: { score: 0.9 },
+      },
+      {
+        id: 'defaulted',
+        displayText: 'src/defaulted.ts',
+      },
+      {
+        id: 'best',
+        displayText: 'src/best.ts',
+        metadata: { score: 0.01 },
+      },
+    ]
+
+    const result = await generateUnifiedSuggestions('src', {}, [])
+
+    expect(result.map(item => item.id)).toEqual([
+      'file-src/best.ts',
+      'file-src/defaulted.ts',
+      'file-src/slow.ts',
+    ])
+  })
+
+  test('uses Fuse matching for MCP resources and agents when querying non-file sources', async () => {
+    const result = await generateUnifiedSuggestions(
+      'deploy',
+      {
+        docs: [
+          resource('docs', 'doc://deploy-checklist', {
+            name: 'Deploy Checklist',
+            description: 'Production rollout steps',
+          }),
+          resource('docs', 'doc://billing', {
+            name: 'Billing Notes',
+            description: 'Invoices and payments',
+          }),
+        ],
+      },
+      [
+        agent('deployer', 'Use for deploy tasks'),
+        agent('reviewer', 'Use for review tasks'),
+      ],
+    )
+
+    expect(result).toEqual(
+      expect.arrayContaining([
+        {
+          id: 'mcp-resource-docs__doc://deploy-checklist',
+          displayText: 'docs:doc://deploy-checklist',
+          description: 'Production rollout steps',
+        },
+        {
+          id: 'agent-deployer',
+          displayText: 'deployer (agent)',
+          description: 'Use for deploy tasks',
+          color: 'blue',
+        },
+      ]),
+    )
+    expect(result.map(item => item.id)).not.toContain('agent-reviewer')
+  })
+
+  test('logs and skips agent suggestions when agent color lookup fails', async () => {
+    const error = new Error('color lookup failed')
+    harness.fileSuggestions = [
+      {
+        id: 'file',
+        displayText: 'src/fallback.ts',
+      },
+    ]
+    harness.getAgentColor.mockImplementation(() => {
+      throw error
+    })
+
+    const result = await generateUnifiedSuggestions(
+      '',
+      {},
+      [agent('builder', 'Use for build work')],
+      true,
+    )
+
+    expect(result).toEqual([
+      {
+        id: 'file-src/fallback.ts',
+        displayText: 'src/fallback.ts',
+        description: undefined,
+      },
+    ])
+    expect(harness.logError).toHaveBeenCalledWith(error)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-208-ink-stringWidth.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-208-ink-stringWidth.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+type StringWidthModule = typeof import('../../../src/tui/ink/stringWidth.js')
+
+async function loadStringWidth(): Promise<StringWidthModule> {
+  vi.resetModules()
+  return import('../../../src/tui/ink/stringWidth.js')
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.resetModules()
+})
+
+describe('stringWidth coverage swarm row 208', () => {
+  test('uses the JavaScript fallback for empty, non-string, and incomplete Bun APIs', async () => {
+    vi.stubGlobal('Bun', {})
+
+    const { stringWidth } = await loadStringWidth()
+    const unsafeStringWidth = stringWidth as unknown as (
+      value: unknown,
+    ) => number
+
+    expect(unsafeStringWidth(undefined)).toBe(0)
+    expect(unsafeStringWidth(7)).toBe(0)
+    expect(stringWidth('')).toBe(0)
+    expect(stringWidth('plain')).toBe(5)
+  })
+
+  test('counts printable Unicode that should not be treated as zero width', async () => {
+    vi.stubGlobal('Bun', undefined)
+
+    const { stringWidth } = await loadStringWidth()
+
+    expect(stringWidth('\u00a0')).toBe(1)
+    expect(stringWidth('\u03a9')).toBe(1)
+    expect(stringWidth('\u26a0')).toBe(1)
+    expect(stringWidth('\u26a0\ufe0e')).toBe(1)
+    expect(stringWidth('\u26a0\ufe0f')).toBe(2)
+    expect(stringWidth('\u0905')).toBe(1)
+    expect(stringWidth('\u0e32\u0e33\u0eb2\u0eb3')).toBe(4)
+    expect(stringWidth('\u0627')).toBe(1)
+  })
+
+  test('segments symbol and joiner inputs without counting joiners as cells', async () => {
+    vi.stubGlobal('Bun', undefined)
+
+    const { stringWidth } = await loadStringWidth()
+
+    expect(stringWidth('\u2600\ufe0f')).toBe(2)
+    expect(stringWidth('A\u200dB')).toBe(2)
+  })
+
+  test('uses the fallback for text-presentation symbols even when Bun is available', async () => {
+    const bunStringWidth = vi.fn(() => 2)
+    vi.stubGlobal('Bun', { stringWidth: bunStringWidth })
+
+    const { stringWidth } = await loadStringWidth()
+
+    expect(stringWidth('\u26a0')).toBe(1)
+    expect(stringWidth('plain')).toBe(2)
+    expect(bunStringWidth).toHaveBeenCalledWith('plain', {
+      ambiguousIsNarrow: true,
+    })
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-209-ink-components-ClockContext.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-209-ink-components-ClockContext.test.tsx
@@ -1,0 +1,178 @@
+import { PassThrough } from 'node:stream'
+
+import React, { act } from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  ClockContext,
+  ClockProvider,
+  createClock,
+  type Clock,
+} from '../../../src/tui/ink/components/ClockContext.js'
+import TerminalFocusContext from '../../../src/tui/ink/components/TerminalFocusContext.js'
+import { createRoot } from '../../../src/tui/ink/root.js'
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough & {
+    columns: number
+    isTTY: boolean
+    rows: number
+  }
+}
+
+const realSetImmediate = setImmediate
+
+function createStreams(): TestStreams {
+  const stdin = new PassThrough() as TestStreams['stdin']
+  const stdout = new PassThrough() as TestStreams['stdout']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 100
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+  })
+  await new Promise<void>(resolve => realSetImmediate(resolve))
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+function ClockProbe({
+  onClock,
+}: {
+  readonly onClock: (clock: Clock | null) => void
+}): null {
+  onClock(React.useContext(ClockContext))
+  return null
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('ClockContext coverage swarm row 209', () => {
+  test('returns live elapsed time while an active interval is waiting for its first tick', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(2_000)
+
+    const clock = createClock(10)
+    const ticks: number[] = []
+    const unsubscribe = clock.subscribe(() => {
+      ticks.push(clock.now())
+    }, true)
+
+    try {
+      expect(clock.now()).toBe(0)
+
+      vi.advanceTimersByTime(9)
+
+      expect(ticks).toEqual([])
+      expect(clock.now()).toBe(9)
+
+      vi.advanceTimersByTime(1)
+
+      expect(ticks).toEqual([10])
+      expect(clock.now()).toBe(10)
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  test('ClockProvider lengthens and restores the active clock interval as focus changes', async () => {
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+    let capturedClock: Clock | null = null
+    let unsubscribe: (() => void) | undefined
+
+    async function renderWithFocus(isTerminalFocused: boolean): Promise<Clock> {
+      await act(async () => {
+        root.render(
+          <TerminalFocusContext.Provider
+            value={{
+              isTerminalFocused,
+              terminalFocusState: isTerminalFocused ? 'focused' : 'blurred',
+            }}
+          >
+            <ClockProvider>
+              <ClockProbe
+                onClock={clock => {
+                  capturedClock = clock
+                }}
+              />
+            </ClockProvider>
+          </TerminalFocusContext.Provider>,
+        )
+      })
+      await flushEffects()
+
+      if (capturedClock === null) {
+        throw new Error('ClockProvider did not expose a clock')
+      }
+
+      return capturedClock
+    }
+
+    try {
+      const clock = await renderWithFocus(true)
+      const ticks: number[] = []
+
+      vi.useFakeTimers()
+      vi.setSystemTime(10_000)
+
+      unsubscribe = clock.subscribe(() => {
+        ticks.push(clock.now())
+      }, true)
+
+      await vi.advanceTimersByTimeAsync(15)
+      expect(ticks).toEqual([])
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(ticks).toEqual([16])
+
+      expect(await renderWithFocus(false)).toBe(clock)
+
+      await vi.advanceTimersByTimeAsync(31)
+      expect(ticks).toEqual([16])
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(ticks).toEqual([16, 48])
+
+      expect(await renderWithFocus(true)).toBe(clock)
+
+      await vi.advanceTimersByTimeAsync(15)
+      expect(ticks).toEqual([16, 48])
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(ticks).toEqual([16, 48, 64])
+    } finally {
+      unsubscribe?.()
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      vi.useRealTimers()
+      await flushEffects()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-210-ink-components-RawAnsi.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-210-ink-components-RawAnsi.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const compilerRuntime = vi.hoisted(() => {
+  const sentinel = Symbol("memo-cache-sentinel");
+  let cache: unknown[] = [];
+
+  function reset(size = 6): void {
+    cache = Array.from({ length: size }, () => sentinel);
+  }
+
+  reset();
+
+  return {
+    c: vi.fn((size: number) => {
+      if (cache.length !== size) reset(size);
+      return cache;
+    }),
+    reset,
+  };
+});
+
+vi.mock("react-compiler-runtime", () => ({
+  c: compilerRuntime.c,
+}));
+
+import { RawAnsi } from "../../../src/tui/ink/components/RawAnsi.js";
+
+type RawAnsiElement = React.ReactElement<{
+  rawHeight: number;
+  rawText: string;
+  rawWidth: number;
+}>;
+
+function renderRawAnsi(
+  props: Parameters<typeof RawAnsi>[0],
+): RawAnsiElement | null {
+  const element = RawAnsi(props);
+
+  if (element !== null) {
+    expect(React.isValidElement(element)).toBe(true);
+  }
+
+  return element as RawAnsiElement | null;
+}
+
+describe("RawAnsi coverage swarm row 210", () => {
+  beforeEach(() => {
+    compilerRuntime.reset();
+    compilerRuntime.c.mockClear();
+  });
+
+  test("returns null when there are no raw lines", () => {
+    expect(renderRawAnsi({ lines: [], width: 12 })).toBeNull();
+    expect(compilerRuntime.c).toHaveBeenCalledWith(6);
+  });
+
+  test("joins raw lines and forwards the producer dimensions to the raw leaf", () => {
+    const element = renderRawAnsi({
+      lines: ["\x1b[31mred\x1b[0m", "", "plain"],
+      width: 18,
+    });
+
+    expect(element?.type).toBe("ink-raw-ansi");
+    expect(element?.props).toMatchObject({
+      rawHeight: 3,
+      rawText: "\x1b[31mred\x1b[0m\n\nplain",
+      rawWidth: 18,
+    });
+  });
+
+  test("reuses the memoized raw leaf for stable lines and width", () => {
+    const lines = ["first row", "second row"];
+
+    const first = renderRawAnsi({ lines, width: 20 });
+    const second = renderRawAnsi({ lines, width: 20 });
+
+    expect(second).toBe(first);
+    expect(compilerRuntime.c).toHaveBeenCalledTimes(2);
+  });
+
+  test("keeps the joined text but refreshes the raw leaf when width changes", () => {
+    const lines = ["gutter", "content"];
+
+    const first = renderRawAnsi({ lines, width: 8 });
+    const second = renderRawAnsi({ lines, width: 13 });
+
+    expect(second).not.toBe(first);
+    expect(second?.props).toMatchObject({
+      rawHeight: 2,
+      rawText: "gutter\ncontent",
+      rawWidth: 13,
+    });
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-211-components-FilePathLink.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-211-components-FilePathLink.test.tsx
@@ -1,0 +1,196 @@
+import { PassThrough } from 'node:stream'
+import { pathToFileURL } from 'node:url'
+
+import React, { useLayoutEffect, useState } from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { FilePathLink } from '../../../src/tui/components/FilePathLink.js'
+import type { DOMElement } from '../../../src/tui/ink/dom.js'
+import instances from '../../../src/tui/ink/instances.js'
+import { createRoot } from '../../../src/tui/ink/root.js'
+import { squashTextNodesToSegments } from '../../../src/tui/ink/squash-text-nodes.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestStdout = PassThrough & {
+  columns: number
+  isTTY: boolean
+  rows: number
+}
+
+const previousForceHyperlink = process.env.FORCE_HYPERLINK
+
+afterEach(() => {
+  if (previousForceHyperlink === undefined) {
+    delete process.env.FORCE_HYPERLINK
+  } else {
+    process.env.FORCE_HYPERLINK = previousForceHyperlink
+  }
+})
+
+function createStreams(): {
+  readonly stdin: TestStdin
+  readonly stdout: TestStdout
+} {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough() as TestStdout
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 120
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function getRootNode(stdout: TestStdout): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+  if (!instance?.rootNode) {
+    throw new Error('Ink root node not found')
+  }
+
+  return instance.rootNode
+}
+
+async function sleep(ms = 25): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitForCondition(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await sleep(10)
+  }
+
+  throw new Error(message)
+}
+
+async function renderSegments(
+  node: React.ReactNode,
+  waitForRender: () => Promise<void> = () => sleep(),
+): Promise<
+  Array<{
+    readonly hyperlink?: string
+    readonly styles: Record<string, unknown>
+    readonly text: string
+  }>
+> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  try {
+    root.render(node)
+    await waitForRender()
+    return squashTextNodesToSegments(getRootNode(stdout))
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await sleep()
+  }
+}
+
+function RerenderingFilePathLink({
+  onStage,
+}: {
+  readonly onStage: (stage: number) => void
+}) {
+  const [stage, setStage] = useState(0)
+  const firstPath = '/tmp/agenc coverage/row 211 cached.ts'
+  const secondPath = '/tmp/agenc coverage/row 211 cached final.ts'
+
+  useLayoutEffect(() => {
+    onStage(stage)
+    if (stage < 3) {
+      setStage(stage + 1)
+    }
+  }, [onStage, stage])
+
+  const filePath = stage === 3 ? secondPath : firstPath
+  const label = stage < 2 ? 'stable row 211 label' : 'updated row 211 label'
+
+  return <FilePathLink filePath={filePath}>{label}</FilePathLink>
+}
+
+describe('FilePathLink coverage swarm row 211', () => {
+  test('renders file URLs with default text and falsey non-nullish children', async () => {
+    process.env.FORCE_HYPERLINK = '1'
+    const defaultPath = '/tmp/agenc coverage/row 211 report.md'
+    const zeroLabelPath = '/tmp/agenc coverage/row 211 zero label.ts'
+
+    const segments = await renderSegments(
+      <>
+        <FilePathLink filePath={defaultPath} />
+        <FilePathLink filePath={zeroLabelPath}>{0}</FilePathLink>
+      </>,
+    )
+
+    expect(
+      segments.filter(
+        segment => segment.hyperlink === pathToFileURL(defaultPath).href,
+      ),
+    ).toEqual([
+      {
+        hyperlink: pathToFileURL(defaultPath).href,
+        styles: {},
+        text: defaultPath,
+      },
+    ])
+    expect(
+      segments.filter(
+        segment => segment.hyperlink === pathToFileURL(zeroLabelPath).href,
+      ),
+    ).toEqual([
+      {
+        hyperlink: pathToFileURL(zeroLabelPath).href,
+        styles: {},
+        text: '0',
+      },
+    ])
+  })
+
+  test('rerenders stable and changed props through cached branches', async () => {
+    process.env.FORCE_HYPERLINK = '1'
+    const onStage = vi.fn()
+
+    const segments = await renderSegments(
+      <RerenderingFilePathLink onStage={onStage} />,
+      () =>
+        waitForCondition(
+          () => onStage.mock.calls.some(([stage]) => stage === 3),
+          'FilePathLink rerender stages did not complete',
+        ),
+    )
+
+    expect(onStage.mock.calls.map(([stage]) => stage)).toEqual([0, 1, 2, 3])
+    expect(segments).toEqual([
+      {
+        hyperlink: pathToFileURL(
+          '/tmp/agenc coverage/row 211 cached final.ts',
+        ).href,
+        styles: {},
+        text: 'updated row 211 label',
+      },
+    ])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-212-components-message-selector-filter.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-212-components-message-selector-filter.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import {
+  BASH_STDERR_TAG,
+  BASH_STDOUT_TAG,
+  LOCAL_COMMAND_STDERR_TAG,
+  LOCAL_COMMAND_STDOUT_TAG,
+  TASK_NOTIFICATION_TAG,
+  TEAMMATE_MESSAGE_TAG,
+  TICK_TAG,
+} from '../../../src/constants/xml.js'
+
+const messageHarness = vi.hoisted(() => ({
+  isSyntheticMessage: vi.fn(() => false),
+}))
+
+vi.mock('../../../src/utils/messages.js', () => ({
+  isSyntheticMessage: messageHarness.isSyntheticMessage,
+}))
+
+import { selectableUserMessagesFilter } from '../../../src/tui/components/message-selector-filter.js'
+
+function userMessage(
+  content: unknown,
+  overrides: Record<string, unknown> = {},
+): never {
+  return {
+    message: { content },
+    type: 'user',
+    uuid: 'user-message',
+    ...overrides,
+  } as never
+}
+
+function typedMessage(type: string, content: unknown = 'visible prompt'): never {
+  return {
+    message: { content },
+    type,
+    uuid: `${type}-message`,
+  } as never
+}
+
+describe('message selector filter coverage swarm row 212', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    messageHarness.isSyntheticMessage.mockReturnValue(false)
+  })
+
+  test('rejects message shapes that cannot be restored from the selector', () => {
+    expect(selectableUserMessagesFilter(typedMessage('assistant'))).toBe(false)
+    expect(
+      selectableUserMessagesFilter(
+        userMessage([
+          {
+            content: 'tool result',
+            tool_use_id: 'tool-1',
+            type: 'tool_result',
+          },
+        ]),
+      ),
+    ).toBe(false)
+
+    messageHarness.isSyntheticMessage.mockReturnValueOnce(true)
+    expect(selectableUserMessagesFilter(userMessage('No response requested.'))).toBe(false)
+    expect(messageHarness.isSyntheticMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'user' }),
+    )
+
+    expect(
+      selectableUserMessagesFilter(
+        userMessage('transcript-only prompt', {
+          isVisibleInTranscriptOnly: true,
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  test('uses the final text block when deciding whether array content is selectable', () => {
+    expect(
+      selectableUserMessagesFilter(
+        userMessage([
+          { text: 'earlier visible text', type: 'text' },
+          {
+            source: {
+              data: 'iVBORw0KGgo=',
+              media_type: 'image/png',
+              type: 'base64',
+            },
+            type: 'image',
+          },
+        ]),
+      ),
+    ).toBe(false)
+
+    expect(
+      selectableUserMessagesFilter(
+        userMessage([
+          {
+            source: {
+              data: 'iVBORw0KGgo=',
+              media_type: 'image/png',
+              type: 'base64',
+            },
+            type: 'image',
+          },
+          { text: '  restore this user prompt  ', type: 'text' },
+        ]),
+      ),
+    ).toBe(true)
+  })
+
+  test.each([
+    {
+      markup: `<${LOCAL_COMMAND_STDOUT_TAG}>hidden output</${LOCAL_COMMAND_STDOUT_TAG}>`,
+      tag: LOCAL_COMMAND_STDOUT_TAG,
+    },
+    {
+      markup: `<${LOCAL_COMMAND_STDERR_TAG}>hidden output</${LOCAL_COMMAND_STDERR_TAG}>`,
+      tag: LOCAL_COMMAND_STDERR_TAG,
+    },
+    {
+      markup: `<${BASH_STDOUT_TAG}>hidden output</${BASH_STDOUT_TAG}>`,
+      tag: BASH_STDOUT_TAG,
+    },
+    {
+      markup: `<${BASH_STDERR_TAG}>hidden output</${BASH_STDERR_TAG}>`,
+      tag: BASH_STDERR_TAG,
+    },
+    {
+      markup: `<${TASK_NOTIFICATION_TAG}>hidden output</${TASK_NOTIFICATION_TAG}>`,
+      tag: TASK_NOTIFICATION_TAG,
+    },
+    {
+      markup: `<${TICK_TAG}>hidden output</${TICK_TAG}>`,
+      tag: TICK_TAG,
+    },
+    {
+      markup: `<${TEAMMATE_MESSAGE_TAG} id="1">hidden output</${TEAMMATE_MESSAGE_TAG}>`,
+      tag: TEAMMATE_MESSAGE_TAG,
+    },
+  ])('rejects synthetic transcript markup tagged as $tag', ({ markup }) => {
+    expect(
+      selectableUserMessagesFilter(
+        userMessage(`before ${markup} after`),
+      ),
+    ).toBe(false)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-213-components-HelpV2-Commands.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-213-components-HelpV2-Commands.test.tsx
@@ -1,0 +1,223 @@
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { Command } from '../../../src/commands.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+
+type CapturedOption = {
+  readonly label: string
+  readonly value: string
+  readonly description?: string
+}
+
+type CapturedSelectProps = {
+  readonly options: CapturedOption[]
+  readonly visibleOptionCount: number
+  readonly onCancel: () => void
+  readonly disableSelection: boolean
+  readonly hideIndexes: boolean
+  readonly layout: string
+  readonly onUpFromFirstItem: () => void
+  readonly isDisabled: boolean
+}
+
+const harness = vi.hoisted(() => {
+  const state = {
+    focusCalls: 0,
+    headerFocused: false,
+    selectProps: [] as CapturedSelectProps[],
+  }
+
+  return {
+    state,
+    focusHeader: () => {
+      state.focusCalls += 1
+    },
+  }
+})
+
+vi.mock('../../../src/tui/components/design-system/Tabs.js', () => ({
+  useTabHeaderFocus: () => ({
+    headerFocused: harness.state.headerFocused,
+    focusHeader: harness.focusHeader,
+  }),
+}))
+
+vi.mock('../../../src/tui/components/CustomSelect/select.js', async () => {
+  const ReactModule = await import('react')
+
+  return {
+    Select: (props: CapturedSelectProps) => {
+      harness.state.selectProps.push(props)
+
+      return ReactModule.createElement(
+        ReactModule.Fragment,
+        null,
+        props.options.map(option =>
+          ReactModule.createElement(
+            'ink-text',
+            { key: option.value },
+            `${option.label}|${option.description}`,
+          ),
+        ),
+      )
+    },
+  }
+})
+
+import { Commands } from '../../../src/tui/components/HelpV2/Commands.js'
+
+function command(
+  name: string,
+  description: string,
+  overrides: Partial<Command> = {},
+): Command {
+  return {
+    type: 'prompt',
+    name,
+    description,
+    progressMessage: 'running',
+    contentLength: description.length,
+    ...overrides,
+  } as Command
+}
+
+function latestSelectProps(): CapturedSelectProps {
+  const props = harness.state.selectProps.at(-1)
+  expect(props).toBeDefined()
+  return props as CapturedSelectProps
+}
+
+describe('HelpV2 Commands coverage swarm row 213', () => {
+  beforeEach(() => {
+    harness.state.focusCalls = 0
+    harness.state.headerFocused = false
+    harness.state.selectProps = []
+  })
+
+  test('deduplicates command names, sorts by help workflow group, and forwards compact select props', async () => {
+    const onCancel = vi.fn()
+
+    const output = await renderToString(
+      <Commands
+        commands={[
+          command('zeta', 'Run zeta command', {
+            pluginInfo: { pluginManifest: { name: 'Acme' } },
+            source: 'plugin',
+          }),
+          command('provider', 'Pick provider', { source: 'bundled' }),
+          command('status', 'Check runtime status'),
+          command('status', 'Duplicate should be hidden'),
+          command('help', 'Show help'),
+        ]}
+        maxHeight={12}
+        columns={60}
+        title="Browse default commands:"
+        onCancel={onCancel}
+      />,
+      { columns: 80, rows: 20 },
+    )
+
+    const props = latestSelectProps()
+    expect(output).toContain('Browse default commands:')
+    expect(props.options.map(option => option.label)).toEqual([
+      '/status',
+      '/provider',
+      '/help',
+      '/zeta',
+    ])
+    expect(props.options.map(option => option.value)).toEqual([
+      'status',
+      'provider',
+      'help',
+      'zeta',
+    ])
+    expect(props.options[0]?.description).toBe(
+      'Session - Check runtime status',
+    )
+    expect(props.options[1]?.description).toBe(
+      'Model / Provider - Pick provider (bundled)',
+    )
+    expect(props.options[3]?.description).toBe(
+      'Other Commands - (Acme) Run zeta command',
+    )
+    expect(output).not.toContain('Duplicate should be hidden')
+    expect(props.visibleOptionCount).toBe(4)
+    expect(props.disableSelection).toBe(true)
+    expect(props.hideIndexes).toBe(true)
+    expect(props.layout).toBe('compact-vertical')
+    expect(props.isDisabled).toBe(false)
+
+    props.onUpFromFirstItem()
+    props.onCancel()
+    expect(harness.state.focusCalls).toBe(1)
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  test('passes the header-focused disabled state through to Select', async () => {
+    harness.state.headerFocused = true
+
+    await renderToString(
+      <Commands
+        commands={[command('help', 'Show help')]}
+        maxHeight={8}
+        columns={40}
+        title="Browse commands:"
+        onCancel={() => {}}
+      />,
+      { columns: 60, rows: 12 },
+    )
+
+    expect(latestSelectProps().isDisabled).toBe(true)
+  })
+
+  test('renders the empty message without mounting Select when commands are absent', async () => {
+    const output = await renderToString(
+      <Commands
+        commands={[]}
+        maxHeight={8}
+        columns={40}
+        title="Hidden title"
+        emptyMessage="No custom commands found"
+        onCancel={() => {}}
+      />,
+      { columns: 60, rows: 12 },
+    )
+
+    expect(output).toContain('No custom commands found')
+    expect(output).not.toContain('Hidden title')
+    expect(harness.state.selectProps).toHaveLength(0)
+  })
+
+  test('shows the too-small terminal message instead of Select when no options fit', async () => {
+    const output = await renderToString(
+      <Commands
+        commands={[command('help', 'Show help')]}
+        maxHeight={5}
+        columns={40}
+        title="Browse commands:"
+        onCancel={() => {}}
+      />,
+      { columns: 60, rows: 8 },
+    )
+
+    expect(output).toContain('Browse commands:')
+    expect(output).toContain('Terminal too small to browse commands')
+    expect(harness.state.selectProps).toHaveLength(0)
+  })
+
+  test('clamps narrow command columns before truncating descriptions', async () => {
+    await renderToString(
+      <Commands
+        commands={[command('help', 'Show help with a long description')]}
+        maxHeight={8}
+        columns={4}
+        title="Browse commands:"
+        onCancel={() => {}}
+      />,
+      { columns: 30, rows: 12 },
+    )
+
+    expect(latestSelectProps().options[0]?.description).toHaveLength(1)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-214-components-dialogs-RateLimitMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-214-components-dialogs-RateLimitMessage.test.tsx
@@ -1,0 +1,189 @@
+import type { ReactNode } from 'react'
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const originalDisableExtraUsageCommand =
+  process.env.DISABLE_EXTRA_USAGE_COMMAND
+
+type LimitSnapshot = {
+  readonly status: string
+  readonly resetsAt?: number
+  readonly isUsingOverage: boolean
+}
+
+const harness = vi.hoisted(() => ({
+  hasBillingAccess: false,
+  isAgenCAISubscriber: vi.fn(() => true),
+  isNonInteractive: false,
+  limits: {
+    status: 'accepted',
+    resetsAt: undefined,
+    isUsingOverage: false,
+  } as LimitSnapshot,
+  overageAllowed: true,
+  rateLimitTier: null as string | null,
+  shouldProcessMockLimits: false,
+  subscriptionType: 'pro' as string | null,
+}))
+
+vi.mock('../../../src/bootstrap/state.js', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('../../../src/bootstrap/state.js')>()
+
+  return {
+    ...actual,
+    getIsNonInteractiveSession: () => harness.isNonInteractive,
+  }
+})
+
+vi.mock('../../../src/services/rateLimitMocking.js', () => ({
+  shouldProcessMockLimits: () => harness.shouldProcessMockLimits,
+}))
+
+vi.mock('../../../src/tui/rate-limits/agenc-ai-limits.js', () => ({
+  useAgenCAiLimits: () => harness.limits,
+}))
+
+vi.mock('../../../src/utils/auth.js', () => ({
+  getRateLimitTier: () => harness.rateLimitTier,
+  getSubscriptionType: () => harness.subscriptionType,
+  isAgenCAISubscriber: harness.isAgenCAISubscriber,
+  isOverageProvisioningAllowed: () => harness.overageAllowed,
+}))
+
+vi.mock('../../../src/utils/billing.js', () => ({
+  hasAgenCAiBillingAccess: () => harness.hasBillingAccess,
+}))
+
+vi.mock('../../../src/tui/components/MessageResponse.js', async () => {
+  const ReactActual = await vi.importActual<typeof import('react')>('react')
+
+  return {
+    MessageResponse: ({ children }: { readonly children: ReactNode }) =>
+      ReactActual.createElement(ReactActual.Fragment, null, children),
+  }
+})
+
+import {
+  getUpsellMessage,
+  RateLimitMessage,
+} from '../../../src/tui/components/dialogs/RateLimitMessage.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+
+function restoreEnv(): void {
+  if (originalDisableExtraUsageCommand === undefined) {
+    delete process.env.DISABLE_EXTRA_USAGE_COMMAND
+    return
+  }
+
+  process.env.DISABLE_EXTRA_USAGE_COMMAND =
+    originalDisableExtraUsageCommand
+}
+
+async function renderRateLimitMessage(
+  props: Partial<React.ComponentProps<typeof RateLimitMessage>> = {},
+): Promise<string> {
+  return renderToString(
+    <RateLimitMessage text="Rate limit reached" {...props} />,
+    { columns: 100 },
+  )
+}
+
+describe('RateLimitMessage coverage swarm row 214', () => {
+  beforeEach(() => {
+    restoreEnv()
+    harness.hasBillingAccess = false
+    harness.isAgenCAISubscriber.mockReset()
+    harness.isAgenCAISubscriber.mockReturnValue(true)
+    harness.isNonInteractive = false
+    harness.limits = {
+      status: 'accepted',
+      resetsAt: undefined,
+      isUsingOverage: false,
+    }
+    harness.overageAllowed = true
+    harness.rateLimitTier = null
+    harness.shouldProcessMockLimits = false
+    harness.subscriptionType = 'pro'
+  })
+
+  afterEach(() => {
+    restoreEnv()
+  })
+
+  test('returns combined upgrade and extra-usage copy for non-team accounts with extra usage enabled', () => {
+    expect(
+      getUpsellMessage({
+        hasBillingAccess: false,
+        isExtraUsageCommandEnabled: true,
+        isMax20x: false,
+        isTeamOrEnterprise: false,
+        shouldAutoOpenRateLimitOptionsMenu: false,
+        shouldShowUpsell: true,
+      }),
+    ).toContain('/upgrade or /extra-usage')
+  })
+
+  test('uses mock limit processing as a subscriber substitute without checking subscriber state', async () => {
+    harness.shouldProcessMockLimits = true
+    harness.isAgenCAISubscriber.mockReturnValue(false)
+
+    const output = await renderRateLimitMessage()
+
+    expect(output).toContain('Rate limit reached')
+    expect(output).toContain('/upgrade or /extra-usage')
+    expect(harness.isAgenCAISubscriber).not.toHaveBeenCalled()
+  })
+
+  test('hides extra-usage guidance when the command is disabled or the session is non-interactive', async () => {
+    process.env.DISABLE_EXTRA_USAGE_COMMAND = '1'
+
+    const disabledByEnvOutput = await renderRateLimitMessage()
+
+    expect(disabledByEnvOutput).toContain(
+      '/upgrade to increase your usage limit.',
+    )
+    expect(disabledByEnvOutput).not.toContain('/extra-usage')
+
+    restoreEnv()
+    harness.isNonInteractive = true
+
+    const nonInteractiveOutput = await renderRateLimitMessage()
+
+    expect(nonInteractiveOutput).toContain(
+      '/upgrade to increase your usage limit.',
+    )
+    expect(nonInteractiveOutput).not.toContain('/extra-usage')
+  })
+
+  test('does not auto-open options without a reset time or while already using overage', async () => {
+    const onOpenRateLimitOptions = vi.fn()
+    harness.limits = {
+      status: 'rejected',
+      resetsAt: undefined,
+      isUsingOverage: false,
+    }
+
+    const missingResetOutput = await renderRateLimitMessage({
+      onOpenRateLimitOptions,
+    })
+
+    expect(missingResetOutput).toContain('/upgrade or /extra-usage')
+    expect(missingResetOutput).not.toContain('Opening your options')
+    expect(onOpenRateLimitOptions).not.toHaveBeenCalled()
+
+    harness.limits = {
+      status: 'rejected',
+      resetsAt: Date.now() + 60_000,
+      isUsingOverage: true,
+    }
+
+    const overageOutput = await renderRateLimitMessage({
+      onOpenRateLimitOptions,
+    })
+
+    expect(overageOutput).toContain('/upgrade or /extra-usage')
+    expect(overageOutput).not.toContain('Opening your options')
+    expect(onOpenRateLimitOptions).not.toHaveBeenCalled()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-215-components-tasks-BackgroundTaskStatus-layout.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-215-components-tasks-BackgroundTaskStatus-layout.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  getTeammateFooterLayout,
+  TEAMMATE_FOOTER_EXPAND_HINT_COLUMNS,
+  TEAMMATE_FOOTER_SCROLL_ARROW_COLUMNS,
+} from "../../../src/tui/components/tasks/BackgroundTaskStatus.layout.js";
+
+function renderedColumns(
+  layout: ReturnType<typeof getTeammateFooterLayout>,
+): number {
+  const pillColumns = layout.visiblePillWidths.reduce(
+    (sum, width) => sum + width,
+    0,
+  );
+  const separatorColumns = Math.max(0, layout.visiblePillWidths.length - 1);
+  const arrowColumns =
+    (layout.showLeftArrow ? TEAMMATE_FOOTER_SCROLL_ARROW_COLUMNS : 0) +
+    (layout.showRightArrow ? TEAMMATE_FOOTER_SCROLL_ARROW_COLUMNS : 0);
+  const hintColumns = layout.showExpandHint
+    ? TEAMMATE_FOOTER_EXPAND_HINT_COLUMNS
+    : 0;
+
+  return pillColumns + separatorColumns + arrowColumns + hintColumns;
+}
+
+describe("BackgroundTaskStatus layout coverage swarm row 215", () => {
+  test("normalizes empty footer widths before deciding whether to reserve the expand hint", () => {
+    expect(
+      getTeammateFooterLayout([], Number.POSITIVE_INFINITY, 99),
+    ).toEqual({
+      startIndex: 0,
+      endIndex: 0,
+      showLeftArrow: false,
+      showRightArrow: false,
+      showExpandHint: false,
+      visiblePillWidths: [],
+    });
+
+    expect(
+      getTeammateFooterLayout([], TEAMMATE_FOOTER_EXPAND_HINT_COLUMNS + 4.9, -1),
+    ).toEqual({
+      startIndex: 0,
+      endIndex: 0,
+      showLeftArrow: false,
+      showRightArrow: false,
+      showExpandHint: true,
+      visiblePillWidths: [],
+    });
+  });
+
+  test("clamps selections to the visible edge and removes leading separators from scrolled pills", () => {
+    const leftEdge = getTeammateFooterLayout([9, 9, 9], 10, -12);
+    expect(leftEdge).toEqual({
+      startIndex: 0,
+      endIndex: 1,
+      showLeftArrow: false,
+      showRightArrow: true,
+      showExpandHint: false,
+      visiblePillWidths: [8],
+    });
+    expect(renderedColumns(leftEdge)).toBeLessThanOrEqual(10);
+
+    const rightEdge = getTeammateFooterLayout([5, 6, 7, 8], 12, 99);
+    expect(rightEdge).toEqual({
+      startIndex: 3,
+      endIndex: 4,
+      showLeftArrow: true,
+      showRightArrow: false,
+      showExpandHint: false,
+      visiblePillWidths: [7],
+    });
+    expect(renderedColumns(rightEdge)).toBeLessThanOrEqual(12);
+  });
+
+  test("suppresses both scroll arrows when a one-column row cannot fit them", () => {
+    const layout = getTeammateFooterLayout([8, 8, 8], 1, 1);
+
+    expect(layout).toEqual({
+      startIndex: 1,
+      endIndex: 2,
+      showLeftArrow: false,
+      showRightArrow: false,
+      showExpandHint: false,
+      visiblePillWidths: [1],
+    });
+    expect(renderedColumns(layout)).toBe(1);
+  });
+
+  test("coerces non-positive pill widths to one column without shrinking below one", () => {
+    const layout = getTeammateFooterLayout([0, -2, 0], 3, 0);
+
+    expect(layout).toEqual({
+      startIndex: 0,
+      endIndex: 1,
+      showLeftArrow: false,
+      showRightArrow: true,
+      showExpandHint: false,
+      visiblePillWidths: [1],
+    });
+    expect(renderedColumns(layout)).toBeLessThanOrEqual(3);
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-216-ink-events-emitter.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-216-ink-events-emitter.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'vitest'
+
+import { Event } from '../../../src/tui/ink/events/event.ts'
+import { EventEmitter } from '../../../src/tui/ink/events/emitter.ts'
+
+describe('EventEmitter coverage swarm row 216', () => {
+  test('disables max listener warnings for many input subscribers', () => {
+    const emitter = new EventEmitter()
+
+    expect(emitter.getMaxListeners()).toBe(0)
+  })
+
+  test('returns false when a normal event has no listeners', () => {
+    const emitter = new EventEmitter()
+
+    expect(emitter.emit('keypress', 'x')).toBe(false)
+  })
+
+  test('calls normal listeners with the emitter context and payload', () => {
+    const emitter = new EventEmitter()
+    const calls: Array<{ self: EventEmitter; value: string }> = []
+
+    emitter.on('keypress', function (this: EventEmitter, value: string) {
+      calls.push({ self: this, value })
+    })
+    emitter.on('keypress', function (this: EventEmitter, value: string) {
+      calls.push({ self: this, value: value.toUpperCase() })
+    })
+
+    expect(emitter.emit('keypress', 'a')).toBe(true)
+    expect(calls).toEqual([
+      { self: emitter, value: 'a' },
+      { self: emitter, value: 'A' },
+    ])
+  })
+
+  test('stops dispatching Event instances after immediate propagation is stopped', () => {
+    const emitter = new EventEmitter()
+    const event = new Event()
+    const calls: string[] = []
+
+    emitter.on('keypress', (received) => {
+      expect(received).toBe(event)
+      calls.push('first')
+      event.stopImmediatePropagation()
+    })
+    emitter.on('keypress', () => {
+      calls.push('second')
+    })
+
+    expect(emitter.emit('keypress', event)).toBe(true)
+    expect(calls).toEqual(['first'])
+  })
+
+  test('preserves once listeners while using raw listener dispatch', () => {
+    const emitter = new EventEmitter()
+    const calls: string[] = []
+
+    emitter.once('resize', () => {
+      calls.push('once')
+    })
+
+    expect(emitter.emit('resize')).toBe(true)
+    expect(emitter.emit('resize')).toBe(false)
+    expect(calls).toEqual(['once'])
+  })
+
+  test('delegates error events to the node emitter semantics', () => {
+    const emitter = new EventEmitter()
+    const error = new Error('boom')
+    const seen: Error[] = []
+
+    emitter.on('error', (received) => {
+      seen.push(received)
+    })
+
+    expect(emitter.emit('error', error)).toBe(true)
+    expect(seen).toEqual([error])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-217-ink-native-ts-file-index-index.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-217-ink-native-ts-file-index-index.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'vitest'
+
+import { FileIndex } from '../../../src/tui/ink/native-ts/file-index/index.js'
+
+describe('coverage swarm row 217 file index', () => {
+  test('handles windows separators and root-only empty top-level segments', () => {
+    const index = new FileIndex()
+
+    index.loadFromFileList([
+      '',
+      '/absolute/file.ts',
+      '\\rooted\\file.ts',
+      'zeta\\leaf.ts',
+      'aa\\win.ts',
+      'aa\\win.ts',
+      'bb/file.ts',
+      'a/file.ts',
+    ])
+
+    expect(index.search('', 10)).toEqual([
+      { path: 'a', score: 0 },
+      { path: 'aa', score: 0 },
+      { path: 'bb', score: 0 },
+      { path: 'zeta', score: 0 },
+    ])
+    expect(index.search('', 2)).toEqual([
+      { path: 'a', score: 0 },
+      { path: 'aa', score: 0 },
+    ])
+  })
+
+  test('matches every boundary form and keeps uppercase queries case-sensitive', () => {
+    const index = new FileIndex()
+
+    index.loadFromFileList([
+      'src/ab.ts',
+      'src/a/b.ts',
+      'src/a\\b.ts',
+      'src/a-b.ts',
+      'src/a_b.ts',
+      'src/a.b.ts',
+      'src/a b.ts',
+      'src/axb.ts',
+      'src/aB.ts',
+      'src/ba.ts',
+    ])
+
+    const paths = index.search('ab', 20).map(result => result.path)
+
+    expect(paths).toEqual(
+      expect.arrayContaining([
+        'src/ab.ts',
+        'src/a/b.ts',
+        'src/a\\b.ts',
+        'src/a-b.ts',
+        'src/a_b.ts',
+        'src/a.b.ts',
+        'src/a b.ts',
+        'src/axb.ts',
+      ]),
+    )
+    expect(paths).not.toContain('src/ba.ts')
+    expect(index.search('aB', 10).map(result => result.path)).toEqual([
+      'src/aB.ts',
+    ])
+  })
+
+  test('replaces weaker top-k entries and rejects paths with missing or misordered matches', () => {
+    const replacementIndex = new FileIndex()
+    replacementIndex.loadFromFileList(['src/a-x-b.ts', 'src/ab.ts'])
+
+    expect(replacementIndex.search('ab', 1)).toEqual([
+      { path: 'src/ab.ts', score: 0 },
+    ])
+
+    const rejectionIndex = new FileIndex()
+    rejectionIndex.loadFromFileList([
+      'src/abc.ts',
+      'src/acb.ts',
+      'src/zzz.ts',
+      `src/a${'x'.repeat(80)}b${'x'.repeat(80)}c.ts`,
+    ])
+
+    expect(rejectionIndex.search('abc', 1)).toEqual([
+      { path: 'src/abc.ts', score: 0 },
+    ])
+    expect(rejectionIndex.search('abc', 10).map(result => result.path)).not.toContain(
+      'src/acb.ts',
+    )
+    expect(rejectionIndex.search('1', 10)).toEqual([])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-218-realtime-commands.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-218-realtime-commands.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type { AgenCRealtimeTuiControls } from "../../../src/tui/realtime/controller.js";
+import {
+  executeRealtimeComposerCommand,
+  parseRealtimeComposerCommand,
+} from "../../../src/tui/realtime/commands.js";
+
+function createControls(
+  phase: ReturnType<AgenCRealtimeTuiControls["getState"]>["phase"] =
+    "inactive",
+): AgenCRealtimeTuiControls {
+  return {
+    start: vi.fn(async () => {}),
+    stop: vi.fn(async () => {}),
+    appendText: vi.fn(async () => {}),
+    appendAudio: vi.fn(async () => {}),
+    setMuted: vi.fn(),
+    setPushToTalk: vi.fn(),
+    setPushToTalkHeld: vi.fn(),
+    getState: vi.fn(() => ({ phase })),
+    subscribe: vi.fn(),
+    handleTranscriptEvent: vi.fn(),
+  } as unknown as AgenCRealtimeTuiControls;
+}
+
+describe("realtime composer commands coverage swarm row 218", () => {
+  test("parses command aliases and rejects empty text payloads", () => {
+    expect(parseRealtimeComposerCommand("  /realtime start  ")).toEqual({
+      kind: "start",
+      transport: "websocket",
+    });
+    expect(parseRealtimeComposerCommand("/realtime stop")).toEqual({
+      kind: "stop",
+    });
+    expect(parseRealtimeComposerCommand("/realtime mute")).toEqual({
+      kind: "mute",
+      muted: true,
+    });
+    expect(parseRealtimeComposerCommand("/realtime unmute")).toEqual({
+      kind: "mute",
+      muted: false,
+    });
+    expect(parseRealtimeComposerCommand("/realtime ptt")).toEqual({
+      kind: "push_to_talk",
+      enabled: true,
+    });
+    expect(parseRealtimeComposerCommand("/realtime ptt off")).toEqual({
+      kind: "push_to_talk",
+      enabled: false,
+    });
+    expect(parseRealtimeComposerCommand("/realtime ptt release")).toEqual({
+      kind: "push_to_talk_held",
+      held: false,
+    });
+    expect(parseRealtimeComposerCommand("/realtime text      ")).toBeNull();
+    expect(parseRealtimeComposerCommand("/realtime-status")).toBeNull();
+  });
+
+  test("executes websocket start and push-to-talk aliases", async () => {
+    const controls = createControls();
+
+    await expect(
+      executeRealtimeComposerCommand(controls, "/realtime start"),
+    ).resolves.toBe(true);
+    expect(controls.start).toHaveBeenCalledWith({ transport: "websocket" });
+
+    await expect(
+      executeRealtimeComposerCommand(controls, "/realtime ptt"),
+    ).resolves.toBe(true);
+    expect(controls.setPushToTalk).toHaveBeenCalledWith(true);
+
+    await expect(
+      executeRealtimeComposerCommand(controls, "/realtime ptt off"),
+    ).resolves.toBe(true);
+    expect(controls.setPushToTalk).toHaveBeenCalledWith(false);
+
+    await expect(
+      executeRealtimeComposerCommand(controls, "/realtime ptt release"),
+    ).resolves.toBe(true);
+    expect(controls.setPushToTalkHeld).toHaveBeenCalledWith(false);
+  });
+
+  test("toggles inactive controls on and active controls off", async () => {
+    const inactiveControls = createControls("inactive");
+    await expect(
+      executeRealtimeComposerCommand(inactiveControls, "/realtime"),
+    ).resolves.toBe(true);
+    expect(inactiveControls.start).toHaveBeenCalledWith({
+      transport: "websocket",
+    });
+    expect(inactiveControls.stop).not.toHaveBeenCalled();
+
+    const activeControls = createControls("active");
+    await expect(
+      executeRealtimeComposerCommand(activeControls, "/realtime"),
+    ).resolves.toBe(true);
+    expect(activeControls.stop).toHaveBeenCalledTimes(1);
+    expect(activeControls.start).not.toHaveBeenCalled();
+  });
+
+  test("leaves non-realtime input and missing controls unhandled", async () => {
+    const controls = createControls();
+
+    await expect(
+      executeRealtimeComposerCommand(controls, "/realtime-status"),
+    ).resolves.toBe(false);
+    expect(controls.start).not.toHaveBeenCalled();
+    expect(controls.stop).not.toHaveBeenCalled();
+
+    await expect(
+      executeRealtimeComposerCommand(undefined, "/realtime mute"),
+    ).resolves.toBe(false);
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-219-components-CtrlOToExpand.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-219-components-CtrlOToExpand.test.tsx
@@ -1,0 +1,154 @@
+import React from 'react'
+import stripAnsi from 'strip-ansi'
+import { describe, expect, test, vi } from 'vitest'
+
+const shortcutMocks = vi.hoisted(() => ({
+  getShortcutDisplay: vi.fn(() => 'ctrl+alt+o'),
+}))
+
+vi.mock('../../../src/tui/keybindings/shortcutFormat.js', () => ({
+  getShortcutDisplay: shortcutMocks.getShortcutDisplay,
+}))
+
+import { renderToString } from '../../../src/utils/staticRender.js'
+import { Box, Text } from '../../../src/tui/ink.js'
+import { KeybindingProvider } from '../../../src/tui/keybindings/KeybindingContext.js'
+import { parseBindings } from '../../../src/tui/keybindings/parser.js'
+import type {
+  KeybindingContextName,
+  ParsedKeystroke,
+} from '../../../src/tui/keybindings/types.js'
+import {
+  CtrlOToExpand,
+  SubAgentProvider,
+  ctrlOToExpand,
+} from '../../../src/tui/components/CtrlOToExpand.js'
+import { InVirtualListContext } from '../../../src/tui/components/messageActions.js'
+
+describe('CtrlOToExpand coverage swarm 219', () => {
+  test('uses configured transcript shortcut text when keybindings are available', async () => {
+    const output = await renderToString(
+      <ConfiguredKeybindings>
+        <Box flexDirection="column">
+          <Box>
+            <Text>configured </Text>
+            <CtrlOToExpand />
+          </Box>
+          <Box>
+            <Text>subagent </Text>
+            <SubAgentProvider>
+              <CtrlOToExpand />
+            </SubAgentProvider>
+          </Box>
+          <InVirtualListContext.Provider value={true}>
+            <Box>
+              <Text>virtual </Text>
+              <CtrlOToExpand />
+            </Box>
+          </InVirtualListContext.Provider>
+        </Box>
+      </ConfiguredKeybindings>,
+      100,
+    )
+
+    expect(output).toContain('configured (ctrl+shift+o to expand)')
+    expect(output).toContain('subagent')
+    expect(output).toContain('virtual')
+    expect(output).not.toContain('(ctrl+o to expand)')
+    expect(output.match(/\bto expand\b/g) ?? []).toHaveLength(1)
+  })
+
+  test('falls back inside a provider with no matching transcript binding', async () => {
+    const output = await renderToString(
+      <ConfiguredKeybindings action="chat:submit">
+        <CtrlOToExpand />
+      </ConfiguredKeybindings>,
+      80,
+    )
+
+    expect(output).toContain('(ctrl+o to expand)')
+  })
+
+  test('keeps rerendered hint output stable and formats the non-React helper', async () => {
+    const output = await renderToString(
+      <ConfiguredKeybindings>
+        <RerenderProbe />
+      </ConfiguredKeybindings>,
+      100,
+    )
+
+    expect(output).toContain('rerender (ctrl+shift+o to expand)')
+    expect(output.match(/\bto expand\b/g) ?? []).toHaveLength(1)
+    expect(stripAnsi(ctrlOToExpand())).toBe('(ctrl+alt+o to expand)')
+    expect(shortcutMocks.getShortcutDisplay).toHaveBeenCalledWith(
+      'app:toggleTranscript',
+      'Global',
+      'ctrl+o',
+    )
+  })
+})
+
+function ConfiguredKeybindings({
+  action = 'app:toggleTranscript',
+  children,
+}: {
+  readonly action?: string
+  readonly children: React.ReactNode
+}): React.ReactElement {
+  const activeContexts = React.useMemo(() => new Set<KeybindingContextName>(), [])
+  const handlerRegistryRef = React.useRef(new Map())
+  const pendingChordRef = React.useRef<ParsedKeystroke[] | null>(null)
+  const [pendingChord, setPendingChordState] =
+    React.useState<ParsedKeystroke[] | null>(null)
+  const bindings = React.useMemo(
+    () =>
+      parseBindings([
+        {
+          context: 'Global',
+          bindings: {
+            'ctrl+shift+o': action,
+          },
+        },
+      ]),
+    [action],
+  )
+  const setPendingChord = React.useCallback(
+    (pending: ParsedKeystroke[] | null) => {
+      pendingChordRef.current = pending
+      setPendingChordState(pending)
+    },
+    [],
+  )
+
+  return (
+    <KeybindingProvider
+      activeContexts={activeContexts}
+      bindings={bindings}
+      handlerRegistryRef={handlerRegistryRef}
+      pendingChord={pendingChord}
+      pendingChordRef={pendingChordRef}
+      registerActiveContext={context => activeContexts.add(context)}
+      setPendingChord={setPendingChord}
+      unregisterActiveContext={context => activeContexts.delete(context)}
+    >
+      {children}
+    </KeybindingProvider>
+  )
+}
+
+function RerenderProbe(): React.ReactElement {
+  const [, forceRerender] = React.useState(0)
+  const stableSubAgentChild = React.useMemo(() => <CtrlOToExpand />, [])
+
+  React.useLayoutEffect(() => {
+    forceRerender(1)
+  }, [])
+
+  return (
+    <Box>
+      <Text>rerender </Text>
+      <CtrlOToExpand />
+      <SubAgentProvider>{stableSubAgentChild}</SubAgentProvider>
+    </Box>
+  )
+}

--- a/runtime/tests/tui/coverage-swarm/swarm-220-components-PromptInput-inputPaste.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-220-components-PromptInput-inputPaste.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'vitest'
+
+import type { PastedContent } from '../../../src/utils/config.js'
+import {
+  maybeTruncateInput,
+  maybeTruncateMessageForInput,
+} from '../../../src/tui/components/PromptInput/inputPaste.js'
+
+const truncationThreshold = 10_000
+const previewHalfLength = 500
+
+function oversizedInput({
+  middle = 'm'.repeat(truncationThreshold - previewHalfLength * 2 + 1),
+  prefix = 'S'.repeat(previewHalfLength),
+  suffix = 'E'.repeat(previewHalfLength),
+}: {
+  middle?: string
+  prefix?: string
+  suffix?: string
+} = {}): string {
+  return `${prefix}${middle}${suffix}`
+}
+
+describe('maybeTruncateMessageForInput', () => {
+  test('leaves input at the truncation threshold untouched', () => {
+    const input = 'a'.repeat(truncationThreshold)
+
+    expect(maybeTruncateMessageForInput(input, 7)).toEqual({
+      truncatedText: input,
+      placeholderContent: '',
+    })
+  })
+
+  test('keeps start and end previews while moving the middle into placeholder content', () => {
+    const middle = `one\ntwo\r\nthree\rfour${'m'.repeat(9_000)}`
+    const input = oversizedInput({ middle })
+
+    const result = maybeTruncateMessageForInput(input, 42)
+
+    expect(result.placeholderContent).toBe(middle)
+    expect(result.truncatedText).toBe(
+      `${'S'.repeat(previewHalfLength)}[...Truncated text #42 +3 lines...]${'E'.repeat(previewHalfLength)}`,
+    )
+  })
+})
+
+describe('maybeTruncateInput', () => {
+  test('returns the original input and pasted content object when no truncation is needed', () => {
+    const pastedContents: Record<number, PastedContent> = {
+      3: {
+        id: 3,
+        type: 'text',
+        content: 'existing paste',
+      },
+    }
+
+    const result = maybeTruncateInput('short prompt', pastedContents)
+
+    expect(result).toEqual({
+      newInput: 'short prompt',
+      newPastedContents: pastedContents,
+    })
+    expect(result.newPastedContents).toBe(pastedContents)
+  })
+
+  test('adds truncated content under the next id after existing pasted content', () => {
+    const pastedContents: Record<number, PastedContent> = {
+      2: {
+        id: 2,
+        type: 'text',
+        content: 'first paste',
+      },
+      9: {
+        id: 9,
+        type: 'image',
+        content: 'image-bytes',
+        mediaType: 'image/png',
+      },
+    }
+    const middle = 'hidden'.repeat(1_600)
+    const input = oversizedInput({ middle })
+
+    const result = maybeTruncateInput(input, pastedContents)
+
+    expect(result.newInput).toBe(
+      `${'S'.repeat(previewHalfLength)}[...Truncated text #10 +0 lines...]${'E'.repeat(previewHalfLength)}`,
+    )
+    expect(result.newPastedContents).toEqual({
+      ...pastedContents,
+      10: {
+        id: 10,
+        type: 'text',
+        content: middle,
+      },
+    })
+    expect(result.newPastedContents[2]).toBe(pastedContents[2])
+    expect(result.newPastedContents[9]).toBe(pastedContents[9])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-221-components-design-system-Pane.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-221-components-design-system-Pane.test.tsx
@@ -1,0 +1,180 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { Pane } from '../../../src/tui/components/design-system/Pane.js'
+import { ModalContext } from '../../../src/tui/context/modalContext.js'
+import type { DOMElement, DOMNode } from '../../../src/tui/ink/dom.js'
+import instances from '../../../src/tui/ink/instances.js'
+import { createRoot } from '../../../src/tui/ink/root.js'
+import { Text } from '../../../src/tui/ink.js'
+import { getTheme } from '../../../src/utils/theme.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestStdout = PassThrough & {
+  columns: number
+  isTTY: boolean
+  rows: number
+}
+
+type MountedRoot = {
+  root: Awaited<ReturnType<typeof createRoot>>
+  stdin: TestStdin
+  stdout: TestStdout
+}
+
+const mountedRoots: MountedRoot[] = []
+
+function createStreams(): { stdin: TestStdin; stdout: TestStdout } {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough() as TestStdout
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 20
+  stdout.rows = 10
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < 2_000) {
+    if (predicate()) return
+    await sleep(10)
+  }
+
+  throw new Error(message)
+}
+
+function getRootNode(stdout: TestStdout): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+
+  if (!instance?.rootNode) {
+    throw new Error('Ink root node not found')
+  }
+
+  return instance.rootNode
+}
+
+function requireElementChild(node: DOMElement, index: number): DOMElement {
+  const child = node.childNodes[index]
+
+  if (!child || child.nodeName === '#text') {
+    throw new Error(`Expected element child at index ${index}`)
+  }
+
+  return child
+}
+
+function collectText(node: DOMNode): string {
+  if (node.nodeName === '#text') return node.nodeValue
+
+  return node.childNodes.map(collectText).join('')
+}
+
+async function renderPane(node: React.ReactNode): Promise<{
+  rootNode: () => DOMElement
+}> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  mountedRoots.push({ root, stdin, stdout })
+  root.render(node)
+
+  await waitFor(
+    () => getRootNode(stdout).childNodes.length > 0,
+    'Pane did not mount',
+  )
+
+  return {
+    rootNode: () => getRootNode(stdout),
+  }
+}
+
+afterEach(() => {
+  for (const { root, stdin, stdout } of mountedRoots.splice(0)) {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    instances.delete(stdout as unknown as NodeJS.WriteStream)
+  }
+})
+
+describe('Pane coverage swarm row 221', () => {
+  test('renders a top divider and padded content outside the modal slot', async () => {
+    const rendered = await renderPane(
+      <Pane color="permission">
+        <Text>Outside child</Text>
+      </Pane>,
+    )
+    const theme = getTheme('dark')
+    const paneBox = requireElementChild(rendered.rootNode(), 0)
+    const divider = requireElementChild(paneBox, 0)
+    const content = requireElementChild(paneBox, 1)
+
+    expect(paneBox.style).toMatchObject({
+      flexDirection: 'column',
+      paddingTop: 1,
+    })
+    expect(paneBox.childNodes).toHaveLength(2)
+    expect(divider.nodeName).toBe('ink-text')
+    expect(divider.textStyles).toMatchObject({ color: theme.permission })
+    expect(collectText(divider)).toHaveLength(20)
+    expect(content.style).toMatchObject({
+      flexDirection: 'column',
+      paddingX: 2,
+    })
+    expect(collectText(content)).toBe('Outside child')
+  })
+
+  test('suppresses the divider and uses modal padding inside the modal slot', async () => {
+    const rendered = await renderPane(
+      <ModalContext.Provider
+        value={{
+          columns: 20,
+          rows: 10,
+          scrollRef: { current: null },
+        }}
+      >
+        <Pane color="permission">
+          <Text>Modal child</Text>
+        </Pane>
+      </ModalContext.Provider>,
+    )
+    const modalBox = requireElementChild(rendered.rootNode(), 0)
+
+    expect(modalBox.style).toMatchObject({
+      flexDirection: 'column',
+      flexShrink: 0,
+      paddingX: 1,
+    })
+    expect(modalBox.style).not.toHaveProperty('paddingTop')
+    expect(modalBox.childNodes).toHaveLength(1)
+    expect(collectText(modalBox)).toBe('Modal child')
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-222-hooks-useTasksV2.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-222-hooks-useTasksV2.test.ts
@@ -1,0 +1,334 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { Task } from '../../../src/utils/tasks.js'
+
+type AppStateFixture = {
+  expandedView: 'none' | 'tasks' | 'teammates'
+  teamContext?: { leadAgentId: string; teamName: string }
+}
+
+type ManualTimer = {
+  active: boolean
+  callback: () => void
+  delay: number
+  unref: ReturnType<typeof vi.fn>
+}
+
+type SubscriptionRecord = {
+  getSnapshot: () => unknown
+  snapshots: unknown[]
+  unsubscribe: () => void
+}
+
+type WatcherRecord = {
+  close: ReturnType<typeof vi.fn>
+  dir: string
+  listener: () => void
+  unref: ReturnType<typeof vi.fn>
+}
+
+const fixture = vi.hoisted(() => {
+  const state = {
+    appState: {
+      expandedView: 'none',
+      teamContext: undefined,
+    } as AppStateFixture,
+    enabled: true,
+    isLead: true,
+    subscriptions: [] as SubscriptionRecord[],
+    taskListId: 'list-a',
+    taskListeners: new Set<() => void>(),
+    tasksByList: new Map<string, Task[]>(),
+    watchers: [] as WatcherRecord[],
+  }
+
+  const listTasks = vi.fn(async (taskListId: string) => {
+    return state.tasksByList.get(taskListId) ?? []
+  })
+
+  const onTasksUpdated = vi.fn((listener: () => void) => {
+    state.taskListeners.add(listener)
+    return vi.fn(() => {
+      state.taskListeners.delete(listener)
+    })
+  })
+
+  const resetTaskList = vi.fn(async (taskListId: string) => {
+    state.tasksByList.set(taskListId, [])
+  })
+
+  const setAppState = vi.fn(
+    (
+      updater:
+        | AppStateFixture
+        | ((previous: AppStateFixture) => AppStateFixture),
+    ) => {
+      state.appState =
+        typeof updater === 'function' ? updater(state.appState) : updater
+    },
+  )
+
+  const useSyncExternalStore = vi.fn(
+    (
+      subscribe: (listener: () => void) => () => void,
+      getSnapshot: () => unknown,
+    ) => {
+      const record: SubscriptionRecord = {
+        getSnapshot,
+        snapshots: [],
+        unsubscribe: () => {},
+      }
+      record.unsubscribe = subscribe(() => {
+        record.snapshots.push(getSnapshot())
+      })
+      record.snapshots.push(getSnapshot())
+      state.subscriptions.push(record)
+      return record.snapshots.at(-1)
+    },
+  )
+
+  const watch = vi.fn((dir: string, listener: () => void) => {
+    const watcher: WatcherRecord = {
+      close: vi.fn(),
+      dir,
+      listener,
+      unref: vi.fn(),
+    }
+    state.watchers.push(watcher)
+    return watcher
+  })
+
+  function reset(): void {
+    state.appState = {
+      expandedView: 'none',
+      teamContext: undefined,
+    }
+    state.enabled = true
+    state.isLead = true
+    state.subscriptions = []
+    state.taskListId = 'list-a'
+    state.taskListeners.clear()
+    state.tasksByList = new Map([['list-a', []]])
+    state.watchers = []
+
+    listTasks.mockClear()
+    onTasksUpdated.mockClear()
+    resetTaskList.mockClear()
+    setAppState.mockClear()
+    useSyncExternalStore.mockClear()
+    watch.mockClear()
+  }
+
+  return {
+    listTasks,
+    onTasksUpdated,
+    reset,
+    resetTaskList,
+    setAppState,
+    state,
+    useSyncExternalStore,
+    watch,
+  }
+})
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react')
+  return {
+    ...actual,
+    useEffect: (effect: () => void | (() => void)) => effect(),
+    useSyncExternalStore: fixture.useSyncExternalStore,
+  }
+})
+
+vi.mock('fs', () => ({
+  watch: fixture.watch,
+}))
+
+vi.mock('src/tui/state/AppState.js', () => ({
+  useAppState: (selector: (state: AppStateFixture) => unknown) =>
+    selector(fixture.state.appState),
+  useSetAppState: () => fixture.setAppState,
+}))
+
+vi.mock('src/utils/tasks.js', () => ({
+  getTaskListId: () => fixture.state.taskListId,
+  getTasksDir: (taskListId: string) => `/tasks/${taskListId}`,
+  isTodoV2Enabled: () => fixture.state.enabled,
+  listTasks: fixture.listTasks,
+  onTasksUpdated: fixture.onTasksUpdated,
+  resetTaskList: fixture.resetTaskList,
+}))
+
+vi.mock('src/utils/teammate.js', () => ({
+  isTeamLead: () => fixture.state.isLead,
+}))
+
+let timers: ManualTimer[] = []
+
+function installTimerMocks(): void {
+  vi.spyOn(globalThis, 'setTimeout').mockImplementation(
+    (handler: TimerHandler, delay?: number, ...args: unknown[]) => {
+      const timer: ManualTimer = {
+        active: true,
+        callback: () => {
+          if (typeof handler !== 'function') {
+            throw new TypeError('string timers are not supported in this test')
+          }
+          handler(...args)
+        },
+        delay: delay ?? 0,
+        unref: vi.fn(),
+      }
+      timers.push(timer)
+      return timer as unknown as ReturnType<typeof setTimeout>
+    },
+  )
+  vi.spyOn(globalThis, 'clearTimeout').mockImplementation(
+    (timer: Parameters<typeof clearTimeout>[0]) => {
+      if (timer && typeof timer === 'object' && 'active' in timer) {
+        ;(timer as unknown as ManualTimer).active = false
+      }
+    },
+  )
+}
+
+function task(id: string, status: Task['status']): Task {
+  return {
+    activeForm: `${status} ${id}`,
+    blockedBy: [],
+    blocks: [],
+    description: `Task ${id}`,
+    id,
+    subject: `Task ${id}`,
+    status,
+  }
+}
+
+function activeTimers(delay?: number): ManualTimer[] {
+  return timers.filter(
+    timer => timer.active && (delay === undefined || timer.delay === delay),
+  )
+}
+
+async function flushPromises(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve()
+  }
+}
+
+async function fireNextTimer(delay?: number): Promise<ManualTimer> {
+  const timer = activeTimers(delay)[0]
+  expect(timer).toBeDefined()
+  timer.active = false
+  timer.callback()
+  await flushPromises()
+  return timer
+}
+
+async function emitTasksUpdated(): Promise<void> {
+  for (const listener of [...fixture.state.taskListeners]) {
+    listener()
+  }
+  await fireNextTimer(50)
+}
+
+function latestTasks(record: SubscriptionRecord): Task[] | undefined {
+  return record.snapshots.at(-1) as Task[] | undefined
+}
+
+async function mountUseTasksV2(): Promise<{
+  dispose: () => void
+  record: SubscriptionRecord
+}> {
+  const { useTasksV2 } = await import('src/tui/hooks/useTasksV2.js')
+  useTasksV2()
+  const record = fixture.state.subscriptions.at(-1)
+  if (!record) {
+    throw new Error('useTasksV2 did not subscribe')
+  }
+  return {
+    dispose: record.unsubscribe,
+    record,
+  }
+}
+
+describe('useTasksV2 coverage swarm row 222', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    fixture.reset()
+    timers = []
+    installTimerMocks()
+  })
+
+  afterEach(() => {
+    for (const subscription of fixture.state.subscriptions) {
+      subscription.unsubscribe()
+    }
+    vi.restoreAllMocks()
+  })
+
+  test('does not reset a completed list when the hide check sees pending work', async () => {
+    fixture.state.tasksByList.set('list-a', [task('done', 'completed')])
+    const mounted = await mountUseTasksV2()
+    await flushPromises()
+
+    fixture.state.tasksByList.set('list-a', [
+      task('done', 'completed'),
+      task('new', 'pending'),
+    ])
+    await fireNextTimer(5000)
+
+    expect(fixture.listTasks).toHaveBeenLastCalledWith('list-a')
+    expect(fixture.resetTaskList).not.toHaveBeenCalled()
+    expect(latestTasks(mounted.record)?.map(item => item.id)).toEqual(['done'])
+  })
+
+  test('keeps one hide timer and one watcher for repeated all-completed updates', async () => {
+    fixture.state.tasksByList.set('list-a', [task('done', 'completed')])
+    const mounted = await mountUseTasksV2()
+    await flushPromises()
+
+    expect(activeTimers(5000)).toHaveLength(1)
+
+    fixture.state.tasksByList.set('list-a', [task('done-again', 'completed')])
+    await emitTasksUpdated()
+
+    expect(latestTasks(mounted.record)?.map(item => item.id)).toEqual([
+      'done-again',
+    ])
+    expect(activeTimers(5000)).toHaveLength(1)
+    expect(fixture.watch).toHaveBeenCalledTimes(1)
+    expect(fixture.state.watchers[0]?.close).not.toHaveBeenCalled()
+  })
+
+  test('collapse effect leaves non-task expanded views unchanged when hidden', async () => {
+    fixture.state.enabled = false
+    fixture.state.appState = {
+      expandedView: 'teammates',
+    }
+    const { useTasksV2WithCollapseEffect } = await import(
+      'src/tui/hooks/useTasksV2.js'
+    )
+
+    const tasks = useTasksV2WithCollapseEffect()
+
+    expect(tasks).toBeUndefined()
+    expect(fixture.setAppState).toHaveBeenCalledTimes(1)
+    expect(fixture.state.appState.expandedView).toBe('teammates')
+  })
+
+  test('collapse effect does nothing when tasks are visible', async () => {
+    fixture.state.tasksByList.set('list-a', [task('open', 'pending')])
+    const mounted = await mountUseTasksV2()
+    await flushPromises()
+    const { useTasksV2WithCollapseEffect } = await import(
+      'src/tui/hooks/useTasksV2.js'
+    )
+
+    const tasks = useTasksV2WithCollapseEffect()
+
+    expect(tasks?.map(item => item.id)).toEqual(['open'])
+    expect(fixture.setAppState).not.toHaveBeenCalled()
+    expect(latestTasks(mounted.record)?.map(item => item.id)).toEqual(['open'])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-223-ink-useTerminalNotification.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-223-ink-useTerminalNotification.test.ts
@@ -1,0 +1,289 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const terminalHarness = vi.hoisted(() => ({
+  progressAvailable: false,
+}))
+
+vi.mock('../../../src/utils/env.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../src/utils/env.js')>()
+  return {
+    ...actual,
+    env: {
+      ...actual.env,
+      terminal: 'xterm',
+    },
+  }
+})
+
+vi.mock('../../../src/tui/ink/terminal.js', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('../../../src/tui/ink/terminal.js')>()
+  return {
+    ...actual,
+    isProgressReportingAvailable: () => terminalHarness.progressAvailable,
+  }
+})
+
+import { createRoot, type Root } from '../../../src/tui/ink.js'
+import {
+  type TerminalNotification,
+  TerminalWriteProvider,
+  useTerminalNotification,
+} from '../../../src/tui/ink/useTerminalNotification.js'
+
+type TestStreams = {
+  readonly stdin: PassThrough & { isTTY: boolean }
+  readonly stdout: PassThrough & {
+    columns: number
+    isTTY: boolean
+    rows: number
+  }
+  readonly stderr: PassThrough
+}
+
+const originalTmux = process.env['TMUX']
+const originalSty = process.env['STY']
+
+beforeEach(() => {
+  terminalHarness.progressAvailable = false
+  delete process.env['TMUX']
+  delete process.env['STY']
+})
+
+afterEach(() => {
+  restoreEnv('TMUX', originalTmux)
+  restoreEnv('STY', originalSty)
+})
+
+function restoreEnv(key: 'TMUX' | 'STY', value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = value
+  }
+}
+
+function createStreams(): TestStreams {
+  const stdin = new PassThrough() as TestStreams['stdin']
+  stdin.isTTY = false
+
+  const stdout = new PassThrough() as TestStreams['stdout']
+  stdout.columns = 80
+  stdout.rows = 24
+  stdout.isTTY = false
+  stdout.resume()
+
+  const stderr = new PassThrough()
+  return { stdin, stdout, stderr }
+}
+
+async function withRoot(
+  run: (root: Root, streams: TestStreams) => Promise<void> | void,
+): Promise<void> {
+  const streams = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stderr: streams.stderr as unknown as NodeJS.WriteStream,
+    stdin: streams.stdin as unknown as NodeJS.ReadStream,
+    stdout: streams.stdout as unknown as NodeJS.WriteStream,
+  })
+
+  try {
+    await run(root, streams)
+  } finally {
+    root.unmount()
+    streams.stdin.end()
+    streams.stdout.end()
+    streams.stderr.end()
+  }
+}
+
+async function waitForCondition(
+  condition: () => boolean,
+  failureMessage: string,
+): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (condition()) return
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+  throw new Error(failureMessage)
+}
+
+function osc(...parts: readonly (number | string)[]): string {
+  return `\x1b]${parts.join(';')}\x07`
+}
+
+function tmuxWrap(sequence: string): string {
+  return `\x1bPtmux;${sequence.replaceAll('\x1b', '\x1b\x1b')}\x1b\\`
+}
+
+function CaptureNotification({
+  onCapture,
+}: {
+  readonly onCapture: (notification: TerminalNotification) => void
+}): null {
+  onCapture(useTerminalNotification())
+  return null
+}
+
+let latestBoundaryError: Error | undefined
+
+function MissingProviderProbe(): null {
+  useTerminalNotification()
+  return null
+}
+
+class CaptureErrorBoundary extends React.Component<
+  {
+    readonly children: React.ReactNode
+    readonly onError: (error: Error) => void
+  },
+  { readonly failed: boolean }
+> {
+  override state = { failed: false }
+
+  static getDerivedStateFromError(error: Error): { readonly failed: boolean } {
+    latestBoundaryError = error
+    return { failed: true }
+  }
+
+  override componentDidCatch(error: Error): void {
+    this.props.onError(error)
+  }
+
+  override render(): React.ReactNode {
+    return this.state.failed ? null : this.props.children
+  }
+}
+
+describe('useTerminalNotification coverage swarm row 223', () => {
+  test('reports a clear error when the terminal writer is missing', async () => {
+    await withRoot(async root => {
+      let capturedError: Error | undefined
+      latestBoundaryError = undefined
+
+      root.render(
+        React.createElement(
+          CaptureErrorBoundary,
+          {
+            onError: error => {
+              capturedError = error
+            },
+          },
+          React.createElement(
+            TerminalWriteProvider,
+            { value: null },
+            React.createElement(MissingProviderProbe),
+          ),
+        ),
+      )
+
+      await waitForCondition(
+        () => capturedError !== undefined || latestBoundaryError !== undefined,
+        'Timed out waiting for TerminalWriteProvider error',
+      )
+
+      expect((capturedError ?? latestBoundaryError)?.message).toBe(
+        'useTerminalNotification must be used within TerminalWriteProvider',
+      )
+    })
+  })
+
+  test('emits notification and reachable progress sequences', async () => {
+    await withRoot(async root => {
+      const writes: string[] = []
+      let notification: TerminalNotification | undefined
+
+      root.render(
+        React.createElement(
+          TerminalWriteProvider,
+          { value: data => writes.push(data) },
+          React.createElement(CaptureNotification, {
+            onCapture: captured => {
+              notification = captured
+            },
+          }),
+        ),
+      )
+
+      await waitForCondition(
+        () => notification !== undefined,
+        'Timed out waiting for terminal notification hook',
+      )
+
+      notification?.progress('running', 41.4)
+      expect(writes).toEqual([])
+
+      notification?.notifyITerm2({ message: 'build passed', title: 'AgenC' })
+      notification?.notifyITerm2({ message: 'plain notice' })
+      notification?.notifyKitty({
+        id: 7,
+        message: 'job complete',
+        title: 'Worker',
+      })
+      notification?.notifyGhostty({ message: 'ready', title: 'Session' })
+      notification?.notifyBell()
+
+      terminalHarness.progressAvailable = true
+      notification?.progress(null)
+      notification?.progress('completed')
+      notification?.progress('error', -4.5)
+      notification?.progress('indeterminate')
+      notification?.progress('running', 100.5)
+      notification?.progress('running')
+
+      expect(writes).toEqual([
+        osc(9, '\n\nAgenC:\nbuild passed'),
+        osc(9, '\n\nplain notice'),
+        osc(99, 'i=7:d=0:p=title', 'Worker'),
+        osc(99, 'i=7:p=body', 'job complete'),
+        osc(99, 'i=7:d=1:a=focus', ''),
+        osc(777, 'notify', 'Session', 'ready'),
+        '\x07',
+        osc(9, 4, 0, ''),
+        osc(9, 4, 0, ''),
+        osc(9, 4, 2, 0),
+        osc(9, 4, 3, ''),
+        osc(9, 4, 1, 100),
+        osc(9, 4, 1, 0),
+      ])
+    })
+  })
+
+  test('wraps OSC notifications for tmux while keeping bell raw', async () => {
+    await withRoot(async root => {
+      const writes: string[] = []
+      let notification: TerminalNotification | undefined
+
+      process.env['TMUX'] = '/tmp/tmux-1000/default,1,0'
+
+      root.render(
+        React.createElement(
+          TerminalWriteProvider,
+          { value: data => writes.push(data) },
+          React.createElement(CaptureNotification, {
+            onCapture: captured => {
+              notification = captured
+            },
+          }),
+        ),
+      )
+
+      await waitForCondition(
+        () => notification !== undefined,
+        'Timed out waiting for terminal notification hook',
+      )
+
+      notification?.notifyITerm2({ message: 'mux notice', title: 'Session' })
+      notification?.notifyBell()
+
+      expect(writes).toEqual([
+        tmuxWrap(osc(9, '\n\nSession:\nmux notice')),
+        '\x07',
+      ])
+    })
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-224-ink-wrap-text.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-224-ink-wrap-text.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { stringWidth } from '../../../src/tui/ink/stringWidth.js'
+import wrapText from '../../../src/tui/ink/wrap-text.js'
+
+const originalGlyphMode = process.env.AGENC_TUI_GLYPHS
+
+afterEach(() => {
+  if (originalGlyphMode === undefined) {
+    delete process.env.AGENC_TUI_GLYPHS
+  } else {
+    process.env.AGENC_TUI_GLYPHS = originalGlyphMode
+  }
+})
+
+describe('wrapText coverage swarm row 224', () => {
+  test('wraps hard lines and trims only for wrap-trim', () => {
+    expect(wrapText('alpha beta', 6, 'wrap')).toBe('alpha \nbeta')
+    expect(wrapText('alpha beta', 6, 'wrap-trim')).toBe('alpha\nbeta')
+    expect(wrapText('abcdefghij', 4, 'wrap')).toBe('abcd\nefgh\nij')
+  })
+
+  test('truncates start, middle, and end positions with the ASCII marker', () => {
+    process.env.AGENC_TUI_GLYPHS = 'ascii'
+
+    expect(wrapText('abcdefghi', 5, 'truncate-end')).toBe('ab...')
+    expect(wrapText('abcdefghi', 5, 'truncate-middle')).toBe('a...i')
+    expect(wrapText('abcdefghi', 5, 'truncate-start')).toBe('...hi')
+  })
+
+  test('leaves non-truncating overflow modes untouched', () => {
+    expect(wrapText('abcdef', 3, 'end')).toBe('abcdef')
+    expect(wrapText('abcdef', 3, 'middle')).toBe('abcdef')
+  })
+
+  test('keeps wide-character truncation inside the requested width', () => {
+    process.env.AGENC_TUI_GLYPHS = 'ascii'
+
+    const output = wrapText('好abcdef', 4, 'truncate')
+
+    expect(output).toBe('...')
+    expect(stringWidth(output)).toBeLessThanOrEqual(4)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-225-ink-components-Newline.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-225-ink-components-Newline.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const compilerRuntime = vi.hoisted(() => {
+  const sentinel = Symbol("memo-cache-sentinel");
+  let cache: unknown[] = [];
+
+  function reset(size = 4): void {
+    cache = Array.from({ length: size }, () => sentinel);
+  }
+
+  reset();
+
+  return {
+    c: vi.fn((size: number) => {
+      if (cache.length !== size) reset(size);
+      return cache;
+    }),
+    reset,
+  };
+});
+
+vi.mock("react-compiler-runtime", () => ({
+  c: compilerRuntime.c,
+}));
+
+import Newline from "../../../src/tui/ink/components/Newline.js";
+
+type NewlineElement = React.ReactElement<{
+  children: string;
+}>;
+
+function renderNewline(props: Parameters<typeof Newline>[0]): NewlineElement {
+  const element = Newline(props);
+
+  expect(React.isValidElement(element)).toBe(true);
+  return element as NewlineElement;
+}
+
+describe("Newline coverage swarm row 225", () => {
+  beforeEach(() => {
+    compilerRuntime.reset();
+    compilerRuntime.c.mockClear();
+  });
+
+  test("renders a single newline by default", () => {
+    const element = renderNewline({});
+
+    expect(element.type).toBe("ink-text");
+    expect(element.props.children).toBe("\n");
+  });
+
+  test("renders the requested number of newline characters", () => {
+    const element = renderNewline({ count: 3 });
+
+    expect(element.type).toBe("ink-text");
+    expect(element.props.children).toBe("\n\n\n");
+  });
+
+  test("supports zero newlines and reuses the cached element for stable input", () => {
+    const first = renderNewline({ count: 0 });
+    const second = renderNewline({ count: 0 });
+
+    expect(first.props.children).toBe("");
+    expect(second).toBe(first);
+    expect(compilerRuntime.c).toHaveBeenCalledTimes(2);
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-226-ink-hooks-use-input.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-226-ink-hooks-use-input.test.ts
@@ -1,0 +1,281 @@
+import { PassThrough } from 'node:stream'
+
+import React, { act } from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import StdinContext, {
+  type Props as StdinProps,
+} from '../../../src/tui/ink/components/StdinContext.js'
+import { EventEmitter } from '../../../src/tui/ink/events/emitter.js'
+import type { InputEvent, Key } from '../../../src/tui/ink/events/input-event.js'
+import useInput from '../../../src/tui/ink/hooks/use-input.js'
+import { createRoot, type Root } from '../../../src/tui/ink/root.js'
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough & {
+    columns: number
+    isTTY: boolean
+    rows: number
+  }
+}
+
+type InputHandler = (input: string, key: Key, event: InputEvent) => void
+
+type HarnessContext = StdinProps & {
+  readonly setRawMode: ReturnType<typeof vi.fn>
+  readonly internal_eventEmitter: EventEmitter | undefined
+}
+
+function createStreams(): TestStreams {
+  const stdin = new PassThrough() as TestStreams['stdin']
+  const stdout = new PassThrough() as TestStreams['stdout']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 80
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+function createKey(overrides: Partial<Key> = {}): Key {
+  return {
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    pageDown: false,
+    pageUp: false,
+    wheelUp: false,
+    wheelDown: false,
+    home: false,
+    end: false,
+    return: false,
+    escape: false,
+    ctrl: false,
+    shift: false,
+    fn: false,
+    tab: false,
+    backspace: false,
+    delete: false,
+    meta: false,
+    super: false,
+    ...overrides,
+  }
+}
+
+function inputEvent(input: string, keyOverrides: Partial<Key> = {}): InputEvent {
+  const key = createKey(keyOverrides)
+
+  return {
+    input,
+    key,
+  } as InputEvent
+}
+
+function createContext(
+  overrides: Partial<HarnessContext> = {},
+): HarnessContext {
+  const { stdin } = createStreams()
+
+  return {
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    setRawMode: vi.fn(),
+    isRawModeSupported: true,
+    internal_exitOnCtrlC: true,
+    internal_eventEmitter: new EventEmitter(),
+    internal_querier: null,
+    ...overrides,
+  }
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+  })
+  await new Promise(resolve => setImmediate(resolve))
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+function InputProbe({
+  handler,
+  isActive,
+}: {
+  readonly handler: InputHandler
+  readonly isActive?: boolean
+}): null {
+  useInput(handler, { isActive })
+  return null
+}
+
+async function renderHookHarness(
+  initialContext: HarnessContext,
+  initialHandler: InputHandler,
+  initialIsActive?: boolean,
+): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly render: (
+    context: HarnessContext,
+    handler: InputHandler,
+    isActive?: boolean,
+  ) => Promise<void>
+}> {
+  const { stdin, stdout } = createStreams()
+  const root: Root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  async function render(
+    context: HarnessContext,
+    handler: InputHandler,
+    isActive?: boolean,
+  ): Promise<void> {
+    await act(async () => {
+      root.render(
+        React.createElement(
+          StdinContext.Provider,
+          { value: context as StdinProps },
+          React.createElement(InputProbe, { handler, isActive }),
+        ),
+      )
+    })
+    await flushEffects()
+  }
+
+  await render(initialContext, initialHandler, initialIsActive)
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushEffects()
+    },
+    render,
+  }
+}
+
+describe('useInput coverage swarm row 226', () => {
+  test('enables raw mode while active and removes the input listener on unmount', async () => {
+    const context = createContext({ internal_exitOnCtrlC: false })
+    const handler = vi.fn<InputHandler>()
+    const rendered = await renderHookHarness(context, handler)
+    const event = inputEvent('x')
+
+    try {
+      expect(context.setRawMode.mock.calls).toEqual([[true]])
+      expect(context.internal_eventEmitter?.listenerCount('input')).toBe(1)
+
+      context.internal_eventEmitter?.emit('input', event)
+
+      expect(handler).toHaveBeenCalledWith('x', event.key, event)
+    } finally {
+      await rendered.dispose()
+    }
+
+    expect(context.setRawMode.mock.calls).toEqual([[true], [false]])
+    expect(context.internal_eventEmitter?.listenerCount('input')).toBe(0)
+
+    context.internal_eventEmitter?.emit('input', inputEvent('after-unmount'))
+
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  test('keeps the listener stable while inactive and gates handler dispatch', async () => {
+    const context = createContext({ internal_exitOnCtrlC: false })
+    const inactiveHandler = vi.fn<InputHandler>()
+    const activeHandler = vi.fn<InputHandler>()
+    const rendered = await renderHookHarness(context, inactiveHandler, false)
+
+    try {
+      const initialListener = context.internal_eventEmitter?.rawListeners('input')[0]
+
+      expect(context.setRawMode).not.toHaveBeenCalled()
+      expect(context.internal_eventEmitter?.listenerCount('input')).toBe(1)
+
+      context.internal_eventEmitter?.emit('input', inputEvent('i'))
+
+      expect(inactiveHandler).not.toHaveBeenCalled()
+
+      await rendered.render(context, activeHandler)
+
+      expect(context.internal_eventEmitter?.rawListeners('input')[0]).toBe(
+        initialListener,
+      )
+      expect(context.setRawMode.mock.calls).toEqual([[true]])
+
+      const activeEvent = inputEvent('a')
+      context.internal_eventEmitter?.emit('input', activeEvent)
+
+      expect(inactiveHandler).not.toHaveBeenCalled()
+      expect(activeHandler).toHaveBeenCalledWith('a', activeEvent.key, activeEvent)
+
+      await rendered.render(context, activeHandler, false)
+
+      expect(context.setRawMode.mock.calls).toEqual([[true], [false]])
+
+      context.internal_eventEmitter?.emit('input', inputEvent('off-again'))
+
+      expect(activeHandler).toHaveBeenCalledTimes(1)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('suppresses Ctrl+C for exit handling unless exitOnCtrlC is disabled', async () => {
+    const context = createContext({ internal_exitOnCtrlC: true })
+    const handler = vi.fn<InputHandler>()
+    const rendered = await renderHookHarness(context, handler)
+
+    try {
+      context.internal_eventEmitter?.emit('input', inputEvent('c', { ctrl: true }))
+
+      expect(handler).not.toHaveBeenCalled()
+
+      await rendered.render(
+        {
+          ...context,
+          internal_exitOnCtrlC: false,
+        },
+        handler,
+      )
+
+      const delegatedCtrlC = inputEvent('c', { ctrl: true })
+      context.internal_eventEmitter?.emit('input', delegatedCtrlC)
+
+      expect(handler).toHaveBeenCalledWith(
+        'c',
+        delegatedCtrlC.key,
+        delegatedCtrlC,
+      )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('tolerates a missing internal event emitter', async () => {
+    const context = createContext({ internal_eventEmitter: undefined })
+    const handler = vi.fn<InputHandler>()
+    const rendered = await renderHookHarness(context, handler)
+
+    await rendered.dispose()
+
+    expect(context.setRawMode.mock.calls).toEqual([[true], [false]])
+    expect(handler).not.toHaveBeenCalled()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-227-message-renderers-HighlightedThinkingText.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-227-message-renderers-HighlightedThinkingText.test.tsx
@@ -1,0 +1,76 @@
+import figures from 'figures'
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { renderToString } from '../../../src/utils/staticRender.js'
+import { HighlightedThinkingText } from '../../../src/tui/message-renderers/HighlightedThinkingText.js'
+
+const thinkingMock = vi.hoisted(() => ({
+  findThinkingTriggerPositions: vi.fn(() => []),
+  getRainbowColor: vi.fn(() => 'suggestion'),
+  isUltrathinkEnabled: vi.fn(() => true),
+}))
+
+const timestampMock = vi.hoisted(() => ({
+  formatBriefTimestamp: vi.fn(() => '9:41 AM'),
+}))
+
+vi.mock('../../../src/utils/thinking.js', () => thinkingMock)
+vi.mock('../../../src/utils/formatBriefTimestamp.js', () => timestampMock)
+
+afterEach(() => {
+  vi.clearAllMocks()
+  thinkingMock.findThinkingTriggerPositions.mockReturnValue([])
+  thinkingMock.getRainbowColor.mockReturnValue('suggestion')
+  thinkingMock.isUltrathinkEnabled.mockReturnValue(true)
+})
+
+describe('HighlightedThinkingText swarm-227 coverage', () => {
+  test('skips trigger lookup and rainbow coloring when ultrathink highlighting is disabled', async () => {
+    thinkingMock.isUltrathinkEnabled.mockReturnValue(false)
+
+    const output = await renderToString(
+      <HighlightedThinkingText
+        text="please ultrathink later"
+        showPointer={false}
+      />,
+      80,
+    )
+
+    expect(output.trim()).toBe('please ultrathink later')
+    expect(thinkingMock.findThinkingTriggerPositions).not.toHaveBeenCalled()
+    expect(thinkingMock.getRainbowColor).not.toHaveBeenCalled()
+  })
+
+  test('renders a full-string thinking trigger without plain leading or trailing spans', async () => {
+    thinkingMock.findThinkingTriggerPositions.mockReturnValue([
+      { word: 'ultra', start: 0, end: 5 },
+    ])
+
+    const output = await renderToString(
+      <HighlightedThinkingText text="ultra" showPointer={false} />,
+      80,
+    )
+
+    expect(output.trim()).toBe('ultra')
+    expect(thinkingMock.getRainbowColor.mock.calls.map(([index]) => index)).toEqual([
+      0, 1, 2, 3, 4,
+    ])
+  })
+
+  test('renders non-queued brief layout without timestamp formatting', async () => {
+    const output = await renderToString(
+      <HighlightedThinkingText
+        text="brief prompt"
+        useBriefLayout={true}
+      />,
+      { columns: 80, rows: 6 },
+    )
+
+    expect(output).toContain('You')
+    expect(output).toContain('brief prompt')
+    expect(output).not.toContain(figures.pointer)
+    expect(timestampMock.formatBriefTimestamp).not.toHaveBeenCalled()
+    expect(thinkingMock.findThinkingTriggerPositions).not.toHaveBeenCalled()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-228-components-SystemAPIErrorMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-228-components-SystemAPIErrorMessage.test.tsx
@@ -1,0 +1,201 @@
+import * as React from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { AgenCSystemAPIErrorMessage } from "../../../src/errors/api.js";
+import { SystemAPIErrorMessage } from "../../../src/tui/components/SystemAPIErrorMessage.js";
+
+const harness = vi.hoisted(() => ({
+  countdownMs: 0,
+  intervalCallback: undefined as (() => void) | undefined,
+  intervalMs: undefined as number | null | undefined,
+  stateUpdates: [] as number[],
+  reset() {
+    harness.countdownMs = 0;
+    harness.intervalCallback = undefined;
+    harness.intervalMs = undefined;
+    harness.stateUpdates = [];
+  },
+}));
+
+vi.mock("react", async importOriginal => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    useState: <T,>(initial: T) => [
+      harness.countdownMs as T,
+      (updater: T | ((value: T) => T)) => {
+        const next =
+          typeof updater === "function"
+            ? (updater as (value: T) => T)(harness.countdownMs as T)
+            : updater;
+        harness.countdownMs = Number(next);
+        harness.stateUpdates.push(harness.countdownMs);
+      },
+    ],
+  };
+});
+
+vi.mock("../../../src/tui/ink.js", async () => {
+  const ReactModule = await import("react");
+  const Passthrough = ({
+    children,
+  }: {
+    readonly children?: React.ReactNode;
+  }) => ReactModule.createElement(ReactModule.Fragment, null, children);
+
+  return {
+    Box: Passthrough,
+    Text: Passthrough,
+    useInterval: (callback: () => void, intervalMs: number | null) => {
+      harness.intervalCallback = callback;
+      harness.intervalMs = intervalMs;
+    },
+  };
+});
+
+vi.mock("../../../src/tui/components/MessageResponse.js", async () => {
+  const ReactModule = await import("react");
+  return {
+    MessageResponse: ({
+      children,
+    }: {
+      readonly children?: React.ReactNode;
+    }) => ReactModule.createElement(ReactModule.Fragment, null, children),
+  };
+});
+
+function message(
+  overrides: Partial<AgenCSystemAPIErrorMessage> = {},
+): AgenCSystemAPIErrorMessage {
+  return {
+    type: "system",
+    subtype: "api_error",
+    level: "error",
+    error: new Error("provider unavailable"),
+    retryAttempt: 4,
+    retryInMs: 3000,
+    maxRetries: 6,
+    ...overrides,
+  };
+}
+
+function renderPlain(node: React.ReactNode): string {
+  return collectText(node);
+}
+
+function collectText(node: React.ReactNode): string {
+  if (node === null || node === undefined || typeof node === "boolean") {
+    return "";
+  }
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map(collectText).join("");
+  }
+  if (React.isValidElement(node)) {
+    const element = node as React.ReactElement<{
+      readonly children?: React.ReactNode;
+    }>;
+    if (typeof element.type === "function") {
+      const Component = element.type as (
+        props: typeof element.props,
+      ) => React.ReactNode;
+      return collectText(Component(element.props));
+    }
+    return collectText(element.props.children);
+  }
+  return "";
+}
+
+describe("SystemAPIErrorMessage coverage swarm row 228", () => {
+  beforeEach(() => {
+    harness.reset();
+  });
+
+  afterEach(() => {
+    delete process.env.API_TIMEOUT_MS;
+  });
+
+  test("suppresses early retry attempts and pauses the countdown interval", () => {
+    const output = renderPlain(
+      <SystemAPIErrorMessage
+        verbose={false}
+        message={message({ retryAttempt: 3 })}
+      />,
+    );
+
+    expect(output).toBe("");
+    expect(harness.intervalMs).toBeNull();
+  });
+
+  test("renders retry details and advances through the countdown callback", () => {
+    process.env.API_TIMEOUT_MS = "2500";
+
+    const output = renderPlain(
+      <SystemAPIErrorMessage verbose={false} message={message()} />,
+    );
+
+    expect(output).toContain("provider unavailable");
+    expect(output).toContain("Retrying in 3 seconds... (attempt 4/6)");
+    expect(output).toContain("API_TIMEOUT_MS=2500ms, try increasing it");
+    expect(harness.intervalMs).toBe(1000);
+
+    harness.intervalCallback?.();
+
+    expect(harness.stateUpdates).toEqual([1000]);
+  });
+
+  test("uses singular seconds and pauses when the retry countdown is done", () => {
+    harness.countdownMs = 1000;
+
+    const output = renderPlain(
+      <SystemAPIErrorMessage
+        verbose={false}
+        message={message({ retryInMs: 1000, maxRetries: 4 })}
+      />,
+    );
+
+    expect(output).toContain("Retrying in 0 seconds... (attempt 4/4)");
+    expect(harness.intervalMs).toBeNull();
+
+    harness.reset();
+
+    const singularOutput = renderPlain(
+      <SystemAPIErrorMessage
+        verbose={false}
+        message={message({ retryInMs: 1000 })}
+      />,
+    );
+
+    expect(singularOutput).toContain("Retrying in 1 second... (attempt 4/6)");
+    expect(harness.intervalMs).toBe(1000);
+  });
+
+  test("truncates long formatted errors unless verbose output is requested", () => {
+    const longMessage = "x".repeat(1200);
+
+    const truncatedOutput = renderPlain(
+      <SystemAPIErrorMessage
+        verbose={false}
+        message={message({ error: new Error(longMessage) })}
+      />,
+    );
+
+    expect(truncatedOutput).toContain(`${"x".repeat(1000)}...`);
+    expect(truncatedOutput).toContain("(ctrl+o to expand)");
+    expect(truncatedOutput).not.toContain("x".repeat(1001));
+
+    harness.reset();
+
+    const verboseOutput = renderPlain(
+      <SystemAPIErrorMessage
+        verbose={true}
+        message={message({ error: new Error(longMessage) })}
+      />,
+    );
+
+    expect(verboseOutput).toContain(longMessage);
+    expect(verboseOutput).not.toContain("(ctrl+o to expand)");
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-229-components-PromptInput-SandboxPromptFooterHint.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-229-components-PromptInput-SandboxPromptFooterHint.test.tsx
@@ -1,0 +1,193 @@
+import { PassThrough } from 'node:stream'
+
+import React, { act } from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const sandboxHarness = vi.hoisted(() => {
+  const subscribers = new Set<() => void>()
+
+  return {
+    enabled: false,
+    subscribers,
+    totalCount: 0,
+    reset() {
+      subscribers.clear()
+      this.enabled = false
+      this.totalCount = 0
+    },
+    notify() {
+      for (const subscriber of [...subscribers]) subscriber()
+    },
+    addViolations(count: number) {
+      this.totalCount += count
+      this.notify()
+    },
+  }
+})
+
+vi.mock('../../../src/tui/keybindings/useShortcutDisplay.js', () => ({
+  useShortcutDisplay: () => 'ctrl+shift+o',
+}))
+
+vi.mock('../../../src/utils/sandbox/sandbox-runtime.js', () => ({
+  SandboxManager: {
+    getSandboxViolationStore: () => ({
+      getTotalCount: () => sandboxHarness.totalCount,
+      subscribe: (subscriber: () => void) => {
+        sandboxHarness.subscribers.add(subscriber)
+        return () => sandboxHarness.subscribers.delete(subscriber)
+      },
+    }),
+    isSandboxingEnabled: () => sandboxHarness.enabled,
+  },
+}))
+
+import { SandboxPromptFooterHint } from '../../../src/tui/components/PromptInput/SandboxPromptFooterHint.js'
+import { createRoot } from '../../../src/tui/ink.js'
+import type { DOMElement, DOMNode } from '../../../src/tui/ink/dom.js'
+import instances from '../../../src/tui/ink/instances.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestStdout = PassThrough & {
+  columns: number
+  isTTY: boolean
+}
+
+const realSetImmediate = setImmediate
+
+function createStreams(): {
+  stdin: TestStdin
+  stdout: TestStdout
+} {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough() as TestStdout
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 120
+  stdout.isTTY = false
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function flushReact(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+  })
+  await new Promise(resolve => realSetImmediate(resolve))
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+function collectText(node: DOMNode): string {
+  if (node.nodeName === '#text') return node.nodeValue
+  return node.childNodes.map(collectText).join('')
+}
+
+function getRootNode(stdout: TestStdout): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+  if (!instance?.rootNode) throw new Error('Ink root node not found')
+  return instance.rootNode
+}
+
+async function renderHint(): Promise<{
+  dispose: () => Promise<void>
+  text: () => string
+}> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  await act(async () => {
+    root.render(<SandboxPromptFooterHint />)
+  })
+  await flushReact()
+
+  return {
+    dispose: async () => {
+      await act(async () => {
+        root.unmount()
+      })
+      stdin.end()
+      stdout.end()
+      await flushReact()
+    },
+    text: () => collectText(getRootNode(stdout)),
+  }
+}
+
+describe('SandboxPromptFooterHint coverage swarm row 229', () => {
+  beforeEach(() => {
+    sandboxHarness.reset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('does not subscribe or render when sandboxing is disabled', async () => {
+    const rendered = await renderHint()
+
+    try {
+      expect(rendered.text()).toBe('')
+      expect(sandboxHarness.subscribers.size).toBe(0)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('resets the latest violation hint after its timeout and unsubscribes on cleanup', async () => {
+    sandboxHarness.enabled = true
+    sandboxHarness.totalCount = 10
+    const rendered = await renderHint()
+    vi.useFakeTimers()
+
+    try {
+      expect(sandboxHarness.subscribers.size).toBe(1)
+      expect(rendered.text()).toBe('')
+
+      await act(async () => {
+        sandboxHarness.addViolations(1)
+      })
+      await flushReact()
+      expect(rendered.text()).toContain('Sandbox blocked 1 operation')
+      expect(rendered.text()).toContain('ctrl+shift+o for details')
+
+      await vi.advanceTimersByTimeAsync(4_999)
+      await flushReact()
+      expect(rendered.text()).toContain('Sandbox blocked 1 operation')
+
+      await act(async () => {
+        sandboxHarness.addViolations(2)
+      })
+      await flushReact()
+      expect(rendered.text()).toContain('Sandbox blocked 2 operations')
+
+      await vi.advanceTimersByTimeAsync(4_999)
+      await flushReact()
+      expect(rendered.text()).toContain('Sandbox blocked 2 operations')
+
+      await vi.advanceTimersByTimeAsync(1)
+      await flushReact()
+      expect(rendered.text()).toBe('')
+    } finally {
+      await rendered.dispose()
+    }
+
+    expect(sandboxHarness.subscribers.size).toBe(0)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-230-hooks-useSettingsChange.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-230-hooks-useSettingsChange.test.ts
@@ -1,0 +1,147 @@
+import { PassThrough } from 'node:stream'
+
+import React, { act } from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const fixture = vi.hoisted(() => ({
+  currentSettings: {} as Record<string, unknown>,
+  getInitialSettings: vi.fn(() => fixture.currentSettings),
+  subscribe: vi.fn(),
+}))
+
+vi.mock('../../../src/utils/settings/changeDetector.js', () => ({
+  settingsChangeDetector: {
+    subscribe: fixture.subscribe,
+  },
+}))
+
+vi.mock('../../../src/utils/settings/settings.js', () => ({
+  getInitialSettings: fixture.getInitialSettings,
+}))
+
+import { createRoot } from '../../../src/tui/ink.js'
+import { useSettingsChange } from '../../../src/tui/hooks/useSettingsChange.js'
+
+type SettingSource =
+  | 'userSettings'
+  | 'policySettings'
+  | 'projectSettings'
+  | 'localSettings'
+  | 'flagSettings'
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough & {
+    columns: number
+    isTTY: boolean
+    rows: number
+  }
+}
+
+function createStreams(): TestStreams {
+  const stdin = new PassThrough() as TestStreams['stdin']
+  const stdout = new PassThrough() as TestStreams['stdout']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 100
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+async function renderHookHarness(onChange: ReturnType<typeof vi.fn>): Promise<{
+  readonly dispose: () => Promise<void>
+}> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    useSettingsChange(onChange)
+    return null
+  }
+
+  await act(async () => {
+    root.render(React.createElement(Harness))
+  })
+  await flushEffects()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushEffects()
+    },
+  }
+}
+
+describe('useSettingsChange coverage swarm row 230', () => {
+  beforeEach(() => {
+    fixture.currentSettings = {}
+    fixture.getInitialSettings.mockClear()
+    fixture.subscribe.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('subscribes to settings changes and forwards freshly loaded settings', async () => {
+    let subscribed:
+      | ((source: SettingSource) => void)
+      | undefined
+    const unsubscribe = vi.fn()
+    fixture.subscribe.mockImplementation(
+      (handler: (source: SettingSource) => void) => {
+        subscribed = handler
+        return unsubscribe
+      },
+    )
+
+    const onChange = vi.fn()
+    const rendered = await renderHookHarness(onChange)
+
+    try {
+      expect(fixture.subscribe).toHaveBeenCalledTimes(1)
+      expect(typeof subscribed).toBe('function')
+      expect(fixture.getInitialSettings).not.toHaveBeenCalled()
+
+      fixture.currentSettings = {
+        autoUpdatesChannel: 'stable',
+        cleanupPeriodDays: 14,
+      }
+      subscribed?.('projectSettings')
+
+      expect(fixture.getInitialSettings).toHaveBeenCalledTimes(1)
+      expect(onChange).toHaveBeenCalledWith('projectSettings', {
+        autoUpdatesChannel: 'stable',
+        cleanupPeriodDays: 14,
+      })
+    } finally {
+      await rendered.dispose()
+    }
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-231-ink-termio-ansi.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-231-ink-termio-ansi.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  BEL,
+  C0,
+  ESC,
+  ESC_TYPE,
+  SEP,
+  isC0,
+  isEscFinal,
+} from '../../../src/tui/ink/termio/ansi.js'
+
+describe('ansi termio coverage swarm row 231', () => {
+  test('exports control-character byte values and string constants', () => {
+    expect(C0.NUL).toBe(0x00)
+    expect(C0.ESC).toBe(0x1b)
+    expect(C0.DEL).toBe(0x7f)
+
+    expect(ESC).toBe('\x1b')
+    expect(BEL).toBe('\x07')
+    expect(SEP).toBe(';')
+  })
+
+  test('exports escape sequence introducer bytes', () => {
+    expect(ESC_TYPE).toEqual({
+      CSI: 0x5b,
+      OSC: 0x5d,
+      DCS: 0x50,
+      APC: 0x5f,
+      PM: 0x5e,
+      SOS: 0x58,
+      ST: 0x5c,
+    })
+  })
+
+  test('classifies C0 controls at the lower range and DEL boundary', () => {
+    expect(isC0(0x00)).toBe(true)
+    expect(isC0(0x1f)).toBe(true)
+    expect(isC0(0x20)).toBe(false)
+    expect(isC0(0x7e)).toBe(false)
+    expect(isC0(0x7f)).toBe(true)
+    expect(isC0(0x80)).toBe(false)
+  })
+
+  test('classifies ESC final bytes across the inclusive range', () => {
+    expect(isEscFinal(0x2f)).toBe(false)
+    expect(isEscFinal(0x30)).toBe(true)
+    expect(isEscFinal(0x3b)).toBe(true)
+    expect(isEscFinal(0x40)).toBe(true)
+    expect(isEscFinal(0x7e)).toBe(true)
+    expect(isEscFinal(0x7f)).toBe(false)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-232-state-onChangeAppState.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-232-state-onChangeAppState.test.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { AppState } from "../../../src/tui/state/AppStateStore.js";
+import {
+  externalMetadataToAppState,
+  onChangeAppState,
+} from "../../../src/tui/state/onChangeAppState.js";
+
+type TestGlobalConfig = {
+  showExpandedTodos?: boolean;
+  showSpinnerTree?: boolean;
+  tungstenPanelVisible?: boolean;
+  verbose?: boolean;
+};
+
+const harness = vi.hoisted(() => ({
+  applyConfigEnvironmentVariables: vi.fn(),
+  clearApiKeyHelperCache: vi.fn(),
+  clearAwsCredentialsCache: vi.fn(),
+  clearGcpCredentialsCache: vi.fn(),
+  globalConfig: {} as TestGlobalConfig,
+  isAntEmployee: vi.fn(() => true),
+  logError: vi.fn(),
+  notifyPermissionModeChanged: vi.fn(),
+  notifySessionMetadataChanged: vi.fn(),
+  persistActiveProviderProfileModel: vi.fn(),
+  saveGlobalConfig: vi.fn(),
+  setMainLoopModelOverride: vi.fn(),
+  updateSettingsForSource: vi.fn(),
+}));
+
+vi.mock("../../../src/bootstrap/state.js", () => ({
+  setMainLoopModelOverride: harness.setMainLoopModelOverride,
+}));
+
+vi.mock("../../../src/utils/auth.js", () => ({
+  clearApiKeyHelperCache: harness.clearApiKeyHelperCache,
+  clearAwsCredentialsCache: harness.clearAwsCredentialsCache,
+  clearGcpCredentialsCache: harness.clearGcpCredentialsCache,
+}));
+
+vi.mock("../../../src/utils/buildConfig.js", () => ({
+  isAntEmployee: harness.isAntEmployee,
+}));
+
+vi.mock("../../../src/utils/config.js", () => ({
+  getGlobalConfig: () => harness.globalConfig,
+  saveGlobalConfig: (updater: (current: TestGlobalConfig) => TestGlobalConfig) => {
+    harness.saveGlobalConfig(updater);
+    harness.globalConfig = updater(harness.globalConfig);
+  },
+}));
+
+vi.mock("../../../src/utils/errors.js", () => ({
+  toError: (error: unknown) =>
+    error instanceof Error ? error : new Error(String(error)),
+}));
+
+vi.mock("../../../src/utils/log.js", () => ({
+  logError: harness.logError,
+}));
+
+vi.mock("../../../src/utils/managedEnv.js", () => ({
+  applyConfigEnvironmentVariables: harness.applyConfigEnvironmentVariables,
+}));
+
+vi.mock("../../../src/utils/permissions/PermissionMode.js", () => ({
+  permissionModeFromString: (mode: string) =>
+    mode === "acceptEdits" || mode === "plan" ? mode : "default",
+  toExternalPermissionMode: (mode: string) =>
+    mode === "auto" || mode === "bubble" ? "default" : mode,
+}));
+
+vi.mock("../../../src/utils/providerProfiles.js", () => ({
+  persistActiveProviderProfileModel: harness.persistActiveProviderProfileModel,
+}));
+
+vi.mock("../../../src/utils/sessionState.js", () => ({
+  notifyPermissionModeChanged: harness.notifyPermissionModeChanged,
+  notifySessionMetadataChanged: harness.notifySessionMetadataChanged,
+}));
+
+vi.mock("../../../src/utils/settings/settings.js", () => ({
+  updateSettingsForSource: harness.updateSettingsForSource,
+}));
+
+function makeState(overrides: Partial<AppState> = {}): AppState {
+  return {
+    expandedView: "none",
+    mainLoopModel: null,
+    settings: { env: { OLD_VALUE: "1" } },
+    toolPermissionContext: { mode: "default" },
+    tungstenPanelVisible: false,
+    verbose: false,
+    ...overrides,
+  } as AppState;
+}
+
+describe("onChangeAppState coverage swarm", () => {
+  beforeEach(() => {
+    delete process.env.AGENC_PROVIDER_PROFILE_ENV_APPLIED;
+    harness.applyConfigEnvironmentVariables.mockReset();
+    harness.clearApiKeyHelperCache.mockReset();
+    harness.clearAwsCredentialsCache.mockReset();
+    harness.clearGcpCredentialsCache.mockReset();
+    harness.globalConfig = {
+      showExpandedTodos: false,
+      showSpinnerTree: false,
+      tungstenPanelVisible: false,
+      verbose: false,
+    };
+    harness.isAntEmployee.mockReset();
+    harness.isAntEmployee.mockReturnValue(true);
+    harness.logError.mockReset();
+    harness.notifyPermissionModeChanged.mockReset();
+    harness.notifySessionMetadataChanged.mockReset();
+    harness.persistActiveProviderProfileModel.mockReset();
+    harness.saveGlobalConfig.mockReset();
+    harness.setMainLoopModelOverride.mockReset();
+    harness.updateSettingsForSource.mockReset();
+  });
+
+  test("hydrates string permission metadata and ignores absent metadata", () => {
+    const previous = makeState({
+      toolPermissionContext: {
+        additionalDirectories: ["/tmp/workspace"],
+        mode: "default",
+      },
+    });
+
+    const hydrated = externalMetadataToAppState({
+      permission_mode: "acceptEdits",
+    })(previous);
+    const unchanged = externalMetadataToAppState({})(previous);
+
+    expect(hydrated.toolPermissionContext).toMatchObject({
+      additionalDirectories: ["/tmp/workspace"],
+      mode: "acceptEdits",
+    });
+    expect(unchanged.toolPermissionContext).toBe(previous.toolPermissionContext);
+  });
+
+  test("notifies raw permission mode changes while suppressing unchanged external metadata", () => {
+    onChangeAppState({
+      oldState: makeState({ toolPermissionContext: { mode: "default" } }),
+      newState: makeState({ toolPermissionContext: { mode: "bubble" } }),
+    });
+
+    expect(harness.notifySessionMetadataChanged).not.toHaveBeenCalled();
+    expect(harness.notifyPermissionModeChanged).toHaveBeenCalledWith("bubble");
+  });
+
+  test("writes selected models and persists provider profile only after profile env is applied", () => {
+    onChangeAppState({
+      oldState: makeState({ mainLoopModel: null }),
+      newState: makeState({ mainLoopModel: "gpt-5.4" }),
+    });
+
+    expect(harness.updateSettingsForSource).toHaveBeenCalledWith(
+      "userSettings",
+      { model: "gpt-5.4" },
+    );
+    expect(harness.setMainLoopModelOverride).toHaveBeenCalledWith("gpt-5.4");
+    expect(harness.persistActiveProviderProfileModel).not.toHaveBeenCalled();
+
+    process.env.AGENC_PROVIDER_PROFILE_ENV_APPLIED = "1";
+    onChangeAppState({
+      oldState: makeState({ mainLoopModel: "gpt-5.4" }),
+      newState: makeState({ mainLoopModel: "gpt-5.4-mini" }),
+    });
+
+    expect(harness.persistActiveProviderProfileModel).toHaveBeenCalledWith(
+      "gpt-5.4-mini",
+    );
+  });
+
+  test("clears selected model settings without provider profile writes", () => {
+    onChangeAppState({
+      oldState: makeState({ mainLoopModel: "gpt-5.4" }),
+      newState: makeState({ mainLoopModel: null }),
+    });
+
+    expect(harness.updateSettingsForSource).toHaveBeenCalledWith(
+      "userSettings",
+      { model: undefined },
+    );
+    expect(harness.setMainLoopModelOverride).toHaveBeenCalledWith(null);
+    expect(harness.persistActiveProviderProfileModel).not.toHaveBeenCalled();
+  });
+
+  test("persists expanded view only when the stored config differs", () => {
+    onChangeAppState({
+      oldState: makeState({ expandedView: "none" }),
+      newState: makeState({ expandedView: "teammates" }),
+    });
+
+    expect(harness.globalConfig).toMatchObject({
+      showExpandedTodos: false,
+      showSpinnerTree: true,
+    });
+    expect(harness.saveGlobalConfig).toHaveBeenCalledTimes(1);
+
+    harness.saveGlobalConfig.mockReset();
+    harness.globalConfig = {
+      showExpandedTodos: false,
+      showSpinnerTree: true,
+    };
+
+    onChangeAppState({
+      oldState: makeState({ expandedView: "none" }),
+      newState: makeState({ expandedView: "teammates" }),
+    });
+
+    expect(harness.saveGlobalConfig).not.toHaveBeenCalled();
+  });
+
+  test("persists verbose and tungsten toggles only for changed mismatched config", () => {
+    onChangeAppState({
+      oldState: makeState({ verbose: false, tungstenPanelVisible: false }),
+      newState: makeState({ verbose: true, tungstenPanelVisible: true }),
+    });
+
+    expect(harness.globalConfig).toMatchObject({
+      tungstenPanelVisible: true,
+      verbose: true,
+    });
+    expect(harness.saveGlobalConfig).toHaveBeenCalledTimes(2);
+
+    harness.saveGlobalConfig.mockReset();
+    harness.globalConfig = {
+      tungstenPanelVisible: true,
+      verbose: true,
+    };
+
+    onChangeAppState({
+      oldState: makeState({ verbose: false, tungstenPanelVisible: false }),
+      newState: makeState({ verbose: true, tungstenPanelVisible: true }),
+    });
+
+    expect(harness.saveGlobalConfig).not.toHaveBeenCalled();
+
+    harness.isAntEmployee.mockReturnValue(false);
+    onChangeAppState({
+      oldState: makeState({ tungstenPanelVisible: false }),
+      newState: makeState({ tungstenPanelVisible: true }),
+    });
+
+    expect(harness.saveGlobalConfig).not.toHaveBeenCalled();
+  });
+
+  test("clears auth caches without reapplying env when settings env is unchanged", () => {
+    const sharedEnv = { SHARED: "1" };
+
+    onChangeAppState({
+      oldState: makeState({ settings: { env: sharedEnv } }),
+      newState: makeState({
+        settings: { env: sharedEnv, apiKeyHelper: "/bin/helper" },
+      }),
+    });
+
+    expect(harness.clearApiKeyHelperCache).toHaveBeenCalledTimes(1);
+    expect(harness.clearAwsCredentialsCache).toHaveBeenCalledTimes(1);
+    expect(harness.clearGcpCredentialsCache).toHaveBeenCalledTimes(1);
+    expect(harness.applyConfigEnvironmentVariables).not.toHaveBeenCalled();
+  });
+
+  test("logs auth cache errors without throwing", () => {
+    const error = new Error("cache clear failed");
+    harness.clearApiKeyHelperCache.mockImplementationOnce(() => {
+      throw error;
+    });
+
+    expect(() =>
+      onChangeAppState({
+        oldState: makeState(),
+        newState: makeState({ settings: { env: { UPDATED: "1" } } }),
+      }),
+    ).not.toThrow();
+
+    expect(harness.logError).toHaveBeenCalledWith(error);
+    expect(harness.clearAwsCredentialsCache).not.toHaveBeenCalled();
+    expect(harness.applyConfigEnvironmentVariables).not.toHaveBeenCalled();
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-233-tool-jsx-state.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-233-tool-jsx-state.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  applyToolJSXUpdate,
+  type ToolJSXArgs,
+  type ToolJSXState,
+} from "src/tui/tool-jsx-state.js";
+
+function toolState(overrides: Partial<ToolJSXState> = {}): ToolJSXState {
+  return {
+    jsx: "tool",
+    shouldHidePromptInput: false,
+    ...overrides,
+  };
+}
+
+function toolArgs(overrides: Partial<ToolJSXArgs> = {}): ToolJSXArgs {
+  return {
+    jsx: "tool",
+    shouldHidePromptInput: false,
+    ...overrides,
+  };
+}
+
+describe("coverage swarm row 233 tool-jsx-state", () => {
+  test("persists local JSX commands without writing the clear directive into state", () => {
+    const result = applyToolJSXUpdate(
+      toolArgs({
+        clearLocalJSX: true,
+        isLocalJSXCommand: true,
+        jsx: "local command",
+        shouldContinueAnimation: true,
+        shouldHidePromptInput: true,
+        showSpinner: true,
+      }),
+      null,
+    );
+
+    expect(result).toEqual({
+      nextLocalRef: {
+        isLocalJSXCommand: true,
+        jsx: "local command",
+        shouldContinueAnimation: true,
+        shouldHidePromptInput: true,
+        showSpinner: true,
+      },
+      nextState: {
+        isLocalJSXCommand: true,
+        jsx: "local command",
+        shouldContinueAnimation: true,
+        shouldHidePromptInput: true,
+        showSpinner: true,
+      },
+    });
+    expect("clearLocalJSX" in result.nextState).toBe(false);
+    expect("clearLocalJSX" in result.nextLocalRef).toBe(false);
+  });
+
+  test("skips ordinary updates while a local JSX command is preserved", () => {
+    const preserved = toolState({
+      isLocalJSXCommand: true,
+      jsx: "preserved",
+      shouldHidePromptInput: true,
+    });
+
+    expect(applyToolJSXUpdate(toolArgs({ jsx: "ordinary" }), preserved)).toEqual({
+      skip: true,
+    });
+    expect(applyToolJSXUpdate(null, preserved)).toEqual({ skip: true });
+  });
+
+  test("clears preserved local JSX when explicitly requested", () => {
+    const preserved = toolState({
+      isLocalJSXCommand: true,
+      jsx: "preserved",
+      shouldHidePromptInput: true,
+    });
+
+    expect(
+      applyToolJSXUpdate(toolArgs({ clearLocalJSX: true, jsx: "replacement" }), preserved),
+    ).toEqual({
+      nextLocalRef: null,
+      nextState: null,
+    });
+  });
+
+  test("clears current state even when no local JSX command is preserved", () => {
+    expect(applyToolJSXUpdate(toolArgs({ clearLocalJSX: true }), null)).toEqual({
+      nextState: null,
+    });
+  });
+
+  test("accepts normal updates and null resets when no local JSX command is active", () => {
+    const ordinary = toolArgs({
+      jsx: "ordinary",
+      shouldHidePromptInput: true,
+      showSpinner: true,
+    });
+
+    expect(applyToolJSXUpdate(ordinary, null)).toEqual({ nextState: ordinary });
+    expect(applyToolJSXUpdate(null, null)).toEqual({ nextState: null });
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-234-components-InterruptedByUser.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-234-components-InterruptedByUser.test.tsx
@@ -1,0 +1,35 @@
+import React, { useLayoutEffect, useState } from "react";
+import { describe, expect, test } from "vitest";
+
+import { InterruptedByUser } from "../../../src/tui/components/InterruptedByUser.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+function RerenderInterruptedByUser() {
+  const [count, setCount] = useState(0);
+
+  useLayoutEffect(() => {
+    if (count === 0) setCount(1);
+  }, [count]);
+
+  return <InterruptedByUser />;
+}
+
+describe("InterruptedByUser coverage swarm row 234", () => {
+  test("renders the interruption prompt and not the disabled issue hint", async () => {
+    const output = await renderToString(<InterruptedByUser />, { columns: 80 });
+
+    expect(output).toContain("Interrupted");
+    expect(output).toContain("What should AgenC do instead?");
+    expect(output).not.toContain("/issue");
+    expect(output).not.toContain("model issue");
+  });
+
+  test("keeps the memoized prompt stable across rerenders", async () => {
+    const output = await renderToString(<RerenderInterruptedByUser />, {
+      columns: 80,
+    });
+
+    expect(output).toContain("Interrupted");
+    expect(output).toContain("What should AgenC do instead?");
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-235-components-design-system-KeyboardShortcutHint.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-235-components-design-system-KeyboardShortcutHint.test.tsx
@@ -1,0 +1,182 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { KeyboardShortcutHint } from '../../../src/tui/components/design-system/KeyboardShortcutHint.js'
+import type { DOMElement, DOMNode } from '../../../src/tui/ink/dom.js'
+import instances from '../../../src/tui/ink/instances.js'
+import { createRoot } from '../../../src/tui/ink/root.js'
+import type { TextStyles } from '../../../src/tui/ink/styles.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestRoot = Awaited<ReturnType<typeof createRoot>>
+
+type StyledSegment = {
+  text: string
+  styles: TextStyles
+}
+
+const mountedRoots: Array<{
+  root: TestRoot
+  stdin: TestStdin
+  stdout: PassThrough
+}> = []
+
+function createStreams(): { stdin: TestStdin; stdout: PassThrough } {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough()
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 80
+  ;(stdout as unknown as { rows: number }).rows = 24
+  ;(stdout as unknown as { isTTY: boolean }).isTTY = true
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 30): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+
+  if (!instance?.rootNode) {
+    throw new Error('Ink root node not found')
+  }
+
+  return instance.rootNode
+}
+
+function collectSegments(
+  node: DOMNode,
+  inheritedStyles: TextStyles = {},
+  segments: StyledSegment[] = [],
+): StyledSegment[] {
+  if (node.nodeName === '#text') {
+    if (node.nodeValue !== '') {
+      segments.push({ text: node.nodeValue, styles: inheritedStyles })
+    }
+    return segments
+  }
+
+  const nextStyles = node.textStyles
+    ? { ...inheritedStyles, ...node.textStyles }
+    : inheritedStyles
+
+  for (const child of node.childNodes) {
+    collectSegments(child, nextStyles, segments)
+  }
+
+  return segments
+}
+
+async function renderHint(
+  node: React.ReactNode,
+): Promise<{
+  rerender: (next: React.ReactNode) => Promise<void>
+  segments: () => StyledSegment[]
+  text: () => string
+}> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  mountedRoots.push({ root, stdin, stdout })
+
+  const rerender = async (next: React.ReactNode) => {
+    root.render(next)
+    await sleep()
+  }
+
+  await rerender(node)
+
+  return {
+    rerender,
+    segments: () => collectSegments(getRootNode(stdout)),
+    text: () =>
+      collectSegments(getRootNode(stdout))
+        .map(segment => segment.text)
+        .join(''),
+  }
+}
+
+afterEach(() => {
+  for (const { root, stdin, stdout } of mountedRoots.splice(0)) {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    instances.delete(stdout as unknown as NodeJS.WriteStream)
+  }
+})
+
+describe('KeyboardShortcutHint coverage swarm row 235', () => {
+  test('renders the default shortcut action hint and reuses the cached non-parenthesized output', async () => {
+    const hint = (
+      <KeyboardShortcutHint shortcut="ctrl+o" action="expand" />
+    )
+    const rendered = await renderHint(hint)
+
+    expect(rendered.text()).toBe('ctrl+o to expand')
+    expect(rendered.segments()).toEqual([
+      { text: 'ctrl+o', styles: {} },
+      { text: ' to ', styles: {} },
+      { text: 'expand', styles: {} },
+    ])
+
+    await rendered.rerender(hint)
+
+    expect(rendered.text()).toBe('ctrl+o to expand')
+    expect(rendered.segments()).toEqual([
+      { text: 'ctrl+o', styles: {} },
+      { text: ' to ', styles: {} },
+      { text: 'expand', styles: {} },
+    ])
+  })
+
+  test('wraps hints in parentheses and reuses the cached parenthesized output', async () => {
+    const hint = (
+      <KeyboardShortcutHint shortcut="tab" action="toggle" parens={true} />
+    )
+    const rendered = await renderHint(hint)
+
+    expect(rendered.text()).toBe('(tab to toggle)')
+    expect(rendered.segments()).toEqual([
+      { text: '(', styles: {} },
+      { text: 'tab', styles: {} },
+      { text: ' to ', styles: {} },
+      { text: 'toggle', styles: {} },
+      { text: ')', styles: {} },
+    ])
+
+    await rendered.rerender(hint)
+
+    expect(rendered.text()).toBe('(tab to toggle)')
+  })
+
+  test('applies bold styling only to the shortcut segment', async () => {
+    const rendered = await renderHint(
+      <KeyboardShortcutHint shortcut="Enter" action="confirm" bold={true} />,
+    )
+
+    expect(rendered.text()).toBe('Enter to confirm')
+    expect(rendered.segments()).toEqual([
+      { text: 'Enter', styles: { bold: true } },
+      { text: ' to ', styles: {} },
+      { text: 'confirm', styles: {} },
+    ])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-236-components-design-system-Ratchet.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-236-components-design-system-Ratchet.test.tsx
@@ -1,0 +1,222 @@
+import { PassThrough } from 'node:stream'
+
+import React, { act } from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const fixture = vi.hoisted(() => {
+  const viewportElements: unknown[] = []
+
+  return {
+    isVisible: true,
+    measureElement: vi.fn(() => ({ height: 1, width: 1 })),
+    rows: 24,
+    viewportElements,
+    viewportRef: vi.fn((element: unknown) => {
+      viewportElements.push(element)
+    }),
+  }
+})
+
+vi.mock('../../../src/tui/hooks/useTerminalSize.js', () => ({
+  useTerminalSize: () => ({
+    columns: 80,
+    rows: fixture.rows,
+  }),
+}))
+
+vi.mock('../../../src/tui/ink/hooks/use-terminal-viewport.js', () => ({
+  useTerminalViewport: () => [
+    fixture.viewportRef,
+    { isVisible: fixture.isVisible },
+  ],
+}))
+
+vi.mock('../../../src/tui/ink.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../src/tui/ink.js')>()
+
+  return {
+    ...actual,
+    measureElement: fixture.measureElement,
+  }
+})
+
+import { Ratchet } from '../../../src/tui/components/design-system/Ratchet.js'
+import type { DOMElement } from '../../../src/tui/ink/dom.js'
+import instances from '../../../src/tui/ink/instances.js'
+import { Box, createRoot, Text, type Root } from '../../../src/tui/ink.js'
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough & {
+    columns: number
+    isTTY: boolean
+    rows: number
+  }
+}
+
+type RenderedRatchet = {
+  readonly dispose: () => Promise<void>
+  readonly outer: () => DOMElement
+  readonly render: (node: React.ReactNode) => Promise<void>
+}
+
+function createStreams(): TestStreams {
+  const stdin = new PassThrough() as TestStreams['stdin']
+  const stdout = new PassThrough() as TestStreams['stdout']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 80
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+function getRootNode(stdout: TestStreams['stdout']): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+
+  if (!instance?.rootNode) {
+    throw new Error('Ink root node not found')
+  }
+
+  return instance.rootNode
+}
+
+function onlyElementChild(node: DOMElement, label: string): DOMElement {
+  const children = node.childNodes.filter(
+    (child): child is DOMElement => child.nodeName !== '#text',
+  )
+
+  expect(children, label).toHaveLength(1)
+  return children[0]!
+}
+
+async function renderRatchet(node: React.ReactNode): Promise<RenderedRatchet> {
+  const { stdin, stdout } = createStreams()
+  const root: Root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  async function render(nextNode: React.ReactNode): Promise<void> {
+    await act(async () => {
+      root.render(nextNode)
+    })
+    await flushEffects()
+  }
+
+  await render(node)
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushEffects()
+    },
+    outer: () => onlyElementChild(getRootNode(stdout), 'ratchet outer box'),
+    render,
+  }
+}
+
+function content(label: string): React.ReactNode {
+  return (
+    <Box flexDirection="column">
+      <Text>{label}</Text>
+    </Box>
+  )
+}
+
+describe('Ratchet coverage swarm row 236', () => {
+  beforeEach(() => {
+    fixture.isVisible = true
+    fixture.measureElement.mockReset()
+    fixture.measureElement.mockReturnValue({ height: 1, width: 1 })
+    fixture.rows = 24
+    fixture.viewportElements.length = 0
+    fixture.viewportRef.mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('default lock holds the measured height but caps it at terminal rows', async () => {
+    fixture.rows = 5
+    fixture.measureElement.mockReturnValue({ height: 8, width: 20 })
+
+    const rendered = await renderRatchet(<Ratchet>{content('tall')}</Ratchet>)
+
+    try {
+      const outer = rendered.outer()
+      const inner = onlyElementChild(outer, 'ratchet inner box')
+
+      expect(fixture.measureElement).toHaveBeenCalledWith(inner)
+      expect(outer.style.minHeight).toBe(5)
+      expect(fixture.viewportRef).toHaveBeenCalledWith(outer)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('offscreen lock stores height while visible and engages it when hidden', async () => {
+    fixture.rows = 20
+    fixture.measureElement.mockReturnValue({ height: 6, width: 10 })
+
+    const rendered = await renderRatchet(
+      <Ratchet lock="offscreen">{content('visible')}</Ratchet>,
+    )
+
+    try {
+      expect(rendered.outer().style.minHeight).toBeUndefined()
+
+      fixture.isVisible = false
+      await rendered.render(
+        <Ratchet lock="offscreen">{content('hidden')}</Ratchet>,
+      )
+
+      expect(rendered.outer().style.minHeight).toBe(6)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('keeps the largest measured height across later shorter renders', async () => {
+    fixture.rows = 20
+    fixture.measureElement
+      .mockReturnValueOnce({ height: 7, width: 10 })
+      .mockReturnValueOnce({ height: 3, width: 10 })
+
+    const rendered = await renderRatchet(
+      <Ratchet>{content('initial height')}</Ratchet>,
+    )
+
+    try {
+      expect(rendered.outer().style.minHeight).toBe(7)
+
+      await rendered.render(<Ratchet>{content('shorter height')}</Ratchet>)
+
+      expect(rendered.outer().style.minHeight).toBe(7)
+      expect(fixture.measureElement.mock.calls.length).toBeGreaterThanOrEqual(2)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-237-ink-terminal.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-237-ink-terminal.test.ts
@@ -1,0 +1,163 @@
+import type { Writable } from 'node:stream'
+
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import type { Diff } from '../../../src/tui/ink/frame.js'
+import type { Terminal } from '../../../src/tui/ink/terminal.js'
+
+type EnvOverrides = Record<string, string | undefined>
+
+const TERMINAL_ENV_KEYS = [
+  'AGENC_ENABLE_EXTENDED_KEYS',
+  'ALACRITTY_LOG',
+  'ConEmuANSI',
+  'ConEmuPID',
+  'ConEmuTask',
+  'CURSOR_TRACE_ID',
+  'GNOME_TERMINAL_SERVICE',
+  'KITTY_WINDOW_ID',
+  'KONSOLE_VERSION',
+  'MSYSTEM',
+  'NODE_ENV',
+  'SESSIONNAME',
+  'SSH_CLIENT',
+  'SSH_CONNECTION',
+  'SSH_TTY',
+  'STY',
+  'TERM',
+  'TERMINAL_EMULATOR',
+  'TERM_PROGRAM',
+  'TERM_PROGRAM_VERSION',
+  'TERMINATOR_UUID',
+  'TILIX_ID',
+  'TMUX',
+  'VSCODE_GIT_ASKPASS_MAIN',
+  'VTE_VERSION',
+  'VisualStudioVersion',
+  'WSL_DISTRO_NAME',
+  'WT_SESSION',
+  'XTERM_VERSION',
+  'ZED_TERM',
+  '__CFBundleIdentifier',
+] as const
+
+const originalEnv = new Map(
+  TERMINAL_ENV_KEYS.map(key => [key, process.env[key]]),
+)
+const originalStdoutIsTTY = Object.getOwnPropertyDescriptor(
+  process.stdout,
+  'isTTY',
+)
+
+function resetTerminalEnv(overrides: EnvOverrides = {}): void {
+  for (const key of TERMINAL_ENV_KEYS) {
+    delete process.env[key]
+  }
+  process.env.NODE_ENV = 'test'
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+function restoreTerminalEnv(): void {
+  for (const key of TERMINAL_ENV_KEYS) {
+    const value = originalEnv.get(key)
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+function setStdoutIsTTY(value: boolean): void {
+  Object.defineProperty(process.stdout, 'isTTY', {
+    configurable: true,
+    value,
+    writable: true,
+  })
+}
+
+function restoreStdoutIsTTY(): void {
+  if (originalStdoutIsTTY) {
+    Object.defineProperty(process.stdout, 'isTTY', originalStdoutIsTTY)
+  } else {
+    delete (process.stdout as { isTTY?: boolean }).isTTY
+  }
+}
+
+async function importTerminal(overrides: EnvOverrides = {}) {
+  vi.resetModules()
+  resetTerminalEnv(overrides)
+  return import('../../../src/tui/ink/terminal.js')
+}
+
+function makeTerminal(writes: string[]): Terminal {
+  const stdout = {
+    write: (chunk: string | Uint8Array): boolean => {
+      writes.push(
+        typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'),
+      )
+      return true
+    },
+  } as unknown as Writable
+
+  return {
+    stderr: stdout,
+    stdout,
+  }
+}
+
+afterEach(() => {
+  restoreTerminalEnv()
+  restoreStdoutIsTTY()
+  vi.restoreAllMocks()
+  vi.resetModules()
+})
+
+describe('terminal coverage swarm row 237', () => {
+  test('detects Ghostty in real sessions from TERM_PROGRAM and TERM', async () => {
+    const termProgram = await importTerminal({
+      NODE_ENV: 'development',
+      TERM_PROGRAM: 'ghostty',
+    })
+    expect(termProgram.isGhosttyTerminal()).toBe(true)
+    expect(termProgram.shouldSkipMainScreenSyncMarkers()).toBe(true)
+    expect(termProgram.shouldUseMainScreenRewrite()).toBe(true)
+
+    const term = await importTerminal({
+      NODE_ENV: 'development',
+      TERM: 'xterm-ghostty',
+    })
+    expect(term.isGhosttyTerminal()).toBe(true)
+  })
+
+  test('falls back when no XTVERSION name or terminal name is available', async () => {
+    const noXtversion = await importTerminal()
+    expect(noXtversion.isXtermJs()).toBe(false)
+
+    setStdoutIsTTY(true)
+    const noTerminalName = await importTerminal({
+      AGENC_ENABLE_EXTENDED_KEYS: '1',
+    })
+    expect(noTerminalName.supportsExtendedKeys()).toBe(false)
+  })
+
+  test('ignores clear patches with non-positive counts', async () => {
+    const terminal = await importTerminal()
+    const writes: string[] = []
+    const output = makeTerminal(writes)
+    const diff: Diff = [
+      { type: 'clear', count: 0 },
+      { type: 'stdout', content: 'after-clear' },
+    ]
+
+    terminal.writeDiffToTerminal(output, diff, true)
+
+    expect(writes).toEqual(['after-clear'])
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-238-ink-components-TerminalFocusContext.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-238-ink-components-TerminalFocusContext.test.tsx
@@ -1,0 +1,239 @@
+import { PassThrough } from 'node:stream'
+
+import React, { act } from 'react'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import TerminalFocusContext, {
+  TerminalFocusProvider,
+  type TerminalFocusContextProps,
+} from '../../../src/tui/ink/components/TerminalFocusContext.js'
+import { createRoot } from '../../../src/tui/ink/root.js'
+import {
+  resetTerminalFocusState,
+  setTerminalFocused,
+} from '../../../src/tui/ink/terminal-focus-state.js'
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough & {
+    columns: number
+    isTTY: boolean
+    rows: number
+  }
+}
+
+const realSetImmediate = setImmediate
+
+function createStreams(): TestStreams {
+  const stdin = new PassThrough() as TestStreams['stdin']
+  const stdout = new PassThrough() as TestStreams['stdout']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 100
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function flushReact(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+  })
+  await new Promise<void>(resolve => realSetImmediate(resolve))
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  const startedAt = Date.now()
+  let lastError: unknown
+
+  while (Date.now() - startedAt < 1_000) {
+    try {
+      assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await flushReact()
+    }
+  }
+
+  throw lastError
+}
+
+function FocusProbe({
+  onValue,
+}: {
+  readonly onValue: (value: TerminalFocusContextProps) => void
+}): null {
+  onValue(React.useContext(TerminalFocusContext))
+  return null
+}
+
+function StableChildrenHarness({
+  onReady,
+  onValue,
+}: {
+  readonly onReady: (forceRender: () => void) => void
+  readonly onValue: (value: TerminalFocusContextProps) => void
+}): React.ReactNode {
+  const [, forceRender] = React.useReducer((tick: number) => tick + 1, 0)
+  const child = React.useMemo(() => <FocusProbe onValue={onValue} />, [onValue])
+
+  React.useEffect(() => {
+    onReady(forceRender)
+  }, [forceRender, onReady])
+
+  return <TerminalFocusProvider>{child}</TerminalFocusProvider>
+}
+
+afterEach(() => {
+  resetTerminalFocusState()
+})
+
+describe('TerminalFocusContext coverage swarm row 238', () => {
+  test('exposes the default focused unknown context outside a provider', async () => {
+    const values: TerminalFocusContextProps[] = []
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      await act(async () => {
+        root.render(<FocusProbe onValue={value => values.push(value)} />)
+      })
+      await waitFor(() => {
+        expect(values.at(-1)).toEqual({
+          isTerminalFocused: true,
+          terminalFocusState: 'unknown',
+        })
+      })
+
+      expect(TerminalFocusContext.displayName).toBe('TerminalFocusContext')
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushReact()
+    }
+  })
+
+  test('publishes terminal focus snapshots and updates subscribers', async () => {
+    const values: TerminalFocusContextProps[] = []
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      await act(async () => {
+        root.render(
+          <TerminalFocusProvider>
+            <FocusProbe onValue={value => values.push(value)} />
+          </TerminalFocusProvider>,
+        )
+      })
+
+      await waitFor(() => {
+        expect(values.at(-1)).toEqual({
+          isTerminalFocused: true,
+          terminalFocusState: 'unknown',
+        })
+      })
+
+      await act(async () => {
+        setTerminalFocused(false)
+      })
+      await waitFor(() => {
+        expect(values.at(-1)).toEqual({
+          isTerminalFocused: false,
+          terminalFocusState: 'blurred',
+        })
+      })
+
+      await act(async () => {
+        setTerminalFocused(true)
+      })
+      await waitFor(() => {
+        expect(values.at(-1)).toEqual({
+          isTerminalFocused: true,
+          terminalFocusState: 'focused',
+        })
+      })
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushReact()
+    }
+  })
+
+  test('keeps stable children from rendering again when focus is unchanged', async () => {
+    const values: TerminalFocusContextProps[] = []
+    let forceRender: (() => void) | undefined
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      await act(async () => {
+        root.render(
+          <StableChildrenHarness
+            onReady={nextForceRender => {
+              forceRender = nextForceRender
+            }}
+            onValue={value => values.push(value)}
+          />,
+        )
+      })
+
+      await waitFor(() => {
+        expect(forceRender).toBeDefined()
+        expect(values).toHaveLength(1)
+      })
+
+      await act(async () => {
+        forceRender?.()
+      })
+      await flushReact()
+
+      expect(values).toHaveLength(1)
+
+      await act(async () => {
+        setTerminalFocused(false)
+      })
+      await waitFor(() => {
+        expect(values).toHaveLength(2)
+        expect(values.at(-1)).toEqual({
+          isTerminalFocused: false,
+          terminalFocusState: 'blurred',
+        })
+      })
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushReact()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-239-components-MessageResponse.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-239-components-MessageResponse.test.tsx
@@ -1,0 +1,101 @@
+import type { ReactNode } from "react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const ratchetHarness = vi.hoisted(() => ({
+  calls: [] as Array<{ readonly lock?: "always" | "offscreen" }>,
+  reset() {
+    ratchetHarness.calls = [];
+  },
+}));
+
+vi.mock("../../../src/tui/components/design-system/Ratchet.js", async () => {
+  const ReactModule = await import("react");
+  const { Box, Text } = await import("../../../src/tui/ink.js");
+
+  return {
+    Ratchet({
+      children,
+      lock,
+    }: {
+      readonly children: ReactNode;
+      readonly lock?: "always" | "offscreen";
+    }) {
+      ratchetHarness.calls.push({ lock });
+
+      return ReactModule.createElement(
+        Box,
+        { flexDirection: "column" },
+        ReactModule.createElement(Text, null, `ratchet:${lock ?? "always"}`),
+        children,
+        ReactModule.createElement(Text, null, "/ratchet"),
+      );
+    },
+  };
+});
+
+import { MessageResponse } from "../../../src/tui/components/MessageResponse.js";
+import { Text } from "../../../src/tui/ink.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+const originalGlyphMode = process.env.AGENC_TUI_GLYPHS;
+
+async function renderResponse(node: ReactNode): Promise<string> {
+  return renderToString(<>{node}</>, { columns: 80, rows: 12 });
+}
+
+describe("MessageResponse coverage swarm row 239", () => {
+  beforeEach(() => {
+    ratchetHarness.reset();
+    process.env.AGENC_TUI_GLYPHS = "ascii";
+  });
+
+  afterEach(() => {
+    if (originalGlyphMode === undefined) {
+      delete process.env.AGENC_TUI_GLYPHS;
+    } else {
+      process.env.AGENC_TUI_GLYPHS = originalGlyphMode;
+    }
+  });
+
+  test("wraps auto-height responses in an offscreen ratchet with a response gutter", async () => {
+    const output = await renderResponse(
+      <MessageResponse>
+        <Text>auto-height reply</Text>
+      </MessageResponse>,
+    );
+
+    expect(ratchetHarness.calls).toEqual([{ lock: "offscreen" }]);
+    expect(output).toContain("ratchet:offscreen");
+    expect(output).toContain("|_");
+    expect(output).toContain("auto-height reply");
+  });
+
+  test("renders fixed-height responses directly without ratchet wrapping", async () => {
+    const output = await renderResponse(
+      <MessageResponse height={2}>
+        <Text>fixed-height reply</Text>
+      </MessageResponse>,
+    );
+
+    expect(ratchetHarness.calls).toEqual([]);
+    expect(output).not.toContain("ratchet:");
+    expect(output).toContain("|_");
+    expect(output).toContain("fixed-height reply");
+  });
+
+  test("does not add a second gutter for nested message responses", async () => {
+    const output = await renderResponse(
+      <MessageResponse height={4}>
+        <Text>outer reply</Text>
+        <MessageResponse>
+          <Text>inner reply</Text>
+        </MessageResponse>
+      </MessageResponse>,
+    );
+
+    expect(output.match(/\|_/g) ?? []).toHaveLength(1);
+    expect(output).toContain("outer reply");
+    expect(output).toContain("inner reply");
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-240-components-PasteConfirmDialog.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-240-components-PasteConfirmDialog.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { PasteConfirmDialog } from '../../../src/tui/components/PasteConfirmDialog.js'
+import { renderToString } from '../../../src/utils/staticRender.js'
+
+type InputEvent = {
+  stopImmediatePropagation: () => void
+}
+
+type InputHandler = (
+  input: string,
+  key: Record<string, boolean>,
+  event: InputEvent,
+) => void
+
+const harness = vi.hoisted(() => ({
+  inputHandler: undefined as InputHandler | undefined,
+  useRegisterOverlay: vi.fn(),
+}))
+
+vi.mock('../../../src/tui/context/overlayContext.js', () => ({
+  useRegisterOverlay: harness.useRegisterOverlay,
+}))
+
+vi.mock('../../../src/tui/ink.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../src/tui/ink.js')>()
+
+  return {
+    ...actual,
+    useInput: (handler: InputHandler) => {
+      harness.inputHandler = handler
+    },
+  }
+})
+
+function key(overrides: Record<string, boolean> = {}): Record<string, boolean> {
+  return {
+    escape: false,
+    return: false,
+    ...overrides,
+  }
+}
+
+function event(): InputEvent {
+  return {
+    stopImmediatePropagation: vi.fn(),
+  }
+}
+
+async function renderDialog(
+  command: string,
+  onDecide = vi.fn(),
+): Promise<string> {
+  return renderToString(
+    <PasteConfirmDialog command={command} onDecide={onDecide} />,
+    { columns: 280, rows: 12 },
+  )
+}
+
+function registeredInputHandler(): InputHandler {
+  expect(harness.inputHandler).toBeDefined()
+  return harness.inputHandler!
+}
+
+describe('PasteConfirmDialog coverage swarm row 240', () => {
+  beforeEach(() => {
+    harness.inputHandler = undefined
+    harness.useRegisterOverlay.mockClear()
+  })
+
+  test('trims whitespace, folds newlines, and truncates long command previews', async () => {
+    const longSegment = 'a'.repeat(205)
+    const output = await renderDialog(`  ${longSegment}\nrm -rf /tmp/example  `)
+
+    expect(output).toContain('Suspected paste detected')
+    expect(output).toContain('a'.repeat(200))
+    expect(output).not.toContain('rm -rf /tmp/example')
+    expect(harness.useRegisterOverlay).toHaveBeenCalledWith('paste-confirm')
+  })
+
+  test('accepts uppercase confirmation and return after consuming the input event', async () => {
+    const onDecide = vi.fn()
+    await renderDialog('echo ok', onDecide)
+    const handleInput = registeredInputHandler()
+
+    const uppercaseEvent = event()
+    handleInput('Y', key(), uppercaseEvent)
+
+    const returnEvent = event()
+    handleInput('', key({ return: true }), returnEvent)
+
+    expect(uppercaseEvent.stopImmediatePropagation).toHaveBeenCalledOnce()
+    expect(returnEvent.stopImmediatePropagation).toHaveBeenCalledOnce()
+    expect(onDecide).toHaveBeenNthCalledWith(1, true)
+    expect(onDecide).toHaveBeenNthCalledWith(2, true)
+  })
+
+  test('rejects uppercase denial and escape after consuming the input event', async () => {
+    const onDecide = vi.fn()
+    await renderDialog('echo ok', onDecide)
+    const handleInput = registeredInputHandler()
+
+    const uppercaseEvent = event()
+    handleInput('N', key(), uppercaseEvent)
+
+    const escapeEvent = event()
+    handleInput('', key({ escape: true }), escapeEvent)
+
+    expect(uppercaseEvent.stopImmediatePropagation).toHaveBeenCalledOnce()
+    expect(escapeEvent.stopImmediatePropagation).toHaveBeenCalledOnce()
+    expect(onDecide).toHaveBeenNthCalledWith(1, false)
+    expect(onDecide).toHaveBeenNthCalledWith(2, false)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-241-components-CustomSelect-use-select-state.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-241-components-CustomSelect-use-select-state.test.ts
@@ -1,0 +1,216 @@
+import { PassThrough } from 'node:stream'
+
+import React, { act } from 'react'
+import { describe, expect, test, vi } from 'vitest'
+
+import type { OptionWithDescription } from '../../../src/tui/components/CustomSelect/select.js'
+import {
+  type SelectState,
+  type UseSelectStateProps,
+  useSelectState,
+} from '../../../src/tui/components/CustomSelect/use-select-state.js'
+import { createRoot } from '../../../src/tui/ink/root.js'
+
+type TestStreams = {
+  stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdout: PassThrough & {
+    columns: number
+    isTTY: boolean
+    rows: number
+  }
+}
+
+type Snapshot = {
+  focusedIndex: number
+  focusedValue: string | undefined
+  isInInput: boolean
+  value: string | undefined
+  visibleValues: string[]
+}
+
+type HarnessProps = UseSelectStateProps<string> & {
+  controlsRef: { current: SelectState<string> | null }
+  snapshots: Snapshot[]
+}
+
+function createTestStreams(): TestStreams {
+  const stdin = new PassThrough() as TestStreams['stdin']
+  const stdout = new PassThrough() as TestStreams['stdout']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 120
+  stdout.rows = 30
+  stdout.isTTY = true
+
+  return { stdin, stdout }
+}
+
+function option(
+  value: string,
+  overrides: Partial<OptionWithDescription<string>> = {},
+): OptionWithDescription<string> {
+  return {
+    value,
+    label: value,
+    ...overrides,
+  }
+}
+
+function snapshotOf(state: SelectState<string>): Snapshot {
+  return {
+    focusedIndex: state.focusedIndex,
+    focusedValue: state.focusedValue,
+    isInInput: state.isInInput,
+    value: state.value,
+    visibleValues: state.visibleOptions.map(visible => visible.value),
+  }
+}
+
+function snapshotsMatch(
+  snapshot: Snapshot,
+  expected: Partial<Snapshot>,
+): boolean {
+  return Object.entries(expected).every(([key, value]) => {
+    const actual = snapshot[key as keyof Snapshot]
+    return Array.isArray(value)
+      ? JSON.stringify(actual) === JSON.stringify(value)
+      : actual === value
+  })
+}
+
+async function waitForSnapshot(
+  snapshots: Snapshot[],
+  expected: Partial<Snapshot>,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < 2_000) {
+    if (snapshots.some(snapshot => snapshotsMatch(snapshot, expected))) {
+      return
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 10))
+  }
+
+  throw new Error(
+    `Timed out waiting for select state ${JSON.stringify({
+      expected,
+      latest: snapshots.at(-1),
+    })}`,
+  )
+}
+
+function Harness({
+  controlsRef,
+  snapshots,
+  ...props
+}: HarnessProps): null {
+  const state = useSelectState(props)
+  controlsRef.current = state
+
+  React.useEffect(() => {
+    snapshots.push(snapshotOf(state))
+  }, [snapshots, state])
+
+  return null
+}
+
+async function renderHarness(props: HarnessProps): Promise<{
+  dispose: () => Promise<void>
+}> {
+  const { stdin, stdout } = createTestStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  await act(async () => {
+    root.render(React.createElement(Harness, props))
+  })
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await act(async () => {
+        await Promise.resolve()
+      })
+    },
+  }
+}
+
+describe('useSelectState coverage swarm row 241', () => {
+  test('keeps selected value local and selects the currently focused option', async () => {
+    const controlsRef = { current: null as SelectState<string> | null }
+    const snapshots: Snapshot[] = []
+    const onCancel = vi.fn()
+    const onChange = vi.fn()
+    const onFocus = vi.fn()
+    const rendered = await renderHarness({
+      controlsRef,
+      defaultFocusValue: 'prompt',
+      defaultValue: 'alpha',
+      onCancel,
+      onChange,
+      onFocus,
+      options: [
+        option('alpha'),
+        option('prompt', { type: 'input', onChange: vi.fn() }),
+        option('omega'),
+      ],
+      snapshots,
+    })
+
+    try {
+      await waitForSnapshot(snapshots, {
+        focusedIndex: 2,
+        focusedValue: 'prompt',
+        isInInput: true,
+        value: 'alpha',
+        visibleValues: ['alpha', 'prompt', 'omega'],
+      })
+
+      expect(onFocus).toHaveBeenCalledWith('prompt')
+      expect(controlsRef.current?.onCancel).toBe(onCancel)
+      expect(controlsRef.current?.onChange).toBe(onChange)
+
+      await act(async () => {
+        controlsRef.current?.selectFocusedOption()
+      })
+      await waitForSnapshot(snapshots, {
+        focusedValue: 'prompt',
+        value: 'prompt',
+      })
+
+      await act(async () => {
+        controlsRef.current?.focusOption('omega')
+      })
+      await waitForSnapshot(snapshots, {
+        focusedIndex: 3,
+        focusedValue: 'omega',
+        isInInput: false,
+      })
+
+      await act(async () => {
+        controlsRef.current?.selectFocusedOption()
+      })
+      await waitForSnapshot(snapshots, {
+        focusedValue: 'omega',
+        value: 'omega',
+      })
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-242-components-PromptInput-PromptInputHelpMenu.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-242-components-PromptInput-PromptInputHelpMenu.test.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { PromptInputHelpMenu } from "../../../src/tui/components/PromptInput/PromptInputHelpMenu.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+const harness = vi.hoisted(() => ({
+  featureEnabled: false,
+  getFeatureValue: vi.fn((_key: string, fallback: boolean) => fallback),
+  platform: "linux",
+  shortcuts: new Map<string, string>(),
+}));
+
+vi.mock("bun:bundle", () => ({
+  feature: () => harness.featureEnabled,
+}));
+
+vi.mock("../../../src/tui/keybindings/useShortcutDisplay.js", () => ({
+  useShortcutDisplay: (_action: string, _context: string, fallback: string) =>
+    harness.shortcuts.get(_action) ?? fallback,
+}));
+
+vi.mock("../../../src/tui/keybindings/loadUserBindings.js", () => ({
+  isKeybindingCustomizationEnabled: () => false,
+}));
+
+vi.mock("../../../src/services/analytics/growthbook.js", () => ({
+  getFeatureValue_CACHED_MAY_BE_STALE: harness.getFeatureValue,
+}));
+
+vi.mock("../../../src/utils/fastMode.js", () => ({
+  isFastModeAvailable: () => false,
+  isFastModeEnabled: () => false,
+}));
+
+vi.mock("../../../src/utils/platform.js", () => ({
+  getPlatform: () => harness.platform,
+}));
+
+beforeEach(() => {
+  harness.featureEnabled = false;
+  harness.platform = "linux";
+  harness.shortcuts.clear();
+  harness.getFeatureValue.mockReset();
+  harness.getFeatureValue.mockImplementation(
+    (_key: string, fallback: boolean) => fallback,
+  );
+});
+
+async function renderHelpMenu(): Promise<string> {
+  return renderToString(
+    <PromptInputHelpMenu dimColor fixedWidth gap={2} paddingX={1} />,
+    { columns: 140, rows: 30 },
+  );
+}
+
+describe("PromptInputHelpMenu coverage swarm row 242", () => {
+  test("renders the terminal panel shortcut when both rollout gates are enabled", async () => {
+    harness.featureEnabled = true;
+    harness.platform = "windows";
+    harness.shortcuts.set("app:toggleTerminal", "meta+shift+j");
+    harness.getFeatureValue.mockReturnValue(true);
+
+    const output = await renderHelpMenu();
+
+    expect(output).toContain("meta + shift + j for terminal");
+    expect(output).not.toContain("ctrl + z to suspend");
+    expect(harness.getFeatureValue).toHaveBeenCalledWith(
+      "agenc_terminal_panel",
+      false,
+    );
+  });
+
+  test("keeps the terminal shortcut hidden when the rollout value is false", async () => {
+    harness.featureEnabled = true;
+    harness.getFeatureValue.mockReturnValue(false);
+
+    const output = await renderHelpMenu();
+
+    expect(output).not.toContain("for terminal");
+    expect(output).toContain("ctrl + z to suspend");
+    expect(harness.getFeatureValue).toHaveBeenCalledWith(
+      "agenc_terminal_panel",
+      false,
+    );
+  });
+});

--- a/runtime/tests/tui/coverage-swarm/swarm-243-components-PromptInput-useSwarmBanner.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-243-components-PromptInput-useSwarmBanner.test.ts
@@ -1,0 +1,325 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const harness = vi.hoisted(() => {
+  function makeState() {
+    return {
+      agent: undefined as string | undefined,
+      agentDefinitions: {
+        activeAgents: [] as Array<{ agentType: string; color?: string }>,
+      },
+      agentNameRegistry: new Map<string, string>(),
+      standaloneAgentContext: undefined as
+        | undefined
+        | { name?: string; color?: string },
+      teamContext: undefined as
+        | undefined
+        | {
+            selfAgentColor?: string
+            teamName?: string
+            teammates?: Record<string, unknown>
+          },
+      viewingAgentTaskId: undefined as string | undefined,
+    }
+  }
+
+  const state = {
+    activeAgent: { type: 'leader' } as
+      | { type: 'leader' }
+      | {
+          type: 'named_agent'
+          task: { id: string; description: string; agentType: string }
+        },
+    appState: makeState(),
+    cachedDetection: undefined as undefined | { isNative?: boolean },
+    inProcessEnabled: false,
+    inProcessTeammate: false,
+    insideTmux: null as boolean | null,
+    teammate: {
+      active: false,
+      agentName: undefined as string | undefined,
+      color: undefined as string | undefined,
+      teamName: undefined as string | undefined,
+    },
+    viewedTeammate: undefined as
+      | undefined
+      | { identity: { agentName: string; color?: string } },
+    reset() {
+      state.activeAgent = { type: 'leader' }
+      state.appState = makeState()
+      state.cachedDetection = undefined
+      state.inProcessEnabled = false
+      state.inProcessTeammate = false
+      state.insideTmux = null
+      state.teammate = {
+        active: false,
+        agentName: undefined,
+        color: undefined,
+        teamName: undefined,
+      }
+      state.viewedTeammate = undefined
+    },
+  }
+
+  return state
+})
+
+vi.mock('../../../src/tui/state/AppState.js', () => ({
+  useAppState: (selector: (state: typeof harness.appState) => unknown) =>
+    selector(harness.appState),
+  useAppStateStore: () => ({
+    getState: () => harness.appState,
+  }),
+}))
+
+vi.mock('../../../src/tui/state/selectors.js', () => ({
+  getActiveAgentForInput: () => harness.activeAgent,
+  getViewedTeammateTask: () => harness.viewedTeammate,
+}))
+
+vi.mock('../../../src/tools/AgentTool/agentColorManager.js', () => ({
+  AGENT_COLOR_TO_THEME_COLOR: {
+    blue: 'blue_FOR_SUBAGENTS_ONLY',
+    cyan: 'cyan_FOR_SUBAGENTS_ONLY',
+    green: 'green_FOR_SUBAGENTS_ONLY',
+    orange: 'orange_FOR_SUBAGENTS_ONLY',
+    pink: 'pink_FOR_SUBAGENTS_ONLY',
+    purple: 'purple_FOR_SUBAGENTS_ONLY',
+    red: 'red_FOR_SUBAGENTS_ONLY',
+    yellow: 'yellow_FOR_SUBAGENTS_ONLY',
+  },
+  AGENT_COLORS: [
+    'red',
+    'blue',
+    'green',
+    'yellow',
+    'purple',
+    'orange',
+    'pink',
+    'cyan',
+  ],
+  getAgentColor: (agentType: string) =>
+    agentType === 'writer' ? 'yellow_FOR_SUBAGENTS_ONLY' : undefined,
+}))
+
+vi.mock('../../../src/utils/standaloneAgent.js', () => ({
+  getStandaloneAgentName: (state: typeof harness.appState) =>
+    state.standaloneAgentContext?.name,
+}))
+
+vi.mock('../../../src/utils/swarm/backends/detection.js', () => ({
+  isInsideTmux: () => Promise.resolve(harness.insideTmux),
+}))
+
+vi.mock('../../../src/utils/swarm/backends/registry.js', () => ({
+  getCachedDetectionResult: () => harness.cachedDetection,
+  isInProcessEnabled: () => harness.inProcessEnabled,
+}))
+
+vi.mock('../../../src/utils/swarm/constants.js', () => ({
+  getSwarmSocketName: () => 'row-243',
+}))
+
+vi.mock('../../../src/utils/teammate.js', () => ({
+  getAgentName: () => harness.teammate.agentName,
+  getTeammateColor: () => harness.teammate.color,
+  getTeamName: () => harness.teammate.teamName,
+  isTeammate: () => harness.teammate.active,
+}))
+
+vi.mock('../../../src/utils/teammateContext.js', () => ({
+  isInProcessTeammate: () => harness.inProcessTeammate,
+}))
+
+import { createRoot } from '../../../src/tui/ink/root.js'
+import { useSwarmBanner } from '../../../src/tui/components/PromptInput/useSwarmBanner.js'
+
+type Banner = ReturnType<typeof useSwarmBanner>
+
+function createStreams(): {
+  readonly stdout: PassThrough
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 120
+
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 25): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function renderBanner(): Promise<Banner> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  let latest: Banner | undefined
+
+  function Harness(): null {
+    latest = useSwarmBanner()
+    return null
+  }
+
+  try {
+    root.render(React.createElement(Harness))
+    await sleep()
+    await sleep()
+    if (latest === undefined) throw new Error('hook did not render')
+    return latest
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    await sleep(0)
+  }
+}
+
+async function expectBanner(
+  setup: () => void,
+  expected: Banner,
+): Promise<void> {
+  harness.reset()
+  setup()
+  expect(await renderBanner()).toEqual(expected)
+}
+
+describe('useSwarmBanner coverage swarm row 243', () => {
+  afterEach(() => {
+    harness.reset()
+    vi.clearAllMocks()
+  })
+
+  test('skips teammate banner when the process is in-process or lacks a team name', async () => {
+    await expectBanner(() => {
+      harness.inProcessTeammate = true
+      harness.teammate = {
+        active: true,
+        agentName: 'builder',
+        color: 'orange',
+        teamName: 'core',
+      }
+      harness.appState.agent = 'planner'
+      harness.appState.agentDefinitions.activeAgents = [
+        { agentType: 'planner', color: 'cyan' },
+      ]
+    }, {
+      bgColor: 'cyan_FOR_SUBAGENTS_ONLY',
+      text: 'planner',
+    })
+
+    await expectBanner(() => {
+      harness.teammate = {
+        active: true,
+        agentName: 'builder',
+        color: 'orange',
+        teamName: undefined,
+      }
+      harness.appState.standaloneAgentContext = { name: 'solo' }
+    }, {
+      bgColor: 'cyan_FOR_SUBAGENTS_ONLY',
+      text: 'solo',
+    })
+  })
+
+  test('falls through when teammate identity is missing and no agent definition matches', async () => {
+    await expectBanner(() => {
+      harness.teammate = {
+        active: true,
+        agentName: undefined,
+        color: 'orange',
+        teamName: 'core',
+      }
+      harness.appState.agent = 'reviewer'
+      harness.appState.agentDefinitions.activeAgents = [
+        { agentType: 'planner', color: 'green' },
+      ]
+    }, {
+      bgColor: 'promptBorder',
+      text: 'reviewer',
+    })
+  })
+
+  test('shows viewed teammate when the leader is inside tmux or in-process mode', async () => {
+    await expectBanner(() => {
+      harness.insideTmux = true
+      harness.appState.teamContext = {
+        teamName: 'launch',
+        teammates: { analyst: {} },
+      }
+      harness.viewedTeammate = {
+        identity: { agentName: 'analyst', color: 'blue' },
+      }
+    }, {
+      bgColor: 'blue_FOR_SUBAGENTS_ONLY',
+      text: '@analyst',
+    })
+
+    await expectBanner(() => {
+      harness.inProcessEnabled = true
+      harness.appState.teamContext = {
+        teamName: 'launch',
+        teammates: { writer: {} },
+      }
+      harness.viewedTeammate = {
+        identity: { agentName: 'writer', color: undefined },
+      }
+    }, {
+      bgColor: 'cyan_FOR_SUBAGENTS_ONLY',
+      text: '@writer',
+    })
+  })
+
+  test('uses background task colors and ignores empty teammate collections', async () => {
+    await expectBanner(() => {
+      harness.activeAgent = {
+        type: 'named_agent',
+        task: {
+          agentType: 'writer',
+          description: 'Draft notes',
+          id: 'task-1',
+        },
+      }
+      harness.appState.agentNameRegistry.set('scribe', 'task-1')
+    }, {
+      bgColor: 'yellow_FOR_SUBAGENTS_ONLY',
+      text: '@scribe',
+    })
+
+    await expectBanner(() => {
+      harness.appState.teamContext = {
+        teamName: 'empty',
+        teammates: {},
+      }
+      harness.appState.standaloneAgentContext = {
+        color: 'red',
+        name: 'solo',
+      }
+    }, {
+      bgColor: 'red_FOR_SUBAGENTS_ONLY',
+      text: 'solo',
+    })
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-244-components-compact-CompactBoundaryMessage.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-244-components-compact-CompactBoundaryMessage.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { CompactBoundaryMessage } from '../../../src/tui/components/compact/CompactBoundaryMessage.js'
+
+const harness = vi.hoisted(() => ({
+  cache: [] as unknown[],
+  shortcut: 'ctrl+o',
+  shortcutCalls: [] as Array<{
+    action: string
+    scope: string
+    fallback: string
+  }>,
+}))
+
+const memoSentinel = Symbol.for('react.memo_cache_sentinel')
+
+vi.mock('react-compiler-runtime', () => ({
+  c: (size: number) => {
+    if (harness.cache.length !== size) {
+      harness.cache = Array.from({ length: size }, () => memoSentinel)
+    }
+
+    return harness.cache
+  },
+}))
+
+vi.mock('../../../src/tui/ink.js', async () => {
+  const ReactModule = await vi.importActual<typeof import('react')>('react')
+  const Passthrough = ({ children }: { children?: React.ReactNode }) =>
+    ReactModule.createElement(ReactModule.Fragment, null, children)
+
+  return {
+    Box: Passthrough,
+    Text: Passthrough,
+  }
+})
+
+vi.mock('../../../src/tui/keybindings/useShortcutDisplay.js', () => ({
+  useShortcutDisplay: (action: string, scope: string, fallback: string) => {
+    harness.shortcutCalls.push({ action, scope, fallback })
+    return harness.shortcut
+  },
+}))
+
+describe('CompactBoundaryMessage coverage swarm', () => {
+  beforeEach(() => {
+    harness.cache = Array.from({ length: 2 }, () => memoSentinel)
+    harness.shortcut = 'ctrl+o'
+    harness.shortcutCalls = []
+  })
+
+  test('renders the configured transcript shortcut and requests the expected fallback binding', () => {
+    harness.shortcut = 'alt+h'
+
+    const output = renderPlain(<CompactBoundaryMessage />)
+
+    expect(output).toContain('Conversation compacted (alt+h for history)')
+    expect(harness.shortcutCalls).toEqual([
+      {
+        action: 'app:toggleTranscript',
+        scope: 'Global',
+        fallback: 'ctrl+o',
+      },
+    ])
+  })
+
+  test('reuses the cached message while the displayed shortcut is unchanged', () => {
+    const first = CompactBoundaryMessage()
+    const second = CompactBoundaryMessage()
+
+    expect(second).toBe(first)
+    expect(renderPlain(second)).toContain(
+      'Conversation compacted (ctrl+o for history)',
+    )
+
+    harness.shortcut = 'cmd+o'
+
+    const updated = CompactBoundaryMessage()
+
+    expect(updated).not.toBe(first)
+    expect(renderPlain(updated)).toContain(
+      'Conversation compacted (cmd+o for history)',
+    )
+  })
+})
+
+function renderPlain(node: React.ReactNode): string {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return ''
+  }
+  if (typeof node === 'string' || typeof node === 'number') {
+    return String(node)
+  }
+  if (Array.isArray(node)) {
+    return node.map(renderPlain).join('')
+  }
+  if (React.isValidElement(node)) {
+    if (typeof node.type === 'function') {
+      const Component = node.type as (
+        props: typeof node.props,
+      ) => React.ReactNode
+      return renderPlain(Component(node.props))
+    }
+    const element = node as React.ReactElement<{
+      children?: React.ReactNode
+    }>
+    return renderPlain(element.props.children)
+  }
+  return ''
+}

--- a/runtime/tests/tui/coverage-swarm/swarm-245-components-design-system-ThemedText.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-245-components-design-system-ThemedText.test.tsx
@@ -1,0 +1,266 @@
+import { PassThrough } from 'node:stream'
+
+import React from 'react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  feature: vi.fn(() => false),
+  getGlobalConfig: vi.fn(() => ({ theme: 'dark' })),
+  getSystemThemeName: vi.fn(() => 'dark'),
+  saveGlobalConfig: vi.fn(),
+}))
+
+vi.mock('bun:bundle', () => ({
+  feature: mocks.feature,
+}))
+
+vi.mock('../../../src/utils/config.js', () => ({
+  getGlobalConfig: mocks.getGlobalConfig,
+  saveGlobalConfig: mocks.saveGlobalConfig,
+}))
+
+vi.mock('../../../src/utils/systemTheme.js', () => ({
+  getSystemThemeName: mocks.getSystemThemeName,
+}))
+
+import ThemedText, {
+  TextHoverColorContext,
+} from '../../../src/tui/components/design-system/ThemedText.js'
+import { ThemeProvider } from '../../../src/tui/components/design-system/ThemeProvider.js'
+import type { DOMElement, DOMNode } from '../../../src/tui/ink/dom.js'
+import instances from '../../../src/tui/ink/instances.js'
+import { createRoot } from '../../../src/tui/ink/root.js'
+import type { TextStyles } from '../../../src/tui/ink/styles.js'
+import { getTheme } from '../../../src/utils/theme.js'
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
+
+type TestRoot = Awaited<ReturnType<typeof createRoot>>
+
+type StyledSegment = {
+  text: string
+  styles: TextStyles
+}
+
+const mountedRoots: Array<{
+  root: TestRoot
+  stdin: TestStdin
+  stdout: PassThrough
+}> = []
+
+function createStreams(): { stdin: TestStdin; stdout: PassThrough } {
+  const stdin = new PassThrough() as TestStdin
+  const stdout = new PassThrough()
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  stdout.resume()
+  ;(stdout as unknown as { columns: number }).columns = 80
+  ;(stdout as unknown as { rows: number }).rows = 24
+  ;(stdout as unknown as { isTTY: boolean }).isTTY = true
+
+  return { stdin, stdout }
+}
+
+function sleep(ms = 30): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function getRootNode(stdout: PassThrough): DOMElement {
+  const instance = instances.get(stdout as unknown as NodeJS.WriteStream)
+
+  if (!instance?.rootNode) {
+    throw new Error('Ink root node not found')
+  }
+
+  return instance.rootNode
+}
+
+function collectSegments(
+  node: DOMNode,
+  inheritedStyles: TextStyles = {},
+  segments: StyledSegment[] = [],
+): StyledSegment[] {
+  if (node.nodeName === '#text') {
+    if (node.nodeValue !== '') {
+      segments.push({ text: node.nodeValue, styles: inheritedStyles })
+    }
+    return segments
+  }
+
+  const nextStyles = node.textStyles
+    ? { ...inheritedStyles, ...node.textStyles }
+    : inheritedStyles
+
+  for (const child of node.childNodes) {
+    collectSegments(child, nextStyles, segments)
+  }
+
+  return segments
+}
+
+function collectTextElements(
+  node: DOMNode,
+  elements: DOMElement[] = [],
+): DOMElement[] {
+  if (node.nodeName === '#text') {
+    return elements
+  }
+
+  if (node.nodeName === 'ink-text') {
+    elements.push(node)
+  }
+
+  for (const child of node.childNodes) {
+    collectTextElements(child, elements)
+  }
+
+  return elements
+}
+
+function findSegment(segments: StyledSegment[], text: string): StyledSegment {
+  const segment = segments.find(entry => entry.text === text)
+  expect(segment).toBeDefined()
+  return segment!
+}
+
+async function renderText(node: React.ReactNode): Promise<{
+  rerender: (next: React.ReactNode) => Promise<void>
+  segments: () => StyledSegment[]
+  textElements: () => DOMElement[]
+}> {
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+  mountedRoots.push({ root, stdin, stdout })
+
+  const rerender = async (next: React.ReactNode) => {
+    root.render(next)
+    await sleep()
+  }
+
+  await rerender(node)
+
+  return {
+    rerender,
+    segments: () => collectSegments(getRootNode(stdout)),
+    textElements: () => collectTextElements(getRootNode(stdout)),
+  }
+}
+
+afterEach(() => {
+  for (const { root, stdin, stdout } of mountedRoots.splice(0)) {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+    instances.delete(stdout as unknown as NodeJS.WriteStream)
+  }
+  vi.clearAllMocks()
+})
+
+describe('ThemedText coverage swarm row 245', () => {
+  test('resolves theme foreground and background colors from the active provider theme', async () => {
+    const theme = getTheme('light')
+    const text = (
+      <ThemeProvider initialState="light">
+        <ThemedText
+          color="success"
+          backgroundColor="background"
+          bold={true}
+          italic={true}
+          underline={true}
+          strikethrough={true}
+          inverse={true}
+          wrap="truncate-end"
+        >
+          Styled
+        </ThemedText>
+      </ThemeProvider>
+    )
+    const rendered = await renderText(text)
+
+    expect(rendered.segments()).toEqual([
+      {
+        text: 'Styled',
+        styles: {
+          backgroundColor: theme.background,
+          bold: true,
+          color: theme.success,
+          inverse: true,
+          italic: true,
+          strikethrough: true,
+          underline: true,
+        },
+      },
+    ])
+    expect(rendered.textElements()[0]?.style).toMatchObject({
+      textWrap: 'truncate-end',
+    })
+
+    await rendered.rerender(
+      <ThemeProvider initialState="light">
+        <ThemedText
+          color="success"
+          backgroundColor="background"
+          bold={true}
+          italic={true}
+          underline={true}
+          strikethrough={true}
+          inverse={true}
+          wrap="truncate-end"
+        >
+          Styled
+        </ThemedText>
+      </ThemeProvider>,
+    )
+
+    expect(rendered.segments()).toHaveLength(1)
+  })
+
+  test('passes raw color formats through without resolving them as theme keys', async () => {
+    const rendered = await renderText(
+      <>
+        <ThemedText color="rgb(1,2,3)">rgb</ThemedText>
+        <ThemedText color="#123abc">hex</ThemedText>
+        <ThemedText color="ansi256(42)">ansi256</ThemedText>
+        <ThemedText color="ansi:yellow">ansi</ThemedText>
+      </>,
+    )
+    const segments = rendered.segments()
+
+    expect(findSegment(segments, 'rgb').styles.color).toBe('rgb(1,2,3)')
+    expect(findSegment(segments, 'hex').styles.color).toBe('#123abc')
+    expect(findSegment(segments, 'ansi256').styles.color).toBe('ansi256(42)')
+    expect(findSegment(segments, 'ansi').styles.color).toBe('ansi:yellow')
+  })
+
+  test('uses hover context for uncolored text and inactive color for dimmed text', async () => {
+    const theme = getTheme('dark')
+    const rendered = await renderText(
+      <>
+        <TextHoverColorContext.Provider value="warning">
+          <ThemedText>Hovered</ThemedText>
+          <ThemedText color="success">Explicit</ThemedText>
+        </TextHoverColorContext.Provider>
+        <ThemedText dimColor={true}>Dimmed</ThemedText>
+        <ThemedText>Plain</ThemedText>
+      </>,
+    )
+    const segments = rendered.segments()
+
+    expect(findSegment(segments, 'Hovered').styles.color).toBe(theme.warning)
+    expect(findSegment(segments, 'Explicit').styles.color).toBe(theme.success)
+    expect(findSegment(segments, 'Dimmed').styles.color).toBe(theme.inactive)
+    expect(findSegment(segments, 'Plain').styles.color).toBeUndefined()
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-246-hooks-useClipboardImageHint.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-246-hooks-useClipboardImageHint.test.ts
@@ -1,0 +1,202 @@
+import { PassThrough } from 'node:stream'
+
+import React, { act } from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+const fixture = vi.hoisted(() => ({
+  addNotification: vi.fn(),
+  hasImageInClipboard: vi.fn(),
+}))
+
+vi.mock('../../../src/tui/context/notifications.js', () => ({
+  useNotifications: () => ({
+    addNotification: fixture.addNotification,
+  }),
+}))
+
+vi.mock('../../../src/tui/keybindings/shortcutFormat.js', () => ({
+  getShortcutDisplay: vi.fn(() => 'Ctrl+V'),
+}))
+
+vi.mock('../../../src/utils/imagePaste.js', () => ({
+  hasImageInClipboard: fixture.hasImageInClipboard,
+}))
+
+import { createRoot } from '../../../src/tui/ink.js'
+import { useClipboardImageHint } from '../../../src/tui/hooks/useClipboardImageHint.js'
+
+type HookProps = {
+  readonly enabled: boolean
+  readonly isFocused: boolean
+}
+
+type TestStreams = {
+  readonly stdin: PassThrough & {
+    isTTY: boolean
+    ref: () => void
+    setRawMode: (mode: boolean) => void
+    unref: () => void
+  }
+  readonly stdout: PassThrough & {
+    columns: number
+    isTTY: boolean
+    rows: number
+  }
+}
+
+function createStreams(): TestStreams {
+  const stdin = new PassThrough() as TestStreams['stdin']
+  const stdout = new PassThrough() as TestStreams['stdout']
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+
+  stdout.columns = 100
+  stdout.rows = 24
+  stdout.isTTY = true
+  stdout.resume()
+
+  return { stdin, stdout }
+}
+
+async function flushEffects(ms = 0): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms)
+    await Promise.resolve()
+  })
+}
+
+async function renderHookHarness(
+  initialProps: HookProps,
+): Promise<{
+  readonly dispose: () => Promise<void>
+  readonly render: (next: Partial<HookProps>) => Promise<void>
+}> {
+  let props = initialProps
+  const { stdin, stdout } = createStreams()
+  const root = await createRoot({
+    patchConsole: false,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+  })
+
+  function Harness(): null {
+    useClipboardImageHint(props.isFocused, props.enabled)
+    return null
+  }
+
+  async function render(next: Partial<HookProps> = {}): Promise<void> {
+    props = { ...props, ...next }
+    await act(async () => {
+      root.render(React.createElement(Harness))
+    })
+    await flushEffects()
+  }
+
+  await render()
+
+  return {
+    dispose: async () => {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+      await flushEffects()
+    },
+    render,
+  }
+}
+
+describe('useClipboardImageHint coverage swarm row 246', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(60_000)
+    fixture.addNotification.mockClear()
+    fixture.hasImageInClipboard.mockReset()
+    fixture.hasImageInClipboard.mockResolvedValue(false)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  test('does not inspect the clipboard on initial focus or disabled focus regain', async () => {
+    const rendered = await renderHookHarness({
+      enabled: true,
+      isFocused: true,
+    })
+
+    try {
+      await flushEffects(1_000)
+      expect(fixture.hasImageInClipboard).not.toHaveBeenCalled()
+
+      await rendered.render({ isFocused: false })
+      await rendered.render({ enabled: false, isFocused: true })
+      await flushEffects(1_000)
+
+      expect(fixture.hasImageInClipboard).not.toHaveBeenCalled()
+      expect(fixture.addNotification).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('clears a pending debounce when focus is lost before the check fires', async () => {
+    const rendered = await renderHookHarness({
+      enabled: true,
+      isFocused: false,
+    })
+
+    try {
+      await rendered.render({ isFocused: true })
+      await flushEffects(999)
+      await rendered.render({ isFocused: false })
+      await flushEffects(1)
+
+      expect(fixture.hasImageInClipboard).not.toHaveBeenCalled()
+      expect(fixture.addNotification).not.toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('notifies for clipboard images and suppresses checks during cooldown', async () => {
+    fixture.hasImageInClipboard.mockResolvedValue(true)
+    const rendered = await renderHookHarness({
+      enabled: true,
+      isFocused: false,
+    })
+
+    try {
+      await rendered.render({ isFocused: true })
+      await flushEffects(1_000)
+
+      expect(fixture.hasImageInClipboard).toHaveBeenCalledTimes(1)
+      expect(fixture.addNotification).toHaveBeenCalledWith({
+        key: 'clipboard-image-hint',
+        text: 'Image in clipboard · Ctrl+V to paste',
+        priority: 'immediate',
+        timeoutMs: 8000,
+      })
+
+      await rendered.render({ isFocused: false })
+      await rendered.render({ isFocused: true })
+      await flushEffects(1_000)
+
+      expect(fixture.hasImageInClipboard).toHaveBeenCalledTimes(1)
+      expect(fixture.addNotification).toHaveBeenCalledTimes(1)
+
+      await rendered.render({ isFocused: false })
+      await flushEffects(30_000)
+      await rendered.render({ isFocused: true })
+      await flushEffects(1_000)
+
+      expect(fixture.hasImageInClipboard).toHaveBeenCalledTimes(2)
+      expect(fixture.addNotification).toHaveBeenCalledTimes(2)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-247-hooks-useTerminalSize.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-247-hooks-useTerminalSize.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import type { TerminalSize } from '../../../src/tui/ink/components/TerminalSizeContext.js'
+
+async function loadHookWithTerminalSize(size: TerminalSize | null): Promise<{
+  readonly useContext: ReturnType<typeof vi.fn>
+  readonly useTerminalSize: () => TerminalSize
+}> {
+  const useContext = vi.fn(() => size)
+
+  vi.doMock('react', async () => {
+    const actual = await vi.importActual<typeof import('react')>('react')
+    return {
+      ...actual,
+      useContext,
+    }
+  })
+
+  const { useTerminalSize } = await import(
+    '../../../src/tui/hooks/useTerminalSize.js'
+  )
+
+  return { useContext, useTerminalSize }
+}
+
+afterEach(() => {
+  vi.doUnmock('react')
+  vi.resetModules()
+})
+
+describe('useTerminalSize coverage swarm row 247', () => {
+  test('returns the terminal size from context', async () => {
+    const size = { columns: 132, rows: 43 }
+    const { useContext, useTerminalSize } = await loadHookWithTerminalSize(size)
+
+    expect(useTerminalSize()).toBe(size)
+    expect(useContext).toHaveBeenCalledTimes(1)
+  })
+
+  test('rejects usage without a terminal size provider', async () => {
+    const { useContext, useTerminalSize } = await loadHookWithTerminalSize(null)
+
+    expect(() => useTerminalSize()).toThrow(
+      'useTerminalSize must be used within an Ink App component',
+    )
+    expect(useContext).toHaveBeenCalledTimes(1)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-248-ink-line-width-cache.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-248-ink-line-width-cache.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+type LineWidthModule = typeof import('../../../src/tui/ink/line-width-cache.js')
+
+async function loadLineWidth(
+  implementation: (line: string) => number,
+): Promise<
+  LineWidthModule & {
+    stringWidth: ReturnType<typeof vi.fn<(line: string) => number>>
+  }
+> {
+  vi.resetModules()
+
+  const stringWidth = vi.fn<(line: string) => number>(implementation)
+  vi.doMock('../../../src/tui/ink/stringWidth.js', () => ({
+    stringWidth,
+  }))
+
+  const module = await import('../../../src/tui/ink/line-width-cache.js')
+  return { ...module, stringWidth }
+}
+
+afterEach(() => {
+  vi.doUnmock('../../../src/tui/ink/stringWidth.js')
+  vi.resetModules()
+})
+
+describe('lineWidth coverage swarm row 248', () => {
+  test('caches measured widths including zero-width lines', async () => {
+    const { lineWidth, stringWidth } = await loadLineWidth(line =>
+      line.length === 0 ? 0 : line.length,
+    )
+
+    expect(lineWidth('')).toBe(0)
+    expect(lineWidth('')).toBe(0)
+    expect(lineWidth('abc')).toBe(3)
+    expect(lineWidth('abc')).toBe(3)
+
+    expect(stringWidth).toHaveBeenCalledTimes(2)
+    expect(stringWidth).toHaveBeenNthCalledWith(1, '')
+    expect(stringWidth).toHaveBeenNthCalledWith(2, 'abc')
+  })
+
+  test('clears the cache after it reaches the maximum size', async () => {
+    const { lineWidth, stringWidth } = await loadLineWidth(line => line.length)
+
+    for (let i = 0; i < 4096; i += 1) {
+      expect(lineWidth(`line-${i}`)).toBe(`line-${i}`.length)
+    }
+
+    expect(lineWidth('line-4096')).toBe('line-4096'.length)
+    expect(lineWidth('line-4096')).toBe('line-4096'.length)
+    expect(lineWidth('line-0')).toBe('line-0'.length)
+
+    expect(stringWidth).toHaveBeenCalledTimes(4098)
+    expect(
+      stringWidth.mock.calls.filter(([line]) => line === 'line-4096'),
+    ).toHaveLength(1)
+    expect(
+      stringWidth.mock.calls.filter(([line]) => line === 'line-0'),
+    ).toHaveLength(2)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-249-ink-render-to-screen.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-249-ink-render-to-screen.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from 'vitest'
+import React from 'react'
+
+import {
+  applyPositionedHighlight,
+  renderToScreen,
+  scanPositions,
+} from '../../../src/tui/ink/render-to-screen.ts'
+import { Box } from '../../../src/tui/ink.ts'
+import {
+  CellWidth,
+  CharPool,
+  HyperlinkPool,
+  StylePool,
+  cellAt,
+  createScreen,
+  setCellAt,
+  type Screen,
+} from '../../../src/tui/ink/screen.ts'
+
+function makeScreen(width: number, height: number): {
+  screen: Screen
+  styles: StylePool
+} {
+  const styles = new StylePool()
+  return {
+    screen: createScreen(
+      width,
+      height,
+      styles,
+      new CharPool(),
+      new HyperlinkPool(),
+    ),
+    styles,
+  }
+}
+
+function writeCell(
+  screen: Screen,
+  styles: StylePool,
+  col: number,
+  row: number,
+  char: string,
+  width = CellWidth.Narrow,
+): void {
+  setCellAt(screen, col, row, {
+    char,
+    hyperlink: undefined,
+    styleId: styles.none,
+    width,
+  })
+}
+
+describe('render-to-screen coverage swarm row 249', () => {
+  test('returns a positive screen height for empty renders', () => {
+    const rendered = renderToScreen(React.createElement(Box), 10)
+
+    expect(rendered.height).toBe(1)
+    expect(rendered.screen.height).toBe(1)
+  })
+
+  test('scanPositions skips spacer heads and maps folded code units to cells', () => {
+    const { screen, styles } = makeScreen(8, 1)
+    ;['a', 'a', 'a', 'a', 'x', 'b', '\u0130', 'z'].forEach((char, col) => {
+      writeCell(
+        screen,
+        styles,
+        col,
+        0,
+        char,
+        col === 4 ? CellWidth.SpacerHead : CellWidth.Narrow,
+      )
+    })
+
+    expect(scanPositions(screen, 'aa')).toEqual([
+      { col: 0, len: 2, row: 0 },
+      { col: 2, len: 2, row: 0 },
+    ])
+    expect(scanPositions(screen, 'xb')).toEqual([])
+    expect(scanPositions(screen, 'i\u0307')).toEqual([
+      { col: 6, len: 1, row: 0 },
+    ])
+  })
+
+  test('applyPositionedHighlight rejects negative indexes and bottom-clipped rows', () => {
+    const { screen, styles } = makeScreen(4, 1)
+    ;['t', 'e', 's', 't'].forEach((char, col) => {
+      writeCell(screen, styles, col, 0, char)
+    })
+
+    expect(
+      applyPositionedHighlight(
+        screen,
+        styles,
+        [{ col: 0, len: 1, row: 0 }],
+        0,
+        -1,
+      ),
+    ).toBe(false)
+    expect(
+      applyPositionedHighlight(
+        screen,
+        styles,
+        [{ col: 0, len: 1, row: 1 }],
+        0,
+        0,
+      ),
+    ).toBe(false)
+    expect(cellAt(screen, 0, 0)?.styleId).toBe(styles.none)
+  })
+})

--- a/runtime/tests/tui/coverage-swarm/swarm-250-ink-searchHighlight.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-250-ink-searchHighlight.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from 'vitest'
+
+import { applySearchHighlight } from '../../../src/tui/ink/searchHighlight.js'
+import {
+  CellWidth,
+  CharPool,
+  HyperlinkPool,
+  StylePool,
+  cellAt,
+  createScreen,
+  markNoSelectRegion,
+  setCellAt,
+  type Screen,
+} from '../../../src/tui/ink/screen.js'
+
+function makeScreen(width: number, height: number): {
+  screen: Screen
+  styles: StylePool
+} {
+  const styles = new StylePool()
+  return {
+    screen: createScreen(
+      width,
+      height,
+      styles,
+      new CharPool(),
+      new HyperlinkPool(),
+    ),
+    styles,
+  }
+}
+
+function writeText(
+  screen: Screen,
+  styles: StylePool,
+  row: number,
+  text: string,
+): void {
+  Array.from(text).forEach((char, col) => {
+    setCellAt(screen, col, row, {
+      char,
+      hyperlink: undefined,
+      styleId: styles.none,
+      width: CellWidth.Narrow,
+    })
+  })
+}
+
+function styleAt(screen: Screen, col: number, row = 0): number {
+  return cellAt(screen, col, row)!.styleId
+}
+
+describe('searchHighlight coverage swarm row 250', () => {
+  test('returns false and leaves styles unchanged for empty or missing queries', () => {
+    const emptyQuery = makeScreen(6, 1)
+    writeText(emptyQuery.screen, emptyQuery.styles, 0, 'Needle')
+
+    expect(
+      applySearchHighlight(emptyQuery.screen, '', emptyQuery.styles),
+    ).toBe(false)
+    expect(Array.from({ length: 6 }, (_, col) => styleAt(emptyQuery.screen, col)))
+      .toEqual(new Array(6).fill(emptyQuery.styles.none))
+
+    const missingQuery = makeScreen(6, 1)
+    writeText(missingQuery.screen, missingQuery.styles, 0, 'Needle')
+
+    expect(
+      applySearchHighlight(missingQuery.screen, 'absent', missingQuery.styles),
+    ).toBe(false)
+    expect(
+      Array.from({ length: 6 }, (_, col) => styleAt(missingQuery.screen, col)),
+    ).toEqual(new Array(6).fill(missingQuery.styles.none))
+  })
+
+  test('highlights case-insensitive non-overlapping matches', () => {
+    const { screen, styles } = makeScreen(3, 1)
+    writeText(screen, styles, 0, 'aAa')
+
+    expect(applySearchHighlight(screen, 'aa', styles)).toBe(true)
+
+    const inverse = styles.withInverse(styles.none)
+    expect(styleAt(screen, 0)).toBe(inverse)
+    expect(styleAt(screen, 1)).toBe(inverse)
+    expect(styleAt(screen, 2)).toBe(styles.none)
+  })
+
+  test('skips no-select cells and wide spacer tails when mapping matches', () => {
+    const { screen, styles } = makeScreen(4, 1)
+    writeText(screen, styles, 0, '>')
+    setCellAt(screen, 1, 0, {
+      char: '好',
+      hyperlink: undefined,
+      styleId: styles.none,
+      width: CellWidth.Wide,
+    })
+    setCellAt(screen, 3, 0, {
+      char: 'B',
+      hyperlink: undefined,
+      styleId: styles.none,
+      width: CellWidth.Narrow,
+    })
+    markNoSelectRegion(screen, 0, 0, 1, 1)
+
+    expect(applySearchHighlight(screen, '好b', styles)).toBe(true)
+
+    const inverse = styles.withInverse(styles.none)
+    expect(styleAt(screen, 0)).toBe(styles.none)
+    expect(styleAt(screen, 1)).toBe(inverse)
+    expect(cellAt(screen, 2, 0)!.width).toBe(CellWidth.SpacerTail)
+    expect(styleAt(screen, 2)).toBe(styles.none)
+    expect(styleAt(screen, 3)).toBe(inverse)
+  })
+
+  test('maps lowercase expansions back to the originating visible cell', () => {
+    const { screen, styles } = makeScreen(2, 1)
+    writeText(screen, styles, 0, 'İx')
+
+    expect(applySearchHighlight(screen, 'İx', styles)).toBe(true)
+
+    const inverse = styles.withInverse(styles.none)
+    expect(styleAt(screen, 0)).toBe(inverse)
+    expect(styleAt(screen, 1)).toBe(inverse)
+  })
+})

--- a/runtime/tests/tui/hooks/notifs/useMcpConnectivityStatus.test.tsx
+++ b/runtime/tests/tui/hooks/notifs/useMcpConnectivityStatus.test.tsx
@@ -43,7 +43,7 @@ vi.mock("../../../bootstrap/state", () => ({
   getIsRemoteMode: () => probes.remoteMode,
 }));
 
-vi.mock("../../../services/mcp/agencai", () => ({
+vi.mock("../../../services/mcp/agencai.js", () => ({
   hasAgenCAiMcpEverConnected: () => probes.agencAiConnected,
 }));
 

--- a/runtime/tests/tui/ink/systemThemeWatcher.test.ts
+++ b/runtime/tests/tui/ink/systemThemeWatcher.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import type { TerminalQuerier } from '../../../src/tui/ink/terminal-querier.js'
+import { watchSystemTheme } from '../../../src/utils/systemThemeWatcher.js'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function flushMicrotasks(): Promise<void> {
+  return Promise.resolve().then(() => undefined)
+}
+
+describe('systemThemeWatcher', () => {
+  test('polls OSC 11 immediately, repeats on an interval, and cleans up', async () => {
+    vi.useFakeTimers()
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({ type: 'osc', code: 11, data: 'rgb:ffff/ffff/ffff' })
+      .mockResolvedValueOnce({ type: 'osc', code: 11, data: 'rgb:0000/0000/0000' })
+    const flush = vi.fn().mockResolvedValue(undefined)
+    const onThemeChange = vi.fn()
+    const querier = { send, flush } as unknown as TerminalQuerier
+
+    const cleanup = watchSystemTheme(querier, onThemeChange)
+    await flushMicrotasks()
+
+    expect(onThemeChange).toHaveBeenLastCalledWith('light')
+    expect(send).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    await flushMicrotasks()
+
+    expect(onThemeChange).toHaveBeenLastCalledWith('dark')
+    expect(send).toHaveBeenCalledTimes(2)
+
+    cleanup()
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    expect(send).toHaveBeenCalledTimes(2)
+  })
+})

--- a/runtime/tests/tui/message-renderers/AttachmentMessage.render.test.tsx
+++ b/runtime/tests/tui/message-renderers/AttachmentMessage.render.test.tsx
@@ -21,6 +21,21 @@ vi.mock("../../utils/agentSwarmsEnabled.js", () => ({
 }));
 
 vi.mock("../../utils/teammateMailbox.js", () => ({
+  isTaskAssignment: (text: string) => {
+    try {
+      const parsed = JSON.parse(text);
+      if (
+        parsed?.type === "task_assignment" &&
+        typeof parsed.taskId === "string" &&
+        typeof parsed.subject === "string"
+      ) {
+        return { assignedBy: "", description: "", timestamp: "", ...parsed };
+      }
+    } catch {
+      // Not JSON.
+    }
+    return null;
+  },
   isShutdownApproved: (text: string) => text === "shutdown-approved",
 }));
 

--- a/runtime/tests/tui/message-renderers/AttachmentMessage.wave200-071.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/AttachmentMessage.wave200-071.coverage.test.tsx
@@ -13,6 +13,21 @@ vi.mock('../../utils/agentSwarmsEnabled.js', () => ({
 }))
 
 vi.mock('../../utils/teammateMailbox.js', () => ({
+  isTaskAssignment: (text: string) => {
+    try {
+      const parsed = JSON.parse(text)
+      if (
+        parsed?.type === 'task_assignment' &&
+        typeof parsed.taskId === 'string' &&
+        typeof parsed.subject === 'string'
+      ) {
+        return { assignedBy: '', description: '', timestamp: '', ...parsed }
+      }
+    } catch {
+      // Not JSON.
+    }
+    return null
+  },
   isShutdownApproved: (text: string) => text === 'shutdown-approved',
 }))
 

--- a/runtime/tests/tui/message-renderers/TaskAssignmentMessage.coverage.test.tsx
+++ b/runtime/tests/tui/message-renderers/TaskAssignmentMessage.coverage.test.tsx
@@ -33,5 +33,11 @@ describe('TaskAssignmentMessage coverage', () => {
     const nonAssignment = JSON.stringify({ type: 'teammate_message' })
     expect(tryRenderTaskAssignmentMessage(nonAssignment)).toBeNull()
     expect(getTaskAssignmentSummary(nonAssignment)).toBeNull()
+    const malformedAssignment = JSON.stringify({
+      type: 'task_assignment',
+      assignedBy: 'lead',
+    })
+    expect(tryRenderTaskAssignmentMessage(malformedAssignment)).toBeNull()
+    expect(getTaskAssignmentSummary(malformedAssignment)).toBeNull()
   })
 })

--- a/runtime/tests/tui/message-renderers/UserTextMessage.render.test.tsx
+++ b/runtime/tests/tui/message-renderers/UserTextMessage.render.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { describe, expect, test, vi } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { NO_CONTENT_MESSAGE } from '../../constants/messages.js'
 import {
@@ -12,10 +12,15 @@ import {
   INTERRUPT_MESSAGE_FOR_TOOL_USE,
 } from '../../utils/messages.js'
 import { renderToString } from '../../utils/staticRender.js'
+import { UserCrossSessionMessage } from './UserCrossSessionMessage.js'
+import { UserForkBoilerplateMessage } from './UserForkBoilerplateMessage.js'
+import { UserGitHubWebhookMessage } from './UserGitHubWebhookMessage.js'
 import { UserTextMessage } from './UserTextMessage.js'
 
+const featureFlags = vi.hoisted(() => new Set<string>())
+
 vi.mock('bun:bundle', () => ({
-  feature: () => false,
+  feature: (name: string) => featureFlags.has(name),
 }))
 vi.mock('../hooks/useSettings.js', () => ({
   useSettings: () => ({
@@ -47,6 +52,10 @@ function renderUserText(
 }
 
 describe('UserTextMessage rendering', () => {
+  beforeEach(() => {
+    featureFlags.clear()
+  })
+
   test('renders ordinary prompt text and plan content', async () => {
     await expect(renderUserText('write tests for the TUI')).resolves.toContain(
       'write tests for the TUI',
@@ -115,6 +124,54 @@ describe('UserTextMessage rendering', () => {
 
     await expect(
       renderUserText('<mcp-resource-update>resource changed</mcp-resource-update>'),
+    ).resolves.toBe('\n')
+  })
+
+  test('renders feature-gated protocol messages without missing-module crashes', async () => {
+    featureFlags.add('KAIROS_GITHUB_WEBHOOKS')
+    const webhook = await renderUserText(
+      '<github-webhook-activity><event>push</event></github-webhook-activity>',
+    )
+    expect(webhook).toContain('GitHub webhook:')
+    expect(webhook).toContain('push')
+
+    featureFlags.clear()
+    featureFlags.add('FORK_SUBAGENT')
+    const fork = await renderUserText(
+      '<fork-boilerplate>Your directive: tighten tests</fork-boilerplate>',
+    )
+    expect(fork).toContain('fork directive:')
+    expect(fork).toContain('tighten tests')
+
+    featureFlags.clear()
+    featureFlags.add('UDS_INBOX')
+    const crossSession = await renderUserText(
+      '<cross-session-message from="peer-1">check status</cross-session-message>',
+    )
+    expect(crossSession).toContain('message from peer-1:')
+    expect(crossSession).toContain('check status')
+  })
+
+  test('dynamic protocol renderers tolerate missing text payloads', async () => {
+    await expect(
+      renderToString(
+        <UserGitHubWebhookMessage addMargin={false} param={{} as never} />,
+        100,
+      ),
+    ).resolves.toContain('activity received')
+
+    await expect(
+      renderToString(
+        <UserForkBoilerplateMessage addMargin={false} param={{} as never} />,
+        100,
+      ),
+    ).resolves.toBe('\n')
+
+    await expect(
+      renderToString(
+        <UserCrossSessionMessage addMargin={false} param={{} as never} />,
+        100,
+      ),
     ).resolves.toBe('\n')
   })
 })


### PR DESCRIPTION
## Summary
- add 250 focused TUI coverage-swarm tests across runtime components, hooks, renderers, Ink internals, state, and utility surfaces
- fix runtime issues exposed by the swarm around MCP connectivity tracking, dynamic message renderers, Ink sizing/layout, hyperlink detection, IDE selection callbacks, task assignment parsing, and system theme watching
- preserve the generated swarm tests as a high-coverage regression net while logging follow-up cleanup for repeated harness patterns and existing hook warning noise

## Coverage
- Statements: 94.8%
- Branches: 88.27%
- Functions: 94.98%
- Lines: 95.48%

## Validation
- `cd runtime && ../node_modules/.bin/vitest run tests/tui/coverage-swarm --reporter=dot --maxWorkers=2`
- `npm run test:coverage:tui --workspace=@tetsuo-ai/runtime -- --reporter=dot --maxWorkers=2`
- `npm run typecheck --workspace=@tetsuo-ai/runtime`
- `node ~/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `git diff --check`

## Notes
- Full TUI coverage passes with existing React `act(...)` warning noise from hook tests; no Vitest failures.