### PR TITLE
fix(tui): log auto theme watcher failures

### DIFF
--- a/runtime/src/tui/components/design-system/ThemeProvider.tsx
+++ b/runtime/src/tui/components/design-system/ThemeProvider.tsx
@@ -5,6 +5,7 @@ import { feature } from 'bun:bundle';
 import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { useStdin } from '../../ink/components/StdinContext.js';
 import { getGlobalConfig, saveGlobalConfig } from '../../../utils/config.js'; // upstream-import: keep target is owned by another Z-PURGE item
+import { logError } from '../../../utils/log.js';
 import { getSystemThemeName, type SystemTheme } from '../../../utils/systemTheme.js'; // upstream-import: keep target is owned by another Z-PURGE item
 import type { ThemeName, ThemeSetting } from '../../../utils/theme.js'; // upstream-import: keep target is owned by another Z-PURGE item
 type ThemeContextValue = {
@@ -72,8 +73,12 @@ export function ThemeProvider({
         watchSystemTheme
       }) => {
         if (cancelled) return;
-        cleanup = watchSystemTheme(internal_querier, setSystemTheme);
-      });
+        try {
+          cleanup = watchSystemTheme(internal_querier, setSystemTheme);
+        } catch (error) {
+          logError(error);
+        }
+      }, logError);
       return () => {
         cancelled = true;
         cleanup?.();

--- a/runtime/src/utils/systemThemeWatcher.ts
+++ b/runtime/src/utils/systemThemeWatcher.ts
@@ -4,6 +4,7 @@ import {
   themeFromOscColor,
   type SystemTheme,
 } from './systemTheme.js'
+import { logError } from './log.js'
 
 const OSC_BACKGROUND_COLOR = 11
 const POLL_INTERVAL_MS = 2_000
@@ -20,6 +21,7 @@ export function watchSystemTheme(
     inFlight = true
     try {
       const responsePromise = querier.send(oscColor(OSC_BACKGROUND_COLOR))
+      void responsePromise.catch(() => undefined)
       await querier.flush()
       const response = await responsePromise
       if (cancelled || !response) return
@@ -27,6 +29,8 @@ export function watchSystemTheme(
       if (!theme) return
       setCachedSystemTheme(theme)
       onThemeChange(theme)
+    } catch (error) {
+      logError(error)
     } finally {
       inFlight = false
     }

--- a/runtime/tests/tui/components/design-system/ThemeProvider.wave200-068.coverage.test.tsx
+++ b/runtime/tests/tui/components/design-system/ThemeProvider.wave200-068.coverage.test.tsx
@@ -15,18 +15,22 @@ import {
 const mocks = vi.hoisted(() => {
   const feature = vi.fn(() => false);
   const getGlobalConfig = vi.fn(() => ({ theme: "auto" }));
+  const logError = vi.fn();
   const savedConfigs: unknown[] = [];
   const saveGlobalConfig = vi.fn((update: (current: unknown) => unknown) => {
     savedConfigs.push(update({ retained: true, theme: "dark" }));
   });
   const getSystemThemeName = vi.fn(() => "light");
+  const watchSystemTheme = vi.fn(() => () => {});
 
   return {
     feature,
     getGlobalConfig,
     getSystemThemeName,
+    logError,
     savedConfigs,
     saveGlobalConfig,
+    watchSystemTheme,
   };
 });
 
@@ -41,6 +45,14 @@ vi.mock("../../../utils/config.js", () => ({
 
 vi.mock("../../../utils/systemTheme.js", () => ({
   getSystemThemeName: mocks.getSystemThemeName,
+}));
+
+vi.mock("../../../utils/systemThemeWatcher.js", () => ({
+  watchSystemTheme: mocks.watchSystemTheme,
+}));
+
+vi.mock("../../../utils/log.js", () => ({
+  logError: mocks.logError,
 }));
 
 type TestStdin = PassThrough & {
@@ -180,6 +192,57 @@ describe("ThemeProvider", () => {
 
       expect(mocks.saveGlobalConfig).toHaveBeenCalledTimes(2);
       expect(mocks.savedConfigs).toContainEqual({ retained: true, theme: "auto" });
+    } finally {
+      root.unmount();
+      stdin.end();
+      stdout.end();
+      stderr.end();
+    }
+  });
+
+  test("logs auto-theme watcher startup failures without unmounting the provider", async () => {
+    mocks.feature.mockReturnValue(true);
+    const watcherError = new Error("theme watcher startup failed");
+    mocks.watchSystemTheme.mockImplementationOnce(() => {
+      throw watcherError;
+    });
+    const snapshots: ThemeSnapshot[] = [];
+    const { stderr, stdin, stdout } = createTestStreams();
+    const root = await createRoot({
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream,
+      patchConsole: false,
+    });
+
+    function Probe() {
+      const [theme] = useTheme();
+      const setting = useThemeSetting();
+
+      React.useEffect(() => {
+        snapshots.push({ setting, theme });
+      }, [setting, theme]);
+
+      return <Text>{`${setting}:${theme}`}</Text>;
+    }
+
+    try {
+      root.render(
+        <ThemeProvider initialState="auto" onThemeSave={vi.fn()}>
+          <Probe />
+        </ThemeProvider>,
+      );
+
+      await waitFor(
+        () => mocks.watchSystemTheme.mock.calls.length === 1,
+        "auto theme watcher did not start",
+      );
+      await waitFor(
+        () => mocks.logError.mock.calls.some(([error]) => error === watcherError),
+        "auto theme watcher startup failure was not logged",
+      );
+
+      expect(snapshots.at(-1)).toEqual({ setting: "auto", theme: "light" });
     } finally {
       root.unmount();
       stdin.end();

--- a/runtime/tests/tui/ink/systemThemeWatcher.test.ts
+++ b/runtime/tests/tui/ink/systemThemeWatcher.test.ts
@@ -1,14 +1,37 @@
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
+const logMocks = vi.hoisted(() => ({
+  logError: vi.fn(),
+}))
+
+vi.mock('../../../src/utils/log.js', () => ({
+  logError: logMocks.logError,
+}))
+
 import type { TerminalQuerier } from '../../../src/tui/ink/terminal-querier.js'
 import { watchSystemTheme } from '../../../src/utils/systemThemeWatcher.js'
 
 afterEach(() => {
   vi.useRealTimers()
+  logMocks.logError.mockReset()
 })
 
 function flushMicrotasks(): Promise<void> {
   return Promise.resolve().then(() => undefined)
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>
+  readonly reject: (error: unknown) => void
+  readonly resolve: (value: T) => void
+} {
+  let reject!: (error: unknown) => void
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((innerResolve, innerReject) => {
+    reject = innerReject
+    resolve = innerResolve
+  })
+  return { promise, reject, resolve }
 }
 
 describe('systemThemeWatcher', () => {
@@ -38,5 +61,55 @@ describe('systemThemeWatcher', () => {
     await vi.advanceTimersByTimeAsync(2_000)
 
     expect(send).toHaveBeenCalledTimes(2)
+  })
+
+  test('logs failed OSC polls and resumes polling on the next interval', async () => {
+    vi.useFakeTimers()
+    const pollError = new Error('osc 11 failed')
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({ type: 'osc', code: 11, data: 'rgb:ffff/ffff/ffff' })
+      .mockResolvedValueOnce({ type: 'osc', code: 11, data: 'rgb:0000/0000/0000' })
+    const flush = vi
+      .fn()
+      .mockRejectedValueOnce(pollError)
+      .mockResolvedValueOnce(undefined)
+    const onThemeChange = vi.fn()
+    const querier = { send, flush } as unknown as TerminalQuerier
+
+    const cleanup = watchSystemTheme(querier, onThemeChange)
+    await flushMicrotasks()
+
+    expect(logMocks.logError).toHaveBeenCalledWith(pollError)
+    expect(onThemeChange).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    await flushMicrotasks()
+
+    expect(onThemeChange).toHaveBeenLastCalledWith('dark')
+    expect(send).toHaveBeenCalledTimes(2)
+
+    cleanup()
+  })
+
+  test('observes pending response failures when flush fails first', async () => {
+    vi.useFakeTimers()
+    const flushError = new Error('flush failed')
+    const responseError = new Error('response failed after flush')
+    const response = deferred<{ type: 'osc'; code: 11; data: string }>()
+    const send = vi.fn().mockReturnValueOnce(response.promise)
+    const flush = vi.fn().mockRejectedValueOnce(flushError)
+    const onThemeChange = vi.fn()
+    const querier = { send, flush } as unknown as TerminalQuerier
+
+    const cleanup = watchSystemTheme(querier, onThemeChange)
+    await flushMicrotasks()
+
+    expect(logMocks.logError).toHaveBeenCalledWith(flushError)
+    response.reject(responseError)
+    await flushMicrotasks()
+
+    expect(onThemeChange).not.toHaveBeenCalled()
+    cleanup()
   })
 })


### PR DESCRIPTION
## Summary
- log auto-theme watcher dynamic import and startup failures instead of letting detached promises reject
- catch OSC 11 poll failures inside the system theme watcher and keep interval polling alive
- add focused regression coverage for provider startup and watcher poll failure paths

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/design-system/ThemeProvider.wave200-068.coverage.test.tsx tests/tui/ink/systemThemeWatcher.test.ts --reporter=dot
- git diff --check
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails only on existing unrelated Knip backlog)
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core