### PR TITLE
fix(tui): preserve manual search selection

### DIFF
--- a/runtime/src/tui/workbench/surfaces/SearchSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/SearchSurface.tsx
@@ -89,15 +89,38 @@ export function SearchSurface({ focused }: { readonly focused: boolean }): React
   const selectedMatch = matches[selectedIndex] ?? null;
   const groups = useMemo(() => groupSearchMatches(matches), [matches]);
   const rows = useMemo(() => visibleSearchRows(groups), [groups]);
+  const disablePendingSelectedMatchRestore = () => {
+    if (selectedMatchId) {
+      appliedSelectedMatchIdRef.current = selectedMatchId;
+    }
+  };
   useRegisterKeybindingContext("Surface", focused);
   useKeybindings(
     {
-      "surface:up": () => setSelected((value) => Math.max(0, value - 1)),
-      "surface:down": () => setSelected((value) => Math.min(Math.max(0, matches.length - 1), value + 1)),
-      "surface:pageUp": () => setSelected((value) => Math.max(0, value - 10)),
-      "surface:pageDown": () => setSelected((value) => Math.min(Math.max(0, matches.length - 1), value + 10)),
-      "surface:top": () => setSelected(0),
-      "surface:bottom": () => setSelected(Math.max(0, matches.length - 1)),
+      "surface:up": () => {
+        disablePendingSelectedMatchRestore();
+        setSelected((value) => Math.max(0, value - 1));
+      },
+      "surface:down": () => {
+        disablePendingSelectedMatchRestore();
+        setSelected((value) => Math.min(Math.max(0, matches.length - 1), value + 1));
+      },
+      "surface:pageUp": () => {
+        disablePendingSelectedMatchRestore();
+        setSelected((value) => Math.max(0, value - 10));
+      },
+      "surface:pageDown": () => {
+        disablePendingSelectedMatchRestore();
+        setSelected((value) => Math.min(Math.max(0, matches.length - 1), value + 10));
+      },
+      "surface:top": () => {
+        disablePendingSelectedMatchRestore();
+        setSelected(0);
+      },
+      "surface:bottom": () => {
+        disablePendingSelectedMatchRestore();
+        setSelected(Math.max(0, matches.length - 1));
+      },
       "surface:open": () => {
         if (selectedMatch) dispatch(openBufferCommand(selectedMatch.file, selectedMatch.line, true));
       },
@@ -110,8 +133,14 @@ export function SearchSurface({ focused }: { readonly focused: boolean }): React
       "surface:attachAll": () => {
         for (const match of matches) dispatch(attachSearchMatchCommand(query, match));
       },
-      "surface:groupUp": () => setSelected((value) => groupStep(groups, matches, value, -1)),
-      "surface:groupDown": () => setSelected((value) => groupStep(groups, matches, value, 1)),
+      "surface:groupUp": () => {
+        disablePendingSelectedMatchRestore();
+        setSelected((value) => groupStep(groups, matches, value, -1));
+      },
+      "surface:groupDown": () => {
+        disablePendingSelectedMatchRestore();
+        setSelected((value) => groupStep(groups, matches, value, 1));
+      },
       "workbench:closeSurface": () => dispatch({ type: "closeSurface" }),
     },
     { context: "Surface", isActive: focused },

--- a/runtime/tests/tui/workbench/search-surface.test.tsx
+++ b/runtime/tests/tui/workbench/search-surface.test.tsx
@@ -313,6 +313,62 @@ describe("SearchSurface", () => {
     }
   });
 
+  it("does not restore a late requested search match after manual navigation during streaming", async () => {
+    searchHarness.autoFlush = false;
+    const changes: AppState[] = [];
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "search",
+              searchQuery: "needle",
+              selectedSearchMatchId: "src/target.ts:20:needle target",
+            },
+          }}
+          onChangeAppState={({ newState }) => changes.push(newState)}
+        >
+          <SearchSurface focused={false} />
+        </AppStateProvider>,
+      );
+      await sleep(180);
+
+      expect(searchHarness.calls).toHaveLength(1);
+      const call = searchHarness.calls[0]!;
+      call.onLines([
+        "src/first.ts:4:const needle = true",
+        "src/second.ts:9:needle()",
+      ]);
+      await sleep();
+
+      searchHarness.handlers["surface:down"]?.();
+      await sleep();
+
+      call.onLines(["src/target.ts:20:needle target"]);
+      await sleep(50);
+      searchHarness.handlers["surface:open"]?.();
+
+      expect(changes.at(-1)?.workbench).toMatchObject({
+        activeSurfaceMode: "buffer",
+        activeFilePath: "src/second.ts",
+        activeFileLine: 9,
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
   it("ignores line batches from an aborted search stream", async () => {
     searchHarness.autoFlush = false;
     let setSearchQuery: ((query: string) => void) | null = null;


### PR DESCRIPTION
## Summary
- Prevent a late streamed Search result from restoring `selectedSearchMatchId` after the user has manually navigated results.
- Consume pending requested-match restoration from all Search selection navigation handlers.
- Add a mounted streaming regression that first fails by opening the late target instead of the user's selected match.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/search-surface.test.tsx --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench --reporter=dot`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `git diff --check`
- Branding/TODO scan over touched source/test files
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` (expected existing unrelated Knip backlog only)