### PR TITLE
fix(tui): ignore stale realtime payloads

### DIFF
--- a/runtime/src/tui/realtime/controller.ts
+++ b/runtime/src/tui/realtime/controller.ts
@@ -271,17 +271,20 @@ class RealtimeTuiController implements AgenCRealtimeTuiControls {
         });
         break;
       case "realtime_sdp":
+        if (!this.#canApplyRealtimeSessionEvent()) return;
         if (typeof payload.sdp === "string") {
           void this.#applyProviderSdp(payload.sdp);
         }
         break;
       case "realtime_output_audio_delta":
+        if (!this.#canApplyRealtimeSessionEvent()) return;
         if (isJsonObject(payload.audio)) {
           const audio = toRealtimeAudioChunk(payload.audio);
           if (audio !== null) this.#audioPlayer.enqueue(audio);
         }
         break;
       case "realtime_transcript_delta":
+        if (!this.#canApplyRealtimeSessionEvent()) return;
         if (
           typeof payload.role === "string" &&
           typeof payload.delta === "string"
@@ -294,6 +297,7 @@ class RealtimeTuiController implements AgenCRealtimeTuiControls {
         }
         break;
       case "realtime_transcript_done":
+        if (!this.#canApplyRealtimeSessionEvent()) return;
         if (
           typeof payload.role === "string" &&
           typeof payload.text === "string"
@@ -306,6 +310,7 @@ class RealtimeTuiController implements AgenCRealtimeTuiControls {
         }
         break;
       case "realtime_item_added":
+        if (!this.#canApplyRealtimeSessionEvent()) return;
         this.#dispatch({ type: "item_added", item: payload.item ?? null });
         break;
       case "realtime_error":
@@ -330,6 +335,7 @@ class RealtimeTuiController implements AgenCRealtimeTuiControls {
         });
         break;
       case "realtime_local_audio_level":
+        if (!this.#canApplyRealtimeSessionEvent()) return;
         if (typeof payload.peak === "number") {
           this.#dispatch({ type: "local_audio_level", peak: payload.peak });
         }
@@ -410,6 +416,13 @@ class RealtimeTuiController implements AgenCRealtimeTuiControls {
 
   #canAppendRealtimeInput(): boolean {
     return this.#state.phase === "starting" || this.#state.phase === "active";
+  }
+
+  #canApplyRealtimeSessionEvent(): boolean {
+    return (
+      !this.#state.requestedClose &&
+      (this.#state.phase === "starting" || this.#state.phase === "active")
+    );
   }
 
   async #handleRealtimeInputFailure(

--- a/runtime/tests/tui/coverage-swarm/swarm-064-realtime-controller.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-064-realtime-controller.test.ts
@@ -234,16 +234,22 @@ describe("AgenC realtime TUI controller coverage swarm row 064", () => {
     });
   });
 
-  test("filters transcript payloads and preserves complete output audio metadata", () => {
+  test("filters transcript payloads and preserves complete output audio metadata", async () => {
     const client = createClient();
     const audioPlayer = createAudioPlayer();
     const controls = createRealtimeTuiControls({
       threadId: "thread-064",
       client,
       emitEvent: () => {},
+      startAudioCapture: createNoopAudioCapture(),
       audioPlayer,
     });
 
+    await controls.start({ transport: "websocket" });
+    controls.handleTranscriptEvent({
+      type: "realtime_started",
+      payload: { realtimeSessionId: "rt_064" },
+    });
     controls.handleTranscriptEvent({
       type: "realtime_sdp",
       payload: { sdp: "ignored-without-webrtc" },

--- a/runtime/tests/tui/daemon-session.contract.test.ts
+++ b/runtime/tests/tui/daemon-session.contract.test.ts
@@ -693,6 +693,7 @@ describe("AgenC TUI daemon session adapter", () => {
       clientId: "tui_1",
       realtimeThreadId: "agent_1",
       realtimeAudioPlayer,
+      realtimeAudioCaptureFactory: async () => ({ stop: vi.fn() }),
     });
     const received: JsonObject[] = [];
     const unsubscribe = session.subscribeToEvents((event) => {
@@ -708,6 +709,7 @@ describe("AgenC TUI daemon session adapter", () => {
         version: "v2",
       },
     });
+    await session.realtime.start({ transport: "websocket" });
     client.emitNotification({
       jsonrpc: JSON_RPC_VERSION,
       method: "thread/realtime/started",

--- a/runtime/tests/tui/realtime/controller.contract.test.ts
+++ b/runtime/tests/tui/realtime/controller.contract.test.ts
@@ -614,13 +614,14 @@ describe("AgenC realtime TUI controller", () => {
     },
   );
 
-  test("enqueues realtime output audio deltas into the audio player", () => {
+  test("enqueues realtime output audio deltas into the audio player", async () => {
     const client = createClient();
     const audioPlayer = createAudioPlayer();
     const controls = createRealtimeTuiControls({
       threadId: "agent_1",
       client,
       emitEvent: () => {},
+      startAudioCapture: createNoopAudioCapture(),
       audioPlayer,
     });
     const audio = {
@@ -629,6 +630,11 @@ describe("AgenC realtime TUI controller", () => {
       numChannels: 1,
     };
 
+    await controls.start({ transport: "websocket" });
+    controls.handleTranscriptEvent({
+      type: "realtime_started",
+      payload: { realtimeSessionId: "rt_1" },
+    });
     controls.handleTranscriptEvent({
       type: "realtime_output_audio_delta",
       payload: { audio },
@@ -642,6 +648,62 @@ describe("AgenC realtime TUI controller", () => {
     expect(audioPlayer.enqueued).toEqual([
       { ...audio, samplesPerChannel: null, itemId: null },
     ]);
+  });
+
+  test("ignores stale media and transcript notifications after stop", async () => {
+    const client = createClient();
+    const audioPlayer = createAudioPlayer();
+    const controls = createRealtimeTuiControls({
+      threadId: "agent_1",
+      client,
+      emitEvent: () => {},
+      startAudioCapture: createNoopAudioCapture(),
+      audioPlayer,
+    });
+    const audio = {
+      data: "AAAA",
+      sampleRate: 24000,
+      numChannels: 1,
+    };
+
+    await controls.start({ transport: "websocket" });
+    controls.handleTranscriptEvent({
+      type: "realtime_started",
+      payload: { realtimeSessionId: "rt_1" },
+    });
+    controls.handleTranscriptEvent({
+      type: "realtime_output_audio_delta",
+      payload: { audio },
+    });
+    await controls.stop();
+
+    controls.handleTranscriptEvent({
+      type: "realtime_output_audio_delta",
+      payload: { audio: { ...audio, data: "BBBB" } },
+    });
+    controls.handleTranscriptEvent({
+      type: "realtime_transcript_delta",
+      payload: { role: "assistant", delta: "stale" },
+    });
+    controls.handleTranscriptEvent({
+      type: "realtime_item_added",
+      payload: { item: { type: "message", id: "stale_item" } },
+    });
+    controls.handleTranscriptEvent({
+      type: "realtime_local_audio_level",
+      payload: { peak: 32000 },
+    });
+
+    expect(audioPlayer.enqueued).toEqual([
+      { ...audio, samplesPerChannel: null, itemId: null },
+    ]);
+    expect(controls.getState()).toMatchObject({
+      phase: "inactive",
+      localAudioLevel: 0,
+      lastTranscript: null,
+      lastItemSummary: null,
+      closedBanner: "Realtime closed: requested",
+    });
   });
 
   test.each([

--- a/runtime/tests/tui/realtime/controller.wave200-105.coverage.test.ts
+++ b/runtime/tests/tui/realtime/controller.wave200-105.coverage.test.ts
@@ -63,6 +63,7 @@ describe("AgenC realtime TUI controller coverage", () => {
 
     controls.handleTranscriptEvent(null);
     controls.handleTranscriptEvent({ type: 105, payload: { peak: 65_535 } });
+    await controls.start({ transport: "websocket" });
     controls.handleTranscriptEvent({
       type: "realtime_output_audio_delta",
       payload: { audio: { data: "AAAA", sampleRate: 24_000 } },
@@ -82,7 +83,6 @@ describe("AgenC realtime TUI controller coverage", () => {
       localAudioLevel: 322,
     });
 
-    await controls.start({ transport: "websocket" });
     controls.handleTranscriptEvent({
       type: "realtime_error",
       payload: "not an object",
@@ -97,7 +97,7 @@ describe("AgenC realtime TUI controller coverage", () => {
       errorBanner: "Realtime error",
     });
     expect(emitted).toEqual([]);
-    expect(snapshots).toContain("inactive|322|null|");
+    expect(snapshots).toContain("starting|322|null|");
     expect(client.requests.map((request) => request.method)).toEqual([
       "thread/realtime/start",
     ]);


### PR DESCRIPTION
## Summary
- Ignore non-terminal realtime session notifications after the TUI controller is no longer live.
- Prevent stale output-audio deltas from restarting playback after `/realtime stop`.
- Update realtime and daemon-session coverage so live media/transcript payload assertions start a realtime session first.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/realtime/controller.contract.test.ts --reporter=dot` failed first before the source fix because a post-stop audio delta was still enqueued.
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/realtime/controller.contract.test.ts tests/tui/realtime/controller.wave200-105.coverage.test.ts --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/realtime --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/daemon-session.contract.test.ts tests/tui/coverage-swarm/swarm-064-realtime-controller.test.ts --reporter=dot`
- `npm run typecheck`
- `git diff --check`
- `rg -n -- "Claude|claude|Codex|codex|OpenClaude|openclaude|TODO|FIXME|HACK" runtime/src/tui/realtime/controller.ts runtime/tests/tui/realtime/controller.contract.test.ts runtime/tests/tui/realtime/controller.wave200-105.coverage.test.ts runtime/tests/tui/daemon-session.contract.test.ts runtime/tests/tui/coverage-swarm/swarm-064-realtime-controller.test.ts` returned no matches.
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.