### PR TITLE
fix(tui): guard package manager updater checks

### DIFF
--- a/runtime/src/tui/components/PackageManagerAutoUpdater.tsx
+++ b/runtime/src/tui/components/PackageManagerAutoUpdater.tsx
@@ -1,11 +1,12 @@
 import { c as _c } from "react-compiler-runtime";
 import * as React from 'react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useInterval } from 'usehooks-ts';
 import { Text } from '../ink.js';
 import { type AutoUpdaterResult, getLatestVersionFromGcs, getMaxVersion, shouldSkipVersion } from '../../utils/autoUpdater.js'; // upstream-import: keep target is owned by another Z-PURGE item
 import { isAutoUpdaterDisabled } from '../../utils/config.js'; // upstream-import: keep target is owned by another Z-PURGE item
 import { logForDebugging } from 'src/utils/debug.js';
+import { logError } from '../../utils/log.js';
 import { getPackageManager } from '../../utils/nativeInstaller/packageManagers.js'; // upstream-import: keep target is owned by another Z-PURGE item
 import { gt, gte } from '../../utils/semver.js'; // upstream-import: keep target is owned by another Z-PURGE item
 import { getInitialSettings } from '../../utils/settings/settings.js'; // upstream-import: keep target is owned by another Z-PURGE item
@@ -18,12 +19,13 @@ type Props = {
   verbose: boolean;
 };
 export function PackageManagerAutoUpdater(t0: Props): React.ReactNode {
-  const $ = _c(10);
+  const $ = _c(12);
   const {
     verbose
   } = t0;
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const [packageManager, setPackageManager] = useState("unknown");
+  const mountedRef = useRef(true);
   let t1;
   if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
     t1 = async () => {
@@ -32,9 +34,15 @@ export function PackageManagerAutoUpdater(t0: Props): React.ReactNode {
         return;
       }
       const [channel, pm] = await Promise.all([Promise.resolve(getInitialSettings()?.autoUpdatesChannel ?? "latest"), getPackageManager()]);
+      if (!mountedRef.current) {
+        return;
+      }
       setPackageManager(pm);
       let latest = await getLatestVersionFromGcs(channel);
       const maxVersion = await getMaxVersion();
+      if (!mountedRef.current) {
+        return;
+      }
       if (maxVersion && latest && gt(latest, maxVersion)) {
         logForDebugging(`PackageManagerAutoUpdater: maxVersion ${maxVersion} is set, capping update from ${latest} to ${maxVersion}`);
         if (gte(MACRO.VERSION, maxVersion)) {
@@ -57,9 +65,13 @@ export function PackageManagerAutoUpdater(t0: Props): React.ReactNode {
   const checkForUpdates = t1;
   let t2;
   let t3;
+  let t4;
+  let t5;
   if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
     t2 = () => {
-      checkForUpdates();
+      void checkForUpdates().catch((error: unknown) => {
+        logError(error);
+      });
     };
     t3 = [checkForUpdates];
     $[1] = t2;
@@ -68,36 +80,52 @@ export function PackageManagerAutoUpdater(t0: Props): React.ReactNode {
     t2 = $[1];
     t3 = $[2];
   }
-  React.useEffect(t2, t3);
-  useInterval(checkForUpdates, 1800000);
+  const guardedCheckForUpdates = t2;
+  if ($[10] === Symbol.for("react.memo_cache_sentinel")) {
+    t4 = () => {
+      mountedRef.current = true;
+      guardedCheckForUpdates();
+      return () => {
+        mountedRef.current = false;
+      };
+    };
+    t5 = [guardedCheckForUpdates];
+    $[10] = t4;
+    $[11] = t5;
+  } else {
+    t4 = $[10];
+    t5 = $[11];
+  }
+  React.useEffect(t4, t5);
+  useInterval(guardedCheckForUpdates, 1800000);
   if (!updateAvailable) {
     return null;
   }
   const updateCommand = packageManager === "homebrew" ? "brew upgrade agenc-code" : packageManager === "winget" ? "winget upgrade AgenC.AgenCCode" : packageManager === "apk" ? "apk upgrade agenc-code" : "your package manager update command";
-  let t4;
-  if ($[3] !== verbose) {
-    t4 = verbose && <Text dimColor={true} wrap="truncate">currentVersion: {MACRO.VERSION}</Text>;
-    $[3] = verbose;
-    $[4] = t4;
-  } else {
-    t4 = $[4];
-  }
-  let t5;
-  if ($[5] !== updateCommand) {
-    t5 = <Text color="warning" wrap="truncate">Update available! Run: <Text bold={true}>{updateCommand}</Text></Text>;
-    $[5] = updateCommand;
-    $[6] = t5;
-  } else {
-    t5 = $[6];
-  }
   let t6;
-  if ($[7] !== t4 || $[8] !== t5) {
-    t6 = <>{t4}{t5}</>;
-    $[7] = t4;
-    $[8] = t5;
-    $[9] = t6;
+  if ($[3] !== verbose) {
+    t6 = verbose && <Text dimColor={true} wrap="truncate">currentVersion: {MACRO.VERSION}</Text>;
+    $[3] = verbose;
+    $[4] = t6;
   } else {
-    t6 = $[9];
+    t6 = $[4];
   }
-  return t6;
+  let t7;
+  if ($[5] !== updateCommand) {
+    t7 = <Text color="warning" wrap="truncate">Update available! Run: <Text bold={true}>{updateCommand}</Text></Text>;
+    $[5] = updateCommand;
+    $[6] = t7;
+  } else {
+    t7 = $[6];
+  }
+  let t8;
+  if ($[7] !== t6 || $[8] !== t7) {
+    t8 = <>{t6}{t7}</>;
+    $[7] = t6;
+    $[8] = t7;
+    $[9] = t8;
+  } else {
+    t8 = $[9];
+  }
+  return t8;
 }

--- a/runtime/tests/tui/components/PackageManagerAutoUpdater.coverage.test.tsx
+++ b/runtime/tests/tui/components/PackageManagerAutoUpdater.coverage.test.tsx
@@ -8,14 +8,17 @@ const harness = vi.hoisted(() => ({
   getLatestVersionFromGcs: vi.fn(async () => "9.0.0"),
   getMaxVersion: vi.fn(async () => "2.0.0"),
   getPackageManager: vi.fn(async () => "homebrew"),
+  intervalCallback: undefined as (() => void) | undefined,
   intervalDelay: undefined as number | null | undefined,
   isAutoUpdaterDisabled: vi.fn(() => false),
   logForDebugging: vi.fn(),
+  logError: vi.fn(),
   shouldSkipVersion: vi.fn(() => false),
 }));
 
 vi.mock("usehooks-ts", () => ({
-  useInterval: (_callback: () => void, delay: number | null) => {
+  useInterval: (callback: () => void, delay: number | null) => {
+    harness.intervalCallback = callback;
     harness.intervalDelay = delay;
   },
 }));
@@ -61,6 +64,10 @@ vi.mock("../../utils/settings/settings.js", () => ({
 
 vi.mock("src/utils/debug.js", () => ({
   logForDebugging: harness.logForDebugging,
+}));
+
+vi.mock("../../utils/log.js", () => ({
+  logError: harness.logError,
 }));
 
 import { createRoot } from "../ink/root.js";
@@ -116,7 +123,9 @@ async function waitForOutput(
 describe("PackageManagerAutoUpdater coverage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    harness.intervalCallback = undefined;
     harness.intervalDelay = undefined;
+    harness.logError.mockReset();
     (globalThis as Record<string, unknown>).MACRO = {
       VERSION: "1.0.0",
     };
@@ -173,6 +182,86 @@ describe("PackageManagerAutoUpdater coverage", () => {
       expect(harness.logForDebugging).toHaveBeenCalledWith(
         "PackageManagerAutoUpdater: Update available 1.0.0 -> 2.0.0",
       );
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  test("logs rejected package-manager probes and leaves the prompt hidden", async () => {
+    const error = new Error("package-manager probe failed");
+    harness.getPackageManager.mockRejectedValueOnce(error);
+    let output = "";
+    const { stdin, stdout } = createStreams();
+    stdout.on("data", chunk => {
+      output += chunk.toString();
+    });
+
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <PackageManagerAutoUpdater
+          autoUpdaterResult={null}
+          isUpdating={false}
+          onAutoUpdaterResult={() => {}}
+          onChangeIsUpdating={() => {}}
+          showSuccessMessage={false}
+          verbose={true}
+        />,
+      );
+
+      await waitForOutput(() => `${harness.getPackageManager.mock.calls.length}`, "1");
+      await sleep(20);
+
+      expect(harness.logError).toHaveBeenCalledWith(error);
+      expect(stripAnsi(output)).not.toContain("Update available");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  test("logs rejected interval checks without leaking async failures", async () => {
+    const error = new Error("latest-version probe failed");
+    let output = "";
+    const { stdin, stdout } = createStreams();
+    stdout.on("data", chunk => {
+      output += chunk.toString();
+    });
+
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <PackageManagerAutoUpdater
+          autoUpdaterResult={null}
+          isUpdating={false}
+          onAutoUpdaterResult={() => {}}
+          onChangeIsUpdating={() => {}}
+          showSuccessMessage={false}
+          verbose={false}
+        />,
+      );
+
+      await waitForOutput(() => output, "brew upgrade");
+      harness.logError.mockReset();
+      harness.getLatestVersionFromGcs.mockRejectedValueOnce(error);
+      harness.intervalCallback?.();
+      await sleep(20);
+
+      expect(harness.logError).toHaveBeenCalledWith(error);
+      expect(stripAnsi(output)).toContain("brew upgrade agenc-code");
     } finally {
       root.unmount();
       stdin.end();


### PR DESCRIPTION
## Summary
- Route package-manager updater mount and interval checks through a guarded callback.
- Log rejected package-manager/version probes instead of leaking unhandled rejections.
- Stop in-flight update checks from setting state after unmount.

## Test plan
- Failing-first focused updater regression reproduced the unhandled rejection.
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/PackageManagerAutoUpdater.coverage.test.tsx --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/PackageManagerAutoUpdater.coverage.test.tsx tests/tui/coverage-swarm/swarm-115-components-PackageManagerAutoUpdater.test.tsx tests/tui/components/AutoUpdaterWrapper.wave200-146.coverage.test.tsx tests/tui/components/NativeAutoUpdater.wave200-053.coverage.test.tsx tests/tui/components/AutoUpdater.ascii.test.tsx --reporter=dot`
- `npm run typecheck`
- `git diff --check`
- `rg -n -- "Claude|claude|Codex|codex|OpenClaude|openclaude|TODO|FIXME|HACK" runtime/src/tui/components/PackageManagerAutoUpdater.tsx runtime/tests/tui/components/PackageManagerAutoUpdater.coverage.test.tsx` (no matches)
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

Known existing issue: `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused tag hints.