### PR TITLE
fix(tui): guard typeahead provider failures

### DIFF
--- a/runtime/src/tui/hooks/useTypeahead.tsx
+++ b/runtime/src/tui/hooks/useTypeahead.tsx
@@ -27,6 +27,7 @@ import { getDirectoryCompletions, getPathCompletions, isPathLikeToken } from '..
 import { getShellHistoryCompletion } from '../../utils/suggestions/shellHistoryCompletion.js';
 import { getSlackChannelSuggestions, hasSlackMcpServer } from '../../utils/suggestions/slackChannelSuggestions.js';
 import { TEAM_LEAD_NAME } from '../../utils/swarm/constants.js';
+import { logError } from '../../utils/log.js';
 import { applyFileSuggestion, findLongestCommonPrefix, onIndexBuildComplete, startBackgroundCacheRefresh } from './fileSuggestions';
 import { generateUnifiedSuggestions } from './unifiedSuggestions';
 import {
@@ -359,7 +360,17 @@ export function useTypeahead({
   // Expensive async operation to fetch file/resource suggestions
   const fetchFileSuggestions = useCallback(async (searchToken: string, isAtSymbol = false): Promise<void> => {
     latestSearchTokenRef.current = searchToken;
-    const combinedItems = await generateUnifiedSuggestions(searchToken, mcpResources, agents, isAtSymbol);
+    let combinedItems: SuggestionItem[];
+    try {
+      combinedItems = await generateUnifiedSuggestions(searchToken, mcpResources, agents, isAtSymbol);
+    } catch (error) {
+      if (latestSearchTokenRef.current !== searchToken) {
+        return;
+      }
+      logError(error);
+      clearSuggestions();
+      return;
+    }
     // Discard stale results if a newer query was initiated while waiting
     if (latestSearchTokenRef.current !== searchToken) {
       return;
@@ -382,7 +393,7 @@ export function useTypeahead({
     }));
     setSuggestionType(combinedItems.length > 0 ? 'file' : 'none');
     setMaxColumnWidth(undefined); // No fixed width for file suggestions
-  }, [mcpResources, setSuggestionsState, setSuggestionType, setMaxColumnWidth, agents]);
+  }, [mcpResources, setSuggestionsState, setSuggestionType, setMaxColumnWidth, agents, clearSuggestions]);
 
   // Pre-warm the file index on mount so the first @-mention doesn't block.
   // The build runs in background with ~4ms event-loop yields, so it doesn't
@@ -418,7 +429,15 @@ export function useTypeahead({
   const debouncedFetchFileSuggestions = useDebounceCallback(fetchFileSuggestions, 50);
   const fetchSlackChannels = useCallback(async (partial: string): Promise<void> => {
     latestSlackTokenRef.current = partial;
-    const channels = await getSlackChannelSuggestions(store.getState().mcp.clients, partial);
+    let channels: SuggestionItem[];
+    try {
+      channels = await getSlackChannelSuggestions(store.getState().mcp.clients, partial);
+    } catch (error) {
+      if (latestSlackTokenRef.current !== partial) return;
+      logError(error);
+      clearSuggestions();
+      return;
+    }
     if (latestSlackTokenRef.current !== partial) return;
     setSuggestionsState(prev => ({
       commandArgumentHint: undefined,
@@ -429,7 +448,7 @@ export function useTypeahead({
     setMaxColumnWidth(undefined);
   },
   // eslint-disable-next-line react-hooks/exhaustive-deps -- store is a stable context ref
-  [setSuggestionsState]);
+  [setSuggestionsState, clearSuggestions]);
 
   // First keystroke after # needs the MCP round-trip; subsequent keystrokes
   // that share the same first-word segment hit the cache synchronously.
@@ -471,7 +490,16 @@ export function useTypeahead({
     // Bash mode: check for history-based ghost text completion
     if (mode === 'bash' && value.trim()) {
       latestBashInputRef.current = value;
-      const historyMatch = await getShellHistoryCompletion(value);
+      let historyMatch: Awaited<ReturnType<typeof getShellHistoryCompletion>> = null;
+      try {
+        historyMatch = await getShellHistoryCompletion(value);
+      } catch (error) {
+        if (latestBashInputRef.current !== value) {
+          return;
+        }
+        logError(error);
+        setInlineGhostText(undefined);
+      }
       // Discard stale results if input changed while waiting
       if (latestBashInputRef.current !== value) {
         return;
@@ -579,7 +607,15 @@ export function useTypeahead({
           clearSuggestions();
           return;
         }
-        const dirSuggestions = await getDirectoryCompletions(args);
+        let dirSuggestions: SuggestionItem[];
+        try {
+          dirSuggestions = await getDirectoryCompletions(args);
+        } catch (error) {
+          logError(error);
+          debouncedFetchFileSuggestions.cancel();
+          clearSuggestions();
+          return;
+        }
         if (dirSuggestions.length > 0) {
           setSuggestionsState(prev => ({
             suggestions: dirSuggestions,
@@ -603,9 +639,16 @@ export function useTypeahead({
         } = parsedCommand;
 
         // Get custom title suggestions using partial match
-        const matches = await searchSessionsByCustomTitle(args, {
-          limit: 10
-        });
+        let matches;
+        try {
+          matches = await searchSessionsByCustomTitle(args, {
+            limit: 10
+          });
+        } catch (error) {
+          logError(error);
+          clearSuggestions();
+          return;
+        }
         const suggestions = matches.map(log => {
           const sessionId = getSessionIdFromLog(log);
           return {
@@ -733,9 +776,19 @@ export function useTypeahead({
         // This handles cases like @~/path, @./path, @/path for directory traversal
         if (isPathLikeToken(searchToken)) {
           latestPathTokenRef.current = searchToken;
-          const pathSuggestions = await getPathCompletions(searchToken, {
-            maxResults: 10
-          });
+          let pathSuggestions: SuggestionItem[];
+          try {
+            pathSuggestions = await getPathCompletions(searchToken, {
+              maxResults: 10
+            });
+          } catch (error) {
+            if (latestPathTokenRef.current !== searchToken) {
+              return;
+            }
+            logError(error);
+            clearSuggestions();
+            return;
+          }
           // Discard stale results if a newer query was initiated while waiting
           if (latestPathTokenRef.current !== searchToken) {
             return;
@@ -1049,7 +1102,13 @@ export function useTypeahead({
           // If token starts with @, search without the @ prefix
           const isAtSymbol = completionInfo.token.startsWith('@');
           const searchToken = isAtSymbol ? completionInfo.token.substring(1) : completionInfo.token;
-          suggestionItems = await generateUnifiedSuggestions(searchToken, mcpResources, agents, isAtSymbol);
+          try {
+            suggestionItems = await generateUnifiedSuggestions(searchToken, mcpResources, agents, isAtSymbol);
+          } catch (error) {
+            logError(error);
+            clearSuggestions();
+            suggestionItems = [];
+          }
         } else {
           suggestionItems = [];
         }

--- a/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
+++ b/runtime/tests/tui/hooks/useTypeahead.hook.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 const harness = vi.hoisted(() => ({
   addNotification: vi.fn(),
+  logError: vi.fn(),
   appState: {
     agentNameRegistry: new Map<string, string>(),
     mcp: {
@@ -33,6 +34,7 @@ const harness = vi.hoisted(() => ({
   unifiedSuggestions: [] as unknown[],
   reset() {
     harness.addNotification.mockClear()
+    harness.logError.mockClear()
     harness.appState.agentNameRegistry = new Map()
     harness.appState.mcp = { clients: [], resources: [] }
     harness.appState.promptSuggestion = {
@@ -77,6 +79,10 @@ vi.mock('../context/notifications.js', () => ({
 
 vi.mock('../../services/analytics/index.js', () => ({
   logEvent: vi.fn(),
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: harness.logError,
 }))
 
 vi.mock('../context/overlayContext', () => ({
@@ -751,6 +757,24 @@ describe('useTypeahead hook paths', () => {
         () => generateUnifiedSuggestionsMock.mock.calls.length > 0,
         'refetch after input changes',
       )
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('logs file suggestion provider failures and fails closed', async () => {
+    const error = new Error('unified suggestions failed')
+    generateUnifiedSuggestionsMock.mockRejectedValueOnce(error)
+    const rendered = await renderHookHarness({ input: '@sr', cursorOffset: 3 })
+
+    try {
+      await waitFor(
+        () => harness.logError.mock.calls.some(call => call[0] === error),
+        'logged suggestion failure',
+      )
+
+      expect(rendered.getSnapshot().suggestionType).toBe('none')
+      expect(rendered.getSnapshot().suggestions).toEqual([])
     } finally {
       await rendered.dispose()
     }


### PR DESCRIPTION
## Summary
- Log and fail closed when async typeahead providers reject.
- Preserve stale-token guards so older provider failures do not clear newer suggestions.
- Add a focused regression for `@` unified suggestion provider rejection.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/useTypeahead.hook.test.tsx --reporter=dot` failed first before the source fix with an unhandled provider rejection.
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/useTypeahead.hook.test.tsx --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/useTypeahead.hook.test.tsx tests/tui/hooks/useTypeahead.test.ts tests/tui/hooks/useTypeahead.coverage2.test.tsx tests/tui/hooks/useTypeahead.wave200-006.coverage.test.tsx tests/tui/coverage-swarm/swarm-009-hooks-useTypeahead.test.tsx --reporter=dot`
- `npm run typecheck`
- `git diff --check`
- `rg -n -- "Claude|claude|Codex|codex|OpenClaude|openclaude|TODO|FIXME|HACK" runtime/src/tui/hooks/useTypeahead.tsx runtime/tests/tui/hooks/useTypeahead.hook.test.tsx` returned no matches.
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.