### PR TITLE
fix(tui): prefer active shell task fallback

### DIFF
--- a/runtime/src/tui/workbench/tasks/shellTasks.ts
+++ b/runtime/src/tui/workbench/tasks/shellTasks.ts
@@ -1,5 +1,6 @@
 import {
   isLocalShellTask,
+  isStoppableTaskStatus,
   type LocalShellTaskState,
   type TaskState,
 } from "../../../tasks/types.js";
@@ -10,5 +11,17 @@ export function resolveWorkbenchShellTask(
 ): LocalShellTaskState | null {
   const selectedTask = selectedTaskId ? tasks?.[selectedTaskId] : undefined;
   if (isLocalShellTask(selectedTask)) return selectedTask;
-  return Object.values(tasks ?? {}).find(isLocalShellTask) ?? null;
+  return Object.values(tasks ?? {})
+    .filter(isLocalShellTask)
+    .sort(compareShellTaskFallbacks)[0] ?? null;
+}
+
+function compareShellTaskFallbacks(
+  left: LocalShellTaskState,
+  right: LocalShellTaskState,
+): number {
+  const leftActive = isStoppableTaskStatus(left.status);
+  const rightActive = isStoppableTaskStatus(right.status);
+  if (leftActive !== rightActive) return leftActive ? -1 : 1;
+  return (right.startTime ?? 0) - (left.startTime ?? 0);
 }

--- a/runtime/tests/tui/workbench/shell-surface.test.tsx
+++ b/runtime/tests/tui/workbench/shell-surface.test.tsx
@@ -96,4 +96,49 @@ describe("ShellSurface", () => {
     expect(output).toContain("No shell task selected");
     expect(output).not.toContain("agent work");
   });
+
+  it("falls back to the running newest shell task after stale selection", async () => {
+    const output = await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...getDefaultAppState(),
+          tasks: {
+            "shell-old": {
+              id: "shell-old",
+              type: "local_bash",
+              status: "completed",
+              description: "old completed shell",
+              command: "npm run old",
+              startTime: 1_000,
+              outputFile: "urn:agenc:task:shell-old:output",
+              outputOffset: 0,
+              notified: false,
+            } as any,
+            "shell-new": {
+              id: "shell-new",
+              type: "local_bash",
+              status: "running",
+              description: "new running shell",
+              command: "npm test",
+              startTime: 2_000,
+              outputFile: "urn:agenc:task:shell-new:output",
+              outputOffset: 0,
+              notified: false,
+            } as any,
+          },
+          workbench: {
+            ...getDefaultAppState().workbench,
+            activeSurfaceMode: "shell",
+            selectedShellTaskId: "missing-shell",
+          },
+        }}
+      >
+        <ShellSurface focused={true} />
+      </AppStateProvider>,
+      100,
+    );
+
+    expect(output).toContain("SHELL - running - new running shell");
+    expect(output).not.toContain("old completed shell");
+  });
 });

--- a/runtime/tests/tui/workbench/shell-tasks.test.ts
+++ b/runtime/tests/tui/workbench/shell-tasks.test.ts
@@ -17,20 +17,58 @@ describe("resolveWorkbenchShellTask", () => {
     expect(resolveWorkbenchShellTask({ "shell-1": shell }, "missing")).toBe(shell);
   });
 
+  it("falls back to the running newest shell task when no selected shell task is usable", () => {
+    const oldCompleted = shellTask("shell-old", {
+      status: "completed",
+      startTime: 1_000,
+    });
+    const newRunning = shellTask("shell-new", {
+      status: "running",
+      startTime: 2_000,
+    });
+
+    expect(resolveWorkbenchShellTask({
+      "shell-old": oldCompleted,
+      "shell-new": newRunning,
+    }, "missing")).toBe(newRunning);
+  });
+
+  it("falls back to the newest shell task when none are active", () => {
+    const oldCompleted = shellTask("shell-old", {
+      status: "completed",
+      startTime: 1_000,
+    });
+    const newFailed = shellTask("shell-new", {
+      status: "failed",
+      startTime: 2_000,
+    });
+
+    expect(resolveWorkbenchShellTask({
+      "shell-old": oldCompleted,
+      "shell-new": newFailed,
+    }, null)).toBe(newFailed);
+  });
+
   it("returns null when no local shell task is available", () => {
     expect(resolveWorkbenchShellTask({ "agent-1": agentTask("agent-1") }, "agent-1")).toBeNull();
     expect(resolveWorkbenchShellTask({}, null)).toBeNull();
   });
 });
 
-function shellTask(id: string) {
+function shellTask(
+  id: string,
+  overrides: Partial<{
+    readonly status: "pending" | "running" | "completed" | "failed" | "killed";
+    readonly startTime: number;
+  }> = {},
+) {
   return {
     id,
     type: "local_bash",
-    status: "running",
+    status: overrides.status ?? "running",
     description: "npm test",
     command: "npm test",
-    startTime: 1_000,
+    startTime: overrides.startTime ?? 1_000,
     outputFile: `urn:agenc:task:${id}:output`,
     outputOffset: 0,
     notified: false,


### PR DESCRIPTION
## Summary
- Prefer selected shell tasks when valid, but fall back to pending/running shell tasks before terminal tasks.
- Use newest shell task ordering when fallback tasks have the same active/terminal class.
- Add resolver and mounted shell-surface coverage for stale selected shell ids.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/shell-tasks.test.ts --reporter=dot (failed before fix, passed after)
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/shell-tasks.test.ts tests/tui/workbench/shell-surface.test.tsx tests/tui/workbench/test-surface.test.tsx --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Notes
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on the existing unrelated Knip backlog.