### PR TITLE
fix(tui): log history selection failures

### DIFF
--- a/runtime/src/tui/history/HistorySearchDialog.tsx
+++ b/runtime/src/tui/history/HistorySearchDialog.tsx
@@ -120,9 +120,10 @@ export function HistorySearchDialog({
       if (!isMountedRef.current) return;
       isSelectionResolvingRef.current = false;
       onSelect(entry);
-    }, () => {
+    }, error => {
       if (!isMountedRef.current) return;
       isSelectionResolvingRef.current = false;
+      logError(error);
       logEvent('agenc_history_picker_select_error', {
         query_length: query.length
       });

--- a/runtime/tests/tui/history/HistorySearchDialog.coverage.test.tsx
+++ b/runtime/tests/tui/history/HistorySearchDialog.coverage.test.tsx
@@ -418,6 +418,51 @@ describe('HistorySearchDialog coverage', () => {
     expect(rendered.onSelect).not.toHaveBeenCalled()
   })
 
+  it('logs rejected history selection resolution and allows retry', async () => {
+    const selectError = new Error('history entry resolve failed')
+    const resolvedEntry = { display: 'retry prompt' }
+    const resolveEntry = vi
+      .fn<() => Promise<HistoryEntryLike>>()
+      .mockRejectedValueOnce(selectError)
+      .mockResolvedValueOnce(resolvedEntry)
+    harness.entries = [
+      {
+        display: 'retry prompt',
+        timestamp: 1710000000000,
+        resolve: resolveEntry,
+      },
+    ]
+
+    const rendered = await renderDialog()
+
+    try {
+      await waitFor(
+        () => pickerProps().items.length === 1,
+        'History search item did not load',
+      )
+
+      const selectedItem = pickerProps().items[0]!
+      pickerProps().onSelect(selectedItem)
+
+      await waitFor(
+        () => harness.logError.mock.calls.some(call => call[0] === selectError),
+        'History selection failure was not logged',
+      )
+      expect(rendered.onSelect).not.toHaveBeenCalled()
+
+      pickerProps().onSelect(selectedItem)
+      await waitFor(
+        () => rendered.onSelect.mock.calls.length === 1,
+        'History selection did not allow retry after rejection',
+      )
+
+      expect(resolveEntry).toHaveBeenCalledTimes(2)
+      expect(rendered.onSelect).toHaveBeenCalledWith(resolvedEntry)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   it('logs rejected history loads and clears the loading state', async () => {
     const error = new Error('history reader failed')
     harness.readerNextError = error


### PR DESCRIPTION
## Summary
- log rejected history entry resolution through the shared error logger
- preserve the existing selection retry behavior after a failed history resolve
- add focused regression coverage for failed selection followed by a successful retry

## Test plan
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/history/HistorySearchDialog.coverage.test.tsx --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/history/HistorySearchDialog.coverage.test.tsx tests/tui/coverage-swarm/swarm-190-history-HistorySearchDialog.test.tsx tests/tui/components/PromptInput/PromptInput.render.test.tsx tests/tui/coverage-swarm/swarm-001-components-PromptInput-PromptInput.test.tsx --reporter=dot`
- `git diff --check`
- branding scan over `runtime/src` and `runtime/tests`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

## Known existing issue
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.