### PR TITLE
fix(tui): separate test surface navigation

### DIFF
--- a/runtime/src/tui/workbench/surfaces/TestSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/TestSurface.tsx
@@ -54,13 +54,13 @@ export function TestSurface({ focused }: { readonly focused: boolean }): React.R
   }, [task?.id, task?.status]);
 
   useRegisterKeybindingContext("Surface", focused);
-  const jumpToSelectedFailure = () => {
+  const jumpToSelectedFailure = (focus = true) => {
     if (selectedFailure?.location) {
       dispatch({
         type: "openBuffer",
         path: selectedFailure.location.file,
         line: selectedFailure.location.line,
-        focus: true,
+        focus,
       });
     }
   };
@@ -68,8 +68,12 @@ export function TestSurface({ focused }: { readonly focused: boolean }): React.R
     {
       "surface:up": () => setSelected((value) => Math.max(0, value - 1)),
       "surface:down": () => setSelected((value) => Math.min(Math.max(0, failures.length - 1), value + 1)),
-      "surface:open": jumpToSelectedFailure,
-      "surface:top": jumpToSelectedFailure,
+      "surface:pageUp": () => setSelected((value) => Math.max(0, value - 10)),
+      "surface:pageDown": () => setSelected((value) => Math.min(Math.max(0, failures.length - 1), value + 10)),
+      "surface:top": () => setSelected(0),
+      "surface:bottom": () => setSelected(Math.max(0, failures.length - 1)),
+      "surface:open": () => jumpToSelectedFailure(true),
+      "surface:openKeepFocus": () => jumpToSelectedFailure(false),
       "surface:attach": () => {
         if (task?.id && selectedFailure?.location) {
           dispatch(attachTaskErrorCommand({
@@ -103,7 +107,7 @@ export function TestSurfaceView({
   const selectedFailure = failures[selectedIndex] ?? null;
   return (
     <Box flexDirection="column" width="100%" height="100%" overflow="hidden">
-      <SurfaceHeader title="TEST" detail={`${failures.length} failure${failures.length === 1 ? "" : "s"} - g/enter edit - @ attach`} focused={focused} />
+      <SurfaceHeader title="TEST" detail={`${failures.length} failure${failures.length === 1 ? "" : "s"} - enter edit - o keep focus - @ attach`} focused={focused} />
       {failures.length === 0 ? (
         <Text dimColor wrap="truncate-end">No parsed test failures in the selected task output.</Text>
       ) : null}

--- a/runtime/tests/tui/workbench/test-surface.test.tsx
+++ b/runtime/tests/tui/workbench/test-surface.test.tsx
@@ -1,10 +1,40 @@
 import React from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { TestSurfaceView } from "../../../src/tui/workbench/surfaces/TestSurface.js";
+const keybindingHarness = vi.hoisted(() => ({
+  handlers: {} as Record<string, () => void>,
+}));
+
+vi.mock("../../../src/utils/fsOperations.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../src/utils/fsOperations.js")>()),
+  tailFile: vi.fn(async () => ({
+    content: [
+      "FAIL first failure",
+      "src/first.ts:4:1",
+      "first message",
+      "FAIL second failure",
+      "src/second.ts:9:1",
+      "second message",
+    ].join("\n"),
+  })),
+}));
+
+vi.mock("../../../src/utils/task/diskOutput.js", () => ({
+  getTaskOutputPath: (taskId: string) => `/tmp/${taskId}.log`,
+}));
+
+vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
+  useKeybinding: () => {},
+  useKeybindings: (handlers: Record<string, () => void>) => {
+    keybindingHarness.handlers = handlers;
+  },
+}));
+
+import { AppStateProvider, getDefaultAppState, type AppState } from "../../../src/tui/state/AppState.js";
+import { TestSurface, TestSurfaceView } from "../../../src/tui/workbench/surfaces/TestSurface.js";
 import { renderToString } from "../../../src/utils/staticRender.js";
 
-describe("TestSurfaceView", () => {
+describe("TestSurface", () => {
   it("clamps stale selection to the last parsed failure", async () => {
     const output = await renderToString(
       <TestSurfaceView
@@ -30,5 +60,53 @@ describe("TestSurfaceView", () => {
 
     expect(output).toContain("second failure");
     expect(output).toContain("second message");
+  });
+
+  it("keeps top navigation separate from opening the selected failure", async () => {
+    const changes: AppState[] = [];
+    const output = await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...getDefaultAppState(),
+          tasks: {
+            "shell-1": {
+              id: "shell-1",
+              type: "local_bash",
+              status: "completed",
+              description: "npm test",
+              command: "npm test",
+              startTime: 1_000,
+              outputFile: "urn:agenc:task:shell-1:output",
+              outputOffset: 0,
+              notified: false,
+            } as any,
+          },
+          workbench: {
+            ...getDefaultAppState().workbench,
+            activeSurfaceMode: "test",
+            selectedShellTaskId: "shell-1",
+          },
+        }}
+        onChangeAppState={({ newState }) => changes.push(newState)}
+      >
+        <TestSurface focused={true} />
+      </AppStateProvider>,
+      100,
+    );
+
+    expect(output).toContain("first failure");
+
+    keybindingHarness.handlers["surface:top"]?.();
+
+    expect(changes).toHaveLength(0);
+
+    keybindingHarness.handlers["surface:open"]?.();
+
+    expect(changes.at(-1)?.workbench).toMatchObject({
+      activeSurfaceMode: "buffer",
+      activeFilePath: "src/first.ts",
+      activeFileLine: 4,
+      focusedPane: "surface",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- make `surface:top` and `surface:bottom` navigate test failures instead of opening the selected failure
- add page navigation and keep-focus open handling for the test surface
- update the test surface hint text and add mounted regression coverage for the `surface:top` handler

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/test-surface.test.tsx tests/tui/workbench/shell-tasks.test.ts tests/tui/workbench/shell-surface.test.tsx --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Notes
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing unrelated Knip backlog; no new test-surface finding was reported.
