### PR TITLE
feat(runtime): preserve file mention read context

### DIFF
--- a/runtime/src/bin/agenc.ts
+++ b/runtime/src/bin/agenc.ts
@@ -54,6 +54,7 @@ import {
 } from "../session/autonomous-mode.js";
 import type { TurnContext } from "../session/turn-context.js";
 import { runTurn } from "../session/run-turn.js";
+import { seedFileMentionSessionReads } from "../session/file-mention-session-reads.js";
 import type { Terminal } from "../session/turn-state.js";
 import {
   SchemaMismatchError,
@@ -969,6 +970,10 @@ async function expandPromptFileMentions(params: {
   if (expansion.attachments.length === 0) {
     return { input: params.input };
   }
+  await seedFileMentionSessionReads(
+    params.session.conversationId,
+    expansion.attachments,
+  );
   return {
     input: expansion.prompt,
     displayInput: params.input,

--- a/runtime/src/prompts/attachments/types.ts
+++ b/runtime/src/prompts/attachments/types.ts
@@ -17,6 +17,7 @@
  */
 
 import type { DiagnosticFile } from "../../services/lsp/types.js";
+import type { FileMentionAttachment } from "../file-mentions.js";
 
 /**
  * Memory file injection from the per-file 4-phase nested traversal.
@@ -261,15 +262,7 @@ export interface AgentMentionAttachment {
  */
 export interface FileMentionContextAttachment {
   readonly kind: "file_mention";
-  readonly files: ReadonlyArray<{
-    readonly raw: string;
-    readonly path: string;
-    readonly resolved: string;
-    readonly bytes: number;
-    readonly lineCount: number;
-    readonly truncated: boolean;
-    readonly content: string;
-  }>;
+  readonly files: readonly FileMentionAttachment[];
 }
 
 /** Image content resolved from a user-authored `@path` mention. */

--- a/runtime/src/prompts/file-mentions.ts
+++ b/runtime/src/prompts/file-mentions.ts
@@ -43,10 +43,13 @@ export interface FileMentionAttachment {
   readonly raw: string;
   readonly path: string;
   readonly resolved: string;
+  readonly canonicalResolved: string;
   readonly bytes: number;
   readonly lineCount: number;
   readonly truncated: boolean;
   readonly content: string;
+  readonly rawContent: string;
+  readonly mtimeMs: number;
 }
 
 export interface FileMentionExpansion {
@@ -425,10 +428,16 @@ export async function expandFileMentions(
       raw: mention.raw,
       path: relativePromptPath(options.cwd, resolved),
       resolved,
+      canonicalResolved: realTarget,
       bytes: rawBytes,
       lineCount: limited.lineCount,
       truncated: limited.truncated,
       content: limited.content,
+      rawContent: normalized,
+      mtimeMs:
+        typeof stat.mtimeMs === "number" && Number.isFinite(stat.mtimeMs)
+          ? stat.mtimeMs
+          : Date.now(),
     });
   }
 

--- a/runtime/src/session/file-mention-session-reads.ts
+++ b/runtime/src/session/file-mention-session-reads.ts
@@ -1,0 +1,50 @@
+import type { Attachment } from "../prompts/attachments/types.js";
+import type { FileMentionAttachment } from "../prompts/file-mentions.js";
+import {
+  canonicalizePath,
+  seedSessionReadState,
+  type SessionReadSeedEntry,
+} from "../tools/system/filesystem.js";
+
+export async function seedFileMentionSessionReads(
+  sessionId: string | undefined,
+  files: readonly FileMentionAttachment[],
+): Promise<void> {
+  if (!sessionId || sessionId.trim().length === 0 || files.length === 0) {
+    return;
+  }
+
+  const entries: SessionReadSeedEntry[] = [];
+  for (const file of files) {
+    if (file.truncated) continue;
+    const canonicalPath =
+      typeof file.canonicalResolved === "string" &&
+      file.canonicalResolved.length > 0
+        ? file.canonicalResolved
+        : await canonicalizePath(file.resolved);
+    entries.push({
+      path: canonicalPath,
+      content: file.content,
+      rawContent: file.rawContent,
+      timestamp:
+        typeof file.mtimeMs === "number" && Number.isFinite(file.mtimeMs)
+          ? file.mtimeMs
+          : Date.now(),
+      viewKind: "full",
+    });
+  }
+
+  if (entries.length > 0) {
+    seedSessionReadState(sessionId, entries);
+  }
+}
+
+export async function seedFileMentionAttachmentSessionReads(
+  sessionId: string | undefined,
+  attachments: readonly Attachment[],
+): Promise<void> {
+  const files = attachments
+    .filter((attachment) => attachment.kind === "file_mention")
+    .flatMap((attachment) => attachment.files);
+  await seedFileMentionSessionReads(sessionId, files);
+}

--- a/runtime/src/session/run-turn.ts
+++ b/runtime/src/session/run-turn.ts
@@ -72,6 +72,7 @@ import { postSampleRecovery } from "../phases/post-sample-recovery.js";
 import { getAttachments } from "../prompts/attachments/orchestrator.js";
 import { attachmentsToMessages } from "../prompts/attachments/messages.js";
 import { extractMentionAllowedRoots } from "../prompts/file-mentions.js";
+import { seedFileMentionAttachmentSessionReads } from "./file-mention-session-reads.js";
 import {
   realtimeEndInstructionMessage,
   realtimeStartInstructionMessage,
@@ -2331,6 +2332,10 @@ async function tryRunSamplingRequest(
     contextWindowTokens: ctx.modelInfo.contextWindow,
   });
   if (attachments.length > 0) {
+    await seedFileMentionAttachmentSessionReads(
+      session.conversationId,
+      attachments,
+    );
     const attachmentMessages = attachmentsToMessages(attachments);
     if (attachmentMessages.length > 0) {
       state.messagesForQuery = insertContextMessagesAfterLeadingSystem(

--- a/runtime/src/tool-registry.ts
+++ b/runtime/src/tool-registry.ts
@@ -72,6 +72,7 @@ import {
   resolvePerToolConfig,
   toolConfigAllowsTool,
 } from "./tools/config.js";
+import { canonicalModelToolName } from "./tools/model-tool-aliases.js";
 
 export interface ToolDispatchResult {
   readonly content: string;
@@ -889,7 +890,10 @@ export function buildToolRegistry(
     },
     async dispatch(toolCall: LLMToolCall): Promise<ToolDispatchResult> {
       const router = buildRouter();
-      const spec = router.findSpec(toolCall.name);
+      const toolName = canonicalModelToolName(toolCall.name);
+      const routedToolCall =
+        toolName === toolCall.name ? toolCall : { ...toolCall, name: toolName };
+      const spec = router.findSpec(toolName);
       if (!spec) {
         return {
           content: safeStringify({
@@ -900,7 +904,7 @@ export function buildToolRegistry(
       }
       try {
         const parseResult = parseToolCallArguments(
-          toolCall,
+          routedToolCall,
           builtinSurface.stringArgumentFields,
         );
         if (!parseResult.ok) {

--- a/runtime/src/tools/model-tool-aliases.ts
+++ b/runtime/src/tools/model-tool-aliases.ts
@@ -1,0 +1,16 @@
+import { FILE_EDIT_TOOL_NAME } from "./system/file-edit.js";
+import { FILE_READ_TOOL_NAME } from "./system/file-read.js";
+import { FILE_WRITE_TOOL_NAME } from "./system/file-write.js";
+
+const MODEL_TOOL_NAME_ALIASES: Readonly<Record<string, string>> = Object.freeze({
+  Read: FILE_READ_TOOL_NAME,
+  FileReadTool: FILE_READ_TOOL_NAME,
+  FileEdit: FILE_EDIT_TOOL_NAME,
+  FileEditTool: FILE_EDIT_TOOL_NAME,
+  FileWrite: FILE_WRITE_TOOL_NAME,
+  FileWriteTool: FILE_WRITE_TOOL_NAME,
+});
+
+export function canonicalModelToolName(name: string): string {
+  return MODEL_TOOL_NAME_ALIASES[name] ?? name;
+}

--- a/runtime/src/tools/router.ts
+++ b/runtime/src/tools/router.ts
@@ -95,6 +95,7 @@ import {
   type PlanFileContext,
 } from "../planning/plan-files.js";
 import { markLoadedToolNamesDiscovered } from "./deferred-discovery.js";
+import { canonicalModelToolName } from "./model-tool-aliases.js";
 import {
   buildToolRuntimeAttemptContext,
   buildToolRuntimeCallContext,
@@ -669,9 +670,14 @@ export class ToolRouter {
     toolCall: LLMToolCall,
     opts: LiveToolDispatchOptions,
   ): Promise<ToolDispatchResult> {
-    const routed = toolCallFromLLMToolCall(toolCall, { session: opts.session });
+    const toolName = canonicalModelToolName(toolCall.name);
+    const routedToolCall =
+      toolName === toolCall.name ? toolCall : { ...toolCall, name: toolName };
+    const routed = toolCallFromLLMToolCall(routedToolCall, {
+      session: opts.session,
+    });
 
-    const spec = this.findSpec(toolCall.name);
+    const spec = this.findSpec(toolName);
     if (!spec) {
       return {
         content: JSON.stringify({ error: `unknown tool: ${toolCall.name}` }),
@@ -684,7 +690,7 @@ export class ToolRouter {
       turn: opts.turn,
       tracker: opts.tracker,
       callId: toolCall.id,
-      toolName: parseToolName(toolCall.name),
+      toolName: parseToolName(toolName),
       payload: routed.payload,
       source: opts.source ?? "direct",
     };

--- a/runtime/tests/bin/agenc.user-prompt-submit.test.ts
+++ b/runtime/tests/bin/agenc.user-prompt-submit.test.ts
@@ -13,6 +13,11 @@ import {
 import { defaultConfig } from "../config/schema.js";
 import { trustProjectSync } from "../permissions/trust/project-trust.js";
 import type { PhaseEvent } from "../phases/events.js";
+import {
+  canonicalizePath,
+  clearSessionReadState,
+  getSessionReadSnapshot,
+} from "../tools/system/filesystem.js";
 
 function fakeSession(cwd: string) {
   let installed:
@@ -226,7 +231,9 @@ describe("TUI session UserPromptSubmit hooks", () => {
 
   it("runs live submit hooks before file mention expansion", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "agenc-prompt-hooks-cwd-"));
-    await writeFile(join(cwd, "note.txt"), "file mention body\n", "utf8");
+    const notePath = join(cwd, "note.txt");
+    await writeFile(notePath, "file mention body\n", "utf8");
+    const noteCanonicalPath = await canonicalizePath(notePath);
     const { session } = fakeSession(cwd);
     const hookPrompts: unknown[] = [];
     const turnInputs: unknown[] = [];
@@ -274,6 +281,11 @@ describe("TUI session UserPromptSubmit hooks", () => {
     expect(String(turnInputs[0])).toContain(
       "<hook_additional_context>\nraw\n</hook_additional_context>",
     );
+    expect(
+      getSessionReadSnapshot(session.conversationId, noteCanonicalPath)
+        ?.rawContent,
+    ).toBe("file mention body\n");
+    clearSessionReadState(session.conversationId);
   });
 
   it("truncates oversized live submit hook context before the turn", async () => {

--- a/runtime/tests/prompts/file-mentions.test.ts
+++ b/runtime/tests/prompts/file-mentions.test.ts
@@ -1,6 +1,8 @@
 import {
   mkdtempSync,
   mkdirSync,
+  realpathSync,
+  statSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -69,6 +71,15 @@ describe("file @mentions", () => {
 
     expect(expanded.rejected).toEqual([]);
     expect(expanded.attachments).toHaveLength(1);
+    expect(expanded.attachments[0]?.canonicalResolved).toBe(
+      realpathSync(join(cwd, "src", "app.ts")),
+    );
+    expect(expanded.attachments[0]?.rawContent).toBe(
+      "export const answer = 42;\n",
+    );
+    expect(expanded.attachments[0]?.mtimeMs).toBe(
+      statSync(join(cwd, "src", "app.ts")).mtimeMs,
+    );
     expect(expanded.prompt).toContain("<attached_files>");
     expect(expanded.prompt).toContain('path="src/app.ts"');
     expect(expanded.prompt).toContain("export const answer = 42;");

--- a/runtime/tests/session/run-turn.test.ts
+++ b/runtime/tests/session/run-turn.test.ts
@@ -101,10 +101,16 @@ import {
   PERSONALITY_SPEC_START_MARKER,
   type ModelMessages,
 } from "../context/personality-spec-instructions.js";
+import {
+  canonicalizePath,
+  clearSessionReadState,
+  getSessionReadSnapshot,
+} from "../tools/system/filesystem.js";
 
 afterEach(() => {
   sessionMemoryPostSamplingMockState.calls.length = 0;
   sessionMemoryPostSamplingMockState.error = null;
+  clearSessionReadState("conv-test");
 });
 
 function mkCtx(): TurnContext {
@@ -705,6 +711,12 @@ describe("runTurn — T6 gap #119 lifecycle emits", () => {
     expect(rendered).toContain("<attached_files>");
     expect(rendered).toContain('path="src/app.ts"');
     expect(rendered).toContain("export const answer = 42;");
+    const snapshot = getSessionReadSnapshot(
+      session.conversationId,
+      await canonicalizePath(join(cwd, "src", "app.ts")),
+    );
+    expect(snapshot?.viewKind).toBe("full");
+    expect(snapshot?.rawContent).toBe("export const answer = 42;\n");
 
     const userMsg = events.find((e) => e.msg.type === "user_message");
     if (userMsg?.msg.type === "user_message") {

--- a/runtime/tests/tool-registry.test.ts
+++ b/runtime/tests/tool-registry.test.ts
@@ -250,6 +250,25 @@ describe("tool-registry dynamic and deferred catalog", () => {
     expect(result.content).toContain("[exec exit_code=0");
   });
 
+  test("dispatch routes legacy Read calls to the canonical FileRead tool", async () => {
+    const root = await mkdtemp(join(tmpdir(), "agenc-registry-read-alias-"));
+    try {
+      await writeFile(join(root, "note.txt"), "alias read body\n", "utf8");
+      const registry = buildToolRegistry({ workspaceRoot: root });
+
+      const result = await registry.dispatch({
+        id: "read-alias-1",
+        name: "Read",
+        arguments: JSON.stringify({ file_path: "note.txt", cwd: root }),
+      });
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toContain("alias read body");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test("model-facing Task tools keep string id dispatch in the registry", async () => {
     const root = await mkdtemp(join(tmpdir(), "agenc-registry-task-tools-"));
     try {

--- a/runtime/tests/tools/router.test.ts
+++ b/runtime/tests/tools/router.test.ts
@@ -65,6 +65,46 @@ describe("ToolRouter", () => {
     expect(router.findSpec("unknown")).toBeUndefined();
   });
 
+  test("dispatchModelToolCall routes legacy Read calls to FileRead", async () => {
+    const execute = vi.fn(async (args: Record<string, unknown>) => ({
+      content: `read ${String(args.file_path)}`,
+    }));
+    const router = new ToolRouter([
+      {
+        tool: { ...readTool, execute },
+        supportsParallelToolCalls: true,
+      },
+    ]);
+
+    const result = await router.dispatchModelToolCall(
+      {
+        id: "call-read-alias",
+        name: "Read",
+        arguments: '{"file_path":"main.c"}',
+      },
+      {
+        session: {
+          eventLog: new EventLog(),
+          services: {},
+        } as never,
+        turn: { subId: "turn-read-alias" } as never,
+        tracker: {
+          appendFileDiff: () => {},
+          snapshot: () => [],
+          clear: () => {},
+        },
+        approvalPolicy: "never",
+        sandboxMode: "workspace_write",
+      },
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toBe("read main.c");
+    expect(execute).toHaveBeenCalledWith(
+      expect.objectContaining({ file_path: "main.c" }),
+    );
+  });
+
   test("findSpec rejects MCP-serverId entry for plain (no-namespace) lookup (router behavior)", () => {
     // A spec registered with `serverId` (MCP umbrella) must not
     // resolve when the request has no namespace. This prevents a


### PR DESCRIPTION
## Summary
- Seed session read snapshots from untruncated file mention attachments.
- Preserve canonical path, raw content, and mtime metadata for file mention attachments.
- Normalize model-facing file tool aliases to canonical tool dispatch paths.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/bin/agenc.user-prompt-submit.test.ts tests/prompts/file-mentions.test.ts tests/session/run-turn.test.ts tests/tool-registry.test.ts tests/tools/router.test.ts --reporter=dot
- npm run typecheck
- npm run build