### PR TITLE
fix(tui): reject pre-aborted approvals

### DIFF
--- a/runtime/src/tui/permission-requests.tsx
+++ b/runtime/src/tui/permission-requests.tsx
@@ -220,6 +220,10 @@ export function usePermissionRequests(
     session.services.approvalResolver = {
       request(ctx) {
         return new Promise<ReviewDecision>((resolve) => {
+          if (ctx.signal?.aborted === true) {
+            resolve(ABORT);
+            return;
+          }
           const request: PendingRequest = {
             id: ctx.callId,
             ctx,

--- a/runtime/tests/tui/coverage-swarm/swarm-035-permission-requests.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-035-permission-requests.test.tsx
@@ -201,6 +201,19 @@ describe("permission request swarm coverage", () => {
       expect(resolver).toBeDefined();
 
       const abortController = new AbortController();
+      const preAbortedController = new AbortController();
+      preAbortedController.abort();
+      const preAbortedDecision = resolver!.request(
+        createCtx(
+          "pre-aborted-shell",
+          "Shell",
+          {
+            kind: "local_shell",
+            params: { command: ["pwd"] },
+          },
+          { signal: preAbortedController.signal },
+        ),
+      );
       const missingPayloadDecision = resolver!.request(
         createCtx("missing-payload", "Read", undefined),
       );
@@ -237,6 +250,8 @@ describe("permission request swarm coverage", () => {
       await waitFor(() => {
         expect(latestRequests).toHaveLength(5);
       });
+      await expect(preAbortedDecision).resolves.toEqual(ABORT);
+      expect(latestRequests.map(request => request.id)).not.toContain("pre-aborted-shell");
       expect(
         latestRequests.map(request => ({
           id: request.id,


### PR DESCRIPTION
## Summary
- Resolve already-aborted permission requests as aborted before queueing them.
- Prevent pre-aborted requests from appearing in the pending approval queue.
- Add permission resolver regression coverage for the pre-aborted signal path.

## Test plan
- Focused permission resolver test passed: 1 file, 2 tests.
- Adjacent permission and approval suites passed: 4 files, 14 tests.
- `npm run typecheck` passed.
- Full TUI coverage passed: 755 files, 3138 tests; 93.47% statements, 86.67% branches, 91.87% functions, 94.47% lines.
- TUI validation gate passed: runtime rebuild plus artifact import and PTY startup smoke.
- `git diff --check` passed.
- Touched-file brand/TODO scan returned no matches.
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails only on existing unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused tag hints.