### PR TITLE
fix(tui): expose search keep-focus shortcut

### DIFF
--- a/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/ActiveWorkSurface.tsx
@@ -77,8 +77,8 @@ export const WORKBENCH_SURFACES: readonly WorkbenchSurfaceDescriptor[] = [
   {
     mode: "search",
     title: () => "SEARCH",
-    keybindings: ["j", "k", "J", "K", "enter", "@", "A", "q"],
-    footerHints: "Search: j/k match  J/K file  enter edit  @ attach  A attach visible  q close",
+    keybindings: ["j", "k", "J", "K", "enter", "o", "@", "A", "q"],
+    footerHints: "Search: j/k match  J/K file  enter edit  o keep focus  @ attach  A attach visible  q close",
     renderBody: ({ focused }) => <SearchSurface focused={focused} />,
   },
   {

--- a/runtime/src/tui/workbench/surfaces/SearchSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/SearchSurface.tsx
@@ -168,7 +168,7 @@ export function SearchSurfaceView({
           ),
         )}
       </Box>
-      {selectedMatch ? <Text dimColor wrap="truncate-end">enter edit  @ attach  A attach visible: {selectedMatch.file}:{selectedMatch.line}</Text> : null}
+      {selectedMatch ? <Text dimColor wrap="truncate-end">enter edit  o keep focus  @ attach  A attach visible: {selectedMatch.file}:{selectedMatch.line}</Text> : null}
     </Box>
   );
 }

--- a/runtime/tests/tui/workbench/keybindings.test.ts
+++ b/runtime/tests/tui/workbench/keybindings.test.ts
@@ -77,8 +77,10 @@ describe("workbench keybinding contract", () => {
     const searchSurface = descriptorForSurface("search");
 
     expect(surfaceBindings.get("enter")).toBe("surface:open");
+    expect(surfaceBindings.get("o")).toBe("surface:openKeepFocus");
     expect(searchSurface.footerHints).toContain("enter edit");
-    expect(searchSurface.keybindings).toContain("enter");
+    expect(searchSurface.footerHints).toContain("o keep focus");
+    expect(searchSurface.keybindings).toEqual(expect.arrayContaining(["enter", "o"]));
   });
 
   it("keeps SHELL surface edit shortcuts represented in descriptor metadata", () => {

--- a/runtime/tests/tui/workbench/search-surface.test.tsx
+++ b/runtime/tests/tui/workbench/search-surface.test.tsx
@@ -173,6 +173,7 @@ describe("SearchSurface", () => {
 
     expect(output).toContain("src/app.ts");
     expect(output).toContain("src/other.ts");
+    expect(output).toContain("o keep focus");
     expect(output).toContain("@ attach");
     for (const line of output.split(/\r?\n/u)) {
       expect(line.length).toBeLessThanOrEqual(60);


### PR DESCRIPTION
## Summary
- Add contract coverage that Search descriptor metadata exposes the live `o` keep-focus shortcut.
- Add the missing `o keep focus` hint to the Search descriptor footer and mounted Search action row.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/keybindings.test.ts tests/tui/workbench/search-surface.test.tsx --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/keybindings.test.ts tests/tui/workbench/search-surface.test.tsx tests/tui/workbench/render.test.tsx --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench --reporter=dot`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `git diff --check`

## Known existing issue
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing unrelated Knip backlog: `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.