### PR TITLE
fix(tui): keep pr status polling after lookup failure

### DIFF
--- a/runtime/src/tui/hooks/usePrStatus.ts
+++ b/runtime/src/tui/hooks/usePrStatus.ts
@@ -60,7 +60,12 @@ export function usePrStatus(isLoading: boolean, enabled = true): PrStatusState {
       }
 
       const start = Date.now()
-      const result = await fetchPrStatus()
+      let result = null
+      try {
+        result = await fetchPrStatus()
+      } catch {
+        result = null
+      }
       if (cancelled) return
       lastFetchRef.current = start
 

--- a/runtime/tests/tui/coverage-swarm/swarm-152-hooks-usePrStatus.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-152-hooks-usePrStatus.test.ts
@@ -217,6 +217,45 @@ describe('usePrStatus coverage swarm row 152', () => {
     }
   })
 
+  test('treats a rejected PR status fetch as unavailable and keeps polling', async () => {
+    fixture.fetchPrStatus
+      .mockRejectedValueOnce(new Error('gh lookup failed'))
+      .mockResolvedValueOnce({
+        number: 153,
+        reviewState: 'approved',
+        url: 'https://example.test/pull/153',
+      })
+    const rendered = await renderHookHarness({
+      enabled: true,
+      isLoading: false,
+    })
+
+    try {
+      await waitFor(() => {
+        expect(fixture.fetchPrStatus).toHaveBeenCalledTimes(1)
+      })
+      expect(rendered.latest()).toEqual({
+        number: null,
+        reviewState: null,
+        url: null,
+        lastUpdated: 0,
+      })
+
+      await flushEffects(POLL_INTERVAL_MS)
+
+      await waitFor(() => {
+        expect(rendered.latest()).toMatchObject({
+          number: 153,
+          reviewState: 'approved',
+          url: 'https://example.test/pull/153',
+        })
+      })
+      expect(fixture.fetchPrStatus).toHaveBeenCalledTimes(2)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('stops polling once the session has been idle for an hour', async () => {
     fixture.fetchPrStatus.mockResolvedValue({
       number: 152,


### PR DESCRIPTION
## Summary
- catch unexpected PR status lookup rejections inside the polling loop
- treat rejected lookups as unavailable PR status so the footer does not crash or stop polling
- add a focused regression that verifies polling resumes after a failed lookup

## Test plan
- failing-first focused regression: `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/coverage-swarm/swarm-152-hooks-usePrStatus.test.ts --reporter=dot`
- focused regression after fix: `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/coverage-swarm/swarm-152-hooks-usePrStatus.test.ts --reporter=dot`
- adjacent hook/footer tests: `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/usePrStatus.wave200-052.coverage.test.tsx tests/tui/coverage-swarm/swarm-152-hooks-usePrStatus.test.ts tests/tui/components/PromptInput/PromptInputFooterLeftSide.render.test.tsx tests/tui/components/PromptInput/PromptInputFooterLeftSide.render.runtime-coverage.test.tsx tests/tui/components/PromptInput/PromptInputFooterLeftSide.wave200-090.coverage.test.tsx tests/tui/coverage-swarm/swarm-047-components-PromptInput-PromptInputFooterLeftSide.test.tsx --reporter=dot`
- `npm run typecheck`
- `git diff --check`
- touched-file branding/TODO scan with `rg`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

## Notes
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on existing unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused tag hints.