### PR TITLE
fix(tui): guard team mode mailbox failures

### DIFF
--- a/runtime/src/tui/components/teams/TeamsDialog.tsx
+++ b/runtime/src/tui/components/teams/TeamsDialog.tsx
@@ -16,6 +16,7 @@ import { AGENT_COLOR_TO_THEME_COLOR } from 'src/tools/AgentTool/agentColorManage
 import { logForDebugging } from 'src/utils/debug.js';
 import { errorMessage } from '../../../utils/errors.js';
 import { execFileNoThrow } from '../../../utils/execFileNoThrow.js';
+import { logError } from '../../../utils/log.js';
 import { getNextPermissionMode } from '../../../utils/permissions/getNextPermissionMode.js';
 import { getModeColor, type PermissionMode, permissionModeFromString, permissionModeSymbol } from '../../../utils/permissions/PermissionMode.js';
 import { jsonStringify } from '../../../utils/slowOperations.js';
@@ -734,7 +735,11 @@ function sendModeChangeToTeammate(teammateName: string, teamName: string, target
   // Update config.json directly so UI shows the change immediately
   setMemberMode(teamName, teammateName, targetMode);
 
-  // Also send message so teammate updates their local permission context
+  sendModeChangeMailboxMessage(teammateName, teamName, targetMode);
+  logForDebugging(`[TeamsDialog] Sent mode change to ${teammateName}: ${targetMode}`);
+}
+
+function sendModeChangeMailboxMessage(teammateName: string, teamName: string, targetMode: PermissionMode): void {
   const message = createModeSetRequestMessage({
     mode: targetMode,
     from: 'team-lead'
@@ -743,8 +748,10 @@ function sendModeChangeToTeammate(teammateName: string, teamName: string, target
     from: 'team-lead',
     text: jsonStringify(message),
     timestamp: new Date().toISOString()
-  }, teamName);
-  logForDebugging(`[TeamsDialog] Sent mode change to ${teammateName}: ${targetMode}`);
+  }, teamName).catch(error => {
+    logError(error);
+    logForDebugging(`[TeamsDialog] Failed to send mode change to ${teammateName}: ${errorMessage(error)}`);
+  });
 }
 
 /**
@@ -788,15 +795,7 @@ function cycleAllTeammateModes(teammates: TeammateStatus[], teamName: string, is
 
   // Send mailbox messages to each teammate
   for (const teammate of teammates) {
-    const message = createModeSetRequestMessage({
-      mode: targetMode,
-      from: 'team-lead'
-    });
-    void writeToMailbox(teammate.name, {
-      from: 'team-lead',
-      text: jsonStringify(message),
-      timestamp: new Date().toISOString()
-    }, teamName);
+    sendModeChangeMailboxMessage(teammate.name, teamName, targetMode);
   }
   logForDebugging(`[TeamsDialog] Sent mode change to all ${teammates.length} teammates: ${targetMode}`);
 }

--- a/runtime/tests/tui/coverage-swarm/swarm-016-components-teams-TeamsDialog.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-016-components-teams-TeamsDialog.test.tsx
@@ -54,6 +54,10 @@ const mailboxMock = vi.hoisted(() => ({
   writeToMailbox: vi.fn(async () => {}),
 }));
 
+const logMock = vi.hoisted(() => ({
+  logError: vi.fn(),
+}));
+
 const teamHelpersMock = vi.hoisted(() => ({
   addHiddenPaneId: vi.fn(() => true),
   removeHiddenPaneId: vi.fn(() => true),
@@ -163,6 +167,9 @@ vi.mock("../../../src/utils/teammateMailbox.js", () => ({
   createModeSetRequestMessage: (message: unknown) => message,
   sendShutdownRequestToMailbox: mailboxMock.sendShutdownRequestToMailbox,
   writeToMailbox: mailboxMock.writeToMailbox,
+}));
+vi.mock("../../../src/utils/log.js", () => ({
+  logError: logMock.logError,
 }));
 vi.mock("../../../src/utils/swarm/teamHelpers.js", () => ({
   addHiddenPaneId: teamHelpersMock.addHiddenPaneId,
@@ -333,6 +340,7 @@ beforeEach(() => {
   mailboxMock.sendShutdownRequestToMailbox.mockResolvedValue(undefined);
   mailboxMock.writeToMailbox.mockReset();
   mailboxMock.writeToMailbox.mockResolvedValue(undefined);
+  logMock.logError.mockReset();
   teamHelpersMock.addHiddenPaneId.mockReset();
   teamHelpersMock.addHiddenPaneId.mockReturnValue(true);
   teamHelpersMock.removeHiddenPaneId.mockReset();
@@ -381,6 +389,53 @@ describe("TeamsDialog coverage-swarm detail actions", () => {
         "alpha",
       );
       expect(teamHelpersMock.setMultipleMemberModes).not.toHaveBeenCalled();
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("logs rejected detail mode mailbox writes without rolling back local mode", async () => {
+    const error = new Error("mailbox lock release failed");
+    mailboxMock.writeToMailbox.mockRejectedValueOnce(error);
+    const harness = await createTeamsDialogHarness();
+
+    try {
+      await harness.press("\r", { return: true });
+      keybindingMock.handlers.get("confirm:cycleMode")?.();
+      await settle();
+
+      expect(teamHelpersMock.setMemberMode).toHaveBeenCalledWith(
+        "alpha",
+        "Fixer",
+        "plan",
+      );
+      expect(mailboxMock.writeToMailbox).toHaveBeenCalledTimes(1);
+      expect(logMock.logError).toHaveBeenCalledWith(error);
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("logs rejected bulk mode mailbox writes after the batch local update", async () => {
+    const error = new Error("bulk mailbox offline");
+    mailboxMock.writeToMailbox
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce(undefined);
+    const harness = await createTeamsDialogHarness();
+
+    try {
+      keybindingMock.handlers.get("confirm:cycleMode")?.();
+      await settle();
+
+      expect(teamHelpersMock.setMultipleMemberModes).toHaveBeenCalledWith(
+        "alpha",
+        [
+          { memberName: "Fixer", mode: "default" },
+          { memberName: "Planner", mode: "default" },
+        ],
+      );
+      expect(mailboxMock.writeToMailbox).toHaveBeenCalledTimes(2);
+      expect(logMock.logError).toHaveBeenCalledWith(error);
     } finally {
       harness.unmount();
     }


### PR DESCRIPTION
## Summary
- Catch and log rejected team mode-change mailbox writes for detail and bulk mode cycling.
- Preserve the already-applied local team config updates when mailbox delivery fails.
- Add regressions for single-teammate and bulk mode-change mailbox rejections.

## Test plan
- [x] Failing-first focused TeamsDialog regressions reproduced missing rejection logging for detail and bulk mailbox writes.
- [x] `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/coverage-swarm/swarm-016-components-teams-TeamsDialog.test.tsx --reporter=dot`
- [x] Adjacent TeamsDialog and PromptInput suites: 6 files, 78 tests.
- [x] `npm run typecheck`
- [x] `git diff --check`
- [x] Touched-file branding/TODO scan.
- [x] `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui` passed with 755 files and 3172 tests.
- [x] TUI validation gate passed rebuild plus runtime startup smoke at 148x40, 120x30, and 80x24 for normal and yolo launches.
- [x] `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails only on known unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused tag hints.
