### PR TITLE
fix(tui): guard pasted image path reads

### DIFF
--- a/runtime/src/tui/hooks/usePasteHandler.ts
+++ b/runtime/src/tui/hooks/usePasteHandler.ts
@@ -178,11 +178,28 @@ export function usePasteHandler({
 
               // Process all image paths
               void Promise.all(
-                imagePaths.map(imagePath => tryReadImageFromPath(imagePath)),
-              ).then(results => {
-                const validImages = results.filter(
-                  (r): r is NonNullable<typeof r> => r !== null,
-                )
+                imagePaths.map(async imagePath => {
+                  try {
+                    return {
+                      image: await tryReadImageFromPath(imagePath),
+                      path: imagePath,
+                    }
+                  } catch (error) {
+                    logError(error as Error)
+                    return { image: null, path: imagePath }
+                  }
+                }),
+              ).then(imageReadResults => {
+                if (!isMountedRef.current) return
+
+                const validImages = imageReadResults
+                  .map(result => result.image)
+                  .filter(
+                    (r): r is NonNullable<typeof r> => r !== null,
+                  )
+                const failedImagePaths = imageReadResults
+                  .filter(result => result.image === null)
+                  .map(result => result.path)
 
                 if (validImages.length > 0) {
                   // Successfully read at least one image
@@ -196,12 +213,13 @@ export function usePasteHandler({
                       imageData.path,
                     )
                   }
-                  // If some paths weren't images, paste them as text
-                  const nonImageLines = lines.filter(
-                    line => !isImageFilePath(line),
-                  )
-                  if (nonImageLines.length > 0 && onPaste) {
-                    onPaste(nonImageLines.join('\n'))
+                  // If some paths were not images or could not be read, paste them as text.
+                  const fallbackLines = [
+                    ...lines.filter(line => !isImageFilePath(line)),
+                    ...failedImagePaths,
+                  ]
+                  if (fallbackLines.length > 0 && onPaste) {
+                    onPaste(fallbackLines.join('\n'))
                   }
                   setIsPasting(false)
                 } else if (isTempScreenshot && isMacOS) {
@@ -248,8 +266,8 @@ export function usePasteHandler({
       )
     },
     [
-      checkClipboardForImage,
       canFallbackToClipboardImage,
+      checkClipboardForImage,
       isMacOS,
       onImagePaste,
       onPaste,

--- a/runtime/tests/tui/hooks/usePasteHandler.test.ts
+++ b/runtime/tests/tui/hooks/usePasteHandler.test.ts
@@ -364,6 +364,36 @@ describe('usePasteHandler', () => {
     }
   })
 
+  test('logs rejected image path reads and falls back to text paste', async () => {
+    const imagePath = '/tmp/agenc-corrupt.png'
+    const error = new Error('image decoder failed')
+    imagePasteMocks.tryReadImageFromPath.mockRejectedValue(error)
+    const onImagePaste = vi.fn()
+    const onInput = vi.fn()
+    const onPaste = vi.fn()
+    const rendered = await renderPasteHandler({
+      onImagePaste,
+      onInput,
+      onPaste,
+    })
+
+    try {
+      rendered.latest().wrappedOnInput(imagePath, key(), inputEvent(false))
+
+      await waitForPasteFlush()
+
+      expect(imagePasteMocks.tryReadImageFromPath).toHaveBeenCalledWith(imagePath)
+      expect(logMocks.logError).toHaveBeenCalledWith(error)
+      expect(onImagePaste).not.toHaveBeenCalled()
+      expect(onPaste).toHaveBeenCalledTimes(1)
+      expect(onPaste).toHaveBeenCalledWith(imagePath)
+      expect(onInput).not.toHaveBeenCalled()
+      expect(rendered.latest().isPasting).toBe(false)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('ignores empty bracketed paste when clipboard image lookup misses', async () => {
     platformMock.current = 'macos'
     imagePasteMocks.getImageFromClipboard.mockResolvedValue(null)


### PR DESCRIPTION
## Summary
- Catch and log rejected pasted-image file reads in the TUI paste handler.
- Treat rejected image reads as unreadable image paths so paste fallback still runs and paste state is cleared.
- Preserve successfully read images while routing unreadable image paths back through text paste when needed.

## Test plan
- Failing-first focused test reproduced the unhandled rejected image-path read before the source fix.
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/usePasteHandler.test.ts --reporter=dot`
- Adjacent paste and clipboard hint suites passed with 4 files and 28 tests; existing act-environment warnings remain in clipboard hint tests.
- `npm run typecheck`
- `git diff --check`
- Touched-file branding and TODO scan: no matches.
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui` passed with 755 files and 3182 tests.
- TUI validation gate passed rebuild plus runtime startup smoke.
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails only on existing unrelated Knip backlog.
