### PR TITLE
fix(tui): log quick open preview failures

### DIFF
--- a/runtime/src/tui/components/QuickOpenDialog.tsx
+++ b/runtime/src/tui/components/QuickOpenDialog.tsx
@@ -139,10 +139,11 @@ export function QuickOpenDialog(t0) {
           path: focusedPath,
           content: r.content
         });
-      }).catch(() => {
+      }).catch(error => {
         if (controller.signal.aborted) {
           return;
         }
+        logError(error);
         setPreview({
           path: focusedPath,
           content: "(preview unavailable)"

--- a/runtime/tests/tui/components/QuickOpenDialog.render.test.tsx
+++ b/runtime/tests/tui/components/QuickOpenDialog.render.test.tsx
@@ -455,7 +455,8 @@ describe('QuickOpenDialog render and interactions', () => {
     const rendered = await renderDialog()
 
     try {
-      harness.readFileInRange.mockRejectedValueOnce(new Error('cannot preview'))
+      const previewError = new Error('cannot preview')
+      harness.readFileInRange.mockRejectedValueOnce(previewError)
 
       await searchFor(
         'broken',
@@ -476,6 +477,7 @@ describe('QuickOpenDialog render and interactions', () => {
       )
       expect(previewOutput).toContain('src/broken.ts')
       expect(previewOutput).toContain('(preview unavailable)')
+      expect(harness.logError).toHaveBeenCalledWith(previewError)
     } finally {
       await rendered.dispose()
     }


### PR DESCRIPTION
## Summary
- Log non-aborted Quick Open preview read failures while preserving the existing unavailable-preview fallback.
- Keep aborted preview reads quiet so stale focus changes do not emit diagnostics.
- Extend the existing preview failure regression to assert the underlying read error is logged.

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/QuickOpenDialog.render.test.tsx --reporter=dot
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/QuickOpenDialog.render.test.tsx tests/tui/components/QuickOpenDialog.layout.test.ts tests/tui/coverage-swarm/swarm-165-components-QuickOpenDialog.test.tsx tests/tui/components/design-system/FuzzyPicker.test.tsx tests/tui/components/design-system/FuzzyPicker.layout.test.ts tests/tui/components/GlobalSearchDialog.render.test.tsx tests/tui/components/GlobalSearchDialog.layout.test.ts tests/tui/components/GlobalSearchDialog.wave200-129.coverage.test.tsx tests/tui/coverage-swarm/swarm-127-components-GlobalSearchDialog.test.tsx --reporter=dot
- git diff --check
- branding/attribution scan over runtime source and tests
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Known unrelated issue
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still reports the existing Knip backlog: unused workbench keymap file, 30 unused exports, and 4 @internal tag hints.