### PR TITLE
fix(tui): resolve stale agents rail selection

### DIFF
--- a/runtime/src/tui/workbench/agents/AgentsRail.tsx
+++ b/runtime/src/tui/workbench/agents/AgentsRail.tsx
@@ -23,8 +23,7 @@ export function AgentsRail({
   const dispatch = useWorkbenchDispatch();
   const taskList = Object.values(tasks ?? {}).filter((task: any) => task.type !== "local_bash");
   const { activeTasks, backgroundTasks } = partitionAgentTasks(taskList);
-  const selectedId = workbench.selectedAgentTaskId ?? taskList[0]?.id ?? null;
-  const selectedIndex = Math.max(0, taskList.findIndex((task: any) => task.id === selectedId));
+  const { selectedId, selectedIndex, selectedTask } = resolveAgentSelection(taskList, workbench.selectedAgentTaskId);
   const selectByDelta = (delta: number) => {
     if (taskList.length === 0) return;
     const base = selectedIndex < 0 ? 0 : selectedIndex;
@@ -39,12 +38,10 @@ export function AgentsRail({
       "agents:up": () => selectByDelta(-1),
       "agents:down": () => selectByDelta(1),
       "agents:open": () => {
-        const taskId = selectedId ?? taskList[0]?.id;
-        if (taskId) dispatch({ type: "openAgent", taskId, focus: true });
+        if (selectedTask?.id) dispatch({ type: "openAgent", taskId: selectedTask.id, focus: true });
       },
       "agents:stop": () => {
-        const task = taskList[selectedIndex] ?? taskList[0];
-        if (task) stopWorkbenchTask(task, setAppState);
+        if (selectedTask) stopWorkbenchTask(selectedTask, setAppState);
       },
     },
     { context: "Agents", isActive: focused },
@@ -72,6 +69,24 @@ export function partitionAgentTasks(tasks: readonly any[]): {
   return {
     activeTasks: tasks.filter((task: any) => task.status === "running" || task.status === "pending"),
     backgroundTasks: tasks.filter((task: any) => task.status !== "running" && task.status !== "pending"),
+  };
+}
+
+export function resolveAgentSelection(tasks: readonly any[], selectedId: string | null | undefined): {
+  readonly selectedId: string | null;
+  readonly selectedIndex: number;
+  readonly selectedTask: any | null;
+} {
+  if (tasks.length === 0) {
+    return { selectedId: null, selectedIndex: -1, selectedTask: null };
+  }
+  const selectedIndex = tasks.findIndex((task: any) => task.id === selectedId);
+  const resolvedIndex = selectedIndex >= 0 ? selectedIndex : 0;
+  const selectedTask = tasks[resolvedIndex] ?? null;
+  return {
+    selectedId: selectedTask?.id ?? null,
+    selectedIndex: selectedTask ? resolvedIndex : -1,
+    selectedTask,
   };
 }
 

--- a/runtime/tests/tui/workbench/agents-rail.test.tsx
+++ b/runtime/tests/tui/workbench/agents-rail.test.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const keybindingHarness = vi.hoisted(() => ({
+  handlers: {} as Record<string, () => void>,
+}));
+
+vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
+  useKeybinding: () => {},
+  useKeybindings: (handlers: Record<string, () => void>) => {
+    keybindingHarness.handlers = handlers;
+  },
+}));
+
+import { AppStateProvider, getDefaultAppState, type AppState } from "../../../src/tui/state/AppState.js";
+import { AgentsRail } from "../../../src/tui/workbench/agents/AgentsRail.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+describe("AgentsRail", () => {
+  it("opens the first live agent when the selected agent id is stale", async () => {
+    const changes: AppState[] = [];
+    const liveAgent = {
+      id: "agent-live",
+      type: "local_agent",
+      status: "running",
+      description: "live agent",
+      startTime: 1_000,
+      outputFile: "urn:agenc:task:agent-live:output",
+      outputOffset: 0,
+      notified: false,
+    } as any;
+
+    await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...getDefaultAppState(),
+          tasks: { [liveAgent.id]: liveAgent },
+          workbench: {
+            ...getDefaultAppState().workbench,
+            selectedAgentTaskId: "agent-gone",
+          },
+        }}
+        onChangeAppState={({ newState }) => changes.push(newState)}
+      >
+        <AgentsRail focused={true} width={40} />
+      </AppStateProvider>,
+      80,
+    );
+
+    keybindingHarness.handlers["agents:open"]?.();
+
+    expect(changes.at(-1)?.workbench).toMatchObject({
+      activeSurfaceMode: "agent",
+      focusedPane: "surface",
+      selectedAgentTaskId: "agent-live",
+    });
+  });
+});

--- a/runtime/tests/tui/workbench/agents.test.ts
+++ b/runtime/tests/tui/workbench/agents.test.ts
@@ -6,7 +6,7 @@ import {
   taskMayReferencePath,
   taskPathLabel,
 } from "../../../src/tui/workbench/agents/activity.js";
-import { partitionAgentTasks } from "../../../src/tui/workbench/agents/AgentsRail.js";
+import { partitionAgentTasks, resolveAgentSelection } from "../../../src/tui/workbench/agents/AgentsRail.js";
 
 describe("workbench agents rail model", () => {
   it("groups active and background agent tasks", () => {
@@ -19,6 +19,29 @@ describe("workbench agents rail model", () => {
 
     expect(grouped.activeTasks.map((task) => task.id)).toEqual(["agent-1", "agent-2"]);
     expect(grouped.backgroundTasks.map((task) => task.id)).toEqual(["agent-3", "agent-4"]);
+  });
+
+  it("resolves stale agent selection to the first live agent", () => {
+    const tasks = [
+      { id: "agent-1", type: "local_agent", status: "running" },
+      { id: "agent-2", type: "remote_agent", status: "completed" },
+    ];
+
+    expect(resolveAgentSelection(tasks, "agent-2")).toMatchObject({
+      selectedId: "agent-2",
+      selectedIndex: 1,
+      selectedTask: tasks[1],
+    });
+    expect(resolveAgentSelection(tasks, "agent-gone")).toMatchObject({
+      selectedId: "agent-1",
+      selectedIndex: 0,
+      selectedTask: tasks[0],
+    });
+    expect(resolveAgentSelection([], "agent-gone")).toEqual({
+      selectedId: null,
+      selectedIndex: -1,
+      selectedTask: null,
+    });
   });
 
   it("formats elapsed runtime and extracts task paths", () => {


### PR DESCRIPTION
## Summary
- resolve stale `selectedAgentTaskId` values to the first live agent before rendering or executing rail actions
- route `agents:open` and `agents:stop` through the same resolved task model
- add model and interaction regression coverage for stale agent selection

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/agents.test.ts tests/tui/workbench/agents-rail.test.tsx --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Notes
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing unrelated Knip backlog; no new agents rail findings were reported.
