### PR TITLE
fix(tui): finalize explorer path actions atomically

### DIFF
--- a/runtime/src/tui/workbench/commands.ts
+++ b/runtime/src/tui/workbench/commands.ts
@@ -28,12 +28,28 @@ export function attachFileCommand(path: string): WorkbenchCommand {
   };
 }
 
-export function renamePathReferencesCommand(fromPath: string, toPath: string): WorkbenchCommand {
-  return { type: "renamePathReferences", fromPath, toPath };
+export function renamePathReferencesCommand(
+  fromPath: string,
+  toPath: string,
+  options: { readonly openAffectedBuffer?: boolean } = {},
+): WorkbenchCommand {
+  return {
+    type: "renamePathReferences",
+    fromPath,
+    toPath,
+    openAffectedBuffer: options.openAffectedBuffer,
+  };
 }
 
-export function deletePathReferencesCommand(path: string): WorkbenchCommand {
-  return { type: "deletePathReferences", path };
+export function deletePathReferencesCommand(
+  path: string,
+  options: { readonly closeAffectedSurface?: boolean } = {},
+): WorkbenchCommand {
+  return {
+    type: "deletePathReferences",
+    path,
+    closeAffectedSurface: options.closeAffectedSurface,
+  };
 }
 
 export function attachFileRangeCommand(

--- a/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
+++ b/runtime/src/tui/workbench/project-tree/ProjectExplorer.tsx
@@ -12,10 +12,6 @@ import TextInput from "../../components/TextInput.js";
 import { getGraphemeSegmenter } from "../../../utils/intl.js";
 import { inFlightPathsFromTasks } from "../agents/activity.js";
 import { attachFileCommand, deletePathReferencesCommand, openBufferCommand, renamePathReferencesCommand } from "../commands.js";
-import {
-  containsWorkspacePathReference,
-  renameWorkspacePathReference,
-} from "../pathReferences.js";
 import { useWorkbenchDispatch, useWorkbenchState } from "../state.js";
 import type { ProjectTreeRow } from "../types.js";
 import { getProjectTreeStore } from "./ProjectTreeStore.js";
@@ -112,12 +108,8 @@ export function ProjectExplorer({ focused, width }: Props): React.ReactElement {
       dispatch(openBufferCommand(result.path, undefined, true));
       return;
     }
-    const renamedActivePath = renamedActiveFilePath(workbench.activeFilePath, action.path, result.path);
-    dispatch(renamePathReferencesCommand(action.path, result.path));
-    if (renamedActivePath) {
-      dispatch(openBufferCommand(renamedActivePath, workbench.activeFileLine ?? undefined, false));
-    }
-  }, [dispatch, fileAction, store, workbench.activeFileLine, workbench.activeFilePath]);
+    dispatch(renamePathReferencesCommand(action.path, result.path, { openAffectedBuffer: true }));
+  }, [dispatch, fileAction, store]);
 
   const confirmDelete = useCallback(async () => {
     const action = fileAction;
@@ -129,11 +121,8 @@ export function ProjectExplorer({ focused, width }: Props): React.ReactElement {
       return;
     }
     setFileAction(null);
-    dispatch(deletePathReferencesCommand(action.path));
-    if (pathContains(workbench.activeFilePath, action.path)) {
-      dispatch({ type: "closeSurface" });
-    }
-  }, [dispatch, fileAction, store, workbench.activeFilePath]);
+    dispatch(deletePathReferencesCommand(action.path, { closeAffectedSurface: true }));
+  }, [dispatch, fileAction, store]);
 
   useRegisterKeybindingContext("Explorer", focused);
   useKeybindings(
@@ -435,12 +424,4 @@ function defaultCreateFilePath(row: ProjectTreeRow | null): string {
     return slash >= 0 ? `${row.path.slice(0, slash)}/` : "";
   }
   return "";
-}
-
-function pathContains(activePath: string | null, targetPath: string): boolean {
-  return containsWorkspacePathReference(activePath, targetPath);
-}
-
-function renamedActiveFilePath(activePath: string | null, fromPath: string, toPath: string): string | null {
-  return renameWorkspacePathReference(activePath, fromPath, toPath);
 }

--- a/runtime/src/tui/workbench/reducer.ts
+++ b/runtime/src/tui/workbench/reducer.ts
@@ -95,10 +95,28 @@ export function workbenchReducer(
       };
     case "closeSurface":
       return openSurface(state, "transcript");
-    case "renamePathReferences":
-      return renamePathReferences(state, command.fromPath, command.toPath);
-    case "deletePathReferences":
-      return deletePathReferences(state, command.path);
+    case "renamePathReferences": {
+      const nextState = renamePathReferences(state, command.fromPath, command.toPath);
+      if (
+        command.openAffectedBuffer === true &&
+        nextState.activeFilePath !== null &&
+        nextState.activeFilePath !== state.activeFilePath
+      ) {
+        return openSurface(nextState, "buffer", false);
+      }
+      return nextState;
+    }
+    case "deletePathReferences": {
+      const nextState = deletePathReferences(state, command.path);
+      if (
+        command.closeAffectedSurface === true &&
+        state.activeFilePath !== null &&
+        nextState.activeFilePath === null
+      ) {
+        return openSurface(nextState, "transcript");
+      }
+      return nextState;
+    }
     case "toggleExplorer":
       return {
         ...state,

--- a/runtime/src/tui/workbench/types.ts
+++ b/runtime/src/tui/workbench/types.ts
@@ -63,8 +63,17 @@ export type WorkbenchCommand =
   | { readonly type: "openAgent"; readonly taskId: string; readonly focus?: boolean }
   | { readonly type: "selectAgent"; readonly taskId: string | null }
   | { readonly type: "closeSurface" }
-  | { readonly type: "renamePathReferences"; readonly fromPath: string; readonly toPath: string }
-  | { readonly type: "deletePathReferences"; readonly path: string }
+  | {
+      readonly type: "renamePathReferences";
+      readonly fromPath: string;
+      readonly toPath: string;
+      readonly openAffectedBuffer?: boolean;
+    }
+  | {
+      readonly type: "deletePathReferences";
+      readonly path: string;
+      readonly closeAffectedSurface?: boolean;
+    }
   | { readonly type: "toggleExplorer"; readonly visible?: boolean }
   | { readonly type: "toggleAgents"; readonly visible?: boolean }
   | { readonly type: "attach"; readonly attachment: WorkbenchAttachment }

--- a/runtime/tests/tui/workbench/project-explorer-interactions.test.tsx
+++ b/runtime/tests/tui/workbench/project-explorer-interactions.test.tsx
@@ -9,6 +9,8 @@ const explorerHarness = vi.hoisted(() => {
     textInputProps: Array<Record<string, unknown>>;
     renameCalls: Array<readonly [string, string]>;
     deleteCalls: string[];
+    deferDelete: boolean;
+    pendingDeleteResolve: null | ((result: { readonly ok: true; readonly path: string }) => void);
     cursorRow: Record<string, unknown> | null;
     snapshot: Record<string, unknown>;
     store: Record<string, unknown>;
@@ -17,6 +19,8 @@ const explorerHarness = vi.hoisted(() => {
     textInputProps: [],
     renameCalls: [],
     deleteCalls: [],
+    deferDelete: false,
+    pendingDeleteResolve: null,
     cursorRow: {
       id: "src",
       path: "src",
@@ -92,6 +96,11 @@ const explorerHarness = vi.hoisted(() => {
     },
     deletePath: async (value: string) => {
       harness.deleteCalls.push(value);
+      if (harness.deferDelete) {
+        return new Promise((resolve) => {
+          harness.pendingDeleteResolve = resolve;
+        });
+      }
       return { ok: true, path: value };
     },
   };
@@ -128,7 +137,7 @@ vi.mock("../../../src/tui/workbench/project-tree/ProjectTreeStore.js", () => ({
 }));
 
 import { createRoot } from "../../../src/tui/ink.js";
-import { AppStateProvider, getDefaultAppState, type AppState } from "../../../src/tui/state/AppState.js";
+import { AppStateProvider, getDefaultAppState, type AppState, useSetAppState } from "../../../src/tui/state/AppState.js";
 import { ProjectExplorer } from "../../../src/tui/workbench/project-tree/ProjectExplorer.js";
 
 type TestStdin = PassThrough & {
@@ -166,6 +175,8 @@ describe("ProjectExplorer interactions", () => {
     explorerHarness.textInputProps = [];
     explorerHarness.renameCalls = [];
     explorerHarness.deleteCalls = [];
+    explorerHarness.deferDelete = false;
+    explorerHarness.pendingDeleteResolve = null;
   });
 
   it("updates the active buffer when renaming a directory that contains it", async () => {
@@ -229,6 +240,57 @@ describe("ProjectExplorer interactions", () => {
           endLine: 15,
         }],
         composerAttachmentIds: ["file-range:lib/nested/app.ts:12-15"],
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  it("does not reopen an unrelated active file when renaming another path", async () => {
+    const changes: AppState[] = [];
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              focusedPane: "explorer",
+              activeSurfaceMode: "preview",
+              activeFilePath: "other.ts",
+              activeFileLine: 5,
+            },
+          }}
+          onChangeAppState={({ newState }) => changes.push(newState)}
+        >
+          <ProjectExplorer focused={true} width={40} />
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      explorerHarness.handlers["explorer:rename"]?.();
+      await sleep();
+
+      const submitRename = explorerHarness.textInputProps.at(-1)?.onSubmit as ((value: string) => void) | undefined;
+      expect(submitRename).toEqual(expect.any(Function));
+      submitRename?.("lib");
+      await sleep();
+
+      expect(explorerHarness.renameCalls).toEqual([["src", "lib"]]);
+      expect(changes.at(-1)?.workbench).toMatchObject({
+        focusedPane: "explorer",
+        activeSurfaceMode: "preview",
+        activeFilePath: "other.ts",
+        activeFileLine: 5,
       });
     } finally {
       root.unmount();
@@ -312,4 +374,86 @@ describe("ProjectExplorer interactions", () => {
       stdout.end();
     }
   });
+
+  it("does not close a newer active file when delete finishes after navigation moved away", async () => {
+    explorerHarness.deferDelete = true;
+    const changes: AppState[] = [];
+    let setWorkbench: ((next: Partial<NonNullable<AppState["workbench"]>>) => void) | null = null;
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              focusedPane: "explorer",
+              activeSurfaceMode: "buffer",
+              activeFilePath: "src/nested/app.ts",
+              activeFileLine: 12,
+            },
+          }}
+          onChangeAppState={({ newState }) => changes.push(newState)}
+        >
+          <WorkbenchStateSetter onReady={(setter) => { setWorkbench = setter; }} />
+          <ProjectExplorer focused={true} width={40} />
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      explorerHarness.handlers["explorer:delete"]?.();
+      await sleep();
+
+      explorerHarness.handlers["confirm:yes"]?.();
+      await sleep();
+
+      setWorkbench?.({
+        activeSurfaceMode: "preview",
+        activeFilePath: "other.ts",
+        activeFileLine: 5,
+      });
+      await sleep();
+
+      explorerHarness.pendingDeleteResolve?.({ ok: true, path: "src" });
+      await sleep();
+
+      expect(explorerHarness.deleteCalls).toEqual(["src"]);
+      expect(changes.at(-1)?.workbench).toMatchObject({
+        activeSurfaceMode: "preview",
+        activeFilePath: "other.ts",
+        activeFileLine: 5,
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
 });
+
+function WorkbenchStateSetter({
+  onReady,
+}: {
+  readonly onReady: (setWorkbench: (next: Partial<NonNullable<AppState["workbench"]>>) => void) => void;
+}): null {
+  const setAppState = useSetAppState();
+  React.useEffect(() => {
+    onReady((next) => {
+      setAppState((state) => ({
+        ...state,
+        workbench: {
+          ...getDefaultAppState().workbench,
+          ...state.workbench,
+          ...next,
+        },
+      }));
+    });
+  }, [onReady, setAppState]);
+  return null;
+}

--- a/runtime/tests/tui/workbench/reducer.test.ts
+++ b/runtime/tests/tui/workbench/reducer.test.ts
@@ -254,6 +254,46 @@ describe("workbenchReducer", () => {
     ]);
   });
 
+  it("opens the buffer only when rename changes the current active path", () => {
+    const affected = workbenchReducer({
+      ...getDefaultWorkbenchState(),
+      focusedPane: "explorer",
+      activeSurfaceMode: "preview",
+      activeFilePath: "src/nested/app.ts",
+      activeFileLine: 12,
+    }, {
+      type: "renamePathReferences",
+      fromPath: "src",
+      toPath: "lib",
+      openAffectedBuffer: true,
+    });
+    const unaffected = workbenchReducer({
+      ...getDefaultWorkbenchState(),
+      focusedPane: "explorer",
+      activeSurfaceMode: "preview",
+      activeFilePath: "other.ts",
+      activeFileLine: 5,
+    }, {
+      type: "renamePathReferences",
+      fromPath: "src",
+      toPath: "lib",
+      openAffectedBuffer: true,
+    });
+
+    expect(affected).toMatchObject({
+      focusedPane: "explorer",
+      activeSurfaceMode: "buffer",
+      activeFilePath: "lib/nested/app.ts",
+      activeFileLine: 12,
+    });
+    expect(unaffected).toMatchObject({
+      focusedPane: "explorer",
+      activeSurfaceMode: "preview",
+      activeFilePath: "other.ts",
+      activeFileLine: 5,
+    });
+  });
+
   it("clears active paths and attached context when a workspace path is deleted", () => {
     const state = {
       ...getDefaultWorkbenchState(),
@@ -296,6 +336,41 @@ describe("workbenchReducer", () => {
       },
     ]);
     expect(next.composerAttachmentIds).toEqual(["file:src-old/app.ts"]);
+  });
+
+  it("closes the active surface only when delete clears the current active path", () => {
+    const affected = workbenchReducer({
+      ...getDefaultWorkbenchState(),
+      activeSurfaceMode: "buffer",
+      activeFilePath: "src/nested/app.ts",
+      activeFileLine: 12,
+    }, {
+      type: "deletePathReferences",
+      path: "src",
+      closeAffectedSurface: true,
+    });
+    const unaffected = workbenchReducer({
+      ...getDefaultWorkbenchState(),
+      activeSurfaceMode: "preview",
+      activeFilePath: "other.ts",
+      activeFileLine: 5,
+    }, {
+      type: "deletePathReferences",
+      path: "src",
+      closeAffectedSurface: true,
+    });
+
+    expect(affected).toMatchObject({
+      focusedPane: "surface",
+      activeSurfaceMode: "transcript",
+      activeFilePath: null,
+      activeFileLine: null,
+    });
+    expect(unaffected).toMatchObject({
+      activeSurfaceMode: "preview",
+      activeFilePath: "other.ts",
+      activeFileLine: 5,
+    });
   });
 
   it("opens and closes non-transcript surfaces", () => {


### PR DESCRIPTION
## Summary
- Move Explorer rename/delete follow-up decisions into workbench reducer commands so they run against current state.
- Avoid reopening unrelated active files after a rename.
- Avoid closing a newer active file when an in-flight delete finishes after navigation moved away.
- Add mounted Explorer regressions plus direct reducer coverage for affected and unaffected path-action finalizers.

## Test plan
- Focused ProjectExplorer tests passed: 1 file, 4 tests.
- Adjacent workbench path/reducer suites passed: 4 files, 41 tests.
- Full workbench tests passed: 31 files, 174 tests.
- `npm run typecheck` passed.
- Full TUI coverage passed: 755 files, 3137 tests; 93.47% statements, 86.66% branches, 91.87% functions, 94.47% lines.
- TUI validation gate passed: runtime rebuild plus artifact import and PTY startup smoke.
- `git diff --check` passed.
- Touched-file brand/TODO scan returned no matches.
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails only on existing unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.