### PR TITLE
fix(tui): ignore non-shell workbench selections

### DIFF
--- a/runtime/src/tui/workbench/surfaces/ShellSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/ShellSurface.tsx
@@ -10,6 +10,7 @@ import { useKeybindings } from "../../keybindings/useKeybinding.js";
 import { useRegisterKeybindingContext } from "../../keybindings/KeybindingContext.js";
 import { attachTaskErrorCommand } from "../commands.js";
 import { useWorkbenchDispatch, useWorkbenchState } from "../state.js";
+import { resolveWorkbenchShellTask } from "../tasks/shellTasks.js";
 import { stopWorkbenchTask, workbenchStopActionForTask } from "../tasks/stopActions.js";
 import { EmptySurface, SurfaceHeader } from "./PreviewSurface.js";
 import { parseSourceLocations } from "./outputParsers.js";
@@ -22,8 +23,7 @@ export function ShellSurface({ focused }: { readonly focused: boolean }): React.
   const dispatch = useWorkbenchDispatch();
   const setAppState = useSetAppState();
   const task = useMemo(() => {
-    if (workbench.selectedShellTaskId && tasks[workbench.selectedShellTaskId]) return tasks[workbench.selectedShellTaskId];
-    return Object.values(tasks).find((item: any) => item.type === "local_bash") ?? null;
+    return resolveWorkbenchShellTask(tasks, workbench.selectedShellTaskId);
   }, [tasks, workbench.selectedShellTaskId]);
   const [tail, setTail] = useState("");
 

--- a/runtime/src/tui/workbench/surfaces/TestSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/TestSurface.tsx
@@ -9,6 +9,7 @@ import { useRegisterKeybindingContext } from "../../keybindings/KeybindingContex
 import { useAppState } from "../../state/AppState.js";
 import { attachTaskErrorCommand } from "../commands.js";
 import { useWorkbenchDispatch, useWorkbenchState } from "../state.js";
+import { resolveWorkbenchShellTask } from "../tasks/shellTasks.js";
 import { EmptySurface, SurfaceHeader } from "./PreviewSurface.js";
 import { parseVitestFailures } from "./outputParsers.js";
 import { clampSurfaceSelection } from "./selection.js";
@@ -20,8 +21,7 @@ export function TestSurface({ focused }: { readonly focused: boolean }): React.R
   const tasks = useAppState((state) => state.tasks);
   const dispatch = useWorkbenchDispatch();
   const task = useMemo(() => {
-    if (workbench.selectedShellTaskId && tasks[workbench.selectedShellTaskId]) return tasks[workbench.selectedShellTaskId];
-    return Object.values(tasks).find((item: any) => item.type === "local_bash") ?? null;
+    return resolveWorkbenchShellTask(tasks, workbench.selectedShellTaskId);
   }, [tasks, workbench.selectedShellTaskId]);
   const [tail, setTail] = useState("");
   const [selected, setSelected] = useState(0);

--- a/runtime/src/tui/workbench/tasks/shellTasks.ts
+++ b/runtime/src/tui/workbench/tasks/shellTasks.ts
@@ -1,0 +1,14 @@
+import {
+  isLocalShellTask,
+  type LocalShellTaskState,
+  type TaskState,
+} from "../../../tasks/types.js";
+
+export function resolveWorkbenchShellTask(
+  tasks: Readonly<Record<string, TaskState>> | null | undefined,
+  selectedTaskId: string | null | undefined,
+): LocalShellTaskState | null {
+  const selectedTask = selectedTaskId ? tasks?.[selectedTaskId] : undefined;
+  if (isLocalShellTask(selectedTask)) return selectedTask;
+  return Object.values(tasks ?? {}).find(isLocalShellTask) ?? null;
+}

--- a/runtime/tests/tui/workbench/shell-surface.test.tsx
+++ b/runtime/tests/tui/workbench/shell-surface.test.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/utils/fsOperations.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../src/utils/fsOperations.js")>()),
+  tailFile: vi.fn(async () => ({ content: "" })),
+}));
+
+vi.mock("../../../src/utils/task/diskOutput.js", () => ({
+  getTaskOutputPath: (taskId: string) => `/tmp/${taskId}.log`,
+}));
+
+vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
+  useKeybinding: () => {},
+  useKeybindings: () => {},
+}));
+
+import { AppStateProvider, getDefaultAppState } from "../../../src/tui/state/AppState.js";
+import { ShellSurface } from "../../../src/tui/workbench/surfaces/ShellSurface.js";
+import { renderToString } from "../../../src/utils/staticRender.js";
+
+describe("ShellSurface", () => {
+  it("ignores stale selected ids that point at non-shell tasks", async () => {
+    const output = await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...getDefaultAppState(),
+          tasks: {
+            "agent-1": {
+              id: "agent-1",
+              type: "local_agent",
+              status: "running",
+              description: "agent work",
+              startTime: 1_000,
+              outputFile: "urn:agenc:task:agent-1:output",
+              outputOffset: 0,
+              notified: false,
+            } as any,
+            "shell-1": {
+              id: "shell-1",
+              type: "local_bash",
+              status: "completed",
+              description: "npm test",
+              command: "npm test",
+              startTime: 1_000,
+              outputFile: "urn:agenc:task:shell-1:output",
+              outputOffset: 0,
+              notified: false,
+            } as any,
+          },
+          workbench: {
+            ...getDefaultAppState().workbench,
+            activeSurfaceMode: "shell",
+            selectedShellTaskId: "agent-1",
+          },
+        }}
+      >
+        <ShellSurface focused={true} />
+      </AppStateProvider>,
+      100,
+    );
+
+    expect(output).toContain("SHELL - completed - npm test");
+    expect(output).not.toContain("agent work");
+  });
+
+  it("shows an empty shell state instead of rendering a selected agent task", async () => {
+    const output = await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...getDefaultAppState(),
+          tasks: {
+            "agent-1": {
+              id: "agent-1",
+              type: "local_agent",
+              status: "running",
+              description: "agent work",
+              startTime: 1_000,
+              outputFile: "urn:agenc:task:agent-1:output",
+              outputOffset: 0,
+              notified: false,
+            } as any,
+          },
+          workbench: {
+            ...getDefaultAppState().workbench,
+            activeSurfaceMode: "shell",
+            selectedShellTaskId: "agent-1",
+          },
+        }}
+      >
+        <ShellSurface focused={true} />
+      </AppStateProvider>,
+      100,
+    );
+
+    expect(output).toContain("No shell task selected");
+    expect(output).not.toContain("agent work");
+  });
+});

--- a/runtime/tests/tui/workbench/shell-tasks.test.ts
+++ b/runtime/tests/tui/workbench/shell-tasks.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveWorkbenchShellTask } from "../../../src/tui/workbench/tasks/shellTasks.js";
+
+describe("resolveWorkbenchShellTask", () => {
+  it("uses the selected task when it is a local shell task", () => {
+    const shell = shellTask("shell-1");
+
+    expect(resolveWorkbenchShellTask({ "shell-1": shell }, "shell-1")).toBe(shell);
+  });
+
+  it("falls back to a live shell task when the selected id is stale or non-shell", () => {
+    const shell = shellTask("shell-1");
+    const agent = agentTask("agent-1");
+
+    expect(resolveWorkbenchShellTask({ "agent-1": agent, "shell-1": shell }, "agent-1")).toBe(shell);
+    expect(resolveWorkbenchShellTask({ "shell-1": shell }, "missing")).toBe(shell);
+  });
+
+  it("returns null when no local shell task is available", () => {
+    expect(resolveWorkbenchShellTask({ "agent-1": agentTask("agent-1") }, "agent-1")).toBeNull();
+    expect(resolveWorkbenchShellTask({}, null)).toBeNull();
+  });
+});
+
+function shellTask(id: string) {
+  return {
+    id,
+    type: "local_bash",
+    status: "running",
+    description: "npm test",
+    command: "npm test",
+    startTime: 1_000,
+    outputFile: `urn:agenc:task:${id}:output`,
+    outputOffset: 0,
+    notified: false,
+  } as const;
+}
+
+function agentTask(id: string) {
+  return {
+    id,
+    type: "local_agent",
+    status: "running",
+    description: "agent work",
+    startTime: 1_000,
+    outputFile: `urn:agenc:task:${id}:output`,
+    outputOffset: 0,
+    notified: false,
+    agentId: id,
+    prompt: "inspect",
+    agentType: "default",
+    retrieved: false,
+    lastReportedToolCount: 0,
+    lastReportedTokenCount: 0,
+    pendingMessages: [],
+    retain: false,
+    diskLoaded: false,
+  } as const;
+}


### PR DESCRIPTION
## Summary
- add a shared resolver for shell-backed workbench surfaces that only accepts local shell tasks
- prevent stale selected shell task ids from making the shell or test surfaces render/act on agent tasks
- add focused regression coverage for non-shell selected ids, shell fallback, and empty shell state

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/shell-surface.test.tsx tests/tui/workbench/shell-tasks.test.ts tests/tui/workbench/test-surface.test.tsx --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Notes
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing unrelated Knip backlog; no new shell-surface finding was reported.
