### PR TITLE
fix(tui): report failed buffer definition jumps

### DIFF
--- a/runtime/src/tui/workbench/buffer/BufferStore.ts
+++ b/runtime/src/tui/workbench/buffer/BufferStore.ts
@@ -254,8 +254,7 @@ export class WorkbenchBufferStore {
       return false;
     }
 
-    await this.#load(file.absolutePath, line, true, file.filePath);
-    return true;
+    return this.#load(file.absolutePath, line, true, file.filePath);
   }
 
   insert(text: string): void {
@@ -376,8 +375,7 @@ export class WorkbenchBufferStore {
     const position = this.#lspPosition(document);
     const target = await requestBufferDefinition(file.absolutePath, position).catch(() => null);
     if (!target || this.#file !== file || this.#document !== document) return false;
-    await this.#load(target.path, target.line, false, displayPathForAbsolute(target.path));
-    return true;
+    return this.#load(target.path, target.line, false, displayPathForAbsolute(target.path));
   }
 
   #handleVimCommandLineInput(input: string, key: Key, onCommand?: BufferVimCommandHandler): boolean {
@@ -742,19 +740,20 @@ export class WorkbenchBufferStore {
     line: number,
     allowDirtyReplace: boolean,
     displayPath = filePath,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const absolutePath = resolve(getCwd(), filePath);
     if (this.#file?.absolutePath === absolutePath && !allowDirtyReplace) {
       if (this.#document) {
         this.#document = moveBufferCursorToLine(this.#document, line);
         this.#ensureCursorVisible();
         this.#emit();
+        return true;
       }
-      return;
+      return false;
     }
     if (this.#isDirty() && !allowDirtyReplace) {
       this.#setProblem("conflict", "Unsaved edits. Save, revert, or close-discard before opening another file.", "disk");
-      return;
+      return false;
     }
 
     const generation = ++this.#openGeneration;
@@ -773,7 +772,7 @@ export class WorkbenchBufferStore {
       const snapshot = await readBufferFileSnapshot(absolutePath, {
         displayPath,
       });
-      if (generation !== this.#openGeneration) return;
+      if (generation !== this.#openGeneration) return false;
       if (previousPath && previousPath !== snapshot.absolutePath) notifyBufferLspClosed(previousPath);
       this.#file = snapshot;
       this.#document = createBufferDocument(snapshot.content, line);
@@ -785,12 +784,14 @@ export class WorkbenchBufferStore {
       this.#ensureCursorVisible();
       notifyBufferLspOpened(snapshot.absolutePath, snapshot.content);
       this.#emit();
+      return true;
     } catch (error) {
-      if (generation !== this.#openGeneration) return;
+      if (generation !== this.#openGeneration) return false;
       this.#status = "error";
       this.#error = errorMessage(error);
       this.#conflictKind = null;
       this.#emit();
+      return false;
     }
   }
 

--- a/runtime/tests/tui/workbench/buffer-store.test.ts
+++ b/runtime/tests/tui/workbench/buffer-store.test.ts
@@ -208,6 +208,47 @@ describe("WorkbenchBufferStore", () => {
     expect(store.getText()).toBe("omega\n");
   });
 
+  it("reports failed definition navigation when unsaved edits block cross-file loads", async () => {
+    await writeFile(join(dir, "target.txt"), "alpha\n", "utf8");
+    await writeFile(join(dir, "definition.txt"), "definition\n", "utf8");
+    lspHarness.requestBufferDefinition.mockResolvedValue({
+      path: join(dir, "definition.txt"),
+      line: 1,
+      character: 0,
+    });
+    const store = new WorkbenchBufferStore();
+
+    await runWithCwdOverride(dir, () => store.open("target.txt"));
+    store.insert("draft ");
+
+    await expect(store.goToDefinition()).resolves.toBe(false);
+    expect(store.getSnapshot()).toMatchObject({
+      status: "conflict",
+      conflictKind: "disk",
+      filePath: "target.txt",
+      dirty: true,
+    });
+    expect(store.getText()).toBe("draft alpha\n");
+  });
+
+  it("reports failed definition navigation when the target cannot be loaded", async () => {
+    await writeFile(join(dir, "target.txt"), "alpha\n", "utf8");
+    lspHarness.requestBufferDefinition.mockResolvedValue({
+      path: join(dir, "missing.txt"),
+      line: 1,
+      character: 0,
+    });
+    const store = new WorkbenchBufferStore();
+
+    await runWithCwdOverride(dir, () => store.open("target.txt"));
+
+    await expect(store.goToDefinition()).resolves.toBe(false);
+    expect(store.getSnapshot()).toMatchObject({
+      status: "error",
+      filePath: null,
+    });
+  });
+
   it("ignores stale LSP responses after moving within the same file", async () => {
     await writeFile(join(dir, "target.txt"), "alpha\nomega\n", "utf8");
     await writeFile(join(dir, "definition.txt"), "definition\n", "utf8");


### PR DESCRIPTION
## Summary
- Return the actual buffer load result from definition navigation and external editor handoff paths.
- Keep definition navigation on the current dirty buffer when unsaved edits block a cross-file jump.
- Cover missing definition targets so failed file loads report `false` instead of success.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime run test -- tests/tui/workbench/buffer-store.test.ts`
- `npm --workspace=@tetsuo-ai/runtime run test -- tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-lsp.test.ts tests/tui/workbench/buffer-surface.test.tsx`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` (expected existing Knip backlog: unused `src/tui/workbench/keymap.ts`, 30 unused exports, 4 unused tag hints)