### PR TITLE
fix(tui): guard history search load failures

### DIFF
--- a/runtime/src/tui/history/HistorySearchDialog.tsx
+++ b/runtime/src/tui/history/HistorySearchDialog.tsx
@@ -11,6 +11,7 @@ import { Box, Text } from '../ink.js';
 import { logEvent } from '../../services/analytics/index.js';
 import type { HistoryEntry } from '../../utils/config.js';
 import { formatRelativeTimeAgo, truncateToWidth } from '../../utils/format.js';
+import { logError } from '../../utils/log.js';
 import { FuzzyPicker } from '../components/design-system/FuzzyPicker.js';
 type Props = {
   initialQuery?: string;
@@ -47,29 +48,46 @@ export function HistorySearchDialog({
   }, []);
   useEffect(() => {
     let cancelled = false;
+    let reader: ReturnType<typeof getTimestampedHistory> | undefined;
+    let returned = false;
+    const closeReader = () => {
+      if (!reader || returned) return;
+      returned = true;
+      void reader.return(undefined).catch(logError);
+    };
     void (async () => {
-      const reader = getTimestampedHistory();
-      const loaded: Item[] = [];
-      for await (const entry of reader) {
+      try {
+        reader = getTimestampedHistory();
+        const loaded: Item[] = [];
+        for await (const entry of reader) {
+          if (cancelled) {
+            closeReader();
+            return;
+          }
+          const display = entry.display;
+          const nl = display.indexOf('\n');
+          const age = formatRelativeTimeAgo(new Date(entry.timestamp));
+          loaded.push({
+            entry,
+            display,
+            lower: display.toLowerCase(),
+            firstLine: nl === -1 ? display : display.slice(0, nl),
+            age: age + ' '.repeat(Math.max(0, AGE_WIDTH - stringWidth(age)))
+          });
+        }
+        if (!cancelled) setItems(loaded);
+      } catch (error) {
         if (cancelled) {
-          void reader.return(undefined);
+          closeReader();
           return;
         }
-        const display = entry.display;
-        const nl = display.indexOf('\n');
-        const age = formatRelativeTimeAgo(new Date(entry.timestamp));
-        loaded.push({
-          entry,
-          display,
-          lower: display.toLowerCase(),
-          firstLine: nl === -1 ? display : display.slice(0, nl),
-          age: age + ' '.repeat(Math.max(0, AGE_WIDTH - stringWidth(age)))
-        });
+        logError(error);
+        setItems([]);
       }
-      if (!cancelled) setItems(loaded);
     })();
     return () => {
       cancelled = true;
+      closeReader();
     };
   }, []);
   const filtered = useMemo(() => {

--- a/runtime/tests/tui/history/HistorySearchDialog.coverage.test.tsx
+++ b/runtime/tests/tui/history/HistorySearchDialog.coverage.test.tsx
@@ -48,6 +48,9 @@ const harness = vi.hoisted(() => ({
     const reader = {
       next: vi.fn(async (): Promise<IteratorResult<TimestampedEntryLike>> => {
         await harness.historyGate?.promise
+        if (harness.readerNextError) {
+          throw harness.readerNextError
+        }
         if (index >= harness.entries.length) {
           return { done: true, value: undefined }
         }
@@ -56,10 +59,15 @@ const harness = vi.hoisted(() => ({
         index += 1
         return { done: false, value: value! }
       }),
-      return: vi.fn(async (): Promise<IteratorResult<TimestampedEntryLike>> => ({
-        done: true,
-        value: undefined,
-      })),
+      return: vi.fn(async (): Promise<IteratorResult<TimestampedEntryLike>> => {
+        if (harness.readerReturnError) {
+          throw harness.readerReturnError
+        }
+        return {
+          done: true,
+          value: undefined,
+        }
+      }),
       [Symbol.asyncIterator]() {
         return this
       },
@@ -69,8 +77,11 @@ const harness = vi.hoisted(() => ({
     return reader
   }),
   historyGate: undefined as Deferred | undefined,
+  logError: vi.fn(),
   logEvent: vi.fn(),
   pickerProps: undefined as CapturedPickerProps | undefined,
+  readerNextError: undefined as unknown | undefined,
+  readerReturnError: undefined as unknown | undefined,
   readers: [] as Array<{
     next: ReturnType<typeof vi.fn>
     return: ReturnType<typeof vi.fn>
@@ -98,6 +109,10 @@ vi.mock('../../services/analytics/index.js', () => ({
   logEvent: harness.logEvent,
 }))
 
+vi.mock('../../utils/log.js', () => ({
+  logError: harness.logError,
+}))
+
 vi.mock('../components/design-system/FuzzyPicker.js', () => ({
   FuzzyPicker: (props: CapturedPickerProps) => {
     harness.pickerProps = props
@@ -122,8 +137,11 @@ function resetHarness() {
   harness.entries = []
   harness.getTimestampedHistory.mockClear()
   harness.historyGate = undefined
+  harness.logError.mockClear()
   harness.logEvent.mockClear()
   harness.pickerProps = undefined
+  harness.readerNextError = undefined
+  harness.readerReturnError = undefined
   harness.readers = []
   harness.registerOverlay.mockClear()
   harness.terminal.columns = 120
@@ -398,5 +416,57 @@ describe('HistorySearchDialog coverage', () => {
 
     expect(resolveEntry).toHaveBeenCalledTimes(1)
     expect(rendered.onSelect).not.toHaveBeenCalled()
+  })
+
+  it('logs rejected history loads and clears the loading state', async () => {
+    const error = new Error('history reader failed')
+    harness.readerNextError = error
+
+    const rendered = await renderDialog()
+
+    try {
+      await waitFor(
+        () => harness.readers[0]?.next.mock.calls.length === 1,
+        'History reader did not attempt to load',
+      )
+      await waitFor(
+        () => harness.logError.mock.calls.length === 1,
+        'History reader failure was not logged',
+      )
+      await waitFor(
+        () => emptyMessage(pickerProps(), '') === 'No history yet',
+        'History reader failure did not clear loading state',
+      )
+
+      const props = pickerProps()
+      expect(harness.logError).toHaveBeenCalledWith(error)
+      expect(props.items).toEqual([])
+      expect(emptyMessage(props, '')).toBe('No history yet')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  it('logs rejected history reader closes during unmount', async () => {
+    const closeError = new Error('history reader close failed')
+    harness.historyGate = deferred()
+    harness.readerReturnError = closeError
+
+    const rendered = await renderDialog()
+
+    try {
+      await waitFor(
+        () => harness.readers.length === 1,
+        'History reader was not created',
+      )
+    } finally {
+      await rendered.dispose()
+    }
+
+    await waitFor(
+      () => harness.logError.mock.calls.some(call => call[0] === closeError),
+      'History reader close failure was not logged',
+    )
+    expect(harness.readers[0]?.return).toHaveBeenCalledWith(undefined)
   })
 })


### PR DESCRIPTION
## Summary
- Catch and log rejected history-search loads instead of leaking unhandled async failures.
- Render a loaded empty picker state when history loading fails so the dialog does not remain stuck on loading.
- Close the history async reader during cancellation and catch/log rejected reader cleanup.

## Test plan
- Failing-first focused HistorySearchDialog regressions reproduced rejected load and rejected cleanup failures.
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/history/HistorySearchDialog.coverage.test.tsx --reporter=dot`
- Adjacent history suites: `HistorySearchDialog.coverage`, `swarm-190-history-HistorySearchDialog`, `useHistorySearch.test`, `useHistorySearch.runtime-coverage`, `swarm-192-hooks-useHistorySearch`, `HistorySearchInput.wave200-127`
- `npm run typecheck`
- `git diff --check`
- Touched-file branding/TODO scan
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

## Known unrelated backlog
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on existing Knip findings: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused tag hints.
