### PR TITLE
fix(tui): log permission metric failures

### DIFF
--- a/runtime/src/tui/hooks/toolPermission/permissionLogging.ts
+++ b/runtime/src/tui/hooks/toolPermission/permissionLogging.ts
@@ -10,6 +10,7 @@ import { sanitizeToolNameForAnalytics } from '../../../services/analytics/metada
 import { getCodeEditToolDecisionCounter } from '../../../bootstrap/state.js'
 import type { Tool as ToolType, ToolUseContext } from '../../../tools/Tool.js'
 import { getLanguageName } from '../../../utils/cliHighlight.js'
+import { logError } from '../../../utils/log.js'
 import { SandboxManager } from '../../../utils/sandbox/sandbox-runtime.js'
 import { logOTelEvent } from '../../../utils/telemetry/events.js'
 import type {
@@ -213,7 +214,14 @@ function logPermissionDecision(
   // Track code editing tool metrics
   if (isCodeEditingTool(tool.name)) {
     void buildCodeEditToolAttributes(tool, input, decision, sourceString).then(
-      attributes => getCodeEditToolDecisionCounter()?.add(1, attributes),
+      attributes => {
+        try {
+          getCodeEditToolDecisionCounter()?.add(1, attributes)
+        } catch (error) {
+          logError(error)
+        }
+      },
+      logError,
     )
   }
 

--- a/runtime/tests/tui/hooks/toolPermission/permissionLogging.wave200-028.coverage.test.ts
+++ b/runtime/tests/tui/hooks/toolPermission/permissionLogging.wave200-028.coverage.test.ts
@@ -7,6 +7,7 @@ const harness = vi.hoisted(() => ({
   features: new Set<string>(),
   getCodeEditToolDecisionCounter: vi.fn(),
   getLanguageName: vi.fn(),
+  logError: vi.fn(),
   logEvent: vi.fn(),
   logOTelEvent: vi.fn(),
   sandboxEnabled: true,
@@ -31,6 +32,10 @@ vi.mock('../../../bootstrap/state.js', () => ({
 
 vi.mock('../../../utils/cliHighlight.js', () => ({
   getLanguageName: harness.getLanguageName,
+}))
+
+vi.mock('../../../utils/log.js', () => ({
+  logError: harness.logError,
 }))
 
 vi.mock('../../../utils/sandbox/sandbox-runtime.js', () => ({
@@ -109,6 +114,7 @@ describe('permissionLogging coverage', () => {
     harness.getCodeEditToolDecisionCounter.mockReturnValue(harness.counter)
     harness.getLanguageName.mockReset()
     harness.getLanguageName.mockResolvedValue('TypeScript')
+    harness.logError.mockClear()
     harness.logEvent.mockClear()
     harness.logOTelEvent.mockClear()
     harness.sandboxEnabled = true
@@ -321,5 +327,65 @@ describe('permissionLogging coverage', () => {
       source: 'user_abort',
       tool_name: 'safe:Read',
     })
+  })
+
+  test('logs rejected code-edit metric enrichment without dropping the decision', async () => {
+    const languageError = new Error('language detection failed')
+    harness.getLanguageName.mockRejectedValueOnce(languageError)
+    const editDecision = context({
+      tool: tool('Write'),
+      toolUseID: 'write-1',
+    })
+
+    logPermissionDecision(
+      editDecision.ctx as never,
+      { decision: 'accept', source: { type: 'user', permanent: false } },
+      1_750,
+    )
+    await flushMicrotasks()
+
+    expect(editDecision.toolUseContext.toolDecisions?.get('write-1')).toEqual({
+      decision: 'accept',
+      source: 'user_temporary',
+      timestamp: 2_000,
+    })
+    expect(harness.counter.add).not.toHaveBeenCalled()
+    expect(harness.logError).toHaveBeenCalledWith(languageError)
+    expect(harness.logOTelEvent).toHaveBeenCalledWith('tool_decision', {
+      decision: 'accept',
+      source: 'user_temporary',
+      tool_name: 'safe:Write',
+    })
+  })
+
+  test('logs thrown code-edit counter updates without dropping the decision', async () => {
+    const counterError = new Error('counter backend failed')
+    harness.counter.add.mockImplementationOnce(() => {
+      throw counterError
+    })
+    const editDecision = context({
+      tool: tool('Edit'),
+      toolUseID: 'edit-counter-1',
+    })
+
+    logPermissionDecision(
+      editDecision.ctx as never,
+      { decision: 'reject', source: { type: 'hook' } },
+      1_500,
+    )
+    await flushMicrotasks()
+
+    expect(editDecision.toolUseContext.toolDecisions?.get('edit-counter-1')).toEqual({
+      decision: 'reject',
+      source: 'hook',
+      timestamp: 2_000,
+    })
+    expect(harness.counter.add).toHaveBeenCalledWith(1, {
+      decision: 'reject',
+      language: 'TypeScript',
+      source: 'hook',
+      tool_name: 'Edit',
+    })
+    expect(harness.logError).toHaveBeenCalledWith(counterError)
   })
 })


### PR DESCRIPTION
## Summary
- log rejected code-edit metric enrichment in TUI permission logging
- guard thrown code-edit counter updates so detached metrics cannot become unhandled rejections
- preserve permission decision storage and OTel decision logging when metrics fail

## Test plan
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/toolPermission/permissionLogging.wave200-028.coverage.test.ts --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/toolPermission/permissionLogging.wave200-028.coverage.test.ts tests/tui/coverage-swarm/swarm-203-hooks-toolPermission-permissionLogging.test.ts tests/tui/hooks/toolPermission/PermissionContext.test.ts tests/tui/coverage-swarm/swarm-129-hooks-toolPermission-PermissionContext.test.ts --reporter=dot`
- `git diff --check`
- branding scan over `runtime/src` and `runtime/tests`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

## Known existing issue
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing unrelated Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.