### PR TITLE
fix(tui): normalize project tree rename paths

### DIFF
--- a/runtime/src/tui/workbench/pathReferences.ts
+++ b/runtime/src/tui/workbench/pathReferences.ts
@@ -1,0 +1,32 @@
+export function normalizeWorkspacePathForReferences(value: string): string {
+  return value.replace(/\\/gu, "/").replace(/\/+$/u, "");
+}
+
+export function renameWorkspacePathReference(
+  value: string | null,
+  fromPath: string,
+  toPath: string,
+): string | null {
+  if (!value) return value;
+  const normalizedFromPath = normalizeWorkspacePathForReferences(fromPath);
+  const normalizedToPath = normalizeWorkspacePathForReferences(toPath);
+  if (!normalizedFromPath) return value;
+  if (value === normalizedFromPath) return normalizedToPath;
+  if (value.startsWith(`${normalizedFromPath}/`)) {
+    return `${normalizedToPath}${value.slice(normalizedFromPath.length)}`;
+  }
+  return value;
+}
+
+export function containsWorkspacePathReference(
+  value: string | null,
+  targetPath: string,
+): boolean {
+  if (!value) return false;
+  const normalizedTargetPath = normalizeWorkspacePathForReferences(targetPath);
+  if (!normalizedTargetPath) return false;
+  return (
+    value === normalizedTargetPath ||
+    value.startsWith(`${normalizedTargetPath}/`)
+  );
+}

--- a/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
+++ b/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
@@ -12,6 +12,10 @@ import TextInput from "../../components/TextInput.js";
 import { getGraphemeSegmenter } from "../../../utils/intl.js";
 import { inFlightPathsFromTasks } from "../agents/activity.js";
 import { attachFileCommand, deletePathReferencesCommand, openBufferCommand, renamePathReferencesCommand } from "../commands.js";
+import {
+  containsWorkspacePathReference,
+  renameWorkspacePathReference,
+} from "../pathReferences.js";
 import { useWorkbenchDispatch, useWorkbenchState } from "../state.js";
 import type { ProjectTreeRow } from "../types.js";
 import { getProjectTreeStore } from "./ProjectTreeStore.js";
@@ -434,12 +438,9 @@ function defaultCreateFilePath(row: ProjectTreeRow | null): string {
 }
 
 function pathContains(activePath: string | null, targetPath: string): boolean {
-  return activePath === targetPath || Boolean(activePath?.startsWith(`${targetPath}/`));
+  return containsWorkspacePathReference(activePath, targetPath);
 }
 
 function renamedActiveFilePath(activePath: string | null, fromPath: string, toPath: string): string | null {
-  if (!activePath) return null;
-  if (activePath === fromPath) return toPath;
-  if (activePath.startsWith(`${fromPath}/`)) return `${toPath}${activePath.slice(fromPath.length)}`;
-  return null;
+  return renameWorkspacePathReference(activePath, fromPath, toPath);
 }

--- a/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
+++ b/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
@@ -427,12 +427,14 @@ function resolveWorkspaceRelativePath(
     return { ok: false, error: "Use a workspace-relative path, not an absolute path." };
   }
 
-  const relativePath = path.posix.normalize(trimmed).replace(/^\.\//u, "");
+  const normalizedPath = path.posix.normalize(trimmed).replace(/^\.\//u, "");
+  if (options.requireFilePath && normalizedPath.endsWith("/")) {
+    return { ok: false, error: "Enter a file path, not a directory path." };
+  }
+
+  const relativePath = stripTrailingSlashes(normalizedPath);
   if (!relativePath || relativePath === "." || relativePath.startsWith("../")) {
     return { ok: false, error: "Path must stay inside the workspace." };
-  }
-  if (options.requireFilePath && relativePath.endsWith("/")) {
-    return { ok: false, error: "Enter a file path, not a directory path." };
   }
 
   const root = path.resolve(cwd);
@@ -446,6 +448,10 @@ function resolveWorkspaceRelativePath(
   }
 
   return { ok: true, relativePath, absolutePath };
+}
+
+function stripTrailingSlashes(value: string): string {
+  return value.replace(/\/+$/u, "");
 }
 
 async function pathExists(absolutePath: string): Promise<boolean> {

--- a/runtime/src/tui/workbench/reducer.ts
+++ b/runtime/src/tui/workbench/reducer.ts
@@ -5,6 +5,11 @@ import type {
   WorkbenchPane,
   WorkbenchState,
 } from "./types.js";
+import {
+  containsWorkspacePathReference,
+  normalizeWorkspacePathForReferences,
+  renameWorkspacePathReference,
+} from "./pathReferences.js";
 
 export function getDefaultWorkbenchState(): WorkbenchState {
   return {
@@ -201,10 +206,16 @@ function renamePathReferences(
   fromPath: string,
   toPath: string,
 ): WorkbenchState {
+  const normalizedFromPath = normalizeWorkspacePathForReferences(fromPath);
+  const normalizedToPath = normalizeWorkspacePathForReferences(toPath);
   const attachmentIdMap = new Map<string, string>();
   const attachmentsById = new Map<string, WorkbenchAttachment>();
   for (const attachment of state.attachments) {
-    const nextAttachment = renameAttachmentPath(attachment, fromPath, toPath);
+    const nextAttachment = renameAttachmentPath(
+      attachment,
+      normalizedFromPath,
+      normalizedToPath,
+    );
     attachmentIdMap.set(attachment.id, nextAttachment.id);
     attachmentsById.set(nextAttachment.id, nextAttachment);
   }
@@ -217,7 +228,12 @@ function renamePathReferences(
   );
   return {
     ...state,
-    activeFilePath: renameWorkspacePath(state.activeFilePath, fromPath, toPath) ?? state.activeFilePath,
+    activeFilePath:
+      renameWorkspacePathReference(
+        state.activeFilePath,
+        normalizedFromPath,
+        normalizedToPath,
+      ) ?? state.activeFilePath,
     attachments,
     composerAttachmentIds,
   };
@@ -227,9 +243,12 @@ function deletePathReferences(
   state: WorkbenchState,
   deletedPath: string,
 ): WorkbenchState {
-  const activeFileDeleted = containsWorkspacePath(state.activeFilePath, deletedPath);
+  const activeFileDeleted = containsWorkspacePathReference(
+    state.activeFilePath,
+    deletedPath,
+  );
   const attachments = state.attachments.filter((attachment) =>
-    !containsWorkspacePath(attachment.path ?? null, deletedPath)
+    !containsWorkspacePathReference(attachment.path ?? null, deletedPath)
   );
   const attachmentIds = new Set(attachments.map((item) => item.id));
   return {
@@ -246,7 +265,11 @@ function renameAttachmentPath(
   fromPath: string,
   toPath: string,
 ): WorkbenchAttachment {
-  const nextPath = renameWorkspacePath(attachment.path ?? null, fromPath, toPath);
+  const nextPath = renameWorkspacePathReference(
+    attachment.path ?? null,
+    fromPath,
+    toPath,
+  );
   if (!nextPath || nextPath === attachment.path) return attachment;
   return {
     ...attachment,
@@ -254,17 +277,6 @@ function renameAttachmentPath(
     path: nextPath,
     label: replaceFirst(attachment.label, attachment.path ?? "", nextPath),
   };
-}
-
-function renameWorkspacePath(value: string | null, fromPath: string, toPath: string): string | null {
-  if (!value) return value;
-  if (value === fromPath) return toPath;
-  if (value.startsWith(`${fromPath}/`)) return `${toPath}${value.slice(fromPath.length)}`;
-  return value;
-}
-
-function containsWorkspacePath(value: string | null, targetPath: string): boolean {
-  return value === targetPath || Boolean(value?.startsWith(`${targetPath}/`));
 }
 
 function replaceFirst(value: string, needle: string, replacement: string): string {

--- a/runtime/tests/tui/workbench/project-explorer-interactions.test.tsx
+++ b/runtime/tests/tui/workbench/project-explorer-interactions.test.tsx
@@ -211,10 +211,10 @@ describe("ProjectExplorer interactions", () => {
 
       const submitRename = explorerHarness.textInputProps.at(-1)?.onSubmit as ((value: string) => void) | undefined;
       expect(submitRename).toEqual(expect.any(Function));
-      submitRename?.("lib");
+      submitRename?.("lib/");
       await sleep();
 
-      expect(explorerHarness.renameCalls).toEqual([["src", "lib"]]);
+      expect(explorerHarness.renameCalls).toEqual([["src", "lib/"]]);
       expect(changes.at(-1)?.workbench).toMatchObject({
         focusedPane: "explorer",
         activeSurfaceMode: "buffer",

--- a/runtime/tests/tui/workbench/project-tree.test.ts
+++ b/runtime/tests/tui/workbench/project-tree.test.ts
@@ -233,6 +233,30 @@ describe("project tree helpers", () => {
     }
   });
 
+  it("returns canonical tree paths when renaming to a trailing slash target", async () => {
+    const repo = await mkdtemp(join(tmpdir(), "agenc-tree-rename-slash-"));
+    const store = new ProjectTreeStore(repo, 0);
+
+    try {
+      await mkdir(join(repo, "src", "nested"), { recursive: true });
+      await writeFile(join(repo, "src", "nested", "app.ts"), "app\n", "utf8");
+      await store.refresh();
+
+      await expect(store.renamePath("src", "lib/")).resolves.toEqual({
+        ok: true,
+        path: "lib",
+      });
+
+      expect(await readFile(join(repo, "lib", "nested", "app.ts"), "utf8")).toBe("app\n");
+      expect(store.getCursorPath()).toBe("lib");
+      expect(store.getSnapshot().rows.map((row) => row.path)).toContain("lib");
+      expect(store.getSnapshot().rows.map((row) => row.path)).not.toContain("lib/");
+    } finally {
+      store.dispose();
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
   it("deletes files and rejects paths outside the workspace", async () => {
     const repo = await mkdtemp(join(tmpdir(), "agenc-tree-delete-"));
     const store = new ProjectTreeStore(repo, 0);

--- a/runtime/tests/tui/workbench/reducer.test.ts
+++ b/runtime/tests/tui/workbench/reducer.test.ts
@@ -221,6 +221,39 @@ describe("workbenchReducer", () => {
     ]);
   });
 
+  it("normalizes trailing slash rename targets before rewriting references", () => {
+    const state = {
+      ...getDefaultWorkbenchState(),
+      activeFilePath: "src/nested/app.ts",
+      attachments: [
+        {
+          id: "file-range:src/nested/app.ts:12-15",
+          kind: "file-range" as const,
+          label: "src/nested/app.ts:12-15",
+          path: "src/nested/app.ts",
+          line: 12,
+          endLine: 15,
+        },
+      ],
+      composerAttachmentIds: ["file-range:src/nested/app.ts:12-15"],
+    };
+    const next = workbenchReducer(state, {
+      type: "renamePathReferences",
+      fromPath: "src",
+      toPath: "lib/",
+    });
+
+    expect(next.activeFilePath).toBe("lib/nested/app.ts");
+    expect(next.attachments[0]).toMatchObject({
+      id: "file-range:lib/nested/app.ts:12-15",
+      label: "lib/nested/app.ts:12-15",
+      path: "lib/nested/app.ts",
+    });
+    expect(next.composerAttachmentIds).toEqual([
+      "file-range:lib/nested/app.ts:12-15",
+    ]);
+  });
+
   it("clears active paths and attached context when a workspace path is deleted", () => {
     const state = {
       ...getDefaultWorkbenchState(),


### PR DESCRIPTION
## Summary
- Canonicalize project tree rename targets so trailing slashes do not leak into tree paths.
- Share workbench path-reference rename/delete helpers between reducer state updates and the mounted project explorer.
- Add regressions for store, reducer, and mounted explorer behavior when renaming `src` to `lib/`.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/reducer.test.ts tests/tui/workbench/project-tree.test.ts tests/tui/workbench/project-explorer-interactions.test.tsx --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench --reporter=dot`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `git diff --check`
- Branding/TODO scan over touched source/test files
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` (expected existing unrelated Knip backlog only)