### PR TITLE
fix(tui): clear input buffer debounce on unmount

### DIFF
--- a/runtime/src/tui/hooks/useInputBuffer.ts
+++ b/runtime/src/tui/hooks/useInputBuffer.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { PastedContent } from '../../utils/config.js' // upstream-import: keep target is owned by another Z-PURGE item
 
 export type BufferEntry = {
@@ -34,6 +34,15 @@ export function useInputBuffer({
   }>({ buffer: [], currentIndex: -1 })
   const lastPushTime = useRef<number>(0)
   const pendingPush = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (pendingPush.current) {
+        clearTimeout(pendingPush.current)
+        pendingPush.current = null
+      }
+    }
+  }, [])
 
   const pushToBuffer = useCallback(
     (

--- a/runtime/tests/tui/coverage-swarm/swarm-202-hooks-useInputBuffer.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-202-hooks-useInputBuffer.test.ts
@@ -211,4 +211,19 @@ describe('useInputBuffer coverage swarm 202', () => {
       await rendered.dispose()
     }
   })
+
+  test('clears a pending debounced push when the hook unmounts', async () => {
+    const rendered = await renderHookHarness({
+      debounceMs: 1_000,
+      maxBufferSize: 5,
+    })
+
+    await rendered.push('settled')
+    await rendered.push('pending')
+    expect(vi.getTimerCount()).toBe(1)
+
+    await rendered.dispose()
+
+    expect(vi.getTimerCount()).toBe(0)
+  })
 })


### PR DESCRIPTION
## Summary
- clear pending input-buffer debounce timers when the hook unmounts
- prevent stale debounced prompt history pushes from running after PromptInput is gone
- add a focused fake-timer regression for the unmount cleanup path

## Test plan
- failing-first focused regression: `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/coverage-swarm/swarm-202-hooks-useInputBuffer.test.ts --reporter=dot`
- focused regression after fix: `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/coverage-swarm/swarm-202-hooks-useInputBuffer.test.ts --reporter=dot`
- adjacent hook/PromptInput tests: `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/useInputBuffer.wave200-058.coverage.test.tsx tests/tui/coverage-swarm/swarm-202-hooks-useInputBuffer.test.ts tests/tui/components/PromptInput/PromptInput.render.test.tsx tests/tui/components/PromptInput/PromptInput.wave200-001.coverage.test.tsx tests/tui/coverage-swarm/swarm-001-components-PromptInput-PromptInput.test.tsx --reporter=dot`
- `npm run typecheck`
- `git diff --check`
- touched-file branding/TODO scan with `rg`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

## Notes
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on existing unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused tag hints.