### PR TITLE
fix(tui): log buffer highlight failures

### DIFF
--- a/runtime/src/tui/workbench/buffer/highlight.ts
+++ b/runtime/src/tui/workbench/buffer/highlight.ts
@@ -1,5 +1,6 @@
 import { basename, extname } from "node:path";
 
+import { logError } from "../../../utils/log.js";
 import type { BufferVisibleLine } from "./BufferStore.js";
 
 type CodeToANSI = (code: string, lang: string, theme: string) => Promise<string>;
@@ -79,7 +80,8 @@ export async function highlightBufferVisibleLines(
     const highlighted = await codeToANSI(code, language, BUFFER_SHIKI_THEME);
     const highlightedLines = trimSingleTrailingLineBreak(highlighted).split("\n");
     return new Map(lines.map((line, index) => [line.number, highlightedLines[index] ?? line.text]));
-  } catch {
+  } catch (error) {
+    logError(error);
     return new Map();
   }
 }
@@ -87,7 +89,10 @@ export async function highlightBufferVisibleLines(
 function getCodeToANSI(): Promise<CodeToANSI | null> {
   codeToANSIPromise ??= import("@shikijs/cli")
     .then((module) => module.codeToANSI as CodeToANSI)
-    .catch(() => null);
+    .catch((error) => {
+      logError(error);
+      return null;
+    });
   return codeToANSIPromise;
 }
 

--- a/runtime/tests/tui/workbench/buffer-highlight.test.ts
+++ b/runtime/tests/tui/workbench/buffer-highlight.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const logHarness = vi.hoisted(() => ({
+  logError: vi.fn(),
+}));
+
+vi.mock("../../../src/utils/log.js", () => logHarness);
+
+type HighlightModule = typeof import("../../../src/tui/workbench/buffer/highlight.js");
+
+async function loadHighlightWithShiki(factory: () => unknown): Promise<HighlightModule> {
+  vi.resetModules();
+  vi.doMock("@shikijs/cli", factory);
+  return import("../../../src/tui/workbench/buffer/highlight.js");
+}
+
+beforeEach(() => {
+  logHarness.logError.mockReset();
+  vi.doUnmock("@shikijs/cli");
+});
+
+describe("buffer syntax highlighting", () => {
+  it("maps highlighted output back to visible line numbers", async () => {
+    const codeToANSI = vi.fn(async () => "\u001b[32mconst value = 1;\u001b[39m\n");
+    const { highlightBufferVisibleLines } = await loadHighlightWithShiki(() => ({
+      codeToANSI,
+    }));
+
+    const result = await highlightBufferVisibleLines("index.ts", [
+      { number: 7, text: "const value = 1;" },
+    ]);
+
+    expect(codeToANSI).toHaveBeenCalledWith("const value = 1;", "ts", "dark-plus");
+    expect(result.get(7)).toBe("\u001b[32mconst value = 1;\u001b[39m");
+  });
+
+  it("logs highlighter render failures while falling back to plain text", async () => {
+    const error = new Error("shiki render failed");
+    const { highlightBufferVisibleLines } = await loadHighlightWithShiki(() => ({
+      codeToANSI: vi.fn().mockRejectedValue(error),
+    }));
+
+    await expect(highlightBufferVisibleLines("index.ts", [
+      { number: 1, text: "const value = 1;" },
+    ])).resolves.toEqual(new Map());
+
+    expect(logHarness.logError).toHaveBeenCalledWith(error);
+  });
+
+  it("logs highlighter module load failures while disabling highlighting", async () => {
+    const error = new Error("shiki module missing");
+    const { highlightBufferVisibleLines } = await loadHighlightWithShiki(() => {
+      throw error;
+    });
+
+    await expect(highlightBufferVisibleLines("index.ts", [
+      { number: 1, text: "const value = 1;" },
+    ])).resolves.toEqual(new Map());
+
+    expect(logHarness.logError).toHaveBeenCalledTimes(1);
+    const loggedError = logHarness.logError.mock.calls[0]?.[0] as { cause?: unknown } | undefined;
+    expect(loggedError === error || loggedError?.cause === error).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Log buffer syntax highlighter module-load failures while keeping the existing no-highlight fallback.
- Log highlighter render failures while preserving plain-text rendering.
- Add focused coverage for successful highlight mapping, render failure logging, and module-load failure logging.

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/buffer-highlight.test.ts --reporter=dot
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/workbench/buffer-highlight.test.ts tests/tui/workbench/buffer-surface.test.tsx tests/tui/workbench/buffer-store.test.ts tests/tui/workbench/buffer-lsp.test.ts tests/tui/workbench/buffer-editing.test.ts tests/tui/workbench/buffer-external-editor.test.ts --reporter=dot
- git diff --check
- branding/attribution scan over runtime source and tests
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Known unrelated issue
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still reports the existing Knip backlog: unused workbench keymap file, 30 unused exports, and 4 @internal tag hints.