### PR TITLE
fix(tui): open external editor from buffer enter

### DIFF
--- a/runtime/src/tui/workbench/buffer/BufferStore.ts
+++ b/runtime/src/tui/workbench/buffer/BufferStore.ts
@@ -316,9 +316,13 @@ export class WorkbenchBufferStore {
       return true;
     }
 
+    if (key.return || input === "\r" || input === "\n") {
+      return false;
+    }
+
     const vimInput = normalizeVimNormalInput(input, key);
     if (vimInput === null) {
-      return key.return || key.tab || input.length > 0;
+      return key.tab || input.length > 0;
     }
 
     const session = this.#createVimEditSession(columns);

--- a/runtime/tests/tui/workbench/buffer-store.test.ts
+++ b/runtime/tests/tui/workbench/buffer-store.test.ts
@@ -336,6 +336,24 @@ describe("WorkbenchBufferStore", () => {
     expect(store.getText()).toBe("omega\n");
   });
 
+  it("lets normal-mode enter fall through to the buffer keybinding", async () => {
+    const file = join(dir, "target.txt");
+    await writeFile(file, "alpha\nomega\n", "utf8");
+    const store = new WorkbenchBufferStore();
+
+    await runWithCwdOverride(dir, () => store.open("target.txt"));
+
+    expect(store.getSnapshot().vimMode).toBe("NORMAL");
+    expect(store.handleVimInput("", key({ return: true }), 80)).toBe(false);
+    expect(store.getText()).toBe("alpha\nomega\n");
+    expect(store.getSnapshot().vimMode).toBe("NORMAL");
+
+    store.handleVimInput("i", key(), 80);
+    expect(store.handleVimInput("", key({ return: true }), 80)).toBe(true);
+    expect(store.getText()).toBe("\nalpha\nomega\n");
+    expect(store.getSnapshot().vimMode).toBe("INSERT");
+  });
+
   it("supports visual selection yank, delete, change, and paste", async () => {
     const file = join(dir, "target.txt");
     await writeFile(file, "abcdef\nomega\n", "utf8");

--- a/runtime/tests/tui/workbench/buffer-surface.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface.test.tsx
@@ -5,7 +5,7 @@ import { PassThrough } from "node:stream";
 
 import React from "react";
 import stripAnsi from "strip-ansi";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   registerPendingLSPDiagnostic,
@@ -356,6 +356,56 @@ describe("BufferSurface", () => {
       expect(getWorkbenchBufferStore().getText()).toBe("qconst value = 1;\n");
       expect(getWorkbenchBufferStore().getSnapshot().vimMode).toBe("INSERT");
       expect(leaked).toEqual([]);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  it("opens the external editor when enter is pressed in normal mode", async () => {
+    await writeFile(join(dir, "target.ts"), "const value = 1;\n", "utf8");
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      await runWithCwdOverride(dir, async () => {
+        root.render(
+          <AppStateProvider
+            initialState={{
+              ...getDefaultAppState(),
+              workbench: {
+                ...getDefaultAppState().workbench,
+                activeSurfaceMode: "buffer",
+                activeFilePath: "target.ts",
+                activeFileLine: 1,
+              },
+            }}
+          >
+            <KeybindingSetup>
+              <BufferSurface focused={true} />
+            </KeybindingSetup>
+          </AppStateProvider>,
+        );
+        await sleep();
+      });
+
+      const store = getWorkbenchBufferStore();
+      expect(store.getSnapshot().vimMode).toBe("NORMAL");
+      const openExternalEditor = vi
+        .spyOn(store, "openExternalEditor")
+        .mockResolvedValue(true);
+
+      stdin.write("\r");
+      await sleep();
+
+      expect(openExternalEditor).toHaveBeenCalledTimes(1);
+      expect(store.getText()).toBe("const value = 1;\n");
+      expect(store.getSnapshot().dirty).toBe(false);
     } finally {
       root.unmount();
       stdin.end();


### PR DESCRIPTION
## Summary
- Let focused BUFFER normal-mode Enter fall through to the configured external-editor keybinding.
- Add direct store coverage for normal-mode Enter fallthrough while preserving Insert-mode newline behavior.
- Add mounted BufferSurface regression coverage for Enter invoking the external-editor action.

## Test plan
- npm --workspace=@tetsuo-ai/runtime run test -- tests/tui/workbench/buffer-surface.test.tsx tests/tui/workbench/buffer-store.test.ts
- npm --workspace=@tetsuo-ai/runtime run test -- tests/tui/workbench/buffer-surface.test.tsx tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-lsp.test.ts tests/tui/workbench/reducer.test.ts tests/tui/workbench/preview-surface.test.tsx tests/tui/keybindings/KeybindingProviderSetup.test.tsx tests/tui/workbench/keybindings.test.ts
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails only known unrelated Knip backlog: src/tui/workbench/keymap.ts, 30 unused exports, 4 unused tag hints)