### PR TITLE
fix(tui): guard message selector diff metadata

### DIFF
--- a/runtime/src/tui/components/MessageSelector.tsx
+++ b/runtime/src/tui/components/MessageSelector.tsx
@@ -126,6 +126,10 @@ export function MessageSelector({
     let cancelled = false;
     void fileHistoryGetDiffStats(fileHistory, preselectedMessage.uuid).then(stats => {
       if (!cancelled) setDiffStatsForRestore(stats);
+    }).catch(error_0 => {
+      if (cancelled) return;
+      logError(error_0 as Error);
+      setDiffStatsForRestore(undefined);
     });
     return () => {
       cancelled = true;
@@ -218,7 +222,13 @@ export function MessageSelector({
       await restoreConversationDirectly(message_0);
       return;
     }
-    const diffStats = await fileHistoryGetDiffStats(fileHistory, message_0.uuid);
+    let diffStats;
+    try {
+      diffStats = await fileHistoryGetDiffStats(fileHistory, message_0.uuid);
+    } catch (error_0) {
+      logError(error_0 as Error);
+      diffStats = undefined;
+    }
     setMessageToRestore(message_0);
     setDiffStatsForRestore(diffStats);
   }

--- a/runtime/tests/tui/components/MessageSelector.render.test.tsx
+++ b/runtime/tests/tui/components/MessageSelector.render.test.tsx
@@ -12,6 +12,7 @@ const harness = vi.hoisted(() => ({
     insertions: 5,
   },
   fileHistoryEnabled: true,
+  fileHistoryGetDiffStats: vi.fn(),
   keybindings: {} as Record<string, () => unknown>,
   logError: vi.fn(),
   logEvent: vi.fn(),
@@ -32,6 +33,8 @@ const harness = vi.hoisted(() => ({
       insertions: 5,
     }
     harness.fileHistoryEnabled = true
+    harness.fileHistoryGetDiffStats.mockReset()
+    harness.fileHistoryGetDiffStats.mockResolvedValue(harness.diffStats)
     harness.keybindings = {}
     harness.logError.mockClear()
     harness.logEvent.mockClear()
@@ -51,7 +54,7 @@ vi.mock('../state/AppState.js', () => ({
 vi.mock('../../utils/fileHistory.js', () => ({
   fileHistoryCanRestore: () => true,
   fileHistoryEnabled: () => harness.fileHistoryEnabled,
-  fileHistoryGetDiffStats: vi.fn(async () => harness.diffStats),
+  fileHistoryGetDiffStats: harness.fileHistoryGetDiffStats,
 }))
 
 vi.mock('../../utils/log.js', () => ({
@@ -275,6 +278,56 @@ describe('MessageSelector render paths', () => {
       expect(onRestoreCode).toHaveBeenCalledWith(selected)
       expect(onRestoreMessage).toHaveBeenCalledWith(selected)
       expect(onClose).toHaveBeenCalled()
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('logs rejected selected-message diff metadata and falls back to conversation restore', async () => {
+    const error = new Error('diff metadata unavailable')
+    harness.fileHistoryGetDiffStats.mockRejectedValueOnce(error)
+    const selected = userMessage('user-1', 'restore with missing metadata')
+    const rendered = await renderSelector({
+      messages: [selected, assistantMessage('assistant-1', 'reply')],
+    })
+
+    try {
+      harness.keybindings['messageSelector:up']?.()
+      await sleep()
+      harness.keybindings['messageSelector:select']?.()
+      await sleep()
+
+      expect(harness.fileHistoryGetDiffStats).toHaveBeenCalledWith(
+        harness.appState.fileHistory,
+        selected.uuid,
+      )
+      expect(harness.logError).toHaveBeenCalledWith(error)
+      expect(rendered.output()).toContain('Restore conversation')
+      expect(rendered.output()).not.toContain('Restore code')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  test('logs rejected preselected diff metadata and renders conversation-only restore', async () => {
+    const error = new Error('preselected diff metadata failed')
+    harness.fileHistoryGetDiffStats.mockRejectedValueOnce(error)
+    const selected = userMessage('user-1', 'preselected missing metadata')
+    const rendered = await renderSelector({
+      messages: [selected, assistantMessage('assistant-1', 'reply')],
+      preselectedMessage: selected,
+    })
+
+    try {
+      await sleep()
+
+      expect(harness.fileHistoryGetDiffStats).toHaveBeenCalledWith(
+        harness.appState.fileHistory,
+        selected.uuid,
+      )
+      expect(harness.logError).toHaveBeenCalledWith(error)
+      expect(rendered.output()).toContain('Restore conversation')
+      expect(rendered.output()).not.toContain('Restore code')
     } finally {
       await rendered.dispose()
     }


### PR DESCRIPTION
## Summary
- Catch and log rejected MessageSelector diff metadata loads for selected-message and preselected rewind flows.
- Fall back to conversation-only restore confirmation when diff metadata is unavailable.
- Add regressions for both rejection paths.

## Test plan
- Failing-first focused regressions reproduced unhandled rejected diff metadata loads.
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/MessageSelector.render.test.tsx --reporter=dot
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/MessageSelector.render.test.tsx tests/tui/components/MessageSelector.coverage.test.tsx tests/tui/components/MessageSelector.coverage2.test.tsx tests/tui/coverage-swarm/swarm-012-components-MessageSelector.test.tsx tests/tui/components/MessageSelector.layout.test.ts tests/tui/components/MessageSelector.filter.test.ts tests/tui/components/App.render.test.tsx tests/tui/parity/App.tooljsx-gating.parity.test.tsx --reporter=dot
- npm run typecheck
- git diff --check
- touched-file branding/TODO scan
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Notes
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still reports the existing unrelated Knip backlog.