### PR TITLE
fix(tui): fail closed on worktree status errors

### DIFF
--- a/runtime/src/tui/components/WorktreeExitDialog.tsx
+++ b/runtime/src/tui/components/WorktreeExitDialog.tsx
@@ -26,6 +26,22 @@ type Props = {
   }) => void;
   onCancel?: () => void;
 };
+
+type GitInspectionResult = {
+  code: number;
+  error?: string;
+  stderr: string;
+  stdout: string;
+};
+
+function describeGitInspectionFailure(
+  command: string,
+  result: GitInspectionResult,
+): string {
+  const detail = result.stderr.trim() || result.error || `exit code ${result.code}`;
+  return `${command} failed: ${detail}`;
+}
+
 export function WorktreeExitLoadingState(): React.ReactNode {
   return <Box flexDirection="row" marginY={1}>
       <Spinner />
@@ -40,23 +56,54 @@ export function WorktreeExitDialog({
   const [changes, setChanges] = useState<string[]>([]);
   const [commitCount, setCommitCount] = useState<number>(0);
   const [resultMessage, setResultMessage] = useState<string | undefined>();
+  const [inspectionFailed, setInspectionFailed] = useState(false);
   const worktreeSession = getCurrentWorktreeSession();
   useEffect(() => {
+    let cancelled = false;
+    function failInspection(message: string) {
+      if (cancelled) return;
+      logForDebugging(`Failed to inspect worktree status: ${message}`, {
+        level: 'error'
+      });
+      setInspectionFailed(true);
+      setStatus('asking');
+    }
     async function loadChanges() {
+      if (!worktreeSession) return;
+      setInspectionFailed(false);
+      setChanges([]);
+      setCommitCount(0);
       let changeLines: string[] = [];
       const gitStatus = await execFileNoThrow('git', ['status', '--porcelain']);
+      if (gitStatus.code !== 0) {
+        failInspection(
+          describeGitInspectionFailure('git status --porcelain', gitStatus),
+        );
+        return;
+      }
       if (gitStatus.stdout) {
         changeLines = gitStatus.stdout.split('\n').filter(_ => _.trim() !== '');
-        setChanges(changeLines);
       }
+      if (cancelled) return;
+      setChanges(changeLines);
 
       // Check for commits to eject
-      if (worktreeSession) {
+      if (worktreeSession.originalHeadCommit) {
         // Get commits in worktree that are not in original branch
-        const {
-          stdout: commitsStr
-        } = await execFileNoThrow('git', ['rev-list', '--count', `${worktreeSession.originalHeadCommit}..HEAD`]);
+        const commitResult = await execFileNoThrow('git', [
+          'rev-list',
+          '--count',
+          `${worktreeSession.originalHeadCommit}..HEAD`
+        ]);
+        if (commitResult.code !== 0) {
+          failInspection(
+            describeGitInspectionFailure('git rev-list --count', commitResult),
+          );
+          return;
+        }
+        const commitsStr = commitResult.stdout;
         const count = parseInt(commitsStr.trim()) || 0;
+        if (cancelled) return;
         setCommitCount(count);
 
         // If no changes and no commits, clean up silently
@@ -80,9 +127,16 @@ export function WorktreeExitDialog({
         } else {
           setStatus('asking');
         }
+      } else {
+        failInspection('missing original head commit');
       }
     }
-    void loadChanges();
+    void loadChanges().catch(error => {
+      failInspection(error instanceof Error ? error.message : String(error));
+    });
+    return () => {
+      cancelled = true;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
     // biome-ignore lint/correctness/useExhaustiveDependencies: intentional
   }, [worktreeSession]);
@@ -193,6 +247,8 @@ export function WorktreeExitDialog({
   let subtitle = '';
   if (hasUncommitted && hasCommits) {
     subtitle = `You have ${changes.length} uncommitted ${changes.length === 1 ? 'file' : 'files'} and ${commitCount} ${commitCount === 1 ? 'commit' : 'commits'} on ${branchName}. All will be lost if you remove.`;
+  } else if (inspectionFailed) {
+    subtitle = 'Unable to inspect worktree status. Keep the worktree unless you have verified it is safe to remove.';
   } else if (hasUncommitted) {
     subtitle = `You have ${changes.length} uncommitted ${changes.length === 1 ? 'file' : 'files'}. These will be lost if you remove the worktree.`;
   } else if (hasCommits) {
@@ -209,7 +265,11 @@ export function WorktreeExitDialog({
     // Fallback: treat Escape as "keep" if no onCancel provided
     void handleSelect('keep');
   }
-  const removeDescription = hasUncommitted || hasCommits ? 'All changes and commits will be lost.' : 'Clean up the worktree directory.';
+  const removeDescription = inspectionFailed
+    ? 'Status could not be checked; removing may discard work.'
+    : hasUncommitted || hasCommits
+      ? 'All changes and commits will be lost.'
+      : 'Clean up the worktree directory.';
   const hasTmuxSession = Boolean(worktreeSession.tmuxSessionName);
   const options = hasTmuxSession ? [{
     label: 'Keep worktree and tmux session',

--- a/runtime/tests/tui/components/WorktreeExitDialog.runtime-coverage.test.tsx
+++ b/runtime/tests/tui/components/WorktreeExitDialog.runtime-coverage.test.tsx
@@ -19,9 +19,13 @@ const execMock = vi.hoisted(() => ({
   statusStdout: "",
   revListStdout: "0\n",
   execFileNoThrow: vi.fn(async (_cmd: string, args: string[]) => {
-    if (args[0] === "status") return { stdout: execMock.statusStdout };
-    if (args[0] === "rev-list") return { stdout: execMock.revListStdout };
-    return { stdout: "" };
+    if (args[0] === "status") {
+      return { code: 0, stderr: "", stdout: execMock.statusStdout };
+    }
+    if (args[0] === "rev-list") {
+      return { code: 0, stderr: "", stdout: execMock.revListStdout };
+    }
+    return { code: 0, stderr: "", stdout: "" };
   }),
 }));
 

--- a/runtime/tests/tui/components/WorktreeExitDialog.test.tsx
+++ b/runtime/tests/tui/components/WorktreeExitDialog.test.tsx
@@ -446,6 +446,117 @@ describe('WorktreeExitDialog', () => {
 
   it.each([
     {
+      failedCommand: 'status',
+      mockGit: () => {
+        harness.execFileNoThrow.mockImplementation(
+          async (file: string, args: string[]) => {
+            expect(file).toBe('git')
+            if (args[0] === 'status') {
+              return {
+                code: 128,
+                error: 'not a git repository',
+                stderr: 'fatal: not a git repository',
+                stdout: '',
+              }
+            }
+            if (args[0] === 'rev-list') {
+              return { code: 0, stderr: '', stdout: '0\n' }
+            }
+            throw new Error(
+              `Unexpected execFileNoThrow call: ${file} ${args.join(' ')}`,
+            )
+          },
+        )
+      },
+    },
+    {
+      failedCommand: 'rev-list',
+      mockGit: () => {
+        harness.execFileNoThrow.mockImplementation(
+          async (file: string, args: string[]) => {
+            expect(file).toBe('git')
+            if (args[0] === 'status') {
+              return { code: 0, stderr: '', stdout: '' }
+            }
+            if (args[0] === 'rev-list') {
+              return {
+                code: 128,
+                error: 'bad revision',
+                stderr: 'fatal: bad revision',
+                stdout: '',
+              }
+            }
+            throw new Error(
+              `Unexpected execFileNoThrow call: ${file} ${args.join(' ')}`,
+            )
+          },
+        )
+      },
+    },
+  ])(
+    'fails closed instead of auto-removing when $failedCommand inspection fails',
+    async ({ mockGit }) => {
+      harness.session = baseSession()
+      mockGit()
+
+      const mounted = await mountDialog()
+      await waitFor(
+        () =>
+          harness.selectProps !== undefined ||
+          harness.cleanupWorktree.mock.calls.length > 0,
+        'inspection failure did not settle',
+      )
+
+      expect(harness.cleanupWorktree).not.toHaveBeenCalled()
+      expect(harness.logForDebugging).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to inspect worktree status:'),
+        { level: 'error' },
+      )
+      expect(harness.selectProps).toBeDefined()
+      expect(dialogProps().subtitle).toBe(
+        'Unable to inspect worktree status. Keep the worktree unless you have verified it is safe to remove.',
+      )
+      expect(selectProps().defaultFocusValue).toBe('keep')
+
+      await mounted.dispose()
+    },
+  )
+
+  it('fails closed instead of auto-removing when the baseline commit is missing', async () => {
+    harness.session = baseSession({ originalHeadCommit: undefined })
+    harness.execFileNoThrow.mockImplementation(
+      async (file: string, args: string[]) => {
+        expect(file).toBe('git')
+        if (args[0] === 'status') {
+          return { code: 0, stderr: '', stdout: '' }
+        }
+        throw new Error(
+          `Unexpected execFileNoThrow call: ${file} ${args.join(' ')}`,
+        )
+      },
+    )
+
+    const mounted = await mountDialog()
+    await waitFor(
+      () => harness.selectProps !== undefined,
+      'missing baseline did not render choices',
+    )
+
+    expect(harness.cleanupWorktree).not.toHaveBeenCalled()
+    expect(harness.logForDebugging).toHaveBeenCalledWith(
+      'Failed to inspect worktree status: missing original head commit',
+      { level: 'error' },
+    )
+    expect(selectProps().defaultFocusValue).toBe('keep')
+    expect(dialogProps().subtitle).toBe(
+      'Unable to inspect worktree status. Keep the worktree unless you have verified it is safe to remove.',
+    )
+
+    await mounted.dispose()
+  })
+
+  it.each([
+    {
       commitCount: 0,
       expectedSubtitle:
         'You have 1 uncommitted file. These will be lost if you remove the worktree.',

--- a/runtime/tests/tui/coverage-swarm/swarm-187-components-WorktreeExitDialog.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-187-components-WorktreeExitDialog.test.tsx
@@ -52,6 +52,7 @@ const harness = vi.hoisted(() => ({
   setChanges: vi.fn(),
   setCommitCount: vi.fn(),
   setCwd: vi.fn(),
+  setInspectionFailed: vi.fn(),
   setResultMessage: vi.fn(),
   setStatus: vi.fn(),
   useEffect: vi.fn(),
@@ -128,6 +129,7 @@ function seedDialogState(): void {
     [[], harness.setChanges],
     [0, harness.setCommitCount],
     [undefined, harness.setResultMessage],
+    [false, harness.setInspectionFailed],
   ]
   let index = 0
 
@@ -164,6 +166,7 @@ describe('WorktreeExitDialog coverage swarm row 187', () => {
     harness.setChanges.mockClear()
     harness.setCommitCount.mockClear()
     harness.setCwd.mockClear()
+    harness.setInspectionFailed.mockClear()
     harness.setResultMessage.mockClear()
     harness.setStatus.mockClear()
     harness.session = {


### PR DESCRIPTION
## Summary
- Treat failed worktree status and commit-count inspection as unsafe instead of clean.
- Render the explicit keep/remove prompt with a warning when inspection fails or the baseline commit is missing.
- Add regressions for status failure, rev-list failure, and missing baseline commit.

## Test plan
- Failing-first focused regressions reproduced cleanupWorktree() being called after failed inspection.
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/WorktreeExitDialog.test.tsx --reporter=dot
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/WorktreeExitDialog.test.tsx tests/tui/components/WorktreeExitDialog.runtime-coverage.test.tsx tests/tui/components/WorktreeExitDialog.loading.test.tsx tests/tui/coverage-swarm/swarm-187-components-WorktreeExitDialog.test.tsx tests/tui/components/ExitFlow.test.tsx tests/tui/components/ExitFlow.wave200-139.coverage.test.tsx --reporter=dot
- npm run typecheck
- git diff --check
- touched-file branding/TODO scan
- npm --workspace=@tetsuo-ai/runtime run check:unused:production
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Notes
- check:unused:production still reports the existing unrelated Knip backlog.