### PR TITLE
fix(tui): bound in-flight task path matches

### DIFF
--- a/runtime/src/tui/workbench/agents/activity.ts
+++ b/runtime/src/tui/workbench/agents/activity.ts
@@ -21,7 +21,7 @@ export function taskMayReferencePath(task: TaskState, pathValue: string | null |
   if (!pathValue) return false;
   const normalized = normalizePath(pathValue);
   if (normalized.length === 0) return false;
-  return taskSearchStrings(task).some((value) => normalizePath(value).includes(normalized));
+  return taskSearchStrings(task).some((value) => containsPathReference(normalizePath(value), normalized));
 }
 
 export function inFlightPathsFromTasks(
@@ -85,4 +85,27 @@ function stringifyInput(input: unknown): string {
 
 function normalizePath(value: string): string {
   return value.replace(/\\/gu, "/").replace(/^\.\//u, "");
+}
+
+function containsPathReference(value: string, pathValue: string): boolean {
+  let index = value.indexOf(pathValue);
+  while (index !== -1) {
+    const before = index > 0 ? value[index - 1] : "";
+    const after = value[index + pathValue.length] ?? "";
+    if (isPathReferenceStart(before) && isPathReferenceEnd(after)) return true;
+    index = value.indexOf(pathValue, index + 1);
+  }
+  return false;
+}
+
+function isPathReferenceStart(value: string): boolean {
+  return value === "" || value === "/" || !isPathContinuation(value);
+}
+
+function isPathReferenceEnd(value: string): boolean {
+  return value === "" || !isPathContinuation(value);
+}
+
+function isPathContinuation(value: string): boolean {
+  return /^[\p{L}\p{N}._~+%/-]$/u.test(value);
 }

--- a/runtime/tests/tui/workbench/agents.test.ts
+++ b/runtime/tests/tui/workbench/agents.test.ts
@@ -82,4 +82,36 @@ describe("workbench agents rail model", () => {
     expect(taskMayReferencePath(task, "src/app.ts")).toBe(true);
     expect(inFlightPathsFromTasks([task], ["src/app.ts", "src/other.ts"])).toEqual(["src/app.ts"]);
   });
+
+  it("does not treat longer sibling file names as the selected in-flight path", () => {
+    const task = {
+      id: "agent-1",
+      type: "local_agent",
+      status: "running",
+      description: "editing src/app.tsx",
+      startTime: 0,
+      outputFile: "urn:agenc:task:agent-1:output",
+      outputOffset: 0,
+      notified: false,
+    } as any;
+
+    expect(taskMayReferencePath(task, "src/app.ts")).toBe(false);
+    expect(taskMayReferencePath(task, "src/app.tsx")).toBe(true);
+    expect(inFlightPathsFromTasks([task], ["src/app.ts", "src/app.tsx"])).toEqual(["src/app.tsx"]);
+  });
+
+  it("recognizes path references with absolute prefixes and line suffixes", () => {
+    const task = {
+      id: "agent-1",
+      type: "local_agent",
+      status: "running",
+      description: "patch /repo/src/app.ts:42",
+      startTime: 0,
+      outputFile: "urn:agenc:task:agent-1:output",
+      outputOffset: 0,
+      notified: false,
+    } as any;
+
+    expect(taskMayReferencePath(task, "src/app.ts")).toBe(true);
+  });
 });

--- a/runtime/tests/tui/workbench/buffer-surface.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface.test.tsx
@@ -119,6 +119,56 @@ describe("BufferSurface", () => {
     }
   });
 
+  it("does not show an in-flight agent warning for longer sibling file names", async () => {
+    await writeFile(join(dir, "target.ts"), "const value = 1;\n", "utf8");
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      await runWithCwdOverride(dir, async () => {
+        root.render(
+          <AppStateProvider
+            initialState={{
+              ...getDefaultAppState(),
+              tasks: {
+                "agent-1": {
+                  id: "agent-1",
+                  type: "local_agent",
+                  status: "running",
+                  description: "editing target.tsx",
+                } as any,
+              },
+              workbench: {
+                ...getDefaultAppState().workbench,
+                activeSurfaceMode: "buffer",
+                activeFilePath: "target.ts",
+                activeFileLine: 1,
+              },
+            }}
+          >
+            <KeybindingSetup>
+              <BufferSurface focused={false} />
+            </KeybindingSetup>
+          </AppStateProvider>,
+        );
+        await sleep();
+      });
+
+      const frame = output();
+      expect(frame).toContain("target.ts");
+      expect(frame).not.toContain("agent edit in flight");
+      expect(frame).not.toMatch(/\bagent\b/u);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
   it("captures focused vim insert text before later input handlers", async () => {
     await writeFile(join(dir, "target.ts"), "const value = 1;\n", "utf8");
     const { stdin, stdout } = createStreams();


### PR DESCRIPTION
## Summary
- bound task/path matching so `src/app.tsx` no longer marks `src/app.ts` as in flight
- keep exact, absolute-prefix, and line-suffixed path references matching
- cover the visible BUFFER warning path so sibling filenames do not show a false in-flight agent warning

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/agents.test.ts tests/tui/workbench/buffer-surface.test.tsx --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- git diff --check

## Notes
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on the existing unrelated Knip backlog.