### PR TITLE
fix(tui): log image paste callback failures

### DIFF
--- a/runtime/src/tui/hooks/usePasteHandler.ts
+++ b/runtime/src/tui/hooks/usePasteHandler.ts
@@ -205,13 +205,17 @@ export function usePasteHandler({
                   // Successfully read at least one image
                   for (const imageData of validImages) {
                     const filename = basename(imageData.path)
-                    onImagePaste(
-                      imageData.base64,
-                      imageData.mediaType,
-                      filename,
-                      imageData.dimensions,
-                      imageData.path,
-                    )
+                    try {
+                      onImagePaste(
+                        imageData.base64,
+                        imageData.mediaType,
+                        filename,
+                        imageData.dimensions,
+                        imageData.path,
+                      )
+                    } catch (error) {
+                      logError(error as Error)
+                    }
                   }
                   // If some paths were not images or could not be read, paste them as text.
                   const fallbackLines = [
@@ -219,7 +223,11 @@ export function usePasteHandler({
                     ...failedImagePaths,
                   ]
                   if (fallbackLines.length > 0 && onPaste) {
-                    onPaste(fallbackLines.join('\n'))
+                    try {
+                      onPaste(fallbackLines.join('\n'))
+                    } catch (error) {
+                      logError(error as Error)
+                    }
                   }
                   setIsPasting(false)
                 } else if (isTempScreenshot && isMacOS) {
@@ -227,7 +235,11 @@ export function usePasteHandler({
                   checkClipboardForImage()
                 } else {
                   if (onPaste) {
-                    onPaste(pastedText)
+                    try {
+                      onPaste(pastedText)
+                    } catch (error) {
+                      logError(error as Error)
+                    }
                   }
                   setIsPasting(false)
                 }

--- a/runtime/tests/tui/hooks/usePasteHandler.test.ts
+++ b/runtime/tests/tui/hooks/usePasteHandler.test.ts
@@ -364,6 +364,46 @@ describe('usePasteHandler', () => {
     }
   })
 
+  test('logs image paste callback failures and clears paste state', async () => {
+    const imagePath = '/tmp/agenc-callback.png'
+    const callbackError = new Error('image paste callback failed')
+    imagePasteMocks.tryReadImageFromPath.mockResolvedValue({
+      base64: 'image-data',
+      dimensions: {
+        displayHeight: 24,
+        displayWidth: 48,
+        originalHeight: 96,
+        originalWidth: 192,
+      },
+      mediaType: 'image/png',
+      path: imagePath,
+    })
+    const onImagePaste = vi.fn(() => {
+      throw callbackError
+    })
+    const onInput = vi.fn()
+    const onPaste = vi.fn()
+    const rendered = await renderPasteHandler({
+      onImagePaste,
+      onInput,
+      onPaste,
+    })
+
+    try {
+      rendered.latest().wrappedOnInput(imagePath, key(), inputEvent(false))
+
+      await waitForPasteFlush()
+
+      expect(onImagePaste).toHaveBeenCalledTimes(1)
+      expect(logMocks.logError).toHaveBeenCalledWith(callbackError)
+      expect(onPaste).not.toHaveBeenCalled()
+      expect(onInput).not.toHaveBeenCalled()
+      expect(rendered.latest().isPasting).toBe(false)
+    } finally {
+      await rendered.dispose()
+    }
+  })
+
   test('logs rejected image path reads and falls back to text paste', async () => {
     const imagePath = '/tmp/agenc-corrupt.png'
     const error = new Error('image decoder failed')


### PR DESCRIPTION
## Summary
- log thrown async image-paste callbacks instead of letting detached promises reject
- clear paste state after handled async image/text paste callback failures
- add focused regression coverage for image paste callback exceptions

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/usePasteHandler.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/usePasteHandler.test.ts tests/tui/coverage-swarm/swarm-078-hooks-usePasteHandler.test.ts tests/tui/components/BaseTextInput.wave200-097.coverage.test.tsx --reporter=dot
- git diff --check
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run check:unused:production (fails only on existing unrelated Knip backlog)
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core