### PR TITLE
fix(tui): guard auto updater detection

### DIFF
--- a/runtime/src/tui/components/AutoUpdaterWrapper.tsx
+++ b/runtime/src/tui/components/AutoUpdaterWrapper.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import type { AutoUpdaterResult } from '../../utils/autoUpdater.js'; // upstream-import: keep target is owned by another Z-PURGE item
 import { isAutoUpdaterDisabled } from '../../utils/config.js'; // upstream-import: keep target is owned by another Z-PURGE item
 import { logForDebugging } from 'src/utils/debug.js';
+import { logError } from '../../utils/log.js';
 import { getCurrentInstallationType } from '../../utils/doctorDiagnostic.js'; // upstream-import: keep target is owned by another Z-PURGE item
 import { AutoUpdater } from './AutoUpdater.js';
 import { NativeAutoUpdater } from './NativeAutoUpdater.js';
@@ -29,6 +30,7 @@ export function AutoUpdaterWrapper({
   const [isPackageManager, setIsPackageManager] = React.useState<boolean | null>(null);
 
   React.useEffect(() => {
+    let mounted = true;
     const checkInstallation = async () => {
       if (feature("SKIP_DETECTION_WHEN_AUTOUPDATES_DISABLED") && isAutoUpdaterDisabled()) {
         logForDebugging("AutoUpdaterWrapper: Skipping detection, auto-updates disabled");
@@ -36,10 +38,18 @@ export function AutoUpdaterWrapper({
       }
       const installationType = await getCurrentInstallationType();
       logForDebugging(`AutoUpdaterWrapper: Installation type: ${installationType}`);
+      if (!mounted) {
+        return;
+      }
       setUseNativeInstaller(installationType === "native");
       setIsPackageManager(installationType === "package-manager");
     };
-    void checkInstallation();
+    void checkInstallation().catch(error => {
+      logError(error);
+    });
+    return () => {
+      mounted = false;
+    };
   }, []);
 
   if (useNativeInstaller === null || isPackageManager === null) {

--- a/runtime/tests/tui/components/AutoUpdaterWrapper.wave200-146.coverage.test.tsx
+++ b/runtime/tests/tui/components/AutoUpdaterWrapper.wave200-146.coverage.test.tsx
@@ -8,6 +8,7 @@ const harness = vi.hoisted(() => ({
   getCurrentInstallationType: vi.fn(async () => "npm-global"),
   isAutoUpdaterDisabled: vi.fn(() => false),
   logForDebugging: vi.fn(),
+  logError: vi.fn(),
   rendered: [] as Array<{
     kind: "standard" | "native" | "package-manager";
     props: Record<string, unknown>;
@@ -28,6 +29,10 @@ vi.mock("../../utils/doctorDiagnostic.js", () => ({
 
 vi.mock("src/utils/debug.js", () => ({
   logForDebugging: harness.logForDebugging,
+}));
+
+vi.mock("../../utils/log.js", () => ({
+  logError: harness.logError,
 }));
 
 vi.mock("./AutoUpdater.js", () => ({
@@ -107,6 +112,7 @@ function resetHarness(): void {
   harness.feature.mockReturnValue(false);
   harness.getCurrentInstallationType.mockResolvedValue("npm-global");
   harness.isAutoUpdaterDisabled.mockReturnValue(false);
+  harness.logError.mockReset();
   harness.rendered = [];
 }
 
@@ -236,6 +242,44 @@ describe("AutoUpdaterWrapper wave200 coverage", () => {
 
       expect(harness.rendered).toEqual([]);
       expect(harness.getCurrentInstallationType).not.toHaveBeenCalled();
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  test("logs rejected installation detection and leaves updater hidden", async () => {
+    resetHarness();
+    const error = new Error("doctor probe failed");
+    harness.getCurrentInstallationType.mockRejectedValueOnce(error);
+
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AutoUpdaterWrapper
+          autoUpdaterResult={null}
+          isUpdating={false}
+          onAutoUpdaterResult={vi.fn()}
+          onChangeIsUpdating={vi.fn()}
+          showSuccessMessage={true}
+          verbose={false}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(harness.getCurrentInstallationType).toHaveBeenCalledOnce();
+      });
+      await sleep(20);
+
+      expect(harness.logError).toHaveBeenCalledWith(error);
+      expect(harness.rendered).toEqual([]);
     } finally {
       root.unmount();
       stdin.end();


### PR DESCRIPTION
## Summary
- Catch rejected installation-type detection in the auto-updater wrapper.
- Log detection failures and keep the updater hidden when routing cannot be determined.
- Ignore late successful detection after the wrapper unmounts.

## Test plan
- Failing-first focused wrapper regression reproduced the unhandled rejection.
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/AutoUpdaterWrapper.wave200-146.coverage.test.tsx --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/AutoUpdaterWrapper.wave200-146.coverage.test.tsx tests/tui/components/PackageManagerAutoUpdater.coverage.test.tsx tests/tui/components/NativeAutoUpdater.wave200-053.coverage.test.tsx tests/tui/components/AutoUpdater.ascii.test.tsx --reporter=dot`
- `npm run typecheck`
- `git diff --check`
- `rg -n -- "Claude|claude|Codex|codex|OpenClaude|openclaude|TODO|FIXME|HACK" runtime/src/tui/components/AutoUpdaterWrapper.tsx runtime/tests/tui/components/AutoUpdaterWrapper.wave200-146.coverage.test.tsx` (no matches)
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

Known existing issue: `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused tag hints.