### PR TITLE
fix(tui): expose surface footer actions

### DIFF
--- a/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
@@ -57,7 +57,7 @@ export const WORKBENCH_SURFACES: readonly WorkbenchSurfaceDescriptor[] = [
     mode: "diff",
     title: () => "DIFF",
     keybindings: ["j", "k", "y", "n", "@", "enter", "q"],
-    footerHints: "Diff: j/k file  y/n approve or mark  enter edit  q close",
+    footerHints: "Diff: j/k file  y/n approve or mark  enter edit  @ attach  q close",
     renderBody: ({ focused, pendingApproval }) => <DiffSurface focused={focused} pendingApproval={pendingApproval} />,
   },
   {
@@ -78,7 +78,7 @@ export const WORKBENCH_SURFACES: readonly WorkbenchSurfaceDescriptor[] = [
     mode: "search",
     title: () => "SEARCH",
     keybindings: ["j", "k", "J", "K", "enter", "@", "A", "q"],
-    footerHints: "Search: j/k match  J/K file  enter edit  @ attach  q close",
+    footerHints: "Search: j/k match  J/K file  enter edit  @ attach  A attach visible  q close",
     renderBody: ({ focused }) => <SearchSurface focused={focused} />,
   },
   {

--- a/runtime/tests/tui/workbench/keybindings.test.ts
+++ b/runtime/tests/tui/workbench/keybindings.test.ts
@@ -90,4 +90,14 @@ describe("workbench keybinding contract", () => {
     expect(shellSurface.footerHints).toContain("g/enter edit");
     expect(shellSurface.keybindings).toEqual(expect.arrayContaining(["g", "enter"]));
   });
+
+  it("keeps action-bearing surface descriptor shortcuts represented in footer hints", () => {
+    const diffSurface = descriptorForSurface("diff");
+    const searchSurface = descriptorForSurface("search");
+
+    expect(diffSurface.keybindings).toContain("@");
+    expect(diffSurface.footerHints).toContain("@ attach");
+    expect(searchSurface.keybindings).toContain("A");
+    expect(searchSurface.footerHints).toContain("A attach");
+  });
 });


### PR DESCRIPTION
## Summary
- Add contract coverage that action-bearing surface descriptor shortcuts are represented in footer hints.
- Add the missing Diff `@ attach` and Search `A attach visible` descriptor footer hints.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench/keybindings.test.ts tests/tui/workbench/diff-surface.test.tsx tests/tui/workbench/search-surface.test.tsx tests/tui/workbench/render.test.tsx --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime exec vitest run tests/tui/workbench --reporter=dot`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `git diff --check`

## Known existing issue
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing unrelated Knip backlog: `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.