### PR TITLE
fix(tui): log realtime cleanup failures

### DIFF
--- a/runtime/src/tui/realtime/controller.ts
+++ b/runtime/src/tui/realtime/controller.ts
@@ -21,6 +21,7 @@ import {
   type RealtimeAudioPlayer,
   type StartRealtimeAudioCapture,
 } from "./audio.js";
+import { logError } from "../../utils/log.js";
 import {
   effectiveRealtimeMicrophoneMuted,
   initialRealtimeTuiState,
@@ -139,9 +140,9 @@ class RealtimeTuiController implements AgenCRealtimeTuiControls {
         await this.#startWebsocketAudioCapture();
       }
     } catch (error) {
-      await this.#stopAudioCapture().catch(() => {});
+      await this.#stopAudioCapture().catch(logError);
       if (startedWebRtc !== null) {
-        await this.#closeWebrtc(startedWebRtc).catch(() => {});
+        await this.#closeWebrtc(startedWebRtc).catch(logError);
       }
       if (this.#webRtc === startedWebRtc) this.#webRtc = null;
       if (daemonStarted) await this.#requestDaemonStop();
@@ -314,7 +315,7 @@ class RealtimeTuiController implements AgenCRealtimeTuiControls {
         this.#dispatch({ type: "item_added", item: payload.item ?? null });
         break;
       case "realtime_error":
-        void this.#stopAudioCapture().catch(() => {});
+        void this.#stopAudioCapture().catch(logError);
         this.#closeActiveWebrtc();
         this.#closeAudioPlayerBestEffort();
         this.#dispatch({
@@ -326,7 +327,7 @@ class RealtimeTuiController implements AgenCRealtimeTuiControls {
         });
         break;
       case "realtime_closed":
-        void this.#stopAudioCapture().catch(() => {});
+        void this.#stopAudioCapture().catch(logError);
         this.#closeActiveWebrtc();
         this.#closeAudioPlayerBestEffort();
         this.#dispatch({
@@ -406,7 +407,7 @@ class RealtimeTuiController implements AgenCRealtimeTuiControls {
       rollback();
       if (started !== null && this.#webRtc === started) {
         this.#webRtc = null;
-        void this.#closeWebrtc(started).catch(() => {});
+        void this.#closeWebrtc(started).catch(logError);
       }
       this.#closeAudioPlayerBestEffort();
       void this.#requestDaemonStop();
@@ -430,7 +431,7 @@ class RealtimeTuiController implements AgenCRealtimeTuiControls {
     fallback: string,
   ): Promise<void> {
     if (this.#state.requestedClose || this.#state.phase === "inactive") return;
-    await this.#stopAudioCapture().catch(() => {});
+    await this.#stopAudioCapture().catch(logError);
     this.#closeActiveWebrtc();
     this.#closeAudioPlayerBestEffort();
     this.#surfaceRealtimeError(error, fallback);
@@ -440,8 +441,9 @@ class RealtimeTuiController implements AgenCRealtimeTuiControls {
   #closeAudioPlayerBestEffort(): void {
     try {
       this.#audioPlayer.close();
-    } catch {
+    } catch (error) {
       // Audio output cleanup must not tear down daemon notification handling.
+      logError(error);
     }
   }
 
@@ -477,7 +479,7 @@ class RealtimeTuiController implements AgenCRealtimeTuiControls {
     message: string,
   ): Promise<void> {
     if (this.#state.requestedClose || this.#state.phase === "inactive") return;
-    await this.#stopAudioCapture().catch(() => {});
+    await this.#stopAudioCapture().catch(logError);
     this.#closeAudioPlayerBestEffort();
     if (kind === "error") {
       this.#surfaceRealtimeError(message, "Realtime audio capture failed");
@@ -503,7 +505,7 @@ class RealtimeTuiController implements AgenCRealtimeTuiControls {
       .request("thread/realtime/stop", {
         threadId: this.#threadId,
       } satisfies ThreadRealtimeStopParams)
-      .catch(() => {});
+      .catch(logError);
   }
 
   async #applyProviderSdp(sdp: string): Promise<void> {
@@ -513,7 +515,7 @@ class RealtimeTuiController implements AgenCRealtimeTuiControls {
       await started.handle.applyAnswerSdp(sdp);
     } catch (error) {
       if (this.#webRtc === started) this.#webRtc = null;
-      await this.#closeWebrtc(started).catch(() => {});
+      await this.#closeWebrtc(started).catch(logError);
       this.#closeAudioPlayerBestEffort();
       this.#surfaceRealtimeError(error, "Realtime SDP failed");
       await this.#requestDaemonStop();
@@ -529,7 +531,7 @@ class RealtimeTuiController implements AgenCRealtimeTuiControls {
     const started = this.#webRtc;
     if (started === null) return;
     this.#webRtc = null;
-    void this.#closeWebrtc(started).catch(() => {});
+    void this.#closeWebrtc(started).catch(logError);
   }
 
   #surfaceRealtimeError(error: unknown, fallback: string): string {

--- a/runtime/tests/tui/realtime/controller.contract.test.ts
+++ b/runtime/tests/tui/realtime/controller.contract.test.ts
@@ -1,4 +1,12 @@
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const logMock = vi.hoisted(() => ({
+  logError: vi.fn(),
+}));
+
+vi.mock("../../utils/log.js", () => ({
+  logError: logMock.logError,
+}));
 
 import {
   createRealtimeWebrtcEventChannel,
@@ -73,6 +81,10 @@ async function waitFor(
 }
 
 describe("AgenC realtime TUI controller", () => {
+  beforeEach(() => {
+    logMock.logError.mockReset();
+  });
+
   test("routes websocket start, text, audio, and stop through daemon RPC", async () => {
     const client = createClient();
     const audioPlayer = createAudioPlayer();
@@ -587,13 +599,17 @@ describe("AgenC realtime TUI controller", () => {
       const client = createClient();
       let callbacks: RealtimeAudioCaptureCallbacks | null = null;
       const emitted: JsonObject[] = [];
+      const cleanupError = new Error(`${kind} capture cleanup failed`);
+      const stop = vi.fn(async () => {
+        throw cleanupError;
+      });
       const controls = createRealtimeTuiControls({
         threadId: "agent_1",
         client,
         emitEvent: (event) => emitted.push(event),
         startAudioCapture: async (nextCallbacks) => {
           callbacks = nextCallbacks;
-          return { stop: vi.fn() };
+          return { stop };
         },
       });
 
@@ -605,9 +621,11 @@ describe("AgenC realtime TUI controller", () => {
         () =>
           client.requests.filter(
             (request) => request.method === "thread/realtime/stop",
-          ).length === 1,
+          ).length === 1 &&
+          logMock.logError.mock.calls.some(([error]) => error === cleanupError),
         "daemon stop after capture terminal event",
       );
+      expect(stop).toHaveBeenCalledTimes(1);
       expect(emitted.at(-1)).toMatchObject({
         type: eventType,
       });
@@ -725,10 +743,11 @@ describe("AgenC realtime TUI controller", () => {
     "guards audio player close failures during remote %s notifications",
     (type, payload, expectedState) => {
       const client = createClient();
+      const closeError = new Error("close failed");
       const audioPlayer = {
         enqueue: vi.fn(),
         close: vi.fn(() => {
-          throw new Error("close failed");
+          throw closeError;
         }),
       };
       const controls = createRealtimeTuiControls({
@@ -742,6 +761,39 @@ describe("AgenC realtime TUI controller", () => {
         controls.handleTranscriptEvent({ type, payload });
       }).not.toThrow();
       expect(controls.getState()).toMatchObject(expectedState);
+      expect(logMock.logError).toHaveBeenCalledWith(closeError);
+    },
+  );
+
+  test.each(["realtime_error", "realtime_closed"] as const)(
+    "logs audio capture cleanup failures during remote %s notifications",
+    async (type) => {
+      const client = createClient();
+      const cleanupError = new Error("capture cleanup failed");
+      const stop = vi.fn(async () => {
+        throw cleanupError;
+      });
+      const controls = createRealtimeTuiControls({
+        threadId: "agent_1",
+        client,
+        emitEvent: () => {},
+        startAudioCapture: async () => ({ stop }),
+      });
+
+      await controls.start({ transport: "websocket" });
+      controls.handleTranscriptEvent({
+        type,
+        payload:
+          type === "realtime_error"
+            ? { message: "remote failed" }
+            : { reason: "remote closed" },
+      });
+
+      await waitFor(
+        () => logMock.logError.mock.calls.some(([error]) => error === cleanupError),
+        "logged remote cleanup failure",
+      );
+      expect(stop).toHaveBeenCalledTimes(1);
     },
   );
 
@@ -851,7 +903,22 @@ describe("AgenC realtime TUI controller", () => {
   ])(
     "stops daemon realtime on unexpected local WebRTC %s events",
     async (event, eventType) => {
-      const client = createClient();
+      const stopError = new Error("daemon stop failed");
+      const requests: Array<{
+        readonly method: AgenCDaemonMethod;
+        readonly params?: JsonObject;
+      }> = [];
+      const client = {
+        requests,
+        async request<Method extends AgenCDaemonMethod>(
+          method: Method,
+          params?: JsonObject,
+        ): Promise<AgenCDaemonResultByMethod[Method]> {
+          requests.push({ method, params });
+          if (method === "thread/realtime/stop") throw stopError;
+          return {} as AgenCDaemonResultByMethod[Method];
+        },
+      };
       const channel = createRealtimeWebrtcEventChannel();
       const emitted: JsonObject[] = [];
       const controls = createRealtimeTuiControls({
@@ -875,7 +942,8 @@ describe("AgenC realtime TUI controller", () => {
         () =>
           client.requests.filter(
             (request) => request.method === "thread/realtime/stop",
-          ).length === 1,
+          ).length === 1 &&
+          logMock.logError.mock.calls.some(([error]) => error === stopError),
         "daemon stop after local WebRTC terminal event",
       );
       expect(emitted.at(-1)).toMatchObject({ type: eventType });
@@ -902,7 +970,10 @@ describe("AgenC realtime TUI controller", () => {
     async (type, payload, expectedState) => {
       const client = createClient();
       const channel = createRealtimeWebrtcEventChannel();
-      const close = vi.fn();
+      const closeError = new Error("remote WebRTC cleanup failed");
+      const close = vi.fn(async () => {
+        throw closeError;
+      });
       const started: StartedRealtimeWebrtcSession = {
         offerSdp: "offer-sdp",
         handle: new RealtimeWebrtcSessionHandle({
@@ -922,7 +993,9 @@ describe("AgenC realtime TUI controller", () => {
       controls.handleTranscriptEvent({ type, payload });
 
       await waitFor(
-        () => close.mock.calls.length === 1,
+        () =>
+          close.mock.calls.length === 1 &&
+          logMock.logError.mock.calls.some(([error]) => error === closeError),
         "remote terminal WebRTC cleanup",
       );
       expect(controls.getState()).toMatchObject(expectedState);


### PR DESCRIPTION
## Summary
- Log rejected best-effort realtime cleanup instead of swallowing cleanup failures.
- Cover audio capture stop, WebRTC close, audio player close, and detached daemon-stop cleanup paths with focused regressions.

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/realtime/controller.contract.test.ts --reporter=dot (failed before the fix)
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/realtime/controller.contract.test.ts tests/tui/realtime/controller.wave200-105.coverage.test.ts tests/tui/realtime/state.contract.test.ts tests/tui/realtime/audio.contract.test.ts tests/tui/realtime/commands.contract.test.ts tests/tui/realtime/panel.contract.test.tsx --reporter=dot
- git diff --check
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui (755 files, 3190 tests)
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Known existing issue
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on the unrelated Knip backlog: unused file src/tui/workbench/keymap.ts, 30 unused exports, and 4 unused @internal tag hints.