### PR TITLE
fix(tui): guard task store fetch failures

### DIFF
--- a/runtime/src/tui/hooks/useTasksV2.ts
+++ b/runtime/src/tui/hooks/useTasksV2.ts
@@ -2,6 +2,7 @@ import { type FSWatcher, watch } from 'fs'
 import { useEffect, useSyncExternalStore } from 'react'
 import { type AppState, useAppState, useSetAppState } from '../state/AppState.js'
 import { createSignal } from '../../utils/signal.js'
+import { logError } from '../../utils/log.js'
 import type { Task } from '../../utils/tasks.js'
 import {
   getTaskListId,
@@ -66,7 +67,7 @@ class TasksV2Store {
       this.#unsubscribeTasksUpdated = onTasksUpdated(this.#debouncedFetch)
       // Fire-and-forget: subscribe is called post-commit (not in render),
       // and the store notifies subscribers when the fetch resolves.
-      void this.#fetch()
+      this.#fetchAndLog()
     }
     let unsubscribed = false
     return () => {
@@ -106,8 +107,14 @@ class TasksV2Store {
 
   #debouncedFetch = (): void => {
     if (this.#debounceTimer) clearTimeout(this.#debounceTimer)
-    this.#debounceTimer = setTimeout(() => void this.#fetch(), DEBOUNCE_MS)
+    this.#debounceTimer = setTimeout(this.#fetchAndLog, DEBOUNCE_MS)
     this.#debounceTimer.unref()
+  }
+
+  #fetchAndLog = (): void => {
+    void this.#fetch().catch(error => {
+      logError(error instanceof Error ? error : new Error(String(error)))
+    })
   }
 
   #fetch = async (): Promise<void> => {
@@ -167,6 +174,9 @@ class TasksV2Store {
         this.#tasks = []
         this.#hidden = true
       }
+      this.#notify()
+    }).catch(error => {
+      logError(error instanceof Error ? error : new Error(String(error)))
       this.#notify()
     })
   }

--- a/runtime/tests/tui/coverage-swarm/swarm-222-hooks-useTasksV2.test.ts
+++ b/runtime/tests/tui/coverage-swarm/swarm-222-hooks-useTasksV2.test.ts
@@ -131,6 +131,10 @@ const fixture = vi.hoisted(() => {
   }
 })
 
+const logMock = vi.hoisted(() => ({
+  logError: vi.fn(),
+}))
+
 vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react')
   return {
@@ -161,6 +165,10 @@ vi.mock('src/utils/tasks.js', () => ({
 
 vi.mock('src/utils/teammate.js', () => ({
   isTeamLead: () => fixture.state.isLead,
+}))
+
+vi.mock('src/utils/log.js', () => ({
+  logError: logMock.logError,
 }))
 
 let timers: ManualTimer[] = []
@@ -256,6 +264,7 @@ describe('useTasksV2 coverage swarm row 222', () => {
   beforeEach(() => {
     vi.resetModules()
     fixture.reset()
+    logMock.logError.mockClear()
     timers = []
     installTimerMocks()
   })

--- a/runtime/tests/tui/hooks/useTasksV2.test.tsx
+++ b/runtime/tests/tui/hooks/useTasksV2.test.tsx
@@ -38,12 +38,16 @@ const fixture = vi.hoisted(() => {
     subscriptions: [] as SubscriptionRecord[],
     taskListId: 'list-a',
     taskListeners: new Set<() => void>(),
+    taskReadError: null as Error | null,
     tasksByList: new Map<string, Task[]>(),
     watchThrows: false,
     watchers: [] as WatcherRecord[],
   }
 
   const listTasks = vi.fn(async (taskListId: string) => {
+    if (state.taskReadError) {
+      throw state.taskReadError
+    }
     return state.tasksByList.get(taskListId) ?? []
   })
 
@@ -109,6 +113,7 @@ const fixture = vi.hoisted(() => {
     state.subscriptions = []
     state.taskListId = 'list-a'
     state.taskListeners.clear()
+    state.taskReadError = null
     state.tasksByList = new Map([['list-a', []]])
     state.watchThrows = false
     state.watchers = []
@@ -132,6 +137,10 @@ const fixture = vi.hoisted(() => {
     watch,
   }
 })
+
+const logMock = vi.hoisted(() => ({
+  logError: vi.fn(),
+}))
 
 vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react')
@@ -163,6 +172,10 @@ vi.mock('../../utils/tasks.js', () => ({
 
 vi.mock('../../utils/teammate.js', () => ({
   isTeamLead: () => fixture.state.isLead,
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: logMock.logError,
 }))
 
 let timers: ManualTimer[] = []
@@ -265,6 +278,7 @@ describe('useTasksV2', () => {
   beforeEach(() => {
     vi.resetModules()
     fixture.reset()
+    logMock.logError.mockClear()
     timers = []
     installTimerMocks()
   })
@@ -316,6 +330,24 @@ describe('useTasksV2', () => {
     expect(fixture.listTasks).toHaveBeenCalledWith('list-a')
     expect(latestTasks(mounted.record)).toBeUndefined()
     expect(activeTimers()).toHaveLength(0)
+  })
+
+  test('logs initial task read failures and retries on later task updates', async () => {
+    const error = new Error('tasks unavailable')
+    fixture.state.taskReadError = error
+
+    const mounted = await mountUseTasksV2()
+    await flushPromises()
+
+    expect(fixture.listTasks).toHaveBeenCalledWith('list-a')
+    expect(logMock.logError).toHaveBeenCalledWith(error)
+    expect(latestTasks(mounted.record)).toBeUndefined()
+
+    fixture.state.taskReadError = null
+    fixture.state.tasksByList.set('list-a', [task('1', 'pending')])
+    await emitTasksUpdated()
+
+    expect(latestTasks(mounted.record)?.map(t => t.id)).toEqual(['1'])
   })
 
   test('filters internal tasks and preserves source ordering across add, update, and remove events', async () => {
@@ -411,6 +443,22 @@ describe('useTasksV2', () => {
     await emitTasksUpdated()
 
     expect(latestTasks(mounted.record)?.map(t => t.id)).toEqual(['2'])
+  })
+
+  test('logs completed-task hide check failures and keeps completed tasks visible', async () => {
+    fixture.state.tasksByList.set('list-a', [task('1', 'completed')])
+    const mounted = await mountUseTasksV2()
+    await flushPromises()
+
+    expect(latestTasks(mounted.record)?.map(t => t.id)).toEqual(['1'])
+
+    const error = new Error('hide check unavailable')
+    fixture.state.taskReadError = error
+    await fireNextTimer(5000)
+
+    expect(logMock.logError).toHaveBeenCalledWith(error)
+    expect(fixture.resetTaskList).not.toHaveBeenCalled()
+    expect(latestTasks(mounted.record)?.map(t => t.id)).toEqual(['1'])
   })
 
   test('cancels completed-task hiding when incomplete work appears before the delay', async () => {


### PR DESCRIPTION
## Summary
- Catch and log rejected task-store fetches from subscribe and debounced update paths.
- Catch and log completed-task hide verification/reset failures while preserving visible tasks.
- Add regressions for initial task-read failures and hide-check failures.

## Test plan
- Failing-first focused test reproduced unhandled rejected task reads before the source fix.
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/useTasksV2.test.tsx --reporter=dot`
- Adjacent task, prompt footer, and spinner suites passed with 8 files and 48 tests.
- `npm run typecheck`
- `git diff --check`
- Touched-file branding and TODO scan: no matches.
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui` passed with 755 files and 3180 tests.
- TUI validation gate passed rebuild plus runtime startup smoke.
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails only on existing unrelated Knip backlog.
