### PR TITLE
fix(tui): handle worktree exit action failures

### DIFF
--- a/runtime/src/tui/components/WorktreeExitDialog.tsx
+++ b/runtime/src/tui/components/WorktreeExitDialog.tsx
@@ -160,71 +160,86 @@ export function WorktreeExitDialog({
   async function handleSelect(value: string) {
     if (!worktreeSession) return;
     const hasTmux = Boolean(worktreeSession.tmuxSessionName);
-    if (value === 'keep' || value === 'keep-with-tmux') {
-      setStatus('keeping');
-      logEvent('agenc_worktree_kept', {
-        commits: commitCount,
-        changed_files: changes.length
-      });
-      await keepWorktree();
-      process.chdir(worktreeSession.originalCwd);
-      setCwd(worktreeSession.originalCwd);
-      await recordWorktreeExit();
-      getPlansDirectory.cache.clear?.();
-      if (hasTmux) {
-        setResultMessage(`Worktree kept. Your work is saved at ${worktreeSession.worktreePath} on branch ${worktreeSession.worktreeBranch}. Reattach to tmux session with: tmux attach -t ${worktreeSession.tmuxSessionName}`);
-      } else {
-        setResultMessage(`Worktree kept. Your work is saved at ${worktreeSession.worktreePath} on branch ${worktreeSession.worktreeBranch}`);
-      }
-      setStatus('done');
-    } else if (value === 'keep-kill-tmux') {
-      setStatus('keeping');
-      logEvent('agenc_worktree_kept', {
-        commits: commitCount,
-        changed_files: changes.length
-      });
-      if (worktreeSession.tmuxSessionName) {
-        await killTmuxSession(worktreeSession.tmuxSessionName);
-      }
-      await keepWorktree();
-      process.chdir(worktreeSession.originalCwd);
-      setCwd(worktreeSession.originalCwd);
-      await recordWorktreeExit();
-      getPlansDirectory.cache.clear?.();
-      setResultMessage(`Worktree kept at ${worktreeSession.worktreePath} on branch ${worktreeSession.worktreeBranch}. Tmux session terminated.`);
-      setStatus('done');
-    } else if (value === 'remove' || value === 'remove-with-tmux') {
-      setStatus('removing');
-      logEvent('agenc_worktree_removed', {
-        commits: commitCount,
-        changed_files: changes.length
-      });
-      if (worktreeSession.tmuxSessionName) {
-        await killTmuxSession(worktreeSession.tmuxSessionName);
-      }
-      try {
-        await cleanupWorktree();
+    try {
+      if (value === 'keep' || value === 'keep-with-tmux') {
+        setStatus('keeping');
+        logEvent('agenc_worktree_kept', {
+          commits: commitCount,
+          changed_files: changes.length
+        });
+        await keepWorktree();
         process.chdir(worktreeSession.originalCwd);
         setCwd(worktreeSession.originalCwd);
         await recordWorktreeExit();
         getPlansDirectory.cache.clear?.();
-      } catch (error) {
+        if (hasTmux) {
+          setResultMessage(`Worktree kept. Your work is saved at ${worktreeSession.worktreePath} on branch ${worktreeSession.worktreeBranch}. Reattach to tmux session with: tmux attach -t ${worktreeSession.tmuxSessionName}`);
+        } else {
+          setResultMessage(`Worktree kept. Your work is saved at ${worktreeSession.worktreePath} on branch ${worktreeSession.worktreeBranch}`);
+        }
+        setStatus('done');
+      } else if (value === 'keep-kill-tmux') {
+        setStatus('keeping');
+        logEvent('agenc_worktree_kept', {
+          commits: commitCount,
+          changed_files: changes.length
+        });
+        if (worktreeSession.tmuxSessionName) {
+          await killTmuxSession(worktreeSession.tmuxSessionName);
+        }
+        await keepWorktree();
+        process.chdir(worktreeSession.originalCwd);
+        setCwd(worktreeSession.originalCwd);
+        await recordWorktreeExit();
+        getPlansDirectory.cache.clear?.();
+        setResultMessage(`Worktree kept at ${worktreeSession.worktreePath} on branch ${worktreeSession.worktreeBranch}. Tmux session terminated.`);
+        setStatus('done');
+      } else if (value === 'remove' || value === 'remove-with-tmux') {
+        setStatus('removing');
+        logEvent('agenc_worktree_removed', {
+          commits: commitCount,
+          changed_files: changes.length
+        });
+        if (worktreeSession.tmuxSessionName) {
+          await killTmuxSession(worktreeSession.tmuxSessionName);
+        }
+        try {
+          await cleanupWorktree();
+          process.chdir(worktreeSession.originalCwd);
+          setCwd(worktreeSession.originalCwd);
+          await recordWorktreeExit();
+          getPlansDirectory.cache.clear?.();
+        } catch (error) {
+          logForDebugging(`Failed to clean up worktree: ${error}`, {
+            level: 'error'
+          });
+          setResultMessage('Worktree cleanup failed, exiting anyway');
+          setStatus('done');
+          return;
+        }
+        const tmuxNote = hasTmux ? ' Tmux session terminated.' : '';
+        if (commitCount > 0 && changes.length > 0) {
+          setResultMessage(`Worktree removed. ${commitCount} ${commitCount === 1 ? 'commit' : 'commits'} and uncommitted changes were discarded.${tmuxNote}`);
+        } else if (commitCount > 0) {
+          setResultMessage(`Worktree removed. ${commitCount} ${commitCount === 1 ? 'commit' : 'commits'} on ${worktreeSession.worktreeBranch} ${commitCount === 1 ? 'was' : 'were'} discarded.${tmuxNote}`);
+        } else if (changes.length > 0) {
+          setResultMessage(`Worktree removed. Uncommitted changes were discarded.${tmuxNote}`);
+        } else {
+          setResultMessage(`Worktree removed.${tmuxNote}`);
+        }
+        setStatus('done');
+      }
+    } catch (error) {
+      if (value === 'keep' || value === 'keep-with-tmux' || value === 'keep-kill-tmux') {
+        logForDebugging(`Failed to keep worktree: ${error}`, {
+          level: 'error'
+        });
+        setResultMessage('Worktree keep failed, exiting anyway');
+      } else {
         logForDebugging(`Failed to clean up worktree: ${error}`, {
           level: 'error'
         });
         setResultMessage('Worktree cleanup failed, exiting anyway');
-        setStatus('done');
-        return;
-      }
-      const tmuxNote = hasTmux ? ' Tmux session terminated.' : '';
-      if (commitCount > 0 && changes.length > 0) {
-        setResultMessage(`Worktree removed. ${commitCount} ${commitCount === 1 ? 'commit' : 'commits'} and uncommitted changes were discarded.${tmuxNote}`);
-      } else if (commitCount > 0) {
-        setResultMessage(`Worktree removed. ${commitCount} ${commitCount === 1 ? 'commit' : 'commits'} on ${worktreeSession.worktreeBranch} ${commitCount === 1 ? 'was' : 'were'} discarded.${tmuxNote}`);
-      } else if (changes.length > 0) {
-        setResultMessage(`Worktree removed. Uncommitted changes were discarded.${tmuxNote}`);
-      } else {
-        setResultMessage(`Worktree removed.${tmuxNote}`);
       }
       setStatus('done');
     }

--- a/runtime/tests/tui/components/WorktreeExitDialog.test.tsx
+++ b/runtime/tests/tui/components/WorktreeExitDialog.test.tsx
@@ -675,6 +675,37 @@ describe('WorktreeExitDialog', () => {
     await mounted.dispose()
   })
 
+  it('reports keep action failures instead of rejecting the select action', async () => {
+    const restoreError = new Error('original cwd vanished')
+    const mounted = await mountAskingDialog({
+      commitCount: 1,
+      statusLines: [],
+    })
+    chdirSpy.mockImplementationOnce(() => {
+      throw restoreError
+    })
+
+    try {
+      await expect(Promise.resolve(selectProps().onChange?.('keep'))).resolves.toBeUndefined()
+      await waitFor(
+        () => mounted.onDone.mock.calls.length > 0,
+        'keep failure did not finish',
+      )
+
+      expect(harness.logForDebugging).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Failed to keep worktree: Error: original cwd vanished',
+        ),
+        { level: 'error' },
+      )
+      expect(mounted.onDone).toHaveBeenCalledWith(
+        'Worktree keep failed, exiting anyway',
+      )
+    } finally {
+      await mounted.dispose()
+    }
+  })
+
   it('keeps a tmux-backed worktree and preserves the reattach instruction', async () => {
     const keep = deferred()
     harness.session = baseSession({ tmuxSessionName: 'agenc-worktree-tmux' })
@@ -740,6 +771,41 @@ describe('WorktreeExitDialog', () => {
     )
 
     await mounted.dispose()
+  })
+
+  it('reports tmux removal failures instead of rejecting the select action', async () => {
+    harness.session = baseSession({ tmuxSessionName: 'agenc-worktree-tmux' })
+    harness.killTmuxSession.mockRejectedValue(new Error('tmux kill failed'))
+    mockGitState({ commitCount: 0, statusLines: [' M README.md'] })
+
+    const mounted = await mountDialog()
+    await waitFor(
+      () => harness.selectProps !== undefined,
+      'tmux remove choices did not render',
+    )
+
+    try {
+      await expect(
+        Promise.resolve(selectProps().onChange?.('remove-with-tmux')),
+      ).resolves.toBeUndefined()
+      await waitFor(
+        () => mounted.onDone.mock.calls.length > 0,
+        'tmux remove failure did not finish',
+      )
+
+      expect(harness.cleanupWorktree).not.toHaveBeenCalled()
+      expect(harness.logForDebugging).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Failed to clean up worktree: Error: tmux kill failed',
+        ),
+        { level: 'error' },
+      )
+      expect(mounted.onDone).toHaveBeenCalledWith(
+        'Worktree cleanup failed, exiting anyway',
+      )
+    } finally {
+      await mounted.dispose()
+    }
   })
 
   it('removes a tmux-backed worktree and reports discarded commits plus changes', async () => {


### PR DESCRIPTION
## Summary
- Add an outer failure boundary around manual worktree exit actions so async select handlers do not reject unseen by the input path.
- Log keep/remove failures and force the dialog to finish with the existing exit-anyway fallback.
- Cover keep restore failures and tmux removal failures with regressions.

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/WorktreeExitDialog.test.tsx --reporter=dot
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/WorktreeExitDialog.test.tsx tests/tui/components/WorktreeExitDialog.runtime-coverage.test.tsx tests/tui/components/WorktreeExitDialog.loading.test.tsx tests/tui/coverage-swarm/swarm-187-components-WorktreeExitDialog.test.tsx --reporter=dot
- git diff --check
- branding/attribution scan over runtime source and tests
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Known unrelated issue
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still reports the existing Knip backlog: unused workbench keymap file, 30 unused exports, and 4 @internal tag hints.