### PR TITLE
fix(tui): log terminal query write failures

### DIFF
--- a/runtime/src/tui/ink/terminal-querier.ts
+++ b/runtime/src/tui/ink/terminal-querier.ts
@@ -23,6 +23,7 @@
 import type { TerminalResponse } from './parse-keypress.js'
 import { csi } from './termio/csi.js'
 import { osc } from './termio/osc.js'
+import { logError } from '../../utils/log.js'
 
 /** A terminal query: an outbound request sequence paired with a matcher
  *  that recognizes the expected inbound response. Built by `decrqm()`,
@@ -185,12 +186,15 @@ export class TerminalQuerier {
         resolve(undefined)
         return
       }
-      this.queue.push({
+      const pending: Pending = {
         kind: 'query',
         match: query.match,
         resolve: r => resolve(r as T | undefined),
+      }
+      this.queue.push(pending)
+      this.writeWhenRawModeReady(query.request, error => {
+        this.resolveFailedQueryWrite(pending, error)
       })
-      this.writeWhenRawModeReady(query.request)
     })
   }
 
@@ -217,8 +221,11 @@ export class TerminalQuerier {
         resolve()
         return
       }
-      this.queue.push({ kind: 'sentinel', resolve })
-      this.writeWhenRawModeReady(SENTINEL)
+      const pending: Pending = { kind: 'sentinel', resolve }
+      this.queue.push(pending)
+      this.writeWhenRawModeReady(SENTINEL, error => {
+        this.resolveFailedSentinelWrite(pending, error)
+      })
     })
   }
 
@@ -236,20 +243,52 @@ export class TerminalQuerier {
    *  handle was provided. Polls with `setImmediate` up to RAW_MODE_POLL_LIMIT
    *  ticks before falling back to a direct write so the queue can't
    *  deadlock on a misconfigured caller. */
-  private writeWhenRawModeReady(data: string): void {
+  private writeWhenRawModeReady(
+    data: string,
+    onWriteError: (error: unknown) => void,
+  ): void {
+    const write = (): void => {
+      try {
+        this.stdout.write(data)
+      } catch (error) {
+        onWriteError(error)
+      }
+    }
     if (this.isRawModeReady()) {
-      this.stdout.write(data)
+      write()
       return
     }
     let attempts = 0
     const tryWrite = (): void => {
       if (this.isRawModeReady() || ++attempts >= RAW_MODE_POLL_LIMIT) {
-        this.stdout.write(data)
+        write()
         return
       }
       setImmediate(tryWrite)
     }
     setImmediate(tryWrite)
+  }
+
+  private resolveFailedQueryWrite(pending: Pending, error: unknown): void {
+    logError(error)
+    const idx = this.queue.indexOf(pending)
+    if (idx === -1) return
+    const [removed] = this.queue.splice(idx, 1)
+    if (removed?.kind === 'query') removed.resolve(undefined)
+  }
+
+  private resolveFailedSentinelWrite(pending: Pending, error: unknown): void {
+    logError(error)
+    const idx = this.queue.indexOf(pending)
+    if (idx === -1) return
+    this.resolveQueueThrough(idx)
+  }
+
+  private resolveQueueThrough(index: number): void {
+    for (const p of this.queue.splice(0, index + 1)) {
+      if (p.kind === 'query') p.resolve(undefined)
+      else p.resolve()
+    }
   }
 
   /**
@@ -281,10 +320,7 @@ export class TerminalQuerier {
     if (r.type === 'da1') {
       const s = this.queue.findIndex(p => p.kind === 'sentinel')
       if (s === -1) return
-      for (const p of this.queue.splice(0, s + 1)) {
-        if (p.kind === 'query') p.resolve(undefined)
-        else p.resolve()
-      }
+      this.resolveQueueThrough(s)
     }
   }
 }

--- a/runtime/tests/tui/ink/terminal-querier.test.ts
+++ b/runtime/tests/tui/ink/terminal-querier.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import {
   TerminalQuerier,
@@ -8,14 +8,23 @@ import {
 } from './terminal-querier.ts'
 import type { TerminalResponse } from './parse-keypress.ts'
 
+const logMock = vi.hoisted(() => ({
+  logError: vi.fn(),
+}))
+
+vi.mock('../../utils/log.js', () => ({
+  logError: logMock.logError,
+}))
+
 /** Minimal writable stub: records every chunk written. */
-function makeStdout(): {
+function makeStdout(writeImpl?: (chunk: string | Uint8Array) => boolean): {
   stdout: NodeJS.WriteStream
   writes: string[]
 } {
   const writes: string[] = []
   const stdout = {
     write: (chunk: string | Uint8Array): boolean => {
+      if (writeImpl !== undefined) return writeImpl(chunk)
       writes.push(
         typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8'),
       )
@@ -31,6 +40,10 @@ function nextTick(): Promise<void> {
 }
 
 describe('TerminalQuerier write gating', () => {
+  beforeEach(() => {
+    logMock.logError.mockClear()
+  })
+
   test('writes immediately when no stdin handle is provided (legacy path)', () => {
     const { stdout, writes } = makeStdout()
     const q = new TerminalQuerier(stdout)
@@ -164,5 +177,53 @@ describe('TerminalQuerier write gating', () => {
     q.onResponse({ type: 'da1', params: [] } as unknown as TerminalResponse)
     const [r2] = await batch2
     expect(r2).toBeUndefined()
+  })
+
+  test('send() logs write failures and resolves undefined instead of rejecting', async () => {
+    const error = new Error('write failed')
+    const { stdout } = makeStdout(() => {
+      throw error
+    })
+    const stdin: QuerierStdin = { isTTY: true, isRaw: true }
+    const q = new TerminalQuerier(stdout, stdin)
+
+    await expect(q.send(xtversion())).resolves.toBeUndefined()
+
+    expect(logMock.logError).toHaveBeenCalledWith(error)
+  })
+
+  test('deferred send() logs write failures after raw mode becomes ready', async () => {
+    const error = new Error('deferred write failed')
+    const { stdout } = makeStdout(() => {
+      throw error
+    })
+    const stdin: QuerierStdin = { isTTY: true, isRaw: false }
+    const q = new TerminalQuerier(stdout, stdin)
+
+    const pending = q.send(xtversion())
+    await nextTick()
+    expect(logMock.logError).not.toHaveBeenCalled()
+
+    stdin.isRaw = true
+    await nextTick()
+
+    await expect(pending).resolves.toBeUndefined()
+    expect(logMock.logError).toHaveBeenCalledWith(error)
+  })
+
+  test('flush() logs sentinel write failures and drains queued queries', async () => {
+    const error = new Error('sentinel write failed')
+    const { stdout } = makeStdout(chunk => {
+      if (chunk === '\x1b[c') throw error
+      return true
+    })
+    const stdin: QuerierStdin = { isTTY: true, isRaw: true }
+    const q = new TerminalQuerier(stdout, stdin)
+
+    const pending = q.send(xtversion())
+    await expect(q.flush()).resolves.toBeUndefined()
+
+    await expect(pending).resolves.toBeUndefined()
+    expect(logMock.logError).toHaveBeenCalledWith(error)
   })
 })


### PR DESCRIPTION
## Summary
- catch stdout write failures inside the terminal query layer so `send()` and `flush()` keep their no-reject/no-hang contract
- log immediate, deferred raw-mode, and sentinel write failures through the shared error logger
- add regression coverage for query and flush write failure paths

## Test plan
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/ink/terminal-querier.test.ts --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/ink/terminal-querier.test.ts tests/tui/coverage-swarm/swarm-055-ink-terminal-querier.test.ts tests/tui/ink/systemThemeWatcher.test.ts tests/tui/ink/components/App.coverage2.test.tsx tests/tui/ink/components/App.wave200-011.coverage.test.tsx --reporter=dot`
- `git diff --check`
- branding scan over `runtime/src` and `runtime/tests`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

## Known existing issue
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.