### PR TITLE
fix(tui): guard direct image paste lookups

### DIFF
--- a/runtime/src/tui/components/CustomSelect/select-input-option.tsx
+++ b/runtime/src/tui/components/CustomSelect/select-input-option.tsx
@@ -8,6 +8,7 @@ import { useKeybinding, useKeybindings } from '../../keybindings/useKeybinding.j
 import type { PastedContent } from '../../../utils/config.js'; // upstream-import: keep target is owned by another Z-PURGE item
 import { getImageFromClipboard } from '../../../utils/imagePaste.js'; // upstream-import: keep target is owned by another Z-PURGE item
 import type { ImageDimensions } from '../../../utils/imageResizer.js'; // upstream-import: keep target is owned by another Z-PURGE item
+import { logError } from '../../../utils/log.js';
 import { ClickableImageRef } from '../ClickableImageRef.js';
 import { ConfigurableShortcutHint } from '../ConfigurableShortcutHint.js';
 import { Byline } from '../design-system/Byline.js';
@@ -190,11 +191,13 @@ export function SelectInputOption<T>(t0: Props<T>) {
       if (!onImagePaste) {
         return;
       }
-      getImageFromClipboard().then(imageData => {
-        if (imageData) {
-          onImagePaste(imageData.base64, imageData.mediaType, undefined, imageData.dimensions);
-        }
-      });
+      void getImageFromClipboard()
+        .then(imageData => {
+          if (imageData) {
+            onImagePaste(imageData.base64, imageData.mediaType, undefined, imageData.dimensions);
+          }
+        })
+        .catch(logError);
     };
     $[16] = onImagePaste;
     $[17] = t10;

--- a/runtime/src/tui/components/PromptInput/PromptInput.tsx
+++ b/runtime/src/tui/components/PromptInput/PromptInput.tsx
@@ -2063,8 +2063,9 @@ function PromptInput({
   }, [previousModeBeforeAuto, toolPermissionContext, setAppState, setToolPermissionContext]);
 
   // Handler for chat:imagePaste - paste image from clipboard
-  const handleImagePaste = useCallback(() => {
-    void getImageFromClipboard().then(imageData => {
+  const handleImagePaste = useCallback(async () => {
+    try {
+      const imageData = await getImageFromClipboard();
       if (imageData) {
         onImagePaste(
           imageData.base64,
@@ -2082,7 +2083,15 @@ function PromptInput({
           timeoutMs: 1000
         });
       }
-    });
+    } catch (err) {
+      logError(err);
+      addNotification({
+        key: 'image-paste-error',
+        text: `Image paste failed: ${errorMessage(err)}`,
+        color: 'warning',
+        priority: 'high'
+      });
+    }
   }, [addNotification, onImagePaste]);
 
   // Register chat:submit handler directly in the handler registry (not via

--- a/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
+++ b/runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx
@@ -770,6 +770,7 @@ vi.mock('./utils.js', async importOriginal => {
 import { createRoot } from '../../ink/root.js'
 import { getImageFromClipboard } from '../../../utils/imagePaste.js'
 import { cacheImagePath, storeImage } from '../../../utils/imageStore.js'
+import { logError } from '../../../utils/log.js'
 import PromptInput from './PromptInput.js'
 
 function sleep(ms: number): Promise<void> {
@@ -925,6 +926,7 @@ describe('PromptInput render surface', () => {
     vi.mocked(getImageFromClipboard).mockResolvedValue(null)
     vi.mocked(cacheImagePath).mockClear()
     vi.mocked(storeImage).mockClear()
+    vi.mocked(logError).mockClear()
   })
 
   test('wires base text input props for the idle prompt surface', async () => {
@@ -1146,6 +1148,39 @@ describe('PromptInput render surface', () => {
       ) => string
       expect(inputFilter('caption', {})).toBe(' caption')
       expect(inputFilter('again', {})).toBe('again')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('logs rejected clipboard image shortcut lookups without routing image paste', async () => {
+    const error = new Error('clipboard read failed')
+    vi.mocked(getImageFromClipboard).mockRejectedValueOnce(error)
+    const onInputChange = vi.fn()
+    const pastedContents = createPastedContentsState()
+    const rendered = await renderPromptInput({
+      input: '',
+      onInputChange,
+      pastedContents: pastedContents.current,
+      setPastedContents: pastedContents.setPastedContents,
+    })
+
+    try {
+      await harness.keybindings['chat:imagePaste']?.()
+      await sleep(25)
+
+      expect(logError).toHaveBeenCalledWith(error)
+      expect(harness.addNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          color: 'warning',
+          key: 'image-paste-error',
+          priority: 'high',
+        }),
+      )
+      expect(onInputChange).not.toHaveBeenCalled()
+      expect(pastedContents.current).toEqual({})
+      expect(cacheImagePath).not.toHaveBeenCalled()
+      expect(storeImage).not.toHaveBeenCalled()
     } finally {
       await rendered.dispose()
     }

--- a/runtime/tests/tui/coverage-swarm/swarm-048-components-CustomSelect-select-input-option.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-048-components-CustomSelect-select-input-option.test.tsx
@@ -9,6 +9,7 @@ import {
   computeSelectInputColumns,
   SelectInputOption,
 } from "../../../src/tui/components/CustomSelect/select-input-option.js";
+import { logError } from "../../../src/utils/log.js";
 
 const keybindingMock = vi.hoisted(() => ({
   single: new Map<
@@ -153,6 +154,10 @@ vi.mock("../../../src/utils/imagePaste.js", () => ({
   getImageFromClipboard: imagePasteMock.getImageFromClipboard,
 }));
 
+vi.mock("../../../src/utils/log.js", () => ({
+  logError: vi.fn(),
+}));
+
 type TestRoot = Awaited<ReturnType<typeof createRoot>>;
 
 const mountedRoots: Array<{ root: TestRoot; stdin: PassThrough }> = [];
@@ -225,6 +230,7 @@ describe("SelectInputOption coverage", () => {
     textInputMock.current = undefined;
     imagePasteMock.result = undefined;
     imagePasteMock.getImageFromClipboard.mockClear();
+    vi.mocked(logError).mockClear();
   });
 
   afterEach(() => {
@@ -292,6 +298,36 @@ describe("SelectInputOption coverage", () => {
     await keybindingMock.single.get("chat:imagePaste")?.at(-1)?.handler();
 
     expect(imagePasteMock.getImageFromClipboard).toHaveBeenCalledTimes(1);
+    expect(onImagePaste).not.toHaveBeenCalled();
+  });
+
+  test("logs rejected image paste shortcut lookups without routing image callbacks", async () => {
+    const error = new Error("clipboard read failed");
+    imagePasteMock.getImageFromClipboard.mockRejectedValueOnce(error);
+    const onImagePaste = vi.fn();
+
+    await renderOption(
+      <SelectInputOption
+        option={inputOption({ showLabelWithValue: false })}
+        isFocused
+        isSelected={false}
+        shouldShowDownArrow={false}
+        shouldShowUpArrow={false}
+        maxIndexWidth={1}
+        index={1}
+        inputValue=""
+        onInputChange={() => {}}
+        onSubmit={() => {}}
+        layout="compact"
+        onImagePaste={onImagePaste}
+      />,
+    );
+
+    await keybindingMock.single.get("chat:imagePaste")?.at(-1)?.handler();
+    await waitForRender();
+
+    expect(imagePasteMock.getImageFromClipboard).toHaveBeenCalledTimes(1);
+    expect(logError).toHaveBeenCalledWith(error);
     expect(onImagePaste).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- Catch rejected direct `chat:imagePaste` clipboard reads in PromptInput and CustomSelect.
- Log failures instead of allowing unhandled rejections from `.then(...)` chains.
- Show a PromptInput warning notification when an explicit image paste read fails.
- Add focused regressions for both direct shortcut paths.

## Test plan
- Failing-first: `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx tests/tui/coverage-swarm/swarm-048-components-CustomSelect-select-input-option.test.tsx --reporter=dot` reproduced two unhandled `clipboard read failed` rejections before the fix.
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx tests/tui/coverage-swarm/swarm-048-components-CustomSelect-select-input-option.test.tsx --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/PromptInput/PromptInput.render.test.tsx tests/tui/coverage-swarm/swarm-001-components-PromptInput-PromptInput.test.tsx tests/tui/coverage-swarm/swarm-048-components-CustomSelect-select-input-option.test.tsx tests/tui/components/CustomSelect/select-input-option.render.test.tsx tests/tui/hooks/usePasteHandler.test.ts tests/tui/coverage-swarm/swarm-078-hooks-usePasteHandler.test.ts --reporter=dot`
- `npm run typecheck`
- `git diff --check`
- `rg -n -- "Claude|claude|Codex|codex|OpenClaude|openclaude|TODO|FIXME|HACK" runtime/src/tui/components/PromptInput/PromptInput.tsx runtime/src/tui/components/CustomSelect/select-input-option.tsx runtime/tests/tui/components/PromptInput/PromptInput.render.test.tsx runtime/tests/tui/coverage-swarm/swarm-048-components-CustomSelect-select-input-option.test.tsx` (no matches)
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui` (755 files, 3159 tests)
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails only on existing unrelated Knip backlog: unused `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused tag hints.
