### PR TITLE
fix(tui): filter ignored project tree fallback dirs

### DIFF
--- a/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
+++ b/runtime/src/tui/workbench/project-tree/ProjectTreeStore.ts
@@ -36,6 +36,12 @@ const WORKSPACE_TREE_IGNORE = [
   "**/out/**",
   "**/target/**",
 ] as const;
+const WORKSPACE_TREE_IGNORED_DIRECTORY_NAMES = new Set(
+  WORKSPACE_TREE_IGNORE.flatMap((pattern) => {
+    const match = pattern.match(/^\*\*\/([^/]+)\/\*\*$/u);
+    return match ? [match[1]!] : [];
+  }),
+);
 
 export class ProjectTreeStore {
   #cwd: string;
@@ -379,7 +385,7 @@ function isDescendantPath(value: string, possibleAncestor: string): boolean {
 async function readTopLevelPaths(cwd: string): Promise<string[]> {
   const entries = await readdir(cwd, { withFileTypes: true });
   return entries
-    .filter((entry) => entry.name !== ".git")
+    .filter((entry) => !(entry.isDirectory() && WORKSPACE_TREE_IGNORED_DIRECTORY_NAMES.has(entry.name)))
     .map((entry) => entry.isDirectory() ? `${entry.name}/` : entry.name)
     .sort((a, b) => a.localeCompare(b));
 }

--- a/runtime/tests/tui/workbench/project-tree.test.ts
+++ b/runtime/tests/tui/workbench/project-tree.test.ts
@@ -170,6 +170,32 @@ describe("project tree helpers", () => {
     }
   });
 
+  it("keeps ignored-only fallback directories out of non-git workspaces", async () => {
+    const repo = await mkdtemp(join(tmpdir(), "agenc-tree-ignored-only-"));
+    const store = new ProjectTreeStore(repo, 0);
+
+    try {
+      await mkdir(join(repo, "node_modules", "ignored"), { recursive: true });
+      await writeFile(join(repo, "node_modules", "ignored", "index.js"), "ignored\n", "utf8");
+
+      await store.refresh();
+
+      const paths = store.getSnapshot().rows.map((row) => row.path);
+
+      expect(paths).not.toContain("node_modules");
+      expect(paths).not.toContain("node_modules/ignored");
+      expect(paths).not.toContain("node_modules/ignored/index.js");
+      expect(store.getSnapshot()).toMatchObject({
+        cursorPath: null,
+        error: null,
+        loading: false,
+      });
+    } finally {
+      store.dispose();
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
   it("falls back to the recursive scanner when git has no indexed paths", async () => {
     const repo = await mkdtemp(join(tmpdir(), "agenc-tree-empty-git-"));
     const store = new ProjectTreeStore(repo, 0);


### PR DESCRIPTION
## Summary
- Keep the project tree top-level fallback from rendering ignored-only directories such as node_modules.
- Derive fallback ignored directory names from the existing workspace ignore list so scanner and fallback behavior stay aligned.
- Add a regression covering a non-git workspace where every discovered entry is ignored.

## Test plan
- Failing-first: `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/project-tree.test.ts --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/project-tree.test.ts tests/tui/workbench/project-explorer-interactions.test.tsx tests/tui/workbench/render.test.tsx --reporter=dot`
- `git diff --check`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` (fails on existing unrelated Knip backlog: unused `src/tui/workbench/keymap.ts`, 30 unused exports, 4 unused tag hints)
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`