### PR TITLE
fix(tui): keep selected diff file visible

### DIFF
--- a/runtime/src/tui/workbench/surfaces/DiffSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/DiffSurface.tsx
@@ -16,6 +16,8 @@ import { useWorkbenchDispatch } from "../state.js";
 import { EmptySurface, SurfaceHeader } from "./PreviewSurface.js";
 import { clampSurfaceSelection } from "./selection.js";
 
+const FILE_LIST_LIMIT = 40;
+
 export function DiffSurface({
   focused,
   pendingApproval,
@@ -121,6 +123,7 @@ export function DiffSurfaceView({
   const files = snapshot.files ?? [];
   const selectedIndex = clampSurfaceSelection(selected, files.length);
   const selectedFile = files[selectedIndex] ?? files[0];
+  const visibleFiles = visibleFileWindow(files, selectedIndex, FILE_LIST_LIMIT);
   const acceptedCount = Object.values(decisions).filter((value) => value === "accept").length;
   const skippedCount = Object.values(decisions).filter((value) => value === "skip").length;
   return (
@@ -139,7 +142,7 @@ export function DiffSurfaceView({
       </Text>
       <Box flexDirection="row" flexGrow={1} overflow="hidden">
         <Box flexDirection="column" width={32} flexShrink={0} borderRight borderColor="gray" paddingRight={1}>
-          {files.slice(0, 40).map((file, index) => (
+          {visibleFiles.map(({ file, index }) => (
             <Text key={file.path} color={index === selectedIndex ? "suggestion" : undefined} wrap="truncate-end">
               {decisionMarker(decisions[file.path])}{statusMarker(file.status)} {file.path}
             </Text>
@@ -160,6 +163,25 @@ export function DiffSurfaceView({
       </Box>
     </Box>
   );
+}
+
+function visibleFileWindow(
+  files: readonly DiffMenuSnapshot["files"][number][],
+  selectedIndex: number,
+  limit: number,
+): Array<{ readonly file: DiffMenuSnapshot["files"][number]; readonly index: number }> {
+  const maxItems = Math.max(1, Math.floor(limit));
+  if (files.length <= maxItems) {
+    return files.map((file, index) => ({ file, index }));
+  }
+  const start = Math.min(
+    Math.max(0, selectedIndex - Math.floor(maxItems / 2)),
+    files.length - maxItems,
+  );
+  return files.slice(start, start + maxItems).map((file, offset) => ({
+    file,
+    index: start + offset,
+  }));
 }
 
 function errorMessage(error: unknown): string {

--- a/runtime/tests/tui/workbench/diff-surface.test.tsx
+++ b/runtime/tests/tui/workbench/diff-surface.test.tsx
@@ -111,6 +111,37 @@ describe("DiffSurface", () => {
     expect(output).toContain("src/new.ts - non-mutating review");
   });
 
+  it("keeps the selected changed file visible beyond the first file-list page", async () => {
+    const fileCount = 45;
+    const snapshot = createDiffMenuSnapshot({
+      rawDiff: Array.from({ length: fileCount }, (_, index) => [
+        `diff --git a/src/file-${index}.ts b/src/file-${index}.ts`,
+        "@@ -1 +1 @@",
+        `-old${index}`,
+        `+new${index}`,
+      ].join("\n")).join("\n"),
+      nameStatus: Array.from({ length: fileCount }, (_, index) => `M\tsrc/file-${index}.ts`).join("\n"),
+      numstat: Array.from({ length: fileCount }, (_, index) => `1\t1\tsrc/file-${index}.ts`).join("\n"),
+      untrackedFiles: [],
+    });
+    const selectedPath = snapshot.files.at(-1)?.path;
+
+    const output = await renderToString(
+      <DiffSurfaceView
+        snapshot={snapshot}
+        selected={fileCount - 1}
+        decisions={{}}
+        focused={true}
+        pendingApprovalRisk={null}
+      />,
+      { columns: 100, rows: 30 },
+    );
+
+    expect(selectedPath).toBeTruthy();
+    expect(compact(output)).toContain(`M${selectedPath}`);
+    expect(output).toContain(`${selectedPath} - non-mutating review`);
+  });
+
   it("keeps destructive pending approvals out of the diff accept shortcut", async () => {
     diffHarness.snapshot = createDiffMenuSnapshot({
       rawDiff: [


### PR DESCRIPTION
## Summary
- Keep the selected diff file visible in the left file list when navigating beyond the initial 40-row window.
- Add a regression covering long diff file lists where the selected preview and file list could diverge.

## Validation
- npm --workspace=@tetsuo-ai/runtime run test -- tests/tui/workbench/diff-surface.test.tsx
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (known unrelated Knip backlog: unused keymap file, 30 unused exports, 4 tag hints)
