### PR TITLE
fix(tui): preserve project tree git status paths

### DIFF
--- a/runtime/src/tui/workbench/project-tree/gitStatus.ts
+++ b/runtime/src/tui/workbench/project-tree/gitStatus.ts
@@ -21,7 +21,7 @@ export function collectGitStatus(cwd: string): Promise<Map<string, ProjectTreeGi
   return new Promise((resolve) => {
     execFile(
       "git",
-      ["status", "--porcelain=v1", "--untracked-files=all"],
+      ["-c", "core.quotepath=false", "status", "--porcelain=v1", "--untracked-files=all"],
       { cwd, encoding: "utf8", timeout: 5_000 },
       (error, stdout) => {
         if (error) {

--- a/runtime/tests/tui/workbench/project-tree.test.ts
+++ b/runtime/tests/tui/workbench/project-tree.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { buildProjectTreeRows } from "../../../src/tui/workbench/project-tree/buildTree.js";
-import { parseGitStatusPorcelain } from "../../../src/tui/workbench/project-tree/gitStatus.js";
+import { collectGitStatus, parseGitStatusPorcelain } from "../../../src/tui/workbench/project-tree/gitStatus.js";
 import { ProjectTreeStore } from "../../../src/tui/workbench/project-tree/ProjectTreeStore.js";
 
 describe("project tree helpers", () => {
@@ -103,6 +103,23 @@ describe("project tree helpers", () => {
     expect(parsed.get("src/new.ts")).toBe("untracked");
     expect(parsed.get("src/conflict.ts")).toBe("unmerged");
     expect(parsed.get("src/new-name.ts")).toBe("renamed");
+  });
+
+  it("collects git status for paths that git would quote by default", async () => {
+    const repo = await mkdtemp(join(tmpdir(), "agenc-tree-git-status-"));
+    const fileName = `${Buffer.from([0xc3, 0xa9]).toString("utf8")}.ts`;
+
+    try {
+      execFileSync("git", ["init"], { cwd: repo, stdio: "ignore" });
+      await writeFile(join(repo, fileName), "accented\n", "utf8");
+
+      const status = await collectGitStatus(repo);
+
+      expect(status.get(fileName)).toBe("untracked");
+      expect([...status.keys()]).not.toContain("\"\\303\\251.ts\"");
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
   });
 
   it("does not start filesystem or git refresh work in the constructor", () => {


### PR DESCRIPTION
## Summary
- Align project tree git status collection with file discovery by disabling Git path quoting.
- Preserve status decoration for paths Git would otherwise emit as quoted octal escapes.
- Add a real temp-repo regression for a UTF-8 filename built from ASCII byte values.

## Test plan
- Failing-first: `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/project-tree.test.ts --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/project-tree.test.ts tests/tui/workbench/project-explorer-interactions.test.tsx tests/tui/workbench/render.test.tsx --reporter=dot`
- `git diff --check`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` (fails on existing unrelated Knip backlog: unused `src/tui/workbench/keymap.ts`, 30 unused exports, 4 unused tag hints)
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`