### PR TITLE
fix(tui): preserve buffer shift selection

### DIFF
--- a/runtime/src/tui/workbench/buffer/BufferStore.ts
+++ b/runtime/src/tui/workbench/buffer/BufferStore.ts
@@ -319,6 +319,9 @@ export class WorkbenchBufferStore {
     if (key.return || input === "\r" || input === "\n") {
       return false;
     }
+    if (isShiftSelectionNavigationKey(key)) {
+      return false;
+    }
 
     const vimInput = normalizeVimNormalInput(input, key);
     if (vimInput === null) {
@@ -940,6 +943,10 @@ function parseVimCommand(rawCommand: string): BufferVimCommand | null {
 
 function isNavigationKey(key: Key): boolean {
   return key.upArrow || key.downArrow || key.leftArrow || key.rightArrow || key.pageUp || key.pageDown || key.home || key.end;
+}
+
+function isShiftSelectionNavigationKey(key: Key): boolean {
+  return key.shift && (key.upArrow || key.downArrow || key.leftArrow || key.rightArrow || key.home || key.end);
 }
 
 function removeLastGrapheme(value: string): string {

--- a/runtime/tests/tui/workbench/buffer-store.test.ts
+++ b/runtime/tests/tui/workbench/buffer-store.test.ts
@@ -354,6 +354,21 @@ describe("WorkbenchBufferStore", () => {
     expect(store.getSnapshot().vimMode).toBe("INSERT");
   });
 
+  it("lets normal-mode shifted arrows fall through to selection keybindings", async () => {
+    const file = join(dir, "target.txt");
+    await writeFile(file, "alpha\nomega\n", "utf8");
+    const store = new WorkbenchBufferStore();
+
+    await runWithCwdOverride(dir, () => store.open("target.txt"));
+
+    expect(store.getSnapshot().vimMode).toBe("NORMAL");
+    expect(store.handleVimInput("", key({ shift: true, rightArrow: true }), 80)).toBe(false);
+    expect(store.getSnapshot().selection).toEqual({ anchor: 0, head: 0 });
+
+    expect(store.handleVimInput("", key({ rightArrow: true }), 80)).toBe(true);
+    expect(store.getSnapshot().selection).toEqual({ anchor: 1, head: 1 });
+  });
+
   it("supports visual selection yank, delete, change, and paste", async () => {
     const file = join(dir, "target.txt");
     await writeFile(file, "abcdef\nomega\n", "utf8");

--- a/runtime/tests/tui/workbench/buffer-surface.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface.test.tsx
@@ -412,4 +412,49 @@ describe("BufferSurface", () => {
       stdout.end();
     }
   });
+
+  it("extends the buffer selection with shifted arrow keybindings", async () => {
+    await writeFile(join(dir, "target.ts"), "const value = 1;\n", "utf8");
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      await runWithCwdOverride(dir, async () => {
+        root.render(
+          <AppStateProvider
+            initialState={{
+              ...getDefaultAppState(),
+              workbench: {
+                ...getDefaultAppState().workbench,
+                activeSurfaceMode: "buffer",
+                activeFilePath: "target.ts",
+                activeFileLine: 1,
+              },
+            }}
+          >
+            <KeybindingSetup>
+              <BufferSurface focused={true} />
+            </KeybindingSetup>
+          </AppStateProvider>,
+        );
+        await sleep();
+      });
+
+      const store = getWorkbenchBufferStore();
+      expect(store.getSnapshot().vimMode).toBe("NORMAL");
+      stdin.write("\x1b[1;2C");
+      await sleep();
+
+      expect(store.getSnapshot().selection).toEqual({ anchor: 0, head: 1 });
+      expect(store.getSnapshot().position.column).toBe(1);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Let normal-mode shifted navigation fall through to BUFFER selection keybindings instead of being consumed as plain Vim movement.
- Add store coverage proving Shift+Right is not consumed by normal-mode Vim input while plain Right still moves normally.
- Add mounted BufferSurface regression coverage for Shift+Right extending the buffer selection.

## Test plan
- npm --workspace=@tetsuo-ai/runtime run test -- tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-surface.test.tsx
- npm --workspace=@tetsuo-ai/runtime run test -- tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-surface.test.tsx tests/tui/workbench/keybindings.test.ts tests/tui/keybindings/KeybindingProviderSetup.test.tsx tests/tui/keybindings/match.wave200-083.coverage.test.ts tests/tui/ink/parse-keypress.test.ts
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails only known unrelated Knip backlog: src/tui/workbench/keymap.ts, 30 unused exports, 4 unused tag hints)