### PR TITLE
fix(tui): log ink selection clipboard failures

### DIFF
--- a/runtime/src/tui/ink/ink.tsx
+++ b/runtime/src/tui/ink/ink.tsx
@@ -1058,7 +1058,7 @@ export default class Ink {
       // drops it silently unless allow-passthrough is on — no regression).
       void setClipboard(text).then(raw => {
         if (raw) this.options.stdout.write(raw);
-      });
+      }).catch(logError);
     }
     return text;
   }

--- a/runtime/tests/tui/ink/ink.render.test.tsx
+++ b/runtime/tests/tui/ink/ink.render.test.tsx
@@ -14,6 +14,7 @@ import { CURSOR_HOME, ERASE_SCREEN } from './termio/csi.ts'
 import { ENABLE_MOUSE_TRACKING, ENTER_ALT_SCREEN } from './termio/dec.ts'
 
 const clipboardMock = vi.hoisted(() => ({
+  logError: vi.fn(),
   setClipboard: vi.fn(async (_text: string) => ''),
   supportsTabStatus: vi.fn(() => false),
 }))
@@ -26,6 +27,10 @@ vi.mock('./termio/osc.js', async importOriginal => {
     supportsTabStatus: clipboardMock.supportsTabStatus,
   }
 })
+
+vi.mock('../../utils/log.js', () => ({
+  logError: clipboardMock.logError,
+}))
 
 vi.mock('../../utils/fullscreen.js', () => ({
   isMouseClicksDisabled: () => false,
@@ -277,6 +282,28 @@ describe('Ink instance rendering paths', () => {
       expect(selectionChanges).toHaveLength(afterCopyChanges)
 
       unsubscribe()
+    } finally {
+      await harness.dispose()
+    }
+  })
+
+  test('logs rejected clipboard writes while preserving copied selection text', async () => {
+    const error = new Error('clipboard write failed')
+    clipboardMock.logError.mockClear()
+    clipboardMock.setClipboard.mockRejectedValueOnce(error)
+    const harness = await createHarness({ columns: 40, rows: 6 })
+
+    try {
+      harness.instance.setAltScreenActive(true)
+      harness.root.render(textNode('alpha beta'))
+      await sleep(10)
+
+      harness.instance.handleMultiClick(1, 0, 2)
+
+      expect(harness.instance.copySelectionNoClear()).toBe('alpha')
+      expect(harness.instance.hasTextSelection()).toBe(true)
+      await sleep(10)
+      expect(clipboardMock.logError).toHaveBeenCalledWith(error)
     } finally {
       await harness.dispose()
     }


### PR DESCRIPTION
## Summary
- Catch and log rejected Ink selection clipboard writes.
- Preserve copied text and selection highlighting when clipboard copy fails.
- Add regression coverage for the previously unhandled rejection path.

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/ink/ink.render.test.tsx --reporter=dot
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/ink/ink.render.test.tsx tests/tui/ink/ink.coverage2.test.tsx tests/tui/ink/ink.wave200-004.coverage.test.tsx tests/tui/ink/selection.test.ts tests/tui/ink/selection.wave200-046.coverage.test.ts tests/tui/ink/hooks/use-selection.wave200-113.coverage.test.ts tests/tui/ink/termio/osc.test.ts tests/tui/ink/termio/osc.wave200-025.coverage.test.ts --reporter=dot
- git diff --check
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails only on existing Knip backlog: src/tui/workbench/keymap.ts, 30 unused exports, 4 unused @internal tag hints)
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core