### PR TITLE
fix(tui): clear empty project tree cursor

### DIFF
--- a/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
+++ b/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
@@ -342,7 +342,7 @@ function selectableRows(rows: readonly ProjectTreeRow[]): readonly ProjectTreeRo
 
 function visibleCursorPath(cursorPath: string | null, rows: readonly ProjectTreeRow[]): string | null {
   const selectable = selectableRows(rows);
-  if (selectable.length === 0) return cursorPath;
+  if (selectable.length === 0) return null;
   if (cursorPath && selectable.some((row) => row.path === cursorPath)) return cursorPath;
 
   let parent = cursorPath ? parentPath(cursorPath) : null;

--- a/runtime/tests/tui/workbench/project-tree.test.ts
+++ b/runtime/tests/tui/workbench/project-tree.test.ts
@@ -255,4 +255,26 @@ describe("project tree helpers", () => {
       await rm(repo, { recursive: true, force: true });
     }
   });
+
+  it("clears the cursor when deleting the last selectable workspace path", async () => {
+    const repo = await mkdtemp(join(tmpdir(), "agenc-tree-delete-empty-"));
+    const store = new ProjectTreeStore(repo, 0);
+
+    try {
+      await writeFile(join(repo, "gone.ts"), "gone\n", "utf8");
+      await store.refresh();
+
+      expect(store.getCursorPath()).toBe("gone.ts");
+
+      await expect(store.deletePath("gone.ts")).resolves.toEqual({ ok: true, path: "gone.ts" });
+
+      const selectableRows = store.getSnapshot().rows.filter((row) => row.kind === "file" || row.kind === "directory");
+      expect(selectableRows).toHaveLength(0);
+      expect(store.getCursorPath()).toBeNull();
+      expect(store.getSnapshot().cursorPath).toBeNull();
+    } finally {
+      store.dispose();
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- clear project tree cursor state when the workspace has no selectable rows
- add a regression for deleting the last selectable workspace path

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/project-tree.test.ts tests/tui/workbench/project-explorer-interactions.test.tsx --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (known unrelated Knip backlog: src/tui/workbench/keymap.ts, 30 unused exports, 4 unused @internal tag hints)