### PR TITLE
fix(tui): preserve project tree git path boundaries

### DIFF
--- a/runtime/src/tui/workbench/project-tree/gitStatus.ts
+++ b/runtime/src/tui/workbench/project-tree/gitStatus.ts
@@ -9,10 +9,24 @@ export function parseGitStatusPorcelain(raw: string): Map<string, ProjectTreeGit
   for (const line of raw.split("\n")) {
     if (line.length < 4) continue;
     const code = line.slice(0, 2);
-    const pathPart = line.slice(3).trim();
+    const pathPart = line.slice(3);
     if (!pathPart) continue;
     const path = normalizePorcelainPath(pathPart);
     out.set(path, statusForCode(code));
+  }
+  return out;
+}
+
+function parseGitStatusPorcelainZ(raw: string): Map<string, ProjectTreeGitState> {
+  const out = new Map<string, ProjectTreeGitState>();
+  const fields = raw.split("\0");
+  for (let index = 0; index < fields.length;) {
+    const entry = fields[index++]!;
+    if (entry.length < 4) continue;
+    const code = entry.slice(0, 2);
+    const path = entry.slice(3);
+    if (path) out.set(path, statusForCode(code));
+    if (isRenameOrCopyCode(code)) index += 1;
   }
   return out;
 }
@@ -21,14 +35,14 @@ export function collectGitStatus(cwd: string): Promise<Map<string, ProjectTreeGi
   return new Promise((resolve) => {
     execFile(
       "git",
-      ["-c", "core.quotepath=false", "status", "--porcelain=v1", "--untracked-files=all"],
+      ["-c", "core.quotepath=false", "status", "--porcelain=v1", "-z", "--untracked-files=all"],
       { cwd, encoding: "utf8", timeout: 5_000 },
       (error, stdout) => {
         if (error) {
           resolve(new Map());
           return;
         }
-        resolve(parseGitStatusPorcelain(stdout));
+        resolve(parseGitStatusPorcelainZ(stdout));
       },
     );
   });
@@ -38,7 +52,7 @@ export function listGitFiles(cwd: string): Promise<string[] | null> {
   return new Promise((resolve) => {
     execFile(
       "git",
-      ["-c", "core.quotepath=false", "ls-files", "--cached", "--others", "--exclude-standard"],
+      ["-c", "core.quotepath=false", "ls-files", "-z", "--cached", "--others", "--exclude-standard"],
       { cwd, encoding: "utf8", timeout: 5_000 },
       (error, stdout) => {
         if (error) {
@@ -46,11 +60,7 @@ export function listGitFiles(cwd: string): Promise<string[] | null> {
           return;
         }
         resolve(
-          stdout
-            .split("\n")
-            .map((line) => line.trim())
-            .filter(Boolean)
-            .sort((a, b) => a.localeCompare(b)),
+          stdout.split("\0").filter(Boolean).sort((a, b) => a.localeCompare(b)),
         );
       },
     );
@@ -61,6 +71,10 @@ function normalizePorcelainPath(pathPart: string): string {
   const rename = pathPart.match(/^(.+)\s+->\s+(.+)$/u);
   const value = rename?.[2] ?? pathPart;
   return value.replace(/^"|"$/gu, "");
+}
+
+function isRenameOrCopyCode(code: string): boolean {
+  return code.includes("R") || code.includes("C");
 }
 
 function statusForCode(code: string): ProjectTreeGitState {

--- a/runtime/tests/tui/workbench/project-tree.test.ts
+++ b/runtime/tests/tui/workbench/project-tree.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { buildProjectTreeRows } from "../../../src/tui/workbench/project-tree/buildTree.js";
-import { collectGitStatus, parseGitStatusPorcelain } from "../../../src/tui/workbench/project-tree/gitStatus.js";
+import { collectGitStatus, listGitFiles, parseGitStatusPorcelain } from "../../../src/tui/workbench/project-tree/gitStatus.js";
 import { ProjectTreeStore } from "../../../src/tui/workbench/project-tree/ProjectTreeStore.js";
 
 describe("project tree helpers", () => {
@@ -117,6 +117,45 @@ describe("project tree helpers", () => {
 
       expect(status.get(fileName)).toBe("untracked");
       expect([...status.keys()]).not.toContain("\"\\303\\251.ts\"");
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves git file paths with leading and trailing spaces", async () => {
+    const repo = await mkdtemp(join(tmpdir(), "agenc-tree-git-files-"));
+    const leading = " spaced.ts";
+    const trailing = "trailing.ts ";
+
+    try {
+      execFileSync("git", ["init"], { cwd: repo, stdio: "ignore" });
+      await writeFile(join(repo, leading), "leading\n", "utf8");
+      await writeFile(join(repo, trailing), "trailing\n", "utf8");
+
+      await expect(listGitFiles(repo)).resolves.toEqual([leading, trailing]);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("collects renamed git status for paths containing rename separators", async () => {
+    const repo = await mkdtemp(join(tmpdir(), "agenc-tree-git-rename-"));
+    const oldPath = "a -> b.ts";
+    const newPath = "c -> d.ts";
+
+    try {
+      execFileSync("git", ["init"], { cwd: repo, stdio: "ignore" });
+      execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repo, stdio: "ignore" });
+      execFileSync("git", ["config", "user.name", "Test User"], { cwd: repo, stdio: "ignore" });
+      await writeFile(join(repo, oldPath), "renamed\n", "utf8");
+      execFileSync("git", ["add", oldPath], { cwd: repo, stdio: "ignore" });
+      execFileSync("git", ["commit", "-m", "init"], { cwd: repo, stdio: "ignore" });
+      execFileSync("git", ["mv", oldPath, newPath], { cwd: repo, stdio: "ignore" });
+
+      const status = await collectGitStatus(repo);
+
+      expect(status.get(newPath)).toBe("renamed");
+      expect(status.has("d.ts")).toBe(false);
     } finally {
       await rm(repo, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Switch project tree Git file and status collectors to NUL-delimited output.
- Preserve leading/trailing spaces in Git-discovered workspace paths.
- Preserve renamed status decoration for paths that contain the rename separator text.

## Test plan
- Failing-first: `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/project-tree.test.ts --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/project-tree.test.ts tests/tui/workbench/project-explorer-interactions.test.tsx tests/tui/workbench/render.test.tsx --reporter=dot`
- `git diff --check`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` (fails on existing unrelated Knip backlog: unused `src/tui/workbench/keymap.ts`, 30 unused exports, 4 unused tag hints)
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`