### PR TITLE
fix(tui): log buffer lsp request failures

### DIFF
--- a/runtime/src/tui/workbench/buffer/BufferStore.ts
+++ b/runtime/src/tui/workbench/buffer/BufferStore.ts
@@ -2,6 +2,7 @@ import { relative, resolve } from "node:path";
 
 import { getCwd } from "../../../utils/cwd.js";
 import { lastGrapheme } from "../../../utils/intl.js";
+import { logError } from "../../../utils/log.js";
 import { TextCursor } from "../../../utils/TextCursor.js";
 import type { VimMode } from "../../../types/textInputTypes.js";
 import type { Key } from "../../ink.js";
@@ -372,7 +373,10 @@ export class WorkbenchBufferStore {
     const document = this.#document;
     if (!file || !document) return null;
     const position = this.#lspPosition(document);
-    const hover = await requestBufferHover(file.absolutePath, position).catch(() => null);
+    const hover = await requestBufferHover(file.absolutePath, position).catch(error => {
+      logError(error);
+      return null;
+    });
     if (this.#file !== file || this.#document !== document) return null;
     this.#hoverText = hover;
     this.#emit();
@@ -384,7 +388,10 @@ export class WorkbenchBufferStore {
     const document = this.#document;
     if (!file || !document) return false;
     const position = this.#lspPosition(document);
-    const target = await requestBufferDefinition(file.absolutePath, position).catch(() => null);
+    const target = await requestBufferDefinition(file.absolutePath, position).catch(error => {
+      logError(error);
+      return null;
+    });
     if (!target || this.#file !== file || this.#document !== document) return false;
     return this.#load(target.path, target.line, false, displayPathForAbsolute(target.path), {
       preserveCurrentOnError: true,

--- a/runtime/tests/tui/workbench/buffer-store.test.ts
+++ b/runtime/tests/tui/workbench/buffer-store.test.ts
@@ -14,7 +14,12 @@ const lspHarness = vi.hoisted(() => ({
   requestBufferHover: vi.fn(),
 }));
 
+const logHarness = vi.hoisted(() => ({
+  logError: vi.fn(),
+}));
+
 vi.mock("../../../src/tui/workbench/buffer/lsp.js", () => lspHarness);
+vi.mock("../../../src/utils/log.js", () => logHarness);
 
 import { runWithCwdOverride } from "../../../src/utils/cwd.js";
 import type { Key } from "../../../src/tui/ink.js";
@@ -56,6 +61,7 @@ function key(overrides: Partial<Key> = {}): Key {
 beforeEach(async () => {
   dir = await mkdtemp(join(tmpdir(), "agenc-buffer-"));
   for (const fn of Object.values(lspHarness)) fn.mockReset();
+  logHarness.logError.mockReset();
 });
 
 afterEach(async () => {
@@ -183,6 +189,24 @@ describe("WorkbenchBufferStore", () => {
     });
   });
 
+  it("logs rejected hover requests while preserving the current buffer", async () => {
+    await writeFile(join(dir, "target.txt"), "alpha\n", "utf8");
+    const error = new Error("hover request failed");
+    lspHarness.requestBufferHover.mockRejectedValue(error);
+    const store = new WorkbenchBufferStore();
+
+    await runWithCwdOverride(dir, () => store.open("target.txt"));
+
+    await expect(store.requestHover()).resolves.toBeNull();
+    expect(logHarness.logError).toHaveBeenCalledWith(error);
+    expect(store.getSnapshot()).toMatchObject({
+      filePath: "target.txt",
+      hoverText: null,
+      status: "ready",
+    });
+    expect(store.getText()).toBe("alpha\n");
+  });
+
   it("ignores stale definition responses after switching files", async () => {
     await writeFile(join(dir, "target.txt"), "alpha\n", "utf8");
     await writeFile(join(dir, "next.txt"), "omega\n", "utf8");
@@ -206,6 +230,24 @@ describe("WorkbenchBufferStore", () => {
       position: { line: 1 },
     });
     expect(store.getText()).toBe("omega\n");
+  });
+
+  it("logs rejected definition requests without changing the buffer", async () => {
+    await writeFile(join(dir, "target.txt"), "alpha\n", "utf8");
+    const error = new Error("definition request failed");
+    lspHarness.requestBufferDefinition.mockRejectedValue(error);
+    const store = new WorkbenchBufferStore();
+
+    await runWithCwdOverride(dir, () => store.open("target.txt"));
+
+    await expect(store.goToDefinition()).resolves.toBe(false);
+    expect(logHarness.logError).toHaveBeenCalledWith(error);
+    expect(store.getSnapshot()).toMatchObject({
+      filePath: "target.txt",
+      position: { line: 1 },
+      status: "ready",
+    });
+    expect(store.getText()).toBe("alpha\n");
   });
 
   it("reports failed definition navigation when unsaved edits block cross-file loads", async () => {


### PR DESCRIPTION
## Summary
- Log rejected buffer hover and definition LSP requests through the shared error logger.
- Preserve existing safe UI behavior: hover resolves to null and definition navigation resolves false without changing the current buffer.
- Add regression coverage for both rejected request paths.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/buffer-store.test.ts --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-lsp.test.ts tests/tui/workbench/buffer-surface.test.tsx --reporter=dot`
- `git diff --check`
- Branding/attribution scan over `runtime/src` and `runtime/tests`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

## Known unrelated backlog
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.
