### PR TITLE
fix(tui): hide stale quick-open previews

### DIFF
--- a/runtime/src/tui/components/QuickOpenDialog.tsx
+++ b/runtime/src/tui/components/QuickOpenDialog.tsx
@@ -231,7 +231,7 @@ export function QuickOpenDialog(t0) {
   }
   let t13;
   if ($[21] !== preview || $[22] !== previewWidth || $[23] !== query) {
-    t13 = p_7 => preview ? <><Text dimColor={true}>{truncatePathMiddle(p_7, previewWidth)}{preview.path !== p_7 ? " - loading..." : ""}</Text>{preview.content.split("\n").map((line, i_1) => <Text key={i_1}>{highlightMatch(truncateToWidth(line, previewWidth), query)}</Text>)}</> : <LoadingState message={"Loading preview..."} dimColor={true} />;
+    t13 = p_7 => preview?.path === p_7 ? <><Text dimColor={true}>{truncatePathMiddle(p_7, previewWidth)}</Text>{preview.content.split("\n").map((line, i_1) => <Text key={i_1}>{highlightMatch(truncateToWidth(line, previewWidth), query)}</Text>)}</> : <><Text dimColor={true}>{truncatePathMiddle(p_7, previewWidth)}{preview ? " - loading..." : ""}</Text><LoadingState message={"Loading preview..."} dimColor={true} /></>;
     $[21] = preview;
     $[22] = previewWidth;
     $[23] = query;

--- a/runtime/tests/tui/components/QuickOpenDialog.render.test.tsx
+++ b/runtime/tests/tui/components/QuickOpenDialog.render.test.tsx
@@ -301,7 +301,7 @@ describe('QuickOpenDialog render and interactions', () => {
     }
   })
 
-  it('loads preview content and shows the stale preview path while a new focus is loading', async () => {
+  it('loads preview content without showing stale content under a new focused path', async () => {
     const rendered = await renderDialog()
 
     try {
@@ -359,7 +359,8 @@ describe('QuickOpenDialog render and interactions', () => {
         120,
       )
       expect(staleOutput).toContain('src/beta.ts - loading...')
-      expect(staleOutput).toContain('needle alpha')
+      expect(staleOutput).toContain('Loading preview...')
+      expect(staleOutput).not.toContain('needle alpha')
 
       secondPreview.resolve({ content: 'beta ready' })
       const refreshedOutput = await waitForRenderedText(


### PR DESCRIPTION
## Summary
- Render Quick Open preview content only when it belongs to the currently focused path.
- Show a loading state for the newly focused path instead of displaying the previous file's preview underneath it.
- Update the mounted Quick Open regression so it catches stale preview content during focus changes.

## Test plan
- Focused Quick Open regression failed before the fix by rendering `src/beta.ts - loading...` with `src/alpha.ts` content underneath.
- Focused Quick Open test passed: 1 file, 6 tests.
- Adjacent Quick Open tests passed: 3 files, 13 tests.
- `npm run typecheck` passed.
- Full TUI coverage passed: 755 files, 3144 tests; 93.49% statements, 86.71% branches, 91.88% functions, 94.50% lines.
- TUI validation gate passed: runtime rebuild plus artifact import and PTY startup smoke.
- `git diff --check` passed.
- Touched-file brand/TODO scan returned no matches.
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails only on existing unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.