### PR TITLE
fix(tui): clamp preview scroll bounds

### DIFF
--- a/runtime/src/tui/workbench/surfaces/PreviewSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/PreviewSurface.tsx
@@ -20,6 +20,7 @@ export function PreviewSurface({ focused }: { readonly focused: boolean }): Reac
   const workbench = useWorkbenchState();
   const dispatch = useWorkbenchDispatch();
   const [startLine, setStartLine] = useState(() => Math.max(0, (workbench.activeFileLine ?? 1) - 1));
+  const [totalLines, setTotalLines] = useState<number | null>(null);
   const [content, setContent] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [gitState, setGitState] = useState<string | null>(null);
@@ -41,6 +42,7 @@ export function PreviewSurface({ focused }: { readonly focused: boolean }): Reac
 
   useEffect(() => {
     setStartLine(Math.max(0, (workbench.activeFileLine ?? 1) - 1));
+    setTotalLines(null);
   }, [workbench.activeFileLine, workbench.activeFilePath]);
 
   useEffect(() => {
@@ -48,18 +50,27 @@ export function PreviewSurface({ focused }: { readonly focused: boolean }): Reac
       setContent("");
       setError(null);
       setGitState(null);
+      setTotalLines(null);
       return;
     }
     const controller = new AbortController();
     readFileInRange(absolutePath, startLine, PAGE_SIZE, undefined, controller.signal)
       .then((result) => {
         if (controller.signal.aborted) return;
+        const nextTotalLines = Math.max(0, result.totalLines ?? result.lineCount ?? 0);
+        const maxStartLine = maxPreviewStartLine(nextTotalLines);
+        setTotalLines(nextTotalLines);
+        if (startLine > maxStartLine) {
+          setStartLine(maxStartLine);
+          return;
+        }
         setContent(result.content);
         setError(null);
       })
       .catch((err) => {
         if (controller.signal.aborted) return;
         setContent("");
+        setTotalLines(null);
         setError(err instanceof Error ? err.message : String(err));
       });
     return () => controller.abort();
@@ -87,9 +98,9 @@ export function PreviewSurface({ focused }: { readonly focused: boolean }): Reac
   useKeybindings(
     {
       "surface:up": () => setStartLine((value) => Math.max(0, value - 1)),
-      "surface:down": () => setStartLine((value) => value + 1),
+      "surface:down": () => setStartLine((value) => clampPreviewStartLine(value + 1, totalLines)),
       "surface:pageUp": () => setStartLine((value) => Math.max(0, value - 20)),
-      "surface:pageDown": () => setStartLine((value) => value + 20),
+      "surface:pageDown": () => setStartLine((value) => clampPreviewStartLine(value + 20, totalLines)),
       "surface:top": () => setStartLine(0),
       "surface:attach": () => {
         if (activePath) dispatch(attachFileRangeCommand(activePath, startLine + 1, startLine + Math.max(1, lines.length)));
@@ -136,6 +147,17 @@ export function PreviewSurface({ focused }: { readonly focused: boolean }): Reac
       </Box>
     </Box>
   );
+}
+
+function maxPreviewStartLine(totalLines: number): number {
+  return Math.max(0, totalLines - 1);
+}
+
+function clampPreviewStartLine(startLine: number, totalLines: number | null): number {
+  const nextStartLine = Math.max(0, Math.floor(startLine));
+  return totalLines === null
+    ? nextStartLine
+    : Math.min(nextStartLine, maxPreviewStartLine(totalLines));
 }
 
 export function SurfaceHeader({

--- a/runtime/tests/tui/workbench/preview-surface-scroll.test.tsx
+++ b/runtime/tests/tui/workbench/preview-surface-scroll.test.tsx
@@ -1,0 +1,119 @@
+import { PassThrough } from "node:stream";
+
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const previewHarness = vi.hoisted(() => ({
+  handlers: {} as Record<string, () => void>,
+  readOffsets: [] as number[],
+}));
+
+vi.mock("../../../src/utils/readFileInRange.js", () => ({
+  readFileInRange: vi.fn(async (
+    _filePath: string,
+    offset: number,
+  ) => {
+    previewHarness.readOffsets.push(offset);
+    return {
+      content: offset <= 0 ? "one\ntwo" : offset === 1 ? "two" : "",
+      lineCount: offset <= 0 ? 2 : offset === 1 ? 1 : 0,
+      totalLines: 2,
+      totalBytes: 7,
+      readBytes: offset <= 0 ? 7 : offset === 1 ? 3 : 0,
+      mtimeMs: 1,
+    };
+  }),
+}));
+
+vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
+  useKeybinding: () => {},
+  useKeybindings: (handlers: Record<string, () => void>) => {
+    previewHarness.handlers = handlers;
+  },
+}));
+
+vi.mock("../../../src/tui/workbench/project-tree/gitStatus.js", () => ({
+  collectGitStatus: vi.fn(async () => new Map()),
+}));
+
+import { createRoot } from "../../../src/tui/ink.js";
+import { AppStateProvider, getDefaultAppState } from "../../../src/tui/state/AppState.js";
+import { PreviewSurface } from "../../../src/tui/workbench/surfaces/PreviewSurface.js";
+
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
+function createStreams(): {
+  readonly stdin: TestStdin;
+  readonly stdout: PassThrough;
+} {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).columns = 80;
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).rows = 24;
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).isTTY = true;
+  stdout.resume();
+
+  return { stdin, stdout };
+}
+
+function sleep(ms = 50): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe("PreviewSurface scrolling", () => {
+  beforeEach(() => {
+    previewHarness.handlers = {};
+    previewHarness.readOffsets = [];
+  });
+
+  it("does not request preview ranges past the final file line", async () => {
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "preview",
+              activeFilePath: "target.txt",
+              activeFileLine: 1,
+            },
+          }}
+        >
+          <PreviewSurface focused={true} />
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      expect(previewHarness.readOffsets).toContain(0);
+
+      for (let index = 0; index < 5; index += 1) {
+        previewHarness.handlers["surface:down"]?.();
+      }
+      await sleep();
+
+      expect(Math.max(...previewHarness.readOffsets)).toBeLessThanOrEqual(1);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Track preview file total lines from the range reader
- Clamp preview down/page-down scrolling and stale offsets so the surface never reads past EOF
- Add a mounted preview regression that fails when repeated down actions request an out-of-range offset

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/preview-surface-scroll.test.tsx tests/tui/workbench/preview-surface.test.tsx --reporter=dot
- git diff --cached --check
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails only on existing unrelated Knip backlog)
