### PR TITLE
fix(tui): parse workbench search results as json

### DIFF
--- a/runtime/src/tui/workbench/search/model.ts
+++ b/runtime/src/tui/workbench/search/model.ts
@@ -2,24 +2,62 @@ import { relativePath } from "../../../utils/permissions/filesystem.js";
 import { isRelativePathOutsideBase } from "../../pathDisplay.js";
 import type { SearchGroup, SearchMatch } from "../types.js";
 
-export function parseWorkbenchRipgrepLine(line: string, cwd: string): SearchMatch | null {
-  const match = /^(.*?):(\d+):(.*)$/u.exec(line);
-  if (!match) return null;
-  const [, rawFile, lineText, text] = match;
-  const lineNumber = Number.parseInt(lineText ?? "", 10);
-  if (!rawFile || !Number.isFinite(lineNumber)) return null;
-  const rel = isAbsoluteLike(rawFile) ? relativePath(cwd, rawFile) : rawFile;
-  const file = isRelativePathOutsideBase(rel) ? rawFile : rel;
+export function parseWorkbenchRipgrepJsonLine(line: string, cwd: string): SearchMatch | null {
+  let message: unknown;
+  try {
+    message = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (!message || typeof message !== "object") return null;
+  const typedMessage = message as {
+    readonly type?: unknown;
+    readonly data?: {
+      readonly path?: {
+        readonly text?: unknown;
+      };
+      readonly line_number?: unknown;
+      readonly lines?: {
+        readonly text?: unknown;
+      };
+    };
+  };
+  if (typedMessage.type !== "match") return null;
+  const rawFile = typedMessage.data?.path?.text;
+  const lineNumber = Number(typedMessage.data?.line_number);
+  const text = typedMessage.data?.lines?.text;
+  if (
+    typeof rawFile !== "string" ||
+    !rawFile ||
+    !Number.isSafeInteger(lineNumber) ||
+    lineNumber < 1 ||
+    typeof text !== "string"
+  ) {
+    return null;
+  }
+  const strippedText = stripJsonLineTerminator(text);
+  const file = normalizeWorkbenchSearchPath(rawFile, cwd);
   return {
-    id: `${file}:${lineNumber}:${text ?? ""}`,
+    id: `${file}:${lineNumber}:${strippedText}`,
     file,
     line: lineNumber,
-    text: text ?? "",
+    text: strippedText,
   };
+}
+
+function normalizeWorkbenchSearchPath(rawFile: string, cwd: string): string {
+  const rel = isAbsoluteLike(rawFile) ? relativePath(cwd, rawFile) : rawFile;
+  return isRelativePathOutsideBase(rel) ? rawFile : rel;
 }
 
 function isAbsoluteLike(value: string): boolean {
   return value.startsWith("/") || /^[A-Za-z]:[\\/]/u.test(value);
+}
+
+function stripJsonLineTerminator(text: string): string {
+  if (text.endsWith("\r\n")) return text.slice(0, -2);
+  if (text.endsWith("\n") || text.endsWith("\r")) return text.slice(0, -1);
+  return text;
 }
 
 export function groupSearchMatches(matches: readonly SearchMatch[]): SearchGroup[] {

--- a/runtime/src/tui/workbench/surfaces/SearchSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/SearchSurface.tsx
@@ -7,7 +7,7 @@ import { Box, Text } from "../../ink.js";
 import { useKeybindings } from "../../keybindings/useKeybinding.js";
 import { useRegisterKeybindingContext } from "../../keybindings/KeybindingContext.js";
 import { attachSearchMatchCommand, openBufferCommand } from "../commands.js";
-import { groupSearchMatches, parseWorkbenchRipgrepLine, visibleSearchRows } from "../search/model.js";
+import { groupSearchMatches, parseWorkbenchRipgrepJsonLine, visibleSearchRows } from "../search/model.js";
 import { useWorkbenchDispatch, useWorkbenchState } from "../state.js";
 import type { SearchMatch } from "../types.js";
 import { EmptySurface, SurfaceHeader } from "./PreviewSurface.js";
@@ -43,13 +43,13 @@ export function SearchSurface({ focused }: { readonly focused: boolean }): React
     const next: SearchMatch[] = [];
     const timer = setTimeout(() => {
       void ripGrepStream(
-        ["-n", "--no-heading", "-i", "-m", "20", "-F", "-e", query],
+        ["--json", "-i", "-m", "20", "-F", "-e", query],
         cwd,
         controller.signal,
         (lines) => {
           if (controller.signal.aborted) return;
           for (const line of lines) {
-            const match = parseWorkbenchRipgrepLine(line, cwd);
+            const match = parseWorkbenchRipgrepJsonLine(line, cwd);
             if (match) next.push(match);
           }
           setMatches(next.slice(0, 500));

--- a/runtime/tests/tui/workbench/search-model.test.ts
+++ b/runtime/tests/tui/workbench/search-model.test.ts
@@ -2,36 +2,48 @@ import { describe, expect, it } from "vitest";
 
 import {
   groupSearchMatches,
-  parseWorkbenchRipgrepLine,
+  parseWorkbenchRipgrepJsonLine,
   visibleSearchRows,
 } from "../../../src/tui/workbench/search/model.js";
 
 describe("workbench search model", () => {
-  it("parses ripgrep output while preserving colon-containing paths", () => {
-    expect(parseWorkbenchRipgrepLine("src/app.ts:12:needle", "/repo")).toEqual({
+  it("parses ripgrep json match events while preserving path boundaries", () => {
+    expect(parseWorkbenchRipgrepJsonLine(jsonMatchLine("src/app.ts", 12, "needle"), "/repo")).toEqual({
       id: "src/app.ts:12:needle",
       file: "src/app.ts",
       line: 12,
       text: "needle",
     });
 
-    expect(parseWorkbenchRipgrepLine("C:/repo/src/app.ts:8:needle", "C:/repo")).toEqual({
+    expect(parseWorkbenchRipgrepJsonLine(jsonMatchLine("C:/repo/src/app.ts", 8, "needle"), "C:/repo")).toEqual({
       id: "src/app.ts:8:needle",
       file: "src/app.ts",
       line: 8,
       text: "needle",
     });
 
-    expect(parseWorkbenchRipgrepLine("not-a-match", "/repo")).toBeNull();
+    expect(parseWorkbenchRipgrepJsonLine("not-a-match", "/repo")).toBeNull();
   });
 
   it("keeps workspace files whose relative names start with dots relative", () => {
-    expect(parseWorkbenchRipgrepLine("/repo/..config:3:needle", "/repo")).toEqual({
+    expect(parseWorkbenchRipgrepJsonLine(jsonMatchLine("/repo/..config", 3, "needle"), "/repo")).toEqual({
       id: "..config:3:needle",
       file: "..config",
       line: 3,
       text: "needle",
     });
+  });
+
+  it("parses ripgrep json match events without splitting colon-number path segments", () => {
+    expect(parseWorkbenchRipgrepJsonLine(jsonMatchLine("/repo/src/topic:12/app.ts", 4, "needle json\r\n"), "/repo")).toEqual({
+      id: "src/topic:12/app.ts:4:needle json",
+      file: "src/topic:12/app.ts",
+      line: 4,
+      text: "needle json",
+    });
+
+    expect(parseWorkbenchRipgrepJsonLine("not json", "/repo")).toBeNull();
+    expect(parseWorkbenchRipgrepJsonLine(JSON.stringify({ type: "begin" }), "/repo")).toBeNull();
   });
 
   it("groups matches by file and exposes visible header rows", () => {
@@ -63,3 +75,14 @@ describe("workbench search model", () => {
     ]);
   });
 });
+
+function jsonMatchLine(file: string, line: number, text: string): string {
+  return JSON.stringify({
+    type: "match",
+    data: {
+      path: { text: file },
+      line_number: line,
+      lines: { text },
+    },
+  });
+}

--- a/runtime/tests/tui/workbench/search-surface.test.tsx
+++ b/runtime/tests/tui/workbench/search-surface.test.tsx
@@ -90,6 +90,17 @@ function sleep(ms = 200): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function jsonMatchLine(file: string, line: number, text: string): string {
+  return JSON.stringify({
+    type: "match",
+    data: {
+      path: { text: file },
+      line_number: line,
+      lines: { text: `${text}\n` },
+    },
+  });
+}
+
 function SearchQueryController({
   onReady,
 }: {
@@ -202,8 +213,8 @@ describe("SearchSurface", () => {
 
   it("selects the requested search match id after ripgrep results load", async () => {
     searchHarness.lines = [
-      "src/first.ts:4:const needle = true",
-      "src/second.ts:9:needle()",
+      jsonMatchLine("src/first.ts", 4, "const needle = true"),
+      jsonMatchLine("src/second.ts", 9, "needle()"),
     ];
     const changes: AppState[] = [];
     const { stdin, stdout, output } = createStreams();
@@ -248,6 +259,65 @@ describe("SearchSurface", () => {
     }
   });
 
+  it("preserves colon-number path segments from structured ripgrep output", async () => {
+    searchHarness.autoFlush = false;
+    const changes: AppState[] = [];
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "search",
+              searchQuery: "needle",
+            },
+          }}
+          onChangeAppState={({ newState }) => changes.push(newState)}
+        >
+          <SearchSurface focused={false} />
+        </AppStateProvider>,
+      );
+      await sleep(180);
+
+      expect(searchHarness.calls).toHaveLength(1);
+      const call = searchHarness.calls[0]!;
+      expect(call.args).toEqual([
+        "--json",
+        "-i",
+        "-m",
+        "20",
+        "-F",
+        "-e",
+        "needle",
+      ]);
+
+      call.onLines([
+        jsonMatchLine("src/topic:12/app.ts", 4, "const needle = true"),
+      ]);
+      call.resolve();
+      await sleep(50);
+      searchHarness.handlers["surface:open"]?.();
+
+      expect(changes.at(-1)?.workbench).toMatchObject({
+        activeSurfaceMode: "buffer",
+        activeFilePath: "src/topic:12/app.ts",
+        activeFileLine: 4,
+      });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
   it("does not restore the requested search match after manual navigation during streaming", async () => {
     searchHarness.autoFlush = false;
     const changes: AppState[] = [];
@@ -280,9 +350,9 @@ describe("SearchSurface", () => {
       expect(searchHarness.calls).toHaveLength(1);
       const call = searchHarness.calls[0]!;
       call.onLines([
-        "src/first.ts:4:const needle = true",
-        "src/second.ts:9:needle()",
-        "src/third.ts:10:needle again",
+        jsonMatchLine("src/first.ts", 4, "const needle = true"),
+        jsonMatchLine("src/second.ts", 9, "needle()"),
+        jsonMatchLine("src/third.ts", 10, "needle again"),
       ]);
       await sleep();
 
@@ -297,7 +367,7 @@ describe("SearchSurface", () => {
         activeFileLine: 10,
       });
 
-      call.onLines(["src/fourth.ts:11:needle later"]);
+      call.onLines([jsonMatchLine("src/fourth.ts", 11, "needle later")]);
       await sleep(50);
       searchHarness.handlers["surface:open"]?.();
 
@@ -345,15 +415,15 @@ describe("SearchSurface", () => {
       expect(searchHarness.calls).toHaveLength(1);
       const call = searchHarness.calls[0]!;
       call.onLines([
-        "src/first.ts:4:const needle = true",
-        "src/second.ts:9:needle()",
+        jsonMatchLine("src/first.ts", 4, "const needle = true"),
+        jsonMatchLine("src/second.ts", 9, "needle()"),
       ]);
       await sleep();
 
       searchHarness.handlers["surface:down"]?.();
       await sleep();
 
-      call.onLines(["src/target.ts:20:needle target"]);
+      call.onLines([jsonMatchLine("src/target.ts", 20, "needle target")]);
       await sleep(50);
       searchHarness.handlers["surface:open"]?.();
 
@@ -403,7 +473,7 @@ describe("SearchSurface", () => {
       await sleep(20);
 
       expect(staleCall.signal.aborted).toBe(true);
-      staleCall.onLines(["src/old.ts:7:old result"]);
+      staleCall.onLines([jsonMatchLine("src/old.ts", 7, "old result")]);
       staleCall.resolve();
       await sleep(50);
 
@@ -444,7 +514,7 @@ describe("SearchSurface", () => {
       await sleep(180);
 
       const oldCall = searchHarness.calls[0]!;
-      oldCall.onLines(["src/old.ts:7:old result"]);
+      oldCall.onLines([jsonMatchLine("src/old.ts", 7, "old result")]);
       oldCall.resolve();
       await sleep(50);
 


### PR DESCRIPTION
## Summary
- Switch workbench Search from ambiguous `rg -n --no-heading` output to structured ripgrep JSON match events.
- Preserve result paths that contain colon-number segments before open/attach commands use them.
- Remove the now-unused text-mode workbench search parser and add focused JSON parsing regressions.

## Test plan
- Failing-first regression: `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/search-surface.test.tsx --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/search-surface.test.tsx tests/tui/workbench/search-model.test.ts --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench --reporter=dot`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `git diff --check`
- Touched-file branding/TODO scan

## Known existing backlog
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the pre-existing unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.
