### PR TITLE
fix(tui): preserve buffer insert repeat after delete

### DIFF
--- a/runtime/src/tui/workbench/buffer/BufferStore.ts
+++ b/runtime/src/tui/workbench/buffer/BufferStore.ts
@@ -446,7 +446,7 @@ export class WorkbenchBufferStore {
       this.deleteForward();
       this.#vimState = {
         mode: "INSERT",
-        insertedText: removeLastGrapheme(state.insertedText),
+        insertedText: state.insertedText,
       };
       return;
     }

--- a/runtime/tests/tui/workbench/buffer-store.test.ts
+++ b/runtime/tests/tui/workbench/buffer-store.test.ts
@@ -354,6 +354,24 @@ describe("WorkbenchBufferStore", () => {
     expect(store.getSnapshot().vimMode).toBe("INSERT");
   });
 
+  it("keeps insert-mode Delete from erasing typed text from dot repeat", async () => {
+    const file = join(dir, "target.txt");
+    await writeFile(file, "alpha\nomega\n", "utf8");
+    const store = new WorkbenchBufferStore();
+
+    await runWithCwdOverride(dir, () => store.open("target.txt"));
+
+    store.handleVimInput("i", key(), 80);
+    store.handleVimInput("X", key({ shift: true }), 80);
+    store.handleVimInput("", key({ delete: true }), 80);
+    store.handleVimInput("", key({ escape: true, meta: true }), 80);
+    expect(store.getText()).toBe("Xlpha\nomega\n");
+
+    store.handleVimInput(".", key(), 80);
+
+    expect(store.getText()).toBe("XXlpha\nomega\n");
+  });
+
   it("lets normal-mode shifted arrows fall through to selection keybindings", async () => {
     const file = join(dir, "target.txt");
     await writeFile(file, "alpha\nomega\n", "utf8");


### PR DESCRIPTION
## Summary
- preserve typed insert text when insert-mode Delete removes text after the cursor
- add a buffer store regression for dot-repeat after insert-mode Delete

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/buffer-store.test.ts -t "keeps insert-mode Delete" --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-surface.test.tsx tests/tui/workbench/buffer-editing.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/vim --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Known unrelated
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on the existing Knip backlog: unused file src/tui/workbench/keymap.ts, 30 unused exports, and 4 unused tag hints.