### PR TITLE
fix(tui): clear stale search results on query change

### DIFF
--- a/runtime/src/tui/workbench/surfaces/SearchSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/SearchSurface.tsx
@@ -27,8 +27,8 @@ export function SearchSurface({ focused }: { readonly focused: boolean }): React
   useEffect(() => {
     abortRef.current?.abort();
     setSelected(0);
+    setMatches([]);
     if (!query.trim()) {
-      setMatches([]);
       setLoading(false);
       setError(null);
       return;

--- a/runtime/tests/tui/workbench/search-surface.test.tsx
+++ b/runtime/tests/tui/workbench/search-surface.test.tsx
@@ -292,6 +292,54 @@ describe("SearchSurface", () => {
       stdout.end();
     }
   });
+
+  it("clears previous search results as soon as the query changes", async () => {
+    searchHarness.autoFlush = false;
+    let setSearchQuery: ((query: string) => void) | null = null;
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "search",
+              searchQuery: "old",
+            },
+          }}
+        >
+          <SearchQueryController onReady={(setter) => { setSearchQuery = setter; }} />
+          <SearchSurface focused={false} />
+        </AppStateProvider>,
+      );
+      await sleep(180);
+
+      const oldCall = searchHarness.calls[0]!;
+      oldCall.onLines(["src/old.ts:7:old result"]);
+      oldCall.resolve();
+      await sleep(50);
+
+      expect(compact(output())).toContain("src/old.ts");
+
+      const beforeQueryChange = output();
+      setSearchQuery?.("new");
+      await sleep(20);
+
+      const afterQueryChange = output().slice(beforeQueryChange.length);
+      expect(compact(afterQueryChange)).not.toContain("src/old.ts");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
 });
 
 function compact(value: string): string {


### PR DESCRIPTION
## Summary
- Clear stale search matches immediately when the workbench search query changes.
- Add a mounted regression test that reproduces old results remaining visible under the new query before the new search stream emits output.

## Test Plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/search-surface.test.tsx --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (expected existing Knip backlog only)