### PR TITLE
fix(tui): log global search preview failures

### DIFF
--- a/runtime/src/tui/components/GlobalSearchDialog.tsx
+++ b/runtime/src/tui/components/GlobalSearchDialog.tsx
@@ -144,10 +144,11 @@ export function GlobalSearchDialog(t0) {
           line: focused.line,
           content: r.content
         });
-      }).catch(() => {
+      }).catch(error => {
         if (controller.signal.aborted) {
           return;
         }
+        logError(error);
         setPreview({
           file: focused.file,
           line: focused.line,

--- a/runtime/tests/tui/components/GlobalSearchDialog.wave200-129.coverage.test.tsx
+++ b/runtime/tests/tui/components/GlobalSearchDialog.wave200-129.coverage.test.tsx
@@ -33,6 +33,7 @@ type CapturedPickerProps = {
 const harness = vi.hoisted(() => ({
   cwd: '/workspace/project',
   logEvent: vi.fn(),
+  logError: vi.fn(),
   openFileInExternalEditor: vi.fn(),
   pickerProps: undefined as CapturedPickerProps | undefined,
   readFileInRange: vi.fn(),
@@ -68,6 +69,10 @@ vi.mock('../../utils/readFileInRange', () => ({
   readFileInRange: harness.readFileInRange,
 }))
 
+vi.mock('../../utils/log', () => ({
+  logError: harness.logError,
+}))
+
 vi.mock('../../utils/ripgrep', () => ({
   ripGrepStream: harness.ripGrepStream,
 }))
@@ -93,6 +98,7 @@ function resetHarness() {
   harness.pickerProps = undefined
   harness.registerOverlay.mockClear()
   harness.logEvent.mockClear()
+  harness.logError.mockClear()
   harness.openFileInExternalEditor.mockReset()
   harness.openFileInExternalEditor.mockReturnValue(true)
   harness.readFileInRange.mockReset()
@@ -222,7 +228,8 @@ describe('GlobalSearchDialog wave 200 worker 129 coverage', () => {
       )
       let searchSignal: AbortSignal | undefined
 
-      harness.readFileInRange.mockRejectedValue(new Error('preview failed'))
+      const previewError = new Error('preview failed')
+      harness.readFileInRange.mockRejectedValue(previewError)
       harness.ripGrepStream.mockImplementation(
         async (
           args: string[],
@@ -293,6 +300,7 @@ describe('GlobalSearchDialog wave 200 worker 129 coverage', () => {
         'Global search did not render the preview failure fallback',
       )
       expect(previewOutput).toContain('src/file-0.ts:1')
+      expect(harness.logError).toHaveBeenCalledWith(previewError)
 
       pickerProps().onQueryChange('   ')
       await waitFor(


### PR DESCRIPTION
## Summary
- Log non-aborted Global Search preview read failures while preserving the existing unavailable-preview fallback.
- Keep aborted preview reads quiet so stale focus changes do not emit diagnostics.
- Extend preview failure coverage to assert the underlying read error is logged.

## Test plan
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/GlobalSearchDialog.wave200-129.coverage.test.tsx --reporter=dot
- npm --workspace=@tetsuo-ai/runtime test -- tests/tui/components/GlobalSearchDialog.render.test.tsx tests/tui/components/GlobalSearchDialog.layout.test.ts tests/tui/components/GlobalSearchDialog.wave200-129.coverage.test.tsx tests/tui/coverage-swarm/swarm-127-components-GlobalSearchDialog.test.tsx tests/tui/components/design-system/FuzzyPicker.test.tsx tests/tui/components/design-system/FuzzyPicker.layout.test.ts tests/tui/components/QuickOpenDialog.render.test.tsx tests/tui/components/QuickOpenDialog.layout.test.ts tests/tui/coverage-swarm/swarm-165-components-QuickOpenDialog.test.tsx --reporter=dot
- git diff --check
- branding/attribution scan over runtime source and tests
- npm run typecheck
- npm --workspace=@tetsuo-ai/runtime run test:coverage:tui
- node /home/tetsuo/.claude/skills/agenc-tui-validate/scripts/run-tui-validate.mjs --repo /home/tetsuo/git/AgenC/agenc-core

## Known unrelated issue
- npm --workspace=@tetsuo-ai/runtime run check:unused:production still reports the existing Knip backlog: unused workbench keymap file, 30 unused exports, and 4 @internal tag hints.