### PR TITLE
fix(tui): guard clipboard image hint probes

### DIFF
--- a/runtime/src/tui/hooks/useClipboardImageHint.ts
+++ b/runtime/src/tui/hooks/useClipboardImageHint.ts
@@ -51,7 +51,13 @@ export function useClipboardImageHint(
         }
 
         // Check if clipboard has an image (async osascript call)
-        if (await hasImageInClipboard()) {
+        let hasImage = false
+        try {
+          hasImage = await hasImageInClipboard()
+        } catch {
+          hasImage = false
+        }
+        if (hasImage) {
           lastHintTimeRef.current = now
           addNotification({
             key: NOTIFICATION_KEY,

--- a/runtime/tests/tui/coverage-swarm/swarm-246-hooks-useClipboardImageHint.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-246-hooks-useClipboardImageHint.test.ts
@@ -199,4 +199,36 @@ describe('useClipboardImageHint coverage swarm row 246', () => {
       await rendered.dispose()
     }
   })
+
+  test('ignores rejected clipboard probes and retries on the next focus regain', async () => {
+    fixture.hasImageInClipboard
+      .mockRejectedValueOnce(new Error('clipboard probe failed'))
+      .mockResolvedValueOnce(true)
+    const rendered = await renderHookHarness({
+      enabled: true,
+      isFocused: false,
+    })
+
+    try {
+      await rendered.render({ isFocused: true })
+      await flushEffects(1_000)
+
+      expect(fixture.hasImageInClipboard).toHaveBeenCalledTimes(1)
+      expect(fixture.addNotification).not.toHaveBeenCalled()
+
+      await rendered.render({ isFocused: false })
+      await rendered.render({ isFocused: true })
+      await flushEffects(1_000)
+
+      expect(fixture.hasImageInClipboard).toHaveBeenCalledTimes(2)
+      expect(fixture.addNotification).toHaveBeenCalledWith({
+        key: 'clipboard-image-hint',
+        text: 'Image in clipboard · Ctrl+V to paste',
+        priority: 'immediate',
+        timeoutMs: 8000,
+      })
+    } finally {
+      await rendered.dispose()
+    }
+  })
 })


### PR DESCRIPTION
## Summary
- Catch rejected clipboard image probes in the focus-regain hint hook.
- Treat a rejected probe as no image for that attempt so the TUI avoids unhandled rejections.
- Add focused regression coverage that verifies a later focus regain still retries and shows the hint.

## Test plan
- Failing-first: `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/coverage-swarm/swarm-246-hooks-useClipboardImageHint.test.ts --reporter=dot` reproduced Vitest's unhandled rejection report before the fix.
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/coverage-swarm/swarm-246-hooks-useClipboardImageHint.test.ts --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/useClipboardImageHint.wave200-126.coverage.test.ts tests/tui/coverage-swarm/swarm-246-hooks-useClipboardImageHint.test.ts tests/tui/coverage-swarm/swarm-052-components-TextInput.test.tsx tests/tui/coverage-swarm/swarm-206-components-VimTextInput.test.tsx tests/tui/components/PromptInput/PromptInput.vimMode.test.tsx --reporter=dot`
- `npm run typecheck`
- `git diff --check`
- `rg -n -- "Claude|claude|Codex|codex|OpenClaude|openclaude|TODO|FIXME|HACK" runtime/src/tui/hooks/useClipboardImageHint.ts runtime/tests/tui/coverage-swarm/swarm-246-hooks-useClipboardImageHint.test.ts` (no matches)
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui` (755 files, 3157 tests)
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails only on existing unrelated Knip backlog: unused `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused tag hints.
