### PR TITLE
fix(tui): honor selected search matches

### DIFF
--- a/runtime/src/tui/workbench/reducer.ts
+++ b/runtime/src/tui/workbench/reducer.ts
@@ -54,10 +54,14 @@ export function workbenchReducer(
         activeFileLine: command.line ?? null,
       };
     case "openSearch":
+      const nextSearchQuery = command.query ?? state.searchQuery;
+      const searchQueryChanged =
+        command.query !== undefined && command.query !== state.searchQuery;
       return {
         ...openSurface(state, "search"),
-        searchQuery: command.query ?? state.searchQuery,
-        selectedSearchMatchId: command.selectedMatchId ?? state.selectedSearchMatchId,
+        searchQuery: nextSearchQuery,
+        selectedSearchMatchId:
+          command.selectedMatchId ?? (searchQueryChanged ? null : state.selectedSearchMatchId),
       };
     case "openDiff":
       return {

--- a/runtime/src/tui/workbench/surfaces/SearchSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/SearchSurface.tsx
@@ -22,9 +22,11 @@ export function SearchSurface({ focused }: { readonly focused: boolean }): React
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const query = workbench.searchQuery;
+  const selectedMatchId = workbench.selectedSearchMatchId;
 
   useEffect(() => {
     abortRef.current?.abort();
+    setSelected(0);
     if (!query.trim()) {
       setMatches([]);
       setLoading(false);
@@ -66,6 +68,12 @@ export function SearchSurface({ focused }: { readonly focused: boolean }): React
       controller.abort();
     };
   }, [query]);
+
+  useEffect(() => {
+    if (!selectedMatchId) return;
+    const index = matches.findIndex((match) => match.id === selectedMatchId);
+    if (index >= 0) setSelected(index);
+  }, [matches, selectedMatchId]);
 
   const selectedIndex = clampSurfaceSelection(selected, matches.length);
   const selectedMatch = matches[selectedIndex] ?? null;

--- a/runtime/tests/tui/workbench/reducer.test.ts
+++ b/runtime/tests/tui/workbench/reducer.test.ts
@@ -162,6 +162,30 @@ describe("workbenchReducer", () => {
     expect(transcript.activeSurfaceMode).toBe("transcript");
   });
 
+  it("clears stale selected search match ids when opening a new query", () => {
+    const first = workbenchReducer(undefined, {
+      type: "openSearch",
+      query: "needle",
+      selectedMatchId: "src/app.ts:4:needle",
+    });
+    const second = workbenchReducer(first, {
+      type: "openSearch",
+      query: "other",
+    });
+    const reopened = workbenchReducer(second, {
+      type: "openSearch",
+    });
+
+    expect(second).toMatchObject({
+      searchQuery: "other",
+      selectedSearchMatchId: null,
+    });
+    expect(reopened).toMatchObject({
+      searchQuery: "other",
+      selectedSearchMatchId: null,
+    });
+  });
+
   it("tracks blocked approval overlays and attachment removal", () => {
     const withAttachment = workbenchReducer(undefined, {
       type: "attach",

--- a/runtime/tests/tui/workbench/search-surface.test.tsx
+++ b/runtime/tests/tui/workbench/search-surface.test.tsx
@@ -1,10 +1,76 @@
-import React from "react";
-import { describe, expect, it } from "vitest";
+import { PassThrough } from "node:stream";
 
-import { SearchSurfaceView } from "../../../src/tui/workbench/surfaces/SearchSurface.js";
+import React from "react";
+import stripAnsi from "strip-ansi";
+import { describe, expect, it, vi } from "vitest";
+
+const searchHarness = vi.hoisted(() => ({
+  handlers: {} as Record<string, () => void>,
+  lines: [] as string[],
+}));
+
+vi.mock("../../../src/utils/ripgrep.js", () => ({
+  ripGrepStream: vi.fn(async (
+    _args: string[],
+    _target: string,
+    _signal: AbortSignal,
+    onLines: (lines: string[]) => void,
+  ) => {
+    onLines(searchHarness.lines);
+  }),
+}));
+
+vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
+  useKeybinding: () => {},
+  useKeybindings: (handlers: Record<string, () => void>) => {
+    searchHarness.handlers = handlers;
+  },
+}));
+
+import { createRoot } from "../../../src/tui/ink.js";
+import { AppStateProvider, getDefaultAppState, type AppState } from "../../../src/tui/state/AppState.js";
+import { SearchSurface, SearchSurfaceView } from "../../../src/tui/workbench/surfaces/SearchSurface.js";
 import { renderToString } from "../../../src/utils/staticRender.js";
 
-describe("SearchSurfaceView", () => {
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+function createStreams(): {
+  readonly stdin: TestStdin;
+  readonly stdout: PassThrough;
+  readonly output: () => string;
+} {
+  let output = "";
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).columns = 120;
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).rows = 24;
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).isTTY = true;
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  return {
+    stdin,
+    stdout,
+    output: () => stripAnsi(output),
+  };
+}
+
+function sleep(ms = 200): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe("SearchSurface", () => {
   it("renders loading, no result, error, and truncated states", async () => {
     const loading = await renderToString(
       <SearchSurfaceView query="needle" matches={[]} selected={0} loading={true} error={null} focused={true} />,
@@ -84,4 +150,56 @@ describe("SearchSurfaceView", () => {
     expect(output).toContain("src/other.ts:9");
     expect(output).toContain("@ attach");
   });
+
+  it("selects the requested search match id after ripgrep results load", async () => {
+    searchHarness.lines = [
+      "src/first.ts:4:const needle = true",
+      "src/second.ts:9:needle()",
+    ];
+    const changes: AppState[] = [];
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "search",
+              searchQuery: "needle",
+              selectedSearchMatchId: "src/second.ts:9:needle()",
+            },
+          }}
+          onChangeAppState={({ newState }) => changes.push(newState)}
+        >
+          <SearchSurface focused={false} />
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      expect(compact(output())).toContain("src/second.ts");
+      searchHarness.handlers["surface:open"]?.();
+
+      expect(changes.at(-1)?.workbench).toMatchObject({
+        activeSurfaceMode: "buffer",
+        activeFilePath: "src/second.ts",
+        activeFileLine: 9,
+        focusedPane: "surface",
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
 });
+
+function compact(value: string): string {
+  return value.replace(/\s+/gu, "");
+}


### PR DESCRIPTION
## Summary
- sync mounted search-surface selection to `selectedSearchMatchId` after ripgrep results load
- reset local search selection on query changes and clear stale selected match ids for new reducer queries
- add mounted regression coverage proving `surface:open` uses the requested search result

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/search-surface.test.tsx tests/tui/workbench/search-model.test.ts tests/tui/workbench/reducer.test.ts --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Notes
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing unrelated Knip backlog; no new search-surface finding was reported.
