### PR TITLE
fix(tui): avoid empty preview crash

### DIFF
--- a/runtime/src/tui/workbench/surfaces/PreviewSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/PreviewSurface.tsx
@@ -55,7 +55,7 @@ export function PreviewSurface({ focused }: { readonly focused: boolean }): Reac
     if (!absolutePath) {
       setContent("");
       setError(null);
-      setGitState(null);
+      setGitStateState({ path: null, status: null });
       setTotalLines(null);
       return;
     }

--- a/runtime/tests/tui/workbench/preview-surface.test.tsx
+++ b/runtime/tests/tui/workbench/preview-surface.test.tsx
@@ -56,6 +56,43 @@ afterEach(() => {
 });
 
 describe("PreviewSurface", () => {
+  it("renders an empty preview without crashing when no file is selected", async () => {
+    const { stdin, stdout, output } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "preview",
+              activeFilePath: null,
+              activeFileLine: null,
+            },
+          }}
+        >
+          <PreviewSurface focused={false} />
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      const frame = output();
+      expect(compact(frame)).toContain("Nofileselected");
+      expect(frame).not.toContain("ERROR");
+      expect(frame).not.toContain("setGitState");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
   it("renders read-only file content without overflowing the terminal", async () => {
     const { stdin, stdout, output } = createStreams();
     const root = await createRoot({
@@ -142,3 +179,7 @@ describe("PreviewSurface", () => {
     }
   });
 });
+
+function compact(value: string): string {
+  return value.replace(/\s+/gu, "");
+}


### PR DESCRIPTION
## Summary
- Fix the empty Preview surface path so it clears git metadata through the real state setter.
- Add a mounted regression for rendering Preview with no selected file.
- Keep the assertion guarding against an Ink error frame from the previous undefined setter.

## Test plan
- Focused Preview regression failed before the fix with `[Ink:uncaught] ReferenceError: setGitState is not defined`.
- Focused Preview test passed: 1 file, 3 tests.
- Adjacent Preview tests passed: 4 files, 6 tests.
- Full workbench suite passed: 31 files, 179 tests.
- `npm run typecheck` passed.
- Full TUI coverage passed: 755 files, 3144 tests; 93.49% statements, 86.71% branches, 91.88% functions, 94.50% lines.
- TUI validation gate passed: runtime rebuild plus artifact import and PTY startup smoke.
- `git diff --check` passed.
- Touched-file brand/TODO scan returned no matches.
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails only on existing unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.