### PR TITLE
fix(tui): guard custom file suggestions

### DIFF
--- a/runtime/src/tui/hooks/fileSuggestions.ts
+++ b/runtime/src/tui/hooks/fileSuggestions.ts
@@ -821,14 +821,19 @@ export async function generateFileSuggestions(
   // Use custom command directly if configured. We don't mix in our config files
   // because the command returns pre-ranked results using its own search logic.
   if (getInitialSettings().fileSuggestion?.type === 'command') {
-    const input: FileSuggestionCommandInput = {
-      ...createBaseHookInput(),
-      query: partialPath,
+    try {
+      const input: FileSuggestionCommandInput = {
+        ...createBaseHookInput(),
+        query: partialPath,
+      }
+      const results = await executeFileSuggestionCommand(input)
+      return results
+        .slice(0, MAX_SUGGESTIONS)
+        .map(path => createFileSuggestionItem(path))
+    } catch (error) {
+      logError(error)
+      return []
     }
-    const results = await executeFileSuggestionCommand(input)
-    return results
-      .slice(0, MAX_SUGGESTIONS)
-      .map(path => createFileSuggestionItem(path))
   }
 
   // If the partial path is empty or just a dot, return current directory suggestions

--- a/runtime/tests/tui/hooks/fileSuggestions.test.ts
+++ b/runtime/tests/tui/hooks/fileSuggestions.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 let tempCwd = ''
 
 const harness = vi.hoisted(() => ({
+  commandError: null as Error | null,
   commandInputs: [] as unknown[],
   commandResults: [] as string[],
   fileIndexLoads: [] as string[][],
@@ -25,6 +26,7 @@ const harness = vi.hoisted(() => ({
   settings: {} as Record<string, unknown>,
   yieldToEventLoop: vi.fn(async () => {}),
   reset() {
+    this.commandError = null
     this.commandInputs = []
     this.commandResults = []
     this.fileIndexLoads = []
@@ -68,6 +70,7 @@ vi.mock('../../utils/hooks.js', () => ({
   createBaseHookInput: () => ({ base: true }),
   executeFileSuggestionCommand: async (input: unknown) => {
     harness.commandInputs.push(input)
+    if (harness.commandError) throw harness.commandError
     return harness.commandResults
   },
 }))
@@ -412,6 +415,16 @@ describe('generateFileSuggestions edge branches', () => {
     expect(items[0]?.metadata).toBeUndefined()
     expect(items[1]?.metadata).toBeUndefined()
     expect(items.at(-1)?.displayText).toBe('result-14.ts')
+  })
+
+  test('custom command suggestion failures are logged and return no suggestions', async () => {
+    const error = new Error('custom command failed')
+    harness.settings = { fileSuggestion: { type: 'command' } }
+    harness.commandError = error
+
+    await expect(generateFileSuggestions('src')).resolves.toEqual([])
+    expect(harness.commandInputs).toEqual([{ base: true, query: 'src' }])
+    expect(harness.logError).toHaveBeenCalledWith(error)
   })
 
   test('non-empty search normalizes current-directory prefixes and backfills hidden matches', async () => {


### PR DESCRIPTION
## Summary
- Catch configured custom file-suggestion command failures inside `generateFileSuggestions`.
- Preserve the hook contract by logging the failure and returning an empty suggestion list.
- Add regression coverage for the failing custom-command branch.

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/fileSuggestions.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/fileSuggestions.test.ts tests/tui/components/QuickOpenDialog.render.test.tsx tests/tui/coverage-swarm/swarm-165-components-QuickOpenDialog.test.tsx tests/tui/components/PromptInput/PromptInput.render.test.tsx --reporter=dot
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core
- git diff --check
- Touched-file branding/TODO scan

## Notes
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on existing unrelated Knip backlog: src/tui/workbench/keymap.ts, unused exports, and @internal tag hints.