### PR TITLE
fix(tui): guard history search reader failures

### DIFF
--- a/runtime/src/tui/hooks/useHistorySearch.ts
+++ b/runtime/src/tui/hooks/useHistorySearch.ts
@@ -13,6 +13,7 @@ import { useInput } from '../ink.js'
 import { useKeybinding, useKeybindings } from '../keybindings/useKeybinding.js'
 import type { PromptInputMode } from '../../types/textInputTypes'
 import type { HistoryEntry } from '../../utils/config' // upstream-import: keep target is owned by another Z-PURGE item
+import { logError } from '../../utils/log.js'
 
 export function useHistorySearch(
   onAcceptHistory: (entry: HistoryEntry) => void,
@@ -105,7 +106,18 @@ export function useHistorySearch(
           return
         }
 
-        const item = await historyReader.current.next()
+        let item
+        try {
+          item = await historyReader.current.next()
+        } catch (error) {
+          if (signal?.aborted) {
+            return
+          }
+          logError(error)
+          setHistoryFailedMatch(true)
+          closeHistoryReader()
+          return
+        }
         if (item.done) {
           // No match found - keep last match but mark as failed
           setHistoryFailedMatch(true)

--- a/runtime/tests/tui/hooks/useHistorySearch.test.tsx
+++ b/runtime/tests/tui/hooks/useHistorySearch.test.tsx
@@ -21,6 +21,8 @@ const harness = vi.hoisted(() => ({
     next: ReturnType<typeof vi.fn>;
     return: ReturnType<typeof vi.fn>;
   }>,
+  readerError: null as Error | null,
+  logError: vi.fn(),
   reset() {
     harness.entries = [];
     harness.features = new Set();
@@ -28,6 +30,8 @@ const harness = vi.hoisted(() => ({
     harness.keybinding = new Map();
     harness.keybindings = new Map();
     harness.readers = [];
+    harness.readerError = null;
+    harness.logError.mockClear();
   },
 }));
 
@@ -45,6 +49,7 @@ vi.mock("../history/history.js", () => ({
     let index = 0;
     const reader = {
       next: vi.fn(async () => {
+        if (harness.readerError) throw harness.readerError;
         if (index >= harness.entries.length) {
           return { done: true, value: undefined };
         }
@@ -59,6 +64,10 @@ vi.mock("../history/history.js", () => ({
     harness.readers.push(reader);
     return reader;
   },
+}));
+
+vi.mock("../../utils/log.js", () => ({
+  logError: harness.logError,
 }));
 
 vi.mock("../keybindings/useKeybinding.js", () => ({
@@ -322,6 +331,32 @@ describe("useHistorySearch", () => {
         keep: true,
       });
       expect(harness.readers.at(-1)?.return).toHaveBeenCalled();
+    } finally {
+      await rendered.dispose();
+    }
+  });
+
+  test("logs history reader failures and marks the search as failed", async () => {
+    const error = new Error("history read failed");
+    harness.readerError = error;
+    const rendered = await renderHistoryHarness({
+      currentInput: "keep me",
+      currentPastedContents: { keep: true },
+    });
+
+    try {
+      harness.keybinding.get("history:search")?.handler();
+      await waitFor(() => expect(rendered.isSearching()).toBe(true));
+      rendered.result().setHistoryQuery("needle");
+
+      await waitFor(() =>
+        expect(rendered.result().historyFailedMatch).toBe(true),
+      );
+      expect(harness.logError).toHaveBeenCalledWith(error);
+      expect(rendered.callbacks.onInputChange).not.toHaveBeenCalledWith(
+        "needle",
+      );
+      expect(rendered.result().historyMatch).toBeUndefined();
     } finally {
       await rendered.dispose();
     }


### PR DESCRIPTION
## Summary
- Catch active history-search reader failures from `historyReader.current.next()`.
- Log non-abort reader errors, mark the search as failed, and close the reader instead of surfacing an unhandled rejection.
- Add a focused regression for reader rejection during active history search.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/useHistorySearch.test.tsx --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/useHistorySearch.test.tsx tests/tui/hooks/useHistorySearch.runtime-coverage.test.tsx tests/tui/coverage-swarm/swarm-192-hooks-useHistorySearch.test.ts tests/tui/components/PromptInput/PromptInput.render.test.tsx --reporter=dot`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `git diff --check`
- Touched-file branding/TODO scan

## Known existing backlog
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the pre-existing unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.
