### PR TITLE
fix(tui): cancel status line mount debounce

### DIFF
--- a/runtime/src/tui/startup/StatusLine.tsx
+++ b/runtime/src/tui/startup/StatusLine.tsx
@@ -191,6 +191,10 @@ function StatusLineInner({
 
   // Stable update function — reads latest values from refs
   const doUpdate = useCallback(async () => {
+    if (debounceTimerRef.current !== undefined) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = undefined;
+    }
     // Cancel any in-flight requests
     abortControllerRef.current?.abort();
     const controller = new AbortController();

--- a/runtime/tests/tui/coverage-swarm/swarm-133-startup-StatusLine.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-133-startup-StatusLine.test.tsx
@@ -420,6 +420,34 @@ describe('StatusLine coverage swarm row 133', () => {
     })
   })
 
+  test('cancels the mount debounce when the initial status update starts', async () => {
+    const messages = [{ uuid: 'assistant-before' }]
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      patchConsole: false,
+    })
+
+    try {
+      root.render(
+        <StatusLine
+          messagesRef={{ current: messages }}
+          lastAssistantMessageId="assistant-before"
+        />,
+      )
+      await waitFor(() => harness.executeStatusLineCommand.mock.calls.length === 1)
+      await new Promise(resolve => setTimeout(resolve, 350))
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+
+    expect(harness.executeStatusLineCommand).toHaveBeenCalledTimes(1)
+    expect(harness.executeStatusLineCommand.mock.calls[0]![3]).toBe(true)
+  })
+
   test('reports trust-blocked status lines and swallows command failures', async () => {
     harness.appState = {
       toolPermissionContext: {


### PR DESCRIPTION
## Summary
- clear any pending StatusLine debounce when an immediate update starts
- prevent duplicate status-line command execution on mount when an existing assistant message is present
- add a focused regression around the 300ms debounce window

## Test plan
- failing-first focused regression: `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/coverage-swarm/swarm-133-startup-StatusLine.test.tsx --reporter=dot`
- focused regression after fix: `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/coverage-swarm/swarm-133-startup-StatusLine.test.tsx --reporter=dot`
- adjacent tests: `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/startup/StatusLine.test.tsx tests/tui/startup/StatusLine.wave200-093.coverage.test.tsx tests/tui/coverage-swarm/swarm-133-startup-StatusLine.test.tsx tests/tui/components/PromptInput/PromptInputFooter.wave200-085.coverage.test.tsx --reporter=dot`
- `npm run typecheck`
- `git diff --check`
- touched-file branding/TODO scan with `rg`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

## Notes
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on existing unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused tag hints.