### PR TITLE
fix(tui): classify split approval commands

### DIFF
--- a/runtime/src/tui/approval-input-text.ts
+++ b/runtime/src/tui/approval-input-text.ts
@@ -1,0 +1,86 @@
+const COMMAND_KEYS = ["command", "cmd"] as const;
+const TEXT_KEYS = ["input", "query", "path", "file_path"] as const;
+
+export interface ApprovalInputTextOptions {
+  readonly prettyJson?: boolean;
+}
+
+export function approvalInputText(
+  input: unknown,
+  options: ApprovalInputTextOptions = {},
+): string {
+  if (input === null || input === undefined) return "";
+  if (typeof input === "string") return input;
+  if (typeof input !== "object") return String(input);
+
+  if (Array.isArray(input)) {
+    return scalarArrayText(input) ?? fallbackText(input, options);
+  }
+
+  const record = input as Record<string, unknown>;
+  const command = commandText(record);
+  if (command !== null) return command;
+
+  for (const key of TEXT_KEYS) {
+    const value = textValue(record[key]);
+    if (value !== null) return value;
+  }
+
+  return fallbackText(record, options);
+}
+
+function commandText(record: Record<string, unknown>): string | null {
+  const args = Array.isArray(record.args)
+    ? (scalarArrayParts(record.args) ?? [])
+    : [];
+  for (const key of COMMAND_KEYS) {
+    const command = commandParts(record[key]);
+    if (command.length > 0) {
+      return [...command, ...args].join(" ");
+    }
+  }
+  return null;
+}
+
+function commandParts(value: unknown): readonly string[] {
+  if (Array.isArray(value)) return scalarArrayParts(value) ?? [];
+  const text = textValue(value);
+  return text === null ? [] : [text];
+}
+
+function scalarArrayText(value: readonly unknown[]): string | null {
+  const parts = scalarArrayParts(value);
+  return parts === null ? null : parts.join(" ");
+}
+
+function scalarArrayParts(value: readonly unknown[]): readonly string[] | null {
+  const parts: string[] = [];
+  for (const item of value) {
+    const text = textValue(item);
+    if (text === null) return null;
+    parts.push(text);
+  }
+  return parts.length > 0 ? parts : null;
+}
+
+function textValue(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value.trim().length > 0 ? value : null;
+  }
+  if (
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint"
+  ) {
+    return String(value);
+  }
+  return null;
+}
+
+function fallbackText(value: unknown, options: ApprovalInputTextOptions): string {
+  try {
+    return JSON.stringify(value, null, options.prettyJson ? 2 : undefined) ?? "";
+  } catch {
+    return String(value);
+  }
+}

--- a/runtime/src/tui/permission-requests.tsx
+++ b/runtime/src/tui/permission-requests.tsx
@@ -18,6 +18,7 @@ import { makeToolUseMessage } from "./session-transcript.js";
 import type { AgenCBridgeSession } from "./session-types.js";
 import { createSessionAppStateBridge } from "./session-app-state.js";
 import type { AppState } from "./state/AppState.js";
+import { approvalInputText } from "./approval-input-text.js";
 import { Box, useInput } from "./ink.js";
 import { useRegisterKeybindingContext } from "./keybindings/KeybindingContext.js";
 import { useKeybindings } from "./keybindings/useKeybinding.js";
@@ -280,24 +281,6 @@ export function AgenCPermissionOverlay({
   return <AgenCApprovalOverlay request={request} toolUseConfirm={toolUseConfirm} />;
 }
 
-function inputValue(input: unknown): string {
-  if (input === null || input === undefined) return "";
-  if (typeof input === "string") return input;
-  if (typeof input !== "object") return String(input);
-  const record = input as Record<string, unknown>;
-  for (const key of ["command", "cmd", "input", "query", "path", "file_path"]) {
-    const value = record[key];
-    if (typeof value === "string" && value.trim().length > 0) {
-      return value;
-    }
-  }
-  try {
-    return JSON.stringify(record, null, 2);
-  } catch {
-    return String(input);
-  }
-}
-
 function toolLabel(toolUseConfirm: ProjectedToolUseConfirm): string {
   const fromTool = toolUseConfirm.tool.userFacingName?.(toolUseConfirm.input);
   if (fromTool && fromTool.trim().length > 0) return fromTool;
@@ -311,7 +294,7 @@ function AgenCApprovalOverlay({
   readonly request: PendingRequest;
   readonly toolUseConfirm: ProjectedToolUseConfirm;
 }) {
-  const command = inputValue(toolUseConfirm.input);
+  const command = approvalInputText(toolUseConfirm.input, { prettyJson: true });
   const risk = classifyApprovalRisk({
     request,
     toolName: toolUseConfirm.tool.name,

--- a/runtime/src/tui/workbench/approvals/inputText.ts
+++ b/runtime/src/tui/workbench/approvals/inputText.ts
@@ -1,13 +1,1 @@
-export function approvalInputText(input: Record<string, unknown>): string {
-  for (const key of ["command", "cmd", "input", "query", "path", "file_path"]) {
-    const value = input[key];
-    if (typeof value === "string" && value.trim().length > 0) {
-      return value;
-    }
-  }
-  try {
-    return JSON.stringify(input);
-  } catch {
-    return "";
-  }
-}
+export { approvalInputText } from "../../approval-input-text.js";

--- a/runtime/tests/tui/permission-requests.coverage.test.tsx
+++ b/runtime/tests/tui/permission-requests.coverage.test.tsx
@@ -74,24 +74,32 @@ async function sleep(ms = 25): Promise<void> {
 
 function createPendingRequest(
   resolve: (decision: ReviewDecision) => void,
+  options: {
+    readonly id?: string;
+    readonly input?: Record<string, unknown>;
+    readonly description?: string;
+  } = {},
 ): PendingRequest {
+  const input = options.input ?? {
+    command: "agenc stake --mainnet --validator 42",
+  };
+  const description = options.description ?? "Stake on mainnet";
+  const id = options.id ?? "request-mainnet-stake";
   return {
-    id: "request-mainnet-stake",
+    id,
     ctx: {
-      callId: "call-mainnet-stake",
+      callId: `call-${id}`,
       toolName: "Bash",
       turnId: "turn-1",
       invocation: {
         payload: {
           kind: "function",
-          arguments: "{\"command\":\"agenc stake --mainnet --validator 42\"}",
+          arguments: JSON.stringify(input),
         },
       },
     } as unknown as ApprovalCtx,
-    input: {
-      command: "agenc stake --mainnet --validator 42",
-    },
-    description: "Stake on mainnet",
+    input,
+    description,
     resolve,
   };
 }
@@ -146,6 +154,43 @@ describe("permission request overlay coverage", () => {
 
       expect(tools[0]?.userFacingName).toHaveBeenCalledWith(request.input);
       expect(resolved).toEqual([APPROVED]);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+
+  test("renders split command arguments as the destructive command", async () => {
+    const resolved: ReviewDecision[] = [];
+    const request = createPendingRequest(
+      decision => {
+        resolved.push(decision);
+      },
+      {
+        id: "request-delete-path",
+        input: { command: "rm", args: ["-rf", "/tmp/agenc-danger"] },
+        description: "Delete generated path",
+      },
+    );
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(<AgenCPermissionOverlay request={request} tools={[{ name: "Bash" }]} />);
+      await sleep();
+
+      const frame = stripAnsi(extractLastFrame(output()));
+      const compactFrame = frame.replace(/\s+/gu, "");
+      expect(compactFrame).toContain("high-riskapproval");
+      expect(compactFrame).toContain("rm-rf/tmp/agenc-danger");
+      expect(compactFrame).toContain("type'delete'toapprove");
+      expect(resolved).toEqual([]);
     } finally {
       root.unmount();
       stdin.end();

--- a/runtime/tests/tui/workbench/approval-input-text.test.ts
+++ b/runtime/tests/tui/workbench/approval-input-text.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { approvalInputText } from "../../../src/tui/workbench/approvals/inputText.js";
+
+describe("approvalInputText", () => {
+  it("renders split shell command and args as one command line", () => {
+    expect(
+      approvalInputText({
+        command: "rm",
+        args: ["-rf", "/tmp/agenc-danger"],
+      }),
+    ).toBe("rm -rf /tmp/agenc-danger");
+  });
+
+  it("renders local-shell argv arrays as one command line", () => {
+    expect(
+      approvalInputText({
+        command: ["bash", "-lc", "rm -rf /tmp/agenc-danger"],
+        cwd: "/tmp/agenc",
+      }),
+    ).toBe("bash -lc rm -rf /tmp/agenc-danger");
+  });
+});

--- a/runtime/tests/tui/workbench/approval-surface-bridge.test.tsx
+++ b/runtime/tests/tui/workbench/approval-surface-bridge.test.tsx
@@ -44,6 +44,25 @@ describe("ApprovalSurfaceBridge", () => {
     expect(output).toContain("risk destructive");
   });
 
+  it("classifies destructive approval risk from split command arguments", async () => {
+    const request = pendingRequest({
+      id: "approval-argv",
+      description: "Run shell command",
+      input: { command: "rm", args: ["-rf", "/tmp/agenc-danger"] },
+      toolName: "Bash",
+    });
+
+    const output = await renderToString(
+      <AppStateProvider initialState={getDefaultAppState()}>
+        <ApprovalSurfaceBridge request={request} />
+      </AppStateProvider>,
+      80,
+    );
+
+    expect(output).toContain("Approval pending: Run shell command");
+    expect(output).toContain("risk destructive");
+  });
+
   it("opens the diff surface for the active approval request", async () => {
     const changes: AppState[] = [];
     const request = pendingRequest({


### PR DESCRIPTION
## Summary
- Normalize approval input command text through a shared TUI helper before risk classification.
- Preserve split `{ command, args }` and local-shell argv arrays as a single command string so destructive commands still require typed confirmation.
- Add regression coverage for the helper, compact workbench approval bridge, and full permission overlay.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/approval-input-text.test.ts tests/tui/workbench/approval-surface-bridge.test.tsx tests/tui/permission-requests.coverage.test.tsx --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench --reporter=dot`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `git diff --check`
- `rg -n "Claude|claude|Codex|codex|OpenClaude|openclaude|TODO|FIXME|HACK" runtime/src/tui/approval-input-text.ts runtime/src/tui/workbench/approvals/inputText.ts runtime/src/tui/permission-requests.tsx runtime/tests/tui/workbench/approval-input-text.test.ts runtime/tests/tui/workbench/approval-surface-bridge.test.tsx runtime/tests/tui/permission-requests.coverage.test.tsx`

## Known existing issue
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.
