### PR TITLE
fix(tui): preserve manual search selection

### DIFF
--- a/runtime/src/tui/workbench/reducer.ts
+++ b/runtime/src/tui/workbench/reducer.ts
@@ -57,11 +57,16 @@ export function workbenchReducer(
       const nextSearchQuery = command.query ?? state.searchQuery;
       const searchQueryChanged =
         command.query !== undefined && command.query !== state.searchQuery;
+      let nextSelectedSearchMatchId = state.selectedSearchMatchId;
+      if (command.selectedMatchId !== undefined) {
+        nextSelectedSearchMatchId = command.selectedMatchId;
+      } else if (searchQueryChanged) {
+        nextSelectedSearchMatchId = null;
+      }
       return {
         ...openSurface(state, "search"),
         searchQuery: nextSearchQuery,
-        selectedSearchMatchId:
-          command.selectedMatchId ?? (searchQueryChanged ? null : state.selectedSearchMatchId),
+        selectedSearchMatchId: nextSelectedSearchMatchId,
       };
     case "openDiff":
       return {

--- a/runtime/src/tui/workbench/surfaces/SearchSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/SearchSurface.tsx
@@ -21,11 +21,13 @@ export function SearchSurface({ focused }: { readonly focused: boolean }): React
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const appliedSelectedMatchIdRef = useRef<string | null>(null);
   const query = workbench.searchQuery;
   const selectedMatchId = workbench.selectedSearchMatchId;
 
   useEffect(() => {
     abortRef.current?.abort();
+    appliedSelectedMatchIdRef.current = null;
     setSelected(0);
     setMatches([]);
     if (!query.trim()) {
@@ -71,9 +73,16 @@ export function SearchSurface({ focused }: { readonly focused: boolean }): React
   }, [query]);
 
   useEffect(() => {
-    if (!selectedMatchId) return;
+    if (!selectedMatchId) {
+      appliedSelectedMatchIdRef.current = null;
+      return;
+    }
+    if (appliedSelectedMatchIdRef.current === selectedMatchId) return;
     const index = matches.findIndex((match) => match.id === selectedMatchId);
-    if (index >= 0) setSelected(index);
+    if (index >= 0) {
+      appliedSelectedMatchIdRef.current = selectedMatchId;
+      setSelected(index);
+    }
   }, [matches, selectedMatchId]);
 
   const selectedIndex = clampSurfaceSelection(selected, matches.length);

--- a/runtime/tests/tui/workbench/reducer.test.ts
+++ b/runtime/tests/tui/workbench/reducer.test.ts
@@ -288,12 +288,20 @@ describe("workbenchReducer", () => {
       type: "openSearch",
       query: "other",
     });
+    const explicitClear = workbenchReducer(first, {
+      type: "openSearch",
+      selectedMatchId: null,
+    });
     const reopened = workbenchReducer(second, {
       type: "openSearch",
     });
 
     expect(second).toMatchObject({
       searchQuery: "other",
+      selectedSearchMatchId: null,
+    });
+    expect(explicitClear).toMatchObject({
+      searchQuery: "needle",
       selectedSearchMatchId: null,
     });
     expect(reopened).toMatchObject({

--- a/runtime/tests/tui/workbench/search-surface.test.tsx
+++ b/runtime/tests/tui/workbench/search-surface.test.tsx
@@ -247,6 +247,71 @@ describe("SearchSurface", () => {
     }
   });
 
+  it("does not restore the requested search match after manual navigation during streaming", async () => {
+    searchHarness.autoFlush = false;
+    const changes: AppState[] = [];
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "search",
+              searchQuery: "needle",
+              selectedSearchMatchId: "src/second.ts:9:needle()",
+            },
+          }}
+          onChangeAppState={({ newState }) => changes.push(newState)}
+        >
+          <SearchSurface focused={false} />
+        </AppStateProvider>,
+      );
+      await sleep(180);
+
+      expect(searchHarness.calls).toHaveLength(1);
+      const call = searchHarness.calls[0]!;
+      call.onLines([
+        "src/first.ts:4:const needle = true",
+        "src/second.ts:9:needle()",
+        "src/third.ts:10:needle again",
+      ]);
+      await sleep();
+
+      searchHarness.handlers["surface:down"]?.();
+      searchHarness.handlers["surface:down"]?.();
+      await sleep();
+      searchHarness.handlers["surface:open"]?.();
+
+      expect(changes.at(-1)?.workbench).toMatchObject({
+        activeSurfaceMode: "buffer",
+        activeFilePath: "src/third.ts",
+        activeFileLine: 10,
+      });
+
+      call.onLines(["src/fourth.ts:11:needle later"]);
+      await sleep(50);
+      searchHarness.handlers["surface:open"]?.();
+
+      expect(changes.at(-1)?.workbench).toMatchObject({
+        activeSurfaceMode: "buffer",
+        activeFilePath: "src/third.ts",
+        activeFileLine: 10,
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
   it("ignores line batches from an aborted search stream", async () => {
     searchHarness.autoFlush = false;
     let setSearchQuery: ((query: string) => void) | null = null;


### PR DESCRIPTION
## Summary
- apply requested Search match ids only once per query/id so streaming result batches do not override manual navigation
- honor explicit `selectedMatchId: null` in the workbench reducer
- add mounted Search surface and reducer regressions for the selection paths

## Test plan
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/search-surface.test.tsx tests/tui/workbench/reducer.test.ts --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench --reporter=dot`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` *(known unrelated Knip backlog: `src/tui/workbench/keymap.ts`, 30 unused exports, 4 unused tag hints)*