### PR TITLE
fix(tui): preserve buffer on definition load failure

### DIFF
--- a/runtime/src/tui/workbench/buffer/BufferStore.ts
+++ b/runtime/src/tui/workbench/buffer/BufferStore.ts
@@ -107,6 +107,9 @@ type BufferVimCommandHandler = (command: BufferVimCommand) => void;
 export type WorkbenchBufferStoreOptions = {
   readonly openExternalEditor?: BufferExternalEditorLauncher;
 };
+type BufferLoadOptions = {
+  readonly preserveCurrentOnError?: boolean;
+};
 type VimEditSession = {
   readonly context: TransitionContext;
   readonly flush: () => void;
@@ -382,7 +385,9 @@ export class WorkbenchBufferStore {
     const position = this.#lspPosition(document);
     const target = await requestBufferDefinition(file.absolutePath, position).catch(() => null);
     if (!target || this.#file !== file || this.#document !== document) return false;
-    return this.#load(target.path, target.line, false, displayPathForAbsolute(target.path));
+    return this.#load(target.path, target.line, false, displayPathForAbsolute(target.path), {
+      preserveCurrentOnError: true,
+    });
   }
 
   #handleVimCommandLineInput(input: string, key: Key, onCommand?: BufferVimCommandHandler): boolean {
@@ -747,6 +752,7 @@ export class WorkbenchBufferStore {
     line: number,
     allowDirtyReplace: boolean,
     displayPath = filePath,
+    options: BufferLoadOptions = {},
   ): Promise<boolean> {
     const absolutePath = resolve(getCwd(), filePath);
     if (this.#file?.absolutePath === absolutePath && !allowDirtyReplace) {
@@ -765,6 +771,13 @@ export class WorkbenchBufferStore {
 
     const generation = ++this.#openGeneration;
     const previousPath = this.#file?.absolutePath;
+    const previousFile = this.#file;
+    const previousDocument = this.#document;
+    const previousScrollLine = this.#scrollLine;
+    const previousVimCommandLine = this.#vimCommandLine;
+    const previousVimState = this.#vimState;
+    const previousVisualAnchor = this.#visualAnchor;
+    const previousVimPersistentState = this.#vimPersistentState;
     this.#status = "loading";
     this.#error = null;
     this.#conflictKind = null;
@@ -794,6 +807,15 @@ export class WorkbenchBufferStore {
       return true;
     } catch (error) {
       if (generation !== this.#openGeneration) return false;
+      if (options.preserveCurrentOnError && previousFile && previousDocument) {
+        this.#file = previousFile;
+        this.#document = previousDocument;
+        this.#scrollLine = previousScrollLine;
+        this.#vimCommandLine = previousVimCommandLine;
+        this.#vimState = previousVimState;
+        this.#visualAnchor = previousVisualAnchor;
+        this.#vimPersistentState = previousVimPersistentState;
+      }
       this.#status = "error";
       this.#error = errorMessage(error);
       this.#conflictKind = null;

--- a/runtime/tests/tui/workbench/buffer-store.test.ts
+++ b/runtime/tests/tui/workbench/buffer-store.test.ts
@@ -245,8 +245,9 @@ describe("WorkbenchBufferStore", () => {
     await expect(store.goToDefinition()).resolves.toBe(false);
     expect(store.getSnapshot()).toMatchObject({
       status: "error",
-      filePath: null,
+      filePath: "target.txt",
     });
+    expect(store.getText()).toBe("alpha\n");
   });
 
   it("ignores stale LSP responses after moving within the same file", async () => {


### PR DESCRIPTION
## Summary
- keep the current buffer loaded when go-to-definition resolves to an unreadable target
- add a buffer store regression that failed before the fix by clearing filePath and text

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/buffer-store.test.ts -t "reports failed definition navigation when the target cannot be loaded" --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-surface.test.tsx tests/tui/workbench/buffer-editing.test.ts tests/tui/workbench/buffer-lsp.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/vim --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Known unrelated
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on the existing Knip backlog: unused file src/tui/workbench/keymap.ts, 30 unused exports, and 4 unused tag hints.