### PR TITLE
fix(tui): stabilize workbench tree and input focus

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -122,6 +122,7 @@
     "marked": "^15.0.12",
     "node-pty": "1.1.0",
     "p-map": "7.0.4",
+    "performant-array-to-tree": "^1.11.0",
     "picomatch": "^4.0.4",
     "proper-lockfile": "^4.1.2",
     "react": "^19.0.0",

--- a/runtime/src/app-server/daemon-autostart.ts
+++ b/runtime/src/app-server/daemon-autostart.ts
@@ -35,6 +35,8 @@ import {
 
 export type AgenCDaemonAutostartStatus = "already-running" | "started";
 
+export const AGENC_DAEMON_AUTOSTART_READY_TIMEOUT_MS = 15_000;
+
 export interface AgenCDaemonConnectionTarget {
   readonly pid: number;
   readonly pidPath: string;
@@ -369,7 +371,7 @@ async function waitForAgenCDaemonReady(
   host: AgenCDaemonCliHost,
   options: AgenCDaemonAutostartOptions,
 ): Promise<boolean> {
-  const timeoutMs = options.waitTimeoutMs ?? 2000;
+  const timeoutMs = options.waitTimeoutMs ?? AGENC_DAEMON_AUTOSTART_READY_TIMEOUT_MS;
   const pollMs = options.pollMs ?? 25;
   const startedAt = Date.now();
   const isReady =

--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -105,6 +105,7 @@ import { HistorySearchDialog } from '../../history/HistorySearchDialog.js';
 import { ModelPicker } from '../ModelPicker.js';
 import { QuickOpenDialog } from '../QuickOpenDialog.js';
 import { materializeAttachmentMentions } from '../../workbench/commands.js';
+import { useWorkbenchComposerFocus } from '../../workbench/composerFocusContext.js';
 import { applyWorkbenchCommand, isWorkbenchEnabled } from '../../workbench/state.js';
 import { ThinkingToggle } from '../ThinkingToggle.js';
 import { BackgroundTasksPanel } from '../tasks/BackgroundTasksPanel.js';
@@ -605,6 +606,8 @@ function PromptInput({
   // system, so treat them as a modal overlay here to stop navigation keys from
   // leaking into TextInput/footer handlers and stacking a second dialog.
   const upstreamModalOverlayActive = useIsModalOverlayActive() || isLocalJSXCommandActive;
+  const workbenchComposerFocused = useWorkbenchComposerFocus();
+  const composerInputEnabled = workbenchComposerFocused ?? true;
   const [isAutoUpdating, setIsAutoUpdating] = useState(false);
   const [exitMessage, setExitMessage] = useState<{
     show: boolean;
@@ -744,6 +747,7 @@ function PromptInput({
   const [showModeSwitcher, setShowModeSwitcher] = useState(false);
   const promptModalOverlayActive =
     upstreamModalOverlayActive || showModeSwitcher || Boolean(showBashesDialog);
+  const promptKeyboardActive = composerInputEnabled && !promptModalOverlayActive;
   const [showAutoModeOptIn, setShowAutoModeOptIn] = useState(false);
   const [previousModeBeforeAuto, setPreviousModeBeforeAuto] = useState<PermissionMode | null>(null);
   const autoModeOptInTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -2089,7 +2093,7 @@ function PromptInput({
   // stopImmediatePropagation on Enter, blocking autocomplete from seeing the key.
   const keybindingContext = useOptionalKeybindingContext();
   useEffect(() => {
-    if (!keybindingContext || promptModalOverlayActive) return;
+    if (!keybindingContext || !promptKeyboardActive) return;
     return keybindingContext.registerHandler({
       action: 'chat:submit',
       context: 'Chat',
@@ -2097,7 +2101,7 @@ function PromptInput({
         void onSubmit(input);
       }
     });
-  }, [keybindingContext, promptModalOverlayActive, onSubmit, input]);
+  }, [keybindingContext, promptKeyboardActive, onSubmit, input]);
 
   // Chat context keybindings for editing shortcuts
   // Note: history:previous/history:next are NOT handled here. They are passed as
@@ -2116,20 +2120,20 @@ function PromptInput({
   }), [handleUndo, handleNewline, handleExternalEditor, handleStash, handleModelPicker, handleThinkingToggle, handleCycleMode, handleImagePaste]);
   useKeybindings(chatHandlers, {
     context: 'Chat',
-    isActive: !promptModalOverlayActive
+    isActive: promptKeyboardActive
   });
 
   // Shift+↑ enters message-actions cursor. Separate isActive so ctrl+r search
   // doesn't leave stale isSearchingHistory on cursor-exit remount.
   useKeybinding('chat:messageActions', () => onMessageActionsEnter?.(), {
     context: 'Chat',
-    isActive: !promptModalOverlayActive && !isSearchingHistory
+    isActive: promptKeyboardActive && !isSearchingHistory
   });
 
   // Fast mode keybinding is only active when fast mode is enabled and available
   useKeybinding('chat:fastMode', handleFastModePicker, {
     context: 'Chat',
-    isActive: !promptModalOverlayActive && isFastModeEnabled() && isFastModeAvailable()
+    isActive: promptKeyboardActive && isFastModeEnabled() && isFastModeAvailable()
   });
 
   // Handle help:dismiss keybinding (ESC closes help menu)
@@ -2139,13 +2143,13 @@ function PromptInput({
     setHelpOpen(false);
   }, {
     context: 'Help',
-    isActive: helpOpen
+    isActive: composerInputEnabled && helpOpen
   });
 
   // Quick Open / Global Search. Hook calls are unconditional (Rules of Hooks);
   // the handler body is feature()-gated so the setState calls and component
   // references get tree-shaken in external builds.
-  const quickSearchActive = feature('QUICK_SEARCH') ? !promptModalOverlayActive : false;
+  const quickSearchActive = feature('QUICK_SEARCH') ? promptKeyboardActive : false;
   useKeybinding('app:quickOpen', () => {
     if (feature('QUICK_SEARCH')) {
       setShowQuickOpen(true);
@@ -2179,7 +2183,7 @@ function PromptInput({
     }
   }, {
     context: 'Global',
-    isActive: feature('HISTORY_PICKER') ? !promptModalOverlayActive : false
+    isActive: feature('HISTORY_PICKER') ? promptKeyboardActive : false
   });
 
   // Handle Ctrl+C to abort speculation when idle (not loading)
@@ -2281,9 +2285,12 @@ function PromptInput({
     }
   }, {
     context: 'Footer',
-    isActive: !!footerItemSelected && !promptModalOverlayActive
+    isActive: !!footerItemSelected && promptKeyboardActive
   });
   useInput((char, key, event) => {
+    if (!composerInputEnabled) {
+      return;
+    }
     // Skip all input handling when a full-screen dialog is open. These dialogs
     // render via early return, but hooks run unconditionally — so without this
     // guard, Escape inside a dialog leaks to the double-press message-selector.
@@ -2626,8 +2633,8 @@ function PromptInput({
     onChangeCursorOffset: setCursorOffset,
     onPaste: onTextPaste,
     onIsPastingChange: setIsPasting,
-    focus: !isSearchingHistory && !promptModalOverlayActive && !footerItemSelected,
-    showCursor: !footerItemSelected && !isSearchingHistory && !cursorAtImageChip,
+    focus: composerInputEnabled && !isSearchingHistory && !promptModalOverlayActive && !footerItemSelected,
+    showCursor: composerInputEnabled && !footerItemSelected && !isSearchingHistory && !cursorAtImageChip,
     argumentHint: commandArgumentHint,
     onUndo: canUndo ? () => {
       const previousState = undo();

--- a/runtime/src/tui/keybindings/KeybindingProviderSetup.tsx
+++ b/runtime/src/tui/keybindings/KeybindingProviderSetup.tsx
@@ -295,17 +295,22 @@ export function createChordInputHandler({
           setPendingChord(null);
           if (wasInChord) {
             const contextsSet = new Set(contexts);
+            let handled = false;
             if (registry) {
               const handlers_0 = registry.get(result.action);
               if (handlers_0 && handlers_0.size > 0) {
                 for (const registration_0 of handlers_0) {
                   if (contextsSet.has(registration_0.context)) {
                     registration_0.handler();
-                    event.stopImmediatePropagation();
+                    handled = true;
                     break;
                   }
                 }
               }
+            }
+            event.stopImmediatePropagation();
+            if (!handled) {
+              logForDebugging(`[keybindings] Chord matched ${result.action} without an active handler`);
             }
           }
           break bb23;

--- a/runtime/src/tui/workbench/WorkbenchLayout.tsx
+++ b/runtime/src/tui/workbench/WorkbenchLayout.tsx
@@ -10,6 +10,7 @@ import type { PendingRequest } from "../permission-requests.js";
 import { AgentsRail } from "./agents/AgentsRail.js";
 import { ProjectExplorer } from "./project-tree/ProjectExplorer.js";
 import { ActiveWorkSurface } from "./surfaces/ActiveWorkSurface.js";
+import { WorkbenchComposerFocusProvider } from "./composerFocusContext.js";
 import { useWorkbenchDispatch, useWorkbenchState } from "./state.js";
 import type { WorkbenchLayoutSize, WorkbenchPane } from "./types.js";
 import { WorkbenchFooter } from "./WorkbenchFooter.js";
@@ -75,7 +76,9 @@ export function WorkbenchLayout({
       ) : null}
       <Box flexDirection="column" flexShrink={0} borderTop borderColor={workbench.focusedPane === "composer" ? "suggestion" : "gray"}>
         <PromptSuggestionsOverlay />
-        {composer}
+        <WorkbenchComposerFocusProvider active={workbench.focusedPane === "composer"}>
+          {composer}
+        </WorkbenchComposerFocusProvider>
       </Box>
       <PromptDialogOverlay />
       {rows >= 5 ? <WorkbenchFooter /> : null}

--- a/runtime/src/tui/workbench/composerFocusContext.tsx
+++ b/runtime/src/tui/workbench/composerFocusContext.tsx
@@ -1,0 +1,21 @@
+import React, { createContext, useContext } from "react";
+
+const WorkbenchComposerFocusContext = createContext<boolean | null>(null);
+
+export function WorkbenchComposerFocusProvider({
+  active,
+  children,
+}: {
+  readonly active: boolean;
+  readonly children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <WorkbenchComposerFocusContext.Provider value={active}>
+      {children}
+    </WorkbenchComposerFocusContext.Provider>
+  );
+}
+
+export function useWorkbenchComposerFocus(): boolean | null {
+  return useContext(WorkbenchComposerFocusContext);
+}

--- a/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
+++ b/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
@@ -1,10 +1,14 @@
 // @ts-nocheck
 import React, { useEffect, useMemo } from "react";
 
+import { selectAgenCTuiGlyphs } from "../../glyphs.js";
+import { useTerminalSize } from "../../hooks/useTerminalSize.js";
 import { Box, Text } from "../../ink.js";
+import { stringWidth } from "../../ink/stringWidth.js";
 import { useKeybindings } from "../../keybindings/useKeybinding.js";
 import { useRegisterKeybindingContext } from "../../keybindings/KeybindingContext.js";
 import { useAppState } from "../../state/AppState.js";
+import { getGraphemeSegmenter } from "../../../utils/intl.js";
 import { inFlightPathsFromTasks } from "../agents/activity.js";
 import { attachFileCommand, openBufferCommand } from "../commands.js";
 import { useWorkbenchDispatch, useWorkbenchState } from "../state.js";
@@ -23,6 +27,8 @@ export function ProjectExplorer({ focused, width }: Props): React.ReactElement {
   const tasks = useAppState((state) => state.tasks);
   const dispatch = useWorkbenchDispatch();
   const store = getProjectTreeStore();
+  const { rows: terminalRows } = useTerminalSize();
+  const maxTreeRows = Math.max(1, terminalRows - 8);
   const attachedPaths = useMemo(
     () => workbench.attachments.flatMap((item) => item.path ? [item.path] : []),
     [workbench.attachments],
@@ -35,6 +41,10 @@ export function ProjectExplorer({ focused, width }: Props): React.ReactElement {
   useEffect(() => {
     store.setAttachedPaths(attachedPaths);
   }, [store, attachedPaths]);
+
+  useEffect(() => {
+    store.setViewportRows(maxTreeRows);
+  }, [store, maxTreeRows]);
 
   useEffect(() => {
     const filePaths = snapshot.rows
@@ -83,22 +93,61 @@ export function ProjectExplorer({ focused, width }: Props): React.ReactElement {
     { context: "Explorer", isActive: focused },
   );
 
-  const visibleRows = snapshot.rows
-    .slice(0, Math.max(1, 200))
+  const viewport = projectTreeViewport(snapshot.rows, maxTreeRows);
+  const visibleRows = viewport.rows
     .map((row) => row.selected ? { ...row, focused } : row);
+  const itemCount = snapshot.rows.filter((row) => row.kind === "file" || row.kind === "directory").length;
+  const dirtyCount = snapshot.rows.filter((row) => row.gitState && row.gitState !== "clean").length;
+  const glyphs = selectAgenCTuiGlyphs();
 
   return (
     <Box flexDirection="column" width={width} height="100%" borderRight borderColor={focused ? "suggestion" : "gray"} paddingX={1}>
-      <Box height={1}>
-        <Text color={focused ? "suggestion" : "gray"} wrap="truncate-end">Explorer</Text>
-        {snapshot.loading ? <Text dimColor> refresh</Text> : null}
+      <Box height={1} flexShrink={0}>
+        <Text color={focused ? "suggestion" : "gray"} wrap="truncate-end">WORKSPACE</Text>
+        <Text dimColor wrap="truncate-end"> {itemCount}{dirtyCount > 0 ? ` ${dirtyCount} changed` : ""}{snapshot.loading ? " sync" : ""}</Text>
       </Box>
-      {snapshot.error ? <Text color="error" wrap="truncate-end">{snapshot.error}</Text> : null}
+      {snapshot.error ? (
+        <Box height={1} flexShrink={0}>
+          <Text color="error" wrap="truncate-end">{snapshot.error}</Text>
+        </Box>
+      ) : null}
       <Box flexDirection="column" flexGrow={1} overflow="hidden">
+        {viewport.above > 0 ? (
+          <Box height={1} flexShrink={0}>
+            <Text dimColor wrap="truncate-end">{glyphs.arrowUp} {viewport.above} more</Text>
+          </Box>
+        ) : null}
         {visibleRows.map((row) => <ProjectExplorerRow key={row.id} row={row} width={Math.max(8, width - 2)} />)}
+        {viewport.below > 0 ? (
+          <Box height={1} flexShrink={0}>
+            <Text dimColor wrap="truncate-end">{glyphs.arrowDown} {viewport.below} more</Text>
+          </Box>
+        ) : null}
       </Box>
     </Box>
   );
+}
+
+export function projectTreeViewport(
+  rows: readonly ProjectTreeRow[],
+  maxRows: number,
+): { readonly rows: readonly ProjectTreeRow[]; readonly above: number; readonly below: number } {
+  const limit = Math.max(1, Math.floor(maxRows));
+  if (rows.length <= limit) return { rows, above: 0, below: 0 };
+
+  const selectedIndex = rows.findIndex((row) => row.selected);
+  const targetIndex = selectedIndex < 0 ? 0 : selectedIndex;
+  const halfWindow = Math.floor(limit / 2);
+  const start = targetIndex < limit
+    ? 0
+    : Math.min(Math.max(0, targetIndex - halfWindow), rows.length - limit);
+  const end = Math.min(rows.length, start + limit);
+
+  return {
+    rows: rows.slice(start, end),
+    above: start,
+    below: Math.max(0, rows.length - end),
+  };
 }
 
 export function ProjectExplorerRow({
@@ -108,53 +157,99 @@ export function ProjectExplorerRow({
   readonly row: ProjectTreeRow;
   readonly width: number;
 }): React.ReactElement {
-  const marker = markerForRow(row);
-  const git = gitMarker(row.gitState);
-  const prefix = "  ".repeat(Math.max(0, row.depth));
-  const extras = `${row.active ? " *" : ""}${row.attached ? " @" : ""}${row.searchHit ? " ?" : ""}${row.inFlight ? " ~" : ""}`;
-  const labelWidth = Math.max(1, width - prefix.length - marker.length - git.length - extras.length - 2);
+  const glyphs = selectAgenCTuiGlyphs();
+  const branch = indentPrefix(row);
+  const marker = markerForRow(row, glyphs);
+  const badges = rowBadges(row, glyphs);
+  const prefix = `${branch}${marker} `;
+  const labelWidth = Math.max(1, width - stringWidth(prefix) - stringWidth(badges) - 1);
   const label = trim(row.label, labelWidth);
-  const color = row.selected ? (row.focused ? "suggestion" : "gray") : row.kind === "file" ? undefined : "text2";
+  const gap = Math.max(0, width - stringWidth(prefix) - stringWidth(label) - stringWidth(badges));
+  const color = colorForRow(row);
   return (
-    <Box height={1}>
+    <Box height={1} flexShrink={0}>
       <Text color={color} inverse={row.focused} wrap="truncate-end">
-        {prefix}{marker} {git}{label}{extras}
+        {prefix}{label}{" ".repeat(gap)}{badges}
       </Text>
     </Box>
   );
 }
 
-function markerForRow(row: ProjectTreeRow): string {
-  if (row.kind === "root") return row.expanded ? "v" : ">";
-  if (row.kind === "directory") return row.expanded ? "v" : ">";
-  if (row.kind === "loading") return ".";
+function indentPrefix(row: ProjectTreeRow): string {
+  return "  ".repeat(Math.max(0, row.depth));
+}
+
+function markerForRow(row: ProjectTreeRow, glyphs: ReturnType<typeof selectAgenCTuiGlyphs>): string {
+  if (row.kind === "root") return row.expanded ? glyphs.arrowDown : glyphs.arrowRight;
+  if (row.kind === "directory") return row.expanded ? glyphs.arrowDown : glyphs.arrowRight;
+  if (row.kind === "loading") return glyphs.ellipsis;
   if (row.kind === "error") return "!";
-  return "-";
+  return " ";
+}
+
+function rowBadges(row: ProjectTreeRow, glyphs: ReturnType<typeof selectAgenCTuiGlyphs>): string {
+  return [
+    gitMarker(row.gitState),
+    row.active ? glyphs.statusDot : "",
+    row.attached ? "@" : "",
+    row.searchHit ? "?" : "",
+    row.inFlight ? "~" : "",
+  ].filter(Boolean).join(" ");
 }
 
 function gitMarker(state: ProjectTreeRow["gitState"]): string {
   switch (state) {
     case "modified":
-      return "M ";
+      return "M";
     case "added":
-      return "A ";
+      return "A";
     case "deleted":
-      return "D ";
+      return "D";
     case "renamed":
-      return "R ";
+      return "R";
     case "unmerged":
-      return "U ";
+      return "U";
     case "untracked":
-      return "? ";
+      return "?";
     case "ignored":
-      return "! ";
+      return "!";
     default:
       return "";
   }
 }
 
+function colorForRow(row: ProjectTreeRow): string | undefined {
+  if (row.selected) return row.focused ? "suggestion" : "gray";
+  if (row.active) return "success";
+  switch (row.gitState) {
+    case "modified":
+    case "renamed":
+      return "warning";
+    case "added":
+      return "success";
+    case "deleted":
+    case "unmerged":
+      return "error";
+    case "untracked":
+    case "ignored":
+      return "gray";
+    default:
+      return row.kind === "file" ? undefined : "text2";
+  }
+}
+
 function trim(value: string, width: number): string {
-  if (value.length <= width) return value;
+  if (stringWidth(value) <= width) return value;
   if (width <= 1) return value.slice(0, width);
-  return `${value.slice(0, Math.max(0, width - 3))}...`;
+  const suffix = "...";
+  const maxWidth = Math.max(0, width - stringWidth(suffix));
+  let output = "";
+  let used = 0;
+  for (const segment of getGraphemeSegmenter().segment(value)) {
+    const nextWidth = used + stringWidth(segment.segment);
+    if (nextWidth > maxWidth) break;
+    output += segment.segment;
+    used = nextWidth;
+  }
+  return `${output}${suffix}`;
 }

--- a/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
+++ b/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
@@ -16,6 +16,7 @@ const EMPTY_SNAPSHOT: ProjectTreeSnapshot = Object.freeze({
   activePath: null,
   expandedPaths: [],
 });
+const DEFAULT_VIEWPORT_ROWS = 20;
 
 export class ProjectTreeStore {
   #cwd: string;
@@ -28,6 +29,7 @@ export class ProjectTreeStore {
   #attachedPaths = new Set<string>();
   #searchHitPaths = new Set<string>();
   #inFlightPaths = new Set<string>();
+  #viewportRows = DEFAULT_VIEWPORT_ROWS;
   #loading = true;
   #error: string | null = null;
   #listeners = new Set<Listener>();
@@ -122,6 +124,12 @@ export class ProjectTreeStore {
     this.#emit();
   }
 
+  setViewportRows(rows: number): void {
+    const nextRows = Math.max(1, Math.floor(rows));
+    if (nextRows === this.#viewportRows) return;
+    this.#viewportRows = nextRows;
+  }
+
   move(delta: number): void {
     const rows = selectableRows(this.#snapshot.rows);
     if (rows.length === 0) return;
@@ -132,7 +140,7 @@ export class ProjectTreeStore {
   }
 
   movePage(delta: number): void {
-    this.move(delta * 10);
+    this.move(delta * Math.max(1, this.#viewportRows - 1));
   }
 
   moveToStart(): void {
@@ -152,8 +160,13 @@ export class ProjectTreeStore {
 
   toggle(pathValue = this.#cursorPath): void {
     if (!pathValue) return;
+    const row = this.#rowForPath(pathValue);
+    if (!row || row.kind !== "directory") return;
     if (this.#expandedPaths.has(pathValue)) {
       this.#expandedPaths.delete(pathValue);
+      if (this.#cursorPath && isDescendantPath(this.#cursorPath, pathValue)) {
+        this.#cursorPath = pathValue;
+      }
     } else {
       this.#expandedPaths.add(pathValue);
     }
@@ -162,14 +175,20 @@ export class ProjectTreeStore {
 
   expand(pathValue = this.#cursorPath): void {
     if (!pathValue) return;
+    const row = this.#rowForPath(pathValue);
+    if (!row || row.kind !== "directory") return;
     this.#expandedPaths.add(pathValue);
     this.#emit();
   }
 
   collapse(pathValue = this.#cursorPath): void {
     if (!pathValue) return;
-    if (this.#expandedPaths.has(pathValue)) {
+    const row = this.#rowForPath(pathValue);
+    if (row?.kind === "directory" && this.#expandedPaths.has(pathValue)) {
       this.#expandedPaths.delete(pathValue);
+      if (this.#cursorPath && isDescendantPath(this.#cursorPath, pathValue)) {
+        this.#cursorPath = pathValue;
+      }
     } else {
       const parent = parentPath(pathValue);
       if (parent !== null) this.#cursorPath = parent;
@@ -196,21 +215,42 @@ export class ProjectTreeStore {
     return this.#snapshot.rows.find((row) => row.path === this.#cursorPath) ?? null;
   }
 
+  #rowForPath(pathValue: string): ProjectTreeRow | null {
+    return this.#snapshot.rows.find((row) => row.path === pathValue) ?? null;
+  }
+
   #emit(): void {
-    this.#snapshot = {
+    const rows = buildProjectTreeRows({
       cwd: this.#cwd,
-      rows: buildProjectTreeRows({
+      paths: this.#paths,
+      expandedPaths: this.#expandedPaths,
+      cursorPath: this.#cursorPath,
+      activePath: this.#activePath,
+      attachedPaths: this.#attachedPaths,
+      searchHitPaths: this.#searchHitPaths,
+      inFlightPaths: this.#inFlightPaths,
+      gitStatus: this.#gitStatus,
+      focused: true,
+    });
+    const normalizedCursorPath = visibleCursorPath(this.#cursorPath, rows);
+    const visibleRows = normalizedCursorPath === this.#cursorPath
+      ? rows
+      : buildProjectTreeRows({
         cwd: this.#cwd,
         paths: this.#paths,
         expandedPaths: this.#expandedPaths,
-        cursorPath: this.#cursorPath,
+        cursorPath: normalizedCursorPath,
         activePath: this.#activePath,
         attachedPaths: this.#attachedPaths,
         searchHitPaths: this.#searchHitPaths,
         inFlightPaths: this.#inFlightPaths,
         gitStatus: this.#gitStatus,
         focused: true,
-      }),
+      });
+    this.#cursorPath = normalizedCursorPath;
+    this.#snapshot = {
+      cwd: this.#cwd,
+      rows: visibleRows,
       loading: this.#loading,
       error: this.#error,
       cursorPath: this.#cursorPath,
@@ -232,6 +272,21 @@ function selectableRows(rows: readonly ProjectTreeRow[]): readonly ProjectTreeRo
   return rows.filter((row) => row.kind === "file" || row.kind === "directory");
 }
 
+function visibleCursorPath(cursorPath: string | null, rows: readonly ProjectTreeRow[]): string | null {
+  const selectable = selectableRows(rows);
+  if (selectable.length === 0) return cursorPath;
+  if (cursorPath && selectable.some((row) => row.path === cursorPath)) return cursorPath;
+
+  let parent = cursorPath ? parentPath(cursorPath) : null;
+  while (parent !== null) {
+    const visibleParent = selectable.find((row) => row.path === parent);
+    if (visibleParent) return visibleParent.path;
+    parent = parentPath(parent);
+  }
+
+  return selectable[0]?.path ?? cursorPath;
+}
+
 function sameSet(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
   if (left.size !== right.size) return false;
   for (const value of left) {
@@ -247,6 +302,10 @@ function firstFilePath(paths: readonly string[]): string | null {
 function parentPath(value: string): string | null {
   const parent = path.posix.dirname(value.split(path.sep).join("/"));
   return parent === "." || parent === value ? null : parent;
+}
+
+function isDescendantPath(value: string, possibleAncestor: string): boolean {
+  return value.length > possibleAncestor.length && value.startsWith(`${possibleAncestor}/`);
 }
 
 async function readTopLevelPaths(cwd: string): Promise<string[]> {

--- a/runtime/src/tui/workbench/project-tree/buildTree.ts
+++ b/runtime/src/tui/workbench/project-tree/buildTree.ts
@@ -1,15 +1,23 @@
 import path from "node:path";
 
+import { arrayToTree } from "performant-array-to-tree";
+
 import type { GitStatusByPath } from "./gitStatus.js";
 import type { ProjectTreeRow } from "../types.js";
 
 type NodeKind = "root" | "directory" | "file";
 
 type TreeNode = {
+  readonly id: string;
+  readonly parentId: string | null;
   readonly path: string;
   readonly label: string;
   readonly kind: NodeKind;
-  readonly children: Map<string, TreeNode>;
+  readonly children: TreeNode[];
+};
+
+type TreeItem = Omit<TreeNode, "children"> & {
+  children?: TreeItem[];
 };
 
 export type BuildProjectTreeOptions = {
@@ -25,31 +33,19 @@ export type BuildProjectTreeOptions = {
   readonly focused?: boolean;
 };
 
+const ROOT_ID = "__agenc_workspace_root__";
+
 export function buildProjectTreeRows(options: BuildProjectTreeOptions): ProjectTreeRow[] {
-  const root = createNode("", path.basename(options.cwd) || "workspace", "root");
-  for (const rawPath of options.paths) {
-    addPath(root, normalizeRelativePath(rawPath));
-  }
+  const root = createProjectTree(options);
+
+  if (!root) return emptyRows(options);
+
+  sortTree(root);
 
   const rows: ProjectTreeRow[] = [];
-  const rootExpanded = true;
-  rows.push(rowForNode(root, 0, rootExpanded, options));
-  appendChildren(root, 1, rows, options);
+  appendRows(root, 0, true, [], rows, options);
   if (rows.length === 1 && options.paths.length === 0) {
-    rows.push({
-      id: "loading-empty",
-      path: "",
-      label: options.gitStatus ? "No project files" : "Loading files",
-      kind: options.gitStatus ? "error" : "loading",
-      depth: 1,
-      expanded: false,
-      selected: false,
-      focused: false,
-      active: false,
-      attached: false,
-      searchHit: false,
-      inFlight: false,
-    });
+    rows.push(...emptyRows(options));
   }
   return rows;
 }
@@ -60,19 +56,44 @@ export function visibleTreePaths(rows: readonly ProjectTreeRow[]): readonly stri
     .map((row) => row.path);
 }
 
-function appendChildren(
+function createProjectTree(options: BuildProjectTreeOptions): TreeNode | null {
+  const items = new Map<string, Omit<TreeNode, "children">>();
+  items.set(ROOT_ID, {
+    id: ROOT_ID,
+    parentId: null,
+    path: "",
+    label: path.basename(options.cwd) || "workspace",
+    kind: "root",
+  });
+
+  for (const rawPath of options.paths) {
+    addPathItems(items, normalizeRelativePath(rawPath));
+  }
+
+  const tree = arrayToTree([...items.values()], {
+    dataField: null,
+    throwIfOrphans: true,
+  }) as TreeItem[];
+  return normalizeTreeItem(tree.find((item) => item.id === ROOT_ID) ?? null);
+}
+
+function appendRows(
   node: TreeNode,
   depth: number,
+  isLast: boolean,
+  ancestorLast: readonly boolean[],
   rows: ProjectTreeRow[],
   options: BuildProjectTreeOptions,
 ): void {
-  const children = [...node.children.values()].sort(compareNodes);
-  for (const child of children) {
-    const expanded = child.kind === "directory" && options.expandedPaths.has(child.path);
-    rows.push(rowForNode(child, depth, expanded, options));
-    if (expanded || child.kind === "root") {
-      appendChildren(child, depth + 1, rows, options);
-    }
+  const expanded = node.kind === "root" || (node.kind === "directory" && options.expandedPaths.has(node.path));
+  rows.push(rowForNode(node, depth, expanded, isLast, ancestorLast, options));
+
+  if (!expanded) return;
+
+  const nextAncestorLast = node.kind === "root" ? ancestorLast : [...ancestorLast, isLast];
+  for (let index = 0; index < node.children.length; index += 1) {
+    const child = node.children[index]!;
+    appendRows(child, depth + 1, index === node.children.length - 1, nextAncestorLast, rows, options);
   }
 }
 
@@ -80,6 +101,8 @@ function rowForNode(
   node: TreeNode,
   depth: number,
   expanded: boolean,
+  isLast: boolean,
+  ancestorLast: readonly boolean[],
   options: BuildProjectTreeOptions,
 ): ProjectTreeRow {
   const selected = options.cursorPath === node.path;
@@ -90,6 +113,9 @@ function rowForNode(
     kind: node.kind === "root" ? "root" : node.kind,
     depth,
     expanded,
+    hasChildren: node.children.length > 0,
+    isLast,
+    ancestorLast,
     selected,
     focused: selected && options.focused === true,
     active: options.activePath === node.path,
@@ -100,33 +126,47 @@ function rowForNode(
   };
 }
 
-function addPath(root: TreeNode, relPath: string): void {
+function addPathItems(items: Map<string, Omit<TreeNode, "children">>, relPath: string): void {
   if (!relPath || relPath.startsWith("../")) return;
   const directoryPath = relPath.endsWith("/");
   const parts = relPath.split("/").filter(Boolean);
-  let node = root;
   for (let index = 0; index < parts.length; index += 1) {
     const label = parts[index]!;
     const childPath = parts.slice(0, index + 1).join("/");
+    const parentPath = index === 0 ? ROOT_ID : parts.slice(0, index).join("/");
     const kind = index === parts.length - 1 && !directoryPath ? "file" : "directory";
-    const existing = node.children.get(label);
+    const existing = items.get(childPath);
     if (existing) {
-      node = existing;
+      if (existing.kind === "file" && kind === "directory") {
+        items.set(childPath, { ...existing, kind: "directory" });
+      }
       continue;
     }
-    const child = createNode(childPath, label, kind);
-    node.children.set(label, child);
-    node = child;
+    items.set(childPath, {
+      id: childPath,
+      parentId: parentPath,
+      path: childPath,
+      label,
+      kind,
+    });
   }
 }
 
-function createNode(pathValue: string, label: string, kind: NodeKind): TreeNode {
+function normalizeTreeItem(item: TreeItem | null): TreeNode | null {
+  if (!item) return null;
   return {
-    path: pathValue,
-    label,
-    kind,
-    children: new Map(),
+    id: item.id,
+    parentId: item.parentId,
+    path: item.path,
+    label: item.label,
+    kind: item.kind,
+    children: (item.children ?? []).map((child) => normalizeTreeItem(child)).filter((child): child is TreeNode => Boolean(child)),
   };
+}
+
+function sortTree(node: TreeNode): void {
+  node.children.sort(compareNodes);
+  for (const child of node.children) sortTree(child);
 }
 
 function compareNodes(left: TreeNode, right: TreeNode): number {
@@ -139,4 +179,24 @@ function compareNodes(left: TreeNode, right: TreeNode): number {
 
 function normalizeRelativePath(value: string): string {
   return value.split(path.sep).join("/");
+}
+
+function emptyRows(options: BuildProjectTreeOptions): ProjectTreeRow[] {
+  return [{
+    id: "loading-empty",
+    path: "",
+    label: options.gitStatus ? "No project files" : "Loading files",
+    kind: options.gitStatus ? "error" : "loading",
+    depth: 1,
+    expanded: false,
+    hasChildren: false,
+    isLast: true,
+    ancestorLast: [],
+    selected: false,
+    focused: false,
+    active: false,
+    attached: false,
+    searchHit: false,
+    inFlight: false,
+  }];
 }

--- a/runtime/src/tui/workbench/reducer.ts
+++ b/runtime/src/tui/workbench/reducer.ts
@@ -8,7 +8,7 @@ import type {
 
 export function getDefaultWorkbenchState(): WorkbenchState {
   return {
-    focusedPane: "surface",
+    focusedPane: "composer",
     explorerVisible: true,
     agentsVisible: true,
     activeSurfaceMode: "transcript",

--- a/runtime/src/tui/workbench/types.ts
+++ b/runtime/src/tui/workbench/types.ts
@@ -92,6 +92,9 @@ export type ProjectTreeRow = {
   readonly kind: ProjectTreeRowKind;
   readonly depth: number;
   readonly expanded: boolean;
+  readonly hasChildren?: boolean;
+  readonly isLast?: boolean;
+  readonly ancestorLast?: readonly boolean[];
   readonly selected: boolean;
   readonly focused: boolean;
   readonly active: boolean;

--- a/runtime/tests/app-server/daemon-autostart.contract.test.ts
+++ b/runtime/tests/app-server/daemon-autostart.contract.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  AGENC_DAEMON_AUTOSTART_READY_TIMEOUT_MS,
   AgenCDaemonAutostartError,
   ensureAgenCDaemonAutostart,
   resolveAgenCDaemonAutostartConfig,
@@ -76,6 +77,12 @@ async function closeServer(server: Server | null): Promise<void> {
 }
 
 describe("AgenC daemon autostart", () => {
+  it("keeps the default readiness window long enough for cold starts", () => {
+    expect(AGENC_DAEMON_AUTOSTART_READY_TIMEOUT_MS).toBeGreaterThanOrEqual(
+      10_000,
+    );
+  });
+
   it("honors the autostart environment opt-out", () => {
     expect(shouldAutostartAgenCDaemon({})).toBe(true);
     expect(shouldAutostartAgenCDaemon({}, false)).toBe(false);

--- a/runtime/tests/tui/keybindings/KeybindingProviderSetup.test.tsx
+++ b/runtime/tests/tui/keybindings/KeybindingProviderSetup.test.tsx
@@ -63,6 +63,9 @@ function key(overrides: Partial<Key> = {}): Key {
 function inputEvent(): InputEvent & { stopped: boolean } {
   return {
     stopped: false,
+    didStopImmediatePropagation() {
+      return this.stopped;
+    },
     stopImmediatePropagation() {
       this.stopped = true;
     },
@@ -144,6 +147,50 @@ describe("KeybindingProviderSetup", () => {
     expect(completionEvent.stopped).toBe(true);
     expect(pendingChordRef.current).toBeNull();
     expect(invoked).toBe(1);
+  });
+
+  test("consumes completed workbench chords even before an action handler is registered", () => {
+    const bindings = parseBindings([
+      {
+        context: "Workbench",
+        bindings: {
+          "ctrl+w d": "workbench:openDiff",
+        },
+      },
+    ]);
+    const pendingChordRef = { current: null as ParsedKeystroke[] | null };
+    const captured: string[] = [];
+    const handler = createChordInputHandler({
+      bindings,
+      pendingChordRef,
+      setPendingChord: pending => {
+        pendingChordRef.current = pending;
+      },
+      activeContexts: new Set(["Workbench"]),
+      handlerRegistryRef: { current: new Map() },
+      inputCaptureRegistryRef: {
+        current: new Set([
+          {
+            context: "Workbench",
+            handler: input => {
+              captured.push(input);
+              return true;
+            },
+          },
+        ]),
+      },
+    });
+
+    const prefixEvent = inputEvent();
+    handler("w", key({ ctrl: true }), prefixEvent);
+    expect(prefixEvent.stopped).toBe(true);
+
+    const completionEvent = inputEvent();
+    handler("d", key(), completionEvent);
+
+    expect(completionEvent.stopped).toBe(true);
+    expect(pendingChordRef.current).toBeNull();
+    expect(captured).toEqual([]);
   });
 
   test("runs active input captures before child input handlers", () => {

--- a/runtime/tests/tui/workbench/project-tree.test.ts
+++ b/runtime/tests/tui/workbench/project-tree.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { buildProjectTreeRows } from "../../../src/tui/workbench/project-tree/buildTree.js";
 import { parseGitStatusPorcelain } from "../../../src/tui/workbench/project-tree/gitStatus.js";
@@ -34,6 +38,8 @@ describe("project tree helpers", () => {
     });
     expect(rows.find((row) => row.path === "src/tui/App.tsx")).toMatchObject({
       attached: true,
+      ancestorLast: [false, false],
+      isLast: true,
     });
   });
 
@@ -75,6 +81,7 @@ describe("project tree helpers", () => {
     expect(rows.find((row) => row.path === "src")).toMatchObject({
       selected: true,
       expanded: true,
+      hasChildren: false,
     });
   });
 
@@ -108,5 +115,32 @@ describe("project tree helpers", () => {
     });
 
     store.dispose();
+  });
+
+  it("normalizes hidden cursor paths to the nearest visible row", async () => {
+    const repo = await mkdtemp(join(tmpdir(), "agenc-tree-store-"));
+    const store = new ProjectTreeStore(repo, 0);
+
+    try {
+      await mkdir(join(repo, ".githooks"), { recursive: true });
+      await mkdir(join(repo, "docs"), { recursive: true });
+      await writeFile(join(repo, ".githooks", "pre-commit"), "#!/bin/sh\n", "utf8");
+      await writeFile(join(repo, "docs", "guide.md"), "guide\n", "utf8");
+      execFileSync("git", ["init"], { cwd: repo, stdio: "ignore" });
+
+      await store.refresh();
+
+      expect(store.getCursorPath()).toBe(".githooks");
+      expect(store.getSnapshot().rows.find((row) => row.path === ".githooks")).toMatchObject({
+        selected: true,
+      });
+
+      store.move(1);
+
+      expect(store.getCursorPath()).toBe("docs");
+    } finally {
+      store.dispose();
+      await rm(repo, { recursive: true, force: true });
+    }
   });
 });

--- a/runtime/tests/tui/workbench/reducer.test.ts
+++ b/runtime/tests/tui/workbench/reducer.test.ts
@@ -8,7 +8,7 @@ import {
 describe("workbenchReducer", () => {
   it("provides stable defaults", () => {
     expect(getDefaultWorkbenchState()).toMatchObject({
-      focusedPane: "surface",
+      focusedPane: "composer",
       explorerVisible: true,
       agentsVisible: true,
       activeSurfaceMode: "transcript",

--- a/runtime/tests/tui/workbench/render.test.tsx
+++ b/runtime/tests/tui/workbench/render.test.tsx
@@ -10,7 +10,8 @@ vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
 import { PromptOverlayProvider, useSetPromptOverlay, useSetPromptOverlayDialog } from "../../../src/tui/context/promptOverlayContext.js";
 import { Text } from "../../../src/tui/ink.js";
 import { AppStateProvider, getDefaultAppState } from "../../../src/tui/state/AppState.js";
-import { ProjectExplorerRow } from "../../../src/tui/workbench/project-tree/ProjectExplorer.js";
+import { ProjectExplorerRow, projectTreeViewport } from "../../../src/tui/workbench/project-tree/ProjectExplorer.js";
+import { useWorkbenchComposerFocus } from "../../../src/tui/workbench/composerFocusContext.js";
 import { WORKBENCH_SURFACES } from "../../../src/tui/workbench/surfaces/ActiveWorkSurface.js";
 import { TranscriptSurface } from "../../../src/tui/workbench/surfaces/TranscriptSurface.js";
 import { WorkbenchFooter } from "../../../src/tui/workbench/WorkbenchFooter.js";
@@ -44,6 +45,11 @@ function DialogWriter(): React.ReactNode {
   return <Text>composer body</Text>;
 }
 
+function ComposerFocusProbe(): React.ReactNode {
+  const active = useWorkbenchComposerFocus();
+  return <Text>{active ? "composer-active" : "composer-inactive"}</Text>;
+}
+
 describe("workbench render contract", () => {
   it.each([28, 30, 44])("renders explorer rows within %i columns", async (width) => {
     const output = await renderToString(
@@ -63,6 +69,9 @@ describe("workbench render contract", () => {
           searchHit: true,
           inFlight: true,
           gitState: "modified",
+          ancestorLast: [false],
+          isLast: true,
+          hasChildren: false,
         }}
       />,
       width,
@@ -73,6 +82,105 @@ describe("workbench render contract", () => {
     }
     expect(output).toContain("@");
     expect(output).toContain("~");
+  });
+
+  it("renders deep explorer rows without connector rails that imply offscreen parents", async () => {
+    const output = await renderToString(
+      <ProjectExplorerRow
+        width={32}
+        row={{
+          id: "runtime/src",
+          path: "runtime/src",
+          label: "src",
+          kind: "directory",
+          depth: 2,
+          expanded: true,
+          selected: false,
+          focused: false,
+          active: false,
+          attached: false,
+          searchHit: false,
+          inFlight: false,
+          ancestorLast: [false],
+          isLast: true,
+          hasChildren: true,
+        }}
+      />,
+      32,
+    );
+
+    expect(output).toContain("src");
+    expect(output).not.toContain("│");
+    expect(output).not.toContain("├");
+    expect(output).not.toContain("└");
+  });
+
+  it("keeps the selected explorer row inside the viewport", () => {
+    const rows = Array.from({ length: 20 }, (_, index) => ({
+      id: `file-${index}`,
+      path: `file-${index}.ts`,
+      label: `file-${index}.ts`,
+      kind: "file" as const,
+      depth: 1,
+      expanded: false,
+      selected: index === 15,
+      focused: index === 15,
+      active: false,
+      attached: false,
+      searchHit: false,
+      inFlight: false,
+    }));
+
+    const viewport = projectTreeViewport(rows, 6);
+
+    expect(viewport.rows.some((row) => row.selected)).toBe(true);
+    expect(viewport.above).toBeGreaterThan(0);
+    expect(viewport.below).toBeGreaterThan(0);
+  });
+
+  it("keeps expanded explorer rows in source order while clipping deep trees", () => {
+    const rows = [
+      row("", "agenc-core", "root", 0),
+      row(".githooks", ".githooks", "directory", 1),
+      row("docs", "docs", "directory", 1),
+      row("packages", "packages", "directory", 1),
+      row("packaging", "packaging", "directory", 1),
+      row("runtime", "runtime", "directory", 1),
+      row("runtime/scripts", "scripts", "directory", 2),
+      row("runtime/src", "src", "directory", 2, true),
+      row("runtime/src/agents", "agents", "directory", 3),
+      row("runtime/src/auth", "auth", "directory", 3),
+      row("runtime/src/bin", "bin", "directory", 3),
+      row("runtime/src/bootstrap.ts", "bootstrap.ts", "file", 3),
+      row("runtime/src/build", "build", "directory", 3),
+    ];
+
+    const viewport = projectTreeViewport(rows, 10);
+    const paths = viewport.rows.map((item) => item.path);
+
+    expect(paths).toEqual(rows.slice(0, 10).map((item) => item.path));
+    expect(paths).toContain("runtime/src");
+    expect(viewport.below).toBeGreaterThan(0);
+  });
+
+  it("keeps the selected explorer row inside a contiguous viewport", () => {
+    const rows = [
+      row("", "agenc-core", "root", 0),
+      row("runtime", "runtime", "directory", 1),
+      row("runtime/src", "src", "directory", 2),
+      ...Array.from({ length: 18 }, (_, index) =>
+        row(`runtime/src/child-${index}`, `child-${index}`, "directory", 3, index === 10),
+      ),
+    ];
+
+    const viewport = projectTreeViewport(rows, 6);
+    const paths = viewport.rows.map((item) => item.path);
+    const indexes = viewport.rows.map((item) => rows.findIndex((row) => row.path === item.path));
+
+    expect(paths).toContain("runtime/src/child-10");
+    expect(indexes).toEqual([10, 11, 12, 13, 14, 15]);
+    expect(viewport.above).toBe(10);
+    expect(viewport.below).toBeGreaterThan(0);
   });
 
   it("changes footer hints and displays composer attachment context", async () => {
@@ -157,6 +265,41 @@ describe("workbench render contract", () => {
     expect(output.replace(/\s+/gu, "")).toContain("dialogmarker");
   });
 
+  it("exposes composer focus only when the workbench composer pane is focused", async () => {
+    const inactiveOutput = await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...getDefaultAppState(),
+          workbench: {
+            ...getDefaultAppState().workbench,
+            focusedPane: "surface",
+          },
+        }}
+      >
+        <WorkbenchLayout transcript={<Text>scroll body</Text>} composer={<ComposerFocusProbe />} />
+      </AppStateProvider>,
+      { columns: 120, rows: 30 },
+    );
+
+    const activeOutput = await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...getDefaultAppState(),
+          workbench: {
+            ...getDefaultAppState().workbench,
+            focusedPane: "composer",
+          },
+        }}
+      >
+        <WorkbenchLayout transcript={<Text>scroll body</Text>} composer={<ComposerFocusProbe />} />
+      </AppStateProvider>,
+      { columns: 120, rows: 30 },
+    );
+
+    expect(inactiveOutput).toContain("composer-inactive");
+    expect(activeOutput).toContain("composer-active");
+  });
+
   it("defines the surface descriptor contract for every live workbench surface", () => {
     expect(WORKBENCH_SURFACES.map((surface) => surface.mode)).toEqual([
       "transcript",
@@ -181,3 +324,26 @@ describe("workbench render contract", () => {
     expect(source).not.toMatch(/readdirSync|getWorkspaceFileTreeRows|WorkspaceFileTreeGutter/u);
   });
 });
+
+function row(
+  path: string,
+  label: string,
+  kind: "root" | "directory" | "file",
+  depth: number,
+  selected = false,
+) {
+  return {
+    id: path || "root",
+    path,
+    label,
+    kind,
+    depth,
+    expanded: kind !== "file",
+    selected,
+    focused: selected,
+    active: false,
+    attached: false,
+    searchHit: false,
+    inFlight: false,
+  };
+}


### PR DESCRIPTION
## Summary
- Rebuild workspace tree rows through a normalized tree model and use a contiguous viewport so deep rows do not disappear while navigating.
- Gate composer keyboard handling by the active workbench pane and focus the composer by default on startup.
- Add focused keybinding, tree rendering, reducer, and daemon autostart timeout coverage.

## Validation
- `npm run test --workspace=@tetsuo-ai/runtime -- tests/tui/workbench/reducer.test.ts tests/tui/workbench/render.test.tsx`
- `npm run test --workspace=@tetsuo-ai/runtime -- tests/tui/workbench/project-tree.test.ts tests/tui/keybindings/KeybindingProviderSetup.test.tsx tests/app-server/daemon-autostart.contract.test.ts`
- `npm run typecheck --workspace=@tetsuo-ai/runtime -- --pretty false`
- `npm run build --workspace=@tetsuo-ai/runtime`
- `node ~/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- Manual PTY startup check: composer focused on first paint, typed text goes into prompt immediately.
