### PR TITLE
fix(tui): clamp stale workbench surface selection

### DIFF
--- a/runtime/src/tui/workbench/surfaces/DiffSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/DiffSurface.tsx
@@ -13,6 +13,7 @@ import type { PendingRequest } from "../../permission-requests.js";
 import { attachDiffHunkCommand, openBufferCommand } from "../commands.js";
 import { useWorkbenchDispatch } from "../state.js";
 import { EmptySurface, SurfaceHeader } from "./PreviewSurface.js";
+import { clampSurfaceSelection } from "./selection.js";
 
 export function DiffSurface({
   focused,
@@ -26,6 +27,7 @@ export function DiffSurface({
   const [selected, setSelected] = useState(0);
   const [decisions, setDecisions] = useState<Record<string, "accept" | "skip">>({});
   const files = snapshot?.files ?? [];
+  const selectedFile = files[clampSurfaceSelection(selected, files.length)] ?? files[0];
   const approvalRisk = pendingApproval
     ? classifyApprovalRisk({
         request: pendingApproval,
@@ -54,28 +56,24 @@ export function DiffSurface({
       "surface:top": () => setSelected(0),
       "surface:bottom": () => setSelected(Math.max(0, files.length - 1)),
       "surface:open": () => {
-        const file = files[selected] ?? files[0];
-        if (file) dispatch(openBufferCommand(file.path, undefined, true));
+        if (selectedFile) dispatch(openBufferCommand(selectedFile.path, undefined, true));
       },
       "surface:attach": () => {
-        const file = files[selected] ?? files[0];
-        if (file) dispatch(attachDiffHunkCommand({ path: file.path, label: `${file.path} diff` }));
+        if (selectedFile) dispatch(attachDiffHunkCommand({ path: selectedFile.path, label: `${selectedFile.path} diff` }));
       },
       "surface:accept": () => {
         if (pendingApproval && approvalRisk !== "destructive") {
           pendingApproval.resolve(APPROVED);
           return;
         }
-        const file = files[selected] ?? files[0];
-        if (file) setDecisions((prev) => ({ ...prev, [file.path]: "accept" }));
+        if (selectedFile) setDecisions((prev) => ({ ...prev, [selectedFile.path]: "accept" }));
       },
       "surface:reject": () => {
         if (pendingApproval) {
           pendingApproval.resolve(DENIED);
           return;
         }
-        const file = files[selected] ?? files[0];
-        if (file) setDecisions((prev) => ({ ...prev, [file.path]: "skip" }));
+        if (selectedFile) setDecisions((prev) => ({ ...prev, [selectedFile.path]: "skip" }));
       },
       "workbench:closeSurface": () => dispatch({ type: "closeSurface" }),
     },
@@ -111,7 +109,8 @@ export function DiffSurfaceView({
   readonly pendingApprovalRisk?: "low" | "medium" | "destructive" | null;
 }): React.ReactElement {
   const files = snapshot.files ?? [];
-  const selectedFile = files[selected] ?? files[0];
+  const selectedIndex = clampSurfaceSelection(selected, files.length);
+  const selectedFile = files[selectedIndex] ?? files[0];
   const acceptedCount = Object.values(decisions).filter((value) => value === "accept").length;
   const skippedCount = Object.values(decisions).filter((value) => value === "skip").length;
   return (
@@ -131,7 +130,7 @@ export function DiffSurfaceView({
       <Box flexDirection="row" flexGrow={1} overflow="hidden">
         <Box flexDirection="column" width={32} flexShrink={0} borderRight borderColor="gray" paddingRight={1}>
           {files.slice(0, 40).map((file, index) => (
-            <Text key={file.path} color={index === selected ? "suggestion" : undefined} wrap="truncate-end">
+            <Text key={file.path} color={index === selectedIndex ? "suggestion" : undefined} wrap="truncate-end">
               {decisionMarker(decisions[file.path])}{statusMarker(file.status)} {file.path}
             </Text>
           ))}

--- a/runtime/src/tui/workbench/surfaces/SearchSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/SearchSurface.tsx
@@ -11,6 +11,7 @@ import { groupSearchMatches, parseWorkbenchRipgrepLine, visibleSearchRows } from
 import { useWorkbenchDispatch, useWorkbenchState } from "../state.js";
 import type { SearchMatch } from "../types.js";
 import { EmptySurface, SurfaceHeader } from "./PreviewSurface.js";
+import { clampSurfaceSelection } from "./selection.js";
 
 export function SearchSurface({ focused }: { readonly focused: boolean }): React.ReactElement {
   const workbench = useWorkbenchState();
@@ -66,7 +67,8 @@ export function SearchSurface({ focused }: { readonly focused: boolean }): React
     };
   }, [query]);
 
-  const selectedMatch = matches[selected] ?? null;
+  const selectedIndex = clampSurfaceSelection(selected, matches.length);
+  const selectedMatch = matches[selectedIndex] ?? null;
   const groups = useMemo(() => groupSearchMatches(matches), [matches]);
   const rows = useMemo(() => visibleSearchRows(groups), [groups]);
   useRegisterKeybindingContext("Surface", focused);
@@ -103,7 +105,7 @@ export function SearchSurface({ focused }: { readonly focused: boolean }): React
     <SearchSurfaceView
       query={query}
       matches={matches}
-      selected={selected}
+      selected={selectedIndex}
       loading={loading}
       error={error}
       focused={focused}
@@ -126,7 +128,8 @@ export function SearchSurfaceView({
   readonly error: string | null;
   readonly focused: boolean;
 }): React.ReactElement {
-  const selectedMatch = matches[selected] ?? null;
+  const selectedIndex = clampSurfaceSelection(selected, matches.length);
+  const selectedMatch = matches[selectedIndex] ?? null;
   const groups = groupSearchMatches(matches);
   const rows = visibleSearchRows(groups);
   return (
@@ -141,7 +144,7 @@ export function SearchSurfaceView({
           row.kind === "file" ? (
             <Text key={row.id} color="text2" wrap="truncate-end">{row.file} ({row.count})</Text>
           ) : (
-            <Text key={row.id} color={matches[selected]?.id === row.match.id ? "suggestion" : undefined} wrap="truncate-end">
+            <Text key={row.id} color={matches[selectedIndex]?.id === row.match.id ? "suggestion" : undefined} wrap="truncate-end">
               <Text dimColor>  {row.match.line} </Text>{row.match.text.trim()}
             </Text>
           ),

--- a/runtime/src/tui/workbench/surfaces/TestSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/TestSurface.tsx
@@ -11,6 +11,7 @@ import { attachTaskErrorCommand } from "../commands.js";
 import { useWorkbenchDispatch, useWorkbenchState } from "../state.js";
 import { EmptySurface, SurfaceHeader } from "./PreviewSurface.js";
 import { parseVitestFailures } from "./outputParsers.js";
+import { clampSurfaceSelection } from "./selection.js";
 
 const TAIL_BYTES = 48_000;
 
@@ -25,7 +26,8 @@ export function TestSurface({ focused }: { readonly focused: boolean }): React.R
   const [tail, setTail] = useState("");
   const [selected, setSelected] = useState(0);
   const failures = useMemo(() => parseVitestFailures(tail), [tail]);
-  const selectedFailure = failures[selected] ?? null;
+  const selectedIndex = clampSurfaceSelection(selected, failures.length);
+  const selectedFailure = failures[selectedIndex] ?? null;
 
   useEffect(() => {
     if (!task?.id) {
@@ -85,6 +87,20 @@ export function TestSurface({ focused }: { readonly focused: boolean }): React.R
 
   if (!task) return <EmptySurface title="TEST" message="No test task selected" />;
 
+  return <TestSurfaceView failures={failures} selected={selectedIndex} focused={focused} />;
+}
+
+export function TestSurfaceView({
+  failures,
+  selected,
+  focused,
+}: {
+  readonly failures: readonly ReturnType<typeof parseVitestFailures>[number][];
+  readonly selected: number;
+  readonly focused: boolean;
+}): React.ReactElement {
+  const selectedIndex = clampSurfaceSelection(selected, failures.length);
+  const selectedFailure = failures[selectedIndex] ?? null;
   return (
     <Box flexDirection="column" width="100%" height="100%" overflow="hidden">
       <SurfaceHeader title="TEST" detail={`${failures.length} failure${failures.length === 1 ? "" : "s"} - g/enter edit - @ attach`} focused={focused} />
@@ -93,7 +109,7 @@ export function TestSurface({ focused }: { readonly focused: boolean }): React.R
       ) : null}
       <Box flexDirection="column" flexGrow={1} overflow="hidden">
         {failures.map((failure, index) => (
-          <Text key={failure.id} color={index === selected ? "suggestion" : undefined} wrap="truncate-end">
+          <Text key={failure.id} color={index === selectedIndex ? "suggestion" : undefined} wrap="truncate-end">
             {failure.location ? `${failure.location.file}:${failure.location.line} ` : ""}
             {failure.name}
           </Text>

--- a/runtime/src/tui/workbench/surfaces/selection.ts
+++ b/runtime/src/tui/workbench/surfaces/selection.ts
@@ -1,0 +1,6 @@
+export function clampSurfaceSelection(selected: number, itemCount: number): number {
+  if (!Number.isFinite(selected) || selected <= 0 || itemCount <= 0) {
+    return 0;
+  }
+  return Math.min(Math.trunc(selected), itemCount - 1);
+}

--- a/runtime/tests/tui/coverage-swarm/swarm-049-keybindings-KeybindingProviderSetup.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-049-keybindings-KeybindingProviderSetup.test.tsx
@@ -182,7 +182,7 @@ describe("KeybindingProviderSetup coverage swarm 049", () => {
     expect(invoked).toHaveBeenCalledTimes(1);
   });
 
-  test("clears chord state without stopping when a completed chord has no handler", () => {
+  test("clears chord state and consumes completed chord input without a handler", () => {
     const bindings = parseBindings([
       {
         context: "Chat",
@@ -211,7 +211,7 @@ describe("KeybindingProviderSetup coverage swarm 049", () => {
     const completionEvent = inputEvent();
     handler("k", key({ ctrl: true }), completionEvent);
 
-    expect(completionEvent.stopped).toBe(false);
+    expect(completionEvent.stopped).toBe(true);
     expect(pendingChordRef.current).toBeNull();
   });
 

--- a/runtime/tests/tui/keybindings/useKeybinding.test.ts
+++ b/runtime/tests/tui/keybindings/useKeybinding.test.ts
@@ -71,6 +71,7 @@ const NON_MENU_CONTEXTS = new Set<KeybindingContextName>([
   "Workbench",
   "Explorer",
   "Surface",
+  "Buffer",
   "Agents",
   "Composer",
 ]);
@@ -79,6 +80,7 @@ const WORKBENCH_CONTEXTS: readonly KeybindingContextName[] = [
   "Workbench",
   "Explorer",
   "Surface",
+  "Buffer",
   "Agents",
   "Composer",
 ];

--- a/runtime/tests/tui/workbench/diff-surface.test.tsx
+++ b/runtime/tests/tui/workbench/diff-surface.test.tsx
@@ -41,4 +41,34 @@ describe("DiffSurfaceView", () => {
       expect(line.length).toBeLessThanOrEqual(columns);
     }
   });
+
+  it("clamps stale selection to the last changed file", async () => {
+    const snapshot = createDiffMenuSnapshot({
+      rawDiff: [
+        "diff --git a/src/app.ts b/src/app.ts",
+        "@@ -1 +1 @@",
+        "-old",
+        "+new",
+        "diff --git a/src/new.ts b/src/new.ts",
+        "@@ -0,0 +1 @@",
+        "+fresh",
+      ].join("\n"),
+      nameStatus: "M\tsrc/app.ts\nA\tsrc/new.ts",
+      numstat: "1\t1\tsrc/app.ts\n1\t0\tsrc/new.ts",
+      untrackedFiles: [],
+    });
+
+    const output = await renderToString(
+      <DiffSurfaceView
+        snapshot={snapshot}
+        selected={99}
+        decisions={{}}
+        focused={true}
+        pendingApprovalRisk={null}
+      />,
+      { columns: 80, rows: 24 },
+    );
+
+    expect(output).toContain("src/new.ts - non-mutating review");
+  });
 });

--- a/runtime/tests/tui/workbench/search-surface.test.tsx
+++ b/runtime/tests/tui/workbench/search-surface.test.tsx
@@ -64,4 +64,24 @@ describe("SearchSurfaceView", () => {
       expect(line.length).toBeLessThanOrEqual(60);
     }
   });
+
+  it("clamps stale selection to a live match", async () => {
+    const output = await renderToString(
+      <SearchSurfaceView
+        query="needle"
+        matches={[
+          { id: "src/app.ts:4:needle", file: "src/app.ts", line: 4, text: "const needle = true" },
+          { id: "src/other.ts:9:needle", file: "src/other.ts", line: 9, text: "needle()" },
+        ]}
+        selected={99}
+        loading={false}
+        error={null}
+        focused={true}
+      />,
+      80,
+    );
+
+    expect(output).toContain("src/other.ts:9");
+    expect(output).toContain("@ attach");
+  });
 });

--- a/runtime/tests/tui/workbench/surface-selection.test.ts
+++ b/runtime/tests/tui/workbench/surface-selection.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { clampSurfaceSelection } from "../../../src/tui/workbench/surfaces/selection.js";
+
+describe("workbench surface selection helpers", () => {
+  it("clamps stale or malformed selected indexes to live rows", () => {
+    expect(clampSurfaceSelection(0, 3)).toBe(0);
+    expect(clampSurfaceSelection(2, 3)).toBe(2);
+    expect(clampSurfaceSelection(99, 3)).toBe(2);
+    expect(clampSurfaceSelection(-4, 3)).toBe(0);
+    expect(clampSurfaceSelection(Number.NaN, 3)).toBe(0);
+    expect(clampSurfaceSelection(1, 0)).toBe(0);
+    expect(clampSurfaceSelection(1.8, 3)).toBe(1);
+  });
+});

--- a/runtime/tests/tui/workbench/test-surface.test.tsx
+++ b/runtime/tests/tui/workbench/test-surface.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+
+import { TestSurfaceView } from "../../../src/tui/workbench/surfaces/TestSurface.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+describe("TestSurfaceView", () => {
+  it("clamps stale selection to the last parsed failure", async () => {
+    const output = await renderToString(
+      <TestSurfaceView
+        failures={[
+          {
+            id: "first",
+            name: "first failure",
+            location: { file: "src/first.ts", line: 4 },
+            message: "first message",
+          },
+          {
+            id: "second",
+            name: "second failure",
+            location: { file: "src/second.ts", line: 9 },
+            message: "second message",
+          },
+        ]}
+        selected={99}
+        focused={true}
+      />,
+      80,
+    );
+
+    expect(output).toContain("second failure");
+    expect(output).toContain("second message");
+  });
+});


### PR DESCRIPTION
## Summary
- clamp stale selected indexes in diff, search, and test workbench surfaces before rendering or executing actions
- add focused coverage for stale surface selection and the shared clamp helper
- update keybinding coverage expectations for the current chord-consumption contract

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/keybindings/useKeybinding.test.ts tests/tui/keybindings/KeybindingProviderSetup.test.tsx tests/tui/coverage-swarm/swarm-049-keybindings-KeybindingProviderSetup.test.tsx --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/surface-selection.test.ts tests/tui/workbench/search-surface.test.tsx tests/tui/workbench/diff-surface.test.tsx tests/tui/workbench/test-surface.test.tsx --reporter=dot
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- npm run typecheck
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
