### PR TITLE
fix(tui): restore buffer editor handoff on failure

### DIFF
--- a/runtime/src/tui/workbench/buffer/externalEditor.ts
+++ b/runtime/src/tui/workbench/buffer/externalEditor.ts
@@ -64,21 +64,28 @@ export function openFileInBufferExternalEditor(filePath: string, line?: number):
     : [...editorArgs, ...terminalGotoArgv(base, filePath, line)];
   const syncOpts: SpawnSyncOptions = { stdio: "inherit" };
 
-  if (guiFamily) {
-    inkInstance.pause();
-    inkInstance.suspendStdin();
-  } else {
-    inkInstance.enterAlternateScreen();
-  }
-
+  let paused = false;
+  let suspendedStdin = false;
+  let enteredAlternateScreen = false;
   try {
+    if (guiFamily) {
+      inkInstance.pause();
+      paused = true;
+      inkInstance.suspendStdin();
+      suspendedStdin = true;
+    } else {
+      inkInstance.enterAlternateScreen();
+      enteredAlternateScreen = true;
+    }
     const result = crossSpawn.sync(base, args, syncOpts);
     return !result.error && (typeof result.status !== "number" || result.status === 0);
+  } catch {
+    return false;
   } finally {
     if (guiFamily) {
-      inkInstance.resumeStdin();
-      inkInstance.resume();
-    } else {
+      if (suspendedStdin) inkInstance.resumeStdin();
+      if (paused) inkInstance.resume();
+    } else if (enteredAlternateScreen) {
       inkInstance.exitAlternateScreen();
     }
   }

--- a/runtime/tests/tui/workbench/buffer-external-editor.test.ts
+++ b/runtime/tests/tui/workbench/buffer-external-editor.test.ts
@@ -1,8 +1,81 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { resolveBufferExternalEditor } from "../../../src/tui/workbench/buffer/externalEditor.js";
+const spawnMock = vi.hoisted(() => ({
+  sync: vi.fn(),
+}));
+
+const instancesMock = vi.hoisted(() => ({
+  get: vi.fn(),
+}));
+
+const whichMock = vi.hoisted(() => vi.fn());
+
+vi.mock("cross-spawn", () => ({
+  default: spawnMock,
+}));
+
+vi.mock("../../../src/tui/ink/instances.js", () => ({
+  default: instancesMock,
+}));
+
+vi.mock("../../../src/utils/which.js", () => ({
+  whichSync: whichMock,
+}));
+
+import {
+  openFileInBufferExternalEditor,
+  resolveBufferExternalEditor,
+} from "../../../src/tui/workbench/buffer/externalEditor.js";
+
+const originalVisual = process.env.VISUAL;
+const originalEditor = process.env.EDITOR;
+
+function restoreEditorEnv(): void {
+  if (originalVisual === undefined) {
+    delete process.env.VISUAL;
+  } else {
+    process.env.VISUAL = originalVisual;
+  }
+  if (originalEditor === undefined) {
+    delete process.env.EDITOR;
+  } else {
+    process.env.EDITOR = originalEditor;
+  }
+}
+
+function mockInkInstance(overrides: Partial<ReturnType<typeof createInkInstance>> = {}) {
+  const instance = createInkInstance();
+  return { ...instance, ...overrides };
+}
+
+function createInkInstance() {
+  return {
+    enterAlternateScreen: vi.fn(),
+    exitAlternateScreen: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    suspendStdin: vi.fn(),
+    resumeStdin: vi.fn(),
+  };
+}
 
 describe("buffer external editor", () => {
+  beforeEach(() => {
+    restoreEditorEnv();
+    delete process.env.VISUAL;
+    delete process.env.EDITOR;
+    spawnMock.sync.mockReset();
+    spawnMock.sync.mockReturnValue({ status: 0 });
+    instancesMock.get.mockReset();
+    instancesMock.get.mockReturnValue(mockInkInstance());
+    whichMock.mockReset();
+    whichMock.mockReturnValue("/usr/bin/editor");
+  });
+
+  afterEach(() => {
+    restoreEditorEnv();
+  });
+
   it("prefers VISUAL and EDITOR before fallback terminal editors", () => {
     expect(resolveBufferExternalEditor(
       { VISUAL: "nvim --clean", EDITOR: "vim" },
@@ -32,5 +105,60 @@ describe("buffer external editor", () => {
         isCommandAvailable: () => false,
       },
     )).toBeUndefined();
+  });
+
+  it("uses terminal editors in the alternate screen and restores after failure", () => {
+    process.env.VISUAL = "vim --clean";
+    const ink = mockInkInstance();
+    instancesMock.get.mockReturnValue(ink);
+    spawnMock.sync.mockReturnValue({ status: 1 });
+
+    expect(openFileInBufferExternalEditor("/tmp/file.ts", 12)).toBe(false);
+
+    expect(spawnMock.sync).toHaveBeenCalledWith(
+      "vim",
+      ["--clean", "+12", "/tmp/file.ts"],
+      { stdio: "inherit" },
+    );
+    expect(ink.enterAlternateScreen).toHaveBeenCalledOnce();
+    expect(ink.exitAlternateScreen).toHaveBeenCalledOnce();
+    expect(ink.pause).not.toHaveBeenCalled();
+  });
+
+  it("uses GUI editors with blocking wait args and restores stdin", () => {
+    process.env.VISUAL = "code";
+    const ink = mockInkInstance();
+    instancesMock.get.mockReturnValue(ink);
+
+    expect(openFileInBufferExternalEditor("/tmp/file.ts", 12)).toBe(true);
+
+    expect(spawnMock.sync).toHaveBeenCalledWith(
+      "code",
+      ["-w", "-g", "/tmp/file.ts:12"],
+      { stdio: "inherit" },
+    );
+    expect(ink.pause).toHaveBeenCalledOnce();
+    expect(ink.suspendStdin).toHaveBeenCalledOnce();
+    expect(ink.resumeStdin).toHaveBeenCalledOnce();
+    expect(ink.resume).toHaveBeenCalledOnce();
+    expect(ink.enterAlternateScreen).not.toHaveBeenCalled();
+  });
+
+  it("restores GUI pause state if suspending stdin fails before spawn", () => {
+    process.env.VISUAL = "code";
+    const ink = mockInkInstance({
+      suspendStdin: vi.fn(() => {
+        throw new Error("stdin handoff failed");
+      }),
+    });
+    instancesMock.get.mockReturnValue(ink);
+
+    expect(openFileInBufferExternalEditor("/tmp/file.ts", 12)).toBe(false);
+
+    expect(ink.pause).toHaveBeenCalledOnce();
+    expect(ink.suspendStdin).toHaveBeenCalledOnce();
+    expect(ink.resumeStdin).not.toHaveBeenCalled();
+    expect(ink.resume).toHaveBeenCalledOnce();
+    expect(spawnMock.sync).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- restore already-acquired Ink terminal state if external editor handoff fails before spawn
- return false instead of throwing when external editor launch setup fails
- add regression coverage for GUI and terminal editor handoff behavior

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/buffer-external-editor.test.ts --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- git diff --check

## Notes
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on the existing unrelated Knip backlog.