### PR TITLE
fix(tui): align task stop actions with state

### DIFF
--- a/runtime/src/tui/components/tasks/BackgroundTasksPanel.tsx
+++ b/runtime/src/tui/components/tasks/BackgroundTasksPanel.tsx
@@ -1,11 +1,7 @@
 import * as React from "react";
 
-import { killAsyncAgent } from "../../../tasks/LocalAgentTask/LocalAgentTask.js";
-import { killTask } from "../../../tasks/LocalShellTask/killShellTasks.js";
-import { requestTeammateShutdown } from "../../../tasks/InProcessTeammateTask/InProcessTeammateTask.js";
 import {
   isBackgroundTask,
-  isStoppableTaskStatus,
   isTaskType,
   type TaskState,
 } from "../../../tasks/types.js";
@@ -17,6 +13,7 @@ import { agentRolePresentation } from "../../../agents/role-presentation.js";
 import { Box, useInput } from "../../ink.js";
 import { useTerminalSize } from "../../hooks/useTerminalSize.js";
 import { useAppState, useSetAppState, type AppState } from "../../state/AppState.js";
+import { stopTuiTask, tuiStopActionForTask } from "../../task-stop-actions.js";
 import ThemedBox from "../design-system/ThemedBox.js";
 import ThemedText from "../design-system/ThemedText.js";
 import { KeyHint, MenuModal } from "../v2/primitives.js";
@@ -367,19 +364,9 @@ function buildTaskDetailRows(
 }
 
 function taskActionLabel(task: TaskState): string {
-  if (!isStoppableTaskStatus(task.status)) {
-    return "View output";
-  }
-  switch (task.type) {
-    case "local_bash":
-    case "local_agent":
-    case "in_process_teammate":
-      return "Stop";
-    case "remote_agent":
-      return "Stop unavailable";
-    default:
-      return "View output";
-  }
+  const stopAction = tuiStopActionForTask(task);
+  if (stopAction === "remote-unavailable") return "Stop unavailable";
+  return stopAction ? "Stop" : "View output";
 }
 
 function isBackgroundDialogTask(task: unknown): task is TaskState {
@@ -405,25 +392,6 @@ function isBackgroundDialogTask(task: unknown): task is TaskState {
     candidate.status === "failed" ||
     candidate.status === "killed"
   );
-}
-
-function stopTask(task: TaskState, setAppState: ReturnType<typeof useSetAppState>): void {
-  if (!isStoppableTaskStatus(task.status)) {
-    return;
-  }
-  switch (task.type) {
-    case "local_bash":
-      killTask(task.id, setAppState);
-      break;
-    case "local_agent":
-      killAsyncAgent(task.id, setAppState);
-      break;
-    case "in_process_teammate":
-      requestTeammateShutdown(task.id, setAppState);
-      break;
-    case "remote_agent":
-      break;
-  }
 }
 
 function setAppStateFromContext(toolUseContext: unknown): ReturnType<typeof useSetAppState> | null {
@@ -502,6 +470,9 @@ export function BackgroundTasksPanel({
     [nameByAgentId, selectedShellOutputTail, selectedTask],
   );
   const selectedTaskDetail = selectedTask ? taskDetail(selectedTask) : null;
+  const selectedTaskStopAction = tuiStopActionForTask(selectedTask);
+  const selectedTaskCanStop =
+    selectedTaskStopAction !== null && selectedTaskStopAction !== "remote-unavailable";
   React.useEffect(() => {
     setDetailIndex(0);
   }, [selectedTaskId]);
@@ -565,7 +536,7 @@ export function BackgroundTasksPanel({
   );
   const stopSelectedTask = React.useCallback(() => {
     if (selectedTask) {
-      stopTask(selectedTask, setAppState);
+      stopTuiTask(selectedTask, setAppState);
     }
   }, [selectedTask, setAppState]);
   const selectDetailRelative = React.useCallback(
@@ -659,14 +630,14 @@ export function BackgroundTasksPanel({
         title="task detail"
         count={taskDetailStatusLabel(selectedTask)}
         summary={truncateToWidth(taskTitle(selectedTask), Math.max(1, columns - 38))}
-        headerRight="↑↓ scroll · ← back · x stop"
+        headerRight={selectedTaskCanStop ? "↑↓ scroll · ← back · x stop" : "↑↓ scroll · ← back"}
         columns={[8, 12, detailValueWidth]}
         headers={["section", "field", "value"]}
         items={detailRows}
         activeIndex={detailIndex}
         footer={[
           { keyName: "←", label: "back" },
-          { keyName: "x", label: "stop" },
+          ...(selectedTaskCanStop ? [{ keyName: "x", label: "stop" }] : []),
         ]}
         hint={truncateToWidth(`${taskKindLabel(selectedTask)} · ${selectedTask.id}`, taskTextWidth)}
         renderRow={(row, _index, active) => [
@@ -689,14 +660,14 @@ export function BackgroundTasksPanel({
       title="background tasks"
       count={summary}
       summary="unified background panel"
-      headerRight="↑↓ select · ⏎ open · x stop"
+      headerRight={selectedTaskCanStop ? "↑↓ select · ⏎ open · x stop" : "↑↓ select · ⏎ open"}
       columns={[2, 8, 18, 28, 18, 12, 8, 8]}
       headers={["", "kind", "id · status", "label", "target", "progress", "elapsed", "cost"]}
       items={sorted}
       activeIndex={selectedIndex}
       footer={[
         { keyName: "⏎", label: "open" },
-        { keyName: "x", label: "stop" },
+        ...(selectedTaskCanStop ? [{ keyName: "x", label: "stop" }] : []),
         { keyName: "l", label: "detail" },
       ]}
       hint={truncateToWidth(

--- a/runtime/src/tui/task-stop-actions.ts
+++ b/runtime/src/tui/task-stop-actions.ts
@@ -1,0 +1,55 @@
+import { requestTeammateShutdown } from "../tasks/InProcessTeammateTask/InProcessTeammateTask.js";
+import { killAsyncAgent } from "../tasks/LocalAgentTask/LocalAgentTask.js";
+import { killTask } from "../tasks/LocalShellTask/killShellTasks.js";
+import type { TaskState } from "../tasks/types.js";
+import type { AppState } from "./state/AppStateStore.js";
+
+type SetAppState = (updater: (prev: AppState) => AppState) => void;
+
+type StopActionTask =
+  Pick<TaskState, "type" | "status"> & {
+    readonly shutdownRequested?: boolean;
+  };
+
+export type TuiTaskStopAction =
+  | "local-shell"
+  | "local-agent"
+  | "teammate"
+  | "remote-unavailable";
+
+export function tuiStopActionForTask(task: StopActionTask | null | undefined): TuiTaskStopAction | null {
+  if (!task) return null;
+  switch (task.type) {
+    case "local_bash":
+      return task.status === "running" ? "local-shell" : null;
+    case "local_agent":
+      return task.status === "pending" || task.status === "running" ? "local-agent" : null;
+    case "in_process_teammate":
+      return task.status === "running" && task.shutdownRequested !== true ? "teammate" : null;
+    case "remote_agent":
+      return task.status === "pending" || task.status === "running" ? "remote-unavailable" : null;
+    default:
+      return null;
+  }
+}
+
+export function stopTuiTask(
+  task: TaskState,
+  setAppState: SetAppState,
+): TuiTaskStopAction | null {
+  const action = tuiStopActionForTask(task);
+  switch (action) {
+    case "local-shell":
+      killTask(task.id, setAppState);
+      return action;
+    case "local-agent":
+      killAsyncAgent(task.id, setAppState);
+      return action;
+    case "teammate":
+      requestTeammateShutdown(task.id, setAppState);
+      return action;
+    case "remote-unavailable":
+    case null:
+      return action;
+  }
+}

--- a/runtime/src/tui/workbench/tasks/stopActions.ts
+++ b/runtime/src/tui/workbench/tasks/stopActions.ts
@@ -1,50 +1,5 @@
-import { requestTeammateShutdown } from "../../../tasks/InProcessTeammateTask/InProcessTeammateTask.js";
-import { killAsyncAgent } from "../../../tasks/LocalAgentTask/LocalAgentTask.js";
-import { killTask } from "../../../tasks/LocalShellTask/killShellTasks.js";
-import { isStoppableTaskStatus, type TaskState } from "../../../tasks/types.js";
-import type { AppState } from "../../state/AppStateStore.js";
-
-type SetAppState = (updater: (prev: AppState) => AppState) => void;
-
-export type WorkbenchTaskStopAction =
-  | "local-shell"
-  | "local-agent"
-  | "teammate"
-  | "remote-unavailable";
-
-export function workbenchStopActionForTask(task: Pick<TaskState, "type" | "status"> | null | undefined): WorkbenchTaskStopAction | null {
-  if (!task || !isStoppableTaskStatus(task.status)) return null;
-  switch (task.type) {
-    case "local_bash":
-      return "local-shell";
-    case "local_agent":
-      return "local-agent";
-    case "in_process_teammate":
-      return "teammate";
-    case "remote_agent":
-      return "remote-unavailable";
-    default:
-      return null;
-  }
-}
-
-export function stopWorkbenchTask(
-  task: TaskState,
-  setAppState: SetAppState,
-): WorkbenchTaskStopAction | null {
-  const action = workbenchStopActionForTask(task);
-  switch (action) {
-    case "local-shell":
-      killTask(task.id, setAppState);
-      return action;
-    case "local-agent":
-      killAsyncAgent(task.id, setAppState);
-      return action;
-    case "teammate":
-      requestTeammateShutdown(task.id, setAppState);
-      return action;
-    case "remote-unavailable":
-    case null:
-      return action;
-  }
-}
+export {
+  stopTuiTask as stopWorkbenchTask,
+  tuiStopActionForTask as workbenchStopActionForTask,
+  type TuiTaskStopAction as WorkbenchTaskStopAction,
+} from "../../task-stop-actions.js";

--- a/runtime/tests/tui/components/tasks/BackgroundTasksPanel.coverage.test.tsx
+++ b/runtime/tests/tui/components/tasks/BackgroundTasksPanel.coverage.test.tsx
@@ -104,7 +104,7 @@ function makeTeammateTask(overrides: Record<string, unknown> = {}) {
       ],
     },
     isIdle: false,
-    shutdownRequested: true,
+    shutdownRequested: false,
     lastReportedToolCount: 3,
     lastReportedTokenCount: 1200,
     ...overrides,
@@ -122,7 +122,7 @@ describe('BackgroundTasksPanel coverage', () => {
     requestTeammateShutdownMock.mockClear()
   })
 
-  it('renders teammate detail rows and stops the selected teammate task', async () => {
+  it('renders teammate detail rows and stops the selected running teammate task', async () => {
     appStateMock.state = {
       tasks: {
         'teammate-1': makeTeammateTask(),
@@ -141,9 +141,9 @@ describe('BackgroundTasksPanel coverage', () => {
     expect(output).toContain('Reviewer · Agent')
     expect(output).toContain('agent-reviewer')
     expect(output).toContain('awaiting plan approval')
-    expect(output).toContain('shutdown requested')
     expect(output).toContain('reading related tests')
     expect(output).toContain('Please check edge cases')
+    expect(output).toContain('x stop')
 
     if (!inputHandler.current) {
       throw new Error('BackgroundTasksPanel did not register input handling')
@@ -154,6 +154,33 @@ describe('BackgroundTasksPanel coverage', () => {
       'teammate-1',
       appStateMock.setAppState,
     )
+    expect(killTaskMock).not.toHaveBeenCalled()
+    expect(killAsyncAgentMock).not.toHaveBeenCalled()
+  })
+
+  it('renders shutdown-requested teammates without another stop affordance', async () => {
+    appStateMock.state = {
+      tasks: {
+        'teammate-1': makeTeammateTask({ shutdownRequested: true }),
+      },
+    }
+
+    const { BackgroundTasksPanel } = await import('./BackgroundTasksPanel.js')
+
+    const output = await renderToString(
+      <BackgroundTasksPanel initialDetailTaskId="teammate-1" />,
+      120,
+    )
+
+    expect(output).toContain('shutdown requested')
+    expect(output).not.toContain('x stop')
+
+    if (!inputHandler.current) {
+      throw new Error('BackgroundTasksPanel did not register input handling')
+    }
+    inputHandler.current('x', key())
+
+    expect(requestTeammateShutdownMock).not.toHaveBeenCalled()
     expect(killTaskMock).not.toHaveBeenCalled()
     expect(killAsyncAgentMock).not.toHaveBeenCalled()
   })

--- a/runtime/tests/tui/components/tasks/BackgroundTasksPanel.test.tsx
+++ b/runtime/tests/tui/components/tasks/BackgroundTasksPanel.test.tsx
@@ -108,6 +108,35 @@ function makeRemoteTask(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function makeTeammateTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 't1',
+    type: 'in_process_teammate',
+    status: 'running',
+    description: 'Teammate work',
+    startTime: Date.now(),
+    outputFile: 'urn:agenc:task:t1:output',
+    outputOffset: 0,
+    notified: false,
+    identity: {
+      agentId: 'teammate-1',
+      agentName: 'Planner',
+      teamName: 'Core',
+      planModeRequired: false,
+      parentSessionId: 'session-1',
+    },
+    prompt: 'Inspect the TUI',
+    awaitingPlanApproval: false,
+    permissionMode: 'default',
+    pendingUserMessages: [],
+    isIdle: false,
+    shutdownRequested: false,
+    lastReportedToolCount: 0,
+    lastReportedTokenCount: 0,
+    ...overrides,
+  }
+}
+
 describe('BackgroundTasksPanel', () => {
   beforeEach(() => {
     appStateMock.state = { tasks: {} }
@@ -269,5 +298,52 @@ describe('BackgroundTasksPanel', () => {
     inputHandler.current('x', key())
 
     expect(killTaskMock).toHaveBeenCalledWith('b1', contextSetAppState)
+  })
+
+  it('does not invoke stop helpers for states those helpers cannot change', async () => {
+    appStateMock.state = {
+      tasks: {
+        b1: makeShellTask({ status: 'pending' }),
+      },
+    }
+
+    const { BackgroundTasksPanel } = await import('./BackgroundTasksPanel.js')
+
+    const pendingShellOutput = await renderToString(
+      <BackgroundTasksPanel initialDetailTaskId="b1" />,
+      100,
+    )
+    expect(pendingShellOutput).not.toContain('x stop')
+
+    if (!inputHandler.current) {
+      throw new Error('BackgroundTasksPanel did not register input handling')
+    }
+    inputHandler.current('x', key())
+
+    expect(killTaskMock).not.toHaveBeenCalled()
+    expect(killAsyncAgentMock).not.toHaveBeenCalled()
+    expect(requestTeammateShutdownMock).not.toHaveBeenCalled()
+
+    appStateMock.state = {
+      tasks: {
+        t1: makeTeammateTask({ shutdownRequested: true }),
+      },
+    }
+    inputHandler.current = undefined
+
+    const shutdownTeammateOutput = await renderToString(
+      <BackgroundTasksPanel initialDetailTaskId="t1" />,
+      100,
+    )
+    expect(shutdownTeammateOutput).not.toContain('x stop')
+
+    if (!inputHandler.current) {
+      throw new Error('BackgroundTasksPanel did not register input handling')
+    }
+    inputHandler.current('x', key())
+
+    expect(killTaskMock).not.toHaveBeenCalled()
+    expect(killAsyncAgentMock).not.toHaveBeenCalled()
+    expect(requestTeammateShutdownMock).not.toHaveBeenCalled()
   })
 })

--- a/runtime/tests/tui/workbench/stop-actions.test.ts
+++ b/runtime/tests/tui/workbench/stop-actions.test.ts
@@ -9,6 +9,22 @@ describe("workbench task stop actions", () => {
     expect(workbenchStopActionForTask({ type: "in_process_teammate", status: "running" })).toBe("teammate");
   });
 
+  it("matches type-specific stop helper state support", () => {
+    expect(workbenchStopActionForTask({ type: "local_bash", status: "pending" })).toBeNull();
+    expect(workbenchStopActionForTask({ type: "local_agent", status: "pending" })).toBe("local-agent");
+    expect(workbenchStopActionForTask({ type: "in_process_teammate", status: "pending" })).toBeNull();
+    expect(workbenchStopActionForTask({
+      type: "in_process_teammate",
+      status: "running",
+      shutdownRequested: true,
+    })).toBeNull();
+    expect(workbenchStopActionForTask({
+      type: "in_process_teammate",
+      status: "running",
+      shutdownRequested: false,
+    })).toBe("teammate");
+  });
+
   it("does not expose fake stop behavior for terminal or remote tasks", () => {
     expect(workbenchStopActionForTask({ type: "local_agent", status: "completed" })).toBeNull();
     expect(workbenchStopActionForTask({ type: "remote_agent", status: "running" })).toBe("remote-unavailable");


### PR DESCRIPTION
## Summary
- add a shared TUI stop-action helper that mirrors the concrete task stop helpers
- hide background-task stop affordances for pending shell tasks and already shutdown-requested teammates
- keep pending local agents stoppable while remote tasks remain explicitly unavailable

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/stop-actions.test.ts tests/tui/components/tasks/BackgroundTasksPanel.test.tsx tests/tui/components/tasks/BackgroundTasksPanel.coverage.test.tsx --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails on existing unrelated Knip backlog: src/tui/workbench/keymap.ts, 30 unused exports, 4 tag hints)