### PR TITLE
fix(tui): ignore hidden workbench pane focus

### DIFF
--- a/runtime/src/tui/workbench/WorkbenchFooter.tsx
+++ b/runtime/src/tui/workbench/WorkbenchFooter.tsx
@@ -3,11 +3,12 @@ import React from "react";
 
 import { Box, Text } from "../ink.js";
 import { footerHintsForSurface } from "./surfaces/ActiveWorkSurface.js";
+import { visibleWorkbenchPane } from "./reducer.js";
 import { useWorkbenchState } from "./state.js";
 
 export function WorkbenchFooter(): React.ReactElement {
   const workbench = useWorkbenchState();
-  const hints = hintsForPane(workbench.focusedPane, workbench.activeSurfaceMode);
+  const hints = hintsForPane(visibleWorkbenchPane(workbench), workbench.activeSurfaceMode);
   return (
     <Box height={1} width="100%">
       <Text dimColor wrap="truncate-end">{hints}</Text>

--- a/runtime/src/tui/workbench/WorkbenchLayout.tsx
+++ b/runtime/src/tui/workbench/WorkbenchLayout.tsx
@@ -11,6 +11,7 @@ import { AgentsRail } from "./agents/AgentsRail.js";
 import { ProjectExplorer } from "./project-tree/ProjectExplorer.js";
 import { ActiveWorkSurface } from "./surfaces/ActiveWorkSurface.js";
 import { WorkbenchComposerFocusProvider } from "./composerFocusContext.js";
+import { visibleWorkbenchPane } from "./reducer.js";
 import { useWorkbenchDispatch, useWorkbenchState } from "./state.js";
 import type { WorkbenchLayoutSize, WorkbenchPane } from "./types.js";
 import { WorkbenchFooter } from "./WorkbenchFooter.js";
@@ -35,6 +36,7 @@ export function WorkbenchLayout({
   const workbench = useWorkbenchState();
   const dispatch = useWorkbenchDispatch();
   const layoutSize = layoutSizeForColumns(columns);
+  const focusedPane = visibleWorkbenchPane(workbench);
   const showExplorer = workbench.explorerVisible && layoutSize !== "narrow";
   const showAgents = workbench.agentsVisible && layoutSize === "wide";
   const visiblePanes = useMemo(
@@ -43,11 +45,11 @@ export function WorkbenchLayout({
   );
 
   useRegisterKeybindingContext("Workbench", true);
-  useRegisterKeybindingContext("Composer", workbench.focusedPane === "composer");
+  useRegisterKeybindingContext("Composer", focusedPane === "composer");
   useKeybindings(
     {
       "workbench:focusExplorer": () => dispatch({ type: "focus", pane: "explorer" }),
-      "workbench:focusSurface": () => dispatch({ type: "focus", pane: nextRightPane(workbench.focusedPane, showAgents) }),
+      "workbench:focusSurface": () => dispatch({ type: "focus", pane: nextRightPane(focusedPane, showAgents) }),
       "workbench:focusAgents": () => dispatch({ type: "focus", pane: "agents" }),
       "workbench:focusComposer": () => dispatch({ type: "focus", pane: "composer" }),
       "workbench:focusUp": () => dispatch({ type: "focus", pane: "surface" }),
@@ -65,29 +67,29 @@ export function WorkbenchLayout({
     <Box flexDirection="column" width="100%" height={rows} overflow="hidden">
       {rows >= 8 ? <WorkbenchStatusBar columns={columns} /> : null}
       <Box flexDirection="row" flexGrow={1} overflow="hidden">
-        {showExplorer ? <ProjectExplorer focused={workbench.focusedPane === "explorer"} width={explorerWidth} /> : null}
-        <ActiveWorkSurface focused={workbench.focusedPane === "surface"} transcript={transcript} pendingApproval={pendingApproval} />
-        {showAgents ? <AgentsRail focused={workbench.focusedPane === "agents"} width={agentsWidth} /> : null}
+        {showExplorer ? <ProjectExplorer focused={focusedPane === "explorer"} width={explorerWidth} /> : null}
+        <ActiveWorkSurface focused={focusedPane === "surface"} transcript={transcript} pendingApproval={pendingApproval} />
+        {showAgents ? <AgentsRail focused={focusedPane === "agents"} width={agentsWidth} /> : null}
       </Box>
       {overlay ? (
         <Box flexDirection="column" borderColor="warning" borderTop paddingX={1}>
           {overlay}
         </Box>
       ) : null}
-      <Box flexDirection="column" flexShrink={0} borderTop borderColor={workbench.focusedPane === "composer" ? "suggestion" : "gray"}>
+      <Box flexDirection="column" flexShrink={0} borderTop borderColor={focusedPane === "composer" ? "suggestion" : "gray"}>
         <PromptSuggestionsOverlay />
-        <WorkbenchComposerFocusProvider active={workbench.focusedPane === "composer"}>
+        <WorkbenchComposerFocusProvider active={focusedPane === "composer"}>
           {composer}
         </WorkbenchComposerFocusProvider>
       </Box>
       <PromptDialogOverlay />
       {rows >= 5 ? <WorkbenchFooter /> : null}
-      {layoutSize !== "wide" && workbench.focusedPane === "agents" ? (
+      {layoutSize !== "wide" && workbench.agentsVisible && focusedPane === "agents" ? (
         <Box position="absolute" right={0} top={1} bottom={2} width={Math.min(34, columns)} opaque>
           <AgentsRail focused={true} width={Math.min(34, columns)} />
         </Box>
       ) : null}
-      {layoutSize === "narrow" && workbench.focusedPane === "explorer" ? (
+      {layoutSize === "narrow" && workbench.explorerVisible && focusedPane === "explorer" ? (
         <Box position="absolute" left={0} top={1} bottom={2} width={Math.min(34, columns)} opaque>
           <ProjectExplorer focused={true} width={Math.min(34, columns)} />
         </Box>

--- a/runtime/src/tui/workbench/reducer.ts
+++ b/runtime/src/tui/workbench/reducer.ts
@@ -134,6 +134,12 @@ export function workbenchReducer(
   }
 }
 
+export function visibleWorkbenchPane(state: WorkbenchState): WorkbenchPane {
+  if (state.focusedPane === "explorer" && !state.explorerVisible) return "surface";
+  if (state.focusedPane === "agents" && !state.agentsVisible) return "surface";
+  return state.focusedPane;
+}
+
 function openSurface(
   state: WorkbenchState,
   mode: ActiveSurfaceMode,

--- a/runtime/tests/tui/workbench/reducer.test.ts
+++ b/runtime/tests/tui/workbench/reducer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   getDefaultWorkbenchState,
+  visibleWorkbenchPane,
   workbenchReducer,
 } from "../../../src/tui/workbench/reducer.js";
 
@@ -90,6 +91,23 @@ describe("workbenchReducer", () => {
 
     expect(surface.focusedPane).toBe("surface");
     expect(composer.focusedPane).toBe("composer");
+  });
+
+  it("falls back to the surface when hidden panes have stale focus", () => {
+    expect(visibleWorkbenchPane({
+      ...getDefaultWorkbenchState(),
+      focusedPane: "agents",
+      agentsVisible: false,
+    })).toBe("surface");
+    expect(visibleWorkbenchPane({
+      ...getDefaultWorkbenchState(),
+      focusedPane: "explorer",
+      explorerVisible: false,
+    })).toBe("surface");
+    expect(visibleWorkbenchPane({
+      ...getDefaultWorkbenchState(),
+      focusedPane: "composer",
+    })).toBe("composer");
   });
 
   it("stores attachment payloads and ids together", () => {

--- a/runtime/tests/tui/workbench/render.test.tsx
+++ b/runtime/tests/tui/workbench/render.test.tsx
@@ -412,6 +412,43 @@ describe("workbench render contract", () => {
     expect(activeOutput).toContain("composer-active");
   });
 
+  it("does not render compact pane overlays when their panes are hidden", async () => {
+    const hiddenAgentsOutput = await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...getDefaultAppState(),
+          workbench: {
+            ...getDefaultAppState().workbench,
+            focusedPane: "agents",
+            agentsVisible: false,
+          },
+        }}
+      >
+        <WorkbenchLayout transcript={<Text>scroll body</Text>} composer={<ComposerFocusProbe />} />
+      </AppStateProvider>,
+      { columns: 120, rows: 30 },
+    );
+
+    const hiddenExplorerOutput = await renderToString(
+      <AppStateProvider
+        initialState={{
+          ...getDefaultAppState(),
+          workbench: {
+            ...getDefaultAppState().workbench,
+            focusedPane: "explorer",
+            explorerVisible: false,
+          },
+        }}
+      >
+        <WorkbenchLayout transcript={<Text>scroll body</Text>} composer={<ComposerFocusProbe />} />
+      </AppStateProvider>,
+      { columns: 80, rows: 30 },
+    );
+
+    expect(hiddenAgentsOutput).not.toContain("Agents");
+    expect(hiddenExplorerOutput).not.toContain("WORKSPACE");
+  });
+
   it("defines the surface descriptor contract for every live workbench surface", () => {
     expect(WORKBENCH_SURFACES.map((surface) => surface.mode)).toEqual([
       "transcript",


### PR DESCRIPTION
## Summary
- Normalize stale workbench focus away from hidden explorer/agents panes before layout rendering
- Reuse the normalized pane for footer hints, composer focus, compact overlays, and focus-surface routing
- Add reducer and render regression coverage for hidden-pane stale focus

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/render.test.tsx tests/tui/workbench/reducer.test.ts --reporter=dot
- git diff --check
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails only on existing unrelated Knip backlog)
