### PR TITLE
fix(tui): log fullscreen hyperlink open failures

### DIFF
--- a/runtime/src/tui/components/FullscreenLayout.tsx
+++ b/runtime/src/tui/components/FullscreenLayout.tsx
@@ -13,6 +13,7 @@ import { Box, Text } from '../ink.js';
 import type { Message } from '../../types/message';
 import { openBrowser, openPath } from '../../utils/browser.js';
 import { isFullscreenEnvEnabled } from '../../utils/fullscreen.js';
+import { logError } from '../../utils/log.js';
 import { plural } from '../../utils/stringUtils.js';
 import { modelDisplayString } from '../../utils/model/model.js';
 import { getTotalCost } from '../../cost/tracker.js';
@@ -675,13 +676,21 @@ function _temp3() {
     ink.onHyperlinkClick = undefined;
   };
 }
+function openFullscreenHyperlinkTarget(result, failureMessage) {
+  void Promise.resolve(result).then((opened) => {
+    if (opened === false) logError(new Error(failureMessage));
+  }, logError);
+}
 function _temp2(url) {
   if (url.startsWith("file:")) {
     try {
-      openPath(fileURLToPath(url));
-    } catch {}
+      const filePath = fileURLToPath(url);
+      openFullscreenHyperlinkTarget(openPath(filePath), `Failed to open path: ${filePath}`);
+    } catch (error) {
+      logError(error);
+    }
   } else {
-    openBrowser(url);
+    openFullscreenHyperlinkTarget(openBrowser(url), `Failed to open URL: ${url}`);
   }
 }
 function _temp() {}

--- a/runtime/tests/tui/coverage-swarm/swarm-019-components-FullscreenLayout.test.tsx
+++ b/runtime/tests/tui/coverage-swarm/swarm-019-components-FullscreenLayout.test.tsx
@@ -5,11 +5,16 @@ import stripAnsi from 'strip-ansi'
 import { describe, expect, test, vi } from 'vitest'
 
 const browser = vi.hoisted(() => ({
+  logError: vi.fn(),
   openBrowser: vi.fn(),
   openPath: vi.fn(),
 }))
 
 vi.mock('../../../src/utils/browser.js', () => browser)
+
+vi.mock('../../../src/utils/log.js', () => ({
+  logError: browser.logError,
+}))
 
 import { createRoot, Text } from '../../../src/tui/ink.js'
 import {
@@ -356,8 +361,11 @@ describe('FullscreenLayout coverage swarm 019', () => {
   })
 
   test('routes fullscreen hyperlink clicks to file and browser openers', async () => {
+    const browserFailure = new Error('browser failed')
+    browser.logError.mockClear()
     browser.openBrowser.mockClear()
     browser.openPath.mockClear()
+    browser.openBrowser.mockRejectedValueOnce(browserFailure)
     const fakeInk = {} as { onHyperlinkClick?: (url: string) => void }
     setInkInstance(process.stdout, fakeInk as never)
 
@@ -384,14 +392,22 @@ describe('FullscreenLayout coverage swarm 019', () => {
         fakeInk.onHyperlinkClick?.('file:///tmp/agenc-layout-marker.txt')
         fakeInk.onHyperlinkClick?.('https://example.test/docs')
         fakeInk.onHyperlinkClick?.('file://%zz')
+        fakeInk.onHyperlinkClick?.('https://example.test/ok')
+        await sleep()
 
         expect(browser.openPath).toHaveBeenCalledTimes(1)
         expect(browser.openPath).toHaveBeenCalledWith(
           '/tmp/agenc-layout-marker.txt',
         )
-        expect(browser.openBrowser).toHaveBeenCalledWith(
+        expect(browser.openBrowser).toHaveBeenNthCalledWith(
+          1,
           'https://example.test/docs',
         )
+        expect(browser.openBrowser).toHaveBeenNthCalledWith(2, 'https://example.test/ok')
+        expect(browser.logError).toHaveBeenCalledWith(browserFailure)
+        expect(browser.logError.mock.calls.some(([error]) =>
+          error instanceof Error && error.message.includes('Invalid URL')
+        )).toBe(true)
       })
     } finally {
       root.unmount()


### PR DESCRIPTION
## Summary
- Log invalid fullscreen `file:` hyperlinks instead of swallowing URL parse failures.
- Catch and log rejected fullscreen browser/path opener promises while keeping hyperlink handling nonblocking.
- Add regression coverage through the existing fullscreen hyperlink routing test.

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/coverage-swarm/swarm-019-components-FullscreenLayout.test.tsx --reporter=dot
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/FullscreenLayout.test.tsx tests/tui/components/FullscreenLayout.render-branches.test.tsx tests/tui/components/FullscreenLayout.coverage2.test.tsx tests/tui/components/FullscreenLayout.wave200-018.coverage.test.tsx tests/tui/coverage-swarm/swarm-019-components-FullscreenLayout.test.tsx --reporter=dot
- git diff --check
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails only on existing Knip backlog: src/tui/workbench/keymap.ts, 30 unused exports, 4 unused @internal tag hints)
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core