### PR TITLE
fix(tui): log osc clipboard fallback failures

### DIFF
--- a/runtime/src/tui/ink/termio/osc.ts
+++ b/runtime/src/tui/ink/termio/osc.ts
@@ -6,6 +6,7 @@ import { Buffer } from 'buffer'
 import { unlink, writeFile } from 'node:fs/promises'
 import { env } from '../../../utils/env.js'
 import { execFileNoThrow } from '../../../utils/execFileNoThrow.js'
+import { logError } from '../../../utils/log.js'
 import { generateTempFilePath } from '../../../utils/tempfile.js'
 import { BEL, ESC, ESC_TYPE, SEP } from './ansi.js'
 import type { Action, Color, TabStatusAction } from './types.js'
@@ -161,6 +162,11 @@ export async function setClipboard(text: string): Promise<string> {
 // Probe order: wl-copy (Wayland) → xclip (X11) → xsel (X11 fallback).
 // Cached after first attempt so repeated mouse-ups skip the probe chain.
 let linuxCopy: 'wl-copy' | 'xclip' | 'xsel' | null | undefined
+type ClipboardExecOptions = {
+  readonly input: string
+  readonly useCwd: false
+  readonly timeout: number
+}
 
 /**
  * Shell out to a native clipboard utility as a safety net for OSC 52.
@@ -169,45 +175,27 @@ let linuxCopy: 'wl-copy' | 'xclip' | 'xsel' | null | undefined
  * Fire-and-forget: failures are silent since OSC 52 may have succeeded.
  */
 function copyNative(text: string): void {
-  const opts = { input: text, useCwd: false, timeout: 2000 }
+  const opts: ClipboardExecOptions = { input: text, useCwd: false, timeout: 2000 }
   switch (process.platform) {
     case 'darwin':
-      void execFileNoThrow('pbcopy', [], opts)
+      void execFileNoThrow('pbcopy', [], opts).catch(logError)
       return
     case 'linux': {
       if (linuxCopy === null) return
       if (linuxCopy === 'wl-copy') {
-        void execFileNoThrow('wl-copy', [], opts)
+        void execFileNoThrow('wl-copy', [], opts).catch(logError)
         return
       }
       if (linuxCopy === 'xclip') {
-        void execFileNoThrow('xclip', ['-selection', 'clipboard'], opts)
+        void execFileNoThrow('xclip', ['-selection', 'clipboard'], opts).catch(logError)
         return
       }
       if (linuxCopy === 'xsel') {
-        void execFileNoThrow('xsel', ['--clipboard', '--input'], opts)
+        void execFileNoThrow('xsel', ['--clipboard', '--input'], opts).catch(logError)
         return
       }
       // First call: probe wl-copy (Wayland) then xclip/xsel (X11), cache winner.
-      void execFileNoThrow('wl-copy', [], opts).then(r => {
-        if (r.code === 0) {
-          linuxCopy = 'wl-copy'
-          return
-        }
-        void execFileNoThrow('xclip', ['-selection', 'clipboard'], opts).then(
-          r2 => {
-            if (r2.code === 0) {
-              linuxCopy = 'xclip'
-              return
-            }
-            void execFileNoThrow('xsel', ['--clipboard', '--input'], opts).then(
-              r3 => {
-                linuxCopy = r3.code === 0 ? 'xsel' : null
-              },
-            )
-          },
-        )
-      })
+      void probeLinuxClipboard(opts)
       return
     }
     case 'win32':
@@ -233,12 +221,44 @@ function copyNative(text: string): void {
               stdin: 'ignore',
             },
           )
+        } catch (error) {
+          logError(error)
         } finally {
-          await unlink(tempPath).catch(() => {})
+          await unlink(tempPath).catch(logError)
         }
-      })().catch(() => {})
+      })().catch(logError)
       return
   }
+}
+
+async function probeLinuxClipboard(opts: ClipboardExecOptions): Promise<void> {
+  const wlCopy = await execFileNoThrow('wl-copy', [], opts).catch(error => {
+    logError(error)
+    return null
+  })
+  if (wlCopy?.code === 0) {
+    linuxCopy = 'wl-copy'
+    return
+  }
+
+  const xclip = await execFileNoThrow('xclip', ['-selection', 'clipboard'], opts).catch(
+    error => {
+      logError(error)
+      return null
+    },
+  )
+  if (xclip?.code === 0) {
+    linuxCopy = 'xclip'
+    return
+  }
+
+  const xsel = await execFileNoThrow('xsel', ['--clipboard', '--input'], opts).catch(
+    error => {
+      logError(error)
+      return null
+    },
+  )
+  linuxCopy = xsel?.code === 0 ? 'xsel' : null
 }
 
 /** @internal test-only */

--- a/runtime/tests/tui/ink/termio/osc.test.ts
+++ b/runtime/tests/tui/ink/termio/osc.test.ts
@@ -10,11 +10,23 @@ const generateTempFilePathMock = vi.fn(() => mockedClipboardPath)
 const execFileNoThrowMock = vi.fn(
   async () => ({ code: 0, stdout: '', stderr: '' }),
 )
+const logErrorMock = vi.fn()
+const writeFileMock = vi.fn(async () => {})
+const unlinkMock = vi.fn(async () => {})
 
 function installOscMocks(): void {
   vi.doMock('../../../utils/execFileNoThrow.js', () => ({
     execFileNoThrow: execFileNoThrowMock,
     execFileNoThrowWithCwd: execFileNoThrowMock,
+  }))
+
+  vi.doMock('../../../utils/log.js', () => ({
+    logError: logErrorMock,
+  }))
+
+  vi.doMock('node:fs/promises', () => ({
+    unlink: unlinkMock,
+    writeFile: writeFileMock,
   }))
 
   vi.doMock('../../../utils/tempfile.js', () => ({
@@ -51,6 +63,9 @@ describe('Windows clipboard fallback', () => {
     installOscMocks()
     execFileNoThrowMock.mockClear()
     generateTempFilePathMock.mockClear()
+    logErrorMock.mockClear()
+    writeFileMock.mockClear()
+    unlinkMock.mockClear()
     process.env = { ...originalEnv }
     delete process.env['SSH_CONNECTION']
     delete process.env['TMUX']
@@ -95,6 +110,28 @@ describe('Windows clipboard fallback', () => {
       `$text = [System.IO.File]::ReadAllText('${mockedClipboardPath.replace(/'/g, "''")}', [System.Text.Encoding]::UTF8); Set-Clipboard -Value $text`,
     )
   })
+
+  test('logs Windows clipboard temp-file failures', async () => {
+    const writeError = new Error('clipboard temp write failed')
+    writeFileMock.mockRejectedValueOnce(writeError)
+    const { setClipboard } = await importFreshOscModule()
+
+    await setClipboard('Привет мир')
+    await flushClipboardCopy()
+
+    expect(logErrorMock).toHaveBeenCalledWith(writeError)
+  })
+
+  test('logs Windows clipboard temp-file cleanup failures', async () => {
+    const unlinkError = new Error('clipboard temp cleanup failed')
+    unlinkMock.mockRejectedValueOnce(unlinkError)
+    const { setClipboard } = await importFreshOscModule()
+
+    await setClipboard('Привет мир')
+    await flushClipboardCopy()
+
+    expect(logErrorMock).toHaveBeenCalledWith(unlinkError)
+  })
 })
 
 describe('clipboard path behavior remains stable', () => {
@@ -102,6 +139,9 @@ describe('clipboard path behavior remains stable', () => {
     vi.resetModules()
     installOscMocks()
     execFileNoThrowMock.mockClear()
+    logErrorMock.mockClear()
+    writeFileMock.mockClear()
+    unlinkMock.mockClear()
     process.env = { ...originalEnv }
     delete process.env['SSH_CONNECTION']
     delete process.env['TMUX']
@@ -148,5 +188,30 @@ describe('clipboard path behavior remains stable', () => {
     expect(execFileNoThrowMock.mock.calls.some(([cmd]) => cmd === 'pbcopy')).toBe(
       true,
     )
+  })
+
+  test('local macOS clipboard fallback logs rejected native copy attempts', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    const copyError = new Error('pbcopy rejected')
+    execFileNoThrowMock.mockRejectedValueOnce(copyError)
+    const { setClipboard } = await importFreshOscModule()
+
+    await setClipboard('hello')
+    await flushClipboardCopy()
+
+    expect(logErrorMock).toHaveBeenCalledWith(copyError)
+  })
+
+  test('local Linux clipboard probe logs rejected native copy attempts', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    const probeError = new Error('wl-copy rejected')
+    execFileNoThrowMock.mockRejectedValueOnce(probeError)
+    const { _resetLinuxCopyCache, setClipboard } = await importFreshOscModule()
+
+    _resetLinuxCopyCache()
+    await setClipboard('hello')
+    await flushClipboardCopy()
+
+    expect(logErrorMock).toHaveBeenCalledWith(probeError)
   })
 })

--- a/runtime/tests/tui/ink/termio/osc.wave200-025.coverage.test.ts
+++ b/runtime/tests/tui/ink/termio/osc.wave200-025.coverage.test.ts
@@ -160,6 +160,7 @@ describe('OSC wave200-025 coverage', () => {
       ['-selection', 'clipboard'],
       { input: linuxText, timeout: 2000, useCwd: false },
     ])
+    await flushClipboardCopy()
 
     execFileNoThrowMock.mockClear()
     await setClipboard('cached linux')


### PR DESCRIPTION
## Summary
- Log rejected native clipboard fallback work instead of swallowing detached promise failures.
- Keep OSC 52 fallback behavior and ordinary missing native-tool probe results non-fatal.
- Add focused coverage for Windows temp-file write/cleanup failures plus macOS and Linux native-copy rejections.

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/ink/termio/osc.test.ts --reporter=dot (failed before the fix)
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/ink/termio/osc.test.ts tests/tui/ink/termio/osc.wave200-025.coverage.test.ts tests/tui/coverage-swarm/swarm-063-ink-termio-osc.test.ts --reporter=dot
- git diff --check
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui (755 files, 3194 tests)
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Known existing issue
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still fails on the unrelated Knip backlog: unused file src/tui/workbench/keymap.ts, 30 unused exports, and 4 unused @internal tag hints.