### PR TITLE
fix(tui): preserve leading-dot paths

### DIFF
--- a/runtime/src/tui/components/GlobalSearchDialog.tsx
+++ b/runtime/src/tui/components/GlobalSearchDialog.tsx
@@ -15,9 +15,9 @@ import { getCwd } from '../../utils/cwd';
 import { openFileInExternalEditor } from '../../utils/editor';
 import { truncatePathMiddle, truncateToWidth } from '../../utils/format';
 import { highlightMatch } from '../../utils/highlightMatch';
-import { relativePath } from '../../utils/permissions/filesystem';
 import { readFileInRange } from '../../utils/readFileInRange';
 import { ripGrepStream } from '../../utils/ripgrep';
+import { displayPathRelativeToBase } from '../pathDisplay.js';
 import { FuzzyPicker } from './design-system/FuzzyPicker';
 import { LoadingState } from './design-system/LoadingState';
 type Props = {
@@ -324,10 +324,9 @@ function _temp4(query_0, controller_1, setMatches_0, setTruncated_0, setIsSearch
       if (!m_1) {
         continue;
       }
-      const rel = relativePath(cwd, m_1.file);
       parsed.push({
         ...m_1,
-        file: rel.startsWith("..") ? m_1.file : rel
+        file: displayPathRelativeToBase(cwd, m_1.file)
       });
     }
     if (!parsed.length) {

--- a/runtime/src/tui/components/memory/path-format.ts
+++ b/runtime/src/tui/components/memory/path-format.ts
@@ -1,9 +1,11 @@
 import { isAbsolute, relative } from 'path';
 
+import { isRelativePathOutsideBase } from '../../pathDisplay.js';
+
 function containedRelativePath(basePath: string, targetPath: string): string | null {
   const relativePath = relative(basePath, targetPath);
   if (relativePath === '') return '';
-  if (relativePath.startsWith('..') || isAbsolute(relativePath)) return null;
+  if (isRelativePathOutsideBase(relativePath) || isAbsolute(relativePath)) return null;
   return relativePath;
 }
 

--- a/runtime/src/tui/hooks/fileSuggestions.ts
+++ b/runtime/src/tui/hooks/fileSuggestions.ts
@@ -13,6 +13,7 @@ import {
   FileIndex,
   yieldToEventLoop,
 } from '../ink/native-ts/file-index/index'
+import { isRelativePathOutsideBase } from '../pathDisplay.js'
 import { logEvent } from '../../services/analytics/index'
 import type { FileSuggestionCommandInput } from '../../types/fileSuggestion'
 import { getGlobalConfig } from '../../utils/config.js' // upstream-import: keep target is owned by another Z-PURGE item
@@ -870,7 +871,7 @@ export async function generateFileSuggestions(
     // untracked dotfiles surface the same way `@` alone shows them.
     if (
       normalizedPath.startsWith('.') &&
-      !normalizedPath.startsWith('..') &&
+      !isRelativePathOutsideBase(normalizedPath) &&
       !normalizedPath.includes(path.sep) &&
       matches.length < MAX_SUGGESTIONS
     ) {

--- a/runtime/src/tui/pathDisplay.ts
+++ b/runtime/src/tui/pathDisplay.ts
@@ -1,0 +1,17 @@
+import { relativePath } from "../utils/permissions/filesystem.js";
+
+export function isAbsoluteLikePath(path: string): boolean {
+  return path.startsWith("/") || /^[A-Za-z]:[\\/]/u.test(path);
+}
+
+export function isRelativePathOutsideBase(path: string): boolean {
+  const normalized = path.replaceAll("\\", "/");
+  return normalized === ".." || normalized.startsWith("../") || isAbsoluteLikePath(path);
+}
+
+export function displayPathRelativeToBase(basePath: string, targetPath: string): string {
+  if (!isAbsoluteLikePath(targetPath)) return targetPath;
+  const relative = relativePath(basePath, targetPath);
+  if (!relative || isRelativePathOutsideBase(relative)) return targetPath;
+  return relative;
+}

--- a/runtime/src/tui/workbench/buffer/BufferStore.ts
+++ b/runtime/src/tui/workbench/buffer/BufferStore.ts
@@ -5,6 +5,7 @@ import { lastGrapheme } from "../../../utils/intl.js";
 import { TextCursor } from "../../../utils/TextCursor.js";
 import type { VimMode } from "../../../types/textInputTypes.js";
 import type { Key } from "../../ink.js";
+import { isRelativePathOutsideBase } from "../../pathDisplay.js";
 import {
   executeIndent,
   executeJoin,
@@ -895,7 +896,7 @@ export class WorkbenchBufferStore {
 function displayPathForAbsolute(absolutePath: string): string {
   const cwd = getCwd();
   const relativePath = relative(cwd, absolutePath);
-  return relativePath.startsWith("..") || relativePath === "" || resolve(cwd, relativePath) !== absolutePath
+  return isRelativePathOutsideBase(relativePath) || relativePath === "" || resolve(cwd, relativePath) !== absolutePath
     ? absolutePath
     : relativePath;
 }

--- a/runtime/src/tui/workbench/search/model.ts
+++ b/runtime/src/tui/workbench/search/model.ts
@@ -1,4 +1,5 @@
 import { relativePath } from "../../../utils/permissions/filesystem.js";
+import { isRelativePathOutsideBase } from "../../pathDisplay.js";
 import type { SearchGroup, SearchMatch } from "../types.js";
 
 export function parseWorkbenchRipgrepLine(line: string, cwd: string): SearchMatch | null {
@@ -8,7 +9,7 @@ export function parseWorkbenchRipgrepLine(line: string, cwd: string): SearchMatc
   const lineNumber = Number.parseInt(lineText ?? "", 10);
   if (!rawFile || !Number.isFinite(lineNumber)) return null;
   const rel = isAbsoluteLike(rawFile) ? relativePath(cwd, rawFile) : rawFile;
-  const file = rel.startsWith("..") ? rawFile : rel;
+  const file = isRelativePathOutsideBase(rel) ? rawFile : rel;
   return {
     id: `${file}:${lineNumber}:${text ?? ""}`,
     file,

--- a/runtime/tests/tui/components/GlobalSearchDialog.render.test.tsx
+++ b/runtime/tests/tui/components/GlobalSearchDialog.render.test.tsx
@@ -271,12 +271,13 @@ describe('GlobalSearchDialog render and interactions', () => {
 
       await searchFor('needle', [
         '/workspace/project/src/app.tsx:12:Needle alpha',
+        '/workspace/project/..config:4:Needle config',
         '/tmp/outside.ts:3:needle beta',
         'not a ripgrep match',
       ])
 
       await waitFor(
-        () => pickerProps().items.length === 2 && pickerProps().matchLabel === '2 matches',
+        () => pickerProps().items.length === 3 && pickerProps().matchLabel === '3 matches',
         'Global search results did not render',
       )
 
@@ -288,6 +289,11 @@ describe('GlobalSearchDialog render and interactions', () => {
         text: 'Needle alpha',
       })
       expect(props.items[1]).toEqual({
+        file: '..config',
+        line: 4,
+        text: 'Needle config',
+      })
+      expect(props.items[2]).toEqual({
         file: '/tmp/outside.ts',
         line: 3,
         text: 'needle beta',

--- a/runtime/tests/tui/components/memory/MemoryUpdateNotification.test.tsx
+++ b/runtime/tests/tui/components/memory/MemoryUpdateNotification.test.tsx
@@ -39,6 +39,13 @@ describe('memory path display formatting', () => {
     ).toBe('./AGENC.md')
     expect(
       getRelativeMemoryPathForRoots(
+        '/workspace/project/..config',
+        '/home/user',
+        '/workspace/project',
+      ),
+    ).toBe('./..config')
+    expect(
+      getRelativeMemoryPathForRoots(
         '/home/user/project/AGENC.md',
         '/home/user',
         '/home/user/project',

--- a/runtime/tests/tui/hooks/fileSuggestions.test.ts
+++ b/runtime/tests/tui/hooks/fileSuggestions.test.ts
@@ -264,6 +264,19 @@ describe('fileSuggestions hidden-file visibility', () => {
     expect(matches).not.toContain('.other')
   })
 
+  test('dotted prefix query with two literal dots surfaces matching top-level files', async () => {
+    writeFileSync(join(tempCwd, '..hidden-file.txt'), '')
+    writeFileSync(join(tempCwd, '..hideme'), '')
+    writeFileSync(join(tempCwd, '..other'), '')
+
+    const items = await generateFileSuggestions('..hid')
+    const names = items.map(i => i.displayText)
+
+    expect(names).toContain('..hidden-file.txt')
+    expect(names).toContain('..hideme')
+    expect(names).not.toContain('..other')
+  })
+
   test('getHiddenTopLevelMatches marks directories with a trailing separator', async () => {
     mkdirSync(join(tempCwd, '.config'), { recursive: true })
 

--- a/runtime/tests/tui/workbench/buffer-store.test.ts
+++ b/runtime/tests/tui/workbench/buffer-store.test.ts
@@ -231,6 +231,27 @@ describe("WorkbenchBufferStore", () => {
     expect(store.getText()).toBe("draft alpha\n");
   });
 
+  it("keeps definition targets with leading-dot relative names relative", async () => {
+    await writeFile(join(dir, "target.txt"), "alpha\n", "utf8");
+    await writeFile(join(dir, "..definition.txt"), "definition\n", "utf8");
+    lspHarness.requestBufferDefinition.mockResolvedValue({
+      path: join(dir, "..definition.txt"),
+      line: 1,
+      character: 0,
+    });
+    const store = new WorkbenchBufferStore();
+
+    await runWithCwdOverride(dir, () => store.open("target.txt"));
+
+    await expect(runWithCwdOverride(dir, () => store.goToDefinition())).resolves.toBe(true);
+    expect(store.getSnapshot()).toMatchObject({
+      status: "ready",
+      filePath: "..definition.txt",
+      position: { line: 1 },
+    });
+    expect(store.getText()).toBe("definition\n");
+  });
+
   it("reports failed definition navigation when the target cannot be loaded", async () => {
     await writeFile(join(dir, "target.txt"), "alpha\n", "utf8");
     lspHarness.requestBufferDefinition.mockResolvedValue({

--- a/runtime/tests/tui/workbench/search-model.test.ts
+++ b/runtime/tests/tui/workbench/search-model.test.ts
@@ -25,6 +25,15 @@ describe("workbench search model", () => {
     expect(parseWorkbenchRipgrepLine("not-a-match", "/repo")).toBeNull();
   });
 
+  it("keeps workspace files whose relative names start with dots relative", () => {
+    expect(parseWorkbenchRipgrepLine("/repo/..config:3:needle", "/repo")).toEqual({
+      id: "..config:3:needle",
+      file: "..config",
+      line: 3,
+      text: "needle",
+    });
+  });
+
   it("groups matches by file and exposes visible header rows", () => {
     const groups = groupSearchMatches([
       { id: "a:1:x", file: "a.ts", line: 1, text: "x" },


### PR DESCRIPTION
## Summary
- Add a shared TUI path-display boundary helper that distinguishes parent traversal from valid leading-dot filenames.
- Keep workspace files such as `..config` relative in workbench search, global search, buffer definition navigation, memory path labels, and file suggestions.
- Add regressions across each affected TUI path.

## Test plan
- Focused regression first failed for `/repo/..config`, proving the parser returned an absolute path instead of `..config`.
- Targeted tests passed: 5 files, 55 tests.
- `npm run typecheck` passed.
- Full TUI coverage passed: 755 files, 3141 tests; 93.47% statements, 86.68% branches, 91.88% functions, 94.47% lines.
- TUI validation gate passed: runtime rebuild plus artifact import and PTY startup smoke.
- `git diff --check` passed.
- Touched-file brand/TODO scan returned no matches.
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails only on existing unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.