### PR TITLE
fix(tui): guard teams output focus failures

### DIFF
--- a/runtime/src/tui/components/teams/TeamsDialog.tsx
+++ b/runtime/src/tui/components/teams/TeamsDialog.tsx
@@ -621,15 +621,20 @@ async function killTeammate(paneId: string, backendType: PaneBackendType | undef
 }
 async function viewTeammateOutput(paneId: string, backendType: PaneBackendType | undefined): Promise<TeamActionResult> {
   let result;
-  if (backendType === 'iterm2') {
-    // -s is required to target a specific session (ITermBackend.ts:216-217)
-    result = await execFileNoThrow(IT2_COMMAND, ['session', 'focus', '-s', paneId]);
-  } else {
-    // External-tmux teammates live on the swarm socket — without -L, this
-    // targets the default server and silently no-ops. Mirrors runTmuxInSwarm
-    // in TmuxBackend.ts:85-89.
-    const args = isInsideTmuxSync() ? ['select-pane', '-t', paneId] : ['-L', getSwarmSocketName(), 'select-pane', '-t', paneId];
-    result = await execFileNoThrow(TMUX_COMMAND, args);
+  try {
+    if (backendType === 'iterm2') {
+      // -s is required to target a specific session (ITermBackend.ts:216-217)
+      result = await execFileNoThrow(IT2_COMMAND, ['session', 'focus', '-s', paneId]);
+    } else {
+      // External-tmux teammates live on the swarm socket — without -L, this
+      // targets the default server and silently no-ops. Mirrors runTmuxInSwarm
+      // in TmuxBackend.ts:85-89.
+      const args = isInsideTmuxSync() ? ['select-pane', '-t', paneId] : ['-L', getSwarmSocketName(), 'select-pane', '-t', paneId];
+      result = await execFileNoThrow(TMUX_COMMAND, args);
+    }
+  } catch (error) {
+    logError(error);
+    return fail(`Cannot view teammate output: ${errorMessage(error)}`);
   }
   if (result.code !== 0) {
     return fail(`Cannot view teammate output: ${result.error || result.stderr || `exit code ${result.code}`}`);

--- a/runtime/tests/tui/components/teams/TeamsDialog.test.tsx
+++ b/runtime/tests/tui/components/teams/TeamsDialog.test.tsx
@@ -67,6 +67,10 @@ const mailboxMock = vi.hoisted(() => ({
   writeToMailbox: vi.fn(async () => {}),
 }));
 
+const logMock = vi.hoisted(() => ({
+  logError: vi.fn(),
+}));
+
 const teamHelpersMock = vi.hoisted(() => ({
   addHiddenPaneId: vi.fn(() => true),
   removeHiddenPaneId: vi.fn(() => true),
@@ -148,6 +152,9 @@ vi.mock("../../../utils/teammateMailbox.js", () => ({
   createModeSetRequestMessage: (message: unknown) => message,
   sendShutdownRequestToMailbox: mailboxMock.sendShutdownRequestToMailbox,
   writeToMailbox: mailboxMock.writeToMailbox,
+}));
+vi.mock("../../../utils/log.js", () => ({
+  logError: logMock.logError,
 }));
 vi.mock("../../../utils/swarm/teamHelpers.js", () => ({
   addHiddenPaneId: teamHelpersMock.addHiddenPaneId,
@@ -321,6 +328,7 @@ beforeEach(() => {
   });
   mailboxMock.sendShutdownRequestToMailbox.mockClear();
   mailboxMock.writeToMailbox.mockClear();
+  logMock.logError.mockClear();
   teamHelpersMock.addHiddenPaneId.mockClear();
   teamHelpersMock.removeHiddenPaneId.mockClear();
   teamHelpersMock.removeMemberFromTeam.mockClear();
@@ -544,6 +552,29 @@ describe("TeamsDialog rendering", () => {
 
       expect(harness.getText()).toContain(
         "Cannot view teammate output: pane disappeared",
+      );
+      expect(harness.getText()).toContain("@Fixer");
+      expect(onDone).not.toHaveBeenCalled();
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  test("logs rejected view-output commands and keeps dialog open", async () => {
+    const onDone = vi.fn();
+    const error = new Error("pane command crashed");
+    execFileNoThrowMock.mockRejectedValue(error);
+    const harness = await createTeamsDialogHarness(
+      <TeamsDialog initialTeams={[{ name: "alpha" } as never]} onDone={onDone} />,
+    );
+
+    try {
+      await harness.press("\r", { return: true }, 80);
+      await harness.press("\r", { return: true }, 80);
+
+      expect(logMock.logError).toHaveBeenCalledWith(error);
+      expect(harness.getText()).toContain(
+        "Cannot view teammate output: pane command crashed",
       );
       expect(harness.getText()).toContain("@Fixer");
       expect(onDone).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Catch and log rejected TeamsDialog pane-focus commands when viewing teammate output.
- Keep the TeamsDialog detail view open and render the same inline action failure style used by other team actions.
- Add a regression for rejected view-output commands.

## Test plan
- Failing-first focused test reproduced the unhandled rejected pane-focus command before the source fix.
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/teams/TeamsDialog.test.tsx --reporter=dot`
- Adjacent TeamsDialog suites passed with 5 files and 44 tests.
- `npm run typecheck`
- `git diff --check`
- Touched-file branding and TODO scan: no matches.
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui` passed with 755 files and 3181 tests.
- TUI validation gate passed rebuild plus runtime startup smoke.
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails only on existing unrelated Knip backlog.
