### PR TITLE
fix(tui): retry buffer active path after save

### DIFF
--- a/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { peekLSPDiagnosticsForFile } from "../../../services/lsp/LSPDiagnosticRegistry.js";
 import type { DiagnosticEntry } from "../../../services/lsp/types.js";
@@ -30,6 +30,8 @@ export function BufferSurface({ focused }: { readonly focused: boolean }): React
   const { rows, columns } = useTerminalSize();
   const tasks = useAppState((state) => state.tasks);
   const activePath = workbench.activeFilePath;
+  const activeLine = workbench.activeFileLine ?? 1;
+  const lastOpenRequest = useRef<string | null>(null);
   const inFlightAgent = useMemo(
     () => Object.values(tasks).find((task) =>
       task.type !== "local_bash" &&
@@ -48,10 +50,18 @@ export function BufferSurface({ focused }: { readonly focused: boolean }): React
   );
 
   useEffect(() => {
-    if (activePath) {
-      void store.open(activePath, workbench.activeFileLine ?? 1);
-    }
-  }, [activePath, store, workbench.activeFileLine]);
+    if (!activePath) return;
+    const requestKey = `${activePath}\u0000${activeLine}`;
+    const isNewRequest = lastOpenRequest.current !== requestKey;
+    const shouldRetryCleanBlockedPath =
+      snapshot.status !== "loading" &&
+      snapshot.filePath !== null &&
+      snapshot.filePath !== activePath &&
+      !snapshot.dirty;
+    if (!isNewRequest && !shouldRetryCleanBlockedPath) return;
+    lastOpenRequest.current = requestKey;
+    void store.open(activePath, activeLine);
+  }, [activeLine, activePath, snapshot.dirty, snapshot.filePath, snapshot.status, store]);
 
   useEffect(() => {
     store.setViewportRows(Math.max(1, rows - 9));

--- a/runtime/tests/tui/workbench/buffer-surface.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface.test.tsx
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { PassThrough } from "node:stream";
@@ -19,6 +19,7 @@ import {
   getWorkbenchBufferStore,
   resetWorkbenchBufferStoreForTesting,
 } from "../../../src/tui/workbench/buffer/BufferStore.js";
+import { useWorkbenchDispatch } from "../../../src/tui/workbench/state.js";
 import { BufferSurface } from "../../../src/tui/workbench/surfaces/BufferSurface.js";
 
 type TestStdin = PassThrough & {
@@ -63,6 +64,14 @@ function LeakyInput({ leaked }: { readonly leaked: string[] }): null {
   useInput((input) => {
     leaked.push(input);
   });
+  return null;
+}
+
+function OpenBufferRequest({ path }: { readonly path: string | null }): null {
+  const dispatch = useWorkbenchDispatch();
+  React.useEffect(() => {
+    if (path) dispatch({ type: "openBuffer", path, line: 1, focus: true });
+  }, [dispatch, path]);
   return null;
 }
 
@@ -223,6 +232,78 @@ describe("BufferSurface", () => {
       const frame = output();
       expect(frame).toMatch(/1\s*diagnostic/u);
       expect(frame).toMatch(/spans\s*block/u);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  it("opens the active file after saving a dirty-buffer conflict", async () => {
+    await writeFile(join(dir, "first.ts"), "first\n", "utf8");
+    await writeFile(join(dir, "second.ts"), "second\n", "utf8");
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    function App({ requestedPath }: { readonly requestedPath: string | null }): React.ReactElement {
+      return (
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "buffer",
+              activeFilePath: "first.ts",
+              activeFileLine: 1,
+            },
+          }}
+        >
+          <KeybindingSetup>
+            <OpenBufferRequest path={requestedPath} />
+            <BufferSurface focused={true} />
+          </KeybindingSetup>
+        </AppStateProvider>
+      );
+    }
+
+    try {
+      await runWithCwdOverride(dir, async () => {
+        root.render(<App requestedPath={null} />);
+        await sleep();
+
+        const store = getWorkbenchBufferStore();
+        expect(store.getSnapshot().filePath).toBe("first.ts");
+        store.insert("draft ");
+        expect(store.getSnapshot()).toMatchObject({
+          filePath: "first.ts",
+          dirty: true,
+        });
+
+        root.render(<App requestedPath="second.ts" />);
+        await sleep();
+
+        expect(store.getSnapshot()).toMatchObject({
+          status: "conflict",
+          conflictKind: "disk",
+          filePath: "first.ts",
+          dirty: true,
+        });
+
+        await expect(store.save()).resolves.toBe(true);
+        await sleep();
+
+        expect(await readFile(join(dir, "first.ts"), "utf8")).toBe("draft first\n");
+        expect(store.getSnapshot()).toMatchObject({
+          status: "ready",
+          filePath: "second.ts",
+          dirty: false,
+        });
+        expect(store.getText()).toBe("second\n");
+      });
     } finally {
       root.unmount();
       stdin.end();


### PR DESCRIPTION
## Summary
- Track the requested BUFFER active path/line so a dirty-open conflict can be retried after the buffer becomes clean.
- Avoid re-opening on ordinary dirty edits while still preserving explicit active-line requests.
- Add a mounted regression covering file A dirty, request file B, save file A, then open file B.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime run test -- tests/tui/workbench/buffer-surface.test.tsx`
- `npm --workspace=@tetsuo-ai/runtime run test -- tests/tui/workbench/buffer-surface.test.tsx tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-lsp.test.ts tests/tui/workbench/reducer.test.ts tests/tui/workbench/preview-surface.test.tsx`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` (expected existing Knip backlog: unused `src/tui/workbench/keymap.ts`, 30 unused exports, 4 unused tag hints)