### PR TITLE
fix(tui): preserve task tails on read failures

### DIFF
--- a/runtime/src/tui/components/tasks/BackgroundTasksPanel.tsx
+++ b/runtime/src/tui/components/tasks/BackgroundTasksPanel.tsx
@@ -499,16 +499,7 @@ export function BackgroundTasksPanel({
           },
         }));
       } catch {
-        if (cancelled) {
-          return;
-        }
-        setShellOutputTails((current) => ({
-          ...current,
-          [selectedTask.id]: {
-            content: "",
-            bytesTotal: 0,
-          },
-        }));
+        // Keep the last successful tail visible across transient read failures.
       }
     };
     void readTail();

--- a/runtime/src/tui/workbench/surfaces/AgentSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/AgentSurface.tsx
@@ -42,7 +42,7 @@ export function AgentSurface({ focused }: { readonly focused: boolean }): React.
           if (mounted) setTailState({ taskId, content: result.content });
         })
         .catch(() => {
-          if (mounted) setTailState({ taskId, content: "" });
+          // Keep the last successful tail visible across transient read failures.
         });
     };
     readTail();

--- a/runtime/src/tui/workbench/surfaces/ShellSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/ShellSurface.tsx
@@ -45,7 +45,7 @@ export function ShellSurface({ focused }: { readonly focused: boolean }): React.
           if (mounted) setTailState({ taskId, content: result.content });
         })
         .catch(() => {
-          if (mounted) setTailState({ taskId, content: "" });
+          // Keep the last successful tail visible across transient read failures.
         });
     };
     readTail();

--- a/runtime/src/tui/workbench/surfaces/TestSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/TestSurface.tsx
@@ -48,7 +48,7 @@ export function TestSurface({ focused }: { readonly focused: boolean }): React.R
           if (mounted) setTailState({ taskId, content: result.content });
         })
         .catch(() => {
-          if (mounted) setTailState({ taskId, content: "" });
+          // Keep the last successful tail visible across transient read failures.
         });
     };
     readTail();

--- a/runtime/tests/tui/coverage-swarm/swarm-013-components-tasks-BackgroundTasksPanel.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-013-components-tasks-BackgroundTasksPanel.test.tsx
@@ -1,6 +1,11 @@
+import { PassThrough } from 'node:stream'
+
 import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { createRoot } from '../ink.js'
+import { getInkInstance } from '../ink/instances.js'
+import { cellAt } from '../ink/screen.js'
 import { renderToString } from '../../utils/staticRender.js'
 
 const appStateMock = vi.hoisted(() => ({
@@ -25,6 +30,13 @@ const tailFileMock = vi.hoisted(() => vi.fn())
 const getTaskOutputPathMock = vi.hoisted(() =>
   vi.fn((taskId: string) => `/tmp/${taskId}.log`),
 )
+
+type TestStdin = PassThrough & {
+  isTTY: boolean
+  ref: () => void
+  setRawMode: (mode: boolean) => void
+  unref: () => void
+}
 
 vi.mock('../state/AppState.js', () => ({
   useAppState: (selector: (state: typeof appStateMock.state) => unknown) =>
@@ -314,6 +326,50 @@ describe('BackgroundTasksPanel swarm row 013', () => {
     expect(tailFileMock).toHaveBeenCalledWith('/tmp/shell-with-result.log', 8192)
   })
 
+  it('keeps the last shell detail tail visible when a later poll fails', async () => {
+    tailFileMock
+      .mockResolvedValueOnce({
+        content: 'tail line from shell',
+        bytesTotal: 1536,
+      })
+      .mockRejectedValueOnce(new Error('tail failed'))
+    appStateMock.state = {
+      tasks: {
+        shell: makeShellTask({
+          id: 'shell-with-result',
+          command: 'node scripts/check.js',
+          kind: 'monitor',
+        }),
+      },
+    }
+    const { stdin, stdout } = createStreams()
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    })
+
+    try {
+      const { BackgroundTasksPanel } = await import(
+        '../components/tasks/BackgroundTasksPanel.js'
+      )
+
+      root.render(<BackgroundTasksPanel initialDetailTaskId="shell-with-result" />)
+      await sleep()
+
+      expect(compact(screenText(stdout))).toContain('taillinefromshell')
+
+      await sleep(1_200)
+
+      expect(compact(screenText(stdout))).toContain('taillinefromshell')
+      expect(compact(screenText(stdout))).not.toContain('(nooutput)')
+    } finally {
+      root.unmount()
+      stdin.end()
+      stdout.end()
+    }
+  })
+
   it('renders remote review progress and ignores stop input for finished tasks', async () => {
     appStateMock.state = {
       tasks: {
@@ -403,3 +459,50 @@ describe('BackgroundTasksPanel swarm row 013', () => {
     expect(output).toContain('write notes.txt')
   })
 })
+
+function createStreams(): {
+  readonly stdin: TestStdin
+  readonly stdout: PassThrough
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as TestStdin
+
+  stdin.isTTY = true
+  stdin.ref = () => {}
+  stdin.setRawMode = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number; rows: number; isTTY: boolean }).columns = 132
+  ;(stdout as unknown as { columns: number; rows: number; isTTY: boolean }).rows = 36
+  ;(stdout as unknown as { columns: number; rows: number; isTTY: boolean }).isTTY = true
+  stdout.resume()
+
+  return {
+    stdin,
+    stdout,
+  }
+}
+
+function sleep(ms = 200): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function compact(value: string): string {
+  return value.replace(/\s+/gu, '')
+}
+
+function screenText(stdout: PassThrough): string {
+  const instance = getInkInstance(stdout as unknown as NodeJS.WriteStream) as
+    | { readonly frontFrame?: { readonly screen?: { readonly width: number; readonly height: number } } }
+    | undefined
+  const screen = instance?.frontFrame?.screen
+  if (!screen) return ''
+  const rows: string[] = []
+  for (let row = 0; row < screen.height; row += 1) {
+    const chars: string[] = []
+    for (let column = 0; column < screen.width; column += 1) {
+      chars.push(cellAt(screen, column, row)?.char ?? ' ')
+    }
+    rows.push(chars.join('').trimEnd())
+  }
+  return rows.join('\n')
+}

--- a/runtime/tests/tui/workbench/agent-surface.test.tsx
+++ b/runtime/tests/tui/workbench/agent-surface.test.tsx
@@ -7,6 +7,8 @@ const keybindingHarness = vi.hoisted(() => ({
   deferredTaskIds: new Set<string>(),
   handlers: {} as Record<string, () => void>,
   pendingReads: new Map<string, (result: { content: string }) => void>(),
+  readCounts: {} as Record<string, number>,
+  rejectOnRead: {} as Record<string, number>,
   tails: {} as Record<string, string>,
 }));
 
@@ -14,6 +16,11 @@ vi.mock("../../../src/utils/fsOperations.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../src/utils/fsOperations.js")>()),
   tailFile: vi.fn(async (path: string) => {
     const taskId = /\/tmp\/(.+)\.log$/u.exec(path)?.[1] ?? path;
+    const readCount = (keybindingHarness.readCounts[taskId] ?? 0) + 1;
+    keybindingHarness.readCounts[taskId] = readCount;
+    if (keybindingHarness.rejectOnRead[taskId] === readCount) {
+      throw new Error(`tail failed for ${taskId}`);
+    }
     if (keybindingHarness.deferredTaskIds.has(taskId)) {
       return new Promise<{ content: string }>((resolve) => {
         keybindingHarness.pendingReads.set(taskId, resolve);
@@ -53,6 +60,8 @@ describe("AgentSurface", () => {
     keybindingHarness.deferredTaskIds = new Set();
     keybindingHarness.handlers = {};
     keybindingHarness.pendingReads = new Map();
+    keybindingHarness.readCounts = {};
+    keybindingHarness.rejectOnRead = {};
     keybindingHarness.tails = {};
   });
 
@@ -204,6 +213,49 @@ describe("AgentSurface", () => {
     expect(canEnterAgentTranscript({ id: "remote", type: "remote_agent" })).toBe(false);
     expect(canEnterAgentTranscript({ type: "local_agent" })).toBe(false);
     expect(canEnterAgentTranscript(null)).toBe(false);
+  });
+
+  it("keeps the last agent tail visible when a later poll fails", async () => {
+    keybindingHarness.tails["agent-1"] = "current agent output";
+    keybindingHarness.rejectOnRead["agent-1"] = 2;
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            tasks: {
+              "agent-1": agentTask("agent-1", "current agent", "running", 1_000),
+            },
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "agent",
+              selectedAgentTaskId: "agent-1",
+            },
+          }}
+        >
+          <AgentSurface focused={true} />
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      expect(compact(screenText(stdout))).toContain("currentagentoutput");
+
+      await sleep(1_200);
+
+      expect(compact(screenText(stdout))).toContain("currentagentoutput");
+      expect(compact(screenText(stdout))).not.toContain("(nooutput)");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
   });
 });
 

--- a/runtime/tests/tui/workbench/shell-surface.test.tsx
+++ b/runtime/tests/tui/workbench/shell-surface.test.tsx
@@ -8,6 +8,8 @@ const shellHarness = vi.hoisted(() => ({
   deferredTaskIds: new Set<string>(),
   handlers: {} as Record<string, () => void>,
   pendingReads: new Map<string, (result: { content: string }) => void>(),
+  readCounts: {} as Record<string, number>,
+  rejectOnRead: {} as Record<string, number>,
   tails: {} as Record<string, string>,
 }));
 
@@ -15,6 +17,11 @@ vi.mock("../../../src/utils/fsOperations.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../src/utils/fsOperations.js")>()),
   tailFile: vi.fn(async (path: string) => {
     const taskId = /\/tmp\/(.+)\.log$/u.exec(path)?.[1] ?? path;
+    const readCount = (shellHarness.readCounts[taskId] ?? 0) + 1;
+    shellHarness.readCounts[taskId] = readCount;
+    if (shellHarness.rejectOnRead[taskId] === readCount) {
+      throw new Error(`tail failed for ${taskId}`);
+    }
     if (shellHarness.deferredTaskIds.has(taskId)) {
       return new Promise<{ content: string }>((resolve) => {
         shellHarness.pendingReads.set(taskId, resolve);
@@ -36,6 +43,8 @@ vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
 }));
 
 import { createRoot } from "../../../src/tui/ink.js";
+import { getInkInstance } from "../../../src/tui/ink/instances.js";
+import { cellAt } from "../../../src/tui/ink/screen.js";
 import { AppStateProvider, getDefaultAppState, type AppState, useSetAppState } from "../../../src/tui/state/AppState.js";
 import { ShellSurface } from "../../../src/tui/workbench/surfaces/ShellSurface.js";
 import { renderToString } from "../../../src/utils/staticRender.js";
@@ -52,6 +61,8 @@ describe("ShellSurface", () => {
     shellHarness.deferredTaskIds = new Set();
     shellHarness.handlers = {};
     shellHarness.pendingReads = new Map();
+    shellHarness.readCounts = {};
+    shellHarness.rejectOnRead = {};
     shellHarness.tails = {};
   });
 
@@ -233,6 +244,52 @@ describe("ShellSurface", () => {
       stdout.end();
     }
   });
+
+  it("keeps the last shell tail visible when a later poll fails", async () => {
+    shellHarness.tails["shell-1"] = [
+      "current task failed",
+      "src/current-task.ts:7:1",
+    ].join("\n");
+    shellHarness.rejectOnRead["shell-1"] = 2;
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            tasks: {
+              "shell-1": shellTask("shell-1", "current shell", "running"),
+            },
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "shell",
+              selectedShellTaskId: "shell-1",
+            },
+          }}
+        >
+          <ShellSurface focused={true} />
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      expect(compact(screenText(stdout))).toContain("src/current-task.ts:7");
+
+      await sleep(1_200);
+
+      expect(compact(screenText(stdout))).toContain("src/current-task.ts:7");
+      expect(compact(screenText(stdout))).not.toContain("(nooutput)");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
 });
 
 function ShellTaskSelector({
@@ -306,4 +363,21 @@ function sleep(ms = 200): Promise<void> {
 
 function compact(value: string): string {
   return value.replace(/\s+/gu, "");
+}
+
+function screenText(stdout: PassThrough): string {
+  const instance = getInkInstance(stdout as unknown as NodeJS.WriteStream) as
+    | { readonly frontFrame?: { readonly screen?: { readonly width: number; readonly height: number } } }
+    | undefined;
+  const screen = instance?.frontFrame?.screen;
+  if (!screen) return "";
+  const rows: string[] = [];
+  for (let row = 0; row < screen.height; row += 1) {
+    const chars: string[] = [];
+    for (let column = 0; column < screen.width; column += 1) {
+      chars.push(cellAt(screen, column, row)?.char ?? " ");
+    }
+    rows.push(chars.join("").trimEnd());
+  }
+  return rows.join("\n");
 }

--- a/runtime/tests/tui/workbench/test-surface.test.tsx
+++ b/runtime/tests/tui/workbench/test-surface.test.tsx
@@ -7,6 +7,8 @@ const keybindingHarness = vi.hoisted(() => ({
   deferredTaskIds: new Set<string>(),
   handlers: {} as Record<string, () => void>,
   pendingReads: new Map<string, (result: { content: string }) => void>(),
+  readCounts: {} as Record<string, number>,
+  rejectOnRead: {} as Record<string, number>,
   tails: {} as Record<string, string>,
 }));
 
@@ -14,6 +16,11 @@ vi.mock("../../../src/utils/fsOperations.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../src/utils/fsOperations.js")>()),
   tailFile: vi.fn(async (path: string) => {
     const taskId = /\/tmp\/(.+)\.log$/u.exec(path)?.[1] ?? path;
+    const readCount = (keybindingHarness.readCounts[taskId] ?? 0) + 1;
+    keybindingHarness.readCounts[taskId] = readCount;
+    if (keybindingHarness.rejectOnRead[taskId] === readCount) {
+      throw new Error(`tail failed for ${taskId}`);
+    }
     if (keybindingHarness.deferredTaskIds.has(taskId)) {
       return new Promise<{ content: string }>((resolve) => {
         keybindingHarness.pendingReads.set(taskId, resolve);
@@ -35,6 +42,8 @@ vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
 }));
 
 import { createRoot } from "../../../src/tui/ink.js";
+import { getInkInstance } from "../../../src/tui/ink/instances.js";
+import { cellAt } from "../../../src/tui/ink/screen.js";
 import { AppStateProvider, getDefaultAppState, type AppState, useSetAppState } from "../../../src/tui/state/AppState.js";
 import { TestSurface, TestSurfaceView } from "../../../src/tui/workbench/surfaces/TestSurface.js";
 import { renderToString } from "../../../src/utils/staticRender.js";
@@ -51,6 +60,8 @@ describe("TestSurface", () => {
     keybindingHarness.deferredTaskIds = new Set();
     keybindingHarness.handlers = {};
     keybindingHarness.pendingReads = new Map();
+    keybindingHarness.readCounts = {};
+    keybindingHarness.rejectOnRead = {};
     keybindingHarness.tails = {};
   });
 
@@ -179,6 +190,48 @@ describe("TestSurface", () => {
       stdout.end();
     }
   });
+
+  it("keeps parsed failures visible when a later tail poll fails", async () => {
+    keybindingHarness.rejectOnRead["shell-1"] = 2;
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            tasks: {
+              "shell-1": shellTask("shell-1", "current test", "running"),
+            },
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "test",
+              selectedShellTaskId: "shell-1",
+            },
+          }}
+        >
+          <TestSurface focused={true} />
+        </AppStateProvider>,
+      );
+      await sleep();
+
+      expect(compact(screenText(stdout))).toContain("firstfailure");
+
+      await sleep(1_200);
+
+      expect(compact(screenText(stdout))).toContain("firstfailure");
+      expect(compact(screenText(stdout))).not.toContain("Noparsedtestfailures");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
 });
 
 function TestTaskSelector({
@@ -254,4 +307,25 @@ function createStreams(): {
 
 function sleep(ms = 200): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function compact(value: string): string {
+  return value.replace(/\s+/gu, "");
+}
+
+function screenText(stdout: PassThrough): string {
+  const instance = getInkInstance(stdout as unknown as NodeJS.WriteStream) as
+    | { readonly frontFrame?: { readonly screen?: { readonly width: number; readonly height: number } } }
+    | undefined;
+  const screen = instance?.frontFrame?.screen;
+  if (!screen) return "";
+  const rows: string[] = [];
+  for (let row = 0; row < screen.height; row += 1) {
+    const chars: string[] = [];
+    for (let column = 0; column < screen.width; column += 1) {
+      chars.push(cellAt(screen, column, row)?.char ?? " ");
+    }
+    rows.push(chars.join("").trimEnd());
+  }
+  return rows.join("\n");
 }


### PR DESCRIPTION
## Summary
- Preserve the last successful task tail when a later polling read fails in workbench shell, agent, and test surfaces.
- Apply the same preservation behavior to the background task detail panel.
- Add regressions for transient tail read failures so output, parsed failures, and task detail tails stay visible.

## Verification
- Failing-first focused regression reproduced the prior clear-to-empty behavior.
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/shell-surface.test.tsx tests/tui/workbench/agent-surface.test.tsx tests/tui/workbench/test-surface.test.tsx tests/tui/coverage-swarm/swarm-013-components-tasks-BackgroundTasksPanel.test.tsx --reporter=dot`
- `git diff --check`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

## Known Existing Failure
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the unrelated existing Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.