### PR TITLE
fix(tui): remap attachments on explorer rename

### DIFF
--- a/runtime/src/tui/workbench/commands.ts
+++ b/runtime/src/tui/workbench/commands.ts
@@ -28,6 +28,10 @@ export function attachFileCommand(path: string): WorkbenchCommand {
   };
 }
 
+export function renamePathReferencesCommand(fromPath: string, toPath: string): WorkbenchCommand {
+  return { type: "renamePathReferences", fromPath, toPath };
+}
+
 export function attachFileRangeCommand(
   path: string,
   line: number,

--- a/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
+++ b/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
@@ -11,7 +11,7 @@ import { useAppState } from "../../state/AppState.js";
 import TextInput from "../../components/TextInput.js";
 import { getGraphemeSegmenter } from "../../../utils/intl.js";
 import { inFlightPathsFromTasks } from "../agents/activity.js";
-import { attachFileCommand, openBufferCommand } from "../commands.js";
+import { attachFileCommand, openBufferCommand, renamePathReferencesCommand } from "../commands.js";
 import { useWorkbenchDispatch, useWorkbenchState } from "../state.js";
 import type { ProjectTreeRow } from "../types.js";
 import { getProjectTreeStore } from "./ProjectTreeStore.js";
@@ -109,6 +109,7 @@ export function ProjectExplorer({ focused, width }: Props): React.ReactElement {
       return;
     }
     const renamedActivePath = renamedActiveFilePath(workbench.activeFilePath, action.path, result.path);
+    dispatch(renamePathReferencesCommand(action.path, result.path));
     if (renamedActivePath) {
       dispatch(openBufferCommand(renamedActivePath, workbench.activeFileLine ?? undefined, false));
     }

--- a/runtime/src/tui/workbench/reducer.ts
+++ b/runtime/src/tui/workbench/reducer.ts
@@ -85,6 +85,8 @@ export function workbenchReducer(
       };
     case "closeSurface":
       return openSurface(state, "transcript");
+    case "renamePathReferences":
+      return renamePathReferences(state, command.fromPath, command.toPath);
     case "toggleExplorer":
       return {
         ...state,
@@ -185,4 +187,64 @@ function attach(
     attachments,
     composerAttachmentIds: attachments.map((item) => item.id),
   };
+}
+
+function renamePathReferences(
+  state: WorkbenchState,
+  fromPath: string,
+  toPath: string,
+): WorkbenchState {
+  const attachmentIdMap = new Map<string, string>();
+  const attachmentsById = new Map<string, WorkbenchAttachment>();
+  for (const attachment of state.attachments) {
+    const nextAttachment = renameAttachmentPath(attachment, fromPath, toPath);
+    attachmentIdMap.set(attachment.id, nextAttachment.id);
+    attachmentsById.set(nextAttachment.id, nextAttachment);
+  }
+  const attachments = [...attachmentsById.values()];
+  const attachmentIds = new Set(attachments.map((item) => item.id));
+  const composerAttachmentIds = unique(
+    state.composerAttachmentIds
+      .map((id) => attachmentIdMap.get(id) ?? id)
+      .filter((id) => attachmentIds.has(id)),
+  );
+  return {
+    ...state,
+    activeFilePath: renameWorkspacePath(state.activeFilePath, fromPath, toPath) ?? state.activeFilePath,
+    attachments,
+    composerAttachmentIds,
+  };
+}
+
+function renameAttachmentPath(
+  attachment: WorkbenchAttachment,
+  fromPath: string,
+  toPath: string,
+): WorkbenchAttachment {
+  const nextPath = renameWorkspacePath(attachment.path ?? null, fromPath, toPath);
+  if (!nextPath || nextPath === attachment.path) return attachment;
+  return {
+    ...attachment,
+    id: replaceFirst(attachment.id, attachment.path ?? "", nextPath),
+    path: nextPath,
+    label: replaceFirst(attachment.label, attachment.path ?? "", nextPath),
+  };
+}
+
+function renameWorkspacePath(value: string | null, fromPath: string, toPath: string): string | null {
+  if (!value) return value;
+  if (value === fromPath) return toPath;
+  if (value.startsWith(`${fromPath}/`)) return `${toPath}${value.slice(fromPath.length)}`;
+  return value;
+}
+
+function replaceFirst(value: string, needle: string, replacement: string): string {
+  if (!needle) return value;
+  const index = value.indexOf(needle);
+  if (index < 0) return value;
+  return `${value.slice(0, index)}${replacement}${value.slice(index + needle.length)}`;
+}
+
+function unique(values: readonly string[]): string[] {
+  return [...new Set(values)];
 }

--- a/runtime/src/tui/workbench/types.ts
+++ b/runtime/src/tui/workbench/types.ts
@@ -63,6 +63,7 @@ export type WorkbenchCommand =
   | { readonly type: "openAgent"; readonly taskId: string; readonly focus?: boolean }
   | { readonly type: "selectAgent"; readonly taskId: string | null }
   | { readonly type: "closeSurface" }
+  | { readonly type: "renamePathReferences"; readonly fromPath: string; readonly toPath: string }
   | { readonly type: "toggleExplorer"; readonly visible?: boolean }
   | { readonly type: "toggleAgents"; readonly visible?: boolean }
   | { readonly type: "attach"; readonly attachment: WorkbenchAttachment }

--- a/runtime/tests/tui/workbench/project-explorer-interactions.test.tsx
+++ b/runtime/tests/tui/workbench/project-explorer-interactions.test.tsx
@@ -182,6 +182,15 @@ describe("ProjectExplorer interactions", () => {
               activeSurfaceMode: "preview",
               activeFilePath: "src/nested/app.ts",
               activeFileLine: 12,
+              attachments: [{
+                id: "file-range:src/nested/app.ts:12-15",
+                kind: "file-range",
+                label: "src/nested/app.ts:12-15",
+                path: "src/nested/app.ts",
+                line: 12,
+                endLine: 15,
+              }],
+              composerAttachmentIds: ["file-range:src/nested/app.ts:12-15"],
             },
           }}
           onChangeAppState={({ newState }) => changes.push(newState)}
@@ -205,6 +214,15 @@ describe("ProjectExplorer interactions", () => {
         activeSurfaceMode: "buffer",
         activeFilePath: "lib/nested/app.ts",
         activeFileLine: 12,
+        attachments: [{
+          id: "file-range:lib/nested/app.ts:12-15",
+          kind: "file-range",
+          label: "lib/nested/app.ts:12-15",
+          path: "lib/nested/app.ts",
+          line: 12,
+          endLine: 15,
+        }],
+        composerAttachmentIds: ["file-range:lib/nested/app.ts:12-15"],
       });
     } finally {
       root.unmount();

--- a/runtime/tests/tui/workbench/reducer.test.ts
+++ b/runtime/tests/tui/workbench/reducer.test.ts
@@ -149,6 +149,60 @@ describe("workbenchReducer", () => {
     expect(second.composerAttachmentIds).toEqual(["file:README.md"]);
   });
 
+  it("renames active paths and attached context without touching sibling prefixes", () => {
+    const state = {
+      ...getDefaultWorkbenchState(),
+      activeFilePath: "src/nested/app.ts",
+      attachments: [
+        {
+          id: "file-range:src/nested/app.ts:12-15",
+          kind: "file-range" as const,
+          label: "src/nested/app.ts:12-15",
+          path: "src/nested/app.ts",
+          line: 12,
+          endLine: 15,
+        },
+        {
+          id: "file:src-old/app.ts",
+          kind: "file" as const,
+          label: "src-old/app.ts",
+          path: "src-old/app.ts",
+        },
+      ],
+      composerAttachmentIds: [
+        "file-range:src/nested/app.ts:12-15",
+        "file:src-old/app.ts",
+      ],
+    };
+    const next = workbenchReducer(state, {
+      type: "renamePathReferences",
+      fromPath: "src",
+      toPath: "lib",
+    });
+
+    expect(next.activeFilePath).toBe("lib/nested/app.ts");
+    expect(next.attachments).toEqual([
+      {
+        id: "file-range:lib/nested/app.ts:12-15",
+        kind: "file-range",
+        label: "lib/nested/app.ts:12-15",
+        path: "lib/nested/app.ts",
+        line: 12,
+        endLine: 15,
+      },
+      {
+        id: "file:src-old/app.ts",
+        kind: "file",
+        label: "src-old/app.ts",
+        path: "src-old/app.ts",
+      },
+    ]);
+    expect(next.composerAttachmentIds).toEqual([
+      "file-range:lib/nested/app.ts:12-15",
+      "file:src-old/app.ts",
+    ]);
+  });
+
   it("opens and closes non-transcript surfaces", () => {
     const diff = workbenchReducer(undefined, {
       type: "openDiff",


### PR DESCRIPTION
## Summary
- Remap workbench active file and attached context when an explorer rename moves a file or containing directory.
- Add mounted explorer coverage for stale attached context after `src -> lib` and reducer coverage for sibling-prefix safety.

## Test Plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/project-explorer-interactions.test.tsx tests/tui/workbench/reducer.test.ts --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (expected existing Knip backlog only)