### PR TITLE
fix(tui): guard mcp import config reads

### DIFF
--- a/runtime/src/tui/components/MCPServerDesktopImportDialog.tsx
+++ b/runtime/src/tui/components/MCPServerDesktopImportDialog.tsx
@@ -5,6 +5,7 @@ import { writeToStdout } from 'src/utils/process.js';
 import { Box, color, Text, useTheme } from '../ink.js';
 import { addMcpConfig, getAllMcpConfigs } from '../../services/mcp/config.js';
 import type { ConfigScope, McpServerConfig, ScopedMcpServerConfig } from '../../services/mcp/types.js';
+import { logError } from '../../utils/log.js';
 import { plural } from '../../utils/stringUtils.js';
 import { ConfigurableShortcutHint } from './ConfigurableShortcutHint.js';
 import { SelectMulti } from './CustomSelect/SelectMulti.js';
@@ -40,16 +41,25 @@ export function MCPServerDesktopImportDialog(t0: Props) {
     t2 = $[2];
   }
   const [existingServers, setExistingServers] = useState<Record<string, ScopedMcpServerConfig>>(t2);
-  let t3: () => void;
+  let t3: () => void | (() => void);
   let t4: [];
   if ($[3] === Symbol.for("react.memo_cache_sentinel")) {
     t3 = () => {
+      let mounted = true;
       getAllMcpConfigs().then((t5) => {
         const {
           servers: servers_0
         } = t5;
+        if (!mounted) {
+          return;
+        }
         return setExistingServers(servers_0);
+      }, error => {
+        logError(error);
       });
+      return () => {
+        mounted = false;
+      };
     };
     t4 = [];
     $[3] = t3;

--- a/runtime/tests/tui/components/MCPServerDesktopImportDialog.test.tsx
+++ b/runtime/tests/tui/components/MCPServerDesktopImportDialog.test.tsx
@@ -40,6 +40,7 @@ const harness = vi.hoisted(() => ({
   dialogProps: undefined as CapturedDialogProps | undefined,
   getAllMcpConfigs: vi.fn(),
   gracefulShutdown: vi.fn(),
+  logError: vi.fn(),
   selectProps: undefined as CapturedSelectMultiProps | undefined,
   writeToStdout: vi.fn(),
 }))
@@ -51,6 +52,10 @@ vi.mock('../../services/mcp/config.js', () => ({
 
 vi.mock('../../utils/gracefulShutdown.js', () => ({
   gracefulShutdown: harness.gracefulShutdown,
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: harness.logError,
 }))
 
 vi.mock('src/utils/process.js', () => ({
@@ -209,6 +214,7 @@ describe('MCPServerDesktopImportDialog', () => {
     harness.dialogProps = undefined
     harness.getAllMcpConfigs.mockReset()
     harness.gracefulShutdown.mockReset()
+    harness.logError.mockReset()
     harness.selectProps = undefined
     harness.writeToStdout.mockReset()
   })
@@ -267,6 +273,29 @@ describe('MCPServerDesktopImportDialog', () => {
       expect(body).toContain('Note: Some servers already exist')
       expect(body).toContain('Please select the servers you want to import')
       expect(body).toContain('docs (already exists)')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  it('logs rejected existing config reads and keeps all imports selectable', async () => {
+    const error = new Error('config read failed')
+    harness.getAllMcpConfigs.mockRejectedValueOnce(error)
+    const rendered = await renderDialog()
+
+    try {
+      await waitFor(
+        () => harness.getAllMcpConfigs.mock.calls.length > 0,
+        'MCP server import dialog did not try to load existing server names',
+      )
+      await sleep(20)
+
+      expect(harness.logError).toHaveBeenCalledWith(error)
+      expect(selectProps().options).toEqual([
+        { label: 'filesystem', value: 'filesystem' },
+        { label: 'docs', value: 'docs' },
+      ])
+      expect(selectProps().defaultValue).toEqual(['filesystem', 'docs'])
     } finally {
       await rendered.dispose()
     }


### PR DESCRIPTION
## Summary
- Catch rejected existing MCP config reads during desktop import dialog mount.
- Log failures and keep all desktop servers selectable when collision data cannot load.
- Ignore late successful config reads after the dialog unmounts.

## Test plan
- Failing-first focused dialog regression reproduced the unhandled rejection.
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/MCPServerDesktopImportDialog.test.tsx --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/MCPServerDesktopImportDialog.test.tsx tests/tui/components/MCPServerDesktopImportDialog.runtime-coverage.test.tsx --reporter=dot`
- `npm run typecheck`
- `git diff --check`
- `rg -n -- "Claude|claude|Codex|codex|OpenClaude|openclaude|TODO|FIXME|HACK" runtime/src/tui/components/MCPServerDesktopImportDialog.tsx runtime/tests/tui/components/MCPServerDesktopImportDialog.test.tsx` (no matches)
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

Known existing issue: `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused tag hints.