### PR TITLE
fix(tui): guard standard auto updater failures

### DIFF
--- a/runtime/src/tui/components/AutoUpdater.tsx
+++ b/runtime/src/tui/components/AutoUpdater.tsx
@@ -7,6 +7,7 @@ import { Box, Text } from '../ink.js';
 import { type AutoUpdaterResult, getLatestVersion, getMaxVersion, type InstallStatus, installGlobalPackage, shouldSkipVersion } from '../../utils/autoUpdater.js'; // upstream-import: keep target is owned by another Z-PURGE item
 import { getGlobalConfig, isAutoUpdaterDisabled } from '../../utils/config.js'; // upstream-import: keep target is owned by another Z-PURGE item
 import { logForDebugging } from 'src/utils/debug.js';
+import { logError } from '../../utils/log.js';
 import { getCurrentInstallationType } from '../../utils/doctorDiagnostic.js'; // upstream-import: keep target is owned by another Z-PURGE item
 import { installOrUpdateAgenCPackage, localInstallationExists } from '../../utils/localInstaller.js'; // upstream-import: keep target is owned by another Z-PURGE item
 import { removeInstalledSymlink } from '../../utils/nativeInstaller/installer.js'; // upstream-import: keep target is owned by another Z-PURGE item
@@ -35,8 +36,19 @@ export function AutoUpdater({
   }>({});
   const [hasLocalInstall, setHasLocalInstall] = useState(false);
   const updateSemver = useUpdateNotification(autoUpdaterResult?.version);
+  const mountedRef = useRef(true);
   useEffect(() => {
-    void localInstallationExists().then(setHasLocalInstall);
+    mountedRef.current = true;
+    void localInstallationExists().then(exists => {
+      if (mountedRef.current) {
+        setHasLocalInstall(exists);
+      }
+    }, (error: unknown) => {
+      logError(error);
+    });
+    return () => {
+      mountedRef.current = false;
+    };
   }, []);
 
   // Track latest isUpdating value in a ref so the memoized checkForUpdates
@@ -47,112 +59,143 @@ export function AutoUpdater({
   const isUpdatingRef = useRef(isUpdating);
   isUpdatingRef.current = isUpdating;
   const checkForUpdates = React.useCallback(async () => {
-    if (isUpdatingRef.current) {
-      return;
-    }
-    if (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') {
-      logForDebugging('AutoUpdater: Skipping update check in test/dev environment');
-      return;
-    }
-    const currentVersion = MACRO.VERSION;
-    const channel = getInitialSettings()?.autoUpdatesChannel ?? 'latest';
-    let latestVersion = await getLatestVersion(channel);
-    const isDisabled = isAutoUpdaterDisabled();
-
-    // Check if max version is set (server-side kill switch for auto-updates)
-    const maxVersion = await getMaxVersion();
-    if (maxVersion && latestVersion && gt(latestVersion, maxVersion)) {
-      logForDebugging(`AutoUpdater: maxVersion ${maxVersion} is set, capping update from ${latestVersion} to ${maxVersion}`);
-      if (gte(currentVersion, maxVersion)) {
-        logForDebugging(`AutoUpdater: current version ${currentVersion} is already at or above maxVersion ${maxVersion}, skipping update`);
-        setVersions({
-          global: currentVersion,
-          latest: latestVersion
-        });
-        return;
-      }
-      latestVersion = maxVersion;
-    }
-    setVersions({
-      global: currentVersion,
-      latest: latestVersion
-    });
-
-    // Check if update needed and perform update
-    if (!isDisabled && currentVersion && latestVersion && !gte(currentVersion, latestVersion) && !shouldSkipVersion(latestVersion)) {
-      const startTime = Date.now();
-      onChangeIsUpdating(true);
-
-      // Remove native installer symlink since we're using JS-based updates
-      // But only if user hasn't migrated to native installation
-      const config = getGlobalConfig();
-      if (config.installMethod !== 'native') {
-        await removeInstalledSymlink();
-      }
-
-      // Detect actual running installation type
-      const installationType = await getCurrentInstallationType();
-      logForDebugging(`AutoUpdater: Detected installation type: ${installationType}`);
-
-      // Skip update for development builds
-      if (installationType === 'development') {
-        logForDebugging('AutoUpdater: Cannot auto-update development build');
+    let didStartUpdating = false;
+    const stopUpdatingAfterFailure = () => {
+      if (didStartUpdating && mountedRef.current) {
         onChangeIsUpdating(false);
+        didStartUpdating = false;
+      }
+    };
+    try {
+      if (isUpdatingRef.current) {
+        return;
+      }
+      if (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') {
+        logForDebugging('AutoUpdater: Skipping update check in test/dev environment');
+        return;
+      }
+      const currentVersion = MACRO.VERSION;
+      const channel = getInitialSettings()?.autoUpdatesChannel ?? 'latest';
+      let latestVersion = await getLatestVersion(channel);
+      const isDisabled = isAutoUpdaterDisabled();
+      if (!mountedRef.current) {
         return;
       }
 
-      // Choose the appropriate update method based on what's actually running
-      let installStatus: InstallStatus;
-      let updateMethod: 'local' | 'global';
-      if (installationType === 'npm-local') {
-        // Use local update for local installations
-        logForDebugging('AutoUpdater: Using local update method');
-        updateMethod = 'local';
-        installStatus = await installOrUpdateAgenCPackage(channel);
-      } else if (installationType === 'npm-global') {
-        // Use global update for global installations
-        logForDebugging('AutoUpdater: Using global update method');
-        updateMethod = 'global';
-        installStatus = await installGlobalPackage();
-      } else if (installationType === 'native') {
-        // This shouldn't happen - native should use NativeAutoUpdater
-        logForDebugging('AutoUpdater: Unexpected native installation in non-native updater');
-        onChangeIsUpdating(false);
+      // Check if max version is set (server-side kill switch for auto-updates)
+      const maxVersion = await getMaxVersion();
+      if (!mountedRef.current) {
         return;
-      } else {
-        // Fallback to config-based detection for unknown types
-        logForDebugging(`AutoUpdater: Unknown installation type, falling back to config`);
-        const isMigrated = config.installMethod === 'local';
-        updateMethod = isMigrated ? 'local' : 'global';
-        if (isMigrated) {
-          installStatus = await installOrUpdateAgenCPackage(channel);
-        } else {
-          installStatus = await installGlobalPackage();
+      }
+      if (maxVersion && latestVersion && gt(latestVersion, maxVersion)) {
+        logForDebugging(`AutoUpdater: maxVersion ${maxVersion} is set, capping update from ${latestVersion} to ${maxVersion}`);
+        if (gte(currentVersion, maxVersion)) {
+          logForDebugging(`AutoUpdater: current version ${currentVersion} is already at or above maxVersion ${maxVersion}, skipping update`);
+          setVersions({
+            global: currentVersion,
+            latest: latestVersion
+          });
+          return;
         }
+        latestVersion = maxVersion;
       }
-      onChangeIsUpdating(false);
-      if (installStatus === 'success') {
-        logEvent('tengu_auto_updater_success', {
-          fromVersion: currentVersion as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-          toVersion: latestVersion as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-          durationMs: Date.now() - startTime,
-          wasMigrated: updateMethod === 'local',
-          installationType: installationType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
-        });
-      } else {
-        logEvent('tengu_auto_updater_fail', {
-          fromVersion: currentVersion as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-          attemptedVersion: latestVersion as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-          status: installStatus as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
-          durationMs: Date.now() - startTime,
-          wasMigrated: updateMethod === 'local',
-          installationType: installationType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
-        });
-      }
-      onAutoUpdaterResult({
-        version: latestVersion,
-        status: installStatus
+      setVersions({
+        global: currentVersion,
+        latest: latestVersion
       });
+
+      // Check if update needed and perform update
+      if (!isDisabled && currentVersion && latestVersion && !gte(currentVersion, latestVersion) && !shouldSkipVersion(latestVersion)) {
+        const startTime = Date.now();
+        onChangeIsUpdating(true);
+        didStartUpdating = true;
+
+        // Remove native installer symlink since we're using JS-based updates
+        // But only if user hasn't migrated to native installation
+        const config = getGlobalConfig();
+        if (config.installMethod !== 'native') {
+          await removeInstalledSymlink();
+        }
+        if (!mountedRef.current) {
+          return;
+        }
+
+        // Detect actual running installation type
+        const installationType = await getCurrentInstallationType();
+        if (!mountedRef.current) {
+          return;
+        }
+        logForDebugging(`AutoUpdater: Detected installation type: ${installationType}`);
+
+        // Skip update for development builds
+        if (installationType === 'development') {
+          logForDebugging('AutoUpdater: Cannot auto-update development build');
+          onChangeIsUpdating(false);
+          didStartUpdating = false;
+          return;
+        }
+
+        // Choose the appropriate update method based on what's actually running
+        let installStatus: InstallStatus;
+        let updateMethod: 'local' | 'global';
+        if (installationType === 'npm-local') {
+          // Use local update for local installations
+          logForDebugging('AutoUpdater: Using local update method');
+          updateMethod = 'local';
+          installStatus = await installOrUpdateAgenCPackage(channel);
+        } else if (installationType === 'npm-global') {
+          // Use global update for global installations
+          logForDebugging('AutoUpdater: Using global update method');
+          updateMethod = 'global';
+          installStatus = await installGlobalPackage();
+        } else if (installationType === 'native') {
+          // This shouldn't happen - native should use NativeAutoUpdater
+          logForDebugging('AutoUpdater: Unexpected native installation in non-native updater');
+          onChangeIsUpdating(false);
+          didStartUpdating = false;
+          return;
+        } else {
+          // Fallback to config-based detection for unknown types
+          logForDebugging(`AutoUpdater: Unknown installation type, falling back to config`);
+          const isMigrated = config.installMethod === 'local';
+          updateMethod = isMigrated ? 'local' : 'global';
+          if (isMigrated) {
+            installStatus = await installOrUpdateAgenCPackage(channel);
+          } else {
+            installStatus = await installGlobalPackage();
+          }
+        }
+        if (!mountedRef.current) {
+          return;
+        }
+        onChangeIsUpdating(false);
+        didStartUpdating = false;
+        if (installStatus === 'success') {
+          logEvent('tengu_auto_updater_success', {
+            fromVersion: currentVersion as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+            toVersion: latestVersion as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+            durationMs: Date.now() - startTime,
+            wasMigrated: updateMethod === 'local',
+            installationType: installationType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
+          });
+        } else {
+          logEvent('tengu_auto_updater_fail', {
+            fromVersion: currentVersion as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+            attemptedVersion: latestVersion as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+            status: installStatus as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
+            durationMs: Date.now() - startTime,
+            wasMigrated: updateMethod === 'local',
+            installationType: installationType as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS
+          });
+        }
+        onAutoUpdaterResult({
+          version: latestVersion,
+          status: installStatus
+        });
+      }
+    } catch (error) {
+      logError(error);
+      stopUpdatingAfterFailure();
     }
     // isUpdating intentionally omitted from deps; we read isUpdatingRef
     // instead so the guard is always current without changing callback

--- a/runtime/tests/tui/components/AutoUpdater.wave200-039.coverage.test.tsx
+++ b/runtime/tests/tui/components/AutoUpdater.wave200-039.coverage.test.tsx
@@ -16,6 +16,7 @@ const harness = vi.hoisted(() => ({
   intervalDelay: undefined as number | null | undefined,
   isAutoUpdaterDisabled: vi.fn(() => false),
   localInstallationExists: vi.fn(async () => true),
+  logError: vi.fn(),
   logEvent: vi.fn(),
   logForDebugging: vi.fn(),
   removeInstalledSymlink: vi.fn(async () => {}),
@@ -34,6 +35,10 @@ vi.mock("../../services/analytics/index.js", () => ({
 
 vi.mock("src/utils/debug.js", () => ({
   logForDebugging: harness.logForDebugging,
+}));
+
+vi.mock("../../utils/log.js", () => ({
+  logError: harness.logError,
 }));
 
 vi.mock("../../utils/autoUpdater.js", () => ({
@@ -138,6 +143,22 @@ async function waitForOutput(
   return stripAnsi(readOutput());
 }
 
+async function waitFor(
+  predicate: () => boolean,
+  label: string,
+): Promise<void> {
+  const deadline = Date.now() + 1000;
+
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await sleep(10);
+  }
+
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
 function Harness(): React.ReactNode {
   const [isUpdating, setIsUpdating] = React.useState(false);
   const [autoUpdaterResult, setAutoUpdaterResult] =
@@ -159,6 +180,7 @@ describe("AutoUpdater wave200 coverage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     harness.intervalDelay = undefined;
+    harness.logError.mockReset();
     process.env.AGENC_TUI_GLYPHS = "ascii";
     process.env.NODE_ENV = "production";
     (globalThis as Record<string, unknown>).MACRO = {
@@ -234,6 +256,85 @@ describe("AutoUpdater wave200 coverage", () => {
           wasMigrated: true,
         }),
       );
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  test("logs rejected local-install probes without leaking async failures", async () => {
+    process.env.NODE_ENV = "development";
+    const error = new Error("local install probe failed");
+    harness.localInstallationExists.mockRejectedValueOnce(error);
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AutoUpdater
+          autoUpdaterResult={null}
+          isUpdating={false}
+          onAutoUpdaterResult={() => {}}
+          onChangeIsUpdating={() => {}}
+          showSuccessMessage={true}
+          verbose={true}
+        />,
+      );
+
+      await waitFor(
+        () => harness.localInstallationExists.mock.calls.length > 0,
+        "local installation probe",
+      );
+      await sleep(20);
+
+      expect(harness.logError).toHaveBeenCalledWith(error);
+      expect(harness.getLatestVersion).not.toHaveBeenCalled();
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  test("logs rejected update installs and clears the updating flag", async () => {
+    const error = new Error("global install failed");
+    harness.getCurrentInstallationType.mockResolvedValue("npm-global");
+    harness.installGlobalPackage.mockRejectedValueOnce(error);
+    const onChangeIsUpdating = vi.fn();
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AutoUpdater
+          autoUpdaterResult={null}
+          isUpdating={false}
+          onAutoUpdaterResult={() => {}}
+          onChangeIsUpdating={onChangeIsUpdating}
+          showSuccessMessage={true}
+          verbose={true}
+        />,
+      );
+
+      await waitFor(
+        () => harness.installGlobalPackage.mock.calls.length > 0,
+        "global install attempt",
+      );
+      await sleep(20);
+
+      expect(harness.logError).toHaveBeenCalledWith(error);
+      expect(onChangeIsUpdating).toHaveBeenNthCalledWith(1, true);
+      expect(onChangeIsUpdating).toHaveBeenLastCalledWith(false);
+      expect(harness.logEvent).not.toHaveBeenCalled();
     } finally {
       root.unmount();
       stdin.end();


### PR DESCRIPTION
## Summary
- Catch and log rejected standard AutoUpdater local-install probes instead of leaking unhandled async failures.
- Catch and log rejected update attempts, then clear the updating flag when an install already started.
- Guard updater state and callback work after unmount across async boundaries.

## Test plan
- Failing-first focused AutoUpdater regression reproduced rejected local-install probe and rejected install attempt failures.
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/AutoUpdater.wave200-039.coverage.test.tsx --reporter=dot`
- Adjacent updater suites: `AutoUpdater.wave200-039`, `swarm-050-components-AutoUpdater`, `AutoUpdater.ascii`, `AutoUpdaterWrapper.wave200-146`, `NativeAutoUpdater.wave200-053`, `PackageManagerAutoUpdater.coverage`
- `npm run typecheck`
- `git diff --check`
- Touched-file branding/TODO scan
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

## Known unrelated backlog
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on existing Knip findings: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused tag hints.
