### PR TITLE
fix(tui): log workbench surface read failures

### DIFF
--- a/runtime/src/tui/workbench/surfaces/AgentSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/AgentSurface.tsx
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import React, { useEffect, useMemo, useState } from "react";
 
+import { logError } from "../../../utils/log.js";
 import { getTaskOutputPath } from "../../../utils/task/diskOutput.js";
 import { tailFile } from "../../../utils/fsOperations.js";
 import { Box, Text } from "../../ink.js";
@@ -41,7 +42,8 @@ export function AgentSurface({ focused }: { readonly focused: boolean }): React.
         .then((result) => {
           if (mounted) setTailState({ taskId, content: result.content });
         })
-        .catch(() => {
+        .catch((error) => {
+          logError(error);
           // Keep the last successful tail visible across transient read failures.
         });
     };

--- a/runtime/src/tui/workbench/surfaces/PreviewSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/PreviewSurface.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useMemo, useState } from "react";
 
 import { peekLSPDiagnosticsForFile } from "../../../services/lsp/LSPDiagnosticRegistry.js";
 import { getCwd } from "../../../utils/cwd.js";
+import { logError } from "../../../utils/log.js";
 import { readFileInRange } from "../../../utils/readFileInRange.js";
 import { Box, Text } from "../../ink.js";
 import { useKeybindings } from "../../keybindings/useKeybinding.js";
@@ -96,7 +97,8 @@ export function PreviewSurface({ focused }: { readonly focused: boolean }): Reac
       .then((status) => {
         if (mounted) setGitStateState({ path: statusPath, status: status.get(statusPath) ?? "clean" });
       })
-      .catch(() => {
+      .catch((error) => {
+        logError(error);
         if (mounted) setGitStateState({ path: statusPath, status: null });
       });
     return () => {

--- a/runtime/src/tui/workbench/surfaces/ShellSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/ShellSurface.tsx
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import React, { useEffect, useMemo, useState } from "react";
 
+import { logError } from "../../../utils/log.js";
 import { getTaskOutputPath } from "../../../utils/task/diskOutput.js";
 import { tailFile } from "../../../utils/fsOperations.js";
 import { Box, Text } from "../../ink.js";
@@ -44,7 +45,8 @@ export function ShellSurface({ focused }: { readonly focused: boolean }): React.
         .then((result) => {
           if (mounted) setTailState({ taskId, content: result.content });
         })
-        .catch(() => {
+        .catch((error) => {
+          logError(error);
           // Keep the last successful tail visible across transient read failures.
         });
     };

--- a/runtime/src/tui/workbench/surfaces/TestSurface.tsx
+++ b/runtime/src/tui/workbench/surfaces/TestSurface.tsx
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import React, { useEffect, useMemo, useState } from "react";
 
+import { logError } from "../../../utils/log.js";
 import { getTaskOutputPath } from "../../../utils/task/diskOutput.js";
 import { tailFile } from "../../../utils/fsOperations.js";
 import { Box, Text } from "../../ink.js";
@@ -47,7 +48,8 @@ export function TestSurface({ focused }: { readonly focused: boolean }): React.R
         .then((result) => {
           if (mounted) setTailState({ taskId, content: result.content });
         })
-        .catch(() => {
+        .catch((error) => {
+          logError(error);
           // Keep the last successful tail visible across transient read failures.
         });
     };

--- a/runtime/tests/tui/workbench/agent-surface.test.tsx
+++ b/runtime/tests/tui/workbench/agent-surface.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const keybindingHarness = vi.hoisted(() => ({
   deferredTaskIds: new Set<string>(),
   handlers: {} as Record<string, () => void>,
+  logError: vi.fn(),
   pendingReads: new Map<string, (result: { content: string }) => void>(),
   readCounts: {} as Record<string, number>,
   rejectOnRead: {} as Record<string, number>,
@@ -41,6 +42,10 @@ vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
   },
 }));
 
+vi.mock("../../../src/utils/log.js", () => ({
+  logError: keybindingHarness.logError,
+}));
+
 import { createRoot } from "../../../src/tui/ink.js";
 import { getInkInstance } from "../../../src/tui/ink/instances.js";
 import { cellAt } from "../../../src/tui/ink/screen.js";
@@ -59,6 +64,7 @@ describe("AgentSurface", () => {
   beforeEach(() => {
     keybindingHarness.deferredTaskIds = new Set();
     keybindingHarness.handlers = {};
+    keybindingHarness.logError.mockReset();
     keybindingHarness.pendingReads = new Map();
     keybindingHarness.readCounts = {};
     keybindingHarness.rejectOnRead = {};
@@ -251,6 +257,9 @@ describe("AgentSurface", () => {
 
       expect(compact(screenText(stdout))).toContain("currentagentoutput");
       expect(compact(screenText(stdout))).not.toContain("(nooutput)");
+      expect(keybindingHarness.logError.mock.calls.some(([error]) =>
+        error instanceof Error && error.message === "tail failed for agent-1"
+      )).toBe(true);
     } finally {
       root.unmount();
       stdin.end();

--- a/runtime/tests/tui/workbench/preview-surface-git-state.test.tsx
+++ b/runtime/tests/tui/workbench/preview-surface-git-state.test.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const previewHarness = vi.hoisted(() => ({
+  logError: vi.fn(),
   statusReads: [] as Array<{
     readonly resolve: (status: Map<string, string>) => void;
     readonly reject: (error: unknown) => void;
@@ -37,6 +38,10 @@ vi.mock("../../../src/tui/workbench/project-tree/gitStatus.js", () => ({
 vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
   useKeybinding: () => {},
   useKeybindings: () => {},
+}));
+
+vi.mock("../../../src/utils/log.js", () => ({
+  logError: previewHarness.logError,
 }));
 
 import { createRoot } from "../../../src/tui/ink.js";
@@ -115,6 +120,7 @@ function PreviewTargetController({
 
 describe("PreviewSurface git state", () => {
   beforeEach(() => {
+    previewHarness.logError.mockReset();
     previewHarness.statusReads = [];
   });
 
@@ -155,6 +161,46 @@ describe("PreviewSurface git state", () => {
       await sleep();
 
       expect(screenLine(stdout, 0)).toContain("new.ts [read-only");
+      expect(screenLine(stdout, 0)).not.toContain("modified");
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+    }
+  });
+
+  it("logs git status refresh failures without showing stale status", async () => {
+    const statusError = new Error("status unavailable");
+    const { stdin, stdout } = createStreams();
+    const root = await createRoot({
+      patchConsole: false,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+    });
+
+    try {
+      root.render(
+        <AppStateProvider
+          initialState={{
+            ...getDefaultAppState(),
+            workbench: {
+              ...getDefaultAppState().workbench,
+              activeSurfaceMode: "preview",
+              activeFilePath: "target.ts",
+              activeFileLine: 1,
+            },
+          }}
+        >
+          <PreviewSurface focused={false} />
+        </AppStateProvider>,
+      );
+
+      const statusRead = await waitForStatusRead(0);
+      statusRead.reject(statusError);
+      await sleep();
+
+      expect(previewHarness.logError).toHaveBeenCalledWith(statusError);
+      expect(screenLine(stdout, 0)).toContain("target.ts [read-only");
       expect(screenLine(stdout, 0)).not.toContain("modified");
     } finally {
       root.unmount();

--- a/runtime/tests/tui/workbench/shell-surface.test.tsx
+++ b/runtime/tests/tui/workbench/shell-surface.test.tsx
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const shellHarness = vi.hoisted(() => ({
   deferredTaskIds: new Set<string>(),
   handlers: {} as Record<string, () => void>,
+  logError: vi.fn(),
   pendingReads: new Map<string, (result: { content: string }) => void>(),
   readCounts: {} as Record<string, number>,
   rejectOnRead: {} as Record<string, number>,
@@ -42,6 +43,10 @@ vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
   },
 }));
 
+vi.mock("../../../src/utils/log.js", () => ({
+  logError: shellHarness.logError,
+}));
+
 import { createRoot } from "../../../src/tui/ink.js";
 import { getInkInstance } from "../../../src/tui/ink/instances.js";
 import { cellAt } from "../../../src/tui/ink/screen.js";
@@ -60,6 +65,7 @@ describe("ShellSurface", () => {
   beforeEach(() => {
     shellHarness.deferredTaskIds = new Set();
     shellHarness.handlers = {};
+    shellHarness.logError.mockReset();
     shellHarness.pendingReads = new Map();
     shellHarness.readCounts = {};
     shellHarness.rejectOnRead = {};
@@ -284,6 +290,9 @@ describe("ShellSurface", () => {
 
       expect(compact(screenText(stdout))).toContain("src/current-task.ts:7");
       expect(compact(screenText(stdout))).not.toContain("(nooutput)");
+      expect(shellHarness.logError.mock.calls.some(([error]) =>
+        error instanceof Error && error.message === "tail failed for shell-1"
+      )).toBe(true);
     } finally {
       root.unmount();
       stdin.end();

--- a/runtime/tests/tui/workbench/test-surface.test.tsx
+++ b/runtime/tests/tui/workbench/test-surface.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const keybindingHarness = vi.hoisted(() => ({
   deferredTaskIds: new Set<string>(),
   handlers: {} as Record<string, () => void>,
+  logError: vi.fn(),
   pendingReads: new Map<string, (result: { content: string }) => void>(),
   readCounts: {} as Record<string, number>,
   rejectOnRead: {} as Record<string, number>,
@@ -41,6 +42,10 @@ vi.mock("../../../src/tui/keybindings/useKeybinding.js", () => ({
   },
 }));
 
+vi.mock("../../../src/utils/log.js", () => ({
+  logError: keybindingHarness.logError,
+}));
+
 import { createRoot } from "../../../src/tui/ink.js";
 import { getInkInstance } from "../../../src/tui/ink/instances.js";
 import { cellAt } from "../../../src/tui/ink/screen.js";
@@ -59,6 +64,7 @@ describe("TestSurface", () => {
   beforeEach(() => {
     keybindingHarness.deferredTaskIds = new Set();
     keybindingHarness.handlers = {};
+    keybindingHarness.logError.mockReset();
     keybindingHarness.pendingReads = new Map();
     keybindingHarness.readCounts = {};
     keybindingHarness.rejectOnRead = {};
@@ -226,6 +232,9 @@ describe("TestSurface", () => {
 
       expect(compact(screenText(stdout))).toContain("firstfailure");
       expect(compact(screenText(stdout))).not.toContain("Noparsedtestfailures");
+      expect(keybindingHarness.logError.mock.calls.some(([error]) =>
+        error instanceof Error && error.message === "tail failed for shell-1"
+      )).toBe(true);
     } finally {
       root.unmount();
       stdin.end();


### PR DESCRIPTION
## Summary
- Log rejected workbench tail reads in shell, test, and agent surfaces while preserving the last successful output.
- Log rejected preview git-status refreshes while keeping stale status out of the header.
- Add regressions for the rejected read/status paths.

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/shell-surface.test.tsx tests/tui/workbench/test-surface.test.tsx tests/tui/workbench/agent-surface.test.tsx tests/tui/workbench/preview-surface-git-state.test.tsx --reporter=dot
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/shell-surface.test.tsx tests/tui/workbench/test-surface.test.tsx tests/tui/workbench/agent-surface.test.tsx tests/tui/workbench/preview-surface.test.tsx tests/tui/workbench/preview-surface-git-state.test.tsx tests/tui/workbench/preview-surface-scroll.test.tsx tests/tui/workbench/preview-surface-clamped-content.test.tsx --reporter=dot
- git diff --check
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails only on existing Knip backlog: src/tui/workbench/keymap.ts, 30 unused exports, 4 unused @internal tag hints)
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core