### PR TITLE
fix(tui): cancel pending buffer loads on close

### DIFF
--- a/runtime/src/tui/workbench/buffer/BufferStore.ts
+++ b/runtime/src/tui/workbench/buffer/BufferStore.ts
@@ -178,6 +178,7 @@ export class WorkbenchBufferStore {
       this.#setProblem("conflict", "Unsaved edits. Save, revert, or close-discard before closing.", "disk");
       return false;
     }
+    this.#openGeneration += 1;
     if (this.#file) notifyBufferLspClosed(this.#file.absolutePath);
     this.#file = null;
     this.#document = null;

--- a/runtime/tests/tui/workbench/buffer-store.test.ts
+++ b/runtime/tests/tui/workbench/buffer-store.test.ts
@@ -104,6 +104,28 @@ describe("WorkbenchBufferStore", () => {
     expect(store.getSnapshot().dirty).toBe(false);
   });
 
+  it("ignores stale file loads after the buffer is closed", async () => {
+    await writeFile(join(dir, "target.txt"), "alpha\n", "utf8");
+    const store = new WorkbenchBufferStore();
+
+    const open = runWithCwdOverride(dir, () => store.open("target.txt"));
+    expect(store.getSnapshot().status).toBe("loading");
+
+    expect(store.close()).toBe(true);
+    expect(store.getSnapshot()).toMatchObject({
+      status: "idle",
+      filePath: null,
+    });
+
+    await open;
+
+    expect(store.getSnapshot()).toMatchObject({
+      status: "idle",
+      filePath: null,
+    });
+    expect(store.getText()).toBe("");
+  });
+
   it("opens the current file in the external editor and reloads after it exits", async () => {
     const file = join(dir, "target.txt");
     await writeFile(file, "alpha\nomega\n", "utf8");


### PR DESCRIPTION
## Summary
- Invalidate pending BUFFER file loads when the buffer is closed so a stale async read cannot repopulate the singleton store after close.
- Add a regression covering close-before-open-resolves behavior in `WorkbenchBufferStore`.

## Validation
- npm --workspace=@tetsuo-ai/runtime run test -- tests/tui/workbench/buffer-store.test.ts
- npm --workspace=@tetsuo-ai/runtime run test -- tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-surface.test.tsx
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (known unrelated Knip backlog: unused keymap file, 30 unused exports, 4 tag hints)
