### PR TITLE
fix(tui): parse global search results as json

### DIFF
--- a/runtime/src/tui/components/GlobalSearchDialog.tsx
+++ b/runtime/src/tui/components/GlobalSearchDialog.tsx
@@ -314,13 +314,13 @@ export function GlobalSearchDialog(t0) {
 function _temp4(query_0, controller_1, setMatches_0, setTruncated_0, setIsSearching_0) {
   const cwd = getCwd();
   let collected = 0;
-  ripGrepStream(["-n", "--no-heading", "-i", "-m", String(MAX_MATCHES_PER_FILE), "-F", "-e", query_0], cwd, controller_1.signal, lines => {
+  ripGrepStream(["--json", "-i", "-m", String(MAX_MATCHES_PER_FILE), "-F", "-e", query_0], cwd, controller_1.signal, lines => {
     if (controller_1.signal.aborted) {
       return;
     }
     const parsed = [];
     for (const line of lines) {
-      const m_1 = parseRipgrepLine(line);
+      const m_1 = parseRipgrepJsonLine(line);
       if (!m_1) {
         continue;
       }
@@ -367,6 +367,46 @@ function _temp(m) {
 }
 function matchKey(m: Match): string {
   return `${m.file}:${m.line}`;
+}
+
+function stripJsonLineTerminator(text: string): string {
+  if (text.endsWith('\r\n')) return text.slice(0, -2);
+  if (text.endsWith('\n') || text.endsWith('\r')) return text.slice(0, -1);
+  return text;
+}
+
+function parseRipgrepJsonLine(line: string): Match | null {
+  let message: unknown;
+  try {
+    message = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (!message || typeof message !== 'object') return null;
+  const typedMessage = message as {
+    type?: unknown;
+    data?: {
+      path?: {
+        text?: unknown;
+      };
+      line_number?: unknown;
+      lines?: {
+        text?: unknown;
+      };
+    };
+  };
+  if (typedMessage.type !== 'match') return null;
+  const file = typedMessage.data?.path?.text;
+  const lineNum = Number(typedMessage.data?.line_number);
+  const text = typedMessage.data?.lines?.text;
+  if (typeof file !== 'string' || !file || !Number.isSafeInteger(lineNum) || lineNum < 1 || typeof text !== 'string') {
+    return null;
+  }
+  return {
+    file,
+    line: lineNum,
+    text: stripJsonLineTerminator(text)
+  };
 }
 
 /**

--- a/runtime/tests/tui/components/GlobalSearchDialog.render.test.tsx
+++ b/runtime/tests/tui/components/GlobalSearchDialog.render.test.tsx
@@ -115,6 +115,17 @@ function emptyMessage(props: CapturedPickerProps, query: string): string {
   return typeof message === 'function' ? message(query) : message ?? ''
 }
 
+function jsonMatchLine(file: string, line: number, text: string): string {
+  return JSON.stringify({
+    type: 'match',
+    data: {
+      path: { text: file },
+      line_number: line,
+      lines: { text: `${text}\n` },
+    },
+  })
+}
+
 async function waitFor(
   predicate: () => boolean,
   message: string,
@@ -205,8 +216,7 @@ async function searchFor(query: string, lines: readonly string[]) {
       onLines: (chunk: readonly string[]) => void,
     ) => {
       expect(args).toEqual([
-        '-n',
-        '--no-heading',
+        '--json',
         '-i',
         '-m',
         '10',
@@ -270,9 +280,9 @@ describe('GlobalSearchDialog render and interactions', () => {
       })
 
       await searchFor('needle', [
-        '/workspace/project/src/app.tsx:12:Needle alpha',
-        '/workspace/project/..config:4:Needle config',
-        '/tmp/outside.ts:3:needle beta',
+        jsonMatchLine('/workspace/project/src/app.tsx', 12, 'Needle alpha'),
+        jsonMatchLine('/workspace/project/..config', 4, 'Needle config'),
+        jsonMatchLine('/tmp/outside.ts', 3, 'needle beta'),
         'not a ripgrep match',
       ])
 
@@ -332,6 +342,60 @@ describe('GlobalSearchDialog render and interactions', () => {
     }
   })
 
+  it('preserves file paths that contain colon-number segments in search results', async () => {
+    const rendered = await renderDialog()
+
+    try {
+      const rawPath = '/workspace/project/src/topic:12/app.ts'
+      harness.ripGrepStream.mockImplementation(
+        async (
+          args: string[],
+          cwd: string,
+          signal: AbortSignal,
+          onLines: (chunk: readonly string[]) => void,
+        ) => {
+          expect(args).toEqual([
+            '--json',
+            '-i',
+            '-m',
+            '10',
+            '-F',
+            '-e',
+            'needle',
+          ])
+          expect(cwd).toBe(harness.cwd)
+          expect(signal.aborted).toBe(false)
+          onLines([
+            JSON.stringify({
+              type: 'match',
+              data: {
+                path: { text: rawPath },
+                line_number: 4,
+                lines: { text: 'Needle in colon path\n' },
+              },
+            }),
+          ])
+        },
+      )
+
+      pickerProps().onQueryChange('needle')
+
+      await waitFor(
+        () =>
+          pickerProps().items.length === 1 &&
+          pickerProps().items[0]?.file === 'src/topic:12/app.ts',
+        'Global search did not preserve the full colon-number path',
+      )
+      expect(pickerProps().items[0]).toEqual({
+        file: 'src/topic:12/app.ts',
+        line: 4,
+        text: 'Needle in colon path',
+      })
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   it('shows no-match state after a completed empty search', async () => {
     const rendered = await renderDialog()
 
@@ -354,7 +418,9 @@ describe('GlobalSearchDialog render and interactions', () => {
     const rendered = await renderDialog()
 
     try {
-      await searchFor('needle', ['/workspace/project/src/app.tsx:12:Needle alpha'])
+      await searchFor('needle', [
+        jsonMatchLine('/workspace/project/src/app.tsx', 12, 'Needle alpha'),
+      ])
       await waitFor(
         () => pickerProps().items.length === 1 && pickerProps().matchLabel === '1 matches',
         'Global search result did not render for action test',

--- a/runtime/tests/tui/components/GlobalSearchDialog.wave200-129.coverage.test.tsx
+++ b/runtime/tests/tui/components/GlobalSearchDialog.wave200-129.coverage.test.tsx
@@ -111,6 +111,17 @@ function emptyMessage(props: CapturedPickerProps, query: string): string {
   return typeof message === 'function' ? message(query) : message ?? ''
 }
 
+function jsonMatchLine(file: string, line: number, text: string): string {
+  return JSON.stringify({
+    type: 'match',
+    data: {
+      path: { text: file },
+      line_number: line,
+      lines: { text: `${text}\n` },
+    },
+  })
+}
+
 async function waitFor(
   predicate: () => boolean,
   message: string,
@@ -202,7 +213,12 @@ describe('GlobalSearchDialog wave 200 worker 129 coverage', () => {
       const query = 'needle'
       const lines = Array.from(
         { length: 501 },
-        (_, i) => `/workspace/project/src/file-${i}.ts:${i + 1}:Needle ${i}`,
+        (_, i) =>
+          jsonMatchLine(
+            `/workspace/project/src/file-${i}.ts`,
+            i + 1,
+            `Needle ${i}`,
+          ),
       )
       let searchSignal: AbortSignal | undefined
 
@@ -215,8 +231,7 @@ describe('GlobalSearchDialog wave 200 worker 129 coverage', () => {
           onLines: (chunk: readonly string[]) => void,
         ) => {
           expect(args).toEqual([
-            '-n',
-            '--no-heading',
+            '--json',
             '-i',
             '-m',
             '10',

--- a/runtime/tests/tui/coverage-swarm/swarm-127-components-GlobalSearchDialog.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-127-components-GlobalSearchDialog.test.tsx
@@ -111,6 +111,17 @@ function pickerProps(): CapturedPickerProps {
   return props
 }
 
+function jsonMatchLine(file: string, line: number, text: string): string {
+  return JSON.stringify({
+    type: 'match',
+    data: {
+      path: { text: file },
+      line_number: line,
+      lines: { text: `${text}\n` },
+    },
+  })
+}
+
 async function waitFor(
   predicate: () => boolean,
   message: string,
@@ -222,27 +233,26 @@ describe('GlobalSearchDialog coverage swarm row 127', () => {
           onLines: (chunk: readonly string[]) => void,
         ) => {
           searchSignals.push(signal)
-          expect(args.slice(0, 8)).toEqual([
-            '-n',
-            '--no-heading',
+          expect(args.slice(0, 7)).toEqual([
+            '--json',
             '-i',
             '-m',
             '10',
             '-F',
             '-e',
-            args[7],
+            args[6],
           ])
           expect(cwd).toBe(harness.cwd)
 
-          if (args[7] === 'needle') {
+          if (args[6] === 'needle') {
             onLines([
-              '/workspace/project/src/alpha.ts:2:Needle alpha',
-              '/workspace/project/src/beta.ts:3:Needle beta',
+              jsonMatchLine('/workspace/project/src/alpha.ts', 2, 'Needle alpha'),
+              jsonMatchLine('/workspace/project/src/beta.ts', 3, 'Needle beta'),
             ])
             return
           }
 
-          onLines(['/workspace/project/src/alpha.ts:2:Needle alpha'])
+          onLines([jsonMatchLine('/workspace/project/src/alpha.ts', 2, 'Needle alpha')])
         },
       )
 


### PR DESCRIPTION
## Summary
- Switch Global Search to consume structured ripgrep JSON match events.
- Preserve full result paths that contain colon-number path segments.
- Add regression coverage for colon-number paths and update existing Global Search stream fixtures.

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/GlobalSearchDialog.render.test.tsx tests/tui/components/GlobalSearchDialog.wave200-129.coverage.test.tsx tests/tui/coverage-swarm/swarm-127-components-GlobalSearchDialog.test.tsx --reporter=dot
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/GlobalSearchDialog.render.test.tsx tests/tui/components/GlobalSearchDialog.wave200-129.coverage.test.tsx tests/tui/components/GlobalSearchDialog.layout.test.ts tests/tui/coverage-swarm/swarm-127-components-GlobalSearchDialog.test.tsx --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- git diff --check
- Touched-file branding/TODO scan

## Notes
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on existing unrelated Knip backlog: src/tui/workbench/keymap.ts, unused exports, and @internal tag hints.