### PR TITLE
fix(tui): advance focus from hidden panes

### DIFF
--- a/runtime/src/tui/workbench/reducer.ts
+++ b/runtime/src/tui/workbench/reducer.ts
@@ -176,7 +176,7 @@ function focusNextPane(
   visiblePanes: readonly WorkbenchPane[],
 ): WorkbenchState {
   const panes = visiblePanes.length > 0 ? visiblePanes : (["surface", "composer"] as const);
-  const current = panes.indexOf(state.focusedPane);
+  const current = panes.indexOf(visibleWorkbenchPane(state));
   const next = panes[(current + 1 + panes.length) % panes.length] ?? "surface";
   return { ...state, focusedPane: next };
 }

--- a/runtime/tests/tui/workbench/reducer.test.ts
+++ b/runtime/tests/tui/workbench/reducer.test.ts
@@ -93,6 +93,24 @@ describe("workbenchReducer", () => {
     expect(composer.focusedPane).toBe("composer");
   });
 
+  it.each([
+    ["explorer" as const, { explorerVisible: false }],
+    ["agents" as const, { agentsVisible: false }],
+  ])("cycles from the visible fallback pane when hidden %s focus is stale", (focusedPane, visibility) => {
+    const hiddenSidePaneFocus = {
+      ...getDefaultWorkbenchState(),
+      focusedPane,
+      ...visibility,
+    };
+    const next = workbenchReducer(hiddenSidePaneFocus, {
+      type: "focusNext",
+      visiblePanes: ["surface", "composer"],
+    });
+
+    expect(visibleWorkbenchPane(hiddenSidePaneFocus)).toBe("surface");
+    expect(next.focusedPane).toBe("composer");
+  });
+
   it("falls back to the surface when hidden panes have stale focus", () => {
     expect(visibleWorkbenchPane({
       ...getDefaultWorkbenchState(),


### PR DESCRIPTION
## Summary
- make workbench focus cycling use the same visible fallback pane as rendering
- add reducer regressions for stale hidden explorer and agents focus

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/reducer.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (known unrelated Knip backlog: src/tui/workbench/keymap.ts, 30 unused exports, 4 unused @internal tag hints)