### PR TITLE
fix(tui): show copied diff files correctly

### DIFF
--- a/runtime/src/commands/diff-menu.tsx
+++ b/runtime/src/commands/diff-menu.tsx
@@ -74,7 +74,7 @@ function parseNumstat(raw: string): Map<string, Pick<DiffFileRow, "additions" | 
     const trimmed = line.trim();
     if (trimmed.length === 0) continue;
     const [addRaw, delRaw, ...pathParts] = trimmed.split(/\t+/);
-    const path = pathParts.join("\t");
+    const path = destinationPathFromNumstat(pathParts.join("\t"));
     if (path.length === 0) continue;
     const binary = addRaw === "-" || delRaw === "-";
     byPath.set(path, {
@@ -84,6 +84,14 @@ function parseNumstat(raw: string): Map<string, Pick<DiffFileRow, "additions" | 
     });
   }
   return byPath;
+}
+
+function destinationPathFromNumstat(path: string): string {
+  const trimmed = path.trim();
+  if (!trimmed.includes(" => ")) return trimmed;
+  const expanded = trimmed.replace(/\{([^{}]*?) => ([^{}]*?)\}/gu, "$2");
+  if (expanded !== trimmed) return expanded;
+  return trimmed.slice(trimmed.lastIndexOf(" => ") + " => ".length).trim();
 }
 
 function diffPathFromHeader(line: string): string | null {

--- a/runtime/src/tui/workbench/surfaces/DiffSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/DiffSurface.tsx
@@ -198,6 +198,8 @@ function statusMarker(status: string): string {
       return "D";
     case "renamed":
       return "R";
+    case "copied":
+      return "C";
     case "unmerged":
       return "U";
     case "untracked":

--- a/runtime/tests/commands/diff.test.ts
+++ b/runtime/tests/commands/diff.test.ts
@@ -217,6 +217,47 @@ describe("createDiffMenuSnapshot", () => {
     ]));
     expect(snapshot.files.find((file) => file.path === "src/changed.ts")?.previewLines).toContain("+new");
   });
+
+  it("normalizes git numstat rename and copy paths to destination rows", () => {
+    const snapshot = createDiffMenuSnapshot({
+      rawDiff: [
+        "diff --git a/old.ts b/new.ts",
+        "similarity index 100%",
+        "rename from old.ts",
+        "rename to new.ts",
+        "diff --git a/src/source.ts b/src/copied.ts",
+        "similarity index 100%",
+        "copy from src/source.ts",
+        "copy to src/copied.ts",
+        "diff --git a/a/file.ts b/b/file.ts",
+        "similarity index 100%",
+        "rename from a/file.ts",
+        "rename to b/file.ts",
+      ].join("\n"),
+      nameStatus: [
+        "R100\told.ts\tnew.ts",
+        "C100\tsrc/source.ts\tsrc/copied.ts",
+        "R100\ta/file.ts\tb/file.ts",
+      ].join("\n"),
+      numstat: [
+        "0\t0\told.ts => new.ts",
+        "0\t0\tsrc/{source.ts => copied.ts}",
+        "0\t0\t{a => b}/file.ts",
+      ].join("\n"),
+      untrackedFiles: [],
+    });
+
+    expect(snapshot.files.map((file) => file.path)).toEqual([
+      "b/file.ts",
+      "new.ts",
+      "src/copied.ts",
+    ]);
+    expect(snapshot.files.map((file) => file.status)).toEqual([
+      "renamed",
+      "renamed",
+      "copied",
+    ]);
+  });
 });
 
 describe("diffCommand", () => {

--- a/runtime/tests/tui/workbench/diff-surface.test.tsx
+++ b/runtime/tests/tui/workbench/diff-surface.test.tsx
@@ -111,6 +111,35 @@ describe("DiffSurface", () => {
     expect(output).toContain("src/new.ts - non-mutating review");
   });
 
+  it("renders copied files with the copied status marker", async () => {
+    const snapshot = createDiffMenuSnapshot({
+      rawDiff: [
+        "diff --git a/src/source.ts b/src/copied.ts",
+        "similarity index 100%",
+        "copy from src/source.ts",
+        "copy to src/copied.ts",
+      ].join("\n"),
+      nameStatus: "C\tsrc/source.ts\tsrc/copied.ts",
+      numstat: "0\t0\tsrc/{source.ts => copied.ts}",
+      untrackedFiles: [],
+    });
+
+    const output = await renderToString(
+      <DiffSurfaceView
+        snapshot={snapshot}
+        selected={0}
+        decisions={{}}
+        focused={true}
+        pendingApprovalRisk={null}
+      />,
+      { columns: 100, rows: 24 },
+    );
+
+    expect(output).toContain("1 file changed");
+    expect(compact(output)).toContain("Csrc/copied.ts");
+    expect(compact(output)).not.toContain("Msrc/copied.ts");
+  });
+
   it("keeps the selected changed file visible beyond the first file-list page", async () => {
     const fileCount = 45;
     const snapshot = createDiffMenuSnapshot({


### PR DESCRIPTION
## Summary
- Normalize Git numstat rename/copy display paths to destination paths in Diff snapshots so copy/rename stats do not create phantom rows.
- Render copied files with a `C` marker in the workbench Diff surface instead of falling through to modified `M`.
- Add parser and mounted Diff surface regressions for copied/renamed paths.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/commands/diff.test.ts tests/tui/workbench/diff-surface.test.tsx --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/commands/diff.test.ts --reporter=dot`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` fails only on the known unrelated Knip backlog: `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.