### PR TITLE
fix(tui): gate explorer file prompts on focus

### DIFF
--- a/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
+++ b/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
@@ -191,6 +191,7 @@ export function ProjectExplorer({ focused, width }: Props): React.ReactElement {
       ) : null}
       {fileAction ? (
         <ProjectFileActionPrompt
+          focused={focused}
           action={fileAction}
           width={Math.max(8, width - 2)}
           onChange={(value) => setFileAction((current) => current ? { ...current, value } : current)}
@@ -217,6 +218,7 @@ export function ProjectExplorer({ focused, width }: Props): React.ReactElement {
 }
 
 export function ProjectFileActionPrompt({
+  focused = true,
   action,
   width,
   onChange,
@@ -231,7 +233,7 @@ export function ProjectFileActionPrompt({
     setCursorOffset(action.value?.length ?? 0);
   }, [actionKey]);
 
-  useRegisterKeybindingContext("Confirmation", action.kind === "delete");
+  useRegisterKeybindingContext("Confirmation", focused && action.kind === "delete");
   useKeybindings(
     {
       "confirm:yes": () => {
@@ -239,7 +241,7 @@ export function ProjectFileActionPrompt({
       },
       "confirm:no": onCancel,
     },
-    { context: "Confirmation", isActive: action.kind === "delete" },
+    { context: "Confirmation", isActive: focused && action.kind === "delete" },
   );
 
   if (action.kind === "delete") {
@@ -274,7 +276,7 @@ export function ProjectFileActionPrompt({
           return input;
         }}
         disableEscapeDoublePress
-        focus={!action.busy}
+        focus={focused && !action.busy}
         showCursor
         multiline={false}
         maxVisibleLines={1}

--- a/runtime/tests/tui/workbench/render.test.tsx
+++ b/runtime/tests/tui/workbench/render.test.tsx
@@ -4,11 +4,20 @@ import { describe, expect, it, vi } from "vitest";
 
 const projectExplorerHarness = vi.hoisted(() => ({
   textInputProps: [] as Array<Record<string, unknown>>,
+  keybindingCalls: [] as Array<{
+    handlers: Record<string, () => void>;
+    options?: Record<string, unknown>;
+  }>,
 }));
 
 vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
   useKeybinding: () => {},
-  useKeybindings: () => {},
+  useKeybindings: (
+    handlers: Record<string, () => void>,
+    options?: Record<string, unknown>,
+  ) => {
+    projectExplorerHarness.keybindingCalls.push({ handlers, options });
+  },
 }));
 
 vi.mock("../../../src/tui/components/TextInput.js", async () => {
@@ -208,6 +217,62 @@ describe("workbench render contract", () => {
       multiline: false,
     });
     expect(props?.onChangeCursorOffset).toEqual(expect.any(Function));
+  });
+
+  it("disables explorer file-action text input when the explorer is unfocused", async () => {
+    projectExplorerHarness.textInputProps = [];
+
+    await renderToString(
+      <ProjectFileActionPrompt
+        focused={false}
+        action={{
+          kind: "rename",
+          path: "src/old.ts",
+          value: "src/old.ts",
+          busy: false,
+          error: null,
+        }}
+        width={40}
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        onConfirmDelete={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+      80,
+    );
+
+    expect(projectExplorerHarness.textInputProps.at(-1)).toMatchObject({
+      focus: false,
+    });
+  });
+
+  it("disables explorer delete confirmations when the explorer is unfocused", async () => {
+    projectExplorerHarness.keybindingCalls = [];
+
+    await renderToString(
+      <ProjectFileActionPrompt
+        focused={false}
+        action={{
+          kind: "delete",
+          path: "src/old.ts",
+          label: "old.ts",
+          rowKind: "file",
+          busy: false,
+          error: null,
+        }}
+        width={40}
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        onConfirmDelete={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+      80,
+    );
+
+    expect(projectExplorerHarness.keybindingCalls.at(-1)?.options).toMatchObject({
+      context: "Confirmation",
+      isActive: false,
+    });
   });
 
   it("keeps the selected explorer row inside a contiguous viewport", () => {


### PR DESCRIPTION
## Summary
- Gate explorer file-action text input focus on the explorer pane focus state.
- Disable delete confirmation keybindings when the explorer is unfocused.
- Add render contract coverage for unfocused rename and delete prompts.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/render.test.tsx --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/project-tree.test.ts tests/tui/workbench/render.test.tsx --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Notes
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on the existing unrelated Knip backlog.