### PR TITLE
fix(tui): surface global search failures

### DIFF
--- a/runtime/src/tui/components/GlobalSearchDialog.tsx
+++ b/runtime/src/tui/components/GlobalSearchDialog.tsx
@@ -17,6 +17,7 @@ import { truncatePathMiddle, truncateToWidth } from '../../utils/format';
 import { highlightMatch } from '../../utils/highlightMatch';
 import { readFileInRange } from '../../utils/readFileInRange';
 import { ripGrepStream } from '../../utils/ripgrep';
+import { logError } from '../../utils/log';
 import { displayPathRelativeToBase } from '../pathDisplay.js';
 import { FuzzyPicker } from './design-system/FuzzyPicker';
 import { LoadingState } from './design-system/LoadingState';
@@ -71,7 +72,7 @@ function renderMatchText(m: Match, query: string, listWidth: number, maxPathWidt
  * Debounced ripgrep search across the workspace.
  */
 export function GlobalSearchDialog(t0) {
-  const $ = _c(41);
+  const $ = _c(42);
   const {
     onDone,
     onInsert
@@ -100,6 +101,7 @@ export function GlobalSearchDialog(t0) {
   const [matches, setMatches] = useState(t1);
   const [truncated, setTruncated] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
+  const [searchError, setSearchError] = useState(null);
   const [query, setQuery] = useState("");
   const [focused, setFocused] = useState(undefined);
   const [preview, setPreview] = useState(null);
@@ -175,18 +177,20 @@ export function GlobalSearchDialog(t0) {
         setMatches(_temp);
         setIsSearching(false);
         setTruncated(false);
+        setSearchError(null);
         return;
       }
       const controller_0 = new AbortController();
       abortRef.current = controller_0;
       setIsSearching(true);
       setTruncated(false);
+      setSearchError(null);
       const queryLower = q.toLowerCase();
       setMatches(m_0 => {
         const filtered = m_0.filter(match => match.text.toLowerCase().includes(queryLower));
         return filtered.length === m_0.length ? m_0 : filtered;
       });
-      timeoutRef.current = setTimeout(_temp4, DEBOUNCE_MS, q, controller_0, setMatches, setTruncated, setIsSearching);
+      timeoutRef.current = setTimeout(_temp4, DEBOUNCE_MS, q, controller_0, setMatches, setTruncated, setIsSearching, setSearchError);
     };
     $[6] = t6;
   } else {
@@ -238,7 +242,7 @@ export function GlobalSearchDialog(t0) {
     t8 = $[13];
   }
   const handleInsert = t8;
-  const matchLabel = matches.length > 0 ? `${matches.length}${truncated ? "+" : ""} matches${isSearching ? "..." : ""}` : " ";
+  const matchLabel = matches.length > 0 ? `${matches.length}${truncated ? "+" : ""} matches${isSearching ? "..." : ""}` : searchError ? "Search failed" : " ";
   const t9 = previewOnRight ? "right" : "bottom";
   let t10;
   if ($[14] !== handleInsert) {
@@ -263,9 +267,10 @@ export function GlobalSearchDialog(t0) {
     t11 = $[17];
   }
   let t12;
-  if ($[18] !== isSearching) {
-    t12 = q_0 => isSearching ? "Searching..." : q_0 ? "No matches" : "Type to search...";
+  if ($[18] !== isSearching || $[41] !== searchError) {
+    t12 = q_0 => isSearching ? "Searching..." : searchError ? `Search failed: ${searchError}` : q_0 ? "No matches" : "Type to search...";
     $[18] = isSearching;
+    $[41] = searchError;
     $[19] = t12;
   } else {
     t12 = $[19];
@@ -311,7 +316,7 @@ export function GlobalSearchDialog(t0) {
   }
   return t15;
 }
-function _temp4(query_0, controller_1, setMatches_0, setTruncated_0, setIsSearching_0) {
+function _temp4(query_0, controller_1, setMatches_0, setTruncated_0, setIsSearching_0, setSearchError_0) {
   const cwd = getCwd();
   let collected = 0;
   ripGrepStream(["--json", "-i", "-m", String(MAX_MATCHES_PER_FILE), "-F", "-e", query_0], cwd, controller_1.signal, lines => {
@@ -348,7 +353,13 @@ function _temp4(query_0, controller_1, setMatches_0, setTruncated_0, setIsSearch
       setTruncated_0(true);
       setIsSearching_0(false);
     }
-  }).catch(_temp2).finally(() => {
+  }).catch(error => {
+    if (controller_1.signal.aborted) {
+      return;
+    }
+    logError(error);
+    setSearchError_0(searchErrorMessage(error));
+  }).finally(() => {
     if (controller_1.signal.aborted) {
       return;
     }
@@ -361,9 +372,12 @@ function _temp4(query_0, controller_1, setMatches_0, setTruncated_0, setIsSearch
 function _temp3(m_2) {
   return m_2.length ? [] : m_2;
 }
-function _temp2() {}
 function _temp(m) {
   return m.length ? [] : m;
+}
+
+function searchErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 function matchKey(m: Match): string {
   return `${m.file}:${m.line}`;

--- a/runtime/tests/tui/components/GlobalSearchDialog.render.test.tsx
+++ b/runtime/tests/tui/components/GlobalSearchDialog.render.test.tsx
@@ -36,6 +36,7 @@ type CapturedPickerProps = {
 const harness = vi.hoisted(() => ({
   cwd: '/workspace/project',
   logEvent: vi.fn(),
+  logError: vi.fn(),
   openFileInExternalEditor: vi.fn(),
   pickerProps: undefined as CapturedPickerProps | undefined,
   readFileInRange: vi.fn(),
@@ -71,6 +72,10 @@ vi.mock('../../utils/readFileInRange', () => ({
   readFileInRange: harness.readFileInRange,
 }))
 
+vi.mock('../../utils/log', () => ({
+  logError: harness.logError,
+}))
+
 vi.mock('../../utils/ripgrep', () => ({
   ripGrepStream: harness.ripGrepStream,
 }))
@@ -96,6 +101,7 @@ function resetHarness() {
   harness.pickerProps = undefined
   harness.registerOverlay.mockClear()
   harness.logEvent.mockClear()
+  harness.logError.mockClear()
   harness.openFileInExternalEditor.mockReset()
   harness.openFileInExternalEditor.mockReturnValue(true)
   harness.readFileInRange.mockReset()
@@ -409,6 +415,34 @@ describe('GlobalSearchDialog render and interactions', () => {
         'Global search did not render the no-match state',
       )
       expect(pickerProps().matchLabel).toBe(' ')
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
+  it('renders search failures instead of treating them as no matches', async () => {
+    const rendered = await renderDialog()
+
+    try {
+      const failure = new Error('ripgrep unavailable')
+      harness.ripGrepStream.mockRejectedValueOnce(failure)
+
+      pickerProps().onQueryChange('needle')
+
+      await waitFor(
+        () => emptyMessage(pickerProps(), 'needle') === 'Searching...',
+        'Global search did not enter searching state before failure',
+      )
+      await waitFor(
+        () =>
+          pickerProps().items.length === 0 &&
+          emptyMessage(pickerProps(), 'needle') ===
+            'Search failed: ripgrep unavailable',
+        'Global search did not render the search failure state',
+      )
+
+      expect(pickerProps().matchLabel).toBe('Search failed')
+      expect(harness.logError).toHaveBeenCalledWith(failure)
     } finally {
       await rendered.dispose()
     }


### PR DESCRIPTION
## Summary
- Render rejected global search streams as an explicit failure state instead of the normal no-match state.
- Log search stream failures through the existing error logger.
- Add a failing-first global search regression for rejected search streams.

## Verification
- Failing-first focused regression reproduced the prior hidden no-match behavior.
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/GlobalSearchDialog.render.test.tsx tests/tui/coverage-swarm/swarm-127-components-GlobalSearchDialog.test.tsx tests/tui/components/GlobalSearchDialog.wave200-129.coverage.test.tsx tests/tui/workbench/search-surface.test.tsx --reporter=dot`
- `git diff --check`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

## Known Existing Failure
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the unrelated existing Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.