### PR TITLE
fix(tui): reset task surface tails

### DIFF
--- a/runtime/src/tui/workbench/surfaces/ShellSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/ShellSurface.tsx
@@ -25,21 +25,27 @@ export function ShellSurface({ focused }: { readonly focused: boolean }): React.
   const task = useMemo(() => {
     return resolveWorkbenchShellTask(tasks, workbench.selectedShellTaskId);
   }, [tasks, workbench.selectedShellTaskId]);
-  const [tail, setTail] = useState("");
+  const [tailState, setTailState] = useState<{ readonly taskId: string | null; readonly content: string }>({
+    taskId: null,
+    content: "",
+  });
+  const tail = tailState.taskId === task?.id ? tailState.content : "";
 
   useEffect(() => {
     if (!task?.id) {
-      setTail("");
+      setTailState({ taskId: null, content: "" });
       return;
     }
+    const taskId = task.id;
+    setTailState({ taskId, content: "" });
     let mounted = true;
     const readTail = () => {
-      tailFile(getTaskOutputPath(task.id), TAIL_BYTES)
+      tailFile(getTaskOutputPath(taskId), TAIL_BYTES)
         .then((result) => {
-          if (mounted) setTail(result.content);
+          if (mounted) setTailState({ taskId, content: result.content });
         })
         .catch(() => {
-          if (mounted) setTail("");
+          if (mounted) setTailState({ taskId, content: "" });
         });
     };
     readTail();

--- a/runtime/src/tui/workbench/surfaces/TestSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/TestSurface.tsx
@@ -23,25 +23,32 @@ export function TestSurface({ focused }: { readonly focused: boolean }): React.R
   const task = useMemo(() => {
     return resolveWorkbenchShellTask(tasks, workbench.selectedShellTaskId);
   }, [tasks, workbench.selectedShellTaskId]);
-  const [tail, setTail] = useState("");
+  const [tailState, setTailState] = useState<{ readonly taskId: string | null; readonly content: string }>({
+    taskId: null,
+    content: "",
+  });
   const [selected, setSelected] = useState(0);
+  const tail = tailState.taskId === task?.id ? tailState.content : "";
   const failures = useMemo(() => parseVitestFailures(tail), [tail]);
   const selectedIndex = clampSurfaceSelection(selected, failures.length);
   const selectedFailure = failures[selectedIndex] ?? null;
 
   useEffect(() => {
     if (!task?.id) {
-      setTail("");
+      setTailState({ taskId: null, content: "" });
       return;
     }
+    const taskId = task.id;
+    setSelected(0);
+    setTailState({ taskId, content: "" });
     let mounted = true;
     const readTail = () => {
-      tailFile(getTaskOutputPath(task.id), TAIL_BYTES)
+      tailFile(getTaskOutputPath(taskId), TAIL_BYTES)
         .then((result) => {
-          if (mounted) setTail(result.content);
+          if (mounted) setTailState({ taskId, content: result.content });
         })
         .catch(() => {
-          if (mounted) setTail("");
+          if (mounted) setTailState({ taskId, content: "" });
         });
     };
     readTail();

--- a/runtime/tests/tui/workbench/shell-surface.test.tsx
+++ b/runtime/tests/tui/workbench/shell-surface.test.tsx
@@ -1,9 +1,27 @@
+import { PassThrough } from "node:stream";
+
 import React from "react";
-import { describe, expect, it, vi } from "vitest";
+import stripAnsi from "strip-ansi";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const shellHarness = vi.hoisted(() => ({
+  deferredTaskIds: new Set<string>(),
+  handlers: {} as Record<string, () => void>,
+  pendingReads: new Map<string, (result: { content: string }) => void>(),
+  tails: {} as Record<string, string>,
+}));
 
 vi.mock("../../../src/utils/fsOperations.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../src/utils/fsOperations.js")>()),
-  tailFile: vi.fn(async () => ({ content: "" })),
+  tailFile: vi.fn(async (path: string) => {
+    const taskId = /\/tmp\/(.+)\.log$/u.exec(path)?.[1] ?? path;
+    if (shellHarness.deferredTaskIds.has(taskId)) {
+      return new Promise<{ content: string }>((resolve) => {
+        shellHarness.pendingReads.set(taskId, resolve);
+      });
+    }
+    return { content: shellHarness.tails[taskId] ?? "" };
+  }),
 }));
 
 vi.mock("../../../src/utils/task/diskOutput.js", () => ({
@@ -12,14 +30,31 @@ vi.mock("../../../src/utils/task/diskOutput.js", () => ({
 
 vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
   useKeybinding: () => {},
-  useKeybindings: () => {},
+  useKeybindings: (handlers: Record<string, () => void>) => {
+    shellHarness.handlers = handlers;
+  },
 }));
 
-import { AppStateProvider, getDefaultAppState } from "../../../src/tui/state/AppState.js";
+import { createRoot } from "../../../src/tui/ink.js";
+import { AppStateProvider, getDefaultAppState, type AppState, useSetAppState } from "../../../src/tui/state/AppState.js";
 import { ShellSurface } from "../../../src/tui/workbench/surfaces/ShellSurface.js";
 import { renderToString } from "../../../src/utils/staticRender.js";
 
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
 describe("ShellSurface", () => {
+  beforeEach(() => {
+    shellHarness.deferredTaskIds = new Set();
+    shellHarness.handlers = {};
+    shellHarness.pendingReads = new Map();
+    shellHarness.tails = {};
+  });
+
   it("ignores stale selected ids that point at non-shell tasks", async () => {
     const output = await renderToString(
       <AppStateProvider
@@ -141,4 +176,134 @@ describe("ShellSurface", () => {
     expect(output).toContain("SHELL - running - new running shell");
     expect(output).not.toContain("old completed shell");
   });
+
+  it("clears stale tail content immediately when switching selected shell tasks", async () => {
+    shellHarness.tails["shell-old"] = [
+      "old task failed",
+      "src/old-task.ts:4:1",
+    ].join("\n");
+    shellHarness.deferredTaskIds.add("shell-new");
+    let selectTask: ((taskId: string) => void) | null = null;
+    const changes: AppState[] = [];
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            tasks: {
+              "shell-old": shellTask("shell-old", "old shell", "completed"),
+              "shell-new": shellTask("shell-new", "new shell", "running"),
+            },
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "shell",
+              selectedShellTaskId: "shell-old",
+            },
+          }}
+          onChangeAppState={({ newState }) => changes.push(newState)}
+        >
+          <ShellTaskSelector onReady={(setter) => { selectTask = setter; }} />
+          <ShellSurface focused={true} />
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      expect(compact(output())).toContain("src/old-task.ts:4");
+
+      const beforeSwitch = output();
+      selectTask?.("shell-new");
+      await sleep(25);
+
+      const afterSwitch = output().slice(beforeSwitch.length);
+      expect(compact(afterSwitch)).toContain("running-newshell");
+      expect(compact(afterSwitch)).not.toContain("src/old-task.ts");
+
+      shellHarness.handlers["surface:open"]?.();
+      expect(changes.at(-1)?.workbench.activeFilePath).not.toBe("src/old-task.ts");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
 });
+
+function ShellTaskSelector({
+  onReady,
+}: {
+  readonly onReady: (selectTask: (taskId: string) => void) => void;
+}): null {
+  const setAppState = useSetAppState();
+  React.useEffect(() => {
+    onReady((selectedShellTaskId: string) => {
+      setAppState((state) => ({
+        ...state,
+        workbench: {
+          ...state.workbench,
+          selectedShellTaskId,
+        },
+      }));
+    });
+  }, [onReady, setAppState]);
+  return null;
+}
+
+function shellTask(
+  id: string,
+  description: string,
+  status: "running" | "completed",
+): any {
+  return {
+    id,
+    type: "local_bash",
+    status,
+    description,
+    command: "npm test",
+    startTime: id === "shell-new" ? 2_000 : 1_000,
+    outputFile: `urn:agenc:task:${id}:output`,
+    outputOffset: 0,
+    notified: false,
+  };
+}
+
+function createStreams(): {
+  readonly stdin: TestStdin;
+  readonly stdout: PassThrough;
+  readonly output: () => string;
+} {
+  let output = "";
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).columns = 120;
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).rows = 24;
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).isTTY = true;
+  stdout.on("data", chunk => {
+    output += chunk.toString();
+  });
+
+  return {
+    stdin,
+    stdout,
+    output: () => stripAnsi(output),
+  };
+}
+
+function sleep(ms = 200): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function compact(value: string): string {
+  return value.replace(/\s+/gu, "");
+}

--- a/runtime/tests/tui/workbench/test-surface.test.tsx
+++ b/runtime/tests/tui/workbench/test-surface.test.tsx
@@ -1,22 +1,26 @@
+import { PassThrough } from "node:stream";
+
 import React from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const keybindingHarness = vi.hoisted(() => ({
+  deferredTaskIds: new Set<string>(),
   handlers: {} as Record<string, () => void>,
+  pendingReads: new Map<string, (result: { content: string }) => void>(),
+  tails: {} as Record<string, string>,
 }));
 
 vi.mock("../../../src/utils/fsOperations.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../src/utils/fsOperations.js")>()),
-  tailFile: vi.fn(async () => ({
-    content: [
-      "FAIL first failure",
-      "src/first.ts:4:1",
-      "first message",
-      "FAIL second failure",
-      "src/second.ts:9:1",
-      "second message",
-    ].join("\n"),
-  })),
+  tailFile: vi.fn(async (path: string) => {
+    const taskId = /\/tmp\/(.+)\.log$/u.exec(path)?.[1] ?? path;
+    if (keybindingHarness.deferredTaskIds.has(taskId)) {
+      return new Promise<{ content: string }>((resolve) => {
+        keybindingHarness.pendingReads.set(taskId, resolve);
+      });
+    }
+    return { content: keybindingHarness.tails[taskId] ?? defaultTestTail() };
+  }),
 }));
 
 vi.mock("../../../src/utils/task/diskOutput.js", () => ({
@@ -30,11 +34,26 @@ vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
   },
 }));
 
-import { AppStateProvider, getDefaultAppState, type AppState } from "../../../src/tui/state/AppState.js";
+import { createRoot } from "../../../src/tui/ink.js";
+import { AppStateProvider, getDefaultAppState, type AppState, useSetAppState } from "../../../src/tui/state/AppState.js";
 import { TestSurface, TestSurfaceView } from "../../../src/tui/workbench/surfaces/TestSurface.js";
 import { renderToString } from "../../../src/utils/staticRender.js";
 
+type TestStdin = PassThrough & {
+  isTTY: boolean;
+  ref: () => void;
+  setRawMode: (mode: boolean) => void;
+  unref: () => void;
+};
+
 describe("TestSurface", () => {
+  beforeEach(() => {
+    keybindingHarness.deferredTaskIds = new Set();
+    keybindingHarness.handlers = {};
+    keybindingHarness.pendingReads = new Map();
+    keybindingHarness.tails = {};
+  });
+
   it("clamps stale selection to the last parsed failure", async () => {
     const output = await renderToString(
       <TestSurfaceView
@@ -109,4 +128,130 @@ describe("TestSurface", () => {
       focusedPane: "surface",
     });
   });
+
+  it("clears stale failure output immediately when switching selected test tasks", async () => {
+    keybindingHarness.tails["shell-old"] = [
+      "FAIL old failure",
+      "src/old-test.ts:4:1",
+      "old message",
+    ].join("\n");
+    keybindingHarness.deferredTaskIds.add("shell-new");
+    let selectTask: ((taskId: string) => void) | null = null;
+    const changes: AppState[] = [];
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            tasks: {
+              "shell-old": shellTask("shell-old", "old test", "completed"),
+              "shell-new": shellTask("shell-new", "new test", "running"),
+            },
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "test",
+              selectedShellTaskId: "shell-old",
+            },
+          }}
+          onChangeAppState={({ newState }) => changes.push(newState)}
+        >
+          <TestTaskSelector onReady={(setter) => { selectTask = setter; }} />
+          <TestSurface focused={true} />
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      selectTask?.("shell-new");
+      await sleep(25);
+
+      keybindingHarness.handlers["surface:open"]?.();
+      expect(changes.at(-1)?.workbench.activeFilePath).not.toBe("src/old-test.ts");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
 });
+
+function TestTaskSelector({
+  onReady,
+}: {
+  readonly onReady: (selectTask: (taskId: string) => void) => void;
+}): null {
+  const setAppState = useSetAppState();
+  React.useEffect(() => {
+    onReady((selectedShellTaskId: string) => {
+      setAppState((state) => ({
+        ...state,
+        workbench: {
+          ...state.workbench,
+          selectedShellTaskId,
+        },
+      }));
+    });
+  }, [onReady, setAppState]);
+  return null;
+}
+
+function defaultTestTail(): string {
+  return [
+    "FAIL first failure",
+    "src/first.ts:4:1",
+    "first message",
+    "FAIL second failure",
+    "src/second.ts:9:1",
+    "second message",
+  ].join("\n");
+}
+
+function shellTask(
+  id: string,
+  description: string,
+  status: "running" | "completed",
+): any {
+  return {
+    id,
+    type: "local_bash",
+    status,
+    description,
+    command: "npm test",
+    startTime: id === "shell-new" ? 2_000 : 1_000,
+    outputFile: `urn:agenc:task:${id}:output`,
+    outputOffset: 0,
+    notified: false,
+  };
+}
+
+function createStreams(): {
+  readonly stdin: TestStdin;
+  readonly stdout: PassThrough;
+} {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough() as TestStdin;
+
+  stdin.isTTY = true;
+  stdin.ref = () => {};
+  stdin.setRawMode = () => {};
+  stdin.unref = () => {};
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).columns = 120;
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).rows = 24;
+  (stdout as unknown as { columns: number; rows: number; isTTY: boolean }).isTTY = true;
+  stdout.resume();
+
+  return {
+    stdin,
+    stdout,
+  };
+}
+
+function sleep(ms = 200): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary
- Reset Shell/Test task tail content immediately when selected task changes.
- Key async tail reads by task id so stale output cannot drive surface actions after a task switch.
- Add focused regressions for Shell and Test task switching while tail reads are pending.

## Test plan
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench/shell-surface.test.tsx tests/tui/workbench/test-surface.test.tsx --reporter=dot
- npm --workspace=@tetsuo-ai/runtime exec -- vitest run tests/tui/workbench --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- TUI validation gate script
- git diff --check
- branding/TODO scan over touched source and test files

## Notes
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on the existing unrelated Knip backlog: unused file src/tui/workbench/keymap.ts, 30 unused exports, and 4 unused @internal tag hints.