### PR TITLE
fix(tui): log buffer lsp notification failures

### DIFF
--- a/runtime/src/tui/workbench/buffer/lsp.ts
+++ b/runtime/src/tui/workbench/buffer/lsp.ts
@@ -2,6 +2,7 @@ import { pathToFileURL, fileURLToPath } from "node:url";
 
 import { clearDeliveredDiagnosticsForFile } from "../../../services/lsp/LSPDiagnosticRegistry.js";
 import { getLspServerManager } from "../../../services/lsp/manager.js";
+import { logError } from "../../../utils/log.js";
 
 export type BufferLspPosition = {
   readonly line: number;
@@ -15,7 +16,7 @@ export type BufferDefinitionTarget = {
 };
 
 function bestEffort(run: () => Promise<void>): void {
-  void run().catch(() => {});
+  void run().catch(logError);
 }
 
 export function notifyBufferLspOpened(filePath: string, content: string): void {

--- a/runtime/tests/tui/workbench/buffer-lsp.test.ts
+++ b/runtime/tests/tui/workbench/buffer-lsp.test.ts
@@ -10,8 +10,16 @@ const manager = vi.hoisted(() => ({
   sendRequest: vi.fn(),
 }));
 
+const logMock = vi.hoisted(() => ({
+  logError: vi.fn(),
+}));
+
 vi.mock("../../../src/services/lsp/manager.js", () => ({
   getLspServerManager: () => manager,
+}));
+
+vi.mock("../../../src/utils/log.js", () => ({
+  logError: logMock.logError,
 }));
 
 import {
@@ -27,6 +35,7 @@ import {
 
 beforeEach(() => {
   for (const fn of Object.values(manager)) fn.mockReset();
+  logMock.logError.mockReset();
 });
 
 describe("buffer LSP helpers", () => {
@@ -69,6 +78,17 @@ describe("buffer LSP helpers", () => {
     expect(manager.changeFile).toHaveBeenCalledWith("/tmp/example.ts", "const value = 2;\n");
     expect(manager.saveFile).toHaveBeenCalledWith("/tmp/example.ts");
     expect(manager.closeFile).toHaveBeenCalledWith("/tmp/example.ts");
+  });
+
+  it("logs best-effort lifecycle notification failures", async () => {
+    const error = new Error("lsp open failed");
+    manager.openFile.mockRejectedValueOnce(error);
+
+    notifyBufferLspOpened("/tmp/example.ts", "const value = 1;\n");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(logMock.logError).toHaveBeenCalledWith(error);
   });
 
   it("requests hover and definition with file URIs", async () => {


### PR DESCRIPTION
## Summary
- Log rejected buffer LSP lifecycle notifications instead of swallowing them.
- Add a regression that verifies rejected best-effort notifications reach the shared error logger.

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/buffer-lsp.test.ts --reporter=dot (failed before the fix)
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/buffer-lsp.test.ts tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-external-editor.test.ts --reporter=dot
- git diff --check
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui (755 files, 3188 tests)
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Known existing issue
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on the unrelated Knip backlog: unused file src/tui/workbench/keymap.ts, 30 unused exports, and 4 unused @internal tag hints.