### PR TITLE
fix(tui): open teammate transcripts from agent surface

### DIFF
--- a/runtime/src/tui/workbench/surfaces/AgentSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/AgentSurface.tsx
@@ -51,7 +51,7 @@ export function AgentSurface({ focused }: { readonly focused: boolean }): React.
   useKeybindings(
     {
       "surface:open": () => {
-        if (task?.type === "local_agent") enterTeammateView(task.id, setAppState);
+        if (canEnterAgentTranscript(task)) enterTeammateView(task.id, setAppState);
       },
       "surface:stop": () => {
         if (task) stopWorkbenchTask(task, setAppState);
@@ -86,7 +86,7 @@ export function AgentSurface({ focused }: { readonly focused: boolean }): React.
         </Box>
       ) : null}
       <Text dimColor wrap="truncate-end">
-        {task.type === "local_agent" ? "enter transcript · " : ""}
+        {canEnterAgentTranscript(task) ? "enter transcript · " : ""}
         {stopAction === "remote-unavailable" ? "stop unavailable from this session" : stopAction ? "x stop" : "view only"}
         {" · steer unavailable unless agent routing is real"}
       </Text>
@@ -97,4 +97,8 @@ export function AgentSurface({ focused }: { readonly focused: boolean }): React.
       </Box>
     </Box>
   );
+}
+
+export function canEnterAgentTranscript(task: { readonly id?: string; readonly type?: string } | null | undefined): task is { readonly id: string; readonly type: "local_agent" | "in_process_teammate" } {
+  return typeof task?.id === "string" && (task.type === "local_agent" || task.type === "in_process_teammate");
 }

--- a/runtime/tests/tui/workbench/agent-surface.test.tsx
+++ b/runtime/tests/tui/workbench/agent-surface.test.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const keybindingHarness = vi.hoisted(() => ({
+  handlers: {} as Record<string, () => void>,
+}));
+
+vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
+  useKeybinding: () => {},
+  useKeybindings: (handlers: Record<string, () => void>) => {
+    keybindingHarness.handlers = handlers;
+  },
+}));
+
+import { AppStateProvider, getDefaultAppState, type AppState } from "../../../src/tui/state/AppState.js";
+import { AgentSurface, canEnterAgentTranscript } from "../../../src/tui/workbench/surfaces/AgentSurface.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+describe("AgentSurface", () => {
+  it("opens in-process teammate transcripts from the agent surface", async () => {
+    const changes: AppState[] = [];
+    const teammateTask = {
+      id: "teammate-1",
+      type: "in_process_teammate",
+      status: "running",
+      description: "reviewing",
+      startTime: 1_000,
+      outputFile: "urn:agenc:task:teammate-1:output",
+      outputOffset: 0,
+      notified: false,
+      identity: {
+        agentId: "agent-1",
+        agentName: "Reviewer",
+        teamName: "audit",
+      },
+    } as any;
+
+    const output = await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...getDefaultAppState(),
+          tasks: { [teammateTask.id]: teammateTask },
+          workbench: {
+            ...getDefaultAppState().workbench,
+            activeSurfaceMode: "agent",
+            selectedAgentTaskId: teammateTask.id,
+          },
+        }}
+        onChangeAppState={({ newState }) => changes.push(newState)}
+      >
+        <AgentSurface focused={true} />
+      </AppStateProvider>,
+      80,
+    );
+
+    expect(output).toContain("enter transcript");
+
+    keybindingHarness.handlers["surface:open"]?.();
+
+    expect(changes.at(-1)).toMatchObject({
+      viewingAgentTaskId: teammateTask.id,
+      viewSelectionMode: "viewing-agent",
+    });
+  });
+
+  it("limits transcript entry to locally viewable agent task types", () => {
+    expect(canEnterAgentTranscript({ id: "local", type: "local_agent" })).toBe(true);
+    expect(canEnterAgentTranscript({ id: "team", type: "in_process_teammate" })).toBe(true);
+    expect(canEnterAgentTranscript({ id: "remote", type: "remote_agent" })).toBe(false);
+    expect(canEnterAgentTranscript({ type: "local_agent" })).toBe(false);
+    expect(canEnterAgentTranscript(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- let the agent surface open in-process teammate transcripts, matching the rest of the teammate TUI entry points
- align the agent surface hint with the locally viewable agent task types
- add focused regression coverage for the surface Enter action and transcript-entry predicate

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/agent-surface.test.tsx tests/tui/state/teammateViewHelpers.test.ts tests/tui/workbench/agents.test.ts tests/tui/workbench/agents-rail.test.tsx --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Notes
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing unrelated Knip backlog; no new AgentSurface finding was reported.
