### PR TITLE
fix(tui): show buffer diagnostics across ranges

### DIFF
--- a/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
@@ -2,6 +2,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 import { peekLSPDiagnosticsForFile } from "../../../services/lsp/LSPDiagnosticRegistry.js";
+import type { DiagnosticEntry } from "../../../services/lsp/types.js";
 import { useTerminalSize } from "../../hooks/useTerminalSize.js";
 import { Box, Text } from "../../ink.js";
 import { useRegisterKeybindingContext } from "../../keybindings/KeybindingContext.js";
@@ -43,7 +44,7 @@ export function BufferSurface({ focused }: { readonly focused: boolean }): React
   const visibleLines = store.getVisibleLines();
   const highlightedLines = useBufferHighlightedLines(snapshot.filePath ?? activePath, visibleLines);
   const currentLineDiagnostic = diagnostics.find(
-    (diagnostic) => (diagnostic.range?.start.line ?? -1) + 1 === snapshot.position.line,
+    (diagnostic) => diagnosticCoversLine(diagnostic, snapshot.position.line),
   );
 
   useEffect(() => {
@@ -182,6 +183,18 @@ function bufferStatusLabel(snapshot: ReturnType<typeof useBufferStore>, hasInFli
 
 function oneLine(value: string): string {
   return value.replace(/\s+/gu, " ").trim();
+}
+
+function diagnosticCoversLine(diagnostic: DiagnosticEntry, line: number): boolean {
+  const range = diagnostic.range;
+  if (!range) return false;
+  const targetLine = line - 1;
+  const startLine = range.start.line;
+  const endLine =
+    range.end.line > startLine && range.end.character === 0
+      ? range.end.line - 1
+      : range.end.line;
+  return targetLine >= startLine && targetLine <= endLine;
 }
 
 function useBufferHighlightedLines(

--- a/runtime/tests/tui/workbench/buffer-surface.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface.test.tsx
@@ -7,6 +7,10 @@ import React from "react";
 import stripAnsi from "strip-ansi";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import {
+  registerPendingLSPDiagnostic,
+  resetAllLSPDiagnosticState,
+} from "../../../src/services/lsp/LSPDiagnosticRegistry.js";
 import { runWithCwdOverride } from "../../../src/utils/cwd.js";
 import { createRoot, useInput } from "../../../src/tui/ink.js";
 import { KeybindingSetup } from "../../../src/tui/keybindings/KeybindingProviderSetup.js";
@@ -69,6 +73,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  resetAllLSPDiagnosticState();
   resetWorkbenchBufferStoreForTesting();
   await rm(dir, { recursive: true, force: true });
 });
@@ -162,6 +167,62 @@ describe("BufferSurface", () => {
       expect(frame).toContain("target.ts");
       expect(frame).not.toContain("agent edit in flight");
       expect(frame).not.toMatch(/\bagent\b/u);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  it("shows diagnostics that span the current buffer line", async () => {
+    const filePath = join(dir, "target.ts");
+    await writeFile(filePath, "function value() {\n  return 1;\n}\n", "utf8");
+    registerPendingLSPDiagnostic({
+      serverName: "ts",
+      files: [{
+        uri: filePath,
+        diagnostics: [{
+          message: "spans block",
+          severity: "Error",
+          range: {
+            start: { line: 0, character: 0 },
+            end: { line: 2, character: 1 },
+          },
+        }],
+      }],
+    });
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      await runWithCwdOverride(dir, async () => {
+        root.render(
+          <AppStateProvider
+            initialState={{
+              ...getDefaultAppState(),
+              workbench: {
+                ...getDefaultAppState().workbench,
+                activeSurfaceMode: "buffer",
+                activeFilePath: "target.ts",
+                activeFileLine: 2,
+              },
+            }}
+          >
+            <KeybindingSetup>
+              <BufferSurface focused={false} />
+            </KeybindingSetup>
+          </AppStateProvider>,
+        );
+        await sleep();
+      });
+
+      const frame = output();
+      expect(frame).toMatch(/1\s*diagnostic/u);
+      expect(frame).toMatch(/spans\s*block/u);
     } finally {
       root.unmount();
       stdin.end();


### PR DESCRIPTION
## Summary
- Treat LSP diagnostics as covering their full range when deciding whether BUFFER is on the current diagnostic line.
- Preserve LSP's exclusive end-line behavior for ranges that end at character 0 on a later line.
- Add a mounted BUFFER regression for diagnostics that span the cursor line.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime run test -- tests/tui/workbench/buffer-surface.test.tsx`
- `npm --workspace=@tetsuo-ai/runtime run test -- tests/tui/workbench/buffer-surface.test.tsx tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-lsp.test.ts tests/tui/workbench/preview-surface.test.tsx tests/services/lsp/LSPDiagnosticRegistry.test.ts`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` (expected existing Knip backlog: unused `src/tui/workbench/keymap.ts`, 30 unused exports, 4 unused tag hints)