### PR TITLE
fix(tui): block destructive diff approvals

### DIFF
--- a/runtime/src/tui/workbench/surfaces/DiffSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/DiffSurface.tsx
@@ -62,8 +62,10 @@ export function DiffSurface({
         if (selectedFile) dispatch(attachDiffHunkCommand({ path: selectedFile.path, label: `${selectedFile.path} diff` }));
       },
       "surface:accept": () => {
-        if (pendingApproval && approvalRisk !== "destructive") {
-          pendingApproval.resolve(APPROVED);
+        if (pendingApproval) {
+          if (approvalRisk !== "destructive") {
+            pendingApproval.resolve(APPROVED);
+          }
           return;
         }
         if (selectedFile) setDecisions((prev) => ({ ...prev, [selectedFile.path]: "accept" }));

--- a/runtime/tests/tui/workbench/diff-surface.test.tsx
+++ b/runtime/tests/tui/workbench/diff-surface.test.tsx
@@ -1,11 +1,45 @@
+import { PassThrough } from "node:stream";
+
 import React from "react";
-import { describe, expect, it } from "vitest";
+import stripAnsi from "strip-ansi";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const diffHarness = vi.hoisted(() => ({
+  handlers: {} as Record<string, () => void>,
+  snapshot: null as ReturnType<typeof import("../../../src/commands/diff-menu.js").createDiffMenuSnapshot> | null,
+}));
+
+vi.mock("../../../src/commands/diff.js", () => ({
+  collectDiffSnapshot: vi.fn(async () => diffHarness.snapshot),
+}));
+
+vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
+  useKeybinding: () => {},
+  useKeybindings: (handlers: Record<string, () => void>) => {
+    diffHarness.handlers = handlers;
+  },
+}));
 
 import { createDiffMenuSnapshot } from "../../../src/commands/diff-menu.js";
-import { DiffSurfaceView } from "../../../src/tui/workbench/surfaces/DiffSurface.js";
+import { createRoot } from "../../../src/tui/ink.js";
+import { AppStateProvider, getDefaultAppState } from "../../../src/tui/state/AppState.js";
+import { DiffSurface, DiffSurfaceView } from "../../../src/tui/workbench/surfaces/DiffSurface.js";
 import { renderToString } from "../../../src/utils/staticRender.js";
 
-describe("DiffSurfaceView", () => {
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+describe("DiffSurface", () => {
+  afterEach(() => {
+    diffHarness.handlers = {};
+    diffHarness.snapshot = null;
+    vi.clearAllMocks();
+  });
+
   it.each([
     [89, 28],
     [60, 20],
@@ -71,4 +105,110 @@ describe("DiffSurfaceView", () => {
 
     expect(output).toContain("src/new.ts - non-mutating review");
   });
+
+  it("keeps destructive pending approvals out of the diff accept shortcut", async () => {
+    diffHarness.snapshot = createDiffMenuSnapshot({
+      rawDiff: [
+        "diff --git a/src/app.ts b/src/app.ts",
+        "@@ -1 +1 @@",
+        "-old",
+        "+new",
+      ].join("\n"),
+      nameStatus: "M\tsrc/app.ts",
+      numstat: "1\t1\tsrc/app.ts",
+      untrackedFiles: [],
+    });
+    const request = pendingRequest({
+      id: "approval-destructive",
+      description: "Run shell command",
+      input: { command: "rm -rf /tmp/agenc-danger" },
+      toolName: "Bash",
+    });
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider initialState={getDefaultAppState()}>
+          <DiffSurface focused={true} pendingApproval={request} />
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      expect(compact(output())).toContain("typedconfirmationstays");
+
+      diffHarness.handlers["surface:accept"]?.();
+      await sleep();
+
+      expect(request.resolve).not.toHaveBeenCalled();
+      expect(compact(output())).not.toContain("markedaccept");
+      expect(compact(output())).not.toContain("YMsrc/app.ts");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
 });
+
+function createStreams(): {
+  readonly stdin: TestStdin;
+  readonly stdout: PassThrough;
+  readonly output: () => string;
+} {
+  let output = "";
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).columns = 120;
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).rows = 24;
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).isTTY = true;
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  return {
+    stdin,
+    stdout,
+    output: () => stripAnsi(output),
+  };
+}
+
+function sleep(ms = 200): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function compact(value: string): string {
+  return value.replace(/\s+/gu, "");
+}
+
+function pendingRequest({
+  id,
+  description,
+  input,
+  toolName,
+}: {
+  readonly id: string;
+  readonly description: string;
+  readonly input: Record<string, unknown>;
+  readonly toolName: string;
+}) {
+  return {
+    id,
+    description,
+    input,
+    ctx: {
+      toolName,
+      invocation: { payload: {} },
+    },
+    resolve: vi.fn(),
+  } as any;
+}


### PR DESCRIPTION
## Summary
- keep destructive pending approvals in the typed-confirmation flow when the diff surface accept shortcut is pressed
- add a mounted DiffSurface regression test that proves the destructive accept shortcut does not resolve or locally mark a file accepted

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/diff-surface.test.tsx tests/tui/workbench/risk.test.ts tests/tui/workbench/approval-surface-bridge.test.tsx --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails on existing unrelated Knip backlog: src/tui/workbench/keymap.ts plus stale bin/transaction-guard exports and tag hints)