### PR TITLE
fix(tui): expose shell enter shortcut metadata

### DIFF
--- a/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
@@ -63,8 +63,8 @@ export const WORKBENCH_SURFACES: readonly WorkbenchSurfaceDescriptor[] = [
   {
     mode: "shell",
     title: () => "SHELL",
-    keybindings: ["g", "@", "x", "q"],
-    footerHints: "Shell: g edit  @ attach error  x stop  q close",
+    keybindings: ["g", "enter", "@", "x", "q"],
+    footerHints: "Shell: g/enter edit  @ attach error  x stop  q close",
     renderBody: ({ focused }) => <ShellSurface focused={focused} />,
   },
   {

--- a/runtime/tests/tui/workbench/keybindings.test.ts
+++ b/runtime/tests/tui/workbench/keybindings.test.ts
@@ -80,4 +80,14 @@ describe("workbench keybinding contract", () => {
     expect(searchSurface.footerHints).toContain("enter edit");
     expect(searchSurface.keybindings).toContain("enter");
   });
+
+  it("keeps SHELL surface edit shortcuts represented in descriptor metadata", () => {
+    const surfaceBindings = new Map(Object.entries(DEFAULT_BINDINGS.find((block) => block.context === "Surface")?.bindings ?? {}));
+    const shellSurface = descriptorForSurface("shell");
+
+    expect(surfaceBindings.get("g")).toBe("surface:top");
+    expect(surfaceBindings.get("enter")).toBe("surface:open");
+    expect(shellSurface.footerHints).toContain("g/enter edit");
+    expect(shellSurface.keybindings).toEqual(expect.arrayContaining(["g", "enter"]));
+  });
 });


### PR DESCRIPTION
## Summary
- Add `enter` to the SHELL surface descriptor key metadata so it matches the live `surface:open` edit shortcut.
- Update the SHELL descriptor footer to advertise `g/enter edit`, matching the mounted Shell surface hint.
- Add a keybinding contract regression for the Shell descriptor.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/keybindings.test.ts tests/tui/workbench/shell-surface.test.tsx tests/tui/workbench/render.test.tsx --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench --reporter=dot`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` fails only on the known unrelated Knip backlog: `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.