### PR TITLE
fix(tui): clear deleted path references

### DIFF
--- a/runtime/src/tui/workbench/commands.ts
+++ b/runtime/src/tui/workbench/commands.ts
@@ -32,6 +32,10 @@ export function renamePathReferencesCommand(fromPath: string, toPath: string): W
   return { type: "renamePathReferences", fromPath, toPath };
 }
 
+export function deletePathReferencesCommand(path: string): WorkbenchCommand {
+  return { type: "deletePathReferences", path };
+}
+
 export function attachFileRangeCommand(
   path: string,
   line: number,

--- a/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
+++ b/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
@@ -11,7 +11,7 @@ import { useAppState } from "../../state/AppState.js";
 import TextInput from "../../components/TextInput.js";
 import { getGraphemeSegmenter } from "../../../utils/intl.js";
 import { inFlightPathsFromTasks } from "../agents/activity.js";
-import { attachFileCommand, openBufferCommand, renamePathReferencesCommand } from "../commands.js";
+import { attachFileCommand, deletePathReferencesCommand, openBufferCommand, renamePathReferencesCommand } from "../commands.js";
 import { useWorkbenchDispatch, useWorkbenchState } from "../state.js";
 import type { ProjectTreeRow } from "../types.js";
 import { getProjectTreeStore } from "./ProjectTreeStore.js";
@@ -125,6 +125,7 @@ export function ProjectExplorer({ focused, width }: Props): React.ReactElement {
       return;
     }
     setFileAction(null);
+    dispatch(deletePathReferencesCommand(action.path));
     if (pathContains(workbench.activeFilePath, action.path)) {
       dispatch({ type: "closeSurface" });
     }

--- a/runtime/src/tui/workbench/reducer.ts
+++ b/runtime/src/tui/workbench/reducer.ts
@@ -87,6 +87,8 @@ export function workbenchReducer(
       return openSurface(state, "transcript");
     case "renamePathReferences":
       return renamePathReferences(state, command.fromPath, command.toPath);
+    case "deletePathReferences":
+      return deletePathReferences(state, command.path);
     case "toggleExplorer":
       return {
         ...state,
@@ -216,6 +218,24 @@ function renamePathReferences(
   };
 }
 
+function deletePathReferences(
+  state: WorkbenchState,
+  deletedPath: string,
+): WorkbenchState {
+  const activeFileDeleted = containsWorkspacePath(state.activeFilePath, deletedPath);
+  const attachments = state.attachments.filter((attachment) =>
+    !containsWorkspacePath(attachment.path ?? null, deletedPath)
+  );
+  const attachmentIds = new Set(attachments.map((item) => item.id));
+  return {
+    ...state,
+    activeFilePath: activeFileDeleted ? null : state.activeFilePath,
+    activeFileLine: activeFileDeleted ? null : state.activeFileLine,
+    attachments,
+    composerAttachmentIds: state.composerAttachmentIds.filter((id) => attachmentIds.has(id)),
+  };
+}
+
 function renameAttachmentPath(
   attachment: WorkbenchAttachment,
   fromPath: string,
@@ -236,6 +256,10 @@ function renameWorkspacePath(value: string | null, fromPath: string, toPath: str
   if (value === fromPath) return toPath;
   if (value.startsWith(`${fromPath}/`)) return `${toPath}${value.slice(fromPath.length)}`;
   return value;
+}
+
+function containsWorkspacePath(value: string | null, targetPath: string): boolean {
+  return value === targetPath || Boolean(value?.startsWith(`${targetPath}/`));
 }
 
 function replaceFirst(value: string, needle: string, replacement: string): string {

--- a/runtime/src/tui/workbench/types.ts
+++ b/runtime/src/tui/workbench/types.ts
@@ -64,6 +64,7 @@ export type WorkbenchCommand =
   | { readonly type: "selectAgent"; readonly taskId: string | null }
   | { readonly type: "closeSurface" }
   | { readonly type: "renamePathReferences"; readonly fromPath: string; readonly toPath: string }
+  | { readonly type: "deletePathReferences"; readonly path: string }
   | { readonly type: "toggleExplorer"; readonly visible?: boolean }
   | { readonly type: "toggleAgents"; readonly visible?: boolean }
   | { readonly type: "attach"; readonly attachment: WorkbenchAttachment }

--- a/runtime/tests/tui/workbench/project-explorer-interactions.test.tsx
+++ b/runtime/tests/tui/workbench/project-explorer-interactions.test.tsx
@@ -8,6 +8,7 @@ const explorerHarness = vi.hoisted(() => {
     handlers: Record<string, () => void>;
     textInputProps: Array<Record<string, unknown>>;
     renameCalls: Array<readonly [string, string]>;
+    deleteCalls: string[];
     cursorRow: Record<string, unknown> | null;
     snapshot: Record<string, unknown>;
     store: Record<string, unknown>;
@@ -15,6 +16,7 @@ const explorerHarness = vi.hoisted(() => {
     handlers: {},
     textInputProps: [],
     renameCalls: [],
+    deleteCalls: [],
     cursorRow: {
       id: "src",
       path: "src",
@@ -88,7 +90,10 @@ const explorerHarness = vi.hoisted(() => {
       harness.renameCalls.push([from, to]);
       return { ok: true, path: to };
     },
-    deletePath: async (value: string) => ({ ok: true, path: value }),
+    deletePath: async (value: string) => {
+      harness.deleteCalls.push(value);
+      return { ok: true, path: value };
+    },
   };
   return harness;
 });
@@ -160,6 +165,7 @@ describe("ProjectExplorer interactions", () => {
     explorerHarness.handlers = {};
     explorerHarness.textInputProps = [];
     explorerHarness.renameCalls = [];
+    explorerHarness.deleteCalls = [];
   });
 
   it("updates the active buffer when renaming a directory that contains it", async () => {
@@ -223,6 +229,82 @@ describe("ProjectExplorer interactions", () => {
           endLine: 15,
         }],
         composerAttachmentIds: ["file-range:lib/nested/app.ts:12-15"],
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  it("clears active and attached references when deleting a directory that contains them", async () => {
+    const changes: AppState[] = [];
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              focusedPane: "explorer",
+              activeSurfaceMode: "buffer",
+              activeFilePath: "src/nested/app.ts",
+              activeFileLine: 12,
+              attachments: [
+                {
+                  id: "file-range:src/nested/app.ts:12-15",
+                  kind: "file-range",
+                  label: "src/nested/app.ts:12-15",
+                  path: "src/nested/app.ts",
+                  line: 12,
+                  endLine: 15,
+                },
+                {
+                  id: "file:src-old/app.ts",
+                  kind: "file",
+                  label: "src-old/app.ts",
+                  path: "src-old/app.ts",
+                },
+              ],
+              composerAttachmentIds: [
+                "file-range:src/nested/app.ts:12-15",
+                "file:src-old/app.ts",
+              ],
+            },
+          }}
+          onChangeAppState={({ newState }) => changes.push(newState)}
+        >
+          <ProjectExplorer focused={true} width={40} />
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      explorerHarness.handlers["explorer:delete"]?.();
+      await sleep();
+
+      explorerHarness.handlers["confirm:yes"]?.();
+      await sleep();
+
+      expect(explorerHarness.deleteCalls).toEqual(["src"]);
+      expect(changes.at(-1)?.workbench).toMatchObject({
+        focusedPane: "surface",
+        activeSurfaceMode: "transcript",
+        activeFilePath: null,
+        activeFileLine: null,
+        attachments: [{
+          id: "file:src-old/app.ts",
+          kind: "file",
+          label: "src-old/app.ts",
+          path: "src-old/app.ts",
+        }],
+        composerAttachmentIds: ["file:src-old/app.ts"],
       });
     } finally {
       root.unmount();

--- a/runtime/tests/tui/workbench/reducer.test.ts
+++ b/runtime/tests/tui/workbench/reducer.test.ts
@@ -203,6 +203,50 @@ describe("workbenchReducer", () => {
     ]);
   });
 
+  it("clears active paths and attached context when a workspace path is deleted", () => {
+    const state = {
+      ...getDefaultWorkbenchState(),
+      activeFilePath: "src/nested/app.ts",
+      activeFileLine: 12,
+      attachments: [
+        {
+          id: "file-range:src/nested/app.ts:12-15",
+          kind: "file-range" as const,
+          label: "src/nested/app.ts:12-15",
+          path: "src/nested/app.ts",
+          line: 12,
+          endLine: 15,
+        },
+        {
+          id: "file:src-old/app.ts",
+          kind: "file" as const,
+          label: "src-old/app.ts",
+          path: "src-old/app.ts",
+        },
+      ],
+      composerAttachmentIds: [
+        "file-range:src/nested/app.ts:12-15",
+        "file:src-old/app.ts",
+      ],
+    };
+    const next = workbenchReducer(state, {
+      type: "deletePathReferences",
+      path: "src",
+    });
+
+    expect(next.activeFilePath).toBeNull();
+    expect(next.activeFileLine).toBeNull();
+    expect(next.attachments).toEqual([
+      {
+        id: "file:src-old/app.ts",
+        kind: "file",
+        label: "src-old/app.ts",
+        path: "src-old/app.ts",
+      },
+    ]);
+    expect(next.composerAttachmentIds).toEqual(["file:src-old/app.ts"]);
+  });
+
   it("opens and closes non-transcript surfaces", () => {
     const diff = workbenchReducer(undefined, {
       type: "openDiff",


### PR DESCRIPTION
## Summary
- clear active file path and line when an explorer delete removes that file or a parent directory
- drop deleted path attachments from composer context while preserving sibling prefixes such as src-old
- cover the reducer command and mounted explorer delete confirmation flow

## Test plan
- npm --workspace=@tetsuo-ai/runtime run test -- tests/tui/workbench/reducer.test.ts tests/tui/workbench/project-explorer-interactions.test.tsx
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails only existing unrelated Knip backlog: src/tui/workbench/keymap.ts, 30 unused exports, 4 unused tag hints)