### PR TITLE
fix(tui): align diff approval risk input

### DIFF
--- a/runtime/src/tui/workbench/approvals/ApprovalSurfaceBridge.tsx
+++ b/runtime/src/tui/workbench/approvals/ApprovalSurfaceBridge.tsx
@@ -6,6 +6,7 @@ import { useKeybinding } from "../../keybindings/useKeybinding.js";
 import type { PendingRequest } from "../../permission-requests.js";
 import { useWorkbenchDispatch } from "../state.js";
 import { classifyApprovalRisk } from "../../../permissions/risk.js";
+import { approvalInputText } from "./inputText.js";
 
 export function ApprovalSurfaceBridge({
   request,
@@ -39,18 +40,4 @@ export function ApprovalSurfaceBridge({
       </Text>
     </Box>
   );
-}
-
-function approvalInputText(input: Record<string, unknown>): string {
-  for (const key of ["command", "cmd", "input", "query", "path", "file_path"]) {
-    const value = input[key];
-    if (typeof value === "string" && value.trim().length > 0) {
-      return value;
-    }
-  }
-  try {
-    return JSON.stringify(input);
-  } catch {
-    return "";
-  }
 }

--- a/runtime/src/tui/workbench/approvals/inputText.ts
+++ b/runtime/src/tui/workbench/approvals/inputText.ts
@@ -1,0 +1,13 @@
+export function approvalInputText(input: Record<string, unknown>): string {
+  for (const key of ["command", "cmd", "input", "query", "path", "file_path"]) {
+    const value = input[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+  try {
+    return JSON.stringify(input);
+  } catch {
+    return "";
+  }
+}

--- a/runtime/src/tui/workbench/surfaces/DiffSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/DiffSurface.tsx
@@ -11,6 +11,7 @@ import { useKeybindings } from "../../keybindings/useKeybinding.js";
 import { useRegisterKeybindingContext } from "../../keybindings/KeybindingContext.js";
 import type { PendingRequest } from "../../permission-requests.js";
 import { attachDiffHunkCommand, openBufferCommand } from "../commands.js";
+import { approvalInputText } from "../approvals/inputText.js";
 import { useWorkbenchDispatch } from "../state.js";
 import { EmptySurface, SurfaceHeader } from "./PreviewSurface.js";
 import { clampSurfaceSelection } from "./selection.js";
@@ -33,7 +34,7 @@ export function DiffSurface({
     ? classifyApprovalRisk({
         request: pendingApproval,
         description: pendingApproval.description,
-        command: commandText(pendingApproval.input),
+        command: approvalInputText(pendingApproval.input),
       })
     : null;
 
@@ -159,16 +160,6 @@ export function DiffSurfaceView({
       </Box>
     </Box>
   );
-}
-
-function commandText(input: Record<string, unknown>): string {
-  const command = input.command;
-  if (typeof command === "string") return command;
-  try {
-    return JSON.stringify(input);
-  } catch {
-    return "";
-  }
 }
 
 function errorMessage(error: unknown): string {

--- a/runtime/tests/tui/workbench/diff-surface.test.tsx
+++ b/runtime/tests/tui/workbench/diff-surface.test.tsx
@@ -159,6 +159,55 @@ describe("DiffSurface", () => {
     }
   });
 
+  it("classifies destructive approvals from non-command input fields before falling back to JSON", async () => {
+    diffHarness.snapshot = createDiffMenuSnapshot({
+      rawDiff: [
+        "diff --git a/src/app.ts b/src/app.ts",
+        "@@ -1 +1 @@",
+        "-old",
+        "+new",
+      ].join("\n"),
+      nameStatus: "M\tsrc/app.ts",
+      numstat: "1\t1\tsrc/app.ts",
+      untrackedFiles: [],
+    });
+    const input: Record<string, unknown> = { cmd: "rm -rf /tmp/agenc-danger" };
+    input.self = input;
+    const request = pendingRequest({
+      id: "approval-destructive-cmd",
+      description: "Run shell command",
+      input,
+      toolName: "Bash",
+    });
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider initialState={getDefaultAppState()}>
+          <DiffSurface focused={true} pendingApproval={request} />
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      expect(compact(output())).toContain("typedconfirmationstays");
+
+      diffHarness.handlers["surface:accept"]?.();
+      await sleep();
+
+      expect(request.resolve).not.toHaveBeenCalled();
+      expect(compact(output())).not.toContain("markedaccept");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
   it("renders diff snapshot load failures instead of staying on the loading state", async () => {
     diffHarness.error = new Error("git status failed");
     const { stdin, stdout, output } = createStreams();


### PR DESCRIPTION
## Summary
- share approval input text extraction between the approval bridge and diff surface
- classify non-command approval fields such as cmd before JSON fallback in the diff surface
- add a mounted regression for a non-JSON-safe destructive cmd approval so the diff accept shortcut cannot approve it

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/diff-surface.test.tsx tests/tui/workbench/approval-surface-bridge.test.tsx tests/tui/workbench/risk.test.ts --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails on existing unrelated Knip backlog: src/tui/workbench/keymap.ts plus stale bin/transaction-guard exports and tag hints)