### PR TITLE
fix(tui): guard pending history selections

### DIFF
--- a/runtime/src/tui/history/HistorySearchDialog.tsx
+++ b/runtime/src/tui/history/HistorySearchDialog.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 // Moved-source note: imported by moved purge roots until the owning subsystem is absorbed.
 import * as React from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRegisterOverlay } from '../context/overlayContext.js';
 import { getTimestampedHistory, type TimestampedHistoryEntry } from './history.js';
 import { useTerminalSize } from '../hooks/useTerminalSize.js';
@@ -37,6 +37,14 @@ export function HistorySearchDialog({
   } = useTerminalSize();
   const [items, setItems] = useState<Item[] | null>(null);
   const [query, setQuery] = useState(initialQuery ?? '');
+  const isMountedRef = useRef(true);
+  const isSelectionResolvingRef = useRef(false);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
   useEffect(() => {
     let cancelled = false;
     void (async () => {
@@ -84,11 +92,23 @@ export function HistorySearchDialog({
   const rowWidth = Math.max(20, listWidth - AGE_WIDTH - 1);
   const previewWidth = previewOnRight ? Math.max(20, columns - listWidth - 12) : Math.max(20, columns - 10);
   return <FuzzyPicker title="Search prompts" placeholder="Filter history…" initialQuery={initialQuery} items={filtered} getKey={item_0 => String(item_0.entry.timestamp)} onQueryChange={setQuery} onSelect={item_1 => {
+    if (isSelectionResolvingRef.current) return;
+    isSelectionResolvingRef.current = true;
     logEvent('agenc_history_picker_select', {
       result_count: filtered.length,
       query_length: query.length
     });
-    void item_1.entry.resolve().then(onSelect);
+    void item_1.entry.resolve().then(entry => {
+      if (!isMountedRef.current) return;
+      isSelectionResolvingRef.current = false;
+      onSelect(entry);
+    }, () => {
+      if (!isMountedRef.current) return;
+      isSelectionResolvingRef.current = false;
+      logEvent('agenc_history_picker_select_error', {
+        query_length: query.length
+      });
+    });
   }} onCancel={onCancel} emptyMessage={q_0 => items === null ? 'Loading…' : q_0 ? 'No matching prompts' : 'No history yet'} selectAction="use" direction="up" previewPosition={previewOnRight ? 'right' : 'bottom'} renderItem={(item_2, isFocused) => <Text>
           <Text dimColor>{item_2.age}</Text>
           <Text color={isFocused ? 'suggestion' : undefined}>

--- a/runtime/tests/tui/history/HistorySearchDialog.coverage.test.tsx
+++ b/runtime/tests/tui/history/HistorySearchDialog.coverage.test.tsx
@@ -36,9 +36,9 @@ type CapturedPickerProps = {
   renderPreview: (item: PickerItem) => React.ReactNode
 }
 
-type Deferred = {
-  promise: Promise<void>
-  resolve: () => void
+type Deferred<T = void> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
 }
 
 const harness = vi.hoisted(() => ({
@@ -109,9 +109,9 @@ import { createRoot } from '../ink/root.js'
 import { renderToString } from '../../utils/staticRender.js'
 import { HistorySearchDialog } from './HistorySearchDialog.js'
 
-function deferred(): Deferred {
-  let resolve!: () => void
-  const promise = new Promise<void>(res => {
+function deferred<T = void>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>(res => {
     resolve = res
   })
 
@@ -335,5 +335,68 @@ describe('HistorySearchDialog coverage', () => {
     } finally {
       await rendered.dispose()
     }
+  })
+
+  it('does not resolve a history selection more than once while it is pending', async () => {
+    const resolvedEntry = { display: 'slow prompt' }
+    const pendingSelection = deferred<HistoryEntryLike>()
+    const resolveEntry = vi.fn(() => pendingSelection.promise)
+    harness.entries = [
+      {
+        display: 'slow prompt',
+        timestamp: 1710000000000,
+        resolve: resolveEntry,
+      },
+    ]
+
+    const rendered = await renderDialog()
+
+    try {
+      await waitFor(
+        () => pickerProps().items.length === 1,
+        'History search item did not load',
+      )
+
+      const selectedItem = pickerProps().items[0]!
+      pickerProps().onSelect(selectedItem)
+      pickerProps().onSelect(selectedItem)
+
+      expect(resolveEntry).toHaveBeenCalledTimes(1)
+      pendingSelection.resolve(resolvedEntry)
+
+      await waitFor(
+        () => rendered.onSelect.mock.calls.length === 1,
+        'History search selection did not resolve exactly once',
+      )
+      expect(rendered.onSelect).toHaveBeenCalledWith(resolvedEntry)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  it('does not apply a pending history selection after the dialog unmounts', async () => {
+    const pendingSelection = deferred<HistoryEntryLike>()
+    const resolveEntry = vi.fn(() => pendingSelection.promise)
+    harness.entries = [
+      {
+        display: 'cancelled slow prompt',
+        timestamp: 1710000000000,
+        resolve: resolveEntry,
+      },
+    ]
+
+    const rendered = await renderDialog()
+    await waitFor(
+      () => pickerProps().items.length === 1,
+      'History search item did not load',
+    )
+
+    pickerProps().onSelect(pickerProps().items[0]!)
+    await rendered.dispose()
+    pendingSelection.resolve({ display: 'cancelled slow prompt' })
+    await sleep(25)
+
+    expect(resolveEntry).toHaveBeenCalledTimes(1)
+    expect(rendered.onSelect).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- Prevent slow history picker selections from starting duplicate lazy resolves
- Ignore a resolved history selection after the dialog has unmounted or been canceled
- Add focused regressions for duplicate pending selection and unmount-before-resolve

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/history/HistorySearchDialog.coverage.test.tsx tests/tui/coverage-swarm/swarm-190-history-HistorySearchDialog.test.tsx --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- git diff --check
- rg touched files for blocked branding/TODO terms

## Notes
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still reports the existing unrelated Knip backlog.