### PR TITLE
fix(tui): guard startup memory diagnostics

### DIFF
--- a/runtime/src/tui/startup/StatusNotices.tsx
+++ b/runtime/src/tui/startup/StatusNotices.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import type { AgentDefinitionsResult } from '../../tools/AgentTool/loadAgentsDir.js';
 import { getGlobalConfig } from '../../utils/config.js';
+import { logError } from '../../utils/log.js';
 import { buildMemoryDiagnostics } from '../../utils/status.js';
 import { Box } from '../ink.js';
 import ThemedBox from '../components/design-system/ThemedBox.js';
@@ -21,6 +22,9 @@ async function loadMemoryDiagnostics(): Promise<void> {
   }
   memoryDiagnosticsPromise = buildMemoryDiagnostics().then(diagnostics => {
     cachedMemoryDiagnostics = diagnostics.map(diagnostic => String(diagnostic));
+  }).catch(error => {
+    logError(error);
+    cachedMemoryDiagnostics = [];
   }).finally(() => {
     memoryDiagnosticsPromise = null;
   });

--- a/runtime/tests/tui/coverage-swarm/swarm-197-startup-StatusNotices.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-197-startup-StatusNotices.test.tsx
@@ -43,6 +43,7 @@ const harness = vi.hoisted(() => ({
     autoInstallIdeExtension: true,
     source: 'swarm-197',
   },
+  logError: vi.fn(),
 }))
 
 vi.mock('../../../src/utils/config.js', () => ({
@@ -51,6 +52,10 @@ vi.mock('../../../src/utils/config.js', () => ({
 
 vi.mock('../../../src/utils/status.js', () => ({
   buildMemoryDiagnostics: harness.buildMemoryDiagnostics,
+}))
+
+vi.mock('../../../src/utils/log.js', () => ({
+  logError: harness.logError,
 }))
 
 vi.mock('../../../src/tui/startup/statusNoticeDefinitions.js', () => ({
@@ -86,6 +91,7 @@ describe('StatusNotices coverage swarm row 197', () => {
     harness.buildMemoryDiagnostics.mockReset()
     harness.buildMemoryDiagnostics.mockResolvedValue([])
     harness.contexts = []
+    harness.logError.mockClear()
     harness.getActiveNotices.mockClear()
     harness.getActiveNotices.mockImplementation((context: CapturedContext) => {
       harness.contexts.push(context)
@@ -176,5 +182,31 @@ describe('StatusNotices coverage swarm row 197', () => {
 
     expect(harness.buildMemoryDiagnostics).toHaveBeenCalledTimes(1)
     expect(cachedOutput).toContain('memory:404|Large memory file')
+  })
+
+  test('logs rejected memory diagnostics and retries on a later render', async () => {
+    const error = new Error('memory diagnostics unavailable')
+    harness.buildMemoryDiagnostics.mockRejectedValueOnce(error)
+
+    const firstOutput = await renderStatusNotices()
+
+    expect(firstOutput).toContain('memory:')
+    await vi.waitFor(() => {
+      expect(harness.buildMemoryDiagnostics).toHaveBeenCalledTimes(1)
+    })
+    await vi.waitFor(() => {
+      expect(harness.logError).toHaveBeenCalledWith(error)
+    })
+
+    harness.buildMemoryDiagnostics.mockResolvedValueOnce(['Recovered memory'])
+    await renderStatusNotices()
+
+    await vi.waitFor(() => {
+      expect(harness.buildMemoryDiagnostics).toHaveBeenCalledTimes(2)
+    })
+
+    const thirdOutput = await renderStatusNotices()
+
+    expect(thirdOutput).toContain('memory:Recovered memory')
   })
 })


### PR DESCRIPTION
## Summary
- Catch and log rejected startup memory diagnostics loads.
- Keep startup status notices rendering without unhandled rejections when diagnostics are unavailable.
- Preserve retry behavior so a later render can load diagnostics successfully.

## Test plan
- Failing-first focused regression reproduced the unhandled rejected diagnostics promise and missing log call.
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/coverage-swarm/swarm-197-startup-StatusNotices.test.tsx --reporter=dot
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/startup/StatusNotices.wave200-073.coverage.test.tsx tests/tui/coverage-swarm/swarm-197-startup-StatusNotices.test.tsx tests/tui/components/Messages.welcome.test.tsx tests/tui/coverage-swarm/swarm-005-components-Messages.test.tsx --reporter=dot
- npm run typecheck
- git diff --check
- touched-file branding/TODO scan
- npm --workspace=@tetsuo-ai/runtime run check:unused:production
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Notes
- check:unused:production still reports the existing unrelated Knip backlog.