### PR TITLE
fix(tui): log file picker ignore read failures

### DIFF
--- a/runtime/src/tui/hooks/fileSuggestions.ts
+++ b/runtime/src/tui/hooks/fileSuggestions.ts
@@ -19,7 +19,7 @@ import type { FileSuggestionCommandInput } from '../../types/fileSuggestion'
 import { getGlobalConfig } from '../../utils/config.js' // upstream-import: keep target is owned by another Z-PURGE item
 import { getCwd } from '../../utils/cwd.js' // upstream-import: keep target is owned by another Z-PURGE item
 import { logForDebugging } from 'src/utils/debug.js'
-import { errorMessage } from '../../utils/errors.js' // upstream-import: keep target is owned by another Z-PURGE item
+import { errorMessage, isENOENT } from '../../utils/errors.js' // upstream-import: keep target is owned by another Z-PURGE item
 import { execFileNoThrowWithCwd } from '../../utils/execFileNoThrow.js' // upstream-import: keep target is owned by another Z-PURGE item
 import { getFsImplementation } from '../../utils/fsOperations.js' // upstream-import: keep target is owned by another Z-PURGE item
 import { findGitRoot, gitExe } from '../../utils/git'
@@ -232,7 +232,16 @@ async function loadFilePickerIgnorePatterns(
     ignoreFiles.map(f => path.join(dir, f)),
   )
   const contents = await Promise.all(
-    paths.map(p => fs.readFile(p, { encoding: 'utf8' }).catch(() => null)),
+    paths.map(async p => {
+      try {
+        return await fs.readFile(p, { encoding: 'utf8' })
+      } catch (error) {
+        if (!isENOENT(error)) {
+          logError(error)
+        }
+        return null
+      }
+    }),
   )
   for (const [i, content] of contents.entries()) {
     if (content === null) continue

--- a/runtime/tests/tui/hooks/fileSuggestions.test.ts
+++ b/runtime/tests/tui/hooks/fileSuggestions.test.ts
@@ -8,6 +8,12 @@ import {
 import { tmpdir } from 'node:os'
 import { join, sep } from 'node:path'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  getFsImplementation,
+  setFsImplementation,
+  setOriginalFsImplementation,
+  type FsOperations,
+} from '../../utils/fsOperations.js'
 
 let tempCwd = ''
 
@@ -242,6 +248,7 @@ describe('fileSuggestions hidden-file visibility', () => {
   })
 
   afterEach(() => {
+    setOriginalFsImplementation()
     rmSync(tempCwd, { recursive: true, force: true })
     tempCwd = ''
   })
@@ -299,6 +306,29 @@ describe('fileSuggestions hidden-file visibility', () => {
     expect(names).toContain('visible.txt')
     expect(names).not.toContain('ignored.txt')
     expect(names).not.toContain('ignored-dir' + sep)
+  })
+
+  test('logs unreadable picker ignore files without hiding suggestions', async () => {
+    const readError = Object.assign(new Error('permission denied'), {
+      code: 'EACCES',
+    })
+    const originalFs = getFsImplementation()
+    setFsImplementation({
+      ...originalFs,
+      async readFile(filePath, options) {
+        if (filePath === join(tempCwd, '.agencignore')) {
+          throw readError
+        }
+        return originalFs.readFile(filePath, options)
+      },
+    } as FsOperations)
+    writeFileSync(join(tempCwd, '.agencignore'), 'secret.txt\n')
+    writeFileSync(join(tempCwd, 'secret.txt'), '')
+
+    const items = await generateFileSuggestions('', true)
+
+    expect(items.map(item => item.displayText)).toContain('secret.txt')
+    expect(harness.logError).toHaveBeenCalledWith(readError)
   })
 
   test('dotted prefix query excludes hidden paths ignored by .agencignore', async () => {


### PR DESCRIPTION
## Summary
- Log non-ENOENT read failures from file-picker ignore files instead of treating them like absent files.
- Keep missing ignore files quiet and preserve the existing suggestion fallback when an ignore file cannot be read.
- Add regression coverage for an unreadable `.agencignore` path.

## Test plan
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/fileSuggestions.test.ts --reporter=dot`
- `npm --workspace=@tetsuo-ai/runtime test -- tests/tui/hooks/fileSuggestions.test.ts tests/tui/hooks/fileSuggestions.coverage2.test.ts tests/tui/hooks/fileSuggestions.runtime-coverage.test.ts tests/tui/hooks/fileSuggestions.wave200-081.coverage.test.ts tests/tui/coverage-swarm/swarm-034-hooks-fileSuggestions.test.ts --reporter=dot`
- `git diff --check`
- Branding/attribution scan over `runtime/src` and `runtime/tests`
- `npm run typecheck`
- `npm --workspace=@tetsuo-ai/runtime run test:coverage:tui`
- `node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core`

## Known unrelated backlog
- `npm --workspace=@tetsuo-ai/runtime run check:unused:production` still fails on the existing Knip backlog: unused file `src/tui/workbench/keymap.ts`, 30 unused exports, and 4 unused `@internal` tag hints.
