### PR TITLE
fix(tui): reset permission confirmation per request

### DIFF
--- a/runtime/src/tui/permission-requests.tsx
+++ b/runtime/src/tui/permission-requests.tsx
@@ -278,7 +278,7 @@ export function AgenCPermissionOverlay({
   if (request === undefined || toolUseConfirm === null) {
     return null;
   }
-  return <AgenCApprovalOverlay request={request} toolUseConfirm={toolUseConfirm} />;
+  return <AgenCApprovalOverlay key={request.id} request={request} toolUseConfirm={toolUseConfirm} />;
 }
 
 function toolLabel(toolUseConfirm: ProjectedToolUseConfirm): string {

--- a/runtime/tests/tui/permission-requests.coverage.test.tsx
+++ b/runtime/tests/tui/permission-requests.coverage.test.tsx
@@ -162,6 +162,69 @@ describe("permission request overlay coverage", () => {
     }
   });
 
+  test("clears typed high-risk confirmation when the pending request changes", async () => {
+    const firstResolved: ReviewDecision[] = [];
+    const secondResolved: ReviewDecision[] = [];
+    const firstRequest = createPendingRequest(
+      decision => {
+        firstResolved.push(decision);
+      },
+      {
+        id: "request-delete-first",
+        input: { command: "rm -rf /tmp/agenc-first" },
+        description: "Delete generated path",
+      },
+    );
+    const secondRequest = createPendingRequest(
+      decision => {
+        secondResolved.push(decision);
+      },
+      {
+        id: "request-delete-second",
+        input: { command: "rm -rf /tmp/agenc-second" },
+        description: "Delete another generated path",
+      },
+    );
+    const tools = [{ name: "Bash" }];
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(<AgenCPermissionOverlay request={firstRequest} tools={tools} />);
+      await sleep();
+
+      for (const character of "delete") {
+        stdin.write(character);
+        await sleep();
+      }
+      stdin.write("\r");
+      await sleep();
+
+      expect(firstResolved).toEqual([APPROVED]);
+      expect(secondResolved).toEqual([]);
+
+      root.render(<AgenCPermissionOverlay request={secondRequest} tools={tools} />);
+      await sleep();
+
+      expect(stripAnsi(extractLastFrame(output()))).toContain("second");
+      expect(secondResolved).toEqual([]);
+
+      stdin.write("\r");
+      await sleep();
+
+      expect(secondResolved).toEqual([]);
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      await sleep();
+    }
+  });
+
   test("renders split command arguments as the destructive command", async () => {
     const resolved: ReviewDecision[] = [];
     const request = createPendingRequest(


### PR DESCRIPTION
## Summary
- Scope destructive approval confirmation state to the active request id.
- Prevent a newly displayed destructive approval from inheriting a typed confirmation word from the previous approval.
- Add a mounted permission-overlay regression that proves Enter alone cannot approve the second request after the first one was confirmed.

## Test plan
- Focused permission overlay tests passed: 1 file, 3 tests.
- Adjacent permission and approval suites passed: 4 files, 14 tests.
- `npm run typecheck` passed.
- Full TUI coverage passed: 755 files, 3138 tests; 93.47% statements, 86.67% branches, 91.87% functions, 94.47% lines.
- TUI validation gate passed: runtime rebuild plus artifact import and PTY startup smoke.
- `git diff --check` passed.
- Touched-file brand/TODO scan returned no matches.
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails only on existing unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.