### PR TITLE
fix(tui): expose search edit shortcut metadata

### DIFF
--- a/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
@@ -77,7 +77,7 @@ export const WORKBENCH_SURFACES: readonly WorkbenchSurfaceDescriptor[] = [
   {
     mode: "search",
     title: () => "SEARCH",
-    keybindings: ["j", "k", "J", "K", "@", "A", "q"],
+    keybindings: ["j", "k", "J", "K", "enter", "@", "A", "q"],
     footerHints: "Search: j/k match  J/K file  enter edit  @ attach  q close",
     renderBody: ({ focused }) => <SearchSurface focused={focused} />,
   },

--- a/runtime/tests/tui/workbench/keybindings.test.ts
+++ b/runtime/tests/tui/workbench/keybindings.test.ts
@@ -71,4 +71,13 @@ describe("workbench keybinding contract", () => {
     expect(testSurface.footerHints).toContain("o keep focus");
     expect(testSurface.footerHints).not.toContain("g edit");
   });
+
+  it("keeps SEARCH surface edit hints represented in descriptor key metadata", () => {
+    const surfaceBindings = new Map(Object.entries(DEFAULT_BINDINGS.find((block) => block.context === "Surface")?.bindings ?? {}));
+    const searchSurface = descriptorForSurface("search");
+
+    expect(surfaceBindings.get("enter")).toBe("surface:open");
+    expect(searchSurface.footerHints).toContain("enter edit");
+    expect(searchSurface.keybindings).toContain("enter");
+  });
 });


### PR DESCRIPTION
## Summary
- Add `enter` to the SEARCH surface descriptor key metadata so it matches the live `enter edit` footer/action contract.
- Add a keybinding contract regression covering SEARCH descriptor metadata.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/keybindings.test.ts tests/tui/workbench/render.test.tsx tests/tui/workbench/search-surface.test.tsx --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench --reporter=dot`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` fails only on the known unrelated Knip backlog: `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.