### PR TITLE
fix(tui): retry repeated buffer opens

### DIFF
--- a/runtime/src/tui/workbench/reducer.ts
+++ b/runtime/src/tui/workbench/reducer.ts
@@ -19,6 +19,7 @@ export function getDefaultWorkbenchState(): WorkbenchState {
     activeSurfaceMode: "transcript",
     activeFilePath: null,
     activeFileLine: null,
+    bufferOpenRequestId: 0,
     selectedAgentTaskId: null,
     selectedShellTaskId: null,
     openDiffId: null,
@@ -57,6 +58,7 @@ export function workbenchReducer(
         ...openSurface(state, "buffer", command.focus ?? true),
         activeFilePath: command.path,
         activeFileLine: command.line ?? null,
+        bufferOpenRequestId: state.bufferOpenRequestId + 1,
       };
     case "openSearch":
       const nextSearchQuery = command.query ?? state.searchQuery;

--- a/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/BufferSurface.tsx
@@ -31,6 +31,7 @@ export function BufferSurface({ focused }: { readonly focused: boolean }): React
   const tasks = useAppState((state) => state.tasks);
   const activePath = workbench.activeFilePath;
   const activeLine = workbench.activeFileLine ?? 1;
+  const activeOpenRequestId = workbench.bufferOpenRequestId;
   const lastOpenRequest = useRef<string | null>(null);
   const inFlightAgent = useMemo(
     () => Object.values(tasks).find((task) =>
@@ -51,7 +52,7 @@ export function BufferSurface({ focused }: { readonly focused: boolean }): React
 
   useEffect(() => {
     if (!activePath) return;
-    const requestKey = `${activePath}\u0000${activeLine}`;
+    const requestKey = `${activePath}\u0000${activeLine}\u0000${activeOpenRequestId}`;
     const isNewRequest = lastOpenRequest.current !== requestKey;
     const shouldRetryCleanBlockedPath =
       snapshot.status !== "loading" &&
@@ -61,7 +62,7 @@ export function BufferSurface({ focused }: { readonly focused: boolean }): React
     if (!isNewRequest && !shouldRetryCleanBlockedPath) return;
     lastOpenRequest.current = requestKey;
     void store.open(activePath, activeLine);
-  }, [activeLine, activePath, snapshot.dirty, snapshot.filePath, snapshot.status, store]);
+  }, [activeLine, activeOpenRequestId, activePath, snapshot.dirty, snapshot.filePath, snapshot.status, store]);
 
   useEffect(() => {
     store.setViewportRows(Math.max(1, rows - 9));

--- a/runtime/src/tui/workbench/types.ts
+++ b/runtime/src/tui/workbench/types.ts
@@ -41,6 +41,7 @@ export type WorkbenchState = {
   readonly activeSurfaceMode: ActiveSurfaceMode;
   readonly activeFilePath: string | null;
   readonly activeFileLine: number | null;
+  readonly bufferOpenRequestId: number;
   readonly selectedAgentTaskId: string | null;
   readonly selectedShellTaskId: string | null;
   readonly openDiffId: string | null;

--- a/runtime/tests/tui/workbench/buffer-surface.test.tsx
+++ b/runtime/tests/tui/workbench/buffer-surface.test.tsx
@@ -75,6 +75,20 @@ function OpenBufferRequest({ path }: { readonly path: string | null }): null {
   return null;
 }
 
+function OpenBufferRetryRequest({
+  path,
+  attempt,
+}: {
+  readonly path: string | null;
+  readonly attempt: number;
+}): null {
+  const dispatch = useWorkbenchDispatch();
+  React.useEffect(() => {
+    if (path) dispatch({ type: "openBuffer", path, line: 1, focus: true });
+  }, [attempt, dispatch, path]);
+  return null;
+}
+
 let dir: string;
 
 beforeEach(async () => {
@@ -303,6 +317,64 @@ describe("BufferSurface", () => {
           dirty: false,
         });
         expect(store.getText()).toBe("second\n");
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  it("retries the same active buffer path after an initial load error", async () => {
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    function App({ retryAttempt }: { readonly retryAttempt: number }): React.ReactElement {
+      return (
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "buffer",
+              activeFilePath: "missing.ts",
+              activeFileLine: 1,
+            },
+          }}
+        >
+          <KeybindingSetup>
+            <OpenBufferRetryRequest path={retryAttempt > 0 ? "missing.ts" : null} attempt={retryAttempt} />
+            <BufferSurface focused={true} />
+          </KeybindingSetup>
+        </AppStateProvider>
+      );
+    }
+
+    try {
+      await runWithCwdOverride(dir, async () => {
+        root.render(<App retryAttempt={0} />);
+        await sleep();
+
+        const store = getWorkbenchBufferStore();
+        expect(store.getSnapshot()).toMatchObject({
+          status: "error",
+          filePath: null,
+        });
+
+        await writeFile(join(dir, "missing.ts"), "created\n", "utf8");
+        root.render(<App retryAttempt={1} />);
+        await sleep();
+
+        expect(store.getSnapshot()).toMatchObject({
+          status: "ready",
+          filePath: "missing.ts",
+          dirty: false,
+        });
+        expect(store.getText()).toBe("created\n");
       });
     } finally {
       root.unmount();

--- a/runtime/tests/tui/workbench/reducer.test.ts
+++ b/runtime/tests/tui/workbench/reducer.test.ts
@@ -75,6 +75,26 @@ describe("workbenchReducer", () => {
     });
   });
 
+  it("increments buffer open requests even when reopening the same path", () => {
+    const first = workbenchReducer(undefined, {
+      type: "openBuffer",
+      path: "src/index.ts",
+      line: 7,
+    });
+    const retry = workbenchReducer(first, {
+      type: "openBuffer",
+      path: "src/index.ts",
+      line: 7,
+    });
+
+    expect(retry).toMatchObject({
+      activeSurfaceMode: "buffer",
+      activeFilePath: "src/index.ts",
+      activeFileLine: 7,
+      bufferOpenRequestId: first.bufferOpenRequestId + 1,
+    });
+  });
+
   it("cycles through visible panes", () => {
     const explorer = workbenchReducer(undefined, {
       type: "focus",


### PR DESCRIPTION
## Summary
- Track explicit buffer open requests separately from the active path and line.
- Retry same-path buffer opens after an initial load error instead of suppressing them as duplicates.
- Add mounted Buffer surface and reducer regressions for repeated buffer open requests.

## Test plan
- Focused Buffer surface test failed before the fix by staying in error state after a same-path retry.
- Targeted Buffer surface and reducer tests passed: 2 files, 27 tests.
- `npm run typecheck` passed.
- Full workbench suite passed: 31 files, 178 tests.
- Full TUI coverage passed: 755 files, 3143 tests; 93.47% statements, 86.69% branches, 91.88% functions, 94.47% lines.
- TUI validation gate passed: runtime rebuild plus artifact import and PTY startup smoke.
- `git diff --check` passed.
- Touched-file brand/TODO scan returned no matches.
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails only on existing unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.