### PR TITLE
fix(tui): classify approval bridge risk from input

### DIFF
--- a/runtime/src/tui/workbench/approvals/ApprovalSurfaceBridge.tsx
+++ b/runtime/src/tui/workbench/approvals/ApprovalSurfaceBridge.tsx
@@ -24,7 +24,11 @@ export function ApprovalSurfaceBridge({
   );
 
   if (!request) return null;
-  const risk = classifyApprovalRisk({ request, description: request.description });
+  const risk = classifyApprovalRisk({
+    request,
+    description: request.description,
+    command: approvalInputText(request.input),
+  });
   return (
     <Box flexDirection="column">
       <Text color={risk === "destructive" ? "error" : risk === "medium" ? "warning" : "text2"} wrap="truncate-end">
@@ -35,4 +39,18 @@ export function ApprovalSurfaceBridge({
       </Text>
     </Box>
   );
+}
+
+function approvalInputText(input: Record<string, unknown>): string {
+  for (const key of ["command", "cmd", "input", "query", "path", "file_path"]) {
+    const value = input[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+  try {
+    return JSON.stringify(input);
+  } catch {
+    return "";
+  }
 }

--- a/runtime/tests/tui/workbench/approval-surface-bridge.test.tsx
+++ b/runtime/tests/tui/workbench/approval-surface-bridge.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+const keybindingHarness = vi.hoisted(() => ({
+  action: "",
+  handler: undefined as undefined | (() => void),
+  options: undefined as undefined | Record<string, unknown>,
+}));
+
+vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
+  useKeybinding: (
+    action: string,
+    handler: () => void,
+    options: Record<string, unknown>,
+  ) => {
+    keybindingHarness.action = action;
+    keybindingHarness.handler = handler;
+    keybindingHarness.options = options;
+  },
+  useKeybindings: () => {},
+}));
+
+import { AppStateProvider, getDefaultAppState, type AppState } from "../../../src/tui/state/AppState.js";
+import { ApprovalSurfaceBridge } from "../../../src/tui/workbench/approvals/ApprovalSurfaceBridge.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+describe("ApprovalSurfaceBridge", () => {
+  it("classifies destructive approval risk from request input commands", async () => {
+    const request = pendingRequest({
+      id: "approval-1",
+      description: "Run shell command",
+      input: { command: "rm -rf /tmp/agenc-danger" },
+      toolName: "Bash",
+    });
+
+    const output = await renderToString(
+      <AppStateProvider initialState={getDefaultAppState()}>
+        <ApprovalSurfaceBridge request={request} />
+      </AppStateProvider>,
+      80,
+    );
+
+    expect(output).toContain("Approval pending: Run shell command");
+    expect(output).toContain("risk destructive");
+  });
+
+  it("opens the diff surface for the active approval request", async () => {
+    const changes: AppState[] = [];
+    const request = pendingRequest({
+      id: "approval-diff",
+      description: "Edit file",
+      input: { command: "apply patch" },
+      toolName: "Edit",
+    });
+
+    await renderToString(
+      <AppStateProvider
+        initialState={getDefaultAppState()}
+        onChangeAppState={({ newState }) => changes.push(newState)}
+      >
+        <ApprovalSurfaceBridge request={request} />
+      </AppStateProvider>,
+      80,
+    );
+
+    expect(keybindingHarness).toMatchObject({
+      action: "workbench:openDiff",
+      options: { context: "Confirmation", isActive: true },
+    });
+
+    keybindingHarness.handler?.();
+
+    expect(changes.at(-1)?.workbench).toMatchObject({
+      activeSurfaceMode: "diff",
+      focusedPane: "surface",
+      openDiffId: "approval-diff",
+    });
+  });
+});
+
+function pendingRequest({
+  id,
+  description,
+  input,
+  toolName,
+}: {
+  readonly id: string;
+  readonly description: string;
+  readonly input: Record<string, unknown>;
+  readonly toolName: string;
+}) {
+  return {
+    id,
+    description,
+    input,
+    ctx: {
+      toolName,
+      invocation: { payload: {} },
+    },
+    resolve: vi.fn(),
+  } as any;
+}


### PR DESCRIPTION
## Summary
- include approval request input when the workbench approval bridge classifies risk
- prevent destructive shell commands from being shown as low-risk in the workbench approval hint
- add focused approval bridge coverage for destructive input and diff-opening keybinding behavior

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/approval-surface-bridge.test.tsx tests/tui/workbench/risk.test.ts tests/tui/workbench/diff-surface.test.tsx tests/tui/workbench/reducer.test.ts --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Notes
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing unrelated Knip backlog; no new ApprovalSurfaceBridge finding was reported.
