### PR TITLE
fix(tui): prefer active agent task fallback

### DIFF
--- a/runtime/src/tui/workbench/agents/AgentsRail.tsx
+++ b/runtime/src/tui/workbench/agents/AgentsRail.tsx
@@ -21,7 +21,7 @@ export function AgentsRail({
   const setAppState = useSetAppState();
   const workbench = useWorkbenchState();
   const dispatch = useWorkbenchDispatch();
-  const taskList = Object.values(tasks ?? {}).filter((task: any) => task.type !== "local_bash");
+  const taskList = orderAgentTasks(Object.values(tasks ?? {}).filter((task: any) => task.type !== "local_bash"));
   const { activeTasks, backgroundTasks } = partitionAgentTasks(taskList);
   const { selectedId, selectedIndex, selectedTask } = resolveAgentSelection(taskList, workbench.selectedAgentTaskId);
   const selectByDelta = (delta: number) => {
@@ -72,22 +72,38 @@ export function partitionAgentTasks(tasks: readonly any[]): {
   };
 }
 
+export function orderAgentTasks(tasks: readonly any[]): readonly any[] {
+  return [...tasks].sort(compareAgentTasks);
+}
+
 export function resolveAgentSelection(tasks: readonly any[], selectedId: string | null | undefined): {
   readonly selectedId: string | null;
   readonly selectedIndex: number;
   readonly selectedTask: any | null;
 } {
-  if (tasks.length === 0) {
+  const orderedTasks = orderAgentTasks(tasks);
+  if (orderedTasks.length === 0) {
     return { selectedId: null, selectedIndex: -1, selectedTask: null };
   }
-  const selectedIndex = tasks.findIndex((task: any) => task.id === selectedId);
+  const selectedIndex = orderedTasks.findIndex((task: any) => task.id === selectedId);
   const resolvedIndex = selectedIndex >= 0 ? selectedIndex : 0;
-  const selectedTask = tasks[resolvedIndex] ?? null;
+  const selectedTask = orderedTasks[resolvedIndex] ?? null;
   return {
     selectedId: selectedTask?.id ?? null,
     selectedIndex: selectedTask ? resolvedIndex : -1,
     selectedTask,
   };
+}
+
+function compareAgentTasks(left: any, right: any): number {
+  const leftActive = isActiveTaskStatus(left?.status);
+  const rightActive = isActiveTaskStatus(right?.status);
+  if (leftActive !== rightActive) return leftActive ? -1 : 1;
+  return (right?.startTime ?? 0) - (left?.startTime ?? 0);
+}
+
+function isActiveTaskStatus(status: unknown): boolean {
+  return status === "running" || status === "pending";
 }
 
 function AgentRailSection({

--- a/runtime/src/tui/workbench/surfaces/AgentSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/AgentSurface.tsx
@@ -9,6 +9,7 @@ import { useRegisterKeybindingContext } from "../../keybindings/KeybindingContex
 import { useAppState, useSetAppState } from "../../state/AppState.js";
 import { enterTeammateView } from "../../state/teammateViewHelpers.js";
 import { formatTaskElapsed, taskPathLabel } from "../agents/activity.js";
+import { orderAgentTasks, resolveAgentSelection } from "../agents/AgentsRail.js";
 import { useWorkbenchState } from "../state.js";
 import { stopWorkbenchTask, workbenchStopActionForTask } from "../tasks/stopActions.js";
 import { EmptySurface, SurfaceHeader } from "./PreviewSurface.js";
@@ -18,8 +19,8 @@ export function AgentSurface({ focused }: { readonly focused: boolean }): React.
   const tasks = useAppState((state) => state.tasks);
   const setAppState = useSetAppState();
   const task = useMemo(() => {
-    if (workbench.selectedAgentTaskId && tasks[workbench.selectedAgentTaskId]) return tasks[workbench.selectedAgentTaskId];
-    return Object.values(tasks).find((item: any) => item.type !== "local_bash") ?? null;
+    const taskList = orderAgentTasks(Object.values(tasks).filter((item: any) => item.type !== "local_bash"));
+    return resolveAgentSelection(taskList, workbench.selectedAgentTaskId).selectedTask;
   }, [tasks, workbench.selectedAgentTaskId]);
   const [tail, setTail] = useState("");
 

--- a/runtime/tests/tui/workbench/agent-surface.test.tsx
+++ b/runtime/tests/tui/workbench/agent-surface.test.tsx
@@ -17,6 +17,52 @@ import { AgentSurface, canEnterAgentTranscript } from "../../../src/tui/workbenc
 import { renderToString } from "../../../src/utils/staticRender.js";
 
 describe("AgentSurface", () => {
+  it("falls back to the running newest agent when the selected agent id is stale", async () => {
+    const oldAgent = {
+      id: "agent-old",
+      type: "local_agent",
+      status: "completed",
+      description: "old completed agent",
+      startTime: 1_000,
+      outputFile: "urn:agenc:task:agent-old:output",
+      outputOffset: 0,
+      notified: false,
+    } as any;
+    const newAgent = {
+      id: "agent-new",
+      type: "local_agent",
+      status: "running",
+      description: "new running agent",
+      startTime: 2_000,
+      outputFile: "urn:agenc:task:agent-new:output",
+      outputOffset: 0,
+      notified: false,
+    } as any;
+
+    const output = await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...getDefaultAppState(),
+          tasks: {
+            [oldAgent.id]: oldAgent,
+            [newAgent.id]: newAgent,
+          },
+          workbench: {
+            ...getDefaultAppState().workbench,
+            activeSurfaceMode: "agent",
+            selectedAgentTaskId: "agent-gone",
+          },
+        }}
+      >
+        <AgentSurface focused={true} />
+      </AppStateProvider>,
+      100,
+    );
+
+    expect(output).toContain("AGENT - running - new running agent");
+    expect(output).not.toContain("old completed agent");
+  });
+
   it("opens in-process teammate transcripts from the agent surface", async () => {
     const changes: AppState[] = [];
     const teammateTask = {

--- a/runtime/tests/tui/workbench/agents-rail.test.tsx
+++ b/runtime/tests/tui/workbench/agents-rail.test.tsx
@@ -55,4 +55,56 @@ describe("AgentsRail", () => {
       selectedAgentTaskId: "agent-live",
     });
   });
+
+  it("opens the running newest agent before older completed agents after stale selection", async () => {
+    const changes: AppState[] = [];
+    const oldAgent = {
+      id: "agent-old",
+      type: "local_agent",
+      status: "completed",
+      description: "old completed agent",
+      startTime: 1_000,
+      outputFile: "urn:agenc:task:agent-old:output",
+      outputOffset: 0,
+      notified: false,
+    } as any;
+    const newAgent = {
+      id: "agent-new",
+      type: "local_agent",
+      status: "running",
+      description: "new running agent",
+      startTime: 2_000,
+      outputFile: "urn:agenc:task:agent-new:output",
+      outputOffset: 0,
+      notified: false,
+    } as any;
+
+    await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...getDefaultAppState(),
+          tasks: {
+            [oldAgent.id]: oldAgent,
+            [newAgent.id]: newAgent,
+          },
+          workbench: {
+            ...getDefaultAppState().workbench,
+            selectedAgentTaskId: "agent-gone",
+          },
+        }}
+        onChangeAppState={({ newState }) => changes.push(newState)}
+      >
+        <AgentsRail focused={true} width={40} />
+      </AppStateProvider>,
+      100,
+    );
+
+    keybindingHarness.handlers["agents:open"]?.();
+
+    expect(changes.at(-1)?.workbench).toMatchObject({
+      activeSurfaceMode: "agent",
+      focusedPane: "surface",
+      selectedAgentTaskId: "agent-new",
+    });
+  });
 });

--- a/runtime/tests/tui/workbench/agents.test.ts
+++ b/runtime/tests/tui/workbench/agents.test.ts
@@ -44,6 +44,19 @@ describe("workbench agents rail model", () => {
     });
   });
 
+  it("resolves stale agent selection to the active newest agent before completed tasks", () => {
+    const tasks = [
+      { id: "agent-old", type: "local_agent", status: "completed", startTime: 1_000 },
+      { id: "agent-new", type: "local_agent", status: "running", startTime: 2_000 },
+    ];
+
+    expect(resolveAgentSelection(tasks, "agent-gone")).toMatchObject({
+      selectedId: "agent-new",
+      selectedIndex: 0,
+      selectedTask: tasks[1],
+    });
+  });
+
   it("formats elapsed runtime and extracts task paths", () => {
     const task = {
       id: "agent-1",


### PR DESCRIPTION
## Summary
- Order agent workbench tasks active-first, newest-first for stale selection fallback.
- Reuse the same resolver in the agents rail and AGENT surface.
- Add model, rail, and mounted surface coverage for stale selected agent ids.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/agents.test.ts tests/tui/workbench/agent-surface.test.tsx --reporter=dot (failed before fix, passed after)
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/agents.test.ts tests/tui/workbench/agent-surface.test.tsx tests/tui/workbench/agents-rail.test.tsx --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Notes
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on the existing unrelated Knip backlog.