### PR TITLE
fix(tui): guard swarm banner tmux detection

### DIFF
--- a/runtime/src/tui/components/PromptInput/useSwarmBanner.ts
+++ b/runtime/src/tui/components/PromptInput/useSwarmBanner.ts
@@ -19,6 +19,7 @@ import {
   isInProcessEnabled,
 } from '../../../utils/swarm/backends/registry.js'
 import { getSwarmSocketName } from '../../../utils/swarm/constants.js'
+import { logError } from '../../../utils/log.js'
 import {
   getAgentName,
   getTeammateColor,
@@ -53,7 +54,10 @@ export function useSwarmBanner(): SwarmBannerInfo {
   const [insideTmux, setInsideTmux] = React.useState<boolean | null>(null)
 
   React.useEffect(() => {
-    void isInsideTmux().then(setInsideTmux)
+    void isInsideTmux().then(setInsideTmux, error => {
+      logError(error)
+      setInsideTmux(false)
+    })
   }, [])
 
   const state = store.getState()

--- a/runtime/tests/tui/components/PromptInput/useSwarmBanner.wave200-037.coverage.test.ts
+++ b/runtime/tests/tui/components/PromptInput/useSwarmBanner.wave200-037.coverage.test.ts
@@ -38,6 +38,7 @@ const harness = vi.hoisted(() => {
     cachedDetection: undefined as undefined | { isNative?: boolean },
     inProcessEnabled: false,
     inProcessTeammate: false,
+    insideTmuxError: undefined as undefined | Error,
     insideTmux: null as boolean | null,
     teammate: {
       active: false,
@@ -55,6 +56,7 @@ const harness = vi.hoisted(() => {
       state.cachedDetection = undefined
       state.inProcessEnabled = false
       state.inProcessTeammate = false
+      state.insideTmuxError = undefined
       state.insideTmux = null
       state.teammate = {
         active: false,
@@ -112,7 +114,14 @@ vi.mock('../../../utils/standaloneAgent.js', () => ({
 }))
 
 vi.mock('../../../utils/swarm/backends/detection.js', () => ({
-  isInsideTmux: () => Promise.resolve(harness.insideTmux),
+  isInsideTmux: () =>
+    harness.insideTmuxError
+      ? Promise.reject(harness.insideTmuxError)
+      : Promise.resolve(harness.insideTmux),
+}))
+
+vi.mock('../../../utils/log.js', () => ({
+  logError: vi.fn(),
 }))
 
 vi.mock('../../../utils/swarm/backends/registry.js', () => ({
@@ -137,6 +146,7 @@ vi.mock('../../../utils/teammateContext.js', () => ({
 
 import { createRoot } from '../../ink/root.js'
 import { useSwarmBanner } from './useSwarmBanner.js'
+import { logError } from '../../../utils/log.js'
 
 type Banner = ReturnType<typeof useSwarmBanner>
 
@@ -317,5 +327,25 @@ describe('useSwarmBanner coverage', () => {
     })
 
     await expectBanner(() => {}, null)
+  })
+
+  test('logs rejected tmux detection and falls back to attach hint', async () => {
+    const error = new Error('tmux detection failed')
+
+    await expectBanner(() => {
+      harness.insideTmuxError = error
+      harness.appState.teamContext = {
+        teamName: 'launch',
+        teammates: { analyst: {} },
+      }
+      harness.viewedTeammate = {
+        identity: { agentName: 'analyst', color: 'blue' },
+      }
+    }, {
+      bgColor: 'blue_FOR_SUBAGENTS_ONLY',
+      text: 'View teammates: `tmux -L agenc-swarm-test a`',
+    })
+
+    expect(logError).toHaveBeenCalledWith(error)
   })
 })


### PR DESCRIPTION
## Summary
- Catch rejected `isInsideTmux()` probes in `useSwarmBanner`.
- Log detection failures and fall back to the external-leader attach hint path.
- Add a focused regression for rejected tmux detection so the banner does not stay hidden and Vitest does not report an unhandled rejection.

## Test plan
- Failing-first: `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/PromptInput/useSwarmBanner.wave200-037.coverage.test.ts --reporter=dot` reproduced a `null` banner plus Vitest unhandled rejection before the fix.
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/PromptInput/useSwarmBanner.wave200-037.coverage.test.ts --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/PromptInput/useSwarmBanner.wave200-037.coverage.test.ts tests/tui/coverage-swarm/swarm-243-components-PromptInput-useSwarmBanner.test.ts tests/tui/components/PromptInput/PromptInput.render.test.tsx tests/tui/coverage-swarm/swarm-001-components-PromptInput-PromptInput.test.tsx --reporter=dot`
- `npm run typecheck`
- `git diff --check`
- `rg -n -- "Claude|claude|Codex|codex|OpenClaude|openclaude|TODO|FIXME|HACK" runtime/src/tui/components/PromptInput/useSwarmBanner.ts runtime/tests/tui/components/PromptInput/useSwarmBanner.wave200-037.coverage.test.ts` (no matches)
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui` (755 files, 3160 tests)
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails only on existing unrelated Knip backlog: unused `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused tag hints.
