### PR TITLE
fix(tui): correct test surface footer hints

### DIFF
--- a/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
@@ -70,8 +70,8 @@ export const WORKBENCH_SURFACES: readonly WorkbenchSurfaceDescriptor[] = [
   {
     mode: "test",
     title: () => "TEST",
-    keybindings: ["j", "k", "g", "@", "q"],
-    footerHints: "Test: j/k failure  g edit  @ attach  q close",
+    keybindings: ["j", "k", "enter", "o", "@", "q"],
+    footerHints: "Test: j/k failure  enter edit  o keep focus  @ attach  q close",
     renderBody: ({ focused }) => <TestSurface focused={focused} />,
   },
   {

--- a/runtime/tests/tui/workbench/keybindings.test.ts
+++ b/runtime/tests/tui/workbench/keybindings.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_BINDINGS } from "../../../src/tui/keybindings/defaultBindings.js";
 import { KEYBINDING_ACTION_NAMES, KEYBINDING_CONTEXT_NAMES } from "../../../src/tui/keybindings/types.js";
 import { WORKBENCH_ACTIONS, WORKBENCH_CONTEXTS } from "../../../src/tui/workbench/keymap.js";
+import { descriptorForSurface } from "../../../src/tui/workbench/surfaces/ActiveWorkSurface.js";
 
 describe("workbench keybinding contract", () => {
   it("registers every workbench context and action with the global keybinding schema", () => {
@@ -58,5 +59,16 @@ describe("workbench keybinding contract", () => {
     expect(byContext.get("Confirmation")).toMatchObject({
       d: "workbench:openDiff",
     });
+  });
+
+  it("keeps TEST surface footer hints aligned with surface navigation bindings", () => {
+    const surfaceBindings = new Map(Object.entries(DEFAULT_BINDINGS.find((block) => block.context === "Surface")?.bindings ?? {}));
+    const testSurface = descriptorForSurface("test");
+
+    expect(surfaceBindings.get("g")).toBe("surface:top");
+    expect(surfaceBindings.get("enter")).toBe("surface:open");
+    expect(testSurface.footerHints).toContain("enter edit");
+    expect(testSurface.footerHints).toContain("o keep focus");
+    expect(testSurface.footerHints).not.toContain("g edit");
   });
 });


### PR DESCRIPTION
## Summary
- align TEST surface footer hints with the actual edit bindings
- add a keybinding contract regression so TEST no longer advertises `g edit` while `g` navigates to the first failure

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/keybindings.test.ts tests/tui/workbench/render.test.tsx tests/tui/workbench/test-surface.test.tsx --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (known unrelated Knip backlog: src/tui/workbench/keymap.ts, 30 unused exports, 4 unused @internal tag hints)