### PR TITLE
fix(tui): show diff snapshot failures

### DIFF
--- a/runtime/src/tui/workbench/surfaces/DiffSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/DiffSurface.tsx
@@ -23,6 +23,7 @@ export function DiffSurface({
   readonly pendingApproval?: PendingRequest | null;
 }): React.ReactElement {
   const dispatch = useWorkbenchDispatch();
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [snapshot, setSnapshot] = useState<DiffMenuSnapshot | null>(null);
   const [selected, setSelected] = useState(0);
   const [decisions, setDecisions] = useState<Record<string, "accept" | "skip">>({});
@@ -38,9 +39,14 @@ export function DiffSurface({
 
   useEffect(() => {
     let mounted = true;
-    collectDiffSnapshot(getCwd()).then((next) => {
-      if (mounted) setSnapshot(next);
-    });
+    collectDiffSnapshot(getCwd()).then(
+      (next) => {
+        if (mounted) setSnapshot(next);
+      },
+      (error) => {
+        if (mounted) setLoadError(errorMessage(error));
+      },
+    );
     return () => {
       mounted = false;
     };
@@ -82,6 +88,7 @@ export function DiffSurface({
     { context: "Surface", isActive: focused },
   );
 
+  if (loadError !== null) return <EmptySurface title="DIFF" message={`Unable to load diff: ${loadError}`} />;
   if (snapshot === null) return <EmptySurface title="DIFF" message="Loading diff" />;
   if (snapshot.state === "not-repo") return <EmptySurface title="DIFF" message="Not a git repository" />;
   if (snapshot.state === "clean") return <EmptySurface title="DIFF" message="No working tree changes" />;
@@ -162,6 +169,12 @@ function commandText(input: Record<string, unknown>): string {
   } catch {
     return "";
   }
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) return error.message;
+  if (typeof error === "string" && error.trim().length > 0) return error;
+  return "unknown error";
 }
 
 function statusMarker(status: string): string {

--- a/runtime/tests/tui/workbench/diff-surface.test.tsx
+++ b/runtime/tests/tui/workbench/diff-surface.test.tsx
@@ -5,12 +5,16 @@ import stripAnsi from "strip-ansi";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const diffHarness = vi.hoisted(() => ({
+  error: null as unknown,
   handlers: {} as Record<string, () => void>,
   snapshot: null as ReturnType<typeof import("../../../src/commands/diff-menu.js").createDiffMenuSnapshot> | null,
 }));
 
 vi.mock("../../../src/commands/diff.js", () => ({
-  collectDiffSnapshot: vi.fn(async () => diffHarness.snapshot),
+  collectDiffSnapshot: vi.fn(async () => {
+    if (diffHarness.error !== null) throw diffHarness.error;
+    return diffHarness.snapshot;
+  }),
 }));
 
 vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
@@ -35,6 +39,7 @@ type TestStdin = PassThrough & {
 
 describe("DiffSurface", () => {
   afterEach(() => {
+    diffHarness.error = null;
     diffHarness.handlers = {};
     diffHarness.snapshot = null;
     vi.clearAllMocks();
@@ -147,6 +152,31 @@ describe("DiffSurface", () => {
       expect(request.resolve).not.toHaveBeenCalled();
       expect(compact(output())).not.toContain("markedaccept");
       expect(compact(output())).not.toContain("YMsrc/app.ts");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  it("renders diff snapshot load failures instead of staying on the loading state", async () => {
+    diffHarness.error = new Error("git status failed");
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider initialState={getDefaultAppState()}>
+          <DiffSurface focused={true} />
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      expect(compact(output())).toContain("toloaddiff:gitstatusfailed");
     } finally {
       root.unmount();
       stdin.end();


### PR DESCRIPTION
## Summary
- render a diff-surface error state when collecting the git diff snapshot fails
- add a mounted regression test for rejected diff snapshot loads so the surface does not remain on the loading state or leak an unhandled rejection

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/diff-surface.test.tsx tests/commands/diff.test.ts --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails on existing unrelated Knip backlog: src/tui/workbench/keymap.ts plus stale bin/transaction-guard exports and tag hints)